### PR TITLE
[Build] Update pinned vcpkg for current MSYS2 packages

### DIFF
--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -31,16 +31,21 @@ jobs:
     - name: Update submodules
       run: git submodule update --init --recursive
 
+    - name: Resolve vcpkg revision
+      id: vcpkg
+      shell: pwsh
+      run: |
+        "revision=$(git -C $env:VCPKG_ROOT rev-parse HEAD)" >> $env:GITHUB_OUTPUT
+
     - name: Cache vcpkg installed packages
       uses: actions/cache@v4
       with:
         path: |
           ${{ env.VCPKG_ROOT }}/installed
           ${{ env.VCPKG_ROOT }}/packages
-        key: vcpkg-${{ runner.os }}-${{ matrix.compiler }}-installed-${{ env.BUILD_TYPE }}
+        key: vcpkg-${{ runner.os }}-${{ matrix.compiler }}-${{ steps.vcpkg.outputs.revision }}-installed-${{ env.BUILD_TYPE }}
         restore-keys: |
-          vcpkg-${{ runner.os }}-${{ matrix.compiler }}-installed-
-          vcpkg-${{ runner.os }}-installed-
+          vcpkg-${{ runner.os }}-${{ matrix.compiler }}-${{ steps.vcpkg.outputs.revision }}-installed-
 
     - name: Show CMake version
       run: cmake --version

--- a/update_deps.py
+++ b/update_deps.py
@@ -6,6 +6,36 @@ import sys
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 VCPKG_ROOT = os.path.join(SCRIPT_DIR, 'External', 'vcpkg')
+VCPKG_TOOL_METADATA = os.path.join(VCPKG_ROOT, 'scripts', 'vcpkg-tool-metadata.txt')
+
+
+def required_vcpkg_tool_release() -> str:
+    with open(VCPKG_TOOL_METADATA, encoding='utf-8-sig') as metadata:
+        for line in metadata:
+            key, separator, value = line.strip().partition('=')
+            if separator and key == 'VCPKG_TOOL_RELEASE_TAG':
+                return value
+
+    raise RuntimeError(f'Unable to read VCPKG_TOOL_RELEASE_TAG from {VCPKG_TOOL_METADATA}')
+
+
+def has_current_vcpkg_tool(vcpkg_exe: str, required_release: str) -> bool:
+    if not os.path.exists(vcpkg_exe):
+        return False
+
+    try:
+        result = subprocess.run(
+            [vcpkg_exe, 'version'],
+            cwd=VCPKG_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return False
+
+    first_line = result.stdout.partition('\n')[0]
+    return result.returncode == 0 and required_release in first_line
 
 
 def main() -> int:
@@ -17,8 +47,9 @@ def main() -> int:
         vcpkg_exe = os.path.join(VCPKG_ROOT, 'vcpkg')
         bootstrap_cmd = ['./bootstrap-vcpkg.sh']
 
-    if not os.path.exists(vcpkg_exe):
-        print('Bootstrap vcpkg...')
+    required_release = required_vcpkg_tool_release()
+    if not has_current_vcpkg_tool(vcpkg_exe, required_release):
+        print('Bootstrap vcpkg...', flush=True)
         subprocess.check_call(bootstrap_cmd, cwd=VCPKG_ROOT)
 
     def run_vcpkg(*args: str) -> None:


### PR DESCRIPTION
Closes #96

## What changed

- Updated the `External/vcpkg` git submodule from `37d46edf0f2024c3d04997a2d432d59278ca1dff` to the minimal official upstream MSYS2 fix, `6fa128f2b6e1dd260ebfb30fdb1c38a191369812` (microsoft/vcpkg#45839).
- Made `update_deps.py` compare the existing vcpkg tool with `scripts/vcpkg-tool-metadata.txt` and bootstrap when the executable is absent or stale.
- Added the exact vcpkg revision to the Windows package-cache key, preventing an old pin's installed-package cache from masking clean-install regressions.

## Why

The old pin requests `libtool-2.4.7-4`, which is no longer present on the configured MSYS2 mirrors. Windows CI for #91 and #92 therefore fails during dependency installation before CMake configure, build, or tests can run.

A normal developer `pull` leaves the ignored `vcpkg`/`vcpkg.exe` binary in the submodule directory. Without the tool-version check, updating the gitlink alone would keep running the old `2025-02-11` tool against a revision that expects `2025-06-02`.

## Impact and risk

The minimal fixed revision is 937 upstream commits newer and updates several direct port versions (`imgui`, `nlohmann-json`, `tbb`, `tinygltf`, and the `yaml-cpp` port revision), so both Windows compiler matrices must complete the entire workflow before merge.

## Validation

Local macOS arm64:
- plain `python3 update_deps.py`: passed;
- simulated existing `2025-02-11` vcpkg binary with the new submodule pin: the script detected it, bootstrapped `2025-06-02`, and completed dependency operations;
- Release engine configure, full build, and install with the updated packages: passed;
- CTest: 7/8 passed; the only failure is the known pre-existing `RemoteViewportMacTransportTests / ConcreteMacLoopbackProviderRecordsRendererOwnedSourceMetadata`;
- editor contracts: 139/139 passed;
- workflow YAML parse, Python byte-compile, and `git diff --check`: passed;
- generated-workspace integration is Windows-only and is covered by both CI matrix jobs.