### PR TITLE
Build editor in separate workflow

### DIFF
--- a/.github/workflows/editor-build.yml
+++ b/.github/workflows/editor-build.yml
@@ -1,0 +1,26 @@
+name: Build Editor
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  build-editor:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+
+      - name: Install MAUI workload
+        run: dotnet workload install maui
+
+      - name: Build Editor
+        run: dotnet build Editor/SailorEditor.csproj -c Release

--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -1,4 +1,4 @@
-name: CMake on a single platform
+name: Engine Build
 
 on:
   workflow_dispatch:
@@ -38,6 +38,7 @@ jobs:
       with:
         version: 1.3.275.0        
         cache: true
+
 
     - name: Configure CMake
       run: cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,5 +29,6 @@ message("cxx Flags:" ${CMAKE_CXX_FLAGS})
 add_subdirectory(Exec)
 add_subdirectory(Lib)
 
+
 enable_testing()
 add_subdirectory(Tests)


### PR DESCRIPTION
## Summary
- rename the workflow file to `engine-build.yml` to handle the C++ build
- create a new `editor-build.yml` workflow that builds the MAUI editor with .NET
- remove the custom SailorEditor target from CMake

## Testing
- `cmake -S . -B build` *(fails to find `yaml-cpp`)*