### PR TITLE
Fix sheen BRDF

### DIFF
--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -61,6 +61,22 @@ float GeometrySchlickGGX(float cosLi, float cosLo, float roughness)
   return GeometrySchlickG1(cosLi, k) * GeometrySchlickG1(cosLo, k);
 }
 
+// Charlie microfacet normal distribution function used for cloth-like sheen.
+float NdfCharlie(float cosLh, float roughness)
+{
+  float alpha = max(roughness, 0.001);
+  float invAlpha = 1.0 / alpha;
+  float cos2h = cosLh * cosLh;
+  float sin2h = max(1.0 - cos2h, 0.0078125);
+  return (2.0 + invAlpha) * pow(sin2h, 0.5 * invAlpha) / (2.0 * PI);
+}
+
+// Neubelt visibility term for cloth-like sheen.
+float GeometryNeubelt(float cosLi, float cosLo)
+{
+  return 1.0 / (4.0 * (cosLi + cosLo - cosLi * cosLo));
+}
+
 // Schlick-GGX approximation of geometric attenuation function using Smith's method (IBL version).
 float GeometrySchlickGGX_IBL(float cosLi, float cosLo, float roughness)
 {

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -513,10 +513,10 @@ glslFragment: |
     float cosLh = max(0.0, dot(normal, Lh));
 
     vec3 F  = FresnelSchlick(color, max(0.0, dot(Lh, Lo)));
-    float D = NdfGGX(cosLh, roughness);
-    float G = GeometrySchlickGGX(cosLi, cosLo, roughness);
+    float D = NdfCharlie(cosLh, roughness);
+    float V = GeometryNeubelt(cosLi, cosLo);
 
-    vec3 specularBRDF = (F * D * G) / max(Epsilon, 4.0 * cosLi * cosLo);
+    vec3 specularBRDF = F * D * V;
     return shadow * (specularBRDF * Lradiance * cosLi) * falloff;
   }
 


### PR DESCRIPTION
## Summary
- implement Charlie NDF and Neubelt visibility for cloth
- use them for KHR_materials_sheen lighting

## Testing
- `python -m pytest -q`
- `python Tests/process_no_crash_test.py`
- `python Tests/container_benchmarks_test.py`

------
https://chatgpt.com/codex/tasks/task_e_6874d4d89550832c97a56bc9de5bea03