### PR TITLE
Store animation bind pose

### DIFF
--- a/Runtime/AssetRegistry/Animation/AnimationImporter.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationImporter.cpp
@@ -4,6 +4,7 @@
 #include <glm/gtc/type_ptr.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/quaternion.hpp>
+#include "Math/Transform.h"
 
 using namespace Sailor;
 
@@ -116,8 +117,8 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 			anim->m_numFrames = (uint32_t)numFrames;
 			anim->m_fps = 30.0f;
 
-			TVector<glm::mat4> framesData;
-			framesData.Resize(numFrames * numBones);
+                       TVector<Math::Transform> framesData;
+                       framesData.Resize(numFrames * numBones);
 
 			TVector<int> parents(gltfModel.nodes.size(), -1);
 			for (size_t i = 0; i < gltfModel.nodes.size(); ++i)
@@ -129,33 +130,17 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 				}
 			}
 
-			TVector<glm::mat4> inverseBind(numBones);
-			if (gltfSkin.inverseBindMatrices >= 0)
-			{
-				const auto& accessor = gltfModel.accessors[gltfSkin.inverseBindMatrices];
-				const auto& view = gltfModel.bufferViews[accessor.bufferView];
-				const float* data = reinterpret_cast<const float*>(&gltfModel.buffers[view.buffer].data[view.byteOffset + accessor.byteOffset]);
-				for (size_t i = 0; i < numBones; ++i)
-				{
-					inverseBind[i] = glm::make_mat4(data + i * 16);
-				}
-			}
-			else
-			{
-				for (size_t i = 0; i < numBones; ++i) inverseBind[i] = glm::mat4(1.0f);
-			}
 
-			struct TRS { glm::vec3 t{ 0 }; glm::quat r{ 1,0,0,0 }; glm::vec3 s{ 1 }; };
-			TVector<TRS> base(gltfModel.nodes.size());
-			for (size_t i = 0; i < gltfModel.nodes.size(); ++i)
-			{
-				const auto& n = gltfModel.nodes[i];
-				if (n.translation.size() == 3) base[i].t = glm::vec3(n.translation[0], n.translation[1], n.translation[2]);
-				if (n.rotation.size() == 4) base[i].r = glm::quat((float)n.rotation[3], (float)n.rotation[0], (float)n.rotation[1], (float)n.rotation[2]);
-				if (n.scale.size() == 3) base[i].s = glm::vec3(n.scale[0], n.scale[1], n.scale[2]);
-			}
+                       TVector<Math::Transform> base(gltfModel.nodes.size());
+                       for (size_t i = 0; i < gltfModel.nodes.size(); ++i)
+                       {
+                               const auto& n = gltfModel.nodes[i];
+                               if (n.translation.size() == 3) base[i].m_position = glm::vec4(n.translation[0], n.translation[1], n.translation[2], 1.0f);
+                               if (n.rotation.size() == 4) base[i].m_rotation = glm::quat((float)n.rotation[3], (float)n.rotation[0], (float)n.rotation[1], (float)n.rotation[2]);
+                               if (n.scale.size() == 3) base[i].m_scale = glm::vec4(n.scale[0], n.scale[1], n.scale[2], 1.0f);
+                       }
 
-			TVector<TVector<TRS>> transforms(numFrames, base);
+                       TVector<TVector<Math::Transform>> transforms(numFrames, base);
 
 			for (const auto& channel : gltfAnim.channels)
 			{
@@ -175,49 +160,50 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 
 					if (channel.target_path == "translation")
 					{
-						nodeTrs.t = glm::make_vec3(outData + offset);
+                                       nodeTrs.m_position = glm::vec4(glm::make_vec3(outData + offset), 1.0f);
 					}
 					else if (channel.target_path == "rotation")
 					{
-						nodeTrs.r = glm::quat(outData[offset + 3], outData[offset], outData[offset + 1], outData[offset + 2]);
+                                       nodeTrs.m_rotation = glm::quat(outData[offset + 3], outData[offset], outData[offset + 1], outData[offset + 2]);
 					}
 					else if (channel.target_path == "scale")
 					{
-						nodeTrs.s = glm::make_vec3(outData + offset);
+                                       nodeTrs.m_scale = glm::vec4(glm::make_vec3(outData + offset), 1.0f);
 					}
 				}
 			}
 
-			auto compose = [&](uint32_t nodeIndex, const TVector<TRS>& local, TVector<glm::mat4>& global)
-				{
-					glm::mat4 localMat = glm::translate(glm::mat4(1.0f), local[nodeIndex].t) * glm::mat4_cast(local[nodeIndex].r) * glm::scale(glm::mat4(1.0f), local[nodeIndex].s);
-					if (parents[nodeIndex] >= 0)
-					{
-						global[nodeIndex] = global[parents[nodeIndex]] * localMat;
-					}
-					else
-					{
-						global[nodeIndex] = localMat;
-					}
-				};
+                       auto compose = [&](uint32_t nodeIndex, const TVector<Math::Transform>& local, TVector<Math::Transform>& global)
+                               {
+                                       global[nodeIndex] = local[nodeIndex];
+                                       if (parents[nodeIndex] >= 0)
+                                       {
+                                               const Math::Transform& parent = global[parents[nodeIndex]];
+                                               global[nodeIndex].m_position = parent.TransformPosition(global[nodeIndex].m_position);
+                                               global[nodeIndex].m_rotation = parent.m_rotation * global[nodeIndex].m_rotation;
+                                               global[nodeIndex].m_scale.x *= parent.m_scale.x;
+                                               global[nodeIndex].m_scale.y *= parent.m_scale.y;
+                                               global[nodeIndex].m_scale.z *= parent.m_scale.z;
+                                       }
+                               };
 
-			for (size_t f = 0; f < numFrames; ++f)
-			{
-				TVector<glm::mat4> global(gltfModel.nodes.size());
-				for (size_t i = 0; i < gltfModel.nodes.size(); ++i)
-				{
-					compose((uint32_t)i, transforms[f], global);
-				}
+                       for (size_t f = 0; f < numFrames; ++f)
+                       {
+                               TVector<Math::Transform> global(gltfModel.nodes.size());
+                               for (size_t i = 0; i < gltfModel.nodes.size(); ++i)
+                               {
+                                       compose((uint32_t)i, transforms[f], global);
+                               }
 
-				for (size_t j = 0; j < numBones; ++j)
-				{
-					uint32_t nodeIndex = gltfSkin.joints[j];
-					framesData[f * numBones + j] = global[nodeIndex] * inverseBind[j];
-				}
-			}
+                               for (size_t j = 0; j < numBones; ++j)
+                               {
+                                       uint32_t nodeIndex = gltfSkin.joints[j];
+                                       framesData[f * numBones + j] = global[nodeIndex];
+                               }
+                       }
 
-			anim->m_frames = std::move(framesData);
-		}
+anim->m_frames = std::move(framesData);
+               }
 	}
 
 	outAnimation = anim;

--- a/Runtime/AssetRegistry/Animation/AnimationImporter.h
+++ b/Runtime/AssetRegistry/Animation/AnimationImporter.h
@@ -5,6 +5,7 @@
 #include "AssetRegistry/AssetFactory.h"
 #include "AnimationAssetInfo.h"
 #include "Engine/Object.h"
+#include "Math/Transform.h"
 #include <glm/mat4x4.hpp>
 #include "Containers/Vector.h"
 #include "Containers/ConcurrentMap.h"
@@ -19,7 +20,7 @@ namespace Sailor
 	public:
 		SAILOR_API Animation(FileId uid) : Object(uid) {}
 
-		TVector<glm::mat4> m_frames;
+		TVector<Math::Transform> m_frames;
 		uint32_t m_numFrames = 0;
 		uint32_t m_numBones = 0;
 		float m_fps = 30.0f;

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -345,24 +345,25 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 		auto& boundsSphere = model->m_boundsSphere;
 		auto& boundsAabb = model->m_boundsAabb;
 
-		struct Data
-		{
-			TVector<MeshContext> m_parsedMeshes;
-			bool m_bIsImported = false;
-		};
+               struct Data
+               {
+                       TVector<MeshContext> m_parsedMeshes;
+                       TVector<glm::mat4> m_inverseBind;
+                       bool m_bIsImported = false;
+               };
 
 		promise = Tasks::CreateTaskWithResult<TSharedPtr<Data>>("Load model",
-			[model, assetInfo, &boundsAabb, &boundsSphere]()
-			{
-				TSharedPtr<Data> res = TSharedPtr<Data>::Make();
-				res->m_bIsImported = ImportModel(assetInfo, res->m_parsedMeshes, boundsAabb, boundsSphere);
-				return res;
-			})->Then<ModelPtr>([model](TSharedPtr<Data> data) mutable
-				{
-					if (data->m_bIsImported)
-					{
-						for (const auto& mesh : data->m_parsedMeshes)
-						{
+                       [model, assetInfo, &boundsAabb, &boundsSphere]()
+                       {
+                               TSharedPtr<Data> res = TSharedPtr<Data>::Make();
+                               res->m_bIsImported = ImportModel(assetInfo, res->m_parsedMeshes, boundsAabb, boundsSphere, res->m_inverseBind);
+                               return res;
+                       })->Then<ModelPtr>([model](TSharedPtr<Data> data) mutable
+                               {
+                                       if (data->m_bIsImported)
+                                       {
+                                               for (const auto& mesh : data->m_parsedMeshes)
+                                               {
 							RHI::RHIMeshPtr ptr = RHI::Renderer::GetDriver()->CreateMesh();
 							ptr->m_vertexDescription = RHI::Renderer::GetDriver()->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4>();
 							ptr->m_bounds = mesh.bounds;
@@ -373,10 +374,11 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 							model->m_meshes.Emplace(ptr);
 						}
 
-						model->Flush();
-					}
-					return model;
-				}, "Update RHI Meshes", EThreadType::RHI)->ToTaskWithResult();
+                                               model->m_inverseBind = std::move(data->m_inverseBind);
+                                               model->Flush();
+                                       }
+                                       return model;
+                               }, "Update RHI Meshes", EThreadType::RHI)->ToTaskWithResult();
 
 			outModel = loadedModel = model;
 			promise->Run();
@@ -430,7 +432,7 @@ void GenerateTangentBitangent(vec3& outTangent, vec3& outBitangent, const vec3* 
 	outTangent = normalize(outTangent);
 }
 
-bool ModelImporter::ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext>& outParsedMeshes, Math::AABB& outBoundsAabb, Math::Sphere& outBoundsSphere)
+bool ModelImporter::ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext>& outParsedMeshes, Math::AABB& outBoundsAabb, Math::Sphere& outBoundsSphere, TVector<glm::mat4>& outInverseBind)
 {
 	tinygltf::Model gltfModel;
 	tinygltf::TinyGLTF loader;
@@ -456,10 +458,33 @@ bool ModelImporter::ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext
 		return false;
 	}
 
-	const float unitScale = assetInfo->GetUnitScale();
+    const float unitScale = assetInfo->GetUnitScale();
 
-	outBoundsAabb.m_max = glm::vec3(std::numeric_limits<float>::min());
-	outBoundsAabb.m_min = glm::vec3(std::numeric_limits<float>::max());
+    outBoundsAabb.m_max = glm::vec3(std::numeric_limits<float>::min());
+    outBoundsAabb.m_min = glm::vec3(std::numeric_limits<float>::max());
+
+    outInverseBind.Clear();
+    if (!gltfModel.skins.empty())
+    {
+            const auto& gltfSkin = gltfModel.skins[0];
+            size_t numBones = gltfSkin.joints.size();
+            outInverseBind.Resize(numBones);
+
+            if (gltfSkin.inverseBindMatrices >= 0)
+            {
+                    const auto& accessor = gltfModel.accessors[gltfSkin.inverseBindMatrices];
+                    const auto& view = gltfModel.bufferViews[accessor.bufferView];
+                    const float* data = reinterpret_cast<const float*>(&gltfModel.buffers[view.buffer].data[view.byteOffset + accessor.byteOffset]);
+                    for (size_t i = 0; i < numBones; ++i)
+                    {
+                            outInverseBind[i] = glm::make_mat4(data + i * 16);
+                    }
+            }
+            else
+            {
+                    for (size_t i = 0; i < numBones; ++i) outInverseBind[i] = glm::mat4(1.0f);
+            }
+    }
 
 	TVector<MeshContext> batchedMeshContexts(gltfModel.materials.size());
 

--- a/Runtime/AssetRegistry/Model/ModelImporter.h
+++ b/Runtime/AssetRegistry/Model/ModelImporter.h
@@ -18,6 +18,7 @@
 #include "RHI/Mesh.h"
 #include "RHI/Material.h"
 #include "Math/Bounds.h"
+#include <glm/mat4x4.hpp>
 #include "Core/YamlSerializable.h"
 #include "Core/Reflection.h"
 
@@ -30,9 +31,9 @@ namespace Sailor
 {
 	using ModelPtr = TObjectPtr<class Model>;
 
-	class Model : public Object, public IYamlSerializable
-	{
-	public:
+class Model : public Object, public IYamlSerializable
+{
+public:
 
 		SAILOR_API Model(FileId uid, TVector<RHI::RHIMeshPtr> meshes = {}) :
 			Object(std::move(uid)),
@@ -50,14 +51,17 @@ namespace Sailor
 
 		SAILOR_API const Math::AABB& GetBoundsAABB() const { return m_boundsAabb; }
 		SAILOR_API const Math::Sphere& GetBoundsSphere() const { return m_boundsSphere; }
+		SAILOR_API const TVector<glm::mat4>& GetInverseBind() const { return m_inverseBind; }
+		SAILOR_API TVector<glm::mat4>& GetInverseBind() { return m_inverseBind; }
 
 		SAILOR_API virtual YAML::Node Serialize() const override;
 		SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
 
-	protected:
+protected:
 
 		TVector<RHI::RHIMeshPtr> m_meshes;
 		std::atomic<bool> m_bIsReady{};
+		TVector<glm::mat4> m_inverseBind;
 
 		Math::AABB m_boundsAabb;
 		Math::Sphere m_boundsSphere;
@@ -93,7 +97,7 @@ namespace Sailor
 
 	protected:
 
-		SAILOR_API static bool ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext>& outParsedMeshes, Math::AABB& outBoundsAabb, Math::Sphere& outBoundsSphere);
+SAILOR_API static bool ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext>& outParsedMeshes, Math::AABB& outBoundsAabb, Math::Sphere& outBoundsSphere, TVector<glm::mat4>& outInverseBind);
 
 		SAILOR_API void GenerateMaterialAssets(ModelAssetInfoPtr assetInfo);
 		SAILOR_API void GenerateAnimationAssets(ModelAssetInfoPtr assetInfo);

--- a/Runtime/ECS/AnimationECS.cpp
+++ b/Runtime/ECS/AnimationECS.cpp
@@ -3,8 +3,10 @@
 #include "RHI/Renderer.h"
 #include "RHI/Shader.h"
 #include "AssetRegistry/Animation/AnimationImporter.h"
+#include "Components/MeshRendererComponent.h"
 #include <cmath>
 #include <limits>
+#include "Math/Transform.h"
 
 using namespace Sailor;
 using namespace Sailor::Tasks;
@@ -87,20 +89,35 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 			m_nextBoneOffset = (std::min)(m_nextBoneOffset, BonesMaxNum);
 		}
 
-		uint32_t nextFrame = (data.m_frameIndex + 1) % anim.m_numFrames;
-		for (uint32_t i = 0; i < anim.m_numBones; i++)
+               uint32_t nextFrame = (data.m_frameIndex + 1) % anim.m_numFrames;
+               for (uint32_t i = 0; i < anim.m_numBones; i++)
+               {
+                       const Math::Transform& a = anim.m_frames[data.m_frameIndex * anim.m_numBones + i];
+                       const Math::Transform& b = anim.m_frames[nextFrame * anim.m_numBones + i];
+                       data.m_currentSkeleton[i] = Math::Lerp(a, b, data.m_lerp);
+               }
+
+		ModelPtr model;
+		if (auto owner = data.m_owner.StaticCast<GameObject>())
 		{
-			const glm::mat4& a = anim.m_frames[data.m_frameIndex * anim.m_numBones + i];
-			const glm::mat4& b = anim.m_frames[nextFrame * anim.m_numBones + i];
-			// TODO: Lerp
-			//data.m_currentSkeleton[i] = glm::mix(a, b, data.m_lerp);
+			if (auto mesh = owner->GetComponent<MeshRendererComponent>())
+			{
+				model = mesh->GetModel();
+			}
 		}
 
-		auto binding = m_bonesBinding->GetOrAddShaderBinding("bones");
-		commands->UpdateShaderBinding(cmdList, binding,
-			data.m_currentSkeleton.GetData(),
-			sizeof(glm::mat4) * data.m_currentSkeleton.Num(),
-			binding->GetBufferOffset() + sizeof(glm::mat4) * data.m_gpuOffset);
+		TVector<glm::mat4> matrices(data.m_currentSkeleton.Num());
+		for (uint32_t i = 0; i < data.m_currentSkeleton.Num(); ++i)
+		{
+			const glm::mat4 bind = model && model->GetInverseBind().Num() > i ? model->GetInverseBind()[i] : glm::mat4(1.0f);
+		matrices[i] = data.m_currentSkeleton[i].Matrix() * bind;
+}
+
+               auto binding = m_bonesBinding->GetOrAddShaderBinding("bones");
+               commands->UpdateShaderBinding(cmdList, binding,
+                       matrices.GetData(),
+                       sizeof(glm::mat4) * matrices.Num(),
+                       binding->GetBufferOffset() + sizeof(glm::mat4) * data.m_gpuOffset);
 	}
 
 	commands->EndDebugRegion(cmdList);

--- a/Runtime/ECS/AnimationECS.h
+++ b/Runtime/ECS/AnimationECS.h
@@ -6,7 +6,7 @@
 #include "Components/Component.h"
 #include "RHI/SceneView.h"
 #include "RHI/Types.h"
-#include <glm/mat4x4.hpp>
+#include "Math/Transform.h"
 
 namespace Sailor
 {
@@ -24,7 +24,7 @@ namespace Sailor
 		uint32_t m_frameIndex = 0;
 		float m_lerp = 0.0f;
 		uint32_t m_gpuOffset = std::numeric_limits<uint32_t>::max();
-		TVector<glm::mat4> m_currentSkeleton;
+               TVector<Math::Transform> m_currentSkeleton;
 
 		bool m_bIsPlaying = false;
 		float m_playSpeed = 1.0f;

--- a/Runtime/Math/Transform.cpp
+++ b/Runtime/Math/Transform.cpp
@@ -76,3 +76,21 @@ vec3 Transform::GetRight() const { return glm::rotate(m_rotation, Math::vec3_Rig
 vec3 Transform::GetUp() const { return glm::rotate(m_rotation, Math::vec3_Up); }
 
 const Transform Transform::Identity;
+
+Transform FromMatrix(const glm::mat4& m)
+{
+       glm::vec3 translation = glm::vec3(m[3]);
+
+       glm::vec3 scale;
+       scale.x = glm::length(glm::vec3(m[0]));
+       scale.y = glm::length(glm::vec3(m[1]));
+       scale.z = glm::length(glm::vec3(m[2]));
+
+       glm::mat3 rotMat;
+       rotMat[0] = scale.x != 0.0f ? glm::vec3(m[0]) / scale.x : glm::vec3(m[0]);
+       rotMat[1] = scale.y != 0.0f ? glm::vec3(m[1]) / scale.y : glm::vec3(m[1]);
+       rotMat[2] = scale.z != 0.0f ? glm::vec3(m[2]) / scale.z : glm::vec3(m[2]);
+       glm::quat rotation = glm::quat_cast(rotMat);
+
+       return Transform(glm::vec4(translation, 1.0f), rotation, glm::vec4(scale, 1.0f));
+}

--- a/Runtime/Math/Transform.h
+++ b/Runtime/Math/Transform.h
@@ -45,5 +45,6 @@ namespace Sailor::Math
 		static const Transform Identity;
 	};
 
-	Transform SAILOR_API Lerp(const Transform& a, const Transform& b, float t);
+       Transform SAILOR_API Lerp(const Transform& a, const Transform& b, float t);
+       Transform SAILOR_API FromMatrix(const glm::mat4& m);
 }


### PR DESCRIPTION
## Summary
- move inverse bind matrices from `Animation` to `Model`
- parse skin inverse bind matrices in `ModelImporter`
- reference bind pose from the model when updating bones
- convert animation importer to build transforms from TRS channels
- compute bone hierarchy using `Transform` objects instead of matrices

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c303305ac832c88dd706c999e9927