### PR TITLE
[Workspace] Validate active workspace content projection

### DIFF
--- a/Editor.Tests/ProjectContentProjectionTests.cs
+++ b/Editor.Tests/ProjectContentProjectionTests.cs
@@ -47,4 +47,33 @@ public class ProjectContentProjectionTests
         Assert.Equal(["Textures"], projection.VisibleFolders.Select(x => x.Name).ToArray());
         Assert.Single(projection.CurrentFolderAssets);
     }
+
+    [Fact]
+    public void Build_UsesActiveWorkspaceRootForFolderPaths()
+    {
+        var repoRoot = Path.Combine(Path.DirectorySeparatorChar.ToString(), "repo", "Content");
+        var workspaceRoot = Path.Combine(Path.DirectorySeparatorChar.ToString(), "workspaces", "Sandbox", "Content");
+        var folders = new[]
+        {
+            new ProjectContentFolderSnapshot(1, "Materials", -1),
+            new ProjectContentFolderSnapshot(2, "Wood", 1),
+        };
+
+        var repoProjection = ProjectContentProjectionBuilder.Build(
+            repoRoot,
+            folders,
+            [new ProjectContentAssetSnapshot("{R}", "repo-material", ".mat", 1, Path.Combine(repoRoot, "Materials", "repo-material.mat"))],
+            new ProjectContentState(CurrentFolderId: 1));
+
+        var workspaceProjection = ProjectContentProjectionBuilder.Build(
+            workspaceRoot,
+            folders,
+            [new ProjectContentAssetSnapshot("{W}", "workspace-material", ".mat", 1, Path.Combine(workspaceRoot, "Materials", "workspace-material.mat"))],
+            new ProjectContentState(CurrentFolderId: 1));
+
+        Assert.Equal(Path.Combine(repoRoot, "Materials"), repoProjection.Folders.Single(x => x.FolderId == 1).FullPath);
+        Assert.Equal(Path.Combine(workspaceRoot, "Materials"), workspaceProjection.Folders.Single(x => x.FolderId == 1).FullPath);
+        Assert.Equal(["repo-material"], repoProjection.VisibleAssets.Select(x => x.DisplayName).ToArray());
+        Assert.Equal(["workspace-material"], workspaceProjection.VisibleAssets.Select(x => x.DisplayName).ToArray());
+    }
 }

--- a/Editor.Tests/WorkspaceLifecycleTests.cs
+++ b/Editor.Tests/WorkspaceLifecycleTests.cs
@@ -89,6 +89,26 @@ public sealed class WorkspaceLifecycleTests
     }
 
     [Fact]
+    public async Task OpenAsync_ResolvesContentDirectoryFromManifest()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var serializer = new WorkspaceManifestSerializer();
+        var service = CreateService(recent.File("recent.yaml"));
+        var manifestPath = workspace.File("custom.sailor");
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id") with
+        {
+            ContentPath = "ProjectContent"
+        };
+        await serializer.SaveAsync(manifestPath, manifest);
+
+        var result = await service.OpenAsync(manifestPath);
+
+        Assert.True(result.Succeeded, result.Error);
+        Assert.Equal(Path.GetFullPath(workspace.Directory("ProjectContent")), result.Session!.ContentDirectory);
+    }
+
+    [Fact]
     public async Task SaveAsync_PersistsManifestUpdates()
     {
         using var workspace = TempWorkspace.Create();


### PR DESCRIPTION
## Summary
- Add content projection coverage proving folder paths and visible assets are rebuilt from the active content root.
- Add workspace lifecycle coverage for resolving `ContentDirectory` from a custom manifest `ContentPath`.
- Completes validation for #76 on top of the workspace content-root routing that landed with PR #86.

Closes #76

## Validation
- `/Users/aantropov/.dotnet/dotnet test Editor.Tests/Editor.Contracts.Tests.csproj` - passed, 96/96 tests.
- `python3 build_editor.py --config Debug` - passed, 0 errors; existing nullable/platform warnings remain.
- `git diff --check` - passed.

## Notes
- Runtime engine launch workspace routing remains out of scope for #76 and belongs to #77.