### PR TITLE
Fix Vulkan external image compilation

### DIFF
--- a/Runtime/Engine/EngineLoop.cpp
+++ b/Runtime/Engine/EngineLoop.cpp
@@ -14,6 +14,9 @@
 #include "RHI/Types.h"
 #include "RHI/CommandList.h"
 
+#include <thread>
+#include <chrono>
+
 using namespace Sailor;
 
 TSharedPtr<World> EngineLoop::CreateEmptyWorld(std::string name, EWorldBehaviourMask mask)

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
@@ -1,5 +1,9 @@
 #include "GraphicsDriver/Vulkan/VulkanApi.h"
 #include <vulkan/vulkan.h>
+#ifdef _WIN32
+#include <vulkan/vulkan_win32.h>
+#include <windows.h>
+#endif
 #include "Containers/Map.h"
 #include "Core/LogMacros.h"
 #include "Containers/Vector.h"
@@ -1021,10 +1025,10 @@ VulkanImagePtr VulkanApi::CreateImage(
 }
 
 VulkanImagePtr VulkanApi::CreateImage_Immediate(
-	VulkanDevicePtr device,
-	const void* pData,
-	VkDeviceSize size,
-	VkExtent3D extent,
+        VulkanDevicePtr device,
+        const void* pData,
+        VkDeviceSize size,
+        VkExtent3D extent,
 	uint32_t mipLevels,
 	VkImageType type,
 	VkFormat format,
@@ -1044,10 +1048,87 @@ VulkanImagePtr VulkanApi::CreateImage_Immediate(
 
 	auto fence = VulkanFencePtr::Make(device);
 	device->SubmitCommandBuffer(cmdBuffer, fence);
-	fence->Wait();
+        fence->Wait();
 
-	return res;
+        return res;
 }
+
+#ifdef _WIN32
+void* VulkanApi::ExportImage(VulkanDevicePtr device, VulkanImagePtr image, VkExternalMemoryHandleTypeFlagBits handleType)
+{
+        auto vkGetMemoryWin32HandleKHR = (PFN_vkGetMemoryWin32HandleKHR)vkGetDeviceProcAddr(*device, "vkGetMemoryWin32HandleKHR");
+        if (!vkGetMemoryWin32HandleKHR)
+        {
+                return nullptr;
+        }
+
+        VkMemoryGetWin32HandleInfoKHR handleInfo{};
+        handleInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR;
+        handleInfo.handleType = handleType;
+        handleInfo.memory = *image->GetMemoryDevice();
+
+        HANDLE handle = nullptr;
+        if (vkGetMemoryWin32HandleKHR(*device, &handleInfo, &handle) != VK_SUCCESS)
+        {
+                return nullptr;
+        }
+        return handle;
+}
+#else
+void* VulkanApi::ExportImage(VulkanDevicePtr /*device*/, VulkanImagePtr /*image*/, VkExternalMemoryHandleTypeFlagBits /*handleType*/)
+{
+    return nullptr;
+}
+#endif
+
+#ifdef _WIN32
+VulkanImagePtr VulkanApi::ImportImage(VulkanDevicePtr device,
+        void* handle,
+        VkExtent3D extent,
+        VkFormat format,
+        VkImageUsageFlags usage,
+        VkImageLayout defaultLayout,
+        VkImageCreateFlags flags,
+        uint32_t arrayLayers,
+        VkSampleCountFlagBits sampleCount)
+{
+        VulkanImagePtr outImage = new VulkanImage(device);
+        outImage->EnableExternalMemory(VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
+        outImage->m_extent = extent;
+        outImage->m_imageType = VK_IMAGE_TYPE_2D;
+        outImage->m_format = format;
+        outImage->m_tiling = VK_IMAGE_TILING_OPTIMAL;
+        outImage->m_usage = usage;
+        outImage->m_mipLevels = 1;
+        outImage->m_samples = sampleCount;
+        outImage->m_arrayLayers = arrayLayers;
+        outImage->m_sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+        outImage->m_defaultLayout = defaultLayout;
+        outImage->m_initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+        outImage->m_flags = flags;
+
+        outImage->Compile();
+
+        VkMemoryRequirements requirements = outImage->GetMemoryRequirements();
+
+        VkImportMemoryWin32HandleInfoKHR importInfo{};
+        importInfo.sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
+        importInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+        importInfo.handle = (HANDLE)handle;
+
+        auto memory = VulkanDeviceMemoryPtr::Make(device, requirements,
+                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &importInfo);
+
+        outImage->Bind(memory, 0);
+
+        return outImage;
+}
+#else
+VulkanImagePtr VulkanApi::ImportImage(VulkanDevicePtr /*device*/, void* /*handle*/, VkExtent3D /*extent*/, VkFormat /*format*/, VkImageUsageFlags /*usage*/, VkImageLayout /*defaultLayout*/, VkImageCreateFlags /*flags*/, uint32_t /*arrayLayers*/, VkSampleCountFlagBits /*sampleCount*/)
+{
+        return nullptr;
+}
+#endif
 
 VkDescriptorSetLayoutBinding VulkanApi::CreateDescriptorSetLayoutBinding(uint32_t binding, VkDescriptorType descriptorType, uint32_t descriptorCount, VkShaderStageFlags stageFlags, const VkSampler* pImmutableSamplers)
 {

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.h
@@ -7,6 +7,10 @@
 #include <iostream>
 #include <cstdint>
 #include <vulkan/vulkan_core.h>
+#ifdef _WIN32
+#include <vulkan/vulkan_win32.h>
+#include <windows.h>
+#endif
 #include "Sailor.h"
 #include "RHI/Types.h"
 #include "AssetRegistry/Shader/ShaderCompiler.h"
@@ -216,11 +220,11 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API static VulkanBufferPtr CreateBuffer_Immediate(VulkanDevicePtr device, const void* pData, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode = VkSharingMode::VK_SHARING_MODE_CONCURRENT);
 		SAILOR_API static void CopyBuffer_Immediate(VulkanDevicePtr device, VulkanBufferMemoryPtr  src, VulkanBufferMemoryPtr dst, VkDeviceSize size, VkDeviceSize srcOffset = 0, VkDeviceSize dstOffset = 0);
 
-		SAILOR_API static VulkanImagePtr CreateImage_Immediate(
-			VulkanDevicePtr device,
-			const void* pData,
-			VkDeviceSize size,
-			VkExtent3D extent,
+                SAILOR_API static VulkanImagePtr CreateImage_Immediate(
+                        VulkanDevicePtr device,
+                        const void* pData,
+                        VkDeviceSize size,
+                        VkExtent3D extent,
 			uint32_t mipLevels = 1,
 			VkImageType type = VK_IMAGE_TYPE_2D,
 			VkFormat format = VK_FORMAT_R8G8B8A8_SRGB,
@@ -228,8 +232,26 @@ namespace Sailor::GraphicsDriver::Vulkan
 			VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
 			VkSharingMode sharingMode = VkSharingMode::VK_SHARING_MODE_EXCLUSIVE,
 			VkImageLayout defaultLayout = VkImageLayout::VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-			VkImageCreateFlags flags = 0,
-			uint32_t arrayLayer = 1);
+                        VkImageCreateFlags flags = 0,
+                        uint32_t arrayLayer = 1);
+
+#ifdef _WIN32
+                SAILOR_API static void* ExportImage(VulkanDevicePtr device, VulkanImagePtr image,
+                        VkExternalMemoryHandleTypeFlagBits handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
+#else
+                SAILOR_API static void* ExportImage(VulkanDevicePtr device, VulkanImagePtr image,
+                        VkExternalMemoryHandleTypeFlagBits handleType = (VkExternalMemoryHandleTypeFlagBits)0);
+#endif
+
+                SAILOR_API static VulkanImagePtr ImportImage(VulkanDevicePtr device,
+                        void* handle,
+                        VkExtent3D extent,
+                        VkFormat format,
+                        VkImageUsageFlags usage,
+                        VkImageLayout defaultLayout,
+                        VkImageCreateFlags flags = 0,
+                        uint32_t arrayLayers = 1,
+                        VkSampleCountFlagBits sampleCount = VK_SAMPLE_COUNT_1_BIT);
 
 		//Immediate context
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -126,17 +126,24 @@ namespace Sailor::GraphicsDriver::Vulkan
 		// Begin Immediate context
 		SAILOR_API virtual RHI::RHIBufferPtr CreateBuffer_Immediate(const void* pData, size_t size, RHI::EBufferUsageFlags usage) override;
 		SAILOR_API virtual void CopyBuffer_Immediate(RHI::RHIBufferPtr src, RHI::RHIBufferPtr dst, size_t size) override;
-		SAILOR_API virtual RHI::RHITexturePtr CreateImage_Immediate(
-			const void* pData,
-			size_t size,
-			glm::ivec3 extent,
-			uint32_t mipLevels = 1,
-			RHI::ETextureType type = RHI::ETextureType::Texture2D,
-			RHI::ETextureFormat format = RHI::ETextureFormat::R8G8B8A8_SRGB,
-			RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear,
-			RHI::ETextureClamping clamping = RHI::ETextureClamping::Clamp,
-			RHI::ETextureUsageFlags usage = RHI::ETextureUsageBit::TextureTransferSrc_Bit | RHI::ETextureUsageBit::TextureTransferDst_Bit | RHI::ETextureUsageBit::Sampled_Bit) override;
-		//End Immediate context
+                SAILOR_API virtual RHI::RHITexturePtr CreateImage_Immediate(
+                        const void* pData,
+                        size_t size,
+                        glm::ivec3 extent,
+                        uint32_t mipLevels = 1,
+                        RHI::ETextureType type = RHI::ETextureType::Texture2D,
+                        RHI::ETextureFormat format = RHI::ETextureFormat::R8G8B8A8_SRGB,
+                        RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear,
+                        RHI::ETextureClamping clamping = RHI::ETextureClamping::Clamp,
+                        RHI::ETextureUsageFlags usage = RHI::ETextureUsageBit::TextureTransferSrc_Bit | RHI::ETextureUsageBit::TextureTransferDst_Bit | RHI::ETextureUsageBit::Sampled_Bit) override;
+
+                SAILOR_API virtual void* ExportImage(RHI::RHITexturePtr image) override;
+                SAILOR_API virtual RHI::RHITexturePtr ImportImage(void* handle,
+                        glm::ivec3 extent,
+                        RHI::ETextureFormat format,
+                        RHI::ETextureUsageFlags usage,
+                        RHI::EImageLayout layout = RHI::EImageLayout::ShaderReadOnlyOptimal) override;
+                //End Immediate context
 
 		//Begin IGraphicsDriverCommands
 

--- a/Runtime/RHI/GraphicsDriver.h
+++ b/Runtime/RHI/GraphicsDriver.h
@@ -192,17 +192,25 @@ namespace Sailor::RHI
 		SAILOR_API virtual void CopyBuffer_Immediate(RHIBufferPtr src, RHIBufferPtr dst, size_t size) = 0;
 		SAILOR_API virtual void SubmitCommandList_Immediate(RHICommandListPtr commandList);
 
-		SAILOR_API virtual RHITexturePtr CreateImage_Immediate(
-			const void* pData,
-			size_t size,
-			glm::ivec3 extent,
-			uint32_t mipLevels = 1,
-			ETextureType type = ETextureType::Texture2D,
-			ETextureFormat format = ETextureFormat::R8G8B8A8_SRGB,
-			ETextureFiltration filtration = ETextureFiltration::Linear,
-			ETextureClamping clamping = ETextureClamping::Clamp,
-			ETextureUsageFlags usage = ETextureUsageBit::TextureTransferSrc_Bit | ETextureUsageBit::TextureTransferDst_Bit | ETextureUsageBit::Sampled_Bit) = 0;
-		//Immediate context
+                SAILOR_API virtual RHITexturePtr CreateImage_Immediate(
+                        const void* pData,
+                        size_t size,
+                        glm::ivec3 extent,
+                        uint32_t mipLevels = 1,
+                        ETextureType type = ETextureType::Texture2D,
+                        ETextureFormat format = ETextureFormat::R8G8B8A8_SRGB,
+                        ETextureFiltration filtration = ETextureFiltration::Linear,
+                        ETextureClamping clamping = ETextureClamping::Clamp,
+                        ETextureUsageFlags usage = ETextureUsageBit::TextureTransferSrc_Bit | ETextureUsageBit::TextureTransferDst_Bit | ETextureUsageBit::Sampled_Bit) = 0;
+
+                // External memory support
+                SAILOR_API virtual void* ExportImage(RHITexturePtr image) = 0;
+                SAILOR_API virtual RHITexturePtr ImportImage(void* handle,
+                        glm::ivec3 extent,
+                        ETextureFormat format,
+                        ETextureUsageFlags usage,
+                        EImageLayout layout = EImageLayout::ShaderReadOnlyOptimal) = 0;
+                //Immediate context
 
 		SAILOR_API virtual void CollectGarbage_RenderThread() = 0;
 		SAILOR_API void TrackResources_ThreadSafe();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -5,3 +5,8 @@ add_test(
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/process_no_crash_test.py
 )
 
+add_test(
+    NAME ContainerBenchmarks
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/container_benchmarks_test.py
+)
+

--- a/Tests/container_benchmarks_test.py
+++ b/Tests/container_benchmarks_test.py
@@ -1,0 +1,34 @@
+import ctypes
+import os
+import platform
+import sys
+
+
+def main():
+    if platform.system() != "Windows":
+        print("Skipping container benchmarks: requires Windows build")
+        return 0
+
+    build_type = os.environ.get("CONFIG", "Release")
+    binaries_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Binaries"))
+    lib_path = os.path.join(binaries_dir, f"Sailor-{build_type}.dll")
+
+    if not os.path.exists(lib_path):
+        print(f"Skipping container benchmarks: {lib_path} not found")
+        return 0
+
+    try:
+        lib = ctypes.CDLL(lib_path)
+        lib.RunVectorBenchmark()
+        lib.RunSetBenchmark()
+        lib.RunMapBenchmark()
+        lib.RunListBenchmark()
+    except Exception as exc:
+        print(f"Benchmark execution failed: {exc}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- guard Windows-specific Vulkan includes and default parameters with `_WIN32`
- return stubs for external-memory helpers on non-Windows builds
- use `VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL` for default textures

## Testing
- `python3 Tests/process_no_crash_test.py`