### PR TITLE
Restore asset hot reload and cache recovery

### DIFF
--- a/.github/workflows/engine-build.yml
+++ b/.github/workflows/engine-build.yml
@@ -68,7 +68,7 @@ jobs:
 
     - name: Test
       working-directory: build
-      run: ctest -C ${{ env.BUILD_TYPE }}
+      run: ctest -C ${{ env.BUILD_TYPE }} --output-on-failure
 
     - name: Install Sailor CMake package
       run: cmake --install build --config ${{ env.BUILD_TYPE }} --prefix build/install

--- a/Content/Shaders/ComputeLightCulling.shader
+++ b/Content/Shaders/ComputeLightCulling.shader
@@ -149,6 +149,11 @@ glslCompute: |
   			break;
   		}
   
+          if(light.instance[lightIndex].type == INVALID_LIGHT_TYPE)
+          {
+              continue;
+          }
+
   		// Directional light
   		if(light.instance[lightIndex].type == 0)
   		{

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -14,6 +14,8 @@ struct LightData
   vec3 bounds;
 };
 
+const uint INVALID_LIGHT_TYPE = 0xFFFFFFFFu;
+
 layout(std430)
 struct LightsGrid
 {

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -84,6 +84,8 @@ glslVertex: |
   {
     mat4 matrix;
   };
+
+  const uint INVALID_SKELETON_OFFSET = 0xFFFFFFFFu;
   
   layout(set = 0, binding = 0) uniform FrameData
   {
@@ -162,16 +164,19 @@ glslVertex: |
   
   void main()
   {
+    mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
   #ifdef SKINNING
     uint offset = data.instance[gl_InstanceIndex].skeletonOffset;
-    mat4 skinMatrix = bones.instance[offset + inBoneIds.x].matrix * inBoneWeights.x +
-                      bones.instance[offset + inBoneIds.y].matrix * inBoneWeights.y +
-                      bones.instance[offset + inBoneIds.z].matrix * inBoneWeights.z +
-                      bones.instance[offset + inBoneIds.w].matrix * inBoneWeights.w;
 
-    mat4 modelMatrix = data.instance[gl_InstanceIndex].model * skinMatrix;
-  #else
-    mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
+    if (offset != INVALID_SKELETON_OFFSET)
+    {
+      mat4 skinMatrix = bones.instance[offset + inBoneIds.x].matrix * inBoneWeights.x +
+                        bones.instance[offset + inBoneIds.y].matrix * inBoneWeights.y +
+                        bones.instance[offset + inBoneIds.z].matrix * inBoneWeights.z +
+                        bones.instance[offset + inBoneIds.w].matrix * inBoneWeights.w;
+
+      modelMatrix *= skinMatrix;
+    }
   #endif
 
     vec4 vertexPosition = modelMatrix * vec4(inPosition, 1.0);

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="EditorPerfTests.cs" />
     <Compile Include="EngineLaunchContractTests.cs" />
     <Compile Include="EngineLifecycleTests.cs" />
+    <Compile Include="WorldSnapshotPublicationGateTests.cs" />
     <Compile Include="EditorTypeCacheStoreTests.cs" />
     <Compile Include="Utf8InteropArgumentsTests.cs" />
     <Compile Include="..\Editor\Panels\PanelContracts.cs" Link="Panels\PanelContracts.cs" />
@@ -100,6 +101,7 @@
     <Compile Include="..\Editor\Utility\EditorDragDrop.cs" Link="Utility\EditorDragDrop.cs" />
     <Compile Include="..\Editor\Utility\EditorPerf.cs" Link="Utility\EditorPerf.cs" />
     <Compile Include="..\Editor\Services\EngineLaunchContract.cs" Link="Services\EngineLaunchContract.cs" />
+    <Compile Include="..\Editor\Services\WorldSnapshotPublicationGate.cs" Link="Services\WorldSnapshotPublicationGate.cs" />
     <Compile Include="..\Editor\Services\EditorTypeCacheStore.cs" Link="Services\EditorTypeCacheStore.cs" />
     <Compile Include="..\Editor\Services\Utf8InteropArguments.cs" Link="Services\Utf8InteropArguments.cs" />
     <Compile Include="..\Editor\Commands\EditorCommandRuntime.cs" Link="Commands\EditorCommandRuntime.cs" />

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -3,6 +3,16 @@ namespace Editor.Tests;
 public sealed class EngineLifecycleTests
 {
     [Fact]
+    public void EditorBundle_CompilesCriticalXamlEntryPoints()
+    {
+        var project = ReadRepositoryFile("Editor", "SailorEditor.csproj");
+
+        AssertMauiXamlGenerator(project, "App.xaml");
+        AssertMauiXamlGenerator(project, "AppShell.xaml");
+        AssertMauiXamlGenerator(project, "Views\\InspectorView\\FrameGraphFileTemplate.xaml");
+    }
+
+    [Fact]
     public void ManagedLifecycle_ExposesExplicitAwaitableOwnershipContract()
     {
         var source = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
@@ -24,10 +34,44 @@ public sealed class EngineLifecycleTests
         var source = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
 
         Assert.Contains("Interlocked.Increment(ref engineGeneration)", source, StringComparison.Ordinal);
-        Assert.Contains("if (IsGenerationActive(generation, allowStarting: true))", source, StringComparison.Ordinal);
+        Assert.Contains("!IsGenerationActive(generation, allowStarting)", source, StringComparison.Ordinal);
+        Assert.Contains("!worldSnapshotPublication.TryAdvance(snapshotSequence)", source, StringComparison.Ordinal);
         Assert.Contains("message.Generation == generation", source, StringComparison.Ordinal);
         Assert.Contains(".Where(message => message.Generation == generation)", source, StringComparison.Ordinal);
         Assert.Contains("QueueWorldUpdate", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SuccessfulLocalWorldMutation_AdvancesSnapshotGateUnderTheInteropLock()
+    {
+        var source = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
+
+        var helper = source.IndexOf("bool InvokeRunningInterop", StringComparison.Ordinal);
+        var interopLock = source.IndexOf("lock (interopLock)", helper, StringComparison.Ordinal);
+        var nativeAction = source.IndexOf("!action()", interopLock, StringComparison.Ordinal);
+        var reserveSequence = source.IndexOf(
+            "worldSnapshotPublication.ReserveSequence()",
+            nativeAction,
+            StringComparison.Ordinal);
+        var advanceGate = source.IndexOf(
+            "worldSnapshotPublication.TryAdvance(mutationSequence)",
+            reserveSequence,
+            StringComparison.Ordinal);
+        var helperEnd = source.IndexOf("public static void ShowMainWindow", advanceGate, StringComparison.Ordinal);
+        var commitChanges = source.IndexOf("public bool CommitChanges", helperEnd, StringComparison.Ordinal);
+        var invalidateQueuedSnapshots = source.IndexOf(
+            "invalidateQueuedWorldSnapshots: true",
+            commitChanges,
+            StringComparison.Ordinal);
+
+        Assert.True(helper >= 0);
+        Assert.True(interopLock > helper);
+        Assert.True(nativeAction > interopLock);
+        Assert.True(reserveSequence > nativeAction);
+        Assert.True(advanceGate > reserveSequence);
+        Assert.True(helperEnd > advanceGate);
+        Assert.True(commitChanges > helperEnd);
+        Assert.True(invalidateQueuedSnapshots > commitChanges);
     }
 
     [Fact]
@@ -42,6 +86,19 @@ public sealed class EngineLifecycleTests
         Assert.Contains("return Sailor::App::GetExitCode();", windowsSource, StringComparison.Ordinal);
         Assert.Contains("SAILOR_API int32_t GetExitCode()", unixSource, StringComparison.Ordinal);
         Assert.Contains("return Sailor::App::GetExitCode();", unixSource, StringComparison.Ordinal);
+    }
+
+    static void AssertMauiXamlGenerator(string project, string xamlPath)
+    {
+        var itemStart = project.IndexOf($"<MauiXaml Update=\"{xamlPath}\">", StringComparison.Ordinal);
+        var itemEnd = project.IndexOf("</MauiXaml>", itemStart, StringComparison.Ordinal);
+
+        Assert.True(itemStart >= 0, $"Missing MauiXaml item for {xamlPath}.");
+        Assert.True(itemEnd > itemStart, $"Malformed MauiXaml item for {xamlPath}.");
+        Assert.Contains(
+            "<Generator>MSBuild:Compile</Generator>",
+            project[itemStart..itemEnd],
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -62,18 +119,48 @@ public sealed class EngineLifecycleTests
         Assert.Contains("SAILOR_API bool RequestAssetReload()", unixSource, StringComparison.Ordinal);
         Assert.Contains("return Sailor::App::RequestAssetReload();", unixSource, StringComparison.Ordinal);
 
-        var f5Request = nativeSource.IndexOf("if (systemInputState.IsKeyPressed(VK_F5))", StringComparison.Ordinal);
-        var queueRequest = nativeSource.IndexOf("RequestAssetReload();", f5Request, StringComparison.Ordinal);
-        var engineThreadApply = nativeSource.IndexOf("ApplyPendingAssetReloadOnEngineThread();", queueRequest, StringComparison.Ordinal);
-        var shaderCacheRecovery = nativeSource.IndexOf("shaderCompiler->RecoverMissingShaderCacheStorage();", engineThreadApply, StringComparison.Ordinal);
-        var queuedScan = nativeSource.IndexOf("assetRegistry->ScanContentFolder();", engineThreadApply, StringComparison.Ordinal);
-        Assert.True(f5Request >= 0);
-        Assert.True(queueRequest > f5Request);
-        Assert.True(engineThreadApply > queueRequest);
-        Assert.True(shaderCacheRecovery > engineThreadApply);
+        var reloadBody = nativeSource.IndexOf("bool ReloadAssetsOnEngineMainThread()", StringComparison.Ordinal);
+        var reloadBodyEnd = nativeSource.IndexOf("bool App::DispatchOnEngineMainThread", reloadBody, StringComparison.Ordinal);
+        var initialWait = nativeSource.IndexOf("scheduler->WaitIdle({", reloadBody, StringComparison.Ordinal);
+        var shaderCacheRecovery = nativeSource.IndexOf("shaderCompiler->RecoverMissingShaderCacheStorage();", initialWait, StringComparison.Ordinal);
+        var queuedScan = nativeSource.IndexOf("assetRegistry->ScanContentFolder();", shaderCacheRecovery, StringComparison.Ordinal);
+        var renderWait = nativeSource.IndexOf("scheduler->WaitIdle({ EThreadType::Render, EThreadType::RHI });", queuedScan, StringComparison.Ordinal);
+        var frameGraphRefresh = nativeSource.IndexOf("renderer->RefreshFrameGraph();", renderWait, StringComparison.Ordinal);
+        Assert.True(reloadBody >= 0);
+        Assert.True(reloadBodyEnd > reloadBody);
+        Assert.True(initialWait > reloadBody);
+        Assert.True(shaderCacheRecovery > initialWait);
         Assert.True(queuedScan > shaderCacheRecovery);
-        Assert.Contains("g_assetReloadRequested.store(true", nativeSource, StringComparison.Ordinal);
-        Assert.Contains("g_assetReloadRequested.exchange(false", nativeSource, StringComparison.Ordinal);
+        Assert.True(renderWait > queuedScan);
+        Assert.True(frameGraphRefresh > renderWait);
+        Assert.DoesNotContain("EThreadType::Main", nativeSource[reloadBody..reloadBodyEnd], StringComparison.Ordinal);
+
+        var f5Request = nativeSource.IndexOf("if (systemInputState.IsKeyPressed(VK_F5))", StringComparison.Ordinal);
+        var queuedReload = nativeSource.IndexOf("RequestAssetReload();", f5Request, StringComparison.Ordinal);
+        Assert.True(f5Request >= 0);
+        Assert.True(queuedReload > f5Request);
+        Assert.Contains("consoleVars[\"scan\"] = []() { App::RequestAssetReload(); };", nativeSource, StringComparison.Ordinal);
+
+        var requestStart = nativeSource.IndexOf("bool App::RequestAssetReload()", StringComparison.Ordinal);
+        var requestProcessor = nativeSource.IndexOf("void App::ProcessAssetReloadRequestOnEngineMainThread()", requestStart, StringComparison.Ordinal);
+        var requestEnd = nativeSource.IndexOf("void App::Shutdown()", requestProcessor, StringComparison.Ordinal);
+        var requestBody = nativeSource[requestStart..requestProcessor];
+        var requestProcessorBody = nativeSource[requestProcessor..requestEnd];
+        Assert.DoesNotContain("std::try_to_lock", requestBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("g_engineMainLoopRunning", requestBody, StringComparison.Ordinal);
+        Assert.Contains("g_engineMainLoopState == EEngineMainLoopState::Exited", requestBody, StringComparison.Ordinal);
+        Assert.Contains("++s_pInstance->m_assetReloadRequestGeneration", requestBody, StringComparison.Ordinal);
+        Assert.Contains("!s_pInstance->m_pendingAssetReloadTask->IsFinished()", requestBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("m_pendingAssetReloadTask->IsStarted()", requestBody, StringComparison.Ordinal);
+        Assert.Contains("requestGeneration = s_pInstance->m_assetReloadRequestGeneration", requestProcessorBody, StringComparison.Ordinal);
+        Assert.Contains("m_assetReloadRequestGeneration == requestGeneration", requestProcessorBody, StringComparison.Ordinal);
+        Assert.Contains("\"Reload assets on engine main thread\"", requestBody, StringComparison.Ordinal);
+        Assert.Contains("EThreadType::Main", requestBody, StringComparison.Ordinal);
+        Assert.Contains("scheduler->Run(task);", requestBody, StringComparison.Ordinal);
+        Assert.Contains("QueueAssetReloadTaskLocked(scheduler);", requestProcessorBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("task->Wait()", nativeSource[requestStart..requestEnd], StringComparison.Ordinal);
+        Assert.DoesNotContain("g_assetReloadRequested", nativeSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("ApplyPendingAssetReloadOnEngineThread", nativeSource, StringComparison.Ordinal);
 
         var appStart = nativeSource.IndexOf("void App::Start()", StringComparison.Ordinal);
         var attachEngineThread = nativeSource.IndexOf("scheduler->AttachCurrentThreadAsMainThread();", appStart, StringComparison.Ordinal);
@@ -82,6 +169,8 @@ public sealed class EngineLifecycleTests
         var attachShutdownThread = nativeSource.IndexOf("scheduler->AttachCurrentThreadAsMainThread();", appShutdown, StringComparison.Ordinal);
         Assert.True(attachEngineThread > appStart);
         Assert.True(frameLoop > attachEngineThread);
+        Assert.Contains("m_assetReloadRequestGeneration > 0", nativeSource[appStart..frameLoop], StringComparison.Ordinal);
+        Assert.Contains("QueueAssetReloadTaskLocked(scheduler);", nativeSource[appStart..frameLoop], StringComparison.Ordinal);
         Assert.True(attachShutdownThread > appShutdown);
         Assert.Contains("std::atomic<DWORD> m_mainThreadId", schedulerHeader, StringComparison.Ordinal);
         Assert.Contains("void Scheduler::AttachCurrentThreadAsMainThread()", schedulerSource, StringComparison.Ordinal);
@@ -184,6 +273,62 @@ public sealed class EngineLifecycleTests
             "EditorTypeCacheStore.ShouldPersistLiveCatalog(cachedEditorTypes.Status)",
             source,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MacStartupWorldSerialization_RunsOnTheAttachedNativeSchedulerThreadBeforeStart()
+    {
+        var source = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
+
+        var startupOrder = source.IndexOf(
+            "// Required startup order: combined editor catalog, world, then initial messages.",
+            StringComparison.Ordinal);
+        var liveCatalog = source.IndexOf(
+            "SerializeEditorTypes(generation, allowStarting: true)",
+            startupOrder,
+            StringComparison.Ordinal);
+        var macBranch = source.IndexOf("#if MACCATALYST", liveCatalog, StringComparison.Ordinal);
+        var mainThreadDispatch = source.IndexOf(
+            "await MainThread.InvokeOnMainThreadAsync(",
+            macBranch,
+            StringComparison.Ordinal);
+        var worldSerialization = source.IndexOf(
+            "() => SerializeWorld(generation, out serializedWorldSequence, allowStarting: true)",
+            mainThreadDispatch,
+            StringComparison.Ordinal);
+        var nativeStart = source.IndexOf(
+            "Task.Run(EngineAppInterop.Start, CancellationToken.None)",
+            worldSerialization,
+            StringComparison.Ordinal);
+
+        Assert.True(startupOrder >= 0);
+        Assert.True(liveCatalog > startupOrder);
+        Assert.True(macBranch > liveCatalog);
+        Assert.True(mainThreadDispatch > macBranch);
+        Assert.True(worldSerialization > mainThreadDispatch);
+        Assert.True(nativeStart > worldSerialization);
+    }
+
+    [Fact]
+    public void MacEditorRenderSurface_DoesNotOwnTheMauiApplicationLifetime()
+    {
+        var source = ReadRepositoryFile("Runtime", "Platform", "Mac", "Window.mm");
+
+        var closeCallback = source.IndexOf("- (void)windowWillClose:", StringComparison.Ordinal);
+        var lifetimeGuard = source.IndexOf(
+            "if (self.terminatesApplicationOnClose)",
+            closeCallback,
+            StringComparison.Ordinal);
+        var terminateCall = source.IndexOf("[NSApp terminate:nil]", lifetimeGuard, StringComparison.Ordinal);
+        var editorOwnership = source.IndexOf(
+            "delegate.terminatesApplicationOnClose = !bRunsInsideEditor;",
+            terminateCall,
+            StringComparison.Ordinal);
+
+        Assert.True(closeCallback >= 0);
+        Assert.True(lifetimeGuard > closeCallback);
+        Assert.True(terminateCall > lifetimeGuard);
+        Assert.True(editorOwnership > terminateCall);
     }
 
     static string ReadRepositoryFile(params string[] relativePath)

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -45,6 +45,57 @@ public sealed class EngineLifecycleTests
     }
 
     [Fact]
+    public void AssetReload_IsQueuedToTheEngineThreadAndBoundToMacCommandR()
+    {
+        var managedSource = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
+        var macMenuSource = ReadRepositoryFile("Editor", "Platforms", "MacCatalyst", "AppDelegate.cs");
+        var nativeSource = ReadRepositoryFile("Runtime", "Sailor.cpp");
+        var schedulerHeader = ReadRepositoryFile("Runtime", "Tasks", "Scheduler.h");
+        var schedulerSource = ReadRepositoryFile("Runtime", "Tasks", "Scheduler.cpp");
+        var windowsSource = ReadRepositoryFile("Lib", "DllMain.cpp");
+        var unixSource = ReadRepositoryFile("Lib", "InteropExports.cpp");
+
+        Assert.Contains("extern bool RequestAssetReload()", managedSource, StringComparison.Ordinal);
+        Assert.Contains("InvokeRunningInterop(EngineAppInterop.RequestAssetReload)", managedSource, StringComparison.Ordinal);
+        Assert.Contains("SAILOR_API bool RequestAssetReload()", windowsSource, StringComparison.Ordinal);
+        Assert.Contains("return Sailor::App::RequestAssetReload();", windowsSource, StringComparison.Ordinal);
+        Assert.Contains("SAILOR_API bool RequestAssetReload()", unixSource, StringComparison.Ordinal);
+        Assert.Contains("return Sailor::App::RequestAssetReload();", unixSource, StringComparison.Ordinal);
+
+        var f5Request = nativeSource.IndexOf("if (systemInputState.IsKeyPressed(VK_F5))", StringComparison.Ordinal);
+        var queueRequest = nativeSource.IndexOf("RequestAssetReload();", f5Request, StringComparison.Ordinal);
+        var engineThreadApply = nativeSource.IndexOf("ApplyPendingAssetReloadOnEngineThread();", queueRequest, StringComparison.Ordinal);
+        var shaderCacheRecovery = nativeSource.IndexOf("shaderCompiler->RecoverMissingShaderCacheStorage();", engineThreadApply, StringComparison.Ordinal);
+        var queuedScan = nativeSource.IndexOf("assetRegistry->ScanContentFolder();", engineThreadApply, StringComparison.Ordinal);
+        Assert.True(f5Request >= 0);
+        Assert.True(queueRequest > f5Request);
+        Assert.True(engineThreadApply > queueRequest);
+        Assert.True(shaderCacheRecovery > engineThreadApply);
+        Assert.True(queuedScan > shaderCacheRecovery);
+        Assert.Contains("g_assetReloadRequested.store(true", nativeSource, StringComparison.Ordinal);
+        Assert.Contains("g_assetReloadRequested.exchange(false", nativeSource, StringComparison.Ordinal);
+
+        var appStart = nativeSource.IndexOf("void App::Start()", StringComparison.Ordinal);
+        var attachEngineThread = nativeSource.IndexOf("scheduler->AttachCurrentThreadAsMainThread();", appStart, StringComparison.Ordinal);
+        var frameLoop = nativeSource.IndexOf("while (pMainWindow->IsRunning())", attachEngineThread, StringComparison.Ordinal);
+        var appShutdown = nativeSource.IndexOf("void App::Shutdown()", StringComparison.Ordinal);
+        var attachShutdownThread = nativeSource.IndexOf("scheduler->AttachCurrentThreadAsMainThread();", appShutdown, StringComparison.Ordinal);
+        Assert.True(attachEngineThread > appStart);
+        Assert.True(frameLoop > attachEngineThread);
+        Assert.True(attachShutdownThread > appShutdown);
+        Assert.Contains("std::atomic<DWORD> m_mainThreadId", schedulerHeader, StringComparison.Ordinal);
+        Assert.Contains("void Scheduler::AttachCurrentThreadAsMainThread()", schedulerSource, StringComparison.Ordinal);
+        Assert.Contains("m_mainThreadId.store(GetCurrentThreadId()", schedulerSource, StringComparison.Ordinal);
+        Assert.Contains("return GetMainThreadId() == GetCurrentThreadId();", schedulerSource, StringComparison.Ordinal);
+
+        Assert.Contains("ReloadAssetsSelector", macMenuSource, StringComparison.Ordinal);
+        Assert.Contains("UIKeyModifierFlags.Command", macMenuSource, StringComparison.Ordinal);
+        Assert.Contains("\"r\"", macMenuSource, StringComparison.Ordinal);
+        Assert.Contains("MauiProgram.GetService<EngineService>().RequestAssetReload()", macMenuSource, StringComparison.Ordinal);
+        Assert.DoesNotContain("ScanContentFolder", macMenuSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WorkspaceCacheIdentity_IsAvailableOnBothExportSurfacesAndManagedInterop()
     {
         var managedSource = ReadRepositoryFile("Editor", "Services", "EngineService.cs");

--- a/Editor.Tests/HistoryContractsTests.cs
+++ b/Editor.Tests/HistoryContractsTests.cs
@@ -38,6 +38,392 @@ public class HistoryContractsTests
         Assert.Null(history.PeekRedo());
     }
 
+    [Fact]
+    public async Task Dispatcher_CoalescesRapidEditsWithoutLosingTheOriginalUndoState()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var context = new ActionContext(Origin: new CommandOrigin(CommandOriginKind.Test, "HistoryContracts"));
+
+        await dispatcher.DispatchAsync(new StubCoalescibleCommand("object-1", "state-0", "state-1", "Edit A"), context);
+        await dispatcher.DispatchAsync(new StubCoalescibleCommand("object-1", "state-1", "state-2", "Edit AB"), context);
+
+        Assert.Equal(1, history.UndoCount);
+        var merged = Assert.IsType<StubCoalescibleCommand>(history.PeekUndo()!.Command);
+        Assert.Equal("state-0", merged.Before);
+        Assert.Equal("state-2", merged.After);
+        Assert.Equal("Edit AB", merged.Description);
+    }
+
+    [Fact]
+    public async Task Dispatcher_DoesNotCoalesceEditsForDifferentTargets()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var context = new ActionContext(Origin: new CommandOrigin(CommandOriginKind.Test, "HistoryContracts"));
+
+        await dispatcher.DispatchAsync(new StubCoalescibleCommand("object-1", "a", "b", "Edit object"), context);
+        await dispatcher.DispatchAsync(new StubCoalescibleCommand("object-2", "x", "y", "Edit object"), context);
+
+        Assert.Equal(2, history.UndoCount);
+    }
+
+    [Fact]
+    public async Task Dispatcher_DoesNotCoalesceAcrossAnUndoBranch()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var context = new ActionContext(Origin: new CommandOrigin(CommandOriginKind.Test, "HistoryContracts"));
+
+        await dispatcher.DispatchAsync(new StubCoalescibleCommand("object-1", "state-0", "state-1", "Edit object"), context);
+        await dispatcher.DispatchAsync(new StubUndoableCommand("Delete object"), context);
+        Assert.True(await dispatcher.UndoAsync());
+
+        await dispatcher.DispatchAsync(new StubCoalescibleCommand("object-1", "state-1", "state-2", "Edit object"), context);
+
+        Assert.Equal(2, history.UndoCount);
+        Assert.Equal(0, history.RedoCount);
+    }
+
+    [Fact]
+    public async Task Dispatcher_FailedUndoRemainsAvailableForRetry()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var command = new StubRecoverableUndoCommand();
+
+        await dispatcher.DispatchAsync(command, new ActionContext());
+
+        Assert.False(await dispatcher.UndoAsync());
+        Assert.Equal(1, history.UndoCount);
+        Assert.Equal(0, history.RedoCount);
+
+        command.AllowUndo = true;
+        Assert.True(await dispatcher.UndoAsync());
+        Assert.Equal(0, history.UndoCount);
+        Assert.Equal(1, history.RedoCount);
+        Assert.Equal(2, command.UndoAttempts);
+    }
+
+    [Fact]
+    public async Task Dispatcher_RedoPreservesRemainingRedoEntries()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+
+        await dispatcher.DispatchAsync(new StubUndoableCommand("First edit"), new ActionContext());
+        await dispatcher.DispatchAsync(new StubUndoableCommand("Second edit"), new ActionContext());
+        Assert.True(await dispatcher.UndoAsync());
+        Assert.True(await dispatcher.UndoAsync());
+        Assert.Equal(2, history.RedoCount);
+
+        Assert.True(await dispatcher.RedoAsync());
+        Assert.Equal(1, history.UndoCount);
+        Assert.Equal(1, history.RedoCount);
+
+        Assert.True(await dispatcher.RedoAsync());
+        Assert.Equal(2, history.UndoCount);
+        Assert.Equal(0, history.RedoCount);
+    }
+
+    [Fact]
+    public async Task Dispatcher_CancelledUndoRemainsAvailableForRetry()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var command = new StubCancellableCommand(cancelUndo: true, cancelRedo: false);
+
+        await dispatcher.DispatchAsync(command, new ActionContext());
+
+        Assert.False(await dispatcher.UndoAsync());
+        Assert.Equal(1, history.UndoCount);
+        Assert.Equal(0, history.RedoCount);
+    }
+
+    [Fact]
+    public async Task Dispatcher_CancelledRedoRemainsAvailableForRetry()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var command = new StubCancellableCommand(cancelUndo: false, cancelRedo: true);
+
+        await dispatcher.DispatchAsync(command, new ActionContext());
+        Assert.True(await dispatcher.UndoAsync());
+
+        Assert.False(await dispatcher.RedoAsync());
+        Assert.Equal(0, history.UndoCount);
+        Assert.Equal(1, history.RedoCount);
+    }
+
+    [Fact]
+    public async Task Dispatcher_RejectsDispatchWhileUndoIsInProgressBeforeCommandMutation()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var blocking = new BlockingUndoCommand("Blocking edit");
+        var concurrent = new StateTrackingCommand("Concurrent dispatch");
+
+        Assert.True((await dispatcher.DispatchAsync(blocking, new ActionContext())).Succeeded);
+        var activeUndo = dispatcher.UndoAsync();
+        await blocking.UndoStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var result = await dispatcher.DispatchAsync(concurrent, new ActionContext());
+        blocking.ReleaseUndo();
+
+        Assert.True(await activeUndo);
+        Assert.False(result.Succeeded);
+        Assert.Contains("undo or redo operation is in progress", result.Message);
+        Assert.Equal(0, concurrent.ExecuteCount);
+        Assert.False(concurrent.IsApplied);
+    }
+
+    [Fact]
+    public async Task Dispatcher_RejectsSecondUndoWhileUndoIsInProgressBeforeCommandMutation()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var earlier = new StateTrackingCommand("Earlier edit");
+        var blocking = new BlockingUndoCommand("Blocking edit");
+
+        Assert.True((await dispatcher.DispatchAsync(earlier, new ActionContext())).Succeeded);
+        Assert.True((await dispatcher.DispatchAsync(blocking, new ActionContext())).Succeeded);
+        var activeUndo = dispatcher.UndoAsync();
+        await blocking.UndoStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var concurrentResult = await dispatcher.UndoAsync();
+        blocking.ReleaseUndo();
+
+        Assert.True(await activeUndo);
+        Assert.False(concurrentResult);
+        Assert.Equal(0, earlier.UndoCount);
+        Assert.True(earlier.IsApplied);
+    }
+
+    [Fact]
+    public async Task Dispatcher_RejectsRedoWhileUndoIsInProgressBeforeCommandMutation()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var blocking = new BlockingUndoCommand("Blocking edit");
+        var redoCandidate = new StateTrackingCommand("Redo candidate");
+
+        Assert.True((await dispatcher.DispatchAsync(blocking, new ActionContext())).Succeeded);
+        Assert.True((await dispatcher.DispatchAsync(redoCandidate, new ActionContext())).Succeeded);
+        Assert.True(await dispatcher.UndoAsync());
+        Assert.False(redoCandidate.IsApplied);
+        Assert.Equal(1, redoCandidate.ExecuteCount);
+
+        var activeUndo = dispatcher.UndoAsync();
+        await blocking.UndoStarted.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var concurrentResult = await dispatcher.RedoAsync();
+        blocking.ReleaseUndo();
+
+        Assert.True(await activeUndo);
+        Assert.False(concurrentResult);
+        Assert.Equal(1, redoCandidate.ExecuteCount);
+        Assert.False(redoCandidate.IsApplied);
+    }
+
+    [Fact]
+    public async Task CompoundExecute_FailedChildRollsBackPriorChildrenAndCanRetryWithoutDoubleApply()
+    {
+        var operations = new List<string>();
+        var first = new ScriptedStateCommand("First", operations);
+        var second = new ScriptedStateCommand(
+            "Second",
+            operations,
+            executeBehaviors: [CommandBehavior.Failure, CommandBehavior.Success]);
+        var compound = new CompoundEditorCommand("Compound edit", [first, second]);
+
+        var failed = await compound.ExecuteAsync(new ActionContext());
+
+        Assert.False(failed.Succeeded);
+        Assert.False(first.IsApplied);
+        Assert.False(second.IsApplied);
+        Assert.Equal(["execute:First", "execute:Second", "undo:First"], operations);
+
+        operations.Clear();
+        var retried = await compound.ExecuteAsync(new ActionContext());
+
+        Assert.True(retried.Succeeded);
+        Assert.True(first.IsApplied);
+        Assert.True(second.IsApplied);
+        Assert.Equal(["execute:First", "execute:Second"], operations);
+    }
+
+    [Fact]
+    public async Task CompoundExecute_ThrownChildRollsBackPriorChildrenAndRethrows()
+    {
+        var operations = new List<string>();
+        var first = new ScriptedStateCommand("First", operations);
+        var second = new ScriptedStateCommand(
+            "Second",
+            operations,
+            executeBehaviors: [CommandBehavior.Throw]);
+        var compound = new CompoundEditorCommand("Compound edit", [first, second]);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => compound.ExecuteAsync(new ActionContext()));
+
+        Assert.Equal("Second execute threw", error.Message);
+        Assert.False(first.IsApplied);
+        Assert.False(second.IsApplied);
+        Assert.Equal(["execute:First", "execute:Second", "undo:First"], operations);
+    }
+
+    [Fact]
+    public async Task CompoundExecute_CancelledChildUsesNonCancelledTokenForCompensation()
+    {
+        var operations = new List<string>();
+        var first = new ScriptedStateCommand("First", operations);
+        var second = new ScriptedStateCommand(
+            "Second",
+            operations,
+            executeBehaviors: [CommandBehavior.Cancel]);
+        var compound = new CompoundEditorCommand("Compound edit", [first, second]);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            () => compound.ExecuteAsync(new ActionContext()));
+
+        Assert.False(first.IsApplied);
+        Assert.False(first.LastUndoTokenCanBeCancelled);
+        Assert.Equal(["execute:First", "execute:Second", "undo:First"], operations);
+    }
+
+    [Fact]
+    public async Task CompoundUndo_FailedChildReappliesUndoneChildrenAndCanRetry()
+    {
+        var operations = new List<string>();
+        var first = new ScriptedStateCommand(
+            "First",
+            operations,
+            initiallyApplied: true,
+            undoBehaviors: [CommandBehavior.Failure, CommandBehavior.Success]);
+        var second = new ScriptedStateCommand("Second", operations, initiallyApplied: true);
+        var compound = new CompoundEditorCommand("Compound edit", [first, second]);
+
+        var failed = await compound.UndoAsync(new ActionContext());
+
+        Assert.False(failed.Succeeded);
+        Assert.True(first.IsApplied);
+        Assert.True(second.IsApplied);
+        Assert.Equal(["undo:Second", "undo:First", "execute:Second"], operations);
+
+        operations.Clear();
+        var retried = await compound.UndoAsync(new ActionContext());
+
+        Assert.True(retried.Succeeded);
+        Assert.False(first.IsApplied);
+        Assert.False(second.IsApplied);
+        Assert.Equal(["undo:Second", "undo:First"], operations);
+    }
+
+    [Fact]
+    public async Task CompoundUndo_CancelledChildReappliesUndoneChildrenWithNonCancelledToken()
+    {
+        var operations = new List<string>();
+        var first = new ScriptedStateCommand(
+            "First",
+            operations,
+            initiallyApplied: true,
+            undoBehaviors: [CommandBehavior.Cancel]);
+        var second = new ScriptedStateCommand("Second", operations, initiallyApplied: true);
+        var compound = new CompoundEditorCommand("Compound edit", [first, second]);
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(
+            async () => await compound.UndoAsync(new ActionContext()));
+
+        Assert.True(first.IsApplied);
+        Assert.True(second.IsApplied);
+        Assert.False(second.LastExecuteTokenCanBeCancelled);
+        Assert.Equal(["undo:Second", "undo:First", "execute:Second"], operations);
+    }
+
+    [Fact]
+    public async Task CompoundUndo_CompensationFailureFaultsCommandAndPreventsUnsafeRetry()
+    {
+        var operations = new List<string>();
+        var first = new ScriptedStateCommand(
+            "First",
+            operations,
+            initiallyApplied: true,
+            undoBehaviors: [CommandBehavior.Failure]);
+        var second = new ScriptedStateCommand(
+            "Second",
+            operations,
+            initiallyApplied: true,
+            executeBehaviors: [CommandBehavior.Failure]);
+        var compound = new CompoundEditorCommand("Compound edit", [first, second]);
+
+        var failed = await compound.UndoAsync(new ActionContext());
+
+        Assert.False(failed.Succeeded);
+        Assert.Contains("Compensation also failed", failed.Message);
+        Assert.Contains("cannot be retried safely", failed.Message);
+        Assert.True(first.IsApplied);
+        Assert.False(second.IsApplied);
+        var attemptsAfterFailure = operations.Count;
+
+        var retried = await compound.UndoAsync(new ActionContext());
+
+        Assert.False(retried.Succeeded);
+        Assert.Equal(attemptsAfterFailure, operations.Count);
+    }
+
+    [Fact]
+    public async Task TransactionDispose_RollsBackActiveNestedScopesInReverseOrder()
+    {
+        var operations = new List<string>();
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var outerCommand = new ScriptedStateCommand("Outer", operations);
+        var innerCommand = new ScriptedStateCommand("Inner", operations);
+        var context = new ActionContext(Origin: new CommandOrigin(CommandOriginKind.Test, "Nested transaction"));
+        var outer = await dispatcher.BeginAsync("Outer transaction", context);
+        Assert.True((await dispatcher.DispatchAsync(outerCommand, context)).Succeeded);
+        var inner = await dispatcher.BeginAsync("Inner transaction", context);
+        Assert.True((await dispatcher.DispatchAsync(innerCommand, context)).Succeeded);
+
+        operations.Clear();
+        await outer.DisposeAsync();
+        await inner.DisposeAsync();
+
+        Assert.False(outerCommand.IsApplied);
+        Assert.False(innerCommand.IsApplied);
+        Assert.Equal(["undo:Inner", "undo:Outer"], operations);
+        Assert.Equal(0, history.UndoCount);
+        Assert.Equal(0, history.RedoCount);
+    }
+
+    [Fact]
+    public async Task TransactionDispose_FailedRollbackIsExplicitAndPreservedForRetry()
+    {
+        var operations = new List<string>();
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubContextProvider(), history);
+        var command = new ScriptedStateCommand(
+            "Recoverable",
+            operations,
+            undoBehaviors: [CommandBehavior.Failure, CommandBehavior.Success]);
+        var context = new ActionContext(Origin: new CommandOrigin(CommandOriginKind.Test, "Failed rollback"));
+        var transaction = await dispatcher.BeginAsync("Recoverable transaction", context);
+        Assert.True((await dispatcher.DispatchAsync(command, context)).Succeeded);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await transaction.DisposeAsync());
+
+        Assert.Contains("could not be rolled back", error.Message);
+        Assert.Contains("preserved for explicit recovery", error.Message);
+        Assert.True(command.IsApplied);
+        Assert.Equal(1, history.UndoCount);
+
+        Assert.True(await dispatcher.UndoAsync());
+        Assert.False(command.IsApplied);
+        Assert.Equal(0, history.UndoCount);
+        Assert.Equal(1, history.RedoCount);
+    }
+
     private sealed class StubUndoableCommand(string description) : IUndoableEditorCommand
     {
         public string Name => description;
@@ -46,7 +432,200 @@ public class HistoryContractsTests
         public bool CanExecute(ActionContext context) => true;
         public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
             => Task.FromResult(CommandResult.Success());
-        public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
-            => ValueTask.CompletedTask;
+        public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(CommandResult.Success());
+    }
+
+    private sealed class StubCoalescibleCommand(string target, string before, string after, string description) : IHistoryCoalescibleCommand
+    {
+        public string Target { get; } = target;
+        public string Before { get; } = before;
+        public string After { get; } = after;
+        public string Name => nameof(StubCoalescibleCommand);
+        public string Description { get; } = description;
+        public IHistoryMergePolicy? MergePolicy => new TimeWindowHistoryMergePolicy(TimeSpan.FromSeconds(1));
+        public bool CanExecute(ActionContext context) => true;
+        public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(CommandResult.Success());
+        public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+            => ValueTask.FromResult(CommandResult.Success());
+        public bool CanCoalesceWith(IUndoableEditorCommand next) =>
+            next is StubCoalescibleCommand command && command.Target == Target;
+        public IUndoableEditorCommand CoalesceWith(IUndoableEditorCommand next)
+        {
+            var command = (StubCoalescibleCommand)next;
+            return new StubCoalescibleCommand(Target, Before, command.After, command.Description);
+        }
+    }
+
+    private sealed class StubRecoverableUndoCommand : IUndoableEditorCommand
+    {
+        public bool AllowUndo { get; set; }
+        public int UndoAttempts { get; private set; }
+        public string Name => nameof(StubRecoverableUndoCommand);
+        public string Description => "Recoverable edit";
+        public bool CanExecute(ActionContext context) => true;
+        public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
+            => Task.FromResult(CommandResult.Success());
+        public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+        {
+            UndoAttempts++;
+            return ValueTask.FromResult(AllowUndo
+                ? CommandResult.Success()
+                : CommandResult.Failure("Undo failed"));
+        }
+    }
+
+    private sealed class StubCancellableCommand(bool cancelUndo, bool cancelRedo) : IUndoableEditorCommand
+    {
+        int _executeCount;
+        public string Name => nameof(StubCancellableCommand);
+        public string Description => "Cancellable edit";
+        public bool CanExecute(ActionContext context) => true;
+        public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
+        {
+            _executeCount++;
+            return cancelRedo && _executeCount > 1
+                ? Task.FromCanceled<CommandResult>(new CancellationToken(canceled: true))
+                : Task.FromResult(CommandResult.Success());
+        }
+        public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+            => cancelUndo
+                ? ValueTask.FromCanceled<CommandResult>(new CancellationToken(canceled: true))
+                : ValueTask.FromResult(CommandResult.Success());
+    }
+
+    private sealed class BlockingUndoCommand(string description) : IUndoableEditorCommand
+    {
+        readonly TaskCompletionSource<bool> _undoStarted = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        readonly TaskCompletionSource<bool> _releaseUndo = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public string Name => description;
+        public string Description => description;
+        public bool IsApplied { get; private set; }
+        public Task UndoStarted => _undoStarted.Task;
+        public bool CanExecute(ActionContext context) => !IsApplied;
+
+        public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
+        {
+            IsApplied = true;
+            return Task.FromResult(CommandResult.Success());
+        }
+
+        public async ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+        {
+            _undoStarted.TrySetResult(true);
+            await _releaseUndo.Task.WaitAsync(cancellationToken);
+            IsApplied = false;
+            return CommandResult.Success();
+        }
+
+        public void ReleaseUndo() => _releaseUndo.TrySetResult(true);
+    }
+
+    private sealed class StateTrackingCommand(string description) : IUndoableEditorCommand
+    {
+        public string Name => description;
+        public string Description => description;
+        public int ExecuteCount { get; private set; }
+        public int UndoCount { get; private set; }
+        public bool IsApplied { get; private set; }
+        public bool CanExecute(ActionContext context) => !IsApplied;
+
+        public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
+        {
+            ExecuteCount++;
+            IsApplied = true;
+            return Task.FromResult(CommandResult.Success());
+        }
+
+        public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+        {
+            UndoCount++;
+            IsApplied = false;
+            return ValueTask.FromResult(CommandResult.Success());
+        }
+    }
+
+    private enum CommandBehavior
+    {
+        Success,
+        Failure,
+        Cancel,
+        Throw,
+    }
+
+    private sealed class ScriptedStateCommand : IUndoableEditorCommand
+    {
+        readonly Queue<CommandBehavior> _executeBehaviors;
+        readonly Queue<CommandBehavior> _undoBehaviors;
+        readonly List<string> _operations;
+
+        public ScriptedStateCommand(
+            string name,
+            List<string> operations,
+            bool initiallyApplied = false,
+            IEnumerable<CommandBehavior>? executeBehaviors = null,
+            IEnumerable<CommandBehavior>? undoBehaviors = null)
+        {
+            Name = name;
+            Description = name;
+            IsApplied = initiallyApplied;
+            _operations = operations;
+            _executeBehaviors = new Queue<CommandBehavior>(executeBehaviors ?? []);
+            _undoBehaviors = new Queue<CommandBehavior>(undoBehaviors ?? []);
+        }
+
+        public string Name { get; }
+        public string Description { get; }
+        public bool IsApplied { get; private set; }
+        public bool LastExecuteTokenCanBeCancelled { get; private set; }
+        public bool LastUndoTokenCanBeCancelled { get; private set; }
+        public bool CanExecute(ActionContext context) => !IsApplied;
+
+        public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
+        {
+            LastExecuteTokenCanBeCancelled = cancellationToken.CanBeCanceled;
+            _operations.Add($"execute:{Name}");
+            var behavior = NextBehavior(_executeBehaviors);
+            if (behavior == CommandBehavior.Cancel)
+                return Task.FromCanceled<CommandResult>(new CancellationToken(canceled: true));
+            if (behavior == CommandBehavior.Throw)
+                throw new InvalidOperationException($"{Name} execute threw");
+            if (behavior == CommandBehavior.Failure)
+                return Task.FromResult(CommandResult.Failure($"{Name} execute failed"));
+            if (IsApplied)
+                return Task.FromResult(CommandResult.Failure($"{Name} was applied twice"));
+
+            IsApplied = true;
+            return Task.FromResult(CommandResult.Success());
+        }
+
+        public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+        {
+            LastUndoTokenCanBeCancelled = cancellationToken.CanBeCanceled;
+            _operations.Add($"undo:{Name}");
+            var behavior = NextBehavior(_undoBehaviors);
+            if (behavior == CommandBehavior.Cancel)
+                return ValueTask.FromCanceled<CommandResult>(new CancellationToken(canceled: true));
+            if (behavior == CommandBehavior.Throw)
+                throw new InvalidOperationException($"{Name} undo threw");
+            if (behavior == CommandBehavior.Failure)
+                return ValueTask.FromResult(CommandResult.Failure($"{Name} undo failed"));
+            if (!IsApplied)
+                return ValueTask.FromResult(CommandResult.Failure($"{Name} was undone twice"));
+
+            IsApplied = false;
+            return ValueTask.FromResult(CommandResult.Success());
+        }
+
+        static CommandBehavior NextBehavior(Queue<CommandBehavior> behaviors) =>
+            behaviors.Count == 0 ? CommandBehavior.Success : behaviors.Dequeue();
+    }
+
+    private sealed class StubContextProvider : IActionContextProvider
+    {
+        public ActionContext GetCurrentContext(CommandOrigin? origin = null, IReadOnlyDictionary<string, string?>? metadata = null)
+            => new(Origin: origin, Metadata: metadata);
     }
 }

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -137,6 +137,21 @@ public sealed class WorkflowProjectionTests
         var decision = controller.OnPropertyChanged("DisplayName");
 
         Assert.True(decision.MarkDirty);
+        Assert.False(decision.CommitNow);
+    }
+
+    [Fact]
+    public void InspectorAutoCommitController_RequestsImmediateCommitForConfiguredProperty()
+    {
+        var controller = new InspectorAutoCommitController(
+            propertyName => propertyName == "IsDirty",
+            propertyName => propertyName == "OverrideProperties");
+        controller.MarkInitialized();
+
+        var decision = controller.OnPropertyChanged("OverrideProperties");
+
+        Assert.True(decision.MarkDirty);
+        Assert.True(decision.CommitNow);
     }
 
     [Theory]
@@ -150,5 +165,202 @@ public sealed class WorkflowProjectionTests
         controller.MarkInitialized();
 
         Assert.Equal(expected, controller.ShouldCommitPendingChanges(isDirty));
+    }
+
+    [Fact]
+    public void InspectorViewModels_DeferGameObjectCommitUntilEditorCompletion()
+    {
+        var gameObjectSource = ReadRepositoryFile("Editor", "ViewModels", "GameObject.cs");
+        var componentSource = ReadRepositoryFile("Editor", "ViewModels", "Component.cs");
+        var gameObjectTemplateSource = ReadRepositoryFile("Editor", "Views", "InspectorView", "GameObjectTemplate.xaml");
+
+        Assert.Contains("propertyName => false", gameObjectSource, StringComparison.Ordinal);
+        Assert.Contains("Completed=\"OnEntryCompleted\"", gameObjectTemplateSource, StringComparison.Ordinal);
+        Assert.Contains("Unfocused=\"OnEntryUnfocused\"", gameObjectTemplateSource, StringComparison.Ordinal);
+        Assert.Contains(
+            "propertyName => propertyName == nameof(OverrideProperties)",
+            componentSource,
+            StringComparison.Ordinal);
+
+        AssertCommitClearsDirtyBeforeDispatch(gameObjectSource);
+        AssertCommitClearsDirtyBeforeDispatch(componentSource);
+        AssertCommitSkipsUnchangedYaml(gameObjectSource);
+        AssertCommitSkipsUnchangedYaml(componentSource);
+    }
+
+    [Fact]
+    public void ComponentMutations_StayOnTheCallingThreadUntilProjectionRefreshCompletes()
+    {
+        var source = ReadRepositoryFile("Editor", "ViewModels", "GameObject.cs");
+        var mutationMethods = Slice(
+            source,
+            "public async Task AddComponentFromInspectorAsync()",
+            "[ObservableProperty]");
+
+        Assert.DoesNotContain("Task.Run", mutationMethods, StringComparison.Ordinal);
+        Assert.DoesNotContain("async void ClearComponentsFromInspector", mutationMethods, StringComparison.Ordinal);
+        Assert.DoesNotContain("new Command(async", source, StringComparison.Ordinal);
+        Assert.Contains(
+            "new AsyncRelayCommand(AddComponentFromInspectorAsync)",
+            source,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            mutationMethods,
+            "ShowAsync(",
+            "WorldService>().AddComponent(this, componentTypeName)",
+            "public void ClearComponentsFromInspector()",
+            "WorldService>().RemoveComponent(component)");
+    }
+
+    [Fact]
+    public void DestroyGameObjectUndo_UsesAnInMemoryPrefabSnapshot()
+    {
+        var source = ReadRepositoryFile("Editor", "Commands", "EditorWorldCommands.cs");
+        var destroyCommand = Slice(
+            source,
+            "public sealed class DestroyGameObjectCommand",
+            "public sealed class ReparentGameObjectCommand");
+
+        Assert.DoesNotContain("CreatePrefabAsset", destroyCommand, StringComparison.Ordinal);
+        Assert.Contains("CreatePrefabFromSubHierarchy", destroyCommand, StringComparison.Ordinal);
+        Assert.Contains("EditorYaml.SerializePrefab", destroyCommand, StringComparison.Ordinal);
+        Assert.Contains("InstantiatePrefabFromYaml", destroyCommand, StringComparison.Ordinal);
+        Assert.Contains("CommandResult.Failure(\"Restore deleted hierarchy failed\")", destroyCommand, StringComparison.Ordinal);
+        Assert.Contains("CommandResult.Failure(\"Restored hierarchy root was not found\")", destroyCommand, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrefabSnapshotInterop_MarshalsYamlAsUtf8()
+    {
+        var source = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
+
+        Assert.Contains(
+            "InstantiatePrefabFromYaml([MarshalAs(UnmanagedType.LPUTF8Str)] string strPrefabYaml, [MarshalAs(UnmanagedType.LPUTF8Str)] string strParentInstanceId)",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void CreationAndComponentUndoRedo_PreserveIdentityAndProjectionState()
+    {
+        var commandSource = ReadRepositoryFile("Editor", "Commands", "EditorWorldCommands.cs");
+        var engineSource = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
+        var createCommand = Slice(
+            commandSource,
+            "public sealed class CreateGameObjectCommand",
+            "public sealed class DestroyGameObjectCommand");
+        var addCommand = Slice(
+            commandSource,
+            "public sealed class AddComponentCommand",
+            "public sealed class RemoveComponentCommand");
+        var removeCommand = Slice(
+            commandSource,
+            "public sealed class RemoveComponentCommand",
+            "public sealed class ResetComponentToDefaultsCommand");
+        var refresh = Slice(
+            engineSource,
+            "public void RefreshCurrentWorld()",
+            "bool InvokeCreationInterop");
+
+        AssertInOrder(
+            createCommand,
+            "CreateGameObject(parentId, _createdId, out var createdId)",
+            "_createdId = createdId;",
+            "TryGetGameObject(createdId",
+            "DestroyObject(createdId)");
+        AssertInOrder(
+            addCommand,
+            "AddComponent(_ownerId, componentTypeName, _componentId, out var createdId)",
+            "_componentId = createdId;",
+            "TryGetComponent(createdId",
+            "RemoveComponent(createdId)");
+        AssertInOrder(
+            removeCommand,
+            "AddComponent(_ownerId, _componentTypeName, _originalInstanceId, out var restoredInstanceId)",
+            "CommitChanges(restored.InstanceId, _beforeYaml)",
+            "ApplyComponentYamlLocal(restored.InstanceId, _beforeYaml)",
+            "_activeInstanceId = restoredInstanceId;");
+        Assert.DoesNotContain("QueueWorldUpdate", refresh, StringComparison.Ordinal);
+        Assert.Contains("MainThread.InvokeOnMainThreadAsync", refresh, StringComparison.Ordinal);
+        Assert.Contains("GetAwaiter().GetResult()", refresh, StringComparison.Ordinal);
+    }
+
+    static void AssertCommitClearsDirtyBeforeDispatch(string source)
+    {
+        var commit = Slice(
+            source,
+            "public bool CommitInspectorChanges()",
+            "public bool HasPendingInspectorChanges");
+
+        AssertInOrder(commit, "IsDirty = false;", "dispatcher.DispatchAsync(");
+        Assert.Contains("catch", commit, StringComparison.Ordinal);
+        Assert.True(
+            CountOccurrences(commit, "IsDirty = true;") >= 2,
+            "A failed or throwing commit must restore the pending edit state.");
+    }
+
+    static void AssertCommitSkipsUnchangedYaml(string source)
+    {
+        var commit = Slice(
+            source,
+            "public bool CommitInspectorChanges()",
+            "public bool HasPendingInspectorChanges");
+
+        AssertInOrder(
+            commit,
+            "var previousYaml = _lastCommittedYaml",
+            "string.Equals(previousYaml",
+            "IsDirty = false;",
+            "return false;",
+            "dispatcher.DispatchAsync(");
+    }
+
+    static string Slice(string source, string startMarker, string endMarker)
+    {
+        var start = source.IndexOf(startMarker, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"Missing source marker: {startMarker}");
+
+        var end = source.IndexOf(endMarker, start + startMarker.Length, StringComparison.Ordinal);
+        Assert.True(end >= 0, $"Missing source marker: {endMarker}");
+        return source[start..end];
+    }
+
+    static void AssertInOrder(string source, params string[] markers)
+    {
+        var previous = -1;
+        foreach (var marker in markers)
+        {
+            var current = source.IndexOf(marker, previous + 1, StringComparison.Ordinal);
+            Assert.True(current >= 0, $"Missing or out-of-order source marker: {marker}");
+            previous = current;
+        }
+    }
+
+    static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        var offset = 0;
+        while ((offset = source.IndexOf(value, offset, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += value.Length;
+        }
+
+        return count;
+    }
+
+    static string ReadRepositoryFile(params string[] relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var candidate = Path.Combine(relativePath.Prepend(current.FullName).ToArray());
+            if (File.Exists(candidate))
+                return File.ReadAllText(candidate);
+
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException($"Could not find repository file: {Path.Combine(relativePath)}");
     }
 }

--- a/Editor.Tests/WorkspaceIsolationRegressionTests.cs
+++ b/Editor.Tests/WorkspaceIsolationRegressionTests.cs
@@ -80,6 +80,8 @@ public sealed class WorkspaceIsolationRegressionTests
         var clear = Slice(source, "public Task ClearAsync", "public async Task CommitAsync");
 
         Assert.Contains("return MainThread.InvokeOnMainThreadAsync(() =>", clear, StringComparison.Ordinal);
+        Assert.Contains("commandHistory.ResetForWorkspaceChange();", clear, StringComparison.Ordinal);
+        Assert.DoesNotContain("Reset(commandHistory.ResetForWorkspaceChange", clear, StringComparison.Ordinal);
         AssertInOrder(
             clear,
             "MainThread.InvokeOnMainThreadAsync",
@@ -91,6 +93,20 @@ public sealed class WorkspaceIsolationRegressionTests
             "projectContentStore.ResetForWorkspaceChange",
             "hierarchyProjection.ResetForWorkspaceChange",
             "inspectorProjection.ResetForWorkspaceChange");
+    }
+
+    [Fact]
+    public void ActivationStop_AwaitsCommandDrainBeforeEngineTeardown()
+    {
+        var source = ReadRepositoryFile("Editor", "Services", "WorkspaceActivationOperations.cs");
+        var stop = Slice(source, "public async Task StopAsync", "public Task ClearAsync");
+
+        AssertInOrder(
+            stop,
+            "commandHistory.BeginWorkspaceChange",
+            "selectionService.BeginWorkspaceChange",
+            "await commandHistory.BeginWorkspaceChangeAsync(CancellationToken.None)",
+            "engineService.StopAsync(cancellationToken)");
     }
 
     static string Slice(string source, string startMarker, string endMarker)

--- a/Editor.Tests/WorkspaceStateResetTests.cs
+++ b/Editor.Tests/WorkspaceStateResetTests.cs
@@ -25,21 +25,122 @@ public sealed class WorkspaceStateResetTests
     }
 
     [Fact]
-    public async Task ResetForWorkspaceChange_RejectsDelayedPriorEpochCommand()
+    public async Task BeginWorkspaceChangeAsync_DrainsNonCooperativeDispatchBeforeReset()
     {
         var history = new InMemoryUndoRedoHistory();
         var dispatcher = new EditorCommandDispatcher(new StubActionContextProvider(), history);
-        var command = new DelayedCommand("Delayed edit");
+        var resetStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var command = new DelayedCommand("Delayed edit", () => resetStarted.Task.IsCompleted);
 
+        Assert.True((await dispatcher.DispatchAsync(new ImmediateCommand("Existing edit"), new ActionContext())).Succeeded);
         var dispatch = dispatcher.DispatchAsync(command, new ActionContext());
         await command.Started.Task.WaitAsync(TimeSpan.FromSeconds(5));
 
-        dispatcher.ResetForWorkspaceChange();
+        dispatcher.BeginWorkspaceChange();
+        var transition = DrainAndResetAsync(dispatcher, resetStarted);
+
+        Assert.False(transition.IsCompleted);
+        var blocked = await dispatcher.DispatchAsync(new ImmediateCommand("Blocked edit"), new ActionContext());
+        Assert.False(blocked.Succeeded);
+        Assert.Contains("activation is in progress", blocked.Message, StringComparison.OrdinalIgnoreCase);
+        var earlyReset = Assert.Throws<InvalidOperationException>(dispatcher.ResetForWorkspaceChange);
+        Assert.Contains("active command executions", earlyReset.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(1, dispatcher.UndoCount);
+
         command.Release.TrySetResult();
         var result = await dispatch.WaitAsync(TimeSpan.FromSeconds(5));
+        await transition.WaitAsync(TimeSpan.FromSeconds(5));
 
         Assert.False(result.Succeeded);
         Assert.Contains("workspace changed", result.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.True(command.SideEffectApplied);
+        Assert.False(command.SideEffectAfterReset);
+        Assert.Equal(0, dispatcher.UndoCount);
+        Assert.Equal(0, dispatcher.RedoCount);
+    }
+
+    [Fact]
+    public async Task BeginWorkspaceChangeAsync_DrainsActiveNonCooperativeUndoBeforeReset()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubActionContextProvider(), history);
+        var resetStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var command = new DelayedHistoryCommand(
+            "Delayed undo",
+            () => resetStarted.Task.IsCompleted,
+            delayUndo: true);
+
+        Assert.True((await dispatcher.DispatchAsync(command, new ActionContext())).Succeeded);
+        var undo = dispatcher.UndoAsync();
+        await command.UndoStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var transition = DrainAndResetAsync(dispatcher, resetStarted);
+
+        Assert.False(transition.IsCompleted);
+        command.ReleaseUndo.TrySetResult();
+        Assert.False(await undo.WaitAsync(TimeSpan.FromSeconds(5)));
+        await transition.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(command.IsApplied);
+        Assert.False(command.SideEffectAfterReset);
+        Assert.Equal(0, dispatcher.UndoCount);
+        Assert.Equal(0, dispatcher.RedoCount);
+    }
+
+    [Fact]
+    public async Task BeginWorkspaceChangeAsync_DrainsActiveNonCooperativeRedoBeforeReset()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubActionContextProvider(), history);
+        var resetStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var command = new DelayedHistoryCommand(
+            "Delayed redo",
+            () => resetStarted.Task.IsCompleted,
+            delayRedo: true);
+
+        Assert.True((await dispatcher.DispatchAsync(command, new ActionContext())).Succeeded);
+        Assert.True(await dispatcher.UndoAsync());
+        var redo = dispatcher.RedoAsync();
+        await command.RedoStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var transition = DrainAndResetAsync(dispatcher, resetStarted);
+
+        Assert.False(transition.IsCompleted);
+        command.ReleaseRedo.TrySetResult();
+        Assert.False(await redo.WaitAsync(TimeSpan.FromSeconds(5)));
+        await transition.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.True(command.IsApplied);
+        Assert.False(command.SideEffectAfterReset);
+        Assert.Equal(0, dispatcher.UndoCount);
+        Assert.Equal(0, dispatcher.RedoCount);
+    }
+
+    [Fact]
+    public async Task BeginWorkspaceChangeAsync_DrainsActiveTransactionRollbackBeforeReset()
+    {
+        var history = new InMemoryUndoRedoHistory();
+        var dispatcher = new EditorCommandDispatcher(new StubActionContextProvider(), history);
+        var resetStarted = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var command = new DelayedHistoryCommand(
+            "Delayed transaction rollback",
+            () => resetStarted.Task.IsCompleted,
+            delayUndo: true);
+        var transaction = await dispatcher.BeginAsync("Transaction", new ActionContext());
+
+        Assert.True((await dispatcher.DispatchAsync(command, new ActionContext())).Succeeded);
+        var rollback = transaction.DisposeAsync().AsTask();
+        await command.UndoStarted.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+        var transition = DrainAndResetAsync(dispatcher, resetStarted);
+
+        Assert.False(transition.IsCompleted);
+        command.ReleaseUndo.TrySetResult();
+        await rollback.WaitAsync(TimeSpan.FromSeconds(5));
+        await transition.WaitAsync(TimeSpan.FromSeconds(5));
+
+        Assert.False(command.IsApplied);
+        Assert.False(command.SideEffectAfterReset);
         Assert.Equal(0, dispatcher.UndoCount);
         Assert.Equal(0, dispatcher.RedoCount);
     }
@@ -119,26 +220,85 @@ public sealed class WorkspaceStateResetTests
         public bool CanExecute(ActionContext context) => true;
         public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default) =>
             Task.FromResult(CommandResult.Success());
-        public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default) =>
-            ValueTask.CompletedTask;
+        public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(CommandResult.Success());
     }
 
-    sealed class DelayedCommand(string description) : IUndoableEditorCommand
+    static async Task DrainAndResetAsync(
+        EditorCommandDispatcher dispatcher,
+        TaskCompletionSource resetStarted)
+    {
+        await dispatcher.BeginWorkspaceChangeAsync();
+        resetStarted.TrySetResult();
+        dispatcher.ResetForWorkspaceChange();
+    }
+
+    sealed class DelayedCommand(string description, Func<bool> hasResetStarted) : IUndoableEditorCommand
     {
         public TaskCompletionSource Started { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
         public string Name => description;
         public string Description => description;
+        public bool SideEffectApplied { get; private set; }
+        public bool SideEffectAfterReset { get; private set; }
         public bool CanExecute(ActionContext context) => true;
 
         public async Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
         {
             Started.TrySetResult();
             await Release.Task;
+            SideEffectAfterReset = hasResetStarted();
+            SideEffectApplied = true;
             return CommandResult.Success();
         }
 
-        public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default) =>
-            ValueTask.CompletedTask;
+        public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default) =>
+            ValueTask.FromResult(CommandResult.Success());
+    }
+
+    sealed class DelayedHistoryCommand(
+        string description,
+        Func<bool> hasResetStarted,
+        bool delayUndo = false,
+        bool delayRedo = false) : IUndoableEditorCommand
+    {
+        int executeCount;
+
+        public TaskCompletionSource UndoStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseUndo { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource RedoStarted { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource ReleaseRedo { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public string Name => description;
+        public string Description => description;
+        public bool IsApplied { get; private set; }
+        public bool SideEffectAfterReset { get; private set; }
+        public bool CanExecute(ActionContext context) => !IsApplied;
+
+        public async Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
+        {
+            executeCount++;
+            if (executeCount > 1 && delayRedo)
+            {
+                RedoStarted.TrySetResult();
+                await ReleaseRedo.Task;
+                SideEffectAfterReset = hasResetStarted();
+            }
+
+            IsApplied = true;
+            return CommandResult.Success();
+        }
+
+        public async ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+        {
+            if (delayUndo)
+            {
+                UndoStarted.TrySetResult();
+                await ReleaseUndo.Task;
+                SideEffectAfterReset = hasResetStarted();
+            }
+
+            IsApplied = false;
+            return CommandResult.Success();
+        }
     }
 }

--- a/Editor.Tests/WorldSnapshotPublicationGateTests.cs
+++ b/Editor.Tests/WorldSnapshotPublicationGateTests.cs
@@ -1,0 +1,28 @@
+using SailorEditor.Services;
+
+namespace SailorEditor.Tests;
+
+public sealed class WorldSnapshotPublicationGateTests
+{
+    [Fact]
+    public void FreshSynchronousSnapshot_PreventsOlderQueuedSnapshotFromPublishing()
+    {
+        var gate = new WorldSnapshotPublicationGate();
+        var olderQueuedSnapshot = gate.ReserveSequence();
+        var freshSynchronousSnapshot = gate.ReserveSequence();
+
+        Assert.True(gate.TryAdvance(freshSynchronousSnapshot));
+        Assert.False(gate.TryAdvance(olderQueuedSnapshot));
+    }
+
+    [Fact]
+    public void LocalMutationBarrier_PreventsOlderQueuedSnapshotFromPublishing()
+    {
+        var gate = new WorldSnapshotPublicationGate();
+        var olderQueuedSnapshot = gate.ReserveSequence();
+        var localMutationBarrier = gate.ReserveSequence();
+
+        Assert.True(gate.TryAdvance(localMutationBarrier));
+        Assert.False(gate.TryAdvance(olderQueuedSnapshot));
+    }
+}

--- a/Editor/Commands/CommandContracts.cs
+++ b/Editor/Commands/CommandContracts.cs
@@ -42,9 +42,16 @@ public interface IUndoableEditorCommand : IEditorCommand
 {
     string Description { get; }
 
-    ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default);
+    ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default);
 
     IHistoryMergePolicy? MergePolicy => null;
+}
+
+public interface IHistoryCoalescibleCommand : IUndoableEditorCommand
+{
+    bool CanCoalesceWith(IUndoableEditorCommand next);
+
+    IUndoableEditorCommand CoalesceWith(IUndoableEditorCommand next);
 }
 
 public sealed record CommandResult(bool Succeeded, string? Message = null, object? Value = null)

--- a/Editor/Commands/EditorCommandRuntime.cs
+++ b/Editor/Commands/EditorCommandRuntime.cs
@@ -15,6 +15,7 @@ public interface ICommandHistoryService
     Task<bool> UndoAsync(CommandOrigin? origin = null, CancellationToken cancellationToken = default);
     Task<bool> RedoAsync(CommandOrigin? origin = null, CancellationToken cancellationToken = default);
     void BeginWorkspaceChange();
+    Task BeginWorkspaceChangeAsync(CancellationToken cancellationToken = default);
     void ResetForWorkspaceChange();
     void CompleteWorkspaceChange();
 }
@@ -26,8 +27,11 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
     readonly Stack<TransactionScope> _transactions = new();
     readonly object _workspaceStateLock = new();
     CancellationTokenSource _workspaceCancellation = new();
+    TaskCompletionSource<bool>? _executionDrain;
     long _workspaceEpoch;
+    int _inFlightExecutionCount;
     bool _workspaceChangeInProgress;
+    bool _transactionRollbackInProgress;
     bool _isUndoRedo;
 
     public EditorCommandDispatcher(IActionContextProvider contextProvider, IUndoRedoHistory history)
@@ -87,40 +91,52 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
         {
             if (_workspaceChangeInProgress)
                 return WorkspaceChangingFailure(command.Name);
-            execution = CaptureExecutionUnderLock(cancellationToken);
+            if (_transactionRollbackInProgress)
+                return TransactionRollbackFailure(command.Name);
+            if (_isUndoRedo)
+                return HistoryOperationInProgressFailure(command.Name);
+            execution = BeginExecutionUnderLock(cancellationToken);
         }
-        using var linkedCancellation = execution.Cancellation;
-        if (context.WorkspaceEpoch is { } contextEpoch && contextEpoch != execution.Epoch)
-            return WorkspaceChangedFailure(command.Name);
-        if (!command.CanExecute(context))
-            return CommandResult.Failure($"Command '{command.Name}' cannot execute.");
 
-        CommandResult result;
         try
         {
-            result = await command.ExecuteAsync(context, linkedCancellation.Token);
-        }
-        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && !IsCurrentEpoch(execution.Epoch))
-        {
-            return WorkspaceChangedFailure(command.Name);
-        }
-
-        lock (_workspaceStateLock)
-        {
-            if (!IsCurrentEpoch(execution.Epoch))
+            using var linkedCancellation = execution.Cancellation;
+            if (context.WorkspaceEpoch is { } contextEpoch && contextEpoch != execution.Epoch)
                 return WorkspaceChangedFailure(command.Name);
+            if (!command.CanExecute(context))
+                return CommandResult.Failure($"Command '{command.Name}' cannot execute.");
 
-            if (!result.Succeeded || command is not IUndoableEditorCommand undoable || _isUndoRedo)
-                return result;
+            CommandResult result;
+            try
+            {
+                result = await command.ExecuteAsync(context, linkedCancellation.Token);
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && !IsCurrentEpoch(execution.Epoch))
+            {
+                return WorkspaceChangedFailure(command.Name);
+            }
 
-            var entry = new HistoryEntry(undoable.Description, undoable, context.Origin, DateTimeOffset.UtcNow, context.Metadata);
-            if (_transactions.TryPeek(out var transaction) && transaction.WorkspaceEpoch == execution.Epoch)
-                transaction.Add(entry);
-            else
-                PushWithMerge(entry);
+            lock (_workspaceStateLock)
+            {
+                if (!IsCurrentEpoch(execution.Epoch))
+                    return WorkspaceChangedFailure(command.Name);
+
+                if (!result.Succeeded || command is not IUndoableEditorCommand undoable || _isUndoRedo)
+                    return result;
+
+                var entry = new HistoryEntry(undoable.Description, undoable, context.Origin, DateTimeOffset.UtcNow, context.Metadata);
+                if (_transactions.TryPeek(out var transaction) && transaction.WorkspaceEpoch == execution.Epoch)
+                    transaction.Add(entry);
+                else
+                    PushWithMerge(entry);
+            }
+
+            return result;
         }
-
-        return result;
+        finally
+        {
+            CompleteExecution();
+        }
     }
 
     public ValueTask<ITransactionScope> BeginAsync(string description, ActionContext context, CancellationToken cancellationToken = default)
@@ -130,6 +146,8 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
         {
             if (_workspaceChangeInProgress)
                 throw new InvalidOperationException("A command transaction cannot begin while the active workspace is changing.");
+            if (_transactionRollbackInProgress)
+                throw new InvalidOperationException("A command transaction cannot begin while another transaction is rolling back.");
             if (context.WorkspaceEpoch is { } contextEpoch && contextEpoch != WorkspaceEpoch)
                 throw new InvalidOperationException("A command transaction cannot begin with context from a previous workspace.");
 
@@ -145,10 +163,10 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
         (long Epoch, CancellationTokenSource Cancellation) execution;
         lock (_workspaceStateLock)
         {
-            if (_workspaceChangeInProgress || _history.UndoCount == 0)
+            if (_workspaceChangeInProgress || _transactionRollbackInProgress || _isUndoRedo || _history.UndoCount == 0)
                 return false;
 
-            execution = CaptureExecutionUnderLock(cancellationToken);
+            execution = BeginExecutionUnderLock(cancellationToken);
             entry = _history.PopUndo();
             _isUndoRedo = true;
         }
@@ -162,11 +180,17 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
             var context = _contextProvider.GetCurrentContext(
                 origin ?? new CommandOrigin(CommandOriginKind.Menu, "Undo"),
                 entry.Metadata);
-            await entry.Command.UndoAsync(context, linkedCancellation.Token);
+            var result = await entry.Command.UndoAsync(context, linkedCancellation.Token);
             lock (_workspaceStateLock)
             {
                 if (!IsCurrentEpoch(execution.Epoch))
                     return false;
+
+                if (!result.Succeeded)
+                {
+                    _history.PushUndoPreservingRedo(entry);
+                    return false;
+                }
 
                 _history.PushRedo(entry);
                 return true;
@@ -176,6 +200,26 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
         {
             return false;
         }
+        catch (OperationCanceledException)
+        {
+            lock (_workspaceStateLock)
+            {
+                if (IsCurrentEpoch(execution.Epoch))
+                    _history.PushUndoPreservingRedo(entry);
+            }
+
+            return false;
+        }
+        catch
+        {
+            lock (_workspaceStateLock)
+            {
+                if (IsCurrentEpoch(execution.Epoch))
+                    _history.PushUndoPreservingRedo(entry);
+            }
+
+            throw;
+        }
         finally
         {
             lock (_workspaceStateLock)
@@ -183,6 +227,7 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
                 if (IsCurrentEpoch(execution.Epoch))
                     _isUndoRedo = false;
             }
+            CompleteExecution();
         }
     }
 
@@ -192,10 +237,10 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
         (long Epoch, CancellationTokenSource Cancellation) execution;
         lock (_workspaceStateLock)
         {
-            if (_workspaceChangeInProgress || _history.RedoCount == 0)
+            if (_workspaceChangeInProgress || _transactionRollbackInProgress || _isUndoRedo || _history.RedoCount == 0)
                 return false;
 
-            execution = CaptureExecutionUnderLock(cancellationToken);
+            execution = BeginExecutionUnderLock(cancellationToken);
             entry = _history.PopRedo();
             _isUndoRedo = true;
         }
@@ -212,16 +257,42 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
             var result = await entry.Command.ExecuteAsync(context, linkedCancellation.Token);
             lock (_workspaceStateLock)
             {
-                if (!IsCurrentEpoch(execution.Epoch) || !result.Succeeded)
+                if (!IsCurrentEpoch(execution.Epoch))
                     return false;
 
-                _history.Push(entry);
+                if (!result.Succeeded)
+                {
+                    _history.PushRedo(entry);
+                    return false;
+                }
+
+                _history.PushUndoPreservingRedo(entry);
                 return true;
             }
         }
         catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested && !IsCurrentEpoch(execution.Epoch))
         {
             return false;
+        }
+        catch (OperationCanceledException)
+        {
+            lock (_workspaceStateLock)
+            {
+                if (IsCurrentEpoch(execution.Epoch))
+                    _history.PushRedo(entry);
+            }
+
+            return false;
+        }
+        catch
+        {
+            lock (_workspaceStateLock)
+            {
+                if (IsCurrentEpoch(execution.Epoch))
+                    _history.PushRedo(entry);
+            }
+
+            throw;
         }
         finally
         {
@@ -230,27 +301,36 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
                 if (IsCurrentEpoch(execution.Epoch))
                     _isUndoRedo = false;
             }
+            CompleteExecution();
         }
     }
 
     public void BeginWorkspaceChange()
     {
-        CancellationTokenSource? previousCancellation = null;
-        lock (_workspaceStateLock)
-        {
-            if (_workspaceChangeInProgress)
-                return;
+        var transition = BeginWorkspaceChangeUnderLock();
+        CancelAndDispose(transition.PreviousCancellation);
+    }
 
-            _workspaceChangeInProgress = true;
-            Interlocked.Increment(ref _workspaceEpoch);
-            previousCancellation = _workspaceCancellation;
-            _workspaceCancellation = new CancellationTokenSource();
-            _transactions.Clear();
-            _isUndoRedo = false;
+    public async Task BeginWorkspaceChangeAsync(CancellationToken cancellationToken = default)
+    {
+        var transition = BeginWorkspaceChangeUnderLock();
+        Exception? cancellationFailure = null;
+        try
+        {
+            CancelAndDispose(transition.PreviousCancellation);
+        }
+        catch (Exception exception)
+        {
+            cancellationFailure = exception;
         }
 
-        previousCancellation.Cancel();
-        previousCancellation.Dispose();
+        await transition.ExecutionDrain.WaitAsync(cancellationToken).ConfigureAwait(false);
+        if (cancellationFailure is not null)
+        {
+            throw new InvalidOperationException(
+                "The previous workspace command cancellation reported an error after its executions drained.",
+                cancellationFailure);
+        }
     }
 
     public void ResetForWorkspaceChange()
@@ -258,6 +338,12 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
         BeginWorkspaceChange();
         lock (_workspaceStateLock)
         {
+            if (_inFlightExecutionCount != 0)
+            {
+                throw new InvalidOperationException(
+                    "Command history cannot reset until active command executions have drained. Await BeginWorkspaceChangeAsync first.");
+            }
+
             _transactions.Clear();
             _isUndoRedo = false;
             _history.Clear();
@@ -267,17 +353,91 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
     public void CompleteWorkspaceChange()
     {
         lock (_workspaceStateLock)
+        {
+            if (_inFlightExecutionCount != 0)
+            {
+                throw new InvalidOperationException(
+                    "Workspace command dispatch cannot resume until prior command executions have drained.");
+            }
+
             _workspaceChangeInProgress = false;
+        }
     }
 
-    (long Epoch, CancellationTokenSource Cancellation) CaptureExecution(CancellationToken cancellationToken)
+    (CancellationTokenSource? PreviousCancellation, Task ExecutionDrain) BeginWorkspaceChangeUnderLock()
     {
         lock (_workspaceStateLock)
-            return CaptureExecutionUnderLock(cancellationToken);
+        {
+            CancellationTokenSource? previousCancellation = null;
+            if (!_workspaceChangeInProgress)
+            {
+                _workspaceChangeInProgress = true;
+                Interlocked.Increment(ref _workspaceEpoch);
+                previousCancellation = _workspaceCancellation;
+                _workspaceCancellation = new CancellationTokenSource();
+                _transactions.Clear();
+                _isUndoRedo = false;
+            }
+
+            var executionDrain = _inFlightExecutionCount == 0
+                ? Task.CompletedTask
+                : _executionDrain?.Task
+                    ?? throw new InvalidOperationException("Active command executions are missing their drain signal.");
+            return (previousCancellation, executionDrain);
+        }
     }
 
-    (long Epoch, CancellationTokenSource Cancellation) CaptureExecutionUnderLock(CancellationToken cancellationToken)
-        => (WorkspaceEpoch, CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _workspaceCancellation.Token));
+    (long Epoch, CancellationTokenSource Cancellation) BeginExecutionUnderLock(CancellationToken cancellationToken)
+    {
+        var cancellation = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, _workspaceCancellation.Token);
+        RegisterExecutionUnderLock();
+        return (WorkspaceEpoch, cancellation);
+    }
+
+    void RegisterExecutionUnderLock()
+    {
+        if (_inFlightExecutionCount == 0)
+        {
+            _executionDrain = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        }
+
+        _inFlightExecutionCount++;
+    }
+
+    void CompleteExecution()
+    {
+        TaskCompletionSource<bool>? completedDrain = null;
+        lock (_workspaceStateLock)
+        {
+            if (_inFlightExecutionCount <= 0)
+                throw new InvalidOperationException("Command execution accounting underflowed.");
+
+            _inFlightExecutionCount--;
+            if (_inFlightExecutionCount == 0)
+            {
+                completedDrain = _executionDrain
+                    ?? throw new InvalidOperationException("Command execution completed without a drain signal.");
+                _executionDrain = null;
+            }
+        }
+
+        completedDrain?.TrySetResult(true);
+    }
+
+    static void CancelAndDispose(CancellationTokenSource? cancellation)
+    {
+        if (cancellation is null)
+            return;
+
+        try
+        {
+            cancellation.Cancel();
+        }
+        finally
+        {
+            cancellation.Dispose();
+        }
+    }
 
     bool IsCurrentEpoch(long epoch) => epoch == WorkspaceEpoch;
 
@@ -287,17 +447,27 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
     static CommandResult WorkspaceChangingFailure(string commandName) =>
         CommandResult.Failure($"Command '{commandName}' was discarded because workspace activation is in progress.");
 
+    static CommandResult TransactionRollbackFailure(string commandName) =>
+        CommandResult.Failure($"Command '{commandName}' was discarded because a command transaction is rolling back.");
+
+    static CommandResult HistoryOperationInProgressFailure(string commandName) =>
+        CommandResult.Failure($"Command '{commandName}' was discarded because an undo or redo operation is in progress.");
+
     void PushWithMerge(HistoryEntry entry)
     {
         var previous = _history.PeekUndo();
-        var merged = entry.Command.MergePolicy is { } policy && previous is not null && policy.CanMerge(previous, entry)
-            ? policy.Merge(previous, entry)
-            : entry;
-
-        if (!ReferenceEquals(merged, entry) && previous is not null)
+        if (_history.RedoCount == 0 &&
+            entry.Command.MergePolicy is { } policy &&
+            previous is not null &&
+            policy.CanMerge(previous, entry))
+        {
+            var merged = policy.Merge(previous, entry);
             _history.PopUndo();
+            _history.Push(merged);
+            return;
+        }
 
-        _history.Push(merged);
+        _history.Push(entry);
     }
 
     void Complete(TransactionScope scope)
@@ -323,18 +493,114 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
         }
     }
 
-    void Cancel(TransactionScope scope)
+    async ValueTask CancelAsync(TransactionScope scope)
     {
+        HistoryEntry[] entries;
         lock (_workspaceStateLock)
         {
-            if (IsCurrentEpoch(scope.WorkspaceEpoch) && _transactions.Count > 0 && ReferenceEquals(_transactions.Peek(), scope))
-                _transactions.Pop();
+            if (!IsCurrentEpoch(scope.WorkspaceEpoch))
+            {
+                scope.MarkFinalizedByOwner();
+                return;
+            }
+
+            var activeScopes = _transactions.ToArray();
+            var scopeIndex = Array.FindIndex(activeScopes, activeScope => ReferenceEquals(activeScope, scope));
+            if (scopeIndex < 0)
+            {
+                scope.MarkFinalizedByOwner();
+                return;
+            }
+
+            var scopesToCancel = activeScopes.Take(scopeIndex + 1).ToArray();
+            foreach (var expectedScope in scopesToCancel)
+            {
+                var poppedScope = _transactions.Pop();
+                if (!ReferenceEquals(expectedScope, poppedScope))
+                    throw new InvalidOperationException("Command transaction nesting changed while cancellation was in progress.");
+
+                poppedScope.MarkFinalizedByOwner();
+            }
+
+            entries = scopesToCancel
+                .Reverse()
+                .SelectMany(cancelledScope => cancelledScope.Entries)
+                .ToArray();
+
+            if (entries.Length == 0)
+                return;
+
+            _transactionRollbackInProgress = true;
+            RegisterExecutionUnderLock();
+        }
+
+        var rollbackCommand = entries.Length == 1
+            ? entries[0].Command
+            : new CompoundEditorCommand(scope.Description, entries.Select(entry => entry.Command).ToArray());
+
+        try
+        {
+            CommandResult? rollbackResult = null;
+            Exception? rollbackException = null;
+            try
+            {
+                rollbackResult = await rollbackCommand.UndoAsync(scope.Context, CancellationToken.None);
+            }
+            catch (Exception exception)
+            {
+                rollbackException = exception;
+            }
+
+            var rollbackFailed = rollbackException is not null || rollbackResult is not { Succeeded: true };
+            lock (_workspaceStateLock)
+            {
+                try
+                {
+                    if (rollbackFailed && IsCurrentEpoch(scope.WorkspaceEpoch))
+                    {
+                        var preservedEntry = new HistoryEntry(
+                            scope.Description,
+                            rollbackCommand,
+                            scope.Context.Origin,
+                            DateTimeOffset.UtcNow,
+                            scope.Context.Metadata);
+                        if (_transactions.TryPeek(out var parent))
+                            parent.Add(preservedEntry);
+                        else
+                            _history.Push(preservedEntry);
+                    }
+                }
+                finally
+                {
+                    _transactionRollbackInProgress = false;
+                }
+            }
+
+            if (rollbackException is not null)
+            {
+                throw new InvalidOperationException(
+                    $"Transaction '{scope.Description}' could not be rolled back. Its history entry was preserved for explicit recovery.",
+                    rollbackException);
+            }
+
+            if (rollbackResult is not { Succeeded: true })
+            {
+                var detail = string.IsNullOrWhiteSpace(rollbackResult?.Message)
+                    ? "A child command rejected the rollback."
+                    : rollbackResult.Message;
+                throw new InvalidOperationException(
+                    $"Transaction '{scope.Description}' could not be rolled back: {detail} Its history entry was preserved for explicit recovery.");
+            }
+        }
+        finally
+        {
+            CompleteExecution();
         }
     }
 
     sealed class TransactionScope(EditorCommandDispatcher owner, string description, ActionContext context, long workspaceEpoch) : ITransactionScope
     {
-        bool _completed;
+        bool _finalized;
         public string Description { get; } = description;
         public ActionContext Context { get; } = context;
         public long WorkspaceEpoch { get; } = workspaceEpoch;
@@ -342,48 +608,218 @@ public sealed class EditorCommandDispatcher : ICommandDispatcher, ICommandHistor
         public void Add(HistoryEntry entry) => Entries.Add(entry);
         public ValueTask CompleteAsync(CancellationToken cancellationToken = default)
         {
-            if (_completed)
+            if (_finalized)
                 return ValueTask.CompletedTask;
-            _completed = true;
+
+            cancellationToken.ThrowIfCancellationRequested();
             owner.Complete(this);
+            _finalized = true;
             return ValueTask.CompletedTask;
         }
         public async ValueTask DisposeAsync()
         {
-            if (!_completed)
-                owner.Cancel(this);
-            await ValueTask.CompletedTask;
+            if (_finalized)
+                return;
+
+            _finalized = true;
+            await owner.CancelAsync(this);
         }
+
+        public void MarkFinalizedByOwner() => _finalized = true;
     }
 }
 
 public sealed class CompoundEditorCommand(string description, IReadOnlyList<IUndoableEditorCommand> commands) : IUndoableEditorCommand
 {
+    readonly object _faultLock = new();
+    string? _faultMessage;
+
     public string Name => description;
     public string Description => description;
     public IHistoryMergePolicy? MergePolicy => null;
     public bool CanExecute(ActionContext context) => commands.All(x => x.CanExecute(context));
+
     public async Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
-        foreach (var command in commands)
+        if (GetFaultResult() is { } faultResult)
+            return faultResult;
+
+        var executedCommands = new List<IUndoableEditorCommand>(commands.Count);
+        try
         {
-            var result = await command.ExecuteAsync(context, cancellationToken);
-            if (!result.Succeeded)
-                return result;
+            foreach (var command in commands)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var result = await command.ExecuteAsync(context, cancellationToken);
+                if (!result.Succeeded)
+                {
+                    var compensation = await UndoCommandsAsync(executedCommands, context);
+                    return compensation.Succeeded
+                        ? result
+                        : MarkFaulted(CreateCompensationFailure("execution", command, result.Message, compensation.Message));
+                }
+
+                executedCommands.Add(command);
+            }
         }
+        catch (Exception exception)
+        {
+            var compensation = await UndoCommandsAsync(executedCommands, context);
+            if (!compensation.Succeeded)
+            {
+                throw MarkFaulted(
+                    CreateCompensationFailure("execution", null, exception.Message, compensation.Message),
+                    exception);
+            }
+
+            throw;
+        }
+
         return CommandResult.Success();
     }
-    public async ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+
+    public async ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
-        for (var i = commands.Count - 1; i >= 0; i--)
-            await commands[i].UndoAsync(context, cancellationToken);
+        if (GetFaultResult() is { } faultResult)
+            return faultResult;
+
+        var undoneCommands = new List<IUndoableEditorCommand>(commands.Count);
+        try
+        {
+            for (var i = commands.Count - 1; i >= 0; i--)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var command = commands[i];
+                var result = await command.UndoAsync(context, cancellationToken);
+                if (!result.Succeeded)
+                {
+                    var compensation = await ExecuteCommandsInOriginalOrderAsync(undoneCommands, context);
+                    return compensation.Succeeded
+                        ? result
+                        : MarkFaulted(CreateCompensationFailure("undo", command, result.Message, compensation.Message));
+                }
+
+                undoneCommands.Add(command);
+            }
+        }
+        catch (Exception exception)
+        {
+            var compensation = await ExecuteCommandsInOriginalOrderAsync(undoneCommands, context);
+            if (!compensation.Succeeded)
+            {
+                throw MarkFaulted(
+                    CreateCompensationFailure("undo", null, exception.Message, compensation.Message),
+                    exception);
+            }
+
+            throw;
+        }
+
+        return CommandResult.Success();
+    }
+
+    CommandResult? GetFaultResult()
+    {
+        lock (_faultLock)
+            return _faultMessage is null ? null : CommandResult.Failure(_faultMessage);
+    }
+
+    CommandResult MarkFaulted(string message)
+    {
+        lock (_faultLock)
+            _faultMessage ??= message;
+        return CommandResult.Failure(_faultMessage);
+    }
+
+    Exception MarkFaulted(string message, Exception innerException)
+    {
+        lock (_faultLock)
+            _faultMessage ??= message;
+        return new InvalidOperationException(_faultMessage, innerException);
+    }
+
+    static async Task<CommandResult> UndoCommandsAsync(
+        IReadOnlyList<IUndoableEditorCommand> executedCommands,
+        ActionContext context)
+    {
+        var failures = new List<string>();
+        for (var i = executedCommands.Count - 1; i >= 0; i--)
+        {
+            var command = executedCommands[i];
+            try
+            {
+                var result = await command.UndoAsync(context, CancellationToken.None);
+                if (!result.Succeeded)
+                    failures.Add(DescribeFailure(command, result.Message));
+            }
+            catch (Exception exception)
+            {
+                failures.Add(DescribeFailure(command, exception.Message));
+            }
+        }
+
+        return failures.Count == 0
+            ? CommandResult.Success()
+            : CommandResult.Failure(string.Join("; ", failures));
+    }
+
+    static async Task<CommandResult> ExecuteCommandsInOriginalOrderAsync(
+        IReadOnlyList<IUndoableEditorCommand> undoneCommands,
+        ActionContext context)
+    {
+        var failures = new List<string>();
+        for (var i = undoneCommands.Count - 1; i >= 0; i--)
+        {
+            var command = undoneCommands[i];
+            try
+            {
+                var result = await command.ExecuteAsync(context, CancellationToken.None);
+                if (!result.Succeeded)
+                    failures.Add(DescribeFailure(command, result.Message));
+            }
+            catch (Exception exception)
+            {
+                failures.Add(DescribeFailure(command, exception.Message));
+            }
+        }
+
+        return failures.Count == 0
+            ? CommandResult.Success()
+            : CommandResult.Failure(string.Join("; ", failures));
+    }
+
+    static string DescribeFailure(IUndoableEditorCommand command, string? message) =>
+        string.IsNullOrWhiteSpace(message)
+            ? $"Command '{command.Name}' rejected compensation"
+            : $"Command '{command.Name}' rejected compensation: {message}";
+
+    static string CreateCompensationFailure(
+        string operation,
+        IUndoableEditorCommand? failedCommand,
+        string? originalFailure,
+        string? compensationFailure)
+    {
+        var commandName = failedCommand is null ? "a child command" : $"command '{failedCommand.Name}'";
+        var originalDetail = string.IsNullOrWhiteSpace(originalFailure) ? "without a diagnostic" : originalFailure;
+        var compensationDetail = string.IsNullOrWhiteSpace(compensationFailure)
+            ? "without a diagnostic"
+            : compensationFailure;
+        return $"Compound {operation} failed in {commandName}: {originalDetail}. " +
+            $"Compensation also failed: {compensationDetail}. The compound command is faulted and cannot be retried safely.";
     }
 }
 
 public sealed class TimeWindowHistoryMergePolicy(TimeSpan window) : IHistoryMergePolicy
 {
     public bool CanMerge(HistoryEntry previous, HistoryEntry next) =>
-        previous.Description == next.Description && next.EffectiveTimestamp - previous.EffectiveTimestamp <= window;
+        next.EffectiveTimestamp >= previous.EffectiveTimestamp &&
+        next.EffectiveTimestamp - previous.EffectiveTimestamp <= window &&
+        previous.Command is IHistoryCoalescibleCommand coalescible &&
+        coalescible.CanCoalesceWith(next.Command);
 
-    public HistoryEntry Merge(HistoryEntry previous, HistoryEntry next) => next;
+    public HistoryEntry Merge(HistoryEntry previous, HistoryEntry next)
+    {
+        var coalescible = (IHistoryCoalescibleCommand)previous.Command;
+        return next with { Command = coalescible.CoalesceWith(next.Command) };
+    }
 }

--- a/Editor/Commands/EditorWorldCommands.cs
+++ b/Editor/Commands/EditorWorldCommands.cs
@@ -13,6 +13,24 @@ public static class EditorYaml
     public static string SerializeGameObject(GameObject gameObject) => SerializationUtils.CreateSerializerBuilder().Build().Serialize(gameObject);
 
     public static string SerializeComponent(Component component) => SerializationUtils.CreateSerializerBuilder().WithTypeConverter(new ComponentYamlConverter()).Build().Serialize(component);
+
+    public static string SerializePrefab(Prefab prefab)
+    {
+        IYamlTypeConverter[] commonConverters =
+        [
+            new ComponentTypeYamlConverter(),
+            new ComponentYamlConverter()
+        ];
+
+        var serializerBuilder = SerializationUtils.CreateSerializerBuilder()
+            .WithTypeConverter(new ObservableListConverter<GameObject>(commonConverters))
+            .WithTypeConverter(new ObservableListConverter<Component>(commonConverters));
+
+        foreach (var converter in commonConverters)
+            serializerBuilder.WithTypeConverter(converter);
+
+        return serializerBuilder.Build().Serialize(prefab);
+    }
 }
 
 public sealed class SelectObjectCommand(InstanceId? instanceId = null, ObservableObject? selectedObject = null) : IEditorCommand
@@ -43,15 +61,39 @@ public sealed class SelectObjectCommand(InstanceId? instanceId = null, Observabl
     }
 }
 
-public sealed class UpdateGameObjectCommand(GameObject gameObject, string beforeYaml, string afterYaml, string description = "Edit object") : IUndoableEditorCommand
+public sealed class UpdateGameObjectCommand : IHistoryCoalescibleCommand
 {
-    readonly InstanceId _instanceId = gameObject.InstanceId;
+    readonly InstanceId _instanceId;
+    readonly string _beforeYaml;
+    readonly string _afterYaml;
+
+    public UpdateGameObjectCommand(GameObject gameObject, string beforeYaml, string afterYaml, string description = "Edit object")
+        : this(new InstanceId(gameObject.InstanceId?.Value ?? InstanceId.NullInstanceId), beforeYaml, afterYaml, description)
+    {
+    }
+
+    UpdateGameObjectCommand(InstanceId instanceId, string beforeYaml, string afterYaml, string description)
+    {
+        _instanceId = instanceId;
+        _beforeYaml = beforeYaml;
+        _afterYaml = afterYaml;
+        Description = description;
+    }
+
     public string Name => nameof(UpdateGameObjectCommand);
-    public string Description => description;
+    public string Description { get; }
     public IHistoryMergePolicy? MergePolicy => new TimeWindowHistoryMergePolicy(TimeSpan.FromMilliseconds(750));
     public bool CanExecute(ActionContext context) => _instanceId is not null && !_instanceId.IsEmpty();
-    public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default) => Task.FromResult(Apply(afterYaml));
-    public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default) { Apply(beforeYaml); return ValueTask.CompletedTask; }
+    public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default) => Task.FromResult(Apply(_afterYaml));
+    public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(Apply(_beforeYaml));
+    public bool CanCoalesceWith(IUndoableEditorCommand next) =>
+        next is UpdateGameObjectCommand command && _instanceId.Equals(command._instanceId);
+    public IUndoableEditorCommand CoalesceWith(IUndoableEditorCommand next)
+    {
+        var command = (UpdateGameObjectCommand)next;
+        return new UpdateGameObjectCommand(_instanceId, _beforeYaml, command._afterYaml, command.Description);
+    }
     CommandResult Apply(string yaml)
     {
         if (!MauiProgram.GetService<EngineService>().CommitChanges(_instanceId, yaml))
@@ -63,15 +105,39 @@ public sealed class UpdateGameObjectCommand(GameObject gameObject, string before
     }
 }
 
-public sealed class UpdateComponentCommand(Component component, string beforeYaml, string afterYaml, string description = "Edit component") : IUndoableEditorCommand
+public sealed class UpdateComponentCommand : IHistoryCoalescibleCommand
 {
-    readonly InstanceId _instanceId = component.InstanceId;
+    readonly InstanceId _instanceId;
+    readonly string _beforeYaml;
+    readonly string _afterYaml;
+
+    public UpdateComponentCommand(Component component, string beforeYaml, string afterYaml, string description = "Edit component")
+        : this(new InstanceId(component.InstanceId?.Value ?? InstanceId.NullInstanceId), beforeYaml, afterYaml, description)
+    {
+    }
+
+    UpdateComponentCommand(InstanceId instanceId, string beforeYaml, string afterYaml, string description)
+    {
+        _instanceId = instanceId;
+        _beforeYaml = beforeYaml;
+        _afterYaml = afterYaml;
+        Description = description;
+    }
+
     public string Name => nameof(UpdateComponentCommand);
-    public string Description => description;
+    public string Description { get; }
     public IHistoryMergePolicy? MergePolicy => new TimeWindowHistoryMergePolicy(TimeSpan.FromMilliseconds(750));
     public bool CanExecute(ActionContext context) => _instanceId is not null && !_instanceId.IsEmpty();
-    public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default) => Task.FromResult(Apply(afterYaml));
-    public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default) { Apply(beforeYaml); return ValueTask.CompletedTask; }
+    public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default) => Task.FromResult(Apply(_afterYaml));
+    public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+        => ValueTask.FromResult(Apply(_beforeYaml));
+    public bool CanCoalesceWith(IUndoableEditorCommand next) =>
+        next is UpdateComponentCommand command && _instanceId.Equals(command._instanceId);
+    public IUndoableEditorCommand CoalesceWith(IUndoableEditorCommand next)
+    {
+        var command = (UpdateComponentCommand)next;
+        return new UpdateComponentCommand(_instanceId, _beforeYaml, command._afterYaml, command.Description);
+    }
     CommandResult Apply(string yaml)
     {
         if (!MauiProgram.GetService<EngineService>().CommitChanges(_instanceId, yaml))
@@ -93,59 +159,76 @@ public sealed class CreateGameObjectCommand(InstanceId? parentId = null) : IUndo
     public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
         var world = MauiProgram.GetService<WorldService>();
-        var before = world.Current.Prefabs.SelectMany(x => x.GameObjects).Select(x => x.InstanceId?.Value).ToHashSet();
-        var ok = MauiProgram.GetService<EngineService>().CreateGameObject(parentId);
-        if (!ok)
+        var engine = MauiProgram.GetService<EngineService>();
+        if (!engine.CreateGameObject(parentId, _createdId, out var createdId))
             return Task.FromResult(CommandResult.Failure());
-        var created = world.Current.Prefabs.SelectMany(x => x.GameObjects).FirstOrDefault(x => x.InstanceId is not null && !before.Contains(x.InstanceId.Value));
-        _createdId = created?.InstanceId;
+
+        _createdId = createdId;
+        if (!world.TryGetGameObject(createdId, out _))
+        {
+            engine.DestroyObject(createdId);
+            return Task.FromResult(CommandResult.Failure("Created object was not projected"));
+        }
+
         return Task.FromResult(CommandResult.Success(value: _createdId));
     }
-    public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+    public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
-        if (_createdId is not null && !_createdId.IsEmpty())
-            MauiProgram.GetService<EngineService>().DestroyObject(_createdId);
-        return ValueTask.CompletedTask;
+        if (_createdId is null || _createdId.IsEmpty())
+            return ValueTask.FromResult(CommandResult.Failure("Created object was not found"));
+
+        return ValueTask.FromResult(MauiProgram.GetService<EngineService>().DestroyObject(_createdId)
+            ? CommandResult.Success()
+            : CommandResult.Failure("Destroy created object failed"));
     }
 }
 
 public sealed class DestroyGameObjectCommand(GameObject gameObject) : IUndoableEditorCommand
 {
-    readonly InstanceId _originalInstanceId = gameObject.InstanceId;
     readonly string _name = gameObject.Name;
     readonly InstanceId? _parentId = gameObject.ParentIndex == uint.MaxValue
         ? null
         : MauiProgram.GetService<WorldService>().Current.Prefabs[gameObject.PrefabIndex].GameObjects[(int)gameObject.ParentIndex].InstanceId;
-    readonly SailorEditor.ViewModels.PrefabFile? _prefabSnapshot = MauiProgram.GetService<AssetsService>().CreatePrefabAsset(null, gameObject);
+    readonly string _prefabSnapshotYaml = CreateSnapshotYaml(gameObject);
     InstanceId _activeInstanceId = gameObject.InstanceId;
 
     public string Name => nameof(DestroyGameObjectCommand);
     public string Description => $"Delete {gameObject.Name}";
     public IHistoryMergePolicy? MergePolicy => null;
-    public bool CanExecute(ActionContext context) => _activeInstanceId is not null && !_activeInstanceId.IsEmpty() && _prefabSnapshot is not null;
+    public bool CanExecute(ActionContext context) => _activeInstanceId is not null && !_activeInstanceId.IsEmpty() && !string.IsNullOrWhiteSpace(_prefabSnapshotYaml);
 
     public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
         => Task.FromResult(MauiProgram.GetService<EngineService>().DestroyObject(_activeInstanceId) ? CommandResult.Success() : CommandResult.Failure("Destroy failed"));
 
-    public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+    public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
         var engine = MauiProgram.GetService<EngineService>();
         var world = MauiProgram.GetService<WorldService>();
         var beforeIds = world.Current.Prefabs.SelectMany(x => x.GameObjects).Select(x => x.InstanceId?.Value).ToHashSet();
 
-        if (_prefabSnapshot is null || !engine.InstantiatePrefab(_prefabSnapshot.FileId, _parentId))
-            return ValueTask.CompletedTask;
+        if (!engine.InstantiatePrefabFromYaml(_prefabSnapshotYaml, _parentId))
+            return ValueTask.FromResult(CommandResult.Failure("Restore deleted hierarchy failed"));
+
+        if (world.TryGetGameObject(_activeInstanceId, out _))
+            return ValueTask.FromResult(CommandResult.Success());
 
         var restored = world.Current.Prefabs
             .SelectMany(x => x.GameObjects)
             .Where(x => x.InstanceId is not null && !beforeIds.Contains(x.InstanceId.Value))
-            .FirstOrDefault(x => x.Name == _name && ((_parentId is null && x.ParentIndex == uint.MaxValue) || (_parentId is not null && x.ParentIndex != uint.MaxValue && world.Current.Prefabs[x.PrefabIndex].GameObjects[(int)x.ParentIndex].InstanceId == _parentId)))
+            .FirstOrDefault(x => x.Name == _name && ((_parentId is null && x.ParentIndex == uint.MaxValue) || (_parentId is not null && x.ParentIndex != uint.MaxValue && world.Current.Prefabs[x.PrefabIndex].GameObjects[(int)x.ParentIndex].InstanceId.Equals(_parentId))))
             ?? world.Current.Prefabs.SelectMany(x => x.GameObjects).FirstOrDefault(x => x.InstanceId is not null && !beforeIds.Contains(x.InstanceId.Value));
 
-        if (restored is not null)
-            _activeInstanceId = restored.InstanceId;
+        if (restored is null)
+            return ValueTask.FromResult(CommandResult.Failure("Restored hierarchy root was not found"));
 
-        return ValueTask.CompletedTask;
+        engine.DestroyObject(restored.InstanceId);
+        return ValueTask.FromResult(CommandResult.Failure("Restored hierarchy did not preserve its instance identity"));
+    }
+
+    static string CreateSnapshotYaml(GameObject root)
+    {
+        var prefab = MauiProgram.GetService<WorldService>().CreatePrefabFromSubHierarchy(root, out _);
+        return EditorYaml.SerializePrefab(prefab);
     }
 }
 
@@ -167,12 +250,12 @@ public sealed class ReparentGameObjectCommand(GameObject child, GameObject? newP
         return Task.FromResult(CommandResult.Success());
     }
 
-    public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+    public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
         var engine = MauiProgram.GetService<EngineService>();
-        engine.ReparentObject(_childId, _oldParentId, keepWorldTransform);
-
-        return ValueTask.CompletedTask;
+        return ValueTask.FromResult(engine.ReparentObject(_childId, _oldParentId, keepWorldTransform)
+            ? CommandResult.Success()
+            : CommandResult.Failure("Restore parent failed"));
     }
 }
 
@@ -190,23 +273,27 @@ public sealed class AddComponentCommand(GameObject gameObject, string componentT
         if (!world.TryGetGameObject(_ownerId, out var owner))
             return Task.FromResult(CommandResult.Failure("Owner not found"));
 
-        var before = world.GetComponents(owner).Select(x => x.InstanceId?.Value).ToHashSet();
-        var ok = MauiProgram.GetService<EngineService>().AddComponent(_ownerId, componentTypeName);
-        if (!ok)
+        var engine = MauiProgram.GetService<EngineService>();
+        if (!engine.AddComponent(_ownerId, componentTypeName, _componentId, out var createdId))
             return Task.FromResult(CommandResult.Failure());
 
-        if (!world.TryGetGameObject(_ownerId, out var refreshedOwner))
-            return Task.FromResult(CommandResult.Success());
+        _componentId = createdId;
+        if (!world.TryGetComponent(createdId, out _))
+        {
+            engine.RemoveComponent(createdId);
+            return Task.FromResult(CommandResult.Failure("Created component was not projected"));
+        }
 
-        var created = world.GetComponents(refreshedOwner).FirstOrDefault(x => x.InstanceId is not null && !before.Contains(x.InstanceId.Value));
-        _componentId = created?.InstanceId;
         return Task.FromResult(CommandResult.Success(value: _componentId));
     }
-    public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+    public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
-        if (_componentId is not null && !_componentId.IsEmpty())
-            MauiProgram.GetService<EngineService>().RemoveComponent(_componentId);
-        return ValueTask.CompletedTask;
+        if (_componentId is null || _componentId.IsEmpty())
+            return ValueTask.FromResult(CommandResult.Failure("Created component was not found"));
+
+        return ValueTask.FromResult(MauiProgram.GetService<EngineService>().RemoveComponent(_componentId)
+            ? CommandResult.Success()
+            : CommandResult.Failure("Remove created component failed"));
     }
 }
 
@@ -226,40 +313,37 @@ public sealed class RemoveComponentCommand(Component component) : IUndoableEdito
     public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
         => Task.FromResult(MauiProgram.GetService<EngineService>().RemoveComponent(_activeInstanceId) ? CommandResult.Success() : CommandResult.Failure());
 
-    public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+    public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
         var engine = MauiProgram.GetService<EngineService>();
         var world = MauiProgram.GetService<WorldService>();
 
         if (!world.TryGetGameObject(_ownerId, out var owner))
-            return ValueTask.CompletedTask;
+            return ValueTask.FromResult(CommandResult.Failure("Component owner was not found"));
 
-        var before = world.GetComponents(owner).Select(x => x.InstanceId?.Value).ToHashSet();
-        if (!engine.AddComponent(_ownerId, _componentTypeName))
-            return ValueTask.CompletedTask;
+        if (!engine.AddComponent(_ownerId, _componentTypeName, _originalInstanceId, out var restoredInstanceId))
+            return ValueTask.FromResult(CommandResult.Failure("Restore component failed"));
 
-        if (!world.TryGetGameObject(_ownerId, out var refreshedOwner))
-            return ValueTask.CompletedTask;
-
-        var restored = world.GetComponents(refreshedOwner)
-            .FirstOrDefault(x => x.InstanceId is not null && !before.Contains(x.InstanceId.Value));
-
-        if (restored is null)
-            return ValueTask.CompletedTask;
-
-        if (!engine.CommitChanges(restored.InstanceId, _beforeYaml))
-            return ValueTask.CompletedTask;
-
-        if (world.TryGetComponent(_originalInstanceId, out var original))
+        if (!restoredInstanceId.Equals(_originalInstanceId) || !world.TryGetComponent(restoredInstanceId, out var restored))
         {
-            _activeInstanceId = original.InstanceId;
-            return ValueTask.CompletedTask;
+            engine.RemoveComponent(restoredInstanceId);
+            return ValueTask.FromResult(CommandResult.Failure("Restored component was not found"));
         }
 
-        if (world.TryGetComponent(restored.InstanceId, out var refreshed))
-            _activeInstanceId = refreshed.InstanceId;
+        if (!engine.CommitChanges(restored.InstanceId, _beforeYaml))
+        {
+            engine.RemoveComponent(restored.InstanceId);
+            return ValueTask.FromResult(CommandResult.Failure("Restore component state failed"));
+        }
 
-        return ValueTask.CompletedTask;
+        if (!world.ApplyComponentYamlLocal(restored.InstanceId, _beforeYaml))
+        {
+            engine.RemoveComponent(restored.InstanceId);
+            return ValueTask.FromResult(CommandResult.Failure("Refresh restored component state failed"));
+        }
+
+        _activeInstanceId = restoredInstanceId;
+        return ValueTask.FromResult(CommandResult.Success());
     }
 }
 
@@ -279,13 +363,13 @@ public sealed class ResetComponentToDefaultsCommand(Component component) : IUndo
             _afterYaml = EditorYaml.SerializeComponent(refreshed);
         return Task.FromResult(ok ? CommandResult.Success() : CommandResult.Failure());
     }
-    public ValueTask UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
+    public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
-        if (MauiProgram.GetService<EngineService>().CommitChanges(_instanceId, _beforeYaml))
-        {
-            MauiProgram.GetService<WorldService>().ApplyComponentYamlLocal(_instanceId, _beforeYaml);
-        }
+        if (!MauiProgram.GetService<EngineService>().CommitChanges(_instanceId, _beforeYaml))
+            return ValueTask.FromResult(CommandResult.Failure("Restore component state failed"));
 
-        return ValueTask.CompletedTask;
+        return ValueTask.FromResult(MauiProgram.GetService<WorldService>().ApplyComponentYamlLocal(_instanceId, _beforeYaml)
+            ? CommandResult.Success()
+            : CommandResult.Failure("Refresh restored component state failed"));
     }
 }

--- a/Editor/History/HistoryContracts.cs
+++ b/Editor/History/HistoryContracts.cs
@@ -31,6 +31,8 @@ public interface IUndoRedoHistory
 
     void Push(HistoryEntry entry);
 
+    void PushUndoPreservingRedo(HistoryEntry entry);
+
     HistoryEntry PopUndo();
 
     HistoryEntry PopRedo();
@@ -58,6 +60,8 @@ public sealed class InMemoryUndoRedoHistory : IUndoRedoHistory
         _undo.Push(entry);
         _redo.Clear();
     }
+
+    public void PushUndoPreservingRedo(HistoryEntry entry) => _undo.Push(entry);
 
     public HistoryEntry PopUndo() => _undo.Pop();
 

--- a/Editor/Platforms/MacCatalyst/AppDelegate.cs
+++ b/Editor/Platforms/MacCatalyst/AppDelegate.cs
@@ -13,6 +13,7 @@ public class AppDelegate : MauiUIApplicationDelegate
     static readonly Selector OpenWorkspaceSelector = new("openWorkspace:");
     static readonly Selector SaveWorkspaceSelector = new("saveWorkspace:");
     static readonly Selector OpenRecentWorkspaceSelector = new("openRecentWorkspace:");
+    static readonly Selector ReloadAssetsSelector = new("reloadAssets:");
 
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
 
@@ -30,7 +31,14 @@ public class AppDelegate : MauiUIApplicationDelegate
                 UICommand.Create("New Workspace...", null, NewWorkspaceSelector, null),
                 UICommand.Create("Open Workspace...", null, OpenWorkspaceSelector, null),
                 UICommand.Create("Save Workspace", null, SaveWorkspaceSelector, null),
-                BuildRecentWorkspacesMenu()
+                BuildRecentWorkspacesMenu(),
+                UIKeyCommand.Create(
+                    "Reload Assets",
+                    null,
+                    ReloadAssetsSelector,
+                    "r",
+                    UIKeyModifierFlags.Command,
+                    null)
             });
 
         builder.InsertChildMenuAtStart(workspaceMenu, UIMenuIdentifier.File.GetConstant().ToString());
@@ -67,6 +75,10 @@ public class AppDelegate : MauiUIApplicationDelegate
 
         RunWorkspaceAction(workspace => workspace.OpenWorkspaceAsync(manifestPath.ToString()));
     }
+
+    [Export("reloadAssets:")]
+    public void ReloadAssets(NSObject sender)
+        => MauiProgram.GetService<EngineService>().RequestAssetReload();
 
     static UIMenu BuildRecentWorkspacesMenu()
     {

--- a/Editor/SailorEditor.csproj
+++ b/Editor/SailorEditor.csproj
@@ -150,6 +150,12 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <MauiXaml Update="App.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="AppShell.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Controls\HorizontalGridSplitterControl.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
@@ -185,6 +191,9 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Views\InspectorView\ControlPanelView.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="Views\InspectorView\FrameGraphFileTemplate.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="Views\InspectorView\MaterialFileTemplate.xaml">

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -272,19 +272,7 @@ namespace SailorEditor.Services
 
         static void WritePrefab(string path, Prefab prefab)
         {
-            var commonConverters = new List<IYamlTypeConverter> {
-                new ComponentTypeYamlConverter(),
-                new ViewModels.ComponentYamlConverter()
-            };
-
-            var serializerBuilder = SerializationUtils.CreateSerializerBuilder()
-                .WithTypeConverter(new ObservableListConverter<GameObject>(commonConverters.ToArray()))
-                .WithTypeConverter(new ObservableListConverter<Component>(commonConverters.ToArray()));
-
-            commonConverters.ForEach(converter => serializerBuilder.WithTypeConverter(converter));
-
-            var serializer = serializerBuilder.Build();
-            File.WriteAllText(path, serializer.Serialize(prefab));
+            File.WriteAllText(path, SailorEditor.Commands.EditorYaml.SerializePrefab(prefab));
         }
 
         static void WritePrefabAssetInfo(string path, FileId fileId, string filename, List<InstanceId> externalRefs)

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -61,6 +61,8 @@ namespace SailorEngine
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void Start();
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void Stop();
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void Shutdown();
+        [return: MarshalAs(UnmanagedType.I1)]
+        [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool RequestAssetReload();
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern int GetExitCode();
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern uint GetMessages(nint[] messages, uint num);
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern uint SerializeCurrentWorld(nint[] yamlNode);
@@ -1459,6 +1461,11 @@ namespace SailorEditor.Services
         {
             var stringId = id.Value.ToString();
             return InvokeRunningInterop(() => EngineAppInterop.UpdateObject(stringId, yamlChanges));
+        }
+
+        public bool RequestAssetReload()
+        {
+            return InvokeRunningInterop(EngineAppInterop.RequestAssetReload);
         }
 
         public void RefreshCurrentWorld()

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -90,17 +90,20 @@ namespace SailorEngine
         [return: MarshalAs(UnmanagedType.I1)]
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool ReparentObject(string strInstanceId, string strParentInstanceId, [MarshalAs(UnmanagedType.I1)] bool bKeepWorldTransform);
         [return: MarshalAs(UnmanagedType.I1)]
-        [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool CreateGameObject(string strParentInstanceId);
+        [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool CreateGameObject(string strParentInstanceId, string strPreferredInstanceId, nint[] outInstanceId);
         [return: MarshalAs(UnmanagedType.I1)]
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool DestroyObject(string strInstanceId);
         [return: MarshalAs(UnmanagedType.I1)]
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool ResetComponentToDefaults(string strInstanceId);
         [return: MarshalAs(UnmanagedType.I1)]
-        [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool AddComponent(string strInstanceId, string strComponentTypeName);
+        [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool AddComponent(string strInstanceId, string strComponentTypeName, string strPreferredInstanceId, nint[] outInstanceId);
         [return: MarshalAs(UnmanagedType.I1)]
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool RemoveComponent(string strInstanceId);
         [return: MarshalAs(UnmanagedType.I1)]
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool InstantiatePrefab(string strFileId, string strParentInstanceId);
+
+        [return: MarshalAs(UnmanagedType.I1)]
+        [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool InstantiatePrefabFromYaml([MarshalAs(UnmanagedType.LPUTF8Str)] string strPrefabYaml, [MarshalAs(UnmanagedType.LPUTF8Str)] string strParentInstanceId);
         [return: MarshalAs(UnmanagedType.I1)]
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern bool SetEditorSelection(string strSelectionYaml);
         [DllImport(EngineLibrary, CharSet = CharSet.Ansi, CallingConvention = CallingConvention.Cdecl)] public static extern void ShowMainWindow([MarshalAs(UnmanagedType.I1)] bool bShow);
@@ -189,6 +192,7 @@ namespace SailorEditor.Services
         readonly object runLock = new();
         readonly SemaphoreSlim lifecycleGate = new(1, 1);
         readonly RingBufferedBatcher<ConsoleMessage> consoleMessages = new(MaxBufferedConsoleMessages);
+        readonly WorldSnapshotPublicationGate worldSnapshotPublication = new();
         EngineTypes editorTypes = new();
         int consoleDispatchScheduled = 0;
         int lifecycleState = (int)EngineLifecycleState.Stopped;
@@ -419,11 +423,20 @@ namespace SailorEditor.Services
 
         bool IsInteropRunningUnderLock() => State == EngineLifecycleState.Running;
 
-        bool InvokeRunningInterop(Func<bool> action)
+        bool InvokeRunningInterop(Func<bool> action, bool invalidateQueuedWorldSnapshots = false)
         {
             lock (interopLock)
             {
-                return IsInteropRunningUnderLock() && action();
+                if (!IsInteropRunningUnderLock() || !action())
+                    return false;
+
+                if (invalidateQueuedWorldSnapshots)
+                {
+                    var mutationSequence = worldSnapshotPublication.ReserveSequence();
+                    worldSnapshotPublication.TryAdvance(mutationSequence);
+                }
+
+                return true;
             }
         }
 
@@ -798,8 +811,15 @@ namespace SailorEditor.Services
                         -1);
                 }
 
-                string serializedWorld = SerializeWorld(generation, allowStarting: true);
-                QueueWorldUpdate(serializedWorld, generation);
+                string serializedWorld;
+                long serializedWorldSequence = 0;
+#if MACCATALYST
+                serializedWorld = await MainThread.InvokeOnMainThreadAsync(
+                    () => SerializeWorld(generation, out serializedWorldSequence, allowStarting: true));
+#else
+                serializedWorld = SerializeWorld(generation, out serializedWorldSequence, allowStarting: true);
+#endif
+                QueueWorldUpdate(serializedWorld, generation, serializedWorldSequence);
 
                 var bootstrapMessages = PullMessages(generation, allowStarting: true);
                 if (bootstrapMessages is not null)
@@ -843,7 +863,8 @@ namespace SailorEditor.Services
 
                 pollTasks.Add(RunPeriodicTaskAsync(() =>
                 {
-                    QueueWorldUpdate(SerializeWorld(generation), generation);
+                    var serializedWorld = SerializeWorld(generation, out var serializedWorldSequence);
+                    QueueWorldUpdate(serializedWorld, generation, serializedWorldSequence);
                     return Task.CompletedTask;
                 }, 1500, 0, pollCancellation.Token, generation));
 
@@ -1277,8 +1298,9 @@ namespace SailorEditor.Services
             return messages;
         }
 
-        string SerializeWorld(long generation, bool allowStarting = false)
+        string SerializeWorld(long generation, out long snapshotSequence, bool allowStarting = false)
         {
+            snapshotSequence = 0;
             if (!IsGenerationActive(generation, allowStarting))
             {
                 return string.Empty;
@@ -1292,6 +1314,7 @@ namespace SailorEditor.Services
                 {
                     return string.Empty;
                 }
+                snapshotSequence = worldSnapshotPublication.ReserveSequence();
                 numChars = EngineAppInterop.SerializeCurrentWorld(yamlNodeChar);
             }
 
@@ -1407,7 +1430,7 @@ namespace SailorEditor.Services
             return identity;
         }
 
-        void QueueWorldUpdate(string serializedWorld, long generation)
+        void QueueWorldUpdate(string serializedWorld, long generation, long snapshotSequence)
         {
             if (string.IsNullOrEmpty(serializedWorld) || !IsGenerationActive(generation, allowStarting: true))
             {
@@ -1416,11 +1439,25 @@ namespace SailorEditor.Services
 
             MainThread.BeginInvokeOnMainThread(() =>
             {
-                if (IsGenerationActive(generation, allowStarting: true))
-                {
-                    OnUpdateCurrentWorldAction?.Invoke(serializedWorld);
-                }
+                PublishWorldUpdate(serializedWorld, generation, snapshotSequence, allowStarting: true);
             });
+        }
+
+        void PublishWorldUpdate(
+            string serializedWorld,
+            long generation,
+            long snapshotSequence,
+            bool allowStarting = false)
+        {
+            if (string.IsNullOrEmpty(serializedWorld) ||
+                !IsGenerationActive(generation, allowStarting) ||
+                !worldSnapshotPublication.TryAdvance(snapshotSequence))
+            {
+                return;
+            }
+
+            if (IsGenerationActive(generation, allowStarting))
+                OnUpdateCurrentWorldAction?.Invoke(serializedWorld);
         }
 
         static bool TryParseEditorTypes(
@@ -1460,7 +1497,9 @@ namespace SailorEditor.Services
         public bool CommitChanges(InstanceId id, string yamlChanges)
         {
             var stringId = id.Value.ToString();
-            return InvokeRunningInterop(() => EngineAppInterop.UpdateObject(stringId, yamlChanges));
+            return InvokeRunningInterop(
+                () => EngineAppInterop.UpdateObject(stringId, yamlChanges),
+                invalidateQueuedWorldSnapshots: true);
         }
 
         public bool RequestAssetReload()
@@ -1472,19 +1511,49 @@ namespace SailorEditor.Services
         {
             using var perfScope = EditorPerf.Scope("EngineService.RefreshCurrentWorld");
             var generation = Volatile.Read(ref engineGeneration);
-            string serializedWorld = SerializeWorld(generation);
+            string serializedWorld = SerializeWorld(generation, out var serializedWorldSequence);
             if (!string.IsNullOrEmpty(serializedWorld))
             {
                 if (MainThread.IsMainThread)
                 {
-                    if (IsGenerationActive(generation))
-                    {
-                        OnUpdateCurrentWorldAction?.Invoke(serializedWorld);
-                    }
+                    PublishWorldUpdate(serializedWorld, generation, serializedWorldSequence);
                 }
                 else
                 {
-                    QueueWorldUpdate(serializedWorld, generation);
+                    MainThread.InvokeOnMainThreadAsync(() =>
+                    {
+                        PublishWorldUpdate(serializedWorld, generation, serializedWorldSequence);
+                    }).GetAwaiter().GetResult();
+                }
+            }
+        }
+
+        bool InvokeCreationInterop(Func<nint[], bool> interop, out InstanceId createdInstanceId)
+        {
+            createdInstanceId = null;
+            nint[] instanceIdPtr = new nint[1];
+            try
+            {
+                if (!InvokeRunningInterop(() => interop(instanceIdPtr)) || instanceIdPtr[0] == IntPtr.Zero)
+                {
+                    return false;
+                }
+
+                var value = Marshal.PtrToStringAnsi(instanceIdPtr[0]);
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    return false;
+                }
+
+                createdInstanceId = new InstanceId(value);
+                RefreshCurrentWorld();
+                return true;
+            }
+            finally
+            {
+                if (instanceIdPtr[0] != IntPtr.Zero)
+                {
+                    EngineAppInterop.FreeInteropString(instanceIdPtr[0]);
                 }
             }
         }
@@ -1504,16 +1573,15 @@ namespace SailorEditor.Services
         }
 
         public bool CreateGameObject(InstanceId parentId = null)
+            => CreateGameObject(parentId, null, out _);
+
+        public bool CreateGameObject(InstanceId parentId, InstanceId preferredInstanceId, out InstanceId createdInstanceId)
         {
             var stringParentId = parentId?.Value ?? string.Empty;
-            bool result = InvokeRunningInterop(() => EngineAppInterop.CreateGameObject(stringParentId));
-
-            if (result)
-            {
-                RefreshCurrentWorld();
-            }
-
-            return result;
+            var stringPreferredInstanceId = preferredInstanceId?.Value ?? string.Empty;
+            return InvokeCreationInterop(
+                output => EngineAppInterop.CreateGameObject(stringParentId, stringPreferredInstanceId, output),
+                out createdInstanceId);
         }
 
         public bool DestroyObject(InstanceId instanceId)
@@ -1543,16 +1611,23 @@ namespace SailorEditor.Services
         }
 
         public bool AddComponent(InstanceId instanceId, string componentTypeName)
+            => AddComponent(instanceId, componentTypeName, null, out _);
+
+        public bool AddComponent(
+            InstanceId instanceId,
+            string componentTypeName,
+            InstanceId preferredInstanceId,
+            out InstanceId createdInstanceId)
         {
             var stringId = instanceId?.Value ?? string.Empty;
-            bool result = InvokeRunningInterop(() => EngineAppInterop.AddComponent(stringId, componentTypeName ?? string.Empty));
-
-            if (result)
-            {
-                RefreshCurrentWorld();
-            }
-
-            return result;
+            var stringPreferredInstanceId = preferredInstanceId?.Value ?? string.Empty;
+            return InvokeCreationInterop(
+                output => EngineAppInterop.AddComponent(
+                    stringId,
+                    componentTypeName ?? string.Empty,
+                    stringPreferredInstanceId,
+                    output),
+                out createdInstanceId);
         }
 
         public bool RemoveComponent(InstanceId instanceId)
@@ -1573,6 +1648,24 @@ namespace SailorEditor.Services
             var stringFileId = prefabId?.Value ?? string.Empty;
             var stringParentId = parentId?.Value ?? string.Empty;
             bool result = InvokeRunningInterop(() => EngineAppInterop.InstantiatePrefab(stringFileId, stringParentId));
+
+            if (result)
+            {
+                RefreshCurrentWorld();
+            }
+
+            return result;
+        }
+
+        public bool InstantiatePrefabFromYaml(string prefabYaml, InstanceId parentId = null)
+        {
+            if (string.IsNullOrWhiteSpace(prefabYaml))
+            {
+                return false;
+            }
+
+            var stringParentId = parentId?.Value ?? string.Empty;
+            bool result = InvokeRunningInterop(() => EngineAppInterop.InstantiatePrefabFromYaml(prefabYaml, stringParentId));
 
             if (result)
             {

--- a/Editor/Services/WorkspaceActivationOperations.cs
+++ b/Editor/Services/WorkspaceActivationOperations.cs
@@ -21,6 +21,22 @@ internal sealed class WorkspaceActivationOperations(
         Reset(commandHistory.BeginWorkspaceChange, failures);
         Reset(selectionService.BeginWorkspaceChange, failures);
 
+        var commandExecutionsDrained = false;
+        try
+        {
+            // Teardown is irreversible. Once new commands are gated, old workspace
+            // executions must finish even when the activation request was cancelled.
+            await commandHistory.BeginWorkspaceChangeAsync(CancellationToken.None).ConfigureAwait(false);
+            commandExecutionsDrained = true;
+        }
+        catch (Exception ex)
+        {
+            failures.Add(ex);
+        }
+
+        if (!commandExecutionsDrained)
+            throw new AggregateException("Workspace command execution drain failed.", failures);
+
         var hadActiveRuntime = engineService.State is
             EngineLifecycleState.Starting or
             EngineLifecycleState.Running or
@@ -51,7 +67,9 @@ internal sealed class WorkspaceActivationOperations(
         return MainThread.InvokeOnMainThreadAsync(() =>
         {
             var failures = new List<Exception>();
-            Reset(commandHistory.ResetForWorkspaceChange, failures);
+            // This guard must succeed before any workspace-owned runtime or
+            // projection state is cleared.
+            commandHistory.ResetForWorkspaceChange();
             Reset(selectionService.ResetForWorkspaceChange, failures);
             Reset(worldService.ResetForWorkspaceChange, failures);
             Reset(engineService.ResetForWorkspaceChange, failures);

--- a/Editor/Services/WorldSnapshotPublicationGate.cs
+++ b/Editor/Services/WorldSnapshotPublicationGate.cs
@@ -1,0 +1,25 @@
+namespace SailorEditor.Services;
+
+internal sealed class WorldSnapshotPublicationGate
+{
+    long _nextSequence;
+    long _lastPublishedSequence;
+
+    public long ReserveSequence() => Interlocked.Increment(ref _nextSequence);
+
+    public bool TryAdvance(long sequence)
+    {
+        if (sequence <= 0)
+            return false;
+
+        while (true)
+        {
+            var lastPublished = Volatile.Read(ref _lastPublishedSequence);
+            if (sequence <= lastPublished)
+                return false;
+
+            if (Interlocked.CompareExchange(ref _lastPublishedSequence, sequence, lastPublished) == lastPublished)
+                return true;
+        }
+    }
+}

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -20,15 +20,19 @@ public partial class Component : ObservableObject, ICloneable, IInspectorEditabl
 {
     readonly InspectorAutoCommitController _autoCommit = new(
         propertyName => propertyName == nameof(IsDirty),
-        propertyName => false);
+        propertyName => propertyName == nameof(OverrideProperties));
 
     public Component()
     {
         PropertyChanged += (s, args) =>
         {
             var decision = _autoCommit.OnPropertyChanged(args.PropertyName);
-            if (decision.MarkDirty)
-                IsDirty = true;
+            if (!decision.MarkDirty)
+                return;
+
+            IsDirty = true;
+            if (decision.CommitNow)
+                CommitInspectorChanges();
         };
     }
 
@@ -38,21 +42,39 @@ public partial class Component : ObservableObject, ICloneable, IInspectorEditabl
             return false;
 
         var yamlComponent = EditorYaml.SerializeComponent(this);
+        var previousYaml = _lastCommittedYaml ?? yamlComponent;
+        if (string.Equals(previousYaml, yamlComponent, StringComparison.Ordinal))
+        {
+            IsDirty = false;
+            return false;
+        }
+
         var dispatcher = MauiProgram.GetService<ICommandDispatcher>();
         var contextProvider = MauiProgram.GetService<IActionContextProvider>();
-        var result = dispatcher.DispatchAsync(
-            new UpdateComponentCommand(this, _lastCommittedYaml ?? yamlComponent, yamlComponent, $"Edit {Typename?.Name}"),
-            contextProvider.GetCurrentContext(new CommandOrigin(CommandOriginKind.UI, nameof(CommitInspectorChanges))))
-            .GetAwaiter()
-            .GetResult();
+        IsDirty = false;
+
+        CommandResult result;
+        try
+        {
+            result = dispatcher.DispatchAsync(
+                new UpdateComponentCommand(this, previousYaml, yamlComponent, $"Edit {Typename?.Name}"),
+                contextProvider.GetCurrentContext(new CommandOrigin(CommandOriginKind.UI, nameof(CommitInspectorChanges))))
+                .GetAwaiter()
+                .GetResult();
+        }
+        catch
+        {
+            IsDirty = true;
+            throw;
+        }
 
         if (result.Succeeded)
         {
             _lastCommittedYaml = yamlComponent;
-            IsDirty = false;
             return true;
         }
 
+        IsDirty = true;
         return false;
     }
 

--- a/Editor/ViewModels/GameObject.cs
+++ b/Editor/ViewModels/GameObject.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
 using SailorEditor.Commands;
 using SailorEditor.Utility;
 using System.Xml.Linq;
@@ -28,14 +29,18 @@ public partial class GameObject : ObservableObject, ICloneable, IInspectorEditab
 
     public GameObject()
     {
-        AddNewComponent = new Command(async () => await AddComponentFromInspectorAsync());
+        AddNewComponent = new AsyncRelayCommand(AddComponentFromInspectorAsync);
         ClearComponentsCommand = new Command(ClearComponentsFromInspector);
 
         PropertyChanged += (s, args) =>
         {
             var decision = _autoCommit.OnPropertyChanged(args.PropertyName);
-            if (decision.MarkDirty)
-                IsDirty = true;
+            if (!decision.MarkDirty)
+                return;
+
+            IsDirty = true;
+            if (decision.CommitNow)
+                CommitInspectorChanges();
         };
     }
 
@@ -45,21 +50,39 @@ public partial class GameObject : ObservableObject, ICloneable, IInspectorEditab
             return false;
 
         var yamlGameObject = EditorYaml.SerializeGameObject(this);
+        var previousYaml = _lastCommittedYaml ?? yamlGameObject;
+        if (string.Equals(previousYaml, yamlGameObject, StringComparison.Ordinal))
+        {
+            IsDirty = false;
+            return false;
+        }
+
         var dispatcher = MauiProgram.GetService<ICommandDispatcher>();
         var contextProvider = MauiProgram.GetService<IActionContextProvider>();
-        var result = dispatcher.DispatchAsync(
-            new UpdateGameObjectCommand(this, _lastCommittedYaml ?? yamlGameObject, yamlGameObject, $"Edit {Name}"),
-            contextProvider.GetCurrentContext(new CommandOrigin(CommandOriginKind.UI, nameof(CommitInspectorChanges))))
-            .GetAwaiter()
-            .GetResult();
+        IsDirty = false;
+
+        CommandResult result;
+        try
+        {
+            result = dispatcher.DispatchAsync(
+                new UpdateGameObjectCommand(this, previousYaml, yamlGameObject, $"Edit {Name}"),
+                contextProvider.GetCurrentContext(new CommandOrigin(CommandOriginKind.UI, nameof(CommitInspectorChanges))))
+                .GetAwaiter()
+                .GetResult();
+        }
+        catch
+        {
+            IsDirty = true;
+            throw;
+        }
 
         if (result.Succeeded)
         {
             _lastCommittedYaml = yamlGameObject;
-            IsDirty = false;
             return true;
         }
 
+        IsDirty = true;
         return false;
     }
 
@@ -124,20 +147,17 @@ public partial class GameObject : ObservableObject, ICloneable, IInspectorEditab
 
         if (!string.IsNullOrWhiteSpace(componentTypeName))
         {
-            await Task.Run(() => MauiProgram.GetService<WorldService>().AddComponent(this, componentTypeName));
+            MauiProgram.GetService<WorldService>().AddComponent(this, componentTypeName);
         }
     }
 
-    public async void ClearComponentsFromInspector()
+    public void ClearComponentsFromInspector()
     {
         var components = Components.ToList();
-        await Task.Run(() =>
+        foreach (var component in components)
         {
-            foreach (var component in components)
-            {
-                MauiProgram.GetService<WorldService>().RemoveComponent(component);
-            }
-        });
+            MauiProgram.GetService<WorldService>().RemoveComponent(component);
+        }
     }
 
     [ObservableProperty]

--- a/Editor/Workflow/InspectorAutoCommitController.cs
+++ b/Editor/Workflow/InspectorAutoCommitController.cs
@@ -1,19 +1,21 @@
 namespace SailorEditor.Workflow;
 
-public readonly record struct InspectorAutoCommitDecision(bool MarkDirty)
+public readonly record struct InspectorAutoCommitDecision(bool MarkDirty, bool CommitNow)
 {
-    public static InspectorAutoCommitDecision None { get; } = new(false);
+    public static InspectorAutoCommitDecision None { get; } = new(false, false);
 }
 
 public sealed class InspectorAutoCommitController
 {
     readonly Func<string?, bool> _shouldIgnoreProperty;
+    readonly Func<string?, bool> _shouldCommitProperty;
 
     bool _isInitialized;
 
     public InspectorAutoCommitController(Func<string?, bool> shouldIgnoreProperty, Func<string?, bool> shouldCommitProperty)
     {
         _shouldIgnoreProperty = shouldIgnoreProperty;
+        _shouldCommitProperty = shouldCommitProperty;
     }
 
     public InspectorAutoCommitDecision OnPropertyChanged(string? propertyName)
@@ -21,7 +23,9 @@ public sealed class InspectorAutoCommitController
         if (!_isInitialized || _shouldIgnoreProperty(propertyName))
             return InspectorAutoCommitDecision.None;
 
-        return new InspectorAutoCommitDecision(MarkDirty: true);
+        return new InspectorAutoCommitDecision(
+            MarkDirty: true,
+            CommitNow: _shouldCommitProperty(propertyName));
     }
 
     public bool ShouldCommitPendingChanges(bool isDirty) => _isInitialized && isDirty;

--- a/Lib/CMakeLists.txt
+++ b/Lib/CMakeLists.txt
@@ -177,7 +177,6 @@ target_compile_definitions(SailorLib PRIVATE SAILOR_ENGINE_VERSION="${PROJECT_VE
 
 if(SAILOR_BUILD_TESTS)
   target_compile_definitions(SailorLib PUBLIC $<BUILD_INTERFACE:SAILOR_SHADER_CACHE_TEST_HOOKS>)
-  target_compile_definitions(SailorLib PRIVATE SAILOR_ASSET_REGISTRY_TEST_HOOKS)
 endif()
 
 target_compile_definitions(SailorLib INTERFACE _SAILOR_IMPORT_)

--- a/Lib/CMakeLists.txt
+++ b/Lib/CMakeLists.txt
@@ -177,6 +177,7 @@ target_compile_definitions(SailorLib PRIVATE SAILOR_ENGINE_VERSION="${PROJECT_VE
 
 if(SAILOR_BUILD_TESTS)
   target_compile_definitions(SailorLib PUBLIC $<BUILD_INTERFACE:SAILOR_SHADER_CACHE_TEST_HOOKS>)
+  target_compile_definitions(SailorLib PRIVATE SAILOR_ASSET_REGISTRY_TEST_HOOKS)
 endif()
 
 target_compile_definitions(SailorLib INTERFACE _SAILOR_IMPORT_)

--- a/Lib/DllMain.cpp
+++ b/Lib/DllMain.cpp
@@ -145,10 +145,10 @@ extern "C"
 		return Sailor::App::ReparentEditorObject(strInstanceId, strParentInstanceId, bKeepWorldTransform);
 	}
 
-	SAILOR_API bool CreateGameObject(char* strParentInstanceId)
+	SAILOR_API bool CreateGameObject(char* strParentInstanceId, char* strPreferredInstanceId, char** outInstanceId)
 	{
 		SAILOR_PROFILE_FUNCTION();
-		return Sailor::App::CreateEditorGameObject(strParentInstanceId);
+		return Sailor::App::CreateEditorGameObject(strParentInstanceId, strPreferredInstanceId, outInstanceId);
 	}
 
 	SAILOR_API bool DestroyObject(char* strInstanceId)
@@ -163,10 +163,10 @@ extern "C"
 		return Sailor::App::ResetEditorComponentToDefaults(strInstanceId);
 	}
 
-	SAILOR_API bool AddComponent(char* strInstanceId, char* strComponentTypeName)
+	SAILOR_API bool AddComponent(char* strInstanceId, char* strComponentTypeName, char* strPreferredInstanceId, char** outInstanceId)
 	{
 		SAILOR_PROFILE_FUNCTION();
-		return Sailor::App::AddEditorComponent(strInstanceId, strComponentTypeName);
+		return Sailor::App::AddEditorComponent(strInstanceId, strComponentTypeName, strPreferredInstanceId, outInstanceId);
 	}
 
 	SAILOR_API bool RemoveComponent(char* strInstanceId)
@@ -179,6 +179,12 @@ extern "C"
 	{
 		SAILOR_PROFILE_FUNCTION();
 		return Sailor::App::InstantiateEditorPrefab(strFileId, strParentInstanceId);
+	}
+
+	SAILOR_API bool InstantiatePrefabFromYaml(char* strPrefabYaml, char* strParentInstanceId)
+	{
+		SAILOR_PROFILE_FUNCTION();
+		return Sailor::App::InstantiateEditorPrefabFromYaml(strPrefabYaml, strParentInstanceId);
 	}
 
 	SAILOR_API bool SetEditorSelection(char* strSelectionYaml)

--- a/Lib/DllMain.cpp
+++ b/Lib/DllMain.cpp
@@ -31,6 +31,11 @@ extern "C"
 		Sailor::App::Shutdown();
 	}
 
+	SAILOR_API bool RequestAssetReload()
+	{
+		return Sailor::App::RequestAssetReload();
+	}
+
 	SAILOR_API int32_t GetExitCode()
 	{
 		return Sailor::App::GetExitCode();

--- a/Lib/InteropExports.cpp
+++ b/Lib/InteropExports.cpp
@@ -129,9 +129,9 @@ extern "C"
 		return Sailor::App::ReparentEditorObject(strInstanceId, strParentInstanceId, bKeepWorldTransform);
 	}
 
-	SAILOR_API bool CreateGameObject(char* strParentInstanceId)
+	SAILOR_API bool CreateGameObject(char* strParentInstanceId, char* strPreferredInstanceId, char** outInstanceId)
 	{
-		return Sailor::App::CreateEditorGameObject(strParentInstanceId);
+		return Sailor::App::CreateEditorGameObject(strParentInstanceId, strPreferredInstanceId, outInstanceId);
 	}
 
 	SAILOR_API bool DestroyObject(char* strInstanceId)
@@ -144,9 +144,9 @@ extern "C"
 		return Sailor::App::ResetEditorComponentToDefaults(strInstanceId);
 	}
 
-	SAILOR_API bool AddComponent(char* strInstanceId, char* strComponentTypeName)
+	SAILOR_API bool AddComponent(char* strInstanceId, char* strComponentTypeName, char* strPreferredInstanceId, char** outInstanceId)
 	{
-		return Sailor::App::AddEditorComponent(strInstanceId, strComponentTypeName);
+		return Sailor::App::AddEditorComponent(strInstanceId, strComponentTypeName, strPreferredInstanceId, outInstanceId);
 	}
 
 	SAILOR_API bool RemoveComponent(char* strInstanceId)
@@ -157,6 +157,11 @@ extern "C"
 	SAILOR_API bool InstantiatePrefab(char* strFileId, char* strParentInstanceId)
 	{
 		return Sailor::App::InstantiateEditorPrefab(strFileId, strParentInstanceId);
+	}
+
+	SAILOR_API bool InstantiatePrefabFromYaml(char* strPrefabYaml, char* strParentInstanceId)
+	{
+		return Sailor::App::InstantiateEditorPrefabFromYaml(strPrefabYaml, strParentInstanceId);
 	}
 
 	SAILOR_API bool SetEditorSelection(char* strSelectionYaml)

--- a/Lib/InteropExports.cpp
+++ b/Lib/InteropExports.cpp
@@ -29,6 +29,11 @@ extern "C"
 		Sailor::App::Shutdown();
 	}
 
+	SAILOR_API bool RequestAssetReload()
+	{
+		return Sailor::App::RequestAssetReload();
+	}
+
 	SAILOR_API int32_t GetExitCode()
 	{
 		return Sailor::App::GetExitCode();

--- a/Runtime/AssetRegistry/AssetCache.cpp
+++ b/Runtime/AssetRegistry/AssetCache.cpp
@@ -11,7 +11,6 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
-#include <limits>
 #include <sstream>
 #include <unordered_set>
 
@@ -20,10 +19,8 @@ using namespace Sailor;
 namespace
 {
 	constexpr const char* AssetCacheKind = "asset-cache";
-	constexpr const char* AssetCacheProducer = "asset-cache-v2";
-	constexpr uint32_t AssetCachePayloadVersion = 2;
-	constexpr AssetCache::FileTimestamp MissingFileTimestamp =
-		std::numeric_limits<AssetCache::FileTimestamp>::min();
+	constexpr const char* AssetCacheProducer = "asset-cache-v1";
+	constexpr uint32_t AssetCachePayloadVersion = 1;
 
 	std::string NormalizeSourcePath(const std::string& sourcePath)
 	{
@@ -166,25 +163,13 @@ std::string AssetCache::GetAssetCacheFilepath()
 	return (std::filesystem::path(AssetRegistry::GetCacheFolder()) / "AssetCache.yaml").string();
 }
 
-AssetCache::FileTimestamp AssetCache::GetFileTimestamp(const std::string& path) noexcept
-{
-	std::error_code error;
-	const std::filesystem::file_time_type writeTime = std::filesystem::last_write_time(path, error);
-	if (error)
-	{
-		return MissingFileTimestamp;
-	}
-
-	return static_cast<FileTimestamp>(writeTime.time_since_epoch().count());
-}
-
 YAML::Node AssetCache::AssetCacheData::Entry::Serialize() const
 {
 	YAML::Node result(YAML::NodeType::Map);
 	result["fileId"] = m_fileId;
-	result["sourceTimestamp"] = m_sourceTimestamp;
+	result["assetImportTime"] = m_assetImportTime;
 	result["sourcePath"] = m_sourcePath;
-	result["metadataTimestamp"] = m_metadataTimestamp;
+	result["metadataLoadTime"] = m_metadataLoadTime;
 	result["metadataPath"] = m_metadataPath;
 	return result;
 }
@@ -192,9 +177,9 @@ YAML::Node AssetCache::AssetCacheData::Entry::Serialize() const
 void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 {
 	m_fileId = FileId();
-	m_sourceTimestamp = 0;
+	m_assetImportTime = 0;
 	m_sourcePath.clear();
-	m_metadataTimestamp = 0;
+	m_metadataLoadTime = 0;
 	m_metadataPath.clear();
 	std::string yamlDiagnostic;
 	if (!Sailor::External::GuardYamlExceptions(
@@ -206,39 +191,40 @@ void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 			}
 
 			const YAML::Node fileId = inData["fileId"];
-			const YAML::Node sourceTimestamp = inData["sourceTimestamp"];
+			const YAML::Node assetImportTime = inData["assetImportTime"];
 			const YAML::Node sourcePath = inData["sourcePath"];
-			const YAML::Node metadataTimestamp = inData["metadataTimestamp"];
+			const YAML::Node metadataLoadTime = inData["metadataLoadTime"];
 			const YAML::Node metadataPath = inData["metadataPath"];
-			if (!fileId || !sourceTimestamp || !sourcePath || !metadataTimestamp || !metadataPath ||
-				!fileId.IsScalar() || !sourceTimestamp.IsScalar() || !sourcePath.IsScalar() ||
-				!metadataTimestamp.IsScalar() || !metadataPath.IsScalar())
+			if (!fileId || !assetImportTime || !sourcePath ||
+				!metadataLoadTime || !metadataPath ||
+				!fileId.IsScalar() || !assetImportTime.IsScalar() ||
+				!sourcePath.IsScalar() || !metadataLoadTime.IsScalar() ||
+				!metadataPath.IsScalar())
 			{
 				return;
 			}
 
 			m_fileId.Deserialize(fileId);
-			m_sourceTimestamp = sourceTimestamp.as<FileTimestamp>();
+			m_assetImportTime = assetImportTime.as<std::time_t>();
 			m_sourcePath = NormalizeSourcePath(sourcePath.as<std::string>());
-			m_metadataTimestamp = metadataTimestamp.as<FileTimestamp>();
+			m_metadataLoadTime = metadataLoadTime.as<std::time_t>();
 			m_metadataPath = NormalizeSourcePath(metadataPath.as<std::string>());
 			if (m_sourcePath.empty() || m_metadataPath.empty() || !m_fileId ||
-				m_sourceTimestamp == MissingFileTimestamp ||
-				m_metadataTimestamp == MissingFileTimestamp)
+				m_assetImportTime <= 0 || m_metadataLoadTime <= 0)
 			{
 				m_fileId = FileId();
-				m_sourceTimestamp = 0;
+				m_assetImportTime = 0;
 				m_sourcePath.clear();
-				m_metadataTimestamp = 0;
+				m_metadataLoadTime = 0;
 				m_metadataPath.clear();
 			}
 		},
 		yamlDiagnostic))
 	{
 		m_fileId = FileId();
-		m_sourceTimestamp = 0;
+		m_assetImportTime = 0;
 		m_sourcePath.clear();
-		m_metadataTimestamp = 0;
+		m_metadataLoadTime = 0;
 		m_metadataPath.clear();
 	}
 }
@@ -320,26 +306,27 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 		if (!entryNode.IsMap() || entryNode.size() != 5)
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId +
-				"' must contain exactly fileId, sourceTimestamp, sourcePath, "
-				"metadataTimestamp, and metadataPath.";
+				"' must contain exactly fileId, assetImportTime, sourcePath, "
+				"metadataLoadTime, and metadataPath.";
 			return false;
 		}
 
 		YAML::Node entryFileId;
-		YAML::Node sourceTimestamp;
+		YAML::Node assetImportTime;
 		YAML::Node sourcePath;
-		YAML::Node metadataTimestamp;
+		YAML::Node metadataLoadTime;
 		YAML::Node metadataPath;
 		if (!ReadRequiredField(entryNode, "fileId", entryFileId, outDiagnostic) ||
-			!ReadRequiredField(entryNode, "sourceTimestamp", sourceTimestamp, outDiagnostic) ||
+			!ReadRequiredField(entryNode, "assetImportTime", assetImportTime, outDiagnostic) ||
 			!ReadRequiredField(entryNode, "sourcePath", sourcePath, outDiagnostic) ||
-			!ReadRequiredField(entryNode, "metadataTimestamp", metadataTimestamp, outDiagnostic) ||
+			!ReadRequiredField(entryNode, "metadataLoadTime", metadataLoadTime, outDiagnostic) ||
 			!ReadRequiredField(entryNode, "metadataPath", metadataPath, outDiagnostic))
 		{
 			return false;
 		}
-		if (!entryFileId.IsScalar() || !sourceTimestamp.IsScalar() || !sourcePath.IsScalar() ||
-			!metadataTimestamp.IsScalar() || !metadataPath.IsScalar())
+		if (!entryFileId.IsScalar() || !assetImportTime.IsScalar() ||
+			!sourcePath.IsScalar() || !metadataLoadTime.IsScalar() ||
+			!metadataPath.IsScalar())
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId + "' contains a non-scalar field.";
 			return false;
@@ -347,7 +334,7 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 
 		AssetCacheData::Entry entry;
 		entry.m_fileId = entryFileId.as<FileId>();
-		entry.m_sourceTimestamp = sourceTimestamp.as<FileTimestamp>();
+		entry.m_assetImportTime = assetImportTime.as<std::time_t>();
 		const std::string serializedSourcePath = sourcePath.as<std::string>();
 		if (serializedSourcePath.empty())
 		{
@@ -355,7 +342,7 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 			return false;
 		}
 		entry.m_sourcePath = NormalizeSourcePath(serializedSourcePath);
-		entry.m_metadataTimestamp = metadataTimestamp.as<FileTimestamp>();
+		entry.m_metadataLoadTime = metadataLoadTime.as<std::time_t>();
 		const std::string serializedMetadataPath = metadataPath.as<std::string>();
 		if (serializedMetadataPath.empty())
 		{
@@ -378,13 +365,11 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 			outDiagnostic = "Asset cache entry '" + serializedFileId + "' has an empty metadataPath.";
 			return false;
 		}
-		if (entry.m_sourceTimestamp == MissingFileTimestamp ||
-			entry.m_metadataTimestamp == MissingFileTimestamp)
+		if (entry.m_assetImportTime <= 0 || entry.m_metadataLoadTime <= 0)
 		{
-			outDiagnostic = "Asset cache entry '" + serializedFileId + "' contains a missing-file timestamp.";
+			outDiagnostic = "Asset cache entry '" + serializedFileId + "' contains an invalid processing time.";
 			return false;
 		}
-
 		candidate.m_data.Insert(fileId, std::move(entry));
 	}
 
@@ -438,6 +423,18 @@ void AssetCache::SaveCache(bool bForcely)
 	SAILOR_PROFILE_FUNCTION();
 
 	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	std::error_code createCacheFolderError;
+	std::filesystem::create_directories(
+		AssetRegistry::GetCacheFolder(),
+		createCacheFolderError);
+	std::error_code cacheFileError;
+	const bool bCacheFileExists = std::filesystem::is_regular_file(
+		GetAssetCacheFilepath(),
+		cacheFileError);
+	if (!bCacheFileExists)
+	{
+		m_bIsDirty = true;
+	}
 	if (!ShouldWriteCacheFile(bForcely, m_bIsDirty, m_bPreserveStorageAfterLoadFailure))
 	{
 		return;
@@ -608,9 +605,10 @@ bool AssetCache::Update(const AssetInfo* info)
 
 	const std::string sourcePath = info->GetAssetFilepath();
 	const std::string metadataPath = info->GetMetaFilepath();
-	const FileTimestamp sourceTimestamp = GetFileTimestamp(sourcePath);
-	const FileTimestamp metadataTimestamp = GetFileTimestamp(metadataPath);
-	if (sourceTimestamp == MissingFileTimestamp || metadataTimestamp == MissingFileTimestamp)
+	std::error_code sourceError;
+	std::error_code metadataError;
+	if (!std::filesystem::is_regular_file(sourcePath, sourceError) || sourceError ||
+		!std::filesystem::is_regular_file(metadataPath, metadataError) || metadataError)
 	{
 		Remove(info->GetFileId());
 		return false;
@@ -618,23 +616,23 @@ bool AssetCache::Update(const AssetInfo* info)
 
 	return Update(
 		info->GetFileId(),
+		info->GetAssetImportTime(),
 		sourcePath,
-		sourceTimestamp,
-		metadataPath,
-		metadataTimestamp);
+		info->m_metaLoadTime,
+		metadataPath);
 }
 
 bool AssetCache::Update(
 	const FileId& id,
+	std::time_t assetImportTime,
 	const std::string& sourcePath,
-	FileTimestamp sourceTimestamp,
-	const std::string& metadataPath,
-	FileTimestamp metadataTimestamp)
+	std::time_t metadataLoadTime,
+	const std::string& metadataPath)
 {
 	std::string normalizedSourcePath = NormalizeSourcePath(sourcePath);
 	std::string normalizedMetadataPath = NormalizeSourcePath(metadataPath);
-	if (!id || normalizedSourcePath.empty() || normalizedMetadataPath.empty() ||
-		sourceTimestamp == MissingFileTimestamp || metadataTimestamp == MissingFileTimestamp)
+	if (!id || assetImportTime <= 0 || metadataLoadTime <= 0 ||
+		normalizedSourcePath.empty() || normalizedMetadataPath.empty())
 	{
 		return false;
 	}
@@ -653,16 +651,63 @@ bool AssetCache::Update(
 	} unlockGuard{ m_cache.m_data, id };
 
 	const bool bChanged = entry.m_fileId != id ||
-		entry.m_sourceTimestamp != sourceTimestamp ||
+		entry.m_assetImportTime != assetImportTime ||
 		entry.m_sourcePath != normalizedSourcePath ||
-		entry.m_metadataTimestamp != metadataTimestamp ||
+		entry.m_metadataLoadTime != metadataLoadTime ||
 		entry.m_metadataPath != normalizedMetadataPath;
 	m_bIsDirty |= bChanged;
 	entry.m_fileId = id;
-	entry.m_sourceTimestamp = sourceTimestamp;
+	entry.m_assetImportTime = assetImportTime;
 	entry.m_sourcePath = std::move(normalizedSourcePath);
-	entry.m_metadataTimestamp = metadataTimestamp;
+	entry.m_metadataLoadTime = metadataLoadTime;
 	entry.m_metadataPath = std::move(normalizedMetadataPath);
+	return bChanged;
+}
+
+bool AssetCache::RestoreProcessingTimes(AssetInfo* info) const
+{
+	if (info == nullptr || !info->GetFileId())
+	{
+		return false;
+	}
+
+	const std::string sourcePath = NormalizeSourcePath(info->GetAssetFilepath());
+	const std::string metadataPath = NormalizeSourcePath(info->GetMetaFilepath());
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	if (!m_cache.m_data.ContainsKey(info->GetFileId()))
+	{
+		return false;
+	}
+
+	const AssetCacheData::Entry entry = m_cache.m_data[info->GetFileId()];
+	if (entry.m_sourcePath != sourcePath || entry.m_metadataPath != metadataPath)
+	{
+		return false;
+	}
+
+	info->m_assetImportTime = entry.m_assetImportTime;
+	info->m_metaLoadTime = entry.m_metadataLoadTime;
+	return true;
+}
+
+bool AssetCache::Prune(const TSet<FileId>& liveAssetIds)
+{
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	TVector<FileId> staleAssetIds;
+	for (const auto& cachedAsset : m_cache.m_data)
+	{
+		if (!liveAssetIds.Contains(cachedAsset.m_first))
+		{
+			staleAssetIds.Add(cachedAsset.m_first);
+		}
+	}
+
+	bool bChanged = false;
+	for (const FileId& staleAssetId : staleAssetIds)
+	{
+		bChanged |= m_cache.m_data.Remove(staleAssetId);
+	}
+	m_bIsDirty |= bChanged;
 	return bChanged;
 }
 
@@ -682,9 +727,10 @@ bool AssetCache::IsExpired(const AssetInfo* info) const
 	const FileId& fileId = info->GetFileId();
 	const std::string sourcePath = NormalizeSourcePath(info->GetAssetFilepath());
 	const std::string metadataPath = NormalizeSourcePath(info->GetMetaFilepath());
-	const FileTimestamp sourceTimestamp = GetFileTimestamp(sourcePath);
-	const FileTimestamp metadataTimestamp = GetFileTimestamp(metadataPath);
-	if (sourceTimestamp == MissingFileTimestamp || metadataTimestamp == MissingFileTimestamp)
+	std::error_code sourceError;
+	std::error_code metadataError;
+	if (!std::filesystem::is_regular_file(sourcePath, sourceError) || sourceError ||
+		!std::filesystem::is_regular_file(metadataPath, metadataError) || metadataError)
 	{
 		return true;
 	}
@@ -697,7 +743,7 @@ bool AssetCache::IsExpired(const AssetInfo* info) const
 
 	const AssetCacheData::Entry entry = m_cache.m_data[fileId];
 	return entry.m_sourcePath != sourcePath ||
-		entry.m_sourceTimestamp != sourceTimestamp ||
+		entry.m_assetImportTime < info->GetAssetLastModificationTime() ||
 		entry.m_metadataPath != metadataPath ||
-		entry.m_metadataTimestamp != metadataTimestamp;
+		entry.m_metadataLoadTime < info->GetMetaLastModificationTime();
 }

--- a/Runtime/AssetRegistry/AssetCache.cpp
+++ b/Runtime/AssetRegistry/AssetCache.cpp
@@ -169,8 +169,6 @@ YAML::Node AssetCache::AssetCacheData::Entry::Serialize() const
 	result["fileId"] = m_fileId;
 	result["assetImportTime"] = m_assetImportTime;
 	result["sourcePath"] = m_sourcePath;
-	result["metadataLoadTime"] = m_metadataLoadTime;
-	result["metadataPath"] = m_metadataPath;
 	return result;
 }
 
@@ -179,13 +177,11 @@ void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 	m_fileId = FileId();
 	m_assetImportTime = 0;
 	m_sourcePath.clear();
-	m_metadataLoadTime = 0;
-	m_metadataPath.clear();
 	std::string yamlDiagnostic;
 	if (!Sailor::External::GuardYamlExceptions(
 		[&]()
 		{
-			if (!inData.IsMap() || inData.size() != 5)
+			if (!inData.IsMap() || inData.size() != 3)
 			{
 				return;
 			}
@@ -193,13 +189,8 @@ void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 			const YAML::Node fileId = inData["fileId"];
 			const YAML::Node assetImportTime = inData["assetImportTime"];
 			const YAML::Node sourcePath = inData["sourcePath"];
-			const YAML::Node metadataLoadTime = inData["metadataLoadTime"];
-			const YAML::Node metadataPath = inData["metadataPath"];
-			if (!fileId || !assetImportTime || !sourcePath ||
-				!metadataLoadTime || !metadataPath ||
-				!fileId.IsScalar() || !assetImportTime.IsScalar() ||
-				!sourcePath.IsScalar() || !metadataLoadTime.IsScalar() ||
-				!metadataPath.IsScalar())
+			if (!fileId || !assetImportTime || !sourcePath || !fileId.IsScalar() ||
+				!assetImportTime.IsScalar() || !sourcePath.IsScalar())
 			{
 				return;
 			}
@@ -207,16 +198,11 @@ void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 			m_fileId.Deserialize(fileId);
 			m_assetImportTime = assetImportTime.as<std::time_t>();
 			m_sourcePath = NormalizeSourcePath(sourcePath.as<std::string>());
-			m_metadataLoadTime = metadataLoadTime.as<std::time_t>();
-			m_metadataPath = NormalizeSourcePath(metadataPath.as<std::string>());
-			if (m_sourcePath.empty() || m_metadataPath.empty() || !m_fileId ||
-				m_assetImportTime <= 0 || m_metadataLoadTime <= 0)
+			if (m_sourcePath.empty() || !m_fileId || m_assetImportTime <= 0)
 			{
 				m_fileId = FileId();
 				m_assetImportTime = 0;
 				m_sourcePath.clear();
-				m_metadataLoadTime = 0;
-				m_metadataPath.clear();
 			}
 		},
 		yamlDiagnostic))
@@ -224,8 +210,6 @@ void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 		m_fileId = FileId();
 		m_assetImportTime = 0;
 		m_sourcePath.clear();
-		m_metadataLoadTime = 0;
-		m_metadataPath.clear();
 	}
 }
 
@@ -303,30 +287,23 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 		}
 
 		const YAML::Node entryNode = serializedEntry.second;
-		if (!entryNode.IsMap() || entryNode.size() != 5)
+		if (!entryNode.IsMap() || entryNode.size() != 3)
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId +
-				"' must contain exactly fileId, assetImportTime, sourcePath, "
-				"metadataLoadTime, and metadataPath.";
+				"' must contain exactly fileId, assetImportTime, and sourcePath.";
 			return false;
 		}
 
 		YAML::Node entryFileId;
 		YAML::Node assetImportTime;
 		YAML::Node sourcePath;
-		YAML::Node metadataLoadTime;
-		YAML::Node metadataPath;
 		if (!ReadRequiredField(entryNode, "fileId", entryFileId, outDiagnostic) ||
 			!ReadRequiredField(entryNode, "assetImportTime", assetImportTime, outDiagnostic) ||
-			!ReadRequiredField(entryNode, "sourcePath", sourcePath, outDiagnostic) ||
-			!ReadRequiredField(entryNode, "metadataLoadTime", metadataLoadTime, outDiagnostic) ||
-			!ReadRequiredField(entryNode, "metadataPath", metadataPath, outDiagnostic))
+			!ReadRequiredField(entryNode, "sourcePath", sourcePath, outDiagnostic))
 		{
 			return false;
 		}
-		if (!entryFileId.IsScalar() || !assetImportTime.IsScalar() ||
-			!sourcePath.IsScalar() || !metadataLoadTime.IsScalar() ||
-			!metadataPath.IsScalar())
+		if (!entryFileId.IsScalar() || !assetImportTime.IsScalar() || !sourcePath.IsScalar())
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId + "' contains a non-scalar field.";
 			return false;
@@ -342,14 +319,6 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 			return false;
 		}
 		entry.m_sourcePath = NormalizeSourcePath(serializedSourcePath);
-		entry.m_metadataLoadTime = metadataLoadTime.as<std::time_t>();
-		const std::string serializedMetadataPath = metadataPath.as<std::string>();
-		if (serializedMetadataPath.empty())
-		{
-			outDiagnostic = "Asset cache entry '" + serializedFileId + "' has an empty metadataPath.";
-			return false;
-		}
-		entry.m_metadataPath = NormalizeSourcePath(serializedMetadataPath);
 		if (!entry.m_fileId || entry.m_fileId != fileId)
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId + "' has a mismatched fileId field.";
@@ -360,14 +329,9 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 			outDiagnostic = "Asset cache entry '" + serializedFileId + "' has an empty sourcePath.";
 			return false;
 		}
-		if (entry.m_metadataPath.empty())
+		if (entry.m_assetImportTime <= 0)
 		{
-			outDiagnostic = "Asset cache entry '" + serializedFileId + "' has an empty metadataPath.";
-			return false;
-		}
-		if (entry.m_assetImportTime <= 0 || entry.m_metadataLoadTime <= 0)
-		{
-			outDiagnostic = "Asset cache entry '" + serializedFileId + "' contains an invalid processing time.";
+			outDiagnostic = "Asset cache entry '" + serializedFileId + "' contains an invalid assetImportTime.";
 			return false;
 		}
 		candidate.m_data.Insert(fileId, std::move(entry));
@@ -604,11 +568,8 @@ bool AssetCache::Update(const AssetInfo* info)
 	}
 
 	const std::string sourcePath = info->GetAssetFilepath();
-	const std::string metadataPath = info->GetMetaFilepath();
 	std::error_code sourceError;
-	std::error_code metadataError;
-	if (!std::filesystem::is_regular_file(sourcePath, sourceError) || sourceError ||
-		!std::filesystem::is_regular_file(metadataPath, metadataError) || metadataError)
+	if (!std::filesystem::is_regular_file(sourcePath, sourceError) || sourceError)
 	{
 		Remove(info->GetFileId());
 		return false;
@@ -617,22 +578,16 @@ bool AssetCache::Update(const AssetInfo* info)
 	return Update(
 		info->GetFileId(),
 		info->GetAssetImportTime(),
-		sourcePath,
-		info->m_metaLoadTime,
-		metadataPath);
+		sourcePath);
 }
 
 bool AssetCache::Update(
 	const FileId& id,
 	std::time_t assetImportTime,
-	const std::string& sourcePath,
-	std::time_t metadataLoadTime,
-	const std::string& metadataPath)
+	const std::string& sourcePath)
 {
 	std::string normalizedSourcePath = NormalizeSourcePath(sourcePath);
-	std::string normalizedMetadataPath = NormalizeSourcePath(metadataPath);
-	if (!id || assetImportTime <= 0 || metadataLoadTime <= 0 ||
-		normalizedSourcePath.empty() || normalizedMetadataPath.empty())
+	if (!id || assetImportTime <= 0 || normalizedSourcePath.empty())
 	{
 		return false;
 	}
@@ -652,19 +607,15 @@ bool AssetCache::Update(
 
 	const bool bChanged = entry.m_fileId != id ||
 		entry.m_assetImportTime != assetImportTime ||
-		entry.m_sourcePath != normalizedSourcePath ||
-		entry.m_metadataLoadTime != metadataLoadTime ||
-		entry.m_metadataPath != normalizedMetadataPath;
+		entry.m_sourcePath != normalizedSourcePath;
 	m_bIsDirty |= bChanged;
 	entry.m_fileId = id;
 	entry.m_assetImportTime = assetImportTime;
 	entry.m_sourcePath = std::move(normalizedSourcePath);
-	entry.m_metadataLoadTime = metadataLoadTime;
-	entry.m_metadataPath = std::move(normalizedMetadataPath);
 	return bChanged;
 }
 
-bool AssetCache::RestoreProcessingTimes(AssetInfo* info) const
+bool AssetCache::RestoreAssetImportTime(AssetInfo* info) const
 {
 	if (info == nullptr || !info->GetFileId())
 	{
@@ -672,7 +623,6 @@ bool AssetCache::RestoreProcessingTimes(AssetInfo* info) const
 	}
 
 	const std::string sourcePath = NormalizeSourcePath(info->GetAssetFilepath());
-	const std::string metadataPath = NormalizeSourcePath(info->GetMetaFilepath());
 	std::lock_guard<std::mutex> lock(m_cacheMutex);
 	if (!m_cache.m_data.ContainsKey(info->GetFileId()))
 	{
@@ -680,13 +630,12 @@ bool AssetCache::RestoreProcessingTimes(AssetInfo* info) const
 	}
 
 	const AssetCacheData::Entry entry = m_cache.m_data[info->GetFileId()];
-	if (entry.m_sourcePath != sourcePath || entry.m_metadataPath != metadataPath)
+	if (entry.m_sourcePath != sourcePath)
 	{
 		return false;
 	}
 
 	info->m_assetImportTime = entry.m_assetImportTime;
-	info->m_metaLoadTime = entry.m_metadataLoadTime;
 	return true;
 }
 
@@ -726,11 +675,8 @@ bool AssetCache::IsExpired(const AssetInfo* info) const
 
 	const FileId& fileId = info->GetFileId();
 	const std::string sourcePath = NormalizeSourcePath(info->GetAssetFilepath());
-	const std::string metadataPath = NormalizeSourcePath(info->GetMetaFilepath());
 	std::error_code sourceError;
-	std::error_code metadataError;
-	if (!std::filesystem::is_regular_file(sourcePath, sourceError) || sourceError ||
-		!std::filesystem::is_regular_file(metadataPath, metadataError) || metadataError)
+	if (!std::filesystem::is_regular_file(sourcePath, sourceError) || sourceError)
 	{
 		return true;
 	}
@@ -743,7 +689,5 @@ bool AssetCache::IsExpired(const AssetInfo* info) const
 
 	const AssetCacheData::Entry entry = m_cache.m_data[fileId];
 	return entry.m_sourcePath != sourcePath ||
-		entry.m_assetImportTime < info->GetAssetLastModificationTime() ||
-		entry.m_metadataPath != metadataPath ||
-		entry.m_metadataLoadTime < info->GetMetaLastModificationTime();
+		entry.m_assetImportTime < info->GetAssetLastModificationTime();
 }

--- a/Runtime/AssetRegistry/AssetCache.cpp
+++ b/Runtime/AssetRegistry/AssetCache.cpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
+#include <limits>
 #include <sstream>
 #include <unordered_set>
 
@@ -19,8 +20,10 @@ using namespace Sailor;
 namespace
 {
 	constexpr const char* AssetCacheKind = "asset-cache";
-	constexpr const char* AssetCacheProducer = "asset-cache-v1";
-	constexpr uint32_t AssetCachePayloadVersion = 1;
+	constexpr const char* AssetCacheProducer = "asset-cache-v2";
+	constexpr uint32_t AssetCachePayloadVersion = 2;
+	constexpr AssetCache::FileTimestamp MissingFileTimestamp =
+		std::numeric_limits<AssetCache::FileTimestamp>::min();
 
 	std::string NormalizeSourcePath(const std::string& sourcePath)
 	{
@@ -163,53 +166,80 @@ std::string AssetCache::GetAssetCacheFilepath()
 	return (std::filesystem::path(AssetRegistry::GetCacheFolder()) / "AssetCache.yaml").string();
 }
 
+AssetCache::FileTimestamp AssetCache::GetFileTimestamp(const std::string& path) noexcept
+{
+	std::error_code error;
+	const std::filesystem::file_time_type writeTime = std::filesystem::last_write_time(path, error);
+	if (error)
+	{
+		return MissingFileTimestamp;
+	}
+
+	return static_cast<FileTimestamp>(writeTime.time_since_epoch().count());
+}
+
 YAML::Node AssetCache::AssetCacheData::Entry::Serialize() const
 {
 	YAML::Node result(YAML::NodeType::Map);
 	result["fileId"] = m_fileId;
-	result["assetImportTime"] = m_assetImportTime;
+	result["sourceTimestamp"] = m_sourceTimestamp;
 	result["sourcePath"] = m_sourcePath;
+	result["metadataTimestamp"] = m_metadataTimestamp;
+	result["metadataPath"] = m_metadataPath;
 	return result;
 }
 
 void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 {
 	m_fileId = FileId();
-	m_assetImportTime = 0;
+	m_sourceTimestamp = 0;
 	m_sourcePath.clear();
+	m_metadataTimestamp = 0;
+	m_metadataPath.clear();
 	std::string yamlDiagnostic;
 	if (!Sailor::External::GuardYamlExceptions(
 		[&]()
 		{
-			if (!inData.IsMap() || inData.size() != 3)
+			if (!inData.IsMap() || inData.size() != 5)
 			{
 				return;
 			}
 
 			const YAML::Node fileId = inData["fileId"];
-			const YAML::Node assetImportTime = inData["assetImportTime"];
+			const YAML::Node sourceTimestamp = inData["sourceTimestamp"];
 			const YAML::Node sourcePath = inData["sourcePath"];
-			if (!fileId || !assetImportTime || !sourcePath || !fileId.IsScalar() ||
-				!assetImportTime.IsScalar() || !sourcePath.IsScalar())
+			const YAML::Node metadataTimestamp = inData["metadataTimestamp"];
+			const YAML::Node metadataPath = inData["metadataPath"];
+			if (!fileId || !sourceTimestamp || !sourcePath || !metadataTimestamp || !metadataPath ||
+				!fileId.IsScalar() || !sourceTimestamp.IsScalar() || !sourcePath.IsScalar() ||
+				!metadataTimestamp.IsScalar() || !metadataPath.IsScalar())
 			{
 				return;
 			}
 
 			m_fileId.Deserialize(fileId);
-			m_assetImportTime = assetImportTime.as<std::time_t>();
+			m_sourceTimestamp = sourceTimestamp.as<FileTimestamp>();
 			m_sourcePath = NormalizeSourcePath(sourcePath.as<std::string>());
-			if (m_sourcePath.empty() || !m_fileId)
+			m_metadataTimestamp = metadataTimestamp.as<FileTimestamp>();
+			m_metadataPath = NormalizeSourcePath(metadataPath.as<std::string>());
+			if (m_sourcePath.empty() || m_metadataPath.empty() || !m_fileId ||
+				m_sourceTimestamp == MissingFileTimestamp ||
+				m_metadataTimestamp == MissingFileTimestamp)
 			{
 				m_fileId = FileId();
-				m_assetImportTime = 0;
+				m_sourceTimestamp = 0;
 				m_sourcePath.clear();
+				m_metadataTimestamp = 0;
+				m_metadataPath.clear();
 			}
 		},
 		yamlDiagnostic))
 	{
 		m_fileId = FileId();
-		m_assetImportTime = 0;
+		m_sourceTimestamp = 0;
 		m_sourcePath.clear();
+		m_metadataTimestamp = 0;
+		m_metadataPath.clear();
 	}
 }
 
@@ -287,23 +317,29 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 		}
 
 		const YAML::Node entryNode = serializedEntry.second;
-		if (!entryNode.IsMap() || entryNode.size() != 3)
+		if (!entryNode.IsMap() || entryNode.size() != 5)
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId +
-				"' must contain exactly fileId, assetImportTime, and sourcePath.";
+				"' must contain exactly fileId, sourceTimestamp, sourcePath, "
+				"metadataTimestamp, and metadataPath.";
 			return false;
 		}
 
 		YAML::Node entryFileId;
-		YAML::Node assetImportTime;
+		YAML::Node sourceTimestamp;
 		YAML::Node sourcePath;
+		YAML::Node metadataTimestamp;
+		YAML::Node metadataPath;
 		if (!ReadRequiredField(entryNode, "fileId", entryFileId, outDiagnostic) ||
-			!ReadRequiredField(entryNode, "assetImportTime", assetImportTime, outDiagnostic) ||
-			!ReadRequiredField(entryNode, "sourcePath", sourcePath, outDiagnostic))
+			!ReadRequiredField(entryNode, "sourceTimestamp", sourceTimestamp, outDiagnostic) ||
+			!ReadRequiredField(entryNode, "sourcePath", sourcePath, outDiagnostic) ||
+			!ReadRequiredField(entryNode, "metadataTimestamp", metadataTimestamp, outDiagnostic) ||
+			!ReadRequiredField(entryNode, "metadataPath", metadataPath, outDiagnostic))
 		{
 			return false;
 		}
-		if (!entryFileId.IsScalar() || !assetImportTime.IsScalar() || !sourcePath.IsScalar())
+		if (!entryFileId.IsScalar() || !sourceTimestamp.IsScalar() || !sourcePath.IsScalar() ||
+			!metadataTimestamp.IsScalar() || !metadataPath.IsScalar())
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId + "' contains a non-scalar field.";
 			return false;
@@ -311,7 +347,7 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 
 		AssetCacheData::Entry entry;
 		entry.m_fileId = entryFileId.as<FileId>();
-		entry.m_assetImportTime = assetImportTime.as<std::time_t>();
+		entry.m_sourceTimestamp = sourceTimestamp.as<FileTimestamp>();
 		const std::string serializedSourcePath = sourcePath.as<std::string>();
 		if (serializedSourcePath.empty())
 		{
@@ -319,6 +355,14 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 			return false;
 		}
 		entry.m_sourcePath = NormalizeSourcePath(serializedSourcePath);
+		entry.m_metadataTimestamp = metadataTimestamp.as<FileTimestamp>();
+		const std::string serializedMetadataPath = metadataPath.as<std::string>();
+		if (serializedMetadataPath.empty())
+		{
+			outDiagnostic = "Asset cache entry '" + serializedFileId + "' has an empty metadataPath.";
+			return false;
+		}
+		entry.m_metadataPath = NormalizeSourcePath(serializedMetadataPath);
 		if (!entry.m_fileId || entry.m_fileId != fileId)
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId + "' has a mismatched fileId field.";
@@ -327,6 +371,17 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 		if (entry.m_sourcePath.empty())
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId + "' has an empty sourcePath.";
+			return false;
+		}
+		if (entry.m_metadataPath.empty())
+		{
+			outDiagnostic = "Asset cache entry '" + serializedFileId + "' has an empty metadataPath.";
+			return false;
+		}
+		if (entry.m_sourceTimestamp == MissingFileTimestamp ||
+			entry.m_metadataTimestamp == MissingFileTimestamp)
+		{
+			outDiagnostic = "Asset cache entry '" + serializedFileId + "' contains a missing-file timestamp.";
 			return false;
 		}
 
@@ -544,33 +599,46 @@ bool AssetCache::Contains(const FileId& uid) const
 	return m_cache.m_data.ContainsKey(uid);
 }
 
-bool AssetCache::GetTimeStamp(
-	const FileId& uid,
-	const std::string& sourcePath,
-	time_t& outAssetTimestamp) const
+bool AssetCache::Update(const AssetInfo* info)
 {
-	std::lock_guard<std::mutex> lock(m_cacheMutex);
-	if (!m_cache.m_data.ContainsKey(uid))
+	if (info == nullptr)
 	{
 		return false;
 	}
 
-	const AssetCacheData::Entry entry = m_cache.m_data[uid];
-	if (entry.m_sourcePath.empty() || entry.m_sourcePath != NormalizeSourcePath(sourcePath))
+	const std::string sourcePath = info->GetAssetFilepath();
+	const std::string metadataPath = info->GetMetaFilepath();
+	const FileTimestamp sourceTimestamp = GetFileTimestamp(sourcePath);
+	const FileTimestamp metadataTimestamp = GetFileTimestamp(metadataPath);
+	if (sourceTimestamp == MissingFileTimestamp || metadataTimestamp == MissingFileTimestamp)
 	{
+		Remove(info->GetFileId());
 		return false;
 	}
 
-	outAssetTimestamp = entry.m_assetImportTime;
-	return true;
+	return Update(
+		info->GetFileId(),
+		sourcePath,
+		sourceTimestamp,
+		metadataPath,
+		metadataTimestamp);
 }
 
-void AssetCache::Update(
+bool AssetCache::Update(
 	const FileId& id,
 	const std::string& sourcePath,
-	const time_t& assetTimestamp)
+	FileTimestamp sourceTimestamp,
+	const std::string& metadataPath,
+	FileTimestamp metadataTimestamp)
 {
 	std::string normalizedSourcePath = NormalizeSourcePath(sourcePath);
+	std::string normalizedMetadataPath = NormalizeSourcePath(metadataPath);
+	if (!id || normalizedSourcePath.empty() || normalizedMetadataPath.empty() ||
+		sourceTimestamp == MissingFileTimestamp || metadataTimestamp == MissingFileTimestamp)
+	{
+		return false;
+	}
+
 	std::lock_guard<std::mutex> lock(m_cacheMutex);
 	auto& entry = m_cache.m_data.At_Lock(id);
 	struct EntryUnlockGuard final
@@ -584,12 +652,18 @@ void AssetCache::Update(
 		}
 	} unlockGuard{ m_cache.m_data, id };
 
-	m_bIsDirty |= entry.m_fileId != id ||
-		entry.m_assetImportTime != assetTimestamp ||
-		entry.m_sourcePath != normalizedSourcePath;
+	const bool bChanged = entry.m_fileId != id ||
+		entry.m_sourceTimestamp != sourceTimestamp ||
+		entry.m_sourcePath != normalizedSourcePath ||
+		entry.m_metadataTimestamp != metadataTimestamp ||
+		entry.m_metadataPath != normalizedMetadataPath;
+	m_bIsDirty |= bChanged;
 	entry.m_fileId = id;
-	entry.m_assetImportTime = assetTimestamp;
+	entry.m_sourceTimestamp = sourceTimestamp;
 	entry.m_sourcePath = std::move(normalizedSourcePath);
+	entry.m_metadataTimestamp = metadataTimestamp;
+	entry.m_metadataPath = std::move(normalizedMetadataPath);
+	return bChanged;
 }
 
 void AssetCache::Remove(const FileId& uid)
@@ -600,7 +674,30 @@ void AssetCache::Remove(const FileId& uid)
 
 bool AssetCache::IsExpired(const AssetInfo* info) const
 {
-	time_t cachedTimestamp = 0;
-	return !GetTimeStamp(info->GetFileId(), info->GetAssetFilepath(), cachedTimestamp) ||
-		cachedTimestamp < info->GetAssetLastModificationTime();
+	if (info == nullptr)
+	{
+		return true;
+	}
+
+	const FileId& fileId = info->GetFileId();
+	const std::string sourcePath = NormalizeSourcePath(info->GetAssetFilepath());
+	const std::string metadataPath = NormalizeSourcePath(info->GetMetaFilepath());
+	const FileTimestamp sourceTimestamp = GetFileTimestamp(sourcePath);
+	const FileTimestamp metadataTimestamp = GetFileTimestamp(metadataPath);
+	if (sourceTimestamp == MissingFileTimestamp || metadataTimestamp == MissingFileTimestamp)
+	{
+		return true;
+	}
+
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	if (!m_cache.m_data.ContainsKey(fileId))
+	{
+		return true;
+	}
+
+	const AssetCacheData::Entry entry = m_cache.m_data[fileId];
+	return entry.m_sourcePath != sourcePath ||
+		entry.m_sourceTimestamp != sourceTimestamp ||
+		entry.m_metadataPath != metadataPath ||
+		entry.m_metadataTimestamp != metadataTimestamp;
 }

--- a/Runtime/AssetRegistry/AssetCache.h
+++ b/Runtime/AssetRegistry/AssetCache.h
@@ -1,6 +1,5 @@
 #pragma once
-#include <chrono>
-#include <ctime>
+#include <cstdint>
 #include "Containers/ConcurrentMap.h"
 #include "AssetRegistry/FileId.h"
 #include "Workspace/WorkspaceCacheContract.h"
@@ -13,21 +12,15 @@ namespace Sailor
 	class AssetCache
 	{
 	public:
+		using FileTimestamp = int64_t;
 
 		SAILOR_API static std::string GetAssetCacheFilepath();
 
 		SAILOR_API void Initialize();
 		SAILOR_API void Shutdown();
 
-		SAILOR_API bool GetTimeStamp(
-			const FileId& uid,
-			const std::string& sourcePath,
-			time_t& outAssetTimestamp) const;
-
-		SAILOR_API void Update(
-			const FileId& id,
-			const std::string& sourcePath,
-			const time_t& assetTimestamp);
+		SAILOR_API bool Update(
+			const class AssetInfo* info);
 		SAILOR_API void Remove(const FileId& uid);
 
 		SAILOR_API bool Contains(const FileId& uid) const;
@@ -52,10 +45,19 @@ namespace Sailor
 			public:
 
 				FileId m_fileId{};
-				std::time_t m_assetImportTime{};
+				FileTimestamp m_sourceTimestamp{};
 				std::string m_sourcePath;
+				FileTimestamp m_metadataTimestamp{};
+				std::string m_metadataPath;
 
-				SAILOR_API bool operator==(const Entry& rhs) const { return m_fileId == rhs.m_fileId; }
+				SAILOR_API bool operator==(const Entry& rhs) const
+				{
+					return m_fileId == rhs.m_fileId &&
+						m_sourceTimestamp == rhs.m_sourceTimestamp &&
+						m_sourcePath == rhs.m_sourcePath &&
+						m_metadataTimestamp == rhs.m_metadataTimestamp &&
+						m_metadataPath == rhs.m_metadataPath;
+				}
 
 				SAILOR_API virtual YAML::Node Serialize() const override;
 				SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
@@ -78,6 +80,12 @@ namespace Sailor
 			bool bForcely,
 			bool bIsDirty,
 			bool bPreserveStorageAfterLoadFailure) noexcept;
+		SAILOR_API bool Update(
+			const FileId& id,
+			const std::string& sourcePath,
+			FileTimestamp sourceTimestamp,
+			const std::string& metadataPath,
+			FileTimestamp metadataTimestamp);
 
 		SAILOR_API static std::string SerializeAssetCachePayload(const AssetCacheData& cache);
 		SAILOR_API static bool TryDeserializeAssetCachePayload(
@@ -90,6 +98,7 @@ namespace Sailor
 		mutable std::mutex m_cacheMutex;
 
 	private:
+		static FileTimestamp GetFileTimestamp(const std::string& path) noexcept;
 
 		AssetCacheData m_cache;
 		bool m_bIsDirty = false;

--- a/Runtime/AssetRegistry/AssetCache.h
+++ b/Runtime/AssetRegistry/AssetCache.h
@@ -44,19 +44,14 @@ namespace Sailor
 			public:
 
 				FileId m_fileId{};
-				// File mtimes of the source and metadata versions acknowledged by their import callbacks.
 				std::time_t m_assetImportTime{};
 				std::string m_sourcePath;
-				std::time_t m_metadataLoadTime{};
-				std::string m_metadataPath;
 
 				SAILOR_API bool operator==(const Entry& rhs) const
 				{
 					return m_fileId == rhs.m_fileId &&
 						m_assetImportTime == rhs.m_assetImportTime &&
-						m_sourcePath == rhs.m_sourcePath &&
-						m_metadataLoadTime == rhs.m_metadataLoadTime &&
-						m_metadataPath == rhs.m_metadataPath;
+						m_sourcePath == rhs.m_sourcePath;
 				}
 
 				SAILOR_API virtual YAML::Node Serialize() const override;
@@ -83,11 +78,9 @@ namespace Sailor
 		SAILOR_API bool Update(
 			const FileId& id,
 			std::time_t assetImportTime,
-			const std::string& sourcePath,
-			std::time_t metadataLoadTime,
-			const std::string& metadataPath);
-		bool RestoreProcessingTimes(class AssetInfo* info) const;
-		bool Prune(const TSet<FileId>& liveAssetIds);
+			const std::string& sourcePath);
+		SAILOR_API bool RestoreAssetImportTime(class AssetInfo* info) const;
+		SAILOR_API bool Prune(const TSet<FileId>& liveAssetIds);
 
 		SAILOR_API static std::string SerializeAssetCachePayload(const AssetCacheData& cache);
 		SAILOR_API static bool TryDeserializeAssetCachePayload(

--- a/Runtime/AssetRegistry/AssetCache.h
+++ b/Runtime/AssetRegistry/AssetCache.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <cstdint>
+#include <ctime>
 #include "Containers/ConcurrentMap.h"
+#include "Containers/Set.h"
 #include "AssetRegistry/FileId.h"
 #include "Workspace/WorkspaceCacheContract.h"
 #include <mutex>
@@ -12,15 +14,12 @@ namespace Sailor
 	class AssetCache
 	{
 	public:
-		using FileTimestamp = int64_t;
-
 		SAILOR_API static std::string GetAssetCacheFilepath();
 
 		SAILOR_API void Initialize();
 		SAILOR_API void Shutdown();
 
-		SAILOR_API bool Update(
-			const class AssetInfo* info);
+		SAILOR_API bool Update(const class AssetInfo* info);
 		SAILOR_API void Remove(const FileId& uid);
 
 		SAILOR_API bool Contains(const FileId& uid) const;
@@ -45,17 +44,18 @@ namespace Sailor
 			public:
 
 				FileId m_fileId{};
-				FileTimestamp m_sourceTimestamp{};
+				// File mtimes of the source and metadata versions acknowledged by their import callbacks.
+				std::time_t m_assetImportTime{};
 				std::string m_sourcePath;
-				FileTimestamp m_metadataTimestamp{};
+				std::time_t m_metadataLoadTime{};
 				std::string m_metadataPath;
 
 				SAILOR_API bool operator==(const Entry& rhs) const
 				{
 					return m_fileId == rhs.m_fileId &&
-						m_sourceTimestamp == rhs.m_sourceTimestamp &&
+						m_assetImportTime == rhs.m_assetImportTime &&
 						m_sourcePath == rhs.m_sourcePath &&
-						m_metadataTimestamp == rhs.m_metadataTimestamp &&
+						m_metadataLoadTime == rhs.m_metadataLoadTime &&
 						m_metadataPath == rhs.m_metadataPath;
 				}
 
@@ -82,10 +82,12 @@ namespace Sailor
 			bool bPreserveStorageAfterLoadFailure) noexcept;
 		SAILOR_API bool Update(
 			const FileId& id,
+			std::time_t assetImportTime,
 			const std::string& sourcePath,
-			FileTimestamp sourceTimestamp,
-			const std::string& metadataPath,
-			FileTimestamp metadataTimestamp);
+			std::time_t metadataLoadTime,
+			const std::string& metadataPath);
+		bool RestoreProcessingTimes(class AssetInfo* info) const;
+		bool Prune(const TSet<FileId>& liveAssetIds);
 
 		SAILOR_API static std::string SerializeAssetCachePayload(const AssetCacheData& cache);
 		SAILOR_API static bool TryDeserializeAssetCachePayload(
@@ -98,12 +100,12 @@ namespace Sailor
 		mutable std::mutex m_cacheMutex;
 
 	private:
-		static FileTimestamp GetFileTimestamp(const std::string& path) noexcept;
-
 		AssetCacheData m_cache;
 		bool m_bIsDirty = false;
 		bool m_bPreserveStorageAfterLoadFailure = false;
 		Workspace::WorkspaceCacheLoadResult m_lastLoadResult{};
 		std::string m_lastSaveDiagnostic;
+
+		friend class AssetRegistry;
 	};
 }

--- a/Runtime/AssetRegistry/AssetInfo.cpp
+++ b/Runtime/AssetRegistry/AssetInfo.cpp
@@ -442,8 +442,7 @@ bool IAssetInfoHandler::ReloadAssetInfo(
 	}
 	AssetRegistry* assetRegistry = App::GetSubmodule<AssetRegistry>();
 	const bool bWasCacheExpired = assetRegistry == nullptr ||
-		!assetRegistry->RestoreAssetProcessingTimes(assetInfo) ||
-		assetInfo->IsMetaExpired() || assetInfo->IsAssetExpired();
+		!assetRegistry->RestoreAssetImportTime(assetInfo) || assetInfo->IsAssetExpired();
 
 	assetInfo->m_assetImportTime = assetInfo->GetAssetLastModificationTime();
 	assetInfo->m_metaLoadTime = metadataLoadTime;

--- a/Runtime/AssetRegistry/AssetInfo.cpp
+++ b/Runtime/AssetRegistry/AssetInfo.cpp
@@ -6,6 +6,7 @@
 #include "Core/Reflection.h"
 #include "Tasks/Scheduler.h"
 #include "Tasks/Tasks.h"
+#include "YamlExceptionBoundary.h"
 #include <iostream>
 
 using namespace Sailor;
@@ -143,14 +144,6 @@ AssetInfoPtr IAssetInfoHandler::ImportAsset(
 	newMeta["fileId"] = fileId.Serialize();
 	newMeta["filename"] = std::filesystem::path(assetFilepath).filename().string();
 
-	if (bUpdateAssetCache)
-	{
-		App::GetSubmodule<AssetRegistry>()->CacheAssetTime(
-			fileId,
-			assetFilepath,
-			std::time(nullptr));
-	}
-
 	assetFile << newMeta;
 	assetFile.close();
 
@@ -164,6 +157,13 @@ AssetInfoPtr IAssetInfoHandler::ImportAsset(
 		true,
 		bNotifyListeners,
 		bUpdateAssetCache);
+	if (assetInfoPtr == nullptr)
+	{
+		std::error_code removeError;
+		std::filesystem::remove(assetInfoFilename, removeError);
+		return nullptr;
+	}
+
 	assetInfoPtr->m_bPendingImportNotification = !bNotifyListeners;
 	if (bNotifyListeners)
 	{
@@ -198,24 +198,53 @@ AssetInfoPtr IAssetInfoHandler::LoadAssetInfo(
 			res->m_assetFilename).generic_string();
 	}
 
-	ReloadAssetInfo(res, bNotifyListeners, bUpdateAssetCache);
+	if (!ReloadAssetInfo(res, bNotifyListeners, bUpdateAssetCache))
+	{
+		delete res;
+		return nullptr;
+	}
 
 	return res;
 }
 
-void IAssetInfoHandler::ReloadAssetInfo(
+bool IAssetInfoHandler::ReloadAssetInfo(
 	AssetInfoPtr assetInfo,
 	bool bNotifyListeners,
 	bool bUpdateAssetCache) const
 {
+	if (assetInfo == nullptr)
+	{
+		SAILOR_LOG_ERROR("Cannot reload null asset metadata.");
+		return false;
+	}
+
 	const bool bWasMetaExpired = assetInfo->IsMetaExpired();
 
 	std::string content;
-	AssetRegistry::ReadAllTextFile(assetInfo->GetMetaFilepath(), content);
+	if (!AssetRegistry::ReadAllTextFile(assetInfo->GetMetaFilepath(), content))
+	{
+		SAILOR_LOG_ERROR(
+			"Failed to read asset metadata: %s",
+			assetInfo->GetMetaFilepath().c_str());
+		return false;
+	}
 
-	YAML::Node meta = YAML::Load(content);
+	std::string yamlDiagnostic;
+	if (!External::GuardYamlExceptions(
+			[assetInfo, &content]()
+			{
+				const YAML::Node meta = YAML::Load(content);
+				assetInfo->Deserialize(meta);
+			},
+			yamlDiagnostic))
+	{
+		SAILOR_LOG_ERROR(
+			"Invalid asset metadata '%s': %s",
+			assetInfo->GetMetaFilepath().c_str(),
+			yamlDiagnostic.c_str());
+		return false;
+	}
 
-	assetInfo->Deserialize(meta);
 	if (!assetInfo->m_virtualMetaFilepath.empty())
 	{
 		assetInfo->m_virtualAssetFilepath = (
@@ -246,6 +275,8 @@ void IAssetInfoHandler::ReloadAssetInfo(
 	{
 		NotifyUpdateAssetInfo(assetInfo);
 	}
+
+	return true;
 
 	/*	if (bWasAssetExpired)
 		{

--- a/Runtime/AssetRegistry/AssetInfo.cpp
+++ b/Runtime/AssetRegistry/AssetInfo.cpp
@@ -7,9 +7,85 @@
 #include "Tasks/Scheduler.h"
 #include "Tasks/Tasks.h"
 #include "YamlExceptionBoundary.h"
+#include <cerrno>
+#include <cstdio>
 #include <iostream>
+#include <iterator>
+#include <sstream>
 
 using namespace Sailor;
+
+namespace
+{
+	bool ReadFileExactly(const std::filesystem::path& filepath, std::string& outContents)
+	{
+		std::ifstream file(filepath, std::ios::binary);
+		if (!file.is_open())
+		{
+			return false;
+		}
+
+		outContents.assign(
+			std::istreambuf_iterator<char>(file),
+			std::istreambuf_iterator<char>());
+		return !file.bad();
+	}
+
+	bool RemoveFileIfContentsMatch(
+		const std::filesystem::path& filepath,
+		const std::string& expectedContents)
+	{
+		std::string currentContents;
+		if (!ReadFileExactly(filepath, currentContents) || currentContents != expectedContents)
+		{
+			return false;
+		}
+
+		std::error_code removeError;
+		return std::filesystem::remove(filepath, removeError) && !removeError;
+	}
+
+	bool WriteNewMetadataFile(
+		const std::filesystem::path& filepath,
+		const YAML::Node& metadata,
+		std::string& outContents,
+		std::string& outDiagnostic)
+	{
+		std::stringstream serialized;
+		serialized << metadata;
+		outContents = serialized.str();
+
+		errno = 0;
+		std::FILE* file = nullptr;
+		int openError = 0;
+#if defined(_WIN32)
+		openError = _wfopen_s(&file, filepath.c_str(), L"wbx");
+#else
+		file = std::fopen(filepath.c_str(), "wbx");
+		openError = errno;
+#endif
+		if (file == nullptr)
+		{
+			const std::error_code error(openError, std::generic_category());
+			outDiagnostic = error
+				? error.message()
+				: "the metadata file already exists or could not be created exclusively";
+			return false;
+		}
+
+		const size_t written = std::fwrite(outContents.data(), 1, outContents.size(), file);
+		const bool bClosed = std::fclose(file) == 0;
+		if (written == outContents.size() && bClosed)
+		{
+			return true;
+		}
+
+		const std::error_code error(errno, std::generic_category());
+		outDiagnostic = error ? error.message() : "the complete metadata payload could not be written";
+		RemoveFileIfContentsMatch(filepath, outContents.substr(0, written));
+		return false;
+	}
+}
 
 std::string AssetInfo::GetAssetInfoType() const
 {
@@ -45,28 +121,28 @@ void AssetInfo::SaveMetaFile()
 
 AssetInfo::AssetInfo()
 {
-	m_metaLoadTime = 0;
+	m_metaLoadTime = std::time(nullptr);
 	m_assetImportTime = 0;
 }
 
 bool AssetInfo::IsAssetExpired() const
 {
-	if (!(std::filesystem::exists(m_folder)))
+	if (!std::filesystem::is_regular_file(GetAssetFilepath()))
 	{
 		return true;
 	}
 
-	return m_assetImportTime != GetAssetLastModificationTime();
+	return m_assetImportTime < GetAssetLastModificationTime();
 }
 
 bool AssetInfo::IsMetaExpired() const
 {
-	if (!(std::filesystem::exists(m_folder)))
+	if (!std::filesystem::is_regular_file(GetMetaFilepath()))
 	{
 		return true;
 	}
 
-	return m_metaLoadTime != GetMetaLastModificationTime();
+	return m_metaLoadTime < GetMetaLastModificationTime();
 }
 
 DefaultAssetInfoHandler::DefaultAssetInfoHandler(AssetRegistry* assetRegistry)
@@ -134,8 +210,6 @@ AssetInfoPtr IAssetInfoHandler::ImportAsset(
 	bool bUpdateAssetCache) const
 {
 	const std::string assetInfoFilename = AssetRegistry::GetMetaFilePath(assetFilepath);
-	std::filesystem::remove(assetInfoFilename);
-	std::ofstream assetFile{ assetInfoFilename };
 
 	YAML::Node newMeta;
 	GetDefaultMeta(newMeta);
@@ -144,8 +218,20 @@ AssetInfoPtr IAssetInfoHandler::ImportAsset(
 	newMeta["fileId"] = fileId.Serialize();
 	newMeta["filename"] = std::filesystem::path(assetFilepath).filename().string();
 
-	assetFile << newMeta;
-	assetFile.close();
+	std::string importedMetadataContents;
+	std::string writeDiagnostic;
+	if (!WriteNewMetadataFile(
+			assetInfoFilename,
+			newMeta,
+			importedMetadataContents,
+			writeDiagnostic))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot import asset without overwriting metadata '%s': %s",
+			assetInfoFilename.c_str(),
+			writeDiagnostic.c_str());
+		return nullptr;
+	}
 
 	const std::string virtualMetaFilepath = virtualAssetFilepath.empty()
 		? std::string{}
@@ -155,18 +241,21 @@ AssetInfoPtr IAssetInfoHandler::ImportAsset(
 		virtualMetaFilepath,
 		EAssetMountKind::Workspace,
 		true,
-		bNotifyListeners,
+		false,
 		false);
 	if (assetInfoPtr == nullptr)
 	{
-		std::error_code removeError;
-		std::filesystem::remove(assetInfoFilename, removeError);
+		RemoveFileIfContentsMatch(assetInfoFilename, importedMetadataContents);
 		return nullptr;
 	}
 
-	assetInfoPtr->m_bPendingImportNotification = !bNotifyListeners;
+	assetInfoPtr->m_importedMetadataContents = std::move(importedMetadataContents);
+	assetInfoPtr->m_bPendingUpdateNotification = true;
+	assetInfoPtr->m_bPendingWasExpired = false;
+	assetInfoPtr->m_bPendingImportNotification = true;
 	if (bNotifyListeners)
 	{
+		NotifyUpdateAssetInfo(assetInfoPtr);
 		NotifyImportAsset(assetInfoPtr);
 	}
 	if (bUpdateAssetCache)
@@ -175,6 +264,20 @@ AssetInfoPtr IAssetInfoHandler::ImportAsset(
 	}
 
 	return assetInfoPtr;
+}
+
+bool IAssetInfoHandler::DiscardImportedMetadataIfUnchanged(AssetInfoPtr assetInfo) const
+{
+	if (assetInfo == nullptr || assetInfo->m_importedMetadataContents.empty())
+	{
+		return false;
+	}
+
+	const bool bRemoved = RemoveFileIfContentsMatch(
+		assetInfo->GetMetaFilepath(),
+		assetInfo->m_importedMetadataContents);
+	assetInfo->m_importedMetadataContents.clear();
+	return bRemoved;
 }
 
 AssetInfoPtr IAssetInfoHandler::LoadAssetInfo(
@@ -223,9 +326,29 @@ bool IAssetInfoHandler::ReloadAssetInfo(
 	}
 
 	const bool bHadLoadedIdentity = static_cast<bool>(assetInfo->GetFileId());
+	const FileId previousFileId = assetInfo->GetFileId();
 	const bool bWasMetaExpired = bHadLoadedIdentity && assetInfo->IsMetaExpired();
 	const bool bWasAssetExpired = bHadLoadedIdentity && assetInfo->IsAssetExpired();
+	YAML::Node previousState;
+	if (bHadLoadedIdentity)
+	{
+		std::string snapshotDiagnostic;
+		if (!External::GuardYamlExceptions(
+				[assetInfo, &previousState]()
+				{
+					previousState = assetInfo->Serialize();
+				},
+				snapshotDiagnostic))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot snapshot asset metadata before reload '%s': %s",
+				assetInfo->GetMetaFilepath().c_str(),
+				snapshotDiagnostic.c_str());
+			return false;
+		}
+	}
 
+	const std::time_t metadataLoadTime = assetInfo->GetMetaLastModificationTime();
 	std::string content;
 	if (!AssetRegistry::ReadAllTextFile(assetInfo->GetMetaFilepath(), content))
 	{
@@ -235,19 +358,79 @@ bool IAssetInfoHandler::ReloadAssetInfo(
 		return false;
 	}
 
+	YAML::Node meta;
 	std::string yamlDiagnostic;
-	if (!External::GuardYamlExceptions(
-			[assetInfo, &content]()
+	if (!External::TryLoadYaml(content, meta, yamlDiagnostic) ||
+		!External::GuardYamlExceptions(
+			[assetInfo, &meta]()
 			{
-				const YAML::Node meta = YAML::Load(content);
 				assetInfo->Deserialize(meta);
 			},
 			yamlDiagnostic))
 	{
+		if (bHadLoadedIdentity)
+		{
+			std::string rollbackDiagnostic;
+			if (!External::GuardYamlExceptions(
+					[assetInfo, &previousState]()
+					{
+						assetInfo->Deserialize(previousState);
+					},
+					rollbackDiagnostic))
+			{
+				SAILOR_LOG_ERROR(
+					"Failed to restore asset metadata after a rejected reload '%s': %s",
+					assetInfo->GetMetaFilepath().c_str(),
+					rollbackDiagnostic.c_str());
+			}
+		}
 		SAILOR_LOG_ERROR(
 			"Invalid asset metadata '%s': %s",
 			assetInfo->GetMetaFilepath().c_str(),
 			yamlDiagnostic.c_str());
+		return false;
+	}
+	if (assetInfo->GetMetaLastModificationTime() != metadataLoadTime)
+	{
+		if (bHadLoadedIdentity)
+		{
+			std::string rollbackDiagnostic;
+			if (!External::GuardYamlExceptions(
+					[assetInfo, &previousState]()
+					{
+						assetInfo->Deserialize(previousState);
+					},
+					rollbackDiagnostic))
+			{
+				SAILOR_LOG_ERROR(
+					"Failed to restore asset metadata after a concurrent edit '%s': %s",
+					assetInfo->GetMetaFilepath().c_str(),
+					rollbackDiagnostic.c_str());
+			}
+		}
+		SAILOR_LOG_ERROR(
+			"Asset metadata changed while it was being loaded; preserving the previous live asset: %s",
+			assetInfo->GetMetaFilepath().c_str());
+		return false;
+	}
+	if (bHadLoadedIdentity && assetInfo->GetFileId() != previousFileId)
+	{
+		std::string rollbackDiagnostic;
+		if (!External::GuardYamlExceptions(
+				[assetInfo, &previousState]()
+				{
+					assetInfo->Deserialize(previousState);
+				},
+				rollbackDiagnostic))
+		{
+			SAILOR_LOG_ERROR(
+				"Failed to restore asset metadata after a FileId change '%s': %s",
+				assetInfo->GetMetaFilepath().c_str(),
+				rollbackDiagnostic.c_str());
+		}
+		SAILOR_LOG_ERROR(
+			"Asset metadata FileId cannot change during an in-place reload: %s",
+			assetInfo->GetMetaFilepath().c_str());
 		return false;
 	}
 
@@ -258,13 +441,16 @@ bool IAssetInfoHandler::ReloadAssetInfo(
 			assetInfo->m_assetFilename).generic_string();
 	}
 	AssetRegistry* assetRegistry = App::GetSubmodule<AssetRegistry>();
-	const bool bWasCacheExpired = assetRegistry != nullptr && assetRegistry->IsAssetExpired(assetInfo);
+	const bool bWasCacheExpired = assetRegistry == nullptr ||
+		!assetRegistry->RestoreAssetProcessingTimes(assetInfo) ||
+		assetInfo->IsMetaExpired() || assetInfo->IsAssetExpired();
 
-	assetInfo->m_metaLoadTime = assetInfo->GetMetaLastModificationTime();
 	assetInfo->m_assetImportTime = assetInfo->GetAssetLastModificationTime();
+	assetInfo->m_metaLoadTime = metadataLoadTime;
 
-	assetInfo->m_bPendingUpdateNotification = !bNotifyListeners;
-	assetInfo->m_bPendingWasExpired = bWasMetaExpired || bWasAssetExpired || bWasCacheExpired;
+	assetInfo->m_bPendingUpdateNotification = true;
+	const bool bWasExpired = bWasMetaExpired || bWasAssetExpired || bWasCacheExpired;
+	assetInfo->m_bPendingWasExpired = bWasExpired;
 	if (bNotifyListeners)
 	{
 		NotifyUpdateAssetInfo(assetInfo);
@@ -291,12 +477,12 @@ void IAssetInfoHandler::NotifyUpdateAssetInfo(AssetInfoPtr assetInfo) const
 	}
 
 	const bool bWasExpired = assetInfo->m_bPendingWasExpired;
-	assetInfo->m_bPendingUpdateNotification = false;
-	assetInfo->m_bPendingWasExpired = false;
 	for (IAssetInfoHandlerListener* listener : m_listeners)
 	{
 		listener->OnUpdateAssetInfo(assetInfo, bWasExpired);
 	}
+	assetInfo->m_bPendingUpdateNotification = false;
+	assetInfo->m_bPendingWasExpired = false;
 }
 
 void IAssetInfoHandler::NotifyImportAsset(AssetInfoPtr assetInfo) const
@@ -306,12 +492,13 @@ void IAssetInfoHandler::NotifyImportAsset(AssetInfoPtr assetInfo) const
 		return;
 	}
 
-	assetInfo->m_bPendingImportNotification = false;
 	for (IAssetInfoHandlerListener* listener : m_listeners)
 	{
 		listener->OnImportAsset(assetInfo);
 	}
+	assetInfo->m_bPendingImportNotification = false;
 	assetInfo->SaveMetaFile();
+	assetInfo->m_importedMetadataContents.clear();
 }
 
 void DefaultAssetInfoHandler::GetDefaultMeta(YAML::Node& outDefaultYaml) const

--- a/Runtime/AssetRegistry/AssetInfo.cpp
+++ b/Runtime/AssetRegistry/AssetInfo.cpp
@@ -45,7 +45,7 @@ void AssetInfo::SaveMetaFile()
 
 AssetInfo::AssetInfo()
 {
-	m_metaLoadTime = std::time(nullptr);
+	m_metaLoadTime = 0;
 	m_assetImportTime = 0;
 }
 
@@ -56,7 +56,7 @@ bool AssetInfo::IsAssetExpired() const
 		return true;
 	}
 
-	return m_assetImportTime < GetAssetLastModificationTime();
+	return m_assetImportTime != GetAssetLastModificationTime();
 }
 
 bool AssetInfo::IsMetaExpired() const
@@ -66,7 +66,7 @@ bool AssetInfo::IsMetaExpired() const
 		return true;
 	}
 
-	return m_metaLoadTime < GetMetaLastModificationTime();
+	return m_metaLoadTime != GetMetaLastModificationTime();
 }
 
 DefaultAssetInfoHandler::DefaultAssetInfoHandler(AssetRegistry* assetRegistry)
@@ -156,7 +156,7 @@ AssetInfoPtr IAssetInfoHandler::ImportAsset(
 		EAssetMountKind::Workspace,
 		true,
 		bNotifyListeners,
-		bUpdateAssetCache);
+		false);
 	if (assetInfoPtr == nullptr)
 	{
 		std::error_code removeError;
@@ -168,6 +168,10 @@ AssetInfoPtr IAssetInfoHandler::ImportAsset(
 	if (bNotifyListeners)
 	{
 		NotifyImportAsset(assetInfoPtr);
+	}
+	if (bUpdateAssetCache)
+	{
+		App::GetSubmodule<AssetRegistry>()->CacheAsset(assetInfoPtr);
 	}
 
 	return assetInfoPtr;
@@ -218,7 +222,9 @@ bool IAssetInfoHandler::ReloadAssetInfo(
 		return false;
 	}
 
-	const bool bWasMetaExpired = assetInfo->IsMetaExpired();
+	const bool bHadLoadedIdentity = static_cast<bool>(assetInfo->GetFileId());
+	const bool bWasMetaExpired = bHadLoadedIdentity && assetInfo->IsMetaExpired();
+	const bool bWasAssetExpired = bHadLoadedIdentity && assetInfo->IsAssetExpired();
 
 	std::string content;
 	if (!AssetRegistry::ReadAllTextFile(assetInfo->GetMetaFilepath(), content))
@@ -251,29 +257,21 @@ bool IAssetInfoHandler::ReloadAssetInfo(
 			std::filesystem::path(assetInfo->m_virtualMetaFilepath).parent_path() /
 			assetInfo->m_assetFilename).generic_string();
 	}
-	assetInfo->m_metaLoadTime = std::time(nullptr);
+	AssetRegistry* assetRegistry = App::GetSubmodule<AssetRegistry>();
+	const bool bWasCacheExpired = assetRegistry != nullptr && assetRegistry->IsAssetExpired(assetInfo);
 
-	App::GetSubmodule<AssetRegistry>()->GetAssetCachedTime(
-		assetInfo->GetFileId(),
-		assetInfo->GetAssetFilepath(),
-		assetInfo->m_assetImportTime);
-
-	const bool bWasAssetExpired = assetInfo->IsAssetExpired();
-
+	assetInfo->m_metaLoadTime = assetInfo->GetMetaLastModificationTime();
 	assetInfo->m_assetImportTime = assetInfo->GetAssetLastModificationTime();
-	if (bUpdateAssetCache)
-	{
-		App::GetSubmodule<AssetRegistry>()->CacheAssetTime(
-			assetInfo->GetFileId(),
-			assetInfo->GetAssetFilepath(),
-			assetInfo->m_assetImportTime);
-	}
 
 	assetInfo->m_bPendingUpdateNotification = !bNotifyListeners;
-	assetInfo->m_bPendingWasExpired = bWasMetaExpired || bWasAssetExpired;
+	assetInfo->m_bPendingWasExpired = bWasMetaExpired || bWasAssetExpired || bWasCacheExpired;
 	if (bNotifyListeners)
 	{
 		NotifyUpdateAssetInfo(assetInfo);
+	}
+	if (bUpdateAssetCache && assetRegistry != nullptr)
+	{
+		assetRegistry->CacheAsset(assetInfo);
 	}
 
 	return true;

--- a/Runtime/AssetRegistry/AssetInfo.h
+++ b/Runtime/AssetRegistry/AssetInfo.h
@@ -69,8 +69,10 @@ namespace Sailor
 		bool m_bPendingUpdateNotification = false;
 		bool m_bPendingWasExpired = false;
 		bool m_bPendingImportNotification = false;
+		std::string m_importedMetadataContents;
 
 		friend class IAssetInfoHandler;
+		friend class AssetCache;
 		friend class AssetRegistry;
 	};
 
@@ -79,7 +81,12 @@ namespace Sailor
 	class SAILOR_API IAssetInfoHandlerListener
 	{
 	public:
+		// bWasExpired means that the source or metadata changed since the last
+		// acknowledged processing watermark, or that no watermark exists yet.
+		// Importers refresh loaded resources here.
 		virtual void OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired) = 0;
+		// Called only after creating metadata for a previously untracked source.
+		// A new source receives OnUpdateAssetInfo(..., false) before this callback.
 		virtual void OnImportAsset(AssetInfoPtr assetInfo) = 0;
 
 	};
@@ -113,6 +120,7 @@ namespace Sailor
 			AssetInfoPtr assetInfo,
 			bool bNotifyListeners = true,
 			bool bUpdateAssetCache = true) const;
+		bool DiscardImportedMetadataIfUnchanged(AssetInfoPtr assetInfo) const;
 		void NotifyUpdateAssetInfo(AssetInfoPtr assetInfo) const;
 		void NotifyImportAsset(AssetInfoPtr assetInfo) const;
 

--- a/Runtime/AssetRegistry/AssetInfo.h
+++ b/Runtime/AssetRegistry/AssetInfo.h
@@ -109,7 +109,7 @@ namespace Sailor
 			const std::string& virtualAssetFilepath = {},
 			bool bNotifyListeners = true,
 			bool bUpdateAssetCache = true) const;
-		virtual void ReloadAssetInfo(
+		virtual bool ReloadAssetInfo(
 			AssetInfoPtr assetInfo,
 			bool bNotifyListeners = true,
 			bool bUpdateAssetCache = true) const;

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -49,6 +49,13 @@ namespace
 		IAssetInfoHandler* m_handler = nullptr;
 		AssetInfoPtr m_assetInfo = nullptr;
 		bool m_bImported = false;
+		bool m_bNotifyUpdate = true;
+	};
+
+	struct ImportedMetadata final
+	{
+		IAssetInfoHandler* m_handler = nullptr;
+		AssetInfoPtr m_assetInfo = nullptr;
 	};
 
 	std::string AsFolderPath(const std::filesystem::path& path)
@@ -279,12 +286,15 @@ AssetRegistry::AssetRegistry()
 	m_assetCache.Initialize();
 }
 
+bool AssetRegistry::RestoreAssetProcessingTimes(AssetInfoPtr info) const
+{
+	return m_assetCache.RestoreProcessingTimes(info);
+}
+
 void AssetRegistry::CacheAsset(const AssetInfoPtr info)
 {
 	if (info != nullptr)
 	{
-		info->m_assetImportTime = info->GetAssetLastModificationTime();
-		info->m_metaLoadTime = info->GetMetaLastModificationTime();
 		m_assetCache.Update(info);
 	}
 }
@@ -490,7 +500,37 @@ void AssetRegistry::ScanContentFolder()
 				"Invalid asset metadata '%s': %s.",
 				metaFile.m_physicalPath.generic_string().c_str(),
 				metadataError.c_str());
+			const std::string invalidMetaPath = PathKey(metaFile.m_physicalPath);
+			bool bInvalidatesLiveAsset = false;
+			for (const auto& loadedAsset : m_loadedAssetInfo)
+			{
+				if (loadedAsset.m_second != nullptr && *loadedAsset.m_second != nullptr &&
+					PathKey((*loadedAsset.m_second)->GetMetaFilepath()) == invalidMetaPath)
+				{
+					bInvalidatesLiveAsset = true;
+					break;
+				}
+			}
+			if (bInvalidatesLiveAsset)
+			{
+				SAILOR_LOG_ERROR(
+					"Asset metadata reload was rejected; preserving the previous registry generation.");
+				return;
+			}
 			continue;
+		}
+		const std::string metadataPhysicalPath = PathKey(metaFile.m_physicalPath);
+		for (const auto& loadedAsset : m_loadedAssetInfo)
+		{
+			if (loadedAsset.m_second != nullptr && *loadedAsset.m_second != nullptr &&
+				PathKey((*loadedAsset.m_second)->GetMetaFilepath()) == metadataPhysicalPath &&
+				(*loadedAsset.m_second)->GetFileId() != ParseFileId(fileId))
+			{
+				SAILOR_LOG_ERROR(
+					"Asset metadata FileId changed during reload; preserving the previous registry generation: %s",
+					metaFile.m_physicalPath.generic_string().c_str());
+				return;
+			}
 		}
 
 		const std::string basenameVirtualPath = std::filesystem::path(
@@ -605,15 +645,15 @@ void AssetRegistry::ScanContentFolder()
 	TMap<std::string, FileId> stagedFileIds;
 	TMap<std::string, FileId> stagedPhysicalFileIds;
 	TVector<PendingAssetNotification> pendingNotifications;
-	TVector<std::filesystem::path> importedMetadata;
+	TVector<ImportedMetadata> importedMetadata;
 	auto rollbackStaging = [&]()
 	{
-		DeleteAssetInfos(stagedAssetInfos);
 		for (size_t index = importedMetadata.Num(); index > 0; --index)
 		{
-			std::error_code removeError;
-			std::filesystem::remove(importedMetadata[index - 1], removeError);
+			importedMetadata[index - 1].m_handler->DiscardImportedMetadataIfUnchanged(
+				importedMetadata[index - 1].m_assetInfo);
 		}
+		DeleteAssetInfos(stagedAssetInfos);
 	};
 	for (const StagedAssetRecord& record : records)
 	{
@@ -631,15 +671,36 @@ void AssetRegistry::ScanContentFolder()
 				SAILOR_LOG_ERROR(
 					"Read-only Engine asset '%s' has no metadata and was not imported.",
 					record.m_assetVirtualPath.c_str());
+				const std::string missingMetaAssetPath = PathKey(record.m_assetPath);
+				for (const auto& loadedAsset : m_loadedAssetInfo)
+				{
+					if (loadedAsset.m_second != nullptr && *loadedAsset.m_second != nullptr &&
+						PathKey((*loadedAsset.m_second)->GetAssetFilepath()) == missingMetaAssetPath)
+					{
+						rollbackStaging();
+						SAILOR_LOG_ERROR(
+							"Read-only asset metadata disappeared; preserving the previous registry generation.");
+						return;
+					}
+				}
 				continue;
 			}
 
 			IAssetInfoHandler* handler = GetAssetInfoHandler(Extension(record.m_assetVirtualPath));
 			check(handler);
-			const bool bMetaExisted = std::filesystem::exists(record.m_metaPath);
-			if (!bMetaExisted)
+			std::error_code metadataStatusError;
+			const std::filesystem::file_status metadataStatus =
+				std::filesystem::symlink_status(record.m_metaPath, metadataStatusError);
+			if ((metadataStatusError &&
+				metadataStatusError != std::errc::no_such_file_or_directory &&
+				metadataStatusError != std::errc::not_a_directory) ||
+				std::filesystem::exists(metadataStatus))
 			{
-				importedMetadata.Add(record.m_metaPath);
+				rollbackStaging();
+				SAILOR_LOG_ERROR(
+					"Asset metadata appeared during staged import; preserving it and the previous registry generation: %s",
+					record.m_metaPath.generic_string().c_str());
+				return;
 			}
 			AssetInfoPtr assetInfo = handler->ImportAsset(
 				record.m_assetPath.string(),
@@ -654,10 +715,11 @@ void AssetRegistry::ScanContentFolder()
 					record.m_metaPath.generic_string().c_str());
 				return;
 			}
+			importedMetadata.Add({ handler, assetInfo });
 			stagedAssetInfos[assetInfo->GetFileId()] = assetInfo;
 			stagedFileIds[VirtualPathKey(record.m_assetVirtualPath)] = assetInfo->GetFileId();
 			stagedPhysicalFileIds[PathKey(record.m_assetPath)] = assetInfo->GetFileId();
-			pendingNotifications.Add({ handler, assetInfo, true });
+			pendingNotifications.Add({ handler, assetInfo, true, true });
 			continue;
 		}
 
@@ -702,11 +764,24 @@ void AssetRegistry::ScanContentFolder()
 			SAILOR_LOG_ERROR(
 				"Asset metadata FileId changed during staged load: %s",
 				record.m_metaPath.generic_string().c_str());
+				return;
+		}
+		if (PathKey(assetInfo->GetMetaFilepath()) != PathKey(record.m_metaPath) ||
+			PathKey(assetInfo->GetAssetFilepath()) != PathKey(record.m_assetPath))
+		{
+			delete assetInfo;
+			rollbackStaging();
+			SAILOR_LOG_ERROR(
+				"Asset metadata paths changed during staged load; preserving the previous registry generation: %s",
+				record.m_metaPath.generic_string().c_str());
 			return;
 		}
 
 		const FileId fileId = assetInfo->GetFileId();
 		assetInfo->m_bPendingWasExpired |= bWasPreviouslyExpired;
+		const bool bNotifyUpdate = previousAssetInfo == m_loadedAssetInfo.end() ||
+			assetInfo->m_bPendingWasExpired;
+		assetInfo->m_bPendingUpdateNotification = bNotifyUpdate;
 		stagedAssetInfos[fileId] = assetInfo;
 		if (record.m_bPrimary)
 		{
@@ -716,7 +791,7 @@ void AssetRegistry::ScanContentFolder()
 		{
 			stagedFileIds[VirtualPathKey(record.m_assetVirtualPath)] = fileId;
 		}
-		pendingNotifications.Add({ handler, assetInfo, false });
+		pendingNotifications.Add({ handler, assetInfo, false, bNotifyUpdate });
 	}
 
 	for (const StagedAssetRecord& record : records)
@@ -737,16 +812,27 @@ void AssetRegistry::ScanContentFolder()
 		}
 	}
 
+	for (const auto& stagedAsset : stagedAssetInfos)
+	{
+		AssetInfoPtr assetInfo = *stagedAsset.m_second;
+		if (assetInfo == nullptr || assetInfo->IsAssetExpired() || assetInfo->IsMetaExpired())
+		{
+			const std::string changedPath = assetInfo == nullptr
+				? std::string("<null asset info>")
+				: assetInfo->GetAssetFilepath();
+			rollbackStaging();
+			SAILOR_LOG_ERROR(
+				"Asset source or metadata changed during staged load; preserving the previous registry generation: %s",
+				changedPath.c_str());
+			return;
+		}
+	}
+
 	if (Tasks::Scheduler* scheduler = App::GetSubmodule<Tasks::Scheduler>())
 	{
 		if (!scheduler->IsMainThread())
 		{
-			DeleteAssetInfos(stagedAssetInfos);
-			for (size_t i = importedMetadata.Num(); i > 0; --i)
-			{
-				std::error_code removeError;
-				std::filesystem::remove(importedMetadata[i - 1], removeError);
-			}
+			rollbackStaging();
 			SAILOR_LOG_ERROR(
 				"Asset registry generations may only be committed from the main thread; preserving the previous generation.");
 			return;
@@ -769,13 +855,22 @@ void AssetRegistry::ScanContentFolder()
 
 	for (const PendingAssetNotification& pending : pendingNotifications)
 	{
-		pending.m_handler->NotifyUpdateAssetInfo(pending.m_assetInfo);
+		if (pending.m_bNotifyUpdate)
+		{
+			pending.m_handler->NotifyUpdateAssetInfo(pending.m_assetInfo);
+		}
 		if (pending.m_bImported)
 		{
 			pending.m_handler->NotifyImportAsset(pending.m_assetInfo);
 		}
 		CacheAsset(pending.m_assetInfo);
 	}
+	TSet<FileId> liveAssetIds;
+	for (const auto& loadedAsset : m_loadedAssetInfo)
+	{
+		liveAssetIds.Insert(loadedAsset.m_first);
+	}
+	m_assetCache.Prune(liveAssetIds);
 	m_assetCache.SaveCache();
 }
 
@@ -911,6 +1006,20 @@ const FileId& AssetRegistry::LoadFile(const std::string& requestedPath)
 	auto physicalId = m_physicalFileIds.Find(PathKey(location.m_physicalPath));
 	if (physicalId != m_physicalFileIds.end())
 	{
+		AssetInfoPtr loadedInfo = GetAssetInfoPtr_Internal(physicalId.Value());
+		if (loadedInfo != nullptr &&
+			!loadedInfo->m_bPendingUpdateNotification &&
+			!loadedInfo->m_bPendingImportNotification &&
+			(loadedInfo->IsMetaExpired() || loadedInfo->IsAssetExpired() || IsAssetExpired(loadedInfo)))
+		{
+			SAILOR_LOG("Reload asset info: %s", loadedInfo->GetMetaFilepath().c_str());
+			if (!loadedInfo->GetHandler()->ReloadAssetInfo(loadedInfo))
+			{
+				SAILOR_LOG_ERROR(
+					"Asset reload failed; preserving the previous live asset: %s",
+					loadedInfo->GetMetaFilepath().c_str());
+			}
+		}
 		return physicalId.Value();
 	}
 
@@ -942,7 +1051,7 @@ const FileId& AssetRegistry::LoadFile(const std::string& requestedPath)
 			location.m_virtualPath,
 			false,
 			false);
-		bImported = true;
+		bImported = assetInfo != nullptr;
 	}
 	else
 	{
@@ -953,11 +1062,6 @@ const FileId& AssetRegistry::LoadFile(const std::string& requestedPath)
 	}
 	if (assetInfo == nullptr)
 	{
-		if (bImported)
-		{
-			std::error_code removeError;
-			std::filesystem::remove(metaPath, removeError);
-		}
 		SAILOR_LOG_ERROR(
 			"Failed to load asset metadata: %s",
 			metaPath.generic_string().c_str());
@@ -971,12 +1075,11 @@ const FileId& AssetRegistry::LoadFile(const std::string& requestedPath)
 		const bool bSamePhysicalAsset =
 			PathKey(existingAssetInfo.Value()->GetAssetFilepath()) ==
 			PathKey(location.m_physicalPath);
-		delete assetInfo;
 		if (bImported)
 		{
-			std::error_code removeError;
-			std::filesystem::remove(metaPath, removeError);
+			handler->DiscardImportedMetadataIfUnchanged(assetInfo);
 		}
+		delete assetInfo;
 		if (bSamePhysicalAsset)
 		{
 			m_physicalFileIds[PathKey(location.m_physicalPath)] = fileId;

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -248,23 +248,6 @@ namespace
 
 }
 
-#if defined(SAILOR_ASSET_REGISTRY_TEST_HOOKS)
-bool AssetRegistryTestAccess::TryReadMetadataIdentity(
-	const std::filesystem::path& metaPath,
-	std::string& outFileId,
-	std::string& outFilename,
-	std::string& outAssetInfoType,
-	std::string& outError)
-{
-	return ReadMetadataIdentity(
-		metaPath,
-		outFileId,
-		outFilename,
-		outAssetInfoType,
-		outError);
-}
-#endif
-
 std::string AssetRegistry::GetContentFolder()
 {
 	return GetWorkspaceContentFolder();
@@ -296,20 +279,14 @@ AssetRegistry::AssetRegistry()
 	m_assetCache.Initialize();
 }
 
-void AssetRegistry::CacheAssetTime(
-	const FileId& id,
-	const std::string& sourcePath,
-	const time_t& assetTimestamp)
+void AssetRegistry::CacheAsset(const AssetInfoPtr info)
 {
-	m_assetCache.Update(id, sourcePath, assetTimestamp);
-}
-
-bool AssetRegistry::GetAssetCachedTime(
-	const FileId& id,
-	const std::string& sourcePath,
-	time_t& outAssetTimestamp) const
-{
-	return m_assetCache.GetTimeStamp(id, sourcePath, outAssetTimestamp);
+	if (info != nullptr)
+	{
+		info->m_assetImportTime = info->GetAssetLastModificationTime();
+		info->m_metaLoadTime = info->GetMetaLastModificationTime();
+		m_assetCache.Update(info);
+	}
 }
 
 bool AssetRegistry::IsAssetExpired(const AssetInfoPtr info) const
@@ -792,15 +769,12 @@ void AssetRegistry::ScanContentFolder()
 
 	for (const PendingAssetNotification& pending : pendingNotifications)
 	{
-		CacheAssetTime(
-			pending.m_assetInfo->GetFileId(),
-			pending.m_assetInfo->GetAssetFilepath(),
-			pending.m_assetInfo->GetAssetImportTime());
 		pending.m_handler->NotifyUpdateAssetInfo(pending.m_assetInfo);
 		if (pending.m_bImported)
 		{
 			pending.m_handler->NotifyImportAsset(pending.m_assetInfo);
 		}
+		CacheAsset(pending.m_assetInfo);
 	}
 	m_assetCache.SaveCache();
 }
@@ -1023,12 +997,12 @@ const FileId& AssetRegistry::LoadFile(const std::string& requestedPath)
 		m_fileIds[virtualPathKey] = fileId;
 		m_contentFileWinners[virtualPathKey] = location;
 	}
-	CacheAssetTime(fileId, location.m_physicalPath.string(), assetInfo->GetAssetImportTime());
 	handler->NotifyUpdateAssetInfo(assetInfo);
 	if (bImported)
 	{
 		handler->NotifyImportAsset(assetInfo);
 	}
+	CacheAsset(assetInfo);
 	return m_loadedAssetInfo.Find(fileId).Value()->GetFileId();
 }
 

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -14,6 +14,7 @@
 #include "Core/Utils.h"
 #include "Tasks/Scheduler.h"
 #include "Tasks/Tasks.h"
+#include "YamlExceptionBoundary.h"
 
 #include <algorithm>
 #include <cctype>
@@ -164,41 +165,69 @@ namespace
 		std::string& outAssetInfoType,
 		std::string& outError)
 	{
-		const YAML::Node metadata = YAML::LoadFile(metaPath.string());
-		const YAML::Node fileId = metadata["fileId"];
-		const YAML::Node filename = metadata["filename"];
-		if (!fileId.IsScalar() || !filename.IsScalar())
-		{
-			outError = "metadata requires scalar fileId and filename";
-			return false;
-		}
+		outFileId.clear();
+		outFilename.clear();
+		outAssetInfoType.clear();
+		outError.clear();
 
-		outFileId = fileId.as<std::string>();
-		outFilename = filename.as<std::string>();
-		YAML::Node assetInfoType(YAML::NodeType::Undefined);
-		for (const auto& field : metadata)
+		bool bSuccess = false;
+		std::string yamlDiagnostic;
+		if (!External::GuardYamlExceptions(
+				[&]()
+				{
+					const YAML::Node metadata = YAML::LoadFile(metaPath.string());
+					if (!metadata.IsMap())
+					{
+						outError = "metadata root must be a map";
+						return;
+					}
+
+					const YAML::Node fileId = metadata["fileId"];
+					const YAML::Node filename = metadata["filename"];
+					if (!fileId.IsScalar() || !filename.IsScalar())
+					{
+						outError = "metadata requires scalar fileId and filename";
+						return;
+					}
+
+					outFileId = fileId.as<std::string>();
+					outFilename = filename.as<std::string>();
+					YAML::Node assetInfoType(YAML::NodeType::Undefined);
+					for (const auto& field : metadata)
+					{
+						if (field.first.IsScalar() && field.first.Scalar() == "assetInfoType")
+						{
+							assetInfoType = field.second;
+							break;
+						}
+					}
+					if (assetInfoType.IsDefined() && !assetInfoType.IsNull() && !assetInfoType.IsScalar())
+					{
+						outError = "metadata assetInfoType must be scalar when present";
+						return;
+					}
+					if (assetInfoType.IsScalar())
+					{
+						outAssetInfoType = assetInfoType.as<std::string>();
+					}
+					if (outFileId.empty() || outFilename.empty() ||
+						!IsSafeVirtualPath(std::filesystem::path(outFilename).generic_string()))
+					{
+						outError = "metadata contains an empty FileId or unsafe filename";
+						return;
+					}
+
+					bSuccess = true;
+				},
+				yamlDiagnostic))
 		{
-			if (field.first.IsScalar() && field.first.Scalar() == "assetInfoType")
-			{
-				assetInfoType = field.second;
-				break;
-			}
-		}
-		if (assetInfoType.IsDefined() && !assetInfoType.IsNull() && !assetInfoType.IsScalar())
-		{
-			outError = "metadata assetInfoType must be scalar when present";
+			outFileId.clear();
+			outFilename.clear();
+			outAssetInfoType.clear();
+			outError = std::move(yamlDiagnostic);
 			return false;
 		}
-		outAssetInfoType = assetInfoType.IsScalar()
-			? assetInfoType.as<std::string>()
-			: std::string{};
-		if (outFileId.empty() || outFilename.empty() ||
-			!IsSafeVirtualPath(std::filesystem::path(outFilename).generic_string()))
-		{
-			outError = "metadata contains an empty FileId or unsafe filename";
-			return false;
-		}
-		return true;
+		return bSuccess;
 	}
 
 	FileId ParseFileId(const std::string& value)
@@ -218,6 +247,23 @@ namespace
 	}
 
 }
+
+#if defined(SAILOR_ASSET_REGISTRY_TEST_HOOKS)
+bool AssetRegistryTestAccess::TryReadMetadataIdentity(
+	const std::filesystem::path& metaPath,
+	std::string& outFileId,
+	std::string& outFilename,
+	std::string& outAssetInfoType,
+	std::string& outError)
+{
+	return ReadMetadataIdentity(
+		metaPath,
+		outFileId,
+		outFilename,
+		outAssetInfoType,
+		outError);
+}
+#endif
 
 std::string AssetRegistry::GetContentFolder()
 {
@@ -277,7 +323,6 @@ bool AssetRegistry::ReadAllTextFile(const std::string& filename, std::string& te
 
 	constexpr auto readSize = std::size_t{ 4096 };
 	auto stream = std::ifstream{ filename.data() };
-	stream.exceptions(std::ios_base::badbit);
 	if (!stream.is_open())
 	{
 		return false;
@@ -290,6 +335,11 @@ bool AssetRegistry::ReadAllTextFile(const std::string& filename, std::string& te
 		text.append(buffer, 0, stream.gcount());
 	}
 	text.append(buffer, 0, stream.gcount());
+	if (stream.bad())
+	{
+		text.clear();
+		return false;
+	}
 	return true;
 }
 
@@ -619,6 +669,14 @@ void AssetRegistry::ScanContentFolder()
 				record.m_assetVirtualPath,
 				false,
 				false);
+			if (assetInfo == nullptr)
+			{
+				rollbackStaging();
+				SAILOR_LOG_ERROR(
+					"Failed to import asset metadata during staged load: %s",
+					record.m_metaPath.generic_string().c_str());
+				return;
+			}
 			stagedAssetInfos[assetInfo->GetFileId()] = assetInfo;
 			stagedFileIds[VirtualPathKey(record.m_assetVirtualPath)] = assetInfo->GetFileId();
 			stagedPhysicalFileIds[PathKey(record.m_assetPath)] = assetInfo->GetFileId();
@@ -652,6 +710,14 @@ void AssetRegistry::ScanContentFolder()
 			record.m_candidate.m_mount.m_bWritable,
 			false,
 			false);
+		if (assetInfo == nullptr)
+		{
+			rollbackStaging();
+			SAILOR_LOG_ERROR(
+				"Failed to load asset metadata during staged load: %s",
+				record.m_metaPath.generic_string().c_str());
+			return;
+		}
 		if (assetInfo->GetFileId().ToString() != record.m_candidate.m_fileId)
 		{
 			delete assetInfo;
@@ -909,6 +975,18 @@ const FileId& AssetRegistry::LoadFile(const std::string& requestedPath)
 		SAILOR_LOG_ERROR(
 			"Read-only Engine asset '%s' has no metadata and was not imported.",
 			location.m_virtualPath.c_str());
+		return FileId::Invalid;
+	}
+	if (assetInfo == nullptr)
+	{
+		if (bImported)
+		{
+			std::error_code removeError;
+			std::filesystem::remove(metaPath, removeError);
+		}
+		SAILOR_LOG_ERROR(
+			"Failed to load asset metadata: %s",
+			metaPath.generic_string().c_str());
 		return FileId::Invalid;
 	}
 

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -286,9 +286,9 @@ AssetRegistry::AssetRegistry()
 	m_assetCache.Initialize();
 }
 
-bool AssetRegistry::RestoreAssetProcessingTimes(AssetInfoPtr info) const
+bool AssetRegistry::RestoreAssetImportTime(AssetInfoPtr info) const
 {
-	return m_assetCache.RestoreProcessingTimes(info);
+	return m_assetCache.RestoreAssetImportTime(info);
 }
 
 void AssetRegistry::CacheAsset(const AssetInfoPtr info)

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -178,7 +178,7 @@ namespace Sailor
 
 		SAILOR_API AssetInfoPtr GetAssetInfoPtr_Internal(FileId uid) const;
 		SAILOR_API AssetInfoPtr GetAssetInfoPtr_Internal(const std::string& assetFilepath) const;
-		bool RestoreAssetProcessingTimes(AssetInfoPtr info) const;
+		bool RestoreAssetImportTime(AssetInfoPtr info) const;
 		bool ResolveDirectLoadPath(
 			const std::string& requestedPath,
 			AssetReadLocation& outLocation) const;

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -203,4 +203,17 @@ namespace Sailor
 
 		AssetCache m_assetCache;
 	};
+
+#if defined(SAILOR_ASSET_REGISTRY_TEST_HOOKS)
+	class AssetRegistryTestAccess final
+	{
+	public:
+		SAILOR_API static bool TryReadMetadataIdentity(
+			const std::filesystem::path& metaPath,
+			std::string& outFileId,
+			std::string& outFilename,
+			std::string& outAssetInfoType,
+			std::string& outError);
+	};
+#endif
 }

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -178,6 +178,7 @@ namespace Sailor
 
 		SAILOR_API AssetInfoPtr GetAssetInfoPtr_Internal(FileId uid) const;
 		SAILOR_API AssetInfoPtr GetAssetInfoPtr_Internal(const std::string& assetFilepath) const;
+		bool RestoreAssetProcessingTimes(AssetInfoPtr info) const;
 		bool ResolveDirectLoadPath(
 			const std::string& requestedPath,
 			AssetReadLocation& outLocation) const;
@@ -195,5 +196,7 @@ namespace Sailor
 		TMap<std::string, AssetReadLocation> m_contentFileWinners;
 
 		AssetCache m_assetCache;
+
+		friend class IAssetInfoHandler;
 	};
 }

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -156,14 +156,7 @@ namespace Sailor
 		SAILOR_API static std::string GetMetaFilePath(const std::string& assetFilePath);
 
 		SAILOR_API bool IsAssetExpired(const AssetInfoPtr info) const;
-		SAILOR_API bool GetAssetCachedTime(
-			const FileId& id,
-			const std::string& sourcePath,
-			time_t& outAssetTimestamp) const;
-		SAILOR_API void CacheAssetTime(
-			const FileId& id,
-			const std::string& sourcePath,
-			const time_t& assetTimestamp);
+		SAILOR_API void CacheAsset(const AssetInfoPtr info);
 
 		template<typename T>
 		TObjectPtr<T> LoadAssetFromFile(const FileId& id, bool bImmediate = true)
@@ -203,17 +196,4 @@ namespace Sailor
 
 		AssetCache m_assetCache;
 	};
-
-#if defined(SAILOR_ASSET_REGISTRY_TEST_HOOKS)
-	class AssetRegistryTestAccess final
-	{
-	public:
-		SAILOR_API static bool TryReadMetadataIdentity(
-			const std::filesystem::path& metaPath,
-			std::string& outFileId,
-			std::string& outFilename,
-			std::string& outAssetInfoType,
-			std::string& outError);
-	};
-#endif
 }

--- a/Runtime/AssetRegistry/Prefab/PrefabImporter.cpp
+++ b/Runtime/AssetRegistry/Prefab/PrefabImporter.cpp
@@ -11,6 +11,8 @@
 #include "Tasks/Scheduler.h"
 #include "Engine/GameObject.h"
 #include "ECS/TransformECS.h"
+#include "Containers/Set.h"
+#include "YamlExceptionBoundary.h"
 
 using namespace Sailor;
 
@@ -35,7 +37,7 @@ void Prefab::ReflectedGameObject::Deserialize(const YAML::Node& inData)
 	DESERIALIZE_PROPERTY(inData, m_position);
 	DESERIALIZE_PROPERTY(inData, m_rotation);
 	DESERIALIZE_PROPERTY(inData, m_scale);
-	DESERIALIZE_PROPERTY(inData, m_parentIndex);
+	m_bHasParentIndex = Sailor::Deserialize(inData, "parentIndex", m_parentIndex);
 	DESERIALIZE_PROPERTY(inData, m_instanceId);
 	DESERIALIZE_PROPERTY(inData, m_components);
 }
@@ -54,6 +56,164 @@ void Prefab::Deserialize(const YAML::Node& inData)
 {
 	DESERIALIZE_PROPERTY(inData, m_gameObjects);
 	DESERIALIZE_PROPERTY(inData, m_components);
+}
+
+bool Prefab::ValidateForInstantiation(std::string& outDiagnostic) const
+{
+	outDiagnostic.clear();
+	if (m_gameObjects.IsEmpty())
+	{
+		outDiagnostic = "the prefab has no game objects";
+		return false;
+	}
+
+	TSet<InstanceId> componentInstanceIds;
+	TVector<InstanceId> componentInstanceIdsByIndex;
+	componentInstanceIdsByIndex.Reserve(m_components.Num());
+	for (uint32_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
+	{
+		const ReflectedData& reflection = m_components[componentIndex];
+		if (!reflection.IsValid())
+		{
+			outDiagnostic = "reflected component " + std::to_string(componentIndex) +
+				" has an unknown type; load or rebuild the workspace logic module";
+			return false;
+		}
+
+		const auto& properties = reflection.GetProperties();
+		if (!properties.ContainsKey("instanceId"))
+		{
+			outDiagnostic = "reflected component " + std::to_string(componentIndex) +
+				" has no instanceId";
+			return false;
+		}
+
+		InstanceId componentInstanceId;
+		std::string conversionDiagnostic;
+		if (!External::TryConvertYaml(properties["instanceId"], componentInstanceId, conversionDiagnostic) ||
+			componentInstanceId.ComponentId() == InstanceId::Invalid ||
+			componentInstanceId.GameObjectId() == InstanceId::Invalid)
+		{
+			outDiagnostic = "reflected component " + std::to_string(componentIndex) +
+				" has an invalid instanceId";
+			if (!conversionDiagnostic.empty())
+			{
+				outDiagnostic += ": " + conversionDiagnostic;
+			}
+			return false;
+		}
+
+		if (!componentInstanceIds.Insert(componentInstanceId))
+		{
+			outDiagnostic = "reflected component " + std::to_string(componentIndex) +
+				" has a duplicate instanceId";
+			return false;
+		}
+
+		componentInstanceIdsByIndex.Add(componentInstanceId);
+	}
+
+	const uint32_t invalidParentIndex = static_cast<uint32_t>(-1);
+	uint32_t numRoots = 0;
+	TSet<InstanceId> gameObjectInstanceIds;
+	TSet<uint32_t> referencedComponentIndices;
+	for (uint32_t gameObjectIndex = 0; gameObjectIndex < m_gameObjects.Num(); ++gameObjectIndex)
+	{
+		const auto& gameObject = m_gameObjects[gameObjectIndex];
+		if (!gameObject.m_bHasParentIndex)
+		{
+			outDiagnostic = "game object " + std::to_string(gameObjectIndex) +
+				" has no parentIndex";
+			return false;
+		}
+
+		if (!gameObject.m_instanceId.IsGameObjectId())
+		{
+			outDiagnostic = "game object " + std::to_string(gameObjectIndex) +
+				" has an invalid instanceId";
+			return false;
+		}
+
+		if (!gameObjectInstanceIds.Insert(gameObject.m_instanceId))
+		{
+			outDiagnostic = "game object " + std::to_string(gameObjectIndex) +
+				" has a duplicate instanceId";
+			return false;
+		}
+
+		if (gameObject.m_parentIndex == invalidParentIndex)
+		{
+			++numRoots;
+		}
+		else if (gameObject.m_parentIndex >= m_gameObjects.Num())
+		{
+			outDiagnostic = "game object " + std::to_string(gameObjectIndex) +
+				" has invalid parent index " + std::to_string(gameObject.m_parentIndex);
+			return false;
+		}
+
+		for (const uint32_t componentIndex : gameObject.m_components)
+		{
+			if (componentIndex >= m_components.Num())
+			{
+				outDiagnostic = "game object " + std::to_string(gameObjectIndex) +
+					" references invalid component index " + std::to_string(componentIndex);
+				return false;
+			}
+
+			if (!referencedComponentIndices.Insert(componentIndex))
+			{
+				outDiagnostic = "component index " + std::to_string(componentIndex) +
+					" is referenced more than once";
+				return false;
+			}
+
+			if (componentInstanceIdsByIndex[componentIndex].GameObjectId() != gameObject.m_instanceId)
+			{
+				outDiagnostic = "reflected component " + std::to_string(componentIndex) +
+					" belongs to a different game object";
+				return false;
+			}
+		}
+	}
+
+	if (referencedComponentIndices.Num() != m_components.Num())
+	{
+		outDiagnostic = "the prefab contains an unreferenced reflected component";
+		return false;
+	}
+
+	if (numRoots != 1)
+	{
+		outDiagnostic = "the prefab must contain exactly one root game object";
+		return false;
+	}
+
+	for (uint32_t gameObjectIndex = 0; gameObjectIndex < m_gameObjects.Num(); ++gameObjectIndex)
+	{
+		uint32_t ancestorIndex = gameObjectIndex;
+		bool bReachedRoot = false;
+		for (uint32_t depth = 0; depth < m_gameObjects.Num(); ++depth)
+		{
+			const uint32_t parentIndex = m_gameObjects[ancestorIndex].m_parentIndex;
+			if (parentIndex == invalidParentIndex)
+			{
+				bReachedRoot = true;
+				break;
+			}
+
+			ancestorIndex = parentIndex;
+		}
+
+		if (!bReachedRoot)
+		{
+			outDiagnostic = "the prefab hierarchy contains a parent cycle at game object " +
+				std::to_string(gameObjectIndex);
+			return false;
+		}
+	}
+
+	return true;
 }
 
 bool Prefab::SaveToFile(const std::string& path) const

--- a/Runtime/AssetRegistry/Prefab/PrefabImporter.h
+++ b/Runtime/AssetRegistry/Prefab/PrefabImporter.h
@@ -36,16 +36,22 @@ namespace Sailor
 			EMobilityType m_mobilityType{};
 
 			glm::vec4 m_position{};
-			glm::quat m_rotation{};
-			glm::vec4 m_scale{};
+			glm::quat m_rotation = glm::identity<glm::quat>();
+			glm::vec4 m_scale{ 1.0f };
 
 			// We store indices
-			uint32_t m_parentIndex;
+			uint32_t m_parentIndex = static_cast<uint32_t>(-1);
 			TVector<uint32_t> m_components;
 			InstanceId m_instanceId;
 
 			SAILOR_API virtual YAML::Node Serialize() const override;
 			SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
+
+		private:
+
+			bool m_bHasParentIndex = true;
+
+			friend class Prefab;
 		};
 
 		SAILOR_API Prefab(FileId uid) :
@@ -56,6 +62,7 @@ namespace Sailor
 
 		SAILOR_API virtual YAML::Node Serialize() const override;
 		SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
+		SAILOR_API bool ValidateForInstantiation(std::string& outDiagnostic) const;
 
 		SAILOR_API bool SaveToFile(const std::string& path) const;
 

--- a/Runtime/AssetRegistry/Shader/ShaderCache.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.cpp
@@ -1038,6 +1038,60 @@ void ShaderCache::SaveCache(bool bForcely)
 	SaveCacheLocked(bForcely);
 }
 
+bool ShaderCache::RecoverMissingStorage()
+{
+	SAILOR_PROFILE_FUNCTION();
+
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	if (m_bPreserveStorageAfterLoadFailure)
+	{
+		return false;
+	}
+
+	bool bStorageMissing = false;
+	auto inspect = [&](const std::filesystem::path& path, bool bExpectDirectory) -> bool
+	{
+		std::error_code error;
+		const std::filesystem::file_status status = std::filesystem::symlink_status(path, error);
+		if (error == std::errc::no_such_file_or_directory ||
+			error == std::errc::not_a_directory)
+		{
+			bStorageMissing = true;
+			return true;
+		}
+		if (error)
+		{
+			m_lastSaveDiagnostic = "Cannot inspect shader cache storage '" +
+				path.generic_string() + "': " + error.message();
+			SAILOR_LOG_ERROR("Shader cache recovery failed: %s", m_lastSaveDiagnostic.c_str());
+			return false;
+		}
+
+		const bool bExpectedType = bExpectDirectory
+			? std::filesystem::is_directory(status)
+			: std::filesystem::is_regular_file(status);
+		bStorageMissing |= !bExpectedType;
+		return true;
+	};
+
+	if (!inspect(GetCacheFilepathLocked(), false) ||
+		!inspect(GetPrecompiledFolderLocked(), true) ||
+		!inspect(GetCompiledFolderLocked(), true) ||
+		!inspect(GetCompiledDebugFolderLocked(), true) ||
+		!bStorageMissing)
+	{
+		return false;
+	}
+
+	Workspace::WorkspaceCacheLoadResult loadResult;
+	loadResult.m_status = Workspace::EWorkspaceCacheLoadStatus::Missing;
+	loadResult.m_diagnostic =
+		"Shader cache storage disappeared during the running session.";
+	ResetInvalidCacheLocked(std::move(loadResult));
+	return m_bHasCommittedSnapshot && !m_bIsDirty &&
+		!m_bPreserveStorageAfterLoadFailure;
+}
+
 bool ShaderCache::SaveCacheLocked(
 	bool bForcely,
 	Workspace::EWorkspaceCacheAtomicWriteFailurePoint failurePoint)
@@ -2197,6 +2251,45 @@ void ShaderCache::Remove(const FileId& uid)
 	{
 		m_lastSaveDiagnostic = std::move(diagnostic);
 		SAILOR_LOG_ERROR("Shader cache remove failed: %s", m_lastSaveDiagnostic.c_str());
+	}
+}
+
+void ShaderCache::Invalidate(const FileId& uid)
+{
+	SAILOR_PROFILE_FUNCTION();
+
+	std::lock_guard<std::mutex> lock(m_cacheMutex);
+	bool bInvalidated = false;
+	if (m_cache.m_data.ContainsKey(uid))
+	{
+		for (ShaderCacheData::Entry& entry : m_cache.m_data[uid])
+		{
+			// Keep the last durable generation as a fallback, but make expiry independent
+			// of the source filesystem's timestamp resolution.
+			entry.m_timestamp = 0;
+			bInvalidated = true;
+		}
+	}
+	for (QuarantinedEntry& entry : m_quarantinedEntries)
+	{
+		if (entry.m_fileId == uid)
+		{
+			entry.m_timestamp = 0;
+			bInvalidated = true;
+		}
+	}
+	if (!bInvalidated)
+	{
+		return;
+	}
+
+	m_bIsDirty = true;
+	if (!SaveCacheLocked(false))
+	{
+		SAILOR_LOG_ERROR(
+			"Shader cache invalidation could not be persisted for %s: %s",
+			uid.ToString().c_str(),
+			m_lastSaveDiagnostic.c_str());
 	}
 }
 

--- a/Runtime/AssetRegistry/Shader/ShaderCache.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.h
@@ -78,12 +78,14 @@ namespace Sailor
 			bool bIsDebug = false);
 
 		SAILOR_API void Remove(const FileId& uid);
+		SAILOR_API void Invalidate(const FileId& uid);
 
 		SAILOR_API bool Contains(const FileId& uid) const;
 		SAILOR_API bool IsExpired(const FileId& uid, uint32_t permutation);
 
 		SAILOR_API void LoadCache();
 		SAILOR_API void SaveCache(bool bForcely = false);
+		SAILOR_API bool RecoverMissingStorage();
 
 		SAILOR_API void ClearAll();
 		SAILOR_API void ClearExpired();

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -10,6 +10,7 @@
 #include "RHI/Shader.h"
 #include "Core/Utils.h"
 #include <atomic>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <algorithm>
@@ -421,6 +422,55 @@ bool ShaderCompiler::ShouldRetryDirtyShaderCache(
 	return numPermutationsToCompile == 0 && bCacheDirty;
 }
 
+TVector<FileId> ShaderCompiler::MergeShaderDependencyCandidates(
+	const TVector<FileId>& parsedShaderIds,
+	const TVector<FileId>& loadedShaderIds)
+{
+	TVector<FileId> result = parsedShaderIds;
+	result.Reserve(parsedShaderIds.Num() + loadedShaderIds.Num());
+	for (const FileId& loadedShaderId : loadedShaderIds)
+	{
+		if (!result.Contains(loadedShaderId))
+		{
+			result.Add(loadedShaderId);
+		}
+	}
+	return result;
+}
+
+std::string ShaderCompiler::NormalizeShaderExtension(const std::string& filepath)
+{
+	std::string extension = Utils::GetFileExtension(filepath);
+	std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char character)
+		{
+			return static_cast<char>(std::tolower(character));
+		});
+	return extension;
+}
+
+bool ShaderCompiler::DoesShaderIncludePath(
+	const TVector<std::string>& includes,
+	const std::string& relativePath)
+{
+	auto normalize = [](const std::string& path)
+	{
+		std::string result = std::filesystem::path(path).lexically_normal().generic_string();
+#if defined(_WIN32)
+		std::transform(result.begin(), result.end(), result.begin(), [](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+#endif
+		return result;
+	};
+
+	const std::string normalizedRelativePath = normalize(relativePath);
+	return includes.ContainsIf([&](const std::string& include)
+		{
+			return normalize(include) == normalizedRelativePath;
+		});
+}
+
 void ShaderCompiler::RemoveFinishedPromiseEntries(
 	TVector<TPair<uint32_t, Tasks::TaskPtr<ShaderSetPtr>>>& entries)
 {
@@ -589,6 +639,48 @@ TWeakPtr<ShaderAsset> ShaderCompiler::LoadShaderAsset(ShaderAssetInfoPtr shaderA
 	return TWeakPtr<ShaderAsset>();
 }
 
+bool ShaderCompiler::RecoverMissingShaderCacheStorage()
+{
+	if (!m_shaderCache.RecoverMissingStorage())
+	{
+		return false;
+	}
+
+	m_loadedShaders.LockAll();
+	const TVector<FileId> loadedShaderIds = m_loadedShaders.GetKeys();
+	m_loadedShaders.UnlockAll();
+
+	bool bReloadedAny = false;
+	bool bAllReloaded = true;
+	for (const FileId& shaderId : loadedShaderIds)
+	{
+		auto& loadedShaders = m_loadedShaders.At_Lock(shaderId);
+		for (auto& loadedShader : loadedShaders)
+		{
+			if (UpdateRHIResource(loadedShader.m_second, loadedShader.m_first))
+			{
+				loadedShader.m_second->TraceHotReload(nullptr);
+				bReloadedAny = true;
+			}
+			else
+			{
+				bAllReloaded = false;
+			}
+		}
+		m_loadedShaders.Unlock(shaderId);
+	}
+
+	if (bReloadedAny || !bAllReloaded)
+	{
+		SaveShaderCacheAndCombineResult(m_shaderCache, bAllReloaded);
+	}
+	SAILOR_LOG(
+		"Recovered missing shader cache storage; reloaded=%s loadedShaderAssets=%zd.",
+		bAllReloaded ? "true" : "false",
+		loadedShaderIds.Num());
+	return true;
+}
+
 void ShaderCompiler::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
 {
 	SAILOR_PROFILE_FUNCTION();
@@ -596,7 +688,7 @@ void ShaderCompiler::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
 
 	if (bWasExpired)
 	{
-		const std::string extension = Utils::GetFileExtension(assetInfo->GetAssetFilepath());
+		const std::string extension = NormalizeShaderExtension(assetInfo->GetAssetFilepath());
 
 		ReplaceTabsWithSpaces(assetInfo);
 
@@ -606,6 +698,7 @@ void ShaderCompiler::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
 			SAILOR_LOG("Updated shader info: %s", assetInfo->GetAssetFilepath().c_str());
 
 			m_shaderAssetsCache.Remove(assetInfo->GetFileId());
+			m_shaderCache.Invalidate(assetInfo->GetFileId());
 
 			if (bShouldAutoCompileAllPermutations)
 			{
@@ -633,6 +726,7 @@ void ShaderCompiler::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
 			}
 			else
 			{
+				bool bReloadedAny = false;
 				auto& loadedShaders = m_loadedShaders.At_Lock(assetInfo->GetFileId());
 				for (auto& loadedShader : loadedShaders)
 				{
@@ -641,19 +735,40 @@ void ShaderCompiler::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
 					if (UpdateRHIResource(loadedShader.m_second, loadedShader.m_first))
 					{
 						loadedShader.m_second->TraceHotReload(nullptr);
+						bReloadedAny = true;
 					}
 				}
 				m_loadedShaders.Unlock(assetInfo->GetFileId());
+				if (bReloadedAny)
+				{
+					SaveShaderCacheAndCombineResult(m_shaderCache, true);
+				}
 			}
 		}
 		else if (extension == "glsl")
 		{
+			m_shaderAssetsCache.LockAll();
+			const TVector<FileId> parsedShaderIds = m_shaderAssetsCache.GetKeys();
+			m_shaderAssetsCache.UnlockAll();
+			m_loadedShaders.LockAll();
+			const TVector<FileId> loadedShaderIds = m_loadedShaders.GetKeys();
+			m_loadedShaders.UnlockAll();
+
+			const TVector<FileId> dependencyCandidates = MergeShaderDependencyCandidates(
+				parsedShaderIds,
+				loadedShaderIds);
 			TVector<AssetInfoPtr> shaderDeps;
-			for (auto& shader : m_shaderAssetsCache)
+			for (const FileId& shaderId : dependencyCandidates)
 			{
-				if (shader.m_second->GetIncludes().Contains(assetInfo->GetRelativeAssetFilepath()))
+				TSharedPtr<ShaderAsset> shader = LoadShaderAsset(shaderId).Lock();
+				if (shader && DoesShaderIncludePath(
+						shader->GetIncludes(),
+						assetInfo->GetRelativeAssetFilepath()))
 				{
-					shaderDeps.Add(App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(shader.m_first));
+					if (AssetInfoPtr shaderAssetInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(shaderId))
+					{
+						shaderDeps.Add(shaderAssetInfo);
+					}
 				}
 			}
 
@@ -678,7 +793,7 @@ void ShaderCompiler::ReplaceTabsWithSpaces(AssetInfoPtr assetInfo) const
 	}
 
 	const std::string& filepath = assetInfo->GetAssetFilepath();
-	const std::string extension = Utils::GetFileExtension(filepath);
+	const std::string extension = NormalizeShaderExtension(filepath);
 	if (extension != "shader")
 	{
 		return;
@@ -1318,6 +1433,25 @@ bool ShaderCompilerTestAccess::ShouldRetryCacheSave(
 	return ShaderCompiler::ShouldRetryDirtyShaderCache(
 		numPermutationsToCompile,
 		bCacheDirty);
+}
+
+TVector<FileId> ShaderCompilerTestAccess::MergeShaderDependencyCandidates(
+	const TVector<FileId>& parsedShaderIds,
+	const TVector<FileId>& loadedShaderIds)
+{
+	return ShaderCompiler::MergeShaderDependencyCandidates(parsedShaderIds, loadedShaderIds);
+}
+
+std::string ShaderCompilerTestAccess::NormalizeShaderExtension(const std::string& filepath)
+{
+	return ShaderCompiler::NormalizeShaderExtension(filepath);
+}
+
+bool ShaderCompilerTestAccess::DoesShaderIncludePath(
+	const TVector<std::string>& includes,
+	const std::string& relativePath)
+{
+	return ShaderCompiler::DoesShaderIncludePath(includes, relativePath);
 }
 
 bool ShaderCompilerTestAccess::NormalizeShaderTabs(

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -3,6 +3,7 @@
 #include "AssetRegistry/FileId.h"
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
+#include "YamlExceptionBoundary.h"
 
 #include "ShaderAssetInfo.h"
 #include "ShaderCache.h"
@@ -13,6 +14,8 @@
 #include <fstream>
 #include <algorithm>
 #include <iostream>
+#include <iterator>
+#include <limits>
 #include <memory>
 
 #include "Core/YamlSerializable.h"
@@ -535,26 +538,49 @@ TWeakPtr<ShaderAsset> ShaderCompiler::LoadShaderAsset(ShaderAssetInfoPtr shaderA
 		FileId uid = shaderAssetInfo->GetFileId();
 
 		auto& shaderAsset = m_shaderAssetsCache.At_Lock(uid);
+		TConcurrentMapEntryUnlockGuard shaderAssetUnlockGuard(m_shaderAssetsCache, uid);
 		if (shaderAsset)
 		{
-			m_shaderAssetsCache.Unlock(uid);
 			return shaderAsset;
 		}
 
 		const std::string& filepath = shaderAssetInfo->GetAssetFilepath();
 
 		std::string shaderText;
-		AssetRegistry::ReadAllTextFile(filepath, shaderText);
+		if (!AssetRegistry::ReadAllTextFile(filepath, shaderText))
+		{
+			SAILOR_LOG_ERROR("Cannot read shader YAML '%s'.", filepath.c_str());
+			return TWeakPtr<ShaderAsset>();
+		}
+
+		std::string yamlDiagnostic;
+		NormalizeShaderTabs("shader", shaderText, yamlDiagnostic);
+		if (!yamlDiagnostic.empty())
+		{
+			SAILOR_LOG_ERROR("Cannot parse shader YAML '%s': %s", filepath.c_str(), yamlDiagnostic.c_str());
+			return TWeakPtr<ShaderAsset>();
+		}
 
 		YAML::Node yamlNode;
-
-		yamlNode = YAML::Load(shaderText);
+		if (!External::TryLoadYaml(shaderText, yamlNode, yamlDiagnostic))
+		{
+			SAILOR_LOG_ERROR("Cannot parse shader YAML '%s': %s", filepath.c_str(), yamlDiagnostic.c_str());
+			return TWeakPtr<ShaderAsset>();
+		}
 
 		ShaderAsset* shader = new ShaderAsset();
-		shader->Deserialize(yamlNode);
+		if (!External::GuardYamlExceptions(
+				[shader, &yamlNode]()
+				{
+					shader->Deserialize(yamlNode);
+				},
+				yamlDiagnostic))
+		{
+			SAILOR_LOG_ERROR("Cannot deserialize shader YAML '%s': %s", filepath.c_str(), yamlDiagnostic.c_str());
+			delete shader;
+			return TWeakPtr<ShaderAsset>();
+		}
 		shaderAsset = TSharedPtr<ShaderAsset>(shader);
-
-		m_shaderAssetsCache.Unlock(uid);
 
 		return shaderAsset;
 	}
@@ -652,13 +678,180 @@ void ShaderCompiler::ReplaceTabsWithSpaces(AssetInfoPtr assetInfo) const
 	}
 
 	const std::string& filepath = assetInfo->GetAssetFilepath();
+	const std::string extension = Utils::GetFileExtension(filepath);
+	if (extension != "shader")
+	{
+		return;
+	}
 
 	std::string shaderText;
-	AssetRegistry::ReadAllTextFile(filepath, shaderText);
+	std::string readDiagnostic;
+	if (!ReadShaderSourceBinary(filepath, shaderText, readDiagnostic))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot read shader YAML '%s': %s",
+			filepath.c_str(),
+			readDiagnostic.c_str());
+		return;
+	}
+	const std::string originalShaderText = shaderText;
+
+	std::string yamlDiagnostic;
+	if (!NormalizeShaderTabs(extension, shaderText, yamlDiagnostic))
+	{
+		if (!yamlDiagnostic.empty())
+		{
+			SAILOR_LOG_ERROR("Cannot parse shader YAML '%s': %s", filepath.c_str(), yamlDiagnostic.c_str());
+		}
+		return;
+	}
+
+	std::string writeDiagnostic;
+	if (!RewriteShaderSourceInPlace(
+			filepath,
+			originalShaderText,
+			shaderText,
+			writeDiagnostic))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot safely rewrite shader YAML '%s': %s",
+			filepath.c_str(),
+			writeDiagnostic.c_str());
+	}
+}
+
+bool ShaderCompiler::ReadShaderSourceBinary(
+	const std::string& filepath,
+	std::string& outSource,
+	std::string& outDiagnostic)
+{
+	outSource.clear();
+	outDiagnostic.clear();
+	std::ifstream shaderFile(filepath, std::ios::in | std::ios::binary);
+	if (!shaderFile.is_open())
+	{
+		outDiagnostic = "Cannot open the shader source for reading.";
+		return false;
+	}
+
+	outSource.assign(
+		std::istreambuf_iterator<char>{ shaderFile },
+		std::istreambuf_iterator<char>{});
+	if (shaderFile.bad())
+	{
+		outSource.clear();
+		outDiagnostic = "Cannot read the complete shader source.";
+		return false;
+	}
+
+	return true;
+}
+
+bool ShaderCompiler::RewriteShaderSourceInPlace(
+	const std::string& filepath,
+	const std::string& expectedSource,
+	const std::string& replacement,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	if (replacement.size() < expectedSource.size())
+	{
+		outDiagnostic = "The normalized shader source must not be smaller than the original source.";
+		return false;
+	}
+
+	if (replacement.size() > static_cast<size_t>((std::numeric_limits<std::streamsize>::max)()))
+	{
+		outDiagnostic = "The normalized shader source is too large to write.";
+		return false;
+	}
+
+	std::fstream shaderFile(filepath, std::ios::in | std::ios::out | std::ios::binary);
+	if (!shaderFile.is_open())
+	{
+		outDiagnostic = "Cannot open the shader source for an in-place update.";
+		return false;
+	}
+
+	const std::string currentSource{
+		std::istreambuf_iterator<char>{ shaderFile },
+		std::istreambuf_iterator<char>{} };
+	if (shaderFile.bad())
+	{
+		outDiagnostic = "Cannot verify the shader source before updating it.";
+		return false;
+	}
+
+	if (currentSource != expectedSource)
+	{
+		outDiagnostic = "The shader source changed while it was being normalized.";
+		return false;
+	}
+
+	shaderFile.clear();
+	shaderFile.seekp(0, std::ios::beg);
+	if (!shaderFile.good())
+	{
+		outDiagnostic = "Cannot seek to the beginning of the shader source.";
+		return false;
+	}
+
+	shaderFile.write(
+		replacement.data(),
+		static_cast<std::streamsize>(replacement.size()));
+	shaderFile.flush();
+	if (!shaderFile.good())
+	{
+		outDiagnostic = "Cannot write the normalized shader source.";
+		return false;
+	}
+	shaderFile.close();
+	if (shaderFile.fail())
+	{
+		outDiagnostic = "Cannot close the normalized shader source.";
+		return false;
+	}
+
+	return true;
+}
+
+bool ShaderCompiler::NormalizeShaderTabs(
+	const std::string& extension,
+	std::string& shaderText,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	if (extension != "shader")
+	{
+		return false;
+	}
 
 	YAML::Node yamlNode;
+	if (External::TryLoadYaml(shaderText, yamlNode, outDiagnostic))
+	{
+		return false;
+	}
 
-	yamlNode = YAML::Load(shaderText);
+	if (shaderText.find('\t') == std::string::npos)
+	{
+		return false;
+	}
+
+	std::string normalizedShaderText = shaderText;
+	static const std::string tab = "\t";
+	static const std::string space = "    ";
+	Utils::ReplaceAll(normalizedShaderText, tab, space);
+
+	std::string normalizedDiagnostic;
+	if (!External::TryLoadYaml(normalizedShaderText, yamlNode, normalizedDiagnostic))
+	{
+		outDiagnostic = std::move(normalizedDiagnostic);
+		return false;
+	}
+
+	shaderText = std::move(normalizedShaderText);
+	outDiagnostic.clear();
+	return true;
 }
 
 void ShaderCompiler::OnImportAsset(AssetInfoPtr assetInfo)
@@ -1125,6 +1318,35 @@ bool ShaderCompilerTestAccess::ShouldRetryCacheSave(
 	return ShaderCompiler::ShouldRetryDirtyShaderCache(
 		numPermutationsToCompile,
 		bCacheDirty);
+}
+
+bool ShaderCompilerTestAccess::NormalizeShaderTabs(
+	const std::string& extension,
+	std::string& shaderText,
+	std::string& outDiagnostic)
+{
+	return ShaderCompiler::NormalizeShaderTabs(extension, shaderText, outDiagnostic);
+}
+
+bool ShaderCompilerTestAccess::RewriteShaderSourceInPlace(
+	const std::string& filepath,
+	const std::string& expectedSource,
+	const std::string& replacement,
+	std::string& outDiagnostic)
+{
+	return ShaderCompiler::RewriteShaderSourceInPlace(
+		filepath,
+		expectedSource,
+		replacement,
+		outDiagnostic);
+}
+
+bool ShaderCompilerTestAccess::ReadShaderSourceBinary(
+	const std::string& filepath,
+	std::string& outSource,
+	std::string& outDiagnostic)
+{
+	return ShaderCompiler::ReadShaderSourceBinary(filepath, outSource, outDiagnostic);
 }
 
 bool ShaderCompilerTestAccess::ExerciseFailedLoadEvictionAndRetry()

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.h
@@ -125,6 +125,7 @@ namespace Sailor
 
 		SAILOR_API virtual void OnImportAsset(AssetInfoPtr assetInfo) override;
 		SAILOR_API virtual void OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired) override;
+		SAILOR_API bool RecoverMissingShaderCacheStorage();
 
 		SAILOR_API bool LoadAsset(FileId uid, TObjectPtr<Object>& out, bool bImmediate = true) override;
 		SAILOR_API bool LoadShader_Immediate(FileId uid, ShaderSetPtr& outShader, const TVector<string>& defines = {});
@@ -164,6 +165,13 @@ namespace Sailor
 		static bool ShouldRetryDirtyShaderCache(
 			size_t numPermutationsToCompile,
 			bool bCacheDirty) noexcept;
+		static TVector<FileId> MergeShaderDependencyCandidates(
+			const TVector<FileId>& parsedShaderIds,
+			const TVector<FileId>& loadedShaderIds);
+		static std::string NormalizeShaderExtension(const std::string& filepath);
+		static bool DoesShaderIncludePath(
+			const TVector<std::string>& includes,
+			const std::string& relativePath);
 
 		template<typename TValue>
 		static size_t FindPermutationIndex(
@@ -263,6 +271,13 @@ namespace Sailor
 		SAILOR_API static bool ShouldRetryCacheSave(
 			size_t numPermutationsToCompile,
 			bool bCacheDirty);
+		SAILOR_API static TVector<FileId> MergeShaderDependencyCandidates(
+			const TVector<FileId>& parsedShaderIds,
+			const TVector<FileId>& loadedShaderIds);
+		SAILOR_API static std::string NormalizeShaderExtension(const std::string& filepath);
+		SAILOR_API static bool DoesShaderIncludePath(
+			const TVector<std::string>& includes,
+			const std::string& relativePath);
 		SAILOR_API static bool NormalizeShaderTabs(
 			const std::string& extension,
 			std::string& shaderText,

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.h
@@ -230,6 +230,19 @@ namespace Sailor
 		}
 
 		SAILOR_API void ReplaceTabsWithSpaces(AssetInfoPtr assetInfo) const;
+		static bool ReadShaderSourceBinary(
+			const std::string& filepath,
+			std::string& outSource,
+			std::string& outDiagnostic);
+		static bool RewriteShaderSourceInPlace(
+			const std::string& filepath,
+			const std::string& expectedSource,
+			const std::string& replacement,
+			std::string& outDiagnostic);
+		static bool NormalizeShaderTabs(
+			const std::string& extension,
+			std::string& shaderText,
+			std::string& outDiagnostic);
 
 		SAILOR_API Tasks::TaskPtr<bool> CompileAllPermutations(ShaderAssetInfoPtr shaderAssetInfo);
 		SAILOR_API TWeakPtr<ShaderAsset> LoadShaderAsset(ShaderAssetInfoPtr shaderAssetInfo);
@@ -250,6 +263,19 @@ namespace Sailor
 		SAILOR_API static bool ShouldRetryCacheSave(
 			size_t numPermutationsToCompile,
 			bool bCacheDirty);
+		SAILOR_API static bool NormalizeShaderTabs(
+			const std::string& extension,
+			std::string& shaderText,
+			std::string& outDiagnostic);
+		SAILOR_API static bool RewriteShaderSourceInPlace(
+			const std::string& filepath,
+			const std::string& expectedSource,
+			const std::string& replacement,
+			std::string& outDiagnostic);
+		SAILOR_API static bool ReadShaderSourceBinary(
+			const std::string& filepath,
+			std::string& outSource,
+			std::string& outDiagnostic);
 		SAILOR_API static bool ExerciseFailedLoadEvictionAndRetry();
 		SAILOR_API static bool ExercisePromiseGarbageCollection();
 	};

--- a/Runtime/Components/AnimatorComponent.cpp
+++ b/Runtime/Components/AnimatorComponent.cpp
@@ -13,6 +13,7 @@ void AnimatorComponent::Initialize()
 void AnimatorComponent::EndPlay()
 {
 	GetOwner()->GetWorld()->GetECS<AnimationECS>()->UnregisterComponent(m_handle);
+	m_handle = ECS::InvalidIndex;
 }
 
 uint32_t AnimatorComponent::GetSkeletonOffset() const
@@ -34,11 +35,7 @@ SAILOR_API const AnimatorComponentData& Sailor::AnimatorComponent::GetData() con
 
 void AnimatorComponent::SetAnimation(const AnimationPtr& animation)
 {
-	GetData().GetAnimation() = animation;
-	GetData().m_currentFrame = 0.0f;
-	GetData().m_frameIndex = 0;
-	GetData().m_lerp = 0.0f;
-	GetData().MarkDirty();
+	GetOwner()->GetWorld()->GetECS<AnimationECS>()->SetAnimation(m_handle, animation);
 }
 
 void AnimatorComponent::Play()

--- a/Runtime/Components/CameraComponent.cpp
+++ b/Runtime/Components/CameraComponent.cpp
@@ -96,4 +96,5 @@ void CameraComponent::UpdateProjectionMatrix()
 void CameraComponent::EndPlay()
 {
 	GetOwner()->GetWorld()->GetECS<CameraECS>()->UnregisterComponent(m_handle);
+	m_handle = ECS::InvalidIndex;
 }

--- a/Runtime/Components/LightComponent.cpp
+++ b/Runtime/Components/LightComponent.cpp
@@ -15,6 +15,7 @@ void LightComponent::Initialize()
 	auto& ecsData = GetData();
 
 	ecsData.SetOwner(GetOwner());
+	ecsData.MarkDirty();
 }
 
 void LightComponent::BeginPlay()
@@ -36,6 +37,7 @@ const LightData& LightComponent::GetData() const
 void LightComponent::EndPlay()
 {
 	GetOwner()->GetWorld()->GetECS<LightingECS>()->UnregisterComponent(m_handle);
+	m_handle = ECS::InvalidIndex;
 }
 
 void LightComponent::OnGizmo()

--- a/Runtime/Components/MeshRendererComponent.cpp
+++ b/Runtime/Components/MeshRendererComponent.cpp
@@ -33,6 +33,7 @@ const StaticMeshRendererData& MeshRendererComponent::GetData() const
 void MeshRendererComponent::EndPlay()
 {
 	GetOwner()->GetWorld()->GetECS<StaticMeshRendererECS>()->UnregisterComponent(m_handle);
+	m_handle = ECS::InvalidIndex;
 }
 
 void MeshRendererComponent::SetModel(const ModelPtr& model)

--- a/Runtime/Components/PathTracerProxyComponent.cpp
+++ b/Runtime/Components/PathTracerProxyComponent.cpp
@@ -18,6 +18,7 @@ void PathTracerProxyComponent::Initialize()
 void PathTracerProxyComponent::EndPlay()
 {
 	GetOwner()->GetWorld()->GetECS<PathTracerECS>()->UnregisterComponent(m_handle);
+	m_handle = ECS::InvalidIndex;
 }
 
 PathTracerProxyData& PathTracerProxyComponent::GetData()
@@ -52,4 +53,3 @@ void PathTracerProxyComponent::SetRebuildEveryFrame(bool bValue)
 		data.MarkDirty();
 	}
 }
-

--- a/Runtime/Containers/Octree.h
+++ b/Runtime/Containers/Octree.h
@@ -194,19 +194,30 @@ namespace Sailor
 				}
 
 				// If not then remove & reinsert
-				if ((*node)->Remove(element))
+				if (!(*node)->Remove(element))
 				{
-					Resolve_Internal(**node);
+					m_map.Remove(element);
+					if (m_num > 0)
+					{
+						m_num--;
+					}
+					return false;
 				}
+
+				Resolve_Internal(**node);
 
 				if (Insert_Internal(*m_root, pos, extents, element))
 				{
-					m_num++;
 					return true;
 				}
 
 				// Cannot insert the element into octree
 				m_map.Remove(element);
+				if (m_num > 0)
+				{
+					m_num--;
+				}
+				return false;
 			}
 
 			if (Insert_Internal(*m_root, pos, extents, element))

--- a/Runtime/ECS/AnimationECS.cpp
+++ b/Runtime/ECS/AnimationECS.cpp
@@ -11,6 +11,34 @@
 using namespace Sailor;
 using namespace Sailor::Tasks;
 
+namespace
+{
+	void MarkMeshSkeletonDirty(GameObjectPtr owner)
+	{
+		if (!owner)
+		{
+			return;
+		}
+
+		auto* meshEcs = owner->GetWorld()->GetECS<StaticMeshRendererECS>();
+		if (!meshEcs)
+		{
+			return;
+		}
+
+		for (auto component : owner->GetComponents())
+		{
+			if (auto mesh = component.DynamicCast<MeshRendererComponent>())
+			{
+				if (meshEcs->IsComponentRegistered(mesh->GetComponentIndex()))
+				{
+					mesh->GetData().MarkDirty();
+				}
+			}
+		}
+	}
+}
+
 void AnimationECS::BeginPlay()
 {
 	auto& driver = RHI::Renderer::GetDriver();
@@ -25,6 +53,53 @@ void AnimationECS::EndPlay()
 	m_nextBoneOffset = 0;
 }
 
+bool AnimationECS::TryAllocateBoneRange(uint32_t numBones, uint32_t& nextBoneOffset, uint32_t& outGpuOffset)
+{
+	outGpuOffset = AnimatorComponentData::InvalidGpuOffset;
+	if (numBones == 0 || nextBoneOffset > BonesMaxNum || numBones > BonesMaxNum - nextBoneOffset)
+	{
+		return false;
+	}
+
+	outGpuOffset = nextBoneOffset;
+	nextBoneOffset += numBones;
+	return true;
+}
+
+void AnimationECS::InvalidateGpuLayout()
+{
+	m_nextBoneOffset = 0;
+
+	for (auto& data : m_components)
+	{
+		data.m_gpuOffset = AnimatorComponentData::InvalidGpuOffset;
+		MarkMeshSkeletonDirty(data.m_owner.StaticCast<GameObject>());
+	}
+}
+
+void AnimationECS::SetAnimation(size_t componentIndex, const TObjectPtr<Animation>& animation)
+{
+	if (!IsComponentRegistered(componentIndex))
+	{
+		return;
+	}
+
+	auto& data = GetComponentData(componentIndex);
+	data.GetAnimation() = animation;
+	data.SetBonesCount(animation ? animation->m_numBones : 0);
+	data.m_currentFrame = 0.0f;
+	data.m_frameIndex = 0;
+	data.m_lerp = 0.0f;
+	data.MarkDirty();
+
+	InvalidateGpuLayout();
+}
+
+void AnimationECS::OnComponentUnregistered(size_t, AnimatorComponentData&)
+{
+	InvalidateGpuLayout();
+}
+
 Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 {
 	auto renderer = App::GetSubmodule<RHI::Renderer>();
@@ -32,9 +107,33 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 	auto cmdList = GetWorld()->GetCommandList();
 	commands->BeginDebugRegion(cmdList, "AnimationECS:Update", RHI::DebugContext::Color_CmdTransfer);
 
+	for (const auto& data : m_components)
+	{
+		if (!data.m_bIsActive || data.m_gpuOffset == AnimatorComponentData::InvalidGpuOffset)
+		{
+			continue;
+		}
+
+		const auto& animation = data.GetAnimation();
+		const bool bHasValidBoneRange = animation && animation->m_numFrames > 0 && animation->m_numBones > 0 &&
+			data.GetBonesCount() == animation->m_numBones &&
+			data.m_gpuOffset <= BonesMaxNum && animation->m_numBones <= BonesMaxNum - data.m_gpuOffset;
+		if (!bHasValidBoneRange)
+		{
+			InvalidateGpuLayout();
+			break;
+		}
+	}
+
 	for (auto& data : m_components)
 	{
-		if (!data.GetAnimation() || data.GetAnimation()->m_numFrames ==0)
+		if (!data.m_bIsActive)
+		{
+			continue;
+		}
+
+		GameObjectPtr owner = data.m_owner.StaticCast<GameObject>();
+		if (!owner || !data.GetAnimation() || data.GetAnimation()->m_numFrames == 0 || data.GetAnimation()->m_numBones == 0)
 		{
 			continue;
 		}
@@ -77,16 +176,19 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 		data.m_frameIndex = (uint32_t)floor(data.m_currentFrame) % anim.m_numFrames;
 		data.m_lerp = data.m_currentFrame - floor(data.m_currentFrame);
 
+		if (data.m_gpuOffset == AnimatorComponentData::InvalidGpuOffset)
+		{
+			if (!TryAllocateBoneRange(anim.m_numBones, m_nextBoneOffset, data.m_gpuOffset))
+			{
+				continue;
+			}
+
+			MarkMeshSkeletonDirty(data.m_owner.StaticCast<GameObject>());
+		}
+
 		if (data.m_currentSkeleton.Num() != anim.m_numBones)
 		{
 			data.m_currentSkeleton.Resize(anim.m_numBones);
-		}
-
-		if (data.m_gpuOffset == std::numeric_limits<uint32_t>::max())
-		{
-			data.m_gpuOffset = m_nextBoneOffset;
-			m_nextBoneOffset += anim.m_numBones;
-			m_nextBoneOffset = (std::min)(m_nextBoneOffset, BonesMaxNum);
 		}
 
 		uint32_t nextFrame = (data.m_frameIndex + 1) % anim.m_numFrames;
@@ -98,12 +200,9 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 		}
 
 		ModelPtr model;
-		if (auto owner = data.m_owner.StaticCast<GameObject>())
+		if (auto mesh = owner->GetComponent<MeshRendererComponent>())
 		{
-			if (auto mesh = owner->GetComponent<MeshRendererComponent>())
-			{
-				model = mesh->GetModel();
-			}
+			model = mesh->GetModel();
 		}
 
 		TVector<glm::mat4> matrices(data.m_currentSkeleton.Num());

--- a/Runtime/ECS/AnimationECS.h
+++ b/Runtime/ECS/AnimationECS.h
@@ -15,6 +15,8 @@ namespace Sailor
 	class AnimatorComponentData final : public ECS::TComponent
 	{
 	public:
+		static constexpr uint32_t InvalidGpuOffset = (std::numeric_limits<uint32_t>::max)();
+
 		SAILOR_API __forceinline TObjectPtr<Animation>& GetAnimation() { return m_animation; }
 		SAILOR_API __forceinline const TObjectPtr<Animation>& GetAnimation() const { return m_animation; }
 
@@ -23,7 +25,7 @@ namespace Sailor
 
 		uint32_t m_frameIndex = 0;
 		float m_lerp = 0.0f;
-		uint32_t m_gpuOffset = std::numeric_limits<uint32_t>::max();
+		uint32_t m_gpuOffset = InvalidGpuOffset;
 		TVector<Math::Transform> m_currentSkeleton;
 
 		bool m_bIsPlaying = true;
@@ -51,6 +53,11 @@ namespace Sailor
 		virtual void EndPlay() override;
 		virtual Tasks::ITaskPtr Tick(float deltaTime) override;
 
+		void SetAnimation(size_t componentIndex, const TObjectPtr<Animation>& animation);
+		void InvalidateGpuLayout();
+
+		static bool TryAllocateBoneRange(uint32_t numBones, uint32_t& nextBoneOffset, uint32_t& outGpuOffset);
+
 		void FillAnimationData(RHI::RHISceneViewPtr& sceneView);
 
 		virtual uint32_t GetOrder() const override { return 200; }
@@ -58,6 +65,8 @@ namespace Sailor
 		RHI::RHIShaderBindingSetPtr GetBonesBinding() const { return m_bonesBinding; }
 
 	protected:
+
+		virtual void OnComponentUnregistered(size_t index, AnimatorComponentData& component) override;
 
 		RHI::RHIShaderBindingSetPtr m_bonesBinding{};
 		RHI::RHIShaderBindingPtr m_bonesBuffer{};

--- a/Runtime/ECS/CameraECS.cpp
+++ b/Runtime/ECS/CameraECS.cpp
@@ -13,18 +13,26 @@ Tasks::ITaskPtr CameraECS::Tick(float deltaTime)
 
 	for (auto& data : m_components)
 	{
-		if (data.m_bIsActive)
+		if (!data.m_bIsActive)
 		{
-			const auto& transformComponent = data.m_owner.StaticCast<GameObject>()->GetTransformComponent();
-			const auto& worldMatrix = transformComponent.GetCachedWorldMatrix();
-
-			// The origin
-			const mat4 origin = glm::mat4(1);// glm::rotate(glm::mat4(1), glm::radians(90.0f), Math::vec3_Up);
-			data.m_viewMatrix = origin * glm::inverse(worldMatrix);
-
-			m_rhiCameras.Add(data);
-			m_rhiCameraTransforms.Add(Math::Transform::FromMatrix(worldMatrix));
+			continue;
 		}
+
+		GameObjectPtr owner = data.m_owner.StaticCast<GameObject>();
+		if (!owner)
+		{
+			continue;
+		}
+
+		const auto& transformComponent = owner->GetTransformComponent();
+		const auto& worldMatrix = transformComponent.GetCachedWorldMatrix();
+
+		// The origin
+		const mat4 origin = glm::mat4(1);// glm::rotate(glm::mat4(1), glm::radians(90.0f), Math::vec3_Up);
+		data.m_viewMatrix = origin * glm::inverse(worldMatrix);
+
+		m_rhiCameras.Add(data);
+		m_rhiCameraTransforms.Add(Math::Transform::FromMatrix(worldMatrix));
 	}
 
 	return nullptr;

--- a/Runtime/ECS/ECS.h
+++ b/Runtime/ECS/ECS.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <typeindex>
 #include <iostream>
+#include <new>
 #include "Sailor.h"
 #include "Core/Defines.h"
 #include "Engine/Types.h"
@@ -14,6 +15,9 @@ namespace Sailor::ECS
 {
 	constexpr size_t InvalidIndex = ((size_t)-1);
 
+	template<typename TECS, typename TData>
+	class TSystem;
+
 	class TComponent
 	{
 	public:
@@ -22,6 +26,7 @@ namespace Sailor::ECS
 		SAILOR_API virtual ~TComponent() = default;
 
 		SAILOR_API virtual void MarkDirty() { m_bIsDirty = true; }
+		SAILOR_API __forceinline bool IsDirty() const { return m_bIsDirty; }
 
 		SAILOR_API void SetLastChange(size_t currentFrame) { m_frameLastChange = currentFrame; }
 
@@ -36,6 +41,9 @@ namespace Sailor::ECS
 		size_t m_frameLastChange = 0;
 		bool m_bIsActive : 1 = true;
 		bool m_bIsDirty : 1 = false;
+
+		template<typename TECS, typename TData>
+		friend class TSystem;
 	};
 
 	using TBaseSystemPtr = TUniquePtr<class TBaseSystem>;
@@ -94,28 +102,51 @@ namespace Sailor::ECS
 
 		virtual size_t RegisterComponent() override
 		{
+			size_t index = InvalidIndex;
+
 			if (m_freeList.Num() == 0)
 			{
 				m_components.AddDefault(1);
-				return m_components.Num() - 1;
+				index = m_components.Num() - 1;
+			}
+			else
+			{
+				index = *(m_freeList.Last());
+				m_freeList.PopBack();
 			}
 
-			size_t res = *(m_freeList.Last());
-			m_freeList.PopBack();
-			return res;
+			auto& component = m_components[index];
+			component.m_bIsActive = true;
+			component.m_bIsDirty = false;
+			return index;
 		}
 
 		virtual void UnregisterComponent(size_t index) override
 		{
-			if (index != InvalidIndex)
+			if (index == InvalidIndex || index >= m_components.Num() || !m_components[index].m_bIsActive)
 			{
-				m_components[index].Clear();
+				return;
 			}
 
+			auto& component = m_components[index];
+			// Reserve the slot before invoking system-specific cleanup. A cleanup hook
+			// may indirectly attempt to unregister the same component again.
+			component.m_bIsActive = false;
+			OnComponentUnregistered(index, component);
+
+			component.~TData();
+			new (&component) TData();
+			component.m_bIsActive = false;
+			component.m_bIsDirty = true;
 			m_freeList.PushBack(index);
 		}
 
 		__forceinline TData& GetComponentData(size_t index) { return m_components[index]; }
+		__forceinline const TData& GetComponentData(size_t index) const { return m_components[index]; }
+		__forceinline bool IsComponentRegistered(size_t index) const
+		{
+			return index < m_components.Num() && m_components[index].m_bIsActive;
+		}
 
 		static size_t GetStaticType() { return std::type_index(typeid(TSystem)).hash_code(); }
 		virtual size_t GetComponentType() const override { return TSystem::GetComponentStaticType(); }
@@ -144,6 +175,8 @@ namespace Sailor::ECS
 		}
 
 	protected:
+
+		virtual void OnComponentUnregistered(size_t index, TData& component) {}
 
 		TVector<TData> m_components;
 		TList<size_t> m_freeList;

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -88,109 +88,82 @@ Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
 
 	TVector<LightShaderData> shaderDataBatch;
 	shaderDataBatch.Reserve(64);
-	bool bShouldWrite = true;
 	size_t startIndex = 0;
+	uint32_t numLights = 0;
 
-	uint32_t skipIndex = 0;
-	for (size_t index = 0; index < m_components.Num(); index++)
+	auto flushBatch = [&]()
 	{
-		if (m_skipList.Num() > 0 && skipIndex < m_skipList.Num() && index == m_skipList[skipIndex].m_first)
+		if (shaderDataBatch.IsEmpty())
 		{
-			index += m_skipList[skipIndex].m_second;
-			if (index >= m_components.Num())
-			{
-				break;
-			}
-			skipIndex++;
+			return;
 		}
 
+		driverCommands->UpdateShaderBinding(cmdList, binding,
+			shaderDataBatch.GetData(),
+			sizeof(LightingECS::LightShaderData) * shaderDataBatch.Num(),
+			binding->GetBufferOffset() + sizeof(LightingECS::LightShaderData) * startIndex);
+		shaderDataBatch.Clear(false);
+	};
+
+	const size_t numGpuLightSlots = GetGpuLightSlotsCount(m_components.Num());
+	for (size_t index = 0; index < numGpuLightSlots; index++)
+	{
 		auto& data = m_components[index];
-		auto owner = data.m_owner.StaticCast<GameObject>();
+		GameObjectPtr owner = data.m_owner.StaticCast<GameObject>();
+		const bool bIsUsable = data.m_bIsActive && owner;
+		bool bShouldWrite = false;
+		LightShaderData shaderData{};
 
-		if (owner->GetMobilityType() == EMobilityType::Static)
+		if (bIsUsable)
 		{
-			bool bPlaced = false;
+			numLights = (uint32_t)index + 1;
+			const auto& ownerTransform = owner->GetTransformComponent();
 
-			// Place in the end of the current batch
-			if (skipIndex > 0 && m_skipList.Num() > 0 && index == m_skipList[skipIndex - 1].m_first + m_skipList[skipIndex - 1].m_second)
+			if (data.m_bIsDirty || data.m_frameLastChange < ownerTransform.GetFrameLastChange())
 			{
-				m_skipList[skipIndex - 1].m_second++;
-				bPlaced = true;
-			}
+				shaderData.m_type = (uint32_t)data.m_type;
+				shaderData.m_shadowType = (uint32_t)data.m_shadowType;
+				shaderData.m_attenuation = data.m_attenuation;
+				shaderData.m_bounds = data.m_bounds;
+				shaderData.m_intensity = data.m_intensity;
+				shaderData.m_direction = glm::normalize(ownerTransform.GetForwardVector());
+				shaderData.m_worldPosition = ownerTransform.GetWorldPosition();
+				shaderData.m_cutOff = vec2(glm::cos(glm::radians(data.m_cutOff.x)), glm::cos(glm::radians(data.m_cutOff.y)));
 
-			if (!bPlaced && skipIndex > 0 && m_skipList.Num() > 0)
-			{
-				// Place in between batches
-				for (int32_t i = skipIndex - 1; i < (int32_t)m_skipList.Num() - 1; i++)
-				{
-					const uint32_t start = m_skipList[i].m_first + m_skipList[skipIndex - 1].m_second;
-					const uint32_t end = m_skipList[i + 1].m_first;
-
-					if (index > start && index < end)
-					{
-						m_skipList.Insert(TPair((uint32_t)index, 1u), i + 1);
-						bPlaced = true;
-						skipIndex++;
-						break;
-					}
-				}
-			}
-
-			// Place in the end
-			if (!bPlaced)
-			{
-				m_skipList.Add(TPair((uint32_t)index, 1u));
-				skipIndex++;
-				bPlaced = true;
+				data.m_frameLastChange = ownerTransform.GetFrameLastChange();
+				data.m_bIsDirty = false;
+				bShouldWrite = true;
 			}
 		}
-
-		if (!data.m_bIsActive)
-			continue;
-
-		const auto& ownerTransform = owner->GetTransformComponent();
-
-		if (data.m_bIsDirty || data.m_frameLastChange < owner->GetFrameLastChange())
+		else if (data.m_bIsDirty)
 		{
-			if (bShouldWrite)
-			{
-				bShouldWrite = false;
-				startIndex = index;
-			}
-
-			const auto& lightData = m_components[index];
-
-			LightShaderData shaderData;
-			shaderData.m_type = (uint32_t)lightData.m_type;
-			shaderData.m_shadowType = (uint32_t)lightData.m_shadowType;
-			shaderData.m_attenuation = lightData.m_attenuation;
-			shaderData.m_bounds = lightData.m_bounds;
-			shaderData.m_intensity = lightData.m_intensity;
-
-			shaderData.m_direction = glm::normalize(ownerTransform.GetForwardVector());
-			shaderData.m_worldPosition = ownerTransform.GetWorldPosition();
-			shaderData.m_cutOff = vec2(glm::cos(glm::radians(lightData.m_cutOff.x)), glm::cos(glm::radians(lightData.m_cutOff.y)));
-			shaderDataBatch.Emplace(std::move(shaderData));
-
-			data.m_frameLastChange = owner->GetFrameLastChange();
+			// A released slot can remain below the highest active index. Clear its
+			// previous GPU data once so the light cannot survive component removal.
 			data.m_bIsDirty = false;
-		}
-		else
-		{
 			bShouldWrite = true;
 		}
 
-		if ((bShouldWrite || index == m_components.Num() - 1) && shaderDataBatch.Num() > 0)
+		if (!bShouldWrite)
 		{
-			RHI::Renderer::GetDriverCommands()->UpdateShaderBinding(cmdList, binding,
-				shaderDataBatch.GetData(),
-				sizeof(LightingECS::LightShaderData) * shaderDataBatch.Num(),
-				binding->GetBufferOffset() +
-				sizeof(LightingECS::LightShaderData) * startIndex);
-
-			shaderDataBatch.Clear();
+			flushBatch();
+			continue;
 		}
+
+		if (!shaderDataBatch.IsEmpty() && startIndex + shaderDataBatch.Num() != index)
+		{
+			flushBatch();
+		}
+
+		if (shaderDataBatch.IsEmpty())
+		{
+			startIndex = index;
+		}
+
+		shaderDataBatch.Emplace(std::move(shaderData));
 	}
+
+	flushBatch();
+	m_numLights = numLights;
 
 	driverCommands->EndDebugRegion(cmdList);
 
@@ -205,6 +178,7 @@ void LightingECS::EndPlay()
 	m_shadowMaps.Clear();
 	m_lightMatrices.Clear();
 	m_shadowIndices.Clear();
+	m_numLights = 0;
 }
 
 void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
@@ -216,12 +190,19 @@ void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
 	SAILOR_PROFILE_FUNCTION();
 
 	// TODO: Cache lights that cast shadows separately to decrease algo complexity
-	for (size_t index = 0; index < m_components.Num(); index++)
+	const size_t numGpuLightSlots = GetGpuLightSlotsCount(m_components.Num());
+	for (size_t index = 0; index < numGpuLightSlots; index++)
 	{
 		auto& light = m_components[index];
 		if (light.m_shadowType != RHI::EShadowType::None && light.m_bIsActive)
 		{
-			const auto& ownerTransform = light.m_owner.StaticCast<GameObject>()->GetTransformComponent();
+			GameObjectPtr owner = light.m_owner.StaticCast<GameObject>();
+			if (!owner)
+			{
+				continue;
+			}
+
+			const auto& ownerTransform = owner->GetTransformComponent();
 
 			RHI::RHILightProxy lightProxy{};
 
@@ -401,18 +382,19 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 		sceneView->m_shadowMapsToUpdate.Add(std::move(updateShadowMaps));
 	}
 
-	// TODO: Pass only active lights
-	sceneView->m_totalNumLights = (uint32_t)m_components.Num();
+	sceneView->m_totalNumLights = m_numLights;
 	sceneView->m_rhiLightsData = m_lightsData;
 }
 
 void LightingECS::GetLightProxies(TVector<Raytracing::LightProxy>& outLights) const
 {
 	outLights.Clear();
-	outLights.Reserve(m_components.Num());
+	const size_t numGpuLightSlots = GetGpuLightSlotsCount(m_components.Num());
+	outLights.Reserve(numGpuLightSlots);
 
-	for (const auto& light : m_components)
+	for (size_t index = 0; index < numGpuLightSlots; ++index)
 	{
+		const auto& light = m_components[index];
 		if (!light.m_bIsActive)
 		{
 			continue;
@@ -439,4 +421,3 @@ void LightingECS::GetLightProxies(TVector<Raytracing::LightProxy>& outLights) co
 		outLights.Add(lightProxy);
 	}
 }
-

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -52,7 +52,11 @@ namespace Sailor
 
 		// Global constants
 		static constexpr uint32_t MaxShadowsInView = 128;
-		const uint32_t LightsMaxNum = 65535;
+		static constexpr uint32_t LightsMaxNum = 65535;
+		static constexpr size_t GetGpuLightSlotsCount(size_t numComponentSlots)
+		{
+			return numComponentSlots < LightsMaxNum ? numComponentSlots : LightsMaxNum;
+		}
 		static constexpr float ShadowsMemoryBudgetMb = 350.0f;
 
 		const RHI::EFormat ShadowMapFormat = RHI::EFormat::R16_SFLOAT;
@@ -71,7 +75,9 @@ namespace Sailor
 		// TODO: Tightly pack
 		struct LightShaderData
 		{
-			uint32_t m_type;
+			static constexpr uint32_t InvalidType = static_cast<uint32_t>(-1);
+
+			uint32_t m_type = InvalidType;
 			uint32_t m_shadowType;
 			alignas(16) glm::vec3 m_worldPosition;
 			alignas(16) glm::vec3 m_direction;
@@ -106,7 +112,7 @@ namespace Sailor
 			TVector<RHI::RHILightProxy>& outSortedSpotLights);
 
 		// Lights
-		TVector<TPair<uint32_t, uint32_t>> m_skipList;
+		uint32_t m_numLights = 0;
 		RHI::RHIShaderBindingSetPtr m_lightsData;
 
 		// Shadows

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -16,11 +16,85 @@ void StaticMeshRendererECS::BeginPlay()
 	m_sceneViewProxiesCache = RHI::RHISceneViewPtr::Make();
 }
 
+void StaticMeshRendererECS::OnComponentUnregistered(size_t index, StaticMeshRendererData& component)
+{
+	if (!m_sceneViewProxiesCache)
+	{
+		return;
+	}
+
+	RHI::RHIMeshProxy stationaryProxy{};
+	stationaryProxy.m_staticMeshEcs = index;
+	m_sceneViewProxiesCache->m_stationaryOctree.Remove(stationaryProxy);
+
+	RHI::RHISceneViewProxy staticProxy{};
+	staticProxy.m_staticMeshEcs = index;
+	m_sceneViewProxiesCache->m_staticOctree.Remove(staticProxy);
+}
+
 Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 {
 	const uint32_t NumComponentsPerTask = 1024;
 
 	SAILOR_PROFILE_FUNCTION();
+
+	if (!m_sceneViewProxiesCache)
+	{
+		return nullptr;
+	}
+
+	// Remove proxies which no longer belong in their previous mobility tree before
+	// producing updates. Marking moved entries dirty lets the opposite tree receive
+	// the proxy during this same tick.
+	for (size_t index = 0; index < m_components.Num(); index++)
+	{
+		auto& data = m_components[index];
+		GameObjectPtr ownerGameObject = data.m_owner.StaticCast<GameObject>();
+		const bool bHasRenderableModel = data.GetModel() && data.GetModel()->IsReady() && data.GetModel()->GetBoundsAABB().IsValid();
+		const bool bShouldBeStationary = data.m_bIsActive && ownerGameObject && bHasRenderableModel &&
+			ownerGameObject->GetMobilityType() == EMobilityType::Stationary;
+
+		if (!bShouldBeStationary)
+		{
+			RHI::RHIMeshProxy proxy{};
+			proxy.m_staticMeshEcs = index;
+			if (m_sceneViewProxiesCache->m_stationaryOctree.Remove(proxy))
+			{
+				data.m_bIsDirty = true;
+			}
+		}
+	}
+
+	auto cleanupStaticTask = Tasks::CreateTask("StaticMeshRendererECS:Remove Stale Static Objects",
+		[this]()
+		{
+			for (size_t index = 0; index < m_components.Num(); index++)
+			{
+				auto& data = m_components[index];
+				GameObjectPtr ownerGameObject = data.m_owner.StaticCast<GameObject>();
+				const bool bHasRenderableModel = data.GetModel() && data.GetModel()->IsReady() && data.GetModel()->GetBoundsAABB().IsValid();
+				bool bHasRenderableMaterials = !data.GetMaterials().IsEmpty();
+				for (const auto& material : data.GetMaterials())
+				{
+					bHasRenderableMaterials &= material && material->IsReady();
+				}
+
+				const bool bShouldBeStatic = data.m_bIsActive && ownerGameObject && bHasRenderableModel && bHasRenderableMaterials &&
+					ownerGameObject->GetMobilityType() == EMobilityType::Static;
+
+				if (!bShouldBeStatic)
+				{
+					RHI::RHISceneViewProxy proxy{};
+					proxy.m_staticMeshEcs = index;
+					if (m_sceneViewProxiesCache->m_staticOctree.Remove(proxy))
+					{
+						data.m_bIsDirty = true;
+					}
+				}
+			}
+		}, EThreadType::RHI)->Run();
+
+	cleanupStaticTask->Wait();
 
 	//TODO: Resolve New/Delete components
 	TVector<Tasks::TaskPtr<TVector<TPair<RHI::RHIMeshProxy, Math::AABB>>>> tasks;
@@ -40,7 +114,17 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 					}
 
 					auto& data = m_components[index];
-					auto ownerGameObject = data.m_owner.StaticCast<GameObject>();
+					if (!data.m_bIsActive)
+					{
+						continue;
+					}
+
+					GameObjectPtr ownerGameObject = data.m_owner.StaticCast<GameObject>();
+					if (!ownerGameObject)
+					{
+						continue;
+					}
+
 					EMobilityType mobilityType = ownerGameObject->GetMobilityType();
 
 					if (mobilityType == EMobilityType::Stationary && data.m_bIsActive && data.GetModel() && data.GetModel()->IsReady())
@@ -54,6 +138,14 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 							RHI::RHIMeshProxy proxy;
 							proxy.m_staticMeshEcs = GetComponentIndex(&data);
 							proxy.m_worldMatrix = ownerTransform.GetCachedWorldMatrix();
+							if (auto animator = ownerGameObject->GetComponent<AnimatorComponent>())
+							{
+								data.m_skeletonOffset = animator->GetSkeletonOffset();
+							}
+							else
+							{
+								data.m_skeletonOffset = StaticMeshRendererData::InvalidSkeletonOffset;
+							}
 
 							adjustedBounds.Apply(proxy.m_worldMatrix);
 
@@ -102,25 +194,45 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 	auto updateStaticTask = Tasks::CreateTask("StaticMeshRendererECS:Update Static Objects",
 		[this]()
 		{
-			for (auto& data : m_components)
+			for (size_t index = 0; index < m_components.Num(); index++)
 			{
-				auto ownerGameObject = data.m_owner.StaticCast<GameObject>();
+				auto& data = m_components[index];
+				if (!data.m_bIsActive)
+				{
+					continue;
+				}
+
+				GameObjectPtr ownerGameObject = data.m_owner.StaticCast<GameObject>();
+				if (!ownerGameObject)
+				{
+					continue;
+				}
+
 				EMobilityType mobilityType = ownerGameObject->GetMobilityType();
 
 				if (mobilityType == EMobilityType::Static && data.m_bIsActive && data.GetModel() && data.GetModel()->IsReady())
 				{
-					auto ownerGameObject = data.m_owner.StaticCast<GameObject>();
 					const auto& ownerTransform = ownerGameObject->GetTransformComponent();
 					Math::AABB adjustedBounds = data.GetModel()->GetBoundsAABB();
+					bool bMaterialsReady = !data.GetMaterials().IsEmpty();
+					for (const auto& material : data.GetMaterials())
+					{
+						bMaterialsReady &= material && material->IsReady();
+					}
 
-					if ((data.m_bIsDirty || ownerTransform.GetFrameLastChange() > data.m_frameLastChange) && adjustedBounds.IsValid())
+					if ((data.m_bIsDirty || ownerTransform.GetFrameLastChange() > data.m_frameLastChange) &&
+						adjustedBounds.IsValid() && bMaterialsReady)
 					{
 						RHI::RHISceneViewProxy proxy;
-						proxy.m_staticMeshEcs = GetComponentIndex(&data);
+						proxy.m_staticMeshEcs = index;
 						proxy.m_worldMatrix = ownerTransform.GetCachedWorldMatrix();
 						if (auto animator = ownerGameObject->GetComponent<AnimatorComponent>())
 						{
 							data.m_skeletonOffset = animator->GetSkeletonOffset();
+						}
+						else
+						{
+							data.m_skeletonOffset = StaticMeshRendererData::InvalidSkeletonOffset;
 						}
 						proxy.m_skeletonOffset = data.m_skeletonOffset;
 						proxy.m_meshes = data.GetModel()->GetMeshes();

--- a/Runtime/ECS/StaticMeshRendererECS.h
+++ b/Runtime/ECS/StaticMeshRendererECS.h
@@ -17,11 +17,19 @@ namespace Sailor
 	class StaticMeshRendererData final : public ECS::TComponent
 	{
 	public:
+		static constexpr uint32_t InvalidSkeletonOffset = (std::numeric_limits<uint32_t>::max)();
 
 		SAILOR_API __forceinline TVector<MaterialPtr>& GetMaterials() { return m_materials; }
 
 		SAILOR_API __forceinline const ModelPtr& GetModel() const { return m_model; }
-		SAILOR_API __forceinline void SetModel(const ModelPtr& model) { m_model = model; }
+		SAILOR_API __forceinline void SetModel(const ModelPtr& model)
+		{
+			m_model = model;
+			if (!m_model)
+			{
+				m_materials.Clear();
+			}
+		}
 
 		SAILOR_API __forceinline bool ShouldCastShadow() const { return true; }
 		SAILOR_API __forceinline uint32_t GetSkeletonOffset() const { return m_skeletonOffset; }
@@ -30,7 +38,7 @@ namespace Sailor
 
 		ModelPtr m_model;
 		TVector<MaterialPtr> m_materials;
-		uint32_t m_skeletonOffset = 0;
+		uint32_t m_skeletonOffset = InvalidSkeletonOffset;
 
 		friend class StaticMeshRendererECS;
 	};
@@ -39,15 +47,17 @@ namespace Sailor
 	{
 	public:
 
-		virtual void BeginPlay() override;
-		virtual void EndPlay() override;
+		SAILOR_API virtual void BeginPlay() override;
+		SAILOR_API virtual void EndPlay() override;
 
-		virtual Tasks::ITaskPtr Tick(float deltaTime) override;
+		SAILOR_API virtual Tasks::ITaskPtr Tick(float deltaTime) override;
 		void CopySceneView(RHI::RHISceneViewPtr& outProxies);
 
 		virtual uint32_t GetOrder() const override { return 1000; }
 
 	protected:
+
+		SAILOR_API virtual void OnComponentUnregistered(size_t index, StaticMeshRendererData& component) override;
 
 		RHI::RHISceneViewPtr m_sceneViewProxiesCache;
 	};

--- a/Runtime/ECS/TransformECS.cpp
+++ b/Runtime/ECS/TransformECS.cpp
@@ -63,6 +63,46 @@ void TransformECS::MarkDirty(TransformComponent* ptr)
 	m_dirtyComponents.Add(TransformECS::GetComponentIndex(ptr));
 }
 
+void TransformECS::OnComponentUnregistered(size_t index, TransformComponent&)
+{
+	m_dirtyComponents.Remove(index);
+
+	// A transform can be queued for reparenting while its previous parent is removed.
+	// Clear only relationships that still target the released slot so a pending move
+	// to another live parent survives cleanup and slot reuse cannot inherit hierarchy.
+	const size_t currentFrame = GetWorld() ? GetWorld()->GetCurrentFrame() : 0;
+	for (size_t otherIndex = 0; otherIndex < m_components.Num(); ++otherIndex)
+	{
+		if (otherIndex == index)
+		{
+			continue;
+		}
+
+		auto& other = m_components[otherIndex];
+		other.m_children.Remove(index);
+
+		bool bRelationshipChanged = false;
+		if (other.m_parent == index)
+		{
+			other.m_parent = ECS::InvalidIndex;
+			bRelationshipChanged = true;
+		}
+
+		if (other.m_newParent == index)
+		{
+			other.m_newParent = ECS::InvalidIndex;
+			bRelationshipChanged = true;
+		}
+
+		if (bRelationshipChanged && other.m_bIsActive)
+		{
+			other.m_bIsDirty = true;
+			other.m_frameLastChange = currentFrame;
+			m_dirtyComponents.AddUnique(otherIndex);
+		}
+	}
+}
+
 Tasks::ITaskPtr TransformECS::PostTick()
 {
 	m_dirtyComponents.Clear(false);
@@ -199,9 +239,15 @@ void TransformECS::CalculateMatrices(TransformComponent& parent)
 	}
 
 	const glm::mat4x4& parentMatrix = parent.GetCachedWorldMatrix();
+	parent.m_frameLastChange = GetWorld()->GetCurrentFrame();
 
 	for (auto& child : parent.GetChildren())
 	{
+		if (child >= m_components.Num() || !m_components[child].m_bIsActive)
+		{
+			continue;
+		}
+
 		m_components[child].m_cachedWorldMatrix = parentMatrix * m_components[child].m_cachedRelativeMatrix;
 
 		CalculateMatrices(m_components[child]);

--- a/Runtime/ECS/TransformECS.h
+++ b/Runtime/ECS/TransformECS.h
@@ -67,6 +67,8 @@ namespace Sailor
 
 	protected:
 
+		virtual void OnComponentUnregistered(size_t index, TransformComponent& component) override;
+
 		TVector<size_t> m_dirtyComponents;
 	};
 

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -2,6 +2,7 @@
 
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/FileId.h"
+#include "AssetRegistry/Prefab/PrefabImporter.h"
 #include "AssetRegistry/World/WorldPrefabImporter.h"
 #include "Core/Reflection.h"
 #include "Engine/EngineLoop.h"
@@ -24,6 +25,51 @@ namespace
 	void LogEditorTypeSerializationFailure(const char* message) noexcept
 	{
 		SAILOR_LOG_ERROR("Failed to serialize editor type metadata: %s", message);
+	}
+
+	bool TryParseOptionalParent(const std::string& value, InstanceId& outParent)
+	{
+		outParent = InstanceId::Invalid;
+		if (value.empty())
+		{
+			return true;
+		}
+
+		outParent.Deserialize(YAML::Node(value));
+		return outParent.IsGameObjectId();
+	}
+
+	bool TryParseOptionalGameObjectId(const std::string& value, InstanceId& outInstanceId)
+	{
+		outInstanceId = InstanceId::Invalid;
+		if (value.empty())
+		{
+			return true;
+		}
+
+		outInstanceId.Deserialize(YAML::Node(value));
+		return outInstanceId.IsGameObjectId();
+	}
+
+	bool TryParseOptionalComponentId(const std::string& value, InstanceId& outInstanceId)
+	{
+		outInstanceId = InstanceId::Invalid;
+		if (value.empty())
+		{
+			return true;
+		}
+
+		outInstanceId.Deserialize(YAML::Node(value));
+		return outInstanceId.ComponentId() != InstanceId::Invalid &&
+			outInstanceId.GameObjectId() != InstanceId::Invalid;
+	}
+
+	void SetInteropString(const std::string& value, char** outValue)
+	{
+		auto result = TUniquePtr<char[]>::Make(value.size() + 1);
+		memcpy(result.GetRawPtr(), value.c_str(), value.size());
+		result[value.size()] = '\0';
+		outValue[0] = result.Release();
 	}
 }
 
@@ -61,27 +107,33 @@ uint32_t App::PullEditorMessages(char** messages, uint32_t num)
 
 uint32_t App::SerializeCurrentWorld(char** yamlNode)
 {
-	auto editor = GetSubmodule<Editor>();
-	if (!editor || !yamlNode)
+	if (!yamlNode)
 	{
 		return 0;
 	}
 
-	auto node = editor->SerializeWorld();
-	if (!node.IsNull())
-	{
-		std::string serializedNode = YAML::Dump(node);
-		size_t length = serializedNode.length();
-
-		yamlNode[0] = new char[length + 1];
-		memcpy(yamlNode[0], serializedNode.c_str(), length);
-		yamlNode[0][length] = '\0';
-
-		return static_cast<uint32_t>(length);
-	}
-
 	yamlNode[0] = nullptr;
-	return 0;
+	return ExecuteOnEngineMainThread<uint32_t>(0, [yamlNode]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return 0u;
+			}
+
+			auto node = editor->SerializeWorld();
+			if (node.IsNull())
+			{
+				return 0u;
+			}
+
+			const std::string serializedNode = YAML::Dump(node);
+			const size_t length = serializedNode.length();
+			yamlNode[0] = new char[length + 1];
+			memcpy(yamlNode[0], serializedNode.c_str(), length);
+			yamlNode[0][length] = '\0';
+			return static_cast<uint32_t>(length);
+		});
 }
 
 uint32_t App::SerializeEngineTypes(char** yamlNode)
@@ -204,195 +256,361 @@ uint32_t App::SerializeWorkspaceCacheIdentity(char** yamlNode)
 
 bool App::LoadEditorWorld(const char* strFileId)
 {
-	auto editor = GetSubmodule<Editor>();
-	auto engineLoop = GetSubmodule<EngineLoop>();
-	auto assetRegistry = GetSubmodule<AssetRegistry>();
-	if (!editor || !engineLoop || !assetRegistry || !strFileId || strFileId[0] == '\0')
+	if (!strFileId || strFileId[0] == '\0')
 	{
 		return false;
 	}
 
-	FileId fileId;
-	fileId.Deserialize(YAML::Node(std::string(strFileId)));
+	const std::string fileIdValue = strFileId;
+	return ExecuteOnEngineMainThread<bool>(false, [fileIdValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			auto engineLoop = GetSubmodule<EngineLoop>();
+			auto assetRegistry = GetSubmodule<AssetRegistry>();
+			if (!editor || !engineLoop || !assetRegistry)
+			{
+				return false;
+			}
 
-	auto worldPrefab = assetRegistry->LoadAssetFromFile<WorldPrefab>(fileId);
-	if (!worldPrefab || !worldPrefab->IsReady())
-	{
-		return false;
-	}
+			FileId fileId;
+			fileId.Deserialize(YAML::Node(fileIdValue));
+			auto worldPrefab = assetRegistry->LoadAssetFromFile<WorldPrefab>(fileId);
+			if (!worldPrefab || !worldPrefab->IsReady())
+			{
+				return false;
+			}
 
-	auto oldWorld = editor->GetWorld();
-	auto newWorld = engineLoop->InstantiateWorld(worldPrefab, EngineLoop::EditorWorldMask);
-	if (!newWorld)
-	{
-		return false;
-	}
+			auto oldWorld = editor->GetWorld();
+			auto newWorld = engineLoop->InstantiateWorld(worldPrefab, EngineLoop::EditorWorldMask);
+			if (!newWorld)
+			{
+				return false;
+			}
 
-	editor->SetWorld(newWorld.GetRawPtr());
-	if (oldWorld)
-	{
-		engineLoop->ExitWorld(oldWorld);
-		engineLoop->ProcessPendingWorldExits();
-	}
+			editor->SetWorld(newWorld.GetRawPtr());
+			if (oldWorld)
+			{
+				engineLoop->ExitWorld(oldWorld);
+				engineLoop->ProcessPendingWorldExits();
+			}
 
-	return true;
+			return true;
+		});
 }
 
 bool App::UpdateEditorObject(const char* strInstanceId, const char* strYamlNode)
 {
-	auto editor = GetSubmodule<Editor>();
-	if (!editor || !strInstanceId || !strYamlNode)
+	if (!strInstanceId || !strYamlNode)
 	{
 		return false;
 	}
 
-	InstanceId instanceId;
-	YAML::Node instanceIdYaml = YAML::Load(strInstanceId);
-	instanceId.Deserialize(instanceIdYaml);
+	const std::string instanceIdValue = strInstanceId;
+	const std::string yamlValue = strYamlNode;
+	return ExecuteOnEngineMainThread<bool>(false, [instanceIdValue, yamlValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
 
-	return editor->UpdateObject(instanceId, strYamlNode);
+			InstanceId instanceId;
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+			return editor->UpdateObject(instanceId, yamlValue);
+		});
 }
 
 bool App::ReparentEditorObject(const char* strInstanceId, const char* strParentInstanceId, bool bKeepWorldTransform)
 {
-	auto editor = GetSubmodule<Editor>();
-	if (!editor || !strInstanceId)
+	if (!strInstanceId)
 	{
 		return false;
 	}
 
-	InstanceId instanceId;
-	instanceId.Deserialize(YAML::Node(std::string(strInstanceId)));
+	const std::string instanceIdValue = strInstanceId;
+	const std::string parentInstanceIdValue = strParentInstanceId ? strParentInstanceId : "";
+	return ExecuteOnEngineMainThread<bool>(false, [instanceIdValue, parentInstanceIdValue, bKeepWorldTransform]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
 
-	InstanceId parentInstanceId;
-	if (strParentInstanceId && strParentInstanceId[0] != '\0')
-	{
-		parentInstanceId.Deserialize(YAML::Node(std::string(strParentInstanceId)));
-	}
+			InstanceId instanceId;
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+			InstanceId parentInstanceId;
+			if (!TryParseOptionalParent(parentInstanceIdValue, parentInstanceId))
+			{
+				return false;
+			}
 
-	return editor->ReparentObject(instanceId, parentInstanceId, bKeepWorldTransform);
+			return editor->ReparentObject(instanceId, parentInstanceId, bKeepWorldTransform);
+		});
 }
 
-bool App::CreateEditorGameObject(const char* strParentInstanceId)
+bool App::CreateEditorGameObject(
+	const char* strParentInstanceId,
+	const char* strPreferredInstanceId,
+	char** outInstanceId)
 {
-	auto editor = GetSubmodule<Editor>();
-	if (!editor)
+	if (!outInstanceId)
 	{
 		return false;
 	}
 
-	InstanceId parentInstanceId;
-	if (strParentInstanceId && strParentInstanceId[0] != '\0')
-	{
-		parentInstanceId.Deserialize(YAML::Node(std::string(strParentInstanceId)));
-	}
+	outInstanceId[0] = nullptr;
+	const std::string parentInstanceIdValue = strParentInstanceId ? strParentInstanceId : "";
+	const std::string preferredInstanceIdValue = strPreferredInstanceId ? strPreferredInstanceId : "";
+	return ExecuteOnEngineMainThread<bool>(false, [parentInstanceIdValue, preferredInstanceIdValue, outInstanceId]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
 
-	return editor->CreateGameObject(parentInstanceId);
+			InstanceId parentInstanceId;
+			if (!TryParseOptionalParent(parentInstanceIdValue, parentInstanceId))
+			{
+				return false;
+			}
+
+			InstanceId preferredInstanceId;
+			if (!TryParseOptionalGameObjectId(preferredInstanceIdValue, preferredInstanceId))
+			{
+				return false;
+			}
+
+			InstanceId createdInstanceId;
+			if (!editor->CreateGameObject(parentInstanceId, preferredInstanceId, createdInstanceId))
+			{
+				return false;
+			}
+
+			SetInteropString(createdInstanceId.ToString(), outInstanceId);
+			return true;
+		});
 }
 
 bool App::DestroyEditorObject(const char* strInstanceId)
 {
-	auto editor = GetSubmodule<Editor>();
-	if (!editor || !strInstanceId)
+	if (!strInstanceId)
 	{
 		return false;
 	}
 
-	InstanceId instanceId;
-	instanceId.Deserialize(YAML::Node(std::string(strInstanceId)));
+	const std::string instanceIdValue = strInstanceId;
+	return ExecuteOnEngineMainThread<bool>(false, [instanceIdValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
 
-	return editor->DestroyObject(instanceId);
+			InstanceId instanceId;
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+			return editor->DestroyObject(instanceId);
+		});
 }
 
 bool App::ResetEditorComponentToDefaults(const char* strInstanceId)
 {
-	auto editor = GetSubmodule<Editor>();
-	if (!editor || !strInstanceId)
+	if (!strInstanceId)
 	{
 		return false;
 	}
 
-	InstanceId instanceId;
-	instanceId.Deserialize(YAML::Node(std::string(strInstanceId)));
+	const std::string instanceIdValue = strInstanceId;
+	return ExecuteOnEngineMainThread<bool>(false, [instanceIdValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
 
-	return editor->ResetComponentToDefaults(instanceId);
+			InstanceId instanceId;
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+			return editor->ResetComponentToDefaults(instanceId);
+		});
 }
 
-bool App::AddEditorComponent(const char* strInstanceId, const char* strComponentTypeName)
+bool App::AddEditorComponent(
+	const char* strInstanceId,
+	const char* strComponentTypeName,
+	const char* strPreferredInstanceId,
+	char** outInstanceId)
 {
-	auto editor = GetSubmodule<Editor>();
-	if (!editor || !strInstanceId || !strComponentTypeName)
+	if (!strInstanceId || !strComponentTypeName || !outInstanceId)
 	{
 		return false;
 	}
 
-	InstanceId instanceId;
-	instanceId.Deserialize(YAML::Node(std::string(strInstanceId)));
+	outInstanceId[0] = nullptr;
+	const std::string instanceIdValue = strInstanceId;
+	const std::string componentTypeName = strComponentTypeName;
+	const std::string preferredInstanceIdValue = strPreferredInstanceId ? strPreferredInstanceId : "";
+	return ExecuteOnEngineMainThread<bool>(false, [instanceIdValue, componentTypeName, preferredInstanceIdValue, outInstanceId]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
 
-	return editor->AddComponent(instanceId, strComponentTypeName);
+			InstanceId instanceId;
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+
+			InstanceId preferredInstanceId;
+			if (!TryParseOptionalComponentId(preferredInstanceIdValue, preferredInstanceId))
+			{
+				return false;
+			}
+
+			InstanceId createdInstanceId;
+			if (!editor->AddComponent(instanceId, componentTypeName, preferredInstanceId, createdInstanceId))
+			{
+				return false;
+			}
+
+			SetInteropString(createdInstanceId.ToString(), outInstanceId);
+			return true;
+		});
 }
 
 bool App::RemoveEditorComponent(const char* strInstanceId)
 {
-	auto editor = GetSubmodule<Editor>();
-	if (!editor || !strInstanceId)
+	if (!strInstanceId)
 	{
 		return false;
 	}
 
-	InstanceId instanceId;
-	instanceId.Deserialize(YAML::Node(std::string(strInstanceId)));
+	const std::string instanceIdValue = strInstanceId;
+	return ExecuteOnEngineMainThread<bool>(false, [instanceIdValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
 
-	return editor->RemoveComponent(instanceId);
+			InstanceId instanceId;
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+			return editor->RemoveComponent(instanceId);
+		});
 }
 
 bool App::InstantiateEditorPrefab(const char* strFileId, const char* strParentInstanceId)
 {
-	auto editor = GetSubmodule<Editor>();
-	if (!editor || !strFileId)
+	if (!strFileId)
 	{
 		return false;
 	}
 
-	FileId fileId;
-	fileId.Deserialize(YAML::Node(std::string(strFileId)));
+	const std::string fileIdValue = strFileId;
+	const std::string parentInstanceIdValue = strParentInstanceId ? strParentInstanceId : "";
+	return ExecuteOnEngineMainThread<bool>(false, [fileIdValue, parentInstanceIdValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
 
-	InstanceId parentInstanceId;
-	if (strParentInstanceId && strParentInstanceId[0] != '\0')
+			FileId fileId;
+			fileId.Deserialize(YAML::Node(fileIdValue));
+			InstanceId parentInstanceId;
+			if (!TryParseOptionalParent(parentInstanceIdValue, parentInstanceId))
+			{
+				return false;
+			}
+
+			return editor->InstantiatePrefab(fileId, parentInstanceId);
+		});
+}
+
+bool App::InstantiateEditorPrefabFromYaml(const char* strPrefabYaml, const char* strParentInstanceId)
+{
+	if (!strPrefabYaml || strPrefabYaml[0] == '\0')
 	{
-		parentInstanceId.Deserialize(YAML::Node(std::string(strParentInstanceId)));
+		return false;
 	}
 
-	return editor->InstantiatePrefab(fileId, parentInstanceId);
+	const std::string prefabYaml = strPrefabYaml;
+	const std::string parentInstanceIdValue = strParentInstanceId ? strParentInstanceId : "";
+	return ExecuteOnEngineMainThread<bool>(false, [prefabYaml, parentInstanceIdValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			auto prefabImporter = GetSubmodule<PrefabImporter>();
+			if (!editor || !prefabImporter)
+			{
+				return false;
+			}
+
+			InstanceId parentInstanceId;
+			if (!TryParseOptionalParent(parentInstanceIdValue, parentInstanceId))
+			{
+				return false;
+			}
+
+			const YAML::Node prefabNode = YAML::Load(prefabYaml);
+			if (!prefabNode.IsMap() ||
+				!prefabNode["gameObjects"].IsSequence() ||
+				!prefabNode["components"].IsSequence())
+			{
+				return false;
+			}
+
+			PrefabPtr prefab = prefabImporter->Create();
+			if (!prefab)
+			{
+				return false;
+			}
+
+			prefab->Deserialize(prefabNode);
+			return editor->InstantiatePrefab(prefab, parentInstanceId);
+		});
 }
 
 bool App::SetEditorSelection(const char* strSelectionYaml)
 {
-	auto editor = GetSubmodule<Editor>();
-	auto* world = editor ? editor->GetWorld() : nullptr;
-	if (!world || !strSelectionYaml)
+	if (!strSelectionYaml)
 	{
 		return false;
 	}
 
-	TVector<InstanceId> selection;
-	const YAML::Node yaml = YAML::Load(strSelectionYaml);
-	if (yaml && yaml.IsSequence())
-	{
-		selection.Reserve(yaml.size());
-		for (const auto& entry : yaml)
+	const std::string selectionYaml = strSelectionYaml;
+	return ExecuteOnEngineMainThread<bool>(false, [selectionYaml]()
 		{
-			InstanceId instanceId{};
-			instanceId.Deserialize(entry);
-			if (instanceId)
+			auto editor = GetSubmodule<Editor>();
+			auto* world = editor ? editor->GetWorld() : nullptr;
+			if (!world)
 			{
-				selection.Add(instanceId);
+				return false;
 			}
-		}
-	}
 
-	world->SetEditorSelection(selection);
-	return true;
+			TVector<InstanceId> selection;
+			const YAML::Node yaml = YAML::Load(selectionYaml);
+			if (yaml && yaml.IsSequence())
+			{
+				selection.Reserve(yaml.size());
+				for (const auto& entry : yaml)
+				{
+					InstanceId instanceId{};
+					instanceId.Deserialize(entry);
+					if (instanceId)
+					{
+						selection.Add(instanceId);
+					}
+				}
+			}
+
+			world->SetEditorSelection(selection);
+			return true;
+		});
 }
 
 bool App::RenderPathTracedImage(const char* strOutputPath, const char* strInstanceId, uint32_t height, uint32_t samplesPerPixel, uint32_t maxBounces)
@@ -402,26 +620,28 @@ bool App::RenderPathTracedImage(const char* strOutputPath, const char* strInstan
 		return false;
 	}
 
-	auto editor = GetSubmodule<Editor>();
-	if (!editor)
-	{
-		return false;
-	}
-
-	InstanceId instanceId{};
-	if (strInstanceId && strInstanceId[0] != '\0')
-	{
-		YAML::Node instanceIdYaml = YAML::Load(strInstanceId);
-		instanceId.Deserialize(instanceIdYaml);
-	}
-
 	const std::string outputPath = strOutputPath;
-	const bool bSuccess = editor->RenderPathTracedImage(instanceId, outputPath, height, samplesPerPixel, maxBounces);
-	editor->PushMessage(bSuccess ?
-		("Path tracer export succeeded: " + outputPath) :
-		("Path tracer export failed: " + outputPath));
+	const std::string instanceIdValue = strInstanceId ? strInstanceId : "";
+	return ExecuteOnEngineMainThread<bool>(false, [outputPath, instanceIdValue, height, samplesPerPixel, maxBounces]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
 
-	return bSuccess;
+			InstanceId instanceId{};
+			if (!instanceIdValue.empty())
+			{
+				instanceId.Deserialize(YAML::Node(instanceIdValue));
+			}
+
+			const bool bSuccess = editor->RenderPathTracedImage(instanceId, outputPath, height, samplesPerPixel, maxBounces);
+			editor->PushMessage(bSuccess ?
+				("Path tracer export succeeded: " + outputPath) :
+				("Path tracer export failed: " + outputPath));
+			return bSuccess;
+		});
 }
 
 void App::ShowMainWindow(bool bShow)

--- a/Runtime/Engine/GameObject.h
+++ b/Runtime/Engine/GameObject.h
@@ -51,13 +51,32 @@ namespace Sailor
 			return newObject;
 		}
 
-		SAILOR_API ComponentPtr AddComponentRaw(ComponentPtr component)
+		SAILOR_API ComponentPtr AddComponentRaw(ComponentPtr component, const InstanceId& preferredInstanceId = InstanceId::Invalid)
 		{
 			check(m_pWorld);
 			check(!component->m_bBeginPlayCalled);
 			check(!component->GetOwner().IsValid());
 
-			component->m_instanceId = InstanceId::GenerateNewComponentId(m_instanceId);
+			if (preferredInstanceId)
+			{
+				if (preferredInstanceId.ComponentId() == InstanceId::Invalid ||
+					preferredInstanceId.GameObjectId() != m_instanceId)
+				{
+					return {};
+				}
+
+				for (const auto& existingComponent : m_components)
+				{
+					if (existingComponent->GetInstanceId() == preferredInstanceId)
+					{
+						return {};
+					}
+				}
+			}
+
+			component->m_instanceId = preferredInstanceId
+				? preferredInstanceId
+				: InstanceId::GenerateNewComponentId(m_instanceId);
 			component->m_owner = m_self;
 			component->Initialize();
 

--- a/Runtime/Engine/InstanceId.cpp
+++ b/Runtime/Engine/InstanceId.cpp
@@ -7,8 +7,56 @@
 #endif
 #include <random>
 #include <iomanip>
+#include <sstream>
+#include <string_view>
 
 using namespace Sailor;
+
+namespace
+{
+	constexpr size_t LegacyGameObjectIdLength = 16;
+	constexpr size_t CanonicalGameObjectIdLength = 20;
+	constexpr size_t LegacyComponentIdLength = 16;
+	constexpr size_t CanonicalComponentIdLength = 32;
+
+	bool IsHexString(std::string_view id)
+	{
+		return std::all_of(id.begin(), id.end(), [](unsigned char character)
+			{
+				return std::isxdigit(character) != 0;
+			});
+	}
+
+	bool IsHexGameObjectId(std::string_view id)
+	{
+		return id.length() >= LegacyGameObjectIdLength &&
+			id.length() <= CanonicalGameObjectIdLength &&
+			IsHexString(id);
+	}
+
+	bool IsHexComponentId(std::string_view id)
+	{
+		return (id.length() == LegacyComponentIdLength || id.length() == CanonicalComponentIdLength) &&
+			IsHexString(id);
+	}
+
+	bool SplitComponentInstanceId(
+		std::string_view instanceId,
+		std::string_view& outComponentId,
+		std::string_view& outGameObjectId)
+	{
+		const size_t separator = instanceId.find('_');
+		if (separator == std::string_view::npos ||
+			instanceId.find('_', separator + 1) != std::string_view::npos)
+		{
+			return false;
+		}
+
+		outComponentId = instanceId.substr(0, separator);
+		outGameObjectId = instanceId.substr(separator + 1);
+		return IsHexComponentId(outComponentId) && IsHexGameObjectId(outGameObjectId);
+	}
+}
 
 const InstanceId InstanceId::Invalid = InstanceId();
 
@@ -56,9 +104,12 @@ InstanceId InstanceId::GenerateNewInstanceId()
 	std::uniform_int_distribution<uint64_t> dis;
 
 	uint64_t randomNumber = dis(gen);
+	const uint16_t randomSuffix = static_cast<uint16_t>(dis(gen));
 
 	std::stringstream ss;
-	ss << std::setw(16) << std::setfill('0') << randomNumber;
+	ss << std::uppercase << std::hex << std::setfill('0')
+		<< std::setw(16) << randomNumber
+		<< std::setw(4) << randomSuffix;
 
 	newInstanceId.m_instanceId = StringHash::Runtime(ss.str());
 
@@ -96,23 +147,21 @@ InstanceId InstanceId::GenerateNewComponentId(const InstanceId& gameObjectId)
 
 bool InstanceId::IsGameObjectId() const
 {
-	std::string idString = m_instanceId.ToString();
-	return idString.length() == 20 && std::all_of(idString.begin(), idString.end(), ::isxdigit);
+	return IsHexGameObjectId(m_instanceId.ToString());
 }
 
 InstanceId InstanceId::GameObjectId() const
 {
-	std::string idString = m_instanceId.ToString();
-	size_t pos = idString.find('_');
-	if (pos != std::string::npos)
+	const std::string& idString = m_instanceId.ToString();
+	std::string_view componentIdString;
+	std::string_view gameObjectIdString;
+	if (SplitComponentInstanceId(idString, componentIdString, gameObjectIdString))
 	{
-		std::string gameObjectIdString = idString.substr(pos + 1);
-
 		InstanceId id{};
-		id.m_instanceId = StringHash::Runtime(gameObjectIdString);
+		id.m_instanceId = StringHash::Runtime(std::string(gameObjectIdString));
 		return id;
 	}
-	else if (IsGameObjectId())
+	else if (idString.find('_') == std::string::npos && IsGameObjectId())
 	{
 		return *this;
 	}
@@ -122,14 +171,13 @@ InstanceId InstanceId::GameObjectId() const
 
 InstanceId InstanceId::ComponentId() const
 {
-	std::string idString = m_instanceId.ToString();
-	size_t pos = idString.find('_');
-	if (pos != std::string::npos)
+	const std::string& idString = m_instanceId.ToString();
+	std::string_view componentIdString;
+	std::string_view gameObjectIdString;
+	if (SplitComponentInstanceId(idString, componentIdString, gameObjectIdString))
 	{
-		std::string componentIdString = idString.substr(0, pos);
-
 		InstanceId id{};
-		id.m_instanceId = StringHash::Runtime(componentIdString);
+		id.m_instanceId = StringHash::Runtime(std::string(componentIdString));
 		return id;
 	}
 

--- a/Runtime/Engine/World.cpp
+++ b/Runtime/Engine/World.cpp
@@ -4,16 +4,80 @@
 #include "AssetRegistry/Prefab/PrefabImporter.h"
 #include "Containers/Set.h"
 #include "Core/LogMacros.h"
+#include "YamlExceptionBoundary.h"
 #include <Components/TestComponent.h>
 #include <ECS/TransformECS.h>
 
 using namespace Sailor;
 
-World::World(std::string name, EWorldBehaviourMask mask) : m_mask(mask), m_currentFrame(1), m_name(std::move(name)), m_frameInput(), m_bIsBeginPlayCalled(false)
+namespace
+{
+	TVector<ECS::TBaseSystemPtr> CreateRegisteredEcs()
+	{
+		auto* ecsFactory = App::GetSubmodule<ECS::ECSFactory>();
+		check(ecsFactory);
+		return ecsFactory->CreateECS();
+	}
+
+	class PrefabInstantiationTransaction final
+	{
+	public:
+
+		PrefabInstantiationTransaction(
+			World& world,
+			TVector<GameObjectPtr>& gameObjects,
+			TVector<TPair<ComponentPtr, ReflectedData>>& pendingDependencies) :
+			m_world(world),
+			m_gameObjects(gameObjects),
+			m_pendingDependencies(pendingDependencies),
+			m_initialPendingDependencies(pendingDependencies.Num())
+		{}
+
+		~PrefabInstantiationTransaction() noexcept
+		{
+			if (m_bCommitted)
+			{
+				return;
+			}
+
+			while (m_pendingDependencies.Num() > m_initialPendingDependencies)
+			{
+				m_pendingDependencies.RemoveAt(m_pendingDependencies.Num() - 1);
+			}
+
+			for (size_t index = m_gameObjects.Num(); index > 0; --index)
+			{
+				m_world.DestroyImmediate(m_gameObjects[index - 1]);
+			}
+		}
+
+		void Commit() { m_bCommitted = true; }
+
+	private:
+
+		World& m_world;
+		TVector<GameObjectPtr>& m_gameObjects;
+		TVector<TPair<ComponentPtr, ReflectedData>>& m_pendingDependencies;
+		size_t m_initialPendingDependencies;
+		bool m_bCommitted = false;
+	};
+}
+
+World::World(std::string name, EWorldBehaviourMask mask) :
+	World(std::move(name), mask, CreateRegisteredEcs())
+{}
+
+World::World(
+	std::string name,
+	EWorldBehaviourMask mask,
+	TVector<ECS::TBaseSystemPtr>&& ecsArray) :
+	m_mask(mask),
+	m_currentFrame(1),
+	m_name(std::move(name)),
+	m_frameInput(),
+	m_bIsBeginPlayCalled(false)
 {
 	m_allocator = Memory::ObjectAllocatorPtr::Make(EAllocationPolicy::LocalMemory_SingleThread);
-
-	auto ecsArray = App::GetSubmodule<ECS::ECSFactory>()->CreateECS();
 
 	for (auto& ecs : ecsArray)
 	{
@@ -147,54 +211,19 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 		return {};
 	}
 
-	for (uint32_t gameObjectIndex = 0; gameObjectIndex < prefab->m_gameObjects.Num(); ++gameObjectIndex)
+	std::string validationDiagnostic;
+	if (!prefab->ValidateForInstantiation(validationDiagnostic))
 	{
-		const auto& prefabGameObject = prefab->m_gameObjects[gameObjectIndex];
-		if (prefabGameObject.m_parentIndex != static_cast<uint32_t>(-1) &&
-			prefabGameObject.m_parentIndex >= prefab->m_gameObjects.Num())
-		{
-			SAILOR_LOG_ERROR(
-				"Cannot instantiate prefab '%s': game object %u has invalid parent index %u.",
-				prefab->GetFileId().ToString().c_str(),
-				gameObjectIndex,
-				prefabGameObject.m_parentIndex);
-			return {};
-		}
-
-		for (const uint32_t componentIndex : prefabGameObject.m_components)
-		{
-			if (componentIndex >= prefab->m_components.Num())
-			{
-				SAILOR_LOG_ERROR(
-					"Cannot instantiate prefab '%s': game object %u references invalid component index %u.",
-					prefab->GetFileId().ToString().c_str(),
-					gameObjectIndex,
-					componentIndex);
-				return {};
-			}
-
-			const ReflectedData& reflection = prefab->m_components[componentIndex];
-			if (!reflection.IsValid())
-			{
-				SAILOR_LOG_ERROR(
-					"Cannot instantiate prefab '%s': reflected component %u has an unknown type. "
-					"Load or rebuild the workspace logic module.",
-					prefab->GetFileId().ToString().c_str(),
-					componentIndex);
-				return {};
-			}
-		}
+		SAILOR_LOG_ERROR("Cannot instantiate prefab '%s': %s.",
+			prefab->GetFileId().ToString().c_str(),
+			validationDiagnostic.c_str());
+		return {};
 	}
 
 	TVector<GameObjectPtr> gameObjects;
+	gameObjects.Reserve(prefab->m_gameObjects.Num());
 	TMap<InstanceId, ObjectPtr> internalDependencies;
-	auto rollback = [&]()
-	{
-		for (auto& gameObject : gameObjects)
-		{
-			DestroyImmediate(gameObject);
-		}
-	};
+	PrefabInstantiationTransaction transaction(*this, gameObjects, ComponentsToResolveDependencies);
 
 	for (uint32_t j = 0; j < prefab->m_gameObjects.Num(); j++)
 	{
@@ -214,7 +243,20 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 		{
 			const uint32_t componentIndex = prefab->m_gameObjects[j].m_components[i];
 			const ReflectedData& reflection = prefab->m_components[componentIndex];
-			const InstanceId oldInstanceId = reflection.GetProperties()["instanceId"].as<InstanceId>();
+			InstanceId oldInstanceId;
+			std::string conversionDiagnostic;
+			if (!External::TryConvertYaml(
+					reflection.GetProperties()["instanceId"],
+					oldInstanceId,
+					conversionDiagnostic))
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot instantiate reflected component %u from prefab '%s': %s.",
+					componentIndex,
+					prefab->GetFileId().ToString().c_str(),
+					conversionDiagnostic.c_str());
+				return {};
+			}
 
 			ComponentPtr newComponent = Reflection::CreateObject<Component>(reflection.GetTypeInfo(), GetAllocator());
 			if (!newComponent)
@@ -223,12 +265,25 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 					"Cannot instantiate reflected component type '%s' from prefab '%s'.",
 					reflection.GetTypeInfo().Name().c_str(),
 					prefab->GetFileId().ToString().c_str());
-				rollback();
 				return {};
 			}
 
 			gameObject->AddComponentRaw(newComponent);
-			newComponent->ApplyReflection(reflection);
+			std::string applyDiagnostic;
+			if (!External::GuardYamlExceptions(
+					[newComponent, &reflection]() mutable
+					{
+						newComponent->ApplyReflection(reflection);
+					},
+					applyDiagnostic))
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot apply reflected component %u from prefab '%s': %s.",
+					componentIndex,
+					prefab->GetFileId().ToString().c_str(),
+					applyDiagnostic.c_str());
+				return {};
+			}
 			newComponent->m_instanceId = InstanceId(oldInstanceId.ComponentId(), gameObject->GetInstanceId());
 
 			// We store the old ids for internal dependencies during resolve
@@ -256,12 +311,42 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 			const ReflectedData& reflection = prefab->m_components[componentIndex];
 
 			// Resolve internal dependencies first
-			bool bResolved = newComp->ResolveRefs(reflection, internalDependencies, false);
+			bool bResolved = false;
+			std::string resolveDiagnostic;
+			if (!External::TryInvokeYaml(
+					[newComp, &reflection, &internalDependencies]() mutable
+					{
+						return newComp->ResolveRefs(reflection, internalDependencies, false);
+					},
+					bResolved,
+					resolveDiagnostic))
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot resolve reflected component %u from prefab '%s': %s.",
+					componentIndex,
+					prefab->GetFileId().ToString().c_str(),
+					resolveDiagnostic.c_str());
+				return {};
+			}
 
 			// Resolve external dependencies
 			if (!bResolved)
 			{
-				bResolved = newComp->ResolveRefs(reflection, m_objectsMap, false);
+				if (!External::TryInvokeYaml(
+						[newComp, &reflection, this]() mutable
+						{
+							return newComp->ResolveRefs(reflection, m_objectsMap, false);
+						},
+						bResolved,
+						resolveDiagnostic))
+				{
+					SAILOR_LOG_ERROR(
+						"Cannot resolve external references for component %u from prefab '%s': %s.",
+						componentIndex,
+						prefab->GetFileId().ToString().c_str(),
+						resolveDiagnostic.c_str());
+					return {};
+				}
 			}
 
 			if (!bResolved)
@@ -293,13 +378,13 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 	{
 		SAILOR_LOG_ERROR("Cannot instantiate prefab '%s': no root game object was found.",
 			prefab->GetFileId().ToString().c_str());
-		rollback();
 		return {};
 	}
 
 	// Should we try to resolve the previous open dependencies?
 	// ResolveExternalDependencies();
 
+	transaction.Commit();
 	return root;
 }
 
@@ -415,6 +500,16 @@ GameObjectPtr World::Instantiate(const std::string& name)
 	auto newObject = NewGameObject(name, InstanceId::GenerateNewInstanceId());
 
 	return newObject;
+}
+
+GameObjectPtr World::Instantiate(const std::string& name, const InstanceId& preferredInstanceId)
+{
+	if (!preferredInstanceId.IsGameObjectId() || m_objectsMap.ContainsKey(preferredInstanceId))
+	{
+		return {};
+	}
+
+	return NewGameObject(name, preferredInstanceId);
 }
 
 void World::Destroy(GameObjectPtr object)

--- a/Runtime/Engine/World.h
+++ b/Runtime/Engine/World.h
@@ -36,6 +36,7 @@ namespace Sailor
 
 		SAILOR_API GameObjectPtr Instantiate(PrefabPtr prefab);
 		SAILOR_API GameObjectPtr Instantiate(const std::string& name = "Untitled");
+		SAILOR_API GameObjectPtr Instantiate(const std::string& name, const InstanceId& preferredInstanceId);
 		SAILOR_API void Destroy(GameObjectPtr object);
 		SAILOR_API void DestroyImmediate(GameObjectPtr object);
 
@@ -75,6 +76,13 @@ namespace Sailor
 		SAILOR_API const TMap<InstanceId, ObjectPtr>& GetObjects() const { return m_objectsMap; }
 
 	protected:
+
+		SAILOR_API World(
+			std::string name,
+			EWorldBehaviourMask mask,
+			TVector<ECS::TBaseSystemPtr>&& ecsArray);
+
+		size_t GetNumPendingDependencyResolutions() const { return ComponentsToResolveDependencies.Num(); }
 
 		SAILOR_API GameObjectPtr NewGameObject(const std::string& name, const InstanceId& instanceId);
 		void DestroyGameObjectHierarchy(GameObjectPtr root);

--- a/Runtime/Math/Transform.cpp
+++ b/Runtime/Math/Transform.cpp
@@ -120,6 +120,23 @@ Transform Transform::FromMatrix(const glm::mat4& m)
 	rotMat[0] = scale.x != 0.0f ? glm::vec3(m[0]) / scale.x : glm::vec3(m[0]);
 	rotMat[1] = scale.y != 0.0f ? glm::vec3(m[1]) / scale.y : glm::vec3(m[1]);
 	rotMat[2] = scale.z != 0.0f ? glm::vec3(m[2]) / scale.z : glm::vec3(m[2]);
+
+	if (glm::determinant(rotMat) < 0.0f)
+	{
+		glm::length_t reflectionAxis = 0;
+		if (scale.y > scale.x)
+		{
+			reflectionAxis = 1;
+		}
+		if (scale.z > scale[reflectionAxis])
+		{
+			reflectionAxis = 2;
+		}
+
+		scale[reflectionAxis] = -scale[reflectionAxis];
+		rotMat[reflectionAxis] = -rotMat[reflectionAxis];
+	}
+
 	glm::quat rotation = glm::quat_cast(rotMat);
 
 	return Transform(glm::vec4(translation, 1.0f), rotation, glm::vec4(scale, 1.0f));

--- a/Runtime/Platform/Mac/Window.mm
+++ b/Runtime/Platform/Mac/Window.mm
@@ -64,8 +64,47 @@ static uint32_t SailorMapMacKeyCode(unsigned short keyCode)
 	}
 }
 
+static void SailorApplyMacWindowSizeOnMainThread(NSWindow* window, int32_t width, int32_t height, bool bIsFullScreen, bool bRunsInsideEditor)
+{
+	if (bRunsInsideEditor)
+	{
+		NSView* contentView = window.contentView;
+		if (contentView)
+		{
+			const CGFloat backingScale = std::max<CGFloat>(window.backingScaleFactor, 1.0);
+			const CGFloat logicalWidth = std::max<CGFloat>(1.0, (CGFloat)width / backingScale);
+			const CGFloat logicalHeight = std::max<CGFloat>(1.0, (CGFloat)height / backingScale);
+			contentView.wantsLayer = YES;
+			contentView.frame = NSMakeRect(0.0, 0.0, logicalWidth, logicalHeight);
+			[window setContentSize:NSMakeSize(logicalWidth, logicalHeight)];
+
+			CAMetalLayer* metalLayer = [contentView.layer isKindOfClass:[CAMetalLayer class]] ? (CAMetalLayer*)contentView.layer : nil;
+			if (!metalLayer)
+			{
+				metalLayer = [CAMetalLayer layer];
+				contentView.layer = metalLayer;
+			}
+
+			metalLayer.contentsScale = backingScale;
+			metalLayer.frame = contentView.bounds;
+			metalLayer.drawableSize = CGSizeMake((CGFloat)width, (CGFloat)height);
+		}
+
+		return;
+	}
+
+	[window setContentSize:NSMakeSize(width, height)];
+
+	const bool bIsCurrentlyFullScreen = (([window styleMask] & NSWindowStyleMaskFullScreen) != 0);
+	if (bIsFullScreen != bIsCurrentlyFullScreen)
+	{
+		[window toggleFullScreen:nil];
+	}
+}
+
 @interface SailorWindowDelegate : NSObject<NSWindowDelegate>
 @property(nonatomic, assign) Sailor::Win32::Window* sailorWindow;
+@property(nonatomic, assign) BOOL terminatesApplicationOnClose;
 @end
 
 @implementation SailorWindowDelegate
@@ -82,11 +121,14 @@ static uint32_t SailorMapMacKeyCode(unsigned short keyCode)
 		sailorWindow->SetRunning(false);
 	}
 
-	// On macOS we want app process to exit when the main window is closed.
-	// This avoids a background engine process that requires Force Quit.
-	dispatch_async(dispatch_get_main_queue(), ^{
-		[NSApp terminate:nil];
-	});
+	if (self.terminatesApplicationOnClose)
+	{
+		// Standalone engine windows own the application lifetime. The hidden
+		// editor rendering surface does not; closing it must leave MAUI alive.
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[NSApp terminate:nil];
+		});
+	}
 }
 
 - (void)windowDidBecomeKey:(NSNotification*)notification
@@ -339,6 +381,7 @@ bool Window::Create(LPCSTR title, LPCSTR className, int32_t inWidth, int32_t inH
 
 		SailorWindowDelegate* delegate = [[SailorWindowDelegate alloc] init];
 		delegate.sailorWindow = this;
+		delegate.terminatesApplicationOnClose = !bRunsInsideEditor;
 		window.delegate = delegate;
 		objc_setAssociatedObject(window, sSailorWindowDelegateKey, delegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
 
@@ -364,15 +407,6 @@ bool Window::Create(LPCSTR title, LPCSTR className, int32_t inWidth, int32_t inH
 
 void Window::ChangeWindowSize(int32_t width, int32_t height, bool bInIsFullScreen)
 {
-	if (![NSThread isMainThread])
-	{
-		dispatch_sync(dispatch_get_main_queue(), ^
-		{
-			ChangeWindowSize(width, height, bInIsFullScreen);
-		});
-		return;
-	}
-
 	NSWindow* window = (__bridge NSWindow*)m_hWnd;
 	if (!window)
 	{
@@ -382,50 +416,23 @@ void Window::ChangeWindowSize(int32_t width, int32_t height, bool bInIsFullScree
 		return;
 	}
 
-	if (App::IsEditorMode())
-	{
-		m_width = std::max<int32_t>(1, width);
-		m_height = std::max<int32_t>(1, height);
-		m_bIsFullscreen = bInIsFullScreen;
-
-		NSView* contentView = window.contentView;
-		if (contentView)
-		{
-			const CGFloat backingScale = std::max<CGFloat>(window.backingScaleFactor, 1.0);
-			const CGFloat logicalWidth = std::max<CGFloat>(1.0, (CGFloat)m_width / backingScale);
-			const CGFloat logicalHeight = std::max<CGFloat>(1.0, (CGFloat)m_height / backingScale);
-			contentView.wantsLayer = YES;
-			contentView.frame = NSMakeRect(0.0, 0.0, logicalWidth, logicalHeight);
-			[window setContentSize:NSMakeSize(logicalWidth, logicalHeight)];
-
-			CAMetalLayer* metalLayer = [contentView.layer isKindOfClass:[CAMetalLayer class]] ? (CAMetalLayer*)contentView.layer : nil;
-			if (!metalLayer)
-			{
-				metalLayer = [CAMetalLayer layer];
-				contentView.layer = metalLayer;
-			}
-
-			metalLayer.contentsScale = backingScale;
-			metalLayer.frame = contentView.bounds;
-			metalLayer.drawableSize = CGSizeMake((CGFloat)m_width, (CGFloat)m_height);
-		}
-
-		return;
-	}
-
 	const int32_t contentWidth = std::max<int32_t>(1, width);
 	const int32_t contentHeight = std::max<int32_t>(1, height);
 	m_width = contentWidth;
 	m_height = contentHeight;
 	m_bIsFullscreen = bInIsFullScreen;
 
-	[window setContentSize:NSMakeSize(contentWidth, contentHeight)];
-
-	const bool bIsCurrentlyFullScreen = (([window styleMask] & NSWindowStyleMaskFullScreen) != 0);
-	if (bInIsFullScreen != bIsCurrentlyFullScreen)
+	const bool bRunsInsideEditor = App::IsEditorMode();
+	if (![NSThread isMainThread])
 	{
-		[window toggleFullScreen:nil];
+		dispatch_async(dispatch_get_main_queue(), ^
+		{
+			SailorApplyMacWindowSizeOnMainThread(window, contentWidth, contentHeight, bInIsFullScreen, bRunsInsideEditor);
+		});
+		return;
 	}
+
+	SailorApplyMacWindowSizeOnMainThread(window, contentWidth, contentHeight, bInIsFullScreen, bRunsInsideEditor);
 }
 
 void Sailor::Win32::Window::ProcessMacMsgs()

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -27,6 +27,7 @@
 #include "Containers/Octree.h"
 #include "Engine/EngineLoop.h"
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <filesystem>
 #include <cstring>
@@ -74,6 +75,8 @@ const Workspace::WorkspaceContext& App::GetWorkspaceContext()
 
 namespace
 {
+	std::atomic_bool g_assetReloadRequested = false;
+
 	bool ContainsWorkspaceManifest(const std::filesystem::path& root)
 	{
 		std::error_code error;
@@ -194,6 +197,8 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	{
 		return;
 	}
+
+	g_assetReloadRequested.store(false, std::memory_order_release);
 
 #if defined(_WIN32)
 	timeBeginPeriod(1);
@@ -420,6 +425,7 @@ void App::Start()
 		SAILOR_LOG_ERROR("App::Start skipped: engine subsystems are not fully initialized.");
 		return;
 	}
+	scheduler->AttachCurrentThreadAsMainThread();
 
 	auto& pMainWindow = s_pInstance->m_pMainWindow;
 
@@ -435,7 +441,7 @@ void App::Start()
 	bool bFirstFrame = true;
 
 	TMap<std::string, std::function<void()>> consoleVars;
-	consoleVars["scan"] = std::bind(&AssetRegistry::ScanContentFolder, GetSubmodule<AssetRegistry>());
+	consoleVars["scan"] = []() { App::RequestAssetReload(); };
 	consoleVars["memory.benchmark"] = &Memory::RunMemoryBenchmark;
 	consoleVars["vector.benchmark"] = &Sailor::RunVectorBenchmark;
 	consoleVars["set.benchmark"] = &Sailor::RunSetBenchmark;
@@ -495,10 +501,10 @@ void App::Start()
 
 		if (systemInputState.IsKeyPressed(VK_F5))
 		{
-			GetSubmodule<AssetRegistry>()->ScanContentFolder();
-			scheduler->WaitIdle({ EThreadType::Render, EThreadType::RHI });
-			renderer->RefreshFrameGraph();
+			RequestAssetReload();
 		}
+
+		ApplyPendingAssetReloadOnEngineThread();
 
 #ifdef SAILOR_BUILD_WITH_RENDER_DOC
 		if (auto renderDoc = App::GetSubmodule<RenderDocApi>())
@@ -622,6 +628,57 @@ void App::Stop()
 	s_pInstance->m_pMainWindow->SetRunning(false);
 }
 
+bool App::RequestAssetReload()
+{
+	if (!s_pInstance)
+	{
+		return false;
+	}
+
+	g_assetReloadRequested.store(true, std::memory_order_release);
+	return true;
+}
+
+bool App::ApplyPendingAssetReloadOnEngineThread()
+{
+	if (!g_assetReloadRequested.exchange(false, std::memory_order_acq_rel))
+	{
+		return false;
+	}
+
+	auto* assetRegistry = GetSubmodule<AssetRegistry>();
+	if (!assetRegistry)
+	{
+		return false;
+	}
+
+	auto* scheduler = GetSubmodule<Tasks::Scheduler>();
+	if (scheduler)
+	{
+		scheduler->WaitIdle({
+			EThreadType::Main,
+			EThreadType::Worker,
+			EThreadType::RHI,
+			EThreadType::Render
+		});
+	}
+	if (auto* shaderCompiler = GetSubmodule<ShaderCompiler>())
+	{
+		shaderCompiler->RecoverMissingShaderCacheStorage();
+	}
+	assetRegistry->ScanContentFolder();
+	if (scheduler)
+	{
+		scheduler->WaitIdle({ EThreadType::Render, EThreadType::RHI });
+	}
+	if (auto* renderer = GetSubmodule<Renderer>())
+	{
+		renderer->RefreshFrameGraph();
+	}
+
+	return true;
+}
+
 void App::Shutdown()
 {
 	if (!s_pInstance)
@@ -634,6 +691,7 @@ void App::Shutdown()
 
 	if (scheduler)
 	{
+		scheduler->AttachCurrentThreadAsMainThread();
 		scheduler->ProcessTasksOnMainThread();
 	}
 

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -17,6 +17,7 @@
 #include "Platform/Win32/Input.h"
 #include "GraphicsDriver/Vulkan/VulkanApi.h"
 #include "Tasks/Scheduler.h"
+#include "Tasks/Tasks.h"
 #include "RHI/Renderer.h"
 #include "Core/Submodule.h"
 #include "Containers/Vector.h"
@@ -27,10 +28,10 @@
 #include "Containers/Octree.h"
 #include "Engine/EngineLoop.h"
 #include <algorithm>
-#include <atomic>
 #include <cctype>
 #include <filesystem>
 #include <cstring>
+#include <mutex>
 #include "Memory/MemoryBlockAllocator.hpp"
 #include "ECS/ECS.h"
 #include "FrameGraph/RHIFrameGraph.h"
@@ -44,6 +45,7 @@
 #include "Engine/InstanceId.h"
 #include "Workspace/WorkspaceModuleManager.h"
 #include "Workspace/WorkspacePathEncoding.h"
+#include "YamlExceptionBoundary.h"
 
 #if defined(_WIN32)
 #include <timeapi.h>
@@ -75,7 +77,30 @@ const Workspace::WorkspaceContext& App::GetWorkspaceContext()
 
 namespace
 {
-	std::atomic_bool g_assetReloadRequested = false;
+	enum class EEngineMainLoopState : uint8_t
+	{
+		Pending,
+		Running,
+		Exited
+	};
+
+	std::mutex g_engineMainThreadDispatchMutex;
+	EEngineMainLoopState g_engineMainLoopState = EEngineMainLoopState::Pending;
+	bool g_engineShuttingDown = false;
+	thread_local bool g_bExecutingEngineMainThreadDispatch = false;
+
+	void ProcessPendingEngineMainThreadTasks(Tasks::Scheduler* scheduler)
+	{
+		if (!scheduler)
+		{
+			return;
+		}
+
+		const bool bWasExecutingDispatch = g_bExecutingEngineMainThreadDispatch;
+		g_bExecutingEngineMainThreadDispatch = true;
+		scheduler->ProcessTasksOnMainThread();
+		g_bExecutingEngineMainThreadDispatch = bWasExecutingDispatch;
+	}
 
 	bool ContainsWorkspaceManifest(const std::filesystem::path& root)
 	{
@@ -137,6 +162,100 @@ namespace
 
 		return parent;
 	}
+
+	bool ReloadAssetsOnEngineMainThread()
+	{
+		auto* assetRegistry = App::GetSubmodule<AssetRegistry>();
+		if (!assetRegistry)
+		{
+			return false;
+		}
+
+		auto* scheduler = App::GetSubmodule<Tasks::Scheduler>();
+		if (scheduler)
+		{
+			scheduler->WaitIdle({
+				EThreadType::Worker,
+				EThreadType::RHI,
+				EThreadType::Render
+			});
+		}
+		if (auto* shaderCompiler = App::GetSubmodule<ShaderCompiler>())
+		{
+			shaderCompiler->RecoverMissingShaderCacheStorage();
+		}
+		assetRegistry->ScanContentFolder();
+		if (scheduler)
+		{
+			scheduler->WaitIdle({ EThreadType::Render, EThreadType::RHI });
+		}
+		if (auto* renderer = App::GetSubmodule<Renderer>())
+		{
+			renderer->RefreshFrameGraph();
+		}
+
+		return true;
+	}
+}
+
+bool App::DispatchOnEngineMainThread(std::function<void()> command)
+{
+	if (!command)
+	{
+		return false;
+	}
+
+	std::function<void()> guardedCommand = [command = std::move(command)]() mutable
+	{
+		const bool bWasExecutingDispatch = g_bExecutingEngineMainThreadDispatch;
+		g_bExecutingEngineMainThreadDispatch = true;
+		std::string diagnostic;
+		const bool bSucceeded = External::GuardYamlExceptions(command, diagnostic);
+		g_bExecutingEngineMainThreadDispatch = bWasExecutingDispatch;
+		if (!bSucceeded)
+		{
+			SAILOR_LOG_ERROR("Editor interop command failed: %s", diagnostic.c_str());
+		}
+	};
+
+	if (g_bExecutingEngineMainThreadDispatch)
+	{
+		guardedCommand();
+		return true;
+	}
+
+	std::unique_lock<std::mutex> dispatchLock(g_engineMainThreadDispatchMutex);
+	if (g_engineShuttingDown)
+	{
+		return false;
+	}
+
+	auto* scheduler = GetSubmodule<Tasks::Scheduler>();
+	if (!scheduler)
+	{
+		return false;
+	}
+
+	if (scheduler->IsMainThread())
+	{
+		guardedCommand();
+		return true;
+	}
+
+	if (g_engineMainLoopState != EEngineMainLoopState::Running)
+	{
+		return false;
+	}
+
+	auto task = Tasks::CreateTask(
+		"Editor interop on engine main thread",
+		std::move(guardedCommand),
+		EThreadType::Main);
+	scheduler->Run(task);
+	dispatchLock.unlock();
+
+	task->Wait();
+	return task->IsFinished();
 }
 
 AppArgs ParseCommandLineArgs(const char** args, int32_t num)
@@ -198,7 +317,11 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 		return;
 	}
 
-	g_assetReloadRequested.store(false, std::memory_order_release);
+	{
+		const std::lock_guard<std::mutex> dispatchLock(g_engineMainThreadDispatchMutex);
+		g_engineMainLoopState = EEngineMainLoopState::Pending;
+		g_engineShuttingDown = false;
+	}
 
 #if defined(_WIN32)
 	timeBeginPeriod(1);
@@ -413,6 +536,8 @@ void App::Start()
 
 	if (s_pInstance->m_bSkipMainLoop)
 	{
+		const std::lock_guard<std::mutex> dispatchLock(g_engineMainThreadDispatchMutex);
+		g_engineMainLoopState = EEngineMainLoopState::Exited;
 		return;
 	}
 
@@ -423,9 +548,21 @@ void App::Start()
 	if (!scheduler || !renderer || !renderer->IsInitialized() || !pEngineLoop)
 	{
 		SAILOR_LOG_ERROR("App::Start skipped: engine subsystems are not fully initialized.");
+		const std::lock_guard<std::mutex> dispatchLock(g_engineMainThreadDispatchMutex);
+		g_engineMainLoopState = EEngineMainLoopState::Exited;
 		return;
 	}
-	scheduler->AttachCurrentThreadAsMainThread();
+	{
+		const std::lock_guard<std::mutex> dispatchLock(g_engineMainThreadDispatchMutex);
+		scheduler->AttachCurrentThreadAsMainThread();
+		g_engineMainLoopState = EEngineMainLoopState::Running;
+		if (s_pInstance->m_assetReloadRequestGeneration > 0 &&
+			(!s_pInstance->m_pendingAssetReloadTask ||
+				s_pInstance->m_pendingAssetReloadTask->IsFinished()))
+		{
+			QueueAssetReloadTaskLocked(scheduler);
+		}
+	}
 
 	auto& pMainWindow = s_pInstance->m_pMainWindow;
 
@@ -503,8 +640,6 @@ void App::Start()
 		{
 			RequestAssetReload();
 		}
-
-		ApplyPendingAssetReloadOnEngineThread();
 
 #ifdef SAILOR_BUILD_WITH_RENDER_DOC
 		if (auto renderDoc = App::GetSubmodule<RenderDocApi>())
@@ -615,6 +750,11 @@ void App::Start()
 
 	pMainWindow->SetActive(false);
 	pMainWindow->SetRunning(false);
+	{
+		const std::lock_guard<std::mutex> dispatchLock(g_engineMainThreadDispatchMutex);
+		g_engineMainLoopState = EEngineMainLoopState::Exited;
+	}
+	ProcessPendingEngineMainThreadTasks(scheduler);
 }
 
 void App::Stop()
@@ -630,53 +770,85 @@ void App::Stop()
 
 bool App::RequestAssetReload()
 {
-	if (!s_pInstance)
-	{
-		return false;
-	}
-
-	g_assetReloadRequested.store(true, std::memory_order_release);
-	return true;
-}
-
-bool App::ApplyPendingAssetReloadOnEngineThread()
-{
-	if (!g_assetReloadRequested.exchange(false, std::memory_order_acq_rel))
-	{
-		return false;
-	}
-
-	auto* assetRegistry = GetSubmodule<AssetRegistry>();
-	if (!assetRegistry)
+	const std::lock_guard<std::mutex> dispatchLock(g_engineMainThreadDispatchMutex);
+	if (!s_pInstance || g_engineShuttingDown ||
+		g_engineMainLoopState == EEngineMainLoopState::Exited)
 	{
 		return false;
 	}
 
 	auto* scheduler = GetSubmodule<Tasks::Scheduler>();
-	if (scheduler)
+	if (!scheduler)
 	{
-		scheduler->WaitIdle({
-			EThreadType::Main,
-			EThreadType::Worker,
-			EThreadType::RHI,
-			EThreadType::Render
-		});
-	}
-	if (auto* shaderCompiler = GetSubmodule<ShaderCompiler>())
-	{
-		shaderCompiler->RecoverMissingShaderCacheStorage();
-	}
-	assetRegistry->ScanContentFolder();
-	if (scheduler)
-	{
-		scheduler->WaitIdle({ EThreadType::Render, EThreadType::RHI });
-	}
-	if (auto* renderer = GetSubmodule<Renderer>())
-	{
-		renderer->RefreshFrameGraph();
+		return false;
 	}
 
+	++s_pInstance->m_assetReloadRequestGeneration;
+	if (s_pInstance->m_pendingAssetReloadTask &&
+		!s_pInstance->m_pendingAssetReloadTask->IsFinished())
+	{
+		return true;
+	}
+
+	QueueAssetReloadTaskLocked(scheduler);
 	return true;
+}
+
+void App::QueueAssetReloadTaskLocked(Tasks::Scheduler* scheduler)
+{
+	check(s_pInstance && scheduler);
+	auto task = Tasks::CreateTask(
+		"Reload assets on engine main thread",
+		[]() { ProcessAssetReloadRequestOnEngineMainThread(); },
+		EThreadType::Main);
+	s_pInstance->m_pendingAssetReloadTask = task;
+	scheduler->Run(task);
+}
+
+void App::ProcessAssetReloadRequestOnEngineMainThread()
+{
+	uint64_t requestGeneration = 0;
+	{
+		const std::lock_guard<std::mutex> dispatchLock(g_engineMainThreadDispatchMutex);
+		if (!s_pInstance || g_engineShuttingDown ||
+			g_engineMainLoopState != EEngineMainLoopState::Running)
+		{
+			if (s_pInstance)
+			{
+				s_pInstance->m_pendingAssetReloadTask.Clear();
+			}
+			return;
+		}
+		requestGeneration = s_pInstance->m_assetReloadRequestGeneration;
+	}
+
+	ReloadAssetsOnEngineMainThread();
+
+	const std::lock_guard<std::mutex> dispatchLock(g_engineMainThreadDispatchMutex);
+	if (!s_pInstance || g_engineShuttingDown ||
+		g_engineMainLoopState != EEngineMainLoopState::Running)
+	{
+		if (s_pInstance)
+		{
+			s_pInstance->m_pendingAssetReloadTask.Clear();
+		}
+		return;
+	}
+
+	if (s_pInstance->m_assetReloadRequestGeneration == requestGeneration)
+	{
+		s_pInstance->m_pendingAssetReloadTask.Clear();
+		return;
+	}
+
+	auto* scheduler = GetSubmodule<Tasks::Scheduler>();
+	if (!scheduler)
+	{
+		s_pInstance->m_pendingAssetReloadTask.Clear();
+		return;
+	}
+
+	QueueAssetReloadTaskLocked(scheduler);
 }
 
 void App::Shutdown()
@@ -689,10 +861,15 @@ void App::Shutdown()
 	auto scheduler = GetSubmodule<Tasks::Scheduler>();
 	auto renderer = GetSubmodule<Renderer>();
 
+	{
+		const std::lock_guard<std::mutex> dispatchLock(g_engineMainThreadDispatchMutex);
+		g_engineShuttingDown = true;
+		g_engineMainLoopState = EEngineMainLoopState::Exited;
+	}
 	if (scheduler)
 	{
 		scheduler->AttachCurrentThreadAsMainThread();
-		scheduler->ProcessTasksOnMainThread();
+		ProcessPendingEngineMainThreadTasks(scheduler);
 	}
 
 	if (renderer)
@@ -703,6 +880,7 @@ void App::Shutdown()
 	if (scheduler)
 	{
 		scheduler->WaitIdle({ EThreadType::Main, EThreadType::Worker, EThreadType::RHI, EThreadType::Render });
+		s_pInstance->m_pendingAssetReloadTask.Clear();
 	}
 
 	SAILOR_LOG("Sailor Engine Releasing");

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -50,6 +50,8 @@ namespace Sailor
 		SAILOR_API static void Start();
 		SAILOR_API static void Stop();
 		SAILOR_API static void Shutdown();
+		SAILOR_API static bool RequestAssetReload();
+		static bool ApplyPendingAssetReloadOnEngineThread();
 		SAILOR_API static bool IsRendererInitialized();
 		SAILOR_API static bool HasEditor();
 		SAILOR_API static bool IsEditorMode();

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -10,12 +10,18 @@
 #include "Containers/Containers.h"
 #include "Math/Math.h"
 #include "Workspace/WorkspaceContext.h"
+#include <functional>
 
 namespace Sailor
 {
 	namespace Workspace
 	{
 		class WorkspaceModuleManager;
+	}
+	namespace Tasks
+	{
+		class ITask;
+		class Scheduler;
 	}
 
 	struct AppArgs
@@ -51,7 +57,6 @@ namespace Sailor
 		SAILOR_API static void Stop();
 		SAILOR_API static void Shutdown();
 		SAILOR_API static bool RequestAssetReload();
-		static bool ApplyPendingAssetReloadOnEngineThread();
 		SAILOR_API static bool IsRendererInitialized();
 		SAILOR_API static bool HasEditor();
 		SAILOR_API static bool IsEditorMode();
@@ -72,12 +77,13 @@ namespace Sailor
 		SAILOR_API static bool LoadEditorWorld(const char* strFileId);
 		SAILOR_API static bool UpdateEditorObject(const char* strInstanceId, const char* strYamlNode);
 		SAILOR_API static bool ReparentEditorObject(const char* strInstanceId, const char* strParentInstanceId, bool bKeepWorldTransform);
-		SAILOR_API static bool CreateEditorGameObject(const char* strParentInstanceId);
+		SAILOR_API static bool CreateEditorGameObject(const char* strParentInstanceId, const char* strPreferredInstanceId, char** outInstanceId);
 		SAILOR_API static bool DestroyEditorObject(const char* strInstanceId);
 		SAILOR_API static bool ResetEditorComponentToDefaults(const char* strInstanceId);
-		SAILOR_API static bool AddEditorComponent(const char* strInstanceId, const char* strComponentTypeName);
+		SAILOR_API static bool AddEditorComponent(const char* strInstanceId, const char* strComponentTypeName, const char* strPreferredInstanceId, char** outInstanceId);
 		SAILOR_API static bool RemoveEditorComponent(const char* strInstanceId);
 		SAILOR_API static bool InstantiateEditorPrefab(const char* strFileId, const char* strParentInstanceId);
+		SAILOR_API static bool InstantiateEditorPrefabFromYaml(const char* strPrefabYaml, const char* strParentInstanceId);
 		SAILOR_API static bool SetEditorSelection(const char* strSelectionYaml);
 		SAILOR_API static bool RenderPathTracedImage(const char* strOutputPath, const char* strInstanceId, uint32_t height, uint32_t samplesPerPixel, uint32_t maxBounces);
 		SAILOR_API static void ShowMainWindow(bool bShow);
@@ -160,7 +166,27 @@ namespace Sailor
 		AppArgs m_args{};
 
 	private:
+		static bool DispatchOnEngineMainThread(std::function<void()> command);
+		static void QueueAssetReloadTaskLocked(Tasks::Scheduler* scheduler);
+		static void ProcessAssetReloadRequestOnEngineMainThread();
 
+		template<typename TResult>
+		static TResult ExecuteOnEngineMainThread(TResult fallback, std::function<TResult()> command)
+		{
+			TResult result = fallback;
+			if (!command || !DispatchOnEngineMainThread([&result, &command]()
+				{
+					result = command();
+				}))
+			{
+				return fallback;
+			}
+
+			return result;
+		}
+
+		TSharedPtr<Tasks::ITask> m_pendingAssetReloadTask;
+		uint64_t m_assetReloadRequestGeneration = 0;
 		TUniquePtr<SubmoduleBase> m_submodules[MaxSubmodules];
 
 		static App* s_pInstance;

--- a/Runtime/Submodules/Editor.cpp
+++ b/Runtime/Submodules/Editor.cpp
@@ -12,6 +12,7 @@
 #include "AssetRegistry/Prefab/PrefabImporter.h"
 #include "AssetRegistry/FileId.h"
 #include "Core/Reflection.h"
+#include "Math/Math.h"
 #include "Math/Transform.h"
 #if defined(_WIN32)
 #include <libloaderapi.h>
@@ -21,6 +22,7 @@
 #include <ctime>
 #include <iomanip>
 #include <sstream>
+#include <algorithm>
 #include <cmath>
 #include "Platform/Win32/Window.h"
 
@@ -39,6 +41,119 @@ namespace
 		}
 
 		return false;
+	}
+
+	glm::mat4 CalculateCurrentWorldMatrix(GameObjectPtr gameObject)
+	{
+		glm::mat4 worldMatrix = glm::identity<glm::mat4>();
+		for (auto current = gameObject; current.IsValid(); current = current->GetParent())
+		{
+			worldMatrix = current->GetTransformComponent().GetTransform().Matrix() * worldMatrix;
+		}
+
+		return worldMatrix;
+	}
+
+	bool IsFiniteMatrix(const glm::mat4& matrix)
+	{
+		for (glm::length_t column = 0; column < matrix.length(); ++column)
+		{
+			for (glm::length_t row = 0; row < matrix[column].length(); ++row)
+			{
+				if (!std::isfinite(matrix[column][row]))
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	bool AreMatricesNear(const glm::mat4& lhs, const glm::mat4& rhs, float tolerance = 0.0001f)
+	{
+		for (glm::length_t column = 0; column < lhs.length(); ++column)
+		{
+			for (glm::length_t row = 0; row < lhs[column].length(); ++row)
+			{
+				const float scale = std::max({ 1.0f, std::abs(lhs[column][row]), std::abs(rhs[column][row]) });
+				if (std::abs(lhs[column][row] - rhs[column][row]) > tolerance * scale)
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	bool TryInvertTransformMatrix(const glm::mat4& matrix, glm::mat4& outInverse)
+	{
+		if (!IsFiniteMatrix(matrix))
+		{
+			return false;
+		}
+
+		const glm::vec3 axisX(matrix[0]);
+		const glm::vec3 axisY(matrix[1]);
+		const glm::vec3 axisZ(matrix[2]);
+		const float axisLengthProduct = glm::length(axisX) * glm::length(axisY) * glm::length(axisZ);
+		const float normalizedVolume = axisLengthProduct > 0.0f
+			? std::abs(glm::dot(glm::cross(axisX, axisY), axisZ)) / axisLengthProduct
+			: 0.0f;
+		if (!std::isfinite(normalizedVolume) || normalizedVolume <= 0.000001f)
+		{
+			return false;
+		}
+
+		outInverse = glm::inverse(matrix);
+		return IsFiniteMatrix(outInverse) &&
+			AreMatricesNear(matrix * outInverse, glm::identity<glm::mat4>(), 0.001f);
+	}
+
+	bool TryMakeExactTransform(const glm::mat4& matrix, Math::Transform& outTransform)
+	{
+		if (!IsFiniteMatrix(matrix))
+		{
+			return false;
+		}
+
+		outTransform = Math::Transform::FromMatrix(matrix);
+		const glm::vec4 rotation(
+			outTransform.m_rotation.x,
+			outTransform.m_rotation.y,
+			outTransform.m_rotation.z,
+			outTransform.m_rotation.w);
+		if (!Math::AllFinite(outTransform.m_position) ||
+			!Math::AllFinite(rotation) ||
+			!Math::AllFinite(outTransform.m_scale))
+		{
+			return false;
+		}
+
+		return AreMatricesNear(outTransform.Matrix(), matrix);
+	}
+
+	bool ResolveParent(World* world, const InstanceId& parentInstanceId, GameObjectPtr& outParent)
+	{
+		outParent = {};
+		if (!parentInstanceId)
+		{
+			return true;
+		}
+
+		if (!world)
+		{
+			return false;
+		}
+		if (!parentInstanceId.IsGameObjectId())
+		{
+			return false;
+		}
+
+		auto parentObject = world->GetObjectByInstanceId(parentInstanceId);
+		outParent = parentObject.DynamicCast<GameObject>();
+		return outParent.IsValid();
 	}
 }
 
@@ -186,7 +301,7 @@ bool Editor::ReparentObject(const InstanceId& instanceId, const InstanceId& pare
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	if (!m_world)
+	if (!m_world || !instanceId.IsGameObjectId())
 	{
 		return false;
 	}
@@ -204,11 +319,14 @@ bool Editor::ReparentObject(const InstanceId& instanceId, const InstanceId& pare
 	}
 
 	GameObjectPtr parentGameObject;
-	if (parentInstanceId)
+	if (!ResolveParent(m_world, parentInstanceId, parentGameObject))
 	{
-		auto parentObject = m_world->GetObjectByInstanceId(parentInstanceId.GameObjectId());
-		parentGameObject = parentObject.DynamicCast<GameObject>();
-		if (!parentGameObject || parentGameObject == gameObject)
+		return false;
+	}
+
+	if (parentGameObject)
+	{
+		if (parentGameObject == gameObject)
 		{
 			return false;
 		}
@@ -219,19 +337,37 @@ bool Editor::ReparentObject(const InstanceId& instanceId, const InstanceId& pare
 		}
 	}
 
-	const glm::mat4 oldWorldMatrix = gameObject->GetTransformComponent().GetCachedWorldMatrix();
-	glm::mat4 parentWorldMatrix = glm::identity<glm::mat4>();
-	if (parentGameObject)
+	if (gameObject->GetParent() == parentGameObject)
 	{
-		parentWorldMatrix = parentGameObject->GetTransformComponent().GetCachedWorldMatrix();
+		return true;
+	}
+
+	Math::Transform localTransform;
+	if (bKeepWorldTransform)
+	{
+		const glm::mat4 oldWorldMatrix = CalculateCurrentWorldMatrix(gameObject);
+		glm::mat4 localMatrix = oldWorldMatrix;
+		if (parentGameObject)
+		{
+			glm::mat4 inverseParentMatrix;
+			if (!TryInvertTransformMatrix(CalculateCurrentWorldMatrix(parentGameObject), inverseParentMatrix))
+			{
+				return false;
+			}
+
+			localMatrix = inverseParentMatrix * oldWorldMatrix;
+		}
+
+		if (!TryMakeExactTransform(localMatrix, localTransform))
+		{
+			return false;
+		}
 	}
 
 	gameObject->SetParent(parentGameObject);
 
 	if (bKeepWorldTransform)
 	{
-		const glm::mat4 localMatrix = parentGameObject ? glm::inverse(parentWorldMatrix) * oldWorldMatrix : oldWorldMatrix;
-		const auto localTransform = Math::Transform::FromMatrix(localMatrix);
 		auto& transform = gameObject->GetTransformComponent();
 		transform.SetPosition(localTransform.m_position);
 		transform.SetRotation(localTransform.m_rotation);
@@ -241,30 +377,36 @@ bool Editor::ReparentObject(const InstanceId& instanceId, const InstanceId& pare
 	return true;
 }
 
-bool Editor::CreateGameObject(const InstanceId& parentInstanceId)
+bool Editor::CreateGameObject(const InstanceId& parentInstanceId, const InstanceId& preferredInstanceId, InstanceId& outInstanceId)
 {
 	SAILOR_PROFILE_FUNCTION();
+	outInstanceId = InstanceId::Invalid;
 
 	if (!m_world)
 	{
 		return false;
 	}
 
-	auto gameObject = m_world->Instantiate("GameObject");
+	GameObjectPtr parentGameObject;
+	if (!ResolveParent(m_world, parentInstanceId, parentGameObject))
+	{
+		return false;
+	}
+
+	auto gameObject = preferredInstanceId
+		? m_world->Instantiate("GameObject", preferredInstanceId)
+		: m_world->Instantiate("GameObject");
 	if (!gameObject)
 	{
 		return false;
 	}
 
-	if (parentInstanceId)
+	if (parentGameObject)
 	{
-		auto parentObject = m_world->GetObjectByInstanceId(parentInstanceId.GameObjectId());
-		if (auto parentGameObject = parentObject.DynamicCast<GameObject>())
-		{
-			gameObject->SetParent(parentGameObject);
-		}
+		gameObject->SetParent(parentGameObject);
 	}
 
+	outInstanceId = gameObject->GetInstanceId();
 	return true;
 }
 
@@ -272,7 +414,7 @@ bool Editor::DestroyObject(const InstanceId& instanceId)
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	if (!m_world || !instanceId)
+	if (!m_world || !instanceId.IsGameObjectId())
 	{
 		return false;
 	}
@@ -321,11 +463,16 @@ bool Editor::ResetComponentToDefaults(const InstanceId& instanceId)
 	return false;
 }
 
-bool Editor::AddComponent(const InstanceId& instanceId, const std::string& componentTypeName)
+bool Editor::AddComponent(
+	const InstanceId& instanceId,
+	const std::string& componentTypeName,
+	const InstanceId& preferredInstanceId,
+	InstanceId& outInstanceId)
 {
 	SAILOR_PROFILE_FUNCTION();
+	outInstanceId = InstanceId::Invalid;
 
-	if (!m_world || !instanceId || componentTypeName.empty())
+	if (!m_world || !instanceId.IsGameObjectId() || componentTypeName.empty())
 	{
 		return false;
 	}
@@ -349,10 +496,16 @@ bool Editor::AddComponent(const InstanceId& instanceId, const std::string& compo
 		return false;
 	}
 
-	gameObject->AddComponentRaw(component);
+	component = gameObject->AddComponentRaw(component, preferredInstanceId);
+	if (!component)
+	{
+		return false;
+	}
+
 	const ReflectedData& defaults = Reflection::GetCDO(componentTypeName);
 	component->ApplyReflection(defaults);
 	component->ResolveRefs(defaults, m_world->GetObjects(), true);
+	outInstanceId = component->GetInstanceId();
 	return true;
 }
 
@@ -405,19 +558,33 @@ bool Editor::InstantiatePrefab(const FileId& prefabId, const InstanceId& parentI
 		return false;
 	}
 
+	return InstantiatePrefab(prefab, parentInstanceId);
+}
+
+bool Editor::InstantiatePrefab(const PrefabPtr& prefab, const InstanceId& parentInstanceId)
+{
+	SAILOR_PROFILE_FUNCTION();
+
+	if (!m_world || !prefab)
+	{
+		return false;
+	}
+
+	GameObjectPtr parentGameObject;
+	if (!ResolveParent(m_world, parentInstanceId, parentGameObject))
+	{
+		return false;
+	}
+
 	auto root = m_world->Instantiate(prefab);
 	if (!root)
 	{
 		return false;
 	}
 
-	if (parentInstanceId)
+	if (parentGameObject)
 	{
-		auto parentObject = m_world->GetObjectByInstanceId(parentInstanceId.GameObjectId());
-		if (auto parentGameObject = parentObject.DynamicCast<GameObject>())
-		{
-			root->SetParent(parentGameObject);
-		}
+		root->SetParent(parentGameObject);
 	}
 
 	return true;

--- a/Runtime/Submodules/Editor.h
+++ b/Runtime/Submodules/Editor.h
@@ -15,6 +15,10 @@ namespace concurrency = tbb;
 
 namespace Sailor
 {
+	template<typename T>
+	class TObjectPtr;
+	class Prefab;
+
 	namespace Win32 
 	{
 		class Window;
@@ -24,7 +28,7 @@ namespace Sailor
 	{
 	public:
 
-		Editor(HWND editorHwnd, uint32_t editorPort, Win32::Window* pMainWindow);
+		SAILOR_API Editor(HWND editorHwnd, uint32_t editorPort, Win32::Window* pMainWindow);
 
 		void SetWorld(class World* world) { m_world = world; }
 		class World* GetWorld() const { return m_world; }
@@ -43,13 +47,14 @@ namespace Sailor
 		RECT GetViewport() const { return m_windowRect; }
 
 		bool UpdateObject(const class InstanceId& instanceId, const std::string& strYamlNode);
-		bool ReparentObject(const class InstanceId& instanceId, const class InstanceId& parentInstanceId, bool bKeepWorldTransform);
-		bool CreateGameObject(const class InstanceId& parentInstanceId);
+		SAILOR_API bool ReparentObject(const class InstanceId& instanceId, const class InstanceId& parentInstanceId, bool bKeepWorldTransform);
+		bool CreateGameObject(const class InstanceId& parentInstanceId, const class InstanceId& preferredInstanceId, class InstanceId& outInstanceId);
 		bool DestroyObject(const class InstanceId& instanceId);
 		bool ResetComponentToDefaults(const class InstanceId& instanceId);
-		bool AddComponent(const class InstanceId& instanceId, const std::string& componentTypeName);
+		bool AddComponent(const class InstanceId& instanceId, const std::string& componentTypeName, const class InstanceId& preferredInstanceId, class InstanceId& outInstanceId);
 		bool RemoveComponent(const class InstanceId& instanceId);
 		bool InstantiatePrefab(const class FileId& prefabId, const class InstanceId& parentInstanceId);
+		bool InstantiatePrefab(const TObjectPtr<Prefab>& prefab, const class InstanceId& parentInstanceId);
 		bool RenderPathTracedImage(const class InstanceId& instanceId, const std::string& outputPath, uint32_t height, uint32_t samplesPerPixel, uint32_t maxBounces);
 
 	protected:

--- a/Runtime/Submodules/EditorRemote/RemoteViewportMacNativeBridge.mm
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportMacNativeBridge.mm
@@ -724,102 +724,101 @@ namespace Sailor::EditorRemote
 
 	Failure PresentMacNativeLayerFrame(MacNativeLayerBinding& inOutBinding, const MacIOSurfaceHandle& surfaceHandle, const FramePacket& frame, MacNativeBridgePresentResult& outResult)
 	{
-		if (![NSThread isMainThread])
+		@autoreleasepool
 		{
-			return RunOnMainThreadSync([&]() -> Failure
+			if (!inOutBinding.IsValid())
 			{
-				return PresentMacNativeLayerFrame(inOutBinding, surfaceHandle, frame, outResult);
-			});
-		}
+				return MakeFailure(2111, "macOS native layer present requires a valid CAMetalLayer binding");
+			}
 
-		if (!inOutBinding.IsValid())
-		{
-			return MakeFailure(2111, "macOS native layer present requires a valid CAMetalLayer binding");
-		}
+			CAMetalLayer* metalLayer = (__bridge CAMetalLayer*)reinterpret_cast<void*>(inOutBinding.m_layerObject);
+			if (metalLayer == nil)
+			{
+				return MakeFailure(2112, "macOS native layer present resolved the CAMetalLayer to nil");
+			}
 
-		CAMetalLayer* metalLayer = (__bridge CAMetalLayer*)reinterpret_cast<void*>(inOutBinding.m_layerObject);
-		if (metalLayer == nil)
-		{
-			return MakeFailure(2112, "macOS native layer present resolved the CAMetalLayer to nil");
-		}
+			id<MTLDevice> device = (__bridge id<MTLDevice>)reinterpret_cast<void*>(inOutBinding.m_deviceObject);
+			if (device == nil)
+			{
+				return MakeFailure(2114, "macOS native layer present resolved the Metal device to nil");
+			}
 
-		id<MTLDevice> device = (__bridge id<MTLDevice>)reinterpret_cast<void*>(inOutBinding.m_deviceObject);
-		if (device == nil)
-		{
-			return MakeFailure(2114, "macOS native layer present resolved the Metal device to nil");
-		}
+			id<MTLCommandQueue> commandQueue = (__bridge id<MTLCommandQueue>)reinterpret_cast<void*>(inOutBinding.m_commandQueueObject);
+			if (commandQueue == nil)
+			{
+				return MakeFailure(2115, "macOS native layer present resolved the Metal command queue to nil");
+			}
 
-		id<MTLCommandQueue> commandQueue = (__bridge id<MTLCommandQueue>)reinterpret_cast<void*>(inOutBinding.m_commandQueueObject);
-		if (commandQueue == nil)
-		{
-			return MakeFailure(2115, "macOS native layer present resolved the Metal command queue to nil");
-		}
+			id<CAMetalDrawable> drawable = [metalLayer nextDrawable];
+			if (drawable == nil)
+			{
+				return MakeFailure(2113, "macOS native layer present could not acquire a drawable");
+			}
 
-		id<CAMetalDrawable> drawable = RunOnMainThreadSync([&]() -> id<CAMetalDrawable>
-		{
-			return [metalLayer nextDrawable];
-		});
-		if (drawable == nil)
-		{
-			return MakeFailure(2113, "macOS native layer present could not acquire a drawable");
-		}
+			id<MTLTexture> sourceTexture = CreateIOSurfaceBackedSourceTexture(device, surfaceHandle, inOutBinding);
+			const bool usedSyntheticSourceTexture = sourceTexture == nil;
+			if (sourceTexture == nil)
+			{
+				sourceTexture = CreateSyntheticSourceTexture(device, frame, inOutBinding);
+			}
+			if (sourceTexture == nil)
+			{
+				return MakeFailure(2116, "macOS native layer present could not create a source Metal texture");
+			}
 
-		id<MTLTexture> sourceTexture = CreateIOSurfaceBackedSourceTexture(device, surfaceHandle, inOutBinding);
-		const bool usedSyntheticSourceTexture = sourceTexture == nil;
-		if (sourceTexture == nil)
-		{
-			sourceTexture = CreateSyntheticSourceTexture(device, frame, inOutBinding);
-		}
-		if (sourceTexture == nil)
-		{
-			return MakeFailure(2116, "macOS native layer present could not create a source Metal texture");
-		}
+			// Both source helpers use Metal's `new` ownership convention. Move that
+			// ownership into the local pool so early returns cannot leak a texture;
+			// the binding retains the successful frame's texture below.
+			[sourceTexture autorelease];
 
-		id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
-		if (commandBuffer == nil)
-		{
-			return MakeFailure(2117, "macOS native layer present could not create a Metal command buffer");
+			id<MTLCommandBuffer> commandBuffer = [commandQueue commandBuffer];
+			if (commandBuffer == nil)
+			{
+				return MakeFailure(2117, "macOS native layer present could not create a Metal command buffer");
+			}
+
+			id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer blitCommandEncoder];
+			if (blitEncoder == nil)
+			{
+				return MakeFailure(2118, "macOS native layer present could not create a Metal blit encoder");
+			}
+
+			const MTLSize copySize = MTLSizeMake((NSUInteger)inOutBinding.m_width, (NSUInteger)inOutBinding.m_height, 1);
+			[blitEncoder copyFromTexture:sourceTexture
+						sourceSlice:0
+						sourceLevel:0
+					   sourceOrigin:MTLOriginMake(0, 0, 0)
+					     sourceSize:copySize
+					      toTexture:drawable.texture
+			 destinationSlice:0
+			 destinationLevel:0
+			destinationOrigin:MTLOriginMake(0, 0, 0)];
+			[blitEncoder endEncoding];
+			[commandBuffer presentDrawable:drawable];
+			[commandBuffer commit];
+			[commandBuffer waitUntilScheduled];
+
+			inOutBinding.m_drawableObject = reinterpret_cast<uintptr_t>((__bridge void*)drawable);
+			inOutBinding.m_importedIOSurfaceObject = surfaceHandle.m_surfaceObject;
+			ReleaseObjectiveCObject(inOutBinding.m_lastSourceTextureObject);
+			inOutBinding.m_lastSourceTextureObject = RetainObjectiveCObject(sourceTexture);
+			inOutBinding.m_presentToken++;
+			inOutBinding.m_sourceTextureToken++;
+			inOutBinding.m_usesSyntheticSourceTexture = usedSyntheticSourceTexture;
+			outResult.m_drawableObject = inOutBinding.m_drawableObject;
+			outResult.m_sourceTextureObject = inOutBinding.m_lastSourceTextureObject;
+			outResult.m_presentToken = inOutBinding.m_presentToken;
+			outResult.m_sourceTextureToken = inOutBinding.m_sourceTextureToken;
+			outResult.m_usedRealCAMetalLayer = true;
+			outResult.m_usedMetalCommandQueue = true;
+			outResult.m_usedSyntheticSourceTexture = usedSyntheticSourceTexture;
+			return Failure::Ok();
 		}
-
-		id<MTLBlitCommandEncoder> blitEncoder = [commandBuffer blitCommandEncoder];
-		if (blitEncoder == nil)
-		{
-			return MakeFailure(2118, "macOS native layer present could not create a Metal blit encoder");
-		}
-
-		const MTLSize copySize = MTLSizeMake((NSUInteger)inOutBinding.m_width, (NSUInteger)inOutBinding.m_height, 1);
-		[blitEncoder copyFromTexture:sourceTexture
-					sourceSlice:0
-					sourceLevel:0
-				   sourceOrigin:MTLOriginMake(0, 0, 0)
-				     sourceSize:copySize
-				      toTexture:drawable.texture
-		 destinationSlice:0
-		 destinationLevel:0
-		destinationOrigin:MTLOriginMake(0, 0, 0)];
-		[blitEncoder endEncoding];
-		[commandBuffer presentDrawable:drawable];
-		[commandBuffer commit];
-		[commandBuffer waitUntilScheduled];
-
-		inOutBinding.m_drawableObject = reinterpret_cast<uintptr_t>((__bridge void*)drawable);
-		inOutBinding.m_importedIOSurfaceObject = surfaceHandle.m_surfaceObject;
-		inOutBinding.m_lastSourceTextureObject = reinterpret_cast<uintptr_t>((__bridge void*)sourceTexture);
-		inOutBinding.m_presentToken++;
-		inOutBinding.m_sourceTextureToken++;
-		inOutBinding.m_usesSyntheticSourceTexture = usedSyntheticSourceTexture;
-		outResult.m_drawableObject = inOutBinding.m_drawableObject;
-		outResult.m_sourceTextureObject = inOutBinding.m_lastSourceTextureObject;
-		outResult.m_presentToken = inOutBinding.m_presentToken;
-		outResult.m_sourceTextureToken = inOutBinding.m_sourceTextureToken;
-		outResult.m_usedRealCAMetalLayer = true;
-		outResult.m_usedMetalCommandQueue = true;
-		outResult.m_usedSyntheticSourceTexture = usedSyntheticSourceTexture;
-		return Failure::Ok();
 	}
 
 	void ResetMacNativeLayerBinding(MacNativeLayerBinding& inOutBinding)
 	{
+		ReleaseObjectiveCObject(inOutBinding.m_lastSourceTextureObject);
 		ReleaseObjectiveCObject(inOutBinding.m_commandQueueObject);
 		ReleaseObjectiveCObject(inOutBinding.m_deviceObject);
 		ReleaseObjectiveCObject(inOutBinding.m_layerObject);

--- a/Runtime/Submodules/EditorRemote/RemoteViewportMacTransport.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportMacTransport.h
@@ -360,33 +360,37 @@ namespace Sailor::EditorRemote
 				auto sourceResult = m_rendererFrameSourceProvider->AcquireFrameSource(state, nextFrameIndex, rendererSource);
 				if (!sourceResult.IsOk())
 				{
+					ReleaseRendererFrameSourceResources(rendererSource);
 					m_lastFailure = sourceResult;
 					return sourceResult;
 				}
 
-				if (!rendererSource.IsValid())
+				if (rendererSource.IsValid())
 				{
-					m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 1004, "macOS renderer source is temporarily unavailable");
-					return m_lastFailure;
+					bHasCpuPayload = rendererSource.m_kind == MacRendererFrameSourceKind::RendererOwnedRenderTargetMetadata &&
+						rendererSource.m_cpuBytes && !rendererSource.m_cpuBytes->empty();
+					const bool bHasCopyableSource =
+						rendererSource.m_kind == MacRendererFrameSourceKind::RendererOwnedMetalTexture || bHasCpuPayload;
+					if (bHasCopyableSource &&
+						(rendererSource.m_width != state.m_nativeAllocation->m_plane.m_width ||
+						rendererSource.m_height != state.m_nativeAllocation->m_plane.m_height))
+					{
+						ReleaseRendererFrameSourceResources(rendererSource);
+						rendererSource = {};
+						bHasCpuPayload = false;
+					}
+					else if (bHasCpuPayload &&
+						rendererSource.m_bytesPerRow < state.m_nativeAllocation->m_plane.m_width * state.m_nativeAllocation->m_plane.m_bytesPerElement)
+					{
+						ReleaseRendererFrameSourceResources(rendererSource);
+						m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 1006, "macOS renderer source row stride is smaller than the current IOSurface row");
+						return m_lastFailure;
+					}
 				}
-
-				bHasCpuPayload = rendererSource.m_kind == MacRendererFrameSourceKind::RendererOwnedRenderTargetMetadata &&
-					rendererSource.m_cpuBytes && !rendererSource.m_cpuBytes->empty();
-				const bool bHasCopyableSource =
-					rendererSource.m_kind == MacRendererFrameSourceKind::RendererOwnedMetalTexture || bHasCpuPayload;
-				if (bHasCopyableSource &&
-					(rendererSource.m_width != state.m_nativeAllocation->m_plane.m_width ||
-					rendererSource.m_height != state.m_nativeAllocation->m_plane.m_height))
+				else
 				{
-					m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 1005, "macOS renderer source extents do not match the current IOSurface");
-					return m_lastFailure;
-				}
-
-				if (bHasCpuPayload &&
-					rendererSource.m_bytesPerRow < state.m_nativeAllocation->m_plane.m_width * state.m_nativeAllocation->m_plane.m_bytesPerElement)
-				{
-					m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 1006, "macOS renderer source row stride is smaller than the current IOSurface row");
-					return m_lastFailure;
+					ReleaseRendererFrameSourceResources(rendererSource);
+					rendererSource = {};
 				}
 			}
 
@@ -397,11 +401,6 @@ namespace Sailor::EditorRemote
 			{
 				sourceTextureObject = rendererSource.m_textureObject;
 				copyResult = CopyMacRendererIntermediateToProducerTexture(state.m_nativeAllocation->m_producerDeviceObject, sourceTextureObject, state.m_nativeAllocation->m_producerTextureObject, state.m_nativeAllocation->m_plane.m_width, state.m_nativeAllocation->m_plane.m_height, rendererFrameInfo, rendererSource.m_crossApiSharedEventObject, rendererSource.m_crossApiAcquireValue);
-				if (rendererSource.m_releaseTextureObjectAfterUse)
-				{
-					ReleaseMacExportedTexture(sourceTextureObject);
-					rendererSource.m_textureObject = 0;
-				}
 			}
 			else if (bHasCpuPayload)
 			{
@@ -419,6 +418,7 @@ namespace Sailor::EditorRemote
 				auto uploadResult = UploadMacRendererPatternToIntermediateTexture(state.m_nativeAllocation->m_rendererIntermediateTextureObject, state.m_nativeAllocation->m_plane.m_width, state.m_nativeAllocation->m_plane.m_height, pattern);
 				if (!uploadResult.IsOk())
 				{
+					ReleaseRendererFrameSourceResources(rendererSource);
 					m_lastFailure = uploadResult;
 					return uploadResult;
 				}
@@ -434,13 +434,7 @@ namespace Sailor::EditorRemote
 				}
 				copyResult = CopyMacRendererIntermediateToProducerTexture(state.m_nativeAllocation->m_producerDeviceObject, state.m_nativeAllocation->m_rendererIntermediateTextureObject, state.m_nativeAllocation->m_producerTextureObject, state.m_nativeAllocation->m_plane.m_width, state.m_nativeAllocation->m_plane.m_height, rendererFrameInfo);
 			}
-			if (rendererSource.m_crossApiSharedEventObject != 0)
-			{
-#if defined(__APPLE__)
-				CFRelease(reinterpret_cast<CFTypeRef>(rendererSource.m_crossApiSharedEventObject));
-#endif
-				rendererSource.m_crossApiSharedEventObject = 0;
-			}
+			ReleaseRendererFrameSourceResources(rendererSource);
 			if (!copyResult.IsOk())
 			{
 				m_lastFailure = copyResult;
@@ -534,6 +528,22 @@ namespace Sailor::EditorRemote
 		size_t GetLiveAllocationCount() const { return m_liveAllocations.Num(); }
 
 	private:
+		static void ReleaseRendererFrameSourceResources(MacRendererFrameSource& rendererSource)
+		{
+			if (rendererSource.m_releaseTextureObjectAfterUse && rendererSource.m_textureObject != 0)
+			{
+				ReleaseMacExportedTexture(rendererSource.m_textureObject);
+				rendererSource.m_textureObject = 0;
+			}
+			if (rendererSource.m_crossApiSharedEventObject != 0)
+			{
+#if defined(__APPLE__)
+				CFRelease(reinterpret_cast<CFTypeRef>(rendererSource.m_crossApiSharedEventObject));
+#endif
+				rendererSource.m_crossApiSharedEventObject = 0;
+			}
+		}
+
 		void StoreAllocation(const MacViewportSurfaceKey& key, const MacIOSurfaceAllocation& allocation)
 		{
 			auto& storedAllocation = m_liveAllocations[key];

--- a/Runtime/Tasks/Scheduler.cpp
+++ b/Runtime/Tasks/Scheduler.cpp
@@ -192,8 +192,7 @@ void Scheduler::Initialize()
 		m_freeList.push((uint16_t)(MaxTasksInPool - i - 1));
 	}
 
-	m_mainThreadId = GetCurrentThreadId();
-	m_threadTypes[m_mainThreadId] = EThreadType::Main;
+	AttachCurrentThreadAsMainThread();
 
 #if defined(_WIN32)
 	SetPriorityClass(GetCurrentProcess(), HIGH_PRIORITY_CLASS);
@@ -240,6 +239,11 @@ void Scheduler::Initialize()
 	}
 
 	SAILOR_LOG("Initialize Tasks::Scheduler. Cores count: %d, Worker threads count: %zd", coresCount, m_workerThreads.Num());
+}
+
+void Scheduler::AttachCurrentThreadAsMainThread()
+{
+	m_mainThreadId.store(GetCurrentThreadId(), std::memory_order_release);
 }
 
 Scheduler::Scheduler()
@@ -384,7 +388,7 @@ void Scheduler::Run(const ITaskPtr& pTask, DWORD threadId, bool bAutoRunChainedT
 		m_workerThreads[result]->ForcelyPushTask(pTask);
 		return;
 	}
-	check(m_mainThreadId == threadId);
+	check(GetMainThreadId() == threadId);
 	// Add to Main thread if cannot find the thread in workers
 	{
 		std::mutex* pOutQueueMutex;
@@ -472,6 +476,11 @@ void Scheduler::NotifyWorkerThread(EThreadType threadType, bool bNotifyAllThread
 
 EThreadType Scheduler::GetCurrentThreadType() const
 {
+	if (IsMainThread())
+	{
+		return EThreadType::Main;
+	}
+
 	return m_threadTypes[GetCurrentThreadId()];
 }
 
@@ -563,7 +572,7 @@ void Scheduler::WaitIdle(EThreadType type)
 
 bool Scheduler::IsMainThread() const
 {
-	return m_mainThreadId == GetCurrentThreadId();
+	return GetMainThreadId() == GetCurrentThreadId();
 }
 
 bool Scheduler::IsRendererThread() const
@@ -573,7 +582,7 @@ bool Scheduler::IsRendererThread() const
 
 bool Scheduler::HasThread(DWORD threadId) const
 {
-	if (m_mainThreadId == threadId)
+	if (GetMainThreadId() == threadId)
 	{
 		return true;
 	}

--- a/Runtime/Tasks/Scheduler.h
+++ b/Runtime/Tasks/Scheduler.h
@@ -115,6 +115,7 @@ namespace Sailor
 		public:
 
 			SAILOR_API void Initialize();
+			SAILOR_API void AttachCurrentThreadAsMainThread();
 
 			SAILOR_API virtual ~Scheduler() override;
 
@@ -141,7 +142,7 @@ namespace Sailor
 			SAILOR_API bool IsRendererThread() const;
 			SAILOR_API bool HasThread(DWORD threadId) const;
 
-			SAILOR_API DWORD GetMainThreadId() const { return m_mainThreadId; }
+			SAILOR_API DWORD GetMainThreadId() const { return m_mainThreadId.load(std::memory_order_acquire); }
 			SAILOR_API DWORD GetRendererThreadId() const { return m_renderingThreadId; }
 			SAILOR_API EThreadType GetCurrentThreadType() const;
 
@@ -171,7 +172,7 @@ namespace Sailor
 			TVector<WorkerThread*> m_workerThreads;
 			std::atomic_bool m_bIsTerminating;
 
-			DWORD m_mainThreadId = -1;
+			std::atomic<DWORD> m_mainThreadId{ static_cast<DWORD>(-1) };
 			DWORD m_renderingThreadId = -1;
 
 			// Task Synchronization primitives pool

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -1,5 +1,9 @@
 #include "AssetRegistry/AssetCache.h"
+#include "AssetRegistry/AssetInfo.h"
 
+#include <chrono>
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <stdexcept>
 #include <string>
@@ -18,6 +22,49 @@ namespace
 		using AssetCache::ShouldResetCacheFile;
 		using AssetCache::ShouldWriteCacheFile;
 		using AssetCache::TryDeserializeAssetCachePayload;
+		using AssetCache::Update;
+	};
+
+	class TempDirectory final
+	{
+	public:
+		explicit TempDirectory(const char* label)
+		{
+			static uint64_t counter = 0;
+			m_path = std::filesystem::temp_directory_path() /
+				("sailor-asset-cache-" + std::string(label) + "-" + std::to_string(++counter));
+			std::filesystem::remove_all(m_path);
+			std::filesystem::create_directories(m_path);
+		}
+
+		~TempDirectory()
+		{
+			std::error_code error;
+			std::filesystem::remove_all(m_path, error);
+		}
+
+		std::filesystem::path Path(const std::filesystem::path& relative) const
+		{
+			return m_path / relative;
+		}
+
+	private:
+		std::filesystem::path m_path;
+	};
+
+	class TestAssetInfo final : public AssetInfo
+	{
+	public:
+		void Configure(
+			const FileId& fileId,
+			const std::filesystem::path& sourcePath,
+			const std::filesystem::path& metadataPath)
+		{
+			m_fileId = fileId;
+			m_folder = sourcePath.parent_path().string() + std::filesystem::path::preferred_separator;
+			m_assetFilename = sourcePath.filename().string();
+			m_metaFilepath = metadataPath.string();
+		}
 	};
 
 	void Require(bool condition, const std::string& message)
@@ -38,22 +85,38 @@ namespace
 	TestAssetCache::CacheData MakeCache(
 		const std::string& fileIdValue,
 		const std::string& sourcePath,
-		std::time_t timestamp)
+		TestAssetCache::FileTimestamp sourceTimestamp,
+		const std::string& metadataPath,
+		TestAssetCache::FileTimestamp metadataTimestamp)
 	{
 		TestAssetCache::CacheData result;
 		const FileId fileId = MakeFileId(fileIdValue);
 		TestAssetCache::CacheEntry entry;
 		entry.m_fileId = fileId;
 		entry.m_sourcePath = sourcePath;
-		entry.m_assetImportTime = timestamp;
+		entry.m_sourceTimestamp = sourceTimestamp;
+		entry.m_metadataPath = metadataPath;
+		entry.m_metadataTimestamp = metadataTimestamp;
 		result.m_data.Insert(fileId, std::move(entry));
 		return result;
+	}
+
+	void WriteFile(const std::filesystem::path& path, const std::string& content)
+	{
+		std::filesystem::create_directories(path.parent_path());
+		std::ofstream stream(path, std::ios::binary);
+		stream << content;
 	}
 
 	void TestPayloadRoundTrip()
 	{
 		const FileId fileId = MakeFileId("{ASSET-CACHE-ROUNDTRIP}");
-		const auto source = MakeCache(fileId.ToString(), "/workspace/Content/Test.mat", 42);
+		const auto source = MakeCache(
+			fileId.ToString(),
+			"/workspace/Content/Test.mat",
+			42,
+			"/workspace/Content/Test.mat.asset",
+			84);
 		const std::string payload = TestAssetCache::SerializeAssetCachePayload(source);
 
 		TestAssetCache::CacheData loaded;
@@ -64,8 +127,10 @@ namespace
 		Require(loaded.m_data.ContainsKey(fileId), "round-tripped payload should retain its file id");
 		const auto entry = loaded.m_data[fileId];
 		Require(entry.m_fileId == fileId, "round-tripped entry identity should match its map key");
-		Require(entry.m_assetImportTime == 42, "round-tripped timestamp should be preserved");
+		Require(entry.m_sourceTimestamp == 42, "round-tripped source timestamp should be preserved");
 		Require(!entry.m_sourcePath.empty(), "round-tripped source path should be normalized");
+		Require(entry.m_metadataTimestamp == 84, "round-tripped metadata timestamp should be preserved");
+		Require(!entry.m_metadataPath.empty(), "round-tripped metadata path should be normalized");
 	}
 
 	void TestEmptyPayloadRoundTrip()
@@ -84,19 +149,26 @@ namespace
 	void TestCorruptPayloadDoesNotPartiallyPublish()
 	{
 		const FileId retainedId = MakeFileId("{ASSET-CACHE-RETAINED}");
-		auto destination = MakeCache(retainedId.ToString(), "/workspace/Content/Retained.mat", 7);
+		auto destination = MakeCache(
+			retainedId.ToString(),
+			"/workspace/Content/Retained.mat",
+			7,
+			"/workspace/Content/Retained.mat.asset",
+			8);
 
 		const std::string corruptPayload =
 			"assetCache:\n"
 			"  assets:\n"
 			"    '{ASSET-CACHE-CORRUPT}':\n"
 			"      fileId: '{ASSET-CACHE-CORRUPT}'\n"
-			"      assetImportTime: 8\n"
-			"      sourcePath: ''\n";
+			"      sourceTimestamp: 8\n"
+			"      sourcePath: '/workspace/Content/Test.mat'\n"
+			"      metadataTimestamp: 9\n"
+			"      metadataPath: ''\n";
 		std::string diagnostic;
 		Require(
 			!TestAssetCache::TryDeserializeAssetCachePayload(corruptPayload, destination, diagnostic),
-			"empty sourcePath should reject the complete payload");
+			"empty metadataPath should reject the complete payload");
 		Require(!diagnostic.empty(), "corrupt asset payload should return an actionable diagnostic");
 		Require(destination.m_data.Num() == 1 && destination.m_data.ContainsKey(retainedId),
 			"failed payload validation must not partially replace existing state");
@@ -109,8 +181,10 @@ namespace
 			"  assets:\n"
 			"    '{ASSET-CACHE-KEY}':\n"
 			"      fileId: '{ASSET-CACHE-OTHER}'\n"
-			"      assetImportTime: 9\n"
-			"      sourcePath: '/workspace/Content/Test.mat'\n";
+			"      sourceTimestamp: 9\n"
+			"      sourcePath: '/workspace/Content/Test.mat'\n"
+			"      metadataTimestamp: 10\n"
+			"      metadataPath: '/workspace/Content/Test.mat.asset'\n";
 
 		TestAssetCache::CacheData destination;
 		std::string diagnostic;
@@ -126,15 +200,19 @@ namespace
 		TestAssetCache::CacheData destination = MakeCache(
 			"{ASSET-CACHE-PRESERVE-ON-THROW}",
 			"/workspace/Content/Preserved.mat",
-			99);
+			99,
+			"/workspace/Content/Preserved.mat.asset",
+			100);
 
 		const std::string corruptPayload =
 			"assetCache:\n"
 			"  assets:\n"
 			"    '{ASSET-CACHE-THROW}':\n"
 			"      fileId: '{ASSET-CACHE-THROW}'\n"
-			"      assetImportTime: abc\n"
-			"      sourcePath: '/workspace/Content/Test.mat'\n";
+			"      sourceTimestamp: abc\n"
+			"      sourcePath: '/workspace/Content/Test.mat'\n"
+			"      metadataTimestamp: 10\n"
+			"      metadataPath: '/workspace/Content/Test.mat.asset'\n";
 		const YAML::Node node = YAML::Load(corruptPayload)["assetCache"];
 
 		try
@@ -159,8 +237,10 @@ namespace
 		const YAML::Node invalidEntry = YAML::Load(
 			"fileId:\n"
 			"  list: value\n"
-			"assetImportTime: invalid\n"
-			"sourcePath: ''");
+			"sourceTimestamp: invalid\n"
+			"sourcePath: ''\n"
+			"metadataTimestamp: invalid\n"
+			"metadataPath: ''");
 
 		try
 		{
@@ -173,6 +253,118 @@ namespace
 		catch (...)
 		{
 			throw std::runtime_error("Asset cache entry Deserialize should never throw.");
+		}
+	}
+
+	void TestUpdateTracksBothObservationsAndPreservesDirtyState()
+	{
+		TestAssetCache cache;
+		const FileId fileId = MakeFileId("{ASSET-CACHE-UPDATE}");
+		const std::string sourcePath = "/workspace/Content/Test.mat";
+		const std::string metadataPath = sourcePath + ".asset";
+
+		Require(cache.Update(fileId, sourcePath, 100, metadataPath, 200),
+			"a new source/metadata observation should change the cache");
+		Require(cache.IsDirty(), "a new observation should mark the cache dirty");
+		Require(!cache.Update(fileId, sourcePath, 100, metadataPath, 200),
+			"an unchanged source/metadata observation should be a no-op");
+		Require(cache.IsDirty(), "a no-op update must not clear an already dirty cache");
+		Require(cache.Update(fileId, sourcePath, 99, metadataPath, 200),
+			"a backdated source timestamp should change the cache");
+		Require(cache.Update(fileId, sourcePath, 99, metadataPath, 199),
+			"a backdated metadata timestamp should change the cache");
+		Require(cache.Update(fileId, sourcePath + ".moved", 99, metadataPath, 199),
+			"a source path change should change the cache");
+		Require(cache.Update(fileId, sourcePath + ".moved", 99, metadataPath + ".moved", 199),
+			"a metadata path change should change the cache");
+	}
+
+	void TestFilesystemObservationsExpireOnEitherFile()
+	{
+		TempDirectory directory("observations");
+		const std::filesystem::path sourcePath = directory.Path("Content/Test.mat");
+		const std::filesystem::path metadataPath = directory.Path("Content/Test.mat.asset");
+		WriteFile(sourcePath, "source");
+		WriteFile(metadataPath, "metadata");
+
+		using FileDuration = std::filesystem::file_time_type::duration;
+		const auto initialDuration = std::chrono::duration_cast<std::chrono::seconds>(
+			std::filesystem::file_time_type::clock::now().time_since_epoch()) - std::chrono::seconds(10);
+		const std::filesystem::file_time_type initialTime(
+			std::chrono::duration_cast<FileDuration>(initialDuration));
+		std::filesystem::last_write_time(sourcePath, initialTime);
+		std::filesystem::last_write_time(metadataPath, initialTime);
+
+		TestAssetInfo info;
+		info.Configure(MakeFileId("{ASSET-CACHE-FILESYSTEM}"), sourcePath, metadataPath);
+		TestAssetCache cache;
+		Require(cache.Update(&info), "the initial filesystem observation should populate the cache");
+		Require(!cache.IsExpired(&info), "unchanged source and metadata files should remain current");
+
+		const FileDuration subsecondDelta = std::chrono::duration_cast<FileDuration>(
+			std::chrono::milliseconds(100));
+		Require(subsecondDelta.count() != 0,
+			"the filesystem clock should represent sub-second cache observations");
+		std::filesystem::last_write_time(sourcePath, initialTime + subsecondDelta);
+		Require(cache.IsExpired(&info),
+			"a source change within the same second should expire the cache");
+		Require(cache.Update(&info), "the sub-second source timestamp should be recorded");
+		Require(!cache.IsExpired(&info), "the refreshed sub-second observation should be current");
+
+		std::filesystem::last_write_time(sourcePath, initialTime - std::chrono::seconds(1));
+		Require(cache.IsExpired(&info), "a backdated source file should expire the cache");
+		Require(cache.Update(&info), "the changed source timestamp should be recorded");
+		Require(!cache.IsExpired(&info), "the refreshed source observation should be current");
+
+		std::filesystem::last_write_time(metadataPath, initialTime - std::chrono::seconds(2));
+		Require(cache.IsExpired(&info), "a backdated metadata file should expire the cache");
+		Require(cache.Update(&info), "the changed metadata timestamp should be recorded");
+		Require(!cache.IsExpired(&info), "the refreshed metadata observation should be current");
+
+		std::filesystem::remove(metadataPath);
+		Require(cache.IsExpired(&info), "a missing metadata file should always expire the cache");
+		Require(!cache.Update(&info), "a missing file must not establish a clean cache observation");
+		Require(cache.IsExpired(&info), "the cache must remain expired while metadata is missing");
+	}
+
+	void TestMetadataFieldsAreStrictAndTransactional()
+	{
+		const FileId retainedId = MakeFileId("{ASSET-CACHE-STRICT-RETAINED}");
+		const std::string prefix =
+			"assetCache:\n"
+			"  assets:\n"
+			"    '{ASSET-CACHE-STRICT}':\n"
+			"      fileId: '{ASSET-CACHE-STRICT}'\n"
+			"      sourceTimestamp: 1\n"
+			"      sourcePath: '/workspace/Content/Test.mat'\n";
+		const std::string invalidPayloads[] =
+		{
+			prefix + "      metadataTimestamp: 2\n",
+			prefix +
+				"      metadataTimestamp: 2\n"
+				"      metadataPath: '/workspace/Content/Test.mat.asset'\n"
+				"      metadataPath: '/workspace/Content/Duplicate.asset'\n",
+			prefix +
+				"      metadataTimestamp:\n"
+				"        - 2\n"
+				"      metadataPath:\n"
+				"        nested: value\n"
+		};
+
+		for (const std::string& payload : invalidPayloads)
+		{
+			auto destination = MakeCache(
+				retainedId.ToString(),
+				"/workspace/Content/Retained.mat",
+				7,
+				"/workspace/Content/Retained.mat.asset",
+				8);
+			std::string diagnostic;
+			Require(!TestAssetCache::TryDeserializeAssetCachePayload(payload, destination, diagnostic),
+				"missing, duplicate, or non-scalar metadata fields should reject the payload");
+			Require(!diagnostic.empty(), "strict metadata validation should return a diagnostic");
+			Require(destination.m_data.Num() == 1 && destination.m_data.ContainsKey(retainedId),
+				"strict metadata validation failures must not partially publish state");
 		}
 	}
 
@@ -212,6 +404,9 @@ int main()
 		TestMismatchedEntryIdentityIsCorrupt();
 		TestDirectDeserializeDoesNotThrowOnCorruptData();
 		TestEntryDeserializeDoesNotThrow();
+		TestUpdateTracksBothObservationsAndPreservesDirtyState();
+		TestFilesystemObservationsExpireOnEitherFile();
+		TestMetadataFieldsAreStrictAndTransactional();
 		TestIoFailurePreservesTheExistingCacheFile();
 		std::cout << "Asset cache contract tests passed.\n";
 		return 0;

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -2,11 +2,14 @@
 #include "AssetRegistry/AssetInfo.h"
 
 #include <chrono>
+#include <ctime>
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <stdexcept>
 #include <string>
+#include <vector>
 #include <yaml-cpp/yaml.h>
 
 namespace
@@ -23,6 +26,7 @@ namespace
 		using AssetCache::ShouldWriteCacheFile;
 		using AssetCache::TryDeserializeAssetCachePayload;
 		using AssetCache::Update;
+		using AssetCache::Prune;
 	};
 
 	class TempDirectory final
@@ -61,9 +65,107 @@ namespace
 			const std::filesystem::path& metadataPath)
 		{
 			m_fileId = fileId;
-			m_folder = sourcePath.parent_path().string() + std::filesystem::path::preferred_separator;
+			m_folder = sourcePath.parent_path().generic_string() + '/';
 			m_assetFilename = sourcePath.filename().string();
 			m_metaFilepath = metadataPath.string();
+		}
+
+		void SetProcessingTimes(std::time_t assetImportTime, std::time_t metadataLoadTime)
+		{
+			m_assetImportTime = assetImportTime;
+			m_metaLoadTime = metadataLoadTime;
+		}
+
+		void SetPendingUpdate(bool bWasExpired)
+		{
+			m_bPendingUpdateNotification = true;
+			m_bPendingWasExpired = bWasExpired;
+		}
+
+		void SaveMetaFile() override
+		{
+			++m_numMetaSaves;
+		}
+
+		YAML::Node Serialize() const override
+		{
+			YAML::Node result(YAML::NodeType::Map);
+			result["fileId"] = m_fileId;
+			result["testValue"] = m_testValue;
+			result["lateValue"] = 1;
+			return result;
+		}
+
+		void Deserialize(const YAML::Node& inData) override
+		{
+			m_fileId = inData["fileId"].as<FileId>();
+			m_testValue = inData["testValue"].as<int32_t>();
+			(void)inData["lateValue"].as<int32_t>();
+			std::function<void()> onDeserialize = std::move(m_onDeserialize);
+			if (onDeserialize)
+			{
+				onDeserialize();
+			}
+		}
+
+		uint32_t m_numMetaSaves = 0;
+		int32_t m_testValue = 0;
+		std::function<void()> m_onDeserialize;
+	};
+
+	class RecordingAssetListener final : public IAssetInfoHandlerListener
+	{
+	public:
+		void OnUpdateAssetInfo(AssetInfoPtr, bool bWasExpired) override
+		{
+			m_events.emplace_back(bWasExpired ? "update:true" : "update:false");
+		}
+
+		void OnImportAsset(AssetInfoPtr) override
+		{
+			m_events.emplace_back("import");
+		}
+
+		std::vector<std::string> m_events;
+	};
+
+	class TestAssetInfoHandler final : public IAssetInfoHandler
+	{
+	public:
+		void GetDefaultMeta(YAML::Node& outDefaultYaml) const override
+		{
+			outDefaultYaml = YAML::Node(YAML::NodeType::Map);
+		}
+
+		AssetInfoPtr LoadAssetInfo(
+			const std::string& metaFilepath,
+			const std::string&,
+			EAssetMountKind,
+			bool,
+			bool,
+			bool) const override
+		{
+			auto* info = new TestAssetInfo();
+			const std::filesystem::path metadataPath(metaFilepath);
+			std::filesystem::path sourcePath(metaFilepath);
+			sourcePath.replace_extension();
+			info->Configure(MakeTestFileId(), sourcePath, metadataPath);
+			info->SetPendingUpdate(true);
+			return info;
+		}
+
+	protected:
+		AssetInfoPtr CreateAssetInfo() const override
+		{
+			return new TestAssetInfo();
+		}
+
+	private:
+		static FileId MakeTestFileId()
+		{
+			FileId result;
+			result.Deserialize(YAML::Node("{ASSET-CACHE-IMPORT-CONTRACT}"));
+			return result;
 		}
 	};
 
@@ -85,18 +187,18 @@ namespace
 	TestAssetCache::CacheData MakeCache(
 		const std::string& fileIdValue,
 		const std::string& sourcePath,
-		TestAssetCache::FileTimestamp sourceTimestamp,
+		std::time_t assetImportTime,
 		const std::string& metadataPath,
-		TestAssetCache::FileTimestamp metadataTimestamp)
+		std::time_t metadataLoadTime)
 	{
 		TestAssetCache::CacheData result;
 		const FileId fileId = MakeFileId(fileIdValue);
 		TestAssetCache::CacheEntry entry;
 		entry.m_fileId = fileId;
+		entry.m_assetImportTime = assetImportTime;
 		entry.m_sourcePath = sourcePath;
-		entry.m_sourceTimestamp = sourceTimestamp;
 		entry.m_metadataPath = metadataPath;
-		entry.m_metadataTimestamp = metadataTimestamp;
+		entry.m_metadataLoadTime = metadataLoadTime;
 		result.m_data.Insert(fileId, std::move(entry));
 		return result;
 	}
@@ -114,9 +216,9 @@ namespace
 		const auto source = MakeCache(
 			fileId.ToString(),
 			"/workspace/Content/Test.mat",
-			42,
+			40,
 			"/workspace/Content/Test.mat.asset",
-			84);
+			80);
 		const std::string payload = TestAssetCache::SerializeAssetCachePayload(source);
 
 		TestAssetCache::CacheData loaded;
@@ -127,9 +229,9 @@ namespace
 		Require(loaded.m_data.ContainsKey(fileId), "round-tripped payload should retain its file id");
 		const auto entry = loaded.m_data[fileId];
 		Require(entry.m_fileId == fileId, "round-tripped entry identity should match its map key");
-		Require(entry.m_sourceTimestamp == 42, "round-tripped source timestamp should be preserved");
+		Require(entry.m_assetImportTime == 40, "round-tripped asset import time should be preserved");
 		Require(!entry.m_sourcePath.empty(), "round-tripped source path should be normalized");
-		Require(entry.m_metadataTimestamp == 84, "round-tripped metadata timestamp should be preserved");
+		Require(entry.m_metadataLoadTime == 80, "round-tripped metadata load time should be preserved");
 		Require(!entry.m_metadataPath.empty(), "round-tripped metadata path should be normalized");
 	}
 
@@ -152,18 +254,18 @@ namespace
 		auto destination = MakeCache(
 			retainedId.ToString(),
 			"/workspace/Content/Retained.mat",
-			7,
+			6,
 			"/workspace/Content/Retained.mat.asset",
-			8);
+			7);
 
 		const std::string corruptPayload =
 			"assetCache:\n"
 			"  assets:\n"
 			"    '{ASSET-CACHE-CORRUPT}':\n"
 			"      fileId: '{ASSET-CACHE-CORRUPT}'\n"
-			"      sourceTimestamp: 8\n"
+			"      assetImportTime: 7\n"
 			"      sourcePath: '/workspace/Content/Test.mat'\n"
-			"      metadataTimestamp: 9\n"
+			"      metadataLoadTime: 8\n"
 			"      metadataPath: ''\n";
 		std::string diagnostic;
 		Require(
@@ -181,9 +283,9 @@ namespace
 			"  assets:\n"
 			"    '{ASSET-CACHE-KEY}':\n"
 			"      fileId: '{ASSET-CACHE-OTHER}'\n"
-			"      sourceTimestamp: 9\n"
+			"      assetImportTime: 8\n"
 			"      sourcePath: '/workspace/Content/Test.mat'\n"
-			"      metadataTimestamp: 10\n"
+			"      metadataLoadTime: 9\n"
 			"      metadataPath: '/workspace/Content/Test.mat.asset'\n";
 
 		TestAssetCache::CacheData destination;
@@ -200,18 +302,18 @@ namespace
 		TestAssetCache::CacheData destination = MakeCache(
 			"{ASSET-CACHE-PRESERVE-ON-THROW}",
 			"/workspace/Content/Preserved.mat",
-			99,
+			98,
 			"/workspace/Content/Preserved.mat.asset",
-			100);
+			99);
 
 		const std::string corruptPayload =
 			"assetCache:\n"
 			"  assets:\n"
 			"    '{ASSET-CACHE-THROW}':\n"
 			"      fileId: '{ASSET-CACHE-THROW}'\n"
-			"      sourceTimestamp: abc\n"
+			"      assetImportTime: abc\n"
 			"      sourcePath: '/workspace/Content/Test.mat'\n"
-			"      metadataTimestamp: 10\n"
+			"      metadataLoadTime: 9\n"
 			"      metadataPath: '/workspace/Content/Test.mat.asset'\n";
 		const YAML::Node node = YAML::Load(corruptPayload)["assetCache"];
 
@@ -237,9 +339,9 @@ namespace
 		const YAML::Node invalidEntry = YAML::Load(
 			"fileId:\n"
 			"  list: value\n"
-			"sourceTimestamp: invalid\n"
+			"assetImportTime: invalid\n"
 			"sourcePath: ''\n"
-			"metadataTimestamp: invalid\n"
+			"metadataLoadTime: invalid\n"
 			"metadataPath: ''");
 
 		try
@@ -256,74 +358,275 @@ namespace
 		}
 	}
 
-	void TestUpdateTracksBothObservationsAndPreservesDirtyState()
+	void TestImportAndUpdateCallbackContract()
+	{
+		TempDirectory directory("callback-contract");
+		const std::filesystem::path sourcePath = directory.Path("Content/New.shader");
+		WriteFile(sourcePath, "stages: []");
+
+		TestAssetInfoHandler handler;
+		RecordingAssetListener listener;
+		handler.Subscribe(&listener);
+		AssetInfoPtr imported = handler.ImportAsset(sourcePath.string(), {}, true, false);
+		Require(imported != nullptr, "a new raw asset should be imported");
+		Require(listener.m_events == std::vector<std::string>({ "update:false", "import" }),
+			"a new raw asset must dispatch Update(false) followed by exactly one Import callback");
+		Require(static_cast<TestAssetInfo*>(imported)->m_numMetaSaves == 1,
+			"the import callback should finalize metadata exactly once");
+		delete imported;
+
+		listener.m_events.clear();
+		TestAssetInfo changed;
+		changed.SetPendingUpdate(true);
+		handler.NotifyUpdateAssetInfo(&changed);
+		Require(listener.m_events == std::vector<std::string>({ "update:true" }),
+			"an existing raw or metadata change must dispatch Update(true) without Import");
+	}
+
+	void TestImportNeverOverwritesExistingMetadata()
+	{
+		TempDirectory directory("import-preserves-metadata");
+		const std::filesystem::path sourcePath = directory.Path("Content/New.shader");
+		const std::filesystem::path metadataPath = directory.Path("Content/New.shader.asset");
+		WriteFile(sourcePath, "stages: []");
+		const std::string userMetadata =
+			"fileId: '{USER-CREATED-METADATA}'\n"
+			"filename: New.shader\n";
+		WriteFile(metadataPath, userMetadata);
+
+		TestAssetInfoHandler handler;
+		RecordingAssetListener listener;
+		handler.Subscribe(&listener);
+		AssetInfoPtr imported = handler.ImportAsset(sourcePath.string(), {}, true, false);
+		Require(imported == nullptr,
+			"import must fail when a metadata sidecar already exists");
+		std::ifstream metadataFile(metadataPath);
+		const std::string preserved(
+			(std::istreambuf_iterator<char>(metadataFile)),
+			std::istreambuf_iterator<char>());
+		Require(preserved == userMetadata,
+			"import must never truncate or replace a user-created metadata sidecar");
+		Require(listener.m_events.empty(),
+			"a rejected import must not notify asset listeners");
+
+		std::filesystem::remove(metadataPath);
+		imported = handler.ImportAsset(sourcePath.string(), {}, false, false);
+		Require(imported != nullptr,
+			"a missing metadata sidecar should still be created exclusively");
+		WriteFile(metadataPath, userMetadata);
+		Require(!handler.DiscardImportedMetadataIfUnchanged(imported),
+			"rollback must not delete metadata edited after exclusive creation");
+		Require(std::filesystem::is_regular_file(metadataPath),
+			"concurrently edited metadata must remain on disk");
+		delete imported;
+
+		std::filesystem::remove(metadataPath);
+		imported = handler.ImportAsset(sourcePath.string(), {}, false, false);
+		Require(imported != nullptr && handler.DiscardImportedMetadataIfUnchanged(imported),
+			"rollback should remove an unchanged sidecar created by this import");
+		Require(!std::filesystem::exists(metadataPath),
+			"discarded generated metadata should be absent for the next import attempt");
+		delete imported;
+	}
+
+	void TestRejectedReloadRestoresTheLiveAsset()
+	{
+		TempDirectory directory("reload-rollback");
+		const std::filesystem::path sourcePath = directory.Path("Content/Existing.raw");
+		const std::filesystem::path metadataPath = directory.Path("Content/Existing.raw.asset");
+		WriteFile(sourcePath, "source");
+		WriteFile(
+			metadataPath,
+			"fileId: '{ASSET-CACHE-RELOAD-ROLLBACK}'\n"
+			"testValue: 99\n"
+			"lateValue: invalid\n");
+
+		TestAssetInfo info;
+		const FileId fileId = MakeFileId("{ASSET-CACHE-RELOAD-ROLLBACK}");
+		info.Configure(fileId, sourcePath, metadataPath);
+		info.SetProcessingTimes(
+			info.GetAssetLastModificationTime(),
+			info.GetMetaLastModificationTime());
+		info.m_testValue = 7;
+
+		TestAssetInfoHandler handler;
+		RecordingAssetListener listener;
+		handler.Subscribe(&listener);
+		Require(!handler.ReloadAssetInfo(&info, true, false),
+			"a partially invalid metadata reload should be rejected");
+		Require(info.GetFileId() == fileId && info.m_testValue == 7,
+			"a rejected metadata reload must restore the previous live object state");
+		Require(listener.m_events.empty(),
+			"a rejected metadata reload must not notify importers");
+	}
+
+	void TestRawEditDispatchesExpiredUpdateWithoutImport()
+	{
+		TempDirectory directory("raw-expired-callback");
+		const std::filesystem::path sourcePath = directory.Path("Content/Existing.raw");
+		const std::filesystem::path metadataPath = directory.Path("Content/Existing.raw.asset");
+		WriteFile(sourcePath, "source-v1");
+		WriteFile(
+			metadataPath,
+			"fileId: '{ASSET-CACHE-RAW-EXPIRED}'\n"
+			"testValue: 7\n"
+			"lateValue: 1\n");
+
+		const std::filesystem::file_time_type initialSourceTime =
+			std::filesystem::file_time_type::clock::now() - std::chrono::seconds(20);
+		std::filesystem::last_write_time(sourcePath, initialSourceTime);
+		TestAssetInfo info;
+		info.Configure(MakeFileId("{ASSET-CACHE-RAW-EXPIRED}"), sourcePath, metadataPath);
+		info.SetProcessingTimes(
+			info.GetAssetLastModificationTime(),
+			info.GetMetaLastModificationTime());
+		std::filesystem::last_write_time(
+			sourcePath,
+			initialSourceTime + std::chrono::seconds(2));
+		Require(info.IsAssetExpired(),
+			"a newer raw file should be expired before metadata reload");
+
+		TestAssetInfoHandler handler;
+		RecordingAssetListener listener;
+		handler.Subscribe(&listener);
+		Require(handler.ReloadAssetInfo(&info, true, false),
+			"an existing asset with a changed raw file should reload its metadata");
+		Require(listener.m_events == std::vector<std::string>({ "update:true" }),
+			"a raw edit must dispatch exactly Update(true) and never Import");
+		Require(!info.IsAssetExpired(),
+			"a successfully dispatched raw edit should advance the in-memory processing watermark");
+	}
+
+	void TestConcurrentMetadataEditDoesNotAdvanceTheWatermark()
+	{
+		TempDirectory directory("reload-concurrent-edit");
+		const std::filesystem::path sourcePath = directory.Path("Content/Existing.raw");
+		const std::filesystem::path metadataPath = directory.Path("Content/Existing.raw.asset");
+		WriteFile(sourcePath, "source");
+		WriteFile(
+			metadataPath,
+			"fileId: '{ASSET-CACHE-RELOAD-CONCURRENT}'\n"
+			"testValue: 99\n"
+			"lateValue: 1\n");
+
+		TestAssetInfo info;
+		const FileId fileId = MakeFileId("{ASSET-CACHE-RELOAD-CONCURRENT}");
+		info.Configure(fileId, sourcePath, metadataPath);
+		info.SetProcessingTimes(
+			info.GetAssetLastModificationTime(),
+			info.GetMetaLastModificationTime());
+		info.m_testValue = 7;
+		const std::filesystem::file_time_type initialMetaTime =
+			std::filesystem::last_write_time(metadataPath);
+		info.m_onDeserialize = [&]()
+		{
+			std::filesystem::last_write_time(
+				metadataPath,
+				initialMetaTime + std::chrono::seconds(2));
+		};
+
+		TestAssetInfoHandler handler;
+		RecordingAssetListener listener;
+		handler.Subscribe(&listener);
+		Require(!handler.ReloadAssetInfo(&info, true, false),
+			"metadata modified during deserialization should reject the reload");
+		Require(info.GetFileId() == fileId && info.m_testValue == 7,
+			"a concurrent metadata edit must restore the previous live state");
+		Require(info.IsMetaExpired(),
+			"the concurrently edited metadata must remain expired for the next reload");
+		Require(listener.m_events.empty(),
+			"a concurrent metadata edit must not notify importers or advance processing watermarks");
+	}
+
+	void TestUpdateTracksProcessingWatermarksAndPreservesDirtyState()
 	{
 		TestAssetCache cache;
 		const FileId fileId = MakeFileId("{ASSET-CACHE-UPDATE}");
 		const std::string sourcePath = "/workspace/Content/Test.mat";
 		const std::string metadataPath = sourcePath + ".asset";
 
-		Require(cache.Update(fileId, sourcePath, 100, metadataPath, 200),
-			"a new source/metadata observation should change the cache");
-		Require(cache.IsDirty(), "a new observation should mark the cache dirty");
-		Require(!cache.Update(fileId, sourcePath, 100, metadataPath, 200),
-			"an unchanged source/metadata observation should be a no-op");
+		Require(cache.Update(fileId, 90, sourcePath, 190, metadataPath),
+			"new processing watermarks should change the cache");
+		Require(cache.IsDirty(), "new processing watermarks should mark the cache dirty");
+		Require(!cache.Update(fileId, 90, sourcePath, 190, metadataPath),
+			"unchanged processing watermarks should be a no-op");
 		Require(cache.IsDirty(), "a no-op update must not clear an already dirty cache");
-		Require(cache.Update(fileId, sourcePath, 99, metadataPath, 200),
-			"a backdated source timestamp should change the cache");
-		Require(cache.Update(fileId, sourcePath, 99, metadataPath, 199),
-			"a backdated metadata timestamp should change the cache");
-		Require(cache.Update(fileId, sourcePath + ".moved", 99, metadataPath, 199),
+		Require(cache.Update(fileId, 91, sourcePath, 190, metadataPath),
+			"a later successful asset import should change the source watermark");
+		Require(cache.Update(fileId, 91, sourcePath, 191, metadataPath),
+			"a later metadata load should change the metadata watermark");
+		Require(cache.Update(fileId, 91, sourcePath + ".moved", 191, metadataPath),
 			"a source path change should change the cache");
-		Require(cache.Update(fileId, sourcePath + ".moved", 99, metadataPath + ".moved", 199),
+		Require(cache.Update(fileId, 91, sourcePath + ".moved", 191, metadataPath + ".moved"),
 			"a metadata path change should change the cache");
 	}
 
-	void TestFilesystemObservationsExpireOnEitherFile()
+	void TestPruneRemovesOnlyStaleEntries()
 	{
-		TempDirectory directory("observations");
+		TestAssetCache cache;
+		const FileId liveId = MakeFileId("{ASSET-CACHE-PRUNE-LIVE}");
+		const FileId staleId = MakeFileId("{ASSET-CACHE-PRUNE-STALE}");
+		Require(cache.Update(liveId, 10, "/workspace/Content/Live.raw", 11,
+			"/workspace/Content/Live.raw.asset"),
+			"the live cache entry should be inserted");
+		Require(cache.Update(staleId, 20, "/workspace/Content/Stale.raw", 21,
+			"/workspace/Content/Stale.raw.asset"),
+			"the stale cache entry should be inserted");
+
+		TSet<FileId> liveAssetIds;
+		liveAssetIds.Insert(liveId);
+		Require(cache.Prune(liveAssetIds),
+			"pruning should report removal of a stale cache entry");
+		Require(cache.Contains(liveId) && !cache.Contains(staleId),
+			"pruning should retain only ids in the committed registry generation");
+		Require(!cache.Prune(liveAssetIds),
+			"pruning an already current cache should be a no-op");
+	}
+
+	void TestProcessingWatermarksExpireOnNewerFiles()
+	{
+		TempDirectory directory("watermarks");
 		const std::filesystem::path sourcePath = directory.Path("Content/Test.mat");
 		const std::filesystem::path metadataPath = directory.Path("Content/Test.mat.asset");
 		WriteFile(sourcePath, "source");
 		WriteFile(metadataPath, "metadata");
 
-		using FileDuration = std::filesystem::file_time_type::duration;
-		const auto initialDuration = std::chrono::duration_cast<std::chrono::seconds>(
-			std::filesystem::file_time_type::clock::now().time_since_epoch()) - std::chrono::seconds(10);
-		const std::filesystem::file_time_type initialTime(
-			std::chrono::duration_cast<FileDuration>(initialDuration));
+		const auto initialTime = std::filesystem::file_time_type::clock::now() - std::chrono::seconds(20);
 		std::filesystem::last_write_time(sourcePath, initialTime);
 		std::filesystem::last_write_time(metadataPath, initialTime);
 
 		TestAssetInfo info;
 		info.Configure(MakeFileId("{ASSET-CACHE-FILESYSTEM}"), sourcePath, metadataPath);
+		info.SetProcessingTimes(
+			info.GetAssetLastModificationTime(),
+			info.GetMetaLastModificationTime());
 		TestAssetCache cache;
-		Require(cache.Update(&info), "the initial filesystem observation should populate the cache");
-		Require(!cache.IsExpired(&info), "unchanged source and metadata files should remain current");
+		Require(cache.Update(&info), "the initial processing watermarks should populate the cache");
+		Require(!cache.IsExpired(&info), "processed source and metadata files should remain current");
 
-		const FileDuration subsecondDelta = std::chrono::duration_cast<FileDuration>(
-			std::chrono::milliseconds(100));
-		Require(subsecondDelta.count() != 0,
-			"the filesystem clock should represent sub-second cache observations");
-		std::filesystem::last_write_time(sourcePath, initialTime + subsecondDelta);
-		Require(cache.IsExpired(&info),
-			"a source change within the same second should expire the cache");
-		Require(cache.Update(&info), "the sub-second source timestamp should be recorded");
-		Require(!cache.IsExpired(&info), "the refreshed sub-second observation should be current");
+		std::filesystem::last_write_time(sourcePath, initialTime + std::chrono::seconds(2));
+		Require(cache.IsExpired(&info), "a newer source file should expire the cache");
+		info.SetProcessingTimes(
+			info.GetAssetLastModificationTime(),
+			info.GetMetaLastModificationTime());
+		Require(cache.Update(&info), "the imported source watermark should advance");
+		Require(!cache.IsExpired(&info), "the processed source version should become current");
 
-		std::filesystem::last_write_time(sourcePath, initialTime - std::chrono::seconds(1));
-		Require(cache.IsExpired(&info), "a backdated source file should expire the cache");
-		Require(cache.Update(&info), "the changed source timestamp should be recorded");
-		Require(!cache.IsExpired(&info), "the refreshed source observation should be current");
+		std::filesystem::last_write_time(sourcePath, initialTime - std::chrono::seconds(2));
+		Require(!cache.IsExpired(&info),
+			"a backdated source should not invalidate an already newer processing watermark");
 
-		std::filesystem::last_write_time(metadataPath, initialTime - std::chrono::seconds(2));
-		Require(cache.IsExpired(&info), "a backdated metadata file should expire the cache");
-		Require(cache.Update(&info), "the changed metadata timestamp should be recorded");
-		Require(!cache.IsExpired(&info), "the refreshed metadata observation should be current");
+		std::filesystem::last_write_time(metadataPath, initialTime + std::chrono::seconds(4));
+		Require(cache.IsExpired(&info), "a newer metadata file should expire the cache");
+		info.SetProcessingTimes(
+			info.GetAssetLastModificationTime(),
+			info.GetMetaLastModificationTime());
+		Require(cache.Update(&info), "the metadata load watermark should advance");
+		Require(!cache.IsExpired(&info), "the processed metadata version should become current");
 
 		std::filesystem::remove(metadataPath);
 		Require(cache.IsExpired(&info), "a missing metadata file should always expire the cache");
-		Require(!cache.Update(&info), "a missing file must not establish a clean cache observation");
+		Require(!cache.Update(&info), "a missing file must not establish clean processing watermarks");
 		Require(cache.IsExpired(&info), "the cache must remain expired while metadata is missing");
 	}
 
@@ -335,20 +638,21 @@ namespace
 			"  assets:\n"
 			"    '{ASSET-CACHE-STRICT}':\n"
 			"      fileId: '{ASSET-CACHE-STRICT}'\n"
-			"      sourceTimestamp: 1\n"
-			"      sourcePath: '/workspace/Content/Test.mat'\n";
+			"      assetImportTime: 1\n"
+			"      sourcePath: '/workspace/Content/Test.mat'\n"
+			"      metadataLoadTime: 2\n";
 		const std::string invalidPayloads[] =
 		{
-			prefix + "      metadataTimestamp: 2\n",
+			prefix,
 			prefix +
-				"      metadataTimestamp: 2\n"
 				"      metadataPath: '/workspace/Content/Test.mat.asset'\n"
 				"      metadataPath: '/workspace/Content/Duplicate.asset'\n",
 			prefix +
-				"      metadataTimestamp:\n"
-				"        - 2\n"
 				"      metadataPath:\n"
-				"        nested: value\n"
+				"        nested: value\n",
+			prefix +
+				"      metadataPath: '/workspace/Content/Test.mat.asset'\n"
+				"      unexpectedField: 3\n"
 		};
 
 		for (const std::string& payload : invalidPayloads)
@@ -356,9 +660,9 @@ namespace
 			auto destination = MakeCache(
 				retainedId.ToString(),
 				"/workspace/Content/Retained.mat",
-				7,
+				6,
 				"/workspace/Content/Retained.mat.asset",
-				8);
+				7);
 			std::string diagnostic;
 			Require(!TestAssetCache::TryDeserializeAssetCachePayload(payload, destination, diagnostic),
 				"missing, duplicate, or non-scalar metadata fields should reject the payload");
@@ -404,8 +708,14 @@ int main()
 		TestMismatchedEntryIdentityIsCorrupt();
 		TestDirectDeserializeDoesNotThrowOnCorruptData();
 		TestEntryDeserializeDoesNotThrow();
-		TestUpdateTracksBothObservationsAndPreservesDirtyState();
-		TestFilesystemObservationsExpireOnEitherFile();
+		TestImportAndUpdateCallbackContract();
+		TestImportNeverOverwritesExistingMetadata();
+		TestRejectedReloadRestoresTheLiveAsset();
+		TestRawEditDispatchesExpiredUpdateWithoutImport();
+		TestConcurrentMetadataEditDoesNotAdvanceTheWatermark();
+		TestUpdateTracksProcessingWatermarksAndPreservesDirtyState();
+		TestPruneRemovesOnlyStaleEntries();
+		TestProcessingWatermarksExpireOnNewerFiles();
 		TestMetadataFieldsAreStrictAndTransactional();
 		TestIoFailurePreservesTheExistingCacheFile();
 		std::cout << "Asset cache contract tests passed.\n";

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -408,6 +408,7 @@ namespace
 		const std::string preserved(
 			(std::istreambuf_iterator<char>(metadataFile)),
 			std::istreambuf_iterator<char>());
+		metadataFile.close();
 		Require(preserved == userMetadata,
 			"import must never truncate or replace a user-created metadata sidecar");
 		Require(listener.m_events.empty(),

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -22,10 +22,12 @@ namespace
 		using CacheData = AssetCacheData;
 		using CacheEntry = AssetCacheData::Entry;
 		using AssetCache::SerializeAssetCachePayload;
+		using AssetCache::Prune;
 		using AssetCache::ShouldResetCacheFile;
 		using AssetCache::ShouldWriteCacheFile;
 		using AssetCache::TryDeserializeAssetCachePayload;
 		using AssetCache::Update;
+		using AssetCache::RestoreAssetImportTime;
 	};
 
 	class TempDirectory final
@@ -73,6 +75,11 @@ namespace
 		{
 			m_assetImportTime = assetImportTime;
 			m_metaLoadTime = metadataLoadTime;
+		}
+
+		std::time_t GetRuntimeMetadataLoadTime() const
+		{
+			return m_metaLoadTime;
 		}
 
 		void SetPendingUpdate(bool bWasExpired)
@@ -191,9 +198,7 @@ namespace
 	TestAssetCache::CacheData MakeCache(
 		const std::string& fileIdValue,
 		const std::string& sourcePath,
-		std::time_t assetImportTime,
-		const std::string& metadataPath,
-		std::time_t metadataLoadTime)
+		std::time_t assetImportTime)
 	{
 		TestAssetCache::CacheData result;
 		const FileId fileId = MakeFileId(fileIdValue);
@@ -201,8 +206,6 @@ namespace
 		entry.m_fileId = fileId;
 		entry.m_assetImportTime = assetImportTime;
 		entry.m_sourcePath = sourcePath;
-		entry.m_metadataPath = metadataPath;
-		entry.m_metadataLoadTime = metadataLoadTime;
 		result.m_data.Insert(fileId, std::move(entry));
 		return result;
 	}
@@ -220,10 +223,14 @@ namespace
 		const auto source = MakeCache(
 			fileId.ToString(),
 			"/workspace/Content/Test.mat",
-			40,
-			"/workspace/Content/Test.mat.asset",
-			80);
+			40);
 		const std::string payload = TestAssetCache::SerializeAssetCachePayload(source);
+		const YAML::Node serializedEntry = YAML::Load(payload)["assetCache"]["assets"][fileId.ToString()];
+		Require(serializedEntry.IsMap() && serializedEntry.size() == 3,
+			"persisted asset cache entries must contain exactly three fields");
+		Require(payload.find("metadataLoadTime") == std::string::npos &&
+			payload.find("metadataPath") == std::string::npos,
+			"runtime metadata state must never be serialized into the asset cache");
 
 		TestAssetCache::CacheData loaded;
 		std::string diagnostic;
@@ -235,8 +242,6 @@ namespace
 		Require(entry.m_fileId == fileId, "round-tripped entry identity should match its map key");
 		Require(entry.m_assetImportTime == 40, "round-tripped asset import time should be preserved");
 		Require(!entry.m_sourcePath.empty(), "round-tripped source path should be normalized");
-		Require(entry.m_metadataLoadTime == 80, "round-tripped metadata load time should be preserved");
-		Require(!entry.m_metadataPath.empty(), "round-tripped metadata path should be normalized");
 	}
 
 	void TestEmptyPayloadRoundTrip()
@@ -258,9 +263,7 @@ namespace
 		auto destination = MakeCache(
 			retainedId.ToString(),
 			"/workspace/Content/Retained.mat",
-			6,
-			"/workspace/Content/Retained.mat.asset",
-			7);
+			6);
 
 		const std::string corruptPayload =
 			"assetCache:\n"
@@ -268,13 +271,11 @@ namespace
 			"    '{ASSET-CACHE-CORRUPT}':\n"
 			"      fileId: '{ASSET-CACHE-CORRUPT}'\n"
 			"      assetImportTime: 7\n"
-			"      sourcePath: '/workspace/Content/Test.mat'\n"
-			"      metadataLoadTime: 8\n"
-			"      metadataPath: ''\n";
+			"      sourcePath: ''\n";
 		std::string diagnostic;
 		Require(
 			!TestAssetCache::TryDeserializeAssetCachePayload(corruptPayload, destination, diagnostic),
-			"empty metadataPath should reject the complete payload");
+			"empty sourcePath should reject the complete payload");
 		Require(!diagnostic.empty(), "corrupt asset payload should return an actionable diagnostic");
 		Require(destination.m_data.Num() == 1 && destination.m_data.ContainsKey(retainedId),
 			"failed payload validation must not partially replace existing state");
@@ -288,9 +289,7 @@ namespace
 			"    '{ASSET-CACHE-KEY}':\n"
 			"      fileId: '{ASSET-CACHE-OTHER}'\n"
 			"      assetImportTime: 8\n"
-			"      sourcePath: '/workspace/Content/Test.mat'\n"
-			"      metadataLoadTime: 9\n"
-			"      metadataPath: '/workspace/Content/Test.mat.asset'\n";
+			"      sourcePath: '/workspace/Content/Test.mat'\n";
 
 		TestAssetCache::CacheData destination;
 		std::string diagnostic;
@@ -306,9 +305,7 @@ namespace
 		TestAssetCache::CacheData destination = MakeCache(
 			"{ASSET-CACHE-PRESERVE-ON-THROW}",
 			"/workspace/Content/Preserved.mat",
-			98,
-			"/workspace/Content/Preserved.mat.asset",
-			99);
+			98);
 
 		const std::string corruptPayload =
 			"assetCache:\n"
@@ -316,9 +313,7 @@ namespace
 			"    '{ASSET-CACHE-THROW}':\n"
 			"      fileId: '{ASSET-CACHE-THROW}'\n"
 			"      assetImportTime: abc\n"
-			"      sourcePath: '/workspace/Content/Test.mat'\n"
-			"      metadataLoadTime: 9\n"
-			"      metadataPath: '/workspace/Content/Test.mat.asset'\n";
+			"      sourcePath: '/workspace/Content/Test.mat'\n";
 		const YAML::Node node = YAML::Load(corruptPayload)["assetCache"];
 
 		try
@@ -344,9 +339,7 @@ namespace
 			"fileId:\n"
 			"  list: value\n"
 			"assetImportTime: invalid\n"
-			"sourcePath: ''\n"
-			"metadataLoadTime: invalid\n"
-			"metadataPath: ''");
+			"sourcePath: ''");
 
 		try
 		{
@@ -599,32 +592,69 @@ namespace
 			"a concurrent metadata edit must not notify importers or advance processing watermarks");
 	}
 
-	void TestUpdateTracksProcessingWatermarksAndPreservesDirtyState()
+	void TestUpdateTracksAssetImportStateAndPreservesDirtyState()
 	{
 		TestAssetCache cache;
 		const FileId fileId = MakeFileId("{ASSET-CACHE-UPDATE}");
 		const std::string sourcePath = "/workspace/Content/Test.mat";
-		const std::string metadataPath = sourcePath + ".asset";
 
-		Require(cache.Update(fileId, 90, sourcePath, 190, metadataPath),
-			"new processing watermarks should change the cache");
-		Require(cache.IsDirty(), "new processing watermarks should mark the cache dirty");
-		Require(!cache.Update(fileId, 90, sourcePath, 190, metadataPath),
-			"unchanged processing watermarks should be a no-op");
+		Require(cache.Update(fileId, 90, sourcePath),
+			"new asset import state should change the cache");
+		Require(cache.IsDirty(), "new asset import state should mark the cache dirty");
+		Require(!cache.Update(fileId, 90, sourcePath),
+			"unchanged asset import state should be a no-op");
 		Require(cache.IsDirty(), "a no-op update must not clear an already dirty cache");
-		Require(cache.Update(fileId, 91, sourcePath, 190, metadataPath),
+		Require(cache.Update(fileId, 91, sourcePath),
 			"a later successful asset import should change the source watermark");
-		Require(cache.Update(fileId, 91, sourcePath, 191, metadataPath),
-			"a later metadata load should change the metadata watermark");
-		Require(cache.Update(fileId, 91, sourcePath + ".moved", 191, metadataPath),
+		Require(cache.Update(fileId, 91, sourcePath + ".moved"),
 			"a source path change should change the cache");
-		Require(cache.Update(fileId, 91, sourcePath + ".moved", 191, metadataPath + ".moved"),
-			"a metadata path change should change the cache");
 	}
 
-	void TestProcessingWatermarksExpireOnNewerFiles()
+	void TestPruneRemovesOnlyEntriesOutsideTheCommittedGeneration()
 	{
-		TempDirectory directory("watermarks");
+		TestAssetCache cache;
+		const FileId liveFileId = MakeFileId("{ASSET-CACHE-PRUNE-LIVE}");
+		const FileId staleFileId = MakeFileId("{ASSET-CACHE-PRUNE-STALE}");
+		Require(cache.Update(liveFileId, 10, "/workspace/Content/Live.mat"),
+			"the live entry should populate the cache");
+		Require(cache.Update(staleFileId, 20, "/workspace/Content/Stale.mat"),
+			"the stale entry should populate the cache");
+
+		TSet<FileId> liveAssetIds;
+		liveAssetIds.Insert(liveFileId);
+		Require(cache.Prune(liveAssetIds),
+			"pruning a committed generation should report removed stale entries");
+		Require(cache.Contains(liveFileId),
+			"pruning must preserve entries from the committed registry generation");
+		Require(!cache.Contains(staleFileId),
+			"pruning must remove entries absent from the committed registry generation");
+		Require(!cache.Prune(liveAssetIds),
+			"pruning an already synchronized cache should be a no-op");
+	}
+
+	void TestRestoreChangesOnlyAssetImportTime()
+	{
+		TestAssetCache cache;
+		const FileId fileId = MakeFileId("{ASSET-CACHE-RUNTIME-METADATA}");
+		const std::filesystem::path sourcePath = "/workspace/Content/Test.mat";
+		const std::filesystem::path metadataPath = "/workspace/Content/Test.mat.asset";
+		Require(cache.Update(fileId, 123, sourcePath.string()),
+			"asset import state should populate the cache");
+
+		TestAssetInfo info;
+		info.Configure(fileId, sourcePath, metadataPath);
+		info.SetProcessingTimes(0, 456);
+		Require(cache.RestoreAssetImportTime(&info),
+			"matching file id and source path should restore the asset import time");
+		Require(info.GetAssetImportTime() == 123,
+			"the persisted asset import time should be restored");
+		Require(info.GetRuntimeMetadataLoadTime() == 456,
+			"restoring the asset cache must not change runtime metadata load time");
+	}
+
+	void TestAssetImportCacheAndRuntimeMetadataExpiration()
+	{
+		TempDirectory directory("import-and-runtime-metadata");
 		const std::filesystem::path sourcePath = directory.Path("Content/Test.mat");
 		const std::filesystem::path metadataPath = directory.Path("Content/Test.mat.asset");
 		WriteFile(sourcePath, "source");
@@ -640,8 +670,8 @@ namespace
 			info.GetAssetLastModificationTime(),
 			info.GetMetaLastModificationTime());
 		TestAssetCache cache;
-		Require(cache.Update(&info), "the initial processing watermarks should populate the cache");
-		Require(!cache.IsExpired(&info), "processed source and metadata files should remain current");
+		Require(cache.Update(&info), "the initial asset import state should populate the cache");
+		Require(!cache.IsExpired(&info), "an unchanged source file should remain current in the cache");
 
 		WriteFile(sourcePath, "source-v2");
 		std::filesystem::last_write_time(sourcePath, initialTime + std::chrono::seconds(2));
@@ -649,28 +679,38 @@ namespace
 		info.SetProcessingTimes(
 			info.GetAssetLastModificationTime(),
 			info.GetMetaLastModificationTime());
-		Require(cache.Update(&info), "the imported source watermark should advance");
+		Require(cache.Update(&info), "the asset import watermark should advance");
 		Require(!cache.IsExpired(&info), "the processed source version should become current");
+		const std::time_t importedSourceTime = info.GetAssetImportTime();
 
 		std::filesystem::last_write_time(sourcePath, initialTime - std::chrono::seconds(2));
 		Require(!cache.IsExpired(&info),
 			"a backdated source should not invalidate an already newer processing watermark");
 
 		std::filesystem::last_write_time(metadataPath, initialTime + std::chrono::seconds(4));
-		Require(cache.IsExpired(&info), "a newer metadata file should expire the cache");
+		Require(!cache.IsExpired(&info),
+			"metadata changes must not participate in persisted asset cache expiration");
+		Require(info.IsMetaExpired(),
+			"a newer metadata file must remain detectable through runtime AssetInfo state");
+		Require(!cache.Update(&info),
+			"metadata load time changes must not dirty the persisted asset cache");
 		info.SetProcessingTimes(
-			info.GetAssetLastModificationTime(),
+			importedSourceTime,
 			info.GetMetaLastModificationTime());
-		Require(cache.Update(&info), "the metadata load watermark should advance");
-		Require(!cache.IsExpired(&info), "the processed metadata version should become current");
+		Require(!info.IsMetaExpired(),
+			"advancing runtime metadata load time should acknowledge the loaded metadata");
 
 		std::filesystem::remove(metadataPath);
-		Require(cache.IsExpired(&info), "a missing metadata file should always expire the cache");
-		Require(!cache.Update(&info), "a missing file must not establish clean processing watermarks");
-		Require(cache.IsExpired(&info), "the cache must remain expired while metadata is missing");
+		Require(info.IsMetaExpired(), "a missing metadata file should expire runtime AssetInfo state");
+		Require(!cache.IsExpired(&info),
+			"missing metadata must not be represented as a persisted cache timestamp or path");
+		Require(!cache.Update(&info),
+			"missing metadata must not dirty or remove persisted source import state");
+		Require(!cache.IsExpired(&info),
+			"runtime metadata validity must remain independent from persisted source import state");
 	}
 
-	void TestMetadataFieldsAreStrictAndTransactional()
+	void TestRuntimeMetadataFieldsAreRejectedTransactionally()
 	{
 		const FileId retainedId = MakeFileId("{ASSET-CACHE-STRICT-RETAINED}");
 		const std::string prefix =
@@ -679,19 +719,15 @@ namespace
 			"    '{ASSET-CACHE-STRICT}':\n"
 			"      fileId: '{ASSET-CACHE-STRICT}'\n"
 			"      assetImportTime: 1\n"
-			"      sourcePath: '/workspace/Content/Test.mat'\n"
-			"      metadataLoadTime: 2\n";
+			"      sourcePath: '/workspace/Content/Test.mat'\n";
 		const std::string invalidPayloads[] =
 		{
-			prefix,
+			prefix + "      metadataLoadTime: 2\n",
+			prefix + "      metadataPath: '/workspace/Content/Test.mat.asset'\n",
 			prefix +
-				"      metadataPath: '/workspace/Content/Test.mat.asset'\n"
-				"      metadataPath: '/workspace/Content/Duplicate.asset'\n",
+				"      metadataLoadTime: 2\n"
+				"      metadataPath: '/workspace/Content/Test.mat.asset'\n",
 			prefix +
-				"      metadataPath:\n"
-				"        nested: value\n",
-			prefix +
-				"      metadataPath: '/workspace/Content/Test.mat.asset'\n"
 				"      unexpectedField: 3\n"
 		};
 
@@ -700,15 +736,13 @@ namespace
 			auto destination = MakeCache(
 				retainedId.ToString(),
 				"/workspace/Content/Retained.mat",
-				6,
-				"/workspace/Content/Retained.mat.asset",
-				7);
+				6);
 			std::string diagnostic;
 			Require(!TestAssetCache::TryDeserializeAssetCachePayload(payload, destination, diagnostic),
-				"missing, duplicate, or non-scalar metadata fields should reject the payload");
-			Require(!diagnostic.empty(), "strict metadata validation should return a diagnostic");
+				"runtime metadata fields and other unknown fields must be rejected");
+			Require(!diagnostic.empty(), "strict persisted schema validation should return a diagnostic");
 			Require(destination.m_data.Num() == 1 && destination.m_data.ContainsKey(retainedId),
-				"strict metadata validation failures must not partially publish state");
+				"strict schema validation failures must not partially publish state");
 		}
 	}
 
@@ -754,9 +788,11 @@ int main()
 		TestRawEditDispatchesExpiredUpdateWithoutImport();
 		TestMetadataEditDispatchesExpiredUpdateWithoutImport();
 		TestConcurrentMetadataEditDoesNotAdvanceTheWatermark();
-		TestUpdateTracksProcessingWatermarksAndPreservesDirtyState();
-		TestProcessingWatermarksExpireOnNewerFiles();
-		TestMetadataFieldsAreStrictAndTransactional();
+		TestUpdateTracksAssetImportStateAndPreservesDirtyState();
+		TestPruneRemovesOnlyEntriesOutsideTheCommittedGeneration();
+		TestRestoreChangesOnlyAssetImportTime();
+		TestAssetImportCacheAndRuntimeMetadataExpiration();
+		TestRuntimeMetadataFieldsAreRejectedTransactionally();
 		TestIoFailurePreservesTheExistingCacheFile();
 		std::cout << "Asset cache contract tests passed.\n";
 		return 0;

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -26,7 +26,6 @@ namespace
 		using AssetCache::ShouldWriteCacheFile;
 		using AssetCache::TryDeserializeAssetCachePayload;
 		using AssetCache::Update;
-		using AssetCache::Prune;
 	};
 
 	class TempDirectory final
@@ -116,9 +115,13 @@ namespace
 	class RecordingAssetListener final : public IAssetInfoHandlerListener
 	{
 	public:
-		void OnUpdateAssetInfo(AssetInfoPtr, bool bWasExpired) override
+		void OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired) override
 		{
 			m_events.emplace_back(bWasExpired ? "update:true" : "update:false");
+			if (bWasExpired && m_onExpiredUpdate)
+			{
+				m_onExpiredUpdate(assetInfo);
+			}
 		}
 
 		void OnImportAsset(AssetInfoPtr) override
@@ -127,6 +130,7 @@ namespace
 		}
 
 		std::vector<std::string> m_events;
+		std::function<void(AssetInfoPtr)> m_onExpiredUpdate;
 	};
 
 	class TestAssetInfoHandler final : public IAssetInfoHandler
@@ -480,6 +484,7 @@ namespace
 		info.SetProcessingTimes(
 			info.GetAssetLastModificationTime(),
 			info.GetMetaLastModificationTime());
+		WriteFile(sourcePath, "source-v2");
 		std::filesystem::last_write_time(
 			sourcePath,
 			initialSourceTime + std::chrono::seconds(2));
@@ -488,13 +493,68 @@ namespace
 
 		TestAssetInfoHandler handler;
 		RecordingAssetListener listener;
+		std::string reprocessedSource;
+		listener.m_onExpiredUpdate = [&reprocessedSource](AssetInfoPtr updatedInfo)
+		{
+			std::ifstream source(updatedInfo->GetAssetFilepath(), std::ios::binary);
+			reprocessedSource.assign(
+				std::istreambuf_iterator<char>(source),
+				std::istreambuf_iterator<char>());
+		};
 		handler.Subscribe(&listener);
 		Require(handler.ReloadAssetInfo(&info, true, false),
 			"an existing asset with a changed raw file should reload its metadata");
 		Require(listener.m_events == std::vector<std::string>({ "update:true" }),
 			"a raw edit must dispatch exactly Update(true) and never Import");
+		Require(reprocessedSource == "source-v2",
+			"Update(true) must let an importer reprocess the changed raw source");
 		Require(!info.IsAssetExpired(),
 			"a successfully dispatched raw edit should advance the in-memory processing watermark");
+	}
+
+	void TestMetadataEditDispatchesExpiredUpdateWithoutImport()
+	{
+		TempDirectory directory("meta-expired-callback");
+		const std::filesystem::path sourcePath = directory.Path("Content/Existing.raw");
+		const std::filesystem::path metadataPath = directory.Path("Content/Existing.raw.asset");
+		WriteFile(sourcePath, "source");
+		WriteFile(
+			metadataPath,
+			"fileId: '{ASSET-CACHE-META-EXPIRED}'\n"
+			"testValue: 7\n"
+			"lateValue: 1\n");
+
+		const std::filesystem::file_time_type initialMetadataTime =
+			std::filesystem::file_time_type::clock::now() - std::chrono::seconds(20);
+		std::filesystem::last_write_time(metadataPath, initialMetadataTime);
+		TestAssetInfo info;
+		info.Configure(MakeFileId("{ASSET-CACHE-META-EXPIRED}"), sourcePath, metadataPath);
+		info.SetProcessingTimes(
+			info.GetAssetLastModificationTime(),
+			info.GetMetaLastModificationTime());
+
+		WriteFile(
+			metadataPath,
+			"fileId: '{ASSET-CACHE-META-EXPIRED}'\n"
+			"testValue: 9\n"
+			"lateValue: 1\n");
+		std::filesystem::last_write_time(
+			metadataPath,
+			initialMetadataTime + std::chrono::seconds(2));
+		Require(info.IsMetaExpired(),
+			"newer metadata should be expired before reload");
+
+		TestAssetInfoHandler handler;
+		RecordingAssetListener listener;
+		handler.Subscribe(&listener);
+		Require(handler.ReloadAssetInfo(&info, true, false),
+			"an existing asset with changed metadata should reload");
+		Require(listener.m_events == std::vector<std::string>({ "update:true" }),
+			"a metadata edit must dispatch exactly Update(true) and never Import");
+		Require(info.m_testValue == 9,
+			"Update(true) should observe the newly loaded metadata values");
+		Require(!info.IsMetaExpired(),
+			"a successfully dispatched metadata edit should advance its processing watermark");
 	}
 
 	void TestConcurrentMetadataEditDoesNotAdvanceTheWatermark()
@@ -561,28 +621,6 @@ namespace
 			"a metadata path change should change the cache");
 	}
 
-	void TestPruneRemovesOnlyStaleEntries()
-	{
-		TestAssetCache cache;
-		const FileId liveId = MakeFileId("{ASSET-CACHE-PRUNE-LIVE}");
-		const FileId staleId = MakeFileId("{ASSET-CACHE-PRUNE-STALE}");
-		Require(cache.Update(liveId, 10, "/workspace/Content/Live.raw", 11,
-			"/workspace/Content/Live.raw.asset"),
-			"the live cache entry should be inserted");
-		Require(cache.Update(staleId, 20, "/workspace/Content/Stale.raw", 21,
-			"/workspace/Content/Stale.raw.asset"),
-			"the stale cache entry should be inserted");
-
-		TSet<FileId> liveAssetIds;
-		liveAssetIds.Insert(liveId);
-		Require(cache.Prune(liveAssetIds),
-			"pruning should report removal of a stale cache entry");
-		Require(cache.Contains(liveId) && !cache.Contains(staleId),
-			"pruning should retain only ids in the committed registry generation");
-		Require(!cache.Prune(liveAssetIds),
-			"pruning an already current cache should be a no-op");
-	}
-
 	void TestProcessingWatermarksExpireOnNewerFiles()
 	{
 		TempDirectory directory("watermarks");
@@ -604,6 +642,7 @@ namespace
 		Require(cache.Update(&info), "the initial processing watermarks should populate the cache");
 		Require(!cache.IsExpired(&info), "processed source and metadata files should remain current");
 
+		WriteFile(sourcePath, "source-v2");
 		std::filesystem::last_write_time(sourcePath, initialTime + std::chrono::seconds(2));
 		Require(cache.IsExpired(&info), "a newer source file should expire the cache");
 		info.SetProcessingTimes(
@@ -712,9 +751,9 @@ int main()
 		TestImportNeverOverwritesExistingMetadata();
 		TestRejectedReloadRestoresTheLiveAsset();
 		TestRawEditDispatchesExpiredUpdateWithoutImport();
+		TestMetadataEditDispatchesExpiredUpdateWithoutImport();
 		TestConcurrentMetadataEditDoesNotAdvanceTheWatermark();
 		TestUpdateTracksProcessingWatermarksAndPreservesDirtyState();
-		TestPruneRemovesOnlyStaleEntries();
 		TestProcessingWatermarksExpireOnNewerFiles();
 		TestMetadataFieldsAreStrictAndTransactional();
 		TestIoFailurePreservesTheExistingCacheFile();

--- a/Tests/AssetMountDiscoveryTests.cpp
+++ b/Tests/AssetMountDiscoveryTests.cpp
@@ -165,25 +165,19 @@ namespace
 	void TestScalarMetadataRootIsRejected()
 	{
 		TempDirectory directory("scalar-metadata");
-		const std::filesystem::path metaPath = directory.Path("scalar.asset");
+		const std::filesystem::path metaPath = directory.Path("Content/scalar.asset");
 		WriteFile(metaPath, "not-a-map\n");
 
-		std::string fileId = "stale-file-id";
-		std::string filename = "stale-filename";
-		std::string assetInfoType = "stale-type";
-		std::string diagnostic;
-		Require(
-			!AssetRegistryTestAccess::TryReadMetadataIdentity(
-				metaPath,
-				fileId,
-				filename,
-				assetInfoType,
-				diagnostic),
+		TypedFailureAssetInfoHandler handler;
+		AssetInfoPtr assetInfo = handler.LoadAssetInfo(
+			metaPath.string(),
+			{},
+			EAssetMountKind::Workspace,
+			true,
+			false,
+			false);
+		Require(assetInfo == nullptr,
 			"scalar metadata root should be rejected without throwing");
-		Require(fileId.empty() && filename.empty() && assetInfoType.empty(),
-			"rejected scalar metadata should clear all identity outputs");
-		Require(diagnostic == "metadata root must be a map",
-			"scalar metadata should return the root-shape diagnostic");
 	}
 
 	void TestTypedMetadataDeserializeFailureIsRejected()

--- a/Tests/AssetMountDiscoveryTests.cpp
+++ b/Tests/AssetMountDiscoveryTests.cpp
@@ -1,4 +1,5 @@
 #include "AssetRegistry/AssetMountDiscovery.h"
+#include "AssetRegistry/AssetRegistry.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -46,6 +47,30 @@ namespace
 
 	private:
 		std::filesystem::path m_path;
+	};
+
+	class TypedFailureAssetInfo final : public AssetInfo
+	{
+	public:
+		void Deserialize(const YAML::Node& inData) override
+		{
+			(void)inData["typedValue"].as<uint32_t>();
+		}
+	};
+
+	class TypedFailureAssetInfoHandler final : public IAssetInfoHandler
+	{
+	public:
+		void GetDefaultMeta(YAML::Node& outDefaultYaml) const override
+		{
+			outDefaultYaml = YAML::Node(YAML::NodeType::Map);
+		}
+
+	protected:
+		AssetInfoPtr CreateAssetInfo() const override
+		{
+			return new TypedFailureAssetInfo();
+		}
 	};
 
 	void WriteFile(const std::filesystem::path& path, const std::string& content = "fixture")
@@ -135,6 +160,48 @@ namespace
 			messages.emplace_back(diagnostic.m_message);
 		}
 		return messages;
+	}
+
+	void TestScalarMetadataRootIsRejected()
+	{
+		TempDirectory directory("scalar-metadata");
+		const std::filesystem::path metaPath = directory.Path("scalar.asset");
+		WriteFile(metaPath, "not-a-map\n");
+
+		std::string fileId = "stale-file-id";
+		std::string filename = "stale-filename";
+		std::string assetInfoType = "stale-type";
+		std::string diagnostic;
+		Require(
+			!AssetRegistryTestAccess::TryReadMetadataIdentity(
+				metaPath,
+				fileId,
+				filename,
+				assetInfoType,
+				diagnostic),
+			"scalar metadata root should be rejected without throwing");
+		Require(fileId.empty() && filename.empty() && assetInfoType.empty(),
+			"rejected scalar metadata should clear all identity outputs");
+		Require(diagnostic == "metadata root must be a map",
+			"scalar metadata should return the root-shape diagnostic");
+	}
+
+	void TestTypedMetadataDeserializeFailureIsRejected()
+	{
+		TempDirectory directory("typed-metadata");
+		const std::filesystem::path metaPath = directory.Path("Content/typed.asset");
+		WriteFile(metaPath, "typedValue: not-an-integer\n");
+
+		TypedFailureAssetInfoHandler handler;
+		AssetInfoPtr assetInfo = handler.LoadAssetInfo(
+			metaPath.string(),
+			{},
+			EAssetMountKind::Workspace,
+			true,
+			false,
+			false);
+		Require(assetInfo == nullptr,
+			"typed metadata conversion failure should return null without throwing");
 	}
 
 	void TestIdenticalRootsAreDeduplicatedToWorkspace()
@@ -429,6 +496,8 @@ int main(int argc, char** argv)
 	try
 	{
 		Require(argc == 2, "Expected the repository Engine Content path as the only argument");
+		TestScalarMetadataRootIsRejected();
+		TestTypedMetadataDeserializeFailureIsRejected();
 		TestIdenticalRootsAreDeduplicatedToWorkspace();
 		TestInvalidMountRootIsFatal();
 		TestDiscoveryIsSortedByVirtualPath();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -35,6 +35,14 @@ add_executable(SmartPointerTests
     SmartPointerTests.cpp
 )
 
+add_executable(InstanceIdContractTests
+    InstanceIdContractTests.cpp
+)
+
+add_executable(EcsLifecycleContractTests
+    EcsLifecycleContractTests.cpp
+)
+
 add_library(WorkspaceModuleFixture SHARED
     WorkspaceModuleFixture.cpp
 )
@@ -130,6 +138,10 @@ if(WIN32)
 endif()
 
 if(APPLE)
+    add_executable(MacWindowThreadingTests
+        MacWindowThreadingTests.mm
+    )
+
     add_executable(RemoteViewportMacTransportTests
         RemoteViewportMacTransportTests.cpp
         ${SAILOR_RUNTIME_DIR}/Submodules/EditorRemote/RemoteViewportMacNativeBridge.mm
@@ -146,6 +158,11 @@ target_compile_features(RemoteViewportContractTests PRIVATE cxx_std_20)
 target_compile_features(RemoteViewportRuntimeTests PRIVATE cxx_std_20)
 target_compile_features(EditorViewportSessionTests PRIVATE cxx_std_20)
 target_compile_features(SmartPointerTests PRIVATE cxx_std_20)
+target_compile_features(InstanceIdContractTests PRIVATE cxx_std_20)
+target_compile_features(EcsLifecycleContractTests PRIVATE cxx_std_20)
+target_compile_definitions(EcsLifecycleContractTests PRIVATE
+    SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
+)
 target_compile_features(WorkspaceModuleFixture PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleIncompatibleFixture PRIVATE cxx_std_20)
 target_compile_features(WorkspaceModuleMissingEntryFixture PRIVATE cxx_std_20)
@@ -179,6 +196,8 @@ target_link_libraries(WorkspaceModuleIncompatibleFixture PRIVATE Sailor::Runtime
 target_link_libraries(RemoteViewportRuntimeTests PRIVATE Sailor::Runtime)
 target_link_libraries(EditorViewportSessionTests PRIVATE Sailor::Runtime)
 target_link_libraries(SmartPointerTests PRIVATE Sailor::Runtime)
+target_link_libraries(InstanceIdContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(EcsLifecycleContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(AssetMountDiscoveryTests PRIVATE Sailor::Runtime)
 target_link_libraries(WorkspaceModuleContractTests PRIVATE
     Sailor::Runtime
@@ -217,14 +236,17 @@ if(WIN32)
     sailor_stage_workspace_test_runtime(WorkspaceCacheContractTests)
     sailor_stage_workspace_test_runtime(AssetCacheContractTests)
     sailor_stage_workspace_test_runtime(ShaderCacheArtifactTests)
+    sailor_stage_workspace_test_runtime(EcsLifecycleContractTests)
 endif()
 if(WIN32)
     target_compile_features(RemoteViewportWindowsTransportTests PRIVATE cxx_std_20)
     target_link_libraries(RemoteViewportWindowsTransportTests PRIVATE Sailor::Runtime)
 endif()
 if(APPLE)
+    target_compile_features(MacWindowThreadingTests PRIVATE cxx_std_20)
     target_compile_features(RemoteViewportMacTransportTests PRIVATE cxx_std_20)
     target_compile_features(RemoteViewportMacNativeBridgeTests PRIVATE cxx_std_20)
+    target_link_libraries(MacWindowThreadingTests PRIVATE Sailor::Runtime)
     target_link_libraries(RemoteViewportMacTransportTests PRIVATE Sailor::Runtime)
 endif()
 target_include_directories(RemoteViewportFoundationTests PRIVATE
@@ -240,6 +262,12 @@ target_include_directories(EditorViewportSessionTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(SmartPointerTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(InstanceIdContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(EcsLifecycleContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(WorkspaceModuleFixture PRIVATE
@@ -279,12 +307,18 @@ if(WIN32)
 endif()
 
 if(APPLE)
+    target_include_directories(MacWindowThreadingTests PRIVATE
+        ${SAILOR_RUNTIME_DIR}
+    )
     target_include_directories(RemoteViewportMacTransportTests PRIVATE
         ${SAILOR_RUNTIME_DIR}
     )
     target_include_directories(RemoteViewportMacNativeBridgeTests PRIVATE
         ${SAILOR_RUNTIME_DIR}
     )
+    target_link_libraries(MacWindowThreadingTests PRIVATE
+        "-framework Cocoa"
+        "-framework QuartzCore")
     target_link_libraries(RemoteViewportMacTransportTests PRIVATE
         "-framework Cocoa"
         "-framework QuartzCore"
@@ -320,6 +354,16 @@ add_test(
 add_test(
     NAME SmartPointerTests
     COMMAND SmartPointerTests
+)
+
+add_test(
+    NAME InstanceIdContractTests
+    COMMAND InstanceIdContractTests
+)
+
+add_test(
+    NAME EcsLifecycleContractTests
+    COMMAND EcsLifecycleContractTests
 )
 
 add_test(
@@ -383,6 +427,8 @@ set_tests_properties(
     WorkspaceModuleContractTests
     WorkspaceModuleRuntimeTests
     SmartPointerTests
+    InstanceIdContractTests
+    EcsLifecycleContractTests
     PROPERTIES TIMEOUT 30
 )
 
@@ -407,6 +453,12 @@ if(WIN32)
 endif()
 
 if(APPLE)
+    add_test(
+        NAME MacWindowThreadingTests
+        COMMAND MacWindowThreadingTests
+    )
+    set_tests_properties(MacWindowThreadingTests PROPERTIES TIMEOUT 15)
+
     add_test(
         NAME RemoteViewportMacTransportTests
         COMMAND RemoteViewportMacTransportTests

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -156,6 +156,9 @@ target_compile_features(WorkspaceCacheContractTests PRIVATE cxx_std_20)
 target_compile_features(AssetCacheContractTests PRIVATE cxx_std_20)
 target_compile_features(ShaderCacheArtifactTests PRIVATE cxx_std_20)
 target_compile_features(AssetMountDiscoveryTests PRIVATE cxx_std_20)
+target_compile_definitions(AssetMountDiscoveryTests PRIVATE
+    SAILOR_ASSET_REGISTRY_TEST_HOOKS
+)
 target_compile_definitions(WorkspaceModuleFixture PRIVATE
     SAILOR_WORKSPACE_MODULE
     SAILOR_WORKSPACE_MODULE_EXPORTS

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -156,9 +156,6 @@ target_compile_features(WorkspaceCacheContractTests PRIVATE cxx_std_20)
 target_compile_features(AssetCacheContractTests PRIVATE cxx_std_20)
 target_compile_features(ShaderCacheArtifactTests PRIVATE cxx_std_20)
 target_compile_features(AssetMountDiscoveryTests PRIVATE cxx_std_20)
-target_compile_definitions(AssetMountDiscoveryTests PRIVATE
-    SAILOR_ASSET_REGISTRY_TEST_HOOKS
-)
 target_compile_definitions(WorkspaceModuleFixture PRIVATE
     SAILOR_WORKSPACE_MODULE
     SAILOR_WORKSPACE_MODULE_EXPORTS

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1,0 +1,888 @@
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include "Containers/Octree.h"
+#include "AssetRegistry/Prefab/PrefabImporter.h"
+#include "Components/AnimatorComponent.h"
+#include "Components/Component.h"
+#include "Components/MeshRendererComponent.h"
+#include "ECS/AnimationECS.h"
+#include "ECS/ECS.h"
+#include "ECS/LightingECS.h"
+#include "ECS/StaticMeshRendererECS.h"
+#include "ECS/TransformECS.h"
+#include "Engine/GameObject.h"
+#include "Engine/World.h"
+#include "Submodules/Editor.h"
+
+using namespace Sailor;
+
+namespace Sailor
+{
+	class PrefabRollbackTestComponent final : public Component
+	{
+		SAILOR_REFLECTABLE(PrefabRollbackTestComponent)
+
+	public:
+
+		PrefabRollbackTestComponent() = default;
+
+		float m_value = 0.0f;
+		ComponentPtr m_dependency;
+	};
+}
+
+REFL_AUTO(
+	type(Sailor::PrefabRollbackTestComponent, bases<Sailor::Component>),
+	field(m_value),
+	field(m_dependency)
+)
+
+namespace
+{
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	bool AreMatricesNear(const glm::mat4& lhs, const glm::mat4& rhs, float tolerance = 0.0001f)
+	{
+		for (glm::length_t column = 0; column < lhs.length(); ++column)
+		{
+			for (glm::length_t row = 0; row < lhs[column].length(); ++row)
+			{
+				const float scale = std::max({ 1.0f, std::abs(lhs[column][row]), std::abs(rhs[column][row]) });
+				if (std::abs(lhs[column][row] - rhs[column][row]) > tolerance * scale)
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	glm::mat4 CalculateCurrentWorldMatrix(GameObjectPtr gameObject)
+	{
+		glm::mat4 worldMatrix = glm::identity<glm::mat4>();
+		for (auto current = gameObject; current.IsValid(); current = current->GetParent())
+		{
+			worldMatrix = current->GetTransformComponent().GetTransform().Matrix() * worldMatrix;
+		}
+
+		return worldMatrix;
+	}
+
+	std::string ReadText(const std::filesystem::path& path)
+	{
+		std::ifstream input(path, std::ios::binary);
+		Require(input.is_open(), "test source should be readable: " + path.generic_string());
+		return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+	}
+
+	class LifecycleData final : public ECS::TComponent
+	{
+	public:
+
+		~LifecycleData() override
+		{
+			++s_numDestructions;
+		}
+
+		bool IsActiveForTest() const { return m_bIsActive; }
+		bool IsDirtyForTest() const { return m_bIsDirty; }
+
+		static inline uint32_t s_numDestructions = 0;
+		uint32_t m_payload = 0;
+	};
+
+	class LifecycleSystem final : public ECS::TSystem<LifecycleSystem, LifecycleData>
+	{
+	public:
+
+		Tasks::ITaskPtr Tick(float deltaTime) override { return nullptr; }
+
+		uint32_t m_numCleanupCalls = 0;
+		uint32_t m_lastCleanupPayload = 0;
+
+	protected:
+
+		void OnComponentUnregistered(size_t index, LifecycleData& component) override
+		{
+			++m_numCleanupCalls;
+			m_lastCleanupPayload = component.m_payload;
+
+			if (m_bReenterCleanup)
+			{
+				UnregisterComponent(index);
+			}
+		}
+
+	public:
+
+		bool m_bReenterCleanup = false;
+	};
+
+	class AnimationLayoutTestSystem final : public AnimationECS
+	{
+	public:
+
+		bool TryAllocateForTest(uint32_t numBones, uint32_t& outGpuOffset)
+		{
+			return TryAllocateBoneRange(numBones, m_nextBoneOffset, outGpuOffset);
+		}
+
+		uint32_t GetNextBoneOffsetForTest() const { return m_nextBoneOffset; }
+	};
+
+	class PrefabTestWorld final : public World
+	{
+	public:
+
+		PrefabTestWorld() : World("PrefabRollbackTests", 0, CreateEcs()) {}
+		size_t GetPendingDependencyCount() const { return GetNumPendingDependencyResolutions(); }
+
+	private:
+
+		static TVector<ECS::TBaseSystemPtr> CreateEcs()
+		{
+			TVector<ECS::TBaseSystemPtr> systems;
+			systems.Add(TUniquePtr<TransformECS>::Make());
+			return systems;
+		}
+	};
+
+	class AnimationMeshTestWorld final : public World
+	{
+	public:
+
+		AnimationMeshTestWorld() : World("AnimationMeshTests", 0, CreateEcs()) {}
+
+	private:
+
+		static TVector<ECS::TBaseSystemPtr> CreateEcs()
+		{
+			TVector<ECS::TBaseSystemPtr> systems;
+			systems.Add(TUniquePtr<TransformECS>::Make());
+			systems.Add(TUniquePtr<AnimationECS>::Make());
+			systems.Add(TUniquePtr<StaticMeshRendererECS>::Make());
+			return systems;
+		}
+	};
+
+	void TestComponentSlotsAreResetAndFreedOnce()
+	{
+		LifecycleData::s_numDestructions = 0;
+		LifecycleSystem system;
+
+		const size_t first = system.RegisterComponent();
+		auto& data = system.GetComponentData(first);
+		Require(system.IsComponentRegistered(first), "new component slot should be registered");
+		Require(data.IsActiveForTest(), "new component slot should be active");
+		Require(!data.IsDirtyForTest(), "registration should preserve component-specific dirty tracking");
+
+		data.m_payload = 42;
+		system.m_bReenterCleanup = true;
+		system.UnregisterComponent(first);
+
+		Require(!system.IsComponentRegistered(first), "unregistered component slot should be inactive");
+		Require(system.GetComponentData(first).IsDirtyForTest(), "released component slot should request stale system-state cleanup");
+		Require(system.m_numCleanupCalls == 1, "system cleanup hook should run exactly once");
+		Require(system.m_lastCleanupPayload == 42, "cleanup hook should observe the live component state");
+		Require(LifecycleData::s_numDestructions == 1, "unregister should destroy the released component state");
+		Require(system.GetComponentData(first).m_payload == 0, "released component slot should be default reconstructed");
+
+		system.UnregisterComponent(first);
+		system.UnregisterComponent(ECS::InvalidIndex);
+		system.UnregisterComponent(first + 100);
+		Require(system.m_numCleanupCalls == 1, "duplicate and invalid unregister calls should be ignored");
+		Require(LifecycleData::s_numDestructions == 1, "duplicate unregister should not destroy a slot twice");
+
+		const size_t reused = system.RegisterComponent();
+		Require(reused == first, "the released slot should be reused once");
+		Require(system.GetComponentData(reused).m_payload == 0, "reused slot should not retain prior component state");
+		Require(!system.GetComponentData(reused).IsDirtyForTest(), "reused component should start with clean component-specific dirty state");
+
+		const size_t second = system.RegisterComponent();
+		Require(second != reused, "a duplicate free-list entry must not hand out an active slot twice");
+	}
+
+	void TestPreferredEditorInstanceIdsArePreserved()
+	{
+		PrefabTestWorld world;
+		InstanceId gameObjectId;
+		gameObjectId.Deserialize(YAML::Node("10010010010010010000"));
+		auto gameObject = world.Instantiate("PreferredIdentity", gameObjectId);
+		Require(static_cast<bool>(gameObject), "a free preferred game-object identity should be accepted");
+		Require(gameObject->GetInstanceId() == gameObjectId, "the preferred game-object identity should be preserved");
+		Require(!world.Instantiate("DuplicateIdentity", gameObjectId), "a duplicate preferred game-object identity should be rejected");
+
+		InstanceId componentId;
+		componentId.Deserialize(YAML::Node("1111111111111111_10010010010010010000"));
+		ComponentPtr component = TObjectPtr<PrefabRollbackTestComponent>::Make(world.GetAllocator());
+		auto added = gameObject->AddComponentRaw(component, componentId);
+		Require(static_cast<bool>(added), "a free preferred component identity should be accepted");
+		Require(added->GetInstanceId() == componentId, "the preferred component identity should be preserved");
+
+		ComponentPtr duplicate = TObjectPtr<PrefabRollbackTestComponent>::Make(world.GetAllocator());
+		Require(!gameObject->AddComponentRaw(duplicate, componentId), "a duplicate preferred component identity should be rejected");
+
+		InstanceId wrongOwnerId;
+		wrongOwnerId.Deserialize(YAML::Node("2222222222222222_20020020020020020000"));
+		ComponentPtr wrongOwner = TObjectPtr<PrefabRollbackTestComponent>::Make(world.GetAllocator());
+		Require(!gameObject->AddComponentRaw(wrongOwner, wrongOwnerId), "a preferred component identity for another owner should be rejected");
+
+		world.Clear();
+	}
+
+	void TestTransformParentCleanupPreservesPendingReparent()
+	{
+		PrefabTestWorld world;
+		auto previousParent = world.Instantiate("PreviousParent");
+		auto nextParent = world.Instantiate("NextParent");
+		auto child = world.Instantiate("Child");
+		auto* transforms = world.GetECS<TransformECS>();
+
+		child->SetParent(previousParent);
+		transforms->Tick(0.0f);
+		transforms->PostTick();
+
+		const size_t previousParentIndex = transforms->GetComponentIndex(&previousParent->GetTransformComponent());
+		const size_t nextParentIndex = transforms->GetComponentIndex(&nextParent->GetTransformComponent());
+		Require(child->GetTransformComponent().GetParent() == previousParentIndex,
+			"the transform fixture should establish its original parent before reparenting");
+
+		child->SetParent(nextParent);
+		world.DestroyImmediate(previousParent);
+		transforms->Tick(0.0f);
+
+		Require(static_cast<bool>(child), "reparenting away should keep the child alive when its previous parent is destroyed");
+		Require(child->GetParent() == nextParent, "the game-object hierarchy should retain the requested new parent");
+		Require(child->GetTransformComponent().GetParent() == nextParentIndex,
+			"transform cleanup should preserve a pending reparent away from the released slot");
+
+		world.Clear();
+	}
+
+	void TestEditorKeepWorldReparentUsesCurrentTransforms()
+	{
+		PrefabTestWorld world;
+		auto parent = world.Instantiate("Parent");
+		auto child = world.Instantiate("Child");
+		parent->GetTransformComponent().SetPosition(glm::vec3(10.0f, 0.0f, 0.0f));
+		child->GetTransformComponent().SetPosition(glm::vec3(1.0f, 0.0f, 0.0f));
+
+		Editor editor(nullptr, 0, nullptr);
+		editor.SetWorld(&world);
+		Require(editor.ReparentObject(child->GetInstanceId(), parent->GetInstanceId(), true),
+			"keep-world reparent should accept a live parent and child");
+
+		auto* transforms = world.GetECS<TransformECS>();
+		transforms->Tick(0.0f);
+		transforms->PostTick();
+
+		const glm::vec3 childWorldPosition = child->GetTransformComponent().GetWorldPosition();
+		Require(glm::distance(childWorldPosition, glm::vec3(1.0f, 0.0f, 0.0f)) < 0.001f,
+			"keep-world reparent should use current local transforms before the first transform tick");
+
+		world.Clear();
+	}
+
+	void TestEditorKeepWorldReparentRejectsSingularParentWithoutMutation()
+	{
+		PrefabTestWorld world;
+		auto previousParent = world.Instantiate("PreviousParent");
+		auto singularParent = world.Instantiate("SingularParent");
+		auto child = world.Instantiate("Child");
+		child->GetTransformComponent().SetPosition(glm::vec3(3.0f, 4.0f, 5.0f));
+		child->GetTransformComponent().SetScale(glm::vec4(1.5f, 0.75f, 2.0f, 1.0f));
+		child->SetParent(previousParent);
+		singularParent->GetTransformComponent().SetScale(glm::vec4(0.0f, 1.0f, 1.0f, 1.0f));
+
+		auto* transforms = world.GetECS<TransformECS>();
+		transforms->Tick(0.0f);
+		transforms->PostTick();
+
+		const Math::Transform localBefore = child->GetTransformComponent().GetTransform();
+		const glm::mat4 worldBefore = CalculateCurrentWorldMatrix(child);
+		const size_t ecsParentBefore = child->GetTransformComponent().GetParent();
+
+		Editor editor(nullptr, 0, nullptr);
+		editor.SetWorld(&world);
+		Require(!editor.ReparentObject(child->GetInstanceId(), singularParent->GetInstanceId(), true),
+			"keep-world reparent should reject a singular parent transform");
+		Require(child->GetParent() == previousParent,
+			"a rejected singular reparent must preserve the game-object parent");
+		Require(AreMatricesNear(child->GetTransformComponent().GetTransform().Matrix(), localBefore.Matrix()),
+			"a rejected singular reparent must preserve the local transform");
+		Require(AreMatricesNear(CalculateCurrentWorldMatrix(child), worldBefore),
+			"a rejected singular reparent must preserve the world transform");
+
+		transforms->Tick(0.0f);
+		Require(child->GetTransformComponent().GetParent() == ecsParentBefore,
+			"a rejected singular reparent must preserve the ECS parent relationship");
+		world.Clear();
+	}
+
+	void TestEditorKeepWorldReparentPreservesMirroredTransform()
+	{
+		PrefabTestWorld world;
+		auto mirroredParent = world.Instantiate("MirroredParent");
+		auto child = world.Instantiate("Child");
+		mirroredParent->GetTransformComponent().SetPosition(glm::vec3(10.0f, -2.0f, 4.0f));
+		mirroredParent->GetTransformComponent().SetScale(glm::vec4(-2.0f, 2.0f, 2.0f, 1.0f));
+		child->GetTransformComponent().SetPosition(glm::vec3(1.0f, 3.0f, -5.0f));
+		child->GetTransformComponent().SetScale(glm::vec4(1.0f, 2.0f, 0.5f, 1.0f));
+		const glm::mat4 worldBefore = CalculateCurrentWorldMatrix(child);
+
+		Editor editor(nullptr, 0, nullptr);
+		editor.SetWorld(&world);
+		Require(editor.ReparentObject(child->GetInstanceId(), mirroredParent->GetInstanceId(), true),
+			"keep-world reparent should accept an exactly representable mirrored transform");
+		Require(AreMatricesNear(CalculateCurrentWorldMatrix(child), worldBefore),
+			"keep-world reparent should preserve a mirrored world transform exactly");
+
+		const glm::vec4 localScale = child->GetTransformComponent().GetScale();
+		Require(localScale.x * localScale.y * localScale.z < 0.0f,
+			"mirrored decomposition should retain reflection in one signed scale axis");
+
+		auto* transforms = world.GetECS<TransformECS>();
+		transforms->Tick(0.0f);
+		Require(AreMatricesNear(child->GetTransformComponent().GetCachedWorldMatrix(), worldBefore),
+			"the transform ECS should retain the mirrored world transform after reparenting");
+		world.Clear();
+	}
+
+	void TestEditorKeepWorldReparentRejectsShearedCandidateWithoutMutation()
+	{
+		PrefabTestWorld world;
+		auto parent = world.Instantiate("NonUniformRotatedParent");
+		auto child = world.Instantiate("Child");
+		parent->GetTransformComponent().SetRotation(
+			glm::angleAxis(glm::radians(45.0f), glm::vec3(0.0f, 0.0f, 1.0f)));
+		parent->GetTransformComponent().SetScale(glm::vec4(2.0f, 1.0f, 1.0f, 1.0f));
+		child->GetTransformComponent().SetPosition(glm::vec3(2.0f, 3.0f, 4.0f));
+		const Math::Transform localBefore = child->GetTransformComponent().GetTransform();
+		const glm::mat4 worldBefore = CalculateCurrentWorldMatrix(child);
+
+		Editor editor(nullptr, 0, nullptr);
+		editor.SetWorld(&world);
+		Require(!editor.ReparentObject(child->GetInstanceId(), parent->GetInstanceId(), true),
+			"keep-world reparent should reject a local matrix that requires shear");
+		Require(!child->GetParent(),
+			"a rejected sheared reparent must preserve the original root relationship");
+		Require(AreMatricesNear(child->GetTransformComponent().GetTransform().Matrix(), localBefore.Matrix()),
+			"a rejected sheared reparent must preserve the local transform");
+		Require(AreMatricesNear(CalculateCurrentWorldMatrix(child), worldBefore),
+			"a rejected sheared reparent must preserve the world transform");
+		world.Clear();
+	}
+
+	void TestOctreeRelocationPreservesElementCount()
+	{
+		TOctree<size_t> octree(glm::ivec3(0), 128, 4);
+		const glm::ivec3 positions[] = {
+			{ -24, -24, -24 }, { 24, -24, -24 }, { -24, -24, 24 }, { 24, -24, 24 },
+			{ -24, 24, -24 }, { 24, 24, -24 }, { -24, 24, 24 }, { 24, 24, 24 }
+		};
+
+		for (size_t index = 0; index < 8; index++)
+		{
+			Require(octree.Insert(positions[index], glm::ivec3(1), index), "octree fixture insertion should succeed");
+		}
+
+		Require(octree.Num() == 8, "octree should contain every fixture element");
+		Require(octree.Update(glm::ivec3(24, 24, 24), glm::ivec3(1), size_t(0)),
+			"moving an element to another octant should succeed");
+		Require(octree.Num() == 8, "relocating an existing element must not increase the element count");
+
+		Require(!octree.Update(glm::ivec3(1000), glm::ivec3(1), size_t(0)),
+			"moving an element outside the root should fail");
+		Require(!octree.Contains(0), "failed relocation should remove the out-of-bounds element");
+		Require(octree.Num() == 7, "failed relocation should decrement the element count exactly once");
+
+		Require(octree.Insert(glm::ivec3(-24), glm::ivec3(1), size_t(0)),
+			"the removed element should remain insertable");
+		Require(octree.Num() == 8, "reinsertion should restore the expected count");
+	}
+
+	void TestClearingMeshModelAlsoClearsMaterials()
+	{
+		StaticMeshRendererData data;
+		data.GetMaterials().Add(MaterialPtr());
+		Require(data.GetMaterials().Num() == 1, "mesh renderer fixture should contain a material slot");
+
+		data.SetModel(ModelPtr());
+		Require(data.GetMaterials().IsEmpty(), "clearing a model should clear its stale material overrides");
+	}
+
+	void TestAnimationGpuBoneLayoutContract()
+	{
+		const uint32_t invalidOffset = AnimatorComponentData::InvalidGpuOffset;
+		AnimatorComponentData animatorData;
+		StaticMeshRendererData meshData;
+		Require(animatorData.m_gpuOffset == invalidOffset,
+			"an animator without an animation should not reference the GPU bone buffer");
+		Require(meshData.GetSkeletonOffset() == invalidOffset,
+			"a mesh without an allocated skeleton should publish the invalid offset");
+
+		uint32_t nextOffset = 0;
+		uint32_t allocatedOffset = 0;
+		Require(!AnimationECS::TryAllocateBoneRange(0, nextOffset, allocatedOffset),
+			"a zero-bone animation should not allocate a GPU range");
+		Require(nextOffset == 0 && allocatedOffset == invalidOffset,
+			"a rejected zero-bone allocation should preserve the layout cursor and invalid offset");
+
+		AnimationLayoutTestSystem system;
+		const size_t replacedAnimator = system.RegisterComponent();
+		const size_t survivingAnimator = system.RegisterComponent();
+		Require(system.TryAllocateForTest(10, allocatedOffset),
+			"the first animation range should fit");
+		system.GetComponentData(replacedAnimator).m_gpuOffset = allocatedOffset;
+		system.GetComponentData(replacedAnimator).SetBonesCount(10);
+		Require(system.TryAllocateForTest(10, allocatedOffset),
+			"the neighboring animation range should fit");
+		system.GetComponentData(survivingAnimator).m_gpuOffset = allocatedOffset;
+		system.GetComponentData(survivingAnimator).SetBonesCount(10);
+
+		system.SetAnimation(replacedAnimator, TObjectPtr<Animation>());
+		Require(system.GetComponentData(replacedAnimator).m_gpuOffset == invalidOffset &&
+			system.GetComponentData(survivingAnimator).m_gpuOffset == invalidOffset,
+			"replacing one animation should invalidate every offset in the compact GPU layout");
+		Require(system.GetNextBoneOffsetForTest() == 0,
+			"replacing an animation should restart compact GPU allocation from the beginning");
+
+		uint32_t replacementOffset = invalidOffset;
+		uint32_t survivorOffset = invalidOffset;
+		Require(system.TryAllocateForTest(100, replacementOffset),
+			"a replacement animation with more bones should receive a new range");
+		Require(system.TryAllocateForTest(10, survivorOffset),
+			"the neighboring animation should be reallocated after the replacement");
+		Require(replacementOffset == 0 && survivorOffset == 100,
+			"replacement relayout should keep neighboring bone ranges disjoint");
+
+		nextOffset = 0;
+		Require(AnimationECS::TryAllocateBoneRange(AnimationECS::BonesMaxNum, nextOffset, allocatedOffset),
+			"an exact-capacity animation range should fit");
+		Require(nextOffset == AnimationECS::BonesMaxNum,
+			"an exact-capacity allocation should advance the cursor to the buffer boundary");
+		Require(!AnimationECS::TryAllocateBoneRange(1, nextOffset, allocatedOffset),
+			"an allocation beyond the bone buffer capacity should be rejected");
+		Require(nextOffset == AnimationECS::BonesMaxNum && allocatedOffset == invalidOffset,
+			"capacity overflow should not clamp to a writable-looking offset");
+		nextOffset = AnimationECS::BonesMaxNum + 1;
+		Require(!AnimationECS::TryAllocateBoneRange(1, nextOffset, allocatedOffset) &&
+			nextOffset == AnimationECS::BonesMaxNum + 1 && allocatedOffset == invalidOffset,
+			"an out-of-range cursor should be rejected without unsigned-capacity underflow");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string shaderSource = ReadText(sourceRoot / "Content/Shaders/Standard_glTF.shader");
+		Require(shaderSource.find("INVALID_SKELETON_OFFSET = 0xFFFFFFFFu") != std::string::npos,
+			"the skinned shader should define the invalid skeleton marker");
+		Require(shaderSource.find("if (offset != INVALID_SKELETON_OFFSET)") != std::string::npos,
+			"the skinned shader should avoid bone-buffer reads for an invalid skeleton offset");
+	}
+
+	void TestAnimationRelayoutMarksEveryOwnedMeshDirty()
+	{
+		AnimationMeshTestWorld world;
+		auto gameObject = world.Instantiate("AnimatedMeshes");
+		auto firstMesh = gameObject->AddComponent<MeshRendererComponent>();
+		auto secondMesh = gameObject->AddComponent<MeshRendererComponent>();
+		gameObject->AddComponent<AnimatorComponent>();
+
+		Require(!firstMesh->GetData().IsDirty() && !secondMesh->GetData().IsDirty(),
+			"mesh fixtures should start with clean ECS data");
+
+		world.GetECS<AnimationECS>()->InvalidateGpuLayout();
+
+		Require(firstMesh->GetData().IsDirty(),
+			"animation relayout should invalidate the first owned mesh renderer");
+		Require(secondMesh->GetData().IsDirty(),
+			"animation relayout should invalidate every additional owned mesh renderer");
+
+		world.Clear();
+	}
+
+	void TestSparseLightSlotInvalidationAndReuse()
+	{
+		Require(LightingECS::GetGpuLightSlotsCount(LightingECS::LightsMaxNum) == LightingECS::LightsMaxNum,
+			"the exact GPU light capacity should remain addressable");
+		Require(LightingECS::GetGpuLightSlotsCount(static_cast<size_t>(LightingECS::LightsMaxNum) + 1) == LightingECS::LightsMaxNum,
+			"a light slot beyond GPU capacity should be clamped before buffer access");
+
+		LightingECS system;
+		const size_t released = system.RegisterComponent();
+		const size_t survivor = system.RegisterComponent();
+		system.GetComponentData(released).m_type = ELightType::Directional;
+		system.GetComponentData(survivor).m_type = ELightType::Spot;
+
+		system.UnregisterComponent(released);
+		Require(!system.IsComponentRegistered(released), "released light slot should be inactive");
+		Require(system.IsComponentRegistered(survivor), "sparse light removal should preserve later slots");
+		Require(system.GetComponentData(survivor).m_type == ELightType::Spot,
+			"sparse light removal should preserve surviving light data");
+
+		const LightingECS::LightShaderData invalidShaderData{};
+		Require(invalidShaderData.m_type == LightingECS::LightShaderData::InvalidType,
+			"released GPU light payload should use an explicit invalid marker");
+
+		const size_t reused = system.RegisterComponent();
+		Require(reused == released, "released sparse light slot should be reused");
+		Require(system.GetComponentData(reused).m_type == ELightType::Point,
+			"reused light slot should restore default component data");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string lightingSource = ReadText(sourceRoot / "Content/Shaders/Lighting.glsl");
+		const std::string cullingSource = ReadText(sourceRoot / "Content/Shaders/ComputeLightCulling.shader");
+		Require(lightingSource.find("INVALID_LIGHT_TYPE = 0xFFFFFFFFu") != std::string::npos,
+			"shader light layout should define the invalid light marker");
+		Require(cullingSource.find("type == INVALID_LIGHT_TYPE") != std::string::npos,
+			"light culling should skip invalid sparse slots");
+	}
+
+	YAML::Node MakePrefabNode(
+		std::initializer_list<uint32_t> parentIndices,
+		bool bReferenceMissingComponent = false,
+		bool bIncludeParentIndex = true)
+	{
+		YAML::Node gameObjects(YAML::NodeType::Sequence);
+		uint32_t index = 0;
+		for (const uint32_t parentIndex : parentIndices)
+		{
+			Prefab::ReflectedGameObject gameObject{};
+			gameObject.m_name = "GameObject" + std::to_string(index++);
+			gameObject.m_position = glm::vec4(0.0f);
+			gameObject.m_rotation = glm::identity<glm::quat>();
+			gameObject.m_scale = glm::vec4(1.0f);
+			gameObject.m_parentIndex = parentIndex;
+			gameObject.m_instanceId = InstanceId::GenerateNewInstanceId();
+			if (bReferenceMissingComponent)
+			{
+				gameObject.m_components.Add(0);
+			}
+			YAML::Node gameObjectNode = gameObject.Serialize();
+			if (!bIncludeParentIndex)
+			{
+				gameObjectNode.remove("parentIndex");
+			}
+			gameObjects.push_back(std::move(gameObjectNode));
+		}
+
+		YAML::Node prefabNode;
+		prefabNode["gameObjects"] = std::move(gameObjects);
+		prefabNode["components"] = YAML::Node(YAML::NodeType::Sequence);
+		return prefabNode;
+	}
+
+	YAML::Node MakeReflectedComponent(
+		const std::string& componentInstanceId,
+		const YAML::Node& overrideProperties,
+		bool bIncludeInstanceId = true)
+	{
+		YAML::Node component;
+		component["typename"] = PrefabRollbackTestComponent::GetStaticTypeInfo().Name();
+		component["overrideProperties"] = overrideProperties;
+		if (bIncludeInstanceId)
+		{
+			component["overrideProperties"]["instanceId"] = componentInstanceId;
+		}
+		return component;
+	}
+
+	YAML::Node MakeComponentPrefabNode(const YAML::Node& components)
+	{
+		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
+		YAML::Node prefabNode = MakePrefabNode({ noParent });
+		prefabNode["components"] = components;
+		prefabNode["gameObjects"][0]["instanceId"] = "10010010010010010000";
+		prefabNode["gameObjects"][0]["components"] = YAML::Node(YAML::NodeType::Sequence);
+		for (uint32_t componentIndex = 0; componentIndex < components.size(); ++componentIndex)
+		{
+			prefabNode["gameObjects"][0]["components"].push_back(componentIndex);
+		}
+		return prefabNode;
+	}
+
+	PrefabPtr DeserializePrefab(PrefabTestWorld& world, const YAML::Node& node)
+	{
+		PrefabPtr prefab = PrefabPtr::Make(world.GetAllocator(), FileId());
+		prefab->Deserialize(node);
+		return prefab;
+	}
+
+	void RequireRejectedWithoutWorldMutation(
+		PrefabTestWorld& world,
+		const YAML::Node& prefabNode,
+		const std::string& message)
+	{
+		const size_t initialObjectCount = world.GetGameObjects().Num();
+		const size_t initialPendingDependencyCount = world.GetPendingDependencyCount();
+		PrefabPtr prefab = DeserializePrefab(world, prefabNode);
+
+		Require(!world.Instantiate(prefab), message + " should be rejected");
+		Require(world.GetGameObjects().Num() == initialObjectCount,
+			message + " must leave the world object count unchanged");
+		Require(world.GetPendingDependencyCount() == initialPendingDependencyCount,
+			message + " must leave the pending dependency queue unchanged");
+	}
+
+	void TestPrefabTopologyValidationRejectsPartialWorldMutations()
+	{
+		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
+		std::string diagnostic;
+
+		Prefab validPrefab{ FileId() };
+		validPrefab.Deserialize(MakePrefabNode({ noParent, 0 }));
+		Require(validPrefab.ValidateForInstantiation(diagnostic),
+			"a single-root acyclic prefab should pass pre-mutation validation: " + diagnostic);
+
+		Prefab multipleRoots{ FileId() };
+		multipleRoots.Deserialize(MakePrefabNode({ noParent, noParent }));
+		Require(!multipleRoots.ValidateForInstantiation(diagnostic) && diagnostic.find("exactly one root") != std::string::npos,
+			"multiple roots must be rejected before any world objects are created");
+
+		Prefab cyclicHierarchy{ FileId() };
+		cyclicHierarchy.Deserialize(MakePrefabNode({ noParent, 2, 1 }));
+		Require(!cyclicHierarchy.ValidateForInstantiation(diagnostic) && diagnostic.find("cycle") != std::string::npos,
+			"a detached parent cycle must be rejected before world mutation");
+
+		Prefab invalidComponentReference{ FileId() };
+		invalidComponentReference.Deserialize(MakePrefabNode({ noParent }, true));
+		Require(!invalidComponentReference.ValidateForInstantiation(diagnostic) && diagnostic.find("component index") != std::string::npos,
+			"out-of-range component references must be rejected before world mutation");
+
+		Prefab missingParentIndex{ FileId() };
+		missingParentIndex.Deserialize(MakePrefabNode({ noParent }, false, false));
+		Require(!missingParentIndex.ValidateForInstantiation(diagnostic) && diagnostic.find("parentIndex") != std::string::npos,
+			"a missing parentIndex must be rejected instead of reading uninitialized hierarchy state");
+
+		YAML::Node malformedGameObjectIdNode = MakePrefabNode({ noParent });
+		malformedGameObjectIdNode["gameObjects"][0]["instanceId"] = "truthy-but-not-a-direct-id";
+		Prefab malformedGameObjectId{ FileId() };
+		malformedGameObjectId.Deserialize(malformedGameObjectIdNode);
+		Require(!malformedGameObjectId.ValidateForInstantiation(diagnostic) && diagnostic.find("invalid instanceId") != std::string::npos,
+			"a malformed truthy game-object instanceId must be rejected before world mutation");
+
+		YAML::Node duplicateGameObjectIdNode = MakePrefabNode({ noParent, 0 });
+		duplicateGameObjectIdNode["gameObjects"][1]["instanceId"] =
+			duplicateGameObjectIdNode["gameObjects"][0]["instanceId"];
+		Prefab duplicateGameObjectId{ FileId() };
+		duplicateGameObjectId.Deserialize(duplicateGameObjectIdNode);
+		Require(!duplicateGameObjectId.ValidateForInstantiation(diagnostic) && diagnostic.find("duplicate instanceId") != std::string::npos,
+			"duplicate original game-object instanceIds must be rejected before dependency remapping");
+
+		YAML::Node validProperties;
+		validProperties["m_value"] = 1.0f;
+		YAML::Node validComponents(YAML::NodeType::Sequence);
+		validComponents.push_back(MakeReflectedComponent(
+			"1111111111111111_10010010010010010000",
+			validProperties));
+
+		YAML::Node duplicateComponentReferenceNode = MakeComponentPrefabNode(validComponents);
+		duplicateComponentReferenceNode["gameObjects"][0]["components"].push_back(0);
+		Prefab duplicateComponentReference{ FileId() };
+		duplicateComponentReference.Deserialize(duplicateComponentReferenceNode);
+		Require(!duplicateComponentReference.ValidateForInstantiation(diagnostic) && diagnostic.find("referenced more than once") != std::string::npos,
+			"a reflected component must not be instantiated more than once");
+
+		YAML::Node orphanComponentNode = MakeComponentPrefabNode(validComponents);
+		orphanComponentNode["gameObjects"][0]["components"] = YAML::Node(YAML::NodeType::Sequence);
+		Prefab orphanComponent{ FileId() };
+		orphanComponent.Deserialize(orphanComponentNode);
+		Require(!orphanComponent.ValidateForInstantiation(diagnostic) && diagnostic.find("unreferenced") != std::string::npos,
+			"an orphan reflected component must be rejected before world mutation");
+
+		YAML::Node mismatchedComponentOwnerNode = MakeComponentPrefabNode(validComponents);
+		mismatchedComponentOwnerNode["components"][0]["overrideProperties"]["instanceId"] =
+			"1111111111111111_20020020020020020000";
+		Prefab mismatchedComponentOwner{ FileId() };
+		mismatchedComponentOwner.Deserialize(mismatchedComponentOwnerNode);
+		Require(!mismatchedComponentOwner.ValidateForInstantiation(diagnostic) && diagnostic.find("different game object") != std::string::npos,
+			"a reflected component must belong to the game object that references it");
+	}
+
+	void TestPrefabInstantiationRollbackPreservesWorldState()
+	{
+		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
+		PrefabTestWorld world;
+		Require(static_cast<bool>(world.Instantiate("ExistingObject")),
+			"the rollback fixture should contain an existing object");
+
+		RequireRejectedWithoutWorldMutation(
+			world,
+			MakePrefabNode({ noParent, noParent }),
+			"a multiple-root prefab");
+		RequireRejectedWithoutWorldMutation(
+			world,
+			MakePrefabNode({ noParent, 2, 1 }),
+			"a cyclic prefab hierarchy");
+		RequireRejectedWithoutWorldMutation(
+			world,
+			MakePrefabNode({ noParent }, false, false),
+			"a prefab with a missing parentIndex");
+
+		YAML::Node malformedGameObjectIdNode = MakePrefabNode({ noParent });
+		malformedGameObjectIdNode["gameObjects"][0]["instanceId"] = "truthy-but-not-a-direct-id";
+		RequireRejectedWithoutWorldMutation(
+			world,
+			malformedGameObjectIdNode,
+			"a prefab with a malformed game-object instanceId");
+
+		YAML::Node duplicateGameObjectIdNode = MakePrefabNode({ noParent, 0 });
+		duplicateGameObjectIdNode["gameObjects"][1]["instanceId"] =
+			duplicateGameObjectIdNode["gameObjects"][0]["instanceId"];
+		RequireRejectedWithoutWorldMutation(
+			world,
+			duplicateGameObjectIdNode,
+			"a prefab with duplicate game-object instanceIds");
+
+		YAML::Node missingIdComponents(YAML::NodeType::Sequence);
+		YAML::Node validProperties;
+		validProperties["m_value"] = 1.0f;
+		missingIdComponents.push_back(MakeReflectedComponent("", validProperties, false));
+		RequireRejectedWithoutWorldMutation(
+			world,
+			MakeComponentPrefabNode(missingIdComponents),
+			"a reflected component with a missing instanceId");
+
+		YAML::Node duplicateIdComponents(YAML::NodeType::Sequence);
+		duplicateIdComponents.push_back(MakeReflectedComponent(
+			"4444444444444444_10010010010010010000",
+			validProperties));
+		duplicateIdComponents.push_back(MakeReflectedComponent(
+			"4444444444444444_10010010010010010000",
+			validProperties));
+		RequireRejectedWithoutWorldMutation(
+			world,
+			MakeComponentPrefabNode(duplicateIdComponents),
+			"reflected components with duplicate full instanceIds");
+
+		YAML::Node validComponent(YAML::NodeType::Sequence);
+		validComponent.push_back(MakeReflectedComponent(
+			"1111111111111111_10010010010010010000",
+			validProperties));
+
+		YAML::Node duplicateComponentReferenceNode = MakeComponentPrefabNode(validComponent);
+		duplicateComponentReferenceNode["gameObjects"][0]["components"].push_back(0);
+		RequireRejectedWithoutWorldMutation(
+			world,
+			duplicateComponentReferenceNode,
+			"a prefab that references one reflected component more than once");
+
+		YAML::Node orphanComponentNode = MakeComponentPrefabNode(validComponent);
+		orphanComponentNode["gameObjects"][0]["components"] = YAML::Node(YAML::NodeType::Sequence);
+		RequireRejectedWithoutWorldMutation(
+			world,
+			orphanComponentNode,
+			"a prefab with an orphan reflected component");
+
+		YAML::Node mismatchedComponentOwnerNode = MakeComponentPrefabNode(validComponent);
+		mismatchedComponentOwnerNode["components"][0]["overrideProperties"]["instanceId"] =
+			"1111111111111111_20020020020020020000";
+		RequireRejectedWithoutWorldMutation(
+			world,
+			mismatchedComponentOwnerNode,
+			"a prefab with a reflected component owned by another game object");
+
+		YAML::Node malformedValueComponents(YAML::NodeType::Sequence);
+		YAML::Node malformedValueProperties;
+		malformedValueProperties["m_value"] = "not-a-float";
+		malformedValueComponents.push_back(MakeReflectedComponent(
+			"1111111111111111_10010010010010010000",
+			malformedValueProperties));
+		RequireRejectedWithoutWorldMutation(
+			world,
+			MakeComponentPrefabNode(malformedValueComponents),
+			"a reflected component with a malformed scalar property");
+
+		YAML::Node lateFailureComponents(YAML::NodeType::Sequence);
+		YAML::Node unresolvedProperties;
+		unresolvedProperties["m_dependency"]["fileId"] = "NullFileId";
+		unresolvedProperties["m_dependency"]["instanceId"] =
+			"AAAAAAAAAAAAAAAA_BBBBBBBBBBBBBBBB";
+
+		YAML::Node unresolvedComponents(YAML::NodeType::Sequence);
+		unresolvedComponents.push_back(MakeReflectedComponent(
+			"5555555555555555_10010010010010010000",
+			unresolvedProperties));
+		const size_t initialObjectCount = world.GetGameObjects().Num();
+		const size_t initialPendingDependencyCount = world.GetPendingDependencyCount();
+		GameObjectPtr unresolvedRoot = world.Instantiate(DeserializePrefab(
+			world,
+			MakeComponentPrefabNode(unresolvedComponents)));
+		Require(static_cast<bool>(unresolvedRoot),
+			"the unresolved dependency fixture should instantiate successfully");
+		Require(world.GetPendingDependencyCount() == initialPendingDependencyCount + 1,
+			"an unresolved reflected dependency should enter the pending queue");
+		world.DestroyImmediate(unresolvedRoot);
+		Require(world.GetGameObjects().Num() == initialObjectCount,
+			"destroying the unresolved dependency fixture should restore the object count");
+		Require(world.GetPendingDependencyCount() == initialPendingDependencyCount,
+			"destroying the unresolved dependency fixture should restore the pending queue");
+
+		lateFailureComponents.push_back(MakeReflectedComponent(
+			"2222222222222222_10010010010010010000",
+			unresolvedProperties));
+
+		YAML::Node malformedReferenceProperties;
+		malformedReferenceProperties["m_dependency"] = "not-an-object-reference";
+		lateFailureComponents.push_back(MakeReflectedComponent(
+			"3333333333333333_10010010010010010000",
+			malformedReferenceProperties));
+		RequireRejectedWithoutWorldMutation(
+			world,
+			MakeComponentPrefabNode(lateFailureComponents),
+			"a late malformed reference after queuing an unresolved dependency");
+
+		world.Clear();
+	}
+}
+
+int main()
+{
+	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "ComponentSlotsAreResetAndFreedOnce", TestComponentSlotsAreResetAndFreedOnce },
+		{ "PreferredEditorInstanceIdsArePreserved", TestPreferredEditorInstanceIdsArePreserved },
+		{ "TransformParentCleanupPreservesPendingReparent", TestTransformParentCleanupPreservesPendingReparent },
+		{ "EditorKeepWorldReparentUsesCurrentTransforms", TestEditorKeepWorldReparentUsesCurrentTransforms },
+		{ "EditorKeepWorldReparentRejectsSingularParentWithoutMutation", TestEditorKeepWorldReparentRejectsSingularParentWithoutMutation },
+		{ "EditorKeepWorldReparentPreservesMirroredTransform", TestEditorKeepWorldReparentPreservesMirroredTransform },
+		{ "EditorKeepWorldReparentRejectsShearedCandidateWithoutMutation", TestEditorKeepWorldReparentRejectsShearedCandidateWithoutMutation },
+		{ "OctreeRelocationPreservesElementCount", TestOctreeRelocationPreservesElementCount },
+		{ "ClearingMeshModelAlsoClearsMaterials", TestClearingMeshModelAlsoClearsMaterials },
+		{ "AnimationGpuBoneLayoutContract", TestAnimationGpuBoneLayoutContract },
+		{ "AnimationRelayoutMarksEveryOwnedMeshDirty", TestAnimationRelayoutMarksEveryOwnedMeshDirty },
+		{ "SparseLightSlotInvalidationAndReuse", TestSparseLightSlotInvalidationAndReuse },
+		{ "PrefabTopologyValidationRejectsPartialWorldMutations", TestPrefabTopologyValidationRejectsPartialWorldMutations },
+		{ "PrefabInstantiationRollbackPreservesWorldState", TestPrefabInstantiationRollbackPreservesWorldState },
+	};
+
+	for (const auto& test : tests)
+	{
+		try
+		{
+			test.second();
+			std::cout << "[PASS] " << test.first << std::endl;
+		}
+		catch (const std::exception& e)
+		{
+			std::cerr << "[FAIL] " << test.first << ": " << e.what() << std::endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/Tests/InstanceIdContractTests.cpp
+++ b/Tests/InstanceIdContractTests.cpp
@@ -1,0 +1,158 @@
+#include "Engine/InstanceId.h"
+
+#include <algorithm>
+#include <cctype>
+#include <functional>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+using namespace Sailor;
+
+namespace
+{
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	InstanceId Parse(const std::string& value)
+	{
+		InstanceId result;
+		result.Deserialize(YAML::Node(value));
+		return result;
+	}
+
+	bool IsHexString(const std::string& value)
+	{
+		return !value.empty() && std::all_of(value.begin(), value.end(), [](unsigned char character)
+			{
+				return std::isxdigit(character) != 0;
+			});
+	}
+
+	void TestGeneratedGameObjectIdsUseCanonicalFormat()
+	{
+		for (uint32_t i = 0; i < 256; ++i)
+		{
+			const InstanceId id = InstanceId::GenerateNewInstanceId();
+			Require(id.ToString().length() == 20, "generated game-object IDs must contain exactly 20 hex characters");
+			Require(IsHexString(id.ToString()), "generated game-object IDs must contain only hex characters");
+			Require(id.IsGameObjectId(), "generated game-object IDs must be recognized as game-object IDs");
+			Require(id.GameObjectId() == id, "a generated direct ID must resolve to itself");
+		}
+	}
+
+	void TestLegacyDirectGameObjectIdsRemainReadable()
+	{
+		const std::string legacyIds[] = {
+			"0123456789ABCDEF",
+			"0123456789ABCDEFF",
+			"0123456789ABCDEFFF",
+			"0123456789ABCDEFFFF",
+			"0123456789ABCDEFFFFF"
+		};
+
+		for (const std::string& value : legacyIds)
+		{
+			const InstanceId id = Parse(value);
+			Require(id.IsGameObjectId(), "legacy 16-20 character game-object IDs must remain valid");
+			Require(id.GameObjectId() == id, "legacy direct IDs must resolve to themselves");
+		}
+	}
+
+	void TestMalformedDirectGameObjectIdsAreRejected()
+	{
+		const std::string malformedIds[] = {
+			"0123456789ABCDE",
+			"0123456789ABCDEFFFFF0",
+			"0123456789ABCDEG",
+			"0123456789ABCDEF_0123456789ABCDEF"
+		};
+
+		for (const std::string& value : malformedIds)
+		{
+			const InstanceId id = Parse(value);
+			Require(!id.IsGameObjectId(), "malformed direct IDs must not be classified as game-object IDs");
+		}
+	}
+
+	void TestComponentIdsResolveLegacyAndCanonicalParents()
+	{
+		const InstanceId legacyParent = Parse("0123456789ABCDEF");
+		const InstanceId canonicalParent = Parse("0123456789ABCDEFFFFF");
+		const InstanceId componentParts[] = {
+			Parse("FEDCBA9876543210"),
+			Parse("FFF4417DA65649588B6B279D47D0EC3E")
+		};
+
+		for (const InstanceId& componentPart : componentParts)
+		{
+			for (const InstanceId& parent : { legacyParent, canonicalParent })
+			{
+				const InstanceId component(componentPart, parent);
+				Require(!component.IsGameObjectId(), "a component ID must not be classified as a direct game-object ID");
+				Require(component.ComponentId() == componentPart, "component IDs must preserve legacy 16- or 32-character prefixes");
+				Require(component.GameObjectId() == parent, "component IDs must resolve their legacy or canonical parent suffix");
+			}
+		}
+
+		const InstanceId malformedSuffix = Parse("FEDCBA9876543210_not-a-game-object");
+		Require(malformedSuffix.GameObjectId() == InstanceId::Invalid, "malformed component parent suffixes must be rejected");
+	}
+
+	void TestMalformedComponentIdsAreRejected()
+	{
+		const std::string malformedIds[] = {
+			"FEDCBA987654321_0123456789ABCDEF",
+			"FEDCBA98765432100_0123456789ABCDEF",
+			"FEDCBA987654321G_0123456789ABCDEF",
+			"FFF4417DA65649588B6B279D47D0EC3_0123456789ABCDEF",
+			"0FFF4417DA65649588B6B279D47D0EC3E_0123456789ABCDEF",
+			"FFF4417DA65649588B6B279D47D0EC3G_0123456789ABCDEF",
+			"FEDCBA9876543210_0123456789ABCDE",
+			"FEDCBA9876543210_0123456789ABCDEG",
+			"FEDCBA9876543210_0123456789ABCDEF_extra"
+		};
+
+		for (const std::string& value : malformedIds)
+		{
+			const InstanceId id = Parse(value);
+			Require(id.ComponentId() == InstanceId::Invalid,
+				"malformed component prefixes and separators must be rejected");
+			Require(id.GameObjectId() == InstanceId::Invalid,
+				"a malformed component ID must not expose an otherwise valid parent suffix");
+		}
+	}
+}
+
+int main()
+{
+	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "GeneratedGameObjectIdsUseCanonicalFormat", TestGeneratedGameObjectIdsUseCanonicalFormat },
+		{ "LegacyDirectGameObjectIdsRemainReadable", TestLegacyDirectGameObjectIdsRemainReadable },
+		{ "MalformedDirectGameObjectIdsAreRejected", TestMalformedDirectGameObjectIdsAreRejected },
+		{ "ComponentIdsResolveLegacyAndCanonicalParents", TestComponentIdsResolveLegacyAndCanonicalParents },
+		{ "MalformedComponentIdsAreRejected", TestMalformedComponentIdsAreRejected },
+	};
+
+	for (const auto& test : tests)
+	{
+		try
+		{
+			test.second();
+			std::cout << "[PASS] " << test.first << std::endl;
+		}
+		catch (const std::exception& error)
+		{
+			std::cerr << "[FAIL] " << test.first << ": " << error.what() << std::endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/Tests/MacWindowThreadingTests.mm
+++ b/Tests/MacWindowThreadingTests.mm
@@ -1,0 +1,190 @@
+#if defined(__APPLE__)
+
+#import <Cocoa/Cocoa.h>
+#import <dispatch/dispatch.h>
+
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <exception>
+#include <iostream>
+#include <memory>
+#include <mutex>
+#include <stdexcept>
+#include <string>
+#include <thread>
+
+#include "Platform/Win32/Window.h"
+
+using Sailor::Win32::Window;
+
+namespace
+{
+	constexpr int32_t TestWidth = 321;
+	constexpr int32_t TestHeight = 177;
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	template<typename Predicate>
+	bool PumpMainRunLoopUntil(Predicate&& predicate, std::chrono::steady_clock::duration timeout)
+	{
+		const auto deadline = std::chrono::steady_clock::now() + timeout;
+		while (!predicate() && std::chrono::steady_clock::now() < deadline)
+		{
+			@autoreleasepool
+			{
+				[[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+			}
+		}
+
+		return predicate();
+	}
+
+	struct BackgroundResizeState
+	{
+		std::shared_ptr<Window> m_window;
+		std::mutex m_mutex;
+		std::condition_variable m_completedCondition;
+		std::exception_ptr m_failure;
+		bool m_completed = false;
+	};
+
+	bool IsBackgroundResizeComplete(const std::shared_ptr<BackgroundResizeState>& state)
+	{
+		std::lock_guard lock(state->m_mutex);
+		return state->m_completed;
+	}
+
+	void TestWindowResizeFromWorkerDoesNotWaitForMainQueue()
+	{
+		Require([NSThread isMainThread], "mac window threading test must start on the main thread");
+
+		auto window = std::make_shared<Window>();
+		Require(window->Create("Sailor window threading test", "SailorWindowThreadingTest", 128, 96, false, false, nullptr),
+			"test should create a real macOS window");
+		window->Show(false);
+
+		NSWindow* nativeWindow = (__bridge NSWindow*)window->GetHWND();
+		Require(nativeWindow != nil, "created Sailor window should expose an NSWindow");
+
+		auto state = std::make_shared<BackgroundResizeState>();
+		state->m_window = window;
+		std::thread resizeThread([state]()
+			{
+				@autoreleasepool
+				{
+					try
+					{
+						state->m_window->ChangeWindowSize(TestWidth, TestHeight, false);
+					}
+					catch (...)
+					{
+						state->m_failure = std::current_exception();
+					}
+				}
+
+				{
+					std::lock_guard lock(state->m_mutex);
+					state->m_completed = true;
+				}
+				state->m_completedCondition.notify_one();
+			});
+
+		bool completedWithoutMainQueuePump = false;
+		{
+			std::unique_lock lock(state->m_mutex);
+			completedWithoutMainQueuePump = state->m_completedCondition.wait_for(
+				lock,
+				std::chrono::seconds(2),
+				[state]() { return state->m_completed; });
+		}
+
+		// A dispatch_sync(main) regression leaves the worker blocked. Pump the
+		// main run loop before failing so the queued resize can finish and join.
+		bool completedEventually = completedWithoutMainQueuePump;
+		if (!completedEventually)
+		{
+			completedEventually = PumpMainRunLoopUntil(
+				[state]() { return IsBackgroundResizeComplete(state); },
+				std::chrono::seconds(2));
+		}
+
+		if (!completedEventually)
+		{
+			// The shared state owns the Window, so detaching cannot leave the
+			// worker with stack references while this standalone test exits.
+			resizeThread.detach();
+			throw std::runtime_error("background window resize did not complete during cleanup");
+		}
+
+		resizeThread.join();
+
+		// Drain all main-queue work submitted before this fence. This applies an
+		// asynchronous resize before inspecting or destroying the native window.
+		auto mainQueueFence = std::make_shared<std::atomic_bool>(false);
+		dispatch_async(dispatch_get_main_queue(), ^
+			{
+				mainQueueFence->store(true, std::memory_order_release);
+			});
+		const bool drainedMainQueue = PumpMainRunLoopUntil(
+			[mainQueueFence]() { return mainQueueFence->load(std::memory_order_acquire); },
+			std::chrono::seconds(2));
+
+		if (!drainedMainQueue)
+		{
+			throw std::runtime_error("main queue did not drain during window resize cleanup");
+		}
+
+		const NSSize contentSize = nativeWindow.contentView.bounds.size;
+		const bool nativeSizeApplied = std::abs(contentSize.width - TestWidth) < 0.5 &&
+			std::abs(contentSize.height - TestHeight) < 0.5;
+		const bool trackedSizeApplied = window->GetWidth() == TestWidth && window->GetHeight() == TestHeight;
+		const std::exception_ptr backgroundFailure = state->m_failure;
+
+		// Window::Destroy closes the NSWindow. Suppress the production delegate's
+		// process-termination behavior in this standalone test executable.
+		nativeWindow.delegate = nil;
+		window->Destroy();
+
+		if (backgroundFailure)
+		{
+			std::rethrow_exception(backgroundFailure);
+		}
+		Require(completedWithoutMainQueuePump,
+			"background ChangeWindowSize must not synchronously wait for the main queue");
+		Require(trackedSizeApplied, "background ChangeWindowSize should update tracked dimensions");
+		Require(nativeSizeApplied, "queued main-thread resize should update the NSWindow content size");
+	}
+}
+
+int main()
+{
+	@autoreleasepool
+	{
+		try
+		{
+			TestWindowResizeFromWorkerDoesNotWaitForMainQueue();
+			std::cout << "[PASS] WindowResizeFromWorkerDoesNotWaitForMainQueue" << std::endl;
+			return 0;
+		}
+		catch (const std::exception& exception)
+		{
+			std::cerr << "[FAIL] WindowResizeFromWorkerDoesNotWaitForMainQueue: " << exception.what() << std::endl;
+			return 1;
+		}
+	}
+}
+
+#else
+int main()
+{
+	return 0;
+}
+#endif

--- a/Tests/RemoteViewportMacNativeBridgeTests.mm
+++ b/Tests/RemoteViewportMacNativeBridgeTests.mm
@@ -3,11 +3,17 @@
 #import <QuartzCore/CAMetalLayer.h>
 #import <Metal/Metal.h>
 #import <IOSurface/IOSurface.h>
+#import <Foundation/Foundation.h>
 
+#include <chrono>
+#include <condition_variable>
 #include <functional>
 #include <iostream>
+#include <memory>
+#include <mutex>
 #include <stdexcept>
 #include <string>
+#include <thread>
 #include <utility>
 
 #include "Submodules/EditorRemote/RemoteViewportMacNativeBridge.h"
@@ -220,6 +226,101 @@ namespace
 		Require(!presentResult.m_usedSyntheticSourceTexture, "bridge should import the real IOSurface into a Metal texture when a live IOSurface handle is supplied");
 		Require(binding.m_importedIOSurfaceObject == surfaceHandle.m_surfaceObject, "binding should retain the imported IOSurface object used for the Metal texture import");
 		Require(binding.m_lastSourceTextureObject == presentResult.m_sourceTextureObject, "binding should retain the last source Metal texture");
+		ResetMacNativeLayerBinding(binding);
+	}
+
+	void TestBridgePresentsOffMainThreadWithoutWaitingForMainQueue()
+	{
+		CAMetalLayer* layer = [CAMetalLayer layer];
+		MacNativeHostHandle hostHandle{ MacNativeHostHandleKind::CAMetalLayer, reinterpret_cast<uintptr_t>((__bridge void*)layer) };
+
+		struct BackgroundPresentState
+		{
+			MacNativeLayerBinding m_binding{};
+			MacIOSurfaceHandle m_surface{};
+			FramePacket m_frame{};
+			MacNativeBridgePresentResult m_presentResult{};
+			Failure m_failure{};
+			std::mutex m_mutex;
+			std::condition_variable m_completedCondition;
+			bool m_completed = false;
+		};
+
+		auto state = std::make_shared<BackgroundPresentState>();
+		Require(BindMacNativeLayer(hostHandle, 64, 64, PixelFormat::B8G8R8A8_UNorm, state->m_binding).IsOk(),
+			"background-present test should bind a real CAMetalLayer on the main thread");
+		state->m_frame.m_viewportId = 1;
+		state->m_frame.m_connectionEpoch = 1;
+		state->m_frame.m_generation = 1;
+		state->m_frame.m_frameIndex = 1;
+		state->m_frame.m_width = 64;
+		state->m_frame.m_height = 64;
+
+		std::thread presenter([state]()
+			{
+				state->m_failure = PresentMacNativeLayerFrame(
+					state->m_binding,
+					state->m_surface,
+					state->m_frame,
+					state->m_presentResult);
+				{
+					std::lock_guard lock(state->m_mutex);
+					state->m_completed = true;
+				}
+				state->m_completedCondition.notify_one();
+			});
+
+		bool completedWithoutMainQueuePump = false;
+		{
+			std::unique_lock lock(state->m_mutex);
+			completedWithoutMainQueuePump = state->m_completedCondition.wait_for(
+				lock,
+				std::chrono::seconds(2),
+				[state]() { return state->m_completed; });
+		}
+
+		// If this regresses to dispatch_sync(main), drain the queued block before
+		// failing so the test does not leave a permanently blocked worker behind.
+		if (!completedWithoutMainQueuePump)
+		{
+			const auto cleanupDeadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+			while (std::chrono::steady_clock::now() < cleanupDeadline)
+			{
+				{
+					std::lock_guard lock(state->m_mutex);
+					if (state->m_completed)
+					{
+						break;
+					}
+				}
+
+				@autoreleasepool
+				{
+					[[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.01]];
+				}
+			}
+		}
+
+		bool completedEventually = false;
+		{
+			std::lock_guard lock(state->m_mutex);
+			completedEventually = state->m_completed;
+		}
+		if (completedEventually)
+		{
+			presenter.join();
+			ResetMacNativeLayerBinding(state->m_binding);
+		}
+		else
+		{
+			presenter.detach();
+		}
+
+		Require(completedEventually, "background present should eventually complete while unwinding the regression test");
+		Require(completedWithoutMainQueuePump,
+			"per-frame CAMetalLayer present must not synchronously dispatch to the main queue");
+		Require(state->m_failure.IsOk(), "background CAMetalLayer present should succeed");
+		Require(state->m_presentResult.IsValid(), "background CAMetalLayer present should produce a real present token");
 	}
 }
 
@@ -231,6 +332,7 @@ int main()
 		{ "SynchronizeMacVulkanRenderTargetPrefersMetalSharedEventWhenSemaphoreExportSeamExists", TestSynchronizeMacVulkanRenderTargetPrefersMetalSharedEventWhenSemaphoreExportSeamExists },
 		{ "BridgeWaitsOnMetalSharedEventBeforeProducerCopy", TestBridgeWaitsOnMetalSharedEventBeforeProducerCopy },
 		{ "BridgeBindsExistingCAMetalLayerAndPresentsDrawable", TestBridgeBindsExistingCAMetalLayerAndPresentsDrawable },
+		{ "BridgePresentsOffMainThreadWithoutWaitingForMainQueue", TestBridgePresentsOffMainThreadWithoutWaitingForMainQueue },
 	};
 
 	for (const auto& test : tests)

--- a/Tests/RemoteViewportMacTransportTests.cpp
+++ b/Tests/RemoteViewportMacTransportTests.cpp
@@ -432,7 +432,85 @@ namespace
 		Require(backend.ReleaseSurface(viewport.m_viewportId, 32, 1).IsOk(), "provider should still release surfaces after metadata-backed begin frame");
 	}
 
+	void TestConcreteMacLoopbackProviderFallsBackWhenRendererSourceIsUnavailable()
+	{
+		FakeMacRendererFrameSourceProvider sourceProvider{};
+		MacLoopbackIOSurfaceProvider provider{ &sourceProvider };
+		MacViewportTransportBackend backend{ provider };
+		auto viewport = MakeViewport(84, 64, 32);
+		TransportDescriptor transport{};
+		Require(backend.EnsureSurface(viewport, 35, 1, transport).IsOk(), "unavailable-source fallback should create the requested IOSurface transport");
+		Require(backend.BeginFrame(viewport, 35, 1).IsOk(), "a temporarily unavailable renderer source should fall back to the synthetic intermediate");
+
+		auto key = MacViewportSurfaceKey{ viewport.m_viewportId, 35, 1 };
+		auto* allocation = provider.FindAllocation(key);
+		Require(allocation != nullptr && allocation->m_lastRendererSource.m_kind == MacRendererFrameSourceKind::SyntheticIntermediate, "unavailable renderer source should record the synthetic intermediate used for the transition frame");
+		Require(allocation != nullptr && allocation->m_lastRendererSource.m_width == viewport.m_width && allocation->m_lastRendererSource.m_height == viewport.m_height, "synthetic fallback should match the current IOSurface extents");
+		Require(transport.m_width == viewport.m_width && transport.m_height == viewport.m_height, "synthetic fallback should not rewrite the host viewport transport descriptor");
+
+		FramePacket frame{};
+		Require(backend.ExportFrame(viewport, 35, 1, frame).IsOk(), "unavailable-source fallback should still export the transition frame");
+		Require(frame.m_width == viewport.m_width && frame.m_height == viewport.m_height, "exported fallback frame should retain the requested viewport extents");
+		Require(sourceProvider.m_calls.size() == 1 && sourceProvider.m_calls.front().second == 1, "unavailable-source fallback should still probe the renderer once for the frame");
+		Require(backend.ReleaseSurface(viewport.m_viewportId, 35, 1).IsOk(), "unavailable-source fallback should release its IOSurface cleanly");
+	}
+
 #if defined(__APPLE__)
+	void TestConcreteMacLoopbackProviderFallsBackWhenRendererSourceExtentsAreStale()
+	{
+		FakeMacRendererFrameSourceProvider sourceProvider{};
+		MacLoopbackIOSurfaceProvider provider{ &sourceProvider };
+		MacViewportTransportBackend backend{ provider };
+		auto viewport = MakeViewport(85, 8, 4);
+		TransportDescriptor transport{};
+		Require(backend.EnsureSurface(viewport, 36, 1, transport).IsOk(), "stale-source fallback should create the requested IOSurface transport");
+
+		auto key = MacViewportSurfaceKey{ viewport.m_viewportId, 36, 1 };
+		auto* allocation = provider.FindAllocation(key);
+		Require(allocation != nullptr, "stale-source fallback needs a live IOSurface allocation");
+		uintptr_t rendererTextureObject = 0;
+		Require(CreateMacRendererIntermediateTexture(allocation->m_producerDeviceObject, viewport.m_width * 2u, viewport.m_height * 2u, viewport.m_pixelFormat, rendererTextureObject).IsOk(), "stale-source fallback should create an old-sized renderer texture");
+
+		const uint8_t sharedEventSentinelByte = 1;
+		CFDataRef sharedEventSentinel = CFDataCreate(kCFAllocatorDefault, &sharedEventSentinelByte, 1);
+		Require(sharedEventSentinel != nullptr, "stale-source fallback should create a shared-event ownership sentinel");
+		CFRetain(reinterpret_cast<CFTypeRef>(rendererTextureObject));
+		CFRetain(sharedEventSentinel);
+		const CFIndex textureRetainCountBefore = CFGetRetainCount(reinterpret_cast<CFTypeRef>(rendererTextureObject));
+		const CFIndex sharedEventRetainCountBefore = CFGetRetainCount(sharedEventSentinel);
+
+		sourceProvider.m_nextSource.m_kind = MacRendererFrameSourceKind::RendererOwnedMetalTexture;
+		sourceProvider.m_nextSource.m_textureObject = rendererTextureObject;
+		sourceProvider.m_nextSource.m_sourceToken = 0xcafef00dull;
+		sourceProvider.m_nextSource.m_crossApiAcquireValue = 44;
+		sourceProvider.m_nextSource.m_crossApiSharedEventObject = reinterpret_cast<uintptr_t>(sharedEventSentinel);
+		sourceProvider.m_nextSource.m_crossApiSyncKind = CrossApiSyncKind::MetalSharedEvent;
+		sourceProvider.m_nextSource.m_width = viewport.m_width * 2u;
+		sourceProvider.m_nextSource.m_height = viewport.m_height * 2u;
+		sourceProvider.m_nextSource.m_pixelFormat = viewport.m_pixelFormat;
+		sourceProvider.m_nextSource.m_debugName = "Renderer.SceneView.PreResize";
+		sourceProvider.m_nextSource.m_releaseTextureObjectAfterUse = true;
+
+		Require(backend.BeginFrame(viewport, 36, 1).IsOk(), "a copyable renderer source with stale extents should fall back to the synthetic intermediate");
+		allocation = provider.FindAllocation(key);
+		Require(allocation != nullptr && allocation->m_lastRendererSource.m_kind == MacRendererFrameSourceKind::SyntheticIntermediate, "stale renderer extents should record the synthetic intermediate used for the transition frame");
+		Require(allocation != nullptr && allocation->m_lastRendererSource.m_width == viewport.m_width && allocation->m_lastRendererSource.m_height == viewport.m_height, "stale-source fallback should match the current IOSurface instead of resizing it back");
+		Require(allocation != nullptr && allocation->m_lastCrossApiAcquireValue == 0, "stale-source fallback should not retain rejected source synchronization metadata");
+		Require(CFGetRetainCount(reinterpret_cast<CFTypeRef>(rendererTextureObject)) == textureRetainCountBefore - 1, "stale-source fallback should release the rejected owned Metal texture");
+		Require(CFGetRetainCount(sharedEventSentinel) == sharedEventRetainCountBefore - 1, "stale-source fallback should release the rejected shared event");
+		Require(transport.m_width == viewport.m_width && transport.m_height == viewport.m_height, "stale-source fallback should preserve the host viewport transport descriptor");
+
+		FramePacket frame{};
+		Require(backend.ExportFrame(viewport, 36, 1, frame).IsOk(), "stale-source fallback should still export the transition frame");
+		Require(frame.m_width == viewport.m_width && frame.m_height == viewport.m_height, "stale-source fallback frame should retain the requested viewport extents");
+		Require(backend.ReleaseSurface(viewport.m_viewportId, 36, 1).IsOk(), "stale-source fallback should release its IOSurface cleanly");
+
+		sourceProvider.m_nextSource.m_textureObject = 0;
+		sourceProvider.m_nextSource.m_crossApiSharedEventObject = 0;
+		ReleaseMacRendererIntermediateTexture(rendererTextureObject);
+		CFRelease(sharedEventSentinel);
+	}
+
 	void TestMacProducerCpuUploadWritesIOSurface()
 	{
 		MacLoopbackIOSurfaceProvider provider{};
@@ -625,8 +703,10 @@ int main()
 		{ "MacProducerCpuUploadWritesIOSurface", TestMacProducerCpuUploadWritesIOSurface },
 		{ "ConcreteMacLoopbackProviderCopiesRendererOwnedMetalTextureIntoIOSurface", TestConcreteMacLoopbackProviderCopiesRendererOwnedMetalTextureIntoIOSurface },
 		{ "MacExportCarriesCrossApiSyncMetadataFromRendererSource", TestMacExportCarriesCrossApiSyncMetadataFromRendererSource },
+		{ "ConcreteMacLoopbackProviderFallsBackWhenRendererSourceExtentsAreStale", TestConcreteMacLoopbackProviderFallsBackWhenRendererSourceExtentsAreStale },
 #endif
 		{ "ConcreteMacLoopbackProviderRecordsRendererOwnedSourceMetadata", TestConcreteMacLoopbackProviderRecordsRendererOwnedSourceMetadata },
+		{ "ConcreteMacLoopbackProviderFallsBackWhenRendererSourceIsUnavailable", TestConcreteMacLoopbackProviderFallsBackWhenRendererSourceIsUnavailable },
 		{ "ConcreteMacLoopbackProviderAndPresenterCarryNativeMetadata", TestConcreteMacLoopbackProviderAndPresenterCarryNativeMetadata },
 	};
 

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -762,6 +762,129 @@ namespace
 		Require(!ShaderCompilerTestAccess::SaveCacheAndCombineResult(cache, false),
 			"a compile failure should remain failed even when cache persistence succeeds");
 	}
+
+	void TestShaderSourceNormalization()
+	{
+		std::string diagnostic;
+		std::string rawGlsl =
+			"vec3 convertRGB2XYZ(vec3 value)\n"
+			"{\n"
+			"    // Reference(s):\n"
+			"\treturn value;\n"
+			"}\n";
+		const std::string originalRawGlsl = rawGlsl;
+		Require(
+			!ShaderCompilerTestAccess::NormalizeShaderTabs("glsl", rawGlsl, diagnostic),
+			"raw GLSL should not be normalized as shader YAML");
+		Require(rawGlsl == originalRawGlsl && diagnostic.empty(),
+			"raw GLSL should remain byte-for-byte unchanged without a YAML diagnostic");
+
+		std::string validShader =
+			"glslVertex: |\n"
+			"  void main() {}\n";
+		const std::string originalValidShader = validShader;
+		Require(
+			!ShaderCompilerTestAccess::NormalizeShaderTabs("shader", validShader, diagnostic),
+			"valid shader YAML should not need normalization");
+		Require(validShader == originalValidShader && diagnostic.empty(),
+			"valid shader YAML should remain byte-for-byte unchanged");
+
+		std::string shaderWithTab =
+			"glslVertex: |\n"
+			"  void main()\n"
+			"  {\n"
+			"\tgl_Position = vec4(0.0);\n"
+			"  }\n";
+		Require(
+			ShaderCompilerTestAccess::NormalizeShaderTabs("shader", shaderWithTab, diagnostic),
+			"invalid YAML indentation tabs should be normalized");
+		Require(shaderWithTab.find('\t') == std::string::npos && diagnostic.empty(),
+			"normalized shader YAML should contain no tabs or diagnostic");
+		Require(shaderWithTab.find("\n    gl_Position") != std::string::npos,
+			"shader YAML tabs should expand to exactly four spaces");
+		Require(YAML::Load(shaderWithTab)["glslVertex"].IsScalar(),
+			"normalized shader YAML should be parseable");
+
+		std::string malformedShader = "glslVertex: [\n";
+		const std::string originalMalformedShader = malformedShader;
+		Require(
+			!ShaderCompilerTestAccess::NormalizeShaderTabs("shader", malformedShader, diagnostic),
+			"non-tab YAML errors should not trigger a rewrite");
+		Require(malformedShader == originalMalformedShader && !diagnostic.empty(),
+			"non-tab YAML errors should preserve the source and publish a diagnostic");
+	}
+
+	void TestShaderSourceRewritePreservesFileIdentity()
+	{
+		TempDirectory directory;
+		const std::filesystem::path shaderPath = directory.Path("User.shader");
+		const std::filesystem::path hardLinkPath = directory.Path("User.shader.link");
+		const std::string onDiskSource =
+			"glslVertex: |\r\n"
+			"  void main()\n"
+			"  {\r\n"
+			"\tgl_Position = vec4(0.0);\n"
+			"  }\r\n";
+		{
+			std::ofstream output(shaderPath, std::ios::binary);
+			Require(output.is_open(), "the shader rewrite fixture should be writable");
+			output << onDiskSource;
+		}
+
+		std::string originalSource;
+		std::string diagnostic;
+		Require(
+			ShaderCompilerTestAccess::ReadShaderSourceBinary(
+				shaderPath.generic_string(),
+				originalSource,
+				diagnostic),
+			"the shader rewrite fixture should use production binary reading: " + diagnostic);
+		Require(originalSource == onDiskSource,
+			"production shader reading should preserve mixed line endings byte-for-byte");
+		std::string normalizedSource = originalSource;
+		Require(
+			ShaderCompilerTestAccess::NormalizeShaderTabs(
+				"shader",
+				normalizedSource,
+				diagnostic),
+			"the rewrite fixture should require normalization");
+		std::error_code filesystemError;
+		std::filesystem::create_hard_link(shaderPath, hardLinkPath, filesystemError);
+		Require(!filesystemError,
+			"the shader rewrite fixture should support hard links: " + filesystemError.message());
+		const auto permissionsBefore = std::filesystem::status(shaderPath).permissions();
+
+		Require(
+			ShaderCompilerTestAccess::RewriteShaderSourceInPlace(
+				shaderPath.generic_string(),
+				originalSource,
+				normalizedSource,
+				diagnostic),
+			"normalized shader source should be written in place: " + diagnostic);
+		Require(ReadText(shaderPath) == normalizedSource && ReadText(hardLinkPath) == normalizedSource,
+			"in-place normalization should preserve the source inode");
+		Require(std::filesystem::status(shaderPath).permissions() == permissionsBefore,
+			"in-place normalization should preserve source permissions");
+		Require(CountRegularFiles(shaderPath.parent_path()) == 2,
+			"in-place normalization should not create discoverable temporary assets");
+
+		const std::string onDiskConcurrentSource = "glslVertex: concurrent-edit\r\n";
+		{
+			std::ofstream output(shaderPath, std::ios::binary | std::ios::trunc);
+			Require(output.is_open(), "the concurrent shader edit should be writable");
+			output << onDiskConcurrentSource;
+		}
+		const std::string concurrentSource = onDiskConcurrentSource;
+		Require(
+			!ShaderCompilerTestAccess::RewriteShaderSourceInPlace(
+				shaderPath.generic_string(),
+				originalSource,
+				normalizedSource,
+				diagnostic),
+			"a concurrent user edit should cancel shader normalization");
+		Require(ReadText(shaderPath) == concurrentSource && !diagnostic.empty(),
+			"a concurrent user edit should remain intact and produce a diagnostic");
+	}
 }
 
 int main()
@@ -780,6 +903,8 @@ int main()
 		TestIoFailureQuarantineIsReadOnlyAndSessionOnly();
 		TestRuntimeArtifactIoFailureEntersReadOnlyQuarantine();
 		TestShaderCompilerFailureLifecycle();
+		TestShaderSourceNormalization();
+		TestShaderSourceRewritePreservesFileIdentity();
 		std::cout << "Shader cache artifact tests passed.\n";
 		return 0;
 	}

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -452,6 +452,71 @@ namespace
 			"save retry should garbage-collect removed artifacts after the committed metadata");
 	}
 
+	void TestExplicitInvalidationSurvivesSameTimestampReload()
+	{
+		TempDirectory directory;
+		const std::filesystem::path cacheRoot = directory.Path("Cache");
+		const FileId uid = MakeFileId("{SHADER-CACHE-EXPLICIT-INVALIDATION}");
+		std::filesystem::path durableArtifact;
+		{
+			ShaderCache cache;
+			Require(ShaderCacheTestAccess::Configure(cache, cacheRoot, 100),
+				"shader cache invalidation storage should initialize");
+			Require(PublishComplete(cache, uid, 0, 45),
+				"the shader generation to invalidate should publish");
+			cache.SaveCache(true);
+			durableArtifact = ShaderCacheTestAccess::GetArtifactPath(
+				cache,
+				uid,
+				0,
+				ShaderCache::VertexShaderTag,
+				false);
+
+			cache.Invalidate(uid);
+			Require(cache.Contains(uid) && cache.IsExpired(uid, 0) && !cache.IsDirty(),
+				"explicit invalidation should persist an expired entry without removing it");
+			Require(std::filesystem::exists(durableArtifact),
+				"explicit invalidation should preserve the last durable SPIR-V generation");
+		}
+
+		ShaderCache reloaded;
+		Require(ShaderCacheTestAccess::Configure(reloaded, cacheRoot, 100),
+			"reloaded shader cache invalidation storage should initialize");
+		reloaded.LoadCache();
+		Require(reloaded.GetLastLoadResult().IsLoaded() && reloaded.IsExpired(uid, 0),
+			"explicit invalidation should remain expired after reload at the same source timestamp");
+		Require(std::filesystem::exists(durableArtifact),
+			"reloading an invalidated entry should retain its last durable artifacts");
+	}
+
+	void TestMissingStorageRecoveryDropsStaleArtifactReferences()
+	{
+		TempDirectory directory;
+		const std::filesystem::path cacheRoot = directory.Path("Cache");
+		const FileId uid = MakeFileId("{SHADER-CACHE-MISSING-STORAGE}");
+		ShaderCache cache;
+		Require(ShaderCacheTestAccess::Configure(cache, cacheRoot, 100),
+			"shader cache recovery storage should initialize");
+		Require(PublishComplete(cache, uid, 0, 46),
+			"the shader generation to recover should publish");
+		cache.SaveCache(true);
+		Require(cache.Contains(uid),
+			"the live cache should contain the published generation before deletion");
+
+		std::error_code removeError;
+		std::filesystem::remove_all(cacheRoot, removeError);
+		Require(!removeError, "the complete shader cache directory should be removable");
+		Require(cache.RecoverMissingStorage(),
+			"runtime recovery should recreate deleted shader cache storage");
+		Require(!cache.Contains(uid) && !cache.IsDirty(),
+			"runtime recovery must drop metadata that points to deleted immutable artifacts");
+		Require(std::filesystem::is_regular_file(ShaderCacheTestAccess::GetCachePath(cache)) &&
+			std::filesystem::is_directory(cacheRoot / "PrecompiledShaders") &&
+			std::filesystem::is_directory(cacheRoot / "CompiledShaders") &&
+			std::filesystem::is_directory(cacheRoot / "CompiledShadersWithDebug"),
+			"runtime recovery should recreate the cache envelope and all owned directories");
+	}
+
 	void TestSameSizeChecksumCorruptionAndClearExpiredTransaction()
 	{
 		TempDirectory directory;
@@ -694,6 +759,36 @@ namespace
 
 	void TestShaderCompilerFailureLifecycle()
 	{
+		const FileId parsedOnly = MakeFileId("{SHADER-DEPENDENCY-PARSED}");
+		const FileId shared = MakeFileId("{SHADER-DEPENDENCY-SHARED}");
+		const FileId loadedOnly = MakeFileId("{SHADER-DEPENDENCY-LOADED}");
+		const TVector<FileId> dependencyCandidates =
+			ShaderCompilerTestAccess::MergeShaderDependencyCandidates(
+				{ parsedOnly, shared },
+				{ shared, loadedOnly });
+		Require(
+			dependencyCandidates.Num() == 3 &&
+			dependencyCandidates.Contains(parsedOnly) &&
+			dependencyCandidates.Contains(shared) &&
+			dependencyCandidates.Contains(loadedOnly),
+			"GLSL dependency propagation should merge parsed and loaded shader ids without duplicates");
+		Require(
+			ShaderCompilerTestAccess::NormalizeShaderExtension("Shaders/Upper.SHADER") == "shader" &&
+			ShaderCompilerTestAccess::NormalizeShaderExtension("Shaders/Upper.GLSL") == "glsl",
+			"shader hot reload should match registered extensions case-insensitively");
+		Require(
+			ShaderCompilerTestAccess::DoesShaderIncludePath(
+				{ "Shaders/Shared/Common.glsl" },
+				"Shaders/Shared/./Common.glsl"),
+			"shader dependency matching should normalize virtual paths");
+#if defined(_WIN32)
+		Require(
+			ShaderCompilerTestAccess::DoesShaderIncludePath(
+				{ "Shaders\\Shared\\Common.GLSL" },
+				"shaders/SHARED/common.glsl"),
+			"Windows shader dependency matching should normalize separators and path case");
+#endif
+
 		const bool allSucceeded[] = { true, true, true };
 		const bool oneFailed[] = { true, false, true };
 		Require(
@@ -899,6 +994,8 @@ int main()
 		TestDebugArtifactsAreRequired();
 		TestFailedGenerationPreservesDurableGeneration();
 		TestRemoveCommitsBeforeGarbageCollection();
+		TestExplicitInvalidationSurvivesSameTimestampReload();
+		TestMissingStorageRecoveryDropsStaleArtifactReferences();
 		TestSameSizeChecksumCorruptionAndClearExpiredTransaction();
 		TestIoFailureQuarantineIsReadOnlyAndSessionOnly();
 		TestRuntimeArtifactIoFailureEntersReadOnlyQuarantine();


### PR DESCRIPTION
## Summary

- restore the original asset callback contract: a new raw asset receives `OnUpdateAssetInfo(..., false)` followed by `OnImportAsset`, while an existing raw or metadata change receives only `OnUpdateAssetInfo(..., true)`
- keep the `asset-cache-v1` contract and persist the successful raw import and metadata load watermarks as `assetImportTime` and `metadataLoadTime`
- rebuild `AssetCache.yaml` transactionally across Engine Content and Workspace Content, discover new raw files, prune deleted assets, and preserve the previous generation on malformed or concurrently edited metadata
- create new `.asset` sidecars exclusively and remove them during rollback only while their bytes still match the file created by that import, so dirty workspace edits are never overwritten
- route F5, the `scan` command, and macOS Cmd+R through one engine-thread reload path
- invalidate and reload changed `.shader` files and their `.glsl` dependencies, including loaded permutations and case-normalized paths
- recover a deleted live `Cache` directory, including `AssetCache.yaml`, `ShaderCache.yaml`, shader directories, and rebuilt immutable SPIR-V artifacts
- remove `SAILOR_ASSET_REGISTRY_TEST_HOOKS`; regression coverage uses public behavior

## Root cause

Recent asset discovery changes mixed filesystem observations with successful processing watermarks. A scan could acknowledge a raw or metadata timestamp before importers had processed it, skip the historical `bWasExpired` path, miss newly added raw files, or publish a partially changed registry generation. Cache saving also assumed the parent directory still existed, so deleting `Cache` during a running session could not recover all storage.

Shader reload only considered already parsed shader assets and did not explicitly invalidate durable permutations. Cmd+R also did not use the same synchronized engine-thread path as F5.

## User impact

Deleting `Cache` now regenerates the active workspace cache both at startup and during a running session. Raw and `.asset` edits remain detectable between sessions and trigger the importer-specific hot reload path through `bWasExpired=true`. Shader edits recompile and update loaded RHI resources.

New files may be added while the workspace already contains unrelated changes. Engine Content remains read-only, Workspace Content may generate sidecars, and both workspace manifests and legacy/no-workspace launches use the same scan and cache behavior.

## Validation

- Debug C++ build succeeded
- `ctest --test-dir build-mac-vcpkg -C Debug --output-on-failure` — 18/18 passed
- editor contract tests — 362/362 passed
- Debug MAUI editor build succeeded with 0 warnings and 0 errors
- live temporary-workspace matrix verified unchanged reload, raw edit, metadata edit, new raw import, invalid YAML rollback, FileId-change rollback, deletion pruning, and cold cache generation
- live deletion of the complete `Cache` directory recreated both cache envelopes, all shader directories, and recompiled SPIR-V artifacts
- `git diff --check`
