### PR TITLE
[Workspace] Version runtime and editor caches

### DIFF
--- a/Docs/WorkspaceLogic.md
+++ b/Docs/WorkspaceLogic.md
@@ -153,6 +153,48 @@ Import callbacks may register newly generated, non-conflicting Workspace assets 
 
 Cache is not a third discoverable content root. The editor's generated `../Cache/Temp.world` is supported through the direct cache-load exception, while normal asset discovery remains limited to Workspace Content and Engine Content.
 
+### Workspace Cache Envelopes
+
+Workspace-generated caches use a strict version 1 YAML envelope. The native asset and shader caches and the managed editor-type cache use the same field contract:
+
+| Field | Compatibility rule |
+| --- | --- |
+| `cacheVersion` | Common envelope format. The current value is `1`; a missing, older, or future value is unsupported. |
+| `payloadVersion` | Producer-specific payload schema. It must exactly match the version expected by that consumer. |
+| `cacheKind` | Identifies the consumer, such as `asset-cache`, `shader-cache`, or `editor-types`; it must match exactly. |
+| `producerIdentity` | Identifies the payload producer and schema family, such as `asset-cache-v1` or `editor-types-v1`; it must match exactly. |
+| `workspaceId` | Uses the manifest workspace ID, or the deterministic legacy identity described below; it must match exactly. |
+| `engineVersion` | Uses the engine build's `SAILOR_ENGINE_VERSION`; it must match exactly. |
+| `buildIdentity` | Combines the active build configuration with the workspace-module ABI tag, including architecture, compiler, C runtime, iterator mode, and configuration; it must match exactly. |
+| `payload` | Contains the producer-owned serialized data and is published only after complete producer-specific validation. |
+
+The current envelope is closed to unknown or duplicate fields. Version mismatches are not migrated implicitly, and identity mismatches are not accepted as a best-effort hit. For a workspace without a manifest ID, the runtime canonicalizes the immutable workspace root as UTF-8, normalizes separators, folds ASCII `A`-`Z` to lowercase on Windows, and prefixes it with `legacy-root:`. The managed launch contract uses the same byte-preserving rule; non-ASCII characters are not locale-case-folded. The editor marshals workspace and manifest launch paths explicitly as UTF-8, and the runtime decodes those command-line path bytes as UTF-8 before canonicalization, so both sides derive the same identity for non-ASCII roots. Two legacy workspaces at different canonical roots therefore cannot share cache identity accidentally.
+
+Cache loads return one of these structured statuses:
+
+| Status | Meaning |
+| --- | --- |
+| `Missing` | The owned cache file does not exist. |
+| `Loaded` | The complete envelope, exact identity, payload version, and producer payload passed validation. |
+| `StaleIdentity` | Cache kind, producer, workspace, engine, or build identity differs from the expected descriptor. |
+| `Corrupt` | YAML, field structure, payload data, or referenced artifact integrity is malformed or incomplete. |
+| `UnsupportedVersion` | The common envelope version or producer payload version is missing or not exactly supported. |
+| `IoFailure` | The cache path could not be inspected or read reliably. Write and invalidation failures use separate diagnostics. |
+
+No non-`Loaded` result publishes decoded state. Asset and shader payloads are decoded into temporary containers and swapped into their live caches only after complete validation. Shader payload version 2 assigns every entry a collision-resistant immutable generation and requires structurally complete regular and debug artifact sets with identical stage topology. Metadata records the byte length and checksum of every present artifact; truncated, misaligned, same-size checksum-mismatched, or missing required SPIR-V is corrupt rather than a partial cache hit. Editor type metadata is cleared before startup cache handling, the native runtime identity is compared with the exact editor launch identity after initialization, and only a fully validated combined type catalog may be published.
+
+Invalidation is scoped by cache ownership:
+
+- AssetCache owns only `Cache/AssetCache.yaml`. A missing, stale, corrupt, or unsupported load clears its in-memory map and atomically writes an empty current envelope without deleting neighboring files.
+- ShaderCache owns `Cache/ShaderCache.yaml` plus `Cache/PrecompiledShaders/`, `Cache/CompiledShaders/`, and `Cache/CompiledShadersWithDebug/`. It verifies that those paths remain contained by the resolved Cache root before deleting or recreating them. Artifact garbage collection uses only the last successfully committed metadata snapshot as its whitelist, so an envelope failure cannot delete the generation still referenced on disk; other cache files and user-authored Content are never part of shader invalidation.
+- EditorTypes owns `Cache/EditorTypes.yaml` and same-directory temporary files matching its own generated name pattern. Stale, corrupt, and unsupported caches are invalidated by removing only that target and its owned temporary files; it does not sweep the Cache directory.
+
+An `IoFailure` is not evidence that stored bytes are invalid. All three consumers clear or withhold in-memory state after an unreadable cache, but preserve the existing target and owned artifacts so a transient sharing, antivirus, permission, or device error cannot destroy a potentially valid cache. After an AssetCache `IoFailure`, ordinary updates and shutdown preserve existing storage; only an explicit forced rebuild or `ClearAll` authorizes replacement. ShaderCache additionally enters a read-only storage quarantine when either envelope loading or later runtime artifact validation encounters an I/O failure: compilation may publish complete regular/debug bytecode in memory for the current session, but save, invalidation, artifact cleanup, and precompiled writes do not touch disk. Missing, corrupt, stale, unsupported, and repeated I/O reload results keep that quarantine and its session state intact. Only a fully successful reload discards the session-only state and restores persistent access; `ClearAll` is the explicit destructive escape hatch.
+
+Cache YAML and shader artifacts are replaced through same-directory temporary files. The complete temporary file is written and flushed before an atomic replace exposes it; native POSIX writes also synchronize the containing directory, while Windows replacement requests write-through behavior. Shader compilation first writes all regular and required debug artifacts under a new immutable generation, then makes that complete generation eligible for the next metadata commit. Remove and expiry cleanup take the inverse order: they atomically commit candidate metadata before garbage-collecting artifacts no longer referenced by the committed snapshot. A successful shader save also sweeps the replaced immutable generation only after the new envelope commits. A failure before replacement leaves the previous target and generation intact and triggers best-effort temporary-file cleanup. If a durability synchronization reports failure after replacement, the target is still a complete old or new file, never a partially written one. Native cache callers retain dirty state after any reported save failure; shader compile-all performs a save-only retry when bytecode is current but its metadata is still dirty. Metadata is not committed as clean until replacement and post-commit cleanup succeed. An editor-type persistence failure likewise preserves the validated live catalog and reports the failed write instead of publishing unvalidated disk data.
+
+Workspace switching therefore preserves A → B → A isolation. A cache copied from workspace A is `StaleIdentity` in B and is never published, so B starts from empty producer-owned state and writes a B envelope. Returning to A can load only data whose complete identity still matches A. Transactional editor activation additionally clears in-memory asset, world, and editor-type projections before the candidate starts, preventing an asynchronous result from the prior workspace from bypassing the on-disk identity check.
+
 For manifest version 1, the runtime resolves the module as `<resolved-logic-output>/<CONFIG>/<platform-module-name>`. `WorkspaceModuleManager` consumes the captured context and never reparses the manifest. It canonicalizes the final module path again immediately before loading and rejects any symlink or junction change observed by that check. Concurrent mutation of the workspace or build tree during the platform's pathname-only library-loader call is not supported. The active CMake configuration is part of both the path and ABI check, so a stale Debug/Release binary fails with rebuild guidance instead of being loaded as a compatible module.
 
 The dynamic library is opened before asset importers scan the resolved Workspace Content and Engine Content mounts. Asset, shader, precompiled-shader, and editor-type caches use the resolved Cache directory, including custom paths with spaces. The generated shader constants library is written below Workspace Content. Static engine registration callbacks triggered by the platform loader are suppressed for that load operation; only the explicit V1 descriptor callback can add workspace types. The host validates the complete descriptor and metadata set before committing it under a module owner. Missing libraries, loader dependencies, entry points, incompatible API/ABI, metadata errors, and registration collisions return structured non-crashing diagnostics.

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -53,6 +53,8 @@
     <Compile Include="EditorPerfTests.cs" />
     <Compile Include="EngineLaunchContractTests.cs" />
     <Compile Include="EngineLifecycleTests.cs" />
+    <Compile Include="EditorTypeCacheStoreTests.cs" />
+    <Compile Include="Utf8InteropArgumentsTests.cs" />
     <Compile Include="..\Editor\Panels\PanelContracts.cs" Link="Panels\PanelContracts.cs" />
     <Compile Include="..\Editor\Panels\PanelRegistry.cs" Link="Panels\PanelRegistry.cs" />
     <Compile Include="..\Editor\Layout\LayoutContracts.cs" Link="Layout\LayoutContracts.cs" />
@@ -93,6 +95,8 @@
     <Compile Include="..\Editor\Utility\EditorDragDrop.cs" Link="Utility\EditorDragDrop.cs" />
     <Compile Include="..\Editor\Utility\EditorPerf.cs" Link="Utility\EditorPerf.cs" />
     <Compile Include="..\Editor\Services\EngineLaunchContract.cs" Link="Services\EngineLaunchContract.cs" />
+    <Compile Include="..\Editor\Services\EditorTypeCacheStore.cs" Link="Services\EditorTypeCacheStore.cs" />
+    <Compile Include="..\Editor\Services\Utf8InteropArguments.cs" Link="Services\Utf8InteropArguments.cs" />
     <Compile Include="..\Editor\Commands\EditorCommandRuntime.cs" Link="Commands\EditorCommandRuntime.cs" />
   </ItemGroup>
 </Project>

--- a/Editor.Tests/EditorTypeCacheStoreTests.cs
+++ b/Editor.Tests/EditorTypeCacheStoreTests.cs
@@ -1,0 +1,393 @@
+using SailorEditor.Services;
+
+namespace Editor.Tests;
+
+public sealed class EditorTypeCacheStoreTests : IDisposable
+{
+    static readonly EditorTypeCacheIdentity WorkspaceA = new(
+        "workspace-a",
+        "0.1",
+        "build-debug-msvc",
+        "editor-types-v1");
+    static readonly string Catalog = """
+        engineTypes:
+          - typename: Sailor::TransformComponent
+        cdo: []
+        enums: {}
+        assetTypes: []
+        """;
+
+    readonly string _directory = Path.Combine(
+        Path.GetTempPath(),
+        $"SailorEditorTypeCacheTests-{Guid.NewGuid():N}");
+
+    string CachePath => Path.Combine(_directory, "EditorTypes.yaml");
+
+    [Fact]
+    public void SaveAndLoad_RoundTripsStrictEnvelopeAndOpaqueCatalog()
+    {
+        var store = new EditorTypeCacheStore();
+
+        var write = store.Save(CachePath, WorkspaceA, Catalog);
+        var load = store.Load(CachePath, WorkspaceA);
+        var envelope = File.ReadAllText(CachePath);
+
+        Assert.True(write.Succeeded, write.Diagnostic);
+        Assert.Equal(EditorTypeCacheStatus.Loaded, load.Status);
+        Assert.True(load.Succeeded);
+        Assert.Equal(Catalog, load.Payload);
+        Assert.Contains("cacheVersion: 1", envelope, StringComparison.Ordinal);
+        Assert.Contains("cacheKind: editor-types", envelope, StringComparison.Ordinal);
+        Assert.Contains("workspaceId: workspace-a", envelope, StringComparison.Ordinal);
+        Assert.Contains("payloadVersion: 1", envelope, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ParseNativeIdentity_RequiresTheExactNativeBridgeContract()
+    {
+        var identity = EditorTypeCacheStore.ParseNativeIdentity("""
+            workspaceIdentity: рабочая-область-а
+            engineVersion: 0.1
+            buildIdentity: sailor-abi-debug
+            producerIdentity: editor-types-v1
+            """);
+
+        Assert.Equal("рабочая-область-а", identity.WorkspaceIdentity);
+        Assert.Equal("0.1", identity.EngineVersion);
+        Assert.Equal("sailor-abi-debug", identity.BuildIdentity);
+        Assert.Equal("editor-types-v1", identity.ProducerIdentity);
+    }
+
+    [Theory]
+    [InlineData("workspaceIdentity: workspace-a\nengineVersion: 0.1\nbuildIdentity: build\n")]
+    [InlineData("workspaceIdentity: workspace-a\nengineVersion: 0.1\nbuildIdentity: build\nproducerIdentity: editor-types-v1\nextra: value\n")]
+    public void ParseNativeIdentity_RejectsIncompleteOrUnknownFields(string yaml)
+    {
+        Assert.Throws<InvalidDataException>(() => EditorTypeCacheStore.ParseNativeIdentity(yaml));
+    }
+
+    [Fact]
+    public void Load_RejectsWorkspaceACacheForWorkspaceB()
+    {
+        var store = new EditorTypeCacheStore();
+        Assert.True(store.Save(CachePath, WorkspaceA, Catalog).Succeeded);
+        var workspaceB = WorkspaceA with { WorkspaceIdentity = "workspace-b" };
+
+        var result = store.Load(CachePath, workspaceB);
+
+        Assert.Equal(EditorTypeCacheStatus.StaleIdentity, result.Status);
+        Assert.Null(result.Payload);
+        Assert.Contains("workspaceId", result.Diagnostic, StringComparison.Ordinal);
+        Assert.Contains("workspace-a", result.Diagnostic, StringComparison.Ordinal);
+        Assert.Contains("workspace-b", result.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_AtoBtoA_NeverPublishesTheOtherWorkspaceCatalog()
+    {
+        var store = new EditorTypeCacheStore();
+        var workspaceAPath = Path.Combine(_directory, "A", "EditorTypes.yaml");
+        var workspaceBPath = Path.Combine(_directory, "B", "EditorTypes.yaml");
+        var workspaceB = WorkspaceA with { WorkspaceIdentity = "workspace-b" };
+        var workspaceBCatalog = Catalog.Replace(
+            "Sailor::TransformComponent",
+            "Game::WorkspaceBComponent",
+            StringComparison.Ordinal);
+
+        Assert.True(store.Save(workspaceAPath, WorkspaceA, Catalog).Succeeded);
+        Directory.CreateDirectory(Path.GetDirectoryName(workspaceBPath)!);
+        File.Copy(workspaceAPath, workspaceBPath);
+
+        var staleInB = store.Load(workspaceBPath, workspaceB);
+        Assert.Equal(EditorTypeCacheStatus.StaleIdentity, staleInB.Status);
+        Assert.Null(staleInB.Payload);
+        Assert.True(store.Invalidate(workspaceBPath).Succeeded);
+        Assert.True(store.Save(workspaceBPath, workspaceB, workspaceBCatalog).Succeeded);
+        Assert.Equal(workspaceBCatalog, store.Load(workspaceBPath, workspaceB).Payload);
+
+        var restoredA = store.Load(workspaceAPath, WorkspaceA);
+        Assert.Equal(EditorTypeCacheStatus.Loaded, restoredA.Status);
+        Assert.Equal(Catalog, restoredA.Payload);
+        Assert.DoesNotContain("WorkspaceBComponent", restoredA.Payload, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("EngineVersion", "0.2", "engineVersion")]
+    [InlineData("BuildIdentity", "build-release-clang", "buildIdentity")]
+    [InlineData("ProducerIdentity", "editor-types-v2", "producerIdentity")]
+    public void Load_RejectsEachStaleProducerIdentity(
+        string property,
+        string replacement,
+        string diagnosticField)
+    {
+        var store = new EditorTypeCacheStore();
+        Assert.True(store.Save(CachePath, WorkspaceA, Catalog).Succeeded);
+        var expected = property switch
+        {
+            nameof(EditorTypeCacheIdentity.EngineVersion) => WorkspaceA with { EngineVersion = replacement },
+            nameof(EditorTypeCacheIdentity.BuildIdentity) => WorkspaceA with { BuildIdentity = replacement },
+            nameof(EditorTypeCacheIdentity.ProducerIdentity) => WorkspaceA with { ProducerIdentity = replacement },
+            _ => throw new ArgumentOutOfRangeException(nameof(property))
+        };
+
+        var result = store.Load(CachePath, expected);
+
+        Assert.Equal(EditorTypeCacheStatus.StaleIdentity, result.Status);
+        Assert.Null(result.Payload);
+        Assert.Contains(diagnosticField, result.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("engineTypes: []\n")]
+    [InlineData("cacheVersion: 0\n")]
+    [InlineData("cacheVersion: 2\n")]
+    [InlineData("cacheVersion: 1\ncacheKind: editor-types\nworkspaceId: workspace-a\nengineVersion: 0.1\nbuildIdentity: build-debug-msvc\nproducerIdentity: editor-types-v1\npayload: '{}'")]
+    [InlineData("cacheVersion: 1\npayloadVersion: 0\n")]
+    [InlineData("cacheVersion: 1\npayloadVersion: 2\n")]
+    public void Load_RejectsRawMissingOldAndFutureVersionsAsUnsupported(string yaml)
+    {
+        Directory.CreateDirectory(_directory);
+        File.WriteAllText(CachePath, yaml);
+
+        var result = new EditorTypeCacheStore().Load(CachePath, WorkspaceA);
+
+        Assert.Equal(EditorTypeCacheStatus.UnsupportedVersion, result.Status);
+        Assert.Null(result.Payload);
+        Assert.Contains("unsupported", result.Diagnostic, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("cacheVersion: [")]
+    [InlineData("cacheVersion: one\npayloadVersion: 1\n")]
+    [InlineData("cacheVersion: 1\npayloadVersion: one\n")]
+    public void Load_ReportsMalformedEnvelopeAsCorrupt(string yaml)
+    {
+        Directory.CreateDirectory(_directory);
+        File.WriteAllText(CachePath, yaml);
+
+        var result = new EditorTypeCacheStore().Load(CachePath, WorkspaceA);
+
+        Assert.Equal(EditorTypeCacheStatus.Corrupt, result.Status);
+        Assert.Null(result.Payload);
+        Assert.Contains("corrupt", result.Diagnostic, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Load_ReportsMalformedOpaquePayloadAsCorrupt()
+    {
+        Directory.CreateDirectory(_directory);
+        File.WriteAllText(CachePath, """
+            cacheVersion: 1
+            cacheKind: editor-types
+            workspaceId: workspace-a
+            engineVersion: 0.1
+            buildIdentity: build-debug-msvc
+            producerIdentity: editor-types-v1
+            payloadVersion: 1
+            payload: |
+              engineTypes: [
+            """);
+
+        var result = new EditorTypeCacheStore().Load(CachePath, WorkspaceA);
+
+        Assert.Equal(EditorTypeCacheStatus.Corrupt, result.Status);
+        Assert.Null(result.Payload);
+        Assert.Contains("Payload", result.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_ReportsInvalidUtf8AsCorruptRatherThanIoFailure()
+    {
+        Directory.CreateDirectory(_directory);
+        File.WriteAllBytes(CachePath, [0xc3, 0x28]);
+
+        var result = new EditorTypeCacheStore().Load(CachePath, WorkspaceA);
+
+        Assert.Equal(EditorTypeCacheStatus.Corrupt, result.Status);
+        Assert.Null(result.Payload);
+        Assert.Contains("UTF-8", result.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_ReturnsMissingWithoutPayload()
+    {
+        var result = new EditorTypeCacheStore().Load(CachePath, WorkspaceA);
+
+        Assert.Equal(EditorTypeCacheStatus.Missing, result.Status);
+        Assert.Null(result.Payload);
+    }
+
+    [Fact]
+    public void Load_MapsFilesystemFailureToIoFailure()
+    {
+        var store = new EditorTypeCacheStore(new ThrowingReadFileOperations());
+
+        var result = store.Load(CachePath, WorkspaceA);
+
+        Assert.Equal(EditorTypeCacheStatus.IoFailure, result.Status);
+        Assert.Null(result.Payload);
+        Assert.Contains("injected read failure", result.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Load_DirectoryAtCachePathIsIoFailureRatherThanMissing()
+    {
+        Directory.CreateDirectory(CachePath);
+
+        var result = new EditorTypeCacheStore().Load(CachePath, WorkspaceA);
+
+        Assert.Equal(EditorTypeCacheStatus.IoFailure, result.Status);
+        Assert.Null(result.Payload);
+        Assert.Contains("Cannot read", result.Diagnostic, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData((int)EditorTypeCacheStatus.StaleIdentity, true)]
+    [InlineData((int)EditorTypeCacheStatus.Corrupt, true)]
+    [InlineData((int)EditorTypeCacheStatus.UnsupportedVersion, true)]
+    [InlineData((int)EditorTypeCacheStatus.Missing, false)]
+    [InlineData((int)EditorTypeCacheStatus.Loaded, false)]
+    [InlineData((int)EditorTypeCacheStatus.IoFailure, false)]
+    public void InvalidationPolicy_PreservesFilesAfterIoFailure(
+        int statusValue,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            EditorTypeCacheStore.ShouldInvalidate((EditorTypeCacheStatus)statusValue));
+    }
+
+    [Theory]
+    [InlineData((int)EditorTypeCacheStatus.Missing, true)]
+    [InlineData((int)EditorTypeCacheStatus.Loaded, true)]
+    [InlineData((int)EditorTypeCacheStatus.StaleIdentity, true)]
+    [InlineData((int)EditorTypeCacheStatus.Corrupt, true)]
+    [InlineData((int)EditorTypeCacheStatus.UnsupportedVersion, true)]
+    [InlineData((int)EditorTypeCacheStatus.IoFailure, false)]
+    public void PersistencePolicy_DoesNotReplaceStorageAfterIoFailure(
+        int statusValue,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            EditorTypeCacheStore.ShouldPersistLiveCatalog((EditorTypeCacheStatus)statusValue));
+    }
+
+    [Fact]
+    public void Save_ReplaceFailurePreservesPreviousTargetAndCleansTemporaryFile()
+    {
+        var physicalStore = new EditorTypeCacheStore();
+        Assert.True(physicalStore.Save(CachePath, WorkspaceA, Catalog).Succeeded);
+        var previousContents = File.ReadAllText(CachePath);
+        var replacementCatalog = "engineTypes: []\ncdo: []\nenums: {}\nassetTypes: []\n";
+        var failingStore = new EditorTypeCacheStore(new FailingReplaceFileOperations());
+
+        var result = failingStore.Save(CachePath, WorkspaceA, replacementCatalog);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("injected replace failure", result.Diagnostic, StringComparison.Ordinal);
+        Assert.Equal(previousContents, File.ReadAllText(CachePath));
+        Assert.Empty(Directory.EnumerateFiles(_directory, "*.tmp"));
+    }
+
+    [Fact]
+    public void Save_CorruptPayloadDoesNotTouchPreviousTarget()
+    {
+        var store = new EditorTypeCacheStore();
+        Assert.True(store.Save(CachePath, WorkspaceA, Catalog).Succeeded);
+        var previousContents = File.ReadAllText(CachePath);
+
+        var result = store.Save(CachePath, WorkspaceA, "engineTypes: [");
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("payload is corrupt", result.Diagnostic, StringComparison.Ordinal);
+        Assert.Equal(previousContents, File.ReadAllText(CachePath));
+        Assert.Empty(Directory.EnumerateFiles(_directory, "*.tmp"));
+    }
+
+    [Fact]
+    public void Invalidate_RemovesOnlyTargetAndOwnedOrphanTemporaryFiles()
+    {
+        var store = new EditorTypeCacheStore();
+        Assert.True(store.Save(CachePath, WorkspaceA, Catalog).Succeeded);
+        var neighbor = Path.Combine(_directory, "ShaderCache.yaml");
+        var lookalike = Path.Combine(_directory, ".EditorTypes.yaml.user.tmp");
+        var ownedTemporary = Path.Combine(
+            _directory,
+            $".EditorTypes.yaml.{Guid.NewGuid():N}.tmp");
+        File.WriteAllText(neighbor, "keep");
+        File.WriteAllText(lookalike, "keep");
+        File.WriteAllText(ownedTemporary, "discard");
+
+        var result = store.Invalidate(CachePath);
+        var missingResult = store.Invalidate(CachePath);
+
+        Assert.True(result.Succeeded, result.Diagnostic);
+        Assert.True(missingResult.Succeeded, missingResult.Diagnostic);
+        Assert.False(File.Exists(CachePath));
+        Assert.False(File.Exists(ownedTemporary));
+        Assert.Equal("keep", File.ReadAllText(neighbor));
+        Assert.Equal("keep", File.ReadAllText(lookalike));
+    }
+
+    [Fact]
+    public void Invalidate_ReportsIoFailureWithoutDeletingNeighboringFiles()
+    {
+        Directory.CreateDirectory(_directory);
+        var neighbor = Path.Combine(_directory, "ShaderCache.yaml");
+        File.WriteAllText(CachePath, "old cache");
+        File.WriteAllText(neighbor, "keep");
+        var store = new EditorTypeCacheStore(new FailingDeleteFileOperations());
+
+        var result = store.Invalidate(CachePath);
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("injected delete failure", result.Diagnostic, StringComparison.Ordinal);
+        Assert.True(File.Exists(CachePath));
+        Assert.Equal("keep", File.ReadAllText(neighbor));
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_directory))
+            Directory.Delete(_directory, recursive: true);
+    }
+
+    sealed class FailingReplaceFileOperations : IEditorTypeCacheFileOperations
+    {
+        readonly PhysicalEditorTypeCacheFileOperations _physical = new();
+
+        public string ReadAllText(string path) => _physical.ReadAllText(path);
+        public void CreateDirectory(string path) => _physical.CreateDirectory(path);
+        public void WriteAllTextDurably(string path, string contents)
+            => _physical.WriteAllTextDurably(path, contents);
+        public void Replace(string temporaryPath, string targetPath)
+            => throw new IOException("injected replace failure");
+        public void DeleteIfExists(string path) => _physical.DeleteIfExists(path);
+        public IEnumerable<string> EnumerateFiles(string directory) => _physical.EnumerateFiles(directory);
+    }
+
+    sealed class ThrowingReadFileOperations : IEditorTypeCacheFileOperations
+    {
+        public string ReadAllText(string path) => throw new IOException("injected read failure");
+        public void CreateDirectory(string path) => throw new NotSupportedException();
+        public void WriteAllTextDurably(string path, string contents) => throw new NotSupportedException();
+        public void Replace(string temporaryPath, string targetPath) => throw new NotSupportedException();
+        public void DeleteIfExists(string path) => throw new NotSupportedException();
+        public IEnumerable<string> EnumerateFiles(string directory) => throw new NotSupportedException();
+    }
+
+    sealed class FailingDeleteFileOperations : IEditorTypeCacheFileOperations
+    {
+        readonly PhysicalEditorTypeCacheFileOperations _physical = new();
+
+        public string ReadAllText(string path) => _physical.ReadAllText(path);
+        public void CreateDirectory(string path) => _physical.CreateDirectory(path);
+        public void WriteAllTextDurably(string path, string contents)
+            => _physical.WriteAllTextDurably(path, contents);
+        public void Replace(string temporaryPath, string targetPath)
+            => _physical.Replace(temporaryPath, targetPath);
+        public void DeleteIfExists(string path) => throw new IOException("injected delete failure");
+        public IEnumerable<string> EnumerateFiles(string directory) => _physical.EnumerateFiles(directory);
+    }
+}

--- a/Editor.Tests/EngineLaunchContractTests.cs
+++ b/Editor.Tests/EngineLaunchContractTests.cs
@@ -1,4 +1,5 @@
 using SailorEditor.Services;
+using SailorEditor.Workspace;
 
 public class EngineLaunchContractTests
 {
@@ -22,6 +23,7 @@ public class EngineLaunchContractTests
         Assert.Equal(Path.GetFullPath(manifestPath), context.WorkspaceManifestPath);
         Assert.Equal(Path.GetFullPath(contentDirectory), context.ContentDirectory);
         Assert.Equal(Path.GetFullPath(cacheDirectory), context.CacheDirectory);
+        Assert.Equal("workspace-sandbox", context.WorkspaceIdentity);
         Assert.Equal(Path.Combine(cacheDirectory, "Temp.world"), context.TempWorldFilePath);
         Assert.Equal(
             Path.GetRelativePath(contentDirectory, Path.Combine(cacheDirectory, "Temp.world")),
@@ -48,6 +50,7 @@ public class EngineLaunchContractTests
         Assert.Equal(Path.Combine(Path.GetFullPath(fallbackRoot), "Content"), context.ContentDirectory);
         Assert.Equal(Path.Combine(Path.GetFullPath(fallbackRoot), "Cache"), context.CacheDirectory);
         Assert.Equal(Path.Combine(Path.GetFullPath(fallbackRoot), "Cache", "EditorTypes.yaml"), context.EditorTypesCacheFilePath);
+        Assert.StartsWith("legacy-root:", context.WorkspaceIdentity, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -112,6 +115,75 @@ public class EngineLaunchContractTests
         Assert.DoesNotContain("--workspace-manifest", context.BuildArguments("Editor.world"));
     }
 
+    [Fact]
+    public void WorkspaceIdentity_ParticipatesInExactLaunchContextEquality()
+    {
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), "Sandbox");
+        var first = EngineLaunchContract.Resolve(
+            workspaceRoot,
+            null,
+            Path.Combine(workspaceRoot, "Content"),
+            Path.Combine(workspaceRoot, "Cache"),
+            Path.GetTempPath(),
+            "workspace-a");
+        var second = first with { WorkspaceIdentity = "workspace-b" };
+
+        Assert.NotEqual(first, second);
+    }
+
+    [Fact]
+    public void Resolve_PreservesUnicodeManifestWorkspaceIdentity()
+    {
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), "Sandbox");
+        var context = EngineLaunchContract.Resolve(
+            workspaceRoot,
+            null,
+            Path.Combine(workspaceRoot, "Content"),
+            Path.Combine(workspaceRoot, "Cache"),
+            Path.GetTempPath(),
+            "  рабочая-область-а  ");
+
+        Assert.Equal("рабочая-область-а", context.WorkspaceIdentity);
+    }
+
+    [Fact]
+    public void Resolve_LegacyIdentityUsesThePhysicalWorkspaceRoot()
+    {
+        var fixtureRoot = Path.Combine(
+            Path.GetTempPath(),
+            $"SailorEngineLaunchIdentity-{Guid.NewGuid():N}");
+        var physicalRoot = Path.Combine(fixtureRoot, "Physical-РАБОЧАЯ-AZ");
+        var selectedRoot = physicalRoot;
+        Directory.CreateDirectory(physicalRoot);
+
+        try
+        {
+            if (!OperatingSystem.IsWindows())
+            {
+                selectedRoot = Path.Combine(fixtureRoot, "Alias");
+                Directory.CreateSymbolicLink(selectedRoot, physicalRoot);
+            }
+
+            var context = EngineLaunchContract.Resolve(
+                null,
+                null,
+                null,
+                null,
+                selectedRoot);
+            var expectedRoot = WorkspacePathPolicy.NormalizePhysicalPath(physicalRoot)
+                .Replace(Path.DirectorySeparatorChar, '/');
+            if (OperatingSystem.IsWindows())
+                expectedRoot = FoldAsciiCase(expectedRoot);
+
+            Assert.Equal($"legacy-root:{expectedRoot}", context.WorkspaceIdentity);
+            Assert.Contains("РАБОЧАЯ", context.WorkspaceIdentity, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(fixtureRoot, recursive: true);
+        }
+    }
+
     [Theory]
     [InlineData(null, "Cache")]
     [InlineData("Content", null)]
@@ -146,5 +218,18 @@ public class EngineLaunchContractTests
             manifestPath,
             contentDirectory,
             cacheDirectory,
-            fallbackRoot);
+            fallbackRoot,
+            workspaceRoot is null ? null : "workspace-sandbox");
+
+    static string FoldAsciiCase(string value)
+    {
+        var characters = value.ToCharArray();
+        for (var index = 0; index < characters.Length; ++index)
+        {
+            if (characters[index] is >= 'A' and <= 'Z')
+                characters[index] = (char)(characters[index] + ('a' - 'A'));
+        }
+
+        return new string(characters);
+    }
 }

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -44,6 +44,97 @@ public sealed class EngineLifecycleTests
         Assert.Contains("return Sailor::App::GetExitCode();", unixSource, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void WorkspaceCacheIdentity_IsAvailableOnBothExportSurfacesAndManagedInterop()
+    {
+        var managedSource = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
+        var windowsSource = ReadRepositoryFile("Lib", "DllMain.cpp");
+        var unixSource = ReadRepositoryFile("Lib", "InteropExports.cpp");
+
+        Assert.Contains("extern uint SerializeWorkspaceCacheIdentity", managedSource, StringComparison.Ordinal);
+        Assert.Contains(
+            "yaml = Marshal.PtrToStringUTF8(yamlNodeChar[0], (int)numChars)",
+            managedSource,
+            StringComparison.Ordinal);
+        Assert.Contains("SAILOR_API uint32_t SerializeWorkspaceCacheIdentity", windowsSource, StringComparison.Ordinal);
+        Assert.Contains("return Sailor::App::SerializeWorkspaceCacheIdentity(yamlNode);", windowsSource, StringComparison.Ordinal);
+        Assert.Contains("SAILOR_API uint32_t SerializeWorkspaceCacheIdentity", unixSource, StringComparison.Ordinal);
+        Assert.Contains("return Sailor::App::SerializeWorkspaceCacheIdentity(yamlNode);", unixSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ManagedInitialization_MarshalsEveryCommandLineTokenAsUtf8AndAlwaysFreesIt()
+    {
+        var managedSource = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
+        var nativeSource = ReadRepositoryFile("Runtime", "Sailor.cpp");
+
+        Assert.Contains(
+            "EntryPoint = \"Initialize\", ExactSpelling = true",
+            managedSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "static extern void InitializeNative([In] nint[] commandLineArgs, int num)",
+            managedSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "extern void Initialize(string[] commandLineArgs",
+            managedSource,
+            StringComparison.Ordinal);
+
+        var allocation = managedSource.IndexOf(
+            "Utf8InteropArguments.Allocate(commandLineArgs, num)",
+            StringComparison.Ordinal);
+        var invocation = managedSource.IndexOf("InitializeNative(nativeArguments, num)", allocation, StringComparison.Ordinal);
+        var finallyBlock = managedSource.IndexOf("finally", invocation, StringComparison.Ordinal);
+        var cleanup = managedSource.IndexOf("Utf8InteropArguments.Free(nativeArguments)", finallyBlock, StringComparison.Ordinal);
+        Assert.True(allocation >= 0);
+        Assert.True(invocation > allocation);
+        Assert.True(finallyBlock > invocation);
+        Assert.True(cleanup > finallyBlock);
+
+        Assert.Contains(
+            "return Workspace::PathFromUtf8(params.m_workspace);",
+            nativeSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Workspace::PathFromUtf8(params.m_workspaceManifest)",
+            nativeSource,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EditorTypeCache_IsValidatedAfterNativeInitializationAndBeforeLivePublication()
+    {
+        var source = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
+
+        var initialize = source.IndexOf("EngineAppInterop.Initialize(args, args.Length)", StringComparison.Ordinal);
+        var identity = source.IndexOf("ReadWorkspaceCacheIdentity(", initialize, StringComparison.Ordinal);
+        var cacheLoad = source.IndexOf("editorTypeCacheStore.Load(", identity, StringComparison.Ordinal);
+        var cachedValidation = source.IndexOf("TryParseEditorTypes(", cacheLoad, StringComparison.Ordinal);
+        var liveCatalog = source.IndexOf("SerializeEditorTypes(generation, allowStarting: true)", cacheLoad, StringComparison.Ordinal);
+        var liveValidation = source.IndexOf("TryParseEditorTypes(", liveCatalog, StringComparison.Ordinal);
+        var livePublication = source.IndexOf("Volatile.Write(ref editorTypes, liveEditorTypes)", liveValidation, StringComparison.Ordinal);
+        var cacheSave = source.IndexOf("editorTypeCacheStore.Save(", liveCatalog, StringComparison.Ordinal);
+
+        Assert.True(initialize >= 0);
+        Assert.True(identity > initialize);
+        Assert.True(cacheLoad > identity);
+        Assert.True(cachedValidation > cacheLoad);
+        Assert.True(liveCatalog > cachedValidation);
+        Assert.True(liveCatalog > cacheLoad);
+        Assert.True(liveValidation > liveCatalog);
+        Assert.True(livePublication > liveValidation);
+        Assert.True(cacheSave > liveCatalog);
+        Assert.Contains(
+            "cachedEditorTypes.Status != EditorTypeCacheStatus.IoFailure",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "EditorTypeCacheStore.ShouldPersistLiveCatalog(cachedEditorTypes.Status)",
+            source,
+            StringComparison.Ordinal);
+    }
+
     static string ReadRepositoryFile(params string[] relativePath)
     {
         var current = new DirectoryInfo(AppContext.BaseDirectory);

--- a/Editor.Tests/Utf8InteropArgumentsTests.cs
+++ b/Editor.Tests/Utf8InteropArgumentsTests.cs
@@ -1,0 +1,55 @@
+using System.Runtime.InteropServices;
+using System.Text;
+using SailorEngine;
+
+namespace Editor.Tests;
+
+public sealed class Utf8InteropArgumentsTests
+{
+    [Fact]
+    public void Allocate_PreservesUtf8ArgumentsAndTokenBoundaries()
+    {
+        string[] arguments =
+        [
+            "SailorEditor",
+            "--workspace",
+            Path.Combine(Path.GetTempPath(), "Physical-РАБОЧАЯ-AZ with spaces"),
+            "--workspace-manifest",
+            "Проект с пробелами.sailor"
+        ];
+        var nativeArguments = Utf8InteropArguments.Allocate(arguments, arguments.Length);
+
+        try
+        {
+            Assert.Equal(arguments.Length, nativeArguments.Length);
+            for (var index = 0; index < arguments.Length; ++index)
+            {
+                Assert.NotEqual(nint.Zero, nativeArguments[index]);
+                Assert.Equal(arguments[index], Marshal.PtrToStringUTF8(nativeArguments[index]));
+                Assert.Equal(
+                    0,
+                    Marshal.ReadByte(
+                        nativeArguments[index],
+                        Encoding.UTF8.GetByteCount(arguments[index])));
+            }
+        }
+        finally
+        {
+            Utf8InteropArguments.Free(nativeArguments);
+        }
+
+        Assert.All(nativeArguments, pointer => Assert.Equal(nint.Zero, pointer));
+        Utf8InteropArguments.Free(nativeArguments);
+    }
+
+    [Fact]
+    public void Allocate_RejectsInvalidCountAndEmbeddedNull()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => Utf8InteropArguments.Allocate(["SailorEditor"], 0));
+        Assert.Throws<ArgumentException>(
+            () => Utf8InteropArguments.Allocate(
+                ["SailorEditor", "workspace\0suffix"],
+                2));
+    }
+}

--- a/Editor.Tests/WorkspaceActivationTests.cs
+++ b/Editor.Tests/WorkspaceActivationTests.cs
@@ -308,7 +308,8 @@ public sealed class WorkspaceActivationTests
             session.WorkspaceRoot,
             session.ManifestPath,
             session.ContentDirectory,
-            session.CacheDirectory);
+            session.CacheDirectory,
+            session.Manifest.WorkspaceId);
         return new WorkspaceActivationCandidate(new WorkspaceLifecyclePreparation(session), launchContext);
     }
 

--- a/Editor/Services/EditorTypeCacheStore.cs
+++ b/Editor/Services/EditorTypeCacheStore.cs
@@ -1,0 +1,548 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace SailorEditor.Services;
+
+internal enum EditorTypeCacheStatus
+{
+    Missing,
+    Loaded,
+    StaleIdentity,
+    Corrupt,
+    UnsupportedVersion,
+    IoFailure
+}
+
+internal sealed record EditorTypeCacheIdentity(
+    string WorkspaceIdentity,
+    string EngineVersion,
+    string BuildIdentity,
+    string ProducerIdentity);
+
+internal sealed record EditorTypeCacheLoadResult(
+    EditorTypeCacheStatus Status,
+    string Diagnostic,
+    string? Payload = null)
+{
+    public bool Succeeded => Status == EditorTypeCacheStatus.Loaded && Payload is not null;
+}
+
+internal sealed record EditorTypeCacheWriteResult(
+    bool Succeeded,
+    string Diagnostic);
+
+internal interface IEditorTypeCacheFileOperations
+{
+    string ReadAllText(string path);
+    void CreateDirectory(string path);
+    void WriteAllTextDurably(string path, string contents);
+    void Replace(string temporaryPath, string targetPath);
+    void DeleteIfExists(string path);
+    IEnumerable<string> EnumerateFiles(string directory);
+}
+
+internal sealed class PhysicalEditorTypeCacheFileOperations : IEditorTypeCacheFileOperations
+{
+    static readonly UTF8Encoding Utf8WithoutBom = new(false, true);
+
+    public string ReadAllText(string path) => File.ReadAllText(path, Utf8WithoutBom);
+
+    public void CreateDirectory(string path) => Directory.CreateDirectory(path);
+
+    public void WriteAllTextDurably(string path, string contents)
+    {
+        using var stream = new FileStream(
+            path,
+            new FileStreamOptions
+            {
+                Mode = FileMode.CreateNew,
+                Access = FileAccess.Write,
+                Share = FileShare.None,
+                Options = FileOptions.WriteThrough
+            });
+        using (var writer = new StreamWriter(stream, Utf8WithoutBom, bufferSize: 4096, leaveOpen: true))
+        {
+            writer.Write(contents);
+            writer.Flush();
+        }
+
+        stream.Flush(flushToDisk: true);
+    }
+
+    public void Replace(string temporaryPath, string targetPath)
+        => File.Move(temporaryPath, targetPath, overwrite: true);
+
+    public void DeleteIfExists(string path)
+    {
+        File.Delete(path);
+    }
+
+    public IEnumerable<string> EnumerateFiles(string directory)
+    {
+        try
+        {
+            return Directory.EnumerateFiles(directory).ToArray();
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return [];
+        }
+    }
+}
+
+internal sealed class EditorTypeCacheStore
+{
+    internal const int CurrentCacheVersion = 1;
+    internal const int CurrentPayloadVersion = 1;
+    internal const string EditorTypesCacheKind = "editor-types";
+
+    public static bool ShouldInvalidate(EditorTypeCacheStatus status)
+        => status is EditorTypeCacheStatus.StaleIdentity
+            or EditorTypeCacheStatus.Corrupt
+            or EditorTypeCacheStatus.UnsupportedVersion;
+
+    public static bool ShouldPersistLiveCatalog(EditorTypeCacheStatus loadStatus)
+        => loadStatus != EditorTypeCacheStatus.IoFailure;
+
+    static readonly string[] RequiredFields =
+    [
+        "cacheVersion",
+        "cacheKind",
+        "workspaceId",
+        "engineVersion",
+        "buildIdentity",
+        "producerIdentity",
+        "payloadVersion",
+        "payload"
+    ];
+
+    static readonly string[] NativeIdentityFields =
+    [
+        "workspaceIdentity",
+        "engineVersion",
+        "buildIdentity",
+        "producerIdentity"
+    ];
+
+    readonly IEditorTypeCacheFileOperations _files;
+
+    public EditorTypeCacheStore()
+        : this(new PhysicalEditorTypeCacheFileOperations())
+    {
+    }
+
+    internal EditorTypeCacheStore(IEditorTypeCacheFileOperations files)
+    {
+        _files = files ?? throw new ArgumentNullException(nameof(files));
+    }
+
+    public static EditorTypeCacheIdentity ParseNativeIdentity(string yaml)
+    {
+        var document = LoadSingleDocument(yaml);
+        var root = document.RootNode as YamlMappingNode
+            ?? throw new InvalidDataException("The native workspace cache identity root must be a mapping.");
+        var fields = ReadStrictFields(root);
+        foreach (var field in NativeIdentityFields)
+        {
+            if (!fields.TryGetValue(field, out var value) || !TryReadRequiredScalar(value, out _))
+                throw new InvalidDataException($"Native workspace cache identity field '{field}' must be a non-empty scalar.");
+        }
+        if (fields.Count != NativeIdentityFields.Length)
+        {
+            var unknown = fields.Keys.Except(NativeIdentityFields, StringComparer.Ordinal).Order().First();
+            throw new InvalidDataException($"Unknown native workspace cache identity field '{unknown}'.");
+        }
+
+        return new EditorTypeCacheIdentity(
+            ((YamlScalarNode)fields["workspaceIdentity"]).Value!,
+            ((YamlScalarNode)fields["engineVersion"]).Value!,
+            ((YamlScalarNode)fields["buildIdentity"]).Value!,
+            ((YamlScalarNode)fields["producerIdentity"]).Value!);
+    }
+
+    public EditorTypeCacheLoadResult Load(
+        string cacheFilePath,
+        EditorTypeCacheIdentity expectedIdentity)
+    {
+        var fullPath = NormalizePath(cacheFilePath);
+        ValidateIdentity(expectedIdentity);
+
+        try
+        {
+            var yaml = _files.ReadAllText(fullPath);
+            return Parse(fullPath, yaml, expectedIdentity);
+        }
+        catch (FileNotFoundException)
+        {
+            return Missing(fullPath);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return Missing(fullPath);
+        }
+        catch (DecoderFallbackException ex)
+        {
+            return Corrupt(fullPath, $"The file is not valid UTF-8: {ex.Message}");
+        }
+        catch (Exception ex)
+        {
+            return new EditorTypeCacheLoadResult(
+                EditorTypeCacheStatus.IoFailure,
+                $"Cannot read editor type cache '{fullPath}': {ex.Message}");
+        }
+    }
+
+    public EditorTypeCacheWriteResult Save(
+        string cacheFilePath,
+        EditorTypeCacheIdentity identity,
+        string payload)
+    {
+        var fullPath = NormalizePath(cacheFilePath);
+        ValidateIdentity(identity);
+
+        if (!TryValidatePayload(payload, out var payloadError))
+        {
+            return new EditorTypeCacheWriteResult(
+                false,
+                $"Cannot save editor type cache '{fullPath}': payload is corrupt: {payloadError}");
+        }
+
+        string? temporaryPath = null;
+        Exception? writeFailure = null;
+        Exception? cleanupFailure = null;
+        try
+        {
+            var directory = Path.GetDirectoryName(fullPath)
+                ?? throw new InvalidOperationException("The cache path does not have a parent directory.");
+            _files.CreateDirectory(directory);
+
+            temporaryPath = Path.Combine(
+                directory,
+                $".{Path.GetFileName(fullPath)}.{Guid.NewGuid():N}.tmp");
+            var envelope = Serialize(identity, payload);
+            _files.WriteAllTextDurably(temporaryPath, envelope);
+            _files.Replace(temporaryPath, fullPath);
+        }
+        catch (Exception ex)
+        {
+            writeFailure = ex;
+        }
+        finally
+        {
+            if (temporaryPath is not null)
+            {
+                try
+                {
+                    _files.DeleteIfExists(temporaryPath);
+                }
+                catch (Exception ex)
+                {
+                    cleanupFailure = ex;
+                }
+            }
+        }
+
+        if (writeFailure is null && cleanupFailure is null)
+        {
+            return new EditorTypeCacheWriteResult(
+                true,
+                $"Saved editor type cache: '{fullPath}'.");
+        }
+
+        var diagnostic = writeFailure is null
+            ? $"Cannot clean editor type cache temporary file for '{fullPath}': {cleanupFailure!.Message}"
+            : $"Cannot atomically save editor type cache '{fullPath}': {writeFailure.Message}";
+        if (writeFailure is not null && cleanupFailure is not null)
+        {
+            diagnostic += $" Temporary-file cleanup also failed: {cleanupFailure.Message}";
+        }
+
+        return new EditorTypeCacheWriteResult(false, diagnostic);
+    }
+
+    public EditorTypeCacheWriteResult Invalidate(string cacheFilePath)
+    {
+        var fullPath = NormalizePath(cacheFilePath);
+        var directory = Path.GetDirectoryName(fullPath)
+            ?? throw new InvalidOperationException("The cache path does not have a parent directory.");
+        var failures = new List<string>();
+
+        try
+        {
+            _files.DeleteIfExists(fullPath);
+        }
+        catch (Exception ex)
+        {
+            failures.Add($"target deletion failed: {ex.Message}");
+        }
+
+        try
+        {
+            foreach (var candidate in _files.EnumerateFiles(directory))
+            {
+                if (!IsOwnedTemporaryFile(fullPath, candidate))
+                    continue;
+
+                try
+                {
+                    _files.DeleteIfExists(candidate);
+                }
+                catch (Exception ex)
+                {
+                    failures.Add($"temporary-file deletion failed for '{candidate}': {ex.Message}");
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            failures.Add($"temporary-file discovery failed: {ex.Message}");
+        }
+
+        return failures.Count == 0
+            ? new EditorTypeCacheWriteResult(
+                true,
+                $"Invalidated editor type cache: '{fullPath}'.")
+            : new EditorTypeCacheWriteResult(
+                false,
+                $"Cannot completely invalidate editor type cache '{fullPath}': {string.Join("; ", failures)}");
+    }
+
+    static EditorTypeCacheLoadResult Parse(
+        string cacheFilePath,
+        string yaml,
+        EditorTypeCacheIdentity expectedIdentity)
+    {
+        YamlMappingNode root;
+        Dictionary<string, YamlNode> fields;
+        try
+        {
+            var document = LoadSingleDocument(yaml);
+            root = document.RootNode as YamlMappingNode
+                ?? throw new InvalidDataException("The envelope root must be a mapping.");
+            fields = ReadStrictFields(root);
+        }
+        catch (Exception ex)
+        {
+            return Corrupt(cacheFilePath, ex.Message);
+        }
+
+        if (!fields.TryGetValue("cacheVersion", out var cacheVersionNode))
+        {
+            return Unsupported(
+                cacheFilePath,
+                "cacheVersion is missing; raw and unversioned caches are not supported.");
+        }
+
+        if (!TryReadVersion(cacheVersionNode, out var cacheVersion))
+            return Corrupt(cacheFilePath, "cacheVersion must be an integer scalar.");
+        if (cacheVersion != CurrentCacheVersion)
+        {
+            return Unsupported(
+                cacheFilePath,
+                $"cacheVersion {cacheVersion} is unsupported; expected {CurrentCacheVersion}.");
+        }
+
+        if (!fields.TryGetValue("payloadVersion", out var payloadVersionNode))
+        {
+            return Unsupported(
+                cacheFilePath,
+                "payloadVersion is missing; unversioned payloads are not supported.");
+        }
+
+        if (!TryReadVersion(payloadVersionNode, out var payloadVersion))
+            return Corrupt(cacheFilePath, "payloadVersion must be an integer scalar.");
+        if (payloadVersion != CurrentPayloadVersion)
+        {
+            return Unsupported(
+                cacheFilePath,
+                $"payloadVersion {payloadVersion} is unsupported; expected {CurrentPayloadVersion}.");
+        }
+
+        foreach (var field in RequiredFields)
+        {
+            if (!fields.ContainsKey(field))
+                return Corrupt(cacheFilePath, $"Required field '{field}' is missing.");
+        }
+
+        if (fields.Count != RequiredFields.Length)
+        {
+            var unknown = fields.Keys.Except(RequiredFields, StringComparer.Ordinal).Order().First();
+            return Corrupt(cacheFilePath, $"Unknown field '{unknown}' is not allowed by cacheVersion {CurrentCacheVersion}.");
+        }
+
+        var expectedFields = new (string Name, string Value)[]
+        {
+            ("cacheKind", EditorTypesCacheKind),
+            ("workspaceId", expectedIdentity.WorkspaceIdentity),
+            ("engineVersion", expectedIdentity.EngineVersion),
+            ("buildIdentity", expectedIdentity.BuildIdentity),
+            ("producerIdentity", expectedIdentity.ProducerIdentity)
+        };
+        foreach (var (name, expected) in expectedFields)
+        {
+            if (!TryReadRequiredScalar(fields[name], out var actual))
+                return Corrupt(cacheFilePath, $"Field '{name}' must be a non-empty scalar.");
+            if (!string.Equals(actual, expected, StringComparison.Ordinal))
+            {
+                return new EditorTypeCacheLoadResult(
+                    EditorTypeCacheStatus.StaleIdentity,
+                    $"Editor type cache '{cacheFilePath}' has stale {name}: expected '{expected}', found '{actual}'.");
+            }
+        }
+
+        if (!TryReadRequiredScalar(fields["payload"], out var payload))
+            return Corrupt(cacheFilePath, "Field 'payload' must be a non-empty scalar.");
+        if (!TryValidatePayload(payload, out var payloadError))
+            return Corrupt(cacheFilePath, $"Payload is corrupt: {payloadError}");
+
+        return new EditorTypeCacheLoadResult(
+            EditorTypeCacheStatus.Loaded,
+            $"Loaded editor type cache: '{cacheFilePath}'.",
+            payload);
+    }
+
+    static Dictionary<string, YamlNode> ReadStrictFields(YamlMappingNode root)
+    {
+        var result = new Dictionary<string, YamlNode>(StringComparer.Ordinal);
+        foreach (var pair in root.Children)
+        {
+            if (pair.Key is not YamlScalarNode key || string.IsNullOrWhiteSpace(key.Value))
+                throw new InvalidDataException("Envelope field names must be non-empty scalars.");
+            if (!result.TryAdd(key.Value, pair.Value))
+                throw new InvalidDataException($"Envelope field '{key.Value}' is duplicated.");
+        }
+
+        return result;
+    }
+
+    static YamlDocument LoadSingleDocument(string yaml)
+    {
+        if (string.IsNullOrWhiteSpace(yaml))
+            throw new InvalidDataException("The YAML document is empty.");
+
+        var stream = new YamlStream();
+        using var reader = new StringReader(yaml);
+        stream.Load(reader);
+        if (stream.Documents.Count != 1)
+            throw new InvalidDataException("Exactly one YAML document is required.");
+        return stream.Documents[0];
+    }
+
+    static bool TryValidatePayload(string payload, out string error)
+    {
+        try
+        {
+            var document = LoadSingleDocument(payload);
+            if (document.RootNode is not YamlMappingNode)
+                throw new InvalidDataException("The type-catalog root must be a mapping.");
+
+            error = string.Empty;
+            return true;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+            return false;
+        }
+    }
+
+    static string Serialize(EditorTypeCacheIdentity identity, string payload)
+    {
+        var root = new YamlMappingNode
+        {
+            { "cacheVersion", CurrentCacheVersion.ToString(CultureInfo.InvariantCulture) },
+            { "cacheKind", EditorTypesCacheKind },
+            { "workspaceId", identity.WorkspaceIdentity },
+            { "engineVersion", identity.EngineVersion },
+            { "buildIdentity", identity.BuildIdentity },
+            { "producerIdentity", identity.ProducerIdentity },
+            { "payloadVersion", CurrentPayloadVersion.ToString(CultureInfo.InvariantCulture) },
+            { new YamlScalarNode("payload"), new YamlScalarNode(payload) { Style = ScalarStyle.Literal } }
+        };
+        var stream = new YamlStream(new YamlDocument(root));
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        stream.Save(writer, assignAnchors: false);
+        return writer.ToString();
+    }
+
+    static bool TryReadVersion(YamlNode node, out int version)
+    {
+        version = 0;
+        return node is YamlScalarNode scalar &&
+            int.TryParse(
+                scalar.Value,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out version);
+    }
+
+    static bool TryReadRequiredScalar(YamlNode node, out string value)
+    {
+        if (node is YamlScalarNode scalar && !string.IsNullOrWhiteSpace(scalar.Value))
+        {
+            value = scalar.Value;
+            return true;
+        }
+
+        value = string.Empty;
+        return false;
+    }
+
+    static bool IsOwnedTemporaryFile(string targetPath, string candidatePath)
+    {
+        var targetDirectory = Path.GetDirectoryName(targetPath);
+        var candidateDirectory = Path.GetDirectoryName(Path.GetFullPath(candidatePath));
+        if (!string.Equals(targetDirectory, candidateDirectory, PathComparison))
+            return false;
+
+        var filename = Path.GetFileName(candidatePath);
+        var prefix = $".{Path.GetFileName(targetPath)}.";
+        const string suffix = ".tmp";
+        if (!filename.StartsWith(prefix, StringComparison.Ordinal) ||
+            !filename.EndsWith(suffix, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        var token = filename[prefix.Length..^suffix.Length];
+        return token.Length == 32 && token.All(Uri.IsHexDigit);
+    }
+
+    static EditorTypeCacheLoadResult Unsupported(string path, string detail)
+        => new(
+            EditorTypeCacheStatus.UnsupportedVersion,
+            $"Editor type cache '{path}' has an unsupported format: {detail}");
+
+    static EditorTypeCacheLoadResult Corrupt(string path, string detail)
+        => new(
+            EditorTypeCacheStatus.Corrupt,
+            $"Editor type cache '{path}' is corrupt: {detail}");
+
+    static EditorTypeCacheLoadResult Missing(string path)
+        => new(
+            EditorTypeCacheStatus.Missing,
+            $"Editor type cache is missing: '{path}'.");
+
+    static string NormalizePath(string cacheFilePath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(cacheFilePath);
+        return Path.GetFullPath(cacheFilePath);
+    }
+
+    static void ValidateIdentity(EditorTypeCacheIdentity identity)
+    {
+        ArgumentNullException.ThrowIfNull(identity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity.WorkspaceIdentity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity.EngineVersion);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity.BuildIdentity);
+        ArgumentException.ThrowIfNullOrWhiteSpace(identity.ProducerIdentity);
+    }
+
+    static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+}

--- a/Editor/Services/EngineLaunchContract.cs
+++ b/Editor/Services/EngineLaunchContract.cs
@@ -1,12 +1,15 @@
 #nullable enable
 
+using SailorEditor.Workspace;
+
 namespace SailorEditor.Services;
 
 public sealed record EngineLaunchContext(
     string WorkspaceRoot,
     string? WorkspaceManifestPath,
     string ContentDirectory,
-    string CacheDirectory)
+    string CacheDirectory,
+    string WorkspaceIdentity)
 {
     public string TempWorldFilePath => Path.Combine(CacheDirectory, "Temp.world");
     public string TempWorldRuntimePath => Path.GetRelativePath(ContentDirectory, TempWorldFilePath);
@@ -51,7 +54,8 @@ public static class EngineLaunchContract
         string? activeWorkspaceManifestPath,
         string? activeContentDirectory,
         string? activeCacheDirectory,
-        string fallbackRoot)
+        string fallbackRoot,
+        string? activeWorkspaceIdentity = null)
     {
         var hasActiveWorkspace = !string.IsNullOrWhiteSpace(activeWorkspaceRoot);
         var selectedRoot = hasActiveWorkspace ? activeWorkspaceRoot : fallbackRoot;
@@ -69,7 +73,35 @@ public static class EngineLaunchContract
             NormalizeRoot(selectedRoot!),
             manifestPath,
             NormalizeRoot(selectedContentDirectory),
-            NormalizeRoot(selectedCacheDirectory));
+            NormalizeRoot(selectedCacheDirectory),
+            ResolveWorkspaceIdentity(hasActiveWorkspace ? activeWorkspaceIdentity : null, selectedRoot!));
+    }
+
+    static string ResolveWorkspaceIdentity(string? workspaceIdentity, string workspaceRoot)
+    {
+        if (!string.IsNullOrWhiteSpace(workspaceIdentity))
+            return workspaceIdentity.Trim();
+
+        var normalizedRoot = WorkspacePathPolicy.NormalizePhysicalPath(workspaceRoot)
+            .Replace(Path.DirectorySeparatorChar, '/');
+        if (Path.AltDirectorySeparatorChar != Path.DirectorySeparatorChar)
+            normalizedRoot = normalizedRoot.Replace(Path.AltDirectorySeparatorChar, '/');
+        if (OperatingSystem.IsWindows())
+            normalizedRoot = FoldAsciiCase(normalizedRoot);
+
+        return $"legacy-root:{normalizedRoot}";
+    }
+
+    static string FoldAsciiCase(string value)
+    {
+        var characters = value.ToCharArray();
+        for (var index = 0; index < characters.Length; ++index)
+        {
+            if (characters[index] is >= 'A' and <= 'Z')
+                characters[index] = (char)(characters[index] + ('a' - 'A'));
+        }
+
+        return new string(characters);
     }
 
     static string RequireResolvedPath(string? path, string parameterName)

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -42,7 +42,22 @@ namespace SailorEngine
         const string EngineLibrary = "../../../../../Sailor-Release.dll";
 #endif
 
-        [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void Initialize(string[] commandLineArgs, int num);
+        [DllImport(EngineLibrary, EntryPoint = "Initialize", ExactSpelling = true, CallingConvention = CallingConvention.Cdecl)]
+        static extern void InitializeNative([In] nint[] commandLineArgs, int num);
+
+        public static void Initialize(string[] commandLineArgs, int num)
+        {
+            var nativeArguments = Utf8InteropArguments.Allocate(commandLineArgs, num);
+            try
+            {
+                InitializeNative(nativeArguments, num);
+            }
+            finally
+            {
+                Utf8InteropArguments.Free(nativeArguments);
+            }
+        }
+
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void Start();
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void Stop();
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void Shutdown();
@@ -50,6 +65,7 @@ namespace SailorEngine
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern uint GetMessages(nint[] messages, uint num);
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern uint SerializeCurrentWorld(nint[] yamlNode);
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern uint SerializeEditorTypes(nint[] yamlNode);
+        [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern uint SerializeWorkspaceCacheIdentity(nint[] yamlNode);
         [return: MarshalAs(UnmanagedType.I1)]
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool LoadEditorWorld(string strFileId);
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void SetViewport(uint windowPosX, uint windowPosY, uint width, uint height);
@@ -184,6 +200,7 @@ namespace SailorEditor.Services
 
         readonly string repoRoot = ResolveRepoRoot();
         readonly WorkspaceLifecycleService workspaceLifecycle;
+        readonly EditorTypeCacheStore editorTypeCacheStore = new();
 
         public EngineService(WorkspaceLifecycleService workspaceLifecycle)
         {
@@ -257,7 +274,8 @@ namespace SailorEditor.Services
                 workspace?.ManifestPath,
                 workspace?.ContentDirectory,
                 workspace?.CacheDirectory,
-                EngineWorkingDirectory);
+                EngineWorkingDirectory,
+                workspace?.Manifest.WorkspaceId);
         }
 
         public string PathToEngineExecDebug
@@ -683,7 +701,6 @@ namespace SailorEditor.Services
                 var args = await BuildInteropArgumentsAsync(launchContext, bDebug, commandLineArgs).ConfigureAwait(false);
                 Console.WriteLine($"Starting SailorEngine interop with workspace: {launchContext.WorkspaceRoot}");
                 Volatile.Write(ref editorTypes, new EngineTypes());
-                TryLoadEditorTypesFromFile("startup cache", launchContext.EditorTypesCacheFilePath);
 
 #if MACCATALYST
                 await MainThread.InvokeOnMainThreadAsync(() =>
@@ -709,15 +726,71 @@ namespace SailorEditor.Services
                         initializationExitCode);
                 }
 
+                var editorTypeCacheIdentity = ReadWorkspaceCacheIdentity(
+                    generation,
+                    launchContext,
+                    allowStarting: true);
+                var cachedEditorTypes = editorTypeCacheStore.Load(
+                    launchContext.EditorTypesCacheFilePath,
+                    editorTypeCacheIdentity);
+                if (cachedEditorTypes.Succeeded)
+                {
+                    if (!TryParseEditorTypes(
+                            cachedEditorTypes.Payload!,
+                            out _,
+                            out var cachedCatalogError))
+                    {
+                        Console.WriteLine(
+                            $"Editor type cache payload is invalid: {cachedCatalogError}");
+                        LogEditorTypeCacheInvalidation(
+                            launchContext.EditorTypesCacheFilePath,
+                            "invalid cached catalog");
+                    }
+                }
+                else if (EditorTypeCacheStore.ShouldInvalidate(cachedEditorTypes.Status))
+                {
+                    Console.WriteLine(cachedEditorTypes.Diagnostic);
+                    LogEditorTypeCacheInvalidation(
+                        launchContext.EditorTypesCacheFilePath,
+                        cachedEditorTypes.Status.ToString());
+                }
+                else if (cachedEditorTypes.Status == EditorTypeCacheStatus.IoFailure)
+                {
+                    Console.WriteLine(cachedEditorTypes.Diagnostic);
+                }
+
                 // Required startup order: combined editor catalog, world, then initial messages.
                 string serializedEditorTypes = SerializeEditorTypes(generation, allowStarting: true);
-                if (TryReplaceEditorTypes(serializedEditorTypes, out var catalogError))
+                if (TryParseEditorTypes(
+                        serializedEditorTypes,
+                        out var liveEditorTypes,
+                        out var catalogError))
                 {
-                    SaveEditorTypesToFile(serializedEditorTypes, launchContext.EditorTypesCacheFilePath);
+                    Volatile.Write(ref editorTypes, liveEditorTypes);
+                    if (EditorTypeCacheStore.ShouldPersistLiveCatalog(cachedEditorTypes.Status))
+                    {
+                        var cacheWrite = editorTypeCacheStore.Save(
+                            launchContext.EditorTypesCacheFilePath,
+                            editorTypeCacheIdentity,
+                            serializedEditorTypes);
+                        if (!cacheWrite.Succeeded)
+                            Console.WriteLine(cacheWrite.Diagnostic);
+                    }
+                    else
+                    {
+                        Console.WriteLine(
+                            $"Preserving editor type cache after {cachedEditorTypes.Status}: '{launchContext.EditorTypesCacheFilePath}'.");
+                    }
                 }
                 else
                 {
                     Volatile.Write(ref editorTypes, new EngineTypes());
+                    if (cachedEditorTypes.Status != EditorTypeCacheStatus.IoFailure)
+                    {
+                        LogEditorTypeCacheInvalidation(
+                            launchContext.EditorTypesCacheFilePath,
+                            "invalid live catalog");
+                    }
                     throw new EngineLifecycleException(
                         $"SailorEngine returned an invalid editor type catalog: {catalogError}",
                         -1);
@@ -1264,6 +1337,74 @@ namespace SailorEditor.Services
             }
         }
 
+        EditorTypeCacheIdentity ReadWorkspaceCacheIdentity(
+            long generation,
+            EngineLaunchContext launchContext,
+            bool allowStarting = false)
+        {
+            if (!IsGenerationActive(generation, allowStarting))
+            {
+                throw new EngineLifecycleException(
+                    "The engine generation changed before workspace cache identity could be read.",
+                    -1);
+            }
+
+            nint[] yamlNodeChar = new nint[1];
+            uint numChars;
+            lock (interopLock)
+            {
+                if (!IsGenerationActive(generation, allowStarting))
+                {
+                    throw new EngineLifecycleException(
+                        "The engine generation changed before workspace cache identity could be read.",
+                        -1);
+                }
+                numChars = EngineAppInterop.SerializeWorkspaceCacheIdentity(yamlNodeChar);
+            }
+
+            if (numChars == 0 || yamlNodeChar[0] == nint.Zero)
+            {
+                throw new EngineLifecycleException(
+                    "SailorEngine did not provide a workspace cache identity.",
+                    -1);
+            }
+
+            string yaml;
+            try
+            {
+                yaml = Marshal.PtrToStringUTF8(yamlNodeChar[0], (int)numChars) ?? string.Empty;
+            }
+            finally
+            {
+                EngineAppInterop.FreeInteropString(yamlNodeChar[0]);
+            }
+
+            EditorTypeCacheIdentity identity;
+            try
+            {
+                identity = EditorTypeCacheStore.ParseNativeIdentity(yaml);
+            }
+            catch (Exception ex)
+            {
+                throw new EngineLifecycleException(
+                    $"SailorEngine returned an invalid workspace cache identity: {ex.Message}",
+                    -1,
+                    ex);
+            }
+
+            if (!string.Equals(
+                    identity.WorkspaceIdentity,
+                    launchContext.WorkspaceIdentity,
+                    StringComparison.Ordinal))
+            {
+                throw new EngineLifecycleException(
+                    $"SailorEngine workspace identity mismatch. Expected '{launchContext.WorkspaceIdentity}', received '{identity.WorkspaceIdentity}'.",
+                    -1);
+            }
+
+            return identity;
+        }
+
         void QueueWorldUpdate(string serializedWorld, long generation)
         {
             if (string.IsNullOrEmpty(serializedWorld) || !IsGenerationActive(generation, allowStarting: true))
@@ -1280,90 +1421,38 @@ namespace SailorEditor.Services
             });
         }
 
-        bool TryLoadEditorTypesFromFile(string reason, string cacheFilePath)
+        static bool TryParseEditorTypes(
+            string yaml,
+            out EngineTypes catalog,
+            out string error)
         {
             try
             {
-                if (!File.Exists(cacheFilePath))
-                {
-                    return false;
-                }
-
-                string yaml = File.ReadAllText(cacheFilePath);
-                if (string.IsNullOrWhiteSpace(yaml))
-                {
-                    return false;
-                }
-
-                if (!TryReplaceEditorTypes(yaml, out var error))
-                {
-                    Console.WriteLine($"Cannot load editor type catalog cache ({reason}): {error}");
-                    return false;
-                }
-
-                Console.WriteLine($"Loaded editor type catalog from cache ({reason}): {cacheFilePath}");
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Cannot load editor type catalog cache ({reason}): {ex.Message}");
-                return false;
-            }
-        }
-
-        bool TryReplaceEditorTypes(string yaml, out string error)
-        {
-            try
-            {
-                var catalog = EngineTypes.FromYaml(yaml);
+                catalog = EngineTypes.FromYaml(yaml);
                 if (catalog.Components.Count == 0 && catalog.Enums.Count == 0 && catalog.AssetTypes.Count == 0)
                 {
                     error = "The catalog does not contain any reflected or asset types.";
+                    catalog = new EngineTypes();
                     return false;
                 }
 
-                Volatile.Write(ref editorTypes, catalog);
                 error = string.Empty;
                 return true;
             }
             catch (Exception ex)
             {
+                catalog = new EngineTypes();
                 error = ex.Message;
                 return false;
             }
         }
 
-        void SaveEditorTypesToFile(string yaml, string cacheFilePath)
+        void LogEditorTypeCacheInvalidation(string cacheFilePath, string reason)
         {
-            if (string.IsNullOrWhiteSpace(yaml))
-            {
-                return;
-            }
-
-            try
-            {
-                string directory = Path.GetDirectoryName(cacheFilePath);
-                if (!string.IsNullOrEmpty(directory))
-                {
-                    Directory.CreateDirectory(directory);
-                }
-
-                var temporaryPath = $"{cacheFilePath}.{Guid.NewGuid():N}.tmp";
-                try
-                {
-                    File.WriteAllText(temporaryPath, yaml);
-                    File.Move(temporaryPath, cacheFilePath, true);
-                }
-                finally
-                {
-                    if (File.Exists(temporaryPath))
-                        File.Delete(temporaryPath);
-                }
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Cannot save editor type catalog cache: {ex.Message}");
-            }
+            var invalidation = editorTypeCacheStore.Invalidate(cacheFilePath);
+            Console.WriteLine(invalidation.Succeeded
+                ? $"Invalidated editor type cache ({reason}): {cacheFilePath}"
+                : invalidation.Diagnostic);
         }
 
         public bool CommitChanges(InstanceId id, string yamlChanges)

--- a/Editor/Services/Utf8InteropArguments.cs
+++ b/Editor/Services/Utf8InteropArguments.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+using System.Runtime.InteropServices;
+
+namespace SailorEngine;
+
+internal static class Utf8InteropArguments
+{
+    public static nint[] Allocate(string[] arguments, int count)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+        if (count != arguments.Length)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(count),
+                count,
+                "The native argument count must match the managed argument array length.");
+        }
+
+        var nativeArguments = new nint[count];
+        try
+        {
+            for (var index = 0; index < count; ++index)
+            {
+                var argument = arguments[index]
+                    ?? throw new ArgumentException(
+                        $"Command-line argument {index} must not be null.",
+                        nameof(arguments));
+                if (argument.Contains('\0', StringComparison.Ordinal))
+                {
+                    throw new ArgumentException(
+                        $"Command-line argument {index} must not contain an embedded null character.",
+                        nameof(arguments));
+                }
+
+                nativeArguments[index] = Marshal.StringToCoTaskMemUTF8(argument);
+            }
+
+            return nativeArguments;
+        }
+        catch
+        {
+            Free(nativeArguments);
+            throw;
+        }
+    }
+
+    public static void Free(nint[] nativeArguments)
+    {
+        ArgumentNullException.ThrowIfNull(nativeArguments);
+        for (var index = 0; index < nativeArguments.Length; ++index)
+        {
+            if (nativeArguments[index] == nint.Zero)
+                continue;
+
+            Marshal.FreeCoTaskMem(nativeArguments[index]);
+            nativeArguments[index] = nint.Zero;
+        }
+    }
+}

--- a/Editor/Services/WorkspaceUiService.cs
+++ b/Editor/Services/WorkspaceUiService.cs
@@ -247,7 +247,8 @@ internal sealed class WorkspaceUiService
                 session.ManifestPath,
                 session.ContentDirectory,
                 session.CacheDirectory,
-                _engineService.EngineWorkingDirectory);
+                _engineService.EngineWorkingDirectory,
+                session.Manifest.WorkspaceId);
             return new WorkspaceActivationCandidate(preparation, launchContext);
         }
         catch

--- a/Lib/CMakeLists.txt
+++ b/Lib/CMakeLists.txt
@@ -173,6 +173,11 @@ target_compile_definitions(SailorLib PUBLIC NOMINMAX)
 
 target_compile_definitions(SailorLib PUBLIC $<$<CONFIG:Release>:_SHIPPING>)
 target_compile_definitions(SailorLib PRIVATE SAILOR_BUILD_CONFIG="$<CONFIG>")
+target_compile_definitions(SailorLib PRIVATE SAILOR_ENGINE_VERSION="${PROJECT_VERSION}")
+
+if(SAILOR_BUILD_TESTS)
+  target_compile_definitions(SailorLib PUBLIC $<BUILD_INTERFACE:SAILOR_SHADER_CACHE_TEST_HOOKS>)
+endif()
 
 target_compile_definitions(SailorLib INTERFACE _SAILOR_IMPORT_)
 

--- a/Lib/DllMain.cpp
+++ b/Lib/DllMain.cpp
@@ -110,6 +110,13 @@ extern "C"
 		return Sailor::App::SerializeEditorTypes(yamlNode);
 	}
 
+	SAILOR_API uint32_t SerializeWorkspaceCacheIdentity(char** yamlNode)
+	{
+		SAILOR_PROFILE_FUNCTION();
+
+		return Sailor::App::SerializeWorkspaceCacheIdentity(yamlNode);
+	}
+
 	SAILOR_API bool LoadEditorWorld(char* strFileId)
 	{
 		SAILOR_PROFILE_FUNCTION();

--- a/Lib/InteropExports.cpp
+++ b/Lib/InteropExports.cpp
@@ -99,6 +99,11 @@ extern "C"
 		return Sailor::App::SerializeEditorTypes(yamlNode);
 	}
 
+	SAILOR_API uint32_t SerializeWorkspaceCacheIdentity(char** yamlNode)
+	{
+		return Sailor::App::SerializeWorkspaceCacheIdentity(yamlNode);
+	}
+
 	SAILOR_API bool LoadEditorWorld(char* strFileId)
 	{
 		return Sailor::App::LoadEditorWorld(strFileId);

--- a/Runtime/AssetRegistry/AssetCache.cpp
+++ b/Runtime/AssetRegistry/AssetCache.cpp
@@ -1,21 +1,32 @@
 #include "AssetCache.h"
-#include <filesystem>
-#include <fstream>
-#include <iostream>
-#include <sstream>
-#include "Core/YamlSerializable.h"
-#include "Containers/ConcurrentMap.h"
+
 #include "AssetRegistry/AssetRegistry.h"
+#include "Containers/ConcurrentMap.h"
+#include "Core/YamlSerializable.h"
+#include "Sailor.h"
+#include "Tasks/Tasks.h"
 
 #include <algorithm>
 #include <cctype>
+#include <filesystem>
+#include <sstream>
+#include <unordered_set>
 
 using namespace Sailor;
 
 namespace
 {
+	constexpr const char* AssetCacheKind = "asset-cache";
+	constexpr const char* AssetCacheProducer = "asset-cache-v1";
+	constexpr uint32_t AssetCachePayloadVersion = 1;
+
 	std::string NormalizeSourcePath(const std::string& sourcePath)
 	{
+		if (sourcePath.empty())
+		{
+			return {};
+		}
+
 		std::error_code error;
 		std::string result = std::filesystem::weakly_canonical(sourcePath, error).generic_string();
 		if (error)
@@ -30,6 +41,120 @@ namespace
 #endif
 		return result;
 	}
+
+	Workspace::WorkspaceCacheIdentity MakeExpectedIdentity()
+	{
+		return Workspace::MakeWorkspaceCacheIdentity(
+			AssetCacheKind,
+			AssetCacheProducer,
+			AssetCachePayloadVersion,
+			App::GetWorkspaceContext());
+	}
+
+	bool ReadRequiredField(
+		const YAML::Node& map,
+		const char* fieldName,
+		YAML::Node& outField,
+		std::string& outDiagnostic)
+	{
+		if (!map.IsMap())
+		{
+			outDiagnostic = "Asset cache payload field container must be a YAML map.";
+			return false;
+		}
+
+		uint32_t matches = 0;
+		for (const auto& field : map)
+		{
+			if (field.first.IsScalar() && field.first.Scalar() == fieldName)
+			{
+				outField = field.second;
+				++matches;
+			}
+		}
+
+		if (matches != 1)
+		{
+			outDiagnostic = matches == 0
+				? "Asset cache payload is missing required field '" + std::string(fieldName) + "'."
+				: "Asset cache payload contains duplicate field '" + std::string(fieldName) + "'.";
+			return false;
+		}
+
+		return true;
+	}
+
+	void AppendDiagnostic(std::string& diagnostic, const std::string& suffix)
+	{
+		if (suffix.empty())
+		{
+			return;
+		}
+
+		if (!diagnostic.empty())
+		{
+			diagnostic += " ";
+		}
+		diagnostic += suffix;
+	}
+
+	const char* CacheLoadStatusName(Workspace::EWorkspaceCacheLoadStatus status) noexcept
+	{
+		switch (status)
+		{
+		case Workspace::EWorkspaceCacheLoadStatus::Missing: return "Missing";
+		case Workspace::EWorkspaceCacheLoadStatus::Loaded: return "Loaded";
+		case Workspace::EWorkspaceCacheLoadStatus::StaleIdentity: return "StaleIdentity";
+		case Workspace::EWorkspaceCacheLoadStatus::Corrupt: return "Corrupt";
+		case Workspace::EWorkspaceCacheLoadStatus::UnsupportedVersion: return "UnsupportedVersion";
+		case Workspace::EWorkspaceCacheLoadStatus::IoFailure: return "IoFailure";
+		default: return "Unknown";
+		}
+	}
+}
+
+std::string AssetCache::SerializeAssetCachePayload(const AssetCacheData& cache)
+{
+	YAML::Node payload(YAML::NodeType::Map);
+	payload["assetCache"] = cache.Serialize();
+
+	std::ostringstream stream;
+	stream << payload;
+	return stream.str();
+}
+
+bool AssetCache::TryDeserializeAssetCachePayload(
+	const std::string& payload,
+	AssetCacheData& outData,
+	std::string& outDiagnostic) noexcept
+{
+	try
+	{
+		const YAML::Node root = YAML::Load(payload);
+		if (!root.IsMap() || root.size() != 1)
+		{
+			outDiagnostic = "Asset cache payload root must contain exactly one 'assetCache' map.";
+			return false;
+		}
+
+		YAML::Node assetCache;
+		if (!ReadRequiredField(root, "assetCache", assetCache, outDiagnostic))
+		{
+			return false;
+		}
+
+		return AssetCacheData::TryDeserialize(assetCache, outData, outDiagnostic);
+	}
+	catch (const std::exception& exception)
+	{
+		outDiagnostic = "Asset cache payload is corrupt: " + std::string(exception.what());
+		return false;
+	}
+	catch (...)
+	{
+		outDiagnostic = "Asset cache payload is corrupt: unknown YAML decoding failure.";
+		return false;
+	}
 }
 
 std::string AssetCache::GetAssetCacheFilepath()
@@ -39,58 +164,177 @@ std::string AssetCache::GetAssetCacheFilepath()
 
 YAML::Node AssetCache::AssetCacheData::Entry::Serialize() const
 {
-	YAML::Node res;
-	res["fileId"] = m_fileId;
-	res["assetImportTime"] = m_assetImportTime;
-	res["sourcePath"] = m_sourcePath;
-
-	return res;
+	YAML::Node result(YAML::NodeType::Map);
+	result["fileId"] = m_fileId;
+	result["assetImportTime"] = m_assetImportTime;
+	result["sourcePath"] = m_sourcePath;
+	return result;
 }
 
 void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 {
 	m_fileId = inData["fileId"].as<FileId>();
 	m_assetImportTime = inData["assetImportTime"].as<std::time_t>();
-	m_sourcePath.clear();
-	for (const auto& field : inData)
-	{
-		if (field.first.IsScalar() && field.first.Scalar() == "sourcePath" && field.second.IsScalar())
-		{
-			m_sourcePath = NormalizeSourcePath(field.second.as<std::string>());
-			break;
-		}
-	}
+	m_sourcePath = NormalizeSourcePath(inData["sourcePath"].as<std::string>());
 }
 
 YAML::Node AssetCache::AssetCacheData::Serialize() const
 {
-	YAML::Node res;
-	res["assets"] = m_data;
-	return res;
+	YAML::Node result(YAML::NodeType::Map);
+	YAML::Node assets(YAML::NodeType::Map);
+	for (const auto& entry : m_data)
+	{
+		assets[entry.m_first] = entry.m_second;
+	}
+	result["assets"] = assets;
+	return result;
 }
 
 void AssetCache::AssetCacheData::Deserialize(const YAML::Node& inData)
 {
-	m_data = inData["assets"].as<TConcurrentMap<FileId, AssetCache::AssetCacheData::Entry>>();
+	AssetCacheData candidate;
+	std::string diagnostic;
+	if (!TryDeserialize(inData, candidate, diagnostic))
+	{
+		throw YAML::RepresentationException(YAML::Mark::null_mark(), diagnostic);
+	}
+	m_data = std::move(candidate.m_data);
+}
+
+bool AssetCache::AssetCacheData::TryDeserialize(
+	const YAML::Node& inData,
+	AssetCacheData& outData,
+	std::string& outDiagnostic) noexcept
+{
+	try
+	{
+		if (!inData.IsMap() || inData.size() != 1)
+		{
+			outDiagnostic = "Asset cache data must contain exactly one 'assets' map.";
+			return false;
+		}
+
+		YAML::Node assets;
+		if (!ReadRequiredField(inData, "assets", assets, outDiagnostic))
+		{
+			return false;
+		}
+		if (!assets.IsMap())
+		{
+			outDiagnostic = "Asset cache field 'assets' must be a YAML map, including when empty.";
+			return false;
+		}
+
+		AssetCacheData candidate;
+		std::unordered_set<std::string> fileIds;
+		fileIds.reserve(assets.size());
+		for (const auto& serializedEntry : assets)
+		{
+			if (!serializedEntry.first.IsScalar())
+			{
+				outDiagnostic = "Asset cache contains a non-scalar file id.";
+				return false;
+			}
+
+			const std::string serializedFileId = serializedEntry.first.Scalar();
+			if (!fileIds.emplace(serializedFileId).second)
+			{
+				outDiagnostic = "Asset cache contains duplicate file id '" + serializedFileId + "'.";
+				return false;
+			}
+
+			const FileId fileId = serializedEntry.first.as<FileId>();
+			if (!fileId)
+			{
+				outDiagnostic = "Asset cache contains invalid file id '" + serializedFileId + "'.";
+				return false;
+			}
+
+			const YAML::Node entryNode = serializedEntry.second;
+			if (!entryNode.IsMap() || entryNode.size() != 3)
+			{
+				outDiagnostic = "Asset cache entry '" + serializedFileId +
+					"' must contain exactly fileId, assetImportTime, and sourcePath.";
+				return false;
+			}
+
+			YAML::Node entryFileId;
+			YAML::Node assetImportTime;
+			YAML::Node sourcePath;
+			if (!ReadRequiredField(entryNode, "fileId", entryFileId, outDiagnostic) ||
+				!ReadRequiredField(entryNode, "assetImportTime", assetImportTime, outDiagnostic) ||
+				!ReadRequiredField(entryNode, "sourcePath", sourcePath, outDiagnostic))
+			{
+				return false;
+			}
+			if (!entryFileId.IsScalar() || !assetImportTime.IsScalar() || !sourcePath.IsScalar())
+			{
+				outDiagnostic = "Asset cache entry '" + serializedFileId + "' contains a non-scalar field.";
+				return false;
+			}
+
+			AssetCacheData::Entry entry;
+			entry.m_fileId = entryFileId.as<FileId>();
+			entry.m_assetImportTime = assetImportTime.as<std::time_t>();
+			const std::string serializedSourcePath = sourcePath.as<std::string>();
+			if (serializedSourcePath.empty())
+			{
+				outDiagnostic = "Asset cache entry '" + serializedFileId + "' has an empty sourcePath.";
+				return false;
+			}
+			entry.m_sourcePath = NormalizeSourcePath(serializedSourcePath);
+			if (!entry.m_fileId || entry.m_fileId != fileId)
+			{
+				outDiagnostic = "Asset cache entry '" + serializedFileId + "' has a mismatched fileId field.";
+				return false;
+			}
+			if (entry.m_sourcePath.empty())
+			{
+				outDiagnostic = "Asset cache entry '" + serializedFileId + "' has an empty sourcePath.";
+				return false;
+			}
+
+			candidate.m_data.Insert(fileId, std::move(entry));
+		}
+
+		outData.m_data = std::move(candidate.m_data);
+		outDiagnostic.clear();
+		return true;
+	}
+	catch (const std::exception& exception)
+	{
+		outDiagnostic = "Asset cache data is corrupt: " + std::string(exception.what());
+		return false;
+	}
+	catch (...)
+	{
+		outDiagnostic = "Asset cache data is corrupt: unknown payload decoding failure.";
+		return false;
+	}
+}
+
+bool AssetCache::ShouldResetCacheFile(Workspace::EWorkspaceCacheLoadStatus status) noexcept
+{
+	return status == Workspace::EWorkspaceCacheLoadStatus::Missing ||
+		status == Workspace::EWorkspaceCacheLoadStatus::StaleIdentity ||
+		status == Workspace::EWorkspaceCacheLoadStatus::Corrupt ||
+		status == Workspace::EWorkspaceCacheLoadStatus::UnsupportedVersion;
+}
+
+bool AssetCache::ShouldWriteCacheFile(
+	bool bForcely,
+	bool bIsDirty,
+	bool bPreserveStorageAfterLoadFailure) noexcept
+{
+	return bForcely || (!bPreserveStorageAfterLoadFailure && bIsDirty);
 }
 
 void AssetCache::Initialize()
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	std::filesystem::create_directories(AssetRegistry::GetCacheFolder());
-
-	auto assetCacheFilePath = std::filesystem::path(GetAssetCacheFilepath());
-	if (!std::filesystem::exists(GetAssetCacheFilepath()))
-	{
-		YAML::Node outData;
-		outData["assetCache"] = m_cache.Serialize();
-
-		std::ofstream assetFile(assetCacheFilePath);
-		assetFile << outData;
-		assetFile.close();
-	}
-
+	std::error_code createError;
+	std::filesystem::create_directories(AssetRegistry::GetCacheFolder(), createError);
 	LoadCache();
 }
 
@@ -103,16 +347,27 @@ void AssetCache::SaveCache(bool bForcely)
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	if (bForcely || m_bIsDirty)
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	if (!ShouldWriteCacheFile(bForcely, m_bIsDirty, m_bPreserveStorageAfterLoadFailure))
 	{
-		YAML::Node outData;
-		outData["assetCache"] = m_cache.Serialize();
+		return;
+	}
+	if (bForcely)
+	{
+		m_bPreserveStorageAfterLoadFailure = false;
+	}
 
-		std::ofstream assetFile(GetAssetCacheFilepath());
-		assetFile << outData;
-		assetFile.close();
-
+	std::string diagnostic;
+	if (WriteCacheLocked(diagnostic))
+	{
 		m_bIsDirty = false;
+		m_lastSaveDiagnostic.clear();
+	}
+	else
+	{
+		m_bIsDirty = true;
+		m_lastSaveDiagnostic = std::move(diagnostic);
+		SAILOR_LOG_ERROR("Asset cache save failed: %s", m_lastSaveDiagnostic.c_str());
 	}
 }
 
@@ -120,39 +375,186 @@ void AssetCache::LoadCache()
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	std::string yaml;
-	AssetRegistry::ReadAllTextFile(GetAssetCacheFilepath(), yaml);
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	Workspace::WorkspaceCacheLoadResult loadResult;
+	try
+	{
+		const auto identity = MakeExpectedIdentity();
+		loadResult = Workspace::LoadWorkspaceCacheEnvelope(GetAssetCacheFilepath(), identity);
+	}
+	catch (const std::exception& exception)
+	{
+		loadResult.m_status = Workspace::EWorkspaceCacheLoadStatus::IoFailure;
+		loadResult.m_diagnostic = "Cannot construct the expected asset cache identity: " +
+			std::string(exception.what());
+	}
+	catch (...)
+	{
+		loadResult.m_status = Workspace::EWorkspaceCacheLoadStatus::IoFailure;
+		loadResult.m_diagnostic = "Cannot construct the expected asset cache identity: unknown failure.";
+	}
+	if (loadResult.IsLoaded())
+	{
+		AssetCacheData candidate;
+		std::string diagnostic;
+		if (TryDeserializeAssetCachePayload(loadResult.m_payload, candidate, diagnostic))
+		{
+			m_cache.m_data = std::move(candidate.m_data);
+			m_bIsDirty = false;
+			m_bPreserveStorageAfterLoadFailure = false;
+			m_lastSaveDiagnostic.clear();
+			m_lastLoadResult = std::move(loadResult);
+			return;
+		}
 
-	YAML::Node yamlNode = YAML::Load(yaml);
-	m_cache.Deserialize(yamlNode["assetCache"]);
+		loadResult.m_status = Workspace::EWorkspaceCacheLoadStatus::Corrupt;
+		loadResult.m_diagnostic = std::move(diagnostic);
+		loadResult.m_payload.clear();
+	}
+	else if (!ShouldResetCacheFile(loadResult.m_status))
+	{
+		m_cache.m_data.Clear();
+		m_bIsDirty = false;
+		m_bPreserveStorageAfterLoadFailure = true;
+		m_lastSaveDiagnostic.clear();
+		m_lastLoadResult = std::move(loadResult);
+		SAILOR_LOG_ERROR(
+			"Asset cache load status=%s: %s The existing cache file was preserved.",
+			CacheLoadStatusName(m_lastLoadResult.m_status),
+			m_lastLoadResult.m_diagnostic.c_str());
+		return;
+	}
 
-	m_bIsDirty = false;
+	ResetInvalidCacheLocked(std::move(loadResult));
+}
+
+bool AssetCache::WriteCacheLocked(std::string& outDiagnostic) noexcept
+{
+	try
+	{
+		std::string envelope;
+		const auto identity = MakeExpectedIdentity();
+		if (!Workspace::SerializeWorkspaceCacheEnvelope(
+			identity,
+			SerializeAssetCachePayload(m_cache),
+			envelope,
+			outDiagnostic))
+		{
+			return false;
+		}
+
+		return Workspace::AtomicReplaceWorkspaceCacheText(
+			GetAssetCacheFilepath(),
+			envelope,
+			outDiagnostic);
+	}
+	catch (const std::exception& exception)
+	{
+		outDiagnostic = "Cannot serialize the asset cache envelope: " + std::string(exception.what());
+		return false;
+	}
+	catch (...)
+	{
+		outDiagnostic = "Cannot serialize the asset cache envelope: unknown failure.";
+		return false;
+	}
+}
+
+void AssetCache::ResetInvalidCacheLocked(Workspace::WorkspaceCacheLoadResult loadResult)
+{
+	m_cache.m_data.Clear();
+	m_bIsDirty = true;
+	m_bPreserveStorageAfterLoadFailure = false;
+	m_lastLoadResult = std::move(loadResult);
+
+	std::string diagnostic;
+	if (WriteCacheLocked(diagnostic))
+	{
+		m_bIsDirty = false;
+		m_lastSaveDiagnostic.clear();
+		AppendDiagnostic(m_lastLoadResult.m_diagnostic, "The cache was reset to an empty current envelope.");
+		SAILOR_LOG(
+			"Asset cache load status=%s: %s",
+			CacheLoadStatusName(m_lastLoadResult.m_status),
+			m_lastLoadResult.m_diagnostic.c_str());
+	}
+	else
+	{
+		m_lastSaveDiagnostic = diagnostic;
+		AppendDiagnostic(
+			m_lastLoadResult.m_diagnostic,
+			"The cache could not be reset: " + diagnostic);
+		SAILOR_LOG_ERROR(
+			"Asset cache load status=%s: %s",
+			CacheLoadStatusName(m_lastLoadResult.m_status),
+			m_lastLoadResult.m_diagnostic.c_str());
+	}
 }
 
 void AssetCache::ClearAll()
 {
-	std::lock_guard<std::mutex> lk(m_saveToCacheMutex);
-	std::filesystem::remove_all(GetAssetCacheFilepath());
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	m_cache.m_data.Clear();
+	m_bIsDirty = false;
+	m_bPreserveStorageAfterLoadFailure = false;
+
+	std::error_code removeError;
+	std::filesystem::remove(GetAssetCacheFilepath(), removeError);
+	if (removeError)
+	{
+		m_bIsDirty = true;
+		m_lastSaveDiagnostic = "Cannot remove AssetCache.yaml: " + removeError.message();
+		SAILOR_LOG_ERROR("Asset cache clear failed: %s", m_lastSaveDiagnostic.c_str());
+	}
+	else
+	{
+		m_lastSaveDiagnostic.clear();
+	}
 }
 
-bool AssetCache::Contains(const FileId& uid) const { return m_cache.m_data.ContainsKey(uid); }
+Workspace::WorkspaceCacheLoadResult AssetCache::GetLastLoadResult() const
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	return m_lastLoadResult;
+}
+
+std::string AssetCache::GetLastSaveDiagnostic() const
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	return m_lastSaveDiagnostic;
+}
+
+bool AssetCache::IsDirty() const
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	return m_bIsDirty;
+}
+
+bool AssetCache::Contains(const FileId& uid) const
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	return m_cache.m_data.ContainsKey(uid);
+}
 
 bool AssetCache::GetTimeStamp(
 	const FileId& uid,
 	const std::string& sourcePath,
 	time_t& outAssetTimestamp) const
 {
-	if (Contains(uid))
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	if (!m_cache.m_data.ContainsKey(uid))
 	{
-		const AssetCacheData::Entry& entry = m_cache.m_data[uid];
-		if (entry.m_sourcePath.empty() || entry.m_sourcePath != NormalizeSourcePath(sourcePath))
-		{
-			return false;
-		}
-		outAssetTimestamp = entry.m_assetImportTime;
-		return true;
+		return false;
 	}
-	return false;
+
+	const AssetCacheData::Entry entry = m_cache.m_data[uid];
+	if (entry.m_sourcePath.empty() || entry.m_sourcePath != NormalizeSourcePath(sourcePath))
+	{
+		return false;
+	}
+
+	outAssetTimestamp = entry.m_assetImportTime;
+	return true;
 }
 
 void AssetCache::Update(
@@ -160,20 +562,32 @@ void AssetCache::Update(
 	const std::string& sourcePath,
 	const time_t& assetTimestamp)
 {
+	std::string normalizedSourcePath = NormalizeSourcePath(sourcePath);
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
 	auto& entry = m_cache.m_data.At_Lock(id);
-	const std::string normalizedSourcePath = NormalizeSourcePath(sourcePath);
+	struct EntryUnlockGuard final
+	{
+		TConcurrentMap<FileId, AssetCacheData::Entry>& m_data;
+		const FileId& m_id;
 
-	m_bIsDirty |= entry.m_assetImportTime != assetTimestamp ||
+		~EntryUnlockGuard() noexcept
+		{
+			m_data.Unlock(m_id);
+		}
+	} unlockGuard{ m_cache.m_data, id };
+
+	m_bIsDirty |= entry.m_fileId != id ||
+		entry.m_assetImportTime != assetTimestamp ||
 		entry.m_sourcePath != normalizedSourcePath;
 	entry.m_fileId = id;
 	entry.m_assetImportTime = assetTimestamp;
-	entry.m_sourcePath = normalizedSourcePath;
-
-	m_cache.m_data.Unlock(id);
+	entry.m_sourcePath = std::move(normalizedSourcePath);
 }
 
 void AssetCache::Remove(const FileId& uid)
 {
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	m_bIsDirty |= m_cache.m_data.Remove(uid);
 }
 
 bool AssetCache::IsExpired(const AssetInfo* info) const

--- a/Runtime/AssetRegistry/AssetCache.h
+++ b/Runtime/AssetRegistry/AssetCache.h
@@ -3,6 +3,7 @@
 #include <ctime>
 #include "Containers/ConcurrentMap.h"
 #include "AssetRegistry/FileId.h"
+#include "Workspace/WorkspaceCacheContract.h"
 #include <mutex>
 #include <filesystem>
 #include <string>
@@ -36,6 +37,9 @@ namespace Sailor
 		SAILOR_API void SaveCache(bool bForcely = false);
 
 		SAILOR_API void ClearAll();
+		SAILOR_API Workspace::WorkspaceCacheLoadResult GetLastLoadResult() const;
+		SAILOR_API std::string GetLastSaveDiagnostic() const;
+		SAILOR_API bool IsDirty() const;
 
 	protected:
 
@@ -61,13 +65,36 @@ namespace Sailor
 
 			SAILOR_API virtual YAML::Node Serialize() const override;
 			SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
+
+			static bool TryDeserialize(
+				const YAML::Node& inData,
+				AssetCacheData& outData,
+				std::string& outDiagnostic) noexcept;
 		};
 
-		std::mutex m_saveToCacheMutex;
+		SAILOR_API static bool ShouldResetCacheFile(
+			Workspace::EWorkspaceCacheLoadStatus status) noexcept;
+		SAILOR_API static bool ShouldWriteCacheFile(
+			bool bForcely,
+			bool bIsDirty,
+			bool bPreserveStorageAfterLoadFailure) noexcept;
+
+		SAILOR_API static std::string SerializeAssetCachePayload(const AssetCacheData& cache);
+		SAILOR_API static bool TryDeserializeAssetCachePayload(
+			const std::string& payload,
+			AssetCacheData& outData,
+			std::string& outDiagnostic) noexcept;
+		bool WriteCacheLocked(std::string& outDiagnostic) noexcept;
+		void ResetInvalidCacheLocked(Workspace::WorkspaceCacheLoadResult loadResult);
+
+		mutable std::mutex m_cacheMutex;
 
 	private:
 
 		AssetCacheData m_cache;
 		bool m_bIsDirty = false;
+		bool m_bPreserveStorageAfterLoadFailure = false;
+		Workspace::WorkspaceCacheLoadResult m_lastLoadResult{};
+		std::string m_lastSaveDiagnostic;
 	};
 }

--- a/Runtime/AssetRegistry/Shader/ShaderCache.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.cpp
@@ -1,92 +1,401 @@
 #include "ShaderCache.h"
-#include <filesystem>
-#include <fstream>
-#include <iostream>
-#include "Containers/Set.h"
+
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/Shader/ShaderCompiler.h"
+#include "Sailor.h"
+
+#include <algorithm>
+#include <cctype>
+#include <cstring>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+#include <unordered_set>
 
 using namespace Sailor;
 
 namespace
 {
-	std::string GetCacheChildPath(const char* child)
+	constexpr const char* ShaderCacheKind = "shader-cache";
+	constexpr uint32_t ShaderCachePayloadVersion = 2;
+	constexpr uint64_t FnvOffsetBasis = 14695981039346656037ull;
+	constexpr uint64_t FnvPrime = 1099511628211ull;
+
+	std::string GetShaderCacheProducerIdentity()
 	{
-		return (std::filesystem::path(AssetRegistry::GetCacheFolder()) / child).string();
+		return "shader-compiler-v" + std::to_string(ShaderCompiler::CacheProducerVersion);
+	}
+
+	Workspace::WorkspaceCacheIdentity MakeExpectedIdentity()
+	{
+		return Workspace::MakeWorkspaceCacheIdentity(
+			ShaderCacheKind,
+			GetShaderCacheProducerIdentity(),
+			ShaderCachePayloadVersion,
+			App::GetWorkspaceContext());
+	}
+
+	std::filesystem::path GetCacheChildPath(const char* child)
+	{
+		return std::filesystem::path(AssetRegistry::GetCacheFolder()) / child;
 	}
 
 	std::filesystem::path GetShaderFilepath(
-		const std::string& folder,
+		const std::filesystem::path& folder,
 		const FileId& uid,
 		int32_t permutation,
 		const std::string& shaderKind,
-		const char* extension)
+		const char* extension,
+		const std::string& generation = {})
 	{
 		const std::string filename = uid.ToString() + shaderKind +
-			std::to_string(permutation) + "." + extension;
-		return std::filesystem::path(folder) / filename;
+			std::to_string(permutation) +
+			(generation.empty() ? std::string() : "." + generation) +
+			"." + extension;
+		return folder / filename;
+	}
+
+	void AppendDiagnostic(std::string& diagnostic, const std::string& suffix)
+	{
+		if (suffix.empty())
+		{
+			return;
+		}
+
+		if (!diagnostic.empty())
+		{
+			diagnostic += " ";
+		}
+		diagnostic += suffix;
+	}
+
+	bool ValidateExactFields(
+		const YAML::Node& node,
+		std::initializer_list<const char*> expectedFields,
+		const std::string& context,
+		std::string& outDiagnostic)
+	{
+		if (!node.IsMap())
+		{
+			outDiagnostic = context + " must be a YAML map.";
+			return false;
+		}
+
+		std::unordered_set<std::string> expected;
+		for (const char* field : expectedFields)
+		{
+			expected.emplace(field);
+		}
+
+		std::unordered_set<std::string> actual;
+		for (const auto& field : node)
+		{
+			if (!field.first.IsScalar())
+			{
+				outDiagnostic = context + " contains a non-scalar field name.";
+				return false;
+			}
+
+			const std::string name = field.first.Scalar();
+			if (!actual.emplace(name).second)
+			{
+				outDiagnostic = context + " contains duplicate field '" + name + "'.";
+				return false;
+			}
+			if (!expected.contains(name))
+			{
+				outDiagnostic = context + " contains unknown field '" + name + "'.";
+				return false;
+			}
+		}
+
+		for (const std::string& field : expected)
+		{
+			if (!actual.contains(field))
+			{
+				outDiagnostic = context + " is missing required field '" + field + "'.";
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	YAML::Node FindField(const YAML::Node& node, const char* fieldName)
+	{
+		for (const auto& field : node)
+		{
+			if (field.first.IsScalar() && field.first.Scalar() == fieldName)
+			{
+				return field.second;
+			}
+		}
+		return YAML::Node(YAML::NodeType::Undefined);
+	}
+
+	bool PathsEqual(const std::filesystem::path& lhs, const std::filesystem::path& rhs)
+	{
+		std::string left = lhs.generic_string();
+		std::string right = rhs.generic_string();
+#if defined(_WIN32)
+		std::transform(left.begin(), left.end(), left.begin(), [](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+		std::transform(right.begin(), right.end(), right.begin(), [](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+#endif
+		return left == right;
+	}
+
+	bool ResolveDirectCacheChild(
+		const std::filesystem::path& cacheRoot,
+		const std::filesystem::path& candidate,
+		std::filesystem::path& outCanonical,
+		std::string& outDiagnostic)
+	{
+		std::error_code error;
+		const std::filesystem::path canonicalRoot = std::filesystem::weakly_canonical(cacheRoot, error);
+		if (error)
+		{
+			outDiagnostic = "Cannot canonicalize shader cache root '" +
+				cacheRoot.generic_string() + "': " + error.message();
+			return false;
+		}
+
+		error.clear();
+		outCanonical = std::filesystem::weakly_canonical(candidate, error);
+		if (error)
+		{
+			outDiagnostic = "Cannot canonicalize shader cache path '" +
+				candidate.generic_string() + "': " + error.message();
+			return false;
+		}
+
+		if (!PathsEqual(outCanonical.parent_path(), canonicalRoot))
+		{
+			outDiagnostic = "Refusing shader cache access outside canonical cache root: '" +
+				candidate.generic_string() + "'.";
+			return false;
+		}
+		return true;
+	}
+
+	bool RemovePath(
+		const std::filesystem::path& cacheRoot,
+		const std::filesystem::path& path,
+		bool bRecursive,
+		std::string& outDiagnostic)
+	{
+		std::filesystem::path canonical;
+		std::string diagnostic;
+		if (!ResolveDirectCacheChild(cacheRoot, path, canonical, diagnostic))
+		{
+			AppendDiagnostic(outDiagnostic, diagnostic);
+			return false;
+		}
+
+		std::error_code error;
+		if (bRecursive)
+		{
+			std::filesystem::remove_all(path, error);
+		}
+		else
+		{
+			std::filesystem::remove(path, error);
+		}
+		if (error)
+		{
+			AppendDiagnostic(
+				outDiagnostic,
+				"Cannot remove shader cache path '" + path.generic_string() + "': " + error.message());
+			return false;
+		}
+		return true;
+	}
+
+	bool ResolveOwnedArtifactPath(
+		const std::filesystem::path& cacheRoot,
+		const std::filesystem::path& ownedDirectory,
+		const std::filesystem::path& artifact,
+		std::filesystem::path& outCanonicalArtifact,
+		std::string& outDiagnostic,
+		bool& outIoFailure)
+	{
+		outIoFailure = false;
+		std::error_code error;
+		const auto status = std::filesystem::symlink_status(ownedDirectory, error);
+		if (error)
+		{
+			outIoFailure = error != std::errc::no_such_file_or_directory;
+			outDiagnostic = "Cannot inspect owned shader cache directory '" +
+				ownedDirectory.generic_string() + "': " + error.message();
+			return false;
+		}
+		if (std::filesystem::is_symlink(status))
+		{
+			outDiagnostic = "Refusing shader artifact access through symlinked cache directory '" +
+				ownedDirectory.generic_string() + "'.";
+			return false;
+		}
+
+		const std::filesystem::path canonicalRoot = std::filesystem::weakly_canonical(cacheRoot, error);
+		if (error)
+		{
+			outIoFailure = true;
+			outDiagnostic = "Cannot canonicalize shader cache root '" +
+				cacheRoot.generic_string() + "': " + error.message();
+			return false;
+		}
+
+		error.clear();
+		const std::filesystem::path canonicalDirectory =
+			std::filesystem::weakly_canonical(ownedDirectory, error);
+		if (error)
+		{
+			outIoFailure = true;
+			outDiagnostic = "Cannot canonicalize owned shader cache directory '" +
+				ownedDirectory.generic_string() + "': " + error.message();
+			return false;
+		}
+		if (!PathsEqual(canonicalDirectory.parent_path(), canonicalRoot))
+		{
+			outDiagnostic = "Refusing shader artifact access outside the canonical cache root: '" +
+				artifact.generic_string() + "'.";
+			return false;
+		}
+
+		error.clear();
+		outCanonicalArtifact = std::filesystem::weakly_canonical(artifact, error);
+		if (error)
+		{
+			outIoFailure = error != std::errc::no_such_file_or_directory;
+			outDiagnostic = "Cannot canonicalize shader artifact '" +
+				artifact.generic_string() + "': " + error.message();
+			return false;
+		}
+		if (!PathsEqual(outCanonicalArtifact.parent_path(), canonicalDirectory))
+		{
+			outDiagnostic = "Refusing shader artifact access outside owned directory '" +
+				canonicalDirectory.generic_string() + "': '" + artifact.generic_string() + "'.";
+			return false;
+		}
+		return true;
+	}
+
+	bool RemoveOwnedArtifact(
+		const std::filesystem::path& cacheRoot,
+		const std::filesystem::path& ownedDirectory,
+		const std::filesystem::path& artifact,
+		std::string& outDiagnostic)
+	{
+		std::filesystem::path canonicalArtifact;
+		bool ignoredIoFailure = false;
+		if (!ResolveOwnedArtifactPath(
+			cacheRoot,
+			ownedDirectory,
+			artifact,
+			canonicalArtifact,
+			outDiagnostic,
+			ignoredIoFailure))
+		{
+			return false;
+		}
+
+		std::error_code error;
+		std::filesystem::remove(artifact, error);
+		if (error)
+		{
+			AppendDiagnostic(
+				outDiagnostic,
+				"Cannot remove shader cache artifact '" + artifact.generic_string() +
+					"': " + error.message());
+			return false;
+		}
+		return true;
+	}
+
+	bool IsMetadataStructurallyValid(const ShaderCache::ArtifactMetadata& metadata)
+	{
+		return metadata.m_byteLength != 0 || metadata.m_checksum == 0;
+	}
+
+	bool ShouldResetCache(Workspace::EWorkspaceCacheLoadStatus status) noexcept
+	{
+		return status == Workspace::EWorkspaceCacheLoadStatus::Missing ||
+			status == Workspace::EWorkspaceCacheLoadStatus::StaleIdentity ||
+			status == Workspace::EWorkspaceCacheLoadStatus::Corrupt ||
+			status == Workspace::EWorkspaceCacheLoadStatus::UnsupportedVersion;
+	}
+
+	const char* CacheLoadStatusName(Workspace::EWorkspaceCacheLoadStatus status) noexcept
+	{
+		switch (status)
+		{
+		case Workspace::EWorkspaceCacheLoadStatus::Missing: return "Missing";
+		case Workspace::EWorkspaceCacheLoadStatus::Loaded: return "Loaded";
+		case Workspace::EWorkspaceCacheLoadStatus::StaleIdentity: return "StaleIdentity";
+		case Workspace::EWorkspaceCacheLoadStatus::Corrupt: return "Corrupt";
+		case Workspace::EWorkspaceCacheLoadStatus::UnsupportedVersion: return "UnsupportedVersion";
+		case Workspace::EWorkspaceCacheLoadStatus::IoFailure: return "IoFailure";
+		default: return "Unknown";
+		}
 	}
 }
 
-std::string ShaderCache::GetShaderCacheFilepath()
+ShaderCache::ShaderCache() = default;
+
+ShaderCache::~ShaderCache() = default;
+
+ShaderCache::ArtifactMetadata::ArtifactMetadata() = default;
+
+ShaderCache::ArtifactMetadata::~ArtifactMetadata() = default;
+
+YAML::Node ShaderCache::ArtifactMetadata::Serialize() const
 {
-	return GetCacheChildPath("ShaderCache.yaml");
+	YAML::Node result(YAML::NodeType::Map);
+	result["byteLength"] = m_byteLength;
+	result["checksum"] = m_checksum;
+	return result;
 }
 
-std::string ShaderCache::GetPrecompiledShadersFolder()
+void ShaderCache::ArtifactMetadata::Deserialize(const YAML::Node& inData)
 {
-	return GetCacheChildPath("PrecompiledShaders");
+	m_byteLength = inData["byteLength"].as<uint64_t>();
+	m_checksum = inData["checksum"].as<uint64_t>();
 }
 
-std::string ShaderCache::GetCompiledShadersFolder()
+YAML::Node ShaderCache::ArtifactSet::Serialize() const
 {
-	return GetCacheChildPath("CompiledShaders");
+	YAML::Node result(YAML::NodeType::Map);
+	result["vertex"] = m_vertex.Serialize();
+	result["fragment"] = m_fragment.Serialize();
+	result["compute"] = m_compute.Serialize();
+	return result;
 }
 
-std::string ShaderCache::GetCompiledShadersWithDebugFolder()
+void ShaderCache::ArtifactSet::Deserialize(const YAML::Node& inData)
 {
-	return GetCacheChildPath("CompiledShadersWithDebug");
-}
-
-std::filesystem::path ShaderCache::GetPrecompiledShaderFilepath(const FileId& uid, int32_t permutation, const std::string& shaderKind)
-{
-	return GetShaderFilepath(
-		GetPrecompiledShadersFolder(),
-		uid,
-		permutation,
-		shaderKind,
-		PrecompiledShaderFileExtension);
-}
-
-std::filesystem::path ShaderCache::GetCachedShaderFilepath(const FileId& uid, int32_t permutation, const std::string& shaderKind)
-{
-	return GetShaderFilepath(
-		GetCompiledShadersFolder(),
-		uid,
-		permutation,
-		shaderKind,
-		CompiledShaderFileExtension);
-}
-
-std::filesystem::path ShaderCache::GetCachedShaderWithDebugFilepath(const FileId& uid, int32_t permutation, const std::string& shaderKind)
-{
-	return GetShaderFilepath(
-		GetCompiledShadersWithDebugFolder(),
-		uid,
-		permutation,
-		shaderKind,
-		CompiledShaderFileExtension);
+	m_vertex.Deserialize(inData["vertex"]);
+	m_fragment.Deserialize(inData["fragment"]);
+	m_compute.Deserialize(inData["compute"]);
 }
 
 YAML::Node ShaderCache::ShaderCacheData::Entry::Serialize() const
 {
-	YAML::Node res;
-
-	res["fileId"] = m_fileId;
-	res["timestamp"] = m_timestamp;
-	res["permutation"] = m_permutation;
-
-	return res;
+	YAML::Node result(YAML::NodeType::Map);
+	result["fileId"] = m_fileId;
+	result["timestamp"] = m_timestamp;
+	result["permutation"] = m_permutation;
+	result["generation"] = m_generation;
+	result["regular"] = m_regular.Serialize();
+	result["debug"] = m_debug.Serialize();
+	return result;
 }
 
 void ShaderCache::ShaderCacheData::Entry::Deserialize(const YAML::Node& inData)
@@ -94,39 +403,627 @@ void ShaderCache::ShaderCacheData::Entry::Deserialize(const YAML::Node& inData)
 	m_fileId = inData["fileId"].as<FileId>();
 	m_timestamp = inData["timestamp"].as<std::time_t>();
 	m_permutation = inData["permutation"].as<uint32_t>();
+	m_generation = inData["generation"].as<std::string>();
+	m_regular.Deserialize(inData["regular"]);
+	m_debug.Deserialize(inData["debug"]);
 }
 
 YAML::Node ShaderCache::ShaderCacheData::Serialize() const
 {
-	YAML::Node res;
-	::Serialize(res, "entries", m_data);
-
-	return res;
+	YAML::Node result(YAML::NodeType::Map);
+	YAML::Node entries(YAML::NodeType::Map);
+	for (const auto& fileEntries : m_data)
+	{
+		YAML::Node serializedEntries(YAML::NodeType::Sequence);
+		for (const Entry& entry : *fileEntries.m_second)
+		{
+			serializedEntries.push_back(entry.Serialize());
+		}
+		entries[fileEntries.m_first] = serializedEntries;
+	}
+	result["entries"] = entries;
+	return result;
 }
 
 void ShaderCache::ShaderCacheData::Deserialize(const YAML::Node& inData)
 {
-	::Deserialize(inData, "entries", m_data);
+	m_data = inData["entries"].as<TMap<FileId, TVector<Entry>>>();
+}
+
+std::string ShaderCache::SerializeShaderCachePayload(const ShaderCacheData& cache)
+{
+	YAML::Node payload(YAML::NodeType::Map);
+	payload["shaderCache"] = cache.Serialize();
+	return YAML::Dump(payload);
+}
+
+bool ShaderCache::TryDeserializeShaderCachePayload(
+	const std::string& payload,
+	ShaderCacheData& outData,
+	std::string& outDiagnostic) noexcept
+{
+	try
+	{
+		const YAML::Node root = YAML::Load(payload);
+		if (!ValidateExactFields(root, { "shaderCache" }, "Shader cache payload root", outDiagnostic))
+		{
+			return false;
+		}
+
+		const YAML::Node shaderCache = FindField(root, "shaderCache");
+		if (!ValidateExactFields(shaderCache, { "entries" }, "Shader cache payload", outDiagnostic))
+		{
+			return false;
+		}
+
+		const YAML::Node entriesNode = FindField(shaderCache, "entries");
+		if (!entriesNode.IsMap())
+		{
+			outDiagnostic = "Shader cache field 'entries' must be a YAML map, including when empty.";
+			return false;
+		}
+
+		auto parseMetadata = [&](const YAML::Node& node,
+			ArtifactMetadata& outMetadata,
+			const std::string& context) -> bool
+		{
+			if (!ValidateExactFields(node, { "byteLength", "checksum" }, context, outDiagnostic))
+			{
+				return false;
+			}
+			const YAML::Node byteLength = FindField(node, "byteLength");
+			const YAML::Node checksum = FindField(node, "checksum");
+			if (!byteLength.IsScalar() || !checksum.IsScalar())
+			{
+				outDiagnostic = context + " fields must be unsigned integer scalars.";
+				return false;
+			}
+			outMetadata.m_byteLength = byteLength.as<uint64_t>();
+			outMetadata.m_checksum = checksum.as<uint64_t>();
+			if (!IsMetadataStructurallyValid(outMetadata))
+			{
+				outDiagnostic = context + " has a checksum for an absent artifact.";
+				return false;
+			}
+			if (outMetadata.IsPresent() && outMetadata.m_byteLength % sizeof(uint32_t) != 0)
+			{
+				outDiagnostic = context + " byteLength is not aligned to uint32 SPIR-V words.";
+				return false;
+			}
+			return true;
+		};
+
+		auto parseSet = [&](const YAML::Node& node,
+			ArtifactSet& outSet,
+			const std::string& context) -> bool
+		{
+			if (!ValidateExactFields(node, { "vertex", "fragment", "compute" }, context, outDiagnostic))
+			{
+				return false;
+			}
+			return parseMetadata(FindField(node, "vertex"), outSet.m_vertex, context + " vertex artifact") &&
+				parseMetadata(FindField(node, "fragment"), outSet.m_fragment, context + " fragment artifact") &&
+				parseMetadata(FindField(node, "compute"), outSet.m_compute, context + " compute artifact");
+		};
+
+		ShaderCacheData candidate;
+		std::unordered_set<std::string> fileIds;
+		for (const auto& serializedFileEntries : entriesNode)
+		{
+			if (!serializedFileEntries.first.IsScalar())
+			{
+				outDiagnostic = "Shader cache contains a non-scalar file id.";
+				return false;
+			}
+
+			const std::string serializedFileId = serializedFileEntries.first.Scalar();
+			if (!fileIds.emplace(serializedFileId).second)
+			{
+				outDiagnostic = "Shader cache contains duplicate file id '" + serializedFileId + "'.";
+				return false;
+			}
+
+			const FileId fileId = serializedFileEntries.first.as<FileId>();
+			if (!fileId)
+			{
+				outDiagnostic = "Shader cache contains invalid file id '" + serializedFileId + "'.";
+				return false;
+			}
+
+			const YAML::Node entrySequence = serializedFileEntries.second;
+			if (!entrySequence.IsSequence() || entrySequence.size() == 0)
+			{
+				outDiagnostic = "Shader cache file id '" + serializedFileId +
+					"' must contain a non-empty entry sequence.";
+				return false;
+			}
+
+			TVector<ShaderCacheData::Entry> entries;
+			entries.Reserve(entrySequence.size());
+			std::unordered_set<uint32_t> permutations;
+			for (size_t index = 0; index < entrySequence.size(); ++index)
+			{
+				const std::string context = "Shader cache entry '" + serializedFileId +
+					"' at index " + std::to_string(index);
+				const YAML::Node entryNode = entrySequence[index];
+				if (!ValidateExactFields(
+					entryNode,
+					{ "fileId", "timestamp", "permutation", "generation", "regular", "debug" },
+					context,
+					outDiagnostic))
+				{
+					return false;
+				}
+
+				const YAML::Node entryFileId = FindField(entryNode, "fileId");
+				const YAML::Node timestamp = FindField(entryNode, "timestamp");
+				const YAML::Node permutation = FindField(entryNode, "permutation");
+				const YAML::Node generation = FindField(entryNode, "generation");
+				if (!entryFileId.IsScalar() || !timestamp.IsScalar() ||
+					!permutation.IsScalar() || !generation.IsScalar())
+				{
+					outDiagnostic = context + " contains a non-scalar identity or timestamp field.";
+					return false;
+				}
+
+				ShaderCacheData::Entry entry;
+				entry.m_fileId = entryFileId.as<FileId>();
+				entry.m_timestamp = timestamp.as<std::time_t>();
+				entry.m_permutation = permutation.as<uint32_t>();
+				entry.m_generation = generation.as<std::string>();
+				if (!entry.m_fileId || entry.m_fileId != fileId)
+				{
+					outDiagnostic = context + " has a mismatched fileId field.";
+					return false;
+				}
+				if (!permutations.emplace(entry.m_permutation).second)
+				{
+					outDiagnostic = context + " duplicates permutation " +
+						std::to_string(entry.m_permutation) + ".";
+					return false;
+				}
+				if (!IsValidGeneration(entry.m_generation))
+				{
+					outDiagnostic = context + " has an invalid immutable artifact generation.";
+					return false;
+				}
+
+				if (!parseSet(FindField(entryNode, "regular"), entry.m_regular, context + " regular artifacts") ||
+					!parseSet(FindField(entryNode, "debug"), entry.m_debug, context + " debug artifacts"))
+				{
+					return false;
+				}
+				if (!IsValidArtifactSet(entry.m_regular, false))
+				{
+					outDiagnostic = context + " regular artifacts must contain a vertex/fragment pair or compute artifact.";
+					return false;
+				}
+				if (!IsValidArtifactSet(entry.m_debug, false))
+				{
+					outDiagnostic = context + " debug artifacts must contain a vertex/fragment pair or compute artifact.";
+					return false;
+				}
+				if (!HasMatchingArtifactTopology(entry.m_regular, entry.m_debug))
+				{
+					outDiagnostic = context + " regular and debug artifacts must contain identical shader stages.";
+					return false;
+				}
+
+				entries.Add(std::move(entry));
+			}
+
+			candidate.m_data.Insert(fileId, std::move(entries));
+		}
+
+		outData.m_data = std::move(candidate.m_data);
+		outDiagnostic.clear();
+		return true;
+	}
+	catch (const std::exception& exception)
+	{
+		outDiagnostic = "Shader cache payload is corrupt: " + std::string(exception.what());
+		return false;
+	}
+	catch (...)
+	{
+		outDiagnostic = "Shader cache payload is corrupt: unknown YAML decoding failure.";
+		return false;
+	}
+}
+
+std::string ShaderCache::GetShaderCacheFilepath()
+{
+	return GetCacheChildPath("ShaderCache.yaml").string();
+}
+
+std::string ShaderCache::GetPrecompiledShadersFolder()
+{
+	return GetCacheChildPath("PrecompiledShaders").string();
+}
+
+std::string ShaderCache::GetCompiledShadersFolder()
+{
+	return GetCacheChildPath("CompiledShaders").string();
+}
+
+std::string ShaderCache::GetCompiledShadersWithDebugFolder()
+{
+	return GetCacheChildPath("CompiledShadersWithDebug").string();
+}
+
+std::filesystem::path ShaderCache::GetPrecompiledShaderFilepath(
+	const FileId& uid,
+	int32_t permutation,
+	const std::string& shaderKind)
+{
+	return GetShaderFilepath(
+		GetCacheChildPath("PrecompiledShaders"),
+		uid,
+		permutation,
+		shaderKind,
+		PrecompiledShaderFileExtension);
+}
+
+std::filesystem::path ShaderCache::GetCachedShaderFilepath(
+	const FileId& uid,
+	int32_t permutation,
+	const std::string& shaderKind)
+{
+	return GetShaderFilepath(
+		GetCacheChildPath("CompiledShaders"),
+		uid,
+		permutation,
+		shaderKind,
+		CompiledShaderFileExtension);
+}
+
+std::filesystem::path ShaderCache::GetCachedShaderWithDebugFilepath(
+	const FileId& uid,
+	int32_t permutation,
+	const std::string& shaderKind)
+{
+	return GetShaderFilepath(
+		GetCacheChildPath("CompiledShadersWithDebug"),
+		uid,
+		permutation,
+		shaderKind,
+		CompiledShaderFileExtension);
+}
+
+uint64_t ShaderCache::CalculateArtifactChecksum(const void* data, uint64_t size) noexcept
+{
+	if (size != 0 && data == nullptr)
+	{
+		return 0;
+	}
+
+	uint64_t checksum = FnvOffsetBasis;
+	const auto* bytes = static_cast<const uint8_t*>(data);
+	for (uint64_t index = 0; index < size; ++index)
+	{
+		checksum ^= bytes[index];
+		checksum *= FnvPrime;
+	}
+	return checksum;
+}
+
+ShaderCache::ArtifactMetadata ShaderCache::DescribeArtifact(const void* data, uint64_t size) noexcept
+{
+	ArtifactMetadata result;
+	if (size == 0 || data == nullptr)
+	{
+		return result;
+	}
+
+	result.m_byteLength = size;
+	result.m_checksum = CalculateArtifactChecksum(data, size);
+	return result;
+}
+
+bool ShaderCache::ReadArtifactBytes(
+	const std::filesystem::path& path,
+	const ArtifactMetadata& metadata,
+	std::vector<uint8_t>& outBytes,
+	std::string& outDiagnostic,
+	bool& outIoFailure) noexcept
+{
+	outIoFailure = false;
+	try
+	{
+		if (!IsMetadataStructurallyValid(metadata))
+		{
+			outDiagnostic = "Artifact metadata is internally inconsistent for '" + path.generic_string() + "'.";
+			return false;
+		}
+		if (!metadata.IsPresent())
+		{
+			outBytes.clear();
+			outDiagnostic.clear();
+			return true;
+		}
+		if (metadata.m_byteLength > std::numeric_limits<size_t>::max() ||
+			metadata.m_byteLength > static_cast<uint64_t>(std::numeric_limits<std::streamsize>::max()))
+		{
+			outDiagnostic = "Artifact is too large to read safely: '" + path.generic_string() + "'.";
+			return false;
+		}
+
+		std::error_code sizeError;
+		const uint64_t actualSize = std::filesystem::file_size(path, sizeError);
+		if (sizeError)
+		{
+			outIoFailure = sizeError != std::errc::no_such_file_or_directory &&
+				sizeError != std::errc::not_a_directory;
+			outDiagnostic = "Cannot inspect shader artifact '" + path.generic_string() + "': " + sizeError.message();
+			return false;
+		}
+		if (actualSize != metadata.m_byteLength)
+		{
+			outDiagnostic = "Shader artifact '" + path.generic_string() + "' has byte length " +
+				std::to_string(actualSize) + ", expected " + std::to_string(metadata.m_byteLength) + ".";
+			return false;
+		}
+
+		std::ifstream stream(path, std::ios::binary);
+		if (!stream.is_open())
+		{
+			std::error_code existsError;
+			const bool bExists = std::filesystem::exists(path, existsError);
+			outIoFailure = bExists || static_cast<bool>(existsError);
+			outDiagnostic = "Cannot open shader artifact '" + path.generic_string() + "'.";
+			return false;
+		}
+
+		std::vector<uint8_t> candidate(static_cast<size_t>(metadata.m_byteLength));
+		stream.read(
+			reinterpret_cast<char*>(candidate.data()),
+			static_cast<std::streamsize>(candidate.size()));
+		if (stream.gcount() != static_cast<std::streamsize>(candidate.size()) || stream.bad())
+		{
+			outIoFailure = stream.bad();
+			outDiagnostic = "Shader artifact read was incomplete for '" + path.generic_string() + "'.";
+			return false;
+		}
+		if (CalculateArtifactChecksum(candidate.data(), candidate.size()) != metadata.m_checksum)
+		{
+			outDiagnostic = "Shader artifact checksum mismatch for '" + path.generic_string() + "'.";
+			return false;
+		}
+
+		outBytes = std::move(candidate);
+		outDiagnostic.clear();
+		return true;
+	}
+	catch (const std::exception& exception)
+	{
+		outIoFailure = true;
+		outDiagnostic = "Cannot read shader artifact '" + path.generic_string() + "': " + exception.what();
+		return false;
+	}
+	catch (...)
+	{
+		outIoFailure = true;
+		outDiagnostic = "Cannot read shader artifact '" + path.generic_string() + "': unknown failure.";
+		return false;
+	}
+}
+
+bool ShaderCache::ReadSpirvArtifact(
+	const std::filesystem::path& path,
+	const ArtifactMetadata& metadata,
+	TVector<uint32_t>& outSpirv,
+	std::string& outDiagnostic) noexcept
+{
+	bool ignoredIoFailure = false;
+	return ReadSpirvArtifactInternal(path, metadata, outSpirv, outDiagnostic, ignoredIoFailure);
+}
+
+bool ShaderCache::ValidateOwnedArtifactPath(
+	const std::filesystem::path& cacheRoot,
+	const std::filesystem::path& ownedDirectory,
+	const std::filesystem::path& artifact,
+	std::string& outDiagnostic) noexcept
+{
+	try
+	{
+		std::filesystem::path canonicalArtifact;
+		bool ignoredIoFailure = false;
+		return ResolveOwnedArtifactPath(
+			cacheRoot,
+			ownedDirectory,
+			artifact,
+			canonicalArtifact,
+			outDiagnostic,
+			ignoredIoFailure);
+	}
+	catch (const std::exception& exception)
+	{
+		outDiagnostic = "Cannot validate owned shader artifact path: " +
+			std::string(exception.what());
+		return false;
+	}
+	catch (...)
+	{
+		outDiagnostic = "Cannot validate owned shader artifact path: unknown failure.";
+		return false;
+	}
+}
+
+bool ShaderCache::ReadSpirvArtifactInternal(
+	const std::filesystem::path& path,
+	const ArtifactMetadata& metadata,
+	TVector<uint32_t>& outSpirv,
+	std::string& outDiagnostic,
+	bool& outIoFailure) noexcept
+{
+	outIoFailure = false;
+	try
+	{
+		if (metadata.IsPresent() && metadata.m_byteLength % sizeof(uint32_t) != 0)
+		{
+			outDiagnostic = "SPIR-V artifact byte length is not aligned to uint32 words for '" +
+				path.generic_string() + "'.";
+			return false;
+		}
+
+		std::vector<uint8_t> bytes;
+		if (!ReadArtifactBytes(path, metadata, bytes, outDiagnostic, outIoFailure))
+		{
+			return false;
+		}
+
+		TVector<uint32_t> candidate;
+		candidate.Resize(bytes.size() / sizeof(uint32_t));
+		if (!bytes.empty())
+		{
+			std::memcpy(candidate.GetData(), bytes.data(), bytes.size());
+		}
+		outSpirv = std::move(candidate);
+		return true;
+	}
+	catch (const std::exception& exception)
+	{
+		outIoFailure = true;
+		outDiagnostic = "Cannot materialize shader artifact '" + path.generic_string() +
+			"': " + exception.what();
+		return false;
+	}
+	catch (...)
+	{
+		outIoFailure = true;
+		outDiagnostic = "Cannot materialize shader artifact: unknown failure.";
+		return false;
+	}
+}
+
+bool ShaderCache::IsValidArtifactSet(const ArtifactSet& artifacts, bool bAllowEmpty) noexcept
+{
+	const bool bHasVertex = artifacts.m_vertex.IsPresent();
+	const bool bHasFragment = artifacts.m_fragment.IsPresent();
+	const bool bHasCompute = artifacts.m_compute.IsPresent();
+	if (!bHasVertex && !bHasFragment && !bHasCompute)
+	{
+		return bAllowEmpty;
+	}
+	return bHasVertex == bHasFragment && ((bHasVertex && bHasFragment) || bHasCompute);
+}
+
+bool ShaderCache::HasMatchingArtifactTopology(
+	const ArtifactSet& regular,
+	const ArtifactSet& debug) noexcept
+{
+	return regular.m_vertex.IsPresent() == debug.m_vertex.IsPresent() &&
+		regular.m_fragment.IsPresent() == debug.m_fragment.IsPresent() &&
+		regular.m_compute.IsPresent() == debug.m_compute.IsPresent();
+}
+
+bool ShaderCache::IsValidGeneration(const std::string& generation) noexcept
+{
+	if (generation.size() != 32)
+	{
+		return false;
+	}
+	return std::all_of(generation.begin(), generation.end(), [](unsigned char character)
+		{
+			return character >= '0' && character <= '9' || character >= 'a' && character <= 'f';
+		});
+}
+
+bool ShaderCache::DescribeArtifactSet(
+	const TVector<uint32_t>& vertexSpirv,
+	const TVector<uint32_t>& fragmentSpirv,
+	const TVector<uint32_t>& computeSpirv,
+	ArtifactSet& outMetadata,
+	std::string& outDiagnostic) noexcept
+{
+	ArtifactSet metadata;
+	metadata.m_vertex = DescribeArtifact(
+		vertexSpirv.Num() == 0 ? nullptr : &vertexSpirv[0],
+		static_cast<uint64_t>(vertexSpirv.Num()) * sizeof(uint32_t));
+	metadata.m_fragment = DescribeArtifact(
+		fragmentSpirv.Num() == 0 ? nullptr : &fragmentSpirv[0],
+		static_cast<uint64_t>(fragmentSpirv.Num()) * sizeof(uint32_t));
+	metadata.m_compute = DescribeArtifact(
+		computeSpirv.Num() == 0 ? nullptr : &computeSpirv[0],
+		static_cast<uint64_t>(computeSpirv.Num()) * sizeof(uint32_t));
+	if (!IsValidArtifactSet(metadata, false))
+	{
+		outDiagnostic = "A shader artifact set must contain a vertex/fragment pair or compute artifact.";
+		return false;
+	}
+	outMetadata = metadata;
+	outDiagnostic.clear();
+	return true;
+}
+
+Workspace::WorkspaceCacheIdentity ShaderCache::GetExpectedIdentityLocked() const
+{
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+	if (m_identityOverride.has_value())
+	{
+		return *m_identityOverride;
+	}
+#endif
+	return MakeExpectedIdentity();
+}
+
+std::filesystem::path ShaderCache::GetCacheFilepathLocked() const
+{
+	return m_cacheRoot / "ShaderCache.yaml";
+}
+
+std::filesystem::path ShaderCache::GetPrecompiledFolderLocked() const
+{
+	return m_cacheRoot / "PrecompiledShaders";
+}
+
+std::filesystem::path ShaderCache::GetCompiledFolderLocked() const
+{
+	return m_cacheRoot / "CompiledShaders";
+}
+
+std::filesystem::path ShaderCache::GetCompiledDebugFolderLocked() const
+{
+	return m_cacheRoot / "CompiledShadersWithDebug";
+}
+
+std::filesystem::path ShaderCache::GetArtifactPathLocked(
+	const ShaderCacheData::Entry& entry,
+	const std::string& shaderKind,
+	bool bIsDebug) const
+{
+	return GetShaderFilepath(
+		bIsDebug ? GetCompiledDebugFolderLocked() : GetCompiledFolderLocked(),
+		entry.m_fileId,
+		static_cast<int32_t>(entry.m_permutation),
+		shaderKind,
+		CompiledShaderFileExtension,
+		entry.m_generation);
 }
 
 void ShaderCache::Initialize()
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	std::filesystem::create_directories(AssetRegistry::GetCacheFolder());
-	std::filesystem::create_directories(GetCompiledShadersFolder());
-	std::filesystem::create_directories(GetPrecompiledShadersFolder());
-	std::filesystem::create_directories(GetCompiledShadersWithDebugFolder());
-
-	auto shaderCacheFilePath = std::filesystem::path(GetShaderCacheFilepath());
-	if (!std::filesystem::exists(GetShaderCacheFilepath()))
+	std::error_code error;
+	m_cacheRoot = std::filesystem::path(AssetRegistry::GetCacheFolder());
+	std::filesystem::create_directories(m_cacheRoot, error);
+	if (!error)
 	{
-		YAML::Node outData;
-		outData["shaderCache"] = m_cache.Serialize();
+		m_cacheRoot = std::filesystem::weakly_canonical(m_cacheRoot, error);
+	}
 
-		std::ofstream assetFile(GetShaderCacheFilepath());
-		assetFile << outData;
-		assetFile.close();
+	{
+		std::lock_guard<std::mutex> lock(m_cacheMutex);
+		std::string diagnostic;
+		m_bStorageReady = !error && EnsureOwnedDirectoriesLocked(diagnostic);
+		if (!m_bStorageReady)
+		{
+			m_lastSaveDiagnostic = error
+				? "Cannot initialize shader cache root: " + error.message()
+				: std::move(diagnostic);
+			SAILOR_LOG_ERROR("Shader cache storage initialization failed: %s", m_lastSaveDiagnostic.c_str());
+		}
 	}
 
 	LoadCache();
@@ -142,351 +1039,1379 @@ void ShaderCache::SaveCache(bool bForcely)
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	if (bForcely || m_bIsDirty)
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	SaveCacheLocked(bForcely);
+}
+
+bool ShaderCache::SaveCacheLocked(
+	bool bForcely,
+	Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint)
+{
+	if (m_bPreserveStorageAfterLoadFailure)
 	{
-		YAML::Node outData;
-		outData["shaderCache"] = m_cache.Serialize();
-
-		std::ofstream assetFile(GetShaderCacheFilepath());
-		assetFile << outData;
-		assetFile.close();
-
-		m_bIsDirty = false;
+		return true;
 	}
+	if (!bForcely && !m_bIsDirty)
+	{
+		return true;
+	}
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+	if (failurePoint == Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None &&
+		m_nextSaveFailureForTests != Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None)
+	{
+		failurePoint = m_nextSaveFailureForTests;
+		m_nextSaveFailureForTests = Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None;
+	}
+#endif
+
+	std::string diagnostic;
+	if (WriteCacheDataLocked(m_cache, diagnostic, failurePoint))
+	{
+		m_bIsDirty = false;
+		m_committedCache = m_cache;
+		m_bHasCommittedSnapshot = true;
+
+		std::string sweepDiagnostic;
+		if (SweepUnreferencedArtifactsLocked(m_committedCache, sweepDiagnostic))
+		{
+			m_lastSaveDiagnostic.clear();
+			return true;
+		}
+
+		m_bIsDirty = true;
+		m_lastSaveDiagnostic = std::move(sweepDiagnostic);
+		SAILOR_LOG_ERROR("Shader cache post-commit cleanup failed: %s", m_lastSaveDiagnostic.c_str());
+		return false;
+	}
+
+	m_bIsDirty = true;
+	m_lastSaveDiagnostic = std::move(diagnostic);
+	SAILOR_LOG_ERROR("Shader cache save failed: %s", m_lastSaveDiagnostic.c_str());
+	return false;
 }
 
 void ShaderCache::LoadCache()
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	std::string yaml;
-	AssetRegistry::ReadAllTextFile(GetShaderCacheFilepath(), yaml);
-	YAML::Node yamlNode = YAML::Load(yaml);
-	m_cache.Deserialize(yamlNode["shaderCache"]);
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	Workspace::WorkspaceCacheLoadResult loadResult;
+	try
+	{
+		const auto identity = GetExpectedIdentityLocked();
+		loadResult = Workspace::LoadWorkspaceCacheEnvelope(GetCacheFilepathLocked(), identity);
+	}
+	catch (const std::exception& exception)
+	{
+		loadResult.m_status = Workspace::EWorkspaceCacheLoadStatus::IoFailure;
+		loadResult.m_diagnostic = "Cannot resolve or load the shader cache: " +
+			std::string(exception.what());
+	}
+	catch (...)
+	{
+		loadResult.m_status = Workspace::EWorkspaceCacheLoadStatus::IoFailure;
+		loadResult.m_diagnostic = "Cannot resolve or load the shader cache: unknown failure.";
+	}
 
-	m_bIsDirty = false;
+	if (loadResult.IsLoaded())
+	{
+		ShaderCacheData candidate;
+		std::string diagnostic;
+		bool bValidArtifacts = false;
+		bool bArtifactIoFailure = false;
+		if (TryDeserializeShaderCachePayload(loadResult.m_payload, candidate, diagnostic))
+		{
+			try
+			{
+				bValidArtifacts = ValidateAllArtifactsLocked(
+					candidate,
+					diagnostic,
+					bArtifactIoFailure);
+			}
+			catch (const std::exception& exception)
+			{
+				bArtifactIoFailure = true;
+				diagnostic = "Cannot resolve shader cache artifact paths: " +
+					std::string(exception.what());
+			}
+			catch (...)
+			{
+				bArtifactIoFailure = true;
+				diagnostic = "Cannot resolve shader cache artifact paths: unknown failure.";
+			}
+		}
+		if (bValidArtifacts)
+		{
+			m_cache = std::move(candidate);
+			m_committedCache = m_cache;
+			m_bIsDirty = false;
+			m_bPreserveStorageAfterLoadFailure = false;
+			m_bHasCommittedSnapshot = true;
+			m_quarantinedEntries.Clear();
+			m_lastSaveDiagnostic.clear();
+			m_lastLoadResult = std::move(loadResult);
+			return;
+		}
+
+		loadResult.m_status = bArtifactIoFailure
+			? Workspace::EWorkspaceCacheLoadStatus::IoFailure
+			: Workspace::EWorkspaceCacheLoadStatus::Corrupt;
+		loadResult.m_diagnostic = std::move(diagnostic);
+		loadResult.m_payload.clear();
+	}
+	if (m_bPreserveStorageAfterLoadFailure)
+	{
+		m_cache.m_data.Clear();
+		m_committedCache.m_data.Clear();
+		m_bIsDirty = false;
+		m_bHasCommittedSnapshot = false;
+		m_lastSaveDiagnostic.clear();
+		m_lastLoadResult = std::move(loadResult);
+		SAILOR_LOG_ERROR(
+			"Shader cache reload status=%s: %s Read-only I/O quarantine remains active until a fully successful reload or ClearAll.",
+			CacheLoadStatusName(m_lastLoadResult.m_status),
+			m_lastLoadResult.m_diagnostic.c_str());
+		return;
+	}
+	if (!ShouldResetCache(loadResult.m_status))
+	{
+		m_cache.m_data.Clear();
+		m_committedCache.m_data.Clear();
+		m_bIsDirty = false;
+		m_bPreserveStorageAfterLoadFailure = true;
+		m_bHasCommittedSnapshot = false;
+		m_lastSaveDiagnostic.clear();
+		m_lastLoadResult = std::move(loadResult);
+		SAILOR_LOG_ERROR(
+			"Shader cache load status=%s: %s Existing cache metadata and artifact directories were preserved.",
+			CacheLoadStatusName(m_lastLoadResult.m_status),
+			m_lastLoadResult.m_diagnostic.c_str());
+		return;
+	}
+
+	ResetInvalidCacheLocked(std::move(loadResult));
 }
 
-void ShaderCache::ClearAll()
+bool ShaderCache::WriteCacheDataLocked(
+	const ShaderCacheData& cache,
+	std::string& outDiagnostic,
+	Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint)
 {
-	std::lock_guard<std::mutex> lk(m_saveToCacheMutex);
+	try
+	{
+		std::string envelope;
+		const auto identity = GetExpectedIdentityLocked();
+		if (!Workspace::SerializeWorkspaceCacheEnvelope(
+			identity,
+			SerializeShaderCachePayload(cache),
+			envelope,
+			outDiagnostic))
+		{
+			return false;
+		}
 
-	std::filesystem::remove_all(GetPrecompiledShadersFolder());
-	std::filesystem::remove_all(GetCompiledShadersFolder());
-	std::filesystem::remove_all(GetCompiledShadersWithDebugFolder());
-	std::filesystem::remove(GetShaderCacheFilepath());
+		return Workspace::AtomicReplaceWorkspaceCacheText(
+			GetCacheFilepathLocked(),
+			envelope,
+			outDiagnostic,
+			failurePoint);
+	}
+	catch (const std::exception& exception)
+	{
+		outDiagnostic = "Cannot serialize shader cache payload: " + std::string(exception.what());
+		return false;
+	}
+	catch (...)
+	{
+		outDiagnostic = "Cannot serialize shader cache payload: unknown failure.";
+		return false;
+	}
 }
 
-void ShaderCache::ClearExpired()
+bool ShaderCache::WriteCacheLocked(std::string& outDiagnostic)
+{
+	return WriteCacheDataLocked(m_cache, outDiagnostic);
+}
+
+bool ShaderCache::CommitCandidateLocked(
+	ShaderCacheData candidate,
+	std::string& outDiagnostic,
+	Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint)
+{
+	if (m_bPreserveStorageAfterLoadFailure)
+	{
+		outDiagnostic = "Shader cache storage is quarantined after an I/O failure; persistent mutation is disabled.";
+		return false;
+	}
+	if (!WriteCacheDataLocked(candidate, outDiagnostic, failurePoint))
+	{
+		return false;
+	}
+	m_cache = std::move(candidate);
+	m_committedCache = m_cache;
+	m_bHasCommittedSnapshot = true;
+	m_bIsDirty = false;
+	m_lastSaveDiagnostic.clear();
+	return true;
+}
+
+void ShaderCache::ResetInvalidCacheLocked(Workspace::WorkspaceCacheLoadResult loadResult)
+{
+	m_cache.m_data.Clear();
+	m_committedCache.m_data.Clear();
+	m_quarantinedEntries.Clear();
+	m_bIsDirty = true;
+	m_bPreserveStorageAfterLoadFailure = false;
+	m_bHasCommittedSnapshot = false;
+	m_lastLoadResult = std::move(loadResult);
+
+	std::string resetDiagnostic;
+	const bool bFilesReset = ClearOwnedCacheFilesLocked(resetDiagnostic);
+	std::string writeDiagnostic;
+	const bool bEnvelopeWritten = WriteCacheLocked(writeDiagnostic);
+	if (bFilesReset && bEnvelopeWritten)
+	{
+		m_bIsDirty = false;
+		m_bPreserveStorageAfterLoadFailure = false;
+		m_committedCache = m_cache;
+		m_bHasCommittedSnapshot = true;
+		m_lastSaveDiagnostic.clear();
+		AppendDiagnostic(
+			m_lastLoadResult.m_diagnostic,
+			"The shader cache and owned artifact directories were reset to an empty current envelope.");
+		SAILOR_LOG(
+			"Shader cache load status=%s: %s",
+			CacheLoadStatusName(m_lastLoadResult.m_status),
+			m_lastLoadResult.m_diagnostic.c_str());
+		return;
+	}
+
+	m_bIsDirty = true;
+	m_bPreserveStorageAfterLoadFailure = false;
+	m_bHasCommittedSnapshot = false;
+	m_lastSaveDiagnostic.clear();
+	AppendDiagnostic(m_lastSaveDiagnostic, resetDiagnostic);
+	AppendDiagnostic(m_lastSaveDiagnostic, writeDiagnostic);
+	AppendDiagnostic(
+		m_lastLoadResult.m_diagnostic,
+		"The shader cache reset was incomplete: " + m_lastSaveDiagnostic);
+	SAILOR_LOG_ERROR(
+		"Shader cache load status=%s: %s",
+		CacheLoadStatusName(m_lastLoadResult.m_status),
+		m_lastLoadResult.m_diagnostic.c_str());
+}
+
+void ShaderCache::EnterStorageQuarantineLocked(std::string diagnostic)
+{
+	m_cache.m_data.Clear();
+	m_committedCache.m_data.Clear();
+	m_bIsDirty = false;
+	m_bPreserveStorageAfterLoadFailure = true;
+	m_bHasCommittedSnapshot = false;
+	m_lastSaveDiagnostic.clear();
+	m_lastLoadResult.m_status = Workspace::EWorkspaceCacheLoadStatus::IoFailure;
+	m_lastLoadResult.m_diagnostic = std::move(diagnostic);
+	m_lastLoadResult.m_payload.clear();
+	SAILOR_LOG_ERROR(
+		"Shader cache entered read-only I/O quarantine: %s Existing metadata and artifacts were preserved.",
+		m_lastLoadResult.m_diagnostic.c_str());
+}
+
+bool ShaderCache::EnsureOwnedDirectoriesLocked(std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	std::error_code error;
+	std::filesystem::create_directories(m_cacheRoot, error);
+	if (error)
+	{
+		outDiagnostic = "Cannot create shader cache root '" + m_cacheRoot.generic_string() +
+			"': " + error.message();
+		return false;
+	}
+
+	bool bSuccess = true;
+	const std::filesystem::path directories[] =
+	{
+		GetPrecompiledFolderLocked(),
+		GetCompiledFolderLocked(),
+		GetCompiledDebugFolderLocked()
+	};
+	for (const auto& directory : directories)
+	{
+		error.clear();
+		const auto status = std::filesystem::symlink_status(directory, error);
+		if (!error && std::filesystem::is_symlink(status))
+		{
+			AppendDiagnostic(
+				outDiagnostic,
+				"Refusing symlinked shader cache directory '" + directory.generic_string() + "'.");
+			bSuccess = false;
+			continue;
+		}
+
+		error.clear();
+		std::filesystem::create_directories(directory, error);
+		if (error)
+		{
+			AppendDiagnostic(
+				outDiagnostic,
+				"Cannot create shader cache directory '" + directory.generic_string() +
+				"': " + error.message());
+			bSuccess = false;
+			continue;
+		}
+
+		std::filesystem::path canonical;
+		std::string diagnostic;
+		if (!ResolveDirectCacheChild(m_cacheRoot, directory, canonical, diagnostic))
+		{
+			AppendDiagnostic(outDiagnostic, diagnostic);
+			bSuccess = false;
+		}
+	}
+
+	m_bStorageReady = bSuccess;
+	return bSuccess;
+}
+
+bool ShaderCache::ClearOwnedCacheFilesLocked(std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	bool bSuccess = true;
+	bSuccess &= RemovePath(m_cacheRoot, GetCacheFilepathLocked(), false, outDiagnostic);
+	bSuccess &= RemovePath(m_cacheRoot, GetPrecompiledFolderLocked(), true, outDiagnostic);
+	bSuccess &= RemovePath(m_cacheRoot, GetCompiledFolderLocked(), true, outDiagnostic);
+	bSuccess &= RemovePath(m_cacheRoot, GetCompiledDebugFolderLocked(), true, outDiagnostic);
+
+	std::string createDiagnostic;
+	if (!EnsureOwnedDirectoriesLocked(createDiagnostic))
+	{
+		AppendDiagnostic(outDiagnostic, createDiagnostic);
+		bSuccess = false;
+	}
+	return bSuccess;
+}
+
+bool ShaderCache::ValidateArtifactSetLocked(
+	const ShaderCacheData::Entry& entry,
+	const ArtifactSet& artifacts,
+	bool bIsDebug,
+	std::string& outDiagnostic,
+	bool& outIoFailure) const
+{
+	TVector<uint32_t> ignored;
+	const std::filesystem::path ownedDirectory = bIsDebug
+		? GetCompiledDebugFolderLocked()
+		: GetCompiledFolderLocked();
+	if (!ReadOwnedSpirvArtifactLocked(
+		ownedDirectory,
+		GetArtifactPathLocked(entry, VertexShaderTag, bIsDebug),
+		artifacts.m_vertex,
+		ignored,
+		outDiagnostic,
+		outIoFailure))
+	{
+		return false;
+	}
+	if (!ReadOwnedSpirvArtifactLocked(
+		ownedDirectory,
+		GetArtifactPathLocked(entry, FragmentShaderTag, bIsDebug),
+		artifacts.m_fragment,
+		ignored,
+		outDiagnostic,
+		outIoFailure))
+	{
+		return false;
+	}
+	return ReadOwnedSpirvArtifactLocked(
+		ownedDirectory,
+		GetArtifactPathLocked(entry, ComputeShaderTag, bIsDebug),
+		artifacts.m_compute,
+		ignored,
+		outDiagnostic,
+		outIoFailure);
+}
+
+bool ShaderCache::ReadOwnedSpirvArtifactLocked(
+	const std::filesystem::path& ownedDirectory,
+	const std::filesystem::path& artifact,
+	const ArtifactMetadata& metadata,
+	TVector<uint32_t>& outSpirv,
+	std::string& outDiagnostic,
+	bool& outIoFailure) const
+{
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+	if (m_bArtifactReadIoFailureForTests)
+	{
+		outIoFailure = true;
+		outDiagnostic = "Injected shader artifact read I/O failure for lifecycle validation.";
+		return false;
+	}
+#endif
+
+	std::filesystem::path canonicalArtifact;
+	if (!ResolveOwnedArtifactPath(
+		m_cacheRoot,
+		ownedDirectory,
+		artifact,
+		canonicalArtifact,
+		outDiagnostic,
+		outIoFailure))
+	{
+		return false;
+	}
+	return ReadSpirvArtifactInternal(
+		artifact,
+		metadata,
+		outSpirv,
+		outDiagnostic,
+		outIoFailure);
+}
+
+bool ShaderCache::ValidateAllArtifactsLocked(
+	const ShaderCacheData& candidate,
+	std::string& outDiagnostic,
+	bool& outIoFailure) const
+{
+	outIoFailure = false;
+	for (const auto& fileEntries : candidate.m_data)
+	{
+		for (const ShaderCacheData::Entry& entry : *fileEntries.m_second)
+		{
+			if (!ValidateArtifactSetLocked(
+				entry,
+				entry.m_regular,
+				false,
+				outDiagnostic,
+				outIoFailure) ||
+				!ValidateArtifactSetLocked(
+					entry,
+					entry.m_debug,
+					true,
+					outDiagnostic,
+					outIoFailure))
+			{
+				outDiagnostic = "Shader cache artifact validation failed for fileId '" +
+					entry.m_fileId.ToString() + "', permutation " +
+					std::to_string(entry.m_permutation) + ": " + outDiagnostic;
+				return false;
+			}
+		}
+	}
+	outDiagnostic.clear();
+	return true;
+}
+
+bool ShaderCache::WriteSpirvSetLocked(
+	const FileId& uid,
+	uint32_t permutation,
+	const std::string& generation,
+	const TVector<uint32_t>& vertexSpirv,
+	const TVector<uint32_t>& fragmentSpirv,
+	const TVector<uint32_t>& computeSpirv,
+	const ArtifactSet& metadata,
+	bool bIsDebug,
+	int32_t& artifactIndex,
+	int32_t failArtifactIndex,
+	std::string& outDiagnostic)
+{
+	if (!EnsureOwnedDirectoriesLocked(outDiagnostic))
+	{
+		return false;
+	}
+
+	if (!IsValidArtifactSet(metadata, false))
+	{
+		outDiagnostic = "A shader artifact set must contain a vertex/fragment pair or compute artifact.";
+		return false;
+	}
+
+	ShaderCacheData::Entry pathEntry;
+	pathEntry.m_fileId = uid;
+	pathEntry.m_permutation = permutation;
+	pathEntry.m_generation = generation;
+	auto write = [&](const TVector<uint32_t>& spirv,
+		const ArtifactMetadata& artifact,
+		const char* shaderKind) -> bool
+	{
+		if (!artifact.IsPresent())
+		{
+			return true;
+		}
+		const auto path = GetArtifactPathLocked(pathEntry, shaderKind, bIsDebug);
+		const auto ownedDirectory = bIsDebug
+			? GetCompiledDebugFolderLocked()
+			: GetCompiledFolderLocked();
+		std::filesystem::path canonicalArtifact;
+		bool ignoredIoFailure = false;
+		if (!ResolveOwnedArtifactPath(
+			m_cacheRoot,
+			ownedDirectory,
+			path,
+			canonicalArtifact,
+			outDiagnostic,
+			ignoredIoFailure))
+		{
+			return false;
+		}
+		std::string diagnostic;
+		const auto failurePoint = artifactIndex == failArtifactIndex
+			? Workspace::EWorkspaceCacheAtomicWriteFailurePoint::BeforeReplace
+			: Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None;
+		++artifactIndex;
+		if (!Workspace::AtomicReplaceWorkspaceCacheBinary(
+			path,
+			&spirv[0],
+			artifact.m_byteLength,
+			diagnostic,
+			failurePoint))
+		{
+			outDiagnostic = "Cannot atomically write shader artifact '" +
+				path.generic_string() + "': " + diagnostic;
+			return false;
+		}
+		return true;
+	};
+
+	if (!write(vertexSpirv, metadata.m_vertex, VertexShaderTag) ||
+		!write(fragmentSpirv, metadata.m_fragment, FragmentShaderTag) ||
+		!write(computeSpirv, metadata.m_compute, ComputeShaderTag))
+	{
+		return false;
+	}
+
+	outDiagnostic.clear();
+	return true;
+}
+
+bool ShaderCache::GenerateUniqueGenerationLocked(
+	const FileId& uid,
+	uint32_t permutation,
+	std::string& outGeneration,
+	std::string& outDiagnostic) const
+{
+	try
+	{
+		std::random_device random;
+		for (uint32_t attempt = 0; attempt < 64; ++attempt)
+		{
+			std::ostringstream stream;
+			stream << std::hex << std::nouppercase << std::setfill('0');
+			for (uint32_t word = 0; word < 4; ++word)
+			{
+				stream << std::setw(8) << static_cast<uint32_t>(random());
+			}
+			const std::string generation = stream.str();
+			if (!IsValidGeneration(generation))
+			{
+				continue;
+			}
+
+			ShaderCacheData::Entry entry;
+			entry.m_fileId = uid;
+			entry.m_permutation = permutation;
+			entry.m_generation = generation;
+			const std::pair<std::filesystem::path, bool> candidates[] =
+			{
+				{ GetArtifactPathLocked(entry, VertexShaderTag, false), false },
+				{ GetArtifactPathLocked(entry, FragmentShaderTag, false), false },
+				{ GetArtifactPathLocked(entry, ComputeShaderTag, false), false },
+				{ GetArtifactPathLocked(entry, VertexShaderTag, true), true },
+				{ GetArtifactPathLocked(entry, FragmentShaderTag, true), true },
+				{ GetArtifactPathLocked(entry, ComputeShaderTag, true), true }
+			};
+			bool bCollision = false;
+			for (const auto& [candidate, bIsDebug] : candidates)
+			{
+				std::filesystem::path canonicalArtifact;
+				bool ignoredIoFailure = false;
+				const std::filesystem::path ownedDirectory = bIsDebug
+					? GetCompiledDebugFolderLocked()
+					: GetCompiledFolderLocked();
+				if (!ResolveOwnedArtifactPath(
+					m_cacheRoot,
+					ownedDirectory,
+					candidate,
+					canonicalArtifact,
+					outDiagnostic,
+					ignoredIoFailure))
+				{
+					return false;
+				}
+				std::error_code error;
+				if (std::filesystem::exists(candidate, error))
+				{
+					bCollision = true;
+					break;
+				}
+				if (error)
+				{
+					outDiagnostic = "Cannot check immutable shader generation collision for '" +
+						candidate.generic_string() + "': " + error.message();
+					return false;
+				}
+			}
+			if (!bCollision)
+			{
+				outGeneration = generation;
+				outDiagnostic.clear();
+				return true;
+			}
+		}
+		outDiagnostic = "Cannot allocate a collision-free immutable shader artifact generation.";
+		return false;
+	}
+	catch (const std::exception& exception)
+	{
+		outDiagnostic = "Cannot generate immutable shader artifact identity: " +
+			std::string(exception.what());
+		return false;
+	}
+	catch (...)
+	{
+		outDiagnostic = "Cannot generate immutable shader artifact identity: unknown failure.";
+		return false;
+	}
+}
+
+bool ShaderCache::CachePrecompiledGlsl(
+	const FileId& uid,
+	uint32_t permutation,
+	const std::string& vertexGlsl,
+	const std::string& fragmentGlsl,
+	const std::string& computeGlsl)
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	TVector<FileId> expiredShaders;
-	TSet<std::string> whiteListSpirv;
-	TVector<ShaderCacheData::Entry> blackListEntry;
-
-	for (const auto& entries : m_cache.m_data)
+	if (!m_bSavePrecompiledGlsl)
 	{
-		if (Contains(entries.m_first))
-		{
-			for (const auto& entry : *entries.m_second)
-			{
-				if (!IsExpired(entry.m_fileId, entry.m_permutation))
-				{
-					//Convert to the same path format
-					auto vertexFilepath = GetCachedShaderFilepath(entry.m_fileId, entry.m_permutation, ShaderCache::VertexShaderTag);
-					auto fragmentFilepath = GetCachedShaderFilepath(entry.m_fileId, entry.m_permutation, ShaderCache::FragmentShaderTag);
-					auto computeFilepath = GetCachedShaderFilepath(entry.m_fileId, entry.m_permutation, ShaderCache::ComputeShaderTag);
+		return true;
+	}
 
-					whiteListSpirv.Insert(vertexFilepath.string());
-					whiteListSpirv.Insert(fragmentFilepath.string());
-					whiteListSpirv.Insert(computeFilepath.string());
-				}
-				else
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	if (m_bPreserveStorageAfterLoadFailure)
+	{
+		m_lastSaveDiagnostic = "Precompiled GLSL persistence is disabled during read-only shader cache quarantine.";
+		return false;
+	}
+	std::string diagnostic;
+	if (!EnsureOwnedDirectoriesLocked(diagnostic))
+	{
+		m_lastSaveDiagnostic = std::move(diagnostic);
+		SAILOR_LOG_ERROR("Precompiled shader cache write failed: %s", m_lastSaveDiagnostic.c_str());
+		return false;
+	}
+
+	auto write = [&](const std::string& glsl, const char* shaderKind) -> bool
+	{
+		if (glsl.empty())
+		{
+			return true;
+		}
+		const auto path = GetShaderFilepath(
+			GetPrecompiledFolderLocked(),
+			uid,
+			static_cast<int32_t>(permutation),
+			shaderKind,
+			PrecompiledShaderFileExtension);
+		std::filesystem::path canonicalArtifact;
+		bool ignoredIoFailure = false;
+		if (!ResolveOwnedArtifactPath(
+			m_cacheRoot,
+			GetPrecompiledFolderLocked(),
+			path,
+			canonicalArtifact,
+			m_lastSaveDiagnostic,
+			ignoredIoFailure))
+		{
+			SAILOR_LOG_ERROR("Precompiled shader cache write failed: %s", m_lastSaveDiagnostic.c_str());
+			return false;
+		}
+		std::string writeDiagnostic;
+		if (!Workspace::AtomicReplaceWorkspaceCacheText(path, glsl, writeDiagnostic))
+		{
+			m_lastSaveDiagnostic = "Cannot atomically write precompiled shader '" +
+				path.generic_string() + "': " + writeDiagnostic;
+			SAILOR_LOG_ERROR("Precompiled shader cache write failed: %s", m_lastSaveDiagnostic.c_str());
+			return false;
+		}
+		return true;
+	};
+
+	return write(vertexGlsl, VertexShaderTag) &&
+		write(fragmentGlsl, FragmentShaderTag) &&
+		write(computeGlsl, ComputeShaderTag);
+}
+
+ShaderCache::QuarantinedEntry* ShaderCache::FindQuarantinedEntryLocked(
+	const FileId& uid,
+	uint32_t permutation)
+{
+	const size_t index = m_quarantinedEntries.FindIf([&](const QuarantinedEntry& entry)
+		{
+			return entry.m_fileId == uid && entry.m_permutation == permutation;
+		});
+	return index == static_cast<size_t>(-1) ? nullptr : &m_quarantinedEntries[index];
+}
+
+const ShaderCache::QuarantinedEntry* ShaderCache::FindQuarantinedEntryLocked(
+	const FileId& uid,
+	uint32_t permutation) const
+{
+	const size_t index = m_quarantinedEntries.FindIf([&](const QuarantinedEntry& entry)
+		{
+			return entry.m_fileId == uid && entry.m_permutation == permutation;
+		});
+	return index == static_cast<size_t>(-1) ? nullptr : &m_quarantinedEntries[index];
+}
+
+bool ShaderCache::CacheCompleteSpirvLocked(
+	const FileId& uid,
+	uint32_t permutation,
+	const TVector<uint32_t>& vertexSpirv,
+	const TVector<uint32_t>& fragmentSpirv,
+	const TVector<uint32_t>& computeSpirv,
+	const TVector<uint32_t>& debugVertexSpirv,
+	const TVector<uint32_t>& debugFragmentSpirv,
+	const TVector<uint32_t>& debugComputeSpirv,
+	int32_t failArtifactIndex,
+	std::string& outDiagnostic)
+{
+	ArtifactSet regularMetadata;
+	ArtifactSet debugMetadata;
+	if (!DescribeArtifactSet(vertexSpirv, fragmentSpirv, computeSpirv, regularMetadata, outDiagnostic) ||
+		!DescribeArtifactSet(
+			debugVertexSpirv,
+			debugFragmentSpirv,
+			debugComputeSpirv,
+			debugMetadata,
+			outDiagnostic))
+	{
+		return false;
+	}
+	if (!HasMatchingArtifactTopology(regularMetadata, debugMetadata))
+	{
+		outDiagnostic = "Regular and debug shader artifact sets must contain identical shader stages.";
+		return false;
+	}
+
+	time_t timestamp = 0;
+	GetTimeStamp(uid, timestamp);
+	if (m_bPreserveStorageAfterLoadFailure)
+	{
+		QuarantinedEntry candidate;
+		candidate.m_fileId = uid;
+		candidate.m_permutation = permutation;
+		candidate.m_timestamp = timestamp;
+		candidate.m_vertex = vertexSpirv;
+		candidate.m_fragment = fragmentSpirv;
+		candidate.m_compute = computeSpirv;
+		candidate.m_debugVertex = debugVertexSpirv;
+		candidate.m_debugFragment = debugFragmentSpirv;
+		candidate.m_debugCompute = debugComputeSpirv;
+		if (QuarantinedEntry* existing = FindQuarantinedEntryLocked(uid, permutation))
+		{
+			*existing = std::move(candidate);
+		}
+		else
+		{
+			m_quarantinedEntries.Add(std::move(candidate));
+		}
+		outDiagnostic.clear();
+		return true;
+	}
+
+	if (!EnsureOwnedDirectoriesLocked(outDiagnostic))
+	{
+		return false;
+	}
+	std::string generation;
+	if (!GenerateUniqueGenerationLocked(uid, permutation, generation, outDiagnostic))
+	{
+		return false;
+	}
+	int32_t artifactIndex = 0;
+	if (!WriteSpirvSetLocked(
+		uid,
+		permutation,
+		generation,
+		vertexSpirv,
+		fragmentSpirv,
+		computeSpirv,
+		regularMetadata,
+		false,
+		artifactIndex,
+		failArtifactIndex,
+		outDiagnostic) ||
+		!WriteSpirvSetLocked(
+			uid,
+			permutation,
+			generation,
+			debugVertexSpirv,
+			debugFragmentSpirv,
+			debugComputeSpirv,
+			debugMetadata,
+			true,
+			artifactIndex,
+			failArtifactIndex,
+			outDiagnostic))
+	{
+		return false;
+	}
+
+	auto& entries = m_cache.m_data[uid];
+	auto existing = std::find_if(
+		std::begin(entries),
+		std::end(entries),
+		[permutation](const ShaderCacheData::Entry& entry)
+		{
+			return entry.m_permutation == permutation;
+		});
+	ShaderCacheData::Entry candidate;
+	candidate.m_fileId = uid;
+	candidate.m_permutation = permutation;
+	candidate.m_timestamp = timestamp;
+	candidate.m_generation = generation;
+	candidate.m_regular = regularMetadata;
+	candidate.m_debug = debugMetadata;
+	if (existing == std::end(entries))
+	{
+		entries.Add(std::move(candidate));
+	}
+	else
+	{
+		*existing = std::move(candidate);
+	}
+
+	const size_t quarantinedIndex = m_quarantinedEntries.FindIf([&](const QuarantinedEntry& entry)
+		{
+			return entry.m_fileId == uid && entry.m_permutation == permutation;
+		});
+	if (quarantinedIndex != static_cast<size_t>(-1))
+	{
+		m_quarantinedEntries.RemoveAt(quarantinedIndex);
+	}
+	m_bIsDirty = true;
+	outDiagnostic.clear();
+	return true;
+}
+
+bool ShaderCache::CacheSpirv_ThreadSafe(
+	const FileId& uid,
+	uint32_t permutation,
+	const TVector<uint32_t>& vertexSpirv,
+	const TVector<uint32_t>& fragmentSpirv,
+	const TVector<uint32_t>& computeSpirv,
+	const TVector<uint32_t>& debugVertexSpirv,
+	const TVector<uint32_t>& debugFragmentSpirv,
+	const TVector<uint32_t>& debugComputeSpirv)
+{
+	SAILOR_PROFILE_FUNCTION();
+
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	std::string diagnostic;
+	if (!CacheCompleteSpirvLocked(
+		uid,
+		permutation,
+		vertexSpirv,
+		fragmentSpirv,
+		computeSpirv,
+		debugVertexSpirv,
+		debugFragmentSpirv,
+		debugComputeSpirv,
+		-1,
+		diagnostic))
+	{
+		m_lastSaveDiagnostic = std::move(diagnostic);
+		SAILOR_LOG_ERROR("Complete SPIR-V cache publication failed: %s", m_lastSaveDiagnostic.c_str());
+		return false;
+	}
+	m_lastSaveDiagnostic.clear();
+	return true;
+}
+
+bool ShaderCache::GetSpirvCode(
+	const FileId& uid,
+	uint32_t permutation,
+	TVector<uint32_t>& vertexSpirv,
+	TVector<uint32_t>& fragmentSpirv,
+	TVector<uint32_t>& computeSpirv,
+	bool bIsDebug)
+{
+	SAILOR_PROFILE_FUNCTION();
+
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	if (IsExpiredLocked(uid, permutation))
+	{
+		return false;
+	}
+	if (const QuarantinedEntry* quarantined = FindQuarantinedEntryLocked(uid, permutation))
+	{
+		const TVector<uint32_t>& candidateVertex = bIsDebug
+			? quarantined->m_debugVertex
+			: quarantined->m_vertex;
+		const TVector<uint32_t>& candidateFragment = bIsDebug
+			? quarantined->m_debugFragment
+			: quarantined->m_fragment;
+		const TVector<uint32_t>& candidateCompute = bIsDebug
+			? quarantined->m_debugCompute
+			: quarantined->m_compute;
+		vertexSpirv = candidateVertex;
+		fragmentSpirv = candidateFragment;
+		computeSpirv = candidateCompute;
+		return true;
+	}
+
+	auto& entries = m_cache.m_data[uid];
+	auto entry = std::find_if(
+		std::cbegin(entries),
+		std::cend(entries),
+		[permutation](const ShaderCacheData::Entry& candidate)
+		{
+			return candidate.m_permutation == permutation;
+		});
+	if (entry == std::cend(entries))
+	{
+		return false;
+	}
+
+	const ArtifactSet& artifacts = bIsDebug ? entry->m_debug : entry->m_regular;
+	if (!IsValidArtifactSet(artifacts, false))
+	{
+		return false;
+	}
+
+	TVector<uint32_t> candidateVertex;
+	TVector<uint32_t> candidateFragment;
+	TVector<uint32_t> candidateCompute;
+	std::string diagnostic;
+	bool ignoredIoFailure = false;
+	const std::filesystem::path ownedDirectory = bIsDebug
+		? GetCompiledDebugFolderLocked()
+		: GetCompiledFolderLocked();
+	if (!ReadOwnedSpirvArtifactLocked(
+		ownedDirectory,
+		GetArtifactPathLocked(*entry, VertexShaderTag, bIsDebug),
+		artifacts.m_vertex,
+		candidateVertex,
+		diagnostic,
+		ignoredIoFailure) ||
+		!ReadOwnedSpirvArtifactLocked(
+			ownedDirectory,
+			GetArtifactPathLocked(*entry, FragmentShaderTag, bIsDebug),
+			artifacts.m_fragment,
+			candidateFragment,
+			diagnostic,
+			ignoredIoFailure) ||
+		!ReadOwnedSpirvArtifactLocked(
+			ownedDirectory,
+			GetArtifactPathLocked(*entry, ComputeShaderTag, bIsDebug),
+			artifacts.m_compute,
+		candidateCompute,
+		diagnostic,
+		ignoredIoFailure))
+	{
+		if (ignoredIoFailure)
+		{
+			EnterStorageQuarantineLocked(
+				"Runtime shader artifact read failed for fileId '" + uid.ToString() +
+				"', permutation " + std::to_string(permutation) + ": " + diagnostic);
+		}
+		return false;
+	}
+
+	vertexSpirv = std::move(candidateVertex);
+	fragmentSpirv = std::move(candidateFragment);
+	computeSpirv = std::move(candidateCompute);
+	return true;
+}
+
+bool ShaderCache::Contains(const FileId& uid) const
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	return m_cache.m_data.ContainsKey(uid) ||
+		m_quarantinedEntries.ContainsIf([&](const QuarantinedEntry& entry)
+			{
+				return entry.m_fileId == uid;
+			});
+}
+
+bool ShaderCache::IsExpired(const FileId& uid, uint32_t permutation)
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	return IsExpiredLocked(uid, permutation);
+}
+
+bool ShaderCache::IsExpiredLocked(const FileId& uid, uint32_t permutation)
+{
+	if (const QuarantinedEntry* quarantined = FindQuarantinedEntryLocked(uid, permutation))
+	{
+		time_t timestamp = 0;
+		const bool bHasAsset = GetTimeStamp(uid, timestamp);
+		return !bHasAsset || quarantined->m_timestamp < timestamp;
+	}
+	if (!m_cache.m_data.ContainsKey(uid))
+	{
+		return true;
+	}
+
+	const auto& entries = m_cache.m_data[uid];
+	const size_t index = entries.FindIf([permutation](const ShaderCacheData::Entry& entry)
+		{
+			return entry.m_permutation == permutation;
+		});
+	if (index == static_cast<size_t>(-1))
+	{
+		return true;
+	}
+
+	const ShaderCacheData::Entry& entry = entries[index];
+	if (!IsValidArtifactSet(entry.m_regular, false) ||
+		!IsValidArtifactSet(entry.m_debug, false) ||
+		!HasMatchingArtifactTopology(entry.m_regular, entry.m_debug) ||
+		!IsValidGeneration(entry.m_generation))
+	{
+		return true;
+	}
+
+	std::string diagnostic;
+	bool bArtifactIoFailure = false;
+	if (!ValidateArtifactSetLocked(
+		entry,
+		entry.m_regular,
+		false,
+		diagnostic,
+		bArtifactIoFailure) ||
+		!ValidateArtifactSetLocked(
+			entry,
+			entry.m_debug,
+			true,
+			diagnostic,
+			bArtifactIoFailure))
+	{
+		if (bArtifactIoFailure)
+		{
+			EnterStorageQuarantineLocked(
+				"Runtime shader artifact validation failed for fileId '" + uid.ToString() +
+				"', permutation " + std::to_string(permutation) + ": " + diagnostic);
+		}
+		return true;
+	}
+
+	time_t timestamp = 0;
+	const bool bHasAsset = GetTimeStamp(uid, timestamp);
+	return !bHasAsset || entry.m_timestamp < timestamp;
+}
+
+bool ShaderCache::SweepUnreferencedArtifactsLocked(
+	const ShaderCacheData& committedSnapshot,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+	if (m_bArtifactSweepFailureForTests)
+	{
+		m_bArtifactSweepFailureForTests = false;
+		outDiagnostic = "Injected shader artifact sweep failure for lifecycle validation.";
+		return false;
+	}
+#endif
+	if (!m_bHasCommittedSnapshot)
+	{
+		outDiagnostic = "Cannot sweep shader artifacts without a successfully committed metadata snapshot.";
+		return false;
+	}
+	if (!EnsureOwnedDirectoriesLocked(outDiagnostic))
+	{
+		return false;
+	}
+
+	std::unordered_set<std::string> whitelist;
+	for (const auto& fileEntries : committedSnapshot.m_data)
+	{
+		for (const ShaderCacheData::Entry& entry : *fileEntries.m_second)
+		{
+			const std::pair<const ArtifactMetadata*, const char*> regular[] =
+			{
+				{ &entry.m_regular.m_vertex, VertexShaderTag },
+				{ &entry.m_regular.m_fragment, FragmentShaderTag },
+				{ &entry.m_regular.m_compute, ComputeShaderTag }
+			};
+			const std::pair<const ArtifactMetadata*, const char*> debug[] =
+			{
+				{ &entry.m_debug.m_vertex, VertexShaderTag },
+				{ &entry.m_debug.m_fragment, FragmentShaderTag },
+				{ &entry.m_debug.m_compute, ComputeShaderTag }
+			};
+			for (const auto& [metadata, kind] : regular)
+			{
+				if (metadata->IsPresent())
 				{
-					blackListEntry.Add(entry);
+					whitelist.emplace(GetArtifactPathLocked(entry, kind, false).lexically_normal().generic_string());
+					if (m_bSavePrecompiledGlsl)
+					{
+						whitelist.emplace(GetShaderFilepath(
+							GetPrecompiledFolderLocked(),
+							entry.m_fileId,
+							entry.m_permutation,
+							kind,
+							PrecompiledShaderFileExtension).lexically_normal().generic_string());
+					}
+				}
+			}
+			for (const auto& [metadata, kind] : debug)
+			{
+				if (metadata->IsPresent())
+				{
+					whitelist.emplace(GetArtifactPathLocked(entry, kind, true).lexically_normal().generic_string());
 				}
 			}
 		}
 	}
 
-	for (auto& entry : blackListEntry)
+	bool bSuccess = true;
+	const std::filesystem::path artifactFolders[] =
 	{
-		Remove(entry);
-	}
-
-	for (const auto& entry : std::filesystem::directory_iterator(GetCompiledShadersFolder()))
+		GetCompiledFolderLocked(),
+		GetCompiledDebugFolderLocked(),
+		GetPrecompiledFolderLocked()
+	};
+	for (const auto& folder : artifactFolders)
 	{
-		if (entry.is_regular_file() && !whiteListSpirv.Contains(entry.path().string()))
+		std::error_code error;
+		for (std::filesystem::directory_iterator iterator(folder, error), end;
+			!error && iterator != end;
+			iterator.increment(error))
 		{
-			std::filesystem::remove(entry);
+			const auto& path = iterator->path();
+			if (iterator->is_regular_file(error) &&
+				!whitelist.contains(path.lexically_normal().generic_string()))
+			{
+				std::string diagnostic;
+				if (!RemoveOwnedArtifact(m_cacheRoot, folder, path, diagnostic))
+				{
+					AppendDiagnostic(outDiagnostic, diagnostic);
+					bSuccess = false;
+				}
+			}
+		}
+		if (error)
+		{
+			AppendDiagnostic(
+				outDiagnostic,
+				"Cannot sweep shader cache directory '" + folder.generic_string() +
+					"': " + error.message());
+			bSuccess = false;
 		}
 	}
-
-	SaveCache();
+	return bSuccess;
 }
 
-void ShaderCache::Remove(const ShaderCacheData::Entry& pEntry)
+bool ShaderCache::RemoveLocked(
+	const FileId& uid,
+	Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint,
+	std::string& outDiagnostic)
 {
-	SAILOR_PROFILE_FUNCTION();
-
-	auto it = m_cache.m_data.Find(pEntry.m_fileId);
-	if (it != m_cache.m_data.end())
+	for (size_t index = m_quarantinedEntries.Num(); index > 0; --index)
 	{
-		FileId uid = pEntry.m_fileId;
-
-		std::filesystem::remove(GetCachedShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::VertexShaderTag));
-		std::filesystem::remove(GetCachedShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::FragmentShaderTag));
-		std::filesystem::remove(GetCachedShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::ComputeShaderTag));
-
-		std::filesystem::remove(GetCachedShaderWithDebugFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::VertexShaderTag));
-		std::filesystem::remove(GetCachedShaderWithDebugFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::FragmentShaderTag));
-		std::filesystem::remove(GetCachedShaderWithDebugFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::ComputeShaderTag));
-
-		std::filesystem::remove(GetPrecompiledShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::VertexShaderTag));
-		std::filesystem::remove(GetPrecompiledShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::FragmentShaderTag));
-		std::filesystem::remove(GetPrecompiledShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::ComputeShaderTag));
-
-		auto& entries = m_cache.m_data[pEntry.m_fileId];
-
-		entries.Remove(pEntry);
-
-		m_bIsDirty = true;
-
-		if (entries.Num() == 0)
+		if (m_quarantinedEntries[index - 1].m_fileId == uid)
 		{
-			Remove(uid);
+			m_quarantinedEntries.RemoveAt(index - 1);
 		}
 	}
+	if (m_bPreserveStorageAfterLoadFailure)
+	{
+		outDiagnostic.clear();
+		return true;
+	}
+	if (!m_cache.m_data.ContainsKey(uid))
+	{
+		outDiagnostic.clear();
+		return true;
+	}
+
+	ShaderCacheData candidate = m_cache;
+	candidate.m_data.Remove(uid);
+	if (!CommitCandidateLocked(std::move(candidate), outDiagnostic, failurePoint))
+	{
+		return false;
+	}
+	std::string sweepDiagnostic;
+	if (!SweepUnreferencedArtifactsLocked(m_committedCache, sweepDiagnostic))
+	{
+		m_bIsDirty = true;
+		AppendDiagnostic(outDiagnostic, sweepDiagnostic);
+		return false;
+	}
+	outDiagnostic.clear();
+	return true;
 }
 
 void ShaderCache::Remove(const FileId& uid)
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	std::lock_guard<std::mutex> lk(m_saveToCacheMutex);
-
-	auto it = m_cache.m_data.Find(uid);
-	if (it != m_cache.m_data.end())
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	std::string diagnostic;
+	if (!RemoveLocked(uid, Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None, diagnostic))
 	{
-		const auto& entries = *it;
+		m_lastSaveDiagnostic = std::move(diagnostic);
+		SAILOR_LOG_ERROR("Shader cache remove failed: %s", m_lastSaveDiagnostic.c_str());
+	}
+}
 
-		for (const auto& pEntry : *entries.m_second)
+bool ShaderCache::ClearExpiredLocked(
+	Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint,
+	std::string& outDiagnostic)
+{
+	if (m_bPreserveStorageAfterLoadFailure)
+	{
+		outDiagnostic.clear();
+		return true;
+	}
+
+	TVector<ShaderCacheData::Entry> expired;
+	const ShaderCacheData inspectedCache = m_cache;
+	for (const auto& fileEntries : inspectedCache.m_data)
+	{
+		for (const ShaderCacheData::Entry& entry : *fileEntries.m_second)
 		{
-			std::filesystem::remove(GetCachedShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::VertexShaderTag));
-			std::filesystem::remove(GetCachedShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::FragmentShaderTag));
-			std::filesystem::remove(GetCachedShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::ComputeShaderTag));
-
-			std::filesystem::remove(GetCachedShaderWithDebugFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::VertexShaderTag));
-			std::filesystem::remove(GetCachedShaderWithDebugFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::FragmentShaderTag));
-			std::filesystem::remove(GetCachedShaderWithDebugFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::ComputeShaderTag));
-
-			std::filesystem::remove(GetPrecompiledShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::VertexShaderTag));
-			std::filesystem::remove(GetPrecompiledShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::FragmentShaderTag));
-			std::filesystem::remove(GetPrecompiledShaderFilepath(pEntry.m_fileId, pEntry.m_permutation, ShaderCache::ComputeShaderTag));
+			if (IsExpiredLocked(entry.m_fileId, entry.m_permutation))
+			{
+				if (m_bPreserveStorageAfterLoadFailure)
+				{
+					outDiagnostic.clear();
+					return true;
+				}
+				expired.Add(entry);
+			}
 		}
+	}
+	ShaderCacheData candidate = m_cache;
+	for (const ShaderCacheData::Entry& entry : expired)
+	{
+		auto mapEntry = candidate.m_data.Find(entry.m_fileId);
+		if (mapEntry == candidate.m_data.end())
+		{
+			continue;
+		}
+		auto& entries = candidate.m_data[entry.m_fileId];
+		entries.Remove(entry);
+		if (entries.Num() == 0)
+		{
+			candidate.m_data.Remove(entry.m_fileId);
+		}
+	}
 
+	if (m_bIsDirty || expired.Num() != 0 || !m_bHasCommittedSnapshot)
+	{
+		if (!CommitCandidateLocked(std::move(candidate), outDiagnostic, failurePoint))
+		{
+			return false;
+		}
+	}
+	if (!SweepUnreferencedArtifactsLocked(m_committedCache, outDiagnostic))
+	{
 		m_bIsDirty = true;
-		m_cache.m_data.Remove(it.Key());
-	}
-}
-
-bool ShaderCache::Contains(const FileId& uid) const
-{
-	return m_cache.m_data.ContainsKey(uid);
-}
-
-void ShaderCache::CachePrecompiledGlsl(const FileId& uid, uint32_t permutation, const std::string& vertexGlsl, const std::string& fragmentGlsl, const std::string& computeGlsl)
-{
-	SAILOR_PROFILE_FUNCTION();
-
-	std::lock_guard<std::mutex> lk(m_saveToCacheMutex);
-
-	if (m_bSavePrecompiledGlsl)
-	{
-		if (!vertexGlsl.empty())
-		{
-			std::ofstream vertexPrecompiled(GetPrecompiledShaderFilepath(uid, permutation, ShaderCache::VertexShaderTag));
-			vertexPrecompiled << vertexGlsl;
-			vertexPrecompiled.close();
-		}
-
-		if (!fragmentGlsl.empty())
-		{
-			std::ofstream fragmentPrecompiled(GetPrecompiledShaderFilepath(uid, permutation, ShaderCache::FragmentShaderTag));
-			fragmentPrecompiled << fragmentGlsl;
-			fragmentPrecompiled.close();
-		}
-
-		if (!computeGlsl.empty())
-		{
-			std::ofstream computePrecompiled(GetPrecompiledShaderFilepath(uid, permutation, ShaderCache::ComputeShaderTag));
-			computePrecompiled << computeGlsl;
-			computePrecompiled.close();
-		}
-	}
-}
-
-void ShaderCache::CacheSpirvWithDebugInfo(const FileId& uid, uint32_t permutation, const TVector<uint32_t>& vertexSpirv, const TVector<uint32_t>& fragmentSpirv, const TVector<uint32_t>& computeSpirv)
-{
-	SAILOR_PROFILE_FUNCTION();
-
-	std::lock_guard<std::mutex> lk(m_saveToCacheMutex);
-
-	if (vertexSpirv.Num() > 0)
-	{
-		std::ofstream vertexCompiled(GetCachedShaderWithDebugFilepath(uid, permutation, ShaderCache::VertexShaderTag), std::ofstream::binary);
-		vertexCompiled.write(reinterpret_cast<const char*>(&vertexSpirv[0]), vertexSpirv.Num() * sizeof(uint32_t));
-		vertexCompiled.close();
-	}
-
-	if (fragmentSpirv.Num() > 0)
-	{
-		std::ofstream fragmentCompiled(GetCachedShaderWithDebugFilepath(uid, permutation, ShaderCache::FragmentShaderTag), std::ofstream::binary);
-		fragmentCompiled.write(reinterpret_cast<const char*>(&fragmentSpirv[0]), fragmentSpirv.Num() * sizeof(uint32_t));
-		fragmentCompiled.close();
-	}
-
-	if (computeSpirv.Num() > 0)
-	{
-		std::ofstream computeCompiled(GetCachedShaderWithDebugFilepath(uid, permutation, ShaderCache::ComputeShaderTag), std::ofstream::binary);
-		computeCompiled.write(reinterpret_cast<const char*>(&computeSpirv[0]), computeSpirv.Num() * sizeof(uint32_t));
-		computeCompiled.close();
-	}
-}
-
-void ShaderCache::CacheSpirv_ThreadSafe(const FileId& uid, uint32_t permutation, const TVector<uint32_t>& vertexSpirv, const TVector<uint32_t>& fragmentSpirv, const TVector<uint32_t>& computeSpirv)
-{
-	SAILOR_PROFILE_FUNCTION();
-
-	std::lock_guard<std::mutex> lk(m_saveToCacheMutex);
-
-	auto it = std::find_if(std::begin(m_cache.m_data[uid]), std::end(m_cache.m_data[uid]),
-		[permutation](const ShaderCacheData::Entry& arg) { return arg.m_permutation == permutation; });
-
-	const bool bAlreadyContains = it != std::end(m_cache.m_data[uid]);
-
-	time_t timeStamp = 0;
-	GetTimeStamp(uid, timeStamp);
-
-	ShaderCacheData::Entry newEntry = ShaderCacheData::Entry();
-	ShaderCacheData::Entry* entry = &newEntry;
-
-	if (bAlreadyContains)
-	{
-		entry = &(*it);
-	}
-
-	entry->m_permutation = permutation;
-	entry->m_fileId = uid;
-	entry->m_timestamp = timeStamp;
-
-	if (vertexSpirv.Num() > 0)
-	{
-		std::ofstream vertexCompiled(GetCachedShaderFilepath(entry->m_fileId, entry->m_permutation, ShaderCache::VertexShaderTag), std::ofstream::binary);
-		vertexCompiled.write(reinterpret_cast<const char*>(&vertexSpirv[0]), vertexSpirv.Num() * sizeof(uint32_t));
-		vertexCompiled.close();
-	}
-
-	if (fragmentSpirv.Num() > 0)
-	{
-		std::ofstream fragmentCompiled(GetCachedShaderFilepath(entry->m_fileId, entry->m_permutation, ShaderCache::FragmentShaderTag), std::ofstream::binary);
-		fragmentCompiled.write(reinterpret_cast<const char*>(&fragmentSpirv[0]), fragmentSpirv.Num() * sizeof(uint32_t));
-		fragmentCompiled.close();
-	}
-
-	if (computeSpirv.Num() > 0)
-	{
-		std::ofstream computeCompiled(GetCachedShaderFilepath(entry->m_fileId, entry->m_permutation, ShaderCache::ComputeShaderTag), std::ofstream::binary);
-		computeCompiled.write(reinterpret_cast<const char*>(&computeSpirv[0]), computeSpirv.Num() * sizeof(uint32_t));
-		computeCompiled.close();
-	}
-
-	if (!bAlreadyContains)
-	{
-		m_cache.m_data[uid].Add(*entry);
-	}
-
-	m_bIsDirty = true;
-}
-
-bool ShaderCache::GetSpirvCode(const FileId& uid, uint32_t permutation, TVector<uint32_t>& vertexSpirv, TVector<uint32_t>& fragmentSpirv, TVector<uint32_t>& computeSpirv, bool bIsDebug)
-{
-	SAILOR_PROFILE_FUNCTION();
-
-	std::lock_guard<std::mutex> lk(m_saveToCacheMutex);
-
-	if (IsExpired(uid, permutation))
-	{
 		return false;
 	}
-
-	const auto& entries = m_cache.m_data[uid];
-	const auto it = std::find_if(std::cbegin(entries), std::cend(entries),
-		[permutation](const ShaderCacheData::Entry& arg) { return arg.m_permutation == permutation; });
-
-	std::filesystem::path vertexFilepath = bIsDebug ?
-		GetCachedShaderWithDebugFilepath((*it).m_fileId, (*it).m_permutation, ShaderCache::VertexShaderTag) :
-		GetCachedShaderFilepath((*it).m_fileId, (*it).m_permutation, ShaderCache::VertexShaderTag);
-
-	std::filesystem::path fragmentFilepath = bIsDebug ?
-		GetCachedShaderWithDebugFilepath((*it).m_fileId, (*it).m_permutation, ShaderCache::FragmentShaderTag) :
-		GetCachedShaderFilepath((*it).m_fileId, (*it).m_permutation, ShaderCache::FragmentShaderTag);
-
-	std::filesystem::path computeFilepath = bIsDebug ?
-		GetCachedShaderWithDebugFilepath((*it).m_fileId, (*it).m_permutation, ShaderCache::ComputeShaderTag) :
-		GetCachedShaderFilepath((*it).m_fileId, (*it).m_permutation, ShaderCache::ComputeShaderTag);
-
-	AssetRegistry::ReadBinaryFile(vertexFilepath, vertexSpirv);
-	AssetRegistry::ReadBinaryFile(fragmentFilepath, fragmentSpirv);
-	AssetRegistry::ReadBinaryFile(computeFilepath, computeSpirv);
-
+	outDiagnostic.clear();
 	return true;
 }
 
-bool ShaderCache::IsExpired(const FileId& uid, uint32_t permutation) const
+void ShaderCache::ClearExpired()
 {
-	if (!Contains(uid))
+	SAILOR_PROFILE_FUNCTION();
+
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	if (m_bPreserveStorageAfterLoadFailure)
 	{
-		return true;
+		SAILOR_LOG(
+			"Shader cache cleanup skipped during read-only I/O quarantine; disk storage is preserved.");
+		return;
 	}
-
-	const auto& entries = m_cache.m_data[uid];
-	size_t index = entries.FindIf([permutation](const ShaderCacheData::Entry& arg) { return arg.m_permutation == permutation; });
-
-	const bool bAlreadyContains = index != -1;
-
-	if (!bAlreadyContains)
+	std::string diagnostic;
+	if (!ClearExpiredLocked(Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None, diagnostic))
 	{
-		return true;
+		m_lastSaveDiagnostic = std::move(diagnostic);
+		SAILOR_LOG_ERROR("Shader cache cleanup failed: %s", m_lastSaveDiagnostic.c_str());
 	}
+}
 
-	auto vertexFilepath = std::filesystem::path(GetCachedShaderFilepath(uid, permutation, ShaderCache::VertexShaderTag));
-	auto fragmentFilepath = std::filesystem::path(GetCachedShaderFilepath(uid, permutation, ShaderCache::FragmentShaderTag));
-	auto computeFilepath = std::filesystem::path(GetCachedShaderFilepath(uid, permutation, ShaderCache::ComputeShaderTag));
-
-	if (!(std::filesystem::exists(vertexFilepath) && std::filesystem::exists(fragmentFilepath)) && !std::filesystem::exists(computeFilepath))
+void ShaderCache::ClearAll()
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	m_cache.m_data.Clear();
+	m_committedCache.m_data.Clear();
+	m_quarantinedEntries.Clear();
+	m_bPreserveStorageAfterLoadFailure = false;
+	m_bHasCommittedSnapshot = false;
+	m_bIsDirty = true;
+	std::string clearDiagnostic;
+	const bool bCleared = ClearOwnedCacheFilesLocked(clearDiagnostic);
+	std::string writeDiagnostic;
+	const bool bEnvelopeWritten = WriteCacheLocked(writeDiagnostic);
+	if (bCleared && bEnvelopeWritten)
 	{
-		return true;
+		m_bIsDirty = false;
+		m_committedCache = m_cache;
+		m_bHasCommittedSnapshot = true;
+		m_lastSaveDiagnostic.clear();
 	}
+	else
+	{
+		m_bIsDirty = true;
+		m_lastSaveDiagnostic.clear();
+		AppendDiagnostic(m_lastSaveDiagnostic, clearDiagnostic);
+		AppendDiagnostic(m_lastSaveDiagnostic, writeDiagnostic);
+		SAILOR_LOG_ERROR("Shader cache clear failed: %s", m_lastSaveDiagnostic.c_str());
+	}
+}
 
-	time_t timeStamp = 0;
-	const bool hasAsset = GetTimeStamp(uid, timeStamp);
+Workspace::WorkspaceCacheLoadResult ShaderCache::GetLastLoadResult() const
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	return m_lastLoadResult;
+}
 
-	return hasAsset ? entries[index].m_timestamp < timeStamp : true;
+std::string ShaderCache::GetLastSaveDiagnostic() const
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	return m_lastSaveDiagnostic;
+}
+
+bool ShaderCache::IsDirty() const
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	return m_bIsDirty;
 }
 
 bool ShaderCache::GetTimeStamp(const FileId& uid, time_t& outTimestamp) const
 {
-	if (ShaderAssetInfoPtr assetInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr<ShaderAssetInfoPtr>(uid))
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+	if (m_timestampOverrideForTests.has_value())
 	{
-		if (TSharedPtr<ShaderAsset> shaderAsset = App::GetSubmodule<ShaderCompiler>()->LoadShaderAsset(assetInfo->GetFileId()).Lock())
+		outTimestamp = *m_timestampOverrideForTests;
+		return true;
+	}
+#endif
+
+	auto* assetRegistry = App::GetSubmodule<AssetRegistry>();
+	auto* shaderCompiler = App::GetSubmodule<ShaderCompiler>();
+	if (!assetRegistry || !shaderCompiler)
+	{
+		return false;
+	}
+
+	if (ShaderAssetInfoPtr assetInfo = assetRegistry->GetAssetInfoPtr<ShaderAssetInfoPtr>(uid))
+	{
+		if (TSharedPtr<ShaderAsset> shaderAsset = shaderCompiler->LoadShaderAsset(assetInfo->GetFileId()).Lock())
 		{
 			outTimestamp = assetInfo->GetAssetLastModificationTime();
 			for (const auto& include : shaderAsset->GetIncludes())
 			{
 				time_t includeTimestamp = 0;
-				if (App::GetSubmodule<AssetRegistry>()->GetContentFileModificationTime(include, includeTimestamp))
+				if (assetRegistry->GetContentFileModificationTime(include, includeTimestamp))
 				{
 					outTimestamp = std::max(outTimestamp, includeTimestamp);
 				}
@@ -496,3 +2421,193 @@ bool ShaderCache::GetTimeStamp(const FileId& uid, time_t& outTimestamp) const
 	}
 	return false;
 }
+
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+void ShaderCacheTestAccess::Configure(
+	ShaderCache& cache,
+	const std::filesystem::path& cacheRoot,
+	std::time_t timestamp)
+{
+	std::filesystem::create_directories(cacheRoot);
+	std::error_code error;
+	const std::filesystem::path canonicalRoot = std::filesystem::weakly_canonical(cacheRoot, error);
+	if (error)
+	{
+		throw std::runtime_error(
+			"cannot canonicalize shader cache test root: " + error.message());
+	}
+
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	cache.m_cacheRoot = canonicalRoot;
+	cache.m_identityOverride = Workspace::MakeWorkspaceCacheIdentity(
+		ShaderCacheKind,
+		GetShaderCacheProducerIdentity(),
+		ShaderCachePayloadVersion,
+		"shader-cache-tests",
+		canonicalRoot.parent_path());
+	cache.m_timestampOverrideForTests = timestamp;
+	std::string diagnostic;
+	if (!cache.EnsureOwnedDirectoriesLocked(diagnostic))
+	{
+		throw std::runtime_error(
+			"cannot initialize shader cache test storage: " + diagnostic);
+	}
+}
+
+std::string ShaderCacheTestAccess::GetGeneration(
+	const ShaderCache& cache,
+	const FileId& uid,
+	uint32_t permutation)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	if (!cache.m_cache.m_data.ContainsKey(uid))
+	{
+		return {};
+	}
+	const auto& entries = cache.m_cache.m_data[uid];
+	const size_t index = entries.FindIf([permutation](const ShaderCache::ShaderCacheData::Entry& entry)
+		{
+			return entry.m_permutation == permutation;
+		});
+	return index == static_cast<size_t>(-1) ? std::string() : entries[index].m_generation;
+}
+
+std::filesystem::path ShaderCacheTestAccess::GetArtifactPath(
+	const ShaderCache& cache,
+	const FileId& uid,
+	uint32_t permutation,
+	const char* stage,
+	bool bIsDebug)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	if (!cache.m_cache.m_data.ContainsKey(uid))
+	{
+		return {};
+	}
+	const auto& entries = cache.m_cache.m_data[uid];
+	const size_t index = entries.FindIf([permutation](const ShaderCache::ShaderCacheData::Entry& entry)
+		{
+			return entry.m_permutation == permutation;
+		});
+	return index == static_cast<size_t>(-1)
+		? std::filesystem::path()
+		: cache.GetArtifactPathLocked(entries[index], stage, bIsDebug);
+}
+
+std::filesystem::path ShaderCacheTestAccess::GetCachePath(const ShaderCache& cache)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	return cache.GetCacheFilepathLocked();
+}
+
+bool ShaderCacheTestAccess::PublishWithArtifactFailure(
+	ShaderCache& cache,
+	const FileId& uid,
+	uint32_t permutation,
+	const TVector<uint32_t>& vertex,
+	const TVector<uint32_t>& fragment,
+	const TVector<uint32_t>& compute,
+	const TVector<uint32_t>& debugVertex,
+	const TVector<uint32_t>& debugFragment,
+	const TVector<uint32_t>& debugCompute,
+	int32_t failArtifactIndex,
+	std::string& outDiagnostic)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	return cache.CacheCompleteSpirvLocked(
+		uid,
+		permutation,
+		vertex,
+		fragment,
+		compute,
+		debugVertex,
+		debugFragment,
+		debugCompute,
+		failArtifactIndex,
+		outDiagnostic);
+}
+
+bool ShaderCacheTestAccess::RemoveWithEnvelopeFailure(
+	ShaderCache& cache,
+	const FileId& uid,
+	std::string& outDiagnostic)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	return cache.RemoveLocked(
+		uid,
+		Workspace::EWorkspaceCacheAtomicWriteFailurePoint::BeforeReplace,
+		outDiagnostic);
+}
+
+bool ShaderCacheTestAccess::ClearExpiredWithEnvelopeFailure(
+	ShaderCache& cache,
+	std::string& outDiagnostic)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	return cache.ClearExpiredLocked(
+		Workspace::EWorkspaceCacheAtomicWriteFailurePoint::BeforeReplace,
+		outDiagnostic);
+}
+
+void ShaderCacheTestAccess::FailNextSaveBeforeReplace(ShaderCache& cache)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	cache.m_nextSaveFailureForTests =
+		Workspace::EWorkspaceCacheAtomicWriteFailurePoint::BeforeReplace;
+}
+
+void ShaderCacheTestAccess::SetArtifactReadIoFailure(ShaderCache& cache, bool bEnabled)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	cache.m_bArtifactReadIoFailureForTests = bEnabled;
+}
+
+void ShaderCacheTestAccess::FailNextArtifactSweep(ShaderCache& cache)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	cache.m_bArtifactSweepFailureForTests = true;
+}
+
+std::string ShaderCacheTestAccess::PayloadWithMissingDebug(const ShaderCache& cache)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	ShaderCache::ShaderCacheData candidate = cache.m_cache;
+	for (auto fileEntries : candidate.m_data)
+	{
+		for (ShaderCache::ShaderCacheData::Entry& entry : *fileEntries.m_second)
+		{
+			entry.m_debug = {};
+		}
+	}
+	return ShaderCache::SerializeShaderCachePayload(candidate);
+}
+
+std::string ShaderCacheTestAccess::PayloadWithMismatchedDebugTopology(const ShaderCache& cache)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	ShaderCache::ShaderCacheData candidate = cache.m_cache;
+	for (auto fileEntries : candidate.m_data)
+	{
+		for (ShaderCache::ShaderCacheData::Entry& entry : *fileEntries.m_second)
+		{
+			entry.m_debug = {};
+			entry.m_debug.m_compute = entry.m_regular.m_vertex;
+		}
+	}
+	return ShaderCache::SerializeShaderCachePayload(candidate);
+}
+
+bool ShaderCacheTestAccess::ParsePayload(
+	const std::string& payload,
+	std::string& outDiagnostic)
+{
+	ShaderCache::ShaderCacheData candidate;
+	return ShaderCache::TryDeserializeShaderCachePayload(payload, candidate, outDiagnostic);
+}
+
+bool ShaderCacheTestAccess::IsQuarantined(const ShaderCache& cache)
+{
+	std::lock_guard<std::mutex> lock(cache.m_cacheMutex);
+	return cache.m_bPreserveStorageAfterLoadFailure;
+}
+#endif

--- a/Runtime/AssetRegistry/Shader/ShaderCache.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.cpp
@@ -925,7 +925,8 @@ bool ShaderCache::IsValidGeneration(const std::string& generation) noexcept
 	}
 	return std::all_of(generation.begin(), generation.end(), [](unsigned char character)
 		{
-			return character >= '0' && character <= '9' || character >= 'a' && character <= 'f';
+			return (character >= '0' && character <= '9') ||
+				(character >= 'a' && character <= 'f');
 		});
 }
 

--- a/Runtime/AssetRegistry/Shader/ShaderCache.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.h
@@ -1,20 +1,41 @@
 #pragma once
-#include <chrono>
-#include <ctime>
-#include "Sailor.h"
-#include "Containers/Vector.h"
-#include "Containers/Map.h"
+
 #include "AssetRegistry/FileId.h"
-#include "Core/Singleton.hpp"
+#include "Containers/Map.h"
+#include "Containers/Vector.h"
 #include "Core/YamlSerializable.h"
-#include <mutex>
+#include "Sailor.h"
+#include "Workspace/WorkspaceCacheContract.h"
+
+#include <cstdint>
+#include <ctime>
 #include <filesystem>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <vector>
 
 namespace Sailor
 {
 	class ShaderCache
 	{
 	public:
+		SAILOR_API ShaderCache();
+		SAILOR_API ~ShaderCache();
+
+		struct ArtifactMetadata final : IYamlSerializable
+		{
+			SAILOR_API ArtifactMetadata();
+			SAILOR_API ~ArtifactMetadata();
+
+			uint64_t m_byteLength = 0;
+			uint64_t m_checksum = 0;
+
+			bool IsPresent() const noexcept { return m_byteLength != 0; }
+
+			SAILOR_API virtual YAML::Node Serialize() const override;
+			SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
+		};
 
 		SAILOR_API static std::string GetShaderCacheFilepath();
 		SAILOR_API static std::string GetPrecompiledShadersFolder();
@@ -31,16 +52,34 @@ namespace Sailor
 		SAILOR_API void Initialize();
 		SAILOR_API void Shutdown();
 
-		SAILOR_API void CachePrecompiledGlsl(const FileId& uid, uint32_t permutation, const std::string& vertexGlsl, const std::string& fragmentGlsl, const std::string& computeGlsl);
-		SAILOR_API void CacheSpirvWithDebugInfo(const FileId& uid, uint32_t permutation, const TVector<uint32_t>& vertexSpirv, const TVector<uint32_t>& fragmentSpirv, const TVector<uint32_t>& computeSpirv);
-		SAILOR_API void CacheSpirv_ThreadSafe(const FileId& uid, uint32_t permutation, const TVector<uint32_t>& vertexSpirv, const TVector<uint32_t>& fragmentSpirv, const TVector<uint32_t>& computeSpirv);
+		SAILOR_API bool CachePrecompiledGlsl(
+			const FileId& uid,
+			uint32_t permutation,
+			const std::string& vertexGlsl,
+			const std::string& fragmentGlsl,
+			const std::string& computeGlsl);
+		SAILOR_API bool CacheSpirv_ThreadSafe(
+			const FileId& uid,
+			uint32_t permutation,
+			const TVector<uint32_t>& vertexSpirv,
+			const TVector<uint32_t>& fragmentSpirv,
+			const TVector<uint32_t>& computeSpirv,
+			const TVector<uint32_t>& debugVertexSpirv,
+			const TVector<uint32_t>& debugFragmentSpirv,
+			const TVector<uint32_t>& debugComputeSpirv);
 
-		SAILOR_API bool GetSpirvCode(const FileId& uid, uint32_t permutation, TVector<uint32_t>& vertexSpirv, TVector<uint32_t>& fragmentSpirv, TVector<uint32_t>& computeSpirv, bool bIsDebug = false);
+		SAILOR_API bool GetSpirvCode(
+			const FileId& uid,
+			uint32_t permutation,
+			TVector<uint32_t>& vertexSpirv,
+			TVector<uint32_t>& fragmentSpirv,
+			TVector<uint32_t>& computeSpirv,
+			bool bIsDebug = false);
 
 		SAILOR_API void Remove(const FileId& uid);
 
 		SAILOR_API bool Contains(const FileId& uid) const;
-		SAILOR_API bool IsExpired(const FileId& uid, uint32_t permutation) const;
+		SAILOR_API bool IsExpired(const FileId& uid, uint32_t permutation);
 
 		SAILOR_API void LoadCache();
 		SAILOR_API void SaveCache(bool bForcely = false);
@@ -48,48 +87,284 @@ namespace Sailor
 		SAILOR_API void ClearAll();
 		SAILOR_API void ClearExpired();
 
-		SAILOR_API static std::filesystem::path GetPrecompiledShaderFilepath(const FileId& uid, int32_t permutation, const std::string& shaderKind);
-		SAILOR_API static std::filesystem::path GetCachedShaderFilepath(const FileId& uid, int32_t permutation, const std::string& shaderKind);
-		SAILOR_API static std::filesystem::path GetCachedShaderWithDebugFilepath(const FileId& uid, int32_t permutation, const std::string& shaderKind);
+		SAILOR_API Workspace::WorkspaceCacheLoadResult GetLastLoadResult() const;
+		SAILOR_API std::string GetLastSaveDiagnostic() const;
+		SAILOR_API bool IsDirty() const;
+
+		SAILOR_API static uint64_t CalculateArtifactChecksum(const void* data, uint64_t size) noexcept;
+		SAILOR_API static ArtifactMetadata DescribeArtifact(const void* data, uint64_t size) noexcept;
+		SAILOR_API static bool ReadSpirvArtifact(
+			const std::filesystem::path& path,
+			const ArtifactMetadata& metadata,
+			TVector<uint32_t>& outSpirv,
+			std::string& outDiagnostic) noexcept;
+		SAILOR_API static bool ValidateOwnedArtifactPath(
+			const std::filesystem::path& cacheRoot,
+			const std::filesystem::path& ownedDirectory,
+			const std::filesystem::path& artifact,
+			std::string& outDiagnostic) noexcept;
+
+		SAILOR_API static std::filesystem::path GetPrecompiledShaderFilepath(
+			const FileId& uid,
+			int32_t permutation,
+			const std::string& shaderKind);
+		SAILOR_API static std::filesystem::path GetCachedShaderFilepath(
+			const FileId& uid,
+			int32_t permutation,
+			const std::string& shaderKind);
+		SAILOR_API static std::filesystem::path GetCachedShaderWithDebugFilepath(
+			const FileId& uid,
+			int32_t permutation,
+			const std::string& shaderKind);
 
 	protected:
-
-		bool GetTimeStamp(const FileId& uid, time_t& outTimestamp) const;
-
-		class ShaderCacheData final : IYamlSerializable
+		struct ArtifactSet final : IYamlSerializable
 		{
-		public:
+			ArtifactMetadata m_vertex;
+			ArtifactMetadata m_fragment;
+			ArtifactMetadata m_compute;
 
-			class Entry final : IYamlSerializable
+			bool IsEmpty() const noexcept
 			{
-			public:
-
-				FileId m_fileId;
-
-				// Last time shader changed
-				std::time_t m_timestamp;
-				uint32_t m_permutation;
-
-				SAILOR_API bool operator==(const Entry& rhs) const { return m_fileId == rhs.m_fileId && m_permutation == rhs.m_permutation; }
-
-				SAILOR_API virtual YAML::Node Serialize() const override;
-				SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
-			};
-
-			TMap<FileId, TVector<ShaderCacheData::Entry>> m_data;
+				return !m_vertex.IsPresent() && !m_fragment.IsPresent() && !m_compute.IsPresent();
+			}
 
 			SAILOR_API virtual YAML::Node Serialize() const override;
 			SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
 		};
 
-		std::mutex m_saveToCacheMutex;
+		class ShaderCacheData final : IYamlSerializable
+		{
+		public:
+			class Entry final : IYamlSerializable
+			{
+			public:
+				FileId m_fileId{};
+				std::time_t m_timestamp{};
+				uint32_t m_permutation = 0;
+				std::string m_generation;
+				ArtifactSet m_regular;
+				ArtifactSet m_debug;
 
-		SAILOR_API void Remove(const ShaderCacheData::Entry& entry);
+				SAILOR_API bool operator==(const Entry& rhs) const
+				{
+					return m_fileId == rhs.m_fileId && m_permutation == rhs.m_permutation;
+				}
+
+				SAILOR_API virtual YAML::Node Serialize() const override;
+				SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
+			};
+
+			TMap<FileId, TVector<Entry>> m_data;
+
+			SAILOR_API virtual YAML::Node Serialize() const override;
+			SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
+		};
+
+		SAILOR_API bool GetTimeStamp(const FileId& uid, time_t& outTimestamp) const;
 
 	private:
+		struct QuarantinedEntry final
+		{
+			FileId m_fileId{};
+			std::time_t m_timestamp{};
+			uint32_t m_permutation = 0;
+			TVector<uint32_t> m_vertex;
+			TVector<uint32_t> m_fragment;
+			TVector<uint32_t> m_compute;
+			TVector<uint32_t> m_debugVertex;
+			TVector<uint32_t> m_debugFragment;
+			TVector<uint32_t> m_debugCompute;
+		};
 
+		static std::string SerializeShaderCachePayload(const ShaderCacheData& cache);
+		static bool TryDeserializeShaderCachePayload(
+			const std::string& payload,
+			ShaderCacheData& outData,
+			std::string& outDiagnostic) noexcept;
+		static bool ReadArtifactBytes(
+			const std::filesystem::path& path,
+			const ArtifactMetadata& metadata,
+			std::vector<uint8_t>& outBytes,
+			std::string& outDiagnostic,
+			bool& outIoFailure) noexcept;
+		static bool ReadSpirvArtifactInternal(
+			const std::filesystem::path& path,
+			const ArtifactMetadata& metadata,
+			TVector<uint32_t>& outSpirv,
+			std::string& outDiagnostic,
+			bool& outIoFailure) noexcept;
+		static bool IsValidArtifactSet(const ArtifactSet& artifacts, bool bAllowEmpty) noexcept;
+		static bool HasMatchingArtifactTopology(
+			const ArtifactSet& regular,
+			const ArtifactSet& debug) noexcept;
+		static bool IsValidGeneration(const std::string& generation) noexcept;
+		static bool DescribeArtifactSet(
+			const TVector<uint32_t>& vertexSpirv,
+			const TVector<uint32_t>& fragmentSpirv,
+			const TVector<uint32_t>& computeSpirv,
+			ArtifactSet& outMetadata,
+			std::string& outDiagnostic) noexcept;
+
+		Workspace::WorkspaceCacheIdentity GetExpectedIdentityLocked() const;
+		std::filesystem::path GetCacheFilepathLocked() const;
+		std::filesystem::path GetPrecompiledFolderLocked() const;
+		std::filesystem::path GetCompiledFolderLocked() const;
+		std::filesystem::path GetCompiledDebugFolderLocked() const;
+		std::filesystem::path GetArtifactPathLocked(
+			const ShaderCacheData::Entry& entry,
+			const std::string& shaderKind,
+			bool bIsDebug) const;
+
+		bool WriteCacheDataLocked(
+			const ShaderCacheData& cache,
+			std::string& outDiagnostic,
+			Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint =
+				Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None);
+		bool WriteCacheLocked(std::string& outDiagnostic);
+		bool SaveCacheLocked(
+			bool bForcely,
+			Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint =
+				Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None);
+		bool CommitCandidateLocked(
+			ShaderCacheData candidate,
+			std::string& outDiagnostic,
+			Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint =
+				Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None);
+		void ResetInvalidCacheLocked(Workspace::WorkspaceCacheLoadResult loadResult);
+		void EnterStorageQuarantineLocked(std::string diagnostic);
+		bool ClearOwnedCacheFilesLocked(std::string& outDiagnostic);
+		bool EnsureOwnedDirectoriesLocked(std::string& outDiagnostic);
+		bool ValidateAllArtifactsLocked(
+			const ShaderCacheData& candidate,
+			std::string& outDiagnostic,
+			bool& outIoFailure) const;
+		bool ValidateArtifactSetLocked(
+			const ShaderCacheData::Entry& entry,
+			const ArtifactSet& artifacts,
+			bool bIsDebug,
+			std::string& outDiagnostic,
+			bool& outIoFailure) const;
+		bool ReadOwnedSpirvArtifactLocked(
+			const std::filesystem::path& ownedDirectory,
+			const std::filesystem::path& artifact,
+			const ArtifactMetadata& metadata,
+			TVector<uint32_t>& outSpirv,
+			std::string& outDiagnostic,
+			bool& outIoFailure) const;
+		bool WriteSpirvSetLocked(
+			const FileId& uid,
+			uint32_t permutation,
+			const std::string& generation,
+			const TVector<uint32_t>& vertexSpirv,
+			const TVector<uint32_t>& fragmentSpirv,
+			const TVector<uint32_t>& computeSpirv,
+			const ArtifactSet& metadata,
+			bool bIsDebug,
+			int32_t& artifactIndex,
+			int32_t failArtifactIndex,
+			std::string& outDiagnostic);
+		bool CacheCompleteSpirvLocked(
+			const FileId& uid,
+			uint32_t permutation,
+			const TVector<uint32_t>& vertexSpirv,
+			const TVector<uint32_t>& fragmentSpirv,
+			const TVector<uint32_t>& computeSpirv,
+			const TVector<uint32_t>& debugVertexSpirv,
+			const TVector<uint32_t>& debugFragmentSpirv,
+			const TVector<uint32_t>& debugComputeSpirv,
+			int32_t failArtifactIndex,
+			std::string& outDiagnostic);
+		bool GenerateUniqueGenerationLocked(
+			const FileId& uid,
+			uint32_t permutation,
+			std::string& outGeneration,
+			std::string& outDiagnostic) const;
+		bool SweepUnreferencedArtifactsLocked(
+			const ShaderCacheData& committedSnapshot,
+			std::string& outDiagnostic);
+		QuarantinedEntry* FindQuarantinedEntryLocked(const FileId& uid, uint32_t permutation);
+		const QuarantinedEntry* FindQuarantinedEntryLocked(const FileId& uid, uint32_t permutation) const;
+		bool RemoveLocked(
+			const FileId& uid,
+			Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint,
+			std::string& outDiagnostic);
+		bool ClearExpiredLocked(
+			Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint,
+			std::string& outDiagnostic);
+		bool IsExpiredLocked(const FileId& uid, uint32_t permutation);
+
+		mutable std::mutex m_cacheMutex;
 		ShaderCacheData m_cache;
+		ShaderCacheData m_committedCache;
+		TVector<QuarantinedEntry> m_quarantinedEntries;
+		std::filesystem::path m_cacheRoot;
 		bool m_bIsDirty = false;
+		bool m_bStorageReady = false;
+		bool m_bPreserveStorageAfterLoadFailure = false;
+		bool m_bHasCommittedSnapshot = false;
 		const bool m_bSavePrecompiledGlsl = false;
+		Workspace::WorkspaceCacheLoadResult m_lastLoadResult{};
+		std::string m_lastSaveDiagnostic;
+		std::optional<Workspace::WorkspaceCacheIdentity> m_identityOverride;
+		std::optional<std::time_t> m_timestampOverrideForTests;
+		Workspace::EWorkspaceCacheAtomicWriteFailurePoint m_nextSaveFailureForTests =
+			Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None;
+		bool m_bArtifactReadIoFailureForTests = false;
+		bool m_bArtifactSweepFailureForTests = false;
+
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+		friend class ShaderCacheTestAccess;
+#endif
 	};
+
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+	class ShaderCacheTestAccess final
+	{
+	public:
+		SAILOR_API static void Configure(
+			ShaderCache& cache,
+			const std::filesystem::path& cacheRoot,
+			std::time_t timestamp = 100);
+		SAILOR_API static std::string GetGeneration(
+			const ShaderCache& cache,
+			const FileId& uid,
+			uint32_t permutation);
+		SAILOR_API static std::filesystem::path GetArtifactPath(
+			const ShaderCache& cache,
+			const FileId& uid,
+			uint32_t permutation,
+			const char* stage,
+			bool bIsDebug);
+		SAILOR_API static std::filesystem::path GetCachePath(const ShaderCache& cache);
+		SAILOR_API static bool PublishWithArtifactFailure(
+			ShaderCache& cache,
+			const FileId& uid,
+			uint32_t permutation,
+			const TVector<uint32_t>& vertex,
+			const TVector<uint32_t>& fragment,
+			const TVector<uint32_t>& compute,
+			const TVector<uint32_t>& debugVertex,
+			const TVector<uint32_t>& debugFragment,
+			const TVector<uint32_t>& debugCompute,
+			int32_t failArtifactIndex,
+			std::string& outDiagnostic);
+		SAILOR_API static bool RemoveWithEnvelopeFailure(
+			ShaderCache& cache,
+			const FileId& uid,
+			std::string& outDiagnostic);
+		SAILOR_API static bool ClearExpiredWithEnvelopeFailure(
+			ShaderCache& cache,
+			std::string& outDiagnostic);
+		SAILOR_API static void FailNextSaveBeforeReplace(ShaderCache& cache);
+		SAILOR_API static void SetArtifactReadIoFailure(ShaderCache& cache, bool bEnabled);
+		SAILOR_API static void FailNextArtifactSweep(ShaderCache& cache);
+		SAILOR_API static std::string PayloadWithMissingDebug(const ShaderCache& cache);
+		SAILOR_API static std::string PayloadWithMismatchedDebugTopology(const ShaderCache& cache);
+		SAILOR_API static bool ParsePayload(
+			const std::string& payload,
+			std::string& outDiagnostic);
+		SAILOR_API static bool IsQuarantined(const ShaderCache& cache);
+	};
+#endif
 }

--- a/Runtime/AssetRegistry/Shader/ShaderCache.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.h
@@ -306,12 +306,12 @@ namespace Sailor
 		const bool m_bSavePrecompiledGlsl = false;
 		Workspace::WorkspaceCacheLoadResult m_lastLoadResult{};
 		std::string m_lastSaveDiagnostic;
-		std::optional<Workspace::WorkspaceCacheIdentity> m_identityOverride;
-		std::optional<std::time_t> m_timestampOverrideForTests;
-		Workspace::EWorkspaceCacheAtomicWriteFailurePoint m_nextSaveFailureForTests =
+		[[maybe_unused]] std::optional<Workspace::WorkspaceCacheIdentity> m_identityOverride;
+		[[maybe_unused]] std::optional<std::time_t> m_timestampOverrideForTests;
+		[[maybe_unused]] Workspace::EWorkspaceCacheAtomicWriteFailurePoint m_nextSaveFailureForTests =
 			Workspace::EWorkspaceCacheAtomicWriteFailurePoint::None;
-		bool m_bArtifactReadIoFailureForTests = false;
-		bool m_bArtifactSweepFailureForTests = false;
+		[[maybe_unused]] bool m_bArtifactReadIoFailureForTests = false;
+		[[maybe_unused]] bool m_bArtifactSweepFailureForTests = false;
 
 #if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
 		friend class ShaderCacheTestAccess;

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -8,10 +8,12 @@
 #include "ShaderCache.h"
 #include "RHI/Shader.h"
 #include "Core/Utils.h"
+#include <atomic>
 #include <filesystem>
 #include <fstream>
 #include <algorithm>
 #include <iostream>
+#include <memory>
 
 #include "Core/YamlSerializable.h"
 #include <shaderc/shaderc.hpp>
@@ -30,6 +32,32 @@
 #include "ECS/LightingECS.h"
 
 using namespace Sailor;
+
+namespace
+{
+	template<typename TMap, typename TKey>
+	class TConcurrentMapEntryUnlockGuard final
+	{
+	public:
+		TConcurrentMapEntryUnlockGuard(TMap& map, const TKey& key) noexcept :
+			m_map(map),
+			m_key(key)
+		{
+		}
+
+		~TConcurrentMapEntryUnlockGuard() noexcept
+		{
+			m_map.Unlock(m_key);
+		}
+
+		TConcurrentMapEntryUnlockGuard(const TConcurrentMapEntryUnlockGuard&) = delete;
+		TConcurrentMapEntryUnlockGuard& operator=(const TConcurrentMapEntryUnlockGuard&) = delete;
+
+	private:
+		TMap& m_map;
+		const TKey& m_key;
+	};
+}
 
 class ShaderIncluder : public shaderc::CompileOptions::IncluderInterface
 {
@@ -185,7 +213,7 @@ void ShaderCompiler::UpdateConstantsLibrary()
 	if (!std::filesystem::exists(constantsLibrary))
 	{
 		std::ofstream assetFile(constantsLibrary);
-		assetFile << GenerateConstantsLibrary(Version);
+		assetFile << GenerateConstantsLibrary(CacheProducerVersion);
 		assetFile.close();
 
 		return;
@@ -211,7 +239,7 @@ void ShaderCompiler::UpdateConstantsLibrary()
 
 		uint32_t versionValue = 0;
 
-		if (ss >> versionValue && (versionValue == Version))
+		if (ss >> versionValue && (versionValue == CacheProducerVersion))
 		{
 			return;
 		}
@@ -223,7 +251,7 @@ void ShaderCompiler::UpdateConstantsLibrary()
 
 		// Update library
 		std::ofstream assetFile(constantsLibrary);
-		assetFile << GenerateConstantsLibrary(Version);
+		assetFile << GenerateConstantsLibrary(CacheProducerVersion);
 		assetFile.close();
 	}
 }
@@ -299,7 +327,20 @@ bool ShaderCompiler::ForceCompilePermutation(ShaderAssetInfoPtr assetInfo, uint3
 		GeneratePrecompiledGlsl(pShader.GetRawPtr(), computeGlsl, pShader->GetIncludes(), computeDefines);
 	}
 
-	m_shaderCache.CachePrecompiledGlsl(assetInfo->GetFileId(), permutation, vertexGlsl, fragmentGlsl, computeGlsl);
+	const bool bPrecompiledCached = m_shaderCache.CachePrecompiledGlsl(
+		assetInfo->GetFileId(),
+		permutation,
+		vertexGlsl,
+		fragmentGlsl,
+		computeGlsl);
+	if (!bPrecompiledCached)
+	{
+		SAILOR_LOG_ERROR(
+			"Failed to cache precompiled GLSL for shader %s permutation %u: %s",
+			assetInfo->GetAssetFilepath().c_str(),
+			permutation,
+			m_shaderCache.GetLastSaveDiagnostic().c_str());
+	}
 
 	RHI::ShaderByteCode spirvVertexByteCode;
 	RHI::ShaderByteCode spirvFragmentByteCode;
@@ -311,10 +352,8 @@ bool ShaderCompiler::ForceCompilePermutation(ShaderAssetInfoPtr assetInfo, uint3
 	const bool bResultCompileFragmentShader = pShader->ContainsFragment() && CompileGlslToSpirv(filename, fragmentGlsl, RHI::EShaderStage::Fragment, spirvFragmentByteCode, false);
 	const bool bResultCompileComputeShader = pShader->ContainsCompute() && CompileGlslToSpirv(filename, computeGlsl, RHI::EShaderStage::Compute, spirvComputeByteCode, false);
 
-	if ((bResultCompileVertexShader && bResultCompileFragmentShader) || bResultCompileComputeShader)
-	{
-		m_shaderCache.CacheSpirv_ThreadSafe(assetInfo->GetFileId(), permutation, spirvVertexByteCode, spirvFragmentByteCode, spirvComputeByteCode);
-	}
+	const bool bCompiledRegular =
+		(bResultCompileVertexShader && bResultCompileFragmentShader) || bResultCompileComputeShader;
 
 	RHI::ShaderByteCode spirvVertexByteCodeDebug;
 	RHI::ShaderByteCode spirvFragmentByteCodeDebug;
@@ -324,12 +363,68 @@ bool ShaderCompiler::ForceCompilePermutation(ShaderAssetInfoPtr assetInfo, uint3
 	const bool bResultCompileFragmentShaderDebug = pShader->ContainsFragment() && CompileGlslToSpirv(filename, fragmentGlsl, RHI::EShaderStage::Fragment, spirvFragmentByteCodeDebug, true);
 	const bool bResultCompileComputeShaderDebug = pShader->ContainsCompute() && CompileGlslToSpirv(filename, computeGlsl, RHI::EShaderStage::Compute, spirvComputeByteCodeDebug, true);
 
-	if ((bResultCompileVertexShaderDebug && bResultCompileFragmentShaderDebug) || bResultCompileComputeShaderDebug)
+	const bool bCompiledDebug =
+		(bResultCompileVertexShaderDebug && bResultCompileFragmentShaderDebug) || bResultCompileComputeShaderDebug;
+	if (bCompiledRegular && !bCompiledDebug)
 	{
-		m_shaderCache.CacheSpirvWithDebugInfo(assetInfo->GetFileId(), permutation, spirvVertexByteCodeDebug, spirvFragmentByteCodeDebug, spirvComputeByteCodeDebug);
+		SAILOR_LOG_ERROR(
+			"Required debug SPIR-V compilation failed for shader %s permutation %u",
+			assetInfo->GetAssetFilepath().c_str(),
+			permutation);
+	}
+	const bool bCachedComplete = bCompiledRegular && bCompiledDebug && m_shaderCache.CacheSpirv_ThreadSafe(
+		assetInfo->GetFileId(),
+		permutation,
+		spirvVertexByteCode,
+		spirvFragmentByteCode,
+		spirvComputeByteCode,
+		spirvVertexByteCodeDebug,
+		spirvFragmentByteCodeDebug,
+		spirvComputeByteCodeDebug);
+	if (bCompiledRegular && bCompiledDebug && !bCachedComplete)
+	{
+		SAILOR_LOG_ERROR(
+			"Failed to publish complete SPIR-V generation for shader %s permutation %u: %s",
+			assetInfo->GetAssetFilepath().c_str(),
+			permutation,
+			m_shaderCache.GetLastSaveDiagnostic().c_str());
 	}
 
-	return (bResultCompileVertexShader && bResultCompileFragmentShader) || bResultCompileComputeShader;
+	return bCompiledRegular && bCompiledDebug && bCachedComplete;
+}
+
+void ShaderCompiler::RecordCompileResult(
+	std::atomic_bool& aggregate,
+	bool bSucceeded) noexcept
+{
+	if (!bSucceeded)
+	{
+		aggregate.store(false, std::memory_order_release);
+	}
+}
+
+bool ShaderCompiler::SaveShaderCacheAndCombineResult(
+	ShaderCache& cache,
+	bool bCompiledSuccessfully)
+{
+	cache.SaveCache();
+	return bCompiledSuccessfully && !cache.IsDirty();
+}
+
+bool ShaderCompiler::ShouldRetryDirtyShaderCache(
+	size_t numPermutationsToCompile,
+	bool bCacheDirty) noexcept
+{
+	return numPermutationsToCompile == 0 && bCacheDirty;
+}
+
+void ShaderCompiler::RemoveFinishedPromiseEntries(
+	TVector<TPair<uint32_t, Tasks::TaskPtr<ShaderSetPtr>>>& entries)
+{
+	RemoveMatchingEntries(entries, [](const Tasks::TaskPtr<ShaderSetPtr>& promise)
+		{
+			return promise && promise->IsFinished();
+		});
 }
 
 Tasks::TaskPtr<bool> ShaderCompiler::CompileAllPermutations(const FileId& uid)
@@ -370,32 +465,50 @@ Tasks::TaskPtr<bool> ShaderCompiler::CompileAllPermutations(ShaderAssetInfoPtr a
 			}
 		}
 
+		auto scheduler = App::GetSubmodule<Tasks::Scheduler>();
 		if (permutationsToCompile.IsEmpty())
 		{
+			if (ShouldRetryDirtyShaderCache(permutationsToCompile.Num(), m_shaderCache.IsDirty()))
+			{
+				Tasks::TaskPtr<bool> retrySaveJob = Tasks::CreateTaskWithResult<bool>(
+					"Retry Save Shader Cache",
+					[this]()
+					{
+						return SaveShaderCacheAndCombineResult(m_shaderCache, true);
+					});
+				scheduler->Run(retrySaveJob);
+				return retrySaveJob;
+			}
 			return Tasks::TaskPtr<bool>::Make(false);
 		}
 
-		auto scheduler = App::GetSubmodule<Tasks::Scheduler>();
-
 		SAILOR_LOG("Compiling shader: %s Num permutations: %zd", assetInfo->GetAssetFilepath().c_str(), permutationsToCompile.Num());
 
+		auto compileSucceeded = std::make_shared<std::atomic_bool>(true);
 		Tasks::TaskPtr<bool> saveCacheJob = Tasks::CreateTaskWithResult<bool>("Save Shader Cache", [=, this]()
 			{
-				SAILOR_LOG("Shader compiled %s", assetInfo->GetAssetFilepath().c_str());
-				m_shaderCache.SaveCache();
+				const bool bCompiled = compileSucceeded->load(std::memory_order_acquire);
+				SAILOR_LOG(
+					bCompiled ? "Shader compiled %s" : "Shader compilation failed %s",
+					assetInfo->GetAssetFilepath().c_str());
+				const bool bResult = SaveShaderCacheAndCombineResult(m_shaderCache, bCompiled);
 
 				//Unload shader asset text
 				m_shaderAssetsCache.Remove(assetInfo->GetFileId());
 
-				return true;
+				return bResult;
 			});
 
 		for (uint32_t i = 0; i < permutationsToCompile.Num(); i++)
 		{
-			Tasks::ITaskPtr job = Tasks::CreateTask("Compile shader", [i, pShader, assetInfo, permutationsToCompile]()
+			Tasks::TaskPtr<bool> job = Tasks::CreateTaskWithResult<bool>("Compile shader", [i, assetInfo, permutationsToCompile, compileSucceeded]()
 				{
 					SAILOR_LOG("Start compiling shader %d", permutationsToCompile[i]);
-					App::GetSubmodule<ShaderCompiler>()->ForceCompilePermutation(assetInfo, permutationsToCompile[i]);
+					const bool bSucceeded = App::GetSubmodule<ShaderCompiler>()->ForceCompilePermutation(
+						assetInfo,
+						permutationsToCompile[i]);
+					ShaderCompiler::RecordCompileResult(*compileSucceeded, bSucceeded);
+					return bSucceeded;
 				});
 
 			saveCacheJob->Join(job);
@@ -767,88 +880,69 @@ Tasks::TaskPtr<ShaderSetPtr> ShaderCompiler::LoadShader(FileId uid, ShaderSetPtr
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	Tasks::TaskPtr<ShaderSetPtr> newPromise;
 	outShader = nullptr;
-
-	if (auto pShader = LoadShaderAsset(uid).TryLock())
+	auto shaderAsset = LoadShaderAsset(uid).TryLock();
+	if (!shaderAsset)
 	{
-		const uint32_t permutation = GetPermutation(pShader->GetSupportedDefines(), defines);
-
-		// Check promises first
-		auto it = m_promises.Find(uid);
-		if (it != m_promises.end())
-		{
-			auto allLoadedPermutations = (*it).m_second;
-			auto shaderIt = std::find_if(allLoadedPermutations.begin(), allLoadedPermutations.end(), [=](const auto& p) { return p.m_first == permutation; });
-			if (shaderIt != allLoadedPermutations.end())
-			{
-				newPromise = (*shaderIt).m_second;
-			}
-		}
-
-		// Check loaded shaders then
-		auto loadedShadersIt = m_loadedShaders.Find(uid);
-		if (loadedShadersIt != m_loadedShaders.end())
-		{
-			auto allLoadedPermutations = (*loadedShadersIt).m_second;
-			auto shaderIt = std::find_if(allLoadedPermutations.begin(), allLoadedPermutations.end(), [=](const auto& p) { return p.m_first == permutation; });
-			if (shaderIt != allLoadedPermutations.end())
-			{
-				outShader = (*shaderIt).m_second;
-				return newPromise ? newPromise : Tasks::TaskPtr<ShaderSetPtr>::Make(outShader);
-			}
-		}
-
-		auto& entry = m_promises.At_Lock(uid);
-
-		// We have promise
-		if (entry.Num() > 0)
-		{
-			const size_t index = entry.FindIf([&](const auto& el) { return el.m_first == permutation; });
-			if (index != -1)
-			{
-				auto& shaders = m_loadedShaders.At_Lock(uid);
-				outShader = shaders[index].m_second;
-				m_loadedShaders.Unlock(uid);
-				m_promises.Unlock(uid);
-
-				return entry[index].m_second;
-			}
-		}
-
-		if (ShaderAssetInfoPtr assetInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr<ShaderAssetInfoPtr>(uid))
-		{
-			SAILOR_PROFILE_TEXT(assetInfo->GetAssetFilepath().c_str());
-			(void)assetInfo;
-
-			auto pShader = ShaderSetPtr::Make(m_allocator, uid, defines);
-
-			newPromise = Tasks::CreateTaskWithResult<ShaderSetPtr>("Load shader",
-				[pShader, this, permutation]()
-				{
-					UpdateRHIResource(pShader, permutation);
-					return pShader;
-				});
-
-			auto& shaders = m_loadedShaders.At_Lock(uid);
-
-			shaders.Add({ permutation, pShader });
-			entry.Add({ permutation, newPromise });
-			outShader = (*(shaders.end() - 1)).m_second;
-
-			m_loadedShaders.Unlock(uid);
-
-			App::GetSubmodule<Tasks::Scheduler>()->Run(newPromise);
-			m_promises.Unlock(uid);
-
-			return newPromise;
-		}
+		SAILOR_LOG("Cannot find shader with uid: %s", uid.ToString().c_str());
+		return Tasks::TaskPtr<ShaderSetPtr>();
 	}
 
-	m_promises.Unlock(uid);
+	const uint32_t permutation = GetPermutation(shaderAsset->GetSupportedDefines(), defines);
+	ShaderAssetInfoPtr assetInfo =
+		App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr<ShaderAssetInfoPtr>(uid);
+	if (!assetInfo)
+	{
+		SAILOR_LOG("Cannot find shader with uid: %s", uid.ToString().c_str());
+		return Tasks::TaskPtr<ShaderSetPtr>();
+	}
+	SAILOR_PROFILE_TEXT(assetInfo->GetAssetFilepath().c_str());
 
-	SAILOR_LOG("Cannot find shader with uid: %s", uid.ToString().c_str());
-	return Tasks::TaskPtr<ShaderSetPtr>();
+	Tasks::TaskPtr<ShaderSetPtr> newPromise;
+	{
+		auto& promises = m_promises.At_Lock(uid);
+		TConcurrentMapEntryUnlockGuard promisesUnlockGuard(m_promises, uid);
+		auto& shaders = m_loadedShaders.At_Lock(uid);
+		TConcurrentMapEntryUnlockGuard shadersUnlockGuard(m_loadedShaders, uid);
+		const size_t promiseIndex = FindPermutationIndex(promises, permutation);
+		const size_t shaderIndex = FindPermutationIndex(shaders, permutation);
+		if (shaderIndex != static_cast<size_t>(-1))
+		{
+			outShader = shaders[shaderIndex].m_second;
+			return promiseIndex == static_cast<size_t>(-1)
+				? Tasks::TaskPtr<ShaderSetPtr>::Make(outShader)
+				: promises[promiseIndex].m_second;
+		}
+		if (promiseIndex != static_cast<size_t>(-1))
+		{
+			return promises[promiseIndex].m_second;
+		}
+
+		auto pShader = ShaderSetPtr::Make(m_allocator, uid, defines);
+		newPromise = Tasks::CreateTaskWithResult<ShaderSetPtr>(
+			"Load shader",
+			[pShader, this, uid, permutation]() mutable
+			{
+				if (!UpdateRHIResource(pShader, permutation))
+				{
+					{
+						auto& failedPromises = m_promises.At_Lock(uid);
+						TConcurrentMapEntryUnlockGuard promisesUnlockGuard(m_promises, uid);
+						auto& failedShaders = m_loadedShaders.At_Lock(uid);
+						TConcurrentMapEntryUnlockGuard shadersUnlockGuard(m_loadedShaders, uid);
+						EvictFailedShaderLoadEntries(failedPromises, failedShaders, permutation);
+					}
+					pShader.DestroyObject(m_allocator);
+					return ShaderSetPtr{};
+				}
+				return pShader;
+			});
+
+		AddShaderLoadEntries(promises, shaders, permutation, newPromise, pShader);
+		outShader = pShader;
+	}
+	App::GetSubmodule<Tasks::Scheduler>()->Run(newPromise);
+	return newPromise;
 }
 
 bool ShaderCompiler::LoadShader_Immediate(FileId uid, ShaderSetPtr& outShader, const TVector<string>& defines)
@@ -862,7 +956,12 @@ bool ShaderCompiler::LoadShader_Immediate(FileId uid, ShaderSetPtr& outShader, c
 	}
 
 	task->Wait();
-	return task->GetResult().IsValid();
+	outShader = task->GetResult();
+	if (!outShader.IsValid())
+	{
+		return false;
+	}
+	return true;
 }
 
 bool ShaderCompiler::UpdateRHIResource(ShaderSetPtr pShader, uint32_t permutation)
@@ -871,7 +970,16 @@ bool ShaderCompiler::UpdateRHIResource(ShaderSetPtr pShader, uint32_t permutatio
 
 	auto pRaw = pShader.GetRawPtr();
 	auto& pRhiDriver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
-	const std::string assetFilename = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(pShader->GetFileId())->GetAssetFilepath();
+	AssetInfoPtr assetInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(pShader->GetFileId());
+	if (!assetInfo)
+	{
+		SAILOR_LOG_ERROR(
+			"UpdateRHIResource could not resolve asset metadata for shader %s permutation %u",
+			pShader->GetFileId().ToString().c_str(),
+			permutation);
+		return false;
+	}
+	const std::string assetFilename = assetInfo->GetAssetFilepath();
 
 	RHI::ShaderByteCode debugVertexSpirv;
 	RHI::ShaderByteCode debugFragmentSpirv;
@@ -891,43 +999,112 @@ bool ShaderCompiler::UpdateRHIResource(ShaderSetPtr pShader, uint32_t permutatio
 		return false;
 	}
 
-	if (debugVertexSpirv.Num() > 0)
+	auto createShader = [&](RHI::EShaderStage stage,
+		const RHI::ShaderByteCode& byteCode,
+		RHI::RHIShaderPtr& outShader,
+		const std::string& debugName) -> bool
 	{
-		pRaw->m_rhiVertexShaderDebug = pRhiDriver->CreateShader(RHI::EShaderStage::Vertex, debugVertexSpirv);
-		pRhiDriver->SetDebugName(pRaw->m_rhiVertexShaderDebug, "Debug Vertex " + assetFilename);
-	}
-	if (debugFragmentSpirv.Num() > 0)
+		if (byteCode.IsEmpty())
+		{
+			return true;
+		}
+		outShader = pRhiDriver->CreateShader(stage, byteCode);
+		if (!outShader)
+		{
+			SAILOR_LOG_ERROR(
+				"UpdateRHIResource failed to create %s for shader %s permutation %u",
+				debugName.c_str(),
+				pShader->GetFileId().ToString().c_str(),
+				permutation);
+			return false;
+		}
+		pRhiDriver->SetDebugName(outShader, debugName + " " + assetFilename);
+		return true;
+	};
+	RHI::RHIShaderPtr stagedVertexShader;
+	RHI::RHIShaderPtr stagedFragmentShader;
+	RHI::RHIShaderPtr stagedComputeShader;
+	RHI::RHIShaderPtr stagedDebugVertexShader;
+	RHI::RHIShaderPtr stagedDebugFragmentShader;
+	RHI::RHIShaderPtr stagedDebugComputeShader;
+
+	if (!createShader(
+		RHI::EShaderStage::Vertex,
+		debugVertexSpirv,
+		stagedDebugVertexShader,
+		"Debug Vertex") ||
+		!createShader(
+			RHI::EShaderStage::Fragment,
+			debugFragmentSpirv,
+			stagedDebugFragmentShader,
+			"Debug Fragment") ||
+		!createShader(
+			RHI::EShaderStage::Compute,
+			debugComputeFragmentSpirv,
+			stagedDebugComputeShader,
+			"Debug Compute") ||
+		!createShader(
+			RHI::EShaderStage::Vertex,
+			vertexByteCode,
+			stagedVertexShader,
+			"Vertex") ||
+		!createShader(
+			RHI::EShaderStage::Fragment,
+			fragmentByteCode,
+			stagedFragmentShader,
+			"Fragment") ||
+		!createShader(
+			RHI::EShaderStage::Compute,
+			computeByteCode,
+			stagedComputeShader,
+			"Compute"))
 	{
-		pRaw->m_rhiFragmentShaderDebug = pRhiDriver->CreateShader(RHI::EShaderStage::Fragment, debugFragmentSpirv);
-		pRhiDriver->SetDebugName(pRaw->m_rhiFragmentShaderDebug, "Debug Fragment " + assetFilename);
-	}
-	if (debugComputeFragmentSpirv.Num() > 0)
-	{
-		pRaw->m_rhiComputeShaderDebug = pRhiDriver->CreateShader(RHI::EShaderStage::Compute, debugComputeFragmentSpirv);
-		pRhiDriver->SetDebugName(pRaw->m_rhiComputeShaderDebug, "Debug Compute " + assetFilename);
+		return false;
 	}
 
-	if (vertexByteCode.Num() > 0)
+	const bool bRegularReady =
+		(stagedVertexShader && stagedFragmentShader) || stagedComputeShader;
+	const bool bDebugReady =
+		(stagedDebugVertexShader && stagedDebugFragmentShader) || stagedDebugComputeShader;
+	if (!bRegularReady || !bDebugReady)
 	{
-		pRaw->m_rhiVertexShader = pRhiDriver->CreateShader(RHI::EShaderStage::Vertex, vertexByteCode);
-		pRhiDriver->SetDebugName(pRaw->m_rhiVertexShader, "Vertex " + assetFilename);
-	}
-	if (fragmentByteCode.Num() > 0)
-	{
-		pRaw->m_rhiFragmentShader = pRhiDriver->CreateShader(RHI::EShaderStage::Fragment, fragmentByteCode);
-		pRhiDriver->SetDebugName(pRaw->m_rhiFragmentShader, "Fragment " + assetFilename);
-	}
-	if (computeByteCode.Num() > 0)
-	{
-		pRaw->m_rhiComputeShader = pRhiDriver->CreateShader(RHI::EShaderStage::Compute, computeByteCode);
-		pRhiDriver->SetDebugName(pRaw->m_rhiComputeShader, "Compute " + assetFilename);
+		SAILOR_LOG_ERROR(
+			"UpdateRHIResource staged an incomplete regular/debug shader set for shader %s permutation %u",
+			pShader->GetFileId().ToString().c_str(),
+			permutation);
+		return false;
 	}
 
 	auto pShaderAsset = LoadShaderAsset(pShader->GetFileId()).Lock();
+	if (!pShaderAsset)
+	{
+		SAILOR_LOG_ERROR(
+			"UpdateRHIResource could not reload shader metadata for shader %s permutation %u",
+			pShader->GetFileId().ToString().c_str(),
+			permutation);
+		return false;
+	}
+	const TVector<RHI::EFormat> stagedColorAttachments = pShaderAsset->GetColorAttachments();
+	const RHI::EFormat stagedDepthStencilAttachment = pShaderAsset->GetDepthStencilAttachment();
 
-	pRaw->m_colorAttachments = pShaderAsset->GetColorAttachments();
-	pRaw->m_depthStencilAttachment = pShaderAsset->GetDepthStencilAttachment();
+	pRaw->m_rhiVertexShader = std::move(stagedVertexShader);
+	pRaw->m_rhiFragmentShader = std::move(stagedFragmentShader);
+	pRaw->m_rhiComputeShader = std::move(stagedComputeShader);
+	pRaw->m_rhiVertexShaderDebug = std::move(stagedDebugVertexShader);
+	pRaw->m_rhiFragmentShaderDebug = std::move(stagedDebugFragmentShader);
+	pRaw->m_rhiComputeShaderDebug = std::move(stagedDebugComputeShader);
 
+	pRaw->m_colorAttachments = stagedColorAttachments;
+	pRaw->m_depthStencilAttachment = stagedDepthStencilAttachment;
+
+	if (!pRaw->IsReady())
+	{
+		SAILOR_LOG_ERROR(
+			"UpdateRHIResource created an incomplete regular/debug shader set for shader %s permutation %u",
+			pShader->GetFileId().ToString().c_str(),
+			permutation);
+		return false;
+	}
 	return true;
 }
 
@@ -941,31 +1118,101 @@ bool ShaderCompiler::LoadAsset(FileId uid, TObjectPtr<Object>& out, bool bImmedi
 
 void ShaderCompiler::CollectGarbage()
 {
-	TVector<FileId> uidsToRemove;
 	m_promises.LockAll();
-
 	for (auto& promiseSet : m_promises)
 	{
-		bool bFullyCompiled = true;
-		for (auto& promise : promiseSet.m_second)
-		{
-			if (!promise.m_second || !promise.m_second->IsFinished())
-			{
-				bFullyCompiled = false;
-				break;
-			}
-		}
-
-		if (bFullyCompiled)
-		{
-			uidsToRemove.Emplace(promiseSet.m_first);
-		}
+		RemoveFinishedPromiseEntries(promiseSet.m_second);
 	}
-
 	m_promises.UnlockAll();
-
-	for (auto& uid : uidsToRemove)
-	{
-		m_promises.Remove(uid);
-	}
 }
+
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+bool ShaderCompilerTestAccess::AggregateCompileResults(const bool* results, size_t count)
+{
+	std::atomic_bool aggregate = true;
+	for (size_t index = 0; index < count; ++index)
+	{
+		ShaderCompiler::RecordCompileResult(aggregate, results[index]);
+	}
+	return aggregate.load(std::memory_order_acquire);
+}
+
+bool ShaderCompilerTestAccess::SaveCacheAndCombineResult(
+	ShaderCache& cache,
+	bool bCompiledSuccessfully)
+{
+	return ShaderCompiler::SaveShaderCacheAndCombineResult(cache, bCompiledSuccessfully);
+}
+
+bool ShaderCompilerTestAccess::ShouldRetryCacheSave(
+	size_t numPermutationsToCompile,
+	bool bCacheDirty)
+{
+	return ShaderCompiler::ShouldRetryDirtyShaderCache(
+		numPermutationsToCompile,
+		bCacheDirty);
+}
+
+bool ShaderCompilerTestAccess::ExerciseFailedLoadEvictionAndRetry()
+{
+	constexpr uint32_t permutation = 7;
+	FileId uid;
+	uid.Deserialize(YAML::Node("{SHADER-COMPILER-FAILURE-LIFECYCLE}"));
+	TConcurrentMap<FileId, TVector<TPair<uint32_t, uint32_t>>> promises;
+	TConcurrentMap<FileId, TVector<TPair<uint32_t, uint32_t>>> shaders;
+	{
+		auto& promiseEntries = promises.At_Lock(uid);
+		TConcurrentMapEntryUnlockGuard promisesUnlockGuard(promises, uid);
+		auto& shaderEntries = shaders.At_Lock(uid);
+		TConcurrentMapEntryUnlockGuard shadersUnlockGuard(shaders, uid);
+		ShaderCompiler::AddShaderLoadEntries(
+			promiseEntries,
+			shaderEntries,
+			permutation,
+			101u,
+			201u);
+	}
+	{
+		auto& promiseEntries = promises.At_Lock(uid);
+		TConcurrentMapEntryUnlockGuard promisesUnlockGuard(promises, uid);
+		auto& shaderEntries = shaders.At_Lock(uid);
+		TConcurrentMapEntryUnlockGuard shadersUnlockGuard(shaders, uid);
+		ShaderCompiler::EvictFailedShaderLoadEntries(
+			promiseEntries,
+			shaderEntries,
+			permutation);
+	}
+	{
+		auto& promiseEntries = promises.At_Lock(uid);
+		TConcurrentMapEntryUnlockGuard promisesUnlockGuard(promises, uid);
+		auto& shaderEntries = shaders.At_Lock(uid);
+		TConcurrentMapEntryUnlockGuard shadersUnlockGuard(shaders, uid);
+		if (!promiseEntries.IsEmpty() || !shaderEntries.IsEmpty())
+		{
+			return false;
+		}
+		ShaderCompiler::AddShaderLoadEntries(
+			promiseEntries,
+			shaderEntries,
+			permutation,
+			102u,
+			202u);
+		return ShaderCompiler::FindPermutationIndex(promiseEntries, permutation) != static_cast<size_t>(-1) &&
+			ShaderCompiler::FindPermutationIndex(shaderEntries, permutation) != static_cast<size_t>(-1);
+	}
+
+	return false;
+}
+
+bool ShaderCompilerTestAccess::ExercisePromiseGarbageCollection()
+{
+	TVector<TPair<uint32_t, Tasks::TaskPtr<ShaderSetPtr>>> promises;
+	auto completed = Tasks::TaskPtr<ShaderSetPtr>::Make(ShaderSetPtr{});
+	completed->Wait();
+	promises.Add({ 1, completed });
+	promises.Add({ 2, Tasks::TaskPtr<ShaderSetPtr>{} });
+	ShaderCompiler::RemoveFinishedPromiseEntries(promises);
+	return ShaderCompiler::FindPermutationIndex(promises, 1) == static_cast<size_t>(-1) &&
+		ShaderCompiler::FindPermutationIndex(promises, 2) != static_cast<size_t>(-1);
+}
+#endif

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Core/Defines.h"
+#include <atomic>
 #include <string>
 #include "Containers/Pair.h"
 #include "Containers/Vector.h"
@@ -110,11 +111,11 @@ namespace Sailor
 	class ShaderCompiler final : public TSubmodule<ShaderCompiler>, public IAssetInfoHandlerListener, public IAssetFactory
 	{
 		const bool bShouldAutoCompileAllPermutations = false;
-		
-		// Version is used to generate shader's code with all constants
-		const uint32_t Version = 4;
 
 	public:
+		// Bump whenever generated shader source or compiled artifact semantics change.
+		static constexpr uint32_t CacheProducerVersion = 4;
+
 		SAILOR_API ShaderCompiler(ShaderAssetInfoHandler* infoHandler);
 
 		SAILOR_API Tasks::TaskPtr<bool> CompileAllPermutations(const FileId& uid);
@@ -156,9 +157,109 @@ namespace Sailor
 
 		SAILOR_API bool UpdateRHIResource(ShaderSetPtr shader, uint32_t permutation);
 
+		static void RecordCompileResult(std::atomic_bool& aggregate, bool bSucceeded) noexcept;
+		static bool SaveShaderCacheAndCombineResult(
+			ShaderCache& cache,
+			bool bCompiledSuccessfully);
+		static bool ShouldRetryDirtyShaderCache(
+			size_t numPermutationsToCompile,
+			bool bCacheDirty) noexcept;
+
+		template<typename TValue>
+		static size_t FindPermutationIndex(
+			const TVector<TPair<uint32_t, TValue>>& entries,
+			uint32_t permutation)
+		{
+			return entries.FindIf([permutation](const auto& entry)
+				{
+					return entry.m_first == permutation;
+				});
+		}
+
+		template<typename TValue>
+		static bool RemovePermutationEntry(
+			TVector<TPair<uint32_t, TValue>>& entries,
+			uint32_t permutation)
+		{
+			const size_t index = FindPermutationIndex(entries, permutation);
+			if (index == static_cast<size_t>(-1))
+			{
+				return false;
+			}
+			entries.RemoveAt(index);
+			return true;
+		}
+
+		static void RemoveFinishedPromiseEntries(
+			TVector<TPair<uint32_t, Tasks::TaskPtr<ShaderSetPtr>>>& entries);
+
+		template<typename TValue, typename TPredicate>
+		static void RemoveMatchingEntries(
+			TVector<TPair<uint32_t, TValue>>& entries,
+			TPredicate&& predicate)
+		{
+			for (size_t index = entries.Num(); index > 0; --index)
+			{
+				if (predicate(entries[index - 1].m_second))
+				{
+					entries.RemoveAt(index - 1);
+				}
+			}
+		}
+
+		template<typename TPromise, typename TShader>
+		static void AddShaderLoadEntries(
+			TVector<TPair<uint32_t, TPromise>>& promises,
+			TVector<TPair<uint32_t, TShader>>& shaders,
+			uint32_t permutation,
+			const TPromise& promise,
+			const TShader& shader)
+		{
+			promises.Add({ permutation, promise });
+			try
+			{
+				shaders.Add({ permutation, shader });
+			}
+			catch (...)
+			{
+				RemovePermutationEntry(promises, permutation);
+				throw;
+			}
+		}
+
+		template<typename TPromise, typename TShader>
+		static void EvictFailedShaderLoadEntries(
+			TVector<TPair<uint32_t, TPromise>>& promises,
+			TVector<TPair<uint32_t, TShader>>& shaders,
+			uint32_t permutation)
+		{
+			RemovePermutationEntry(promises, permutation);
+			RemovePermutationEntry(shaders, permutation);
+		}
+
 		SAILOR_API void ReplaceTabsWithSpaces(AssetInfoPtr assetInfo) const;
 
 		SAILOR_API Tasks::TaskPtr<bool> CompileAllPermutations(ShaderAssetInfoPtr shaderAssetInfo);
 		SAILOR_API TWeakPtr<ShaderAsset> LoadShaderAsset(ShaderAssetInfoPtr shaderAssetInfo);
+
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+		friend class ShaderCompilerTestAccess;
+#endif
 	};
+
+#if defined(SAILOR_SHADER_CACHE_TEST_HOOKS)
+	class ShaderCompilerTestAccess final
+	{
+	public:
+		SAILOR_API static bool AggregateCompileResults(const bool* results, size_t count);
+		SAILOR_API static bool SaveCacheAndCombineResult(
+			ShaderCache& cache,
+			bool bCompiledSuccessfully);
+		SAILOR_API static bool ShouldRetryCacheSave(
+			size_t numPermutationsToCompile,
+			bool bCacheDirty);
+		SAILOR_API static bool ExerciseFailedLoadEvictionAndRetry();
+		SAILOR_API static bool ExercisePromiseGarbageCollection();
+	};
+#endif
 }

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -9,6 +9,7 @@
 #include "Engine/InstanceId.h"
 #include "Submodules/Editor.h"
 #include "Workspace/WorkspaceModuleManager.h"
+#include "Workspace/WorkspaceCacheContract.h"
 
 #include <algorithm>
 #include <cstring>
@@ -175,6 +176,56 @@ uint32_t App::SerializeEditorTypes(char** yamlNode)
 	catch (...)
 	{
 		LogEditorTypeSerializationFailure("an unknown native exception was raised");
+	}
+
+	yamlNode[0] = nullptr;
+	return 0;
+}
+
+uint32_t App::SerializeWorkspaceCacheIdentity(char** yamlNode)
+{
+	if (!yamlNode || !GetInstance())
+	{
+		return 0;
+	}
+
+	yamlNode[0] = nullptr;
+	try
+	{
+		const auto identity = Workspace::MakeWorkspaceCacheIdentity(
+			"editor-types",
+			"editor-types-v1",
+			1,
+			GetWorkspaceContext());
+
+		YAML::Node identityNode;
+		identityNode["workspaceIdentity"] = identity.m_workspaceId;
+		identityNode["engineVersion"] = identity.m_engineVersion;
+		identityNode["buildIdentity"] = identity.m_buildIdentity;
+		identityNode["producerIdentity"] = identity.m_producerIdentity;
+
+		const std::string serializedNode = YAML::Dump(identityNode);
+		const size_t length = serializedNode.length();
+		if (length > std::numeric_limits<uint32_t>::max())
+		{
+			LogEditorTypeSerializationFailure("the serialized workspace cache identity exceeds the interop size limit");
+			return 0;
+		}
+
+		auto serializedOutput = std::make_unique<char[]>(length + 1);
+		memcpy(serializedOutput.get(), serializedNode.c_str(), length);
+		serializedOutput[length] = '\0';
+		yamlNode[0] = serializedOutput.release();
+
+		return static_cast<uint32_t>(length);
+	}
+	catch (const std::exception& e)
+	{
+		LogEditorTypeSerializationFailure(e.what());
+	}
+	catch (...)
+	{
+		LogEditorTypeSerializationFailure("an unknown native exception was raised while serializing workspace cache identity");
 	}
 
 	yamlNode[0] = nullptr;

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -42,6 +42,7 @@
 #include "Submodules/Editor.h"
 #include "Engine/InstanceId.h"
 #include "Workspace/WorkspaceModuleManager.h"
+#include "Workspace/WorkspacePathEncoding.h"
 
 #if defined(_WIN32)
 #include <timeapi.h>
@@ -109,10 +110,11 @@ namespace
 	{
 		if (!params.m_workspace.empty())
 		{
-			return params.m_workspace;
+			return Workspace::PathFromUtf8(params.m_workspace);
 		}
 
-		const std::filesystem::path requestedManifest = params.m_workspaceManifest;
+		const std::filesystem::path requestedManifest =
+			Workspace::PathFromUtf8(params.m_workspaceManifest);
 		if (requestedManifest.is_absolute())
 		{
 			return requestedManifest.parent_path();
@@ -226,7 +228,7 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	const Workspace::WorkspaceContextResolveResult workspaceContextResult =
 		Workspace::ResolveWorkspaceContext(
 			SelectWorkspaceRoot(params),
-			params.m_workspaceManifest);
+			Workspace::PathFromUtf8(params.m_workspaceManifest));
 	if (!workspaceContextResult.IsSuccess())
 	{
 		SAILOR_LOG_ERROR("%s", workspaceContextResult.m_message.c_str());

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -66,6 +66,7 @@ namespace Sailor
 		SAILOR_API static uint32_t SerializeCurrentWorld(char** yamlNode);
 		SAILOR_API static uint32_t SerializeEngineTypes(char** yamlNode);
 		SAILOR_API static uint32_t SerializeEditorTypes(char** yamlNode);
+		SAILOR_API static uint32_t SerializeWorkspaceCacheIdentity(char** yamlNode);
 		SAILOR_API static bool LoadEditorWorld(const char* strFileId);
 		SAILOR_API static bool UpdateEditorObject(const char* strInstanceId, const char* strYamlNode);
 		SAILOR_API static bool ReparentEditorObject(const char* strInstanceId, const char* strParentInstanceId, bool bKeepWorldTransform);

--- a/Runtime/Tasks/Tasks.cpp
+++ b/Runtime/Tasks/Tasks.cpp
@@ -29,7 +29,16 @@ void ITask::Join(const TWeakPtr<ITask>& job)
 
 bool ITask::AddDependency(ITaskPtr dependentJob)
 {
-	auto& syncBlock = App::GetSubmodule<Scheduler>()->GetTaskSyncBlock(*this);
+	if (!m_bOwnsTaskSyncBlock || IsFinished())
+	{
+		return false;
+	}
+	auto* scheduler = App::GetSubmodule<Scheduler>();
+	if (!scheduler)
+	{
+		return false;
+	}
+	auto& syncBlock = scheduler->GetTaskSyncBlock(*this);
 	std::unique_lock<std::mutex> lk(syncBlock.m_mutex);
 	if (IsFinished())
 	{
@@ -100,8 +109,17 @@ void ITask::Complete()
 void ITask::Wait()
 {
 	SAILOR_PROFILE_FUNCTION();
+	if (IsFinished() || !m_bOwnsTaskSyncBlock)
+	{
+		return;
+	}
 
-	auto& syncBlock = App::GetSubmodule<Scheduler>()->GetTaskSyncBlock(*this);
+	auto* scheduler = App::GetSubmodule<Scheduler>();
+	if (!scheduler)
+	{
+		return;
+	}
+	auto& syncBlock = scheduler->GetTaskSyncBlock(*this);
 	std::unique_lock<std::mutex> lk(syncBlock.m_mutex);
 
 	if (!IsFinished())

--- a/Runtime/Tasks/Tasks.h
+++ b/Runtime/Tasks/Tasks.h
@@ -33,7 +33,11 @@ namespace Sailor
 		{
 			auto task = TaskPtr<TResult, TArgs>::Make(name, std::move(lambda), thread);
 			task->m_self = task;
-			task->m_taskSyncBlockHandle = App::GetSubmodule<Tasks::Scheduler>()->AcquireTaskSyncBlock();
+			if (auto* scheduler = App::GetSubmodule<Tasks::Scheduler>())
+			{
+				task->m_taskSyncBlockHandle = scheduler->AcquireTaskSyncBlock();
+				task->m_bOwnsTaskSyncBlock = true;
+			}
 			return task;
 		}
 
@@ -111,6 +115,7 @@ namespace Sailor
 			std::atomic<uint8_t> m_state = 0;
 			std::atomic<uint16_t> m_numBlockers = 0;
 			uint16_t m_taskSyncBlockHandle = 0;
+			bool m_bOwnsTaskSyncBlock = false;
 
 			TWeakPtr<ITask> m_self;
 
@@ -173,7 +178,14 @@ namespace Sailor
 
 			SAILOR_API virtual ~Task()
 			{
-				App::GetSubmodule<Scheduler>()->ReleaseTaskSyncBlock(*this);
+				if (ITask::m_bOwnsTaskSyncBlock)
+				{
+					if (auto* scheduler = App::GetSubmodule<Scheduler>())
+					{
+						scheduler->ReleaseTaskSyncBlock(*this);
+					}
+					ITask::m_bOwnsTaskSyncBlock = false;
+				}
 			}
 
 			SAILOR_API void Execute() override

--- a/Runtime/Workspace/WorkspaceCacheContract.cpp
+++ b/Runtime/Workspace/WorkspaceCacheContract.cpp
@@ -1,0 +1,1001 @@
+#include "Workspace/WorkspaceCacheContract.h"
+
+#include "Workspace/WorkspaceContext.h"
+#include "Workspace/WorkspaceModuleApi.h"
+
+#include <algorithm>
+#include <atomic>
+#include <cctype>
+#include <cerrno>
+#include <charconv>
+#include <chrono>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <system_error>
+#include <unordered_set>
+#include <yaml-cpp/yaml.h>
+
+#if defined(_WIN32)
+#include <Windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+#if !defined(SAILOR_ENGINE_VERSION)
+#define SAILOR_ENGINE_VERSION "unknown"
+#endif
+
+#if !defined(SAILOR_BUILD_CONFIG)
+#define SAILOR_BUILD_CONFIG "unknown"
+#endif
+
+namespace
+{
+	using namespace Sailor::Workspace;
+
+	constexpr const char* CacheVersionField = "cacheVersion";
+	constexpr const char* PayloadVersionField = "payloadVersion";
+	constexpr const char* CacheKindField = "cacheKind";
+	constexpr const char* ProducerIdentityField = "producerIdentity";
+	constexpr const char* WorkspaceIdField = "workspaceId";
+	constexpr const char* EngineVersionField = "engineVersion";
+	constexpr const char* BuildIdentityField = "buildIdentity";
+	constexpr const char* PayloadField = "payload";
+
+	const std::unordered_set<std::string> EnvelopeFields =
+	{
+		CacheVersionField,
+		PayloadVersionField,
+		CacheKindField,
+		ProducerIdentityField,
+		WorkspaceIdField,
+		EngineVersionField,
+		BuildIdentityField,
+		PayloadField
+	};
+
+	std::atomic<uint64_t> TemporaryFileCounter = 0;
+
+	WorkspaceCacheLoadResult Fail(
+		EWorkspaceCacheLoadStatus status,
+		std::string diagnostic) noexcept
+	{
+		WorkspaceCacheLoadResult result;
+		result.m_status = status;
+		try
+		{
+			result.m_diagnostic = std::move(diagnostic);
+		}
+		catch (...)
+		{
+			result.m_diagnostic.clear();
+		}
+		return result;
+	}
+
+	std::string Quote(const std::string& value)
+	{
+		return "'" + value + "'";
+	}
+
+	std::string SourceLabel(const std::string& sourceName)
+	{
+		return sourceName.empty() ? "workspace cache" : sourceName;
+	}
+
+	YAML::Node FindField(const YAML::Node& document, const char* fieldName)
+	{
+		for (const auto& field : document)
+		{
+			if (field.first.IsScalar() && field.first.Scalar() == fieldName)
+			{
+				return field.second;
+			}
+		}
+
+		return YAML::Node(YAML::NodeType::Undefined);
+	}
+
+	bool ValidateMapKeys(
+		const YAML::Node& document,
+		const std::string& sourceName,
+		std::string& outDiagnostic)
+	{
+		std::unordered_set<std::string> keys;
+		keys.reserve(document.size());
+		for (const auto& field : document)
+		{
+			if (!field.first.IsScalar())
+			{
+				outDiagnostic = sourceName + " is corrupt: its envelope contains a non-scalar field name.";
+				return false;
+			}
+
+			const std::string key = field.first.Scalar();
+			if (key.empty() || !keys.emplace(key).second)
+			{
+				outDiagnostic = sourceName + " is corrupt: its envelope contains duplicate or empty field " +
+					Quote(key) + ".";
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool ValidateCurrentEnvelopeFields(
+		const YAML::Node& document,
+		const std::string& sourceName,
+		std::string& outDiagnostic)
+	{
+		for (const auto& field : document)
+		{
+			const std::string key = field.first.Scalar();
+			if (!EnvelopeFields.contains(key))
+			{
+				outDiagnostic = sourceName + " is corrupt: its current envelope contains unknown field " +
+					Quote(key) + ".";
+				return false;
+			}
+		}
+
+		for (const std::string& requiredField : EnvelopeFields)
+		{
+			if (!FindField(document, requiredField.c_str()).IsDefined())
+			{
+				outDiagnostic = sourceName + " is corrupt: its current envelope is missing required field " +
+					Quote(requiredField) + ".";
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool ReadUint32(
+		const YAML::Node& field,
+		const char* fieldName,
+		const std::string& sourceName,
+		uint32_t& outValue,
+		std::string& outDiagnostic)
+	{
+		if (!field.IsDefined() || !field.IsScalar())
+		{
+			outDiagnostic = sourceName + " is corrupt: field " + Quote(fieldName) +
+				" must be an unsigned integer scalar.";
+			return false;
+		}
+
+		const std::string scalar = field.Scalar();
+		if (scalar.empty() ||
+			!std::all_of(scalar.begin(), scalar.end(), [](unsigned char character)
+				{
+					return std::isdigit(character) != 0;
+				}))
+		{
+			outDiagnostic = sourceName + " is corrupt: field " + Quote(fieldName) +
+				" must be an unsigned integer scalar.";
+			return false;
+		}
+
+		const char* begin = scalar.data();
+		const char* end = begin + scalar.size();
+		const auto parsed = std::from_chars(begin, end, outValue);
+		if (parsed.ec != std::errc() || parsed.ptr != end)
+		{
+			outDiagnostic = sourceName + " is corrupt: field " + Quote(fieldName) +
+				" must be an unsigned 32-bit integer scalar.";
+			return false;
+		}
+		return true;
+	}
+
+	bool ReadRequiredString(
+		const YAML::Node& document,
+		const char* fieldName,
+		const std::string& sourceName,
+		std::string& outValue,
+		std::string& outDiagnostic,
+		bool bAllowEmpty = false)
+	{
+		const YAML::Node field = FindField(document, fieldName);
+		if (!field.IsDefined() || !field.IsScalar())
+		{
+			outDiagnostic = sourceName + " is corrupt: field " + Quote(fieldName) +
+				" must be a scalar.";
+			return false;
+		}
+
+		outValue = field.Scalar();
+		if (!bAllowEmpty && outValue.empty())
+		{
+			outDiagnostic = sourceName + " is corrupt: field " + Quote(fieldName) +
+				" cannot be empty.";
+			return false;
+		}
+		return true;
+	}
+
+	WorkspaceCacheLoadResult VersionMismatch(
+		const std::string& sourceName,
+		const char* fieldName,
+		uint32_t expected,
+		const std::string& actual)
+	{
+		return Fail(
+			EWorkspaceCacheLoadStatus::UnsupportedVersion,
+			sourceName + " has unsupported " + fieldName +
+			" (expected " + Quote(std::to_string(expected)) +
+			", actual " + Quote(actual) + ").");
+	}
+
+	WorkspaceCacheLoadResult IdentityMismatch(
+		const std::string& sourceName,
+		const char* fieldName,
+		const std::string& expected,
+		const std::string& actual)
+	{
+		return Fail(
+			EWorkspaceCacheLoadStatus::StaleIdentity,
+			sourceName + " has stale identity field " + Quote(fieldName) +
+			" (expected " + Quote(expected) + ", actual " + Quote(actual) + ").");
+	}
+
+	bool ValidateIdentityForSerialization(
+		const WorkspaceCacheIdentity& identity,
+		std::string& outDiagnostic)
+	{
+		if (identity.m_cacheVersion != WorkspaceCacheFormatVersion)
+		{
+			outDiagnostic = "Cannot serialize workspace cache envelope: cacheVersion must be " +
+				Quote(std::to_string(WorkspaceCacheFormatVersion)) + ", actual " +
+				Quote(std::to_string(identity.m_cacheVersion)) + ".";
+			return false;
+		}
+		if (identity.m_payloadVersion == 0)
+		{
+			outDiagnostic = "Cannot serialize workspace cache envelope: payloadVersion must be greater than zero.";
+			return false;
+		}
+
+		const std::pair<const char*, const std::string*> fields[] =
+		{
+			{ CacheKindField, &identity.m_cacheKind },
+			{ ProducerIdentityField, &identity.m_producerIdentity },
+			{ WorkspaceIdField, &identity.m_workspaceId },
+			{ EngineVersionField, &identity.m_engineVersion },
+			{ BuildIdentityField, &identity.m_buildIdentity }
+		};
+		for (const auto& [fieldName, value] : fields)
+		{
+			if (value->empty())
+			{
+				outDiagnostic = "Cannot serialize workspace cache envelope: field " +
+					Quote(fieldName) + " cannot be empty.";
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	std::filesystem::path NormalizeLegacyRoot(const std::filesystem::path& root)
+	{
+		std::error_code error;
+		std::filesystem::path normalized = std::filesystem::weakly_canonical(root, error);
+		if (error)
+		{
+			error.clear();
+			normalized = std::filesystem::absolute(root, error);
+			if (error)
+			{
+				normalized = root;
+			}
+		}
+		return normalized.lexically_normal();
+	}
+
+	std::string GenericUtf8String(const std::filesystem::path& path)
+	{
+		const std::u8string utf8 = path.generic_u8string();
+		return std::string(
+			reinterpret_cast<const char*>(utf8.data()),
+			utf8.size());
+	}
+
+#if defined(_WIN32)
+	void FoldAsciiCaseForWindows(std::string& value) noexcept
+	{
+		for (char& character : value)
+		{
+			if (character >= 'A' && character <= 'Z')
+			{
+				character = static_cast<char>(character + ('a' - 'A'));
+			}
+		}
+	}
+#endif
+
+	uint64_t GetProcessIdentity() noexcept
+	{
+#if defined(_WIN32)
+		return static_cast<uint64_t>(GetCurrentProcessId());
+#else
+		return static_cast<uint64_t>(getpid());
+#endif
+	}
+
+	std::filesystem::path MakeTemporaryPath(const std::filesystem::path& target)
+	{
+		const uint64_t counter = TemporaryFileCounter.fetch_add(1, std::memory_order_relaxed) + 1;
+		const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+		std::filesystem::path filename = target.filename();
+		filename += "." + std::to_string(GetProcessIdentity()) + "." +
+			std::to_string(timestamp) + "." +
+			std::to_string(counter) + ".tmp";
+		return target.parent_path() / filename;
+	}
+
+	class TemporaryFileCleanup final
+	{
+	public:
+		explicit TemporaryFileCleanup(std::filesystem::path path) : m_path(std::move(path)) {}
+
+		~TemporaryFileCleanup() noexcept
+		{
+			if (!m_bReleased)
+			{
+				std::error_code error;
+				std::filesystem::remove(m_path, error);
+			}
+		}
+
+		void Release() noexcept { m_bReleased = true; }
+
+	private:
+		std::filesystem::path m_path;
+		bool m_bReleased = false;
+	};
+
+#if defined(_WIN32)
+	std::string WindowsErrorMessage(DWORD error)
+	{
+		return std::system_category().message(static_cast<int>(error));
+	}
+
+	bool WriteTemporaryFile(
+		const std::filesystem::path& temporaryPath,
+		const void* data,
+		uint64_t size,
+		std::string& outDiagnostic)
+	{
+		HANDLE file = CreateFileW(
+			temporaryPath.c_str(),
+			GENERIC_WRITE,
+			0,
+			nullptr,
+			CREATE_NEW,
+			FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_WRITE_THROUGH,
+			nullptr);
+		if (file == INVALID_HANDLE_VALUE)
+		{
+			const DWORD error = GetLastError();
+			outDiagnostic = "Cannot create workspace cache temporary file " +
+				Quote(temporaryPath.generic_string()) + ": " + WindowsErrorMessage(error) + ".";
+			return false;
+		}
+
+		const uint8_t* cursor = static_cast<const uint8_t*>(data);
+		uint64_t remaining = size;
+		while (remaining > 0)
+		{
+			const DWORD chunk = static_cast<DWORD>((std::min)(
+				remaining,
+				static_cast<uint64_t>((std::numeric_limits<DWORD>::max)())));
+			DWORD written = 0;
+			if (!WriteFile(file, cursor, chunk, &written, nullptr) || written != chunk)
+			{
+				const DWORD error = GetLastError();
+				CloseHandle(file);
+				outDiagnostic = "Cannot write workspace cache temporary file " +
+					Quote(temporaryPath.generic_string()) + ": " + WindowsErrorMessage(error) + ".";
+				return false;
+			}
+			cursor += written;
+			remaining -= written;
+		}
+
+		if (!FlushFileBuffers(file))
+		{
+			const DWORD error = GetLastError();
+			CloseHandle(file);
+			outDiagnostic = "Cannot flush workspace cache temporary file " +
+				Quote(temporaryPath.generic_string()) + ": " + WindowsErrorMessage(error) + ".";
+			return false;
+		}
+
+		if (!CloseHandle(file))
+		{
+			const DWORD error = GetLastError();
+			outDiagnostic = "Cannot close workspace cache temporary file " +
+				Quote(temporaryPath.generic_string()) + ": " + WindowsErrorMessage(error) + ".";
+			return false;
+		}
+
+		return true;
+	}
+#else
+	std::string PosixErrorMessage(int error)
+	{
+		return std::generic_category().message(error);
+	}
+
+	bool WriteTemporaryFile(
+		const std::filesystem::path& temporaryPath,
+		const void* data,
+		uint64_t size,
+		std::string& outDiagnostic)
+	{
+		int flags = O_WRONLY | O_CREAT | O_EXCL;
+#if defined(O_CLOEXEC)
+		flags |= O_CLOEXEC;
+#endif
+		const int file = open(temporaryPath.c_str(), flags, 0666);
+		if (file < 0)
+		{
+			const int error = errno;
+			outDiagnostic = "Cannot create workspace cache temporary file " +
+				Quote(temporaryPath.generic_string()) + ": " + PosixErrorMessage(error) + ".";
+			return false;
+		}
+
+		const uint8_t* cursor = static_cast<const uint8_t*>(data);
+		uint64_t remaining = size;
+		while (remaining > 0)
+		{
+			const size_t chunk = static_cast<size_t>((std::min)(
+				remaining,
+				static_cast<uint64_t>((std::numeric_limits<ssize_t>::max)())));
+			const ssize_t written = write(file, cursor, chunk);
+			if (written < 0)
+			{
+				if (errno == EINTR)
+				{
+					continue;
+				}
+
+				const int error = errno;
+				close(file);
+				outDiagnostic = "Cannot write workspace cache temporary file " +
+					Quote(temporaryPath.generic_string()) + ": " + PosixErrorMessage(error) + ".";
+				return false;
+			}
+			if (written == 0)
+			{
+				close(file);
+				outDiagnostic = "Cannot write workspace cache temporary file " +
+					Quote(temporaryPath.generic_string()) + ": the write made no progress.";
+				return false;
+			}
+
+			cursor += written;
+			remaining -= static_cast<uint64_t>(written);
+		}
+
+		if (fsync(file) != 0)
+		{
+			const int error = errno;
+			close(file);
+			outDiagnostic = "Cannot flush workspace cache temporary file " +
+				Quote(temporaryPath.generic_string()) + ": " + PosixErrorMessage(error) + ".";
+			return false;
+		}
+
+		if (close(file) != 0)
+		{
+			const int error = errno;
+			outDiagnostic = "Cannot close workspace cache temporary file " +
+				Quote(temporaryPath.generic_string()) + ": " + PosixErrorMessage(error) + ".";
+			return false;
+		}
+
+		return true;
+	}
+
+	bool IsUnsupportedDirectorySyncError(int error) noexcept
+	{
+		return error == EINVAL
+#if defined(ENOTSUP)
+			|| error == ENOTSUP
+#endif
+#if defined(EOPNOTSUPP) && (!defined(ENOTSUP) || EOPNOTSUPP != ENOTSUP)
+			|| error == EOPNOTSUPP
+#endif
+			;
+	}
+
+	bool FlushDirectory(
+		const std::filesystem::path& directory,
+		std::string& outDiagnostic)
+	{
+		int flags = O_RDONLY;
+#if defined(O_CLOEXEC)
+		flags |= O_CLOEXEC;
+#endif
+#if defined(O_DIRECTORY)
+		flags |= O_DIRECTORY;
+#endif
+		const int directoryFile = open(directory.c_str(), flags);
+		if (directoryFile < 0)
+		{
+			const int error = errno;
+			outDiagnostic = "Workspace cache was replaced, but its directory could not be opened for durability sync " +
+				Quote(directory.generic_string()) + ": " + PosixErrorMessage(error) + ".";
+			return false;
+		}
+
+		if (fsync(directoryFile) != 0)
+		{
+			const int error = errno;
+			close(directoryFile);
+			if (IsUnsupportedDirectorySyncError(error))
+			{
+				return true;
+			}
+			outDiagnostic = "Workspace cache was replaced, but its directory durability sync failed " +
+				Quote(directory.generic_string()) + ": " + PosixErrorMessage(error) + ".";
+			return false;
+		}
+
+		if (close(directoryFile) != 0)
+		{
+			const int error = errno;
+			outDiagnostic = "Workspace cache was replaced, but its directory handle could not be closed " +
+				Quote(directory.generic_string()) + ": " + PosixErrorMessage(error) + ".";
+			return false;
+		}
+
+		return true;
+	}
+#endif
+}
+
+using namespace Sailor::Workspace;
+
+std::string Sailor::Workspace::ResolveWorkspaceCacheIdentity(
+	const std::string& workspaceId,
+	const std::filesystem::path& canonicalWorkspaceRoot)
+{
+	if (!workspaceId.empty())
+	{
+		return workspaceId;
+	}
+
+	std::string normalizedRoot = GenericUtf8String(NormalizeLegacyRoot(canonicalWorkspaceRoot));
+#if defined(_WIN32)
+	FoldAsciiCaseForWindows(normalizedRoot);
+#endif
+	return "legacy-root:" + normalizedRoot;
+}
+
+const std::string& Sailor::Workspace::GetWorkspaceCacheEngineVersion()
+{
+	static const std::string EngineVersion = SAILOR_ENGINE_VERSION;
+	return EngineVersion;
+}
+
+const std::string& Sailor::Workspace::GetWorkspaceCacheBuildIdentity()
+{
+	static const std::string BuildIdentity =
+		std::string("config=") + SAILOR_BUILD_CONFIG + ";" + GetWorkspaceModuleAbiTagV1();
+	return BuildIdentity;
+}
+
+WorkspaceCacheIdentity Sailor::Workspace::MakeWorkspaceCacheIdentity(
+	const std::string& cacheKind,
+	const std::string& producerIdentity,
+	uint32_t payloadVersion,
+	const WorkspaceContext& workspaceContext)
+{
+	return MakeWorkspaceCacheIdentity(
+		cacheKind,
+		producerIdentity,
+		payloadVersion,
+		workspaceContext.GetWorkspaceId(),
+		workspaceContext.GetRoot());
+}
+
+WorkspaceCacheIdentity Sailor::Workspace::MakeWorkspaceCacheIdentity(
+	const std::string& cacheKind,
+	const std::string& producerIdentity,
+	uint32_t payloadVersion,
+	const std::string& workspaceId,
+	const std::filesystem::path& canonicalWorkspaceRoot)
+{
+	WorkspaceCacheIdentity identity;
+	identity.m_cacheVersion = WorkspaceCacheFormatVersion;
+	identity.m_payloadVersion = payloadVersion;
+	identity.m_cacheKind = cacheKind;
+	identity.m_producerIdentity = producerIdentity;
+	identity.m_workspaceId = ResolveWorkspaceCacheIdentity(workspaceId, canonicalWorkspaceRoot);
+	identity.m_engineVersion = GetWorkspaceCacheEngineVersion();
+	identity.m_buildIdentity = GetWorkspaceCacheBuildIdentity();
+	return identity;
+}
+
+bool Sailor::Workspace::SerializeWorkspaceCacheEnvelope(
+	const WorkspaceCacheIdentity& identity,
+	const std::string& payload,
+	std::string& outEnvelope,
+	std::string& outDiagnostic) noexcept
+{
+	outEnvelope.clear();
+	outDiagnostic.clear();
+	try
+	{
+		if (!ValidateIdentityForSerialization(identity, outDiagnostic))
+		{
+			return false;
+		}
+
+		YAML::Node document;
+		document[CacheVersionField] = identity.m_cacheVersion;
+		document[PayloadVersionField] = identity.m_payloadVersion;
+		document[CacheKindField] = identity.m_cacheKind;
+		document[ProducerIdentityField] = identity.m_producerIdentity;
+		document[WorkspaceIdField] = identity.m_workspaceId;
+		document[EngineVersionField] = identity.m_engineVersion;
+		document[BuildIdentityField] = identity.m_buildIdentity;
+		document[PayloadField] = payload;
+		outEnvelope = YAML::Dump(document);
+		return true;
+	}
+	catch (const std::exception& e)
+	{
+		outEnvelope.clear();
+		outDiagnostic = std::string("Cannot serialize workspace cache envelope: ") + e.what() + ".";
+	}
+	catch (...)
+	{
+		outEnvelope.clear();
+		outDiagnostic = "Cannot serialize workspace cache envelope: an unknown error occurred.";
+	}
+	return false;
+}
+
+WorkspaceCacheLoadResult Sailor::Workspace::ParseWorkspaceCacheEnvelope(
+	const std::string& envelope,
+	const WorkspaceCacheIdentity& expectedIdentity,
+	const std::string& sourceName) noexcept
+{
+	const std::string source = SourceLabel(sourceName);
+	try
+	{
+		const YAML::Node document = YAML::Load(envelope);
+		if (!document.IsMap())
+		{
+			return Fail(
+				EWorkspaceCacheLoadStatus::Corrupt,
+				source + " is corrupt: its envelope must be a YAML map.");
+		}
+
+		std::string diagnostic;
+		if (!ValidateMapKeys(document, source, diagnostic))
+		{
+			return Fail(EWorkspaceCacheLoadStatus::Corrupt, std::move(diagnostic));
+		}
+
+		const YAML::Node cacheVersionField = FindField(document, CacheVersionField);
+		if (!cacheVersionField.IsDefined())
+		{
+			return VersionMismatch(
+				source,
+				CacheVersionField,
+				WorkspaceCacheFormatVersion,
+				"missing");
+		}
+
+		uint32_t cacheVersion = 0;
+		if (!ReadUint32(
+				cacheVersionField,
+				CacheVersionField,
+				source,
+				cacheVersion,
+				diagnostic))
+		{
+			return Fail(EWorkspaceCacheLoadStatus::Corrupt, std::move(diagnostic));
+		}
+		if (cacheVersion != WorkspaceCacheFormatVersion)
+		{
+			return VersionMismatch(
+				source,
+				CacheVersionField,
+				WorkspaceCacheFormatVersion,
+				std::to_string(cacheVersion));
+		}
+
+		const YAML::Node payloadVersionField = FindField(document, PayloadVersionField);
+		if (!payloadVersionField.IsDefined())
+		{
+			return VersionMismatch(
+				source,
+				PayloadVersionField,
+				expectedIdentity.m_payloadVersion,
+				"missing");
+		}
+
+		uint32_t payloadVersion = 0;
+		if (!ReadUint32(
+				payloadVersionField,
+				PayloadVersionField,
+				source,
+				payloadVersion,
+				diagnostic))
+		{
+			return Fail(EWorkspaceCacheLoadStatus::Corrupt, std::move(diagnostic));
+		}
+		if (payloadVersion == 0 || payloadVersion != expectedIdentity.m_payloadVersion)
+		{
+			return VersionMismatch(
+				source,
+				PayloadVersionField,
+				expectedIdentity.m_payloadVersion,
+				std::to_string(payloadVersion));
+		}
+
+		if (!ValidateCurrentEnvelopeFields(document, source, diagnostic))
+		{
+			return Fail(EWorkspaceCacheLoadStatus::Corrupt, std::move(diagnostic));
+		}
+
+		std::string cacheKind;
+		std::string producerIdentity;
+		std::string workspaceId;
+		std::string engineVersion;
+		std::string buildIdentity;
+		if (!ReadRequiredString(document, CacheKindField, source, cacheKind, diagnostic) ||
+			!ReadRequiredString(document, ProducerIdentityField, source, producerIdentity, diagnostic) ||
+			!ReadRequiredString(document, WorkspaceIdField, source, workspaceId, diagnostic) ||
+			!ReadRequiredString(document, EngineVersionField, source, engineVersion, diagnostic) ||
+			!ReadRequiredString(document, BuildIdentityField, source, buildIdentity, diagnostic))
+		{
+			return Fail(EWorkspaceCacheLoadStatus::Corrupt, std::move(diagnostic));
+		}
+
+		if (cacheKind != expectedIdentity.m_cacheKind)
+		{
+			return IdentityMismatch(source, CacheKindField, expectedIdentity.m_cacheKind, cacheKind);
+		}
+		if (producerIdentity != expectedIdentity.m_producerIdentity)
+		{
+			return IdentityMismatch(
+				source,
+				ProducerIdentityField,
+				expectedIdentity.m_producerIdentity,
+				producerIdentity);
+		}
+		if (workspaceId != expectedIdentity.m_workspaceId)
+		{
+			return IdentityMismatch(source, WorkspaceIdField, expectedIdentity.m_workspaceId, workspaceId);
+		}
+		if (engineVersion != expectedIdentity.m_engineVersion)
+		{
+			return IdentityMismatch(
+				source,
+				EngineVersionField,
+				expectedIdentity.m_engineVersion,
+				engineVersion);
+		}
+		if (buildIdentity != expectedIdentity.m_buildIdentity)
+		{
+			return IdentityMismatch(
+				source,
+				BuildIdentityField,
+				expectedIdentity.m_buildIdentity,
+				buildIdentity);
+		}
+
+		std::string payload;
+		if (!ReadRequiredString(document, PayloadField, source, payload, diagnostic, true))
+		{
+			return Fail(EWorkspaceCacheLoadStatus::Corrupt, std::move(diagnostic));
+		}
+
+		WorkspaceCacheLoadResult result;
+		result.m_status = EWorkspaceCacheLoadStatus::Loaded;
+		result.m_diagnostic = source + " loaded with matching workspace and producer identity.";
+		result.m_payload = std::move(payload);
+		return result;
+	}
+	catch (const YAML::Exception& e)
+	{
+		return Fail(
+			EWorkspaceCacheLoadStatus::Corrupt,
+			source + " is corrupt: " + e.what() + ".");
+	}
+	catch (const std::exception& e)
+	{
+		return Fail(
+			EWorkspaceCacheLoadStatus::Corrupt,
+			source + " is corrupt: " + e.what() + ".");
+	}
+	catch (...)
+	{
+		return Fail(
+			EWorkspaceCacheLoadStatus::Corrupt,
+			source + " is corrupt: an unknown parsing error occurred.");
+	}
+}
+
+WorkspaceCacheLoadResult Sailor::Workspace::LoadWorkspaceCacheEnvelope(
+	const std::filesystem::path& path,
+	const WorkspaceCacheIdentity& expectedIdentity) noexcept
+{
+	try
+	{
+		std::error_code error;
+		const bool exists = std::filesystem::exists(path, error);
+		if (error)
+		{
+			return Fail(
+				EWorkspaceCacheLoadStatus::IoFailure,
+				"Cannot inspect workspace cache " + Quote(path.generic_string()) + ": " +
+					error.message() + ".");
+		}
+		if (!exists)
+		{
+			return Fail(
+				EWorkspaceCacheLoadStatus::Missing,
+				"Workspace cache " + Quote(path.generic_string()) + " is missing.");
+		}
+
+		if (!std::filesystem::is_regular_file(path, error) || error)
+		{
+			return Fail(
+				EWorkspaceCacheLoadStatus::IoFailure,
+				"Workspace cache " + Quote(path.generic_string()) + " is not a readable regular file" +
+					(error ? ": " + error.message() : std::string()) + ".");
+		}
+
+		std::ifstream stream(path, std::ios::binary);
+		if (!stream.is_open())
+		{
+			return Fail(
+				EWorkspaceCacheLoadStatus::IoFailure,
+				"Cannot open workspace cache " + Quote(path.generic_string()) + ".");
+		}
+
+		std::ostringstream payload;
+		payload << stream.rdbuf();
+		if (stream.bad())
+		{
+			return Fail(
+				EWorkspaceCacheLoadStatus::IoFailure,
+				"Cannot read workspace cache " + Quote(path.generic_string()) + ".");
+		}
+
+		return ParseWorkspaceCacheEnvelope(payload.str(), expectedIdentity, path.generic_string());
+	}
+	catch (const std::exception& e)
+	{
+		return Fail(
+			EWorkspaceCacheLoadStatus::IoFailure,
+			"Cannot read workspace cache " + Quote(path.generic_string()) + ": " + e.what() + ".");
+	}
+	catch (...)
+	{
+		return Fail(
+			EWorkspaceCacheLoadStatus::IoFailure,
+			"Cannot read workspace cache " + Quote(path.generic_string()) +
+				": an unknown I/O error occurred.");
+	}
+}
+
+bool Sailor::Workspace::AtomicReplaceWorkspaceCacheBinary(
+	const std::filesystem::path& target,
+	const void* data,
+	uint64_t size,
+	std::string& outDiagnostic,
+	EWorkspaceCacheAtomicWriteFailurePoint failurePoint) noexcept
+{
+	outDiagnostic.clear();
+	try
+	{
+		if (target.empty() || target.filename().empty())
+		{
+			outDiagnostic = "Cannot atomically replace workspace cache: the target path is empty or has no filename.";
+			return false;
+		}
+		if (size > 0 && data == nullptr)
+		{
+			outDiagnostic = "Cannot atomically replace workspace cache " + Quote(target.generic_string()) +
+				": non-empty data has a null address.";
+			return false;
+		}
+
+		const std::filesystem::path parent = target.parent_path().empty()
+			? std::filesystem::path(".")
+			: target.parent_path();
+		std::error_code directoryError;
+		std::filesystem::create_directories(parent, directoryError);
+		if (directoryError)
+		{
+			outDiagnostic = "Cannot create workspace cache directory " + Quote(parent.generic_string()) +
+				": " + directoryError.message() + ".";
+			return false;
+		}
+
+		const std::filesystem::path temporaryPath = MakeTemporaryPath(target);
+		TemporaryFileCleanup cleanup(temporaryPath);
+		if (!WriteTemporaryFile(temporaryPath, data, size, outDiagnostic))
+		{
+			return false;
+		}
+
+		if (failurePoint == EWorkspaceCacheAtomicWriteFailurePoint::BeforeReplace)
+		{
+			outDiagnostic = "Injected workspace cache replacement failure before replacing " +
+				Quote(target.generic_string()) + ".";
+			return false;
+		}
+
+#if defined(_WIN32)
+		if (!MoveFileExW(
+				temporaryPath.c_str(),
+				target.c_str(),
+				MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH))
+		{
+			const DWORD error = GetLastError();
+			outDiagnostic = "Cannot atomically replace workspace cache " + Quote(target.generic_string()) +
+				": " + WindowsErrorMessage(error) + ".";
+			return false;
+		}
+		cleanup.Release();
+#else
+		if (rename(temporaryPath.c_str(), target.c_str()) != 0)
+		{
+			const int error = errno;
+			outDiagnostic = "Cannot atomically replace workspace cache " + Quote(target.generic_string()) +
+				": " + PosixErrorMessage(error) + ".";
+			return false;
+		}
+		cleanup.Release();
+		if (!FlushDirectory(parent, outDiagnostic))
+		{
+			return false;
+		}
+#endif
+
+		outDiagnostic = "Atomically replaced workspace cache " + Quote(target.generic_string()) + ".";
+		return true;
+	}
+	catch (const std::exception& e)
+	{
+		outDiagnostic = "Cannot atomically replace workspace cache " + Quote(target.generic_string()) +
+			": " + e.what() + ".";
+	}
+	catch (...)
+	{
+		outDiagnostic = "Cannot atomically replace workspace cache " + Quote(target.generic_string()) +
+			": an unknown I/O error occurred.";
+	}
+	return false;
+}
+
+bool Sailor::Workspace::AtomicReplaceWorkspaceCacheText(
+	const std::filesystem::path& target,
+	const std::string& text,
+	std::string& outDiagnostic,
+	EWorkspaceCacheAtomicWriteFailurePoint failurePoint) noexcept
+{
+	return AtomicReplaceWorkspaceCacheBinary(
+		target,
+		text.data(),
+		static_cast<uint64_t>(text.size()),
+		outDiagnostic,
+		failurePoint);
+}

--- a/Runtime/Workspace/WorkspaceCacheContract.h
+++ b/Runtime/Workspace/WorkspaceCacheContract.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "Core/Defines.h"
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+namespace Sailor::Workspace
+{
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+
+	class WorkspaceContext;
+	inline constexpr uint32_t WorkspaceCacheFormatVersion = 1;
+
+	enum class EWorkspaceCacheLoadStatus : uint32_t
+	{
+		Missing,
+		Loaded,
+		StaleIdentity,
+		Corrupt,
+		UnsupportedVersion,
+		IoFailure
+	};
+
+	enum class EWorkspaceCacheAtomicWriteFailurePoint : uint32_t
+	{
+		None,
+		BeforeReplace
+	};
+
+	struct SAILOR_SHARED_API WorkspaceCacheIdentity final
+	{
+		uint32_t m_cacheVersion = WorkspaceCacheFormatVersion;
+		uint32_t m_payloadVersion = 0;
+		std::string m_cacheKind;
+		std::string m_producerIdentity;
+		std::string m_workspaceId;
+		std::string m_engineVersion;
+		std::string m_buildIdentity;
+	};
+
+	struct SAILOR_SHARED_API WorkspaceCacheLoadResult final
+	{
+		EWorkspaceCacheLoadStatus m_status = EWorkspaceCacheLoadStatus::IoFailure;
+		std::string m_diagnostic;
+		std::string m_payload;
+
+		bool IsLoaded() const noexcept
+		{
+			return m_status == EWorkspaceCacheLoadStatus::Loaded;
+		}
+	};
+
+	SAILOR_SHARED_API std::string ResolveWorkspaceCacheIdentity(
+		const std::string& workspaceId,
+		const std::filesystem::path& canonicalWorkspaceRoot);
+
+	SAILOR_SHARED_API const std::string& GetWorkspaceCacheEngineVersion();
+	SAILOR_SHARED_API const std::string& GetWorkspaceCacheBuildIdentity();
+
+	SAILOR_SHARED_API WorkspaceCacheIdentity MakeWorkspaceCacheIdentity(
+		const std::string& cacheKind,
+		const std::string& producerIdentity,
+		uint32_t payloadVersion,
+		const WorkspaceContext& workspaceContext);
+
+	SAILOR_SHARED_API WorkspaceCacheIdentity MakeWorkspaceCacheIdentity(
+		const std::string& cacheKind,
+		const std::string& producerIdentity,
+		uint32_t payloadVersion,
+		const std::string& workspaceId,
+		const std::filesystem::path& canonicalWorkspaceRoot);
+
+	SAILOR_SHARED_API bool SerializeWorkspaceCacheEnvelope(
+		const WorkspaceCacheIdentity& identity,
+		const std::string& payload,
+		std::string& outEnvelope,
+		std::string& outDiagnostic) noexcept;
+
+	SAILOR_SHARED_API WorkspaceCacheLoadResult ParseWorkspaceCacheEnvelope(
+		const std::string& envelope,
+		const WorkspaceCacheIdentity& expectedIdentity,
+		const std::string& sourceName = "workspace cache") noexcept;
+
+	SAILOR_SHARED_API WorkspaceCacheLoadResult LoadWorkspaceCacheEnvelope(
+		const std::filesystem::path& path,
+		const WorkspaceCacheIdentity& expectedIdentity) noexcept;
+
+	SAILOR_SHARED_API bool AtomicReplaceWorkspaceCacheBinary(
+		const std::filesystem::path& target,
+		const void* data,
+		uint64_t size,
+		std::string& outDiagnostic,
+		EWorkspaceCacheAtomicWriteFailurePoint failurePoint =
+			EWorkspaceCacheAtomicWriteFailurePoint::None) noexcept;
+
+	SAILOR_SHARED_API bool AtomicReplaceWorkspaceCacheText(
+		const std::filesystem::path& target,
+		const std::string& text,
+		std::string& outDiagnostic,
+		EWorkspaceCacheAtomicWriteFailurePoint failurePoint =
+			EWorkspaceCacheAtomicWriteFailurePoint::None) noexcept;
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+}

--- a/Runtime/Workspace/WorkspaceContext.cpp
+++ b/Runtime/Workspace/WorkspaceContext.cpp
@@ -1,4 +1,5 @@
 #include "Workspace/WorkspaceContext.h"
+#include "Workspace/WorkspacePathEncoding.h"
 
 #include <algorithm>
 #include <cctype>
@@ -148,7 +149,7 @@ namespace
 
 	bool HasSailorExtension(const std::filesystem::path& path)
 	{
-		std::string extension = path.extension().string();
+		std::string extension = PathToUtf8(path.extension());
 		std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char character)
 			{
 				return static_cast<char>(std::tolower(character));
@@ -182,16 +183,20 @@ namespace
 				return false;
 			}
 
-			std::string rootValue = rootPart->generic_string();
-			std::string candidateValue = candidatePart->generic_string();
+			std::string rootValue = PathToUtf8(*rootPart);
+			std::string candidateValue = PathToUtf8(*candidatePart);
 #if defined(_WIN32)
 			std::transform(rootValue.begin(), rootValue.end(), rootValue.begin(), [](unsigned char character)
 				{
-					return static_cast<char>(std::tolower(character));
+					return character >= 'A' && character <= 'Z'
+						? static_cast<char>(character + ('a' - 'A'))
+						: static_cast<char>(character);
 				});
 			std::transform(candidateValue.begin(), candidateValue.end(), candidateValue.begin(), [](unsigned char character)
 				{
-					return static_cast<char>(std::tolower(character));
+					return character >= 'A' && character <= 'Z'
+						? static_cast<char>(character + ('a' - 'A'))
+						: static_cast<char>(character);
 				});
 #endif
 			if (rootValue != candidateValue)
@@ -287,7 +292,7 @@ namespace
 		if (fileError || fileSize > MaxManifestSize ||
 			fileSize > static_cast<uintmax_t>((std::numeric_limits<std::streamsize>::max)()))
 		{
-			outError = "Workspace manifest '" + manifestPath.generic_string() +
+			outError = "Workspace manifest '" + PathToUtf8(manifestPath) +
 				"' is unreadable or exceeds the size limit.";
 			return false;
 		}
@@ -295,14 +300,14 @@ namespace
 		std::ifstream stream(manifestPath, std::ios::binary);
 		if (!stream.is_open())
 		{
-			outError = "Workspace manifest could not be opened: '" + manifestPath.generic_string() + "'.";
+			outError = "Workspace manifest could not be opened: '" + PathToUtf8(manifestPath) + "'.";
 			return false;
 		}
 
 		std::string payload(static_cast<size_t>(fileSize), '\0');
 		if (fileSize > 0 && !stream.read(payload.data(), static_cast<std::streamsize>(fileSize)))
 		{
-			outError = "Workspace manifest could not be read: '" + manifestPath.generic_string() + "'.";
+			outError = "Workspace manifest could not be read: '" + PathToUtf8(manifestPath) + "'.";
 			return false;
 		}
 
@@ -321,7 +326,7 @@ namespace
 		outFields.m_manifestVersion = version.as<uint32_t>();
 		if (outFields.m_manifestVersion != SupportedManifestVersion)
 		{
-			outError = "Workspace manifest '" + manifestPath.generic_string() +
+			outError = "Workspace manifest '" + PathToUtf8(manifestPath) +
 				"' has unsupported manifestVersion '" +
 				std::to_string(outFields.m_manifestVersion) + "'.";
 			return false;
@@ -400,7 +405,7 @@ namespace
 		const bool bWindowsDrivePath = normalized.size() >= 2 &&
 			std::isalpha(static_cast<unsigned char>(normalized[0])) != 0 &&
 			normalized[1] == ':';
-		const std::filesystem::path path(normalized);
+		const std::filesystem::path path = PathFromUtf8(normalized);
 		if (normalized.empty() || normalized.find('\0') != std::string::npos ||
 			normalized.front() == '/' || bWindowsDrivePath ||
 			path.is_absolute() || path.has_root_name() || path.has_root_directory())
@@ -421,7 +426,7 @@ namespace
 		}
 
 		outPath = path.lexically_normal();
-		outNormalized = outPath.generic_string();
+		outNormalized = PathToUtf8(outPath);
 		return true;
 	}
 
@@ -437,13 +442,13 @@ namespace
 		if (pathError || outPath.empty())
 		{
 			outError = "Workspace path '" + std::string(fieldName) +
-				"' could not be resolved: '" + (root / relativePath).generic_string() + "'.";
+				"' could not be resolved: '" + PathToUtf8(root / relativePath) + "'.";
 			return false;
 		}
 		if (!IsInside(root, outPath))
 		{
 			outError = "Workspace path '" + std::string(fieldName) +
-				"' escapes the workspace after physical resolution: '" + outPath.generic_string() + "'.";
+				"' escapes the workspace after physical resolution: '" + PathToUtf8(outPath) + "'.";
 			return false;
 		}
 		return true;
@@ -463,7 +468,7 @@ namespace
 			return false;
 		}
 
-		const std::filesystem::path engineReference(rawEnginePath);
+		const std::filesystem::path engineReference = PathFromUtf8(rawEnginePath);
 		const std::filesystem::path requestedEngineRoot = engineReference.is_absolute()
 			? engineReference
 			: workspaceRoot / engineReference;
@@ -472,7 +477,7 @@ namespace
 		if (pathError || !std::filesystem::is_directory(outEngineRoot, pathError) || pathError)
 		{
 			outError = "Workspace manifest field 'enginePath' must resolve to an existing directory: '" +
-				requestedEngineRoot.generic_string() + "'.";
+				PathToUtf8(requestedEngineRoot) + "'.";
 			return false;
 		}
 
@@ -484,13 +489,13 @@ namespace
 			if (engineReferenceKind == "installed")
 			{
 				outError = "Installed engine reference does not provide runtime Content at '" +
-					requestedEngineContent.generic_string() +
+					PathToUtf8(requestedEngineContent) +
 					"'. Packaging runtime Content for installed engines is not supported by this build.";
 			}
 			else
 			{
 				outError = "Engine Content must be an existing directory: '" +
-					requestedEngineContent.generic_string() + "'.";
+					PathToUtf8(requestedEngineContent) + "'.";
 			}
 			return false;
 		}
@@ -510,7 +515,7 @@ namespace
 		if (pathError)
 		{
 			outError = "Workspace directory '" + std::string(fieldName) +
-				"' could not be inspected: '" + directory.generic_string() + "'.";
+				"' could not be inspected: '" + PathToUtf8(directory) + "'.";
 			return false;
 		}
 		if (bExists)
@@ -518,7 +523,7 @@ namespace
 			if (!std::filesystem::is_directory(directory, pathError) || pathError)
 			{
 				outError = "Workspace path '" + std::string(fieldName) +
-					"' is not a directory: '" + directory.generic_string() + "'.";
+					"' is not a directory: '" + PathToUtf8(directory) + "'.";
 				return false;
 			}
 			return true;
@@ -537,7 +542,7 @@ namespace
 			if (pathError)
 			{
 				outError = "Workspace directory '" + std::string(fieldName) +
-					"' could not be inspected: '" + current.generic_string() + "'.";
+					"' could not be inspected: '" + PathToUtf8(current) + "'.";
 				return false;
 			}
 			missingDirectories.emplace_back(current);
@@ -554,7 +559,7 @@ namespace
 			{
 				outError = "Workspace directory '" + std::string(fieldName) +
 					"' parent escapes the workspace during recovery: '" +
-					missingDirectory.parent_path().generic_string() + "'.";
+					PathToUtf8(missingDirectory.parent_path()) + "'.";
 				return false;
 			}
 
@@ -564,7 +569,7 @@ namespace
 			if (pathError)
 			{
 				outError = "Workspace directory '" + std::string(fieldName) +
-					"' could not be created: '" + verifiedDirectory.generic_string() +
+					"' could not be created: '" + PathToUtf8(verifiedDirectory) +
 					"': " + pathError.message() + ".";
 				return false;
 			}
@@ -582,7 +587,7 @@ namespace
 			{
 				outError = "Workspace directory '" + std::string(fieldName) +
 					"' escaped the workspace during recovery: '" +
-					verifiedDirectory.generic_string() + "'.";
+					PathToUtf8(verifiedDirectory) + "'.";
 				return false;
 			}
 		}
@@ -601,7 +606,7 @@ namespace
 		if (pathError || !IsInside(root, directory))
 		{
 			outError = "Workspace directory '" + std::string(fieldName) +
-				"' escapes the workspace after recovery: '" + directory.generic_string() + "'.";
+				"' escapes the workspace after recovery: '" + PathToUtf8(directory) + "'.";
 			return false;
 		}
 		return true;
@@ -623,7 +628,7 @@ namespace
 			if (!std::filesystem::is_regular_file(candidate, pathError) || pathError)
 			{
 				outFailureStatus = EWorkspaceContextResolveStatus::ManifestNotFound;
-				outError = "Workspace manifest was not found: '" + candidate.generic_string() + "'.";
+				outError = "Workspace manifest was not found: '" + PathToUtf8(candidate) + "'.";
 				return false;
 			}
 
@@ -632,7 +637,7 @@ namespace
 			{
 				outFailureStatus = EWorkspaceContextResolveStatus::PathInvalid;
 				outError = "Workspace manifest resolves outside the workspace: '" +
-					outManifest.generic_string() + "'.";
+					PathToUtf8(outManifest) + "'.";
 				return false;
 			}
 			return true;
@@ -647,7 +652,7 @@ namespace
 			{
 				outFailureStatus = EWorkspaceContextResolveStatus::PathInvalid;
 				outError = "Workspace manifest resolves outside the workspace: '" +
-					outManifest.generic_string() + "'.";
+					PathToUtf8(outManifest) + "'.";
 				return false;
 			}
 			return true;
@@ -667,7 +672,7 @@ namespace
 		if (pathError)
 		{
 			outFailureStatus = EWorkspaceContextResolveStatus::WorkspaceInvalid;
-			outError = "Workspace manifests could not be enumerated in '" + root.generic_string() +
+			outError = "Workspace manifests could not be enumerated in '" + PathToUtf8(root) +
 				"': " + pathError.message() + ".";
 			return false;
 		}
@@ -681,7 +686,7 @@ namespace
 		if (manifests.size() > 1)
 		{
 			outFailureStatus = EWorkspaceContextResolveStatus::ManifestAmbiguous;
-			outError = "Multiple .sailor manifests were found in '" + root.generic_string() +
+			outError = "Multiple .sailor manifests were found in '" + PathToUtf8(root) +
 				"'. Select one explicitly.";
 			return false;
 		}
@@ -691,7 +696,7 @@ namespace
 		{
 			outFailureStatus = EWorkspaceContextResolveStatus::PathInvalid;
 			outError = "Workspace manifest resolves outside the workspace: '" +
-				outManifest.generic_string() + "'.";
+				PathToUtf8(outManifest) + "'.";
 			return false;
 		}
 		return true;
@@ -720,7 +725,7 @@ Sailor::Workspace::WorkspaceContextResolveResult Sailor::Workspace::ResolveWorks
 		{
 			return Fail(
 				EWorkspaceContextResolveStatus::WorkspaceInvalid,
-				"Workspace root must be an existing directory: '" + requestedRoot.generic_string() + "'.");
+				"Workspace root must be an existing directory: '" + PathToUtf8(requestedRoot) + "'.");
 		}
 
 		WorkspaceContextCandidate candidate;
@@ -756,7 +761,7 @@ Sailor::Workspace::WorkspaceContextResolveResult Sailor::Workspace::ResolveWorks
 			{
 				return Fail(
 					EWorkspaceContextResolveStatus::ManifestInvalid,
-					"Workspace manifest '" + candidate.m_manifest.generic_string() +
+					"Workspace manifest '" + PathToUtf8(candidate.m_manifest) +
 						"' is invalid YAML: " + e.what());
 			}
 			candidate.m_manifestVersion = fields.m_manifestVersion;
@@ -810,21 +815,21 @@ Sailor::Workspace::WorkspaceContextResolveResult Sailor::Workspace::ResolveWorks
 			return Fail(
 				EWorkspaceContextResolveStatus::PathInvalid,
 				"Workspace content path could not be inspected: '" +
-					candidate.m_content.generic_string() + "'.");
+					PathToUtf8(candidate.m_content) + "'.");
 		}
 		if (bContentExists && !std::filesystem::is_directory(candidate.m_content))
 		{
 			return Fail(
 				EWorkspaceContextResolveStatus::PathInvalid,
 				"Workspace content path is not a directory: '" +
-					candidate.m_content.generic_string() + "'.");
+					PathToUtf8(candidate.m_content) + "'.");
 		}
 		if (!bContentExists && !IsDefaultContentPath(normalizedContent))
 		{
 			return Fail(
 				EWorkspaceContextResolveStatus::ContentMissing,
 				"Custom workspace content directory is missing and will not be created: '" +
-					candidate.m_content.generic_string() + "'.");
+					PathToUtf8(candidate.m_content) + "'.");
 		}
 
 		CreatedDirectoriesRollback rollback;
@@ -855,8 +860,8 @@ Sailor::Workspace::WorkspaceContextResolveResult Sailor::Workspace::ResolveWorks
 			: EWorkspaceContextResolveStatus::Success;
 		result.m_message = candidate.m_bLegacy
 			? "No workspace manifest was found; using legacy Content and Cache directories under '" +
-				root.generic_string() + "'."
-			: "Resolved workspace manifest '" + candidate.m_manifest.generic_string() + "'.";
+				PathToUtf8(root) + "'."
+			: "Resolved workspace manifest '" + PathToUtf8(candidate.m_manifest) + "'.";
 		result.m_context.m_root = std::move(candidate.m_root);
 		result.m_context.m_manifest = std::move(candidate.m_manifest);
 		result.m_context.m_engineRoot = std::move(candidate.m_engineRoot);

--- a/Runtime/Workspace/WorkspacePathEncoding.h
+++ b/Runtime/Workspace/WorkspacePathEncoding.h
@@ -20,4 +20,12 @@ namespace Sailor::Workspace
 		return std::filesystem::u8path(utf8Path.begin(), utf8Path.end());
 #endif
 	}
+
+	inline std::string PathToUtf8(const std::filesystem::path& path)
+	{
+		const auto utf8Path = path.generic_u8string();
+		return std::string(
+			reinterpret_cast<const char*>(utf8Path.data()),
+			utf8Path.size());
+	}
 }

--- a/Runtime/Workspace/WorkspacePathEncoding.h
+++ b/Runtime/Workspace/WorkspacePathEncoding.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <string_view>
+
+namespace Sailor::Workspace
+{
+	inline std::filesystem::path PathFromUtf8(std::string_view utf8Path)
+	{
+		if (utf8Path.empty())
+		{
+			return {};
+		}
+
+#if defined(__cpp_char8_t)
+		const auto* begin = reinterpret_cast<const char8_t*>(utf8Path.data());
+		return std::filesystem::path(std::u8string(begin, begin + utf8Path.size()));
+#else
+		return std::filesystem::u8path(utf8Path.begin(), utf8Path.end());
+#endif
+	}
+}

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -1,0 +1,166 @@
+#include "AssetRegistry/AssetCache.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <yaml-cpp/yaml.h>
+
+namespace
+{
+	using namespace Sailor;
+
+	class TestAssetCache final : public AssetCache
+	{
+	public:
+		using AssetCache::AssetCacheData;
+		using AssetCache::SerializeAssetCachePayload;
+		using AssetCache::ShouldResetCacheFile;
+		using AssetCache::ShouldWriteCacheFile;
+		using AssetCache::TryDeserializeAssetCachePayload;
+	};
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	FileId MakeFileId(const std::string& value)
+	{
+		FileId result;
+		result.Deserialize(YAML::Node(value));
+		return result;
+	}
+
+	TestAssetCache::AssetCacheData MakeCache(
+		const std::string& fileIdValue,
+		const std::string& sourcePath,
+		std::time_t timestamp)
+	{
+		TestAssetCache::AssetCacheData result;
+		const FileId fileId = MakeFileId(fileIdValue);
+		TestAssetCache::AssetCacheData::Entry entry;
+		entry.m_fileId = fileId;
+		entry.m_sourcePath = sourcePath;
+		entry.m_assetImportTime = timestamp;
+		result.m_data.Insert(fileId, std::move(entry));
+		return result;
+	}
+
+	void TestPayloadRoundTrip()
+	{
+		const FileId fileId = MakeFileId("{ASSET-CACHE-ROUNDTRIP}");
+		const auto source = MakeCache(fileId.ToString(), "/workspace/Content/Test.mat", 42);
+		const std::string payload = TestAssetCache::SerializeAssetCachePayload(source);
+
+		TestAssetCache::AssetCacheData loaded;
+		std::string diagnostic;
+		Require(
+			TestAssetCache::TryDeserializeAssetCachePayload(payload, loaded, diagnostic),
+			"current asset payload should load: " + diagnostic);
+		Require(loaded.m_data.ContainsKey(fileId), "round-tripped payload should retain its file id");
+		const auto entry = loaded.m_data[fileId];
+		Require(entry.m_fileId == fileId, "round-tripped entry identity should match its map key");
+		Require(entry.m_assetImportTime == 42, "round-tripped timestamp should be preserved");
+		Require(!entry.m_sourcePath.empty(), "round-tripped source path should be normalized");
+	}
+
+	void TestEmptyPayloadRoundTrip()
+	{
+		const TestAssetCache::AssetCacheData source;
+		const std::string payload = TestAssetCache::SerializeAssetCachePayload(source);
+
+		TestAssetCache::AssetCacheData loaded;
+		std::string diagnostic;
+		Require(
+			TestAssetCache::TryDeserializeAssetCachePayload(payload, loaded, diagnostic),
+			"deterministic empty asset payload should load: " + diagnostic);
+		Require(loaded.m_data.Num() == 0, "empty asset payload should remain empty");
+	}
+
+	void TestCorruptPayloadDoesNotPartiallyPublish()
+	{
+		const FileId retainedId = MakeFileId("{ASSET-CACHE-RETAINED}");
+		auto destination = MakeCache(retainedId.ToString(), "/workspace/Content/Retained.mat", 7);
+
+		const std::string corruptPayload =
+			"assetCache:\n"
+			"  assets:\n"
+			"    '{ASSET-CACHE-CORRUPT}':\n"
+			"      fileId: '{ASSET-CACHE-CORRUPT}'\n"
+			"      assetImportTime: 8\n"
+			"      sourcePath: ''\n";
+		std::string diagnostic;
+		Require(
+			!TestAssetCache::TryDeserializeAssetCachePayload(corruptPayload, destination, diagnostic),
+			"empty sourcePath should reject the complete payload");
+		Require(!diagnostic.empty(), "corrupt asset payload should return an actionable diagnostic");
+		Require(destination.m_data.Num() == 1 && destination.m_data.ContainsKey(retainedId),
+			"failed payload validation must not partially replace existing state");
+	}
+
+	void TestMismatchedEntryIdentityIsCorrupt()
+	{
+		const std::string payload =
+			"assetCache:\n"
+			"  assets:\n"
+			"    '{ASSET-CACHE-KEY}':\n"
+			"      fileId: '{ASSET-CACHE-OTHER}'\n"
+			"      assetImportTime: 9\n"
+			"      sourcePath: '/workspace/Content/Test.mat'\n";
+
+		TestAssetCache::AssetCacheData destination;
+		std::string diagnostic;
+		Require(
+			!TestAssetCache::TryDeserializeAssetCachePayload(payload, destination, diagnostic),
+			"an entry whose fileId disagrees with its map key should be rejected");
+		Require(diagnostic.find("mismatched") != std::string::npos,
+			"identity mismatch diagnostic should explain the corruption");
+	}
+
+	void TestIoFailurePreservesTheExistingCacheFile()
+	{
+		using Status = Workspace::EWorkspaceCacheLoadStatus;
+		Require(TestAssetCache::ShouldResetCacheFile(Status::Missing),
+			"a missing cache should be initialized with a current envelope");
+		Require(TestAssetCache::ShouldResetCacheFile(Status::StaleIdentity),
+			"a stale cache should be invalidated");
+		Require(TestAssetCache::ShouldResetCacheFile(Status::Corrupt),
+			"a corrupt cache should be invalidated");
+		Require(TestAssetCache::ShouldResetCacheFile(Status::UnsupportedVersion),
+			"an unsupported cache should be invalidated");
+		Require(!TestAssetCache::ShouldResetCacheFile(Status::IoFailure),
+			"a transient I/O failure must preserve the existing cache file");
+		Require(!TestAssetCache::ShouldResetCacheFile(Status::Loaded),
+			"a loaded cache must not be reset");
+		Require(!TestAssetCache::ShouldWriteCacheFile(false, false, true),
+			"idle shutdown after an I/O failure must preserve the existing cache file");
+		Require(!TestAssetCache::ShouldWriteCacheFile(false, true, true),
+			"ordinary updates after an I/O failure must not authorize replacing unreadable storage");
+		Require(TestAssetCache::ShouldWriteCacheFile(true, true, true),
+			"an explicit forced rebuild may authorize replacing preserved cache storage");
+		Require(TestAssetCache::ShouldWriteCacheFile(false, true, false),
+			"a dirty cache without an I/O preservation barrier should be persisted");
+	}
+}
+
+int main()
+{
+	try
+	{
+		TestPayloadRoundTrip();
+		TestEmptyPayloadRoundTrip();
+		TestCorruptPayloadDoesNotPartiallyPublish();
+		TestMismatchedEntryIdentityIsCorrupt();
+		TestIoFailurePreservesTheExistingCacheFile();
+		std::cout << "Asset cache contract tests passed.\n";
+		return 0;
+	}
+	catch (const std::exception& exception)
+	{
+		std::cerr << "Asset cache contract tests failed: " << exception.what() << '\n';
+		return 1;
+	}
+}

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -12,7 +12,8 @@ namespace
 	class TestAssetCache final : public AssetCache
 	{
 	public:
-		using AssetCache::AssetCacheData;
+		using CacheData = AssetCacheData;
+		using CacheEntry = AssetCacheData::Entry;
 		using AssetCache::SerializeAssetCachePayload;
 		using AssetCache::ShouldResetCacheFile;
 		using AssetCache::ShouldWriteCacheFile;
@@ -34,14 +35,14 @@ namespace
 		return result;
 	}
 
-	TestAssetCache::AssetCacheData MakeCache(
+	TestAssetCache::CacheData MakeCache(
 		const std::string& fileIdValue,
 		const std::string& sourcePath,
 		std::time_t timestamp)
 	{
-		TestAssetCache::AssetCacheData result;
+		TestAssetCache::CacheData result;
 		const FileId fileId = MakeFileId(fileIdValue);
-		TestAssetCache::AssetCacheData::Entry entry;
+		TestAssetCache::CacheEntry entry;
 		entry.m_fileId = fileId;
 		entry.m_sourcePath = sourcePath;
 		entry.m_assetImportTime = timestamp;
@@ -55,7 +56,7 @@ namespace
 		const auto source = MakeCache(fileId.ToString(), "/workspace/Content/Test.mat", 42);
 		const std::string payload = TestAssetCache::SerializeAssetCachePayload(source);
 
-		TestAssetCache::AssetCacheData loaded;
+		TestAssetCache::CacheData loaded;
 		std::string diagnostic;
 		Require(
 			TestAssetCache::TryDeserializeAssetCachePayload(payload, loaded, diagnostic),
@@ -69,10 +70,10 @@ namespace
 
 	void TestEmptyPayloadRoundTrip()
 	{
-		const TestAssetCache::AssetCacheData source;
+		const TestAssetCache::CacheData source;
 		const std::string payload = TestAssetCache::SerializeAssetCachePayload(source);
 
-		TestAssetCache::AssetCacheData loaded;
+		TestAssetCache::CacheData loaded;
 		std::string diagnostic;
 		Require(
 			TestAssetCache::TryDeserializeAssetCachePayload(payload, loaded, diagnostic),
@@ -111,7 +112,7 @@ namespace
 			"      assetImportTime: 9\n"
 			"      sourcePath: '/workspace/Content/Test.mat'\n";
 
-		TestAssetCache::AssetCacheData destination;
+		TestAssetCache::CacheData destination;
 		std::string diagnostic;
 		Require(
 			!TestAssetCache::TryDeserializeAssetCachePayload(payload, destination, diagnostic),

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -102,6 +102,18 @@ add_executable(WorkspaceContextTests
     WorkspaceContextTests.cpp
 )
 
+add_executable(WorkspaceCacheContractTests
+    WorkspaceCacheContractTests.cpp
+)
+
+add_executable(AssetCacheContractTests
+    AssetCacheContractTests.cpp
+)
+
+add_executable(ShaderCacheArtifactTests
+    ShaderCacheArtifactTests.cpp
+)
+
 add_executable(AssetMountDiscoveryTests
     AssetMountDiscoveryTests.cpp
     ${SAILOR_RUNTIME_DIR}/AssetRegistry/AssetMountDiscovery.cpp
@@ -135,6 +147,9 @@ target_compile_features(WorkspaceModuleMissingEntryFixture PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleContractTests PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleRuntimeTests PRIVATE cxx_std_20)
 target_compile_features(WorkspaceContextTests PRIVATE cxx_std_20)
+target_compile_features(WorkspaceCacheContractTests PRIVATE cxx_std_20)
+target_compile_features(AssetCacheContractTests PRIVATE cxx_std_20)
+target_compile_features(ShaderCacheArtifactTests PRIVATE cxx_std_20)
 target_compile_features(AssetMountDiscoveryTests PRIVATE cxx_std_20)
 target_compile_definitions(WorkspaceModuleFixture PRIVATE
     SAILOR_WORKSPACE_MODULE
@@ -161,6 +176,9 @@ target_link_libraries(WorkspaceModuleContractTests PRIVATE
 )
 target_link_libraries(WorkspaceModuleRuntimeTests PRIVATE Sailor::Runtime)
 target_link_libraries(WorkspaceContextTests PRIVATE Sailor::Runtime)
+target_link_libraries(WorkspaceCacheContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(AssetCacheContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(ShaderCacheArtifactTests PRIVATE Sailor::Runtime)
 add_dependencies(WorkspaceModuleRuntimeTests
     WorkspaceModuleFixture
     WorkspaceModuleIncompatibleFixture
@@ -187,6 +205,9 @@ if(WIN32)
     sailor_stage_workspace_test_runtime(WorkspaceModuleContractTests)
     sailor_stage_workspace_test_runtime(WorkspaceModuleRuntimeTests)
     sailor_stage_workspace_test_runtime(WorkspaceContextTests)
+    sailor_stage_workspace_test_runtime(WorkspaceCacheContractTests)
+    sailor_stage_workspace_test_runtime(AssetCacheContractTests)
+    sailor_stage_workspace_test_runtime(ShaderCacheArtifactTests)
 endif()
 if(WIN32)
     target_compile_features(RemoteViewportWindowsTransportTests PRIVATE cxx_std_20)
@@ -223,6 +244,15 @@ target_include_directories(WorkspaceModuleRuntimeTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(WorkspaceContextTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(WorkspaceCacheContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(AssetCacheContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(ShaderCacheArtifactTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(AssetMountDiscoveryTests PRIVATE
@@ -284,6 +314,21 @@ add_test(
 )
 
 add_test(
+    NAME WorkspaceCacheContractTests
+    COMMAND WorkspaceCacheContractTests
+)
+
+add_test(
+    NAME AssetCacheContractTests
+    COMMAND AssetCacheContractTests
+)
+
+add_test(
+    NAME ShaderCacheArtifactTests
+    COMMAND ShaderCacheArtifactTests
+)
+
+add_test(
     NAME AssetMountDiscoveryTests
     COMMAND AssetMountDiscoveryTests "${PROJECT_SOURCE_DIR}/Content"
 )
@@ -312,6 +357,9 @@ add_test(
 )
 set_tests_properties(
     WorkspaceContextTests
+    WorkspaceCacheContractTests
+    AssetCacheContractTests
+    ShaderCacheArtifactTests
     AssetMountDiscoveryTests
     WorkspaceModuleContractTests
     WorkspaceModuleRuntimeTests
@@ -321,6 +369,9 @@ set_tests_properties(
 if(WIN32 AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.22" AND VCPKG_INSTALLED_DIR AND VCPKG_TARGET_TRIPLET)
     set_tests_properties(
         WorkspaceContextTests
+        WorkspaceCacheContractTests
+        AssetCacheContractTests
+        ShaderCacheArtifactTests
         WorkspaceModuleContractTests
         WorkspaceModuleRuntimeTests
         PROPERTIES ENVIRONMENT_MODIFICATION

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -1,0 +1,784 @@
+#include "AssetRegistry/Shader/ShaderCache.h"
+#include "AssetRegistry/Shader/ShaderCompiler.h"
+#include "Workspace/WorkspaceCacheContract.h"
+
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <yaml-cpp/yaml.h>
+
+namespace
+{
+	using namespace Sailor;
+
+	class TempDirectory final
+	{
+	public:
+		TempDirectory()
+		{
+			static uint64_t nextId = 0;
+			const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+			m_path = std::filesystem::temp_directory_path() /
+				("sailor-shader-cache-artifacts-" + std::to_string(timestamp) + "-" +
+					std::to_string(nextId++));
+			std::filesystem::create_directories(m_path);
+		}
+
+		~TempDirectory() noexcept
+		{
+			std::error_code error;
+			std::filesystem::remove_all(m_path, error);
+		}
+
+		std::filesystem::path Path(const char* filename) const
+		{
+			return m_path / filename;
+		}
+
+	private:
+		std::filesystem::path m_path;
+	};
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	FileId MakeFileId(const std::string& value)
+	{
+		FileId result;
+		result.Deserialize(YAML::Node(value));
+		return result;
+	}
+
+	TVector<uint32_t> Words(uint32_t seed)
+	{
+		TVector<uint32_t> result;
+		result.Add(0x07230203);
+		result.Add(seed);
+		result.Add(seed ^ 0x5a5a5a5a);
+		result.Add(seed + 17);
+		return result;
+	}
+
+	std::string ReadText(const std::filesystem::path& path)
+	{
+		std::ifstream input(path, std::ios::binary);
+		Require(input.is_open(), "test text should be readable: " + path.generic_string());
+		return std::string(
+			std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>());
+	}
+
+	size_t CountRegularFiles(const std::filesystem::path& root)
+	{
+		std::error_code error;
+		size_t result = 0;
+		for (std::filesystem::recursive_directory_iterator iterator(root, error), end;
+			!error && iterator != end;
+			iterator.increment(error))
+		{
+			if (iterator->is_regular_file(error))
+			{
+				++result;
+			}
+		}
+		Require(!error, "test storage should be enumerable: " + error.message());
+		return result;
+	}
+
+	void RequireWords(
+		const TVector<uint32_t>& actual,
+		const TVector<uint32_t>& expected,
+		const std::string& context)
+	{
+		Require(actual.Num() == expected.Num(), context + " should preserve the word count");
+		for (size_t index = 0; index < expected.Num(); ++index)
+		{
+			Require(actual[index] == expected[index], context + " should preserve every word");
+		}
+	}
+
+	void WriteWords(const std::filesystem::path& path, const TVector<uint32_t>& words)
+	{
+		std::string diagnostic;
+		Require(
+			Workspace::AtomicReplaceWorkspaceCacheBinary(
+				path,
+				words.Num() == 0 ? nullptr : &words[0],
+				static_cast<uint64_t>(words.Num()) * sizeof(uint32_t),
+				diagnostic),
+			"test SPIR-V should be writable: " + diagnostic);
+	}
+
+	bool PublishComplete(
+		ShaderCache& cache,
+		const FileId& uid,
+		uint32_t permutation,
+		uint32_t seed)
+	{
+		const TVector<uint32_t> empty;
+		return cache.CacheSpirv_ThreadSafe(
+			uid,
+			permutation,
+			Words(seed),
+			Words(seed + 1),
+			empty,
+			Words(seed + 2),
+			Words(seed + 3),
+			empty);
+	}
+
+	template<size_t Size>
+	void WriteArtifact(const std::filesystem::path& path, const std::array<uint8_t, Size>& bytes)
+	{
+		std::string diagnostic;
+		Require(
+			Workspace::AtomicReplaceWorkspaceCacheBinary(
+				path,
+				bytes.data(),
+				bytes.size(),
+				diagnostic),
+			"test artifact should be writable: " + diagnostic);
+	}
+
+	TVector<uint32_t> SentinelOutput()
+	{
+		TVector<uint32_t> result;
+		result.Add(0xdecafbad);
+		result.Add(0xabcdef01);
+		return result;
+	}
+
+	void RequireSentinel(const TVector<uint32_t>& output, const std::string& context)
+	{
+		Require(
+			output.Num() == 2 && output[0] == 0xdecafbad && output[1] == 0xabcdef01,
+			context + " must not partially replace caller output");
+	}
+
+	void TestArtifactRoundTrip()
+	{
+		TempDirectory directory;
+		const std::array<uint32_t, 4> words =
+		{
+			0x07230203,
+			0x00010000,
+			0x000d000b,
+			0x00000001
+		};
+		const auto metadata = ShaderCache::DescribeArtifact(words.data(), sizeof(words));
+		const auto path = directory.Path("valid.spirv");
+		std::string writeDiagnostic;
+		Require(
+			Workspace::AtomicReplaceWorkspaceCacheBinary(
+				path,
+				words.data(),
+				sizeof(words),
+				writeDiagnostic),
+			"valid SPIR-V fixture should be writable: " + writeDiagnostic);
+
+		TVector<uint32_t> output = SentinelOutput();
+		std::string diagnostic;
+		Require(
+			ShaderCache::ReadSpirvArtifact(path, metadata, output, diagnostic),
+			"matching artifact should load: " + diagnostic);
+		Require(output.Num() == words.size(), "matching artifact should preserve its word count");
+		for (size_t index = 0; index < words.size(); ++index)
+		{
+			Require(output[index] == words[index], "matching artifact should preserve every word");
+		}
+	}
+
+	void TestTruncatedArtifactIsRejected()
+	{
+		TempDirectory directory;
+		const std::array<uint8_t, 8> complete = { 3, 2, 35, 7, 0, 0, 1, 0 };
+		const std::array<uint8_t, 4> truncated = { 3, 2, 35, 7 };
+		const auto metadata = ShaderCache::DescribeArtifact(complete.data(), complete.size());
+		const auto path = directory.Path("truncated.spirv");
+		WriteArtifact(path, truncated);
+
+		TVector<uint32_t> output = SentinelOutput();
+		std::string diagnostic;
+		Require(
+			!ShaderCache::ReadSpirvArtifact(path, metadata, output, diagnostic),
+			"truncated artifact should be rejected");
+		Require(diagnostic.find("byte length") != std::string::npos,
+			"truncated artifact diagnostic should identify its byte length");
+		RequireSentinel(output, "truncated artifact failure");
+	}
+
+	void TestMisalignedArtifactIsRejected()
+	{
+		TempDirectory directory;
+		const std::array<uint8_t, 3> bytes = { 3, 2, 35 };
+		const auto metadata = ShaderCache::DescribeArtifact(bytes.data(), bytes.size());
+		const auto path = directory.Path("misaligned.spirv");
+		WriteArtifact(path, bytes);
+
+		TVector<uint32_t> output = SentinelOutput();
+		std::string diagnostic;
+		Require(
+			!ShaderCache::ReadSpirvArtifact(path, metadata, output, diagnostic),
+			"misaligned artifact should be rejected");
+		Require(diagnostic.find("aligned") != std::string::npos,
+			"misaligned artifact diagnostic should identify word alignment");
+		RequireSentinel(output, "misaligned artifact failure");
+	}
+
+	void TestChecksumMismatchIsRejected()
+	{
+		TempDirectory directory;
+		const std::array<uint8_t, 8> bytes = { 3, 2, 35, 7, 0, 0, 1, 0 };
+		auto metadata = ShaderCache::DescribeArtifact(bytes.data(), bytes.size());
+		metadata.m_checksum ^= 1;
+		const auto path = directory.Path("checksum.spirv");
+		WriteArtifact(path, bytes);
+
+		TVector<uint32_t> output = SentinelOutput();
+		std::string diagnostic;
+		Require(
+			!ShaderCache::ReadSpirvArtifact(path, metadata, output, diagnostic),
+			"checksum mismatch should be rejected");
+		Require(diagnostic.find("checksum mismatch") != std::string::npos,
+			"checksum mismatch diagnostic should identify checksum validation");
+		RequireSentinel(output, "checksum mismatch failure");
+	}
+
+	void TestOwnedArtifactContainment()
+	{
+		TempDirectory directory;
+		const std::filesystem::path cacheRoot = directory.Path("Cache");
+		const std::filesystem::path ownedDirectory = cacheRoot / "CompiledShaders";
+		std::filesystem::create_directories(ownedDirectory);
+
+		std::string diagnostic;
+		Require(
+			ShaderCache::ValidateOwnedArtifactPath(
+				cacheRoot,
+				ownedDirectory,
+				ownedDirectory / "direct.spirv",
+				diagnostic),
+			"a direct child artifact should be accepted: " + diagnostic);
+
+		diagnostic.clear();
+		Require(
+			!ShaderCache::ValidateOwnedArtifactPath(
+				cacheRoot,
+				ownedDirectory,
+				ownedDirectory / ".." / "neighbor.txt",
+				diagnostic),
+			"a traversal artifact path should be rejected");
+		Require(diagnostic.find("outside owned directory") != std::string::npos,
+			"traversal diagnostic should identify the owned-directory boundary");
+
+		const std::filesystem::path symlinkTarget = cacheRoot / "Neighbor";
+		std::filesystem::create_directories(symlinkTarget);
+		std::filesystem::remove_all(ownedDirectory);
+		std::error_code symlinkError;
+		std::filesystem::create_directory_symlink(symlinkTarget, ownedDirectory, symlinkError);
+		if (!symlinkError)
+		{
+			diagnostic.clear();
+			Require(
+				!ShaderCache::ValidateOwnedArtifactPath(
+					cacheRoot,
+					ownedDirectory,
+					ownedDirectory / "linked.spirv",
+					diagnostic),
+				"a symlinked owned directory should be rejected");
+			Require(diagnostic.find("symlinked") != std::string::npos,
+				"symlink diagnostic should identify the unsafe directory");
+		}
+	}
+
+	void TestDebugArtifactsAreRequired()
+	{
+		TempDirectory directory;
+		ShaderCache cache;
+		ShaderCacheTestAccess::Configure(cache, directory.Path("Cache"));
+		const FileId uid = MakeFileId("{SHADER-CACHE-DEBUG-REQUIRED}");
+
+		Require(PublishComplete(cache, uid, 0, 10),
+			"a complete regular/debug generation should publish");
+		cache.SaveCache(true);
+		Require(!cache.IsDirty(), "a complete generation should save before payload validation");
+
+		const std::string payload = ShaderCacheTestAccess::PayloadWithMissingDebug(cache);
+		std::string diagnostic;
+		Require(!ShaderCacheTestAccess::ParsePayload(payload, diagnostic),
+			"payload v2 must reject entries without required debug artifacts");
+		Require(diagnostic.find("debug artifacts") != std::string::npos,
+			"missing-debug diagnostic should identify the required debug artifact set");
+
+		diagnostic.clear();
+		Require(
+			!ShaderCacheTestAccess::ParsePayload(
+				ShaderCacheTestAccess::PayloadWithMismatchedDebugTopology(cache),
+				diagnostic),
+			"payload v2 must reject different regular/debug shader stage topology");
+		Require(diagnostic.find("identical shader stages") != std::string::npos,
+			"topology diagnostic should identify the regular/debug stage mismatch");
+
+		const TVector<uint32_t> empty;
+		Require(
+			!cache.CacheSpirv_ThreadSafe(
+				uid,
+				1,
+				Words(11),
+				Words(12),
+				empty,
+				empty,
+				empty,
+				Words(13)),
+			"live publication must reject different regular/debug shader stage topology");
+	}
+
+	void TestFailedGenerationPreservesDurableGeneration()
+	{
+		TempDirectory directory;
+		const std::filesystem::path cacheRoot = directory.Path("Cache");
+		ShaderCache cache;
+		ShaderCacheTestAccess::Configure(cache, cacheRoot);
+		const FileId uid = MakeFileId("{SHADER-CACHE-GENERATION-TRANSACTION}");
+
+		Require(PublishComplete(cache, uid, 3, 20), "the initial generation should publish");
+		cache.SaveCache(true);
+		Require(!cache.IsDirty(), "the initial generation should be durable");
+
+		const std::string durableGeneration = ShaderCacheTestAccess::GetGeneration(cache, uid, 3);
+		Require(!durableGeneration.empty(), "the durable generation should expose test metadata");
+		const auto durableVertexPath = ShaderCacheTestAccess::GetArtifactPath(
+			cache,
+			uid,
+			3,
+			ShaderCache::VertexShaderTag,
+			false);
+		const auto cachePath = ShaderCacheTestAccess::GetCachePath(cache);
+		const std::string durableEnvelope = ReadText(cachePath);
+		const size_t durableFileCount = CountRegularFiles(cacheRoot);
+
+		const TVector<uint32_t> empty;
+		std::string diagnostic;
+		Require(
+			!ShaderCacheTestAccess::PublishWithArtifactFailure(
+				cache,
+				uid,
+				3,
+				Words(30),
+				Words(31),
+				empty,
+				Words(32),
+				Words(33),
+				empty,
+				1,
+				diagnostic),
+			"an injected artifact replacement failure should reject the new generation");
+		Require(!diagnostic.empty(), "failed generation publication should report a diagnostic");
+
+		Require(ShaderCacheTestAccess::GetGeneration(cache, uid, 3) == durableGeneration,
+			"failed generation publication must retain the durable generation metadata");
+		Require(ReadText(cachePath) == durableEnvelope,
+			"failed generation publication must not replace the durable envelope");
+		Require(std::filesystem::exists(durableVertexPath),
+			"failed generation publication must preserve durable artifacts");
+
+		TVector<uint32_t> loadedVertex;
+		TVector<uint32_t> loadedFragment;
+		TVector<uint32_t> loadedCompute;
+		Require(cache.GetSpirvCode(uid, 3, loadedVertex, loadedFragment, loadedCompute),
+			"the durable generation should remain readable after failed publication");
+		RequireWords(loadedVertex, Words(20), "the durable generation");
+
+		Require(CountRegularFiles(cacheRoot) > durableFileCount,
+			"the failure seam should leave an uncommitted immutable artifact for cleanup");
+		cache.ClearExpired();
+		Require(CountRegularFiles(cacheRoot) == durableFileCount,
+			"cleanup should sweep only the uncommitted generation");
+		Require(std::filesystem::exists(durableVertexPath),
+			"cleanup must whitelist artifacts from the committed metadata snapshot");
+		Require(ReadText(cachePath) == durableEnvelope,
+			"orphan cleanup should not rewrite unchanged committed metadata");
+	}
+
+	void TestRemoveCommitsBeforeGarbageCollection()
+	{
+		TempDirectory directory;
+		ShaderCache cache;
+		ShaderCacheTestAccess::Configure(cache, directory.Path("Cache"));
+		const FileId uid = MakeFileId("{SHADER-CACHE-REMOVE-TRANSACTION}");
+
+		Require(PublishComplete(cache, uid, 0, 40), "the removable generation should publish");
+		cache.SaveCache(true);
+		const auto artifactPath = ShaderCacheTestAccess::GetArtifactPath(
+			cache,
+			uid,
+			0,
+			ShaderCache::VertexShaderTag,
+			false);
+		const auto cachePath = ShaderCacheTestAccess::GetCachePath(cache);
+		const std::string durableEnvelope = ReadText(cachePath);
+
+		std::string diagnostic;
+		Require(!ShaderCacheTestAccess::RemoveWithEnvelopeFailure(cache, uid, diagnostic),
+			"remove should fail when its metadata replacement is injected to fail");
+		Require(cache.Contains(uid), "failed remove must retain its live metadata");
+		Require(std::filesystem::exists(artifactPath),
+			"failed remove must not garbage-collect a durably referenced artifact");
+		Require(ReadText(cachePath) == durableEnvelope,
+			"failed remove must preserve the durable envelope");
+
+		ShaderCacheTestAccess::FailNextArtifactSweep(cache);
+		cache.Remove(uid);
+		Require(!cache.Contains(uid) && cache.IsDirty(),
+			"remove should retain retryable dirty state when post-commit cleanup fails");
+		Require(std::filesystem::exists(artifactPath),
+			"failed post-commit cleanup should retain the now-unreferenced artifact");
+		cache.SaveCache();
+		Require(!cache.IsDirty() && !std::filesystem::exists(artifactPath),
+			"save retry should garbage-collect removed artifacts after the committed metadata");
+	}
+
+	void TestSameSizeChecksumCorruptionAndClearExpiredTransaction()
+	{
+		TempDirectory directory;
+		ShaderCache cache;
+		ShaderCacheTestAccess::Configure(cache, directory.Path("Cache"));
+		const FileId uid = MakeFileId("{SHADER-CACHE-CHECKSUM-EXPIRY}");
+
+		Require(PublishComplete(cache, uid, 1, 50), "the corruption fixture should publish");
+		cache.SaveCache(true);
+		const auto artifactPath = ShaderCacheTestAccess::GetArtifactPath(
+			cache,
+			uid,
+			1,
+			ShaderCache::VertexShaderTag,
+			false);
+		const auto cachePath = ShaderCacheTestAccess::GetCachePath(cache);
+		const std::string durableEnvelope = ReadText(cachePath);
+		const std::string corruptGeneration = ShaderCacheTestAccess::GetGeneration(cache, uid, 1);
+
+		WriteWords(artifactPath, Words(500));
+		Require(cache.IsExpired(uid, 1),
+			"same-size checksum corruption must expire a cached generation");
+
+		std::string diagnostic;
+		Require(!ShaderCacheTestAccess::ClearExpiredWithEnvelopeFailure(cache, diagnostic),
+			"expired cleanup should fail when metadata replacement is injected to fail");
+		Require(cache.Contains(uid), "failed expired cleanup must retain its live entry");
+		Require(std::filesystem::exists(artifactPath),
+			"failed expired cleanup must preserve artifacts until metadata commits");
+		Require(ReadText(cachePath) == durableEnvelope,
+			"failed expired cleanup must preserve the durable envelope");
+
+		Require(PublishComplete(cache, uid, 1, 55),
+			"same-size corruption should self-heal through replacement compilation");
+		const std::string healedGeneration = ShaderCacheTestAccess::GetGeneration(cache, uid, 1);
+		const auto healedArtifactPath = ShaderCacheTestAccess::GetArtifactPath(
+			cache,
+			uid,
+			1,
+			ShaderCache::VertexShaderTag,
+			false);
+		Require(healedGeneration != corruptGeneration && std::filesystem::exists(artifactPath),
+			"self-heal should stage a new generation while retaining the durable corrupt generation");
+		cache.SaveCache();
+		Require(!cache.IsDirty() && ReadText(cachePath) != durableEnvelope,
+			"self-heal should commit its replacement generation");
+		Require(!std::filesystem::exists(artifactPath) && std::filesystem::exists(healedArtifactPath),
+			"self-heal should sweep the corrupt generation only after replacement commit");
+		TVector<uint32_t> vertex;
+		TVector<uint32_t> fragment;
+		TVector<uint32_t> compute;
+		Require(cache.GetSpirvCode(uid, 1, vertex, fragment, compute),
+			"self-healed bytecode should be readable");
+		RequireWords(vertex, Words(55), "self-healed bytecode");
+
+		const FileId cleanupUid = MakeFileId("{SHADER-CACHE-EXPIRED-CLEANUP}");
+		Require(PublishComplete(cache, cleanupUid, 0, 60),
+			"the successful expiry-cleanup fixture should publish");
+		cache.SaveCache();
+		const auto cleanupArtifactPath = ShaderCacheTestAccess::GetArtifactPath(
+			cache,
+			cleanupUid,
+			0,
+			ShaderCache::VertexShaderTag,
+			false);
+		WriteWords(cleanupArtifactPath, Words(600));
+		ShaderCacheTestAccess::FailNextArtifactSweep(cache);
+		cache.ClearExpired();
+		Require(!cache.Contains(cleanupUid) && cache.IsDirty() &&
+			std::filesystem::exists(cleanupArtifactPath),
+			"expired cleanup should remain dirty when post-commit artifact sweeping fails");
+		cache.SaveCache();
+		Require(!cache.IsDirty() && !std::filesystem::exists(cleanupArtifactPath),
+			"save retry should finish expired artifact sweeping after metadata commit");
+		Require(cache.Contains(uid), "successful expired cleanup should retain unrelated healed metadata");
+	}
+
+	void TestIoFailureQuarantineIsReadOnlyAndSessionOnly()
+	{
+		TempDirectory directory;
+		const std::filesystem::path cacheRoot = directory.Path("Cache");
+		ShaderCache cache;
+		ShaderCacheTestAccess::Configure(cache, cacheRoot);
+		const FileId durableUid = MakeFileId("{SHADER-CACHE-QUARANTINE-DURABLE}");
+		const FileId sessionUid = MakeFileId("{SHADER-CACHE-QUARANTINE-SESSION}");
+
+		Require(PublishComplete(cache, durableUid, 0, 60), "the durable quarantine fixture should publish");
+		cache.SaveCache(true);
+		const auto cachePath = ShaderCacheTestAccess::GetCachePath(cache);
+		const auto backupPath = cacheRoot / "ShaderCache.backup.yaml";
+		std::filesystem::rename(cachePath, backupPath);
+		std::filesystem::create_directory(cachePath);
+		const std::string durableEnvelope = ReadText(backupPath);
+		const size_t preservedFileCount = CountRegularFiles(cacheRoot);
+
+		cache.LoadCache();
+		Require(
+			cache.GetLastLoadResult().m_status == Workspace::EWorkspaceCacheLoadStatus::IoFailure,
+			"an unreadable non-file cache target should enter I/O quarantine");
+		Require(ShaderCacheTestAccess::IsQuarantined(cache),
+			"I/O failure should make shader cache storage read-only");
+		Require(!cache.Contains(durableUid),
+			"quarantine should withhold disk-backed metadata that could not be fully reloaded");
+
+		Require(PublishComplete(cache, sessionUid, 2, 70),
+			"compilation should remain available as memory-only data during quarantine");
+		Require(cache.Contains(sessionUid), "memory-only quarantine publication should be visible in-session");
+		Require(!cache.IsDirty(), "memory-only quarantine publication should not claim pending disk state");
+		Require(CountRegularFiles(cacheRoot) == preservedFileCount,
+			"memory-only quarantine publication must not create disk artifacts");
+
+		TVector<uint32_t> vertex;
+		TVector<uint32_t> fragment;
+		TVector<uint32_t> compute;
+		Require(cache.GetSpirvCode(sessionUid, 2, vertex, fragment, compute, false),
+			"regular memory-only SPIR-V should be readable during quarantine");
+		RequireWords(vertex, Words(70), "regular quarantine vertex SPIR-V");
+		RequireWords(fragment, Words(71), "regular quarantine fragment SPIR-V");
+		Require(compute.IsEmpty(), "regular quarantine graphics SPIR-V should not invent compute data");
+		Require(cache.GetSpirvCode(sessionUid, 2, vertex, fragment, compute, true),
+			"debug memory-only SPIR-V should be readable during quarantine");
+		RequireWords(vertex, Words(72), "debug quarantine vertex SPIR-V");
+		RequireWords(fragment, Words(73), "debug quarantine fragment SPIR-V");
+		Require(compute.IsEmpty(), "debug quarantine graphics SPIR-V should not invent compute data");
+
+		std::filesystem::remove(cachePath);
+		cache.LoadCache();
+		Require(
+			cache.GetLastLoadResult().m_status == Workspace::EWorkspaceCacheLoadStatus::Missing,
+			"a missing retry target should not escape an existing I/O quarantine");
+		Require(ShaderCacheTestAccess::IsQuarantined(cache),
+			"quarantine should persist until a fully successful reload or ClearAll");
+		Require(cache.Contains(sessionUid),
+			"a failed reload should retain session-only quarantine artifacts");
+
+		cache.SaveCache(true);
+		cache.ClearExpired();
+		Require(ReadText(backupPath) == durableEnvelope,
+			"save and cleanup must preserve unreadable durable storage during quarantine");
+		Require(CountRegularFiles(cacheRoot) == preservedFileCount,
+			"save and cleanup must not mutate artifact storage during quarantine");
+
+		std::string writeDiagnostic;
+		Require(
+			Workspace::AtomicReplaceWorkspaceCacheText(
+				cachePath,
+				"not: [valid",
+				writeDiagnostic),
+			"a corrupt retry fixture should be writable: " + writeDiagnostic);
+		cache.LoadCache();
+		Require(
+			cache.GetLastLoadResult().m_status == Workspace::EWorkspaceCacheLoadStatus::Corrupt,
+			"a corrupt retry target should not escape an existing I/O quarantine");
+		Require(ShaderCacheTestAccess::IsQuarantined(cache) && cache.Contains(sessionUid),
+			"corrupt reload should retain read-only session state");
+		cache.SaveCache(true);
+		cache.ClearExpired();
+		Require(ReadText(cachePath) == "not: [valid",
+			"quarantine must not replace a corrupt retry target without ClearAll");
+
+		std::filesystem::remove(cachePath);
+		std::filesystem::rename(backupPath, cachePath);
+		cache.LoadCache();
+		Require(cache.GetLastLoadResult().IsLoaded(),
+			"a later full successful reload should leave I/O quarantine");
+		Require(!ShaderCacheTestAccess::IsQuarantined(cache),
+			"successful full reload should restore persistent cache access");
+		Require(cache.Contains(durableUid), "successful reload should restore durable metadata");
+		Require(!cache.Contains(sessionUid),
+			"successful reload should discard session-only quarantine artifacts");
+	}
+
+	void TestRuntimeArtifactIoFailureEntersReadOnlyQuarantine()
+	{
+		TempDirectory directory;
+		const std::filesystem::path cacheRoot = directory.Path("Cache");
+		ShaderCache cache;
+		ShaderCacheTestAccess::Configure(cache, cacheRoot);
+		const FileId uid = MakeFileId("{SHADER-CACHE-RUNTIME-IO-QUARANTINE}");
+
+		Require(PublishComplete(cache, uid, 0, 80), "the runtime I/O fixture should publish");
+		cache.SaveCache(true);
+		const auto cachePath = ShaderCacheTestAccess::GetCachePath(cache);
+		const auto artifactPath = ShaderCacheTestAccess::GetArtifactPath(
+			cache,
+			uid,
+			0,
+			ShaderCache::VertexShaderTag,
+			false);
+		const std::string durableEnvelope = ReadText(cachePath);
+		const std::string durableArtifact = ReadText(artifactPath);
+		const std::string durableGeneration = ShaderCacheTestAccess::GetGeneration(cache, uid, 0);
+		const size_t durableFileCount = CountRegularFiles(cacheRoot);
+
+		ShaderCacheTestAccess::SetArtifactReadIoFailure(cache, true);
+		Require(cache.IsExpired(uid, 0),
+			"runtime artifact I/O failure should force a session recompile");
+		ShaderCacheTestAccess::SetArtifactReadIoFailure(cache, false);
+		Require(ShaderCacheTestAccess::IsQuarantined(cache),
+			"runtime artifact I/O failure should enter read-only storage quarantine");
+		Require(
+			cache.GetLastLoadResult().m_status == Workspace::EWorkspaceCacheLoadStatus::IoFailure,
+			"runtime artifact I/O failure should publish an I/O load status");
+		Require(!cache.Contains(uid),
+			"runtime I/O quarantine should withhold the unread disk-backed entry");
+
+		Require(PublishComplete(cache, uid, 0, 90),
+			"runtime I/O quarantine should accept session-only recompiled bytecode");
+		Require(cache.Contains(uid) && !cache.IsDirty(),
+			"session-only recompile should be visible without pending disk mutation");
+		TVector<uint32_t> vertex;
+		TVector<uint32_t> fragment;
+		TVector<uint32_t> compute;
+		Require(cache.GetSpirvCode(uid, 0, vertex, fragment, compute),
+			"session-only recompiled bytecode should be readable");
+		RequireWords(vertex, Words(90), "runtime quarantine bytecode");
+
+		cache.SaveCache(true);
+		cache.ClearExpired();
+		Require(ReadText(cachePath) == durableEnvelope,
+			"runtime I/O quarantine must preserve durable metadata byte-for-byte");
+		Require(ReadText(artifactPath) == durableArtifact,
+			"runtime I/O quarantine must preserve durable artifacts byte-for-byte");
+		Require(CountRegularFiles(cacheRoot) == durableFileCount,
+			"runtime I/O quarantine must not create or collect disk files");
+
+		cache.LoadCache();
+		Require(cache.GetLastLoadResult().IsLoaded() &&
+			!ShaderCacheTestAccess::IsQuarantined(cache),
+			"a full successful reload should leave runtime I/O quarantine");
+		Require(ShaderCacheTestAccess::GetGeneration(cache, uid, 0) == durableGeneration,
+			"successful reload should restore the durable immutable generation");
+		Require(cache.GetSpirvCode(uid, 0, vertex, fragment, compute),
+			"restored durable bytecode should be readable");
+		RequireWords(vertex, Words(80), "restored durable bytecode");
+	}
+
+	void TestShaderCompilerFailureLifecycle()
+	{
+		const bool allSucceeded[] = { true, true, true };
+		const bool oneFailed[] = { true, false, true };
+		Require(
+			ShaderCompilerTestAccess::AggregateCompileResults(allSucceeded, std::size(allSucceeded)),
+			"compile aggregation should retain all-success results");
+		Require(
+			!ShaderCompilerTestAccess::AggregateCompileResults(oneFailed, std::size(oneFailed)),
+			"one failed permutation should fail the aggregate compile result");
+		Require(ShaderCompilerTestAccess::ShouldRetryCacheSave(0, true),
+			"current bytecode with dirty metadata should select the save-only retry branch");
+		Require(!ShaderCompilerTestAccess::ShouldRetryCacheSave(0, false) &&
+			!ShaderCompilerTestAccess::ShouldRetryCacheSave(1, true),
+			"save-only retry should require both no compilation work and dirty metadata");
+		Require(ShaderCompilerTestAccess::ExerciseFailedLoadEvictionAndRetry(),
+			"failed shader load eviction should permit a second permutation load attempt");
+		Require(ShaderCompilerTestAccess::ExercisePromiseGarbageCollection(),
+			"promise garbage collection should retain newly pending permutations");
+
+		TempDirectory directory;
+		const std::filesystem::path cacheRoot = directory.Path("Cache");
+		ShaderCache cache;
+		ShaderCacheTestAccess::Configure(cache, cacheRoot);
+		const FileId uid = MakeFileId("{SHADER-CACHE-SAVE-RETRY}");
+
+		Require(PublishComplete(cache, uid, 0, 100), "the first save generation should publish");
+		cache.SaveCache(true);
+		const auto cachePath = ShaderCacheTestAccess::GetCachePath(cache);
+		const auto oldArtifactPath = ShaderCacheTestAccess::GetArtifactPath(
+			cache,
+			uid,
+			0,
+			ShaderCache::VertexShaderTag,
+			false);
+		const std::string oldGeneration = ShaderCacheTestAccess::GetGeneration(cache, uid, 0);
+		const std::string oldEnvelope = ReadText(cachePath);
+
+		Require(PublishComplete(cache, uid, 0, 110), "the replacement generation should publish");
+		const auto newArtifactPath = ShaderCacheTestAccess::GetArtifactPath(
+			cache,
+			uid,
+			0,
+			ShaderCache::VertexShaderTag,
+			false);
+		const std::string newGeneration = ShaderCacheTestAccess::GetGeneration(cache, uid, 0);
+		Require(oldGeneration != newGeneration && cache.IsDirty(),
+			"replacement publication should remain dirty under a new immutable generation");
+		Require(std::filesystem::exists(oldArtifactPath) && std::filesystem::exists(newArtifactPath),
+			"both generations should exist before metadata commit");
+
+		ShaderCacheTestAccess::FailNextSaveBeforeReplace(cache);
+		Require(
+			!ShaderCompilerTestAccess::SaveCacheAndCombineResult(cache, true),
+			"compile orchestration should report the first injected save failure");
+		Require(cache.IsDirty() && ReadText(cachePath) == oldEnvelope,
+			"failed save should retain dirty state and the old durable envelope");
+		Require(std::filesystem::exists(oldArtifactPath) && std::filesystem::exists(newArtifactPath),
+			"failed save must retain both the durable and uncommitted generations");
+
+		Require(ShaderCompilerTestAccess::SaveCacheAndCombineResult(cache, true),
+			"a no-recompile save retry should publish the already compiled generation");
+		Require(!cache.IsDirty() && ReadText(cachePath) != oldEnvelope,
+			"successful retry should commit the new envelope and clear dirty state");
+		Require(!std::filesystem::exists(oldArtifactPath) && std::filesystem::exists(newArtifactPath),
+			"post-commit GC should remove only the old immutable generation");
+		Require(!ShaderCompilerTestAccess::SaveCacheAndCombineResult(cache, false),
+			"a compile failure should remain failed even when cache persistence succeeds");
+	}
+}
+
+int main()
+{
+	try
+	{
+		TestArtifactRoundTrip();
+		TestTruncatedArtifactIsRejected();
+		TestMisalignedArtifactIsRejected();
+		TestChecksumMismatchIsRejected();
+		TestOwnedArtifactContainment();
+		TestDebugArtifactsAreRequired();
+		TestFailedGenerationPreservesDurableGeneration();
+		TestRemoveCommitsBeforeGarbageCollection();
+		TestSameSizeChecksumCorruptionAndClearExpiredTransaction();
+		TestIoFailureQuarantineIsReadOnlyAndSessionOnly();
+		TestRuntimeArtifactIoFailureEntersReadOnlyQuarantine();
+		TestShaderCompilerFailureLifecycle();
+		std::cout << "Shader cache artifact tests passed.\n";
+		return 0;
+	}
+	catch (const std::exception& exception)
+	{
+		std::cerr << "Shader cache artifact tests failed: " << exception.what() << '\n';
+		return 1;
+	}
+}

--- a/Tests/WorkspaceCacheContractTests.cpp
+++ b/Tests/WorkspaceCacheContractTests.cpp
@@ -1,0 +1,406 @@
+#include "Workspace/WorkspaceCacheContract.h"
+#include "Workspace/WorkspaceContext.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <yaml-cpp/yaml.h>
+
+using namespace Sailor::Workspace;
+
+namespace
+{
+	class TempDirectory final
+	{
+	public:
+		explicit TempDirectory(const char* label)
+		{
+			static uint64_t nextId = 0;
+			const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+			m_path = std::filesystem::temp_directory_path() /
+				("sailor-workspace-cache-" + std::string(label) + "-" +
+					std::to_string(timestamp) + "-" + std::to_string(nextId++));
+			std::filesystem::create_directories(m_path);
+		}
+
+		~TempDirectory() noexcept
+		{
+			std::error_code removeError;
+			std::filesystem::remove_all(m_path, removeError);
+		}
+
+		const std::filesystem::path& Get() const noexcept { return m_path; }
+		std::filesystem::path Path(const std::filesystem::path& relative) const
+		{
+			return m_path / relative;
+		}
+
+	private:
+		std::filesystem::path m_path;
+	};
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	std::string ReadText(const std::filesystem::path& path)
+	{
+		std::ifstream input(path, std::ios::binary);
+		Require(input.is_open(), "test file should be readable: " + path.generic_string());
+		return std::string(
+			std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>());
+	}
+
+	std::string GenericUtf8String(const std::filesystem::path& path)
+	{
+		const std::u8string utf8 = path.generic_u8string();
+		return std::string(
+			reinterpret_cast<const char*>(utf8.data()),
+			utf8.size());
+	}
+
+#if defined(_WIN32)
+	void FoldAsciiCaseForWindows(std::string& value)
+	{
+		for (char& character : value)
+		{
+			if (character >= 'A' && character <= 'Z')
+			{
+				character = static_cast<char>(character + ('a' - 'A'));
+			}
+		}
+	}
+#endif
+
+	std::string Serialize(
+		const WorkspaceCacheIdentity& identity,
+		const std::string& payload = "entries:\n  - value: 42\n")
+	{
+		std::string envelope;
+		std::string diagnostic;
+		Require(
+			SerializeWorkspaceCacheEnvelope(identity, payload, envelope, diagnostic),
+			"test envelope should serialize: " + diagnostic);
+		return envelope;
+	}
+
+	WorkspaceCacheIdentity Identity(
+		const std::string& workspaceId = "workspace-a",
+		const std::filesystem::path& root = "/workspace/a")
+	{
+		return MakeWorkspaceCacheIdentity(
+			"asset-cache",
+			"asset-cache-v1",
+			1,
+			workspaceId,
+			root);
+	}
+
+	void RequireStatus(
+		const WorkspaceCacheLoadResult& result,
+		EWorkspaceCacheLoadStatus expected,
+		const std::string& message)
+	{
+		Require(result.m_status == expected, message + ": " + result.m_diagnostic);
+		if (expected != EWorkspaceCacheLoadStatus::Loaded)
+		{
+			Require(result.m_payload.empty(), message + " must not expose an unvalidated payload");
+		}
+	}
+
+	void TestIdentityContract()
+	{
+		TempDirectory first("legacy-a");
+		TempDirectory second("legacy-b");
+		const std::string explicitId = ResolveWorkspaceCacheIdentity("manifest-id", first.Get());
+		Require(explicitId == "manifest-id", "manifest workspace id should be preserved exactly");
+
+		const std::string firstLegacy = ResolveWorkspaceCacheIdentity({}, first.Get());
+		const std::string repeatedLegacy = ResolveWorkspaceCacheIdentity({}, first.Get() / ".");
+		const std::string secondLegacy = ResolveWorkspaceCacheIdentity({}, second.Get());
+		Require(firstLegacy.starts_with("legacy-root:"), "legacy identity should be explicitly namespaced");
+		Require(firstLegacy == repeatedLegacy, "legacy identity should be stable for equivalent canonical roots");
+		Require(firstLegacy != secondLegacy, "different legacy workspace roots must have different identities");
+
+		const std::filesystem::path unicodeRoot = first.Get() /
+			std::filesystem::path(u8"Legacy-РАБОЧАЯ-AZ");
+		std::filesystem::create_directories(unicodeRoot);
+		std::string expectedUnicodeRoot = GenericUtf8String(
+			std::filesystem::weakly_canonical(unicodeRoot));
+#if defined(_WIN32)
+		FoldAsciiCaseForWindows(expectedUnicodeRoot);
+#endif
+		const std::string unicodeLegacy = ResolveWorkspaceCacheIdentity({}, unicodeRoot);
+		Require(unicodeLegacy == "legacy-root:" + expectedUnicodeRoot,
+			"legacy identity must use canonical UTF-8 and the shared ASCII-only Windows case fold");
+		Require(unicodeLegacy.find(GenericUtf8String(std::filesystem::path(u8"РАБОЧАЯ"))) != std::string::npos,
+			"legacy identity must preserve non-ASCII UTF-8 bytes exactly");
+
+		const WorkspaceCacheIdentity identity = Identity();
+		Require(identity.m_cacheVersion == WorkspaceCacheFormatVersion,
+			"identity should use the current common cache format");
+		Require(identity.m_payloadVersion == 1, "identity should preserve the payload version");
+		Require(identity.m_cacheKind == "asset-cache", "identity should preserve the cache kind");
+		Require(identity.m_producerIdentity == "asset-cache-v1",
+			"identity should preserve the producer identity");
+		Require(identity.m_workspaceId == "workspace-a", "identity should preserve manifest workspace id");
+		Require(!identity.m_engineVersion.empty() && identity.m_engineVersion != "unknown",
+			"engine version should come from the CMake project version");
+		Require(identity.m_buildIdentity.find("config=") != std::string::npos,
+			"build identity should contain the CMake build configuration");
+		Require(identity.m_buildIdentity.find("sailor-workspace-abi-") != std::string::npos,
+			"build identity should contain the existing workspace ABI tag");
+
+		const WorkspaceContextResolveResult contextResult = ResolveWorkspaceContext(first.Get());
+		Require(contextResult.IsSuccess(), "legacy context should resolve for cache identity test");
+		const WorkspaceCacheIdentity contextIdentity = MakeWorkspaceCacheIdentity(
+			"asset-cache",
+			"asset-cache-v1",
+			1,
+			contextResult.m_context);
+		Require(contextIdentity.m_workspaceId == firstLegacy,
+			"context overload should derive the same deterministic legacy identity");
+	}
+
+	void TestRoundTripAndFileStatuses()
+	{
+		TempDirectory directory("roundtrip");
+		const WorkspaceCacheIdentity identity = Identity();
+		const std::string payload = "entries:\n  - value: 42\n  - value: cache payload\n";
+		const std::string envelope = Serialize(identity, payload);
+
+		const WorkspaceCacheLoadResult parsed = ParseWorkspaceCacheEnvelope(
+			envelope,
+			identity,
+			"memory fixture");
+		RequireStatus(parsed, EWorkspaceCacheLoadStatus::Loaded, "matching envelope should load");
+		Require(parsed.IsLoaded(), "loaded result helper should report success");
+		Require(parsed.m_payload == payload, "payload should round-trip exactly as an envelope scalar");
+
+		const std::filesystem::path cachePath = directory.Path("Nested/AssetCache.yaml");
+		WorkspaceCacheLoadResult missing = LoadWorkspaceCacheEnvelope(cachePath, identity);
+		RequireStatus(missing, EWorkspaceCacheLoadStatus::Missing, "missing cache should be distinguished");
+
+		std::string diagnostic;
+		Require(
+			AtomicReplaceWorkspaceCacheText(cachePath, envelope, diagnostic),
+			"cache envelope should be atomically writable: " + diagnostic);
+		const WorkspaceCacheLoadResult loaded = LoadWorkspaceCacheEnvelope(cachePath, identity);
+		RequireStatus(loaded, EWorkspaceCacheLoadStatus::Loaded, "written cache should load");
+		Require(loaded.m_payload == payload, "file load should return the complete payload");
+
+		const WorkspaceCacheLoadResult ioFailure = LoadWorkspaceCacheEnvelope(directory.Get(), identity);
+		RequireStatus(ioFailure, EWorkspaceCacheLoadStatus::IoFailure,
+			"directory in place of a cache file should be an I/O failure");
+	}
+
+	void TestIdentityMismatches()
+	{
+		const WorkspaceCacheIdentity expected = Identity();
+		struct Mismatch
+		{
+			const char* m_field;
+			std::string WorkspaceCacheIdentity::* m_value;
+			const char* m_actual;
+		};
+		const Mismatch mismatches[] =
+		{
+			{ "cacheKind", &WorkspaceCacheIdentity::m_cacheKind, "shader-cache" },
+			{ "producerIdentity", &WorkspaceCacheIdentity::m_producerIdentity, "asset-cache-v2" },
+			{ "workspaceId", &WorkspaceCacheIdentity::m_workspaceId, "workspace-b" },
+			{ "engineVersion", &WorkspaceCacheIdentity::m_engineVersion, "other-engine" },
+			{ "buildIdentity", &WorkspaceCacheIdentity::m_buildIdentity, "other-build" }
+		};
+
+		for (const Mismatch& mismatch : mismatches)
+		{
+			WorkspaceCacheIdentity actual = expected;
+			actual.*(mismatch.m_value) = mismatch.m_actual;
+			const WorkspaceCacheLoadResult result = ParseWorkspaceCacheEnvelope(
+				Serialize(actual),
+				expected,
+				"identity fixture");
+			RequireStatus(result, EWorkspaceCacheLoadStatus::StaleIdentity,
+				std::string(mismatch.m_field) + " mismatch should be stale");
+			Require(result.m_diagnostic.find(mismatch.m_field) != std::string::npos,
+				"stale diagnostic should name field " + std::string(mismatch.m_field));
+			Require(result.m_diagnostic.find(mismatch.m_actual) != std::string::npos,
+				"stale diagnostic should contain actual value for " + std::string(mismatch.m_field));
+			Require(result.m_diagnostic.find(expected.*(mismatch.m_value)) != std::string::npos,
+				"stale diagnostic should contain expected value for " + std::string(mismatch.m_field));
+		}
+	}
+
+	void TestUnsupportedVersions()
+	{
+		const WorkspaceCacheIdentity expected = Identity();
+
+		WorkspaceCacheLoadResult raw = ParseWorkspaceCacheEnvelope(
+			"assets: []\n",
+			expected,
+			"raw legacy cache");
+		RequireStatus(raw, EWorkspaceCacheLoadStatus::UnsupportedVersion,
+			"raw legacy payload should be unsupported rather than accepted");
+		Require(raw.m_diagnostic.find("expected '1'") != std::string::npos &&
+			raw.m_diagnostic.find("actual 'missing'") != std::string::npos,
+			"missing format diagnostic should contain expected and actual version");
+
+		YAML::Node futureDocument = YAML::Load(Serialize(expected));
+		futureDocument["cacheVersion"] = WorkspaceCacheFormatVersion + 1;
+		WorkspaceCacheLoadResult future = ParseWorkspaceCacheEnvelope(
+			YAML::Dump(futureDocument),
+			expected,
+			"future cache");
+		RequireStatus(future, EWorkspaceCacheLoadStatus::UnsupportedVersion,
+			"future cache format should be unsupported");
+		Require(future.m_diagnostic.find("actual '2'") != std::string::npos,
+			"future format diagnostic should contain actual version");
+
+		YAML::Node payloadDocument = YAML::Load(Serialize(expected));
+		payloadDocument["payloadVersion"] = 2;
+		WorkspaceCacheLoadResult payloadVersion = ParseWorkspaceCacheEnvelope(
+			YAML::Dump(payloadDocument),
+			expected,
+			"future payload");
+		RequireStatus(payloadVersion, EWorkspaceCacheLoadStatus::UnsupportedVersion,
+			"future payload version should be unsupported");
+		Require(payloadVersion.m_diagnostic.find("payloadVersion") != std::string::npos &&
+			payloadVersion.m_diagnostic.find("expected '1'") != std::string::npos &&
+			payloadVersion.m_diagnostic.find("actual '2'") != std::string::npos,
+			"payload version diagnostic should contain field, expected, and actual values");
+
+		payloadDocument.remove("payloadVersion");
+		WorkspaceCacheLoadResult missingPayloadVersion = ParseWorkspaceCacheEnvelope(
+			YAML::Dump(payloadDocument),
+			expected,
+			"legacy envelope");
+		RequireStatus(missingPayloadVersion, EWorkspaceCacheLoadStatus::UnsupportedVersion,
+			"missing payload version should be unsupported");
+	}
+
+	void TestCorruptEnvelopes()
+	{
+		const WorkspaceCacheIdentity expected = Identity();
+		WorkspaceCacheLoadResult malformed = ParseWorkspaceCacheEnvelope(
+			"cacheVersion: [1\n",
+			expected,
+			"truncated cache");
+		RequireStatus(malformed, EWorkspaceCacheLoadStatus::Corrupt,
+			"truncated YAML should be corrupt");
+
+		const std::string valid = Serialize(expected);
+		WorkspaceCacheLoadResult duplicate = ParseWorkspaceCacheEnvelope(
+			"cacheVersion: 1\n" + valid,
+			expected,
+			"duplicate cache");
+		RequireStatus(duplicate, EWorkspaceCacheLoadStatus::Corrupt,
+			"duplicate envelope field should be corrupt");
+
+		YAML::Node unknownDocument = YAML::Load(valid);
+		unknownDocument["unexpected"] = "value";
+		WorkspaceCacheLoadResult unknown = ParseWorkspaceCacheEnvelope(
+			YAML::Dump(unknownDocument),
+			expected,
+			"unknown-field cache");
+		RequireStatus(unknown, EWorkspaceCacheLoadStatus::Corrupt,
+			"unknown field in current envelope should be corrupt");
+
+		YAML::Node missingDocument = YAML::Load(valid);
+		missingDocument.remove("workspaceId");
+		WorkspaceCacheLoadResult missing = ParseWorkspaceCacheEnvelope(
+			YAML::Dump(missingDocument),
+			expected,
+			"missing-field cache");
+		RequireStatus(missing, EWorkspaceCacheLoadStatus::Corrupt,
+			"missing identity field should be corrupt");
+
+		YAML::Node invalidPayload = YAML::Load(valid);
+		invalidPayload["payload"] = YAML::Node(YAML::NodeType::Map);
+		invalidPayload["payload"]["entry"] = 1;
+		WorkspaceCacheLoadResult nonScalarPayload = ParseWorkspaceCacheEnvelope(
+			YAML::Dump(invalidPayload),
+			expected,
+			"invalid-payload cache");
+		RequireStatus(nonScalarPayload, EWorkspaceCacheLoadStatus::Corrupt,
+			"non-scalar envelope payload should be corrupt");
+	}
+
+	void TestAtomicReplacementAndInjectedFailure()
+	{
+		TempDirectory directory("atomic");
+		const std::filesystem::path target = directory.Path("Cache/AssetCache.yaml");
+		std::string diagnostic;
+		Require(
+			AtomicReplaceWorkspaceCacheText(target, "old-cache", diagnostic),
+			"initial atomic write should succeed: " + diagnostic);
+		Require(ReadText(target) == "old-cache", "initial cache contents should be complete");
+
+		Require(
+			!AtomicReplaceWorkspaceCacheText(
+				target,
+				"new-cache-that-must-not-appear",
+				diagnostic,
+				EWorkspaceCacheAtomicWriteFailurePoint::BeforeReplace),
+			"injected pre-replace failure should be reported");
+		Require(diagnostic.find("Injected") != std::string::npos,
+			"injected failure should have a targeted diagnostic");
+		Require(ReadText(target) == "old-cache",
+			"failed replacement must preserve the complete previous target");
+
+		for (const auto& entry : std::filesystem::directory_iterator(target.parent_path()))
+		{
+			Require(entry.path().extension() != ".tmp",
+				"failed replacement must clean its same-directory temporary file");
+		}
+
+		const uint8_t binary[] = { 0, 1, 2, 3, 4, 5, 255 };
+		Require(
+			AtomicReplaceWorkspaceCacheBinary(target, binary, sizeof(binary), diagnostic),
+			"binary atomic replacement should succeed: " + diagnostic);
+		std::ifstream input(target, std::ios::binary);
+		const std::string actual{
+			std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>() };
+		Require(actual.size() == sizeof(binary), "binary atomic replacement should preserve exact size");
+		Require(std::equal(actual.begin(), actual.end(), reinterpret_cast<const char*>(binary)),
+			"binary atomic replacement should preserve exact bytes");
+
+		for (const auto& entry : std::filesystem::directory_iterator(target.parent_path()))
+		{
+			Require(entry.path().extension() != ".tmp",
+				"successful replacement must not leave a temporary file");
+		}
+	}
+}
+
+int main()
+{
+	try
+	{
+		TestIdentityContract();
+		TestRoundTripAndFileStatuses();
+		TestIdentityMismatches();
+		TestUnsupportedVersions();
+		TestCorruptEnvelopes();
+		TestAtomicReplacementAndInjectedFailure();
+		std::cout << "[PASS] Workspace cache contract" << std::endl;
+		return 0;
+	}
+	catch (const std::exception& e)
+	{
+		std::cerr << "[FAIL] Workspace cache contract: " << e.what() << std::endl;
+		return 1;
+	}
+}

--- a/Tests/WorkspaceContextTests.cpp
+++ b/Tests/WorkspaceContextTests.cpp
@@ -75,7 +75,7 @@ namespace
 	{
 		std::error_code pathError;
 		const std::filesystem::path canonical = std::filesystem::canonical(path, pathError);
-		Require(!pathError, "test path should be canonicalizable: " + path.generic_string());
+		Require(!pathError, "test path should be canonicalizable: " + PathToUtf8(path));
 		return canonical;
 	}
 
@@ -92,7 +92,7 @@ namespace
 			std::error_code createError;
 			std::filesystem::create_directories(engineRoot / "Content", createError);
 			Require(!createError,
-				"test engine Content should be creatable: " + engineRoot.generic_string());
+				"test engine Content should be creatable: " + PathToUtf8(engineRoot));
 		}
 
 		YAML::Node manifest;
@@ -114,14 +114,14 @@ namespace
 
 		std::ofstream output(path);
 		output << manifest;
-		Require(output.good(), "test manifest should be writable: " + path.generic_string());
+		Require(output.good(), "test manifest should be writable: " + PathToUtf8(path));
 	}
 
 	void WriteText(const std::filesystem::path& path, const std::string& value)
 	{
 		std::ofstream output(path);
 		output << value;
-		Require(output.good(), "test file should be writable: " + path.generic_string());
+		Require(output.good(), "test file should be writable: " + PathToUtf8(path));
 	}
 
 	void TestLegacyFallbackAndRecovery()
@@ -156,12 +156,7 @@ namespace
 		const std::string utf8Component =
 			reinterpret_cast<const char*>(u8"Physical-РАБОЧАЯ-AZ");
 		const std::filesystem::path component = PathFromUtf8(utf8Component);
-		const std::u8string roundTrip = component.generic_u8string();
-		const std::string roundTripUtf8(
-			reinterpret_cast<const char*>(roundTrip.data()),
-			roundTrip.size());
-
-		Require(roundTripUtf8 == utf8Component,
+		Require(PathToUtf8(component) == utf8Component,
 			"command-line workspace paths must round-trip through the native path type as UTF-8");
 
 		TempDirectory fixture("utf8-command-line");
@@ -273,7 +268,7 @@ namespace
 		Require(!relativeError, "relative engine fixture should be computable");
 
 		ManifestSpec spec;
-		spec.m_enginePath = relativeEngine.generic_string();
+		spec.m_enginePath = PathToUtf8(relativeEngine);
 		spec.m_createEngineContent = false;
 		WriteManifest(workspace.Path("workspace.sailor"), spec);
 
@@ -293,7 +288,7 @@ namespace
 		std::filesystem::create_directories(engine.Path("Content"));
 
 		ManifestSpec spec;
-		spec.m_enginePath = engine.Get().generic_string();
+		spec.m_enginePath = PathToUtf8(engine.Get());
 		spec.m_createEngineContent = false;
 		WriteManifest(workspace.Path("workspace.sailor"), spec);
 
@@ -311,7 +306,7 @@ namespace
 		TempDirectory workspace("missing-engine-content-workspace");
 		TempDirectory engine("missing-engine-content-root");
 		ManifestSpec spec;
-		spec.m_enginePath = engine.Get().generic_string();
+		spec.m_enginePath = PathToUtf8(engine.Get());
 		spec.m_createEngineContent = false;
 		WriteManifest(workspace.Path("workspace.sailor"), spec);
 
@@ -334,7 +329,7 @@ namespace
 		TempDirectory workspace("missing-installed-engine-content-workspace");
 		TempDirectory engine("missing-installed-engine-content-root");
 		ManifestSpec spec;
-		spec.m_enginePath = engine.Get().generic_string();
+		spec.m_enginePath = PathToUtf8(engine.Get());
 		spec.m_engineReferenceKind = "installed";
 		spec.m_createEngineContent = false;
 		WriteManifest(workspace.Path("workspace.sailor"), spec);

--- a/Tests/WorkspaceContextTests.cpp
+++ b/Tests/WorkspaceContextTests.cpp
@@ -1,4 +1,5 @@
 #include "Workspace/WorkspaceContext.h"
+#include "Workspace/WorkspacePathEncoding.h"
 
 #include <chrono>
 #include <cstdlib>
@@ -148,6 +149,29 @@ namespace
 			"legacy resolution should recreate default Content");
 		Require(std::filesystem::is_directory(workspace.Path("Cache")),
 			"legacy resolution should recreate default Cache");
+	}
+
+	void TestUtf8CommandLinePathConversion()
+	{
+		const std::string utf8Component =
+			reinterpret_cast<const char*>(u8"Physical-РАБОЧАЯ-AZ");
+		const std::filesystem::path component = PathFromUtf8(utf8Component);
+		const std::u8string roundTrip = component.generic_u8string();
+		const std::string roundTripUtf8(
+			reinterpret_cast<const char*>(roundTrip.data()),
+			roundTrip.size());
+
+		Require(roundTripUtf8 == utf8Component,
+			"command-line workspace paths must round-trip through the native path type as UTF-8");
+
+		TempDirectory fixture("utf8-command-line");
+		const std::filesystem::path workspaceRoot = fixture.Path(component);
+		std::filesystem::create_directories(workspaceRoot);
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspaceRoot);
+		Require(result.IsSuccess(),
+			"a workspace root decoded from UTF-8 command-line bytes should resolve: " + result.m_message);
+		Require(result.m_context.GetRoot() == Canonical(workspaceRoot),
+			"UTF-8 command-line path conversion must preserve the physical workspace root");
 	}
 
 	void TestManifestPathsWithSpaces()
@@ -538,6 +562,7 @@ int main()
 	try
 	{
 		TestLegacyFallbackAndRecovery();
+		TestUtf8CommandLinePathConversion();
 		TestManifestPathsWithSpaces();
 		TestManifestDefaultRecovery();
 		TestManifestDefaultsMissingEngineReferenceKindToSource();


### PR DESCRIPTION
Fixes #102

Parent hardening issue: #82  
Parent epic: #72

## What changed

- added a strict native workspace-cache envelope with workspace, engine, build/ABI, producer, and payload identities plus distinct missing/stale/corrupt/version/I/O outcomes
- made AssetCache and ShaderCache validate into candidate state, preserve storage after uncertain I/O failures, and replace cache metadata and shader artifacts atomically
- versioned immutable shader artifact generations with regular/debug topology, byte-size, and checksum validation, transactional metadata publication, and post-commit garbage collection
- added the native workspace identity bridge and explicit UTF-8 argument marshalling so the editor and runtime derive the same identity for non-ASCII workspace paths
- replaced the raw editor type cache with a strict managed envelope and generation-gated live catalog publication
- fixed immediate-result Task sync-block ownership exposed by the shader lifecycle tests
- documented cache compatibility, ownership, invalidation, quarantine, and atomicity guarantees

## Why

The previous cache files carried no workspace or producer identity and were decoded directly into live state. Reusing, corrupting, or interrupting a cache write could therefore leak stale data across workspaces or expose a partial cache. The new contracts reject incompatible data before publication and scope all recovery to producer-owned cache paths.

## User and developer impact

Workspace A cache data is never accepted for workspace B. Old, future, malformed, stale, and unreadable caches now produce distinct diagnostics. Interrupted writes retain a complete old or new file, while uncertain I/O failures preserve the existing storage for explicit recovery.

## Validation

- `ctest --test-dir build-mac-vcpkg -C Debug -R '^(WorkspaceCacheContractTests|AssetCacheContractTests|ShaderCacheArtifactTests|WorkspaceContextTests)$' --output-on-failure` — 4/4 passed
- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --configuration Release --no-restore --nologo` — 307/307 passed
- `$HOME/.dotnet/dotnet build Editor/SailorEditor.csproj -f net10.0-maccatalyst --configuration Debug --no-restore --nologo` — 0 errors (359 existing warnings)
- `python3 run_world_tests.py --config Release --engine Binaries/SailorEngine-Release --direct-exec` — 6/6 passed
- full macOS CTest — 14/15 passed; only the pre-existing unrelated `RemoteViewportMacTransportTests` case `ConcreteMacLoopbackProviderRecordsRendererOwnedSourceMetadata` failed and reproduces independently
- production `SAILOR_BUILD_TESTS=OFF` SailorLib build passed; symbol audit confirmed no ShaderCache/ShaderCompiler test-access exports
- CMake install passed and installed the new public workspace headers
- `git diff --check` passed

Windows MSVC and clang-cl builds, CTest, install, and generated-project integration are intentionally gated by this PR's exact-head CI.
