### PR TITLE
Build .NET editor during CI

### DIFF
--- a/.github/workflows/cmake-single-platform.yml
+++ b/.github/workflows/cmake-single-platform.yml
@@ -39,6 +39,14 @@ jobs:
         version: 1.3.275.0        
         cache: true
 
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '8.0.x'
+
+    - name: Install MAUI workload
+      run: dotnet workload install maui
+
     - name: Configure CMake
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,5 +29,12 @@ message("cxx Flags:" ${CMAKE_CXX_FLAGS})
 add_subdirectory(Exec)
 add_subdirectory(Lib)
 
+# Build the .NET MAUI editor
+add_custom_target(SailorEditor ALL
+    COMMAND dotnet build ${PROJECT_SOURCE_DIR}/Editor/SailorEditor.csproj -c ${CMAKE_BUILD_TYPE}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/Editor
+    COMMENT "Building Sailor Editor")
+set_property(TARGET SailorEditor PROPERTY FOLDER "Editor")
+
 enable_testing()
 add_subdirectory(Tests)


### PR DESCRIPTION
## Summary
- build the SailorEditor .NET MAUI project with the rest of the code
- prepare the GitHub Actions workflow with .NET and MAUI workload

## Testing
- `cmake ..` *(fails: yaml-cpp not found)*