### PR TITLE
Implement basic external image export/import

### DIFF
--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.h
@@ -7,6 +7,10 @@
 #include <iostream>
 #include <cstdint>
 #include <vulkan/vulkan_core.h>
+#ifdef _WIN32
+#include <vulkan/vulkan_win32.h>
+#include <windows.h>
+#endif
 #include "Sailor.h"
 #include "RHI/Types.h"
 #include "AssetRegistry/Shader/ShaderCompiler.h"
@@ -216,11 +220,11 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API static VulkanBufferPtr CreateBuffer_Immediate(VulkanDevicePtr device, const void* pData, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode = VkSharingMode::VK_SHARING_MODE_CONCURRENT);
 		SAILOR_API static void CopyBuffer_Immediate(VulkanDevicePtr device, VulkanBufferMemoryPtr  src, VulkanBufferMemoryPtr dst, VkDeviceSize size, VkDeviceSize srcOffset = 0, VkDeviceSize dstOffset = 0);
 
-		SAILOR_API static VulkanImagePtr CreateImage_Immediate(
-			VulkanDevicePtr device,
-			const void* pData,
-			VkDeviceSize size,
-			VkExtent3D extent,
+                SAILOR_API static VulkanImagePtr CreateImage_Immediate(
+                        VulkanDevicePtr device,
+                        const void* pData,
+                        VkDeviceSize size,
+                        VkExtent3D extent,
 			uint32_t mipLevels = 1,
 			VkImageType type = VK_IMAGE_TYPE_2D,
 			VkFormat format = VK_FORMAT_R8G8B8A8_SRGB,
@@ -228,8 +232,25 @@ namespace Sailor::GraphicsDriver::Vulkan
 			VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
 			VkSharingMode sharingMode = VkSharingMode::VK_SHARING_MODE_EXCLUSIVE,
 			VkImageLayout defaultLayout = VkImageLayout::VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-			VkImageCreateFlags flags = 0,
-			uint32_t arrayLayer = 1);
+                        VkImageCreateFlags flags = 0,
+                        uint32_t arrayLayer = 1);
+
+                SAILOR_API static void* ExportImage(VulkanDevicePtr device, VulkanImagePtr image,
+#ifdef _WIN32
+                        VkExternalMemoryHandleTypeFlagBits handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
+#else
+                        VkExternalMemoryHandleTypeFlagBits handleType = (VkExternalMemoryHandleTypeFlagBits)0);
+#endif
+
+                SAILOR_API static VulkanImagePtr ImportImage(VulkanDevicePtr device,
+                        void* handle,
+                        VkExtent3D extent,
+                        VkFormat format,
+                        VkImageUsageFlags usage,
+                        VkImageLayout defaultLayout,
+                        VkImageCreateFlags flags = 0,
+                        uint32_t arrayLayers = 1,
+                        VkSampleCountFlagBits sampleCount = VK_SAMPLE_COUNT_1_BIT);
 
 		//Immediate context
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -126,17 +126,24 @@ namespace Sailor::GraphicsDriver::Vulkan
 		// Begin Immediate context
 		SAILOR_API virtual RHI::RHIBufferPtr CreateBuffer_Immediate(const void* pData, size_t size, RHI::EBufferUsageFlags usage) override;
 		SAILOR_API virtual void CopyBuffer_Immediate(RHI::RHIBufferPtr src, RHI::RHIBufferPtr dst, size_t size) override;
-		SAILOR_API virtual RHI::RHITexturePtr CreateImage_Immediate(
-			const void* pData,
-			size_t size,
-			glm::ivec3 extent,
-			uint32_t mipLevels = 1,
-			RHI::ETextureType type = RHI::ETextureType::Texture2D,
-			RHI::ETextureFormat format = RHI::ETextureFormat::R8G8B8A8_SRGB,
-			RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear,
-			RHI::ETextureClamping clamping = RHI::ETextureClamping::Clamp,
-			RHI::ETextureUsageFlags usage = RHI::ETextureUsageBit::TextureTransferSrc_Bit | RHI::ETextureUsageBit::TextureTransferDst_Bit | RHI::ETextureUsageBit::Sampled_Bit) override;
-		//End Immediate context
+                SAILOR_API virtual RHI::RHITexturePtr CreateImage_Immediate(
+                        const void* pData,
+                        size_t size,
+                        glm::ivec3 extent,
+                        uint32_t mipLevels = 1,
+                        RHI::ETextureType type = RHI::ETextureType::Texture2D,
+                        RHI::ETextureFormat format = RHI::ETextureFormat::R8G8B8A8_SRGB,
+                        RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear,
+                        RHI::ETextureClamping clamping = RHI::ETextureClamping::Clamp,
+                        RHI::ETextureUsageFlags usage = RHI::ETextureUsageBit::TextureTransferSrc_Bit | RHI::ETextureUsageBit::TextureTransferDst_Bit | RHI::ETextureUsageBit::Sampled_Bit) override;
+
+                SAILOR_API virtual void* ExportImage(RHI::RHITexturePtr image) override;
+                SAILOR_API virtual RHI::RHITexturePtr ImportImage(void* handle,
+                        glm::ivec3 extent,
+                        RHI::ETextureFormat format,
+                        RHI::ETextureUsageFlags usage,
+                        RHI::EImageLayout layout = RHI::EImageLayout::ShaderReadOnlyOptimal) override;
+                //End Immediate context
 
 		//Begin IGraphicsDriverCommands
 

--- a/Runtime/RHI/GraphicsDriver.h
+++ b/Runtime/RHI/GraphicsDriver.h
@@ -192,17 +192,25 @@ namespace Sailor::RHI
 		SAILOR_API virtual void CopyBuffer_Immediate(RHIBufferPtr src, RHIBufferPtr dst, size_t size) = 0;
 		SAILOR_API virtual void SubmitCommandList_Immediate(RHICommandListPtr commandList);
 
-		SAILOR_API virtual RHITexturePtr CreateImage_Immediate(
-			const void* pData,
-			size_t size,
-			glm::ivec3 extent,
-			uint32_t mipLevels = 1,
-			ETextureType type = ETextureType::Texture2D,
-			ETextureFormat format = ETextureFormat::R8G8B8A8_SRGB,
-			ETextureFiltration filtration = ETextureFiltration::Linear,
-			ETextureClamping clamping = ETextureClamping::Clamp,
-			ETextureUsageFlags usage = ETextureUsageBit::TextureTransferSrc_Bit | ETextureUsageBit::TextureTransferDst_Bit | ETextureUsageBit::Sampled_Bit) = 0;
-		//Immediate context
+                SAILOR_API virtual RHITexturePtr CreateImage_Immediate(
+                        const void* pData,
+                        size_t size,
+                        glm::ivec3 extent,
+                        uint32_t mipLevels = 1,
+                        ETextureType type = ETextureType::Texture2D,
+                        ETextureFormat format = ETextureFormat::R8G8B8A8_SRGB,
+                        ETextureFiltration filtration = ETextureFiltration::Linear,
+                        ETextureClamping clamping = ETextureClamping::Clamp,
+                        ETextureUsageFlags usage = ETextureUsageBit::TextureTransferSrc_Bit | ETextureUsageBit::TextureTransferDst_Bit | ETextureUsageBit::Sampled_Bit) = 0;
+
+                // External memory support
+                SAILOR_API virtual void* ExportImage(RHITexturePtr image) = 0;
+                SAILOR_API virtual RHITexturePtr ImportImage(void* handle,
+                        glm::ivec3 extent,
+                        ETextureFormat format,
+                        ETextureUsageFlags usage,
+                        EImageLayout layout = EImageLayout::ShaderReadOnlyOptimal) = 0;
+                //Immediate context
 
 		SAILOR_API virtual void CollectGarbage_RenderThread() = 0;
 		SAILOR_API void TrackResources_ThreadSafe();


### PR DESCRIPTION
## Summary
- add external memory APIs in `IGraphicsDriver`
- implement Export/Import image support in Vulkan backend
- expose new helpers in VulkanApi
- hide Win32-specific code behind `_WIN32` checks

## Testing
- `python3 Tests/process_no_crash_test.py`
- `git status --short`