### PR TITLE
[Editor] Add screenshot smoke test

### DIFF
--- a/.github/workflows/editor-build.yml
+++ b/.github/workflows/editor-build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-editor:
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -33,7 +33,7 @@ jobs:
       - name: Publish unpackaged Editor (Windows)
         shell: pwsh
         run: |
-          $publishDirectory = Join-Path $env:RUNNER_TEMP 'SailorEditorPublish'
+          $publishDirectory = Join-Path $env:GITHUB_WORKSPACE 'Binaries\EditorScreenshotPublish'
           if (Test-Path $publishDirectory) {
             Remove-Item $publishDirectory -Recurse -Force
           }
@@ -50,7 +50,7 @@ jobs:
         shell: pwsh
         run: |
           ./Editor.Tests/Visual/RunEditorScreenshotTest.ps1 `
-            -EditorExecutable (Join-Path $env:RUNNER_TEMP 'SailorEditorPublish\SailorEditor.exe') `
+            -EditorExecutable (Join-Path $env:GITHUB_WORKSPACE 'Binaries\EditorScreenshotPublish\SailorEditor.exe') `
             -OutputDirectory (Join-Path $env:GITHUB_WORKSPACE 'Binaries\EditorScreenshot') `
             -TimeoutSeconds 120
 

--- a/.github/workflows/editor-build.yml
+++ b/.github/workflows/editor-build.yml
@@ -46,6 +46,32 @@ jobs:
             -p:WindowsPackageType=None `
             -p:WindowsAppSDKSelfContained=true
 
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+
+          $evidenceDirectory = Join-Path $env:GITHUB_WORKSPACE 'Binaries\EditorScreenshot'
+          [System.IO.Directory]::CreateDirectory($evidenceDirectory) | Out-Null
+          Get-ChildItem -LiteralPath $publishDirectory -Recurse -File |
+            Sort-Object FullName |
+            ForEach-Object {
+              $relativePath = [System.IO.Path]::GetRelativePath($publishDirectory, $_.FullName)
+              "{0}`t{1}" -f $relativePath, $_.Length
+            } |
+            Set-Content `
+              -LiteralPath (Join-Path $evidenceDirectory 'editor-screenshot.publish-files.log') `
+              -Encoding utf8NoBOM
+
+          foreach ($requiredFile in @(
+            'Microsoft.UI.Xaml.Controls.pri',
+            'Microsoft.UI.Xaml.Controls.dll',
+            'Microsoft.ui.xaml.dll')) {
+            $requiredPath = Join-Path $publishDirectory $requiredFile
+            if (-not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+              throw "Self-contained Windows App SDK publish is missing '$requiredFile'."
+            }
+          }
+
       - name: Run Editor screenshot smoke test
         shell: pwsh
         run: |

--- a/.github/workflows/editor-build.yml
+++ b/.github/workflows/editor-build.yml
@@ -17,10 +17,51 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: '10.0.x'
+          dotnet-version: |
+            9.0.x
+            10.0.x
 
       - name: Install MAUI workload
         run: dotnet workload install maui
 
+      - name: Test Editor contracts
+        run: dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --configuration Release
+
       - name: Build Editor (Windows)
         run: dotnet build Editor/SailorEditor.csproj -c Release -f net10.0-windows10.0.19041.0
+
+      - name: Publish unpackaged Editor (Windows)
+        shell: pwsh
+        run: |
+          $publishDirectory = Join-Path $env:RUNNER_TEMP 'SailorEditorPublish'
+          if (Test-Path $publishDirectory) {
+            Remove-Item $publishDirectory -Recurse -Force
+          }
+
+          dotnet publish Editor/SailorEditor.csproj `
+            --configuration Release `
+            --framework net10.0-windows10.0.19041.0 `
+            --output $publishDirectory `
+            -p:RuntimeIdentifierOverride=win-x64 `
+            -p:WindowsPackageType=None `
+            -p:WindowsAppSDKSelfContained=true
+
+      - name: Run Editor screenshot smoke test
+        shell: pwsh
+        run: |
+          ./Editor.Tests/Visual/RunEditorScreenshotTest.ps1 `
+            -EditorExecutable (Join-Path $env:RUNNER_TEMP 'SailorEditorPublish\SailorEditor.exe') `
+            -OutputDirectory (Join-Path $env:GITHUB_WORKSPACE 'Binaries\EditorScreenshot') `
+            -TimeoutSeconds 120
+
+      - name: Upload Editor screenshot evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: editor-screenshot-windows
+          path: |
+            Binaries/EditorScreenshot/*.png
+            Binaries/EditorScreenshot/*.json
+            Binaries/EditorScreenshot/*.log
+          if-no-files-found: warn
+          retention-days: 14

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="EditorDragDropRoutingTests.cs" />
     <Compile Include="EditorDragDropTestStubs.cs" />
     <Compile Include="EditorPerfTests.cs" />
+    <Compile Include="EditorScreenshotTestOptionsTests.cs" />
     <Compile Include="EngineLaunchContractTests.cs" />
     <Compile Include="EngineLifecycleTests.cs" />
     <Compile Include="EditorTypeCacheStoreTests.cs" />
@@ -99,6 +100,7 @@
     <Compile Include="..\Editor\Workflow\InspectorAutoCommitController.cs" Link="Workflow\InspectorAutoCommitController.cs" />
     <Compile Include="..\Editor\Utility\EditorDragDrop.cs" Link="Utility\EditorDragDrop.cs" />
     <Compile Include="..\Editor\Utility\EditorPerf.cs" Link="Utility\EditorPerf.cs" />
+    <Compile Include="..\Editor\Testing\EditorScreenshotTestOptions.cs" Link="Testing\EditorScreenshotTestOptions.cs" />
     <Compile Include="..\Editor\Services\EngineLaunchContract.cs" Link="Services\EngineLaunchContract.cs" />
     <Compile Include="..\Editor\Services\EditorTypeCacheStore.cs" Link="Services\EditorTypeCacheStore.cs" />
     <Compile Include="..\Editor\Services\Utf8InteropArguments.cs" Link="Services\Utf8InteropArguments.cs" />

--- a/Editor.Tests/EditorScreenshotTestOptionsTests.cs
+++ b/Editor.Tests/EditorScreenshotTestOptionsTests.cs
@@ -1,0 +1,91 @@
+using SailorEditor.Testing;
+
+namespace Editor.Tests;
+
+public sealed class EditorScreenshotTestOptionsTests
+{
+    [Fact]
+    public void Parse_DisablesScreenshotModeWhenOptionIsAbsent()
+    {
+        var options = EditorScreenshotTestOptions.Parse(
+            ["SailorEditor.exe", "--workspace=/tmp/project", "--editor"]);
+
+        Assert.False(options.IsEnabled);
+        Assert.Null(options.ScreenshotPath);
+        Assert.Null(options.StateDirectory);
+        Assert.Null(options.ResultPath);
+    }
+
+    [Fact]
+    public void Parse_NormalizesOutputAndDerivesAdjacentAutomationPaths()
+    {
+        var requestedPath = Path.Combine(
+            Path.GetTempPath(),
+            "sailor-screenshot-tests",
+            "intermediate",
+            "..",
+            "captures",
+            "Editor Main.PNG");
+        var expectedPath = Path.GetFullPath(requestedPath);
+        var expectedDirectory = Path.GetDirectoryName(expectedPath)!;
+
+        var options = EditorScreenshotTestOptions.Parse(
+            ["SailorEditor.exe", "--unrelated", $"--editor-screenshot={requestedPath}"]);
+
+        Assert.True(options.IsEnabled);
+        Assert.Equal(expectedPath, options.ScreenshotPath);
+        Assert.Equal(Path.Combine(expectedDirectory, ".screenshot-state"), options.StateDirectory);
+        Assert.Equal(Path.Combine(expectedDirectory, "Editor Main.result.json"), options.ResultPath);
+    }
+
+    [Theory]
+    [InlineData("--editor-screenshot")]
+    [InlineData("--editor-screenshot=")]
+    [InlineData("--editor-screenshot=   ")]
+    public void Parse_RejectsMissingOutputPath(string argument)
+    {
+        var error = Assert.Throws<ArgumentException>(
+            () => EditorScreenshotTestOptions.Parse(["SailorEditor.exe", argument]));
+
+        Assert.Contains("absolute PNG output path", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_RejectsRelativeOutputPath()
+    {
+        var error = Assert.Throws<ArgumentException>(
+            () => EditorScreenshotTestOptions.Parse(
+                ["SailorEditor.exe", $"--editor-screenshot={Path.Combine("captures", "editor.png")}"]));
+
+        Assert.Contains("must be absolute", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_RejectsDuplicateOption()
+    {
+        var firstPath = Path.Combine(Path.GetTempPath(), "first.png");
+        var secondPath = Path.Combine(Path.GetTempPath(), "second.png");
+
+        var error = Assert.Throws<ArgumentException>(
+            () => EditorScreenshotTestOptions.Parse(
+            [
+                "SailorEditor.exe",
+                $"--editor-screenshot={firstPath}",
+                $"--editor-screenshot={secondPath}"
+            ]));
+
+        Assert.Contains("may only be specified once", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Parse_RejectsNonPngOutputPath()
+    {
+        var outputPath = Path.Combine(Path.GetTempPath(), "editor.jpg");
+
+        var error = Assert.Throws<ArgumentException>(
+            () => EditorScreenshotTestOptions.Parse(
+                ["SailorEditor.exe", $"--editor-screenshot={outputPath}"]));
+
+        Assert.Contains("must name a PNG file", error.Message, StringComparison.Ordinal);
+    }
+}

--- a/Editor.Tests/Visual/RunEditorScreenshotTest.ps1
+++ b/Editor.Tests/Visual/RunEditorScreenshotTest.ps1
@@ -24,11 +24,20 @@ $resultPath = [System.IO.Path]::ChangeExtension($screenshotPath, '.result.json')
 $stdoutPath = Join-Path $outputPath 'editor-screenshot.stdout.log'
 $stderrPath = Join-Path $outputPath 'editor-screenshot.stderr.log'
 $runnerLogPath = Join-Path $outputPath 'editor-screenshot.runner.log'
+$startupLogPath = Join-Path $outputPath 'editor-screenshot.startup.log'
+$windowsEventsPath = Join-Path $outputPath 'editor-screenshot.windows-events.log'
 $stateDirectory = Join-Path $outputPath '.screenshot-state'
 
 [System.IO.Directory]::CreateDirectory($outputPath) | Out-Null
 
-foreach ($path in @($screenshotPath, $resultPath, $stdoutPath, $stderrPath, $runnerLogPath)) {
+foreach ($path in @(
+    $screenshotPath,
+    $resultPath,
+    $stdoutPath,
+    $stderrPath,
+    $runnerLogPath,
+    $startupLogPath,
+    $windowsEventsPath)) {
     if ([System.IO.File]::Exists($path)) {
         [System.IO.File]::Delete($path)
     }
@@ -163,8 +172,78 @@ function Read-PngEvidence {
     }
 }
 
+function Write-WindowsEventDiagnostics {
+    param(
+        [Parameter(Mandatory)]
+        [System.DateTimeOffset] $StartedAt,
+
+        [Parameter(Mandatory)]
+        [string] $ProcessName
+    )
+
+    Start-Sleep -Seconds 2
+    $knownProviders = @(
+        'Application Error',
+        '.NET Runtime',
+        'Windows Error Reporting',
+        'Microsoft-Windows-AppModel-Runtime'
+    )
+    $processPattern = [System.Text.RegularExpressions.Regex]::Escape($ProcessName)
+    $sections = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($logName in @('Application', 'Microsoft-Windows-AppModel-Runtime/Admin')) {
+        try {
+            $events = @(
+                Get-WinEvent `
+                    -FilterHashtable @{
+                        LogName = $logName
+                        StartTime = $StartedAt.UtcDateTime
+                    } `
+                    -ErrorAction Stop |
+                    Where-Object {
+                        $knownProviders -contains $_.ProviderName -or
+                        $_.Message -match $processPattern
+                    } |
+                    Sort-Object TimeCreated |
+                    Select-Object -Last 50
+            )
+
+            if ($events.Count -eq 0) {
+                $sections.Add("=== $logName ===$([Environment]::NewLine)No matching events.")
+                continue
+            }
+
+            $eventEntries = foreach ($event in $events) {
+                @(
+                    "TimeCreated: $($event.TimeCreated.ToUniversalTime().ToString('O'))"
+                    "ProviderName: $($event.ProviderName)"
+                    "Id: $($event.Id)"
+                    "Level: $($event.LevelDisplayName)"
+                    'Message:'
+                    $event.Message
+                    'Raw XML:'
+                    $event.ToXml()
+                ) -join [Environment]::NewLine
+            }
+            $eventText = $eventEntries -join (
+                "$([Environment]::NewLine)$([Environment]::NewLine)---$([Environment]::NewLine)")
+            $sections.Add("=== $logName ===$([Environment]::NewLine)$eventText")
+        }
+        catch {
+            $sections.Add(
+                "=== $logName ===$([Environment]::NewLine)Could not query log: $($_.Exception.Message)")
+        }
+    }
+
+    [System.IO.File]::WriteAllText(
+        $windowsEventsPath,
+        [string]::Join("$([Environment]::NewLine)$([Environment]::NewLine)", $sections),
+        $utf8WithoutBom)
+}
+
 $process = $null
 $processStarted = $false
+$processStartedAt = $null
 $stdoutTask = $null
 $stderrTask = $null
 $failure = $null
@@ -194,9 +273,11 @@ try {
     $startInfo.RedirectStandardError = $true
     $startInfo.CreateNoWindow = $false
     $startInfo.ArgumentList.Add("--editor-screenshot=$screenshotPath")
+    $startInfo.Environment['SAILOR_EDITOR_STARTUP_LOG'] = $startupLogPath
 
     $process = [System.Diagnostics.Process]::new()
     $process.StartInfo = $startInfo
+    $processStartedAt = [System.DateTimeOffset]::UtcNow
     if (-not $process.Start()) {
         throw "Failed to start Editor executable: $editorPath"
     }
@@ -329,6 +410,29 @@ try {
 catch {
     $failure = $_
     Write-RunnerLog "FAILED: $($_.Exception.Message)"
+
+    if ($null -ne $processStartedAt) {
+        try {
+            Write-WindowsEventDiagnostics `
+                -StartedAt $processStartedAt `
+                -ProcessName ([System.IO.Path]::GetFileName($editorPath))
+            Write-RunnerLog "Windows event diagnostics: $windowsEventsPath"
+            Write-Host ([System.IO.File]::ReadAllText($windowsEventsPath, $utf8WithoutBom))
+        }
+        catch {
+            Write-RunnerLog "Could not collect Windows event diagnostics: $($_.Exception.Message)"
+        }
+    }
+
+    if ([System.IO.File]::Exists($startupLogPath)) {
+        try {
+            Write-RunnerLog "Editor startup diagnostics: $startupLogPath"
+            Write-Host ([System.IO.File]::ReadAllText($startupLogPath, $utf8WithoutBom))
+        }
+        catch {
+            Write-RunnerLog "Could not read Editor startup diagnostics: $($_.Exception.Message)"
+        }
+    }
 }
 finally {
     if ($processStarted -and $null -ne $process) {

--- a/Editor.Tests/Visual/RunEditorScreenshotTest.ps1
+++ b/Editor.Tests/Visual/RunEditorScreenshotTest.ps1
@@ -1,0 +1,391 @@
+#Requires -Version 7.0
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $EditorExecutable,
+
+    [Parameter(Mandatory)]
+    [ValidateNotNullOrEmpty()]
+    [string] $OutputDirectory,
+
+    [ValidateRange(1, 900)]
+    [int] $TimeoutSeconds = 120
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$utf8WithoutBom = [System.Text.UTF8Encoding]::new($false)
+$outputPath = [System.IO.Path]::GetFullPath($OutputDirectory)
+$screenshotPath = Join-Path $outputPath 'editor-screenshot.png'
+$resultPath = [System.IO.Path]::ChangeExtension($screenshotPath, '.result.json')
+$stdoutPath = Join-Path $outputPath 'editor-screenshot.stdout.log'
+$stderrPath = Join-Path $outputPath 'editor-screenshot.stderr.log'
+$runnerLogPath = Join-Path $outputPath 'editor-screenshot.runner.log'
+$stateDirectory = Join-Path $outputPath '.screenshot-state'
+
+[System.IO.Directory]::CreateDirectory($outputPath) | Out-Null
+
+foreach ($path in @($screenshotPath, $resultPath, $stdoutPath, $stderrPath, $runnerLogPath)) {
+    if ([System.IO.File]::Exists($path)) {
+        [System.IO.File]::Delete($path)
+    }
+}
+
+[System.IO.File]::WriteAllText($stdoutPath, [string]::Empty, $utf8WithoutBom)
+[System.IO.File]::WriteAllText($stderrPath, [string]::Empty, $utf8WithoutBom)
+
+function Write-RunnerLog {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Message
+    )
+
+    $line = '{0:O} {1}' -f [System.DateTimeOffset]::UtcNow, $Message
+    [System.IO.File]::AppendAllText($runnerLogPath, "$line$([Environment]::NewLine)", $utf8WithoutBom)
+    Write-Host $line
+}
+
+function Get-RequiredJsonProperty {
+    param(
+        [Parameter(Mandatory)]
+        [psobject] $JsonObject,
+
+        [Parameter(Mandatory)]
+        [string] $Name
+    )
+
+    $property = $JsonObject.PSObject.Properties[$Name]
+    if ($null -eq $property) {
+        throw "Screenshot result is missing required property '$Name'."
+    }
+
+    return $property.Value
+}
+
+function ConvertTo-ResultInt64 {
+    param(
+        [AllowNull()]
+        [object] $Value,
+
+        [Parameter(Mandatory)]
+        [string] $Name
+    )
+
+    if ($null -eq $Value) {
+        throw "Screenshot result property '$Name' must not be null."
+    }
+
+    try {
+        return [System.Convert]::ToInt64($Value, [System.Globalization.CultureInfo]::InvariantCulture)
+    }
+    catch {
+        throw "Screenshot result property '$Name' is not an integer: $Value"
+    }
+}
+
+function Read-PngEvidence {
+    param(
+        [Parameter(Mandatory)]
+        [string] $Path
+    )
+
+    Add-Type -AssemblyName PresentationCore -ErrorAction Stop
+
+    $stream = $null
+    try {
+        $stream = [System.IO.File]::Open(
+            $Path,
+            [System.IO.FileMode]::Open,
+            [System.IO.FileAccess]::Read,
+            [System.IO.FileShare]::Read)
+        $decoder = [System.Windows.Media.Imaging.PngBitmapDecoder]::new(
+            $stream,
+            [System.Windows.Media.Imaging.BitmapCreateOptions]::PreservePixelFormat,
+            [System.Windows.Media.Imaging.BitmapCacheOption]::OnLoad)
+
+        if ($decoder.Frames.Count -ne 1) {
+            throw "Expected one PNG frame, found $($decoder.Frames.Count)."
+        }
+
+        $frame = $decoder.Frames[0]
+        $width = $frame.PixelWidth
+        $height = $frame.PixelHeight
+        if ($width -lt 800 -or $height -lt 600 -or $width -gt 8192 -or $height -gt 8192) {
+            throw "PNG dimensions are outside the expected range: ${width}x${height}."
+        }
+
+        $bitmap = [System.Windows.Media.Imaging.FormatConvertedBitmap]::new(
+            $frame,
+            [System.Windows.Media.PixelFormats]::Bgra32,
+            $null,
+            0)
+        $stride = $width * 4
+        $pixels = [byte[]]::new($stride * $height)
+        $bitmap.CopyPixels($pixels, $stride, 0)
+
+        $sampleColumns = 17
+        $sampleRows = 13
+        $sampledColors = [System.Collections.Generic.HashSet[string]]::new(
+            [System.StringComparer]::Ordinal)
+
+        for ($row = 0; $row -lt $sampleRows; $row++) {
+            $y = [System.Convert]::ToInt32(
+                [System.Math]::Round((($row + 1) * ($height - 1)) / ($sampleRows + 1)))
+            for ($column = 0; $column -lt $sampleColumns; $column++) {
+                $x = [System.Convert]::ToInt32(
+                    [System.Math]::Round((($column + 1) * ($width - 1)) / ($sampleColumns + 1)))
+                $offset = ($y * $stride) + ($x * 4)
+                $color = '{0:X2}{1:X2}{2:X2}' -f `
+                    $pixels[$offset + 2], `
+                    $pixels[$offset + 1], `
+                    $pixels[$offset]
+                [void] $sampledColors.Add($color)
+            }
+        }
+
+        if ($sampledColors.Count -lt 2) {
+            throw 'PNG is visually uniform across the sampled pixel grid.'
+        }
+
+        return [pscustomobject]@{
+            Width = $width
+            Height = $height
+            SampledColorCount = $sampledColors.Count
+        }
+    }
+    finally {
+        if ($null -ne $stream) {
+            $stream.Dispose()
+        }
+    }
+}
+
+$process = $null
+$processStarted = $false
+$stdoutTask = $null
+$stderrTask = $null
+$failure = $null
+$processCompleted = $false
+
+try {
+    $editorPath = [System.IO.Path]::GetFullPath($EditorExecutable)
+    Write-RunnerLog "Editor executable: $editorPath"
+    Write-RunnerLog "Screenshot output: $screenshotPath"
+    Write-RunnerLog "Result output: $resultPath"
+    Write-RunnerLog "Timeout: $TimeoutSeconds seconds"
+
+    if ([System.IO.Directory]::Exists($stateDirectory)) {
+        Write-RunnerLog "Removing previous isolated screenshot state: $stateDirectory"
+        [System.IO.Directory]::Delete($stateDirectory, $true)
+    }
+
+    if (-not [System.IO.File]::Exists($editorPath)) {
+        throw "Editor executable does not exist: $editorPath"
+    }
+
+    $startInfo = [System.Diagnostics.ProcessStartInfo]::new()
+    $startInfo.FileName = $editorPath
+    $startInfo.WorkingDirectory = [System.IO.Path]::GetDirectoryName($editorPath)
+    $startInfo.UseShellExecute = $false
+    $startInfo.RedirectStandardOutput = $true
+    $startInfo.RedirectStandardError = $true
+    $startInfo.CreateNoWindow = $false
+    $startInfo.ArgumentList.Add("--editor-screenshot=$screenshotPath")
+
+    $process = [System.Diagnostics.Process]::new()
+    $process.StartInfo = $startInfo
+    if (-not $process.Start()) {
+        throw "Failed to start Editor executable: $editorPath"
+    }
+
+    $processStarted = $true
+    $stdoutTask = $process.StandardOutput.ReadToEndAsync()
+    $stderrTask = $process.StandardError.ReadToEndAsync()
+    Write-RunnerLog "Started Editor process $($process.Id)."
+
+    if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+        Write-RunnerLog "Editor process exceeded the $TimeoutSeconds-second timeout."
+        try {
+            $process.Kill($true)
+            $processCompleted = $process.WaitForExit(10000)
+            if (-not $processCompleted) {
+                Write-RunnerLog 'Timed-out Editor process did not exit within the cleanup window.'
+            }
+        }
+        catch {
+            Write-RunnerLog "Failed to terminate timed-out process tree: $($_.Exception.Message)"
+        }
+
+        throw "Editor screenshot test timed out after $TimeoutSeconds seconds."
+    }
+
+    $process.WaitForExit()
+    $processCompleted = $true
+    Write-RunnerLog "Editor process exited with code $($process.ExitCode)."
+
+    if (-not [System.IO.File]::Exists($resultPath)) {
+        throw "Editor exited with code $($process.ExitCode) without creating the screenshot result: $resultPath"
+    }
+
+    $result = [System.IO.File]::ReadAllText($resultPath, $utf8WithoutBom) | ConvertFrom-Json
+    $success = Get-RequiredJsonProperty -JsonObject $result -Name 'success'
+    if ($success -isnot [bool]) {
+        throw "Screenshot result property 'success' must be a Boolean."
+    }
+
+    $reportedError = Get-RequiredJsonProperty -JsonObject $result -Name 'error'
+    if (-not $success) {
+        throw "Editor reported screenshot failure (process exit code $($process.ExitCode)): $reportedError"
+    }
+
+    if ($null -ne $reportedError) {
+        throw "Successful screenshot result unexpectedly contains an error: $reportedError"
+    }
+
+    if ($process.ExitCode -ne 0) {
+        throw "Editor reported screenshot success but exited with code $($process.ExitCode)."
+    }
+
+    $reportedPngPath = Get-RequiredJsonProperty -JsonObject $result -Name 'pngPath'
+    if ($reportedPngPath -isnot [string] -or
+        -not [System.IO.Path]::IsPathFullyQualified($reportedPngPath)) {
+        throw "Screenshot result property 'pngPath' must be an absolute path."
+    }
+
+    $resolvedReportedPngPath = [System.IO.Path]::GetFullPath($reportedPngPath)
+    if (-not [System.StringComparer]::OrdinalIgnoreCase.Equals(
+        $resolvedReportedPngPath,
+        $screenshotPath)) {
+        throw "Screenshot result points to '$resolvedReportedPngPath' instead of '$screenshotPath'."
+    }
+
+    if (-not [System.IO.File]::Exists($screenshotPath)) {
+        throw "Editor reported success without creating the PNG: $screenshotPath"
+    }
+
+    $readyAtText = Get-RequiredJsonProperty -JsonObject $result -Name 'readyAtUtc'
+    $capturedAtText = Get-RequiredJsonProperty -JsonObject $result -Name 'capturedAtUtc'
+    try {
+        $readyAt = [System.DateTimeOffset]::Parse(
+            $readyAtText,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::AssumeUniversal)
+        $capturedAt = [System.DateTimeOffset]::Parse(
+            $capturedAtText,
+            [System.Globalization.CultureInfo]::InvariantCulture,
+            [System.Globalization.DateTimeStyles]::AssumeUniversal)
+    }
+    catch {
+        throw 'Screenshot result timestamps must be valid ISO-8601 values.'
+    }
+
+    $delayMilliseconds = ConvertTo-ResultInt64 `
+        -Value (Get-RequiredJsonProperty -JsonObject $result -Name 'delayMilliseconds') `
+        -Name 'delayMilliseconds'
+    if ($delayMilliseconds -lt 5000) {
+        throw "Reported screenshot delay is less than five seconds: $delayMilliseconds ms."
+    }
+
+    $actualDelayMilliseconds = ($capturedAt - $readyAt).TotalMilliseconds
+    if ($actualDelayMilliseconds -lt 5000) {
+        throw "Screenshot was captured less than five seconds after readiness: $actualDelayMilliseconds ms."
+    }
+
+    $reportedWidth = ConvertTo-ResultInt64 `
+        -Value (Get-RequiredJsonProperty -JsonObject $result -Name 'width') `
+        -Name 'width'
+    $reportedHeight = ConvertTo-ResultInt64 `
+        -Value (Get-RequiredJsonProperty -JsonObject $result -Name 'height') `
+        -Name 'height'
+    $reportedByteCount = ConvertTo-ResultInt64 `
+        -Value (Get-RequiredJsonProperty -JsonObject $result -Name 'byteCount') `
+        -Name 'byteCount'
+    $pngByteCount = ([System.IO.FileInfo]::new($screenshotPath)).Length
+
+    if ($reportedByteCount -ne $pngByteCount) {
+        throw "Reported PNG byte count ($reportedByteCount) differs from the file length ($pngByteCount)."
+    }
+
+    if ($pngByteCount -le 4096) {
+        throw "PNG is unexpectedly small: $pngByteCount bytes."
+    }
+
+    $pngEvidence = Read-PngEvidence -Path $screenshotPath
+    if ($reportedWidth -ne $pngEvidence.Width -or $reportedHeight -ne $pngEvidence.Height) {
+        throw "Reported PNG dimensions (${reportedWidth}x${reportedHeight}) differ from the decoded dimensions ($($pngEvidence.Width)x$($pngEvidence.Height))."
+    }
+
+    Write-RunnerLog (
+        'Validated PNG: {0}x{1}, {2} bytes, {3} distinct sampled colors, {4:N0} ms after readiness.' -f
+        $pngEvidence.Width,
+        $pngEvidence.Height,
+        $pngByteCount,
+        $pngEvidence.SampledColorCount,
+        $actualDelayMilliseconds)
+}
+catch {
+    $failure = $_
+    Write-RunnerLog "FAILED: $($_.Exception.Message)"
+}
+finally {
+    if ($processStarted -and $null -ne $process) {
+        try {
+            if (-not $process.HasExited) {
+                Write-RunnerLog "Terminating remaining Editor process tree $($process.Id)."
+                $process.Kill($true)
+            }
+
+            $processCompleted = $process.WaitForExit(10000)
+            if (-not $processCompleted) {
+                Write-RunnerLog 'Editor process did not exit within the final cleanup window.'
+            }
+        }
+        catch {
+            Write-RunnerLog "Process cleanup warning: $($_.Exception.Message)"
+        }
+    }
+
+    if ($null -ne $stdoutTask -and $processCompleted) {
+        try {
+            [System.IO.File]::WriteAllText(
+                $stdoutPath,
+                $stdoutTask.GetAwaiter().GetResult(),
+                $utf8WithoutBom)
+        }
+        catch {
+            Write-RunnerLog "Could not persist Editor stdout: $($_.Exception.Message)"
+        }
+    }
+
+    if ($null -ne $stderrTask -and $processCompleted) {
+        try {
+            [System.IO.File]::WriteAllText(
+                $stderrPath,
+                $stderrTask.GetAwaiter().GetResult(),
+                $utf8WithoutBom)
+        }
+        catch {
+            Write-RunnerLog "Could not persist Editor stderr: $($_.Exception.Message)"
+        }
+    }
+
+    if (-not $processCompleted -and $processStarted) {
+        [System.IO.File]::AppendAllText(
+            $stderrPath,
+            "Editor process output could not be drained because the process did not exit.$([Environment]::NewLine)",
+            $utf8WithoutBom)
+    }
+
+    if ($null -ne $process) {
+        $process.Dispose()
+    }
+}
+
+if ($null -ne $failure) {
+    throw $failure
+}
+
+Write-RunnerLog 'Editor screenshot smoke test passed.'

--- a/Editor/MainPage.xaml.cs
+++ b/Editor/MainPage.xaml.cs
@@ -3,6 +3,7 @@ using SailorEditor.Platforms.MacCatalyst;
 #endif
 using SailorEditor.Services;
 using SailorEditor.Shell;
+using SailorEditor.Testing;
 using SailorEditor.Workspace;
 using System.ComponentModel;
 
@@ -12,11 +13,13 @@ public partial class MainPage : ContentPage
 {
     readonly EditorShellHost _shellHost;
     readonly WorkspaceUiService _workspaceUi;
+    readonly EditorScreenshotTestRunner _screenshotTestRunner;
     bool _workspaceUiInitialized;
 
     public MainPage(EditorShellHost shellHost)
     {
         _shellHost = shellHost;
+        _screenshotTestRunner = MauiProgram.GetService<EditorScreenshotTestRunner>();
         _workspaceUi = MauiProgram.GetService<WorkspaceUiService>();
         InitializeComponent();
 #if MACCATALYST
@@ -42,6 +45,7 @@ public partial class MainPage : ContentPage
             await _shellHost.InitializeAsync();
         ShellLayoutHost.Rebuild();
         UpdateStatusText();
+        await _screenshotTestRunner.CaptureAndExitAsync();
     }
 
     void OnShellHostPropertyChanged(object? sender, PropertyChangedEventArgs e)

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -13,6 +13,7 @@ using SailorEditor.Content;
 using SailorEditor.Settings;
 using SailorEditor.AI;
 using SailorEditor.Workspace;
+using SailorEditor.Testing;
 #if MACCATALYST
 using SailorEditor.Platforms.MacCatalyst;
 #endif
@@ -25,6 +26,7 @@ namespace SailorEditor
         public static TService GetService<TService>() => serviceProvider.GetService<TService>();
         public static MauiApp CreateMauiApp()
         {
+            var screenshotTestOptions = EditorScreenshotTestOptions.Parse(Environment.GetCommandLineArgs());
             var builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
@@ -54,7 +56,11 @@ namespace SailorEditor
             builder.Services.AddSingleton<WorkspaceGeneratedProjectStateService>();
             builder.Services.AddSingleton<WorkspaceProjectGenerator>();
             builder.Services.AddSingleton<WorkspaceTemplateService>();
-            builder.Services.AddSingleton(_ => new RecentWorkspaceStore());
+            builder.Services.AddSingleton(screenshotTestOptions);
+            builder.Services.AddSingleton(_ => new RecentWorkspaceStore(
+                screenshotTestOptions.IsEnabled
+                    ? Path.Combine(screenshotTestOptions.StateDirectory!, "Workspaces", "recent-workspaces.yaml")
+                    : null));
             builder.Services.AddSingleton<WorkspaceLifecycleService>();
             builder.Services.AddSingleton<WorkspaceActivationOperations>();
             builder.Services.AddSingleton<IWorkspaceActivationOperations>(sp => sp.GetRequiredService<WorkspaceActivationOperations>());
@@ -68,14 +74,21 @@ namespace SailorEditor
             builder.Services.AddSingleton<ICommandDispatcher>(sp => sp.GetRequiredService<EditorCommandDispatcher>());
             builder.Services.AddSingleton<ICommandHistoryService>(sp => sp.GetRequiredService<EditorCommandDispatcher>());
             builder.Services.AddSingleton<ITransactionScopeFactory>(sp => sp.GetRequiredService<EditorCommandDispatcher>());
-            builder.Services.AddSingleton<IEditorShellLayoutStore, YamlEditorShellLayoutStore>();
+            builder.Services.AddSingleton<IEditorShellLayoutStore>(_ => new YamlEditorShellLayoutStore(
+                screenshotTestOptions.IsEnabled
+                    ? Path.Combine(screenshotTestOptions.StateDirectory!, "Layouts", "editor-shell-layout.yaml")
+                    : null));
             builder.Services.AddSingleton(sp => new UnifiedSettingsStore(EditorSettingsCatalog.Definitions));
-            builder.Services.AddSingleton<EditorSettingsPersistenceStore>();
+            builder.Services.AddSingleton(_ => new EditorSettingsPersistenceStore(
+                screenshotTestOptions.IsEnabled
+                    ? Path.Combine(screenshotTestOptions.StateDirectory!, "Settings", "editor-settings.yaml")
+                    : null));
             builder.Services.AddSingleton<EditorShellHost>();
             builder.Services.AddSingleton<IAIAgentInstructionsProvider, MarkdownAIAgentInstructionsProvider>();
             builder.Services.AddSingleton<IAIEditorContextProvider, EditorAIContextProvider>();
             builder.Services.AddSingleton<IAIActionPlanner, HeuristicAIActionPlanner>();
             builder.Services.AddSingleton<AIOperatorService>();
+            builder.Services.AddSingleton<EditorScreenshotTestRunner>();
             builder.Services.AddTransient<MainPage>();
             builder.Services.AddTransient<ContentFolderView>();
 

--- a/Editor/Platforms/Windows/App.xaml.cs
+++ b/Editor/Platforms/Windows/App.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.UI.Xaml;
+using SailorEditor.Testing;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -16,9 +17,49 @@ namespace SailorEditor.WinUI
         /// </summary>
         public App()
         {
-            this.InitializeComponent();
+            if (EditorScreenshotTestDiagnostics.IsEnabled)
+            {
+                UnhandledException += OnWinUiUnhandledException;
+                AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
+                TaskScheduler.UnobservedTaskException += OnUnobservedTaskException;
+                EditorScreenshotTestDiagnostics.TryWriteCheckpoint("WinUI App constructor");
+            }
+
+            try
+            {
+                InitializeComponent();
+                EditorScreenshotTestDiagnostics.TryWriteCheckpoint("WinUI App.InitializeComponent completed");
+            }
+            catch (Exception ex)
+            {
+                EditorScreenshotTestDiagnostics.TryWriteUnhandledException("WinUI App.InitializeComponent", ex);
+                throw;
+            }
         }
 
-        protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+        protected override MauiApp CreateMauiApp()
+        {
+            try
+            {
+                EditorScreenshotTestDiagnostics.TryWriteCheckpoint("MauiProgram.CreateMauiApp starting");
+                var app = MauiProgram.CreateMauiApp();
+                EditorScreenshotTestDiagnostics.TryWriteCheckpoint("MauiProgram.CreateMauiApp completed");
+                return app;
+            }
+            catch (Exception ex)
+            {
+                EditorScreenshotTestDiagnostics.TryWriteUnhandledException("MauiProgram.CreateMauiApp", ex);
+                throw;
+            }
+        }
+
+        static void OnWinUiUnhandledException(object sender, Microsoft.UI.Xaml.UnhandledExceptionEventArgs args)
+            => EditorScreenshotTestDiagnostics.TryWriteUnhandledException("WinUI Application.UnhandledException", args.Exception);
+
+        static void OnAppDomainUnhandledException(object sender, System.UnhandledExceptionEventArgs args)
+            => EditorScreenshotTestDiagnostics.TryWriteUnhandledException("AppDomain.UnhandledException", args.ExceptionObject);
+
+        static void OnUnobservedTaskException(object? sender, UnobservedTaskExceptionEventArgs args)
+            => EditorScreenshotTestDiagnostics.TryWriteUnhandledException("TaskScheduler.UnobservedTaskException", args.Exception);
     }
 }

--- a/Editor/SailorEditor.csproj
+++ b/Editor/SailorEditor.csproj
@@ -42,6 +42,10 @@
 	    <ValidateXcodeVersion>false</ValidateXcodeVersion>
   </PropertyGroup>
 
+	<PropertyGroup Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows' and '$(RuntimeIdentifierOverride)' != ''">
+		<RuntimeIdentifier>$(RuntimeIdentifierOverride)</RuntimeIdentifier>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-maccatalyst|AnyCPU'">
 	  <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
 	  <ApplicationTitle>SailorEditor</ApplicationTitle>

--- a/Editor/Services/WorkspaceUiService.cs
+++ b/Editor/Services/WorkspaceUiService.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Maui.Storage;
 using SailorEditor.Commands;
 using SailorEditor.Shell;
+using SailorEditor.Testing;
 using SailorEditor.Workspace;
 
 namespace SailorEditor.Services;
@@ -13,6 +14,7 @@ internal sealed class WorkspaceUiService
     readonly EditorShellHost _shellHost;
     readonly ICommandHistoryService _commandHistory;
     readonly SelectionService _selectionService;
+    readonly EditorScreenshotTestOptions _screenshotTestOptions;
     static readonly FilePickerFileType WorkspaceManifestFileType = new(new Dictionary<DevicePlatform, IEnumerable<string>>
     {
         { DevicePlatform.WinUI, [".sailor"] },
@@ -27,7 +29,8 @@ internal sealed class WorkspaceUiService
         WorkspaceActivationCoordinator activationCoordinator,
         EditorShellHost shellHost,
         ICommandHistoryService commandHistory,
-        SelectionService selectionService)
+        SelectionService selectionService,
+        EditorScreenshotTestOptions screenshotTestOptions)
     {
         _workspaceLifecycle = workspaceLifecycle;
         _engineService = engineService;
@@ -35,6 +38,7 @@ internal sealed class WorkspaceUiService
         _shellHost = shellHost;
         _commandHistory = commandHistory;
         _selectionService = selectionService;
+        _screenshotTestOptions = screenshotTestOptions;
         _activationCoordinator.StateChanged += OnActivationStateChanged;
         _engineService.OnLifecycleStateChanged += OnEngineLifecycleStateChanged;
     }
@@ -46,6 +50,9 @@ internal sealed class WorkspaceUiService
     public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
         await RefreshAsync(cancellationToken);
+        if (_screenshotTestOptions.IsEnabled)
+            return;
+
         if (_engineService.State is EngineLifecycleState.Stopped or EngineLifecycleState.Faulted)
         {
             try

--- a/Editor/Testing/EditorScreenshotTestDiagnostics.cs
+++ b/Editor/Testing/EditorScreenshotTestDiagnostics.cs
@@ -1,0 +1,83 @@
+#nullable enable
+
+using System.Text;
+
+namespace SailorEditor.Testing;
+
+internal static class EditorScreenshotTestDiagnostics
+{
+    const string StartupLogEnvironmentVariable = "SAILOR_EDITOR_STARTUP_LOG";
+    static readonly object Sync = new();
+    static readonly UTF8Encoding Utf8WithoutBom = new(false);
+
+    public static bool IsEnabled => TryGetStartupLogPath(out _);
+
+    public static void TryWriteCheckpoint(string source)
+        => TryWrite(source, "Checkpoint reached.");
+
+    public static void TryWriteUnhandledException(string source, object? exception)
+        => TryWrite(source, exception switch
+        {
+            Exception error => $"{error.GetType().FullName} (HRESULT 0x{error.HResult:X8}){Environment.NewLine}{error}",
+            null => "No exception object was provided.",
+            _ => exception.ToString() ?? exception.GetType().FullName ?? "Unknown exception"
+        });
+
+    static void TryWrite(string source, string details)
+    {
+        try
+        {
+            if (!TryGetStartupLogPath(out var startupLogPath))
+                return;
+
+            var outputDirectory = Path.GetDirectoryName(startupLogPath);
+            if (string.IsNullOrWhiteSpace(outputDirectory))
+                return;
+
+            Directory.CreateDirectory(outputDirectory);
+            var entry = $"""
+                {DateTimeOffset.UtcNow:O} {source}
+                Process: {Environment.ProcessId}; managed thread: {Environment.CurrentManagedThreadId}
+                Base directory: {AppContext.BaseDirectory}
+                Current directory: {Environment.CurrentDirectory}
+                {details}
+
+                """;
+
+            lock (Sync)
+            {
+                using var output = new FileStream(
+                    startupLogPath,
+                    FileMode.Append,
+                    FileAccess.Write,
+                    FileShare.ReadWrite);
+                using var writer = new StreamWriter(output, Utf8WithoutBom, 1024, leaveOpen: true);
+                writer.Write(entry);
+                writer.Flush();
+                output.Flush(flushToDisk: true);
+            }
+        }
+        catch
+        {
+            // Diagnostics must never mask the original startup failure.
+        }
+    }
+
+    static bool TryGetStartupLogPath(out string startupLogPath)
+    {
+        startupLogPath = string.Empty;
+        try
+        {
+            var requestedPath = Environment.GetEnvironmentVariable(StartupLogEnvironmentVariable);
+            if (string.IsNullOrWhiteSpace(requestedPath) || !Path.IsPathFullyQualified(requestedPath))
+                return false;
+
+            startupLogPath = Path.GetFullPath(requestedPath);
+            return true;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+}

--- a/Editor/Testing/EditorScreenshotTestOptions.cs
+++ b/Editor/Testing/EditorScreenshotTestOptions.cs
@@ -1,0 +1,89 @@
+#nullable enable
+
+namespace SailorEditor.Testing;
+
+internal sealed record EditorScreenshotTestOptions(
+    string? ScreenshotPath,
+    string? StateDirectory,
+    string? ResultPath)
+{
+    const string ScreenshotArgument = "--editor-screenshot";
+    const string ScreenshotArgumentPrefix = ScreenshotArgument + "=";
+    const string StateDirectoryName = ".screenshot-state";
+    const string ResultFileSuffix = ".result.json";
+
+    public bool IsEnabled => ScreenshotPath is not null;
+
+    public static EditorScreenshotTestOptions Parse(IEnumerable<string> arguments)
+    {
+        ArgumentNullException.ThrowIfNull(arguments);
+
+        string? screenshotPath = null;
+        var foundScreenshotArgument = false;
+
+        foreach (var argument in arguments)
+        {
+            if (string.Equals(argument, ScreenshotArgument, StringComparison.Ordinal))
+            {
+                throw new ArgumentException(
+                    $"{ScreenshotArgument} requires an absolute PNG output path.",
+                    nameof(arguments));
+            }
+
+            if (argument is null ||
+                !argument.StartsWith(ScreenshotArgumentPrefix, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (foundScreenshotArgument)
+            {
+                throw new ArgumentException(
+                    $"{ScreenshotArgument} may only be specified once.",
+                    nameof(arguments));
+            }
+
+            foundScreenshotArgument = true;
+            var requestedPath = argument[ScreenshotArgumentPrefix.Length..];
+            if (string.IsNullOrWhiteSpace(requestedPath))
+            {
+                throw new ArgumentException(
+                    $"{ScreenshotArgument} requires an absolute PNG output path.",
+                    nameof(arguments));
+            }
+
+            if (!Path.IsPathFullyQualified(requestedPath))
+            {
+                throw new ArgumentException(
+                    $"{ScreenshotArgument} output path must be absolute.",
+                    nameof(arguments));
+            }
+
+            if (!string.Equals(Path.GetExtension(requestedPath), ".png", StringComparison.OrdinalIgnoreCase) ||
+                string.IsNullOrWhiteSpace(Path.GetFileNameWithoutExtension(requestedPath)))
+            {
+                throw new ArgumentException(
+                    $"{ScreenshotArgument} output path must name a PNG file.",
+                    nameof(arguments));
+            }
+
+            screenshotPath = Path.GetFullPath(requestedPath);
+        }
+
+        if (screenshotPath is null)
+        {
+            return new EditorScreenshotTestOptions(null, null, null);
+        }
+
+        var outputDirectory = Path.GetDirectoryName(screenshotPath)
+            ?? throw new ArgumentException(
+                $"{ScreenshotArgument} output path must have a parent directory.",
+                nameof(arguments));
+        var resultFileName = Path.GetFileNameWithoutExtension(screenshotPath) + ResultFileSuffix;
+
+        return new EditorScreenshotTestOptions(
+            screenshotPath,
+            Path.Combine(outputDirectory, StateDirectoryName),
+            Path.Combine(outputDirectory, resultFileName));
+    }
+}

--- a/Editor/Testing/EditorScreenshotTestRunner.cs
+++ b/Editor/Testing/EditorScreenshotTestRunner.cs
@@ -1,0 +1,183 @@
+#nullable enable
+
+using System.Diagnostics;
+using System.Text.Json;
+using Microsoft.Maui.Media;
+
+namespace SailorEditor.Testing;
+
+internal sealed class EditorScreenshotTestRunner
+{
+    static readonly TimeSpan CaptureDelay = TimeSpan.FromSeconds(5);
+    static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true
+    };
+
+    readonly EditorScreenshotTestOptions _options;
+    int _started;
+
+    public EditorScreenshotTestRunner(EditorScreenshotTestOptions options)
+    {
+        _options = options;
+    }
+
+    public async Task CaptureAndExitAsync(CancellationToken cancellationToken = default)
+    {
+        if (!_options.IsEnabled || Interlocked.Exchange(ref _started, 1) != 0)
+            return;
+
+        var readyAtUtc = DateTimeOffset.UtcNow;
+        var stopwatch = Stopwatch.StartNew();
+        string? temporaryScreenshotPath = null;
+
+        try
+        {
+            if (Application.Current?.Windows.FirstOrDefault() is { } window)
+            {
+                window.Width = 1024;
+                window.Height = 768;
+            }
+
+            Directory.CreateDirectory(_options.StateDirectory!);
+            Directory.CreateDirectory(Path.GetDirectoryName(_options.ScreenshotPath!)!);
+            DeleteIfExists(_options.ScreenshotPath!);
+            DeleteIfExists(_options.ResultPath!);
+
+            await Task.Delay(CaptureDelay, cancellationToken);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!Screenshot.Default.IsCaptureSupported)
+                throw new InvalidOperationException("MAUI screenshot capture is not supported on this Windows runner.");
+
+            var screenshot = await Screenshot.Default.CaptureAsync();
+            if (screenshot.Width < 800 || screenshot.Height < 600)
+            {
+                throw new InvalidOperationException(
+                    $"Captured screenshot dimensions are too small: {screenshot.Width}x{screenshot.Height}; expected at least 800x600.");
+            }
+
+            temporaryScreenshotPath = $"{_options.ScreenshotPath}.{Guid.NewGuid():N}.tmp";
+            await using (var output = new FileStream(
+                temporaryScreenshotPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                81920,
+                FileOptions.Asynchronous | FileOptions.WriteThrough))
+            {
+                await screenshot.CopyToAsync(output, ScreenshotFormat.Png, 100);
+                await output.FlushAsync(cancellationToken);
+            }
+
+            var byteCount = new FileInfo(temporaryScreenshotPath).Length;
+            if (byteCount < 4096)
+                throw new InvalidOperationException($"Captured PNG is unexpectedly small: {byteCount} bytes.");
+
+            File.Move(temporaryScreenshotPath, _options.ScreenshotPath!, true);
+            temporaryScreenshotPath = null;
+
+            var capturedAtUtc = DateTimeOffset.UtcNow;
+            await WriteResultAsync(new EditorScreenshotTestResult(
+                true,
+                _options.ScreenshotPath!,
+                readyAtUtc,
+                capturedAtUtc,
+                stopwatch.ElapsedMilliseconds,
+                screenshot.Width,
+                screenshot.Height,
+                byteCount,
+                null));
+
+            Console.WriteLine(
+                $"Editor screenshot test captured {_options.ScreenshotPath} ({screenshot.Width}x{screenshot.Height}, {byteCount} bytes) after {stopwatch.ElapsedMilliseconds} ms.");
+            ExitApplication(0);
+        }
+        catch (Exception ex)
+        {
+            if (temporaryScreenshotPath is not null)
+                DeleteIfExists(temporaryScreenshotPath);
+
+            Console.Error.WriteLine($"Editor screenshot test failed: {ex}");
+            await TryWriteFailureResultAsync(readyAtUtc, stopwatch.ElapsedMilliseconds, ex);
+            ExitApplication(1);
+        }
+    }
+
+    async Task WriteResultAsync(EditorScreenshotTestResult result)
+    {
+        var temporaryResultPath = $"{_options.ResultPath}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            var json = JsonSerializer.Serialize(result, JsonOptions);
+            await File.WriteAllTextAsync(temporaryResultPath, json);
+            File.Move(temporaryResultPath, _options.ResultPath!, true);
+        }
+        finally
+        {
+            DeleteIfExists(temporaryResultPath);
+        }
+    }
+
+    async Task TryWriteFailureResultAsync(DateTimeOffset readyAtUtc, long delayMilliseconds, Exception exception)
+    {
+        try
+        {
+            var resultDirectory = Path.GetDirectoryName(_options.ResultPath!);
+            if (!string.IsNullOrWhiteSpace(resultDirectory))
+                Directory.CreateDirectory(resultDirectory);
+
+            await WriteResultAsync(new EditorScreenshotTestResult(
+                false,
+                _options.ScreenshotPath!,
+                readyAtUtc,
+                null,
+                delayMilliseconds,
+                null,
+                null,
+                null,
+                exception.ToString()));
+        }
+        catch (Exception resultException)
+        {
+            Console.Error.WriteLine($"Could not write screenshot test result: {resultException}");
+        }
+    }
+
+    static void ExitApplication(int exitCode)
+    {
+        Environment.ExitCode = exitCode;
+        try
+        {
+            if (Application.Current is not null)
+            {
+                Application.Current.Quit();
+                return;
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Could not close the screenshot test application cleanly: {ex}");
+        }
+
+        Environment.Exit(exitCode);
+    }
+
+    static void DeleteIfExists(string path)
+    {
+        if (File.Exists(path))
+            File.Delete(path);
+    }
+
+    sealed record EditorScreenshotTestResult(
+        bool Success,
+        string PngPath,
+        DateTimeOffset ReadyAtUtc,
+        DateTimeOffset? CapturedAtUtc,
+        long DelayMilliseconds,
+        int? Width,
+        int? Height,
+        long? ByteCount,
+        string? Error);
+}

--- a/Editor/Views/SceneView.xaml.cs
+++ b/Editor/Views/SceneView.xaml.cs
@@ -3,6 +3,7 @@ using SailorEditor.Helpers;
 using SailorEditor.Commands;
 using SailorEditor.Services;
 using SailorEditor.Settings;
+using SailorEditor.Testing;
 using SailorEditor.Controls;
 using SailorEditor.Scene;
 using SailorEditor.Utility;
@@ -205,6 +206,9 @@ namespace SailorEditor.Views
 
             Loaded += (sender, args) =>
             {
+                if (MauiProgram.GetService<EditorScreenshotTestOptions>().IsEnabled)
+                    return;
+
                 isRunning = true;
 #if MACCATALYST
                 if (!UseNativeViewportHost)


### PR DESCRIPTION
Closes #68

## Implementation Summary

- Added an opt-in `--editor-screenshot=<absolute.png>` mode for the real .NET MAUI Editor.
- Isolated recent-workspace, layout, and settings state for deterministic `New Workspace` startup.
- Skipped native Engine startup and Scene polling only in screenshot mode.
- Captured the initialized 1024×768 shell after a five-second readiness delay and wrote atomic PNG/JSON evidence.
- Added a bounded PowerShell launcher that validates process outcome, JSON timing/schema, PNG decoding, dimensions, file size, and sampled nonuniform pixels.
- Extended Windows Editor CI to run contracts, publish an unpackaged `win-x64` app, execute the smoke test, and always upload evidence/logs.

## Corrective QA cycles

Initial exact-head run [29264341987](https://github.com/aantropov/sailor/actions/runs/29264341987) passed contracts/build/publish but exposed an early WinUI `0xC000027B` startup crash before capture.

Commit `3e968ad66d916511e33ac741e1977afad8e7371d`:

- Pinned the visual job to `windows-2022`, supported by the current Windows App SDK.
- Published beneath the checked-out repository so existing repository-root/content discovery remains valid.
- Added screenshot-only pre-XAML/WinUI/AppDomain diagnostics and raw Windows event evidence.

Those diagnostics made run [29265984129](https://github.com/aantropov/sailor/actions/runs/29265984129) actionable: WinUI reached `MauiAppBuilder.Build()` and failed because the self-contained publish could not locate `Microsoft.UI.Xaml/Themes/themeresources.xaml`.

Commit `85adca9f`:

- Adds the MAUI-documented Windows-only `RuntimeIdentifierOverride` → `RuntimeIdentifier` bridge needed to select the `win-x64` Windows App SDK payload.
- Records a sorted publish-file manifest.
- Fails before launch if the required WinUI DLL/PRI payload is absent.

## Validation

- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --configuration Release --nologo` — 369/369 passed.
- `dotnet build Editor/SailorEditor.csproj --configuration Release --framework net10.0-maccatalyst --no-restore --nologo -clp:ErrorsOnly` — 0 warnings, 0 errors.
- MSBuild property evaluation — `RuntimeIdentifier=win-x64`, `WindowsPackageType=None`, `WindowsAppSDKSelfContained=true`.
- Workflow YAML parse, project XML validation, and `git diff --check` — passed.
- Initial and all corrective Tech Reviews — approved, no required changes.

## Remaining exact-head validation

- Corrected Windows unpackaged publish/launch/capture in GitHub Actions.
- Downloaded screenshot artifact visual inspection by Lead QA.

## Risk

Medium. Normal startup remains on the existing code path when screenshot mode and the diagnostic hook are absent. The RID bridge is restricted to explicit Windows CLI publishes; Windows hosted-runner GUI/capture behavior is intentionally validated by this PR's exact-head CI.