### PR TITLE
Fix AnimationImporter async logic

### DIFF
--- a/Runtime/AssetRegistry/Animation/AnimationImporter.h
+++ b/Runtime/AssetRegistry/Animation/AnimationImporter.h
@@ -41,7 +41,7 @@ namespace Sailor
 		SAILOR_API Tasks::TaskPtr<AnimationPtr> LoadAnimation(FileId uid, AnimationPtr& outAnimation);
 		SAILOR_API bool LoadAnimation_Immediate(FileId uid, AnimationPtr& outAnimation);
 
-		SAILOR_API virtual void CollectGarbage() override {}
+SAILOR_API virtual void CollectGarbage() override;
 
 	protected:
 		TConcurrentMap<FileId, Tasks::TaskPtr<AnimationPtr>> m_promises{};


### PR DESCRIPTION
## Summary
- fix `AnimationImporter` promise/task handling
- add garbage collection for `AnimationImporter`

## Testing
- `pytest -q`
- `python update_deps.py` *(fails: FileNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6862ead75a70832c854d014ea2522f97