### PR TITLE
Add adjustable EVSM blur

### DIFF
--- a/Runtime/Components/LightComponent.cpp
+++ b/Runtime/Components/LightComponent.cpp
@@ -98,11 +98,22 @@ void LightComponent::SetBounds(const glm::vec3& value)
 
 void LightComponent::SetLightType(ELightType value)
 {
-	LightData& lightData = GetData();
+        LightData& lightData = GetData();
 
 	if (value != lightData.m_type)
 	{
-		lightData.m_type = value;
-		lightData.MarkDirty();
-	}
+                lightData.m_type = value;
+                lightData.MarkDirty();
+        }
+}
+
+void LightComponent::SetEvsmBlurScale(float value)
+{
+        LightData& lightData = GetData();
+
+        if (value != lightData.m_evsmBlurScale)
+        {
+                lightData.m_evsmBlurScale = value;
+                lightData.MarkDirty();
+        }
 }

--- a/Runtime/Components/LightComponent.h
+++ b/Runtime/Components/LightComponent.h
@@ -26,14 +26,16 @@ namespace Sailor
 		SAILOR_API __forceinline const glm::vec3& GetIntensity() const { return GetData().m_intensity; }
 		SAILOR_API __forceinline const glm::vec3& GetAttenuation() const { return GetData().m_attenuation; }
 		SAILOR_API __forceinline const glm::vec3& GetBounds() const { return GetData().m_bounds; }
-		SAILOR_API __forceinline const glm::vec2& GetCutOff() const { return GetData().m_cutOff; }
-		SAILOR_API __forceinline ELightType GetLightType() const { return (ELightType)GetData().m_type; }
+                SAILOR_API __forceinline const glm::vec2& GetCutOff() const { return GetData().m_cutOff; }
+                SAILOR_API __forceinline ELightType GetLightType() const { return (ELightType)GetData().m_type; }
+                SAILOR_API __forceinline float GetEvsmBlurScale() const { return GetData().m_evsmBlurScale; }
 
 		SAILOR_API void SetCutOff(const glm::vec2& innerOuterDegrees);
 		SAILOR_API void SetIntensity(const glm::vec3& value);
 		SAILOR_API void SetAttenuation(const glm::vec3& value);
 		SAILOR_API void SetBounds(const glm::vec3& value);
-		SAILOR_API void SetLightType(ELightType value);
+                SAILOR_API void SetLightType(ELightType value);
+                SAILOR_API void SetEvsmBlurScale(float value);
 
 	protected:
 
@@ -58,8 +60,11 @@ REFL_AUTO(
 	func(SetBounds, property("bounds"), SkipCDO()),
 
 	func(GetCutOff, property("cutOff"), SkipCDO()),
-	func(SetCutOff, property("cutOff"), SkipCDO()),
+        func(SetCutOff, property("cutOff"), SkipCDO()),
 
-	func(GetLightType, property("lightType"), SkipCDO()),
-	func(SetLightType, property("lightType"), SkipCDO())
+        func(GetLightType, property("lightType"), SkipCDO()),
+        func(SetLightType, property("lightType"), SkipCDO()),
+
+        func(GetEvsmBlurScale, property("evsmBlurScale"), SkipCDO()),
+        func(SetEvsmBlurScale, property("evsmBlurScale"), SkipCDO())
 )

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -222,13 +222,14 @@ void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
 		{
 			const auto& ownerTransform = light.m_owner.StaticCast<GameObject>()->GetTransformComponent();
 
-			RHI::RHILightProxy lightProxy{};
+                        RHI::RHILightProxy lightProxy{};
 
 			lightProxy.m_lightMatrix = glm::inverse(ownerTransform.GetCachedWorldMatrix());
 			lightProxy.m_lightTransform = ownerTransform.GetTransform();
 			lightProxy.m_distanceToCamera = 0.0f;
 			lightProxy.m_index = (uint32_t)index;
-			lightProxy.m_shadowType = light.m_shadowType;
+                        lightProxy.m_shadowType = light.m_shadowType;
+                        lightProxy.m_evsmBlurScale = light.m_evsmBlurScale;
 
 			if (light.m_type != ELightType::Directional)
 			{
@@ -297,7 +298,7 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 			cascade.m_shadowMap = m_csmShadowMaps[k];
 			cascade.m_lightMatrix = lightMatrix;
 			cascade.m_lighMatrixIndex = k;
-			cascade.m_blurRadius = ShadowCascadeBlur[k];
+                        cascade.m_blurRadius = ShadowCascadeBlur[k] * directionalLight.m_evsmBlurScale;
 			
 			// For EVSM only 1st cascade is EVSM
 			cascade.m_shadowType = k > 0 ? RHI::EShadowType::PCF : directionalLight.m_shadowType;

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -24,8 +24,9 @@ namespace Sailor
 		glm::vec3 m_attenuation{ 1.0f, 0.022f, 0.0019f };
 		glm::vec3 m_bounds{ 100.0f, 100.0f, 100.0f };
 		glm::vec2 m_cutOff{ 30.0f, 45.0f };
-		ELightType m_type = ELightType::Point;
-		RHI::EShadowType m_shadowType = RHI::EShadowType::PCF;
+                ELightType m_type = ELightType::Point;
+                RHI::EShadowType m_shadowType = RHI::EShadowType::PCF;
+                float m_evsmBlurScale{ 1.0f };
 
 	protected:
 
@@ -64,8 +65,8 @@ namespace Sailor
 		// Also handy paper: https://dl.acm.org/doi/pdf/10.5555/1375714.1375739
 		static constexpr uint32_t NumCascades = 4;
 		static constexpr float ShadowCascadeLevels[NumCascades] = { 1.0f / 20.0f, 1.0f / 10.0f, 1.0f / 3.0f, 1.0f / 2.0f };
-		static constexpr glm::ivec2 ShadowCascadeResolutions[NumCascades] = { {4096,4096}, {4096,4096}, {4096,4096}, {4096,4096} };
-		static constexpr glm::ivec2 ShadowCascadeBlur[NumCascades] = { glm::vec2(2, 5), glm::vec2(1, 4), glm::vec2(1, 3), glm::vec2(1, 2) };
+                static constexpr glm::ivec2 ShadowCascadeResolutions[NumCascades] = { {4096,4096}, {4096,4096}, {4096,4096}, {4096,4096} };
+                static constexpr glm::vec2 ShadowCascadeBlur[NumCascades] = { {2.0f, 5.0f}, {1.0f, 4.0f}, {1.0f, 3.0f}, {1.0f, 2.0f} };
 
 		// TODO: Tightly pack
 		struct LightShaderData

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -24,14 +24,15 @@ namespace Sailor::RHI
 		SAILOR_API bool operator==(const RHIMeshProxy& rhs) const { return m_staticMeshEcs == rhs.m_staticMeshEcs; }
 	};
 
-	struct RHILightProxy
-	{
-		uint32_t m_index = 0;
-		float m_distanceToCamera{};
-		EShadowType m_shadowType = EShadowType::None;
-		glm::mat4 m_lightMatrix{};
-		Math::Transform m_cameraTransform{};
-		Math::Transform m_lightTransform{};
+        struct RHILightProxy
+        {
+                uint32_t m_index = 0;
+                float m_distanceToCamera{};
+                EShadowType m_shadowType = EShadowType::None;
+                float m_evsmBlurScale{ 1.0f };
+                glm::mat4 m_lightMatrix{};
+                Math::Transform m_cameraTransform{};
+                Math::Transform m_lightTransform{};
 
 		SAILOR_API bool operator<(const RHILightProxy& rhs) const { return m_distanceToCamera < rhs.m_distanceToCamera; }
 	};


### PR DESCRIPTION
## Summary
- allow controlling EVSM blur with a new `evsmBlurScale` value on lights
- propagate the blur scale to `RHILightProxy` and shadow cascade setup

## Testing
- `update_deps.bat` *(fails: `%VCPKG_ROOT%: No such file or directory`)*