### PR TITLE
Fix stb_image_write redefinitions

### DIFF
--- a/Runtime/AssetRegistry/Texture/TextureImporter.cpp
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.cpp
@@ -17,8 +17,12 @@
 #ifndef STB_IMAGE_IMPLEMENTATION
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_MSC_SECURE_CRT
-#define STB_IMAGE_WRITE_IMPLEMENTATION
 #include <stb_image.h>
+#endif
+
+#ifndef STB_IMAGE_WRITE_IMPLEMENTATION
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#include <stb_image_write.h>
 #endif
 
 using namespace Sailor;

--- a/Runtime/Raytracing/PathTracer.cpp
+++ b/Runtime/Raytracing/PathTracer.cpp
@@ -10,12 +10,6 @@
 
 #include <stb_image.h>
 
-#ifndef STB_IMAGE_WRITE_IMPLEMENTATION
-#define STB_IMAGE_WRITE_IMPLEMENTATION
-#define __STDC_LIB_EXT1__
-#include <stb_image_write.h>
-#endif 
-
 //#include "assimp/scene.h"
 //#include "assimp/postprocess.h"
 //#include "assimp/Importer.hpp"


### PR DESCRIPTION
## Summary
- prevent double inclusion of stb_image_write in PathTracer
- ensure stb_image_write implementation is included in TextureImporter

## Testing
- `git status --short`