### PR TITLE
Add volumetric fog compute pass

### DIFF
--- a/Content/DefaultRenderer.renderer
+++ b/Content/DefaultRenderer.renderer
@@ -154,6 +154,16 @@ frame:
 #  - EnvironmentMap: Textures/Environment.hdr
 ############################
 
+############################
+- name: VolumetricFog
+############################
+  float:
+  - stepSize: 0.1
+  vec4:
+  - fogColor: [0.7, 0.8, 1.0, 0]
+  renderTargets:
+  - target: Sky
+
 #############################
 #- name: PostProcess
 ############################

--- a/Content/Shaders/ComputeVolumetricFog.shader
+++ b/Content/Shaders/ComputeVolumetricFog.shader
@@ -1,0 +1,62 @@
+includes:
+- Shaders/Constants.glsl
+- Shaders/Math.glsl
+
+defines: []
+
+glslCommon: |
+  #version 460
+  #extension GL_ARB_separate_shader_objects : enable
+
+glslCompute: |
+  layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+  layout(set = 0, binding = 0) uniform sampler3D u_densityVolume;
+  layout(set = 0, binding = 1, rgba16f) writeonly uniform image2D u_output_image;
+
+  layout(set = 1, binding = 0) uniform FrameData
+  {
+      mat4 view;
+      mat4 projection;
+      mat4 invProjection;
+      vec4 cameraPosition;
+      ivec2 viewportSize;
+      vec2 cameraZNearZFar;
+      float currentTime;
+      float deltaTime;
+  } frame;
+
+  layout(push_constant) uniform Constants
+  {
+      float stepSize;
+      vec3 fogColor;
+  } PushConstants;
+
+  void main()
+  {
+      ivec2 pixel = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 dim = imageSize(u_output_image);
+      if (pixel.x >= dim.x || pixel.y >= dim.y) return;
+
+      vec2 uv = (vec2(pixel) + vec2(0.5)) / vec2(dim);
+      vec4 ndc = vec4(uv * 2.0 - 1.0, 1.0, 1.0);
+      vec4 viewPos = frame.invProjection * ndc;
+      viewPos.xyz /= viewPos.w;
+      vec3 dir = normalize(viewPos.xyz);
+      vec3 origin = frame.cameraPosition.xyz;
+
+      float t = frame.cameraZNearZFar.x;
+      float tFar = frame.cameraZNearZFar.y;
+      float trans = 1.0;
+
+      for (; t < tFar && trans > 0.01; t += PushConstants.stepSize)
+      {
+          vec3 samplePos = origin + dir * t;
+          float density = texture(u_densityVolume, samplePos).r;
+          float atten = exp(-density * PushConstants.stepSize);
+          trans *= atten;
+      }
+
+      vec3 color = mix(PushConstants.fogColor, vec3(0.0), trans);
+      imageStore(u_output_image, pixel, vec4(color, 1.0 - trans));
+  }

--- a/Content/Shaders/ComputeVolumetricFog.shader.asset
+++ b/Content/Shaders/ComputeVolumetricFog.shader.asset
@@ -1,0 +1,2 @@
+fileId: "{AECF1F61-7B98-4159-AF34-F71901DBB4E9}"
+filename: ComputeVolumetricFog.shader

--- a/Runtime/FrameGraph/VolumetricFogNode.cpp
+++ b/Runtime/FrameGraph/VolumetricFogNode.cpp
@@ -1,0 +1,111 @@
+#include "VolumetricFogNode.h"
+#include "RHI/Renderer.h"
+#include "RHI/Shader.h"
+#include "AssetRegistry/AssetRegistry.h"
+#include "RHI/SceneView.h"
+#include "Containers/Vector.h"
+
+using namespace Sailor;
+using namespace Sailor::RHI;
+using namespace Sailor::Framegraph;
+
+const char* VolumetricFogNode::m_name = "VolumetricFog";
+
+void VolumetricFogNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList,
+    RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
+{
+    SAILOR_PROFILE_FUNCTION();
+
+    auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
+    auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
+    commands->BeginDebugRegion(commandList, GetName(), DebugContext::Color_CmdCompute);
+
+    if (!m_pComputeShader)
+    {
+        if (auto shaderInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr("Shaders/ComputeVolumetricFog.shader"))
+        {
+            App::GetSubmodule<ShaderCompiler>()->LoadShader(shaderInfo->GetFileId(), m_pComputeShader);
+        }
+    }
+
+    if (!m_pComputeShader || !m_pComputeShader->IsReady())
+    {
+        commands->EndDebugRegion(commandList);
+        return;
+    }
+
+    if (!m_densityVolume)
+    {
+        constexpr int Size = 64;
+        TVector<uint16_t> data;
+        data.Resize(Size * Size * Size);
+
+        for (size_t i = 0; i < data.Num(); ++i)
+        {
+            data[i] = 6553; // ~0.1 in half float
+        }
+
+        m_densityVolume = driver->CreateTexture(data.GetData(), data.Num() * sizeof(uint16_t),
+            glm::ivec3(Size, Size, Size),
+            1,
+            ETextureType::Texture3D,
+            ETextureFormat::R16_SFLOAT,
+            ETextureFiltration::Linear,
+            ETextureClamping::Clamp,
+            ETextureUsageBit::Sampled_Bit | ETextureUsageBit::TextureTransferDst_Bit);
+        driver->SetDebugName(m_densityVolume, "VolumetricFogVolume");
+    }
+
+    RHITexturePtr densityVolume = GetResolvedAttachment("densityVolume");
+    if (!densityVolume)
+    {
+        densityVolume = m_densityVolume;
+    }
+
+    RHITexturePtr target = GetResolvedAttachment("target");
+
+    if (!target)
+    {
+        commands->EndDebugRegion(commandList);
+        return;
+    }
+
+    if (!m_shaderBindings)
+    {
+        m_shaderBindings = driver->CreateShaderBindings();
+        driver->AddSamplerToShaderBindings(m_shaderBindings, "u_densityVolume", densityVolume, 0);
+        driver->AddStorageImageToShaderBindings(m_shaderBindings, "u_output_image", target, 1);
+    }
+    else
+    {
+        driver->AddSamplerToShaderBindings(m_shaderBindings, "u_densityVolume", densityVolume, 0);
+        driver->AddStorageImageToShaderBindings(m_shaderBindings, "u_output_image", target, 1);
+    }
+
+    m_shaderBindings->RecalculateCompatibility();
+
+    PushConstants params{};
+    params.stepSize = GetFloat("stepSize");
+    params.fogColor = glm::vec3(GetVec4("fogColor"));
+
+    glm::uvec2 dim(target->GetExtent().x, target->GetExtent().y);
+
+    commands->ImageMemoryBarrier(commandList, densityVolume, EImageLayout::ComputeRead);
+    commands->ImageMemoryBarrier(commandList, target, EImageLayout::ComputeWrite);
+
+    commands->Dispatch(commandList, m_pComputeShader->GetComputeShaderRHI(),
+        (uint32_t)glm::ceil(float(dim.x) / 16.0f),
+        (uint32_t)glm::ceil(float(dim.y) / 16.0f),
+        1u,
+        { m_shaderBindings, sceneView.m_frameBindings },
+        &params, sizeof(PushConstants));
+
+    commands->EndDebugRegion(commandList);
+}
+
+void VolumetricFogNode::Clear()
+{
+    m_pComputeShader.Clear();
+    m_shaderBindings.Clear();
+    m_densityVolume.Clear();
+}

--- a/Runtime/FrameGraph/VolumetricFogNode.h
+++ b/Runtime/FrameGraph/VolumetricFogNode.h
@@ -1,0 +1,37 @@
+#pragma once
+#include "Core/Defines.h"
+#include "Memory/RefPtr.hpp"
+#include "Engine/Object.h"
+#include "RHI/Types.h"
+#include "FrameGraph/BaseFrameGraphNode.h"
+#include "FrameGraph/FrameGraphNode.h"
+
+namespace Sailor::Framegraph
+{
+    class VolumetricFogNode : public TFrameGraphNode<VolumetricFogNode>
+    {
+    public:
+        SAILOR_API static const char* GetName() { return m_name; }
+
+        SAILOR_API virtual void Process(RHI::RHIFrameGraphPtr frameGraph,
+            RHI::RHICommandListPtr transferCommandList,
+            RHI::RHICommandListPtr commandList,
+            const RHI::RHISceneViewSnapshot& sceneView) override;
+        SAILOR_API virtual void Clear() override;
+
+    protected:
+        struct PushConstants
+        {
+            float stepSize = 0.1f;
+            alignas(16) glm::vec3 fogColor = glm::vec3(1.0f);
+        };
+
+        static const char* m_name;
+
+        ShaderSetPtr m_pComputeShader{};
+        RHI::RHIShaderBindingSetPtr m_shaderBindings{};
+        RHI::RHITexturePtr m_densityVolume{};
+    };
+
+    template class TFrameGraphNode<VolumetricFogNode>;
+}


### PR DESCRIPTION
## Summary
- add compute shader for volumetric fog
- implement `VolumetricFogNode` for framegraph
- insert the node in `DefaultRenderer` config

## Testing
- `python3 Tests/process_no_crash_test.py`
- `python3 Tests/container_benchmarks_test.py`