### PR TITLE
[Workspace] Keep engine content as a read-only library

### DIFF
--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -24,8 +24,10 @@
     <Compile Include="LayoutContractsTests.cs" />
     <Compile Include="LayoutOperationsTests.cs" />
     <Compile Include="PanelContractsTests.cs" />
+    <Compile Include="ProjectContentAssetResolutionPolicyTests.cs" />
     <Compile Include="ProjectContentProjectionTests.cs" />
     <Compile Include="ProjectContentFolderIdsTests.cs" />
+    <Compile Include="ProjectContentPathPolicyTests.cs" />
     <Compile Include="WorkspaceManifestTests.cs" />
     <Compile Include="WorkspaceLifecycleTests.cs" />
     <Compile Include="WorkspaceUiProjectionTests.cs" />
@@ -50,8 +52,10 @@
     <Compile Include="..\Editor\History\HistoryContracts.cs" Link="History\HistoryContracts.cs" />
     <Compile Include="..\Editor\Settings\SettingsContracts.cs" Link="Settings\SettingsContracts.cs" />
     <Compile Include="..\Editor\Settings\UnifiedSettingsStore.cs" Link="Settings\UnifiedSettingsStore.cs" />
+    <Compile Include="..\Editor\Content\ProjectContentAssetResolutionPolicy.cs" Link="Content\ProjectContentAssetResolutionPolicy.cs" />
     <Compile Include="..\Editor\Content\ProjectContentModels.cs" Link="Content\ProjectContentModels.cs" />
     <Compile Include="..\Editor\Content\ProjectContentFolderIds.cs" Link="Content\ProjectContentFolderIds.cs" />
+    <Compile Include="..\Editor\Content\ProjectContentPathPolicy.cs" Link="Content\ProjectContentPathPolicy.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceManifest.cs" Link="Workspace\WorkspaceManifest.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceLifecycle.cs" Link="Workspace\WorkspaceLifecycle.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceUiContracts.cs" Link="Workspace\WorkspaceUiContracts.cs" />

--- a/Editor.Tests/ProjectContentAssetResolutionPolicyTests.cs
+++ b/Editor.Tests/ProjectContentAssetResolutionPolicyTests.cs
@@ -1,0 +1,21 @@
+using SailorEditor.Content;
+
+public class ProjectContentAssetResolutionPolicyTests
+{
+    [Fact]
+    public void WorkspaceAssetOverridesEngineAsset()
+    {
+        Assert.True(ProjectContentAssetResolutionPolicy.ShouldReplace(
+            existingIsReadOnly: true,
+            incomingIsReadOnly: false));
+    }
+
+    [Theory]
+    [InlineData(false, true)]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public void EngineOrSameMountDuplicateDoesNotReplaceExisting(bool existingIsReadOnly, bool incomingIsReadOnly)
+    {
+        Assert.False(ProjectContentAssetResolutionPolicy.ShouldReplace(existingIsReadOnly, incomingIsReadOnly));
+    }
+}

--- a/Editor.Tests/ProjectContentFolderIdsTests.cs
+++ b/Editor.Tests/ProjectContentFolderIdsTests.cs
@@ -22,4 +22,29 @@ public class ProjectContentFolderIdsTests
         Assert.NotEqual(materials, nested);
         Assert.NotEqual(models, nested);
     }
+
+    [Fact]
+    public void FromRootedRelativePath_IsDistinctAcrossContentRoots()
+    {
+        var workspaceMaterials = ProjectContentFolderIds.FromRootedRelativePath(1, "Materials");
+        var engineMaterials = ProjectContentFolderIds.FromRootedRelativePath(2, "Materials");
+
+        Assert.NotEqual(workspaceMaterials, engineMaterials);
+        Assert.NotEqual(ProjectContentFolderIds.WorkspaceContentRootId, workspaceMaterials);
+        Assert.NotEqual(ProjectContentFolderIds.EngineContentRootId, engineMaterials);
+    }
+
+    [Fact]
+    public void Allocator_ProbesPastAnExistingFolderId()
+    {
+        var allocator = new ProjectContentFolderIdAllocator();
+        var original = ProjectContentFolderIds.FromRootedRelativePath(1, "Materials");
+        allocator.Reserve(original);
+
+        var allocated = allocator.Allocate(1, "Materials", useRootedFolderIds: true);
+
+        Assert.NotEqual(original, allocated);
+        Assert.NotEqual(ProjectContentFolderIds.WorkspaceContentRootId, allocated);
+        Assert.NotEqual(ProjectContentFolderIds.EngineContentRootId, allocated);
+    }
 }

--- a/Editor.Tests/ProjectContentPathPolicyTests.cs
+++ b/Editor.Tests/ProjectContentPathPolicyTests.cs
@@ -41,6 +41,34 @@ public class ProjectContentPathPolicyTests
         }
         finally
         {
+            if (Directory.Exists(linkPath))
+                Directory.Delete(linkPath);
+            if (Directory.Exists(testRoot))
+                Directory.Delete(testRoot, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void IsSamePath_ResolvesSymlinkTargetAliases()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var testRoot = Path.Combine(Path.GetTempPath(), $"sailor-path-alias-{Guid.NewGuid():N}");
+        var contentRoot = Path.Combine(testRoot, "Content");
+        var linkPath = Path.Combine(contentRoot, "Cycle");
+
+        try
+        {
+            Directory.CreateDirectory(contentRoot);
+            Directory.CreateSymbolicLink(linkPath, contentRoot);
+
+            Assert.True(ProjectContentPathPolicy.IsSamePath(contentRoot, linkPath));
+        }
+        finally
+        {
+            if (Directory.Exists(linkPath))
+                Directory.Delete(linkPath);
             if (Directory.Exists(testRoot))
                 Directory.Delete(testRoot, recursive: true);
         }

--- a/Editor.Tests/ProjectContentPathPolicyTests.cs
+++ b/Editor.Tests/ProjectContentPathPolicyTests.cs
@@ -1,0 +1,48 @@
+using SailorEditor.Content;
+
+public class ProjectContentPathPolicyTests
+{
+    [Fact]
+    public void IsInsideRoot_RejectsSiblingWithSharedPrefix()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "sailor-content");
+        var sibling = Path.Combine(Path.GetTempPath(), "sailor-content-copy", "asset.asset");
+
+        Assert.False(ProjectContentPathPolicy.IsInsideRoot(root, sibling));
+    }
+
+    [Fact]
+    public void IsInsideRoot_AcceptsRootAndDescendants()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "sailor-content");
+
+        Assert.True(ProjectContentPathPolicy.IsInsideRoot(root, root));
+        Assert.True(ProjectContentPathPolicy.IsInsideRoot(root, Path.Combine(root, "Materials", "wood.mat.asset")));
+    }
+
+    [Fact]
+    public void IsInsideRoot_RejectsDescendantSymlinkThatEscapesRoot()
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        var testRoot = Path.Combine(Path.GetTempPath(), $"sailor-path-policy-{Guid.NewGuid():N}");
+        var contentRoot = Path.Combine(testRoot, "Content");
+        var externalRoot = Path.Combine(testRoot, "External");
+        var linkPath = Path.Combine(contentRoot, "ExternalLink");
+
+        try
+        {
+            Directory.CreateDirectory(contentRoot);
+            Directory.CreateDirectory(externalRoot);
+            Directory.CreateSymbolicLink(linkPath, externalRoot);
+
+            Assert.False(ProjectContentPathPolicy.IsInsideRoot(contentRoot, Path.Combine(linkPath, "asset.asset")));
+        }
+        finally
+        {
+            if (Directory.Exists(testRoot))
+                Directory.Delete(testRoot, recursive: true);
+        }
+    }
+}

--- a/Editor.Tests/ProjectContentProjectionTests.cs
+++ b/Editor.Tests/ProjectContentProjectionTests.cs
@@ -76,4 +76,68 @@ public class ProjectContentProjectionTests
         Assert.Equal(["repo-material"], repoProjection.VisibleAssets.Select(x => x.DisplayName).ToArray());
         Assert.Equal(["workspace-material"], workspaceProjection.VisibleAssets.Select(x => x.DisplayName).ToArray());
     }
+
+    [Fact]
+    public void Build_UsesFolderSnapshotFullPathForMultipleRoots()
+    {
+        var workspaceRoot = Path.Combine(Path.DirectorySeparatorChar.ToString(), "workspaces", "Sandbox", "Content");
+        var engineRoot = Path.Combine(Path.DirectorySeparatorChar.ToString(), "repo", "Content");
+        var workspaceMaterialsId = ProjectContentFolderIds.FromRootedRelativePath(1, "Materials");
+        var engineMaterialsId = ProjectContentFolderIds.FromRootedRelativePath(2, "Materials");
+        var folders = new[]
+        {
+            new ProjectContentFolderSnapshot(ProjectContentFolderIds.WorkspaceContentRootId, "Workspace Content", -1, workspaceRoot),
+            new ProjectContentFolderSnapshot(workspaceMaterialsId, "Materials", ProjectContentFolderIds.WorkspaceContentRootId, Path.Combine(workspaceRoot, "Materials")),
+            new ProjectContentFolderSnapshot(ProjectContentFolderIds.EngineContentRootId, "Engine Content", -1, engineRoot, IsReadOnly: true),
+            new ProjectContentFolderSnapshot(engineMaterialsId, "Materials", ProjectContentFolderIds.EngineContentRootId, Path.Combine(engineRoot, "Materials"), IsReadOnly: true),
+        };
+
+        var projection = ProjectContentProjectionBuilder.Build(
+            workspaceRoot,
+            folders,
+            [],
+            new ProjectContentState());
+
+        Assert.Equal(
+            [Path.Combine(engineRoot, "Materials"), Path.Combine(workspaceRoot, "Materials")],
+            projection.Folders.Where(x => x.Name == "Materials").Select(x => x.FullPath).Order(StringComparer.OrdinalIgnoreCase).ToArray());
+        Assert.True(projection.Folders.Single(x => x.FolderId == ProjectContentFolderIds.EngineContentRootId).IsReadOnly);
+        Assert.False(projection.Folders.Single(x => x.FolderId == ProjectContentFolderIds.WorkspaceContentRootId).IsReadOnly);
+    }
+
+    [Fact]
+    public void Build_KeepsDuplicateFileIdsDistinctByMountedPath()
+    {
+        var workspacePath = Path.Combine(Path.GetTempPath(), "workspace", "Content", "Materials", "wood.mat");
+        var enginePath = Path.Combine(Path.GetTempPath(), "engine", "Content", "Materials", "wood.mat");
+        var assets = new[]
+        {
+            new ProjectContentAssetSnapshot("{WOOD}", "wood", ".mat", 1, workspacePath, ProjectRootId: 1),
+            new ProjectContentAssetSnapshot("{WOOD}", "wood", ".mat", 2, enginePath, ProjectRootId: 2, IsReadOnly: true),
+        };
+
+        var projection = ProjectContentProjectionBuilder.Build(
+            Path.Combine(Path.GetTempPath(), "workspace", "Content"),
+            [new ProjectContentFolderSnapshot(2, "Engine Materials", -1, Path.GetDirectoryName(enginePath), IsReadOnly: true)],
+            assets,
+            new ProjectContentState(CurrentFolderId: 2, SelectedAssetFileId: "{WOOD}", SelectedAssetPath: enginePath));
+
+        Assert.Single(projection.VisibleAssets);
+        Assert.Equal(enginePath, projection.VisibleAssets[0].FullPath);
+        Assert.True(projection.VisibleAssets[0].IsReadOnly);
+        Assert.Equal(enginePath, projection.State.SelectedAssetPath);
+    }
+
+    [Fact]
+    public void Build_ClearsSelectionThatIsMissingAfterRootSwitch()
+    {
+        var projection = ProjectContentProjectionBuilder.Build(
+            Path.Combine(Path.GetTempPath(), "workspace-b", "Content"),
+            [],
+            [],
+            new ProjectContentState(SelectedAssetFileId: "{OLD}", SelectedAssetPath: Path.Combine(Path.GetTempPath(), "workspace-a", "Content", "old.mat")));
+
+        Assert.Null(projection.State.SelectedAssetFileId);
+        Assert.Null(projection.State.SelectedAssetPath);
+    }
 }

--- a/Editor/Commands/EditorAssetCommands.cs
+++ b/Editor/Commands/EditorAssetCommands.cs
@@ -19,11 +19,13 @@ public sealed class OpenAssetCommand(AssetFile assetFile) : IEditorCommand
 public sealed class RenameAssetCommand(AssetFile assetFile, string newName) : IEditorCommand
 {
     public string Name => nameof(RenameAssetCommand);
-    public bool CanExecute(ActionContext context) => assetFile is not null && !string.IsNullOrWhiteSpace(newName);
+    public bool CanExecute(ActionContext context) => assetFile is not null && !assetFile.IsReadOnly && !string.IsNullOrWhiteSpace(newName);
 
     public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
         var success = MauiProgram.GetService<AssetsService>().RenameAsset(assetFile, newName);
+        if (success)
+            MauiProgram.GetService<SelectionService>().ClearSelection();
         return Task.FromResult(success ? CommandResult.Success(value: assetFile.FileId) : CommandResult.Failure("Rename failed"));
     }
 }
@@ -31,32 +33,27 @@ public sealed class RenameAssetCommand(AssetFile assetFile, string newName) : IE
 public sealed class DeleteAssetCommand(AssetFile assetFile) : IEditorCommand
 {
     public string Name => nameof(DeleteAssetCommand);
-    public bool CanExecute(ActionContext context) => assetFile?.AssetInfo?.Exists == true;
+    public bool CanExecute(ActionContext context) => assetFile is { IsReadOnly: false, AssetInfo.Exists: true };
 
     public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
-        try
+        var success = MauiProgram.GetService<AssetsService>().DeleteAsset(assetFile);
+        if (success)
         {
-            if (assetFile.Asset?.Exists == true)
-                File.Delete(assetFile.Asset.FullName);
-            if (assetFile.AssetInfo.Exists)
-                File.Delete(assetFile.AssetInfo.FullName);
-
-            MauiProgram.GetService<AssetsService>().Refresh();
             MauiProgram.GetService<SelectionService>().ClearSelection();
             return Task.FromResult(CommandResult.Success());
         }
-        catch (Exception ex)
-        {
-            return Task.FromResult(CommandResult.Failure(ex.Message));
-        }
+
+        return Task.FromResult(CommandResult.Failure("Delete failed"));
     }
 }
 
 public sealed class CreatePrefabAssetCommand(GameObject gameObject, AssetFolder? targetFolder = null, PrefabFile? existingPrefab = null) : IEditorCommand
 {
     public string Name => nameof(CreatePrefabAssetCommand);
-    public bool CanExecute(ActionContext context) => gameObject is not null;
+    public bool CanExecute(ActionContext context) => gameObject is not null
+        && targetFolder?.IsReadOnly != true
+        && existingPrefab?.IsReadOnly != true;
 
     public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
     {

--- a/Editor/Content/ProjectContentAssetResolutionPolicy.cs
+++ b/Editor/Content/ProjectContentAssetResolutionPolicy.cs
@@ -1,0 +1,7 @@
+namespace SailorEditor.Content;
+
+public static class ProjectContentAssetResolutionPolicy
+{
+    public static bool ShouldReplace(bool existingIsReadOnly, bool incomingIsReadOnly)
+        => existingIsReadOnly && !incomingIsReadOnly;
+}

--- a/Editor/Content/ProjectContentFolderIds.cs
+++ b/Editor/Content/ProjectContentFolderIds.cs
@@ -2,9 +2,17 @@ namespace SailorEditor.Content;
 
 public static class ProjectContentFolderIds
 {
+    public const int WorkspaceContentRootId = int.MaxValue - 1;
+    public const int EngineContentRootId = int.MaxValue - 2;
+
     public static int FromRelativePath(string relativePath)
+        => FromNormalizedPath(Normalize(relativePath));
+
+    public static int FromRootedRelativePath(int rootId, string relativePath)
+        => FromNormalizedPath($"{rootId}:{Normalize(relativePath)}");
+
+    static int FromNormalizedPath(string normalized)
     {
-        var normalized = Normalize(relativePath);
         if (normalized.Length == 0)
             return 1;
 
@@ -21,6 +29,8 @@ public static class ProjectContentFolderIds
         var id = (int)(hash & 0x7fffffff);
         if (id is 0 or -1)
             id = 1;
+        if (id is WorkspaceContentRootId or EngineContentRootId)
+            id -= 3;
 
         return id;
     }
@@ -30,4 +40,31 @@ public static class ProjectContentFolderIds
         .Replace('/', Path.DirectorySeparatorChar)
         .Trim(Path.DirectorySeparatorChar)
         .ToLowerInvariant();
+}
+
+public sealed class ProjectContentFolderIdAllocator
+{
+    readonly HashSet<int> _used =
+    [
+        0,
+        -1,
+        ProjectContentFolderIds.WorkspaceContentRootId,
+        ProjectContentFolderIds.EngineContentRootId
+    ];
+
+    public int Allocate(int rootId, string relativePath, bool useRootedFolderIds)
+    {
+        var candidate = useRootedFolderIds
+            ? ProjectContentFolderIds.FromRootedRelativePath(rootId, relativePath)
+            : ProjectContentFolderIds.FromRelativePath(relativePath);
+
+        while (!_used.Add(candidate))
+            candidate = Next(candidate);
+
+        return candidate;
+    }
+
+    public void Reserve(int id) => _used.Add(id);
+
+    static int Next(int id) => id >= int.MaxValue - 3 ? 1 : id + 1;
 }

--- a/Editor/Content/ProjectContentModels.cs
+++ b/Editor/Content/ProjectContentModels.cs
@@ -1,7 +1,16 @@
 namespace SailorEditor.Content;
 
-public sealed record ProjectContentFolderSnapshot(int Id, string Name, int ParentFolderId);
-public sealed record ProjectContentAssetSnapshot(string FileId, string DisplayName, string Extension, int FolderId, string FullPath, string? AssetInfoTypeName = null);
+public sealed record ProjectContentFolderSnapshot(int Id, string Name, int ParentFolderId, string? FullPath = null, bool IsReadOnly = false);
+public sealed record ProjectContentAssetSnapshot(
+    string FileId,
+    string DisplayName,
+    string Extension,
+    int FolderId,
+    string FullPath,
+    string? AssetInfoTypeName = null,
+    string IdentityPath = "",
+    int ProjectRootId = 0,
+    bool IsReadOnly = false);
 
 public enum ProjectContentSortMode
 {
@@ -12,12 +21,22 @@ public enum ProjectContentSortMode
 public sealed record ProjectContentState(
     int? CurrentFolderId = null,
     string? SelectedAssetFileId = null,
+    string? SelectedAssetPath = null,
     string? Filter = null,
     ProjectContentSortMode SortMode = ProjectContentSortMode.NameAscending);
 
-public sealed record ProjectContentFolderItem(int? FolderId, string Name, string FullPath, int? ParentFolderId, bool IsRoot = false);
+public sealed record ProjectContentFolderItem(int? FolderId, string Name, string FullPath, int? ParentFolderId, bool IsRoot = false, bool IsReadOnly = false);
 
-public sealed record ProjectContentAssetItem(string FileId, string DisplayName, string Extension, int FolderId, string FullPath, string? AssetInfoTypeName = null);
+public sealed record ProjectContentAssetItem(
+    string FileId,
+    string DisplayName,
+    string Extension,
+    int FolderId,
+    string FullPath,
+    string? AssetInfoTypeName = null,
+    string IdentityPath = "",
+    int ProjectRootId = 0,
+    bool IsReadOnly = false);
 
 public sealed record ProjectContentProjection(
     ProjectContentFolderItem Root,
@@ -39,9 +58,9 @@ public static class ProjectContentProjectionBuilder
         IReadOnlyList<ProjectContentAssetSnapshot> assets,
         ProjectContentState state)
     {
-        var normalizedState = NormalizeState(folders, state);
+        var normalizedState = NormalizeState(folders, assets, state);
         var folderItems = folders
-            .Select(folder => new ProjectContentFolderItem(folder.Id, folder.Name, BuildFolderPath(rootPath, folder, folders), folder.ParentFolderId))
+            .Select(folder => new ProjectContentFolderItem(folder.Id, folder.Name, BuildFolderPath(rootPath, folder, folders), folder.ParentFolderId, IsReadOnly: folder.IsReadOnly))
             .OrderBy(x => x.FullPath, StringComparer.OrdinalIgnoreCase)
             .ToArray();
 
@@ -52,7 +71,16 @@ public static class ProjectContentProjectionBuilder
 
         var assetItems = assets
             .Where(asset => !string.IsNullOrWhiteSpace(asset.FileId))
-            .Select(asset => new ProjectContentAssetItem(asset.FileId, asset.DisplayName, asset.Extension, asset.FolderId, asset.FullPath, asset.AssetInfoTypeName))
+            .Select(asset => new ProjectContentAssetItem(
+                asset.FileId,
+                asset.DisplayName,
+                asset.Extension,
+                asset.FolderId,
+                asset.FullPath,
+                asset.AssetInfoTypeName,
+                asset.IdentityPath,
+                asset.ProjectRootId,
+                asset.IsReadOnly))
             .Where(asset => MatchesFolder(asset, normalizedState.CurrentFolderId) && MatchesFilter(asset, normalizedState.Filter))
             .OrderBy(asset => asset.DisplayName, StringComparer.OrdinalIgnoreCase)
             .ToArray();
@@ -82,14 +110,32 @@ public static class ProjectContentProjectionBuilder
             || (asset.AssetInfoTypeName?.Contains(filter, StringComparison.OrdinalIgnoreCase) ?? false);
     }
 
-    static ProjectContentState NormalizeState(IReadOnlyList<ProjectContentFolderSnapshot> folders, ProjectContentState state)
+    static ProjectContentState NormalizeState(
+        IReadOnlyList<ProjectContentFolderSnapshot> folders,
+        IReadOnlyList<ProjectContentAssetSnapshot> assets,
+        ProjectContentState state)
     {
         var folderExists = state.CurrentFolderId is null or -1 || folders.Any(x => x.Id == state.CurrentFolderId);
-        return folderExists ? state : state with { CurrentFolderId = null };
+        var assetExists = string.IsNullOrWhiteSpace(state.SelectedAssetPath)
+            ? string.IsNullOrWhiteSpace(state.SelectedAssetFileId) || assets.Any(x => x.FileId == state.SelectedAssetFileId)
+            : assets.Any(x => string.Equals(
+                string.IsNullOrWhiteSpace(x.IdentityPath) ? x.FullPath : x.IdentityPath,
+                state.SelectedAssetPath,
+                ProjectContentPathPolicy.PathComparison));
+
+        return state with
+        {
+            CurrentFolderId = folderExists ? state.CurrentFolderId : null,
+            SelectedAssetFileId = assetExists ? state.SelectedAssetFileId : null,
+            SelectedAssetPath = assetExists ? state.SelectedAssetPath : null
+        };
     }
 
     static string BuildFolderPath(string rootPath, ProjectContentFolderSnapshot folder, IReadOnlyList<ProjectContentFolderSnapshot> folders)
     {
+        if (!string.IsNullOrWhiteSpace(folder.FullPath))
+            return folder.FullPath;
+
         var parts = new Stack<string>();
         ProjectContentFolderSnapshot? current = folder;
         while (current is not null)

--- a/Editor/Content/ProjectContentPathPolicy.cs
+++ b/Editor/Content/ProjectContentPathPolicy.cs
@@ -1,0 +1,59 @@
+namespace SailorEditor.Content;
+
+public static class ProjectContentPathPolicy
+{
+    public static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    public static StringComparer PathComparer => OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
+    public static string NormalizeRoot(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var pathRoot = Path.GetPathRoot(fullPath);
+        if (string.IsNullOrEmpty(pathRoot))
+            return TrimTrailingSeparators(fullPath);
+
+        var current = pathRoot;
+        var relativePath = Path.GetRelativePath(pathRoot, fullPath);
+        if (relativePath == ".")
+            return pathRoot;
+
+        foreach (var part in relativePath.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
+        {
+            var next = Path.Combine(current, part);
+            FileSystemInfo? info = Directory.Exists(next)
+                ? new DirectoryInfo(next)
+                : File.Exists(next) ? new FileInfo(next) : null;
+            var resolved = info?.LinkTarget is not null
+                ? info.ResolveLinkTarget(returnFinalTarget: true)
+                : null;
+            current = resolved?.FullName ?? next;
+        }
+
+        return TrimTrailingSeparators(current);
+    }
+
+    public static bool IsSamePath(string left, string right)
+        => string.Equals(NormalizeRoot(left), NormalizeRoot(right), PathComparison);
+
+    public static bool IsInsideRoot(string rootPath, string candidatePath)
+    {
+        var root = NormalizeRoot(rootPath);
+        var candidate = NormalizeRoot(candidatePath);
+
+        return string.Equals(root, candidate, PathComparison)
+            || candidate.StartsWith(root + Path.DirectorySeparatorChar, PathComparison);
+    }
+
+    static string TrimTrailingSeparators(string path)
+    {
+        var pathRoot = Path.GetPathRoot(path);
+        return string.Equals(path, pathRoot, PathComparison)
+            ? path
+            : path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+}

--- a/Editor/Content/ProjectContentPathPolicy.cs
+++ b/Editor/Content/ProjectContentPathPolicy.cs
@@ -31,7 +31,7 @@ public static class ProjectContentPathPolicy
             var resolved = info?.LinkTarget is not null
                 ? info.ResolveLinkTarget(returnFinalTarget: true)
                 : null;
-            current = resolved?.FullName ?? next;
+            current = resolved is null ? next : NormalizeRoot(resolved.FullName);
         }
 
         return TrimTrailingSeparators(current);

--- a/Editor/Content/ProjectContentStore.cs
+++ b/Editor/Content/ProjectContentStore.cs
@@ -1,4 +1,5 @@
 using SailorEditor.Services;
+using SailorEditor.ViewModels;
 
 namespace SailorEditor.Content;
 
@@ -20,13 +21,30 @@ public sealed class ProjectContentStore
 
     public ProjectContentProjection Refresh() => Update(State, force: true);
 
-    public ProjectContentProjection SelectFolder(int? folderId) => Update(State with { CurrentFolderId = folderId, SelectedAssetFileId = null });
-
-    public ProjectContentProjection SelectAsset(string? fileId)
+    public ProjectContentProjection SelectFolder(int? folderId) => Update(State with
     {
-        var asset = CreateAssetSnapshots().FirstOrDefault(x => x.FileId == fileId);
+        CurrentFolderId = folderId,
+        SelectedAssetFileId = null,
+        SelectedAssetPath = null
+    });
+
+    public ProjectContentProjection SelectAsset(AssetFile? assetFile)
+    {
+        var fullPath = assetFile?.AssetInfo?.FullName ?? assetFile?.Asset?.FullName;
+        var asset = CreateAssetSnapshots().FirstOrDefault(x =>
+            string.Equals(
+                string.IsNullOrWhiteSpace(x.IdentityPath) ? x.FullPath : x.IdentityPath,
+                fullPath,
+                ProjectContentPathPolicy.PathComparison));
         var folderId = asset is null ? State.CurrentFolderId : asset.FolderId == -1 ? null : asset.FolderId;
-        return Update(State with { CurrentFolderId = folderId, SelectedAssetFileId = fileId });
+        return Update(State with
+        {
+            CurrentFolderId = folderId,
+            SelectedAssetFileId = asset?.FileId,
+            SelectedAssetPath = asset is null
+                ? null
+                : (string.IsNullOrWhiteSpace(asset.IdentityPath) ? asset.FullPath : asset.IdentityPath)
+        });
     }
 
     public ProjectContentProjection SetFilter(string? filter) => Update(State with { Filter = filter });
@@ -40,8 +58,8 @@ public sealed class ProjectContentStore
         if (!force && state == State)
             return Projection;
 
-        State = state;
-        Projection = BuildProjection(State);
+        Projection = BuildProjection(state);
+        State = Projection.State;
         ProjectionChanged?.Invoke(Projection);
         return Projection;
     }
@@ -53,11 +71,20 @@ public sealed class ProjectContentStore
         state);
 
     IReadOnlyList<ProjectContentFolderSnapshot> CreateFolderSnapshots() => _assetsService.Folders
-        .Select(x => new ProjectContentFolderSnapshot(x.Id, x.Name, x.ParentFolderId))
+        .Select(x => new ProjectContentFolderSnapshot(x.Id, x.Name, x.ParentFolderId, x.FullPath, x.IsReadOnly))
         .ToArray();
 
     IReadOnlyList<ProjectContentAssetSnapshot> CreateAssetSnapshots() => _assetsService.Files
         .Where(x => x.FileId is not null && !x.FileId.IsEmpty())
-        .Select(x => new ProjectContentAssetSnapshot(x.FileId!.Value, x.DisplayName, x.Asset?.Extension ?? string.Empty, x.FolderId, x.Asset?.FullName ?? x.AssetInfo?.FullName ?? x.DisplayName, x.AssetInfoTypeName))
+        .Select(x => new ProjectContentAssetSnapshot(
+            x.FileId!.Value,
+            x.DisplayName,
+            x.Asset?.Extension ?? string.Empty,
+            x.FolderId,
+            x.Asset?.FullName ?? x.AssetInfo?.FullName ?? x.DisplayName,
+            x.AssetInfoTypeName,
+            x.AssetInfo?.FullName ?? string.Empty,
+            x.ProjectRootId,
+            x.IsReadOnly))
         .ToArray();
 }

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -14,6 +14,15 @@ namespace SailorEditor.Services
 {
     public class AssetsService
     {
+        const int ActiveProjectRootId = 1;
+        const int EngineProjectRootId = 2;
+
+        readonly string _engineContentDirectory;
+        ProjectContentFolderIdAllocator _folderIdAllocator = new();
+        HashSet<string> _visitedDirectories = new(ProjectContentPathPolicy.PathComparer);
+        int _nextAssetId = 1;
+        int _assetOverrideCount;
+
         public event Action? Changed;
 
         public ProjectRoot Root { get; private set; }
@@ -22,13 +31,24 @@ namespace SailorEditor.Services
         public List<AssetFile> Files { get; private set; } = new();
         public string CurrentProjectRootPath { get; private set; }
 
-        public AssetsService() => AddProjectRoot(MauiProgram.GetService<EngineService>().EngineContentDirectory);
+        public AssetsService()
+        {
+            var engineContentDirectory = Path.GetFullPath(MauiProgram.GetService<EngineService>().EngineContentDirectory);
+            Directory.CreateDirectory(engineContentDirectory);
+            _engineContentDirectory = ProjectContentPathPolicy.NormalizeRoot(engineContentDirectory);
+            AddProjectRoot(_engineContentDirectory);
+        }
 
-        public string GetFolderPath(AssetFolder folder)
+        public string GetFolderPath(AssetFolder? folder)
         {
             if (folder == null)
             {
                 return CurrentProjectRootPath;
+            }
+
+            if (!string.IsNullOrWhiteSpace(folder.FullPath))
+            {
+                return folder.FullPath;
             }
 
             var parts = new Stack<string>();
@@ -42,11 +62,17 @@ namespace SailorEditor.Services
             return Path.Combine(CurrentProjectRootPath, Path.Combine(parts.ToArray()));
         }
 
-        public PrefabFile CreatePrefabAsset(AssetFolder targetFolder, GameObject root, bool overwrite = false, PrefabFile existingPrefab = null)
+        public PrefabFile? CreatePrefabAsset(AssetFolder? targetFolder, GameObject root, bool overwrite = false, PrefabFile? existingPrefab = null)
         {
+            if ((targetFolder?.IsReadOnly ?? false) || (existingPrefab?.IsReadOnly ?? false))
+                return null;
+
             var worldService = MauiProgram.GetService<WorldService>();
             var prefab = worldService.CreatePrefabFromSubHierarchy(root, out var externalRefs);
             var folderPath = existingPrefab?.Asset?.DirectoryName ?? GetFolderPath(targetFolder);
+            if (!ProjectContentPathPolicy.IsInsideRoot(CurrentProjectRootPath, folderPath))
+                return null;
+
             Directory.CreateDirectory(folderPath);
 
             var prefabName = existingPrefab?.Asset?.Name ?? GetUniqueAssetName(folderPath, root.Name, ".prefab");
@@ -67,7 +93,7 @@ namespace SailorEditor.Services
 
         public bool RenameAsset(AssetFile assetFile, string newName)
         {
-            if (assetFile?.AssetInfo == null || string.IsNullOrWhiteSpace(newName))
+            if (!CanModifyAsset(assetFile) || string.IsNullOrWhiteSpace(newName))
             {
                 return false;
             }
@@ -87,22 +113,22 @@ namespace SailorEditor.Services
             var targetAssetPath = Path.Combine(directory, targetAssetFileName);
             var targetAssetInfoPath = targetAssetPath + ".asset";
 
-            if (!string.Equals(oldAssetPath, targetAssetPath, StringComparison.OrdinalIgnoreCase) && File.Exists(targetAssetPath))
+            if (!string.Equals(oldAssetPath, targetAssetPath, ProjectContentPathPolicy.PathComparison) && File.Exists(targetAssetPath))
             {
                 return false;
             }
 
-            if (!string.Equals(oldAssetInfoPath, targetAssetInfoPath, StringComparison.OrdinalIgnoreCase) && File.Exists(targetAssetInfoPath))
+            if (!string.Equals(oldAssetInfoPath, targetAssetInfoPath, ProjectContentPathPolicy.PathComparison) && File.Exists(targetAssetInfoPath))
             {
                 return false;
             }
 
-            if (!string.IsNullOrEmpty(oldAssetPath) && File.Exists(oldAssetPath) && !string.Equals(oldAssetPath, targetAssetPath, StringComparison.OrdinalIgnoreCase))
+            if (!string.IsNullOrEmpty(oldAssetPath) && File.Exists(oldAssetPath) && !string.Equals(oldAssetPath, targetAssetPath, ProjectContentPathPolicy.PathComparison))
             {
                 File.Move(oldAssetPath, targetAssetPath);
             }
 
-            if (!string.Equals(oldAssetInfoPath, targetAssetInfoPath, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(oldAssetInfoPath, targetAssetInfoPath, ProjectContentPathPolicy.PathComparison))
             {
                 File.Move(oldAssetInfoPath, targetAssetInfoPath);
             }
@@ -110,6 +136,28 @@ namespace SailorEditor.Services
             UpdateAssetInfoFilename(targetAssetInfoPath, targetAssetFileName);
             Refresh();
             return true;
+        }
+
+        public bool DeleteAsset(AssetFile assetFile)
+        {
+            if (!CanModifyAsset(assetFile))
+                return false;
+
+            try
+            {
+                if (assetFile.Asset?.Exists == true)
+                    File.Delete(assetFile.Asset.FullName);
+                if (assetFile.AssetInfo.Exists)
+                    File.Delete(assetFile.AssetInfo.FullName);
+
+                Refresh();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"[AssetsService] Failed to delete asset: {ex.Message}");
+                return false;
+            }
         }
 
         public void Refresh() => AddProjectRoot(CurrentProjectRootPath);
@@ -120,15 +168,62 @@ namespace SailorEditor.Services
 
             Folders = [];
             Assets = [];
+            Files = [];
+            _folderIdAllocator = new ProjectContentFolderIdAllocator();
+            _visitedDirectories = new HashSet<string>(ProjectContentPathPolicy.PathComparer);
+            _nextAssetId = 1;
+            _assetOverrideCount = 0;
 
-            CurrentProjectRootPath = Path.GetFullPath(projectRoot);
-            Directory.CreateDirectory(CurrentProjectRootPath);
+            var requestedRoot = Path.GetFullPath(projectRoot);
+            Directory.CreateDirectory(requestedRoot);
+            CurrentProjectRootPath = ProjectContentPathPolicy.NormalizeRoot(requestedRoot);
 
             Root = new ProjectRoot { Name = CurrentProjectRootPath, Id = 1 };
-            ReadDirectory(Root, CurrentProjectRootPath, -1);
+            if (ProjectContentPathPolicy.IsSamePath(CurrentProjectRootPath, _engineContentDirectory))
+            {
+                ReadDirectory(Root, CurrentProjectRootPath, CurrentProjectRootPath, -1, useRootedFolderIds: false, isReadOnly: false);
+            }
+            else
+            {
+                var workspaceRoot = new ProjectRoot { Name = "Workspace Content", Id = ActiveProjectRootId };
+                var engineRoot = new ProjectRoot { Name = "Engine Content", Id = EngineProjectRootId };
 
-            Files = new HashSet<AssetFile>([.. Assets.Values]).ToList();
+                AddContentRootFolder(workspaceRoot, ProjectContentFolderIds.WorkspaceContentRootId, CurrentProjectRootPath, isReadOnly: false);
+                AddContentRootFolder(engineRoot, ProjectContentFolderIds.EngineContentRootId, _engineContentDirectory, isReadOnly: true);
+
+                ReadDirectory(engineRoot, _engineContentDirectory, _engineContentDirectory, ProjectContentFolderIds.EngineContentRootId, useRootedFolderIds: true, isReadOnly: true);
+                ReadDirectory(workspaceRoot, CurrentProjectRootPath, CurrentProjectRootPath, ProjectContentFolderIds.WorkspaceContentRootId, useRootedFolderIds: true, isReadOnly: false);
+            }
+
+            if (_assetOverrideCount > 0)
+                Console.WriteLine($"[AssetsService] Resolved {_assetOverrideCount} duplicate asset IDs; workspace content takes precedence when present.");
+
             Changed?.Invoke();
+        }
+
+        void AddContentRootFolder(ProjectRoot root, int folderId, string rootPath, bool isReadOnly)
+        {
+            Folders.Add(new AssetFolder
+            {
+                ProjectRootId = root.Id,
+                Name = root.Name,
+                Id = folderId,
+                ParentFolderId = -1,
+                FullPath = rootPath,
+                IsReadOnly = isReadOnly
+            });
+        }
+
+        public bool CanModifyAsset(AssetFile? assetFile)
+        {
+            if (assetFile is null || assetFile.IsReadOnly || assetFile.AssetInfo is null)
+                return false;
+
+            if (!ProjectContentPathPolicy.IsInsideRoot(CurrentProjectRootPath, assetFile.AssetInfo.FullName))
+                return false;
+
+            return assetFile.Asset is null
+                || ProjectContentPathPolicy.IsInsideRoot(CurrentProjectRootPath, assetFile.Asset.FullName);
         }
 
         static string GetUniqueAssetName(string folderPath, string baseName, string extension)
@@ -212,7 +307,7 @@ namespace SailorEditor.Services
             yaml.Save(writer, false);
         }
 
-        private AssetFile ReadAssetFile(FileInfo assetInfo, int parentFolderId)
+        private AssetFile ReadAssetFile(FileInfo assetInfo, int parentFolderId, int projectRootId, bool isReadOnly)
         {
             FileInfo assetFile = new(Path.ChangeExtension(assetInfo.FullName, null));
 
@@ -246,13 +341,15 @@ namespace SailorEditor.Services
                 engineTypes?.AssetTypesByExtension?.TryGetValue(extension.TrimStart('.').ToLowerInvariant(), out assetType);
             }
 
-            newAssetFile.Id = Files.Count + 1;
+            newAssetFile.Id = _nextAssetId++;
             newAssetFile.DisplayName = assetFile.Name;
             newAssetFile.FolderId = parentFolderId;
+            newAssetFile.ProjectRootId = projectRootId;
             newAssetFile.AssetInfo = assetInfo;
             newAssetFile.Asset = assetFile;
             newAssetFile.AssetType = assetType;
             newAssetFile.IsDirty = false;
+            newAssetFile.IsReadOnly = isReadOnly;
 
             _ = newAssetFile.Revert();
 
@@ -352,34 +449,55 @@ namespace SailorEditor.Services
             }
         }
 
-        private void ReadDirectory(ProjectRoot root, string directoryPath, int parentFolderId)
+        private void ReadDirectory(
+            ProjectRoot root,
+            string rootPath,
+            string directoryPath,
+            int parentFolderId,
+            bool useRootedFolderIds,
+            bool isReadOnly)
         {
-            foreach (var directory in Directory.GetDirectories(directoryPath))
+            var canonicalDirectoryPath = ProjectContentPathPolicy.NormalizeRoot(directoryPath);
+            var visitKey = $"{root.Id}:{canonicalDirectoryPath}";
+            if (!ProjectContentPathPolicy.IsInsideRoot(rootPath, canonicalDirectoryPath) || !_visitedDirectories.Add(visitKey))
+                return;
+
+            foreach (var directory in Directory.GetDirectories(directoryPath).Order(ProjectContentPathPolicy.PathComparer))
             {
+                var canonicalChildPath = ProjectContentPathPolicy.NormalizeRoot(directory);
+                if (!ProjectContentPathPolicy.IsInsideRoot(rootPath, canonicalChildPath)
+                    || _visitedDirectories.Contains($"{root.Id}:{canonicalChildPath}"))
+                    continue;
+
                 var dirInfo = new DirectoryInfo(directory);
-                var relativeDirectoryPath = Path.GetRelativePath(CurrentProjectRootPath, directory);
+                var relativeDirectoryPath = Path.GetRelativePath(rootPath, directory);
                 var folder = new AssetFolder
                 {
                     ProjectRootId = root.Id,
                     Name = dirInfo.Name,
-                    Id = ProjectContentFolderIds.FromRelativePath(relativeDirectoryPath),
-                    ParentFolderId = parentFolderId
+                    Id = _folderIdAllocator.Allocate(root.Id, relativeDirectoryPath, useRootedFolderIds),
+                    ParentFolderId = parentFolderId,
+                    FullPath = canonicalChildPath,
+                    IsReadOnly = isReadOnly
                 };
 
                 Folders.Add(folder);
 
-                ReadDirectory(root, directory, folder.Id);
+                ReadDirectory(root, rootPath, directory, folder.Id, useRootedFolderIds, isReadOnly);
             }
 
-            foreach (var file in Directory.GetFiles(directoryPath))
+            foreach (var file in Directory.GetFiles(directoryPath).Order(ProjectContentPathPolicy.PathComparer))
             {
+                if (!ProjectContentPathPolicy.IsInsideRoot(rootPath, file))
+                    continue;
+
                 var assetInfo = new FileInfo(file);
-                if (assetInfo.Extension != ".asset")
+                if (!string.Equals(assetInfo.Extension, ".asset", StringComparison.OrdinalIgnoreCase))
                     continue;
 
                 try
                 {
-                    var newAssetInfo = ReadAssetFile(assetInfo, parentFolderId);
+                    var newAssetInfo = ReadAssetFile(assetInfo, parentFolderId, root.Id, isReadOnly);
                     TryPopulateAssetMetadataFromYaml(newAssetInfo);
                     if (newAssetInfo.FileId == null || newAssetInfo.FileId.IsEmpty())
                     {
@@ -387,7 +505,19 @@ namespace SailorEditor.Services
                         continue;
                     }
 
-                    Assets[newAssetInfo.FileId] = newAssetInfo;
+                    Files.Add(newAssetInfo);
+                    if (Assets.ContainsKey(newAssetInfo.FileId))
+                    {
+                        _assetOverrideCount++;
+                        if (ProjectContentAssetResolutionPolicy.ShouldReplace(
+                            Assets[newAssetInfo.FileId].IsReadOnly,
+                            newAssetInfo.IsReadOnly))
+                            Assets[newAssetInfo.FileId] = newAssetInfo;
+                    }
+                    else
+                    {
+                        Assets.Add(newAssetInfo.FileId, newAssetInfo);
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -395,5 +525,6 @@ namespace SailorEditor.Services
                 }
             }
         }
+
     }
 }

--- a/Editor/Services/EditorToolbarActions.cs
+++ b/Editor/Services/EditorToolbarActions.cs
@@ -17,6 +17,10 @@ namespace SailorEditor.Services
 
             switch (selected)
             {
+                case AssetFile { IsReadOnly: true } readOnlyAsset:
+                    await DisplayStatus("Save", $"{readOnlyAsset.DisplayName} belongs to read-only engine content.");
+                    return;
+
                 case AssetFile assetFile when assetFile.IsDirty:
                     await Task.Yield();
                     await assetFile.Save();
@@ -39,7 +43,7 @@ namespace SailorEditor.Services
                     return;
             }
 
-            var dirtyAsset = MauiProgram.GetService<AssetsService>().Files.FirstOrDefault(x => x.IsDirty);
+            var dirtyAsset = MauiProgram.GetService<AssetsService>().Files.FirstOrDefault(x => x.IsDirty && !x.IsReadOnly);
             if (dirtyAsset != null)
             {
                 await dirtyAsset.Save();

--- a/Editor/Services/WorkspaceUiService.cs
+++ b/Editor/Services/WorkspaceUiService.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Maui.Storage;
+using SailorEditor.Content;
 using SailorEditor.Shell;
 using SailorEditor.Workspace;
 
@@ -140,7 +141,11 @@ internal sealed class WorkspaceUiService
 
         await RefreshAsync(cancellationToken);
         if (result.Session is not null)
+        {
+            if (!ProjectContentPathPolicy.IsSamePath(_assetsService.CurrentProjectRootPath, result.Session.ContentDirectory))
+                MauiProgram.GetService<SelectionService>().ClearSelection();
             _assetsService.AddProjectRoot(result.Session.ContentDirectory);
+        }
         MauiProgram.GetService<EditorShellHost>().SetStatus(successMessage);
 #if MACCATALYST
         SailorEditor.AppDelegate.RequestMenuRebuild();

--- a/Editor/Services/WorldService.cs
+++ b/Editor/Services/WorldService.cs
@@ -180,7 +180,8 @@ namespace SailorEditor.Services
         public bool SaveCurrentWorld()
         {
             var worldAsset = CurrentWorldAsset ?? ResolveCurrentWorldAsset();
-            if (worldAsset?.Asset?.FullName == null)
+            var assetsService = MauiProgram.GetService<AssetsService>();
+            if (worldAsset?.Asset?.FullName == null || !assetsService.CanModifyAsset(worldAsset))
             {
                 return false;
             }
@@ -210,12 +211,11 @@ namespace SailorEditor.Services
         WorldFile ResolveCurrentWorldAsset()
         {
             var assets = MauiProgram.GetService<AssetsService>();
-            var byName = assets.Files
-                .OfType<WorldFile>()
+            var resolvedWorldAssets = assets.Assets.Values.OfType<WorldFile>();
+            var byName = resolvedWorldAssets
                 .FirstOrDefault(x => string.Equals(Path.GetFileNameWithoutExtension(x.Asset?.Name), Current?.Name, StringComparison.OrdinalIgnoreCase));
 
-            CurrentWorldAsset = byName ?? assets.Files
-                .OfType<WorldFile>()
+            CurrentWorldAsset = byName ?? resolvedWorldAssets
                 .FirstOrDefault(x => string.Equals(x.Asset?.Name, "Editor.world", StringComparison.OrdinalIgnoreCase));
 
             return CurrentWorldAsset;

--- a/Editor/ViewModels/AssetFile.cs
+++ b/Editor/ViewModels/AssetFile.cs
@@ -43,6 +43,9 @@ public partial class AssetFile : ObservableObject, ICloneable
     public int FolderId { get; set; }
 
     [YamlIgnore]
+    public int ProjectRootId { get; set; }
+
+    [YamlIgnore]
     public bool CanOpenAssetFile { get => !IsDirty; }
 
     [YamlIgnore]
@@ -72,6 +75,8 @@ public partial class AssetFile : ObservableObject, ICloneable
 
     public virtual Task Save()
     {
+        EnsureWritable();
+
         if (!AssetProperties.Any())
         {
             return Save(new AssetFileYamlConverter());
@@ -454,6 +459,9 @@ public partial class AssetFile : ObservableObject, ICloneable
     public bool IsLoaded { get; set; }
 
     [YamlIgnore]
+    public bool IsReadOnly { get; set; }
+
+    [YamlIgnore]
     public bool IsDirty
     {
         get => isDirty;
@@ -489,6 +497,8 @@ public partial class AssetFile : ObservableObject, ICloneable
 
     protected Task Save(IYamlTypeConverter converter)
     {
+        EnsureWritable();
+
         using (var yamlAssetInfo = new FileStream(AssetInfo.FullName, FileMode.Create))
         using (var writer = new StreamWriter(yamlAssetInfo))
         {
@@ -502,6 +512,12 @@ public partial class AssetFile : ObservableObject, ICloneable
 
         IsDirty = false;
         return Task.CompletedTask;
+    }
+
+    protected void EnsureWritable()
+    {
+        if (IsReadOnly)
+            throw new InvalidOperationException($"{DisplayName} belongs to read-only engine content.");
     }
 }
 

--- a/Editor/ViewModels/AssetFolder.cs
+++ b/Editor/ViewModels/AssetFolder.cs
@@ -3,7 +3,9 @@
 public class AssetFolder
 {
     public int Id { get; set; }
-    public string Name { get; set; }
+    public string Name { get; set; } = string.Empty;
     public int ParentFolderId { get; set; }
     public int ProjectRootId { get; set; }
+    public string FullPath { get; set; } = string.Empty;
+    public bool IsReadOnly { get; set; }
 }

--- a/Editor/ViewModels/FrameGraphFile.cs
+++ b/Editor/ViewModels/FrameGraphFile.cs
@@ -56,6 +56,7 @@ public partial class FrameGraphFile : AssetFile
 
     public override Task Save()
     {
+        EnsureWritable();
         SaveRendererAsset();
         return base.Save();
     }

--- a/Editor/ViewModels/MaterialFile.cs
+++ b/Editor/ViewModels/MaterialFile.cs
@@ -223,8 +223,7 @@ public partial class MaterialFile : AssetFile
                 {
                     var task = Task.Run(() =>
                     {
-                        var file = AssetService.Files.Find((el) => el.FileId == tex.Value.Value);
-                        if (file != null)
+                        if (AssetService.Assets.TryGetValue(tex.Value.Value, out var file))
                         {
                             _ = file.LoadDependentResources();
                         }
@@ -248,6 +247,8 @@ public partial class MaterialFile : AssetFile
 
     public override Task Save()
     {
+        EnsureWritable();
+
         using (var yamlAsset = new FileStream(Asset.FullName, FileMode.Create))
         using (var writer = new StreamWriter(yamlAsset))
         {

--- a/Editor/Views/ContentFolderView.xaml.cs
+++ b/Editor/Views/ContentFolderView.xaml.cs
@@ -62,6 +62,7 @@ namespace SailorEditor.Views
         {
             if (obj is not AssetFile file || file.FileId is null || file.FileId.IsEmpty())
             {
+                contentStore.SelectAsset(null);
                 suppressSelectionChanged = true;
                 try
                 {
@@ -75,7 +76,7 @@ namespace SailorEditor.Views
             }
 
             EnsureFolderVisible(file.FolderId);
-            contentStore.SelectAsset(file.FileId.Value);
+            contentStore.SelectAsset(file);
         }
 
         async void OnContentSelectionChanged(object sender, SelectionChangedEventArgs args)
@@ -118,7 +119,7 @@ namespace SailorEditor.Views
             {
                 case AssetFile assetFile:
                     MauiProgram.GetService<SelectionService>().SelectObject(assetFile, force: true);
-                    contentStore.SelectAsset(assetFile.FileId?.Value);
+                    contentStore.SelectAsset(assetFile);
                     await dispatcher.DispatchAsync(
                         new OpenAssetCommand(assetFile),
                         contextProvider.GetCurrentContext(new CommandOrigin(CommandOriginKind.Panel, nameof(ContentFolderView))));
@@ -138,6 +139,9 @@ namespace SailorEditor.Views
             {
                 return;
             }
+
+            if (target is AssetFolder { IsReadOnly: true } or AssetFile { IsReadOnly: true })
+                return;
 
             if (!e.Data.Properties.TryGetValue(EditorDragDrop.DragItemKey, out var source))
             {
@@ -334,10 +338,12 @@ namespace SailorEditor.Views
                         id,
                         depth,
                         folder.Name,
-                        isExpanded ? "folder_open_24.png" : "folder_24.png",
+                        folder.IsReadOnly ? "lock_24.png" : isExpanded ? "folder_open_24.png" : "folder_24.png",
                         HasChildren(foldersByParent, assetsByFolder, folder.Id),
                         isExpanded,
-                        projection.State.SelectedAssetFileId is null && projection.State.CurrentFolderId == folder.Id));
+                        projection.State.SelectedAssetPath is null
+                            && projection.State.SelectedAssetFileId is null
+                            && projection.State.CurrentFolderId == folder.Id));
 
                     if (isExpanded)
                     {
@@ -350,7 +356,8 @@ namespace SailorEditor.Views
             {
                 foreach (var asset in assets)
                 {
-                    var id = AssetRowId(asset.FileId.Value);
+                    var assetPath = GetAssetPath(asset);
+                    var id = AssetRowId(assetPath);
                     rowModelsById[id] = asset;
                     rows.Add(new ContentListRow(
                         id,
@@ -359,7 +366,7 @@ namespace SailorEditor.Views
                         GetAssetIcon(asset),
                         false,
                         false,
-                        string.Equals(projection.State.SelectedAssetFileId, asset.FileId.Value, StringComparison.Ordinal)));
+                        string.Equals(projection.State.SelectedAssetPath, assetPath, ProjectContentPathPolicy.PathComparison)));
                 }
             }
         }
@@ -439,7 +446,13 @@ namespace SailorEditor.Views
                 border.GestureRecognizers.Add(dragGesture);
 
                 var dropGesture = new DropGestureRecognizer();
-                dropGesture.DragOver += (_, e) => e.AcceptedOperation = DataPackageOperation.Copy;
+                dropGesture.DragOver += (_, e) =>
+                {
+                    var isReadOnly = border.BindingContext is ContentListRow row
+                        && rowModelsById.TryGetValue(row.Id, out var model)
+                        && model is AssetFolder { IsReadOnly: true } or AssetFile { IsReadOnly: true };
+                    e.AcceptedOperation = isReadOnly ? DataPackageOperation.None : DataPackageOperation.Copy;
+                };
                 dropGesture.Drop += async (_, e) =>
                 {
                     object target = null;
@@ -508,7 +521,7 @@ namespace SailorEditor.Views
         void ShowContextMenu(object model)
         {
             var contextMenu = MauiProgram.GetService<EditorContextMenuService>();
-            if (model is AssetFile assetFile)
+            if (model is AssetFile { IsReadOnly: false } assetFile)
             {
                 contextMenu.Show(
                     new EditorContextMenuItem
@@ -553,7 +566,9 @@ namespace SailorEditor.Views
         }
 
         static bool IsSelectedRoot(ProjectContentProjection projection)
-            => projection.State.SelectedAssetFileId is null && projection.State.CurrentFolderId is null;
+            => projection.State.SelectedAssetPath is null
+                && projection.State.SelectedAssetFileId is null
+                && projection.State.CurrentFolderId is null;
 
         static bool HasChildren(
             IReadOnlyDictionary<int, AssetFolder[]> foldersByParent,
@@ -577,7 +592,10 @@ namespace SailorEditor.Views
 
         static string FolderRowId(int folderId) => $"folder:{folderId}";
 
-        static string AssetRowId(string fileId) => $"asset:{fileId}";
+        static string AssetRowId(string assetPath) => $"asset:{assetPath}";
+
+        static string GetAssetPath(AssetFile asset)
+            => asset.AssetInfo?.FullName ?? asset.Asset?.FullName ?? $"asset-{asset.Id}";
 
         static bool TryParseFolderId(string id, out int folderId)
         {

--- a/Editor/Views/InspectorView.xaml.cs
+++ b/Editor/Views/InspectorView.xaml.cs
@@ -79,6 +79,7 @@ namespace SailorEditor.Views
                 if (content is View view)
                 {
                     view.BindingContext = inspectorProjection.SelectedItem;
+                    view.IsEnabled = inspectorProjection.SelectedItem is not AssetFile { IsReadOnly: true };
                     InspectedItemHost.Content = view;
                 }
             }


### PR DESCRIPTION
## Summary
- Mount active workspace `Content` and engine `Content` as distinct editor roots.
- Keep physical duplicates visible while resolving FileId lookups through an explicit workspace-over-engine precedence policy.
- Mark engine folders/assets read-only and enforce that boundary in commands, saves, world saves, drag/drop, and inspector editing.
- Canonicalize paths, prevent symlink escape/cycles, allocate collision-safe folder IDs, and clear stale asset selection on workspace switches.

## Root Cause
PR #87 validated active workspace projection but the production editor still replaced the repository content root entirely. That left the #76 requirement to retain engine content as an engine/library root incomplete.

Closes #76

## Developer Impact
- Workspace assets remain editable and override engine assets with the same FileId.
- Engine assets remain browsable under a locked library root.
- Repository-root fallback remains a single editable content root.

## Validation
- `/Users/aantropov/.dotnet/dotnet test Editor.Tests/Editor.Contracts.Tests.csproj` - passed, 109/109.
- `python3 build_editor.py --config Debug` - passed, 0 errors; existing 339 warnings remain.
- Temp-directory `AssetsService` smoke - passed, 23/23 assertions.
- `git diff --check` - passed.
- Tech Lead agent review - approved.
- Lead QA agent validation - approved.

## Residual Risk
- Interactive MAUI visual verification and Windows x64 junction behavior were not exercised.
- Runtime engine-content mounting is outside #76; this PR changes editor projection only.