### PR TITLE
[Workspace] Add .sailor manifest serializer

### DIFF
--- a/Editor.Tests/AIOperatorTests.cs
+++ b/Editor.Tests/AIOperatorTests.cs
@@ -8,15 +8,17 @@ public class AIOperatorTests
     [Fact]
     public void EditorAIContextProvider_ShapesSelectionAndOriginMetadata()
     {
-        var provider = new EditorAIContextProvider(new StubActionContextProvider(new ActionContext(
-            ActiveWorldId: "MainWorld",
-            ActiveSelectionIds: new[] { "go-1", "cmp-2" },
-            ActivePanelId: "AI",
-            ActiveDocumentId: "Scene",
-            FocusedViewportId: "SceneViewport",
-            CurrentAssetId: "asset-1",
-            IsPlayMode: true,
-            Origin: new CommandOrigin(CommandOriginKind.Panel, "AIPanel", "tester"))));
+        var provider = new EditorAIContextProvider(
+            new StubActionContextProvider(new ActionContext(
+                ActiveWorldId: "MainWorld",
+                ActiveSelectionIds: new[] { "go-1", "cmp-2" },
+                ActivePanelId: "AI",
+                ActiveDocumentId: "Scene",
+                FocusedViewportId: "SceneViewport",
+                CurrentAssetId: "asset-1",
+                IsPlayMode: true,
+                Origin: new CommandOrigin(CommandOriginKind.Panel, "AIPanel", "tester"))),
+            new StaticAgentInstructionsProvider());
 
         var snapshot = provider.GetCurrentContext();
 
@@ -38,6 +40,7 @@ public class AIOperatorTests
                 AIEditorContextSnapshot.Empty,
                 new[] { new AIProposedAction("create-1", "Create GameObject", new[] { new StubCommand("Create") }, AIActionSafety.ConfirmRequired, "Create through command bus") })),
             new StaticAIContextProvider(),
+            new StaticAgentInstructionsProvider(),
             new StubActionContextProvider(new ActionContext()),
             dispatcher);
 
@@ -57,6 +60,7 @@ public class AIOperatorTests
         var service = new AIOperatorService(
             new StaticPlanner(new AIPlanResponse("open console", "Safe action ready.", AIEditorContextSnapshot.Empty, new[] { proposal })),
             new StaticAIContextProvider(),
+            new StaticAgentInstructionsProvider(),
             new StubActionContextProvider(new ActionContext(ActivePanelId: "AI")),
             dispatcher);
 
@@ -75,6 +79,11 @@ public class AIOperatorTests
     sealed class StaticAIContextProvider : IAIEditorContextProvider
     {
         public AIEditorContextSnapshot GetCurrentContext() => AIEditorContextSnapshot.Empty;
+    }
+
+    sealed class StaticAgentInstructionsProvider : IAIAgentInstructionsProvider
+    {
+        public string Instructions => "Test instructions";
     }
 
     sealed class StaticPlanner(AIPlanResponse response) : IAIActionPlanner

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -26,6 +26,7 @@
     <Compile Include="PanelContractsTests.cs" />
     <Compile Include="ProjectContentProjectionTests.cs" />
     <Compile Include="ProjectContentFolderIdsTests.cs" />
+    <Compile Include="WorkspaceManifestTests.cs" />
     <Compile Include="AIOperatorTests.cs" />
     <Compile Include="SettingsContractsTests.cs" />
     <Compile Include="UnifiedSettingsStoreTests.cs" />
@@ -49,6 +50,7 @@
     <Compile Include="..\Editor\Settings\UnifiedSettingsStore.cs" Link="Settings\UnifiedSettingsStore.cs" />
     <Compile Include="..\Editor\Content\ProjectContentModels.cs" Link="Content\ProjectContentModels.cs" />
     <Compile Include="..\Editor\Content\ProjectContentFolderIds.cs" Link="Content\ProjectContentFolderIds.cs" />
+    <Compile Include="..\Editor\Workspace\WorkspaceManifest.cs" Link="Workspace\WorkspaceManifest.cs" />
     <Compile Include="..\Editor\Shell\EditorShellContracts.cs" Link="Shell\EditorShellContracts.cs" />
     <Compile Include="..\Editor\Shell\EditorShellHost.cs" Link="Shell\EditorShellHost.cs" />
     <Compile Include="..\Editor\State\ShellState.cs" Link="State\ShellState.cs" />

--- a/Editor.Tests/EditorDragDropTestStubs.cs
+++ b/Editor.Tests/EditorDragDropTestStubs.cs
@@ -22,6 +22,8 @@ namespace SailorEditor.ViewModels
     public class AssetFile
     {
         public SailorEngine.FileId? FileId { get; set; }
+        public string AssetInfoTypeName { get; set; } = string.Empty;
+        public FileInfo? Asset { get; set; }
     }
 
     public sealed class MaterialFile : AssetFile;
@@ -72,7 +74,7 @@ namespace SailorEditor.Commands
         public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default) => Task.FromResult(CommandResult.Success());
     }
 
-    public sealed class InstantiatePrefabAssetCommand(SailorEditor.ViewModels.PrefabFile prefabFile, SailorEditor.ViewModels.GameObject? parent = null) : IEditorCommand
+    public sealed class InstantiatePrefabAssetCommand(SailorEditor.ViewModels.AssetFile prefabFile, SailorEditor.ViewModels.GameObject? parent = null) : IEditorCommand
     {
         public string Name => nameof(InstantiatePrefabAssetCommand);
         public bool CanExecute(ActionContext context) => true;

--- a/Editor.Tests/ShellHostTestStubs.cs
+++ b/Editor.Tests/ShellHostTestStubs.cs
@@ -19,4 +19,5 @@ namespace SailorEditor.Views
     public sealed class ConsoleView : Microsoft.Maui.Controls.ContentView;
     public sealed class SettingsPanelView : Microsoft.Maui.Controls.ContentView;
     public sealed class AIPanelView : Microsoft.Maui.Controls.ContentView;
+    public sealed class EditorPerformanceView : Microsoft.Maui.Controls.ContentView;
 }

--- a/Editor.Tests/WorkspaceManifestTests.cs
+++ b/Editor.Tests/WorkspaceManifestTests.cs
@@ -1,0 +1,163 @@
+using SailorEditor.Workspace;
+
+namespace SailorEditor.Editor.Tests;
+
+public sealed class WorkspaceManifestTests
+{
+    [Fact]
+    public void CreateDefault_CreatesValidManifest()
+    {
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id");
+        var serializer = new WorkspaceManifestSerializer();
+
+        var validation = serializer.Validate(manifest);
+
+        Assert.True(validation.IsValid);
+        Assert.Equal(WorkspaceManifest.CurrentVersion, manifest.ManifestVersion);
+        Assert.Equal("workspace-id", manifest.WorkspaceId);
+        Assert.Equal("Sandbox", manifest.Name);
+        Assert.Equal("../Sailor", manifest.EnginePath);
+        Assert.Equal("Content", manifest.ContentPath);
+        Assert.Equal("Source", manifest.SourcePath);
+        Assert.Equal("Generated", manifest.GeneratedProjectPath);
+        Assert.Equal("Cache", manifest.CachePath);
+    }
+
+    [Fact]
+    public async Task SaveAndLoad_RoundTripsYamlManifest()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sailor-workspace-{Guid.NewGuid():N}.sailor");
+        var serializer = new WorkspaceManifestSerializer();
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id") with
+        {
+            ContentPath = "./Game\\Content\\",
+            SourcePath = "Game\\Source",
+            GeneratedProjectPath = "./Generated\\Project\\",
+            CachePath = "Cache\\"
+        };
+
+        try
+        {
+            await serializer.SaveAsync(path, manifest);
+
+            var result = await serializer.LoadAsync(path);
+
+            Assert.True(result.Succeeded);
+            Assert.NotNull(result.Manifest);
+            Assert.Equal("Game/Content", result.Manifest.ContentPath);
+            Assert.Equal("Game/Source", result.Manifest.SourcePath);
+            Assert.Equal("Generated/Project", result.Manifest.GeneratedProjectPath);
+            Assert.Equal("Cache", result.Manifest.CachePath);
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public async Task SaveAsync_RejectsInvalidManifest()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"sailor-workspace-{Guid.NewGuid():N}.sailor");
+        var serializer = new WorkspaceManifestSerializer();
+        var manifest = new WorkspaceManifest();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => serializer.SaveAsync(path, manifest));
+        Assert.False(File.Exists(path));
+    }
+
+    [Fact]
+    public void Deserialize_ReportsMissingRequiredFields()
+    {
+        var serializer = new WorkspaceManifestSerializer();
+
+        var result = serializer.Deserialize("""
+manifestVersion: 1
+name: ""
+contentPath: Content
+""");
+
+        Assert.False(result.Succeeded);
+        Assert.NotNull(result.Manifest);
+        Assert.Contains(result.Validation.Issues, x => x.Field == nameof(WorkspaceManifest.WorkspaceId));
+        Assert.Contains(result.Validation.Issues, x => x.Field == nameof(WorkspaceManifest.Name));
+        Assert.Contains(result.Validation.Issues, x => x.Field == nameof(WorkspaceManifest.EnginePath));
+        Assert.Contains(result.Validation.Issues, x => x.Field == nameof(WorkspaceManifest.SourcePath));
+        Assert.Contains(result.Validation.Issues, x => x.Field == nameof(WorkspaceManifest.GeneratedProjectPath));
+        Assert.Contains(result.Validation.Issues, x => x.Field == nameof(WorkspaceManifest.CachePath));
+    }
+
+    [Fact]
+    public void Deserialize_ReportsUnsupportedVersion()
+    {
+        var serializer = new WorkspaceManifestSerializer();
+
+        var result = serializer.Deserialize("""
+manifestVersion: 999
+workspaceId: workspace-id
+name: Sandbox
+enginePath: ../Sailor
+contentPath: Content
+sourcePath: Source
+generatedProjectPath: Generated
+cachePath: Cache
+""");
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Validation.Issues, x =>
+            x.Field == nameof(WorkspaceManifest.ManifestVersion) &&
+            x.Message.Contains("Unsupported workspace manifest version", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void Deserialize_ReportsMissingManifestVersion()
+    {
+        var serializer = new WorkspaceManifestSerializer();
+
+        var result = serializer.Deserialize("""
+workspaceId: workspace-id
+name: Sandbox
+enginePath: ../Sailor
+contentPath: Content
+sourcePath: Source
+generatedProjectPath: Generated
+cachePath: Cache
+""");
+
+        Assert.False(result.Succeeded);
+        Assert.Contains(result.Validation.Issues, x => x.Field == nameof(WorkspaceManifest.ManifestVersion));
+    }
+
+    [Fact]
+    public void Deserialize_NormalizesNullStringFieldsBeforeValidation()
+    {
+        var serializer = new WorkspaceManifestSerializer();
+
+        var result = serializer.Deserialize("""
+manifestVersion: 1
+workspaceId:
+name:
+enginePath:
+contentPath:
+sourcePath:
+generatedProjectPath:
+cachePath:
+""");
+
+        Assert.False(result.Succeeded);
+        Assert.NotNull(result.Manifest);
+        Assert.Equal(string.Empty, result.Manifest.WorkspaceId);
+        Assert.Contains(result.Validation.Issues, x => x.Field == nameof(WorkspaceManifest.WorkspaceId));
+    }
+
+    [Theory]
+    [InlineData("./Content", "Content")]
+    [InlineData(".\\Content\\Textures\\", "Content/Textures")]
+    [InlineData("Generated\\Project", "Generated/Project")]
+    [InlineData("  Cache/  ", "Cache")]
+    public void NormalizePath_UsesStableManifestFormat(string input, string expected)
+    {
+        Assert.Equal(expected, WorkspaceManifestPaths.Normalize(input));
+    }
+}

--- a/Editor/Utility/EditorDragDrop.cs
+++ b/Editor/Utility/EditorDragDrop.cs
@@ -3,6 +3,7 @@ using SailorEditor.Services;
 using SailorEditor.ViewModels;
 using SailorEngine;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace SailorEditor.Utility;
 
@@ -83,7 +84,7 @@ public static class EditorDragDrop
         return world.TryGetGameObject(gameObject.InstanceId, out var current) ? current : null;
     }
 
-    static bool TryResolvePrefabAsset(object? source, out AssetFile prefab)
+    static bool TryResolvePrefabAsset(object? source, [NotNullWhen(true)] out AssetFile? prefab)
     {
         prefab = null;
         if (source is not AssetFile assetFile || assetFile.FileId is null || assetFile.FileId.IsEmpty())

--- a/Editor/Workspace/WorkspaceManifest.cs
+++ b/Editor/Workspace/WorkspaceManifest.cs
@@ -1,0 +1,157 @@
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SailorEditor.Workspace;
+
+public sealed record WorkspaceManifest
+{
+    public const int CurrentVersion = 1;
+
+    public int ManifestVersion { get; init; }
+    public string WorkspaceId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string EnginePath { get; init; } = string.Empty;
+    public string ContentPath { get; init; } = string.Empty;
+    public string SourcePath { get; init; } = string.Empty;
+    public string GeneratedProjectPath { get; init; } = string.Empty;
+    public string CachePath { get; init; } = string.Empty;
+
+    public static WorkspaceManifest CreateDefault(string name, string enginePath, string? workspaceId = null) => new()
+    {
+        ManifestVersion = CurrentVersion,
+        WorkspaceId = string.IsNullOrWhiteSpace(workspaceId) ? Guid.NewGuid().ToString("D") : workspaceId.Trim(),
+        Name = name.Trim(),
+        EnginePath = WorkspaceManifestPaths.Normalize(enginePath),
+        ContentPath = "Content",
+        SourcePath = "Source",
+        GeneratedProjectPath = "Generated",
+        CachePath = "Cache"
+    };
+}
+
+public sealed record WorkspaceManifestIssue(string Field, string Message);
+
+public sealed record WorkspaceManifestValidationResult(IReadOnlyList<WorkspaceManifestIssue> Issues)
+{
+    public static WorkspaceManifestValidationResult Success { get; } = new([]);
+
+    public bool IsValid => Issues.Count == 0;
+}
+
+public sealed record WorkspaceManifestLoadResult(
+    WorkspaceManifest? Manifest,
+    WorkspaceManifestValidationResult Validation,
+    string? Error = null)
+{
+    public bool Succeeded => Manifest is not null && Validation.IsValid && string.IsNullOrEmpty(Error);
+}
+
+public static class WorkspaceManifestPaths
+{
+    public static string Normalize(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        var normalized = path.Trim().Replace('\\', '/');
+        while (normalized.StartsWith("./", StringComparison.Ordinal))
+            normalized = normalized[2..];
+
+        while (normalized.Length > 1 && normalized.EndsWith("/", StringComparison.Ordinal))
+            normalized = normalized[..^1];
+
+        return normalized;
+    }
+}
+
+public sealed class WorkspaceManifestSerializer
+{
+    readonly ISerializer _serializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitNull)
+        .Build();
+
+    readonly IDeserializer _deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    public string Serialize(WorkspaceManifest manifest)
+        => _serializer.Serialize(Normalize(manifest));
+
+    public WorkspaceManifestLoadResult Deserialize(string yaml)
+    {
+        try
+        {
+            var manifest = _deserializer.Deserialize<WorkspaceManifest>(yaml) ?? new WorkspaceManifest();
+            manifest = Normalize(manifest);
+            return new WorkspaceManifestLoadResult(manifest, Validate(manifest));
+        }
+        catch (YamlException ex)
+        {
+            return new WorkspaceManifestLoadResult(null, WorkspaceManifestValidationResult.Success, $"Failed to parse workspace manifest: {ex.Message}");
+        }
+    }
+
+    public async Task SaveAsync(string path, WorkspaceManifest manifest, CancellationToken cancellationToken = default)
+    {
+        var validation = Validate(manifest);
+        if (!validation.IsValid)
+            throw new InvalidOperationException($"Workspace manifest is invalid: {string.Join("; ", validation.Issues.Select(x => x.Message))}");
+
+        var directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory);
+
+        await File.WriteAllTextAsync(path, Serialize(manifest), cancellationToken);
+    }
+
+    public async Task<WorkspaceManifestLoadResult> LoadAsync(string path, CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(path))
+            return new WorkspaceManifestLoadResult(null, WorkspaceManifestValidationResult.Success, $"Workspace manifest was not found: {path}");
+
+        var yaml = await File.ReadAllTextAsync(path, cancellationToken);
+        return Deserialize(yaml);
+    }
+
+    public WorkspaceManifestValidationResult Validate(WorkspaceManifest manifest)
+    {
+        var issues = new List<WorkspaceManifestIssue>();
+
+        if (manifest.ManifestVersion != WorkspaceManifest.CurrentVersion)
+            issues.Add(new WorkspaceManifestIssue(nameof(WorkspaceManifest.ManifestVersion), $"Unsupported workspace manifest version '{manifest.ManifestVersion}'. Supported version is '{WorkspaceManifest.CurrentVersion}'."));
+
+        AddRequiredStringIssue(issues, nameof(WorkspaceManifest.WorkspaceId), manifest.WorkspaceId);
+        AddRequiredStringIssue(issues, nameof(WorkspaceManifest.Name), manifest.Name);
+        AddRequiredStringIssue(issues, nameof(WorkspaceManifest.EnginePath), manifest.EnginePath);
+        AddRequiredStringIssue(issues, nameof(WorkspaceManifest.ContentPath), manifest.ContentPath);
+        AddRequiredStringIssue(issues, nameof(WorkspaceManifest.SourcePath), manifest.SourcePath);
+        AddRequiredStringIssue(issues, nameof(WorkspaceManifest.GeneratedProjectPath), manifest.GeneratedProjectPath);
+        AddRequiredStringIssue(issues, nameof(WorkspaceManifest.CachePath), manifest.CachePath);
+
+        return issues.Count == 0
+            ? WorkspaceManifestValidationResult.Success
+            : new WorkspaceManifestValidationResult(issues);
+    }
+
+    static WorkspaceManifest Normalize(WorkspaceManifest manifest) => manifest with
+    {
+        WorkspaceId = NormalizeText(manifest.WorkspaceId),
+        Name = NormalizeText(manifest.Name),
+        EnginePath = WorkspaceManifestPaths.Normalize(manifest.EnginePath),
+        ContentPath = WorkspaceManifestPaths.Normalize(manifest.ContentPath),
+        SourcePath = WorkspaceManifestPaths.Normalize(manifest.SourcePath),
+        GeneratedProjectPath = WorkspaceManifestPaths.Normalize(manifest.GeneratedProjectPath),
+        CachePath = WorkspaceManifestPaths.Normalize(manifest.CachePath)
+    };
+
+    static string NormalizeText(string? value) => value?.Trim() ?? string.Empty;
+
+    static void AddRequiredStringIssue(ICollection<WorkspaceManifestIssue> issues, string field, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            issues.Add(new WorkspaceManifestIssue(field, $"{field} is required."));
+    }
+}


### PR DESCRIPTION
## Summary
- Add the initial `.sailor` YAML workspace manifest model and serializer.
- Validate manifest version and required fields, normalize stored path strings, and reject invalid manifests before saving.
- Add contract tests for round-trip YAML, missing/unsupported versions, null scalar normalization, invalid saves, and stable path formatting.
- Refresh editor contract test stubs to match current editor APIs.

Closes #74.

## Validation
- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj` - passed, 78/78 tests.
- `git diff --check` - passed.

## Agent Workflow
- Manager: issue #74 moved into implementation and scoped to the manifest serializer subtask.
- Tech Lead: implementation plan posted on the issue.
- Coder: implemented the manifest model, serializer, validation, and tests.
- Architector: reviewed the staged diff; no blockers. One remaining low-risk path semantics item is deferred to workspace lifecycle/content routing.
- Lead QA: local contract tests passed with existing CS9113 warnings in test stubs only.