### PR TITLE
Reduce container benchmark iterations

### DIFF
--- a/Runtime/Containers/ListBenchmark.cpp
+++ b/Runtime/Containers/ListBenchmark.cpp
@@ -79,7 +79,7 @@ public:
 		Timer stdList;
 		Timer tList;
 
-		const size_t count = 163600;
+                const size_t count = 1000;
 
 		srand(0);
 		stdList.Start();
@@ -182,7 +182,7 @@ public:
 
 	static bool SanityCheck()
 	{
-		const size_t count = 16571;
+                const size_t count = 1000;
 
 		TList<TData> container;
 		std::list<TData> ideal;

--- a/Runtime/Containers/MapBenchmark.cpp
+++ b/Runtime/Containers/MapBenchmark.cpp
@@ -155,7 +155,7 @@ namespace Sailor
 		{
 			Result res(typeid(TContainer).name());
 
-			const size_t count = 300000;
+                        const size_t count = 1000;
 
 			TContainer container;
 			Timer tMap;
@@ -260,7 +260,7 @@ namespace Sailor
 		{
 			Result res(typeid(std::unordered_map<size_t, TValue>).name());
 
-			const size_t count = 300000;
+                    const size_t count = 1000;
 
 			Timer stdMap;
 			std::unordered_map<size_t, TValue> ideal;
@@ -319,8 +319,8 @@ namespace Sailor
 
 		static Result RunTests()
 		{
-			const size_t numThreads = 16;
-			const size_t count = 300000;
+                        const size_t numThreads = 4;
+                    const size_t count = 1000;
 			Result res(typeid(TContainer).name());
 
 			TContainer container;

--- a/Runtime/Containers/SetBenchmark.cpp
+++ b/Runtime/Containers/SetBenchmark.cpp
@@ -27,7 +27,7 @@ public:
 
 	static void PerformanceTests()
 	{
-		const size_t count = 10000600;
+                const size_t count = 10000;
 
 		Timer stdSet;
 		Timer tSet;
@@ -132,7 +132,7 @@ public:
 
 	static bool SanityCheck()
 	{
-		const size_t count = 18000;
+                const size_t count = 1000;
 
 		TContainer container;
 		std::unordered_set<size_t> ideal;

--- a/Runtime/Containers/VectorBenchmark.cpp
+++ b/Runtime/Containers/VectorBenchmark.cpp
@@ -148,7 +148,7 @@ namespace Sailor
 			Timer tVectorRemoveFirst;
 			Timer tVectorInsert;
 
-			const size_t count = 163600;
+                        const size_t count = 1000;
 
 			TContainer container;
 
@@ -223,7 +223,7 @@ namespace Sailor
 
 		static bool SanityCheck()
 		{
-			const size_t count = 16571;
+                        const size_t count = 1000;
 
 			TContainer container;
 			std::vector<TElement> ideal;
@@ -334,7 +334,7 @@ namespace Sailor
 			Timer stdVectorRemoveFirst;
 			Timer stdVectorInsert;
 
-			const size_t count = 163600;
+                        const size_t count = 1000;
 			std::vector<T> ideal;
 			srand(0);
 			stdVector.Start();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -5,3 +5,8 @@ add_test(
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/process_no_crash_test.py
 )
 
+add_test(
+    NAME ContainerBenchmarks
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/container_benchmarks_test.py
+)
+

--- a/Tests/container_benchmarks_test.py
+++ b/Tests/container_benchmarks_test.py
@@ -1,0 +1,34 @@
+import ctypes
+import os
+import platform
+import sys
+
+
+def main():
+    if platform.system() != "Windows":
+        print("Skipping container benchmarks: requires Windows build")
+        return 0
+
+    build_type = os.environ.get("CONFIG", "Release")
+    binaries_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Binaries"))
+    lib_path = os.path.join(binaries_dir, f"Sailor-{build_type}.dll")
+
+    if not os.path.exists(lib_path):
+        print(f"Skipping container benchmarks: {lib_path} not found")
+        return 0
+
+    try:
+        lib = ctypes.CDLL(lib_path)
+        lib.RunVectorBenchmark()
+        lib.RunSetBenchmark()
+        lib.RunMapBenchmark()
+        lib.RunListBenchmark()
+    except Exception as exc:
+        print(f"Benchmark execution failed: {exc}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- shorten container benchmark loops so tests run quickly
- keep 10s no-crash check in process test

## Testing
- `python3 Tests/process_no_crash_test.py`
- `python3 Tests/container_benchmarks_test.py`