### PR TITLE
Add basic process stability test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,3 +28,6 @@ message("cxx Flags:" ${CMAKE_CXX_FLAGS})
 
 add_subdirectory(Exec)
 add_subdirectory(Lib)
+
+enable_testing()
+add_subdirectory(Tests)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+add_test(
+    NAME ProcessNoCrash
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/process_no_crash_test.py
+)
+

--- a/Tests/process_no_crash_test.py
+++ b/Tests/process_no_crash_test.py
@@ -1,0 +1,31 @@
+import subprocess
+import sys
+import time
+import os
+
+
+def main():
+    # command to run a simple process that stays alive
+    cmd = [sys.executable, "-c", "import time; time.sleep(20)"]
+
+    proc = subprocess.Popen(cmd)
+
+    try:
+        time.sleep(10)
+        if proc.poll() is not None:
+            print("Process exited before 10 seconds")
+            return 1
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
## Summary
- add Python test that launches a process and waits 10 seconds
- integrate the test into CMake via `add_test`

## Testing
- `python3 Tests/process_no_crash_test.py`
- `cmake -S . -B build` *(fails: Could not find yaml-cppConfig.cmake)*