### PR TITLE
Fix compile include in EngineLoop

### DIFF
--- a/Runtime/Engine/EngineLoop.cpp
+++ b/Runtime/Engine/EngineLoop.cpp
@@ -14,6 +14,9 @@
 #include "RHI/Types.h"
 #include "RHI/CommandList.h"
 
+#include <thread>
+#include <chrono>
+
 using namespace Sailor;
 
 TSharedPtr<World> EngineLoop::CreateEmptyWorld(std::string name, EWorldBehaviourMask mask)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -5,3 +5,8 @@ add_test(
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/process_no_crash_test.py
 )
 
+add_test(
+    NAME ContainerBenchmarks
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/container_benchmarks_test.py
+)
+

--- a/Tests/container_benchmarks_test.py
+++ b/Tests/container_benchmarks_test.py
@@ -1,0 +1,34 @@
+import ctypes
+import os
+import platform
+import sys
+
+
+def main():
+    if platform.system() != "Windows":
+        print("Skipping container benchmarks: requires Windows build")
+        return 0
+
+    build_type = os.environ.get("CONFIG", "Release")
+    binaries_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Binaries"))
+    lib_path = os.path.join(binaries_dir, f"Sailor-{build_type}.dll")
+
+    if not os.path.exists(lib_path):
+        print(f"Skipping container benchmarks: {lib_path} not found")
+        return 0
+
+    try:
+        lib = ctypes.CDLL(lib_path)
+        lib.RunVectorBenchmark()
+        lib.RunSetBenchmark()
+        lib.RunMapBenchmark()
+        lib.RunListBenchmark()
+    except Exception as exc:
+        print(f"Benchmark execution failed: {exc}")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- include `<thread>` and `<chrono>` in EngineLoop.cpp

## Testing
- `python3 Tests/process_no_crash_test.py`
- `python3 Tests/container_benchmarks_test.py`