### PR TITLE
[Workspace] Resolve manifest-owned paths end to end

### DIFF
--- a/Docs/WorkspaceLogic.md
+++ b/Docs/WorkspaceLogic.md
@@ -33,9 +33,15 @@ The default manifest values are:
 | Field | Default | Meaning |
 | --- | --- | --- |
 | `engineReferenceKind` | `source` | Use an engine source tree; `installed` selects a CMake package prefix. |
+| `contentPath` | `Content` | User-authored assets owned by the workspace. |
+| `sourcePath` | `Source` | User-authored game logic sources. |
+| `generatedProjectPath` | `Generated` | Generated project files owned by the workspace. |
+| `cachePath` | `Cache` | Disposable workspace runtime and editor caches. |
 | `buildPath` | `Cache/Build` | CMake binary directory relative to the workspace. |
 | `logicOutputPath` | `Binaries` | Root for configuration-specific module outputs. |
 | `logicModuleName` | `SailorGame` | Generated shared-library target and module name. |
+
+All workspace-owned paths in the table are safe relative paths. Rooted, drive-relative, traversal, and physical symlink or junction escapes are rejected. `enginePath` is intentionally different: it is an external engine source or install reference and may resolve outside the workspace.
 
 ## Source Engine Reference
 
@@ -110,11 +116,15 @@ Workspace placement factories run without the reflection registry mutex held, so
 
 ## Runtime Discovery And Lifecycle
 
-At startup, the runtime resolves the active workspace before content scanning. `--workspace-manifest <path>` selects an explicit manifest inside that workspace. Without the option, discovery prefers `workspace.sailor`; if that file is absent, exactly one root-level `*.sailor` file is accepted. No manifest preserves legacy engine-only startup, while multiple candidates are rejected with an ambiguity diagnostic.
+At startup, the runtime resolves one immutable workspace context before module loading, content scanning, registry construction, or cache initialization. The context contains the canonical root and manifest plus the resolved Content, Cache, Source, Generated, Build, logic-output, workspace identity, version, and module name. The editor resolves the same manifest-owned paths in its workspace session and passes the exact root, manifest, Content, and Cache paths into its launch contract.
 
-For manifest version 1, the runtime resolves the module as `<workspace>/<logicOutputPath>/<CONFIG>/<platform-module-name>`. The default values are `Binaries` and `SailorGame`. The manifest output path, module name, build configuration, and canonical module path are validated so discovery cannot escape the workspace. The active CMake configuration is part of both the path and ABI check, so a stale Debug/Release binary fails with rebuild guidance instead of being loaded as a compatible module.
+`--workspace-manifest <path>` selects an explicit manifest inside the workspace. Without the option, discovery prefers `workspace.sailor`; if that file is absent, exactly one root-level `*.sailor` file is accepted. No manifest creates a legacy context using `<root>/Content` and `<root>/Cache`; multiple candidates are rejected with an ambiguity diagnostic.
 
-The dynamic library is opened before asset importers scan `Content`. Static engine registration callbacks triggered by the platform loader are suppressed for that load operation; only the explicit V1 descriptor callback can add workspace types. The host validates the complete descriptor and metadata set before committing it under a module owner. Missing libraries, loader dependencies, entry points, incompatible API/ABI, metadata errors, and registration collisions return structured non-crashing diagnostics.
+Every workspace-owned manifest path is normalized lexically and then checked for physical containment after existing symlinks or Windows junctions are resolved. Validation completes before the context or editor session is published. A missing default `Content` directory is recreated, while a missing custom content path is rejected without creating a replacement. Cache directories are disposable and are recreated at their configured path. If later validation or recovery fails, directories created by that resolution attempt are rolled back.
+
+For manifest version 1, the runtime resolves the module as `<resolved-logic-output>/<CONFIG>/<platform-module-name>`. `WorkspaceModuleManager` consumes the captured context and never reparses the manifest. It canonicalizes the final module path again immediately before loading and rejects any symlink or junction change observed by that check. Concurrent mutation of the workspace or build tree during the platform's pathname-only library-loader call is not supported. The active CMake configuration is part of both the path and ABI check, so a stale Debug/Release binary fails with rebuild guidance instead of being loaded as a compatible module.
+
+The dynamic library is opened before asset importers scan the resolved Content directory. Asset, shader, precompiled-shader, and editor-type caches use the resolved Cache directory, including custom paths with spaces. The generated shader constants library is written below resolved Content. Static engine registration callbacks triggered by the platform loader are suppressed for that load operation; only the explicit V1 descriptor callback can add workspace types. The host validates the complete descriptor and metadata set before committing it under a module owner. Missing libraries, loader dependencies, entry points, incompatible API/ABI, metadata errors, and registration collisions return structured non-crashing diagnostics.
 
 Standalone startup treats a configured module or requested-world activation failure as fatal and returns a nonzero exit code. Editor startup reports the same error but remains available with an empty world so the project can be repaired. During shutdown, worlds, importers, the asset registry, scheduler, and remaining submodules are destroyed before workspace registrations are removed and the library is closed. Runtime hot reload and live workspace switching are not supported by this contract.
 

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -62,6 +62,7 @@
     <Compile Include="..\Editor\Content\ProjectContentFolderIds.cs" Link="Content\ProjectContentFolderIds.cs" />
     <Compile Include="..\Editor\Content\ProjectContentPathPolicy.cs" Link="Content\ProjectContentPathPolicy.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceManifest.cs" Link="Workspace\WorkspaceManifest.cs" />
+    <Compile Include="..\Editor\Workspace\WorkspacePathPolicy.cs" Link="Workspace\WorkspacePathPolicy.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceLifecycle.cs" Link="Workspace\WorkspaceLifecycle.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceProjectGenerator.cs" Link="Workspace\WorkspaceProjectGenerator.cs" />
     <Compile Include="..\Editor\Utility\EngineTypeMetadataContract.cs" Link="Utility\EngineTypeMetadataContract.cs" />

--- a/Editor.Tests/EngineLaunchContractTests.cs
+++ b/Editor.Tests/EngineLaunchContractTests.cs
@@ -3,20 +3,30 @@ using SailorEditor.Services;
 public class EngineLaunchContractTests
 {
     [Fact]
-    public void Resolve_UsesActiveWorkspaceRoot()
+    public void Resolve_UsesResolvedActiveWorkspacePaths()
     {
         var fallbackRoot = Path.Combine(Path.GetTempPath(), "Sailor");
         var workspaceRoot = Path.Combine(Path.GetTempPath(), "Sailor Workspaces", "Sandbox");
         var manifestPath = Path.Combine(workspaceRoot, "Sandbox Project.sailor");
+        var contentDirectory = Path.Combine(workspaceRoot, "Project Content");
+        var cacheDirectory = Path.Combine(workspaceRoot, "Generated Cache");
 
-        var context = EngineLaunchContract.Resolve(workspaceRoot, manifestPath, fallbackRoot);
+        var context = Resolve(
+            workspaceRoot,
+            manifestPath,
+            contentDirectory,
+            cacheDirectory,
+            fallbackRoot);
 
         Assert.Equal(Path.GetFullPath(workspaceRoot), context.WorkspaceRoot);
         Assert.Equal(Path.GetFullPath(manifestPath), context.WorkspaceManifestPath);
-        Assert.Equal(Path.Combine(workspaceRoot, "Content"), context.ContentDirectory);
-        Assert.Equal(Path.Combine(workspaceRoot, "Cache"), context.CacheDirectory);
-        Assert.Equal(Path.Combine(workspaceRoot, "Cache", "Temp.world"), context.TempWorldFilePath);
-        Assert.Equal(Path.Combine(workspaceRoot, "Cache", "EditorTypes.yaml"), context.EditorTypesCacheFilePath);
+        Assert.Equal(Path.GetFullPath(contentDirectory), context.ContentDirectory);
+        Assert.Equal(Path.GetFullPath(cacheDirectory), context.CacheDirectory);
+        Assert.Equal(Path.Combine(cacheDirectory, "Temp.world"), context.TempWorldFilePath);
+        Assert.Equal(
+            Path.GetRelativePath(contentDirectory, Path.Combine(cacheDirectory, "Temp.world")),
+            context.TempWorldRuntimePath);
+        Assert.Equal(Path.Combine(cacheDirectory, "EditorTypes.yaml"), context.EditorTypesCacheFilePath);
     }
 
     [Theory]
@@ -27,9 +37,17 @@ public class EngineLaunchContractTests
     {
         var fallbackRoot = Path.Combine(Path.GetTempPath(), "Sailor");
 
-        var context = EngineLaunchContract.Resolve(activeWorkspaceRoot, fallbackRoot);
+        var context = EngineLaunchContract.Resolve(
+            activeWorkspaceRoot,
+            null,
+            null,
+            null,
+            fallbackRoot);
 
         Assert.Equal(Path.GetFullPath(fallbackRoot), context.WorkspaceRoot);
+        Assert.Equal(Path.Combine(Path.GetFullPath(fallbackRoot), "Content"), context.ContentDirectory);
+        Assert.Equal(Path.Combine(Path.GetFullPath(fallbackRoot), "Cache"), context.CacheDirectory);
+        Assert.Equal(Path.Combine(Path.GetFullPath(fallbackRoot), "Cache", "EditorTypes.yaml"), context.EditorTypesCacheFilePath);
     }
 
     [Fact]
@@ -37,9 +55,16 @@ public class EngineLaunchContractTests
     {
         var workspaceRoot = Path.Combine(Path.GetTempPath(), "Sailor Workspaces", "Sandbox");
         var manifestPath = Path.Combine(workspaceRoot, "Sandbox Project.sailor");
-        var context = EngineLaunchContract.Resolve(workspaceRoot, manifestPath, Path.GetTempPath());
+        var contentDirectory = Path.Combine(workspaceRoot, "Project Content");
+        var cacheDirectory = Path.Combine(workspaceRoot, "Cache With Spaces");
+        var context = Resolve(
+            workspaceRoot,
+            manifestPath,
+            contentDirectory,
+            cacheDirectory,
+            Path.GetTempPath());
 
-        var arguments = context.BuildArguments("../Cache/Temp world.world", ["--noconsole", "--editor"]);
+        var arguments = context.BuildArguments(context.TempWorldRuntimePath, ["--noconsole", "--editor"]);
 
         Assert.Equal(
             [
@@ -48,7 +73,7 @@ public class EngineLaunchContractTests
                 "--workspace-manifest",
                 Path.GetFullPath(manifestPath),
                 "--world",
-                "../Cache/Temp world.world",
+                Path.GetRelativePath(contentDirectory, Path.Combine(cacheDirectory, "Temp.world")),
                 "--noconsole",
                 "--editor"
             ],
@@ -58,7 +83,13 @@ public class EngineLaunchContractTests
     [Fact]
     public void BuildInteropArguments_KeepsWorldFlagAndValueSeparate()
     {
-        var context = EngineLaunchContract.Resolve(Path.Combine(Path.GetTempPath(), "Sandbox"), Path.GetTempPath());
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), "Sandbox");
+        var context = Resolve(
+            workspaceRoot,
+            null,
+            Path.Combine(workspaceRoot, "Content"),
+            Path.Combine(workspaceRoot, "Cache"),
+            Path.GetTempPath());
 
         var arguments = context.BuildInteropArguments("SailorEditor", "Editor.world", ["--editor"]);
 
@@ -75,9 +106,45 @@ public class EngineLaunchContractTests
         var fallbackRoot = Path.Combine(Path.GetTempPath(), "Sailor");
         var ignoredManifest = Path.Combine(Path.GetTempPath(), "Ignored.sailor");
 
-        var context = EngineLaunchContract.Resolve(null, ignoredManifest, fallbackRoot);
+        var context = Resolve(null, ignoredManifest, null, null, fallbackRoot);
 
         Assert.Null(context.WorkspaceManifestPath);
         Assert.DoesNotContain("--workspace-manifest", context.BuildArguments("Editor.world"));
     }
+
+    [Theory]
+    [InlineData(null, "Cache")]
+    [InlineData("Content", null)]
+    public void Resolve_RejectsActiveWorkspaceWithoutResolvedPaths(
+        string? contentDirectoryName,
+        string? cacheDirectoryName)
+    {
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), "Sandbox");
+        var contentDirectory = contentDirectoryName is null
+            ? null
+            : Path.Combine(workspaceRoot, contentDirectoryName);
+        var cacheDirectory = cacheDirectoryName is null
+            ? null
+            : Path.Combine(workspaceRoot, cacheDirectoryName);
+
+        Assert.Throws<ArgumentException>(() => Resolve(
+            workspaceRoot,
+            null,
+            contentDirectory,
+            cacheDirectory,
+            Path.GetTempPath()));
+    }
+
+    static EngineLaunchContext Resolve(
+        string? workspaceRoot,
+        string? manifestPath,
+        string? contentDirectory,
+        string? cacheDirectory,
+        string fallbackRoot)
+        => EngineLaunchContract.Resolve(
+            workspaceRoot,
+            manifestPath,
+            contentDirectory,
+            cacheDirectory,
+            fallbackRoot);
 }

--- a/Editor.Tests/ProjectContentPathPolicyTests.cs
+++ b/Editor.Tests/ProjectContentPathPolicyTests.cs
@@ -1,4 +1,6 @@
+using System.Diagnostics;
 using SailorEditor.Content;
+using SailorEditor.Workspace;
 
 public class ProjectContentPathPolicyTests
 {
@@ -23,9 +25,6 @@ public class ProjectContentPathPolicyTests
     [Fact]
     public void IsInsideRoot_RejectsDescendantSymlinkThatEscapesRoot()
     {
-        if (OperatingSystem.IsWindows())
-            return;
-
         var testRoot = Path.Combine(Path.GetTempPath(), $"sailor-path-policy-{Guid.NewGuid():N}");
         var contentRoot = Path.Combine(testRoot, "Content");
         var externalRoot = Path.Combine(testRoot, "External");
@@ -35,9 +34,10 @@ public class ProjectContentPathPolicyTests
         {
             Directory.CreateDirectory(contentRoot);
             Directory.CreateDirectory(externalRoot);
-            Directory.CreateSymbolicLink(linkPath, externalRoot);
+            CreateDirectoryLink(linkPath, externalRoot);
 
             Assert.False(ProjectContentPathPolicy.IsInsideRoot(contentRoot, Path.Combine(linkPath, "asset.asset")));
+            Assert.False(WorkspacePathPolicy.IsInsideRoot(contentRoot, Path.Combine(linkPath, "asset.asset")));
         }
         finally
         {
@@ -51,9 +51,6 @@ public class ProjectContentPathPolicyTests
     [Fact]
     public void IsSamePath_ResolvesSymlinkTargetAliases()
     {
-        if (OperatingSystem.IsWindows())
-            return;
-
         var testRoot = Path.Combine(Path.GetTempPath(), $"sailor-path-alias-{Guid.NewGuid():N}");
         var contentRoot = Path.Combine(testRoot, "Content");
         var linkPath = Path.Combine(contentRoot, "Cycle");
@@ -61,8 +58,12 @@ public class ProjectContentPathPolicyTests
         try
         {
             Directory.CreateDirectory(contentRoot);
-            Directory.CreateSymbolicLink(linkPath, contentRoot);
+            CreateDirectoryLink(linkPath, contentRoot);
 
+            Assert.Equal(
+                WorkspacePathPolicy.NormalizePhysicalPath(contentRoot),
+                WorkspacePathPolicy.NormalizePhysicalPath(linkPath),
+                ignoreCase: OperatingSystem.IsWindows());
             Assert.True(ProjectContentPathPolicy.IsSamePath(contentRoot, linkPath));
         }
         finally
@@ -71,6 +72,37 @@ public class ProjectContentPathPolicyTests
                 Directory.Delete(linkPath);
             if (Directory.Exists(testRoot))
                 Directory.Delete(testRoot, recursive: true);
+        }
+    }
+
+    static void CreateDirectoryLink(string linkPath, string targetPath)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Directory.CreateSymbolicLink(linkPath, targetPath);
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo("cmd.exe")
+        {
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("/d");
+        startInfo.ArgumentList.Add("/c");
+        startInfo.ArgumentList.Add("mklink");
+        startInfo.ArgumentList.Add("/J");
+        startInfo.ArgumentList.Add(linkPath);
+        startInfo.ArgumentList.Add(targetPath);
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Could not start mklink.");
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Could not create test junction: {process.StandardError.ReadToEnd()}{process.StandardOutput.ReadToEnd()}");
         }
     }
 }

--- a/Editor.Tests/WorkspaceLifecycleTests.cs
+++ b/Editor.Tests/WorkspaceLifecycleTests.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using SailorEditor.Workspace;
 
 namespace SailorEditor.Editor.Tests;
@@ -29,8 +30,8 @@ public sealed class WorkspaceLifecycleTests
         Assert.True(File.Exists(workspace.File("Source/WorkspaceTypes.h")));
         Assert.True(File.Exists(workspace.File("Source/WorkspaceModule.cpp")));
         Assert.Equal("workspace-id", result.Session.Manifest.WorkspaceId);
-        Assert.Equal(workspace.Directory("Cache/Build"), result.Session.BuildDirectory);
-        Assert.Equal(workspace.Directory("Binaries"), result.Session.LogicOutputDirectory);
+        Assert.Equal(Physical(workspace.Directory("Cache/Build")), result.Session.BuildDirectory);
+        Assert.Equal(Physical(workspace.Directory("Binaries")), result.Session.LogicOutputDirectory);
     }
 
     [Fact]
@@ -47,7 +48,7 @@ public sealed class WorkspaceLifecycleTests
         Assert.NotNull(reopened.Session);
         Assert.Equal(created.Session.ManifestPath, reopened.Session.ManifestPath);
         Assert.Equal("Sandbox", reopened.Session.Manifest.Name);
-        Assert.Equal(workspace.Directory("Content"), reopened.Session.ContentDirectory);
+        Assert.Equal(Physical(workspace.Directory("Content")), reopened.Session.ContentDirectory);
     }
 
     [Fact]
@@ -61,7 +62,7 @@ public sealed class WorkspaceLifecycleTests
         var result = await service.CreateAsync(new WorkspaceCreateRequest("Sandbox", workspace.Root, "../Sailor", "workspace-id", manifestPath));
 
         Assert.True(result.Succeeded, result.Error);
-        Assert.Equal(Path.GetFullPath(manifestPath), result.Session!.ManifestPath);
+        Assert.Equal(Physical(manifestPath), result.Session!.ManifestPath);
         Assert.True(File.Exists(manifestPath));
         Assert.False(File.Exists(workspace.File(WorkspaceTemplateService.ManifestFileName)));
     }
@@ -160,7 +161,7 @@ public sealed class WorkspaceLifecycleTests
         var result = await service.OpenAsync(manifestPath);
 
         Assert.True(result.Succeeded, result.Error);
-        Assert.Equal(Path.GetFullPath(manifestPath), result.Session!.ManifestPath);
+        Assert.Equal(Physical(manifestPath), result.Session!.ManifestPath);
     }
 
     [Fact]
@@ -175,12 +176,161 @@ public sealed class WorkspaceLifecycleTests
         {
             ContentPath = "ProjectContent"
         };
+        Directory.CreateDirectory(workspace.Directory("ProjectContent"));
         await serializer.SaveAsync(manifestPath, manifest);
 
         var result = await service.OpenAsync(manifestPath);
 
         Assert.True(result.Succeeded, result.Error);
-        Assert.Equal(Path.GetFullPath(workspace.Directory("ProjectContent")), result.Session!.ContentDirectory);
+        Assert.Equal(Physical(workspace.Directory("ProjectContent")), result.Session!.ContentDirectory);
+    }
+
+    [Fact]
+    public async Task OpenAsync_RecoversMissingDefaultContentAndCacheDirectories()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var created = await service.CreateAsync(new WorkspaceCreateRequest("Sandbox", workspace.Root, "../Sailor", "workspace-id"));
+        Directory.Delete(workspace.Directory("Content"), recursive: true);
+        Directory.Delete(workspace.Directory("Cache"), recursive: true);
+
+        var reopened = await service.OpenAsync(created.Session!.ManifestPath);
+
+        Assert.True(reopened.Succeeded, reopened.Error);
+        Assert.True(Directory.Exists(workspace.Directory("Content")));
+        Assert.True(Directory.Exists(workspace.Directory("Cache")));
+    }
+
+    [Fact]
+    public async Task OpenAsync_RecoversMissingCustomCacheDirectory()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var serializer = new WorkspaceManifestSerializer();
+        var service = CreateService(recent.File("recent.yaml"));
+        var manifestPath = workspace.File("workspace.sailor");
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id") with
+        {
+            CachePath = "Generated Cache"
+        };
+        await serializer.SaveAsync(manifestPath, manifest);
+
+        var reopened = await service.OpenAsync(manifestPath);
+
+        Assert.True(reopened.Succeeded, reopened.Error);
+        Assert.True(Directory.Exists(workspace.Directory("Content")));
+        Assert.True(Directory.Exists(workspace.Directory("Generated Cache")));
+    }
+
+    [Fact]
+    public async Task OpenAsync_RejectsMissingCustomContentWithoutCreatingDirectories()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var serializer = new WorkspaceManifestSerializer();
+        var service = CreateService(recent.File("recent.yaml"));
+        var manifestPath = workspace.File("workspace.sailor");
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id") with
+        {
+            ContentPath = "ProjectContent"
+        };
+        await serializer.SaveAsync(manifestPath, manifest);
+
+        var result = await service.OpenAsync(manifestPath);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("custom ContentPath directory does not exist", result.Error, StringComparison.Ordinal);
+        Assert.False(Directory.Exists(workspace.Directory("ProjectContent")));
+        Assert.False(Directory.Exists(workspace.Directory("Cache")));
+        Assert.Null(service.Current);
+    }
+
+    [Fact]
+    public async Task OpenAsync_RollsBackRecoveredContentWhenNestedCacheCreationFails()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var serializer = new WorkspaceManifestSerializer();
+        var service = CreateService(recent.File("recent.yaml"));
+        var manifestPath = workspace.File("workspace.sailor");
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id") with
+        {
+            CachePath = "Blocked/Cache"
+        };
+        await serializer.SaveAsync(manifestPath, manifest);
+        File.WriteAllText(workspace.File("Blocked"), "prevents cache directory creation");
+
+        var result = await service.OpenAsync(manifestPath);
+
+        Assert.False(result.Succeeded);
+        Assert.False(Directory.Exists(workspace.Directory("Content")));
+        Assert.True(File.Exists(workspace.File("Blocked")));
+        Assert.Null(service.Current);
+    }
+
+    [Fact]
+    public async Task OpenAsync_RejectsContentLinkEscapeBeforeRecoveringDirectories()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var outside = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var serializer = new WorkspaceManifestSerializer();
+        var service = CreateService(recent.File("recent.yaml"));
+        var manifestPath = workspace.File("workspace.sailor");
+        var linkPath = workspace.Directory("Content");
+        await serializer.SaveAsync(
+            manifestPath,
+            WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id"));
+        CreateDirectoryLink(linkPath, outside.Root);
+
+        try
+        {
+            var result = await service.OpenAsync(manifestPath);
+
+            Assert.False(result.Succeeded);
+            Assert.Contains("symbolic link or junction", result.Error, StringComparison.OrdinalIgnoreCase);
+            Assert.False(Directory.Exists(workspace.Directory("Cache")));
+            Assert.Null(service.Current);
+        }
+        finally
+        {
+            if (Directory.Exists(linkPath))
+                Directory.Delete(linkPath);
+        }
+    }
+
+    [Fact]
+    public async Task OpenAsync_PublishesPhysicalPathsForContainedDirectoryLinks()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var serializer = new WorkspaceManifestSerializer();
+        var service = CreateService(recent.File("recent.yaml"));
+        var manifestPath = workspace.File("workspace.sailor");
+        var physicalContent = workspace.Directory("Data/Content");
+        var contentLink = workspace.Directory("Content");
+        Directory.CreateDirectory(physicalContent);
+        await serializer.SaveAsync(
+            manifestPath,
+            WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id"));
+        CreateDirectoryLink(contentLink, physicalContent);
+
+        try
+        {
+            var result = await service.OpenAsync(manifestPath);
+
+            Assert.True(result.Succeeded, result.Error);
+            Assert.Equal(
+                WorkspacePathPolicy.NormalizePhysicalPath(physicalContent),
+                result.Session!.ContentDirectory,
+                ignoreCase: OperatingSystem.IsWindows());
+        }
+        finally
+        {
+            if (Directory.Exists(contentLink))
+                Directory.Delete(contentLink);
+        }
     }
 
     [Fact]
@@ -324,6 +474,116 @@ public sealed class WorkspaceLifecycleTests
     }
 
     [Fact]
+    public async Task CreateAsync_DoesNotPublishSessionWhenRecentWorkspaceUpdateFails()
+    {
+        using var currentWorkspace = TempWorkspace.Create();
+        using var newWorkspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var recentPath = recent.File("store/recent.yaml");
+        var service = CreateService(recentPath);
+        var current = await service.CreateAsync(new WorkspaceCreateRequest(
+            "Current",
+            currentWorkspace.Root,
+            "../Sailor",
+            "current-id"));
+        var published = Assert.IsType<WorkspaceSession>(current.Session);
+        BlockRecentStore(recentPath);
+
+        var result = await service.CreateAsync(new WorkspaceCreateRequest(
+            "New",
+            newWorkspace.Root,
+            "../Sailor",
+            "new-id"));
+
+        Assert.False(result.Succeeded);
+        Assert.Same(published, service.Current);
+    }
+
+    [Fact]
+    public async Task OpenAsync_DoesNotPublishSessionWhenRecentWorkspaceUpdateFails()
+    {
+        using var currentWorkspace = TempWorkspace.Create();
+        using var openedWorkspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var recentPath = recent.File("store/recent.yaml");
+        var service = CreateService(recentPath);
+        var serializer = new WorkspaceManifestSerializer();
+        var current = await service.CreateAsync(new WorkspaceCreateRequest(
+            "Current",
+            currentWorkspace.Root,
+            "../Sailor",
+            "current-id"));
+        var published = Assert.IsType<WorkspaceSession>(current.Session);
+        var openedManifestPath = openedWorkspace.File("workspace.sailor");
+        await serializer.SaveAsync(
+            openedManifestPath,
+            WorkspaceManifest.CreateDefault("Opened", "../Sailor", "opened-id"));
+        BlockRecentStore(recentPath);
+
+        var result = await service.OpenAsync(openedManifestPath);
+
+        Assert.False(result.Succeeded);
+        Assert.Same(published, service.Current);
+        Assert.False(Directory.Exists(openedWorkspace.Directory("Content")));
+        Assert.False(Directory.Exists(openedWorkspace.Directory("Cache")));
+    }
+
+    [Fact]
+    public async Task SaveAsync_DoesNotPublishSessionWhenRecentWorkspaceUpdateFails()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var recentPath = recent.File("store/recent.yaml");
+        var service = CreateService(recentPath);
+        var created = await service.CreateAsync(new WorkspaceCreateRequest(
+            "Current",
+            workspace.Root,
+            "../Sailor",
+            "current-id"));
+        var published = Assert.IsType<WorkspaceSession>(created.Session);
+        Directory.Delete(workspace.Directory("Content"), recursive: true);
+        Directory.Delete(workspace.Directory("Cache"), recursive: true);
+        BlockRecentStore(recentPath);
+        var renamed = published with
+        {
+            Manifest = published.Manifest with { Name = "Renamed" }
+        };
+
+        var result = await service.SaveAsync(renamed);
+
+        Assert.False(result.Succeeded);
+        Assert.Same(published, service.Current);
+        Assert.Equal("Current", service.Current!.Manifest.Name);
+        Assert.False(Directory.Exists(workspace.Directory("Content")));
+        Assert.False(Directory.Exists(workspace.Directory("Cache")));
+    }
+
+    [Fact]
+    public async Task SaveAsync_RollsBackRecoveredDirectoriesWhenManifestWriteIsCancelled()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var created = await service.CreateAsync(new WorkspaceCreateRequest(
+            "Current",
+            workspace.Root,
+            "../Sailor",
+            "current-id"));
+        var published = Assert.IsType<WorkspaceSession>(created.Session);
+        Directory.Delete(workspace.Directory("Content"), recursive: true);
+        Directory.Delete(workspace.Directory("Cache"), recursive: true);
+        using var cancellation = new CancellationTokenSource();
+        cancellation.Cancel();
+
+        var result = await service.SaveAsync(published, cancellation.Token);
+
+        Assert.False(result.Succeeded);
+        Assert.Same(published, service.Current);
+        Assert.False(Directory.Exists(workspace.Directory("Content")));
+        Assert.False(Directory.Exists(workspace.Directory("Cache")));
+    }
+
+    [Fact]
     public async Task RecentWorkspaceStore_RoundTripsNewestFirstAndDeduplicates()
     {
         using var workspace = TempWorkspace.Create();
@@ -381,6 +641,52 @@ public sealed class WorkspaceLifecycleTests
         var template = new WorkspaceTemplateService(serializer);
         var recentStore = new RecentWorkspaceStore(recentPath);
         return new WorkspaceLifecycleService(serializer, template, recentStore);
+    }
+
+    static string Physical(string path) => WorkspacePathPolicy.NormalizePhysicalPath(path);
+
+    static void BlockRecentStore(string recentPath)
+    {
+        if (File.Exists(recentPath))
+            File.Delete(recentPath);
+
+        var directory = Path.GetDirectoryName(recentPath)
+            ?? throw new InvalidOperationException("Recent workspace path has no directory.");
+        if (Directory.Exists(directory))
+            Directory.Delete(directory, recursive: true);
+
+        File.WriteAllText(directory, "blocks recent-workspace directory creation");
+    }
+
+    static void CreateDirectoryLink(string linkPath, string targetPath)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Directory.CreateSymbolicLink(linkPath, targetPath);
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo("cmd.exe")
+        {
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("/d");
+        startInfo.ArgumentList.Add("/c");
+        startInfo.ArgumentList.Add("mklink");
+        startInfo.ArgumentList.Add("/J");
+        startInfo.ArgumentList.Add(linkPath);
+        startInfo.ArgumentList.Add(targetPath);
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Could not start mklink.");
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Could not create test junction: {process.StandardError.ReadToEnd()}{process.StandardOutput.ReadToEnd()}");
+        }
     }
 
     sealed class UnsafeWorkspaceTemplateService(WorkspaceManifestSerializer serializer) : WorkspaceTemplateService(serializer)

--- a/Editor.Tests/WorkspaceManifestTests.cs
+++ b/Editor.Tests/WorkspaceManifestTests.cs
@@ -131,6 +131,62 @@ cachePath: Cache
         Assert.Equal(!expectedValid, validation.Issues.Any(x => x.Field == nameof(WorkspaceManifest.LogicModuleName)));
     }
 
+    public static IEnumerable<object[]> UnsafeWorkspaceOwnedPaths()
+    {
+        var fields = new[]
+        {
+            nameof(WorkspaceManifest.ContentPath),
+            nameof(WorkspaceManifest.SourcePath),
+            nameof(WorkspaceManifest.GeneratedProjectPath),
+            nameof(WorkspaceManifest.CachePath),
+            nameof(WorkspaceManifest.BuildPath),
+            nameof(WorkspaceManifest.LogicOutputPath)
+        };
+        var paths = new[]
+        {
+            "/absolute/path",
+            "C:/absolute/path",
+            "C:drive-relative",
+            "../outside",
+            "safe/../../outside",
+            @"safe\..\outside",
+            "Content\0Invalid"
+        };
+
+        return fields.SelectMany(field => paths.Select(path => new object[] { field, path }));
+    }
+
+    [Theory]
+    [MemberData(nameof(UnsafeWorkspaceOwnedPaths))]
+    public void Validate_RejectsUnsafeWorkspaceOwnedPaths(string field, string path)
+    {
+        var serializer = new WorkspaceManifestSerializer();
+        var manifest = WithWorkspaceOwnedPath(
+            WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id"),
+            field,
+            path);
+
+        var validation = serializer.Validate(manifest);
+
+        Assert.False(validation.IsValid);
+        Assert.Contains(validation.Issues, x => x.Field == field && x.Message.Contains("safe relative path", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("/opt/sailor")]
+    [InlineData("C:/Sailor")]
+    [InlineData("C:Sailor")]
+    [InlineData("../Sailor")]
+    public void Validate_AllowsExternalEnginePath(string enginePath)
+    {
+        var serializer = new WorkspaceManifestSerializer();
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", enginePath, "workspace-id");
+
+        var validation = serializer.Validate(manifest);
+
+        Assert.True(validation.IsValid);
+    }
+
     [Fact]
     public async Task SaveAsync_RejectsInvalidManifest()
     {
@@ -235,4 +291,16 @@ cachePath:
     {
         Assert.Equal(expected, WorkspaceManifestPaths.Normalize(input));
     }
+
+    static WorkspaceManifest WithWorkspaceOwnedPath(WorkspaceManifest manifest, string field, string path)
+        => field switch
+        {
+            nameof(WorkspaceManifest.ContentPath) => manifest with { ContentPath = path },
+            nameof(WorkspaceManifest.SourcePath) => manifest with { SourcePath = path },
+            nameof(WorkspaceManifest.GeneratedProjectPath) => manifest with { GeneratedProjectPath = path },
+            nameof(WorkspaceManifest.CachePath) => manifest with { CachePath = path },
+            nameof(WorkspaceManifest.BuildPath) => manifest with { BuildPath = path },
+            nameof(WorkspaceManifest.LogicOutputPath) => manifest with { LogicOutputPath = path },
+            _ => throw new ArgumentOutOfRangeException(nameof(field), field, null)
+        };
 }

--- a/Editor/Content/ProjectContentPathPolicy.cs
+++ b/Editor/Content/ProjectContentPathPolicy.cs
@@ -1,59 +1,19 @@
+using SailorEditor.Workspace;
+
 namespace SailorEditor.Content;
 
 public static class ProjectContentPathPolicy
 {
-    public static StringComparison PathComparison => OperatingSystem.IsWindows()
-        ? StringComparison.OrdinalIgnoreCase
-        : StringComparison.Ordinal;
+    public static StringComparison PathComparison => WorkspacePathPolicy.PathComparison;
 
-    public static StringComparer PathComparer => OperatingSystem.IsWindows()
-        ? StringComparer.OrdinalIgnoreCase
-        : StringComparer.Ordinal;
+    public static StringComparer PathComparer => WorkspacePathPolicy.PathComparer;
 
     public static string NormalizeRoot(string path)
-    {
-        var fullPath = Path.GetFullPath(path);
-        var pathRoot = Path.GetPathRoot(fullPath);
-        if (string.IsNullOrEmpty(pathRoot))
-            return TrimTrailingSeparators(fullPath);
-
-        var current = pathRoot;
-        var relativePath = Path.GetRelativePath(pathRoot, fullPath);
-        if (relativePath == ".")
-            return pathRoot;
-
-        foreach (var part in relativePath.Split([Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar], StringSplitOptions.RemoveEmptyEntries))
-        {
-            var next = Path.Combine(current, part);
-            FileSystemInfo? info = Directory.Exists(next)
-                ? new DirectoryInfo(next)
-                : File.Exists(next) ? new FileInfo(next) : null;
-            var resolved = info?.LinkTarget is not null
-                ? info.ResolveLinkTarget(returnFinalTarget: true)
-                : null;
-            current = resolved is null ? next : NormalizeRoot(resolved.FullName);
-        }
-
-        return TrimTrailingSeparators(current);
-    }
+        => WorkspacePathPolicy.NormalizePhysicalPath(path);
 
     public static bool IsSamePath(string left, string right)
-        => string.Equals(NormalizeRoot(left), NormalizeRoot(right), PathComparison);
+        => WorkspacePathPolicy.IsSamePath(left, right);
 
     public static bool IsInsideRoot(string rootPath, string candidatePath)
-    {
-        var root = NormalizeRoot(rootPath);
-        var candidate = NormalizeRoot(candidatePath);
-
-        return string.Equals(root, candidate, PathComparison)
-            || candidate.StartsWith(root + Path.DirectorySeparatorChar, PathComparison);
-    }
-
-    static string TrimTrailingSeparators(string path)
-    {
-        var pathRoot = Path.GetPathRoot(path);
-        return string.Equals(path, pathRoot, PathComparison)
-            ? path
-            : path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-    }
+        => WorkspacePathPolicy.IsInsideRoot(rootPath, candidatePath);
 }

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -166,6 +166,14 @@ namespace SailorEditor.Services
         {
             using var perfScope = EditorPerf.Scope("AssetsService.AddProjectRoot");
 
+            var requestedRoot = Path.GetFullPath(projectRoot);
+            if (!Directory.Exists(requestedRoot))
+            {
+                throw new DirectoryNotFoundException(
+                    $"The active content directory does not exist: {requestedRoot}");
+            }
+            var normalizedRoot = ProjectContentPathPolicy.NormalizeRoot(requestedRoot);
+
             Folders = [];
             Assets = [];
             Files = [];
@@ -174,9 +182,7 @@ namespace SailorEditor.Services
             _nextAssetId = 1;
             _assetOverrideCount = 0;
 
-            var requestedRoot = Path.GetFullPath(projectRoot);
-            Directory.CreateDirectory(requestedRoot);
-            CurrentProjectRootPath = ProjectContentPathPolicy.NormalizeRoot(requestedRoot);
+            CurrentProjectRootPath = normalizedRoot;
 
             Root = new ProjectRoot { Name = CurrentProjectRootPath, Id = 1 };
             if (ProjectContentPathPolicy.IsSamePath(CurrentProjectRootPath, _engineContentDirectory))

--- a/Editor/Services/EditorToolbarActions.cs
+++ b/Editor/Services/EditorToolbarActions.cs
@@ -77,7 +77,7 @@ namespace SailorEditor.Services
 
                 File.WriteAllText(launchContext.TempWorldFilePath, world);
 
-                engineService.RunWorld("../Cache/Temp.world", debug, launchContext);
+                engineService.RunWorld(launchContext.TempWorldRuntimePath, debug, launchContext);
             });
         }
 

--- a/Editor/Services/EngineLaunchContract.cs
+++ b/Editor/Services/EngineLaunchContract.cs
@@ -2,11 +2,14 @@
 
 namespace SailorEditor.Services;
 
-public sealed record EngineLaunchContext(string WorkspaceRoot, string? WorkspaceManifestPath)
+public sealed record EngineLaunchContext(
+    string WorkspaceRoot,
+    string? WorkspaceManifestPath,
+    string ContentDirectory,
+    string CacheDirectory)
 {
-    public string ContentDirectory => Path.Combine(WorkspaceRoot, "Content");
-    public string CacheDirectory => Path.Combine(WorkspaceRoot, "Cache");
     public string TempWorldFilePath => Path.Combine(CacheDirectory, "Temp.world");
+    public string TempWorldRuntimePath => Path.GetRelativePath(ContentDirectory, TempWorldFilePath);
     public string EditorTypesCacheFilePath => Path.Combine(CacheDirectory, "EditorTypes.yaml");
 
     public IReadOnlyList<string> BuildArguments(string world, IEnumerable<string>? extraArguments = null)
@@ -43,24 +46,36 @@ public sealed record EngineLaunchContext(string WorkspaceRoot, string? Workspace
 
 public static class EngineLaunchContract
 {
-    public static EngineLaunchContext Resolve(string? activeWorkspaceRoot, string fallbackRoot)
-        => Resolve(activeWorkspaceRoot, null, fallbackRoot);
-
     public static EngineLaunchContext Resolve(
         string? activeWorkspaceRoot,
         string? activeWorkspaceManifestPath,
+        string? activeContentDirectory,
+        string? activeCacheDirectory,
         string fallbackRoot)
     {
-        var selectedRoot = string.IsNullOrWhiteSpace(activeWorkspaceRoot)
-            ? fallbackRoot
-            : activeWorkspaceRoot;
-        var manifestPath = string.IsNullOrWhiteSpace(activeWorkspaceRoot) ||
-            string.IsNullOrWhiteSpace(activeWorkspaceManifestPath)
-            ? null
-            : NormalizePath(activeWorkspaceManifestPath);
+        var hasActiveWorkspace = !string.IsNullOrWhiteSpace(activeWorkspaceRoot);
+        var selectedRoot = hasActiveWorkspace ? activeWorkspaceRoot : fallbackRoot;
+        var selectedContentDirectory = hasActiveWorkspace
+            ? RequireResolvedPath(activeContentDirectory, nameof(activeContentDirectory))
+            : Path.Combine(fallbackRoot, "Content");
+        var selectedCacheDirectory = hasActiveWorkspace
+            ? RequireResolvedPath(activeCacheDirectory, nameof(activeCacheDirectory))
+            : Path.Combine(fallbackRoot, "Cache");
+        var manifestPath = hasActiveWorkspace && !string.IsNullOrWhiteSpace(activeWorkspaceManifestPath)
+            ? NormalizePath(activeWorkspaceManifestPath)
+            : null;
 
-        return new EngineLaunchContext(NormalizeRoot(selectedRoot), manifestPath);
+        return new EngineLaunchContext(
+            NormalizeRoot(selectedRoot!),
+            manifestPath,
+            NormalizeRoot(selectedContentDirectory),
+            NormalizeRoot(selectedCacheDirectory));
     }
+
+    static string RequireResolvedPath(string? path, string parameterName)
+        => string.IsNullOrWhiteSpace(path)
+            ? throw new ArgumentException("An active workspace must provide its resolved content and cache paths.", parameterName)
+            : path;
 
     static string NormalizeRoot(string path)
     {

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -175,6 +175,8 @@ namespace SailorEditor.Services
             return EngineLaunchContract.Resolve(
                 workspace?.WorkspaceRoot,
                 workspace?.ManifestPath,
+                workspace?.ContentDirectory,
+                workspace?.CacheDirectory,
                 EngineWorkingDirectory);
         }
 

--- a/Editor/Workspace/WorkspaceLifecycle.cs
+++ b/Editor/Workspace/WorkspaceLifecycle.cs
@@ -92,16 +92,9 @@ public class WorkspaceTemplateService
                 $"Workspace manifest is invalid: {string.Join("; ", validation.Issues.Select(x => x.Message))}");
         }
 
-        EnsureInsideWorkspace(workspaceRoot, manifestPath, nameof(WorkspaceCreateRequest.ManifestPath));
+        WorkspacePathPolicy.EnsureInsideRoot(workspaceRoot, manifestPath, nameof(WorkspaceCreateRequest.ManifestPath));
         ValidateCleanWorkspaceDirectory(workspaceRoot, manifestPath);
         var session = CreateSession(workspaceRoot, manifest, manifestPath);
-
-        EnsureInsideWorkspace(workspaceRoot, session.ContentDirectory, nameof(WorkspaceManifest.ContentPath));
-        EnsureInsideWorkspace(workspaceRoot, session.SourceDirectory, nameof(WorkspaceManifest.SourcePath));
-        EnsureInsideWorkspace(workspaceRoot, session.GeneratedProjectDirectory, nameof(WorkspaceManifest.GeneratedProjectPath));
-        EnsureInsideWorkspace(workspaceRoot, session.CacheDirectory, nameof(WorkspaceManifest.CachePath));
-        EnsureInsideWorkspace(workspaceRoot, session.BuildDirectory, nameof(WorkspaceManifest.BuildPath));
-        EnsureInsideWorkspace(workspaceRoot, session.LogicOutputDirectory, nameof(WorkspaceManifest.LogicOutputPath));
 
         var manifestPlaceholderExisted = File.Exists(manifestPath) || Directory.Exists(manifestPath);
         var manifestPlaceholderContents = File.Exists(manifestPath)
@@ -137,21 +130,29 @@ public class WorkspaceTemplateService
 
     public WorkspaceSession CreateSession(string workspaceRoot, WorkspaceManifest manifest, string? manifestPath = null)
     {
-        var root = Path.GetFullPath(workspaceRoot);
-        var resolvedManifestPath = Path.GetFullPath(manifestPath ?? Path.Combine(root, ManifestFileName));
-        EnsureInsideWorkspace(root, resolvedManifestPath, nameof(WorkspaceSession.ManifestPath));
+        var validation = _serializer.Validate(manifest);
+        if (!validation.IsValid)
+        {
+            throw new InvalidOperationException(
+                $"Workspace manifest is invalid: {string.Join("; ", validation.Issues.Select(x => x.Message))}");
+        }
+
+        var root = WorkspacePathPolicy.NormalizePhysicalPath(workspaceRoot);
+        var resolvedManifestPath = WorkspacePathPolicy.NormalizePhysicalPath(
+            manifestPath ?? Path.Combine(root, ManifestFileName));
+        WorkspacePathPolicy.EnsureInsideRoot(root, resolvedManifestPath, nameof(WorkspaceSession.ManifestPath));
 
         return new WorkspaceSession(
             root,
             resolvedManifestPath,
             manifest,
-            ResolveWorkspacePath(root, manifest.ContentPath),
-            ResolveWorkspacePath(root, manifest.SourcePath),
-            ResolveWorkspacePath(root, manifest.GeneratedProjectPath),
-            ResolveWorkspacePath(root, manifest.CachePath))
+            WorkspacePathPolicy.ResolveOwnedPath(root, manifest.ContentPath, nameof(WorkspaceManifest.ContentPath)),
+            WorkspacePathPolicy.ResolveOwnedPath(root, manifest.SourcePath, nameof(WorkspaceManifest.SourcePath)),
+            WorkspacePathPolicy.ResolveOwnedPath(root, manifest.GeneratedProjectPath, nameof(WorkspaceManifest.GeneratedProjectPath)),
+            WorkspacePathPolicy.ResolveOwnedPath(root, manifest.CachePath, nameof(WorkspaceManifest.CachePath)))
         {
-            BuildDirectory = ResolveWorkspacePath(root, manifest.BuildPath),
-            LogicOutputDirectory = ResolveWorkspacePath(root, manifest.LogicOutputPath)
+            BuildDirectory = WorkspacePathPolicy.ResolveOwnedPath(root, manifest.BuildPath, nameof(WorkspaceManifest.BuildPath)),
+            LogicOutputDirectory = WorkspacePathPolicy.ResolveOwnedPath(root, manifest.LogicOutputPath, nameof(WorkspaceManifest.LogicOutputPath))
         };
     }
 
@@ -161,7 +162,8 @@ public class WorkspaceTemplateService
             return;
 
         var allowed = NormalizePath(allowedManifestPath);
-        if (Directory.EnumerateFileSystemEntries(workspaceRoot).Any(x => !string.Equals(NormalizePath(x), allowed, PathComparison)))
+        if (Directory.EnumerateFileSystemEntries(workspaceRoot).Any(x =>
+            !string.Equals(NormalizePath(x), allowed, WorkspacePathPolicy.PathComparison)))
             throw new InvalidOperationException($"Workspace directory is not empty: {workspaceRoot}");
     }
 
@@ -192,33 +194,6 @@ public class WorkspaceTemplateService
     static string NormalizePath(string path)
         => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
 
-    static string ResolveWorkspacePath(string workspaceRoot, string relativePath)
-    {
-        var path = relativePath
-            .Replace('/', Path.DirectorySeparatorChar)
-            .Replace('\\', Path.DirectorySeparatorChar);
-
-        var fullPath = Path.GetFullPath(Path.Combine(workspaceRoot, path));
-        EnsureInsideWorkspace(workspaceRoot, fullPath, relativePath);
-        return fullPath;
-    }
-
-    static void EnsureInsideWorkspace(string workspaceRoot, string path, string field)
-    {
-        var root = Path.GetFullPath(workspaceRoot).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-        var fullPath = Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
-
-        if (string.Equals(root, fullPath, PathComparison))
-            return;
-
-        var prefix = root + Path.DirectorySeparatorChar;
-        if (!fullPath.StartsWith(prefix, PathComparison))
-            throw new InvalidOperationException($"{field} resolves outside the workspace root.");
-    }
-
-    static StringComparison PathComparison => OperatingSystem.IsWindows()
-        ? StringComparison.OrdinalIgnoreCase
-        : StringComparison.Ordinal;
 }
 
 public sealed class RecentWorkspaceStore
@@ -360,8 +335,8 @@ public sealed class WorkspaceLifecycleService
         try
         {
             var session = await _templateService.CreateAsync(request, cancellationToken);
-            Current = session;
             await _recentWorkspaceStore.RecordAsync(session, cancellationToken);
+            Current = session;
             return new WorkspaceLifecycleResult(session, WorkspaceManifestValidationResult.Success);
         }
         catch (Exception ex)
@@ -376,6 +351,7 @@ public sealed class WorkspaceLifecycleService
         if (!loadResult.Succeeded || loadResult.Manifest is null)
             return new WorkspaceLifecycleResult(null, loadResult.Validation, loadResult.Error);
 
+        WorkspaceDirectoryRecovery? recovery = null;
         try
         {
             var workspaceRoot = Path.GetDirectoryName(Path.GetFullPath(manifestPath));
@@ -383,29 +359,190 @@ public sealed class WorkspaceLifecycleService
                 return new WorkspaceLifecycleResult(null, WorkspaceManifestValidationResult.Success, $"Workspace manifest path is invalid: {manifestPath}");
 
             var session = _templateService.CreateSession(workspaceRoot, loadResult.Manifest, manifestPath);
-            Current = session;
+            recovery = RecoverDefaultDirectories(session);
+            session = recovery.Session;
             await _recentWorkspaceStore.RecordAsync(session, cancellationToken);
+            recovery.Commit();
+            Current = session;
             return new WorkspaceLifecycleResult(session, loadResult.Validation);
         }
         catch (Exception ex)
         {
-            return new WorkspaceLifecycleResult(null, loadResult.Validation, ex.Message);
+            return new WorkspaceLifecycleResult(
+                null,
+                loadResult.Validation,
+                RollbackRecovery(recovery, ex).Message);
         }
     }
 
     public async Task<WorkspaceLifecycleResult> SaveAsync(WorkspaceSession session, CancellationToken cancellationToken = default)
     {
+        WorkspaceDirectoryRecovery? recovery = null;
         try
         {
             var validated = _templateService.CreateSession(session.WorkspaceRoot, session.Manifest, session.ManifestPath);
+            recovery = RecoverDefaultDirectories(validated);
+            validated = recovery.Session;
             await _serializer.SaveAsync(validated.ManifestPath, validated.Manifest, cancellationToken);
-            Current = validated;
             await _recentWorkspaceStore.RecordAsync(validated, cancellationToken);
+            recovery.Commit();
+            Current = validated;
             return new WorkspaceLifecycleResult(validated, WorkspaceManifestValidationResult.Success);
         }
         catch (Exception ex)
         {
-            return new WorkspaceLifecycleResult(null, WorkspaceManifestValidationResult.Success, ex.Message);
+            return new WorkspaceLifecycleResult(
+                null,
+                WorkspaceManifestValidationResult.Success,
+                RollbackRecovery(recovery, ex).Message);
+        }
+    }
+
+    WorkspaceDirectoryRecovery RecoverDefaultDirectories(WorkspaceSession session)
+    {
+        var directoriesToCreate = new List<string>();
+        ValidateRecoverableDirectory(
+            session.Manifest.ContentPath,
+            "Content",
+            session.ContentDirectory,
+            nameof(WorkspaceManifest.ContentPath),
+            allowCustomCreation: false,
+            directoriesToCreate);
+        ValidateRecoverableDirectory(
+            session.Manifest.CachePath,
+            "Cache",
+            session.CacheDirectory,
+            nameof(WorkspaceManifest.CachePath),
+            allowCustomCreation: true,
+            directoriesToCreate);
+
+        var createdDirectories = new List<string>();
+        var recovery = new WorkspaceDirectoryRecovery(session, createdDirectories);
+        try
+        {
+            foreach (var directory in directoriesToCreate)
+            {
+                var missingDirectories = GetMissingDirectories(session.WorkspaceRoot, directory);
+                createdDirectories.AddRange(missingDirectories);
+                Directory.CreateDirectory(directory);
+            }
+
+            var resolved = _templateService.CreateSession(
+                session.WorkspaceRoot,
+                session.Manifest,
+                session.ManifestPath);
+            if (!Directory.Exists(resolved.ContentDirectory))
+                throw new DirectoryNotFoundException($"ContentPath was not recovered: {resolved.ContentDirectory}");
+            if (!Directory.Exists(resolved.CacheDirectory))
+                throw new DirectoryNotFoundException($"CachePath was not recovered: {resolved.CacheDirectory}");
+
+            recovery.SetSession(resolved);
+            return recovery;
+        }
+        catch (Exception ex)
+        {
+            throw RollbackRecovery(recovery, ex);
+        }
+    }
+
+    static Exception RollbackRecovery(WorkspaceDirectoryRecovery? recovery, Exception error)
+    {
+        if (recovery is null)
+            return error;
+
+        try
+        {
+            recovery.Rollback();
+            return error;
+        }
+        catch (Exception rollbackError)
+        {
+            return new AggregateException(
+                "Workspace operation failed and recovered directories could not be rolled back.",
+                error,
+                rollbackError);
+        }
+    }
+
+    static void ValidateRecoverableDirectory(
+        string configuredPath,
+        string defaultPath,
+        string resolvedPath,
+        string field,
+        bool allowCustomCreation,
+        ICollection<string> directoriesToCreate)
+    {
+        if (Directory.Exists(resolvedPath))
+            return;
+
+        if (File.Exists(resolvedPath))
+            throw new InvalidOperationException($"{field} resolves to a file instead of a directory: {resolvedPath}");
+
+        var normalizedConfiguredPath = WorkspaceManifestPaths.Normalize(configuredPath);
+        if (!allowCustomCreation &&
+            !string.Equals(normalizedConfiguredPath, defaultPath, WorkspacePathPolicy.PathComparison))
+        {
+            throw new InvalidOperationException(
+                $"The custom {field} directory does not exist and will not be created automatically: {resolvedPath}");
+        }
+
+        directoriesToCreate.Add(resolvedPath);
+    }
+
+    static IReadOnlyList<string> GetMissingDirectories(string workspaceRoot, string directory)
+    {
+        var missing = new List<string>();
+        var root = Path.GetFullPath(workspaceRoot)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        for (var current = Path.GetFullPath(directory)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            !string.Equals(current, root, WorkspacePathPolicy.PathComparison) &&
+            !Directory.Exists(current) &&
+            !File.Exists(current);
+            current = Path.GetDirectoryName(current) ?? root)
+        {
+            missing.Add(current);
+        }
+
+        missing.Reverse();
+        return missing;
+    }
+
+    sealed class WorkspaceDirectoryRecovery
+    {
+        readonly IReadOnlyList<string> _createdDirectories;
+        bool _completed;
+
+        public WorkspaceDirectoryRecovery(
+            WorkspaceSession session,
+            IReadOnlyList<string> createdDirectories)
+        {
+            Session = session;
+            _createdDirectories = createdDirectories;
+        }
+
+        public WorkspaceSession Session { get; private set; }
+
+        public void SetSession(WorkspaceSession session) => Session = session;
+
+        public void Commit() => _completed = true;
+
+        public void Rollback()
+        {
+            if (_completed)
+                return;
+
+            foreach (var directory in _createdDirectories
+                .Distinct(WorkspacePathPolicy.PathComparer)
+                .Reverse())
+            {
+                if (!WorkspacePathPolicy.IsInsideRoot(Session.WorkspaceRoot, directory))
+                    continue;
+                if (Directory.Exists(directory) && !Directory.EnumerateFileSystemEntries(directory).Any())
+                    Directory.Delete(directory);
+            }
+
+            _completed = true;
         }
     }
 }

--- a/Editor/Workspace/WorkspaceManifest.cs
+++ b/Editor/Workspace/WorkspaceManifest.cs
@@ -160,6 +160,13 @@ public sealed class WorkspaceManifestSerializer
         AddRequiredStringIssue(issues, nameof(WorkspaceManifest.LogicOutputPath), manifest.LogicOutputPath);
         AddRequiredStringIssue(issues, nameof(WorkspaceManifest.LogicModuleName), manifest.LogicModuleName);
 
+        AddWorkspaceOwnedPathIssue(issues, nameof(WorkspaceManifest.ContentPath), manifest.ContentPath);
+        AddWorkspaceOwnedPathIssue(issues, nameof(WorkspaceManifest.SourcePath), manifest.SourcePath);
+        AddWorkspaceOwnedPathIssue(issues, nameof(WorkspaceManifest.GeneratedProjectPath), manifest.GeneratedProjectPath);
+        AddWorkspaceOwnedPathIssue(issues, nameof(WorkspaceManifest.CachePath), manifest.CachePath);
+        AddWorkspaceOwnedPathIssue(issues, nameof(WorkspaceManifest.BuildPath), manifest.BuildPath);
+        AddWorkspaceOwnedPathIssue(issues, nameof(WorkspaceManifest.LogicOutputPath), manifest.LogicOutputPath);
+
         if (!string.IsNullOrWhiteSpace(manifest.EngineReferenceKind) &&
             !WorkspaceEngineReferenceKinds.IsSupported(manifest.EngineReferenceKind))
         {
@@ -201,6 +208,16 @@ public sealed class WorkspaceManifestSerializer
     {
         if (string.IsNullOrWhiteSpace(value))
             issues.Add(new WorkspaceManifestIssue(field, $"{field} is required."));
+    }
+
+    static void AddWorkspaceOwnedPathIssue(ICollection<WorkspaceManifestIssue> issues, string field, string value)
+    {
+        if (string.IsNullOrWhiteSpace(value) || WorkspacePathPolicy.IsSafeRelativePath(value))
+            return;
+
+        issues.Add(new WorkspaceManifestIssue(
+            field,
+            $"{field} must be a safe relative path inside the workspace root; rooted, drive-relative, and traversal paths can resolve outside it and are not allowed."));
     }
 
     static bool IsCIdentifier(string value)

--- a/Editor/Workspace/WorkspacePathPolicy.cs
+++ b/Editor/Workspace/WorkspacePathPolicy.cs
@@ -1,0 +1,186 @@
+namespace SailorEditor.Workspace;
+
+public static class WorkspacePathPolicy
+{
+    public static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    public static StringComparer PathComparer => OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
+    public static bool IsSafeRelativePath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        var normalized = path.Trim().Replace('\\', '/');
+        if (normalized[0] == '/' || HasDrivePrefix(normalized))
+            return false;
+
+        if (normalized.Split('/', StringSplitOptions.None).Any(x => x == ".."))
+            return false;
+
+        try
+        {
+            var platformPath = normalized.Replace('/', Path.DirectorySeparatorChar);
+            if (Path.IsPathRooted(platformPath))
+                return false;
+
+            _ = Path.GetFullPath(platformPath, Path.GetFullPath("."));
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static string ResolveOwnedPath(string rootPath, string relativePath, string field)
+    {
+        if (!IsSafeRelativePath(relativePath))
+        {
+            throw new InvalidOperationException(
+                $"{field} must be a safe relative path inside the workspace root; rooted, drive-relative, and traversal paths can resolve outside it and are not allowed.");
+        }
+
+        var root = Path.GetFullPath(rootPath);
+        var platformPath = relativePath
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+        var candidate = Path.GetFullPath(Path.Combine(root, platformPath));
+        EnsureInsideRoot(root, candidate, field);
+        return NormalizePhysicalPath(candidate);
+    }
+
+    public static void EnsureInsideRoot(string rootPath, string candidatePath, string field)
+    {
+        var lexicalRoot = NormalizeLexicalPath(rootPath);
+        var lexicalCandidate = NormalizeLexicalPath(candidatePath);
+        if (!IsContained(lexicalRoot, lexicalCandidate))
+            throw new InvalidOperationException($"{field} resolves outside the workspace root.");
+
+        string physicalRoot;
+        string physicalCandidate;
+        try
+        {
+            physicalRoot = NormalizePhysicalPath(lexicalRoot);
+            physicalCandidate = NormalizePhysicalPath(lexicalCandidate);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            throw new InvalidOperationException($"{field} could not be safely resolved inside the workspace root.", ex);
+        }
+
+        if (!IsContained(physicalRoot, physicalCandidate))
+        {
+            throw new InvalidOperationException(
+                $"{field} resolves outside the workspace root through a symbolic link or junction.");
+        }
+    }
+
+    public static bool IsInsideRoot(string rootPath, string candidatePath)
+    {
+        try
+        {
+            var lexicalRoot = NormalizeLexicalPath(rootPath);
+            var lexicalCandidate = NormalizeLexicalPath(candidatePath);
+            return IsContained(lexicalRoot, lexicalCandidate)
+                && IsContained(NormalizePhysicalPath(lexicalRoot), NormalizePhysicalPath(lexicalCandidate));
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static bool IsSamePath(string left, string right)
+    {
+        try
+        {
+            return string.Equals(NormalizePhysicalPath(left), NormalizePhysicalPath(right), PathComparison);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static string NormalizePhysicalPath(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var pathRoot = Path.GetPathRoot(fullPath);
+        if (string.IsNullOrEmpty(pathRoot))
+            return TrimTrailingSeparators(fullPath);
+
+        var current = pathRoot;
+        var relativePath = Path.GetRelativePath(pathRoot, fullPath);
+        if (relativePath == ".")
+            return pathRoot;
+
+        foreach (var part in relativePath.Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries))
+        {
+            var next = Path.Combine(current, part);
+            var resolved = ResolveLinkTarget(next);
+            current = resolved is null ? next : NormalizePhysicalPath(resolved);
+        }
+
+        return TrimTrailingSeparators(current);
+    }
+
+    static string NormalizeLexicalPath(string path)
+        => TrimTrailingSeparators(Path.GetFullPath(path));
+
+    static string? ResolveLinkTarget(string path)
+    {
+        var directory = new DirectoryInfo(path);
+        if (directory.LinkTarget is not null)
+        {
+            return directory.ResolveLinkTarget(returnFinalTarget: true)?.FullName
+                ?? throw new IOException($"Could not resolve directory link target: {path}");
+        }
+
+        if (directory.Exists)
+            return null;
+
+        var file = new FileInfo(path);
+        if (file.LinkTarget is not null)
+        {
+            return file.ResolveLinkTarget(returnFinalTarget: true)?.FullName
+                ?? throw new IOException($"Could not resolve file link target: {path}");
+        }
+
+        return null;
+    }
+
+    static bool IsContained(string rootPath, string candidatePath)
+    {
+        if (string.Equals(rootPath, candidatePath, PathComparison))
+            return true;
+
+        var prefix = EndsWithDirectorySeparator(rootPath)
+            ? rootPath
+            : rootPath + Path.DirectorySeparatorChar;
+        return candidatePath.StartsWith(prefix, PathComparison);
+    }
+
+    static string TrimTrailingSeparators(string path)
+    {
+        var pathRoot = Path.GetPathRoot(path);
+        return string.Equals(path, pathRoot, PathComparison)
+            ? path
+            : path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    static bool EndsWithDirectorySeparator(string path)
+        => path.EndsWith(Path.DirectorySeparatorChar)
+            || path.EndsWith(Path.AltDirectorySeparatorChar);
+
+    static bool HasDrivePrefix(string path)
+        => path.Length >= 2
+            && path[1] == ':'
+            && (path[0] is >= 'A' and <= 'Z' || path[0] is >= 'a' and <= 'z');
+}

--- a/Editor/Workspace/WorkspaceProjectGenerator.cs
+++ b/Editor/Workspace/WorkspaceProjectGenerator.cs
@@ -357,20 +357,11 @@ public sealed class WorkspaceProjectGenerator
 
     static void EnsureInsideWorkspace(string workspaceRoot, string path)
     {
-        var root = NormalizePath(workspaceRoot);
-        var fullPath = NormalizePath(path);
-
-        if (string.Equals(root, fullPath, PathComparison))
-            return;
-
-        if (!fullPath.StartsWith(root + Path.DirectorySeparatorChar, PathComparison))
+        if (!WorkspacePathPolicy.IsInsideRoot(workspaceRoot, path))
             throw new InvalidOperationException($"Generated path resolves outside the workspace root: {path}");
     }
 
-    static string NormalizePath(string path)
-        => Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    static string NormalizePath(string path) => WorkspacePathPolicy.NormalizePhysicalPath(path);
 
-    static StringComparison PathComparison => OperatingSystem.IsWindows()
-        ? StringComparison.OrdinalIgnoreCase
-        : StringComparison.Ordinal;
+    static StringComparison PathComparison => WorkspacePathPolicy.PathComparison;
 }

--- a/Runtime/AssetRegistry/AssetCache.cpp
+++ b/Runtime/AssetRegistry/AssetCache.cpp
@@ -9,6 +9,11 @@
 
 using namespace Sailor;
 
+std::string AssetCache::GetAssetCacheFilepath()
+{
+	return (std::filesystem::path(AssetRegistry::GetCacheFolder()) / "AssetCache.yaml").string();
+}
+
 YAML::Node AssetCache::AssetCacheData::Entry::Serialize() const
 {
 	YAML::Node res;
@@ -40,7 +45,7 @@ void AssetCache::Initialize()
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	std::filesystem::create_directory(AssetRegistry::GetCacheFolder());
+	std::filesystem::create_directories(AssetRegistry::GetCacheFolder());
 
 	auto assetCacheFilePath = std::filesystem::path(GetAssetCacheFilepath());
 	if (!std::filesystem::exists(GetAssetCacheFilepath()))

--- a/Runtime/AssetRegistry/AssetCache.h
+++ b/Runtime/AssetRegistry/AssetCache.h
@@ -12,7 +12,7 @@ namespace Sailor
 	{
 	public:
 
-		static std::string GetAssetCacheFilepath() { return App::GetWorkspace() + "Cache/AssetCache.yaml"; }
+		SAILOR_API static std::string GetAssetCacheFilepath();
 
 		SAILOR_API void Initialize();
 		SAILOR_API void Shutdown();

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -16,6 +16,29 @@
 using namespace Sailor;
 using namespace nlohmann;
 
+namespace
+{
+	std::string AsFolderPath(const std::filesystem::path& path)
+	{
+		std::string result = path.generic_string();
+		if (!result.ends_with('/'))
+		{
+			result += '/';
+		}
+		return result;
+	}
+}
+
+std::string AssetRegistry::GetContentFolder()
+{
+	return AsFolderPath(App::GetWorkspaceContext().GetContent());
+}
+
+std::string AssetRegistry::GetCacheFolder()
+{
+	return AsFolderPath(App::GetWorkspaceContext().GetCache());
+}
+
 AssetRegistry::AssetRegistry()
 {
 	m_assetCache.Initialize();

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -21,8 +21,8 @@ namespace Sailor
 	{
 	public:
 
-		static std::string GetContentFolder() { return App::GetWorkspace() + "Content/"; }
-		static std::string GetCacheFolder() { return App::GetWorkspace() + "Cache/"; }
+		SAILOR_API static std::string GetContentFolder();
+		SAILOR_API static std::string GetCacheFolder();
 
 		static constexpr const char* MetaFileExtension = "asset";
 

--- a/Runtime/AssetRegistry/Shader/ShaderCache.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.cpp
@@ -2,38 +2,80 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include "Containers/Set.h"
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/Shader/ShaderCompiler.h"
 
 using namespace Sailor;
 
+namespace
+{
+	std::string GetCacheChildPath(const char* child)
+	{
+		return (std::filesystem::path(AssetRegistry::GetCacheFolder()) / child).string();
+	}
+
+	std::filesystem::path GetShaderFilepath(
+		const std::string& folder,
+		const FileId& uid,
+		int32_t permutation,
+		const std::string& shaderKind,
+		const char* extension)
+	{
+		const std::string filename = uid.ToString() + shaderKind +
+			std::to_string(permutation) + "." + extension;
+		return std::filesystem::path(folder) / filename;
+	}
+}
+
+std::string ShaderCache::GetShaderCacheFilepath()
+{
+	return GetCacheChildPath("ShaderCache.yaml");
+}
+
+std::string ShaderCache::GetPrecompiledShadersFolder()
+{
+	return GetCacheChildPath("PrecompiledShaders");
+}
+
+std::string ShaderCache::GetCompiledShadersFolder()
+{
+	return GetCacheChildPath("CompiledShaders");
+}
+
+std::string ShaderCache::GetCompiledShadersWithDebugFolder()
+{
+	return GetCacheChildPath("CompiledShadersWithDebug");
+}
+
 std::filesystem::path ShaderCache::GetPrecompiledShaderFilepath(const FileId& uid, int32_t permutation, const std::string& shaderKind)
 {
-	std::string res;
-	std::stringstream stream;
-	stream << uid.ToString() << shaderKind << permutation << "." << PrecompiledShaderFileExtension;
-	stream >> res;
-	return res;
+	return GetShaderFilepath(
+		GetPrecompiledShadersFolder(),
+		uid,
+		permutation,
+		shaderKind,
+		PrecompiledShaderFileExtension);
 }
 
 std::filesystem::path ShaderCache::GetCachedShaderFilepath(const FileId& uid, int32_t permutation, const std::string& shaderKind)
 {
-	std::string res;
-	std::stringstream stream;
-	stream << GetCompiledShadersFolder() << uid.ToString() << shaderKind << permutation << "." << CompiledShaderFileExtension;
-	stream >> res;
-	return res;
+	return GetShaderFilepath(
+		GetCompiledShadersFolder(),
+		uid,
+		permutation,
+		shaderKind,
+		CompiledShaderFileExtension);
 }
 
 std::filesystem::path ShaderCache::GetCachedShaderWithDebugFilepath(const FileId& uid, int32_t permutation, const std::string& shaderKind)
 {
-	std::string res;
-	std::stringstream stream;
-	stream << GetCompiledShadersWithDebugFolder() << uid.ToString() << shaderKind << permutation << "." << CompiledShaderFileExtension;
-	stream >> res;
-	return res;
+	return GetShaderFilepath(
+		GetCompiledShadersWithDebugFolder(),
+		uid,
+		permutation,
+		shaderKind,
+		CompiledShaderFileExtension);
 }
 
 YAML::Node ShaderCache::ShaderCacheData::Entry::Serialize() const
@@ -71,10 +113,10 @@ void ShaderCache::Initialize()
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	std::filesystem::create_directory(AssetRegistry::GetCacheFolder());
-	std::filesystem::create_directory(GetCompiledShadersFolder());
-	std::filesystem::create_directory(GetPrecompiledShadersFolder());
-	std::filesystem::create_directory(GetCompiledShadersWithDebugFolder());
+	std::filesystem::create_directories(AssetRegistry::GetCacheFolder());
+	std::filesystem::create_directories(GetCompiledShadersFolder());
+	std::filesystem::create_directories(GetPrecompiledShadersFolder());
+	std::filesystem::create_directories(GetCompiledShadersWithDebugFolder());
 
 	auto shaderCacheFilePath = std::filesystem::path(GetShaderCacheFilepath());
 	if (!std::filesystem::exists(GetShaderCacheFilepath()))
@@ -130,7 +172,7 @@ void ShaderCache::ClearAll()
 	std::lock_guard<std::mutex> lk(m_saveToCacheMutex);
 
 	std::filesystem::remove_all(GetPrecompiledShadersFolder());
-	std::filesystem::remove_all(CompiledShaderFileExtension);
+	std::filesystem::remove_all(GetCompiledShadersFolder());
 	std::filesystem::remove_all(GetCompiledShadersWithDebugFolder());
 	std::filesystem::remove(GetShaderCacheFilepath());
 }

--- a/Runtime/AssetRegistry/Shader/ShaderCache.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.h
@@ -16,10 +16,10 @@ namespace Sailor
 	{
 	public:
 
-		static std::string GetShaderCacheFilepath() { return App::GetWorkspace() + "Cache/ShaderCache.yaml"; }
-		static std::string GetPrecompiledShadersFolder() { return App::GetWorkspace() + "Cache/PrecompiledShaders/"; }
-		static std::string GetCompiledShadersFolder() { return App::GetWorkspace() + "Cache/CompiledShaders/"; }
-		static std::string GetCompiledShadersWithDebugFolder() { return App::GetWorkspace() + "Cache/CompiledShadersWithDebug/"; }
+		SAILOR_API static std::string GetShaderCacheFilepath();
+		SAILOR_API static std::string GetPrecompiledShadersFolder();
+		SAILOR_API static std::string GetCompiledShadersFolder();
+		SAILOR_API static std::string GetCompiledShadersWithDebugFolder();
 
 		static constexpr const char* FragmentShaderTag = "FRAGMENT";
 		static constexpr const char* VertexShaderTag = "VERTEX";

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -171,7 +171,9 @@ std::string GenerateConstantsLibrary(uint32_t version)
 
 void ShaderCompiler::UpdateConstantsLibrary()
 {
-	auto constantsLibrary = std::filesystem::path(ConstantsLibrary);
+	const std::filesystem::path constantsLibrary =
+		std::filesystem::path(AssetRegistry::GetContentFolder()) / "Shaders" / "Constants.glsl";
+	std::filesystem::create_directories(constantsLibrary.parent_path());
 	if (!std::filesystem::exists(constantsLibrary))
 	{
 		std::ofstream assetFile(constantsLibrary);

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.h
@@ -113,7 +113,6 @@ namespace Sailor
 		
 		// Version is used to generate shader's code with all constants
 		const uint32_t Version = 4;
-		static constexpr const char* ConstantsLibrary = "../Content/Shaders/Constants.glsl";
 
 	public:
 		SAILOR_API ShaderCompiler(ShaderAssetInfoHandler* infoHandler);

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -27,6 +27,7 @@
 #include "Containers/Octree.h"
 #include "Engine/EngineLoop.h"
 #include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <cstring>
 #include "Memory/MemoryBlockAllocator.hpp"
@@ -62,6 +63,75 @@ App* App::GetInstance()
 const std::string& App::GetWorkspace()
 {
 	return s_workspace;
+}
+
+const Workspace::WorkspaceContext& App::GetWorkspaceContext()
+{
+	check(s_pInstance);
+	return s_pInstance->m_workspaceContext;
+}
+
+namespace
+{
+	bool ContainsWorkspaceManifest(const std::filesystem::path& root)
+	{
+		std::error_code error;
+		if (!std::filesystem::is_directory(root, error) || error)
+		{
+			return false;
+		}
+
+		if (std::filesystem::is_regular_file(root / "workspace.sailor", error) && !error)
+		{
+			return true;
+		}
+
+		error.clear();
+		for (std::filesystem::directory_iterator it(root, error), end;
+			!error && it != end;
+			it.increment(error))
+		{
+			std::string extension = it->path().extension().string();
+			std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char character)
+				{
+					return static_cast<char>(std::tolower(character));
+				});
+			if (it->is_regular_file(error) && !error && extension == ".sailor")
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	std::filesystem::path SelectWorkspaceRoot(const AppArgs& params)
+	{
+		if (!params.m_workspace.empty())
+		{
+			return params.m_workspace;
+		}
+
+		const std::filesystem::path requestedManifest = params.m_workspaceManifest;
+		if (requestedManifest.is_absolute())
+		{
+			return requestedManifest.parent_path();
+		}
+
+		const std::filesystem::path current = std::filesystem::current_path();
+		const std::filesystem::path parent = current.parent_path();
+		std::error_code contentError;
+		const bool bHasLegacyContent = std::filesystem::is_directory(
+			current / "Content",
+			contentError) && !contentError;
+		if (ContainsWorkspaceManifest(current) ||
+			(!ContainsWorkspaceManifest(parent) && bHasLegacyContent))
+		{
+			return current;
+		}
+
+		return parent;
+	}
 }
 
 AppArgs ParseCommandLineArgs(const char** args, int32_t num)
@@ -153,35 +223,30 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	}
 #endif
 
-	if (!params.m_workspace.empty())
+	const Workspace::WorkspaceContextResolveResult workspaceContextResult =
+		Workspace::ResolveWorkspaceContext(
+			SelectWorkspaceRoot(params),
+			params.m_workspaceManifest);
+	if (!workspaceContextResult.IsSuccess())
 	{
-		s_pInstance->s_workspace = Utils::SanitizeFilepath(params.m_workspace);
-		if (!s_pInstance->s_workspace.ends_with("/"))
-		{
-			s_pInstance->s_workspace += "/";
-		}
+		SAILOR_LOG_ERROR("%s", workspaceContextResult.m_message.c_str());
+		SetExitCode(1);
+		s_pInstance->m_bSkipMainLoop = true;
+		return;
 	}
-	else
-	{
-		const std::filesystem::path cwd = std::filesystem::current_path();
-		const bool hasContentInCwd = std::filesystem::exists(cwd / "Content");
-		const bool hasContentInParent = std::filesystem::exists(cwd / ".." / "Content");
 
-		if (hasContentInCwd)
-		{
-			s_pInstance->s_workspace = "./";
-		}
-		else if (!hasContentInParent)
-		{
-			SAILOR_LOG_ERROR("Content folder was not found from current working directory. Use --workspace <path>.");
-		}
+	s_pInstance->m_workspaceContext = workspaceContextResult.m_context;
+	s_pInstance->s_workspace = Utils::SanitizeFilepath(
+		s_pInstance->m_workspaceContext.GetRoot().generic_string());
+	if (!s_pInstance->s_workspace.ends_with("/"))
+	{
+		s_pInstance->s_workspace += "/";
 	}
 
 	bool bWorkspaceModuleActivationFailed = false;
 	s_pInstance->m_pWorkspaceModuleManager = TUniquePtr<Workspace::WorkspaceModuleManager>::Make();
 	const auto& workspaceModuleResult = s_pInstance->m_pWorkspaceModuleManager->Load(
-		s_pInstance->s_workspace,
-		params.m_workspaceManifest,
+		s_pInstance->m_workspaceContext,
 		GetBuildConfig());
 	if (workspaceModuleResult.IsSuccess())
 	{

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -9,6 +9,7 @@
 #include "Platform/Win32/Window.h"
 #include "Containers/Containers.h"
 #include "Math/Math.h"
+#include "Workspace/WorkspaceContext.h"
 
 namespace Sailor
 {
@@ -43,6 +44,7 @@ namespace Sailor
 
 		SAILOR_API static App* GetInstance();
 		SAILOR_API static const std::string& GetWorkspace();
+		SAILOR_API static const Workspace::WorkspaceContext& GetWorkspaceContext();
 
 		SAILOR_API static void Initialize(const char** commandLineArgs = nullptr, int32_t num = 0);
 		SAILOR_API static void Start();
@@ -149,6 +151,7 @@ namespace Sailor
 
 		TUniquePtr<Win32::Window> m_pMainWindow;
 		TUniquePtr<Workspace::WorkspaceModuleManager> m_pWorkspaceModuleManager;
+		Workspace::WorkspaceContext m_workspaceContext;
 		bool m_bSkipMainLoop = false;
 		int32_t m_exitCode = 0;
 		AppArgs m_args{};

--- a/Runtime/Workspace/WorkspaceContext.cpp
+++ b/Runtime/Workspace/WorkspaceContext.cpp
@@ -1,0 +1,822 @@
+#include "Workspace/WorkspaceContext.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <limits>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+#include <yaml-cpp/yaml.h>
+
+namespace
+{
+	using namespace Sailor::Workspace;
+
+	constexpr uint32_t SupportedManifestVersion = 1;
+	constexpr uintmax_t MaxManifestSize = 1024 * 1024;
+	constexpr const char* DefaultContentPath = "Content";
+	constexpr const char* DefaultCachePath = "Cache";
+	constexpr const char* DefaultSourcePath = "Source";
+	constexpr const char* DefaultGeneratedPath = "Generated";
+	constexpr const char* DefaultBuildPath = "Cache/Build";
+	constexpr const char* DefaultLogicOutputPath = "Binaries";
+	constexpr const char* DefaultModuleName = "SailorGame";
+
+	struct WorkspaceContextCandidate
+	{
+		std::filesystem::path m_root;
+		std::filesystem::path m_manifest;
+		std::filesystem::path m_content;
+		std::filesystem::path m_cache;
+		std::filesystem::path m_source;
+		std::filesystem::path m_generated;
+		std::filesystem::path m_build;
+		std::filesystem::path m_logicOutput;
+		std::string m_moduleName;
+		std::string m_workspaceId;
+		std::string m_workspaceName;
+		uint32_t m_manifestVersion = 0;
+		bool m_bLegacy = false;
+	};
+
+	struct ManifestFields
+	{
+		std::string m_workspaceId;
+		std::string m_workspaceName;
+		std::string m_enginePath;
+		std::string m_engineReferenceKind = "source";
+		std::string m_content = DefaultContentPath;
+		std::string m_cache = DefaultCachePath;
+		std::string m_source = DefaultSourcePath;
+		std::string m_generated = DefaultGeneratedPath;
+		std::string m_build = DefaultBuildPath;
+		std::string m_logicOutput = DefaultLogicOutputPath;
+		std::string m_moduleName = DefaultModuleName;
+		uint32_t m_manifestVersion = 0;
+	};
+
+	class CreatedDirectoriesRollback final
+	{
+	public:
+		~CreatedDirectoriesRollback() noexcept
+		{
+			if (m_bCommitted)
+			{
+				return;
+			}
+
+			for (auto it = m_directories.rbegin(); it != m_directories.rend(); ++it)
+			{
+				std::error_code removeError;
+				std::filesystem::remove(*it, removeError);
+			}
+		}
+
+		void Track(std::vector<std::filesystem::path> directories)
+		{
+			m_directories.insert(
+				m_directories.end(),
+				std::make_move_iterator(directories.begin()),
+				std::make_move_iterator(directories.end()));
+		}
+
+		void Commit() noexcept { m_bCommitted = true; }
+
+	private:
+		std::vector<std::filesystem::path> m_directories;
+		bool m_bCommitted = false;
+	};
+
+	WorkspaceContextResolveResult Fail(
+		EWorkspaceContextResolveStatus status,
+		std::string message) noexcept
+	{
+		WorkspaceContextResolveResult result;
+		result.m_status = status;
+		try
+		{
+			result.m_message = std::move(message);
+		}
+		catch (...)
+		{
+			result.m_message.clear();
+		}
+		return result;
+	}
+
+	std::string Trim(std::string value)
+	{
+		value.erase(value.begin(), std::find_if(value.begin(), value.end(), [](unsigned char character)
+			{
+				return std::isspace(character) == 0;
+			}));
+		value.erase(std::find_if(value.rbegin(), value.rend(), [](unsigned char character)
+			{
+				return std::isspace(character) == 0;
+			}).base(), value.end());
+		return value;
+	}
+
+	bool IsCIdentifier(const std::string& value)
+	{
+		if (value.empty())
+		{
+			return false;
+		}
+
+		auto isIdentifierStart = [](char character)
+		{
+			return character == '_' ||
+				(character >= 'A' && character <= 'Z') ||
+				(character >= 'a' && character <= 'z');
+		};
+
+		if (!isIdentifierStart(value.front()))
+		{
+			return false;
+		}
+
+		return std::all_of(value.begin() + 1, value.end(), [&](char character)
+			{
+				return isIdentifierStart(character) ||
+					(character >= '0' && character <= '9');
+			});
+	}
+
+	bool HasSailorExtension(const std::filesystem::path& path)
+	{
+		std::string extension = path.extension().string();
+		std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+		return extension == ".sailor";
+	}
+
+	bool IsDefaultContentPath(const std::string& path)
+	{
+#if defined(_WIN32)
+		return path.size() == std::char_traits<char>::length(DefaultContentPath) &&
+			std::equal(path.begin(), path.end(), DefaultContentPath, [](unsigned char left, unsigned char right)
+				{
+					return std::tolower(left) == std::tolower(right);
+				});
+#else
+		return path == DefaultContentPath;
+#endif
+	}
+
+	bool IsInside(
+		const std::filesystem::path& root,
+		const std::filesystem::path& candidate)
+	{
+		auto rootPart = root.begin();
+		auto candidatePart = candidate.begin();
+		for (; rootPart != root.end(); ++rootPart, ++candidatePart)
+		{
+			if (candidatePart == candidate.end())
+			{
+				return false;
+			}
+
+			std::string rootValue = rootPart->generic_string();
+			std::string candidateValue = candidatePart->generic_string();
+#if defined(_WIN32)
+			std::transform(rootValue.begin(), rootValue.end(), rootValue.begin(), [](unsigned char character)
+				{
+					return static_cast<char>(std::tolower(character));
+				});
+			std::transform(candidateValue.begin(), candidateValue.end(), candidateValue.begin(), [](unsigned char character)
+				{
+					return static_cast<char>(std::tolower(character));
+				});
+#endif
+			if (rootValue != candidateValue)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	YAML::Node FindField(const YAML::Node& document, const char* fieldName)
+	{
+		for (const auto& field : document)
+		{
+			if (field.first.IsScalar() && field.first.Scalar() == fieldName)
+			{
+				return field.second;
+			}
+		}
+
+		return YAML::Node(YAML::NodeType::Undefined);
+	}
+
+	bool ValidateManifestMap(const YAML::Node& document, std::string& outError)
+	{
+		if (!document.IsMap())
+		{
+			outError = "Workspace manifest must contain a YAML map.";
+			return false;
+		}
+
+		std::unordered_set<std::string> keys;
+		keys.reserve(document.size());
+		for (const auto& field : document)
+		{
+			if (!field.first.IsScalar())
+			{
+				outError = "Workspace manifest contains a non-scalar field name.";
+				return false;
+			}
+
+			const std::string key = field.first.Scalar();
+			if (key.empty() || !keys.emplace(key).second)
+			{
+				outError = "Workspace manifest contains duplicate or empty field '" + key + "'.";
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool ReadScalarField(
+		const YAML::Node& document,
+		const char* fieldName,
+		bool bRequired,
+		std::string& outValue,
+		std::string& outError)
+	{
+		const YAML::Node field = FindField(document, fieldName);
+		if (!field.IsDefined() || field.IsNull())
+		{
+			if (bRequired)
+			{
+				outError = "Workspace manifest field '" + std::string(fieldName) + "' is required.";
+				return false;
+			}
+			return true;
+		}
+		if (!field.IsScalar())
+		{
+			outError = "Workspace manifest field '" + std::string(fieldName) + "' must be scalar.";
+			return false;
+		}
+
+		outValue = Trim(field.Scalar());
+		if (bRequired && outValue.empty())
+		{
+			outError = "Workspace manifest field '" + std::string(fieldName) + "' is required.";
+			return false;
+		}
+		return true;
+	}
+
+	bool ParseManifest(
+		const std::filesystem::path& manifestPath,
+		ManifestFields& outFields,
+		std::string& outError)
+	{
+		std::error_code fileError;
+		const uintmax_t fileSize = std::filesystem::file_size(manifestPath, fileError);
+		if (fileError || fileSize > MaxManifestSize ||
+			fileSize > static_cast<uintmax_t>((std::numeric_limits<std::streamsize>::max)()))
+		{
+			outError = "Workspace manifest '" + manifestPath.generic_string() +
+				"' is unreadable or exceeds the size limit.";
+			return false;
+		}
+
+		std::ifstream stream(manifestPath, std::ios::binary);
+		if (!stream.is_open())
+		{
+			outError = "Workspace manifest could not be opened: '" + manifestPath.generic_string() + "'.";
+			return false;
+		}
+
+		std::string payload(static_cast<size_t>(fileSize), '\0');
+		if (fileSize > 0 && !stream.read(payload.data(), static_cast<std::streamsize>(fileSize)))
+		{
+			outError = "Workspace manifest could not be read: '" + manifestPath.generic_string() + "'.";
+			return false;
+		}
+
+		const YAML::Node document = YAML::Load(payload);
+		if (!ValidateManifestMap(document, outError))
+		{
+			return false;
+		}
+
+		const YAML::Node version = FindField(document, "manifestVersion");
+		if (!version.IsDefined() || !version.IsScalar())
+		{
+			outError = "Workspace manifest field 'manifestVersion' must be scalar.";
+			return false;
+		}
+		outFields.m_manifestVersion = version.as<uint32_t>();
+		if (outFields.m_manifestVersion != SupportedManifestVersion)
+		{
+			outError = "Workspace manifest '" + manifestPath.generic_string() +
+				"' has unsupported manifestVersion '" +
+				std::to_string(outFields.m_manifestVersion) + "'.";
+			return false;
+		}
+
+		if (!ReadScalarField(document, "workspaceId", true, outFields.m_workspaceId, outError) ||
+			!ReadScalarField(document, "name", true, outFields.m_workspaceName, outError) ||
+			!ReadScalarField(document, "enginePath", true, outFields.m_enginePath, outError) ||
+			!ReadScalarField(document, "engineReferenceKind", false, outFields.m_engineReferenceKind, outError) ||
+			!ReadScalarField(document, "contentPath", true, outFields.m_content, outError) ||
+			!ReadScalarField(document, "cachePath", true, outFields.m_cache, outError) ||
+			!ReadScalarField(document, "sourcePath", true, outFields.m_source, outError) ||
+			!ReadScalarField(document, "generatedProjectPath", true, outFields.m_generated, outError) ||
+			!ReadScalarField(document, "buildPath", false, outFields.m_build, outError) ||
+			!ReadScalarField(document, "logicOutputPath", false, outFields.m_logicOutput, outError) ||
+			!ReadScalarField(document, "logicModuleName", false, outFields.m_moduleName, outError))
+		{
+			return false;
+		}
+
+		if (outFields.m_build.empty())
+		{
+			outFields.m_build = DefaultBuildPath;
+		}
+		if (outFields.m_logicOutput.empty())
+		{
+			outFields.m_logicOutput = DefaultLogicOutputPath;
+		}
+		if (outFields.m_moduleName.empty())
+		{
+			outFields.m_moduleName = DefaultModuleName;
+		}
+		if (!IsCIdentifier(outFields.m_moduleName))
+		{
+			outError = "Workspace manifest logicModuleName '" + outFields.m_moduleName +
+				"' must be a valid C identifier.";
+			return false;
+		}
+
+		std::transform(
+			outFields.m_engineReferenceKind.begin(),
+			outFields.m_engineReferenceKind.end(),
+			outFields.m_engineReferenceKind.begin(),
+			[](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+		if (outFields.m_engineReferenceKind != "source" &&
+			outFields.m_engineReferenceKind != "installed")
+		{
+			outError = "Workspace manifest engineReferenceKind must be 'source' or 'installed'.";
+			return false;
+		}
+
+		return true;
+	}
+
+	bool NormalizeOwnedRelativePath(
+		const std::string& rawValue,
+		const char* fieldName,
+		std::filesystem::path& outPath,
+		std::string& outNormalized,
+		std::string& outError)
+	{
+		std::string normalized = Trim(rawValue);
+		std::replace(normalized.begin(), normalized.end(), '\\', '/');
+		while (normalized.rfind("./", 0) == 0)
+		{
+			normalized.erase(0, 2);
+		}
+		while (normalized.size() > 1 && normalized.back() == '/')
+		{
+			normalized.pop_back();
+		}
+
+		const bool bWindowsDrivePath = normalized.size() >= 2 &&
+			std::isalpha(static_cast<unsigned char>(normalized[0])) != 0 &&
+			normalized[1] == ':';
+		const std::filesystem::path path(normalized);
+		if (normalized.empty() || normalized.find('\0') != std::string::npos ||
+			normalized.front() == '/' || bWindowsDrivePath ||
+			path.is_absolute() || path.has_root_name() || path.has_root_directory())
+		{
+			outError = "Workspace manifest field '" + std::string(fieldName) +
+				"' must be a safe relative path: '" + rawValue + "'.";
+			return false;
+		}
+
+		for (const std::filesystem::path& component : path)
+		{
+			if (component == "..")
+			{
+				outError = "Workspace manifest field '" + std::string(fieldName) +
+					"' contains traversal: '" + rawValue + "'.";
+				return false;
+			}
+		}
+
+		outPath = path.lexically_normal();
+		outNormalized = outPath.generic_string();
+		return true;
+	}
+
+	bool ResolveOwnedPath(
+		const std::filesystem::path& root,
+		const std::filesystem::path& relativePath,
+		const char* fieldName,
+		std::filesystem::path& outPath,
+		std::string& outError)
+	{
+		std::error_code pathError;
+		outPath = std::filesystem::weakly_canonical(root / relativePath, pathError);
+		if (pathError || outPath.empty())
+		{
+			outError = "Workspace path '" + std::string(fieldName) +
+				"' could not be resolved: '" + (root / relativePath).generic_string() + "'.";
+			return false;
+		}
+		if (!IsInside(root, outPath))
+		{
+			outError = "Workspace path '" + std::string(fieldName) +
+				"' escapes the workspace after physical resolution: '" + outPath.generic_string() + "'.";
+			return false;
+		}
+		return true;
+	}
+
+	bool EnsureDirectory(
+		const std::filesystem::path& root,
+		const std::filesystem::path& directory,
+		const char* fieldName,
+		CreatedDirectoriesRollback& rollback,
+		std::string& outError)
+	{
+		std::error_code pathError;
+		const bool bExists = std::filesystem::exists(directory, pathError);
+		if (pathError)
+		{
+			outError = "Workspace directory '" + std::string(fieldName) +
+				"' could not be inspected: '" + directory.generic_string() + "'.";
+			return false;
+		}
+		if (bExists)
+		{
+			if (!std::filesystem::is_directory(directory, pathError) || pathError)
+			{
+				outError = "Workspace path '" + std::string(fieldName) +
+					"' is not a directory: '" + directory.generic_string() + "'.";
+				return false;
+			}
+			return true;
+		}
+
+		std::vector<std::filesystem::path> missingDirectories;
+		for (std::filesystem::path current = directory;
+			current != root && !current.empty();
+			current = current.parent_path())
+		{
+			pathError.clear();
+			if (std::filesystem::exists(current, pathError))
+			{
+				break;
+			}
+			if (pathError)
+			{
+				outError = "Workspace directory '" + std::string(fieldName) +
+					"' could not be inspected: '" + current.generic_string() + "'.";
+				return false;
+			}
+			missingDirectories.emplace_back(current);
+		}
+
+		std::reverse(missingDirectories.begin(), missingDirectories.end());
+		for (const std::filesystem::path& missingDirectory : missingDirectories)
+		{
+			pathError.clear();
+			const std::filesystem::path parent = std::filesystem::canonical(
+				missingDirectory.parent_path(),
+				pathError);
+			if (pathError || !IsInside(root, parent))
+			{
+				outError = "Workspace directory '" + std::string(fieldName) +
+					"' parent escapes the workspace during recovery: '" +
+					missingDirectory.parent_path().generic_string() + "'.";
+				return false;
+			}
+
+			const std::filesystem::path verifiedDirectory = parent / missingDirectory.filename();
+			pathError.clear();
+			const bool bCreated = std::filesystem::create_directory(verifiedDirectory, pathError);
+			if (pathError)
+			{
+				outError = "Workspace directory '" + std::string(fieldName) +
+					"' could not be created: '" + verifiedDirectory.generic_string() +
+					"': " + pathError.message() + ".";
+				return false;
+			}
+			if (bCreated)
+			{
+				rollback.Track({ verifiedDirectory });
+			}
+
+			pathError.clear();
+			const std::filesystem::path physicalDirectory = std::filesystem::canonical(
+				verifiedDirectory,
+				pathError);
+			if (pathError || !IsInside(root, physicalDirectory) ||
+				!std::filesystem::is_directory(physicalDirectory, pathError) || pathError)
+			{
+				outError = "Workspace directory '" + std::string(fieldName) +
+					"' escaped the workspace during recovery: '" +
+					verifiedDirectory.generic_string() + "'.";
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool RecanonicalizeDirectory(
+		const std::filesystem::path& root,
+		std::filesystem::path& directory,
+		const char* fieldName,
+		std::string& outError)
+	{
+		std::error_code pathError;
+		directory = std::filesystem::canonical(directory, pathError);
+		if (pathError || !IsInside(root, directory))
+		{
+			outError = "Workspace directory '" + std::string(fieldName) +
+				"' escapes the workspace after recovery: '" + directory.generic_string() + "'.";
+			return false;
+		}
+		return true;
+	}
+
+	bool DiscoverManifest(
+		const std::filesystem::path& root,
+		const std::filesystem::path& requestedManifest,
+		std::filesystem::path& outManifest,
+		EWorkspaceContextResolveStatus& outFailureStatus,
+		std::string& outError)
+	{
+		std::error_code pathError;
+		if (!requestedManifest.empty())
+		{
+			const std::filesystem::path candidate = requestedManifest.is_absolute()
+				? requestedManifest
+				: root / requestedManifest;
+			if (!std::filesystem::is_regular_file(candidate, pathError) || pathError)
+			{
+				outFailureStatus = EWorkspaceContextResolveStatus::ManifestNotFound;
+				outError = "Workspace manifest was not found: '" + candidate.generic_string() + "'.";
+				return false;
+			}
+
+			outManifest = std::filesystem::canonical(candidate, pathError);
+			if (pathError || !IsInside(root, outManifest))
+			{
+				outFailureStatus = EWorkspaceContextResolveStatus::PathInvalid;
+				outError = "Workspace manifest resolves outside the workspace: '" +
+					outManifest.generic_string() + "'.";
+				return false;
+			}
+			return true;
+		}
+
+		const std::filesystem::path defaultManifest = root / "workspace.sailor";
+		pathError.clear();
+		if (std::filesystem::is_regular_file(defaultManifest, pathError) && !pathError)
+		{
+			outManifest = std::filesystem::canonical(defaultManifest, pathError);
+			if (pathError || !IsInside(root, outManifest))
+			{
+				outFailureStatus = EWorkspaceContextResolveStatus::PathInvalid;
+				outError = "Workspace manifest resolves outside the workspace: '" +
+					outManifest.generic_string() + "'.";
+				return false;
+			}
+			return true;
+		}
+
+		std::vector<std::filesystem::path> manifests;
+		for (std::filesystem::directory_iterator it(root, pathError), end;
+			!pathError && it != end;
+			it.increment(pathError))
+		{
+			std::error_code entryError;
+			if (it->is_regular_file(entryError) && !entryError && HasSailorExtension(it->path()))
+			{
+				manifests.emplace_back(it->path());
+			}
+		}
+		if (pathError)
+		{
+			outFailureStatus = EWorkspaceContextResolveStatus::WorkspaceInvalid;
+			outError = "Workspace manifests could not be enumerated in '" + root.generic_string() +
+				"': " + pathError.message() + ".";
+			return false;
+		}
+
+		std::sort(manifests.begin(), manifests.end());
+		if (manifests.empty())
+		{
+			outManifest.clear();
+			return true;
+		}
+		if (manifests.size() > 1)
+		{
+			outFailureStatus = EWorkspaceContextResolveStatus::ManifestAmbiguous;
+			outError = "Multiple .sailor manifests were found in '" + root.generic_string() +
+				"'. Select one explicitly.";
+			return false;
+		}
+
+		outManifest = std::filesystem::canonical(manifests.front(), pathError);
+		if (pathError || !IsInside(root, outManifest))
+		{
+			outFailureStatus = EWorkspaceContextResolveStatus::PathInvalid;
+			outError = "Workspace manifest resolves outside the workspace: '" +
+				outManifest.generic_string() + "'.";
+			return false;
+		}
+		return true;
+	}
+}
+
+Sailor::Workspace::WorkspaceContextResolveResult Sailor::Workspace::ResolveWorkspaceContext(
+	const std::filesystem::path& requestedRoot,
+	const std::filesystem::path& requestedManifest) noexcept
+{
+	try
+	{
+		if (requestedRoot.empty())
+		{
+			return Fail(
+				EWorkspaceContextResolveStatus::WorkspaceInvalid,
+				"Workspace root must not be empty.");
+		}
+
+		std::error_code pathError;
+		const std::filesystem::path absoluteRoot = std::filesystem::absolute(requestedRoot, pathError);
+		const std::filesystem::path root = pathError
+			? std::filesystem::path{}
+			: std::filesystem::canonical(absoluteRoot, pathError);
+		if (pathError || root.empty() || !std::filesystem::is_directory(root))
+		{
+			return Fail(
+				EWorkspaceContextResolveStatus::WorkspaceInvalid,
+				"Workspace root must be an existing directory: '" + requestedRoot.generic_string() + "'.");
+		}
+
+		WorkspaceContextCandidate candidate;
+		candidate.m_root = root;
+		EWorkspaceContextResolveStatus discoveryFailure = EWorkspaceContextResolveStatus::ManifestNotFound;
+		std::string error;
+		if (!DiscoverManifest(
+				root,
+				requestedManifest,
+				candidate.m_manifest,
+				discoveryFailure,
+				error))
+		{
+			return Fail(discoveryFailure, std::move(error));
+		}
+
+		ManifestFields fields;
+		if (candidate.m_manifest.empty())
+		{
+			candidate.m_bLegacy = true;
+			candidate.m_moduleName = DefaultModuleName;
+		}
+		else
+		{
+			try
+			{
+				if (!ParseManifest(candidate.m_manifest, fields, error))
+				{
+					return Fail(EWorkspaceContextResolveStatus::ManifestInvalid, std::move(error));
+				}
+			}
+			catch (const YAML::Exception& e)
+			{
+				return Fail(
+					EWorkspaceContextResolveStatus::ManifestInvalid,
+					"Workspace manifest '" + candidate.m_manifest.generic_string() +
+						"' is invalid YAML: " + e.what());
+			}
+			candidate.m_manifestVersion = fields.m_manifestVersion;
+			candidate.m_workspaceId = fields.m_workspaceId;
+			candidate.m_workspaceName = fields.m_workspaceName;
+			candidate.m_moduleName = fields.m_moduleName;
+		}
+
+		std::filesystem::path contentRelative;
+		std::filesystem::path cacheRelative;
+		std::filesystem::path sourceRelative;
+		std::filesystem::path generatedRelative;
+		std::filesystem::path buildRelative;
+		std::filesystem::path logicOutputRelative;
+		std::string normalizedContent;
+		std::string unusedNormalized;
+		if (!NormalizeOwnedRelativePath(fields.m_content, "contentPath", contentRelative, normalizedContent, error) ||
+			!NormalizeOwnedRelativePath(fields.m_cache, "cachePath", cacheRelative, unusedNormalized, error) ||
+			!NormalizeOwnedRelativePath(fields.m_source, "sourcePath", sourceRelative, unusedNormalized, error) ||
+			!NormalizeOwnedRelativePath(fields.m_generated, "generatedProjectPath", generatedRelative, unusedNormalized, error) ||
+			!NormalizeOwnedRelativePath(fields.m_build, "buildPath", buildRelative, unusedNormalized, error) ||
+			!NormalizeOwnedRelativePath(fields.m_logicOutput, "logicOutputPath", logicOutputRelative, unusedNormalized, error))
+		{
+			return Fail(EWorkspaceContextResolveStatus::PathInvalid, std::move(error));
+		}
+
+		if (!ResolveOwnedPath(root, contentRelative, "contentPath", candidate.m_content, error) ||
+			!ResolveOwnedPath(root, cacheRelative, "cachePath", candidate.m_cache, error) ||
+			!ResolveOwnedPath(root, sourceRelative, "sourcePath", candidate.m_source, error) ||
+			!ResolveOwnedPath(root, generatedRelative, "generatedProjectPath", candidate.m_generated, error) ||
+			!ResolveOwnedPath(root, buildRelative, "buildPath", candidate.m_build, error) ||
+			!ResolveOwnedPath(root, logicOutputRelative, "logicOutputPath", candidate.m_logicOutput, error))
+		{
+			return Fail(EWorkspaceContextResolveStatus::PathInvalid, std::move(error));
+		}
+
+		pathError.clear();
+		const bool bContentExists = std::filesystem::exists(candidate.m_content, pathError);
+		if (pathError)
+		{
+			return Fail(
+				EWorkspaceContextResolveStatus::PathInvalid,
+				"Workspace content path could not be inspected: '" +
+					candidate.m_content.generic_string() + "'.");
+		}
+		if (bContentExists && !std::filesystem::is_directory(candidate.m_content))
+		{
+			return Fail(
+				EWorkspaceContextResolveStatus::PathInvalid,
+				"Workspace content path is not a directory: '" +
+					candidate.m_content.generic_string() + "'.");
+		}
+		if (!bContentExists && !IsDefaultContentPath(normalizedContent))
+		{
+			return Fail(
+				EWorkspaceContextResolveStatus::ContentMissing,
+				"Custom workspace content directory is missing and will not be created: '" +
+					candidate.m_content.generic_string() + "'.");
+		}
+
+		CreatedDirectoriesRollback rollback;
+		if (!bContentExists &&
+			!EnsureDirectory(root, candidate.m_content, "contentPath", rollback, error))
+		{
+			return Fail(EWorkspaceContextResolveStatus::DirectoryCreationFailed, std::move(error));
+		}
+		if (!EnsureDirectory(root, candidate.m_cache, "cachePath", rollback, error))
+		{
+			return Fail(EWorkspaceContextResolveStatus::DirectoryCreationFailed, std::move(error));
+		}
+
+		if (!RecanonicalizeDirectory(root, candidate.m_content, "contentPath", error) ||
+			!RecanonicalizeDirectory(root, candidate.m_cache, "cachePath", error))
+		{
+			return Fail(EWorkspaceContextResolveStatus::PathInvalid, std::move(error));
+		}
+
+		WorkspaceContextResolveResult result;
+		result.m_status = candidate.m_bLegacy
+			? EWorkspaceContextResolveStatus::Legacy
+			: EWorkspaceContextResolveStatus::Success;
+		result.m_message = candidate.m_bLegacy
+			? "No workspace manifest was found; using legacy Content and Cache directories under '" +
+				root.generic_string() + "'."
+			: "Resolved workspace manifest '" + candidate.m_manifest.generic_string() + "'.";
+		result.m_context.m_root = std::move(candidate.m_root);
+		result.m_context.m_manifest = std::move(candidate.m_manifest);
+		result.m_context.m_content = std::move(candidate.m_content);
+		result.m_context.m_cache = std::move(candidate.m_cache);
+		result.m_context.m_source = std::move(candidate.m_source);
+		result.m_context.m_generated = std::move(candidate.m_generated);
+		result.m_context.m_build = std::move(candidate.m_build);
+		result.m_context.m_logicOutput = std::move(candidate.m_logicOutput);
+		result.m_context.m_moduleName = std::move(candidate.m_moduleName);
+		result.m_context.m_workspaceId = std::move(candidate.m_workspaceId);
+		result.m_context.m_workspaceName = std::move(candidate.m_workspaceName);
+		result.m_context.m_manifestVersion = candidate.m_manifestVersion;
+		result.m_context.m_bLegacy = candidate.m_bLegacy;
+		rollback.Commit();
+		return result;
+	}
+	catch (const std::exception& e)
+	{
+		return Fail(
+			EWorkspaceContextResolveStatus::ManifestInvalid,
+			"Workspace context resolution failed: " + std::string(e.what()));
+	}
+	catch (...)
+	{
+		return Fail(
+			EWorkspaceContextResolveStatus::ManifestInvalid,
+			"Workspace context resolution failed with an unknown error.");
+	}
+}

--- a/Runtime/Workspace/WorkspaceContext.h
+++ b/Runtime/Workspace/WorkspaceContext.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "Core/Defines.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+namespace Sailor::Workspace
+{
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+
+	enum class EWorkspaceContextResolveStatus : uint32_t
+	{
+		Success,
+		Legacy,
+		WorkspaceInvalid,
+		ManifestNotFound,
+		ManifestAmbiguous,
+		ManifestInvalid,
+		PathInvalid,
+		ContentMissing,
+		DirectoryCreationFailed
+	};
+
+	struct WorkspaceContextResolveResult;
+	SAILOR_SHARED_API WorkspaceContextResolveResult ResolveWorkspaceContext(
+		const std::filesystem::path& root,
+		const std::filesystem::path& requestedManifest) noexcept;
+
+	class SAILOR_SHARED_API WorkspaceContext final
+	{
+	public:
+		const std::filesystem::path& GetRoot() const noexcept { return m_root; }
+		const std::filesystem::path& GetManifest() const noexcept { return m_manifest; }
+		const std::filesystem::path& GetContent() const noexcept { return m_content; }
+		const std::filesystem::path& GetCache() const noexcept { return m_cache; }
+		const std::filesystem::path& GetSource() const noexcept { return m_source; }
+		const std::filesystem::path& GetGenerated() const noexcept { return m_generated; }
+		const std::filesystem::path& GetBuild() const noexcept { return m_build; }
+		const std::filesystem::path& GetLogicOutput() const noexcept { return m_logicOutput; }
+		const std::string& GetModuleName() const noexcept { return m_moduleName; }
+		const std::string& GetWorkspaceId() const noexcept { return m_workspaceId; }
+		const std::string& GetWorkspaceName() const noexcept { return m_workspaceName; }
+		uint32_t GetManifestVersion() const noexcept { return m_manifestVersion; }
+		bool IsLegacy() const noexcept { return m_bLegacy; }
+
+	private:
+		std::filesystem::path m_root;
+		std::filesystem::path m_manifest;
+		std::filesystem::path m_content;
+		std::filesystem::path m_cache;
+		std::filesystem::path m_source;
+		std::filesystem::path m_generated;
+		std::filesystem::path m_build;
+		std::filesystem::path m_logicOutput;
+		std::string m_moduleName;
+		std::string m_workspaceId;
+		std::string m_workspaceName;
+		uint32_t m_manifestVersion = 0;
+		bool m_bLegacy = false;
+
+		friend struct WorkspaceContextResolveResult;
+		friend WorkspaceContextResolveResult ResolveWorkspaceContext(
+			const std::filesystem::path&,
+			const std::filesystem::path&) noexcept;
+	};
+
+	struct SAILOR_SHARED_API WorkspaceContextResolveResult
+	{
+		EWorkspaceContextResolveStatus m_status = EWorkspaceContextResolveStatus::WorkspaceInvalid;
+		std::string m_message;
+		WorkspaceContext m_context;
+
+		bool IsSuccess() const noexcept
+		{
+			return m_status == EWorkspaceContextResolveStatus::Success ||
+				m_status == EWorkspaceContextResolveStatus::Legacy;
+		}
+	};
+
+	SAILOR_SHARED_API WorkspaceContextResolveResult ResolveWorkspaceContext(
+		const std::filesystem::path& root,
+		const std::filesystem::path& requestedManifest = {}) noexcept;
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+}

--- a/Runtime/Workspace/WorkspaceModuleManager.cpp
+++ b/Runtime/Workspace/WorkspaceModuleManager.cpp
@@ -133,69 +133,36 @@ namespace
 		}
 	}
 
-	bool IsCIdentifier(const std::string& value)
+	bool IsInside(const std::filesystem::path& root, const std::filesystem::path& candidate)
 	{
-		if (value.empty())
+		auto rootPart = root.begin();
+		auto candidatePart = candidate.begin();
+		for (; rootPart != root.end(); ++rootPart, ++candidatePart)
 		{
-			return false;
-		}
-
-		auto isIdentifierStart = [](char character)
-		{
-			return character == '_' ||
-				(character >= 'A' && character <= 'Z') ||
-				(character >= 'a' && character <= 'z');
-		};
-
-		if (!isIdentifierStart(value.front()))
-		{
-			return false;
-		}
-
-		return std::all_of(value.begin() + 1, value.end(), [&](char character)
+			if (candidatePart == candidate.end())
 			{
-				return isIdentifierStart(character) || (character >= '0' && character <= '9');
-			});
-	}
+				return false;
+			}
 
-	bool IsSafeRelativePath(const std::filesystem::path& path)
-	{
-		if (path.empty() || path.is_absolute())
-		{
-			return false;
-		}
-
-		for (const std::filesystem::path& component : path)
-		{
-			if (component == "..")
+			std::string rootValue = rootPart->generic_string();
+			std::string candidateValue = candidatePart->generic_string();
+#if defined(_WIN32)
+			std::transform(rootValue.begin(), rootValue.end(), rootValue.begin(), [](unsigned char character)
+				{
+					return static_cast<char>(std::tolower(character));
+				});
+			std::transform(candidateValue.begin(), candidateValue.end(), candidateValue.begin(), [](unsigned char character)
+				{
+					return static_cast<char>(std::tolower(character));
+				});
+#endif
+			if (rootValue != candidateValue)
 			{
 				return false;
 			}
 		}
 
 		return true;
-	}
-
-	bool IsInside(const std::filesystem::path& root, const std::filesystem::path& candidate)
-	{
-		const std::filesystem::path relative = candidate.lexically_relative(root);
-		if (relative.empty() || relative.is_absolute())
-		{
-			return false;
-		}
-
-		const auto first = relative.begin();
-		return first != relative.end() && *first != "..";
-	}
-
-	bool HasSailorExtension(const std::filesystem::path& path)
-	{
-		std::string extension = path.extension().string();
-		std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char character)
-			{
-				return static_cast<char>(std::tolower(character));
-			});
-		return extension == ".sailor";
 	}
 
 	bool IsBlank(const std::string& value)
@@ -1095,11 +1062,9 @@ Sailor::Workspace::WorkspaceModuleManager::~WorkspaceModuleManager() noexcept
 }
 
 const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::WorkspaceModuleManager::Load(
-	const std::filesystem::path& workspaceRoot,
-	const std::filesystem::path& requestedManifestPath,
+	const WorkspaceContext& context,
 	std::string buildConfig) noexcept
 {
-	EWorkspaceModuleLoadStatus yamlFailureStatus = EWorkspaceModuleLoadStatus::ManifestInvalid;
 	try
 	{
 		if (!Unload())
@@ -1110,120 +1075,25 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 		m_result = {};
 		m_state = EWorkspaceModuleState::NotConfigured;
 		m_result.m_buildConfig = std::move(buildConfig);
+		m_result.m_manifestPath = context.GetManifest();
+		m_result.m_moduleName = context.GetModuleName();
+
+		if (context.IsLegacy())
+		{
+			m_result.m_status = EWorkspaceModuleLoadStatus::NotConfigured;
+			m_result.m_message = "No workspace manifest is active; runtime will use engine-only types.";
+			return m_result;
+		}
 
 		std::error_code pathError;
-		const std::filesystem::path root = std::filesystem::weakly_canonical(
-			std::filesystem::absolute(workspaceRoot, pathError),
-			pathError);
-		if (pathError || root.empty() || !std::filesystem::is_directory(root))
+		const std::filesystem::path root = context.GetRoot();
+		if (root.empty() || !std::filesystem::is_directory(root, pathError) || pathError)
 		{
 			return Fail(
 				EWorkspaceModuleLoadStatus::WorkspaceInvalid,
-				"Workspace module discovery requires an existing workspace directory: '" +
-				workspaceRoot.generic_string() + "'.");
+				"Workspace module activation requires a valid resolved workspace context.");
 		}
-
-		std::filesystem::path manifestPath;
-		if (!requestedManifestPath.empty())
-		{
-			manifestPath = requestedManifestPath.is_absolute()
-				? requestedManifestPath
-				: root / requestedManifestPath;
-			manifestPath = std::filesystem::weakly_canonical(manifestPath, pathError);
-			if (pathError || !std::filesystem::is_regular_file(manifestPath) || !IsInside(root, manifestPath))
-			{
-				m_result.m_manifestPath = manifestPath;
-				return Fail(
-					EWorkspaceModuleLoadStatus::ManifestNotFound,
-					"Workspace manifest was not found inside the workspace: '" +
-					manifestPath.generic_string() + "'.");
-			}
-		}
-		else
-		{
-			const std::filesystem::path defaultManifest = root / "workspace.sailor";
-			if (std::filesystem::is_regular_file(defaultManifest))
-			{
-				manifestPath = defaultManifest;
-			}
-			else
-			{
-				std::vector<std::filesystem::path> manifests;
-				for (std::filesystem::directory_iterator it(root, pathError), end; !pathError && it != end; it.increment(pathError))
-				{
-					if (it->is_regular_file() && HasSailorExtension(it->path()))
-					{
-						manifests.emplace_back(it->path());
-					}
-				}
-
-				if (pathError)
-				{
-					return Fail(
-						EWorkspaceModuleLoadStatus::WorkspaceInvalid,
-						"Failed to enumerate workspace manifests in '" + root.generic_string() +
-						"': " + pathError.message() + ".");
-				}
-
-				std::sort(manifests.begin(), manifests.end());
-				if (manifests.empty())
-				{
-					m_result.m_status = EWorkspaceModuleLoadStatus::NotConfigured;
-					m_result.m_message = "No workspace manifest was found; runtime will use engine-only types.";
-					return m_result;
-				}
-
-				if (manifests.size() != 1)
-				{
-					return Fail(
-						EWorkspaceModuleLoadStatus::ManifestAmbiguous,
-						"Multiple .sailor manifests were found in '" + root.generic_string() +
-						"'. Pass --workspace-manifest with the exact manifest path.");
-				}
-
-				manifestPath = manifests.front();
-			}
-		}
-
-		pathError.clear();
-		manifestPath = std::filesystem::weakly_canonical(manifestPath, pathError);
-		if (pathError || !std::filesystem::is_regular_file(manifestPath) || !IsInside(root, manifestPath))
-		{
-			m_result.m_manifestPath = manifestPath;
-			return Fail(
-				EWorkspaceModuleLoadStatus::ManifestNotFound,
-				"Workspace manifest was not found inside the workspace: '" +
-				manifestPath.generic_string() + "'.");
-		}
-
-		m_result.m_manifestPath = manifestPath;
-		const YAML::Node manifest = YAML::LoadFile(manifestPath.string());
-		const uint32_t manifestVersion = manifest["manifestVersion"]
-			? manifest["manifestVersion"].as<uint32_t>()
-			: 0;
-		if (manifestVersion != 1)
-		{
-			return Fail(
-				EWorkspaceModuleLoadStatus::ManifestInvalid,
-				"Workspace manifest '" + manifestPath.generic_string() +
-				"' has unsupported manifestVersion '" + std::to_string(manifestVersion) + "'.");
-		}
-
-		const std::string logicOutputPath = manifest["logicOutputPath"]
-			? manifest["logicOutputPath"].as<std::string>()
-			: "Binaries";
-		const std::string moduleName = manifest["logicModuleName"]
-			? manifest["logicModuleName"].as<std::string>()
-			: "SailorGame";
-		m_result.m_moduleName = moduleName;
-
-		if (!IsSafeRelativePath(logicOutputPath) || !IsCIdentifier(moduleName))
-		{
-			return Fail(
-				EWorkspaceModuleLoadStatus::ManifestInvalid,
-				"Workspace manifest '" + manifestPath.generic_string() +
-				"' contains an unsafe logicOutputPath or logicModuleName.");
-		}
+		const std::string& moduleName = context.GetModuleName();
 
 		if (m_result.m_buildConfig.empty() ||
 			m_result.m_buildConfig == "." ||
@@ -1237,7 +1107,7 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 
 		pathError.clear();
 		const std::filesystem::path modulePath = std::filesystem::weakly_canonical(
-			root / logicOutputPath / m_result.m_buildConfig / GetModuleFilename(moduleName),
+			context.GetLogicOutput() / m_result.m_buildConfig / GetModuleFilename(moduleName),
 			pathError);
 		m_result.m_modulePath = modulePath;
 		if (pathError || !IsInside(root, modulePath))
@@ -1255,8 +1125,20 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 				"' was not found at '" + modulePath.generic_string() + "'. Build the workspace logic project first.");
 		}
 
+		pathError.clear();
+		const std::filesystem::path loadPath = std::filesystem::canonical(modulePath, pathError);
+		if (pathError || !IsInside(root, loadPath) ||
+			!std::filesystem::is_regular_file(loadPath, pathError) || pathError)
+		{
+			return Fail(
+				EWorkspaceModuleLoadStatus::ManifestInvalid,
+				"Workspace module path changed or escaped the workspace before loading: '" +
+					modulePath.generic_string() + "'.");
+		}
+		m_result.m_modulePath = loadPath;
+
 		Reflection::SetEngineAutoRegistrationSuppressed(true);
-		const bool bLibraryOpened = m_library.Open(modulePath);
+		const bool bLibraryOpened = m_library.Open(loadPath);
 		Reflection::SetEngineAutoRegistrationSuppressed(false);
 		if (!bLibraryOpened)
 		{
@@ -1335,7 +1217,6 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 				"Workspace module failed to write its V1 metadata payload.");
 		}
 
-		yamlFailureStatus = EWorkspaceModuleLoadStatus::MetadataInvalid;
 		const YAML::Node metadata = YAML::Load(m_metadata);
 		MetadataIdentities metadataIdentities;
 		std::string metadataError;
@@ -1498,8 +1379,8 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 	catch (const YAML::Exception& e)
 	{
 		return Fail(
-			yamlFailureStatus,
-			"Failed to parse workspace manifest or module metadata: " + std::string(e.what()));
+			EWorkspaceModuleLoadStatus::MetadataInvalid,
+			"Failed to parse workspace module metadata: " + std::string(e.what()));
 	}
 	catch (const std::exception& e)
 	{

--- a/Runtime/Workspace/WorkspaceModuleManager.h
+++ b/Runtime/Workspace/WorkspaceModuleManager.h
@@ -2,6 +2,7 @@
 
 #include "Core/Defines.h"
 #include "Platform/DynamicLibrary.h"
+#include "Workspace/WorkspaceContext.h"
 
 #include <filesystem>
 #include <string>
@@ -74,8 +75,7 @@ namespace Sailor::Workspace
 		WorkspaceModuleManager& operator=(WorkspaceModuleManager&&) = delete;
 
 		const WorkspaceModuleLoadResult& Load(
-			const std::filesystem::path& workspaceRoot,
-			const std::filesystem::path& manifestPath,
+			const WorkspaceContext& context,
 			std::string buildConfig) noexcept;
 		bool Unload() noexcept;
 		bool BuildEditorTypeMetadata(

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -98,6 +98,10 @@ add_executable(WorkspaceModuleRuntimeTests
     WorkspaceModuleRuntimeTests.cpp
 )
 
+add_executable(WorkspaceContextTests
+    WorkspaceContextTests.cpp
+)
+
 if(WIN32)
     add_executable(RemoteViewportWindowsTransportTests
         RemoteViewportWindowsTransportTests.cpp
@@ -125,6 +129,7 @@ target_compile_features(WorkspaceModuleIncompatibleFixture PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleMissingEntryFixture PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleContractTests PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleRuntimeTests PRIVATE cxx_std_20)
+target_compile_features(WorkspaceContextTests PRIVATE cxx_std_20)
 target_compile_definitions(WorkspaceModuleFixture PRIVATE
     SAILOR_WORKSPACE_MODULE
     SAILOR_WORKSPACE_MODULE_EXPORTS
@@ -149,6 +154,7 @@ target_link_libraries(WorkspaceModuleContractTests PRIVATE
     Sailor::Runtime
 )
 target_link_libraries(WorkspaceModuleRuntimeTests PRIVATE Sailor::Runtime)
+target_link_libraries(WorkspaceContextTests PRIVATE Sailor::Runtime)
 add_dependencies(WorkspaceModuleRuntimeTests
     WorkspaceModuleFixture
     WorkspaceModuleIncompatibleFixture
@@ -174,6 +180,7 @@ set_target_properties(WorkspaceModuleMissingEntryFixture PROPERTIES OUTPUT_NAME 
 if(WIN32)
     sailor_stage_workspace_test_runtime(WorkspaceModuleContractTests)
     sailor_stage_workspace_test_runtime(WorkspaceModuleRuntimeTests)
+    sailor_stage_workspace_test_runtime(WorkspaceContextTests)
 endif()
 if(WIN32)
     target_compile_features(RemoteViewportWindowsTransportTests PRIVATE cxx_std_20)
@@ -207,6 +214,9 @@ target_include_directories(WorkspaceModuleContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(WorkspaceModuleRuntimeTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(WorkspaceContextTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 if(WIN32)
@@ -260,6 +270,11 @@ add_test(
 )
 
 add_test(
+    NAME WorkspaceContextTests
+    COMMAND WorkspaceContextTests
+)
+
+add_test(
     NAME WorkspaceModuleRuntimeTests
     COMMAND WorkspaceModuleRuntimeTests
         $<TARGET_FILE:WorkspaceModuleFixture>
@@ -282,6 +297,7 @@ add_test(
         $<CONFIG>
 )
 set_tests_properties(
+    WorkspaceContextTests
     WorkspaceModuleContractTests
     WorkspaceModuleRuntimeTests
     PROPERTIES TIMEOUT 30
@@ -289,6 +305,7 @@ set_tests_properties(
 
 if(WIN32 AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.22" AND VCPKG_INSTALLED_DIR AND VCPKG_TARGET_TRIPLET)
     set_tests_properties(
+        WorkspaceContextTests
         WorkspaceModuleContractTests
         WorkspaceModuleRuntimeTests
         PROPERTIES ENVIRONMENT_MODIFICATION

--- a/Tests/WorkspaceContextTests.cpp
+++ b/Tests/WorkspaceContextTests.cpp
@@ -1,0 +1,439 @@
+#include "Workspace/WorkspaceContext.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+#include <yaml-cpp/yaml.h>
+
+using namespace Sailor::Workspace;
+
+namespace
+{
+	struct ManifestSpec
+	{
+		uint32_t m_version = 1;
+		std::string m_workspaceId = "workspace-id";
+		std::string m_name = "Sandbox";
+		std::string m_enginePath = "../Sailor";
+		std::string m_engineReferenceKind = "source";
+		bool m_includeEngineReferenceKind = true;
+		std::string m_content = "Content";
+		std::string m_cache = "Cache";
+		std::string m_source = "Source";
+		std::string m_generated = "Generated";
+		std::string m_build = "Cache/Build";
+		std::string m_logicOutput = "Binaries";
+		std::string m_moduleName = "SailorGame";
+	};
+
+	class TempDirectory final
+	{
+	public:
+		explicit TempDirectory(const char* label)
+		{
+			static uint64_t nextId = 0;
+			const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+			m_path = std::filesystem::temp_directory_path() /
+				("sailor-workspace-context-" + std::string(label) + "-" +
+					std::to_string(timestamp) + "-" + std::to_string(nextId++));
+			std::filesystem::create_directories(m_path);
+		}
+
+		~TempDirectory() noexcept
+		{
+			std::error_code removeError;
+			std::filesystem::remove_all(m_path, removeError);
+		}
+
+		const std::filesystem::path& Get() const noexcept { return m_path; }
+		std::filesystem::path Path(const std::filesystem::path& relative) const
+		{
+			return m_path / relative;
+		}
+
+	private:
+		std::filesystem::path m_path;
+	};
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	std::filesystem::path Canonical(const std::filesystem::path& path)
+	{
+		std::error_code pathError;
+		const std::filesystem::path canonical = std::filesystem::canonical(path, pathError);
+		Require(!pathError, "test path should be canonicalizable: " + path.generic_string());
+		return canonical;
+	}
+
+	void WriteManifest(
+		const std::filesystem::path& path,
+		const ManifestSpec& spec = {})
+	{
+		YAML::Node manifest;
+		manifest["manifestVersion"] = spec.m_version;
+		manifest["workspaceId"] = spec.m_workspaceId;
+		manifest["name"] = spec.m_name;
+		manifest["enginePath"] = spec.m_enginePath;
+		if (spec.m_includeEngineReferenceKind)
+		{
+			manifest["engineReferenceKind"] = spec.m_engineReferenceKind;
+		}
+		manifest["contentPath"] = spec.m_content;
+		manifest["cachePath"] = spec.m_cache;
+		manifest["sourcePath"] = spec.m_source;
+		manifest["generatedProjectPath"] = spec.m_generated;
+		manifest["buildPath"] = spec.m_build;
+		manifest["logicOutputPath"] = spec.m_logicOutput;
+		manifest["logicModuleName"] = spec.m_moduleName;
+
+		std::ofstream output(path);
+		output << manifest;
+		Require(output.good(), "test manifest should be writable: " + path.generic_string());
+	}
+
+	void WriteText(const std::filesystem::path& path, const std::string& value)
+	{
+		std::ofstream output(path);
+		output << value;
+		Require(output.good(), "test file should be writable: " + path.generic_string());
+	}
+
+	void TestLegacyFallbackAndRecovery()
+	{
+		TempDirectory workspace("legacy");
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		Require(result.IsSuccess(), "legacy workspace should resolve: " + result.m_message);
+		Require(result.m_status == EWorkspaceContextResolveStatus::Legacy,
+			"legacy workspace should return the Legacy status");
+		Require(result.m_context.IsLegacy(), "legacy context should identify itself");
+		Require(result.m_context.GetRoot() == Canonical(workspace.Get()),
+			"legacy context should canonicalize its root");
+		Require(result.m_context.GetManifest().empty(), "legacy context should not invent a manifest");
+		Require(result.m_context.GetContent() == Canonical(workspace.Path("Content")),
+			"legacy context should use the default Content directory");
+		Require(result.m_context.GetCache() == Canonical(workspace.Path("Cache")),
+			"legacy context should use the default Cache directory");
+		Require(std::filesystem::is_directory(workspace.Path("Content")),
+			"legacy resolution should recreate default Content");
+		Require(std::filesystem::is_directory(workspace.Path("Cache")),
+			"legacy resolution should recreate default Cache");
+	}
+
+	void TestManifestPathsWithSpaces()
+	{
+		TempDirectory workspace("spaces");
+		ManifestSpec spec;
+		spec.m_workspaceId = "workspace with spaces";
+		spec.m_name = "Sandbox With Spaces";
+		spec.m_content = "Game Data/Content Files";
+		spec.m_cache = "State Data/Cache Files";
+		spec.m_source = "Game Code/Source Files";
+		spec.m_generated = "Generated Project/Files";
+		spec.m_build = "State Data/Build Output";
+		spec.m_logicOutput = "Game Binaries/Modules";
+		spec.m_moduleName = "SandboxLogic";
+		std::filesystem::create_directories(workspace.Path(spec.m_content));
+		const std::filesystem::path manifestPath = workspace.Path("Sandbox Project.sailor");
+		WriteManifest(manifestPath, spec);
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(
+			workspace.Path("."),
+			manifestPath);
+
+		Require(result.IsSuccess(), "manifest paths with spaces should resolve: " + result.m_message);
+		Require(result.m_status == EWorkspaceContextResolveStatus::Success,
+			"manifest context should return Success");
+		Require(!result.m_context.IsLegacy(), "manifest context should not be legacy");
+		Require(result.m_context.GetManifest() == Canonical(manifestPath),
+			"manifest path should be canonical");
+		Require(result.m_context.GetManifestVersion() == 1,
+			"manifest version should be preserved");
+		Require(result.m_context.GetWorkspaceId() == spec.m_workspaceId,
+			"workspace id should be preserved");
+		Require(result.m_context.GetWorkspaceName() == spec.m_name,
+			"workspace name should be preserved");
+		Require(result.m_context.GetContent() == Canonical(workspace.Path(spec.m_content)),
+			"custom content path should preserve spaces");
+		Require(result.m_context.GetCache() == Canonical(workspace.Path(spec.m_cache)),
+			"custom cache path should preserve spaces and be created");
+		Require(result.m_context.GetSource() ==
+			std::filesystem::weakly_canonical(workspace.Path(spec.m_source)),
+			"source path should preserve spaces");
+		Require(result.m_context.GetGenerated() ==
+			std::filesystem::weakly_canonical(workspace.Path(spec.m_generated)),
+			"generated path should preserve spaces");
+		Require(result.m_context.GetBuild() ==
+			std::filesystem::weakly_canonical(workspace.Path(spec.m_build)),
+			"build path should preserve spaces");
+		Require(result.m_context.GetLogicOutput() ==
+			std::filesystem::weakly_canonical(workspace.Path(spec.m_logicOutput)),
+			"logic output path should preserve spaces");
+		Require(result.m_context.GetModuleName() == spec.m_moduleName,
+			"module name should be preserved");
+	}
+
+	void TestManifestDefaultRecovery()
+	{
+		TempDirectory workspace("default-recovery");
+		WriteManifest(workspace.Path("workspace.sailor"));
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		Require(result.IsSuccess(), "default manifest paths should recover: " + result.m_message);
+		Require(std::filesystem::is_directory(workspace.Path("Content")),
+			"missing default manifest Content should be created");
+		Require(std::filesystem::is_directory(workspace.Path("Cache")),
+			"missing default manifest Cache should be created");
+	}
+
+	void TestManifestDefaultsMissingEngineReferenceKindToSource()
+	{
+		TempDirectory workspace("default-engine-reference");
+		ManifestSpec spec;
+		spec.m_includeEngineReferenceKind = false;
+		WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		Require(result.IsSuccess(),
+			"v1 manifest without engineReferenceKind should default to source: " + result.m_message);
+	}
+
+	void TestMissingCustomContentDoesNotMutateWorkspace()
+	{
+		TempDirectory workspace("missing-custom-content");
+		ManifestSpec spec;
+		spec.m_content = "Moved Content";
+		spec.m_cache = "Disposable Cache";
+		WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		Require(result.m_status == EWorkspaceContextResolveStatus::ContentMissing,
+			"missing custom content should be rejected: " + result.m_message);
+		Require(!result.IsSuccess(), "missing custom content should not publish a context");
+		Require(result.m_context.GetRoot().empty(), "failed resolution should keep context transactional");
+		Require(!std::filesystem::exists(workspace.Path(spec.m_content)),
+			"missing custom content must not be created");
+		Require(!std::filesystem::exists(workspace.Path(spec.m_cache)),
+			"cache recovery must not run after custom content validation fails");
+	}
+
+	void TestRecoveryRollbackOnLaterFailure()
+	{
+		TempDirectory workspace("recovery-rollback");
+		WriteManifest(workspace.Path("workspace.sailor"));
+		WriteText(workspace.Path("Cache"), "cache path is a file");
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		Require(result.m_status == EWorkspaceContextResolveStatus::DirectoryCreationFailed,
+			"cache recovery failure should be actionable: " + result.m_message);
+		Require(!std::filesystem::exists(workspace.Path("Content")),
+			"default Content created before a later failure should be rolled back");
+		Require(std::filesystem::is_regular_file(workspace.Path("Cache")),
+			"rollback must preserve pre-existing paths");
+		Require(result.m_context.GetRoot().empty(), "failed recovery should not publish a partial context");
+	}
+
+	void TestManifestDiscoveryFailures()
+	{
+		{
+			TempDirectory workspace("ambiguous");
+			WriteManifest(workspace.Path("First.sailor"));
+			WriteManifest(workspace.Path("Second.SAILOR"));
+
+			const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+			Require(result.m_status == EWorkspaceContextResolveStatus::ManifestAmbiguous,
+				"multiple manifests should be rejected: " + result.m_message);
+			Require(!std::filesystem::exists(workspace.Path("Content")),
+				"ambiguous discovery must not recover directories");
+		}
+		{
+			TempDirectory workspace("corrupt");
+			WriteText(workspace.Path("workspace.sailor"), "manifestVersion: [");
+
+			const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+			Require(result.m_status == EWorkspaceContextResolveStatus::ManifestInvalid,
+				"corrupt manifest should be rejected: " + result.m_message);
+			Require(result.m_message.find("invalid YAML") != std::string::npos,
+				"corrupt manifest should produce an actionable YAML diagnostic");
+		}
+		{
+			TempDirectory workspace("future-version");
+			ManifestSpec spec;
+			spec.m_version = 999;
+			WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+			const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+			Require(result.m_status == EWorkspaceContextResolveStatus::ManifestInvalid,
+				"future manifest version should be rejected: " + result.m_message);
+			Require(result.m_message.find("unsupported manifestVersion") != std::string::npos,
+				"future version diagnostic should identify the version contract");
+		}
+		{
+			TempDirectory workspace("missing-id");
+			ManifestSpec spec;
+			spec.m_workspaceId.clear();
+			WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+			const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+			Require(result.m_status == EWorkspaceContextResolveStatus::ManifestInvalid,
+				"missing workspace id should be rejected: " + result.m_message);
+			Require(result.m_message.find("workspaceId") != std::string::npos,
+				"missing field diagnostic should identify workspaceId");
+		}
+		{
+			TempDirectory workspace("missing-engine-path");
+			ManifestSpec spec;
+			spec.m_enginePath.clear();
+			WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+			const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+			Require(result.m_status == EWorkspaceContextResolveStatus::ManifestInvalid,
+				"missing engine path should be rejected: " + result.m_message);
+			Require(result.m_message.find("enginePath") != std::string::npos,
+				"missing field diagnostic should identify enginePath");
+		}
+		{
+			TempDirectory workspace("invalid-engine-reference");
+			ManifestSpec spec;
+			spec.m_engineReferenceKind = "remote";
+			WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+			const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+			Require(result.m_status == EWorkspaceContextResolveStatus::ManifestInvalid,
+				"unsupported engine reference kind should be rejected: " + result.m_message);
+			Require(result.m_message.find("engineReferenceKind") != std::string::npos,
+				"engine reference diagnostic should identify its field");
+		}
+		{
+			TempDirectory workspace("missing-explicit");
+
+			const WorkspaceContextResolveResult result = ResolveWorkspaceContext(
+				workspace.Get(),
+				workspace.Path("Missing.sailor"));
+			Require(result.m_status == EWorkspaceContextResolveStatus::ManifestNotFound,
+				"missing requested manifest should be distinguished");
+		}
+	}
+
+	void TestUnsafeOwnedPaths()
+	{
+		struct OwnedPathField
+		{
+			const char* m_name;
+			std::string ManifestSpec::* m_value;
+		};
+
+		const std::vector<OwnedPathField> fields
+		{
+			{ "contentPath", &ManifestSpec::m_content },
+			{ "cachePath", &ManifestSpec::m_cache },
+			{ "sourcePath", &ManifestSpec::m_source },
+			{ "generatedProjectPath", &ManifestSpec::m_generated },
+			{ "buildPath", &ManifestSpec::m_build },
+			{ "logicOutputPath", &ManifestSpec::m_logicOutput }
+		};
+		const std::vector<std::string> unsafePaths
+		{
+			"../Outside",
+			"Nested/../../Outside",
+			"/Absolute/Content",
+			"C:/Absolute/Content",
+			"C:DriveRelative",
+			"\\\\Server\\Share\\Content",
+			std::string("Content\0Invalid", 15)
+		};
+
+		for (size_t fieldIndex = 0; fieldIndex < fields.size(); ++fieldIndex)
+		{
+			for (size_t pathIndex = 0; pathIndex < unsafePaths.size(); ++pathIndex)
+			{
+				TempDirectory workspace(("unsafe-" + std::to_string(fieldIndex) + "-" +
+					std::to_string(pathIndex)).c_str());
+				ManifestSpec spec;
+				spec.*(fields[fieldIndex].m_value) = unsafePaths[pathIndex];
+				WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+				const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+				Require(result.m_status == EWorkspaceContextResolveStatus::PathInvalid,
+					"unsafe path should be rejected for '" + std::string(fields[fieldIndex].m_name) +
+						"': '" + unsafePaths[pathIndex] + "': " + result.m_message);
+				Require(result.m_message.find(fields[fieldIndex].m_name) != std::string::npos,
+					"unsafe path diagnostic should identify its manifest field");
+				Require(!std::filesystem::exists(workspace.Path("Content")),
+					"unsafe path validation must precede default recovery");
+			}
+		}
+	}
+
+	void TestPhysicalEscape()
+	{
+		TempDirectory workspace("physical-escape");
+		TempDirectory external("physical-external");
+		std::filesystem::create_directories(external.Path("Content"));
+		const std::filesystem::path linkPath = workspace.Path("ExternalLink");
+#if defined(_WIN32)
+		const std::string command = "cmd.exe /d /c mklink /J \"" +
+			linkPath.string() + "\" \"" + external.Get().string() + "\" >NUL";
+		Require(std::system(command.c_str()) == 0,
+			"Windows junction fixture should be creatable");
+#else
+		std::error_code linkError;
+		std::filesystem::create_directory_symlink(
+			external.Get(),
+			linkPath,
+			linkError);
+		Require(!linkError, "directory symlink fixture should be creatable: " + linkError.message());
+#endif
+
+		ManifestSpec spec;
+		spec.m_content = "ExternalLink/Content";
+		WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		Require(result.m_status == EWorkspaceContextResolveStatus::PathInvalid,
+			"physical content escape should be rejected: " + result.m_message);
+		Require(result.m_message.find("physical resolution") != std::string::npos,
+			"physical escape diagnostic should explain containment failure");
+	}
+}
+
+int main()
+{
+	try
+	{
+		TestLegacyFallbackAndRecovery();
+		TestManifestPathsWithSpaces();
+		TestManifestDefaultRecovery();
+		TestManifestDefaultsMissingEngineReferenceKindToSource();
+		TestMissingCustomContentDoesNotMutateWorkspace();
+		TestRecoveryRollbackOnLaterFailure();
+		TestManifestDiscoveryFailures();
+		TestUnsafeOwnedPaths();
+		TestPhysicalEscape();
+		std::cout << "[PASS] Workspace context contract" << std::endl;
+		return 0;
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "[FAIL] Workspace context contract: " << e.what() << std::endl;
+		return 1;
+	}
+}

--- a/Tests/WorkspaceModuleRuntimeTests.cpp
+++ b/Tests/WorkspaceModuleRuntimeTests.cpp
@@ -4,6 +4,7 @@
 #include "Memory/ObjectAllocator.hpp"
 #include "Platform/DynamicLibrary.h"
 #include "Workspace/WorkspaceModuleApi.h"
+#include "Workspace/WorkspaceContext.h"
 #include "Workspace/WorkspaceModuleManager.h"
 
 #include <algorithm>
@@ -61,24 +62,56 @@ namespace
 #endif
 	}
 
-	void WriteManifest(const std::filesystem::path& root, const std::string& moduleName)
+	void WriteManifest(
+		const std::filesystem::path& root,
+		const std::string& moduleName,
+		const std::string& logicOutputPath = "Binaries")
 	{
 		std::filesystem::create_directories(root);
 		std::ofstream manifest(root / "workspace.sailor");
 		manifest
 			<< "manifestVersion: 1\n"
-			<< "logicOutputPath: Binaries\n"
+			<< "workspaceId: 00000000-0000-0000-0000-000000000001\n"
+			<< "name: Workspace Module Runtime Fixture\n"
+			<< "enginePath: ../Engine\n"
+			<< "engineReferenceKind: source\n"
+			<< "contentPath: Content\n"
+			<< "sourcePath: Source\n"
+			<< "generatedProjectPath: Generated\n"
+			<< "cachePath: Cache\n"
+			<< "buildPath: Cache/Build\n"
+			<< "logicOutputPath: " << logicOutputPath << "\n"
 			<< "logicModuleName: " << moduleName << "\n";
 		Require(manifest.good(), "workspace fixture manifest should be writable");
+	}
+
+	WorkspaceContext ResolveContext(
+		const std::filesystem::path& root,
+		const std::filesystem::path& manifest = {})
+	{
+		WorkspaceContextResolveResult result = ResolveWorkspaceContext(root, manifest);
+		Require(result.IsSuccess(), "workspace context should resolve: " + result.m_message);
+		return std::move(result.m_context);
+	}
+
+	const WorkspaceModuleLoadResult& LoadWorkspaceModule(
+		WorkspaceModuleManager& manager,
+		const std::filesystem::path& root,
+		const std::string& config)
+	{
+		const WorkspaceContext context = ResolveContext(root);
+		return manager.Load(context, config);
 	}
 
 	std::filesystem::path InstallFixture(
 		const std::filesystem::path& root,
 		const std::string& config,
 		const std::string& moduleName,
-		const std::filesystem::path& sourceLibrary)
+		const std::filesystem::path& sourceLibrary,
+		const std::string& logicOutputPath = "Binaries")
 	{
-		const std::filesystem::path destination = root / "Binaries" / config / ModuleFilename(moduleName);
+		const std::filesystem::path destination =
+			root / logicOutputPath / config / ModuleFilename(moduleName);
 		std::filesystem::create_directories(destination.parent_path());
 		std::filesystem::copy_file(
 			sourceLibrary,
@@ -316,14 +349,14 @@ namespace
 		const std::filesystem::path legacyRoot = tempRoot / "legacy";
 		std::filesystem::create_directories(legacyRoot);
 		WorkspaceModuleManager legacyManager;
-		const auto& legacy = legacyManager.Load(legacyRoot, {}, config);
+		const auto& legacy = legacyManager.Load(ResolveContext(legacyRoot), config);
 		Require(legacy.m_status == EWorkspaceModuleLoadStatus::NotConfigured,
 			"workspace without a manifest should preserve engine-only startup");
 
 		const std::filesystem::path missingRoot = tempRoot / "missing";
 		WriteManifest(missingRoot, FixtureModuleName);
 		WorkspaceModuleManager missingManager;
-		const auto& missing = missingManager.Load(missingRoot, {}, config);
+		const auto& missing = LoadWorkspaceModule(missingManager, missingRoot, config);
 		Require(missing.m_status == EWorkspaceModuleLoadStatus::ModuleNotFound,
 			"missing workspace binary should return ModuleNotFound");
 		Require(missing.m_message.find(config) != std::string::npos,
@@ -333,9 +366,8 @@ namespace
 		std::filesystem::create_directories(ambiguousRoot);
 		std::ofstream(ambiguousRoot / "one.sailor") << "manifestVersion: 1\n";
 		std::ofstream(ambiguousRoot / "two.sailor") << "manifestVersion: 1\n";
-		WorkspaceModuleManager ambiguousManager;
-		const auto& ambiguous = ambiguousManager.Load(ambiguousRoot, {}, config);
-		Require(ambiguous.m_status == EWorkspaceModuleLoadStatus::ManifestAmbiguous,
+		const WorkspaceContextResolveResult ambiguous = ResolveWorkspaceContext(ambiguousRoot);
+		Require(!ambiguous.IsSuccess(),
 			"multiple non-default manifests should require an explicit path");
 	}
 
@@ -397,7 +429,7 @@ namespace
 			"sentinel owner registration should succeed: " + registrationError);
 
 		WorkspaceModuleManager manager;
-		const EWorkspaceModuleLoadStatus resultStatus = manager.Load(root, {}, config).m_status;
+		const EWorkspaceModuleLoadStatus resultStatus = LoadWorkspaceModule(manager, root, config).m_status;
 		const bool bOwnerPreserved = Reflection::GetNumWorkspaceTypes(owner) == 1 &&
 			Reflection::IsWorkspaceTypeRegistered(sentinelType.Name());
 		Reflection::UnregisterWorkspaceTypes(owner);
@@ -419,7 +451,7 @@ namespace
 		InstallFixture(root, config, "IncompatibleFixture", incompatibleLibrary);
 
 		WorkspaceModuleManager manager;
-		const auto& result = manager.Load(root, {}, config);
+		const auto& result = LoadWorkspaceModule(manager, root, config);
 		Require(result.m_status == EWorkspaceModuleLoadStatus::AbiMismatch,
 			"incompatible module should fail before metadata or registration callbacks");
 		Require(result.m_message.find("sailor-workspace-abi-" +
@@ -438,7 +470,7 @@ namespace
 		InstallFixture(root, config, "MissingEntryFixture", missingEntryLibrary);
 
 		WorkspaceModuleManager manager;
-		const auto& result = manager.Load(root, {}, config);
+		const auto& result = LoadWorkspaceModule(manager, root, config);
 		Require(result.m_status == EWorkspaceModuleLoadStatus::EntryPointMissing,
 			"module without the V1 API symbol should return EntryPointMissing");
 		Require(result.m_message.find(WorkspaceModuleApiEntryPointV1) != std::string::npos,
@@ -477,7 +509,7 @@ namespace
 		InstallFixture(root, config, "RenamedFixture", fixtureLibrary);
 
 		WorkspaceModuleManager manager;
-		const auto& result = manager.Load(root, {}, config);
+		const auto& result = LoadWorkspaceModule(manager, root, config);
 		Require(result.m_status == EWorkspaceModuleLoadStatus::ApiInvalid,
 			"renaming a module must not bypass its declared module identity");
 		Require(!manager.IsRegistered(), "identity mismatch must not leave registrations behind");
@@ -512,7 +544,7 @@ namespace
 			InstallFixture(root, config, moduleName, sourceLibrary);
 
 			WorkspaceModuleManager manager;
-			const auto& result = manager.Load(root, {}, config);
+			const auto& result = LoadWorkspaceModule(manager, root, config);
 			Require(result.m_status == EWorkspaceModuleLoadStatus::MetadataInvalid,
 				std::string("malformed metadata fixture '") + moduleName + "' should be rejected: " +
 				result.m_message);
@@ -634,13 +666,19 @@ namespace
 			!ContainsEngineType(engineOnlyEditorTypes, FixtureTypeName),
 			"unconfigured editor metadata should remain engine-only");
 
-		const std::filesystem::path root = tempRoot / "registered";
-		WriteManifest(root, FixtureModuleName);
-		InstallFixture(root, config, FixtureModuleName, fixtureLibrary);
+		const std::filesystem::path root = tempRoot / "registered workspace with spaces";
+		const std::string logicOutputPath = "Logic Output With Spaces";
+		WriteManifest(root, FixtureModuleName, logicOutputPath);
+		InstallFixture(root, config, FixtureModuleName, fixtureLibrary, logicOutputPath);
+		const WorkspaceContext context = ResolveContext(root);
+		std::ofstream(root / "workspace.sailor", std::ios::trunc)
+			<< "manifestVersion: 999\n";
 
 		WorkspaceModuleManager manager;
-		const auto& result = manager.Load(root, {}, config);
+		const auto& result = manager.Load(context, config);
 		Require(result.IsSuccess(), "workspace fixture should load and register: " + result.m_message);
+		Require(result.m_manifestPath == context.GetManifest(),
+			"module manager should consume the captured context without reparsing a changed manifest");
 		Require(result.m_numRegisteredTypes == 1, "workspace fixture should register one type");
 		Require(Reflection::IsWorkspaceTypeRegistered(FixtureTypeName),
 			"workspace fixture type should be visible in unified reflection lookup");
@@ -726,7 +764,7 @@ namespace
 		WriteManifest(collisionRoot, FixtureModuleName);
 		InstallFixture(collisionRoot, config, FixtureModuleName, fixtureLibrary);
 		WorkspaceModuleManager collisionManager;
-		const auto& collision = collisionManager.Load(collisionRoot, {}, config);
+		const auto& collision = LoadWorkspaceModule(collisionManager, collisionRoot, config);
 		Require(collision.m_status == EWorkspaceModuleLoadStatus::RegistrationFailed,
 			"second module with the same type should fail transactional preflight");
 		Require(Reflection::GetNumWorkspaceTypes(result.m_moduleName + "@" + result.m_modulePath.generic_string()) == 1,
@@ -744,7 +782,7 @@ namespace
 		Require(!ContainsEngineType(editorTypesAfterUnload, FixtureTypeName) &&
 			editorTypesAfterUnload["engineTypes"].size() == engineTypesBefore["engineTypes"].size(),
 			"workspace unload must remove custom entries from editor metadata");
-		const auto& reload = collisionManager.Load(collisionRoot, {}, config);
+		const auto& reload = LoadWorkspaceModule(collisionManager, collisionRoot, config);
 		Require(reload.IsSuccess(), "workspace module should reload after owner cleanup: " + reload.m_message);
 		Require(collisionManager.Unload(), "reloaded workspace fixture should unload cleanly");
 		Require(!Reflection::IsWorkspaceTypeRegistered(FixtureTypeName),


### PR DESCRIPTION
Closes #101

## Summary
- resolve one canonical manifest-aware workspace context before runtime activation
- route runtime assets, caches, shaders, module loading, and editor launch paths through resolved manifest-owned paths
- enforce lexical and physical containment, deterministic Content/Cache recovery, rollback, and legacy fallback
- align editor lifecycle/path policy with runtime behavior, including paths with spaces

## Validation
- Editor contracts: 228/228 passed
- WorkspaceContextTests, WorkspaceModuleContractTests, WorkspaceModuleRuntimeTests: 3/3 passed
- Full local macOS CTest: 10/11 passed; RemoteViewportMacTransportTests has a reproducible failure in an unchanged target
- git diff --check passed
- Editor and native Tech Review approved

Windows MSVC and clang-cl validation will run in CI.