### PR TITLE
[Workspace] Pass active workspace to engine launch

### DIFF
--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -42,6 +42,7 @@
     <Compile Include="EditorDragDropRoutingTests.cs" />
     <Compile Include="EditorDragDropTestStubs.cs" />
     <Compile Include="EditorPerfTests.cs" />
+    <Compile Include="EngineLaunchContractTests.cs" />
     <Compile Include="..\Editor\Panels\PanelContracts.cs" Link="Panels\PanelContracts.cs" />
     <Compile Include="..\Editor\Panels\PanelRegistry.cs" Link="Panels\PanelRegistry.cs" />
     <Compile Include="..\Editor\Layout\LayoutContracts.cs" Link="Layout\LayoutContracts.cs" />
@@ -68,5 +69,6 @@
     <Compile Include="..\Editor\Workflow\InspectorAutoCommitController.cs" Link="Workflow\InspectorAutoCommitController.cs" />
     <Compile Include="..\Editor\Utility\EditorDragDrop.cs" Link="Utility\EditorDragDrop.cs" />
     <Compile Include="..\Editor\Utility\EditorPerf.cs" Link="Utility\EditorPerf.cs" />
+    <Compile Include="..\Editor\Services\EngineLaunchContract.cs" Link="Services\EngineLaunchContract.cs" />
   </ItemGroup>
 </Project>

--- a/Editor.Tests/EngineLaunchContractTests.cs
+++ b/Editor.Tests/EngineLaunchContractTests.cs
@@ -1,0 +1,59 @@
+using SailorEditor.Services;
+
+public class EngineLaunchContractTests
+{
+    [Fact]
+    public void Resolve_UsesActiveWorkspaceRoot()
+    {
+        var fallbackRoot = Path.Combine(Path.GetTempPath(), "Sailor");
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), "Sailor Workspaces", "Sandbox");
+
+        var context = EngineLaunchContract.Resolve(workspaceRoot, fallbackRoot);
+
+        Assert.Equal(Path.GetFullPath(workspaceRoot), context.WorkspaceRoot);
+        Assert.Equal(Path.Combine(workspaceRoot, "Content"), context.ContentDirectory);
+        Assert.Equal(Path.Combine(workspaceRoot, "Cache"), context.CacheDirectory);
+        Assert.Equal(Path.Combine(workspaceRoot, "Cache", "Temp.world"), context.TempWorldFilePath);
+        Assert.Equal(Path.Combine(workspaceRoot, "Cache", "EngineTypes.yaml"), context.EngineTypesCacheFilePath);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Resolve_UsesFallbackWithoutActiveWorkspace(string? activeWorkspaceRoot)
+    {
+        var fallbackRoot = Path.Combine(Path.GetTempPath(), "Sailor");
+
+        var context = EngineLaunchContract.Resolve(activeWorkspaceRoot, fallbackRoot);
+
+        Assert.Equal(Path.GetFullPath(fallbackRoot), context.WorkspaceRoot);
+    }
+
+    [Fact]
+    public void BuildArguments_PreservesPathsWithSpacesAsSingleTokens()
+    {
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), "Sailor Workspaces", "Sandbox");
+        var context = EngineLaunchContract.Resolve(workspaceRoot, Path.GetTempPath());
+
+        var arguments = context.BuildArguments("../Cache/Temp world.world", ["--noconsole", "--editor"]);
+
+        Assert.Equal(
+            ["--workspace", Path.GetFullPath(workspaceRoot), "--world", "../Cache/Temp world.world", "--noconsole", "--editor"],
+            arguments);
+    }
+
+    [Fact]
+    public void BuildInteropArguments_KeepsWorldFlagAndValueSeparate()
+    {
+        var context = EngineLaunchContract.Resolve(Path.Combine(Path.GetTempPath(), "Sandbox"), Path.GetTempPath());
+
+        var arguments = context.BuildInteropArguments("SailorEditor", "Editor.world", ["--editor"]);
+
+        Assert.Equal("SailorEditor", arguments[0]);
+        Assert.Equal("--workspace", arguments[1]);
+        Assert.Equal("--world", arguments[3]);
+        Assert.Equal("Editor.world", arguments[4]);
+        Assert.DoesNotContain("--world Editor.world", arguments);
+    }
+}

--- a/Editor/Services/EditorToolbarActions.cs
+++ b/Editor/Services/EditorToolbarActions.cs
@@ -67,15 +67,13 @@ namespace SailorEditor.Services
 
             Task.Run(() =>
             {
+                var launchContext = engineService.GetLaunchContext();
                 string world = worldService.SerializeCurrentWorld();
+                Directory.CreateDirectory(launchContext.CacheDirectory);
 
-                using (var yamlAssetInfo = new FileStream(engineService.EngineCacheDirectory + "\\Temp.world", FileMode.OpenOrCreate))
-                using (var writer = new StreamWriter(yamlAssetInfo))
-                {
-                    writer.Write(world);
-                }
+                File.WriteAllText(launchContext.TempWorldFilePath, world);
 
-                engineService.RunWorld("../Cache/Temp.world", debug);
+                engineService.RunWorld("../Cache/Temp.world", debug, launchContext);
             });
         }
 

--- a/Editor/Services/EngineLaunchContract.cs
+++ b/Editor/Services/EngineLaunchContract.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+namespace SailorEditor.Services;
+
+public sealed record EngineLaunchContext(string WorkspaceRoot)
+{
+    public string ContentDirectory => Path.Combine(WorkspaceRoot, "Content");
+    public string CacheDirectory => Path.Combine(WorkspaceRoot, "Cache");
+    public string TempWorldFilePath => Path.Combine(CacheDirectory, "Temp.world");
+    public string EngineTypesCacheFilePath => Path.Combine(CacheDirectory, "EngineTypes.yaml");
+
+    public IReadOnlyList<string> BuildArguments(string world, IEnumerable<string>? extraArguments = null)
+    {
+        var arguments = new List<string>
+        {
+            "--workspace",
+            WorkspaceRoot,
+            "--world",
+            world
+        };
+
+        if (extraArguments is not null)
+            arguments.AddRange(extraArguments.Where(x => !string.IsNullOrWhiteSpace(x)));
+
+        return arguments;
+    }
+
+    public IReadOnlyList<string> BuildInteropArguments(
+        string executableToken,
+        string world,
+        IEnumerable<string>? extraArguments = null)
+        => new[] { executableToken }
+            .Concat(BuildArguments(world, extraArguments))
+            .ToArray();
+}
+
+public static class EngineLaunchContract
+{
+    public static EngineLaunchContext Resolve(string? activeWorkspaceRoot, string fallbackRoot)
+    {
+        var selectedRoot = string.IsNullOrWhiteSpace(activeWorkspaceRoot)
+            ? fallbackRoot
+            : activeWorkspaceRoot;
+
+        return new EngineLaunchContext(NormalizeRoot(selectedRoot));
+    }
+
+    static string NormalizeRoot(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var pathRoot = Path.GetPathRoot(fullPath);
+        return string.Equals(fullPath, pathRoot, PathComparison)
+            ? fullPath
+            : fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+}

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -3,7 +3,9 @@ using System.Runtime.InteropServices;
 using System.Diagnostics;
 using YamlDotNet.Serialization;
 using SailorEditor.Utility;
+using SailorEditor.Workspace;
 using System.Threading;
+using System.Globalization;
 
 namespace SailorEngine
 {
@@ -140,6 +142,12 @@ namespace SailorEditor.Services
         const int MaxBufferedConsoleMessages = 1000;
 
         readonly string repoRoot = ResolveRepoRoot();
+        readonly WorkspaceLifecycleService workspaceLifecycle;
+
+        public EngineService(WorkspaceLifecycleService workspaceLifecycle)
+        {
+            this.workspaceLifecycle = workspaceLifecycle;
+        }
 
         public string EngineContentDirectory => Path.Combine(repoRoot, "Content");
 
@@ -158,7 +166,10 @@ namespace SailorEditor.Services
 
         public string EngineWorkingDirectory => repoRoot + Path.DirectorySeparatorChar;
 
-        public string EngineTypesCacheFilePath => Path.Combine(repoRoot, "Cache", "EngineTypes.yaml");
+        public string EngineTypesCacheFilePath => GetLaunchContext().EngineTypesCacheFilePath;
+
+        public EngineLaunchContext GetLaunchContext()
+            => EngineLaunchContract.Resolve(workspaceLifecycle.Current?.WorkspaceRoot, EngineWorkingDirectory);
 
         public string PathToEngineExecDebug
         {
@@ -407,7 +418,7 @@ namespace SailorEditor.Services
 #endif
         }
 
-        public void RunProcess(bool bDebug, string commandlineArgs)
+        public void RunProcess(bool bDebug, params string[] commandLineArgs)
         {
 #if WINDOWS || MACCATALYST
             lock (runLock)
@@ -450,18 +461,32 @@ namespace SailorEditor.Services
                 return;
             }
 
-            string workspace = EngineWorkingDirectory.Replace("\\", "/");
+            var launchContext = GetLaunchContext();
 #if WINDOWS
-            string commandArgs = $"--noconsole --hwnd {handle} --editor " + commandlineArgs;
-            var args = new string[] { bDebug ? PathToEngineExecDebug : PathToEngineExec, "--workspace", workspace, "--world Editor.world" }.Concat(commandArgs.Split(" ", StringSplitOptions.RemoveEmptyEntries)).ToArray();
+            var extraArguments = new[]
+            {
+                "--noconsole",
+                "--hwnd",
+                handle.ToInt64().ToString(CultureInfo.InvariantCulture),
+                "--editor"
+            }.Concat(commandLineArgs ?? Array.Empty<string>());
+            var args = launchContext.BuildInteropArguments(
+                bDebug ? PathToEngineExecDebug : PathToEngineExec,
+                "Editor.world",
+                extraArguments).ToArray();
 #else
-            string commandArgs = $"--noconsole --editor {commandlineArgs}";
-            var args = new string[] { "SailorEditor", "--workspace", workspace, "--world", "Editor.world" }.Concat(commandArgs.Split(" ", StringSplitOptions.RemoveEmptyEntries)).ToArray();
+            var extraArguments = new[] { "--noconsole", "--editor" }
+                .Concat(commandLineArgs ?? Array.Empty<string>());
+            var args = launchContext.BuildInteropArguments(
+                "SailorEditor",
+                "Editor.world",
+                extraArguments).ToArray();
 #endif
+            Console.WriteLine($"Starting SailorEngine interop with workspace: {launchContext.WorkspaceRoot}");
 
             try
             {
-                TryLoadEngineTypesFromFile("startup cache");
+                TryLoadEngineTypesFromFile("startup cache", launchContext.EngineTypesCacheFilePath);
 
                 //ProcessStartInfo startInfo = new ProcessStartInfo
                 //{
@@ -499,12 +524,12 @@ namespace SailorEditor.Services
                     string serializedEngineTypes = SerializeEngineTypes();
                     if (!string.IsNullOrEmpty(serializedEngineTypes))
                     {
-                        SaveEngineTypesToFile(serializedEngineTypes);
+                        SaveEngineTypesToFile(serializedEngineTypes, launchContext.EngineTypesCacheFilePath);
                         EngineTypes = EngineTypes.FromYaml(serializedEngineTypes);
                     }
                     else
                     {
-                        TryLoadEngineTypesFromFile("empty interop export");
+                        TryLoadEngineTypesFromFile("empty interop export", launchContext.EngineTypesCacheFilePath);
                     }
 
                     string serializedWorld = SerializeWorld();
@@ -563,7 +588,7 @@ namespace SailorEditor.Services
                     catch (Exception ex)
                     {
                         Console.WriteLine($"SailorEngine task failed: {ex.Message}");
-                        TryLoadEngineTypesFromFile("engine startup failed");
+                        TryLoadEngineTypesFromFile("engine startup failed", launchContext.EngineTypesCacheFilePath);
                     }
                     finally
                     {
@@ -687,16 +712,16 @@ namespace SailorEditor.Services
             }
         }
 
-        bool TryLoadEngineTypesFromFile(string reason)
+        bool TryLoadEngineTypesFromFile(string reason, string cacheFilePath)
         {
             try
             {
-                if (!File.Exists(EngineTypesCacheFilePath))
+                if (!File.Exists(cacheFilePath))
                 {
                     return false;
                 }
 
-                string yaml = File.ReadAllText(EngineTypesCacheFilePath);
+                string yaml = File.ReadAllText(cacheFilePath);
                 if (string.IsNullOrWhiteSpace(yaml))
                 {
                     return false;
@@ -709,7 +734,7 @@ namespace SailorEditor.Services
                 }
 
                 EngineTypes = engineTypes;
-                Console.WriteLine($"Loaded engine types from cache ({reason}): {EngineTypesCacheFilePath}");
+                Console.WriteLine($"Loaded engine types from cache ({reason}): {cacheFilePath}");
                 return true;
             }
             catch (Exception ex)
@@ -719,7 +744,7 @@ namespace SailorEditor.Services
             }
         }
 
-        void SaveEngineTypesToFile(string yaml)
+        void SaveEngineTypesToFile(string yaml, string cacheFilePath)
         {
             if (string.IsNullOrWhiteSpace(yaml))
             {
@@ -728,13 +753,13 @@ namespace SailorEditor.Services
 
             try
             {
-                string directory = Path.GetDirectoryName(EngineTypesCacheFilePath);
+                string directory = Path.GetDirectoryName(cacheFilePath);
                 if (!string.IsNullOrEmpty(directory))
                 {
                     Directory.CreateDirectory(directory);
                 }
 
-                File.WriteAllText(EngineTypesCacheFilePath, yaml);
+                File.WriteAllText(cacheFilePath, yaml);
             }
             catch (Exception ex)
             {
@@ -947,21 +972,24 @@ namespace SailorEditor.Services
         }
 
         public void RunWorld(string world, bool bDebug)
+            => RunWorld(world, bDebug, GetLaunchContext());
+
+        public void RunWorld(string world, bool bDebug, EngineLaunchContext launchContext)
         {
             try
             {
-                string workspace = (EngineWorkingDirectory + Path.DirectorySeparatorChar).Replace("\\", "/");
-                string arguments = $"--workspace {workspace} --world {world}";
-
                 ProcessStartInfo startInfo = new ProcessStartInfo
                 {
                     FileName = bDebug ? PathToEngineExecDebug : PathToEngineExec,
-                    Arguments = arguments,
                     WorkingDirectory = EngineWorkingDirectory,
                     UseShellExecute = false
                 };
 
+                foreach (var argument in launchContext.BuildArguments(world))
+                    startInfo.ArgumentList.Add(argument);
+
                 Process process = new Process { StartInfo = startInfo };
+                Console.WriteLine($"Starting SailorEngine process with workspace: {launchContext.WorkspaceRoot}");
                 process.Start();
             }
             catch (Exception ex)

--- a/Editor/Views/SceneView.xaml.cs
+++ b/Editor/Views/SceneView.xaml.cs
@@ -213,7 +213,7 @@ namespace SailorEditor.Views
                     return;
                 }
 #endif
-                MauiProgram.GetService<EngineService>().RunProcess(false, "");
+                MauiProgram.GetService<EngineService>().RunProcess(false);
                 RequestNativeViewportLayout();
 
                 Dispatcher.StartTimer(TimeSpan.FromMilliseconds(50), () =>


### PR DESCRIPTION
Closes #77

## Summary
- resolve engine launches from the active workspace with repository-root fallback
- share one immutable launch context across embedded interop, standalone Play, engine-type cache, and temporary world output
- pass `--workspace` and `--world` as separate argument tokens so paths with spaces remain intact
- keep executable/library discovery rooted at the engine repository

## Runtime contract
The existing runtime flow remains unchanged: `ParseCommandLineArgs` populates `AppArgs.m_workspace`, `App::Initialize` normalizes it, and `AssetRegistry` derives workspace-relative `Content/` and `Cache/` paths.

## Validation
- `/Users/aantropov/.dotnet/dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --no-restore` (102/102)
- `python3 build_editor.py --config Debug` (0 warnings, 0 errors)
- `git diff --check`
- MacCatalyst launch smoke: embedded engine logged the repository fallback workspace and initialized successfully

## Residual risk
- Windows launch smoke is left to CI/manual validation.
- Retargeting an already-running embedded engine after workspace switching is out of scope and remains covered by #82.
- This branch is based on current `main`; #88 touches nearby editor content code but is not a functional dependency.