### PR TITLE
[Workspace] Support custom game classes in editor

### DIFF
--- a/Docs/WorkspaceLogic.md
+++ b/Docs/WorkspaceLogic.md
@@ -118,6 +118,12 @@ The dynamic library is opened before asset importers scan `Content`. Static engi
 
 Standalone startup treats a configured module or requested-world activation failure as fatal and returns a nonzero exit code. Editor startup reports the same error but remains available with an empty world so the project can be repaired. During shutdown, worlds, importers, the asset registry, scheduler, and remaining submodules are destroyed before workspace registrations are removed and the library is closed. Runtime hot reload and live workspace switching are not supported by this contract.
 
+## Editor Type Metadata
+
+`SerializeEngineTypes` remains the legacy engine-only C export. Editor consumers use the distinct `SerializeEditorTypes` export, which starts from a fresh engine snapshot and appends the validated metadata of the active workspace module. The combined document keeps each custom component's fully-qualified `typename`, reflected properties, and default object values.
+
+The merge validates all four catalogs before publishing a result. Type and CDO identities use `typename`, enum identities use their map key, and asset-type identities use `typename`. Duplicate entries, engine/workspace collisions, malformed sections, or mismatched workspace type/default sets reject the complete merge without returning a partial catalog. A missing, failed, or unloaded workspace module produces a fresh engine-only editor snapshot so custom types cannot survive through stale runtime state.
+
 ## SDK Limitations
 
 `Sailor::Runtime` is a consistent CMake target name, not a cross-version C++ ABI guarantee. Build the engine and game module with compatible compiler versions, toolsets, configurations, and C runtime settings.

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -33,6 +33,7 @@
     <Compile Include="WorkspaceProjectGeneratorTests.cs" />
     <Compile Include="EngineTypeMetadataContractTests.cs" />
     <Compile Include="EditorTypeCatalogContractTests.cs" />
+    <Compile Include="NumericValueConverterTests.cs" />
     <Compile Include="WorkspaceUiProjectionTests.cs" />
     <Compile Include="AIOperatorTests.cs" />
     <Compile Include="SettingsContractsTests.cs" />
@@ -67,6 +68,9 @@
     <Compile Include="..\Editor\Utility\EditorComponentScalarCodec.cs" Link="Utility\EditorComponentScalarCodec.cs" />
     <Compile Include="..\Editor\Utility\EditorComponentPropertyContract.cs" Link="Utility\EditorComponentPropertyContract.cs" />
     <Compile Include="..\Editor\Utility\EditorComponentYamlContract.cs" Link="Utility\EditorComponentYamlContract.cs" />
+    <Compile Include="..\Editor\Controls\FloatValueConverter.cs" Link="Controls\FloatValueConverter.cs" />
+    <Compile Include="..\Editor\Controls\IntValueConverter.cs" Link="Controls\IntValueConverter.cs" />
+    <Compile Include="..\Editor\Controls\UIntValueConverter.cs" Link="Controls\UIntValueConverter.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceUiContracts.cs" Link="Workspace\WorkspaceUiContracts.cs" />
     <Compile Include="..\Editor\Shell\EditorShellContracts.cs" Link="Shell\EditorShellContracts.cs" />
     <Compile Include="..\Editor\Shell\EditorShellHost.cs" Link="Shell\EditorShellHost.cs" />

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -32,6 +32,7 @@
     <Compile Include="WorkspaceLifecycleTests.cs" />
     <Compile Include="WorkspaceProjectGeneratorTests.cs" />
     <Compile Include="EngineTypeMetadataContractTests.cs" />
+    <Compile Include="EditorTypeCatalogContractTests.cs" />
     <Compile Include="WorkspaceUiProjectionTests.cs" />
     <Compile Include="AIOperatorTests.cs" />
     <Compile Include="SettingsContractsTests.cs" />
@@ -63,6 +64,8 @@
     <Compile Include="..\Editor\Workspace\WorkspaceLifecycle.cs" Link="Workspace\WorkspaceLifecycle.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceProjectGenerator.cs" Link="Workspace\WorkspaceProjectGenerator.cs" />
     <Compile Include="..\Editor\Utility\EngineTypeMetadataContract.cs" Link="Utility\EngineTypeMetadataContract.cs" />
+    <Compile Include="..\Editor\Utility\EditorComponentScalarCodec.cs" Link="Utility\EditorComponentScalarCodec.cs" />
+    <Compile Include="..\Editor\Utility\EditorComponentYamlContract.cs" Link="Utility\EditorComponentYamlContract.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceUiContracts.cs" Link="Workspace\WorkspaceUiContracts.cs" />
     <Compile Include="..\Editor\Shell\EditorShellContracts.cs" Link="Shell\EditorShellContracts.cs" />
     <Compile Include="..\Editor\Shell\EditorShellHost.cs" Link="Shell\EditorShellHost.cs" />

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="..\Editor\Workspace\WorkspaceProjectGenerator.cs" Link="Workspace\WorkspaceProjectGenerator.cs" />
     <Compile Include="..\Editor\Utility\EngineTypeMetadataContract.cs" Link="Utility\EngineTypeMetadataContract.cs" />
     <Compile Include="..\Editor\Utility\EditorComponentScalarCodec.cs" Link="Utility\EditorComponentScalarCodec.cs" />
+    <Compile Include="..\Editor\Utility\EditorComponentPropertyContract.cs" Link="Utility\EditorComponentPropertyContract.cs" />
     <Compile Include="..\Editor\Utility\EditorComponentYamlContract.cs" Link="Utility\EditorComponentYamlContract.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceUiContracts.cs" Link="Workspace\WorkspaceUiContracts.cs" />
     <Compile Include="..\Editor\Shell\EditorShellContracts.cs" Link="Shell\EditorShellContracts.cs" />

--- a/Editor.Tests/EditorTypeCatalogContractTests.cs
+++ b/Editor.Tests/EditorTypeCatalogContractTests.cs
@@ -15,6 +15,16 @@ public sealed class EditorTypeCatalogContractTests
         Assert.True(snapshot.TryGetType("SandboxLogic::SampleComponent", out var customType));
         Assert.Equal("Sailor::Component", customType.Base);
         Assert.Equal("float", customType.Properties["moveSpeed"]);
+        Assert.Equal("enum SandboxLogic::ESampleMode", customType.Properties["mode"]);
+        Assert.True(snapshot.IsKnownReadOnlyProperty(
+            "SandboxLogic::SampleComponent",
+            "readOnlyValue"));
+        Assert.True(snapshot.IsKnownReadOnlyProperty(
+            "SandboxLogic::SampleComponent",
+            "skippedReadOnlyValue"));
+        Assert.False(snapshot.IsKnownReadOnlyProperty(
+            "SandboxLogic::SampleComponent",
+            "moveSpeed"));
         Assert.True(snapshot.IsComponentType("SandboxLogic::SampleComponent"));
         Assert.Equal(
             ["SandboxLogic::SampleComponent"],
@@ -27,6 +37,58 @@ public sealed class EditorTypeCatalogContractTests
                 defaults.DefaultValues["orientation"],
                 4,
                 "SandboxLogic::SampleComponent.orientation"));
+        Assert.Equal(
+            ["Default", "Alternate"],
+            Assert.Single(snapshot.Document.Enums)["enum SandboxLogic::ESampleMode"]);
+    }
+
+    [Fact]
+    public void Parse_RejectsPropertyWhoseEnumMetadataIsMissing()
+    {
+        const string yaml = """
+engineTypes:
+  - typename: Sailor::Component
+    base: Sailor::IReflectable
+    properties: {}
+  - typename: SandboxLogic::SampleComponent
+    base: Sailor::Component
+    properties:
+      mode: enum SandboxLogic::ESampleMode
+cdos: []
+enums: []
+assetTypes: []
+""";
+
+        var error = Assert.Throws<InvalidDataException>(() => EditorTypeCatalogSnapshot.Parse(yaml));
+
+        Assert.Contains("missing enum metadata 'enum SandboxLogic::ESampleMode'", error.Message);
+    }
+
+    [Fact]
+    public void ComponentPropertyContract_DistinguishesWritableReadOnlyAndUnknownProperties()
+    {
+        var writable = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["moveSpeed"] = "float"
+        };
+        var readOnly = new HashSet<string>(StringComparer.Ordinal)
+        {
+            "readOnlyValue",
+            "skippedReadOnlyValue"
+        };
+
+        Assert.Equal(
+            EditorComponentPropertyAccess.Writable,
+            EditorComponentPropertyContract.Classify("moveSpeed", writable, readOnly));
+        Assert.Equal(
+            EditorComponentPropertyAccess.ReadOnly,
+            EditorComponentPropertyContract.Classify("readOnlyValue", writable, readOnly));
+        Assert.Equal(
+            EditorComponentPropertyAccess.ReadOnly,
+            EditorComponentPropertyContract.Classify("skippedReadOnlyValue", writable, readOnly));
+        Assert.Equal(
+            EditorComponentPropertyAccess.Unknown,
+            EditorComponentPropertyContract.Classify("typo", writable, readOnly));
     }
 
     [Fact]
@@ -131,6 +193,8 @@ overrideProperties:
   moveSpeed: 12.5
   enabled: true
   retries: 3
+  readOnlyValue: 17
+  skippedReadOnlyValue: 23
 typename: SandboxLogic::SampleComponent
 """;
         var serializer = new SerializerBuilder()
@@ -153,6 +217,12 @@ typename: SandboxLogic::SampleComponent
         Assert.Equal(3, (int)EditorComponentScalarCodec.Parse(
             EditorComponentScalarKind.Int32,
             Convert.ToString(roundTrip.OverrideProperties["retries"], CultureInfo.InvariantCulture)));
+        Assert.Equal(17, Convert.ToInt32(
+            roundTrip.OverrideProperties["readOnlyValue"],
+            CultureInfo.InvariantCulture));
+        Assert.Equal(23, Convert.ToInt32(
+            roundTrip.OverrideProperties["skippedReadOnlyValue"],
+            CultureInfo.InvariantCulture));
     }
 
     const string CombinedCatalogYaml = """
@@ -170,12 +240,17 @@ engineTypes:
     properties:
       moveSpeed: float
       orientation: struct glm::qua<float,0>
+      mode: enum SandboxLogic::ESampleMode
+    readOnlyProperties: [readOnlyValue, skippedReadOnlyValue]
 cdos:
   - typename: SandboxLogic::SampleComponent
     defaultValues:
       moveSpeed: 5
       orientation: [0, 0.25, 0.5, 1]
-enums: []
+      mode: Default
+      readOnlyValue: 17
+enums:
+  - enum SandboxLogic::ESampleMode: [Default, Alternate]
 assetTypes: []
 """;
 }

--- a/Editor.Tests/EditorTypeCatalogContractTests.cs
+++ b/Editor.Tests/EditorTypeCatalogContractTests.cs
@@ -65,6 +65,32 @@ assetTypes: []
     }
 
     [Fact]
+    public void Parse_RejectsEnumDefaultOutsideDeclaredValues()
+    {
+        var yaml = CombinedCatalogYaml.Replace("mode: Default", "mode: NotARealMode", StringComparison.Ordinal);
+
+        var error = Assert.Throws<InvalidDataException>(() => EditorTypeCatalogSnapshot.Parse(yaml));
+
+        Assert.Contains("NotARealMode", error.Message);
+        Assert.Contains("SandboxLogic::SampleComponent.mode", error.Message);
+    }
+
+    [Fact]
+    public void ComponentPropertyContract_RejectsEnumOverrideOutsideDeclaredValues()
+    {
+        var error = Assert.Throws<InvalidDataException>(() =>
+            EditorComponentPropertyContract.ValidateEnumValue(
+                "SandboxLogic::SampleComponent",
+                "mode",
+                "enum SandboxLogic::ESampleMode",
+                "NotARealMode",
+                ["Default", "Alternate"]));
+
+        Assert.Contains("NotARealMode", error.Message);
+        Assert.Contains("SandboxLogic::SampleComponent.mode", error.Message);
+    }
+
+    [Fact]
     public void ComponentPropertyContract_DistinguishesWritableReadOnlyAndUnknownProperties()
     {
         var writable = new Dictionary<string, string>(StringComparer.Ordinal)

--- a/Editor.Tests/EditorTypeCatalogContractTests.cs
+++ b/Editor.Tests/EditorTypeCatalogContractTests.cs
@@ -1,0 +1,181 @@
+using System.Globalization;
+using SailorEngine;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SailorEditor.Editor.Tests;
+
+public sealed class EditorTypeCatalogContractTests
+{
+    [Fact]
+    public void Parse_CombinedCatalogPreservesCustomFullyQualifiedType()
+    {
+        var snapshot = EditorTypeCatalogSnapshot.Parse(CombinedCatalogYaml);
+
+        Assert.True(snapshot.TryGetType("SandboxLogic::SampleComponent", out var customType));
+        Assert.Equal("Sailor::Component", customType.Base);
+        Assert.Equal("float", customType.Properties["moveSpeed"]);
+        Assert.True(snapshot.IsComponentType("SandboxLogic::SampleComponent"));
+        Assert.Equal(
+            ["SandboxLogic::SampleComponent"],
+            snapshot.GetComponentTypeNames());
+
+        var defaults = snapshot.Document.Cdos.Single(x => x.Typename == "SandboxLogic::SampleComponent");
+        Assert.Equal(
+            [0.0f, 0.25f, 0.5f, 1.0f],
+            EditorTypeMetadataValueCodec.ParseFloatSequence(
+                defaults.DefaultValues["orientation"],
+                4,
+                "SandboxLogic::SampleComponent.orientation"));
+    }
+
+    [Fact]
+    public void Parse_RejectsDuplicateTypeWithoutReturningPartialCatalog()
+    {
+        const string yaml = """
+engineTypes:
+  - typename: Sailor::Component
+    base: Sailor::IReflectable
+  - typename: Sailor::Component
+    base: Sailor::IReflectable
+cdos: []
+enums: []
+assetTypes: []
+""";
+
+        var error = Assert.Throws<InvalidDataException>(() => EditorTypeCatalogSnapshot.Parse(yaml));
+
+        Assert.Contains("Duplicate type 'Sailor::Component'", error.Message);
+    }
+
+    [Fact]
+    public void ComponentQuery_HandlesMissingBaseAndCycles()
+    {
+        const string yaml = """
+engineTypes:
+  - typename: MissingBaseComponent
+    base: DoesNotExist
+  - typename: CycleA
+    base: CycleB
+  - typename: CycleB
+    base: CycleA
+cdos: []
+enums: []
+assetTypes: []
+""";
+
+        var snapshot = EditorTypeCatalogSnapshot.Parse(yaml);
+
+        Assert.False(snapshot.IsComponentType("MissingBaseComponent"));
+        Assert.False(snapshot.IsComponentType("CycleA"));
+        Assert.False(snapshot.IsComponentType("CycleB"));
+        Assert.False(snapshot.IsComponentType("UnknownComponent"));
+        Assert.Empty(snapshot.GetComponentTypeNames());
+    }
+
+    [Theory]
+    [InlineData(EditorComponentScalarKind.String, "true: still text")]
+    [InlineData(EditorComponentScalarKind.Boolean, "true")]
+    [InlineData(EditorComponentScalarKind.Int32, "-42")]
+    [InlineData(EditorComponentScalarKind.UInt32, "42")]
+    [InlineData(EditorComponentScalarKind.Float, "3.125")]
+    public void ScalarCodec_RoundTripsWithoutCurrentCultureLoss(
+        EditorComponentScalarKind kind,
+        string serializedValue)
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            var value = EditorComponentScalarCodec.Parse(kind, serializedValue);
+            var roundTrip = EditorComponentScalarCodec.Format(kind, value);
+
+            Assert.Equal(serializedValue, roundTrip);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+    }
+
+    [Fact]
+    public void ScalarCodec_RejectsInvalidPrimitiveInsteadOfSubstitutingDefault()
+    {
+        var error = Assert.Throws<InvalidDataException>(() =>
+            EditorComponentScalarCodec.Parse(EditorComponentScalarKind.Int32, "not-an-int"));
+
+        Assert.Contains("not-an-int", error.Message);
+    }
+
+    [Fact]
+    public void ScalarCodec_RejectsNegativeUnsignedValue()
+    {
+        Assert.Throws<InvalidDataException>(() =>
+            EditorComponentScalarCodec.Parse(EditorComponentScalarKind.UInt32, "-1"));
+    }
+
+    [Fact]
+    public void MetadataValueCodec_RejectsMalformedSequence()
+    {
+        Assert.Throws<InvalidDataException>(() =>
+            EditorTypeMetadataValueCodec.ParseFloatSequence(new object[] { 1, "invalid" }, 2, "rotation"));
+        Assert.Throws<InvalidDataException>(() =>
+            EditorTypeMetadataValueCodec.ParseFloatSequence(new object[] { 1, 2, 3 }, 4, "rotation"));
+    }
+
+    [Fact]
+    public void ComponentContract_PreservesFqnAndScalarsRegardlessOfKeyOrder()
+    {
+        const string yaml = """
+overrideProperties:
+  moveSpeed: 12.5
+  enabled: true
+  retries: 3
+typename: SandboxLogic::SampleComponent
+""";
+        var serializer = new SerializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build();
+        var deserializer = new DeserializerBuilder()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build();
+
+        var document = deserializer.Deserialize<EditorComponentYamlContract>(yaml);
+        var roundTrip = deserializer.Deserialize<EditorComponentYamlContract>(serializer.Serialize(document));
+
+        Assert.Equal("SandboxLogic::SampleComponent", roundTrip.Typename);
+        Assert.Equal(12.5f, (float)EditorComponentScalarCodec.Parse(
+            EditorComponentScalarKind.Float,
+            Convert.ToString(roundTrip.OverrideProperties["moveSpeed"], CultureInfo.InvariantCulture)));
+        Assert.True((bool)EditorComponentScalarCodec.Parse(
+            EditorComponentScalarKind.Boolean,
+            Convert.ToString(roundTrip.OverrideProperties["enabled"], CultureInfo.InvariantCulture)));
+        Assert.Equal(3, (int)EditorComponentScalarCodec.Parse(
+            EditorComponentScalarKind.Int32,
+            Convert.ToString(roundTrip.OverrideProperties["retries"], CultureInfo.InvariantCulture)));
+    }
+
+    const string CombinedCatalogYaml = """
+metadataVersion: 1
+moduleName: SailorEditor
+engineTypes:
+  - typename: Sailor::IReflectable
+    base: ''
+    properties: {}
+  - typename: Sailor::Component
+    base: Sailor::IReflectable
+    properties: {}
+  - typename: SandboxLogic::SampleComponent
+    base: Sailor::Component
+    properties:
+      moveSpeed: float
+      orientation: struct glm::qua<float,0>
+cdos:
+  - typename: SandboxLogic::SampleComponent
+    defaultValues:
+      moveSpeed: 5
+      orientation: [0, 0.25, 0.5, 1]
+enums: []
+assetTypes: []
+""";
+}

--- a/Editor.Tests/EngineLaunchContractTests.cs
+++ b/Editor.Tests/EngineLaunchContractTests.cs
@@ -7,14 +7,16 @@ public class EngineLaunchContractTests
     {
         var fallbackRoot = Path.Combine(Path.GetTempPath(), "Sailor");
         var workspaceRoot = Path.Combine(Path.GetTempPath(), "Sailor Workspaces", "Sandbox");
+        var manifestPath = Path.Combine(workspaceRoot, "Sandbox Project.sailor");
 
-        var context = EngineLaunchContract.Resolve(workspaceRoot, fallbackRoot);
+        var context = EngineLaunchContract.Resolve(workspaceRoot, manifestPath, fallbackRoot);
 
         Assert.Equal(Path.GetFullPath(workspaceRoot), context.WorkspaceRoot);
+        Assert.Equal(Path.GetFullPath(manifestPath), context.WorkspaceManifestPath);
         Assert.Equal(Path.Combine(workspaceRoot, "Content"), context.ContentDirectory);
         Assert.Equal(Path.Combine(workspaceRoot, "Cache"), context.CacheDirectory);
         Assert.Equal(Path.Combine(workspaceRoot, "Cache", "Temp.world"), context.TempWorldFilePath);
-        Assert.Equal(Path.Combine(workspaceRoot, "Cache", "EngineTypes.yaml"), context.EngineTypesCacheFilePath);
+        Assert.Equal(Path.Combine(workspaceRoot, "Cache", "EditorTypes.yaml"), context.EditorTypesCacheFilePath);
     }
 
     [Theory]
@@ -34,12 +36,22 @@ public class EngineLaunchContractTests
     public void BuildArguments_PreservesPathsWithSpacesAsSingleTokens()
     {
         var workspaceRoot = Path.Combine(Path.GetTempPath(), "Sailor Workspaces", "Sandbox");
-        var context = EngineLaunchContract.Resolve(workspaceRoot, Path.GetTempPath());
+        var manifestPath = Path.Combine(workspaceRoot, "Sandbox Project.sailor");
+        var context = EngineLaunchContract.Resolve(workspaceRoot, manifestPath, Path.GetTempPath());
 
         var arguments = context.BuildArguments("../Cache/Temp world.world", ["--noconsole", "--editor"]);
 
         Assert.Equal(
-            ["--workspace", Path.GetFullPath(workspaceRoot), "--world", "../Cache/Temp world.world", "--noconsole", "--editor"],
+            [
+                "--workspace",
+                Path.GetFullPath(workspaceRoot),
+                "--workspace-manifest",
+                Path.GetFullPath(manifestPath),
+                "--world",
+                "../Cache/Temp world.world",
+                "--noconsole",
+                "--editor"
+            ],
             arguments);
     }
 
@@ -55,5 +67,17 @@ public class EngineLaunchContractTests
         Assert.Equal("--world", arguments[3]);
         Assert.Equal("Editor.world", arguments[4]);
         Assert.DoesNotContain("--world Editor.world", arguments);
+    }
+
+    [Fact]
+    public void Resolve_DoesNotAttachManifestWithoutActiveWorkspace()
+    {
+        var fallbackRoot = Path.Combine(Path.GetTempPath(), "Sailor");
+        var ignoredManifest = Path.Combine(Path.GetTempPath(), "Ignored.sailor");
+
+        var context = EngineLaunchContract.Resolve(null, ignoredManifest, fallbackRoot);
+
+        Assert.Null(context.WorkspaceManifestPath);
+        Assert.DoesNotContain("--workspace-manifest", context.BuildArguments("Editor.world"));
     }
 }

--- a/Editor.Tests/NumericValueConverterTests.cs
+++ b/Editor.Tests/NumericValueConverterTests.cs
@@ -1,0 +1,50 @@
+using System.Globalization;
+using SailorEditor.Controls;
+
+namespace SailorEditor.Editor.Tests;
+
+public sealed class NumericValueConverterTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("-")]
+    [InlineData("not-a-number")]
+    public void IntConverter_InvalidTransientTextDoesNotReplaceTheBoundValue(string text)
+    {
+        var result = new IntValueConverter().ConvertBack(text, typeof(int), null!, CultureInfo.InvariantCulture);
+
+        Assert.Same(BindableProperty.UnsetValue, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("-1")]
+    [InlineData("not-a-number")]
+    public void UIntConverter_InvalidTransientTextDoesNotReplaceTheBoundValue(string text)
+    {
+        var result = new UIntValueConverter().ConvertBack(text, typeof(uint), null!, CultureInfo.InvariantCulture);
+
+        Assert.Same(BindableProperty.UnsetValue, result);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("-")]
+    [InlineData("NaN")]
+    [InlineData("Infinity")]
+    [InlineData("not-a-number")]
+    public void FloatConverter_InvalidTransientTextDoesNotReplaceTheBoundValue(string text)
+    {
+        var result = new FloatValueConverter().ConvertBack(text, typeof(float), null!, CultureInfo.InvariantCulture);
+
+        Assert.Same(BindableProperty.UnsetValue, result);
+    }
+
+    [Fact]
+    public void NumericConverters_ParseInvariantValuesThroughConvertBack()
+    {
+        Assert.Equal(-42, new IntValueConverter().ConvertBack("-42", typeof(int), null!, CultureInfo.GetCultureInfo("fr-FR")));
+        Assert.Equal(42u, new UIntValueConverter().ConvertBack("42", typeof(uint), null!, CultureInfo.GetCultureInfo("fr-FR")));
+        Assert.Equal(3.125f, new FloatValueConverter().ConvertBack("3.125", typeof(float), null!, CultureInfo.GetCultureInfo("fr-FR")));
+    }
+}

--- a/Editor.Tests/ShellHostTestStubs.cs
+++ b/Editor.Tests/ShellHostTestStubs.cs
@@ -1,5 +1,16 @@
 namespace Microsoft.Maui.Controls
 {
+    public interface IValueConverter
+    {
+        object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture);
+        object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture);
+    }
+
+    public class BindableProperty
+    {
+        public static readonly object UnsetValue = new();
+    }
+
     public class View;
 
     public class Label : View

--- a/Editor/Controls/FloatValueConverter.cs
+++ b/Editor/Controls/FloatValueConverter.cs
@@ -5,22 +5,17 @@ namespace SailorEditor.Controls;
 public class FloatValueConverter : IValueConverter
 {
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (value is float floatValue)
-        {
-            return floatValue.ToString(CultureInfo.InvariantCulture);
-        }
-
-        return value.ToString();
-    }
+        => value is float floatValue
+            ? floatValue.ToString(CultureInfo.InvariantCulture)
+            : value?.ToString() ?? string.Empty;
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-    {
-        if (value is string stringValue && float.TryParse(stringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out float result))
-        {
-            return result;
-        }
-
-        return 0;
-    }
+        => value is string stringValue && float.TryParse(
+            stringValue,
+            NumberStyles.Float,
+            CultureInfo.InvariantCulture,
+            out var result) &&
+            float.IsFinite(result)
+            ? result
+            : BindableProperty.UnsetValue;
 }

--- a/Editor/Controls/IntValueConverter.cs
+++ b/Editor/Controls/IntValueConverter.cs
@@ -16,5 +16,5 @@ public class IntValueConverter : IValueConverter
             CultureInfo.InvariantCulture,
             out var result)
             ? result
-            : 0;
+            : BindableProperty.UnsetValue;
 }

--- a/Editor/Controls/IntValueConverter.cs
+++ b/Editor/Controls/IntValueConverter.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+
+namespace SailorEditor.Controls;
+
+public class IntValueConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is int intValue
+            ? intValue.ToString(CultureInfo.InvariantCulture)
+            : value?.ToString() ?? string.Empty;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is string stringValue && int.TryParse(
+            stringValue,
+            NumberStyles.Integer,
+            CultureInfo.InvariantCulture,
+            out var result)
+            ? result
+            : 0;
+}

--- a/Editor/Controls/UIntValueConverter.cs
+++ b/Editor/Controls/UIntValueConverter.cs
@@ -16,5 +16,5 @@ public class UIntValueConverter : IValueConverter
             CultureInfo.InvariantCulture,
             out var result)
             ? result
-            : 0u;
+            : BindableProperty.UnsetValue;
 }

--- a/Editor/Controls/UIntValueConverter.cs
+++ b/Editor/Controls/UIntValueConverter.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+
+namespace SailorEditor.Controls;
+
+public class UIntValueConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is uint uintValue
+            ? uintValue.ToString(CultureInfo.InvariantCulture)
+            : value?.ToString() ?? string.Empty;
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        => value is string stringValue && uint.TryParse(
+            stringValue,
+            NumberStyles.Integer,
+            CultureInfo.InvariantCulture,
+            out var result)
+            ? result
+            : 0u;
+}

--- a/Editor/Services/EngineLaunchContract.cs
+++ b/Editor/Services/EngineLaunchContract.cs
@@ -2,22 +2,29 @@
 
 namespace SailorEditor.Services;
 
-public sealed record EngineLaunchContext(string WorkspaceRoot)
+public sealed record EngineLaunchContext(string WorkspaceRoot, string? WorkspaceManifestPath)
 {
     public string ContentDirectory => Path.Combine(WorkspaceRoot, "Content");
     public string CacheDirectory => Path.Combine(WorkspaceRoot, "Cache");
     public string TempWorldFilePath => Path.Combine(CacheDirectory, "Temp.world");
-    public string EngineTypesCacheFilePath => Path.Combine(CacheDirectory, "EngineTypes.yaml");
+    public string EditorTypesCacheFilePath => Path.Combine(CacheDirectory, "EditorTypes.yaml");
 
     public IReadOnlyList<string> BuildArguments(string world, IEnumerable<string>? extraArguments = null)
     {
         var arguments = new List<string>
         {
             "--workspace",
-            WorkspaceRoot,
-            "--world",
-            world
+            WorkspaceRoot
         };
+
+        if (!string.IsNullOrWhiteSpace(WorkspaceManifestPath))
+        {
+            arguments.Add("--workspace-manifest");
+            arguments.Add(WorkspaceManifestPath);
+        }
+
+        arguments.Add("--world");
+        arguments.Add(world);
 
         if (extraArguments is not null)
             arguments.AddRange(extraArguments.Where(x => !string.IsNullOrWhiteSpace(x)));
@@ -37,12 +44,22 @@ public sealed record EngineLaunchContext(string WorkspaceRoot)
 public static class EngineLaunchContract
 {
     public static EngineLaunchContext Resolve(string? activeWorkspaceRoot, string fallbackRoot)
+        => Resolve(activeWorkspaceRoot, null, fallbackRoot);
+
+    public static EngineLaunchContext Resolve(
+        string? activeWorkspaceRoot,
+        string? activeWorkspaceManifestPath,
+        string fallbackRoot)
     {
         var selectedRoot = string.IsNullOrWhiteSpace(activeWorkspaceRoot)
             ? fallbackRoot
             : activeWorkspaceRoot;
+        var manifestPath = string.IsNullOrWhiteSpace(activeWorkspaceRoot) ||
+            string.IsNullOrWhiteSpace(activeWorkspaceManifestPath)
+            ? null
+            : NormalizePath(activeWorkspaceManifestPath);
 
-        return new EngineLaunchContext(NormalizeRoot(selectedRoot));
+        return new EngineLaunchContext(NormalizeRoot(selectedRoot), manifestPath);
     }
 
     static string NormalizeRoot(string path)
@@ -53,6 +70,8 @@ public static class EngineLaunchContract
             ? fullPath
             : fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
     }
+
+    static string NormalizePath(string path) => Path.GetFullPath(path);
 
     static StringComparison PathComparison => OperatingSystem.IsWindows()
         ? StringComparison.OrdinalIgnoreCase

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -48,7 +48,7 @@ namespace SailorEngine
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void Shutdown();
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern uint GetMessages(nint[] messages, uint num);
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern uint SerializeCurrentWorld(nint[] yamlNode);
-        [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern uint SerializeEngineTypes(nint[] yamlNode);
+        [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern uint SerializeEditorTypes(nint[] yamlNode);
         [return: MarshalAs(UnmanagedType.I1)]
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool LoadEditorWorld(string strFileId);
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void SetViewport(uint windowPosX, uint windowPosY, uint width, uint height);
@@ -137,6 +137,7 @@ namespace SailorEditor.Services
         readonly object interopLock = new();
         readonly object runLock = new();
         readonly RingBufferedBatcher<string> consoleMessages = new(MaxBufferedConsoleMessages);
+        EngineTypes editorTypes = new();
         int consoleDispatchScheduled = 0;
         bool isRunning = false;
         const int MaxBufferedConsoleMessages = 1000;
@@ -166,10 +167,16 @@ namespace SailorEditor.Services
 
         public string EngineWorkingDirectory => repoRoot + Path.DirectorySeparatorChar;
 
-        public string EngineTypesCacheFilePath => GetLaunchContext().EngineTypesCacheFilePath;
+        public string EditorTypesCacheFilePath => GetLaunchContext().EditorTypesCacheFilePath;
 
         public EngineLaunchContext GetLaunchContext()
-            => EngineLaunchContract.Resolve(workspaceLifecycle.Current?.WorkspaceRoot, EngineWorkingDirectory);
+        {
+            var workspace = workspaceLifecycle.Current;
+            return EngineLaunchContract.Resolve(
+                workspace?.WorkspaceRoot,
+                workspace?.ManifestPath,
+                EngineWorkingDirectory);
+        }
 
         public string PathToEngineExecDebug
         {
@@ -200,7 +207,7 @@ namespace SailorEditor.Services
         public event Action<string[]> OnPullMessagesAction = delegate { };
         public event Action<string> OnUpdateCurrentWorldAction = delegate { };
 
-        public EngineTypes EngineTypes { get; private set; } = new();
+        public EngineTypes EngineTypes => Volatile.Read(ref editorTypes);
 
         public string[] GetRecentConsoleMessages() => consoleMessages.Snapshot();
 
@@ -486,7 +493,7 @@ namespace SailorEditor.Services
 
             try
             {
-                TryLoadEngineTypesFromFile("startup cache", launchContext.EngineTypesCacheFilePath);
+                TryLoadEditorTypesFromFile("startup cache", launchContext.EditorTypesCacheFilePath);
 
                 //ProcessStartInfo startInfo = new ProcessStartInfo
                 //{
@@ -520,16 +527,16 @@ namespace SailorEditor.Services
 #endif
 
                     // Required startup order:
-                    // 1) engine types, 2) world, 3) initial messages
-                    string serializedEngineTypes = SerializeEngineTypes();
-                    if (!string.IsNullOrEmpty(serializedEngineTypes))
+                    // 1) combined editor catalog, 2) world, 3) initial messages
+                    string serializedEditorTypes = SerializeEditorTypes();
+                    if (TryReplaceEditorTypes(serializedEditorTypes, out var catalogError))
                     {
-                        SaveEngineTypesToFile(serializedEngineTypes, launchContext.EngineTypesCacheFilePath);
-                        EngineTypes = EngineTypes.FromYaml(serializedEngineTypes);
+                        SaveEditorTypesToFile(serializedEditorTypes, launchContext.EditorTypesCacheFilePath);
                     }
                     else
                     {
-                        TryLoadEngineTypesFromFile("empty interop export", launchContext.EngineTypesCacheFilePath);
+                        Console.WriteLine($"Cannot replace editor type catalog from interop: {catalogError}");
+                        TryLoadEditorTypesFromFile("invalid interop export", launchContext.EditorTypesCacheFilePath);
                     }
 
                     string serializedWorld = SerializeWorld();
@@ -588,7 +595,7 @@ namespace SailorEditor.Services
                     catch (Exception ex)
                     {
                         Console.WriteLine($"SailorEngine task failed: {ex.Message}");
-                        TryLoadEngineTypesFromFile("engine startup failed", launchContext.EngineTypesCacheFilePath);
+                        TryLoadEditorTypesFromFile("engine startup failed", launchContext.EditorTypesCacheFilePath);
                     }
                     finally
                     {
@@ -690,13 +697,13 @@ namespace SailorEditor.Services
             }
         }
 
-        string SerializeEngineTypes()
+        string SerializeEditorTypes()
         {
             nint[] yamlNodeChar = new nint[1];
             uint numChars;
             lock (interopLock)
             {
-                numChars = EngineAppInterop.SerializeEngineTypes(yamlNodeChar);
+                numChars = EngineAppInterop.SerializeEditorTypes(yamlNodeChar);
             }
 
             if (numChars == 0)
@@ -712,7 +719,7 @@ namespace SailorEditor.Services
             }
         }
 
-        bool TryLoadEngineTypesFromFile(string reason, string cacheFilePath)
+        bool TryLoadEditorTypesFromFile(string reason, string cacheFilePath)
         {
             try
             {
@@ -727,24 +734,45 @@ namespace SailorEditor.Services
                     return false;
                 }
 
-                var engineTypes = EngineTypes.FromYaml(yaml);
-                if (engineTypes.Components.Count == 0 && engineTypes.Enums.Count == 0)
+                if (!TryReplaceEditorTypes(yaml, out var error))
                 {
+                    Console.WriteLine($"Cannot load editor type catalog cache ({reason}): {error}");
                     return false;
                 }
 
-                EngineTypes = engineTypes;
-                Console.WriteLine($"Loaded engine types from cache ({reason}): {cacheFilePath}");
+                Console.WriteLine($"Loaded editor type catalog from cache ({reason}): {cacheFilePath}");
                 return true;
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Cannot load engine types cache ({reason}): {ex.Message}");
+                Console.WriteLine($"Cannot load editor type catalog cache ({reason}): {ex.Message}");
                 return false;
             }
         }
 
-        void SaveEngineTypesToFile(string yaml, string cacheFilePath)
+        bool TryReplaceEditorTypes(string yaml, out string error)
+        {
+            try
+            {
+                var catalog = EngineTypes.FromYaml(yaml);
+                if (catalog.Components.Count == 0 && catalog.Enums.Count == 0 && catalog.AssetTypes.Count == 0)
+                {
+                    error = "The catalog does not contain any reflected or asset types.";
+                    return false;
+                }
+
+                Volatile.Write(ref editorTypes, catalog);
+                error = string.Empty;
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = ex.Message;
+                return false;
+            }
+        }
+
+        void SaveEditorTypesToFile(string yaml, string cacheFilePath)
         {
             if (string.IsNullOrWhiteSpace(yaml))
             {
@@ -759,11 +787,21 @@ namespace SailorEditor.Services
                     Directory.CreateDirectory(directory);
                 }
 
-                File.WriteAllText(cacheFilePath, yaml);
+                var temporaryPath = $"{cacheFilePath}.{Guid.NewGuid():N}.tmp";
+                try
+                {
+                    File.WriteAllText(temporaryPath, yaml);
+                    File.Move(temporaryPath, cacheFilePath, true);
+                }
+                finally
+                {
+                    if (File.Exists(temporaryPath))
+                        File.Delete(temporaryPath);
+                }
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Cannot save engine types cache: {ex.Message}");
+                Console.WriteLine($"Cannot save editor type catalog cache: {ex.Message}");
             }
         }
 

--- a/Editor/Utility/EditorComponentPropertyContract.cs
+++ b/Editor/Utility/EditorComponentPropertyContract.cs
@@ -21,4 +21,21 @@ public static class EditorComponentPropertyContract
 
         return EditorComponentPropertyAccess.Unknown;
     }
+
+    public static string ValidateEnumValue(
+        string componentTypeName,
+        string propertyName,
+        string enumTypeName,
+        string value,
+        IReadOnlyCollection<string> allowedValues)
+    {
+        if (!allowedValues.Contains(value, StringComparer.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"Invalid value '{value}' for enum property '{componentTypeName}.{propertyName}' " +
+                $"of type '{enumTypeName}'.");
+        }
+
+        return value;
+    }
 }

--- a/Editor/Utility/EditorComponentPropertyContract.cs
+++ b/Editor/Utility/EditorComponentPropertyContract.cs
@@ -1,0 +1,24 @@
+namespace SailorEngine;
+
+public enum EditorComponentPropertyAccess
+{
+    Writable,
+    ReadOnly,
+    Unknown
+}
+
+public static class EditorComponentPropertyContract
+{
+    public static EditorComponentPropertyAccess Classify<TProperty>(
+        string propertyName,
+        IReadOnlyDictionary<string, TProperty> writableProperties,
+        IReadOnlySet<string> readOnlyProperties)
+    {
+        if (writableProperties.ContainsKey(propertyName))
+            return EditorComponentPropertyAccess.Writable;
+        if (readOnlyProperties.Contains(propertyName))
+            return EditorComponentPropertyAccess.ReadOnly;
+
+        return EditorComponentPropertyAccess.Unknown;
+    }
+}

--- a/Editor/Utility/EditorComponentScalarCodec.cs
+++ b/Editor/Utility/EditorComponentScalarCodec.cs
@@ -1,0 +1,56 @@
+#nullable enable
+
+using System.Globalization;
+
+namespace SailorEngine;
+
+public enum EditorComponentScalarKind
+{
+    String,
+    Boolean,
+    Int32,
+    UInt32,
+    Float
+}
+
+public static class EditorComponentScalarCodec
+{
+    public static object Parse(EditorComponentScalarKind kind, string? value)
+    {
+        var scalar = value ?? string.Empty;
+        return kind switch
+        {
+            EditorComponentScalarKind.String => scalar,
+            EditorComponentScalarKind.Boolean when bool.TryParse(scalar, out var parsed) => parsed,
+            EditorComponentScalarKind.Int32 when int.TryParse(
+                scalar,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var parsed) => parsed,
+            EditorComponentScalarKind.UInt32 when uint.TryParse(
+                scalar,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var parsed) => parsed,
+            EditorComponentScalarKind.Float when float.TryParse(
+                scalar,
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out var parsed) => parsed,
+            _ => throw new InvalidDataException($"Invalid {kind} scalar value '{scalar}'.")
+        };
+    }
+
+    public static string Format(EditorComponentScalarKind kind, object? value)
+    {
+        return kind switch
+        {
+            EditorComponentScalarKind.String when value is string stringValue => stringValue,
+            EditorComponentScalarKind.Boolean when value is bool boolValue => boolValue ? "true" : "false",
+            EditorComponentScalarKind.Int32 when value is int intValue => intValue.ToString(CultureInfo.InvariantCulture),
+            EditorComponentScalarKind.UInt32 when value is uint uintValue => uintValue.ToString(CultureInfo.InvariantCulture),
+            EditorComponentScalarKind.Float when value is float floatValue => floatValue.ToString("R", CultureInfo.InvariantCulture),
+            _ => throw new InvalidDataException($"Value '{value}' does not match scalar kind {kind}.")
+        };
+    }
+}

--- a/Editor/Utility/EditorComponentYamlContract.cs
+++ b/Editor/Utility/EditorComponentYamlContract.cs
@@ -1,0 +1,9 @@
+#nullable enable
+
+namespace SailorEngine;
+
+public sealed class EditorComponentYamlContract
+{
+    public string Typename { get; set; } = string.Empty;
+    public Dictionary<string, object> OverrideProperties { get; set; } = [];
+}

--- a/Editor/Utility/EngineTypeMetadataContract.cs
+++ b/Editor/Utility/EngineTypeMetadataContract.cs
@@ -23,6 +23,7 @@ public sealed class EngineTypeMetadataType
     public string Typename { get; set; } = string.Empty;
     public string Base { get; set; } = string.Empty;
     public Dictionary<string, string> Properties { get; set; } = [];
+    public List<string> ReadOnlyProperties { get; set; } = [];
 }
 
 public sealed class EngineTypeMetadataDefaults
@@ -49,13 +50,16 @@ public sealed class EditorTypeCatalogSnapshot
     const string ComponentRootTypeName = "Sailor::Component";
 
     readonly Dictionary<string, EngineTypeMetadataType> types;
+    readonly Dictionary<string, EngineTypeMetadataDefaults> defaults;
 
     EditorTypeCatalogSnapshot(
         EngineTypeMetadataContract document,
-        Dictionary<string, EngineTypeMetadataType> types)
+        Dictionary<string, EngineTypeMetadataType> types,
+        Dictionary<string, EngineTypeMetadataDefaults> defaults)
     {
         Document = document;
         this.types = types;
+        this.defaults = defaults;
     }
 
     public EngineTypeMetadataContract Document { get; }
@@ -104,15 +108,31 @@ public sealed class EditorTypeCatalogSnapshot
                 throw new InvalidDataException($"Default object '{cdoName}' has no matching reflected type.");
         }
 
+        foreach (var defaultObject in defaults.Values)
+            defaultObject.DefaultValues ??= [];
+
         foreach (var type in types.Values)
         {
             type.Properties ??= [];
+            type.ReadOnlyProperties ??= [];
             foreach (var property in type.Properties)
             {
                 if (string.IsNullOrWhiteSpace(property.Key) || string.IsNullOrWhiteSpace(property.Value))
                 {
                     throw new InvalidDataException(
                         $"Reflected type '{type.Typename}' contains a property with an empty name or type.");
+                }
+            }
+
+            var readOnlyProperties = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var propertyName in type.ReadOnlyProperties)
+            {
+                if (string.IsNullOrWhiteSpace(propertyName) ||
+                    !readOnlyProperties.Add(propertyName) ||
+                    type.Properties.ContainsKey(propertyName))
+                {
+                    throw new InvalidDataException(
+                        $"Reflected type '{type.Typename}' contains an invalid read-only property '{propertyName}'.");
                 }
             }
         }
@@ -132,6 +152,19 @@ public sealed class EditorTypeCatalogSnapshot
             }
         }
 
+        foreach (var type in types.Values)
+        {
+            foreach (var property in type.Properties)
+            {
+                if (property.Value.StartsWith("enum ", StringComparison.Ordinal) &&
+                    !enumNames.Contains(property.Value))
+                {
+                    throw new InvalidDataException(
+                        $"Reflected property '{type.Typename}.{property.Key}' references missing enum metadata '{property.Value}'.");
+                }
+            }
+        }
+
         var extensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var assetType in assetTypes.Values)
         {
@@ -146,11 +179,20 @@ public sealed class EditorTypeCatalogSnapshot
             }
         }
 
-        return new EditorTypeCatalogSnapshot(document, types);
+        return new EditorTypeCatalogSnapshot(document, types, defaults);
     }
 
     public bool TryGetType(string typeName, out EngineTypeMetadataType type)
         => types.TryGetValue(typeName, out type!);
+
+    public bool IsKnownReadOnlyProperty(string typeName, string propertyName)
+    {
+        return types.TryGetValue(typeName, out var type) &&
+            !type.Properties.ContainsKey(propertyName) &&
+            (type.ReadOnlyProperties.Contains(propertyName, StringComparer.Ordinal) ||
+                (defaults.TryGetValue(typeName, out var defaultObject) &&
+                    defaultObject.DefaultValues.ContainsKey(propertyName)));
+    }
 
     public bool IsComponentType(string typeName)
     {

--- a/Editor/Utility/EngineTypeMetadataContract.cs
+++ b/Editor/Utility/EngineTypeMetadataContract.cs
@@ -137,17 +137,30 @@ public sealed class EditorTypeCatalogSnapshot
             }
         }
 
-        var enumNames = new HashSet<string>(StringComparer.Ordinal);
+        var enumValuesByName = new Dictionary<string, IReadOnlyCollection<string>>(StringComparer.Ordinal);
         foreach (var enumGroup in document.Enums)
         {
-            if (enumGroup is null)
+            if (enumGroup is null || enumGroup.Count == 0)
                 throw new InvalidDataException("The editor type catalog contains an empty enum group.");
 
             foreach (var enumEntry in enumGroup)
             {
                 if (string.IsNullOrWhiteSpace(enumEntry.Key))
                     throw new InvalidDataException("The editor type catalog contains an enum with an empty name.");
-                if (!enumNames.Add(enumEntry.Key))
+                if (enumEntry.Value is null || enumEntry.Value.Count == 0)
+                    throw new InvalidDataException($"Enum '{enumEntry.Key}' has no values in the editor type catalog.");
+
+                var uniqueValues = new HashSet<string>(StringComparer.Ordinal);
+                foreach (var enumValue in enumEntry.Value)
+                {
+                    if (string.IsNullOrWhiteSpace(enumValue) || !uniqueValues.Add(enumValue))
+                    {
+                        throw new InvalidDataException(
+                            $"Enum '{enumEntry.Key}' contains an empty or duplicate value '{enumValue}'.");
+                    }
+                }
+
+                if (!enumValuesByName.TryAdd(enumEntry.Key, uniqueValues))
                     throw new InvalidDataException($"Duplicate enum '{enumEntry.Key}' in the editor type catalog.");
             }
         }
@@ -157,10 +170,23 @@ public sealed class EditorTypeCatalogSnapshot
             foreach (var property in type.Properties)
             {
                 if (property.Value.StartsWith("enum ", StringComparison.Ordinal) &&
-                    !enumNames.Contains(property.Value))
+                    !enumValuesByName.ContainsKey(property.Value))
                 {
                     throw new InvalidDataException(
                         $"Reflected property '{type.Typename}.{property.Key}' references missing enum metadata '{property.Value}'.");
+                }
+
+                if (enumValuesByName.TryGetValue(property.Value, out var allowedValues) &&
+                    defaults.TryGetValue(type.Typename, out var defaultObject) &&
+                    defaultObject.DefaultValues.TryGetValue(property.Key, out var rawDefault))
+                {
+                    var value = Convert.ToString(rawDefault, System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty;
+                    EditorComponentPropertyContract.ValidateEnumValue(
+                        type.Typename,
+                        property.Key,
+                        property.Value,
+                        value,
+                        allowedValues);
                 }
             }
         }

--- a/Editor/Utility/EngineTypeMetadataContract.cs
+++ b/Editor/Utility/EngineTypeMetadataContract.cs
@@ -1,5 +1,10 @@
 #nullable enable
 
+using System.Collections;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
 namespace SailorEngine;
 
 public sealed class EngineTypeMetadataContract
@@ -37,4 +42,194 @@ public sealed class EngineTypeMetadataAssetProperty
 {
     public string Name { get; set; } = string.Empty;
     public string Type { get; set; } = string.Empty;
+}
+
+public sealed class EditorTypeCatalogSnapshot
+{
+    const string ComponentRootTypeName = "Sailor::Component";
+
+    readonly Dictionary<string, EngineTypeMetadataType> types;
+
+    EditorTypeCatalogSnapshot(
+        EngineTypeMetadataContract document,
+        Dictionary<string, EngineTypeMetadataType> types)
+    {
+        Document = document;
+        this.types = types;
+    }
+
+    public EngineTypeMetadataContract Document { get; }
+
+    public static EditorTypeCatalogSnapshot Parse(string yaml)
+    {
+        if (string.IsNullOrWhiteSpace(yaml))
+            throw new InvalidDataException("The editor type catalog is empty.");
+
+        EngineTypeMetadataContract document;
+        try
+        {
+            document = new DeserializerBuilder()
+                .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                .IgnoreUnmatchedProperties()
+                .Build()
+                .Deserialize<EngineTypeMetadataContract>(yaml)
+                ?? throw new InvalidDataException("The editor type catalog document is empty.");
+        }
+        catch (YamlException ex)
+        {
+            throw new InvalidDataException($"The editor type catalog is invalid YAML: {ex.Message}", ex);
+        }
+
+        document.EngineTypes ??= [];
+        document.Cdos ??= [];
+        document.Enums ??= [];
+        document.AssetTypes ??= [];
+
+        var types = BuildUniqueIndex(
+            document.EngineTypes,
+            type => type.Typename,
+            "type");
+        var defaults = BuildUniqueIndex(
+            document.Cdos,
+            cdo => cdo.Typename,
+            "default object");
+        var assetTypes = BuildUniqueIndex(
+            document.AssetTypes,
+            assetType => assetType.Typename,
+            "asset type");
+
+        foreach (var cdoName in defaults.Keys)
+        {
+            if (!types.ContainsKey(cdoName))
+                throw new InvalidDataException($"Default object '{cdoName}' has no matching reflected type.");
+        }
+
+        foreach (var type in types.Values)
+        {
+            type.Properties ??= [];
+            foreach (var property in type.Properties)
+            {
+                if (string.IsNullOrWhiteSpace(property.Key) || string.IsNullOrWhiteSpace(property.Value))
+                {
+                    throw new InvalidDataException(
+                        $"Reflected type '{type.Typename}' contains a property with an empty name or type.");
+                }
+            }
+        }
+
+        var enumNames = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var enumGroup in document.Enums)
+        {
+            if (enumGroup is null)
+                throw new InvalidDataException("The editor type catalog contains an empty enum group.");
+
+            foreach (var enumEntry in enumGroup)
+            {
+                if (string.IsNullOrWhiteSpace(enumEntry.Key))
+                    throw new InvalidDataException("The editor type catalog contains an enum with an empty name.");
+                if (!enumNames.Add(enumEntry.Key))
+                    throw new InvalidDataException($"Duplicate enum '{enumEntry.Key}' in the editor type catalog.");
+            }
+        }
+
+        var extensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var assetType in assetTypes.Values)
+        {
+            assetType.Extensions ??= [];
+            foreach (var extension in assetType.Extensions)
+            {
+                var normalized = extension?.Trim().TrimStart('.');
+                if (string.IsNullOrWhiteSpace(normalized))
+                    throw new InvalidDataException($"Asset type '{assetType.Typename}' contains an empty extension.");
+                if (!extensions.Add(normalized))
+                    throw new InvalidDataException($"Duplicate asset extension '{normalized}' in the editor type catalog.");
+            }
+        }
+
+        return new EditorTypeCatalogSnapshot(document, types);
+    }
+
+    public bool TryGetType(string typeName, out EngineTypeMetadataType type)
+        => types.TryGetValue(typeName, out type!);
+
+    public bool IsComponentType(string typeName)
+    {
+        if (string.IsNullOrWhiteSpace(typeName) ||
+            string.Equals(typeName, ComponentRootTypeName, StringComparison.Ordinal) ||
+            !types.TryGetValue(typeName, out var current))
+        {
+            return false;
+        }
+
+        var visited = new HashSet<string>(StringComparer.Ordinal) { typeName };
+        while (!string.IsNullOrWhiteSpace(current.Base))
+        {
+            if (string.Equals(current.Base, ComponentRootTypeName, StringComparison.Ordinal))
+                return true;
+            if (!visited.Add(current.Base) || !types.TryGetValue(current.Base, out current))
+                return false;
+        }
+
+        return false;
+    }
+
+    public IReadOnlyList<string> GetComponentTypeNames()
+        => types.Keys
+            .Where(IsComponentType)
+            .OrderBy(typeName => typeName, StringComparer.Ordinal)
+            .ToArray();
+
+    static Dictionary<string, T> BuildUniqueIndex<T>(
+        IEnumerable<T> values,
+        Func<T, string> getName,
+        string identityKind)
+    {
+        var result = new Dictionary<string, T>(StringComparer.Ordinal);
+        foreach (var value in values)
+        {
+            if (value is null)
+                throw new InvalidDataException($"The editor type catalog contains an empty {identityKind} entry.");
+
+            var name = getName(value);
+            if (string.IsNullOrWhiteSpace(name))
+                throw new InvalidDataException($"The editor type catalog contains a {identityKind} with an empty name.");
+            if (!result.TryAdd(name, value))
+                throw new InvalidDataException($"Duplicate {identityKind} '{name}' in the editor type catalog.");
+        }
+
+        return result;
+    }
+}
+
+public static class EditorTypeMetadataValueCodec
+{
+    public static IReadOnlyList<float> ParseFloatSequence(
+        object? value,
+        int expectedCount,
+        string valueName)
+    {
+        if (expectedCount <= 0)
+            throw new ArgumentOutOfRangeException(nameof(expectedCount));
+        if (value is string || value is not IEnumerable sequence)
+            throw new InvalidDataException($"Metadata value '{valueName}' must be a numeric sequence.");
+
+        var result = new List<float>(expectedCount);
+        try
+        {
+            foreach (var item in sequence)
+                result.Add(Convert.ToSingle(item, System.Globalization.CultureInfo.InvariantCulture));
+        }
+        catch (Exception ex) when (ex is FormatException or InvalidCastException or OverflowException)
+        {
+            throw new InvalidDataException($"Metadata value '{valueName}' contains a non-numeric element.", ex);
+        }
+
+        if (result.Count != expectedCount)
+        {
+            throw new InvalidDataException(
+                $"Metadata value '{valueName}' must contain exactly {expectedCount} elements.");
+        }
+
+        return result;
+    }
 }

--- a/Editor/Utility/EngineTypes.cs
+++ b/Editor/Utility/EngineTypes.cs
@@ -161,6 +161,7 @@ namespace SailorEngine
         public string Name { get; set; }
         public string Base { get; set; }
         public Dictionary<string, PropertyBase> Properties { get; set; } = [];
+        public HashSet<string> ReadOnlyProperties { get; set; } = [];
     };
 
     public class AssetType
@@ -234,7 +235,8 @@ namespace SailorEngine
 
         public static EngineTypes FromYaml(string yamlContent)
         {
-            var rootNode = EditorTypeCatalogSnapshot.Parse(yamlContent).Document;
+            var snapshot = EditorTypeCatalogSnapshot.Parse(yamlContent);
+            var rootNode = snapshot.Document;
             var res = new EngineTypes();
 
             var cdoByType = new Dictionary<string, EngineTypeMetadataDefaults>();
@@ -341,6 +343,24 @@ namespace SailorEngine
 
                 newComponent.Properties["fileId"] = new FileIdProperty() { DefaultValue = FileId.NullFileId };
                 newComponent.Properties["instanceId"] = new InstanceIdProperty() { DefaultValue = InstanceId.NullInstanceId };
+
+                foreach (var property in component.ReadOnlyProperties)
+                {
+                    if (!newComponent.Properties.ContainsKey(property))
+                        newComponent.ReadOnlyProperties.Add(property);
+                }
+
+                if (cdoNode is not null)
+                {
+                    foreach (var property in cdoNode.DefaultValues.Keys)
+                    {
+                        if (!newComponent.Properties.ContainsKey(property) &&
+                            snapshot.IsKnownReadOnlyProperty(component.Typename, property))
+                        {
+                            newComponent.ReadOnlyProperties.Add(property);
+                        }
+                    }
+                }
             }
 
             return res;

--- a/Editor/Utility/EngineTypes.cs
+++ b/Editor/Utility/EngineTypes.cs
@@ -200,6 +200,10 @@ namespace SailorEngine
             return engineType switch
             {
                 "f" => "float",
+                "j" => "uint32",
+                "unsigned int" => "uint32",
+                "unsigned __int32" => "uint32",
+                "uint32_t" => "uint32",
                 "N3glm3quaIfLNS_9qualifierE0EEE" => "struct glm::qua<float,0>",
                 "N3glm3vecILi2EfLNS_9qualifierE0EEE" => "struct glm::vec<2,float,0>",
                 "N3glm3vecILi3EfLNS_9qualifierE0EEE" => "struct glm::vec<3,float,0>",
@@ -230,148 +234,189 @@ namespace SailorEngine
 
         public static EngineTypes FromYaml(string yamlContent)
         {
-            var deserializer = SerializationUtils.CreateDeserializerBuilder().Build();
-
+            var rootNode = EditorTypeCatalogSnapshot.Parse(yamlContent).Document;
             var res = new EngineTypes();
+
+            var cdoByType = new Dictionary<string, EngineTypeMetadataDefaults>();
+            foreach (var cdo in rootNode.Cdos)
+            {
+                cdoByType.Add(cdo.Typename, cdo);
+            }
+
+            foreach (var enumNode in rootNode.Enums)
+            {
+                foreach (var enumEntry in enumNode)
+                {
+                    res.Enums.Add(enumEntry.Key, enumEntry.Value);
+                }
+            }
+
+            foreach (var assetTypeNode in rootNode.AssetTypes)
+            {
+                var assetType = new AssetType
+                {
+                    Name = assetTypeNode.Typename,
+                    Extensions = assetTypeNode.Extensions
+                };
+
+                foreach (var property in EnumerateAssetTypeProperties(assetTypeNode.Properties))
+                {
+                    var propertyType = property.Type;
+                    assetType.Properties[property.Name] = CreateAssetProperty(propertyType);
+                }
+
+                res.AssetTypes.Add(assetType.Name, assetType);
+                foreach (var extension in assetType.Extensions)
+                {
+                    res.AssetTypesByExtension.Add(extension.Trim().TrimStart('.').ToLowerInvariant(), assetType);
+                }
+            }
+
+            // Pass 1: register all reflected types first.
+            foreach (var component in rootNode.EngineTypes)
+            {
+                res.Components.Add(component.Typename, new ComponentType
+                {
+                    Name = component.Typename,
+                    Base = component.Base
+                });
+            }
+
+            // Pass 2: resolve properties/defaults after all types are known.
+            foreach (var component in rootNode.EngineTypes)
+            {
+                var newComponent = res.Components[component.Typename];
+
+                cdoByType.TryGetValue(component.Typename, out var cdoNode);
+
+                foreach (var property in component.Properties)
+                {
+                    string propertyType = NormalizePropertyType(property.Value);
+                    string genericType = GetGenericTypeName(property.Value);
+
+                    Quat defaultQuat = default;
+                    object defaultValue = null;
+                    cdoNode?.DefaultValues?.TryGetValue(property.Key, out defaultValue);
+                    if (defaultValue is Quat q)
+                    {
+                        defaultQuat = q;
+                    }
+                    else if (defaultValue is Rotation r)
+                    {
+                        defaultQuat = r.Quat;
+                    }
+                    else if (defaultValue is not null &&
+                        propertyType == "struct glm::qua<float,0>")
+                    {
+                        var values = EditorTypeMetadataValueCodec.ParseFloatSequence(
+                            defaultValue,
+                            4,
+                            $"{component.Typename}.{property.Key}");
+                        defaultQuat = new Quat(values[0], values[1], values[2], values[3]);
+                    }
+
+                    PropertyBase newProperty = CreateCommonProperty(propertyType) ?? propertyType switch
+                    {
+                        "struct glm::qua<float,0>" => new RotationProperty(defaultQuat),
+                        "struct glm::vec<2,float,0>" => new Vec2Property(),
+                        "struct glm::vec<3,float,0>" => new Vec3Property(),
+                        "struct glm::vec<4,float,0>" => new Vec4Property(),
+                        var value when value.Contains("TObjectPtr") => new ObjectPtrProperty()
+                        {
+                            GenericTypename = genericType,
+                            GenericType = GetEditorType(genericType)
+                        },
+                        var value when value.Contains("InstanceId") => new InstanceIdProperty(),
+                        "FileId" => new FileIdProperty(),
+                        "List<FileId>" => new Property<List<FileId>>(),
+                        var value when value.StartsWith("enum") => new EnumProperty() { Typename = value },
+                        var value when res.Enums.ContainsKey(value) => new EnumProperty() { Typename = value },
+                        _ => throw new InvalidDataException(
+                            $"Unsupported reflected property type '{property.Value}' for '{component.Typename}.{property.Key}'.")
+                    };
+
+                    ApplyScalarDefault(newProperty, defaultValue, component.Typename, property.Key);
+                    newComponent.Properties.Add(property.Key, newProperty);
+                }
+
+                newComponent.Properties["fileId"] = new FileIdProperty() { DefaultValue = FileId.NullFileId };
+                newComponent.Properties["instanceId"] = new InstanceIdProperty() { DefaultValue = InstanceId.NullInstanceId };
+            }
+
+            return res;
+        }
+
+        static void ApplyScalarDefault(
+            PropertyBase property,
+            object defaultValue,
+            string componentTypeName,
+            string propertyName)
+        {
+            if (defaultValue is null)
+                return;
 
             try
             {
-                var rootNode = deserializer.Deserialize<EngineTypeMetadataContract>(yamlContent);
-                if (rootNode?.EngineTypes == null)
-                    return res;
-
-                var cdoByType = new Dictionary<string, EngineTypeMetadataDefaults>();
-                foreach (var cdo in rootNode.Cdos ?? new List<EngineTypeMetadataDefaults>())
+                switch (property)
                 {
-                    if (string.IsNullOrEmpty(cdo?.Typename))
-                        continue;
-
-                    // Keep first occurrence; avoid hard failure on duplicates.
-                    if (!cdoByType.ContainsKey(cdo.Typename))
-                        cdoByType[cdo.Typename] = cdo;
-                }
-
-                foreach (var enumNode in rootNode.Enums ?? Enumerable.Empty<Dictionary<string, List<string>>>())
-                {
-                    foreach (var enumEntry in enumNode)
-                    {
-                        res.Enums[enumEntry.Key] = enumEntry.Value;
-                    }
-                }
-
-                foreach (var assetTypeNode in rootNode.AssetTypes ?? Enumerable.Empty<EngineTypeMetadataAssetType>())
-                {
-                    if (string.IsNullOrEmpty(assetTypeNode.Typename))
-                        continue;
-
-                    var assetType = new AssetType
-                    {
-                        Name = assetTypeNode.Typename,
-                        Extensions = assetTypeNode.Extensions ?? []
-                    };
-
-                    foreach (var property in EnumerateAssetTypeProperties(assetTypeNode.Properties))
-                    {
-                        var propertyType = property.Type;
-                        assetType.Properties[property.Name] = CreateAssetProperty(propertyType);
-                    }
-
-                    res.AssetTypes[assetType.Name] = assetType;
-                    foreach (var extension in assetType.Extensions)
-                    {
-                        res.AssetTypesByExtension[extension.TrimStart('.').ToLowerInvariant()] = assetType;
-                    }
-                }
-
-                // Pass 1: register all component types first.
-                foreach (var component in rootNode.EngineTypes)
-                {
-                    if (string.IsNullOrEmpty(component.Typename))
-                        continue;
-
-                    if (!res.Components.ContainsKey(component.Typename))
-                    {
-                        res.Components[component.Typename] = new ComponentType
-                        {
-                            Name = component.Typename,
-                            Base = component.Base
-                        };
-                    }
-                }
-
-                // Pass 2: resolve properties/defaults after all types are known.
-                foreach (var component in rootNode.EngineTypes)
-                {
-                    if (string.IsNullOrEmpty(component.Typename))
-                        continue;
-
-                    var newComponent = res.Components[component.Typename];
-
-                    if (component.Properties == null)
-                        component.Properties = new();
-
-                    cdoByType.TryGetValue(component.Typename, out var cdoNode);
-
-                    foreach (var property in component.Properties)
-                    {
-                        try
-                        {
-                            string propertyType = NormalizePropertyType(property.Value);
-                            string genericType = GetGenericTypeName(property.Value);
-
-                            Quat defaultQuat = default;
-                            if (cdoNode != null &&
-                                cdoNode.DefaultValues != null &&
-                                cdoNode.DefaultValues.TryGetValue(property.Key, out var defaultQuatObj))
-                            {
-                                if (defaultQuatObj is Quat q)
-                                {
-                                    defaultQuat = q;
-                                }
-                                else if (defaultQuatObj is Rotation r)
-                                {
-                                    defaultQuat = r.Quat;
-                                }
-                            }
-
-                            PropertyBase newProperty = CreateCommonProperty(propertyType) ?? propertyType switch
-                            {
-                                "struct glm::qua<float,0>" => new RotationProperty(defaultQuat),
-                                "struct glm::vec<2,float,0>" => new Vec2Property(),
-                                "struct glm::vec<3,float,0>" => new Vec3Property(),
-                                "struct glm::vec<4,float,0>" => new Vec4Property(),
-                                var value when value.Contains("TObjectPtr") => new ObjectPtrProperty()
-                                {
-                                    GenericTypename = genericType,
-                                    GenericType = GetEditorType(genericType)
-                                },
-                                var value when value.Contains("InstanceId") => new InstanceIdProperty(),
-                                var value when value.StartsWith("enum") => new EnumProperty() { Typename = value },
-                                var value when res.Enums.ContainsKey(value) => new EnumProperty() { Typename = value },
-                                _ => null
-                            };
-
-                            if (newProperty != null)
-                            {
-                                newComponent.Properties[property.Key] = newProperty;
-                            }
-                        }
-                        catch (Exception ex)
-                        {
-                            Console.WriteLine($"EngineTypes: failed to import property '{property.Key}' for '{component.Typename}': {ex.Message}");
-                        }
-                    }
-
-                    newComponent.Properties["fileId"] = new FileIdProperty() { DefaultValue = FileId.NullFileId };
-                    newComponent.Properties["instanceId"] = new InstanceIdProperty() { DefaultValue = InstanceId.NullInstanceId };
+                    case FloatProperty floatProperty:
+                        floatProperty.DefaultValue = Convert.ToSingle(defaultValue, CultureInfo.InvariantCulture);
+                        break;
+                    case Property<int> intProperty:
+                        intProperty.DefaultValue = Convert.ToInt32(defaultValue, CultureInfo.InvariantCulture);
+                        break;
+                    case Property<uint> uintProperty:
+                        uintProperty.DefaultValue = Convert.ToUInt32(defaultValue, CultureInfo.InvariantCulture);
+                        break;
+                    case Property<bool> boolProperty:
+                        boolProperty.DefaultValue = Convert.ToBoolean(defaultValue, CultureInfo.InvariantCulture);
+                        break;
+                    case EnumProperty enumProperty:
+                        enumProperty.DefaultValue = Convert.ToString(defaultValue, CultureInfo.InvariantCulture) ?? string.Empty;
+                        break;
+                    case Property<string> stringProperty:
+                        stringProperty.DefaultValue = Convert.ToString(defaultValue, CultureInfo.InvariantCulture) ?? string.Empty;
+                        break;
                 }
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex.Message);
+                throw new InvalidDataException(
+                    $"Invalid default for reflected property '{componentTypeName}.{propertyName}': {ex.Message}",
+                    ex);
             }
-            return res;
         }
+
+        public bool TryGetComponent(string typeName, out ComponentType componentType)
+            => Components.TryGetValue(typeName, out componentType);
+
+        public bool IsComponentType(string typeName)
+        {
+            const string componentRootTypeName = "Sailor::Component";
+            if (string.IsNullOrWhiteSpace(typeName) ||
+                string.Equals(typeName, componentRootTypeName, StringComparison.Ordinal) ||
+                !Components.TryGetValue(typeName, out var current))
+            {
+                return false;
+            }
+
+            var visited = new HashSet<string>(StringComparer.Ordinal) { typeName };
+            while (!string.IsNullOrWhiteSpace(current.Base))
+            {
+                if (string.Equals(current.Base, componentRootTypeName, StringComparison.Ordinal))
+                    return true;
+                if (!visited.Add(current.Base) || !Components.TryGetValue(current.Base, out current))
+                    return false;
+            }
+
+            return false;
+        }
+
+        public IReadOnlyList<string> GetComponentTypeNames()
+            => Components.Keys
+                .Where(IsComponentType)
+                .OrderBy(typeName => typeName, StringComparer.Ordinal)
+                .ToArray();
 
         static PropertyBase CreateAssetProperty(string propertyType)
         {
@@ -391,6 +436,7 @@ namespace SailorEngine
                 "string" => new Property<string>(),
                 "bool" => new Property<bool>(),
                 "int32" => new Property<int>(),
+                "uint32" => new Property<uint>(),
                 "float" => new FloatProperty(),
                 _ => null
             };
@@ -816,16 +862,17 @@ namespace SailorEditor
 
         public object ReadYaml(IParser parser, Type type)
         {
-            string name = string.Empty;
+            if (parser.Current is not Scalar scalar || string.IsNullOrWhiteSpace(scalar.Value))
+                throw new YamlException("A component typename must be a non-empty scalar.");
 
-            if (parser.Current is Scalar scalar)
-            {
-                name = scalar.Value;
-            }
-
+            var name = scalar.Value;
             parser.MoveNext();
 
-            return MauiProgram.GetService<EngineService>().EngineTypes.Components[name];
+            var catalog = MauiProgram.GetService<EngineService>().EngineTypes;
+            if (!catalog.TryGetComponent(name, out var componentType))
+                throw new YamlException($"Unknown component type '{name}'.");
+
+            return componentType;
         }
 
         public void WriteYaml(IEmitter emitter, object value, Type type)

--- a/Editor/Utility/Templates.cs
+++ b/Editor/Utility/Templates.cs
@@ -70,6 +70,14 @@ static class Templates
         return checkBox;
     }
 
+    public static View BoolEditor<TBindingContext>(Expression<Func<TBindingContext, bool>> getter, Action<TBindingContext, bool> setter)
+        where TBindingContext : class
+    {
+        var checkBox = CheckBox(getter, setter);
+        checkBox.CheckedChanged += (sender, args) => CommitInspectorBindingContext(((CheckBox)sender).BindingContext);
+        return checkBox;
+    }
+
     public static Picker EnumPicker<TBinding, TEnum>(Expression<Func<TBinding, TEnum>> getter, Action<TBinding, TEnum> setter)
         where TBinding : class
         where TEnum : struct
@@ -409,6 +417,69 @@ static class Templates
             converter: new FloatValueConverter());
 
         return value;
+    }
+
+    public static View IntEditor<TBindingContext>(Expression<Func<TBindingContext, int>> getter, Action<TBindingContext, int> setter)
+        where TBindingContext : class
+    {
+        var value = CreateInspectorEntry();
+        value.Keyboard = Keyboard.Numeric;
+        value.ReturnType = ReturnType.Done;
+        value.IsTextPredictionEnabled = false;
+        ConfigureCommittingEntry(value);
+
+        value.Bind<Entry, TBindingContext, int, string>(Entry.TextProperty,
+            getter: getter,
+            setter: setter,
+            mode: BindingMode.TwoWay,
+            converter: new IntValueConverter());
+
+        return value;
+    }
+
+    public static View UIntEditor<TBindingContext>(Expression<Func<TBindingContext, uint>> getter, Action<TBindingContext, uint> setter)
+        where TBindingContext : class
+    {
+        var value = CreateInspectorEntry();
+        value.Keyboard = Keyboard.Numeric;
+        value.ReturnType = ReturnType.Done;
+        value.IsTextPredictionEnabled = false;
+        ConfigureCommittingEntry(value);
+
+        value.Bind<Entry, TBindingContext, uint, string>(Entry.TextProperty,
+            getter: getter,
+            setter: setter,
+            mode: BindingMode.TwoWay,
+            converter: new UIntValueConverter());
+
+        return value;
+    }
+
+    public static View StringEditor<TBindingContext>(Expression<Func<TBindingContext, string>> getter, Action<TBindingContext, string> setter)
+        where TBindingContext : class
+    {
+        var value = CreateInspectorEntry();
+        value.ReturnType = ReturnType.Done;
+        ConfigureCommittingEntry(value);
+
+        value.Bind<Entry, TBindingContext, string, string>(Entry.TextProperty,
+            getter: getter,
+            setter: setter,
+            mode: BindingMode.TwoWay,
+            converter: (IValueConverter)null);
+
+        return value;
+    }
+
+    static void ConfigureCommittingEntry(Entry entry)
+    {
+        entry.Completed += (sender, args) =>
+        {
+            var current = (Entry)sender;
+            CommitInspectorBindingContext(current.BindingContext);
+            current.Unfocus();
+        };
+        entry.Unfocused += (sender, args) => CommitInspectorBindingContext(((Entry)sender).BindingContext);
     }
 
     public static View UniformEditor<TBindingContext, T>(

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -160,8 +160,11 @@ public class ComponentYamlConverter : IYamlTypeConverter
                 ObjectPtrProperty => property.Value is null
                     ? new ObjectPtr()
                     : DeserializeBuffered<ObjectPtr>(property.Value, serializer, deserializer),
-                EnumProperty => new Observable<string>((string)EditorComponentScalarCodec.Parse(
-                    EditorComponentScalarKind.String,
+                EnumProperty enumProperty => new Observable<string>(ParseEnumOverride(
+                    catalog,
+                    componentType,
+                    property.Key,
+                    enumProperty,
                     scalar)),
                 Property<string> => new Observable<string>((string)EditorComponentScalarCodec.Parse(
                     EditorComponentScalarKind.String,
@@ -182,6 +185,38 @@ public class ComponentYamlConverter : IYamlTypeConverter
         }
 
         return component;
+    }
+
+    static string ParseEnumOverride(
+        EngineTypes catalog,
+        ComponentType componentType,
+        string propertyName,
+        EnumProperty enumProperty,
+        string scalar)
+    {
+        if (!catalog.Enums.TryGetValue(enumProperty.Typename, out var allowedValues))
+        {
+            throw new YamlException(
+                $"Missing enum metadata '{enumProperty.Typename}' for " +
+                $"'{componentType.Name}.{propertyName}'.");
+        }
+
+        var value = (string)EditorComponentScalarCodec.Parse(
+            EditorComponentScalarKind.String,
+            scalar);
+        try
+        {
+            return EditorComponentPropertyContract.ValidateEnumValue(
+                componentType.Name,
+                propertyName,
+                enumProperty.Typename,
+                value,
+                allowedValues);
+        }
+        catch (InvalidDataException ex)
+        {
+            throw new YamlException(ex.Message);
+        }
     }
 
     static T DeserializeBuffered<T>(object value, ISerializer serializer, IDeserializer deserializer)

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -91,6 +91,9 @@ public partial class Component : ObservableObject, ICloneable, IInspectorEditabl
     [YamlIgnore]
     string? _lastCommittedYaml;
 
+    [YamlIgnore]
+    public Dictionary<string, object?> PreservedReadOnlyProperties { get; } = new(StringComparer.Ordinal);
+
     [ObservableProperty]
     protected string displayName;
 
@@ -126,12 +129,22 @@ public class ComponentYamlConverter : IYamlTypeConverter
         var component = new Component { Typename = componentType };
         foreach (var property in document.OverrideProperties ?? [])
         {
-            if (!componentType.Properties.TryGetValue(property.Key, out var propType))
+            var propertyAccess = EditorComponentPropertyContract.Classify(
+                property.Key,
+                componentType.Properties,
+                componentType.ReadOnlyProperties);
+            if (propertyAccess == EditorComponentPropertyAccess.ReadOnly)
+            {
+                component.PreservedReadOnlyProperties[property.Key] = property.Value;
+                continue;
+            }
+            if (propertyAccess == EditorComponentPropertyAccess.Unknown)
             {
                 throw new YamlException(
                     $"Unknown property '{property.Key}' for component type '{componentType.Name}'.");
             }
 
+            var propType = componentType.Properties[property.Key];
             var scalar = Convert.ToString(property.Value, CultureInfo.InvariantCulture) ?? string.Empty;
             ObservableObject value = propType switch
             {
@@ -257,6 +270,12 @@ public class ComponentYamlConverter : IYamlTypeConverter
                 default:
                     throw new InvalidOperationException($"Unexpected property type: {kvp.Value.GetType().Name}");
             }
+        }
+
+        foreach (var kvp in component.PreservedReadOnlyProperties)
+        {
+            emitter.Emit(new Scalar(null, kvp.Key));
+            serializer.Serialize(emitter, kvp.Value);
         }
 
         emitter.Emit(new MappingEnd());

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -113,70 +113,66 @@ public class ComponentYamlConverter : IYamlTypeConverter
             .WithTypeConverter(new ComponentYamlConverter())
             .Build();
 
-        var component = new Component();
+        var serializer = SerializationUtils.CreateSerializerBuilder().Build();
+        var document = deserializer.Deserialize<EditorComponentYamlContract>(parser) ??
+            throw new YamlException("A component YAML document is required.");
+        if (string.IsNullOrWhiteSpace(document.Typename))
+            throw new YamlException("A component typename must be a non-empty scalar.");
 
-        parser.Consume<MappingStart>();
+        var catalog = MauiProgram.GetService<EngineService>().EngineTypes;
+        if (!catalog.TryGetComponent(document.Typename, out var componentType))
+            throw new YamlException($"Unknown component type '{document.Typename}'.");
 
-        while (!parser.TryConsume<MappingEnd>(out var _))
+        var component = new Component { Typename = componentType };
+        foreach (var property in document.OverrideProperties ?? [])
         {
-            var propertyName = parser.Consume<Scalar>().Value;
-
-            switch (propertyName)
+            if (!componentType.Properties.TryGetValue(property.Key, out var propType))
             {
-                case "typename":
-                    component.Typename = deserializer.Deserialize<ComponentType>(parser);
-                    break;
-                case "overrideProperties":
-                    {
-                        parser.Consume<MappingStart>();
-
-                        while (!parser.TryConsume<MappingEnd>(out var _))
-                        {
-                            if (parser.Current is Scalar scalar)
-                            {
-                                string key = scalar.Value;
-
-                                parser.MoveNext();
-                                if (component.Typename?.Properties == null ||
-                                    !component.Typename.Properties.TryGetValue(key, out var propType))
-                                {
-                                    deserializer.Deserialize<object>(parser);
-                                    continue;
-                                }
-
-                                ObservableObject value = propType switch
-                                {
-                                    RotationProperty => deserializer.Deserialize<Rotation>(parser),
-                                    Vec4Property => deserializer.Deserialize<Vec4>(parser),
-                                    Vec3Property => deserializer.Deserialize<Vec3>(parser),
-                                    Vec2Property => deserializer.Deserialize<Vec2>(parser),
-                                    FileIdProperty => new Observable<FileId>(deserializer.Deserialize<string>(parser)),
-                                    InstanceIdProperty => new Observable<InstanceId>(deserializer.Deserialize<string>(parser)),
-                                    FloatProperty => new Observable<float>(deserializer.Deserialize<float>(parser)),
-                                    ObjectPtrProperty => deserializer.Deserialize<ObjectPtr>(parser),
-                                    EnumProperty => new Observable<string>(deserializer.Deserialize<string>(parser)),
-                                    _ => throw new InvalidOperationException($"Unexpected property type: {propType.GetType().Name}")
-                                };
-
-                                if (propType is ObjectPtrProperty && value == null)
-                                {
-                                    value = new ObjectPtr();
-                                }
-
-                                component.OverrideProperties[key] = value;
-                            }
-                        }
-
-                    }
-                    break;
-                default:
-                    deserializer.Deserialize<object>(parser);
-                    break;
+                throw new YamlException(
+                    $"Unknown property '{property.Key}' for component type '{componentType.Name}'.");
             }
+
+            var scalar = Convert.ToString(property.Value, CultureInfo.InvariantCulture) ?? string.Empty;
+            ObservableObject value = propType switch
+            {
+                RotationProperty => DeserializeBuffered<Rotation>(property.Value, serializer, deserializer),
+                Vec4Property => DeserializeBuffered<Vec4>(property.Value, serializer, deserializer),
+                Vec3Property => DeserializeBuffered<Vec3>(property.Value, serializer, deserializer),
+                Vec2Property => DeserializeBuffered<Vec2>(property.Value, serializer, deserializer),
+                FileIdProperty => new Observable<FileId>(scalar),
+                InstanceIdProperty => new Observable<InstanceId>(scalar),
+                FloatProperty => new Observable<float>((float)EditorComponentScalarCodec.Parse(
+                    EditorComponentScalarKind.Float,
+                    scalar)),
+                ObjectPtrProperty => property.Value is null
+                    ? new ObjectPtr()
+                    : DeserializeBuffered<ObjectPtr>(property.Value, serializer, deserializer),
+                EnumProperty => new Observable<string>((string)EditorComponentScalarCodec.Parse(
+                    EditorComponentScalarKind.String,
+                    scalar)),
+                Property<string> => new Observable<string>((string)EditorComponentScalarCodec.Parse(
+                    EditorComponentScalarKind.String,
+                    scalar)),
+                Property<bool> => new Observable<bool>((bool)EditorComponentScalarCodec.Parse(
+                    EditorComponentScalarKind.Boolean,
+                    scalar)),
+                Property<int> => new Observable<int>((int)EditorComponentScalarCodec.Parse(
+                    EditorComponentScalarKind.Int32,
+                    scalar)),
+                Property<uint> => new Observable<uint>((uint)EditorComponentScalarCodec.Parse(
+                    EditorComponentScalarKind.UInt32,
+                    scalar)),
+                _ => throw new InvalidOperationException($"Unexpected property type: {propType.GetType().Name}")
+            };
+
+            component.OverrideProperties[property.Key] = value;
         }
 
         return component;
     }
+
+    static T DeserializeBuffered<T>(object value, ISerializer serializer, IDeserializer deserializer)
+        => deserializer.Deserialize<T>(serializer.Serialize(value));
 
     public void WriteYaml(IEmitter emitter, object value, Type type)
     {
@@ -188,7 +184,8 @@ public class ComponentYamlConverter : IYamlTypeConverter
         emitter.Emit(new MappingStart(null, null, false, MappingStyle.Block));
 
         emitter.Emit(new Scalar(null, "typename"));
-        emitter.Emit(new Scalar(null, component.Typename.Name));
+        emitter.Emit(new Scalar(null, component.Typename?.Name ??
+            throw new InvalidOperationException("Cannot serialize a component without a reflected type.")));
 
         emitter.Emit(new Scalar(null, "overrideProperties"));
         emitter.Emit(new MappingStart(null, null, false, MappingStyle.Block));
@@ -230,10 +227,29 @@ public class ComponentYamlConverter : IYamlTypeConverter
                     instanceIdConverter.WriteYaml(emitter, id.Value, typeof(InstanceId));
                     break;
                 case Observable<string> str:
-                    emitter.Emit(new Scalar(null, str.Value));
+                    emitter.Emit(new Scalar(null, EditorComponentScalarCodec.Format(
+                        EditorComponentScalarKind.String,
+                        str.Value)));
+                    break;
+                case Observable<bool> boolValue:
+                    emitter.Emit(new Scalar(null, EditorComponentScalarCodec.Format(
+                        EditorComponentScalarKind.Boolean,
+                        boolValue.Value)));
+                    break;
+                case Observable<int> intValue:
+                    emitter.Emit(new Scalar(null, EditorComponentScalarCodec.Format(
+                        EditorComponentScalarKind.Int32,
+                        intValue.Value)));
+                    break;
+                case Observable<uint> uintValue:
+                    emitter.Emit(new Scalar(null, EditorComponentScalarCodec.Format(
+                        EditorComponentScalarKind.UInt32,
+                        uintValue.Value)));
                     break;
                 case Observable<float> floatVal:
-                    emitter.Emit(new Scalar(null, floatVal.Value.ToString()));
+                    emitter.Emit(new Scalar(null, EditorComponentScalarCodec.Format(
+                        EditorComponentScalarKind.Float,
+                        floatVal.Value)));
                     break;
                 case ObjectPtr objPtr:
                     objPtrConverter.WriteYaml(emitter, objPtr, typeof(ObjectPtr));

--- a/Editor/ViewModels/GameObject.cs
+++ b/Editor/ViewModels/GameObject.cs
@@ -118,40 +118,14 @@ public partial class GameObject : ObservableObject, ICloneable, IInspectorEditab
 
     public async Task AddComponentFromInspectorAsync()
     {
+        var editorTypes = MauiProgram.GetService<EngineService>().EngineTypes;
         var componentTypeName = await Views.AddComponentDialogPage.ShowAsync(
-            MauiProgram.GetService<EngineService>().EngineTypes.Components.Values
-                .Where(IsComponentType)
-                .Select(type => type.Name)
-                .OrderBy(name => name)
-                .ToList());
+            editorTypes.GetComponentTypeNames());
 
         if (!string.IsNullOrWhiteSpace(componentTypeName))
         {
             await Task.Run(() => MauiProgram.GetService<WorldService>().AddComponent(this, componentTypeName));
         }
-    }
-
-    static bool IsComponentType(ComponentType type)
-    {
-        if (type.Name == "Sailor::Component")
-        {
-            return false;
-        }
-
-        var engineTypes = MauiProgram.GetService<EngineService>().EngineTypes;
-        var baseType = type.Base;
-
-        while (!string.IsNullOrEmpty(baseType))
-        {
-            if (baseType == "Sailor::Component")
-            {
-                return true;
-            }
-
-            baseType = engineTypes.Components[baseType].Base;
-        }
-
-        return false;
     }
 
     public async void ClearComponentsFromInspector()

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -146,8 +146,19 @@ public class ComponentTemplate : DataTemplate
                     if (component.Typename.Properties[property.Key] is EnumProperty enumProp)
                     {
                         var observableString = property.Value as Observable<string>;
-                        propertyEditor = Templates.EnumPicker(engineTypes.Enums[enumProp.Typename],
-                            (Component vm) => observableString.Value, (vm, value) => observableString.Value = value);
+                        if (engineTypes.Enums.TryGetValue(enumProp.Typename, out var enumValues))
+                        {
+                            propertyEditor = Templates.EnumPicker(enumValues,
+                                (Component vm) => observableString.Value, (vm, value) => observableString.Value = value);
+                        }
+                        else
+                        {
+                            propertyEditor = new Label
+                            {
+                                Text = $"Missing enum metadata: {enumProp.Typename}",
+                                VerticalTextAlignment = TextAlignment.Center
+                            };
+                        }
                     }
                     else
                     {

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -176,6 +176,10 @@ public class ComponentTemplate : DataTemplate
                             propertyEditor = property.Value switch
                             {
                                 Observable<float> observableFloat => Templates.FloatEditor((Component vm) => observableFloat.Value, (vm, value) => observableFloat.Value = value),
+                                Observable<int> observableInt => Templates.IntEditor((Component vm) => observableInt.Value, (vm, value) => observableInt.Value = value),
+                                Observable<uint> observableUInt => Templates.UIntEditor((Component vm) => observableUInt.Value, (vm, value) => observableUInt.Value = value),
+                                Observable<bool> observableBool => Templates.BoolEditor((Component vm) => observableBool.Value, (vm, value) => observableBool.Value = value),
+                                Observable<string> observableString => Templates.StringEditor((Component vm) => observableString.Value, (vm, value) => observableString.Value = value),
                                 Rotation quat => Templates.RotationEditor((Component vm) => quat),
                                 Vec4 vec4 => Templates.Vec4Editor((Component vm) => vec4),
                                 Vec3 vec3 => Templates.Vec3Editor((Component vm) => vec3),

--- a/Lib/DllMain.cpp
+++ b/Lib/DllMain.cpp
@@ -98,6 +98,13 @@ extern "C"
 		return Sailor::App::SerializeEngineTypes(yamlNode);
 	}
 
+	SAILOR_API uint32_t SerializeEditorTypes(char** yamlNode)
+	{
+		SAILOR_PROFILE_FUNCTION();
+
+		return Sailor::App::SerializeEditorTypes(yamlNode);
+	}
+
 	SAILOR_API bool LoadEditorWorld(char* strFileId)
 	{
 		SAILOR_PROFILE_FUNCTION();

--- a/Lib/InteropExports.cpp
+++ b/Lib/InteropExports.cpp
@@ -89,6 +89,11 @@ extern "C"
 		return Sailor::App::SerializeEngineTypes(yamlNode);
 	}
 
+	SAILOR_API uint32_t SerializeEditorTypes(char** yamlNode)
+	{
+		return Sailor::App::SerializeEditorTypes(yamlNode);
+	}
+
 	SAILOR_API bool LoadEditorWorld(char* strFileId)
 	{
 		return Sailor::App::LoadEditorWorld(strFileId);

--- a/Runtime/Core/Reflection.h
+++ b/Runtime/Core/Reflection.h
@@ -218,6 +218,10 @@ namespace Sailor
 			{
 				return "int32";
 			}
+			else if constexpr (std::is_same_v<PropertyType, uint32_t>)
+			{
+				return "uint32";
+			}
 			else if constexpr (std::is_same_v<PropertyType, TVector<FileId>>)
 			{
 				return "List<FileId>";

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -8,10 +8,12 @@
 #include "Engine/World.h"
 #include "Engine/InstanceId.h"
 #include "Submodules/Editor.h"
+#include "Workspace/WorkspaceModuleManager.h"
 
 #include <algorithm>
 #include <cstring>
 #include <filesystem>
+#include <utility>
 
 using namespace Sailor;
 
@@ -97,6 +99,43 @@ uint32_t App::SerializeEngineTypes(char** yamlNode)
 
 	yamlNode[0] = nullptr;
 	return 0;
+}
+
+uint32_t App::SerializeEditorTypes(char** yamlNode)
+{
+	if (!yamlNode)
+	{
+		return 0;
+	}
+
+	yamlNode[0] = nullptr;
+	YAML::Node editorTypes = Reflection::ExportEngineTypes();
+	if (App* app = GetInstance(); app && app->m_pWorkspaceModuleManager)
+	{
+		YAML::Node combinedTypes;
+		std::string mergeError;
+		if (app->m_pWorkspaceModuleManager->BuildEditorTypeMetadata(editorTypes, combinedTypes, mergeError))
+		{
+			editorTypes = std::move(combinedTypes);
+		}
+		else
+		{
+			SAILOR_LOG_ERROR("Failed to merge workspace editor type metadata: %s", mergeError.c_str());
+		}
+	}
+
+	if (editorTypes.IsNull())
+	{
+		return 0;
+	}
+
+	const std::string serializedNode = YAML::Dump(editorTypes);
+	const size_t length = serializedNode.length();
+	yamlNode[0] = new char[length + 1];
+	memcpy(yamlNode[0], serializedNode.c_str(), length);
+	yamlNode[0][length] = '\0';
+
+	return static_cast<uint32_t>(length);
 }
 
 bool App::LoadEditorWorld(const char* strFileId)

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -12,10 +12,27 @@
 
 #include <algorithm>
 #include <cstring>
+#include <exception>
 #include <filesystem>
+#include <limits>
+#include <memory>
 #include <utility>
 
 using namespace Sailor;
+
+namespace
+{
+	void LogEditorTypeSerializationFailure(const char* message) noexcept
+	{
+		try
+		{
+			SAILOR_LOG_ERROR("Failed to serialize editor type metadata: %s", message);
+		}
+		catch (...)
+		{
+		}
+	}
+}
 
 uint32_t App::PullEditorMessages(char** messages, uint32_t num)
 {
@@ -109,33 +126,59 @@ uint32_t App::SerializeEditorTypes(char** yamlNode)
 	}
 
 	yamlNode[0] = nullptr;
-	YAML::Node editorTypes = Reflection::ExportEngineTypes();
-	if (App* app = GetInstance(); app && app->m_pWorkspaceModuleManager)
+	try
 	{
-		YAML::Node combinedTypes;
-		std::string mergeError;
-		if (app->m_pWorkspaceModuleManager->BuildEditorTypeMetadata(editorTypes, combinedTypes, mergeError))
+		YAML::Node editorTypes = Reflection::ExportEngineTypes();
+		if (App* app = GetInstance(); app && app->m_pWorkspaceModuleManager)
 		{
+			YAML::Node combinedTypes;
+			std::string mergeError;
+			if (!app->m_pWorkspaceModuleManager->BuildEditorTypeMetadata(
+					editorTypes,
+					combinedTypes,
+					mergeError))
+			{
+				LogEditorTypeSerializationFailure(mergeError.empty()
+					? "workspace editor metadata merge failed"
+					: mergeError.c_str());
+				return 0;
+			}
+
 			editorTypes = std::move(combinedTypes);
 		}
-		else
+
+		if (editorTypes.IsNull())
 		{
-			SAILOR_LOG_ERROR("Failed to merge workspace editor type metadata: %s", mergeError.c_str());
+			LogEditorTypeSerializationFailure("the editor type catalog is null");
+			return 0;
 		}
-	}
 
-	if (editorTypes.IsNull())
+		const std::string serializedNode = YAML::Dump(editorTypes);
+		const size_t length = serializedNode.length();
+		if (length > std::numeric_limits<uint32_t>::max())
+		{
+			LogEditorTypeSerializationFailure("the serialized catalog exceeds the interop size limit");
+			return 0;
+		}
+
+		auto serializedOutput = std::make_unique<char[]>(length + 1);
+		memcpy(serializedOutput.get(), serializedNode.c_str(), length);
+		serializedOutput[length] = '\0';
+		yamlNode[0] = serializedOutput.release();
+
+		return static_cast<uint32_t>(length);
+	}
+	catch (const std::exception& e)
 	{
-		return 0;
+		LogEditorTypeSerializationFailure(e.what());
+	}
+	catch (...)
+	{
+		LogEditorTypeSerializationFailure("an unknown native exception was raised");
 	}
 
-	const std::string serializedNode = YAML::Dump(editorTypes);
-	const size_t length = serializedNode.length();
-	yamlNode[0] = new char[length + 1];
-	memcpy(yamlNode[0], serializedNode.c_str(), length);
-	yamlNode[0][length] = '\0';
-
-	return static_cast<uint32_t>(length);
+	yamlNode[0] = nullptr;
+	return 0;
 }
 
 bool App::LoadEditorWorld(const char* strFileId)

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -63,6 +63,7 @@ namespace Sailor
 		SAILOR_API static uint32_t PullEditorMessages(char** messages, uint32_t num);
 		SAILOR_API static uint32_t SerializeCurrentWorld(char** yamlNode);
 		SAILOR_API static uint32_t SerializeEngineTypes(char** yamlNode);
+		SAILOR_API static uint32_t SerializeEditorTypes(char** yamlNode);
 		SAILOR_API static bool LoadEditorWorld(const char* strFileId);
 		SAILOR_API static bool UpdateEditorObject(const char* strInstanceId, const char* strYamlNode);
 		SAILOR_API static bool ReparentEditorObject(const char* strInstanceId, const char* strParentInstanceId, bool bKeepWorldTransform);

--- a/Runtime/Workspace/WorkspaceModuleManager.cpp
+++ b/Runtime/Workspace/WorkspaceModuleManager.cpp
@@ -747,6 +747,54 @@ namespace
 		return false;
 	}
 
+	bool CollectSharedEnumIdentities(
+		const YAML::Node& engineMetadata,
+		const YAML::Node& workspaceMetadata,
+		const std::unordered_set<std::string>& engineEnums,
+		std::unordered_set<std::string>& outSharedEnums,
+		std::string& outError)
+	{
+		for (const YAML::Node& workspaceEnum : workspaceMetadata["enums"])
+		{
+			const std::string identity = workspaceEnum.begin()->first.as<std::string>();
+			if (!engineEnums.contains(identity))
+			{
+				continue;
+			}
+
+			YAML::Node engineEnum;
+			for (const YAML::Node& candidate : engineMetadata["enums"])
+			{
+				if (candidate[identity])
+				{
+					engineEnum = candidate;
+					break;
+				}
+			}
+
+			const YAML::Node engineValues = engineEnum[identity];
+			const YAML::Node workspaceValues = workspaceEnum[identity];
+			bool bDefinitionsMatch = engineValues.IsSequence() &&
+				workspaceValues.IsSequence() &&
+				engineValues.size() == workspaceValues.size();
+			for (size_t index = 0; bDefinitionsMatch && index < engineValues.size(); ++index)
+			{
+				bDefinitionsMatch = engineValues[index].IsScalar() &&
+					workspaceValues[index].IsScalar() &&
+					engineValues[index].as<std::string>() == workspaceValues[index].as<std::string>();
+			}
+			if (!bDefinitionsMatch)
+			{
+				outError = "Workspace editor enum metadata conflicts with engine identity '" + identity + "'.";
+				return false;
+			}
+
+			outSharedEnums.insert(identity);
+		}
+
+		return true;
+	}
+
 	void SetMetadataError(std::string& outError, const std::string& message) noexcept
 	{
 		try
@@ -1226,9 +1274,20 @@ bool Sailor::Workspace::WorkspaceModuleManager::MergeEditorTypeMetadata(
 	{
 		MetadataIdentities engineIdentities;
 		MetadataIdentities workspaceIdentities;
+		std::unordered_set<std::string> sharedEnums;
 		std::string validationError;
 		if (!ValidateMetadataDocument(engineMetadata, false, {}, engineIdentities, validationError) ||
 			!ValidateMetadataDocument(workspaceMetadata, true, {}, workspaceIdentities, validationError))
+		{
+			outError = std::move(validationError);
+			return false;
+		}
+		if (!CollectSharedEnumIdentities(
+				engineMetadata,
+				workspaceMetadata,
+				engineIdentities.m_enums,
+				sharedEnums,
+				validationError))
 		{
 			outError = std::move(validationError);
 			return false;
@@ -1243,11 +1302,6 @@ bool Sailor::Workspace::WorkspaceModuleManager::MergeEditorTypeMetadata(
 				engineIdentities.m_cdos,
 				workspaceIdentities.m_cdos,
 				MetadataSections[1],
-				validationError) ||
-			HasMetadataCollision(
-				engineIdentities.m_enums,
-				workspaceIdentities.m_enums,
-				MetadataSections[2],
 				validationError) ||
 			HasMetadataCollision(
 				engineIdentities.m_assetTypes,
@@ -1269,6 +1323,11 @@ bool Sailor::Workspace::WorkspaceModuleManager::MergeEditorTypeMetadata(
 		{
 			for (const YAML::Node& entry : workspaceMetadata[sectionName])
 			{
+				if (std::strcmp(sectionName, "enums") == 0 &&
+					sharedEnums.contains(entry.begin()->first.as<std::string>()))
+				{
+					continue;
+				}
 				mergedMetadata[sectionName].push_back(YAML::Clone(entry));
 			}
 		}

--- a/Runtime/Workspace/WorkspaceModuleManager.cpp
+++ b/Runtime/Workspace/WorkspaceModuleManager.cpp
@@ -41,6 +41,23 @@ namespace
 		uint64_t m_totalCanonicalDefaultValuesLength = 0;
 	};
 
+	struct MetadataIdentities
+	{
+		std::unordered_set<std::string> m_engineTypes;
+		std::unordered_set<std::string> m_cdos;
+		std::unordered_set<std::string> m_enums;
+		std::unordered_set<std::string> m_assetTypes;
+		std::unordered_set<std::string> m_assetExtensions;
+	};
+
+	constexpr const char* MetadataSections[]
+	{
+		"engineTypes",
+		"cdos",
+		"enums",
+		"assetTypes"
+	};
+
 	uint32_t SAILOR_WORKSPACE_CALL CollectWorkspaceType(
 		void* context,
 		const WorkspaceTypeDescriptorV1* descriptor) noexcept
@@ -530,6 +547,217 @@ namespace
 
 		return true;
 	}
+
+	bool GetMetadataIdentity(
+		const YAML::Node& entry,
+		const char* sectionName,
+		std::string& outIdentity,
+		std::string& outError)
+	{
+		if (!entry.IsMap())
+		{
+			outError = "Editor metadata section '" + std::string(sectionName) + "' contains a non-map entry.";
+			return false;
+		}
+
+		if (std::strcmp(sectionName, "enums") == 0)
+		{
+			if (entry.size() != 1 || !entry.begin()->first.IsScalar() || !entry.begin()->second.IsSequence())
+			{
+				outError = "Editor metadata section 'enums' contains an invalid enum entry.";
+				return false;
+			}
+
+			outIdentity = entry.begin()->first.as<std::string>();
+		}
+		else
+		{
+			const YAML::Node typeName = entry["typename"];
+			if (!typeName.IsScalar())
+			{
+				outError = "Editor metadata section '" + std::string(sectionName) +
+					"' contains an entry without a scalar typename.";
+				return false;
+			}
+
+			outIdentity = typeName.as<std::string>();
+		}
+
+		if (outIdentity.empty())
+		{
+			outError = "Editor metadata section '" + std::string(sectionName) + "' contains an empty identity.";
+			return false;
+		}
+
+		return true;
+	}
+
+	bool CollectMetadataIdentities(
+		const YAML::Node& metadata,
+		const char* sectionName,
+		std::unordered_set<std::string>& outIdentities,
+		std::string& outError)
+	{
+		const YAML::Node entries = metadata[sectionName];
+		if (!entries.IsSequence())
+		{
+			outError = "Editor metadata section '" + std::string(sectionName) + "' must be a sequence.";
+			return false;
+		}
+
+		for (const YAML::Node& entry : entries)
+		{
+			std::string identity;
+			if (!GetMetadataIdentity(entry, sectionName, identity, outError))
+			{
+				return false;
+			}
+
+			if (!outIdentities.emplace(identity).second)
+			{
+				outError = "Editor metadata section '" + std::string(sectionName) +
+					"' contains duplicate identity '" + identity + "'.";
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool CollectAssetExtensions(
+		const YAML::Node& metadata,
+		std::unordered_set<std::string>& outExtensions,
+		std::string& outError)
+	{
+		for (const YAML::Node& assetType : metadata["assetTypes"])
+		{
+			const YAML::Node extensions = assetType["extensions"];
+			if (!extensions.IsDefined() || extensions.IsNull())
+			{
+				continue;
+			}
+			if (!extensions.IsSequence())
+			{
+				outError = "Editor asset metadata must provide an extension sequence.";
+				return false;
+			}
+
+			for (const YAML::Node& extensionNode : extensions)
+			{
+				if (!extensionNode.IsScalar())
+				{
+					outError = "Editor asset metadata contains a non-scalar extension.";
+					return false;
+				}
+
+				std::string extension = extensionNode.as<std::string>();
+				extension.erase(extension.begin(), std::find_if(extension.begin(), extension.end(), [](unsigned char character)
+					{
+						return !std::isspace(character);
+					}));
+				extension.erase(std::find_if(extension.rbegin(), extension.rend(), [](unsigned char character)
+					{
+						return !std::isspace(character);
+					}).base(), extension.end());
+				while (!extension.empty() && extension.front() == '.')
+				{
+					extension.erase(extension.begin());
+				}
+				std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char character)
+					{
+						return static_cast<char>(std::tolower(character));
+					});
+
+				if (extension.empty() || !outExtensions.emplace(extension).second)
+				{
+					outError = "Editor asset metadata contains an empty or duplicate extension '" + extension + "'.";
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	bool ValidateMetadataDocument(
+		const YAML::Node& metadata,
+		bool bWorkspaceMetadata,
+		const std::string& expectedModuleName,
+		MetadataIdentities& outIdentities,
+		std::string& outError)
+	{
+		if (!metadata.IsMap() || !metadata["timeStamp"].IsScalar())
+		{
+			outError = "Editor metadata must be a map with a scalar timeStamp.";
+			return false;
+		}
+
+		if (bWorkspaceMetadata)
+		{
+			if (!metadata["metadataVersion"].IsScalar() ||
+				metadata["metadataVersion"].as<uint32_t>() != WorkspaceTypeMetadataVersion ||
+				!metadata["moduleName"].IsScalar())
+			{
+				outError = "Workspace editor metadata has an invalid version or module identity.";
+				return false;
+			}
+
+			const std::string moduleName = metadata["moduleName"].as<std::string>();
+			if (moduleName.empty() || (!expectedModuleName.empty() && moduleName != expectedModuleName))
+			{
+				outError = "Workspace editor metadata module identity does not match the active module.";
+				return false;
+			}
+		}
+
+		if (!CollectMetadataIdentities(metadata, MetadataSections[0], outIdentities.m_engineTypes, outError) ||
+			!CollectMetadataIdentities(metadata, MetadataSections[1], outIdentities.m_cdos, outError) ||
+			!CollectMetadataIdentities(metadata, MetadataSections[2], outIdentities.m_enums, outError) ||
+			!CollectMetadataIdentities(metadata, MetadataSections[3], outIdentities.m_assetTypes, outError) ||
+			!CollectAssetExtensions(metadata, outIdentities.m_assetExtensions, outError))
+		{
+			return false;
+		}
+
+		if (bWorkspaceMetadata && outIdentities.m_engineTypes != outIdentities.m_cdos)
+		{
+			outError = "Workspace editor metadata must provide exactly one default object for every reflected type.";
+			return false;
+		}
+
+		return true;
+	}
+
+	bool HasMetadataCollision(
+		const std::unordered_set<std::string>& engineIdentities,
+		const std::unordered_set<std::string>& workspaceIdentities,
+		const char* sectionName,
+		std::string& outError)
+	{
+		for (const std::string& identity : workspaceIdentities)
+		{
+			if (engineIdentities.contains(identity))
+			{
+				outError = "Workspace editor metadata section '" + std::string(sectionName) +
+					"' conflicts with engine identity '" + identity + "'.";
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	void SetMetadataError(std::string& outError, const std::string& message) noexcept
+	{
+		try
+		{
+			outError = message;
+		}
+		catch (...)
+		{
+			outError.clear();
+		}
+	}
 }
 
 Sailor::Workspace::WorkspaceModuleManager::~WorkspaceModuleManager() noexcept
@@ -780,17 +1008,25 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 
 		yamlFailureStatus = EWorkspaceModuleLoadStatus::MetadataInvalid;
 		const YAML::Node metadata = YAML::Load(m_metadata);
-		if (!metadata.IsMap() ||
-			!metadata["metadataVersion"] ||
-			metadata["metadataVersion"].as<uint32_t>() != WorkspaceTypeMetadataVersion ||
-			!metadata["moduleName"] ||
-			metadata["moduleName"].as<std::string>() != moduleName ||
-			!metadata["engineTypes"].IsSequence() ||
-			!metadata["cdos"].IsSequence())
+		MetadataIdentities metadataIdentities;
+		std::string metadataError;
+		if (!ValidateMetadataDocument(metadata, true, moduleName, metadataIdentities, metadataError))
 		{
 			return Fail(
 				EWorkspaceModuleLoadStatus::MetadataInvalid,
-				"Workspace module metadata schema or module identity is invalid.");
+				std::move(metadataError));
+		}
+
+		YAML::Node editorMetadataPreflight;
+		if (!MergeEditorTypeMetadata(
+				Reflection::ExportEngineTypes(),
+				metadata,
+				editorMetadataPreflight,
+				metadataError))
+		{
+			return Fail(
+				EWorkspaceModuleLoadStatus::MetadataInvalid,
+				std::move(metadataError));
 		}
 
 		WorkspaceTypeCollector collector;
@@ -817,7 +1053,6 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 
 		MetadataEntries metadataTypes;
 		MetadataEntries metadataDefaults;
-		std::string metadataError;
 		if (!IndexMetadataEntries(metadata["engineTypes"], "engineTypes", metadataTypes, metadataError) ||
 			!IndexMetadataEntries(metadata["cdos"], "cdos", metadataDefaults, metadataError))
 		{
@@ -949,6 +1184,111 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 			EWorkspaceModuleLoadStatus::RegistrationFailed,
 			"Workspace module activation failed with an unknown error.");
 	}
+}
+
+bool Sailor::Workspace::WorkspaceModuleManager::BuildEditorTypeMetadata(
+	const YAML::Node& engineMetadata,
+	YAML::Node& outMetadata,
+	std::string& outError) const noexcept
+{
+	try
+	{
+		if (!IsRegistered() || m_metadata.empty())
+		{
+			YAML::Node engineOnly = YAML::Clone(engineMetadata);
+			outMetadata = std::move(engineOnly);
+			outError.clear();
+			return true;
+		}
+
+		const YAML::Node workspaceMetadata = YAML::Load(m_metadata);
+		return MergeEditorTypeMetadata(engineMetadata, workspaceMetadata, outMetadata, outError);
+	}
+	catch (const std::exception& e)
+	{
+		SetMetadataError(outError, "Failed to build editor type metadata: " + std::string(e.what()));
+	}
+	catch (...)
+	{
+		SetMetadataError(outError, "Failed to build editor type metadata.");
+	}
+
+	return false;
+}
+
+bool Sailor::Workspace::WorkspaceModuleManager::MergeEditorTypeMetadata(
+	const YAML::Node& engineMetadata,
+	const YAML::Node& workspaceMetadata,
+	YAML::Node& outMetadata,
+	std::string& outError) noexcept
+{
+	try
+	{
+		MetadataIdentities engineIdentities;
+		MetadataIdentities workspaceIdentities;
+		std::string validationError;
+		if (!ValidateMetadataDocument(engineMetadata, false, {}, engineIdentities, validationError) ||
+			!ValidateMetadataDocument(workspaceMetadata, true, {}, workspaceIdentities, validationError))
+		{
+			outError = std::move(validationError);
+			return false;
+		}
+
+		if (HasMetadataCollision(
+				engineIdentities.m_engineTypes,
+				workspaceIdentities.m_engineTypes,
+				MetadataSections[0],
+				validationError) ||
+			HasMetadataCollision(
+				engineIdentities.m_cdos,
+				workspaceIdentities.m_cdos,
+				MetadataSections[1],
+				validationError) ||
+			HasMetadataCollision(
+				engineIdentities.m_enums,
+				workspaceIdentities.m_enums,
+				MetadataSections[2],
+				validationError) ||
+			HasMetadataCollision(
+				engineIdentities.m_assetTypes,
+				workspaceIdentities.m_assetTypes,
+				MetadataSections[3],
+				validationError) ||
+			HasMetadataCollision(
+				engineIdentities.m_assetExtensions,
+				workspaceIdentities.m_assetExtensions,
+				"asset extensions",
+				validationError))
+		{
+			outError = std::move(validationError);
+			return false;
+		}
+
+		YAML::Node mergedMetadata = YAML::Clone(engineMetadata);
+		for (const char* sectionName : MetadataSections)
+		{
+			for (const YAML::Node& entry : workspaceMetadata[sectionName])
+			{
+				mergedMetadata[sectionName].push_back(YAML::Clone(entry));
+			}
+		}
+
+		mergedMetadata["metadataVersion"] = workspaceMetadata["metadataVersion"].as<uint32_t>();
+		mergedMetadata["moduleName"] = workspaceMetadata["moduleName"].as<std::string>();
+		outMetadata = std::move(mergedMetadata);
+		outError.clear();
+		return true;
+	}
+	catch (const std::exception& e)
+	{
+		SetMetadataError(outError, "Failed to merge editor type metadata: " + std::string(e.what()));
+	}
+	catch (...)
+	{
+		SetMetadataError(outError, "Failed to merge editor type metadata.");
+	}
+
+	return false;
 }
 
 bool Sailor::Workspace::WorkspaceModuleManager::Unload() noexcept

--- a/Runtime/Workspace/WorkspaceModuleManager.cpp
+++ b/Runtime/Workspace/WorkspaceModuleManager.cpp
@@ -198,6 +198,14 @@ namespace
 		return extension == ".sailor";
 	}
 
+	bool IsBlank(const std::string& value)
+	{
+		return value.empty() || std::all_of(value.begin(), value.end(), [](unsigned char character)
+			{
+				return std::isspace(character) != 0;
+			});
+	}
+
 	std::filesystem::path GetModuleFilename(const std::string& moduleName)
 	{
 #if defined(_WIN32)
@@ -211,6 +219,15 @@ namespace
 
 	using MetadataEntries = std::unordered_map<std::string, YAML::Node>;
 	using CollectedTypeInfos = std::unordered_map<std::string, const TypeInfo*>;
+	using EditorEnumDefinitions = std::unordered_map<std::string, std::unordered_set<std::string>>;
+
+	struct EditorTypeSchema
+	{
+		std::string m_baseType;
+		std::unordered_map<std::string, std::string> m_properties;
+	};
+
+	using EditorTypeSchemas = std::unordered_map<std::string, EditorTypeSchema>;
 	constexpr size_t MaxCanonicalYamlDepth = 64;
 	constexpr size_t MaxCanonicalYamlNodes = 262144;
 	constexpr size_t MaxCanonicalYamlBytes = 64 * 1024 * 1024;
@@ -583,7 +600,7 @@ namespace
 			outIdentity = typeName.as<std::string>();
 		}
 
-		if (outIdentity.empty())
+		if (IsBlank(outIdentity))
 		{
 			outError = "Editor metadata section '" + std::string(sectionName) + "' contains an empty identity.";
 			return false;
@@ -618,6 +635,263 @@ namespace
 				outError = "Editor metadata section '" + std::string(sectionName) +
 					"' contains duplicate identity '" + identity + "'.";
 				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool ValidateEditorTypeSchemas(
+		const YAML::Node& metadata,
+		bool bWorkspaceMetadata,
+		std::string& outError)
+	{
+		for (const YAML::Node& type : metadata["engineTypes"])
+		{
+			const std::string typeName = type["typename"].as<std::string>();
+			if (bWorkspaceMetadata && !type["base"].IsScalar())
+			{
+				outError = "Workspace editor metadata type '" + typeName +
+					"' must provide a scalar base type.";
+				return false;
+			}
+
+			const YAML::Node properties = type["properties"];
+			if ((bWorkspaceMetadata && !properties.IsDefined()) ||
+				(properties.IsDefined() && !properties.IsNull() && !properties.IsMap()))
+			{
+				outError = "Editor metadata type '" + typeName + "' has an invalid property schema.";
+				return false;
+			}
+
+			std::unordered_set<std::string> propertyNames;
+			if (properties.IsMap())
+			{
+				propertyNames.reserve(properties.size());
+				for (const auto& property : properties)
+				{
+					if (!property.first.IsScalar() || !property.second.IsScalar())
+					{
+						outError = "Editor metadata type '" + typeName +
+							"' must contain scalar property names and type names.";
+						return false;
+					}
+
+					const std::string propertyName = property.first.as<std::string>();
+					const std::string propertyType = property.second.as<std::string>();
+					if (IsBlank(propertyName) || IsBlank(propertyType) ||
+						!propertyNames.emplace(propertyName).second)
+					{
+						outError = "Editor metadata type '" + typeName +
+							"' contains an empty or duplicate property '" + propertyName + "'.";
+						return false;
+					}
+				}
+			}
+
+			YAML::Node readOnlyProperties(YAML::NodeType::Undefined);
+			for (const auto& field : type)
+			{
+				if (field.first.IsScalar() && field.first.as<std::string>() == "readOnlyProperties")
+				{
+					readOnlyProperties = field.second;
+					break;
+				}
+			}
+			if (bWorkspaceMetadata && !readOnlyProperties.IsSequence())
+			{
+				outError = "Workspace editor metadata type '" + typeName +
+					"' must provide a readOnlyProperties sequence.";
+				return false;
+			}
+			if (readOnlyProperties.IsDefined() && !readOnlyProperties.IsNull() &&
+				!readOnlyProperties.IsSequence())
+			{
+				outError = "Editor metadata type '" + typeName +
+					"' has an invalid readOnlyProperties schema.";
+				return false;
+			}
+
+			std::unordered_set<std::string> readOnlyPropertyNames;
+			if (readOnlyProperties.IsSequence())
+			{
+				readOnlyPropertyNames.reserve(readOnlyProperties.size());
+				for (const YAML::Node& property : readOnlyProperties)
+				{
+					if (!property.IsScalar())
+					{
+						outError = "Editor metadata type '" + typeName +
+							"' contains a non-scalar read-only property.";
+						return false;
+					}
+
+					const std::string propertyName = property.as<std::string>();
+					if (IsBlank(propertyName) || propertyNames.contains(propertyName) ||
+						!readOnlyPropertyNames.emplace(propertyName).second)
+					{
+						outError = "Editor metadata type '" + typeName +
+							"' contains invalid read-only property '" + propertyName + "'.";
+						return false;
+					}
+				}
+			}
+		}
+
+		return true;
+	}
+
+	bool CollectEditorEnumDefinitions(
+		const YAML::Node& metadata,
+		EditorEnumDefinitions& outDefinitions,
+		std::string& outError)
+	{
+		outDefinitions.clear();
+		for (const YAML::Node& enumEntry : metadata["enums"])
+		{
+			const std::string enumName = enumEntry.begin()->first.as<std::string>();
+			const YAML::Node values = enumEntry.begin()->second;
+			if (values.size() == 0)
+			{
+				outError = "Editor enum metadata '" + enumName + "' must declare at least one value.";
+				return false;
+			}
+
+			std::unordered_set<std::string> enumValues;
+			enumValues.reserve(values.size());
+			for (const YAML::Node& value : values)
+			{
+				if (!value.IsScalar())
+				{
+					outError = "Editor enum metadata '" + enumName + "' contains a non-scalar value.";
+					return false;
+				}
+
+				const std::string enumValue = value.as<std::string>();
+				if (IsBlank(enumValue) || !enumValues.emplace(enumValue).second)
+				{
+					outError = "Editor enum metadata '" + enumName +
+						"' contains an empty or duplicate value '" + enumValue + "'.";
+					return false;
+				}
+			}
+
+			if (!outDefinitions.emplace(enumName, std::move(enumValues)).second)
+			{
+				outError = "Editor enum metadata contains duplicate identity '" + enumName + "'.";
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	const std::string* FindEditorPropertyType(
+		const EditorTypeSchemas& schemas,
+		const std::string& typeName,
+		const std::string& propertyName)
+	{
+		std::unordered_set<std::string> visitedTypes;
+		std::string currentType = typeName;
+		while (!currentType.empty() && visitedTypes.emplace(currentType).second)
+		{
+			const auto schema = schemas.find(currentType);
+			if (schema == schemas.end())
+			{
+				return nullptr;
+			}
+
+			const auto property = schema->second.m_properties.find(propertyName);
+			if (property != schema->second.m_properties.end())
+			{
+				return &property->second;
+			}
+
+			currentType = schema->second.m_baseType;
+		}
+
+		return nullptr;
+	}
+
+	bool ValidateEditorMetadataCrossSchema(const YAML::Node& metadata, std::string& outError)
+	{
+		EditorEnumDefinitions enumDefinitions;
+		if (!CollectEditorEnumDefinitions(metadata, enumDefinitions, outError))
+		{
+			return false;
+		}
+
+		EditorTypeSchemas typeSchemas;
+		typeSchemas.reserve(metadata["engineTypes"].size());
+		for (const YAML::Node& type : metadata["engineTypes"])
+		{
+			const std::string typeName = type["typename"].as<std::string>();
+			EditorTypeSchema schema;
+			if (type["base"].IsScalar())
+			{
+				schema.m_baseType = type["base"].as<std::string>();
+			}
+			if (type["properties"].IsMap())
+			{
+				for (const auto& property : type["properties"])
+				{
+					const std::string propertyName = property.first.as<std::string>();
+					const std::string propertyType = property.second.as<std::string>();
+					if (propertyType.rfind("enum ", 0) == 0 && !enumDefinitions.contains(propertyType))
+					{
+						outError = "Editor property '" + typeName + "::" + propertyName +
+							"' references missing enum metadata '" + propertyType + "'.";
+						return false;
+					}
+					schema.m_properties.emplace(propertyName, propertyType);
+				}
+			}
+			typeSchemas.emplace(typeName, std::move(schema));
+		}
+
+		for (const YAML::Node& defaultObject : metadata["cdos"])
+		{
+			const std::string typeName = defaultObject["typename"].as<std::string>();
+			if (!typeSchemas.contains(typeName))
+			{
+				outError = "Editor default object '" + typeName + "' has no matching reflected type.";
+				return false;
+			}
+
+			const YAML::Node defaultValues = defaultObject["defaultValues"];
+			if (!defaultValues.IsDefined() || (!defaultValues.IsNull() && !defaultValues.IsMap()))
+			{
+				outError = "Editor default object '" + typeName + "' has an invalid defaultValues schema.";
+				return false;
+			}
+			if (!defaultValues.IsMap())
+			{
+				continue;
+			}
+
+			for (const auto& defaultValue : defaultValues)
+			{
+				if (!defaultValue.first.IsScalar())
+				{
+					outError = "Editor default object '" + typeName + "' contains a non-scalar property name.";
+					return false;
+				}
+
+				const std::string propertyName = defaultValue.first.as<std::string>();
+				const std::string* propertyType = FindEditorPropertyType(typeSchemas, typeName, propertyName);
+				if (propertyType == nullptr || propertyType->rfind("enum ", 0) != 0)
+				{
+					continue;
+				}
+
+				const auto enumDefinition = enumDefinitions.find(*propertyType);
+				if (!defaultValue.second.IsScalar() ||
+					enumDefinition == enumDefinitions.end() ||
+					!enumDefinition->second.contains(defaultValue.second.as<std::string>()))
+				{
+					outError = "Editor enum default '" + typeName + "::" + propertyName +
+						"' is not a declared member of '" + *propertyType + "'.";
+					return false;
+				}
 			}
 		}
 
@@ -703,7 +977,7 @@ namespace
 			}
 
 			const std::string moduleName = metadata["moduleName"].as<std::string>();
-			if (moduleName.empty() || (!expectedModuleName.empty() && moduleName != expectedModuleName))
+			if (IsBlank(moduleName) || (!expectedModuleName.empty() && moduleName != expectedModuleName))
 			{
 				outError = "Workspace editor metadata module identity does not match the active module.";
 				return false;
@@ -714,7 +988,14 @@ namespace
 			!CollectMetadataIdentities(metadata, MetadataSections[1], outIdentities.m_cdos, outError) ||
 			!CollectMetadataIdentities(metadata, MetadataSections[2], outIdentities.m_enums, outError) ||
 			!CollectMetadataIdentities(metadata, MetadataSections[3], outIdentities.m_assetTypes, outError) ||
-			!CollectAssetExtensions(metadata, outIdentities.m_assetExtensions, outError))
+			!CollectAssetExtensions(metadata, outIdentities.m_assetExtensions, outError) ||
+			!ValidateEditorTypeSchemas(metadata, bWorkspaceMetadata, outError))
+		{
+			return false;
+		}
+
+		EditorEnumDefinitions enumDefinitions;
+		if (!CollectEditorEnumDefinitions(metadata, enumDefinitions, outError))
 		{
 			return false;
 		}
@@ -1334,6 +1615,11 @@ bool Sailor::Workspace::WorkspaceModuleManager::MergeEditorTypeMetadata(
 
 		mergedMetadata["metadataVersion"] = workspaceMetadata["metadataVersion"].as<uint32_t>();
 		mergedMetadata["moduleName"] = workspaceMetadata["moduleName"].as<std::string>();
+		if (!ValidateEditorMetadataCrossSchema(mergedMetadata, validationError))
+		{
+			outError = std::move(validationError);
+			return false;
+		}
 		outMetadata = std::move(mergedMetadata);
 		outError.clear();
 		return true;

--- a/Runtime/Workspace/WorkspaceModuleManager.h
+++ b/Runtime/Workspace/WorkspaceModuleManager.h
@@ -6,6 +6,11 @@
 #include <filesystem>
 #include <string>
 
+namespace YAML
+{
+	class Node;
+}
+
 namespace Sailor::Workspace
 {
 	enum class EWorkspaceModuleState : uint32_t
@@ -73,6 +78,16 @@ namespace Sailor::Workspace
 			const std::filesystem::path& manifestPath,
 			std::string buildConfig) noexcept;
 		bool Unload() noexcept;
+		bool BuildEditorTypeMetadata(
+			const YAML::Node& engineMetadata,
+			YAML::Node& outMetadata,
+			std::string& outError) const noexcept;
+
+		static bool MergeEditorTypeMetadata(
+			const YAML::Node& engineMetadata,
+			const YAML::Node& workspaceMetadata,
+			YAML::Node& outMetadata,
+			std::string& outError) noexcept;
 
 		EWorkspaceModuleState GetState() const noexcept { return m_state; }
 		const WorkspaceModuleLoadResult& GetResult() const noexcept { return m_result; }

--- a/Runtime/Workspace/WorkspaceTypeMetadata.h
+++ b/Runtime/Workspace/WorkspaceTypeMetadata.h
@@ -11,6 +11,7 @@
 #include <string_view>
 #include <type_traits>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 
 namespace Sailor::Workspace
@@ -151,6 +152,85 @@ namespace Sailor::Workspace
 			return GetWorkspaceDefaultObjectSnapshot<TType>().m_metadata;
 		}
 
+		template<typename TType>
+		YAML::Node SerializeWorkspaceType()
+		{
+			YAML::Node metadata = TypeInfo::Get<TType>().Serialize();
+			std::unordered_set<std::string> writableProperties;
+			for_each(refl::reflect<TType>().members, [&](auto member)
+				{
+					if constexpr (is_writable(member))
+					{
+						writableProperties.insert(get_display_name(member));
+					}
+				});
+
+			YAML::Node readOnlyProperties(YAML::NodeType::Sequence);
+			std::unordered_set<std::string> emittedReadOnlyProperties;
+			for_each(refl::reflect<TType>().members, [&](auto member)
+				{
+					if constexpr (is_readable(member) &&
+						!refl::descriptor::has_attribute<Attributes::Transient>(member))
+					{
+						const std::string displayName = get_display_name(member);
+						if (!writableProperties.contains(displayName) &&
+							emittedReadOnlyProperties.insert(displayName).second)
+						{
+							readOnlyProperties.push_back(displayName);
+						}
+					}
+				});
+
+			metadata["readOnlyProperties"] = std::move(readOnlyProperties);
+			return metadata;
+		}
+
+		template<typename TProperty>
+		void AppendWorkspaceEnum(YAML::Node& enums, std::unordered_set<std::string>& enumNames)
+		{
+			using EnumType = ::refl::trait::remove_qualifiers_t<TProperty>;
+			if constexpr (std::is_enum_v<EnumType>)
+			{
+				const std::string enumName = TypeInfo::GetReflectedEnumTypeName<EnumType>();
+				if (!enumNames.insert(enumName).second)
+				{
+					return;
+				}
+
+				YAML::Node values(YAML::NodeType::Sequence);
+				for (const auto& value : magic_enum::enum_names<EnumType>())
+				{
+					values.push_back(std::string(value));
+				}
+
+				YAML::Node metadata;
+				metadata[enumName] = std::move(values);
+				enums.push_back(std::move(metadata));
+			}
+		}
+
+		template<typename TType>
+		void AppendWorkspaceEnums(YAML::Node& enums, std::unordered_set<std::string>& enumNames)
+		{
+			TType* empty = nullptr;
+			for_each(refl::reflect<TType>().members, [&](auto member)
+				{
+					if constexpr (is_writable(member))
+					{
+						if constexpr (is_readable(member))
+						{
+							using PropertyType = ::refl::trait::remove_qualifiers_t<decltype(member(*empty))>;
+							AppendWorkspaceEnum<PropertyType>(enums, enumNames);
+						}
+						else
+						{
+							using PropertyType = ::refl::trait::remove_qualifiers_t<decltype(get_reader(member)(*empty))>;
+							AppendWorkspaceEnum<PropertyType>(enums, enumNames);
+						}
+					}
+				});
+		}
+
 		template<typename TWorkspaceTypes>
 		struct TWorkspaceTypeMetadataSerializer;
 
@@ -165,10 +245,14 @@ namespace Sailor::Workspace
 				}
 
 				YAML::Node types(YAML::NodeType::Sequence);
-				(types.push_back(TypeInfo::Get<TTypes>().Serialize()), ...);
+				(types.push_back(SerializeWorkspaceType<TTypes>()), ...);
 
 				YAML::Node defaultObjects(YAML::NodeType::Sequence);
 				(defaultObjects.push_back(SerializeWorkspaceDefaultObject<TTypes>()), ...);
+
+				YAML::Node enums(YAML::NodeType::Sequence);
+				std::unordered_set<std::string> enumNames;
+				(AppendWorkspaceEnums<TTypes>(enums, enumNames), ...);
 
 				YAML::Node metadata;
 				metadata["metadataVersion"] = WorkspaceTypeMetadataVersion;
@@ -176,7 +260,7 @@ namespace Sailor::Workspace
 				metadata["timeStamp"] = std::time(nullptr);
 				metadata["engineTypes"] = types;
 				metadata["cdos"] = defaultObjects;
-				metadata["enums"] = YAML::Node(YAML::NodeType::Sequence);
+				metadata["enums"] = std::move(enums);
 				metadata["assetTypes"] = YAML::Node(YAML::NodeType::Sequence);
 
 				YAML::Emitter emitter;

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -84,6 +84,10 @@ add_workspace_malformed_metadata_fixture(
     WorkspaceModuleMissingEmptyPropertySchemaFixture MissingEmptyPropertySchemaFixture 11)
 add_workspace_malformed_metadata_fixture(
     WorkspaceModuleAliasExpansionFixture AliasExpansionFixture 12)
+add_workspace_malformed_metadata_fixture(
+    WorkspaceModuleInvalidReadOnlyPropertiesFixture InvalidReadOnlyPropertiesFixture 13)
+add_workspace_malformed_metadata_fixture(
+    WorkspaceModuleMissingEnumDefinitionFixture MissingEnumDefinitionFixture 14)
 
 add_executable(WorkspaceModuleContractTests
     WorkspaceModuleContractTests.cpp
@@ -161,6 +165,8 @@ add_dependencies(WorkspaceModuleRuntimeTests
     WorkspaceModuleShadowedPropertyFixture
     WorkspaceModuleMissingEmptyPropertySchemaFixture
     WorkspaceModuleAliasExpansionFixture
+    WorkspaceModuleInvalidReadOnlyPropertiesFixture
+    WorkspaceModuleMissingEnumDefinitionFixture
 )
 set_target_properties(WorkspaceModuleFixture PROPERTIES OUTPUT_NAME WorkspaceFixture)
 set_target_properties(WorkspaceModuleIncompatibleFixture PROPERTIES OUTPUT_NAME IncompatibleFixture)
@@ -271,6 +277,8 @@ add_test(
         $<TARGET_FILE:WorkspaceModuleShadowedPropertyFixture>
         $<TARGET_FILE:WorkspaceModuleMissingEmptyPropertySchemaFixture>
         $<TARGET_FILE:WorkspaceModuleAliasExpansionFixture>
+        $<TARGET_FILE:WorkspaceModuleInvalidReadOnlyPropertiesFixture>
+        $<TARGET_FILE:WorkspaceModuleMissingEnumDefinitionFixture>
         $<CONFIG>
 )
 set_tests_properties(

--- a/Tests/WorkspaceModuleContractTests.cpp
+++ b/Tests/WorkspaceModuleContractTests.cpp
@@ -399,6 +399,12 @@ namespace
 			after["engineTypes"].size() == engineTypeCount,
 			"workspace metadata export should preserve the engine registry contents");
 	}
+
+	void TestStablePropertyNames()
+	{
+		Require(TypeInfo::GetReflectedPropertyTypeName<uint32_t>() == "uint32",
+			"workspace metadata should use a platform-independent uint32 property name");
+	}
 }
 
 int main()
@@ -409,6 +415,7 @@ int main()
 		{ "RepeatedAndConcurrentCalls", TestRepeatedAndConcurrentCalls },
 		{ "FactoryInvocationLease", TestFactoryInvocationLease },
 		{ "EngineRegistryRemainsEngineOnly", TestEngineRegistryRemainsEngineOnly },
+		{ "StablePropertyNames", TestStablePropertyNames },
 	};
 
 	for (const auto& test : tests)

--- a/Tests/WorkspaceModuleContractTests.cpp
+++ b/Tests/WorkspaceModuleContractTests.cpp
@@ -100,6 +100,27 @@ namespace
 		return YAML::Node(YAML::NodeType::Undefined);
 	}
 
+	const YAML::Node FindEnum(const YAML::Node& enums, const std::string& enumName)
+	{
+		for (const YAML::Node& reflectedEnum : enums)
+		{
+			if (reflectedEnum[enumName])
+			{
+				return reflectedEnum[enumName];
+			}
+		}
+
+		return YAML::Node(YAML::NodeType::Undefined);
+	}
+
+	bool ContainsScalar(const YAML::Node& values, const std::string& expected)
+	{
+		return std::any_of(values.begin(), values.end(), [&](const YAML::Node& value)
+			{
+				return value.IsScalar() && value.as<std::string>() == expected;
+			});
+	}
+
 	bool ContainsType(const YAML::Node& metadata, const std::string& typeName)
 	{
 		return FindType(metadata["engineTypes"], typeName).IsDefined();
@@ -160,10 +181,27 @@ namespace
 			"workspace component metadata should preserve reflected bool properties");
 		Require(!type["properties"]["readOnlyValue"].IsDefined(),
 			"getter-only properties should remain outside the writable property schema");
+		Require(type["readOnlyProperties"].IsSequence() &&
+			ContainsScalar(type["readOnlyProperties"], "readOnlyValue") &&
+			ContainsScalar(type["readOnlyProperties"], "skippedReadOnlyValue"),
+			"workspace metadata should explicitly identify serialized read-only properties");
 		Require(type["properties"]["skippedDefault"].as<std::string>() == "float",
 			"SkipCDO properties should remain available in the writable property schema");
 		Require(type["properties"]["mode"].as<std::string>().rfind("enum ", 0) == 0,
 			"workspace component metadata should preserve reflected enum properties");
+		const YAML::Node fixtureModeValues = FindEnum(
+			metadata["enums"],
+			type["properties"]["mode"].as<std::string>());
+		Require(fixtureModeValues.IsSequence() && fixtureModeValues.size() == 2,
+			"workspace metadata should export values for reflected enum properties");
+		Require(fixtureModeValues[0].as<std::string>() == "Default" &&
+			fixtureModeValues[1].as<std::string>() == "Alternate",
+			"workspace metadata should preserve reflected enum value names");
+		const YAML::Node mobilityValues = FindEnum(
+			metadata["enums"],
+			type["properties"]["mobility"].as<std::string>());
+		Require(mobilityValues.IsSequence() && mobilityValues.size() > 0,
+			"workspace metadata should describe referenced engine enum values");
 		Require(type["properties"]["offset"].IsScalar(),
 			"workspace component metadata should preserve custom structured property types");
 		Require(type["properties"]["nullableComponent"].IsScalar(),
@@ -183,6 +221,8 @@ namespace
 			"workspace defaults should include inherited Component instanceId metadata");
 		Require(defaultObject["defaultValues"]["readOnlyValue"].as<int32_t>() == 17,
 			"workspace defaults should include getter-only reflected properties");
+		Require(!defaultObject["defaultValues"]["skippedReadOnlyValue"].IsDefined(),
+			"workspace defaults should omit getter-only properties marked SkipCDO");
 		Require(!defaultObject["defaultValues"]["skippedDefault"].IsDefined(),
 			"workspace defaults should omit properties marked SkipCDO");
 		Require(defaultObject["defaultValues"]["mode"].as<std::string>() == "Default",

--- a/Tests/WorkspaceModuleFixture.cpp
+++ b/Tests/WorkspaceModuleFixture.cpp
@@ -25,10 +25,13 @@ namespace WorkspaceFixture
 		bool GetRegistryLookupSucceeded() const { return m_registryLookupSucceeded; }
 		void SetRegistryLookupSucceeded(bool succeeded) { m_registryLookupSucceeded = succeeded; }
 		int32_t GetReadOnlyValue() const { return m_readOnlyValue; }
+		int32_t GetSkippedReadOnlyValue() const { return m_skippedReadOnlyValue; }
 		float GetSkippedDefault() const { return m_skippedDefault; }
 		void SetSkippedDefault(float value) { m_skippedDefault = value; }
 		EFixtureMode GetMode() const { return m_mode; }
 		void SetMode(EFixtureMode mode) { m_mode = mode; }
+		Sailor::EMobilityType GetMobility() const { return m_mobility; }
+		void SetMobility(Sailor::EMobilityType mobility) { m_mobility = mobility; }
 		glm::vec3 GetOffset() const { return m_offset; }
 		void SetOffset(const glm::vec3& offset) { m_offset = offset; }
 		Sailor::ComponentPtr GetNullableComponent() const { return m_nullableComponent; }
@@ -38,8 +41,10 @@ namespace WorkspaceFixture
 		float m_moveSpeed = 5.0f;
 		bool m_registryLookupSucceeded = false;
 		int32_t m_readOnlyValue = 17;
+		int32_t m_skippedReadOnlyValue = 23;
 		float m_skippedDefault = 9.0f;
 		EFixtureMode m_mode = EFixtureMode::Default;
+		Sailor::EMobilityType m_mobility = Sailor::EMobilityType::Stationary;
 		glm::vec3 m_offset{ 1.0f, 2.0f, 3.0f };
 		Sailor::ComponentPtr m_nullableComponent;
 	};
@@ -54,10 +59,13 @@ REFL_AUTO(
 	func(GetRegistryLookupSucceeded, property("registryLookupSucceeded")),
 	func(SetRegistryLookupSucceeded, property("registryLookupSucceeded")),
 	func(GetReadOnlyValue, property("readOnlyValue")),
+	func(GetSkippedReadOnlyValue, property("skippedReadOnlyValue"), Sailor::Attributes::SkipCDO()),
 	func(GetSkippedDefault, property("skippedDefault"), Sailor::Attributes::SkipCDO()),
 	func(SetSkippedDefault, property("skippedDefault"), Sailor::Attributes::SkipCDO()),
 	func(GetMode, property("mode")),
 	func(SetMode, property("mode")),
+	func(GetMobility, property("mobility")),
+	func(SetMobility, property("mobility")),
 	func(GetOffset, property("offset")),
 	func(SetOffset, property("offset")),
 	func(GetNullableComponent, property("nullableComponent")),

--- a/Tests/WorkspaceModuleMalformedMetadataFixture.cpp
+++ b/Tests/WorkspaceModuleMalformedMetadataFixture.cpp
@@ -34,6 +34,10 @@
 #define SAILOR_TEST_FIXTURE_NAMESPACE MissingEmptyPropertySchemaWorkspaceFixture
 #elif SAILOR_TEST_METADATA_MODE == 12
 #define SAILOR_TEST_FIXTURE_NAMESPACE AliasExpansionWorkspaceFixture
+#elif SAILOR_TEST_METADATA_MODE == 13
+#define SAILOR_TEST_FIXTURE_NAMESPACE InvalidReadOnlyPropertiesWorkspaceFixture
+#elif SAILOR_TEST_METADATA_MODE == 14
+#define SAILOR_TEST_FIXTURE_NAMESPACE MissingEnumDefinitionWorkspaceFixture
 #else
 #error Unsupported SAILOR_TEST_METADATA_MODE
 #endif
@@ -163,6 +167,10 @@ namespace
 	constexpr char WorkspaceModuleName[] = "MissingEmptyPropertySchemaFixture";
 #elif SAILOR_TEST_METADATA_MODE == 12
 	constexpr char WorkspaceModuleName[] = "AliasExpansionFixture";
+#elif SAILOR_TEST_METADATA_MODE == 13
+	constexpr char WorkspaceModuleName[] = "InvalidReadOnlyPropertiesFixture";
+#elif SAILOR_TEST_METADATA_MODE == 14
+	constexpr char WorkspaceModuleName[] = "MissingEnumDefinitionFixture";
 #else
 #error Unsupported SAILOR_TEST_METADATA_MODE
 #endif
@@ -197,6 +205,11 @@ namespace
 		metadata["engineTypes"][0].remove("properties");
 #elif SAILOR_TEST_METADATA_MODE == 12
 		// The alias expansion is injected into the serialized payload below.
+#elif SAILOR_TEST_METADATA_MODE == 13
+		metadata["engineTypes"][0]["readOnlyProperties"] = YAML::Node(YAML::NodeType::Map);
+#elif SAILOR_TEST_METADATA_MODE == 14
+		metadata["engineTypes"][0]["properties"]["mode"] =
+			"enum MissingEnumDefinitionWorkspaceFixture::MissingMode";
 #endif
 
 		YAML::Emitter emitter;

--- a/Tests/WorkspaceModuleRuntimeTests.cpp
+++ b/Tests/WorkspaceModuleRuntimeTests.cpp
@@ -6,6 +6,7 @@
 #include "Workspace/WorkspaceModuleApi.h"
 #include "Workspace/WorkspaceModuleManager.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cctype>
 #include <filesystem>
@@ -113,6 +114,14 @@ namespace
 		return YAML::Node(YAML::NodeType::Undefined);
 	}
 
+	size_t CountEnumEntries(const YAML::Node& entries, const std::string& enumName)
+	{
+		return static_cast<size_t>(std::count_if(entries.begin(), entries.end(), [&](const YAML::Node& entry)
+			{
+				return entry[enumName].IsDefined();
+			}));
+	}
+
 	void TestEditorMetadataMergeRollback(
 		const YAML::Node& engineMetadata,
 		const YAML::Node& workspaceMetadata)
@@ -146,6 +155,31 @@ namespace
 			"editor metadata collision diagnostic should identify the conflicting type");
 		Require(output.size() == 1 && output["sentinel"].as<std::string>() == "unchanged",
 			"failed duplicate merge must not partially mutate its output");
+
+		constexpr const char* EngineEnumName = "enum Sailor::EMobilityType";
+		YAML::Node enumCollision = YAML::Clone(workspaceMetadata);
+		bool bChangedEnum = false;
+		for (YAML::Node workspaceEnum : enumCollision["enums"])
+		{
+			if (workspaceEnum[EngineEnumName])
+			{
+				workspaceEnum[EngineEnumName] = YAML::Load("[Mismatched]");
+				bChangedEnum = true;
+				break;
+			}
+		}
+		Require(bChangedEnum, "workspace fixture should reference an engine enum for merge validation");
+		error.clear();
+		Require(!WorkspaceModuleManager::MergeEditorTypeMetadata(
+				engineMetadata,
+				enumCollision,
+				output,
+				error),
+			"editor metadata merge should reject conflicting engine enum definitions");
+		Require(error.find(EngineEnumName) != std::string::npos,
+			"engine enum collision diagnostic should identify the conflicting enum");
+		Require(output.size() == 1 && output["sentinel"].as<std::string>() == "unchanged",
+			"failed enum merge must not partially mutate its output");
 
 		YAML::Node malformedMetadata = YAML::Clone(workspaceMetadata);
 		malformedMetadata["assetTypes"] = YAML::Node(YAML::NodeType::Map);
@@ -526,6 +560,8 @@ namespace
 		Require(editorDefaults.IsDefined() &&
 			editorDefaults["defaultValues"]["moveSpeed"].as<float>() == 5.0f,
 			"combined editor metadata should expose workspace component defaults");
+		Require(CountEnumEntries(editorTypes["enums"], "enum Sailor::EMobilityType") == 1,
+			"combined editor metadata should deduplicate referenced engine enum definitions");
 		TestEditorMetadataMergeRollback(engineTypesBefore, YAML::Load(manager.GetMetadata()));
 
 		const TypeInfo* fixtureType = Reflection::TryGetTypeByName(FixtureTypeName);
@@ -541,8 +577,12 @@ namespace
 				"workspace component construction should re-enter reflection lookup without holding the registry lock");
 			Require(reflected.GetProperties()["readOnlyValue"].as<int32_t>() == 17,
 				"workspace component construction should preserve getter-only reflected defaults");
+			Require(reflected.GetProperties()["skippedReadOnlyValue"].as<int32_t>() == 23,
+				"workspace component serialization should retain getter-only SkipCDO properties");
 			Require(reflected.GetProperties()["mode"].as<std::string>() == "Default",
 				"workspace component construction should preserve validated enum defaults");
+			Require(reflected.GetProperties()["mobility"].as<std::string>() == "Stationary",
+				"workspace component construction should preserve referenced engine enum defaults");
 			Require(reflected.GetProperties()["offset"].IsSequence(),
 				"workspace component construction should preserve validated structured defaults");
 			Require(reflected.GetProperties()["nullableComponent"].IsNull(),

--- a/Tests/WorkspaceModuleRuntimeTests.cpp
+++ b/Tests/WorkspaceModuleRuntimeTests.cpp
@@ -7,6 +7,7 @@
 #include "Workspace/WorkspaceModuleManager.h"
 
 #include <chrono>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -95,6 +96,100 @@ namespace
 			}
 		}
 		return false;
+	}
+
+	YAML::Node FindMetadataEntry(
+		const YAML::Node& entries,
+		const std::string& typeName)
+	{
+		for (const YAML::Node& entry : entries)
+		{
+			if (entry["typename"] && entry["typename"].as<std::string>() == typeName)
+			{
+				return entry;
+			}
+		}
+
+		return YAML::Node(YAML::NodeType::Undefined);
+	}
+
+	void TestEditorMetadataMergeRollback(
+		const YAML::Node& engineMetadata,
+		const YAML::Node& workspaceMetadata)
+	{
+		std::string collisionTypeName;
+		for (const YAML::Node& type : engineMetadata["engineTypes"])
+		{
+			const std::string typeName = type["typename"].as<std::string>();
+			if (FindMetadataEntry(engineMetadata["cdos"], typeName).IsDefined())
+			{
+				collisionTypeName = typeName;
+				break;
+			}
+		}
+		Require(!collisionTypeName.empty(), "engine metadata should contain a type with a default object");
+
+		YAML::Node duplicateMetadata = YAML::Clone(workspaceMetadata);
+		duplicateMetadata["engineTypes"][0]["typename"] = collisionTypeName;
+		duplicateMetadata["cdos"][0]["typename"] = collisionTypeName;
+
+		YAML::Node output;
+		output["sentinel"] = "unchanged";
+		std::string error;
+		Require(!WorkspaceModuleManager::MergeEditorTypeMetadata(
+				engineMetadata,
+				duplicateMetadata,
+				output,
+				error),
+			"editor metadata merge should reject engine/workspace type collisions");
+		Require(error.find(collisionTypeName) != std::string::npos,
+			"editor metadata collision diagnostic should identify the conflicting type");
+		Require(output.size() == 1 && output["sentinel"].as<std::string>() == "unchanged",
+			"failed duplicate merge must not partially mutate its output");
+
+		YAML::Node malformedMetadata = YAML::Clone(workspaceMetadata);
+		malformedMetadata["assetTypes"] = YAML::Node(YAML::NodeType::Map);
+		error.clear();
+		Require(!WorkspaceModuleManager::MergeEditorTypeMetadata(
+				engineMetadata,
+				malformedMetadata,
+				output,
+				error),
+			"editor metadata merge should reject malformed workspace sections");
+		Require(!error.empty(), "malformed editor metadata should return a diagnostic");
+		Require(output.size() == 1 && output["sentinel"].as<std::string>() == "unchanged",
+			"failed malformed merge must not partially mutate its output");
+
+		std::string collisionExtension;
+		for (const YAML::Node& assetTypeNode : engineMetadata["assetTypes"])
+		{
+			if (assetTypeNode["extensions"].IsSequence() && assetTypeNode["extensions"].size() > 0)
+			{
+				collisionExtension = assetTypeNode["extensions"][0].as<std::string>();
+				break;
+			}
+		}
+		Require(!collisionExtension.empty(), "engine metadata should expose an asset extension for collision testing");
+		std::transform(collisionExtension.begin(), collisionExtension.end(), collisionExtension.begin(), [](unsigned char character)
+			{
+				return static_cast<char>(std::toupper(character));
+			});
+
+		YAML::Node extensionCollision = YAML::Clone(workspaceMetadata);
+		YAML::Node assetType;
+		assetType["typename"] = "WorkspaceFixture::CollidingAsset";
+		assetType["extensions"].push_back(" ." + collisionExtension + " ");
+		assetType["properties"] = YAML::Node(YAML::NodeType::Sequence);
+		extensionCollision["assetTypes"].push_back(assetType);
+		error.clear();
+		Require(!WorkspaceModuleManager::MergeEditorTypeMetadata(
+				engineMetadata,
+				extensionCollision,
+				output,
+				error),
+			"editor metadata merge should reject normalized asset extension collisions");
+		Require(output.size() == 1 && output["sentinel"].as<std::string>() == "unchanged",
+			"failed extension merge must not partially mutate its output");
 	}
 
 	void TestDiscoveryFailures(const std::filesystem::path& tempRoot, const std::string& config)
@@ -393,6 +488,17 @@ namespace
 		Require(engineComponentType != nullptr, "engine Component TypeInfo should be registered");
 		Require(!ContainsEngineType(engineTypesBefore, FixtureTypeName),
 			"workspace fixture must not be present before module registration");
+		WorkspaceModuleManager engineOnlyManager;
+		YAML::Node engineOnlyEditorTypes;
+		std::string metadataError;
+		Require(engineOnlyManager.BuildEditorTypeMetadata(
+				engineTypesBefore,
+				engineOnlyEditorTypes,
+				metadataError),
+			"unconfigured workspace should build engine-only editor metadata: " + metadataError);
+		Require(engineOnlyEditorTypes["engineTypes"].size() == engineTypesBefore["engineTypes"].size() &&
+			!ContainsEngineType(engineOnlyEditorTypes, FixtureTypeName),
+			"unconfigured editor metadata should remain engine-only");
 
 		const std::filesystem::path root = tempRoot / "registered";
 		WriteManifest(root, FixtureModuleName);
@@ -406,6 +512,21 @@ namespace
 			"workspace fixture type should be visible in unified reflection lookup");
 		Require(Reflection::TryGetTypeByName("Sailor::Component") == engineComponentType,
 			"loading a workspace DLL must not replace host engine type registration");
+
+		YAML::Node editorTypes;
+		Require(manager.BuildEditorTypeMetadata(engineTypesBefore, editorTypes, metadataError),
+			"active workspace should build combined editor metadata: " + metadataError);
+		Require(editorTypes["engineTypes"].size() == engineTypesBefore["engineTypes"].size() + 1,
+			"combined editor metadata should append the workspace type exactly once");
+		Require(ContainsEngineType(editorTypes, FixtureTypeName),
+			"combined editor metadata should expose the workspace component FQN");
+		Require(editorTypes["moduleName"].as<std::string>() == FixtureModuleName,
+			"combined editor metadata should identify the active workspace module");
+		const YAML::Node editorDefaults = FindMetadataEntry(editorTypes["cdos"], FixtureTypeName);
+		Require(editorDefaults.IsDefined() &&
+			editorDefaults["defaultValues"]["moveSpeed"].as<float>() == 5.0f,
+			"combined editor metadata should expose workspace component defaults");
+		TestEditorMetadataMergeRollback(engineTypesBefore, YAML::Load(manager.GetMetadata()));
 
 		const TypeInfo* fixtureType = Reflection::TryGetTypeByName(FixtureTypeName);
 		Require(fixtureType != nullptr, "workspace fixture TypeInfo should be discoverable by name");
@@ -426,6 +547,27 @@ namespace
 				"workspace component construction should preserve validated structured defaults");
 			Require(reflected.GetProperties()["nullableComponent"].IsNull(),
 				"workspace component construction should preserve a null object reference");
+		}
+		{
+			YAML::Node serializedComponent;
+			serializedComponent["typename"] = FixtureTypeName;
+			serializedComponent["overrideProperties"]["moveSpeed"] = 12.5f;
+
+			ReflectedData deserializedComponent;
+			deserializedComponent.Deserialize(serializedComponent);
+			Require(deserializedComponent.IsValid() &&
+				deserializedComponent.GetTypeInfo().Name() == FixtureTypeName,
+				"workspace component deserialization should preserve its exact FQN");
+
+			ComponentPtr roundTrippedComponent = Reflection::CreateObject<Component>(*fixtureType, allocator);
+			Require(static_cast<bool>(roundTrippedComponent) &&
+				Reflection::ApplyReflection(roundTrippedComponent.GetRawPtr(), deserializedComponent),
+				"workspace component should be recreated and populated from serialized reflection");
+			const YAML::Node roundTrippedYaml = roundTrippedComponent->GetReflectedData().Serialize();
+			Require(roundTrippedYaml["typename"].as<std::string>() == FixtureTypeName &&
+				roundTrippedYaml["overrideProperties"]["moveSpeed"].as<float>() == 12.5f,
+				"workspace component round trip should preserve type identity and scalar values");
+			roundTrippedComponent.ForcelyDestroyObject();
 		}
 		Require(Reflection::GetCDO(FixtureTypeName).GetProperties()["moveSpeed"].as<float>() == 5.0f,
 			"workspace registry should preserve metadata defaults");
@@ -456,6 +598,12 @@ namespace
 			"workspace type should be removed before its library closes");
 		Require(Reflection::TryGetTypeByName("Sailor::Component") == engineComponentType,
 			"workspace unload must preserve host engine type registration");
+		YAML::Node editorTypesAfterUnload;
+		Require(manager.BuildEditorTypeMetadata(engineTypesBefore, editorTypesAfterUnload, metadataError),
+			"unloaded workspace should rebuild a fresh engine-only editor catalog: " + metadataError);
+		Require(!ContainsEngineType(editorTypesAfterUnload, FixtureTypeName) &&
+			editorTypesAfterUnload["engineTypes"].size() == engineTypesBefore["engineTypes"].size(),
+			"workspace unload must remove custom entries from editor metadata");
 		const auto& reload = collisionManager.Load(collisionRoot, {}, config);
 		Require(reload.IsSuccess(), "workspace module should reload after owner cleanup: " + reload.m_message);
 		Require(collisionManager.Unload(), "reloaded workspace fixture should unload cleanly");

--- a/Tests/WorkspaceModuleRuntimeTests.cpp
+++ b/Tests/WorkspaceModuleRuntimeTests.cpp
@@ -194,6 +194,91 @@ namespace
 		Require(output.size() == 1 && output["sentinel"].as<std::string>() == "unchanged",
 			"failed malformed merge must not partially mutate its output");
 
+		auto requireCrossSchemaRejection = [&](YAML::Node invalidMetadata,
+			const char* expectedDiagnostic,
+			const char* message)
+		{
+			error.clear();
+			Require(!WorkspaceModuleManager::MergeEditorTypeMetadata(
+					engineMetadata,
+					invalidMetadata,
+					output,
+					error),
+				message);
+			Require(error.find(expectedDiagnostic) != std::string::npos,
+				std::string(message) + ": " + error);
+			Require(output.size() == 1 && output["sentinel"].as<std::string>() == "unchanged",
+				"failed cross-schema merge must not partially mutate its output");
+		};
+
+		YAML::Node malformedReadOnlyProperties = YAML::Clone(workspaceMetadata);
+		malformedReadOnlyProperties["engineTypes"][0]["readOnlyProperties"] =
+			YAML::Node(YAML::NodeType::Map);
+		requireCrossSchemaRejection(
+			std::move(malformedReadOnlyProperties),
+			"readOnlyProperties",
+			"editor metadata merge should reject malformed read-only property schemas");
+
+		YAML::Node duplicateReadOnlyProperty = YAML::Clone(workspaceMetadata);
+		duplicateReadOnlyProperty["engineTypes"][0]["readOnlyProperties"].push_back(
+			duplicateReadOnlyProperty["engineTypes"][0]["readOnlyProperties"][0]);
+		requireCrossSchemaRejection(
+			std::move(duplicateReadOnlyProperty),
+			"read-only property",
+			"editor metadata merge should reject duplicate read-only properties");
+
+		YAML::Node overlappingReadOnlyProperty = YAML::Clone(workspaceMetadata);
+		overlappingReadOnlyProperty["engineTypes"][0]["readOnlyProperties"].push_back("moveSpeed");
+		requireCrossSchemaRejection(
+			std::move(overlappingReadOnlyProperty),
+			"moveSpeed",
+			"editor metadata merge should reject writable/read-only property overlap");
+
+		YAML::Node missingEnumDefinition = YAML::Clone(workspaceMetadata);
+		missingEnumDefinition["engineTypes"][0]["properties"]["mode"] =
+			"enum WorkspaceFixture::MissingMode";
+		requireCrossSchemaRejection(
+			std::move(missingEnumDefinition),
+			"references missing enum metadata",
+			"editor metadata merge should reject missing enum definitions");
+
+		const std::string fixtureEnumName =
+			workspaceMetadata["engineTypes"][0]["properties"]["mode"].as<std::string>();
+		YAML::Node emptyEnumDefinition = YAML::Clone(workspaceMetadata);
+		for (YAML::Node enumEntry : emptyEnumDefinition["enums"])
+		{
+			if (enumEntry[fixtureEnumName])
+			{
+				enumEntry[fixtureEnumName] = YAML::Node(YAML::NodeType::Sequence);
+				break;
+			}
+		}
+		requireCrossSchemaRejection(
+			std::move(emptyEnumDefinition),
+			"at least one value",
+			"editor metadata merge should reject empty enum definitions");
+
+		YAML::Node duplicateEnumValue = YAML::Clone(workspaceMetadata);
+		for (YAML::Node enumEntry : duplicateEnumValue["enums"])
+		{
+			if (enumEntry[fixtureEnumName])
+			{
+				enumEntry[fixtureEnumName].push_back(enumEntry[fixtureEnumName][0]);
+				break;
+			}
+		}
+		requireCrossSchemaRejection(
+			std::move(duplicateEnumValue),
+			"duplicate value",
+			"editor metadata merge should reject duplicate enum values");
+
+		YAML::Node invalidEnumDefault = YAML::Clone(workspaceMetadata);
+		invalidEnumDefault["cdos"][0]["defaultValues"]["mode"] = "NotARealMode";
+		requireCrossSchemaRejection(
+			std::move(invalidEnumDefault),
+			"not a declared member",
+			"editor metadata merge should reject enum defaults outside the declared membership");
+
 		std::string collisionExtension;
 		for (const YAML::Node& assetTypeNode : engineMetadata["assetTypes"])
 		{
@@ -412,6 +497,8 @@ namespace
 		const std::filesystem::path& shadowedPropertyLibrary,
 		const std::filesystem::path& missingEmptyPropertySchemaLibrary,
 		const std::filesystem::path& aliasExpansionLibrary,
+		const std::filesystem::path& invalidReadOnlyPropertiesLibrary,
+		const std::filesystem::path& missingEnumDefinitionLibrary,
 		const std::string& config)
 	{
 		auto requireRejected = [&](const char* directoryName,
@@ -475,7 +562,8 @@ namespace
 			"invalid-enum-default",
 			"InvalidEnumDefaultFixture",
 			"InvalidEnumDefaultWorkspaceFixture::FixtureComponent",
-			invalidEnumDefaultLibrary);
+			invalidEnumDefaultLibrary,
+			"not a declared member");
 		requireRejected(
 			"invalid-structured-default",
 			"InvalidStructuredDefaultFixture",
@@ -510,6 +598,18 @@ namespace
 			"AliasExpansionWorkspaceFixture::FixtureComponent",
 			aliasExpansionLibrary,
 			"canonical descriptor snapshot");
+		requireRejected(
+			"invalid-read-only-properties",
+			"InvalidReadOnlyPropertiesFixture",
+			"InvalidReadOnlyPropertiesWorkspaceFixture::FixtureComponent",
+			invalidReadOnlyPropertiesLibrary,
+			"readOnlyProperties");
+		requireRejected(
+			"missing-enum-definition",
+			"MissingEnumDefinitionFixture",
+			"MissingEnumDefinitionWorkspaceFixture::FixtureComponent",
+			missingEnumDefinitionLibrary,
+			"references missing enum metadata");
 	}
 
 	void TestRegistrationInstantiationAndCleanup(
@@ -658,7 +758,7 @@ namespace
 
 int main(int argc, char** argv)
 {
-	if (argc != 17)
+	if (argc != 19)
 	{
 		std::cerr << "Usage: WorkspaceModuleRuntimeTests <fixture> <incompatible-fixture> "
 			"<missing-entry-fixture> <property-mismatch-fixture> <duplicate-cdo-fixture> "
@@ -666,7 +766,8 @@ int main(int argc, char** argv)
 			"<invalid-enum-default-fixture> <invalid-structured-default-fixture> "
 			"<missing-cdo-fixture> <oversized-structured-default-fixture> "
 			"<shadowed-property-fixture> <missing-empty-property-schema-fixture> "
-			"<alias-expansion-fixture> <config>" << std::endl;
+			"<alias-expansion-fixture> <invalid-read-only-properties-fixture> "
+			"<missing-enum-definition-fixture> <config>" << std::endl;
 		return 1;
 	}
 
@@ -685,7 +786,9 @@ int main(int argc, char** argv)
 	const std::filesystem::path shadowedPropertyLibrary = std::filesystem::absolute(argv[13]);
 	const std::filesystem::path missingEmptyPropertySchemaLibrary = std::filesystem::absolute(argv[14]);
 	const std::filesystem::path aliasExpansionLibrary = std::filesystem::absolute(argv[15]);
-	const std::string config = argv[16];
+	const std::filesystem::path invalidReadOnlyPropertiesLibrary = std::filesystem::absolute(argv[16]);
+	const std::filesystem::path missingEnumDefinitionLibrary = std::filesystem::absolute(argv[17]);
+	const std::string config = argv[18];
 	const auto uniqueSuffix = std::chrono::steady_clock::now().time_since_epoch().count();
 	const std::filesystem::path tempRoot = std::filesystem::temp_directory_path() /
 		("sailor-workspace-module-runtime-" + std::to_string(uniqueSuffix));
@@ -714,6 +817,8 @@ int main(int argc, char** argv)
 			shadowedPropertyLibrary,
 			missingEmptyPropertySchemaLibrary,
 			aliasExpansionLibrary,
+			invalidReadOnlyPropertiesLibrary,
+			missingEnumDefinitionLibrary,
 			config);
 		TestRegistrationInstantiationAndCleanup(tempRoot, fixtureLibrary, config);
 		std::filesystem::remove_all(tempRoot);


### PR DESCRIPTION
Closes #81.

## Summary

- export workspace component, property, default-value, and enum metadata through the runtime bridge
- merge workspace types into the editor catalog with transactional collision and cross-schema validation
- create inspector controls for custom scalar and enum properties
- preserve getter-only/read-only workspace properties during YAML round trips
- reject invalid enum defaults/overrides and preserve numeric values during transient invalid input
- contain native interop exceptions and report metadata merge failures without engine-only fallback
- add contract coverage for custom components, enum values, defaults, readonly properties, malformed metadata, rollback, and converters

## Validation

- [x] rebased directly onto current `main` after #92
- [x] `python3 update_deps.py`
- [x] Editor contracts — 170/170
- [x] local WorkspaceModuleContractTests + WorkspaceModuleRuntimeTests — 2/2
- [x] final Tech Review approved
- [x] Windows Editor / .NET 10 MAUI — SUCCESS
- [x] Windows clang-cl — build, CTest 9/9, install, generated workspace 2/2
- [x] Windows MSVC — build, CTest 9/9, install, generated workspace 2/2
- [x] `git diff --check`

Validated exact head: `df842bc7670301181474876371a31e3839a4a751`.

## Non-Goals

Visual scripting, hot reload UX, packaging, and broad prefab workflow redesign remain outside this PR.