### PR TITLE
[Workspace] Add workspace lifecycle service

### DIFF
--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -27,6 +27,7 @@
     <Compile Include="ProjectContentProjectionTests.cs" />
     <Compile Include="ProjectContentFolderIdsTests.cs" />
     <Compile Include="WorkspaceManifestTests.cs" />
+    <Compile Include="WorkspaceLifecycleTests.cs" />
     <Compile Include="AIOperatorTests.cs" />
     <Compile Include="SettingsContractsTests.cs" />
     <Compile Include="UnifiedSettingsStoreTests.cs" />
@@ -51,6 +52,7 @@
     <Compile Include="..\Editor\Content\ProjectContentModels.cs" Link="Content\ProjectContentModels.cs" />
     <Compile Include="..\Editor\Content\ProjectContentFolderIds.cs" Link="Content\ProjectContentFolderIds.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceManifest.cs" Link="Workspace\WorkspaceManifest.cs" />
+    <Compile Include="..\Editor\Workspace\WorkspaceLifecycle.cs" Link="Workspace\WorkspaceLifecycle.cs" />
     <Compile Include="..\Editor\Shell\EditorShellContracts.cs" Link="Shell\EditorShellContracts.cs" />
     <Compile Include="..\Editor\Shell\EditorShellHost.cs" Link="Shell\EditorShellHost.cs" />
     <Compile Include="..\Editor\State\ShellState.cs" Link="State\ShellState.cs" />

--- a/Editor.Tests/WorkspaceLifecycleTests.cs
+++ b/Editor.Tests/WorkspaceLifecycleTests.cs
@@ -1,0 +1,252 @@
+using SailorEditor.Workspace;
+
+namespace SailorEditor.Editor.Tests;
+
+public sealed class WorkspaceLifecycleTests
+{
+    [Fact]
+    public async Task CreateAsync_CreatesManifestAndExpectedFolders()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+
+        var result = await service.CreateAsync(new WorkspaceCreateRequest("Sandbox", workspace.Root, "../Sailor", "workspace-id"));
+
+        Assert.True(result.Succeeded, result.Error);
+        Assert.NotNull(result.Session);
+        Assert.True(File.Exists(workspace.File(WorkspaceTemplateService.ManifestFileName)));
+        Assert.True(Directory.Exists(workspace.Directory("Content")));
+        Assert.True(Directory.Exists(workspace.Directory("Source")));
+        Assert.True(Directory.Exists(workspace.Directory("Generated")));
+        Assert.True(Directory.Exists(workspace.Directory("Cache")));
+        Assert.Equal("workspace-id", result.Session.Manifest.WorkspaceId);
+    }
+
+    [Fact]
+    public async Task OpenAsync_LoadsExistingWorkspaceManifest()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var created = await service.CreateAsync(new WorkspaceCreateRequest("Sandbox", workspace.Root, "../Sailor", "workspace-id"));
+
+        var reopened = await service.OpenAsync(created.Session!.ManifestPath);
+
+        Assert.True(reopened.Succeeded, reopened.Error);
+        Assert.NotNull(reopened.Session);
+        Assert.Equal(created.Session.ManifestPath, reopened.Session.ManifestPath);
+        Assert.Equal("Sandbox", reopened.Session.Manifest.Name);
+        Assert.Equal(workspace.Directory("Content"), reopened.Session.ContentDirectory);
+    }
+
+    [Fact]
+    public async Task OpenAsync_PreservesOpenedManifestPath()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var serializer = new WorkspaceManifestSerializer();
+        var service = CreateService(recent.File("recent.yaml"));
+        var manifestPath = workspace.File("custom.sailor");
+        await serializer.SaveAsync(manifestPath, WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id"));
+
+        var result = await service.OpenAsync(manifestPath);
+
+        Assert.True(result.Succeeded, result.Error);
+        Assert.Equal(Path.GetFullPath(manifestPath), result.Session!.ManifestPath);
+    }
+
+    [Fact]
+    public async Task SaveAsync_PersistsManifestUpdates()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var created = await service.CreateAsync(new WorkspaceCreateRequest("Sandbox", workspace.Root, "../Sailor", "workspace-id"));
+        var renamed = created.Session! with
+        {
+            Manifest = created.Session.Manifest with { Name = "Renamed" }
+        };
+
+        var saved = await service.SaveAsync(renamed);
+        var reopened = await service.OpenAsync(created.Session.ManifestPath);
+
+        Assert.True(saved.Succeeded, saved.Error);
+        Assert.True(reopened.Succeeded, reopened.Error);
+        Assert.Equal("Renamed", reopened.Session!.Manifest.Name);
+    }
+
+    [Fact]
+    public async Task SaveAsync_RejectsManifestPathsOutsideWorkspace()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var outside = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var created = await service.CreateAsync(new WorkspaceCreateRequest("Sandbox", workspace.Root, "../Sailor", "workspace-id"));
+        var unsafeSession = created.Session! with
+        {
+            ManifestPath = outside.File("workspace.sailor")
+        };
+
+        var result = await service.SaveAsync(unsafeSession);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("outside", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(outside.File("workspace.sailor")));
+    }
+
+    [Fact]
+    public async Task SaveAsync_RejectsManifestContentPathsOutsideWorkspace()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var created = await service.CreateAsync(new WorkspaceCreateRequest("Sandbox", workspace.Root, "../Sailor", "workspace-id"));
+        var unsafeSession = created.Session! with
+        {
+            Manifest = created.Session.Manifest with { ContentPath = "../Content" }
+        };
+
+        var result = await service.SaveAsync(unsafeSession);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("outside", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsNonEmptyDirectory()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        await File.WriteAllTextAsync(workspace.File("existing.txt"), "existing");
+        var service = CreateService(recent.File("recent.yaml"));
+
+        var result = await service.CreateAsync(new WorkspaceCreateRequest("Sandbox", workspace.Root, "../Sailor"));
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("not empty", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.False(File.Exists(workspace.File(WorkspaceTemplateService.ManifestFileName)));
+    }
+
+    [Fact]
+    public async Task OpenAsync_ReturnsErrorForMissingManifest()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+
+        var result = await service.OpenAsync(workspace.File(WorkspaceTemplateService.ManifestFileName));
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("not found", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task CreateAsync_RejectsPathsOutsideWorkspace()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var serializer = new WorkspaceManifestSerializer();
+        var template = new UnsafeWorkspaceTemplateService(serializer);
+        var service = new WorkspaceLifecycleService(serializer, template, new RecentWorkspaceStore(recent.File("recent.yaml")));
+
+        var result = await service.CreateAsync(new WorkspaceCreateRequest("Sandbox", workspace.Root, "../Sailor"));
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("outside", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task RecentWorkspaceStore_RoundTripsNewestFirstAndDeduplicates()
+    {
+        using var workspace = TempWorkspace.Create();
+        var now = new DateTimeOffset(2026, 6, 25, 12, 0, 0, TimeSpan.Zero);
+        var store = new RecentWorkspaceStore(workspace.File("recent.yaml"), () => now);
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id");
+        var first = new WorkspaceSession(
+            workspace.Root,
+            workspace.File("first.sailor"),
+            manifest,
+            workspace.Directory("Content"),
+            workspace.Directory("Source"),
+            workspace.Directory("Generated"),
+            workspace.Directory("Cache"));
+        var second = first with
+        {
+            ManifestPath = workspace.File("second.sailor"),
+            Manifest = manifest with { WorkspaceId = "workspace-id-2", Name = "Second" }
+        };
+
+        await store.RecordAsync(first);
+        now = now.AddMinutes(1);
+        await store.RecordAsync(second);
+        now = now.AddMinutes(1);
+        await store.RecordAsync(first with { Manifest = manifest with { Name = "Sandbox Updated" } });
+
+        var entries = await store.LoadAsync();
+
+        Assert.Equal(2, entries.Count);
+        Assert.Equal("Sandbox Updated", entries[0].Name);
+        Assert.Equal(Path.GetFullPath(first.ManifestPath), entries[0].ManifestPath);
+        Assert.Equal("Second", entries[1].Name);
+    }
+
+    [Fact]
+    public async Task RecentWorkspaceStore_ReturnsEmptyListForCorruptedYaml()
+    {
+        using var workspace = TempWorkspace.Create();
+        var path = workspace.File("recent.yaml");
+        await File.WriteAllTextAsync(path, "not: [valid");
+        var store = new RecentWorkspaceStore(path);
+
+        var entries = await store.LoadAsync();
+
+        Assert.Empty(entries);
+    }
+
+    static WorkspaceLifecycleService CreateService(string recentPath)
+    {
+        var serializer = new WorkspaceManifestSerializer();
+        var template = new WorkspaceTemplateService(serializer);
+        var recentStore = new RecentWorkspaceStore(recentPath);
+        return new WorkspaceLifecycleService(serializer, template, recentStore);
+    }
+
+    sealed class UnsafeWorkspaceTemplateService(WorkspaceManifestSerializer serializer) : WorkspaceTemplateService(serializer)
+    {
+        public override Task<WorkspaceSession> CreateAsync(WorkspaceCreateRequest request, CancellationToken cancellationToken = default)
+        {
+            var manifest = WorkspaceManifest.CreateDefault(request.Name, request.EnginePath, request.WorkspaceId) with
+            {
+                ContentPath = "../Content"
+            };
+
+            return Task.FromResult(CreateSession(request.WorkspaceDirectory, manifest));
+        }
+    }
+
+    sealed class TempWorkspace : IDisposable
+    {
+        TempWorkspace(string root)
+        {
+            Root = root;
+            System.IO.Directory.CreateDirectory(root);
+        }
+
+        public string Root { get; }
+
+        public static TempWorkspace Create()
+            => new(Path.Combine(Path.GetTempPath(), $"sailor-workspace-{Guid.NewGuid():N}"));
+
+        public string File(string relativePath) => Path.Combine(Root, relativePath);
+
+        public string Directory(string relativePath) => Path.Combine(Root, relativePath);
+
+        public void Dispose()
+        {
+            if (System.IO.Directory.Exists(Root))
+                System.IO.Directory.Delete(Root, recursive: true);
+        }
+    }
+}

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -12,6 +12,7 @@ using SailorEditor.History;
 using SailorEditor.Content;
 using SailorEditor.Settings;
 using SailorEditor.AI;
+using SailorEditor.Workspace;
 #if MACCATALYST
 using SailorEditor.Platforms.MacCatalyst;
 #endif
@@ -49,6 +50,10 @@ namespace SailorEditor
             builder.Services.AddSingleton<EngineService>();
             builder.Services.AddSingleton<EditorToolbarActions>();
             builder.Services.AddSingleton<EditorContextMenuService>();
+            builder.Services.AddSingleton<WorkspaceManifestSerializer>();
+            builder.Services.AddSingleton<WorkspaceTemplateService>();
+            builder.Services.AddSingleton(_ => new RecentWorkspaceStore());
+            builder.Services.AddSingleton<WorkspaceLifecycleService>();
             builder.Services.AddSingleton<PanelRegistry>();
             builder.Services.AddSingleton<ShellState>();
             builder.Services.AddSingleton<IUndoRedoHistory, InMemoryUndoRedoHistory>();

--- a/Editor/Workspace/WorkspaceLifecycle.cs
+++ b/Editor/Workspace/WorkspaceLifecycle.cs
@@ -1,0 +1,308 @@
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SailorEditor.Workspace;
+
+public sealed record WorkspaceCreateRequest(
+    string Name,
+    string WorkspaceDirectory,
+    string EnginePath,
+    string? WorkspaceId = null);
+
+public sealed record WorkspaceSession(
+    string WorkspaceRoot,
+    string ManifestPath,
+    WorkspaceManifest Manifest,
+    string ContentDirectory,
+    string SourceDirectory,
+    string GeneratedProjectDirectory,
+    string CacheDirectory);
+
+public sealed record WorkspaceLifecycleResult(
+    WorkspaceSession? Session,
+    WorkspaceManifestValidationResult Validation,
+    string? Error = null)
+{
+    public bool Succeeded => Session is not null && Validation.IsValid && string.IsNullOrEmpty(Error);
+}
+
+public sealed record RecentWorkspaceEntry
+{
+    public RecentWorkspaceEntry()
+    {
+    }
+
+    public RecentWorkspaceEntry(string workspaceId, string name, string manifestPath, DateTimeOffset lastOpenedAt)
+    {
+        WorkspaceId = workspaceId;
+        Name = name;
+        ManifestPath = manifestPath;
+        LastOpenedAt = lastOpenedAt;
+    }
+
+    public string WorkspaceId { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string ManifestPath { get; init; } = string.Empty;
+    public DateTimeOffset LastOpenedAt { get; init; }
+}
+
+public class WorkspaceTemplateService
+{
+    public const string ManifestFileName = "workspace.sailor";
+
+    readonly WorkspaceManifestSerializer _serializer;
+
+    public WorkspaceTemplateService(WorkspaceManifestSerializer serializer)
+    {
+        _serializer = serializer;
+    }
+
+    public virtual async Task<WorkspaceSession> CreateAsync(WorkspaceCreateRequest request, CancellationToken cancellationToken = default)
+    {
+        var workspaceRoot = Path.GetFullPath(request.WorkspaceDirectory);
+        ValidateCleanWorkspaceDirectory(workspaceRoot);
+
+        Directory.CreateDirectory(workspaceRoot);
+
+        var manifest = WorkspaceManifest.CreateDefault(request.Name, request.EnginePath, request.WorkspaceId);
+        var session = CreateSession(workspaceRoot, manifest);
+
+        EnsureInsideWorkspace(workspaceRoot, session.ContentDirectory, nameof(WorkspaceManifest.ContentPath));
+        EnsureInsideWorkspace(workspaceRoot, session.SourceDirectory, nameof(WorkspaceManifest.SourcePath));
+        EnsureInsideWorkspace(workspaceRoot, session.GeneratedProjectDirectory, nameof(WorkspaceManifest.GeneratedProjectPath));
+        EnsureInsideWorkspace(workspaceRoot, session.CacheDirectory, nameof(WorkspaceManifest.CachePath));
+
+        Directory.CreateDirectory(session.ContentDirectory);
+        Directory.CreateDirectory(session.SourceDirectory);
+        Directory.CreateDirectory(session.GeneratedProjectDirectory);
+        Directory.CreateDirectory(session.CacheDirectory);
+
+        await _serializer.SaveAsync(session.ManifestPath, manifest, cancellationToken);
+        return session;
+    }
+
+    public WorkspaceSession CreateSession(string workspaceRoot, WorkspaceManifest manifest, string? manifestPath = null)
+    {
+        var root = Path.GetFullPath(workspaceRoot);
+        var resolvedManifestPath = Path.GetFullPath(manifestPath ?? Path.Combine(root, ManifestFileName));
+        EnsureInsideWorkspace(root, resolvedManifestPath, nameof(WorkspaceSession.ManifestPath));
+
+        return new WorkspaceSession(
+            root,
+            resolvedManifestPath,
+            manifest,
+            ResolveWorkspacePath(root, manifest.ContentPath),
+            ResolveWorkspacePath(root, manifest.SourcePath),
+            ResolveWorkspacePath(root, manifest.GeneratedProjectPath),
+            ResolveWorkspacePath(root, manifest.CachePath));
+    }
+
+    static void ValidateCleanWorkspaceDirectory(string workspaceRoot)
+    {
+        if (!Directory.Exists(workspaceRoot))
+            return;
+
+        if (Directory.EnumerateFileSystemEntries(workspaceRoot).Any())
+            throw new InvalidOperationException($"Workspace directory is not empty: {workspaceRoot}");
+    }
+
+    static string ResolveWorkspacePath(string workspaceRoot, string relativePath)
+    {
+        var path = relativePath
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+
+        var fullPath = Path.GetFullPath(Path.Combine(workspaceRoot, path));
+        EnsureInsideWorkspace(workspaceRoot, fullPath, relativePath);
+        return fullPath;
+    }
+
+    static void EnsureInsideWorkspace(string workspaceRoot, string path, string field)
+    {
+        var root = Path.GetFullPath(workspaceRoot).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        var fullPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+
+        if (string.Equals(root, fullPath, PathComparison))
+            return;
+
+        var prefix = root + Path.DirectorySeparatorChar;
+        if (!fullPath.StartsWith(prefix, PathComparison))
+            throw new InvalidOperationException($"{field} resolves outside the workspace root.");
+    }
+
+    static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+}
+
+public sealed class RecentWorkspaceStore
+{
+    const int DefaultMaxEntries = 20;
+
+    readonly string _path;
+    readonly Func<DateTimeOffset> _clock;
+    readonly int _maxEntries;
+    readonly ISerializer _serializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+    readonly IDeserializer _deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    public RecentWorkspaceStore(string? path = null, Func<DateTimeOffset>? clock = null, int maxEntries = DefaultMaxEntries)
+    {
+        var appDataDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+        _path = path ?? Path.Combine(appDataDirectory, "SailorEditor", "Workspaces", "recent-workspaces.yaml");
+        _clock = clock ?? (() => DateTimeOffset.UtcNow);
+        _maxEntries = maxEntries;
+    }
+
+    public async Task<IReadOnlyList<RecentWorkspaceEntry>> LoadAsync(CancellationToken cancellationToken = default)
+    {
+        if (!File.Exists(_path))
+            return [];
+
+        try
+        {
+            var yaml = await File.ReadAllTextAsync(_path, cancellationToken);
+            var entries = _deserializer.Deserialize<List<RecentWorkspaceEntry>>(yaml) ?? [];
+            return Normalize(entries);
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    public async Task SaveAsync(IReadOnlyList<RecentWorkspaceEntry> entries, CancellationToken cancellationToken = default)
+    {
+        var directory = Path.GetDirectoryName(_path);
+        if (!string.IsNullOrWhiteSpace(directory))
+            Directory.CreateDirectory(directory);
+
+        await File.WriteAllTextAsync(_path, _serializer.Serialize(Normalize(entries)), cancellationToken);
+    }
+
+    public async Task<IReadOnlyList<RecentWorkspaceEntry>> RecordAsync(WorkspaceSession session, CancellationToken cancellationToken = default)
+    {
+        var entries = await LoadAsync(cancellationToken);
+        var updated = new RecentWorkspaceEntry(
+            session.Manifest.WorkspaceId,
+            session.Manifest.Name,
+            Path.GetFullPath(session.ManifestPath),
+            _clock());
+
+        var normalizedPath = NormalizePath(updated.ManifestPath);
+        var next = entries
+            .Where(x => !string.Equals(NormalizePath(x.ManifestPath), normalizedPath, StringComparison.OrdinalIgnoreCase))
+            .Prepend(updated)
+            .ToArray();
+
+        await SaveAsync(next, cancellationToken);
+        return Normalize(next);
+    }
+
+    IReadOnlyList<RecentWorkspaceEntry> Normalize(IEnumerable<RecentWorkspaceEntry> entries)
+        => entries
+            .Where(x => !string.IsNullOrWhiteSpace(x.ManifestPath))
+            .Select(TryNormalize)
+            .Where(x => x is not null)
+            .Select(x => x!)
+            .GroupBy(x => NormalizePath(x.ManifestPath), StringComparer.OrdinalIgnoreCase)
+            .Select(x => x.OrderByDescending(entry => entry.LastOpenedAt).First())
+            .OrderByDescending(x => x.LastOpenedAt)
+            .Take(_maxEntries)
+            .ToArray();
+
+    static RecentWorkspaceEntry? TryNormalize(RecentWorkspaceEntry entry)
+    {
+        try
+        {
+            return entry with { ManifestPath = Path.GetFullPath(entry.ManifestPath) };
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static string NormalizePath(string path) => Path.GetFullPath(path)
+        .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+}
+
+public sealed class WorkspaceLifecycleService
+{
+    readonly WorkspaceManifestSerializer _serializer;
+    readonly WorkspaceTemplateService _templateService;
+    readonly RecentWorkspaceStore _recentWorkspaceStore;
+
+    public WorkspaceLifecycleService(
+        WorkspaceManifestSerializer serializer,
+        WorkspaceTemplateService templateService,
+        RecentWorkspaceStore recentWorkspaceStore)
+    {
+        _serializer = serializer;
+        _templateService = templateService;
+        _recentWorkspaceStore = recentWorkspaceStore;
+    }
+
+    public WorkspaceSession? Current { get; private set; }
+
+    public Task<IReadOnlyList<RecentWorkspaceEntry>> LoadRecentAsync(CancellationToken cancellationToken = default)
+        => _recentWorkspaceStore.LoadAsync(cancellationToken);
+
+    public async Task<WorkspaceLifecycleResult> CreateAsync(WorkspaceCreateRequest request, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var session = await _templateService.CreateAsync(request, cancellationToken);
+            Current = session;
+            await _recentWorkspaceStore.RecordAsync(session, cancellationToken);
+            return new WorkspaceLifecycleResult(session, WorkspaceManifestValidationResult.Success);
+        }
+        catch (Exception ex)
+        {
+            return new WorkspaceLifecycleResult(null, WorkspaceManifestValidationResult.Success, ex.Message);
+        }
+    }
+
+    public async Task<WorkspaceLifecycleResult> OpenAsync(string manifestPath, CancellationToken cancellationToken = default)
+    {
+        var loadResult = await _serializer.LoadAsync(manifestPath, cancellationToken);
+        if (!loadResult.Succeeded || loadResult.Manifest is null)
+            return new WorkspaceLifecycleResult(null, loadResult.Validation, loadResult.Error);
+
+        try
+        {
+            var workspaceRoot = Path.GetDirectoryName(Path.GetFullPath(manifestPath));
+            if (string.IsNullOrWhiteSpace(workspaceRoot))
+                return new WorkspaceLifecycleResult(null, WorkspaceManifestValidationResult.Success, $"Workspace manifest path is invalid: {manifestPath}");
+
+            var session = _templateService.CreateSession(workspaceRoot, loadResult.Manifest, manifestPath);
+            Current = session;
+            await _recentWorkspaceStore.RecordAsync(session, cancellationToken);
+            return new WorkspaceLifecycleResult(session, loadResult.Validation);
+        }
+        catch (Exception ex)
+        {
+            return new WorkspaceLifecycleResult(null, loadResult.Validation, ex.Message);
+        }
+    }
+
+    public async Task<WorkspaceLifecycleResult> SaveAsync(WorkspaceSession session, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var validated = _templateService.CreateSession(session.WorkspaceRoot, session.Manifest, session.ManifestPath);
+            await _serializer.SaveAsync(validated.ManifestPath, validated.Manifest, cancellationToken);
+            Current = validated;
+            await _recentWorkspaceStore.RecordAsync(validated, cancellationToken);
+            return new WorkspaceLifecycleResult(validated, WorkspaceManifestValidationResult.Success);
+        }
+        catch (Exception ex)
+        {
+            return new WorkspaceLifecycleResult(null, WorkspaceManifestValidationResult.Success, ex.Message);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add editor-side workspace lifecycle contracts and services for create/open/save flows.
- Add default workspace template creation with `workspace.sailor`, `Content`, `Source`, `Generated`, and `Cache`.
- Add recent workspace YAML persistence with newest-first ordering and path deduplication.
- Register workspace lifecycle services in editor DI.
- Add contract tests for template creation, open/save, path safety, missing manifests, corrupted recent state, and recent ordering.

Closes #75.

## Scope Notes
- This intentionally does not switch `AssetsService` or runtime launch paths to workspace content yet. That remains in #76/#77.
- Starter workspace content is empty for this task; template asset packs can be added separately.

## Validation
- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj` - passed, 89/89 tests.
- `/Users/aantropov/.dotnet/dotnet build Editor/SailorEditor.csproj -f net10.0-maccatalyst -c Debug -r maccatalyst-arm64` - passed, 0 errors.
- `git diff --check` - passed.

## Agent Workflow
- Manager: issue #75 moved into implementation.
- Tech Lead: plan posted on the issue.
- Coder: implemented lifecycle/template/recent workspace services and tests.
- Architector: initial blocker found around `SaveAsync` path invariants; fixed and re-reviewed with no blockers.