### PR TITLE
Editor serialization cleanup

### DIFF
--- a/Editor/Services/WorldService.cs
+++ b/Editor/Services/WorldService.cs
@@ -38,10 +38,8 @@ namespace SailorEditor.Services
 
         public async void PopulateWorld(string yaml)
         {
-            var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new WorldYamlConverter())
-            .IncludeNonPublicProperties()
             .Build();
 
             var world = deserializer.Deserialize<World>(yaml);
@@ -112,10 +110,9 @@ namespace SailorEditor.Services
 
             using (var writer = new StringWriter())
             {
-                var serializer = new SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                var serializer = SerializationUtils.CreateSerializerBuilder()
                 .WithTypeConverter(new WorldYamlConverter())
-                .IncludeNonPublicProperties().Build();
+                .Build();
 
                 var yaml = serializer.Serialize(Current);
                 writer.Write(yaml);

--- a/Editor/Utility/EngineTypes.cs
+++ b/Editor/Utility/EngineTypes.cs
@@ -176,10 +176,7 @@ namespace SailorEngine
 
         public static EngineTypes FromYaml(string yamlContent)
         {
-            var deserializer = new DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .IgnoreUnmatchedProperties()
-                .Build();
+            var deserializer = SerializationUtils.CreateDeserializerBuilder().Build();
 
             var res = new EngineTypes();
 
@@ -577,27 +574,14 @@ namespace SailorEditor
 
         public object ReadYaml(IParser parser, Type type)
         {
-            var list = new List<float>();
-            parser.Consume<SequenceStart>();
-            while (parser.Current is SequenceEnd == false)
-            {
-                if (parser.Current is Scalar scalar)
-                {
-                    list.Add(float.Parse(scalar.Value, CultureInfo.InvariantCulture.NumberFormat));
-                }
-                parser.MoveNext();
-            }
-            parser.Consume<SequenceEnd>();
+            var list = YamlHelper.ParseFloatSequence(parser);
             return new Vec2 { X = list[0], Y = list[1] };
         }
 
         public void WriteYaml(IEmitter emitter, object value, Type type)
         {
             var vec = (Vec2)value;
-            emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
-            emitter.Emit(new Scalar(null, vec.X.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, vec.Y.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new SequenceEnd());
+            YamlHelper.EmitFloatSequence(emitter, new[] { vec.X, vec.Y });
         }
     }
 
@@ -607,28 +591,14 @@ namespace SailorEditor
 
         public object ReadYaml(IParser parser, Type type)
         {
-            var list = new List<float>();
-            parser.Consume<SequenceStart>();
-            while (parser.Current is SequenceEnd == false)
-            {
-                if (parser.Current is Scalar scalar)
-                {
-                    list.Add(float.Parse(scalar.Value, CultureInfo.InvariantCulture.NumberFormat));
-                }
-                parser.MoveNext();
-            }
-            parser.Consume<SequenceEnd>();
+            var list = YamlHelper.ParseFloatSequence(parser);
             return new Vec3 { X = list[0], Y = list[1], Z = list[2] };
         }
 
         public void WriteYaml(IEmitter emitter, object value, Type type)
         {
             var vec = (Vec3)value;
-            emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
-            emitter.Emit(new Scalar(null, vec.X.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, vec.Y.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, vec.Z.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new SequenceEnd());
+            YamlHelper.EmitFloatSequence(emitter, new[] { vec.X, vec.Y, vec.Z });
         }
     }
 
@@ -638,30 +608,14 @@ namespace SailorEditor
 
         public object ReadYaml(IParser parser, Type type)
         {
-            var list = new List<float>();
-            parser.Consume<SequenceStart>();
-            while (parser.Current is SequenceEnd == false)
-            {
-                if (parser.Current is Scalar scalar)
-                {
-                    list.Add(float.Parse(scalar.Value, CultureInfo.InvariantCulture.NumberFormat));
-                }
-                parser.MoveNext();
-            }
-            parser.Consume<SequenceEnd>();
-
+            var list = YamlHelper.ParseFloatSequence(parser);
             return new Vec4 { X = list[0], Y = list[1], Z = list[2], W = list[3] };
         }
 
         public void WriteYaml(IEmitter emitter, object value, Type type)
         {
             var vec = (Vec4)value;
-            emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
-            emitter.Emit(new Scalar(null, vec.X.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, vec.Y.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, vec.Z.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, vec.W.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new SequenceEnd());
+            YamlHelper.EmitFloatSequence(emitter, new[] { vec.X, vec.Y, vec.Z, vec.W });
         }
     }
 
@@ -671,30 +625,14 @@ namespace SailorEditor
 
         public object ReadYaml(IParser parser, Type type)
         {
-            var list = new List<float>();
-            parser.Consume<SequenceStart>();
-            while (parser.Current is SequenceEnd == false)
-            {
-                if (parser.Current is Scalar scalar)
-                {
-                    list.Add(float.Parse(scalar.Value, CultureInfo.InvariantCulture.NumberFormat));
-                }
-                parser.MoveNext();
-            }
-            parser.Consume<SequenceEnd>();
-
+            var list = YamlHelper.ParseFloatSequence(parser);
             return new Quat { X = list[0], Y = list[1], Z = list[2], W = list[3] };
         }
 
         public void WriteYaml(IEmitter emitter, object value, Type type)
         {
             var vec = (Quat)value;
-            emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
-            emitter.Emit(new Scalar(null, vec.X.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, vec.Y.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, vec.Z.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, vec.W.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new SequenceEnd());
+            YamlHelper.EmitFloatSequence(emitter, new[] { vec.X, vec.Y, vec.Z, vec.W });
         }
     }
 
@@ -704,30 +642,14 @@ namespace SailorEditor
 
         public object ReadYaml(IParser parser, Type type)
         {
-            var list = new List<float>();
-            parser.Consume<SequenceStart>();
-            while (parser.Current is SequenceEnd == false)
-            {
-                if (parser.Current is Scalar scalar)
-                {
-                    list.Add(float.Parse(scalar.Value, CultureInfo.InvariantCulture.NumberFormat));
-                }
-                parser.MoveNext();
-            }
-            parser.Consume<SequenceEnd>();
-
+            var list = YamlHelper.ParseFloatSequence(parser);
             return new Rotation(new Quat { X = list[0], Y = list[1], Z = list[2], W = list[3] });
         }
 
         public void WriteYaml(IEmitter emitter, object value, Type type)
         {
             var quat = ((Rotation)value).Quat;
-            emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
-            emitter.Emit(new Scalar(null, quat.X.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, quat.Y.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, quat.Z.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new Scalar(null, quat.W.ToString(CultureInfo.InvariantCulture)));
-            emitter.Emit(new SequenceEnd());
+            YamlHelper.EmitFloatSequence(emitter, new[] { quat.X, quat.Y, quat.Z, quat.W });
         }
     }
 

--- a/Editor/Utility/Observable.cs
+++ b/Editor/Utility/Observable.cs
@@ -44,9 +44,7 @@ public class ObservableObjectYamlConverter<T> : IYamlTypeConverter
     public bool Accepts(Type type) => type == typeof(Observable<T>);
     public object ReadYaml(IParser parser, Type type)
     {
-        var deserializer = new DeserializerBuilder()
-        .WithNamingConvention(CamelCaseNamingConvention.Instance)
-        .Build();
+        var deserializer = SerializationUtils.CreateDeserializerBuilder().Build();
 
         var t = deserializer.Deserialize<T>(parser);
         return new Observable<T>(t);
@@ -55,9 +53,7 @@ public class ObservableObjectYamlConverter<T> : IYamlTypeConverter
     public void WriteYaml(IEmitter emitter, object value, Type type)
     {
         var observableValue = (Observable<T>)value;
-        var serializer = new SerializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-            .Build();
+        var serializer = SerializationUtils.CreateSerializerBuilder().Build();
 
         serializer.Serialize(emitter, observableValue.Value);
     }

--- a/Editor/Utility/ObservableDictionary.cs
+++ b/Editor/Utility/ObservableDictionary.cs
@@ -205,10 +205,7 @@ namespace SailorEditor.Utility
 
         public object ReadYaml(IParser parser, Type type)
         {
-            var deserializerBuilder = new DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .IgnoreUnmatchedProperties()
-                .IncludeNonPublicProperties();
+            var deserializerBuilder = SerializationUtils.CreateDeserializerBuilder();
 
             if (valueConverter != null)
                 deserializerBuilder.WithTypeConverter(valueConverter);
@@ -236,8 +233,7 @@ namespace SailorEditor.Utility
         public void WriteYaml(IEmitter emitter, object value, Type type)
         {
             var dict = (ObservableDictionary<TKey, TValue>)value;
-            var serializerBuilder = new SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance);
+            var serializerBuilder = SerializationUtils.CreateSerializerBuilder();
 
             if (valueConverter != null)
                 serializerBuilder.WithTypeConverter(valueConverter);

--- a/Editor/Utility/ObservableList.cs
+++ b/Editor/Utility/ObservableList.cs
@@ -81,10 +81,7 @@ namespace SailorEditor.Utility
 
         public object ReadYaml(IParser parser, Type type)
         {
-            var deserializerBuilder = new DeserializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
-                .IgnoreUnmatchedProperties()
-                .IncludeNonPublicProperties();
+            var deserializerBuilder = SerializationUtils.CreateDeserializerBuilder();
 
             foreach (var valueConverter in valueConverters)
             {
@@ -115,8 +112,7 @@ namespace SailorEditor.Utility
         public void WriteYaml(IEmitter emitter, object value, Type type)
         {
             var list = (ObservableList<T>)value;
-            var serializerBuilder = new SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance);
+            var serializerBuilder = SerializationUtils.CreateSerializerBuilder();
 
             valueConverters.ForEach((el) => serializerBuilder.WithTypeConverter(el));
 

--- a/Editor/Utility/SerializationUtils.cs
+++ b/Editor/Utility/SerializationUtils.cs
@@ -1,0 +1,41 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using SailorEditor.Helpers;
+
+namespace SailorEditor.Utility;
+
+static class SerializationUtils
+{
+    static readonly IYamlTypeConverter[] DefaultConverters = new IYamlTypeConverter[]
+    {
+        new FileIdYamlConverter(),
+        new InstanceIdYamlConverter(),
+        new ObjectPtrYamlConverter(),
+        new Vec2YamlConverter(),
+        new Vec3YamlConverter(),
+        new Vec4YamlConverter(),
+        new QuatYamlConverter(),
+        new RotationYamlConverter(),
+    };
+
+    public static SerializerBuilder CreateSerializerBuilder()
+    {
+        var builder = new SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IncludeNonPublicProperties();
+        foreach (var conv in DefaultConverters)
+            builder.WithTypeConverter(conv);
+        return builder;
+    }
+
+    public static DeserializerBuilder CreateDeserializerBuilder()
+    {
+        var builder = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .IgnoreUnmatchedProperties()
+            .IncludeNonPublicProperties();
+        foreach (var conv in DefaultConverters)
+            builder.WithTypeConverter(conv);
+        return builder;
+    }
+}

--- a/Editor/Utility/YamlHelper.cs
+++ b/Editor/Utility/YamlHelper.cs
@@ -2,6 +2,8 @@
 using YamlDotNet.Core.Events;
 using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
+using System.Collections.Generic;
+using System.Globalization;
 using Window = Microsoft.Maui.Controls.Window;
 
 namespace SailorEditor.Helpers
@@ -33,6 +35,32 @@ namespace SailorEditor.Helpers
                     emitter.Emit(new SequenceEnd());
                     break;
             }
+        }
+
+        public static List<float> ParseFloatSequence(IParser parser)
+        {
+            var list = new List<float>();
+            parser.Consume<SequenceStart>();
+            while (parser.Current is not SequenceEnd)
+            {
+                if (parser.Current is Scalar scalar)
+                {
+                    list.Add(float.Parse(scalar.Value, CultureInfo.InvariantCulture.NumberFormat));
+                }
+                parser.MoveNext();
+            }
+            parser.Consume<SequenceEnd>();
+            return list;
+        }
+
+        public static void EmitFloatSequence(IEmitter emitter, IEnumerable<float> values)
+        {
+            emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
+            foreach (var v in values)
+            {
+                emitter.Emit(new Scalar(null, v.ToString(CultureInfo.InvariantCulture)));
+            }
+            emitter.Emit(new SequenceEnd());
         }
     };
 }

--- a/Editor/ViewModels/AssetFile.cs
+++ b/Editor/ViewModels/AssetFile.cs
@@ -49,10 +49,8 @@ public partial class AssetFile : ObservableObject, ICloneable
         try
         {
             var yaml = File.ReadAllText(AssetInfo.FullName);
-            var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new AssetFileYamlConverter())
-            .IgnoreUnmatchedProperties()
             .Build();
 
             var intermediateObject = deserializer.Deserialize<AssetFile>(yaml);
@@ -103,8 +101,7 @@ public partial class AssetFile : ObservableObject, ICloneable
         using (var yamlAssetInfo = new FileStream(AssetInfo.FullName, FileMode.Create))
         using (var writer = new StreamWriter(yamlAssetInfo))
         {
-            var serializer = new SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var serializer = SerializationUtils.CreateSerializerBuilder()
                 .WithTypeConverter(converter)
                 .Build();
 
@@ -122,10 +119,8 @@ public class AssetFileYamlConverter : IYamlTypeConverter
 
     public object ReadYaml(IParser parser, Type type)
     {
-        var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new FileIdYamlConverter())
-            .IgnoreUnmatchedProperties()
             .Build();
 
         var assetFile = new AssetFile();

--- a/Editor/ViewModels/AssetFile.cs
+++ b/Editor/ViewModels/AssetFile.cs
@@ -120,7 +120,6 @@ public class AssetFileYamlConverter : IYamlTypeConverter
     public object ReadYaml(IParser parser, Type type)
     {
         var deserializer = SerializationUtils.CreateDeserializerBuilder()
-            .WithTypeConverter(new FileIdYamlConverter())
             .Build();
 
         var assetFile = new AssetFile();

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -37,8 +37,7 @@ public partial class Component : ObservableObject, ICloneable
 
         using (var writer = new StringWriter())
         {
-            var serializer = new SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var serializer = SerializationUtils.CreateSerializerBuilder()
                 .WithTypeConverter(new ComponentYamlConverter())
                 .Build();
 
@@ -96,8 +95,7 @@ public class ComponentYamlConverter : IYamlTypeConverter
 
     public object ReadYaml(IParser parser, Type type)
     {
-        var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new ObservableDictionaryConverter<string, PropertyBase>())
             .WithTypeConverter(new ComponentTypeYamlConverter())
             .WithTypeConverter(new FileIdYamlConverter())
@@ -169,8 +167,7 @@ public class ComponentYamlConverter : IYamlTypeConverter
 
     public void WriteYaml(IEmitter emitter, object value, Type type)
     {
-        var serializer = new SerializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        var serializer = SerializationUtils.CreateSerializerBuilder()
             .WithTypeConverter(new Vec3YamlConverter())
             .WithTypeConverter(new Vec4YamlConverter())
             .WithTypeConverter(new FileIdYamlConverter())

--- a/Editor/ViewModels/GameObject.cs
+++ b/Editor/ViewModels/GameObject.cs
@@ -38,8 +38,7 @@ public partial class GameObject : ObservableObject, ICloneable
 
         using (var writer = new StringWriter())
         {
-            var serializer = new SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var serializer = SerializationUtils.CreateSerializerBuilder()
                 .WithTypeConverter(new InstanceIdYamlConverter())
                 .WithTypeConverter(new RotationYamlConverter())
                 .WithTypeConverter(new Vec4YamlConverter())

--- a/Editor/ViewModels/MaterialFile.cs
+++ b/Editor/ViewModels/MaterialFile.cs
@@ -83,8 +83,7 @@ public class UniformYamlConverter<T> : IYamlTypeConverter where T : IComparable<
 
     public object ReadYaml(IParser parser, Type type)
     {
-        var deserializerBuilder = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance);
+        var deserializerBuilder = SerializationUtils.CreateDeserializerBuilder();
 
         foreach (var valueConverter in valueConverters)
         {
@@ -103,8 +102,7 @@ public class UniformYamlConverter<T> : IYamlTypeConverter where T : IComparable<
     public void WriteYaml(IEmitter emitter, object value, Type type)
     {
         var uniform = (Uniform<T>)value;
-        var serializerBuilder = new SerializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance);
+        var serializerBuilder = SerializationUtils.CreateSerializerBuilder();
 
         foreach (var valueConverter in valueConverters)
         {
@@ -237,8 +235,7 @@ public partial class MaterialFile : AssetFile
         using (var yamlAsset = new FileStream(Asset.FullName, FileMode.Create))
         using (var writer = new StreamWriter(yamlAsset))
         {
-            var serializer = new SerializerBuilder()
-                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var serializer = SerializationUtils.CreateSerializerBuilder()
                 .WithTypeConverter(new MaterialFileYamlConverter())
                 .Build();
 
@@ -256,10 +253,8 @@ public partial class MaterialFile : AssetFile
             // Asset Info
             var yamlAssetInfo = File.ReadAllText(AssetInfo.FullName);
 
-            var deserializerAssetInfo = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var deserializerAssetInfo = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new AssetFileYamlConverter())
-            .IgnoreUnmatchedProperties()
             .Build();
 
             var intermediateObjectAssetInfo = deserializerAssetInfo.Deserialize<AssetFile>(yamlAssetInfo);
@@ -269,10 +264,8 @@ public partial class MaterialFile : AssetFile
             // Asset
             var yamlAsset = File.ReadAllText(Asset.FullName);
 
-            var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new MaterialFileYamlConverter())
-            .IgnoreUnmatchedProperties()
             .Build();
 
             var intermediateObject = deserializer.Deserialize<MaterialFile>(yamlAsset);
@@ -384,8 +377,7 @@ public class MaterialFileYamlConverter : IYamlTypeConverter
 
     public object ReadYaml(IParser parser, Type type)
     {
-        var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new FileIdYamlConverter())
             .WithTypeConverter(new Vec4YamlConverter())
             .WithTypeConverter(new ObservableListConverter<Observable<FileId>>([new FileIdYamlConverter(), new ObservableObjectYamlConverter<FileId>()]))
@@ -393,7 +385,6 @@ public class MaterialFileYamlConverter : IYamlTypeConverter
             .WithTypeConverter(new ObservableListConverter<Uniform<Vec4>>([new Vec4YamlConverter(), new UniformYamlConverter<Vec4>()]))
             .WithTypeConverter(new ObservableListConverter<Uniform<float>>([new UniformYamlConverter<float>()]))
             .WithTypeConverter(new ObservableListConverter<Observable<string>>([new ObservableObjectYamlConverter<string>()]))
-            .IgnoreUnmatchedProperties()
             .Build();
 
         var assetFile = new MaterialFile();

--- a/Editor/ViewModels/MaterialFile.cs
+++ b/Editor/ViewModels/MaterialFile.cs
@@ -378,8 +378,6 @@ public class MaterialFileYamlConverter : IYamlTypeConverter
     public object ReadYaml(IParser parser, Type type)
     {
         var deserializer = SerializationUtils.CreateDeserializerBuilder()
-            .WithTypeConverter(new FileIdYamlConverter())
-            .WithTypeConverter(new Vec4YamlConverter())
             .WithTypeConverter(new ObservableListConverter<Observable<FileId>>([new FileIdYamlConverter(), new ObservableObjectYamlConverter<FileId>()]))
             .WithTypeConverter(new ObservableListConverter<Uniform<FileId>>([new FileIdYamlConverter(), new UniformYamlConverter<FileId>()]))
             .WithTypeConverter(new ObservableListConverter<Uniform<Vec4>>([new Vec4YamlConverter(), new UniformYamlConverter<Vec4>()]))

--- a/Editor/ViewModels/ModelFile.cs
+++ b/Editor/ViewModels/ModelFile.cs
@@ -54,10 +54,8 @@ public partial class ModelFile : AssetFile
         try
         {
             var yaml = File.ReadAllText(AssetInfo.FullName);
-            var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new ModelFileYamlConverter())
-            .IgnoreUnmatchedProperties()
             .Build();
 
             var intermediateObject = deserializer.Deserialize<ModelFile>(yaml);
@@ -91,14 +89,12 @@ public class ModelFileYamlConverter : IYamlTypeConverter
 
     public object ReadYaml(IParser parser, Type type)
     {
-        var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-            .WithTypeConverter(new ObservableListConverter<Observable<FileId>>(
+        var deserializer = SerializationUtils.CreateDeserializerBuilder()
+            .WithTypeConverter(new ObservableListConverter<Observable<FileId>>( 
                  [
                      new FileIdYamlConverter(),
                      new ObservableObjectYamlConverter<FileId>(),
                  ]))
-            .IgnoreUnmatchedProperties()
             .Build();
 
         var assetFile = new ModelFile();

--- a/Editor/ViewModels/ModelFile.cs
+++ b/Editor/ViewModels/ModelFile.cs
@@ -90,11 +90,7 @@ public class ModelFileYamlConverter : IYamlTypeConverter
     public object ReadYaml(IParser parser, Type type)
     {
         var deserializer = SerializationUtils.CreateDeserializerBuilder()
-            .WithTypeConverter(new ObservableListConverter<Observable<FileId>>( 
-                 [
-                     new FileIdYamlConverter(),
-                     new ObservableObjectYamlConverter<FileId>(),
-                 ]))
+            .WithTypeConverter(new ObservableObjectYamlConverter<FileId>())
             .Build();
 
         var assetFile = new ModelFile();

--- a/Editor/ViewModels/ShaderFile.cs
+++ b/Editor/ViewModels/ShaderFile.cs
@@ -4,6 +4,7 @@ using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
+using SailorEditor.Utility;
 
 namespace SailorEditor.ViewModels;
 
@@ -80,10 +81,8 @@ public class ShaderFileYamlConverter : IYamlTypeConverter
 
     public object ReadYaml(IParser parser, Type type)
     {
-        var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new FileIdYamlConverter())
-            .IgnoreUnmatchedProperties()
             .Build();
 
         var assetFile = new ShaderFile();

--- a/Editor/ViewModels/ShaderLibraryFile.cs
+++ b/Editor/ViewModels/ShaderLibraryFile.cs
@@ -4,6 +4,7 @@ using YamlDotNet.Core.Events;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization.NamingConventions;
 using YamlDotNet.Serialization;
+using SailorEditor.Utility;
 using CommunityToolkit.Mvvm.ComponentModel;
 
 namespace SailorEditor.ViewModels;
@@ -30,10 +31,8 @@ public class ShaderLibraryFileYamlConverter : IYamlTypeConverter
 
     public object ReadYaml(IParser parser, Type type)
     {
-        var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new FileIdYamlConverter())
-            .IgnoreUnmatchedProperties()
             .Build();
 
         var assetFile = new ShaderLibraryFile();

--- a/Editor/ViewModels/TextureFile.cs
+++ b/Editor/ViewModels/TextureFile.cs
@@ -78,10 +78,8 @@ public partial class TextureFile : AssetFile
         try
         {
             var yaml = File.ReadAllText(AssetInfo.FullName);
-            var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new TextureFileYamlConverter())
-            .IgnoreUnmatchedProperties()
             .Build();
 
             var intermediateObject = deserializer.Deserialize<TextureFile>(yaml);
@@ -114,10 +112,8 @@ public class TextureFileYamlConverter : IYamlTypeConverter
 
     public object ReadYaml(IParser parser, Type type)
     {
-        var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new FileIdYamlConverter())
-            .IgnoreUnmatchedProperties()
             .Build();
 
         var textureFile = new TextureFile();

--- a/Editor/ViewModels/TextureFile.cs
+++ b/Editor/ViewModels/TextureFile.cs
@@ -113,7 +113,6 @@ public class TextureFileYamlConverter : IYamlTypeConverter
     public object ReadYaml(IParser parser, Type type)
     {
         var deserializer = SerializationUtils.CreateDeserializerBuilder()
-            .WithTypeConverter(new FileIdYamlConverter())
             .Build();
 
         var textureFile = new TextureFile();

--- a/Editor/ViewModels/World.cs
+++ b/Editor/ViewModels/World.cs
@@ -27,10 +27,8 @@ public partial class World : AssetFile
         try
         {
             var yaml = File.ReadAllText(AssetInfo.FullName);
-            var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new WorldYamlConverter())
-            .IgnoreUnmatchedProperties()
             .Build();
 
             var intermediateObject = deserializer.Deserialize<World>(yaml);
@@ -71,10 +69,7 @@ public class WorldYamlConverter : IYamlTypeConverter
                 new ViewModels.ComponentYamlConverter()
             };
 
-        var deserializer = new DeserializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-            .IgnoreUnmatchedProperties()
-            .IncludeNonPublicProperties()
+        var deserializer = SerializationUtils.CreateDeserializerBuilder()
             .WithTypeConverter(new ObservableListConverter<Prefab>(
                 new IYamlTypeConverter[]{
                         new ObservableListConverter<GameObject>(commonConverters.ToArray()),
@@ -114,9 +109,7 @@ public class WorldYamlConverter : IYamlTypeConverter
                 new ViewModels.ComponentYamlConverter()
             };
 
-        var serializerBuilder = new SerializerBuilder()
-            .WithNamingConvention(CamelCaseNamingConvention.Instance)
-            .IncludeNonPublicProperties()
+        var serializerBuilder = SerializationUtils.CreateSerializerBuilder()
             .WithTypeConverter(new ObservableListConverter<Prefab>(
                 new IYamlTypeConverter[]{
                         new ObservableListConverter<GameObject>(commonConverters.ToArray()),


### PR DESCRIPTION
## Summary
- centralize YAML helpers and add float sequence utils
- provide serialization builder utilities
- refactor editor YAML converters to use new helpers
- reduce duplicate builder code across editor services and view models

## Testing
- `cmd.exe /c update_deps.bat` *(fails: command not found)*