### PR TITLE
Fix glTF texture mapping for path tracer

### DIFF
--- a/Runtime/Raytracing/MaterialUtils.h
+++ b/Runtime/Raytracing/MaterialUtils.h
@@ -186,13 +186,13 @@ namespace Sailor::Raytracing
 	SAILOR_API void GenerateTangentBitangent(vec3& outTangent, vec3& outBitangent, const vec3* vert, const vec2* uv);
 
 
-	template<typename T>
-	void LoadTexture(const tinygltf::Model& model,
-		const std::filesystem::path& sceneDir,
-		TVector<TSharedPtr<CombinedSampler2D>>& textures,
-		uint32_t textureIndex,
-		bool bConvertToLinear,
-		bool bNormalMap = false)
+        template<typename T>
+        void LoadTexture(const tinygltf::Model& model,
+                const std::filesystem::path& sceneDir,
+                TVector<TSharedPtr<CombinedSampler2D>>& textures,
+                uint32_t textureIndex,
+                bool bConvertToLinear,
+                bool bNormalMap = false)
 	{
 		auto ptr = textures[textureIndex] = TSharedPtr<CombinedSampler2D>::Make();
 
@@ -261,6 +261,21 @@ namespace Sailor::Raytracing
 		{
 			ptr->Initialize<T, u8vec4>((u8vec4*)pixelsU8, bConvertToLinear, bNormalMap);
 			stbi_image_free(pixelsU8);
-		}
-	}
+                }
+        }
+
+       template<typename T>
+       Tasks::ITaskPtr LoadTexture_Task(const tinygltf::Model& model,
+               const std::filesystem::path& sceneDir,
+               TVector<TSharedPtr<CombinedSampler2D>>& textures,
+               uint32_t textureIndex,
+               bool bConvertToLinear,
+               bool bNormalMap = false)
+       {
+               return Tasks::CreateTask("Load Texture",
+                       [&model, &sceneDir, &textures, textureIndex, bConvertToLinear, bNormalMap]()
+                       {
+                               LoadTexture<T>(model, sceneDir, textures, textureIndex, bConvertToLinear, bNormalMap);
+                       });
+       }
 }

--- a/Runtime/Raytracing/PathTracer.h
+++ b/Runtime/Raytracing/PathTracer.h
@@ -3,6 +3,7 @@
 #include "Math/Bounds.h"
 #include "Containers/Vector.h"
 #include "Containers/Map.h"
+#include "Containers/Hash.h"
 
 #include "BVH.h"
 #include "MaterialUtils.h"
@@ -14,7 +15,32 @@ using namespace Sailor;
 
 namespace Sailor::Raytracing
 {
-	class PathTracer
+       struct TextureKey
+       {
+               int32_t m_textureIndex{};
+               SamplerClamping m_clamping = SamplerClamping::Clamp;
+               bool m_convertToLinear = false;
+               bool m_normalMap = false;
+               uint8_t m_channels = 4;
+
+               bool operator==(const TextureKey& rhs) const
+               {
+                       return m_textureIndex == rhs.m_textureIndex &&
+                               m_clamping == rhs.m_clamping &&
+                               m_convertToLinear == rhs.m_convertToLinear &&
+                               m_normalMap == rhs.m_normalMap &&
+                               m_channels == rhs.m_channels;
+               }
+
+               size_t GetHash() const
+               {
+                       size_t hash = 0;
+                       HashCombine(hash, m_textureIndex, (int)m_clamping, m_convertToLinear, m_normalMap, m_channels);
+                       return hash;
+               }
+       };
+
+       class PathTracer
 	{
 	public:
 
@@ -50,7 +76,7 @@ namespace Sailor::Raytracing
 		TVector<DirectionalLight> m_directionalLights{};
 		TVector<Math::Triangle> m_triangles{};
 		TVector<Material> m_materials{};
-		TVector<TSharedPtr<CombinedSampler2D>> m_textures{};
-		TMap<std::string, uint32_t> m_textureMapping{};
-	};
+               TVector<TSharedPtr<CombinedSampler2D>> m_textures{};
+               TMap<TextureKey, uint32_t> m_textureMapping{};
+       };
 }


### PR DESCRIPTION
## Summary
- support async texture loading in MaterialUtils
- track unique texture usages by sampler and format
- load textures with correct channel types
- parse TEXCOORD_0 and TEXCOORD_1 for ray tracing

## Testing
- `python3 Tests/process_no_crash_test.py`
- `python3 Tests/container_benchmarks_test.py`