### PR TITLE
Fix MacCatalyst editor toolbar chrome

### DIFF
--- a/Editor/App.xaml.cs
+++ b/Editor/App.xaml.cs
@@ -1,4 +1,9 @@
-﻿[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
+﻿#if MACCATALYST
+using SailorEditor.Platforms.MacCatalyst;
+#endif
+
+[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
+
 namespace SailorEditor
 {
     public partial class App : Application
@@ -13,6 +18,10 @@ namespace SailorEditor
             var window = base.CreateWindow(state);
             window.MinimumWidth = 1024;
             window.MinimumHeight = 768;
+#if MACCATALYST
+            window.Title = string.Empty;
+            MacCatalystWindowChrome.UseCompactTitlebar(window);
+#endif
 
             return window;
         }

--- a/Editor/AppShell.xaml.cs
+++ b/Editor/AppShell.xaml.cs
@@ -5,6 +5,9 @@
         public AppShell()
         {
             InitializeComponent();
+#if MACCATALYST
+            Title = string.Empty;
+#endif
         }
     }
 }

--- a/Editor/MainPage.xaml
+++ b/Editor/MainPage.xaml
@@ -15,7 +15,7 @@
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
 
-        <views:ToolbarView Grid.Row="0"/>
+        <views:ToolbarView x:Name="ToolbarHost" Grid.Row="0"/>
         <shell:ShellLayoutView x:Name="ShellLayoutHost" Grid.Row="1"/>
 
         <Border Grid.Row="2" StrokeThickness="1" Stroke="DimGray" BackgroundColor="#1E1E1E" Padding="10,6">

--- a/Editor/MainPage.xaml.cs
+++ b/Editor/MainPage.xaml.cs
@@ -16,6 +16,12 @@ public partial class MainPage : ContentPage
     {
         _shellHost = shellHost;
         InitializeComponent();
+#if MACCATALYST
+        Title = string.Empty;
+        ToolbarHost.IsVisible = false;
+        ToolbarHost.HeightRequest = 0;
+        Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific.Page.SetUseSafeArea(this, false);
+#endif
         ShellLayoutHost.Host = _shellHost;
         _shellHost.PropertyChanged += OnShellHostPropertyChanged;
         BuildMenus();

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -47,6 +47,7 @@ namespace SailorEditor
             builder.Services.AddSingleton<HierarchyProjectionService>();
             builder.Services.AddSingleton<InspectorProjectionService>();
             builder.Services.AddSingleton<EngineService>();
+            builder.Services.AddSingleton<EditorToolbarActions>();
             builder.Services.AddSingleton<EditorContextMenuService>();
             builder.Services.AddSingleton<PanelRegistry>();
             builder.Services.AddSingleton<ShellState>();

--- a/Editor/Platforms/MacCatalyst/MacCatalystWindowChrome.cs
+++ b/Editor/Platforms/MacCatalyst/MacCatalystWindowChrome.cs
@@ -1,0 +1,235 @@
+﻿using AppKit;
+using CoreFoundation;
+using Foundation;
+using ObjCRuntime;
+using SailorEditor.Services;
+using UIKit;
+using MauiWindow = Microsoft.Maui.Controls.Window;
+
+namespace SailorEditor.Platforms.MacCatalyst
+{
+    public static class MacCatalystWindowChrome
+    {
+        const string SaveItem = "SailorEditorToolbarSave";
+        const string UndoItem = "SailorEditorToolbarUndo";
+        const string RedoItem = "SailorEditorToolbarRedo";
+        const string PlayItem = "SailorEditorToolbarPlay";
+        const string DebugItem = "SailorEditorToolbarDebug";
+        const string TraceSceneItem = "SailorEditorToolbarTraceScene";
+        const string TraceSelectionItem = "SailorEditorToolbarTraceSelection";
+        const string SaveLayoutItem = "SailorEditorToolbarSaveLayout";
+        const string ResetLayoutItem = "SailorEditorToolbarResetLayout";
+        const string SettingsItem = "SailorEditorToolbarSettings";
+        static readonly string[] ToolbarItems =
+        [
+            SaveItem,
+            UndoItem,
+            RedoItem,
+            NSToolbar.NSToolbarFlexibleSpaceItemIdentifier,
+            PlayItem,
+            DebugItem,
+            NSToolbar.NSToolbarFlexibleSpaceItemIdentifier,
+            TraceSceneItem,
+            TraceSelectionItem,
+            SaveLayoutItem,
+            ResetLayoutItem,
+            SettingsItem
+        ];
+
+        static readonly NSSet<NSString> CenterToolbarItems = new(new NSString[]
+        {
+            new NSString(PlayItem),
+            new NSString(DebugItem)
+        });
+
+        static readonly NativeToolbarDelegate ToolbarDelegate = new();
+        static readonly NSToolbar CompactToolbar = CreateCompactToolbar();
+        static NSObject? windowVisibleObserver;
+
+        public static void UseCompactTitlebar(MauiWindow window)
+        {
+            windowVisibleObserver ??= UIWindow.Notifications.ObserveDidBecomeVisible((_, _) => ApplySoon());
+
+            window.Created += OnWindowChanged;
+            window.Activated += OnWindowChanged;
+            window.HandlerChanged += OnWindowChanged;
+
+            ApplySoon();
+        }
+
+        static void OnWindowChanged(object sender, EventArgs e)
+        {
+            ApplySoon();
+        }
+
+        static void ApplySoon()
+        {
+            DispatchQueue.MainQueue.DispatchAsync(Apply);
+            _ = ApplyLater(100);
+            _ = ApplyLater(350);
+        }
+
+        static async Task ApplyLater(int delayMs)
+        {
+            await Task.Delay(delayMs);
+            Microsoft.Maui.ApplicationModel.MainThread.BeginInvokeOnMainThread(Apply);
+        }
+
+        static void Apply()
+        {
+            foreach (var window in Application.Current?.Windows ?? [])
+            {
+                window.Title = string.Empty;
+            }
+
+            foreach (var scene in UIApplication.SharedApplication.ConnectedScenes)
+            {
+                if (scene is not UIWindowScene windowScene || windowScene.Titlebar is not { } titlebar)
+                {
+                    continue;
+                }
+
+                titlebar.TitleVisibility = UITitlebarTitleVisibility.Hidden;
+                titlebar.Toolbar = CompactToolbar;
+
+                if (OperatingSystem.IsMacOSVersionAtLeast(12))
+                {
+                    titlebar.ToolbarStyle = UITitlebarToolbarStyle.UnifiedCompact;
+                }
+            }
+
+            CollapseTopSafeArea();
+        }
+
+        static void CollapseTopSafeArea()
+        {
+            foreach (var scene in UIApplication.SharedApplication.ConnectedScenes)
+            {
+                if (scene is not UIWindowScene windowScene)
+                {
+                    continue;
+                }
+
+                foreach (var window in windowScene.Windows)
+                {
+                    CollapseTopSafeArea(window);
+                }
+            }
+        }
+
+        static void CollapseTopSafeArea(UIWindow window)
+        {
+            if (window.RootViewController is null)
+            {
+                return;
+            }
+
+            var topInset = window.SafeAreaInsets.Top;
+            window.RootViewController.AdditionalSafeAreaInsets = new UIEdgeInsets(-topInset, 0, 0, 0);
+        }
+
+        static NSToolbar CreateCompactToolbar()
+        {
+            var toolbar = new NSToolbar("SailorEditorCompactTitlebar")
+            {
+                AllowsDisplayModeCustomization = false,
+                AllowsUserCustomization = false,
+                AutosavesConfiguration = false,
+                DisplayMode = NSToolbarDisplayMode.Icon,
+                ShowsBaselineSeparator = false,
+                SizeMode = NSToolbarSizeMode.Small
+            };
+
+            toolbar.Delegate = ToolbarDelegate;
+            if (OperatingSystem.IsMacCatalystVersionAtLeast(16))
+            {
+                toolbar.CenteredItemIdentifiers = CenterToolbarItems;
+            }
+
+            return toolbar;
+        }
+
+        sealed class NativeToolbarDelegate : NSToolbarDelegate
+        {
+            static readonly Selector InvokeSelector = new("invoke:");
+            readonly Dictionary<string, ToolbarActionTarget> actionTargets = [];
+
+            public override string[] DefaultItemIdentifiers(NSToolbar toolbar)
+            {
+                return ToolbarItems;
+            }
+
+            public override string[] AllowedItemIdentifiers(NSToolbar toolbar)
+            {
+                return ToolbarItems;
+            }
+
+            public override NSToolbarItem WillInsertItem(NSToolbar toolbar, string itemIdentifier, bool willBeInserted)
+            {
+                return itemIdentifier switch
+                {
+                    SaveItem => CreateItem(SaveItem, "Save", "square.and.arrow.down", actions => actions.SaveAsync()),
+                    UndoItem => CreateItem(UndoItem, "Undo", "arrow.uturn.backward", actions => actions.UndoAsync()),
+                    RedoItem => CreateItem(RedoItem, "Redo", "arrow.uturn.forward", actions => actions.RedoAsync()),
+                    PlayItem => CreateItem(PlayItem, "Play", "play.fill", actions =>
+                    {
+                        actions.RunWorld(false);
+                        return Task.CompletedTask;
+                    }),
+                    DebugItem => CreateItem(DebugItem, "Debug", "ladybug.fill", actions =>
+                    {
+                        actions.RunWorld(true);
+                        return Task.CompletedTask;
+                    }),
+                    TraceSceneItem => CreateItem(TraceSceneItem, "Trace Scene", "camera.metering.matrix", actions => actions.ExportPathTracedImageAsync(false)),
+                    TraceSelectionItem => CreateItem(TraceSelectionItem, "Trace Selection", "scope", actions => actions.ExportPathTracedImageAsync(true)),
+                    SaveLayoutItem => CreateItem(SaveLayoutItem, "Save Layout", "rectangle.3.group", actions => actions.SaveLayoutAsync()),
+                    ResetLayoutItem => CreateItem(ResetLayoutItem, "Reset Layout", "arrow.counterclockwise", actions => actions.ResetLayoutAsync()),
+                    SettingsItem => CreateItem(SettingsItem, "Settings", "gearshape", actions => actions.OpenSettingsAsync()),
+                    _ => new NSToolbarItem(itemIdentifier)
+                };
+            }
+
+            NSToolbarItem CreateItem(string identifier, string label, string symbolName, Func<EditorToolbarActions, Task> action)
+            {
+                var target = new ToolbarActionTarget(() => action(MauiProgram.GetService<EditorToolbarActions>()));
+                actionTargets[identifier] = target;
+
+                var barButton = CreateButton(label, symbolName, target);
+                var item = NSToolbarItem.Create(identifier, barButton);
+                item.Action = InvokeSelector;
+                item.Target = target;
+                item.Enabled = true;
+                item.Label = label;
+                item.PaletteLabel = label;
+                item.ToolTip = label;
+                item.Autovalidates = false;
+                return item;
+            }
+
+            static UIBarButtonItem CreateButton(string label, string symbolName, NSObject target)
+            {
+                var image = UIImage.GetSystemImage(symbolName);
+                return image != null
+                    ? new UIBarButtonItem(image, UIBarButtonItemStyle.Plain, target, InvokeSelector)
+                    : new UIBarButtonItem(label, UIBarButtonItemStyle.Plain, target, InvokeSelector);
+            }
+
+            sealed class ToolbarActionTarget : NSObject
+            {
+                readonly Func<Task> action;
+
+                public ToolbarActionTarget(Func<Task> action)
+                {
+                    this.action = action;
+                }
+
+                [Export("invoke:")]
+                public async void Invoke(NSObject sender)
+                {
+                    await action();
+                }
+            }
+        }
+    }
+}

--- a/Editor/Services/EditorToolbarActions.cs
+++ b/Editor/Services/EditorToolbarActions.cs
@@ -1,0 +1,145 @@
+using SailorEditor.Commands;
+using SailorEditor.Panels;
+using SailorEditor.Shell;
+using SailorEditor.ViewModels;
+using SailorEngine;
+using ViewModelComponent = SailorEditor.ViewModels.Component;
+using ViewModelGameObject = SailorEditor.ViewModels.GameObject;
+
+namespace SailorEditor.Services
+{
+    public sealed class EditorToolbarActions
+    {
+        public async Task SaveAsync()
+        {
+            var selectionService = MauiProgram.GetService<SelectionService>();
+            var selected = selectionService.SelectedItem;
+
+            switch (selected)
+            {
+                case AssetFile assetFile when assetFile.IsDirty:
+                    await Task.Yield();
+                    await assetFile.Save();
+                    await DisplayStatus("Save", $"Saved {assetFile.DisplayName}");
+                    return;
+
+                case IInspectorEditable editable when editable.HasPendingInspectorChanges:
+                    if (editable.CommitInspectorChanges())
+                    {
+                        await DisplayStatus("Save", "Committed inspector changes.");
+                    }
+                    else
+                    {
+                        await DisplayStatus("Save", "Nothing was committed.");
+                    }
+                    return;
+
+                case AssetFile assetFile:
+                    await DisplayStatus("Save", $"{assetFile.DisplayName} has no pending changes.");
+                    return;
+            }
+
+            var dirtyAsset = MauiProgram.GetService<AssetsService>().Files.FirstOrDefault(x => x.IsDirty);
+            if (dirtyAsset != null)
+            {
+                await dirtyAsset.Save();
+                await DisplayStatus("Save", $"Saved {dirtyAsset.DisplayName}");
+                return;
+            }
+
+            await DisplayStatus("Save", "Nothing to save.");
+        }
+
+        public Task UndoAsync()
+        {
+            return MauiProgram.GetService<ICommandHistoryService>().UndoAsync(new CommandOrigin(CommandOriginKind.UI, "ToolbarUndo"));
+        }
+
+        public Task RedoAsync()
+        {
+            return MauiProgram.GetService<ICommandHistoryService>().RedoAsync(new CommandOrigin(CommandOriginKind.UI, "ToolbarRedo"));
+        }
+
+        public void RunWorld(bool debug)
+        {
+            var worldService = MauiProgram.GetService<WorldService>();
+            var engineService = MauiProgram.GetService<EngineService>();
+
+            Task.Run(() =>
+            {
+                string world = worldService.SerializeCurrentWorld();
+
+                using (var yamlAssetInfo = new FileStream(engineService.EngineCacheDirectory + "\\Temp.world", FileMode.OpenOrCreate))
+                using (var writer = new StreamWriter(yamlAssetInfo))
+                {
+                    writer.Write(world);
+                }
+
+                engineService.RunWorld("../Cache/Temp.world", debug);
+            });
+        }
+
+        public async Task ExportPathTracedImageAsync(bool selectedOnly)
+        {
+            var engineService = MauiProgram.GetService<EngineService>();
+            var selectionService = MauiProgram.GetService<SelectionService>();
+
+            InstanceId targetInstance = null;
+            if (selectedOnly)
+            {
+                var selectedItem = selectionService.SelectedItems.FirstOrDefault();
+                switch (selectedItem)
+                {
+                    case ViewModelComponent component:
+                        targetInstance = component.InstanceId;
+                        break;
+
+                    case ViewModelGameObject gameObject:
+                        targetInstance = gameObject.InstanceId;
+                        break;
+                }
+
+                if (targetInstance == null || targetInstance.IsEmpty())
+                {
+                    await DisplayStatus("Path Tracing", "Select a GameObject or a component first.");
+                    return;
+                }
+            }
+
+            var outputDir = Path.Combine(engineService.EngineCacheDirectory, "PathTracing");
+            Directory.CreateDirectory(outputDir);
+
+            var mode = selectedOnly ? "selection" : "scene";
+            var outputPath = Path.Combine(outputDir, $"pathtrace_{mode}_{DateTime.Now:yyyyMMdd_HHmmss}.png");
+
+            bool exported = engineService.ExportPathTracedImage(outputPath, targetInstance);
+            string message = exported ? $"Saved: {outputPath}" : "Path tracing export failed. Check Console panel for details.";
+
+            await DisplayStatus("Path Tracing", message);
+        }
+
+        public Task SaveLayoutAsync()
+        {
+            return MauiProgram.GetService<EditorShellHost>().SaveLayoutAsync();
+        }
+
+        public Task ResetLayoutAsync()
+        {
+            return MauiProgram.GetService<EditorShellHost>().ResetLayoutAsync();
+        }
+
+        public async Task OpenSettingsAsync()
+        {
+            await MauiProgram.GetService<EditorShellHost>().OpenPanelAsync(KnownPanelTypes.Settings);
+        }
+
+        static async Task DisplayStatus(string title, string message)
+        {
+            var page = Application.Current?.Windows?.FirstOrDefault()?.Page;
+            if (page != null)
+            {
+                await page.DisplayAlert(title, message, "OK");
+            }
+        }
+    }
+}

--- a/Editor/Views/ToolbarView.xaml.cs
+++ b/Editor/Views/ToolbarView.xaml.cs
@@ -1,140 +1,27 @@
-﻿using SailorEditor.Commands;
-using SailorEditor.Panels;
-using SailorEditor.Services;
-using SailorEditor.Shell;
-using SailorEditor.Utility;
-using SailorEditor.ViewModels;
-using System;
-using System.Linq;
-using SailorEngine;
-using YamlDotNet.Serialization.NamingConventions;
-using YamlDotNet.Serialization;
-using System.Diagnostics;
-using ViewModelComponent = SailorEditor.ViewModels.Component;
-using ViewModelGameObject = SailorEditor.ViewModels.GameObject;
+﻿using SailorEditor.Services;
 
 namespace SailorEditor.Views
 {
     public partial class ToolbarView : ContentView
     {
+        readonly EditorToolbarActions actions;
+
         public ToolbarView()
         {
             InitializeComponent();
             BindingContext = this;
+            actions = MauiProgram.GetService<EditorToolbarActions>();
         }
 
-        private async void OnSaveButtonClicked(object sender, EventArgs e)
-        {
-            var selectionService = MauiProgram.GetService<SelectionService>();
-            var selected = selectionService.SelectedItem;
-
-            switch (selected)
-            {
-                case AssetFile assetFile when assetFile.IsDirty:
-                    await Task.Yield();
-                    await assetFile.Save();
-                    await DisplayStatus("Save", $"Saved {assetFile.DisplayName}");
-                    return;
-
-                case IInspectorEditable editable when editable.HasPendingInspectorChanges:
-                    if (editable.CommitInspectorChanges())
-                    {
-                        await DisplayStatus("Save", "Committed inspector changes.");
-                    }
-                    else
-                    {
-                        await DisplayStatus("Save", "Nothing was committed.");
-                    }
-                    return;
-
-                case AssetFile assetFile:
-                    await DisplayStatus("Save", $"{assetFile.DisplayName} has no pending changes.");
-                    return;
-            }
-
-            var dirtyAsset = MauiProgram.GetService<AssetsService>().Files.FirstOrDefault(x => x.IsDirty);
-            if (dirtyAsset != null)
-            {
-                await dirtyAsset.Save();
-                await DisplayStatus("Save", $"Saved {dirtyAsset.DisplayName}");
-                return;
-            }
-
-            await DisplayStatus("Save", "Nothing to save.");
-        }
-
-        private async void OnUndoButtonClicked(object sender, EventArgs e) => await MauiProgram.GetService<ICommandHistoryService>().UndoAsync(new CommandOrigin(CommandOriginKind.UI, "ToolbarUndo"));
-        private async void OnRedoButtonClicked(object sender, EventArgs e) => await MauiProgram.GetService<ICommandHistoryService>().RedoAsync(new CommandOrigin(CommandOriginKind.UI, "ToolbarRedo"));
-        private void OnPlayButtonClicked(object sender, EventArgs e) => RunWorld(false);
-        private void OnPlayDebugButtonClicked(object sender, EventArgs e) => RunWorld(true);
-        private async void OnPathTraceSceneButtonClicked(object sender, EventArgs e) => await ExportPathTracedImage(false);
-        private async void OnPathTraceSelectionButtonClicked(object sender, EventArgs e) => await ExportPathTracedImage(true);
-        private async void OnSaveLayoutButtonClicked(object sender, EventArgs e) => await MauiProgram.GetService<EditorShellHost>().SaveLayoutAsync();
-        private async void OnResetLayoutButtonClicked(object sender, EventArgs e) => await MauiProgram.GetService<EditorShellHost>().ResetLayoutAsync();
-        private async void OnSettingsButtonClicked(object sender, EventArgs e) => await MauiProgram.GetService<EditorShellHost>().OpenPanelAsync(KnownPanelTypes.Settings);
-
-        void RunWorld(bool bDebug)
-        {
-            var worldService = MauiProgram.GetService<WorldService>();
-            var engineService = MauiProgram.GetService<EngineService>();
-
-            Task.Run(() =>
-            {
-                string world = worldService.SerializeCurrentWorld();
-
-                using (var yamlAssetInfo = new FileStream(engineService.EngineCacheDirectory + "\\Temp.world", FileMode.OpenOrCreate))
-                using (var writer = new StreamWriter(yamlAssetInfo))
-                {
-                    writer.Write(world);
-                }
-
-                engineService.RunWorld("../Cache/Temp.world", bDebug);
-            });
-        }
-
-        async Task ExportPathTracedImage(bool bSelectedOnly)
-        {
-            var engineService = MauiProgram.GetService<EngineService>();
-            var selectionService = MauiProgram.GetService<SelectionService>();
-
-            InstanceId targetInstance = null;
-            if (bSelectedOnly)
-            {
-                var selectedItem = selectionService.SelectedItems.FirstOrDefault();
-                switch (selectedItem)
-                {
-                    case ViewModelComponent component:
-                        targetInstance = component.InstanceId;
-                        break;
-
-                    case ViewModelGameObject gameObject:
-                        targetInstance = gameObject.InstanceId;
-                        break;
-                }
-
-                if (targetInstance == null || targetInstance.IsEmpty())
-                {
-                    await DisplayStatus("Path Tracing", "Select a GameObject or a component first.");
-                    return;
-                }
-            }
-
-            var outputDir = Path.Combine(engineService.EngineCacheDirectory, "PathTracing");
-            Directory.CreateDirectory(outputDir);
-
-            var mode = bSelectedOnly ? "selection" : "scene";
-            var outputPath = Path.Combine(outputDir, $"pathtrace_{mode}_{DateTime.Now:yyyyMMdd_HHmmss}.png");
-
-            bool bExported = engineService.ExportPathTracedImage(outputPath, targetInstance);
-            string message = bExported ? $"Saved: {outputPath}" : "Path tracing export failed. Check Console panel for details.";
-
-            await DisplayStatus("Path Tracing", message);
-        }
-
-        static Task DisplayStatus(string title, string message)
-        {
-            var page = Application.Current?.Windows?.FirstOrDefault()?.Page;
-            return page != null ? page.DisplayAlert(title, message, "OK") : Task.CompletedTask;
-        }
+        private async void OnSaveButtonClicked(object sender, EventArgs e) => await actions.SaveAsync();
+        private async void OnUndoButtonClicked(object sender, EventArgs e) => await actions.UndoAsync();
+        private async void OnRedoButtonClicked(object sender, EventArgs e) => await actions.RedoAsync();
+        private void OnPlayButtonClicked(object sender, EventArgs e) => actions.RunWorld(false);
+        private void OnPlayDebugButtonClicked(object sender, EventArgs e) => actions.RunWorld(true);
+        private async void OnPathTraceSceneButtonClicked(object sender, EventArgs e) => await actions.ExportPathTracedImageAsync(false);
+        private async void OnPathTraceSelectionButtonClicked(object sender, EventArgs e) => await actions.ExportPathTracedImageAsync(true);
+        private async void OnSaveLayoutButtonClicked(object sender, EventArgs e) => await actions.SaveLayoutAsync();
+        private async void OnResetLayoutButtonClicked(object sender, EventArgs e) => await actions.ResetLayoutAsync();
+        private async void OnSettingsButtonClicked(object sender, EventArgs e) => await actions.OpenSettingsAsync();
     }
 }


### PR DESCRIPTION
## Summary

Closes #67.

This moves the MacCatalyst editor controls into a native titlebar toolbar and removes the unused top safe-area/header space so the editor content starts directly below the compact toolbar.

## Agent Workflow

- Manager: scoped the work to issue #67 and kept unrelated local changes out of the branch.
- Team Lead: selected a MacCatalyst-specific native toolbar approach instead of continuing to shrink the MAUI toolbar row.
- Implementer: extracted shared toolbar actions into `EditorToolbarActions`, wired the existing XAML toolbar fallback to the same actions, and added `MacCatalystWindowChrome` for the native titlebar toolbar.
- Tech Lead review: verified the implementation keeps the change isolated to MacCatalyst chrome and shared toolbar action plumbing.
- Lead QA: built the Debug MacCatalyst editor and confirmed visually with the user that the empty top space is gone and toolbar buttons remain accepted.

## Validation

- `python3 build_editor.py --config Debug`
- Manual MacCatalyst launch from the Debug app bundle
- User visual acceptance: top empty space resolved

## Notes

A local unrelated change to `Content/Textures/Environment.hdr.asset` was intentionally not committed or pushed.