### PR TITLE
Add external memory support to VulkanImage

### DIFF
--- a/Runtime/GraphicsDriver/Vulkan/VulkanImage.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanImage.cpp
@@ -71,9 +71,19 @@ void VulkanImage::Compile()
 		return;
 	}
 
-	VkImageCreateInfo info = {};
-	info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-	info.pNext = nullptr;
+       VkImageCreateInfo info = {};
+       info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+       VkExternalMemoryImageCreateInfo externalInfo{};
+       if (m_useExternalMemory)
+       {
+               externalInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+               externalInfo.handleTypes = m_externalHandleType;
+               info.pNext = &externalInfo;
+       }
+       else
+       {
+               info.pNext = nullptr;
+       }
 	info.flags = m_flags;
 	info.imageType = m_imageType;
 	info.extent = m_extent;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanImage.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanImage.h
@@ -32,7 +32,18 @@ namespace Sailor::GraphicsDriver::Vulkan
 		VkSharingMode m_sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 		TVector<uint32_t> m_queueFamilyIndices;
 		VkImageLayout m_initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-		VkImageLayout m_defaultLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+               VkImageLayout m_defaultLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+
+               // External memory support
+               bool m_useExternalMemory = false;
+               VkExternalMemoryHandleTypeFlagBits m_externalHandleType = (VkExternalMemoryHandleTypeFlagBits)0;
+
+               SAILOR_API void EnableExternalMemory(VkExternalMemoryHandleTypeFlagBits handleType)
+               {
+                       m_useExternalMemory = true;
+                       m_externalHandleType = handleType;
+               }
+               SAILOR_API bool IsExternalMemoryEnabled() const { return m_useExternalMemory; }
 
 		SAILOR_API operator VkImage() const { return m_image; }
 


### PR DESCRIPTION
## Summary
- allow VulkanImage to opt into external memory
- configure image creation with `VkExternalMemoryImageCreateInfo`

## Testing
- `git status --short`
