### PR TITLE
Fix glTF skinning support

### DIFF
--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -362,14 +362,14 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 				{
 					if (data->m_bIsImported)
 					{
-						for (const auto& mesh : data->m_parsedMeshes)
-						{
-							RHI::RHIMeshPtr ptr = RHI::Renderer::GetDriver()->CreateMesh();
-							ptr->m_vertexDescription = RHI::Renderer::GetDriver()->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4>();
-							ptr->m_bounds = mesh.bounds;
-							RHI::Renderer::GetDriver()->UpdateMesh(ptr,
-								mesh.outVertices.GetData(), sizeof(RHI::VertexP3N3T3B3UV2C4) * mesh.outVertices.Num(),
-								mesh.outIndices.GetData(), sizeof(uint32_t)* mesh.outIndices.Num());
+	                                        for (const auto& mesh : data->m_parsedMeshes)
+	                                        {
+	                                                RHI::RHIMeshPtr ptr = RHI::Renderer::GetDriver()->CreateMesh();
+	                                                ptr->m_vertexDescription = RHI::Renderer::GetDriver()->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4I4W4>();
+	                                                ptr->m_bounds = mesh.bounds;
+	                                                RHI::Renderer::GetDriver()->UpdateMesh(ptr,
+	                                                        mesh.outVertices.GetData(), sizeof(RHI::VertexP3N3T3B3UV2C4I4W4) * mesh.outVertices.Num(),
+	                                                        mesh.outIndices.GetData(), sizeof(uint32_t)* mesh.outIndices.Num());
 
 							model->m_meshes.Emplace(ptr);
 						}
@@ -599,22 +599,74 @@ bool ModelImporter::ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext
 				tanData = reinterpret_cast<const float*>(&gltfModel.buffers[tanView->buffer].data[tanView->byteOffset + tanAccessor->byteOffset]);
 			}
 
-			const tinygltf::Accessor* colAccessor = nullptr;
-			const tinygltf::BufferView* colView = nullptr;
-			const float* colData = nullptr;
+	                const tinygltf::Accessor* colAccessor = nullptr;
+	                const tinygltf::BufferView* colView = nullptr;
+	                const float* colData = nullptr;
 
-			if (primitive.attributes.find("COLOR_0") != primitive.attributes.end())
-			{
-				colAccessor = &gltfModel.accessors[primitive.attributes.find("COLOR_0")->second];
-				colView = &gltfModel.bufferViews[std::max(0, colAccessor->bufferView)];
-				colData = reinterpret_cast<const float*>(&gltfModel.buffers[colView->buffer].data[colView->byteOffset + colAccessor->byteOffset]);
-			}
+	                const tinygltf::Accessor* jointsAccessor = nullptr;
+	                const tinygltf::BufferView* jointsView = nullptr;
+	                const unsigned char* jointsData8 = nullptr;
+	                const unsigned short* jointsData16 = nullptr;
+	                const unsigned int* jointsData32 = nullptr;
+
+	                const tinygltf::Accessor* weightsAccessor = nullptr;
+	                const tinygltf::BufferView* weightsView = nullptr;
+	                const float* weightsDataF = nullptr;
+	                const unsigned char* weightsData8 = nullptr;
+	                const unsigned short* weightsData16 = nullptr;
+
+	                if (primitive.attributes.find("COLOR_0") != primitive.attributes.end())
+	                {
+	                        colAccessor = &gltfModel.accessors[primitive.attributes.find("COLOR_0")->second];
+	                        colView = &gltfModel.bufferViews[std::max(0, colAccessor->bufferView)];
+	                        colData = reinterpret_cast<const float*>(&gltfModel.buffers[colView->buffer].data[colView->byteOffset + colAccessor->byteOffset]);
+	                }
+
+	                if (primitive.attributes.find("JOINTS_0") != primitive.attributes.end())
+	                {
+	                        jointsAccessor = &gltfModel.accessors[primitive.attributes.find("JOINTS_0")->second];
+	                        jointsView = &gltfModel.bufferViews[std::max(0, jointsAccessor->bufferView)];
+	                        const unsigned char* ptr = reinterpret_cast<const unsigned char*>(&gltfModel.buffers[jointsView->buffer].data[jointsView->byteOffset + jointsAccessor->byteOffset]);
+	                        if (jointsAccessor->componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE)
+	                        {
+	                                jointsData8 = ptr;
+	                        }
+	                        else if (jointsAccessor->componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT)
+	                        {
+	                                jointsData16 = reinterpret_cast<const unsigned short*>(ptr);
+	                        }
+	                        else
+	                        {
+	                                jointsData32 = reinterpret_cast<const unsigned int*>(ptr);
+	                        }
+	                }
+
+	                if (primitive.attributes.find("WEIGHTS_0") != primitive.attributes.end())
+	                {
+	                        weightsAccessor = &gltfModel.accessors[primitive.attributes.find("WEIGHTS_0")->second];
+	                        weightsView = &gltfModel.bufferViews[std::max(0, weightsAccessor->bufferView)];
+	                        const unsigned char* ptr = reinterpret_cast<const unsigned char*>(&gltfModel.buffers[weightsView->buffer].data[weightsView->byteOffset + weightsAccessor->byteOffset]);
+	                        if (weightsAccessor->componentType == TINYGLTF_COMPONENT_TYPE_FLOAT)
+	                        {
+	                                weightsDataF = reinterpret_cast<const float*>(ptr);
+	                        }
+	                        else if (weightsAccessor->componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE)
+	                        {
+	                                weightsData8 = ptr;
+	                        }
+	                        else if (weightsAccessor->componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT)
+	                        {
+	                                weightsData16 = reinterpret_cast<const unsigned short*>(ptr);
+	                        }
+	                }
 
 			const uint32_t colSize = (colAccessor && colAccessor->type == TINYGLTF_PARAMETER_TYPE_FLOAT_VEC3) ? 3 : 4;
 
-			for (size_t i = 0; i < posAccessor.count; ++i)
-			{
-				Sailor::RHI::VertexP3N3T3B3UV2C4 vertex{};
+	                for (size_t i = 0; i < posAccessor.count; ++i)
+	                {
+	                        Sailor::RHI::VertexP3N3T3B3UV2C4I4W4 vertex{};
+	                        vertex.m_boneIds = glm::ivec4(0);
+	                        vertex.m_boneWeights = glm::vec4(0.0f);
 				vertex.m_position = glm::make_vec3(posData + i * 3) * unitScale;
 
 				if (normData)
@@ -638,20 +690,57 @@ bool ModelImporter::ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext
 					vertex.m_color = glm::vec4(1.0f);
 				}
 
-				if (texData)
-				{
-					vertex.m_texcoord = glm::make_vec2(texData + i * 2);
-				}
+	                       if (texData)
+	                       {
+	                               vertex.m_texcoord = glm::make_vec2(texData + i * 2);
+	                       }
 
-				if (tanData)
-				{
-					vertex.m_tangent = glm::make_vec3(tanData + i * 3);
-					vertex.m_bitangent = glm::cross(vertex.m_normal, vertex.m_tangent);
-				}
-				else
-				{
-					GenerateTangentBitangent(vertex.m_tangent, vertex.m_bitangent, &vertex.m_position, &vertex.m_texcoord);
-				}
+	                       if (tanData)
+	                       {
+	                               vertex.m_tangent = glm::make_vec3(tanData + i * 3);
+	                               vertex.m_bitangent = glm::cross(vertex.m_normal, vertex.m_tangent);
+	                       }
+	                       else
+	                       {
+	                               GenerateTangentBitangent(vertex.m_tangent, vertex.m_bitangent, &vertex.m_position, &vertex.m_texcoord);
+	                       }
+
+	                        if (jointsAccessor)
+	                        {
+	                                if (jointsData8)
+	                                {
+	                                        const unsigned char* d = jointsData8 + i * 4;
+	                                        vertex.m_boneIds = glm::ivec4(d[0], d[1], d[2], d[3]);
+	                                }
+	                                else if (jointsData16)
+	                                {
+	                                        const unsigned short* d = jointsData16 + i * 4;
+	                                        vertex.m_boneIds = glm::ivec4(d[0], d[1], d[2], d[3]);
+	                                }
+	                                else if (jointsData32)
+	                                {
+	                                        const unsigned int* d = jointsData32 + i * 4;
+	                                        vertex.m_boneIds = glm::ivec4(d[0], d[1], d[2], d[3]);
+	                                }
+	                        }
+
+	                        if (weightsAccessor)
+	                        {
+	                                if (weightsDataF)
+	                                {
+	                                        vertex.m_boneWeights = glm::make_vec4(weightsDataF + i * 4);
+	                                }
+	                                else if (weightsData8)
+	                                {
+	                                        const unsigned char* d = weightsData8 + i * 4;
+	                                        vertex.m_boneWeights = glm::vec4(d[0], d[1], d[2], d[3]) / 255.0f;
+	                                }
+	                                else if (weightsData16)
+	                                {
+	                                        const unsigned short* d = weightsData16 + i * 4;
+	                                        vertex.m_boneWeights = glm::vec4(d[0], d[1], d[2], d[3]) / 65535.0f;
+	                                }
+	                        }
 
 				pMeshContext->outVertices.Add(vertex);
 				outBoundsAabb.Extend(vertex.m_position);

--- a/Runtime/AssetRegistry/Model/ModelImporter.h
+++ b/Runtime/AssetRegistry/Model/ModelImporter.h
@@ -73,13 +73,13 @@ namespace Sailor
 	{
 	public:
 
-		struct MeshContext
-		{
-			std::unordered_map<RHI::VertexP3N3T3B3UV2C4, uint32_t> uniqueVertices;
-			TVector<RHI::VertexP3N3T3B3UV2C4> outVertices;
-			TVector<uint32_t> outIndices;
-			Math::AABB bounds{};
-		};
+               struct MeshContext
+               {
+                       std::unordered_map<RHI::VertexP3N3T3B3UV2C4I4W4, uint32_t> uniqueVertices;
+                       TVector<RHI::VertexP3N3T3B3UV2C4I4W4> outVertices;
+                       TVector<uint32_t> outIndices;
+                       Math::AABB bounds{};
+               };
 
 		SAILOR_API ModelImporter(ModelAssetInfoHandler* infoHandler);
 		SAILOR_API virtual ~ModelImporter() override;


### PR DESCRIPTION
## Summary
- support bone weights and indices when importing glTF models
- use the skinned vertex layout for imported meshes

## Testing
- `python Tests/process_no_crash_test.py`
- `python Tests/container_benchmarks_test.py`

------
https://chatgpt.com/codex/tasks/task_e_68639a1f6ba0832cb2935a7045375938