### PR TITLE
Fix editor content roots and Mac workspace menu

### DIFF
--- a/Editor.Tests/ProjectContentFolderIdsTests.cs
+++ b/Editor.Tests/ProjectContentFolderIdsTests.cs
@@ -30,7 +30,7 @@ public class ProjectContentFolderIdsTests
         var engineMaterials = ProjectContentFolderIds.FromRootedRelativePath(2, "Materials");
 
         Assert.NotEqual(workspaceMaterials, engineMaterials);
-        Assert.NotEqual(ProjectContentFolderIds.WorkspaceContentRootId, workspaceMaterials);
+        Assert.NotEqual(ProjectContentFolderIds.ContentRootId, workspaceMaterials);
         Assert.NotEqual(ProjectContentFolderIds.EngineContentRootId, engineMaterials);
     }
 
@@ -44,7 +44,7 @@ public class ProjectContentFolderIdsTests
         var allocated = allocator.Allocate(1, "Materials", useRootedFolderIds: true);
 
         Assert.NotEqual(original, allocated);
-        Assert.NotEqual(ProjectContentFolderIds.WorkspaceContentRootId, allocated);
+        Assert.NotEqual(ProjectContentFolderIds.ContentRootId, allocated);
         Assert.NotEqual(ProjectContentFolderIds.EngineContentRootId, allocated);
     }
 }

--- a/Editor.Tests/ProjectContentProjectionTests.cs
+++ b/Editor.Tests/ProjectContentProjectionTests.cs
@@ -44,6 +44,8 @@ public class ProjectContentProjectionTests
             new ProjectContentState(CurrentFolderId: 99));
 
         Assert.Null(projection.State.CurrentFolderId);
+        Assert.True(projection.IsRootVisible);
+        Assert.Equal(1, projection.TopLevelDepth);
         Assert.Equal(["Textures"], projection.VisibleFolders.Select(x => x.Name).ToArray());
         Assert.Single(projection.CurrentFolderAssets);
     }
@@ -86,8 +88,8 @@ public class ProjectContentProjectionTests
         var engineMaterialsId = ProjectContentFolderIds.FromRootedRelativePath(2, "Materials");
         var folders = new[]
         {
-            new ProjectContentFolderSnapshot(ProjectContentFolderIds.WorkspaceContentRootId, "Workspace Content", -1, workspaceRoot),
-            new ProjectContentFolderSnapshot(workspaceMaterialsId, "Materials", ProjectContentFolderIds.WorkspaceContentRootId, Path.Combine(workspaceRoot, "Materials")),
+            new ProjectContentFolderSnapshot(ProjectContentFolderIds.ContentRootId, "Content", -1, workspaceRoot),
+            new ProjectContentFolderSnapshot(workspaceMaterialsId, "Materials", ProjectContentFolderIds.ContentRootId, Path.Combine(workspaceRoot, "Materials")),
             new ProjectContentFolderSnapshot(ProjectContentFolderIds.EngineContentRootId, "Engine Content", -1, engineRoot, IsReadOnly: true),
             new ProjectContentFolderSnapshot(engineMaterialsId, "Materials", ProjectContentFolderIds.EngineContentRootId, Path.Combine(engineRoot, "Materials"), IsReadOnly: true),
         };
@@ -101,8 +103,31 @@ public class ProjectContentProjectionTests
         Assert.Equal(
             [Path.Combine(engineRoot, "Materials"), Path.Combine(workspaceRoot, "Materials")],
             projection.Folders.Where(x => x.Name == "Materials").Select(x => x.FullPath).Order(StringComparer.OrdinalIgnoreCase).ToArray());
+        Assert.False(projection.IsRootVisible);
+        Assert.Equal(0, projection.TopLevelDepth);
+        Assert.Equal(["Content", "Engine Content"], projection.VisibleFolders.Select(x => x.Name).ToArray());
         Assert.True(projection.Folders.Single(x => x.FolderId == ProjectContentFolderIds.EngineContentRootId).IsReadOnly);
-        Assert.False(projection.Folders.Single(x => x.FolderId == ProjectContentFolderIds.WorkspaceContentRootId).IsReadOnly);
+        Assert.False(projection.Folders.Single(x => x.FolderId == ProjectContentFolderIds.ContentRootId).IsReadOnly);
+    }
+
+    [Fact]
+    public void Build_ShowsEngineMountAtTopLevelWithoutWorkspace()
+    {
+        var engineRoot = Path.Combine(Path.DirectorySeparatorChar.ToString(), "repo", "Content");
+        var engineMaterialsId = ProjectContentFolderIds.FromRootedRelativePath(2, "Materials");
+        var projection = ProjectContentProjectionBuilder.Build(
+            engineRoot,
+            [
+                new ProjectContentFolderSnapshot(ProjectContentFolderIds.EngineContentRootId, "Engine Content", -1, engineRoot),
+                new ProjectContentFolderSnapshot(engineMaterialsId, "Materials", ProjectContentFolderIds.EngineContentRootId, Path.Combine(engineRoot, "Materials"))
+            ],
+            [],
+            new ProjectContentState());
+
+        Assert.False(projection.IsRootVisible);
+        Assert.Equal(0, projection.TopLevelDepth);
+        Assert.Equal(["Engine Content"], projection.VisibleFolders.Select(x => x.Name).ToArray());
+        Assert.DoesNotContain(projection.Folders, x => x.Name == "Content");
     }
 
     [Fact]

--- a/Editor/AppShell.xaml.cs
+++ b/Editor/AppShell.xaml.cs
@@ -43,13 +43,13 @@ namespace SailorEditor
             var history = MauiProgram.GetService<ICommandHistoryService>();
 
             var file = new MenuBarItem { Text = "File" };
+#if !MACCATALYST
             file.Add(CreateWorkspaceMenuItem("New Workspace...", () => _workspaceUi.NewWorkspaceAsync()));
             file.Add(CreateWorkspaceMenuItem("Open Workspace...", () => _workspaceUi.OpenWorkspaceAsync()));
             file.Add(CreateWorkspaceMenuItem("Save Workspace", () => _workspaceUi.SaveWorkspaceAsync()));
-#if !MACCATALYST
             file.Add(BuildRecentWorkspacesMenu());
-#endif
             file.Add(new MenuFlyoutSeparator());
+#endif
             file.Add(new MenuFlyoutItem { Text = "Undo", Command = new Command(async () => await history.UndoAsync(new CommandOrigin(CommandOriginKind.Menu, "Undo"))) });
             file.Add(new MenuFlyoutItem { Text = "Redo", Command = new Command(async () => await history.RedoAsync(new CommandOrigin(CommandOriginKind.Menu, "Redo"))) });
             file.Add(new MenuFlyoutSeparator());

--- a/Editor/Content/ProjectContentFolderIds.cs
+++ b/Editor/Content/ProjectContentFolderIds.cs
@@ -2,7 +2,7 @@ namespace SailorEditor.Content;
 
 public static class ProjectContentFolderIds
 {
-    public const int WorkspaceContentRootId = int.MaxValue - 1;
+    public const int ContentRootId = int.MaxValue - 1;
     public const int EngineContentRootId = int.MaxValue - 2;
 
     public static int FromRelativePath(string relativePath)
@@ -29,7 +29,7 @@ public static class ProjectContentFolderIds
         var id = (int)(hash & 0x7fffffff);
         if (id is 0 or -1)
             id = 1;
-        if (id is WorkspaceContentRootId or EngineContentRootId)
+        if (id is ContentRootId or EngineContentRootId)
             id -= 3;
 
         return id;
@@ -48,7 +48,7 @@ public sealed class ProjectContentFolderIdAllocator
     [
         0,
         -1,
-        ProjectContentFolderIds.WorkspaceContentRootId,
+        ProjectContentFolderIds.ContentRootId,
         ProjectContentFolderIds.EngineContentRootId
     ];
 

--- a/Editor/Content/ProjectContentModels.cs
+++ b/Editor/Content/ProjectContentModels.cs
@@ -43,8 +43,11 @@ public sealed record ProjectContentProjection(
     IReadOnlyList<ProjectContentFolderItem> Folders,
     IReadOnlyList<ProjectContentFolderItem> VisibleFolders,
     IReadOnlyList<ProjectContentAssetItem> VisibleAssets,
-    ProjectContentState State)
+    ProjectContentState State,
+    bool IsRootVisible)
 {
+    public int TopLevelDepth => IsRootVisible ? 1 : 0;
+
     public IReadOnlyList<ProjectContentFolderItem> CurrentFolderFolders => VisibleFolders;
 
     public IReadOnlyList<ProjectContentAssetItem> CurrentFolderAssets => VisibleAssets;
@@ -93,8 +96,14 @@ public static class ProjectContentProjectionBuilder
             folderItems,
             visibleFolders,
             assetItems,
-            normalizedState);
+            normalizedState,
+            IsRootVisible(folderItems));
     }
+
+    static bool IsRootVisible(IReadOnlyList<ProjectContentFolderItem> folders)
+        => !folders.Any(folder =>
+            (folder.FolderId is ProjectContentFolderIds.ContentRootId or ProjectContentFolderIds.EngineContentRootId) &&
+            folder.ParentFolderId == -1);
 
     static bool MatchesFolder(ProjectContentFolderItem folder, int? folderId) => (folderId ?? -1) == (folder.ParentFolderId ?? -1);
 

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -181,18 +181,21 @@ namespace SailorEditor.Services
             Root = new ProjectRoot { Name = CurrentProjectRootPath, Id = 1 };
             if (ProjectContentPathPolicy.IsSamePath(CurrentProjectRootPath, _engineContentDirectory))
             {
-                ReadDirectory(Root, CurrentProjectRootPath, CurrentProjectRootPath, -1, useRootedFolderIds: false, isReadOnly: false);
+                var engineRoot = new ProjectRoot { Name = "Engine Content", Id = EngineProjectRootId };
+
+                AddContentRootFolder(engineRoot, ProjectContentFolderIds.EngineContentRootId, _engineContentDirectory, isReadOnly: false);
+                ReadDirectory(engineRoot, _engineContentDirectory, _engineContentDirectory, ProjectContentFolderIds.EngineContentRootId, useRootedFolderIds: true, isReadOnly: false);
             }
             else
             {
-                var workspaceRoot = new ProjectRoot { Name = "Workspace Content", Id = ActiveProjectRootId };
+                var workspaceRoot = new ProjectRoot { Name = "Content", Id = ActiveProjectRootId };
                 var engineRoot = new ProjectRoot { Name = "Engine Content", Id = EngineProjectRootId };
 
-                AddContentRootFolder(workspaceRoot, ProjectContentFolderIds.WorkspaceContentRootId, CurrentProjectRootPath, isReadOnly: false);
+                AddContentRootFolder(workspaceRoot, ProjectContentFolderIds.ContentRootId, CurrentProjectRootPath, isReadOnly: false);
                 AddContentRootFolder(engineRoot, ProjectContentFolderIds.EngineContentRootId, _engineContentDirectory, isReadOnly: true);
 
                 ReadDirectory(engineRoot, _engineContentDirectory, _engineContentDirectory, ProjectContentFolderIds.EngineContentRootId, useRootedFolderIds: true, isReadOnly: true);
-                ReadDirectory(workspaceRoot, CurrentProjectRootPath, CurrentProjectRootPath, ProjectContentFolderIds.WorkspaceContentRootId, useRootedFolderIds: true, isReadOnly: false);
+                ReadDirectory(workspaceRoot, CurrentProjectRootPath, CurrentProjectRootPath, ProjectContentFolderIds.ContentRootId, useRootedFolderIds: true, isReadOnly: false);
             }
 
             if (_assetOverrideCount > 0)

--- a/Editor/Views/ContentFolderView.xaml.cs
+++ b/Editor/Views/ContentFolderView.xaml.cs
@@ -299,19 +299,26 @@ namespace SailorEditor.Views
                 .ToDictionary(x => x.Key, x => x.OrderBy(folder => folder.Name, StringComparer.OrdinalIgnoreCase).ToArray());
 
             var rows = new List<ContentListRow>();
-            rowModelsById[RootRowId] = projection.Root;
-            rows.Add(new ContentListRow(
-                RootRowId,
-                0,
-                projection.Root.Name,
-                "folder_open_24.png",
-                HasChildren(foldersByParent, assetsByFolder, -1),
-                isRootExpanded,
-                IsSelectedRoot(projection)));
-
-            if (isRootExpanded)
+            if (projection.IsRootVisible)
             {
-                AppendChildren(rows, foldersByParent, assetsByFolder, foldersById, -1, 1, projection);
+                rowModelsById[RootRowId] = projection.Root;
+                rows.Add(new ContentListRow(
+                    RootRowId,
+                    0,
+                    projection.Root.Name,
+                    "folder_open_24.png",
+                    HasChildren(foldersByParent, assetsByFolder, -1),
+                    isRootExpanded,
+                    IsSelectedRoot(projection)));
+
+                if (isRootExpanded)
+                {
+                    AppendChildren(rows, foldersByParent, assetsByFolder, foldersById, -1, projection.TopLevelDepth, projection);
+                }
+            }
+            else
+            {
+                AppendChildren(rows, foldersByParent, assetsByFolder, foldersById, -1, projection.TopLevelDepth, projection);
             }
 
             ReplaceRows(visibleRows, rows);
@@ -385,11 +392,10 @@ namespace SailorEditor.Views
                     TextColor = Color.FromArgb("#D7DCE2")
                 };
                 expandLabel.SetBinding(Label.TextProperty, nameof(ContentListRow.ExpandGlyph));
-                expandLabel.SetBinding(IsVisibleProperty, nameof(ContentListRow.HasChildren));
                 var expandTap = new TapGestureRecognizer();
                 expandTap.Tapped += (_, _) =>
                 {
-                    if (expandLabel.BindingContext is ContentListRow row)
+                    if (expandLabel.BindingContext is ContentListRow { HasChildren: true } row)
                     {
                         ToggleFolder(row);
                     }
@@ -616,6 +622,6 @@ namespace SailorEditor.Views
 
     public sealed record ContentListRow(string Id, int Depth, string Label, string Icon, bool HasChildren, bool IsExpanded, bool IsSelected)
     {
-        public string ExpandGlyph => IsExpanded ? "−" : "+";
+        public string ExpandGlyph => HasChildren ? (IsExpanded ? "−" : "+") : string.Empty;
     }
 }


### PR DESCRIPTION
## Summary

- show `Content` and `Engine Content` as sibling top-level roots in the Content Browser
- remove the redundant `Workspace Content` wrapper and hide the synthetic workspace root
- keep engine-only startup mounted as a top-level `Engine Content` root
- reserve the expander column for leaf rows so sibling roots remain visually aligned
- make the native MacCatalyst menu the sole owner of workspace commands, removing duplicate `New/Open/Save/Recent` entries
- update root IDs and projection coverage for single- and multi-root modes

## Root causes

The Content Browser always rendered an additional projection root, placing mounted content roots one level below it. After flattening the data hierarchy, an empty `Content` root still appeared shallower because its expander control was collapsed while the non-empty engine root retained that column.

On MacCatalyst, workspace commands were registered twice: once through MAUI `AppShell` menu items and once through the native `AppDelegate` menu builder.

## User impact

An opened workspace now displays exactly two aligned top-level roots: `Content` and `Engine Content`. Workspace assets map directly into `Content`; engine assets remain available through `Engine Content`. The File menu contains one workspace command group.

## Validation

- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --no-restore` — 116 passed
- `python3 run_editor.py --skip-engine --config Debug --no-launch` — succeeded (0 errors; existing warnings only)
- MacCatalyst File menu smoke test — one `New/Open/Save/Recent` group followed by `Undo/Redo`
- manual MacCatalyst content-root validation with `SailorWorkspace` — confirmed by user