### PR TITLE
[Workspace] Define generated state and manifest compatibility

### DIFF
--- a/Docs/WorkspaceLogic.md
+++ b/Docs/WorkspaceLogic.md
@@ -19,10 +19,12 @@ Generated/
 Cache/
   Build/
 Binaries/
+.sailor/
+  GeneratedProjectState.yaml
 .gitignore
 ```
 
-`Generated/CMakeLists.txt` is created with the workspace and is not overwritten when the workspace is opened or saved. It can be edited when the project needs custom CMake behavior, while game code remains under `Source/`. Build-system intermediates belong in `Cache/Build`; configuration-specific logic modules are written to `Binaries/<CONFIG>/`.
+`Generated/CMakeLists.txt` and the sample files under `Source/` are created with the workspace and are not overwritten when the workspace is opened or saved. They become user-owned immediately after creation and can be edited when the project needs custom build or game behavior. Build-system intermediates belong in `Cache/Build`; configuration-specific logic modules are written to `Binaries/<CONFIG>/`.
 
 `WorkspaceTypes.h` is the explicit list of reflected game types exported by the module. Add each new reflected component to its `TWorkspaceTypeList`. `WorkspaceModule.cpp` defines the versioned module API and metadata entry points from that same list; both files are created once and remain user-editable.
 
@@ -42,6 +44,35 @@ The default manifest values are:
 | `logicModuleName` | `SailorGame` | Generated shared-library target and module name. |
 
 All workspace-owned paths in the table are safe relative paths. Rooted, drive-relative, traversal, and physical symlink or junction escapes are rejected. `enginePath` is intentionally different: it is an external engine source or install reference and may resolve outside the workspace.
+
+## Generated State And Manifest Compatibility
+
+`.sailor/GeneratedProjectState.yaml` is source-controlled generator metadata, not a cache and not an ownership claim over generated CMake or source files. New Workspace writes it last, after every user-owned project artifact has been created successfully. Open and Save only assess it: they never create, backfill, regenerate, or replace the sidecar, `Generated/CMakeLists.txt`, or any file under `Source/`.
+
+The current generated-state contract is:
+
+```yaml
+generatorSchemaVersion: 1
+creationInputs:
+  manifestVersion: 1
+  enginePath: ../Sailor
+  engineReferenceKind: source
+  contentPath: Content
+  sourcePath: Source
+  generatedProjectPath: Generated
+  cachePath: Cache
+  buildPath: Cache/Build
+  logicOutputPath: Binaries
+  logicModuleName: SailorGame
+```
+
+Only manifest values that affect the originally generated project are recorded. `name`, `workspaceId`, absolute workspace roots, timestamps, hashes, file content, and mtimes are deliberately excluded. Values are normalized with the manifest rules and compared in the fixed order shown above. A matching sidecar is `Current`; a missing sidecar is `Untracked`; an input mismatch is `Stale`; and an unreadable, unsafe, malformed, or unsupported sidecar is `Invalid`. All four outcomes are advisory for an otherwise valid workspace. Non-current outcomes remain visible in editor status with deterministic guidance, but do not enter activation `Repair` and do not authorize an implicit write. Reconciliation is manual: restore the recorded manifest inputs, or update the user-owned project and sidecar deliberately after verifying them; creating a clean workspace with the current editor is the safe fallback when no regeneration command exists.
+
+The only supported workspace manifest format is currently `manifestVersion: 1`. A present manifest must contain exactly one positive scalar version field. Missing, zero, future, duplicate, and non-scalar versions are rejected before typed fields are deserialized, directories are recovered, recents or the active session are changed, or the manifest is written. The runtime's legacy mode applies only when no manifest file exists; a present versionless manifest is not legacy input.
+
+Version 1 retains additive compatibility: unknown fields are ignored, and `engineReferenceKind`, `buildPath`, `logicOutputPath`, and `logicModuleName` receive their documented defaults only when their fields are absent. An explicitly null or empty value is invalid in both the editor and runtime. Opening a valid older v1 document may therefore normalize the in-memory model, but it does not rewrite the file.
+
+A future migration must be editor-only and sequential (`vN -> vN+1` for every intermediate version). Each step must validate its source, create a unique backup without overwriting an earlier backup, transform entirely in memory, validate the target, write and durably flush a same-directory temporary file, and atomically replace the manifest. Any failure leaves the source manifest and generated project files intact. The runtime never migrates. Manifest migration never regenerates CMake/source files or updates generated state implicitly; changed creation inputs intentionally leave the sidecar stale until the user reconciles them.
 
 ## Source Engine Reference
 

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -29,6 +29,7 @@
     <Compile Include="ProjectContentFolderIdsTests.cs" />
     <Compile Include="ProjectContentPathPolicyTests.cs" />
     <Compile Include="WorkspaceManifestTests.cs" />
+    <Compile Include="WorkspaceGeneratedProjectStateTests.cs" />
     <Compile Include="WorkspaceLifecycleTests.cs" />
     <Compile Include="WorkspaceActivationTests.cs" />
     <Compile Include="WorkspaceStateResetTests.cs" />
@@ -68,6 +69,8 @@
     <Compile Include="..\Editor\Content\ProjectContentFolderIds.cs" Link="Content\ProjectContentFolderIds.cs" />
     <Compile Include="..\Editor\Content\ProjectContentPathPolicy.cs" Link="Content\ProjectContentPathPolicy.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceManifest.cs" Link="Workspace\WorkspaceManifest.cs" />
+    <Compile Include="..\Editor\Workspace\WorkspaceYamlVersionProbe.cs" Link="Workspace\WorkspaceYamlVersionProbe.cs" />
+    <Compile Include="..\Editor\Workspace\WorkspaceGeneratedProjectState.cs" Link="Workspace\WorkspaceGeneratedProjectState.cs" />
     <Compile Include="..\Editor\Workspace\WorkspacePathPolicy.cs" Link="Workspace\WorkspacePathPolicy.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceLifecycle.cs" Link="Workspace\WorkspaceLifecycle.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceActivationContracts.cs" Link="Workspace\WorkspaceActivationContracts.cs" />

--- a/Editor.Tests/WorkspaceGeneratedProjectStateTests.cs
+++ b/Editor.Tests/WorkspaceGeneratedProjectStateTests.cs
@@ -1,0 +1,355 @@
+using System.Diagnostics;
+using SailorEditor.Workspace;
+
+namespace SailorEditor.Editor.Tests;
+
+public sealed class WorkspaceGeneratedProjectStateTests
+{
+    [Fact]
+    public void Serialize_EmitsDeterministicSchemaAndOnlyGeneratorInputs()
+    {
+        var manifest = WorkspaceManifest.CreateDefault(
+            "Workspace Name Must Not Be Recorded",
+            "../Engine Root/",
+            "workspace-id-must-not-be-recorded",
+            WorkspaceEngineReferenceKinds.Installed) with
+        {
+            ContentPath = "Game/Content",
+            SourcePath = "Game/Source",
+            GeneratedProjectPath = "Project Files",
+            CachePath = "Intermediate/Cache",
+            BuildPath = "Intermediate/Build",
+            LogicOutputPath = "Output/Binaries",
+            LogicModuleName = "GameLogic"
+        };
+        var service = new WorkspaceGeneratedProjectStateService();
+
+        var first = service.Serialize(manifest);
+        var second = service.Serialize(manifest);
+
+        Assert.Equal(first, second);
+        Assert.DoesNotContain('\r', first);
+        Assert.EndsWith("\n", first, StringComparison.Ordinal);
+        Assert.Contains("generatorSchemaVersion: 1", first, StringComparison.Ordinal);
+        Assert.Contains("creationInputs:", first, StringComparison.Ordinal);
+        AssertFieldOrder(first, [
+            "manifestVersion:",
+            "enginePath:",
+            "engineReferenceKind:",
+            "contentPath:",
+            "sourcePath:",
+            "generatedProjectPath:",
+            "cachePath:",
+            "buildPath:",
+            "logicOutputPath:",
+            "logicModuleName:"
+        ]);
+        Assert.DoesNotContain("Workspace Name Must Not Be Recorded", first, StringComparison.Ordinal);
+        Assert.DoesNotContain("workspace-id-must-not-be-recorded", first, StringComparison.Ordinal);
+        Assert.DoesNotContain("workspaceRoot", first, StringComparison.Ordinal);
+        Assert.DoesNotContain("timestamp", first, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("hash", first, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task AssessAsync_ReturnsCurrentForEquivalentNormalizedInputs()
+    {
+        using var workspace = TempWorkspace.Create();
+        var service = new WorkspaceGeneratedProjectStateService();
+        var recorded = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor/", "workspace-id") with
+        {
+            SourcePath = "./Game\\Source\\",
+            BuildPath = ".\\Cache\\Build\\"
+        };
+        WriteState(workspace.Root, service.Serialize(recorded));
+        var equivalent = recorded with
+        {
+            EnginePath = "../Sailor",
+            SourcePath = "Game/Source",
+            BuildPath = "Cache/Build"
+        };
+
+        var assessment = await service.AssessAsync(workspace.Root, equivalent);
+
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Current, assessment.Status);
+        Assert.False(assessment.RequiresAttention);
+        Assert.Empty(assessment.Guidance);
+        Assert.Empty(assessment.Mismatches);
+    }
+
+    [Fact]
+    public async Task AssessAsync_ReportsAllStaleInputsInContractOrderWithoutWriting()
+    {
+        using var workspace = TempWorkspace.Create();
+        var service = new WorkspaceGeneratedProjectStateService();
+        var recorded = WorkspaceManifest.CreateDefault("Recorded", "../RecordedEngine", "recorded-id");
+        var statePath = WriteState(workspace.Root, service.Serialize(recorded));
+        var before = await File.ReadAllBytesAsync(statePath);
+        var current = recorded with
+        {
+            ManifestVersion = 2,
+            EnginePath = "../CurrentEngine",
+            EngineReferenceKind = WorkspaceEngineReferenceKinds.Installed,
+            ContentPath = "Game/Content",
+            SourcePath = "Game/Source",
+            GeneratedProjectPath = "Project Files",
+            CachePath = "Intermediate/Cache",
+            BuildPath = "Intermediate/Build",
+            LogicOutputPath = "Output/Binaries",
+            LogicModuleName = "CurrentLogic"
+        };
+
+        var assessment = await service.AssessAsync(workspace.Root, current);
+
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Stale, assessment.Status);
+        Assert.True(assessment.RequiresAttention);
+        Assert.Equal(
+            [
+                "manifestVersion",
+                "enginePath",
+                "engineReferenceKind",
+                "contentPath",
+                "sourcePath",
+                "generatedProjectPath",
+                "cachePath",
+                "buildPath",
+                "logicOutputPath",
+                "logicModuleName"
+            ],
+            assessment.Mismatches.Select(x => x.Field));
+        Assert.Contains("Restore the recorded manifest values", assessment.Guidance, StringComparison.Ordinal);
+        Assert.Contains("Sailor did not regenerate or overwrite anything", assessment.Guidance, StringComparison.Ordinal);
+        Assert.Equal(before, await File.ReadAllBytesAsync(statePath));
+    }
+
+    [Fact]
+    public async Task AssessAsync_PositiveNonCurrentRecordedManifestVersionIsStaleRatherThanInvalid()
+    {
+        using var workspace = TempWorkspace.Create();
+        var service = new WorkspaceGeneratedProjectStateService();
+        var current = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id");
+        var yaml = service.Serialize(current).Replace(
+            "manifestVersion: 1",
+            "manifestVersion: 2",
+            StringComparison.Ordinal);
+        WriteState(workspace.Root, yaml);
+
+        var assessment = await service.AssessAsync(workspace.Root, current);
+
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Stale, assessment.Status);
+        var mismatch = Assert.Single(assessment.Mismatches);
+        Assert.Equal("manifestVersion", mismatch.Field);
+        Assert.Equal("2", mismatch.RecordedValue);
+        Assert.Equal("1", mismatch.CurrentValue);
+    }
+
+    [Fact]
+    public async Task AssessAsync_MissingStateIsUntrackedAndIsNotBackfilled()
+    {
+        using var workspace = TempWorkspace.Create();
+        var service = new WorkspaceGeneratedProjectStateService();
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id");
+
+        var assessment = await service.AssessAsync(workspace.Root, manifest);
+
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Untracked, assessment.Status);
+        Assert.True(assessment.RequiresAttention);
+        Assert.Empty(assessment.Mismatches);
+        Assert.Contains("add the state file to source control", assessment.Guidance, StringComparison.Ordinal);
+        Assert.Contains("did not backfill or overwrite anything", assessment.Guidance, StringComparison.Ordinal);
+        Assert.False(Directory.Exists(workspace.Directory(WorkspaceGeneratedProjectStateService.StateDirectoryName)));
+    }
+
+    [Theory]
+    [InlineData("generatorSchemaVersion: 0\ncreationInputs: {}\n", "greater than zero")]
+    [InlineData("generatorSchemaVersion: 2\ncreationInputs: [future, schema]\n", "Unsupported generated project state version '2'")]
+    [InlineData("creationInputs: {}\n", "generatorSchemaVersion")]
+    public async Task AssessAsync_InvalidSchemaIsAdvisoryAndDoesNotRewrite(
+        string yaml,
+        string expectedGuidance)
+    {
+        using var workspace = TempWorkspace.Create();
+        var service = new WorkspaceGeneratedProjectStateService();
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id");
+        var statePath = WriteState(workspace.Root, yaml);
+        var before = await File.ReadAllBytesAsync(statePath);
+
+        var assessment = await service.AssessAsync(workspace.Root, manifest);
+
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Invalid, assessment.Status);
+        Assert.True(assessment.RequiresAttention);
+        Assert.Empty(assessment.Mismatches);
+        Assert.Contains(expectedGuidance, assessment.Guidance, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("did not backfill, regenerate, or overwrite anything", assessment.Guidance, StringComparison.Ordinal);
+        Assert.Equal(before, await File.ReadAllBytesAsync(statePath));
+    }
+
+    [Fact]
+    public async Task AssessAsync_IncompleteCurrentSchemaIsInvalidWithoutWriting()
+    {
+        using var workspace = TempWorkspace.Create();
+        var service = new WorkspaceGeneratedProjectStateService();
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id");
+        var statePath = WriteState(workspace.Root, "generatorSchemaVersion: 1\ncreationInputs:\n  manifestVersion: 1\n");
+        var before = await File.ReadAllBytesAsync(statePath);
+
+        var assessment = await service.AssessAsync(workspace.Root, manifest);
+
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Invalid, assessment.Status);
+        Assert.Contains("complete schema v1 creation inputs", assessment.Guidance, StringComparison.Ordinal);
+        Assert.Equal(before, await File.ReadAllBytesAsync(statePath));
+    }
+
+    public static IEnumerable<object[]> MalformedCreationInputs()
+    {
+        yield return ["manifestVersion"];
+        yield return ["enginePath"];
+        yield return ["engineReferenceKind"];
+        yield return [nameof(WorkspaceManifest.ContentPath)];
+        yield return [nameof(WorkspaceManifest.SourcePath)];
+        yield return [nameof(WorkspaceManifest.GeneratedProjectPath)];
+        yield return [nameof(WorkspaceManifest.CachePath)];
+        yield return [nameof(WorkspaceManifest.BuildPath)];
+        yield return [nameof(WorkspaceManifest.LogicOutputPath)];
+        yield return ["logicModuleName"];
+    }
+
+    [Theory]
+    [MemberData(nameof(MalformedCreationInputs))]
+    public async Task AssessAsync_MalformedOrUnsafeRecordedInputsAreInvalid(string field)
+    {
+        using var workspace = TempWorkspace.Create();
+        var service = new WorkspaceGeneratedProjectStateService();
+        var current = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id");
+        var recorded = field switch
+        {
+            "manifestVersion" => current with { ManifestVersion = 0 },
+            "enginePath" => current with { EnginePath = "" },
+            "engineReferenceKind" => current with { EngineReferenceKind = "git" },
+            nameof(WorkspaceManifest.ContentPath) => current with { ContentPath = "../Content" },
+            nameof(WorkspaceManifest.SourcePath) => current with { SourcePath = "../Source" },
+            nameof(WorkspaceManifest.GeneratedProjectPath) => current with { GeneratedProjectPath = "../Generated" },
+            nameof(WorkspaceManifest.CachePath) => current with { CachePath = "../Cache" },
+            nameof(WorkspaceManifest.BuildPath) => current with { BuildPath = "../Build" },
+            nameof(WorkspaceManifest.LogicOutputPath) => current with { LogicOutputPath = "../Binaries" },
+            "logicModuleName" => current with { LogicModuleName = "Invalid-Module" },
+            _ => throw new ArgumentOutOfRangeException(nameof(field), field, null)
+        };
+        var statePath = WriteState(workspace.Root, service.Serialize(recorded));
+        var before = await File.ReadAllBytesAsync(statePath);
+
+        var assessment = await service.AssessAsync(workspace.Root, current);
+
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Invalid, assessment.Status);
+        Assert.Empty(assessment.Mismatches);
+        Assert.Contains("malformed or unsafe creation inputs", assessment.Guidance, StringComparison.Ordinal);
+        Assert.Equal(before, await File.ReadAllBytesAsync(statePath));
+    }
+
+    [Fact]
+    public async Task AssessAsync_RejectsStateDirectoryLinkEscapeWithoutReadingOrWritingOutside()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var outside = TempWorkspace.Create();
+        var service = new WorkspaceGeneratedProjectStateService();
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id");
+        var outsideState = outside.File(WorkspaceGeneratedProjectStateService.StateFileName);
+        await File.WriteAllTextAsync(outsideState, service.Serialize(manifest));
+        var before = await File.ReadAllBytesAsync(outsideState);
+        var linkPath = workspace.Directory(WorkspaceGeneratedProjectStateService.StateDirectoryName);
+        CreateDirectoryLink(linkPath, outside.Root);
+
+        try
+        {
+            var assessment = await service.AssessAsync(workspace.Root, manifest);
+
+            Assert.Equal(WorkspaceGeneratedProjectStateStatus.Invalid, assessment.Status);
+            Assert.Contains("safely contained", assessment.Guidance, StringComparison.Ordinal);
+            Assert.Equal(before, await File.ReadAllBytesAsync(outsideState));
+        }
+        finally
+        {
+            if (Directory.Exists(linkPath))
+                Directory.Delete(linkPath);
+        }
+    }
+
+    static string WriteState(string workspaceRoot, string yaml)
+    {
+        var stateDirectory = Path.Combine(
+            workspaceRoot,
+            WorkspaceGeneratedProjectStateService.StateDirectoryName);
+        Directory.CreateDirectory(stateDirectory);
+        var statePath = Path.Combine(
+            stateDirectory,
+            WorkspaceGeneratedProjectStateService.StateFileName);
+        File.WriteAllText(statePath, yaml);
+        return statePath;
+    }
+
+    static void AssertFieldOrder(string yaml, IReadOnlyList<string> fields)
+    {
+        var previous = -1;
+        foreach (var field in fields)
+        {
+            var current = yaml.IndexOf(field, StringComparison.Ordinal);
+            Assert.True(current > previous, $"Expected '{field}' after the previous generated-state field.\n{yaml}");
+            previous = current;
+        }
+    }
+
+    static void CreateDirectoryLink(string linkPath, string targetPath)
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Directory.CreateSymbolicLink(linkPath, targetPath);
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo("cmd.exe")
+        {
+            CreateNoWindow = true,
+            RedirectStandardError = true,
+            RedirectStandardOutput = true,
+            UseShellExecute = false
+        };
+        startInfo.ArgumentList.Add("/d");
+        startInfo.ArgumentList.Add("/c");
+        startInfo.ArgumentList.Add("mklink");
+        startInfo.ArgumentList.Add("/J");
+        startInfo.ArgumentList.Add(linkPath);
+        startInfo.ArgumentList.Add(targetPath);
+
+        using var process = Process.Start(startInfo) ?? throw new InvalidOperationException("Could not start mklink.");
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+        {
+            throw new InvalidOperationException(
+                $"Could not create test junction: {process.StandardError.ReadToEnd()}{process.StandardOutput.ReadToEnd()}");
+        }
+    }
+
+    sealed class TempWorkspace : IDisposable
+    {
+        TempWorkspace(string root)
+        {
+            Root = root;
+            System.IO.Directory.CreateDirectory(root);
+        }
+
+        public string Root { get; }
+
+        public static TempWorkspace Create()
+            => new(Path.Combine(Path.GetTempPath(), $"sailor-generated-state-{Guid.NewGuid():N}"));
+
+        public string File(string relativePath) => Path.Combine(Root, relativePath);
+
+        public string Directory(string relativePath) => Path.Combine(Root, relativePath);
+
+        public void Dispose()
+        {
+            if (System.IO.Directory.Exists(Root))
+                System.IO.Directory.Delete(Root, recursive: true);
+        }
+    }
+}

--- a/Editor.Tests/WorkspaceLifecycleTests.cs
+++ b/Editor.Tests/WorkspaceLifecycleTests.cs
@@ -29,9 +29,11 @@ public sealed class WorkspaceLifecycleTests
         Assert.True(File.Exists(workspace.File("Source/Components/SampleComponent.cpp")));
         Assert.True(File.Exists(workspace.File("Source/WorkspaceTypes.h")));
         Assert.True(File.Exists(workspace.File("Source/WorkspaceModule.cpp")));
+        Assert.True(File.Exists(workspace.File(WorkspaceGeneratedProjectStateService.RelativePath)));
         Assert.Equal("workspace-id", result.Session.Manifest.WorkspaceId);
         Assert.Equal(Physical(workspace.Directory("Cache/Build")), result.Session.BuildDirectory);
         Assert.Equal(Physical(workspace.Directory("Binaries")), result.Session.LogicOutputDirectory);
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Current, result.Session.GeneratedProjectState.Status);
     }
 
     [Fact]
@@ -49,6 +51,102 @@ public sealed class WorkspaceLifecycleTests
         Assert.Equal(created.Session.ManifestPath, reopened.Session.ManifestPath);
         Assert.Equal("Sandbox", reopened.Session.Manifest.Name);
         Assert.Equal(Physical(workspace.Directory("Content")), reopened.Session.ContentDirectory);
+    }
+
+    [Fact]
+    public async Task OpenAndSave_UntrackedGeneratedStateRemainNonBlockingWithoutBackfillOrProjectWrites()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var created = await service.CreateAsync(new WorkspaceCreateRequest(
+            "Sandbox",
+            workspace.Root,
+            "../Sailor",
+            "workspace-id"));
+        var generatedStatePath = workspace.File(WorkspaceGeneratedProjectStateService.RelativePath);
+        File.Delete(generatedStatePath);
+        var ownedProjectFiles = new[]
+        {
+            workspace.File("Generated/CMakeLists.txt"),
+            workspace.File("Source/Components/SampleComponent.h"),
+            workspace.File("Source/Components/SampleComponent.cpp"),
+            workspace.File("Source/WorkspaceTypes.h"),
+            workspace.File("Source/WorkspaceModule.cpp")
+        };
+        var bytesBefore = ownedProjectFiles.ToDictionary(path => path, File.ReadAllBytes);
+
+        var opened = await service.OpenAsync(created.Session!.ManifestPath);
+        var saved = await service.SaveAsync(Assert.IsType<WorkspaceSession>(opened.Session));
+
+        Assert.True(opened.Succeeded, opened.Error);
+        Assert.True(saved.Succeeded, saved.Error);
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Untracked, opened.Session!.GeneratedProjectState.Status);
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Untracked, saved.Session!.GeneratedProjectState.Status);
+        Assert.True(opened.Session.GeneratedProjectState.RequiresAttention);
+        Assert.False(File.Exists(generatedStatePath));
+        foreach (var path in ownedProjectFiles)
+            Assert.Equal(bytesBefore[path], await File.ReadAllBytesAsync(path));
+    }
+
+    [Fact]
+    public async Task SaveAsync_ChangedCreationInputLeavesGeneratedStateStaleAndUserProjectUntouched()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var created = await service.CreateAsync(new WorkspaceCreateRequest(
+            "Sandbox",
+            workspace.Root,
+            "../Sailor",
+            "workspace-id"));
+        var session = Assert.IsType<WorkspaceSession>(created.Session);
+        var generatedStatePath = workspace.File(WorkspaceGeneratedProjectStateService.RelativePath);
+        var stateBefore = await File.ReadAllBytesAsync(generatedStatePath);
+        var cmakePath = workspace.File("Generated/CMakeLists.txt");
+        var cmakeBefore = await File.ReadAllBytesAsync(cmakePath);
+        var changed = session with
+        {
+            Manifest = session.Manifest with { LogicModuleName = "RenamedGame" }
+        };
+
+        var result = await service.SaveAsync(changed);
+
+        Assert.True(result.Succeeded, result.Error);
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Stale, result.Session!.GeneratedProjectState.Status);
+        var mismatch = Assert.Single(result.Session.GeneratedProjectState.Mismatches);
+        Assert.Equal("logicModuleName", mismatch.Field);
+        Assert.Equal("SailorGame", mismatch.RecordedValue);
+        Assert.Equal("RenamedGame", mismatch.CurrentValue);
+        Assert.Equal(stateBefore, await File.ReadAllBytesAsync(generatedStatePath));
+        Assert.Equal(cmakeBefore, await File.ReadAllBytesAsync(cmakePath));
+    }
+
+    [Fact]
+    public async Task OpenAsync_InvalidOrEscapedGeneratedStateIsAdvisoryAndReadOnly()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var outside = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var created = await service.CreateAsync(new WorkspaceCreateRequest(
+            "Sandbox",
+            workspace.Root,
+            "../Sailor",
+            "workspace-id"));
+        var stateDirectory = workspace.Directory(".sailor");
+        Directory.Delete(stateDirectory, recursive: true);
+        var outsideState = outside.File("GeneratedProjectState.yaml");
+        const string invalidState = "generatorSchemaVersion: 999\ncreationInputs: {}\n";
+        await File.WriteAllTextAsync(outsideState, invalidState);
+        CreateDirectoryLink(stateDirectory, outside.Root);
+
+        var result = await service.OpenAsync(created.Session!.ManifestPath);
+
+        Assert.True(result.Succeeded, result.Error);
+        Assert.Equal(WorkspaceGeneratedProjectStateStatus.Invalid, result.Session!.GeneratedProjectState.Status);
+        Assert.True(result.Session.GeneratedProjectState.RequiresAttention);
+        Assert.Equal(invalidState, await File.ReadAllTextAsync(outsideState));
     }
 
     [Fact]
@@ -146,6 +244,35 @@ public sealed class WorkspaceLifecycleTests
 
         Assert.Equal("selected manifest placeholder", await File.ReadAllTextAsync(manifestPath));
         Assert.Equal(manifestPath, Assert.Single(Directory.EnumerateFileSystemEntries(workspace.Root)));
+    }
+
+    [Fact]
+    public async Task CreateAsync_ManifestWriteFailureRollsBackGeneratedStateAndProjectFiles()
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var manifestPath = workspace.Directory("Blocked.sailor");
+        Directory.CreateDirectory(manifestPath);
+
+        var result = await service.CreateAsync(new WorkspaceCreateRequest(
+            "Sandbox",
+            workspace.Root,
+            "../Sailor",
+            "workspace-id",
+            manifestPath));
+
+        Assert.False(result.Succeeded);
+        Assert.True(Directory.Exists(manifestPath));
+        Assert.Equal(manifestPath, Assert.Single(Directory.EnumerateFileSystemEntries(workspace.Root)));
+        Assert.False(File.Exists(workspace.File(".gitignore")));
+        Assert.False(File.Exists(workspace.File(WorkspaceGeneratedProjectStateService.RelativePath)));
+        Assert.False(Directory.Exists(workspace.Directory(WorkspaceGeneratedProjectStateService.StateDirectoryName)));
+        Assert.False(Directory.Exists(workspace.Directory("Content")));
+        Assert.False(Directory.Exists(workspace.Directory("Source")));
+        Assert.False(Directory.Exists(workspace.Directory("Generated")));
+        Assert.False(Directory.Exists(workspace.Directory("Cache")));
+        Assert.False(Directory.Exists(workspace.Directory("Binaries")));
     }
 
     [Fact]
@@ -458,6 +585,35 @@ public sealed class WorkspaceLifecycleTests
         Assert.Contains("not found", result.Error, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Theory]
+    [MemberData(nameof(InvalidManifestVersionPayloads))]
+    public async Task OpenAsync_InvalidManifestVersionDoesNotMutatePublishedOrCandidateState(string payload)
+    {
+        using var currentWorkspace = TempWorkspace.Create();
+        using var candidateWorkspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var recentPath = recent.File("recent.yaml");
+        var service = CreateService(recentPath);
+        var current = await service.CreateAsync(new WorkspaceCreateRequest(
+            "Current",
+            currentWorkspace.Root,
+            "../Sailor",
+            "current-id"));
+        var published = Assert.IsType<WorkspaceSession>(current.Session);
+        var recentBefore = await File.ReadAllBytesAsync(recentPath);
+        var manifestPath = candidateWorkspace.File("candidate.sailor");
+        await File.WriteAllTextAsync(manifestPath, payload);
+
+        var result = await service.OpenAsync(manifestPath);
+
+        Assert.False(result.Succeeded);
+        Assert.Same(published, service.Current);
+        Assert.Equal(payload, await File.ReadAllTextAsync(manifestPath));
+        Assert.Equal(recentBefore, await File.ReadAllBytesAsync(recentPath));
+        Assert.False(Directory.Exists(candidateWorkspace.Directory("Content")));
+        Assert.False(Directory.Exists(candidateWorkspace.Directory("Cache")));
+    }
+
     [Fact]
     public async Task CreateAsync_RejectsPathsOutsideWorkspace()
     {
@@ -581,6 +737,41 @@ public sealed class WorkspaceLifecycleTests
         Assert.Same(published, service.Current);
         Assert.False(Directory.Exists(workspace.Directory("Content")));
         Assert.False(Directory.Exists(workspace.Directory("Cache")));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public async Task SaveAsync_RejectsMissingOrUnsupportedOnDiskManifestBeforeRecovery(bool writeFutureManifest)
+    {
+        using var workspace = TempWorkspace.Create();
+        using var recent = TempWorkspace.Create();
+        var service = CreateService(recent.File("recent.yaml"));
+        var created = await service.CreateAsync(new WorkspaceCreateRequest(
+            "Current",
+            workspace.Root,
+            "../Sailor",
+            "current-id"));
+        var published = Assert.IsType<WorkspaceSession>(created.Session);
+        Directory.Delete(workspace.Directory("Content"), recursive: true);
+        Directory.Delete(workspace.Directory("Cache"), recursive: true);
+
+        const string futureManifest = "manifestVersion: 2\nworkspaceId: [not, a, scalar]\n";
+        if (writeFutureManifest)
+            await File.WriteAllTextAsync(published.ManifestPath, futureManifest);
+        else
+            File.Delete(published.ManifestPath);
+
+        var result = await service.SaveAsync(published);
+
+        Assert.False(result.Succeeded);
+        Assert.Same(published, service.Current);
+        Assert.False(Directory.Exists(workspace.Directory("Content")));
+        Assert.False(Directory.Exists(workspace.Directory("Cache")));
+        if (writeFutureManifest)
+            Assert.Equal(futureManifest, await File.ReadAllTextAsync(published.ManifestPath));
+        else
+            Assert.False(File.Exists(published.ManifestPath));
     }
 
     [Fact]
@@ -716,6 +907,15 @@ public sealed class WorkspaceLifecycleTests
         var recentStore = new RecentWorkspaceStore(recentPath);
         return new WorkspaceLifecycleService(serializer, template, recentStore);
     }
+
+    public static TheoryData<string> InvalidManifestVersionPayloads => new()
+    {
+        "workspaceId: candidate-id\n",
+        "manifestVersion: 0\n",
+        "manifestVersion: 2\nworkspaceId: [not, a, scalar]\n",
+        "manifestVersion: 1\nmanifestVersion: 1\n",
+        "manifestVersion: [1]\n"
+    };
 
     static string Physical(string path) => WorkspacePathPolicy.NormalizePhysicalPath(path);
 

--- a/Editor.Tests/WorkspaceManifestTests.cs
+++ b/Editor.Tests/WorkspaceManifestTests.cs
@@ -69,7 +69,7 @@ public sealed class WorkspaceManifestTests
     }
 
     [Fact]
-    public void Deserialize_OldVersionOneManifestUsesLogicProjectDefaults()
+    public void Deserialize_OldVersionOneManifestUsesMissingOnlyDefaults()
     {
         var serializer = new WorkspaceManifestSerializer();
 
@@ -90,6 +90,45 @@ cachePath: Cache
         Assert.Equal("Cache/Build", result.Manifest.BuildPath);
         Assert.Equal("Binaries", result.Manifest.LogicOutputPath);
         Assert.Equal("SailorGame", result.Manifest.LogicModuleName);
+    }
+
+    [Theory]
+    [InlineData("engineReferenceKind", nameof(WorkspaceManifest.EngineReferenceKind), "")]
+    [InlineData("engineReferenceKind", nameof(WorkspaceManifest.EngineReferenceKind), "\"\"")]
+    [InlineData("buildPath", nameof(WorkspaceManifest.BuildPath), "")]
+    [InlineData("buildPath", nameof(WorkspaceManifest.BuildPath), "\"\"")]
+    [InlineData("logicOutputPath", nameof(WorkspaceManifest.LogicOutputPath), "")]
+    [InlineData("logicOutputPath", nameof(WorkspaceManifest.LogicOutputPath), "\"\"")]
+    [InlineData("logicModuleName", nameof(WorkspaceManifest.LogicModuleName), "")]
+    [InlineData("logicModuleName", nameof(WorkspaceManifest.LogicModuleName), "\"\"")]
+    public void Deserialize_VersionOneRejectsExplicitNullOrEmptyDefaultedFields(
+        string yamlField,
+        string manifestField,
+        string yamlValue)
+    {
+        var serializer = new WorkspaceManifestSerializer();
+
+        var result = serializer.Deserialize(ValidManifest($"{yamlField}: {yamlValue}"));
+
+        Assert.False(result.Succeeded);
+        Assert.NotNull(result.Manifest);
+        Assert.Contains(result.Validation.Issues, issue => issue.Field == manifestField);
+    }
+
+    [Fact]
+    public void Deserialize_ToleratesUnknownAdditiveVersionOneFields()
+    {
+        var serializer = new WorkspaceManifestSerializer();
+
+        var result = serializer.Deserialize(ValidManifest("""
+futureFeature:
+  enabled: true
+  options: [one, two]
+"""));
+
+        Assert.True(result.Succeeded, result.Error);
+        Assert.NotNull(result.Manifest);
+        Assert.Equal("workspace-id", result.Manifest.WorkspaceId);
     }
 
     [Theory]
@@ -260,6 +299,69 @@ cachePath: Cache
         Assert.Contains(result.Validation.Issues, x => x.Field == nameof(WorkspaceManifest.ManifestVersion));
     }
 
+    [Theory]
+    [MemberData(nameof(InvalidManifestVersionDocuments))]
+    public void Deserialize_RawVersionProbeRejectsInvalidVersionContracts(
+        string yaml,
+        WorkspaceYamlVersionProbeFailure expectedFailure,
+        string expectedDiagnostic)
+    {
+        var serializer = new WorkspaceManifestSerializer();
+
+        var probe = WorkspaceYamlVersionProbe.Probe(
+            yaml,
+            "manifestVersion",
+            WorkspaceManifest.CurrentVersion,
+            "Workspace manifest");
+        var result = serializer.Deserialize(yaml);
+
+        Assert.False(probe.Succeeded);
+        Assert.Equal(expectedFailure, probe.Failure);
+        Assert.Contains(expectedDiagnostic, probe.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Manifest);
+        var issue = Assert.Single(result.Validation.Issues);
+        Assert.Equal(nameof(WorkspaceManifest.ManifestVersion), issue.Field);
+        Assert.Equal(probe.Error, issue.Message);
+    }
+
+    [Fact]
+    public void Deserialize_FutureVersionPrecedesMalformedLaterTypedFields()
+    {
+        var serializer = new WorkspaceManifestSerializer();
+
+        var result = serializer.Deserialize("""
+workspaceId: [not, a, string]
+manifestVersion: 999
+name:
+  invalid: for-a-string
+enginePath: ../Sailor
+contentPath: [not, a, path]
+""");
+
+        Assert.False(result.Succeeded);
+        Assert.Null(result.Manifest);
+        Assert.Null(result.Error);
+        var issue = Assert.Single(result.Validation.Issues);
+        Assert.Equal(nameof(WorkspaceManifest.ManifestVersion), issue.Field);
+        Assert.Contains("Unsupported workspace manifest version '999'", issue.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("parse", issue.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void VersionProbe_UsesCallerProvidedVersionContract()
+    {
+        var result = WorkspaceYamlVersionProbe.Probe(
+            "generatorSchemaVersion: 3",
+            "generatorSchemaVersion",
+            3,
+            "Generated project state");
+
+        Assert.True(result.Succeeded, result.Error);
+        Assert.Equal(3, result.Version);
+        Assert.Equal(WorkspaceYamlVersionProbeFailure.None, result.Failure);
+    }
+
     [Fact]
     public void Deserialize_NormalizesNullStringFieldsBeforeValidation()
     {
@@ -303,4 +405,62 @@ cachePath:
             nameof(WorkspaceManifest.LogicOutputPath) => manifest with { LogicOutputPath = path },
             _ => throw new ArgumentOutOfRangeException(nameof(field), field, null)
         };
+
+    public static IEnumerable<object[]> InvalidManifestVersionDocuments()
+    {
+        yield return [
+            """
+workspaceId: workspace-id
+name: Sandbox
+""",
+            WorkspaceYamlVersionProbeFailure.MissingVersion,
+            "required"
+        ];
+        yield return [
+            """
+manifestVersion: 0
+workspaceId: workspace-id
+""",
+            WorkspaceYamlVersionProbeFailure.InvalidVersion,
+            "greater than zero"
+        ];
+        yield return [
+            """
+manifestVersion: 999
+workspaceId: workspace-id
+""",
+            WorkspaceYamlVersionProbeFailure.UnsupportedVersion,
+            "unsupported workspace manifest version"
+        ];
+        yield return [
+            """
+manifestVersion: 1
+manifestVersion: 1
+workspaceId: workspace-id
+""",
+            WorkspaceYamlVersionProbeFailure.DuplicateVersion,
+            "duplicate field"
+        ];
+        yield return [
+            """
+manifestVersion: [1]
+workspaceId: workspace-id
+""",
+            WorkspaceYamlVersionProbeFailure.NonScalarVersion,
+            "scalar integer"
+        ];
+    }
+
+    static string ValidManifest(string optionalYaml = "")
+        => $$"""
+manifestVersion: 1
+workspaceId: workspace-id
+name: Sandbox
+enginePath: ../Sailor
+contentPath: Content
+sourcePath: Source
+generatedProjectPath: Generated
+cachePath: Cache
+{{optionalYaml}}
+""";
 }

--- a/Editor.Tests/WorkspaceProjectGeneratorTests.cs
+++ b/Editor.Tests/WorkspaceProjectGeneratorTests.cs
@@ -14,7 +14,7 @@ public sealed class WorkspaceProjectGeneratorTests
         var session = CreateSession(workspace.Root, manifest);
         var generator = new WorkspaceProjectGenerator();
 
-        await generator.GenerateAsync(session);
+        var generated = await generator.GenerateAsync(session);
 
         var cmake = await File.ReadAllTextAsync(workspace.File("Generated/CMakeLists.txt"));
         Assert.Contains($"add_subdirectory(\"{ToCMakePath(engine.Root)}\" \"${{CMAKE_BINARY_DIR}}/SailorEngine\" EXCLUDE_FROM_ALL)", cmake);
@@ -36,6 +36,12 @@ public sealed class WorkspaceProjectGeneratorTests
         Assert.True(File.Exists(workspace.File("Source/WorkspaceTypes.h")));
         Assert.True(File.Exists(workspace.File("Source/WorkspaceModule.cpp")));
         Assert.True(File.Exists(workspace.File(".gitignore")));
+        var generatedState = new WorkspaceGeneratedProjectStateService().GetStatePath(workspace.Root);
+        Assert.True(File.Exists(generatedState));
+        Assert.Equal(generatedState, generated.CreatedFiles.Last());
+        Assert.Equal(
+            WorkspaceGeneratedProjectStateStatus.Current,
+            (await new WorkspaceGeneratedProjectStateService().AssessAsync(workspace.Root, manifest)).Status);
         Assert.True(Directory.Exists(workspace.Directory("Cache/Build")));
         Assert.True(Directory.Exists(workspace.Directory("Binaries")));
     }
@@ -94,6 +100,67 @@ public sealed class WorkspaceProjectGeneratorTests
     }
 
     [Fact]
+    public async Task GenerateAsync_DoesNotOverwriteExistingGeneratedState()
+    {
+        using var workspace = TempWorkspace.Create();
+        var stateDirectory = workspace.Directory(WorkspaceGeneratedProjectStateService.StateDirectoryName);
+        Directory.CreateDirectory(stateDirectory);
+        var statePath = workspace.File(WorkspaceGeneratedProjectStateService.RelativePath);
+        await File.WriteAllTextAsync(statePath, "source-controlled user state");
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id");
+        var session = CreateSession(workspace.Root, manifest);
+        var generator = new WorkspaceProjectGenerator();
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() => generator.GenerateAsync(session));
+
+        Assert.Contains("will not be overwritten", error.Message, StringComparison.Ordinal);
+        Assert.Equal("source-controlled user state", await File.ReadAllTextAsync(statePath));
+        Assert.False(File.Exists(workspace.File(".gitignore")));
+        Assert.False(File.Exists(workspace.File("Generated/CMakeLists.txt")));
+        Assert.False(File.Exists(workspace.File("Source/WorkspaceModule.cpp")));
+    }
+
+    [Fact]
+    public async Task GenerateAsync_PreflightsDirectoryCollisionWithGeneratedStateWithoutMutation()
+    {
+        using var workspace = TempWorkspace.Create();
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id") with
+        {
+            CachePath = WorkspaceGeneratedProjectStateService.RelativePath
+        };
+        var session = CreateSession(workspace.Root, manifest);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            new WorkspaceProjectGenerator().GenerateAsync(session));
+
+        Assert.Contains("conflicts with generated file", error.Message, StringComparison.Ordinal);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(workspace.Root));
+    }
+
+    [Fact]
+    public async Task GenerateAsync_DoesNotIgnoreStateDirectoryWhenCacheUsesSamePath()
+    {
+        using var workspace = TempWorkspace.Create();
+        var manifest = WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id") with
+        {
+            CachePath = WorkspaceGeneratedProjectStateService.StateDirectoryName,
+            BuildPath = WorkspaceGeneratedProjectStateService.StateDirectoryName + "/Build"
+        };
+        var session = CreateSession(workspace.Root, manifest);
+
+        await new WorkspaceProjectGenerator().GenerateAsync(session);
+
+        var ignoredLines = (await File.ReadAllLinesAsync(workspace.File(".gitignore")))
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .ToArray();
+        Assert.Contains("/.sailor/*", ignoredLines);
+        Assert.Contains("!/.sailor/GeneratedProjectState.yaml", ignoredLines);
+        Assert.DoesNotContain("/.sailor/", ignoredLines);
+        Assert.Contains("/.sailor/Build/", ignoredLines);
+        Assert.True(File.Exists(workspace.File(WorkspaceGeneratedProjectStateService.RelativePath)));
+    }
+
+    [Fact]
     public async Task GenerateAsync_EmitsEditableSampleComponent()
     {
         using var workspace = TempWorkspace.Create();
@@ -135,21 +202,27 @@ public sealed class WorkspaceProjectGeneratorTests
         var sourceDirectory = workspace.Directory("Source");
         var componentsDirectory = workspace.Directory("Source/Components");
         var generatedDirectory = workspace.Directory("Generated");
+        var stateDirectory = workspace.Directory(WorkspaceGeneratedProjectStateService.StateDirectoryName);
         Directory.CreateDirectory(componentsDirectory);
         Directory.CreateDirectory(generatedDirectory);
+        Directory.CreateDirectory(stateDirectory);
         var trackedFile = workspace.File("Source/Components/SampleComponent.h");
+        var trackedState = workspace.File(WorkspaceGeneratedProjectStateService.RelativePath);
         var untrackedFile = workspace.File("Source/UserComponent.cpp");
         await File.WriteAllTextAsync(trackedFile, "generated");
+        await File.WriteAllTextAsync(trackedState, "generated state");
         await File.WriteAllTextAsync(untrackedFile, "user-owned");
 
         WorkspaceProjectGenerator.Rollback(new WorkspaceProjectGenerationResult(
-            [trackedFile],
-            [sourceDirectory, componentsDirectory, generatedDirectory]));
+            [trackedFile, trackedState],
+            [sourceDirectory, componentsDirectory, generatedDirectory, stateDirectory]));
 
         Assert.False(File.Exists(trackedFile));
+        Assert.False(File.Exists(trackedState));
         Assert.True(File.Exists(untrackedFile));
         Assert.True(Directory.Exists(sourceDirectory));
         Assert.False(Directory.Exists(generatedDirectory));
+        Assert.False(Directory.Exists(stateDirectory));
     }
 
     static WorkspaceSession CreateSession(string workspaceRoot, WorkspaceManifest manifest)

--- a/Editor.Tests/WorkspaceUiProjectionTests.cs
+++ b/Editor.Tests/WorkspaceUiProjectionTests.cs
@@ -76,6 +76,44 @@ public sealed class WorkspaceUiProjectionTests
         Assert.Equal("Native startup failed.", projection.ActivationError);
     }
 
+    [Fact]
+    public void Build_ProjectsGeneratedStateAttentionWithoutRepair()
+    {
+        const string guidance = "Generated project inputs are stale; user-owned files were not changed.";
+        var session = CreateSession(new WorkspaceGeneratedProjectStateAssessment(
+            WorkspaceGeneratedProjectStateStatus.Stale,
+            guidance,
+            [new WorkspaceGeneratedProjectStateMismatch("logicModuleName", "OldGame", "SailorGame")]));
+
+        var projection = WorkspaceUiProjectionBuilder.Build(session, []);
+
+        Assert.True(projection.HasActiveWorkspace);
+        Assert.True(projection.HasGeneratedProjectAttention);
+        Assert.Equal(guidance, projection.GeneratedProjectAttention);
+        Assert.False(projection.RequiresRepair);
+    }
+
+    [Fact]
+    public void Build_PreservesGeneratedStateAttentionAlongsideRepair()
+    {
+        const string guidance = "Generated project state is untracked; no files were changed.";
+        var session = CreateSession(new WorkspaceGeneratedProjectStateAssessment(
+            WorkspaceGeneratedProjectStateStatus.Untracked,
+            guidance,
+            []));
+        var activation = new WorkspaceActivationState(
+            WorkspaceActivationPhase.Repair,
+            5,
+            Error: "Native startup failed.");
+
+        var projection = WorkspaceUiProjectionBuilder.Build(session, [], activation);
+
+        Assert.True(projection.RequiresRepair);
+        Assert.True(projection.HasGeneratedProjectAttention);
+        Assert.Equal(guidance, projection.GeneratedProjectAttention);
+        Assert.Equal("Native startup failed.", projection.ActivationError);
+    }
+
     [Theory]
     [InlineData(WorkspaceActivationPhase.Preflighting)]
     [InlineData(WorkspaceActivationPhase.Stopping)]
@@ -91,5 +129,21 @@ public sealed class WorkspaceUiProjectionTests
 
         Assert.True(projection.IsActivationInProgress);
         Assert.False(projection.RequiresRepair);
+    }
+
+    static WorkspaceSession CreateSession(WorkspaceGeneratedProjectStateAssessment assessment)
+    {
+        var root = Path.GetFullPath(Path.Combine(Path.GetTempPath(), "sailor-ui-projection-state"));
+        return new WorkspaceSession(
+            root,
+            Path.Combine(root, WorkspaceTemplateService.ManifestFileName),
+            WorkspaceManifest.CreateDefault("Sandbox", "../Sailor", "workspace-id"),
+            Path.Combine(root, "Content"),
+            Path.Combine(root, "Source"),
+            Path.Combine(root, "Generated"),
+            Path.Combine(root, "Cache"))
+        {
+            GeneratedProjectState = assessment
+        };
     }
 }

--- a/Editor/MainPage.xaml.cs
+++ b/Editor/MainPage.xaml.cs
@@ -67,11 +67,14 @@ public partial class MainPage : ContentPage
         var workspaceStatus = projection.HasActiveWorkspace
             ? $"{_shellHost.StatusText} • Workspace: {projection.ActiveWorkspaceName} - {projection.ActiveWorkspacePath}"
             : _shellHost.StatusText;
-        StatusTextLabel.Text = projection.RequiresRepair
+        var statusText = projection.RequiresRepair
             ? $"{workspaceStatus} • Repair required: {projection.ActivationError}"
             : projection.IsActivationInProgress
                 ? $"{workspaceStatus} • Workspace activation: {projection.ActivationPhase}"
                 : workspaceStatus;
+        if (projection.HasGeneratedProjectAttention)
+            statusText = $"{statusText} • Generated project: {projection.GeneratedProjectAttention}";
+        StatusTextLabel.Text = statusText;
     }
 
     void UpdateWindowTitle()

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -51,6 +51,7 @@ namespace SailorEditor
             builder.Services.AddSingleton<EditorToolbarActions>();
             builder.Services.AddSingleton<EditorContextMenuService>();
             builder.Services.AddSingleton<WorkspaceManifestSerializer>();
+            builder.Services.AddSingleton<WorkspaceGeneratedProjectStateService>();
             builder.Services.AddSingleton<WorkspaceProjectGenerator>();
             builder.Services.AddSingleton<WorkspaceTemplateService>();
             builder.Services.AddSingleton(_ => new RecentWorkspaceStore());

--- a/Editor/Services/WorkspaceUiService.cs
+++ b/Editor/Services/WorkspaceUiService.cs
@@ -211,6 +211,7 @@ internal sealed class WorkspaceUiService
                 var message = string.IsNullOrWhiteSpace(result.Error)
                     ? "Workspace activation failed after the previous runtime stopped. Open a valid workspace or retry activation to repair the editor session."
                     : $"{result.Error}{Environment.NewLine}{Environment.NewLine}Open a valid workspace or retry activation to repair the editor session.";
+                message = AppendGeneratedProjectGuidance(message, result.Candidate?.Session);
                 _shellHost.SetStatus("Workspace activation requires repair.");
                 if (GetPage() is { } repairPage)
                     await repairPage.DisplayAlert(title, message, "OK");
@@ -223,11 +224,12 @@ internal sealed class WorkspaceUiService
         }
 
         var activatedName = result.Candidate?.Session.Manifest.Name;
-        _shellHost.SetStatus(string.IsNullOrWhiteSpace(activatedName)
+        var status = string.IsNullOrWhiteSpace(activatedName)
             ? successMessage
             : title == "New Workspace"
                 ? $"Created workspace '{activatedName}'."
-                : $"Loaded workspace '{activatedName}'.");
+                : $"Loaded workspace '{activatedName}'.";
+        _shellHost.SetStatus(status);
 #if MACCATALYST
         SailorEditor.AppDelegate.RequestMenuRebuild();
 #endif
@@ -300,7 +302,10 @@ internal sealed class WorkspaceUiService
                         ? Path.GetFileName(candidate.Session.WorkspaceRoot)
                         : candidate.Session.Manifest.Name,
                     ActiveWorkspacePath = candidate.Session.WorkspaceRoot,
-                    HasActiveWorkspace = true
+                    HasActiveWorkspace = true,
+                    GeneratedProjectAttention = candidate.Session.GeneratedProjectState.RequiresAttention
+                        ? candidate.Session.GeneratedProjectState.Guidance
+                        : null
                 };
             }
 
@@ -431,6 +436,14 @@ internal sealed class WorkspaceUiService
             return string.Join(Environment.NewLine, result.Validation.Issues.Select(x => $"{x.Field}: {x.Message}"));
 
         return "Workspace preflight failed.";
+    }
+
+    static string AppendGeneratedProjectGuidance(string message, WorkspaceSession? session)
+    {
+        if (session?.GeneratedProjectState.RequiresAttention != true)
+            return message;
+
+        return $"{message}{Environment.NewLine}{Environment.NewLine}{session.GeneratedProjectState.Guidance}";
     }
 
 }

--- a/Editor/Workspace/WorkspaceGeneratedProjectState.cs
+++ b/Editor/Workspace/WorkspaceGeneratedProjectState.cs
@@ -1,0 +1,311 @@
+using System.Globalization;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace SailorEditor.Workspace;
+
+public enum WorkspaceGeneratedProjectStateStatus
+{
+    Current,
+    Untracked,
+    Stale,
+    Invalid
+}
+
+public sealed record WorkspaceGeneratedProjectStateMismatch(
+    string Field,
+    string RecordedValue,
+    string CurrentValue);
+
+public sealed record WorkspaceGeneratedProjectStateAssessment(
+    WorkspaceGeneratedProjectStateStatus Status,
+    string Guidance,
+    IReadOnlyList<WorkspaceGeneratedProjectStateMismatch> Mismatches)
+{
+    public bool RequiresAttention => Status != WorkspaceGeneratedProjectStateStatus.Current;
+}
+
+public sealed record WorkspaceGeneratedProjectCreationInputs
+{
+    public int? ManifestVersion { get; init; }
+    public string? EnginePath { get; init; }
+    public string? EngineReferenceKind { get; init; }
+    public string? ContentPath { get; init; }
+    public string? SourcePath { get; init; }
+    public string? GeneratedProjectPath { get; init; }
+    public string? CachePath { get; init; }
+    public string? BuildPath { get; init; }
+    public string? LogicOutputPath { get; init; }
+    public string? LogicModuleName { get; init; }
+}
+
+public sealed record WorkspaceGeneratedProjectState
+{
+    public int GeneratorSchemaVersion { get; init; }
+    public WorkspaceGeneratedProjectCreationInputs? CreationInputs { get; init; }
+}
+
+public sealed class WorkspaceGeneratedProjectStateService
+{
+    public const int CurrentGeneratorSchemaVersion = 1;
+    public const string StateDirectoryName = ".sailor";
+    public const string StateFileName = "GeneratedProjectState.yaml";
+    public const string RelativePath = StateDirectoryName + "/" + StateFileName;
+
+    const string VersionField = "generatorSchemaVersion";
+    const string DocumentName = "Generated project state";
+
+    static readonly IReadOnlyList<WorkspaceGeneratedProjectStateMismatch> NoMismatches =
+        Array.Empty<WorkspaceGeneratedProjectStateMismatch>();
+
+    readonly ISerializer _serializer = new SerializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .Build();
+
+    readonly IDeserializer _deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    public string GetStatePath(string workspaceRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(workspaceRoot);
+
+        var root = WorkspacePathPolicy.NormalizePhysicalPath(workspaceRoot);
+        var statePath = Path.GetFullPath(Path.Combine(root, StateDirectoryName, StateFileName));
+        WorkspacePathPolicy.EnsureInsideRoot(root, statePath, RelativePath);
+        return statePath;
+    }
+
+    public WorkspaceGeneratedProjectState Create(WorkspaceManifest manifest)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        return new WorkspaceGeneratedProjectState
+        {
+            GeneratorSchemaVersion = CurrentGeneratorSchemaVersion,
+            CreationInputs = BuildInputs(manifest)
+        };
+    }
+
+    public string Serialize(WorkspaceManifest manifest)
+    {
+        var yaml = _serializer.Serialize(Create(manifest)).ReplaceLineEndings("\n");
+        return yaml.EndsWith('\n') ? yaml : yaml + "\n";
+    }
+
+    public async Task<WorkspaceGeneratedProjectStateAssessment> AssessAsync(
+        string workspaceRoot,
+        WorkspaceManifest manifest,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(manifest);
+
+        string statePath;
+        try
+        {
+            statePath = GetStatePath(workspaceRoot);
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or InvalidOperationException or
+            NotSupportedException or UnauthorizedAccessException)
+        {
+            return Invalid("The generated project state path is not safely contained by the workspace root.");
+        }
+
+        string yaml;
+        try
+        {
+            yaml = await File.ReadAllTextAsync(statePath, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            return Untracked();
+        }
+        catch (Exception ex) when (ex is IOException or NotSupportedException or UnauthorizedAccessException)
+        {
+            return Invalid($"The generated project state at '{RelativePath}' could not be read.");
+        }
+
+        var version = WorkspaceYamlVersionProbe.Probe(
+            yaml,
+            VersionField,
+            CurrentGeneratorSchemaVersion,
+            DocumentName);
+        if (!version.Succeeded)
+            return Invalid(version.Error ?? $"The generated project state at '{RelativePath}' is invalid.");
+
+        WorkspaceGeneratedProjectState? state;
+        try
+        {
+            state = _deserializer.Deserialize<WorkspaceGeneratedProjectState>(yaml);
+        }
+        catch (YamlException)
+        {
+            return Invalid($"The generated project state at '{RelativePath}' is invalid YAML.");
+        }
+
+        if (state is null ||
+            state.GeneratorSchemaVersion != CurrentGeneratorSchemaVersion ||
+            !HasCompleteInputs(state.CreationInputs))
+        {
+            return Invalid($"The generated project state at '{RelativePath}' does not contain the complete schema v{CurrentGeneratorSchemaVersion} creation inputs.");
+        }
+
+        var recorded = NormalizeInputs(state.CreationInputs!);
+        if (!HasValidInputs(recorded))
+        {
+            return Invalid($"The generated project state at '{RelativePath}' contains malformed or unsafe creation inputs.");
+        }
+
+        var current = BuildInputs(manifest);
+        var mismatches = Compare(recorded, current);
+        if (mismatches.Count == 0)
+        {
+            return new WorkspaceGeneratedProjectStateAssessment(
+                WorkspaceGeneratedProjectStateStatus.Current,
+                string.Empty,
+                NoMismatches);
+        }
+
+        return new WorkspaceGeneratedProjectStateAssessment(
+            WorkspaceGeneratedProjectStateStatus.Stale,
+            BuildStaleGuidance(mismatches),
+            mismatches);
+    }
+
+    static WorkspaceGeneratedProjectCreationInputs BuildInputs(WorkspaceManifest manifest)
+        => NormalizeInputs(new WorkspaceGeneratedProjectCreationInputs
+        {
+            ManifestVersion = manifest.ManifestVersion,
+            EnginePath = manifest.EnginePath,
+            EngineReferenceKind = manifest.EngineReferenceKind,
+            ContentPath = manifest.ContentPath,
+            SourcePath = manifest.SourcePath,
+            GeneratedProjectPath = manifest.GeneratedProjectPath,
+            CachePath = manifest.CachePath,
+            BuildPath = manifest.BuildPath,
+            LogicOutputPath = manifest.LogicOutputPath,
+            LogicModuleName = manifest.LogicModuleName
+        });
+
+    static WorkspaceGeneratedProjectCreationInputs NormalizeInputs(WorkspaceGeneratedProjectCreationInputs inputs)
+        => inputs with
+        {
+            EnginePath = WorkspaceManifestPaths.Normalize(inputs.EnginePath),
+            EngineReferenceKind = WorkspaceEngineReferenceKinds.Normalize(inputs.EngineReferenceKind),
+            ContentPath = WorkspaceManifestPaths.Normalize(inputs.ContentPath),
+            SourcePath = WorkspaceManifestPaths.Normalize(inputs.SourcePath),
+            GeneratedProjectPath = WorkspaceManifestPaths.Normalize(inputs.GeneratedProjectPath),
+            CachePath = WorkspaceManifestPaths.Normalize(inputs.CachePath),
+            BuildPath = WorkspaceManifestPaths.Normalize(inputs.BuildPath),
+            LogicOutputPath = WorkspaceManifestPaths.Normalize(inputs.LogicOutputPath),
+            LogicModuleName = inputs.LogicModuleName?.Trim() ?? string.Empty
+        };
+
+    static bool HasCompleteInputs(WorkspaceGeneratedProjectCreationInputs? inputs)
+        => inputs is not null &&
+            inputs.ManifestVersion.HasValue &&
+            inputs.EnginePath is not null &&
+            inputs.EngineReferenceKind is not null &&
+            inputs.ContentPath is not null &&
+            inputs.SourcePath is not null &&
+            inputs.GeneratedProjectPath is not null &&
+            inputs.CachePath is not null &&
+            inputs.BuildPath is not null &&
+            inputs.LogicOutputPath is not null &&
+            inputs.LogicModuleName is not null;
+
+    static bool HasValidInputs(WorkspaceGeneratedProjectCreationInputs inputs)
+        => inputs.ManifestVersion > 0 &&
+            !string.IsNullOrWhiteSpace(inputs.EnginePath) &&
+            WorkspaceEngineReferenceKinds.IsSupported(inputs.EngineReferenceKind!) &&
+            WorkspacePathPolicy.IsSafeRelativePath(inputs.ContentPath) &&
+            WorkspacePathPolicy.IsSafeRelativePath(inputs.SourcePath) &&
+            WorkspacePathPolicy.IsSafeRelativePath(inputs.GeneratedProjectPath) &&
+            WorkspacePathPolicy.IsSafeRelativePath(inputs.CachePath) &&
+            WorkspacePathPolicy.IsSafeRelativePath(inputs.BuildPath) &&
+            WorkspacePathPolicy.IsSafeRelativePath(inputs.LogicOutputPath) &&
+            IsCIdentifier(inputs.LogicModuleName!);
+
+    static bool IsCIdentifier(string value)
+    {
+        if (value.Length == 0 || !IsAsciiLetterOrUnderscore(value[0]))
+            return false;
+
+        return value.Skip(1).All(x => IsAsciiLetterOrUnderscore(x) || x is >= '0' and <= '9');
+    }
+
+    static bool IsAsciiLetterOrUnderscore(char value)
+        => value == '_' || value is >= 'A' and <= 'Z' || value is >= 'a' and <= 'z';
+
+    static IReadOnlyList<WorkspaceGeneratedProjectStateMismatch> Compare(
+        WorkspaceGeneratedProjectCreationInputs recorded,
+        WorkspaceGeneratedProjectCreationInputs current)
+    {
+        var mismatches = new List<WorkspaceGeneratedProjectStateMismatch>();
+        AddMismatch(
+            mismatches,
+            "manifestVersion",
+            recorded.ManifestVersion!.Value.ToString(CultureInfo.InvariantCulture),
+            current.ManifestVersion!.Value.ToString(CultureInfo.InvariantCulture));
+        AddMismatch(mismatches, "enginePath", recorded.EnginePath!, current.EnginePath!);
+        AddMismatch(mismatches, "engineReferenceKind", recorded.EngineReferenceKind!, current.EngineReferenceKind!);
+        AddMismatch(mismatches, "contentPath", recorded.ContentPath!, current.ContentPath!);
+        AddMismatch(mismatches, "sourcePath", recorded.SourcePath!, current.SourcePath!);
+        AddMismatch(mismatches, "generatedProjectPath", recorded.GeneratedProjectPath!, current.GeneratedProjectPath!);
+        AddMismatch(mismatches, "cachePath", recorded.CachePath!, current.CachePath!);
+        AddMismatch(mismatches, "buildPath", recorded.BuildPath!, current.BuildPath!);
+        AddMismatch(mismatches, "logicOutputPath", recorded.LogicOutputPath!, current.LogicOutputPath!);
+        AddMismatch(mismatches, "logicModuleName", recorded.LogicModuleName!, current.LogicModuleName!);
+        return mismatches;
+    }
+
+    static void AddMismatch(
+        ICollection<WorkspaceGeneratedProjectStateMismatch> mismatches,
+        string field,
+        string recordedValue,
+        string currentValue)
+    {
+        if (!string.Equals(recordedValue, currentValue, StringComparison.Ordinal))
+        {
+            mismatches.Add(new WorkspaceGeneratedProjectStateMismatch(
+                field,
+                recordedValue,
+                currentValue));
+        }
+    }
+
+    static WorkspaceGeneratedProjectStateAssessment Untracked()
+        => new(
+            WorkspaceGeneratedProjectStateStatus.Untracked,
+            $"Generated project state is not tracked at '{RelativePath}'. The workspace remains usable, but Sailor cannot verify that its user-owned CMake and source files match the manifest. Manually reconcile those files, or create a clean workspace with the current editor and merge the user-owned changes, then add the state file to source control; Sailor did not backfill or overwrite anything.",
+            NoMismatches);
+
+    static WorkspaceGeneratedProjectStateAssessment Invalid(string reason)
+        => new(
+            WorkspaceGeneratedProjectStateStatus.Invalid,
+            $"{reason} Restore a compatible source-controlled state file, manually reconcile the user-owned CMake and source files, or create a clean workspace with the current editor and merge the user-owned changes; Sailor did not backfill, regenerate, or overwrite anything.",
+            NoMismatches);
+
+    static string BuildStaleGuidance(IReadOnlyList<WorkspaceGeneratedProjectStateMismatch> mismatches)
+    {
+        var changes = string.Join(
+            "; ",
+            mismatches.Select(x =>
+                $"{x.Field} (recorded '{FormatValue(x.RecordedValue)}', current '{FormatValue(x.CurrentValue)}')"));
+        return $"Generated project state is stale: {changes}. Restore the recorded manifest values, manually reconcile the user-owned CMake and source files, or create a clean workspace with the current editor and merge the user-owned changes, then update '{RelativePath}' in source control; Sailor did not regenerate or overwrite anything.";
+    }
+
+    static string FormatValue(string value)
+        => value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("'", "''", StringComparison.Ordinal)
+            .Replace("\r", "\\r", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal)
+            .Replace("\t", "\\t", StringComparison.Ordinal);
+}

--- a/Editor/Workspace/WorkspaceLifecycle.cs
+++ b/Editor/Workspace/WorkspaceLifecycle.cs
@@ -24,6 +24,10 @@ public sealed record WorkspaceSession(
 {
     public string BuildDirectory { get; init; } = string.Empty;
     public string LogicOutputDirectory { get; init; } = string.Empty;
+    public WorkspaceGeneratedProjectStateAssessment GeneratedProjectState { get; init; } = new(
+        WorkspaceGeneratedProjectStateStatus.Current,
+        string.Empty,
+        []);
 }
 
 public sealed record WorkspaceLifecycleResult(
@@ -357,15 +361,30 @@ public sealed class WorkspaceLifecycleService
     readonly WorkspaceManifestSerializer _serializer;
     readonly WorkspaceTemplateService _templateService;
     readonly RecentWorkspaceStore _recentWorkspaceStore;
+    readonly WorkspaceGeneratedProjectStateService _generatedProjectState;
 
     public WorkspaceLifecycleService(
         WorkspaceManifestSerializer serializer,
         WorkspaceTemplateService templateService,
         RecentWorkspaceStore recentWorkspaceStore)
+        : this(
+            serializer,
+            templateService,
+            recentWorkspaceStore,
+            new WorkspaceGeneratedProjectStateService())
+    {
+    }
+
+    public WorkspaceLifecycleService(
+        WorkspaceManifestSerializer serializer,
+        WorkspaceTemplateService templateService,
+        RecentWorkspaceStore recentWorkspaceStore,
+        WorkspaceGeneratedProjectStateService generatedProjectState)
     {
         _serializer = serializer;
         _templateService = templateService;
         _recentWorkspaceStore = recentWorkspaceStore;
+        _generatedProjectState = generatedProjectState;
     }
 
     public WorkspaceSession? Current { get; private set; }
@@ -456,11 +475,22 @@ public sealed class WorkspaceLifecycleService
             }
 
             var session = _templateService.CreateSession(workspaceRoot, loadResult.Manifest, manifestPath);
+            session = session with
+            {
+                GeneratedProjectState = await _generatedProjectState.AssessAsync(
+                    workspaceRoot,
+                    loadResult.Manifest,
+                    cancellationToken)
+            };
             recovery = RecoverDefaultDirectories(session);
             session = recovery.Session;
             return new WorkspaceLifecyclePreparationResult(
                 new WorkspaceLifecyclePreparation(session, recovery.Commit, recovery.Rollback),
                 loadResult.Validation);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
@@ -523,22 +553,44 @@ public sealed class WorkspaceLifecycleService
     public async Task<WorkspaceLifecycleResult> SaveAsync(WorkspaceSession session, CancellationToken cancellationToken = default)
     {
         WorkspaceDirectoryRecovery? recovery = null;
+        var validation = WorkspaceManifestValidationResult.Success;
         try
         {
+            WorkspacePathPolicy.EnsureInsideRoot(
+                session.WorkspaceRoot,
+                session.ManifestPath,
+                nameof(WorkspaceSession.ManifestPath));
+            var onDisk = await _serializer.LoadAsync(session.ManifestPath, cancellationToken);
+            validation = onDisk.Validation;
+            if (!onDisk.Succeeded)
+            {
+                return new WorkspaceLifecycleResult(
+                    null,
+                    onDisk.Validation,
+                    onDisk.Error);
+            }
+
             var validated = _templateService.CreateSession(session.WorkspaceRoot, session.Manifest, session.ManifestPath);
+            validated = validated with
+            {
+                GeneratedProjectState = await _generatedProjectState.AssessAsync(
+                    validated.WorkspaceRoot,
+                    validated.Manifest,
+                    cancellationToken)
+            };
             recovery = RecoverDefaultDirectories(validated);
             validated = recovery.Session;
             await _serializer.SaveAsync(validated.ManifestPath, validated.Manifest, cancellationToken);
             await _recentWorkspaceStore.RecordAsync(validated, cancellationToken);
             recovery.Commit();
             Current = validated;
-            return new WorkspaceLifecycleResult(validated, WorkspaceManifestValidationResult.Success);
+            return new WorkspaceLifecycleResult(validated, validation);
         }
         catch (Exception ex)
         {
             return new WorkspaceLifecycleResult(
                 null,
-                WorkspaceManifestValidationResult.Success,
+                validation,
                 RollbackRecovery(recovery, ex).Message);
         }
     }
@@ -575,7 +627,10 @@ public sealed class WorkspaceLifecycleService
             var resolved = _templateService.CreateSession(
                 session.WorkspaceRoot,
                 session.Manifest,
-                session.ManifestPath);
+                session.ManifestPath) with
+            {
+                GeneratedProjectState = session.GeneratedProjectState
+            };
             if (!Directory.Exists(resolved.ContentDirectory))
                 throw new DirectoryNotFoundException($"ContentPath was not recovered: {resolved.ContentDirectory}");
             if (!Directory.Exists(resolved.CacheDirectory))

--- a/Editor/Workspace/WorkspaceManifest.cs
+++ b/Editor/Workspace/WorkspaceManifest.cs
@@ -106,6 +106,30 @@ public sealed class WorkspaceManifestSerializer
 
     public WorkspaceManifestLoadResult Deserialize(string yaml)
     {
+        var versionProbe = WorkspaceYamlVersionProbe.Probe(
+            yaml,
+            "manifestVersion",
+            WorkspaceManifest.CurrentVersion,
+            "Workspace manifest");
+        if (!versionProbe.Succeeded)
+        {
+            if (versionProbe.IsVersionContractFailure)
+            {
+                return new WorkspaceManifestLoadResult(
+                    null,
+                    new WorkspaceManifestValidationResult([
+                        new WorkspaceManifestIssue(
+                            nameof(WorkspaceManifest.ManifestVersion),
+                            versionProbe.Error ?? "Workspace manifest version is invalid.")
+                    ]));
+            }
+
+            return new WorkspaceManifestLoadResult(
+                null,
+                WorkspaceManifestValidationResult.Success,
+                versionProbe.Error ?? "Failed to inspect workspace manifest version.");
+        }
+
         try
         {
             var manifest = _deserializer.Deserialize<WorkspaceManifest>(yaml) ?? new WorkspaceManifest();

--- a/Editor/Workspace/WorkspaceProjectGenerator.cs
+++ b/Editor/Workspace/WorkspaceProjectGenerator.cs
@@ -8,6 +8,18 @@ public sealed record WorkspaceProjectGenerationResult(
 
 public sealed class WorkspaceProjectGenerator
 {
+    readonly WorkspaceGeneratedProjectStateService _generatedProjectState;
+
+    public WorkspaceProjectGenerator()
+        : this(new WorkspaceGeneratedProjectStateService())
+    {
+    }
+
+    public WorkspaceProjectGenerator(WorkspaceGeneratedProjectStateService generatedProjectState)
+    {
+        _generatedProjectState = generatedProjectState ?? throw new ArgumentNullException(nameof(generatedProjectState));
+    }
+
     public async Task<WorkspaceProjectGenerationResult> GenerateAsync(
         WorkspaceSession session,
         CancellationToken cancellationToken = default)
@@ -15,6 +27,10 @@ public sealed class WorkspaceProjectGenerator
         ArgumentNullException.ThrowIfNull(session);
 
         var componentsDirectory = Path.Combine(session.SourceDirectory, "Components");
+        var generatedStatePath = _generatedProjectState.GetStatePath(session.WorkspaceRoot);
+        var generatedStateDirectory = Path.GetDirectoryName(generatedStatePath)
+            ?? throw new InvalidOperationException($"Generated project state path has no directory: {generatedStatePath}");
+        var generatedState = _generatedProjectState.Serialize(session.Manifest);
         var generatedFiles = new Dictionary<string, string>
         {
             [Path.Combine(session.WorkspaceRoot, ".gitignore")] = BuildGitIgnore(session.Manifest),
@@ -24,12 +40,26 @@ public sealed class WorkspaceProjectGenerator
             [Path.Combine(session.SourceDirectory, "WorkspaceTypes.h")] = BuildWorkspaceTypesHeader(session.Manifest.LogicModuleName),
             [Path.Combine(session.SourceDirectory, "WorkspaceModule.cpp")] = BuildWorkspaceModuleSource(session.Manifest.LogicModuleName)
         };
+        var projectDirectories = GetProjectDirectories(session, componentsDirectory, generatedStateDirectory).ToArray();
 
-        foreach (var path in generatedFiles.Keys)
+        var generatedFilePaths = generatedFiles.Keys.Append(generatedStatePath).ToArray();
+        foreach (var path in generatedFilePaths)
         {
             EnsureInsideWorkspace(session.WorkspaceRoot, path);
             if (File.Exists(path) || Directory.Exists(path))
                 throw new InvalidOperationException($"Workspace project file already exists and will not be overwritten: {path}");
+        }
+
+        foreach (var directory in projectDirectories)
+        {
+            EnsureInsideWorkspace(session.WorkspaceRoot, directory);
+            var blockingFile = generatedFilePaths.FirstOrDefault(file =>
+                WorkspacePathPolicy.IsInsideRoot(file, directory));
+            if (blockingFile is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Workspace project directory conflicts with generated file '{blockingFile}': {directory}");
+            }
         }
 
         var createdFiles = new List<string>();
@@ -37,14 +67,15 @@ public sealed class WorkspaceProjectGenerator
 
         try
         {
-            foreach (var directory in GetProjectDirectories(session, componentsDirectory))
+            foreach (var directory in projectDirectories)
             {
-                EnsureInsideWorkspace(session.WorkspaceRoot, directory);
                 CreateDirectoryTracked(session.WorkspaceRoot, directory, createdDirectories);
             }
 
             foreach (var (path, content) in generatedFiles)
                 await WriteNewFileAsync(path, content, createdFiles, cancellationToken);
+
+            await WriteNewFileAsync(generatedStatePath, generatedState, createdFiles, cancellationToken);
 
             return new WorkspaceProjectGenerationResult(createdFiles.ToArray(), createdDirectories.ToArray());
         }
@@ -63,7 +94,10 @@ public sealed class WorkspaceProjectGenerator
         }
     }
 
-    static IEnumerable<string> GetProjectDirectories(WorkspaceSession session, string componentsDirectory)
+    static IEnumerable<string> GetProjectDirectories(
+        WorkspaceSession session,
+        string componentsDirectory,
+        string generatedStateDirectory)
     {
         yield return session.ContentDirectory;
         yield return session.SourceDirectory;
@@ -72,6 +106,7 @@ public sealed class WorkspaceProjectGenerator
         yield return session.CacheDirectory;
         yield return session.BuildDirectory;
         yield return session.LogicOutputDirectory;
+        yield return generatedStateDirectory;
     }
 
     static string BuildCMakeProject(WorkspaceSession session)
@@ -290,12 +325,22 @@ public sealed class WorkspaceProjectGenerator
         var ignoredPaths = new[] { manifest.CachePath, manifest.BuildPath, manifest.LogicOutputPath }
             .Select(WorkspaceManifestPaths.Normalize)
             .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Where(x => !string.Equals(
+                x,
+                WorkspaceGeneratedProjectStateService.StateDirectoryName,
+                WorkspacePathPolicy.PathComparison))
             .Select(x => $"/{x}/")
             .Distinct(StringComparer.Ordinal);
 
         return string.Join("\n", new[] { "# Sailor workspace build outputs" }
             .Concat(ignoredPaths)
-            .Concat(["/.vs/", "/.idea/", string.Empty]));
+            .Concat([
+                $"/{WorkspaceGeneratedProjectStateService.StateDirectoryName}/*",
+                $"!/{WorkspaceGeneratedProjectStateService.RelativePath}",
+                "/.vs/",
+                "/.idea/",
+                string.Empty
+            ]));
     }
 
     static async Task WriteNewFileAsync(

--- a/Editor/Workspace/WorkspaceUiContracts.cs
+++ b/Editor/Workspace/WorkspaceUiContracts.cs
@@ -12,7 +12,8 @@ public sealed record WorkspaceUiProjection(
     bool HasActiveWorkspace,
     IReadOnlyList<WorkspaceRecentItem> RecentWorkspaces,
     WorkspaceActivationPhase ActivationPhase = WorkspaceActivationPhase.Idle,
-    string? ActivationError = null)
+    string? ActivationError = null,
+    string? GeneratedProjectAttention = null)
 {
     public static WorkspaceUiProjection Empty { get; } = new("No workspace", "Repository fallback", false, []);
 
@@ -24,6 +25,7 @@ public sealed record WorkspaceUiProjection(
         WorkspaceActivationPhase.Committing or
         WorkspaceActivationPhase.Starting;
     public bool RequiresRepair => ActivationPhase == WorkspaceActivationPhase.Repair;
+    public bool HasGeneratedProjectAttention => !string.IsNullOrWhiteSpace(GeneratedProjectAttention);
 }
 
 public static class WorkspaceUiProjectionBuilder
@@ -60,7 +62,10 @@ public static class WorkspaceUiProjectionBuilder
             true,
             recent,
             activationPhase,
-            activationError);
+            activationError,
+            current.GeneratedProjectState.RequiresAttention
+                ? current.GeneratedProjectState.Guidance
+                : null);
     }
 
     static string CompactPath(string path)

--- a/Editor/Workspace/WorkspaceYamlVersionProbe.cs
+++ b/Editor/Workspace/WorkspaceYamlVersionProbe.cs
@@ -1,0 +1,163 @@
+using System.Globalization;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+
+namespace SailorEditor.Workspace;
+
+public enum WorkspaceYamlVersionProbeFailure
+{
+    None,
+    InvalidYaml,
+    InvalidDocument,
+    MissingVersion,
+    DuplicateVersion,
+    NonScalarVersion,
+    InvalidVersion,
+    UnsupportedVersion
+}
+
+public sealed record WorkspaceYamlVersionProbeResult(
+    int? Version,
+    string? Error,
+    WorkspaceYamlVersionProbeFailure Failure)
+{
+    public bool Succeeded =>
+        Version.HasValue &&
+        Error is null &&
+        Failure == WorkspaceYamlVersionProbeFailure.None;
+
+    public bool IsVersionContractFailure => Failure is
+        WorkspaceYamlVersionProbeFailure.MissingVersion or
+        WorkspaceYamlVersionProbeFailure.DuplicateVersion or
+        WorkspaceYamlVersionProbeFailure.NonScalarVersion or
+        WorkspaceYamlVersionProbeFailure.InvalidVersion or
+        WorkspaceYamlVersionProbeFailure.UnsupportedVersion;
+}
+
+public static class WorkspaceYamlVersionProbe
+{
+    public static WorkspaceYamlVersionProbeResult Probe(
+        string yaml,
+        string versionField,
+        int supportedVersion,
+        string documentName)
+    {
+        ArgumentNullException.ThrowIfNull(yaml);
+        ArgumentException.ThrowIfNullOrWhiteSpace(versionField);
+        ArgumentException.ThrowIfNullOrWhiteSpace(documentName);
+        if (supportedVersion <= 0)
+            throw new ArgumentOutOfRangeException(nameof(supportedVersion), "Supported YAML versions must be positive.");
+
+        try
+        {
+            using var reader = new StringReader(yaml);
+            var parser = new Parser(reader);
+            parser.Consume<StreamStart>();
+            if (!parser.TryConsume<DocumentStart>(out _))
+                return InvalidDocument(documentName);
+            if (!parser.TryConsume<MappingStart>(out _))
+                return InvalidDocument(documentName);
+
+            var versionOccurrences = 0;
+            var versionWasNonScalar = false;
+            string? rawVersion = null;
+            while (!parser.Accept<MappingEnd>(out _))
+            {
+                if (!parser.TryConsume<Scalar>(out var key))
+                {
+                    parser.SkipThisAndNestedEvents();
+                    parser.SkipThisAndNestedEvents();
+                    continue;
+                }
+
+                if (!string.Equals(key.Value, versionField, StringComparison.Ordinal))
+                {
+                    parser.SkipThisAndNestedEvents();
+                    continue;
+                }
+
+                versionOccurrences++;
+                if (parser.TryConsume<Scalar>(out var value))
+                {
+                    rawVersion ??= value.Value;
+                }
+                else
+                {
+                    versionWasNonScalar = true;
+                    parser.SkipThisAndNestedEvents();
+                }
+            }
+
+            parser.Consume<MappingEnd>();
+            parser.Consume<DocumentEnd>();
+            if (!parser.TryConsume<StreamEnd>(out _))
+            {
+                return new WorkspaceYamlVersionProbeResult(
+                    null,
+                    $"{documentName} must contain exactly one YAML document.",
+                    WorkspaceYamlVersionProbeFailure.InvalidDocument);
+            }
+
+            if (versionOccurrences == 0)
+            {
+                return new WorkspaceYamlVersionProbeResult(
+                    null,
+                    $"{documentName} field '{versionField}' is required.",
+                    WorkspaceYamlVersionProbeFailure.MissingVersion);
+            }
+            if (versionOccurrences > 1)
+            {
+                return new WorkspaceYamlVersionProbeResult(
+                    null,
+                    $"{documentName} contains duplicate field '{versionField}'.",
+                    WorkspaceYamlVersionProbeFailure.DuplicateVersion);
+            }
+            if (versionWasNonScalar)
+            {
+                return new WorkspaceYamlVersionProbeResult(
+                    null,
+                    $"{documentName} field '{versionField}' must be a scalar integer.",
+                    WorkspaceYamlVersionProbeFailure.NonScalarVersion);
+            }
+            if (!int.TryParse(rawVersion, NumberStyles.Integer, CultureInfo.InvariantCulture, out var version))
+            {
+                return new WorkspaceYamlVersionProbeResult(
+                    null,
+                    $"{documentName} field '{versionField}' must be a positive integer.",
+                    WorkspaceYamlVersionProbeFailure.InvalidVersion);
+            }
+            if (version <= 0)
+            {
+                return new WorkspaceYamlVersionProbeResult(
+                    version,
+                    $"{documentName} field '{versionField}' must be greater than zero.",
+                    WorkspaceYamlVersionProbeFailure.InvalidVersion);
+            }
+            if (version != supportedVersion)
+            {
+                return new WorkspaceYamlVersionProbeResult(
+                    version,
+                    $"Unsupported {documentName.ToLowerInvariant()} version '{version}'. Supported version is '{supportedVersion}'.",
+                    WorkspaceYamlVersionProbeFailure.UnsupportedVersion);
+            }
+
+            return new WorkspaceYamlVersionProbeResult(
+                version,
+                null,
+                WorkspaceYamlVersionProbeFailure.None);
+        }
+        catch (YamlException ex)
+        {
+            return new WorkspaceYamlVersionProbeResult(
+                null,
+                $"{documentName} is invalid YAML: {ex.Message}",
+                WorkspaceYamlVersionProbeFailure.InvalidYaml);
+        }
+    }
+
+    static WorkspaceYamlVersionProbeResult InvalidDocument(string documentName)
+        => new(
+            null,
+            $"{documentName} must contain a top-level YAML mapping.",
+            WorkspaceYamlVersionProbeFailure.InvalidDocument);
+}

--- a/Runtime/Workspace/WorkspaceContext.cpp
+++ b/Runtime/Workspace/WorkspaceContext.cpp
@@ -250,6 +250,66 @@ namespace
 		return true;
 	}
 
+	bool ReadManifestVersion(
+		const YAML::Node& document,
+		const std::filesystem::path& manifestPath,
+		uint32_t& outVersion,
+		std::string& outError)
+	{
+		if (!document.IsMap())
+		{
+			outError = "Workspace manifest must contain a YAML map.";
+			return false;
+		}
+
+		YAML::Node version;
+		size_t versionCount = 0;
+		for (const auto& field : document)
+		{
+			if (field.first.IsScalar() && field.first.Scalar() == "manifestVersion")
+			{
+				version = field.second;
+				++versionCount;
+			}
+		}
+
+		if (versionCount == 0)
+		{
+			outError = "Workspace manifest field 'manifestVersion' is required.";
+			return false;
+		}
+		if (versionCount > 1)
+		{
+			outError = "Workspace manifest contains duplicate field 'manifestVersion'.";
+			return false;
+		}
+		if (version.IsNull() || !version.IsScalar())
+		{
+			outError = "Workspace manifest field 'manifestVersion' must be an unsigned integer scalar.";
+			return false;
+		}
+
+		try
+		{
+			outVersion = version.as<uint32_t>();
+		}
+		catch (const YAML::Exception&)
+		{
+			outError = "Workspace manifest field 'manifestVersion' must be an unsigned integer scalar.";
+			return false;
+		}
+
+		if (outVersion != SupportedManifestVersion)
+		{
+			outError = "Workspace manifest '" + PathToUtf8(manifestPath) +
+				"' has unsupported manifestVersion '" +
+				std::to_string(outVersion) + "'.";
+			return false;
+		}
+
+		return true;
+	}
+
 	bool ReadScalarField(
 		const YAML::Node& document,
 		const char* fieldName,
@@ -258,7 +318,7 @@ namespace
 		std::string& outError)
 	{
 		const YAML::Node field = FindField(document, fieldName);
-		if (!field.IsDefined() || field.IsNull())
+		if (!field.IsDefined())
 		{
 			if (bRequired)
 			{
@@ -267,16 +327,18 @@ namespace
 			}
 			return true;
 		}
-		if (!field.IsScalar())
+		if (field.IsNull() || !field.IsScalar())
 		{
 			outError = "Workspace manifest field '" + std::string(fieldName) + "' must be scalar.";
 			return false;
 		}
 
 		outValue = Trim(field.Scalar());
-		if (bRequired && outValue.empty())
+		if (outValue.empty())
 		{
-			outError = "Workspace manifest field '" + std::string(fieldName) + "' is required.";
+			outError = bRequired
+				? "Workspace manifest field '" + std::string(fieldName) + "' is required."
+				: "Workspace manifest field '" + std::string(fieldName) + "' must not be empty.";
 			return false;
 		}
 		return true;
@@ -312,23 +374,16 @@ namespace
 		}
 
 		const YAML::Node document = YAML::Load(payload);
+		if (!ReadManifestVersion(
+				document,
+				manifestPath,
+				outFields.m_manifestVersion,
+				outError))
+		{
+			return false;
+		}
 		if (!ValidateManifestMap(document, outError))
 		{
-			return false;
-		}
-
-		const YAML::Node version = FindField(document, "manifestVersion");
-		if (!version.IsDefined() || !version.IsScalar())
-		{
-			outError = "Workspace manifest field 'manifestVersion' must be scalar.";
-			return false;
-		}
-		outFields.m_manifestVersion = version.as<uint32_t>();
-		if (outFields.m_manifestVersion != SupportedManifestVersion)
-		{
-			outError = "Workspace manifest '" + PathToUtf8(manifestPath) +
-				"' has unsupported manifestVersion '" +
-				std::to_string(outFields.m_manifestVersion) + "'.";
 			return false;
 		}
 
@@ -347,18 +402,6 @@ namespace
 			return false;
 		}
 
-		if (outFields.m_build.empty())
-		{
-			outFields.m_build = DefaultBuildPath;
-		}
-		if (outFields.m_logicOutput.empty())
-		{
-			outFields.m_logicOutput = DefaultLogicOutputPath;
-		}
-		if (outFields.m_moduleName.empty())
-		{
-			outFields.m_moduleName = DefaultModuleName;
-		}
 		if (!IsCIdentifier(outFields.m_moduleName))
 		{
 			outError = "Workspace manifest logicModuleName '" + outFields.m_moduleName +

--- a/Tests/WorkspaceContextTests.cpp
+++ b/Tests/WorkspaceContextTests.cpp
@@ -24,6 +24,9 @@ namespace
 		std::string m_enginePath = "Engine";
 		std::string m_engineReferenceKind = "source";
 		bool m_includeEngineReferenceKind = true;
+		bool m_includeBuildPath = true;
+		bool m_includeLogicOutputPath = true;
+		bool m_includeLogicModuleName = true;
 		bool m_createEngineContent = true;
 		std::string m_content = "Content";
 		std::string m_cache = "Cache";
@@ -108,9 +111,18 @@ namespace
 		manifest["cachePath"] = spec.m_cache;
 		manifest["sourcePath"] = spec.m_source;
 		manifest["generatedProjectPath"] = spec.m_generated;
-		manifest["buildPath"] = spec.m_build;
-		manifest["logicOutputPath"] = spec.m_logicOutput;
-		manifest["logicModuleName"] = spec.m_moduleName;
+		if (spec.m_includeBuildPath)
+		{
+			manifest["buildPath"] = spec.m_build;
+		}
+		if (spec.m_includeLogicOutputPath)
+		{
+			manifest["logicOutputPath"] = spec.m_logicOutput;
+		}
+		if (spec.m_includeLogicModuleName)
+		{
+			manifest["logicModuleName"] = spec.m_moduleName;
+		}
 
 		std::ofstream output(path);
 		output << manifest;
@@ -122,6 +134,52 @@ namespace
 		std::ofstream output(path);
 		output << value;
 		Require(output.good(), "test file should be writable: " + PathToUtf8(path));
+	}
+
+	std::string BuildManifestPayload(
+		const std::string& versionDeclaration,
+		const std::string& overriddenField = {},
+		const std::string& overriddenValue = {})
+	{
+		std::string payload = versionDeclaration;
+		auto appendField = [&](const char* fieldName, const char* defaultValue)
+		{
+			payload += fieldName;
+			payload += ": ";
+			payload += overriddenField == fieldName ? overriddenValue : defaultValue;
+			payload += '\n';
+		};
+
+		appendField("workspaceId", "workspace-id");
+		appendField("name", "Sandbox");
+		appendField("enginePath", "Engine");
+		appendField("engineReferenceKind", "source");
+		appendField("contentPath", "Content");
+		appendField("cachePath", "Cache");
+		appendField("sourcePath", "Source");
+		appendField("generatedProjectPath", "Generated");
+		appendField("buildPath", "Cache/Build");
+		appendField("logicOutputPath", "Binaries");
+		appendField("logicModuleName", "SailorGame");
+		return payload;
+	}
+
+	void RequireManifestRejectedWithoutMutation(
+		const WorkspaceContextResolveResult& result,
+		const TempDirectory& workspace,
+		const std::string& scenario)
+	{
+		Require(result.m_status == EWorkspaceContextResolveStatus::ManifestInvalid,
+			scenario + " should be rejected as an invalid manifest: " + result.m_message);
+		Require(!result.IsSuccess(), scenario + " must not publish a successful context");
+		Require(result.m_context.GetRoot().empty(),
+			scenario + " must not publish a partial context");
+		Require(result.m_context.GetManifest().empty(),
+			scenario + " must not publish a manifest path");
+		Require(!std::filesystem::exists(workspace.Path("Content")),
+			scenario + " must be rejected before Content recovery");
+		Require(!std::filesystem::exists(workspace.Path("Cache")),
+			scenario + " must be rejected before Cache recovery");
 	}
 
 	void TestLegacyFallbackAndRecovery()
@@ -242,17 +300,70 @@ namespace
 			"missing default manifest Cache should be created");
 	}
 
-	void TestManifestDefaultsMissingEngineReferenceKindToSource()
+	void TestManifestDefaultsMissingOptionalV1Fields()
 	{
-		TempDirectory workspace("default-engine-reference");
+		TempDirectory workspace("default-optional-fields");
 		ManifestSpec spec;
 		spec.m_includeEngineReferenceKind = false;
+		spec.m_includeBuildPath = false;
+		spec.m_includeLogicOutputPath = false;
+		spec.m_includeLogicModuleName = false;
 		WriteManifest(workspace.Path("workspace.sailor"), spec);
 
 		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
 
 		Require(result.IsSuccess(),
-			"v1 manifest without engineReferenceKind should default to source: " + result.m_message);
+			"v1 manifest without optional fields should use v1 defaults: " + result.m_message);
+		Require(result.m_context.GetBuild() ==
+			std::filesystem::weakly_canonical(workspace.Path("Cache/Build")),
+			"missing buildPath should default to Cache/Build");
+		Require(result.m_context.GetLogicOutput() ==
+			std::filesystem::weakly_canonical(workspace.Path("Binaries")),
+			"missing logicOutputPath should default to Binaries");
+		Require(result.m_context.GetModuleName() == "SailorGame",
+			"missing logicModuleName should default to SailorGame");
+	}
+
+	void TestExplicitOptionalFieldsAreInvalid()
+	{
+		const std::vector<std::string> fields
+		{
+			"engineReferenceKind",
+			"buildPath",
+			"logicOutputPath",
+			"logicModuleName"
+		};
+		struct InvalidValue
+		{
+			const char* m_label;
+			const char* m_yaml;
+		};
+		const std::vector<InvalidValue> invalidValues
+		{
+			{ "null", "null" },
+			{ "empty", "''" }
+		};
+
+		for (const std::string& field : fields)
+		{
+			for (const InvalidValue& invalidValue : invalidValues)
+			{
+				const std::string scenario = "explicit-" + std::string(invalidValue.m_label) + "-" + field;
+				TempDirectory workspace(scenario.c_str());
+				WriteText(
+					workspace.Path("workspace.sailor"),
+					BuildManifestPayload(
+						"manifestVersion: 1\n",
+						field,
+						invalidValue.m_yaml));
+
+				const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+				RequireManifestRejectedWithoutMutation(result, workspace, scenario);
+				Require(result.m_message.find(field) != std::string::npos,
+					scenario + " diagnostic should identify its field: " + result.m_message);
+			}
+		}
 	}
 
 	void TestRelativeEnginePathOutsideWorkspace()
@@ -387,6 +498,58 @@ namespace
 		Require(result.m_context.GetRoot().empty(), "failed recovery should not publish a partial context");
 	}
 
+	void TestManifestVersionPreflightDoesNotMutateWorkspace()
+	{
+		struct InvalidVersion
+		{
+			const char* m_label;
+			const char* m_declaration;
+			const char* m_expectedDiagnostic;
+		};
+		const std::vector<InvalidVersion> invalidVersions
+		{
+			{ "missing-version", "", "required" },
+			{ "zero-version", "manifestVersion: 0\n", "unsupported manifestVersion" },
+			{ "future-version", "manifestVersion: 999\n", "unsupported manifestVersion" },
+			{ "duplicate-version", "manifestVersion: 1\nmanifestVersion: 1\n", "duplicate" },
+			{ "non-scalar-version", "manifestVersion: [1]\n", "unsigned integer scalar" }
+		};
+
+		for (const InvalidVersion& invalidVersion : invalidVersions)
+		{
+			TempDirectory workspace(invalidVersion.m_label);
+			WriteText(
+				workspace.Path("workspace.sailor"),
+				BuildManifestPayload(invalidVersion.m_declaration));
+
+			const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+			RequireManifestRejectedWithoutMutation(result, workspace, invalidVersion.m_label);
+			Require(result.m_message.find("manifestVersion") != std::string::npos,
+				std::string(invalidVersion.m_label) +
+					" diagnostic should identify manifestVersion: " + result.m_message);
+			Require(result.m_message.find(invalidVersion.m_expectedDiagnostic) != std::string::npos,
+				std::string(invalidVersion.m_label) +
+					" diagnostic should explain the version failure: " + result.m_message);
+		}
+
+		TempDirectory workspace("future-version-precedence");
+		WriteText(
+			workspace.Path("workspace.sailor"),
+			BuildManifestPayload(
+				"manifestVersion: 999\n",
+				"workspaceId",
+				"[malformed, later, field]"));
+
+		const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
+
+		RequireManifestRejectedWithoutMutation(result, workspace, "future-version-precedence");
+		Require(result.m_message.find("unsupported manifestVersion '999'") != std::string::npos,
+			"future manifest diagnostic should precede malformed later fields: " + result.m_message);
+		Require(result.m_message.find("workspaceId") == std::string::npos,
+			"future manifest diagnostic must not be replaced by later field validation");
+	}
+
 	void TestManifestDiscoveryFailures()
 	{
 		{
@@ -409,18 +572,6 @@ namespace
 				"corrupt manifest should be rejected: " + result.m_message);
 			Require(result.m_message.find("invalid YAML") != std::string::npos,
 				"corrupt manifest should produce an actionable YAML diagnostic");
-		}
-		{
-			TempDirectory workspace("future-version");
-			ManifestSpec spec;
-			spec.m_version = 999;
-			WriteManifest(workspace.Path("workspace.sailor"), spec);
-
-			const WorkspaceContextResolveResult result = ResolveWorkspaceContext(workspace.Get());
-			Require(result.m_status == EWorkspaceContextResolveStatus::ManifestInvalid,
-				"future manifest version should be rejected: " + result.m_message);
-			Require(result.m_message.find("unsupported manifestVersion") != std::string::npos,
-				"future version diagnostic should identify the version contract");
 		}
 		{
 			TempDirectory workspace("missing-id");
@@ -560,13 +711,15 @@ int main()
 		TestUtf8CommandLinePathConversion();
 		TestManifestPathsWithSpaces();
 		TestManifestDefaultRecovery();
-		TestManifestDefaultsMissingEngineReferenceKindToSource();
+		TestManifestDefaultsMissingOptionalV1Fields();
+		TestExplicitOptionalFieldsAreInvalid();
 		TestRelativeEnginePathOutsideWorkspace();
 		TestAbsoluteEnginePath();
 		TestMissingEngineContentDoesNotMutateWorkspace();
 		TestMissingInstalledEngineContentHasTargetedDiagnostic();
 		TestMissingCustomContentDoesNotMutateWorkspace();
 		TestRecoveryRollbackOnLaterFailure();
+		TestManifestVersionPreflightDoesNotMutateWorkspace();
 		TestManifestDiscoveryFailures();
 		TestUnsafeOwnedPaths();
 		TestPhysicalEscape();


### PR DESCRIPTION
Closes #103
Parent hardening issue: #82
Parent epic: #72

## Summary

- add source-controlled .sailor/GeneratedProjectState.yaml metadata with deterministic Current, Untracked, Stale, and Invalid assessment
- make workspace manifest and generated-state version probing happen before typed deserialization or filesystem/session mutation
- keep generated CMake and source files user-owned: Open and Save assess only and never backfill or regenerate them
- write generated state last during workspace creation with collision preflight, CreateNew semantics, rollback, and source-control-safe .gitignore rules
- surface non-blocking generated-state guidance in the editor and document the v1 compatibility and future migration contract
- align native runtime defaults and explicit null/empty rejection with the managed editor

## Validation

- Editor contracts: 359/359 passed
- WorkspaceContextTests: passed
- MAUI net10.0-maccatalyst Debug build: passed, 0 warnings, 0 errors
- full native CTest: 14/15 passed; the only failure is the pre-existing unrelated RemoteViewportMacTransportTests.ConcreteMacLoopbackProviderRecordsRendererOwnedSourceMetadata case
- git diff --check: passed

## Risk

Medium. The change affects manifest loading, workspace lifecycle preflight, generated project creation, and native runtime manifest parsing. Focused no-mutation, rollback, stale-state, path-containment, version-precedence, and managed/native parity contracts cover these boundaries.