### PR TITLE
Add scheduler tests

### DIFF
--- a/Runtime/Tasks/Scheduler.cpp
+++ b/Runtime/Tasks/Scheduler.cpp
@@ -518,5 +518,19 @@ TaskSyncBlock& Scheduler::GetTaskSyncBlock(const ITask& task)
 
 void Scheduler::ReleaseTaskSyncBlock(const ITask& task)
 {
-	m_freeList.push(task.m_taskSyncBlockHandle);
+        m_freeList.push(task.m_taskSyncBlockHandle);
+}
+
+void Scheduler::ReleaseTaskSyncBlock(uint16_t handle)
+{
+        m_freeList.push(handle);
+}
+
+DWORD Scheduler::GetWorkerThreadId(uint32_t index) const
+{
+        if (index < m_workerThreads.Num())
+        {
+                return m_workerThreads[index]->GetThreadId();
+        }
+        return (DWORD)-1;
 }

--- a/Runtime/Tasks/Scheduler.h
+++ b/Runtime/Tasks/Scheduler.h
@@ -134,6 +134,7 @@ namespace Sailor
 
 			SAILOR_API DWORD GetMainThreadId() const { return m_mainThreadId; }
 			SAILOR_API DWORD GetRendererThreadId() const { return m_renderingThreadId; }
+			SAILOR_API DWORD GetWorkerThreadId(uint32_t index) const;
 			SAILOR_API EThreadType GetCurrentThreadType() const;
 
 			SAILOR_API Scheduler();
@@ -143,6 +144,7 @@ namespace Sailor
 			SAILOR_API TaskSyncBlock& GetTaskSyncBlock(const ITask& task);
 			SAILOR_API uint16_t AcquireTaskSyncBlock();
 			SAILOR_API void ReleaseTaskSyncBlock(const ITask& task);
+			SAILOR_API void ReleaseTaskSyncBlock(uint16_t handle);
 
 		protected:
 

--- a/Runtime/Tasks/SchedulerTests.cpp
+++ b/Runtime/Tasks/SchedulerTests.cpp
@@ -1,0 +1,188 @@
+		#include "Sailor.h"
+	#include "Tasks/Tasks.h"
+	#include "Tasks/Scheduler.h"
+	#include <atomic>
+	#include <thread>
+	
+	using namespace Sailor;
+	using namespace Sailor::Tasks;
+	
+	extern "C" {
+	
+	SAILOR_API bool SchedulerTest_Initialization()
+	{
+	App::Initialize();
+	auto scheduler = App::GetSubmodule<Sailor::Tasks::Scheduler>();
+	const unsigned cores = std::thread::hardware_concurrency();
+	unsigned expectedWorkers = std::max(1u, cores - 2u - scheduler->GetNumRHIThreads());
+	unsigned expectedTotal = 1u + expectedWorkers + scheduler->GetNumRHIThreads();
+	bool result = scheduler->GetNumWorkerThreads() == expectedTotal;
+	App::Shutdown();
+	return result;
+	}
+	
+	SAILOR_API bool SchedulerTest_BasicTaskExecution()
+	{
+	App::Initialize();
+	auto scheduler = App::GetSubmodule<Sailor::Tasks::Scheduler>();
+	std::atomic<bool> flag = false;
+	auto task = Tasks::CreateTask("BasicTask", [&]() { flag = true; });
+	scheduler->Run(task);
+	scheduler->WaitIdle(EThreadType::Worker);
+	bool result = flag && task->IsFinished();
+	App::Shutdown();
+	return result;
+	}
+	
+	SAILOR_API bool SchedulerTest_TaskChaining()
+	{
+	App::Initialize();
+	auto scheduler = App::GetSubmodule<Sailor::Tasks::Scheduler>();
+	std::atomic<int> value = 0;
+	auto first = Tasks::CreateTaskWithResult<int>("First", []() { return 42; });
+	auto second = first->Then<void>([&](int v) { value = v; });
+	scheduler->Run(first);
+	scheduler->WaitIdle(EThreadType::Worker);
+	bool result = value == 42 && first->IsFinished() && second->IsFinished();
+	App::Shutdown();
+	return result;
+	}
+	
+	SAILOR_API bool SchedulerTest_TaskDependencies()
+	{
+	App::Initialize();
+	auto scheduler = App::GetSubmodule<Sailor::Tasks::Scheduler>();
+	std::atomic<int> order = 0;
+	auto first = Tasks::CreateTask("First", [&]() { order = 1; });
+	auto second = Tasks::CreateTask("Second", [&]() { if(order==1) order = 2; else order = -1; });
+	second->Join(first);
+	scheduler->Run(first);
+	scheduler->Run(second);
+	scheduler->WaitIdle(EThreadType::Worker);
+	bool result = order == 2;
+	App::Shutdown();
+	return result;
+	}
+	
+	SAILOR_API bool SchedulerTest_ThreadSpecificExecution()
+	{
+	App::Initialize();
+	auto scheduler = App::GetSubmodule<Sailor::Tasks::Scheduler>();
+	DWORD renderThreadId = 0;
+	EThreadType renderType = EThreadType::Worker;
+	SAILOR_ENQUEUE_TASK_RENDER_THREAD("RenderTask", [&]() { renderThreadId = GetCurrentThreadId(); renderType = scheduler->GetCurrentThreadType(); });
+	scheduler->WaitIdle(EThreadType::Render);
+	DWORD rhiThreadId = 0;
+	EThreadType rhiType = EThreadType::Worker;
+	SAILOR_ENQUEUE_TASK_RHI_THREAD("RhiTask", [&]() { rhiThreadId = GetCurrentThreadId(); rhiType = scheduler->GetCurrentThreadType(); });
+	scheduler->WaitIdle(EThreadType::RHI);
+	bool result = renderThreadId == scheduler->GetRendererThreadId() && renderType == EThreadType::Render && rhiType == EThreadType::RHI;
+	App::Shutdown();
+	return result;
+	}
+	
+	SAILOR_API bool SchedulerTest_WaitIdleRHI()
+	{
+	App::Initialize();
+	auto scheduler = App::GetSubmodule<Sailor::Tasks::Scheduler>();
+	std::atomic<int> counter = 0;
+	for(int i=0;i<5;i++)
+	{
+	auto task = Tasks::CreateTask("RhiTask", [&](){ counter++; }, EThreadType::RHI);
+	scheduler->Run(task);
+	}
+	scheduler->WaitIdle(EThreadType::RHI);
+	bool result = counter == 5;
+	App::Shutdown();
+	return result;
+	}
+	
+	SAILOR_API bool SchedulerTest_RunExplicitThread()
+	{
+	App::Initialize();
+	auto scheduler = App::GetSubmodule<Sailor::Tasks::Scheduler>();
+	if(scheduler->GetNumWorkerThreads() < 2)
+	{
+	App::Shutdown();
+	return false;
+	}
+	DWORD workerId = scheduler->GetWorkerThreadId(1);
+	std::atomic<DWORD> executedId = 0;
+	auto task = Tasks::CreateTask("Explicit", [&]() { executedId = GetCurrentThreadId(); });
+	scheduler->Run(task, workerId);
+	scheduler->WaitIdle(EThreadType::Worker);
+	bool result = executedId == workerId;
+	App::Shutdown();
+	return result;
+	}
+	
+	SAILOR_API bool SchedulerTest_ConcurrentInsertion()
+	{
+	App::Initialize();
+	auto scheduler = App::GetSubmodule<Sailor::Tasks::Scheduler>();
+	std::atomic<int> counter = 0;
+	const int tasksPerThread = 50;
+	const int numThreads = 4;
+	std::vector<std::thread> threads;
+	for(int t=0;t<numThreads;t++)
+	{
+	threads.emplace_back([&]() {
+	for(int i=0;i<tasksPerThread;i++)
+	{
+	auto task = Tasks::CreateTask("Conc", [&]() { counter++; });
+	scheduler->Run(task);
+	}
+	});
+	}
+	for(auto& th : threads) th.join();
+	scheduler->WaitIdle(EThreadType::Worker);
+	bool result = counter == tasksPerThread * numThreads;
+	App::Shutdown();
+	return result;
+	}
+	
+	SAILOR_API bool SchedulerTest_TaskSyncBlockReuse()
+	{
+	App::Initialize();
+	auto scheduler = App::GetSubmodule<Sailor::Tasks::Scheduler>();
+	TVector<uint16_t> handles;
+	for(int i=0;i<100;i++)
+	{
+	handles.Add(scheduler->AcquireTaskSyncBlock());
+	}
+	for(auto h : handles)
+	{
+	scheduler->ReleaseTaskSyncBlock(h);
+	}
+	TVector<uint16_t> reacquired;
+	for(int i=0;i<100;i++)
+	{
+	reacquired.Add(scheduler->AcquireTaskSyncBlock());
+	}
+	bool result = true;
+	for(int i=0;i<100;i++)
+	{
+	if(handles[i]!=reacquired[i]){ result=false; break; }
+	scheduler->ReleaseTaskSyncBlock(reacquired[i]);
+	}
+	App::Shutdown();
+	return result;
+	}
+	
+	SAILOR_API bool SchedulerTest_MainThreadProcessing()
+	{
+	App::Initialize();
+	auto scheduler = App::GetSubmodule<Sailor::Tasks::Scheduler>();
+	TVector<int> order;
+	for(int i=0;i<3;i++)
+	{
+	auto task = Tasks::CreateTask("Main", [&,i]() { order.Add(i); }, EThreadType::Main);
+	scheduler->Run(task);
+	}
+	scheduler->ProcessTasksOnMainThread();
+	bool result = order.Num()==3 && order[0]==0 && order[1]==1 && order[2]==2;
+	App::Shutdown();
+	return result;
+	}
+	
+	}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -10,3 +10,8 @@ add_test(
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/container_benchmarks_test.py
 )
 
+add_test(
+    NAME SchedulerTests
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/tasks_scheduler_test.py
+)
+

--- a/Tests/tasks_scheduler_test.py
+++ b/Tests/tasks_scheduler_test.py
@@ -1,0 +1,45 @@
+import ctypes
+import os
+import platform
+import sys
+
+
+def main():
+    if platform.system() != "Windows":
+        print("Skipping scheduler tests: requires Windows build")
+        return 0
+
+    build_type = os.environ.get("CONFIG", "Release")
+    binaries_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "Binaries"))
+    lib_path = os.path.join(binaries_dir, f"Sailor-{build_type}.dll")
+
+    if not os.path.exists(lib_path):
+        print(f"Skipping scheduler tests: {lib_path} not found")
+        return 0
+
+    lib = ctypes.CDLL(lib_path)
+
+    tests = [
+        ("SchedulerTest_Initialization", lib.SchedulerTest_Initialization),
+        ("SchedulerTest_BasicTaskExecution", lib.SchedulerTest_BasicTaskExecution),
+        ("SchedulerTest_TaskChaining", lib.SchedulerTest_TaskChaining),
+        ("SchedulerTest_TaskDependencies", lib.SchedulerTest_TaskDependencies),
+        ("SchedulerTest_ThreadSpecificExecution", lib.SchedulerTest_ThreadSpecificExecution),
+        ("SchedulerTest_WaitIdleRHI", lib.SchedulerTest_WaitIdleRHI),
+        ("SchedulerTest_RunExplicitThread", lib.SchedulerTest_RunExplicitThread),
+        ("SchedulerTest_ConcurrentInsertion", lib.SchedulerTest_ConcurrentInsertion),
+        ("SchedulerTest_TaskSyncBlockReuse", lib.SchedulerTest_TaskSyncBlockReuse),
+        ("SchedulerTest_MainThreadProcessing", lib.SchedulerTest_MainThreadProcessing),
+    ]
+
+    for name, func in tests:
+        func.restype = ctypes.c_bool
+        if not func():
+            print(f"{name} failed")
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- expand Scheduler with helper to get worker thread ids and raw sync block release
- implement C++ scheduler tests verifying initialization, task execution, chaining, dependencies, thread affinity, wait idle, explicit thread selection, concurrent enqueues, sync block reuse and main thread processing
- add Python script running the new tests when built on Windows
- register the new test script in CMake
- fix newline at end of scheduler files

## Testing
- `ctest --output-on-failure -j 4` *(fails: No tests were found)*