### PR TITLE
Reset remote viewport state across workspace restarts

### DIFF
--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -45,6 +45,32 @@ public sealed class EngineLifecycleTests
     }
 
     [Fact]
+    public void NativeViewportState_IsResetBeforeRendererShutdown()
+    {
+        var appSource = ReadRepositoryFile("Runtime", "Sailor.cpp");
+        var bridgeSource = ReadRepositoryFile("Runtime", "Editor", "EditorRuntimeBridge.cpp");
+
+        var initialize = appSource.IndexOf("void App::Initialize(", StringComparison.Ordinal);
+        var initializeReset = appSource.IndexOf("EditorRuntime::ResetForAppLifecycle();", initialize, StringComparison.Ordinal);
+        var instanceCreation = appSource.IndexOf("s_pInstance = new App();", initialize, StringComparison.Ordinal);
+        var shutdown = appSource.IndexOf("void App::Shutdown()", StringComparison.Ordinal);
+        var reset = appSource.IndexOf("EditorRuntime::ResetForAppLifecycle();", shutdown, StringComparison.Ordinal);
+        var rendererShutdown = appSource.IndexOf("renderer->BeginConditionalDestroy();", shutdown, StringComparison.Ordinal);
+        Assert.True(initialize >= 0);
+        Assert.True(initializeReset > initialize);
+        Assert.True(instanceCreation > initializeReset);
+        Assert.True(shutdown >= 0);
+        Assert.True(reset > shutdown);
+        Assert.True(rendererShutdown > reset);
+
+        Assert.Contains("g_remoteViewportBindings.Clear();", bridgeSource, StringComparison.Ordinal);
+        Assert.Contains("g_pendingEditorViewport = {};", bridgeSource, StringComparison.Ordinal);
+        Assert.Contains("g_appliedEditorRenderArea = { 0, 0 };", bridgeSource, StringComparison.Ordinal);
+        Assert.Contains("g_editorRemoteViewportRenderArea = { 0, 0 };", bridgeSource, StringComparison.Ordinal);
+        Assert.Contains("g_hasPendingEditorViewport = false;", bridgeSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void WorkspaceCacheIdentity_IsAvailableOnBothExportSurfacesAndManagedInterop()
     {
         var managedSource = ReadRepositoryFile("Editor", "Services", "EngineService.cs");

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -19,6 +19,73 @@ public sealed class EngineLifecycleTests
     }
 
     [Fact]
+    public void NativeLifecycle_CreatesAndDestroysPlatformWindowsInsideMainThreadInteropLock()
+    {
+        var source = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
+
+        var start = source.IndexOf("public async Task StartAsync(", StringComparison.Ordinal);
+        var initialize = source.IndexOf("EngineAppInterop.Initialize(args, args.Length);", start, StringComparison.Ordinal);
+        var initializeDispatch = source.LastIndexOf("await MainThread.InvokeOnMainThreadAsync", initialize, StringComparison.Ordinal);
+        var initializeLock = source.LastIndexOf("lock (interopLock)", initialize, StringComparison.Ordinal);
+        Assert.True(start >= 0);
+        Assert.True(initializeDispatch > start);
+        Assert.True(initializeLock > initializeDispatch);
+        Assert.True(initialize > initializeLock);
+
+        var complete = source.IndexOf("async Task CompleteSessionAsync", StringComparison.Ordinal);
+        var completeShutdown = source.IndexOf("await ShutdownNativeSessionAsync(", complete, StringComparison.Ordinal);
+        Assert.True(complete >= 0);
+        Assert.True(completeShutdown > complete);
+
+        var failedStart = source.IndexOf("async Task ShutdownNativeAfterFailedStartAsync", StringComparison.Ordinal);
+        var failedStartShutdown = source.IndexOf("await ShutdownNativeSessionAsync(", failedStart, StringComparison.Ordinal);
+        Assert.True(failedStart >= 0);
+        Assert.True(failedStartShutdown > failedStart);
+
+        var dispatchHelper = source.IndexOf("Task<Exception?> ShutdownNativeSessionAsync", StringComparison.Ordinal);
+        var shutdownDispatch = source.IndexOf("return MainThread.InvokeOnMainThreadAsync", dispatchHelper, StringComparison.Ordinal);
+        var shutdownDispatchCall = source.IndexOf("ShutdownNativeSessionUnderLock", shutdownDispatch, StringComparison.Ordinal);
+        var lockedHelper = source.IndexOf("Exception? ShutdownNativeSessionUnderLock", shutdownDispatchCall, StringComparison.Ordinal);
+        var shutdownLock = source.IndexOf("lock (interopLock)", lockedHelper, StringComparison.Ordinal);
+        var nativeShutdown = source.IndexOf("EngineAppInterop.Shutdown();", shutdownLock, StringComparison.Ordinal);
+        Assert.True(dispatchHelper >= 0);
+        Assert.True(shutdownDispatch > dispatchHelper);
+        Assert.True(shutdownDispatchCall > shutdownDispatch);
+        Assert.True(lockedHelper > shutdownDispatchCall);
+        Assert.True(shutdownLock > lockedHelper);
+        Assert.True(nativeShutdown > shutdownLock);
+    }
+
+    [Fact]
+    public void MacHostBinding_IsAcknowledgedPerGenerationAndRetriedUntilApplied()
+    {
+        var source = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
+        var lifecycleSource = ReadRepositoryFile("Editor", "Scene", "SceneViewportLifecycle.cs");
+
+        Assert.Contains("Dictionary<ulong, (long Generation, nint Handle)> appliedMacRemoteViewportHosts", source, StringComparison.Ordinal);
+
+        var bind = source.IndexOf("public void BindMacRemoteViewportHost", StringComparison.Ordinal);
+        var generation = source.IndexOf("Volatile.Read(ref engineGeneration)", bind, StringComparison.Ordinal);
+        var runningGuard = source.IndexOf("if (!IsInteropRunningUnderLock())", generation, StringComparison.Ordinal);
+        var removeWhileStopped = source.IndexOf("appliedMacRemoteViewportHosts.Remove(viewportId);", runningGuard, StringComparison.Ordinal);
+        var nativeBind = source.IndexOf("EngineAppInterop.SetRemoteViewportMacHostHandle", removeWhileStopped, StringComparison.Ordinal);
+        var acknowledge = source.IndexOf("appliedMacRemoteViewportHosts[viewportId] = (generation, hostHandle);", nativeBind, StringComparison.Ordinal);
+        Assert.True(bind >= 0);
+        Assert.True(generation > bind);
+        Assert.True(runningGuard > generation);
+        Assert.True(removeWhileStopped > runningGuard);
+        Assert.True(nativeBind > removeWhileStopped);
+        Assert.True(acknowledge > nativeBind);
+
+        var sync = lifecycleSource.IndexOf("public bool Sync", StringComparison.Ordinal);
+        var announceHost = lifecycleSource.IndexOf("backend.BindMacHost(viewportId, frame.NativeHostHandle);", sync, StringComparison.Ordinal);
+        var updateViewport = lifecycleSource.IndexOf("backend.TryUpdateViewport", announceHost, StringComparison.Ordinal);
+        Assert.True(sync >= 0);
+        Assert.True(announceHost > sync);
+        Assert.True(updateViewport > announceHost);
+    }
+
+    [Fact]
     public void DeferredPublications_AreRejectedAfterGenerationChanges()
     {
         var source = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
@@ -64,10 +131,112 @@ public sealed class EngineLifecycleTests
         Assert.True(rendererShutdown > reset);
 
         Assert.Contains("g_remoteViewportBindings.Clear();", bridgeSource, StringComparison.Ordinal);
+        Assert.Contains("Win32::GlobalInput::Reset();", bridgeSource, StringComparison.Ordinal);
+        Assert.Contains("g_pendingRemoteViewportHostHandles.Clear();", bridgeSource, StringComparison.Ordinal);
         Assert.Contains("g_pendingEditorViewport = {};", bridgeSource, StringComparison.Ordinal);
         Assert.Contains("g_appliedEditorRenderArea = { 0, 0 };", bridgeSource, StringComparison.Ordinal);
         Assert.Contains("g_editorRemoteViewportRenderArea = { 0, 0 };", bridgeSource, StringComparison.Ordinal);
         Assert.Contains("g_hasPendingEditorViewport = false;", bridgeSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MacNativeWindow_TeardownReusesEditorSurfaceAndClosesStandalone()
+    {
+        var header = ReadRepositoryFile("Runtime", "Platform", "Win32", "Window.h");
+        var source = ReadRepositoryFile("Runtime", "Platform", "Mac", "Window.mm");
+
+        Assert.Contains("SAILOR_API ~Window() override;", header, StringComparison.Ordinal);
+
+        var destructor = source.IndexOf("Window::~Window()", StringComparison.Ordinal);
+        var destructorCleanup = source.IndexOf("Destroy();", destructor, StringComparison.Ordinal);
+        Assert.True(destructor >= 0);
+        Assert.True(destructorCleanup > destructor);
+
+        var create = source.IndexOf("bool Window::Create(", StringComparison.Ordinal);
+        var acquireReusable = source.IndexOf(
+            "NSWindow* window = bRunsInsideEditor ? sReusableEditorRenderingWindow : nil;",
+            create,
+            StringComparison.Ordinal);
+        var clearReusable = source.IndexOf(
+            "sReusableEditorRenderingWindow = nil;",
+            acquireReusable,
+            StringComparison.Ordinal);
+        Assert.True(create >= 0);
+        Assert.True(acquireReusable > create);
+        Assert.True(clearReusable > acquireReusable);
+
+        var destroy = source.IndexOf("void Window::Destroy()", StringComparison.Ordinal);
+        var mainThreadCheck = source.IndexOf("if (![NSThread isMainThread])", destroy, StringComparison.Ordinal);
+        var mainThreadDispatch = source.IndexOf("dispatch_sync(dispatch_get_main_queue()", mainThreadCheck, StringComparison.Ordinal);
+        var clearHandle = source.IndexOf("m_hWnd = nullptr;", destroy, StringComparison.Ordinal);
+        var unregister = source.IndexOf("g_windows.Remove(this);", destroy, StringComparison.Ordinal);
+        var clearDelegateTarget = source.IndexOf("delegate.sailorWindow = nullptr;", destroy, StringComparison.Ordinal);
+        var detachDelegate = source.IndexOf("window.delegate = nil;", destroy, StringComparison.Ordinal);
+        var clearAssociation = source.IndexOf("objc_setAssociatedObject(window, sSailorWindowDelegateKey, nil", destroy, StringComparison.Ordinal);
+        var close = source.IndexOf("[window close];", destroy, StringComparison.Ordinal);
+        var standaloneRelease = source.IndexOf("[window release];", close, StringComparison.Ordinal);
+        var orderOut = source.IndexOf("[window orderOut:nil];", standaloneRelease, StringComparison.Ordinal);
+        var preserveReusable = source.IndexOf(
+            "sReusableEditorRenderingWindow = window;",
+            orderOut,
+            StringComparison.Ordinal);
+        var nativeCloseHandler = source.IndexOf("void Window::HandleNativeWindowWillClose", destroy, StringComparison.Ordinal);
+
+        Assert.True(destroy >= 0);
+        Assert.True(mainThreadCheck > destroy);
+        Assert.True(mainThreadDispatch > mainThreadCheck);
+        Assert.True(clearHandle > mainThreadDispatch);
+        Assert.True(unregister > mainThreadDispatch);
+        Assert.True(clearDelegateTarget > destroy);
+        Assert.True(detachDelegate > clearDelegateTarget);
+        Assert.True(clearAssociation > detachDelegate);
+        Assert.True(close > clearHandle);
+        Assert.True(close > unregister);
+        Assert.True(close > clearAssociation);
+        Assert.True(standaloneRelease > close);
+        Assert.True(orderOut > standaloneRelease);
+        Assert.True(preserveReusable > orderOut);
+        Assert.True(nativeCloseHandler > preserveReusable);
+        Assert.DoesNotContain(
+            "[window release];",
+            source[orderOut..nativeCloseHandler],
+            StringComparison.Ordinal);
+        Assert.Contains("delegate.terminateApplicationOnClose = !bRunsInsideEditor;", source, StringComparison.Ordinal);
+        Assert.Contains("if (bTerminateApplicationOnClose)", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Win32NativeWindow_TeardownOwnsClassAndDetachesBeforeDestroyCallbacks()
+    {
+        var header = ReadRepositoryFile("Runtime", "Platform", "Win32", "Window.h");
+        var source = ReadRepositoryFile("Runtime", "Platform", "Win32", "Window.cpp");
+
+        Assert.Contains("ATOM m_windowClassAtom = 0;", header, StringComparison.Ordinal);
+        Assert.Contains("m_windowClassAtom = RegisterClassEx(&wcx);", source, StringComparison.Ordinal);
+
+        var destructor = source.IndexOf("Window::~Window()", StringComparison.Ordinal);
+        var destructorCleanup = source.IndexOf("Destroy();", destructor, StringComparison.Ordinal);
+        var destroy = source.IndexOf("void Window::Destroy()", StringComparison.Ordinal);
+        var ownerThreadCheck = source.IndexOf("GetWindowThreadProcessId", destroy, StringComparison.Ordinal);
+        var clearHandle = source.IndexOf("m_hWnd = nullptr;", destroy, StringComparison.Ordinal);
+        var unregisterWindow = source.IndexOf("g_windows.Remove(this);", destroy, StringComparison.Ordinal);
+        var nativeDestroy = source.IndexOf("DestroyWindow(hWnd)", destroy, StringComparison.Ordinal);
+        var unregisterClass = source.IndexOf("UnregisterClass(MAKEINTATOM(windowClassAtom)", nativeDestroy, StringComparison.Ordinal);
+        Assert.True(destructor >= 0);
+        Assert.True(destructorCleanup > destructor);
+        Assert.True(destroy >= 0);
+        Assert.True(ownerThreadCheck > destroy);
+        Assert.True(clearHandle > ownerThreadCheck);
+        Assert.True(unregisterWindow > clearHandle);
+        Assert.True(nativeDestroy > unregisterWindow);
+        Assert.True(unregisterClass > nativeDestroy);
+
+        var windowProc = source.IndexOf("LRESULT CALLBACK Sailor::Win32::WindowProc", StringComparison.Ordinal);
+        var nullGuard = source.IndexOf("if (!pWindow)", windowProc, StringComparison.Ordinal);
+        var defaultDispatch = source.IndexOf("return DefWindowProc(hWnd, msg, wParam, lParam);", nullGuard, StringComparison.Ordinal);
+        Assert.True(windowProc >= 0);
+        Assert.True(nullGuard > windowProc);
+        Assert.True(defaultDispatch > nullGuard);
     }
 
     [Fact]

--- a/Editor.Tests/SceneViewportLifecycleTests.cs
+++ b/Editor.Tests/SceneViewportLifecycleTests.cs
@@ -30,7 +30,7 @@ public sealed class SceneViewportLifecycleTests
     }
 
     [Fact]
-    public void Sync_DoesNotReapplyStableRenderTargetOrHostBinding()
+    public void Sync_ReannouncesStableHostBeforeUpdate_ButDoesNotReapplyStableRenderTarget()
     {
         var backend = new FakeSceneViewportBackend();
         var sut = new SceneViewportLifecycleAdapter(backend, 7);
@@ -39,9 +39,55 @@ public sealed class SceneViewportLifecycleTests
         sut.Sync(frame);
         sut.Sync(frame);
 
-        Assert.Equal(1, backend.BindCount);
+        Assert.Equal(2, backend.BindCount);
         Assert.Equal(1, backend.RenderTargetSetCount);
         Assert.Equal(2, backend.UpdatedViewportIds.Count);
+        Assert.Equal(["bind:42", "update", "bind:42", "update"], backend.Operations);
+    }
+
+    [Fact]
+    public void Sync_ClearsObservedHost_WhenFrameNoLongerProvidesOne()
+    {
+        var backend = new FakeSceneViewportBackend();
+        var sut = new SceneViewportLifecycleAdapter(backend, 7);
+
+        sut.Sync(new SceneViewportFrame(
+            new SceneViewportRect(0, 0, 640, 480),
+            new SceneViewportRect(0, 0, 640, 480),
+            default,
+            true,
+            false,
+            (nint)42));
+        sut.Sync(new SceneViewportFrame(
+            new SceneViewportRect(0, 0, 640, 480),
+            new SceneViewportRect(0, 0, 640, 480),
+            default,
+            true,
+            false));
+
+        Assert.Equal([(nint)42, nint.Zero], backend.BoundHostHandles);
+    }
+
+    [Fact]
+    public void Destroy_UnbindsObservedHostBeforeDestroyingViewport_AndRemainsIdempotent()
+    {
+        var backend = new FakeSceneViewportBackend();
+        var sut = new SceneViewportLifecycleAdapter(backend, 7);
+
+        sut.Sync(new SceneViewportFrame(
+            new SceneViewportRect(0, 0, 640, 480),
+            new SceneViewportRect(0, 0, 640, 480),
+            default,
+            true,
+            false,
+            (nint)42));
+
+        sut.Destroy();
+        sut.Destroy();
+
+        Assert.Equal([(nint)42, nint.Zero], backend.BoundHostHandles);
+        Assert.Equal(1, backend.DestroyCount);
+        Assert.Equal(["bind:42", "update", "bind:0", "destroy"], backend.Operations);
     }
 
     [Fact]
@@ -98,21 +144,27 @@ public sealed class SceneViewportLifecycleTests
         public ulong BoundViewportId { get; private set; }
         public nint BoundHostHandle { get; private set; }
         public int BindCount { get; private set; }
+        public List<nint> BoundHostHandles { get; } = [];
         public SceneViewportRect LastEditorViewport { get; private set; }
         public SceneViewportRenderTarget LastRenderTarget { get; private set; }
         public int RenderTargetSetCount { get; private set; }
+        public int DestroyCount { get; private set; }
         public List<ulong> UpdatedViewportIds { get; } = [];
+        public List<string> Operations { get; } = [];
 
         public void BindMacHost(ulong viewportId, nint hostHandle)
         {
             BoundViewportId = viewportId;
             BoundHostHandle = hostHandle;
             BindCount++;
+            BoundHostHandles.Add(hostHandle);
+            Operations.Add($"bind:{hostHandle}");
         }
 
         public bool TryUpdateViewport(ulong viewportId, SceneViewportRect rect, bool visible, bool focused)
         {
             UpdatedViewportIds.Add(viewportId);
+            Operations.Add("update");
             return true;
         }
 
@@ -124,7 +176,11 @@ public sealed class SceneViewportLifecycleTests
             RenderTargetSetCount++;
         }
 
-        public void DestroyViewport(ulong viewportId) { }
+        public void DestroyViewport(ulong viewportId)
+        {
+            DestroyCount++;
+            Operations.Add("destroy");
+        }
         public void RetryViewport(ulong viewportId) { }
         public RemoteViewportSessionState GetViewportState(ulong viewportId) => RemoteViewportSessionState.Active;
         public string GetViewportDiagnostics(ulong viewportId) => string.Empty;

--- a/Editor/Scene/SceneViewportLifecycle.cs
+++ b/Editor/Scene/SceneViewportLifecycle.cs
@@ -52,7 +52,7 @@ public interface ISceneViewportBackend
 
 public sealed class SceneViewportLifecycleAdapter(ISceneViewportBackend backend, ulong viewportId)
 {
-    nint _boundHostHandle;
+    nint _observedHostHandle;
     SceneViewportRenderTarget _renderTarget;
     bool _destroyed;
 
@@ -60,10 +60,15 @@ public sealed class SceneViewportLifecycleAdapter(ISceneViewportBackend backend,
     {
         _destroyed = false;
 
-        if (frame.HasNativeHost && frame.NativeHostHandle != _boundHostHandle)
+        if (frame.HasNativeHost)
         {
             backend.BindMacHost(viewportId, frame.NativeHostHandle);
-            _boundHostHandle = frame.NativeHostHandle;
+            _observedHostHandle = frame.NativeHostHandle;
+        }
+        else if (_observedHostHandle != 0)
+        {
+            backend.BindMacHost(viewportId, 0);
+            _observedHostHandle = 0;
         }
 
         if (!frame.EditorViewport.IsEmpty)
@@ -88,9 +93,14 @@ public sealed class SceneViewportLifecycleAdapter(ISceneViewportBackend backend,
         if (_destroyed)
             return;
 
+        if (_observedHostHandle != 0)
+        {
+            backend.BindMacHost(viewportId, 0);
+            _observedHostHandle = 0;
+        }
+
         backend.DestroyViewport(viewportId);
         _destroyed = true;
-        _boundHostHandle = 0;
         _renderTarget = default;
     }
 

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -191,6 +191,9 @@ namespace SailorEditor.Services
         int consoleDispatchScheduled = 0;
         int lifecycleState = (int)EngineLifecycleState.Stopped;
         long engineGeneration;
+#if MACCATALYST
+        readonly Dictionary<ulong, (long Generation, nint Handle)> appliedMacRemoteViewportHosts = [];
+#endif
         EngineSession? activeSession;
         EngineLaunchContext? activeLaunchContext;
         int lastExitCode;
@@ -463,16 +466,29 @@ namespace SailorEditor.Services
         public void BindMacRemoteViewportHost(ulong viewportId, nint hostHandle)
         {
 #if MACCATALYST
-            if (hostHandle == nint.Zero || !IsRunning)
-            {
-                return;
-            }
-
             lock (interopLock)
             {
-                if (IsInteropRunningUnderLock())
+                var generation = Volatile.Read(ref engineGeneration);
+                if (!IsInteropRunningUnderLock())
                 {
-                    EngineAppInterop.SetRemoteViewportMacHostHandle(viewportId, 2u, (ulong)hostHandle);
+                    appliedMacRemoteViewportHosts.Remove(viewportId);
+                    return;
+                }
+
+                if (appliedMacRemoteViewportHosts.TryGetValue(viewportId, out var applied) &&
+                    applied.Generation == generation &&
+                    applied.Handle == hostHandle)
+                {
+                    return;
+                }
+
+                if (EngineAppInterop.SetRemoteViewportMacHostHandle(viewportId, 2u, (ulong)hostHandle))
+                {
+                    appliedMacRemoteViewportHosts[viewportId] = (generation, hostHandle);
+                }
+                else
+                {
+                    appliedMacRemoteViewportHosts.Remove(viewportId);
                 }
             }
 #endif
@@ -702,7 +718,7 @@ namespace SailorEditor.Services
                 Console.WriteLine($"Starting SailorEngine interop with workspace: {launchContext.WorkspaceRoot}");
                 Volatile.Write(ref editorTypes, new EngineTypes());
 
-#if MACCATALYST
+#if WINDOWS || MACCATALYST
                 await MainThread.InvokeOnMainThreadAsync(() =>
                 {
                     lock (interopLock)
@@ -882,7 +898,7 @@ namespace SailorEditor.Services
 
                     try
                     {
-                        ShutdownNativeAfterFailedStart();
+                        await ShutdownNativeAfterFailedStartAsync().ConfigureAwait(false);
                     }
                     catch (Exception teardownException)
                     {
@@ -1080,25 +1096,12 @@ namespace SailorEditor.Services
                     failure = CombineFailures(failure, ex);
                 }
 
-                lock (interopLock)
+                var shutdownFailure = await ShutdownNativeSessionAsync(
+                    stopNative: false,
+                    destroyRemoteViewport: true).ConfigureAwait(false);
+                if (shutdownFailure is not null)
                 {
-                    try
-                    {
-                        EngineAppInterop.DestroyRemoteViewport(SceneViewportId);
-                    }
-                    catch (Exception ex)
-                    {
-                        failure = CombineFailures(failure, ex);
-                    }
-
-                    try
-                    {
-                        EngineAppInterop.Shutdown();
-                    }
-                    catch (Exception ex)
-                    {
-                        failure = CombineFailures(failure, ex);
-                    }
+                    failure = CombineFailures(failure, shutdownFailure);
                 }
 
                 if (exitCode == 0 && failure is not null)
@@ -1212,18 +1215,54 @@ namespace SailorEditor.Services
         static Exception CombineFailures(Exception? current, Exception next)
             => current is null ? next : new AggregateException(current, next);
 
-        void ShutdownNativeAfterFailedStart()
+        async Task ShutdownNativeAfterFailedStartAsync()
+        {
+            var failure = await ShutdownNativeSessionAsync(
+                stopNative: true,
+                destroyRemoteViewport: false).ConfigureAwait(false);
+            if (failure is not null)
+            {
+                throw failure;
+            }
+        }
+
+        Task<Exception?> ShutdownNativeSessionAsync(bool stopNative, bool destroyRemoteViewport)
+        {
+#if WINDOWS || MACCATALYST
+            return MainThread.InvokeOnMainThreadAsync(() =>
+                ShutdownNativeSessionUnderLock(stopNative, destroyRemoteViewport));
+#else
+            return Task.FromResult(ShutdownNativeSessionUnderLock(stopNative, destroyRemoteViewport));
+#endif
+        }
+
+        Exception? ShutdownNativeSessionUnderLock(bool stopNative, bool destroyRemoteViewport)
         {
             lock (interopLock)
             {
                 Exception? failure = null;
-                try
+                if (stopNative)
                 {
-                    EngineAppInterop.Stop();
+                    try
+                    {
+                        EngineAppInterop.Stop();
+                    }
+                    catch (Exception ex)
+                    {
+                        failure = ex;
+                    }
                 }
-                catch (Exception ex)
+
+                if (destroyRemoteViewport)
                 {
-                    failure = ex;
+                    try
+                    {
+                        EngineAppInterop.DestroyRemoteViewport(SceneViewportId);
+                    }
+                    catch (Exception ex)
+                    {
+                        failure = failure is null ? ex : new AggregateException(failure, ex);
+                    }
                 }
 
                 try
@@ -1237,8 +1276,10 @@ namespace SailorEditor.Services
                         : new AggregateException(failure, ex);
                 }
 
-                if (failure is not null)
-                    throw failure;
+#if MACCATALYST
+                appliedMacRemoteViewportHosts.Clear();
+#endif
+                return failure;
             }
         }
 

--- a/Runtime/Editor/EditorRuntimeBridge.cpp
+++ b/Runtime/Editor/EditorRuntimeBridge.cpp
@@ -708,6 +708,39 @@ bool Sailor::EditorRuntime::ApplyPendingEditorViewportOnEngineThread()
 	return true;
 }
 
+void Sailor::EditorRuntime::ResetForAppLifecycle()
+{
+	{
+		std::lock_guard bindingsLock(g_remoteViewportBindingsMutex);
+		for (const auto& bindingEntry : g_remoteViewportBindings)
+		{
+			const auto& binding = *bindingEntry.m_second;
+			if (!binding)
+			{
+				continue;
+			}
+
+			std::lock_guard bindingLock(binding->m_mutex);
+			if (binding->m_created)
+			{
+				binding->m_binding.Destroy();
+				binding->m_created = false;
+			}
+		}
+
+		g_remoteViewportBindings.Clear();
+		g_remoteViewportMouseButtons.Clear();
+	}
+
+	{
+		std::lock_guard viewportLock(g_editorViewportMutex);
+		g_pendingEditorViewport = {};
+		g_appliedEditorRenderArea = { 0, 0 };
+		g_editorRemoteViewportRenderArea = { 0, 0 };
+		g_hasPendingEditorViewport = false;
+	}
+}
+
 bool Sailor::EditorRuntime::HasAppliedEditorRenderArea()
 {
 	std::lock_guard lock(g_editorViewportMutex);
@@ -735,6 +768,15 @@ void Sailor::EditorRuntime::PumpEditorRemoteViewportsOnEngineThread()
 		std::lock_guard bindingLock(binding->m_mutex);
 		if (binding && binding->m_created && binding->m_visible)
 		{
+#if defined(__APPLE__)
+			const glm::ivec2 appliedRenderArea = GetAppliedEditorRenderArea();
+			const auto& descriptor = binding->m_binding.GetRuntimeSession().GetDescriptor();
+			if (descriptor.m_width != static_cast<uint32_t>(appliedRenderArea.x) ||
+				descriptor.m_height != static_cast<uint32_t>(appliedRenderArea.y))
+			{
+				continue;
+			}
+#endif
 			binding->Pump();
 		}
 	}

--- a/Runtime/Editor/EditorRuntimeBridge.cpp
+++ b/Runtime/Editor/EditorRuntimeBridge.cpp
@@ -729,8 +729,10 @@ void Sailor::EditorRuntime::ResetForAppLifecycle()
 		}
 
 		g_remoteViewportBindings.Clear();
+		g_pendingRemoteViewportHostHandles.Clear();
 		g_remoteViewportMouseButtons.Clear();
 	}
+	Win32::GlobalInput::Reset();
 
 	{
 		std::lock_guard viewportLock(g_editorViewportMutex);

--- a/Runtime/Editor/EditorRuntimeBridge.h
+++ b/Runtime/Editor/EditorRuntimeBridge.h
@@ -2,6 +2,7 @@
 
 namespace Sailor::EditorRuntime
 {
+	void ResetForAppLifecycle();
 	bool ApplyPendingEditorViewportOnEngineThread();
 	bool HasAppliedEditorRenderArea();
 	void PumpEditorRemoteViewportsOnEngineThread();

--- a/Runtime/Platform/Mac/Window.mm
+++ b/Runtime/Platform/Mac/Window.mm
@@ -18,6 +18,7 @@ using namespace Sailor::Win32;
 namespace
 {
 	constexpr char sSailorWindowDelegateKey[] = "sailor_delegate";
+	NSWindow* sReusableEditorRenderingWindow = nil;
 }
 
 static void SailorDispatchImGuiMacEvent(const ImGuiApi::MacEvent& event)
@@ -66,27 +67,32 @@ static uint32_t SailorMapMacKeyCode(unsigned short keyCode)
 
 @interface SailorWindowDelegate : NSObject<NSWindowDelegate>
 @property(nonatomic, assign) Sailor::Win32::Window* sailorWindow;
+@property(nonatomic, assign) BOOL terminateApplicationOnClose;
 @end
 
 @implementation SailorWindowDelegate
 
 - (void)windowWillClose:(NSNotification*)notification
 {
-	(void)notification;
+	SailorWindowDelegate* retainedSelf = [self retain];
 	Sailor::Win32::Window* sailorWindow = self.sailorWindow;
+	const BOOL bTerminateApplicationOnClose = self.terminateApplicationOnClose;
 	self.sailorWindow = nullptr;
 
 	if (sailorWindow && Sailor::Win32::Window::IsWindowAlive(sailorWindow))
 	{
-		sailorWindow->SetActive(false);
-		sailorWindow->SetRunning(false);
+		NSWindow* window = (NSWindow*)notification.object;
+		sailorWindow->HandleNativeWindowWillClose((HWND)(__bridge void*)window);
 	}
+	[retainedSelf release];
 
-	// On macOS we want app process to exit when the main window is closed.
-	// This avoids a background engine process that requires Force Quit.
-	dispatch_async(dispatch_get_main_queue(), ^{
-		[NSApp terminate:nil];
-	});
+	if (bTerminateApplicationOnClose)
+	{
+		// Standalone applications should exit when their main window closes.
+		dispatch_async(dispatch_get_main_queue(), ^{
+			[NSApp terminate:nil];
+		});
+	}
 }
 
 - (void)windowDidBecomeKey:(NSNotification*)notification
@@ -251,6 +257,11 @@ static uint32_t SailorMapMacKeyCode(unsigned short keyCode)
 
 TVector<Window*> Window::g_windows;
 
+Window::~Window()
+{
+	Destroy();
+}
+
 bool Window::IsParentWindowValid() const
 {
 	if (m_parentHwnd == nullptr)
@@ -319,11 +330,21 @@ bool Window::Create(LPCSTR title, LPCSTR className, int32_t inWidth, int32_t inH
 			NSWindowStyleMaskBorderless;
 
 		NSRect frame = NSMakeRect(0, 0, inWidth, inHeight);
-		NSWindow* window = [[NSWindow alloc] initWithContentRect:frame styleMask:style backing:NSBackingStoreBuffered defer:NO];
+		NSWindow* window = bRunsInsideEditor ? sReusableEditorRenderingWindow : nil;
+		if (window)
+		{
+			sReusableEditorRenderingWindow = nil;
+			[window setContentSize:frame.size];
+		}
+		else
+		{
+			window = [[NSWindow alloc] initWithContentRect:frame styleMask:style backing:NSBackingStoreBuffered defer:NO];
+		}
 		if (!window)
 		{
 			return false;
 		}
+		window.releasedWhenClosed = NO;
 
 		SailorContentView* contentView = [[SailorContentView alloc] initWithFrame:frame];
 		contentView.sailorWindow = this;
@@ -336,11 +357,14 @@ bool Window::Create(LPCSTR title, LPCSTR className, int32_t inWidth, int32_t inH
 		window.title = [NSString stringWithUTF8String:title ? title : "Sailor"];
 		[window makeFirstResponder:contentView];
 		[window center];
+		[contentView release];
 
 		SailorWindowDelegate* delegate = [[SailorWindowDelegate alloc] init];
 		delegate.sailorWindow = this;
+		delegate.terminateApplicationOnClose = !bRunsInsideEditor;
 		window.delegate = delegate;
 		objc_setAssociatedObject(window, sSailorWindowDelegateKey, delegate, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+		[delegate release];
 
 		if (!bRunsInsideEditor)
 		{
@@ -510,20 +534,81 @@ void Window::RecalculateWindowSize()
 
 void Window::Destroy()
 {
+	if (![NSThread isMainThread])
+	{
+		dispatch_sync(dispatch_get_main_queue(), ^
+		{
+			Destroy();
+		});
+		return;
+	}
+
 	NSWindow* window = (__bridge NSWindow*)m_hWnd;
+	m_hWnd = nullptr;
+	g_windows.Remove(this);
+	m_bIsShown = false;
+	m_bIsActive = false;
+	m_bIsRunning = false;
+
 	if (window)
 	{
 		SailorWindowDelegate* delegate = (SailorWindowDelegate*)objc_getAssociatedObject(window, sSailorWindowDelegateKey);
+		const BOOL bTerminateApplicationOnClose = delegate ? delegate.terminateApplicationOnClose : NO;
 		if (delegate)
 		{
 			delegate.sailorWindow = nullptr;
 		}
-		objc_setAssociatedObject(window, sSailorWindowDelegateKey, nil, OBJC_ASSOCIATION_ASSIGN);
-		[window close];
+
+		SailorContentView* contentView = [window.contentView isKindOfClass:[SailorContentView class]] ? (SailorContentView*)window.contentView : nil;
+		if (contentView)
+		{
+			contentView.sailorWindow = nullptr;
+		}
+
+		window.delegate = nil;
+		objc_setAssociatedObject(window, sSailorWindowDelegateKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+		if (bTerminateApplicationOnClose)
+		{
+			[window close];
+			[window release];
+		}
+		else
+		{
+			// Closing or deallocating the last AppKit NSWindow terminates a Catalyst
+			// host. Keep one process-owned hidden surface and reuse it when the
+			// engine is initialized for the next workspace.
+			[window orderOut:nil];
+			sReusableEditorRenderingWindow = window;
+		}
+	}
+}
+
+void Window::HandleNativeWindowWillClose(HWND nativeWindow)
+{
+	NSWindow* window = (__bridge NSWindow*)nativeWindow;
+	if (!window || (__bridge NSWindow*)m_hWnd != window)
+	{
+		return;
 	}
 
 	m_hWnd = nullptr;
 	g_windows.Remove(this);
+	m_bIsShown = false;
+	m_bIsActive = false;
+	m_bIsRunning = false;
+
+	SailorContentView* contentView = [window.contentView isKindOfClass:[SailorContentView class]] ? (SailorContentView*)window.contentView : nil;
+	if (contentView)
+	{
+		contentView.sailorWindow = nullptr;
+	}
+
+	window.delegate = nil;
+	objc_setAssociatedObject(window, sSailorWindowDelegateKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+	dispatch_async(dispatch_get_main_queue(), ^
+	{
+		[window release];
+	});
 }
 
 bool Window::IsWindowAlive(const Window* pWindow)

--- a/Runtime/Platform/Win32/Input.cpp
+++ b/Runtime/Platform/Win32/Input.cpp
@@ -130,3 +130,8 @@ void GlobalInput::SetCursorPosition(int32_t x, int32_t y)
 	m_rawState.m_cursorPosition[0] = x;
 	m_rawState.m_cursorPosition[1] = y;
 }
+
+void GlobalInput::Reset()
+{
+	m_rawState = {};
+}

--- a/Runtime/Platform/Win32/Input.h
+++ b/Runtime/Platform/Win32/Input.h
@@ -48,6 +48,7 @@ namespace Sailor::Win32
 		SAILOR_API static void SetKeyState(uint32_t key, KeyState state);
 		SAILOR_API static void SetMouseButtonState(uint32_t button, KeyState state);
 		SAILOR_API static void SetCursorPosition(int32_t x, int32_t y);
+		SAILOR_API static void Reset();
 
 	protected:
 

--- a/Runtime/Platform/Win32/Window.cpp
+++ b/Runtime/Platform/Win32/Window.cpp
@@ -15,6 +15,11 @@ using namespace Sailor::Win32;
 
 TVector<Window*> Window::g_windows;
 
+Window::~Window()
+{
+	Destroy();
+}
+
 bool Window::IsParentWindowValid() const
 {
 	if (m_parentHwnd == 0)
@@ -103,7 +108,8 @@ bool Window::Create(LPCSTR title, LPCSTR className, int32_t inWidth, int32_t inH
 	wcx.hIcon = LoadIcon(NULL, IDI_APPLICATION);
 	wcx.hCursor = LoadCursor(NULL, IDC_ARROW);
 
-	if (!RegisterClassEx(&wcx))
+	m_windowClassAtom = RegisterClassEx(&wcx);
+	if (m_windowClassAtom == 0)
 	{
 		char message[MAXCHAR];
 		sprintf_s(message, "RegisterClassEx fail (%d)", GetLastError());
@@ -141,6 +147,7 @@ bool Window::Create(LPCSTR title, LPCSTR className, int32_t inWidth, int32_t inH
 	{
 		char message[MAXCHAR];
 		sprintf_s(message, "CreateWindowEx fail (%d)", GetLastError());
+		Destroy();
 		return false;
 	}
 
@@ -150,6 +157,7 @@ bool Window::Create(LPCSTR title, LPCSTR className, int32_t inWidth, int32_t inH
 	{
 		char message[MAXCHAR];
 		sprintf_s(message, "GetDC fail (%d)", GetLastError());
+		Destroy();
 		return false;
 	}
 
@@ -171,6 +179,7 @@ bool Window::Create(LPCSTR title, LPCSTR className, int32_t inWidth, int32_t inH
 	{
 		char message[MAXCHAR];
 		sprintf_s(message, "Setting pixel format fail (%d)", GetLastError());
+		Destroy();
 		return false;
 	}
 
@@ -329,28 +338,55 @@ void Window::RecalculateWindowSize()
 
 void Window::Destroy()
 {
-	if (m_bIsFullscreen)
+	check(!m_hWnd || ::GetWindowThreadProcessId(m_hWnd, nullptr) == ::GetCurrentThreadId());
+
+	HWND hWnd = m_hWnd;
+	HDC hDC = m_hDC;
+	HINSTANCE hInstance = m_hInstance;
+	const ATOM windowClassAtom = m_windowClassAtom;
+	const bool bWasFullscreen = m_bIsFullscreen;
+
+	m_hWnd = nullptr;
+	m_hDC = nullptr;
+	m_hInstance = nullptr;
+	m_parentHwnd = nullptr;
+	m_windowClassAtom = 0;
+	m_bIsShown = false;
+	m_bIsFullscreen = false;
+	m_bIsActive = false;
+	m_bIsRunning = false;
+	m_bIsIconic = false;
+	m_bIsResizing = false;
+	m_bIsVsyncRequested = false;
+	m_width = 0;
+	m_height = 0;
+	m_renderArea = {};
+	m_viewport = {};
+	m_windowClassName.clear();
+	g_windows.Remove(this);
+
+	if (bWasFullscreen)
 	{
 		ChangeDisplaySettings(NULL, CDS_RESET);
 		ShowCursor(TRUE);
 	}
 
-	if (m_hDC)
+	if (hWnd && hDC && ReleaseDC(hWnd, hDC) == 0)
 	{
-		ReleaseDC(m_hWnd, m_hDC);
+		SAILOR_LOG_ERROR("Failed to release window device context. error=%lu", static_cast<unsigned long>(GetLastError()));
 	}
 
-	if (m_hWnd)
+	bool bWindowDestroyed = true;
+	if (hWnd && !DestroyWindow(hWnd))
 	{
-		DestroyWindow(m_hWnd);
+		bWindowDestroyed = false;
+		SAILOR_LOG_ERROR("Failed to destroy Win32 window. error=%lu", static_cast<unsigned long>(GetLastError()));
 	}
 
-	if (m_hInstance)
+	if (windowClassAtom != 0 && hInstance && bWindowDestroyed && !UnregisterClass(MAKEINTATOM(windowClassAtom), hInstance))
 	{
-		UnregisterClass(m_windowClassName.c_str(), m_hInstance);
+		SAILOR_LOG_ERROR("Failed to unregister Win32 window class. error=%lu", static_cast<unsigned long>(GetLastError()));
 	}
-
-	g_windows.Remove(this);
 }
 
 bool Window::IsIconic() const
@@ -367,6 +403,10 @@ LRESULT CALLBACK Sailor::Win32::WindowProc(HWND hWnd, UINT msg, WPARAM wParam, L
 	{
 		pWindow = Window::g_windows[windowIndex];
 	}
+	if (!pWindow)
+	{
+		return DefWindowProc(hWnd, msg, wParam, lParam);
+	}
 
 	if (auto* imGui = App::GetSubmodule<ImGuiApi>())
 	{
@@ -377,13 +417,10 @@ LRESULT CALLBACK Sailor::Win32::WindowProc(HWND hWnd, UINT msg, WPARAM wParam, L
 	{
 	case WM_SIZE:
 	{
-		if (pWindow)
-		{
-			pWindow->SetIsIconic(wParam == SIZE_MINIMIZED);
-			//pWindow->RecalculateWindowSize();
-			pWindow->m_width = LOWORD(lParam);
-			pWindow->m_height = HIWORD(lParam);
-		}
+		pWindow->SetIsIconic(wParam == SIZE_MINIMIZED);
+		//pWindow->RecalculateWindowSize();
+		pWindow->m_width = LOWORD(lParam);
+		pWindow->m_height = HIWORD(lParam);
 
 		return FALSE;
 	}

--- a/Runtime/Platform/Win32/Window.h
+++ b/Runtime/Platform/Win32/Window.h
@@ -76,6 +76,10 @@ namespace Sailor::Win32
 
 		HWND      m_parentHwnd = nullptr;
 
+#if defined(_WIN32)
+		ATOM m_windowClassAtom = 0;
+#endif
+
 		std::atomic<int> m_width = 1024;
 		std::atomic<int> m_height = 768;
 		std::string m_windowClassName;
@@ -93,7 +97,11 @@ namespace Sailor::Win32
 	public:
 
 		SAILOR_API Window() = default;
+#if defined(_WIN32) || defined(__APPLE__)
+		SAILOR_API ~Window() override;
+#else
 		SAILOR_API ~Window() override = default;
+#endif
 
 		SAILOR_API bool IsShown() const override { return m_bIsShown; }
 		SAILOR_API bool IsResizing() const override { return m_bIsResizing; }
@@ -119,6 +127,7 @@ namespace Sailor::Win32
 #if defined(__APPLE__)
 		SAILOR_API void* GetMetalLayer() const override;
 		SAILOR_API void* GetNativeView() const override;
+		SAILOR_API void HandleNativeWindowWillClose(HWND nativeWindow);
 #endif
 
 		SAILOR_API int32_t GetWidth() const override { return m_width; }

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -195,6 +195,8 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 		return;
 	}
 
+	EditorRuntime::ResetForAppLifecycle();
+
 #if defined(_WIN32)
 	timeBeginPeriod(1);
 #endif
@@ -628,6 +630,8 @@ void App::Shutdown()
 	{
 		return;
 	}
+
+	EditorRuntime::ResetForAppLifecycle();
 
 	auto scheduler = GetSubmodule<Tasks::Scheduler>();
 	auto renderer = GetSubmodule<Renderer>();

--- a/Runtime/Submodules/EditorRemote/RemoteViewportMacTransport.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportMacTransport.h
@@ -378,7 +378,15 @@ namespace Sailor::EditorRemote
 					(rendererSource.m_width != state.m_nativeAllocation->m_plane.m_width ||
 					rendererSource.m_height != state.m_nativeAllocation->m_plane.m_height))
 				{
-					m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 1005, "macOS renderer source extents do not match the current IOSurface");
+					std::ostringstream message;
+					message << "macOS renderer source extents do not match the current IOSurface"
+						<< ": source=" << rendererSource.m_width << "x" << rendererSource.m_height
+						<< " surface=" << state.m_nativeAllocation->m_plane.m_width << "x" << state.m_nativeAllocation->m_plane.m_height
+						<< " viewport=" << state.m_key.m_viewportId
+						<< " epoch=" << state.m_key.m_epoch
+						<< " generation=" << state.m_key.m_generation
+						<< " sourceName='" << rendererSource.m_debugName << "'";
+					m_lastFailure = Failure::FromDomain(ErrorDomain::Session, 1005, message.str());
 					return m_lastFailure;
 				}
 

--- a/Tests/RemoteViewportMacTransportTests.cpp
+++ b/Tests/RemoteViewportMacTransportTests.cpp
@@ -432,6 +432,48 @@ namespace
 		Require(backend.ReleaseSurface(viewport.m_viewportId, 32, 1).IsOk(), "provider should still release surfaces after metadata-backed begin frame");
 	}
 
+	void TestRendererExtentMismatchRemainsADiagnosticInvariant()
+	{
+		FakeMacRendererFrameSourceProvider sourceProvider{};
+		sourceProvider.m_nextSource.m_kind = MacRendererFrameSourceKind::RendererOwnedRenderTargetMetadata;
+		sourceProvider.m_nextSource.m_sourceToken = 0x1010ull;
+		sourceProvider.m_nextSource.m_width = 2;
+		sourceProvider.m_nextSource.m_height = 2;
+		sourceProvider.m_nextSource.m_bytesPerRow = 2 * 4;
+		sourceProvider.m_nextSource.m_pixelFormat = PixelFormat::B8G8R8A8_UNorm;
+		sourceProvider.m_nextSource.m_cpuBytes = Sailor::TSharedPtr<std::vector<uint8_t>>::Make(2 * 2 * 4, 0x7f);
+		sourceProvider.m_nextSource.m_debugName = "Renderer.SceneView.EditorReadback";
+
+		MacLoopbackIOSurfaceProvider provider{ &sourceProvider };
+		MacViewportTransportBackend backend{ provider };
+		auto viewport = MakeViewport(84, 4, 2);
+		TransportDescriptor transport{};
+		Require(backend.EnsureSurface(viewport, 35, 1, transport).IsOk(), "extent invariant test should create the current IOSurface");
+		const Failure mismatch = backend.BeginFrame(viewport, 35, 1);
+		Require(!mismatch.IsOk() && mismatch.m_code == ResultCode::Retryable && mismatch.m_scope == FailureScope::Session,
+			"a renderer extent mismatch should remain a retryable session diagnostic");
+		Require(mismatch.m_nativeCode == 1005,
+			"a renderer extent mismatch should retain its stable native diagnostic code");
+		Require(mismatch.m_message.find("source=2x2") != std::string::npos && mismatch.m_message.find("surface=4x2") != std::string::npos,
+			"the extent diagnostic should include both renderer and IOSurface sizes");
+
+		sourceProvider.m_nextSource.m_sourceToken = 0x2020ull;
+		sourceProvider.m_nextSource.m_width = viewport.m_width;
+		sourceProvider.m_nextSource.m_height = viewport.m_height;
+		sourceProvider.m_nextSource.m_bytesPerRow = viewport.m_width * 4;
+		sourceProvider.m_nextSource.m_cpuBytes = Sailor::TSharedPtr<std::vector<uint8_t>>::Make(viewport.m_width * viewport.m_height * 4, 0x3f);
+		Require(backend.BeginFrame(viewport, 35, 1).IsOk(), "the renderer source should resume once its extents match the IOSurface");
+
+		const MacViewportSurfaceKey key{ viewport.m_viewportId, 35, 1 };
+		const auto* allocation = provider.FindAllocation(key);
+		Require(allocation != nullptr && allocation->m_lastRendererSource.m_kind == MacRendererFrameSourceKind::RendererOwnedRenderTargetMetadata,
+			"the provider should record the real renderer source after resize synchronization");
+		Require(allocation != nullptr && allocation->m_lastRendererTextureToken == 0x2020ull,
+			"the synchronized renderer frame should restore real-source provenance");
+
+		Require(backend.ReleaseSurface(viewport.m_viewportId, 35, 1).IsOk(), "extent invariant test should release its IOSurface");
+	}
+
 #if defined(__APPLE__)
 	void TestMacProducerCpuUploadWritesIOSurface()
 	{
@@ -627,6 +669,7 @@ int main()
 		{ "MacExportCarriesCrossApiSyncMetadataFromRendererSource", TestMacExportCarriesCrossApiSyncMetadataFromRendererSource },
 #endif
 		{ "ConcreteMacLoopbackProviderRecordsRendererOwnedSourceMetadata", TestConcreteMacLoopbackProviderRecordsRendererOwnedSourceMetadata },
+		{ "RendererExtentMismatchRemainsADiagnosticInvariant", TestRendererExtentMismatchRemainsADiagnosticInvariant },
 		{ "ConcreteMacLoopbackProviderAndPresenterCarryNativeMetadata", TestConcreteMacLoopbackProviderAndPresenterCarryNativeMetadata },
 	};
 

--- a/Tests/RemoteViewportRuntimeTests.cpp
+++ b/Tests/RemoteViewportRuntimeTests.cpp
@@ -5,6 +5,7 @@
 #include <utility>
 #include <vector>
 
+#include "Platform/Win32/Input.h"
 #include "Submodules/EditorRemote/RemoteViewportRuntime.h"
 
 using namespace Sailor::EditorRemote;
@@ -509,6 +510,23 @@ namespace
 		Require(session.GetLastPublishedFrameIndex() == 1, "each recreate loop should reset frame indexing for the new epoch");
 	}
 
+	void TestGlobalInputResetClearsLifecycleState()
+	{
+		using Sailor::Win32::GlobalInput;
+		using Sailor::Win32::KeyState;
+
+		GlobalInput::SetKeyState('W', KeyState::Pressed);
+		GlobalInput::SetMouseButtonState(0, KeyState::Pressed);
+		GlobalInput::SetCursorPosition(320, 240);
+
+		GlobalInput::Reset();
+		const auto& state = GlobalInput::GetInputState();
+		Require(!state.IsKeyDown('W'), "lifecycle reset should release keyboard input");
+		Require(!state.IsButtonDown(0), "lifecycle reset should release mouse input");
+		const glm::ivec2 cursor = state.GetCursorPos();
+		Require(cursor.x == 0 && cursor.y == 0, "lifecycle reset should clear the stale cursor position");
+	}
+
 }
 
 int main()
@@ -526,6 +544,7 @@ int main()
 		{ "RemoteViewportReconnectTimeoutBackoffAndDiagnostics", TestRemoteViewportReconnectTimeoutBackoffAndDiagnostics },
 		{ "RemoteViewportFrameFloodKeepsLatestFrameAndStableCounters", TestRemoteViewportFrameFloodKeepsLatestFrameAndStableCounters },
 		{ "RemoteViewportDisconnectRecreateLoopResetsEpochGenerationAndState", TestRemoteViewportDisconnectRecreateLoopResetsEpochGenerationAndState },
+		{ "GlobalInputResetClearsLifecycleState", TestGlobalInputResetClearsLifecycleState },
 	};
 
 	for (const auto& test : tests)


### PR DESCRIPTION
## Summary

- reset remote viewport bindings, pending host handles, render sizes, and input state for every engine lifecycle
- rebind Mac viewport hosts per engine generation and marshal native window creation and teardown through the UI thread
- harden Win32 and macOS native window ownership, while reusing the hidden Catalyst rendering surface across workspace restarts
- reject mismatched IOSurface source extents before presentation and keep detailed native diagnostics

## Validation

- dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --no-restore: 368/368 passed
- ctest --test-dir build-mac-vcpkg -C Debug --output-on-failure: 18/18 passed
- python3 run_editor.py --config Debug --no-launch: build and bundle sync passed
- live Mac Catalyst smoke: two consecutive engine restarts restored Remote viewport active without native 1005, the editor process remained alive, and final quit exited cleanly with code 0

The unrelated local Content/Experimental/MeshParticles/Particle.gltf.asset change is not included.