### PR TITLE
Improve job threading checks

### DIFF
--- a/Runtime/Tasks/Scheduler.cpp
+++ b/Runtime/Tasks/Scheduler.cpp
@@ -81,16 +81,18 @@ void WorkerThread::ProcessTask(ITaskPtr& task)
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	if (task)
-	{
-		SAILOR_PROFILE_SCOPE("Task Execution");
-		SAILOR_PROFILE_TEXT(task->GetName().c_str());
+        if (task)
+        {
+                SAILOR_PROFILE_SCOPE("Task Execution");
+                SAILOR_PROFILE_TEXT(task->GetName().c_str());
 
-		m_bIsBusy = true;
-		task->Execute();
-		task.Clear();
-		m_bIsBusy = false;
-	}
+                check(task->GetThreadType() == m_threadType);
+
+                m_bIsBusy = true;
+                task->Execute();
+                task.Clear();
+                m_bIsBusy = false;
+        }
 }
 
 void WorkerThread::SetExecFlag()
@@ -227,17 +229,19 @@ void Scheduler::ProcessTasksOnMainThread()
 {
 	SAILOR_PROFILE_FUNCTION();
 	ITaskPtr pCurrentTask;
-	while (TryFetchNextAvailiableTask(pCurrentTask, EThreadType::Main))
-	{
-		if (pCurrentTask)
-		{
-			SAILOR_PROFILE_SCOPE("Task Execution");
-			SAILOR_PROFILE_TEXT(pCurrentTask->GetName().c_str());
+        while (TryFetchNextAvailiableTask(pCurrentTask, EThreadType::Main))
+        {
+                if (pCurrentTask)
+                {
+                        SAILOR_PROFILE_SCOPE("Task Execution");
+                        SAILOR_PROFILE_TEXT(pCurrentTask->GetName().c_str());
 
-			pCurrentTask->Execute();
-			pCurrentTask.Clear();
-		}
-	}
+                        check(pCurrentTask->GetThreadType() == EThreadType::Main);
+
+                        pCurrentTask->Execute();
+                        pCurrentTask.Clear();
+                }
+        }
 }
 
 void Scheduler::RunChainedTasks_Internal(const ITaskPtr& pTask, const ITaskPtr& pTaskToIgnore)

--- a/Runtime/Tasks/Tasks.h
+++ b/Runtime/Tasks/Tasks.h
@@ -238,13 +238,13 @@ namespace Sailor
 				m_function = std::move(function);
 			}
 
-			template<typename TContinuationResult = void>
-			TaskPtr<TContinuationResult, TResult> Then(
-				typename TFunction<TContinuationResult, TResult>::type function,
-				std::string name = "ChainedTask",
-				EThreadType thread = EThreadType::Worker)
-			{
-				auto resultTask = Tasks::CreateTask<TContinuationResult, TResult>(std::move(name), std::move(function), thread);
+                        template<typename TContinuationResult = void>
+                        TaskPtr<TContinuationResult, TResult> Then(
+                                typename TFunction<TContinuationResult, TResult>::type function,
+                                std::string name,
+                                EThreadType thread)
+                        {
+                                auto resultTask = Tasks::CreateTask<TContinuationResult, TResult>(std::move(name), std::move(function), thread);
 				if constexpr (NotVoid<TResult>)
 				{
 					resultTask->SetArgs(ResultBase::m_result);
@@ -253,8 +253,16 @@ namespace Sailor
 				ChainTasks(resultTask);
 				RunTaskIfNeeded(resultTask);
 
-				return resultTask;
-			}
+                                return resultTask;
+                        }
+
+                        template<typename TContinuationResult = void>
+                        TaskPtr<TContinuationResult, TResult> Then(
+                                typename TFunction<TContinuationResult, TResult>::type function,
+                                std::string name = "ChainedTask")
+                        {
+                                return Then<TContinuationResult>(std::move(function), std::move(name), ITask::m_threadType);
+                        }
 
 			SAILOR_API TaskPtr<TResult, void> ToTaskWithResult()
 			{


### PR DESCRIPTION
## Summary
- add overload of `Task::Then` that defaults to the current thread
- assert that tasks execute on the designated thread

## Testing
- `python3 Tests/process_no_crash_test.py`
- `python3 Tests/container_benchmarks_test.py`