### PR TITLE
Add editor UI to create game projects

### DIFF
--- a/Editor/MainPage.xaml
+++ b/Editor/MainPage.xaml
@@ -9,6 +9,7 @@
 
     <ContentPage.MenuBarItems>
         <MenuBarItem Text = "File">
+            <MenuFlyoutItem Text="Create Game Project" Clicked="OnCreateGameProjectClicked" />
             <MenuFlyoutItem Text ="Save" ></MenuFlyoutItem>
             <MenuFlyoutSeparator/>
             <MenuFlyoutItem Text ="Exit"></MenuFlyoutItem>

--- a/Editor/MainPage.xaml.cs
+++ b/Editor/MainPage.xaml.cs
@@ -15,6 +15,11 @@ namespace SailorEditor
             InitializeComponent();
         }
 
+        private async void OnCreateGameProjectClicked(object sender, EventArgs e)
+        {
+            await Navigation.PushModalAsync(new Views.CreateGameProjectPage());
+        }
+
         private void ChangeTheme(string theme)
         {
             var mergedDictionaries = Application.Current.Resources.MergedDictionaries;

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -26,6 +26,7 @@ namespace SailorEditor
             builder.Services.AddSingleton<SelectionService>();
             builder.Services.AddSingleton<WorldService>();
             builder.Services.AddSingleton<EngineService>();
+            builder.Services.AddSingleton<GameProjectService>();
             builder.Services.AddTransient<MainPage>();
             builder.Services.AddTransient<ContentFolderView>();
 

--- a/Editor/SailorEditor.csproj
+++ b/Editor/SailorEditor.csproj
@@ -138,10 +138,13 @@
 	  <Compile Update="Views\InspectorView\TextureFileTemplate.xaml.cs">
 	    <DependentUpon>TextureFileTemplate.xaml</DependentUpon>
 	  </Compile>
-	  <Compile Update="Views\SceneView.xaml.cs">
-	    <DependentUpon>SceneView.xaml</DependentUpon>
-	  </Compile>
-	</ItemGroup>
+        <Compile Update="Views\SceneView.xaml.cs">
+            <DependentUpon>SceneView.xaml</DependentUpon>
+        </Compile>
+        <Compile Update="Views\CreateGameProjectPage.xaml.cs">
+          <DependentUpon>CreateGameProjectPage.xaml</DependentUpon>
+        </Compile>
+      </ItemGroup>
 
 	<ItemGroup>
 	  <MauiXaml Update="Controls\HorizontalGridSplitterControl.xaml">
@@ -202,10 +205,13 @@
 	  <MauiXaml Update="Views\InspectorView\AssetFileTemplate.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\SceneView.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	</ItemGroup>
+        <MauiXaml Update="Views\SceneView.xaml">
+            <Generator>MSBuild:Compile</Generator>
+        </MauiXaml>
+        <MauiXaml Update="Views\CreateGameProjectPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+        </MauiXaml>
+      </ItemGroup>
 
 	<ItemGroup>
 	  <PackageReference Update="Microsoft.Maui.Controls.Compatibility" Version="8.0.7" />

--- a/Editor/Services/GameProjectService.cs
+++ b/Editor/Services/GameProjectService.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Linq;
+
+namespace SailorEditor.Services
+{
+    internal class GameProjectService
+    {
+        private static readonly string RootDir = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
+        private static readonly string GamesDir = Path.Combine(RootDir, "Games");
+
+        private const string CMakeInsertAfter = "add_subdirectory(Lib)";
+
+        private const string MainCpp = """struct IUnknown; // Workaround for \"combaseapi.h(229): error C2187: syntax error: 'identifier' was unexpected here\" when using /permissive-
+
+#include <wtypes.h>
+#include <shellapi.h>
+#include <windows.h>
+
+#include \"Sailor.h\"
+
+using namespace Sailor;
+
+int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
+{
+\tApp::Initialize(nullptr, 0);
+\tApp::Start();
+\tApp::Stop();
+\tApp::Shutdown();
+\treturn 0;
+}
+""";
+
+        public void CreateGameProject(string name)
+        {
+            Directory.CreateDirectory(GamesDir);
+            string projectDir = Path.Combine(GamesDir, name);
+            Directory.CreateDirectory(projectDir);
+
+            string cmakeContent = $"add_executable({name} WIN32 Main.cpp)\n" +
+                                   $"add_dependencies({name} SailorLib)\n" +
+                                   $"target_link_libraries({name} SailorLib)\n" +
+                                   $"target_compile_definitions({name} PUBLIC NOMINMAX)\n" +
+                                   $"set_property(TARGET {name} PROPERTY FOLDER \"Games\")\n" +
+                                   $"set_property(TARGET {name} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY \"${{SAILOR_BINARIES_DIR}}\")\n";
+
+            File.WriteAllText(Path.Combine(projectDir, "CMakeLists.txt"), cmakeContent);
+            File.WriteAllText(Path.Combine(projectDir, "Main.cpp"), MainCpp);
+
+            UpdateRootCMake(name);
+        }
+
+        private static void UpdateRootCMake(string projectName)
+        {
+            string cmakePath = Path.Combine(RootDir, "CMakeLists.txt");
+            string subdirLine = $"add_subdirectory(Games/{projectName})\n";
+
+            var lines = File.ReadAllLines(cmakePath).ToList();
+
+            if (lines.Any(l => l.Trim() == subdirLine.Trim()))
+            {
+                return;
+            }
+
+            int idx = lines.FindIndex(l => l.Trim().StartsWith(CMakeInsertAfter));
+            if (idx >= 0)
+            {
+                lines.Insert(idx + 1, subdirLine);
+            }
+            else
+            {
+                lines.Add(subdirLine);
+            }
+
+            File.WriteAllLines(cmakePath, lines);
+        }
+    }
+}

--- a/Editor/Views/CreateGameProjectPage.xaml
+++ b/Editor/Views/CreateGameProjectPage.xaml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="SailorEditor.Views.CreateGameProjectPage"
+             Title="New Game Project">
+    <VerticalStackLayout Padding="20" Spacing="10">
+        <Entry x:Name="ProjectNameEntry" Placeholder="Project Name" />
+        <Button Text="Create" Clicked="OnCreateClicked" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/Editor/Views/CreateGameProjectPage.xaml.cs
+++ b/Editor/Views/CreateGameProjectPage.xaml.cs
@@ -1,0 +1,29 @@
+using SailorEditor.Services;
+using System;
+using System.Threading.Tasks;
+
+namespace SailorEditor.Views;
+
+public partial class CreateGameProjectPage : ContentPage
+{
+    public CreateGameProjectPage()
+    {
+        InitializeComponent();
+    }
+
+    private async void OnCreateClicked(object sender, EventArgs e)
+    {
+        var name = ProjectNameEntry.Text?.Trim();
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            await DisplayAlert("Error", "Project name cannot be empty", "OK");
+            return;
+        }
+
+        var service = MauiProgram.GetService<GameProjectService>();
+        service.CreateGameProject(name);
+
+        await DisplayAlert("Game Project", $"Created project {name}", "OK");
+        await Navigation.PopModalAsync();
+    }
+}

--- a/Scripts/create_game_project.py
+++ b/Scripts/create_game_project.py
@@ -1,0 +1,80 @@
+import os
+import sys
+
+ROOT_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+GAMES_DIR = os.path.join(ROOT_DIR, 'Games')
+
+CMAKE_INSERT_AFTER = 'add_subdirectory(Lib)'
+
+MAIN_CPP = '''struct IUnknown; // Workaround for "combaseapi.h(229): error C2187: syntax error: 'identifier' was unexpected here" when using /permissive-
+
+#include <wtypes.h>
+#include <shellapi.h>
+#include <windows.h>
+
+#include "Sailor.h"
+
+using namespace Sailor;
+
+int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
+{
+\tApp::Initialize(nullptr, 0);
+\tApp::Start();
+\tApp::Stop();
+\tApp::Shutdown();
+\treturn 0;
+}
+'''
+
+def create_project(name: str):
+    project_dir = os.path.join(GAMES_DIR, name)
+    os.makedirs(project_dir, exist_ok=True)
+
+    cmake_content = f"add_executable({name} WIN32 Main.cpp)\n" \
+                     f"add_dependencies({name} SailorLib)\n" \
+                     f"target_link_libraries({name} SailorLib)\n" \
+                     f"target_compile_definitions({name} PUBLIC NOMINMAX)\n" \
+                     f"set_property(TARGET {name} PROPERTY FOLDER \"Games\")\n" \
+                     f"set_property(TARGET {name} PROPERTY VS_DEBUGGER_WORKING_DIRECTORY \"\${{SAILOR_BINARIES_DIR}}\")\n"
+
+    with open(os.path.join(project_dir, 'CMakeLists.txt'), 'w') as f:
+        f.write(cmake_content)
+
+    with open(os.path.join(project_dir, 'Main.cpp'), 'w') as f:
+        f.write(MAIN_CPP)
+
+    update_root_cmake(name)
+
+
+def update_root_cmake(project_name: str):
+    cmake_path = os.path.join(ROOT_DIR, 'CMakeLists.txt')
+    subdir_line = f"add_subdirectory(Games/{project_name})\n"
+
+    with open(cmake_path, 'r') as f:
+        lines = f.readlines()
+
+    if any(line.strip() == subdir_line.strip() for line in lines):
+        return
+
+    for idx, line in enumerate(lines):
+        if line.strip().startswith(CMAKE_INSERT_AFTER):
+            lines.insert(idx + 1, subdir_line)
+            break
+    else:
+        lines.append(subdir_line)
+
+    with open(cmake_path, 'w') as f:
+        f.writelines(lines)
+
+
+def main():
+    if len(sys.argv) != 2:
+        print('Usage: create_game_project.py <ProjectName>')
+        return 1
+    create_project(sys.argv[1])
+    print(f'Created game project {sys.argv[1]}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- implement `GameProjectService` for generating new game projects
- add menu item in the editor to open a creation dialog
- create `CreateGameProjectPage` UI for naming and creating projects
- register the new service in the editor app

## Testing
- `python3 Tests/process_no_crash_test.py`
- `python3 Tests/container_benchmarks_test.py`