### PR TITLE
Fix multiple tinygltf implementations

### DIFF
--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -15,10 +15,7 @@
 #include "RHI/Renderer.h"
 #include "Memory/ObjectAllocator.hpp"
 
-#ifndef TINYGLTF_IMPLEMENTATION
-#define TINYGLTF_IMPLEMENTATION
 #include <tiny_gltf.h>
-#endif
 
 using namespace Sailor;
 

--- a/Runtime/AssetRegistry/Texture/TextureImporter.cpp
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.cpp
@@ -12,18 +12,12 @@
 #include "RHI/Renderer.h"
 #include "RHI/Shader.h"
 
-#ifndef TINYGLTF_IMPLEMENTATION
-#define TINYGLTF_IMPLEMENTATION
-#include <tiny_gltf.h>
-#endif
 
-#ifndef STB_IMAGE_IMPLEMENTATION
-#define STB_IMAGE_IMPLEMENTATION
-#define STBI_MSC_SECURE_CRT
-#define STB_IMAGE_WRITE_IMPLEMENTATION
-#define __STDC_LIB_EXT1__
+
+#include <tiny_gltf.h>
 #include <stb_image.h>
-#endif
+
+
 
 using namespace Sailor;
 

--- a/Runtime/Raytracing/PathTracer.cpp
+++ b/Runtime/Raytracing/PathTracer.cpp
@@ -8,10 +8,8 @@
 #include <glm/gtc/random.hpp>
 #include <glm/gtx/matrix_transform_2d.hpp>
 
-#ifndef TINYGLTF_IMPLEMENTATION
-#define TINYGLTF_IMPLEMENTATION
 #include <tiny_gltf.h>
-#endif
+#include <stb_image_write.h>
 
 using namespace Sailor;
 using namespace Sailor::Math;

--- a/Runtime/Submodules/TinyGLTF.cpp
+++ b/Runtime/Submodules/TinyGLTF.cpp
@@ -1,0 +1,10 @@
+#define STB_IMAGE_IMPLEMENTATION
+#define STB_IMAGE_WRITE_IMPLEMENTATION
+#define STBI_MSC_SECURE_CRT
+#define __STDC_LIB_EXT1__
+
+#include <stb_image.h>
+#include <stb_image_write.h>
+
+#define TINYGLTF_IMPLEMENTATION
+#include <tiny_gltf.h>


### PR DESCRIPTION
## Summary
- include tinygltf once to avoid duplicate symbol errors
- centralize STB and tinygltf implementations in a new file
- remove redundant macro definitions from other sources

## Testing
- `cmake -S . -B build` *(fails: could not find yaml-cpp)*