### PR TITLE
Introduce platform interface

### DIFF
--- a/Runtime/Engine/Frame.cpp
+++ b/Runtime/Engine/Frame.cpp
@@ -1,6 +1,6 @@
 #include "Frame.h"
 #include "Core/Defines.h"
-#include "Platform/Win32/Input.h"
+#include "Platform/Input.h"
 #include "Core/Utils.h"
 #include "RHI/Renderer.h"
 #include "RHI/Mesh.h"

--- a/Runtime/Engine/Frame.h
+++ b/Runtime/Engine/Frame.h
@@ -7,11 +7,11 @@
 #include "Memory/SharedPtr.hpp"
 #include "RHI/Renderer.h"
 #include "RHI/DebugContext.h"
-#include "Platform/Win32/Input.h"
+#include "Platform/Input.h"
 
 namespace Sailor
 {
-	using FrameInputState = Win32::InputState;
+       using FrameInputState = Platform::InputState;
 
 	class FrameState
 	{

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
@@ -5,7 +5,7 @@
 #include "Containers/Vector.h"
 #include "Containers/Set.h"
 #include "Sailor.h"
-#include "Platform/Win32/Window.h"
+#include "Platform/Window.h"
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/Shader/ShaderCompiler.h"
 #include "VulkanDevice.h"

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
@@ -13,7 +13,7 @@ struct IUnknown; // Workaround for "combaseapi.h(229): error C2187: syntax error
 #include "AssetRegistry/Shader/ShaderCompiler.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "AssetRegistry/Model/ModelImporter.h"
-#include "Platform/Win32/Window.h"
+#include "Platform/Window.h"
 #include "Math/Math.h"
 #include "VulkanDevice.h"
 #include "VulkanApi.h"
@@ -34,7 +34,7 @@ struct IUnknown; // Workaround for "combaseapi.h(229): error C2187: syntax error
 #include "VulkanDescriptors.h"
 #include "VulkanPipileneStates.h"
 #include "Tasks/Scheduler.h"
-#include "Platform/Win32/Input.h"
+#include "Platform/Input.h"
 #include "Winuser.h"
 #include "Engine/EngineLoop.h"
 #include "Memory/MemoryBlockAllocator.hpp"
@@ -71,7 +71,7 @@ VkSampleCountFlagBits CalculateMaxAllowedMSAASamples(VkSampleCountFlags counts)
 	return VK_SAMPLE_COUNT_1_BIT;
 }
 
-VulkanDevice::VulkanDevice(Window* pViewport, RHI::EMsaaSamples requestMsaa)
+VulkanDevice::VulkanDevice(Platform::Window* pViewport, RHI::EMsaaSamples requestMsaa)
 {
 	// Create Win32 surface
 	CreateWin32Surface(pViewport);
@@ -426,7 +426,7 @@ void VulkanDevice::CreateFrameSyncSemaphores()
 	}
 }
 
-bool VulkanDevice::RecreateSwapchain(Window* pViewport)
+bool VulkanDevice::RecreateSwapchain(Platform::Window* pViewport)
 {
 	if (pViewport->GetWidth() == 0 || pViewport->GetHeight() == 0)
 	{
@@ -646,7 +646,7 @@ void VulkanDevice::CreateLogicalDevice(VkPhysicalDevice physicalDevice)
 	m_computeQueue = VulkanQueuePtr::Make(computeQueue, m_queueFamilies.m_computeFamily.value(), 0);
 }
 
-void VulkanDevice::CreateWin32Surface(const Window* viewport)
+void VulkanDevice::CreateWin32Surface(const Platform::Window* viewport)
 {
 	VkWin32SurfaceCreateInfoKHR createInfoWin32{ VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR };
 	createInfoWin32.hwnd = viewport->GetHWND();
@@ -657,7 +657,7 @@ void VulkanDevice::CreateWin32Surface(const Window* viewport)
 	m_surface = VulkanSurfacePtr::Make(surface, VulkanApi::GetVkInstance());
 }
 
-void VulkanDevice::CreateSwapchain(Window* pViewport)
+void VulkanDevice::CreateSwapchain(Platform::Window* pViewport)
 {
 	m_oldSwapchain = m_swapchain;
 
@@ -706,7 +706,7 @@ void VulkanDevice::WaitIdle()
 	vkDeviceWaitIdle(m_device);
 }
 
-bool VulkanDevice::ShouldFixLostDevice(const Win32::Window* pViewport)
+bool VulkanDevice::ShouldFixLostDevice(const Platform::Window* pViewport)
 {
 	SAILOR_PROFILE_FUNCTION();
 
@@ -721,7 +721,7 @@ bool VulkanDevice::ShouldFixLostDevice(const Win32::Window* pViewport)
 	return m_swapchain && (swapchainExtent.width != m_swapchain->GetExtent().width || swapchainExtent.height != m_swapchain->GetExtent().height);
 }
 
-void VulkanDevice::FixLostDevice(Win32::Window* pViewport)
+void VulkanDevice::FixLostDevice(Platform::Window* pViewport)
 {
 	RecreateSwapchain(pViewport);
 	m_bIsDeviceLost = false;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
@@ -10,13 +10,14 @@
 #include "VulkanMemory.h"
 #include "VulkanBufferMemory.h"
 #include "VulkanPipileneStates.h"
+#include "Platform/Window.h"
 
 using namespace Sailor;
 class FrameState;
 
-namespace Win32
+namespace Platform
 {
-	class Window;
+       class Window;
 }
 
 using namespace Sailor::Memory;
@@ -43,7 +44,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 		SAILOR_API operator VkDevice() const { return m_device; }
 
-		SAILOR_API VulkanDevice(Win32::Window* pViewport, RHI::EMsaaSamples requestMsaa);
+               SAILOR_API VulkanDevice(Platform::Window* pViewport, RHI::EMsaaSamples requestMsaa);
 		SAILOR_API virtual ~VulkanDevice();
 
 		SAILOR_API void BeginConditionalDestroy();
@@ -74,8 +75,8 @@ namespace Sailor::GraphicsDriver::Vulkan
 			TVector<VulkanSemaphorePtr> signalSemaphores = {},
 			TVector<VulkanSemaphorePtr> waitSemaphores = {});
 
-		SAILOR_API bool ShouldFixLostDevice(const Win32::Window* pViewport);
-		SAILOR_API void FixLostDevice(Win32::Window* pViewport);
+               SAILOR_API bool ShouldFixLostDevice(const Platform::Window* pViewport);
+               SAILOR_API void FixLostDevice(Platform::Window* pViewport);
 
 		SAILOR_API bool IsMultiDrawIndirectSupported() const { return m_bSupportsMultiDrawIndirect; };
 		SAILOR_API float GetMaxAllowedAnisotropy() const { return m_physicalDeviceProperties.limits.maxSamplerAnisotropy; };
@@ -149,9 +150,9 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API TUniquePtr<ThreadContext> CreateThreadContext();
 
 		SAILOR_API void CreateLogicalDevice(VkPhysicalDevice physicalDevice);
-		SAILOR_API void CreateWin32Surface(const Win32::Window* pViewport);
-		SAILOR_API void CreateSwapchain(Win32::Window* pViewport);
-		SAILOR_API bool RecreateSwapchain(Win32::Window* pViewport);
+               SAILOR_API void CreateWin32Surface(const Platform::Window* pViewport);
+               SAILOR_API void CreateSwapchain(Platform::Window* pViewport);
+               SAILOR_API bool RecreateSwapchain(Platform::Window* pViewport);
 		SAILOR_API void CreateDefaultRenderPass();
 		SAILOR_API void CreateFrameDependencies();
 		SAILOR_API void CreateFrameSyncSemaphores();

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -13,7 +13,7 @@
 #include "RHI/Types.h"
 #include "Memory.h"
 #include "Memory/MemoryBlockAllocator.hpp"
-#include "Platform/Win32/Window.h"
+#include "Platform/Window.h"
 #include "VulkanApi.h"
 #include "VulkanImageView.h"
 #include "VulkanImage.h"
@@ -33,7 +33,7 @@
 using namespace Sailor;
 using namespace Sailor::GraphicsDriver::Vulkan;
 
-void VulkanGraphicsDriver::Initialize(Win32::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug)
+void VulkanGraphicsDriver::Initialize(Platform::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug)
 {
 	GraphicsDriver::Vulkan::VulkanApi::Initialize(pViewport, msaaSamples, bIsDebug);
 	m_vkInstance = GraphicsDriver::Vulkan::VulkanApi::GetInstance();
@@ -121,12 +121,12 @@ uint32_t VulkanGraphicsDriver::GetNumSubmittedCommandBuffers() const
 	return m_vkInstance->GetMainDevice()->GetNumSubmittedCommandBufers();
 }
 
-bool VulkanGraphicsDriver::ShouldFixLostDevice(const Win32::Window* pViewport)
+bool VulkanGraphicsDriver::ShouldFixLostDevice(const Platform::Window* pViewport)
 {
 	return m_vkInstance->GetMainDevice()->ShouldFixLostDevice(pViewport);
 }
 
-bool VulkanGraphicsDriver::FixLostDevice(Win32::Window* pViewport)
+bool VulkanGraphicsDriver::FixLostDevice(Platform::Window* pViewport)
 {
 	SAILOR_PROFILE_FUNCTION();
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -12,7 +12,7 @@
 #include "GraphicsDriver/Vulkan/VulkanMemory.h"
 #include "GraphicsDriver/Vulkan/VulkanBufferMemory.h"
 #include "GraphicsDriver/Vulkan/VulkanDevice.h"
-#include "Platform/Win32/Window.h"
+#include "Platform/Window.h"
 #include "Containers/ConcurrentMap.h"
 
 #ifdef SAILOR_BUILD_WITH_VULKAN
@@ -23,7 +23,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 	{
 	public:
 
-		SAILOR_API virtual void Initialize(Win32::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug) override;
+               SAILOR_API virtual void Initialize(Platform::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug) override;
 		SAILOR_API virtual ~VulkanGraphicsDriver() override;
 		SAILOR_API virtual void BeginConditionalDestroy() override;
 
@@ -32,8 +32,8 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 		SAILOR_API virtual uint32_t GetNumSubmittedCommandBuffers() const override;
 
-		SAILOR_API virtual bool ShouldFixLostDevice(const Win32::Window* pViewport) override;
-		SAILOR_API virtual bool FixLostDevice(Win32::Window* pViewport) override;
+               SAILOR_API virtual bool ShouldFixLostDevice(const Platform::Window* pViewport) override;
+               SAILOR_API virtual bool FixLostDevice(Platform::Window* pViewport) override;
 
 		SAILOR_API virtual bool AcquireNextImage() override;
 		SAILOR_API virtual bool PresentFrame(const class FrameState& state, const TVector<RHI::RHICommandListPtr>& primaryCommandBuffers, const TVector<RHI::RHISemaphorePtr>& waitSemaphores) const override;

--- a/Runtime/Platform/ConsoleWindow.h
+++ b/Runtime/Platform/ConsoleWindow.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#ifdef _WIN32
+#include "Platform/Win32/ConsoleWindow.h"
+namespace Sailor::Platform
+{
+    using ConsoleWindow = Sailor::Win32::ConsoleWindow;
+}
+#else
+namespace Sailor::Platform
+{
+    class ConsoleWindow
+    {
+    public:
+        static void Initialize(bool) {}
+        void OpenWindow(const wchar_t*) {}
+        void CloseWindow() {}
+        void Update() {}
+    };
+}
+#endif

--- a/Runtime/Platform/Input.h
+++ b/Runtime/Platform/Input.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#ifdef _WIN32
+#include "Platform/Win32/Input.h"
+namespace Sailor::Platform
+{
+    using InputState = Sailor::Win32::InputState;
+    using GlobalInput = Sailor::Win32::GlobalInput;
+}
+#else
+namespace Sailor::Platform
+{
+    struct InputState {};
+    class GlobalInput
+    {
+    public:
+        static const InputState& GetInputState()
+        {
+            static InputState state{};
+            return state;
+        }
+    };
+}
+#endif

--- a/Runtime/Platform/Platform.h
+++ b/Runtime/Platform/Platform.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "Platform/Window.h"
+#include "Platform/Input.h"
+#include "Platform/ConsoleWindow.h"

--- a/Runtime/Platform/Window.h
+++ b/Runtime/Platform/Window.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#ifdef _WIN32
+#include "Platform/Win32/Window.h"
+namespace Sailor::Platform
+{
+    using Window = Sailor::Win32::Window;
+}
+#else
+namespace Sailor::Platform
+{
+    class Window
+    {
+        // TODO: Implement window for non-Windows platforms
+    };
+}
+#endif

--- a/Runtime/RHI/GraphicsDriver.h
+++ b/Runtime/RHI/GraphicsDriver.h
@@ -49,9 +49,9 @@ namespace Sailor
 	using ShaderSetPtr = TObjectPtr<class ShaderSet>;
 }
 
-namespace Sailor::Win32
+namespace Sailor::Platform
 {
-	class Window;
+       class Window;
 }
 
 namespace Sailor::RHI
@@ -60,7 +60,7 @@ namespace Sailor::RHI
 	{
 	public:
 
-		SAILOR_API virtual void Initialize(Win32::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug) = 0;
+               SAILOR_API virtual void Initialize(Platform::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug) = 0;
 		SAILOR_API virtual ~IGraphicsDriver() = default;
 
 		SAILOR_API virtual void BeginConditionalDestroy() = 0;
@@ -70,8 +70,8 @@ namespace Sailor::RHI
 
 		SAILOR_API virtual uint32_t GetNumSubmittedCommandBuffers() const = 0;
 
-		SAILOR_API virtual bool ShouldFixLostDevice(const Win32::Window* pViewport) = 0;
-		SAILOR_API virtual bool FixLostDevice(Win32::Window* pViewport) = 0;
+               SAILOR_API virtual bool ShouldFixLostDevice(const Platform::Window* pViewport) = 0;
+               SAILOR_API virtual bool FixLostDevice(Platform::Window* pViewport) = 0;
 
 		SAILOR_API virtual bool AcquireNextImage() = 0;
 		SAILOR_API virtual bool PresentFrame(const Sailor::FrameState& state,

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -12,6 +12,7 @@
 #include "Tasks/Scheduler.h"
 #include "Memory/MemoryBlockAllocator.hpp"
 #include "GraphicsDriver/Vulkan/VulkanGraphicsDriver.h"
+#include "Platform/Window.h"
 #include "Components/TestComponent.h"
 #include "Components/MeshRendererComponent.h"
 #include "Engine/World.h"
@@ -52,7 +53,7 @@ bool IDelayedInitialization::IsReady() const
 	return m_dependencies.Num() == 0;
 }
 
-Renderer::Renderer(Win32::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug)
+Renderer::Renderer(Platform::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug)
 {
 	m_pViewport = pViewport;
 	m_msaaSamples = msaaSamples;

--- a/Runtime/RHI/Renderer.h
+++ b/Runtime/RHI/Renderer.h
@@ -16,6 +16,7 @@
 #include "Tasks/Scheduler.h"
 #include "GraphicsDriver.h"
 #include "SceneView.h"
+#include "Platform/Window.h"
 
 namespace Sailor
 {
@@ -33,7 +34,7 @@ namespace Sailor::RHI
 
 		static constexpr uint32_t MaxFramesInQueue = 2;
 
-		SAILOR_API Renderer(class Win32::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug);
+               SAILOR_API Renderer(class Platform::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug);
 		SAILOR_API ~Renderer() override;
 
 		SAILOR_API RHI::EMsaaSamples GetMsaaSamples() const { return m_msaaSamples; }
@@ -67,7 +68,7 @@ namespace Sailor::RHI
 
 		RHI::Stats m_stats{};
 
-		class Win32::Window* m_pViewport;
+               class Platform::Window* m_pViewport;
 
 		FrameGraphPtr m_frameGraph{};
 		TConcurrentMap<WorldPtr, TList<TPair<RHISceneViewPtr,bool>>, 4, ERehashPolicy::Never> m_cachedSceneViews{};

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -7,8 +7,8 @@
 #include "AssetRegistry/FrameGraph/FrameGraphImporter.h"
 #include "AssetRegistry/Prefab/PrefabImporter.h"
 #include "AssetRegistry/World/WorldPrefabImporter.h"
-#include "Platform/Win32/ConsoleWindow.h"
-#include "Platform/Win32/Input.h"
+#include "Platform/ConsoleWindow.h"
+#include "Platform/Input.h"
 #include "GraphicsDriver/Vulkan/VulkanApi.h"
 #include "Tasks/Scheduler.h"
 #include "RHI/Renderer.h"
@@ -105,12 +105,12 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 
 	s_pInstance = new App();
 
-	Win32::ConsoleWindow::Initialize(false);
+       Platform::ConsoleWindow::Initialize(false);
 
-	if (params.m_bRunConsole)
-	{
-		Win32::ConsoleWindow::GetInstance()->OpenWindow(L"Sailor Console");
-	}
+       if (params.m_bRunConsole)
+       {
+               Platform::ConsoleWindow::GetInstance()->OpenWindow(L"Sailor Console");
+       }
 
 	if (!params.m_workspace.empty())
 	{
@@ -131,7 +131,7 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	bEnableRenderValidationLayers = false;
 #endif
 
-	s_pInstance->m_pMainWindow = TUniquePtr<Win32::Window>::Make();
+       s_pInstance->m_pMainWindow = TUniquePtr<Platform::Window>::Make();
 
 	std::string className = "SailorEngine";
 	if (params.m_editorHwnd != 0)
@@ -236,10 +236,10 @@ void App::Start()
 		timer.Start();
 		trackEditor.Start();
 
-		Win32::ConsoleWindow::GetInstance()->Update();
+               Platform::ConsoleWindow::GetInstance()->Update();
 
 		char line[256];
-		if (Win32::ConsoleWindow::GetInstance()->Read(line, 256) != 0)
+               if (Platform::ConsoleWindow::GetInstance()->Read(line, 256) != 0)
 		{
 			std::string cmd = std::string(line);
 			Utils::Trim(cmd);
@@ -251,7 +251,7 @@ void App::Start()
 			}
 		}
 
-		Win32::Window::ProcessWin32Msgs();
+               Platform::Window::ProcessWin32Msgs();
 		renderer->FixLostDevice();
 
 		scheduler->ProcessTasksOnMainThread();
@@ -405,7 +405,7 @@ void App::Shutdown()
 	RemoveSubmodule<Renderer>();
 	RemoveSubmodule<Tasks::Scheduler>();
 
-	Win32::ConsoleWindow::Shutdown();
+       Platform::ConsoleWindow::Shutdown();
 
 	// Remove all left submodules
 	for (auto& pSubmodule : s_pInstance->m_submodules)
@@ -420,7 +420,7 @@ void App::Shutdown()
 	s_pInstance = nullptr;
 }
 
-TUniquePtr<Sailor::Win32::Window>& App::GetMainWindow()
+TUniquePtr<Sailor::Platform::Window>& App::GetMainWindow()
 {
 	return s_pInstance->m_pMainWindow;
 }

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -6,7 +6,7 @@
 #include "Memory/SharedPtr.hpp"
 #include "Memory/WeakPtr.hpp"
 #include "Memory/UniquePtr.hpp"
-#include "Platform/Win32/Window.h"
+#include "Platform/Window.h"
 #include "Containers/Containers.h"
 #include "Math/Math.h"
 
@@ -74,13 +74,13 @@ namespace Sailor
 			s_pInstance->m_submodules[TSubmodule<T>::GetTypeId()].Clear();
 		}
 
-		static TUniquePtr<Win32::Window>& GetMainWindow();
+               static TUniquePtr<Platform::Window>& GetMainWindow();
 		static const char* GetApplicationName() { return "SailorEngine"; }
 		static const char* GetEngineName() { return "SailorEngine"; }
 
 	protected:
 
-		TUniquePtr<Win32::Window> m_pMainWindow;
+               TUniquePtr<Platform::Window> m_pMainWindow;
 
 	private:
 

--- a/Runtime/Submodules/Editor.cpp
+++ b/Runtime/Submodules/Editor.cpp
@@ -12,11 +12,11 @@
 #include <ctime>
 #include <iomanip>
 #include <sstream>
-#include "Platform/Win32/Window.h"
+#include "Platform/Window.h"
 
 using namespace Sailor;
 
-Editor::Editor(HWND editorHwnd, uint32_t editorPort, Sailor::Win32::Window* pMainWindow) :
+Editor::Editor(HWND editorHwnd, uint32_t editorPort, Sailor::Platform::Window* pMainWindow) :
 	m_editorPort(editorPort),
 	m_editorHwnd(editorHwnd),
 	m_pMainWindow(pMainWindow)

--- a/Runtime/Submodules/Editor.h
+++ b/Runtime/Submodules/Editor.h
@@ -3,19 +3,21 @@
 #include <yaml-cpp/yaml.h>
 #include <concurrent_queue.h>
 #include <wtypes.h>
+#include "Platform/Window.h"
 
 namespace Sailor
 {
-	namespace Win32 
-	{
-		class Window;
-	}
+
+       namespace Platform
+       {
+               class Window;
+       }
 
 	class Editor : public TSubmodule<Editor>
 	{
 	public:
 
-		Editor(HWND editorHwnd, uint32_t editorPort, Win32::Window* pMainWindow);
+               Editor(HWND editorHwnd, uint32_t editorPort, Platform::Window* pMainWindow);
 
 		void SetWorld(class World* world) { m_world = world; }
 
@@ -42,7 +44,7 @@ namespace Sailor
 		uint32_t m_editorPort;
 		HWND m_editorHwnd;
 
-		class Win32::Window* m_pMainWindow = nullptr;
+               class Platform::Window* m_pMainWindow = nullptr;
 
 		class World* m_world;
 	};


### PR DESCRIPTION
## Summary
- add new `Platform` headers and wrap Win32 implementation behind `_WIN32`
- use `Platform::Window`, `Platform::InputState` and `Platform::ConsoleWindow`
- update various modules to rely on platform-agnostic types

## Testing
- `cmake -S . -B build` *(fails: Could not find yaml-cpp)*