### PR TITLE
Restore Windows CI baseline

### DIFF
--- a/Editor.Tests/WorkspaceProjectGeneratorTests.cs
+++ b/Editor.Tests/WorkspaceProjectGeneratorTests.cs
@@ -23,9 +23,9 @@ public sealed class WorkspaceProjectGeneratorTests
         Assert.Contains("SAILOR_WORKSPACE_MODULE", cmake);
         Assert.Contains("SAILOR_WORKSPACE_MODULE_EXPORTS", cmake);
         Assert.DoesNotContain("WINDOWS_EXPORT_ALL_SYMBOLS", cmake);
-        Assert.Contains("if(NOT WIN32)", cmake);
+        Assert.DoesNotContain("if(NOT WIN32)", cmake);
         Assert.Contains("if(NOT CMAKE_SIZEOF_VOID_P EQUAL 8)", cmake);
-        Assert.Contains("CMAKE_CXX_COMPILER_FRONTEND_VARIANT STREQUAL \"MSVC\"", cmake);
+        Assert.Contains("CMAKE_CXX_COMPILER_ID MATCHES \"AppleClang|Clang|GNU\"", cmake);
         Assert.Contains("PDB_OUTPUT_DIRECTORY \"${SAILOR_GAME_OUTPUT_DIR}/$<CONFIG>\"", cmake);
         Assert.Contains("COMPILE_PDB_OUTPUT_DIRECTORY \"${SAILOR_GAME_OUTPUT_DIR}/$<CONFIG>\"", cmake);
         Assert.Contains("${CMAKE_CURRENT_LIST_DIR}/../Source", cmake);

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
@@ -218,6 +218,7 @@ void VulkanDevice::BeginConditionalDestroy()
 		maxThreadContexts += 4;
 	}
 #endif
+	(void)maxThreadContexts;
 	check(m_threadContext.Num() <= maxThreadContexts);
 
 	for (auto& pair : m_threadContext)


### PR DESCRIPTION
Closes #116

## What changed

- Mark the Vulkan teardown thread-limit value as intentionally used when `check` compiles out.
- Align workspace project generator contract assertions with the current cross-platform CMake output.

## Root cause

The workspace-load change made the generated CMake compiler validation cross-platform, but left the old Windows-only test expectations behind. The Vulkan limit is consumed only by `check`, which disappears in the Windows Release clang-cl build and turns the local variable into a warning-as-error.

## Impact

No runtime or generated-project behavior changes. This restores the Windows CI baseline for `main` and dependent pull requests.

## Validation

- Focused workspace project generator test: 1/1 passed.
- Full `Editor.Contracts.Tests` Release suite: 361/361 passed.
- `git diff --check`: passed.
- Windows clang-cl/MSVC GitHub Actions remain the authoritative platform validation.
