### PR TITLE
Fix indentation with tabs in Runtime

### DIFF
--- a/Runtime/Containers/Vector.h
+++ b/Runtime/Containers/Vector.h
@@ -419,7 +419,7 @@ namespace Sailor
 			m_arrayNum += count;
 		}
 
-               __forceinline bool IsValidIndex(size_t index) const { return index < m_arrayNum; }
+			__forceinline bool IsValidIndex(size_t index) const { return index < m_arrayNum; }
 
 		__forceinline size_t Num() const { return m_arrayNum; }
 		__forceinline size_t Capacity() const { return m_capacity; }

--- a/Runtime/Core/Utils.cpp
+++ b/Runtime/Core/Utils.cpp
@@ -9,8 +9,8 @@
 #include <ntverp.h>
 #endif
 
-#include <algorithm> 
-#include <functional> 
+#include <algorithm>
+#include <functional>
 #include <cctype>
 
 #include <sstream>

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
@@ -320,13 +320,13 @@ VulkanQueueFamilyIndices VulkanApi::FindQueueFamilies(VkPhysicalDevice device, V
 			indices.m_computeFamily = i;
 		}
 
-		// Get queue that is shared 
+		// Get queue that is shared
 		if (!indices.m_computeFamily.has_value() && (queueFamily.queueFlags & VK_QUEUE_COMPUTE_BIT))
 		{
 			indices.m_computeFamily = i;
 		}
 
-		// Get queue that is shared 
+		// Get queue that is shared
 		if (!indices.m_transferFamily.has_value() && (queueFamily.queueFlags & VK_QUEUE_TRANSFER_BIT))
 		{
 			indices.m_transferFamily = i;
@@ -1025,10 +1025,10 @@ VulkanImagePtr VulkanApi::CreateImage(
 }
 
 VulkanImagePtr VulkanApi::CreateImage_Immediate(
-        VulkanDevicePtr device,
-        const void* pData,
-        VkDeviceSize size,
-        VkExtent3D extent,
+		VulkanDevicePtr device,
+		const void* pData,
+		VkDeviceSize size,
+		VkExtent3D extent,
 	uint32_t mipLevels,
 	VkImageType type,
 	VkFormat format,
@@ -1048,85 +1048,85 @@ VulkanImagePtr VulkanApi::CreateImage_Immediate(
 
 	auto fence = VulkanFencePtr::Make(device);
 	device->SubmitCommandBuffer(cmdBuffer, fence);
-        fence->Wait();
+		fence->Wait();
 
-        return res;
+		return res;
 }
 
 #ifdef _WIN32
 void* VulkanApi::ExportImage(VulkanDevicePtr device, VulkanImagePtr image, VkExternalMemoryHandleTypeFlagBits handleType)
 {
-        auto vkGetMemoryWin32HandleKHR = (PFN_vkGetMemoryWin32HandleKHR)vkGetDeviceProcAddr(*device, "vkGetMemoryWin32HandleKHR");
-        if (!vkGetMemoryWin32HandleKHR)
-        {
-                return nullptr;
-        }
+		auto vkGetMemoryWin32HandleKHR = (PFN_vkGetMemoryWin32HandleKHR)vkGetDeviceProcAddr(*device, "vkGetMemoryWin32HandleKHR");
+		if (!vkGetMemoryWin32HandleKHR)
+		{
+			return nullptr;
+		}
 
-        VkMemoryGetWin32HandleInfoKHR handleInfo{};
-        handleInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR;
-        handleInfo.handleType = handleType;
-        handleInfo.memory = *image->GetMemoryDevice();
+		VkMemoryGetWin32HandleInfoKHR handleInfo{};
+		handleInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR;
+		handleInfo.handleType = handleType;
+		handleInfo.memory = *image->GetMemoryDevice();
 
-        HANDLE handle = nullptr;
-        if (vkGetMemoryWin32HandleKHR(*device, &handleInfo, &handle) != VK_SUCCESS)
-        {
-                return nullptr;
-        }
-        return handle;
+		HANDLE handle = nullptr;
+		if (vkGetMemoryWin32HandleKHR(*device, &handleInfo, &handle) != VK_SUCCESS)
+		{
+			return nullptr;
+		}
+		return handle;
 }
 #else
 void* VulkanApi::ExportImage(VulkanDevicePtr /*device*/, VulkanImagePtr /*image*/, VkExternalMemoryHandleTypeFlagBits /*handleType*/)
 {
-    return nullptr;
+	return nullptr;
 }
 #endif
 
 #ifdef _WIN32
 VulkanImagePtr VulkanApi::ImportImage(VulkanDevicePtr device,
-        void* handle,
-        VkExtent3D extent,
-        VkFormat format,
-        VkImageUsageFlags usage,
-        VkImageLayout defaultLayout,
-        VkImageCreateFlags flags,
-        uint32_t arrayLayers,
-        VkSampleCountFlagBits sampleCount)
+		void* handle,
+		VkExtent3D extent,
+		VkFormat format,
+		VkImageUsageFlags usage,
+		VkImageLayout defaultLayout,
+		VkImageCreateFlags flags,
+		uint32_t arrayLayers,
+		VkSampleCountFlagBits sampleCount)
 {
-        VulkanImagePtr outImage = new VulkanImage(device);
-        outImage->EnableExternalMemory(VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
-        outImage->m_extent = extent;
-        outImage->m_imageType = VK_IMAGE_TYPE_2D;
-        outImage->m_format = format;
-        outImage->m_tiling = VK_IMAGE_TILING_OPTIMAL;
-        outImage->m_usage = usage;
-        outImage->m_mipLevels = 1;
-        outImage->m_samples = sampleCount;
-        outImage->m_arrayLayers = arrayLayers;
-        outImage->m_sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-        outImage->m_defaultLayout = defaultLayout;
-        outImage->m_initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        outImage->m_flags = flags;
+		VulkanImagePtr outImage = new VulkanImage(device);
+		outImage->EnableExternalMemory(VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
+		outImage->m_extent = extent;
+		outImage->m_imageType = VK_IMAGE_TYPE_2D;
+		outImage->m_format = format;
+		outImage->m_tiling = VK_IMAGE_TILING_OPTIMAL;
+		outImage->m_usage = usage;
+		outImage->m_mipLevels = 1;
+		outImage->m_samples = sampleCount;
+		outImage->m_arrayLayers = arrayLayers;
+		outImage->m_sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		outImage->m_defaultLayout = defaultLayout;
+		outImage->m_initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+		outImage->m_flags = flags;
 
-        outImage->Compile();
+		outImage->Compile();
 
-        VkMemoryRequirements requirements = outImage->GetMemoryRequirements();
+		VkMemoryRequirements requirements = outImage->GetMemoryRequirements();
 
-        VkImportMemoryWin32HandleInfoKHR importInfo{};
-        importInfo.sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
-        importInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-        importInfo.handle = (HANDLE)handle;
+		VkImportMemoryWin32HandleInfoKHR importInfo{};
+		importInfo.sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
+		importInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+		importInfo.handle = (HANDLE)handle;
 
-        auto memory = VulkanDeviceMemoryPtr::Make(device, requirements,
-                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &importInfo);
+		auto memory = VulkanDeviceMemoryPtr::Make(device, requirements,
+			VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &importInfo);
 
-        outImage->Bind(memory, 0);
+		outImage->Bind(memory, 0);
 
-        return outImage;
+		return outImage;
 }
 #else
 VulkanImagePtr VulkanApi::ImportImage(VulkanDevicePtr /*device*/, void* /*handle*/, VkExtent3D /*extent*/, VkFormat /*format*/, VkImageUsageFlags /*usage*/, VkImageLayout /*defaultLayout*/, VkImageCreateFlags /*flags*/, uint32_t /*arrayLayers*/, VkSampleCountFlagBits /*sampleCount*/)
 {
-        return nullptr;
+		return nullptr;
 }
 #endif
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.h
@@ -220,11 +220,11 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API static VulkanBufferPtr CreateBuffer_Immediate(VulkanDevicePtr device, const void* pData, VkDeviceSize size, VkBufferUsageFlags usage, VkSharingMode sharingMode = VkSharingMode::VK_SHARING_MODE_CONCURRENT);
 		SAILOR_API static void CopyBuffer_Immediate(VulkanDevicePtr device, VulkanBufferMemoryPtr  src, VulkanBufferMemoryPtr dst, VkDeviceSize size, VkDeviceSize srcOffset = 0, VkDeviceSize dstOffset = 0);
 
-                SAILOR_API static VulkanImagePtr CreateImage_Immediate(
-                        VulkanDevicePtr device,
-                        const void* pData,
-                        VkDeviceSize size,
-                        VkExtent3D extent,
+			SAILOR_API static VulkanImagePtr CreateImage_Immediate(
+			VulkanDevicePtr device,
+			const void* pData,
+			VkDeviceSize size,
+			VkExtent3D extent,
 			uint32_t mipLevels = 1,
 			VkImageType type = VK_IMAGE_TYPE_2D,
 			VkFormat format = VK_FORMAT_R8G8B8A8_SRGB,
@@ -232,26 +232,26 @@ namespace Sailor::GraphicsDriver::Vulkan
 			VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
 			VkSharingMode sharingMode = VkSharingMode::VK_SHARING_MODE_EXCLUSIVE,
 			VkImageLayout defaultLayout = VkImageLayout::VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
-                        VkImageCreateFlags flags = 0,
-                        uint32_t arrayLayer = 1);
+			VkImageCreateFlags flags = 0,
+			uint32_t arrayLayer = 1);
 
 #ifdef _WIN32
-                SAILOR_API static void* ExportImage(VulkanDevicePtr device, VulkanImagePtr image,
-                        VkExternalMemoryHandleTypeFlagBits handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
+			SAILOR_API static void* ExportImage(VulkanDevicePtr device, VulkanImagePtr image,
+			VkExternalMemoryHandleTypeFlagBits handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
 #else
-                SAILOR_API static void* ExportImage(VulkanDevicePtr device, VulkanImagePtr image,
-                        VkExternalMemoryHandleTypeFlagBits handleType = (VkExternalMemoryHandleTypeFlagBits)0);
+			SAILOR_API static void* ExportImage(VulkanDevicePtr device, VulkanImagePtr image,
+			VkExternalMemoryHandleTypeFlagBits handleType = (VkExternalMemoryHandleTypeFlagBits)0);
 #endif
 
-                SAILOR_API static VulkanImagePtr ImportImage(VulkanDevicePtr device,
-                        void* handle,
-                        VkExtent3D extent,
-                        VkFormat format,
-                        VkImageUsageFlags usage,
-                        VkImageLayout defaultLayout,
-                        VkImageCreateFlags flags = 0,
-                        uint32_t arrayLayers = 1,
-                        VkSampleCountFlagBits sampleCount = VK_SAMPLE_COUNT_1_BIT);
+			SAILOR_API static VulkanImagePtr ImportImage(VulkanDevicePtr device,
+			void* handle,
+			VkExtent3D extent,
+			VkFormat format,
+			VkImageUsageFlags usage,
+			VkImageLayout defaultLayout,
+			VkImageCreateFlags flags = 0,
+			uint32_t arrayLayers = 1,
+			VkSampleCountFlagBits sampleCount = VK_SAMPLE_COUNT_1_BIT);
 
 		//Immediate context
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -53,7 +53,7 @@ void VulkanGraphicsDriver::Initialize(Win32::Window* pViewport, RHI::EMsaaSample
 		VK_IMAGE_TILING_OPTIMAL,
 		VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
 		VK_SHARING_MODE_EXCLUSIVE,
-               VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+			VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
 	auto defaultCubemap = VulkanApi::CreateImage_Immediate(m_vkInstance->GetMainDevice(), &invalidColor, sizeof(DWORD), VkExtent3D{ 1,1,1 }, 1,
 		VK_IMAGE_TYPE_2D,
@@ -61,7 +61,7 @@ void VulkanGraphicsDriver::Initialize(Win32::Window* pViewport, RHI::EMsaaSample
 		VK_IMAGE_TILING_OPTIMAL,
 		VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT,
 		VK_SHARING_MODE_EXCLUSIVE,
-               VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+			VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
 		VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT,
 		6);
 
@@ -490,10 +490,10 @@ void VulkanGraphicsDriver::EndDebugRegion(RHI::RHICommandListPtr cmdList)
 }
 
 RHI::RHITexturePtr VulkanGraphicsDriver::CreateImage_Immediate(
-        const void* pData,
-        size_t size,
-        glm::ivec3 extent,
-        uint32_t mipLevels,
+		const void* pData,
+		size_t size,
+		glm::ivec3 extent,
+		uint32_t mipLevels,
 	RHI::ETextureType type,
 	RHI::ETextureFormat format,
 	RHI::ETextureFiltration filtration,
@@ -535,41 +535,41 @@ RHI::RHITexturePtr VulkanGraphicsDriver::CreateImage_Immediate(
 		arrayLayers);
 
 	res->m_vulkan.m_imageView = VulkanImageViewPtr::Make(device, res->m_vulkan.m_image);
-        res->m_vulkan.m_imageView->Compile();
+		res->m_vulkan.m_imageView->Compile();
 
-        return res;
+		return res;
 }
 
 void* VulkanGraphicsDriver::ExportImage(RHI::RHITexturePtr image)
 {
-        if (!image || !image->m_vulkan.m_image)
-        {
-                return nullptr;
-        }
+		if (!image || !image->m_vulkan.m_image)
+		{
+			return nullptr;
+		}
 
-        auto device = m_vkInstance->GetMainDevice();
-        return VulkanApi::ExportImage(device, image->m_vulkan.m_image);
+		auto device = m_vkInstance->GetMainDevice();
+		return VulkanApi::ExportImage(device, image->m_vulkan.m_image);
 }
 
 RHI::RHITexturePtr VulkanGraphicsDriver::ImportImage(void* handle,
-        glm::ivec3 extent,
-        RHI::ETextureFormat format,
-        RHI::ETextureUsageFlags usage,
-        RHI::EImageLayout layout)
+		glm::ivec3 extent,
+		RHI::ETextureFormat format,
+		RHI::ETextureUsageFlags usage,
+		RHI::EImageLayout layout)
 {
-        auto device = m_vkInstance->GetMainDevice();
+		auto device = m_vkInstance->GetMainDevice();
 
-        VkExtent3D vkExtent{ (uint32_t)extent.x, (uint32_t)extent.y, (uint32_t)extent.z };
-        auto vkImage = VulkanApi::ImportImage(device, handle, vkExtent, (VkFormat)format,
-                (VkImageUsageFlags)usage, (VkImageLayout)layout);
+		VkExtent3D vkExtent{ (uint32_t)extent.x, (uint32_t)extent.y, (uint32_t)extent.z };
+		auto vkImage = VulkanApi::ImportImage(device, handle, vkExtent, (VkFormat)format,
+			(VkImageUsageFlags)usage, (VkImageLayout)layout);
 
-        RHI::RHITexturePtr result = RHI::RHITexturePtr::Make(RHI::ETextureFiltration::Linear,
-                RHI::ETextureClamping::Clamp, false, layout);
-        result->m_vulkan.m_image = vkImage;
-        result->m_vulkan.m_imageView = VulkanImageViewPtr::Make(device, vkImage);
-        result->m_vulkan.m_imageView->Compile();
+		RHI::RHITexturePtr result = RHI::RHITexturePtr::Make(RHI::ETextureFiltration::Linear,
+			RHI::ETextureClamping::Clamp, false, layout);
+		result->m_vulkan.m_image = vkImage;
+		result->m_vulkan.m_imageView = VulkanImageViewPtr::Make(device, vkImage);
+		result->m_vulkan.m_imageView->Compile();
 
-        return result;
+		return result;
 }
 
 RHI::RHITexturePtr VulkanGraphicsDriver::CreateTexture(
@@ -1008,7 +1008,7 @@ void VulkanGraphicsDriver::UpdateDescriptorSet(RHI::RHIShaderBindingSetPtr bindi
 	VkDescriptorSet handleSet = *bindings->m_vulkan.m_descriptorSet;
 	static uint32_t s_debugIterator = 0;
 	m_vkInstance->GetMainDevice()->SetDebugName(VkObjectType::VK_OBJECT_TYPE_DESCRIPTOR_SET, (uint64_t)handleSet, std::format("ShaderBinding's Descriptor Set {}", s_debugIterator++));
-#endif 
+#endif
 }
 
 RHI::RHIMaterialPtr VulkanGraphicsDriver::CreateMaterial(const RHI::RHIVertexDescriptionPtr& vertexDescription, RHI::EPrimitiveTopology topology, const RHI::RenderState& renderState, const Sailor::ShaderSetPtr& shader)
@@ -1219,7 +1219,7 @@ TSharedPtr<VulkanBufferAllocator>& VulkanGraphicsDriver::GetMaterialSsboAllocato
 {
 	if (!m_materialSsboAllocator)
 	{
-		// 8 mb should be enough to store all material data, 
+		// 8 mb should be enough to store all material data,
 		// pessimistically ~256b per material instance, ~32000 materials per world
 		const size_t StorageBufferBlockSize = 8 * 1024 * 1024u;
 
@@ -2461,7 +2461,7 @@ TVector<VulkanDescriptorSetPtr> VulkanGraphicsDriver::GetCompatibleDescriptorSet
 							return lhs.binding == layout.m_binding && (layout.IsImage() == bIsImage); })
 						)
 					{
-						// We don't add extra bindings 
+						// We don't add extra bindings
 						continue;
 					}
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -126,24 +126,24 @@ namespace Sailor::GraphicsDriver::Vulkan
 		// Begin Immediate context
 		SAILOR_API virtual RHI::RHIBufferPtr CreateBuffer_Immediate(const void* pData, size_t size, RHI::EBufferUsageFlags usage) override;
 		SAILOR_API virtual void CopyBuffer_Immediate(RHI::RHIBufferPtr src, RHI::RHIBufferPtr dst, size_t size) override;
-                SAILOR_API virtual RHI::RHITexturePtr CreateImage_Immediate(
-                        const void* pData,
-                        size_t size,
-                        glm::ivec3 extent,
-                        uint32_t mipLevels = 1,
-                        RHI::ETextureType type = RHI::ETextureType::Texture2D,
-                        RHI::ETextureFormat format = RHI::ETextureFormat::R8G8B8A8_SRGB,
-                        RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear,
-                        RHI::ETextureClamping clamping = RHI::ETextureClamping::Clamp,
-                        RHI::ETextureUsageFlags usage = RHI::ETextureUsageBit::TextureTransferSrc_Bit | RHI::ETextureUsageBit::TextureTransferDst_Bit | RHI::ETextureUsageBit::Sampled_Bit) override;
+			SAILOR_API virtual RHI::RHITexturePtr CreateImage_Immediate(
+			const void* pData,
+			size_t size,
+			glm::ivec3 extent,
+			uint32_t mipLevels = 1,
+			RHI::ETextureType type = RHI::ETextureType::Texture2D,
+			RHI::ETextureFormat format = RHI::ETextureFormat::R8G8B8A8_SRGB,
+			RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear,
+			RHI::ETextureClamping clamping = RHI::ETextureClamping::Clamp,
+			RHI::ETextureUsageFlags usage = RHI::ETextureUsageBit::TextureTransferSrc_Bit | RHI::ETextureUsageBit::TextureTransferDst_Bit | RHI::ETextureUsageBit::Sampled_Bit) override;
 
-                SAILOR_API virtual void* ExportImage(RHI::RHITexturePtr image) override;
-                SAILOR_API virtual RHI::RHITexturePtr ImportImage(void* handle,
-                        glm::ivec3 extent,
-                        RHI::ETextureFormat format,
-                        RHI::ETextureUsageFlags usage,
-                        RHI::EImageLayout layout = RHI::EImageLayout::ShaderReadOnlyOptimal) override;
-                //End Immediate context
+			SAILOR_API virtual void* ExportImage(RHI::RHITexturePtr image) override;
+			SAILOR_API virtual RHI::RHITexturePtr ImportImage(void* handle,
+			glm::ivec3 extent,
+			RHI::ETextureFormat format,
+			RHI::ETextureUsageFlags usage,
+			RHI::EImageLayout layout = RHI::EImageLayout::ShaderReadOnlyOptimal) override;
+			//End Immediate context
 
 		//Begin IGraphicsDriverCommands
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanImage.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanImage.cpp
@@ -71,19 +71,19 @@ void VulkanImage::Compile()
 		return;
 	}
 
-       VkImageCreateInfo info = {};
-       info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
-       VkExternalMemoryImageCreateInfo externalInfo{};
-       if (m_useExternalMemory)
-       {
-               externalInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
-               externalInfo.handleTypes = m_externalHandleType;
-               info.pNext = &externalInfo;
-       }
-       else
-       {
-               info.pNext = nullptr;
-       }
+	VkImageCreateInfo info = {};
+	info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
+	VkExternalMemoryImageCreateInfo externalInfo{};
+	if (m_useExternalMemory)
+	{
+			externalInfo.sType = VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO;
+			externalInfo.handleTypes = m_externalHandleType;
+			info.pNext = &externalInfo;
+	}
+	else
+	{
+			info.pNext = nullptr;
+	}
 	info.flags = m_flags;
 	info.imageType = m_imageType;
 	info.extent = m_extent;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanImage.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanImage.h
@@ -32,18 +32,18 @@ namespace Sailor::GraphicsDriver::Vulkan
 		VkSharingMode m_sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 		TVector<uint32_t> m_queueFamilyIndices;
 		VkImageLayout m_initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-               VkImageLayout m_defaultLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+			VkImageLayout m_defaultLayout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
 
-               // External memory support
-               bool m_useExternalMemory = false;
-               VkExternalMemoryHandleTypeFlagBits m_externalHandleType = (VkExternalMemoryHandleTypeFlagBits)0;
+			// External memory support
+			bool m_useExternalMemory = false;
+			VkExternalMemoryHandleTypeFlagBits m_externalHandleType = (VkExternalMemoryHandleTypeFlagBits)0;
 
-               SAILOR_API void EnableExternalMemory(VkExternalMemoryHandleTypeFlagBits handleType)
-               {
-                       m_useExternalMemory = true;
-                       m_externalHandleType = handleType;
-               }
-               SAILOR_API bool IsExternalMemoryEnabled() const { return m_useExternalMemory; }
+			SAILOR_API void EnableExternalMemory(VkExternalMemoryHandleTypeFlagBits handleType)
+			{
+			m_useExternalMemory = true;
+			m_externalHandleType = handleType;
+			}
+			SAILOR_API bool IsExternalMemoryEnabled() const { return m_useExternalMemory; }
 
 		SAILOR_API operator VkImage() const { return m_image; }
 

--- a/Runtime/RHI/GraphicsDriver.h
+++ b/Runtime/RHI/GraphicsDriver.h
@@ -192,25 +192,25 @@ namespace Sailor::RHI
 		SAILOR_API virtual void CopyBuffer_Immediate(RHIBufferPtr src, RHIBufferPtr dst, size_t size) = 0;
 		SAILOR_API virtual void SubmitCommandList_Immediate(RHICommandListPtr commandList);
 
-                SAILOR_API virtual RHITexturePtr CreateImage_Immediate(
-                        const void* pData,
-                        size_t size,
-                        glm::ivec3 extent,
-                        uint32_t mipLevels = 1,
-                        ETextureType type = ETextureType::Texture2D,
-                        ETextureFormat format = ETextureFormat::R8G8B8A8_SRGB,
-                        ETextureFiltration filtration = ETextureFiltration::Linear,
-                        ETextureClamping clamping = ETextureClamping::Clamp,
-                        ETextureUsageFlags usage = ETextureUsageBit::TextureTransferSrc_Bit | ETextureUsageBit::TextureTransferDst_Bit | ETextureUsageBit::Sampled_Bit) = 0;
+			SAILOR_API virtual RHITexturePtr CreateImage_Immediate(
+			const void* pData,
+			size_t size,
+			glm::ivec3 extent,
+			uint32_t mipLevels = 1,
+			ETextureType type = ETextureType::Texture2D,
+			ETextureFormat format = ETextureFormat::R8G8B8A8_SRGB,
+			ETextureFiltration filtration = ETextureFiltration::Linear,
+			ETextureClamping clamping = ETextureClamping::Clamp,
+			ETextureUsageFlags usage = ETextureUsageBit::TextureTransferSrc_Bit | ETextureUsageBit::TextureTransferDst_Bit | ETextureUsageBit::Sampled_Bit) = 0;
 
-                // External memory support
-                SAILOR_API virtual void* ExportImage(RHITexturePtr image) = 0;
-                SAILOR_API virtual RHITexturePtr ImportImage(void* handle,
-                        glm::ivec3 extent,
-                        ETextureFormat format,
-                        ETextureUsageFlags usage,
-                        EImageLayout layout = EImageLayout::ShaderReadOnlyOptimal) = 0;
-                //Immediate context
+			// External memory support
+			SAILOR_API virtual void* ExportImage(RHITexturePtr image) = 0;
+			SAILOR_API virtual RHITexturePtr ImportImage(void* handle,
+			glm::ivec3 extent,
+			ETextureFormat format,
+			ETextureUsageFlags usage,
+			EImageLayout layout = EImageLayout::ShaderReadOnlyOptimal) = 0;
+			//Immediate context
 
 		SAILOR_API virtual void CollectGarbage_RenderThread() = 0;
 		SAILOR_API void TrackResources_ThreadSafe();
@@ -337,7 +337,7 @@ namespace Sailor::RHI
 		SAILOR_API virtual void CopyBufferToImage(RHI::RHICommandListPtr cmd, RHI::RHIBufferPtr src, RHI::RHITexturePtr dst) = 0;
 		SAILOR_API virtual void CopyImageToBuffer(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr src, RHI::RHIBufferPtr dst) = 0;
 
-		// Used for variables inside uniform buffer 
+		// Used for variables inside uniform buffer
 		// 'customData.color' would be parsed as 'customData' buffer with 'color' variable
 		template<typename TDataType>
 		void SetMaterialParameter(RHICommandListPtr cmd, RHI::RHIShaderBindingSetPtr bindings, const std::string& parameter, const TDataType& value)


### PR DESCRIPTION
## Summary
- convert leading spaces after tab-indents to tabs in Runtime modules
- keep consistent tab indentation across Vulkan driver headers and sources

## Testing
- `bash update_deps.bat` *(fails: command not found)*
- `python3 Tests/process_no_crash_test.py`
- `python3 Tests/container_benchmarks_test.py` *(skipped: requires Windows build)*