### PR TITLE
Add cross platform dependency updater

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,5 +3,6 @@ This repository uses git submodules for dependencies (`External/renderdoc` and `
 The project is a game engine written in C++ and built with CMake. It targets Windows x64 and can be compiled with either the MSVC or clang toolchains.
 
 Dependencies are managed through vcpkg. Whenever you update the repository (for example, pull new commits or fetch submodule changes) run `update_deps.bat` from the repository root to update and install the required packages.
+A cross-platform Python version `update_deps.py` can be used on Linux and Windows as well.
 
 The editor application is written in C# using .NET MAUI. Its source code lives in the `Editor` directory.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ Visit the Wiki to explore everything you need to get started, understand the eng
 - **Editor:** Built with `.NET MAUI`.
 - **Engine:** Built with `C++20` (`MSVC` and `clang`).
 
+## Dependencies
+
+This project uses [vcpkg](https://github.com/microsoft/vcpkg) to manage C++ dependencies. Run `update_deps.bat` on Windows or `python update_deps.py` on Linux to install the required packages.
+
 ## Sponsorship and Contribution
 
 **Support Sailor Engine's Development**  

--- a/update_deps.py
+++ b/update_deps.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+import os
+import platform
+import subprocess
+import sys
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+VCPKG_ROOT = os.path.join(SCRIPT_DIR, 'External', 'vcpkg')
+
+system = platform.system()
+if system == 'Windows':
+    vcpkg_exe = os.path.join(VCPKG_ROOT, 'vcpkg.exe')
+    bootstrap_cmd = ['cmd', '/c', 'bootstrap-vcpkg.bat']
+else:
+    vcpkg_exe = os.path.join(VCPKG_ROOT, 'vcpkg')
+    bootstrap_cmd = ['./bootstrap-vcpkg.sh']
+
+if not os.path.exists(vcpkg_exe):
+    print('Bootstrap vcpkg...')
+    subprocess.check_call(bootstrap_cmd, cwd=VCPKG_ROOT)
+
+
+def run_vcpkg(*args):
+    subprocess.check_call([vcpkg_exe] + list(args), cwd=VCPKG_ROOT)
+
+run_vcpkg('update')
+run_vcpkg('upgrade', '--no-dry-run')
+
+triplet = 'x64-windows' if system == 'Windows' else 'x64-linux'
+packages = [
+    'glm',
+    'imgui[win32-binding]' if system == 'Windows' else 'imgui',
+    'magic-enum',
+    'nlohmann-json',
+    'refl-cpp',
+    'spirv-reflect',
+    'stb',
+    'tinygltf',
+    'tracy',
+    'yaml-cpp',
+]
+
+for pkg in packages:
+    run_vcpkg('install', f'{pkg}:{triplet}')
+
+print('Dependencies updated and installed.')


### PR DESCRIPTION
## Summary
- add `update_deps.py` script for updating vcpkg dependencies on Windows and Linux
- document how to use the script in README
- mention the Python script in `AGENTS.md`

## Testing
- `python Tests/process_no_crash_test.py`
- `python Tests/container_benchmarks_test.py`