### PR TITLE
[Task] Get rid of std containers

### DIFF
--- a/Runtime/AssetRegistry/AssetCache.cpp
+++ b/Runtime/AssetRegistry/AssetCache.cpp
@@ -1,4 +1,5 @@
 #include "AssetCache.h"
+#include "Containers/Containers.h"
 
 #include "AssetRegistry/AssetRegistry.h"
 #include "Containers/ConcurrentMap.h"
@@ -262,8 +263,7 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 	}
 
 	AssetCacheData candidate;
-	std::unordered_set<std::string> fileIds;
-	fileIds.reserve(assets.size());
+	TSet<std::string> fileIds;
 	for (const auto& serializedEntry : assets)
 	{
 		if (!serializedEntry.first.IsScalar())
@@ -273,7 +273,7 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 		}
 
 		const std::string serializedFileId = serializedEntry.first.Scalar();
-		if (!fileIds.emplace(serializedFileId).second)
+		if (!fileIds.Insert(serializedFileId))
 		{
 			outDiagnostic = "Asset cache contains duplicate file id '" + serializedFileId + "'.";
 			return false;

--- a/Runtime/AssetRegistry/AssetMountDiscovery.cpp
+++ b/Runtime/AssetRegistry/AssetMountDiscovery.cpp
@@ -1,4 +1,5 @@
 #include "AssetRegistry/AssetMountDiscovery.h"
+#include "Containers/Containers.h"
 
 #include <algorithm>
 #include <cctype>
@@ -141,7 +142,7 @@ namespace
 		return IsPreferred(leftCandidate, rightCandidate);
 	}
 
-	void SortDiagnostics(std::vector<AssetMountDiagnostic>& diagnostics)
+	void SortDiagnostics(TVector<AssetMountDiagnostic>& diagnostics)
 	{
 		std::sort(diagnostics.begin(), diagnostics.end(), [](const AssetMountDiagnostic& left, const AssetMountDiagnostic& right)
 			{
@@ -178,11 +179,11 @@ namespace
 		return diagnostic;
 	}
 
-	std::vector<AssetMountDescriptor> NormalizeMounts(
-		const std::vector<AssetMountDescriptor>& mounts,
-		std::vector<AssetMountDiagnostic>& diagnostics)
+	TVector<AssetMountDescriptor> NormalizeMounts(
+		const TVector<AssetMountDescriptor>& mounts,
+		TVector<AssetMountDiagnostic>& diagnostics)
 	{
-		std::vector<AssetMountDescriptor> normalized;
+		TVector<AssetMountDescriptor> normalized;
 		for (const AssetMountDescriptor& input : mounts)
 		{
 			std::error_code error;
@@ -196,13 +197,13 @@ namespace
 				diagnostic.m_conflictingKind = input.m_kind;
 				diagnostic.m_message = "Asset mount root is not a readable directory: '" +
 					PathDisplay(input.m_root) + "'.";
-				diagnostics.emplace_back(std::move(diagnostic));
+				diagnostics.Add(std::move(diagnostic));
 				continue;
 			}
 
 			AssetMountDescriptor descriptor = input;
 			descriptor.m_root = root;
-			normalized.emplace_back(std::move(descriptor));
+			normalized.Add(std::move(descriptor));
 		}
 
 		std::sort(normalized.begin(), normalized.end(), [](const AssetMountDescriptor& left, const AssetMountDescriptor& right)
@@ -216,17 +217,17 @@ namespace
 				return IsPreferredMount(left, right);
 			});
 
-		std::vector<AssetMountDescriptor> deduplicated;
-		for (size_t begin = 0; begin < normalized.size();)
+		TVector<AssetMountDescriptor> deduplicated;
+		for (size_t begin = 0; begin < normalized.Num();)
 		{
 			size_t end = begin + 1;
-			while (end < normalized.size() && PathKey(normalized[end].m_root) == PathKey(normalized[begin].m_root))
+			while (end < normalized.Num() && PathKey(normalized[end].m_root) == PathKey(normalized[begin].m_root))
 			{
 				++end;
 			}
 
 			const AssetMountDescriptor& winner = normalized[begin];
-			deduplicated.emplace_back(winner);
+			deduplicated.Add(winner);
 			for (size_t duplicate = begin + 1; duplicate < end; ++duplicate)
 			{
 				const AssetMountDescriptor& conflicting = normalized[duplicate];
@@ -240,14 +241,14 @@ namespace
 				diagnostic.m_message = "Duplicate asset mount root '" + PathDisplay(winner.m_root) +
 					"' keeps " + KindName(winner.m_kind) + " and discards " +
 					KindName(conflicting.m_kind) + ".";
-				diagnostics.emplace_back(std::move(diagnostic));
+				diagnostics.Add(std::move(diagnostic));
 			}
 			begin = end;
 		}
 
-		for (size_t leftIndex = 0; leftIndex < deduplicated.size(); ++leftIndex)
+		for (size_t leftIndex = 0; leftIndex < deduplicated.Num(); ++leftIndex)
 		{
-			for (size_t rightIndex = leftIndex + 1; rightIndex < deduplicated.size(); ++rightIndex)
+			for (size_t rightIndex = leftIndex + 1; rightIndex < deduplicated.Num(); ++rightIndex)
 			{
 				const AssetMountDescriptor& left = deduplicated[leftIndex];
 				const AssetMountDescriptor& right = deduplicated[rightIndex];
@@ -266,7 +267,7 @@ namespace
 				diagnostic.m_message = "Asset mount roots overlap and cannot be activated: " +
 					std::string(KindName(left.m_kind)) + " '" + PathDisplay(left.m_root) +
 					"' and " + KindName(right.m_kind) + " '" + PathDisplay(right.m_root) + "'.";
-				diagnostics.emplace_back(std::move(diagnostic));
+				diagnostics.Add(std::move(diagnostic));
 			}
 		}
 
@@ -276,15 +277,15 @@ namespace
 	void DiscoverDirectory(
 		const AssetMountDescriptor& mount,
 		const std::filesystem::path& logicalDirectory,
-		std::set<std::string>& visitedDirectories,
-		std::vector<AssetMountDiscoveredFile>& files,
-		std::vector<AssetMountDiagnostic>& diagnostics)
+		TSet<std::string>& visitedDirectories,
+		TVector<AssetMountDiscoveredFile>& files,
+		TVector<AssetMountDiagnostic>& diagnostics)
 	{
 		std::error_code error;
 		const std::filesystem::path physicalDirectory = std::filesystem::canonical(logicalDirectory, error);
 		if (error)
 		{
-			diagnostics.emplace_back(MakeInspectionDiagnostic(
+			diagnostics.Add(MakeInspectionDiagnostic(
 				EAssetMountDiagnosticCode::PathInspectionFailed,
 				mount,
 				logicalDirectory,
@@ -293,7 +294,7 @@ namespace
 		}
 		if (!IsInside(mount.m_root, physicalDirectory))
 		{
-			diagnostics.emplace_back(MakeInspectionDiagnostic(
+			diagnostics.Add(MakeInspectionDiagnostic(
 				EAssetMountDiagnosticCode::PhysicalEscapeSkipped,
 				mount,
 				logicalDirectory,
@@ -302,9 +303,9 @@ namespace
 		}
 
 		const std::string directoryKey = PathKey(physicalDirectory);
-		if (!visitedDirectories.emplace(directoryKey).second)
+		if (!visitedDirectories.Insert(directoryKey))
 		{
-			diagnostics.emplace_back(MakeInspectionDiagnostic(
+			diagnostics.Add(MakeInspectionDiagnostic(
 				EAssetMountDiagnosticCode::DirectoryCycleSkipped,
 				mount,
 				logicalDirectory,
@@ -313,7 +314,7 @@ namespace
 			return;
 		}
 
-		std::vector<std::filesystem::directory_entry> entries;
+		TVector<std::filesystem::directory_entry> entries;
 		for (std::filesystem::directory_iterator it(
 				logicalDirectory,
 				std::filesystem::directory_options::skip_permission_denied,
@@ -321,11 +322,11 @@ namespace
 			!error && it != end;
 			it.increment(error))
 		{
-			entries.emplace_back(*it);
+			entries.Add(*it);
 		}
 		if (error)
 		{
-			diagnostics.emplace_back(MakeInspectionDiagnostic(
+			diagnostics.Add(MakeInspectionDiagnostic(
 				EAssetMountDiagnosticCode::PathInspectionFailed,
 				mount,
 				logicalDirectory,
@@ -348,7 +349,7 @@ namespace
 			const bool bIsDirectory = entry.is_directory(error);
 			if (error)
 			{
-				diagnostics.emplace_back(MakeInspectionDiagnostic(
+				diagnostics.Add(MakeInspectionDiagnostic(
 					EAssetMountDiagnosticCode::PathInspectionFailed,
 					mount,
 					entry.path(),
@@ -370,7 +371,7 @@ namespace
 			const std::filesystem::path physicalPath = std::filesystem::canonical(entry.path(), error);
 			if (error)
 			{
-				diagnostics.emplace_back(MakeInspectionDiagnostic(
+				diagnostics.Add(MakeInspectionDiagnostic(
 					EAssetMountDiagnosticCode::PathInspectionFailed,
 					mount,
 					entry.path(),
@@ -379,7 +380,7 @@ namespace
 			}
 			if (!IsInside(mount.m_root, physicalPath))
 			{
-				diagnostics.emplace_back(MakeInspectionDiagnostic(
+				diagnostics.Add(MakeInspectionDiagnostic(
 					EAssetMountDiagnosticCode::PhysicalEscapeSkipped,
 					mount,
 					entry.path(),
@@ -391,7 +392,7 @@ namespace
 			const std::string virtualPath = relativePath.generic_string();
 			if (!IsSafeVirtualPath(virtualPath))
 			{
-				diagnostics.emplace_back(MakeInspectionDiagnostic(
+				diagnostics.Add(MakeInspectionDiagnostic(
 					EAssetMountDiagnosticCode::PathInspectionFailed,
 					mount,
 					entry.path(),
@@ -400,7 +401,7 @@ namespace
 				continue;
 			}
 
-			files.emplace_back(AssetMountDiscoveredFile{ mount, physicalPath, virtualPath });
+			files.Add(AssetMountDiscoveredFile{ mount, physicalPath, virtualPath });
 		}
 	}
 
@@ -433,25 +434,27 @@ namespace
 
 	template<typename TKeySelector>
 	void BuildWinnerIndex(
-		const std::vector<AssetMountCandidate>& candidates,
-		std::map<std::string, size_t>& winners,
-		std::vector<AssetMountDiagnostic>& diagnostics,
+		const TVector<AssetMountCandidate>& candidates,
+		TMap<std::string, size_t>& winners,
+		TVector<AssetMountDiagnostic>& diagnostics,
 		EAssetMountDiagnosticCode collisionCode,
 		TKeySelector selectKey)
 	{
-		std::map<std::string, std::vector<size_t>> groups;
-		for (size_t index = 0; index < candidates.size(); ++index)
+		TMap<std::string, TVector<size_t>> groups;
+		for (size_t index = 0; index < candidates.Num(); ++index)
 		{
 			const std::string key = selectKey(candidates[index]);
 			if (!key.empty())
 			{
-				groups[key].emplace_back(index);
+				groups[key].Add(index);
 			}
 		}
 
-		for (const auto& [key, indexes] : groups)
+		for (const auto& group : groups)
 		{
-			size_t winnerIndex = indexes.front();
+			const std::string& key = group.m_first;
+			const TVector<size_t>& indexes = *group.m_second;
+			size_t winnerIndex = indexes[0];
 			for (size_t index : indexes)
 			{
 				if (IsPreferred(candidates[index], candidates[winnerIndex]))
@@ -459,7 +462,7 @@ namespace
 					winnerIndex = index;
 				}
 			}
-			winners.emplace(key, winnerIndex);
+			winners.Insert(key, winnerIndex);
 
 			for (size_t index : indexes)
 			{
@@ -468,7 +471,7 @@ namespace
 				{
 					continue;
 				}
-				diagnostics.emplace_back(MakeCollisionDiagnostic(
+				diagnostics.Add(MakeCollisionDiagnostic(
 					collisionCode,
 					key,
 					candidates[winnerIndex],
@@ -479,7 +482,7 @@ namespace
 }
 
 AssetMountDiscoveryResult Sailor::DiscoverAssetMountFiles(
-	const std::vector<AssetMountDescriptor>& mounts)
+	const TVector<AssetMountDescriptor>& mounts)
 {
 	AssetMountDiscoveryResult result;
 	result.m_mounts = NormalizeMounts(mounts, result.m_diagnostics);
@@ -490,7 +493,7 @@ AssetMountDiscoveryResult Sailor::DiscoverAssetMountFiles(
 	}
 	for (const AssetMountDescriptor& mount : result.m_mounts)
 	{
-		std::set<std::string> visitedDirectories;
+		TSet<std::string> visitedDirectories;
 		DiscoverDirectory(
 			mount,
 			mount.m_root,
@@ -517,7 +520,7 @@ bool AssetMountDiscoveryResult::HasFatalErrors() const noexcept
 }
 
 AssetMountResolutionResult Sailor::ResolveAssetMountCandidates(
-	std::vector<AssetMountCandidate> candidates)
+	TVector<AssetMountCandidate> candidates)
 {
 	AssetMountResolutionResult result;
 	for (AssetMountCandidate& candidate : candidates)
@@ -537,10 +540,10 @@ AssetMountResolutionResult Sailor::ResolveAssetMountCandidates(
 			diagnostic.m_conflictingFileId = candidate.m_fileId;
 			diagnostic.m_message = "Asset candidate has an invalid virtual path and was skipped: '" +
 				candidate.m_virtualPath + "'.";
-			result.m_diagnostics.emplace_back(std::move(diagnostic));
+			result.m_diagnostics.Add(std::move(diagnostic));
 			continue;
 		}
-		result.m_candidates.emplace_back(std::move(candidate));
+		result.m_candidates.Add(std::move(candidate));
 	}
 
 	std::sort(result.m_candidates.begin(), result.m_candidates.end(), [](const AssetMountCandidate& left, const AssetMountCandidate& right)
@@ -574,13 +577,13 @@ AssetMountResolutionResult Sailor::ResolveAssetMountCandidates(
 const AssetMountCandidate* AssetMountResolutionResult::FindByVirtualPath(
 	const std::string& virtualPath) const noexcept
 {
-	const auto it = m_virtualPathWinners.find(VirtualPathKey(virtualPath));
-	return it == m_virtualPathWinners.end() ? nullptr : &m_candidates[it->second];
+	const auto it = m_virtualPathWinners.Find(VirtualPathKey(virtualPath));
+	return it == m_virtualPathWinners.end() ? nullptr : &m_candidates[it.Value()];
 }
 
 const AssetMountCandidate* AssetMountResolutionResult::FindByFileId(
 	const std::string& fileId) const noexcept
 {
-	const auto it = m_fileIdWinners.find(fileId);
-	return it == m_fileIdWinners.end() ? nullptr : &m_candidates[it->second];
+	const auto it = m_fileIdWinners.Find(fileId);
+	return it == m_fileIdWinners.end() ? nullptr : &m_candidates[it.Value()];
 }

--- a/Runtime/AssetRegistry/AssetMountDiscovery.h
+++ b/Runtime/AssetRegistry/AssetMountDiscovery.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Containers/Containers.h"
 
 #include <cstdint>
 #include <filesystem>
@@ -65,36 +66,36 @@ namespace Sailor
 
 	struct AssetMountDiscoveryResult final
 	{
-		std::vector<AssetMountDescriptor> m_mounts;
-		std::vector<AssetMountDiscoveredFile> m_files;
-		std::vector<AssetMountDiagnostic> m_diagnostics;
+		TVector<AssetMountDescriptor> m_mounts;
+		TVector<AssetMountDiscoveredFile> m_files;
+		TVector<AssetMountDiagnostic> m_diagnostics;
 
 		bool HasFatalErrors() const noexcept;
 	};
 
 	class AssetMountResolutionResult;
 	AssetMountResolutionResult ResolveAssetMountCandidates(
-		std::vector<AssetMountCandidate> candidates);
+		TVector<AssetMountCandidate> candidates);
 
 	class AssetMountResolutionResult final
 	{
 	public:
-		const std::vector<AssetMountCandidate>& GetCandidates() const noexcept { return m_candidates; }
-		const std::vector<AssetMountDiagnostic>& GetDiagnostics() const noexcept { return m_diagnostics; }
+		const TVector<AssetMountCandidate>& GetCandidates() const noexcept { return m_candidates; }
+		const TVector<AssetMountDiagnostic>& GetDiagnostics() const noexcept { return m_diagnostics; }
 
 		const AssetMountCandidate* FindByVirtualPath(const std::string& virtualPath) const noexcept;
 		const AssetMountCandidate* FindByFileId(const std::string& fileId) const noexcept;
 
 	private:
-		std::vector<AssetMountCandidate> m_candidates;
-		std::map<std::string, size_t> m_virtualPathWinners;
-		std::map<std::string, size_t> m_fileIdWinners;
-		std::vector<AssetMountDiagnostic> m_diagnostics;
+		TVector<AssetMountCandidate> m_candidates;
+		TMap<std::string, size_t> m_virtualPathWinners;
+		TMap<std::string, size_t> m_fileIdWinners;
+		TVector<AssetMountDiagnostic> m_diagnostics;
 
 		friend AssetMountResolutionResult ResolveAssetMountCandidates(
-			std::vector<AssetMountCandidate> candidates);
+			TVector<AssetMountCandidate> candidates);
 	};
 
 	AssetMountDiscoveryResult DiscoverAssetMountFiles(
-		const std::vector<AssetMountDescriptor>& mounts);
+		const TVector<AssetMountDescriptor>& mounts);
 }

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -1,4 +1,5 @@
 #include "AssetRegistry/AssetRegistry.h"
+#include "Containers/Containers.h"
 
 #include "AssetRegistry/Animation/AnimationAssetInfo.h"
 #include "AssetRegistry/AssetInfo.h"
@@ -301,12 +302,12 @@ bool AssetRegistry::ResolveContentFile(
 		return false;
 	}
 
-	const auto winner = m_contentFileWinners.find(VirtualPathKey(virtualPath));
+	const auto winner = m_contentFileWinners.Find(VirtualPathKey(virtualPath));
 	if (winner == m_contentFileWinners.end())
 	{
 		return false;
 	}
-	outLocation = winner->second;
+	outLocation = winner.Value();
 	return true;
 }
 
@@ -423,21 +424,21 @@ void AssetRegistry::ScanContentFolder()
 		return;
 	}
 
-	std::map<std::string, const AssetMountDiscoveredFile*> filesByMountAndVirtualPath;
-	std::set<std::string> metadataFileKeys;
+	TMap<std::string, const AssetMountDiscoveredFile*> filesByMountAndVirtualPath;
+	TSet<std::string> metadataFileKeys;
 	for (const AssetMountDiscoveredFile& file : discovery.m_files)
 	{
 		const std::string key = MountFileKey(file.m_mount, file.m_virtualPath);
-		filesByMountAndVirtualPath.emplace(key, &file);
+		filesByMountAndVirtualPath.Insert(key, &file);
 		if (Extension(file.m_virtualPath) == MetaFileExtension)
 		{
-			metadataFileKeys.emplace(key);
+			metadataFileKeys.Insert(key);
 		}
 	}
 
-	std::vector<StagedAssetRecord> records;
-	std::set<std::string> consumedPrimaryMetadata;
-	std::set<std::string> invalidMetadata;
+	TVector<StagedAssetRecord> records;
+	TSet<std::string> consumedPrimaryMetadata;
+	TSet<std::string> invalidMetadata;
 	for (const AssetMountDiscoveredFile& metaFile : discovery.m_files)
 	{
 		if (Extension(metaFile.m_virtualPath) != MetaFileExtension)
@@ -457,7 +458,7 @@ void AssetRegistry::ScanContentFolder()
 				assetInfoType,
 				metadataError))
 		{
-			invalidMetadata.emplace(metaKey);
+			invalidMetadata.Insert(metaKey);
 			SAILOR_LOG_ERROR(
 				"Invalid asset metadata '%s': %s.",
 				metaFile.m_physicalPath.generic_string().c_str(),
@@ -467,7 +468,7 @@ void AssetRegistry::ScanContentFolder()
 
 		const std::string basenameVirtualPath = std::filesystem::path(
 			metaFile.m_virtualPath).replace_extension().generic_string();
-		const auto basenameAsset = filesByMountAndVirtualPath.find(
+		const auto basenameAsset = filesByMountAndVirtualPath.Find(
 			MountFileKey(metaFile.m_mount, basenameVirtualPath));
 		const bool bFilenameMatchesBasename =
 			std::filesystem::path(filename).generic_string() ==
@@ -482,18 +483,18 @@ void AssetRegistry::ScanContentFolder()
 		if (basenameAsset != filesByMountAndVirtualPath.end() && bFilenameMatchesBasename)
 		{
 			record.m_bPrimary = true;
-			record.m_assetPath = basenameAsset->second->m_physicalPath;
-			record.m_assetVirtualPath = basenameAsset->second->m_virtualPath;
+			record.m_assetPath = basenameAsset.Value()->m_physicalPath;
+			record.m_assetVirtualPath = basenameAsset.Value()->m_virtualPath;
 			record.m_candidate.m_physicalPath = record.m_assetPath;
 			record.m_candidate.m_virtualPath = record.m_assetVirtualPath;
-			consumedPrimaryMetadata.emplace(metaKey);
+			consumedPrimaryMetadata.Insert(metaKey);
 		}
 		else
 		{
 			const std::string declaredVirtualPath = (
 				std::filesystem::path(metaFile.m_virtualPath).parent_path() /
 				filename).generic_string();
-			const auto declaredAsset = filesByMountAndVirtualPath.find(
+			const auto declaredAsset = filesByMountAndVirtualPath.Find(
 				MountFileKey(metaFile.m_mount, declaredVirtualPath));
 			if (declaredAsset == filesByMountAndVirtualPath.end())
 			{
@@ -504,13 +505,13 @@ void AssetRegistry::ScanContentFolder()
 				continue;
 			}
 
-			record.m_assetPath = declaredAsset->second->m_physicalPath;
-			record.m_assetVirtualPath = declaredAsset->second->m_virtualPath;
+			record.m_assetPath = declaredAsset.Value()->m_physicalPath;
+			record.m_assetVirtualPath = declaredAsset.Value()->m_virtualPath;
 			record.m_candidate.m_physicalPath = record.m_metaPath;
 			record.m_candidate.m_virtualPath = record.m_metaVirtualPath;
 		}
 		record.m_candidate.m_fileId = fileId;
-		records.emplace_back(std::move(record));
+		records.Add(std::move(record));
 	}
 
 	for (const AssetMountDiscoveredFile& assetFile : discovery.m_files)
@@ -522,7 +523,7 @@ void AssetRegistry::ScanContentFolder()
 
 		const std::string metaVirtualPath = assetFile.m_virtualPath + "." + MetaFileExtension;
 		const std::string metaKey = MountFileKey(assetFile.m_mount, metaVirtualPath);
-		if (consumedPrimaryMetadata.contains(metaKey))
+		if (consumedPrimaryMetadata.Contains(metaKey))
 		{
 			continue;
 		}
@@ -536,16 +537,16 @@ void AssetRegistry::ScanContentFolder()
 		record.m_metaPath = assetFile.m_physicalPath.string() + "." + MetaFileExtension;
 		record.m_metaVirtualPath = metaVirtualPath;
 		record.m_bPrimary = true;
-		record.m_bMetadataInvalid = invalidMetadata.contains(metaKey) ||
-			(metadataFileKeys.contains(metaKey) && !consumedPrimaryMetadata.contains(metaKey));
-		records.emplace_back(std::move(record));
+		record.m_bMetadataInvalid = invalidMetadata.Contains(metaKey) ||
+			(metadataFileKeys.Contains(metaKey) && !consumedPrimaryMetadata.Contains(metaKey));
+		records.Add(std::move(record));
 	}
 
-	std::vector<AssetMountCandidate> candidates;
-	candidates.reserve(records.size());
+	TVector<AssetMountCandidate> candidates;
+	candidates.Reserve(records.Num());
 	for (const StagedAssetRecord& record : records)
 	{
-		candidates.emplace_back(record.m_candidate);
+		candidates.Add(record.m_candidate);
 	}
 	const AssetMountResolutionResult resolution = ResolveAssetMountCandidates(std::move(candidates));
 	for (const AssetMountDiagnostic& diagnostic : resolution.GetDiagnostics())
@@ -553,7 +554,7 @@ void AssetRegistry::ScanContentFolder()
 		SAILOR_LOG("%s", diagnostic.m_message.c_str());
 	}
 
-	std::map<std::string, AssetReadLocation> stagedContentWinners;
+	TMap<std::string, AssetReadLocation> stagedContentWinners;
 	for (const StagedAssetRecord& record : records)
 	{
 		if (!record.m_bPrimary ||
@@ -576,15 +577,15 @@ void AssetRegistry::ScanContentFolder()
 	TMap<FileId, AssetInfoPtr> stagedAssetInfos;
 	TMap<std::string, FileId> stagedFileIds;
 	TMap<std::string, FileId> stagedPhysicalFileIds;
-	std::vector<PendingAssetNotification> pendingNotifications;
-	std::vector<std::filesystem::path> importedMetadata;
+	TVector<PendingAssetNotification> pendingNotifications;
+	TVector<std::filesystem::path> importedMetadata;
 	auto rollbackStaging = [&]()
 	{
 		DeleteAssetInfos(stagedAssetInfos);
-		for (auto it = importedMetadata.rbegin(); it != importedMetadata.rend(); ++it)
+		for (size_t index = importedMetadata.Num(); index > 0; --index)
 		{
 			std::error_code removeError;
-			std::filesystem::remove(*it, removeError);
+			std::filesystem::remove(importedMetadata[index - 1], removeError);
 		}
 	};
 	for (const StagedAssetRecord& record : records)
@@ -611,7 +612,7 @@ void AssetRegistry::ScanContentFolder()
 			const bool bMetaExisted = std::filesystem::exists(record.m_metaPath);
 			if (!bMetaExisted)
 			{
-				importedMetadata.emplace_back(record.m_metaPath);
+				importedMetadata.Add(record.m_metaPath);
 			}
 			AssetInfoPtr assetInfo = handler->ImportAsset(
 				record.m_assetPath.string(),
@@ -621,7 +622,7 @@ void AssetRegistry::ScanContentFolder()
 			stagedAssetInfos[assetInfo->GetFileId()] = assetInfo;
 			stagedFileIds[VirtualPathKey(record.m_assetVirtualPath)] = assetInfo->GetFileId();
 			stagedPhysicalFileIds[PathKey(record.m_assetPath)] = assetInfo->GetFileId();
-			pendingNotifications.push_back({ handler, assetInfo, true });
+			pendingNotifications.Add({ handler, assetInfo, true });
 			continue;
 		}
 
@@ -672,7 +673,7 @@ void AssetRegistry::ScanContentFolder()
 		{
 			stagedFileIds[VirtualPathKey(record.m_assetVirtualPath)] = fileId;
 		}
-		pendingNotifications.push_back({ handler, assetInfo, false });
+		pendingNotifications.Add({ handler, assetInfo, false });
 	}
 
 	for (const StagedAssetRecord& record : records)
@@ -698,10 +699,10 @@ void AssetRegistry::ScanContentFolder()
 		if (!scheduler->IsMainThread())
 		{
 			DeleteAssetInfos(stagedAssetInfos);
-			for (auto it = importedMetadata.rbegin(); it != importedMetadata.rend(); ++it)
+			for (size_t i = importedMetadata.Num(); i > 0; --i)
 			{
 				std::error_code removeError;
-				std::filesystem::remove(*it, removeError);
+				std::filesystem::remove(importedMetadata[i - 1], removeError);
 			}
 			SAILOR_LOG_ERROR(
 				"Asset registry generations may only be committed from the main thread; preserving the previous generation.");
@@ -778,10 +779,10 @@ bool AssetRegistry::ResolveDirectLoadPath(
 			IsInside(App::GetWorkspaceContext().GetContent(), workspaceCandidate))
 		{
 			const std::string virtualPath = std::filesystem::path(requestedPath).generic_string();
-			const auto winner = m_contentFileWinners.find(VirtualPathKey(virtualPath));
+			const auto winner = m_contentFileWinners.Find(VirtualPathKey(virtualPath));
 			if (winner == m_contentFileWinners.end() ||
-				winner->second.m_mountKind == EAssetMountKind::Engine ||
-				PathKey(winner->second.m_physicalPath) == PathKey(workspaceCandidate))
+				winner.Value().m_mountKind == EAssetMountKind::Engine ||
+				PathKey(winner.Value().m_physicalPath) == PathKey(workspaceCandidate))
 			{
 				outLocation = AssetReadLocation{
 					workspaceCandidate,
@@ -815,16 +816,16 @@ bool AssetRegistry::ResolveDirectLoadPath(
 		if (IsInside(mount.m_root, candidate))
 		{
 			const std::string virtualPath = candidate.lexically_relative(mount.m_root).generic_string();
-			const auto winner = m_contentFileWinners.find(VirtualPathKey(virtualPath));
+			const auto winner = m_contentFileWinners.Find(VirtualPathKey(virtualPath));
 			if (winner != m_contentFileWinners.end() &&
-				PathKey(winner->second.m_physicalPath) == PathKey(candidate))
+				PathKey(winner.Value().m_physicalPath) == PathKey(candidate))
 			{
-				outLocation = winner->second;
+				outLocation = winner.Value();
 				return true;
 			}
 			if (mount.m_kind != EAssetMountKind::Workspace || !mount.m_bWritable ||
 				(winner != m_contentFileWinners.end() &&
-					winner->second.m_mountKind == EAssetMountKind::Workspace))
+					winner.Value().m_mountKind == EAssetMountKind::Workspace))
 			{
 				return false;
 			}

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -198,8 +198,8 @@ namespace Sailor
 		TMap<std::string, FileId> m_fileIds;
 		TMap<std::string, FileId> m_physicalFileIds;
 		TMap<std::string, class IAssetInfoHandler*> m_assetInfoHandlers;
-		std::vector<AssetMountDescriptor> m_contentMounts;
-		std::map<std::string, AssetReadLocation> m_contentFileWinners;
+		TVector<AssetMountDescriptor> m_contentMounts;
+		TMap<std::string, AssetReadLocation> m_contentFileWinners;
 
 		AssetCache m_assetCache;
 	};

--- a/Runtime/AssetRegistry/Model/ModelImporter.h
+++ b/Runtime/AssetRegistry/Model/ModelImporter.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Containers/Containers.h"
 #include "Core/Defines.h"
 #include <string>
 #include "Containers/Vector.h"
@@ -93,7 +94,7 @@ namespace Sailor
 
 		struct MeshContext
 		{
-			std::unordered_map<RHI::VertexP3N3T3B3UV2C4I4W4, uint32_t> uniqueVertices;
+			TMap<RHI::VertexP3N3T3B3UV2C4I4W4, uint32_t> uniqueVertices;
 			TVector<RHI::VertexP3N3T3B3UV2C4I4W4> outVertices;
 			TVector<uint32_t> outIndices;
 			Math::AABB bounds{};

--- a/Runtime/AssetRegistry/Shader/ShaderCache.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.cpp
@@ -1,4 +1,5 @@
 #include "ShaderCache.h"
+#include "Containers/Containers.h"
 
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/Shader/ShaderCompiler.h"
@@ -84,13 +85,13 @@ namespace
 			return false;
 		}
 
-		std::unordered_set<std::string> expected;
+		TSet<std::string> expected;
 		for (const char* field : expectedFields)
 		{
-			expected.emplace(field);
+			expected.Insert(field);
 		}
 
-		std::unordered_set<std::string> actual;
+		TSet<std::string> actual;
 		for (const auto& field : node)
 		{
 			if (!field.first.IsScalar())
@@ -100,12 +101,12 @@ namespace
 			}
 
 			const std::string name = field.first.Scalar();
-			if (!actual.emplace(name).second)
+			if (!actual.Insert(name))
 			{
 				outDiagnostic = context + " contains duplicate field '" + name + "'.";
 				return false;
 			}
-			if (!expected.contains(name))
+			if (!expected.Contains(name))
 			{
 				outDiagnostic = context + " contains unknown field '" + name + "'.";
 				return false;
@@ -114,7 +115,7 @@ namespace
 
 		for (const std::string& field : expected)
 		{
-			if (!actual.contains(field))
+			if (!actual.Contains(field))
 			{
 				outDiagnostic = context + " is missing required field '" + field + "'.";
 				return false;
@@ -546,7 +547,7 @@ bool ShaderCache::TryDeserializeShaderCachePayload(
 	};
 
 	ShaderCacheData candidate;
-	std::unordered_set<std::string> fileIds;
+	TSet<std::string> fileIds;
 	for (const auto& serializedFileEntries : entriesNode)
 	{
 		if (!serializedFileEntries.first.IsScalar())
@@ -556,7 +557,7 @@ bool ShaderCache::TryDeserializeShaderCachePayload(
 		}
 
 		const std::string serializedFileId = serializedFileEntries.first.Scalar();
-		if (!fileIds.emplace(serializedFileId).second)
+		if (!fileIds.Insert(serializedFileId))
 		{
 			outDiagnostic = "Shader cache contains duplicate file id '" + serializedFileId + "'.";
 			return false;
@@ -579,7 +580,7 @@ bool ShaderCache::TryDeserializeShaderCachePayload(
 
 		TVector<ShaderCacheData::Entry> entries;
 		entries.Reserve(entrySequence.size());
-		std::unordered_set<uint32_t> permutations;
+		TSet<uint32_t> permutations;
 		for (size_t index = 0; index < entrySequence.size(); ++index)
 		{
 			const std::string context = "Shader cache entry '" + serializedFileId +
@@ -615,7 +616,7 @@ bool ShaderCache::TryDeserializeShaderCachePayload(
 				outDiagnostic = context + " has a mismatched fileId field.";
 				return false;
 			}
-			if (!permutations.emplace(entry.m_permutation).second)
+			if (!permutations.Insert(entry.m_permutation))
 			{
 				outDiagnostic = context + " duplicates permutation " +
 					std::to_string(entry.m_permutation) + ".";
@@ -761,7 +762,7 @@ ShaderCache::ArtifactMetadata ShaderCache::DescribeArtifact(const void* data, ui
 bool ShaderCache::ReadArtifactBytes(
 	const std::filesystem::path& path,
 	const ArtifactMetadata& metadata,
-	std::vector<uint8_t>& outBytes,
+	TVector<uint8_t>& outBytes,
 	std::string& outDiagnostic,
 	bool& outIoFailure) noexcept
 {
@@ -773,7 +774,7 @@ bool ShaderCache::ReadArtifactBytes(
 	}
 	if (!metadata.IsPresent())
 	{
-		outBytes.clear();
+		outBytes.Clear();
 		outDiagnostic.clear();
 		return true;
 	}
@@ -810,17 +811,17 @@ bool ShaderCache::ReadArtifactBytes(
 		return false;
 	}
 
-	std::vector<uint8_t> candidate(static_cast<size_t>(metadata.m_byteLength));
+	TVector<uint8_t> candidate(static_cast<size_t>(metadata.m_byteLength));
 	stream.read(
-		reinterpret_cast<char*>(candidate.data()),
-		static_cast<std::streamsize>(candidate.size()));
-	if (stream.gcount() != static_cast<std::streamsize>(candidate.size()) || stream.bad())
+		reinterpret_cast<char*>(candidate.GetData()),
+		static_cast<std::streamsize>(candidate.Num()));
+	if (stream.gcount() != static_cast<std::streamsize>(candidate.Num()) || stream.bad())
 	{
 		outIoFailure = stream.bad();
 		outDiagnostic = "Shader artifact read was incomplete for '" + path.generic_string() + "'.";
 		return false;
 	}
-	if (CalculateArtifactChecksum(candidate.data(), candidate.size()) != metadata.m_checksum)
+	if (CalculateArtifactChecksum(candidate.GetData(), candidate.Num()) != metadata.m_checksum)
 	{
 		outDiagnostic = "Shader artifact checksum mismatch for '" + path.generic_string() + "'.";
 		return false;
@@ -873,17 +874,17 @@ bool ShaderCache::ReadSpirvArtifactInternal(
 		return false;
 	}
 
-	std::vector<uint8_t> bytes;
+	TVector<uint8_t> bytes;
 	if (!ReadArtifactBytes(path, metadata, bytes, outDiagnostic, outIoFailure))
 	{
 		return false;
 	}
 
 	TVector<uint32_t> candidate;
-	candidate.Resize(bytes.size() / sizeof(uint32_t));
-	if (!bytes.empty())
+	candidate.Resize(bytes.Num() / sizeof(uint32_t));
+	if (!bytes.IsEmpty())
 	{
-		std::memcpy(candidate.GetData(), bytes.data(), bytes.size());
+		std::memcpy(candidate.GetData(), bytes.GetData(), bytes.Num());
 	}
 	outSpirv = std::move(candidate);
 	return true;
@@ -2065,7 +2066,7 @@ bool ShaderCache::SweepUnreferencedArtifactsLocked(
 		return false;
 	}
 
-	std::unordered_set<std::string> whitelist;
+	TSet<std::string> whitelist;
 	for (const auto& fileEntries : committedSnapshot.m_data)
 	{
 		for (const ShaderCacheData::Entry& entry : *fileEntries.m_second)
@@ -2086,10 +2087,10 @@ bool ShaderCache::SweepUnreferencedArtifactsLocked(
 			{
 				if (metadata->IsPresent())
 				{
-					whitelist.emplace(GetArtifactPathLocked(entry, kind, false).lexically_normal().generic_string());
+					whitelist.Insert(GetArtifactPathLocked(entry, kind, false).lexically_normal().generic_string());
 					if (m_bSavePrecompiledGlsl)
 					{
-						whitelist.emplace(GetShaderFilepath(
+						whitelist.Insert(GetShaderFilepath(
 							GetPrecompiledFolderLocked(),
 							entry.m_fileId,
 							entry.m_permutation,
@@ -2102,7 +2103,7 @@ bool ShaderCache::SweepUnreferencedArtifactsLocked(
 			{
 				if (metadata->IsPresent())
 				{
-					whitelist.emplace(GetArtifactPathLocked(entry, kind, true).lexically_normal().generic_string());
+					whitelist.Insert(GetArtifactPathLocked(entry, kind, true).lexically_normal().generic_string());
 				}
 			}
 		}
@@ -2124,7 +2125,7 @@ bool ShaderCache::SweepUnreferencedArtifactsLocked(
 		{
 			const auto& path = iterator->path();
 			if (iterator->is_regular_file(error) &&
-				!whitelist.contains(path.lexically_normal().generic_string()))
+				!whitelist.Contains(path.lexically_normal().generic_string()))
 			{
 				std::string diagnostic;
 				if (!RemoveOwnedArtifact(m_cacheRoot, folder, path, diagnostic))

--- a/Runtime/AssetRegistry/Shader/ShaderCache.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Containers/Containers.h"
 
 #include "AssetRegistry/FileId.h"
 #include "Containers/Map.h"
@@ -185,7 +186,7 @@ namespace Sailor
 		static bool ReadArtifactBytes(
 			const std::filesystem::path& path,
 			const ArtifactMetadata& metadata,
-			std::vector<uint8_t>& outBytes,
+			TVector<uint8_t>& outBytes,
 			std::string& outDiagnostic,
 			bool& outIoFailure) noexcept;
 		static bool ReadSpirvArtifactInternal(

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -484,7 +484,7 @@ Tasks::TaskPtr<bool> ShaderCompiler::CompileAllPermutations(ShaderAssetInfoPtr a
 
 		SAILOR_LOG("Compiling shader: %s Num permutations: %zd", assetInfo->GetAssetFilepath().c_str(), permutationsToCompile.Num());
 
-		auto compileSucceeded = std::make_shared<std::atomic_bool>(true);
+		auto compileSucceeded = TSharedPtr<std::atomic_bool>::Make(true);
 		Tasks::TaskPtr<bool> saveCacheJob = Tasks::CreateTaskWithResult<bool>("Save Shader Cache", [=, this]()
 			{
 				const bool bCompiled = compileSucceeded->load(std::memory_order_acquire);

--- a/Runtime/AssetRegistry/Texture/TextureImporter.cpp
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.cpp
@@ -1,4 +1,5 @@
 #include "AssetRegistry/Texture/TextureImporter.h"
+#include "Containers/Containers.h"
 #include "AssetRegistry/FileId.h"
 #include "AssetRegistry/AssetRegistry.h"
 #include "TextureAssetInfo.h"
@@ -61,9 +62,11 @@ bool ExtractTextureFromGLB(const std::string& filePath, int32_t textureIndex, Sa
 		return false;
 	}
 
-	std::vector<char> jsonChunk(jsonChunkHeader.chunkLength);
-	file.read(jsonChunk.data(), jsonChunkHeader.chunkLength);
-	nlohmann::json gltfJson = nlohmann::json::parse(jsonChunk);
+	TVector<char> jsonChunk(jsonChunkHeader.chunkLength);
+	file.read(jsonChunk.GetData(), jsonChunkHeader.chunkLength);
+	nlohmann::json gltfJson = nlohmann::json::parse(
+		jsonChunk.GetData(),
+		jsonChunk.GetData() + jsonChunk.Num());
 
 	if (textureIndex < 0 || textureIndex >= gltfJson["textures"].size())
 	{
@@ -474,5 +477,4 @@ void TextureImporter::CollectGarbage()
 		m_promises.Remove(uid);
 	}
 }
-
 

--- a/Runtime/Containers/Map.h
+++ b/Runtime/Containers/Map.h
@@ -49,10 +49,10 @@ namespace Sailor
 			bool operator!=(const TBaseIterator& rhs) const { return m_it != rhs.m_it; }
 
 			TPair<TKeyType, TValueType*> operator*() { return TPair<TKeyType, TValueType*>(m_it->m_first, &(*m_map->m_values[m_it->m_second])); }
-			TPair<TKeyType, const TValueType*> operator*() const { return TPair<TKeyType, TValueType*>(m_it->m_first, &(*m_map->m_values[m_it->m_second])); }
+			TPair<TKeyType, const TValueType*> operator*() const { return TPair<TKeyType, const TValueType*>(m_it->m_first, &(*m_map->m_values[m_it->m_second])); }
 
 			TPair<TKeyType, TValueType*> operator->() { return TPair<TKeyType, TValueType*>(m_it->m_first, &(*m_map->m_values[m_it->m_second])); }
-			TPair<TKeyType, const TValueType*> operator->() const { return TPair<TKeyType, TValueType*>(m_it->m_first, &(*m_map->m_values[m_it->m_second])); }
+			TPair<TKeyType, const TValueType*> operator->() const { return TPair<TKeyType, const TValueType*>(m_it->m_first, &(*m_map->m_values[m_it->m_second])); }
 
 			const TKeyType& Key() const { return m_it->m_first; }
 
@@ -162,8 +162,13 @@ namespace Sailor
 			Insert(key, value);
 		}
 
-		void Insert(const TKeyType& key, const TValueType& value) requires IsCopyConstructible<TValueType>
+		bool Insert(const TKeyType& key, const TValueType& value) requires IsCopyConstructible<TValueType>
 		{
+			if (ContainsKey(key))
+			{
+				return false;
+			}
+
 			size_t index = 0;
 			if (m_freeList.Num() > 0)
 			{
@@ -178,10 +183,16 @@ namespace Sailor
 			}
 
 			Super::Insert(TElementType(key, index));
+			return true;
 		}
 
-		void Insert(const TKeyType& key, TValueType&& value) requires IsMoveConstructible<TValueType>
+		bool Insert(const TKeyType& key, TValueType&& value) requires IsMoveConstructible<TValueType>
 		{
+			if (ContainsKey(key))
+			{
+				return false;
+			}
+
 			size_t index = 0;
 			if (m_freeList.Num() > 0)
 			{
@@ -196,6 +207,7 @@ namespace Sailor
 			}
 
 			Super::Insert(TElementType(key, index));
+			return true;
 		}
 
 		bool Remove(const TKeyType& key)

--- a/Runtime/Containers/Set.h
+++ b/Runtime/Containers/Set.h
@@ -221,7 +221,7 @@ namespace Sailor
 			}
 		}
 
-		void Insert(TElementType inElement)
+		bool Insert(TElementType inElement)
 		{
 			if (ShouldRehash())
 			{
@@ -250,13 +250,14 @@ namespace Sailor
 
 			if (element->GetContainer().Contains(inElement))
 			{
-				return;
+				return false;
 			}
 
 			element->GetContainer().EmplaceBack(std::move(inElement));
 			element->m_bloom |= hash;
 
 			m_num++;
+			return true;
 		}
 
 		bool RemoveFirst(const TPredicate<TElementType>& predicate)

--- a/Runtime/Containers/Vector.h
+++ b/Runtime/Containers/Vector.h
@@ -56,6 +56,9 @@ namespace Sailor
 		bool operator!=(const TVectorIterator& rhs) const { return m_element != rhs.m_element; }
 
 		bool operator<(const TVectorIterator& rhs) const { return m_element < rhs.m_element; }
+		bool operator>(const TVectorIterator& rhs) const { return m_element > rhs.m_element; }
+		bool operator<=(const TVectorIterator& rhs) const { return m_element <= rhs.m_element; }
+		bool operator>=(const TVectorIterator& rhs) const { return m_element >= rhs.m_element; }
 
 		reference operator*() { return *m_element; }
 		reference operator*() const { return *m_element; }
@@ -69,10 +72,24 @@ namespace Sailor
 			return *this;
 		}
 
+		TVectorIterator operator++(int)
+		{
+			TVectorIterator previous(*this);
+			++(*this);
+			return previous;
+		}
+
 		TVectorIterator& operator--()
 		{
 			--m_element;
 			return *this;
+		}
+
+		TVectorIterator operator--(int)
+		{
+			TVectorIterator previous(*this);
+			--(*this);
+			return previous;
 		}
 
 		TVectorIterator operator-(difference_type rhs) const { return m_element - rhs; }

--- a/Runtime/Core/Reflection.cpp
+++ b/Runtime/Core/Reflection.cpp
@@ -18,7 +18,6 @@
 #include <algorithm>
 #include <condition_variable>
 #include <iterator>
-#include <memory>
 #include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
@@ -140,7 +139,7 @@ namespace Sailor::Internal
 			}
 		}
 
-		bool Acquire(const std::shared_ptr<WorkspaceTypeInvocationState>& state)
+		bool Acquire(const TSharedPtr<WorkspaceTypeInvocationState>& state)
 		{
 			if (!state)
 			{
@@ -159,14 +158,14 @@ namespace Sailor::Internal
 		}
 
 	private:
-		std::shared_ptr<WorkspaceTypeInvocationState> m_state;
+		TSharedPtr<WorkspaceTypeInvocationState> m_state;
 	};
 
 	struct WorkspaceTypeEntry
 	{
 		std::string m_owner;
 		const TypeInfo* m_typeInfo{};
-		std::shared_ptr<WorkspaceTypeInvocationState> m_invocationState;
+		TSharedPtr<WorkspaceTypeInvocationState> m_invocationState;
 		Reflection::TPlacementFactoryMethod m_placementFactory;
 		ReflectedData m_defaultObject;
 		size_t m_alignment = 8;
@@ -339,7 +338,7 @@ bool Reflection::RegisterWorkspaceTypes(
 		}
 	}
 
-	const auto invocationState = std::make_shared<Internal::WorkspaceTypeInvocationState>();
+	const auto invocationState = TSharedPtr<Internal::WorkspaceTypeInvocationState>::Make();
 	for (WorkspaceTypeRegistration& registration : registrations)
 	{
 		const std::string typeName = registration.m_typeInfo->Name();
@@ -358,7 +357,7 @@ bool Reflection::RegisterWorkspaceTypes(
 
 size_t Reflection::UnregisterWorkspaceTypes(const std::string& owner)
 {
-	std::shared_ptr<Internal::WorkspaceTypeInvocationState> invocationState;
+	TSharedPtr<Internal::WorkspaceTypeInvocationState> invocationState;
 	size_t numRemoved = 0;
 	{
 		std::unique_lock lock(Internal::GetWorkspaceTypesMutex());

--- a/Runtime/Core/Reflection.cpp
+++ b/Runtime/Core/Reflection.cpp
@@ -170,6 +170,7 @@ namespace Sailor::Internal
 		ReflectedData m_defaultObject;
 		size_t m_alignment = 8;
 	};
+	using WorkspaceTypeEntryPtr = TUniquePtr<WorkspaceTypeEntry>;
 
 	TUniquePtr<TConcurrentMap<std::string, ReflectedData, 32u, ERehashPolicy::Never>> g_pCdos;
 	TUniquePtr<TConcurrentMap<std::string, Reflection::TPlacementFactoryMethod>> g_pPlacementFactoryMethods;
@@ -178,9 +179,9 @@ namespace Sailor::Internal
 
 	// Engine reflection registration can run during static initialization.
 	// Process-lifetime storage avoids cross-translation-unit initialization and teardown ordering.
-	TMap<std::string, WorkspaceTypeEntry>& GetWorkspaceTypes()
+	TMap<std::string, WorkspaceTypeEntryPtr>& GetWorkspaceTypes()
 	{
-		static auto* workspaceTypes = new TMap<std::string, WorkspaceTypeEntry>();
+		static auto* workspaceTypes = new TMap<std::string, WorkspaceTypeEntryPtr>();
 		return *workspaceTypes;
 	}
 
@@ -287,7 +288,7 @@ bool Reflection::RegisterWorkspaceTypes(
 	std::unique_lock lock(Internal::GetWorkspaceTypesMutex());
 	for (const auto& pair : Internal::GetWorkspaceTypes())
 	{
-		if (pair.m_second->m_owner == owner)
+		if ((*pair.m_second)->m_owner == owner)
 		{
 			outError = "Workspace owner '" + owner + "' is already registered.";
 			return false;
@@ -342,13 +343,13 @@ bool Reflection::RegisterWorkspaceTypes(
 	for (WorkspaceTypeRegistration& registration : registrations)
 	{
 		const std::string typeName = registration.m_typeInfo->Name();
-		Internal::WorkspaceTypeEntry entry;
-		entry.m_owner = owner;
-		entry.m_typeInfo = registration.m_typeInfo;
-		entry.m_invocationState = invocationState;
-		entry.m_placementFactory = std::move(registration.m_placementFactory);
-		entry.m_defaultObject = std::move(registration.m_defaultObject);
-		entry.m_alignment = registration.m_alignment;
+		auto entry = Internal::WorkspaceTypeEntryPtr::Make();
+		entry->m_owner = owner;
+		entry->m_typeInfo = registration.m_typeInfo;
+		entry->m_invocationState = invocationState;
+		entry->m_placementFactory = std::move(registration.m_placementFactory);
+		entry->m_defaultObject = std::move(registration.m_defaultObject);
+		entry->m_alignment = registration.m_alignment;
 		Internal::GetWorkspaceTypes().Insert(typeName, std::move(entry));
 	}
 
@@ -363,17 +364,17 @@ size_t Reflection::UnregisterWorkspaceTypes(const std::string& owner)
 		std::unique_lock lock(Internal::GetWorkspaceTypesMutex());
 		for (auto it = Internal::GetWorkspaceTypes().begin(); it != Internal::GetWorkspaceTypes().end();)
 		{
-			if (it.Value().m_owner == owner)
+			if (it.Value()->m_owner == owner)
 			{
 				if (!invocationState)
 				{
-					invocationState = it.Value().m_invocationState;
+					invocationState = it.Value()->m_invocationState;
 					std::lock_guard invocationLock(invocationState->m_mutex);
 					invocationState->m_bUnloading = true;
 				}
 				else
 				{
-					check(invocationState == it.Value().m_invocationState);
+					check(invocationState == it.Value()->m_invocationState);
 				}
 
 				const std::string typeName = it.Key();
@@ -412,7 +413,7 @@ size_t Reflection::GetNumWorkspaceTypes(const std::string& owner)
 	return static_cast<size_t>(std::count_if(
 		Internal::GetWorkspaceTypes().begin(),
 		Internal::GetWorkspaceTypes().end(),
-		[&owner](const auto& pair) { return pair.m_second->m_owner == owner; }));
+		[&owner](const auto& pair) { return (*pair.m_second)->m_owner == owner; }));
 }
 
 const TypeInfo* Reflection::TryGetTypeByName(const std::string& typeName)
@@ -422,7 +423,7 @@ const TypeInfo* Reflection::TryGetTypeByName(const std::string& typeName)
 		const auto workspaceType = Internal::GetWorkspaceTypes().Find(typeName);
 		if (workspaceType != Internal::GetWorkspaceTypes().end())
 		{
-			return workspaceType.Value().m_typeInfo;
+			return workspaceType.Value()->m_typeInfo;
 		}
 	}
 
@@ -463,7 +464,7 @@ const ReflectedData& Reflection::GetCDO(const std::string& typeName)
 		const auto workspaceType = Internal::GetWorkspaceTypes().Find(typeName);
 		if (workspaceType != Internal::GetWorkspaceTypes().end())
 		{
-			return workspaceType.Value().m_defaultObject;
+			return workspaceType.Value()->m_defaultObject;
 		}
 	}
 
@@ -474,7 +475,7 @@ size_t Reflection::GetObjectAlignment(const std::string& typeName)
 {
 	std::shared_lock lock(Internal::GetWorkspaceTypesMutex());
 	const auto workspaceType = Internal::GetWorkspaceTypes().Find(typeName);
-	return workspaceType != Internal::GetWorkspaceTypes().end() ? workspaceType.Value().m_alignment : 8;
+	return workspaceType != Internal::GetWorkspaceTypes().end() ? workspaceType.Value()->m_alignment : 8;
 }
 
 bool Reflection::ConstructObject(const std::string& typeName, void* destination)
@@ -487,12 +488,12 @@ bool Reflection::ConstructObject(const std::string& typeName, void* destination)
 		const auto workspaceType = Internal::GetWorkspaceTypes().Find(typeName);
 		if (workspaceType != Internal::GetWorkspaceTypes().end())
 		{
-			if (!workspaceInvocation.Acquire(workspaceType.Value().m_invocationState))
+			if (!workspaceInvocation.Acquire(workspaceType.Value()->m_invocationState))
 			{
 				return false;
 			}
 
-			workspacePlacementFactory = workspaceType.Value().m_placementFactory;
+			workspacePlacementFactory = workspaceType.Value()->m_placementFactory;
 		}
 	}
 

--- a/Runtime/Core/Reflection.cpp
+++ b/Runtime/Core/Reflection.cpp
@@ -1,4 +1,5 @@
 #include "Reflection.h"
+#include "Containers/Containers.h"
 #include "Components/Component.h"
 #include "Containers/ConcurrentMap.h"
 #include "RHI/Types.h"
@@ -178,9 +179,9 @@ namespace Sailor::Internal
 
 	// Engine reflection registration can run during static initialization.
 	// Process-lifetime storage avoids cross-translation-unit initialization and teardown ordering.
-	std::unordered_map<std::string, WorkspaceTypeEntry>& GetWorkspaceTypes()
+	TMap<std::string, WorkspaceTypeEntry>& GetWorkspaceTypes()
 	{
-		static auto* workspaceTypes = new std::unordered_map<std::string, WorkspaceTypeEntry>();
+		static auto* workspaceTypes = new TMap<std::string, WorkspaceTypeEntry>();
 		return *workspaceTypes;
 	}
 
@@ -274,7 +275,7 @@ bool Reflection::IsEngineAutoRegistrationSuppressed()
 
 bool Reflection::RegisterWorkspaceTypes(
 	const std::string& owner,
-	std::vector<WorkspaceTypeRegistration>&& registrations,
+	TVector<WorkspaceTypeRegistration>&& registrations,
 	std::string& outError)
 {
 	outError.clear();
@@ -287,14 +288,14 @@ bool Reflection::RegisterWorkspaceTypes(
 	std::unique_lock lock(Internal::GetWorkspaceTypesMutex());
 	for (const auto& pair : Internal::GetWorkspaceTypes())
 	{
-		if (pair.second.m_owner == owner)
+		if (pair.m_second->m_owner == owner)
 		{
 			outError = "Workspace owner '" + owner + "' is already registered.";
 			return false;
 		}
 	}
 
-	std::unordered_set<std::string> incomingTypeNames;
+	TSet<std::string> incomingTypeNames;
 	for (const WorkspaceTypeRegistration& registration : registrations)
 	{
 		if (registration.m_typeInfo == nullptr || registration.m_typeInfo->Name().empty())
@@ -304,14 +305,14 @@ bool Reflection::RegisterWorkspaceTypes(
 		}
 
 		const std::string& typeName = registration.m_typeInfo->Name();
-		if (!incomingTypeNames.emplace(typeName).second)
+		if (!incomingTypeNames.Insert(typeName))
 		{
 			outError = "Workspace module contains duplicate type '" + typeName + "'.";
 			return false;
 		}
 
 		if ((Internal::g_pReflectionTypes && Internal::g_pReflectionTypes->ContainsKey(typeName)) ||
-			Internal::GetWorkspaceTypes().contains(typeName))
+			Internal::GetWorkspaceTypes().ContainsKey(typeName))
 		{
 			outError = "Workspace type '" + typeName + "' conflicts with an existing reflected type.";
 			return false;
@@ -339,7 +340,6 @@ bool Reflection::RegisterWorkspaceTypes(
 	}
 
 	const auto invocationState = std::make_shared<Internal::WorkspaceTypeInvocationState>();
-	Internal::GetWorkspaceTypes().reserve(Internal::GetWorkspaceTypes().size() + registrations.size());
 	for (WorkspaceTypeRegistration& registration : registrations)
 	{
 		const std::string typeName = registration.m_typeInfo->Name();
@@ -350,7 +350,7 @@ bool Reflection::RegisterWorkspaceTypes(
 		entry.m_placementFactory = std::move(registration.m_placementFactory);
 		entry.m_defaultObject = std::move(registration.m_defaultObject);
 		entry.m_alignment = registration.m_alignment;
-		Internal::GetWorkspaceTypes().emplace(typeName, std::move(entry));
+		Internal::GetWorkspaceTypes().Insert(typeName, std::move(entry));
 	}
 
 	return true;
@@ -364,20 +364,22 @@ size_t Reflection::UnregisterWorkspaceTypes(const std::string& owner)
 		std::unique_lock lock(Internal::GetWorkspaceTypesMutex());
 		for (auto it = Internal::GetWorkspaceTypes().begin(); it != Internal::GetWorkspaceTypes().end();)
 		{
-			if (it->second.m_owner == owner)
+			if (it.Value().m_owner == owner)
 			{
 				if (!invocationState)
 				{
-					invocationState = it->second.m_invocationState;
+					invocationState = it.Value().m_invocationState;
 					std::lock_guard invocationLock(invocationState->m_mutex);
 					invocationState->m_bUnloading = true;
 				}
 				else
 				{
-					check(invocationState == it->second.m_invocationState);
+					check(invocationState == it.Value().m_invocationState);
 				}
 
-				it = Internal::GetWorkspaceTypes().erase(it);
+				const std::string typeName = it.Key();
+				++it;
+				Internal::GetWorkspaceTypes().Remove(typeName);
 				++numRemoved;
 			}
 			else
@@ -402,7 +404,7 @@ size_t Reflection::UnregisterWorkspaceTypes(const std::string& owner)
 bool Reflection::IsWorkspaceTypeRegistered(const std::string& typeName)
 {
 	std::shared_lock lock(Internal::GetWorkspaceTypesMutex());
-	return Internal::GetWorkspaceTypes().contains(typeName);
+	return Internal::GetWorkspaceTypes().ContainsKey(typeName);
 }
 
 size_t Reflection::GetNumWorkspaceTypes(const std::string& owner)
@@ -411,17 +413,17 @@ size_t Reflection::GetNumWorkspaceTypes(const std::string& owner)
 	return static_cast<size_t>(std::count_if(
 		Internal::GetWorkspaceTypes().begin(),
 		Internal::GetWorkspaceTypes().end(),
-		[&owner](const auto& pair) { return pair.second.m_owner == owner; }));
+		[&owner](const auto& pair) { return pair.m_second->m_owner == owner; }));
 }
 
 const TypeInfo* Reflection::TryGetTypeByName(const std::string& typeName)
 {
 	{
 		std::shared_lock lock(Internal::GetWorkspaceTypesMutex());
-		const auto workspaceType = Internal::GetWorkspaceTypes().find(typeName);
+		const auto workspaceType = Internal::GetWorkspaceTypes().Find(typeName);
 		if (workspaceType != Internal::GetWorkspaceTypes().end())
 		{
-			return workspaceType->second.m_typeInfo;
+			return workspaceType.Value().m_typeInfo;
 		}
 	}
 
@@ -459,10 +461,10 @@ const ReflectedData& Reflection::GetCDO(const std::string& typeName)
 {
 	{
 		std::shared_lock lock(Internal::GetWorkspaceTypesMutex());
-		const auto workspaceType = Internal::GetWorkspaceTypes().find(typeName);
+		const auto workspaceType = Internal::GetWorkspaceTypes().Find(typeName);
 		if (workspaceType != Internal::GetWorkspaceTypes().end())
 		{
-			return workspaceType->second.m_defaultObject;
+			return workspaceType.Value().m_defaultObject;
 		}
 	}
 
@@ -472,8 +474,8 @@ const ReflectedData& Reflection::GetCDO(const std::string& typeName)
 size_t Reflection::GetObjectAlignment(const std::string& typeName)
 {
 	std::shared_lock lock(Internal::GetWorkspaceTypesMutex());
-	const auto workspaceType = Internal::GetWorkspaceTypes().find(typeName);
-	return workspaceType != Internal::GetWorkspaceTypes().end() ? workspaceType->second.m_alignment : 8;
+	const auto workspaceType = Internal::GetWorkspaceTypes().Find(typeName);
+	return workspaceType != Internal::GetWorkspaceTypes().end() ? workspaceType.Value().m_alignment : 8;
 }
 
 bool Reflection::ConstructObject(const std::string& typeName, void* destination)
@@ -483,15 +485,15 @@ bool Reflection::ConstructObject(const std::string& typeName, void* destination)
 	TPlacementFactoryMethod workspacePlacementFactory;
 	{
 		std::shared_lock lock(Internal::GetWorkspaceTypesMutex());
-		const auto workspaceType = Internal::GetWorkspaceTypes().find(typeName);
+		const auto workspaceType = Internal::GetWorkspaceTypes().Find(typeName);
 		if (workspaceType != Internal::GetWorkspaceTypes().end())
 		{
-			if (!workspaceInvocation.Acquire(workspaceType->second.m_invocationState))
+			if (!workspaceInvocation.Acquire(workspaceType.Value().m_invocationState))
 			{
 				return false;
 			}
 
-			workspacePlacementFactory = workspaceType->second.m_placementFactory;
+			workspacePlacementFactory = workspaceType.Value().m_placementFactory;
 		}
 	}
 

--- a/Runtime/Core/Reflection.h
+++ b/Runtime/Core/Reflection.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Containers/Containers.h"
 #include "Containers/Concepts.h"
 #include "Core/Defines.h"
 #include "Core/IReflectable.h"
@@ -476,7 +477,7 @@ namespace Sailor
 		static void RegisterType(const std::string& typeName, const TypeInfo* pType);
 		static bool RegisterWorkspaceTypes(
 			const std::string& owner,
-			std::vector<WorkspaceTypeRegistration>&& registrations,
+			TVector<WorkspaceTypeRegistration>&& registrations,
 			std::string& outError);
 		static size_t UnregisterWorkspaceTypes(const std::string& owner);
 		static bool IsWorkspaceTypeRegistered(const std::string& typeName);

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -15,7 +15,6 @@
 #include <cstring>
 #include <filesystem>
 #include <limits>
-#include <memory>
 #include <utility>
 
 using namespace Sailor;
@@ -153,10 +152,10 @@ uint32_t App::SerializeEditorTypes(char** yamlNode)
 		return 0;
 	}
 
-	auto serializedOutput = std::make_unique<char[]>(length + 1);
-	memcpy(serializedOutput.get(), serializedNode.c_str(), length);
+	auto serializedOutput = TUniquePtr<char[]>::Make(length + 1);
+	memcpy(serializedOutput.GetRawPtr(), serializedNode.c_str(), length);
 	serializedOutput[length] = '\0';
-	yamlNode[0] = serializedOutput.release();
+	yamlNode[0] = serializedOutput.Release();
 
 	return static_cast<uint32_t>(length);
 
@@ -192,10 +191,10 @@ uint32_t App::SerializeWorkspaceCacheIdentity(char** yamlNode)
 		return 0;
 	}
 
-	auto serializedOutput = std::make_unique<char[]>(length + 1);
-	memcpy(serializedOutput.get(), serializedNode.c_str(), length);
+	auto serializedOutput = TUniquePtr<char[]>::Make(length + 1);
+	memcpy(serializedOutput.GetRawPtr(), serializedNode.c_str(), length);
 	serializedOutput[length] = '\0';
-	yamlNode[0] = serializedOutput.release();
+	yamlNode[0] = serializedOutput.Release();
 
 	return static_cast<uint32_t>(length);
 

--- a/Runtime/Editor/EditorRuntimeBridge.cpp
+++ b/Runtime/Editor/EditorRuntimeBridge.cpp
@@ -1,4 +1,5 @@
 #include "EditorRuntimeBridge.h"
+#include "Containers/Containers.h"
 
 #include "Sailor.h"
 #include "AssetRegistry/AssetRegistry.h"
@@ -464,9 +465,9 @@ namespace
 		}
 	};
 
-	std::unordered_map<ViewportId, std::shared_ptr<RemoteViewportBinding>> g_remoteViewportBindings;
-	std::unordered_map<ViewportId, Sailor::EditorRemote::MacNativeHostHandle> g_pendingRemoteViewportHostHandles;
-	std::unordered_map<ViewportId, std::array<bool, 3>> g_remoteViewportMouseButtons;
+	TMap<ViewportId, std::shared_ptr<RemoteViewportBinding>> g_remoteViewportBindings;
+	TMap<ViewportId, Sailor::EditorRemote::MacNativeHostHandle> g_pendingRemoteViewportHostHandles;
+	TMap<ViewportId, std::array<bool, 3>> g_remoteViewportMouseButtons;
 	std::mutex g_remoteViewportBindingsMutex;
 	std::mutex g_editorViewportMutex;
 	RECT g_pendingEditorViewport{};
@@ -715,16 +716,16 @@ bool Sailor::EditorRuntime::HasAppliedEditorRenderArea()
 
 void Sailor::EditorRuntime::PumpEditorRemoteViewportsOnEngineThread()
 {
-	std::vector<std::shared_ptr<RemoteViewportBinding>> bindings{};
+	TVector<std::shared_ptr<RemoteViewportBinding>> bindings{};
 	{
 		std::lock_guard lock(g_remoteViewportBindingsMutex);
-		bindings.reserve(g_remoteViewportBindings.size());
-		for (auto& [viewportId, binding] : g_remoteViewportBindings)
+		bindings.Reserve(g_remoteViewportBindings.Num());
+		for (const auto& bindingEntry : g_remoteViewportBindings)
 		{
-			(void)viewportId;
+			const auto& binding = *bindingEntry.m_second;
 			if (binding)
 			{
-				bindings.push_back(binding);
+				bindings.Add(binding);
 			}
 		}
 	}
@@ -823,9 +824,9 @@ bool App::UpsertEditorRemoteViewport(uint64_t viewportId, uint32_t windowPosX, u
 	{
 		return true;
 	}
-	if (const auto hostIt = g_pendingRemoteViewportHostHandles.find(viewportId); hostIt != g_pendingRemoteViewportHostHandles.end())
+	if (const auto hostIt = g_pendingRemoteViewportHostHandles.Find(viewportId); hostIt != g_pendingRemoteViewportHostHandles.end())
 	{
-		binding->m_binding.GetHost().BindNativeHostHandle(viewportId, hostIt->second);
+		binding->m_binding.GetHost().BindNativeHostHandle(viewportId, hostIt.Value());
 	}
 	if (!binding->m_created)
 	{
@@ -858,20 +859,20 @@ bool App::DestroyEditorRemoteViewport(uint64_t viewportId)
 {
 	viewportId = viewportId == 0 ? kPrimaryEditorViewportId : viewportId;
 	std::lock_guard bindingsLock(g_remoteViewportBindingsMutex);
-	auto it = g_remoteViewportBindings.find(viewportId);
+	auto it = g_remoteViewportBindings.Find(viewportId);
 	if (it == g_remoteViewportBindings.end())
 	{
 		return false;
 	}
 
-	auto binding = it->second;
+	auto binding = it.Value();
 	std::unique_lock bindingLock(binding->m_mutex, std::try_to_lock);
 	if (!bindingLock.owns_lock())
 	{
 		return false;
 	}
 	binding->m_binding.Destroy();
-	g_remoteViewportBindings.erase(it);
+	g_remoteViewportBindings.Remove(viewportId);
 	return true;
 }
 
@@ -879,18 +880,18 @@ uint32_t App::GetEditorRemoteViewportState(uint64_t viewportId)
 {
 	viewportId = viewportId == 0 ? kPrimaryEditorViewportId : viewportId;
 	std::lock_guard bindingsLock(g_remoteViewportBindingsMutex);
-	auto it = g_remoteViewportBindings.find(viewportId);
+	auto it = g_remoteViewportBindings.Find(viewportId);
 	if (it == g_remoteViewportBindings.end())
 	{
 		return static_cast<uint32_t>(Sailor::EditorRemote::SessionState::Created);
 	}
 
-	std::unique_lock bindingLock(it->second->m_mutex, std::try_to_lock);
+	std::unique_lock bindingLock(it.Value()->m_mutex, std::try_to_lock);
 	if (!bindingLock.owns_lock())
 	{
 		return static_cast<uint32_t>(Sailor::EditorRemote::SessionState::Active);
 	}
-	return static_cast<uint32_t>(it->second->m_binding.GetRuntimeSession().GetState());
+	return static_cast<uint32_t>(it.Value()->m_binding.GetRuntimeSession().GetState());
 }
 
 uint32_t App::GetEditorRemoteViewportDiagnostics(uint64_t viewportId, char** diagnostics)
@@ -902,14 +903,14 @@ uint32_t App::GetEditorRemoteViewportDiagnostics(uint64_t viewportId, char** dia
 
 	viewportId = viewportId == 0 ? kPrimaryEditorViewportId : viewportId;
 	std::lock_guard bindingsLock(g_remoteViewportBindingsMutex);
-	auto it = g_remoteViewportBindings.find(viewportId);
+	auto it = g_remoteViewportBindings.Find(viewportId);
 	if (it == g_remoteViewportBindings.end())
 	{
 		diagnostics[0] = nullptr;
 		return 0;
 	}
 
-	std::unique_lock bindingLock(it->second->m_mutex, std::try_to_lock);
+	std::unique_lock bindingLock(it.Value()->m_mutex, std::try_to_lock);
 	if (!bindingLock.owns_lock())
 	{
 		static constexpr const char* kBusyDiagnostics = "busy";
@@ -919,10 +920,10 @@ uint32_t App::GetEditorRemoteViewportDiagnostics(uint64_t viewportId, char** dia
 		return static_cast<uint32_t>(kBusyDiagnosticsLen);
 	}
 
-	auto info = it->second->m_binding.GetRuntimeSession().GetDiagnostics();
+	auto info = it.Value()->m_binding.GetRuntimeSession().GetDiagnostics();
 #if defined(__APPLE__)
-	info.m_nativePresenterSummary = it->second->m_presenter.BuildViewportSummary(viewportId);
-	if (const auto* allocation = it->second->m_surfaceProvider.FindAllocation({ viewportId, info.m_connectionEpoch, info.m_generation }))
+	info.m_nativePresenterSummary = it.Value()->m_presenter.BuildViewportSummary(viewportId);
+	if (const auto* allocation = it.Value()->m_surfaceProvider.FindAllocation({ viewportId, info.m_connectionEpoch, info.m_generation }))
 	{
 		if (!allocation->m_lastRendererSource.m_debugName.empty())
 		{
@@ -941,7 +942,7 @@ uint32_t App::GetEditorRemoteViewportDiagnostics(uint64_t viewportId, char** dia
 		}
 	}
 
-	const std::string probeSummary = it->second->m_rendererFrameSourceProvider.GetLastProbeSummary();
+	const std::string probeSummary = it.Value()->m_rendererFrameSourceProvider.GetLastProbeSummary();
 	if (!probeSummary.empty())
 	{
 		if (!info.m_nativePresenterSummary.empty())
@@ -989,22 +990,22 @@ bool App::RetryEditorRemoteViewport(uint64_t viewportId)
 {
 	viewportId = viewportId == 0 ? kPrimaryEditorViewportId : viewportId;
 	std::lock_guard bindingsLock(g_remoteViewportBindingsMutex);
-	auto it = g_remoteViewportBindings.find(viewportId);
+	auto it = g_remoteViewportBindings.Find(viewportId);
 	if (it == g_remoteViewportBindings.end())
 	{
 		return false;
 	}
 
-	std::unique_lock bindingLock(it->second->m_mutex, std::try_to_lock);
+	std::unique_lock bindingLock(it.Value()->m_mutex, std::try_to_lock);
 	if (!bindingLock.owns_lock())
 	{
 		return false;
 	}
-	if (it->second->m_binding.GetRuntimeSession().GetState() == Sailor::EditorRemote::SessionState::Recovering ||
-		it->second->m_binding.GetRuntimeSession().GetState() == Sailor::EditorRemote::SessionState::Lost)
+	if (it.Value()->m_binding.GetRuntimeSession().GetState() == Sailor::EditorRemote::SessionState::Recovering ||
+		it.Value()->m_binding.GetRuntimeSession().GetState() == Sailor::EditorRemote::SessionState::Lost)
 	{
-		it->second->m_binding.Create();
-		it->second->Pump();
+		it.Value()->m_binding.Create();
+		it.Value()->Pump();
 	}
 	return true;
 }
@@ -1019,18 +1020,18 @@ bool App::SetEditorRemoteViewportMacHostHandle(uint64_t viewportId, uint32_t hos
 	hostHandle.m_value = static_cast<uintptr_t>(hostHandleValue);
 	g_pendingRemoteViewportHostHandles[viewportId] = hostHandle;
 
-	auto it = g_remoteViewportBindings.find(viewportId);
-	if (it == g_remoteViewportBindings.end() || !it->second)
+	auto it = g_remoteViewportBindings.Find(viewportId);
+	if (it == g_remoteViewportBindings.end() || !it.Value())
 	{
 		return true;
 	}
 
-	std::unique_lock bindingLock(it->second->m_mutex, std::try_to_lock);
+	std::unique_lock bindingLock(it.Value()->m_mutex, std::try_to_lock);
 	if (!bindingLock.owns_lock())
 	{
 		return true;
 	}
-	it->second->m_binding.GetHost().BindNativeHostHandle(viewportId, hostHandle);
+	it.Value()->m_binding.GetHost().BindNativeHostHandle(viewportId, hostHandle);
 	return true;
 #else
 	(void)viewportId;
@@ -1059,22 +1060,22 @@ bool App::SendEditorRemoteViewportInput(uint64_t viewportId, uint32_t kind, floa
 	DispatchEditorInputToRuntime(input);
 
 	std::lock_guard bindingsLock(g_remoteViewportBindingsMutex);
-	auto it = g_remoteViewportBindings.find(viewportId);
+	auto it = g_remoteViewportBindings.Find(viewportId);
 	if (it == g_remoteViewportBindings.end())
 	{
 		return false;
 	}
 
-	std::unique_lock bindingLock(it->second->m_mutex, std::try_to_lock);
+	std::unique_lock bindingLock(it.Value()->m_mutex, std::try_to_lock);
 	if (!bindingLock.owns_lock())
 	{
 		return true;
 	}
 
-	auto& runtimeSession = it->second->m_binding.GetRuntimeSession();
+	auto& runtimeSession = it.Value()->m_binding.GetRuntimeSession();
 	input.m_viewportId = runtimeSession.GetViewportId();
 	input.m_connectionEpoch = runtimeSession.GetConnectionEpoch();
 	input.m_generation = runtimeSession.GetGeneration();
-	input.m_timestampNs = ++it->second->m_nowMs;
+	input.m_timestampNs = ++it.Value()->m_nowMs;
 	return runtimeSession.HandleInput(input).IsOk();
 }

--- a/Runtime/Editor/EditorRuntimeBridge.cpp
+++ b/Runtime/Editor/EditorRuntimeBridge.cpp
@@ -104,7 +104,7 @@ namespace
 		return static_cast<uint8_t>(value * 255.0f + 0.5f);
 	}
 
-	std::shared_ptr<std::vector<uint8_t>> TryReadbackRendererTargetToBGRA8Bytes(const RHI::RHIRenderTargetPtr& renderTarget, PixelFormat pixelFormat, uint32_t& outBytesPerRow)
+	TSharedPtr<std::vector<uint8_t>> TryReadbackRendererTargetToBGRA8Bytes(const RHI::RHIRenderTargetPtr& renderTarget, PixelFormat pixelFormat, uint32_t& outBytesPerRow)
 	{
 		auto& driver = RHI::Renderer::GetDriver();
 		auto* commands = RHI::Renderer::GetDriverCommands();
@@ -142,7 +142,7 @@ namespace
 		}
 
 		outBytesPerRow = static_cast<uint32_t>(extent.x) * 4u;
-		auto outBytes = std::make_shared<std::vector<uint8_t>>(static_cast<size_t>(outBytesPerRow) * static_cast<size_t>(extent.y));
+		auto outBytes = TSharedPtr<std::vector<uint8_t>>::Make(static_cast<size_t>(outBytesPerRow) * static_cast<size_t>(extent.y));
 		for (int y = 0; y < extent.y; ++y)
 		{
 			uint8_t* dstRow = outBytes->data() + static_cast<size_t>(y) * outBytesPerRow;
@@ -219,7 +219,7 @@ namespace
 			outSource.m_bytesPerRow = readbackNode->GetBytesPerRow();
 			outSource.m_debugName = "EditorReadback";
 			const size_t totalBytes = static_cast<size_t>(outSource.m_bytesPerRow) * static_cast<size_t>(outSource.m_height);
-			outSource.m_cpuBytes = std::make_shared<std::vector<uint8_t>>(src, src + totalBytes);
+			outSource.m_cpuBytes = TSharedPtr<std::vector<uint8_t>>::Make(src, src + totalBytes);
 		}
 
 		if (outSummary)
@@ -465,7 +465,7 @@ namespace
 		}
 	};
 
-	TMap<ViewportId, std::shared_ptr<RemoteViewportBinding>> g_remoteViewportBindings;
+	TMap<ViewportId, TSharedPtr<RemoteViewportBinding>> g_remoteViewportBindings;
 	TMap<ViewportId, Sailor::EditorRemote::MacNativeHostHandle> g_pendingRemoteViewportHostHandles;
 	TMap<ViewportId, std::array<bool, 3>> g_remoteViewportMouseButtons;
 	std::mutex g_remoteViewportBindingsMutex;
@@ -716,7 +716,7 @@ bool Sailor::EditorRuntime::HasAppliedEditorRenderArea()
 
 void Sailor::EditorRuntime::PumpEditorRemoteViewportsOnEngineThread()
 {
-	TVector<std::shared_ptr<RemoteViewportBinding>> bindings{};
+	TVector<TSharedPtr<RemoteViewportBinding>> bindings{};
 	{
 		std::lock_guard lock(g_remoteViewportBindingsMutex);
 		bindings.Reserve(g_remoteViewportBindings.Num());
@@ -810,7 +810,7 @@ bool App::UpsertEditorRemoteViewport(uint64_t viewportId, uint32_t windowPosX, u
 	auto& binding = g_remoteViewportBindings[viewportId];
 	if (!binding)
 	{
-		binding = std::make_shared<RemoteViewportBinding>(MakeRemoteViewportDescriptor(viewportId, remoteWidth, remoteHeight));
+		binding = TSharedPtr<RemoteViewportBinding>::Make(MakeRemoteViewportDescriptor(viewportId, remoteWidth, remoteHeight));
 	}
 
 	RECT rect{};

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
@@ -1,4 +1,5 @@
 #include "GraphicsDriver/Vulkan/VulkanApi.h"
+#include "Containers/Containers.h"
 #include <algorithm>
 #include <cstring>
 #include <vulkan/vulkan.h>
@@ -471,7 +472,7 @@ VkPhysicalDevice VulkanApi::PickPhysicalDevice(VulkanSurfacePtr surface)
 	}
 
 	TVector<VkPhysicalDevice> devices(deviceCount);
-	std::multimap<int, VkPhysicalDevice> candidates;
+	int bestScore = 0;
 
 	if (vkEnumeratePhysicalDevices(GetVkInstance(), &deviceCount, devices.GetData()) != VK_SUCCESS)
 	{
@@ -483,17 +484,18 @@ VkPhysicalDevice VulkanApi::PickPhysicalDevice(VulkanSurfacePtr surface)
 	{
 		if (IsDeviceSuitable(device, surface))
 		{
-			int score = GetDeviceScore(device);
-			candidates.insert(std::make_pair(score, device));
+			const int score = GetDeviceScore(device);
+			if (score >= bestScore)
+			{
+				bestScore = score;
+				physicalDevice = device;
+			}
 		}
 	}
 
-	if (!candidates.empty() && candidates.rbegin()->first > 0)
+	if (bestScore <= 0)
 	{
-		physicalDevice = candidates.rbegin()->second;
-	}
-	else
-	{
+		physicalDevice = VK_NULL_HANDLE;
 		SAILOR_LOG("Failed to find a suitable GPU!");
 	}
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
@@ -1,6 +1,7 @@
 struct IUnknown; // Workaround for "combaseapi.h(229): error C2187: syntax error: 'identifier' was unexpected here" when using /permissive-
 
 #include <chrono>
+#include "Containers/Containers.h"
 #include <cstdlib>
 #include <set>
 #include <map>
@@ -593,7 +594,7 @@ void VulkanDevice::CreateLogicalDevice(VkPhysicalDevice physicalDevice)
 	m_queueFamilies = VulkanApi::FindQueueFamilies(physicalDevice, m_surface);
 
 	TVector<VkDeviceQueueCreateInfo> queueCreateInfos;
-	std::set<uint32_t> uniqueQueueFamilies = { m_queueFamilies.m_graphicsFamily.value(),
+	TSet<uint32_t> uniqueQueueFamilies = { m_queueFamilies.m_graphicsFamily.value(),
 		m_queueFamilies.m_presentFamily.value(),
 		m_queueFamilies.m_transferFamily.value() };
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -1193,7 +1193,7 @@ void VulkanGraphicsDriver::UpdateDescriptorSet(RHI::RHIShaderBindingSetPtr bindi
 				const auto type = binding.m_second->GetLayout().m_type;
 				const bool bBindWithoutOffset = (type == RHI::EShaderBindingType::StorageBuffer && !binding.m_second->m_vulkan.m_bBindSsboWithOffset);
 
-				auto& valueBinding = *(binding.m_second->m_vulkan.m_valueBinding->Get());
+				const auto valueBinding = *(binding.m_second->m_vulkan.m_valueBinding->Get());
 				auto descr = VulkanDescriptorBufferPtr::Make(binding.m_second->m_vulkan.m_descriptorSetLayout.binding, 0,
 					valueBinding.m_buffer,
 					bBindWithoutOffset ? 0 : valueBinding.m_offset,
@@ -2803,7 +2803,7 @@ TVector<VulkanDescriptorSetPtr> VulkanGraphicsDriver::GetCompatibleDescriptorSet
 						const auto type = binding.m_second->GetLayout().m_type;
 						const bool bBindWithoutOffset = (type == RHI::EShaderBindingType::StorageBuffer && !binding.m_second->m_vulkan.m_bBindSsboWithOffset);
 
-						auto& valueBinding = *(binding.m_second->m_vulkan.m_valueBinding->Get());
+						const auto valueBinding = *(binding.m_second->m_vulkan.m_valueBinding->Get());
 						auto descr = VulkanDescriptorBufferPtr::Make(matchedLayoutBinding.binding,
 							0,
 							valueBinding.m_buffer,

--- a/Runtime/Memory/LockFreeHeapAllocator.cpp
+++ b/Runtime/Memory/LockFreeHeapAllocator.cpp
@@ -10,10 +10,10 @@ using namespace Sailor::Memory;
 
 // For now TConcurrentMap doesn't have dll interface, so cannot 
 // handle that in class
-std::unique_ptr<TConcurrentMap<DWORD, TUniquePtr<HeapAllocator>, 8, ERehashPolicy::Never, Memory::MallocAllocator>>& GetAllocator()
+TUniquePtr<TConcurrentMap<DWORD, TUniquePtr<HeapAllocator>, 8, ERehashPolicy::Never, Memory::MallocAllocator>>& GetAllocator()
 {
-	static std::unique_ptr<TConcurrentMap<DWORD, TUniquePtr<HeapAllocator>, 8, ERehashPolicy::Never, Memory::MallocAllocator>> g_lockFreeAllocators =
-		std::make_unique<TConcurrentMap<DWORD, TUniquePtr<HeapAllocator>, 8, ERehashPolicy::Never, Memory::MallocAllocator>>();
+	static TUniquePtr<TConcurrentMap<DWORD, TUniquePtr<HeapAllocator>, 8, ERehashPolicy::Never, Memory::MallocAllocator>> g_lockFreeAllocators =
+		TUniquePtr<TConcurrentMap<DWORD, TUniquePtr<HeapAllocator>, 8, ERehashPolicy::Never, Memory::MallocAllocator>>::Make();
 
 	return g_lockFreeAllocators;
 }

--- a/Runtime/Memory/SharedPtr.hpp
+++ b/Runtime/Memory/SharedPtr.hpp
@@ -2,6 +2,7 @@
 #include "Core/Defines.h"
 #include <atomic>
 #include <cassert>
+#include <compare>
 #include <type_traits>
 #include "Containers/Concepts.h"
 #include "Memory/MallocAllocator.hpp"
@@ -87,10 +88,10 @@ namespace Sailor
 		T* GetRawPtr() const noexcept { return m_pRawPtr; }
 
 		T* operator->()  noexcept { return m_pRawPtr; }
-		const T* operator->() const { return m_pRawPtr; }
+		T* operator->() const noexcept { return m_pRawPtr; }
 
 		T& operator*() noexcept { return *m_pRawPtr; }
-		const T& operator*() const { return *m_pRawPtr; }
+		T& operator*() const noexcept { return *m_pRawPtr; }
 
 		bool IsShared() const  noexcept { return m_pRawPtr != nullptr && m_pControlBlock->m_sharedPtrCounter > 1; }
 		bool IsValid() const noexcept { return m_pRawPtr != nullptr; }
@@ -105,6 +106,11 @@ namespace Sailor
 		bool operator!=(const TSharedPtr& pRhs) const
 		{
 			return m_pRawPtr != pRhs.m_pRawPtr;
+		}
+
+		std::strong_ordering operator<=>(const TSharedPtr& pRhs) const noexcept
+		{
+			return std::compare_three_way{}(m_pRawPtr, pRhs.m_pRawPtr);
 		}
 
 		void Clear() noexcept

--- a/Runtime/Memory/UniquePtr.hpp
+++ b/Runtime/Memory/UniquePtr.hpp
@@ -148,7 +148,7 @@ namespace Sailor
 	};
 
 	template<typename T>
-	class SAILOR_API TUniquePtr<T[]> final
+	class TUniquePtr<T[]> final
 	{
 	public:
 

--- a/Runtime/Memory/UniquePtr.hpp
+++ b/Runtime/Memory/UniquePtr.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "Core/Defines.h"
 #include <atomic>
+#include <cstddef>
 #include <type_traits>
 
 namespace Sailor
@@ -96,6 +97,13 @@ namespace Sailor
 			return m_pRawPtr != pRhs.m_pRawPtr;
 		}
 
+		T* Release() noexcept
+		{
+			T* pRawPtr = m_pRawPtr;
+			m_pRawPtr = nullptr;
+			return pRawPtr;
+		}
+
 		void Clear() noexcept
 		{
 			if (m_pRawPtr)
@@ -137,5 +145,73 @@ namespace Sailor
 
 		template<typename>
 		friend class TUniquePtr;
+	};
+
+	template<typename T>
+	class SAILOR_API TUniquePtr<T[]> final
+	{
+	public:
+
+		static TUniquePtr<T[]> Make(size_t numElements)
+		{
+			return TUniquePtr<T[]>(new T[numElements]());
+		}
+
+		TUniquePtr() noexcept = default;
+		TUniquePtr(const TUniquePtr&) noexcept = delete;
+		TUniquePtr& operator=(const TUniquePtr&) = delete;
+
+		explicit TUniquePtr(T* pRawPtr) noexcept : m_pRawPtr(pRawPtr) {}
+
+		TUniquePtr(TUniquePtr&& pPtr) noexcept
+		{
+			Swap(std::move(pPtr));
+		}
+
+		TUniquePtr& operator=(TUniquePtr&& pPtr) noexcept
+		{
+			Swap(std::move(pPtr));
+			return *this;
+		}
+
+		T* GetRawPtr() const noexcept { return m_pRawPtr; }
+		T& operator[](size_t index) noexcept { return m_pRawPtr[index]; }
+		const T& operator[](size_t index) const noexcept { return m_pRawPtr[index]; }
+		bool IsValid() const noexcept { return m_pRawPtr != nullptr; }
+		explicit operator bool() const noexcept { return m_pRawPtr != nullptr; }
+
+		T* Release() noexcept
+		{
+			T* pRawPtr = m_pRawPtr;
+			m_pRawPtr = nullptr;
+			return pRawPtr;
+		}
+
+		void Clear() noexcept
+		{
+			delete[] m_pRawPtr;
+			m_pRawPtr = nullptr;
+		}
+
+		~TUniquePtr()
+		{
+			Clear();
+		}
+
+	private:
+
+		T* m_pRawPtr = nullptr;
+
+		void Swap(TUniquePtr&& pPtr) noexcept
+		{
+			if (this == &pPtr)
+			{
+				return;
+			}
+
+			Clear();
+			m_pRawPtr = pPtr.m_pRawPtr;
+			pPtr.m_pRawPtr = nullptr;
+		}
 	};
 }

--- a/Runtime/Submodules/EditorRemote/EditorViewportSession.h
+++ b/Runtime/Submodules/EditorRemote/EditorViewportSession.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Containers/Containers.h"
 
 #include <functional>
 #include <optional>
@@ -430,7 +431,7 @@ namespace Sailor::EditorRemote
 		std::optional<FramePacket> m_lastFrame{};
 		std::optional<InputPacket> m_lastForwardedInput{};
 		FrameIndex m_lastPresentedFrameIndex = 0;
-		std::vector<size_t> m_rejectedFrameCounts = std::vector<size_t>(5, 0);
+		TVector<size_t> m_rejectedFrameCounts = { 0, 0, 0, 0, 0 };
 		size_t m_acceptedFrameCount = 0;
 		bool m_visible = true;
 		bool m_focused = false;

--- a/Runtime/Submodules/EditorRemote/RemoteViewportMacTransport.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportMacTransport.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Containers/Containers.h"
 
 #include <algorithm>
 #include <optional>
@@ -38,15 +39,11 @@ namespace Sailor::EditorRemote
 		SurfaceGeneration m_generation = 0;
 
 		auto operator<=>(const MacViewportSurfaceKey&) const = default;
-	};
 
-	struct MacViewportSurfaceKeyHasher
-	{
-		size_t operator()(const MacViewportSurfaceKey& key) const noexcept
+		size_t GetHash() const noexcept
 		{
-			size_t seed = std::hash<uint64_t>{}(key.m_viewportId);
-			seed ^= std::hash<uint64_t>{}(key.m_epoch) + 0x9e3779b97f4a7c15ull + (seed << 6) + (seed >> 2);
-			seed ^= std::hash<uint64_t>{}(key.m_generation) + 0x9e3779b97f4a7c15ull + (seed << 6) + (seed >> 2);
+			size_t seed = 0;
+			HashCombine(seed, m_viewportId, m_epoch, m_generation);
 			return seed;
 		}
 	};
@@ -357,6 +354,7 @@ namespace Sailor::EditorRemote
 
 			const auto nextFrameIndex = state.m_lastExportedFrameIndex + 1;
 			MacRendererFrameSource rendererSource{};
+			bool bHasCpuPayload = false;
 			if (m_rendererFrameSourceProvider != nullptr)
 			{
 				auto sourceResult = m_rendererFrameSourceProvider->AcquireFrameSource(state, nextFrameIndex, rendererSource);
@@ -372,14 +370,19 @@ namespace Sailor::EditorRemote
 					return m_lastFailure;
 				}
 
-				if (rendererSource.m_width != state.m_nativeAllocation->m_plane.m_width ||
-					rendererSource.m_height != state.m_nativeAllocation->m_plane.m_height)
+				bHasCpuPayload = rendererSource.m_kind == MacRendererFrameSourceKind::RendererOwnedRenderTargetMetadata &&
+					rendererSource.m_cpuBytes && !rendererSource.m_cpuBytes->empty();
+				const bool bHasCopyableSource =
+					rendererSource.m_kind == MacRendererFrameSourceKind::RendererOwnedMetalTexture || bHasCpuPayload;
+				if (bHasCopyableSource &&
+					(rendererSource.m_width != state.m_nativeAllocation->m_plane.m_width ||
+					rendererSource.m_height != state.m_nativeAllocation->m_plane.m_height))
 				{
 					m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 1005, "macOS renderer source extents do not match the current IOSurface");
 					return m_lastFailure;
 				}
 
-				if (rendererSource.m_kind == MacRendererFrameSourceKind::RendererOwnedRenderTargetMetadata &&
+				if (bHasCpuPayload &&
 					rendererSource.m_bytesPerRow < state.m_nativeAllocation->m_plane.m_width * state.m_nativeAllocation->m_plane.m_bytesPerElement)
 				{
 					m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 1006, "macOS renderer source row stride is smaller than the current IOSurface row");
@@ -400,7 +403,7 @@ namespace Sailor::EditorRemote
 					rendererSource.m_textureObject = 0;
 				}
 			}
-			else if (rendererSource.m_kind == MacRendererFrameSourceKind::RendererOwnedRenderTargetMetadata && rendererSource.m_cpuBytes && !rendererSource.m_cpuBytes->empty())
+			else if (bHasCpuPayload)
 			{
 				copyResult = UploadMacRendererBytesToProducerTexture(state.m_nativeAllocation->m_producerTextureObject, state.m_nativeAllocation->m_plane.m_width, state.m_nativeAllocation->m_plane.m_height, rendererSource.m_cpuBytes->data(), rendererSource.m_bytesPerRow, rendererFrameInfo);
 			}
@@ -502,17 +505,17 @@ namespace Sailor::EditorRemote
 		Failure ReleaseSurface(const MacViewportSurfaceState& state) override
 		{
 #if defined(__APPLE__)
-			if (auto it = m_liveAllocations.find(state.m_key); it != m_liveAllocations.end())
+			if (auto it = m_liveAllocations.Find(state.m_key); it != m_liveAllocations.end())
 			{
-				ReleaseMacRendererIntermediateTexture(it->second.m_rendererIntermediateTextureObject);
-				ReleaseMacIOSurfaceProducerTexture(it->second.m_producerDeviceObject, it->second.m_producerTextureObject);
-				if (it->second.m_surfaceObject != 0)
+				ReleaseMacRendererIntermediateTexture(it.Value().m_rendererIntermediateTextureObject);
+				ReleaseMacIOSurfaceProducerTexture(it.Value().m_producerDeviceObject, it.Value().m_producerTextureObject);
+				if (it.Value().m_surfaceObject != 0)
 				{
-					CFRelease(reinterpret_cast<IOSurfaceRef>(it->second.m_surfaceObject));
+					CFRelease(reinterpret_cast<IOSurfaceRef>(it.Value().m_surfaceObject));
 				}
 			}
 #endif
-			m_liveAllocations.erase(state.m_key);
+			m_liveAllocations.Remove(state.m_key);
 			m_lastFailure = Failure::Ok();
 			return Failure::Ok();
 		}
@@ -524,14 +527,14 @@ namespace Sailor::EditorRemote
 
 		const MacIOSurfaceAllocation* FindAllocation(const MacViewportSurfaceKey& key) const
 		{
-			auto it = m_liveAllocations.find(key);
-			return it != m_liveAllocations.end() ? &it->second : nullptr;
+			auto it = m_liveAllocations.Find(key);
+			return it != m_liveAllocations.end() ? &it.Value() : nullptr;
 		}
 
-		size_t GetLiveAllocationCount() const { return m_liveAllocations.size(); }
+		size_t GetLiveAllocationCount() const { return m_liveAllocations.Num(); }
 
 	private:
-		std::unordered_map<MacViewportSurfaceKey, MacIOSurfaceAllocation, MacViewportSurfaceKeyHasher> m_liveAllocations{};
+		TMap<MacViewportSurfaceKey, MacIOSurfaceAllocation> m_liveAllocations{};
 		IMacRendererFrameSourceProvider* m_rendererFrameSourceProvider = nullptr;
 		Failure m_lastFailure = Failure::Ok();
 		uint32_t m_nextSurfaceId = 100;
@@ -635,21 +638,21 @@ namespace Sailor::EditorRemote
 		Failure ReleaseSurface(ViewportId viewportId, ConnectionEpoch epoch, SurfaceGeneration generation) override
 		{
 			MacViewportSurfaceKey key{ viewportId, epoch, generation };
-			auto it = m_surfaces.find(key);
+			auto it = m_surfaces.Find(key);
 			if (it == m_surfaces.end())
 			{
 				m_lastFailure = Failure::Ok();
 				return Failure::Ok();
 			}
 
-			auto result = m_provider.ReleaseSurface(it->second);
+			auto result = m_provider.ReleaseSurface(it.Value());
 			if (!result.IsOk())
 			{
 				m_lastFailure = m_provider.GetLastFailure();
 				return result;
 			}
 
-			m_surfaces.erase(it);
+			m_surfaces.Remove(key);
 			m_lastFailure = Failure::Ok();
 			return Failure::Ok();
 		}
@@ -662,22 +665,22 @@ namespace Sailor::EditorRemote
 		const MacViewportSurfaceState* FindSurface(ViewportId viewportId, ConnectionEpoch epoch, SurfaceGeneration generation) const
 		{
 			MacViewportSurfaceKey key{ viewportId, epoch, generation };
-			auto it = m_surfaces.find(key);
-			return it != m_surfaces.end() ? &it->second : nullptr;
+			auto it = m_surfaces.Find(key);
+			return it != m_surfaces.end() ? &it.Value() : nullptr;
 		}
 
-		size_t GetSurfaceCount() const { return m_surfaces.size(); }
+		size_t GetSurfaceCount() const { return m_surfaces.Num(); }
 
 	private:
 		MacViewportSurfaceState* FindSurface(ViewportId viewportId, ConnectionEpoch epoch, SurfaceGeneration generation)
 		{
 			MacViewportSurfaceKey key{ viewportId, epoch, generation };
-			auto it = m_surfaces.find(key);
-			return it != m_surfaces.end() ? &it->second : nullptr;
+			auto it = m_surfaces.Find(key);
+			return it != m_surfaces.end() ? &it.Value() : nullptr;
 		}
 
 		IMacIOSurfaceProvider& m_provider;
-		std::unordered_map<MacViewportSurfaceKey, MacViewportSurfaceState, MacViewportSurfaceKeyHasher> m_surfaces{};
+		TMap<MacViewportSurfaceKey, MacViewportSurfaceState> m_surfaces{};
 		Failure m_lastFailure = Failure::Ok();
 	};
 
@@ -703,14 +706,14 @@ namespace Sailor::EditorRemote
 			}
 			else
 			{
-				m_hostHandles.erase(viewportId);
+				m_hostHandles.Remove(viewportId);
 			}
 
-			auto it = m_importedStates.find(viewportId);
+			auto it = m_importedStates.Find(viewportId);
 			if (it != m_importedStates.end())
 			{
-				it->second.m_hostHandle = hostHandle;
-				RefreshNativeLayerBinding(it->second);
+				it.Value().m_hostHandle = hostHandle;
+				RefreshNativeLayerBinding(it.Value());
 			}
 		}
 
@@ -737,9 +740,9 @@ namespace Sailor::EditorRemote
 			state.m_pixelFormat = transport.m_pixelFormat;
 			state.m_framebufferOnly = handle.m_framebufferOnly;
 			state.m_importedSurface = handle;
-			if (auto hostIt = m_hostHandles.find(viewport.m_viewportId); hostIt != m_hostHandles.end())
+			if (auto hostIt = m_hostHandles.Find(viewport.m_viewportId); hostIt != m_hostHandles.end())
 			{
-				state.m_hostHandle = hostIt->second;
+					state.m_hostHandle = hostIt.Value();
 			}
 			if (!state.IsValid())
 			{
@@ -761,14 +764,14 @@ namespace Sailor::EditorRemote
 
 		Failure PresentFrame(ViewportId viewportId, const FramePacket& frame) override
 		{
-			auto it = m_importedStates.find(viewportId);
+			auto it = m_importedStates.Find(viewportId);
 			if (it == m_importedStates.end())
 			{
 				m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 2003, "macOS presenter has no imported viewport state to present into");
 				return m_lastFailure;
 			}
 
-			auto& state = it->second;
+			auto& state = it.Value();
 			if (state.m_epoch != frame.m_connectionEpoch || state.m_generation != frame.m_generation)
 			{
 				m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 2004, "macOS presenter rejected frame for stale imported generation");
@@ -814,12 +817,12 @@ namespace Sailor::EditorRemote
 
 		void ResetViewport(ViewportId viewportId) override
 		{
-			auto it = m_importedStates.find(viewportId);
-			if (it != m_importedStates.end() && it->second.m_layerBinding.has_value())
+			auto it = m_importedStates.Find(viewportId);
+			if (it != m_importedStates.end() && it.Value().m_layerBinding.has_value())
 			{
-				ResetMacNativeLayerBinding(*it->second.m_layerBinding);
+				ResetMacNativeLayerBinding(*it.Value().m_layerBinding);
 			}
-			m_importedStates.erase(viewportId);
+			m_importedStates.Remove(viewportId);
 			if (m_lastPresentedFrame.has_value() && m_lastPresentedFrame->m_viewportId == viewportId)
 			{
 				m_lastPresentedFrame.reset();
@@ -833,19 +836,19 @@ namespace Sailor::EditorRemote
 
 		const MacNativePresentationState* FindImportedState(ViewportId viewportId) const
 		{
-			auto it = m_importedStates.find(viewportId);
-			return it != m_importedStates.end() ? &it->second : nullptr;
+			auto it = m_importedStates.Find(viewportId);
+			return it != m_importedStates.end() ? &it.Value() : nullptr;
 		}
 
 		std::string BuildViewportSummary(ViewportId viewportId) const
 		{
-			auto it = m_importedStates.find(viewportId);
+			auto it = m_importedStates.Find(viewportId);
 			if (it == m_importedStates.end())
 			{
 				return {};
 			}
 
-			const auto& state = it->second;
+			const auto& state = it.Value();
 			std::ostringstream ss;
 			ss << "nativeLayer=" << (state.m_usesRealCAMetalLayer ? 1 : 0)
 				<< " host=" << static_cast<uint32_t>(state.m_hostHandle.m_kind)
@@ -900,8 +903,8 @@ namespace Sailor::EditorRemote
 			return Failure::Ok();
 		}
 
-		std::unordered_map<ViewportId, MacNativeHostHandle> m_hostHandles{};
-		std::unordered_map<ViewportId, MacNativePresentationState> m_importedStates{};
+		TMap<ViewportId, MacNativeHostHandle> m_hostHandles{};
+		TMap<ViewportId, MacNativePresentationState> m_importedStates{};
 		std::optional<FramePacket> m_lastPresentedFrame{};
 		Failure m_lastFailure = Failure::Ok();
 		uint64_t m_nextImportToken = 0;

--- a/Runtime/Submodules/EditorRemote/RemoteViewportMacTransport.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportMacTransport.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Containers/Containers.h"
+#include "Memory/SharedPtr.hpp"
 
 #include <algorithm>
 #include <optional>
@@ -8,7 +9,6 @@
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <memory>
 
 #if defined(__APPLE__)
 #include <CoreFoundation/CoreFoundation.h>
@@ -86,7 +86,7 @@ namespace Sailor::EditorRemote
 		uint32_t m_bytesPerRow = 0;
 		PixelFormat m_pixelFormat = PixelFormat::Unknown;
 		CrossApiSyncKind m_crossApiSyncKind = CrossApiSyncKind::None;
-		std::shared_ptr<std::vector<uint8_t>> m_cpuBytes{};
+		TSharedPtr<std::vector<uint8_t>> m_cpuBytes{};
 		std::string m_debugName{};
 		bool m_releaseTextureObjectAfterUse = false;
 		bool m_crossApiCpuWaited = false;

--- a/Runtime/Submodules/EditorRemote/RemoteViewportMacTransport.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportMacTransport.h
@@ -1,12 +1,12 @@
 #pragma once
 #include "Containers/Containers.h"
 #include "Memory/SharedPtr.hpp"
+#include "Memory/UniquePtr.hpp"
 
 #include <algorithm>
 #include <optional>
 #include <sstream>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -339,7 +339,7 @@ namespace Sailor::EditorRemote
 			inOutState.m_frameBegun = false;
 			inOutState.m_nativeAllocation = allocation;
 			inOutState.m_lastExport = exportMetadata;
-			m_liveAllocations[inOutState.m_key] = allocation;
+			StoreAllocation(inOutState.m_key, allocation);
 			m_lastFailure = Failure::Ok();
 			return Failure::Ok();
 		}
@@ -465,7 +465,7 @@ namespace Sailor::EditorRemote
 				state.m_transport.m_macSurfaces.front().m_sharedEventObject = rendererSource.m_crossApiSharedEventObject;
 			}
 			state.m_frameBegun = true;
-			m_liveAllocations[state.m_key] = *state.m_nativeAllocation;
+			StoreAllocation(state.m_key, *state.m_nativeAllocation);
 			m_lastFailure = Failure::Ok();
 			return Failure::Ok();
 		}
@@ -507,11 +507,11 @@ namespace Sailor::EditorRemote
 #if defined(__APPLE__)
 			if (auto it = m_liveAllocations.Find(state.m_key); it != m_liveAllocations.end())
 			{
-				ReleaseMacRendererIntermediateTexture(it.Value().m_rendererIntermediateTextureObject);
-				ReleaseMacIOSurfaceProducerTexture(it.Value().m_producerDeviceObject, it.Value().m_producerTextureObject);
-				if (it.Value().m_surfaceObject != 0)
+				ReleaseMacRendererIntermediateTexture(it.Value()->m_rendererIntermediateTextureObject);
+				ReleaseMacIOSurfaceProducerTexture(it.Value()->m_producerDeviceObject, it.Value()->m_producerTextureObject);
+				if (it.Value()->m_surfaceObject != 0)
 				{
-					CFRelease(reinterpret_cast<IOSurfaceRef>(it.Value().m_surfaceObject));
+					CFRelease(reinterpret_cast<IOSurfaceRef>(it.Value()->m_surfaceObject));
 				}
 			}
 #endif
@@ -528,13 +528,26 @@ namespace Sailor::EditorRemote
 		const MacIOSurfaceAllocation* FindAllocation(const MacViewportSurfaceKey& key) const
 		{
 			auto it = m_liveAllocations.Find(key);
-			return it != m_liveAllocations.end() ? &it.Value() : nullptr;
+			return it != m_liveAllocations.end() ? it.Value().GetRawPtr() : nullptr;
 		}
 
 		size_t GetLiveAllocationCount() const { return m_liveAllocations.Num(); }
 
 	private:
-		TMap<MacViewportSurfaceKey, MacIOSurfaceAllocation> m_liveAllocations{};
+		void StoreAllocation(const MacViewportSurfaceKey& key, const MacIOSurfaceAllocation& allocation)
+		{
+			auto& storedAllocation = m_liveAllocations[key];
+			if (storedAllocation)
+			{
+				*storedAllocation = allocation;
+			}
+			else
+			{
+				storedAllocation = TUniquePtr<MacIOSurfaceAllocation>::Make(allocation);
+			}
+		}
+
+		TMap<MacViewportSurfaceKey, TUniquePtr<MacIOSurfaceAllocation>> m_liveAllocations{};
 		IMacRendererFrameSourceProvider* m_rendererFrameSourceProvider = nullptr;
 		Failure m_lastFailure = Failure::Ok();
 		uint32_t m_nextSurfaceId = 100;
@@ -582,7 +595,15 @@ namespace Sailor::EditorRemote
 			}
 
 			outTransport = state.m_transport;
-			m_surfaces[state.m_key] = state;
+			auto& storedState = m_surfaces[state.m_key];
+			if (storedState)
+			{
+				*storedState = state;
+			}
+			else
+			{
+				storedState = TUniquePtr<MacViewportSurfaceState>::Make(state);
+			}
 			m_lastFailure = Failure::Ok();
 			return Failure::Ok();
 		}
@@ -645,7 +666,7 @@ namespace Sailor::EditorRemote
 				return Failure::Ok();
 			}
 
-			auto result = m_provider.ReleaseSurface(it.Value());
+			auto result = m_provider.ReleaseSurface(*it.Value());
 			if (!result.IsOk())
 			{
 				m_lastFailure = m_provider.GetLastFailure();
@@ -666,7 +687,7 @@ namespace Sailor::EditorRemote
 		{
 			MacViewportSurfaceKey key{ viewportId, epoch, generation };
 			auto it = m_surfaces.Find(key);
-			return it != m_surfaces.end() ? &it.Value() : nullptr;
+			return it != m_surfaces.end() ? it.Value().GetRawPtr() : nullptr;
 		}
 
 		size_t GetSurfaceCount() const { return m_surfaces.Num(); }
@@ -676,11 +697,11 @@ namespace Sailor::EditorRemote
 		{
 			MacViewportSurfaceKey key{ viewportId, epoch, generation };
 			auto it = m_surfaces.Find(key);
-			return it != m_surfaces.end() ? &it.Value() : nullptr;
+			return it != m_surfaces.end() ? it.Value().GetRawPtr() : nullptr;
 		}
 
 		IMacIOSurfaceProvider& m_provider;
-		TMap<MacViewportSurfaceKey, MacViewportSurfaceState> m_surfaces{};
+		TMap<MacViewportSurfaceKey, TUniquePtr<MacViewportSurfaceState>> m_surfaces{};
 		Failure m_lastFailure = Failure::Ok();
 	};
 
@@ -712,8 +733,8 @@ namespace Sailor::EditorRemote
 			auto it = m_importedStates.Find(viewportId);
 			if (it != m_importedStates.end())
 			{
-				it.Value().m_hostHandle = hostHandle;
-				RefreshNativeLayerBinding(it.Value());
+				it.Value()->m_hostHandle = hostHandle;
+				RefreshNativeLayerBinding(*it.Value());
 			}
 		}
 
@@ -757,7 +778,15 @@ namespace Sailor::EditorRemote
 				return bindingResult;
 			}
 
-			m_importedStates[viewport.m_viewportId] = state;
+			auto& storedState = m_importedStates[viewport.m_viewportId];
+			if (storedState)
+			{
+				*storedState = state;
+			}
+			else
+			{
+				storedState = TUniquePtr<MacNativePresentationState>::Make(state);
+			}
 			m_lastFailure = Failure::Ok();
 			return Failure::Ok();
 		}
@@ -771,7 +800,7 @@ namespace Sailor::EditorRemote
 				return m_lastFailure;
 			}
 
-			auto& state = it.Value();
+			auto& state = *it.Value();
 			if (state.m_epoch != frame.m_connectionEpoch || state.m_generation != frame.m_generation)
 			{
 				m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 2004, "macOS presenter rejected frame for stale imported generation");
@@ -818,9 +847,9 @@ namespace Sailor::EditorRemote
 		void ResetViewport(ViewportId viewportId) override
 		{
 			auto it = m_importedStates.Find(viewportId);
-			if (it != m_importedStates.end() && it.Value().m_layerBinding.has_value())
+			if (it != m_importedStates.end() && it.Value()->m_layerBinding.has_value())
 			{
-				ResetMacNativeLayerBinding(*it.Value().m_layerBinding);
+				ResetMacNativeLayerBinding(*it.Value()->m_layerBinding);
 			}
 			m_importedStates.Remove(viewportId);
 			if (m_lastPresentedFrame.has_value() && m_lastPresentedFrame->m_viewportId == viewportId)
@@ -837,7 +866,7 @@ namespace Sailor::EditorRemote
 		const MacNativePresentationState* FindImportedState(ViewportId viewportId) const
 		{
 			auto it = m_importedStates.Find(viewportId);
-			return it != m_importedStates.end() ? &it.Value() : nullptr;
+			return it != m_importedStates.end() ? it.Value().GetRawPtr() : nullptr;
 		}
 
 		std::string BuildViewportSummary(ViewportId viewportId) const
@@ -848,7 +877,7 @@ namespace Sailor::EditorRemote
 				return {};
 			}
 
-			const auto& state = it.Value();
+			const auto& state = *it.Value();
 			std::ostringstream ss;
 			ss << "nativeLayer=" << (state.m_usesRealCAMetalLayer ? 1 : 0)
 				<< " host=" << static_cast<uint32_t>(state.m_hostHandle.m_kind)
@@ -904,7 +933,7 @@ namespace Sailor::EditorRemote
 		}
 
 		TMap<ViewportId, MacNativeHostHandle> m_hostHandles{};
-		TMap<ViewportId, MacNativePresentationState> m_importedStates{};
+		TMap<ViewportId, TUniquePtr<MacNativePresentationState>> m_importedStates{};
 		std::optional<FramePacket> m_lastPresentedFrame{};
 		Failure m_lastFailure = Failure::Ok();
 		uint64_t m_nextImportToken = 0;

--- a/Runtime/Submodules/EditorRemote/RemoteViewportRuntime.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportRuntime.h
@@ -1,11 +1,11 @@
 #pragma once
 #include "Containers/Containers.h"
+#include "Memory/UniquePtr.hpp"
 
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <memory>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -363,13 +363,13 @@ namespace Sailor::EditorRemote
 		RemoteViewportSession* FindSession(ViewportId viewportId)
 		{
 			auto it = m_sessions.Find(viewportId);
-			return it != m_sessions.end() ? it.Value().get() : nullptr;
+			return it != m_sessions.end() ? it.Value().GetRawPtr() : nullptr;
 		}
 
 		const RemoteViewportSession* FindSession(ViewportId viewportId) const
 		{
 			auto it = m_sessions.Find(viewportId);
-			return it != m_sessions.end() ? it.Value().get() : nullptr;
+			return it != m_sessions.end() ? it.Value().GetRawPtr() : nullptr;
 		}
 
 		RemoteViewportSession& CreateOrReplaceSession(const ViewportDescriptor& descriptor, ConnectionEpoch epoch)
@@ -379,8 +379,8 @@ namespace Sailor::EditorRemote
 				PruneEpochViewport(descriptor.m_viewportId, it.Value()->GetConnectionEpoch());
 			}
 
-			auto session = std::make_unique<RemoteViewportSession>(descriptor, epoch);
-			auto* result = session.get();
+			auto session = TUniquePtr<RemoteViewportSession>::Make(descriptor, epoch);
+			auto* result = session.GetRawPtr();
 			m_sessions[descriptor.m_viewportId] = std::move(session);
 			auto& epochViewports = m_viewportsByEpoch[epoch];
 			if (std::find(epochViewports.begin(), epochViewports.end(), descriptor.m_viewportId) == epochViewports.end())
@@ -457,7 +457,7 @@ namespace Sailor::EditorRemote
 			}
 		}
 
-		TMap<ViewportId, std::unique_ptr<RemoteViewportSession>> m_sessions{};
+		TMap<ViewportId, TUniquePtr<RemoteViewportSession>> m_sessions{};
 		TMap<ConnectionEpoch, TVector<ViewportId>> m_viewportsByEpoch{};
 		SessionCleanupHook m_cleanupHook{};
 	};

--- a/Runtime/Submodules/EditorRemote/RemoteViewportRuntime.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportRuntime.h
@@ -8,7 +8,6 @@
 #include <functional>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -491,7 +490,15 @@ namespace Sailor::EditorRemote
 				}
 			}
 
-			m_connections[request.m_connectionId] = negotiated;
+			auto& storedConnection = m_connections[request.m_connectionId];
+			if (storedConnection)
+			{
+				*storedConnection = negotiated;
+			}
+			else
+			{
+				storedConnection = TUniquePtr<BridgeConnectionInfo>::Make(negotiated);
+			}
 			return Failure::Ok();
 		}
 
@@ -510,7 +517,7 @@ namespace Sailor::EditorRemote
 			{
 				return Failure::Ok();
 			}
-			return m_commandHandler(it.Value(), command);
+			return m_commandHandler(*it.Value(), command);
 		}
 
 		bool Disconnect(uint64_t connectionId, const Failure& reason = Failure::FromDomain(ErrorDomain::Connection, 1, "Disconnected"))
@@ -522,7 +529,7 @@ namespace Sailor::EditorRemote
 			}
 			if (m_disconnectHandler)
 			{
-				m_disconnectHandler(it.Value(), reason);
+				m_disconnectHandler(*it.Value(), reason);
 			}
 			m_connections.Remove(connectionId);
 			return true;
@@ -537,11 +544,11 @@ namespace Sailor::EditorRemote
 		const BridgeConnectionInfo* FindConnection(uint64_t connectionId) const
 		{
 			auto it = m_connections.Find(connectionId);
-			return it != m_connections.end() ? &it.Value() : nullptr;
+			return it != m_connections.end() ? it.Value().GetRawPtr() : nullptr;
 		}
 
 	private:
-		TMap<uint64_t, BridgeConnectionInfo> m_connections{};
+		TMap<uint64_t, TUniquePtr<BridgeConnectionInfo>> m_connections{};
 		NegotiationHandler m_negotiationHandler{};
 		CommandHandler m_commandHandler{};
 		DisconnectHandler m_disconnectHandler{};

--- a/Runtime/Submodules/EditorRemote/RemoteViewportRuntime.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportRuntime.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Containers/Containers.h"
 
 #include <algorithm>
 #include <cstddef>
@@ -361,21 +362,21 @@ namespace Sailor::EditorRemote
 
 		RemoteViewportSession* FindSession(ViewportId viewportId)
 		{
-			auto it = m_sessions.find(viewportId);
-			return it != m_sessions.end() ? it->second.get() : nullptr;
+			auto it = m_sessions.Find(viewportId);
+			return it != m_sessions.end() ? it.Value().get() : nullptr;
 		}
 
 		const RemoteViewportSession* FindSession(ViewportId viewportId) const
 		{
-			auto it = m_sessions.find(viewportId);
-			return it != m_sessions.end() ? it->second.get() : nullptr;
+			auto it = m_sessions.Find(viewportId);
+			return it != m_sessions.end() ? it.Value().get() : nullptr;
 		}
 
 		RemoteViewportSession& CreateOrReplaceSession(const ViewportDescriptor& descriptor, ConnectionEpoch epoch)
 		{
-			if (auto it = m_sessions.find(descriptor.m_viewportId); it != m_sessions.end())
+			if (auto it = m_sessions.Find(descriptor.m_viewportId); it != m_sessions.end())
 			{
-				PruneEpochViewport(descriptor.m_viewportId, it->second->GetConnectionEpoch());
+				PruneEpochViewport(descriptor.m_viewportId, it.Value()->GetConnectionEpoch());
 			}
 
 			auto session = std::make_unique<RemoteViewportSession>(descriptor, epoch);
@@ -384,45 +385,45 @@ namespace Sailor::EditorRemote
 			auto& epochViewports = m_viewportsByEpoch[epoch];
 			if (std::find(epochViewports.begin(), epochViewports.end(), descriptor.m_viewportId) == epochViewports.end())
 			{
-				epochViewports.push_back(descriptor.m_viewportId);
+				epochViewports.Add(descriptor.m_viewportId);
 			}
 			return *result;
 		}
 
 		bool DestroySession(ViewportId viewportId)
 		{
-			auto it = m_sessions.find(viewportId);
+			auto it = m_sessions.Find(viewportId);
 			if (it == m_sessions.end())
 			{
 				return false;
 			}
 
-			const auto epoch = it->second->GetConnectionEpoch();
-			(void)it->second->Destroy();
+			const auto epoch = it.Value()->GetConnectionEpoch();
+			(void)it.Value()->Destroy();
 			if (m_cleanupHook)
 			{
 				m_cleanupHook(viewportId, epoch);
 			}
-			m_sessions.erase(it);
+			m_sessions.Remove(viewportId);
 			PruneEpochViewport(viewportId, epoch);
 			return true;
 		}
 
 		size_t DestroySessionsForEpoch(ConnectionEpoch epoch)
 		{
-			auto epochIt = m_viewportsByEpoch.find(epoch);
+			auto epochIt = m_viewportsByEpoch.Find(epoch);
 			if (epochIt == m_viewportsByEpoch.end())
 			{
 				return 0;
 			}
 
-			auto viewportIds = epochIt->second;
+			auto viewportIds = epochIt.Value();
 			size_t destroyedCount = 0;
 			for (auto viewportId : viewportIds)
 			{
 				destroyedCount += DestroySession(viewportId) ? 1u : 0u;
 			}
-			m_viewportsByEpoch.erase(epoch);
+			m_viewportsByEpoch.Remove(epoch);
 			return destroyedCount;
 		}
 
@@ -431,33 +432,33 @@ namespace Sailor::EditorRemote
 			m_cleanupHook = std::move(hook);
 		}
 
-		size_t GetSessionCount() const { return m_sessions.size(); }
-		bool HasViewport(ViewportId viewportId) const { return m_sessions.contains(viewportId); }
+		size_t GetSessionCount() const { return m_sessions.Num(); }
+		bool HasViewport(ViewportId viewportId) const { return m_sessions.ContainsKey(viewportId); }
 		size_t GetViewportCountForEpoch(ConnectionEpoch epoch) const
 		{
-			auto it = m_viewportsByEpoch.find(epoch);
-			return it != m_viewportsByEpoch.end() ? it->second.size() : 0;
+			auto it = m_viewportsByEpoch.Find(epoch);
+			return it != m_viewportsByEpoch.end() ? it.Value().Num() : 0;
 		}
 
 	private:
 		void PruneEpochViewport(ViewportId viewportId, ConnectionEpoch epoch)
 		{
-			auto epochIt = m_viewportsByEpoch.find(epoch);
+			auto epochIt = m_viewportsByEpoch.Find(epoch);
 			if (epochIt == m_viewportsByEpoch.end())
 			{
 				return;
 			}
 
-			auto& viewports = epochIt->second;
-			viewports.erase(std::remove(viewports.begin(), viewports.end(), viewportId), viewports.end());
-			if (viewports.empty())
+			auto& viewports = epochIt.Value();
+			viewports.RemoveAll([viewportId](ViewportId candidate) { return candidate == viewportId; });
+			if (viewports.Num() == 0)
 			{
-				m_viewportsByEpoch.erase(epochIt);
+				m_viewportsByEpoch.Remove(epoch);
 			}
 		}
 
-		std::unordered_map<ViewportId, std::unique_ptr<RemoteViewportSession>> m_sessions{};
-		std::unordered_map<ConnectionEpoch, std::vector<ViewportId>> m_viewportsByEpoch{};
+		TMap<ViewportId, std::unique_ptr<RemoteViewportSession>> m_sessions{};
+		TMap<ConnectionEpoch, TVector<ViewportId>> m_viewportsByEpoch{};
 		SessionCleanupHook m_cleanupHook{};
 	};
 
@@ -496,7 +497,7 @@ namespace Sailor::EditorRemote
 
 		Failure RouteCommand(uint64_t connectionId, const ProtocolMessage& command) const
 		{
-			auto it = m_connections.find(connectionId);
+			auto it = m_connections.Find(connectionId);
 			if (it == m_connections.end())
 			{
 				return Failure::FromDomain(ErrorDomain::Connection, 1, "Unknown bridge connection");
@@ -509,21 +510,21 @@ namespace Sailor::EditorRemote
 			{
 				return Failure::Ok();
 			}
-			return m_commandHandler(it->second, command);
+			return m_commandHandler(it.Value(), command);
 		}
 
 		bool Disconnect(uint64_t connectionId, const Failure& reason = Failure::FromDomain(ErrorDomain::Connection, 1, "Disconnected"))
 		{
-			auto it = m_connections.find(connectionId);
+			auto it = m_connections.Find(connectionId);
 			if (it == m_connections.end())
 			{
 				return false;
 			}
 			if (m_disconnectHandler)
 			{
-				m_disconnectHandler(it->second, reason);
+				m_disconnectHandler(it.Value(), reason);
 			}
-			m_connections.erase(it);
+			m_connections.Remove(connectionId);
 			return true;
 		}
 
@@ -531,16 +532,16 @@ namespace Sailor::EditorRemote
 		void SetCommandHandler(CommandHandler handler) { m_commandHandler = std::move(handler); }
 		void SetDisconnectHandler(DisconnectHandler handler) { m_disconnectHandler = std::move(handler); }
 
-		bool HasConnection(uint64_t connectionId) const { return m_connections.contains(connectionId); }
-		size_t GetConnectionCount() const { return m_connections.size(); }
+		bool HasConnection(uint64_t connectionId) const { return m_connections.ContainsKey(connectionId); }
+		size_t GetConnectionCount() const { return m_connections.Num(); }
 		const BridgeConnectionInfo* FindConnection(uint64_t connectionId) const
 		{
-			auto it = m_connections.find(connectionId);
-			return it != m_connections.end() ? &it->second : nullptr;
+			auto it = m_connections.Find(connectionId);
+			return it != m_connections.end() ? &it.Value() : nullptr;
 		}
 
 	private:
-		std::unordered_map<uint64_t, BridgeConnectionInfo> m_connections{};
+		TMap<uint64_t, BridgeConnectionInfo> m_connections{};
 		NegotiationHandler m_negotiationHandler{};
 		CommandHandler m_commandHandler{};
 		DisconnectHandler m_disconnectHandler{};

--- a/Runtime/Submodules/EditorRemote/RemoteViewportWindowsTransport.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportWindowsTransport.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Containers/Containers.h"
 
 #include <optional>
 #include <unordered_map>
@@ -16,15 +17,11 @@ namespace Sailor::EditorRemote
 		SurfaceGeneration m_generation = 0;
 
 		auto operator<=>(const WindowsViewportSurfaceKey&) const = default;
-	};
 
-	struct WindowsViewportSurfaceKeyHasher
-	{
-		size_t operator()(const WindowsViewportSurfaceKey& key) const noexcept
+		size_t GetHash() const noexcept
 		{
-			size_t seed = std::hash<uint64_t>{}(key.m_viewportId);
-			seed ^= std::hash<uint64_t>{}(key.m_epoch) + 0x9e3779b97f4a7c15ull + (seed << 6) + (seed >> 2);
-			seed ^= std::hash<uint64_t>{}(key.m_generation) + 0x9e3779b97f4a7c15ull + (seed << 6) + (seed >> 2);
+			size_t seed = 0;
+			HashCombine(seed, m_viewportId, m_epoch, m_generation);
 			return seed;
 		}
 	};
@@ -144,21 +141,21 @@ namespace Sailor::EditorRemote
 		Failure ReleaseSurface(ViewportId viewportId, ConnectionEpoch epoch, SurfaceGeneration generation) override
 		{
 			WindowsViewportSurfaceKey key{ viewportId, epoch, generation };
-			auto it = m_surfaces.find(key);
+			auto it = m_surfaces.Find(key);
 			if (it == m_surfaces.end())
 			{
 				m_lastFailure = Failure::Ok();
 				return Failure::Ok();
 			}
 
-			auto result = m_provider.ReleaseSurface(it->second);
+			auto result = m_provider.ReleaseSurface(it.Value());
 			if (!result.IsOk())
 			{
 				m_lastFailure = m_provider.GetLastFailure();
 				return result;
 			}
 
-			m_surfaces.erase(it);
+			m_surfaces.Remove(key);
 			m_lastFailure = Failure::Ok();
 			return Failure::Ok();
 		}
@@ -171,22 +168,22 @@ namespace Sailor::EditorRemote
 		const WindowsViewportSurfaceState* FindSurface(ViewportId viewportId, ConnectionEpoch epoch, SurfaceGeneration generation) const
 		{
 			WindowsViewportSurfaceKey key{ viewportId, epoch, generation };
-			auto it = m_surfaces.find(key);
-			return it != m_surfaces.end() ? &it->second : nullptr;
+			auto it = m_surfaces.Find(key);
+			return it != m_surfaces.end() ? &it.Value() : nullptr;
 		}
 
-		size_t GetSurfaceCount() const { return m_surfaces.size(); }
+		size_t GetSurfaceCount() const { return m_surfaces.Num(); }
 
 	private:
 		WindowsViewportSurfaceState* FindSurface(ViewportId viewportId, ConnectionEpoch epoch, SurfaceGeneration generation)
 		{
 			WindowsViewportSurfaceKey key{ viewportId, epoch, generation };
-			auto it = m_surfaces.find(key);
-			return it != m_surfaces.end() ? &it->second : nullptr;
+			auto it = m_surfaces.Find(key);
+			return it != m_surfaces.end() ? &it.Value() : nullptr;
 		}
 
 		IWindowsSharedSurfaceProvider& m_provider;
-		std::unordered_map<WindowsViewportSurfaceKey, WindowsViewportSurfaceState, WindowsViewportSurfaceKeyHasher> m_surfaces{};
+		TMap<WindowsViewportSurfaceKey, WindowsViewportSurfaceState> m_surfaces{};
 		Failure m_lastFailure = Failure::Ok();
 	};
 

--- a/Runtime/Submodules/EditorRemote/RemoteViewportWindowsTransport.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportWindowsTransport.h
@@ -1,8 +1,8 @@
 #pragma once
 #include "Containers/Containers.h"
+#include "Memory/UniquePtr.hpp"
 
 #include <optional>
-#include <unordered_map>
 #include <utility>
 
 #include "EditorViewportSession.h"
@@ -85,7 +85,15 @@ namespace Sailor::EditorRemote
 			}
 
 			outTransport = state.m_transport;
-			m_surfaces[state.m_key] = state;
+			auto& storedState = m_surfaces[state.m_key];
+			if (storedState)
+			{
+				*storedState = state;
+			}
+			else
+			{
+				storedState = TUniquePtr<WindowsViewportSurfaceState>::Make(state);
+			}
 			m_lastFailure = Failure::Ok();
 			return Failure::Ok();
 		}
@@ -148,7 +156,7 @@ namespace Sailor::EditorRemote
 				return Failure::Ok();
 			}
 
-			auto result = m_provider.ReleaseSurface(it.Value());
+			auto result = m_provider.ReleaseSurface(*it.Value());
 			if (!result.IsOk())
 			{
 				m_lastFailure = m_provider.GetLastFailure();
@@ -169,7 +177,7 @@ namespace Sailor::EditorRemote
 		{
 			WindowsViewportSurfaceKey key{ viewportId, epoch, generation };
 			auto it = m_surfaces.Find(key);
-			return it != m_surfaces.end() ? &it.Value() : nullptr;
+			return it != m_surfaces.end() ? it.Value().GetRawPtr() : nullptr;
 		}
 
 		size_t GetSurfaceCount() const { return m_surfaces.Num(); }
@@ -179,11 +187,11 @@ namespace Sailor::EditorRemote
 		{
 			WindowsViewportSurfaceKey key{ viewportId, epoch, generation };
 			auto it = m_surfaces.Find(key);
-			return it != m_surfaces.end() ? &it.Value() : nullptr;
+			return it != m_surfaces.end() ? it.Value().GetRawPtr() : nullptr;
 		}
 
 		IWindowsSharedSurfaceProvider& m_provider;
-		TMap<WindowsViewportSurfaceKey, WindowsViewportSurfaceState> m_surfaces{};
+		TMap<WindowsViewportSurfaceKey, TUniquePtr<WindowsViewportSurfaceState>> m_surfaces{};
 		Failure m_lastFailure = Failure::Ok();
 	};
 

--- a/Runtime/Workspace/WorkspaceCacheContract.cpp
+++ b/Runtime/Workspace/WorkspaceCacheContract.cpp
@@ -1,4 +1,5 @@
 #include "Workspace/WorkspaceCacheContract.h"
+#include "Containers/Containers.h"
 
 #include "Workspace/WorkspaceContext.h"
 #include "Workspace/WorkspaceModuleApi.h"
@@ -36,6 +37,7 @@
 
 namespace
 {
+	using Sailor::TSet;
 	using namespace Sailor::Workspace;
 
 	constexpr const char* CacheVersionField = "cacheVersion";
@@ -47,7 +49,7 @@ namespace
 	constexpr const char* BuildIdentityField = "buildIdentity";
 	constexpr const char* PayloadField = "payload";
 
-	const std::unordered_set<std::string> EnvelopeFields =
+	const TSet<std::string> EnvelopeFields =
 	{
 		CacheVersionField,
 		PayloadVersionField,
@@ -99,8 +101,7 @@ namespace
 		const std::string& sourceName,
 		std::string& outDiagnostic)
 	{
-		std::unordered_set<std::string> keys;
-		keys.reserve(document.size());
+		TSet<std::string> keys;
 		for (const auto& field : document)
 		{
 			if (!field.first.IsScalar())
@@ -110,7 +111,7 @@ namespace
 			}
 
 			const std::string key = field.first.Scalar();
-			if (key.empty() || !keys.emplace(key).second)
+			if (key.empty() || !keys.Insert(key))
 			{
 				outDiagnostic = sourceName + " is corrupt: its envelope contains duplicate or empty field " +
 					Quote(key) + ".";
@@ -129,7 +130,7 @@ namespace
 		for (const auto& field : document)
 		{
 			const std::string key = field.first.Scalar();
-			if (!EnvelopeFields.contains(key))
+			if (!EnvelopeFields.Contains(key))
 			{
 				outDiagnostic = sourceName + " is corrupt: its current envelope contains unknown field " +
 					Quote(key) + ".";

--- a/Runtime/Workspace/WorkspaceContext.cpp
+++ b/Runtime/Workspace/WorkspaceContext.cpp
@@ -1,4 +1,5 @@
 #include "Workspace/WorkspaceContext.h"
+#include "Containers/Containers.h"
 #include "Workspace/WorkspacePathEncoding.h"
 #include "YamlExceptionBoundary.h"
 
@@ -13,6 +14,8 @@
 
 namespace
 {
+	using Sailor::TSet;
+	using Sailor::TVector;
 	using namespace Sailor::Workspace;
 
 	constexpr uint32_t SupportedManifestVersion = 1;
@@ -70,25 +73,22 @@ namespace
 				return;
 			}
 
-			for (auto it = m_directories.rbegin(); it != m_directories.rend(); ++it)
+			for (size_t index = m_directories.Num(); index > 0; --index)
 			{
 				std::error_code removeError;
-				std::filesystem::remove(*it, removeError);
+				std::filesystem::remove(m_directories[index - 1], removeError);
 			}
 		}
 
-		void Track(std::vector<std::filesystem::path> directories)
+		void Track(TVector<std::filesystem::path>&& directories)
 		{
-			m_directories.insert(
-				m_directories.end(),
-				std::make_move_iterator(directories.begin()),
-				std::make_move_iterator(directories.end()));
+			m_directories.AddRange(std::move(directories));
 		}
 
 		void Commit() noexcept { m_bCommitted = true; }
 
 	private:
-		std::vector<std::filesystem::path> m_directories;
+		TVector<std::filesystem::path> m_directories;
 		bool m_bCommitted = false;
 	};
 
@@ -223,8 +223,7 @@ namespace
 			return false;
 		}
 
-		std::unordered_set<std::string> keys;
-		keys.reserve(document.size());
+		TSet<std::string> keys;
 		for (const auto& field : document)
 		{
 			if (!field.first.IsScalar())
@@ -234,7 +233,7 @@ namespace
 			}
 
 			const std::string key = field.first.Scalar();
-			if (key.empty() || !keys.emplace(key).second)
+			if (key.empty() || !keys.Insert(key))
 			{
 				outError = "Workspace manifest contains duplicate or empty field '" + key + "'.";
 				return false;
@@ -571,7 +570,7 @@ namespace
 			return true;
 		}
 
-		std::vector<std::filesystem::path> missingDirectories;
+		TVector<std::filesystem::path> missingDirectories;
 		for (std::filesystem::path current = directory;
 			current != root && !current.empty();
 			current = current.parent_path())
@@ -587,7 +586,7 @@ namespace
 					"' could not be inspected: '" + PathToUtf8(current) + "'.";
 				return false;
 			}
-			missingDirectories.emplace_back(current);
+			missingDirectories.Add(current);
 		}
 
 		std::reverse(missingDirectories.begin(), missingDirectories.end());
@@ -700,7 +699,7 @@ namespace
 			return true;
 		}
 
-		std::vector<std::filesystem::path> manifests;
+		TVector<std::filesystem::path> manifests;
 		for (std::filesystem::directory_iterator it(root, pathError), end;
 			!pathError && it != end;
 			it.increment(pathError))
@@ -708,7 +707,7 @@ namespace
 			std::error_code entryError;
 			if (it->is_regular_file(entryError) && !entryError && HasSailorExtension(it->path()))
 			{
-				manifests.emplace_back(it->path());
+				manifests.Add(it->path());
 			}
 		}
 		if (pathError)
@@ -720,12 +719,12 @@ namespace
 		}
 
 		std::sort(manifests.begin(), manifests.end());
-		if (manifests.empty())
+		if (manifests.Num() == 0)
 		{
 			outManifest.clear();
 			return true;
 		}
-		if (manifests.size() > 1)
+		if (manifests.Num() > 1)
 		{
 			outFailureStatus = EWorkspaceContextResolveStatus::ManifestAmbiguous;
 			outError = "Multiple .sailor manifests were found in '" + PathToUtf8(root) +
@@ -733,7 +732,7 @@ namespace
 			return false;
 		}
 
-		outManifest = std::filesystem::canonical(manifests.front(), pathError);
+		outManifest = std::filesystem::canonical(manifests[0], pathError);
 		if (pathError || !IsInside(root, outManifest))
 		{
 			outFailureStatus = EWorkspaceContextResolveStatus::PathInvalid;

--- a/Runtime/Workspace/WorkspaceModuleManager.cpp
+++ b/Runtime/Workspace/WorkspaceModuleManager.cpp
@@ -1,4 +1,5 @@
 #include "Workspace/WorkspaceModuleManager.h"
+#include "Containers/Containers.h"
 
 #include "Components/Component.h"
 #include "Core/Reflection.h"
@@ -36,18 +37,18 @@ namespace
 
 	struct WorkspaceTypeCollector
 	{
-		std::vector<CollectedWorkspaceType> m_types;
+		TVector<CollectedWorkspaceType> m_types;
 		std::string m_error;
 		uint64_t m_totalCanonicalDefaultValuesLength = 0;
 	};
 
 	struct MetadataIdentities
 	{
-		std::unordered_set<std::string> m_engineTypes;
-		std::unordered_set<std::string> m_cdos;
-		std::unordered_set<std::string> m_enums;
-		std::unordered_set<std::string> m_assetTypes;
-		std::unordered_set<std::string> m_assetExtensions;
+		TSet<std::string> m_engineTypes;
+		TSet<std::string> m_cdos;
+		TSet<std::string> m_enums;
+		TSet<std::string> m_assetTypes;
+		TSet<std::string> m_assetExtensions;
 	};
 
 	constexpr const char* MetadataSections[]
@@ -107,7 +108,7 @@ namespace
 			static_cast<size_t>(descriptor->canonicalDefaultValuesLength));
 		type.m_flags = descriptor->flags;
 		type.m_placementFactory = descriptor->placementFactory;
-		collector.m_types.emplace_back(std::move(type));
+		collector.m_types.Add(std::move(type));
 		collector.m_totalCanonicalDefaultValuesLength +=
 			descriptor->canonicalDefaultValuesLength;
 		return static_cast<uint32_t>(EWorkspaceModuleResult::Success);
@@ -164,17 +165,17 @@ namespace
 #endif
 	}
 
-	using MetadataEntries = std::unordered_map<std::string, YAML::Node>;
-	using CollectedTypeInfos = std::unordered_map<std::string, const TypeInfo*>;
-	using EditorEnumDefinitions = std::unordered_map<std::string, std::unordered_set<std::string>>;
+	using MetadataEntries = TMap<std::string, YAML::Node>;
+	using CollectedTypeInfos = TMap<std::string, const TypeInfo*>;
+	using EditorEnumDefinitions = TMap<std::string, TSet<std::string>>;
 
 	struct EditorTypeSchema
 	{
 		std::string m_baseType;
-		std::unordered_map<std::string, std::string> m_properties;
+		TMap<std::string, std::string> m_properties;
 	};
 
-	using EditorTypeSchemas = std::unordered_map<std::string, EditorTypeSchema>;
+	using EditorTypeSchemas = TMap<std::string, EditorTypeSchema>;
 	constexpr size_t MaxCanonicalYamlDepth = 64;
 	constexpr size_t MaxCanonicalYamlNodes = 262144;
 	constexpr size_t MaxCanonicalYamlBytes = 64 * 1024 * 1024;
@@ -185,7 +186,7 @@ namespace
 		MetadataEntries& outEntries,
 		std::string& outError)
 	{
-		outEntries.clear();
+		outEntries.Clear();
 		for (const YAML::Node& entry : entries)
 		{
 			if (!entry.IsMap() || !entry["typename"] || !entry["typename"].IsScalar())
@@ -196,7 +197,7 @@ namespace
 			}
 
 			const std::string typeName = entry["typename"].as<std::string>();
-			if (typeName.empty() || !outEntries.emplace(typeName, entry).second)
+			if (typeName.empty() || !outEntries.Insert(typeName, entry))
 			{
 				outError = std::string("Workspace metadata section '") + sectionName +
 					"' contains duplicate or empty typename '" + typeName + "'.";
@@ -235,7 +236,7 @@ namespace
 			return false;
 		}
 
-		std::unordered_set<std::string> propertyNames;
+		TSet<std::string> propertyNames;
 		for (const auto& property : metadataProperties)
 		{
 			if (!property.first.IsScalar() || !property.second.IsScalar())
@@ -247,7 +248,7 @@ namespace
 
 			const std::string propertyName = property.first.as<std::string>();
 			const std::string propertyType = property.second.as<std::string>();
-			if (!propertyNames.emplace(propertyName).second ||
+			if (!propertyNames.Insert(propertyName) ||
 				!reflectedProperties.ContainsKey(propertyName) ||
 				reflectedProperties[propertyName] != propertyType)
 			{
@@ -265,12 +266,12 @@ namespace
 		const CollectedTypeInfos& collectedTypes,
 		std::string& outError)
 	{
-		std::unordered_set<std::string> visitedTypes;
+		TSet<std::string> visitedTypes;
 		const TypeInfo* currentType = &typeInfo;
 		while (currentType != nullptr)
 		{
 			const std::string& currentTypeName = currentType->Name();
-			if (!visitedTypes.emplace(currentTypeName).second)
+			if (!visitedTypes.Insert(currentTypeName))
 			{
 				outError = "Workspace type '" + typeInfo.Name() +
 					"' contains a cycle in its reflected base hierarchy.";
@@ -288,10 +289,10 @@ namespace
 				break;
 			}
 
-			const auto collectedBase = collectedTypes.find(baseTypeName);
+			const auto collectedBase = collectedTypes.Find(baseTypeName);
 			if (collectedBase != collectedTypes.end())
 			{
-				currentType = collectedBase->second;
+				currentType = collectedBase.Value();
 			}
 			else
 			{
@@ -403,8 +404,8 @@ namespace
 		}
 		case YAML::NodeType::Map:
 		{
-			std::vector<std::pair<std::string, std::string>> entries;
-			entries.reserve(node.size());
+			TVector<std::pair<std::string, std::string>> entries;
+			entries.Reserve(node.size());
 			for (const auto& entry : node)
 			{
 				std::string canonicalKey;
@@ -424,14 +425,14 @@ namespace
 				{
 					return false;
 				}
-				entries.emplace_back(std::move(canonicalKey), std::move(canonicalValue));
+				entries.Add(std::make_pair(std::move(canonicalKey), std::move(canonicalValue)));
 			}
 
 			std::sort(entries.begin(), entries.end(), [](const auto& lhs, const auto& rhs)
 				{
 					return lhs.first < rhs.first;
 				});
-			for (size_t index = 1; index < entries.size(); ++index)
+			for (size_t index = 1; index < entries.Num(); ++index)
 			{
 				if (entries[index - 1].first == entries[index].first)
 				{
@@ -439,7 +440,7 @@ namespace
 				}
 			}
 
-			const std::string numEntries = std::to_string(entries.size());
+			const std::string numEntries = std::to_string(entries.Num());
 			if (!AppendCanonicalCharacter(destination, 'M', remainingBytes) ||
 				!AppendCanonicalField(destination, node.Tag(), remainingBytes) ||
 				!AppendCanonicalText(destination, numEntries, remainingBytes) ||
@@ -477,11 +478,10 @@ namespace
 			return false;
 		}
 
-		std::unordered_set<std::string> keys;
-		keys.reserve(node.size());
+		TSet<std::string> keys;
 		for (const auto& entry : node)
 		{
-			if (!entry.first.IsScalar() || !keys.emplace(entry.first.Scalar()).second)
+			if (!entry.first.IsScalar() || !keys.Insert(entry.first.Scalar()))
 			{
 				return false;
 			}
@@ -559,7 +559,7 @@ namespace
 	bool CollectMetadataIdentities(
 		const YAML::Node& metadata,
 		const char* sectionName,
-		std::unordered_set<std::string>& outIdentities,
+		TSet<std::string>& outIdentities,
 		std::string& outError)
 	{
 		const YAML::Node entries = metadata[sectionName];
@@ -577,7 +577,7 @@ namespace
 				return false;
 			}
 
-			if (!outIdentities.emplace(identity).second)
+			if (!outIdentities.Insert(identity))
 			{
 				outError = "Editor metadata section '" + std::string(sectionName) +
 					"' contains duplicate identity '" + identity + "'.";
@@ -611,10 +611,9 @@ namespace
 				return false;
 			}
 
-			std::unordered_set<std::string> propertyNames;
+			TSet<std::string> propertyNames;
 			if (properties.IsMap())
 			{
-				propertyNames.reserve(properties.size());
 				for (const auto& property : properties)
 				{
 					if (!property.first.IsScalar() || !property.second.IsScalar())
@@ -627,7 +626,7 @@ namespace
 					const std::string propertyName = property.first.as<std::string>();
 					const std::string propertyType = property.second.as<std::string>();
 					if (IsBlank(propertyName) || IsBlank(propertyType) ||
-						!propertyNames.emplace(propertyName).second)
+						!propertyNames.Insert(propertyName))
 					{
 						outError = "Editor metadata type '" + typeName +
 							"' contains an empty or duplicate property '" + propertyName + "'.";
@@ -659,10 +658,9 @@ namespace
 				return false;
 			}
 
-			std::unordered_set<std::string> readOnlyPropertyNames;
+			TSet<std::string> readOnlyPropertyNames;
 			if (readOnlyProperties.IsSequence())
 			{
-				readOnlyPropertyNames.reserve(readOnlyProperties.size());
 				for (const YAML::Node& property : readOnlyProperties)
 				{
 					if (!property.IsScalar())
@@ -673,8 +671,8 @@ namespace
 					}
 
 					const std::string propertyName = property.as<std::string>();
-					if (IsBlank(propertyName) || propertyNames.contains(propertyName) ||
-						!readOnlyPropertyNames.emplace(propertyName).second)
+					if (IsBlank(propertyName) || propertyNames.Contains(propertyName) ||
+						!readOnlyPropertyNames.Insert(propertyName))
 					{
 						outError = "Editor metadata type '" + typeName +
 							"' contains invalid read-only property '" + propertyName + "'.";
@@ -692,7 +690,7 @@ namespace
 		EditorEnumDefinitions& outDefinitions,
 		std::string& outError)
 	{
-		outDefinitions.clear();
+		outDefinitions.Clear();
 		for (const YAML::Node& enumEntry : metadata["enums"])
 		{
 			const std::string enumName = enumEntry.begin()->first.as<std::string>();
@@ -703,8 +701,7 @@ namespace
 				return false;
 			}
 
-			std::unordered_set<std::string> enumValues;
-			enumValues.reserve(values.size());
+			TSet<std::string> enumValues;
 			for (const YAML::Node& value : values)
 			{
 				if (!value.IsScalar())
@@ -714,7 +711,7 @@ namespace
 				}
 
 				const std::string enumValue = value.as<std::string>();
-				if (IsBlank(enumValue) || !enumValues.emplace(enumValue).second)
+				if (IsBlank(enumValue) || !enumValues.Insert(enumValue))
 				{
 					outError = "Editor enum metadata '" + enumName +
 						"' contains an empty or duplicate value '" + enumValue + "'.";
@@ -722,7 +719,7 @@ namespace
 				}
 			}
 
-			if (!outDefinitions.emplace(enumName, std::move(enumValues)).second)
+			if (!outDefinitions.Insert(enumName, std::move(enumValues)))
 			{
 				outError = "Editor enum metadata contains duplicate identity '" + enumName + "'.";
 				return false;
@@ -737,23 +734,23 @@ namespace
 		const std::string& typeName,
 		const std::string& propertyName)
 	{
-		std::unordered_set<std::string> visitedTypes;
+		TSet<std::string> visitedTypes;
 		std::string currentType = typeName;
-		while (!currentType.empty() && visitedTypes.emplace(currentType).second)
+		while (!currentType.empty() && visitedTypes.Insert(currentType))
 		{
-			const auto schema = schemas.find(currentType);
+			const auto schema = schemas.Find(currentType);
 			if (schema == schemas.end())
 			{
 				return nullptr;
 			}
 
-			const auto property = schema->second.m_properties.find(propertyName);
-			if (property != schema->second.m_properties.end())
+			const auto property = schema.Value().m_properties.Find(propertyName);
+			if (property != schema.Value().m_properties.end())
 			{
-				return &property->second;
+				return &property.Value();
 			}
 
-			currentType = schema->second.m_baseType;
+			currentType = schema.Value().m_baseType;
 		}
 
 		return nullptr;
@@ -768,7 +765,6 @@ namespace
 		}
 
 		EditorTypeSchemas typeSchemas;
-		typeSchemas.reserve(metadata["engineTypes"].size());
 		for (const YAML::Node& type : metadata["engineTypes"])
 		{
 			const std::string typeName = type["typename"].as<std::string>();
@@ -783,22 +779,22 @@ namespace
 				{
 					const std::string propertyName = property.first.as<std::string>();
 					const std::string propertyType = property.second.as<std::string>();
-					if (propertyType.rfind("enum ", 0) == 0 && !enumDefinitions.contains(propertyType))
+					if (propertyType.rfind("enum ", 0) == 0 && !enumDefinitions.ContainsKey(propertyType))
 					{
 						outError = "Editor property '" + typeName + "::" + propertyName +
 							"' references missing enum metadata '" + propertyType + "'.";
 						return false;
 					}
-					schema.m_properties.emplace(propertyName, propertyType);
+					schema.m_properties.Insert(propertyName, propertyType);
 				}
 			}
-			typeSchemas.emplace(typeName, std::move(schema));
+			typeSchemas.Insert(typeName, std::move(schema));
 		}
 
 		for (const YAML::Node& defaultObject : metadata["cdos"])
 		{
 			const std::string typeName = defaultObject["typename"].as<std::string>();
-			if (!typeSchemas.contains(typeName))
+			if (!typeSchemas.ContainsKey(typeName))
 			{
 				outError = "Editor default object '" + typeName + "' has no matching reflected type.";
 				return false;
@@ -830,10 +826,10 @@ namespace
 					continue;
 				}
 
-				const auto enumDefinition = enumDefinitions.find(*propertyType);
+				const auto enumDefinition = enumDefinitions.Find(*propertyType);
 				if (!defaultValue.second.IsScalar() ||
 					enumDefinition == enumDefinitions.end() ||
-					!enumDefinition->second.contains(defaultValue.second.as<std::string>()))
+					!enumDefinition.Value().Contains(defaultValue.second.as<std::string>()))
 				{
 					outError = "Editor enum default '" + typeName + "::" + propertyName +
 						"' is not a declared member of '" + *propertyType + "'.";
@@ -847,7 +843,7 @@ namespace
 
 	bool CollectAssetExtensions(
 		const YAML::Node& metadata,
-		std::unordered_set<std::string>& outExtensions,
+		TSet<std::string>& outExtensions,
 		std::string& outError)
 	{
 		for (const YAML::Node& assetType : metadata["assetTypes"])
@@ -889,7 +885,7 @@ namespace
 						return static_cast<char>(std::tolower(character));
 					});
 
-				if (extension.empty() || !outExtensions.emplace(extension).second)
+				if (extension.empty() || !outExtensions.Insert(extension))
 				{
 					outError = "Editor asset metadata contains an empty or duplicate extension '" + extension + "'.";
 					return false;
@@ -957,14 +953,14 @@ namespace
 	}
 
 	bool HasMetadataCollision(
-		const std::unordered_set<std::string>& engineIdentities,
-		const std::unordered_set<std::string>& workspaceIdentities,
+		const TSet<std::string>& engineIdentities,
+		const TSet<std::string>& workspaceIdentities,
 		const char* sectionName,
 		std::string& outError)
 	{
 		for (const std::string& identity : workspaceIdentities)
 		{
-			if (engineIdentities.contains(identity))
+			if (engineIdentities.Contains(identity))
 			{
 				outError = "Workspace editor metadata section '" + std::string(sectionName) +
 					"' conflicts with engine identity '" + identity + "'.";
@@ -978,14 +974,14 @@ namespace
 	bool CollectSharedEnumIdentities(
 		const YAML::Node& engineMetadata,
 		const YAML::Node& workspaceMetadata,
-		const std::unordered_set<std::string>& engineEnums,
-		std::unordered_set<std::string>& outSharedEnums,
+		const TSet<std::string>& engineEnums,
+		TSet<std::string>& outSharedEnums,
 		std::string& outError)
 	{
 		for (const YAML::Node& workspaceEnum : workspaceMetadata["enums"])
 		{
 			const std::string identity = workspaceEnum.begin()->first.as<std::string>();
-			if (!engineEnums.contains(identity))
+			if (!engineEnums.Contains(identity))
 			{
 				continue;
 			}
@@ -1017,7 +1013,7 @@ namespace
 				return false;
 			}
 
-			outSharedEnums.insert(identity);
+			outSharedEnums.Insert(identity);
 		}
 
 		return true;
@@ -1240,8 +1236,8 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 		return Fail(EWorkspaceModuleLoadStatus::MetadataInvalid, std::move(metadataError));
 	}
 
-	if (metadataTypes.size() != collector.m_types.size() ||
-		metadataDefaults.size() != collector.m_types.size())
+	if (metadataTypes.Num() != collector.m_types.Num() ||
+		metadataDefaults.Num() != collector.m_types.Num())
 	{
 		return Fail(
 			EWorkspaceModuleLoadStatus::MetadataInvalid,
@@ -1249,7 +1245,6 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 	}
 
 	CollectedTypeInfos collectedTypeInfos;
-	collectedTypeInfos.reserve(collector.m_types.size());
 	for (const CollectedWorkspaceType& collected : collector.m_types)
 	{
 		if (collected.m_typeInfo == nullptr ||
@@ -1259,7 +1254,7 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 			collected.m_typeSize > std::numeric_limits<size_t>::max() ||
 			collected.m_typeAlignment > std::numeric_limits<size_t>::max() ||
 			Reflection::TryGetTypeByName(collected.m_typeName) != nullptr ||
-			!collectedTypeInfos.emplace(collected.m_typeName, collected.m_typeInfo).second)
+			!collectedTypeInfos.Insert(collected.m_typeName, collected.m_typeInfo))
 		{
 			return Fail(
 				EWorkspaceModuleLoadStatus::RegistrationFailed,
@@ -1268,8 +1263,8 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 		}
 	}
 
-	std::vector<Reflection::WorkspaceTypeRegistration> registrations;
-	registrations.reserve(collector.m_types.size());
+	TVector<Reflection::WorkspaceTypeRegistration> registrations;
+	registrations.Reserve(collector.m_types.Num());
 	for (const CollectedWorkspaceType& collected : collector.m_types)
 	{
 		if ((collected.m_flags & WorkspaceTypeDescriptorFlagAmbiguousProperties) != 0)
@@ -1280,8 +1275,8 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 				"' contains ambiguous or shadowed reflected property names.");
 		}
 
-		const auto metadataTypeIt = metadataTypes.find(collected.m_typeName);
-		const auto metadataDefaultsIt = metadataDefaults.find(collected.m_typeName);
+		const auto metadataTypeIt = metadataTypes.Find(collected.m_typeName);
+		const auto metadataDefaultsIt = metadataDefaults.Find(collected.m_typeName);
 		if (metadataTypeIt == metadataTypes.end() || metadataDefaultsIt == metadataDefaults.end())
 		{
 			return Fail(
@@ -1289,8 +1284,8 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 				"Workspace metadata is missing type or CDO data for '" + collected.m_typeName + "'.");
 		}
 
-		const YAML::Node& metadataType = metadataTypeIt->second;
-		const YAML::Node& metadataDefaultObject = metadataDefaultsIt->second;
+		const YAML::Node& metadataType = metadataTypeIt.Value();
+		const YAML::Node& metadataDefaultObject = metadataDefaultsIt.Value();
 		if (!metadataType["base"] || !metadataType["base"].IsScalar() ||
 			metadataType["base"].as<std::string>() != collected.m_baseTypeName)
 		{
@@ -1328,7 +1323,7 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 
 			return static_cast<Component*>(destination);
 		};
-		registrations.emplace_back(std::move(registration));
+		registrations.Add(std::move(registration));
 	}
 
 	std::string candidateOwner = moduleName + "@" + modulePath.generic_string();
@@ -1341,9 +1336,9 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 
 	m_state = EWorkspaceModuleState::Registered;
 	m_result.m_status = EWorkspaceModuleLoadStatus::Success;
-	m_result.m_numRegisteredTypes = collector.m_types.size();
+	m_result.m_numRegisteredTypes = collector.m_types.Num();
 	m_result.m_message = "Loaded workspace module '" + moduleName + "' from '" +
-		modulePath.generic_string() + "' with " + std::to_string(collector.m_types.size()) +
+		modulePath.generic_string() + "' with " + std::to_string(collector.m_types.Num()) +
 		" reflected type(s).";
 	return m_result;
 }
@@ -1375,7 +1370,7 @@ bool Sailor::Workspace::WorkspaceModuleManager::MergeEditorTypeMetadata(
 {
 	MetadataIdentities engineIdentities;
 	MetadataIdentities workspaceIdentities;
-	std::unordered_set<std::string> sharedEnums;
+	TSet<std::string> sharedEnums;
 	std::string validationError;
 	if (!ValidateMetadataDocument(engineMetadata, false, {}, engineIdentities, validationError) ||
 		!ValidateMetadataDocument(workspaceMetadata, true, {}, workspaceIdentities, validationError))
@@ -1425,7 +1420,7 @@ bool Sailor::Workspace::WorkspaceModuleManager::MergeEditorTypeMetadata(
 		for (const YAML::Node& entry : workspaceMetadata[sectionName])
 		{
 			if (std::strcmp(sectionName, "enums") == 0 &&
-				sharedEnums.contains(entry.begin()->first.as<std::string>()))
+				sharedEnums.Contains(entry.begin()->first.as<std::string>()))
 			{
 				continue;
 			}

--- a/Runtime/Workspace/WorkspaceTypeMetadata.h
+++ b/Runtime/Workspace/WorkspaceTypeMetadata.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Containers/Containers.h"
 
 #include "Core/Reflection.h"
 #include "Workspace/WorkspaceModuleApi.h"
@@ -84,7 +85,7 @@ namespace Sailor::Workspace
 		template<typename TType>
 		uint32_t GetWorkspaceTypeDescriptorFlags()
 		{
-			std::unordered_map<std::string, WorkspacePropertyDeclaration> declarations;
+			TMap<std::string, WorkspacePropertyDeclaration> declarations;
 			uint32_t flags = 0;
 			TType* empty = nullptr;
 
@@ -114,22 +115,25 @@ namespace Sailor::Workspace
 									bWritable
 								};
 
-								const auto [existing, bInserted] = declarations.try_emplace(
-									displayName,
-									std::move(declaration));
-								if (!bInserted)
-								{
-									if (existing->second.m_declarator != declarator ||
-										existing->second.m_typeName != typeName ||
-										(existing->second.m_bReadable && bReadable) ||
-										(existing->second.m_bWritable && bWritable))
+									auto existing = declarations.Find(displayName);
+									if (existing == declarations.end())
 									{
-										flags |= WorkspaceTypeDescriptorFlagAmbiguousProperties;
+										declarations.Insert(displayName, declaration);
 									}
+									else
+									{
+										auto& existingDeclaration = existing.Value();
+										if (existingDeclaration.m_declarator != declarator ||
+											existingDeclaration.m_typeName != typeName ||
+											(existingDeclaration.m_bReadable && bReadable) ||
+											(existingDeclaration.m_bWritable && bWritable))
+										{
+											flags |= WorkspaceTypeDescriptorFlagAmbiguousProperties;
+										}
 
-									existing->second.m_bReadable |= bReadable;
-									existing->second.m_bWritable |= bWritable;
-								}
+										existingDeclaration.m_bReadable |= bReadable;
+										existingDeclaration.m_bWritable |= bWritable;
+									}
 							};
 
 							if constexpr (bReadable)
@@ -159,25 +163,25 @@ namespace Sailor::Workspace
 		YAML::Node SerializeWorkspaceType()
 		{
 			YAML::Node metadata = TypeInfo::Get<TType>().Serialize();
-			std::unordered_set<std::string> writableProperties;
+			TSet<std::string> writableProperties;
 			for_each(refl::reflect<TType>().members, [&](auto member)
 				{
 					if constexpr (is_writable(member))
 					{
-						writableProperties.insert(get_display_name(member));
+						writableProperties.Insert(get_display_name(member));
 					}
 				});
 
 			YAML::Node readOnlyProperties(YAML::NodeType::Sequence);
-			std::unordered_set<std::string> emittedReadOnlyProperties;
+			TSet<std::string> emittedReadOnlyProperties;
 			for_each(refl::reflect<TType>().members, [&](auto member)
 				{
 					if constexpr (is_readable(member) &&
 						!refl::descriptor::has_attribute<Attributes::Transient>(member))
 					{
 						const std::string displayName = get_display_name(member);
-						if (!writableProperties.contains(displayName) &&
-							emittedReadOnlyProperties.insert(displayName).second)
+						if (!writableProperties.Contains(displayName) &&
+							emittedReadOnlyProperties.Insert(displayName))
 						{
 							readOnlyProperties.push_back(displayName);
 						}
@@ -189,13 +193,13 @@ namespace Sailor::Workspace
 		}
 
 		template<typename TProperty>
-		void AppendWorkspaceEnum(YAML::Node& enums, std::unordered_set<std::string>& enumNames)
+		void AppendWorkspaceEnum(YAML::Node& enums, TSet<std::string>& enumNames)
 		{
 			using EnumType = ::refl::trait::remove_qualifiers_t<TProperty>;
 			if constexpr (std::is_enum_v<EnumType>)
 			{
 				const std::string enumName = TypeInfo::GetReflectedEnumTypeName<EnumType>();
-				if (!enumNames.insert(enumName).second)
+				if (!enumNames.Insert(enumName))
 				{
 					return;
 				}
@@ -213,7 +217,7 @@ namespace Sailor::Workspace
 		}
 
 		template<typename TType>
-		void AppendWorkspaceEnums(YAML::Node& enums, std::unordered_set<std::string>& enumNames)
+		void AppendWorkspaceEnums(YAML::Node& enums, TSet<std::string>& enumNames)
 		{
 			TType* empty = nullptr;
 			for_each(refl::reflect<TType>().members, [&](auto member)
@@ -254,7 +258,7 @@ namespace Sailor::Workspace
 				(defaultObjects.push_back(SerializeWorkspaceDefaultObject<TTypes>()), ...);
 
 				YAML::Node enums(YAML::NodeType::Sequence);
-				std::unordered_set<std::string> enumNames;
+				TSet<std::string> enumNames;
 				(AppendWorkspaceEnums<TTypes>(enums, enumNames), ...);
 
 				YAML::Node metadata;

--- a/Tests/AssetMountDiscoveryTests.cpp
+++ b/Tests/AssetMountDiscoveryTests.cpp
@@ -106,7 +106,7 @@ namespace
 	}
 
 	bool HasDiagnostic(
-		const std::vector<AssetMountDiagnostic>& diagnostics,
+		const TVector<AssetMountDiagnostic>& diagnostics,
 		EAssetMountDiagnosticCode code)
 	{
 		return std::any_of(diagnostics.begin(), diagnostics.end(), [&](const AssetMountDiagnostic& diagnostic)
@@ -116,7 +116,7 @@ namespace
 	}
 
 	const AssetMountDiagnostic& FindDiagnostic(
-		const std::vector<AssetMountDiagnostic>& diagnostics,
+		const TVector<AssetMountDiagnostic>& diagnostics,
 		EAssetMountDiagnosticCode code)
 	{
 		const auto it = std::find_if(diagnostics.begin(), diagnostics.end(), [&](const AssetMountDiagnostic& diagnostic)
@@ -150,12 +150,12 @@ namespace
 			Mount(workspaceAlias, EAssetMountKind::Workspace, 0, true)
 		});
 
-		Require(result.m_mounts.size() == 1, "Identical physical roots should be scanned once");
-		Require(result.m_mounts.front().m_kind == EAssetMountKind::Workspace,
+		Require(result.m_mounts.Num() == 1, "Identical physical roots should be scanned once");
+		Require(result.m_mounts[0].m_kind == EAssetMountKind::Workspace,
 			"Workspace should win an identical-root mount collision");
-		Require(result.m_mounts.front().m_bWritable,
+		Require(result.m_mounts[0].m_bWritable,
 			"The retained workspace mount should preserve its writable property");
-		Require(result.m_files.size() == 1, "Deduplicated roots should not duplicate files");
+		Require(result.m_files.Num() == 1, "Deduplicated roots should not duplicate files");
 		Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::DuplicateMountRoot),
 			"Identical roots should emit a deterministic dedupe diagnostic");
 	}
@@ -172,7 +172,7 @@ namespace
 		});
 
 		Require(result.HasFatalErrors(), "An invalid mount root should be reported as fatal");
-		Require(result.m_files.empty(), "A fatal mount set must not publish partial discovery files");
+		Require(result.m_files.IsEmpty(), "A fatal mount set must not publish partial discovery files");
 		Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::InvalidMountRoot),
 			"Invalid roots should remain distinguishable from overlap failures");
 	}
@@ -215,7 +215,7 @@ namespace
 
 			Require(result.HasFatalErrors(),
 				"Workspace roots containing Engine roots must be rejected as fatal");
-			Require(result.m_files.empty(),
+			Require(result.m_files.IsEmpty(),
 				"Fatal root overlap must stop discovery before either root is scanned");
 			Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::OverlappingMountRoot),
 				"Workspace-parent overlap should identify the root conflict");
@@ -234,7 +234,7 @@ namespace
 
 			Require(result.HasFatalErrors(),
 				"Engine roots containing Workspace roots must be rejected as fatal");
-			Require(result.m_files.empty(),
+			Require(result.m_files.IsEmpty(),
 				"Reverse root overlap must stop discovery before either root is scanned");
 			Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::OverlappingMountRoot),
 				"Engine-parent overlap should identify the root conflict");
@@ -254,7 +254,7 @@ namespace
 			Mount(content.Get(), EAssetMountKind::Workspace, 10, true)
 		});
 
-		Require(result.m_files.size() == 1 && result.m_files.front().m_virtualPath == "safe.txt",
+		Require(result.m_files.Num() == 1 && result.m_files[0].m_virtualPath == "safe.txt",
 			"Escaping and cyclic directory links must not contribute files");
 		Require(HasDiagnostic(result.m_diagnostics, EAssetMountDiagnosticCode::PhysicalEscapeSkipped),
 			"Physical escapes should produce a diagnostic");
@@ -391,7 +391,7 @@ namespace
 		};
 
 		const AssetMountResolutionResult result = ResolveAssetMountCandidates({ invalid });
-		Require(result.GetCandidates().empty(), "Traversal candidates should not enter winner indexes");
+		Require(result.GetCandidates().IsEmpty(), "Traversal candidates should not enter winner indexes");
 		Require(HasDiagnostic(result.GetDiagnostics(), EAssetMountDiagnosticCode::InvalidCandidate),
 			"Rejected candidates should produce an actionable diagnostic");
 	}

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -171,6 +171,9 @@ target_compile_definitions(WorkspaceModuleMissingEntryFixture PRIVATE
 )
 target_link_libraries(WorkspaceModuleFixture PRIVATE Sailor::Runtime)
 target_link_libraries(WorkspaceModuleIncompatibleFixture PRIVATE Sailor::Runtime)
+target_link_libraries(RemoteViewportRuntimeTests PRIVATE Sailor::Runtime)
+target_link_libraries(EditorViewportSessionTests PRIVATE Sailor::Runtime)
+target_link_libraries(AssetMountDiscoveryTests PRIVATE Sailor::Runtime)
 target_link_libraries(WorkspaceModuleContractTests PRIVATE
     Sailor::Runtime
 )
@@ -211,10 +214,12 @@ if(WIN32)
 endif()
 if(WIN32)
     target_compile_features(RemoteViewportWindowsTransportTests PRIVATE cxx_std_20)
+    target_link_libraries(RemoteViewportWindowsTransportTests PRIVATE Sailor::Runtime)
 endif()
 if(APPLE)
     target_compile_features(RemoteViewportMacTransportTests PRIVATE cxx_std_20)
     target_compile_features(RemoteViewportMacNativeBridgeTests PRIVATE cxx_std_20)
+    target_link_libraries(RemoteViewportMacTransportTests PRIVATE Sailor::Runtime)
 endif()
 target_include_directories(RemoteViewportFoundationTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
@@ -401,6 +406,11 @@ endif()
 add_test(
     NAME RuntimeNoExceptions
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/runtime_no_exceptions_test.py ${SAILOR_RUNTIME_DIR}
+)
+
+add_test(
+    NAME RuntimeNoStdContainers
+    COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/runtime_no_std_containers_test.py ${SAILOR_RUNTIME_DIR}
 )
 
 add_test(

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -31,6 +31,10 @@ add_executable(EditorViewportSessionTests
     EditorViewportSessionTests.cpp
 )
 
+add_executable(SmartPointerTests
+    SmartPointerTests.cpp
+)
+
 add_library(WorkspaceModuleFixture SHARED
     WorkspaceModuleFixture.cpp
 )
@@ -141,6 +145,7 @@ target_compile_features(RemoteViewportFoundationTests PRIVATE cxx_std_20)
 target_compile_features(RemoteViewportContractTests PRIVATE cxx_std_20)
 target_compile_features(RemoteViewportRuntimeTests PRIVATE cxx_std_20)
 target_compile_features(EditorViewportSessionTests PRIVATE cxx_std_20)
+target_compile_features(SmartPointerTests PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleFixture PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleIncompatibleFixture PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleMissingEntryFixture PRIVATE cxx_std_20)
@@ -173,6 +178,7 @@ target_link_libraries(WorkspaceModuleFixture PRIVATE Sailor::Runtime)
 target_link_libraries(WorkspaceModuleIncompatibleFixture PRIVATE Sailor::Runtime)
 target_link_libraries(RemoteViewportRuntimeTests PRIVATE Sailor::Runtime)
 target_link_libraries(EditorViewportSessionTests PRIVATE Sailor::Runtime)
+target_link_libraries(SmartPointerTests PRIVATE Sailor::Runtime)
 target_link_libraries(AssetMountDiscoveryTests PRIVATE Sailor::Runtime)
 target_link_libraries(WorkspaceModuleContractTests PRIVATE
     Sailor::Runtime
@@ -231,6 +237,9 @@ target_include_directories(RemoteViewportRuntimeTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(EditorViewportSessionTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(SmartPointerTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(WorkspaceModuleFixture PRIVATE
@@ -309,6 +318,11 @@ add_test(
 )
 
 add_test(
+    NAME SmartPointerTests
+    COMMAND SmartPointerTests
+)
+
+add_test(
     NAME WorkspaceModuleContractTests
     COMMAND WorkspaceModuleContractTests
 )
@@ -368,6 +382,7 @@ set_tests_properties(
     AssetMountDiscoveryTests
     WorkspaceModuleContractTests
     WorkspaceModuleRuntimeTests
+    SmartPointerTests
     PROPERTIES TIMEOUT 30
 )
 
@@ -409,7 +424,7 @@ add_test(
 )
 
 add_test(
-    NAME RuntimeNoStdContainers
+    NAME RuntimeNoStdContainersOrSmartPointers
     COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/runtime_no_std_containers_test.py ${SAILOR_RUNTIME_DIR}
 )
 

--- a/Tests/RemoteViewportMacTransportTests.cpp
+++ b/Tests/RemoteViewportMacTransportTests.cpp
@@ -8,6 +8,9 @@
 
 using namespace Sailor::EditorRemote;
 
+static_assert(std::three_way_comparable<MacRendererFrameSource>);
+static_assert(std::three_way_comparable<MacIOSurfaceAllocation>);
+
 namespace
 {
 

--- a/Tests/RemoteViewportRuntimeTests.cpp
+++ b/Tests/RemoteViewportRuntimeTests.cpp
@@ -352,6 +352,61 @@ namespace
 		Require(server.GetConnectionCount() == 0, "disconnect should remove connection from server");
 	}
 
+	void TestEditorBridgeServerConnectionAddressStability()
+	{
+		EditorBridgeServer server{};
+		auto makeRequest = [](uint64_t connectionId, ConnectionEpoch epoch)
+		{
+			BridgeConnectionRequest request{};
+			request.m_connectionId = connectionId;
+			request.m_epoch = epoch;
+			request.m_protocolVersion = 1;
+			return request;
+		};
+
+		Require(server.AcceptConnection(makeRequest(1, 10)).IsOk(),
+			"address-stability server should accept its first connection");
+		const BridgeConnectionInfo* firstAddress = server.FindConnection(1);
+		for (uint64_t connectionId = 2; connectionId <= 64; ++connectionId)
+		{
+			Require(server.AcceptConnection(makeRequest(connectionId, connectionId + 10)).IsOk(),
+				"address-stability server should accept growth connections");
+		}
+
+		const BridgeConnectionInfo* addressAfterGrowth = server.FindConnection(1);
+		Require(firstAddress != nullptr && addressAfterGrowth == firstAddress && addressAfterGrowth->m_epoch == 10,
+			"connection address and contents should survive unrelated map growth");
+		Require(server.AcceptConnection(makeRequest(1, 99)).IsOk(),
+			"address-stability server should update an existing connection");
+		Require(server.FindConnection(1) == firstAddress && firstAddress->m_epoch == 99,
+			"same-key connection updates should preserve the published address");
+
+		EditorBridgeServer reentrantServer{};
+		for (uint64_t connectionId = 1; connectionId <= 16; ++connectionId)
+		{
+			Require(reentrantServer.AcceptConnection(makeRequest(connectionId, connectionId)).IsOk(),
+				"reentrant server should fill its initial connection capacity");
+		}
+
+		bool bHandlerReferenceStable = false;
+		reentrantServer.SetCommandHandler([&](const BridgeConnectionInfo& connection, const ProtocolMessage&)
+		{
+			const BridgeConnectionInfo* addressBeforeInsert = &connection;
+			const auto insertion = reentrantServer.AcceptConnection(makeRequest(17, 17));
+			bHandlerReferenceStable = insertion.IsOk() &&
+				addressBeforeInsert == reentrantServer.FindConnection(connection.m_connectionId) &&
+				connection.m_connectionId == 1 && connection.m_epoch == 1;
+			return Failure::Ok();
+		});
+
+		ProtocolMessage command{};
+		command.m_envelope.m_category = MessageCategory::Command;
+		Require(reentrantServer.RouteCommand(1, command).IsOk(),
+			"reentrant connection handler should accept an unrelated insertion");
+		Require(bHandlerReferenceStable,
+			"connection handler reference should survive reentrant map growth");
+	}
+
 	class FakeRenderBridge : public IEditorRenderBridge
 	{
 	public:
@@ -466,6 +521,7 @@ int main()
 		{ "ViewportSessionManagerLifecycleAndEpochCleanup", TestViewportSessionManagerLifecycleAndEpochCleanup },
 		{ "ViewportSessionManagerReplacementStormPrunesEpochBookkeeping", TestViewportSessionManagerReplacementStormPrunesEpochBookkeeping },
 		{ "EditorBridgeServerNegotiationRoutingAndDisconnect", TestEditorBridgeServerNegotiationRoutingAndDisconnect },
+		{ "EditorBridgeServerConnectionAddressStability", TestEditorBridgeServerConnectionAddressStability },
 		{ "EditorRenderFacadeBoundary", TestEditorRenderFacadeBoundary },
 		{ "RemoteViewportReconnectTimeoutBackoffAndDiagnostics", TestRemoteViewportReconnectTimeoutBackoffAndDiagnostics },
 		{ "RemoteViewportFrameFloodKeepsLatestFrameAndStableCounters", TestRemoteViewportFrameFloodKeepsLatestFrameAndStableCounters },

--- a/Tests/SmartPointerTests.cpp
+++ b/Tests/SmartPointerTests.cpp
@@ -1,0 +1,155 @@
+#include <compare>
+#include <cstdint>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "Memory/SharedPtr.hpp"
+#include "Memory/UniquePtr.hpp"
+
+using namespace Sailor;
+
+namespace
+{
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	struct LifetimeProbe
+	{
+		LifetimeProbe()
+		{
+			++s_liveCount;
+		}
+
+		explicit LifetimeProbe(int value) : m_value(value)
+		{
+			++s_liveCount;
+		}
+
+		~LifetimeProbe()
+		{
+			--s_liveCount;
+			++s_destroyedCount;
+		}
+
+		static void Reset()
+		{
+			s_liveCount = 0;
+			s_destroyedCount = 0;
+		}
+
+		static inline int s_liveCount = 0;
+		static inline int s_destroyedCount = 0;
+		int m_value = 0;
+	};
+
+	void TestSharedPtrConstObserversAndComparison()
+	{
+		LifetimeProbe::Reset();
+		{
+			auto shared = TSharedPtr<LifetimeProbe>::Make(3);
+			const TSharedPtr<LifetimeProbe> constShared = shared;
+			constShared->m_value = 7;
+			(*constShared).m_value = 11;
+
+			Require(shared->m_value == 11, "const shared pointer should preserve mutable pointee access");
+			Require((shared <=> constShared) == std::strong_ordering::equal, "shared copies should compare equal");
+
+			auto other = TSharedPtr<LifetimeProbe>::Make(5);
+			Require((shared <=> other) != std::strong_ordering::equal, "different shared objects should not compare equal");
+			Require(LifetimeProbe::s_liveCount == 2, "shared pointers should retain both live objects");
+		}
+
+		Require(LifetimeProbe::s_liveCount == 0, "shared pointers should destroy their pointees exactly once");
+		Require(LifetimeProbe::s_destroyedCount == 2, "shared pointer destruction count should match allocations");
+	}
+
+	void TestUniquePtrScalarRelease()
+	{
+		LifetimeProbe::Reset();
+		LifetimeProbe* released = nullptr;
+		{
+			auto pointer = TUniquePtr<LifetimeProbe>::Make(17);
+			released = pointer.Release();
+			Require(!pointer, "released scalar unique pointer should become empty");
+			Require(released != nullptr && released->m_value == 17, "scalar release should return the owned pointee");
+		}
+
+		Require(LifetimeProbe::s_liveCount == 1, "released scalar pointee should outlive its former owner");
+		delete released;
+		Require(LifetimeProbe::s_liveCount == 0, "released scalar pointee should remain manually deletable");
+		Require(LifetimeProbe::s_destroyedCount == 1, "scalar release should not double-delete the pointee");
+	}
+
+	void TestUniquePtrArrayLifetimeMoveAndRelease()
+	{
+		LifetimeProbe::Reset();
+		LifetimeProbe* released = nullptr;
+		{
+			auto array = TUniquePtr<LifetimeProbe[]>::Make(3);
+			Require(LifetimeProbe::s_liveCount == 3, "array unique pointer should construct every element");
+			array[1].m_value = 23;
+
+			auto moved = std::move(array);
+			Require(!array && moved[1].m_value == 23, "array move construction should transfer ownership");
+
+			moved = std::move(moved);
+			Require(moved && moved[1].m_value == 23, "array self-move assignment should preserve ownership");
+
+			auto replacement = TUniquePtr<LifetimeProbe[]>::Make(1);
+			replacement = std::move(moved);
+			Require(!moved && replacement[1].m_value == 23, "array move assignment should replace and transfer ownership");
+			Require(LifetimeProbe::s_liveCount == 3, "array move assignment should destroy the replaced allocation");
+
+			released = replacement.Release();
+			Require(!replacement && released[1].m_value == 23, "array release should return the allocation and clear ownership");
+		}
+
+		Require(LifetimeProbe::s_liveCount == 3, "released array should outlive its former owner");
+		delete[] released;
+		Require(LifetimeProbe::s_liveCount == 0, "released array should remain manually deletable");
+		Require(LifetimeProbe::s_destroyedCount == 4, "array move and release should destroy each element exactly once");
+	}
+
+	void TestUniquePtrArrayValueInitialization()
+	{
+		auto values = TUniquePtr<uint32_t[]>::Make(4);
+		for (size_t i = 0; i < 4; ++i)
+		{
+			Require(values[i] == 0, "array Make should value-initialize fundamental elements");
+		}
+	}
+}
+
+int main()
+{
+	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "SharedPtrConstObserversAndComparison", TestSharedPtrConstObserversAndComparison },
+		{ "UniquePtrScalarRelease", TestUniquePtrScalarRelease },
+		{ "UniquePtrArrayLifetimeMoveAndRelease", TestUniquePtrArrayLifetimeMoveAndRelease },
+		{ "UniquePtrArrayValueInitialization", TestUniquePtrArrayValueInitialization },
+	};
+
+	for (const auto& test : tests)
+	{
+		try
+		{
+			test.second();
+			std::cout << "[PASS] " << test.first << std::endl;
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "[FAIL] " << test.first << ": " << e.what() << std::endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/Tests/WorkspaceModuleContractTests.cpp
+++ b/Tests/WorkspaceModuleContractTests.cpp
@@ -336,8 +336,8 @@ namespace
 		};
 
 		constexpr const char* owner = "WorkspaceModuleContractTests.FactoryInvocationLease";
-		std::vector<Reflection::WorkspaceTypeRegistration> registrations;
-		registrations.emplace_back(std::move(registration));
+		Sailor::TVector<Reflection::WorkspaceTypeRegistration> registrations;
+		registrations.Add(std::move(registration));
 		std::string registrationError;
 		Require(Reflection::RegisterWorkspaceTypes(owner, std::move(registrations), registrationError),
 			"workspace fixture should register for lease validation: " + registrationError);

--- a/Tests/WorkspaceModuleRuntimeTests.cpp
+++ b/Tests/WorkspaceModuleRuntimeTests.cpp
@@ -422,8 +422,8 @@ namespace
 			return new (destination) WorkspaceOwnerSentinel::OwnerSentinelComponent();
 		};
 
-		std::vector<Reflection::WorkspaceTypeRegistration> registrations;
-		registrations.emplace_back(std::move(sentinelRegistration));
+		Sailor::TVector<Reflection::WorkspaceTypeRegistration> registrations;
+		registrations.Add(std::move(sentinelRegistration));
 		std::string registrationError;
 		Require(
 			Reflection::RegisterWorkspaceTypes(owner, std::move(registrations), registrationError),

--- a/Tests/WorkspaceModuleRuntimeTests.cpp
+++ b/Tests/WorkspaceModuleRuntimeTests.cpp
@@ -442,6 +442,72 @@ namespace
 			"a rejected manager must not unregister the active registration owned by another manager");
 	}
 
+	void TestWorkspaceCdoAddressStability()
+	{
+		constexpr const char* primaryOwner = "WorkspaceModuleRuntimeTests.CdoAddressPrimary";
+		constexpr const char* growthOwner = "WorkspaceModuleRuntimeTests.CdoAddressGrowth";
+		const TypeInfo& sentinelType = WorkspaceOwnerSentinel::OwnerSentinelComponent::GetStaticTypeInfo();
+
+		auto makeRegistration = [](const TypeInfo& type, const YAML::Node& properties)
+		{
+			Reflection::WorkspaceTypeRegistration registration;
+			registration.m_typeInfo = &type;
+			registration.m_alignment = alignof(WorkspaceOwnerSentinel::OwnerSentinelComponent);
+			registration.m_defaultObject = Reflection::CreateReflectedData(type, properties);
+			registration.m_placementFactory = [](void*) -> IReflectable* { return nullptr; };
+			return registration;
+		};
+
+		YAML::Node sentinelProperties(YAML::NodeType::Map);
+		sentinelProperties["addressStabilitySentinel"] = 73;
+		TVector<Reflection::WorkspaceTypeRegistration> primaryRegistrations;
+		primaryRegistrations.Add(makeRegistration(sentinelType, sentinelProperties));
+		std::string registrationError;
+		Require(
+			Reflection::RegisterWorkspaceTypes(primaryOwner, std::move(primaryRegistrations), registrationError),
+			"primary CDO address-stability registration should succeed: " + registrationError);
+
+		const ReflectedData* addressBeforeGrowth = &Reflection::GetCDO(sentinelType.Name());
+		const ReflectedData snapshot = *addressBeforeGrowth;
+
+		std::vector<TypeInfo> fillerTypes;
+		fillerTypes.reserve(64);
+		TVector<Reflection::WorkspaceTypeRegistration> growthRegistrations;
+		growthRegistrations.Reserve(64);
+		for (size_t i = 0; i < 64; ++i)
+		{
+			fillerTypes.emplace_back(sentinelType);
+			YAML::Node fillerType = fillerTypes.back().Serialize();
+			fillerType["typename"] = "WorkspaceCdoAddressFiller::Type" + std::to_string(i);
+			fillerTypes.back().Deserialize(fillerType);
+			growthRegistrations.Add(makeRegistration(fillerTypes.back(), YAML::Node(YAML::NodeType::Map)));
+		}
+
+		const bool bGrowthRegistered = Reflection::RegisterWorkspaceTypes(
+			growthOwner,
+			std::move(growthRegistrations),
+			registrationError);
+		if (!bGrowthRegistered)
+		{
+			Reflection::UnregisterWorkspaceTypes(primaryOwner);
+			Require(false, "growth CDO registrations should succeed: " + registrationError);
+		}
+
+		const ReflectedData* addressAfterGrowth = &Reflection::GetCDO(sentinelType.Name());
+		const bool bAddressStable = addressBeforeGrowth == addressAfterGrowth;
+		const bool bContentsStable = *addressAfterGrowth == snapshot &&
+			addressAfterGrowth->GetProperties()["addressStabilitySentinel"].as<int>() == 73;
+		const size_t numGrowthRemoved = Reflection::UnregisterWorkspaceTypes(growthOwner);
+		const size_t numPrimaryRemoved = Reflection::UnregisterWorkspaceTypes(primaryOwner);
+
+		Require(bAddressStable,
+			"workspace CDO address should remain stable when later registrations grow the registry map");
+		Require(bContentsStable,
+			"workspace CDO contents should remain intact when later registrations grow the registry map");
+		Require(numGrowthRemoved == 64 && numPrimaryRemoved == 1,
+			"address-stability registrations should be removed exactly once");
+	}
+
 	void TestIncompatibleModule(
 		const std::filesystem::path& tempRoot,
 		const std::filesystem::path& incompatibleLibrary,
@@ -837,6 +903,7 @@ int main(int argc, char** argv)
 		TestDynamicLibraryFailures(tempRoot, missingEntryLibrary);
 		TestDiscoveryFailures(tempRoot, config);
 		TestFailedOwnerClaimPreservesExistingRegistration(tempRoot, fixtureLibrary, config);
+		TestWorkspaceCdoAddressStability();
 		TestUnknownReflectedType();
 		TestWorldInstantiationGuards();
 		TestIncompatibleModule(tempRoot, incompatibleLibrary, config);

--- a/Tests/runtime_no_std_containers_test.py
+++ b/Tests/runtime_no_std_containers_test.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 
 CONTAINER_PATTERN = re.compile(
-    r"\bstd::(vector|deque|list|forward_list|map|multimap|unordered_map|set|multiset|unordered_set)\s*<"
+    r"\bstd\s*::\s*(vector|deque|list|forward_list|map|multimap|unordered_map|set|multiset|unordered_set)\s*<"
+)
+SMART_POINTER_PATTERN = re.compile(
+    r"\bstd\s*::\s*(shared_ptr|weak_ptr|unique_ptr|make_shared|make_unique|enable_shared_from_this)\b"
 )
 SOURCE_SUFFIXES = {".h", ".hpp", ".inl", ".cpp", ".cc", ".cxx", ".mm"}
 ALLOWED_CONTAINERS = {
@@ -100,13 +103,18 @@ def main() -> int:
                 line = source.count("\n", 0, match.start()) + 1
                 violations.append(f"{relative_path}:{line}: std::{container} is not allowed in Runtime")
 
+        for match in SMART_POINTER_PATTERN.finditer(masked):
+            smart_pointer = match.group(1)
+            line = source.count("\n", 0, match.start()) + 1
+            violations.append(f"{relative_path}:{line}: std::{smart_pointer} is not allowed in Runtime")
+
     if violations:
-        print("Runtime allocator-backed code must use Sailor containers:", file=sys.stderr)
+        print("Runtime ownership must use Sailor containers and smart pointers:", file=sys.stderr)
         for violation in violations:
             print(f"  {violation}", file=sys.stderr)
         return 1
 
-    print("Runtime std container policy passed.")
+    print("Runtime std container and smart pointer policy passed.")
     return 0
 
 

--- a/Tests/runtime_no_std_containers_test.py
+++ b/Tests/runtime_no_std_containers_test.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+
+import re
+import sys
+from pathlib import Path
+
+
+CONTAINER_PATTERN = re.compile(
+    r"\bstd::(vector|deque|list|forward_list|map|multimap|unordered_map|set|multiset|unordered_set)\s*<"
+)
+SOURCE_SUFFIXES = {".h", ".hpp", ".inl", ".cpp", ".cc", ".cxx", ".mm"}
+ALLOWED_CONTAINERS = {
+    Path("Editor/EditorRuntimeBridge.cpp"): {"vector"},
+    Path("Submodules/EditorRemote/RemoteViewportFoundation.h"): {"vector"},
+    Path("Submodules/EditorRemote/RemoteViewportHarness.h"): {"deque"},
+    Path("Submodules/EditorRemote/RemoteViewportMacTransport.h"): {"vector"},
+}
+
+
+def mask_span(characters: list[str], source: str, start: int, end: int) -> None:
+    for index in range(start, end):
+        if source[index] != "\n":
+            characters[index] = " "
+
+
+def mask_comments_and_literals(source: str) -> str:
+    masked = list(source)
+    index = 0
+
+    while index < len(source):
+        if source.startswith("//", index):
+            end = source.find("\n", index + 2)
+            end = len(source) if end == -1 else end
+            mask_span(masked, source, index, end)
+            index = end
+            continue
+
+        if source.startswith("/*", index):
+            end = source.find("*/", index + 2)
+            end = len(source) if end == -1 else end + 2
+            mask_span(masked, source, index, end)
+            index = end
+            continue
+
+        if index == 0 or not (source[index - 1].isalnum() or source[index - 1] == "_"):
+            raw_match = re.match(r'(?:u8|u|U|L)?R"([^ ()\\\t\r\n]{0,16})\(', source[index:])
+            if raw_match:
+                terminator = ")" + raw_match.group(1) + '"'
+                end = source.find(terminator, index + raw_match.end())
+                end = len(source) if end == -1 else end + len(terminator)
+                mask_span(masked, source, index, end)
+                index = end
+                continue
+
+        if source[index] in {'"', "'"}:
+            quote = source[index]
+            end = index + 1
+            while end < len(source):
+                if source[end] == "\\":
+                    end += 2
+                    continue
+                end += 1
+                if source[end - 1] == quote:
+                    break
+            mask_span(masked, source, index, min(end, len(source)))
+            index = end
+            continue
+
+        index += 1
+
+    return "".join(masked)
+
+
+def is_allowed(relative_path: Path, container: str) -> bool:
+    if relative_path == Path("Memory/Memory.cpp"):
+        return True
+    if relative_path.parent == Path("Containers") and relative_path.name.endswith("Benchmark.cpp"):
+        return True
+    return container in ALLOWED_CONTAINERS.get(relative_path, set())
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"Usage: {Path(sys.argv[0]).name} <Runtime directory>", file=sys.stderr)
+        return 2
+
+    runtime_dir = Path(sys.argv[1]).resolve()
+    violations: list[str] = []
+
+    for source_path in sorted(runtime_dir.rglob("*")):
+        if not source_path.is_file() or source_path.suffix not in SOURCE_SUFFIXES:
+            continue
+
+        relative_path = source_path.relative_to(runtime_dir)
+        source = source_path.read_text(encoding="utf-8", errors="replace")
+        masked = mask_comments_and_literals(source)
+        for match in CONTAINER_PATTERN.finditer(masked):
+            container = match.group(1)
+            if not is_allowed(relative_path, container):
+                line = source.count("\n", 0, match.start()) + 1
+                violations.append(f"{relative_path}:{line}: std::{container} is not allowed in Runtime")
+
+    if violations:
+        print("Runtime allocator-backed code must use Sailor containers:", file=sys.stderr)
+        for violation in violations:
+            print(f"  {violation}", file=sys.stderr)
+        return 1
+
+    print("Runtime std container policy passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- migrate allocator-backed Runtime collections to `TVector`, `TMap`, and `TSet`
- retain explicit benchmark, harness, protocol, and native byte-buffer exceptions
- extend Sailor container APIs needed by migrated call sites
- add a source policy test preventing new allocator-backed STL containers in Runtime
- update affected contract tests and standalone test linkage

## Validation

- `cmake --build build-mac-vcpkg --config Debug --parallel 4`
- `ctest --test-dir build-mac-vcpkg -C Debug --output-on-failure` (17/17)
- `python3 run_world_tests.py --config Release` (6/6)
- `python3 Tests/runtime_no_std_containers_test.py Runtime`
- `git diff --check`

## Stack

This PR is based on `issue-112-remove-runtime-exceptions` and should be reviewed after #114. Retarget it to `main` after #114 merges.

Closes #113
