### PR TITLE
Improve glTF occlusion workflow

### DIFF
--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -371,8 +371,9 @@ glslFragment: |
     // Total specular IBL contribution.
     vec3 specularIBL = (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance;
     
-    // Total ambient lighting contribution.  
-    return material.ao * (diffuseIBL + specularIBL);
+    // Total ambient lighting contribution. Screen-space AO only affects the
+    // diffuse portion similar to the glTF occlusion workflow.
+    return diffuseIBL * material.ao + specularIBL;
   }
   
   // Constant normal incidence Fresnel factor for all dielectrics.


### PR DESCRIPTION
## Summary
- update the glTF shader to apply occlusion per glTF spec
- combine occlusion texture with screen-space AO using `min`
- apply AO only to the diffuse term in Standard shader
- pass final occlusion factor via `material.occlusionStrength`

## Testing
- `python Tests/process_no_crash_test.py`
- `python Tests/container_benchmarks_test.py`

------
https://chatgpt.com/codex/tasks/task_e_687290a515f4832cba7d34beb9c6977d