### PR TITLE
Mount engine content alongside workspace content at runtime

### DIFF
--- a/Docs/WorkspaceLogic.md
+++ b/Docs/WorkspaceLogic.md
@@ -64,7 +64,7 @@ Install Sailor to a package prefix after configuring and building it with real d
 cmake --install <engine-build> --config Release --prefix <engine-prefix>
 ```
 
-An install configured with dependency stubs is rejected. The package contains the runtime library, public runtime headers, the public RenderDoc API header, `SailorConfig.cmake`, and the exported `Sailor::Runtime` target.
+An install configured with dependency stubs is rejected. The package contains the runtime library, public runtime headers, the public RenderDoc API header, `SailorConfig.cmake`, and the exported `Sailor::Runtime` target. It does not currently install the engine `Content/` tree. Runtime activation of an installed engine reference therefore remains unsupported until that prefix also provides `<engine-prefix>/Content`; workspace resolution reports the missing Engine Content directory instead of silently falling back to workspace assets.
 
 For `engineReferenceKind: installed`, set `enginePath` to `<engine-prefix>`. The generated project prepends that prefix to `CMAKE_PREFIX_PATH` and uses:
 
@@ -116,15 +116,32 @@ Workspace placement factories run without the reflection registry mutex held, so
 
 ## Runtime Discovery And Lifecycle
 
-At startup, the runtime resolves one immutable workspace context before module loading, content scanning, registry construction, or cache initialization. The context contains the canonical root and manifest plus the resolved Content, Cache, Source, Generated, Build, logic-output, workspace identity, version, and module name. The editor resolves the same manifest-owned paths in its workspace session and passes the exact root, manifest, Content, and Cache paths into its launch contract.
+At startup, the runtime resolves one immutable workspace context before module loading, content scanning, registry construction, or cache initialization. The context contains the canonical workspace and engine roots and manifest plus the resolved Workspace Content, Engine Content, Cache, Source, Generated, Build, logic-output, workspace identity, version, and module name. The editor resolves the same manifest-owned paths in its workspace session and passes the exact root, manifest, Content, and Cache paths into its launch contract.
 
 `--workspace-manifest <path>` selects an explicit manifest inside the workspace. Without the option, discovery prefers `workspace.sailor`; if that file is absent, exactly one root-level `*.sailor` file is accepted. No manifest creates a legacy context using `<root>/Content` and `<root>/Cache`; multiple candidates are rejected with an ambiguity diagnostic.
 
 Every workspace-owned manifest path is normalized lexically and then checked for physical containment after existing symlinks or Windows junctions are resolved. Validation completes before the context or editor session is published. A missing default `Content` directory is recreated, while a missing custom content path is rejected without creating a replacement. Cache directories are disposable and are recreated at their configured path. If later validation or recovery fails, directories created by that resolution attempt are rolled back.
 
+### Runtime Content Mounts
+
+The asset registry exposes exactly two discoverable content roots in one virtual namespace:
+
+- Workspace Content is writable and has higher priority.
+- Engine Content is read-only and has lower priority.
+
+Lookups use paths relative to either Content root. When both roots provide the same virtual path, Workspace Content wins. The same precedence applies when metadata in both roots declares the same `FileId`, so path-based and ID-based access select a consistent workspace override. Engine assets with unique paths and IDs remain available. Every virtual-path or `FileId` collision produces a deterministic diagnostic that identifies the selected and shadowed files.
+
+The roots are canonicalized before discovery. If Workspace Content and Engine Content resolve to the same physical directory, the registry keeps one writable Workspace mount and reports the deduplication; this preserves legacy workspaces whose engine and workspace roots are the same. Distinct roots may not contain one another. A nested-root configuration is rejected before a new registry generation is published, preventing one file from entering the namespace through two relative paths.
+
+Engine Content is never mutated by discovery. An Engine asset without metadata is diagnosed and skipped rather than imported or assigned newly generated metadata. Source rewrites and generated asset metadata are likewise restricted to Workspace Content; derived runtime data may still be written to the workspace Cache. Plain-text and binary content reads, including shader includes, particle data, and star-catalog data, use the same virtual-path resolver and workspace-over-engine precedence as registered assets.
+
+Import callbacks may register newly generated, non-conflicting Workspace assets into the active generation. A newly created Workspace file that collides with an active `FileId` is rejected until the next explicit Content rescan can apply the complete mount-precedence policy transactionally. Runtime hot replacement remains outside this contract.
+
+Cache is not a third discoverable content root. The editor's generated `../Cache/Temp.world` is supported through the direct cache-load exception, while normal asset discovery remains limited to Workspace Content and Engine Content.
+
 For manifest version 1, the runtime resolves the module as `<resolved-logic-output>/<CONFIG>/<platform-module-name>`. `WorkspaceModuleManager` consumes the captured context and never reparses the manifest. It canonicalizes the final module path again immediately before loading and rejects any symlink or junction change observed by that check. Concurrent mutation of the workspace or build tree during the platform's pathname-only library-loader call is not supported. The active CMake configuration is part of both the path and ABI check, so a stale Debug/Release binary fails with rebuild guidance instead of being loaded as a compatible module.
 
-The dynamic library is opened before asset importers scan the resolved Content directory. Asset, shader, precompiled-shader, and editor-type caches use the resolved Cache directory, including custom paths with spaces. The generated shader constants library is written below resolved Content. Static engine registration callbacks triggered by the platform loader are suppressed for that load operation; only the explicit V1 descriptor callback can add workspace types. The host validates the complete descriptor and metadata set before committing it under a module owner. Missing libraries, loader dependencies, entry points, incompatible API/ABI, metadata errors, and registration collisions return structured non-crashing diagnostics.
+The dynamic library is opened before asset importers scan the resolved Workspace Content and Engine Content mounts. Asset, shader, precompiled-shader, and editor-type caches use the resolved Cache directory, including custom paths with spaces. The generated shader constants library is written below Workspace Content. Static engine registration callbacks triggered by the platform loader are suppressed for that load operation; only the explicit V1 descriptor callback can add workspace types. The host validates the complete descriptor and metadata set before committing it under a module owner. Missing libraries, loader dependencies, entry points, incompatible API/ABI, metadata errors, and registration collisions return structured non-crashing diagnostics.
 
 Standalone startup treats a configured module or requested-world activation failure as fatal and returns a nonzero exit code. Editor startup reports the same error but remains available with an empty world so the project can be repaired. During shutdown, worlds, importers, the asset registry, scheduler, and remaining submodules are destroyed before workspace registrations are removed and the library is closed. Runtime hot reload and live workspace switching are not supported by this contract.
 

--- a/Runtime/AssetRegistry/AssetCache.cpp
+++ b/Runtime/AssetRegistry/AssetCache.cpp
@@ -7,7 +7,30 @@
 #include "Containers/ConcurrentMap.h"
 #include "AssetRegistry/AssetRegistry.h"
 
+#include <algorithm>
+#include <cctype>
+
 using namespace Sailor;
+
+namespace
+{
+	std::string NormalizeSourcePath(const std::string& sourcePath)
+	{
+		std::error_code error;
+		std::string result = std::filesystem::weakly_canonical(sourcePath, error).generic_string();
+		if (error)
+		{
+			result = std::filesystem::path(sourcePath).lexically_normal().generic_string();
+		}
+#if defined(_WIN32)
+		std::transform(result.begin(), result.end(), result.begin(), [](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+#endif
+		return result;
+	}
+}
 
 std::string AssetCache::GetAssetCacheFilepath()
 {
@@ -19,6 +42,7 @@ YAML::Node AssetCache::AssetCacheData::Entry::Serialize() const
 	YAML::Node res;
 	res["fileId"] = m_fileId;
 	res["assetImportTime"] = m_assetImportTime;
+	res["sourcePath"] = m_sourcePath;
 
 	return res;
 }
@@ -27,6 +51,15 @@ void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 {
 	m_fileId = inData["fileId"].as<FileId>();
 	m_assetImportTime = inData["assetImportTime"].as<std::time_t>();
+	m_sourcePath.clear();
+	for (const auto& field : inData)
+	{
+		if (field.first.IsScalar() && field.first.Scalar() == "sourcePath" && field.second.IsScalar())
+		{
+			m_sourcePath = NormalizeSourcePath(field.second.as<std::string>());
+			break;
+		}
+	}
 }
 
 YAML::Node AssetCache::AssetCacheData::Serialize() const
@@ -104,22 +137,37 @@ void AssetCache::ClearAll()
 
 bool AssetCache::Contains(const FileId& uid) const { return m_cache.m_data.ContainsKey(uid); }
 
-bool AssetCache::GetTimeStamp(const FileId& uid, time_t& outAssetTimestamp) const
+bool AssetCache::GetTimeStamp(
+	const FileId& uid,
+	const std::string& sourcePath,
+	time_t& outAssetTimestamp) const
 {
 	if (Contains(uid))
 	{
-		outAssetTimestamp = m_cache.m_data[uid].m_assetImportTime;
+		const AssetCacheData::Entry& entry = m_cache.m_data[uid];
+		if (entry.m_sourcePath.empty() || entry.m_sourcePath != NormalizeSourcePath(sourcePath))
+		{
+			return false;
+		}
+		outAssetTimestamp = entry.m_assetImportTime;
 		return true;
 	}
 	return false;
 }
 
-void AssetCache::Update(const FileId& id, const time_t& assetTimestamp)
+void AssetCache::Update(
+	const FileId& id,
+	const std::string& sourcePath,
+	const time_t& assetTimestamp)
 {
 	auto& entry = m_cache.m_data.At_Lock(id);
+	const std::string normalizedSourcePath = NormalizeSourcePath(sourcePath);
 
-	m_bIsDirty |= entry.m_assetImportTime < assetTimestamp;
+	m_bIsDirty |= entry.m_assetImportTime != assetTimestamp ||
+		entry.m_sourcePath != normalizedSourcePath;
+	entry.m_fileId = id;
 	entry.m_assetImportTime = assetTimestamp;
+	entry.m_sourcePath = normalizedSourcePath;
 
 	m_cache.m_data.Unlock(id);
 }
@@ -130,5 +178,7 @@ void AssetCache::Remove(const FileId& uid)
 
 bool AssetCache::IsExpired(const AssetInfo* info) const
 {
-	return m_cache.m_data[info->GetFileId()].m_assetImportTime < info->GetAssetLastModificationTime();
+	time_t cachedTimestamp = 0;
+	return !GetTimeStamp(info->GetFileId(), info->GetAssetFilepath(), cachedTimestamp) ||
+		cachedTimestamp < info->GetAssetLastModificationTime();
 }

--- a/Runtime/AssetRegistry/AssetCache.h
+++ b/Runtime/AssetRegistry/AssetCache.h
@@ -5,6 +5,7 @@
 #include "AssetRegistry/FileId.h"
 #include <mutex>
 #include <filesystem>
+#include <string>
 
 namespace Sailor
 {
@@ -17,9 +18,15 @@ namespace Sailor
 		SAILOR_API void Initialize();
 		SAILOR_API void Shutdown();
 
-		SAILOR_API bool GetTimeStamp(const FileId& uid, time_t& outAssetTimestamp) const;
+		SAILOR_API bool GetTimeStamp(
+			const FileId& uid,
+			const std::string& sourcePath,
+			time_t& outAssetTimestamp) const;
 
-		SAILOR_API void Update(const FileId& id, const time_t& assetTimestamp);
+		SAILOR_API void Update(
+			const FileId& id,
+			const std::string& sourcePath,
+			const time_t& assetTimestamp);
 		SAILOR_API void Remove(const FileId& uid);
 
 		SAILOR_API bool Contains(const FileId& uid) const;
@@ -42,6 +49,7 @@ namespace Sailor
 
 				FileId m_fileId{};
 				std::time_t m_assetImportTime{};
+				std::string m_sourcePath;
 
 				SAILOR_API bool operator==(const Entry& rhs) const { return m_fileId == rhs.m_fileId; }
 

--- a/Runtime/AssetRegistry/AssetInfo.cpp
+++ b/Runtime/AssetRegistry/AssetInfo.cpp
@@ -4,6 +4,8 @@
 #include <fstream>
 #include "Core/Utils.h"
 #include "Core/Reflection.h"
+#include "Tasks/Scheduler.h"
+#include "Tasks/Tasks.h"
 #include <iostream>
 
 using namespace Sailor;
@@ -25,6 +27,12 @@ void AssetInfo::Deserialize(const YAML::Node& inData)
 
 void AssetInfo::SaveMetaFile()
 {
+	if (!m_bWritable)
+	{
+		SAILOR_LOG_ERROR("Cannot write read-only engine asset metadata: %s", GetMetaFilepath().c_str());
+		return;
+	}
+
 	std::ofstream assetFile{ GetMetaFilepath() };
 
 	YAML::Node node = Serialize();
@@ -82,11 +90,20 @@ std::time_t AssetInfo::GetMetaLastModificationTime() const
 
 std::string AssetInfo::GetMetaFilepath() const
 {
+	if (!m_metaFilepath.empty())
+	{
+		return m_metaFilepath;
+	}
 	return m_folder + m_assetFilename + "." + AssetRegistry::MetaFileExtension;
 }
 
 std::string AssetInfo::GetRelativeAssetFilepath() const
 {
+	if (!m_virtualAssetFilepath.empty())
+	{
+		return m_virtualAssetFilepath;
+	}
+
 	std::string res = GetAssetFilepath();
 	Utils::Erase(res, AssetRegistry::GetContentFolder());
 	return res;
@@ -94,6 +111,11 @@ std::string AssetInfo::GetRelativeAssetFilepath() const
 
 std::string AssetInfo::GetRelativeMetaFilepath() const
 {
+	if (!m_virtualMetaFilepath.empty())
+	{
+		return m_virtualMetaFilepath;
+	}
+
 	std::string res = GetMetaFilepath();
 	Utils::Erase(res, AssetRegistry::GetContentFolder());
 	return res;
@@ -104,7 +126,11 @@ IAssetInfoHandler* AssetInfo::GetHandler()
 	return App::GetSubmodule<DefaultAssetInfoHandler>();
 }
 
-AssetInfoPtr IAssetInfoHandler::ImportAsset(const std::string& assetFilepath) const
+AssetInfoPtr IAssetInfoHandler::ImportAsset(
+	const std::string& assetFilepath,
+	const std::string& virtualAssetFilepath,
+	bool bNotifyListeners,
+	bool bUpdateAssetCache) const
 {
 	const std::string assetInfoFilename = AssetRegistry::GetMetaFilePath(assetFilepath);
 	std::filesystem::remove(assetInfoFilename);
@@ -117,37 +143,70 @@ AssetInfoPtr IAssetInfoHandler::ImportAsset(const std::string& assetFilepath) co
 	newMeta["fileId"] = fileId.Serialize();
 	newMeta["filename"] = std::filesystem::path(assetFilepath).filename().string();
 
-	App::GetSubmodule<AssetRegistry>()->CacheAssetTime(fileId, std::time(nullptr));
+	if (bUpdateAssetCache)
+	{
+		App::GetSubmodule<AssetRegistry>()->CacheAssetTime(
+			fileId,
+			assetFilepath,
+			std::time(nullptr));
+	}
 
 	assetFile << newMeta;
 	assetFile.close();
 
-	auto assetInfoPtr = LoadAssetInfo(assetInfoFilename);
-	for (IAssetInfoHandlerListener* listener : m_listeners)
+	const std::string virtualMetaFilepath = virtualAssetFilepath.empty()
+		? std::string{}
+		: virtualAssetFilepath + "." + AssetRegistry::MetaFileExtension;
+	auto assetInfoPtr = LoadAssetInfo(
+		assetInfoFilename,
+		virtualMetaFilepath,
+		EAssetMountKind::Workspace,
+		true,
+		bNotifyListeners,
+		bUpdateAssetCache);
+	assetInfoPtr->m_bPendingImportNotification = !bNotifyListeners;
+	if (bNotifyListeners)
 	{
-		listener->OnImportAsset(assetInfoPtr);
+		NotifyImportAsset(assetInfoPtr);
 	}
-
-	assetInfoPtr->SaveMetaFile();
 
 	return assetInfoPtr;
 }
 
-AssetInfoPtr IAssetInfoHandler::LoadAssetInfo(const std::string& assetInfoPath) const
+AssetInfoPtr IAssetInfoHandler::LoadAssetInfo(
+	const std::string& assetInfoPath,
+	const std::string& virtualMetaFilepath,
+	EAssetMountKind mountKind,
+	bool bWritable,
+	bool bNotifyListeners,
+	bool bUpdateAssetCache) const
 {
 	AssetInfoPtr res = CreateAssetInfo();
 	res->m_folder = std::filesystem::path(assetInfoPath).remove_filename().string();
+	res->m_metaFilepath = assetInfoPath;
+	res->m_virtualMetaFilepath = virtualMetaFilepath;
+	res->m_mountKind = mountKind;
+	res->m_bWritable = bWritable;
 
 	// Temp to pass asset filename to Reload Asset Info
 	const std::string filename = std::filesystem::path(assetInfoPath).filename().string();
 	res->m_assetFilename = filename.substr(0, filename.length() - strlen(AssetRegistry::MetaFileExtension) - 1);
+	if (!res->m_virtualMetaFilepath.empty())
+	{
+		res->m_virtualAssetFilepath = (
+			std::filesystem::path(res->m_virtualMetaFilepath).parent_path() /
+			res->m_assetFilename).generic_string();
+	}
 
-	ReloadAssetInfo(res);
+	ReloadAssetInfo(res, bNotifyListeners, bUpdateAssetCache);
 
 	return res;
 }
 
-void IAssetInfoHandler::ReloadAssetInfo(AssetInfoPtr assetInfo) const
+void IAssetInfoHandler::ReloadAssetInfo(
+	AssetInfoPtr assetInfo,
+	bool bNotifyListeners,
+	bool bUpdateAssetCache) const
 {
 	const bool bWasMetaExpired = assetInfo->IsMetaExpired();
 
@@ -157,18 +216,35 @@ void IAssetInfoHandler::ReloadAssetInfo(AssetInfoPtr assetInfo) const
 	YAML::Node meta = YAML::Load(content);
 
 	assetInfo->Deserialize(meta);
+	if (!assetInfo->m_virtualMetaFilepath.empty())
+	{
+		assetInfo->m_virtualAssetFilepath = (
+			std::filesystem::path(assetInfo->m_virtualMetaFilepath).parent_path() /
+			assetInfo->m_assetFilename).generic_string();
+	}
 	assetInfo->m_metaLoadTime = std::time(nullptr);
 
-	App::GetSubmodule<AssetRegistry>()->GetAssetCachedTime(assetInfo->GetFileId(), assetInfo->m_assetImportTime);
+	App::GetSubmodule<AssetRegistry>()->GetAssetCachedTime(
+		assetInfo->GetFileId(),
+		assetInfo->GetAssetFilepath(),
+		assetInfo->m_assetImportTime);
 
 	const bool bWasAssetExpired = assetInfo->IsAssetExpired();
 
 	assetInfo->m_assetImportTime = assetInfo->GetAssetLastModificationTime();
-	App::GetSubmodule<AssetRegistry>()->CacheAssetTime(assetInfo->GetFileId(), assetInfo->m_assetImportTime);
-
-	for (IAssetInfoHandlerListener* listener : m_listeners)
+	if (bUpdateAssetCache)
 	{
-		listener->OnUpdateAssetInfo(assetInfo, bWasMetaExpired || bWasAssetExpired);
+		App::GetSubmodule<AssetRegistry>()->CacheAssetTime(
+			assetInfo->GetFileId(),
+			assetInfo->GetAssetFilepath(),
+			assetInfo->m_assetImportTime);
+	}
+
+	assetInfo->m_bPendingUpdateNotification = !bNotifyListeners;
+	assetInfo->m_bPendingWasExpired = bWasMetaExpired || bWasAssetExpired;
+	if (bNotifyListeners)
+	{
+		NotifyUpdateAssetInfo(assetInfo);
 	}
 
 	/*	if (bWasAssetExpired)
@@ -176,6 +252,37 @@ void IAssetInfoHandler::ReloadAssetInfo(AssetInfoPtr assetInfo) const
 			assetInfo->SaveMetaFile();
 		}
 		*/
+}
+
+void IAssetInfoHandler::NotifyUpdateAssetInfo(AssetInfoPtr assetInfo) const
+{
+	if (assetInfo == nullptr)
+	{
+		return;
+	}
+
+	const bool bWasExpired = assetInfo->m_bPendingWasExpired;
+	assetInfo->m_bPendingUpdateNotification = false;
+	assetInfo->m_bPendingWasExpired = false;
+	for (IAssetInfoHandlerListener* listener : m_listeners)
+	{
+		listener->OnUpdateAssetInfo(assetInfo, bWasExpired);
+	}
+}
+
+void IAssetInfoHandler::NotifyImportAsset(AssetInfoPtr assetInfo) const
+{
+	if (assetInfo == nullptr)
+	{
+		return;
+	}
+
+	assetInfo->m_bPendingImportNotification = false;
+	for (IAssetInfoHandlerListener* listener : m_listeners)
+	{
+		listener->OnImportAsset(assetInfo);
+	}
+	assetInfo->SaveMetaFile();
 }
 
 void DefaultAssetInfoHandler::GetDefaultMeta(YAML::Node& outDefaultYaml) const

--- a/Runtime/AssetRegistry/AssetInfo.h
+++ b/Runtime/AssetRegistry/AssetInfo.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <ctime>
 #include "AssetRegistry/FileId.h"
+#include "AssetRegistry/AssetMountDiscovery.h"
 #include "Core/Singleton.hpp"
 #include "Containers/Vector.h"
 #include "Core/YamlSerializable.h"
@@ -27,6 +28,10 @@ namespace Sailor
 
 		SAILOR_API std::string GetRelativeAssetFilepath() const;
 		SAILOR_API std::string GetRelativeMetaFilepath() const;
+		SAILOR_API bool IsWritable() const noexcept { return m_bWritable; }
+		SAILOR_API EAssetMountKind GetMountKind() const noexcept { return m_mountKind; }
+		SAILOR_API const std::string& GetVirtualAssetFilepath() const noexcept { return m_virtualAssetFilepath; }
+		SAILOR_API const std::string& GetVirtualMetaFilepath() const noexcept { return m_virtualMetaFilepath; }
 
 		// That includes "../Content/" in the beginning
 		SAILOR_API std::string GetAssetFilepath() const { return m_folder + m_assetFilename; }
@@ -55,9 +60,18 @@ namespace Sailor
 		std::time_t m_assetImportTime;
 		std::string m_folder;
 		std::string m_assetFilename;
+		std::string m_metaFilepath;
+		std::string m_virtualAssetFilepath;
+		std::string m_virtualMetaFilepath;
 		FileId m_fileId;
+		EAssetMountKind m_mountKind = EAssetMountKind::Workspace;
+		bool m_bWritable = true;
+		bool m_bPendingUpdateNotification = false;
+		bool m_bPendingWasExpired = false;
+		bool m_bPendingImportNotification = false;
 
 		friend class IAssetInfoHandler;
+		friend class AssetRegistry;
 	};
 
 	using AssetInfoPtr = AssetInfo*;
@@ -83,9 +97,24 @@ namespace Sailor
 
 		virtual void GetDefaultMeta(YAML::Node& outDefaultYaml) const = 0;
 
-		virtual AssetInfoPtr LoadAssetInfo(const std::string& metaFilepath) const;
-		virtual AssetInfoPtr ImportAsset(const std::string& assetFilepath) const;
-		virtual void ReloadAssetInfo(AssetInfoPtr assetInfo) const;
+		virtual AssetInfoPtr LoadAssetInfo(
+			const std::string& metaFilepath,
+			const std::string& virtualMetaFilepath = {},
+			EAssetMountKind mountKind = EAssetMountKind::Workspace,
+			bool bWritable = true,
+			bool bNotifyListeners = true,
+			bool bUpdateAssetCache = true) const;
+		virtual AssetInfoPtr ImportAsset(
+			const std::string& assetFilepath,
+			const std::string& virtualAssetFilepath = {},
+			bool bNotifyListeners = true,
+			bool bUpdateAssetCache = true) const;
+		virtual void ReloadAssetInfo(
+			AssetInfoPtr assetInfo,
+			bool bNotifyListeners = true,
+			bool bUpdateAssetCache = true) const;
+		void NotifyUpdateAssetInfo(AssetInfoPtr assetInfo) const;
+		void NotifyImportAsset(AssetInfoPtr assetInfo) const;
 
 		virtual ~IAssetInfoHandler() = default;
 

--- a/Runtime/AssetRegistry/AssetMountDiscovery.cpp
+++ b/Runtime/AssetRegistry/AssetMountDiscovery.cpp
@@ -1,0 +1,586 @@
+#include "AssetRegistry/AssetMountDiscovery.h"
+
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <set>
+#include <sstream>
+#include <system_error>
+#include <tuple>
+#include <utility>
+
+using namespace Sailor;
+
+namespace
+{
+	std::string PathDisplay(const std::filesystem::path& path)
+	{
+		return path.generic_string();
+	}
+
+	std::string PathKey(const std::filesystem::path& path)
+	{
+		std::string key = PathDisplay(path.lexically_normal());
+#if defined(_WIN32)
+		std::transform(key.begin(), key.end(), key.begin(), [](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+#endif
+		while (key.size() > 1 && key.back() == '/')
+		{
+			key.pop_back();
+		}
+		return key;
+	}
+
+	std::string VirtualPathKey(std::string path)
+	{
+		std::replace(path.begin(), path.end(), '\\', '/');
+		while (path.rfind("./", 0) == 0)
+		{
+			path.erase(0, 2);
+		}
+		while (!path.empty() && path.front() == '/')
+		{
+			path.erase(path.begin());
+		}
+		while (path.size() > 1 && path.back() == '/')
+		{
+			path.pop_back();
+		}
+#if defined(_WIN32)
+		std::transform(path.begin(), path.end(), path.begin(), [](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+#endif
+		return path;
+	}
+
+	bool IsSafeVirtualPath(const std::string& path)
+	{
+		if (path.empty())
+		{
+			return false;
+		}
+		if (path.size() >= 2 && path[1] == ':' &&
+			((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')))
+		{
+			return false;
+		}
+
+		const std::filesystem::path virtualPath(path);
+		if (virtualPath.is_absolute() || virtualPath.has_root_name() || virtualPath.has_root_directory())
+		{
+			return false;
+		}
+
+		return std::none_of(virtualPath.begin(), virtualPath.end(), [](const std::filesystem::path& component)
+			{
+				return component == "..";
+			});
+	}
+
+	bool IsInside(const std::filesystem::path& root, const std::filesystem::path& candidate)
+	{
+		const std::string rootKey = PathKey(root);
+		const std::string candidateKey = PathKey(candidate);
+		if (candidateKey == rootKey)
+		{
+			return true;
+		}
+		const std::string prefix = !rootKey.empty() && rootKey.back() == '/'
+			? rootKey
+			: rootKey + '/';
+		return candidateKey.rfind(prefix, 0) == 0;
+	}
+
+	int32_t KindRank(EAssetMountKind kind)
+	{
+		return kind == EAssetMountKind::Workspace ? 1 : 0;
+	}
+
+	const char* KindName(EAssetMountKind kind)
+	{
+		return kind == EAssetMountKind::Workspace ? "Workspace" : "Engine";
+	}
+
+	template<typename TCandidate>
+	bool IsPreferred(const TCandidate& left, const TCandidate& right)
+	{
+		const int32_t leftKind = KindRank(left.m_mount.m_kind);
+		const int32_t rightKind = KindRank(right.m_mount.m_kind);
+		if (leftKind != rightKind)
+		{
+			return leftKind > rightKind;
+		}
+		if (left.m_mount.m_priority != right.m_mount.m_priority)
+		{
+			return left.m_mount.m_priority > right.m_mount.m_priority;
+		}
+		if (left.m_mount.m_bWritable != right.m_mount.m_bWritable)
+		{
+			return left.m_mount.m_bWritable;
+		}
+		if (PathKey(left.m_physicalPath) != PathKey(right.m_physicalPath))
+		{
+			return PathKey(left.m_physicalPath) < PathKey(right.m_physicalPath);
+		}
+		if (left.m_virtualPath != right.m_virtualPath)
+		{
+			return left.m_virtualPath < right.m_virtualPath;
+		}
+		return left.m_fileId < right.m_fileId;
+	}
+
+	bool IsPreferredMount(const AssetMountDescriptor& left, const AssetMountDescriptor& right)
+	{
+		AssetMountCandidate leftCandidate{ left, left.m_root, {}, {} };
+		AssetMountCandidate rightCandidate{ right, right.m_root, {}, {} };
+		return IsPreferred(leftCandidate, rightCandidate);
+	}
+
+	void SortDiagnostics(std::vector<AssetMountDiagnostic>& diagnostics)
+	{
+		std::sort(diagnostics.begin(), diagnostics.end(), [](const AssetMountDiagnostic& left, const AssetMountDiagnostic& right)
+			{
+				return std::tie(
+					left.m_code,
+					left.m_key,
+					left.m_message) < std::tie(
+						right.m_code,
+						right.m_key,
+						right.m_message);
+			});
+	}
+
+	bool IsFatalDiagnostic(EAssetMountDiagnosticCode code)
+	{
+		return code == EAssetMountDiagnosticCode::InvalidMountRoot ||
+			code == EAssetMountDiagnosticCode::OverlappingMountRoot;
+	}
+
+	AssetMountDiagnostic MakeInspectionDiagnostic(
+		EAssetMountDiagnosticCode code,
+		const AssetMountDescriptor& mount,
+		const std::filesystem::path& path,
+		const std::string& reason)
+	{
+		AssetMountDiagnostic diagnostic;
+		diagnostic.m_code = code;
+		diagnostic.m_key = PathDisplay(path);
+		diagnostic.m_winnerPath = mount.m_root;
+		diagnostic.m_conflictingPath = path;
+		diagnostic.m_winnerKind = mount.m_kind;
+		diagnostic.m_conflictingKind = mount.m_kind;
+		diagnostic.m_message = reason;
+		return diagnostic;
+	}
+
+	std::vector<AssetMountDescriptor> NormalizeMounts(
+		const std::vector<AssetMountDescriptor>& mounts,
+		std::vector<AssetMountDiagnostic>& diagnostics)
+	{
+		std::vector<AssetMountDescriptor> normalized;
+		for (const AssetMountDescriptor& input : mounts)
+		{
+			std::error_code error;
+			const std::filesystem::path root = std::filesystem::canonical(input.m_root, error);
+			if (error || !std::filesystem::is_directory(root, error) || error)
+			{
+				AssetMountDiagnostic diagnostic;
+				diagnostic.m_code = EAssetMountDiagnosticCode::InvalidMountRoot;
+				diagnostic.m_key = PathDisplay(input.m_root);
+				diagnostic.m_conflictingPath = input.m_root;
+				diagnostic.m_conflictingKind = input.m_kind;
+				diagnostic.m_message = "Asset mount root is not a readable directory: '" +
+					PathDisplay(input.m_root) + "'.";
+				diagnostics.emplace_back(std::move(diagnostic));
+				continue;
+			}
+
+			AssetMountDescriptor descriptor = input;
+			descriptor.m_root = root;
+			normalized.emplace_back(std::move(descriptor));
+		}
+
+		std::sort(normalized.begin(), normalized.end(), [](const AssetMountDescriptor& left, const AssetMountDescriptor& right)
+			{
+				const std::string leftRoot = PathKey(left.m_root);
+				const std::string rightRoot = PathKey(right.m_root);
+				if (leftRoot != rightRoot)
+				{
+					return leftRoot < rightRoot;
+				}
+				return IsPreferredMount(left, right);
+			});
+
+		std::vector<AssetMountDescriptor> deduplicated;
+		for (size_t begin = 0; begin < normalized.size();)
+		{
+			size_t end = begin + 1;
+			while (end < normalized.size() && PathKey(normalized[end].m_root) == PathKey(normalized[begin].m_root))
+			{
+				++end;
+			}
+
+			const AssetMountDescriptor& winner = normalized[begin];
+			deduplicated.emplace_back(winner);
+			for (size_t duplicate = begin + 1; duplicate < end; ++duplicate)
+			{
+				const AssetMountDescriptor& conflicting = normalized[duplicate];
+				AssetMountDiagnostic diagnostic;
+				diagnostic.m_code = EAssetMountDiagnosticCode::DuplicateMountRoot;
+				diagnostic.m_key = PathKey(winner.m_root);
+				diagnostic.m_winnerPath = winner.m_root;
+				diagnostic.m_conflictingPath = conflicting.m_root;
+				diagnostic.m_winnerKind = winner.m_kind;
+				diagnostic.m_conflictingKind = conflicting.m_kind;
+				diagnostic.m_message = "Duplicate asset mount root '" + PathDisplay(winner.m_root) +
+					"' keeps " + KindName(winner.m_kind) + " and discards " +
+					KindName(conflicting.m_kind) + ".";
+				diagnostics.emplace_back(std::move(diagnostic));
+			}
+			begin = end;
+		}
+
+		for (size_t leftIndex = 0; leftIndex < deduplicated.size(); ++leftIndex)
+		{
+			for (size_t rightIndex = leftIndex + 1; rightIndex < deduplicated.size(); ++rightIndex)
+			{
+				const AssetMountDescriptor& left = deduplicated[leftIndex];
+				const AssetMountDescriptor& right = deduplicated[rightIndex];
+				if (!IsInside(left.m_root, right.m_root) && !IsInside(right.m_root, left.m_root))
+				{
+					continue;
+				}
+
+				AssetMountDiagnostic diagnostic;
+				diagnostic.m_code = EAssetMountDiagnosticCode::OverlappingMountRoot;
+				diagnostic.m_key = PathKey(left.m_root) + "|" + PathKey(right.m_root);
+				diagnostic.m_winnerPath = left.m_root;
+				diagnostic.m_conflictingPath = right.m_root;
+				diagnostic.m_winnerKind = left.m_kind;
+				diagnostic.m_conflictingKind = right.m_kind;
+				diagnostic.m_message = "Asset mount roots overlap and cannot be activated: " +
+					std::string(KindName(left.m_kind)) + " '" + PathDisplay(left.m_root) +
+					"' and " + KindName(right.m_kind) + " '" + PathDisplay(right.m_root) + "'.";
+				diagnostics.emplace_back(std::move(diagnostic));
+			}
+		}
+
+		return deduplicated;
+	}
+
+	void DiscoverDirectory(
+		const AssetMountDescriptor& mount,
+		const std::filesystem::path& logicalDirectory,
+		std::set<std::string>& visitedDirectories,
+		std::vector<AssetMountDiscoveredFile>& files,
+		std::vector<AssetMountDiagnostic>& diagnostics)
+	{
+		std::error_code error;
+		const std::filesystem::path physicalDirectory = std::filesystem::canonical(logicalDirectory, error);
+		if (error)
+		{
+			diagnostics.emplace_back(MakeInspectionDiagnostic(
+				EAssetMountDiagnosticCode::PathInspectionFailed,
+				mount,
+				logicalDirectory,
+				"Asset mount directory could not be resolved: '" + PathDisplay(logicalDirectory) + "'."));
+			return;
+		}
+		if (!IsInside(mount.m_root, physicalDirectory))
+		{
+			diagnostics.emplace_back(MakeInspectionDiagnostic(
+				EAssetMountDiagnosticCode::PhysicalEscapeSkipped,
+				mount,
+				logicalDirectory,
+				"Asset mount path escapes its root and was skipped: '" + PathDisplay(logicalDirectory) + "'."));
+			return;
+		}
+
+		const std::string directoryKey = PathKey(physicalDirectory);
+		if (!visitedDirectories.emplace(directoryKey).second)
+		{
+			diagnostics.emplace_back(MakeInspectionDiagnostic(
+				EAssetMountDiagnosticCode::DirectoryCycleSkipped,
+				mount,
+				logicalDirectory,
+				"Asset mount directory resolves to an already visited location and was skipped: '" +
+					PathDisplay(logicalDirectory) + "'."));
+			return;
+		}
+
+		std::vector<std::filesystem::directory_entry> entries;
+		for (std::filesystem::directory_iterator it(
+				logicalDirectory,
+				std::filesystem::directory_options::skip_permission_denied,
+				error), end;
+			!error && it != end;
+			it.increment(error))
+		{
+			entries.emplace_back(*it);
+		}
+		if (error)
+		{
+			diagnostics.emplace_back(MakeInspectionDiagnostic(
+				EAssetMountDiagnosticCode::PathInspectionFailed,
+				mount,
+				logicalDirectory,
+				"Asset mount directory could not be enumerated: '" + PathDisplay(logicalDirectory) + "'."));
+			return;
+		}
+
+		std::sort(entries.begin(), entries.end(), [](const std::filesystem::directory_entry& left, const std::filesystem::directory_entry& right)
+			{
+				const std::string leftKey = PathKey(left.path());
+				const std::string rightKey = PathKey(right.path());
+				return leftKey != rightKey
+					? leftKey < rightKey
+					: PathDisplay(left.path()) < PathDisplay(right.path());
+			});
+
+		for (const std::filesystem::directory_entry& entry : entries)
+		{
+			error.clear();
+			const bool bIsDirectory = entry.is_directory(error);
+			if (error)
+			{
+				diagnostics.emplace_back(MakeInspectionDiagnostic(
+					EAssetMountDiagnosticCode::PathInspectionFailed,
+					mount,
+					entry.path(),
+					"Asset mount entry could not be inspected: '" + PathDisplay(entry.path()) + "'."));
+				continue;
+			}
+			if (bIsDirectory)
+			{
+				DiscoverDirectory(mount, entry.path(), visitedDirectories, files, diagnostics);
+				continue;
+			}
+
+			error.clear();
+			if (!entry.is_regular_file(error) || error)
+			{
+				continue;
+			}
+
+			const std::filesystem::path physicalPath = std::filesystem::canonical(entry.path(), error);
+			if (error)
+			{
+				diagnostics.emplace_back(MakeInspectionDiagnostic(
+					EAssetMountDiagnosticCode::PathInspectionFailed,
+					mount,
+					entry.path(),
+					"Asset mount file could not be resolved: '" + PathDisplay(entry.path()) + "'."));
+				continue;
+			}
+			if (!IsInside(mount.m_root, physicalPath))
+			{
+				diagnostics.emplace_back(MakeInspectionDiagnostic(
+					EAssetMountDiagnosticCode::PhysicalEscapeSkipped,
+					mount,
+					entry.path(),
+					"Asset mount file escapes its root and was skipped: '" + PathDisplay(entry.path()) + "'."));
+				continue;
+			}
+
+			const std::filesystem::path relativePath = entry.path().lexically_relative(mount.m_root);
+			const std::string virtualPath = relativePath.generic_string();
+			if (!IsSafeVirtualPath(virtualPath))
+			{
+				diagnostics.emplace_back(MakeInspectionDiagnostic(
+					EAssetMountDiagnosticCode::PathInspectionFailed,
+					mount,
+					entry.path(),
+					"Asset mount file has an invalid virtual path and was skipped: '" +
+						PathDisplay(entry.path()) + "'."));
+				continue;
+			}
+
+			files.emplace_back(AssetMountDiscoveredFile{ mount, physicalPath, virtualPath });
+		}
+	}
+
+	AssetMountDiagnostic MakeCollisionDiagnostic(
+		EAssetMountDiagnosticCode code,
+		const std::string& key,
+		const AssetMountCandidate& winner,
+		const AssetMountCandidate& conflicting)
+	{
+		AssetMountDiagnostic diagnostic;
+		diagnostic.m_code = code;
+		diagnostic.m_key = key;
+		diagnostic.m_winnerPath = winner.m_physicalPath;
+		diagnostic.m_conflictingPath = conflicting.m_physicalPath;
+		diagnostic.m_winnerKind = winner.m_mount.m_kind;
+		diagnostic.m_conflictingKind = conflicting.m_mount.m_kind;
+		diagnostic.m_winnerFileId = winner.m_fileId;
+		diagnostic.m_conflictingFileId = conflicting.m_fileId;
+
+		const char* collisionName = code == EAssetMountDiagnosticCode::VirtualPathCollision
+			? "virtual path"
+			: "FileId";
+		diagnostic.m_message = "Asset " + std::string(collisionName) + " collision '" + key +
+			"' keeps " + KindName(winner.m_mount.m_kind) + " '" +
+			PathDisplay(winner.m_physicalPath) + "' (FileId '" + winner.m_fileId +
+			"') over " + KindName(conflicting.m_mount.m_kind) + " '" +
+			PathDisplay(conflicting.m_physicalPath) + "' (FileId '" + conflicting.m_fileId + "').";
+		return diagnostic;
+	}
+
+	template<typename TKeySelector>
+	void BuildWinnerIndex(
+		const std::vector<AssetMountCandidate>& candidates,
+		std::map<std::string, size_t>& winners,
+		std::vector<AssetMountDiagnostic>& diagnostics,
+		EAssetMountDiagnosticCode collisionCode,
+		TKeySelector selectKey)
+	{
+		std::map<std::string, std::vector<size_t>> groups;
+		for (size_t index = 0; index < candidates.size(); ++index)
+		{
+			const std::string key = selectKey(candidates[index]);
+			if (!key.empty())
+			{
+				groups[key].emplace_back(index);
+			}
+		}
+
+		for (const auto& [key, indexes] : groups)
+		{
+			size_t winnerIndex = indexes.front();
+			for (size_t index : indexes)
+			{
+				if (IsPreferred(candidates[index], candidates[winnerIndex]))
+				{
+					winnerIndex = index;
+				}
+			}
+			winners.emplace(key, winnerIndex);
+
+			for (size_t index : indexes)
+			{
+				if (index == winnerIndex ||
+					PathKey(candidates[index].m_physicalPath) == PathKey(candidates[winnerIndex].m_physicalPath))
+				{
+					continue;
+				}
+				diagnostics.emplace_back(MakeCollisionDiagnostic(
+					collisionCode,
+					key,
+					candidates[winnerIndex],
+					candidates[index]));
+			}
+		}
+	}
+}
+
+AssetMountDiscoveryResult Sailor::DiscoverAssetMountFiles(
+	const std::vector<AssetMountDescriptor>& mounts)
+{
+	AssetMountDiscoveryResult result;
+	result.m_mounts = NormalizeMounts(mounts, result.m_diagnostics);
+	if (result.HasFatalErrors())
+	{
+		SortDiagnostics(result.m_diagnostics);
+		return result;
+	}
+	for (const AssetMountDescriptor& mount : result.m_mounts)
+	{
+		std::set<std::string> visitedDirectories;
+		DiscoverDirectory(
+			mount,
+			mount.m_root,
+			visitedDirectories,
+			result.m_files,
+			result.m_diagnostics);
+	}
+
+	std::sort(result.m_files.begin(), result.m_files.end(), [](const AssetMountDiscoveredFile& left, const AssetMountDiscoveredFile& right)
+		{
+			return std::tie(left.m_virtualPath, left.m_mount.m_kind, left.m_mount.m_priority, left.m_physicalPath) <
+				std::tie(right.m_virtualPath, right.m_mount.m_kind, right.m_mount.m_priority, right.m_physicalPath);
+		});
+	SortDiagnostics(result.m_diagnostics);
+	return result;
+}
+
+bool AssetMountDiscoveryResult::HasFatalErrors() const noexcept
+{
+	return std::any_of(m_diagnostics.begin(), m_diagnostics.end(), [](const AssetMountDiagnostic& diagnostic)
+		{
+			return IsFatalDiagnostic(diagnostic.m_code);
+		});
+}
+
+AssetMountResolutionResult Sailor::ResolveAssetMountCandidates(
+	std::vector<AssetMountCandidate> candidates)
+{
+	AssetMountResolutionResult result;
+	for (AssetMountCandidate& candidate : candidates)
+	{
+		std::replace(candidate.m_virtualPath.begin(), candidate.m_virtualPath.end(), '\\', '/');
+		while (candidate.m_virtualPath.rfind("./", 0) == 0)
+		{
+			candidate.m_virtualPath.erase(0, 2);
+		}
+		if (!IsSafeVirtualPath(candidate.m_virtualPath))
+		{
+			AssetMountDiagnostic diagnostic;
+			diagnostic.m_code = EAssetMountDiagnosticCode::InvalidCandidate;
+			diagnostic.m_key = candidate.m_virtualPath;
+			diagnostic.m_conflictingPath = candidate.m_physicalPath;
+			diagnostic.m_conflictingKind = candidate.m_mount.m_kind;
+			diagnostic.m_conflictingFileId = candidate.m_fileId;
+			diagnostic.m_message = "Asset candidate has an invalid virtual path and was skipped: '" +
+				candidate.m_virtualPath + "'.";
+			result.m_diagnostics.emplace_back(std::move(diagnostic));
+			continue;
+		}
+		result.m_candidates.emplace_back(std::move(candidate));
+	}
+
+	std::sort(result.m_candidates.begin(), result.m_candidates.end(), [](const AssetMountCandidate& left, const AssetMountCandidate& right)
+		{
+			return std::tie(left.m_virtualPath, left.m_fileId, left.m_mount.m_kind, left.m_mount.m_priority, left.m_physicalPath) <
+				std::tie(right.m_virtualPath, right.m_fileId, right.m_mount.m_kind, right.m_mount.m_priority, right.m_physicalPath);
+		});
+
+	BuildWinnerIndex(
+		result.m_candidates,
+		result.m_virtualPathWinners,
+		result.m_diagnostics,
+		EAssetMountDiagnosticCode::VirtualPathCollision,
+		[](const AssetMountCandidate& candidate)
+		{
+			return VirtualPathKey(candidate.m_virtualPath);
+		});
+	BuildWinnerIndex(
+		result.m_candidates,
+		result.m_fileIdWinners,
+		result.m_diagnostics,
+		EAssetMountDiagnosticCode::FileIdCollision,
+		[](const AssetMountCandidate& candidate)
+		{
+			return candidate.m_fileId;
+		});
+	SortDiagnostics(result.m_diagnostics);
+	return result;
+}
+
+const AssetMountCandidate* AssetMountResolutionResult::FindByVirtualPath(
+	const std::string& virtualPath) const noexcept
+{
+	const auto it = m_virtualPathWinners.find(VirtualPathKey(virtualPath));
+	return it == m_virtualPathWinners.end() ? nullptr : &m_candidates[it->second];
+}
+
+const AssetMountCandidate* AssetMountResolutionResult::FindByFileId(
+	const std::string& fileId) const noexcept
+{
+	const auto it = m_fileIdWinners.find(fileId);
+	return it == m_fileIdWinners.end() ? nullptr : &m_candidates[it->second];
+}

--- a/Runtime/AssetRegistry/AssetMountDiscovery.h
+++ b/Runtime/AssetRegistry/AssetMountDiscovery.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Sailor
+{
+	enum class EAssetMountKind : uint8_t
+	{
+		Engine,
+		Workspace
+	};
+
+	enum class EAssetMountDiagnosticCode : uint8_t
+	{
+		InvalidMountRoot,
+		DuplicateMountRoot,
+		OverlappingMountRoot,
+		PhysicalEscapeSkipped,
+		DirectoryCycleSkipped,
+		PathInspectionFailed,
+		InvalidCandidate,
+		VirtualPathCollision,
+		FileIdCollision
+	};
+
+	struct AssetMountDescriptor final
+	{
+		std::filesystem::path m_root;
+		EAssetMountKind m_kind = EAssetMountKind::Engine;
+		int32_t m_priority = 0;
+		bool m_bWritable = false;
+	};
+
+	struct AssetMountDiscoveredFile final
+	{
+		AssetMountDescriptor m_mount;
+		std::filesystem::path m_physicalPath;
+		std::string m_virtualPath;
+	};
+
+	struct AssetMountCandidate final
+	{
+		AssetMountDescriptor m_mount;
+		std::filesystem::path m_physicalPath;
+		std::string m_virtualPath;
+		std::string m_fileId;
+	};
+
+	struct AssetMountDiagnostic final
+	{
+		EAssetMountDiagnosticCode m_code = EAssetMountDiagnosticCode::PathInspectionFailed;
+		std::string m_key;
+		std::filesystem::path m_winnerPath;
+		std::filesystem::path m_conflictingPath;
+		EAssetMountKind m_winnerKind = EAssetMountKind::Engine;
+		EAssetMountKind m_conflictingKind = EAssetMountKind::Engine;
+		std::string m_winnerFileId;
+		std::string m_conflictingFileId;
+		std::string m_message;
+	};
+
+	struct AssetMountDiscoveryResult final
+	{
+		std::vector<AssetMountDescriptor> m_mounts;
+		std::vector<AssetMountDiscoveredFile> m_files;
+		std::vector<AssetMountDiagnostic> m_diagnostics;
+
+		bool HasFatalErrors() const noexcept;
+	};
+
+	class AssetMountResolutionResult;
+	AssetMountResolutionResult ResolveAssetMountCandidates(
+		std::vector<AssetMountCandidate> candidates);
+
+	class AssetMountResolutionResult final
+	{
+	public:
+		const std::vector<AssetMountCandidate>& GetCandidates() const noexcept { return m_candidates; }
+		const std::vector<AssetMountDiagnostic>& GetDiagnostics() const noexcept { return m_diagnostics; }
+
+		const AssetMountCandidate* FindByVirtualPath(const std::string& virtualPath) const noexcept;
+		const AssetMountCandidate* FindByFileId(const std::string& fileId) const noexcept;
+
+	private:
+		std::vector<AssetMountCandidate> m_candidates;
+		std::map<std::string, size_t> m_virtualPathWinners;
+		std::map<std::string, size_t> m_fileIdWinners;
+		std::vector<AssetMountDiagnostic> m_diagnostics;
+
+		friend AssetMountResolutionResult ResolveAssetMountCandidates(
+			std::vector<AssetMountCandidate> candidates);
+	};
+
+	AssetMountDiscoveryResult DiscoverAssetMountFiles(
+		const std::vector<AssetMountDescriptor>& mounts);
+}

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -1,23 +1,55 @@
 #include "AssetRegistry/AssetRegistry.h"
-#include <filesystem>
-#include <fstream>
-#include <iostream>
-#include "Containers/Map.h"
+
+#include "AssetRegistry/Animation/AnimationAssetInfo.h"
 #include "AssetRegistry/AssetInfo.h"
+#include "AssetRegistry/FrameGraph/FrameGraphAssetInfo.h"
+#include "AssetRegistry/Material/MaterialAssetInfo.h"
+#include "AssetRegistry/Model/ModelAssetInfo.h"
+#include "AssetRegistry/Prefab/PrefabAssetInfo.h"
 #include "AssetRegistry/Shader/ShaderAssetInfo.h"
 #include "AssetRegistry/Texture/TextureAssetInfo.h"
-#include "AssetRegistry/Model/ModelAssetInfo.h"
-#include "AssetRegistry/Material/MaterialAssetInfo.h"
-#include "AssetRegistry/Animation/AnimationAssetInfo.h"
+#include "AssetRegistry/World/WorldPrefabAssetInfo.h"
+#include "Containers/Map.h"
 #include "Core/Utils.h"
-#include "Tasks/Tasks.h"
 #include "Tasks/Scheduler.h"
+#include "Tasks/Tasks.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <set>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+#include <yaml-cpp/yaml.h>
 
 using namespace Sailor;
-using namespace nlohmann;
 
 namespace
 {
+	struct StagedAssetRecord final
+	{
+		AssetMountCandidate m_candidate;
+		std::filesystem::path m_assetPath;
+		std::filesystem::path m_metaPath;
+		std::string m_assetVirtualPath;
+		std::string m_metaVirtualPath;
+		std::string m_assetInfoType;
+		bool m_bPrimary = false;
+		bool m_bMetadataInvalid = false;
+	};
+
+	struct PendingAssetNotification final
+	{
+		IAssetInfoHandler* m_handler = nullptr;
+		AssetInfoPtr m_assetInfo = nullptr;
+		bool m_bImported = false;
+	};
+
 	std::string AsFolderPath(const std::filesystem::path& path)
 	{
 		std::string result = path.generic_string();
@@ -27,11 +59,187 @@ namespace
 		}
 		return result;
 	}
+
+	std::string Lowercase(std::string value)
+	{
+		std::transform(value.begin(), value.end(), value.begin(), [](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+		return value;
+	}
+
+	std::string PathKey(const std::filesystem::path& path)
+	{
+		std::string value = path.lexically_normal().generic_string();
+#if defined(_WIN32)
+		value = Lowercase(std::move(value));
+#endif
+		while (value.size() > 1 && value.back() == '/')
+		{
+			value.pop_back();
+		}
+		return value;
+	}
+
+	std::string VirtualPathKey(std::string path)
+	{
+		std::replace(path.begin(), path.end(), '\\', '/');
+		while (path.rfind("./", 0) == 0)
+		{
+			path.erase(0, 2);
+		}
+		while (!path.empty() && path.front() == '/')
+		{
+			path.erase(path.begin());
+		}
+#if defined(_WIN32)
+		path = Lowercase(std::move(path));
+#endif
+		return path;
+	}
+
+	bool IsSafeVirtualPath(const std::string& path)
+	{
+		if (path.empty() || path.find('\0') != std::string::npos)
+		{
+			return false;
+		}
+
+		const std::filesystem::path value(path);
+		if (value.is_absolute() || value.has_root_name() || value.has_root_directory())
+		{
+			return false;
+		}
+
+		return std::none_of(value.begin(), value.end(), [](const std::filesystem::path& component)
+			{
+				return component == "..";
+			});
+	}
+
+	bool IsInside(const std::filesystem::path& root, const std::filesystem::path& candidate)
+	{
+		const std::string rootKey = PathKey(root);
+		const std::string candidateKey = PathKey(candidate);
+		return candidateKey == rootKey ||
+			(candidateKey.size() > rootKey.size() &&
+				candidateKey.compare(0, rootKey.size(), rootKey) == 0 &&
+				candidateKey[rootKey.size()] == '/');
+	}
+
+	std::string MountFileKey(const AssetMountDescriptor& mount, const std::string& virtualPath)
+	{
+		return PathKey(mount.m_root) + "\n" + VirtualPathKey(virtualPath);
+	}
+
+	std::string Extension(const std::string& path)
+	{
+		return Lowercase(Utils::GetFileExtension(path));
+	}
+
+	std::string HandlerExtension(const StagedAssetRecord& record)
+	{
+		if (record.m_bPrimary)
+		{
+			return Extension(record.m_assetVirtualPath);
+		}
+
+		return Extension(std::filesystem::path(
+			record.m_metaVirtualPath).replace_extension().generic_string());
+	}
+
+	bool CandidateMatches(const AssetMountCandidate* winner, const AssetMountCandidate& candidate)
+	{
+		return winner != nullptr &&
+			PathKey(winner->m_physicalPath) == PathKey(candidate.m_physicalPath) &&
+			VirtualPathKey(winner->m_virtualPath) == VirtualPathKey(candidate.m_virtualPath) &&
+			winner->m_fileId == candidate.m_fileId;
+	}
+
+	bool ReadMetadataIdentity(
+		const std::filesystem::path& metaPath,
+		std::string& outFileId,
+		std::string& outFilename,
+		std::string& outAssetInfoType,
+		std::string& outError)
+	{
+		try
+		{
+			const YAML::Node metadata = YAML::LoadFile(metaPath.string());
+			const YAML::Node fileId = metadata["fileId"];
+			const YAML::Node filename = metadata["filename"];
+			if (!fileId.IsScalar() || !filename.IsScalar())
+			{
+				outError = "metadata requires scalar fileId and filename";
+				return false;
+			}
+
+			outFileId = fileId.as<std::string>();
+			outFilename = filename.as<std::string>();
+			YAML::Node assetInfoType(YAML::NodeType::Undefined);
+			for (const auto& field : metadata)
+			{
+				if (field.first.IsScalar() && field.first.Scalar() == "assetInfoType")
+				{
+					assetInfoType = field.second;
+					break;
+				}
+			}
+			if (assetInfoType.IsDefined() && !assetInfoType.IsNull() && !assetInfoType.IsScalar())
+			{
+				outError = "metadata assetInfoType must be scalar when present";
+				return false;
+			}
+			outAssetInfoType = assetInfoType.IsScalar()
+				? assetInfoType.as<std::string>()
+				: std::string{};
+			if (outFileId.empty() || outFilename.empty() ||
+				!IsSafeVirtualPath(std::filesystem::path(outFilename).generic_string()))
+			{
+				outError = "metadata contains an empty FileId or unsafe filename";
+				return false;
+			}
+			return true;
+		}
+		catch (const std::exception& e)
+		{
+			outError = e.what();
+			return false;
+		}
+	}
+
+	FileId ParseFileId(const std::string& value)
+	{
+		FileId result;
+		result.Deserialize(YAML::Node(value));
+		return result;
+	}
+
+	void DeleteAssetInfos(TMap<FileId, AssetInfoPtr>& assetInfos)
+	{
+		for (const auto& assetInfo : assetInfos)
+		{
+			delete *assetInfo.m_second;
+		}
+		assetInfos.Clear();
+	}
+
 }
 
 std::string AssetRegistry::GetContentFolder()
 {
+	return GetWorkspaceContentFolder();
+}
+
+std::string AssetRegistry::GetWorkspaceContentFolder()
+{
 	return AsFolderPath(App::GetWorkspaceContext().GetContent());
+}
+
+std::string AssetRegistry::GetEngineContentFolder()
+{
+	return AsFolderPath(App::GetWorkspaceContext().GetEngineContent());
 }
 
 std::string AssetRegistry::GetCacheFolder()
@@ -41,17 +249,29 @@ std::string AssetRegistry::GetCacheFolder()
 
 AssetRegistry::AssetRegistry()
 {
+	const Workspace::WorkspaceContext& context = App::GetWorkspaceContext();
+	m_contentMounts =
+	{
+		AssetMountDescriptor{ context.GetEngineContent(), EAssetMountKind::Engine, 0, false },
+		AssetMountDescriptor{ context.GetContent(), EAssetMountKind::Workspace, 100, true }
+	};
 	m_assetCache.Initialize();
 }
 
-void AssetRegistry::CacheAssetTime(const FileId& id, const time_t& assetTimestamp)
+void AssetRegistry::CacheAssetTime(
+	const FileId& id,
+	const std::string& sourcePath,
+	const time_t& assetTimestamp)
 {
-	m_assetCache.Update(id, assetTimestamp);
+	m_assetCache.Update(id, sourcePath, assetTimestamp);
 }
 
-bool AssetRegistry::GetAssetCachedTime(const FileId& id, time_t& outAssetTimestamp) const
+bool AssetRegistry::GetAssetCachedTime(
+	const FileId& id,
+	const std::string& sourcePath,
+	time_t& outAssetTimestamp) const
 {
-	return m_assetCache.GetTimeStamp(id, outAssetTimestamp);
+	return m_assetCache.GetTimeStamp(id, sourcePath, outAssetTimestamp);
 }
 
 bool AssetRegistry::IsAssetExpired(const AssetInfoPtr info) const
@@ -66,47 +286,486 @@ bool AssetRegistry::ReadAllTextFile(const std::string& filename, std::string& te
 	constexpr auto readSize = std::size_t{ 4096 };
 	auto stream = std::ifstream{ filename.data() };
 	stream.exceptions(std::ios_base::badbit);
-
 	if (!stream.is_open())
 	{
 		return false;
 	}
 
-	text = std::string{};
-	auto buf = std::string(readSize, '\0');
-	while (stream.read(&buf[0], readSize))
+	text.clear();
+	auto buffer = std::string(readSize, '\0');
+	while (stream.read(buffer.data(), readSize))
 	{
-		text.append(buf, 0, stream.gcount());
+		text.append(buffer, 0, stream.gcount());
 	}
-	text.append(buf, 0, stream.gcount());
-
+	text.append(buffer, 0, stream.gcount());
 	return true;
+}
+
+bool AssetRegistry::ResolveContentFile(
+	const std::string& virtualPath,
+	AssetReadLocation& outLocation) const
+{
+	if (!IsSafeVirtualPath(virtualPath))
+	{
+		return false;
+	}
+
+	const auto winner = m_contentFileWinners.find(VirtualPathKey(virtualPath));
+	if (winner == m_contentFileWinners.end())
+	{
+		return false;
+	}
+	outLocation = winner->second;
+	return true;
+}
+
+bool AssetRegistry::ReadContentText(const std::string& virtualPath, std::string& outText) const
+{
+	AssetReadLocation location;
+	return ResolveContentFile(virtualPath, location) &&
+		ReadAllTextFile(location.m_physicalPath.string(), outText);
+}
+
+bool AssetRegistry::GetContentFileModificationTime(
+	const std::string& virtualPath,
+	std::time_t& outTimestamp) const
+{
+	AssetReadLocation location;
+	if (!ResolveContentFile(virtualPath, location))
+	{
+		return false;
+	}
+	outTimestamp = Utils::GetFileModificationTime(location.m_physicalPath.string());
+	return true;
+}
+
+bool AssetRegistry::ResolveWorkspaceContentPathForWrite(
+	const std::string& virtualPath,
+	std::filesystem::path& outPath) const
+{
+	if (!IsSafeVirtualPath(virtualPath))
+	{
+		return false;
+	}
+
+	std::error_code error;
+	const std::filesystem::path root = App::GetWorkspaceContext().GetContent();
+	outPath = std::filesystem::weakly_canonical(root / std::filesystem::path(virtualPath), error);
+	return !error && IsInside(root, outPath);
+}
+
+IAssetInfoHandler* AssetRegistry::GetAssetInfoHandler(const std::string& extension) const
+{
+	IAssetInfoHandler* handler = App::GetSubmodule<DefaultAssetInfoHandler>();
+	auto handlerIt = m_assetInfoHandlers.Find(Lowercase(extension));
+	if (handlerIt != m_assetInfoHandlers.end())
+	{
+		handler = *(*handlerIt).m_second;
+	}
+	return handler;
+}
+
+IAssetInfoHandler* AssetRegistry::GetAssetInfoHandler(
+	const std::string& extension,
+	const std::string& assetInfoType,
+	bool bPrimary) const
+{
+	if (bPrimary || assetInfoType.empty())
+	{
+		return GetAssetInfoHandler(extension);
+	}
+	if (assetInfoType == "Sailor::AnimationAssetInfo")
+	{
+		return App::GetSubmodule<AnimationAssetInfoHandler>();
+	}
+	if (assetInfoType == "Sailor::FrameGraphAssetInfo")
+	{
+		return App::GetSubmodule<FrameGraphAssetInfoHandler>();
+	}
+	if (assetInfoType == "Sailor::MaterialAssetInfo")
+	{
+		return App::GetSubmodule<MaterialAssetInfoHandler>();
+	}
+	if (assetInfoType == "Sailor::ModelAssetInfo")
+	{
+		return App::GetSubmodule<ModelAssetInfoHandler>();
+	}
+	if (assetInfoType == "Sailor::PrefabAssetInfo")
+	{
+		return App::GetSubmodule<PrefabAssetInfoHandler>();
+	}
+	if (assetInfoType == "Sailor::ShaderAssetInfo")
+	{
+		return App::GetSubmodule<ShaderAssetInfoHandler>();
+	}
+	if (assetInfoType == "Sailor::TextureAssetInfo")
+	{
+		return App::GetSubmodule<TextureAssetInfoHandler>();
+	}
+	if (assetInfoType == "Sailor::WorldPrefabAssetInfo")
+	{
+		return App::GetSubmodule<WorldPrefabAssetInfoHandler>();
+	}
+	return GetAssetInfoHandler(extension);
 }
 
 void AssetRegistry::ScanContentFolder()
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	ScanFolder(GetContentFolder());
-	m_assetCache.SaveCache();
-}
-
-bool AssetRegistry::RegisterAssetInfoHandler(const TVector<std::string>& supportedExtensions, IAssetInfoHandler* assetInfoHandler)
-{
-	SAILOR_PROFILE_FUNCTION();
-
-	bool bAssigned = false;
-	for (const auto& extension : supportedExtensions)
+	const AssetMountDiscoveryResult discovery = DiscoverAssetMountFiles(m_contentMounts);
+	for (const AssetMountDiagnostic& diagnostic : discovery.m_diagnostics)
 	{
-		if (m_assetInfoHandlers.ContainsKey(extension))
+		if (diagnostic.m_code == EAssetMountDiagnosticCode::InvalidMountRoot ||
+			diagnostic.m_code == EAssetMountDiagnosticCode::OverlappingMountRoot)
+		{
+			SAILOR_LOG_ERROR("%s", diagnostic.m_message.c_str());
+		}
+		else
+		{
+			SAILOR_LOG("%s", diagnostic.m_message.c_str());
+		}
+	}
+	if (discovery.HasFatalErrors())
+	{
+		SAILOR_LOG_ERROR("Asset content mounts are invalid; preserving the previous registry generation.");
+		return;
+	}
+
+	std::map<std::string, const AssetMountDiscoveredFile*> filesByMountAndVirtualPath;
+	std::set<std::string> metadataFileKeys;
+	for (const AssetMountDiscoveredFile& file : discovery.m_files)
+	{
+		const std::string key = MountFileKey(file.m_mount, file.m_virtualPath);
+		filesByMountAndVirtualPath.emplace(key, &file);
+		if (Extension(file.m_virtualPath) == MetaFileExtension)
+		{
+			metadataFileKeys.emplace(key);
+		}
+	}
+
+	std::vector<StagedAssetRecord> records;
+	std::set<std::string> consumedPrimaryMetadata;
+	std::set<std::string> invalidMetadata;
+	for (const AssetMountDiscoveredFile& metaFile : discovery.m_files)
+	{
+		if (Extension(metaFile.m_virtualPath) != MetaFileExtension)
 		{
 			continue;
 		}
 
-		m_assetInfoHandlers[extension] = assetInfoHandler;
-		bAssigned = true;
+		std::string fileId;
+		std::string filename;
+		std::string assetInfoType;
+		std::string metadataError;
+		const std::string metaKey = MountFileKey(metaFile.m_mount, metaFile.m_virtualPath);
+		if (!ReadMetadataIdentity(
+				metaFile.m_physicalPath,
+				fileId,
+				filename,
+				assetInfoType,
+				metadataError))
+		{
+			invalidMetadata.emplace(metaKey);
+			SAILOR_LOG_ERROR(
+				"Invalid asset metadata '%s': %s.",
+				metaFile.m_physicalPath.generic_string().c_str(),
+				metadataError.c_str());
+			continue;
+		}
+
+		const std::string basenameVirtualPath = std::filesystem::path(
+			metaFile.m_virtualPath).replace_extension().generic_string();
+		const auto basenameAsset = filesByMountAndVirtualPath.find(
+			MountFileKey(metaFile.m_mount, basenameVirtualPath));
+		const bool bFilenameMatchesBasename =
+			std::filesystem::path(filename).generic_string() ==
+			std::filesystem::path(basenameVirtualPath).filename().generic_string();
+
+		StagedAssetRecord record;
+		record.m_candidate.m_mount = metaFile.m_mount;
+		record.m_candidate.m_fileId = fileId;
+		record.m_metaPath = metaFile.m_physicalPath;
+		record.m_metaVirtualPath = metaFile.m_virtualPath;
+		record.m_assetInfoType = assetInfoType;
+		if (basenameAsset != filesByMountAndVirtualPath.end() && bFilenameMatchesBasename)
+		{
+			record.m_bPrimary = true;
+			record.m_assetPath = basenameAsset->second->m_physicalPath;
+			record.m_assetVirtualPath = basenameAsset->second->m_virtualPath;
+			record.m_candidate.m_physicalPath = record.m_assetPath;
+			record.m_candidate.m_virtualPath = record.m_assetVirtualPath;
+			consumedPrimaryMetadata.emplace(metaKey);
+		}
+		else
+		{
+			const std::string declaredVirtualPath = (
+				std::filesystem::path(metaFile.m_virtualPath).parent_path() /
+				filename).generic_string();
+			const auto declaredAsset = filesByMountAndVirtualPath.find(
+				MountFileKey(metaFile.m_mount, declaredVirtualPath));
+			if (declaredAsset == filesByMountAndVirtualPath.end())
+			{
+				SAILOR_LOG_ERROR(
+					"Asset metadata '%s' references missing source '%s' and was skipped.",
+					metaFile.m_physicalPath.generic_string().c_str(),
+					declaredVirtualPath.c_str());
+				continue;
+			}
+
+			record.m_assetPath = declaredAsset->second->m_physicalPath;
+			record.m_assetVirtualPath = declaredAsset->second->m_virtualPath;
+			record.m_candidate.m_physicalPath = record.m_metaPath;
+			record.m_candidate.m_virtualPath = record.m_metaVirtualPath;
+		}
+		record.m_candidate.m_fileId = fileId;
+		records.emplace_back(std::move(record));
 	}
 
+	for (const AssetMountDiscoveredFile& assetFile : discovery.m_files)
+	{
+		if (Extension(assetFile.m_virtualPath) == MetaFileExtension)
+		{
+			continue;
+		}
+
+		const std::string metaVirtualPath = assetFile.m_virtualPath + "." + MetaFileExtension;
+		const std::string metaKey = MountFileKey(assetFile.m_mount, metaVirtualPath);
+		if (consumedPrimaryMetadata.contains(metaKey))
+		{
+			continue;
+		}
+
+		StagedAssetRecord record;
+		record.m_candidate.m_mount = assetFile.m_mount;
+		record.m_candidate.m_physicalPath = assetFile.m_physicalPath;
+		record.m_candidate.m_virtualPath = assetFile.m_virtualPath;
+		record.m_assetPath = assetFile.m_physicalPath;
+		record.m_assetVirtualPath = assetFile.m_virtualPath;
+		record.m_metaPath = assetFile.m_physicalPath.string() + "." + MetaFileExtension;
+		record.m_metaVirtualPath = metaVirtualPath;
+		record.m_bPrimary = true;
+		record.m_bMetadataInvalid = invalidMetadata.contains(metaKey) ||
+			(metadataFileKeys.contains(metaKey) && !consumedPrimaryMetadata.contains(metaKey));
+		records.emplace_back(std::move(record));
+	}
+
+	std::vector<AssetMountCandidate> candidates;
+	candidates.reserve(records.size());
+	for (const StagedAssetRecord& record : records)
+	{
+		candidates.emplace_back(record.m_candidate);
+	}
+	const AssetMountResolutionResult resolution = ResolveAssetMountCandidates(std::move(candidates));
+	for (const AssetMountDiagnostic& diagnostic : resolution.GetDiagnostics())
+	{
+		SAILOR_LOG("%s", diagnostic.m_message.c_str());
+	}
+
+	std::map<std::string, AssetReadLocation> stagedContentWinners;
+	for (const StagedAssetRecord& record : records)
+	{
+		if (!record.m_bPrimary ||
+			!CandidateMatches(
+				resolution.FindByVirtualPath(record.m_candidate.m_virtualPath),
+				record.m_candidate))
+		{
+			continue;
+		}
+
+		stagedContentWinners[VirtualPathKey(record.m_assetVirtualPath)] = AssetReadLocation
+		{
+			record.m_assetPath,
+			record.m_assetVirtualPath,
+			record.m_candidate.m_mount.m_kind,
+			record.m_candidate.m_mount.m_bWritable
+		};
+	}
+
+	TMap<FileId, AssetInfoPtr> stagedAssetInfos;
+	TMap<std::string, FileId> stagedFileIds;
+	TMap<std::string, FileId> stagedPhysicalFileIds;
+	std::vector<PendingAssetNotification> pendingNotifications;
+	std::vector<std::filesystem::path> importedMetadata;
+	try
+	{
+		for (const StagedAssetRecord& record : records)
+		{
+			const bool bVirtualWinner = CandidateMatches(
+				resolution.FindByVirtualPath(record.m_candidate.m_virtualPath),
+				record.m_candidate);
+			if (record.m_candidate.m_fileId.empty())
+			{
+				if (!record.m_bPrimary || !bVirtualWinner || record.m_bMetadataInvalid)
+				{
+					continue;
+				}
+				if (!record.m_candidate.m_mount.m_bWritable)
+				{
+					SAILOR_LOG_ERROR(
+						"Read-only Engine asset '%s' has no metadata and was not imported.",
+						record.m_assetVirtualPath.c_str());
+					continue;
+				}
+
+				IAssetInfoHandler* handler = GetAssetInfoHandler(Extension(record.m_assetVirtualPath));
+				check(handler);
+				const bool bMetaExisted = std::filesystem::exists(record.m_metaPath);
+				if (!bMetaExisted)
+				{
+					importedMetadata.emplace_back(record.m_metaPath);
+				}
+				AssetInfoPtr assetInfo = handler->ImportAsset(
+					record.m_assetPath.string(),
+					record.m_assetVirtualPath,
+					false,
+					false);
+				stagedAssetInfos[assetInfo->GetFileId()] = assetInfo;
+				stagedFileIds[VirtualPathKey(record.m_assetVirtualPath)] = assetInfo->GetFileId();
+				stagedPhysicalFileIds[PathKey(record.m_assetPath)] = assetInfo->GetFileId();
+				pendingNotifications.push_back({ handler, assetInfo, true });
+				continue;
+			}
+
+			if (!CandidateMatches(
+					resolution.FindByFileId(record.m_candidate.m_fileId),
+					record.m_candidate))
+			{
+				continue;
+			}
+
+			const FileId expectedFileId = ParseFileId(record.m_candidate.m_fileId);
+			auto previousAssetInfo = m_loadedAssetInfo.Find(expectedFileId);
+			const bool bWasPreviouslyExpired = previousAssetInfo != m_loadedAssetInfo.end() &&
+				(previousAssetInfo.Value()->IsMetaExpired() ||
+					previousAssetInfo.Value()->IsAssetExpired() ||
+					PathKey(previousAssetInfo.Value()->GetAssetFilepath()) != PathKey(record.m_assetPath));
+
+			IAssetInfoHandler* handler = GetAssetInfoHandler(
+				HandlerExtension(record),
+				record.m_assetInfoType,
+				record.m_bPrimary);
+			check(handler);
+			AssetInfoPtr assetInfo = handler->LoadAssetInfo(
+				record.m_metaPath.string(),
+				record.m_metaVirtualPath,
+				record.m_candidate.m_mount.m_kind,
+				record.m_candidate.m_mount.m_bWritable,
+				false,
+				false);
+			if (assetInfo->GetFileId().ToString() != record.m_candidate.m_fileId)
+			{
+				delete assetInfo;
+				throw std::runtime_error(
+					"Asset metadata FileId changed during staged load: " +
+					record.m_metaPath.generic_string());
+			}
+
+			const FileId fileId = assetInfo->GetFileId();
+			assetInfo->m_bPendingWasExpired |= bWasPreviouslyExpired;
+			stagedAssetInfos[fileId] = assetInfo;
+			if (record.m_bPrimary)
+			{
+				stagedPhysicalFileIds[PathKey(record.m_assetPath)] = fileId;
+			}
+			if (record.m_bPrimary && bVirtualWinner)
+			{
+				stagedFileIds[VirtualPathKey(record.m_assetVirtualPath)] = fileId;
+			}
+			pendingNotifications.push_back({ handler, assetInfo, false });
+		}
+
+		for (const StagedAssetRecord& record : records)
+		{
+			if (!record.m_bPrimary || record.m_candidate.m_fileId.empty() ||
+				!CandidateMatches(
+					resolution.FindByVirtualPath(record.m_candidate.m_virtualPath),
+					record.m_candidate))
+			{
+				continue;
+			}
+
+			const FileId fileId = ParseFileId(record.m_candidate.m_fileId);
+			if (stagedAssetInfos.ContainsKey(fileId))
+			{
+				stagedFileIds[VirtualPathKey(record.m_assetVirtualPath)] = fileId;
+				stagedPhysicalFileIds[PathKey(record.m_assetPath)] = fileId;
+			}
+		}
+	}
+	catch (const std::exception& e)
+	{
+		DeleteAssetInfos(stagedAssetInfos);
+		for (auto it = importedMetadata.rbegin(); it != importedMetadata.rend(); ++it)
+		{
+			std::error_code removeError;
+			std::filesystem::remove(*it, removeError);
+		}
+		SAILOR_LOG_ERROR("Asset registry staging failed: %s", e.what());
+		return;
+	}
+
+	if (Tasks::Scheduler* scheduler = App::GetSubmodule<Tasks::Scheduler>())
+	{
+		if (!scheduler->IsMainThread())
+		{
+			DeleteAssetInfos(stagedAssetInfos);
+			for (auto it = importedMetadata.rbegin(); it != importedMetadata.rend(); ++it)
+			{
+				std::error_code removeError;
+				std::filesystem::remove(*it, removeError);
+			}
+			SAILOR_LOG_ERROR(
+				"Asset registry generations may only be committed from the main thread; preserving the previous generation.");
+			return;
+		}
+		scheduler->WaitIdle({
+			EThreadType::Main,
+			EThreadType::Worker,
+			EThreadType::RHI,
+			EThreadType::Render
+		});
+	}
+
+	TMap<FileId, AssetInfoPtr> previousAssetInfos = std::move(m_loadedAssetInfo);
+	m_loadedAssetInfo = std::move(stagedAssetInfos);
+	m_fileIds = std::move(stagedFileIds);
+	m_physicalFileIds = std::move(stagedPhysicalFileIds);
+	m_contentMounts = discovery.m_mounts;
+	m_contentFileWinners = std::move(stagedContentWinners);
+	DeleteAssetInfos(previousAssetInfos);
+
+	for (const PendingAssetNotification& pending : pendingNotifications)
+	{
+		CacheAssetTime(
+			pending.m_assetInfo->GetFileId(),
+			pending.m_assetInfo->GetAssetFilepath(),
+			pending.m_assetInfo->GetAssetImportTime());
+		pending.m_handler->NotifyUpdateAssetInfo(pending.m_assetInfo);
+		if (pending.m_bImported)
+		{
+			pending.m_handler->NotifyImportAsset(pending.m_assetInfo);
+		}
+	}
+	m_assetCache.SaveCache();
+}
+
+bool AssetRegistry::RegisterAssetInfoHandler(
+	const TVector<std::string>& supportedExtensions,
+	IAssetInfoHandler* assetInfoHandler)
+{
+	SAILOR_PROFILE_FUNCTION();
+
+	bool bAssigned = false;
+	for (const std::string& extension : supportedExtensions)
+	{
+		const std::string key = Lowercase(extension);
+		if (!m_assetInfoHandlers.ContainsKey(key))
+		{
+			m_assetInfoHandlers[key] = assetInfoHandler;
+			bAssigned = true;
+		}
+	}
 	return bAssigned;
 }
 
@@ -115,140 +774,205 @@ std::string AssetRegistry::GetMetaFilePath(const std::string& assetFilepath)
 	return assetFilepath + "." + MetaFileExtension;
 }
 
+bool AssetRegistry::ResolveDirectLoadPath(
+	const std::string& requestedPath,
+	AssetReadLocation& outLocation) const
+{
+	if (IsSafeVirtualPath(requestedPath))
+	{
+		std::error_code workspaceError;
+		const std::filesystem::path workspaceCandidate = std::filesystem::weakly_canonical(
+			App::GetWorkspaceContext().GetContent() / requestedPath,
+			workspaceError);
+		if (!workspaceError &&
+			std::filesystem::is_regular_file(workspaceCandidate, workspaceError) &&
+			!workspaceError &&
+			IsInside(App::GetWorkspaceContext().GetContent(), workspaceCandidate))
+		{
+			const std::string virtualPath = std::filesystem::path(requestedPath).generic_string();
+			const auto winner = m_contentFileWinners.find(VirtualPathKey(virtualPath));
+			if (winner == m_contentFileWinners.end() ||
+				winner->second.m_mountKind == EAssetMountKind::Engine ||
+				PathKey(winner->second.m_physicalPath) == PathKey(workspaceCandidate))
+			{
+				outLocation = AssetReadLocation{
+					workspaceCandidate,
+					virtualPath,
+					EAssetMountKind::Workspace,
+					true
+				};
+				return true;
+			}
+		}
+		if (ResolveContentFile(requestedPath, outLocation))
+		{
+			return true;
+		}
+	}
+
+	std::error_code error;
+	const std::filesystem::path requested(requestedPath);
+	const std::filesystem::path candidate = std::filesystem::weakly_canonical(
+		requested.is_absolute()
+			? requested
+			: App::GetWorkspaceContext().GetContent() / requested,
+		error);
+	if (error || !std::filesystem::is_regular_file(candidate, error) || error)
+	{
+		return false;
+	}
+
+	for (const AssetMountDescriptor& mount : m_contentMounts)
+	{
+		if (IsInside(mount.m_root, candidate))
+		{
+			const std::string virtualPath = candidate.lexically_relative(mount.m_root).generic_string();
+			const auto winner = m_contentFileWinners.find(VirtualPathKey(virtualPath));
+			if (winner != m_contentFileWinners.end() &&
+				PathKey(winner->second.m_physicalPath) == PathKey(candidate))
+			{
+				outLocation = winner->second;
+				return true;
+			}
+			if (mount.m_kind != EAssetMountKind::Workspace || !mount.m_bWritable ||
+				(winner != m_contentFileWinners.end() &&
+					winner->second.m_mountKind == EAssetMountKind::Workspace))
+			{
+				return false;
+			}
+
+			outLocation.m_physicalPath = candidate;
+			outLocation.m_virtualPath = virtualPath;
+			outLocation.m_mountKind = EAssetMountKind::Workspace;
+			outLocation.m_bWritable = true;
+			return true;
+		}
+	}
+
+	const std::filesystem::path cache = App::GetWorkspaceContext().GetCache();
+	const std::filesystem::path tempWorld = std::filesystem::weakly_canonical(
+		cache / "Temp.world",
+		error);
+	if (!error && PathKey(candidate) == PathKey(tempWorld))
+	{
+		outLocation.m_physicalPath = candidate;
+		outLocation.m_virtualPath = candidate.lexically_relative(
+			App::GetWorkspaceContext().GetContent()).generic_string();
+		outLocation.m_mountKind = EAssetMountKind::Workspace;
+		outLocation.m_bWritable = true;
+		return true;
+	}
+	return false;
+}
+
 const FileId& AssetRegistry::GetOrLoadFile(const std::string& assetFilepath)
 {
-	if (auto assetInfo = GetAssetInfoPtr(assetFilepath))
-	{
-		return assetInfo->GetFileId();
-	}
 	return LoadFile(assetFilepath);
 }
 
-const FileId& AssetRegistry::LoadFile(const std::string& assetFilepath)
+const FileId& AssetRegistry::LoadFile(const std::string& requestedPath)
 {
-	// Convert to absolute path
-	const std::string filepath = (!assetFilepath.starts_with(GetContentFolder())) ?
-		(GetContentFolder() + Utils::SanitizeFilepath(assetFilepath)) :
-		Utils::SanitizeFilepath(assetFilepath);
-
-	const std::string extension = Utils::GetFileExtension(filepath);
-
-	if (extension != MetaFileExtension)
+	AssetReadLocation location;
+	if (!ResolveDirectLoadPath(requestedPath, location))
 	{
-		const std::string assetInfoFile = GetMetaFilePath(filepath);
-		IAssetInfoHandler* assetInfoHandler = App::GetSubmodule<DefaultAssetInfoHandler>();
+		SAILOR_LOG_ERROR("Asset file could not be resolved: %s", requestedPath.c_str());
+		return FileId::Invalid;
+	}
 
-		auto assetInfoHandlerIt = m_assetInfoHandlers.Find(extension);
-		if (assetInfoHandlerIt != m_assetInfoHandlers.end())
-		{
-			assetInfoHandler = *(*assetInfoHandlerIt).m_second;
-		}
+	auto physicalId = m_physicalFileIds.Find(PathKey(location.m_physicalPath));
+	if (physicalId != m_physicalFileIds.end())
+	{
+		return physicalId.Value();
+	}
 
-		check(assetInfoHandler);
+	if (Extension(location.m_physicalPath.string()) == MetaFileExtension)
+	{
+		SAILOR_LOG_ERROR("Direct metadata loading is not supported: %s", requestedPath.c_str());
+		return FileId::Invalid;
+	}
 
-		auto uid = m_fileIds.Find(filepath);
-		if (uid != m_fileIds.end())
-		{
-			auto assetInfoIt = m_loadedAssetInfo.Find(uid.Value());
-			if (assetInfoIt != m_loadedAssetInfo.end())
-			{
-				AssetInfoPtr assetInfo = assetInfoIt.Value();
-				if (assetInfo->IsMetaExpired() || assetInfo->IsAssetExpired())
-				{
-					SAILOR_LOG("Reload asset info: %s", assetInfoFile.c_str());
-					assetInfoHandler->ReloadAssetInfo(assetInfo);
-				}
-				return uid.Value();
-			}
-
-			// Meta were delete
-			m_fileIds.Remove(uid.Key());
-		}
-
-		AssetInfoPtr assetInfo = nullptr;
-		if (std::filesystem::exists(assetInfoFile))
-		{
-			//SAILOR_LOG("Load asset info: %s", assetInfoFile.c_str());
-			assetInfo = assetInfoHandler->LoadAssetInfo(assetInfoFile);
-		}
-		else
-		{
-			SAILOR_LOG("Import new asset: %s", filepath.c_str());
-			assetInfo = assetInfoHandler->ImportAsset(filepath);
-		}
-
-		m_loadedAssetInfo[assetInfo->GetFileId()] = assetInfo;
-		m_fileIds[filepath] = assetInfo->GetFileId();
-
-		return assetInfo->GetFileId();
+	IAssetInfoHandler* handler = GetAssetInfoHandler(Extension(location.m_physicalPath.string()));
+	check(handler);
+	const std::filesystem::path metaPath = GetMetaFilePath(location.m_physicalPath.string());
+	AssetInfoPtr assetInfo = nullptr;
+	bool bImported = false;
+	if (std::filesystem::is_regular_file(metaPath))
+	{
+		assetInfo = handler->LoadAssetInfo(
+			metaPath.string(),
+			location.m_virtualPath + "." + MetaFileExtension,
+			location.m_mountKind,
+			location.m_bWritable,
+			false,
+			false);
+	}
+	else if (location.m_bWritable)
+	{
+		assetInfo = handler->ImportAsset(
+			location.m_physicalPath.string(),
+			location.m_virtualPath,
+			false,
+			false);
+		bImported = true;
 	}
 	else
 	{
-		const bool bAssetFilenameDiffers = !std::filesystem::exists(Utils::RemoveFileExtension(filepath));
-		if (bAssetFilenameDiffers)
-		{
-			auto defaultAssetInfoHandler = App::GetSubmodule<DefaultAssetInfoHandler>();
-			auto defaultAssetInfo = defaultAssetInfoHandler->LoadAssetInfo(filepath);
-
-			const bool bMissingAssetFile = !std::filesystem::exists(defaultAssetInfo->GetAssetFilepath());
-			const bool bAlreadyLoadedSomehow = m_loadedAssetInfo.ContainsKey(defaultAssetInfo->GetFileId());
-
-			if (!bMissingAssetFile && !bAlreadyLoadedSomehow)
-			{
-				// One assetfile could be bound to many of asset infos (glb container)
-				// Now that is used only for textures, animations and glb container
-
-				const std::string path = Utils::RemoveFileExtension(filepath);
-				const std::string extension = Utils::GetFileExtension(path);
-				const bool bIsAnimation = extension == "anim";
-
-				IAssetInfoHandler* assetInfoHandler = nullptr;
-				
-				if (bIsAnimation)
-				{
-					assetInfoHandler = App::GetSubmodule<AnimationAssetInfoHandler>();
-				}
-				else
-				{
-					assetInfoHandler = App::GetSubmodule<TextureAssetInfoHandler>();
-				}
-
-				auto assetInfo = assetInfoHandler->LoadAssetInfo(filepath);
-
-				m_loadedAssetInfo[assetInfo->GetFileId()] = assetInfo;
-			}
-			else if (bMissingAssetFile)
-			{
-				SAILOR_LOG("AssetInfo %s lacks AssetFile!", filepath.c_str());
-			}
-		}
+		SAILOR_LOG_ERROR(
+			"Read-only Engine asset '%s' has no metadata and was not imported.",
+			location.m_virtualPath.c_str());
+		return FileId::Invalid;
 	}
 
-	return FileId::Invalid;
-}
-
-void AssetRegistry::ScanFolder(const std::string& folderPath)
-{
-	SAILOR_PROFILE_FUNCTION();
-
-	for (const auto& entry : std::filesystem::directory_iterator(folderPath))
+	const FileId fileId = assetInfo->GetFileId();
+	auto existingAssetInfo = m_loadedAssetInfo.Find(fileId);
+	if (existingAssetInfo != m_loadedAssetInfo.end())
 	{
-		if (entry.is_directory())
+		const bool bSamePhysicalAsset =
+			PathKey(existingAssetInfo.Value()->GetAssetFilepath()) ==
+			PathKey(location.m_physicalPath);
+		delete assetInfo;
+		if (bImported)
 		{
-			ScanFolder(entry.path().string());
+			std::error_code removeError;
+			std::filesystem::remove(metaPath, removeError);
 		}
-		else if (entry.is_regular_file())
+		if (bSamePhysicalAsset)
 		{
-			GetOrLoadFile(entry.path().string());
+			m_physicalFileIds[PathKey(location.m_physicalPath)] = fileId;
+			return existingAssetInfo.Value()->GetFileId();
 		}
+
+		SAILOR_LOG_ERROR(
+			"Live asset '%s' collides with an active FileId; rescan Content to apply mount precedence.",
+			location.m_virtualPath.c_str());
+		return FileId::Invalid;
 	}
+
+	m_loadedAssetInfo[fileId] = assetInfo;
+	m_physicalFileIds[PathKey(location.m_physicalPath)] = fileId;
+	if (IsSafeVirtualPath(location.m_virtualPath))
+	{
+		const std::string virtualPathKey = VirtualPathKey(location.m_virtualPath);
+		m_fileIds[virtualPathKey] = fileId;
+		m_contentFileWinners[virtualPathKey] = location;
+	}
+	CacheAssetTime(fileId, location.m_physicalPath.string(), assetInfo->GetAssetImportTime());
+	handler->NotifyUpdateAssetInfo(assetInfo);
+	if (bImported)
+	{
+		handler->NotifyImportAsset(assetInfo);
+	}
+	return m_loadedAssetInfo.Find(fileId).Value()->GetFileId();
 }
 
-TObjectPtr<Object> AssetRegistry::LoadAsset(IAssetInfoHandler* assetInfoHandler, const FileId& id, bool bImmediate)
+TObjectPtr<Object> AssetRegistry::LoadAsset(
+	IAssetInfoHandler* assetInfoHandler,
+	const FileId& id,
+	bool bImmediate)
 {
-	TObjectPtr<Object> out;
-	assetInfoHandler->GetFactory()->LoadAsset(id, out, bImmediate);
-	return out;
+	TObjectPtr<Object> result;
+	assetInfoHandler->GetFactory()->LoadAsset(id, result, bImmediate);
+	return result;
 }
 
 AssetInfoPtr AssetRegistry::GetAssetInfoPtr_Internal(FileId uid) const
@@ -256,30 +980,34 @@ AssetInfoPtr AssetRegistry::GetAssetInfoPtr_Internal(FileId uid) const
 	SAILOR_PROFILE_FUNCTION();
 
 	auto it = m_loadedAssetInfo.Find(uid);
-	if (it != m_loadedAssetInfo.end())
-	{
-		return it.Value();
-	}
-	return nullptr;
+	return it != m_loadedAssetInfo.end() ? it.Value() : nullptr;
 }
 
 AssetInfoPtr AssetRegistry::GetAssetInfoPtr_Internal(const std::string& assetFilepath) const
 {
-	auto it = m_fileIds.Find(GetContentFolder() + assetFilepath);
-	if (it != m_fileIds.end())
+	if (IsSafeVirtualPath(assetFilepath))
 	{
-		return GetAssetInfoPtr_Internal(it.Value());
+		auto virtualId = m_fileIds.Find(VirtualPathKey(assetFilepath));
+		if (virtualId != m_fileIds.end())
+		{
+			return GetAssetInfoPtr_Internal(virtualId.Value());
+		}
 	}
 
+	AssetReadLocation location;
+	if (ResolveDirectLoadPath(assetFilepath, location))
+	{
+		auto physicalId = m_physicalFileIds.Find(PathKey(location.m_physicalPath));
+		if (physicalId != m_physicalFileIds.end())
+		{
+			return GetAssetInfoPtr_Internal(physicalId.Value());
+		}
+	}
 	return nullptr;
 }
 
 AssetRegistry::~AssetRegistry()
 {
 	m_assetCache.Shutdown();
-
-	for (const auto& assetIt : m_loadedAssetInfo)
-	{
-		delete* assetIt.m_second;
-	}
+	DeleteAssetInfos(m_loadedAssetInfo);
 }

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -1,6 +1,9 @@
 #pragma once
 #include <string>
 #include <fstream>
+#include <filesystem>
+#include <map>
+#include <vector>
 #include "Sailor.h"
 #include "Containers/Containers.h"
 #include "AssetRegistry/FileId.h"
@@ -20,8 +23,17 @@ namespace Sailor
 	class AssetRegistry final : public TSubmodule<AssetRegistry>
 	{
 	public:
+		struct AssetReadLocation final
+		{
+			std::filesystem::path m_physicalPath;
+			std::string m_virtualPath;
+			EAssetMountKind m_mountKind = EAssetMountKind::Engine;
+			bool m_bWritable = false;
+		};
 
 		SAILOR_API static std::string GetContentFolder();
+		SAILOR_API static std::string GetWorkspaceContentFolder();
+		SAILOR_API static std::string GetEngineContentFolder();
 		SAILOR_API static std::string GetCacheFolder();
 
 		static constexpr const char* MetaFileExtension = "asset";
@@ -93,9 +105,26 @@ namespace Sailor
 		}
 
 		SAILOR_API static bool ReadAllTextFile(const std::string& filename, std::string& text);
+		SAILOR_API bool ResolveContentFile(
+			const std::string& virtualPath,
+			AssetReadLocation& outLocation) const;
+		SAILOR_API bool ReadContentText(const std::string& virtualPath, std::string& outText) const;
+		SAILOR_API bool GetContentFileModificationTime(
+			const std::string& virtualPath,
+			std::time_t& outTimestamp) const;
+		SAILOR_API bool ResolveWorkspaceContentPathForWrite(
+			const std::string& virtualPath,
+			std::filesystem::path& outPath) const;
+
+		template<typename TBinaryType>
+		bool ReadContentBinary(const std::string& virtualPath, TVector<TBinaryType>& outBuffer) const
+		{
+			AssetReadLocation location;
+			return ResolveContentFile(virtualPath, location) &&
+				ReadBinaryFile(location.m_physicalPath, outBuffer);
+		}
 
 		SAILOR_API void ScanContentFolder();
-		SAILOR_API void ScanFolder(const std::string& folderPath);		
 		SAILOR_API const FileId& GetOrLoadFile(const std::string& filepath);
 
 		template<typename TAssetInfoPtr = AssetInfoPtr>
@@ -127,8 +156,14 @@ namespace Sailor
 		SAILOR_API static std::string GetMetaFilePath(const std::string& assetFilePath);
 
 		SAILOR_API bool IsAssetExpired(const AssetInfoPtr info) const;
-		SAILOR_API bool GetAssetCachedTime(const FileId& id, time_t& outAssetTimestamp) const;
-		SAILOR_API void CacheAssetTime(const FileId& id, const time_t& assetTimestamp);
+		SAILOR_API bool GetAssetCachedTime(
+			const FileId& id,
+			const std::string& sourcePath,
+			time_t& outAssetTimestamp) const;
+		SAILOR_API void CacheAssetTime(
+			const FileId& id,
+			const std::string& sourcePath,
+			const time_t& assetTimestamp);
 
 		template<typename T>
 		TObjectPtr<T> LoadAssetFromFile(const FileId& id, bool bImmediate = true)
@@ -150,10 +185,21 @@ namespace Sailor
 
 		SAILOR_API AssetInfoPtr GetAssetInfoPtr_Internal(FileId uid) const;
 		SAILOR_API AssetInfoPtr GetAssetInfoPtr_Internal(const std::string& assetFilepath) const;
+		bool ResolveDirectLoadPath(
+			const std::string& requestedPath,
+			AssetReadLocation& outLocation) const;
+		IAssetInfoHandler* GetAssetInfoHandler(const std::string& extension) const;
+		IAssetInfoHandler* GetAssetInfoHandler(
+			const std::string& extension,
+			const std::string& assetInfoType,
+			bool bPrimary) const;
 
 		TMap<FileId, AssetInfoPtr> m_loadedAssetInfo;
 		TMap<std::string, FileId> m_fileIds;
+		TMap<std::string, FileId> m_physicalFileIds;
 		TMap<std::string, class IAssetInfoHandler*> m_assetInfoHandlers;
+		std::vector<AssetMountDescriptor> m_contentMounts;
+		std::map<std::string, AssetReadLocation> m_contentFileWinners;
 
 		AssetCache m_assetCache;
 	};

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -170,6 +170,11 @@ void ModelImporter::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
 
 	if (ModelAssetInfoPtr modelAssetInfo = dynamic_cast<ModelAssetInfoPtr>(assetInfo))
 	{
+		if (!modelAssetInfo->IsWritable())
+		{
+			return;
+		}
+
 		if (bWasExpired && modelAssetInfo->ShouldGenerateMaterials() && modelAssetInfo->GetDefaultMaterials().Num() == 0)
 		{
 			GenerateMaterialAssets(modelAssetInfo);
@@ -255,13 +260,21 @@ void ModelImporter::GenerateAnimationAssets(ModelAssetInfoPtr assetInfo)
 		return;
 	}
 
-	const std::string animationsFolder = AssetRegistry::GetContentFolder() + Utils::GetFileFolder(assetInfo->GetRelativeAssetFilepath());
+	const std::string animationsFolder = Utils::GetFileFolder(assetInfo->GetRelativeAssetFilepath());
 
 	for (size_t i = 0; i < gltfModel.animations.size(); ++i)
 	{
 		const auto& anim = gltfModel.animations[i];
 		std::string name = !anim.name.empty() ? anim.name : ("animation" + std::to_string(i));
-		FileId id = CreateAnimationAsset(animationsFolder + assetInfo->GetAssetFilename() + "_" + name + ".anim.asset",
+		std::filesystem::path outputPath;
+		if (!App::GetSubmodule<AssetRegistry>()->ResolveWorkspaceContentPathForWrite(
+				animationsFolder + assetInfo->GetAssetFilename() + "_" + name + ".anim.asset",
+				outputPath))
+		{
+			SAILOR_LOG_ERROR("Cannot resolve generated animation output for %s.", assetInfo->GetAssetFilepath().c_str());
+			continue;
+		}
+		FileId id = CreateAnimationAsset(outputPath.string(),
 			assetInfo->GetAssetFilename(), (uint32_t)i, 0);
 		assetInfo->GetAnimations().Add(id);
 	}
@@ -307,7 +320,15 @@ void ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 		MaterialAsset::Data& data = materials[i];
 		data.m_name = !material.name.empty() ? material.name : ("material" + std::to_string(i));
 
-		const std::string materialName = AssetRegistry::GetContentFolder() + texturesFolder + assetInfo->GetAssetFilename() + "_" + data.m_name;
+		std::filesystem::path materialNamePath;
+		if (!App::GetSubmodule<AssetRegistry>()->ResolveWorkspaceContentPathForWrite(
+				texturesFolder + assetInfo->GetAssetFilename() + "_" + data.m_name,
+				materialNamePath))
+		{
+			SAILOR_LOG_ERROR("Cannot resolve generated material output for %s.", assetInfo->GetAssetFilepath().c_str());
+			continue;
+		}
+		const std::string materialName = materialNamePath.string();
 
 		if (material.pbrMetallicRoughness.baseColorTexture.index != -1)
 		{
@@ -498,10 +519,19 @@ void ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 
 	for (const auto& material : materials)
 	{
-		std::string materialsFolder = AssetRegistry::GetContentFolder() + texturesFolder + "materials/";
-		std::filesystem::create_directory(materialsFolder);
+		std::filesystem::path materialsFolder;
+		if (!App::GetSubmodule<AssetRegistry>()->ResolveWorkspaceContentPathForWrite(
+				texturesFolder + "materials",
+				materialsFolder))
+		{
+			SAILOR_LOG_ERROR("Cannot resolve generated materials folder for %s.", assetInfo->GetAssetFilepath().c_str());
+			continue;
+		}
+		std::filesystem::create_directories(materialsFolder);
 
-		FileId materialFileId = App::GetSubmodule<MaterialImporter>()->CreateMaterialAsset(materialsFolder + material.m_name + ".mat", material);
+		FileId materialFileId = App::GetSubmodule<MaterialImporter>()->CreateMaterialAsset(
+			(materialsFolder / (material.m_name + ".mat")).string(),
+			material);
 		materialFiles.Add(materialFileId);
 	}
 
@@ -1191,5 +1221,3 @@ void ModelImporter::CollectGarbage()
 		m_promises.Remove(uid);
 	}
 }
-
-

--- a/Runtime/AssetRegistry/Shader/ShaderCache.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.cpp
@@ -485,7 +485,11 @@ bool ShaderCache::GetTimeStamp(const FileId& uid, time_t& outTimestamp) const
 			outTimestamp = assetInfo->GetAssetLastModificationTime();
 			for (const auto& include : shaderAsset->GetIncludes())
 			{
-				outTimestamp = std::max(outTimestamp, Sailor::Utils::GetFileModificationTime(AssetRegistry::GetContentFolder() + include));
+				time_t includeTimestamp = 0;
+				if (App::GetSubmodule<AssetRegistry>()->GetContentFileModificationTime(include, includeTimestamp))
+				{
+					outTimestamp = std::max(outTimestamp, includeTimestamp);
+				}
 			}
 			return true;
 		}

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -64,9 +64,11 @@ public:
 
 	static std::string ReadIncludeFile(const std::string& requestedSource)
 	{
-		const string filepath = AssetRegistry::GetContentFolder() + string(requestedSource);
 		string contents = "";
-		AssetRegistry::ReadAllTextFile(filepath, contents);
+		if (AssetRegistry* assetRegistry = App::GetSubmodule<AssetRegistry>())
+		{
+			assetRegistry->ReadContentText(requestedSource, contents);
+		}
 		return contents;
 	}
 };
@@ -171,8 +173,14 @@ std::string GenerateConstantsLibrary(uint32_t version)
 
 void ShaderCompiler::UpdateConstantsLibrary()
 {
-	const std::filesystem::path constantsLibrary =
-		std::filesystem::path(AssetRegistry::GetContentFolder()) / "Shaders" / "Constants.glsl";
+	std::filesystem::path constantsLibrary;
+	if (!App::GetSubmodule<AssetRegistry>()->ResolveWorkspaceContentPathForWrite(
+			"Shaders/Constants.glsl",
+			constantsLibrary))
+	{
+		SAILOR_LOG_ERROR("Cannot resolve the writable shader constants library path.");
+		return;
+	}
 	std::filesystem::create_directories(constantsLibrary.parent_path());
 	if (!std::filesystem::exists(constantsLibrary))
 	{
@@ -523,12 +531,20 @@ void ShaderCompiler::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
 			}
 		}
 
-		assetInfo->SaveMetaFile();
+		if (assetInfo->IsWritable())
+		{
+			assetInfo->SaveMetaFile();
+		}
 	}
 }
 
 void ShaderCompiler::ReplaceTabsWithSpaces(AssetInfoPtr assetInfo) const
 {
+	if (!assetInfo->IsWritable())
+	{
+		return;
+	}
+
 	const std::string& filepath = assetInfo->GetAssetFilepath();
 
 	std::string shaderText;

--- a/Runtime/FrameGraph/ParticlesNode.cpp
+++ b/Runtime/FrameGraph/ParticlesNode.cpp
@@ -36,17 +36,14 @@ void ParticlesNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr 
 	if (!m_particlesHeader.m_bIsLoaded && TryGetString("particlesData", m_particlesPath))
 	{
 		std::string yamlParticlesData;
-		std::string dataPath = assetRegistry->GetContentFolder() + m_particlesPath;
-
-		if (assetRegistry->ReadAllTextFile(dataPath, yamlParticlesData))
+		if (assetRegistry->ReadContentText(m_particlesPath, yamlParticlesData))
 		{
 			YAML::Node yamlNode = YAML::Load(yamlParticlesData);
 			m_particlesHeader.Deserialize(yamlNode);
 		}
 
-		dataPath = Utils::RemoveFileExtension(dataPath) + ".dat";
-
-		if (assetRegistry->ReadBinaryFile(dataPath, m_particlesDataBinary))
+		const std::string dataPath = Utils::RemoveFileExtension(m_particlesPath) + ".dat";
+		if (assetRegistry->ReadContentBinary(dataPath, m_particlesDataBinary))
 		{
 			m_particlesHeader.m_bIsLoaded = true;
 		}

--- a/Runtime/FrameGraph/SkyNode.cpp
+++ b/Runtime/FrameGraph/SkyNode.cpp
@@ -33,8 +33,9 @@ Tasks::TaskPtr<RHI::RHIMeshPtr, TParseRes> SkyNode::CreateStarsMesh()
 	auto task = Tasks::CreateTaskWithResult<TParseRes>("Parse Stars Mesh",
 		[=]() -> TParseRes
 		{
+			auto assetRegistry = App::GetSubmodule<AssetRegistry>();
 			std::string temperatures;
-			if (!AssetRegistry::ReadAllTextFile(AssetRegistry::GetContentFolder() + std::string("StarsColor.yaml"), temperatures))
+			if (!assetRegistry || !assetRegistry->ReadContentText("StarsColor.yaml", temperatures))
 			{
 				return TParseRes();
 			}
@@ -59,7 +60,10 @@ Tasks::TaskPtr<RHI::RHIMeshPtr, TParseRes> SkyNode::CreateStarsMesh()
 			}
 
 			TVector<uint8_t> starCatalogueData;
-			AssetRegistry::ReadBinaryFile(std::filesystem::path(AssetRegistry::GetContentFolder() + std::string("BSC5")), starCatalogueData);
+			if (!assetRegistry->ReadContentBinary("BSC5", starCatalogueData))
+			{
+				return TParseRes();
+			}
 
 			BrighStarCatalogue_Header* header = (BrighStarCatalogue_Header*)starCatalogueData.GetData();
 
@@ -696,8 +700,8 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 	// Longitude in radians (east positive)
 	// Latitude in radians (north positive)
 	//
-	// New York lat	40° 42' 51.6708" N	40.7143528	0.710599509
-	// New York lon    74° 0' 21.5022" W	-74.0059731	-1.291647896
+	// New York lat	40Â° 42' 51.6708" N	40.7143528	0.710599509
+	// New York lon    74Â° 0' 21.5022" W	-74.0059731	-1.291647896
 	// Rome lat 41.8919300 degrees
 	// Rome lon 12.5113300 degrees
 	SetLocation(41.8919300f, 12.5113300f);

--- a/Runtime/Tasks/Scheduler.cpp
+++ b/Runtime/Tasks/Scheduler.cpp
@@ -51,7 +51,21 @@ void WorkerThread::Join()
 void WorkerThread::WaitIdle()
 {
 	SAILOR_PROFILE_FUNCTION();
-	while (m_bIsBusy);
+	while (HasPendingTasks())
+	{
+		std::this_thread::yield();
+	}
+}
+
+bool WorkerThread::HasPendingTasks() const
+{
+	if (m_bIsBusy.load())
+	{
+		return true;
+	}
+
+	const std::lock_guard<std::mutex> lock(m_queueMutex);
+	return m_bIsBusy.load() || !m_pTaskQueue.IsEmpty();
 }
 
 void WorkerThread::ForcelyPushTask(const ITaskPtr& pTask)
@@ -154,6 +168,10 @@ void WorkerThread::Process()
 					const bool res = hasTask || (bool)scheduler->m_bIsTerminating;
 					return res;
 				});
+			if (pCurrentTask)
+			{
+				m_bIsBusy = true;
+			}
 
 			if (m_bExecFlag > 0)
 			{
@@ -459,6 +477,7 @@ EThreadType Scheduler::GetCurrentThreadType() const
 
 uint32_t Scheduler::GetNumTasks(EThreadType thread) const
 {
+	const std::lock_guard<std::mutex> lock(m_queueMutex[(uint32_t)thread]);
 	return (uint32_t)m_pSharedTaskQueue[(uint32_t)thread].Num();
 }
 
@@ -466,9 +485,10 @@ void Scheduler::WaitIdle(const TSet<EThreadType>& threads)
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	for (const auto& thread : threads)
+	bool bHasPendingTasks = false;
+	do
 	{
-		if (GetNumTasks(thread) > 0)
+		for (const EThreadType thread : threads)
 		{
 			if (thread == EThreadType::Main && IsMainThread())
 			{
@@ -479,7 +499,17 @@ void Scheduler::WaitIdle(const TSet<EThreadType>& threads)
 				WaitIdle(thread);
 			}
 		}
-	}
+
+		bHasPendingTasks = false;
+		for (const EThreadType thread : threads)
+		{
+			bHasPendingTasks |= GetNumTasks(thread) > 0;
+			for (const WorkerThread* worker : m_workerThreads)
+			{
+				bHasPendingTasks |= worker->GetThreadType() == thread && worker->HasPendingTasks();
+			}
+		}
+	} while (bHasPendingTasks);
 }
 
 void Scheduler::WaitIdle(EThreadType type)

--- a/Runtime/Tasks/Scheduler.h
+++ b/Runtime/Tasks/Scheduler.h
@@ -79,6 +79,7 @@ namespace Sailor
 			SAILOR_API void Process();
 			SAILOR_API void Join();
 			SAILOR_API void WaitIdle();
+			SAILOR_API bool HasPendingTasks() const;
 
 		protected:
 
@@ -96,7 +97,7 @@ namespace Sailor
 			std::mutex m_execMutex;
 
 			// Specific tasks for this thread
-			std::mutex m_queueMutex;
+			mutable std::mutex m_queueMutex;
 			TVector<ITaskPtr> m_pTaskQueue;
 
 			// Assigned from scheduler
@@ -162,7 +163,7 @@ namespace Sailor
 				TVector<ITaskPtr>*& pOutQueue,
 				std::condition_variable*& pOutCondVar);
 
-			std::mutex m_queueMutex[MaxThreadTypes];
+			mutable std::mutex m_queueMutex[MaxThreadTypes];
 			std::condition_variable m_refreshCondVar[MaxThreadTypes];
 			TVector<ITaskPtr> m_pSharedTaskQueue[MaxThreadTypes];
 

--- a/Runtime/Workspace/WorkspaceContext.cpp
+++ b/Runtime/Workspace/WorkspaceContext.cpp
@@ -27,6 +27,8 @@ namespace
 	{
 		std::filesystem::path m_root;
 		std::filesystem::path m_manifest;
+		std::filesystem::path m_engineRoot;
+		std::filesystem::path m_engineContent;
 		std::filesystem::path m_content;
 		std::filesystem::path m_cache;
 		std::filesystem::path m_source;
@@ -447,6 +449,55 @@ namespace
 		return true;
 	}
 
+	bool ResolveEnginePaths(
+		const std::filesystem::path& workspaceRoot,
+		const std::string& rawEnginePath,
+		const std::string& engineReferenceKind,
+		std::filesystem::path& outEngineRoot,
+		std::filesystem::path& outEngineContent,
+		std::string& outError)
+	{
+		if (rawEnginePath.find('\0') != std::string::npos)
+		{
+			outError = "Workspace manifest field 'enginePath' contains an invalid null character.";
+			return false;
+		}
+
+		const std::filesystem::path engineReference(rawEnginePath);
+		const std::filesystem::path requestedEngineRoot = engineReference.is_absolute()
+			? engineReference
+			: workspaceRoot / engineReference;
+		std::error_code pathError;
+		outEngineRoot = std::filesystem::canonical(requestedEngineRoot, pathError);
+		if (pathError || !std::filesystem::is_directory(outEngineRoot, pathError) || pathError)
+		{
+			outError = "Workspace manifest field 'enginePath' must resolve to an existing directory: '" +
+				requestedEngineRoot.generic_string() + "'.";
+			return false;
+		}
+
+		const std::filesystem::path requestedEngineContent = outEngineRoot / DefaultContentPath;
+		pathError.clear();
+		outEngineContent = std::filesystem::canonical(requestedEngineContent, pathError);
+		if (pathError || !std::filesystem::is_directory(outEngineContent, pathError) || pathError)
+		{
+			if (engineReferenceKind == "installed")
+			{
+				outError = "Installed engine reference does not provide runtime Content at '" +
+					requestedEngineContent.generic_string() +
+					"'. Packaging runtime Content for installed engines is not supported by this build.";
+			}
+			else
+			{
+				outError = "Engine Content must be an existing directory: '" +
+					requestedEngineContent.generic_string() + "'.";
+			}
+			return false;
+		}
+
+		return true;
+	}
+
 	bool EnsureDirectory(
 		const std::filesystem::path& root,
 		const std::filesystem::path& directory,
@@ -712,6 +763,16 @@ Sailor::Workspace::WorkspaceContextResolveResult Sailor::Workspace::ResolveWorks
 			candidate.m_workspaceId = fields.m_workspaceId;
 			candidate.m_workspaceName = fields.m_workspaceName;
 			candidate.m_moduleName = fields.m_moduleName;
+			if (!ResolveEnginePaths(
+					root,
+					fields.m_enginePath,
+					fields.m_engineReferenceKind,
+					candidate.m_engineRoot,
+					candidate.m_engineContent,
+					error))
+			{
+				return Fail(EWorkspaceContextResolveStatus::PathInvalid, std::move(error));
+			}
 		}
 
 		std::filesystem::path contentRelative;
@@ -782,6 +843,11 @@ Sailor::Workspace::WorkspaceContextResolveResult Sailor::Workspace::ResolveWorks
 		{
 			return Fail(EWorkspaceContextResolveStatus::PathInvalid, std::move(error));
 		}
+		if (candidate.m_bLegacy)
+		{
+			candidate.m_engineRoot = candidate.m_root;
+			candidate.m_engineContent = candidate.m_content;
+		}
 
 		WorkspaceContextResolveResult result;
 		result.m_status = candidate.m_bLegacy
@@ -793,6 +859,8 @@ Sailor::Workspace::WorkspaceContextResolveResult Sailor::Workspace::ResolveWorks
 			: "Resolved workspace manifest '" + candidate.m_manifest.generic_string() + "'.";
 		result.m_context.m_root = std::move(candidate.m_root);
 		result.m_context.m_manifest = std::move(candidate.m_manifest);
+		result.m_context.m_engineRoot = std::move(candidate.m_engineRoot);
+		result.m_context.m_engineContent = std::move(candidate.m_engineContent);
 		result.m_context.m_content = std::move(candidate.m_content);
 		result.m_context.m_cache = std::move(candidate.m_cache);
 		result.m_context.m_source = std::move(candidate.m_source);

--- a/Runtime/Workspace/WorkspaceContext.h
+++ b/Runtime/Workspace/WorkspaceContext.h
@@ -36,6 +36,8 @@ namespace Sailor::Workspace
 	public:
 		const std::filesystem::path& GetRoot() const noexcept { return m_root; }
 		const std::filesystem::path& GetManifest() const noexcept { return m_manifest; }
+		const std::filesystem::path& GetEngineRoot() const noexcept { return m_engineRoot; }
+		const std::filesystem::path& GetEngineContent() const noexcept { return m_engineContent; }
 		const std::filesystem::path& GetContent() const noexcept { return m_content; }
 		const std::filesystem::path& GetCache() const noexcept { return m_cache; }
 		const std::filesystem::path& GetSource() const noexcept { return m_source; }
@@ -51,6 +53,8 @@ namespace Sailor::Workspace
 	private:
 		std::filesystem::path m_root;
 		std::filesystem::path m_manifest;
+		std::filesystem::path m_engineRoot;
+		std::filesystem::path m_engineContent;
 		std::filesystem::path m_content;
 		std::filesystem::path m_cache;
 		std::filesystem::path m_source;

--- a/Tests/AssetMountDiscoveryTests.cpp
+++ b/Tests/AssetMountDiscoveryTests.cpp
@@ -1,0 +1,450 @@
+#include "AssetRegistry/AssetMountDiscovery.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace
+{
+	using namespace Sailor;
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	class TempDirectory final
+	{
+	public:
+		explicit TempDirectory(const char* label)
+		{
+			static uint64_t counter = 0;
+			m_path = std::filesystem::temp_directory_path() /
+				("sailor-asset-mount-" + std::string(label) + "-" +
+					std::to_string(++counter));
+			std::filesystem::remove_all(m_path);
+			std::filesystem::create_directories(m_path);
+		}
+
+		~TempDirectory()
+		{
+			std::error_code error;
+			std::filesystem::remove_all(m_path, error);
+		}
+
+		const std::filesystem::path& Get() const noexcept { return m_path; }
+		std::filesystem::path Path(const std::filesystem::path& relative) const { return m_path / relative; }
+
+	private:
+		std::filesystem::path m_path;
+	};
+
+	void WriteFile(const std::filesystem::path& path, const std::string& content = "fixture")
+	{
+		std::filesystem::create_directories(path.parent_path());
+		std::ofstream stream(path);
+		stream << content;
+	}
+
+	void CreateDirectoryLink(const std::filesystem::path& link, const std::filesystem::path& target)
+	{
+#if defined(_WIN32)
+		const std::string command = "cmd.exe /d /c mklink /J \"" +
+			link.string() + "\" \"" + target.string() + "\" >NUL";
+		Require(std::system(command.c_str()) == 0,
+			"Windows junction fixture should be creatable: " + link.string());
+#else
+		std::error_code error;
+		std::filesystem::create_directory_symlink(target, link, error);
+		Require(!error, "Directory symlink fixture should be creatable: " + error.message());
+#endif
+	}
+
+	AssetMountDescriptor Mount(
+		const std::filesystem::path& root,
+		EAssetMountKind kind,
+		int32_t priority,
+		bool bWritable)
+	{
+		return AssetMountDescriptor{ root, kind, priority, bWritable };
+	}
+
+	const AssetMountDiscoveredFile& FindFile(
+		const AssetMountDiscoveryResult& discovery,
+		EAssetMountKind kind,
+		const std::string& virtualPath)
+	{
+		const auto it = std::find_if(discovery.m_files.begin(), discovery.m_files.end(),
+			[&](const AssetMountDiscoveredFile& file)
+			{
+				return file.m_mount.m_kind == kind && file.m_virtualPath == virtualPath;
+			});
+		Require(it != discovery.m_files.end(), "Expected discovered file: " + virtualPath);
+		return *it;
+	}
+
+	AssetMountCandidate Candidate(
+		const AssetMountDiscoveredFile& file,
+		std::string virtualPath,
+		std::string fileId)
+	{
+		return AssetMountCandidate{
+			file.m_mount,
+			file.m_physicalPath,
+			std::move(virtualPath),
+			std::move(fileId)
+		};
+	}
+
+	bool HasDiagnostic(
+		const std::vector<AssetMountDiagnostic>& diagnostics,
+		EAssetMountDiagnosticCode code)
+	{
+		return std::any_of(diagnostics.begin(), diagnostics.end(), [&](const AssetMountDiagnostic& diagnostic)
+			{
+				return diagnostic.m_code == code;
+			});
+	}
+
+	const AssetMountDiagnostic& FindDiagnostic(
+		const std::vector<AssetMountDiagnostic>& diagnostics,
+		EAssetMountDiagnosticCode code)
+	{
+		const auto it = std::find_if(diagnostics.begin(), diagnostics.end(), [&](const AssetMountDiagnostic& diagnostic)
+			{
+				return diagnostic.m_code == code;
+			});
+		Require(it != diagnostics.end(), "Expected mount diagnostic was not produced");
+		return *it;
+	}
+
+	std::vector<std::string> DiagnosticMessages(const AssetMountResolutionResult& result)
+	{
+		std::vector<std::string> messages;
+		for (const AssetMountDiagnostic& diagnostic : result.GetDiagnostics())
+		{
+			messages.emplace_back(diagnostic.m_message);
+		}
+		return messages;
+	}
+
+	void TestIdenticalRootsAreDeduplicatedToWorkspace()
+	{
+		TempDirectory content("dedupe");
+		TempDirectory aliases("dedupe-alias");
+		WriteFile(content.Path("asset.txt"));
+		const std::filesystem::path workspaceAlias = aliases.Path("WorkspaceContent");
+		CreateDirectoryLink(workspaceAlias, content.Get());
+
+		const AssetMountDiscoveryResult result = DiscoverAssetMountFiles({
+			Mount(content.Get(), EAssetMountKind::Engine, 100, false),
+			Mount(workspaceAlias, EAssetMountKind::Workspace, 0, true)
+		});
+
+		Require(result.m_mounts.size() == 1, "Identical physical roots should be scanned once");
+		Require(result.m_mounts.front().m_kind == EAssetMountKind::Workspace,
+			"Workspace should win an identical-root mount collision");
+		Require(result.m_mounts.front().m_bWritable,
+			"The retained workspace mount should preserve its writable property");
+		Require(result.m_files.size() == 1, "Deduplicated roots should not duplicate files");
+		Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::DuplicateMountRoot),
+			"Identical roots should emit a deterministic dedupe diagnostic");
+	}
+
+	void TestInvalidMountRootIsFatal()
+	{
+		TempDirectory valid("invalid-root");
+		WriteFile(valid.Path("valid.asset"));
+		const std::filesystem::path missing = valid.Path("MissingContent");
+
+		const AssetMountDiscoveryResult result = DiscoverAssetMountFiles({
+			Mount(valid.Get(), EAssetMountKind::Workspace, 10, true),
+			Mount(missing, EAssetMountKind::Engine, 0, false)
+		});
+
+		Require(result.HasFatalErrors(), "An invalid mount root should be reported as fatal");
+		Require(result.m_files.empty(), "A fatal mount set must not publish partial discovery files");
+		Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::InvalidMountRoot),
+			"Invalid roots should remain distinguishable from overlap failures");
+	}
+
+	void TestDiscoveryIsSortedByVirtualPath()
+	{
+		TempDirectory content("sorted");
+		WriteFile(content.Path("z-last.txt"));
+		WriteFile(content.Path("nested/c-middle.txt"));
+		WriteFile(content.Path("a-first.txt"));
+
+		const AssetMountDiscoveryResult result = DiscoverAssetMountFiles({
+			Mount(content.Get(), EAssetMountKind::Workspace, 10, true)
+		});
+
+		std::vector<std::string> virtualPaths;
+		for (const AssetMountDiscoveredFile& file : result.m_files)
+		{
+			virtualPaths.emplace_back(file.m_virtualPath);
+		}
+		Require(virtualPaths == std::vector<std::string>{
+			"a-first.txt",
+			"nested/c-middle.txt",
+			"z-last.txt"
+		}, "Discovery output should be globally sorted by normalized virtual path");
+	}
+
+	void TestOverlappingRootsAreRejectedInBothDirections()
+	{
+		{
+			TempDirectory workspace("workspace-contains-engine");
+			const std::filesystem::path engine = workspace.Path("Libraries/EngineContent");
+			WriteFile(workspace.Path("workspace.asset"));
+			WriteFile(engine / "engine.asset");
+
+			const AssetMountDiscoveryResult result = DiscoverAssetMountFiles({
+				Mount(workspace.Get(), EAssetMountKind::Workspace, 10, true),
+				Mount(engine, EAssetMountKind::Engine, 0, false)
+			});
+
+			Require(result.HasFatalErrors(),
+				"Workspace roots containing Engine roots must be rejected as fatal");
+			Require(result.m_files.empty(),
+				"Fatal root overlap must stop discovery before either root is scanned");
+			Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::OverlappingMountRoot),
+				"Workspace-parent overlap should identify the root conflict");
+		}
+
+		{
+			TempDirectory engine("engine-contains-workspace");
+			const std::filesystem::path workspace = engine.Path("Projects/WorkspaceContent");
+			WriteFile(engine.Path("engine.asset"));
+			WriteFile(workspace / "workspace.asset");
+
+			const AssetMountDiscoveryResult result = DiscoverAssetMountFiles({
+				Mount(engine.Get(), EAssetMountKind::Engine, 0, false),
+				Mount(workspace, EAssetMountKind::Workspace, 10, true)
+			});
+
+			Require(result.HasFatalErrors(),
+				"Engine roots containing Workspace roots must be rejected as fatal");
+			Require(result.m_files.empty(),
+				"Reverse root overlap must stop discovery before either root is scanned");
+			Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::OverlappingMountRoot),
+				"Engine-parent overlap should identify the root conflict");
+		}
+	}
+
+	void TestDiscoverySkipsPhysicalEscapesAndCycles()
+	{
+		TempDirectory content("safe-root");
+		TempDirectory outside("outside-root");
+		WriteFile(content.Path("safe.txt"));
+		WriteFile(outside.Path("secret.txt"));
+		CreateDirectoryLink(content.Path("Escape"), outside.Get());
+		CreateDirectoryLink(content.Path("Cycle"), content.Get());
+
+		const AssetMountDiscoveryResult result = DiscoverAssetMountFiles({
+			Mount(content.Get(), EAssetMountKind::Workspace, 10, true)
+		});
+
+		Require(result.m_files.size() == 1 && result.m_files.front().m_virtualPath == "safe.txt",
+			"Escaping and cyclic directory links must not contribute files");
+		Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::PhysicalEscapeSkipped),
+			"Physical escapes should produce a diagnostic");
+		Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::DirectoryCycleSkipped),
+			"Directory cycles should produce a diagnostic");
+	}
+
+	void TestWorkspaceWinsVirtualPathIndependentOfInputOrder()
+	{
+		TempDirectory engine("virtual-engine");
+		TempDirectory workspace("virtual-workspace");
+		WriteFile(engine.Path("Materials/shared.mat"));
+		WriteFile(workspace.Path("Materials/shared.mat"));
+		const AssetMountDiscoveryResult discovery = DiscoverAssetMountFiles({
+			Mount(engine.Get(), EAssetMountKind::Engine, 100, false),
+			Mount(workspace.Get(), EAssetMountKind::Workspace, 0, true)
+		});
+
+		const AssetMountCandidate engineCandidate = Candidate(
+			FindFile(discovery, EAssetMountKind::Engine, "Materials/shared.mat"),
+			"Materials/shared.mat",
+			"{ENGINE-ID}");
+		const AssetMountCandidate workspaceCandidate = Candidate(
+			FindFile(discovery, EAssetMountKind::Workspace, "Materials/shared.mat"),
+			"Materials/shared.mat",
+			"{WORKSPACE-ID}");
+
+		const AssetMountResolutionResult forward = ResolveAssetMountCandidates({
+			engineCandidate,
+			workspaceCandidate
+		});
+		const AssetMountResolutionResult reverse = ResolveAssetMountCandidates({
+			workspaceCandidate,
+			engineCandidate
+		});
+		const AssetMountCandidate* winner = forward.FindByVirtualPath("Materials/shared.mat");
+		Require(winner && winner->m_mount.m_kind == EAssetMountKind::Workspace,
+			"Workspace should override Engine for a colliding virtual path");
+		Require(winner->m_fileId == "{WORKSPACE-ID}",
+			"Virtual-path resolution should retain winner collision data");
+		Require(reverse.FindByVirtualPath("Materials\\shared.mat") &&
+			reverse.FindByVirtualPath("Materials\\shared.mat")->m_fileId == "{WORKSPACE-ID}",
+			"Virtual lookup should normalize separators");
+		Require(DiagnosticMessages(forward) == DiagnosticMessages(reverse),
+			"Collision diagnostics must not depend on candidate input order");
+		Require(HasDiagnostic(forward.GetDiagnostics(), EAssetMountDiagnosticCode::VirtualPathCollision),
+			"Virtual-path collision data should be reported");
+		const AssetMountDiagnostic& diagnostic = FindDiagnostic(
+			forward.GetDiagnostics(),
+			EAssetMountDiagnosticCode::VirtualPathCollision);
+		Require(diagnostic.m_winnerKind == EAssetMountKind::Workspace &&
+			diagnostic.m_conflictingKind == EAssetMountKind::Engine &&
+			diagnostic.m_winnerFileId == "{WORKSPACE-ID}" &&
+			diagnostic.m_conflictingFileId == "{ENGINE-ID}",
+			"Virtual-path diagnostics should carry deterministic winner and loser provenance");
+	}
+
+	void TestWorkspaceWinsFileIdWhileUniqueVirtualPathsRemainAddressable()
+	{
+		TempDirectory engine("fileid-engine");
+		TempDirectory workspace("fileid-workspace");
+		WriteFile(engine.Path("Engine/asset.mat"));
+		WriteFile(workspace.Path("Workspace/asset.mat"));
+		const AssetMountDiscoveryResult discovery = DiscoverAssetMountFiles({
+			Mount(engine.Get(), EAssetMountKind::Engine, 100, false),
+			Mount(workspace.Get(), EAssetMountKind::Workspace, 0, true)
+		});
+
+		const AssetMountCandidate engineCandidate = Candidate(
+			FindFile(discovery, EAssetMountKind::Engine, "Engine/asset.mat"),
+			"Engine/asset.mat",
+			"{SHARED-ID}");
+		const AssetMountCandidate workspaceCandidate = Candidate(
+			FindFile(discovery, EAssetMountKind::Workspace, "Workspace/asset.mat"),
+			"Workspace/asset.mat",
+			"{SHARED-ID}");
+		const AssetMountResolutionResult result = ResolveAssetMountCandidates({
+			engineCandidate,
+			workspaceCandidate
+		});
+
+		Require(result.FindByFileId("{SHARED-ID}") &&
+			result.FindByFileId("{SHARED-ID}")->m_mount.m_kind == EAssetMountKind::Workspace,
+			"Workspace should override Engine for a colliding FileId");
+		Require(result.FindByVirtualPath("Engine/asset.mat") != nullptr &&
+			result.FindByVirtualPath("Workspace/asset.mat") != nullptr,
+			"Different virtual paths should remain independently addressable");
+		Require(HasDiagnostic(result.GetDiagnostics(), EAssetMountDiagnosticCode::FileIdCollision),
+			"FileId collision data should be reported");
+		const AssetMountDiagnostic& diagnostic = FindDiagnostic(
+			result.GetDiagnostics(),
+			EAssetMountDiagnosticCode::FileIdCollision);
+		Require(diagnostic.m_key == "{SHARED-ID}" &&
+			diagnostic.m_winnerKind == EAssetMountKind::Workspace &&
+			diagnostic.m_conflictingKind == EAssetMountKind::Engine,
+			"FileId diagnostics should identify the key and winning mount explicitly");
+	}
+
+	void TestPriorityBreaksTiesWithinTheSameMountKind()
+	{
+		TempDirectory first("priority-first");
+		TempDirectory second("priority-second");
+		WriteFile(first.Path("shared.asset"));
+		WriteFile(second.Path("shared.asset"));
+		const AssetMountDiscoveryResult discovery = DiscoverAssetMountFiles({
+			Mount(first.Get(), EAssetMountKind::Engine, 1, false),
+			Mount(second.Get(), EAssetMountKind::Engine, 20, false)
+		});
+
+		const AssetMountResolutionResult result = ResolveAssetMountCandidates({
+			Candidate(FindFile(discovery, EAssetMountKind::Engine, "shared.asset"), "shared.asset", "{LOW}"),
+			AssetMountCandidate{
+				Mount(second.Get(), EAssetMountKind::Engine, 20, false),
+				std::filesystem::canonical(second.Path("shared.asset")),
+				"shared.asset",
+				"{HIGH}"
+			}
+		});
+
+		Require(result.FindByVirtualPath("shared.asset") &&
+			result.FindByVirtualPath("shared.asset")->m_fileId == "{HIGH}",
+			"Priority should break ties within the same mount kind");
+	}
+
+	void TestInvalidCandidatesAreRejected()
+	{
+		TempDirectory root("invalid-candidate");
+		WriteFile(root.Path("asset.mat"));
+		const AssetMountCandidate invalid{
+			Mount(root.Get(), EAssetMountKind::Workspace, 10, true),
+			std::filesystem::canonical(root.Path("asset.mat")),
+			"../escape.mat",
+			"{INVALID}"
+		};
+
+		const AssetMountResolutionResult result = ResolveAssetMountCandidates({ invalid });
+		Require(result.GetCandidates().empty(), "Traversal candidates should not enter winner indexes");
+		Require(HasDiagnostic(result.GetDiagnostics(), EAssetMountDiagnosticCode::InvalidCandidate),
+			"Rejected candidates should produce an actionable diagnostic");
+	}
+
+	void TestEmptyWorkspaceDiscoversRealEngineContent(const std::filesystem::path& engineContent)
+	{
+		TempDirectory workspace("real-engine-content");
+		const AssetMountDiscoveryResult discovery = DiscoverAssetMountFiles({
+			Mount(engineContent, EAssetMountKind::Engine, 0, false),
+			Mount(workspace.Get(), EAssetMountKind::Workspace, 100, true)
+		});
+
+		Require(!discovery.HasFatalErrors(),
+			"An empty workspace should accept the repository Engine Content mount");
+		Require(std::none_of(discovery.m_files.begin(), discovery.m_files.end(), [](const AssetMountDiscoveredFile& file)
+			{
+				return file.m_mount.m_kind == EAssetMountKind::Workspace;
+			}), "The workspace fixture should remain empty during Engine Content discovery");
+		const AssetMountDiscoveredFile& editorWorld = FindFile(
+			discovery,
+			EAssetMountKind::Engine,
+			"Editor.world");
+		Require(editorWorld.m_physicalPath ==
+			std::filesystem::canonical(engineContent / "Editor.world"),
+			"The default editor world should resolve from Engine Content");
+		Require(!editorWorld.m_mount.m_bWritable,
+			"The real Engine Content smoke must preserve read-only provenance");
+		FindFile(discovery, EAssetMountKind::Engine, "Editor.world.asset");
+		FindFile(discovery, EAssetMountKind::Engine, "Shaders/Constants.glsl");
+	}
+}
+
+int main(int argc, char** argv)
+{
+	try
+	{
+		Require(argc == 2, "Expected the repository Engine Content path as the only argument");
+		TestIdenticalRootsAreDeduplicatedToWorkspace();
+		TestInvalidMountRootIsFatal();
+		TestDiscoveryIsSortedByVirtualPath();
+		TestOverlappingRootsAreRejectedInBothDirections();
+		TestDiscoverySkipsPhysicalEscapesAndCycles();
+		TestWorkspaceWinsVirtualPathIndependentOfInputOrder();
+		TestWorkspaceWinsFileIdWhileUniqueVirtualPathsRemainAddressable();
+		TestPriorityBreaksTiesWithinTheSameMountKind();
+		TestInvalidCandidatesAreRejected();
+		TestEmptyWorkspaceDiscoversRealEngineContent(argv[1]);
+		std::cout << "Asset mount discovery tests passed.\n";
+		return 0;
+	}
+	catch (const std::exception& error)
+	{
+		std::cerr << "Asset mount discovery tests failed: " << error.what() << '\n';
+		return 1;
+	}
+}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -102,6 +102,11 @@ add_executable(WorkspaceContextTests
     WorkspaceContextTests.cpp
 )
 
+add_executable(AssetMountDiscoveryTests
+    AssetMountDiscoveryTests.cpp
+    ${SAILOR_RUNTIME_DIR}/AssetRegistry/AssetMountDiscovery.cpp
+)
+
 if(WIN32)
     add_executable(RemoteViewportWindowsTransportTests
         RemoteViewportWindowsTransportTests.cpp
@@ -130,6 +135,7 @@ target_compile_features(WorkspaceModuleMissingEntryFixture PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleContractTests PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleRuntimeTests PRIVATE cxx_std_20)
 target_compile_features(WorkspaceContextTests PRIVATE cxx_std_20)
+target_compile_features(AssetMountDiscoveryTests PRIVATE cxx_std_20)
 target_compile_definitions(WorkspaceModuleFixture PRIVATE
     SAILOR_WORKSPACE_MODULE
     SAILOR_WORKSPACE_MODULE_EXPORTS
@@ -219,6 +225,9 @@ target_include_directories(WorkspaceModuleRuntimeTests PRIVATE
 target_include_directories(WorkspaceContextTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
+target_include_directories(AssetMountDiscoveryTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
 if(WIN32)
     target_include_directories(RemoteViewportWindowsTransportTests PRIVATE
         ${SAILOR_RUNTIME_DIR}
@@ -275,6 +284,11 @@ add_test(
 )
 
 add_test(
+    NAME AssetMountDiscoveryTests
+    COMMAND AssetMountDiscoveryTests "${PROJECT_SOURCE_DIR}/Content"
+)
+
+add_test(
     NAME WorkspaceModuleRuntimeTests
     COMMAND WorkspaceModuleRuntimeTests
         $<TARGET_FILE:WorkspaceModuleFixture>
@@ -298,6 +312,7 @@ add_test(
 )
 set_tests_properties(
     WorkspaceContextTests
+    AssetMountDiscoveryTests
     WorkspaceModuleContractTests
     WorkspaceModuleRuntimeTests
     PROPERTIES TIMEOUT 30

--- a/Tests/WorkspaceContextTests.cpp
+++ b/Tests/WorkspaceContextTests.cpp
@@ -20,9 +20,10 @@ namespace
 		uint32_t m_version = 1;
 		std::string m_workspaceId = "workspace-id";
 		std::string m_name = "Sandbox";
-		std::string m_enginePath = "../Sailor";
+		std::string m_enginePath = "Engine";
 		std::string m_engineReferenceKind = "source";
 		bool m_includeEngineReferenceKind = true;
+		bool m_createEngineContent = true;
 		std::string m_content = "Content";
 		std::string m_cache = "Cache";
 		std::string m_source = "Source";
@@ -81,6 +82,18 @@ namespace
 		const std::filesystem::path& path,
 		const ManifestSpec& spec = {})
 	{
+		if (spec.m_createEngineContent && !spec.m_enginePath.empty())
+		{
+			const std::filesystem::path engineReference(spec.m_enginePath);
+			const std::filesystem::path engineRoot = engineReference.is_absolute()
+				? engineReference
+				: path.parent_path() / engineReference;
+			std::error_code createError;
+			std::filesystem::create_directories(engineRoot / "Content", createError);
+			Require(!createError,
+				"test engine Content should be creatable: " + engineRoot.generic_string());
+		}
+
 		YAML::Node manifest;
 		manifest["manifestVersion"] = spec.m_version;
 		manifest["workspaceId"] = spec.m_workspaceId;
@@ -125,6 +138,10 @@ namespace
 		Require(result.m_context.GetManifest().empty(), "legacy context should not invent a manifest");
 		Require(result.m_context.GetContent() == Canonical(workspace.Path("Content")),
 			"legacy context should use the default Content directory");
+		Require(result.m_context.GetEngineRoot() == result.m_context.GetRoot(),
+			"legacy context should deduplicate the engine and workspace roots");
+		Require(result.m_context.GetEngineContent() == result.m_context.GetContent(),
+			"legacy context should deduplicate engine and workspace Content");
 		Require(result.m_context.GetCache() == Canonical(workspace.Path("Cache")),
 			"legacy context should use the default Cache directory");
 		Require(std::filesystem::is_directory(workspace.Path("Content")),
@@ -139,6 +156,7 @@ namespace
 		ManifestSpec spec;
 		spec.m_workspaceId = "workspace with spaces";
 		spec.m_name = "Sandbox With Spaces";
+		spec.m_enginePath = "Engine Install With Spaces";
 		spec.m_content = "Game Data/Content Files";
 		spec.m_cache = "State Data/Cache Files";
 		spec.m_source = "Game Code/Source Files";
@@ -166,6 +184,11 @@ namespace
 			"workspace id should be preserved");
 		Require(result.m_context.GetWorkspaceName() == spec.m_name,
 			"workspace name should be preserved");
+		Require(result.m_context.GetEngineRoot() == Canonical(workspace.Path(spec.m_enginePath)),
+			"engine root should preserve spaces");
+		Require(result.m_context.GetEngineContent() ==
+			Canonical(workspace.Path(spec.m_enginePath) / "Content"),
+			"engine Content should resolve below the engine root");
 		Require(result.m_context.GetContent() == Canonical(workspace.Path(spec.m_content)),
 			"custom content path should preserve spaces");
 		Require(result.m_context.GetCache() == Canonical(workspace.Path(spec.m_cache)),
@@ -211,6 +234,101 @@ namespace
 
 		Require(result.IsSuccess(),
 			"v1 manifest without engineReferenceKind should default to source: " + result.m_message);
+	}
+
+	void TestRelativeEnginePathOutsideWorkspace()
+	{
+		TempDirectory workspace("relative-engine-workspace");
+		TempDirectory engine("relative-engine-root");
+		std::filesystem::create_directories(engine.Path("Content"));
+		std::error_code relativeError;
+		const std::filesystem::path relativeEngine = std::filesystem::relative(
+			engine.Get(),
+			workspace.Get(),
+			relativeError);
+		Require(!relativeError, "relative engine fixture should be computable");
+
+		ManifestSpec spec;
+		spec.m_enginePath = relativeEngine.generic_string();
+		spec.m_createEngineContent = false;
+		WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		Require(result.IsSuccess(), "relative engine path should resolve outside the workspace: " + result.m_message);
+		Require(result.m_context.GetEngineRoot() == Canonical(engine.Get()),
+			"relative engine path should be canonicalized from the workspace root");
+		Require(result.m_context.GetEngineContent() == Canonical(engine.Path("Content")),
+			"relative engine Content should be canonicalized");
+	}
+
+	void TestAbsoluteEnginePath()
+	{
+		TempDirectory workspace("absolute-engine-workspace");
+		TempDirectory engine("absolute-engine-root");
+		std::filesystem::create_directories(engine.Path("Content"));
+
+		ManifestSpec spec;
+		spec.m_enginePath = engine.Get().generic_string();
+		spec.m_createEngineContent = false;
+		WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		Require(result.IsSuccess(), "absolute engine path should resolve: " + result.m_message);
+		Require(result.m_context.GetEngineRoot() == Canonical(engine.Get()),
+			"absolute engine root should be canonicalized without workspace containment");
+		Require(result.m_context.GetEngineContent() == Canonical(engine.Path("Content")),
+			"absolute engine Content should be canonicalized");
+	}
+
+	void TestMissingEngineContentDoesNotMutateWorkspace()
+	{
+		TempDirectory workspace("missing-engine-content-workspace");
+		TempDirectory engine("missing-engine-content-root");
+		ManifestSpec spec;
+		spec.m_enginePath = engine.Get().generic_string();
+		spec.m_createEngineContent = false;
+		WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		Require(result.m_status == EWorkspaceContextResolveStatus::PathInvalid,
+			"missing engine Content should be rejected: " + result.m_message);
+		Require(result.m_message.find("Engine Content") != std::string::npos,
+			"missing engine Content diagnostic should identify the invalid directory");
+		Require(result.m_context.GetRoot().empty(),
+			"missing engine Content must not publish a partial context");
+		Require(!std::filesystem::exists(workspace.Path("Content")),
+			"engine validation must precede workspace Content recovery");
+		Require(!std::filesystem::exists(workspace.Path("Cache")),
+			"engine validation must precede workspace Cache recovery");
+	}
+
+	void TestMissingInstalledEngineContentHasTargetedDiagnostic()
+	{
+		TempDirectory workspace("missing-installed-engine-content-workspace");
+		TempDirectory engine("missing-installed-engine-content-root");
+		ManifestSpec spec;
+		spec.m_enginePath = engine.Get().generic_string();
+		spec.m_engineReferenceKind = "installed";
+		spec.m_createEngineContent = false;
+		WriteManifest(workspace.Path("workspace.sailor"), spec);
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		Require(result.m_status == EWorkspaceContextResolveStatus::PathInvalid,
+			"installed engine without runtime Content should be rejected: " + result.m_message);
+		Require(result.m_message.find("Installed engine reference") != std::string::npos,
+			"installed engine diagnostic should identify the reference kind");
+		Require(result.m_message.find("Packaging runtime Content") != std::string::npos,
+			"installed engine diagnostic should identify the known packaging limitation");
+		Require(result.m_context.GetRoot().empty(),
+			"missing installed engine Content must not publish a partial context");
+		Require(!std::filesystem::exists(workspace.Path("Content")),
+			"installed engine validation must precede workspace Content recovery");
+		Require(!std::filesystem::exists(workspace.Path("Cache")),
+			"installed engine validation must precede workspace Cache recovery");
 	}
 
 	void TestMissingCustomContentDoesNotMutateWorkspace()
@@ -423,6 +541,10 @@ int main()
 		TestManifestPathsWithSpaces();
 		TestManifestDefaultRecovery();
 		TestManifestDefaultsMissingEngineReferenceKindToSource();
+		TestRelativeEnginePathOutsideWorkspace();
+		TestAbsoluteEnginePath();
+		TestMissingEngineContentDoesNotMutateWorkspace();
+		TestMissingInstalledEngineContentHasTargetedDiagnostic();
 		TestMissingCustomContentDoesNotMutateWorkspace();
 		TestRecoveryRollbackOnLaterFailure();
 		TestManifestDiscoveryFailures();

--- a/Tests/WorkspaceModuleRuntimeTests.cpp
+++ b/Tests/WorkspaceModuleRuntimeTests.cpp
@@ -68,6 +68,7 @@ namespace
 		const std::string& logicOutputPath = "Binaries")
 	{
 		std::filesystem::create_directories(root);
+		std::filesystem::create_directories(root.parent_path() / "Engine" / "Content");
 		std::ofstream manifest(root / "workspace.sailor");
 		manifest
 			<< "manifestVersion: 1\n"


### PR DESCRIPTION
Closes #100

## Summary

- add canonical Workspace Content and read-only Engine Content mounts to runtime discovery
- apply deterministic workspace precedence for virtual-path and FileId collisions
- stage registry generations transactionally, preserve cache provenance, and reconcile rescans safely
- route shader includes and raw runtime data through the shared mount resolver
- prevent engine metadata/source mutation while keeping workspace-generated assets writable
- document the two-root contract and installed-content packaging limitation

## Validation

- `cmake --build build-mac-vcpkg -j6`
- `ctest --test-dir build-mac-vcpkg -R '^(AssetMountDiscoveryTests|WorkspaceContextTests|WorkspaceModuleRuntimeTests)$' --output-on-failure` (3/3)
- full CTest: 11/12; only the pre-existing unrelated `RemoteViewportMacTransportTests` metadata-only adapter assertion fails
- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --no-restore --configuration Debug` (228/228)
- `python3 run_world_tests.py --config Debug --engine Binaries/SailorEngine-Debug` (6/6)
- separate empty-workspace runtime smoke using repository Engine Content and `EmptyWorldStartupShutdown.world` (exit 0, Engine Content unchanged)
- writable workspace model-import smoke generated and registered `.mat` plus metadata with a valid FileId (exit 0)
- `git diff --check`
