### PR TITLE
Fix Windows Vulkan includes

### DIFF
--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.h
@@ -6,6 +6,9 @@
 #include <cassert>
 #include <iostream>
 #include <cstdint>
+#ifdef _WIN32
+#include <Windows.h>
+#endif
 #include <vulkan/vulkan_core.h>
 #include "Sailor.h"
 #include "RHI/Types.h"

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
@@ -6,6 +6,7 @@ struct IUnknown; // Workaround for "combaseapi.h(229): error C2187: syntax error
 #include "Containers/Vector.h"
 #include <optional>
 #include <wtypes.h>
+#include "VulkanApi.h"
 #include <vulkan/vulkan.h>
 #include <vulkan/vulkan_win32.h>
 #include "AssetRegistry/AssetRegistry.h"
@@ -16,7 +17,6 @@ struct IUnknown; // Workaround for "combaseapi.h(229): error C2187: syntax error
 #include "Platform/Win32/Window.h"
 #include "Math/Math.h"
 #include "VulkanDevice.h"
-#include "VulkanApi.h"
 #include "VulkanRenderPass.h"
 #include "VulkanSwapchain.h"
 #include "VulkanCommandBuffer.h"


### PR DESCRIPTION
## Summary
- include `<Windows.h>` inside VulkanApi on Windows builds so win32 types are defined
- make VulkanDevice include VulkanApi before including Vulkan headers

## Testing
- `pytest -q`
- `ctest --output-on-failure`