### PR TITLE
Refine editor scene controls and prefab workflows

### DIFF
--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -25,6 +25,7 @@
     <Compile Include="GlobalUsings.cs" />
     <Compile Include="CommandContractsTests.cs" />
     <Compile Include="HistoryContractsTests.cs" />
+    <Compile Include="HierarchyMutationRecoveryPolicyTests.cs" />
     <Compile Include="LayoutContractsTests.cs" />
     <Compile Include="LayoutOperationsTests.cs" />
     <Compile Include="PanelContractsTests.cs" />
@@ -56,6 +57,7 @@
     <Compile Include="UnifiedSettingsStoreTests.cs" />
     <Compile Include="WorkflowProjectionTests.cs" />
     <Compile Include="SceneViewportLifecycleTests.cs" />
+    <Compile Include="SceneViewportInteractionTests.cs" />
     <Compile Include="SceneSelectionRoutingTests.cs" />
     <Compile Include="NativeViewportInputQueueTests.cs" />
     <Compile Include="EditorViewportEventContractTests.cs" />
@@ -91,6 +93,7 @@
     <Compile Include="..\Editor\Layout\LayoutContracts.cs" Link="Layout\LayoutContracts.cs" />
     <Compile Include="..\Editor\Layout\LayoutOperations.cs" Link="Layout\LayoutOperations.cs" />
     <Compile Include="..\Editor\Commands\CommandContracts.cs" Link="Commands\CommandContracts.cs" />
+    <Compile Include="..\Editor\Commands\HierarchyMutationRecovery.cs" Link="Commands\HierarchyMutationRecovery.cs" />
     <Compile Include="..\Editor\History\HistoryContracts.cs" Link="History\HistoryContracts.cs" />
     <Compile Include="..\Editor\Settings\SettingsContracts.cs" Link="Settings\SettingsContracts.cs" />
     <Compile Include="..\Editor\Settings\UnifiedSettingsStore.cs" Link="Settings\UnifiedSettingsStore.cs" />
@@ -127,6 +130,9 @@
     <Compile Include="..\Editor\Scene\SceneSelectionRouting.cs" Link="Scene\SceneSelectionRouting.cs" />
     <Compile Include="..\Editor\Scene\NativeViewportInputQueue.cs" Link="Scene\NativeViewportInputQueue.cs" />
     <Compile Include="..\Editor\Scene\EditorViewportEventContract.cs" Link="Scene\EditorViewportEventContract.cs" />
+    <Compile Include="..\Editor\Scene\SceneViewportDropCoordinates.cs" Link="Scene\SceneViewportDropCoordinates.cs" />
+    <Compile Include="..\Editor\Scene\SceneViewportAssetDropPayload.cs" Link="Scene\SceneViewportAssetDropPayload.cs" />
+    <Compile Include="..\Editor\Scene\SceneViewportToolState.cs" Link="Scene\SceneViewportToolState.cs" />
     <Compile Include="..\Editor\Commands\AlreadyAppliedTransformCommand.cs" Link="Commands\AlreadyAppliedTransformCommand.cs" />
     <Compile Include="..\Editor\AI\AIContracts.cs" Link="AI\AIContracts.cs" />
     <Compile Include="..\Editor\AI\AIOperatorService.cs" Link="AI\AIOperatorService.cs" />

--- a/Editor.Tests/EditorDragDropRoutingTests.cs
+++ b/Editor.Tests/EditorDragDropRoutingTests.cs
@@ -154,6 +154,7 @@ public sealed class EditorDragDropRoutingTests
         Assert.True(resolved);
         Assert.NotNull(command);
         Assert.IsType<InstantiatePrefabAssetCommand>(command);
+        Assert.IsAssignableFrom<IUndoableEditorCommand>(command);
     }
 
     [Fact]
@@ -169,6 +170,113 @@ public sealed class EditorDragDropRoutingTests
 
         Assert.True(resolved);
         Assert.IsType<InstantiatePrefabAssetCommand>(command);
+    }
+
+    [Fact]
+    public void TryCreateSceneDropCommand_RoutesModelCreationToTarget()
+    {
+        var model = new ModelFile
+        {
+            FileId = new FileId("{MODEL}"),
+            Asset = new FileInfo("/Content/Models/Duck.glb")
+        };
+        var target = new GameObject
+        {
+            InstanceId = new InstanceId("go-target")
+        };
+
+        var resolved = EditorDragDrop.TryCreateSceneDropCommand(
+            model,
+            target,
+            out var command);
+
+        Assert.True(resolved);
+        Assert.IsType<CreateModelGameObjectCommand>(command);
+        Assert.IsAssignableFrom<IUndoableEditorCommand>(command);
+        Assert.Equal("Duck", EditorDragDrop.ResolveAssetObjectName(model));
+    }
+
+    [Fact]
+    public void TryCreateViewportDropCommand_RoutesModelAndPrefabAtResolvedPosition()
+    {
+        var position = new Vec4 { X = 1, Y = 2, Z = 3, W = 1 };
+        var model = new ModelFile
+        {
+            FileId = new FileId("{MODEL}"),
+            Asset = new FileInfo("/Content/Models/Duck.glb")
+        };
+        var prefab = new PrefabFile
+        {
+            FileId = new FileId("{PREFAB}")
+        };
+
+        Assert.True(EditorDragDrop.TryCreateViewportDropCommand(
+            model,
+            position,
+            out var modelCommand));
+        Assert.IsType<CreateModelGameObjectCommand>(modelCommand);
+        Assert.IsAssignableFrom<IUndoableEditorCommand>(modelCommand);
+        Assert.True(EditorDragDrop.TryCreateViewportDropCommand(
+            prefab,
+            position,
+            out var prefabCommand));
+        Assert.IsType<InstantiatePrefabAssetCommand>(prefabCommand);
+        Assert.IsAssignableFrom<IUndoableEditorCommand>(prefabCommand);
+    }
+
+    [Fact]
+    public void IsViewportAssetDrop_RecognizesAssetInfoTypeFallbacks()
+    {
+        var model = new AssetFile
+        {
+            FileId = new FileId("{MODEL}"),
+            AssetInfoTypeName = "Sailor::ModelAssetInfo"
+        };
+        var prefab = new AssetFile
+        {
+            FileId = new FileId("{PREFAB}"),
+            AssetInfoTypeName = "Sailor::PrefabAssetInfo"
+        };
+
+        Assert.True(EditorDragDrop.IsViewportAssetDrop(model));
+        Assert.True(EditorDragDrop.IsViewportAssetDrop(prefab));
+        Assert.False(EditorDragDrop.IsViewportAssetDrop(
+            new MaterialFile { FileId = new FileId("{MATERIAL}") }));
+    }
+
+    [Fact]
+    public void IsViewportAssetDrop_UsesExplicitAssetInfoTypeBeforeSourceExtension()
+    {
+        var secondaryTextureFromGlb = new AssetFile
+        {
+            FileId = new FileId("{TEXTURE}"),
+            AssetInfoTypeName = "Sailor::TextureAssetInfo",
+            Asset = new FileInfo("/Content/Models/Duck.glb")
+        };
+        var nonPrefabWithPrefabFilename = new AssetFile
+        {
+            FileId = new FileId("{MATERIAL}"),
+            AssetInfoTypeName = "Sailor::MaterialAssetInfo",
+            Asset = new FileInfo("/Content/Prefabs/Duck.prefab")
+        };
+        var legacyModel = new AssetFile
+        {
+            FileId = new FileId("{LEGACY-MODEL}"),
+            Asset = new FileInfo("/Content/Models/Legacy.glb")
+        };
+        var genericModel = new AssetFile
+        {
+            FileId = new FileId("{GENERIC-MODEL}"),
+            AssetInfoTypeName = "Sailor::AssetInfo",
+            Asset = new FileInfo("/Content/Models/Generic.obj")
+        };
+
+        Assert.False(EditorDragDrop.IsViewportAssetDrop(
+            secondaryTextureFromGlb));
+        Assert.False(EditorDragDrop.IsViewportAssetDrop(
+            nonPrefabWithPrefabFilename));
+        Assert.True(EditorDragDrop.IsViewportAssetDrop(legacyModel));
+        Assert.True(EditorDragDrop.IsViewportAssetDrop(genericModel));
     }
 
     [Fact]
@@ -215,6 +323,82 @@ public sealed class EditorDragDropRoutingTests
         Assert.True(resolved);
         Assert.NotNull(command);
         Assert.IsType<ReparentGameObjectCommand>(command);
+    }
+
+    [Fact]
+    public void TryCreateSceneDropCommand_RoutesExternallyParentedRootToWorldRoot()
+    {
+        var parent = new GameObject
+        {
+            InstanceId = new InstanceId("go-parent"),
+            PrefabIndex = 0,
+            ParentIndex = uint.MaxValue
+        };
+        var child = new GameObject
+        {
+            InstanceId = new InstanceId("go-external-child"),
+            PrefabIndex = 1,
+            ParentIndex = uint.MaxValue
+        };
+        var worldService =
+            SailorEditor.MauiProgram
+                .GetService<SailorEditor.Services.WorldService>();
+        worldService.Current.Prefabs.Clear();
+        var parentPrefab = new SailorEditor.Services.PrefabState();
+        parentPrefab.GameObjects.Add(parent);
+        var childPrefab = new SailorEditor.Services.PrefabState
+        {
+            ParentInstanceId = parent.InstanceId!.Value
+        };
+        childPrefab.GameObjects.Add(child);
+        worldService.Current.Prefabs.Add(parentPrefab);
+        worldService.Current.Prefabs.Add(childPrefab);
+
+        var resolved = EditorDragDrop.TryCreateSceneDropCommand(
+            child,
+            null,
+            out var command);
+
+        Assert.True(resolved);
+        Assert.IsType<ReparentGameObjectCommand>(command);
+    }
+
+    [Fact]
+    public void TryCreateSceneDropCommand_RejectsNoOpReparentToExternalParent()
+    {
+        var parent = new GameObject
+        {
+            InstanceId = new InstanceId("go-parent"),
+            PrefabIndex = 0,
+            ParentIndex = uint.MaxValue
+        };
+        var child = new GameObject
+        {
+            InstanceId = new InstanceId("go-external-child"),
+            PrefabIndex = 1,
+            ParentIndex = uint.MaxValue
+        };
+        var worldService =
+            SailorEditor.MauiProgram
+                .GetService<SailorEditor.Services.WorldService>();
+        worldService.Current.Prefabs.Clear();
+        var parentPrefab = new SailorEditor.Services.PrefabState();
+        parentPrefab.GameObjects.Add(parent);
+        var childPrefab = new SailorEditor.Services.PrefabState
+        {
+            ParentInstanceId = parent.InstanceId!.Value
+        };
+        childPrefab.GameObjects.Add(child);
+        worldService.Current.Prefabs.Add(parentPrefab);
+        worldService.Current.Prefabs.Add(childPrefab);
+
+        var resolved = EditorDragDrop.TryCreateSceneDropCommand(
+            child,
+            parent,
+            out var command);
+
+        Assert.False(resolved);
+        Assert.Null(command);
     }
 
     [Fact]

--- a/Editor.Tests/EditorDragDropTestStubs.cs
+++ b/Editor.Tests/EditorDragDropTestStubs.cs
@@ -15,12 +15,22 @@ namespace SailorEngine
         public string Value { get; set; } = value;
         public bool IsEmpty() => string.IsNullOrWhiteSpace(Value);
     }
+
+    public sealed class Vec4
+    {
+        public float X { get; set; }
+        public float Y { get; set; }
+        public float Z { get; set; }
+        public float W { get; set; }
+    }
 }
 
 namespace SailorEditor.ViewModels
 {
     public class AssetFile
     {
+        internal const string DefaultAssetInfoTypeName = "Sailor::AssetInfo";
+
         public SailorEngine.FileId? FileId { get; set; }
         public string AssetInfoTypeName { get; set; } = string.Empty;
         public FileInfo? Asset { get; set; }
@@ -29,6 +39,7 @@ namespace SailorEditor.ViewModels
 
     public sealed class MaterialFile : AssetFile;
     public sealed class TextureFile : AssetFile;
+    public sealed class ModelFile : AssetFile;
     public sealed class PrefabFile : AssetFile;
     public sealed class AssetFolder
     {
@@ -57,6 +68,32 @@ namespace SailorEditor.Services
                 .FirstOrDefault(go => go.InstanceId is not null && instanceId is not null && string.Equals(go.InstanceId.Value, instanceId.Value, StringComparison.Ordinal));
             return gameObject is not null;
         }
+
+        public SailorEngine.InstanceId? ResolveParentInstanceId(
+            SailorEditor.ViewModels.GameObject gameObject)
+        {
+            if (gameObject.PrefabIndex < 0 ||
+                gameObject.PrefabIndex >= Current.Prefabs.Count)
+            {
+                return null;
+            }
+
+            var prefab = Current.Prefabs[gameObject.PrefabIndex];
+            if (gameObject.ParentIndex != uint.MaxValue)
+            {
+                if (gameObject.ParentIndex >= prefab.GameObjects.Count)
+                {
+                    return null;
+                }
+
+                return prefab.GameObjects[(int)gameObject.ParentIndex]
+                    .InstanceId;
+            }
+
+            return string.IsNullOrWhiteSpace(prefab.ParentInstanceId)
+                ? null
+                : new SailorEngine.InstanceId(prefab.ParentInstanceId);
+        }
     }
 
     public sealed class WorldState
@@ -66,6 +103,7 @@ namespace SailorEditor.Services
 
     public sealed class PrefabState
     {
+        public string? ParentInstanceId { get; set; }
         public List<SailorEditor.ViewModels.GameObject> GameObjects { get; } = [];
     }
 }
@@ -79,11 +117,29 @@ namespace SailorEditor.Commands
         public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default) => Task.FromResult(CommandResult.Success());
     }
 
-    public sealed class InstantiatePrefabAssetCommand(SailorEditor.ViewModels.AssetFile prefabFile, SailorEditor.ViewModels.GameObject? parent = null) : IEditorCommand
+    public sealed class InstantiatePrefabAssetCommand(
+        SailorEditor.ViewModels.AssetFile prefabFile,
+        SailorEditor.ViewModels.GameObject? parent = null,
+        SailorEngine.Vec4? worldPosition = null) : IUndoableEditorCommand
     {
         public string Name => nameof(InstantiatePrefabAssetCommand);
+        public string Description => "Instantiate Prefab";
         public bool CanExecute(ActionContext context) => true;
         public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default) => Task.FromResult(CommandResult.Success());
+        public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default) => ValueTask.FromResult(CommandResult.Success());
+    }
+
+    public sealed class CreateModelGameObjectCommand(
+        SailorEditor.ViewModels.AssetFile modelFile,
+        string objectName,
+        SailorEditor.ViewModels.GameObject? parent = null,
+        SailorEngine.Vec4? worldPosition = null) : IUndoableEditorCommand
+    {
+        public string Name => nameof(CreateModelGameObjectCommand);
+        public string Description => $"Create {objectName}";
+        public bool CanExecute(ActionContext context) => true;
+        public Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default) => Task.FromResult(CommandResult.Success());
+        public ValueTask<CommandResult> UndoAsync(ActionContext context, CancellationToken cancellationToken = default) => ValueTask.FromResult(CommandResult.Success());
     }
 
     public sealed class MoveAssetCommand(SailorEditor.ViewModels.AssetFile assetFile, SailorEditor.ViewModels.AssetFolder? destinationFolder = null) : IEditorCommand

--- a/Editor.Tests/EditorViewportEventContractTests.cs
+++ b/Editor.Tests/EditorViewportEventContractTests.cs
@@ -127,6 +127,191 @@ public sealed class EditorViewportEventContractTests
         Assert.Contains("non-finite", nonFiniteError, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public void AssetDropEvent_MapsTypedAndYamlPayloads()
+    {
+        var source = new ViewportEvent
+        {
+            Revision = 31,
+            ManagedMutationRevision = 9,
+            AssetDrop = new ViewportAssetDropEvent
+            {
+                FileId = "{12345678-1234-1234-1234-123456789ABC}",
+                NormalizedX = 0.25f,
+                NormalizedY = 0.75f
+            }
+        };
+
+        Assert.True(
+            EditorViewportEventContract.TryCreate(
+                source,
+                out var typedEvent,
+                out var typedError),
+            typedError);
+        var typedDrop =
+            Assert.IsType<EditorViewportAssetDropEvent>(typedEvent);
+        Assert.Equal(31ul, typedDrop.Revision);
+        Assert.Equal(9ul, typedDrop.ManagedMutationRevision);
+        Assert.Equal(source.AssetDrop.FileId, typedDrop.FileId);
+        Assert.Equal(0.25f, typedDrop.NormalizedX);
+        Assert.Equal(0.75f, typedDrop.NormalizedY);
+
+        Assert.True(
+            EditorViewportEventContract.TryParse(
+                """
+                kind: assetDrop
+                revision: 32
+                managedMutationRevision: 10
+                fileId: "{12345678-1234-1234-1234-123456789ABC}"
+                normalizedX: 0
+                normalizedY: 1
+                """,
+                out var yamlEvent,
+                out var yamlError),
+            yamlError);
+        var yamlDrop =
+            Assert.IsType<EditorViewportAssetDropEvent>(yamlEvent);
+        Assert.Equal(0f, yamlDrop.NormalizedX);
+        Assert.Equal(1f, yamlDrop.NormalizedY);
+    }
+
+    [Fact]
+    public void AssetDropEvent_RejectsMissingIdentityAndInvalidCoordinates()
+    {
+        var source = new ViewportEvent
+        {
+            AssetDrop = new ViewportAssetDropEvent
+            {
+                FileId = string.Empty,
+                NormalizedX = 0.5f,
+                NormalizedY = 0.5f
+            }
+        };
+
+        Assert.False(
+            EditorViewportEventContract.TryCreate(
+                source,
+                out var missingId,
+                out var missingIdError));
+        Assert.Null(missingId);
+        Assert.Contains(
+            "file",
+            missingIdError,
+            StringComparison.OrdinalIgnoreCase);
+
+        source.AssetDrop.FileId =
+            "{12345678-1234-1234-1234-123456789ABC}";
+        source.AssetDrop.NormalizedX = float.NaN;
+        Assert.False(
+            EditorViewportEventContract.TryCreate(
+                source,
+                out var nonFinite,
+                out var nonFiniteError));
+        Assert.Null(nonFinite);
+        Assert.Contains(
+            "normalized",
+            nonFiniteError,
+            StringComparison.OrdinalIgnoreCase);
+
+        Assert.False(
+            EditorViewportEventContract.TryParse(
+                """
+                kind: assetDrop
+                revision: 33
+                managedMutationRevision: 10
+                fileId: "{12345678-1234-1234-1234-123456789ABC}"
+                normalizedX: -0.1
+                normalizedY: 0.5
+                """,
+                out var outOfRange,
+                out var outOfRangeError));
+        Assert.Null(outOfRange);
+        Assert.Contains(
+            "normalized",
+            outOfRangeError,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ToolShortcutEvent_MapsTypedAndYamlPayloads()
+    {
+        var source = new ViewportEvent
+        {
+            Revision = 34,
+            ManagedMutationRevision = 12,
+            ToolShortcut = new ViewportToolShortcutEvent
+            {
+                KeyCode = 'W'
+            }
+        };
+
+        Assert.True(
+            EditorViewportEventContract.TryCreate(
+                source,
+                out var typedEvent,
+                out var typedError),
+            typedError);
+        var typedShortcut =
+            Assert.IsType<EditorViewportToolShortcutEvent>(typedEvent);
+        Assert.Equal(34ul, typedShortcut.Revision);
+        Assert.Equal(12ul, typedShortcut.ManagedMutationRevision);
+        Assert.Equal((uint)'W', typedShortcut.KeyCode);
+
+        Assert.True(
+            EditorViewportEventContract.TryParse(
+                """
+                kind: toolShortcut
+                revision: 35
+                managedMutationRevision: 13
+                keyCode: 84
+                """,
+                out var yamlEvent,
+                out var yamlError),
+            yamlError);
+        var yamlShortcut =
+            Assert.IsType<EditorViewportToolShortcutEvent>(yamlEvent);
+        Assert.Equal((uint)'T', yamlShortcut.KeyCode);
+    }
+
+    [Fact]
+    public void ToolShortcutEvent_RejectsUnsupportedKeys()
+    {
+        var source = new ViewportEvent
+        {
+            ToolShortcut = new ViewportToolShortcutEvent
+            {
+                KeyCode = 'X'
+            }
+        };
+
+        Assert.False(
+            EditorViewportEventContract.TryCreate(
+                source,
+                out var typedEvent,
+                out var typedError));
+        Assert.Null(typedEvent);
+        Assert.Contains(
+            "unsupported",
+            typedError,
+            StringComparison.OrdinalIgnoreCase);
+
+        Assert.False(
+            EditorViewportEventContract.TryParse(
+                """
+                kind: toolShortcut
+                revision: 36
+                managedMutationRevision: 13
+                keyCode: 119
+                """,
+                out var yamlEvent,
+                out var yamlError));
+        Assert.Null(yamlEvent);
+        Assert.Contains(
+            "unsupported",
+            yamlError,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
     [Theory]
     [InlineData("kind: unknown\nrevision: 1\nmanagedMutationRevision: 0\n", "Unsupported viewport event kind")]
     [InlineData("kind: selection\nrevision: 1\nmanagedMutationRevision: 0\nselectedInstanceId: go\nunexpected: true\n", "unexpected field")]

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -907,6 +907,17 @@ public sealed class EngineLifecycleTests
     }
 
     [Fact]
+    public void AssetProjection_SkipsInternalTransactionDirectories()
+    {
+        var assetsSource = ReadRepositoryFile("Editor", "Services", "AssetsService.cs");
+
+        Assert.Contains(
+            "ProjectContentInternalPathPolicy.IsTransactionDirectory(directory)",
+            assetsSource,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void ContentAssetDuplicate_RoutesTheWholeGroupThroughOneRegistryReload()
     {
         var viewSource = ReadRepositoryFile("Editor", "Views", "ContentFolderView.xaml.cs");

--- a/Editor.Tests/EngineProtocolClientTests.cs
+++ b/Editor.Tests/EngineProtocolClientTests.cs
@@ -363,6 +363,49 @@ public sealed class EngineProtocolClientTests
     }
 
     [Fact]
+    public async Task InitializeAsync_LocalTransportNegotiatesCapabilitiesOverHost()
+    {
+        var transport = new LocalCapabilityRecordingTransport();
+        var client = new EngineProtocolClient(transport);
+
+        await client.InitializeAsync(["SailorEditor"]);
+        Assert.True(
+            await client.InstantiatePrefabFromYamlStrictAsync(
+                "prefab: undo",
+                string.Empty));
+
+        Assert.Single(transport.InitializeRequests);
+        Assert.Equal(
+            ProtocolRequest.CommandOneofCase.Initialize,
+            transport.InitializeRequests[0].CommandCase);
+        Assert.Equal(
+            EngineProtocolClient.ProtocolVersion,
+            transport.InitializeRequests[0].ProtocolVersion);
+        Assert.Collection(
+            transport.InvokedRequests,
+            request =>
+            {
+                Assert.Equal(
+                    ProtocolRequest.CommandOneofCase.GetExitCode,
+                    request.CommandCase);
+                Assert.Equal(
+                    EngineProtocolClient.ProtocolVersion,
+                    request.ProtocolVersion);
+            },
+            request =>
+            {
+                Assert.Equal(
+                    ProtocolRequest.CommandOneofCase.InstantiatePrefabFromYaml,
+                    request.CommandCase);
+                Assert.Equal(
+                    EngineProtocolClient.StrictInstanceIdsProtocolVersion,
+                    request.ProtocolVersion);
+                Assert.True(
+                    request.InstantiatePrefabFromYaml.StrictInstanceIds);
+            });
+    }
+
+    [Fact]
     public async Task EngineReadinessAsync_UsesDedicatedMainThreadProbe()
     {
         ProtocolRequest? captured = null;
@@ -437,6 +480,209 @@ public sealed class EngineProtocolClientTests
     }
 
     [Fact]
+    public async Task InstantiatePrefabFromYamlAsync_UsesVersionGatedStrictRequest()
+    {
+        var requests = new List<ProtocolRequest>();
+        var client = CreateClient(request =>
+        {
+            requests.Add(request);
+            return Success(
+                request,
+                response => response.BoolResult =
+                    new BoolResult { Value = true });
+        });
+
+        Assert.True(
+            await client.InstantiatePrefabFromYamlAsync(
+                "prefab: default",
+                string.Empty));
+        Assert.True(
+            await client.InstantiatePrefabFromYamlStrictAsync(
+                "prefab: undo",
+                "parent"));
+
+        Assert.Collection(
+            requests,
+            request =>
+            {
+                Assert.Equal(
+                    ProtocolRequest.CommandOneofCase.InstantiatePrefabFromYaml,
+                    request.CommandCase);
+                Assert.Equal(
+                    EngineProtocolClient.ProtocolVersion,
+                    request.ProtocolVersion);
+                Assert.Equal(
+                    "prefab: default",
+                    request.InstantiatePrefabFromYaml.PrefabYaml);
+                Assert.False(
+                    request.InstantiatePrefabFromYaml.StrictInstanceIds);
+            },
+            request =>
+            {
+                Assert.Equal(
+                    ProtocolRequest.CommandOneofCase.InstantiatePrefabFromYaml,
+                    request.CommandCase);
+                Assert.Equal(
+                    EngineProtocolClient.StrictInstanceIdsProtocolVersion,
+                    request.ProtocolVersion);
+                Assert.Equal(
+                    "prefab: undo",
+                    request.InstantiatePrefabFromYaml.PrefabYaml);
+                Assert.Equal(
+                    "parent",
+                    request.InstantiatePrefabFromYaml.ParentInstanceId);
+                Assert.True(
+                    request.InstantiatePrefabFromYaml.StrictInstanceIds);
+            });
+    }
+
+    [Fact]
+    public async Task InstantiatePrefabFromYamlStrictAsync_ProbesCapabilityBeforeColdRequest()
+    {
+        var requests = new List<ProtocolRequest>();
+        var client = CreateClient(request =>
+        {
+            requests.Add(request);
+            return request.CommandCase switch
+            {
+                ProtocolRequest.CommandOneofCase.GetExitCode =>
+                    Success(
+                        request,
+                        response => response.Int32Result =
+                            new Int32Result { Value = 0 }),
+                ProtocolRequest.CommandOneofCase.InstantiatePrefabFromYaml =>
+                    Success(
+                        request,
+                        response => response.BoolResult =
+                            new BoolResult { Value = true }),
+                _ => throw new InvalidOperationException(
+                    $"Unexpected command {request.CommandCase}.")
+            };
+        });
+
+        Assert.True(
+            await client.InstantiatePrefabFromYamlStrictAsync(
+                "prefab: undo",
+                "parent"));
+
+        Assert.Collection(
+            requests,
+            request =>
+            {
+                Assert.Equal(
+                    ProtocolRequest.CommandOneofCase.GetExitCode,
+                    request.CommandCase);
+                Assert.Equal(
+                    EngineProtocolClient.ProtocolVersion,
+                    request.ProtocolVersion);
+            },
+            request =>
+            {
+                Assert.Equal(
+                    ProtocolRequest.CommandOneofCase.InstantiatePrefabFromYaml,
+                    request.CommandCase);
+                Assert.Equal(
+                    EngineProtocolClient.StrictInstanceIdsProtocolVersion,
+                    request.ProtocolVersion);
+                Assert.True(
+                    request.InstantiatePrefabFromYaml.StrictInstanceIds);
+            });
+    }
+
+    [Fact]
+    public async Task InstantiatePrefabFromYamlStrictAsync_RejectsOldV1HostWithoutSendingMutation()
+    {
+        var requests = new List<ProtocolRequest>();
+        var client = CreateClient(request =>
+        {
+            requests.Add(request);
+            return Success(
+                request,
+                response =>
+                {
+                    if (request.CommandCase ==
+                        ProtocolRequest.CommandOneofCase.Initialize)
+                    {
+                        response.EmptyResult = new Empty();
+                    }
+                    else
+                    {
+                        response.BoolResult =
+                            new BoolResult { Value = true };
+                    }
+                },
+                supportsStrictInstanceIds: false);
+        });
+
+        await client.InitializeAsync(["SailorEditor"]);
+        Assert.True(
+            await client.InstantiatePrefabFromYamlAsync(
+                "prefab: legacy",
+                string.Empty));
+
+        var exception =
+            await Assert.ThrowsAsync<EngineProtocolException>(
+                () => client.InstantiatePrefabFromYamlStrictAsync(
+                    "prefab: undo",
+                    string.Empty));
+        Assert.Contains(
+            "does not advertise strict",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.Equal(2, requests.Count);
+        Assert.DoesNotContain(
+            requests,
+            request =>
+                request.CommandCase ==
+                    ProtocolRequest.CommandOneofCase.InstantiatePrefabFromYaml &&
+                request.InstantiatePrefabFromYaml.StrictInstanceIds);
+    }
+
+    [Fact]
+    public async Task InstantiatePrefabFromYamlStrictAsync_RejectsV1ResponseAfterStaleCapability()
+    {
+        var requests = new List<ProtocolRequest>();
+        var client = CreateClient(request =>
+        {
+            requests.Add(request);
+            if (request.CommandCase ==
+                ProtocolRequest.CommandOneofCase.RequestAssetReload)
+            {
+                return Success(
+                    request,
+                    response => response.BoolResult =
+                        new BoolResult { Value = true });
+            }
+
+            return new ProtocolResponse
+            {
+                ProtocolVersion = EngineProtocolClient.ProtocolVersion,
+                RequestId = request.RequestId,
+                Success = true,
+                BoolResult = new BoolResult { Value = true }
+            };
+        });
+
+        Assert.True(await client.RequestAssetReloadAsync());
+        var exception =
+            await Assert.ThrowsAsync<EngineProtocolException>(
+                () => client.InstantiatePrefabFromYamlStrictAsync(
+                    "prefab: undo",
+                    string.Empty));
+
+        Assert.Contains(
+            "protocol version",
+            exception.Message,
+            StringComparison.Ordinal);
+        Assert.Equal(2, requests.Count);
+        Assert.Equal(
+            EngineProtocolClient.StrictInstanceIdsProtocolVersion,
+            requests[1].ProtocolVersion);
+        Assert.True(
+            requests[1].InstantiatePrefabFromYaml.StrictInstanceIds);
+    }
+
+    [Fact]
     public async Task SerializeEngineTypesAsync_UsesDedicatedProtocolCommand()
     {
         ProtocolRequest? captured = null;
@@ -460,6 +706,185 @@ public sealed class EngineProtocolClientTests
         Assert.Equal(
             ProtocolRequest.CommandOneofCase.SerializeEngineTypes,
             captured.CommandCase);
+    }
+
+    [Fact]
+    public async Task EditorControlCommands_UseTypedPayloadsAndExpectedLanes()
+    {
+        var requests = new List<ProtocolRequest>();
+        var lanes = new List<EngineProtocolInvocationKind>();
+        var client = CreateClient(
+            request =>
+            {
+                requests.Add(request);
+                return request.CommandCase switch
+                {
+                    ProtocolRequest.CommandOneofCase.ResolveViewportDropPosition =>
+                        Success(
+                            request,
+                            response => response.Vector4Result =
+                                new Vector4Result
+                                {
+                                    Value = new Vector4
+                                    {
+                                        X = 1,
+                                        Y = 2,
+                                        Z = 3,
+                                        W = 1
+                                    }
+                                }),
+                    ProtocolRequest.CommandOneofCase.CreateModelGameObject or
+                    ProtocolRequest.CommandOneofCase.InstantiatePrefabInstance =>
+                        Success(
+                            request,
+                            response => response.InstanceIdResult =
+                                new InstanceIdResult
+                                {
+                                    Succeeded = true,
+                                    InstanceId = "go-created"
+                                }),
+                    ProtocolRequest.CommandOneofCase.GetViewportToolState =>
+                        Success(
+                            request,
+                            response => response.ViewportToolStateResult =
+                                new ViewportToolStateResult
+                                {
+                                    Operation =
+                                        ViewportTransformOperation.Rotate,
+                                    Space =
+                                        ViewportTransformSpace.Local
+                                }),
+                    _ => Success(
+                        request,
+                        response => response.BoolResult =
+                            new BoolResult { Value = true })
+                };
+            },
+            lanes.Add);
+
+        Assert.Equal(
+            new EngineProtocolVector4(1, 2, 3, 1),
+            await client.ResolveViewportDropPositionAsync(
+                1,
+                0.25f,
+                0.75f));
+        Assert.True((await client.CreateModelGameObjectAsync(
+            "{MODEL}",
+            "Duck",
+            "parent",
+            new EngineProtocolVector4(4, 5, 6, 1))).Succeeded);
+        Assert.True((await client.InstantiatePrefabInstanceAsync(
+            "{PREFAB}",
+            string.Empty,
+            null)).Succeeded);
+        Assert.True(await client.FocusEditorCameraAsync(1, "go-created"));
+        Assert.True(await client.SetPrefabLinkAsync("go-created", "{PREFAB}"));
+        Assert.True(await client.BreakPrefabLinkAsync("go-created"));
+        Assert.True(await client.SetViewportToolStateAsync(
+            1,
+            ViewportTransformOperation.Scale,
+            ViewportTransformSpace.World));
+        Assert.Equal(
+            new EngineProtocolViewportToolState(
+                ViewportTransformOperation.Rotate,
+                ViewportTransformSpace.Local),
+            await client.GetViewportToolStateAsync(1));
+
+        Assert.Collection(
+            requests,
+            request =>
+            {
+                Assert.Equal(
+                    ProtocolRequest.CommandOneofCase.ResolveViewportDropPosition,
+                    request.CommandCase);
+                Assert.Equal(1ul, request.ResolveViewportDropPosition.ViewportId);
+                Assert.Equal(0.25f, request.ResolveViewportDropPosition.NormalizedX);
+                Assert.Equal(0.75f, request.ResolveViewportDropPosition.NormalizedY);
+            },
+            request =>
+            {
+                Assert.Equal(
+                    ProtocolRequest.CommandOneofCase.CreateModelGameObject,
+                    request.CommandCase);
+                Assert.Equal("{MODEL}", request.CreateModelGameObject.ModelFileId);
+                Assert.Equal("Duck", request.CreateModelGameObject.Name);
+                Assert.Equal("parent", request.CreateModelGameObject.ParentInstanceId);
+                Assert.True(request.CreateModelGameObject.ApplyWorldPosition);
+                Assert.NotNull(request.CreateModelGameObject.WorldPosition);
+                Assert.Equal(4f, request.CreateModelGameObject.WorldPosition.X);
+            },
+            request =>
+            {
+                Assert.Equal(
+                    ProtocolRequest.CommandOneofCase.InstantiatePrefabInstance,
+                    request.CommandCase);
+                Assert.Equal("{PREFAB}", request.InstantiatePrefabInstance.FileId);
+                Assert.False(request.InstantiatePrefabInstance.ApplyWorldPosition);
+                Assert.Null(request.InstantiatePrefabInstance.WorldPosition);
+            },
+            request => Assert.Equal(
+                ProtocolRequest.CommandOneofCase.FocusEditorCamera,
+                request.CommandCase),
+            request => Assert.Equal(
+                ProtocolRequest.CommandOneofCase.SetPrefabLink,
+                request.CommandCase),
+            request => Assert.Equal(
+                ProtocolRequest.CommandOneofCase.BreakPrefabLink,
+                request.CommandCase),
+            request =>
+            {
+                Assert.Equal(
+                    ProtocolRequest.CommandOneofCase.SetViewportToolState,
+                    request.CommandCase);
+                Assert.Equal(
+                    ViewportTransformOperation.Scale,
+                    request.SetViewportToolState.Operation);
+                Assert.Equal(
+                    ViewportTransformSpace.World,
+                    request.SetViewportToolState.Space);
+            },
+            request => Assert.Equal(
+                ProtocolRequest.CommandOneofCase.GetViewportToolState,
+                request.CommandCase));
+        Assert.Equal(
+            [
+                EngineProtocolInvocationKind.Interactive,
+                EngineProtocolInvocationKind.Request,
+                EngineProtocolInvocationKind.Request,
+                EngineProtocolInvocationKind.Interactive,
+                EngineProtocolInvocationKind.Request,
+                EngineProtocolInvocationKind.Request,
+                EngineProtocolInvocationKind.Interactive,
+                EngineProtocolInvocationKind.Interactive
+            ],
+            lanes);
+    }
+
+    [Theory]
+    [InlineData(float.NaN, 0.5f)]
+    [InlineData(0.5f, float.PositiveInfinity)]
+    [InlineData(-0.01f, 0.5f)]
+    [InlineData(0.5f, 1.01f)]
+    public async Task ViewportDropPosition_RejectsInvalidCoordinates(
+        float normalizedX,
+        float normalizedY)
+    {
+        var invokeCount = 0;
+        var client = CreateClient(request =>
+        {
+            invokeCount++;
+            return Success(
+                request,
+                response => response.Vector4Result =
+                    new Vector4Result { Value = new Vector4() });
+        });
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            client.ResolveViewportDropPositionAsync(
+                1,
+                normalizedX,
+                normalizedY));
+        Assert.Equal(0, invokeCount);
     }
 
     [Fact]
@@ -523,6 +948,12 @@ public sealed class EngineProtocolClientTests
                 "yaml\0value",
                 "parent"),
             () => client.InstantiatePrefabFromYamlAsync(
+                "yaml",
+                "parent\0id"),
+            () => client.InstantiatePrefabFromYamlStrictAsync(
+                "yaml\0value",
+                "parent"),
+            () => client.InstantiatePrefabFromYamlStrictAsync(
                 "yaml",
                 "parent\0id"),
             () => client.SetEditorSelectionAsync(
@@ -598,13 +1029,15 @@ public sealed class EngineProtocolClientTests
 
     static ProtocolResponse Success(
         ProtocolRequest request,
-        Action<ProtocolResponse> setResult)
+        Action<ProtocolResponse> setResult,
+        bool supportsStrictInstanceIds = true)
     {
         var response = new ProtocolResponse
         {
-            ProtocolVersion = EngineProtocolClient.ProtocolVersion,
+            ProtocolVersion = request.ProtocolVersion,
             RequestId = request.RequestId,
-            Success = true
+            Success = true,
+            SupportsStrictInstanceIds = supportsStrictInstanceIds
         };
         setResult(response);
         return response;
@@ -664,5 +1097,63 @@ public sealed class EngineProtocolClientTests
 
         public void CompleteDisposal()
             => disposalCompletion.TrySetResult(true);
+    }
+
+    sealed class LocalCapabilityRecordingTransport :
+        IEngineProtocolTransport,
+        ILocalEngineProtocolTransport
+    {
+        public List<ProtocolRequest> InitializeRequests { get; } = [];
+        public List<ProtocolRequest> InvokedRequests { get; } = [];
+
+        public Task InitializeAsync(
+            byte[] requestData,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            InitializeRequests.Add(
+                ProtocolRequest.Parser.ParseFrom(requestData));
+            return Task.CompletedTask;
+        }
+
+        public Task<byte[]> InvokeAsync(
+            byte[] requestData,
+            EngineProtocolInvocationKind invocationKind,
+            CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var request = ProtocolRequest.Parser.ParseFrom(requestData);
+            InvokedRequests.Add(request);
+            return Task.FromResult(
+                Success(
+                    request,
+                    response =>
+                    {
+                        if (request.CommandCase ==
+                            ProtocolRequest.CommandOneofCase.GetExitCode)
+                        {
+                            response.Int32Result =
+                                new Int32Result { Value = 0 };
+                        }
+                        else
+                        {
+                            response.BoolResult =
+                                new BoolResult { Value = true };
+                        }
+                    }).ToByteArray());
+        }
+
+        public Task RequestStopFallbackAsync()
+            => Task.CompletedTask;
+
+        public Task CompleteShutdownAsync(bool shutdownEngine)
+            => Task.CompletedTask;
+
+        public void Dispose()
+        {
+        }
+
+        public ValueTask DisposeAsync()
+            => ValueTask.CompletedTask;
     }
 }

--- a/Editor.Tests/HierarchyMutationRecoveryPolicyTests.cs
+++ b/Editor.Tests/HierarchyMutationRecoveryPolicyTests.cs
@@ -1,0 +1,129 @@
+using SailorEditor.Commands;
+using SailorEditor.Protocol;
+
+namespace Editor.Tests;
+
+public sealed class HierarchyMutationRecoveryPolicyTests
+{
+    [Fact]
+    public void StrictRestore_LostResponseWithExactProjection_ReconcilesSuccess()
+    {
+        var result = HierarchyMutationRecoveryPolicy.ResolveStrictRestore(
+            EngineMutationResponseState.Unknown,
+            AuthoritativeHierarchyProjection.Exact);
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.RollbackOwnedHierarchy);
+        Assert.True(result.OutcomeUncertain);
+    }
+
+    [Theory]
+    [InlineData((int)AuthoritativeHierarchyProjection.Mismatch)]
+    [InlineData((int)AuthoritativeHierarchyProjection.Unavailable)]
+    public void StrictRestore_LostResponseWithoutOwnershipProof_NeverRollsBack(
+        int projectionValue)
+    {
+        var result = HierarchyMutationRecoveryPolicy.ResolveStrictRestore(
+            EngineMutationResponseState.Unknown,
+            (AuthoritativeHierarchyProjection)projectionValue);
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.RollbackOwnedHierarchy);
+        Assert.True(result.OutcomeUncertain);
+    }
+
+    [Fact]
+    public void StrictRestore_AcceptedResponse_AllowsExactRootRollback()
+    {
+        var result = HierarchyMutationRecoveryPolicy.ResolveStrictRestore(
+            EngineMutationResponseState.Accepted,
+            AuthoritativeHierarchyProjection.Mismatch);
+
+        Assert.False(result.Succeeded);
+        Assert.True(result.RollbackOwnedHierarchy);
+    }
+
+    [Fact]
+    public void Destroy_LostResponseWithAbsentProjection_RetainsUndoHistory()
+    {
+        var result = HierarchyMutationRecoveryPolicy.ResolveDestroy(
+            EngineMutationResponseState.Unknown,
+            AuthoritativeHierarchyProjection.Absent);
+
+        Assert.True(result.Succeeded);
+        Assert.False(result.RetainRecoveryHistory);
+    }
+
+    [Fact]
+    public void Destroy_LostResponseWithOriginalProjection_IsKnownNotApplied()
+    {
+        var result = HierarchyMutationRecoveryPolicy.ResolveDestroy(
+            EngineMutationResponseState.Unknown,
+            AuthoritativeHierarchyProjection.Exact);
+
+        Assert.False(result.Succeeded);
+        Assert.False(result.RetainRecoveryHistory);
+    }
+
+    [Theory]
+    [InlineData((int)AuthoritativeHierarchyProjection.Mismatch)]
+    [InlineData((int)AuthoritativeHierarchyProjection.Unavailable)]
+    public void Destroy_AmbiguousProjection_RetainsRecoverableHistory(
+        int projectionValue)
+    {
+        var result = HierarchyMutationRecoveryPolicy.ResolveDestroy(
+            EngineMutationResponseState.Unknown,
+            (AuthoritativeHierarchyProjection)projectionValue);
+
+        Assert.True(result.Succeeded);
+        Assert.True(result.RetainRecoveryHistory);
+        Assert.True(result.OutcomeUncertain);
+    }
+
+    [Fact]
+    public void Destroy_AmbiguousHistory_UndoAndRedoRemainRecoverable()
+    {
+        var ambiguousDelete =
+            HierarchyMutationRecoveryPolicy.ResolveDestroy(
+                EngineMutationResponseState.Unknown,
+                AuthoritativeHierarchyProjection.Unavailable);
+        var undo =
+            HierarchyMutationRecoveryPolicy.ResolveDestroyUndo(
+                ambiguousDelete.RetainRecoveryHistory,
+                AuthoritativeHierarchyProjection.Exact);
+        var redo =
+            HierarchyMutationRecoveryPolicy.ResolveDestroy(
+                EngineMutationResponseState.Unknown,
+                AuthoritativeHierarchyProjection.Absent);
+
+        Assert.True(ambiguousDelete.Succeeded);
+        Assert.Equal(
+            DestroyHierarchyUndoAction.CompleteWithoutMutation,
+            undo);
+        Assert.True(redo.Succeeded);
+    }
+
+    [Fact]
+    public void Destroy_MismatchedConcurrentState_UndoNeverMutates()
+    {
+        var undo = HierarchyMutationRecoveryPolicy.ResolveDestroyUndo(
+            recoveryHistoryRetained: true,
+            AuthoritativeHierarchyProjection.Mismatch);
+
+        Assert.Equal(
+            DestroyHierarchyUndoAction.FailWithoutMutation,
+            undo);
+    }
+
+    [Fact]
+    public void LegacyInstantiateCall_WithThirdDefaultArgument_RemainsUnambiguous()
+    {
+        Func<EngineProtocolClient, Task<bool>> compileLegacyCall =
+            client => client.InstantiatePrefabFromYamlAsync(
+                "prefab: {}",
+                string.Empty,
+                default);
+
+        Assert.NotNull(compileLegacyCall);
+    }
+}

--- a/Editor.Tests/ProjectContentFileOperationsTests.cs
+++ b/Editor.Tests/ProjectContentFileOperationsTests.cs
@@ -22,6 +22,190 @@ public sealed class ProjectContentFileOperationsTests : IDisposable
     }
 
     [Fact]
+    public void AssetPairWrite_RollbackRemovesANewlyPublishedPair()
+    {
+        var directory = Directory.CreateDirectory(
+            Path.Combine(contentRoot, "Prefabs")).FullName;
+        var sourcePath = Path.Combine(directory, "Duck.prefab");
+        var transaction = new ProjectContentFileOperations()
+            .BeginWriteAssetPair(
+                contentRoot,
+                sourcePath,
+                "new prefab",
+                "new metadata",
+                "{NEW}",
+                overwrite: false);
+
+        Assert.True(transaction.Result.Succeeded, transaction.Result.Error);
+        Assert.True(File.Exists(sourcePath));
+        Assert.True(File.Exists(sourcePath + ".asset"));
+
+        var rollback = transaction.Rollback();
+
+        Assert.True(rollback.Succeeded, rollback.Error);
+        Assert.False(File.Exists(sourcePath));
+        Assert.False(File.Exists(sourcePath + ".asset"));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(
+            directory,
+            ".sailor-asset-write-*"));
+    }
+
+    [Fact]
+    public void AssetPairWrite_CommitKeepsPublishedPairAndRemovesBackup()
+    {
+        var directory = Directory.CreateDirectory(
+            Path.Combine(contentRoot, "Prefabs")).FullName;
+        var sourcePath = WriteSource(
+            directory,
+            "Duck.prefab",
+            "old prefab");
+        var metadataPath = WriteSource(
+            directory,
+            "Duck.prefab.asset",
+            "old metadata");
+        var transaction = new ProjectContentFileOperations()
+            .BeginWriteAssetPair(
+                contentRoot,
+                sourcePath,
+                "new prefab",
+                "new metadata",
+                "{EXISTING}",
+                overwrite: true);
+
+        Assert.True(transaction.Result.Succeeded, transaction.Result.Error);
+        var commit = transaction.Commit();
+
+        Assert.True(commit.Succeeded, commit.Error);
+        Assert.Equal("new prefab", File.ReadAllText(sourcePath));
+        Assert.Equal("new metadata", File.ReadAllText(metadataPath));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(
+            directory,
+            ".sailor-asset-write-*"));
+    }
+
+    [Fact]
+    public void AssetPairWrite_PartialCommitCleanupPreservesPublishedPairAndCommitsTransaction()
+    {
+        var directory = Directory.CreateDirectory(
+            Path.Combine(contentRoot, "Prefabs")).FullName;
+        var sourcePath = WriteSource(
+            directory,
+            "Duck.prefab",
+            "old prefab");
+        var metadataPath = WriteSource(
+            directory,
+            "Duck.prefab.asset",
+            "old metadata");
+        var transaction = new ProjectContentFileOperations(
+                new FaultInjectingFileSystem
+                {
+                    DeleteOneFileThenThrowOnDeleteNumber = 1
+                })
+            .BeginWriteAssetPair(
+                contentRoot,
+                sourcePath,
+                "new prefab",
+                "new metadata",
+                "{EXISTING}",
+                overwrite: true);
+
+        Assert.True(transaction.Result.Succeeded, transaction.Result.Error);
+
+        var commit = transaction.Commit();
+
+        Assert.True(commit.Succeeded, commit.Error);
+        Assert.False(transaction.IsActive);
+        Assert.Contains("committed", commit.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.NotEmpty(commit.UnrestoredPaths);
+        Assert.Equal("new prefab", File.ReadAllText(sourcePath));
+        Assert.Equal("new metadata", File.ReadAllText(metadataPath));
+
+        var rollback = transaction.Rollback();
+
+        Assert.False(rollback.Succeeded);
+        Assert.Contains("already committed", rollback.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("new prefab", File.ReadAllText(sourcePath));
+        Assert.Equal("new metadata", File.ReadAllText(metadataPath));
+    }
+
+    [Theory]
+    [InlineData(".sailor-asset-write-fixture.pending", true)]
+    [InlineData(".SAILOR-ASSET-WRITE-FIXTURE.PENDING", true)]
+    [InlineData(".sailor-asset-write-fixture", false)]
+    [InlineData("sailor-asset-write-fixture.pending", false)]
+    [InlineData(".sailor-assets", false)]
+    public void InternalPathPolicy_RecognizesOnlyTransactionDirectories(
+        string directoryName,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            ProjectContentInternalPathPolicy.IsTransactionDirectory(
+                Path.Combine(contentRoot, directoryName)));
+    }
+
+    [Fact]
+    public void AssetPairWrite_OverwriteRollbackRestoresBothOriginalFiles()
+    {
+        var directory = Directory.CreateDirectory(
+            Path.Combine(contentRoot, "Prefabs")).FullName;
+        var sourcePath = WriteSource(
+            directory,
+            "Duck.prefab",
+            "old prefab");
+        var metadataPath = WriteSource(
+            directory,
+            "Duck.prefab.asset",
+            "old metadata");
+        var transaction = new ProjectContentFileOperations()
+            .BeginWriteAssetPair(
+                contentRoot,
+                sourcePath,
+                "new prefab",
+                "new metadata",
+                "{EXISTING}",
+                overwrite: true);
+
+        Assert.True(transaction.Result.Succeeded, transaction.Result.Error);
+        var rollback = transaction.Rollback();
+
+        Assert.True(rollback.Succeeded, rollback.Error);
+        Assert.Equal("old prefab", File.ReadAllText(sourcePath));
+        Assert.Equal("old metadata", File.ReadAllText(metadataPath));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(
+            directory,
+            ".sailor-asset-write-*"));
+    }
+
+    [Fact]
+    public void AssetPairWrite_PartialWriteFailureLeavesNoFiles()
+    {
+        var directory = Directory.CreateDirectory(
+            Path.Combine(contentRoot, "Prefabs")).FullName;
+        var sourcePath = Path.Combine(directory, "Duck.prefab");
+        var transaction = new ProjectContentFileOperations(
+                new FaultInjectingFileSystem
+                {
+                    WriteThenThrowOnWriteNumber = 1
+                })
+            .BeginWriteAssetPair(
+                contentRoot,
+                sourcePath,
+                "new prefab",
+                "new metadata",
+                "{NEW}",
+                overwrite: false);
+
+        Assert.False(transaction.Result.Succeeded);
+        Assert.True(transaction.Result.RollbackSucceeded);
+        Assert.False(File.Exists(sourcePath));
+        Assert.False(File.Exists(sourcePath + ".asset"));
+        Assert.Empty(Directory.EnumerateFileSystemEntries(
+            directory,
+            ".sailor-asset-write-*"));
+    }
+
+    [Fact]
     public void MoveAssetGroup_MovesSourceAndEverySidecarThatResolvesToIt()
     {
         var sourceDirectory = Directory.CreateDirectory(Path.Combine(contentRoot, "Models")).FullName;

--- a/Editor.Tests/SceneViewportInteractionTests.cs
+++ b/Editor.Tests/SceneViewportInteractionTests.cs
@@ -1,0 +1,158 @@
+using SailorEditor.Scene;
+
+namespace Editor.Tests;
+
+public sealed class SceneViewportInteractionTests
+{
+    [Theory]
+    [InlineData('Q', EditorViewportTransformOperation.Select)]
+    [InlineData('W', EditorViewportTransformOperation.Translate)]
+    [InlineData('E', EditorViewportTransformOperation.Rotate)]
+    [InlineData('R', EditorViewportTransformOperation.Scale)]
+    [InlineData('w', EditorViewportTransformOperation.Translate)]
+    public void ToolShortcut_ChangesOperationOnlyWithViewportFocus(
+        char shortcut,
+        EditorViewportTransformOperation expectedOperation)
+    {
+        var current = new SceneViewportToolState(
+            EditorViewportTransformOperation.Scale,
+            EditorViewportTransformSpace.World);
+
+        Assert.True(SceneViewportToolShortcuts.TryApply(
+            shortcut,
+            isPressed: true,
+            hasViewportFocus: true,
+            current,
+            out var next));
+        Assert.Equal(expectedOperation, next.Operation);
+        Assert.Equal(current.Space, next.Space);
+        Assert.False(SceneViewportToolShortcuts.TryApply(
+            shortcut,
+            isPressed: true,
+            hasViewportFocus: false,
+            current,
+            out var ignored));
+        Assert.Equal(current, ignored);
+    }
+
+    [Fact]
+    public void ToolShortcut_TogglesTransformSpace()
+    {
+        var world = new SceneViewportToolState(
+            EditorViewportTransformOperation.Translate,
+            EditorViewportTransformSpace.World);
+
+        Assert.True(SceneViewportToolShortcuts.TryApply(
+            'T',
+            isPressed: true,
+            hasViewportFocus: true,
+            world,
+            out var local));
+        Assert.Equal(EditorViewportTransformSpace.Local, local.Space);
+        Assert.True(SceneViewportToolShortcuts.TryApply(
+            'T',
+            isPressed: true,
+            hasViewportFocus: true,
+            local,
+            out var restored));
+        Assert.Equal(EditorViewportTransformSpace.World, restored.Space);
+    }
+
+    [Fact]
+    public void ToolShortcut_IgnoresReleaseAndUnknownKey()
+    {
+        var current = SceneViewportToolShortcuts.Default;
+
+        Assert.False(SceneViewportToolShortcuts.TryApply(
+            'W',
+            isPressed: false,
+            hasViewportFocus: true,
+            current,
+            out _));
+        Assert.False(SceneViewportToolShortcuts.TryApply(
+            'X',
+            isPressed: true,
+            hasViewportFocus: true,
+            current,
+            out _));
+    }
+
+    [Theory]
+    [InlineData(50, 25, 100, 50, 0.5, 0.5)]
+    [InlineData(-10, 75, 100, 50, 0.0, 1.0)]
+    [InlineData(125, -5, 100, 50, 1.0, 0.0)]
+    public void DropCoordinates_NormalizeAndClamp(
+        double x,
+        double y,
+        double width,
+        double height,
+        double expectedX,
+        double expectedY)
+    {
+        Assert.True(SceneViewportDropCoordinateResolver.TryResolve(
+            x,
+            y,
+            width,
+            height,
+            out var coordinates));
+        Assert.Equal(expectedX, coordinates.NormalizedX);
+        Assert.Equal(expectedY, coordinates.NormalizedY);
+    }
+
+    [Fact]
+    public void DropCoordinates_RejectInvalidViewport()
+    {
+        Assert.False(SceneViewportDropCoordinateResolver.TryResolve(
+            10,
+            10,
+            0,
+            100,
+            out _));
+        Assert.False(SceneViewportDropCoordinateResolver.TryResolve(
+            double.NaN,
+            10,
+            100,
+            100,
+            out _));
+    }
+
+    [Theory]
+    [InlineData("{01234567-89AB-CDEF-0123-456789ABCDEF}")]
+    [InlineData("{01234567-89ab-cdef-0123-456789abcdef}")]
+    [InlineData("01234567-89AB-CDEF-0123-456789ABCDEF")]
+    [InlineData("01234567-89ab-cdef-0123-456789abcdef")]
+    public void AssetDropPayload_CreatesForEverySerializedFileIdFormat(
+        string fileId)
+    {
+        Assert.True(SceneViewportAssetDropPayload.TryCreate(
+            new SailorEngine.FileId(fileId),
+            out var payload));
+        Assert.Equal(
+            SceneViewportAssetDropPayload.Prefix + fileId,
+            payload);
+        Assert.Equal(
+            SceneViewportAssetDropPayload.Prefix.Length + fileId.Length,
+            payload.Length);
+        Assert.True(
+            payload.Length <= SceneViewportAssetDropPayload.MaxLength);
+    }
+
+    [Theory]
+    [InlineData("0123456789AB-CDEF-0123-456789ABCDEF")]
+    [InlineData("01234567-89AB-CDEG-0123-456789ABCDEF")]
+    [InlineData("01234567-89AB-CDEF-0123-456789ABCDEFsuffix")]
+    [InlineData("{0123456789AB-CDEF-0123-456789ABCDEF}")]
+    [InlineData("{01234567-89AB-CDEG-0123-456789ABCDEF}")]
+    [InlineData("{01234567-89AB-CDEF-0123-456789ABCDEF}suffix")]
+    [InlineData("[01234567-89AB-CDEF-0123-456789ABCDEF]")]
+    [InlineData("{01234567-89AB-CDEF-0123-456789ABCDEF")]
+    [InlineData("")]
+    public void AssetDropPayload_RejectsMalformedOrOversizedFileId(
+        string fileId)
+    {
+        Assert.False(SceneViewportAssetDropPayload.TryCreate(
+            new SailorEngine.FileId(fileId),
+            out var payload));
+        Assert.Equal(string.Empty, payload);
+    }
+}

--- a/Editor.Tests/UiAsyncExceptionSafetyContractTests.cs
+++ b/Editor.Tests/UiAsyncExceptionSafetyContractTests.cs
@@ -114,6 +114,36 @@ public sealed class UiAsyncExceptionSafetyContractTests
     }
 
     [Fact]
+    public void ContentDropHandlers_ObserveAsyncFailures()
+    {
+        var contentSource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "ContentFolderView.xaml.cs");
+        var helper = Slice(
+            contentSource,
+            "static async Task ExecuteContentUiActionAsync(",
+            "void EnsureFolderVisible(");
+
+        Assert.DoesNotContain(
+            "Drop += async",
+            contentSource,
+            StringComparison.Ordinal);
+        Assert.True(
+            CountOccurrences(
+                contentSource,
+                "RunContentUiAction(") >= 3);
+        AssertInOrder(
+            helper,
+            "try",
+            "await action();",
+            "catch (Exception exception)",
+            "Console.Error.WriteLine",
+            "DisplayAlert(",
+            "catch (Exception reportingException)");
+    }
+
+    [Fact]
     public void ToolbarAndNativeToolbarHandlers_ObserveAsyncFailures()
     {
         var toolbarSource = ReadRepositoryFile(
@@ -227,6 +257,24 @@ public sealed class UiAsyncExceptionSafetyContractTests
                 $"Missing or out-of-order source marker: {marker}");
             previous = current;
         }
+    }
+
+    static int CountOccurrences(
+        string source,
+        string value)
+    {
+        var count = 0;
+        var offset = 0;
+        while ((offset = source.IndexOf(
+                   value,
+                   offset,
+                   StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            offset += value.Length;
+        }
+
+        return count;
     }
 
     static string ReadRepositoryFile(params string[] relativePath)

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -1162,7 +1162,7 @@ public sealed class WorkflowProjectionTests
         {
             var candidate = Path.Combine(relativePath.Prepend(current.FullName).ToArray());
             if (File.Exists(candidate))
-                return File.ReadAllText(candidate);
+                return File.ReadAllText(candidate).ReplaceLineEndings("\n");
 
             current = current.Parent;
         }

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -87,6 +87,200 @@ public sealed class WorkflowProjectionTests
     }
 
     [Fact]
+    public void HierarchyProjection_PreservesPrefabLinkOnEveryInstanceRow()
+    {
+        var roots = HierarchyProjectionBuilder.Build(
+        [
+            new HierarchySourceItem(
+                "root",
+                "Duck",
+                null,
+                IsPrefabLinked: true,
+                PrefabFileId: "{PREFAB}",
+                PrefabRootInstanceId: "root"),
+            new HierarchySourceItem(
+                "child",
+                "Mesh",
+                "root",
+                IsPrefabLinked: true,
+                PrefabFileId: "{PREFAB}",
+                PrefabRootInstanceId: "root")
+        ],
+        new HashSet<string> { "root" },
+        null);
+
+        var rows = HierarchyProjectionBuilder.Flatten(roots);
+
+        Assert.True(rows[0].IsPrefabLinked);
+        Assert.Equal("{PREFAB}", rows[0].PrefabFileId);
+        Assert.Equal("root", rows[0].PrefabRootInstanceId);
+        Assert.Equal("◆", rows[0].PrefabLinkGlyph);
+        Assert.True(rows[1].IsPrefabLinked);
+        Assert.Equal("{PREFAB}", rows[1].PrefabFileId);
+        Assert.Equal("root", rows[1].PrefabRootInstanceId);
+        Assert.Equal("◆", rows[1].PrefabLinkGlyph);
+    }
+
+    [Fact]
+    public void HierarchyBreakPrefabLink_UsesProjectedRootForChildRows()
+    {
+        var hierarchySource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "HierarchyView.xaml.cs");
+        var breakLinkMenu = Slice(
+            hierarchySource,
+            "if (row is",
+            "return contextMenu.CreateFlyout([.. items]);");
+
+        Assert.Contains(
+            "PrefabRootInstanceId: not null",
+            breakLinkMenu,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "new InstanceId(",
+            breakLinkMenu,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "row.PrefabRootInstanceId",
+            breakLinkMenu,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "gameObject.InstanceId,",
+            breakLinkMenu,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void HierarchyProjection_NestsLinkedRootUnderExternalParent()
+    {
+        var roots = HierarchyProjectionBuilder.Build(
+        [
+            new HierarchySourceItem(
+                "external-parent",
+                "Parent",
+                null),
+            new HierarchySourceItem(
+                "linked-root",
+                "Duck",
+                "external-parent",
+                IsPrefabLinked: true,
+                PrefabFileId: "{PREFAB}")
+        ],
+        new HashSet<string> { "external-parent" },
+        null);
+
+        var rows = HierarchyProjectionBuilder.Flatten(roots);
+
+        Assert.Collection(
+            rows,
+            row =>
+            {
+                Assert.Equal("external-parent", row.InstanceId);
+                Assert.Equal(0, row.Depth);
+            },
+            row =>
+            {
+                Assert.Equal("linked-root", row.InstanceId);
+                Assert.Equal(1, row.Depth);
+                Assert.True(row.IsPrefabLinked);
+            });
+    }
+
+    [Fact]
+    public void WorldPopulation_PreservesPrefabLinkMetadataAndCloneIsolation()
+    {
+        var worldServiceSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "WorldService.cs");
+        var prefabSource = ReadRepositoryFile(
+            "Editor",
+            "ViewModels",
+            "Prefab.cs");
+        var projectionSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "HierarchyProjectionService.cs");
+        var populate = Slice(
+            worldServiceSource,
+            "public bool TryPopulateWorld(",
+            "void PublishCurrentWorld()");
+
+        AssertInOrder(
+            populate,
+            "var newPrefab = (Prefab)prefab.Clone();",
+            "newPrefab.GameObjects.Clear();",
+            "newPrefab.Components.Clear();",
+            "Current.Prefabs.Add(newPrefab);");
+        Assert.DoesNotContain(
+            "var newPrefab = new Prefab();",
+            populate,
+            StringComparison.Ordinal);
+
+        Assert.Contains(
+            "FileId = FileId is null",
+            prefabSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ParentInstanceId = ParentInstanceId",
+            prefabSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "new Dictionary<string, string>(",
+            prefabSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "GameObjectOverrides = GameObjectOverrides?",
+            prefabSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ComponentOverrides = ComponentOverrides?",
+            prefabSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            ": (Vec4)Position.Clone()",
+            prefabSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            ": (Rotation)Rotation.Clone()",
+            prefabSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            ": (Vec4)Scale.Clone()",
+            prefabSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Position = Position,",
+            prefabSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Rotation = Rotation,",
+            prefabSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Scale = Scale,",
+            prefabSource,
+            StringComparison.Ordinal);
+
+        Assert.Contains(
+            "prefab.ParentInstanceId",
+            worldServiceSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ResolveParentInstanceId(",
+            projectionSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "static string? ResolveParentId(",
+            projectionSource,
+            StringComparison.Ordinal);
+        Assert.True(
+            CountOccurrences(projectionSource, "x.prefab.FileId") >= 4,
+            "Hierarchy projection must carry the linked prefab id to every source row.");
+    }
+
+    [Fact]
     public void HierarchyRows_ReparentThenUnrelatedRefreshPreservesStableRowsAndSelection()
     {
         var selectedRow = new HierarchyListRow("c", 0, "C", false, false, true);
@@ -297,17 +491,265 @@ public sealed class WorkflowProjectionTests
     public void DestroyGameObjectUndo_UsesAnInMemoryPrefabSnapshot()
     {
         var source = ReadRepositoryFile("Editor", "Commands", "EditorWorldCommands.cs");
+        var snapshot = Slice(
+            source,
+            "sealed class CreatedHierarchySnapshot",
+            "static class OwnedHierarchyRollback");
         var destroyCommand = Slice(
             source,
             "public sealed class DestroyGameObjectCommand",
             "public sealed class ReparentGameObjectCommand");
 
         Assert.DoesNotContain("CreatePrefabAsset", destroyCommand, StringComparison.Ordinal);
-        Assert.Contains("CreatePrefabFromSubHierarchy", destroyCommand, StringComparison.Ordinal);
-        Assert.Contains("EditorYaml.SerializePrefab", destroyCommand, StringComparison.Ordinal);
-        Assert.Contains("InstantiatePrefabFromYaml", destroyCommand, StringComparison.Ordinal);
-        Assert.Contains("CommandResult.Failure(\"Restore deleted hierarchy failed\")", destroyCommand, StringComparison.Ordinal);
-        Assert.Contains("CommandResult.Failure(\"Restored hierarchy root was not found\")", destroyCommand, StringComparison.Ordinal);
+        Assert.Contains(
+            "CreatedHierarchySnapshot? _snapshot",
+            destroyCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "CreatedHierarchySnapshot.TryCapture(",
+            destroyCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "StrictHierarchyRestore.RestoreAsync(",
+            destroyCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "CreatePrefabFromSubHierarchy",
+            snapshot,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "EditorYaml.SerializePrefab",
+            snapshot,
+            StringComparison.Ordinal);
+        Assert.Contains("_gameObjectIds", snapshot, StringComparison.Ordinal);
+        Assert.Contains("_componentIds", snapshot, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DestroyGameObjectUndo_IsAtomicAndRollsBackOnlyExactIdentity()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Commands",
+            "EditorWorldCommands.cs");
+        var snapshot = Slice(
+            source,
+            "sealed class CreatedHierarchySnapshot",
+            "static class OwnedHierarchyRollback");
+        var ownedRollback = Slice(
+            source,
+            "static class OwnedHierarchyRollback",
+            "static class StrictHierarchyRestore");
+        var strictRestore = Slice(
+            source,
+            "static class StrictHierarchyRestore",
+            "sealed class CreatedHierarchyCommandState");
+        var destroyCommand = Slice(
+            source,
+            "public sealed class DestroyGameObjectCommand",
+            "public sealed class ReparentGameObjectCommand");
+
+        Assert.DoesNotContain(
+            "beforeIds",
+            destroyCommand,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "SelectMany(",
+            destroyCommand,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "FirstOrDefault(",
+            destroyCommand,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "restored.InstanceId",
+            destroyCommand,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            destroyCommand,
+            "cancellationToken.ThrowIfCancellationRequested();",
+            "RefreshAndClassifyAsync(",
+            "AuthoritativeHierarchyProjection.Exact",
+            "RequestDestroyObjectAsync(",
+            "CancellationToken.None",
+            "HierarchyMutationRecoveryPolicy.ResolveDestroy(",
+            "RecoverySuccess(");
+        Assert.Contains(
+            "ResolveLinkedRootPrefabFileId(gameObject)",
+            destroyCommand,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            destroyCommand,
+            "gameObject.ParentIndex != uint.MaxValue",
+            "var prefabFileId = prefab.FileId",
+            "new FileId(prefabFileId.Value)");
+        AssertInOrder(
+            strictRestore,
+            "RefreshCurrentWorldAuthoritativelyAsync(",
+            "snapshot.ClassifyProjection(world, parentId)",
+            "AuthoritativeHierarchyProjection.Absent",
+            "RequestInstantiatePrefabFromYamlStrictAsync(",
+            "CancellationToken.None",
+            "RefreshCurrentWorldAuthoritativelyAsync(",
+            "HierarchyMutationRecoveryPolicy.ResolveStrictRestore(",
+            "if (resolution.RollbackOwnedHierarchy)",
+            "OwnedHierarchyRollback.FailureAsync(");
+        Assert.Contains(
+            "catch (Exception exception)",
+            destroyCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Destroy outcome is uncertain; the undo entry is retained for recovery",
+            destroyCommand,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "RequestDestroyObjectAsync(\n                    _activeInstanceId,\n                    cancellationToken",
+            destroyCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "DestroyObjectAsync(\n                rootInstanceId,",
+            ownedRollback,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RefreshCurrentWorldAsync(",
+            ownedRollback,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "SelectMany(",
+            ownedRollback,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "MatchesProjection(world, expectedParentId)",
+            snapshot,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "EditorYaml.SerializePrefab(projectedPrefab)",
+            snapshot,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DestroyGameObjectUndo_RejectsRootIdentityCollisionBeforeNativeMutation()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Commands",
+            "EditorWorldCommands.cs");
+        var destroyCommand = Slice(
+            source,
+            "public sealed class DestroyGameObjectCommand",
+            "public sealed class ReparentGameObjectCommand");
+        var strictRestore = Slice(
+            source,
+            "static class StrictHierarchyRestore",
+            "sealed class CreatedHierarchyCommandState");
+        var collisionGuard = Slice(
+            strictRestore,
+            "if (snapshot.ClassifyProjection(world, parentId) !=",
+            "// EditorCommandDispatcher serializes managed mutations.");
+
+        Assert.Contains(
+            "saved instance ids are already in use",
+            collisionGuard,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "RequestInstantiatePrefabFromYamlStrictAsync(",
+            collisionGuard,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "DestroyObjectAsync(",
+            collisionGuard,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "OwnedHierarchyRollback.FailureAsync(",
+            collisionGuard,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            strictRestore,
+            "RefreshCurrentWorldAuthoritativelyAsync(",
+            "snapshot.ClassifyProjection(world, parentId)",
+            "saved instance ids are already in use",
+            "// EditorCommandDispatcher serializes managed mutations.",
+            "RequestInstantiatePrefabFromYamlStrictAsync(");
+        AssertInOrder(
+            destroyCommand,
+            "cancellationToken.ThrowIfCancellationRequested();",
+            "RefreshAndClassifyAsync(",
+            "AuthoritativeHierarchyProjection.Exact",
+            "ResolveDestroyUndo(",
+            "DestroyHierarchyUndoAction.CompleteWithoutMutation",
+            "DestroyHierarchyUndoAction.FailWithoutMutation",
+            "StrictHierarchyRestore.RestoreAsync(");
+    }
+
+    [Fact]
+    public void ExternalProjectedParent_IsPreservedByDeleteUndoAndReparentToRoot()
+    {
+        var commandSource = ReadRepositoryFile(
+            "Editor",
+            "Commands",
+            "EditorWorldCommands.cs");
+        var worldSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "WorldService.cs");
+        var destroyCommand = Slice(
+            commandSource,
+            "public sealed class DestroyGameObjectCommand",
+            "public sealed class ReparentGameObjectCommand");
+        var hierarchySnapshot = Slice(
+            commandSource,
+            "sealed class CreatedHierarchySnapshot",
+            "static class OwnedHierarchyRollback");
+        var reparentCommand = Slice(
+            commandSource,
+            "public sealed class ReparentGameObjectCommand",
+            "public sealed class AddComponentCommand");
+        var parentResolver = Slice(
+            worldSource,
+            "public InstanceId? ResolveParentInstanceId(",
+            "public List<Component> GetComponents(");
+        var reparentToRoot = Slice(
+            worldSource,
+            "public async Task<bool> ReparentToRootAsync(",
+            "public bool ApplyReparentLocal(");
+
+        AssertInOrder(
+            parentResolver,
+            "if (gameObject.ParentIndex != uint.MaxValue)",
+            "prefab.GameObjects[(int)gameObject.ParentIndex].InstanceId",
+            "prefab.ParentInstanceId",
+            "new InstanceId(prefab.ParentInstanceId)");
+        Assert.Contains(
+            ".ResolveParentInstanceId(gameObject)",
+            destroyCommand,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            hierarchySnapshot,
+            "var linkedParentPrefab =",
+            "linkedParentPrefab.FileId",
+            "!ContainsMappedInstanceId(linkedParentPrefab, parentId)",
+            "ContainsMappedInstanceId(",
+            "root.InstanceId",
+            "prefab.DetachedFromPrefab = true;",
+            "prefab.ParentInstanceId = parentId.Value;");
+        AssertInOrder(
+            destroyCommand,
+            "_snapshot.DetachedFromPrefab",
+            "? null",
+            ": _prefabLinkFileId");
+        Assert.Contains(
+            ".ResolveParentInstanceId(child)",
+            reparentCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ResolveParentInstanceId(child) is null",
+            reparentToRoot,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "child.ParentIndex == uint.MaxValue",
+            reparentToRoot,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -337,6 +779,68 @@ public sealed class WorkflowProjectionTests
             clientSource,
             StringComparison.Ordinal);
         Assert.DoesNotContain("MarshalAs", serviceSource, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void LinkedPrefabSnapshotRestore_IsStrictSourceResolvedAndSkipsRelink()
+    {
+        var commandSource = ReadRepositoryFile(
+            "Editor",
+            "Commands",
+            "EditorWorldCommands.cs");
+        var interopSource = ReadRepositoryFile(
+            "Runtime",
+            "Editor",
+            "EditorInterop.cpp");
+        var worldSource = ReadRepositoryFile(
+            "Runtime",
+            "Engine",
+            "World.cpp");
+        var snapshot = Slice(
+            commandSource,
+            "sealed class CreatedHierarchySnapshot",
+            "static class OwnedHierarchyRollback");
+        var strictInterop = Slice(
+            interopSource,
+            "bool App::InstantiateEditorPrefabFromYaml(",
+            "bool App::FocusEditorCamera(");
+        var instantiate = Slice(
+            worldSource,
+            "GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)",
+            "void World::ResolveExternalDependencies()");
+
+        AssertInOrder(
+            snapshot,
+            "root.ParentIndex == uint.MaxValue",
+            "linkedRootPrefab.FileId",
+            "ContainsMappedInstanceId(",
+            "prefab.FileId =",
+            "prefab.ParentInstanceId = parentId?.Value;",
+            "prefab.InstanceIds =",
+            "prefab.GameObjectOverrides =",
+            "prefab.ComponentOverrides =",
+            "prefab.LinkedPrefabSnapshot = true;");
+        Assert.Contains(
+            "snapshot.DetachedFromPrefab ||\n                snapshot.LinkedPrefabSnapshot",
+            commandSource,
+            StringComparison.Ordinal);
+
+        AssertInOrder(
+            strictInterop,
+            "if (prefab->IsLinkedPrefabSnapshotRecord())",
+            "if (!bStrictInstanceIds ||",
+            "prefab->GetLinkedParentInstanceId() !=",
+            "prefab->ValidateForInstantiation(",
+            "prefabImporter->LoadPrefab_Immediate(",
+            "linkedPrefab->ConfigureLinkedInstance(",
+            "linkedPrefab->AppendDetachedSupplementalHierarchy(",
+            "prefab = std::move(linkedPrefab);",
+            "return editor->InstantiatePrefab(");
+        AssertInOrder(
+            instantiate,
+            "if (prefab->m_bLinkedPrefabSnapshotRecord)",
+            "Cannot instantiate linked prefab snapshot directly",
+            "return {};");
     }
 
     [Fact]
@@ -386,6 +890,205 @@ public sealed class WorkflowProjectionTests
         Assert.Contains("MainThread.InvokeOnMainThreadAsync", refresh, StringComparison.Ordinal);
         Assert.Contains("await MainThread.InvokeOnMainThreadAsync", refresh, StringComparison.Ordinal);
         Assert.DoesNotContain("GetAwaiter().GetResult()", refresh, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ModelAndPrefabDrops_AreAtomicUndoableHierarchyCommands()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Commands",
+            "EditorWorldCommands.cs");
+        var sharedState = Slice(
+            source,
+            "sealed class CreatedHierarchySnapshot",
+            "public sealed class CreateModelGameObjectCommand");
+        var modelCommand = Slice(
+            source,
+            "public sealed class CreateModelGameObjectCommand",
+            "public sealed class InstantiatePrefabAssetCommand");
+        var prefabCommand = Slice(
+            source,
+            "public sealed class InstantiatePrefabAssetCommand",
+            "public sealed class FocusEditorCameraCommand");
+
+        Assert.Contains(
+            ": IUndoableEditorCommand",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            ": IUndoableEditorCommand",
+            prefabCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "CreatePrefabFromSubHierarchy",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "EditorYaml.SerializePrefab",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "snapshot.ClassifyProjection(world, parentId)",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RequestInstantiatePrefabFromYamlStrictAsync(",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RefreshCurrentWorldAuthoritativelyAsync(",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "MatchesProjection(world, expectedParentId)",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "SetPrefabLinkAsync(",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "catch (Exception exception)",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "OwnedHierarchyRollback.FailureAsync(",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "DestroyObjectAsync(",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "CancellationToken.None",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "SelectInstance(snapshot.RootInstanceId)",
+            sharedState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "public ValueTask<CommandResult> UndoAsync(",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "public ValueTask<CommandResult> UndoAsync(",
+            prefabCommand,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrefabAssetCreation_RollsBackFilesAndPossibleLinkOnEveryFailure()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Commands",
+            "EditorAssetCommands.cs");
+        var command = Slice(
+            source,
+            "public sealed class CreatePrefabAssetCommand",
+            "static class AssetCommandMessages");
+
+        AssertInOrder(
+            command,
+            "cancellationToken.ThrowIfCancellationRequested();",
+            "var atomicCancellationToken = CancellationToken.None;",
+            "BeginCreatePrefabAsset(",
+            "try",
+            "linkAttempted = true;",
+            "SetPrefabLinkAsync(",
+            "IsProjectedLinkedPrefab(",
+            "CompletePrefabAssetWrite(",
+            "catch (Exception exception)",
+            "RollbackAsync(");
+        Assert.Contains(
+            "cleanupPossibleLink: linkAttempted || linkEstablished",
+            command,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "creation.Transaction.IsActive",
+            command,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "engine.BreakPrefabLinkAsync(",
+            command,
+            StringComparison.Ordinal);
+        Assert.True(
+            CountOccurrences(
+                command,
+                "engine.RequestAssetReloadAsync(") >= 2);
+        Assert.True(
+            CountOccurrences(
+                command,
+                "catch (Exception exception)") >= 4);
+    }
+
+    [Fact]
+    public void BreakPrefabLink_IsAtomicAndVerifiesBothHistoryStates()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Commands",
+            "EditorWorldCommands.cs");
+        var command = Slice(
+            source,
+            "public sealed class BreakPrefabLinkCommand",
+            "public sealed class DestroyGameObjectCommand");
+
+        AssertInOrder(
+            command,
+            "cancellationToken.ThrowIfCancellationRequested();",
+            "engine.BreakPrefabLinkAsync(",
+            "CancellationToken.None",
+            "IsProjectedUnlinked(");
+        Assert.Contains(
+            "RestoreLinkAsync(",
+            command,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "IsProjectedLinked(",
+            command,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RestoreUnlinkedAsync(",
+            command,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RefreshProjectionSafelyAsync(",
+            command,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PrefabCreationAndHierarchyFocus_CommitPendingInspectorEditsFirst()
+    {
+        var contentSource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "ContentFolderView.xaml.cs");
+        var hierarchySource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "HierarchyView.xaml.cs");
+        var prefabDrop = Slice(
+            contentSource,
+            "if (command is CreatePrefabAssetCommand)",
+            "var context = contextProvider.GetCurrentContext");
+        var focus = Slice(
+            hierarchySource,
+            "async Task FocusGameObjectAsync(",
+            "async Task BreakPrefabLinkAsync(");
+
+        AssertInOrder(
+            prefabDrop,
+            "CommitPendingChangesAsync()",
+            "EditorDragDrop.TryCreateContentDropCommand(");
+        AssertInOrder(
+            focus,
+            "CommitPendingChangesAsync()",
+            "gameObjectsById.TryGetValue(",
+            "new FocusEditorCameraCommand(");
     }
 
     static void AssertCommitClearsDirtyBeforeDispatch(string source)

--- a/Editor/Commands/EditorAssetCommands.cs
+++ b/Editor/Commands/EditorAssetCommands.cs
@@ -166,35 +166,254 @@ public sealed class CreatePrefabAssetCommand(GameObject gameObject, AssetFolder?
 
     public async Task<CommandResult> ExecuteAsync(ActionContext context, CancellationToken cancellationToken = default)
     {
-        var prefab = MauiProgram.GetService<AssetsService>().CreatePrefabAsset(targetFolder, gameObject, overwrite: existingPrefab is not null, existingPrefab: existingPrefab);
-        if (prefab is null)
+        cancellationToken.ThrowIfCancellationRequested();
+        var atomicCancellationToken = CancellationToken.None;
+        var assets = MauiProgram.GetService<AssetsService>();
+        var world = MauiProgram.GetService<WorldService>();
+        if (gameObject.InstanceId is null ||
+            gameObject.InstanceId.IsEmpty())
+        {
+            return CommandResult.Failure(
+                "The source GameObject is no longer available");
+        }
+        if (HasProjectedPrefabLink(
+                world,
+                gameObject.InstanceId))
+        {
+            return CommandResult.Failure(
+                "Break the existing prefab link before creating another prefab");
+        }
+
+        var creation = assets.BeginCreatePrefabAsset(
+            targetFolder,
+            gameObject,
+            overwrite: existingPrefab is not null,
+            existingPrefab: existingPrefab);
+        if (creation is null)
             return CommandResult.Failure("Prefab asset creation failed");
 
-        return await MauiProgram.GetService<EngineService>().RequestAssetReloadAsync(cancellationToken)
-            ? CommandResult.Success(value: prefab.FileId)
-            : CommandResult.Failure("Prefab files were created, but the native registry rejected the reload");
+        var engine = MauiProgram.GetService<EngineService>();
+        var linkAttempted = false;
+        var linkEstablished = false;
+        try
+        {
+            if (!await engine.RequestAssetReloadAsync(
+                    atomicCancellationToken))
+            {
+                return await RollbackAsync(
+                    assets,
+                    creation,
+                    engine,
+                    gameObject.InstanceId,
+                    cleanupPossibleLink: false,
+                    "The native registry rejected the prefab reload",
+                    atomicCancellationToken);
+            }
+
+            if (gameObject.InstanceId is null ||
+                gameObject.InstanceId.IsEmpty() ||
+                creation.Prefab.FileId is null ||
+                creation.Prefab.FileId.IsEmpty())
+            {
+                return await RollbackAsync(
+                    assets,
+                    creation,
+                    engine,
+                    gameObject.InstanceId,
+                    cleanupPossibleLink: false,
+                    "The source GameObject could not be linked to the prefab",
+                    atomicCancellationToken);
+            }
+
+            linkAttempted = true;
+            linkEstablished = await engine.SetPrefabLinkAsync(
+                gameObject.InstanceId,
+                creation.Prefab.FileId,
+                atomicCancellationToken);
+            if (!linkEstablished)
+            {
+                return await RollbackAsync(
+                    assets,
+                    creation,
+                    engine,
+                    gameObject.InstanceId,
+                    cleanupPossibleLink: false,
+                    "The source GameObject could not be linked to the prefab",
+                    atomicCancellationToken);
+            }
+            if (!IsProjectedLinkedPrefab(
+                    world,
+                    gameObject.InstanceId,
+                    creation.Prefab.FileId))
+            {
+                return await RollbackAsync(
+                    assets,
+                    creation,
+                    engine,
+                    gameObject.InstanceId,
+                    cleanupPossibleLink: true,
+                    "The source GameObject prefab link was not projected",
+                    atomicCancellationToken);
+            }
+
+            var commit = assets.CompletePrefabAssetWrite(
+                creation.Transaction,
+                commit: true);
+            if (!commit.Succeeded)
+            {
+                return await RollbackAsync(
+                    assets,
+                    creation,
+                    engine,
+                    gameObject.InstanceId,
+                    cleanupPossibleLink: true,
+                    AssetCommandMessages.Error(
+                        commit,
+                        "The prefab write transaction could not be committed"),
+                    atomicCancellationToken);
+            }
+
+            return CommandResult.Success(value: creation.Prefab.FileId);
+        }
+        catch (Exception exception)
+        {
+            return await RollbackAsync(
+                assets,
+                creation,
+                engine,
+                gameObject.InstanceId,
+                cleanupPossibleLink: linkAttempted || linkEstablished,
+                $"Prefab creation failed unexpectedly: {exception.Message}",
+                atomicCancellationToken);
+        }
     }
-}
 
-public sealed class InstantiatePrefabAssetCommand(AssetFile prefabFile, GameObject? parent = null) : IEditorCommand
-{
-    readonly FileId prefabFileId = prefabFile?.FileId;
-
-    public string Name => nameof(InstantiatePrefabAssetCommand);
-    public bool CanExecute(ActionContext context) => prefabFileId is not null && !prefabFileId.IsEmpty();
-
-    public async Task<CommandResult> ExecuteAsync(
-        ActionContext context,
-        CancellationToken cancellationToken = default)
+    static async Task<CommandResult> RollbackAsync(
+        AssetsService assets,
+        PrefabAssetWriteResult creation,
+        EngineService engine,
+        InstanceId? linkedRootInstanceId,
+        bool cleanupPossibleLink,
+        string reason,
+        CancellationToken cancellationToken)
     {
-        var ok = await MauiProgram.GetService<EngineService>()
-            .InstantiatePrefabAsync(
-                prefabFileId,
-                parent?.InstanceId,
-                cancellationToken);
-        return ok
-            ? CommandResult.Success(value: prefabFileId)
-            : CommandResult.Failure("Instantiate prefab failed");
+        var diagnostics = new List<string> { reason };
+        if (cleanupPossibleLink &&
+            linkedRootInstanceId is not null &&
+            !linkedRootInstanceId.IsEmpty())
+        {
+            try
+            {
+                if (!await engine.BreakPrefabLinkAsync(
+                        linkedRootInstanceId,
+                        cancellationToken))
+                {
+                    diagnostics.Add(
+                        "The live prefab link cleanup could not be confirmed.");
+                }
+            }
+            catch (Exception exception)
+            {
+                diagnostics.Add(
+                    $"The live prefab link cleanup failed: {exception.Message}");
+            }
+        }
+
+        try
+        {
+            if (creation.Transaction.IsActive)
+            {
+                var rollback = assets.CompletePrefabAssetWrite(
+                    creation.Transaction,
+                    commit: false);
+                if (!rollback.Succeeded)
+                {
+                    diagnostics.Add(
+                        AssetCommandMessages.Error(
+                            rollback,
+                            "Prefab file rollback failed"));
+                }
+            }
+        }
+        catch (Exception exception)
+        {
+            diagnostics.Add(
+                $"Prefab file rollback failed: {exception.Message}");
+        }
+
+        try
+        {
+            if (!await engine.RequestAssetReloadAsync(
+                    cancellationToken))
+            {
+                diagnostics.Add(
+                    "The native registry rejected the rollback reconciliation reload.");
+            }
+        }
+        catch (Exception exception)
+        {
+            diagnostics.Add(
+                $"The rollback reconciliation reload failed: {exception.Message}");
+        }
+        if (cleanupPossibleLink &&
+            linkedRootInstanceId is not null &&
+            !linkedRootInstanceId.IsEmpty())
+        {
+            try
+            {
+                await engine.RefreshCurrentWorldAsync(
+                    CancellationToken.None);
+                if (HasProjectedPrefabLink(
+                        MauiProgram.GetService<WorldService>(),
+                        linkedRootInstanceId))
+                {
+                    diagnostics.Add(
+                        "The live prefab link cleanup is still present in the world projection.");
+                }
+            }
+            catch (Exception exception)
+            {
+                diagnostics.Add(
+                    $"The world projection reconciliation failed: {exception.Message}");
+            }
+        }
+
+        return CommandResult.Failure(
+            string.Join(" ", diagnostics.Where(
+                diagnostic => !string.IsNullOrWhiteSpace(diagnostic))));
+    }
+
+    static bool IsProjectedLinkedPrefab(
+        WorldService world,
+        InstanceId rootInstanceId,
+        FileId prefabFileId)
+    {
+        if (!world.TryGetGameObject(rootInstanceId, out var root) ||
+            root.PrefabIndex < 0 ||
+            root.PrefabIndex >= world.Current.Prefabs.Count)
+        {
+            return false;
+        }
+
+        var projectedPrefab = world.Current.Prefabs[root.PrefabIndex];
+        return projectedPrefab.FileId is not null &&
+            projectedPrefab.FileId.Equals(prefabFileId);
+    }
+
+    static bool HasProjectedPrefabLink(
+        WorldService world,
+        InstanceId rootInstanceId)
+    {
+        if (!world.TryGetGameObject(rootInstanceId, out var root) ||
+            root.PrefabIndex < 0 ||
+            root.PrefabIndex >= world.Current.Prefabs.Count)
+        {
+            return false;
+        }
+
+        var projectedPrefab = world.Current.Prefabs[root.PrefabIndex];
+        return projectedPrefab.FileId is not null &&
+            !projectedPrefab.FileId.IsEmpty();
     }
 }
 

--- a/Editor/Commands/EditorWorldCommands.cs
+++ b/Editor/Commands/EditorWorldCommands.cs
@@ -232,65 +232,1233 @@ public sealed class CreateGameObjectCommand(InstanceId? parentId = null) : IUndo
     }
 }
 
-public sealed class DestroyGameObjectCommand(GameObject gameObject) : IUndoableEditorCommand
+sealed class CreatedHierarchySnapshot
 {
-    readonly string _name = gameObject.Name;
-    readonly InstanceId? _parentId = gameObject.ParentIndex == uint.MaxValue
-        ? null
-        : MauiProgram.GetService<WorldService>().Current.Prefabs[gameObject.PrefabIndex].GameObjects[(int)gameObject.ParentIndex].InstanceId;
-    readonly string _prefabSnapshotYaml = CreateSnapshotYaml(gameObject);
-    InstanceId _activeInstanceId = gameObject.InstanceId;
+    readonly HashSet<string> _gameObjectIds;
+    readonly HashSet<string> _componentIds;
 
-    public string Name => nameof(DestroyGameObjectCommand);
-    public string Description => $"Delete {gameObject.Name}";
+    CreatedHierarchySnapshot(
+        InstanceId rootInstanceId,
+        string prefabYaml,
+        HashSet<string> gameObjectIds,
+        HashSet<string> componentIds,
+        bool detachedFromPrefab,
+        bool linkedPrefabSnapshot)
+    {
+        RootInstanceId = rootInstanceId;
+        PrefabYaml = prefabYaml;
+        _gameObjectIds = gameObjectIds;
+        _componentIds = componentIds;
+        DetachedFromPrefab = detachedFromPrefab;
+        LinkedPrefabSnapshot = linkedPrefabSnapshot;
+    }
+
+    public InstanceId RootInstanceId { get; }
+    public string PrefabYaml { get; }
+    public bool DetachedFromPrefab { get; }
+    public bool LinkedPrefabSnapshot { get; }
+
+    public bool Contains(InstanceId? instanceId) =>
+        instanceId is not null &&
+        (_gameObjectIds.Contains(instanceId.Value) ||
+            _componentIds.Contains(instanceId.Value));
+
+    public bool IsAbsent(WorldService world) =>
+        _gameObjectIds.All(value =>
+            !world.TryGetGameObject(new InstanceId(value), out _)) &&
+        _componentIds.All(value =>
+            !world.TryGetComponent(new InstanceId(value), out _));
+
+    public bool IsProjected(WorldService world) =>
+        _gameObjectIds.All(value =>
+            world.TryGetGameObject(new InstanceId(value), out _)) &&
+        _componentIds.All(value =>
+            world.TryGetComponent(new InstanceId(value), out _));
+
+    public AuthoritativeHierarchyProjection ClassifyProjection(
+        WorldService world,
+        InstanceId? expectedParentId)
+    {
+        if (IsAbsent(world))
+        {
+            return AuthoritativeHierarchyProjection.Absent;
+        }
+
+        return MatchesProjection(world, expectedParentId)
+            ? AuthoritativeHierarchyProjection.Exact
+            : AuthoritativeHierarchyProjection.Mismatch;
+    }
+
+    public bool MatchesProjection(
+        WorldService world,
+        InstanceId? expectedParentId)
+    {
+        if (!IsProjected(world) ||
+            !world.TryGetGameObject(RootInstanceId, out var root) ||
+            !SameInstanceId(
+                world.ResolveParentInstanceId(root),
+                expectedParentId))
+        {
+            return false;
+        }
+
+        try
+        {
+            var projectedPrefab =
+                CreateSnapshotPrefab(world, root);
+            return string.Equals(
+                EditorYaml.SerializePrefab(projectedPrefab),
+                PrefabYaml,
+                StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    public static bool TryCapture(
+        WorldService world,
+        GameObject root,
+        out CreatedHierarchySnapshot? snapshot,
+        out string diagnostic)
+    {
+        snapshot = null;
+        diagnostic = string.Empty;
+
+        try
+        {
+            var prefab = CreateSnapshotPrefab(world, root);
+            var gameObjectIds = prefab.GameObjects
+                .Where(gameObject => gameObject.InstanceId is not null)
+                .Select(gameObject => gameObject.InstanceId.Value)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .ToHashSet(StringComparer.Ordinal);
+            var componentIds = prefab.Components
+                .Where(component => component.InstanceId is not null)
+                .Select(component => component.InstanceId.Value)
+                .Where(value => !string.IsNullOrWhiteSpace(value))
+                .ToHashSet(StringComparer.Ordinal);
+
+            if (gameObjectIds.Count != prefab.GameObjects.Count ||
+                componentIds.Count != prefab.Components.Count ||
+                root.InstanceId is null ||
+                root.InstanceId.IsEmpty() ||
+                !gameObjectIds.Contains(root.InstanceId.Value))
+            {
+                diagnostic =
+                    "Created hierarchy contains invalid or duplicate instance ids";
+                return false;
+            }
+
+            snapshot = new CreatedHierarchySnapshot(
+                new InstanceId(root.InstanceId.Value),
+                EditorYaml.SerializePrefab(prefab),
+                gameObjectIds,
+                componentIds,
+                prefab.DetachedFromPrefab,
+                prefab.LinkedPrefabSnapshot);
+            return true;
+        }
+        catch (Exception exception)
+        {
+            diagnostic = exception.Message;
+            return false;
+        }
+    }
+
+    static bool SameInstanceId(InstanceId? left, InstanceId? right)
+    {
+        var leftValue = left is null || left.IsEmpty()
+            ? null
+            : left.Value;
+        var rightValue = right is null || right.IsEmpty()
+            ? null
+            : right.Value;
+        return string.Equals(
+            leftValue,
+            rightValue,
+            StringComparison.Ordinal);
+    }
+
+    static Prefab CreateSnapshotPrefab(
+        WorldService world,
+        GameObject root)
+    {
+        var prefab = world.CreatePrefabFromSubHierarchy(root, out _);
+        var parentId = world.ResolveParentInstanceId(root);
+        if (root.ParentIndex == uint.MaxValue &&
+            root.PrefabIndex >= 0 &&
+            root.PrefabIndex < world.Current.Prefabs.Count)
+        {
+            var linkedRootPrefab =
+                world.Current.Prefabs[root.PrefabIndex];
+            if (linkedRootPrefab.FileId is not null &&
+                !linkedRootPrefab.FileId.IsEmpty() &&
+                ContainsMappedInstanceId(
+                    linkedRootPrefab,
+                    root.InstanceId))
+            {
+                prefab.FileId =
+                    (FileId)linkedRootPrefab.FileId.Clone();
+                prefab.ParentInstanceId = parentId?.Value;
+                prefab.InstanceIds = linkedRootPrefab.InstanceIds is null
+                    ? null
+                    : new Dictionary<string, string>(
+                        linkedRootPrefab.InstanceIds,
+                        StringComparer.Ordinal);
+                prefab.GameObjectOverrides =
+                    linkedRootPrefab.GameObjectOverrides?
+                        .ToDictionary(
+                            entry => entry.Key,
+                            entry =>
+                                (PrefabGameObjectOverride)
+                                    entry.Value.Clone(),
+                            StringComparer.Ordinal);
+                prefab.ComponentOverrides =
+                    linkedRootPrefab.ComponentOverrides?
+                        .ToDictionary(
+                            entry => entry.Key,
+                            entry =>
+                                (PrefabComponentOverride)
+                                    entry.Value.Clone(),
+                            StringComparer.Ordinal);
+                prefab.LinkedPrefabSnapshot = true;
+                return prefab;
+            }
+        }
+
+        if (parentId is null ||
+            !world.TryGetGameObject(parentId, out var parent) ||
+            parent.PrefabIndex < 0 ||
+            parent.PrefabIndex >= world.Current.Prefabs.Count)
+        {
+            return prefab;
+        }
+
+        var linkedParentPrefab =
+            world.Current.Prefabs[parent.PrefabIndex];
+        if (linkedParentPrefab.FileId is null ||
+            linkedParentPrefab.FileId.IsEmpty() ||
+            !ContainsMappedInstanceId(linkedParentPrefab, parentId) ||
+            ContainsMappedInstanceId(
+                linkedParentPrefab,
+                root.InstanceId))
+        {
+            return prefab;
+        }
+
+        prefab.DetachedFromPrefab = true;
+        prefab.ParentInstanceId = parentId.Value;
+        return prefab;
+    }
+
+    static bool ContainsMappedInstanceId(
+        Prefab prefab,
+        InstanceId? instanceId)
+        => instanceId is not null &&
+            !instanceId.IsEmpty() &&
+            prefab.InstanceIds?.Values.Any(value =>
+                string.Equals(
+                    value,
+                    instanceId.Value,
+                    StringComparison.Ordinal)) == true;
+}
+
+static class OwnedHierarchyRollback
+{
+    public static async Task<CommandResult> FailureAsync(
+        EngineService engine,
+        WorldService world,
+        InstanceId rootInstanceId,
+        string failureMessage)
+    {
+        string? cleanupDiagnostic = null;
+        var destroyed = false;
+        try
+        {
+            destroyed = await engine.DestroyObjectAsync(
+                rootInstanceId,
+                CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            cleanupDiagnostic =
+                $"exact-root destroy failed: {exception.Message}";
+        }
+
+        if (destroyed &&
+            !world.TryGetGameObject(rootInstanceId, out _))
+        {
+            return CommandResult.Failure(failureMessage);
+        }
+
+        try
+        {
+            await engine.RefreshCurrentWorldAsync(
+                CancellationToken.None);
+            if (!world.TryGetGameObject(rootInstanceId, out _))
+            {
+                return CommandResult.Failure(failureMessage);
+            }
+        }
+        catch (Exception exception)
+        {
+            cleanupDiagnostic = cleanupDiagnostic is null
+                ? $"exact-root verification failed: {exception.Message}"
+                : $"{cleanupDiagnostic}; exact-root verification failed: {exception.Message}";
+        }
+
+        return CommandResult.Failure(
+            cleanupDiagnostic is null
+                ? $"{failureMessage}; exact-root rollback could not be confirmed"
+                : $"{failureMessage}; exact-root rollback could not be confirmed ({cleanupDiagnostic})");
+    }
+}
+
+static class StrictHierarchyRestore
+{
+    public static async Task<CommandResult> RestoreAsync(
+        CreatedHierarchySnapshot snapshot,
+        InstanceId? parentId,
+        FileId? prefabLinkFileId,
+        string failureMessage)
+    {
+        var engine = MauiProgram.GetService<EngineService>();
+        var world = MauiProgram.GetService<WorldService>();
+
+        try
+        {
+            if (!await engine.RefreshCurrentWorldAuthoritativelyAsync(
+                    CancellationToken.None))
+            {
+                return CommandResult.Failure(
+                    $"{failureMessage}: authoritative preflight refresh failed");
+            }
+        }
+        catch (Exception exception)
+        {
+            return CommandResult.Failure(
+                $"{failureMessage}: authoritative preflight refresh failed: {exception.Message}");
+        }
+
+        if (snapshot.ClassifyProjection(world, parentId) !=
+            AuthoritativeHierarchyProjection.Absent)
+        {
+            return CommandResult.Failure(
+                $"{failureMessage}: saved instance ids are already in use");
+        }
+
+        // EditorCommandDispatcher serializes managed mutations. Once the
+        // authoritative preflight proves every saved id absent, a full
+        // post-request snapshot match is ownership proof for this operation.
+        var response = EngineMutationResponseState.Unknown;
+        string? requestDiagnostic = null;
+        try
+        {
+            response =
+                await engine.RequestInstantiatePrefabFromYamlStrictAsync(
+                    snapshot.PrefabYaml,
+                    parentId,
+                    CancellationToken.None)
+                ? EngineMutationResponseState.Accepted
+                : EngineMutationResponseState.Rejected;
+        }
+        catch (Exception exception)
+        {
+            requestDiagnostic = exception.Message;
+        }
+
+        var projection = AuthoritativeHierarchyProjection.Unavailable;
+        string? refreshDiagnostic = null;
+        try
+        {
+            if (await engine.RefreshCurrentWorldAuthoritativelyAsync(
+                    CancellationToken.None))
+            {
+                projection = snapshot.ClassifyProjection(
+                    world,
+                    parentId);
+            }
+        }
+        catch (Exception exception)
+        {
+            refreshDiagnostic = exception.Message;
+        }
+
+        var resolution =
+            HierarchyMutationRecoveryPolicy.ResolveStrictRestore(
+                response,
+                projection);
+        if (resolution.RollbackOwnedHierarchy)
+        {
+            return await OwnedHierarchyRollback.FailureAsync(
+                engine,
+                world,
+                snapshot.RootInstanceId,
+                BuildFailureMessage(
+                    failureMessage,
+                    "restored hierarchy did not match the saved snapshot",
+                    requestDiagnostic,
+                    refreshDiagnostic));
+        }
+
+        if (!resolution.Succeeded)
+        {
+            return CommandResult.Failure(
+                BuildFailureMessage(
+                    failureMessage,
+                    resolution.OutcomeUncertain
+                        ? "restore outcome is uncertain; no rollback was performed because ownership was not proven"
+                        : "restore was not applied",
+                    requestDiagnostic,
+                    refreshDiagnostic));
+        }
+
+        if (prefabLinkFileId is not null)
+        {
+            try
+            {
+                var linked = await engine.SetPrefabLinkAsync(
+                    snapshot.RootInstanceId,
+                    prefabLinkFileId,
+                    CancellationToken.None);
+                if ((!linked ||
+                        !IsLinkedToPrefab(
+                            world,
+                            snapshot.RootInstanceId,
+                            prefabLinkFileId)) &&
+                    (!await TryRefreshAuthoritativeAsync(engine) ||
+                        !IsLinkedToPrefab(
+                            world,
+                            snapshot.RootInstanceId,
+                            prefabLinkFileId)))
+                {
+                    return await OwnedHierarchyRollback.FailureAsync(
+                        engine,
+                        world,
+                        snapshot.RootInstanceId,
+                        $"{failureMessage}: prefab link restore failed");
+                }
+            }
+            catch (Exception exception)
+            {
+                if (await TryRefreshAuthoritativeAsync(engine) &&
+                    IsLinkedToPrefab(
+                        world,
+                        snapshot.RootInstanceId,
+                        prefabLinkFileId))
+                {
+                    return CommandResult.Success(
+                        "Strict hierarchy restore was reconciled after a lost prefab-link response.",
+                        snapshot.RootInstanceId);
+                }
+
+                return await OwnedHierarchyRollback.FailureAsync(
+                    engine,
+                    world,
+                    snapshot.RootInstanceId,
+                    $"{failureMessage}: prefab link restore failed unexpectedly: {exception.Message}");
+            }
+        }
+
+        return CommandResult.Success(
+            resolution.OutcomeUncertain
+                ? "Strict hierarchy restore was reconciled from the authoritative full snapshot."
+                : null,
+            snapshot.RootInstanceId);
+    }
+
+    static async Task<bool> TryRefreshAuthoritativeAsync(
+        EngineService engine)
+    {
+        try
+        {
+            return await engine.RefreshCurrentWorldAuthoritativelyAsync(
+                CancellationToken.None);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    static bool IsLinkedToPrefab(
+        WorldService world,
+        InstanceId rootInstanceId,
+        FileId prefabFileId)
+    {
+        if (!world.TryGetGameObject(rootInstanceId, out var root) ||
+            root.PrefabIndex < 0 ||
+            root.PrefabIndex >= world.Current.Prefabs.Count)
+        {
+            return false;
+        }
+
+        var projectedPrefab = world.Current.Prefabs[root.PrefabIndex];
+        return projectedPrefab.FileId is not null &&
+            projectedPrefab.FileId.Equals(prefabFileId);
+    }
+
+    static string BuildFailureMessage(
+        string failureMessage,
+        string detail,
+        string? requestDiagnostic,
+        string? refreshDiagnostic)
+    {
+        var diagnostics = new List<string>();
+        if (!string.IsNullOrWhiteSpace(requestDiagnostic))
+        {
+            diagnostics.Add($"request: {requestDiagnostic}");
+        }
+        if (!string.IsNullOrWhiteSpace(refreshDiagnostic))
+        {
+            diagnostics.Add($"refresh: {refreshDiagnostic}");
+        }
+
+        return diagnostics.Count == 0
+            ? $"{failureMessage}: {detail}"
+            : $"{failureMessage}: {detail} ({string.Join("; ", diagnostics)})";
+    }
+}
+
+sealed class CreatedHierarchyCommandState(
+    InstanceId? parentId,
+    FileId? prefabLinkFileId = null)
+{
+    readonly InstanceId? _parentId = parentId is null ||
+        parentId.IsEmpty()
+        ? null
+        : new InstanceId(parentId.Value);
+    readonly FileId? _prefabLinkFileId = prefabLinkFileId is null ||
+        prefabLinkFileId.IsEmpty()
+        ? null
+        : new FileId(prefabLinkFileId.Value);
+    CreatedHierarchySnapshot? _snapshot;
+
+    public async Task<CommandResult> ExecuteAsync(
+        Func<Task<InstanceId?>> createAsync,
+        string createFailureMessage,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (_snapshot is not null)
+        {
+            return await RestoreAsync(createFailureMessage);
+        }
+
+        var engine = MauiProgram.GetService<EngineService>();
+        var world = MauiProgram.GetService<WorldService>();
+        var createdId = await createAsync();
+        if (createdId is null || createdId.IsEmpty())
+        {
+            return CommandResult.Failure(createFailureMessage);
+        }
+
+        if (!world.TryGetGameObject(createdId, out var root))
+        {
+            return await OwnedHierarchyRollback.FailureAsync(
+                engine,
+                world,
+                createdId,
+                $"{createFailureMessage}: created hierarchy was not projected");
+        }
+
+        if (!CreatedHierarchySnapshot.TryCapture(
+                world,
+                root,
+                out var snapshot,
+                out var diagnostic) ||
+            snapshot is null)
+        {
+            return await OwnedHierarchyRollback.FailureAsync(
+                engine,
+                world,
+                createdId,
+                string.IsNullOrWhiteSpace(diagnostic)
+                    ? $"{createFailureMessage}: snapshot failed"
+                    : $"{createFailureMessage}: {diagnostic}");
+        }
+
+        _snapshot = snapshot;
+        try
+        {
+            MauiProgram.GetService<SelectionService>()
+                .SelectInstance(snapshot.RootInstanceId);
+        }
+        catch (Exception exception)
+        {
+            return CommandResult.Success(
+                $"Hierarchy was created, but editor selection failed: {exception.Message}",
+                snapshot.RootInstanceId);
+        }
+
+        return CommandResult.Success(value: snapshot.RootInstanceId);
+    }
+
+    public async ValueTask<CommandResult> UndoAsync(
+        CancellationToken cancellationToken)
+    {
+        if (_snapshot is null)
+        {
+            return CommandResult.Failure(
+                "Created hierarchy snapshot was not found");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var engine = MauiProgram.GetService<EngineService>();
+        var world = MauiProgram.GetService<WorldService>();
+        if (!world.TryGetGameObject(_snapshot.RootInstanceId, out _))
+        {
+            return CommandResult.Failure(
+                "Created hierarchy root was not found");
+        }
+
+        if (!await engine.DestroyObjectAsync(
+                _snapshot.RootInstanceId,
+                CancellationToken.None))
+        {
+            return CommandResult.Failure(
+                "Destroy created hierarchy failed");
+        }
+
+        if (!_snapshot.IsAbsent(world))
+        {
+            return CommandResult.Failure(
+                "Destroyed hierarchy is still present in the projection");
+        }
+
+        var selection = MauiProgram.GetService<SelectionService>();
+        if (_snapshot.Contains(selection.SelectedInstanceId))
+        {
+            selection.ClearSelection();
+        }
+
+        return CommandResult.Success();
+    }
+
+    async Task<CommandResult> RestoreAsync(string createFailureMessage)
+    {
+        var snapshot = _snapshot!;
+        var result = await StrictHierarchyRestore.RestoreAsync(
+            snapshot,
+            _parentId,
+            snapshot.DetachedFromPrefab ||
+                snapshot.LinkedPrefabSnapshot
+                ? null
+                : _prefabLinkFileId,
+            createFailureMessage);
+        if (result.Succeeded)
+        {
+            try
+            {
+                MauiProgram.GetService<SelectionService>()
+                    .SelectInstance(snapshot.RootInstanceId);
+            }
+            catch (Exception exception)
+            {
+                return CommandResult.Success(
+                    string.IsNullOrWhiteSpace(result.Message)
+                        ? $"Hierarchy was restored, but editor selection failed: {exception.Message}"
+                        : $"{result.Message} Editor selection failed: {exception.Message}",
+                    result.Value);
+            }
+        }
+
+        return result;
+    }
+
+}
+
+public sealed class CreateModelGameObjectCommand(
+    AssetFile modelFile,
+    string objectName,
+    GameObject? parent = null,
+    Vec4? worldPosition = null) : IUndoableEditorCommand
+{
+    readonly FileId _modelFileId = modelFile?.FileId;
+    readonly InstanceId? _parentId = parent?.InstanceId;
+    readonly Vec4? _worldPosition = worldPosition;
+    readonly string _objectName = objectName;
+    readonly CreatedHierarchyCommandState _state = new(
+        parent?.InstanceId);
+
+    public string Name => nameof(CreateModelGameObjectCommand);
+    public string Description => $"Create {_objectName}";
     public IHistoryMergePolicy? MergePolicy => null;
-    public bool CanExecute(ActionContext context) => _activeInstanceId is not null && !_activeInstanceId.IsEmpty() && !string.IsNullOrWhiteSpace(_prefabSnapshotYaml);
+    public bool CanExecute(ActionContext context) =>
+        _modelFileId is not null &&
+        !_modelFileId.IsEmpty() &&
+        !string.IsNullOrWhiteSpace(_objectName);
+
+    public async Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var engine = MauiProgram.GetService<EngineService>();
+        return await _state.ExecuteAsync(
+            () => engine.CreateModelGameObjectAsync(
+                _modelFileId,
+                _objectName,
+                _parentId,
+                _worldPosition,
+                CancellationToken.None),
+            "Create model GameObject failed",
+            cancellationToken);
+    }
+
+    public ValueTask<CommandResult> UndoAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+        => _state.UndoAsync(cancellationToken);
+}
+
+public sealed class InstantiatePrefabAssetCommand(
+    AssetFile prefabFile,
+    GameObject? parent = null,
+    Vec4? worldPosition = null) : IUndoableEditorCommand
+{
+    readonly FileId _prefabFileId = prefabFile?.FileId;
+    readonly InstanceId? _parentId = parent?.InstanceId;
+    readonly Vec4? _worldPosition = worldPosition;
+    readonly CreatedHierarchyCommandState _state = new(
+        parent?.InstanceId,
+        prefabFile?.FileId);
+
+    public string Name => nameof(InstantiatePrefabAssetCommand);
+    public string Description => "Instantiate Prefab";
+    public IHistoryMergePolicy? MergePolicy => null;
+    public bool CanExecute(ActionContext context) =>
+        _prefabFileId is not null && !_prefabFileId.IsEmpty();
+
+    public async Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var engine = MauiProgram.GetService<EngineService>();
+        return await _state.ExecuteAsync(
+            () => engine.InstantiatePrefabInstanceAsync(
+                _prefabFileId,
+                _parentId,
+                _worldPosition,
+                CancellationToken.None),
+            "Instantiate prefab failed",
+            cancellationToken);
+    }
+
+    public ValueTask<CommandResult> UndoAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+        => _state.UndoAsync(cancellationToken);
+}
+
+public sealed class FocusEditorCameraCommand(InstanceId instanceId) : IEditorCommand
+{
+    public string Name => nameof(FocusEditorCameraCommand);
+    public bool CanExecute(ActionContext context) =>
+        instanceId is not null && !instanceId.IsEmpty();
 
     public async Task<CommandResult> ExecuteAsync(
         ActionContext context,
         CancellationToken cancellationToken = default)
         => await MauiProgram.GetService<EngineService>()
-            .DestroyObjectAsync(_activeInstanceId, cancellationToken)
+            .FocusEditorCameraAsync(instanceId, cancellationToken)
             ? CommandResult.Success()
-            : CommandResult.Failure("Destroy failed");
+            : CommandResult.Failure("Focus editor camera failed");
+}
+
+public sealed class BreakPrefabLinkCommand(
+    InstanceId instanceId,
+    FileId prefabFileId) : IUndoableEditorCommand
+{
+    public string Name => nameof(BreakPrefabLinkCommand);
+    public string Description => "Break Prefab Link";
+    public IHistoryMergePolicy? MergePolicy => null;
+    public bool CanExecute(ActionContext context) =>
+        instanceId is not null &&
+        !instanceId.IsEmpty() &&
+        prefabFileId is not null &&
+        !prefabFileId.IsEmpty();
+
+    public async Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var engine = MauiProgram.GetService<EngineService>();
+        var world = MauiProgram.GetService<WorldService>();
+        try
+        {
+            if (!await engine.BreakPrefabLinkAsync(
+                    instanceId,
+                    CancellationToken.None))
+            {
+                return CommandResult.Failure("Break prefab link failed");
+            }
+
+            if (IsProjectedUnlinked(world, instanceId))
+            {
+                return CommandResult.Success();
+            }
+
+            var restored = await RestoreLinkAsync(
+                engine,
+                world,
+                instanceId,
+                prefabFileId);
+            return CommandResult.Failure(
+                restored
+                    ? "Break prefab link was not reflected in the world projection; the original link was restored."
+                    : "Break prefab link was not reflected in the world projection and the original link could not be restored.");
+        }
+        catch (Exception exception)
+        {
+            var restored = await RestoreLinkAsync(
+                engine,
+                world,
+                instanceId,
+                prefabFileId);
+            return CommandResult.Failure(
+                restored
+                    ? $"Break prefab link failed: {exception.Message}. The original link was restored."
+                    : $"Break prefab link failed: {exception.Message}. The original link could not be restored.");
+        }
+    }
 
     public async ValueTask<CommandResult> UndoAsync(
         ActionContext context,
         CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         var engine = MauiProgram.GetService<EngineService>();
         var world = MauiProgram.GetService<WorldService>();
-        var beforeIds = world.Current.Prefabs.SelectMany(x => x.GameObjects).Select(x => x.InstanceId?.Value).ToHashSet();
+        try
+        {
+            if (!await engine.SetPrefabLinkAsync(
+                    instanceId,
+                    prefabFileId,
+                    CancellationToken.None))
+            {
+                return CommandResult.Failure("Restore prefab link failed");
+            }
 
-        if (!await engine.InstantiatePrefabFromYamlAsync(
-                _prefabSnapshotYaml,
-                _parentId,
-                cancellationToken))
-            return CommandResult.Failure("Restore deleted hierarchy failed");
+            if (IsProjectedLinked(
+                    world,
+                    instanceId,
+                    prefabFileId))
+            {
+                return CommandResult.Success();
+            }
 
-        if (world.TryGetGameObject(_activeInstanceId, out _))
-            return CommandResult.Success();
-
-        var restored = world.Current.Prefabs
-            .SelectMany(x => x.GameObjects)
-            .Where(x => x.InstanceId is not null && !beforeIds.Contains(x.InstanceId.Value))
-            .FirstOrDefault(x => x.Name == _name && ((_parentId is null && x.ParentIndex == uint.MaxValue) || (_parentId is not null && x.ParentIndex != uint.MaxValue && world.Current.Prefabs[x.PrefabIndex].GameObjects[(int)x.ParentIndex].InstanceId.Equals(_parentId))))
-            ?? world.Current.Prefabs.SelectMany(x => x.GameObjects).FirstOrDefault(x => x.InstanceId is not null && !beforeIds.Contains(x.InstanceId.Value));
-
-        if (restored is null)
-            return CommandResult.Failure("Restored hierarchy root was not found");
-
-        await engine.DestroyObjectAsync(
-            restored.InstanceId,
-            CancellationToken.None);
-        return CommandResult.Failure(
-            "Restored hierarchy did not preserve its instance identity");
+            var restoredUnlinked = await RestoreUnlinkedAsync(
+                engine,
+                world,
+                instanceId);
+            return CommandResult.Failure(
+                restoredUnlinked
+                    ? "Restore prefab link was not reflected in the world projection; the unlinked state was restored."
+                    : "Restore prefab link was not reflected in the world projection and the unlinked state could not be restored.");
+        }
+        catch (Exception exception)
+        {
+            var restoredUnlinked = await RestoreUnlinkedAsync(
+                engine,
+                world,
+                instanceId);
+            return CommandResult.Failure(
+                restoredUnlinked
+                    ? $"Restore prefab link failed: {exception.Message}. The unlinked state was restored."
+                    : $"Restore prefab link failed: {exception.Message}. The unlinked state could not be restored.");
+        }
     }
 
-    static string CreateSnapshotYaml(GameObject root)
+    static async Task<bool> RestoreLinkAsync(
+        EngineService engine,
+        WorldService world,
+        InstanceId rootInstanceId,
+        FileId sourcePrefabFileId)
     {
-        var prefab = MauiProgram.GetService<WorldService>().CreatePrefabFromSubHierarchy(root, out _);
-        return EditorYaml.SerializePrefab(prefab);
+        try
+        {
+            await engine.SetPrefabLinkAsync(
+                rootInstanceId,
+                sourcePrefabFileId,
+                CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"Restore original prefab link cleanup failed: {exception}");
+        }
+        await RefreshProjectionSafelyAsync(
+            engine,
+            "Restore original prefab link");
+
+        return IsProjectedLinked(
+            world,
+            rootInstanceId,
+            sourcePrefabFileId);
+    }
+
+    static async Task<bool> RestoreUnlinkedAsync(
+        EngineService engine,
+        WorldService world,
+        InstanceId rootInstanceId)
+    {
+        try
+        {
+            await engine.BreakPrefabLinkAsync(
+                rootInstanceId,
+                CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"Restore unlinked prefab state cleanup failed: {exception}");
+        }
+        await RefreshProjectionSafelyAsync(
+            engine,
+            "Restore unlinked prefab state");
+
+        return IsProjectedUnlinked(world, rootInstanceId);
+    }
+
+    static async Task RefreshProjectionSafelyAsync(
+        EngineService engine,
+        string operation)
+    {
+        try
+        {
+            await engine.RefreshCurrentWorldAsync(
+                CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"{operation} projection refresh failed: {exception}");
+        }
+    }
+
+    static bool IsProjectedLinked(
+        WorldService world,
+        InstanceId rootInstanceId,
+        FileId sourcePrefabFileId)
+    {
+        if (!TryGetProjectedPrefab(
+                world,
+                rootInstanceId,
+                out var prefab))
+        {
+            return false;
+        }
+
+        return prefab.FileId is not null &&
+            prefab.FileId.Equals(sourcePrefabFileId);
+    }
+
+    static bool IsProjectedUnlinked(
+        WorldService world,
+        InstanceId rootInstanceId)
+    {
+        if (!TryGetProjectedPrefab(
+                world,
+                rootInstanceId,
+                out var prefab))
+        {
+            return false;
+        }
+
+        return prefab.FileId is null || prefab.FileId.IsEmpty();
+    }
+
+    static bool TryGetProjectedPrefab(
+        WorldService world,
+        InstanceId rootInstanceId,
+        out Prefab prefab)
+    {
+        prefab = null!;
+        if (!world.TryGetGameObject(
+                rootInstanceId,
+                out var root) ||
+            root.PrefabIndex < 0 ||
+            root.PrefabIndex >= world.Current.Prefabs.Count)
+        {
+            return false;
+        }
+
+        prefab = world.Current.Prefabs[root.PrefabIndex];
+        return true;
+    }
+}
+
+public sealed class DestroyGameObjectCommand(GameObject gameObject) : IUndoableEditorCommand
+{
+    readonly CreatedHierarchySnapshot? _snapshot =
+        CaptureSnapshot(gameObject);
+    readonly InstanceId? _parentId =
+        MauiProgram.GetService<WorldService>()
+            .ResolveParentInstanceId(gameObject);
+    readonly FileId? _prefabLinkFileId =
+        ResolveLinkedRootPrefabFileId(gameObject);
+    readonly InstanceId _activeInstanceId = gameObject.InstanceId;
+    bool _deleteOutcomeAmbiguous;
+
+    public string Name => nameof(DestroyGameObjectCommand);
+    public string Description => $"Delete {gameObject.Name}";
+    public IHistoryMergePolicy? MergePolicy => null;
+    public bool CanExecute(ActionContext context) =>
+        _snapshot is not null &&
+        _activeInstanceId is not null &&
+        !_activeInstanceId.IsEmpty();
+
+    public async Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_snapshot is null)
+        {
+            return CommandResult.Failure(
+                "Destroy failed: hierarchy snapshot was not captured");
+        }
+
+        var engine = MauiProgram.GetService<EngineService>();
+        var world = MauiProgram.GetService<WorldService>();
+        var preflight = await RefreshAndClassifyAsync(
+            engine,
+            world,
+            _snapshot,
+            _parentId);
+        if (preflight.Projection ==
+            AuthoritativeHierarchyProjection.Unavailable)
+        {
+            return CommandResult.Failure(
+                $"Destroy failed: authoritative preflight refresh failed{FormatDiagnostic(preflight.Diagnostic)}");
+        }
+        if (preflight.Projection ==
+            AuthoritativeHierarchyProjection.Absent)
+        {
+            _deleteOutcomeAmbiguous = false;
+            return RecoverySuccess(
+                preflight.Projection,
+                outcomeUncertain: false,
+                "Hierarchy was already absent; a recovery history entry was retained.");
+        }
+        if (preflight.Projection !=
+            AuthoritativeHierarchyProjection.Exact)
+        {
+            return CommandResult.Failure(
+                "Destroy failed: the authoritative hierarchy no longer matches the saved snapshot");
+        }
+
+        var response = EngineMutationResponseState.Unknown;
+        string? requestDiagnostic = null;
+        try
+        {
+            response = await engine.RequestDestroyObjectAsync(
+                    _activeInstanceId,
+                    CancellationToken.None)
+                ? EngineMutationResponseState.Accepted
+                : EngineMutationResponseState.Rejected;
+        }
+        catch (Exception exception)
+        {
+            requestDiagnostic = exception.Message;
+        }
+
+        var postMutation = await RefreshAndClassifyAsync(
+            engine,
+            world,
+            _snapshot,
+            _parentId);
+        var resolution = HierarchyMutationRecoveryPolicy.ResolveDestroy(
+            response,
+            postMutation.Projection);
+        _deleteOutcomeAmbiguous = resolution.RetainRecoveryHistory;
+        if (!resolution.Succeeded)
+        {
+            return CommandResult.Failure(
+                $"Destroy was not applied{FormatDiagnostics(requestDiagnostic, postMutation.Diagnostic)}");
+        }
+
+        return RecoverySuccess(
+            postMutation.Projection,
+            resolution.OutcomeUncertain,
+            resolution.OutcomeUncertain
+                ? $"Destroy outcome is uncertain; the undo entry is retained for recovery{FormatDiagnostics(requestDiagnostic, postMutation.Diagnostic)}"
+                : null);
+    }
+
+    public async ValueTask<CommandResult> UndoAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var engine = MauiProgram.GetService<EngineService>();
+        var world = MauiProgram.GetService<WorldService>();
+        if (_snapshot is null)
+        {
+            return CommandResult.Failure(
+                "Restore deleted hierarchy failed: hierarchy snapshot was not captured");
+        }
+
+        var preflight = await RefreshAndClassifyAsync(
+            engine,
+            world,
+            _snapshot,
+            _parentId);
+        if (preflight.Projection ==
+            AuthoritativeHierarchyProjection.Unavailable)
+        {
+            return CommandResult.Failure(
+                $"Restore deleted hierarchy failed: authoritative preflight refresh failed{FormatDiagnostic(preflight.Diagnostic)}");
+        }
+
+        var undoAction =
+            HierarchyMutationRecoveryPolicy.ResolveDestroyUndo(
+                _deleteOutcomeAmbiguous,
+                preflight.Projection);
+        if (undoAction ==
+            DestroyHierarchyUndoAction.CompleteWithoutMutation)
+        {
+            _deleteOutcomeAmbiguous = false;
+            return RecoverySuccess(
+                preflight.Projection,
+                outcomeUncertain: false,
+                "Destroy was not applied; undo reconciled the original hierarchy without mutation.");
+        }
+        if (undoAction ==
+            DestroyHierarchyUndoAction.FailWithoutMutation)
+        {
+            return CommandResult.Failure(
+                "Restore deleted hierarchy failed: authoritative state does not match either the deleted or saved hierarchy; no mutation was attempted");
+        }
+
+        var result = await StrictHierarchyRestore.RestoreAsync(
+            _snapshot,
+            _parentId,
+            _snapshot.DetachedFromPrefab ||
+                _snapshot.LinkedPrefabSnapshot
+                ? null
+                : _prefabLinkFileId,
+            "Restore deleted hierarchy failed");
+        if (result.Succeeded)
+        {
+            _deleteOutcomeAmbiguous = false;
+        }
+
+        return result;
+    }
+
+    static FileId? ResolveLinkedRootPrefabFileId(GameObject gameObject)
+    {
+        if (gameObject.ParentIndex != uint.MaxValue ||
+            !TryGetProjectedPrefab(gameObject, out var prefab))
+        {
+            return null;
+        }
+
+        var prefabFileId = prefab.FileId;
+        return prefabFileId is null || prefabFileId.IsEmpty()
+            ? null
+            : new FileId(prefabFileId.Value);
+    }
+
+    static bool TryGetProjectedPrefab(
+        GameObject gameObject,
+        out Prefab prefab)
+    {
+        var world = MauiProgram.GetService<WorldService>();
+        prefab = null!;
+        if (gameObject.PrefabIndex < 0 ||
+            gameObject.PrefabIndex >= world.Current.Prefabs.Count)
+        {
+            return false;
+        }
+
+        prefab = world.Current.Prefabs[gameObject.PrefabIndex];
+        return true;
+    }
+
+    static CreatedHierarchySnapshot? CaptureSnapshot(
+        GameObject root)
+    {
+        return CreatedHierarchySnapshot.TryCapture(
+            MauiProgram.GetService<WorldService>(),
+            root,
+            out var snapshot,
+            out _)
+            ? snapshot
+            : null;
+    }
+
+    static async Task<(
+        AuthoritativeHierarchyProjection Projection,
+        string? Diagnostic)> RefreshAndClassifyAsync(
+        EngineService engine,
+        WorldService world,
+        CreatedHierarchySnapshot snapshot,
+        InstanceId? parentId)
+    {
+        try
+        {
+            if (!await engine.RefreshCurrentWorldAuthoritativelyAsync(
+                    CancellationToken.None))
+            {
+                return (
+                    AuthoritativeHierarchyProjection.Unavailable,
+                    "authoritative refresh was not published");
+            }
+
+            return (
+                snapshot.ClassifyProjection(world, parentId),
+                null);
+        }
+        catch (Exception exception)
+        {
+            return (
+                AuthoritativeHierarchyProjection.Unavailable,
+                exception.Message);
+        }
+    }
+
+    CommandResult RecoverySuccess(
+        AuthoritativeHierarchyProjection projection,
+        bool outcomeUncertain,
+        string? message)
+        => CommandResult.Success(
+            message,
+            new HierarchyMutationRecoveryOutcome(
+                "DestroyHierarchy",
+                _activeInstanceId.Value,
+                projection,
+                outcomeUncertain));
+
+    static string FormatDiagnostic(string? diagnostic) =>
+        string.IsNullOrWhiteSpace(diagnostic)
+            ? string.Empty
+            : $": {diagnostic}";
+
+    static string FormatDiagnostics(
+        string? requestDiagnostic,
+        string? refreshDiagnostic)
+    {
+        var diagnostics = new List<string>();
+        if (!string.IsNullOrWhiteSpace(requestDiagnostic))
+        {
+            diagnostics.Add($"request: {requestDiagnostic}");
+        }
+        if (!string.IsNullOrWhiteSpace(refreshDiagnostic))
+        {
+            diagnostics.Add($"refresh: {refreshDiagnostic}");
+        }
+
+        return diagnostics.Count == 0
+            ? string.Empty
+            : $" ({string.Join("; ", diagnostics)})";
     }
 }
 
@@ -298,7 +1466,9 @@ public sealed class ReparentGameObjectCommand(GameObject child, GameObject? newP
 {
     readonly InstanceId _childId = child.InstanceId;
     readonly InstanceId? _newParentId = newParent?.InstanceId;
-    readonly InstanceId? _oldParentId = child.ParentIndex == uint.MaxValue ? null : MauiProgram.GetService<WorldService>().Current.Prefabs[child.PrefabIndex].GameObjects[(int)child.ParentIndex].InstanceId;
+    readonly InstanceId? _oldParentId =
+        MauiProgram.GetService<WorldService>()
+            .ResolveParentInstanceId(child);
     public string Name => nameof(ReparentGameObjectCommand);
     public string Description => "Reparent GameObject";
     public IHistoryMergePolicy? MergePolicy => null;

--- a/Editor/Commands/HierarchyMutationRecovery.cs
+++ b/Editor/Commands/HierarchyMutationRecovery.cs
@@ -1,0 +1,114 @@
+namespace SailorEditor.Commands;
+
+internal enum EngineMutationResponseState
+{
+    Accepted,
+    Rejected,
+    Unknown
+}
+
+internal enum AuthoritativeHierarchyProjection
+{
+    Unavailable,
+    Absent,
+    Exact,
+    Mismatch
+}
+
+internal readonly record struct StrictHierarchyRestoreResolution(
+    bool Succeeded,
+    bool RollbackOwnedHierarchy,
+    bool OutcomeUncertain);
+
+internal readonly record struct DestroyHierarchyResolution(
+    bool Succeeded,
+    bool RetainRecoveryHistory,
+    bool OutcomeUncertain);
+
+internal enum DestroyHierarchyUndoAction
+{
+    Restore,
+    CompleteWithoutMutation,
+    FailWithoutMutation
+}
+
+internal sealed record HierarchyMutationRecoveryOutcome(
+    string Operation,
+    string RootInstanceId,
+    AuthoritativeHierarchyProjection Projection,
+    bool OutcomeUncertain);
+
+internal static class HierarchyMutationRecoveryPolicy
+{
+    public static StrictHierarchyRestoreResolution ResolveStrictRestore(
+        EngineMutationResponseState response,
+        AuthoritativeHierarchyProjection projection)
+    {
+        if (projection == AuthoritativeHierarchyProjection.Exact)
+        {
+            return new StrictHierarchyRestoreResolution(
+                Succeeded: true,
+                RollbackOwnedHierarchy: false,
+                OutcomeUncertain: response !=
+                    EngineMutationResponseState.Accepted);
+        }
+
+        if (response == EngineMutationResponseState.Accepted)
+        {
+            return new StrictHierarchyRestoreResolution(
+                Succeeded: false,
+                RollbackOwnedHierarchy: true,
+                OutcomeUncertain: projection ==
+                    AuthoritativeHierarchyProjection.Unavailable);
+        }
+
+        return new StrictHierarchyRestoreResolution(
+            Succeeded: false,
+            RollbackOwnedHierarchy: false,
+            OutcomeUncertain:
+                projection == AuthoritativeHierarchyProjection.Mismatch ||
+                projection == AuthoritativeHierarchyProjection.Unavailable);
+    }
+
+    public static DestroyHierarchyResolution ResolveDestroy(
+        EngineMutationResponseState response,
+        AuthoritativeHierarchyProjection projection)
+    {
+        if (response == EngineMutationResponseState.Accepted ||
+            projection == AuthoritativeHierarchyProjection.Absent)
+        {
+            var uncertain =
+                projection != AuthoritativeHierarchyProjection.Absent;
+            return new DestroyHierarchyResolution(
+                Succeeded: true,
+                RetainRecoveryHistory: uncertain,
+                OutcomeUncertain: uncertain);
+        }
+
+        if (projection == AuthoritativeHierarchyProjection.Exact)
+        {
+            return new DestroyHierarchyResolution(
+                Succeeded: false,
+                RetainRecoveryHistory: false,
+                OutcomeUncertain: false);
+        }
+
+        return new DestroyHierarchyResolution(
+            Succeeded: true,
+            RetainRecoveryHistory: true,
+            OutcomeUncertain: true);
+    }
+
+    public static DestroyHierarchyUndoAction ResolveDestroyUndo(
+        bool recoveryHistoryRetained,
+        AuthoritativeHierarchyProjection projection)
+        => projection switch
+        {
+            AuthoritativeHierarchyProjection.Absent =>
+                DestroyHierarchyUndoAction.Restore,
+            AuthoritativeHierarchyProjection.Exact
+                when recoveryHistoryRetained =>
+                DestroyHierarchyUndoAction.CompleteWithoutMutation,
+            _ => DestroyHierarchyUndoAction.FailWithoutMutation
+        };
+}

--- a/Editor/Content/ProjectContentFileOperations.cs
+++ b/Editor/Content/ProjectContentFileOperations.cs
@@ -11,6 +11,117 @@ public sealed record ProjectContentFileOperationResult(
     string? CreatedAssetInfoPath = null,
     string? CreatedFileId = null);
 
+public static class ProjectContentInternalPathPolicy
+{
+    const string TransactionDirectoryPrefix = ".sailor-";
+    const string TransactionDirectorySuffix = ".pending";
+
+    public static bool IsTransactionDirectory(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        var directoryName = Path.GetFileName(
+            Path.TrimEndingDirectorySeparator(path));
+        return directoryName.StartsWith(
+                TransactionDirectoryPrefix,
+                StringComparison.OrdinalIgnoreCase) &&
+            directoryName.EndsWith(
+                TransactionDirectorySuffix,
+                StringComparison.OrdinalIgnoreCase);
+    }
+}
+
+public sealed class ProjectContentAssetWriteTransaction
+{
+    readonly object stateLock = new();
+    readonly Func<ProjectContentFileOperationResult>? commit;
+    readonly Func<ProjectContentFileOperationResult>? rollback;
+    ProjectContentFileOperationResult? completion;
+    TransactionState state;
+
+    internal ProjectContentAssetWriteTransaction(
+        ProjectContentFileOperationResult result,
+        Func<ProjectContentFileOperationResult>? commit = null,
+        Func<ProjectContentFileOperationResult>? rollback = null)
+    {
+        Result = result;
+        this.commit = commit;
+        this.rollback = rollback;
+        state = result.Succeeded
+            ? TransactionState.Active
+            : TransactionState.Failed;
+    }
+
+    public ProjectContentFileOperationResult Result { get; }
+    public bool IsActive
+    {
+        get
+        {
+            lock (stateLock)
+            {
+                return state == TransactionState.Active;
+            }
+        }
+    }
+
+    public ProjectContentFileOperationResult Commit()
+    {
+        lock (stateLock)
+        {
+            if (state == TransactionState.Failed)
+                return Result;
+            if (state == TransactionState.Committed)
+                return completion!;
+            if (state == TransactionState.RolledBack)
+            {
+                return new ProjectContentFileOperationResult(
+                    false,
+                    "The content write transaction was already rolled back.",
+                    true,
+                    Array.Empty<string>());
+            }
+
+            completion = commit!();
+            if (completion.Succeeded)
+                state = TransactionState.Committed;
+            return completion;
+        }
+    }
+
+    public ProjectContentFileOperationResult Rollback()
+    {
+        lock (stateLock)
+        {
+            if (state == TransactionState.Failed)
+                return Result;
+            if (state == TransactionState.RolledBack)
+                return completion!;
+            if (state == TransactionState.Committed)
+            {
+                return new ProjectContentFileOperationResult(
+                    false,
+                    "The content write transaction was already committed.",
+                    false,
+                    Array.Empty<string>());
+            }
+
+            completion = rollback!();
+            if (completion.Succeeded)
+                state = TransactionState.RolledBack;
+            return completion;
+        }
+    }
+
+    enum TransactionState
+    {
+        Failed,
+        Active,
+        Committed,
+        RolledBack
+    }
+}
+
 public interface IProjectContentFileSystem
 {
     bool FileExists(string path);
@@ -243,6 +354,169 @@ public sealed class ProjectContentFileOperations
                     $"Cannot delete the asset group: {exception.Message}",
                     unrestored);
             }
+        }
+    }
+
+    public ProjectContentAssetWriteTransaction BeginWriteAssetPair(
+        string writableRoot,
+        string sourcePath,
+        string sourceContents,
+        string metadataContents,
+        string fileId,
+        bool overwrite)
+    {
+        lock (mutationLock)
+        {
+            if (!TryResolveWritableRoot(writableRoot, out var root, out var error))
+                return FailedAssetWrite(error);
+
+            string finalSourcePath;
+            try
+            {
+                finalSourcePath =
+                    ProjectContentPathPolicy.NormalizeRoot(sourcePath);
+            }
+            catch (Exception exception)
+            {
+                return FailedAssetWrite(
+                    $"The asset path is invalid: {exception.Message}");
+            }
+
+            var finalMetadataPath = finalSourcePath + ".asset";
+            var parentDirectory = Path.GetDirectoryName(finalSourcePath);
+            if (string.IsNullOrWhiteSpace(parentDirectory) ||
+                !ProjectContentPathPolicy.IsInsideRoot(root, finalSourcePath) ||
+                !ProjectContentPathPolicy.IsInsideRoot(root, finalMetadataPath))
+            {
+                return FailedAssetWrite(
+                    "The asset and metadata must stay inside the writable Content root.");
+            }
+            if (!fileSystem.DirectoryExists(parentDirectory))
+            {
+                return FailedAssetWrite(
+                    "The destination Content directory does not exist.");
+            }
+            if (fileSystem.DirectoryExists(finalSourcePath) ||
+                fileSystem.DirectoryExists(finalMetadataPath))
+            {
+                return FailedAssetWrite(
+                    "An asset destination is occupied by a directory.");
+            }
+
+            var sourceExists = fileSystem.FileExists(finalSourcePath);
+            var metadataExists = fileSystem.FileExists(finalMetadataPath);
+            if (overwrite)
+            {
+                if (!sourceExists || !metadataExists)
+                {
+                    return FailedAssetWrite(
+                        "Both the source and primary metadata must exist before overwrite.");
+                }
+            }
+            else if (sourceExists || metadataExists)
+            {
+                return FailedAssetWrite(
+                    "The asset source or primary metadata already exists.");
+            }
+
+            string? originalSourceContents = null;
+            string? originalMetadataContents = null;
+            if (overwrite)
+            {
+                try
+                {
+                    originalSourceContents =
+                        fileSystem.ReadAllText(finalSourcePath);
+                    originalMetadataContents =
+                        fileSystem.ReadAllText(finalMetadataPath);
+                }
+                catch (Exception exception)
+                {
+                    return FailedAssetWrite(
+                        $"Cannot read the existing asset before overwrite: {exception.Message}");
+                }
+            }
+
+            if (!TryCreateStagingDirectory(
+                    root,
+                    parentDirectory,
+                    "asset-write",
+                    out var stagingDirectory,
+                    out error))
+            {
+                return FailedAssetWrite(error);
+            }
+
+            var pending = new PendingAssetWrite(
+                finalSourcePath,
+                finalMetadataPath,
+                sourceContents,
+                metadataContents,
+                originalSourceContents,
+                originalMetadataContents,
+                overwrite,
+                stagingDirectory,
+                Path.Combine(stagingDirectory, "source.backup"),
+                Path.Combine(stagingDirectory, "metadata.backup"),
+                Path.Combine(stagingDirectory, "source.pending"),
+                Path.Combine(stagingDirectory, "metadata.pending"));
+
+            try
+            {
+                fileSystem.CreateDirectory(stagingDirectory);
+                if (overwrite)
+                {
+                    pending.SourceBackedUp = true;
+                    fileSystem.MoveFile(
+                        finalSourcePath,
+                        pending.SourceBackupPath);
+                    pending.MetadataBackedUp = true;
+                    fileSystem.MoveFile(
+                        finalMetadataPath,
+                        pending.MetadataBackupPath);
+                }
+
+                fileSystem.WriteAllTextNew(
+                    pending.SourcePendingPath,
+                    sourceContents);
+                fileSystem.WriteAllTextNew(
+                    pending.MetadataPendingPath,
+                    metadataContents);
+
+                pending.SourcePublished = true;
+                fileSystem.MoveFile(
+                    pending.SourcePendingPath,
+                    finalSourcePath);
+                pending.MetadataPublished = true;
+                fileSystem.MoveFile(
+                    pending.MetadataPendingPath,
+                    finalMetadataPath);
+            }
+            catch (Exception exception)
+            {
+                var rollbackResult = RollbackAssetWrite(pending);
+                return new ProjectContentAssetWriteTransaction(
+                    Failure(
+                        $"Cannot write the asset pair: {exception.Message}",
+                        rollbackResult.UnrestoredPaths));
+            }
+
+            return new ProjectContentAssetWriteTransaction(
+                Success(finalMetadataPath, fileId),
+                () =>
+                {
+                    lock (mutationLock)
+                    {
+                        return CommitAssetWrite(pending);
+                    }
+                },
+                () =>
+                {
+                    lock (mutationLock)
+                    {
+                        return RollbackAssetWrite(pending);
+                    }
+                });
         }
     }
 
@@ -1210,6 +1484,183 @@ public sealed class ProjectContentFileOperations
         return true;
     }
 
+    ProjectContentFileOperationResult CommitAssetWrite(
+        PendingAssetWrite pending)
+    {
+        var unrestored = new List<string>();
+        if (!FileHasContents(
+                pending.SourcePath,
+                pending.SourceContents) ||
+            !FileHasContents(
+                pending.MetadataPath,
+                pending.MetadataContents))
+        {
+            unrestored.Add(pending.SourcePath);
+            unrestored.Add(pending.MetadataPath);
+            unrestored.Add(pending.StagingDirectory);
+            return Failure(
+                "The published asset changed before the write transaction could be committed.",
+                unrestored);
+        }
+
+        TryRemoveStagingDirectory(pending.StagingDirectory, unrestored);
+        return unrestored.Count == 0
+            ? Success(pending.MetadataPath)
+            : CommittedWithCleanupDiagnostic(
+                "The asset pair was committed, but its transaction backup could not be removed.",
+                unrestored,
+                pending.MetadataPath);
+    }
+
+    ProjectContentFileOperationResult RollbackAssetWrite(
+        PendingAssetWrite pending)
+    {
+        var unrestored = new List<string>();
+        TryRemovePublishedFile(
+            pending.SourcePath,
+            pending.SourceContents,
+            pending.SourcePublished,
+            unrestored);
+        TryRemovePublishedFile(
+            pending.MetadataPath,
+            pending.MetadataContents,
+            pending.MetadataPublished,
+            unrestored);
+
+        if (pending.Overwrite)
+        {
+            TryRestoreAssetBackup(
+                pending.SourceBackupPath,
+                pending.SourcePath,
+                pending.OriginalSourceContents!,
+                pending.SourceBackedUp,
+                unrestored);
+            TryRestoreAssetBackup(
+                pending.MetadataBackupPath,
+                pending.MetadataPath,
+                pending.OriginalMetadataContents!,
+                pending.MetadataBackedUp,
+                unrestored);
+        }
+        else
+        {
+            if (PathExists(pending.SourcePath))
+                unrestored.Add(pending.SourcePath);
+            if (PathExists(pending.MetadataPath))
+                unrestored.Add(pending.MetadataPath);
+        }
+
+        var finalStateRestored = pending.Overwrite
+            ? FileHasContents(
+                    pending.SourcePath,
+                    pending.OriginalSourceContents!) &&
+                FileHasContents(
+                    pending.MetadataPath,
+                    pending.OriginalMetadataContents!)
+            : !PathExists(pending.SourcePath) &&
+                !PathExists(pending.MetadataPath);
+        if (!finalStateRestored)
+        {
+            unrestored.Add(pending.SourcePath);
+            unrestored.Add(pending.MetadataPath);
+        }
+        else
+        {
+            TryRemoveStagingDirectory(
+                pending.StagingDirectory,
+                unrestored);
+        }
+
+        return unrestored.Count == 0
+            ? Success()
+            : Failure(
+                "The asset write transaction could not be rolled back completely.",
+                unrestored);
+    }
+
+    void TryRemovePublishedFile(
+        string path,
+        string expectedContents,
+        bool publicationAttempted,
+        List<string> unrestored)
+    {
+        if (!publicationAttempted || !fileSystem.FileExists(path))
+            return;
+
+        try
+        {
+            if (!FileHasContents(path, expectedContents))
+            {
+                unrestored.Add(path);
+                return;
+            }
+
+            fileSystem.DeleteFile(path);
+            if (PathExists(path))
+                unrestored.Add(path);
+        }
+        catch
+        {
+            unrestored.Add(path);
+        }
+    }
+
+    void TryRestoreAssetBackup(
+        string backupPath,
+        string finalPath,
+        string expectedOriginalContents,
+        bool backupAttempted,
+        List<string> unrestored)
+    {
+        if (!backupAttempted)
+            return;
+
+        try
+        {
+            if (fileSystem.FileExists(backupPath))
+            {
+                if (!PathExists(finalPath))
+                {
+                    fileSystem.MoveFile(backupPath, finalPath);
+                }
+                else if (!FileHasContents(
+                    finalPath,
+                    expectedOriginalContents))
+                {
+                    unrestored.Add(finalPath);
+                    unrestored.Add(backupPath);
+                }
+            }
+
+            if (!FileHasContents(finalPath, expectedOriginalContents))
+                unrestored.Add(finalPath);
+        }
+        catch
+        {
+            unrestored.Add(finalPath);
+            if (fileSystem.FileExists(backupPath))
+                unrestored.Add(backupPath);
+        }
+    }
+
+    bool FileHasContents(string path, string contents)
+    {
+        if (!fileSystem.FileExists(path))
+            return false;
+
+        try
+        {
+            return string.Equals(
+                fileSystem.ReadAllText(path),
+                contents,
+                StringComparison.Ordinal);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
     bool TryCreateStagingDirectory(
         string root,
         string parentDirectory,
@@ -1269,6 +1720,23 @@ public sealed class ProjectContentFileOperations
             createdAssetInfoPath,
             createdFileId);
 
+    static ProjectContentFileOperationResult CommittedWithCleanupDiagnostic(
+        string diagnostic,
+        IEnumerable<string> pendingCleanupPaths,
+        string? createdAssetInfoPath = null)
+    {
+        var paths = pendingCleanupPaths
+            .Distinct(ProjectContentPathPolicy.PathComparer)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        return new(
+            true,
+            diagnostic,
+            true,
+            paths,
+            createdAssetInfoPath);
+    }
+
     static ProjectContentFileOperationResult Failure(
         string error,
         IEnumerable<string>? unrestoredPaths = null)
@@ -1279,6 +1747,10 @@ public sealed class ProjectContentFileOperations
             .ToArray();
         return new(false, error, unrestored.Length == 0, unrestored);
     }
+
+    static ProjectContentAssetWriteTransaction FailedAssetWrite(
+        string error)
+        => new(Failure(error));
 
     sealed record AssetGroup(string SourcePath, IReadOnlyList<string> AssetInfoPaths);
     sealed record DuplicateAssetPlan(
@@ -1305,4 +1777,38 @@ public sealed class ProjectContentFileOperations
         string FinalPath,
         string OriginalContents,
         string UpdatedContents);
+
+    sealed class PendingAssetWrite(
+        string sourcePath,
+        string metadataPath,
+        string sourceContents,
+        string metadataContents,
+        string? originalSourceContents,
+        string? originalMetadataContents,
+        bool overwrite,
+        string stagingDirectory,
+        string sourceBackupPath,
+        string metadataBackupPath,
+        string sourcePendingPath,
+        string metadataPendingPath)
+    {
+        public string SourcePath { get; } = sourcePath;
+        public string MetadataPath { get; } = metadataPath;
+        public string SourceContents { get; } = sourceContents;
+        public string MetadataContents { get; } = metadataContents;
+        public string? OriginalSourceContents { get; } =
+            originalSourceContents;
+        public string? OriginalMetadataContents { get; } =
+            originalMetadataContents;
+        public bool Overwrite { get; } = overwrite;
+        public string StagingDirectory { get; } = stagingDirectory;
+        public string SourceBackupPath { get; } = sourceBackupPath;
+        public string MetadataBackupPath { get; } = metadataBackupPath;
+        public string SourcePendingPath { get; } = sourcePendingPath;
+        public string MetadataPendingPath { get; } = metadataPendingPath;
+        public bool SourceBackedUp { get; set; }
+        public bool MetadataBackedUp { get; set; }
+        public bool SourcePublished { get; set; }
+        public bool MetadataPublished { get; set; }
+    }
 }

--- a/Editor/Protocol/EngineProtocolClient.cs
+++ b/Editor/Protocol/EngineProtocolClient.cs
@@ -26,13 +26,28 @@ internal readonly record struct EngineProtocolCreationResult(
     bool Succeeded,
     string InstanceId);
 
+internal readonly record struct EngineProtocolVector4(
+    float X,
+    float Y,
+    float Z,
+    float W);
+
+internal readonly record struct EngineProtocolViewportToolState(
+    ViewportTransformOperation Operation,
+    ViewportTransformSpace Space);
+
 internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
 {
     internal const uint ProtocolVersion = 1;
+    internal const uint StrictInstanceIdsProtocolVersion = 2;
     internal const uint MaxPayloadSize = 64u * 1024u * 1024u;
+    const int CapabilityUnknown = -1;
+    const int CapabilityUnsupported = 0;
+    const int CapabilitySupported = 1;
 
     readonly IEngineProtocolTransport transport;
     long nextRequestId;
+    int strictInstanceIdsCapability = CapabilityUnknown;
 
     public EngineProtocolClient()
         : this(new LocalEngineProtocolTransport())
@@ -71,12 +86,18 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
             argumentIndex++;
         }
 
+        Volatile.Write(
+            ref strictInstanceIdsCapability,
+            CapabilityUnknown);
         RequireResult<Empty>(
             (await SendAsync(
                     new ProtocolRequest { Initialize = initialize },
                     cancellationToken)
                 .ConfigureAwait(false)).EmptyResult,
             nameof(ProtocolRequest.Initialize));
+        await EnsureProtocolCapabilitiesNegotiatedAsync(
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     public async Task StartAsync(
@@ -661,10 +682,229 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                 .ConfigureAwait(false),
             nameof(ProtocolRequest.InstantiatePrefab));
 
-    public async Task<bool> InstantiatePrefabFromYamlAsync(
+    public async Task<EngineProtocolVector4> ResolveViewportDropPositionAsync(
+        ulong viewportId,
+        float normalizedX,
+        float normalizedY,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateNormalizedCoordinate(normalizedX, nameof(normalizedX));
+        ValidateNormalizedCoordinate(normalizedY, nameof(normalizedY));
+        var result = RequireResult<Vector4Result>(
+            (await SendAsync(
+                    new ProtocolRequest
+                    {
+                        ResolveViewportDropPosition =
+                            new ViewportDropPositionRequest
+                            {
+                                ViewportId = viewportId,
+                                NormalizedX = normalizedX,
+                                NormalizedY = normalizedY
+                            }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false)).Vector4Result,
+            nameof(ProtocolRequest.ResolveViewportDropPosition));
+        return ReadVector4(result.Value, nameof(ProtocolRequest.ResolveViewportDropPosition));
+    }
+
+    public async Task<EngineProtocolCreationResult> CreateModelGameObjectAsync(
+        string modelFileId,
+        string name,
+        string parentInstanceId,
+        EngineProtocolVector4? worldPosition,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new CreateModelGameObjectRequest
+        {
+            ModelFileId = ValidateString(modelFileId, nameof(modelFileId)),
+            Name = ValidateString(name, nameof(name)),
+            ParentInstanceId = ValidateString(
+                parentInstanceId,
+                nameof(parentInstanceId)),
+            ApplyWorldPosition = worldPosition.HasValue
+        };
+        if (worldPosition is { } position)
+        {
+            request.WorldPosition = CreateVector4(position, nameof(worldPosition));
+        }
+
+        return ReadCreation(
+            await SendAsync(
+                    new ProtocolRequest { CreateModelGameObject = request },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.CreateModelGameObject));
+    }
+
+    public async Task<EngineProtocolCreationResult> InstantiatePrefabInstanceAsync(
+        string fileId,
+        string parentInstanceId,
+        EngineProtocolVector4? worldPosition,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new InstantiatePrefabInstanceRequest
+        {
+            FileId = ValidateString(fileId, nameof(fileId)),
+            ParentInstanceId = ValidateString(
+                parentInstanceId,
+                nameof(parentInstanceId)),
+            ApplyWorldPosition = worldPosition.HasValue
+        };
+        if (worldPosition is { } position)
+        {
+            request.WorldPosition = CreateVector4(position, nameof(worldPosition));
+        }
+
+        return ReadCreation(
+            await SendAsync(
+                    new ProtocolRequest { InstantiatePrefabInstance = request },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.InstantiatePrefabInstance));
+    }
+
+    public async Task<bool> FocusEditorCameraAsync(
+        ulong viewportId,
+        string instanceId,
+        CancellationToken cancellationToken = default)
+        => ReadBool(
+            await SendAsync(
+                    new ProtocolRequest
+                    {
+                        FocusEditorCamera = new ViewportObjectRequest
+                        {
+                            ViewportId = viewportId,
+                            InstanceId = ValidateString(
+                                instanceId,
+                                nameof(instanceId))
+                        }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.FocusEditorCamera));
+
+    public async Task<bool> SetPrefabLinkAsync(
+        string instanceId,
+        string fileId,
+        CancellationToken cancellationToken = default)
+        => ReadBool(
+            await SendAsync(
+                    new ProtocolRequest
+                    {
+                        SetPrefabLink = new PrefabLinkRequest
+                        {
+                            InstanceId = ValidateString(
+                                instanceId,
+                                nameof(instanceId)),
+                            FileId = ValidateString(fileId, nameof(fileId))
+                        }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.SetPrefabLink));
+
+    public async Task<bool> BreakPrefabLinkAsync(
+        string instanceId,
+        CancellationToken cancellationToken = default)
+        => ReadBool(
+            await SendAsync(
+                    new ProtocolRequest
+                    {
+                        BreakPrefabLink = new InstanceIdRequest
+                        {
+                            InstanceId = ValidateString(
+                                instanceId,
+                                nameof(instanceId))
+                        }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.BreakPrefabLink));
+
+    public async Task<bool> SetViewportToolStateAsync(
+        ulong viewportId,
+        ViewportTransformOperation operation,
+        ViewportTransformSpace space,
+        CancellationToken cancellationToken = default)
+        => ReadBool(
+            await SendAsync(
+                    new ProtocolRequest
+                    {
+                        SetViewportToolState = new ViewportToolStateRequest
+                        {
+                            ViewportId = viewportId,
+                            Operation = ValidateTransformOperation(operation),
+                            Space = ValidateTransformSpace(space)
+                        }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.SetViewportToolState));
+
+    public async Task<EngineProtocolViewportToolState> GetViewportToolStateAsync(
+        ulong viewportId,
+        CancellationToken cancellationToken = default)
+    {
+        var result = RequireResult<ViewportToolStateResult>(
+            (await SendAsync(
+                    new ProtocolRequest
+                    {
+                        GetViewportToolState =
+                            new ViewportIdRequest { ViewportId = viewportId }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false)).ViewportToolStateResult,
+            nameof(ProtocolRequest.GetViewportToolState));
+        return new EngineProtocolViewportToolState(
+            ValidateTransformOperation(result.Operation),
+            ValidateTransformSpace(result.Space));
+    }
+
+    public Task<bool> InstantiatePrefabFromYamlAsync(
         string prefabYaml,
         string parentInstanceId,
         CancellationToken cancellationToken = default)
+        => InstantiatePrefabFromYamlCoreAsync(
+            prefabYaml,
+            parentInstanceId,
+            strictInstanceIds: false,
+            protocolVersion: ProtocolVersion,
+            cancellationToken: cancellationToken);
+
+    public async Task<bool> InstantiatePrefabFromYamlStrictAsync(
+        string prefabYaml,
+        string parentInstanceId,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateString(prefabYaml, nameof(prefabYaml));
+        ValidateString(parentInstanceId, nameof(parentInstanceId));
+        await EnsureProtocolCapabilitiesNegotiatedAsync(
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (Volatile.Read(ref strictInstanceIdsCapability) !=
+            CapabilitySupported)
+        {
+            throw new EngineProtocolException(
+                "The connected Engine host does not advertise strict " +
+                "instance-id restoration support.");
+        }
+
+        return await InstantiatePrefabFromYamlCoreAsync(
+                prefabYaml,
+                parentInstanceId,
+                strictInstanceIds: true,
+                protocolVersion: StrictInstanceIdsProtocolVersion,
+                cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    async Task<bool> InstantiatePrefabFromYamlCoreAsync(
+        string prefabYaml,
+        string parentInstanceId,
+        bool strictInstanceIds,
+        uint protocolVersion,
+        CancellationToken cancellationToken)
         => ReadBool(
             await SendAsync(
                     new ProtocolRequest
@@ -677,12 +917,27 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                                     nameof(prefabYaml)),
                                 ParentInstanceId = ValidateString(
                                     parentInstanceId,
-                                    nameof(parentInstanceId))
+                                    nameof(parentInstanceId)),
+                                StrictInstanceIds = strictInstanceIds
                             }
                     },
-                    cancellationToken)
+                    cancellationToken,
+                    protocolVersion)
                 .ConfigureAwait(false),
             nameof(ProtocolRequest.InstantiatePrefabFromYaml));
+
+    async Task EnsureProtocolCapabilitiesNegotiatedAsync(
+        CancellationToken cancellationToken)
+    {
+        if (Volatile.Read(ref strictInstanceIdsCapability) !=
+            CapabilityUnknown)
+        {
+            return;
+        }
+
+        _ = await GetExitCodeAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
 
     public async Task<bool> SetEditorSelectionAsync(
         IEnumerable<string> instanceIds,
@@ -752,7 +1007,8 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
 
     internal async Task<ProtocolResponse> SendAsync(
         ProtocolRequest request,
-        CancellationToken cancellationToken = default)
+        CancellationToken cancellationToken = default,
+        uint protocolVersion = ProtocolVersion)
     {
         ArgumentNullException.ThrowIfNull(request);
         if (request.CommandCase == ProtocolRequest.CommandOneofCase.None)
@@ -763,7 +1019,7 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
         }
 
         var requestId = NextRequestId();
-        request.ProtocolVersion = ProtocolVersion;
+        request.ProtocolVersion = protocolVersion;
         request.RequestId = requestId;
 
         var requestData = request.ToByteArray();
@@ -783,7 +1039,7 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                 .ConfigureAwait(false);
             response = new ProtocolResponse
             {
-                ProtocolVersion = ProtocolVersion,
+                ProtocolVersion = protocolVersion,
                 RequestId = requestId,
                 Success = true,
                 EmptyResult = new Empty()
@@ -816,11 +1072,11 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
             }
         }
 
-        if (response.ProtocolVersion != ProtocolVersion)
+        if (response.ProtocolVersion != protocolVersion)
         {
             throw new EngineProtocolException(
                 $"Engine protocol transport returned protocol version " +
-                $"{response.ProtocolVersion}; expected {ProtocolVersion}.");
+                $"{response.ProtocolVersion}; expected {protocolVersion}.");
         }
 
         if (response.RequestId != requestId)
@@ -836,6 +1092,17 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                 ? "The engine rejected the protocol request."
                 : response.Error;
             throw new EngineProtocolException(error);
+        }
+
+        if (!(request.CommandCase ==
+                ProtocolRequest.CommandOneofCase.Initialize &&
+            transport is ILocalEngineProtocolTransport))
+        {
+            Volatile.Write(
+                ref strictInstanceIdsCapability,
+                response.SupportsStrictInstanceIds
+                    ? CapabilitySupported
+                    : CapabilityUnsupported);
         }
 
         return response;
@@ -860,9 +1127,13 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                 ProtocolRequest.CommandOneofCase.GetRemoteViewportState or
                 ProtocolRequest.CommandOneofCase.GetRemoteViewportDiagnostics or
                 ProtocolRequest.CommandOneofCase.RetryRemoteViewport or
-                ProtocolRequest.CommandOneofCase.SetRemoteViewportMacHostHandle or
+            ProtocolRequest.CommandOneofCase.SetRemoteViewportMacHostHandle or
                 ProtocolRequest.CommandOneofCase.SendRemoteViewportInput or
                 ProtocolRequest.CommandOneofCase.PullEditorViewportEvents or
+                ProtocolRequest.CommandOneofCase.ResolveViewportDropPosition or
+                ProtocolRequest.CommandOneofCase.FocusEditorCamera or
+                ProtocolRequest.CommandOneofCase.SetViewportToolState or
+                ProtocolRequest.CommandOneofCase.GetViewportToolState or
                 ProtocolRequest.CommandOneofCase.ShowMainWindow or
                 ProtocolRequest.CommandOneofCase.IsEngineMainThreadReady =>
                 EngineProtocolInvocationKind.Interactive,
@@ -892,6 +1163,82 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
 
         return normalizedValue;
     }
+
+    static void ValidateNormalizedCoordinate(float value, string parameterName)
+    {
+        if (!float.IsFinite(value) || value < 0.0f || value > 1.0f)
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                value,
+                "Viewport coordinates must be finite and normalized to [0, 1].");
+        }
+    }
+
+    static Vector4 CreateVector4(
+        EngineProtocolVector4 value,
+        string parameterName)
+    {
+        if (!float.IsFinite(value.X) ||
+            !float.IsFinite(value.Y) ||
+            !float.IsFinite(value.Z) ||
+            !float.IsFinite(value.W))
+        {
+            throw new ArgumentOutOfRangeException(
+                parameterName,
+                value,
+                "Vector components must be finite.");
+        }
+
+        return new Vector4
+        {
+            X = value.X,
+            Y = value.Y,
+            Z = value.Z,
+            W = value.W
+        };
+    }
+
+    static EngineProtocolVector4 ReadVector4(
+        Vector4? value,
+        string commandName)
+    {
+        if (value is null ||
+            !float.IsFinite(value.X) ||
+            !float.IsFinite(value.Y) ||
+            !float.IsFinite(value.Z) ||
+            !float.IsFinite(value.W))
+        {
+            throw new EngineProtocolException(
+                $"The protocol response for '{commandName}' contains an invalid vector.");
+        }
+
+        return new EngineProtocolVector4(value.X, value.Y, value.Z, value.W);
+    }
+
+    static ViewportTransformOperation ValidateTransformOperation(
+        ViewportTransformOperation operation)
+        => operation is
+            ViewportTransformOperation.Select or
+            ViewportTransformOperation.Translate or
+            ViewportTransformOperation.Rotate or
+            ViewportTransformOperation.Scale
+            ? operation
+            : throw new ArgumentOutOfRangeException(
+                nameof(operation),
+                operation,
+                "The viewport transform operation is unsupported.");
+
+    static ViewportTransformSpace ValidateTransformSpace(
+        ViewportTransformSpace space)
+        => space is
+            ViewportTransformSpace.World or
+            ViewportTransformSpace.Local
+            ? space
+            : throw new ArgumentOutOfRangeException(
+                nameof(space),
+                space,
+                "The viewport transform space is unsupported.");
 
     static void RequireEmpty(ProtocolResponse response, string commandName)
         => RequireResult<Empty>(response.EmptyResult, commandName);

--- a/Editor/Protocol/Generated/EditorEngine.cs
+++ b/Editor/Protocol/Generated/EditorEngine.cs
@@ -25,7 +25,7 @@ namespace SailorEditor.Protocol.Generated {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "ChNlZGl0b3JfZW5naW5lLnByb3RvEhBzYWlsb3IuZWRpdG9yLnYxIgcKBUVt",
-            "cHR5IoMVCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
+            "cHR5IuwZCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
             "IAEoDRISCgpyZXF1ZXN0X2lkGAIgASgEEjkKCmluaXRpYWxpemUYCiABKAsy",
             "Iy5zYWlsb3IuZWRpdG9yLnYxLkluaXRpYWxpemVSZXF1ZXN0SAASKAoFc3Rh",
             "cnQYCyABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASJwoEc3RvcBgM",
@@ -84,105 +84,150 @@ namespace SailorEditor.Protocol.Generated {
             "cGVzGC4gASgLMhcuc2FpbG9yLmVkaXRvci52MS5FbXB0eUgAEj4KG2lzX2Vu",
             "Z2luZV9tYWluX3RocmVhZF9yZWFkeRgvIAEoCzIXLnNhaWxvci5lZGl0b3Iu",
             "djEuRW1wdHlIABI0ChFpc19lbmdpbmVfcnVubmluZxgwIAEoCzIXLnNhaWxv",
-            "ci5lZGl0b3IudjEuRW1wdHlIAEIJCgdjb21tYW5kSgQIAxAKSgQIMRBkIuQF",
-            "ChBQcm90b2NvbFJlc3BvbnNlEhgKEHByb3RvY29sX3ZlcnNpb24YASABKA0S",
-            "EgoKcmVxdWVzdF9pZBgCIAEoBBIPCgdzdWNjZXNzGAMgASgIEg0KBWVycm9y",
-            "GAQgASgJEi8KDGVtcHR5X3Jlc3VsdBgKIAEoCzIXLnNhaWxvci5lZGl0b3Iu",
-            "djEuRW1wdHlIABIzCgtib29sX3Jlc3VsdBgLIAEoCzIcLnNhaWxvci5lZGl0",
-            "b3IudjEuQm9vbFJlc3VsdEgAEjUKDGludDMyX3Jlc3VsdBgMIAEoCzIdLnNh",
-            "aWxvci5lZGl0b3IudjEuSW50MzJSZXN1bHRIABI3Cg11aW50MzJfcmVzdWx0",
-            "GA0gASgLMh4uc2FpbG9yLmVkaXRvci52MS5VSW50MzJSZXN1bHRIABI3Cg11",
-            "aW50NjRfcmVzdWx0GA4gASgLMh4uc2FpbG9yLmVkaXRvci52MS5VSW50NjRS",
-            "ZXN1bHRIABI3Cg1zdHJpbmdfcmVzdWx0GA8gASgLMh4uc2FpbG9yLmVkaXRv",
-            "ci52MS5TdHJpbmdSZXN1bHRIABJAChJzdHJpbmdfbGlzdF9yZXN1bHQYECAB",
-            "KAsyIi5zYWlsb3IuZWRpdG9yLnYxLlN0cmluZ0xpc3RSZXN1bHRIABJNChlh",
-            "c3NldF9yZWxvYWRfc3RhdGVfcmVzdWx0GBEgASgLMiguc2FpbG9yLmVkaXRv",
-            "ci52MS5Bc3NldFJlbG9hZFN0YXRlUmVzdWx0SAASQAoSaW5zdGFuY2VfaWRf",
-            "cmVzdWx0GBIgASgLMiIuc2FpbG9yLmVkaXRvci52MS5JbnN0YW5jZUlkUmVz",
-            "dWx0SAASUQobdmlld3BvcnRfZXZlbnRfYmF0Y2hfcmVzdWx0GBMgASgLMiou",
-            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHRIAEII",
-            "CgZyZXN1bHRKBAgFEApKBAgUEGQiJgoRSW5pdGlhbGl6ZVJlcXVlc3QSEQoJ",
-            "YXJndW1lbnRzGAEgAygJIiEKDENvdW50UmVxdWVzdBIRCgltYXhfY291bnQY",
-            "ASABKA0iIAoNRmlsZUlkUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJIigKEUlu",
-            "c3RhbmNlSWRSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJIigKEVZpZXdw",
-            "b3J0SWRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEImAKE1ZpZXdwb3J0",
-            "UmVjdFJlcXVlc3QSFAoMd2luZG93X3Bvc194GAEgASgNEhQKDHdpbmRvd19w",
-            "b3NfeRgCIAEoDRINCgV3aWR0aBgDIAEoDRIOCgZoZWlnaHQYBCABKA0iLAoL",
-            "U2l6ZVJlcXVlc3QSDQoFd2lkdGgYASABKA0SDgoGaGVpZ2h0GAIgASgNIpkB",
-            "ChVSZW1vdGVWaWV3cG9ydFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQS",
-            "FAoMd2luZG93X3Bvc194GAIgASgNEhQKDHdpbmRvd19wb3NfeRgDIAEoDRIN",
-            "CgV3aWR0aBgEIAEoDRIOCgZoZWlnaHQYBSABKA0SDwoHdmlzaWJsZRgGIAEo",
-            "CBIPCgdmb2N1c2VkGAcgASgIImUKGVJlbW90ZVZpZXdwb3J0SG9zdFJlcXVl",
-            "c3QSEwoLdmlld3BvcnRfaWQYASABKAQSGAoQaG9zdF9oYW5kbGVfa2luZBgC",
-            "IAEoDRIZChFob3N0X2hhbmRsZV92YWx1ZRgDIAEoBCL8AQoaUmVtb3RlVmll",
-            "d3BvcnRJbnB1dFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQSDAoEa2lu",
-            "ZBgCIAEoDRIRCglwb2ludGVyX3gYAyABKAISEQoJcG9pbnRlcl95GAQgASgC",
-            "EhUKDXdoZWVsX2RlbHRhX3gYBSABKAISFQoNd2hlZWxfZGVsdGFfeRgGIAEo",
-            "AhIQCghrZXlfY29kZRgHIAEoDRIOCgZidXR0b24YCCABKA0SEQoJbW9kaWZp",
-            "ZXJzGAkgASgNEg8KB3ByZXNzZWQYCiABKAgSDwoHZm9jdXNlZBgLIAEoCBIQ",
-            "CghjYXB0dXJlZBgMIAEoCCJDCh5NYW5hZ2VkTXV0YXRpb25SZXZpc2lvblJl",
-            "cXVlc3QSDAoEa2luZBgBIAEoDRITCgtpbnN0YW5jZV9pZBgCIAEoCSJAChNV",
-            "cGRhdGVPYmplY3RSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEhQKDHlh",
-            "bWxfY2hhbmdlcxgCIAEoCSJmChVSZXBhcmVudE9iamVjdFJlcXVlc3QSEwoL",
-            "aW5zdGFuY2VfaWQYASABKAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAIgASgJ",
-            "EhwKFGtlZXBfd29ybGRfdHJhbnNmb3JtGAMgASgIIlQKF0NyZWF0ZUdhbWVP",
-            "YmplY3RSZXF1ZXN0EhoKEnBhcmVudF9pbnN0YW5jZV9pZBgBIAEoCRIdChVw",
-            "cmVmZXJyZWRfaW5zdGFuY2VfaWQYAiABKAkiZgoTQWRkQ29tcG9uZW50UmVx",
-            "dWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCRIbChNjb21wb25lbnRfdHlwZV9u",
-            "YW1lGAIgASgJEh0KFXByZWZlcnJlZF9pbnN0YW5jZV9pZBgDIAEoCSJHChhJ",
-            "bnN0YW50aWF0ZVByZWZhYlJlcXVlc3QSDwoHZmlsZV9pZBgBIAEoCRIaChJw",
-            "YXJlbnRfaW5zdGFuY2VfaWQYAiABKAkiUwogSW5zdGFudGlhdGVQcmVmYWJG",
-            "cm9tWWFtbFJlcXVlc3QSEwoLcHJlZmFiX3lhbWwYASABKAkSGgoScGFyZW50",
-            "X2luc3RhbmNlX2lkGAIgASgJIigKEFNlbGVjdGlvblJlcXVlc3QSFAoMaW5z",
-            "dGFuY2VfaWRzGAEgAygJIiUKFVNob3dNYWluV2luZG93UmVxdWVzdBIMCgRz",
-            "aG93GAEgASgIIogBChxSZW5kZXJQYXRoVHJhY2VkSW1hZ2VSZXF1ZXN0EhMK",
-            "C291dHB1dF9wYXRoGAEgASgJEhMKC2luc3RhbmNlX2lkGAIgASgJEg4KBmhl",
-            "aWdodBgDIAEoDRIZChFzYW1wbGVzX3Blcl9waXhlbBgEIAEoDRITCgttYXhf",
-            "Ym91bmNlcxgFIAEoDSIbCgpCb29sUmVzdWx0Eg0KBXZhbHVlGAEgASgIIhwK",
-            "C0ludDMyUmVzdWx0Eg0KBXZhbHVlGAEgASgFIh0KDFVJbnQzMlJlc3VsdBIN",
-            "CgV2YWx1ZRgBIAEoDSIdCgxVSW50NjRSZXN1bHQSDQoFdmFsdWUYASABKAQi",
-            "MAoMU3RyaW5nUmVzdWx0EhEKCWhhc192YWx1ZRgBIAEoCBINCgV2YWx1ZRgC",
-            "IAEoCSIiChBTdHJpbmdMaXN0UmVzdWx0Eg4KBnZhbHVlcxgBIAMoCSKEAQoW",
-            "QXNzZXRSZWxvYWRTdGF0ZVJlc3VsdBIRCglhdmFpbGFibGUYASABKAgSGgoS",
-            "cmVxdWVzdF9nZW5lcmF0aW9uGAIgASgEEhwKFGNvbXBsZXRlZF9nZW5lcmF0",
-            "aW9uGAMgASgEEh0KFXN1Y2Nlc3NmdWxfZ2VuZXJhdGlvbhgEIAEoBCI6ChBJ",
-            "bnN0YW5jZUlkUmVzdWx0EhEKCXN1Y2NlZWRlZBgBIAEoCBITCgtpbnN0YW5j",
-            "ZV9pZBgCIAEoCSI1CgdWZWN0b3I0EgkKAXgYASABKAISCQoBeRgCIAEoAhIJ",
-            "CgF6GAMgASgCEgkKAXcYBCABKAIiNgoWVmlld3BvcnRTZWxlY3Rpb25FdmVu",
-            "dBIcChRzZWxlY3RlZF9pbnN0YW5jZV9pZBgBIAEoCSLWAwoWVmlld3BvcnRU",
-            "cmFuc2Zvcm1FdmVudBITCgtpbnN0YW5jZV9pZBgBIAEoCRI/CglvcGVyYXRp",
-            "b24YAiABKA4yLC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3Jt",
-            "T3BlcmF0aW9uEjcKBXNwYWNlGAMgASgOMiguc2FpbG9yLmVkaXRvci52MS5W",
-            "aWV3cG9ydFRyYW5zZm9ybVNwYWNlEjIKD2JlZm9yZV9wb3NpdGlvbhgEIAEo",
-            "CzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNBIyCg9iZWZvcmVfcm90YXRp",
-            "b24YBSABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQSLwoMYmVmb3Jl",
-            "X3NjYWxlGAYgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0EjEKDmFm",
-            "dGVyX3Bvc2l0aW9uGAcgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0",
-            "EjEKDmFmdGVyX3JvdGF0aW9uGAggASgLMhkuc2FpbG9yLmVkaXRvci52MS5W",
-            "ZWN0b3I0Ei4KC2FmdGVyX3NjYWxlGAkgASgLMhkuc2FpbG9yLmVkaXRvci52",
-            "MS5WZWN0b3I0ItMBCg1WaWV3cG9ydEV2ZW50EhAKCHJldmlzaW9uGAEgASgE",
-            "EiEKGW1hbmFnZWRfbXV0YXRpb25fcmV2aXNpb24YAiABKAQSPQoJc2VsZWN0",
-            "aW9uGAogASgLMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFNlbGVjdGlv",
-            "bkV2ZW50SAASPQoJdHJhbnNmb3JtGAsgASgLMiguc2FpbG9yLmVkaXRvci52",
-            "MS5WaWV3cG9ydFRyYW5zZm9ybUV2ZW50SABCCQoHcGF5bG9hZEoECAMQCiJL",
-            "ChhWaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHQSLwoGZXZlbnRzGAEgAygLMh8u",
-            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEV2ZW50KvABChpWaWV3cG9ydFRy",
-            "YW5zZm9ybU9wZXJhdGlvbhIsCihWSUVXUE9SVF9UUkFOU0ZPUk1fT1BFUkFU",
-            "SU9OX1VOU1BFQ0lGSUVEEAASJwojVklFV1BPUlRfVFJBTlNGT1JNX09QRVJB",
-            "VElPTl9TRUxFQ1QQARIqCiZWSUVXUE9SVF9UUkFOU0ZPUk1fT1BFUkFUSU9O",
-            "X1RSQU5TTEFURRACEicKI1ZJRVdQT1JUX1RSQU5TRk9STV9PUEVSQVRJT05f",
-            "Uk9UQVRFEAMSJgoiVklFV1BPUlRfVFJBTlNGT1JNX09QRVJBVElPTl9TQ0FM",
-            "RRAEKooBChZWaWV3cG9ydFRyYW5zZm9ybVNwYWNlEigKJFZJRVdQT1JUX1RS",
-            "QU5TRk9STV9TUEFDRV9VTlNQRUNJRklFRBAAEiIKHlZJRVdQT1JUX1RSQU5T",
-            "Rk9STV9TUEFDRV9XT1JMRBABEiIKHlZJRVdQT1JUX1RSQU5TRk9STV9TUEFD",
-            "RV9MT0NBTBACQiKqAh9TYWlsb3JFZGl0b3IuUHJvdG9jb2wuR2VuZXJhdGVk",
-            "YgZwcm90bzM="));
+            "ci5lZGl0b3IudjEuRW1wdHlIABJXCh5yZXNvbHZlX3ZpZXdwb3J0X2Ryb3Bf",
+            "cG9zaXRpb24YMSABKAsyLS5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0RHJv",
+            "cFBvc2l0aW9uUmVxdWVzdEgAElIKGGNyZWF0ZV9tb2RlbF9nYW1lX29iamVj",
+            "dBgyIAEoCzIuLnNhaWxvci5lZGl0b3IudjEuQ3JlYXRlTW9kZWxHYW1lT2Jq",
+            "ZWN0UmVxdWVzdEgAElkKG2luc3RhbnRpYXRlX3ByZWZhYl9pbnN0YW5jZRgz",
+            "IAEoCzIyLnNhaWxvci5lZGl0b3IudjEuSW5zdGFudGlhdGVQcmVmYWJJbnN0",
+            "YW5jZVJlcXVlc3RIABJGChNmb2N1c19lZGl0b3JfY2FtZXJhGDQgASgLMicu",
+            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydE9iamVjdFJlcXVlc3RIABI+Cg9z",
+            "ZXRfcHJlZmFiX2xpbmsYNSABKAsyIy5zYWlsb3IuZWRpdG9yLnYxLlByZWZh",
+            "YkxpbmtSZXF1ZXN0SAASQAoRYnJlYWtfcHJlZmFiX2xpbmsYNiABKAsyIy5z",
+            "YWlsb3IuZWRpdG9yLnYxLkluc3RhbmNlSWRSZXF1ZXN0SAASTQoXc2V0X3Zp",
+            "ZXdwb3J0X3Rvb2xfc3RhdGUYNyABKAsyKi5zYWlsb3IuZWRpdG9yLnYxLlZp",
+            "ZXdwb3J0VG9vbFN0YXRlUmVxdWVzdEgAEkYKF2dldF92aWV3cG9ydF90b29s",
+            "X3N0YXRlGDggASgLMiMuc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydElkUmVx",
+            "dWVzdEgAQgkKB2NvbW1hbmRKBAgDEApKBAg5EGQilgcKEFByb3RvY29sUmVz",
+            "cG9uc2USGAoQcHJvdG9jb2xfdmVyc2lvbhgBIAEoDRISCgpyZXF1ZXN0X2lk",
+            "GAIgASgEEg8KB3N1Y2Nlc3MYAyABKAgSDQoFZXJyb3IYBCABKAkSJAocc3Vw",
+            "cG9ydHNfc3RyaWN0X2luc3RhbmNlX2lkcxgFIAEoCBIvCgxlbXB0eV9yZXN1",
+            "bHQYCiABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASMwoLYm9vbF9y",
+            "ZXN1bHQYCyABKAsyHC5zYWlsb3IuZWRpdG9yLnYxLkJvb2xSZXN1bHRIABI1",
+            "CgxpbnQzMl9yZXN1bHQYDCABKAsyHS5zYWlsb3IuZWRpdG9yLnYxLkludDMy",
+            "UmVzdWx0SAASNwoNdWludDMyX3Jlc3VsdBgNIAEoCzIeLnNhaWxvci5lZGl0",
+            "b3IudjEuVUludDMyUmVzdWx0SAASNwoNdWludDY0X3Jlc3VsdBgOIAEoCzIe",
+            "LnNhaWxvci5lZGl0b3IudjEuVUludDY0UmVzdWx0SAASNwoNc3RyaW5nX3Jl",
+            "c3VsdBgPIAEoCzIeLnNhaWxvci5lZGl0b3IudjEuU3RyaW5nUmVzdWx0SAAS",
+            "QAoSc3RyaW5nX2xpc3RfcmVzdWx0GBAgASgLMiIuc2FpbG9yLmVkaXRvci52",
+            "MS5TdHJpbmdMaXN0UmVzdWx0SAASTQoZYXNzZXRfcmVsb2FkX3N0YXRlX3Jl",
+            "c3VsdBgRIAEoCzIoLnNhaWxvci5lZGl0b3IudjEuQXNzZXRSZWxvYWRTdGF0",
+            "ZVJlc3VsdEgAEkAKEmluc3RhbmNlX2lkX3Jlc3VsdBgSIAEoCzIiLnNhaWxv",
+            "ci5lZGl0b3IudjEuSW5zdGFuY2VJZFJlc3VsdEgAElEKG3ZpZXdwb3J0X2V2",
+            "ZW50X2JhdGNoX3Jlc3VsdBgTIAEoCzIqLnNhaWxvci5lZGl0b3IudjEuVmll",
+            "d3BvcnRFdmVudEJhdGNoUmVzdWx0SAASOQoOdmVjdG9yNF9yZXN1bHQYFCAB",
+            "KAsyHy5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjRSZXN1bHRIABJPChp2aWV3",
+            "cG9ydF90b29sX3N0YXRlX3Jlc3VsdBgVIAEoCzIpLnNhaWxvci5lZGl0b3Iu",
+            "djEuVmlld3BvcnRUb29sU3RhdGVSZXN1bHRIAEIICgZyZXN1bHRKBAgGEApK",
+            "BAgWEGQiJgoRSW5pdGlhbGl6ZVJlcXVlc3QSEQoJYXJndW1lbnRzGAEgAygJ",
+            "IiEKDENvdW50UmVxdWVzdBIRCgltYXhfY291bnQYASABKA0iIAoNRmlsZUlk",
+            "UmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJIigKEUluc3RhbmNlSWRSZXF1ZXN0",
+            "EhMKC2luc3RhbmNlX2lkGAEgASgJIigKEVZpZXdwb3J0SWRSZXF1ZXN0EhMK",
+            "C3ZpZXdwb3J0X2lkGAEgASgEImAKE1ZpZXdwb3J0UmVjdFJlcXVlc3QSFAoM",
+            "d2luZG93X3Bvc194GAEgASgNEhQKDHdpbmRvd19wb3NfeRgCIAEoDRINCgV3",
+            "aWR0aBgDIAEoDRIOCgZoZWlnaHQYBCABKA0iLAoLU2l6ZVJlcXVlc3QSDQoF",
+            "d2lkdGgYASABKA0SDgoGaGVpZ2h0GAIgASgNIpkBChVSZW1vdGVWaWV3cG9y",
+            "dFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQSFAoMd2luZG93X3Bvc194",
+            "GAIgASgNEhQKDHdpbmRvd19wb3NfeRgDIAEoDRINCgV3aWR0aBgEIAEoDRIO",
+            "CgZoZWlnaHQYBSABKA0SDwoHdmlzaWJsZRgGIAEoCBIPCgdmb2N1c2VkGAcg",
+            "ASgIImUKGVJlbW90ZVZpZXdwb3J0SG9zdFJlcXVlc3QSEwoLdmlld3BvcnRf",
+            "aWQYASABKAQSGAoQaG9zdF9oYW5kbGVfa2luZBgCIAEoDRIZChFob3N0X2hh",
+            "bmRsZV92YWx1ZRgDIAEoBCL8AQoaUmVtb3RlVmlld3BvcnRJbnB1dFJlcXVl",
+            "c3QSEwoLdmlld3BvcnRfaWQYASABKAQSDAoEa2luZBgCIAEoDRIRCglwb2lu",
+            "dGVyX3gYAyABKAISEQoJcG9pbnRlcl95GAQgASgCEhUKDXdoZWVsX2RlbHRh",
+            "X3gYBSABKAISFQoNd2hlZWxfZGVsdGFfeRgGIAEoAhIQCghrZXlfY29kZRgH",
+            "IAEoDRIOCgZidXR0b24YCCABKA0SEQoJbW9kaWZpZXJzGAkgASgNEg8KB3By",
+            "ZXNzZWQYCiABKAgSDwoHZm9jdXNlZBgLIAEoCBIQCghjYXB0dXJlZBgMIAEo",
+            "CCJDCh5NYW5hZ2VkTXV0YXRpb25SZXZpc2lvblJlcXVlc3QSDAoEa2luZBgB",
+            "IAEoDRITCgtpbnN0YW5jZV9pZBgCIAEoCSJAChNVcGRhdGVPYmplY3RSZXF1",
+            "ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEhQKDHlhbWxfY2hhbmdlcxgCIAEo",
+            "CSJmChVSZXBhcmVudE9iamVjdFJlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASAB",
+            "KAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAIgASgJEhwKFGtlZXBfd29ybGRf",
+            "dHJhbnNmb3JtGAMgASgIIlQKF0NyZWF0ZUdhbWVPYmplY3RSZXF1ZXN0EhoK",
+            "EnBhcmVudF9pbnN0YW5jZV9pZBgBIAEoCRIdChVwcmVmZXJyZWRfaW5zdGFu",
+            "Y2VfaWQYAiABKAkiZgoTQWRkQ29tcG9uZW50UmVxdWVzdBITCgtpbnN0YW5j",
+            "ZV9pZBgBIAEoCRIbChNjb21wb25lbnRfdHlwZV9uYW1lGAIgASgJEh0KFXBy",
+            "ZWZlcnJlZF9pbnN0YW5jZV9pZBgDIAEoCSJHChhJbnN0YW50aWF0ZVByZWZh",
+            "YlJlcXVlc3QSDwoHZmlsZV9pZBgBIAEoCRIaChJwYXJlbnRfaW5zdGFuY2Vf",
+            "aWQYAiABKAkicAogSW5zdGFudGlhdGVQcmVmYWJGcm9tWWFtbFJlcXVlc3QS",
+            "EwoLcHJlZmFiX3lhbWwYASABKAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAIg",
+            "ASgJEhsKE3N0cmljdF9pbnN0YW5jZV9pZHMYAyABKAgiXgobVmlld3BvcnRE",
+            "cm9wUG9zaXRpb25SZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhQKDG5v",
+            "cm1hbGl6ZWRfeBgCIAEoAhIUCgxub3JtYWxpemVkX3kYAyABKAIisAEKHENy",
+            "ZWF0ZU1vZGVsR2FtZU9iamVjdFJlcXVlc3QSFQoNbW9kZWxfZmlsZV9pZBgB",
+            "IAEoCRIMCgRuYW1lGAIgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgDIAEo",
+            "CRIcChRhcHBseV93b3JsZF9wb3NpdGlvbhgEIAEoCBIxCg53b3JsZF9wb3Np",
+            "dGlvbhgFIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNCKgAQogSW5z",
+            "dGFudGlhdGVQcmVmYWJJbnN0YW5jZVJlcXVlc3QSDwoHZmlsZV9pZBgBIAEo",
+            "CRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAiABKAkSHAoUYXBwbHlfd29ybGRf",
+            "cG9zaXRpb24YAyABKAgSMQoOd29ybGRfcG9zaXRpb24YBCABKAsyGS5zYWls",
+            "b3IuZWRpdG9yLnYxLlZlY3RvcjQiQQoVVmlld3BvcnRPYmplY3RSZXF1ZXN0",
+            "EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhMKC2luc3RhbmNlX2lkGAIgASgJIjkK",
+            "EVByZWZhYkxpbmtSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEg8KB2Zp",
+            "bGVfaWQYAiABKAkiqQEKGFZpZXdwb3J0VG9vbFN0YXRlUmVxdWVzdBITCgt2",
+            "aWV3cG9ydF9pZBgBIAEoBBI/CglvcGVyYXRpb24YAiABKA4yLC5zYWlsb3Iu",
+            "ZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtT3BlcmF0aW9uEjcKBXNwYWNl",
+            "GAMgASgOMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybVNw",
+            "YWNlIigKEFNlbGVjdGlvblJlcXVlc3QSFAoMaW5zdGFuY2VfaWRzGAEgAygJ",
+            "IiUKFVNob3dNYWluV2luZG93UmVxdWVzdBIMCgRzaG93GAEgASgIIogBChxS",
+            "ZW5kZXJQYXRoVHJhY2VkSW1hZ2VSZXF1ZXN0EhMKC291dHB1dF9wYXRoGAEg",
+            "ASgJEhMKC2luc3RhbmNlX2lkGAIgASgJEg4KBmhlaWdodBgDIAEoDRIZChFz",
+            "YW1wbGVzX3Blcl9waXhlbBgEIAEoDRITCgttYXhfYm91bmNlcxgFIAEoDSIb",
+            "CgpCb29sUmVzdWx0Eg0KBXZhbHVlGAEgASgIIhwKC0ludDMyUmVzdWx0Eg0K",
+            "BXZhbHVlGAEgASgFIh0KDFVJbnQzMlJlc3VsdBINCgV2YWx1ZRgBIAEoDSId",
+            "CgxVSW50NjRSZXN1bHQSDQoFdmFsdWUYASABKAQiMAoMU3RyaW5nUmVzdWx0",
+            "EhEKCWhhc192YWx1ZRgBIAEoCBINCgV2YWx1ZRgCIAEoCSIiChBTdHJpbmdM",
+            "aXN0UmVzdWx0Eg4KBnZhbHVlcxgBIAMoCSKEAQoWQXNzZXRSZWxvYWRTdGF0",
+            "ZVJlc3VsdBIRCglhdmFpbGFibGUYASABKAgSGgoScmVxdWVzdF9nZW5lcmF0",
+            "aW9uGAIgASgEEhwKFGNvbXBsZXRlZF9nZW5lcmF0aW9uGAMgASgEEh0KFXN1",
+            "Y2Nlc3NmdWxfZ2VuZXJhdGlvbhgEIAEoBCI6ChBJbnN0YW5jZUlkUmVzdWx0",
+            "EhEKCXN1Y2NlZWRlZBgBIAEoCBITCgtpbnN0YW5jZV9pZBgCIAEoCSI5Cg1W",
+            "ZWN0b3I0UmVzdWx0EigKBXZhbHVlGAEgASgLMhkuc2FpbG9yLmVkaXRvci52",
+            "MS5WZWN0b3I0IpMBChdWaWV3cG9ydFRvb2xTdGF0ZVJlc3VsdBI/CglvcGVy",
+            "YXRpb24YASABKA4yLC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNm",
+            "b3JtT3BlcmF0aW9uEjcKBXNwYWNlGAIgASgOMiguc2FpbG9yLmVkaXRvci52",
+            "MS5WaWV3cG9ydFRyYW5zZm9ybVNwYWNlIjUKB1ZlY3RvcjQSCQoBeBgBIAEo",
+            "AhIJCgF5GAIgASgCEgkKAXoYAyABKAISCQoBdxgEIAEoAiI2ChZWaWV3cG9y",
+            "dFNlbGVjdGlvbkV2ZW50EhwKFHNlbGVjdGVkX2luc3RhbmNlX2lkGAEgASgJ",
+            "ItYDChZWaWV3cG9ydFRyYW5zZm9ybUV2ZW50EhMKC2luc3RhbmNlX2lkGAEg",
+            "ASgJEj8KCW9wZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmll",
+            "d3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAyABKA4yKC5zYWls",
+            "b3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2USMgoPYmVmb3Jl",
+            "X3Bvc2l0aW9uGAQgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0EjIK",
+            "D2JlZm9yZV9yb3RhdGlvbhgFIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVj",
+            "dG9yNBIvCgxiZWZvcmVfc2NhbGUYBiABKAsyGS5zYWlsb3IuZWRpdG9yLnYx",
+            "LlZlY3RvcjQSMQoOYWZ0ZXJfcG9zaXRpb24YByABKAsyGS5zYWlsb3IuZWRp",
+            "dG9yLnYxLlZlY3RvcjQSMQoOYWZ0ZXJfcm90YXRpb24YCCABKAsyGS5zYWls",
+            "b3IuZWRpdG9yLnYxLlZlY3RvcjQSLgoLYWZ0ZXJfc2NhbGUYCSABKAsyGS5z",
+            "YWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQiVQoWVmlld3BvcnRBc3NldERyb3BF",
+            "dmVudBIPCgdmaWxlX2lkGAEgASgJEhQKDG5vcm1hbGl6ZWRfeBgCIAEoAhIU",
+            "Cgxub3JtYWxpemVkX3kYAyABKAIiLQoZVmlld3BvcnRUb29sU2hvcnRjdXRF",
+            "dmVudBIQCghrZXlfY29kZRgBIAEoDSLZAgoNVmlld3BvcnRFdmVudBIQCghy",
+            "ZXZpc2lvbhgBIAEoBBIhChltYW5hZ2VkX211dGF0aW9uX3JldmlzaW9uGAIg",
+            "ASgEEj0KCXNlbGVjdGlvbhgKIAEoCzIoLnNhaWxvci5lZGl0b3IudjEuVmll",
+            "d3BvcnRTZWxlY3Rpb25FdmVudEgAEj0KCXRyYW5zZm9ybRgLIAEoCzIoLnNh",
+            "aWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1FdmVudEgAEj4KCmFz",
+            "c2V0X2Ryb3AYDCABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0QXNz",
+            "ZXREcm9wRXZlbnRIABJECg10b29sX3Nob3J0Y3V0GA0gASgLMisuc2FpbG9y",
+            "LmVkaXRvci52MS5WaWV3cG9ydFRvb2xTaG9ydGN1dEV2ZW50SABCCQoHcGF5",
+            "bG9hZEoECAMQCiJLChhWaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHQSLwoGZXZl",
+            "bnRzGAEgAygLMh8uc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEV2ZW50KvAB",
+            "ChpWaWV3cG9ydFRyYW5zZm9ybU9wZXJhdGlvbhIsCihWSUVXUE9SVF9UUkFO",
+            "U0ZPUk1fT1BFUkFUSU9OX1VOU1BFQ0lGSUVEEAASJwojVklFV1BPUlRfVFJB",
+            "TlNGT1JNX09QRVJBVElPTl9TRUxFQ1QQARIqCiZWSUVXUE9SVF9UUkFOU0ZP",
+            "Uk1fT1BFUkFUSU9OX1RSQU5TTEFURRACEicKI1ZJRVdQT1JUX1RSQU5TRk9S",
+            "TV9PUEVSQVRJT05fUk9UQVRFEAMSJgoiVklFV1BPUlRfVFJBTlNGT1JNX09Q",
+            "RVJBVElPTl9TQ0FMRRAEKooBChZWaWV3cG9ydFRyYW5zZm9ybVNwYWNlEigK",
+            "JFZJRVdQT1JUX1RSQU5TRk9STV9TUEFDRV9VTlNQRUNJRklFRBAAEiIKHlZJ",
+            "RVdQT1JUX1RSQU5TRk9STV9TUEFDRV9XT1JMRBABEiIKHlZJRVdQT1JUX1RS",
+            "QU5TRk9STV9TUEFDRV9MT0NBTBACQiKqAh9TYWlsb3JFZGl0b3IuUHJvdG9j",
+            "b2wuR2VuZXJhdGVkYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::SailorEditor.Protocol.Generated.ViewportTransformOperation), typeof(global::SailorEditor.Protocol.Generated.ViewportTransformSpace), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Empty), global::SailorEditor.Protocol.Generated.Empty.Parser, null, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning" }, new[]{ "Command" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult" }, new[]{ "Result" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "ResolveViewportDropPosition", "CreateModelGameObject", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState" }, new[]{ "Command" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "SupportsStrictInstanceIds", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult", "Vector4Result", "ViewportToolStateResult" }, new[]{ "Result" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InitializeRequest), global::SailorEditor.Protocol.Generated.InitializeRequest.Parser, new[]{ "Arguments" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CountRequest), global::SailorEditor.Protocol.Generated.CountRequest.Parser, new[]{ "MaxCount" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.FileIdRequest), global::SailorEditor.Protocol.Generated.FileIdRequest.Parser, new[]{ "FileId" }, null, null, null, null),
@@ -199,7 +244,13 @@ namespace SailorEditor.Protocol.Generated {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CreateGameObjectRequest), global::SailorEditor.Protocol.Generated.CreateGameObjectRequest.Parser, new[]{ "ParentInstanceId", "PreferredInstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.AddComponentRequest), global::SailorEditor.Protocol.Generated.AddComponentRequest.Parser, new[]{ "InstanceId", "ComponentTypeName", "PreferredInstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstantiatePrefabRequest), global::SailorEditor.Protocol.Generated.InstantiatePrefabRequest.Parser, new[]{ "FileId", "ParentInstanceId" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstantiatePrefabFromYamlRequest), global::SailorEditor.Protocol.Generated.InstantiatePrefabFromYamlRequest.Parser, new[]{ "PrefabYaml", "ParentInstanceId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstantiatePrefabFromYamlRequest), global::SailorEditor.Protocol.Generated.InstantiatePrefabFromYamlRequest.Parser, new[]{ "PrefabYaml", "ParentInstanceId", "StrictInstanceIds" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest), global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest.Parser, new[]{ "ViewportId", "NormalizedX", "NormalizedY" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest), global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest.Parser, new[]{ "ModelFileId", "Name", "ParentInstanceId", "ApplyWorldPosition", "WorldPosition" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest), global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest.Parser, new[]{ "FileId", "ParentInstanceId", "ApplyWorldPosition", "WorldPosition" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportObjectRequest), global::SailorEditor.Protocol.Generated.ViewportObjectRequest.Parser, new[]{ "ViewportId", "InstanceId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.PrefabLinkRequest), global::SailorEditor.Protocol.Generated.PrefabLinkRequest.Parser, new[]{ "InstanceId", "FileId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportToolStateRequest), global::SailorEditor.Protocol.Generated.ViewportToolStateRequest.Parser, new[]{ "ViewportId", "Operation", "Space" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.SelectionRequest), global::SailorEditor.Protocol.Generated.SelectionRequest.Parser, new[]{ "InstanceIds" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ShowMainWindowRequest), global::SailorEditor.Protocol.Generated.ShowMainWindowRequest.Parser, new[]{ "Show" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.RenderPathTracedImageRequest), global::SailorEditor.Protocol.Generated.RenderPathTracedImageRequest.Parser, new[]{ "OutputPath", "InstanceId", "Height", "SamplesPerPixel", "MaxBounces" }, null, null, null, null),
@@ -211,10 +262,14 @@ namespace SailorEditor.Protocol.Generated {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.StringListResult), global::SailorEditor.Protocol.Generated.StringListResult.Parser, new[]{ "Values" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.AssetReloadStateResult), global::SailorEditor.Protocol.Generated.AssetReloadStateResult.Parser, new[]{ "Available", "RequestGeneration", "CompletedGeneration", "SuccessfulGeneration" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstanceIdResult), global::SailorEditor.Protocol.Generated.InstanceIdResult.Parser, new[]{ "Succeeded", "InstanceId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Vector4Result), global::SailorEditor.Protocol.Generated.Vector4Result.Parser, new[]{ "Value" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportToolStateResult), global::SailorEditor.Protocol.Generated.ViewportToolStateResult.Parser, new[]{ "Operation", "Space" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Vector4), global::SailorEditor.Protocol.Generated.Vector4.Parser, new[]{ "X", "Y", "Z", "W" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportSelectionEvent), global::SailorEditor.Protocol.Generated.ViewportSelectionEvent.Parser, new[]{ "SelectedInstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportTransformEvent), global::SailorEditor.Protocol.Generated.ViewportTransformEvent.Parser, new[]{ "InstanceId", "Operation", "Space", "BeforePosition", "BeforeRotation", "BeforeScale", "AfterPosition", "AfterRotation", "AfterScale" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportEvent), global::SailorEditor.Protocol.Generated.ViewportEvent.Parser, new[]{ "Revision", "ManagedMutationRevision", "Selection", "Transform" }, new[]{ "Payload" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportAssetDropEvent), global::SailorEditor.Protocol.Generated.ViewportAssetDropEvent.Parser, new[]{ "FileId", "NormalizedX", "NormalizedY" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportToolShortcutEvent), global::SailorEditor.Protocol.Generated.ViewportToolShortcutEvent.Parser, new[]{ "KeyCode" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportEvent), global::SailorEditor.Protocol.Generated.ViewportEvent.Parser, new[]{ "Revision", "ManagedMutationRevision", "Selection", "Transform", "AssetDrop", "ToolShortcut" }, new[]{ "Payload" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportEventBatchResult), global::SailorEditor.Protocol.Generated.ViewportEventBatchResult.Parser, new[]{ "Events" }, null, null, null, null)
           }));
     }
@@ -554,6 +609,30 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case CommandOneofCase.IsEngineRunning:
           IsEngineRunning = other.IsEngineRunning.Clone();
+          break;
+        case CommandOneofCase.ResolveViewportDropPosition:
+          ResolveViewportDropPosition = other.ResolveViewportDropPosition.Clone();
+          break;
+        case CommandOneofCase.CreateModelGameObject:
+          CreateModelGameObject = other.CreateModelGameObject.Clone();
+          break;
+        case CommandOneofCase.InstantiatePrefabInstance:
+          InstantiatePrefabInstance = other.InstantiatePrefabInstance.Clone();
+          break;
+        case CommandOneofCase.FocusEditorCamera:
+          FocusEditorCamera = other.FocusEditorCamera.Clone();
+          break;
+        case CommandOneofCase.SetPrefabLink:
+          SetPrefabLink = other.SetPrefabLink.Clone();
+          break;
+        case CommandOneofCase.BreakPrefabLink:
+          BreakPrefabLink = other.BreakPrefabLink.Clone();
+          break;
+        case CommandOneofCase.SetViewportToolState:
+          SetViewportToolState = other.SetViewportToolState.Clone();
+          break;
+        case CommandOneofCase.GetViewportToolState:
+          GetViewportToolState = other.GetViewportToolState.Clone();
           break;
       }
 
@@ -1058,6 +1137,102 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "resolve_viewport_drop_position" field.</summary>
+    public const int ResolveViewportDropPositionFieldNumber = 49;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest ResolveViewportDropPosition {
+      get { return commandCase_ == CommandOneofCase.ResolveViewportDropPosition ? (global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.ResolveViewportDropPosition;
+      }
+    }
+
+    /// <summary>Field number for the "create_model_game_object" field.</summary>
+    public const int CreateModelGameObjectFieldNumber = 50;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest CreateModelGameObject {
+      get { return commandCase_ == CommandOneofCase.CreateModelGameObject ? (global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.CreateModelGameObject;
+      }
+    }
+
+    /// <summary>Field number for the "instantiate_prefab_instance" field.</summary>
+    public const int InstantiatePrefabInstanceFieldNumber = 51;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest InstantiatePrefabInstance {
+      get { return commandCase_ == CommandOneofCase.InstantiatePrefabInstance ? (global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.InstantiatePrefabInstance;
+      }
+    }
+
+    /// <summary>Field number for the "focus_editor_camera" field.</summary>
+    public const int FocusEditorCameraFieldNumber = 52;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportObjectRequest FocusEditorCamera {
+      get { return commandCase_ == CommandOneofCase.FocusEditorCamera ? (global::SailorEditor.Protocol.Generated.ViewportObjectRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.FocusEditorCamera;
+      }
+    }
+
+    /// <summary>Field number for the "set_prefab_link" field.</summary>
+    public const int SetPrefabLinkFieldNumber = 53;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.PrefabLinkRequest SetPrefabLink {
+      get { return commandCase_ == CommandOneofCase.SetPrefabLink ? (global::SailorEditor.Protocol.Generated.PrefabLinkRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.SetPrefabLink;
+      }
+    }
+
+    /// <summary>Field number for the "break_prefab_link" field.</summary>
+    public const int BreakPrefabLinkFieldNumber = 54;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.InstanceIdRequest BreakPrefabLink {
+      get { return commandCase_ == CommandOneofCase.BreakPrefabLink ? (global::SailorEditor.Protocol.Generated.InstanceIdRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.BreakPrefabLink;
+      }
+    }
+
+    /// <summary>Field number for the "set_viewport_tool_state" field.</summary>
+    public const int SetViewportToolStateFieldNumber = 55;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportToolStateRequest SetViewportToolState {
+      get { return commandCase_ == CommandOneofCase.SetViewportToolState ? (global::SailorEditor.Protocol.Generated.ViewportToolStateRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.SetViewportToolState;
+      }
+    }
+
+    /// <summary>Field number for the "get_viewport_tool_state" field.</summary>
+    public const int GetViewportToolStateFieldNumber = 56;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportIdRequest GetViewportToolState {
+      get { return commandCase_ == CommandOneofCase.GetViewportToolState ? (global::SailorEditor.Protocol.Generated.ViewportIdRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.GetViewportToolState;
+      }
+    }
+
     private object command_;
     /// <summary>Enum of possible cases for the "command" oneof.</summary>
     public enum CommandOneofCase {
@@ -1101,6 +1276,14 @@ namespace SailorEditor.Protocol.Generated {
       SerializeEngineTypes = 46,
       IsEngineMainThreadReady = 47,
       IsEngineRunning = 48,
+      ResolveViewportDropPosition = 49,
+      CreateModelGameObject = 50,
+      InstantiatePrefabInstance = 51,
+      FocusEditorCamera = 52,
+      SetPrefabLink = 53,
+      BreakPrefabLink = 54,
+      SetViewportToolState = 55,
+      GetViewportToolState = 56,
     }
     private CommandOneofCase commandCase_ = CommandOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1172,6 +1355,14 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(SerializeEngineTypes, other.SerializeEngineTypes)) return false;
       if (!object.Equals(IsEngineMainThreadReady, other.IsEngineMainThreadReady)) return false;
       if (!object.Equals(IsEngineRunning, other.IsEngineRunning)) return false;
+      if (!object.Equals(ResolveViewportDropPosition, other.ResolveViewportDropPosition)) return false;
+      if (!object.Equals(CreateModelGameObject, other.CreateModelGameObject)) return false;
+      if (!object.Equals(InstantiatePrefabInstance, other.InstantiatePrefabInstance)) return false;
+      if (!object.Equals(FocusEditorCamera, other.FocusEditorCamera)) return false;
+      if (!object.Equals(SetPrefabLink, other.SetPrefabLink)) return false;
+      if (!object.Equals(BreakPrefabLink, other.BreakPrefabLink)) return false;
+      if (!object.Equals(SetViewportToolState, other.SetViewportToolState)) return false;
+      if (!object.Equals(GetViewportToolState, other.GetViewportToolState)) return false;
       if (CommandCase != other.CommandCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -1221,6 +1412,14 @@ namespace SailorEditor.Protocol.Generated {
       if (commandCase_ == CommandOneofCase.SerializeEngineTypes) hash ^= SerializeEngineTypes.GetHashCode();
       if (commandCase_ == CommandOneofCase.IsEngineMainThreadReady) hash ^= IsEngineMainThreadReady.GetHashCode();
       if (commandCase_ == CommandOneofCase.IsEngineRunning) hash ^= IsEngineRunning.GetHashCode();
+      if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) hash ^= ResolveViewportDropPosition.GetHashCode();
+      if (commandCase_ == CommandOneofCase.CreateModelGameObject) hash ^= CreateModelGameObject.GetHashCode();
+      if (commandCase_ == CommandOneofCase.InstantiatePrefabInstance) hash ^= InstantiatePrefabInstance.GetHashCode();
+      if (commandCase_ == CommandOneofCase.FocusEditorCamera) hash ^= FocusEditorCamera.GetHashCode();
+      if (commandCase_ == CommandOneofCase.SetPrefabLink) hash ^= SetPrefabLink.GetHashCode();
+      if (commandCase_ == CommandOneofCase.BreakPrefabLink) hash ^= BreakPrefabLink.GetHashCode();
+      if (commandCase_ == CommandOneofCase.SetViewportToolState) hash ^= SetViewportToolState.GetHashCode();
+      if (commandCase_ == CommandOneofCase.GetViewportToolState) hash ^= GetViewportToolState.GetHashCode();
       hash ^= (int) commandCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -1404,6 +1603,38 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(130, 3);
         output.WriteMessage(IsEngineRunning);
       }
+      if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) {
+        output.WriteRawTag(138, 3);
+        output.WriteMessage(ResolveViewportDropPosition);
+      }
+      if (commandCase_ == CommandOneofCase.CreateModelGameObject) {
+        output.WriteRawTag(146, 3);
+        output.WriteMessage(CreateModelGameObject);
+      }
+      if (commandCase_ == CommandOneofCase.InstantiatePrefabInstance) {
+        output.WriteRawTag(154, 3);
+        output.WriteMessage(InstantiatePrefabInstance);
+      }
+      if (commandCase_ == CommandOneofCase.FocusEditorCamera) {
+        output.WriteRawTag(162, 3);
+        output.WriteMessage(FocusEditorCamera);
+      }
+      if (commandCase_ == CommandOneofCase.SetPrefabLink) {
+        output.WriteRawTag(170, 3);
+        output.WriteMessage(SetPrefabLink);
+      }
+      if (commandCase_ == CommandOneofCase.BreakPrefabLink) {
+        output.WriteRawTag(178, 3);
+        output.WriteMessage(BreakPrefabLink);
+      }
+      if (commandCase_ == CommandOneofCase.SetViewportToolState) {
+        output.WriteRawTag(186, 3);
+        output.WriteMessage(SetViewportToolState);
+      }
+      if (commandCase_ == CommandOneofCase.GetViewportToolState) {
+        output.WriteRawTag(194, 3);
+        output.WriteMessage(GetViewportToolState);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1578,6 +1809,38 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(130, 3);
         output.WriteMessage(IsEngineRunning);
       }
+      if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) {
+        output.WriteRawTag(138, 3);
+        output.WriteMessage(ResolveViewportDropPosition);
+      }
+      if (commandCase_ == CommandOneofCase.CreateModelGameObject) {
+        output.WriteRawTag(146, 3);
+        output.WriteMessage(CreateModelGameObject);
+      }
+      if (commandCase_ == CommandOneofCase.InstantiatePrefabInstance) {
+        output.WriteRawTag(154, 3);
+        output.WriteMessage(InstantiatePrefabInstance);
+      }
+      if (commandCase_ == CommandOneofCase.FocusEditorCamera) {
+        output.WriteRawTag(162, 3);
+        output.WriteMessage(FocusEditorCamera);
+      }
+      if (commandCase_ == CommandOneofCase.SetPrefabLink) {
+        output.WriteRawTag(170, 3);
+        output.WriteMessage(SetPrefabLink);
+      }
+      if (commandCase_ == CommandOneofCase.BreakPrefabLink) {
+        output.WriteRawTag(178, 3);
+        output.WriteMessage(BreakPrefabLink);
+      }
+      if (commandCase_ == CommandOneofCase.SetViewportToolState) {
+        output.WriteRawTag(186, 3);
+        output.WriteMessage(SetViewportToolState);
+      }
+      if (commandCase_ == CommandOneofCase.GetViewportToolState) {
+        output.WriteRawTag(194, 3);
+        output.WriteMessage(GetViewportToolState);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -1710,6 +1973,30 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (commandCase_ == CommandOneofCase.IsEngineRunning) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(IsEngineRunning);
+      }
+      if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(ResolveViewportDropPosition);
+      }
+      if (commandCase_ == CommandOneofCase.CreateModelGameObject) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(CreateModelGameObject);
+      }
+      if (commandCase_ == CommandOneofCase.InstantiatePrefabInstance) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(InstantiatePrefabInstance);
+      }
+      if (commandCase_ == CommandOneofCase.FocusEditorCamera) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(FocusEditorCamera);
+      }
+      if (commandCase_ == CommandOneofCase.SetPrefabLink) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(SetPrefabLink);
+      }
+      if (commandCase_ == CommandOneofCase.BreakPrefabLink) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(BreakPrefabLink);
+      }
+      if (commandCase_ == CommandOneofCase.SetViewportToolState) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(SetViewportToolState);
+      }
+      if (commandCase_ == CommandOneofCase.GetViewportToolState) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetViewportToolState);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -1964,6 +2251,54 @@ namespace SailorEditor.Protocol.Generated {
           }
           IsEngineRunning.MergeFrom(other.IsEngineRunning);
           break;
+        case CommandOneofCase.ResolveViewportDropPosition:
+          if (ResolveViewportDropPosition == null) {
+            ResolveViewportDropPosition = new global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest();
+          }
+          ResolveViewportDropPosition.MergeFrom(other.ResolveViewportDropPosition);
+          break;
+        case CommandOneofCase.CreateModelGameObject:
+          if (CreateModelGameObject == null) {
+            CreateModelGameObject = new global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest();
+          }
+          CreateModelGameObject.MergeFrom(other.CreateModelGameObject);
+          break;
+        case CommandOneofCase.InstantiatePrefabInstance:
+          if (InstantiatePrefabInstance == null) {
+            InstantiatePrefabInstance = new global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest();
+          }
+          InstantiatePrefabInstance.MergeFrom(other.InstantiatePrefabInstance);
+          break;
+        case CommandOneofCase.FocusEditorCamera:
+          if (FocusEditorCamera == null) {
+            FocusEditorCamera = new global::SailorEditor.Protocol.Generated.ViewportObjectRequest();
+          }
+          FocusEditorCamera.MergeFrom(other.FocusEditorCamera);
+          break;
+        case CommandOneofCase.SetPrefabLink:
+          if (SetPrefabLink == null) {
+            SetPrefabLink = new global::SailorEditor.Protocol.Generated.PrefabLinkRequest();
+          }
+          SetPrefabLink.MergeFrom(other.SetPrefabLink);
+          break;
+        case CommandOneofCase.BreakPrefabLink:
+          if (BreakPrefabLink == null) {
+            BreakPrefabLink = new global::SailorEditor.Protocol.Generated.InstanceIdRequest();
+          }
+          BreakPrefabLink.MergeFrom(other.BreakPrefabLink);
+          break;
+        case CommandOneofCase.SetViewportToolState:
+          if (SetViewportToolState == null) {
+            SetViewportToolState = new global::SailorEditor.Protocol.Generated.ViewportToolStateRequest();
+          }
+          SetViewportToolState.MergeFrom(other.SetViewportToolState);
+          break;
+        case CommandOneofCase.GetViewportToolState:
+          if (GetViewportToolState == null) {
+            GetViewportToolState = new global::SailorEditor.Protocol.Generated.ViewportIdRequest();
+          }
+          GetViewportToolState.MergeFrom(other.GetViewportToolState);
+          break;
       }
 
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -2344,6 +2679,78 @@ namespace SailorEditor.Protocol.Generated {
             IsEngineRunning = subBuilder;
             break;
           }
+          case 394: {
+            global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest();
+            if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) {
+              subBuilder.MergeFrom(ResolveViewportDropPosition);
+            }
+            input.ReadMessage(subBuilder);
+            ResolveViewportDropPosition = subBuilder;
+            break;
+          }
+          case 402: {
+            global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest subBuilder = new global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest();
+            if (commandCase_ == CommandOneofCase.CreateModelGameObject) {
+              subBuilder.MergeFrom(CreateModelGameObject);
+            }
+            input.ReadMessage(subBuilder);
+            CreateModelGameObject = subBuilder;
+            break;
+          }
+          case 410: {
+            global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest subBuilder = new global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest();
+            if (commandCase_ == CommandOneofCase.InstantiatePrefabInstance) {
+              subBuilder.MergeFrom(InstantiatePrefabInstance);
+            }
+            input.ReadMessage(subBuilder);
+            InstantiatePrefabInstance = subBuilder;
+            break;
+          }
+          case 418: {
+            global::SailorEditor.Protocol.Generated.ViewportObjectRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportObjectRequest();
+            if (commandCase_ == CommandOneofCase.FocusEditorCamera) {
+              subBuilder.MergeFrom(FocusEditorCamera);
+            }
+            input.ReadMessage(subBuilder);
+            FocusEditorCamera = subBuilder;
+            break;
+          }
+          case 426: {
+            global::SailorEditor.Protocol.Generated.PrefabLinkRequest subBuilder = new global::SailorEditor.Protocol.Generated.PrefabLinkRequest();
+            if (commandCase_ == CommandOneofCase.SetPrefabLink) {
+              subBuilder.MergeFrom(SetPrefabLink);
+            }
+            input.ReadMessage(subBuilder);
+            SetPrefabLink = subBuilder;
+            break;
+          }
+          case 434: {
+            global::SailorEditor.Protocol.Generated.InstanceIdRequest subBuilder = new global::SailorEditor.Protocol.Generated.InstanceIdRequest();
+            if (commandCase_ == CommandOneofCase.BreakPrefabLink) {
+              subBuilder.MergeFrom(BreakPrefabLink);
+            }
+            input.ReadMessage(subBuilder);
+            BreakPrefabLink = subBuilder;
+            break;
+          }
+          case 442: {
+            global::SailorEditor.Protocol.Generated.ViewportToolStateRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportToolStateRequest();
+            if (commandCase_ == CommandOneofCase.SetViewportToolState) {
+              subBuilder.MergeFrom(SetViewportToolState);
+            }
+            input.ReadMessage(subBuilder);
+            SetViewportToolState = subBuilder;
+            break;
+          }
+          case 450: {
+            global::SailorEditor.Protocol.Generated.ViewportIdRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportIdRequest();
+            if (commandCase_ == CommandOneofCase.GetViewportToolState) {
+              subBuilder.MergeFrom(GetViewportToolState);
+            }
+            input.ReadMessage(subBuilder);
+            GetViewportToolState = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -2722,6 +3129,78 @@ namespace SailorEditor.Protocol.Generated {
             IsEngineRunning = subBuilder;
             break;
           }
+          case 394: {
+            global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest();
+            if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) {
+              subBuilder.MergeFrom(ResolveViewportDropPosition);
+            }
+            input.ReadMessage(subBuilder);
+            ResolveViewportDropPosition = subBuilder;
+            break;
+          }
+          case 402: {
+            global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest subBuilder = new global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest();
+            if (commandCase_ == CommandOneofCase.CreateModelGameObject) {
+              subBuilder.MergeFrom(CreateModelGameObject);
+            }
+            input.ReadMessage(subBuilder);
+            CreateModelGameObject = subBuilder;
+            break;
+          }
+          case 410: {
+            global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest subBuilder = new global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest();
+            if (commandCase_ == CommandOneofCase.InstantiatePrefabInstance) {
+              subBuilder.MergeFrom(InstantiatePrefabInstance);
+            }
+            input.ReadMessage(subBuilder);
+            InstantiatePrefabInstance = subBuilder;
+            break;
+          }
+          case 418: {
+            global::SailorEditor.Protocol.Generated.ViewportObjectRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportObjectRequest();
+            if (commandCase_ == CommandOneofCase.FocusEditorCamera) {
+              subBuilder.MergeFrom(FocusEditorCamera);
+            }
+            input.ReadMessage(subBuilder);
+            FocusEditorCamera = subBuilder;
+            break;
+          }
+          case 426: {
+            global::SailorEditor.Protocol.Generated.PrefabLinkRequest subBuilder = new global::SailorEditor.Protocol.Generated.PrefabLinkRequest();
+            if (commandCase_ == CommandOneofCase.SetPrefabLink) {
+              subBuilder.MergeFrom(SetPrefabLink);
+            }
+            input.ReadMessage(subBuilder);
+            SetPrefabLink = subBuilder;
+            break;
+          }
+          case 434: {
+            global::SailorEditor.Protocol.Generated.InstanceIdRequest subBuilder = new global::SailorEditor.Protocol.Generated.InstanceIdRequest();
+            if (commandCase_ == CommandOneofCase.BreakPrefabLink) {
+              subBuilder.MergeFrom(BreakPrefabLink);
+            }
+            input.ReadMessage(subBuilder);
+            BreakPrefabLink = subBuilder;
+            break;
+          }
+          case 442: {
+            global::SailorEditor.Protocol.Generated.ViewportToolStateRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportToolStateRequest();
+            if (commandCase_ == CommandOneofCase.SetViewportToolState) {
+              subBuilder.MergeFrom(SetViewportToolState);
+            }
+            input.ReadMessage(subBuilder);
+            SetViewportToolState = subBuilder;
+            break;
+          }
+          case 450: {
+            global::SailorEditor.Protocol.Generated.ViewportIdRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportIdRequest();
+            if (commandCase_ == CommandOneofCase.GetViewportToolState) {
+              subBuilder.MergeFrom(GetViewportToolState);
+            }
+            input.ReadMessage(subBuilder);
+            GetViewportToolState = subBuilder;
+            break;
+          }
         }
       }
     }
@@ -2768,6 +3247,7 @@ namespace SailorEditor.Protocol.Generated {
       requestId_ = other.requestId_;
       success_ = other.success_;
       error_ = other.error_;
+      supportsStrictInstanceIds_ = other.supportsStrictInstanceIds_;
       switch (other.ResultCase) {
         case ResultOneofCase.EmptyResult:
           EmptyResult = other.EmptyResult.Clone();
@@ -2798,6 +3278,12 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case ResultOneofCase.ViewportEventBatchResult:
           ViewportEventBatchResult = other.ViewportEventBatchResult.Clone();
+          break;
+        case ResultOneofCase.Vector4Result:
+          Vector4Result = other.Vector4Result.Clone();
+          break;
+        case ResultOneofCase.ViewportToolStateResult:
+          ViewportToolStateResult = other.ViewportToolStateResult.Clone();
           break;
       }
 
@@ -2855,6 +3341,18 @@ namespace SailorEditor.Protocol.Generated {
       get { return error_; }
       set {
         error_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "supports_strict_instance_ids" field.</summary>
+    public const int SupportsStrictInstanceIdsFieldNumber = 5;
+    private bool supportsStrictInstanceIds_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool SupportsStrictInstanceIds {
+      get { return supportsStrictInstanceIds_; }
+      set {
+        supportsStrictInstanceIds_ = value;
       }
     }
 
@@ -2978,6 +3476,30 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "vector4_result" field.</summary>
+    public const int Vector4ResultFieldNumber = 20;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.Vector4Result Vector4Result {
+      get { return resultCase_ == ResultOneofCase.Vector4Result ? (global::SailorEditor.Protocol.Generated.Vector4Result) result_ : null; }
+      set {
+        result_ = value;
+        resultCase_ = value == null ? ResultOneofCase.None : ResultOneofCase.Vector4Result;
+      }
+    }
+
+    /// <summary>Field number for the "viewport_tool_state_result" field.</summary>
+    public const int ViewportToolStateResultFieldNumber = 21;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportToolStateResult ViewportToolStateResult {
+      get { return resultCase_ == ResultOneofCase.ViewportToolStateResult ? (global::SailorEditor.Protocol.Generated.ViewportToolStateResult) result_ : null; }
+      set {
+        result_ = value;
+        resultCase_ = value == null ? ResultOneofCase.None : ResultOneofCase.ViewportToolStateResult;
+      }
+    }
+
     private object result_;
     /// <summary>Enum of possible cases for the "result" oneof.</summary>
     public enum ResultOneofCase {
@@ -2992,6 +3514,8 @@ namespace SailorEditor.Protocol.Generated {
       AssetReloadStateResult = 17,
       InstanceIdResult = 18,
       ViewportEventBatchResult = 19,
+      Vector4Result = 20,
+      ViewportToolStateResult = 21,
     }
     private ResultOneofCase resultCase_ = ResultOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3026,6 +3550,7 @@ namespace SailorEditor.Protocol.Generated {
       if (RequestId != other.RequestId) return false;
       if (Success != other.Success) return false;
       if (Error != other.Error) return false;
+      if (SupportsStrictInstanceIds != other.SupportsStrictInstanceIds) return false;
       if (!object.Equals(EmptyResult, other.EmptyResult)) return false;
       if (!object.Equals(BoolResult, other.BoolResult)) return false;
       if (!object.Equals(Int32Result, other.Int32Result)) return false;
@@ -3036,6 +3561,8 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(AssetReloadStateResult, other.AssetReloadStateResult)) return false;
       if (!object.Equals(InstanceIdResult, other.InstanceIdResult)) return false;
       if (!object.Equals(ViewportEventBatchResult, other.ViewportEventBatchResult)) return false;
+      if (!object.Equals(Vector4Result, other.Vector4Result)) return false;
+      if (!object.Equals(ViewportToolStateResult, other.ViewportToolStateResult)) return false;
       if (ResultCase != other.ResultCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -3048,6 +3575,7 @@ namespace SailorEditor.Protocol.Generated {
       if (RequestId != 0UL) hash ^= RequestId.GetHashCode();
       if (Success != false) hash ^= Success.GetHashCode();
       if (Error.Length != 0) hash ^= Error.GetHashCode();
+      if (SupportsStrictInstanceIds != false) hash ^= SupportsStrictInstanceIds.GetHashCode();
       if (resultCase_ == ResultOneofCase.EmptyResult) hash ^= EmptyResult.GetHashCode();
       if (resultCase_ == ResultOneofCase.BoolResult) hash ^= BoolResult.GetHashCode();
       if (resultCase_ == ResultOneofCase.Int32Result) hash ^= Int32Result.GetHashCode();
@@ -3058,6 +3586,8 @@ namespace SailorEditor.Protocol.Generated {
       if (resultCase_ == ResultOneofCase.AssetReloadStateResult) hash ^= AssetReloadStateResult.GetHashCode();
       if (resultCase_ == ResultOneofCase.InstanceIdResult) hash ^= InstanceIdResult.GetHashCode();
       if (resultCase_ == ResultOneofCase.ViewportEventBatchResult) hash ^= ViewportEventBatchResult.GetHashCode();
+      if (resultCase_ == ResultOneofCase.Vector4Result) hash ^= Vector4Result.GetHashCode();
+      if (resultCase_ == ResultOneofCase.ViewportToolStateResult) hash ^= ViewportToolStateResult.GetHashCode();
       hash ^= (int) resultCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -3093,6 +3623,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(34);
         output.WriteString(Error);
       }
+      if (SupportsStrictInstanceIds != false) {
+        output.WriteRawTag(40);
+        output.WriteBool(SupportsStrictInstanceIds);
+      }
       if (resultCase_ == ResultOneofCase.EmptyResult) {
         output.WriteRawTag(82);
         output.WriteMessage(EmptyResult);
@@ -3132,6 +3666,14 @@ namespace SailorEditor.Protocol.Generated {
       if (resultCase_ == ResultOneofCase.ViewportEventBatchResult) {
         output.WriteRawTag(154, 1);
         output.WriteMessage(ViewportEventBatchResult);
+      }
+      if (resultCase_ == ResultOneofCase.Vector4Result) {
+        output.WriteRawTag(162, 1);
+        output.WriteMessage(Vector4Result);
+      }
+      if (resultCase_ == ResultOneofCase.ViewportToolStateResult) {
+        output.WriteRawTag(170, 1);
+        output.WriteMessage(ViewportToolStateResult);
       }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
@@ -3159,6 +3701,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(34);
         output.WriteString(Error);
       }
+      if (SupportsStrictInstanceIds != false) {
+        output.WriteRawTag(40);
+        output.WriteBool(SupportsStrictInstanceIds);
+      }
       if (resultCase_ == ResultOneofCase.EmptyResult) {
         output.WriteRawTag(82);
         output.WriteMessage(EmptyResult);
@@ -3199,6 +3745,14 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(154, 1);
         output.WriteMessage(ViewportEventBatchResult);
       }
+      if (resultCase_ == ResultOneofCase.Vector4Result) {
+        output.WriteRawTag(162, 1);
+        output.WriteMessage(Vector4Result);
+      }
+      if (resultCase_ == ResultOneofCase.ViewportToolStateResult) {
+        output.WriteRawTag(170, 1);
+        output.WriteMessage(ViewportToolStateResult);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -3220,6 +3774,9 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (Error.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(Error);
+      }
+      if (SupportsStrictInstanceIds != false) {
+        size += 1 + 1;
       }
       if (resultCase_ == ResultOneofCase.EmptyResult) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(EmptyResult);
@@ -3251,6 +3808,12 @@ namespace SailorEditor.Protocol.Generated {
       if (resultCase_ == ResultOneofCase.ViewportEventBatchResult) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(ViewportEventBatchResult);
       }
+      if (resultCase_ == ResultOneofCase.Vector4Result) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(Vector4Result);
+      }
+      if (resultCase_ == ResultOneofCase.ViewportToolStateResult) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(ViewportToolStateResult);
+      }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
       }
@@ -3274,6 +3837,9 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (other.Error.Length != 0) {
         Error = other.Error;
+      }
+      if (other.SupportsStrictInstanceIds != false) {
+        SupportsStrictInstanceIds = other.SupportsStrictInstanceIds;
       }
       switch (other.ResultCase) {
         case ResultOneofCase.EmptyResult:
@@ -3336,6 +3902,18 @@ namespace SailorEditor.Protocol.Generated {
           }
           ViewportEventBatchResult.MergeFrom(other.ViewportEventBatchResult);
           break;
+        case ResultOneofCase.Vector4Result:
+          if (Vector4Result == null) {
+            Vector4Result = new global::SailorEditor.Protocol.Generated.Vector4Result();
+          }
+          Vector4Result.MergeFrom(other.Vector4Result);
+          break;
+        case ResultOneofCase.ViewportToolStateResult:
+          if (ViewportToolStateResult == null) {
+            ViewportToolStateResult = new global::SailorEditor.Protocol.Generated.ViewportToolStateResult();
+          }
+          ViewportToolStateResult.MergeFrom(other.ViewportToolStateResult);
+          break;
       }
 
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -3373,6 +3951,10 @@ namespace SailorEditor.Protocol.Generated {
             Error = input.ReadString();
             break;
           }
+          case 40: {
+            SupportsStrictInstanceIds = input.ReadBool();
+            break;
+          }
           case 82: {
             global::SailorEditor.Protocol.Generated.Empty subBuilder = new global::SailorEditor.Protocol.Generated.Empty();
             if (resultCase_ == ResultOneofCase.EmptyResult) {
@@ -3461,6 +4043,24 @@ namespace SailorEditor.Protocol.Generated {
             }
             input.ReadMessage(subBuilder);
             ViewportEventBatchResult = subBuilder;
+            break;
+          }
+          case 162: {
+            global::SailorEditor.Protocol.Generated.Vector4Result subBuilder = new global::SailorEditor.Protocol.Generated.Vector4Result();
+            if (resultCase_ == ResultOneofCase.Vector4Result) {
+              subBuilder.MergeFrom(Vector4Result);
+            }
+            input.ReadMessage(subBuilder);
+            Vector4Result = subBuilder;
+            break;
+          }
+          case 170: {
+            global::SailorEditor.Protocol.Generated.ViewportToolStateResult subBuilder = new global::SailorEditor.Protocol.Generated.ViewportToolStateResult();
+            if (resultCase_ == ResultOneofCase.ViewportToolStateResult) {
+              subBuilder.MergeFrom(ViewportToolStateResult);
+            }
+            input.ReadMessage(subBuilder);
+            ViewportToolStateResult = subBuilder;
             break;
           }
         }
@@ -3498,6 +4098,10 @@ namespace SailorEditor.Protocol.Generated {
             Error = input.ReadString();
             break;
           }
+          case 40: {
+            SupportsStrictInstanceIds = input.ReadBool();
+            break;
+          }
           case 82: {
             global::SailorEditor.Protocol.Generated.Empty subBuilder = new global::SailorEditor.Protocol.Generated.Empty();
             if (resultCase_ == ResultOneofCase.EmptyResult) {
@@ -3586,6 +4190,24 @@ namespace SailorEditor.Protocol.Generated {
             }
             input.ReadMessage(subBuilder);
             ViewportEventBatchResult = subBuilder;
+            break;
+          }
+          case 162: {
+            global::SailorEditor.Protocol.Generated.Vector4Result subBuilder = new global::SailorEditor.Protocol.Generated.Vector4Result();
+            if (resultCase_ == ResultOneofCase.Vector4Result) {
+              subBuilder.MergeFrom(Vector4Result);
+            }
+            input.ReadMessage(subBuilder);
+            Vector4Result = subBuilder;
+            break;
+          }
+          case 170: {
+            global::SailorEditor.Protocol.Generated.ViewportToolStateResult subBuilder = new global::SailorEditor.Protocol.Generated.ViewportToolStateResult();
+            if (resultCase_ == ResultOneofCase.ViewportToolStateResult) {
+              subBuilder.MergeFrom(ViewportToolStateResult);
+            }
+            input.ReadMessage(subBuilder);
+            ViewportToolStateResult = subBuilder;
             break;
           }
         }
@@ -7936,6 +8558,7 @@ namespace SailorEditor.Protocol.Generated {
     public InstantiatePrefabFromYamlRequest(InstantiatePrefabFromYamlRequest other) : this() {
       prefabYaml_ = other.prefabYaml_;
       parentInstanceId_ = other.parentInstanceId_;
+      strictInstanceIds_ = other.strictInstanceIds_;
       _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
     }
 
@@ -7969,6 +8592,18 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "strict_instance_ids" field.</summary>
+    public const int StrictInstanceIdsFieldNumber = 3;
+    private bool strictInstanceIds_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool StrictInstanceIds {
+      get { return strictInstanceIds_; }
+      set {
+        strictInstanceIds_ = value;
+      }
+    }
+
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
@@ -7986,6 +8621,7 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (PrefabYaml != other.PrefabYaml) return false;
       if (ParentInstanceId != other.ParentInstanceId) return false;
+      if (StrictInstanceIds != other.StrictInstanceIds) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
 
@@ -7995,6 +8631,7 @@ namespace SailorEditor.Protocol.Generated {
       int hash = 1;
       if (PrefabYaml.Length != 0) hash ^= PrefabYaml.GetHashCode();
       if (ParentInstanceId.Length != 0) hash ^= ParentInstanceId.GetHashCode();
+      if (StrictInstanceIds != false) hash ^= StrictInstanceIds.GetHashCode();
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
       }
@@ -8021,6 +8658,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(18);
         output.WriteString(ParentInstanceId);
       }
+      if (StrictInstanceIds != false) {
+        output.WriteRawTag(24);
+        output.WriteBool(StrictInstanceIds);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -8039,6 +8680,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(18);
         output.WriteString(ParentInstanceId);
       }
+      if (StrictInstanceIds != false) {
+        output.WriteRawTag(24);
+        output.WriteBool(StrictInstanceIds);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -8054,6 +8699,9 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (ParentInstanceId.Length != 0) {
         size += 1 + pb::CodedOutputStream.ComputeStringSize(ParentInstanceId);
+      }
+      if (StrictInstanceIds != false) {
+        size += 1 + 1;
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -8072,6 +8720,9 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (other.ParentInstanceId.Length != 0) {
         ParentInstanceId = other.ParentInstanceId;
+      }
+      if (other.StrictInstanceIds != false) {
+        StrictInstanceIds = other.StrictInstanceIds;
       }
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
     }
@@ -8098,6 +8749,10 @@ namespace SailorEditor.Protocol.Generated {
           }
           case 18: {
             ParentInstanceId = input.ReadString();
+            break;
+          }
+          case 24: {
+            StrictInstanceIds = input.ReadBool();
             break;
           }
         }
@@ -8127,6 +8782,1697 @@ namespace SailorEditor.Protocol.Generated {
             ParentInstanceId = input.ReadString();
             break;
           }
+          case 24: {
+            StrictInstanceIds = input.ReadBool();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class ViewportDropPositionRequest : pb::IMessage<ViewportDropPositionRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<ViewportDropPositionRequest> _parser = new pb::MessageParser<ViewportDropPositionRequest>(() => new ViewportDropPositionRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<ViewportDropPositionRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportDropPositionRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportDropPositionRequest(ViewportDropPositionRequest other) : this() {
+      viewportId_ = other.viewportId_;
+      normalizedX_ = other.normalizedX_;
+      normalizedY_ = other.normalizedY_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportDropPositionRequest Clone() {
+      return new ViewportDropPositionRequest(this);
+    }
+
+    /// <summary>Field number for the "viewport_id" field.</summary>
+    public const int ViewportIdFieldNumber = 1;
+    private ulong viewportId_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ulong ViewportId {
+      get { return viewportId_; }
+      set {
+        viewportId_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "normalized_x" field.</summary>
+    public const int NormalizedXFieldNumber = 2;
+    private float normalizedX_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public float NormalizedX {
+      get { return normalizedX_; }
+      set {
+        normalizedX_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "normalized_y" field.</summary>
+    public const int NormalizedYFieldNumber = 3;
+    private float normalizedY_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public float NormalizedY {
+      get { return normalizedY_; }
+      set {
+        normalizedY_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as ViewportDropPositionRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(ViewportDropPositionRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (ViewportId != other.ViewportId) return false;
+      if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(NormalizedX, other.NormalizedX)) return false;
+      if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(NormalizedY, other.NormalizedY)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (ViewportId != 0UL) hash ^= ViewportId.GetHashCode();
+      if (NormalizedX != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(NormalizedX);
+      if (NormalizedY != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(NormalizedY);
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (ViewportId != 0UL) {
+        output.WriteRawTag(8);
+        output.WriteUInt64(ViewportId);
+      }
+      if (NormalizedX != 0F) {
+        output.WriteRawTag(21);
+        output.WriteFloat(NormalizedX);
+      }
+      if (NormalizedY != 0F) {
+        output.WriteRawTag(29);
+        output.WriteFloat(NormalizedY);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (ViewportId != 0UL) {
+        output.WriteRawTag(8);
+        output.WriteUInt64(ViewportId);
+      }
+      if (NormalizedX != 0F) {
+        output.WriteRawTag(21);
+        output.WriteFloat(NormalizedX);
+      }
+      if (NormalizedY != 0F) {
+        output.WriteRawTag(29);
+        output.WriteFloat(NormalizedY);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (ViewportId != 0UL) {
+        size += 1 + pb::CodedOutputStream.ComputeUInt64Size(ViewportId);
+      }
+      if (NormalizedX != 0F) {
+        size += 1 + 4;
+      }
+      if (NormalizedY != 0F) {
+        size += 1 + 4;
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(ViewportDropPositionRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.ViewportId != 0UL) {
+        ViewportId = other.ViewportId;
+      }
+      if (other.NormalizedX != 0F) {
+        NormalizedX = other.NormalizedX;
+      }
+      if (other.NormalizedY != 0F) {
+        NormalizedY = other.NormalizedY;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            ViewportId = input.ReadUInt64();
+            break;
+          }
+          case 21: {
+            NormalizedX = input.ReadFloat();
+            break;
+          }
+          case 29: {
+            NormalizedY = input.ReadFloat();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            ViewportId = input.ReadUInt64();
+            break;
+          }
+          case 21: {
+            NormalizedX = input.ReadFloat();
+            break;
+          }
+          case 29: {
+            NormalizedY = input.ReadFloat();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class CreateModelGameObjectRequest : pb::IMessage<CreateModelGameObjectRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<CreateModelGameObjectRequest> _parser = new pb::MessageParser<CreateModelGameObjectRequest>(() => new CreateModelGameObjectRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<CreateModelGameObjectRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public CreateModelGameObjectRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public CreateModelGameObjectRequest(CreateModelGameObjectRequest other) : this() {
+      modelFileId_ = other.modelFileId_;
+      name_ = other.name_;
+      parentInstanceId_ = other.parentInstanceId_;
+      applyWorldPosition_ = other.applyWorldPosition_;
+      worldPosition_ = other.worldPosition_ != null ? other.worldPosition_.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public CreateModelGameObjectRequest Clone() {
+      return new CreateModelGameObjectRequest(this);
+    }
+
+    /// <summary>Field number for the "model_file_id" field.</summary>
+    public const int ModelFileIdFieldNumber = 1;
+    private string modelFileId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string ModelFileId {
+      get { return modelFileId_; }
+      set {
+        modelFileId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "name" field.</summary>
+    public const int NameFieldNumber = 2;
+    private string name_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Name {
+      get { return name_; }
+      set {
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "parent_instance_id" field.</summary>
+    public const int ParentInstanceIdFieldNumber = 3;
+    private string parentInstanceId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string ParentInstanceId {
+      get { return parentInstanceId_; }
+      set {
+        parentInstanceId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "apply_world_position" field.</summary>
+    public const int ApplyWorldPositionFieldNumber = 4;
+    private bool applyWorldPosition_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool ApplyWorldPosition {
+      get { return applyWorldPosition_; }
+      set {
+        applyWorldPosition_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "world_position" field.</summary>
+    public const int WorldPositionFieldNumber = 5;
+    private global::SailorEditor.Protocol.Generated.Vector4 worldPosition_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.Vector4 WorldPosition {
+      get { return worldPosition_; }
+      set {
+        worldPosition_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as CreateModelGameObjectRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(CreateModelGameObjectRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (ModelFileId != other.ModelFileId) return false;
+      if (Name != other.Name) return false;
+      if (ParentInstanceId != other.ParentInstanceId) return false;
+      if (ApplyWorldPosition != other.ApplyWorldPosition) return false;
+      if (!object.Equals(WorldPosition, other.WorldPosition)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (ModelFileId.Length != 0) hash ^= ModelFileId.GetHashCode();
+      if (Name.Length != 0) hash ^= Name.GetHashCode();
+      if (ParentInstanceId.Length != 0) hash ^= ParentInstanceId.GetHashCode();
+      if (ApplyWorldPosition != false) hash ^= ApplyWorldPosition.GetHashCode();
+      if (worldPosition_ != null) hash ^= WorldPosition.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (ModelFileId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(ModelFileId);
+      }
+      if (Name.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Name);
+      }
+      if (ParentInstanceId.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(ParentInstanceId);
+      }
+      if (ApplyWorldPosition != false) {
+        output.WriteRawTag(32);
+        output.WriteBool(ApplyWorldPosition);
+      }
+      if (worldPosition_ != null) {
+        output.WriteRawTag(42);
+        output.WriteMessage(WorldPosition);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (ModelFileId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(ModelFileId);
+      }
+      if (Name.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Name);
+      }
+      if (ParentInstanceId.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(ParentInstanceId);
+      }
+      if (ApplyWorldPosition != false) {
+        output.WriteRawTag(32);
+        output.WriteBool(ApplyWorldPosition);
+      }
+      if (worldPosition_ != null) {
+        output.WriteRawTag(42);
+        output.WriteMessage(WorldPosition);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (ModelFileId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ModelFileId);
+      }
+      if (Name.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+      }
+      if (ParentInstanceId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ParentInstanceId);
+      }
+      if (ApplyWorldPosition != false) {
+        size += 1 + 1;
+      }
+      if (worldPosition_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(WorldPosition);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(CreateModelGameObjectRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.ModelFileId.Length != 0) {
+        ModelFileId = other.ModelFileId;
+      }
+      if (other.Name.Length != 0) {
+        Name = other.Name;
+      }
+      if (other.ParentInstanceId.Length != 0) {
+        ParentInstanceId = other.ParentInstanceId;
+      }
+      if (other.ApplyWorldPosition != false) {
+        ApplyWorldPosition = other.ApplyWorldPosition;
+      }
+      if (other.worldPosition_ != null) {
+        if (worldPosition_ == null) {
+          WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
+        }
+        WorldPosition.MergeFrom(other.WorldPosition);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            ModelFileId = input.ReadString();
+            break;
+          }
+          case 18: {
+            Name = input.ReadString();
+            break;
+          }
+          case 26: {
+            ParentInstanceId = input.ReadString();
+            break;
+          }
+          case 32: {
+            ApplyWorldPosition = input.ReadBool();
+            break;
+          }
+          case 42: {
+            if (worldPosition_ == null) {
+              WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
+            }
+            input.ReadMessage(WorldPosition);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            ModelFileId = input.ReadString();
+            break;
+          }
+          case 18: {
+            Name = input.ReadString();
+            break;
+          }
+          case 26: {
+            ParentInstanceId = input.ReadString();
+            break;
+          }
+          case 32: {
+            ApplyWorldPosition = input.ReadBool();
+            break;
+          }
+          case 42: {
+            if (worldPosition_ == null) {
+              WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
+            }
+            input.ReadMessage(WorldPosition);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class InstantiatePrefabInstanceRequest : pb::IMessage<InstantiatePrefabInstanceRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<InstantiatePrefabInstanceRequest> _parser = new pb::MessageParser<InstantiatePrefabInstanceRequest>(() => new InstantiatePrefabInstanceRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<InstantiatePrefabInstanceRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public InstantiatePrefabInstanceRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public InstantiatePrefabInstanceRequest(InstantiatePrefabInstanceRequest other) : this() {
+      fileId_ = other.fileId_;
+      parentInstanceId_ = other.parentInstanceId_;
+      applyWorldPosition_ = other.applyWorldPosition_;
+      worldPosition_ = other.worldPosition_ != null ? other.worldPosition_.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public InstantiatePrefabInstanceRequest Clone() {
+      return new InstantiatePrefabInstanceRequest(this);
+    }
+
+    /// <summary>Field number for the "file_id" field.</summary>
+    public const int FileIdFieldNumber = 1;
+    private string fileId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string FileId {
+      get { return fileId_; }
+      set {
+        fileId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "parent_instance_id" field.</summary>
+    public const int ParentInstanceIdFieldNumber = 2;
+    private string parentInstanceId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string ParentInstanceId {
+      get { return parentInstanceId_; }
+      set {
+        parentInstanceId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "apply_world_position" field.</summary>
+    public const int ApplyWorldPositionFieldNumber = 3;
+    private bool applyWorldPosition_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool ApplyWorldPosition {
+      get { return applyWorldPosition_; }
+      set {
+        applyWorldPosition_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "world_position" field.</summary>
+    public const int WorldPositionFieldNumber = 4;
+    private global::SailorEditor.Protocol.Generated.Vector4 worldPosition_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.Vector4 WorldPosition {
+      get { return worldPosition_; }
+      set {
+        worldPosition_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as InstantiatePrefabInstanceRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(InstantiatePrefabInstanceRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (FileId != other.FileId) return false;
+      if (ParentInstanceId != other.ParentInstanceId) return false;
+      if (ApplyWorldPosition != other.ApplyWorldPosition) return false;
+      if (!object.Equals(WorldPosition, other.WorldPosition)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (FileId.Length != 0) hash ^= FileId.GetHashCode();
+      if (ParentInstanceId.Length != 0) hash ^= ParentInstanceId.GetHashCode();
+      if (ApplyWorldPosition != false) hash ^= ApplyWorldPosition.GetHashCode();
+      if (worldPosition_ != null) hash ^= WorldPosition.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (FileId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(FileId);
+      }
+      if (ParentInstanceId.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(ParentInstanceId);
+      }
+      if (ApplyWorldPosition != false) {
+        output.WriteRawTag(24);
+        output.WriteBool(ApplyWorldPosition);
+      }
+      if (worldPosition_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(WorldPosition);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (FileId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(FileId);
+      }
+      if (ParentInstanceId.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(ParentInstanceId);
+      }
+      if (ApplyWorldPosition != false) {
+        output.WriteRawTag(24);
+        output.WriteBool(ApplyWorldPosition);
+      }
+      if (worldPosition_ != null) {
+        output.WriteRawTag(34);
+        output.WriteMessage(WorldPosition);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (FileId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(FileId);
+      }
+      if (ParentInstanceId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ParentInstanceId);
+      }
+      if (ApplyWorldPosition != false) {
+        size += 1 + 1;
+      }
+      if (worldPosition_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(WorldPosition);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(InstantiatePrefabInstanceRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.FileId.Length != 0) {
+        FileId = other.FileId;
+      }
+      if (other.ParentInstanceId.Length != 0) {
+        ParentInstanceId = other.ParentInstanceId;
+      }
+      if (other.ApplyWorldPosition != false) {
+        ApplyWorldPosition = other.ApplyWorldPosition;
+      }
+      if (other.worldPosition_ != null) {
+        if (worldPosition_ == null) {
+          WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
+        }
+        WorldPosition.MergeFrom(other.WorldPosition);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            FileId = input.ReadString();
+            break;
+          }
+          case 18: {
+            ParentInstanceId = input.ReadString();
+            break;
+          }
+          case 24: {
+            ApplyWorldPosition = input.ReadBool();
+            break;
+          }
+          case 34: {
+            if (worldPosition_ == null) {
+              WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
+            }
+            input.ReadMessage(WorldPosition);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            FileId = input.ReadString();
+            break;
+          }
+          case 18: {
+            ParentInstanceId = input.ReadString();
+            break;
+          }
+          case 24: {
+            ApplyWorldPosition = input.ReadBool();
+            break;
+          }
+          case 34: {
+            if (worldPosition_ == null) {
+              WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
+            }
+            input.ReadMessage(WorldPosition);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class ViewportObjectRequest : pb::IMessage<ViewportObjectRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<ViewportObjectRequest> _parser = new pb::MessageParser<ViewportObjectRequest>(() => new ViewportObjectRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<ViewportObjectRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportObjectRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportObjectRequest(ViewportObjectRequest other) : this() {
+      viewportId_ = other.viewportId_;
+      instanceId_ = other.instanceId_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportObjectRequest Clone() {
+      return new ViewportObjectRequest(this);
+    }
+
+    /// <summary>Field number for the "viewport_id" field.</summary>
+    public const int ViewportIdFieldNumber = 1;
+    private ulong viewportId_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ulong ViewportId {
+      get { return viewportId_; }
+      set {
+        viewportId_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "instance_id" field.</summary>
+    public const int InstanceIdFieldNumber = 2;
+    private string instanceId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string InstanceId {
+      get { return instanceId_; }
+      set {
+        instanceId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as ViewportObjectRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(ViewportObjectRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (ViewportId != other.ViewportId) return false;
+      if (InstanceId != other.InstanceId) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (ViewportId != 0UL) hash ^= ViewportId.GetHashCode();
+      if (InstanceId.Length != 0) hash ^= InstanceId.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (ViewportId != 0UL) {
+        output.WriteRawTag(8);
+        output.WriteUInt64(ViewportId);
+      }
+      if (InstanceId.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(InstanceId);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (ViewportId != 0UL) {
+        output.WriteRawTag(8);
+        output.WriteUInt64(ViewportId);
+      }
+      if (InstanceId.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(InstanceId);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (ViewportId != 0UL) {
+        size += 1 + pb::CodedOutputStream.ComputeUInt64Size(ViewportId);
+      }
+      if (InstanceId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(InstanceId);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(ViewportObjectRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.ViewportId != 0UL) {
+        ViewportId = other.ViewportId;
+      }
+      if (other.InstanceId.Length != 0) {
+        InstanceId = other.InstanceId;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            ViewportId = input.ReadUInt64();
+            break;
+          }
+          case 18: {
+            InstanceId = input.ReadString();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            ViewportId = input.ReadUInt64();
+            break;
+          }
+          case 18: {
+            InstanceId = input.ReadString();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class PrefabLinkRequest : pb::IMessage<PrefabLinkRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<PrefabLinkRequest> _parser = new pb::MessageParser<PrefabLinkRequest>(() => new PrefabLinkRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<PrefabLinkRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PrefabLinkRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PrefabLinkRequest(PrefabLinkRequest other) : this() {
+      instanceId_ = other.instanceId_;
+      fileId_ = other.fileId_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public PrefabLinkRequest Clone() {
+      return new PrefabLinkRequest(this);
+    }
+
+    /// <summary>Field number for the "instance_id" field.</summary>
+    public const int InstanceIdFieldNumber = 1;
+    private string instanceId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string InstanceId {
+      get { return instanceId_; }
+      set {
+        instanceId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "file_id" field.</summary>
+    public const int FileIdFieldNumber = 2;
+    private string fileId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string FileId {
+      get { return fileId_; }
+      set {
+        fileId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as PrefabLinkRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(PrefabLinkRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (InstanceId != other.InstanceId) return false;
+      if (FileId != other.FileId) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (InstanceId.Length != 0) hash ^= InstanceId.GetHashCode();
+      if (FileId.Length != 0) hash ^= FileId.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (InstanceId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(InstanceId);
+      }
+      if (FileId.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(FileId);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (InstanceId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(InstanceId);
+      }
+      if (FileId.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(FileId);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (InstanceId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(InstanceId);
+      }
+      if (FileId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(FileId);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(PrefabLinkRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.InstanceId.Length != 0) {
+        InstanceId = other.InstanceId;
+      }
+      if (other.FileId.Length != 0) {
+        FileId = other.FileId;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            InstanceId = input.ReadString();
+            break;
+          }
+          case 18: {
+            FileId = input.ReadString();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            InstanceId = input.ReadString();
+            break;
+          }
+          case 18: {
+            FileId = input.ReadString();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class ViewportToolStateRequest : pb::IMessage<ViewportToolStateRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<ViewportToolStateRequest> _parser = new pb::MessageParser<ViewportToolStateRequest>(() => new ViewportToolStateRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<ViewportToolStateRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportToolStateRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportToolStateRequest(ViewportToolStateRequest other) : this() {
+      viewportId_ = other.viewportId_;
+      operation_ = other.operation_;
+      space_ = other.space_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportToolStateRequest Clone() {
+      return new ViewportToolStateRequest(this);
+    }
+
+    /// <summary>Field number for the "viewport_id" field.</summary>
+    public const int ViewportIdFieldNumber = 1;
+    private ulong viewportId_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ulong ViewportId {
+      get { return viewportId_; }
+      set {
+        viewportId_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "operation" field.</summary>
+    public const int OperationFieldNumber = 2;
+    private global::SailorEditor.Protocol.Generated.ViewportTransformOperation operation_ = global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportTransformOperation Operation {
+      get { return operation_; }
+      set {
+        operation_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "space" field.</summary>
+    public const int SpaceFieldNumber = 3;
+    private global::SailorEditor.Protocol.Generated.ViewportTransformSpace space_ = global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportTransformSpace Space {
+      get { return space_; }
+      set {
+        space_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as ViewportToolStateRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(ViewportToolStateRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (ViewportId != other.ViewportId) return false;
+      if (Operation != other.Operation) return false;
+      if (Space != other.Space) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (ViewportId != 0UL) hash ^= ViewportId.GetHashCode();
+      if (Operation != global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified) hash ^= Operation.GetHashCode();
+      if (Space != global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified) hash ^= Space.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (ViewportId != 0UL) {
+        output.WriteRawTag(8);
+        output.WriteUInt64(ViewportId);
+      }
+      if (Operation != global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified) {
+        output.WriteRawTag(16);
+        output.WriteEnum((int) Operation);
+      }
+      if (Space != global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified) {
+        output.WriteRawTag(24);
+        output.WriteEnum((int) Space);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (ViewportId != 0UL) {
+        output.WriteRawTag(8);
+        output.WriteUInt64(ViewportId);
+      }
+      if (Operation != global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified) {
+        output.WriteRawTag(16);
+        output.WriteEnum((int) Operation);
+      }
+      if (Space != global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified) {
+        output.WriteRawTag(24);
+        output.WriteEnum((int) Space);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (ViewportId != 0UL) {
+        size += 1 + pb::CodedOutputStream.ComputeUInt64Size(ViewportId);
+      }
+      if (Operation != global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Operation);
+      }
+      if (Space != global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Space);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(ViewportToolStateRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.ViewportId != 0UL) {
+        ViewportId = other.ViewportId;
+      }
+      if (other.Operation != global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified) {
+        Operation = other.Operation;
+      }
+      if (other.Space != global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified) {
+        Space = other.Space;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            ViewportId = input.ReadUInt64();
+            break;
+          }
+          case 16: {
+            Operation = (global::SailorEditor.Protocol.Generated.ViewportTransformOperation) input.ReadEnum();
+            break;
+          }
+          case 24: {
+            Space = (global::SailorEditor.Protocol.Generated.ViewportTransformSpace) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            ViewportId = input.ReadUInt64();
+            break;
+          }
+          case 16: {
+            Operation = (global::SailorEditor.Protocol.Generated.ViewportTransformOperation) input.ReadEnum();
+            break;
+          }
+          case 24: {
+            Space = (global::SailorEditor.Protocol.Generated.ViewportTransformSpace) input.ReadEnum();
+            break;
+          }
         }
       }
     }
@@ -8149,7 +10495,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8336,7 +10682,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8534,7 +10880,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8880,7 +11226,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9078,7 +11424,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9276,7 +11622,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9474,7 +11820,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9672,7 +12018,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9907,7 +12253,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10094,7 +12440,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10403,7 +12749,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10624,6 +12970,448 @@ namespace SailorEditor.Protocol.Generated {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class Vector4Result : pb::IMessage<Vector4Result>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<Vector4Result> _parser = new pb::MessageParser<Vector4Result>(() => new Vector4Result());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<Vector4Result> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public Vector4Result() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public Vector4Result(Vector4Result other) : this() {
+      value_ = other.value_ != null ? other.value_.Clone() : null;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public Vector4Result Clone() {
+      return new Vector4Result(this);
+    }
+
+    /// <summary>Field number for the "value" field.</summary>
+    public const int ValueFieldNumber = 1;
+    private global::SailorEditor.Protocol.Generated.Vector4 value_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.Vector4 Value {
+      get { return value_; }
+      set {
+        value_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as Vector4Result);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(Vector4Result other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (!object.Equals(Value, other.Value)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (value_ != null) hash ^= Value.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (value_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(Value);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (value_ != null) {
+        output.WriteRawTag(10);
+        output.WriteMessage(Value);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (value_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Value);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(Vector4Result other) {
+      if (other == null) {
+        return;
+      }
+      if (other.value_ != null) {
+        if (value_ == null) {
+          Value = new global::SailorEditor.Protocol.Generated.Vector4();
+        }
+        Value.MergeFrom(other.Value);
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            if (value_ == null) {
+              Value = new global::SailorEditor.Protocol.Generated.Vector4();
+            }
+            input.ReadMessage(Value);
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            if (value_ == null) {
+              Value = new global::SailorEditor.Protocol.Generated.Vector4();
+            }
+            input.ReadMessage(Value);
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class ViewportToolStateResult : pb::IMessage<ViewportToolStateResult>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<ViewportToolStateResult> _parser = new pb::MessageParser<ViewportToolStateResult>(() => new ViewportToolStateResult());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<ViewportToolStateResult> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportToolStateResult() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportToolStateResult(ViewportToolStateResult other) : this() {
+      operation_ = other.operation_;
+      space_ = other.space_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportToolStateResult Clone() {
+      return new ViewportToolStateResult(this);
+    }
+
+    /// <summary>Field number for the "operation" field.</summary>
+    public const int OperationFieldNumber = 1;
+    private global::SailorEditor.Protocol.Generated.ViewportTransformOperation operation_ = global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportTransformOperation Operation {
+      get { return operation_; }
+      set {
+        operation_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "space" field.</summary>
+    public const int SpaceFieldNumber = 2;
+    private global::SailorEditor.Protocol.Generated.ViewportTransformSpace space_ = global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportTransformSpace Space {
+      get { return space_; }
+      set {
+        space_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as ViewportToolStateResult);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(ViewportToolStateResult other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Operation != other.Operation) return false;
+      if (Space != other.Space) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Operation != global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified) hash ^= Operation.GetHashCode();
+      if (Space != global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified) hash ^= Space.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Operation != global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified) {
+        output.WriteRawTag(8);
+        output.WriteEnum((int) Operation);
+      }
+      if (Space != global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified) {
+        output.WriteRawTag(16);
+        output.WriteEnum((int) Space);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Operation != global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified) {
+        output.WriteRawTag(8);
+        output.WriteEnum((int) Operation);
+      }
+      if (Space != global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified) {
+        output.WriteRawTag(16);
+        output.WriteEnum((int) Space);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Operation != global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Operation);
+      }
+      if (Space != global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Space);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(ViewportToolStateResult other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Operation != global::SailorEditor.Protocol.Generated.ViewportTransformOperation.Unspecified) {
+        Operation = other.Operation;
+      }
+      if (other.Space != global::SailorEditor.Protocol.Generated.ViewportTransformSpace.Unspecified) {
+        Space = other.Space;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            Operation = (global::SailorEditor.Protocol.Generated.ViewportTransformOperation) input.ReadEnum();
+            break;
+          }
+          case 16: {
+            Space = (global::SailorEditor.Protocol.Generated.ViewportTransformSpace) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            Operation = (global::SailorEditor.Protocol.Generated.ViewportTransformOperation) input.ReadEnum();
+            break;
+          }
+          case 16: {
+            Space = (global::SailorEditor.Protocol.Generated.ViewportTransformSpace) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Vector4 : pb::IMessage<Vector4>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -10638,7 +13426,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10947,7 +13735,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11145,7 +13933,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11679,6 +14467,476 @@ namespace SailorEditor.Protocol.Generated {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class ViewportAssetDropEvent : pb::IMessage<ViewportAssetDropEvent>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<ViewportAssetDropEvent> _parser = new pb::MessageParser<ViewportAssetDropEvent>(() => new ViewportAssetDropEvent());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<ViewportAssetDropEvent> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportAssetDropEvent() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportAssetDropEvent(ViewportAssetDropEvent other) : this() {
+      fileId_ = other.fileId_;
+      normalizedX_ = other.normalizedX_;
+      normalizedY_ = other.normalizedY_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportAssetDropEvent Clone() {
+      return new ViewportAssetDropEvent(this);
+    }
+
+    /// <summary>Field number for the "file_id" field.</summary>
+    public const int FileIdFieldNumber = 1;
+    private string fileId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string FileId {
+      get { return fileId_; }
+      set {
+        fileId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "normalized_x" field.</summary>
+    public const int NormalizedXFieldNumber = 2;
+    private float normalizedX_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public float NormalizedX {
+      get { return normalizedX_; }
+      set {
+        normalizedX_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "normalized_y" field.</summary>
+    public const int NormalizedYFieldNumber = 3;
+    private float normalizedY_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public float NormalizedY {
+      get { return normalizedY_; }
+      set {
+        normalizedY_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as ViewportAssetDropEvent);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(ViewportAssetDropEvent other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (FileId != other.FileId) return false;
+      if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(NormalizedX, other.NormalizedX)) return false;
+      if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(NormalizedY, other.NormalizedY)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (FileId.Length != 0) hash ^= FileId.GetHashCode();
+      if (NormalizedX != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(NormalizedX);
+      if (NormalizedY != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(NormalizedY);
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (FileId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(FileId);
+      }
+      if (NormalizedX != 0F) {
+        output.WriteRawTag(21);
+        output.WriteFloat(NormalizedX);
+      }
+      if (NormalizedY != 0F) {
+        output.WriteRawTag(29);
+        output.WriteFloat(NormalizedY);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (FileId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(FileId);
+      }
+      if (NormalizedX != 0F) {
+        output.WriteRawTag(21);
+        output.WriteFloat(NormalizedX);
+      }
+      if (NormalizedY != 0F) {
+        output.WriteRawTag(29);
+        output.WriteFloat(NormalizedY);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (FileId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(FileId);
+      }
+      if (NormalizedX != 0F) {
+        size += 1 + 4;
+      }
+      if (NormalizedY != 0F) {
+        size += 1 + 4;
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(ViewportAssetDropEvent other) {
+      if (other == null) {
+        return;
+      }
+      if (other.FileId.Length != 0) {
+        FileId = other.FileId;
+      }
+      if (other.NormalizedX != 0F) {
+        NormalizedX = other.NormalizedX;
+      }
+      if (other.NormalizedY != 0F) {
+        NormalizedY = other.NormalizedY;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            FileId = input.ReadString();
+            break;
+          }
+          case 21: {
+            NormalizedX = input.ReadFloat();
+            break;
+          }
+          case 29: {
+            NormalizedY = input.ReadFloat();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            FileId = input.ReadString();
+            break;
+          }
+          case 21: {
+            NormalizedX = input.ReadFloat();
+            break;
+          }
+          case 29: {
+            NormalizedY = input.ReadFloat();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class ViewportToolShortcutEvent : pb::IMessage<ViewportToolShortcutEvent>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<ViewportToolShortcutEvent> _parser = new pb::MessageParser<ViewportToolShortcutEvent>(() => new ViewportToolShortcutEvent());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<ViewportToolShortcutEvent> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportToolShortcutEvent() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportToolShortcutEvent(ViewportToolShortcutEvent other) : this() {
+      keyCode_ = other.keyCode_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ViewportToolShortcutEvent Clone() {
+      return new ViewportToolShortcutEvent(this);
+    }
+
+    /// <summary>Field number for the "key_code" field.</summary>
+    public const int KeyCodeFieldNumber = 1;
+    private uint keyCode_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public uint KeyCode {
+      get { return keyCode_; }
+      set {
+        keyCode_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as ViewportToolShortcutEvent);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(ViewportToolShortcutEvent other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (KeyCode != other.KeyCode) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (KeyCode != 0) hash ^= KeyCode.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (KeyCode != 0) {
+        output.WriteRawTag(8);
+        output.WriteUInt32(KeyCode);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (KeyCode != 0) {
+        output.WriteRawTag(8);
+        output.WriteUInt32(KeyCode);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (KeyCode != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeUInt32Size(KeyCode);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(ViewportToolShortcutEvent other) {
+      if (other == null) {
+        return;
+      }
+      if (other.KeyCode != 0) {
+        KeyCode = other.KeyCode;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            KeyCode = input.ReadUInt32();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            KeyCode = input.ReadUInt32();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class ViewportEvent : pb::IMessage<ViewportEvent>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -11693,7 +14951,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11721,6 +14979,12 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case PayloadOneofCase.Transform:
           Transform = other.Transform.Clone();
+          break;
+        case PayloadOneofCase.AssetDrop:
+          AssetDrop = other.AssetDrop.Clone();
+          break;
+        case PayloadOneofCase.ToolShortcut:
+          ToolShortcut = other.ToolShortcut.Clone();
           break;
       }
 
@@ -11781,12 +15045,38 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "asset_drop" field.</summary>
+    public const int AssetDropFieldNumber = 12;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportAssetDropEvent AssetDrop {
+      get { return payloadCase_ == PayloadOneofCase.AssetDrop ? (global::SailorEditor.Protocol.Generated.ViewportAssetDropEvent) payload_ : null; }
+      set {
+        payload_ = value;
+        payloadCase_ = value == null ? PayloadOneofCase.None : PayloadOneofCase.AssetDrop;
+      }
+    }
+
+    /// <summary>Field number for the "tool_shortcut" field.</summary>
+    public const int ToolShortcutFieldNumber = 13;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.ViewportToolShortcutEvent ToolShortcut {
+      get { return payloadCase_ == PayloadOneofCase.ToolShortcut ? (global::SailorEditor.Protocol.Generated.ViewportToolShortcutEvent) payload_ : null; }
+      set {
+        payload_ = value;
+        payloadCase_ = value == null ? PayloadOneofCase.None : PayloadOneofCase.ToolShortcut;
+      }
+    }
+
     private object payload_;
     /// <summary>Enum of possible cases for the "payload" oneof.</summary>
     public enum PayloadOneofCase {
       None = 0,
       Selection = 10,
       Transform = 11,
+      AssetDrop = 12,
+      ToolShortcut = 13,
     }
     private PayloadOneofCase payloadCase_ = PayloadOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11821,6 +15111,8 @@ namespace SailorEditor.Protocol.Generated {
       if (ManagedMutationRevision != other.ManagedMutationRevision) return false;
       if (!object.Equals(Selection, other.Selection)) return false;
       if (!object.Equals(Transform, other.Transform)) return false;
+      if (!object.Equals(AssetDrop, other.AssetDrop)) return false;
+      if (!object.Equals(ToolShortcut, other.ToolShortcut)) return false;
       if (PayloadCase != other.PayloadCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -11833,6 +15125,8 @@ namespace SailorEditor.Protocol.Generated {
       if (ManagedMutationRevision != 0UL) hash ^= ManagedMutationRevision.GetHashCode();
       if (payloadCase_ == PayloadOneofCase.Selection) hash ^= Selection.GetHashCode();
       if (payloadCase_ == PayloadOneofCase.Transform) hash ^= Transform.GetHashCode();
+      if (payloadCase_ == PayloadOneofCase.AssetDrop) hash ^= AssetDrop.GetHashCode();
+      if (payloadCase_ == PayloadOneofCase.ToolShortcut) hash ^= ToolShortcut.GetHashCode();
       hash ^= (int) payloadCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -11868,6 +15162,14 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(90);
         output.WriteMessage(Transform);
       }
+      if (payloadCase_ == PayloadOneofCase.AssetDrop) {
+        output.WriteRawTag(98);
+        output.WriteMessage(AssetDrop);
+      }
+      if (payloadCase_ == PayloadOneofCase.ToolShortcut) {
+        output.WriteRawTag(106);
+        output.WriteMessage(ToolShortcut);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -11894,6 +15196,14 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(90);
         output.WriteMessage(Transform);
       }
+      if (payloadCase_ == PayloadOneofCase.AssetDrop) {
+        output.WriteRawTag(98);
+        output.WriteMessage(AssetDrop);
+      }
+      if (payloadCase_ == PayloadOneofCase.ToolShortcut) {
+        output.WriteRawTag(106);
+        output.WriteMessage(ToolShortcut);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -11915,6 +15225,12 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (payloadCase_ == PayloadOneofCase.Transform) {
         size += 1 + pb::CodedOutputStream.ComputeMessageSize(Transform);
+      }
+      if (payloadCase_ == PayloadOneofCase.AssetDrop) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(AssetDrop);
+      }
+      if (payloadCase_ == PayloadOneofCase.ToolShortcut) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(ToolShortcut);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -11946,6 +15262,18 @@ namespace SailorEditor.Protocol.Generated {
             Transform = new global::SailorEditor.Protocol.Generated.ViewportTransformEvent();
           }
           Transform.MergeFrom(other.Transform);
+          break;
+        case PayloadOneofCase.AssetDrop:
+          if (AssetDrop == null) {
+            AssetDrop = new global::SailorEditor.Protocol.Generated.ViewportAssetDropEvent();
+          }
+          AssetDrop.MergeFrom(other.AssetDrop);
+          break;
+        case PayloadOneofCase.ToolShortcut:
+          if (ToolShortcut == null) {
+            ToolShortcut = new global::SailorEditor.Protocol.Generated.ViewportToolShortcutEvent();
+          }
+          ToolShortcut.MergeFrom(other.ToolShortcut);
           break;
       }
 
@@ -11994,6 +15322,24 @@ namespace SailorEditor.Protocol.Generated {
             Transform = subBuilder;
             break;
           }
+          case 98: {
+            global::SailorEditor.Protocol.Generated.ViewportAssetDropEvent subBuilder = new global::SailorEditor.Protocol.Generated.ViewportAssetDropEvent();
+            if (payloadCase_ == PayloadOneofCase.AssetDrop) {
+              subBuilder.MergeFrom(AssetDrop);
+            }
+            input.ReadMessage(subBuilder);
+            AssetDrop = subBuilder;
+            break;
+          }
+          case 106: {
+            global::SailorEditor.Protocol.Generated.ViewportToolShortcutEvent subBuilder = new global::SailorEditor.Protocol.Generated.ViewportToolShortcutEvent();
+            if (payloadCase_ == PayloadOneofCase.ToolShortcut) {
+              subBuilder.MergeFrom(ToolShortcut);
+            }
+            input.ReadMessage(subBuilder);
+            ToolShortcut = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -12039,6 +15385,24 @@ namespace SailorEditor.Protocol.Generated {
             Transform = subBuilder;
             break;
           }
+          case 98: {
+            global::SailorEditor.Protocol.Generated.ViewportAssetDropEvent subBuilder = new global::SailorEditor.Protocol.Generated.ViewportAssetDropEvent();
+            if (payloadCase_ == PayloadOneofCase.AssetDrop) {
+              subBuilder.MergeFrom(AssetDrop);
+            }
+            input.ReadMessage(subBuilder);
+            AssetDrop = subBuilder;
+            break;
+          }
+          case 106: {
+            global::SailorEditor.Protocol.Generated.ViewportToolShortcutEvent subBuilder = new global::SailorEditor.Protocol.Generated.ViewportToolShortcutEvent();
+            if (payloadCase_ == PayloadOneofCase.ToolShortcut) {
+              subBuilder.MergeFrom(ToolShortcut);
+            }
+            input.ReadMessage(subBuilder);
+            ToolShortcut = subBuilder;
+            break;
+          }
         }
       }
     }
@@ -12061,7 +15425,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/Editor/Scene/EditorViewportEventContract.cs
+++ b/Editor/Scene/EditorViewportEventContract.cs
@@ -49,6 +49,20 @@ public sealed record EditorViewportTransformEvent(
     EditorViewportVector4 AfterScale)
     : EditorViewportEvent(Revision, ManagedMutationRevision);
 
+public sealed record EditorViewportAssetDropEvent(
+    ulong Revision,
+    ulong ManagedMutationRevision,
+    string FileId,
+    float NormalizedX,
+    float NormalizedY)
+    : EditorViewportEvent(Revision, ManagedMutationRevision);
+
+public sealed record EditorViewportToolShortcutEvent(
+    ulong Revision,
+    ulong ManagedMutationRevision,
+    uint KeyCode)
+    : EditorViewportEvent(Revision, ManagedMutationRevision);
+
 public static class EditorViewportEventContract
 {
     public static bool TryCreate(
@@ -112,6 +126,45 @@ public static class EditorViewportEventContract
                     afterScale);
                 return true;
 
+            case ViewportEvent.PayloadOneofCase.AssetDrop:
+                var assetDrop = source.AssetDrop;
+                if (string.IsNullOrWhiteSpace(assetDrop.FileId))
+                {
+                    error = "Viewport asset-drop event file id must not be empty.";
+                    return false;
+                }
+
+                if (!IsNormalized(assetDrop.NormalizedX) ||
+                    !IsNormalized(assetDrop.NormalizedY))
+                {
+                    error =
+                        "Viewport asset-drop coordinates must be finite and normalized to [0, 1].";
+                    return false;
+                }
+
+                viewportEvent = new EditorViewportAssetDropEvent(
+                    source.Revision,
+                    source.ManagedMutationRevision,
+                    assetDrop.FileId,
+                    assetDrop.NormalizedX,
+                    assetDrop.NormalizedY);
+                return true;
+
+            case ViewportEvent.PayloadOneofCase.ToolShortcut:
+                var keyCode = source.ToolShortcut.KeyCode;
+                if (!IsToolShortcutKey(keyCode))
+                {
+                    error =
+                        "The viewport tool shortcut event contains an unsupported key.";
+                    return false;
+                }
+
+                viewportEvent = new EditorViewportToolShortcutEvent(
+                    source.Revision,
+                    source.ManagedMutationRevision,
+                    keyCode);
+                return true;
+
             default:
                 error = "The viewport event does not contain a supported payload.";
                 return false;
@@ -140,6 +193,24 @@ public static class EditorViewportEventContract
         "afterPosition",
         "afterRotation",
         "afterScale",
+    ];
+
+    static readonly HashSet<string> AssetDropFields =
+    [
+        "kind",
+        "revision",
+        "managedMutationRevision",
+        "fileId",
+        "normalizedX",
+        "normalizedY",
+    ];
+
+    static readonly HashSet<string> ToolShortcutFields =
+    [
+        "kind",
+        "revision",
+        "managedMutationRevision",
+        "keyCode",
     ];
 
     static bool TryMapOperation(
@@ -303,6 +374,61 @@ public static class EditorViewportEventContract
                     afterScale);
                 return true;
 
+            case "assetDrop":
+                if (!ValidateFields(fields, AssetDropFields, out error) ||
+                    !TryReadScalar(
+                        fields,
+                        "fileId",
+                        allowEmpty: false,
+                        out var fileId,
+                        out error) ||
+                    !TryReadNormalizedFloat(
+                        fields,
+                        "normalizedX",
+                        out var normalizedX,
+                        out error) ||
+                    !TryReadNormalizedFloat(
+                        fields,
+                        "normalizedY",
+                        out var normalizedY,
+                        out error))
+                {
+                    return false;
+                }
+
+                viewportEvent = new EditorViewportAssetDropEvent(
+                    revision,
+                    managedMutationRevision,
+                    fileId,
+                    normalizedX,
+                    normalizedY);
+                return true;
+
+            case "toolShortcut":
+                if (!ValidateFields(fields, ToolShortcutFields, out error) ||
+                    !TryReadUnsignedInteger(
+                        fields,
+                        "keyCode",
+                        out var serializedKeyCode,
+                        out error))
+                {
+                    return false;
+                }
+
+                if (serializedKeyCode > uint.MaxValue ||
+                    !IsToolShortcutKey((uint)serializedKeyCode))
+                {
+                    error =
+                        "Viewport tool shortcut event field 'keyCode' is unsupported.";
+                    return false;
+                }
+
+                viewportEvent = new EditorViewportToolShortcutEvent(
+                    revision,
+                    managedMutationRevision,
+                    (uint)serializedKeyCode);
+                return true;
+
             default:
                 error = $"Unsupported viewport event kind '{kind}'.";
                 return false;
@@ -352,6 +478,44 @@ public static class EditorViewportEventContract
 
         return true;
     }
+
+    static bool TryReadNormalizedFloat(
+        IReadOnlyDictionary<string, YamlNode> fields,
+        string field,
+        out float value,
+        out string error)
+    {
+        value = 0;
+        if (!TryReadScalar(
+                fields,
+                field,
+                allowEmpty: false,
+                out var scalar,
+                out error))
+        {
+            return false;
+        }
+
+        if (!float.TryParse(
+                scalar,
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out value) ||
+            !IsNormalized(value))
+        {
+            error =
+                $"Viewport event field '{field}' must be finite and normalized to [0, 1].";
+            return false;
+        }
+
+        return true;
+    }
+
+    static bool IsNormalized(float value)
+        => float.IsFinite(value) && value >= 0.0f && value <= 1.0f;
+
+    static bool IsToolShortcutKey(uint keyCode)
+        => keyCode is 'Q' or 'W' or 'E' or 'R' or 'T';
 
     static bool TryReadScalar(
         IReadOnlyDictionary<string, YamlNode> fields,

--- a/Editor/Scene/SceneViewportAssetDropPayload.cs
+++ b/Editor/Scene/SceneViewportAssetDropPayload.cs
@@ -1,0 +1,81 @@
+#nullable enable
+using SailorEngine;
+
+namespace SailorEditor.Scene;
+
+public static class SceneViewportAssetDropPayload
+{
+    public const string Prefix = "SailorEditor.Asset:";
+    public const int UnbracedFileIdLength = 36;
+    public const int BracedFileIdLength = 38;
+    public const int MaxLength = 57;
+
+    public static bool TryCreate(
+        FileId? fileId,
+        out string payload)
+    {
+        payload = string.Empty;
+        if (fileId is null ||
+            !IsSerializedFileId(fileId.Value))
+        {
+            return false;
+        }
+
+        payload = Prefix + fileId.Value;
+        return payload.Length <= MaxLength;
+    }
+
+    public static bool IsSerializedFileId(string? value)
+    {
+        if (value is null)
+        {
+            return false;
+        }
+
+        ReadOnlySpan<char> uuid;
+        if (value.Length == BracedFileIdLength)
+        {
+            if (value[0] != '{' || value[^1] != '}')
+            {
+                return false;
+            }
+
+            uuid = value.AsSpan(1, UnbracedFileIdLength);
+        }
+        else if (value.Length == UnbracedFileIdLength)
+        {
+            uuid = value.AsSpan();
+        }
+        else
+        {
+            return false;
+        }
+
+        for (var index = 0; index < uuid.Length; index++)
+        {
+            var isHyphenPosition =
+                index is 8 or 13 or 18 or 23;
+            if (isHyphenPosition)
+            {
+                if (uuid[index] != '-')
+                {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if (!IsHexDigit(uuid[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    static bool IsHexDigit(char value) =>
+        value is >= '0' and <= '9' or
+            >= 'a' and <= 'f' or
+            >= 'A' and <= 'F';
+}

--- a/Editor/Scene/SceneViewportDropCoordinates.cs
+++ b/Editor/Scene/SceneViewportDropCoordinates.cs
@@ -1,0 +1,32 @@
+namespace SailorEditor.Scene;
+
+public readonly record struct SceneViewportDropCoordinates(
+    double NormalizedX,
+    double NormalizedY);
+
+public static class SceneViewportDropCoordinateResolver
+{
+    public static bool TryResolve(
+        double pointerX,
+        double pointerY,
+        double viewportWidth,
+        double viewportHeight,
+        out SceneViewportDropCoordinates coordinates)
+    {
+        coordinates = default;
+        if (!double.IsFinite(pointerX) ||
+            !double.IsFinite(pointerY) ||
+            !double.IsFinite(viewportWidth) ||
+            !double.IsFinite(viewportHeight) ||
+            viewportWidth <= 0 ||
+            viewportHeight <= 0)
+        {
+            return false;
+        }
+
+        coordinates = new SceneViewportDropCoordinates(
+            Math.Clamp(pointerX / viewportWidth, 0.0, 1.0),
+            Math.Clamp(pointerY / viewportHeight, 0.0, 1.0));
+        return true;
+    }
+}

--- a/Editor/Scene/SceneViewportToolState.cs
+++ b/Editor/Scene/SceneViewportToolState.cs
@@ -1,0 +1,58 @@
+namespace SailorEditor.Scene;
+
+public readonly record struct SceneViewportToolState(
+    EditorViewportTransformOperation Operation,
+    EditorViewportTransformSpace Space);
+
+public static class SceneViewportToolShortcuts
+{
+    public static SceneViewportToolState Default { get; } = new(
+        EditorViewportTransformOperation.Select,
+        EditorViewportTransformSpace.World);
+
+    public static bool TryApply(
+        uint keyCode,
+        bool isPressed,
+        bool hasViewportFocus,
+        SceneViewportToolState current,
+        out SceneViewportToolState next)
+    {
+        next = current;
+        if (!isPressed || !hasViewportFocus)
+        {
+            return false;
+        }
+
+        var normalizedKeyCode = keyCode is >= 'a' and <= 'z'
+            ? keyCode - ('a' - 'A')
+            : keyCode;
+        next = normalizedKeyCode switch
+        {
+            'Q' => current with
+            {
+                Operation = EditorViewportTransformOperation.Select
+            },
+            'W' => current with
+            {
+                Operation = EditorViewportTransformOperation.Translate
+            },
+            'E' => current with
+            {
+                Operation = EditorViewportTransformOperation.Rotate
+            },
+            'R' => current with
+            {
+                Operation = EditorViewportTransformOperation.Scale
+            },
+            'T' => current with
+            {
+                Space = current.Space == EditorViewportTransformSpace.Local
+                    ? EditorViewportTransformSpace.World
+                    : EditorViewportTransformSpace.Local
+            },
+            _ => current
+        };
+
+        return normalizedKeyCode is 'Q' or 'W' or 'E' or 'R' or 'T';
+    }
+}

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -12,6 +12,10 @@ using SailorEditor.Content;
 
 namespace SailorEditor.Services
 {
+    public sealed record PrefabAssetWriteResult(
+        PrefabFile Prefab,
+        ProjectContentAssetWriteTransaction Transaction);
+
     public class AssetsService : IDisposable
     {
         const int ActiveProjectRootId = 1;
@@ -105,7 +109,39 @@ namespace SailorEditor.Services
             return Path.Combine(CurrentProjectRootPath, Path.Combine(parts.ToArray()));
         }
 
-        public PrefabFile? CreatePrefabAsset(AssetFolder? targetFolder, GameObject root, bool overwrite = false, PrefabFile? existingPrefab = null)
+        public PrefabFile? CreatePrefabAsset(
+            AssetFolder? targetFolder,
+            GameObject root,
+            bool overwrite = false,
+            PrefabFile? existingPrefab = null)
+        {
+            var creation = BeginCreatePrefabAsset(
+                targetFolder,
+                root,
+                overwrite,
+                existingPrefab);
+            if (creation is null)
+                return null;
+
+            var commit = CompletePrefabAssetWrite(
+                creation.Transaction,
+                commit: true);
+            if (!commit.Succeeded)
+            {
+                CompletePrefabAssetWrite(
+                    creation.Transaction,
+                    commit: false);
+            }
+            return commit.Succeeded
+                ? creation.Prefab
+                : null;
+        }
+
+        public PrefabAssetWriteResult? BeginCreatePrefabAsset(
+            AssetFolder? targetFolder,
+            GameObject root,
+            bool overwrite = false,
+            PrefabFile? existingPrefab = null)
         {
             if ((targetFolder?.IsReadOnly ?? false) || (existingPrefab?.IsReadOnly ?? false))
                 return null;
@@ -116,22 +152,107 @@ namespace SailorEditor.Services
             if (!ProjectContentPathPolicy.IsInsideRoot(CurrentProjectRootPath, folderPath))
                 return null;
 
-            Directory.CreateDirectory(folderPath);
+            if (!Directory.Exists(folderPath))
+                return null;
 
             var prefabName = existingPrefab?.Asset?.Name ?? GetUniqueAssetName(folderPath, root.Name, ".prefab");
             var prefabPath = existingPrefab?.Asset?.FullName ?? Path.Combine(folderPath, prefabName);
-            var assetInfoPath = prefabPath + ".asset";
             var fileId = existingPrefab?.FileId ?? new FileId($"{{{Guid.NewGuid().ToString().ToUpperInvariant()}}}");
+            var sourceContents =
+                SailorEditor.Commands.EditorYaml.SerializePrefab(prefab);
+            var metadataContents = SerializePrefabAssetInfo(
+                fileId,
+                Path.GetFileName(prefabPath),
+                externalRefs);
 
-            WritePrefab(prefabPath, prefab);
-            WritePrefabAssetInfo(assetInfoPath, fileId, Path.GetFileName(prefabPath), externalRefs);
+            ProjectContentAssetWriteTransaction transaction;
+            lock (_watcherLock)
+            {
+                var watcherStates = _contentWatchers
+                    .Select(watcher => watcher.EnableRaisingEvents)
+                    .ToArray();
+                try
+                {
+                    foreach (var watcher in _contentWatchers)
+                        watcher.EnableRaisingEvents = false;
+                    transaction = _fileOperations.BeginWriteAssetPair(
+                        CurrentProjectRootPath,
+                        prefabPath,
+                        sourceContents,
+                        metadataContents,
+                        fileId.Value,
+                        overwrite);
+                }
+                finally
+                {
+                    for (var index = 0;
+                        index < _contentWatchers.Count;
+                        index++)
+                    {
+                        _contentWatchers[index].EnableRaisingEvents =
+                            watcherStates[index];
+                    }
+                }
+            }
 
-            Refresh();
+            if (!transaction.Result.Succeeded)
+                return null;
+
+            try
+            {
+                Refresh();
+            }
+            catch
+            {
+                CompletePrefabAssetWrite(transaction, commit: false);
+                return null;
+            }
+
             var created = Assets.TryGetValue(fileId, out var asset) && asset is PrefabFile prefabFile
                 ? prefabFile
                 : null;
+            if (created is null)
+            {
+                CompletePrefabAssetWrite(transaction, commit: false);
+                return null;
+            }
 
-            return created;
+            return new PrefabAssetWriteResult(created, transaction);
+        }
+
+        public ProjectContentFileOperationResult CompletePrefabAssetWrite(
+            ProjectContentAssetWriteTransaction transaction,
+            bool commit)
+        {
+            ProjectContentFileOperationResult result;
+            lock (_watcherLock)
+            {
+                var watcherStates = _contentWatchers
+                    .Select(watcher => watcher.EnableRaisingEvents)
+                    .ToArray();
+                try
+                {
+                    foreach (var watcher in _contentWatchers)
+                        watcher.EnableRaisingEvents = false;
+                    result = commit
+                        ? transaction.Commit()
+                        : transaction.Rollback();
+                }
+                finally
+                {
+                    for (var index = 0;
+                        index < _contentWatchers.Count;
+                        index++)
+                    {
+                        _contentWatchers[index].EnableRaisingEvents =
+                            watcherStates[index];
+                    }
+                }
+            }
+
+            if (!commit || !result.Succeeded)
+                Refresh();
+            return result;
         }
 
         public ProjectContentFileOperationResult RenameAsset(AssetFile assetFile, string newName)
@@ -678,12 +799,10 @@ namespace SailorEditor.Services
             return fileName;
         }
 
-        static void WritePrefab(string path, Prefab prefab)
-        {
-            File.WriteAllText(path, SailorEditor.Commands.EditorYaml.SerializePrefab(prefab));
-        }
-
-        static void WritePrefabAssetInfo(string path, FileId fileId, string filename, List<InstanceId> externalRefs)
+        static string SerializePrefabAssetInfo(
+            FileId fileId,
+            string filename,
+            List<InstanceId> externalRefs)
         {
             var root = new YamlMappingNode
             {
@@ -700,8 +819,9 @@ namespace SailorEditor.Services
             }
 
             var yaml = new YamlStream(new YamlDocument(root));
-            using var writer = new StreamWriter(new FileStream(path, FileMode.Create));
+            using var writer = new StringWriter();
             yaml.Save(writer, false);
+            return writer.ToString();
         }
 
         private AssetFile ReadAssetFile(FileInfo assetInfo, int parentFolderId, int projectRootId, bool isReadOnly)
@@ -871,6 +991,9 @@ namespace SailorEditor.Services
 
             foreach (var directory in Directory.GetDirectories(directoryPath).Order(ProjectContentPathPolicy.PathComparer))
             {
+                if (ProjectContentInternalPathPolicy.IsTransactionDirectory(directory))
+                    continue;
+
                 var canonicalChildPath = ProjectContentPathPolicy.NormalizeRoot(directory);
                 if (!ProjectContentPathPolicy.IsInsideRoot(rootPath, canonicalChildPath)
                     || _visitedDirectories.Contains($"{root.Id}:{canonicalChildPath}"))

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -2359,6 +2359,53 @@ namespace SailorEditor.Services
             }
         }
 
+        public async Task<bool> RefreshCurrentWorldAuthoritativelyAsync(
+            CancellationToken cancellationToken = default)
+        {
+            using var perfScope = EditorPerf.Scope(
+                "EngineService.RefreshCurrentWorldAuthoritatively");
+            var generation = Volatile.Read(ref engineGeneration);
+            var world = MauiProgram.GetService<WorldService>();
+            var workspaceEpoch = world.WorkspaceEpoch;
+            var snapshot =
+                await SerializeWorldAsync(
+                    generation,
+                    cancellationToken: cancellationToken)
+                    .ConfigureAwait(false);
+            if (string.IsNullOrEmpty(snapshot.SerializedWorld))
+            {
+                return false;
+            }
+
+            var populated = false;
+            void PopulateAuthoritativeSnapshot()
+            {
+                if (!IsGenerationActive(generation) ||
+                    !worldSnapshotPublication.TryAdvance(snapshot.Sequence))
+                {
+                    return;
+                }
+
+                populated = world.TryPopulateWorld(
+                    snapshot.SerializedWorld,
+                    workspaceEpoch);
+            }
+
+            if (MainThread.IsMainThread)
+            {
+                PopulateAuthoritativeSnapshot();
+            }
+            else
+            {
+                await MainThread.InvokeOnMainThreadAsync(
+                    PopulateAuthoritativeSnapshot);
+            }
+
+            return populated &&
+                IsGenerationActive(generation) &&
+                world.WorkspaceEpoch == workspaceEpoch;
+        }
+
         async Task<InstanceId?> InvokeCreationInteropAsync(
             Func<CancellationToken, Task<EngineProtocolCreationResult>> interop,
             CancellationToken cancellationToken)
@@ -2427,16 +2474,75 @@ namespace SailorEditor.Services
                 cancellationToken);
         }
 
+        public async Task<Vec4?> ResolveViewportDropPositionAsync(
+            double normalizedX,
+            double normalizedY,
+            CancellationToken cancellationToken = default)
+        {
+            if (!double.IsFinite(normalizedX) ||
+                !double.IsFinite(normalizedY) ||
+                normalizedX < 0.0 ||
+                normalizedX > 1.0 ||
+                normalizedY < 0.0 ||
+                normalizedY > 1.0)
+            {
+                return null;
+            }
+
+            var resolved = default(EngineProtocolVector4);
+            var succeeded = await InvokeRunningInteropAsync(async token =>
+                {
+                    resolved =
+                        await protocolClient.ResolveViewportDropPositionAsync(
+                            SceneViewportId,
+                            (float)normalizedX,
+                            (float)normalizedY,
+                            token).ConfigureAwait(false);
+                    return true;
+                },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            return succeeded
+                ? new Vec4
+                {
+                    X = resolved.X,
+                    Y = resolved.Y,
+                    Z = resolved.Z,
+                    W = resolved.W
+                }
+                : null;
+        }
+
+        public Task<InstanceId?> CreateModelGameObjectAsync(
+            FileId modelFileId,
+            string name,
+            InstanceId? parentId = null,
+            Vec4? worldPosition = null,
+            CancellationToken cancellationToken = default)
+        {
+            var position = worldPosition is null
+                ? (EngineProtocolVector4?)null
+                : new EngineProtocolVector4(
+                    worldPosition.X,
+                    worldPosition.Y,
+                    worldPosition.Z,
+                    worldPosition.W);
+            return InvokeCreationInteropAsync(
+                token => protocolClient.CreateModelGameObjectAsync(
+                    modelFileId?.Value ?? string.Empty,
+                    name ?? string.Empty,
+                    parentId?.Value ?? string.Empty,
+                    position,
+                    token),
+                cancellationToken);
+        }
+
         public async Task<bool> DestroyObjectAsync(
             InstanceId instanceId,
             CancellationToken cancellationToken = default)
         {
-            var stringId = instanceId?.Value ?? string.Empty;
-            var result = await InvokeRunningInteropAsync(
-                token => protocolClient.DestroyObjectAsync(
-                    stringId,
-                    token),
-                cancellationToken: cancellationToken).ConfigureAwait(false);
+            var result = await RequestDestroyObjectAsync(
+                instanceId,
+                cancellationToken).ConfigureAwait(false);
 
             if (result)
             {
@@ -2445,6 +2551,18 @@ namespace SailorEditor.Services
             }
 
             return result;
+        }
+
+        internal Task<bool> RequestDestroyObjectAsync(
+            InstanceId instanceId,
+            CancellationToken cancellationToken = default)
+        {
+            var stringId = instanceId?.Value ?? string.Empty;
+            return InvokeRunningInteropAsync(
+                token => protocolClient.DestroyObjectAsync(
+                    stringId,
+                    token),
+                cancellationToken: cancellationToken);
         }
 
         public async Task<bool> ResetComponentToDefaultsAsync(
@@ -2527,10 +2645,211 @@ namespace SailorEditor.Services
             return result;
         }
 
-        public async Task<bool> InstantiatePrefabFromYamlAsync(
+        public Task<InstanceId?> InstantiatePrefabInstanceAsync(
+            FileId prefabId,
+            InstanceId? parentId = null,
+            Vec4? worldPosition = null,
+            CancellationToken cancellationToken = default)
+        {
+            var position = worldPosition is null
+                ? (EngineProtocolVector4?)null
+                : new EngineProtocolVector4(
+                    worldPosition.X,
+                    worldPosition.Y,
+                    worldPosition.Z,
+                    worldPosition.W);
+            return InvokeCreationInteropAsync(
+                token => protocolClient.InstantiatePrefabInstanceAsync(
+                    prefabId?.Value ?? string.Empty,
+                    parentId?.Value ?? string.Empty,
+                    position,
+                    token),
+                cancellationToken);
+        }
+
+        public Task<bool> FocusEditorCameraAsync(
+            InstanceId instanceId,
+            CancellationToken cancellationToken = default)
+            => InvokeRunningInteropAsync(
+                token => protocolClient.FocusEditorCameraAsync(
+                    SceneViewportId,
+                    instanceId?.Value ?? string.Empty,
+                    token),
+                cancellationToken: cancellationToken);
+
+        public async Task<bool> SetPrefabLinkAsync(
+            InstanceId instanceId,
+            FileId prefabId,
+            CancellationToken cancellationToken = default)
+        {
+            var result = await InvokeRunningInteropAsync(
+                token => protocolClient.SetPrefabLinkAsync(
+                    instanceId?.Value ?? string.Empty,
+                    prefabId?.Value ?? string.Empty,
+                    token),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (result)
+            {
+                await RefreshCurrentWorldAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            return result;
+        }
+
+        public async Task<bool> BreakPrefabLinkAsync(
+            InstanceId instanceId,
+            CancellationToken cancellationToken = default)
+        {
+            var result = await InvokeRunningInteropAsync(
+                token => protocolClient.BreakPrefabLinkAsync(
+                    instanceId?.Value ?? string.Empty,
+                    token),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (result)
+            {
+                await RefreshCurrentWorldAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            return result;
+        }
+
+        public Task<bool> SetViewportToolStateAsync(
+            EditorViewportTransformOperation operation,
+            EditorViewportTransformSpace space,
+            CancellationToken cancellationToken = default)
+            => InvokeRunningInteropAsync(
+                token => protocolClient.SetViewportToolStateAsync(
+                    SceneViewportId,
+                    ToProtocolOperation(operation),
+                    ToProtocolSpace(space),
+                    token),
+                cancellationToken: cancellationToken);
+
+        public async Task<SceneViewportToolState?> GetViewportToolStateAsync(
+            CancellationToken cancellationToken = default)
+        {
+            var state = default(EngineProtocolViewportToolState);
+            var succeeded = await InvokeRunningInteropAsync(async token =>
+                {
+                    state = await protocolClient.GetViewportToolStateAsync(
+                        SceneViewportId,
+                        token).ConfigureAwait(false);
+                    return true;
+                },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            return succeeded
+                ? new SceneViewportToolState(
+                    FromProtocolOperation(state.Operation),
+                    FromProtocolSpace(state.Space))
+                : null;
+        }
+
+        static ViewportTransformOperation ToProtocolOperation(
+            EditorViewportTransformOperation operation)
+            => operation switch
+            {
+                EditorViewportTransformOperation.Select =>
+                    ViewportTransformOperation.Select,
+                EditorViewportTransformOperation.Translate =>
+                    ViewportTransformOperation.Translate,
+                EditorViewportTransformOperation.Rotate =>
+                    ViewportTransformOperation.Rotate,
+                EditorViewportTransformOperation.Scale =>
+                    ViewportTransformOperation.Scale,
+                _ => throw new ArgumentOutOfRangeException(nameof(operation))
+            };
+
+        static ViewportTransformSpace ToProtocolSpace(
+            EditorViewportTransformSpace space)
+            => space switch
+            {
+                EditorViewportTransformSpace.World =>
+                    ViewportTransformSpace.World,
+                EditorViewportTransformSpace.Local =>
+                    ViewportTransformSpace.Local,
+                _ => throw new ArgumentOutOfRangeException(nameof(space))
+            };
+
+        static EditorViewportTransformOperation FromProtocolOperation(
+            ViewportTransformOperation operation)
+            => operation switch
+            {
+                ViewportTransformOperation.Select =>
+                    EditorViewportTransformOperation.Select,
+                ViewportTransformOperation.Translate =>
+                    EditorViewportTransformOperation.Translate,
+                ViewportTransformOperation.Rotate =>
+                    EditorViewportTransformOperation.Rotate,
+                ViewportTransformOperation.Scale =>
+                    EditorViewportTransformOperation.Scale,
+                _ => throw new EngineProtocolException(
+                    $"Unsupported viewport transform operation '{operation}'.")
+            };
+
+        static EditorViewportTransformSpace FromProtocolSpace(
+            ViewportTransformSpace space)
+            => space switch
+            {
+                ViewportTransformSpace.World =>
+                    EditorViewportTransformSpace.World,
+                ViewportTransformSpace.Local =>
+                    EditorViewportTransformSpace.Local,
+                _ => throw new EngineProtocolException(
+                    $"Unsupported viewport transform space '{space}'.")
+            };
+
+        public Task<bool> InstantiatePrefabFromYamlAsync(
             string prefabYaml,
             InstanceId? parentId = null,
             CancellationToken cancellationToken = default)
+            => InstantiatePrefabFromYamlCoreAsync(
+                prefabYaml,
+                parentId,
+                cancellationToken);
+
+        public async Task<bool> InstantiatePrefabFromYamlStrictAsync(
+            string prefabYaml,
+            InstanceId? parentId,
+            CancellationToken cancellationToken = default)
+        {
+            var result =
+                await RequestInstantiatePrefabFromYamlStrictAsync(
+                    prefabYaml,
+                    parentId,
+                    cancellationToken).ConfigureAwait(false);
+
+            if (result)
+            {
+                await RefreshCurrentWorldAsync(
+                    cancellationToken).ConfigureAwait(false);
+            }
+
+            return result;
+        }
+
+        internal Task<bool> RequestInstantiatePrefabFromYamlStrictAsync(
+            string prefabYaml,
+            InstanceId? parentId,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(prefabYaml))
+            {
+                return Task.FromResult(false);
+            }
+
+            var stringParentId = parentId?.Value ?? string.Empty;
+            return InvokeRunningInteropAsync(
+                token => protocolClient.InstantiatePrefabFromYamlStrictAsync(
+                    prefabYaml,
+                    stringParentId,
+                    token),
+                cancellationToken: cancellationToken);
+        }
+
+        async Task<bool> InstantiatePrefabFromYamlCoreAsync(
+            string prefabYaml,
+            InstanceId? parentId,
+            CancellationToken cancellationToken)
         {
             if (string.IsNullOrWhiteSpace(prefabYaml))
             {

--- a/Editor/Services/HierarchyProjectionService.cs
+++ b/Editor/Services/HierarchyProjectionService.cs
@@ -61,7 +61,12 @@ public sealed partial class HierarchyProjectionService : ObservableObject
             return;
 
         var parentById = _worldService.Current.Prefabs
-            .SelectMany(prefab => prefab.GameObjects.Select(gameObject => new { gameObject, parentId = ResolveParentId(prefab, gameObject) }))
+            .SelectMany(prefab => prefab.GameObjects.Select(gameObject => new
+            {
+                gameObject,
+                parentId = _worldService
+                    .ResolveParentInstanceId(gameObject)?.Value
+            }))
             .Where(x => x.gameObject.InstanceId is not null && !x.gameObject.InstanceId.IsEmpty())
             .ToDictionary(x => x.gameObject.InstanceId!.Value, x => x.parentId, StringComparer.Ordinal);
 
@@ -84,19 +89,29 @@ public sealed partial class HierarchyProjectionService : ObservableObject
             .Select(x => new HierarchySourceItem(
                 x.gameObject.InstanceId?.Value ?? string.Empty,
                 x.gameObject.Name,
-                ResolveParentId(x.prefab, x.gameObject)))
+                _worldService.ResolveParentInstanceId(x.gameObject)?.Value,
+                x.prefab.FileId is not null &&
+                    !x.prefab.FileId.IsEmpty(),
+                x.prefab.FileId is not null &&
+                    !x.prefab.FileId.IsEmpty()
+                    ? x.prefab.FileId.Value
+                    : null,
+                ResolvePrefabRootInstanceId(x.prefab)))
             .Where(x => !string.IsNullOrWhiteSpace(x.Id));
 
         Roots = HierarchyProjectionBuilder.Build(items, _expandedIds, _selectionService.SelectedInstanceId?.Value);
         VisibleRows = HierarchyProjectionBuilder.Flatten(Roots);
     }
 
-    static string? ResolveParentId(Prefab prefab, GameObject gameObject)
+    static string? ResolvePrefabRootInstanceId(Prefab prefab)
     {
-        if (gameObject.ParentIndex == uint.MaxValue || gameObject.ParentIndex >= prefab.GameObjects.Count)
+        if (prefab.FileId is null || prefab.FileId.IsEmpty())
             return null;
 
-        var parent = prefab.GameObjects[(int)gameObject.ParentIndex];
-        return parent.InstanceId is not null && !parent.InstanceId.IsEmpty() ? parent.InstanceId.Value : null;
+        var root = prefab.GameObjects.FirstOrDefault(
+            gameObject => gameObject.ParentIndex == uint.MaxValue);
+        return root?.InstanceId is not null && !root.InstanceId.IsEmpty()
+            ? root.InstanceId.Value
+            : null;
     }
 }

--- a/Editor/Services/WorldService.cs
+++ b/Editor/Services/WorldService.cs
@@ -107,6 +107,39 @@ namespace SailorEditor.Services
         public bool TryGetComponent(InstanceId instanceId, out Component component) => componentsDict.TryGetValue(instanceId, out component);
         public bool TryGetGameObject(InstanceId instanceId, out GameObject gameObject) => gameObjectsDict.TryGetValue(instanceId, out gameObject);
 
+        public InstanceId? ResolveParentInstanceId(GameObject gameObject)
+        {
+            if (gameObject is null ||
+                gameObject.PrefabIndex < 0 ||
+                gameObject.PrefabIndex >= Current.Prefabs.Count)
+            {
+                return null;
+            }
+
+            var prefab = Current.Prefabs[gameObject.PrefabIndex];
+            if (gameObject.ParentIndex != uint.MaxValue)
+            {
+                if (gameObject.ParentIndex >= prefab.GameObjects.Count)
+                {
+                    return null;
+                }
+
+                var parentInstanceId =
+                    prefab.GameObjects[(int)gameObject.ParentIndex].InstanceId;
+                return parentInstanceId is null || parentInstanceId.IsEmpty()
+                    ? null
+                    : new InstanceId(parentInstanceId.Value);
+            }
+
+            return string.IsNullOrWhiteSpace(prefab.ParentInstanceId) ||
+                string.Equals(
+                    prefab.ParentInstanceId,
+                    InstanceId.NullInstanceId,
+                    StringComparison.Ordinal)
+                ? null
+                : new InstanceId(prefab.ParentInstanceId);
+        }
+
         public List<Component> GetComponents(GameObject gameObject)
         {
             List<Component> res = [];
@@ -556,7 +589,8 @@ namespace SailorEditor.Services
             bool keepWorldTransform = true,
             CancellationToken cancellationToken = default)
         {
-            if (child == null || child.ParentIndex == uint.MaxValue)
+            if (child == null ||
+                ResolveParentInstanceId(child) is null)
             {
                 return false;
             }
@@ -807,7 +841,9 @@ namespace SailorEditor.Services
                 prefab.GameObjects ??= [];
                 prefab.Components ??= [];
 
-                var newPrefab = new Prefab();
+                var newPrefab = (Prefab)prefab.Clone();
+                newPrefab.GameObjects.Clear();
+                newPrefab.Components.Clear();
                 foreach (var go in prefab.GameObjects)
                 {
                     var gameObject = go;

--- a/Editor/Utility/EditorDragDrop.cs
+++ b/Editor/Utility/EditorDragDrop.cs
@@ -53,8 +53,53 @@ public static class EditorDragDrop
             return true;
         }
 
+        if (TryResolveModelAsset(source, out var model) &&
+            (currentTarget is null || currentTarget.InstanceId is not null))
+        {
+            command = new CreateModelGameObjectCommand(
+                model,
+                ResolveAssetObjectName(model),
+                currentTarget);
+            return true;
+        }
+
         return false;
     }
+
+    public static bool TryCreateViewportDropCommand(
+        object? source,
+        Vec4 worldPosition,
+        out IEditorCommand? command)
+    {
+        command = null;
+        if (worldPosition is null)
+        {
+            return false;
+        }
+
+        if (TryResolvePrefabAsset(source, out var prefab))
+        {
+            command = new InstantiatePrefabAssetCommand(
+                prefab,
+                worldPosition: worldPosition);
+            return true;
+        }
+
+        if (TryResolveModelAsset(source, out var model))
+        {
+            command = new CreateModelGameObjectCommand(
+                model,
+                ResolveAssetObjectName(model),
+                worldPosition: worldPosition);
+            return true;
+        }
+
+        return false;
+    }
+
+    public static bool IsViewportAssetDrop(object? source) =>
+        TryResolvePrefabAsset(source, out _) ||
+        TryResolveModelAsset(source, out _);
 
     public static bool TryCreateContentDropCommand(object? source, object? target, out IEditorCommand? command, out bool requiresConfirmation)
     {
@@ -100,9 +145,30 @@ public static class EditorDragDrop
         if (source is not AssetFile assetFile || assetFile.FileId is null || assetFile.FileId.IsEmpty())
             return false;
 
-        if (assetFile is PrefabFile ||
-            string.Equals(assetFile.AssetInfoTypeName, "Sailor::PrefabAssetInfo", StringComparison.Ordinal) ||
-            string.Equals(assetFile.Asset?.Extension, ".prefab", StringComparison.OrdinalIgnoreCase))
+        if (assetFile is PrefabFile)
+        {
+            prefab = assetFile;
+            return true;
+        }
+
+        if (HasAuthoritativeAssetInfoType(assetFile))
+        {
+            if (string.Equals(
+                    assetFile.AssetInfoTypeName,
+                    "Sailor::PrefabAssetInfo",
+                    StringComparison.Ordinal))
+            {
+                prefab = assetFile;
+                return true;
+            }
+
+            return false;
+        }
+
+        if (string.Equals(
+                assetFile.Asset?.Extension,
+                ".prefab",
+                StringComparison.OrdinalIgnoreCase))
         {
             prefab = assetFile;
             return true;
@@ -111,10 +177,76 @@ public static class EditorDragDrop
         return false;
     }
 
+    static bool TryResolveModelAsset(object? source, [NotNullWhen(true)] out AssetFile? model)
+    {
+        model = null;
+        if (source is not AssetFile assetFile ||
+            assetFile.FileId is null ||
+            assetFile.FileId.IsEmpty())
+        {
+            return false;
+        }
+
+        if (assetFile is ModelFile)
+        {
+            model = assetFile;
+            return true;
+        }
+
+        if (HasAuthoritativeAssetInfoType(assetFile))
+        {
+            if (string.Equals(
+                    assetFile.AssetInfoTypeName,
+                    "Sailor::ModelAssetInfo",
+                    StringComparison.Ordinal))
+            {
+                model = assetFile;
+                return true;
+            }
+
+            return false;
+        }
+
+        var extension = assetFile.Asset?.Extension;
+        if (string.Equals(extension, ".obj", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(extension, ".gltf", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(extension, ".glb", StringComparison.OrdinalIgnoreCase))
+        {
+            model = assetFile;
+            return true;
+        }
+
+        return false;
+    }
+
+    static bool HasAuthoritativeAssetInfoType(AssetFile assetFile)
+        => !string.IsNullOrWhiteSpace(assetFile.AssetInfoTypeName) &&
+            !string.Equals(
+                assetFile.AssetInfoTypeName,
+                AssetFile.DefaultAssetInfoTypeName,
+                StringComparison.Ordinal);
+
+    public static string ResolveAssetObjectName(AssetFile assetFile)
+    {
+        var filename = assetFile.Asset?.Name;
+        if (string.IsNullOrWhiteSpace(filename))
+        {
+            return "GameObject";
+        }
+
+        var name = Path.GetFileNameWithoutExtension(filename);
+        return string.IsNullOrWhiteSpace(name)
+            ? "GameObject"
+            : name;
+    }
+
     static bool CanReparent(GameObject source, GameObject? target)
     {
         if (target is null)
-            return source.ParentIndex != uint.MaxValue;
+        {
+            return MauiProgram.GetService<WorldService>()
+                .ResolveParentInstanceId(source) is not null;
+        }
 
         if (ReferenceEquals(source, target) || HasSameInstanceId(source, target))
             return false;
@@ -127,17 +259,14 @@ public static class EditorDragDrop
 
     static bool HasSameParent(GameObject source, GameObject target)
     {
-        if (source.ParentIndex == uint.MaxValue)
-            return false;
-
-        if (source.PrefabIndex != target.PrefabIndex)
-            return false;
-
-        var prefab = MauiProgram.GetService<Services.WorldService>().Current.Prefabs[source.PrefabIndex];
-        if ((int)source.ParentIndex >= prefab.GameObjects.Count)
-            return false;
-
-        return ReferenceEquals(prefab.GameObjects[(int)source.ParentIndex], target) || HasSameInstanceId(prefab.GameObjects[(int)source.ParentIndex], target);
+        var parentInstanceId = MauiProgram.GetService<WorldService>()
+            .ResolveParentInstanceId(source);
+        return parentInstanceId is not null
+            && target.InstanceId is not null
+            && string.Equals(
+                parentInstanceId.Value,
+                target.InstanceId.Value,
+                StringComparison.Ordinal);
     }
 
     static bool HasSameInstanceId(GameObject? left, GameObject? right)

--- a/Editor/ViewModels/Prefab.cs
+++ b/Editor/ViewModels/Prefab.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿#nullable enable
+using CommunityToolkit.Mvvm.ComponentModel;
 using SailorEditor.Utility;
 using System.Xml.Linq;
 using YamlDotNet.Core.Events;
@@ -6,16 +7,132 @@ using YamlDotNet.Core;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
 using System.ComponentModel;
+using SailorEngine;
 
 namespace SailorEditor.ViewModels;
+
+public sealed class PrefabGameObjectOverride : ICloneable
+{
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public string? Name { get; set; }
+
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public Vec4? Position { get; set; }
+
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public Rotation? Rotation { get; set; }
+
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public Vec4? Scale { get; set; }
+
+    public object Clone() => new PrefabGameObjectOverride
+    {
+        Name = Name,
+        Position = Position is null
+            ? null
+            : (Vec4)Position.Clone(),
+        Rotation = Rotation is null
+            ? null
+            : (Rotation)Rotation.Clone(),
+        Scale = Scale is null
+            ? null
+            : (Vec4)Scale.Clone()
+    };
+}
+
+public sealed class PrefabComponentOverride : ICloneable
+{
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public string? Typename { get; set; }
+
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public Dictionary<string, object?>? OverrideProperties { get; set; }
+
+    public object Clone() => new PrefabComponentOverride
+    {
+        Typename = Typename,
+        OverrideProperties = OverrideProperties is null
+            ? null
+            : new Dictionary<string, object?>(
+                OverrideProperties,
+                StringComparer.Ordinal)
+    };
+}
 
 public partial class Prefab : ObservableObject, ICloneable
 {
     public object Clone() => new Prefab()
     {
+        FileId = FileId is null
+            ? null
+            : (FileId)FileId.Clone(),
+        DetachedFromPrefab = DetachedFromPrefab,
+        LinkedPrefabSnapshot = LinkedPrefabSnapshot,
+        ParentInstanceId = ParentInstanceId,
+        InstanceIds = InstanceIds is null
+            ? null
+            : new Dictionary<string, string>(
+                InstanceIds,
+                StringComparer.Ordinal),
+        GameObjectOverrides = GameObjectOverrides?
+            .ToDictionary(
+                entry => entry.Key,
+                entry => (PrefabGameObjectOverride)entry.Value.Clone(),
+                StringComparer.Ordinal),
+        ComponentOverrides = ComponentOverrides?
+            .ToDictionary(
+                entry => entry.Key,
+                entry => (PrefabComponentOverride)entry.Value.Clone(),
+                StringComparer.Ordinal),
         GameObjects = new ObservableList<GameObject>(GameObjects),
         Components = new ObservableList<Component>(Components)
     };
+
+    [YamlMember(
+        Alias = "fileId",
+        DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public FileId? FileId { get; set; }
+
+    [YamlIgnore]
+    public bool IsLinked => FileId is not null && !FileId.IsEmpty();
+
+    [YamlMember(
+        Alias = "detachedFromPrefab",
+        DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    public bool DetachedFromPrefab { get; set; }
+
+    [YamlMember(
+        Alias = "linkedPrefabSnapshot",
+        DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    public bool LinkedPrefabSnapshot { get; set; }
+
+    [YamlMember(
+        Alias = "parentInstanceId",
+        DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public string? ParentInstanceId { get; set; }
+
+    [YamlMember(
+        Alias = "instanceIds",
+        DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public Dictionary<string, string>? InstanceIds { get; set; }
+
+    [YamlMember(
+        Alias = "gameObjectOverrides",
+        DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public Dictionary<string, PrefabGameObjectOverride>? GameObjectOverrides
+    {
+        get;
+        set;
+    }
+
+    [YamlMember(
+        Alias = "componentOverrides",
+        DefaultValuesHandling = DefaultValuesHandling.OmitNull)]
+    public Dictionary<string, PrefabComponentOverride>? ComponentOverrides
+    {
+        get;
+        set;
+    }
 
     [ObservableProperty]
     ObservableList<GameObject> gameObjects = [];

--- a/Editor/Views/ContentFolderView.xaml.cs
+++ b/Editor/Views/ContentFolderView.xaml.cs
@@ -3,6 +3,7 @@ using SailorEditor.Commands;
 using SailorEditor.Content;
 using SailorEditor.Controls;
 using SailorEditor.Services;
+using SailorEditor.Scene;
 using SailorEditor.Utility;
 using SailorEditor.ViewModels;
 using SailorEditor.Workflow;
@@ -28,6 +29,7 @@ namespace SailorEditor.Views
         readonly ProjectContentStore contentStore;
         readonly ICommandDispatcher dispatcher;
         readonly IActionContextProvider contextProvider;
+        readonly InspectorPendingEditCoordinator inspectorPendingEditCoordinator;
         readonly ObservableCollection<ContentListRow> visibleRows = [];
         readonly HashSet<int> expandedFolderIds = [];
         readonly Dictionary<string, object> rowModelsById = new(StringComparer.Ordinal);
@@ -42,6 +44,8 @@ namespace SailorEditor.Views
             contentStore = MauiProgram.GetService<ProjectContentStore>();
             dispatcher = MauiProgram.GetService<ICommandDispatcher>();
             contextProvider = MauiProgram.GetService<IActionContextProvider>();
+            inspectorPendingEditCoordinator =
+                MauiProgram.GetService<InspectorPendingEditCoordinator>();
 
             if (!string.IsNullOrEmpty(contentStore.State.Filter))
             {
@@ -54,7 +58,10 @@ namespace SailorEditor.Views
 
             var rootDropGesture = new DropGestureRecognizer();
             rootDropGesture.DragOver += (_, e) => ApplyContentDropOperation(e, null);
-            rootDropGesture.Drop += async (_, e) => await HandleContentDrop(e, null);
+            rootDropGesture.Drop += (_, e) =>
+                RunContentUiAction(
+                    () => HandleContentDrop(e, null),
+                    "Drop Content item");
             ContentDropSurface.GestureRecognizers.Add(rootDropGesture);
 
             contentStore.ProjectionChanged += PopulateRows;
@@ -179,6 +186,33 @@ namespace SailorEditor.Views
 
                 if (!overwrite)
                 {
+                    return;
+                }
+            }
+
+            if (command is CreatePrefabAssetCommand)
+            {
+                if (!await inspectorPendingEditCoordinator
+                        .CommitPendingChangesAsync())
+                {
+                    await Application.Current.MainPage.DisplayAlert(
+                        "Drop failed",
+                        "Pending Inspector changes could not be committed.",
+                        "OK");
+                    return;
+                }
+
+                if (!EditorDragDrop.TryCreateContentDropCommand(
+                        source,
+                        target,
+                        out command,
+                        out _) ||
+                    command is not CreatePrefabAssetCommand)
+                {
+                    await Application.Current.MainPage.DisplayAlert(
+                        "Drop failed",
+                        "The GameObject is no longer available for prefab creation.",
+                        "OK");
                     return;
                 }
             }
@@ -623,6 +657,15 @@ namespace SailorEditor.Views
                         {
                             case AssetFile assetFile:
                                 e.Data.Properties[EditorDragDrop.DragItemKey] = assetFile;
+#if WINDOWS
+                                if (EditorDragDrop.IsViewportAssetDrop(assetFile) &&
+                                    SceneViewportAssetDropPayload.TryCreate(
+                                        assetFile.FileId,
+                                        out var payload))
+                                {
+                                    e.Data.Text = payload;
+                                }
+#endif
                                 return;
                             case AssetFolder folder when service.CanModifyFolder(folder):
                                 e.Data.Properties[EditorDragDrop.DragItemKey] = folder;
@@ -645,7 +688,7 @@ namespace SailorEditor.Views
 
                     ApplyContentDropOperation(e, target);
                 };
-                dropGesture.Drop += async (_, e) =>
+                dropGesture.Drop += (_, e) =>
                 {
                     object target = null;
                     if (border.BindingContext is ContentListRow row && rowModelsById.TryGetValue(row.Id, out var model))
@@ -653,7 +696,9 @@ namespace SailorEditor.Views
                         target = model is ProjectContentFolderItem ? null : model;
                     }
 
-                    await HandleContentDrop(e, target);
+                    RunContentUiAction(
+                        () => HandleContentDrop(e, target),
+                        "Drop Content item");
                 };
                 border.GestureRecognizers.Add(dropGesture);
 
@@ -791,6 +836,49 @@ namespace SailorEditor.Views
             finally
             {
                 suppressSelectionChanged = false;
+            }
+        }
+
+        static void RunContentUiAction(
+            Func<Task> action,
+            string operation)
+        {
+            _ = ExecuteContentUiActionAsync(
+                action,
+                operation);
+        }
+
+        static async Task ExecuteContentUiActionAsync(
+            Func<Task> action,
+            string operation)
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"{operation} failed: {exception}");
+                try
+                {
+                    var page =
+                        Application.Current?.Windows
+                            .FirstOrDefault()?.Page ??
+                        Application.Current?.MainPage;
+                    if (page is not null)
+                    {
+                        await page.DisplayAlert(
+                            "Content operation failed",
+                            exception.Message,
+                            "OK");
+                    }
+                }
+                catch (Exception reportingException)
+                {
+                    Console.Error.WriteLine(
+                        $"Failed to report {operation} error: {reportingException}");
+                }
             }
         }
 

--- a/Editor/Views/HierarchyView.xaml.cs
+++ b/Editor/Views/HierarchyView.xaml.cs
@@ -16,6 +16,7 @@ namespace SailorEditor.Views
 
         readonly WorldService service;
         readonly HierarchyProjectionService projectionService;
+        readonly InspectorPendingEditCoordinator inspectorPendingEditCoordinator;
         readonly ObservableCollection<HierarchyListRow> visibleRows = [];
         readonly Dictionary<string, GameObject> gameObjectsById = new(StringComparer.Ordinal);
         bool suppressSelectionChanged;
@@ -27,6 +28,8 @@ namespace SailorEditor.Views
 
             service = MauiProgram.GetService<WorldService>();
             projectionService = MauiProgram.GetService<HierarchyProjectionService>();
+            inspectorPendingEditCoordinator =
+                MauiProgram.GetService<InspectorPendingEditCoordinator>();
 
             HierarchyList.ItemsSource = visibleRows;
             HierarchyList.SelectionChanged += OnHierarchySelectionChanged;
@@ -78,6 +81,11 @@ namespace SailorEditor.Views
         }
 
         async void OnHierarchySelectionChanged(object? sender, SelectionChangedEventArgs args)
+            => await ExecuteHierarchyActionAsync(
+                () => ApplyHierarchySelectionAsync(args),
+                "Select GameObject");
+
+        async Task ApplyHierarchySelectionAsync(SelectionChangedEventArgs args)
         {
             if (suppressSelectionChanged)
             {
@@ -101,9 +109,9 @@ namespace SailorEditor.Views
         }
 
         async void OnHierarchyRootDrop(object? sender, DropEventArgs e)
-        {
-            await HandleDrop(e, null);
-        }
+            => await ExecuteHierarchyActionAsync(
+                () => HandleDrop(e, null),
+                "Drop hierarchy item");
 
         async Task HandleDrop(DropEventArgs e, GameObject? target)
         {
@@ -130,7 +138,8 @@ namespace SailorEditor.Views
                 return;
             }
 
-            e.Handled = (await dispatcher.DispatchAsync(command, context)).Succeeded;
+            e.Handled = true;
+            await dispatcher.DispatchAsync(command, context);
         }
 
         void ToggleRowExpansion(HierarchyListRow row)
@@ -265,6 +274,22 @@ namespace SailorEditor.Views
                 };
                 nameLabel.SetBinding(Label.TextProperty, nameof(HierarchyListRow.Label));
 
+                var prefabLinkLabel = new Label
+                {
+                    WidthRequest = 14,
+                    HorizontalTextAlignment = TextAlignment.Center,
+                    VerticalTextAlignment = TextAlignment.Center,
+                    FontSize = 9,
+                    TextColor = Color.FromArgb("#74B9FF"),
+                    Margin = new Thickness(0, 0, 3, 0)
+                };
+                prefabLinkLabel.SetBinding(
+                    Label.TextProperty,
+                    nameof(HierarchyListRow.PrefabLinkGlyph));
+                prefabLinkLabel.SetBinding(
+                    IsVisibleProperty,
+                    nameof(HierarchyListRow.IsPrefabLinked));
+
                 var rowLayout = new HorizontalStackLayout
                 {
                     Spacing = 0,
@@ -274,6 +299,7 @@ namespace SailorEditor.Views
                     HorizontalOptions = LayoutOptions.Fill
                 };
                 rowLayout.Children.Add(expandLabel);
+                rowLayout.Children.Add(prefabLinkLabel);
                 rowLayout.Children.Add(nameLabel);
 
                 var border = new Border
@@ -296,7 +322,7 @@ namespace SailorEditor.Views
 
                 var dropGesture = new DropGestureRecognizer();
                 dropGesture.DragOver += (_, e) => e.AcceptedOperation = DataPackageOperation.Copy;
-                dropGesture.Drop += async (_, e) =>
+                dropGesture.Drop += (_, e) =>
                 {
                     if (border.BindingContext is not HierarchyListRow row)
                     {
@@ -304,9 +330,24 @@ namespace SailorEditor.Views
                     }
 
                     gameObjectsById.TryGetValue(row.InstanceId, out var target);
-                    await HandleDrop(e, target);
+                    _ = ExecuteHierarchyActionAsync(
+                        () => HandleDrop(e, target),
+                        "Drop hierarchy item");
                 };
                 border.GestureRecognizers.Add(dropGesture);
+
+                var focusGesture = new TapGestureRecognizer
+                {
+                    NumberOfTapsRequired = 2
+                };
+                focusGesture.Tapped += (_, _) =>
+                {
+                    if (border.BindingContext is HierarchyListRow row)
+                    {
+                        _ = FocusGameObjectAsync(row);
+                    }
+                };
+                border.GestureRecognizers.Add(focusGesture);
 
                 border.BindingContextChanged += (_, _) =>
                 {
@@ -317,7 +358,9 @@ namespace SailorEditor.Views
 
                         if (gameObjectsById.TryGetValue(row.InstanceId, out var gameObject))
                         {
-                            FlyoutBase.SetContextFlyout(border, CreateHierarchyContextFlyout(gameObject));
+                            FlyoutBase.SetContextFlyout(
+                                border,
+                                CreateHierarchyContextFlyout(gameObject, row));
                             return;
                         }
                     }
@@ -329,7 +372,9 @@ namespace SailorEditor.Views
             });
         }
 
-        MenuFlyout CreateHierarchyContextFlyout(GameObject? gameObject)
+        MenuFlyout CreateHierarchyContextFlyout(
+            GameObject? gameObject,
+            HierarchyListRow? row = null)
         {
             var contextMenu = MauiProgram.GetService<EditorContextMenuService>();
             if (gameObject == null)
@@ -343,7 +388,8 @@ namespace SailorEditor.Views
                 });
             }
 
-            return contextMenu.CreateFlyout(
+            var items = new List<EditorContextMenuItem>
+            {
                 new EditorContextMenuItem
                 {
                     Text = "New GameObject",
@@ -365,7 +411,31 @@ namespace SailorEditor.Views
                     Command = CreateContextMenuCommand(
                         () => service.RemoveGameObjectAsync(gameObject),
                         "Remove GameObject")
-                });
+                }
+            };
+            if (row is
+                {
+                    IsPrefabLinked: true,
+                    PrefabFileId: not null,
+                    PrefabRootInstanceId: not null
+                } &&
+                !string.IsNullOrWhiteSpace(row.PrefabRootInstanceId))
+            {
+                items.Insert(
+                    2,
+                    new EditorContextMenuItem
+                    {
+                        Text = "Break Prefab Link",
+                        Command = CreateContextMenuCommand(
+                            () => BreakPrefabLinkAsync(
+                                new InstanceId(
+                                    row.PrefabRootInstanceId),
+                                row.PrefabFileId),
+                            "Break Prefab Link")
+                    });
+            }
+
+            return contextMenu.CreateFlyout([.. items]);
         }
 
         static Command CreateContextMenuCommand(
@@ -408,6 +478,90 @@ namespace SailorEditor.Views
                     Console.Error.WriteLine(
                         $"Failed to publish hierarchy action error status: {statusException}");
                 }
+            }
+        }
+
+        async Task FocusGameObjectAsync(HierarchyListRow row)
+        {
+            try
+            {
+                if (!await inspectorPendingEditCoordinator
+                        .CommitPendingChangesAsync())
+                {
+                    throw new InvalidOperationException(
+                        "Pending Inspector changes could not be committed.");
+                }
+
+                if (!gameObjectsById.TryGetValue(
+                        row.InstanceId,
+                        out var gameObject) ||
+                    gameObject.InstanceId is null ||
+                    gameObject.InstanceId.IsEmpty())
+                {
+                    return;
+                }
+
+                var contextProvider =
+                    MauiProgram.GetService<IActionContextProvider>();
+                var context = contextProvider.GetCurrentContext(
+                    new CommandOrigin(
+                        CommandOriginKind.UI,
+                        nameof(HierarchyView)));
+                var result = await MauiProgram
+                    .GetService<ICommandDispatcher>()
+                    .DispatchAsync(
+                        new FocusEditorCameraCommand(
+                            gameObject.InstanceId),
+                        context);
+                if (!result.Succeeded)
+                {
+                    throw new InvalidOperationException(
+                        result.Message ??
+                        "Focus editor camera failed");
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"Focus editor camera failed: {ex}");
+            }
+        }
+
+        async Task BreakPrefabLinkAsync(
+            InstanceId instanceId,
+            string prefabFileId)
+        {
+            var contextProvider =
+                MauiProgram.GetService<IActionContextProvider>();
+            var context = contextProvider.GetCurrentContext(
+                new CommandOrigin(
+                    CommandOriginKind.Menu,
+                    nameof(HierarchyView)));
+            var result = await MauiProgram
+                .GetService<ICommandDispatcher>()
+                .DispatchAsync(
+                    new BreakPrefabLinkCommand(
+                        instanceId,
+                        new FileId(prefabFileId)),
+                    context);
+            if (!result.Succeeded)
+            {
+                throw new InvalidOperationException(
+                    result.Message ?? "Break prefab link failed");
+            }
+        }
+
+        static async Task ExecuteHierarchyActionAsync(
+            Func<Task> action,
+            string operation)
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"{operation} failed: {ex}");
             }
         }
 

--- a/Editor/Views/SceneView.xaml
+++ b/Editor/Views/SceneView.xaml
@@ -3,8 +3,60 @@
              x:Name="this"
              x:Class="SailorEditor.Views.SceneView">
 
-    <Grid>
+    <Grid RowDefinitions="32,*"
+          RowSpacing="0">
+        <Border Grid.Row="0"
+                BackgroundColor="#202020"
+                Stroke="#2A2A2A"
+                StrokeThickness="1"
+                Padding="3,2">
+            <HorizontalStackLayout Spacing="3"
+                                   VerticalOptions="Center">
+                <Button x:Name="SelectToolButton"
+                        Text="Q  Select"
+                        HeightRequest="26"
+                        MinimumHeightRequest="26"
+                        Padding="7,0"
+                        FontSize="11"
+                        CornerRadius="3"
+                        Clicked="OnSelectToolClicked" />
+                <Button x:Name="TranslateToolButton"
+                        Text="W  Move"
+                        HeightRequest="26"
+                        MinimumHeightRequest="26"
+                        Padding="7,0"
+                        FontSize="11"
+                        CornerRadius="3"
+                        Clicked="OnTranslateToolClicked" />
+                <Button x:Name="RotateToolButton"
+                        Text="E  Rotate"
+                        HeightRequest="26"
+                        MinimumHeightRequest="26"
+                        Padding="7,0"
+                        FontSize="11"
+                        CornerRadius="3"
+                        Clicked="OnRotateToolClicked" />
+                <Button x:Name="ScaleToolButton"
+                        Text="R  Scale"
+                        HeightRequest="26"
+                        MinimumHeightRequest="26"
+                        Padding="7,0"
+                        FontSize="11"
+                        CornerRadius="3"
+                        Clicked="OnScaleToolClicked" />
+                <Button x:Name="TransformSpaceButton"
+                        Text="T  World"
+                        HeightRequest="26"
+                        MinimumHeightRequest="26"
+                        Padding="7,0"
+                        FontSize="11"
+                        CornerRadius="3"
+                        Clicked="OnTransformSpaceClicked" />
+            </HorizontalStackLayout>
+        </Border>
+
         <Border x:Name="Viewport"
+                Grid.Row="1"
                 BackgroundColor="#111111"
                 Stroke="#2A2A2A"
                 StrokeThickness="1"

--- a/Editor/Views/SceneView.xaml.cs
+++ b/Editor/Views/SceneView.xaml.cs
@@ -50,6 +50,10 @@ namespace SailorEditor.Views
         readonly EditorViewportEventRevisionGate viewportEventRevisionGate = new();
         readonly UnifiedSettingsStore settingsStore;
         readonly NativeViewportInputQueue nativeViewportInputQueue;
+        readonly object viewportToolStateLock = new();
+        readonly SemaphoreSlim viewportToolStateGate = new(1, 1);
+        SceneViewportToolState viewportToolState =
+            SceneViewportToolShortcuts.Default;
         long lastViewportIntegrationTickMs = -1;
         long lastViewportStatusTickMs = -1;
         bool lifecycleSubscribed;
@@ -62,6 +66,7 @@ namespace SailorEditor.Views
         public SceneView()
         {
             InitializeComponent();
+            UpdateViewportToolVisuals();
             settingsStore = MauiProgram.GetService<UnifiedSettingsStore>();
             engineService = MauiProgram.GetService<EngineService>();
             worldService = MauiProgram.GetService<WorldService>();
@@ -145,6 +150,7 @@ namespace SailorEditor.Views
             {
                 isRunning = true;
                 SubscribeToEngineLifecycle();
+                _ = RefreshViewportToolStateAsync();
 #if MACCATALYST
                 if (!UseNativeViewportHost)
                 {
@@ -218,6 +224,20 @@ namespace SailorEditor.Views
         {
             cancellationToken.ThrowIfCancellationRequested();
             var captured = input.Captured || isInputCaptured;
+
+            if (input.Kind == NativeSceneViewportInputKind.Key &&
+                SceneViewportToolShortcuts.TryApply(
+                    input.KeyCode,
+                    input.Pressed,
+                    isFocused,
+                    GetViewportToolState(),
+                    out var shortcutState) &&
+                await ApplyViewportToolStateAsync(
+                    shortcutState,
+                    cancellationToken))
+            {
+                return NativeViewportInputDispatchResult.Forwarded;
+            }
 
             if (input.Kind ==
                     NativeSceneViewportInputKind.PointerButton &&
@@ -334,6 +354,7 @@ namespace SailorEditor.Views
             viewportAdapter.ResetForBackendRestart();
             QueueViewportRetry(TimeSpan.FromSeconds(1));
             UpdateViewportIntegration();
+            _ = RefreshViewportToolStateAsync();
         }
 
         async void OnEditorViewportEvents(IReadOnlyList<EditorViewportEvent> viewportEvents)
@@ -360,6 +381,14 @@ namespace SailorEditor.Views
 
                         case EditorViewportTransformEvent transformEvent:
                             await ApplyViewportTransformAsync(transformEvent);
+                            break;
+
+                        case EditorViewportAssetDropEvent assetDropEvent:
+                            await ApplyViewportAssetDropAsync(assetDropEvent);
+                            break;
+
+                        case EditorViewportToolShortcutEvent shortcutEvent:
+                            await ApplyViewportToolShortcutAsync(shortcutEvent);
                             break;
                     }
                 }
@@ -489,6 +518,54 @@ namespace SailorEditor.Views
             }
         }
 
+        async Task ApplyViewportAssetDropAsync(
+            EditorViewportAssetDropEvent viewportEvent)
+        {
+            var fileId = new FileId(viewportEvent.FileId);
+            if (!MauiProgram.GetService<AssetsService>()
+                    .Assets.TryGetValue(fileId, out var assetFile))
+            {
+                Console.WriteLine(
+                    $"[SceneView] Rejected viewport asset drop revision {viewportEvent.Revision}: '{viewportEvent.FileId}' is not a known asset.");
+                return;
+            }
+
+            var result = await DispatchViewportAssetDropAsync(
+                assetFile,
+                viewportEvent.NormalizedX,
+                viewportEvent.NormalizedY,
+                CreateViewportActionContext(viewportEvent));
+            if (!result.Succeeded)
+            {
+                Console.WriteLine(
+                    $"[SceneView] Viewport asset drop revision {viewportEvent.Revision} failed: {result.Message}");
+            }
+        }
+
+        async Task ApplyViewportToolShortcutAsync(
+            EditorViewportToolShortcutEvent viewportEvent)
+        {
+            SetSceneFocus(true, sendRemoteFocus: !isFocused);
+            if (!SceneViewportToolShortcuts.TryApply(
+                    viewportEvent.KeyCode,
+                    isPressed: true,
+                    hasViewportFocus: true,
+                    GetViewportToolState(),
+                    out var shortcutState))
+            {
+                Console.WriteLine(
+                    $"[SceneView] Rejected viewport tool shortcut revision {viewportEvent.Revision}: key={viewportEvent.KeyCode}.");
+                return;
+            }
+
+            lock (viewportToolStateLock)
+            {
+                viewportToolState = shortcutState;
+            }
+            UpdateViewportToolVisuals();
+            await ApplyViewportToolStateSafelyAsync(shortcutState);
+        }
+
         ActionContext CreateViewportActionContext(EditorViewportEvent viewportEvent) =>
             actionContextProvider.GetCurrentContext(
                 new CommandOrigin(CommandOriginKind.UI, nameof(SceneView)),
@@ -541,29 +618,305 @@ namespace SailorEditor.Views
         }
 
         async void OnSceneDrop(object? sender, DropEventArgs e)
+            => await ExecuteSceneUiActionAsync(
+                () => HandleSceneDropAsync(e),
+                "Viewport drop");
+
+        async Task HandleSceneDropAsync(DropEventArgs e)
         {
             if (e.Handled || !e.Data.Properties.TryGetValue(EditorDragDrop.DragItemKey, out var source))
             {
                 return;
             }
 
-            if (!EditorDragDrop.TryCreateSceneDropCommand(source, null, out var command) || command is null)
+            var context = actionContextProvider.GetCurrentContext(
+                new CommandOrigin(
+                    CommandOriginKind.DragDrop,
+                    nameof(SceneView)));
+            if (EditorDragDrop.IsViewportAssetDrop(source))
             {
+                e.Handled = true;
+                var pointer = e.GetPosition(NativeViewportContainer) ??
+                    e.GetPosition(Viewport);
+                if (pointer is null ||
+                    !SceneViewportDropCoordinateResolver.TryResolve(
+                        pointer.Value.X,
+                        pointer.Value.Y,
+                        NativeViewportContainer.Width,
+                        NativeViewportContainer.Height,
+                        out var coordinates))
+                {
+                    return;
+                }
+
+                var result = await DispatchViewportAssetDropAsync(
+                    source,
+                    coordinates.NormalizedX,
+                    coordinates.NormalizedY,
+                    context);
+                if (!result.Succeeded)
+                {
+                    Console.WriteLine(
+                        $"[SceneView] Viewport drop failed: {result.Message}");
+                }
                 return;
             }
 
-            var dispatcher = MauiProgram.GetService<ICommandDispatcher>();
-            var contextProvider = MauiProgram.GetService<IActionContextProvider>();
-            var context = contextProvider.GetCurrentContext(new CommandOrigin(CommandOriginKind.DragDrop, nameof(SceneView)));
-            e.Handled = (await dispatcher.DispatchAsync(command, context)).Succeeded;
+            if (EditorDragDrop.TryCreateSceneDropCommand(
+                    source,
+                    null,
+                    out var command) &&
+                command is not null)
+            {
+                e.Handled = true;
+                await commandDispatcher.DispatchAsync(command, context);
+            }
+        }
+
+        async Task<CommandResult> DispatchViewportAssetDropAsync(
+            object source,
+            double normalizedX,
+            double normalizedY,
+            ActionContext context)
+        {
+            var worldPosition = await engineService
+                .ResolveViewportDropPositionAsync(
+                    normalizedX,
+                    normalizedY);
+            if (worldPosition is null)
+            {
+                return CommandResult.Failure(
+                    "Viewport drop position could not be resolved");
+            }
+
+            if (!EditorDragDrop.TryCreateViewportDropCommand(
+                    source,
+                    worldPosition,
+                    out var command) ||
+                command is null)
+            {
+                return CommandResult.Failure(
+                    "The dropped asset is not a model or prefab");
+            }
+
+            return await commandDispatcher.DispatchAsync(
+                command,
+                context);
         }
 
         DropGestureRecognizer CreateSceneDropGesture()
         {
             var gesture = new DropGestureRecognizer();
-            gesture.DragOver += (_, e) => e.AcceptedOperation = DataPackageOperation.Copy;
+            gesture.DragOver += (_, e) =>
+            {
+                if (e.Data.Properties.TryGetValue(
+                        EditorDragDrop.DragItemKey,
+                        out var source) &&
+                    (EditorDragDrop.IsViewportAssetDrop(source) ||
+                     source is SailorEditor.ViewModels.GameObject))
+                {
+                    e.AcceptedOperation = DataPackageOperation.Copy;
+                }
+            };
             gesture.Drop += OnSceneDrop;
             return gesture;
+        }
+
+        void OnSelectToolClicked(object sender, EventArgs e) =>
+            QueueViewportToolState(
+                GetViewportToolState() with
+                {
+                    Operation =
+                        EditorViewportTransformOperation.Select
+                });
+
+        void OnTranslateToolClicked(object sender, EventArgs e) =>
+            QueueViewportToolState(
+                GetViewportToolState() with
+                {
+                    Operation =
+                        EditorViewportTransformOperation.Translate
+                });
+
+        void OnRotateToolClicked(object sender, EventArgs e) =>
+            QueueViewportToolState(
+                GetViewportToolState() with
+                {
+                    Operation =
+                        EditorViewportTransformOperation.Rotate
+                });
+
+        void OnScaleToolClicked(object sender, EventArgs e) =>
+            QueueViewportToolState(
+                GetViewportToolState() with
+                {
+                    Operation =
+                        EditorViewportTransformOperation.Scale
+                });
+
+        void OnTransformSpaceClicked(object sender, EventArgs e)
+        {
+            var current = GetViewportToolState();
+            QueueViewportToolState(
+                current with
+                {
+                    Space =
+                        current.Space ==
+                        EditorViewportTransformSpace.Local
+                            ? EditorViewportTransformSpace.World
+                            : EditorViewportTransformSpace.Local
+                });
+        }
+
+        void QueueViewportToolState(SceneViewportToolState state)
+        {
+            SetSceneFocus(true, sendRemoteFocus: !isFocused);
+            nativeViewportHost?.RequestInputFocus();
+            lock (viewportToolStateLock)
+            {
+                viewportToolState = state;
+            }
+            UpdateViewportToolVisuals();
+            _ = ApplyViewportToolStateSafelyAsync(state);
+        }
+
+        async Task ApplyViewportToolStateSafelyAsync(
+            SceneViewportToolState state)
+        {
+            try
+            {
+                if (!await ApplyViewportToolStateAsync(
+                        state,
+                        CancellationToken.None))
+                {
+                    Console.WriteLine(
+                        "[SceneView] Viewport tool state was rejected by the engine.");
+                    await RefreshViewportToolStateAsync();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(
+                    $"[SceneView] Failed to set viewport tool state: {ex}");
+                await RefreshViewportToolStateAsync();
+            }
+        }
+
+        async Task<bool> ApplyViewportToolStateAsync(
+            SceneViewportToolState state,
+            CancellationToken cancellationToken)
+        {
+            await viewportToolStateGate.WaitAsync(cancellationToken);
+            try
+            {
+                if (!await engineService.SetViewportToolStateAsync(
+                        state.Operation,
+                        state.Space,
+                        cancellationToken))
+                {
+                    return false;
+                }
+
+                lock (viewportToolStateLock)
+                {
+                    viewportToolState = state;
+                }
+
+                Dispatcher.Dispatch(UpdateViewportToolVisuals);
+                return true;
+            }
+            finally
+            {
+                viewportToolStateGate.Release();
+            }
+        }
+
+        async Task RefreshViewportToolStateAsync()
+        {
+            try
+            {
+                await viewportToolStateGate.WaitAsync();
+                try
+                {
+                    var state = await engineService
+                        .GetViewportToolStateAsync();
+                    if (state is null)
+                    {
+                        return;
+                    }
+
+                    lock (viewportToolStateLock)
+                    {
+                        viewportToolState = state.Value;
+                    }
+
+                    Dispatcher.Dispatch(UpdateViewportToolVisuals);
+                }
+                finally
+                {
+                    viewportToolStateGate.Release();
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(
+                    $"[SceneView] Failed to read viewport tool state: {ex}");
+            }
+        }
+
+        SceneViewportToolState GetViewportToolState()
+        {
+            lock (viewportToolStateLock)
+            {
+                return viewportToolState;
+            }
+        }
+
+        void UpdateViewportToolVisuals()
+        {
+            var state = GetViewportToolState();
+            var activeColor = Color.FromArgb("#455F80");
+            var inactiveColor = Color.FromArgb("#303030");
+            SelectToolButton.BackgroundColor =
+                state.Operation ==
+                EditorViewportTransformOperation.Select
+                    ? activeColor
+                    : inactiveColor;
+            TranslateToolButton.BackgroundColor =
+                state.Operation ==
+                EditorViewportTransformOperation.Translate
+                    ? activeColor
+                    : inactiveColor;
+            RotateToolButton.BackgroundColor =
+                state.Operation ==
+                EditorViewportTransformOperation.Rotate
+                    ? activeColor
+                    : inactiveColor;
+            ScaleToolButton.BackgroundColor =
+                state.Operation ==
+                EditorViewportTransformOperation.Scale
+                    ? activeColor
+                    : inactiveColor;
+            TransformSpaceButton.BackgroundColor = inactiveColor;
+            TransformSpaceButton.Text =
+                state.Space == EditorViewportTransformSpace.Local
+                    ? "T  Local"
+                    : "T  World";
+        }
+
+        static async Task ExecuteSceneUiActionAsync(
+            Func<Task> action,
+            string operation)
+        {
+            try
+            {
+                await action();
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine(
+                    $"[SceneView] {operation} failed: {ex}");
+            }
         }
 
         void SetSceneFocus(bool focused, bool sendRemoteFocus)

--- a/Editor/Workflow/WorkflowProjections.cs
+++ b/Editor/Workflow/WorkflowProjections.cs
@@ -35,13 +35,37 @@ public sealed class SelectionStore
     public bool Clear() => Select(null, SelectionTargetKind.None);
 }
 
-public sealed record HierarchySourceItem(string Id, string Label, string? ParentId);
+public sealed record HierarchySourceItem(
+    string Id,
+    string Label,
+    string? ParentId,
+    bool IsPrefabLinked = false,
+    string? PrefabFileId = null,
+    string? PrefabRootInstanceId = null);
 
-public sealed record HierarchyProjectionNode(string Id, string Label, bool IsSelected, bool IsExpanded, IReadOnlyList<HierarchyProjectionNode> Children);
+public sealed record HierarchyProjectionNode(
+    string Id,
+    string Label,
+    bool IsSelected,
+    bool IsExpanded,
+    IReadOnlyList<HierarchyProjectionNode> Children,
+    bool IsPrefabLinked = false,
+    string? PrefabFileId = null,
+    string? PrefabRootInstanceId = null);
 
-public sealed record HierarchyListRow(string InstanceId, int Depth, string Label, bool HasChildren, bool IsExpanded, bool IsSelected)
+public sealed record HierarchyListRow(
+    string InstanceId,
+    int Depth,
+    string Label,
+    bool HasChildren,
+    bool IsExpanded,
+    bool IsSelected,
+    bool IsPrefabLinked = false,
+    string? PrefabFileId = null,
+    string? PrefabRootInstanceId = null)
 {
     public string ExpandGlyph => IsExpanded ? "−" : "+";
+    public string PrefabLinkGlyph => IsPrefabLinked ? "◆" : string.Empty;
 }
 
 public static class HierarchyRowReconciler
@@ -139,7 +163,10 @@ public static class HierarchyProjectionBuilder
                 item.Label,
                 string.Equals(item.Id, selectedId, StringComparison.Ordinal),
                 expandedIds.Contains(item.Id),
-                Array.Empty<HierarchyProjectionNode>());
+                Array.Empty<HierarchyProjectionNode>(),
+                item.IsPrefabLinked,
+                item.PrefabFileId,
+                item.PrefabRootInstanceId);
         }
 
         var children = childrenLookup.TryGetValue(item.Id, out var childItems)
@@ -151,12 +178,24 @@ public static class HierarchyProjectionBuilder
             item.Label,
             string.Equals(item.Id, selectedId, StringComparison.Ordinal),
             expandedIds.Contains(item.Id),
-            children);
+            children,
+            item.IsPrefabLinked,
+            item.PrefabFileId,
+            item.PrefabRootInstanceId);
     }
 
     static void AppendVisibleRows(HierarchyProjectionNode node, int depth, ICollection<HierarchyListRow> rows)
     {
-        rows.Add(new HierarchyListRow(node.Id, depth, node.Label, node.Children.Count > 0, node.IsExpanded, node.IsSelected));
+        rows.Add(new HierarchyListRow(
+            node.Id,
+            depth,
+            node.Label,
+            node.Children.Count > 0,
+            node.IsExpanded,
+            node.IsSelected,
+            node.IsPrefabLinked,
+            node.PrefabFileId,
+            node.PrefabRootInstanceId));
         if (!node.IsExpanded)
             return;
 

--- a/Lib/EditorEngineProtocol.cpp
+++ b/Lib/EditorEngineProtocol.cpp
@@ -60,6 +60,8 @@ namespace
 {
 	using Sailor::Protocol::EEditorEngineTransportStatus;
 	using Sailor::Protocol::EditorEngineProtocolMaxPayloadSize;
+	using Sailor::Protocol::EditorEngineProtocolLatestVersion;
+	using Sailor::Protocol::EditorEngineProtocolStrictInstanceIdsVersion;
 	using Sailor::Protocol::EditorEngineProtocolVersion;
 	using sailor::editor::v1::ProtocolRequest;
 	using sailor::editor::v1::ProtocolResponse;
@@ -208,6 +210,43 @@ namespace
 	{
 		SetSuccess(response);
 		response.mutable_uint64_result()->set_value(value);
+	}
+
+	void SetVector4Result(
+		ProtocolResponse& response,
+		float x,
+		float y,
+		float z,
+		float w)
+	{
+		SetSuccess(response);
+		auto* value = response.mutable_vector4_result()->mutable_value();
+		value->set_x(x);
+		value->set_y(y);
+		value->set_z(z);
+		value->set_w(w);
+	}
+
+	void SetInstanceIdResult(
+		ProtocolResponse& response,
+		bool bSucceeded,
+		const char* instanceId)
+	{
+		SetSuccess(response);
+		auto* result = response.mutable_instance_id_result();
+		result->set_succeeded(bSucceeded);
+		if (instanceId)
+		{
+			result->set_instance_id(instanceId);
+		}
+	}
+
+	bool IsFiniteVector4(const Vector4& value)
+	{
+		return std::isfinite(value.x()) &&
+			std::isfinite(value.y()) &&
+			std::isfinite(value.z()) &&
+			std::isfinite(value.w());
 	}
 
 	void SetStringResult(
@@ -438,6 +477,67 @@ namespace
 
 			outEvent.mutable_selection()->set_selected_instance_id(
 				selectedInstanceIdNode.as<std::string>());
+			return true;
+		}
+
+		if (kind == "assetDrop")
+		{
+			const YAML::Node fileIdNode = event["fileId"];
+			const YAML::Node normalizedXNode = event["normalizedX"];
+			const YAML::Node normalizedYNode = event["normalizedY"];
+			if (!fileIdNode.IsScalar() ||
+				!normalizedXNode.IsScalar() ||
+				!normalizedYNode.IsScalar())
+			{
+				outError =
+					"The native viewport asset drop event is missing scalar fields.";
+				return false;
+			}
+
+			const float normalizedX = normalizedXNode.as<float>();
+			const float normalizedY = normalizedYNode.as<float>();
+			if (!std::isfinite(normalizedX) ||
+				!std::isfinite(normalizedY) ||
+				normalizedX < 0.0f ||
+				normalizedX > 1.0f ||
+				normalizedY < 0.0f ||
+				normalizedY > 1.0f)
+			{
+				outError =
+					"The native viewport asset drop coordinates are invalid.";
+				return false;
+			}
+
+			auto* assetDrop = outEvent.mutable_asset_drop();
+			assetDrop->set_file_id(fileIdNode.as<std::string>());
+			assetDrop->set_normalized_x(normalizedX);
+			assetDrop->set_normalized_y(normalizedY);
+			return true;
+		}
+
+		if (kind == "toolShortcut")
+		{
+			const YAML::Node keyCodeNode = event["keyCode"];
+			if (!keyCodeNode.IsScalar())
+			{
+				outError =
+					"The native viewport tool shortcut event is missing keyCode.";
+				return false;
+			}
+
+			const uint32_t keyCode = keyCodeNode.as<uint32_t>();
+			if (keyCode != 'Q' &&
+				keyCode != 'W' &&
+				keyCode != 'E' &&
+				keyCode != 'R' &&
+				keyCode != 'T')
+			{
+				outError =
+					"The native viewport tool shortcut key is unsupported.";
+				return false;
+			}
+
+			outEvent.mutable_tool_shortcut()->set_key_code(keyCode);
 			return true;
 		}
 
@@ -679,6 +779,115 @@ namespace
 		{
 			result->set_instance_id(instanceId.GetValue());
 		}
+	}
+
+	void DispatchResolveViewportDropPosition(
+		const sailor::editor::v1::ViewportDropPositionRequest& request,
+		ProtocolResponse& response)
+	{
+		if (request.viewport_id() == 0 ||
+			!std::isfinite(request.normalized_x()) ||
+			!std::isfinite(request.normalized_y()) ||
+			request.normalized_x() < 0.0f ||
+			request.normalized_x() > 1.0f ||
+			request.normalized_y() < 0.0f ||
+			request.normalized_y() > 1.0f)
+		{
+			SetError(response, "The viewport drop request is invalid.");
+			return;
+		}
+
+		float worldX = 0.0f;
+		float worldY = 0.0f;
+		float worldZ = 0.0f;
+		if (!Sailor::App::ResolveEditorViewportDropPosition(
+				request.normalized_x(),
+				request.normalized_y(),
+				worldX,
+				worldY,
+				worldZ))
+		{
+			SetError(response, "Failed to resolve the viewport drop position.");
+			return;
+		}
+
+		SetVector4Result(response, worldX, worldY, worldZ, 1.0f);
+	}
+
+	void DispatchCreateModelGameObject(
+		const sailor::editor::v1::CreateModelGameObjectRequest& request,
+		ProtocolResponse& response)
+	{
+		if (request.apply_world_position() &&
+			(!request.has_world_position() ||
+				!IsFiniteVector4(request.world_position())))
+		{
+			SetError(response, "The model world position is invalid.");
+			return;
+		}
+
+		TInteropString instanceId;
+		const Vector4& worldPosition = request.world_position();
+		const bool bSucceeded = Sailor::App::CreateEditorModelGameObject(
+			request.model_file_id().c_str(),
+			request.name().c_str(),
+			request.parent_instance_id().c_str(),
+			request.apply_world_position(),
+			worldPosition.x(),
+			worldPosition.y(),
+			worldPosition.z(),
+			instanceId.GetOutput());
+		SetInstanceIdResult(response, bSucceeded, instanceId.GetValue());
+	}
+
+	void DispatchInstantiatePrefabInstance(
+		const sailor::editor::v1::InstantiatePrefabInstanceRequest& request,
+		ProtocolResponse& response)
+	{
+		if (request.apply_world_position() &&
+			(!request.has_world_position() ||
+				!IsFiniteVector4(request.world_position())))
+		{
+			SetError(response, "The prefab world position is invalid.");
+			return;
+		}
+
+		TInteropString instanceId;
+		const Vector4& worldPosition = request.world_position();
+		const bool bSucceeded = Sailor::App::InstantiateEditorPrefabInstance(
+			request.file_id().c_str(),
+			request.parent_instance_id().c_str(),
+			request.apply_world_position(),
+			worldPosition.x(),
+			worldPosition.y(),
+			worldPosition.z(),
+			instanceId.GetOutput());
+		SetInstanceIdResult(response, bSucceeded, instanceId.GetValue());
+	}
+
+	void DispatchGetViewportToolState(
+		const sailor::editor::v1::ViewportIdRequest& request,
+		ProtocolResponse& response)
+	{
+		if (request.viewport_id() == 0)
+		{
+			SetError(response, "The viewport id is invalid.");
+			return;
+		}
+
+		uint32_t operation = 0;
+		uint32_t space = 0;
+		if (!Sailor::App::GetEditorViewportToolState(operation, space))
+		{
+			SetError(response, "Failed to read the viewport tool state.");
+			return;
+		}
+
+		SetSuccess(response);
+		auto* result = response.mutable_viewport_tool_state_result();
+		result->set_operation(
+			static_cast<ViewportTransformOperation>(operation));
+		result->set_space(static_cast<ViewportTransformSpace>(space));
 	}
 
 	void DispatchSelection(
@@ -960,7 +1169,8 @@ namespace
 				response,
 				Sailor::App::InstantiateEditorPrefabFromYaml(
 					instantiate.prefab_yaml().c_str(),
-					instantiate.parent_instance_id().c_str()));
+					instantiate.parent_instance_id().c_str(),
+					instantiate.strict_instance_ids()));
 			break;
 		}
 
@@ -995,6 +1205,73 @@ namespace
 			SetBoolResult(
 				response,
 				Sailor::App::IsEngineMainThreadReady());
+			break;
+
+		case ProtocolRequest::kResolveViewportDropPosition:
+			DispatchResolveViewportDropPosition(
+				request.resolve_viewport_drop_position(),
+				response);
+			break;
+
+		case ProtocolRequest::kCreateModelGameObject:
+			DispatchCreateModelGameObject(
+				request.create_model_game_object(),
+				response);
+			break;
+
+		case ProtocolRequest::kInstantiatePrefabInstance:
+			DispatchInstantiatePrefabInstance(
+				request.instantiate_prefab_instance(),
+				response);
+			break;
+
+		case ProtocolRequest::kFocusEditorCamera:
+		{
+			const auto& focus = request.focus_editor_camera();
+			SetBoolResult(
+				response,
+				focus.viewport_id() != 0 &&
+					Sailor::App::FocusEditorCamera(
+						focus.instance_id().c_str()));
+			break;
+		}
+
+		case ProtocolRequest::kSetPrefabLink:
+		{
+			const auto& link = request.set_prefab_link();
+			SetBoolResult(
+				response,
+				Sailor::App::SetEditorPrefabLink(
+					link.instance_id().c_str(),
+					link.file_id().c_str()));
+			break;
+		}
+
+		case ProtocolRequest::kBreakPrefabLink:
+			SetBoolResult(
+				response,
+				Sailor::App::BreakEditorPrefabLink(
+					request.break_prefab_link()
+						.instance_id()
+						.c_str()));
+			break;
+
+		case ProtocolRequest::kSetViewportToolState:
+		{
+			const auto& state = request.set_viewport_tool_state();
+			SetBoolResult(
+				response,
+				state.viewport_id() != 0 &&
+					Sailor::App::SetEditorViewportToolState(
+						static_cast<uint32_t>(state.operation()),
+						static_cast<uint32_t>(state.space())));
+			break;
+		}
+
+		case ProtocolRequest::kGetViewportToolState:
+			DispatchGetViewportToolState(
+				request.get_viewport_tool_state(),
+				response);
 			break;
 
 		case ProtocolRequest::COMMAND_NOT_SET:
@@ -1337,10 +1614,24 @@ int32_t Sailor::Protocol::InvokeEditorEngineProtocol(
 	}
 
 	ProtocolResponse response;
-	response.set_protocol_version(EditorEngineProtocolVersion);
+	const bool bUsesStrictInstanceIdsVersion =
+		request.protocol_version() ==
+			EditorEngineProtocolStrictInstanceIdsVersion;
+	response.set_protocol_version(
+		bUsesStrictInstanceIdsVersion
+			? EditorEngineProtocolStrictInstanceIdsVersion
+			: request.protocol_version() == EditorEngineProtocolVersion
+				? EditorEngineProtocolVersion
+				: EditorEngineProtocolLatestVersion);
 	response.set_request_id(request.request_id());
+	response.set_supports_strict_instance_ids(true);
 
-	if (request.protocol_version() != EditorEngineProtocolVersion)
+	const bool bRequestsStrictInstanceIds =
+		request.command_case() ==
+			ProtocolRequest::kInstantiatePrefabFromYaml &&
+		request.instantiate_prefab_from_yaml().strict_instance_ids();
+	if (request.protocol_version() != EditorEngineProtocolVersion &&
+		!bUsesStrictInstanceIdsVersion)
 	{
 		SetError(
 			response,
@@ -1348,7 +1639,30 @@ int32_t Sailor::Protocol::InvokeEditorEngineProtocol(
 			std::to_string(request.protocol_version()) +
 			"; expected " +
 			std::to_string(EditorEngineProtocolVersion) +
+			" or " +
+			std::to_string(
+				EditorEngineProtocolStrictInstanceIdsVersion) +
 			".");
+	}
+	else if (bRequestsStrictInstanceIds &&
+		!bUsesStrictInstanceIdsVersion)
+	{
+		SetError(
+			response,
+			"Strict instance-id restoration requires protocol version " +
+			std::to_string(
+				EditorEngineProtocolStrictInstanceIdsVersion) +
+			".");
+	}
+	else if (bUsesStrictInstanceIdsVersion &&
+		!bRequestsStrictInstanceIds)
+	{
+		SetError(
+			response,
+			"Protocol version " +
+			std::to_string(
+				EditorEngineProtocolStrictInstanceIdsVersion) +
+			" is reserved for strict instance-id restoration.");
 	}
 	else if (request.request_id() == 0)
 	{

--- a/Lib/EditorEngineProtocolInternal.h
+++ b/Lib/EditorEngineProtocolInternal.h
@@ -20,6 +20,9 @@ namespace Sailor::Protocol
 	};
 
 	constexpr uint32_t EditorEngineProtocolVersion = 1u;
+	constexpr uint32_t EditorEngineProtocolStrictInstanceIdsVersion = 2u;
+	constexpr uint32_t EditorEngineProtocolLatestVersion =
+		EditorEngineProtocolStrictInstanceIdsVersion;
 	constexpr uint32_t EditorEngineProtocolMaxPayloadSize =
 		64u * 1024u * 1024u;
 

--- a/Protocol/README.md
+++ b/Protocol/README.md
@@ -53,7 +53,14 @@ Editor-worker task and attempt to join itself.
 
 Compatibility rules:
 
-- Keep `protocol_version` at `1` for additive, wire-compatible changes.
+- Ordinary commands use baseline `protocol_version = 1`. Strict InstanceId
+  restoration uses feature version `2`; the current host accepts version `2`
+  only for `instantiate_prefab_from_yaml` with `strict_instance_ids = true`.
+- Every current host response advertises
+  `supports_strict_instance_ids = true`. A new Editor probes this additive
+  capability over a baseline v1 request before sending a strict restore. An
+  older v1 host omits the field, so ordinary v1 commands remain available but
+  strict restore fails closed without sending the mutation.
 - Never reuse a field number. Reserve removed fields and enum values.
 - Keep `InstanceId` and `FileId` strings byte-for-byte compatible with their
   existing serialized forms.

--- a/Protocol/editor_engine.proto
+++ b/Protocol/editor_engine.proto
@@ -51,10 +51,18 @@ message ProtocolRequest {
 		Empty serialize_engine_types = 46;
 		Empty is_engine_main_thread_ready = 47;
 		Empty is_engine_running = 48;
+		ViewportDropPositionRequest resolve_viewport_drop_position = 49;
+		CreateModelGameObjectRequest create_model_game_object = 50;
+		InstantiatePrefabInstanceRequest instantiate_prefab_instance = 51;
+		ViewportObjectRequest focus_editor_camera = 52;
+		PrefabLinkRequest set_prefab_link = 53;
+		InstanceIdRequest break_prefab_link = 54;
+		ViewportToolStateRequest set_viewport_tool_state = 55;
+		ViewportIdRequest get_viewport_tool_state = 56;
 	}
 
 	reserved 3 to 9;
-	reserved 49 to 99;
+	reserved 57 to 99;
 }
 
 message ProtocolResponse {
@@ -62,6 +70,7 @@ message ProtocolResponse {
 	uint64 request_id = 2;
 	bool success = 3;
 	string error = 4;
+	bool supports_strict_instance_ids = 5;
 
 	oneof result {
 		Empty empty_result = 10;
@@ -74,10 +83,12 @@ message ProtocolResponse {
 		AssetReloadStateResult asset_reload_state_result = 17;
 		InstanceIdResult instance_id_result = 18;
 		ViewportEventBatchResult viewport_event_batch_result = 19;
+		Vector4Result vector4_result = 20;
+		ViewportToolStateResult viewport_tool_state_result = 21;
 	}
 
-	reserved 5 to 9;
-	reserved 20 to 99;
+	reserved 6 to 9;
+	reserved 22 to 99;
 }
 
 message InitializeRequest {
@@ -178,6 +189,44 @@ message InstantiatePrefabRequest {
 message InstantiatePrefabFromYamlRequest {
 	string prefab_yaml = 1;
 	string parent_instance_id = 2;
+	bool strict_instance_ids = 3;
+}
+
+message ViewportDropPositionRequest {
+	uint64 viewport_id = 1;
+	float normalized_x = 2;
+	float normalized_y = 3;
+}
+
+message CreateModelGameObjectRequest {
+	string model_file_id = 1;
+	string name = 2;
+	string parent_instance_id = 3;
+	bool apply_world_position = 4;
+	Vector4 world_position = 5;
+}
+
+message InstantiatePrefabInstanceRequest {
+	string file_id = 1;
+	string parent_instance_id = 2;
+	bool apply_world_position = 3;
+	Vector4 world_position = 4;
+}
+
+message ViewportObjectRequest {
+	uint64 viewport_id = 1;
+	string instance_id = 2;
+}
+
+message PrefabLinkRequest {
+	string instance_id = 1;
+	string file_id = 2;
+}
+
+message ViewportToolStateRequest {
+	uint64 viewport_id = 1;
+	ViewportTransformOperation operation = 2;
+	ViewportTransformSpace space = 3;
 }
 
 message SelectionRequest {
@@ -233,6 +282,15 @@ message InstanceIdResult {
 	string instance_id = 2;
 }
 
+message Vector4Result {
+	Vector4 value = 1;
+}
+
+message ViewportToolStateResult {
+	ViewportTransformOperation operation = 1;
+	ViewportTransformSpace space = 2;
+}
+
 enum ViewportTransformOperation {
 	VIEWPORT_TRANSFORM_OPERATION_UNSPECIFIED = 0;
 	VIEWPORT_TRANSFORM_OPERATION_SELECT = 1;
@@ -270,6 +328,16 @@ message ViewportTransformEvent {
 	Vector4 after_scale = 9;
 }
 
+message ViewportAssetDropEvent {
+	string file_id = 1;
+	float normalized_x = 2;
+	float normalized_y = 3;
+}
+
+message ViewportToolShortcutEvent {
+	uint32 key_code = 1;
+}
+
 message ViewportEvent {
 	uint64 revision = 1;
 	uint64 managed_mutation_revision = 2;
@@ -277,6 +345,8 @@ message ViewportEvent {
 	oneof payload {
 		ViewportSelectionEvent selection = 10;
 		ViewportTransformEvent transform = 11;
+		ViewportAssetDropEvent asset_drop = 12;
+		ViewportToolShortcutEvent tool_shortcut = 13;
 	}
 
 	reserved 3 to 9;

--- a/Runtime/AssetRegistry/AssetMountDiscovery.cpp
+++ b/Runtime/AssetRegistry/AssetMountDiscovery.cpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <set>
 #include <sstream>
+#include <string_view>
 #include <system_error>
 #include <tuple>
 #include <utility>
@@ -57,6 +58,28 @@ namespace
 			});
 #endif
 		return path;
+	}
+
+	bool IsInternalTransactionDirectory(const std::filesystem::path& path)
+	{
+		std::string directoryName = path.filename().string();
+		std::transform(
+			directoryName.begin(),
+			directoryName.end(),
+			directoryName.begin(),
+			[](unsigned char character)
+			{
+				return static_cast<char>(std::tolower(character));
+			});
+
+		constexpr std::string_view Prefix = ".sailor-";
+		constexpr std::string_view Suffix = ".pending";
+		return directoryName.size() >= Prefix.size() + Suffix.size() &&
+			directoryName.compare(0, Prefix.size(), Prefix) == 0 &&
+			directoryName.compare(
+				directoryName.size() - Suffix.size(),
+				Suffix.size(),
+				Suffix) == 0;
 	}
 
 	bool IsSafeVirtualPath(const std::string& path)
@@ -358,6 +381,11 @@ namespace
 			}
 			if (bIsDirectory)
 			{
+				if (IsInternalTransactionDirectory(entry.path()))
+				{
+					continue;
+				}
+
 				DiscoverDirectory(mount, entry.path(), visitedDirectories, files, diagnostics);
 				continue;
 			}

--- a/Runtime/AssetRegistry/Prefab/PrefabImporter.cpp
+++ b/Runtime/AssetRegistry/Prefab/PrefabImporter.cpp
@@ -12,9 +12,79 @@
 #include "Engine/GameObject.h"
 #include "ECS/TransformECS.h"
 #include "Containers/Set.h"
+#include "Core/LogMacros.h"
 #include "YamlExceptionBoundary.h"
 
 using namespace Sailor;
+
+namespace
+{
+	bool TryGetComponentInstanceId(
+		const ReflectedData& reflection,
+		InstanceId& outInstanceId,
+		std::string& outDiagnostic)
+	{
+		if (!reflection.IsValid() || !reflection.GetProperties().ContainsKey("instanceId"))
+		{
+			outDiagnostic = "the reflected component has no valid instanceId";
+			return false;
+		}
+
+		if (!External::TryConvertYaml(
+				reflection.GetProperties()["instanceId"],
+				outInstanceId,
+				outDiagnostic) ||
+			outInstanceId.ComponentId() == InstanceId::Invalid ||
+			outInstanceId.GameObjectId() == InstanceId::Invalid)
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = "the reflected component has an invalid instanceId";
+			}
+			return false;
+		}
+
+		return true;
+	}
+
+	bool TryMergeComponentOverride(
+		const ReflectedData& base,
+		const ReflectedData& delta,
+		ReflectedData& outMerged,
+		std::string& outDiagnostic)
+	{
+		if (!base.IsValid() || !delta.IsValid() || base.GetTypeInfo() != delta.GetTypeInfo())
+		{
+			outDiagnostic = "the component override type does not match the source component";
+			return false;
+		}
+
+		YAML::Node merged = base.Serialize();
+		YAML::Node mergedProperties = merged["overrideProperties"];
+		for (const auto& property : delta.GetProperties())
+		{
+			if (property.m_first == "instanceId" || property.m_first == "fileId")
+			{
+				outDiagnostic = "component identity properties cannot be overridden";
+				return false;
+			}
+
+			mergedProperties[property.m_first] = YAML::Clone(*property.m_second);
+		}
+
+		if (!External::GuardYamlExceptions(
+				[&outMerged, &merged]()
+				{
+					outMerged.Deserialize(merged);
+				},
+				outDiagnostic))
+		{
+			return false;
+		}
+
+		return outMerged.IsValid();
+	}
+}
 
 YAML::Node Prefab::ReflectedGameObject::Serialize() const
 {
@@ -48,14 +118,87 @@ YAML::Node Prefab::Serialize() const
 
 	SERIALIZE_PROPERTY(outData, m_gameObjects);
 	SERIALIZE_PROPERTY(outData, m_components);
+	if (m_bDetachedFromPrefabRecord)
+	{
+		::Serialize(outData, "detachedFromPrefab", true);
+		::Serialize(outData, "parentInstanceId", m_detachedParentInstanceId);
+	}
+	if (m_bLinkedPrefabSnapshotRecord)
+	{
+		::Serialize(outData, "linkedPrefabSnapshot", true);
+		::Serialize(outData, "fileId", m_linkedSnapshotSourceFileId);
+		::Serialize(outData, "parentInstanceId", m_linkedParentInstanceId);
+		::Serialize(outData, "instanceIds", m_linkedInstanceIds);
+		::Serialize(
+			outData,
+			"gameObjectOverrides",
+			m_gameObjectOverrides);
+		::Serialize(
+			outData,
+			"componentOverrides",
+			m_componentOverrides);
+	}
 
 	return outData;
 }
 
 void Prefab::Deserialize(const YAML::Node& inData)
 {
+	m_gameObjects.Clear();
+	m_components.Clear();
+	m_linkedInstanceIds.Clear();
+	m_gameObjectOverrides.Clear();
+	m_componentOverrides.Clear();
+	m_detachedSupplementalInstanceIds.Clear();
+	m_linkedSnapshotSourceFileId = FileId::Invalid;
+	m_linkedParentInstanceId = InstanceId::Invalid;
+	m_detachedParentInstanceId = InstanceId::Invalid;
+	m_bLinkedInstanceRecord = false;
+	m_bExpandedLinkedInstanceRecord = false;
+	m_bDetachedFromPrefabRecord = false;
+	m_bLinkedPrefabSnapshotRecord = false;
+	m_bIsReady.store(false, std::memory_order_release);
+
 	DESERIALIZE_PROPERTY(inData, m_gameObjects);
 	DESERIALIZE_PROPERTY(inData, m_components);
+	::Deserialize(
+		inData,
+		"detachedFromPrefab",
+		m_bDetachedFromPrefabRecord);
+	::Deserialize(
+		inData,
+		"linkedPrefabSnapshot",
+		m_bLinkedPrefabSnapshotRecord);
+	if (m_bDetachedFromPrefabRecord)
+	{
+		::Deserialize(
+			inData,
+			"parentInstanceId",
+			m_detachedParentInstanceId);
+	}
+	if (m_bLinkedPrefabSnapshotRecord)
+	{
+		::Deserialize(
+			inData,
+			"fileId",
+			m_linkedSnapshotSourceFileId);
+		::Deserialize(
+			inData,
+			"parentInstanceId",
+			m_linkedParentInstanceId);
+		::Deserialize(
+			inData,
+			"instanceIds",
+			m_linkedInstanceIds);
+		::Deserialize(
+			inData,
+			"gameObjectOverrides",
+			m_gameObjectOverrides);
+		::Deserialize(
+			inData,
+			"componentOverrides",
+			m_componentOverrides);
+	}
 }
 
 bool Prefab::ValidateForInstantiation(std::string& outDiagnostic) const
@@ -64,6 +207,63 @@ bool Prefab::ValidateForInstantiation(std::string& outDiagnostic) const
 	if (m_gameObjects.IsEmpty())
 	{
 		outDiagnostic = "the prefab has no game objects";
+		return false;
+	}
+
+	if (m_bDetachedFromPrefabRecord &&
+		m_bLinkedPrefabSnapshotRecord)
+	{
+		outDiagnostic =
+			"a prefab snapshot cannot be both detached and linked";
+		return false;
+	}
+
+	if (m_bDetachedFromPrefabRecord)
+	{
+		if (GetFileId() ||
+			m_bLinkedInstanceRecord ||
+			m_bExpandedLinkedInstanceRecord ||
+			!m_detachedParentInstanceId.IsGameObjectId())
+		{
+			outDiagnostic =
+				"a detached prefab snapshot must have no source asset, no linked-instance metadata, and a valid parent";
+			return false;
+		}
+	}
+	else if (m_detachedParentInstanceId)
+	{
+		outDiagnostic =
+			"a prefab without detachedFromPrefab metadata cannot specify a detached parent";
+		return false;
+	}
+
+	if (m_bLinkedPrefabSnapshotRecord)
+	{
+		if (GetFileId() ||
+			m_bLinkedInstanceRecord ||
+			m_bExpandedLinkedInstanceRecord ||
+			!m_linkedSnapshotSourceFileId ||
+			m_linkedInstanceIds.IsEmpty() ||
+			(m_linkedParentInstanceId &&
+				!m_linkedParentInstanceId.IsGameObjectId()))
+		{
+			outDiagnostic =
+				"a linked prefab snapshot must have no runtime FileId and must contain a source, mapping, and valid optional parent";
+			return false;
+		}
+	}
+	else if (m_linkedSnapshotSourceFileId)
+	{
+		outDiagnostic =
+			"a prefab without linkedPrefabSnapshot metadata cannot specify a snapshot source";
+		return false;
+	}
+
+	if (!m_bLinkedInstanceRecord &&
+		!m_detachedSupplementalInstanceIds.IsEmpty())
+	{
+		outDiagnostic =
+			"only a linked prefab instance record can contain detached supplemental game objects";
 		return false;
 	}
 
@@ -177,6 +377,51 @@ bool Prefab::ValidateForInstantiation(std::string& outDiagnostic) const
 		}
 	}
 
+	if (m_bLinkedInstanceRecord)
+	{
+		TSet<InstanceId> mappedExpandedInstanceIds;
+		if (m_bExpandedLinkedInstanceRecord)
+		{
+			for (const auto& mapping :
+				m_linkedInstanceIds)
+			{
+				mappedExpandedInstanceIds.Insert(
+					*mapping.m_second);
+			}
+		}
+
+		for (const auto& gameObject : m_gameObjects)
+		{
+			const bool bMappedSource =
+				m_bExpandedLinkedInstanceRecord
+					? mappedExpandedInstanceIds.Contains(
+						gameObject.m_instanceId)
+					: m_linkedInstanceIds.ContainsKey(
+						gameObject.m_instanceId);
+			const bool bDetachedSupplemental =
+				m_detachedSupplementalInstanceIds.Contains(
+					gameObject.m_instanceId);
+			if (bMappedSource == bDetachedSupplemental)
+			{
+				outDiagnostic =
+					"every linked prefab game object must be either a mapped source object or detached supplemental data";
+				return false;
+			}
+		}
+
+		for (const InstanceId& supplementalInstanceId :
+			m_detachedSupplementalInstanceIds)
+		{
+			if (!gameObjectInstanceIds.Contains(
+					supplementalInstanceId))
+			{
+				outDiagnostic =
+					"the linked prefab contains detached supplemental metadata for an unknown game object";
+				return false;
+			}
+		}
+	}
+
 	if (referencedComponentIndices.Num() != m_components.Num())
 	{
 		outDiagnostic = "the prefab contains an unreferenced reflected component";
@@ -222,37 +467,9 @@ bool Prefab::SaveToFile(const std::string& path) const
 	return true;
 }
 
-void Prefab::SerializeGameObject(GameObjectPtr root, uint32_t parentIndex, TVector<ReflectedData>& components, TVector<Prefab::ReflectedGameObject>& gameObjects)
-{
-	Prefab::ReflectedGameObject rootData{};
-
-	auto& transform = root->GetTransformComponent();
-	rootData.m_position = transform.GetPosition();
-	rootData.m_rotation = transform.GetRotation();
-	rootData.m_scale = transform.GetScale();
-
-	rootData.m_name = root->GetName();
-	rootData.m_parentIndex = parentIndex;
-	rootData.m_instanceId = root->GetInstanceId();
-
-	for (auto& component : root->GetComponents())
-	{
-		auto reflection = component->GetReflectedData();
-
-		rootData.m_components.Add((uint32_t)components.Num());
-		components.Add(reflection);
-	}
-
-	parentIndex = (uint32_t)gameObjects.Num();
-	gameObjects.Add(rootData);
-
-	for (auto& child : root->GetChildren())
-	{
-		SerializeGameObject(child, parentIndex, components, gameObjects);
-	}
-}
-
-bool Prefab::GetOverridePrefab(const PrefabPtr base, PrefabPtr outOverride) const
+bool Prefab::GetOverridePrefab(
+	const PrefabPtr base,
+	PrefabPtr outOverride) const
 {
 	if (base->GetFileId() != GetFileId())
 	{
@@ -278,11 +495,412 @@ bool Prefab::GetOverridePrefab(const PrefabPtr base, PrefabPtr outOverride) cons
 	return true;
 }
 
-PrefabPtr Prefab::FromGameObject(GameObjectPtr root)
+void Prefab::SerializeGameObject(
+	GameObjectPtr root,
+	uint32_t parentIndex,
+	TVector<ReflectedData>& components,
+	TVector<Prefab::ReflectedGameObject>& gameObjects,
+	const TSet<InstanceId>* excludedRoots)
 {
-	PrefabPtr res = App::GetSubmodule<PrefabImporter>()->Create();
+	if (!root || (excludedRoots && excludedRoots->Contains(root->GetInstanceId())))
+	{
+		return;
+	}
 
-	SerializeGameObject(root, -1, res->m_components, res->m_gameObjects);
+	Prefab::ReflectedGameObject rootData{};
+
+	auto& transform = root->GetTransformComponent();
+	rootData.m_position = transform.GetPosition();
+	rootData.m_rotation = transform.GetRotation();
+	rootData.m_scale = transform.GetScale();
+
+	rootData.m_name = root->GetName();
+	rootData.m_parentIndex = parentIndex;
+	rootData.m_instanceId = root->GetInstanceId();
+
+	for (auto& component : root->GetComponents())
+	{
+		auto reflection = component->GetReflectedData();
+
+		rootData.m_components.Add((uint32_t)components.Num());
+		components.Add(reflection);
+	}
+
+	parentIndex = (uint32_t)gameObjects.Num();
+	gameObjects.Add(rootData);
+
+	for (auto& child : root->GetChildren())
+	{
+		SerializeGameObject(child, parentIndex, components, gameObjects, excludedRoots);
+	}
+}
+
+bool Prefab::ConfigureLinkedInstance(
+	const PrefabPtr& basePrefab,
+	const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+	const InstanceId& parentInstanceId,
+	const TMap<InstanceId, YAML::Node>& gameObjectOverrides,
+	const TMap<InstanceId, ReflectedData>& componentOverrides,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	m_bIsReady.store(false, std::memory_order_release);
+	m_gameObjects.Clear();
+	m_components.Clear();
+	m_linkedInstanceIds.Clear();
+	m_gameObjectOverrides.Clear();
+	m_componentOverrides.Clear();
+	m_detachedSupplementalInstanceIds.Clear();
+	m_linkedSnapshotSourceFileId = FileId::Invalid;
+	m_linkedParentInstanceId = InstanceId::Invalid;
+	m_detachedParentInstanceId = InstanceId::Invalid;
+	m_bLinkedInstanceRecord = false;
+	m_bExpandedLinkedInstanceRecord = false;
+	m_bDetachedFromPrefabRecord = false;
+	m_bLinkedPrefabSnapshotRecord = false;
+
+	if (basePrefab && basePrefab.GetRawPtr() == this)
+	{
+		outDiagnostic = "a linked prefab cannot use itself as its source";
+		return false;
+	}
+
+	if (!basePrefab || !basePrefab->GetFileId() || basePrefab->GetFileId() != GetFileId())
+	{
+		outDiagnostic = "the linked prefab source is missing or has a mismatched FileId";
+		return false;
+	}
+
+	if (!basePrefab->ValidateForInstantiation(outDiagnostic))
+	{
+		return false;
+	}
+
+	if (sourceToInstanceIds.Num() != basePrefab->m_gameObjects.Num())
+	{
+		outDiagnostic = "the linked prefab instance mapping does not cover every source game object";
+		return false;
+	}
+
+	TSet<InstanceId> liveInstanceIds;
+	for (const auto& gameObject : basePrefab->m_gameObjects)
+	{
+		if (!sourceToInstanceIds.ContainsKey(gameObject.m_instanceId))
+		{
+			outDiagnostic = "the linked prefab instance mapping is missing source game object " +
+				gameObject.m_instanceId.ToString();
+			return false;
+		}
+
+		const InstanceId& liveInstanceId = sourceToInstanceIds[gameObject.m_instanceId];
+		if (!liveInstanceId.IsGameObjectId() || !liveInstanceIds.Insert(liveInstanceId))
+		{
+			outDiagnostic = "the linked prefab instance mapping contains an invalid or duplicate live game object id";
+			return false;
+		}
+	}
+
+	for (const auto& mapping : sourceToInstanceIds)
+	{
+		bool bKnownSource = false;
+		for (const auto& gameObject : basePrefab->m_gameObjects)
+		{
+			if (gameObject.m_instanceId == mapping.m_first)
+			{
+				bKnownSource = true;
+				break;
+			}
+		}
+
+		if (!bKnownSource)
+		{
+			outDiagnostic = "the linked prefab instance mapping contains an unknown source game object id";
+			return false;
+		}
+	}
+
+	m_gameObjects = basePrefab->m_gameObjects;
+	m_components = basePrefab->m_components;
+
+	for (const auto& overrideEntry : gameObjectOverrides)
+	{
+		ReflectedGameObject* target = nullptr;
+		for (auto& gameObject : m_gameObjects)
+		{
+			if (gameObject.m_instanceId == overrideEntry.m_first)
+			{
+				target = &gameObject;
+				break;
+			}
+		}
+
+		if (!target || !overrideEntry.m_second || !overrideEntry.m_second->IsMap())
+		{
+			outDiagnostic = "the linked prefab contains a game object override for an unknown source id";
+			return false;
+		}
+
+		const YAML::Node& properties = *overrideEntry.m_second;
+		for (const auto& property : properties)
+		{
+			const std::string name = property.first.as<std::string>();
+			if (name != "name" && name != "position" && name != "rotation" && name != "scale")
+			{
+				outDiagnostic = "unsupported linked game object override property '" + name + "'";
+				return false;
+			}
+		}
+
+		if (!External::GuardYamlExceptions(
+				[&properties, target]()
+				{
+					::Deserialize(properties, "name", target->m_name);
+					::Deserialize(properties, "position", target->m_position);
+					::Deserialize(properties, "rotation", target->m_rotation);
+					::Deserialize(properties, "scale", target->m_scale);
+				},
+				outDiagnostic))
+		{
+			return false;
+		}
+	}
+
+	for (const auto& overrideEntry : componentOverrides)
+	{
+		uint32_t componentIndex = static_cast<uint32_t>(-1);
+		for (uint32_t index = 0; index < m_components.Num(); ++index)
+		{
+			InstanceId componentInstanceId;
+			std::string conversionDiagnostic;
+			if (!TryGetComponentInstanceId(m_components[index], componentInstanceId, conversionDiagnostic))
+			{
+				outDiagnostic = conversionDiagnostic;
+				return false;
+			}
+
+			if (componentInstanceId == overrideEntry.m_first)
+			{
+				componentIndex = index;
+				break;
+			}
+		}
+
+		if (componentIndex == static_cast<uint32_t>(-1))
+		{
+			outDiagnostic = "the linked prefab contains a component override for an unknown source id";
+			return false;
+		}
+
+		ReflectedData merged;
+		if (!TryMergeComponentOverride(
+				m_components[componentIndex],
+				*overrideEntry.m_second,
+				merged,
+				outDiagnostic))
+		{
+			return false;
+		}
+
+		m_components[componentIndex] = std::move(merged);
+	}
+
+	m_linkedInstanceIds = sourceToInstanceIds;
+	m_linkedParentInstanceId = parentInstanceId;
+	m_gameObjectOverrides = gameObjectOverrides;
+	m_componentOverrides = componentOverrides;
+	m_bLinkedInstanceRecord = true;
+
+	if (!ValidateForInstantiation(outDiagnostic))
+	{
+		return false;
+	}
+
+	m_bIsReady.store(true, std::memory_order_release);
+	return true;
+}
+
+bool Prefab::AppendDetachedSupplementalHierarchy(
+	const PrefabPtr& expandedPrefab,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	if (!m_bLinkedInstanceRecord ||
+		!expandedPrefab ||
+		expandedPrefab.GetRawPtr() == this)
+	{
+		outDiagnostic =
+			"detached supplemental hierarchy requires distinct expanded and linked prefab records";
+		return false;
+	}
+
+	if (!ValidateForInstantiation(outDiagnostic) ||
+		!expandedPrefab->ValidateForInstantiation(outDiagnostic))
+	{
+		return false;
+	}
+
+	TMap<InstanceId, uint32_t> sourceIndices;
+	for (uint32_t sourceIndex = 0;
+		sourceIndex < m_gameObjects.Num();
+		++sourceIndex)
+	{
+		sourceIndices[
+			m_gameObjects[sourceIndex].m_instanceId] =
+			sourceIndex;
+	}
+
+	TMap<InstanceId, InstanceId> liveToSourceIds;
+	for (const auto& mapping : m_linkedInstanceIds)
+	{
+		if (!mapping.m_first.IsGameObjectId() ||
+			!mapping.m_second->IsGameObjectId() ||
+			liveToSourceIds.ContainsKey(*mapping.m_second))
+		{
+			outDiagnostic =
+				"the linked prefab mapping contains an invalid or duplicate live game object id";
+			return false;
+		}
+
+		liveToSourceIds[*mapping.m_second] =
+			mapping.m_first;
+	}
+
+	const uint32_t invalidIndex =
+		static_cast<uint32_t>(-1);
+	TVector<uint32_t> expandedToResultIndices;
+	expandedToResultIndices.Reserve(
+		expandedPrefab->m_gameObjects.Num());
+
+	uint32_t nextResultIndex =
+		static_cast<uint32_t>(m_gameObjects.Num());
+	for (const ReflectedGameObject& expandedGameObject :
+		expandedPrefab->m_gameObjects)
+	{
+		if (liveToSourceIds.ContainsKey(
+				expandedGameObject.m_instanceId))
+		{
+			const InstanceId& sourceInstanceId =
+				liveToSourceIds[
+					expandedGameObject.m_instanceId];
+			if (!sourceIndices.ContainsKey(sourceInstanceId))
+			{
+				outDiagnostic =
+					"the expanded linked prefab maps to an unknown source game object";
+				return false;
+			}
+
+			expandedToResultIndices.Add(
+				sourceIndices[sourceInstanceId]);
+			continue;
+		}
+
+		if (sourceIndices.ContainsKey(
+				expandedGameObject.m_instanceId))
+		{
+			outDiagnostic =
+				"a detached supplemental game object id collides with a current source id";
+			return false;
+		}
+
+		expandedToResultIndices.Add(nextResultIndex++);
+	}
+
+	TVector<ReflectedGameObject> nextGameObjects =
+		m_gameObjects;
+	TVector<ReflectedData> nextComponents = m_components;
+	TSet<InstanceId> nextSupplementalInstanceIds =
+		m_detachedSupplementalInstanceIds;
+
+	for (uint32_t expandedIndex = 0;
+		expandedIndex < expandedPrefab->m_gameObjects.Num();
+		++expandedIndex)
+	{
+		const ReflectedGameObject& expandedGameObject =
+			expandedPrefab->m_gameObjects[expandedIndex];
+		if (liveToSourceIds.ContainsKey(
+				expandedGameObject.m_instanceId))
+		{
+			continue;
+		}
+
+		ReflectedGameObject supplementalGameObject =
+			expandedGameObject;
+		supplementalGameObject.m_components.Clear();
+
+		if (expandedGameObject.m_parentIndex ==
+			invalidIndex)
+		{
+			outDiagnostic =
+				"the expanded linked prefab root is not covered by the current source mapping";
+			return false;
+		}
+
+		if (expandedGameObject.m_parentIndex >=
+			expandedToResultIndices.Num())
+		{
+			outDiagnostic =
+				"a detached supplemental game object has an invalid expanded parent";
+			return false;
+		}
+
+		supplementalGameObject.m_parentIndex =
+			expandedToResultIndices[
+				expandedGameObject.m_parentIndex];
+		for (const uint32_t expandedComponentIndex :
+			expandedGameObject.m_components)
+		{
+			if (expandedComponentIndex >=
+				expandedPrefab->m_components.Num())
+			{
+				outDiagnostic =
+					"a detached supplemental game object references an invalid component";
+				return false;
+			}
+
+			supplementalGameObject.m_components.Add(
+				static_cast<uint32_t>(
+					nextComponents.Num()));
+			nextComponents.Add(
+				expandedPrefab->m_components[
+					expandedComponentIndex]);
+		}
+
+		if (!nextSupplementalInstanceIds.Insert(
+				supplementalGameObject.m_instanceId))
+		{
+			outDiagnostic =
+				"the expanded linked prefab contains duplicate detached supplemental data";
+			return false;
+		}
+
+		nextGameObjects.Add(
+			std::move(supplementalGameObject));
+	}
+
+	m_bIsReady.store(false, std::memory_order_release);
+	m_gameObjects = std::move(nextGameObjects);
+	m_components = std::move(nextComponents);
+	m_detachedSupplementalInstanceIds =
+		std::move(nextSupplementalInstanceIds);
+	if (!ValidateForInstantiation(outDiagnostic))
+	{
+		return false;
+	}
+
+	m_bIsReady.store(true, std::memory_order_release);
+	return true;
+}
+
+PrefabPtr Prefab::FromGameObject(
+	GameObjectPtr root,
+	const FileId& sourcePrefabId,
+	const TSet<InstanceId>* excludedRoots)
+{
+	PrefabPtr res = App::GetSubmodule<PrefabImporter>()->Create(sourcePrefabId);
+
+	SerializeGameObject(root, -1, res->m_components, res->m_gameObjects, excludedRoots);
+	std::string diagnostic;
+	res->m_bIsReady.store(res->ValidateForInstantiation(diagnostic), std::memory_order_release);
 
 	return res;
 }
@@ -304,10 +922,26 @@ PrefabImporter::~PrefabImporter()
 
 PrefabPtr PrefabImporter::Create()
 {
-	return PrefabPtr::Make(m_allocator, FileId());
+	return Create(FileId::Invalid);
 }
 
-void PrefabImporter::OnUpdateAssetInfo(AssetInfoPtr, bool) {}
+PrefabPtr PrefabImporter::Create(const FileId& uid)
+{
+	return PrefabPtr::Make(m_allocator, uid);
+}
+
+void PrefabImporter::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
+{
+	SAILOR_PROFILE_FUNCTION();
+	if (!assetInfo || !bWasExpired)
+	{
+		return;
+	}
+
+	const FileId uid = assetInfo->GetFileId();
+	m_loadedPrefabs.Remove(uid);
+	m_promises.Remove(uid);
+}
 
 void PrefabImporter::OnImportAsset(AssetInfoPtr assetInfo) {}
 
@@ -316,8 +950,13 @@ bool PrefabImporter::LoadPrefab_Immediate(FileId uid, PrefabPtr& outPrefab)
 	SAILOR_PROFILE_FUNCTION();
 
 	auto task = LoadPrefab(uid, outPrefab);
+	if (!task)
+	{
+		return false;
+	}
+
 	task->Wait();
-	return task->GetResult().IsValid();
+	return task->GetResult().IsValid() && outPrefab && outPrefab->IsReady();
 }
 
 Tasks::TaskPtr<PrefabPtr> PrefabImporter::LoadPrefab(FileId uid, PrefabPtr& outPrefab)
@@ -331,13 +970,30 @@ Tasks::TaskPtr<PrefabPtr> PrefabImporter::LoadPrefab(FileId uid, PrefabPtr& outP
 	// Check loaded assets
 	if (loadedPrefab)
 	{
-		outPrefab = loadedPrefab;
-		auto res = promise ? promise : Tasks::TaskPtr<PrefabPtr>::Make(outPrefab);
+		if (promise && !promise->IsFinished())
+		{
+			outPrefab = loadedPrefab;
+			auto res = promise;
 
-		m_loadedPrefabs.Unlock(uid);
-		m_promises.Unlock(uid);
+			m_loadedPrefabs.Unlock(uid);
+			m_promises.Unlock(uid);
 
-		return res;
+			return res;
+		}
+
+		if (loadedPrefab->IsReady())
+		{
+			outPrefab = loadedPrefab;
+			auto res = Tasks::TaskPtr<PrefabPtr>::Make(outPrefab);
+
+			m_loadedPrefabs.Unlock(uid);
+			m_promises.Unlock(uid);
+
+			return res;
+		}
+
+		loadedPrefab = nullptr;
+		promise = nullptr;
 	}
 
 	// There is no promise, we need to load prefab
@@ -354,10 +1010,31 @@ Tasks::TaskPtr<PrefabPtr> PrefabImporter::LoadPrefab(FileId uid, PrefabPtr& outP
 				TSharedPtr<Data> res = TSharedPtr<Data>::Make();
 
 				std::string text;
-				AssetRegistry::ReadTextFile(assetInfo->GetAssetFilepath(), text);
+				std::string diagnostic;
+				bool bLoaded = AssetRegistry::ReadTextFile(assetInfo->GetAssetFilepath(), text);
+				if (bLoaded)
+				{
+					bLoaded = External::GuardYamlExceptions(
+						[&prefab, &text]()
+						{
+							prefab->Deserialize(YAML::Load(text));
+						},
+						diagnostic);
+				}
 
-				YAML::Node node = YAML::Load(text);
-				prefab->Deserialize(node);
+				if (bLoaded)
+				{
+					bLoaded = prefab->ValidateForInstantiation(diagnostic);
+				}
+
+				prefab->m_bIsReady.store(bLoaded, std::memory_order_release);
+				if (!bLoaded)
+				{
+					SAILOR_LOG_ERROR(
+						"Cannot load prefab '%s': %s.",
+						assetInfo->GetAssetFilepath().c_str(),
+						diagnostic.empty() ? "cannot read the prefab file" : diagnostic.c_str());
+				}
 
 				return res;
 

--- a/Runtime/AssetRegistry/Prefab/PrefabImporter.h
+++ b/Runtime/AssetRegistry/Prefab/PrefabImporter.h
@@ -100,7 +100,7 @@ namespace Sailor
 
 	protected:
 
-		static void SerializeGameObject(
+		SAILOR_API static void SerializeGameObject(
 			GameObjectPtr root,
 			uint32_t parentIndex,
 			TVector<ReflectedData>& components,

--- a/Runtime/AssetRegistry/Prefab/PrefabImporter.h
+++ b/Runtime/AssetRegistry/Prefab/PrefabImporter.h
@@ -17,6 +17,7 @@
 #include "Memory/ObjectAllocator.hpp"
 #include "Core/Reflection.h"
 #include "Tasks/Tasks.h"
+#include "Containers/Set.h"
 
 using namespace Sailor::Memory;
 
@@ -66,20 +67,64 @@ namespace Sailor
 
 		SAILOR_API bool SaveToFile(const std::string& path) const;
 
-		static PrefabPtr FromGameObject(GameObjectPtr go);
+		SAILOR_API bool GetOverridePrefab(
+			const PrefabPtr base,
+			PrefabPtr outOverride) const;
 
-		SAILOR_API bool GetOverridePrefab(const PrefabPtr base, PrefabPtr outOverride) const;
+		static PrefabPtr FromGameObject(
+			GameObjectPtr go,
+			const FileId& sourcePrefabId = FileId::Invalid,
+			const TSet<InstanceId>* excludedRoots = nullptr);
+
+		SAILOR_API bool ConfigureLinkedInstance(
+			const PrefabPtr& basePrefab,
+			const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+			const InstanceId& parentInstanceId,
+			const TMap<InstanceId, YAML::Node>& gameObjectOverrides,
+			const TMap<InstanceId, ReflectedData>& componentOverrides,
+			std::string& outDiagnostic);
+
+		SAILOR_API bool AppendDetachedSupplementalHierarchy(
+			const PrefabPtr& expandedPrefab,
+			std::string& outDiagnostic);
+
+		SAILOR_API bool IsLinkedInstanceRecord() const { return m_bLinkedInstanceRecord; }
+		SAILOR_API const InstanceId& GetLinkedParentInstanceId() const { return m_linkedParentInstanceId; }
+		SAILOR_API const TMap<InstanceId, InstanceId>& GetLinkedInstanceIds() const { return m_linkedInstanceIds; }
+		SAILOR_API const TMap<InstanceId, YAML::Node>& GetLinkedGameObjectOverrides() const { return m_gameObjectOverrides; }
+		SAILOR_API const TMap<InstanceId, ReflectedData>& GetLinkedComponentOverrides() const { return m_componentOverrides; }
+		SAILOR_API bool IsDetachedFromPrefabRecord() const { return m_bDetachedFromPrefabRecord; }
+		SAILOR_API const InstanceId& GetDetachedParentInstanceId() const { return m_detachedParentInstanceId; }
+		SAILOR_API bool IsLinkedPrefabSnapshotRecord() const { return m_bLinkedPrefabSnapshotRecord; }
+		SAILOR_API const FileId& GetLinkedSnapshotSourceFileId() const { return m_linkedSnapshotSourceFileId; }
 
 	protected:
 
-		static void SerializeGameObject(GameObjectPtr root, uint32_t parentIndex, TVector<ReflectedData>& components, TVector<Prefab::ReflectedGameObject>& gameObjects);
+		static void SerializeGameObject(
+			GameObjectPtr root,
+			uint32_t parentIndex,
+			TVector<ReflectedData>& components,
+			TVector<Prefab::ReflectedGameObject>& gameObjects,
+			const TSet<InstanceId>* excludedRoots);
 
 		std::atomic<bool> m_bIsReady{};
 
 		TVector<ReflectedData> m_components{};
 		TVector<ReflectedGameObject> m_gameObjects{};
+		TMap<InstanceId, InstanceId> m_linkedInstanceIds{};
+		TMap<InstanceId, YAML::Node> m_gameObjectOverrides{};
+		TMap<InstanceId, ReflectedData> m_componentOverrides{};
+		TSet<InstanceId> m_detachedSupplementalInstanceIds{};
+		FileId m_linkedSnapshotSourceFileId{};
+		InstanceId m_linkedParentInstanceId{};
+		InstanceId m_detachedParentInstanceId{};
+		bool m_bLinkedInstanceRecord = false;
+		bool m_bExpandedLinkedInstanceRecord = false;
+		bool m_bDetachedFromPrefabRecord = false;
+		bool m_bLinkedPrefabSnapshotRecord = false;
 
 		friend class PrefabImporter;
+		friend class WorldPrefab;
 
 		// We need that for object instantiation
 		friend class World;
@@ -102,6 +147,7 @@ namespace Sailor
 		SAILOR_API virtual void CollectGarbage() override;
 
 		SAILOR_API PrefabPtr Create();
+		SAILOR_API PrefabPtr Create(const FileId& uid);
 
 	protected:
 

--- a/Runtime/AssetRegistry/World/WorldPrefabImporter.cpp
+++ b/Runtime/AssetRegistry/World/WorldPrefabImporter.cpp
@@ -6,24 +6,246 @@
 #include <filesystem>
 #include <fstream>
 #include <algorithm>
+#include <iomanip>
 #include <iostream>
+#include <sstream>
 #include "Memory/ObjectAllocator.hpp"
 #include "Tasks/Scheduler.h"
 #include "Engine/GameObject.h"
 #include "Engine/World.h"
 #include "ECS/TransformECS.h"
+#include "Core/LogMacros.h"
+#include "Containers/Hash.h"
+#include "YamlExceptionBoundary.h"
 
 using namespace Sailor;
 
+namespace
+{
+	bool AreYamlNodesEqual(const YAML::Node& lhs, const YAML::Node& rhs)
+	{
+		if (lhs.IsDefined() != rhs.IsDefined())
+		{
+			return false;
+		}
+
+		if (!lhs.IsDefined())
+		{
+			return true;
+		}
+
+		if (lhs.Type() != rhs.Type())
+		{
+			return false;
+		}
+
+		switch (lhs.Type())
+		{
+		case YAML::NodeType::Null:
+			return true;
+
+		case YAML::NodeType::Scalar:
+			return lhs.Scalar() == rhs.Scalar();
+
+		case YAML::NodeType::Sequence:
+			if (lhs.size() != rhs.size())
+			{
+				return false;
+			}
+
+			for (size_t index = 0; index < lhs.size(); ++index)
+			{
+				if (!AreYamlNodesEqual(lhs[index], rhs[index]))
+				{
+					return false;
+				}
+			}
+			return true;
+
+		case YAML::NodeType::Map:
+			if (lhs.size() != rhs.size())
+			{
+				return false;
+			}
+
+			{
+				TVector<bool> matchedRightEntries(rhs.size());
+				for (const auto& leftEntry : lhs)
+				{
+					bool bFoundMatch = false;
+					size_t rightIndex = 0;
+					for (const auto& rightEntry : rhs)
+					{
+						if (!matchedRightEntries[rightIndex] &&
+							AreYamlNodesEqual(leftEntry.first, rightEntry.first) &&
+							AreYamlNodesEqual(leftEntry.second, rightEntry.second))
+						{
+							matchedRightEntries[rightIndex] = true;
+							bFoundMatch = true;
+							break;
+						}
+						++rightIndex;
+					}
+
+					if (!bFoundMatch)
+					{
+						return false;
+					}
+				}
+			}
+			return true;
+
+		case YAML::NodeType::Undefined:
+		default:
+			return false;
+		}
+	}
+
+	bool TryGetComponentInstanceId(
+		const ReflectedData& reflection,
+		InstanceId& outInstanceId,
+		std::string& outDiagnostic)
+	{
+		if (!reflection.IsValid() || !reflection.GetProperties().ContainsKey("instanceId"))
+		{
+			outDiagnostic = "a reflected component has no instanceId";
+			return false;
+		}
+
+		return External::TryConvertYaml(
+			reflection.GetProperties()["instanceId"],
+			outInstanceId,
+			outDiagnostic);
+	}
+
+	InstanceId NormalizeInstanceId(
+		const InstanceId& liveInstanceId,
+		const TMap<InstanceId, InstanceId>& instanceToSourceIds)
+	{
+		if (!liveInstanceId)
+		{
+			return liveInstanceId;
+		}
+
+		const InstanceId liveGameObjectId = liveInstanceId.GameObjectId();
+		if (!instanceToSourceIds.ContainsKey(liveGameObjectId))
+		{
+			return liveInstanceId;
+		}
+
+		const InstanceId& sourceGameObjectId = instanceToSourceIds[liveGameObjectId];
+		return liveInstanceId.IsGameObjectId()
+			? sourceGameObjectId
+			: InstanceId(liveInstanceId.ComponentId(), sourceGameObjectId);
+	}
+
+	YAML::Node NormalizeInstanceReferences(
+		const YAML::Node& node,
+		const TMap<InstanceId, InstanceId>& instanceToSourceIds)
+	{
+		if (!node)
+		{
+			return YAML::Node();
+		}
+
+		if (node.IsScalar() || node.IsNull())
+		{
+			return YAML::Clone(node);
+		}
+
+		YAML::Node normalized;
+		if (node.IsSequence())
+		{
+			normalized = YAML::Node(YAML::NodeType::Sequence);
+			for (const auto& child : node)
+			{
+				normalized.push_back(NormalizeInstanceReferences(child, instanceToSourceIds));
+			}
+			return normalized;
+		}
+
+		normalized = YAML::Node(YAML::NodeType::Map);
+		for (const auto& property : node)
+		{
+			normalized[YAML::Clone(property.first)] =
+				NormalizeInstanceReferences(property.second, instanceToSourceIds);
+		}
+
+		if (normalized["instanceId"])
+		{
+			InstanceId liveInstanceId;
+			std::string conversionDiagnostic;
+			if (External::TryConvertYaml(
+					normalized["instanceId"],
+					liveInstanceId,
+					conversionDiagnostic))
+			{
+				normalized["instanceId"] = NormalizeInstanceId(
+					liveInstanceId,
+					instanceToSourceIds);
+			}
+		}
+
+		return normalized;
+	}
+
+	InstanceId MakeDeterministicLinkedInstanceId(
+		const FileId& sourcePrefabId,
+		const std::string& instanceSeed,
+		const InstanceId& sourceInstanceId,
+		uint32_t collisionAttempt)
+	{
+		const std::string key =
+			sourcePrefabId.ToString() + "|" +
+			instanceSeed + "|" +
+			sourceInstanceId.ToString() + "|" +
+			std::to_string(collisionAttempt);
+		const uint64_t primaryHash = Sailor::fnv1a(key.data(), key.size());
+		const std::string suffixKey = key + "|suffix";
+		const uint16_t suffixHash = static_cast<uint16_t>(
+			Sailor::fnv1a(suffixKey.data(), suffixKey.size()));
+
+		std::stringstream stream;
+		stream << std::uppercase << std::hex << std::setfill('0')
+			<< std::setw(16) << primaryHash
+			<< std::setw(4) << suffixHash;
+
+		InstanceId result;
+		result.Deserialize(YAML::Node(stream.str()));
+		return result;
+	}
+}
+
 YAML::Node WorldPrefab::Serialize() const
 {
+	if (!IsReady() || !m_loadDiagnostic.empty())
+	{
+		return YAML::Node();
+	}
+
 	YAML::Node outData;
 	::Serialize(outData, "name", m_name);
 
 	TVector<YAML::Node> nodes;
-	for (auto& go : m_gameObjects)
+	for (const auto& prefab : m_gameObjects)
 	{
-		nodes.Add(go->Serialize());
+		YAML::Node prefabNode = prefab->Serialize();
+		if (prefab->m_bLinkedInstanceRecord)
+		{
+			::Serialize(prefabNode, "fileId", prefab->GetFileId());
+			::Serialize(prefabNode, "parentInstanceId", prefab->m_linkedParentInstanceId);
+			::Serialize(prefabNode, "instanceIds", prefab->m_linkedInstanceIds);
+			::Serialize(
+				prefabNode,
+				"gameObjectOverrides",
+				prefab->m_gameObjectOverrides);
+			::Serialize(
+				prefabNode,
+				"componentOverrides",
+				prefab->m_componentOverrides);
+		}
+
+		nodes.Add(std::move(prefabNode));
 	}
 
 	outData["prefabs"] = nodes;
@@ -33,23 +255,1063 @@ YAML::Node WorldPrefab::Serialize() const
 
 void WorldPrefab::Deserialize(const YAML::Node& inData)
 {
+	m_bIsReady.store(false, std::memory_order_release);
+	m_loadDiagnostic.clear();
+	m_name.clear();
+	m_gameObjects.Clear();
 	::Deserialize(inData, "name", m_name);
 
-	check(inData["prefabs"].IsSequence());
-
-	size_t numGameObjects = inData["prefabs"].size();
-	m_gameObjects.Reserve(numGameObjects);
-
-	for (uint32_t i = 0; i < numGameObjects; i++)
+	if (!inData["prefabs"] || !inData["prefabs"].IsSequence())
 	{
-		auto newPrefab = App::GetSubmodule<PrefabImporter>()->Create();
-		newPrefab->Deserialize(inData["prefabs"][i]);
-		m_gameObjects.Add(newPrefab);
+		m_loadDiagnostic = "the world has no prefab sequence";
+		return;
 	}
+
+	const size_t numPrefabs = inData["prefabs"].size();
+	m_gameObjects.Reserve(numPrefabs);
+	TVector<PrefabPtr> linkedPrefabs;
+	linkedPrefabs.Reserve(numPrefabs);
+	TSet<InstanceId> reservedInstanceIds;
+	for (const auto& prefabNode : inData["prefabs"])
+	{
+		if (prefabNode["gameObjects"] &&
+			prefabNode["gameObjects"].IsSequence())
+		{
+			for (const auto& gameObjectNode :
+				prefabNode["gameObjects"])
+			{
+				InstanceId instanceId;
+				if (::Deserialize(
+						gameObjectNode,
+						"instanceId",
+						instanceId) &&
+					instanceId.IsGameObjectId())
+				{
+					reservedInstanceIds.Insert(instanceId);
+				}
+			}
+		}
+
+		if (prefabNode["instanceIds"])
+		{
+			TMap<InstanceId, InstanceId> savedMappings;
+			::Deserialize(
+				prefabNode,
+				"instanceIds",
+				savedMappings);
+			for (const auto& savedMapping : savedMappings)
+			{
+				if (savedMapping.m_second->IsGameObjectId())
+				{
+					reservedInstanceIds.Insert(*savedMapping.m_second);
+				}
+			}
+		}
+	}
+
+	for (uint32_t prefabIndex = 0; prefabIndex < numPrefabs; ++prefabIndex)
+	{
+		const YAML::Node& prefabNode = inData["prefabs"][prefabIndex];
+		FileId sourcePrefabId;
+		::Deserialize(prefabNode, "fileId", sourcePrefabId);
+
+		if (!sourcePrefabId)
+		{
+			PrefabPtr inlinePrefab = App::GetSubmodule<PrefabImporter>()->Create();
+			inlinePrefab->Deserialize(prefabNode);
+			if (!inlinePrefab->ValidateForInstantiation(m_loadDiagnostic))
+			{
+				m_loadDiagnostic = "inline prefab " + std::to_string(prefabIndex) +
+					" is invalid: " + m_loadDiagnostic;
+				return;
+			}
+
+			inlinePrefab->m_bIsReady.store(true, std::memory_order_release);
+			m_gameObjects.Add(inlinePrefab);
+			continue;
+		}
+
+		PrefabAssetInfoPtr sourceAssetInfo =
+			App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr<PrefabAssetInfoPtr>(
+				sourcePrefabId);
+		if (!sourceAssetInfo)
+		{
+			m_loadDiagnostic = "linked prefab " + std::to_string(prefabIndex) +
+				" references an unknown source asset " + sourcePrefabId.ToString();
+			return;
+		}
+
+		std::string sourceText;
+		if (!AssetRegistry::ReadTextFile(
+				sourceAssetInfo->GetAssetFilepath(),
+				sourceText))
+		{
+			m_loadDiagnostic = "cannot read linked prefab source " +
+				sourceAssetInfo->GetAssetFilepath();
+			return;
+		}
+
+		PrefabPtr sourcePrefab =
+			App::GetSubmodule<PrefabImporter>()->Create(sourcePrefabId);
+		sourcePrefab->Deserialize(YAML::Load(sourceText));
+		if (!sourcePrefab->ValidateForInstantiation(m_loadDiagnostic))
+		{
+			m_loadDiagnostic = "linked prefab source '" +
+				sourceAssetInfo->GetAssetFilepath() + "' is invalid: " +
+				m_loadDiagnostic;
+			return;
+		}
+
+		PrefabPtr expandedPrefab = App::GetSubmodule<PrefabImporter>()->Create();
+		expandedPrefab->Deserialize(prefabNode);
+		if (!expandedPrefab->ValidateForInstantiation(m_loadDiagnostic))
+		{
+			m_loadDiagnostic = "expanded linked prefab " +
+				std::to_string(prefabIndex) + " is invalid: " +
+				m_loadDiagnostic;
+			return;
+		}
+
+		TMap<InstanceId, InstanceId> savedSourceToInstanceIds;
+		if (prefabNode["instanceIds"])
+		{
+			::Deserialize(
+				prefabNode,
+				"instanceIds",
+				savedSourceToInstanceIds);
+		}
+		else if (expandedPrefab->m_gameObjects.Num() ==
+			sourcePrefab->m_gameObjects.Num())
+		{
+			for (uint32_t gameObjectIndex = 0;
+				gameObjectIndex < sourcePrefab->m_gameObjects.Num();
+				++gameObjectIndex)
+			{
+				savedSourceToInstanceIds[
+					sourcePrefab->m_gameObjects[gameObjectIndex].m_instanceId] =
+					expandedPrefab->m_gameObjects[gameObjectIndex].m_instanceId;
+			}
+		}
+		else
+		{
+			for (const auto& sourceGameObject :
+				sourcePrefab->m_gameObjects)
+			{
+				for (const auto& expandedGameObject :
+					expandedPrefab->m_gameObjects)
+				{
+					if (sourceGameObject.m_instanceId ==
+						expandedGameObject.m_instanceId)
+					{
+						savedSourceToInstanceIds[
+							sourceGameObject.m_instanceId] =
+							expandedGameObject.m_instanceId;
+						break;
+					}
+				}
+			}
+		}
+
+		TMap<InstanceId, InstanceId> sourceToInstanceIds;
+		if (!ReconcileLinkedInstanceIds(
+				expandedPrefab,
+				sourcePrefab,
+				savedSourceToInstanceIds,
+				reservedInstanceIds,
+				sourceToInstanceIds,
+				m_loadDiagnostic))
+		{
+			m_loadDiagnostic = "cannot reconcile linked prefab " +
+				std::to_string(prefabIndex) + " identities: " +
+				m_loadDiagnostic;
+			return;
+		}
+
+		InstanceId parentInstanceId;
+		::Deserialize(prefabNode, "parentInstanceId", parentInstanceId);
+
+		TMap<InstanceId, YAML::Node> gameObjectOverrides;
+		TMap<InstanceId, ReflectedData> componentOverrides;
+		if (prefabNode["gameObjectOverrides"])
+		{
+			::Deserialize(
+				prefabNode,
+				"gameObjectOverrides",
+				gameObjectOverrides);
+		}
+		if (prefabNode["componentOverrides"])
+		{
+			::Deserialize(
+				prefabNode,
+				"componentOverrides",
+				componentOverrides);
+		}
+
+		TSet<InstanceId> currentSourceGameObjectIds;
+		TSet<InstanceId> currentSourceComponentIds;
+		TMap<InstanceId, std::string> currentSourceComponentTypes;
+		for (const auto& sourceGameObject :
+			sourcePrefab->m_gameObjects)
+		{
+			currentSourceGameObjectIds.Insert(
+				sourceGameObject.m_instanceId);
+		}
+		for (const auto& sourceComponent :
+			sourcePrefab->m_components)
+		{
+			InstanceId sourceComponentId;
+			std::string conversionDiagnostic;
+			if (!TryGetComponentInstanceId(
+					sourceComponent,
+					sourceComponentId,
+					conversionDiagnostic))
+			{
+				m_loadDiagnostic =
+					"linked prefab source contains an invalid component identity: " +
+					conversionDiagnostic;
+				return;
+			}
+			currentSourceComponentIds.Insert(sourceComponentId);
+			currentSourceComponentTypes[sourceComponentId] =
+				sourceComponent.GetTypeInfo().Name();
+		}
+
+		TMap<InstanceId, YAML::Node> filteredGameObjectOverrides;
+		for (const auto& overrideEntry : gameObjectOverrides)
+		{
+			if (currentSourceGameObjectIds.Contains(
+					overrideEntry.m_first))
+			{
+				filteredGameObjectOverrides[
+					overrideEntry.m_first] =
+					*overrideEntry.m_second;
+			}
+		}
+		gameObjectOverrides = std::move(
+			filteredGameObjectOverrides);
+
+		TMap<InstanceId, ReflectedData> filteredComponentOverrides;
+		for (const auto& overrideEntry : componentOverrides)
+		{
+			if (currentSourceComponentIds.Contains(
+					overrideEntry.m_first) &&
+				overrideEntry.m_second->IsValid() &&
+				overrideEntry.m_second->GetTypeInfo().Name() ==
+					currentSourceComponentTypes[overrideEntry.m_first])
+			{
+				filteredComponentOverrides[
+					overrideEntry.m_first] =
+					*overrideEntry.m_second;
+			}
+		}
+		componentOverrides = std::move(filteredComponentOverrides);
+
+		if (!prefabNode["gameObjectOverrides"] ||
+			!prefabNode["componentOverrides"])
+		{
+			TMap<InstanceId, YAML::Node> derivedGameObjectOverrides;
+			TMap<InstanceId, ReflectedData> derivedComponentOverrides;
+			if (!BuildLinkedOverrides(
+					expandedPrefab,
+					sourcePrefab,
+					sourceToInstanceIds,
+					derivedGameObjectOverrides,
+					derivedComponentOverrides,
+					m_loadDiagnostic))
+			{
+				m_loadDiagnostic = "cannot derive linked prefab " +
+					std::to_string(prefabIndex) + " overrides: " +
+					m_loadDiagnostic;
+				return;
+			}
+
+			if (!prefabNode["gameObjectOverrides"])
+			{
+				gameObjectOverrides = std::move(derivedGameObjectOverrides);
+			}
+			if (!prefabNode["componentOverrides"])
+			{
+				componentOverrides = std::move(derivedComponentOverrides);
+			}
+		}
+
+		PrefabPtr linkedPrefab =
+			App::GetSubmodule<PrefabImporter>()->Create(sourcePrefabId);
+		if (!linkedPrefab->ConfigureLinkedInstance(
+				sourcePrefab,
+				sourceToInstanceIds,
+				parentInstanceId,
+				gameObjectOverrides,
+				componentOverrides,
+				m_loadDiagnostic))
+		{
+			m_loadDiagnostic = "linked prefab " + std::to_string(prefabIndex) +
+				" is invalid: " + m_loadDiagnostic;
+			return;
+		}
+
+		if (!linkedPrefab->AppendDetachedSupplementalHierarchy(
+				expandedPrefab,
+				m_loadDiagnostic))
+		{
+			m_loadDiagnostic =
+				"linked prefab " + std::to_string(prefabIndex) +
+				" has invalid detached supplemental data: " +
+				m_loadDiagnostic;
+			return;
+		}
+
+		linkedPrefabs.Add(linkedPrefab);
+	}
+
+	m_gameObjects.AddRange(linkedPrefabs);
+	m_bIsReady.store(true, std::memory_order_release);
+}
+
+bool WorldPrefab::ReconcileLinkedInstanceIds(
+	const PrefabPtr& expandedPrefab,
+	const PrefabPtr& sourcePrefab,
+	const TMap<InstanceId, InstanceId>& savedSourceToInstanceIds,
+	TSet<InstanceId>& reservedInstanceIds,
+	TMap<InstanceId, InstanceId>& outSourceToInstanceIds,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	outSourceToInstanceIds.Clear();
+	if (!expandedPrefab || !sourcePrefab || !sourcePrefab->GetFileId())
+	{
+		outDiagnostic = "the expanded or source prefab is missing";
+		return false;
+	}
+
+	std::string instanceSeed;
+	auto considerSeed = [&instanceSeed](const InstanceId& instanceId)
+		{
+			if (!instanceId.IsGameObjectId())
+			{
+				return;
+			}
+
+			const std::string& candidate = instanceId.ToString();
+			if (instanceSeed.empty() || candidate < instanceSeed)
+			{
+				instanceSeed = candidate;
+			}
+		};
+
+	for (const auto& savedMapping : savedSourceToInstanceIds)
+	{
+		considerSeed(*savedMapping.m_second);
+	}
+	for (const auto& expandedGameObject : expandedPrefab->m_gameObjects)
+	{
+		considerSeed(expandedGameObject.m_instanceId);
+	}
+
+	if (instanceSeed.empty())
+	{
+		outDiagnostic = "the linked prefab record has no stable live instance seed";
+		return false;
+	}
+
+	TSet<InstanceId> assignedInstanceIds;
+	for (const auto& sourceGameObject : sourcePrefab->m_gameObjects)
+	{
+		InstanceId liveInstanceId;
+		if (savedSourceToInstanceIds.ContainsKey(
+				sourceGameObject.m_instanceId))
+		{
+			liveInstanceId = savedSourceToInstanceIds[
+				sourceGameObject.m_instanceId];
+			if (!liveInstanceId.IsGameObjectId())
+			{
+				outDiagnostic = "the saved linked prefab mapping contains an invalid live game object id";
+				return false;
+			}
+
+			if (!assignedInstanceIds.Insert(liveInstanceId))
+			{
+				outDiagnostic = "the saved linked prefab mapping contains duplicate live game object ids";
+				return false;
+			}
+		}
+		else
+		{
+			uint32_t collisionAttempt = 0;
+			do
+			{
+				liveInstanceId = MakeDeterministicLinkedInstanceId(
+					sourcePrefab->GetFileId(),
+					instanceSeed,
+					sourceGameObject.m_instanceId,
+					collisionAttempt++);
+			}
+			while (reservedInstanceIds.Contains(liveInstanceId) ||
+				assignedInstanceIds.Contains(liveInstanceId));
+
+			assignedInstanceIds.Insert(liveInstanceId);
+			reservedInstanceIds.Insert(liveInstanceId);
+		}
+
+		outSourceToInstanceIds[sourceGameObject.m_instanceId] =
+			liveInstanceId;
+	}
+
+	return true;
+}
+
+bool WorldPrefab::BuildLinkedOverrides(
+	const PrefabPtr& expandedPrefab,
+	const PrefabPtr& sourcePrefab,
+	const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+	TMap<InstanceId, YAML::Node>& outGameObjectOverrides,
+	TMap<InstanceId, ReflectedData>& outComponentOverrides,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	outGameObjectOverrides.Clear();
+	outComponentOverrides.Clear();
+
+	if (!expandedPrefab || !sourcePrefab)
+	{
+		outDiagnostic = "the expanded or source prefab is missing";
+		return false;
+	}
+
+	if (!expandedPrefab->ValidateForInstantiation(outDiagnostic) ||
+		!sourcePrefab->ValidateForInstantiation(outDiagnostic))
+	{
+		return false;
+	}
+
+	if (sourceToInstanceIds.Num() != sourcePrefab->m_gameObjects.Num())
+	{
+		outDiagnostic = "the reconciled source-to-instance mapping is incomplete";
+		return false;
+	}
+
+	TMap<InstanceId, InstanceId> instanceToSourceIds;
+	for (const auto& mapping : sourceToInstanceIds)
+	{
+		if (!mapping.m_first.IsGameObjectId() ||
+			!mapping.m_second->IsGameObjectId() ||
+			instanceToSourceIds.ContainsKey(*mapping.m_second))
+		{
+			outDiagnostic = "the source-to-instance mapping contains an invalid or duplicate id";
+			return false;
+		}
+
+		instanceToSourceIds[*mapping.m_second] = mapping.m_first;
+	}
+
+	for (uint32_t sourceGameObjectIndex = 0;
+		sourceGameObjectIndex < sourcePrefab->m_gameObjects.Num();
+		++sourceGameObjectIndex)
+	{
+		const Prefab::ReflectedGameObject& sourceGameObject =
+			sourcePrefab->m_gameObjects[sourceGameObjectIndex];
+		if (!sourceToInstanceIds.ContainsKey(sourceGameObject.m_instanceId))
+		{
+			outDiagnostic = "the source-to-instance mapping is incomplete";
+			return false;
+		}
+
+		const InstanceId& liveInstanceId =
+			sourceToInstanceIds[sourceGameObject.m_instanceId];
+		const Prefab::ReflectedGameObject* expandedGameObject = nullptr;
+		for (uint32_t candidateIndex = 0;
+			candidateIndex < expandedPrefab->m_gameObjects.Num();
+			++candidateIndex)
+		{
+			if (expandedPrefab->m_gameObjects[candidateIndex].m_instanceId ==
+				liveInstanceId)
+			{
+				expandedGameObject =
+					&expandedPrefab->m_gameObjects[candidateIndex];
+				break;
+			}
+		}
+
+		if (!expandedGameObject)
+		{
+			// The source added this game object after the scene record was saved.
+			// It inherits source values and receives no instance override yet.
+			continue;
+		}
+
+		YAML::Node gameObjectOverride;
+		if (expandedGameObject->m_name != sourceGameObject.m_name)
+		{
+			gameObjectOverride["name"] = expandedGameObject->m_name;
+		}
+
+		if (!AreYamlNodesEqual(
+				YAML::Node(expandedGameObject->m_position),
+				YAML::Node(sourceGameObject.m_position)))
+		{
+			gameObjectOverride["position"] = expandedGameObject->m_position;
+		}
+
+		if (!AreYamlNodesEqual(
+				YAML::Node(expandedGameObject->m_rotation),
+				YAML::Node(sourceGameObject.m_rotation)))
+		{
+			gameObjectOverride["rotation"] = expandedGameObject->m_rotation;
+		}
+
+		if (!AreYamlNodesEqual(
+				YAML::Node(expandedGameObject->m_scale),
+				YAML::Node(sourceGameObject.m_scale)))
+		{
+			gameObjectOverride["scale"] = expandedGameObject->m_scale;
+		}
+
+		if (gameObjectOverride.size() > 0)
+		{
+			outGameObjectOverrides[
+				sourceGameObject.m_instanceId] = std::move(gameObjectOverride);
+		}
+
+		for (const uint32_t sourceComponentIndex :
+			sourceGameObject.m_components)
+		{
+			const ReflectedData& sourceReflection =
+				sourcePrefab->m_components[sourceComponentIndex];
+			InstanceId sourceComponentId;
+			if (!TryGetComponentInstanceId(
+					sourceReflection,
+					sourceComponentId,
+					outDiagnostic))
+			{
+				return false;
+			}
+
+			const InstanceId expectedLiveComponentId(
+				sourceComponentId.ComponentId(),
+				liveInstanceId);
+			const ReflectedData* expandedReflection = nullptr;
+			for (const uint32_t expandedComponentIndex :
+				expandedGameObject->m_components)
+			{
+				const ReflectedData& candidate =
+					expandedPrefab->m_components[expandedComponentIndex];
+				InstanceId candidateInstanceId;
+				std::string conversionDiagnostic;
+				if (!TryGetComponentInstanceId(
+						candidate,
+						candidateInstanceId,
+						conversionDiagnostic))
+				{
+					outDiagnostic = conversionDiagnostic;
+					return false;
+				}
+
+				if (candidateInstanceId == expectedLiveComponentId)
+				{
+					expandedReflection = &candidate;
+					break;
+				}
+			}
+
+			if (!expandedReflection ||
+				expandedReflection->GetTypeInfo() !=
+					sourceReflection.GetTypeInfo())
+			{
+				// The source added or replaced this component after the linked
+				// scene record was saved. Source values are authoritative.
+				continue;
+			}
+
+			YAML::Node overrideProperties;
+			for (const auto& liveProperty :
+				expandedReflection->GetProperties())
+			{
+				if (liveProperty.m_first == "instanceId" ||
+					liveProperty.m_first == "fileId")
+				{
+					continue;
+				}
+
+				const YAML::Node normalizedLiveValue =
+					NormalizeInstanceReferences(
+						*liveProperty.m_second,
+						instanceToSourceIds);
+				if (!sourceReflection.GetProperties().ContainsKey(
+						liveProperty.m_first) ||
+					!AreYamlNodesEqual(
+						normalizedLiveValue,
+						sourceReflection.GetProperties()[
+							liveProperty.m_first]))
+				{
+					overrideProperties[liveProperty.m_first] =
+						normalizedLiveValue;
+				}
+			}
+
+			if (overrideProperties.size() > 0)
+			{
+				YAML::Node reflectedOverride;
+				reflectedOverride["typename"] =
+					sourceReflection.GetTypeInfo().Name();
+				reflectedOverride["overrideProperties"] =
+					std::move(overrideProperties);
+
+				ReflectedData componentOverride;
+				componentOverride.Deserialize(reflectedOverride);
+				if (!componentOverride.IsValid())
+				{
+					outDiagnostic = "cannot create a reflected component override";
+					return false;
+				}
+
+				outComponentOverrides[sourceComponentId] =
+					std::move(componentOverride);
+			}
+		}
+
+	}
+
+	return true;
+}
+
+bool WorldPrefab::BuildUpdatedLinkedOverrides(
+	const PrefabPtr& expandedPrefab,
+	const PrefabPtr& sourcePrefab,
+	const PrefabPtr& effectiveBaseline,
+	const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+	TMap<InstanceId, YAML::Node>& outGameObjectOverrides,
+	TMap<InstanceId, ReflectedData>& outComponentOverrides,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	outGameObjectOverrides.Clear();
+	outComponentOverrides.Clear();
+
+	if (!expandedPrefab ||
+		!sourcePrefab ||
+		!effectiveBaseline ||
+		sourcePrefab->GetFileId() != effectiveBaseline->GetFileId())
+	{
+		outDiagnostic = "the expanded, source, or effective baseline prefab is missing or mismatched";
+		return false;
+	}
+
+	if (!expandedPrefab->ValidateForInstantiation(outDiagnostic) ||
+		!sourcePrefab->ValidateForInstantiation(outDiagnostic) ||
+		!effectiveBaseline->ValidateForInstantiation(outDiagnostic))
+	{
+		return false;
+	}
+
+	if (sourceToInstanceIds.Num() != sourcePrefab->m_gameObjects.Num())
+	{
+		outDiagnostic = "the reconciled source-to-instance mapping is incomplete";
+		return false;
+	}
+
+	TMap<InstanceId, InstanceId> instanceToSourceIds;
+	for (const auto& mapping : sourceToInstanceIds)
+	{
+		if (!mapping.m_first.IsGameObjectId() ||
+			!mapping.m_second->IsGameObjectId() ||
+			instanceToSourceIds.ContainsKey(*mapping.m_second))
+		{
+			outDiagnostic = "the source-to-instance mapping contains an invalid or duplicate id";
+			return false;
+		}
+
+		instanceToSourceIds[*mapping.m_second] = mapping.m_first;
+	}
+
+	for (const Prefab::ReflectedGameObject& sourceGameObject :
+		sourcePrefab->m_gameObjects)
+	{
+		if (!sourceToInstanceIds.ContainsKey(sourceGameObject.m_instanceId))
+		{
+			outDiagnostic = "the source-to-instance mapping is incomplete";
+			return false;
+		}
+
+		const InstanceId& liveInstanceId =
+			sourceToInstanceIds[sourceGameObject.m_instanceId];
+		const Prefab::ReflectedGameObject* expandedGameObject = nullptr;
+		for (const Prefab::ReflectedGameObject& candidate :
+			expandedPrefab->m_gameObjects)
+		{
+			if (candidate.m_instanceId == liveInstanceId)
+			{
+				expandedGameObject = &candidate;
+				break;
+			}
+		}
+
+		const Prefab::ReflectedGameObject* baselineGameObject = nullptr;
+		for (const Prefab::ReflectedGameObject& candidate :
+			effectiveBaseline->m_gameObjects)
+		{
+			if (candidate.m_instanceId == sourceGameObject.m_instanceId)
+			{
+				baselineGameObject = &candidate;
+				break;
+			}
+		}
+
+		const bool bHasPriorGameObjectOverride =
+			effectiveBaseline->m_bLinkedInstanceRecord &&
+			effectiveBaseline->m_gameObjectOverrides.ContainsKey(
+				sourceGameObject.m_instanceId);
+		const YAML::Node priorGameObjectOverride =
+			bHasPriorGameObjectOverride
+				? effectiveBaseline->m_gameObjectOverrides[
+					sourceGameObject.m_instanceId]
+				: YAML::Node();
+
+		YAML::Node gameObjectOverride;
+		if (expandedGameObject)
+		{
+			const bool bNameChangedFromBaseline =
+				baselineGameObject &&
+				expandedGameObject->m_name != baselineGameObject->m_name;
+			if (bNameChangedFromBaseline)
+			{
+				if (expandedGameObject->m_name != sourceGameObject.m_name)
+				{
+					gameObjectOverride["name"] =
+						expandedGameObject->m_name;
+				}
+			}
+			else if (priorGameObjectOverride["name"])
+			{
+				gameObjectOverride["name"] =
+					YAML::Clone(priorGameObjectOverride["name"]);
+			}
+
+			auto mergeTransformOverride = [
+				&gameObjectOverride,
+				&priorGameObjectOverride](
+					const char* propertyName,
+					const YAML::Node& liveValue,
+					const YAML::Node& baselineValue,
+					const YAML::Node& sourceValue,
+					bool bHasBaseline)
+				{
+					const bool bChangedFromBaseline =
+						bHasBaseline &&
+						!AreYamlNodesEqual(liveValue, baselineValue);
+					if (bChangedFromBaseline)
+					{
+						if (!AreYamlNodesEqual(liveValue, sourceValue))
+						{
+							gameObjectOverride[propertyName] =
+								YAML::Clone(liveValue);
+						}
+					}
+					else if (priorGameObjectOverride[propertyName])
+					{
+						gameObjectOverride[propertyName] =
+							YAML::Clone(
+								priorGameObjectOverride[propertyName]);
+					}
+				};
+
+			mergeTransformOverride(
+				"position",
+				YAML::Node(expandedGameObject->m_position),
+				baselineGameObject
+					? YAML::Node(baselineGameObject->m_position)
+					: YAML::Node(),
+				YAML::Node(sourceGameObject.m_position),
+				baselineGameObject != nullptr);
+			mergeTransformOverride(
+				"rotation",
+				YAML::Node(expandedGameObject->m_rotation),
+				baselineGameObject
+					? YAML::Node(baselineGameObject->m_rotation)
+					: YAML::Node(),
+				YAML::Node(sourceGameObject.m_rotation),
+				baselineGameObject != nullptr);
+			mergeTransformOverride(
+				"scale",
+				YAML::Node(expandedGameObject->m_scale),
+				baselineGameObject
+					? YAML::Node(baselineGameObject->m_scale)
+					: YAML::Node(),
+				YAML::Node(sourceGameObject.m_scale),
+				baselineGameObject != nullptr);
+		}
+
+		if (gameObjectOverride.size() > 0)
+		{
+			outGameObjectOverrides[sourceGameObject.m_instanceId] =
+				std::move(gameObjectOverride);
+		}
+
+		for (const uint32_t sourceComponentIndex :
+			sourceGameObject.m_components)
+		{
+			const ReflectedData& sourceReflection =
+				sourcePrefab->m_components[sourceComponentIndex];
+			InstanceId sourceComponentId;
+			if (!TryGetComponentInstanceId(
+					sourceReflection,
+					sourceComponentId,
+					outDiagnostic))
+			{
+				return false;
+			}
+
+			const InstanceId expectedLiveComponentId(
+				sourceComponentId.ComponentId(),
+				liveInstanceId);
+			const ReflectedData* expandedReflection = nullptr;
+			if (expandedGameObject)
+			{
+				for (const uint32_t componentIndex :
+					expandedGameObject->m_components)
+				{
+					const ReflectedData& candidate =
+						expandedPrefab->m_components[componentIndex];
+					InstanceId candidateInstanceId;
+					std::string conversionDiagnostic;
+					if (!TryGetComponentInstanceId(
+							candidate,
+							candidateInstanceId,
+							conversionDiagnostic))
+					{
+						outDiagnostic = conversionDiagnostic;
+						return false;
+					}
+
+					if (candidateInstanceId == expectedLiveComponentId &&
+						candidate.GetTypeInfo() ==
+							sourceReflection.GetTypeInfo())
+					{
+						expandedReflection = &candidate;
+						break;
+					}
+				}
+			}
+
+			const ReflectedData* baselineReflection = nullptr;
+			if (baselineGameObject)
+			{
+				for (const uint32_t componentIndex :
+					baselineGameObject->m_components)
+				{
+					const ReflectedData& candidate =
+						effectiveBaseline->m_components[componentIndex];
+					InstanceId candidateInstanceId;
+					std::string conversionDiagnostic;
+					if (!TryGetComponentInstanceId(
+							candidate,
+							candidateInstanceId,
+							conversionDiagnostic))
+					{
+						outDiagnostic = conversionDiagnostic;
+						return false;
+					}
+
+					if (candidateInstanceId == sourceComponentId &&
+						candidate.GetTypeInfo() ==
+							sourceReflection.GetTypeInfo())
+					{
+						baselineReflection = &candidate;
+						break;
+					}
+				}
+			}
+
+			const ReflectedData* priorComponentOverride = nullptr;
+			if (effectiveBaseline->m_bLinkedInstanceRecord &&
+				effectiveBaseline->m_componentOverrides.ContainsKey(
+					sourceComponentId))
+			{
+				const ReflectedData& candidate =
+					effectiveBaseline->m_componentOverrides[
+						sourceComponentId];
+				if (candidate.IsValid() &&
+					candidate.GetTypeInfo() ==
+						sourceReflection.GetTypeInfo())
+				{
+					priorComponentOverride = &candidate;
+				}
+			}
+
+			if (!expandedReflection)
+			{
+				continue;
+			}
+
+			YAML::Node overrideProperties;
+			for (const auto& liveProperty :
+				expandedReflection->GetProperties())
+			{
+				if (liveProperty.m_first == "instanceId" ||
+					liveProperty.m_first == "fileId")
+				{
+					continue;
+				}
+
+				const YAML::Node normalizedLiveValue =
+					NormalizeInstanceReferences(
+						*liveProperty.m_second,
+						instanceToSourceIds);
+				const bool bHasBaselineProperty =
+					baselineReflection &&
+					baselineReflection->GetProperties().ContainsKey(
+						liveProperty.m_first);
+				const bool bChangedFromBaseline =
+					baselineReflection &&
+					(!bHasBaselineProperty ||
+						!AreYamlNodesEqual(
+							normalizedLiveValue,
+							baselineReflection->GetProperties()[
+								liveProperty.m_first]));
+
+				if (bChangedFromBaseline)
+				{
+					if (!sourceReflection.GetProperties().ContainsKey(
+							liveProperty.m_first) ||
+						!AreYamlNodesEqual(
+							normalizedLiveValue,
+							sourceReflection.GetProperties()[
+								liveProperty.m_first]))
+					{
+						overrideProperties[liveProperty.m_first] =
+							normalizedLiveValue;
+					}
+				}
+				else if (priorComponentOverride &&
+					priorComponentOverride->GetProperties().ContainsKey(
+						liveProperty.m_first))
+				{
+					overrideProperties[liveProperty.m_first] =
+						YAML::Clone(
+							priorComponentOverride->GetProperties()[
+								liveProperty.m_first]);
+				}
+			}
+
+			if (overrideProperties.size() > 0)
+			{
+				YAML::Node reflectedOverride;
+				reflectedOverride["typename"] =
+					sourceReflection.GetTypeInfo().Name();
+				reflectedOverride["overrideProperties"] =
+					std::move(overrideProperties);
+
+				ReflectedData componentOverride;
+				componentOverride.Deserialize(reflectedOverride);
+				if (!componentOverride.IsValid())
+				{
+					outDiagnostic =
+						"cannot create an updated reflected component override";
+					return false;
+				}
+
+				outComponentOverrides[sourceComponentId] =
+					std::move(componentOverride);
+			}
+		}
+	}
+
+	return true;
+}
+
+bool WorldPrefab::CommitLinkedInstanceUpdates(
+	WorldPtr world,
+	TVector<PendingPrefabLinkUpdate>& pendingUpdates,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	if (!world)
+	{
+		outDiagnostic = "the target world is missing";
+		return false;
+	}
+
+	if (pendingUpdates.Num() != world->m_prefabInstances.Num())
+	{
+		outDiagnostic =
+			"the linked prefab set changed before its baselines could be committed";
+		return false;
+	}
+
+	TSet<InstanceId> pendingRoots;
+	TMap<InstanceId, InstanceId> nextPrefabInstanceRootsByObject;
+	for (const auto& pendingUpdate : pendingUpdates)
+	{
+		if (!pendingRoots.Insert(pendingUpdate.m_rootInstanceId) ||
+			!world->m_prefabInstances.ContainsKey(
+				pendingUpdate.m_rootInstanceId))
+		{
+			outDiagnostic =
+				"a linked prefab instance disappeared or was duplicated before commit";
+			return false;
+		}
+
+		for (const auto& mapping :
+			pendingUpdate.m_sourceToInstanceIds)
+		{
+			const InstanceId& liveInstanceId = *mapping.m_second;
+			if (!liveInstanceId.IsGameObjectId())
+			{
+				outDiagnostic =
+					"a linked prefab mapping contains an invalid live game object id";
+				return false;
+			}
+
+			// Newly introduced source objects receive deterministic ids now but
+			// do not become live members until the scene is instantiated again.
+			if (!world->m_objectsMap.ContainsKey(liveInstanceId))
+			{
+				continue;
+			}
+
+			if (nextPrefabInstanceRootsByObject.ContainsKey(
+					liveInstanceId))
+			{
+				outDiagnostic =
+					"multiple linked prefab instances claim the same live game object";
+				return false;
+			}
+
+			nextPrefabInstanceRootsByObject[liveInstanceId] =
+				pendingUpdate.m_rootInstanceId;
+		}
+
+		if (!nextPrefabInstanceRootsByObject.ContainsKey(
+				pendingUpdate.m_rootInstanceId))
+		{
+			outDiagnostic =
+				"a linked prefab mapping no longer contains its live root";
+			return false;
+		}
+	}
+
+	for (auto& pendingUpdate : pendingUpdates)
+	{
+		PrefabInstanceLink& link =
+			world->m_prefabInstances[
+				pendingUpdate.m_rootInstanceId];
+		link.m_sourceToInstanceIds =
+			std::move(pendingUpdate.m_sourceToInstanceIds);
+		link.m_effectiveBaseline =
+			std::move(pendingUpdate.m_effectiveBaseline);
+	}
+	world->m_prefabInstanceRootsByObject =
+		std::move(nextPrefabInstanceRootsByObject);
+
+	return true;
 }
 
 bool WorldPrefab::SaveToFile(const std::string& path) const
 {
+	if (!IsReady() || !m_loadDiagnostic.empty())
+	{
+		return false;
+	}
+
 	AssetRegistry::WriteTextFile(path, Serialize());
 	return true;
 }
@@ -59,36 +1321,371 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 	auto res = App::GetSubmodule<WorldPrefabImporter>()->Create();
 	res->m_name = world->GetName();
 
-	auto gameObjects = world->GetGameObjects();
+	TVector<PendingPrefabLinkUpdate> pendingLinkUpdates;
 
-	for (auto& go : gameObjects)
+	TSet<InstanceId> linkedRoots;
+	for (const auto& linkEntry : world->GetPrefabInstances())
 	{
-		if (go->GetParent())
+		linkedRoots.Insert(linkEntry.m_first);
+	}
+
+	const auto& gameObjects = world->GetGameObjects();
+	TSet<InstanceId> reservedInstanceIds;
+	for (const auto& gameObject : gameObjects)
+	{
+		if (gameObject)
+		{
+			reservedInstanceIds.Insert(gameObject->GetInstanceId());
+		}
+	}
+
+	for (const auto& go : gameObjects)
+	{
+		if (go->GetParent() || linkedRoots.Contains(go->GetInstanceId()))
 		{
 			continue;
 		}
 
-		auto prefab = Prefab::FromGameObject(go);
-		if (!go->GetFileId())
+		PrefabPtr inlinePrefab =
+			Prefab::FromGameObject(go, FileId::Invalid, &linkedRoots);
+		if (!inlinePrefab->m_gameObjects.IsEmpty())
 		{
-			res->m_gameObjects.Add(prefab);
-		}
-		else
-		{
-			PrefabPtr basePrefab;
-			App::GetSubmodule<PrefabImporter>()->LoadPrefab_Immediate(go->GetFileId(), basePrefab);
-
-			PrefabPtr overridePrefab;
-			if (prefab->GetOverridePrefab(basePrefab, overridePrefab))
-			{
-				res->m_gameObjects.Add(overridePrefab);
-			}
-			else
-			{
-				res->m_gameObjects.Add(prefab);
-			}
+			res->m_gameObjects.Add(inlinePrefab);
 		}
 	}
+
+	for (auto linkEntry : world->m_prefabInstances)
+	{
+		PrefabInstanceLink& link = *linkEntry.m_second;
+		GameObjectPtr root = world->GetObjectByInstanceId(
+			link.m_rootInstanceId).DynamicCast<GameObject>();
+		if (!root)
+		{
+			res->m_loadDiagnostic =
+				"cannot serialize linked prefab '" +
+				link.m_sourcePrefabId.ToString() +
+				"': live root '" +
+				link.m_rootInstanceId.ToString() +
+				"' is missing";
+			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
+			res->m_gameObjects.Clear();
+			return res;
+		}
+
+		if (!link.m_effectiveBaseline)
+		{
+			res->m_loadDiagnostic =
+				"cannot serialize linked prefab '" +
+				link.m_sourcePrefabId.ToString() +
+				"': its effective baseline is unavailable";
+			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
+			res->m_gameObjects.Clear();
+			return res;
+		}
+
+		PrefabPtr sourcePrefab;
+		if (!App::GetSubmodule<PrefabImporter>()->LoadPrefab_Immediate(
+				link.m_sourcePrefabId,
+				sourcePrefab))
+		{
+			res->m_loadDiagnostic =
+				"cannot serialize linked prefab '" +
+				link.m_sourcePrefabId.ToString() +
+				"': source asset is unavailable";
+			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
+			res->m_gameObjects.Clear();
+			return res;
+		}
+
+		PrefabPtr expandedPrefab =
+			Prefab::FromGameObject(root, link.m_sourcePrefabId);
+		std::string diagnostic;
+		TMap<InstanceId, InstanceId> reconciledInstanceIds;
+		if (!ReconcileLinkedInstanceIds(
+				expandedPrefab,
+				sourcePrefab,
+				link.m_sourceToInstanceIds,
+				reservedInstanceIds,
+				reconciledInstanceIds,
+				diagnostic))
+		{
+			res->m_loadDiagnostic =
+				"cannot reconcile linked prefab '" +
+				link.m_sourcePrefabId.ToString() +
+				"': " +
+				diagnostic;
+			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
+			res->m_gameObjects.Clear();
+			return res;
+		}
+
+		if (!BuildUpdatedLinkedOverrides(
+				expandedPrefab,
+				sourcePrefab,
+				link.m_effectiveBaseline,
+				reconciledInstanceIds,
+				expandedPrefab->m_gameObjectOverrides,
+				expandedPrefab->m_componentOverrides,
+				diagnostic))
+		{
+			res->m_loadDiagnostic =
+				"cannot serialize linked prefab '" +
+				link.m_sourcePrefabId.ToString() +
+				"': " +
+				diagnostic;
+			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
+			res->m_gameObjects.Clear();
+			return res;
+		}
+
+		PrefabPtr nextEffectiveBaseline =
+			PrefabPtr::Make(
+				world->GetAllocator(),
+				link.m_sourcePrefabId);
+		nextEffectiveBaseline->m_gameObjects =
+			sourcePrefab->m_gameObjects;
+		nextEffectiveBaseline->m_components =
+			sourcePrefab->m_components;
+
+		TMap<InstanceId, InstanceId> instanceToSourceIds;
+		for (const auto& mapping : reconciledInstanceIds)
+		{
+			instanceToSourceIds[*mapping.m_second] =
+				mapping.m_first;
+		}
+
+		bool bBuiltNextBaseline = true;
+		for (uint32_t sourceGameObjectIndex = 0;
+			sourceGameObjectIndex < sourcePrefab->m_gameObjects.Num();
+			++sourceGameObjectIndex)
+		{
+			const Prefab::ReflectedGameObject& sourceGameObject =
+				sourcePrefab->m_gameObjects[sourceGameObjectIndex];
+			if (!reconciledInstanceIds.ContainsKey(
+					sourceGameObject.m_instanceId))
+			{
+				diagnostic =
+					"the reconciled mapping is missing a baseline game object";
+				bBuiltNextBaseline = false;
+				break;
+			}
+
+			const InstanceId& liveInstanceId =
+				reconciledInstanceIds[sourceGameObject.m_instanceId];
+			const Prefab::ReflectedGameObject* liveGameObject = nullptr;
+			for (const Prefab::ReflectedGameObject& candidate :
+				expandedPrefab->m_gameObjects)
+			{
+				if (candidate.m_instanceId == liveInstanceId)
+				{
+					liveGameObject = &candidate;
+					break;
+				}
+			}
+
+			if (!liveGameObject)
+			{
+				continue;
+			}
+
+			Prefab::ReflectedGameObject& baselineGameObject =
+				nextEffectiveBaseline->m_gameObjects[
+					sourceGameObjectIndex];
+			baselineGameObject.m_name = liveGameObject->m_name;
+			baselineGameObject.m_position =
+				liveGameObject->m_position;
+			baselineGameObject.m_rotation =
+				liveGameObject->m_rotation;
+			baselineGameObject.m_scale =
+				liveGameObject->m_scale;
+
+			for (const uint32_t sourceComponentIndex :
+				sourceGameObject.m_components)
+			{
+				const ReflectedData& sourceReflection =
+					sourcePrefab->m_components[
+						sourceComponentIndex];
+				InstanceId sourceComponentId;
+				if (!TryGetComponentInstanceId(
+						sourceReflection,
+						sourceComponentId,
+						diagnostic))
+				{
+					bBuiltNextBaseline = false;
+					break;
+				}
+
+				const InstanceId liveComponentId(
+					sourceComponentId.ComponentId(),
+					liveInstanceId);
+				const ReflectedData* liveReflection = nullptr;
+				for (const uint32_t liveComponentIndex :
+					liveGameObject->m_components)
+				{
+					const ReflectedData& candidate =
+						expandedPrefab->m_components[
+							liveComponentIndex];
+					InstanceId candidateInstanceId;
+					std::string conversionDiagnostic;
+					if (!TryGetComponentInstanceId(
+							candidate,
+							candidateInstanceId,
+							conversionDiagnostic))
+					{
+						diagnostic = conversionDiagnostic;
+						bBuiltNextBaseline = false;
+						break;
+					}
+
+					if (candidateInstanceId == liveComponentId &&
+						candidate.GetTypeInfo() ==
+							sourceReflection.GetTypeInfo())
+					{
+						liveReflection = &candidate;
+						break;
+					}
+				}
+
+				if (!bBuiltNextBaseline)
+				{
+					break;
+				}
+
+				if (!liveReflection)
+				{
+					continue;
+				}
+
+				const YAML::Node normalizedReflection =
+					NormalizeInstanceReferences(
+						liveReflection->Serialize(),
+						instanceToSourceIds);
+				ReflectedData baselineReflection;
+				if (!External::GuardYamlExceptions(
+						[&baselineReflection, &normalizedReflection]()
+							{
+								baselineReflection.Deserialize(
+									normalizedReflection);
+							},
+						diagnostic) ||
+					!baselineReflection.IsValid())
+				{
+					if (diagnostic.empty())
+					{
+						diagnostic =
+							"cannot normalize a live component baseline";
+					}
+					bBuiltNextBaseline = false;
+					break;
+				}
+
+				nextEffectiveBaseline->m_components[
+					sourceComponentIndex] =
+					std::move(baselineReflection);
+			}
+
+			if (!bBuiltNextBaseline)
+			{
+				break;
+			}
+		}
+
+		nextEffectiveBaseline->m_linkedInstanceIds =
+			reconciledInstanceIds;
+		nextEffectiveBaseline->m_gameObjectOverrides =
+			expandedPrefab->m_gameObjectOverrides;
+		nextEffectiveBaseline->m_componentOverrides =
+			expandedPrefab->m_componentOverrides;
+		nextEffectiveBaseline->m_linkedParentInstanceId =
+			root->GetParent()
+				? root->GetParent()->GetInstanceId()
+				: InstanceId::Invalid;
+		nextEffectiveBaseline->m_bLinkedInstanceRecord = true;
+		if (!bBuiltNextBaseline ||
+			!nextEffectiveBaseline->ValidateForInstantiation(
+				diagnostic))
+		{
+			res->m_loadDiagnostic =
+				"cannot update linked prefab '" +
+				link.m_sourcePrefabId.ToString() +
+				"' baseline: " +
+				diagnostic;
+			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
+			res->m_gameObjects.Clear();
+			return res;
+		}
+		nextEffectiveBaseline->m_bIsReady.store(
+			true,
+			std::memory_order_release);
+
+		expandedPrefab->m_linkedInstanceIds =
+			reconciledInstanceIds;
+		expandedPrefab->m_linkedParentInstanceId = root->GetParent()
+			? root->GetParent()->GetInstanceId()
+			: InstanceId::Invalid;
+		expandedPrefab->m_bLinkedInstanceRecord = true;
+		expandedPrefab->m_bExpandedLinkedInstanceRecord =
+			true;
+		expandedPrefab->m_detachedSupplementalInstanceIds.
+			Clear();
+		TSet<InstanceId> mappedLiveInstanceIds;
+		for (const auto& mapping :
+			expandedPrefab->m_linkedInstanceIds)
+		{
+			mappedLiveInstanceIds.Insert(
+				*mapping.m_second);
+		}
+		for (const auto& expandedGameObject :
+			expandedPrefab->m_gameObjects)
+		{
+			if (!mappedLiveInstanceIds.Contains(
+					expandedGameObject.m_instanceId))
+			{
+				expandedPrefab->
+					m_detachedSupplementalInstanceIds.Insert(
+						expandedGameObject.m_instanceId);
+			}
+		}
+		if (!expandedPrefab->ValidateForInstantiation(
+				diagnostic))
+		{
+			res->m_loadDiagnostic =
+				"cannot validate expanded linked prefab '" +
+				link.m_sourcePrefabId.ToString() +
+				"': " +
+				diagnostic;
+			SAILOR_LOG_ERROR("%s.",
+				res->m_loadDiagnostic.c_str());
+			res->m_gameObjects.Clear();
+			return res;
+		}
+		res->m_gameObjects.Add(expandedPrefab);
+
+		PendingPrefabLinkUpdate pendingUpdate;
+		pendingUpdate.m_rootInstanceId =
+			link.m_rootInstanceId;
+		pendingUpdate.m_sourceToInstanceIds =
+			std::move(reconciledInstanceIds);
+		pendingUpdate.m_effectiveBaseline =
+			std::move(nextEffectiveBaseline);
+		pendingLinkUpdates.Add(std::move(pendingUpdate));
+	}
+
+	std::string commitDiagnostic;
+	if (!CommitLinkedInstanceUpdates(
+			world,
+			pendingLinkUpdates,
+			commitDiagnostic))
+	{
+		res->m_loadDiagnostic =
+			"cannot commit linked prefab baselines: " +
+			commitDiagnostic;
+		SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
+		res->m_gameObjects.Clear();
+		return res;
+	}
+
+	res->m_bIsReady.store(true, std::memory_order_release);
 	return res;
 }
 
@@ -96,11 +1693,27 @@ WorldPrefabImporter::WorldPrefabImporter(WorldPrefabAssetInfoHandler* infoHandle
 {
 	SAILOR_PROFILE_FUNCTION();
 	m_allocator = ObjectAllocatorPtr::Make(EAllocationPolicy::SharedMemory_MultiThreaded);
-	infoHandler->Subscribe(this);
+	m_worldInfoHandler = infoHandler;
+	m_worldInfoHandler->Subscribe(this);
+
+	m_prefabInfoHandler = App::GetSubmodule<PrefabAssetInfoHandler>();
+	if (m_prefabInfoHandler)
+	{
+		m_prefabInfoHandler->Subscribe(this);
+	}
 }
 
 WorldPrefabImporter::~WorldPrefabImporter()
 {
+	if (m_worldInfoHandler)
+	{
+		m_worldInfoHandler->Unsubscribe(this);
+	}
+	if (m_prefabInfoHandler)
+	{
+		m_prefabInfoHandler->Unsubscribe(this);
+	}
+
 	for (auto& model : m_loadedWorldPrefabs)
 	{
 		model.m_second.DestroyObject(m_allocator);
@@ -126,6 +1739,13 @@ void WorldPrefabImporter::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExp
 		return;
 	}
 
+	if (dynamic_cast<PrefabAssetInfo*>(assetInfo))
+	{
+		m_loadedWorldPrefabs.Clear();
+		m_promises.Clear();
+		return;
+	}
+
 	const FileId uid = assetInfo->GetFileId();
 	m_loadedWorldPrefabs.Remove(uid);
 	m_promises.Remove(uid);
@@ -138,8 +1758,15 @@ bool WorldPrefabImporter::LoadWorld_Immediate(FileId uid, WorldPrefabPtr& outWor
 	SAILOR_PROFILE_FUNCTION();
 
 	auto task = LoadWorld(uid, outWorldPrefab);
+	if (!task)
+	{
+		return false;
+	}
+
 	task->Wait();
-	return task->GetResult().IsValid();
+	return task->GetResult().IsValid() &&
+		outWorldPrefab &&
+		outWorldPrefab->IsReady();
 }
 
 Tasks::TaskPtr<WorldPrefabPtr> WorldPrefabImporter::LoadWorld(FileId uid, WorldPrefabPtr& outWorldPrefab)
@@ -153,13 +1780,30 @@ Tasks::TaskPtr<WorldPrefabPtr> WorldPrefabImporter::LoadWorld(FileId uid, WorldP
 	// Check loaded assets
 	if (loadedWorldPrefab)
 	{
-		outWorldPrefab = loadedWorldPrefab;
-		auto res = promise ? promise : Tasks::TaskPtr<WorldPrefabPtr>::Make(outWorldPrefab);
+		if (promise && !promise->IsFinished())
+		{
+			outWorldPrefab = loadedWorldPrefab;
+			auto res = promise;
 
-		m_loadedWorldPrefabs.Unlock(uid);
-		m_promises.Unlock(uid);
+			m_loadedWorldPrefabs.Unlock(uid);
+			m_promises.Unlock(uid);
 
-		return res;
+			return res;
+		}
+
+		if (loadedWorldPrefab->IsReady())
+		{
+			outWorldPrefab = loadedWorldPrefab;
+			auto res = Tasks::TaskPtr<WorldPrefabPtr>::Make(outWorldPrefab);
+
+			m_loadedWorldPrefabs.Unlock(uid);
+			m_promises.Unlock(uid);
+
+			return res;
+		}
+
+		loadedWorldPrefab = nullptr;
+		promise = nullptr;
 	}
 
 	// There is no promise, we need to load WorldPrefab
@@ -176,11 +1820,35 @@ Tasks::TaskPtr<WorldPrefabPtr> WorldPrefabImporter::LoadWorld(FileId uid, WorldP
 				TSharedPtr<Data> res = TSharedPtr<Data>::Make();
 
 				std::string text;
-				AssetRegistry::ReadTextFile(assetInfo->GetAssetFilepath(), text);
+				std::string diagnostic;
+				bool bLoaded =
+					AssetRegistry::ReadTextFile(
+						assetInfo->GetAssetFilepath(),
+						text);
+				if (bLoaded)
+				{
+					bLoaded = External::GuardYamlExceptions(
+						[&pWorldPrefab, &text]()
+						{
+							pWorldPrefab->Deserialize(YAML::Load(text));
+						},
+						diagnostic);
+				}
 
-				YAML::Node node = YAML::Load(text);
-				pWorldPrefab->Deserialize(node);
-				pWorldPrefab->m_bIsReady = true;
+				bLoaded = bLoaded && pWorldPrefab->IsReady();
+				if (!bLoaded)
+				{
+					if (diagnostic.empty())
+					{
+						diagnostic = pWorldPrefab->GetLoadDiagnostic();
+					}
+					SAILOR_LOG_ERROR(
+						"Cannot load world '%s': %s.",
+						assetInfo->GetAssetFilepath().c_str(),
+						diagnostic.empty()
+							? "cannot read or validate the world file"
+							: diagnostic.c_str());
+				}
 
 				return res;
 

--- a/Runtime/AssetRegistry/World/WorldPrefabImporter.h
+++ b/Runtime/AssetRegistry/World/WorldPrefabImporter.h
@@ -54,7 +54,7 @@ namespace Sailor
 			PrefabPtr m_effectiveBaseline{};
 		};
 
-		static bool ReconcileLinkedInstanceIds(
+		SAILOR_API static bool ReconcileLinkedInstanceIds(
 			const PrefabPtr& expandedPrefab,
 			const PrefabPtr& sourcePrefab,
 			const TMap<InstanceId, InstanceId>& savedSourceToInstanceIds,
@@ -70,7 +70,7 @@ namespace Sailor
 			TMap<InstanceId, ReflectedData>& outComponentOverrides,
 			std::string& outDiagnostic);
 
-		static bool BuildUpdatedLinkedOverrides(
+		SAILOR_API static bool BuildUpdatedLinkedOverrides(
 			const PrefabPtr& expandedPrefab,
 			const PrefabPtr& sourcePrefab,
 			const PrefabPtr& effectiveBaseline,
@@ -79,7 +79,7 @@ namespace Sailor
 			TMap<InstanceId, ReflectedData>& outComponentOverrides,
 			std::string& outDiagnostic);
 
-		static bool CommitLinkedInstanceUpdates(
+		SAILOR_API static bool CommitLinkedInstanceUpdates(
 			WorldPtr world,
 			TVector<PendingPrefabLinkUpdate>& pendingUpdates,
 			std::string& outDiagnostic);

--- a/Runtime/AssetRegistry/World/WorldPrefabImporter.h
+++ b/Runtime/AssetRegistry/World/WorldPrefabImporter.h
@@ -3,6 +3,7 @@
 #include <string>
 #include "Containers/Vector.h"
 #include "Containers/ConcurrentMap.h"
+#include "Containers/Set.h"
 #include "Core/Submodule.h"
 #include "Memory/SharedPtr.hpp"
 #include "Memory/WeakPtr.hpp"
@@ -40,14 +41,53 @@ namespace Sailor
 
 		SAILOR_API const std::string& GetName() const { return m_name; }
 		SAILOR_API const TVector<PrefabPtr>& GetGameObjects() const { return m_gameObjects; }
+		SAILOR_API const std::string& GetLoadDiagnostic() const { return m_loadDiagnostic; }
 
 		static WorldPrefabPtr FromWorld(WorldPtr world);
 
 	protected:
 
+		struct PendingPrefabLinkUpdate final
+		{
+			InstanceId m_rootInstanceId{};
+			TMap<InstanceId, InstanceId> m_sourceToInstanceIds{};
+			PrefabPtr m_effectiveBaseline{};
+		};
+
+		static bool ReconcileLinkedInstanceIds(
+			const PrefabPtr& expandedPrefab,
+			const PrefabPtr& sourcePrefab,
+			const TMap<InstanceId, InstanceId>& savedSourceToInstanceIds,
+			TSet<InstanceId>& reservedInstanceIds,
+			TMap<InstanceId, InstanceId>& outSourceToInstanceIds,
+			std::string& outDiagnostic);
+
+		static bool BuildLinkedOverrides(
+			const PrefabPtr& expandedPrefab,
+			const PrefabPtr& sourcePrefab,
+			const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+			TMap<InstanceId, YAML::Node>& outGameObjectOverrides,
+			TMap<InstanceId, ReflectedData>& outComponentOverrides,
+			std::string& outDiagnostic);
+
+		static bool BuildUpdatedLinkedOverrides(
+			const PrefabPtr& expandedPrefab,
+			const PrefabPtr& sourcePrefab,
+			const PrefabPtr& effectiveBaseline,
+			const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+			TMap<InstanceId, YAML::Node>& outGameObjectOverrides,
+			TMap<InstanceId, ReflectedData>& outComponentOverrides,
+			std::string& outDiagnostic);
+
+		static bool CommitLinkedInstanceUpdates(
+			WorldPtr world,
+			TVector<PendingPrefabLinkUpdate>& pendingUpdates,
+			std::string& outDiagnostic);
+
 		std::atomic<bool> m_bIsReady{};
 
 		std::string m_name{};
+		std::string m_loadDiagnostic{};
 		TVector<PrefabPtr> m_gameObjects;
 
 		friend class WorldPrefabImporter;
@@ -79,5 +119,7 @@ namespace Sailor
 		TConcurrentMap<FileId, WorldPrefabPtr> m_loadedWorldPrefabs;
 
 		ObjectAllocatorPtr m_allocator;
+		WorldPrefabAssetInfoHandler* m_worldInfoHandler{};
+		PrefabAssetInfoHandler* m_prefabInfoHandler{};
 	};
 }

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -8,6 +8,7 @@
 #include "Engine/EngineLoop.h"
 #include "Engine/World.h"
 #include "Engine/InstanceId.h"
+#include "Editor/EditorViewportController.h"
 #include "Submodules/Editor.h"
 #include "Workspace/WorkspaceModuleManager.h"
 #include "Workspace/WorkspaceCacheContract.h"
@@ -74,6 +75,67 @@ namespace
 		result[value.size()] = '\0';
 		outValue[0] = result.Release();
 	}
+
+	bool TryParseViewportToolState(
+		uint32_t operationValue,
+		uint32_t spaceValue,
+		EditorViewport::ETransformOperation& outOperation,
+		EditorViewport::ETransformSpace& outSpace)
+	{
+		switch (operationValue)
+		{
+		case 1:
+			outOperation = EditorViewport::ETransformOperation::Select;
+			break;
+		case 2:
+			outOperation = EditorViewport::ETransformOperation::Translate;
+			break;
+		case 3:
+			outOperation = EditorViewport::ETransformOperation::Rotate;
+			break;
+		case 4:
+			outOperation = EditorViewport::ETransformOperation::Scale;
+			break;
+		default:
+			return false;
+		}
+
+		switch (spaceValue)
+		{
+		case 1:
+			outSpace = EditorViewport::ETransformSpace::World;
+			break;
+		case 2:
+			outSpace = EditorViewport::ETransformSpace::Local;
+			break;
+		default:
+			return false;
+		}
+
+		return true;
+	}
+
+	uint32_t ToInteropOperation(EditorViewport::ETransformOperation operation)
+	{
+		switch (operation)
+		{
+		case EditorViewport::ETransformOperation::Select: return 1;
+		case EditorViewport::ETransformOperation::Translate: return 2;
+		case EditorViewport::ETransformOperation::Rotate: return 3;
+		case EditorViewport::ETransformOperation::Scale: return 4;
+		default: return 0;
+		}
+	}
+
+	uint32_t ToInteropSpace(EditorViewport::ETransformSpace space)
+	{
+		switch (space)
+		{
+		case EditorViewport::ETransformSpace::World: return 1;
+		case EditorViewport::ETransformSpace::Local: return 2;
+		default: return 0;
+		}
+	}
 }
 
 uint32_t App::PullEditorMessages(char** messages, uint32_t num)
@@ -132,6 +194,39 @@ uint32_t App::PullEditorViewportEvents(char** events, uint32_t num)
 			}
 
 			return numEvents;
+		});
+}
+
+bool App::ResolveEditorViewportDropPosition(
+	float normalizedX,
+	float normalizedY,
+	float& outWorldX,
+	float& outWorldY,
+	float& outWorldZ)
+{
+	outWorldX = 0.0f;
+	outWorldY = 0.0f;
+	outWorldZ = 0.0f;
+
+	return ExecuteOnEngineMainThread<bool>(
+		false,
+		[normalizedX, normalizedY, &outWorldX, &outWorldY, &outWorldZ]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			glm::vec3 worldPosition{};
+			if (!editor ||
+				!editor->ResolveViewportDropPosition(
+					normalizedX,
+					normalizedY,
+					worldPosition))
+			{
+				return false;
+			}
+
+			outWorldX = worldPosition.x;
+			outWorldY = worldPosition.y;
+			outWorldZ = worldPosition.z;
+			return true;
 		});
 }
 
@@ -590,6 +685,78 @@ bool App::RemoveEditorComponent(const char* strInstanceId)
 		});
 }
 
+bool App::CreateEditorModelGameObject(
+	const char* strModelFileId,
+	const char* strName,
+	const char* strParentInstanceId,
+	bool bHasWorldPosition,
+	float worldX,
+	float worldY,
+	float worldZ,
+	char** outInstanceId)
+{
+	if (!strModelFileId ||
+		!strName ||
+		strName[0] == '\0' ||
+		!outInstanceId)
+	{
+		return false;
+	}
+
+	outInstanceId[0] = nullptr;
+	const std::string modelFileIdValue = strModelFileId;
+	const std::string name = strName;
+	const std::string parentInstanceIdValue =
+		strParentInstanceId ? strParentInstanceId : "";
+	return ExecuteOnEngineMainThread<bool>(
+		false,
+		[modelFileIdValue,
+			name,
+			parentInstanceIdValue,
+			bHasWorldPosition,
+			worldX,
+			worldY,
+			worldZ,
+			outInstanceId]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
+
+			FileId modelFileId{};
+			modelFileId.Deserialize(YAML::Node(modelFileIdValue));
+			if (!modelFileId)
+			{
+				return false;
+			}
+
+			InstanceId parentInstanceId{};
+			if (!TryParseOptionalParent(
+					parentInstanceIdValue,
+					parentInstanceId))
+			{
+				return false;
+			}
+
+			const glm::vec3 worldPosition(worldX, worldY, worldZ);
+			InstanceId createdInstanceId{};
+			if (!editor->CreateModelGameObject(
+					modelFileId,
+					name,
+					parentInstanceId,
+					bHasWorldPosition ? &worldPosition : nullptr,
+					createdInstanceId))
+			{
+				return false;
+			}
+
+			SetInteropString(createdInstanceId.ToString(), outInstanceId);
+			return true;
+		});
+}
+
 bool App::InstantiateEditorPrefab(const char* strFileId, const char* strParentInstanceId)
 {
 	if (!strFileId)
@@ -619,7 +786,85 @@ bool App::InstantiateEditorPrefab(const char* strFileId, const char* strParentIn
 		});
 }
 
-bool App::InstantiateEditorPrefabFromYaml(const char* strPrefabYaml, const char* strParentInstanceId)
+bool App::InstantiateEditorPrefabInstance(
+	const char* strFileId,
+	const char* strParentInstanceId,
+	bool bHasWorldPosition,
+	float worldX,
+	float worldY,
+	float worldZ,
+	char** outInstanceId)
+{
+	if (!strFileId || !outInstanceId)
+	{
+		return false;
+	}
+
+	outInstanceId[0] = nullptr;
+	const std::string fileIdValue = strFileId;
+	const std::string parentInstanceIdValue =
+		strParentInstanceId ? strParentInstanceId : "";
+	return ExecuteOnEngineMainThread<bool>(
+		false,
+		[fileIdValue,
+			parentInstanceIdValue,
+			bHasWorldPosition,
+			worldX,
+			worldY,
+			worldZ,
+			outInstanceId]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
+
+			FileId fileId{};
+			fileId.Deserialize(YAML::Node(fileIdValue));
+			if (!fileId)
+			{
+				return false;
+			}
+
+			InstanceId parentInstanceId{};
+			if (!TryParseOptionalParent(
+					parentInstanceIdValue,
+					parentInstanceId))
+			{
+				return false;
+			}
+
+			const glm::vec3 worldPosition(worldX, worldY, worldZ);
+			InstanceId createdInstanceId{};
+			if (!editor->InstantiatePrefab(
+					fileId,
+					parentInstanceId,
+					bHasWorldPosition ? &worldPosition : nullptr,
+					createdInstanceId))
+			{
+				return false;
+			}
+
+			SetInteropString(createdInstanceId.ToString(), outInstanceId);
+			return true;
+		});
+}
+
+bool App::InstantiateEditorPrefabFromYaml(
+	const char* strPrefabYaml,
+	const char* strParentInstanceId)
+{
+	return InstantiateEditorPrefabFromYaml(
+		strPrefabYaml,
+		strParentInstanceId,
+		false);
+}
+
+bool App::InstantiateEditorPrefabFromYaml(
+	const char* strPrefabYaml,
+	const char* strParentInstanceId,
+	bool bStrictInstanceIds)
 {
 	if (!strPrefabYaml || strPrefabYaml[0] == '\0')
 	{
@@ -628,7 +873,9 @@ bool App::InstantiateEditorPrefabFromYaml(const char* strPrefabYaml, const char*
 
 	const std::string prefabYaml = strPrefabYaml;
 	const std::string parentInstanceIdValue = strParentInstanceId ? strParentInstanceId : "";
-	return ExecuteOnEngineMainThread<bool>(false, [prefabYaml, parentInstanceIdValue]()
+	return ExecuteOnEngineMainThread<bool>(
+		false,
+		[prefabYaml, parentInstanceIdValue, bStrictInstanceIds]()
 		{
 			auto editor = GetSubmodule<Editor>();
 			auto prefabImporter = GetSubmodule<PrefabImporter>();
@@ -658,7 +905,181 @@ bool App::InstantiateEditorPrefabFromYaml(const char* strPrefabYaml, const char*
 			}
 
 			prefab->Deserialize(prefabNode);
-			return editor->InstantiatePrefab(prefab, parentInstanceId);
+			if (prefab->IsLinkedPrefabSnapshotRecord())
+			{
+				if (!bStrictInstanceIds ||
+					prefab->GetLinkedParentInstanceId() !=
+						parentInstanceId)
+				{
+					return false;
+				}
+
+				std::string diagnostic;
+				if (!prefab->ValidateForInstantiation(
+						diagnostic))
+				{
+					return false;
+				}
+
+				PrefabPtr sourcePrefab;
+				const FileId& sourcePrefabId =
+					prefab->GetLinkedSnapshotSourceFileId();
+				if (!prefabImporter->LoadPrefab_Immediate(
+						sourcePrefabId,
+						sourcePrefab) ||
+					!sourcePrefab ||
+					!sourcePrefab->IsReady())
+				{
+					return false;
+				}
+
+				PrefabPtr linkedPrefab =
+					prefabImporter->Create(
+						sourcePrefabId);
+				if (!linkedPrefab ||
+					!linkedPrefab->ConfigureLinkedInstance(
+						sourcePrefab,
+						prefab->GetLinkedInstanceIds(),
+						parentInstanceId,
+						prefab->GetLinkedGameObjectOverrides(),
+						prefab->GetLinkedComponentOverrides(),
+						diagnostic) ||
+					!linkedPrefab->AppendDetachedSupplementalHierarchy(
+						prefab,
+						diagnostic))
+				{
+					return false;
+				}
+
+				prefab = std::move(linkedPrefab);
+			}
+
+			return editor->InstantiatePrefab(
+				prefab,
+				parentInstanceId,
+				bStrictInstanceIds);
+		});
+}
+
+bool App::FocusEditorCamera(const char* strInstanceId)
+{
+	if (!strInstanceId)
+	{
+		return false;
+	}
+
+	const std::string instanceIdValue = strInstanceId;
+	return ExecuteOnEngineMainThread<bool>(
+		false,
+		[instanceIdValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
+
+			InstanceId instanceId{};
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+			return instanceId.IsGameObjectId() &&
+				editor->FocusEditorCamera(instanceId);
+		});
+}
+
+bool App::SetEditorPrefabLink(
+	const char* strInstanceId,
+	const char* strFileId)
+{
+	if (!strInstanceId || !strFileId)
+	{
+		return false;
+	}
+
+	const std::string instanceIdValue = strInstanceId;
+	const std::string fileIdValue = strFileId;
+	return ExecuteOnEngineMainThread<bool>(
+		false,
+		[instanceIdValue, fileIdValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
+
+			InstanceId instanceId{};
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+			FileId fileId{};
+			fileId.Deserialize(YAML::Node(fileIdValue));
+			return editor->SetPrefabLink(instanceId, fileId);
+		});
+}
+
+bool App::BreakEditorPrefabLink(const char* strInstanceId)
+{
+	if (!strInstanceId)
+	{
+		return false;
+	}
+
+	const std::string instanceIdValue = strInstanceId;
+	return ExecuteOnEngineMainThread<bool>(
+		false,
+		[instanceIdValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
+
+			InstanceId instanceId{};
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+			return editor->BreakPrefabLink(instanceId);
+		});
+}
+
+bool App::SetEditorViewportToolState(uint32_t operation, uint32_t space)
+{
+	return ExecuteOnEngineMainThread<bool>(
+		false,
+		[operation, space]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			EditorViewport::ETransformOperation parsedOperation{};
+			EditorViewport::ETransformSpace parsedSpace{};
+			return editor &&
+				TryParseViewportToolState(
+					operation,
+					space,
+					parsedOperation,
+					parsedSpace) &&
+				editor->SetViewportToolState(parsedOperation, parsedSpace);
+		});
+}
+
+bool App::GetEditorViewportToolState(
+	uint32_t& outOperation,
+	uint32_t& outSpace)
+{
+	outOperation = 0;
+	outSpace = 0;
+	return ExecuteOnEngineMainThread<bool>(
+		false,
+		[&outOperation, &outSpace]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
+
+			EditorViewport::ETransformOperation operation{};
+			EditorViewport::ETransformSpace space{};
+			editor->GetViewportToolState(operation, space);
+			outOperation = ToInteropOperation(operation);
+			outSpace = ToInteropSpace(space);
+			return outOperation != 0 && outSpace != 0;
 		});
 }
 

--- a/Runtime/Editor/EditorViewportController.cpp
+++ b/Runtime/Editor/EditorViewportController.cpp
@@ -1,6 +1,7 @@
 #include "Editor/EditorViewportController.h"
 
 #include "AssetRegistry/Model/ModelImporter.h"
+#include "Components/CameraComponent.h"
 #include "Components/EditorComponent.h"
 #include "Components/MeshRendererComponent.h"
 #include "Core/YamlSerializable.h"
@@ -25,6 +26,10 @@ namespace
 	constexpr float c_clickSlop = 4.0f;
 	constexpr float c_originFallbackExtent = 25.0f;
 	constexpr float c_matrixTolerance = 0.001f;
+	constexpr float c_dropFallbackDistance = 1000.0f;
+	constexpr float c_dropPlaneEpsilon = 0.000001f;
+	constexpr float c_cameraFramePadding = 1.2f;
+	constexpr float c_minimumCameraFrameRadius = 1.0f;
 
 	bool IsFiniteMatrix(const glm::mat4& matrix)
 	{
@@ -127,22 +132,29 @@ namespace
 		}
 	}
 
-	void DrawOperationButton(const char* label, ETransformOperation value, ETransformOperation& operation)
+	bool IsValidTransformOperation(ETransformOperation operation)
 	{
-		const bool bSelected = operation == value;
-		if (bSelected)
+		switch (operation)
 		{
-			ImGui::PushStyleColor(ImGuiCol_Button, ImVec4(0.20f, 0.45f, 0.75f, 1.0f));
+		case ETransformOperation::Select:
+		case ETransformOperation::Translate:
+		case ETransformOperation::Rotate:
+		case ETransformOperation::Scale:
+			return true;
+		default:
+			return false;
 		}
+	}
 
-		if (ImGui::Button(label))
+	bool IsValidTransformSpace(ETransformSpace space)
+	{
+		switch (space)
 		{
-			operation = value;
-		}
-
-		if (bSelected)
-		{
-			ImGui::PopStyleColor();
+		case ETransformSpace::World:
+		case ETransformSpace::Local:
+			return true;
+		default:
+			return false;
 		}
 	}
 
@@ -241,6 +253,108 @@ bool EditorViewport::TryPickNearest(
 	}
 
 	return outInstanceId.IsGameObjectId();
+}
+
+bool EditorViewport::TryResolveDropPosition(
+	const Math::Ray& ray,
+	const TVector<PickCandidate>& candidates,
+	glm::vec3& outPosition)
+{
+	outPosition = {};
+	const float directionLength = glm::length(ray.GetDirection());
+	if (!Math::AllFinite(ray.GetOrigin()) ||
+		!Math::AllFinite(ray.GetDirection()) ||
+		!std::isfinite(directionLength) ||
+		directionLength <= std::numeric_limits<float>::epsilon())
+	{
+		return false;
+	}
+
+	InstanceId pickedId{};
+	float distance = std::numeric_limits<float>::max();
+	if (TryPickNearest(ray, candidates, pickedId, distance))
+	{
+		outPosition = ray.GetOrigin() + ray.GetDirection() * distance;
+		return Math::AllFinite(outPosition);
+	}
+
+	if (std::abs(ray.GetDirection().y) > c_dropPlaneEpsilon)
+	{
+		const float planeDistance = -ray.GetOrigin().y / ray.GetDirection().y;
+		if (std::isfinite(planeDistance) && planeDistance >= 0.0f)
+		{
+			outPosition = ray.GetOrigin() + ray.GetDirection() * planeDistance;
+			return Math::AllFinite(outPosition);
+		}
+	}
+
+	outPosition = ray.GetOrigin() + ray.GetDirection() * c_dropFallbackDistance;
+	return Math::AllFinite(outPosition);
+}
+
+bool EditorViewport::TryCalculateFramedCameraPosition(
+	const Math::AABB& bounds,
+	const Math::Transform& cameraWorldTransform,
+	float verticalFovDegrees,
+	float aspect,
+	float zNear,
+	glm::vec3& outPosition)
+{
+	if (!bounds.IsValid() ||
+		!std::isfinite(verticalFovDegrees) ||
+		verticalFovDegrees <= 0.0f ||
+		verticalFovDegrees >= 179.0f ||
+		!std::isfinite(aspect) ||
+		aspect <= 0.0f ||
+		!std::isfinite(zNear) ||
+		zNear < 0.0f)
+	{
+		return false;
+	}
+
+	const glm::vec4 cameraRotation(
+		cameraWorldTransform.m_rotation.x,
+		cameraWorldTransform.m_rotation.y,
+		cameraWorldTransform.m_rotation.z,
+		cameraWorldTransform.m_rotation.w);
+	const glm::vec3 forward = cameraWorldTransform.GetForward();
+	const float forwardLength = glm::length(forward);
+	if (!Math::AllFinite(cameraWorldTransform.m_position) ||
+		!Math::AllFinite(cameraRotation) ||
+		!Math::AllFinite(forward) ||
+		!std::isfinite(forwardLength) ||
+		forwardLength <= std::numeric_limits<float>::epsilon())
+	{
+		return false;
+	}
+
+	const float verticalHalfFov = glm::radians(verticalFovDegrees) * 0.5f;
+	const float horizontalHalfFov = std::atan(std::tan(verticalHalfFov) * aspect);
+	const float limitingHalfFov = std::min(verticalHalfFov, horizontalHalfFov);
+	const float sineHalfFov = std::sin(limitingHalfFov);
+	if (!std::isfinite(sineHalfFov) ||
+		sineHalfFov <= std::numeric_limits<float>::epsilon())
+	{
+		return false;
+	}
+
+	const float radius = std::max(
+		glm::length(bounds.GetExtents()),
+		c_minimumCameraFrameRadius);
+	const float distance = std::max(
+		radius * c_cameraFramePadding / sineHalfFov,
+		radius + zNear * 2.0f);
+	const glm::vec3 position =
+		bounds.GetCenter() - (forward / forwardLength) * distance;
+	if (!std::isfinite(radius) ||
+		!std::isfinite(distance) ||
+		!Math::AllFinite(position))
+	{
+		return false;
+	}
+
+	outPosition = position;
+	return true;
 }
 
 bool EditorViewport::CanBeginSelectionGesture(
@@ -381,8 +495,6 @@ void EditorViewportController::Tick(World& world)
 		return;
 	}
 
-	DrawToolbar();
-
 	const auto selectedObject = ResolveSelectedObject(world);
 	TickTransformGizmo(world, selectedObject);
 	if (!m_gizmoSubmittedThisFrame)
@@ -437,6 +549,222 @@ bool EditorViewportController::PullEvent(std::string& outEvent)
 	return true;
 }
 
+bool EditorViewportController::QueueAssetDropEvent(
+	const std::string& fileId,
+	float normalizedX,
+	float normalizedY)
+{
+	if (fileId.empty() ||
+		!std::isfinite(normalizedX) ||
+		!std::isfinite(normalizedY) ||
+		normalizedX < 0.0f ||
+		normalizedX > 1.0f ||
+		normalizedY < 0.0f ||
+		normalizedY > 1.0f)
+	{
+		return false;
+	}
+
+	YAML::Node event{};
+	event["kind"] = "assetDrop";
+	event["revision"] = ++m_eventRevision;
+	event["managedMutationRevision"] =
+		m_managedSelectionMutationRevision;
+	event["fileId"] = fileId;
+	event["normalizedX"] = normalizedX;
+	event["normalizedY"] = normalizedY;
+	m_pendingEvents.Add(YAML::Dump(event));
+	return true;
+}
+
+bool EditorViewportController::QueueToolShortcutEvent(uint32_t keyCode)
+{
+	if (keyCode != 'Q' &&
+		keyCode != 'W' &&
+		keyCode != 'E' &&
+		keyCode != 'R' &&
+		keyCode != 'T')
+	{
+		return false;
+	}
+
+	YAML::Node event{};
+	event["kind"] = "toolShortcut";
+	event["revision"] = ++m_eventRevision;
+	event["managedMutationRevision"] =
+		m_managedSelectionMutationRevision;
+	event["keyCode"] = keyCode;
+	m_pendingEvents.Add(YAML::Dump(event));
+	return true;
+}
+
+bool EditorViewportController::TryResolveDropPosition(
+	World& world,
+	float normalizedX,
+	float normalizedY,
+	glm::vec3& outPosition) const
+{
+	outPosition = {};
+	if (!std::isfinite(normalizedX) ||
+		!std::isfinite(normalizedY) ||
+		normalizedX < 0.0f ||
+		normalizedX > 1.0f ||
+		normalizedY < 0.0f ||
+		normalizedY > 1.0f)
+	{
+		return false;
+	}
+
+	Math::Transform cameraTransform{};
+	CameraData cameraData{};
+	auto* cameraEcs = world.GetECS<CameraECS>();
+	Math::Ray ray{};
+	if (!cameraEcs ||
+		!cameraEcs->TryGetActiveCamera(cameraTransform, cameraData) ||
+		!BuildWorldRay(
+			normalizedX,
+			normalizedY,
+			1.0f,
+			1.0f,
+			cameraData.GetViewMatrix(),
+			cameraData.GetProjectionMatrix(),
+			ray))
+	{
+		return false;
+	}
+
+	TVector<PickCandidate> candidates{};
+	for (const auto& gameObject : world.GetGameObjects())
+	{
+		Math::AABB bounds{};
+		bool bUsesMeshBounds = false;
+		if (ResolveGameObjectBounds(gameObject, bounds, bUsesMeshBounds) &&
+			bUsesMeshBounds)
+		{
+			candidates.Add(PickCandidate{ gameObject->GetInstanceId(), bounds });
+		}
+	}
+
+	return EditorViewport::TryResolveDropPosition(
+		ray,
+		candidates,
+		outPosition);
+}
+
+bool EditorViewportController::FocusCameraOnObject(
+	World& world,
+	const InstanceId& instanceId)
+{
+	if (!instanceId.IsGameObjectId())
+	{
+		return false;
+	}
+
+	const auto targetObject =
+		world.GetObjectByInstanceId(instanceId).DynamicCast<GameObject>();
+	Math::AABB targetBounds{};
+	bool bUsesMeshBounds = false;
+	if (!targetObject ||
+		!ResolveGameObjectBounds(
+			targetObject,
+			targetBounds,
+			bUsesMeshBounds))
+	{
+		return false;
+	}
+
+	if (!bUsesMeshBounds)
+	{
+		targetBounds = Math::AABB(
+			targetBounds.GetCenter(),
+			glm::vec3(c_minimumCameraFrameRadius));
+	}
+
+	TObjectPtr<GameObject> cameraObject{};
+	TObjectPtr<CameraComponent> cameraComponent{};
+	for (const auto& gameObject : world.GetGameObjects())
+	{
+		if (!gameObject || !gameObject->GetComponent<EditorComponent>())
+		{
+			continue;
+		}
+
+		auto candidateCamera = gameObject->GetComponent<CameraComponent>();
+		if (candidateCamera)
+		{
+			cameraObject = gameObject;
+			cameraComponent = candidateCamera;
+			break;
+		}
+	}
+
+	if (!cameraObject || !cameraComponent)
+	{
+		return false;
+	}
+
+	const glm::mat4 cameraWorldMatrix =
+		CalculateCurrentWorldMatrix(cameraObject);
+	if (!IsFiniteMatrix(cameraWorldMatrix))
+	{
+		return false;
+	}
+
+	Math::Transform cameraWorldTransform =
+		Math::Transform::FromMatrix(cameraWorldMatrix);
+	glm::vec3 framedPosition{};
+	if (!TryCalculateFramedCameraPosition(
+			targetBounds,
+			cameraWorldTransform,
+			cameraComponent->GetFov(),
+			cameraComponent->GetAspect(),
+			cameraComponent->GetZNear(),
+			framedPosition))
+	{
+		return false;
+	}
+
+	const auto cameraParent = cameraObject->GetParent();
+	glm::vec4 localPosition(framedPosition, 1.0f);
+	if (cameraParent)
+	{
+		glm::mat4 inverseParentWorldMatrix{};
+		if (!TryInvertTransformMatrix(
+				CalculateCurrentWorldMatrix(cameraParent),
+				inverseParentWorldMatrix))
+		{
+			return false;
+		}
+
+		localPosition = inverseParentWorldMatrix * localPosition;
+		if (!Math::AllFinite(localPosition) ||
+			std::abs(localPosition.w) <= std::numeric_limits<float>::epsilon())
+		{
+			return false;
+		}
+		localPosition /= localPosition.w;
+	}
+
+	cameraObject->GetTransformComponent().SetPosition(glm::vec3(localPosition));
+	return true;
+}
+
+bool EditorViewportController::SetTransformToolState(
+	ETransformOperation operation,
+	ETransformSpace space)
+{
+	if (m_wasUsingGizmo ||
+		!IsValidTransformOperation(operation) ||
+		!IsValidTransformSpace(space))
+	{
+		return false;
+	}
+
+	m_operation = operation;
+	m_space = space;
+	return true;
+}
+
 TObjectPtr<GameObject> EditorViewportController::ResolveSelectedObject(World& world) const
 {
 	for (auto gameObject : world.GetGameObjects())
@@ -450,59 +778,6 @@ TObjectPtr<GameObject> EditorViewportController::ResolveSelectedObject(World& wo
 	}
 
 	return {};
-}
-
-void EditorViewportController::DrawToolbar()
-{
-	ImGuiIO& io = ImGui::GetIO();
-	const bool bCanChangeTool = !m_wasUsingGizmo;
-	const bool bCanUseHotkeys = bCanChangeTool && !io.WantTextInput && !io.MouseDown[1];
-	if (bCanUseHotkeys)
-	{
-		if (ImGui::IsKeyPressed(ImGuiKey_Q, false)) m_operation = ETransformOperation::Select;
-		if (ImGui::IsKeyPressed(ImGuiKey_W, false)) m_operation = ETransformOperation::Translate;
-		if (ImGui::IsKeyPressed(ImGuiKey_E, false)) m_operation = ETransformOperation::Rotate;
-		if (ImGui::IsKeyPressed(ImGuiKey_R, false)) m_operation = ETransformOperation::Scale;
-		if (ImGui::IsKeyPressed(ImGuiKey_T, false))
-		{
-			m_space = m_space == ETransformSpace::World ? ETransformSpace::Local : ETransformSpace::World;
-		}
-	}
-
-	ImGui::SetNextWindowPos(ImVec2(12.0f, 12.0f), ImGuiCond_Always);
-	ImGui::SetNextWindowBgAlpha(0.85f);
-	constexpr ImGuiWindowFlags flags =
-		ImGuiWindowFlags_NoTitleBar |
-		ImGuiWindowFlags_NoResize |
-		ImGuiWindowFlags_NoMove |
-		ImGuiWindowFlags_NoScrollbar |
-		ImGuiWindowFlags_NoSavedSettings |
-		ImGuiWindowFlags_AlwaysAutoResize |
-		ImGuiWindowFlags_NoFocusOnAppearing |
-		ImGuiWindowFlags_NoNav;
-
-	if (ImGui::Begin("Scene transform##SailorSceneTransform", nullptr, flags))
-	{
-		ImGui::BeginDisabled(!bCanChangeTool);
-		DrawOperationButton("Q Select", ETransformOperation::Select, m_operation);
-		ImGui::SameLine();
-		DrawOperationButton("W Move", ETransformOperation::Translate, m_operation);
-		ImGui::SameLine();
-		DrawOperationButton("E Rotate", ETransformOperation::Rotate, m_operation);
-		ImGui::SameLine();
-		DrawOperationButton("R Scale", ETransformOperation::Scale, m_operation);
-		ImGui::SameLine();
-		if (ImGui::Button(m_space == ETransformSpace::World ? "World (T)" : "Local (T)"))
-		{
-			m_space = m_space == ETransformSpace::World ? ETransformSpace::Local : ETransformSpace::World;
-		}
-		ImGui::EndDisabled();
-		if (ImGui::IsItemHovered())
-		{
-			ImGui::SetTooltip("Hold Ctrl while dragging to snap");
-		}
-	}
-	ImGui::End();
 }
 
 void EditorViewportController::CompleteActiveTransform(World& world)

--- a/Runtime/Editor/EditorViewportController.h
+++ b/Runtime/Editor/EditorViewportController.h
@@ -50,6 +50,19 @@ namespace Sailor
 			InstanceId& outInstanceId,
 			float& outDistance);
 
+		SAILOR_API bool TryResolveDropPosition(
+			const Math::Ray& ray,
+			const TVector<PickCandidate>& candidates,
+			glm::vec3& outPosition);
+
+		SAILOR_API bool TryCalculateFramedCameraPosition(
+			const Math::AABB& bounds,
+			const Math::Transform& cameraWorldTransform,
+			float verticalFovDegrees,
+			float aspect,
+			float zNear,
+			glm::vec3& outPosition);
+
 		SAILOR_API bool TryConvertWorldToLocalTransform(
 			const glm::mat4& worldMatrix,
 			const glm::mat4* parentWorldMatrix,
@@ -82,19 +95,34 @@ namespace Sailor
 			SAILOR_API void CancelPointerInteraction();
 			SAILOR_API void CancelInteraction(World& world);
 			SAILOR_API bool PullEvent(std::string& outEvent);
+			SAILOR_API bool QueueAssetDropEvent(
+				const std::string& fileId,
+				float normalizedX,
+				float normalizedY);
+			SAILOR_API bool QueueToolShortcutEvent(uint32_t keyCode);
+			SAILOR_API bool TryResolveDropPosition(
+				World& world,
+				float normalizedX,
+				float normalizedY,
+				glm::vec3& outPosition) const;
+			SAILOR_API bool FocusCameraOnObject(
+				World& world,
+				const InstanceId& instanceId);
+			SAILOR_API bool SetTransformToolState(
+				ETransformOperation operation,
+				ETransformSpace space);
 			void SetManagedMutationRevisions(uint64_t selectionRevision, uint64_t selectedObjectRevision)
 			{
 				m_managedSelectionMutationRevision = selectionRevision;
 				m_selectedObjectMutationRevision = selectedObjectRevision;
 			}
 
-			ETransformOperation GetOperation() const { return m_operation; }
-			ETransformSpace GetSpace() const { return m_space; }
+			SAILOR_API ETransformOperation GetOperation() const { return m_operation; }
+			SAILOR_API ETransformSpace GetSpace() const { return m_space; }
 
 		private:
 			TObjectPtr<GameObject> ResolveSelectedObject(World& world) const;
 			void CompleteActiveTransform(World& world);
-			void DrawToolbar();
 			void TickTransformGizmo(World& world, TObjectPtr<GameObject> selectedObject);
 			void TickSelection(World& world);
 			void QueueSelectionEvent(const InstanceId& selectedInstanceId);

--- a/Runtime/Engine/GameObject.cpp
+++ b/Runtime/Engine/GameObject.cpp
@@ -3,6 +3,7 @@
 #include "Components/Component.h"
 #include "ECS/TransformECS.h"
 #include "Editor/EditorViewportController.h"
+#include "Core/LogMacros.h"
 #include <algorithm>
 
 using namespace Sailor;
@@ -30,6 +31,13 @@ TransformComponent& GameObject::GetTransformComponent()
 
 void GameObject::SetParent(GameObjectPtr parent)
 {
+	SetParentInternal(parent, false);
+}
+
+void GameObject::SetParentInternal(
+	GameObjectPtr parent,
+	bool bAllowLinkedParent)
+{
 	for (auto current = parent; current.IsValid(); current = current->m_parent)
 	{
 		if (current == m_self)
@@ -40,6 +48,20 @@ void GameObject::SetParent(GameObjectPtr parent)
 
 	if (m_parent == parent)
 	{
+		return;
+	}
+
+	std::string diagnostic;
+	if (!bAllowLinkedParent &&
+		!m_pWorld->CanReparentPrefabObject(
+			m_instanceId,
+			parent ? parent->GetInstanceId() : InstanceId::Invalid,
+			&diagnostic))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot reparent game object '%s': %s.",
+			m_instanceId.ToString().c_str(),
+			diagnostic.c_str());
 		return;
 	}
 
@@ -64,6 +86,10 @@ void GameObject::SetParent(GameObjectPtr parent)
 bool GameObject::RemoveComponent(ComponentPtr component)
 {
 	check(component);
+	if (!m_pWorld->CanModifyPrefabStructure(m_instanceId))
+	{
+		return false;
+	}
 
 	if (m_components.RemoveFirst(component))
 	{
@@ -78,6 +104,11 @@ bool GameObject::RemoveComponent(ComponentPtr component)
 
 void GameObject::RemoveAllComponents()
 {
+	if (!m_pWorld->CanModifyPrefabStructure(m_instanceId))
+	{
+		return;
+	}
+
 	for (auto& el : m_components)
 	{
 		m_pWorld->RemovePendingDependencyResolutions(el);

--- a/Runtime/Engine/GameObject.h
+++ b/Runtime/Engine/GameObject.h
@@ -33,6 +33,11 @@ namespace Sailor
 		SAILOR_API TObjectPtr<TComponent> AddComponent(TArgs&& ... args) requires IsBaseOf<Component, TComponent>
 		{
 			check(m_pWorld);
+			if (!m_pWorld->CanModifyPrefabStructure(m_instanceId))
+			{
+				return {};
+			}
+
 			auto newObject = TObjectPtr<TComponent>::Make(m_pWorld->GetAllocator(), std::forward<TArgs>(args) ...);
 
 			newObject->m_instanceId = InstanceId::GenerateNewComponentId(m_instanceId);
@@ -56,6 +61,10 @@ namespace Sailor
 			check(m_pWorld);
 			check(!component->m_bBeginPlayCalled);
 			check(!component->GetOwner().IsValid());
+			if (!m_pWorld->CanModifyPrefabStructure(m_instanceId))
+			{
+				return {};
+			}
 
 			if (preferredInstanceId)
 			{
@@ -138,6 +147,10 @@ namespace Sailor
 		SAILOR_API ComponentPtr GetComponent(uint32_t index) { return m_components[index]; }
 
 	protected:
+
+		void SetParentInternal(
+			GameObjectPtr parent,
+			bool bAllowLinkedParent);
 
 		size_t m_transformHandle = (size_t)(-1);
 

--- a/Runtime/Engine/World.cpp
+++ b/Runtime/Engine/World.cpp
@@ -2,6 +2,7 @@
 #include "Engine/GameObject.h"
 #include "Engine/EngineLoop.h"
 #include "AssetRegistry/Prefab/PrefabImporter.h"
+#include "AssetRegistry/World/WorldPrefabImporter.h"
 #include "Containers/Set.h"
 #include "Core/LogMacros.h"
 #include "YamlExceptionBoundary.h"
@@ -108,6 +109,563 @@ ObjectPtr World::GetObjectByInstanceId(const InstanceId& instanceId) const
 	return ObjectPtr();
 }
 
+bool World::TryGetPrefabInstance(
+	const InstanceId& objectInstanceId,
+	const PrefabInstanceLink*& outLink) const
+{
+	outLink = nullptr;
+	if (!m_prefabInstanceRootsByObject.ContainsKey(objectInstanceId))
+	{
+		return false;
+	}
+
+	const InstanceId& rootInstanceId = m_prefabInstanceRootsByObject[objectInstanceId];
+	if (!m_prefabInstances.ContainsKey(rootInstanceId))
+	{
+		return false;
+	}
+
+	outLink = &m_prefabInstances[rootInstanceId];
+	return true;
+}
+
+bool World::IsPrefabLinked(const InstanceId& objectInstanceId) const
+{
+	return m_prefabInstanceRootsByObject.ContainsKey(objectInstanceId);
+}
+
+bool World::IsPrefabInstanceRoot(const InstanceId& objectInstanceId) const
+{
+	return m_prefabInstances.ContainsKey(objectInstanceId);
+}
+
+bool World::RegisterPrefabInstance(
+	GameObjectPtr root,
+	const FileId& sourcePrefabId,
+	const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+	const PrefabPtr& effectiveBaseline,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	if (!root ||
+		!sourcePrefabId ||
+		sourceToInstanceIds.IsEmpty() ||
+		!effectiveBaseline ||
+		effectiveBaseline->GetFileId() != sourcePrefabId)
+	{
+		outDiagnostic = "the prefab link has no root, source asset, instance mapping, or effective baseline";
+		return false;
+	}
+
+	if (!effectiveBaseline->ValidateForInstantiation(outDiagnostic))
+	{
+		outDiagnostic = "the prefab link has an invalid effective baseline: " +
+			outDiagnostic;
+		return false;
+	}
+
+	if (root->GetWorld() != this ||
+		!m_objectsMap.ContainsKey(root->GetInstanceId()) ||
+		GetObjectByInstanceId(root->GetInstanceId()).DynamicCast<GameObject>() !=
+			root)
+	{
+		outDiagnostic = "the prefab instance root does not belong to this world";
+		return false;
+	}
+
+	if (m_prefabInstances.ContainsKey(root->GetInstanceId()))
+	{
+		outDiagnostic = "the prefab instance root is already linked";
+		return false;
+	}
+
+	TSet<InstanceId> liveInstanceIds;
+	for (const auto& mapping : sourceToInstanceIds)
+	{
+		const InstanceId& liveInstanceId = *mapping.m_second;
+		if (!mapping.m_first.IsGameObjectId() ||
+			!liveInstanceId.IsGameObjectId() ||
+			!liveInstanceIds.Insert(liveInstanceId) ||
+			!m_objectsMap.ContainsKey(liveInstanceId))
+		{
+			outDiagnostic = "the prefab link contains an invalid, duplicate, or missing game object";
+			return false;
+		}
+
+		for (GameObjectPtr current = GetObjectByInstanceId(liveInstanceId).DynamicCast<GameObject>();
+			current;
+			current = current->GetParent())
+		{
+			if (current == root)
+			{
+				break;
+			}
+
+			if (!current->GetParent())
+			{
+				outDiagnostic = "a mapped game object is outside the prefab instance hierarchy";
+				return false;
+			}
+		}
+
+		if (m_prefabInstanceRootsByObject.ContainsKey(liveInstanceId))
+		{
+			outDiagnostic = "a mapped game object already belongs to another linked prefab instance";
+			return false;
+		}
+	}
+
+	if (!liveInstanceIds.Contains(root->GetInstanceId()))
+	{
+		outDiagnostic = "the prefab instance mapping does not contain its live root";
+		return false;
+	}
+
+	PrefabInstanceLink link;
+	link.m_sourcePrefabId = sourcePrefabId;
+	link.m_rootInstanceId = root->GetInstanceId();
+	link.m_sourceToInstanceIds = sourceToInstanceIds;
+	link.m_effectiveBaseline =
+		PrefabPtr::Make(m_allocator, sourcePrefabId);
+	link.m_effectiveBaseline->m_gameObjects =
+		effectiveBaseline->m_gameObjects;
+	link.m_effectiveBaseline->m_components =
+		effectiveBaseline->m_components;
+	link.m_effectiveBaseline->m_linkedInstanceIds =
+		effectiveBaseline->m_linkedInstanceIds;
+	link.m_effectiveBaseline->m_gameObjectOverrides =
+		effectiveBaseline->m_gameObjectOverrides;
+	link.m_effectiveBaseline->m_componentOverrides =
+		effectiveBaseline->m_componentOverrides;
+	link.m_effectiveBaseline->m_detachedSupplementalInstanceIds =
+		effectiveBaseline->m_detachedSupplementalInstanceIds;
+	link.m_effectiveBaseline->m_linkedParentInstanceId =
+		effectiveBaseline->m_linkedParentInstanceId;
+	link.m_effectiveBaseline->m_bLinkedInstanceRecord =
+		effectiveBaseline->m_bLinkedInstanceRecord;
+	link.m_effectiveBaseline->m_bExpandedLinkedInstanceRecord =
+		effectiveBaseline->m_bExpandedLinkedInstanceRecord;
+	link.m_effectiveBaseline->m_bIsReady.store(
+		effectiveBaseline->IsReady(),
+		std::memory_order_release);
+	for (const auto& mapping : sourceToInstanceIds)
+	{
+		GameObjectPtr liveGameObject =
+			GetObjectByInstanceId(*mapping.m_second).DynamicCast<GameObject>();
+		if (!liveGameObject)
+		{
+			continue;
+		}
+
+		for (Prefab::ReflectedGameObject& baselineGameObject :
+			link.m_effectiveBaseline->m_gameObjects)
+		{
+			if (baselineGameObject.m_instanceId != mapping.m_first)
+			{
+				continue;
+			}
+
+			baselineGameObject.m_name = liveGameObject->GetName();
+			baselineGameObject.m_position =
+				liveGameObject->GetTransformComponent().GetPosition();
+			baselineGameObject.m_rotation =
+				liveGameObject->GetTransformComponent().GetRotation();
+			baselineGameObject.m_scale =
+				liveGameObject->GetTransformComponent().GetScale();
+			break;
+		}
+	}
+
+	m_prefabInstances[link.m_rootInstanceId] = link;
+	for (const auto& mapping : sourceToInstanceIds)
+	{
+		m_prefabInstanceRootsByObject[*mapping.m_second] = link.m_rootInstanceId;
+	}
+
+	root->m_fileId = sourcePrefabId;
+	return true;
+}
+
+bool World::LinkPrefabInstance(
+	GameObjectPtr root,
+	const PrefabPtr& sourcePrefab,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	if (!root || !sourcePrefab)
+	{
+		outDiagnostic = "the prefab instance root or source prefab is invalid";
+		return false;
+	}
+
+	TVector<GameObjectPtr> liveGameObjects;
+	TVector<GameObjectPtr> pendingGameObjects;
+	pendingGameObjects.Add(root);
+	while (!pendingGameObjects.IsEmpty())
+	{
+		GameObjectPtr current =
+			pendingGameObjects[pendingGameObjects.Num() - 1];
+		pendingGameObjects.RemoveLast();
+		liveGameObjects.Add(current);
+
+		const auto& children = current->GetChildren();
+		for (size_t childIndex = children.Num();
+			childIndex > 0;
+			--childIndex)
+		{
+			pendingGameObjects.Add(children[childIndex - 1]);
+		}
+	}
+
+	if (liveGameObjects.Num() != sourcePrefab->m_gameObjects.Num())
+	{
+		outDiagnostic = "the live hierarchy size does not match the source prefab";
+		return false;
+	}
+
+	const uint32_t invalidParentIndex = static_cast<uint32_t>(-1);
+	uint32_t sourceRootIndex = invalidParentIndex;
+	for (uint32_t gameObjectIndex = 0;
+		gameObjectIndex < sourcePrefab->m_gameObjects.Num();
+		++gameObjectIndex)
+	{
+		if (sourcePrefab->m_gameObjects[gameObjectIndex].m_parentIndex ==
+			invalidParentIndex)
+		{
+			sourceRootIndex = gameObjectIndex;
+			break;
+		}
+	}
+
+	if (sourceRootIndex == invalidParentIndex)
+	{
+		outDiagnostic = "the source prefab has no hierarchy root";
+		return false;
+	}
+
+	TVector<uint32_t> sourcePreorder;
+	TVector<uint32_t> pendingSourceIndices;
+	pendingSourceIndices.Add(sourceRootIndex);
+	while (!pendingSourceIndices.IsEmpty())
+	{
+		const uint32_t currentSourceIndex =
+			pendingSourceIndices[pendingSourceIndices.Num() - 1];
+		pendingSourceIndices.RemoveLast();
+		sourcePreorder.Add(currentSourceIndex);
+
+		for (uint32_t candidateIndex = static_cast<uint32_t>(
+				sourcePrefab->m_gameObjects.Num());
+			candidateIndex > 0;
+			--candidateIndex)
+		{
+			const uint32_t childIndex = candidateIndex - 1;
+			if (sourcePrefab->m_gameObjects[childIndex].m_parentIndex ==
+				currentSourceIndex)
+			{
+				pendingSourceIndices.Add(childIndex);
+			}
+		}
+	}
+
+	if (sourcePreorder.Num() != sourcePrefab->m_gameObjects.Num())
+	{
+		outDiagnostic = "the source prefab hierarchy is disconnected";
+		return false;
+	}
+
+	TMap<InstanceId, InstanceId> sourceToInstanceIds;
+	for (uint32_t preorderIndex = 0;
+		preorderIndex < sourcePreorder.Num();
+		++preorderIndex)
+	{
+		sourceToInstanceIds[
+			sourcePrefab->m_gameObjects[
+				sourcePreorder[preorderIndex]].m_instanceId] =
+			liveGameObjects[preorderIndex]->GetInstanceId();
+	}
+
+	return LinkPrefabInstance(
+		root,
+		sourcePrefab,
+		sourceToInstanceIds,
+		outDiagnostic);
+}
+
+bool World::LinkPrefabInstance(
+	GameObjectPtr root,
+	const PrefabPtr& sourcePrefab,
+	const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	if (!root || !sourcePrefab || !sourcePrefab->GetFileId())
+	{
+		outDiagnostic = "the prefab instance root or source prefab is invalid";
+		return false;
+	}
+
+	if (!sourcePrefab->ValidateForInstantiation(outDiagnostic))
+	{
+		return false;
+	}
+
+	if (sourceToInstanceIds.Num() != sourcePrefab->m_gameObjects.Num())
+	{
+		outDiagnostic = "the source-to-instance mapping does not cover the complete prefab hierarchy";
+		return false;
+	}
+
+	const uint32_t invalidParentIndex = static_cast<uint32_t>(-1);
+	uint32_t numLiveObjects = 0;
+	TVector<GameObjectPtr> pendingObjects;
+	pendingObjects.Add(root);
+	while (!pendingObjects.IsEmpty())
+	{
+		GameObjectPtr current = pendingObjects[pendingObjects.Num() - 1];
+		pendingObjects.RemoveLast();
+		++numLiveObjects;
+		pendingObjects.AddRange(current->GetChildren());
+	}
+
+	if (numLiveObjects != sourcePrefab->m_gameObjects.Num())
+	{
+		outDiagnostic = "the live hierarchy has structural changes and cannot be linked";
+		return false;
+	}
+
+	for (uint32_t gameObjectIndex = 0;
+		gameObjectIndex < sourcePrefab->m_gameObjects.Num();
+		++gameObjectIndex)
+	{
+		const auto& sourceGameObject = sourcePrefab->m_gameObjects[gameObjectIndex];
+		if (!sourceToInstanceIds.ContainsKey(sourceGameObject.m_instanceId))
+		{
+			outDiagnostic = "the source-to-instance mapping is missing a source game object";
+			return false;
+		}
+
+		GameObjectPtr liveGameObject = GetObjectByInstanceId(
+			sourceToInstanceIds[sourceGameObject.m_instanceId]).DynamicCast<GameObject>();
+		if (!liveGameObject)
+		{
+			outDiagnostic = "the source-to-instance mapping references a missing live game object";
+			return false;
+		}
+
+		if (sourceGameObject.m_parentIndex == invalidParentIndex)
+		{
+			if (liveGameObject != root)
+			{
+				outDiagnostic = "the source prefab root maps to a different live game object";
+				return false;
+			}
+		}
+		else
+		{
+			const InstanceId& expectedParentId = sourceToInstanceIds[
+				sourcePrefab->m_gameObjects[sourceGameObject.m_parentIndex].m_instanceId];
+			if (!liveGameObject->GetParent() ||
+				liveGameObject->GetParent()->GetInstanceId() != expectedParentId)
+			{
+				outDiagnostic = "the live prefab hierarchy does not match its source hierarchy";
+				return false;
+			}
+		}
+
+		if (liveGameObject->GetComponents().Num() != sourceGameObject.m_components.Num())
+		{
+			outDiagnostic = "the live prefab components do not match the source prefab";
+			return false;
+		}
+
+		for (const uint32_t componentIndex : sourceGameObject.m_components)
+		{
+			const ReflectedData& sourceReflection = sourcePrefab->m_components[componentIndex];
+			InstanceId sourceComponentId;
+			std::string conversionDiagnostic;
+			if (!External::TryConvertYaml(
+					sourceReflection.GetProperties()["instanceId"],
+					sourceComponentId,
+					conversionDiagnostic))
+			{
+				outDiagnostic = "the source prefab contains an invalid component identity: " +
+					conversionDiagnostic;
+				return false;
+			}
+
+			const InstanceId expectedLiveComponentId(
+				sourceComponentId.ComponentId(),
+				liveGameObject->GetInstanceId());
+			bool bFoundComponent = false;
+			for (const auto& liveComponent : liveGameObject->GetComponents())
+			{
+				if (liveComponent->GetInstanceId() == expectedLiveComponentId &&
+					liveComponent->GetTypeInfo() == sourceReflection.GetTypeInfo())
+				{
+					bFoundComponent = true;
+					break;
+				}
+			}
+
+			if (!bFoundComponent)
+			{
+				outDiagnostic = "the live prefab component identities or types do not match the source prefab";
+				return false;
+			}
+		}
+	}
+
+	PrefabPtr expandedPrefab =
+		PrefabPtr::Make(m_allocator, sourcePrefab->GetFileId());
+	Prefab::SerializeGameObject(
+		root,
+		static_cast<uint32_t>(-1),
+		expandedPrefab->m_components,
+		expandedPrefab->m_gameObjects,
+		nullptr);
+	if (!expandedPrefab->ValidateForInstantiation(outDiagnostic))
+	{
+		outDiagnostic = "cannot capture the linked prefab baseline: " +
+			outDiagnostic;
+		return false;
+	}
+
+	TMap<InstanceId, YAML::Node> gameObjectOverrides;
+	TMap<InstanceId, ReflectedData> componentOverrides;
+	if (!WorldPrefab::BuildLinkedOverrides(
+			expandedPrefab,
+			sourcePrefab,
+			sourceToInstanceIds,
+			gameObjectOverrides,
+			componentOverrides,
+			outDiagnostic))
+	{
+		outDiagnostic = "cannot derive the linked prefab baseline overrides: " +
+			outDiagnostic;
+		return false;
+	}
+
+	PrefabPtr effectiveBaseline =
+		PrefabPtr::Make(m_allocator, sourcePrefab->GetFileId());
+	const InstanceId parentInstanceId = root->GetParent()
+		? root->GetParent()->GetInstanceId()
+		: InstanceId::Invalid;
+	if (!effectiveBaseline->ConfigureLinkedInstance(
+			sourcePrefab,
+			sourceToInstanceIds,
+			parentInstanceId,
+			gameObjectOverrides,
+			componentOverrides,
+			outDiagnostic))
+	{
+		outDiagnostic = "cannot configure the linked prefab baseline: " +
+			outDiagnostic;
+		return false;
+	}
+
+	return RegisterPrefabInstance(
+		root,
+		sourcePrefab->GetFileId(),
+		sourceToInstanceIds,
+		effectiveBaseline,
+		outDiagnostic);
+}
+
+bool World::BreakPrefabLink(
+	const InstanceId& objectInstanceId,
+	PrefabInstanceLink* outPreviousLink)
+{
+	if (!m_prefabInstanceRootsByObject.ContainsKey(objectInstanceId))
+	{
+		return false;
+	}
+
+	const InstanceId rootInstanceId = m_prefabInstanceRootsByObject[objectInstanceId];
+	auto purgeRootMembership = [this, &rootInstanceId]()
+		{
+			TVector<InstanceId> memberInstanceIds;
+			for (const auto& membership :
+				m_prefabInstanceRootsByObject)
+			{
+				if (*membership.m_second == rootInstanceId)
+				{
+					memberInstanceIds.Add(membership.m_first);
+				}
+			}
+
+			for (const InstanceId& memberInstanceId :
+				memberInstanceIds)
+			{
+				m_prefabInstanceRootsByObject.Remove(
+					memberInstanceId);
+			}
+		};
+
+	if (!m_prefabInstances.ContainsKey(rootInstanceId))
+	{
+		purgeRootMembership();
+		return false;
+	}
+
+	const PrefabInstanceLink previousLink = m_prefabInstances[rootInstanceId];
+	if (outPreviousLink)
+	{
+		*outPreviousLink = previousLink;
+	}
+
+	purgeRootMembership();
+	m_prefabInstances.Remove(rootInstanceId);
+
+	if (GameObjectPtr root = GetObjectByInstanceId(rootInstanceId).DynamicCast<GameObject>())
+	{
+		root->m_fileId = FileId::Invalid;
+	}
+
+	return true;
+}
+
+bool World::CanModifyPrefabStructure(
+	const InstanceId& objectInstanceId,
+	std::string* outDiagnostic) const
+{
+	const bool bCanModify = !IsPrefabLinked(objectInstanceId);
+	if (!bCanModify && outDiagnostic)
+	{
+		*outDiagnostic = "structural changes are disabled for linked prefab instances; break the prefab link first";
+	}
+	return bCanModify;
+}
+
+bool World::CanReparentPrefabObject(
+	const InstanceId& objectInstanceId,
+	const InstanceId& parentInstanceId,
+	std::string* outDiagnostic) const
+{
+	if (IsPrefabLinked(objectInstanceId))
+	{
+		const InstanceId& rootInstanceId = m_prefabInstanceRootsByObject[objectInstanceId];
+		if (rootInstanceId != objectInstanceId)
+		{
+			if (outDiagnostic)
+			{
+				*outDiagnostic = "internal linked prefab game objects cannot be reparented";
+			}
+			return false;
+		}
+	}
+
+	if (parentInstanceId && IsPrefabLinked(parentInstanceId))
+	{
+		if (outDiagnostic)
+		{
+			*outDiagnostic = "game objects cannot be parented inside a linked prefab instance";
+		}
+		return false;
+	}
+
+	return true;
+}
+
 void World::Tick(FrameState& frameState)
 {
 	const bool bShouldCallBeginPlay = (m_mask & (uint8_t)EWorldBehaviourBit::CallBeginPlay) != 0;
@@ -211,6 +769,11 @@ void World::Tick(FrameState& frameState)
 
 GameObjectPtr World::Instantiate(PrefabPtr prefab)
 {
+	return Instantiate(prefab, false);
+}
+
+GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
+{
 	if (!prefab || prefab->m_gameObjects.IsEmpty())
 	{
 		SAILOR_LOG_ERROR("Cannot instantiate an invalid or empty prefab.");
@@ -226,16 +789,299 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 		return {};
 	}
 
+	if (prefab->m_bLinkedPrefabSnapshotRecord)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot instantiate linked prefab snapshot directly; it must be resolved against its current source first.");
+		return {};
+	}
+
+	if (prefab->m_bExpandedLinkedInstanceRecord)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot instantiate an expanded linked serialization record directly.");
+		return {};
+	}
+
+	GameObjectPtr detachedParent;
+	if (prefab->m_bDetachedFromPrefabRecord)
+	{
+		if (!bStrictInstanceIds)
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot instantiate detached prefab snapshot: exact instance ids are required.");
+			return {};
+		}
+
+		detachedParent = GetObjectByInstanceId(
+			prefab->m_detachedParentInstanceId).DynamicCast<GameObject>();
+		if (!detachedParent ||
+			!IsPrefabLinked(
+				prefab->m_detachedParentInstanceId))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot instantiate detached prefab snapshot: parent '%s' is missing or is not a linked prefab member.",
+				prefab->m_detachedParentInstanceId.ToString().c_str());
+			return {};
+		}
+	}
+
+	if (prefab->m_bLinkedInstanceRecord)
+	{
+		TMap<InstanceId, InstanceId> dependencyAliasTargets;
+		auto registerDependencyAlias =
+			[&dependencyAliasTargets](
+				const InstanceId& alias,
+				const InstanceId& target)
+			{
+				if (!alias || !target)
+				{
+					return false;
+				}
+
+				if (dependencyAliasTargets.ContainsKey(alias))
+				{
+					return dependencyAliasTargets[alias] ==
+						target;
+				}
+
+				dependencyAliasTargets[alias] = target;
+				return true;
+			};
+
+		for (const auto& sourceGameObject :
+			prefab->m_gameObjects)
+		{
+			const InstanceId& sourceInstanceId =
+				sourceGameObject.m_instanceId;
+			const InstanceId desiredGameObjectId =
+				prefab->m_linkedInstanceIds.ContainsKey(
+					sourceInstanceId)
+					? prefab->m_linkedInstanceIds[
+						sourceInstanceId]
+					: sourceInstanceId;
+			if (!registerDependencyAlias(
+					sourceInstanceId,
+					desiredGameObjectId) ||
+				!registerDependencyAlias(
+					desiredGameObjectId,
+					desiredGameObjectId))
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot instantiate linked prefab '%s': source and live game object dependency aliases are ambiguous.",
+					prefab->GetFileId().ToString().c_str());
+				return {};
+			}
+
+			for (const uint32_t componentIndex :
+				sourceGameObject.m_components)
+			{
+				const ReflectedData& reflection =
+					prefab->m_components[componentIndex];
+				InstanceId sourceComponentId;
+				std::string conversionDiagnostic;
+				if (!External::TryConvertYaml(
+						reflection.GetProperties()[
+							"instanceId"],
+						sourceComponentId,
+						conversionDiagnostic))
+				{
+					SAILOR_LOG_ERROR(
+						"Cannot instantiate reflected component %u from linked prefab '%s': %s.",
+						componentIndex,
+						prefab->GetFileId().ToString().c_str(),
+						conversionDiagnostic.c_str());
+					return {};
+				}
+
+				const InstanceId desiredComponentId(
+					sourceComponentId.ComponentId(),
+					desiredGameObjectId);
+				if (!registerDependencyAlias(
+						sourceComponentId,
+						desiredComponentId) ||
+					!registerDependencyAlias(
+						desiredComponentId,
+						desiredComponentId))
+				{
+					SAILOR_LOG_ERROR(
+						"Cannot instantiate linked prefab '%s': source and live component dependency aliases are ambiguous.",
+						prefab->GetFileId().ToString().c_str());
+					return {};
+				}
+			}
+		}
+	}
+
+	TMap<InstanceId, InstanceId> strictSourceToInstanceIds;
+	if (bStrictInstanceIds)
+	{
+		TSet<InstanceId> desiredGameObjectIds;
+		TSet<InstanceId> desiredComponentIds;
+		TSet<InstanceId> existingComponentIds;
+		for (const auto& existingGameObject : m_objects)
+		{
+			if (!existingGameObject)
+			{
+				continue;
+			}
+
+			for (const auto& existingComponent :
+				existingGameObject->GetComponents())
+			{
+				if (existingComponent)
+				{
+					existingComponentIds.Insert(
+						existingComponent->GetInstanceId());
+				}
+			}
+		}
+
+		for (const auto& sourceGameObject : prefab->m_gameObjects)
+		{
+			const InstanceId& sourceInstanceId =
+				sourceGameObject.m_instanceId;
+			InstanceId desiredGameObjectId = sourceInstanceId;
+			if (prefab->m_bLinkedInstanceRecord)
+			{
+				if (prefab->m_linkedInstanceIds.ContainsKey(
+						sourceInstanceId))
+				{
+					desiredGameObjectId =
+						prefab->m_linkedInstanceIds[
+							sourceInstanceId];
+				}
+				else if (prefab->m_detachedSupplementalInstanceIds.Contains(
+						sourceInstanceId))
+				{
+					desiredGameObjectId = sourceInstanceId;
+				}
+				else
+				{
+					SAILOR_LOG_ERROR(
+						"Cannot strictly instantiate linked prefab '%s': a game object is neither mapped source data nor detached supplemental data.",
+						prefab->GetFileId().ToString().c_str());
+					return {};
+				}
+			}
+
+			if (!desiredGameObjectId.IsGameObjectId() ||
+				m_objectsMap.ContainsKey(desiredGameObjectId) ||
+				!desiredGameObjectIds.Insert(desiredGameObjectId))
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot strictly instantiate prefab '%s': game object id '%s' is invalid, duplicated, or already in use.",
+					prefab->GetFileId().ToString().c_str(),
+					desiredGameObjectId.ToString().c_str());
+				return {};
+			}
+
+			strictSourceToInstanceIds[sourceInstanceId] =
+				desiredGameObjectId;
+			for (const uint32_t componentIndex :
+				sourceGameObject.m_components)
+			{
+				const ReflectedData& reflection =
+					prefab->m_components[componentIndex];
+				InstanceId sourceComponentId;
+				std::string conversionDiagnostic;
+				if (!External::TryConvertYaml(
+						reflection.GetProperties()["instanceId"],
+						sourceComponentId,
+						conversionDiagnostic))
+				{
+					SAILOR_LOG_ERROR(
+						"Cannot strictly instantiate reflected component %u from prefab '%s': %s.",
+						componentIndex,
+						prefab->GetFileId().ToString().c_str(),
+						conversionDiagnostic.c_str());
+					return {};
+				}
+
+				const InstanceId desiredComponentId(
+					sourceComponentId.ComponentId(),
+					desiredGameObjectId);
+				if (!desiredComponentId ||
+					existingComponentIds.Contains(desiredComponentId) ||
+					!desiredComponentIds.Insert(desiredComponentId))
+				{
+					SAILOR_LOG_ERROR(
+						"Cannot strictly instantiate prefab '%s': component id '%s' is invalid, duplicated, or already in use.",
+						prefab->GetFileId().ToString().c_str(),
+						desiredComponentId.ToString().c_str());
+					return {};
+				}
+			}
+		}
+	}
+
 	TVector<GameObjectPtr> gameObjects;
 	gameObjects.Reserve(prefab->m_gameObjects.Num());
 	TMap<InstanceId, ObjectPtr> internalDependencies;
+	TMap<InstanceId, InstanceId> sourceToInstanceIds;
+	TSet<InstanceId> reservedInstanceIds;
 	PrefabInstantiationTransaction transaction(*this, gameObjects, ComponentsToResolveDependencies);
 
 	for (uint32_t j = 0; j < prefab->m_gameObjects.Num(); j++)
 	{
-		// We generate new instance id for game objects if the same is already in use
-		const bool bShouldGenerateNewId = !prefab->m_gameObjects[j].m_instanceId || m_objectsMap.ContainsKey(prefab->m_gameObjects[j].m_instanceId);
-		const InstanceId gameObjectId = bShouldGenerateNewId ? InstanceId::GenerateNewInstanceId() : prefab->m_gameObjects[j].m_instanceId;
+		const InstanceId& sourceInstanceId = prefab->m_gameObjects[j].m_instanceId;
+		InstanceId gameObjectId;
+		if (prefab->m_bLinkedInstanceRecord)
+		{
+			if (prefab->m_linkedInstanceIds.ContainsKey(
+					sourceInstanceId))
+			{
+				gameObjectId =
+					prefab->m_linkedInstanceIds[
+						sourceInstanceId];
+				sourceToInstanceIds[sourceInstanceId] =
+					gameObjectId;
+			}
+			else if (prefab->m_detachedSupplementalInstanceIds.Contains(
+					sourceInstanceId))
+			{
+				gameObjectId = sourceInstanceId;
+			}
+			else
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot instantiate linked prefab '%s': a game object is neither mapped source data nor detached supplemental data.",
+					prefab->GetFileId().ToString().c_str());
+				return {};
+			}
+
+			if (!gameObjectId.IsGameObjectId() ||
+				m_objectsMap.ContainsKey(gameObjectId) ||
+				!reservedInstanceIds.Insert(gameObjectId))
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot instantiate linked prefab '%s': preferred game object id '%s' is invalid or already in use.",
+					prefab->GetFileId().ToString().c_str(),
+					gameObjectId.ToString().c_str());
+				return {};
+			}
+		}
+		else
+		{
+			gameObjectId = bStrictInstanceIds
+				? strictSourceToInstanceIds[sourceInstanceId]
+				: sourceInstanceId;
+			if (!bStrictInstanceIds &&
+				(!gameObjectId ||
+					m_objectsMap.ContainsKey(gameObjectId) ||
+					reservedInstanceIds.Contains(gameObjectId)))
+			{
+				do
+				{
+					gameObjectId = InstanceId::GenerateNewInstanceId();
+				}
+				while (m_objectsMap.ContainsKey(gameObjectId) || reservedInstanceIds.Contains(gameObjectId));
+			}
+
+			reservedInstanceIds.Insert(gameObjectId);
+			sourceToInstanceIds[sourceInstanceId] =
+				gameObjectId;
+		}
 
 		GameObjectPtr gameObject = NewGameObject(prefab->m_gameObjects[j].m_name, gameObjectId);
 		gameObjects.Add(gameObject);
@@ -274,7 +1120,17 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 				return {};
 			}
 
-			gameObject->AddComponentRaw(newComponent);
+			const InstanceId newComponentInstanceId(oldInstanceId.ComponentId(), gameObject->GetInstanceId());
+			if (!gameObject->AddComponentRaw(newComponent, newComponentInstanceId))
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot instantiate reflected component %u from prefab '%s': component id '%s' is invalid or already in use.",
+					componentIndex,
+					prefab->GetFileId().ToString().c_str(),
+					newComponentInstanceId.ToString().c_str());
+				return {};
+			}
+
 			std::string applyDiagnostic;
 			if (!External::GuardYamlExceptions(
 					[newComponent, &reflection]() mutable
@@ -290,14 +1146,17 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 					applyDiagnostic.c_str());
 				return {};
 			}
-			newComponent->m_instanceId = InstanceId(oldInstanceId.ComponentId(), gameObject->GetInstanceId());
 
 			// We store the old ids for internal dependencies during resolve
 			internalDependencies[oldInstanceId] = newComponent;
+			internalDependencies[newComponentInstanceId] =
+				newComponent;
 		}
 
 		// We store the old ids for internal dependencies during resolve
 		internalDependencies[prefab->m_gameObjects[j].m_instanceId] = gameObject;
+		internalDependencies[gameObject->GetInstanceId()] =
+			gameObject;
 	}
 
 	for (uint32_t goIndex = 0; goIndex < gameObjects.Num(); goIndex++)
@@ -322,7 +1181,10 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 			if (!External::TryInvokeYaml(
 					[newComp, &reflection, &internalDependencies]() mutable
 					{
-						return newComp->ResolveRefs(reflection, internalDependencies, false);
+						return newComp->ResolveRefs(
+							reflection,
+							internalDependencies,
+							false);
 					},
 					bResolved,
 					resolveDiagnostic))
@@ -385,6 +1247,62 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 		SAILOR_LOG_ERROR("Cannot instantiate prefab '%s': no root game object was found.",
 			prefab->GetFileId().ToString().c_str());
 		return {};
+	}
+
+	if (prefab->m_bLinkedInstanceRecord && prefab->m_linkedParentInstanceId)
+	{
+		GameObjectPtr externalParent =
+			GetObjectByInstanceId(prefab->m_linkedParentInstanceId).DynamicCast<GameObject>();
+		if (!externalParent)
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot instantiate linked prefab '%s': external parent '%s' does not exist.",
+				prefab->GetFileId().ToString().c_str(),
+				prefab->m_linkedParentInstanceId.ToString().c_str());
+			return {};
+		}
+
+		root->SetParent(externalParent);
+		if (root->GetParent() != externalParent)
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot instantiate linked prefab '%s': external parent '%s' rejects structural changes.",
+				prefab->GetFileId().ToString().c_str(),
+				prefab->m_linkedParentInstanceId.ToString().c_str());
+			return {};
+		}
+	}
+
+	if (prefab->m_bDetachedFromPrefabRecord)
+	{
+		root->SetParentInternal(
+			detachedParent,
+			true);
+		if (root->GetParent() != detachedParent)
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot restore detached prefab snapshot under linked parent '%s'.",
+				prefab->m_detachedParentInstanceId.ToString().c_str());
+			return {};
+		}
+	}
+
+	if (prefab->GetFileId())
+	{
+		std::string linkDiagnostic;
+		if (!RegisterPrefabInstance(
+				root,
+				prefab->GetFileId(),
+				sourceToInstanceIds,
+				prefab,
+				linkDiagnostic))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot register linked prefab '%s': %s.",
+				prefab->GetFileId().ToString().c_str(),
+				linkDiagnostic.c_str());
+			return {};
+		}
 	}
 
 	// Should we try to resolve the previous open dependencies?
@@ -472,6 +1390,8 @@ void World::DestroyGameObjectHierarchy(GameObjectPtr root)
 		return;
 	}
 
+	RemovePrefabLinksInHierarchy(root);
+
 	TVector<GameObjectPtr> destroyingObjects;
 	destroyingObjects.Reserve(root->GetChildren().Num() + 1);
 	destroyingObjects.Add(root);
@@ -507,6 +1427,38 @@ void World::DestroyGameObjectHierarchy(GameObjectPtr root)
 		m_objectsMap.Remove(go->m_instanceId);
 		m_objects.RemoveFirst(go);
 		go.DestroyObject(m_allocator);
+	}
+}
+
+void World::RemovePrefabLinksInHierarchy(GameObjectPtr root)
+{
+	if (!root)
+	{
+		return;
+	}
+
+	TVector<InstanceId> linkedRoots;
+	TVector<GameObjectPtr> pendingObjects;
+	pendingObjects.Add(root);
+	while (!pendingObjects.IsEmpty())
+	{
+		GameObjectPtr current = pendingObjects[pendingObjects.Num() - 1];
+		pendingObjects.RemoveLast();
+		if (!current)
+		{
+			continue;
+		}
+
+		if (IsPrefabInstanceRoot(current->GetInstanceId()))
+		{
+			linkedRoots.Add(current->GetInstanceId());
+		}
+		pendingObjects.AddRange(current->GetChildren());
+	}
+
+	for (const InstanceId& rootInstanceId : linkedRoots)
+	{
+		BreakPrefabLink(rootInstanceId);
 	}
 }
 
@@ -557,6 +1509,15 @@ void World::Destroy(GameObjectPtr object)
 {
 	if (object && !object->m_bPendingDestroy)
 	{
+		if (IsPrefabLinked(object->GetInstanceId()) &&
+			!IsPrefabInstanceRoot(object->GetInstanceId()))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot destroy internal linked prefab game object '%s'; break the prefab link first.",
+				object->GetInstanceId().ToString().c_str());
+			return;
+		}
+
 		object->m_bPendingDestroy = true;
 		m_pendingDestroyObjects.PushBack(std::move(object));
 	}
@@ -566,6 +1527,15 @@ void World::DestroyImmediate(GameObjectPtr object)
 {
 	if (!object || !m_objectsMap.ContainsKey(object->m_instanceId))
 	{
+		return;
+	}
+
+	if (IsPrefabLinked(object->GetInstanceId()) &&
+		!IsPrefabInstanceRoot(object->GetInstanceId()))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot destroy internal linked prefab game object '%s'; break the prefab link first.",
+			object->GetInstanceId().ToString().c_str());
 		return;
 	}
 
@@ -590,6 +1560,8 @@ void World::Clear()
 
 	m_objects.Clear();
 	m_pendingDestroyObjects.Clear();
+	m_prefabInstances.Clear();
+	m_prefabInstanceRootsByObject.Clear();
 	m_editorSelection.Clear();
 	m_pDebugContext.Clear();
 

--- a/Runtime/Engine/World.h
+++ b/Runtime/Engine/World.h
@@ -5,6 +5,9 @@
 #include "Memory/ObjectAllocator.hpp"
 #include "Engine/Frame.h"
 #include "Engine/Types.h"
+#include "Engine/InstanceId.h"
+#include "AssetRegistry/FileId.h"
+#include "Containers/Map.h"
 #include "RHI/DebugContext.h"
 #include "ECS/ECS.h"
 
@@ -19,6 +22,14 @@ namespace Sailor
 	};
 
 	typedef uint8_t EWorldBehaviourMask;
+
+	struct PrefabInstanceLink final
+	{
+		FileId m_sourcePrefabId{};
+		InstanceId m_rootInstanceId{};
+		TMap<InstanceId, InstanceId> m_sourceToInstanceIds{};
+		PrefabPtr m_effectiveBaseline{};
+	};
 
 	class World
 	{
@@ -35,6 +46,9 @@ namespace Sailor
 		SAILOR_API World& operator=(World&&) = default;
 
 		SAILOR_API GameObjectPtr Instantiate(PrefabPtr prefab);
+		SAILOR_API GameObjectPtr Instantiate(
+			PrefabPtr prefab,
+			bool bStrictInstanceIds);
 		SAILOR_API GameObjectPtr Instantiate(const std::string& name = "Untitled");
 		SAILOR_API GameObjectPtr Instantiate(const std::string& name, const InstanceId& preferredInstanceId);
 		SAILOR_API void Destroy(GameObjectPtr object);
@@ -74,6 +88,31 @@ namespace Sailor
 		SAILOR_API ObjectPtr GetObjectByInstanceId(const InstanceId& instanceId) const;
 
 		SAILOR_API const TMap<InstanceId, ObjectPtr>& GetObjects() const { return m_objectsMap; }
+		SAILOR_API const TMap<InstanceId, PrefabInstanceLink>& GetPrefabInstances() const { return m_prefabInstances; }
+		SAILOR_API bool TryGetPrefabInstance(
+			const InstanceId& objectInstanceId,
+			const PrefabInstanceLink*& outLink) const;
+		SAILOR_API bool IsPrefabLinked(const InstanceId& objectInstanceId) const;
+		SAILOR_API bool IsPrefabInstanceRoot(const InstanceId& objectInstanceId) const;
+		SAILOR_API bool LinkPrefabInstance(
+			GameObjectPtr root,
+			const PrefabPtr& sourcePrefab,
+			std::string& outDiagnostic);
+		SAILOR_API bool LinkPrefabInstance(
+			GameObjectPtr root,
+			const PrefabPtr& sourcePrefab,
+			const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+			std::string& outDiagnostic);
+		SAILOR_API bool BreakPrefabLink(
+			const InstanceId& objectInstanceId,
+			PrefabInstanceLink* outPreviousLink = nullptr);
+		SAILOR_API bool CanModifyPrefabStructure(
+			const InstanceId& objectInstanceId,
+			std::string* outDiagnostic = nullptr) const;
+		SAILOR_API bool CanReparentPrefabObject(
+			const InstanceId& objectInstanceId,
+			const InstanceId& parentInstanceId,
+			std::string* outDiagnostic = nullptr) const;
 
 	protected:
 
@@ -88,6 +127,13 @@ namespace Sailor
 
 		SAILOR_API GameObjectPtr NewGameObject(const std::string& name, const InstanceId& instanceId);
 		void DestroyGameObjectHierarchy(GameObjectPtr root);
+		bool RegisterPrefabInstance(
+			GameObjectPtr root,
+			const FileId& sourcePrefabId,
+			const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+			const PrefabPtr& effectiveBaseline,
+			std::string& outDiagnostic);
+		void RemovePrefabLinksInHierarchy(GameObjectPtr root);
 
 		float m_time{};
 		float m_smoothDeltaTime = 0.016f;
@@ -99,6 +145,8 @@ namespace Sailor
 
 		TVector<GameObjectPtr> m_objects;
 		TMap<InstanceId, ObjectPtr> m_objectsMap;
+		TMap<InstanceId, PrefabInstanceLink> m_prefabInstances;
+		TMap<InstanceId, InstanceId> m_prefabInstanceRootsByObject;
 		TSet<InstanceId> m_editorSelection;
 
 		TVector<size_t> m_sortedEcs;
@@ -118,5 +166,6 @@ namespace Sailor
 
 		friend class GameObject;
 		friend class Editor;
+		friend class WorldPrefab;
 	};
 }

--- a/Runtime/Platform/Win32/Window.cpp
+++ b/Runtime/Platform/Win32/Window.cpp
@@ -3,6 +3,11 @@
 #include "Window.h"
 
 #include <algorithm>
+#include <cstring>
+#include <string_view>
+#include <utility>
+
+#include <ole2.h>
 
 #include "Input.h"
 #include "Sailor.h"
@@ -10,12 +15,344 @@
 #include "Tasks/Scheduler.h"
 #include "Submodules/ImGuiApi.h"
 
+#pragma comment(lib, "ole32.lib")
+
 using namespace Sailor;
 using namespace Sailor::Win32;
 
 namespace
 {
 	constexpr UINT c_destroyWindowMessage = WM_APP + 0x351;
+	constexpr std::wstring_view c_editorAssetDropPrefix =
+		L"SailorEditor.Asset:";
+	constexpr size_t c_unbracedFileIdLength = 36;
+	constexpr size_t c_bracedFileIdLength = 38;
+	constexpr size_t c_maxDropPayloadLength =
+		c_editorAssetDropPrefix.size() + c_bracedFileIdLength;
+
+	bool IsEditorViewportToolShortcutKey(uint32_t keyCode)
+	{
+		return keyCode == 'Q' ||
+			keyCode == 'W' ||
+			keyCode == 'E' ||
+			keyCode == 'R' ||
+			keyCode == 'T';
+	}
+
+	bool IsHexDigit(wchar_t value)
+	{
+		return (value >= L'0' && value <= L'9') ||
+			(value >= L'a' && value <= L'f') ||
+			(value >= L'A' && value <= L'F');
+	}
+
+	bool IsSerializedFileId(std::wstring_view fileId)
+	{
+		if (fileId.size() == c_bracedFileIdLength)
+		{
+			if (fileId.front() != L'{' || fileId.back() != L'}')
+			{
+				return false;
+			}
+
+			fileId = fileId.substr(1, c_unbracedFileIdLength);
+		}
+		else if (fileId.size() != c_unbracedFileIdLength)
+		{
+			return false;
+		}
+
+		for (size_t i = 0; i < fileId.size(); ++i)
+		{
+			const bool bHyphenPosition =
+				i == 8 || i == 13 || i == 18 || i == 23;
+			if ((bHyphenPosition && fileId[i] != L'-') ||
+				(!bHyphenPosition && !IsHexDigit(fileId[i])))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool TryReadEditorAssetFileId(
+		IDataObject* dataObject,
+		std::string& outFileId)
+	{
+		outFileId.clear();
+		if (!dataObject)
+		{
+			return false;
+		}
+
+		FORMATETC format{};
+		format.cfFormat = CF_UNICODETEXT;
+		format.dwAspect = DVASPECT_CONTENT;
+		format.lindex = -1;
+		format.tymed = TYMED_HGLOBAL;
+
+		STGMEDIUM medium{};
+		if (FAILED(dataObject->GetData(&format, &medium)))
+		{
+			return false;
+		}
+
+		bool bValid = false;
+		if (medium.tymed == TYMED_HGLOBAL && medium.hGlobal)
+		{
+			const SIZE_T bytes = GlobalSize(medium.hGlobal);
+			const size_t availableCharacters = bytes / sizeof(wchar_t);
+			const auto* text =
+				static_cast<const wchar_t*>(GlobalLock(medium.hGlobal));
+			if (text && availableCharacters > 0)
+			{
+				size_t length = 0;
+				const size_t scanLimit = std::min(
+					availableCharacters,
+					c_maxDropPayloadLength + 1);
+				while (length < scanLimit && text[length] != L'\0')
+				{
+					++length;
+				}
+
+				if (length < scanLimit &&
+					length > c_editorAssetDropPrefix.size())
+				{
+					const std::wstring_view payload(text, length);
+					const std::wstring_view fileId =
+						payload.substr(c_editorAssetDropPrefix.size());
+					if (payload.starts_with(c_editorAssetDropPrefix) &&
+						IsSerializedFileId(fileId))
+					{
+						outFileId.reserve(fileId.size());
+						for (const wchar_t value : fileId)
+						{
+							outFileId.push_back(
+								static_cast<char>(value));
+						}
+						bValid = true;
+					}
+				}
+
+				GlobalUnlock(medium.hGlobal);
+			}
+		}
+
+		ReleaseStgMedium(&medium);
+		return bValid;
+	}
+
+	class EditorViewportDropTarget final : public IDropTarget
+	{
+	public:
+		explicit EditorViewportDropTarget(Window* window) :
+			m_window(window)
+		{}
+
+		HRESULT STDMETHODCALLTYPE QueryInterface(
+			REFIID interfaceId,
+			void** object) override
+		{
+			if (!object)
+			{
+				return E_POINTER;
+			}
+
+			*object = nullptr;
+			if (IsEqualIID(interfaceId, IID_IUnknown) ||
+				IsEqualIID(interfaceId, IID_IDropTarget))
+			{
+				*object = static_cast<IDropTarget*>(this);
+				AddRef();
+				return S_OK;
+			}
+
+			return E_NOINTERFACE;
+		}
+
+		ULONG STDMETHODCALLTYPE AddRef() override
+		{
+			return static_cast<ULONG>(
+				InterlockedIncrement(&m_referenceCount));
+		}
+
+		ULONG STDMETHODCALLTYPE Release() override
+		{
+			const LONG referenceCount =
+				InterlockedDecrement(&m_referenceCount);
+			if (referenceCount == 0)
+			{
+				delete this;
+			}
+			return static_cast<ULONG>(referenceCount);
+		}
+
+		HRESULT STDMETHODCALLTYPE DragEnter(
+			IDataObject* dataObject,
+			DWORD,
+			POINTL,
+			DWORD* effect) override
+		{
+			std::string fileId;
+			const bool bCopyAllowed =
+				effect && ((*effect & DROPEFFECT_COPY) != 0);
+			m_bAcceptingDrop =
+				bCopyAllowed &&
+				TryReadEditorAssetFileId(dataObject, fileId);
+			if (effect)
+			{
+				*effect &=
+					m_bAcceptingDrop
+						? DROPEFFECT_COPY
+						: DROPEFFECT_NONE;
+			}
+			return S_OK;
+		}
+
+		HRESULT STDMETHODCALLTYPE DragOver(
+			DWORD,
+			POINTL,
+			DWORD* effect) override
+		{
+			if (effect)
+			{
+				*effect &=
+					m_bAcceptingDrop
+						? DROPEFFECT_COPY
+						: DROPEFFECT_NONE;
+			}
+			return S_OK;
+		}
+
+		HRESULT STDMETHODCALLTYPE DragLeave() override
+		{
+			m_bAcceptingDrop = false;
+			return S_OK;
+		}
+
+		HRESULT STDMETHODCALLTYPE Drop(
+			IDataObject* dataObject,
+			DWORD,
+			POINTL point,
+			DWORD* effect) override
+		{
+			std::string fileId;
+			const bool bCopyAllowed =
+				effect && ((*effect & DROPEFFECT_COPY) != 0);
+			bool bAccepted =
+				bCopyAllowed &&
+				m_bAcceptingDrop &&
+				m_window &&
+				TryReadEditorAssetFileId(dataObject, fileId);
+			if (bAccepted)
+			{
+				POINT clientPoint{ point.x, point.y };
+				RECT clientRect{};
+				const HWND windowHandle = m_window->GetHWND();
+				bAccepted =
+					windowHandle &&
+					ScreenToClient(windowHandle, &clientPoint) &&
+					GetClientRect(windowHandle, &clientRect);
+				const LONG width =
+					clientRect.right - clientRect.left;
+				const LONG height =
+					clientRect.bottom - clientRect.top;
+				bAccepted =
+					bAccepted &&
+					width > 0 &&
+					height > 0 &&
+					clientPoint.x >= clientRect.left &&
+					clientPoint.x <= clientRect.right &&
+					clientPoint.y >= clientRect.top &&
+					clientPoint.y <= clientRect.bottom;
+				if (bAccepted)
+				{
+					m_window->QueueEditorViewportAssetDrop(
+						std::move(fileId),
+						static_cast<float>(
+							clientPoint.x - clientRect.left) /
+							static_cast<float>(width),
+						static_cast<float>(
+							clientPoint.y - clientRect.top) /
+							static_cast<float>(height));
+				}
+			}
+
+			m_bAcceptingDrop = false;
+			if (effect)
+			{
+				*effect &=
+					bAccepted ? DROPEFFECT_COPY : DROPEFFECT_NONE;
+			}
+			return S_OK;
+		}
+
+	private:
+		LONG m_referenceCount = 1;
+		Window* m_window = nullptr;
+		bool m_bAcceptingDrop = false;
+	};
+
+	void RegisterEditorViewportDropTarget(
+		Window& window,
+		IUnknown*& outDropTarget,
+		bool& outOleInitialized)
+	{
+		outDropTarget = nullptr;
+		outOleInitialized = false;
+
+		const HRESULT initializeResult = OleInitialize(nullptr);
+		if (FAILED(initializeResult))
+		{
+			SAILOR_LOG_ERROR(
+				"Failed to initialize OLE for the editor viewport drop target. error=0x%08lX",
+				static_cast<unsigned long>(initializeResult));
+			return;
+		}
+		outOleInitialized = true;
+
+		auto* dropTarget = new EditorViewportDropTarget(&window);
+		const HRESULT registerResult =
+			RegisterDragDrop(window.GetHWND(), dropTarget);
+		if (FAILED(registerResult))
+		{
+			SAILOR_LOG_ERROR(
+				"Failed to register the editor viewport drop target. error=0x%08lX",
+				static_cast<unsigned long>(registerResult));
+			dropTarget->Release();
+			OleUninitialize();
+			outOleInitialized = false;
+			return;
+		}
+
+		outDropTarget = dropTarget;
+	}
+
+	void RevokeEditorViewportDropTarget(
+		HWND window,
+		IUnknown*& dropTarget,
+		bool& oleInitialized)
+	{
+		if (dropTarget)
+		{
+			const HRESULT revokeResult = RevokeDragDrop(window);
+			if (FAILED(revokeResult))
+			{
+				SAILOR_LOG_ERROR(
+					"Failed to revoke the editor viewport drop target. error=0x%08lX",
+					static_cast<unsigned long>(revokeResult));
+			}
+			dropTarget->Release();
+			dropTarget = nullptr;
+		}
+
+		if (oleInitialized)
+		{
+			OleUninitialize();
+			oleInitialized = false;
+		}
+	}
 }
 
 TVector<Window*> Window::g_windows;
@@ -200,6 +537,15 @@ bool Window::Create(LPCSTR title, LPCSTR className, int32_t inWidth, int32_t inH
 	m_bIsFullscreen = inbIsFullScreen;
 
 	ChangeWindowSize(m_width, m_height, m_bIsFullscreen);
+
+	if (m_parentHwnd &&
+		m_windowClassName.starts_with("SailorEditor"))
+	{
+		RegisterEditorViewportDropTarget(
+			*this,
+			m_editorViewportDropTarget,
+			m_bEditorViewportDropOleInitialized);
+	}
 
 	SAILOR_LOG("Window created");
 	return true;
@@ -399,6 +745,15 @@ void Window::Destroy()
 
 	check(!hWnd || ::GetWindowThreadProcessId(hWnd, nullptr) == ::GetCurrentThreadId());
 
+	if (m_editorViewportDropTarget ||
+		m_bEditorViewportDropOleInitialized)
+	{
+		RevokeEditorViewportDropTarget(
+			hWnd,
+			m_editorViewportDropTarget,
+			m_bEditorViewportDropOleInitialized);
+	}
+
 	HDC hDC = nullptr;
 	HINSTANCE hInstance = nullptr;
 	ATOM windowClassAtom = 0;
@@ -430,6 +785,16 @@ void Window::Destroy()
 	m_renderArea = {};
 	m_viewport = {};
 	m_windowClassName.clear();
+	{
+		const std::lock_guard<std::mutex> lock(
+			m_editorViewportAssetDropMutex);
+		m_pendingEditorViewportAssetDrop.reset();
+	}
+	{
+		const std::lock_guard<std::mutex> lock(
+			m_editorViewportToolShortcutMutex);
+		m_pendingEditorViewportToolShortcuts.Clear();
+	}
 
 	if (bWasFullscreen)
 	{
@@ -453,6 +818,73 @@ void Window::Destroy()
 	{
 		SAILOR_LOG_ERROR("Failed to unregister Win32 window class. error=%lu", static_cast<unsigned long>(GetLastError()));
 	}
+}
+
+void Window::QueueEditorViewportAssetDrop(
+	std::string fileId,
+	float normalizedX,
+	float normalizedY)
+{
+	const std::lock_guard<std::mutex> lock(
+		m_editorViewportAssetDropMutex);
+	m_pendingEditorViewportAssetDrop = EditorViewportAssetDrop{
+		std::move(fileId),
+		normalizedX,
+		normalizedY
+	};
+}
+
+bool Window::PullEditorViewportAssetDrop(
+	std::string& outFileId,
+	float& outNormalizedX,
+	float& outNormalizedY)
+{
+	outFileId.clear();
+	outNormalizedX = 0.0f;
+	outNormalizedY = 0.0f;
+
+	const std::lock_guard<std::mutex> lock(
+		m_editorViewportAssetDropMutex);
+	if (!m_pendingEditorViewportAssetDrop)
+	{
+		return false;
+	}
+
+	outFileId = std::move(
+		m_pendingEditorViewportAssetDrop->m_fileId);
+	outNormalizedX =
+		m_pendingEditorViewportAssetDrop->m_normalizedX;
+	outNormalizedY =
+		m_pendingEditorViewportAssetDrop->m_normalizedY;
+	m_pendingEditorViewportAssetDrop.reset();
+	return true;
+}
+
+void Window::QueueEditorViewportToolShortcut(uint32_t keyCode)
+{
+	if (!IsEditorViewportToolShortcutKey(keyCode))
+	{
+		return;
+	}
+
+	const std::lock_guard<std::mutex> lock(
+		m_editorViewportToolShortcutMutex);
+	m_pendingEditorViewportToolShortcuts.Add(keyCode);
+}
+
+bool Window::PullEditorViewportToolShortcut(uint32_t& outKeyCode)
+{
+	outKeyCode = 0;
+	const std::lock_guard<std::mutex> lock(
+		m_editorViewportToolShortcutMutex);
+	if (m_pendingEditorViewportToolShortcuts.IsEmpty())
+	{
+		return false;
+	}
+
+	outKeyCode = m_pendingEditorViewportToolShortcuts[0];
+	m_pendingEditorViewportToolShortcuts.RemoveAt(0);
+	return true;
 }
 
 bool Window::IsIconic() const
@@ -528,7 +960,14 @@ LRESULT CALLBACK Sailor::Win32::WindowProc(HWND hWnd, UINT msg, WPARAM wParam, L
 	{
 		if (wParam < 256 && (lParam & 0x40000000) == 0)
 		{
-			GlobalInput::SetKeyState((uint32_t)wParam, KeyState::Pressed);
+			const uint32_t keyCode = static_cast<uint32_t>(wParam);
+			GlobalInput::SetKeyState(keyCode, KeyState::Pressed);
+			if (pWindow->m_parentHwnd &&
+				pWindow->m_windowClassName.starts_with("SailorEditor") &&
+				IsEditorViewportToolShortcutKey(keyCode))
+			{
+				pWindow->QueueEditorViewportToolShortcut(keyCode);
+			}
 		}
 
 		return FALSE;
@@ -567,6 +1006,25 @@ LRESULT CALLBACK Sailor::Win32::WindowProc(HWND hWnd, UINT msg, WPARAM wParam, L
 
 	case WM_NCDESTROY:
 	{
+		if (pWindow->m_editorViewportDropTarget ||
+			pWindow->m_bEditorViewportDropOleInitialized)
+		{
+			RevokeEditorViewportDropTarget(
+				hWnd,
+				pWindow->m_editorViewportDropTarget,
+				pWindow->m_bEditorViewportDropOleInitialized);
+		}
+		{
+			const std::lock_guard<std::mutex> assetDropLock(
+				pWindow->m_editorViewportAssetDropMutex);
+			pWindow->m_pendingEditorViewportAssetDrop.reset();
+		}
+		{
+			const std::lock_guard<std::mutex> shortcutLock(
+				pWindow->m_editorViewportToolShortcutMutex);
+			pWindow->m_pendingEditorViewportToolShortcuts.Clear();
+		}
+
 		const std::lock_guard<std::mutex> lock(Window::g_windowsMutex);
 		pWindow->m_hWnd = nullptr;
 		pWindow->m_hDC = nullptr;

--- a/Runtime/Platform/Win32/Window.h
+++ b/Runtime/Platform/Win32/Window.h
@@ -6,6 +6,8 @@
 #endif
 #include <atomic>
 #include <mutex>
+#include <optional>
+#include <string>
 #include "Math/Math.h"
 #include "Containers/Containers.h"
 
@@ -79,6 +81,21 @@ namespace Sailor::Win32
 
 #if defined(_WIN32)
 		ATOM m_windowClassAtom = 0;
+		IUnknown* m_editorViewportDropTarget = nullptr;
+		bool m_bEditorViewportDropOleInitialized = false;
+
+		struct EditorViewportAssetDrop
+		{
+			std::string m_fileId{};
+			float m_normalizedX = 0.0f;
+			float m_normalizedY = 0.0f;
+		};
+
+		std::mutex m_editorViewportAssetDropMutex{};
+		std::optional<EditorViewportAssetDrop>
+			m_pendingEditorViewportAssetDrop{};
+		std::mutex m_editorViewportToolShortcutMutex{};
+		TVector<uint32_t> m_pendingEditorViewportToolShortcuts{};
 #endif
 
 		std::atomic<int> m_width = 1024;
@@ -156,6 +173,18 @@ namespace Sailor::Win32
 
 		SAILOR_API static void ProcessWin32Msgs();
 		SAILOR_API static bool IsWindowAlive(const Window* pWindow);
+#if defined(_WIN32)
+		void QueueEditorViewportAssetDrop(
+			std::string fileId,
+			float normalizedX,
+			float normalizedY);
+		bool PullEditorViewportAssetDrop(
+			std::string& outFileId,
+			float& outNormalizedX,
+			float& outNormalizedY);
+		void QueueEditorViewportToolShortcut(uint32_t keyCode);
+		bool PullEditorViewportToolShortcut(uint32_t& outKeyCode);
+#endif
 #if defined(__APPLE__)
 		SAILOR_API static void ProcessMacMsgs();
 #endif

--- a/Runtime/Protocol/Generated/editor_engine.pb.cc
+++ b/Runtime/Protocol/Generated/editor_engine.pb.cc
@@ -28,6 +28,84 @@ namespace sailor {
 namespace editor {
 namespace v1 {
 
+inline constexpr ViewportToolStateResult::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : operation_{static_cast< ::sailor::editor::v1::ViewportTransformOperation >(0)},
+        space_{static_cast< ::sailor::editor::v1::ViewportTransformSpace >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR ViewportToolStateResult::ViewportToolStateResult(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct ViewportToolStateResultDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ViewportToolStateResultDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ViewportToolStateResultDefaultTypeInternal() {}
+  union {
+    ViewportToolStateResult _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportToolStateResultDefaultTypeInternal _ViewportToolStateResult_default_instance_;
+
+inline constexpr ViewportToolStateRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : viewport_id_{::uint64_t{0u}},
+        operation_{static_cast< ::sailor::editor::v1::ViewportTransformOperation >(0)},
+        space_{static_cast< ::sailor::editor::v1::ViewportTransformSpace >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR ViewportToolStateRequest::ViewportToolStateRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct ViewportToolStateRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ViewportToolStateRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ViewportToolStateRequestDefaultTypeInternal() {}
+  union {
+    ViewportToolStateRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportToolStateRequestDefaultTypeInternal _ViewportToolStateRequest_default_instance_;
+
+inline constexpr ViewportToolShortcutEvent::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : key_code_{0u},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR ViewportToolShortcutEvent::ViewportToolShortcutEvent(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct ViewportToolShortcutEventDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ViewportToolShortcutEventDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ViewportToolShortcutEventDefaultTypeInternal() {}
+  union {
+    ViewportToolShortcutEvent _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportToolShortcutEventDefaultTypeInternal _ViewportToolShortcutEvent_default_instance_;
+
 inline constexpr ViewportSelectionEvent::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : selected_instance_id_(
@@ -83,6 +161,34 @@ struct ViewportRectRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportRectRequestDefaultTypeInternal _ViewportRectRequest_default_instance_;
 
+inline constexpr ViewportObjectRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : instance_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        viewport_id_{::uint64_t{0u}},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR ViewportObjectRequest::ViewportObjectRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct ViewportObjectRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ViewportObjectRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ViewportObjectRequestDefaultTypeInternal() {}
+  union {
+    ViewportObjectRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportObjectRequestDefaultTypeInternal _ViewportObjectRequest_default_instance_;
+
 inline constexpr ViewportIdRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : viewport_id_{::uint64_t{0u}},
@@ -107,6 +213,62 @@ struct ViewportIdRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportIdRequestDefaultTypeInternal _ViewportIdRequest_default_instance_;
+
+inline constexpr ViewportDropPositionRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : viewport_id_{::uint64_t{0u}},
+        normalized_x_{0},
+        normalized_y_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR ViewportDropPositionRequest::ViewportDropPositionRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct ViewportDropPositionRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ViewportDropPositionRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ViewportDropPositionRequestDefaultTypeInternal() {}
+  union {
+    ViewportDropPositionRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportDropPositionRequestDefaultTypeInternal _ViewportDropPositionRequest_default_instance_;
+
+inline constexpr ViewportAssetDropEvent::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : file_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        normalized_x_{0},
+        normalized_y_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR ViewportAssetDropEvent::ViewportAssetDropEvent(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct ViewportAssetDropEventDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ViewportAssetDropEventDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ViewportAssetDropEventDefaultTypeInternal() {}
+  union {
+    ViewportAssetDropEvent _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportAssetDropEventDefaultTypeInternal _ViewportAssetDropEvent_default_instance_;
 
 inline constexpr Vector4::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -503,6 +665,36 @@ struct RemoteViewportHostRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 RemoteViewportHostRequestDefaultTypeInternal _RemoteViewportHostRequest_default_instance_;
 
+inline constexpr PrefabLinkRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : instance_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        file_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR PrefabLinkRequest::PrefabLinkRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct PrefabLinkRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR PrefabLinkRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~PrefabLinkRequestDefaultTypeInternal() {}
+  union {
+    PrefabLinkRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 PrefabLinkRequestDefaultTypeInternal _PrefabLinkRequest_default_instance_;
+
 inline constexpr ManagedMutationRevisionRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : instance_id_(
@@ -594,6 +786,7 @@ inline constexpr InstantiatePrefabFromYamlRequest::Impl_::Impl_(
         parent_instance_id_(
             &::google::protobuf::internal::fixed_address_empty_string,
             ::_pbi::ConstantInitialized()),
+        strict_instance_ids_{false},
         _cached_size_{0} {}
 
 template <typename>
@@ -917,16 +1110,13 @@ struct ViewportTransformEventDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportTransformEventDefaultTypeInternal _ViewportTransformEvent_default_instance_;
 
-inline constexpr ProtocolRequest::Impl_::Impl_(
+inline constexpr Vector4Result::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
-      : request_id_{::uint64_t{0u}},
-        protocol_version_{0u},
-        command_{},
-        _cached_size_{0},
-        _oneof_case_{} {}
+      : _cached_size_{0},
+        value_{nullptr} {}
 
 template <typename>
-PROTOBUF_CONSTEXPR ProtocolRequest::ProtocolRequest(::_pbi::ConstantInitialized)
+PROTOBUF_CONSTEXPR Vector4Result::Vector4Result(::_pbi::ConstantInitialized)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(_class_data_.base()),
 #else   // PROTOBUF_CUSTOM_VTABLE
@@ -934,16 +1124,83 @@ PROTOBUF_CONSTEXPR ProtocolRequest::ProtocolRequest(::_pbi::ConstantInitialized)
 #endif  // PROTOBUF_CUSTOM_VTABLE
       _impl_(::_pbi::ConstantInitialized()) {
 }
-struct ProtocolRequestDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR ProtocolRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
-  ~ProtocolRequestDefaultTypeInternal() {}
+struct Vector4ResultDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR Vector4ResultDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~Vector4ResultDefaultTypeInternal() {}
   union {
-    ProtocolRequest _instance;
+    Vector4Result _instance;
   };
 };
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
-    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ProtocolRequestDefaultTypeInternal _ProtocolRequest_default_instance_;
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 Vector4ResultDefaultTypeInternal _Vector4Result_default_instance_;
+
+inline constexpr InstantiatePrefabInstanceRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        file_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        parent_instance_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        world_position_{nullptr},
+        apply_world_position_{false} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR InstantiatePrefabInstanceRequest::InstantiatePrefabInstanceRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct InstantiatePrefabInstanceRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR InstantiatePrefabInstanceRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~InstantiatePrefabInstanceRequestDefaultTypeInternal() {}
+  union {
+    InstantiatePrefabInstanceRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 InstantiatePrefabInstanceRequestDefaultTypeInternal _InstantiatePrefabInstanceRequest_default_instance_;
+
+inline constexpr CreateModelGameObjectRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        model_file_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        name_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        parent_instance_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        world_position_{nullptr},
+        apply_world_position_{false} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR CreateModelGameObjectRequest::CreateModelGameObjectRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct CreateModelGameObjectRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR CreateModelGameObjectRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~CreateModelGameObjectRequestDefaultTypeInternal() {}
+  union {
+    CreateModelGameObjectRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 CreateModelGameObjectRequestDefaultTypeInternal _CreateModelGameObjectRequest_default_instance_;
 
 inline constexpr ViewportEvent::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -972,6 +1229,34 @@ struct ViewportEventDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportEventDefaultTypeInternal _ViewportEvent_default_instance_;
+
+inline constexpr ProtocolRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : request_id_{::uint64_t{0u}},
+        protocol_version_{0u},
+        command_{},
+        _cached_size_{0},
+        _oneof_case_{} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR ProtocolRequest::ProtocolRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct ProtocolRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ProtocolRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ProtocolRequestDefaultTypeInternal() {}
+  union {
+    ProtocolRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ProtocolRequestDefaultTypeInternal _ProtocolRequest_default_instance_;
 
 inline constexpr ViewportEventBatchResult::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -1006,6 +1291,7 @@ inline constexpr ProtocolResponse::Impl_::Impl_(
         request_id_{::uint64_t{0u}},
         protocol_version_{0u},
         success_{false},
+        supports_strict_instance_ids_{false},
         result_{},
         _cached_size_{0},
         _oneof_case_{} {}
@@ -1095,6 +1381,14 @@ const ::uint32_t
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolRequest, _impl_.command_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _internal_metadata_),
@@ -1108,6 +1402,9 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _impl_.request_id_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _impl_.success_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _impl_.error_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _impl_.supports_strict_instance_ids_),
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
@@ -1304,6 +1601,83 @@ const ::uint32_t
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabFromYamlRequest, _impl_.prefab_yaml_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabFromYamlRequest, _impl_.parent_instance_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabFromYamlRequest, _impl_.strict_instance_ids_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportDropPositionRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportDropPositionRequest, _impl_.viewport_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportDropPositionRequest, _impl_.normalized_x_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportDropPositionRequest, _impl_.normalized_y_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_.model_file_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_.name_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_.parent_instance_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_.apply_world_position_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_.world_position_),
+        ~0u,
+        ~0u,
+        ~0u,
+        ~0u,
+        0,
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabInstanceRequest, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabInstanceRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabInstanceRequest, _impl_.file_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabInstanceRequest, _impl_.parent_instance_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabInstanceRequest, _impl_.apply_world_position_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabInstanceRequest, _impl_.world_position_),
+        ~0u,
+        ~0u,
+        ~0u,
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportObjectRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportObjectRequest, _impl_.viewport_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportObjectRequest, _impl_.instance_id_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::PrefabLinkRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::PrefabLinkRequest, _impl_.instance_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::PrefabLinkRequest, _impl_.file_id_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolStateRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolStateRequest, _impl_.viewport_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolStateRequest, _impl_.operation_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolStateRequest, _impl_.space_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::SelectionRequest, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -1412,6 +1786,26 @@ const ::uint32_t
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstanceIdResult, _impl_.succeeded_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstanceIdResult, _impl_.instance_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::Vector4Result, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::Vector4Result, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::Vector4Result, _impl_.value_),
+        0,
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolStateResult, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolStateResult, _impl_.operation_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolStateResult, _impl_.space_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::Vector4, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -1460,6 +1854,26 @@ const ::uint32_t
         4,
         5,
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportAssetDropEvent, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportAssetDropEvent, _impl_.file_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportAssetDropEvent, _impl_.normalized_x_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportAssetDropEvent, _impl_.normalized_y_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolShortcutEvent, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolShortcutEvent, _impl_.key_code_),
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportEvent, _internal_metadata_),
         ~0u,  // no _extensions_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportEvent, _impl_._oneof_case_[0]),
@@ -1469,6 +1883,8 @@ const ::uint32_t
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportEvent, _impl_.revision_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportEvent, _impl_.managed_mutation_revision_),
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportEvent, _impl_.payload_),
@@ -1487,40 +1903,50 @@ static const ::_pbi::MigrationSchema
     schemas[] ABSL_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
         {0, -1, -1, sizeof(::sailor::editor::v1::Empty)},
         {8, -1, -1, sizeof(::sailor::editor::v1::ProtocolRequest)},
-        {58, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
-        {81, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
-        {90, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
-        {99, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
-        {108, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
-        {117, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
-        {126, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
-        {138, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
-        {148, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
-        {163, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
-        {174, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
-        {194, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
-        {204, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
-        {214, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
-        {225, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
-        {235, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
-        {246, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
-        {256, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
-        {266, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
-        {275, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
-        {284, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
-        {297, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
-        {306, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
-        {315, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
-        {324, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
-        {333, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
-        {343, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
-        {352, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
-        {364, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
-        {374, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
-        {386, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
-        {395, 412, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
-        {421, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
-        {434, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
+        {66, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
+        {92, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
+        {101, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
+        {110, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
+        {119, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
+        {128, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
+        {137, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
+        {149, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
+        {159, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
+        {174, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
+        {185, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
+        {205, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
+        {215, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
+        {225, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
+        {236, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
+        {246, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
+        {257, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
+        {267, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
+        {278, -1, -1, sizeof(::sailor::editor::v1::ViewportDropPositionRequest)},
+        {289, 302, -1, sizeof(::sailor::editor::v1::CreateModelGameObjectRequest)},
+        {307, 319, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
+        {323, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
+        {333, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
+        {343, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
+        {354, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
+        {363, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
+        {372, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
+        {385, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
+        {394, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
+        {403, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
+        {412, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
+        {421, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
+        {431, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
+        {440, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
+        {452, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
+        {462, 471, -1, sizeof(::sailor::editor::v1::Vector4Result)},
+        {472, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
+        {482, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
+        {494, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
+        {503, 520, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
+        {529, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
+        {540, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
+        {549, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
+        {564, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_Empty_default_instance_._instance,
@@ -1543,6 +1969,12 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_AddComponentRequest_default_instance_._instance,
     &::sailor::editor::v1::_InstantiatePrefabRequest_default_instance_._instance,
     &::sailor::editor::v1::_InstantiatePrefabFromYamlRequest_default_instance_._instance,
+    &::sailor::editor::v1::_ViewportDropPositionRequest_default_instance_._instance,
+    &::sailor::editor::v1::_CreateModelGameObjectRequest_default_instance_._instance,
+    &::sailor::editor::v1::_InstantiatePrefabInstanceRequest_default_instance_._instance,
+    &::sailor::editor::v1::_ViewportObjectRequest_default_instance_._instance,
+    &::sailor::editor::v1::_PrefabLinkRequest_default_instance_._instance,
+    &::sailor::editor::v1::_ViewportToolStateRequest_default_instance_._instance,
     &::sailor::editor::v1::_SelectionRequest_default_instance_._instance,
     &::sailor::editor::v1::_ShowMainWindowRequest_default_instance_._instance,
     &::sailor::editor::v1::_RenderPathTracedImageRequest_default_instance_._instance,
@@ -1554,16 +1986,20 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_StringListResult_default_instance_._instance,
     &::sailor::editor::v1::_AssetReloadStateResult_default_instance_._instance,
     &::sailor::editor::v1::_InstanceIdResult_default_instance_._instance,
+    &::sailor::editor::v1::_Vector4Result_default_instance_._instance,
+    &::sailor::editor::v1::_ViewportToolStateResult_default_instance_._instance,
     &::sailor::editor::v1::_Vector4_default_instance_._instance,
     &::sailor::editor::v1::_ViewportSelectionEvent_default_instance_._instance,
     &::sailor::editor::v1::_ViewportTransformEvent_default_instance_._instance,
+    &::sailor::editor::v1::_ViewportAssetDropEvent_default_instance_._instance,
+    &::sailor::editor::v1::_ViewportToolShortcutEvent_default_instance_._instance,
     &::sailor::editor::v1::_ViewportEvent_default_instance_._instance,
     &::sailor::editor::v1::_ViewportEventBatchResult_default_instance_._instance,
 };
 const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
     protodesc_cold) = {
     "\n\023editor_engine.proto\022\020sailor.editor.v1\""
-    "\007\n\005Empty\"\203\025\n\017ProtocolRequest\022\030\n\020protocol"
+    "\007\n\005Empty\"\354\031\n\017ProtocolRequest\022\030\n\020protocol"
     "_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\0229\n\nin"
     "itialize\030\n \001(\0132#.sailor.editor.v1.Initia"
     "lizeRequestH\000\022(\n\005start\030\013 \001(\0132\027.sailor.ed"
@@ -1629,63 +2065,102 @@ const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SE
     "ne_types\030. \001(\0132\027.sailor.editor.v1.EmptyH"
     "\000\022>\n\033is_engine_main_thread_ready\030/ \001(\0132\027"
     ".sailor.editor.v1.EmptyH\000\0224\n\021is_engine_r"
-    "unning\0300 \001(\0132\027.sailor.editor.v1.EmptyH\000B"
-    "\t\n\007commandJ\004\010\003\020\nJ\004\0101\020d\"\344\005\n\020ProtocolRespo"
-    "nse\022\030\n\020protocol_version\030\001 \001(\r\022\022\n\nrequest"
-    "_id\030\002 \001(\004\022\017\n\007success\030\003 \001(\010\022\r\n\005error\030\004 \001("
-    "\t\022/\n\014empty_result\030\n \001(\0132\027.sailor.editor."
-    "v1.EmptyH\000\0223\n\013bool_result\030\013 \001(\0132\034.sailor"
-    ".editor.v1.BoolResultH\000\0225\n\014int32_result\030"
-    "\014 \001(\0132\035.sailor.editor.v1.Int32ResultH\000\0227"
-    "\n\ruint32_result\030\r \001(\0132\036.sailor.editor.v1"
-    ".UInt32ResultH\000\0227\n\ruint64_result\030\016 \001(\0132\036"
-    ".sailor.editor.v1.UInt64ResultH\000\0227\n\rstri"
-    "ng_result\030\017 \001(\0132\036.sailor.editor.v1.Strin"
-    "gResultH\000\022@\n\022string_list_result\030\020 \001(\0132\"."
-    "sailor.editor.v1.StringListResultH\000\022M\n\031a"
-    "sset_reload_state_result\030\021 \001(\0132(.sailor."
-    "editor.v1.AssetReloadStateResultH\000\022@\n\022in"
-    "stance_id_result\030\022 \001(\0132\".sailor.editor.v"
-    "1.InstanceIdResultH\000\022Q\n\033viewport_event_b"
-    "atch_result\030\023 \001(\0132*.sailor.editor.v1.Vie"
-    "wportEventBatchResultH\000B\010\n\006resultJ\004\010\005\020\nJ"
-    "\004\010\024\020d\"&\n\021InitializeRequest\022\021\n\targuments\030"
-    "\001 \003(\t\"!\n\014CountRequest\022\021\n\tmax_count\030\001 \001(\r"
-    "\" \n\rFileIdRequest\022\017\n\007file_id\030\001 \001(\t\"(\n\021In"
-    "stanceIdRequest\022\023\n\013instance_id\030\001 \001(\t\"(\n\021"
-    "ViewportIdRequest\022\023\n\013viewport_id\030\001 \001(\004\"`"
-    "\n\023ViewportRectRequest\022\024\n\014window_pos_x\030\001 "
-    "\001(\r\022\024\n\014window_pos_y\030\002 \001(\r\022\r\n\005width\030\003 \001(\r"
-    "\022\016\n\006height\030\004 \001(\r\",\n\013SizeRequest\022\r\n\005width"
-    "\030\001 \001(\r\022\016\n\006height\030\002 \001(\r\"\231\001\n\025RemoteViewpor"
-    "tRequest\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014window_"
-    "pos_x\030\002 \001(\r\022\024\n\014window_pos_y\030\003 \001(\r\022\r\n\005wid"
-    "th\030\004 \001(\r\022\016\n\006height\030\005 \001(\r\022\017\n\007visible\030\006 \001("
-    "\010\022\017\n\007focused\030\007 \001(\010\"e\n\031RemoteViewportHost"
-    "Request\022\023\n\013viewport_id\030\001 \001(\004\022\030\n\020host_han"
-    "dle_kind\030\002 \001(\r\022\031\n\021host_handle_value\030\003 \001("
-    "\004\"\374\001\n\032RemoteViewportInputRequest\022\023\n\013view"
-    "port_id\030\001 \001(\004\022\014\n\004kind\030\002 \001(\r\022\021\n\tpointer_x"
-    "\030\003 \001(\002\022\021\n\tpointer_y\030\004 \001(\002\022\025\n\rwheel_delta"
-    "_x\030\005 \001(\002\022\025\n\rwheel_delta_y\030\006 \001(\002\022\020\n\010key_c"
-    "ode\030\007 \001(\r\022\016\n\006button\030\010 \001(\r\022\021\n\tmodifiers\030\t"
-    " \001(\r\022\017\n\007pressed\030\n \001(\010\022\017\n\007focused\030\013 \001(\010\022\020"
-    "\n\010captured\030\014 \001(\010\"C\n\036ManagedMutationRevis"
-    "ionRequest\022\014\n\004kind\030\001 \001(\r\022\023\n\013instance_id\030"
-    "\002 \001(\t\"@\n\023UpdateObjectRequest\022\023\n\013instance"
-    "_id\030\001 \001(\t\022\024\n\014yaml_changes\030\002 \001(\t\"f\n\025Repar"
-    "entObjectRequest\022\023\n\013instance_id\030\001 \001(\t\022\032\n"
-    "\022parent_instance_id\030\002 \001(\t\022\034\n\024keep_world_"
-    "transform\030\003 \001(\010\"T\n\027CreateGameObjectReque"
-    "st\022\032\n\022parent_instance_id\030\001 \001(\t\022\035\n\025prefer"
-    "red_instance_id\030\002 \001(\t\"f\n\023AddComponentReq"
-    "uest\022\023\n\013instance_id\030\001 \001(\t\022\033\n\023component_t"
-    "ype_name\030\002 \001(\t\022\035\n\025preferred_instance_id\030"
-    "\003 \001(\t\"G\n\030InstantiatePrefabRequest\022\017\n\007fil"
-    "e_id\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\"S"
-    "\n InstantiatePrefabFromYamlRequest\022\023\n\013pr"
-    "efab_yaml\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 "
-    "\001(\t\"(\n\020SelectionRequest\022\024\n\014instance_ids\030"
+    "unning\0300 \001(\0132\027.sailor.editor.v1.EmptyH\000\022"
+    "W\n\036resolve_viewport_drop_position\0301 \001(\0132"
+    "-.sailor.editor.v1.ViewportDropPositionR"
+    "equestH\000\022R\n\030create_model_game_object\0302 \001"
+    "(\0132..sailor.editor.v1.CreateModelGameObj"
+    "ectRequestH\000\022Y\n\033instantiate_prefab_insta"
+    "nce\0303 \001(\01322.sailor.editor.v1.Instantiate"
+    "PrefabInstanceRequestH\000\022F\n\023focus_editor_"
+    "camera\0304 \001(\0132\'.sailor.editor.v1.Viewport"
+    "ObjectRequestH\000\022>\n\017set_prefab_link\0305 \001(\013"
+    "2#.sailor.editor.v1.PrefabLinkRequestH\000\022"
+    "@\n\021break_prefab_link\0306 \001(\0132#.sailor.edit"
+    "or.v1.InstanceIdRequestH\000\022M\n\027set_viewpor"
+    "t_tool_state\0307 \001(\0132*.sailor.editor.v1.Vi"
+    "ewportToolStateRequestH\000\022F\n\027get_viewport"
+    "_tool_state\0308 \001(\0132#.sailor.editor.v1.Vie"
+    "wportIdRequestH\000B\t\n\007commandJ\004\010\003\020\nJ\004\0109\020d\""
+    "\226\007\n\020ProtocolResponse\022\030\n\020protocol_version"
+    "\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\022\017\n\007success\030\003 "
+    "\001(\010\022\r\n\005error\030\004 \001(\t\022$\n\034supports_strict_in"
+    "stance_ids\030\005 \001(\010\022/\n\014empty_result\030\n \001(\0132\027"
+    ".sailor.editor.v1.EmptyH\000\0223\n\013bool_result"
+    "\030\013 \001(\0132\034.sailor.editor.v1.BoolResultH\000\0225"
+    "\n\014int32_result\030\014 \001(\0132\035.sailor.editor.v1."
+    "Int32ResultH\000\0227\n\ruint32_result\030\r \001(\0132\036.s"
+    "ailor.editor.v1.UInt32ResultH\000\0227\n\ruint64"
+    "_result\030\016 \001(\0132\036.sailor.editor.v1.UInt64R"
+    "esultH\000\0227\n\rstring_result\030\017 \001(\0132\036.sailor."
+    "editor.v1.StringResultH\000\022@\n\022string_list_"
+    "result\030\020 \001(\0132\".sailor.editor.v1.StringLi"
+    "stResultH\000\022M\n\031asset_reload_state_result\030"
+    "\021 \001(\0132(.sailor.editor.v1.AssetReloadStat"
+    "eResultH\000\022@\n\022instance_id_result\030\022 \001(\0132\"."
+    "sailor.editor.v1.InstanceIdResultH\000\022Q\n\033v"
+    "iewport_event_batch_result\030\023 \001(\0132*.sailo"
+    "r.editor.v1.ViewportEventBatchResultH\000\0229"
+    "\n\016vector4_result\030\024 \001(\0132\037.sailor.editor.v"
+    "1.Vector4ResultH\000\022O\n\032viewport_tool_state"
+    "_result\030\025 \001(\0132).sailor.editor.v1.Viewpor"
+    "tToolStateResultH\000B\010\n\006resultJ\004\010\006\020\nJ\004\010\026\020d"
+    "\"&\n\021InitializeRequest\022\021\n\targuments\030\001 \003(\t"
+    "\"!\n\014CountRequest\022\021\n\tmax_count\030\001 \001(\r\" \n\rF"
+    "ileIdRequest\022\017\n\007file_id\030\001 \001(\t\"(\n\021Instanc"
+    "eIdRequest\022\023\n\013instance_id\030\001 \001(\t\"(\n\021Viewp"
+    "ortIdRequest\022\023\n\013viewport_id\030\001 \001(\004\"`\n\023Vie"
+    "wportRectRequest\022\024\n\014window_pos_x\030\001 \001(\r\022\024"
+    "\n\014window_pos_y\030\002 \001(\r\022\r\n\005width\030\003 \001(\r\022\016\n\006h"
+    "eight\030\004 \001(\r\",\n\013SizeRequest\022\r\n\005width\030\001 \001("
+    "\r\022\016\n\006height\030\002 \001(\r\"\231\001\n\025RemoteViewportRequ"
+    "est\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014window_pos_x"
+    "\030\002 \001(\r\022\024\n\014window_pos_y\030\003 \001(\r\022\r\n\005width\030\004 "
+    "\001(\r\022\016\n\006height\030\005 \001(\r\022\017\n\007visible\030\006 \001(\010\022\017\n\007"
+    "focused\030\007 \001(\010\"e\n\031RemoteViewportHostReque"
+    "st\022\023\n\013viewport_id\030\001 \001(\004\022\030\n\020host_handle_k"
+    "ind\030\002 \001(\r\022\031\n\021host_handle_value\030\003 \001(\004\"\374\001\n"
+    "\032RemoteViewportInputRequest\022\023\n\013viewport_"
+    "id\030\001 \001(\004\022\014\n\004kind\030\002 \001(\r\022\021\n\tpointer_x\030\003 \001("
+    "\002\022\021\n\tpointer_y\030\004 \001(\002\022\025\n\rwheel_delta_x\030\005 "
+    "\001(\002\022\025\n\rwheel_delta_y\030\006 \001(\002\022\020\n\010key_code\030\007"
+    " \001(\r\022\016\n\006button\030\010 \001(\r\022\021\n\tmodifiers\030\t \001(\r\022"
+    "\017\n\007pressed\030\n \001(\010\022\017\n\007focused\030\013 \001(\010\022\020\n\010cap"
+    "tured\030\014 \001(\010\"C\n\036ManagedMutationRevisionRe"
+    "quest\022\014\n\004kind\030\001 \001(\r\022\023\n\013instance_id\030\002 \001(\t"
+    "\"@\n\023UpdateObjectRequest\022\023\n\013instance_id\030\001"
+    " \001(\t\022\024\n\014yaml_changes\030\002 \001(\t\"f\n\025ReparentOb"
+    "jectRequest\022\023\n\013instance_id\030\001 \001(\t\022\032\n\022pare"
+    "nt_instance_id\030\002 \001(\t\022\034\n\024keep_world_trans"
+    "form\030\003 \001(\010\"T\n\027CreateGameObjectRequest\022\032\n"
+    "\022parent_instance_id\030\001 \001(\t\022\035\n\025preferred_i"
+    "nstance_id\030\002 \001(\t\"f\n\023AddComponentRequest\022"
+    "\023\n\013instance_id\030\001 \001(\t\022\033\n\023component_type_n"
+    "ame\030\002 \001(\t\022\035\n\025preferred_instance_id\030\003 \001(\t"
+    "\"G\n\030InstantiatePrefabRequest\022\017\n\007file_id\030"
+    "\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\"p\n Ins"
+    "tantiatePrefabFromYamlRequest\022\023\n\013prefab_"
+    "yaml\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\033"
+    "\n\023strict_instance_ids\030\003 \001(\010\"^\n\033ViewportD"
+    "ropPositionRequest\022\023\n\013viewport_id\030\001 \001(\004\022"
+    "\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 "
+    "\001(\002\"\260\001\n\034CreateModelGameObjectRequest\022\025\n\r"
+    "model_file_id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\032\n\022par"
+    "ent_instance_id\030\003 \001(\t\022\034\n\024apply_world_pos"
+    "ition\030\004 \001(\010\0221\n\016world_position\030\005 \001(\0132\031.sa"
+    "ilor.editor.v1.Vector4\"\240\001\n InstantiatePr"
+    "efabInstanceRequest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022"
+    "parent_instance_id\030\002 \001(\t\022\034\n\024apply_world_"
+    "position\030\003 \001(\010\0221\n\016world_position\030\004 \001(\0132\031"
+    ".sailor.editor.v1.Vector4\"A\n\025ViewportObj"
+    "ectRequest\022\023\n\013viewport_id\030\001 \001(\004\022\023\n\013insta"
+    "nce_id\030\002 \001(\t\"9\n\021PrefabLinkRequest\022\023\n\013ins"
+    "tance_id\030\001 \001(\t\022\017\n\007file_id\030\002 \001(\t\"\251\001\n\030View"
+    "portToolStateRequest\022\023\n\013viewport_id\030\001 \001("
+    "\004\022\?\n\toperation\030\002 \001(\0162,.sailor.editor.v1."
+    "ViewportTransformOperation\0227\n\005space\030\003 \001("
+    "\0162(.sailor.editor.v1.ViewportTransformSp"
+    "ace\"(\n\020SelectionRequest\022\024\n\014instance_ids\030"
     "\001 \003(\t\"%\n\025ShowMainWindowRequest\022\014\n\004show\030\001"
     " \001(\010\"\210\001\n\034RenderPathTracedImageRequest\022\023\n"
     "\013output_path\030\001 \001(\t\022\023\n\013instance_id\030\002 \001(\t\022"
@@ -1700,52 +2175,64 @@ const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SE
     "request_generation\030\002 \001(\004\022\034\n\024completed_ge"
     "neration\030\003 \001(\004\022\035\n\025successful_generation\030"
     "\004 \001(\004\":\n\020InstanceIdResult\022\021\n\tsucceeded\030\001"
-    " \001(\010\022\023\n\013instance_id\030\002 \001(\t\"5\n\007Vector4\022\t\n\001"
-    "x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002"
-    "\"6\n\026ViewportSelectionEvent\022\034\n\024selected_i"
-    "nstance_id\030\001 \001(\t\"\326\003\n\026ViewportTransformEv"
-    "ent\022\023\n\013instance_id\030\001 \001(\t\022\?\n\toperation\030\002 "
-    "\001(\0162,.sailor.editor.v1.ViewportTransform"
-    "Operation\0227\n\005space\030\003 \001(\0162(.sailor.editor"
-    ".v1.ViewportTransformSpace\0222\n\017before_pos"
-    "ition\030\004 \001(\0132\031.sailor.editor.v1.Vector4\0222"
-    "\n\017before_rotation\030\005 \001(\0132\031.sailor.editor."
-    "v1.Vector4\022/\n\014before_scale\030\006 \001(\0132\031.sailo"
-    "r.editor.v1.Vector4\0221\n\016after_position\030\007 "
-    "\001(\0132\031.sailor.editor.v1.Vector4\0221\n\016after_"
-    "rotation\030\010 \001(\0132\031.sailor.editor.v1.Vector"
-    "4\022.\n\013after_scale\030\t \001(\0132\031.sailor.editor.v"
-    "1.Vector4\"\323\001\n\rViewportEvent\022\020\n\010revision\030"
-    "\001 \001(\004\022!\n\031managed_mutation_revision\030\002 \001(\004"
-    "\022=\n\tselection\030\n \001(\0132(.sailor.editor.v1.V"
-    "iewportSelectionEventH\000\022=\n\ttransform\030\013 \001"
-    "(\0132(.sailor.editor.v1.ViewportTransformE"
-    "ventH\000B\t\n\007payloadJ\004\010\003\020\n\"K\n\030ViewportEvent"
-    "BatchResult\022/\n\006events\030\001 \003(\0132\037.sailor.edi"
-    "tor.v1.ViewportEvent*\360\001\n\032ViewportTransfo"
-    "rmOperation\022,\n(VIEWPORT_TRANSFORM_OPERAT"
-    "ION_UNSPECIFIED\020\000\022\'\n#VIEWPORT_TRANSFORM_"
-    "OPERATION_SELECT\020\001\022*\n&VIEWPORT_TRANSFORM"
-    "_OPERATION_TRANSLATE\020\002\022\'\n#VIEWPORT_TRANS"
-    "FORM_OPERATION_ROTATE\020\003\022&\n\"VIEWPORT_TRAN"
-    "SFORM_OPERATION_SCALE\020\004*\212\001\n\026ViewportTran"
-    "sformSpace\022(\n$VIEWPORT_TRANSFORM_SPACE_U"
-    "NSPECIFIED\020\000\022\"\n\036VIEWPORT_TRANSFORM_SPACE"
-    "_WORLD\020\001\022\"\n\036VIEWPORT_TRANSFORM_SPACE_LOC"
-    "AL\020\002B\"\252\002\037SailorEditor.Protocol.Generated"
-    "b\006proto3"
+    " \001(\010\022\023\n\013instance_id\030\002 \001(\t\"9\n\rVector4Resu"
+    "lt\022(\n\005value\030\001 \001(\0132\031.sailor.editor.v1.Vec"
+    "tor4\"\223\001\n\027ViewportToolStateResult\022\?\n\toper"
+    "ation\030\001 \001(\0162,.sailor.editor.v1.ViewportT"
+    "ransformOperation\0227\n\005space\030\002 \001(\0162(.sailo"
+    "r.editor.v1.ViewportTransformSpace\"5\n\007Ve"
+    "ctor4\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n\001z\030\003 \001(\002\022\t"
+    "\n\001w\030\004 \001(\002\"6\n\026ViewportSelectionEvent\022\034\n\024s"
+    "elected_instance_id\030\001 \001(\t\"\326\003\n\026ViewportTr"
+    "ansformEvent\022\023\n\013instance_id\030\001 \001(\t\022\?\n\tope"
+    "ration\030\002 \001(\0162,.sailor.editor.v1.Viewport"
+    "TransformOperation\0227\n\005space\030\003 \001(\0162(.sail"
+    "or.editor.v1.ViewportTransformSpace\0222\n\017b"
+    "efore_position\030\004 \001(\0132\031.sailor.editor.v1."
+    "Vector4\0222\n\017before_rotation\030\005 \001(\0132\031.sailo"
+    "r.editor.v1.Vector4\022/\n\014before_scale\030\006 \001("
+    "\0132\031.sailor.editor.v1.Vector4\0221\n\016after_po"
+    "sition\030\007 \001(\0132\031.sailor.editor.v1.Vector4\022"
+    "1\n\016after_rotation\030\010 \001(\0132\031.sailor.editor."
+    "v1.Vector4\022.\n\013after_scale\030\t \001(\0132\031.sailor"
+    ".editor.v1.Vector4\"U\n\026ViewportAssetDropE"
+    "vent\022\017\n\007file_id\030\001 \001(\t\022\024\n\014normalized_x\030\002 "
+    "\001(\002\022\024\n\014normalized_y\030\003 \001(\002\"-\n\031ViewportToo"
+    "lShortcutEvent\022\020\n\010key_code\030\001 \001(\r\"\331\002\n\rVie"
+    "wportEvent\022\020\n\010revision\030\001 \001(\004\022!\n\031managed_"
+    "mutation_revision\030\002 \001(\004\022=\n\tselection\030\n \001"
+    "(\0132(.sailor.editor.v1.ViewportSelectionE"
+    "ventH\000\022=\n\ttransform\030\013 \001(\0132(.sailor.edito"
+    "r.v1.ViewportTransformEventH\000\022>\n\nasset_d"
+    "rop\030\014 \001(\0132(.sailor.editor.v1.ViewportAss"
+    "etDropEventH\000\022D\n\rtool_shortcut\030\r \001(\0132+.s"
+    "ailor.editor.v1.ViewportToolShortcutEven"
+    "tH\000B\t\n\007payloadJ\004\010\003\020\n\"K\n\030ViewportEventBat"
+    "chResult\022/\n\006events\030\001 \003(\0132\037.sailor.editor"
+    ".v1.ViewportEvent*\360\001\n\032ViewportTransformO"
+    "peration\022,\n(VIEWPORT_TRANSFORM_OPERATION"
+    "_UNSPECIFIED\020\000\022\'\n#VIEWPORT_TRANSFORM_OPE"
+    "RATION_SELECT\020\001\022*\n&VIEWPORT_TRANSFORM_OP"
+    "ERATION_TRANSLATE\020\002\022\'\n#VIEWPORT_TRANSFOR"
+    "M_OPERATION_ROTATE\020\003\022&\n\"VIEWPORT_TRANSFO"
+    "RM_OPERATION_SCALE\020\004*\212\001\n\026ViewportTransfo"
+    "rmSpace\022(\n$VIEWPORT_TRANSFORM_SPACE_UNSP"
+    "ECIFIED\020\000\022\"\n\036VIEWPORT_TRANSFORM_SPACE_WO"
+    "RLD\020\001\022\"\n\036VIEWPORT_TRANSFORM_SPACE_LOCAL\020"
+    "\002B\"\252\002\037SailorEditor.Protocol.Generatedb\006p"
+    "roto3"
 };
 static ::absl::once_flag descriptor_table_editor_5fengine_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_editor_5fengine_2eproto = {
     false,
     false,
-    6848,
+    8885,
     descriptor_table_protodef_editor_5fengine_2eproto,
     "editor_engine.proto",
     &descriptor_table_editor_5fengine_2eproto_once,
     nullptr,
     0,
-    36,
+    46,
     schemas,
     file_default_instances,
     TableStruct_editor_5fengine_2eproto::offsets,
@@ -2391,6 +2878,110 @@ void ProtocolRequest::set_allocated_is_engine_running(::sailor::editor::v1::Empt
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.is_engine_running)
 }
+void ProtocolRequest::set_allocated_resolve_viewport_drop_position(::sailor::editor::v1::ViewportDropPositionRequest* resolve_viewport_drop_position) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (resolve_viewport_drop_position) {
+    ::google::protobuf::Arena* submessage_arena = resolve_viewport_drop_position->GetArena();
+    if (message_arena != submessage_arena) {
+      resolve_viewport_drop_position = ::google::protobuf::internal::GetOwnedMessage(message_arena, resolve_viewport_drop_position, submessage_arena);
+    }
+    set_has_resolve_viewport_drop_position();
+    _impl_.command_.resolve_viewport_drop_position_ = resolve_viewport_drop_position;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
+}
+void ProtocolRequest::set_allocated_create_model_game_object(::sailor::editor::v1::CreateModelGameObjectRequest* create_model_game_object) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (create_model_game_object) {
+    ::google::protobuf::Arena* submessage_arena = create_model_game_object->GetArena();
+    if (message_arena != submessage_arena) {
+      create_model_game_object = ::google::protobuf::internal::GetOwnedMessage(message_arena, create_model_game_object, submessage_arena);
+    }
+    set_has_create_model_game_object();
+    _impl_.command_.create_model_game_object_ = create_model_game_object;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.create_model_game_object)
+}
+void ProtocolRequest::set_allocated_instantiate_prefab_instance(::sailor::editor::v1::InstantiatePrefabInstanceRequest* instantiate_prefab_instance) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (instantiate_prefab_instance) {
+    ::google::protobuf::Arena* submessage_arena = instantiate_prefab_instance->GetArena();
+    if (message_arena != submessage_arena) {
+      instantiate_prefab_instance = ::google::protobuf::internal::GetOwnedMessage(message_arena, instantiate_prefab_instance, submessage_arena);
+    }
+    set_has_instantiate_prefab_instance();
+    _impl_.command_.instantiate_prefab_instance_ = instantiate_prefab_instance;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.instantiate_prefab_instance)
+}
+void ProtocolRequest::set_allocated_focus_editor_camera(::sailor::editor::v1::ViewportObjectRequest* focus_editor_camera) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (focus_editor_camera) {
+    ::google::protobuf::Arena* submessage_arena = focus_editor_camera->GetArena();
+    if (message_arena != submessage_arena) {
+      focus_editor_camera = ::google::protobuf::internal::GetOwnedMessage(message_arena, focus_editor_camera, submessage_arena);
+    }
+    set_has_focus_editor_camera();
+    _impl_.command_.focus_editor_camera_ = focus_editor_camera;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.focus_editor_camera)
+}
+void ProtocolRequest::set_allocated_set_prefab_link(::sailor::editor::v1::PrefabLinkRequest* set_prefab_link) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (set_prefab_link) {
+    ::google::protobuf::Arena* submessage_arena = set_prefab_link->GetArena();
+    if (message_arena != submessage_arena) {
+      set_prefab_link = ::google::protobuf::internal::GetOwnedMessage(message_arena, set_prefab_link, submessage_arena);
+    }
+    set_has_set_prefab_link();
+    _impl_.command_.set_prefab_link_ = set_prefab_link;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.set_prefab_link)
+}
+void ProtocolRequest::set_allocated_break_prefab_link(::sailor::editor::v1::InstanceIdRequest* break_prefab_link) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (break_prefab_link) {
+    ::google::protobuf::Arena* submessage_arena = break_prefab_link->GetArena();
+    if (message_arena != submessage_arena) {
+      break_prefab_link = ::google::protobuf::internal::GetOwnedMessage(message_arena, break_prefab_link, submessage_arena);
+    }
+    set_has_break_prefab_link();
+    _impl_.command_.break_prefab_link_ = break_prefab_link;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.break_prefab_link)
+}
+void ProtocolRequest::set_allocated_set_viewport_tool_state(::sailor::editor::v1::ViewportToolStateRequest* set_viewport_tool_state) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (set_viewport_tool_state) {
+    ::google::protobuf::Arena* submessage_arena = set_viewport_tool_state->GetArena();
+    if (message_arena != submessage_arena) {
+      set_viewport_tool_state = ::google::protobuf::internal::GetOwnedMessage(message_arena, set_viewport_tool_state, submessage_arena);
+    }
+    set_has_set_viewport_tool_state();
+    _impl_.command_.set_viewport_tool_state_ = set_viewport_tool_state;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.set_viewport_tool_state)
+}
+void ProtocolRequest::set_allocated_get_viewport_tool_state(::sailor::editor::v1::ViewportIdRequest* get_viewport_tool_state) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (get_viewport_tool_state) {
+    ::google::protobuf::Arena* submessage_arena = get_viewport_tool_state->GetArena();
+    if (message_arena != submessage_arena) {
+      get_viewport_tool_state = ::google::protobuf::internal::GetOwnedMessage(message_arena, get_viewport_tool_state, submessage_arena);
+    }
+    set_has_get_viewport_tool_state();
+    _impl_.command_.get_viewport_tool_state_ = get_viewport_tool_state;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.get_viewport_tool_state)
+}
 ProtocolRequest::ProtocolRequest(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
@@ -2546,6 +3137,30 @@ ProtocolRequest::ProtocolRequest(
         break;
       case kIsEngineRunning:
         _impl_.command_.is_engine_running_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Empty>(arena, *from._impl_.command_.is_engine_running_);
+        break;
+      case kResolveViewportDropPosition:
+        _impl_.command_.resolve_viewport_drop_position_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportDropPositionRequest>(arena, *from._impl_.command_.resolve_viewport_drop_position_);
+        break;
+      case kCreateModelGameObject:
+        _impl_.command_.create_model_game_object_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::CreateModelGameObjectRequest>(arena, *from._impl_.command_.create_model_game_object_);
+        break;
+      case kInstantiatePrefabInstance:
+        _impl_.command_.instantiate_prefab_instance_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::InstantiatePrefabInstanceRequest>(arena, *from._impl_.command_.instantiate_prefab_instance_);
+        break;
+      case kFocusEditorCamera:
+        _impl_.command_.focus_editor_camera_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportObjectRequest>(arena, *from._impl_.command_.focus_editor_camera_);
+        break;
+      case kSetPrefabLink:
+        _impl_.command_.set_prefab_link_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::PrefabLinkRequest>(arena, *from._impl_.command_.set_prefab_link_);
+        break;
+      case kBreakPrefabLink:
+        _impl_.command_.break_prefab_link_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::InstanceIdRequest>(arena, *from._impl_.command_.break_prefab_link_);
+        break;
+      case kSetViewportToolState:
+        _impl_.command_.set_viewport_tool_state_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportToolStateRequest>(arena, *from._impl_.command_.set_viewport_tool_state_);
+        break;
+      case kGetViewportToolState:
+        _impl_.command_.get_viewport_tool_state_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportIdRequest>(arena, *from._impl_.command_.get_viewport_tool_state_);
         break;
   }
 
@@ -2897,6 +3512,70 @@ void ProtocolRequest::clear_command() {
       }
       break;
     }
+    case kResolveViewportDropPosition: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.resolve_viewport_drop_position_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.resolve_viewport_drop_position_);
+      }
+      break;
+    }
+    case kCreateModelGameObject: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.create_model_game_object_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.create_model_game_object_);
+      }
+      break;
+    }
+    case kInstantiatePrefabInstance: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.instantiate_prefab_instance_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.instantiate_prefab_instance_);
+      }
+      break;
+    }
+    case kFocusEditorCamera: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.focus_editor_camera_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.focus_editor_camera_);
+      }
+      break;
+    }
+    case kSetPrefabLink: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.set_prefab_link_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_prefab_link_);
+      }
+      break;
+    }
+    case kBreakPrefabLink: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.break_prefab_link_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.break_prefab_link_);
+      }
+      break;
+    }
+    case kSetViewportToolState: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.set_viewport_tool_state_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_viewport_tool_state_);
+      }
+      break;
+    }
+    case kGetViewportToolState: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.get_viewport_tool_state_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.get_viewport_tool_state_);
+      }
+      break;
+    }
     case COMMAND_NOT_SET: {
       break;
     }
@@ -2941,16 +3620,16 @@ const ::google::protobuf::internal::ClassData* ProtocolRequest::GetClassData() c
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 41, 39, 0, 7> ProtocolRequest::_table_ = {
+const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    48, 8,  // max_field_number, fast_idx_mask
+    56, 8,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
     508,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    41,  // num_field_entries
-    39,  // num_aux_entries
+    49,  // num_field_entries
+    47,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -2966,8 +3645,8 @@ const ::_pbi::TcParseTable<1, 41, 39, 0, 7> ProtocolRequest::_table_ = {
     {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(ProtocolRequest, _impl_.protocol_version_), 63>(),
      {8, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.protocol_version_)}},
   }}, {{
-    33, 0, 1,
-    0, 25,
+    33, 0, 2,
+    0, 25, 65280, 41,
     65535, 65535
   }}, {{
     // uint32 protocol_version = 1;
@@ -3093,6 +3772,30 @@ const ::_pbi::TcParseTable<1, 41, 39, 0, 7> ProtocolRequest::_table_ = {
     // .sailor.editor.v1.Empty is_engine_running = 48;
     {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.is_engine_running_), _Internal::kOneofCaseOffset + 0, 38,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.ViewportDropPositionRequest resolve_viewport_drop_position = 49;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.resolve_viewport_drop_position_), _Internal::kOneofCaseOffset + 0, 39,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.CreateModelGameObjectRequest create_model_game_object = 50;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.create_model_game_object_), _Internal::kOneofCaseOffset + 0, 40,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.InstantiatePrefabInstanceRequest instantiate_prefab_instance = 51;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.instantiate_prefab_instance_), _Internal::kOneofCaseOffset + 0, 41,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.ViewportObjectRequest focus_editor_camera = 52;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.focus_editor_camera_), _Internal::kOneofCaseOffset + 0, 42,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.PrefabLinkRequest set_prefab_link = 53;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_prefab_link_), _Internal::kOneofCaseOffset + 0, 43,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.InstanceIdRequest break_prefab_link = 54;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.break_prefab_link_), _Internal::kOneofCaseOffset + 0, 44,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.ViewportToolStateRequest set_viewport_tool_state = 55;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_viewport_tool_state_), _Internal::kOneofCaseOffset + 0, 45,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.ViewportIdRequest get_viewport_tool_state = 56;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.get_viewport_tool_state_), _Internal::kOneofCaseOffset + 0, 46,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InitializeRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
@@ -3133,6 +3836,14 @@ const ::_pbi::TcParseTable<1, 41, 39, 0, 7> ProtocolRequest::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportDropPositionRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::CreateModelGameObjectRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::InstantiatePrefabInstanceRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportObjectRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::PrefabLinkRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::InstanceIdRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportToolStateRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportIdRequest>()},
   }}, {{
   }},
 };
@@ -3415,6 +4126,54 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
                   stream);
               break;
             }
+            case kResolveViewportDropPosition: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  49, *this_._impl_.command_.resolve_viewport_drop_position_, this_._impl_.command_.resolve_viewport_drop_position_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kCreateModelGameObject: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  50, *this_._impl_.command_.create_model_game_object_, this_._impl_.command_.create_model_game_object_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kInstantiatePrefabInstance: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  51, *this_._impl_.command_.instantiate_prefab_instance_, this_._impl_.command_.instantiate_prefab_instance_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kFocusEditorCamera: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  52, *this_._impl_.command_.focus_editor_camera_, this_._impl_.command_.focus_editor_camera_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kSetPrefabLink: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  53, *this_._impl_.command_.set_prefab_link_, this_._impl_.command_.set_prefab_link_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kBreakPrefabLink: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  54, *this_._impl_.command_.break_prefab_link_, this_._impl_.command_.break_prefab_link_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kSetViewportToolState: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  55, *this_._impl_.command_.set_viewport_tool_state_, this_._impl_.command_.set_viewport_tool_state_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kGetViewportToolState: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  56, *this_._impl_.command_.get_viewport_tool_state_, this_._impl_.command_.get_viewport_tool_state_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -3687,6 +4446,54 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
             case kIsEngineRunning: {
               total_size += 2 +
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.is_engine_running_);
+              break;
+            }
+            // .sailor.editor.v1.ViewportDropPositionRequest resolve_viewport_drop_position = 49;
+            case kResolveViewportDropPosition: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.resolve_viewport_drop_position_);
+              break;
+            }
+            // .sailor.editor.v1.CreateModelGameObjectRequest create_model_game_object = 50;
+            case kCreateModelGameObject: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.create_model_game_object_);
+              break;
+            }
+            // .sailor.editor.v1.InstantiatePrefabInstanceRequest instantiate_prefab_instance = 51;
+            case kInstantiatePrefabInstance: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.instantiate_prefab_instance_);
+              break;
+            }
+            // .sailor.editor.v1.ViewportObjectRequest focus_editor_camera = 52;
+            case kFocusEditorCamera: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.focus_editor_camera_);
+              break;
+            }
+            // .sailor.editor.v1.PrefabLinkRequest set_prefab_link = 53;
+            case kSetPrefabLink: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.set_prefab_link_);
+              break;
+            }
+            // .sailor.editor.v1.InstanceIdRequest break_prefab_link = 54;
+            case kBreakPrefabLink: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.break_prefab_link_);
+              break;
+            }
+            // .sailor.editor.v1.ViewportToolStateRequest set_viewport_tool_state = 55;
+            case kSetViewportToolState: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.set_viewport_tool_state_);
+              break;
+            }
+            // .sailor.editor.v1.ViewportIdRequest get_viewport_tool_state = 56;
+            case kGetViewportToolState: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.get_viewport_tool_state_);
               break;
             }
             case COMMAND_NOT_SET: {
@@ -4074,6 +4881,78 @@ void ProtocolRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const :
         }
         break;
       }
+      case kResolveViewportDropPosition: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.resolve_viewport_drop_position_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportDropPositionRequest>(arena, *from._impl_.command_.resolve_viewport_drop_position_);
+        } else {
+          _this->_impl_.command_.resolve_viewport_drop_position_->MergeFrom(from._internal_resolve_viewport_drop_position());
+        }
+        break;
+      }
+      case kCreateModelGameObject: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.create_model_game_object_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::CreateModelGameObjectRequest>(arena, *from._impl_.command_.create_model_game_object_);
+        } else {
+          _this->_impl_.command_.create_model_game_object_->MergeFrom(from._internal_create_model_game_object());
+        }
+        break;
+      }
+      case kInstantiatePrefabInstance: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.instantiate_prefab_instance_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::InstantiatePrefabInstanceRequest>(arena, *from._impl_.command_.instantiate_prefab_instance_);
+        } else {
+          _this->_impl_.command_.instantiate_prefab_instance_->MergeFrom(from._internal_instantiate_prefab_instance());
+        }
+        break;
+      }
+      case kFocusEditorCamera: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.focus_editor_camera_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportObjectRequest>(arena, *from._impl_.command_.focus_editor_camera_);
+        } else {
+          _this->_impl_.command_.focus_editor_camera_->MergeFrom(from._internal_focus_editor_camera());
+        }
+        break;
+      }
+      case kSetPrefabLink: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.set_prefab_link_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::PrefabLinkRequest>(arena, *from._impl_.command_.set_prefab_link_);
+        } else {
+          _this->_impl_.command_.set_prefab_link_->MergeFrom(from._internal_set_prefab_link());
+        }
+        break;
+      }
+      case kBreakPrefabLink: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.break_prefab_link_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::InstanceIdRequest>(arena, *from._impl_.command_.break_prefab_link_);
+        } else {
+          _this->_impl_.command_.break_prefab_link_->MergeFrom(from._internal_break_prefab_link());
+        }
+        break;
+      }
+      case kSetViewportToolState: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.set_viewport_tool_state_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportToolStateRequest>(arena, *from._impl_.command_.set_viewport_tool_state_);
+        } else {
+          _this->_impl_.command_.set_viewport_tool_state_->MergeFrom(from._internal_set_viewport_tool_state());
+        }
+        break;
+      }
+      case kGetViewportToolState: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.get_viewport_tool_state_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportIdRequest>(arena, *from._impl_.command_.get_viewport_tool_state_);
+        } else {
+          _this->_impl_.command_.get_viewport_tool_state_->MergeFrom(from._internal_get_viewport_tool_state());
+        }
+        break;
+      }
       case COMMAND_NOT_SET:
         break;
     }
@@ -4243,6 +5122,32 @@ void ProtocolResponse::set_allocated_viewport_event_batch_result(::sailor::edito
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolResponse.viewport_event_batch_result)
 }
+void ProtocolResponse::set_allocated_vector4_result(::sailor::editor::v1::Vector4Result* vector4_result) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_result();
+  if (vector4_result) {
+    ::google::protobuf::Arena* submessage_arena = vector4_result->GetArena();
+    if (message_arena != submessage_arena) {
+      vector4_result = ::google::protobuf::internal::GetOwnedMessage(message_arena, vector4_result, submessage_arena);
+    }
+    set_has_vector4_result();
+    _impl_.result_.vector4_result_ = vector4_result;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolResponse.vector4_result)
+}
+void ProtocolResponse::set_allocated_viewport_tool_state_result(::sailor::editor::v1::ViewportToolStateResult* viewport_tool_state_result) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_result();
+  if (viewport_tool_state_result) {
+    ::google::protobuf::Arena* submessage_arena = viewport_tool_state_result->GetArena();
+    if (message_arena != submessage_arena) {
+      viewport_tool_state_result = ::google::protobuf::internal::GetOwnedMessage(message_arena, viewport_tool_state_result, submessage_arena);
+    }
+    set_has_viewport_tool_state_result();
+    _impl_.result_.viewport_tool_state_result_ = viewport_tool_state_result;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolResponse.viewport_tool_state_result)
+}
 ProtocolResponse::ProtocolResponse(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
@@ -4277,9 +5182,9 @@ ProtocolResponse::ProtocolResponse(
                offsetof(Impl_, request_id_),
            reinterpret_cast<const char *>(&from._impl_) +
                offsetof(Impl_, request_id_),
-           offsetof(Impl_, success_) -
+           offsetof(Impl_, supports_strict_instance_ids_) -
                offsetof(Impl_, request_id_) +
-               sizeof(Impl_::success_));
+               sizeof(Impl_::supports_strict_instance_ids_));
   switch (result_case()) {
     case RESULT_NOT_SET:
       break;
@@ -4313,6 +5218,12 @@ ProtocolResponse::ProtocolResponse(
       case kViewportEventBatchResult:
         _impl_.result_.viewport_event_batch_result_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportEventBatchResult>(arena, *from._impl_.result_.viewport_event_batch_result_);
         break;
+      case kVector4Result:
+        _impl_.result_.vector4_result_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4Result>(arena, *from._impl_.result_.vector4_result_);
+        break;
+      case kViewportToolStateResult:
+        _impl_.result_.viewport_tool_state_result_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportToolStateResult>(arena, *from._impl_.result_.viewport_tool_state_result_);
+        break;
   }
 
   // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.ProtocolResponse)
@@ -4330,9 +5241,9 @@ inline void ProtocolResponse::SharedCtor(::_pb::Arena* arena) {
   ::memset(reinterpret_cast<char *>(&_impl_) +
                offsetof(Impl_, request_id_),
            0,
-           offsetof(Impl_, success_) -
+           offsetof(Impl_, supports_strict_instance_ids_) -
                offsetof(Impl_, request_id_) +
-               sizeof(Impl_::success_));
+               sizeof(Impl_::supports_strict_instance_ids_));
 }
 ProtocolResponse::~ProtocolResponse() {
   // @@protoc_insertion_point(destructor:sailor.editor.v1.ProtocolResponse)
@@ -4433,6 +5344,22 @@ void ProtocolResponse::clear_result() {
       }
       break;
     }
+    case kVector4Result: {
+      if (GetArena() == nullptr) {
+        delete _impl_.result_.vector4_result_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.result_.vector4_result_);
+      }
+      break;
+    }
+    case kViewportToolStateResult: {
+      if (GetArena() == nullptr) {
+        delete _impl_.result_.viewport_tool_state_result_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.result_.viewport_tool_state_result_);
+      }
+      break;
+    }
     case RESULT_NOT_SET: {
       break;
     }
@@ -4477,16 +5404,16 @@ const ::google::protobuf::internal::ClassData* ProtocolResponse::GetClassData() 
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<2, 14, 10, 55, 2> ProtocolResponse::_table_ = {
+const ::_pbi::TcParseTable<3, 17, 12, 63, 2> ProtocolResponse::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    19, 24,  // max_field_number, fast_idx_mask
+    21, 56,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4294443504,  // skipmap
+    4292870624,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    14,  // num_field_entries
-    10,  // num_aux_entries
+    17,  // num_field_entries
+    12,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -4495,9 +5422,7 @@ const ::_pbi::TcParseTable<2, 14, 10, 55, 2> ProtocolResponse::_table_ = {
     ::_pbi::TcParser::GetTable<::sailor::editor::v1::ProtocolResponse>(),  // to_prefetch
     #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
   }, {{
-    // string error = 4;
-    {::_pbi::TcParser::FastUS1,
-     {34, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.error_)}},
+    {::_pbi::TcParser::MiniParse, {}},
     // uint32 protocol_version = 1;
     {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(ProtocolResponse, _impl_.protocol_version_), 63>(),
      {8, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.protocol_version_)}},
@@ -4507,6 +5432,14 @@ const ::_pbi::TcParseTable<2, 14, 10, 55, 2> ProtocolResponse::_table_ = {
     // bool success = 3;
     {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(ProtocolResponse, _impl_.success_), 63>(),
      {24, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.success_)}},
+    // string error = 4;
+    {::_pbi::TcParser::FastUS1,
+     {34, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.error_)}},
+    // bool supports_strict_instance_ids = 5;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(ProtocolResponse, _impl_.supports_strict_instance_ids_), 63>(),
+     {40, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.supports_strict_instance_ids_)}},
+    {::_pbi::TcParser::MiniParse, {}},
+    {::_pbi::TcParser::MiniParse, {}},
   }}, {{
     65535, 65535
   }}, {{
@@ -4522,6 +5455,9 @@ const ::_pbi::TcParseTable<2, 14, 10, 55, 2> ProtocolResponse::_table_ = {
     // string error = 4;
     {PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.error_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // bool supports_strict_instance_ids = 5;
+    {PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.supports_strict_instance_ids_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
     // .sailor.editor.v1.Empty empty_result = 10;
     {PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.result_.empty_result_), _Internal::kOneofCaseOffset + 0, 0,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
@@ -4552,6 +5488,12 @@ const ::_pbi::TcParseTable<2, 14, 10, 55, 2> ProtocolResponse::_table_ = {
     // .sailor.editor.v1.ViewportEventBatchResult viewport_event_batch_result = 19;
     {PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.result_.viewport_event_batch_result_), _Internal::kOneofCaseOffset + 0, 9,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.Vector4Result vector4_result = 20;
+    {PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.result_.vector4_result_), _Internal::kOneofCaseOffset + 0, 10,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.ViewportToolStateResult viewport_tool_state_result = 21;
+    {PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.result_.viewport_tool_state_result_), _Internal::kOneofCaseOffset + 0, 11,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::BoolResult>()},
@@ -4563,8 +5505,10 @@ const ::_pbi::TcParseTable<2, 14, 10, 55, 2> ProtocolResponse::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::AssetReloadStateResult>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InstanceIdResult>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportEventBatchResult>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::Vector4Result>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportToolStateResult>()},
   }}, {{
-    "\41\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0"
+    "\41\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
     "sailor.editor.v1.ProtocolResponse"
     "error"
   }},
@@ -4579,8 +5523,8 @@ PROTOBUF_NOINLINE void ProtocolResponse::Clear() {
 
   _impl_.error_.ClearToEmpty();
   ::memset(&_impl_.request_id_, 0, static_cast<::size_t>(
-      reinterpret_cast<char*>(&_impl_.success_) -
-      reinterpret_cast<char*>(&_impl_.request_id_)) + sizeof(_impl_.success_));
+      reinterpret_cast<char*>(&_impl_.supports_strict_instance_ids_) -
+      reinterpret_cast<char*>(&_impl_.request_id_)) + sizeof(_impl_.supports_strict_instance_ids_));
   clear_result();
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
 }
@@ -4627,6 +5571,13 @@ PROTOBUF_NOINLINE void ProtocolResponse::Clear() {
             ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
                 _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.ProtocolResponse.error");
             target = stream->WriteStringMaybeAliased(4, _s, target);
+          }
+
+          // bool supports_strict_instance_ids = 5;
+          if (this_._internal_supports_strict_instance_ids() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                5, this_._internal_supports_strict_instance_ids(), target);
           }
 
           switch (this_.result_case()) {
@@ -4690,6 +5641,18 @@ PROTOBUF_NOINLINE void ProtocolResponse::Clear() {
                   stream);
               break;
             }
+            case kVector4Result: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  20, *this_._impl_.result_.vector4_result_, this_._impl_.result_.vector4_result_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kViewportToolStateResult: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  21, *this_._impl_.result_.viewport_tool_state_result_, this_._impl_.result_.viewport_tool_state_result_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -4735,6 +5698,10 @@ PROTOBUF_NOINLINE void ProtocolResponse::Clear() {
             }
             // bool success = 3;
             if (this_._internal_success() != 0) {
+              total_size += 2;
+            }
+            // bool supports_strict_instance_ids = 5;
+            if (this_._internal_supports_strict_instance_ids() != 0) {
               total_size += 2;
             }
           }
@@ -4799,6 +5766,18 @@ PROTOBUF_NOINLINE void ProtocolResponse::Clear() {
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.result_.viewport_event_batch_result_);
               break;
             }
+            // .sailor.editor.v1.Vector4Result vector4_result = 20;
+            case kVector4Result: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.result_.vector4_result_);
+              break;
+            }
+            // .sailor.editor.v1.ViewportToolStateResult viewport_tool_state_result = 21;
+            case kViewportToolStateResult: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.result_.viewport_tool_state_result_);
+              break;
+            }
             case RESULT_NOT_SET: {
               break;
             }
@@ -4827,6 +5806,9 @@ void ProtocolResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const 
   }
   if (from._internal_success() != 0) {
     _this->_impl_.success_ = from._impl_.success_;
+  }
+  if (from._internal_supports_strict_instance_ids() != 0) {
+    _this->_impl_.supports_strict_instance_ids_ = from._impl_.supports_strict_instance_ids_;
   }
   if (const uint32_t oneof_from_case = from._impl_._oneof_case_[0]) {
     const uint32_t oneof_to_case = _this->_impl_._oneof_case_[0];
@@ -4929,6 +5911,24 @@ void ProtocolResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const 
         }
         break;
       }
+      case kVector4Result: {
+        if (oneof_needs_init) {
+          _this->_impl_.result_.vector4_result_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4Result>(arena, *from._impl_.result_.vector4_result_);
+        } else {
+          _this->_impl_.result_.vector4_result_->MergeFrom(from._internal_vector4_result());
+        }
+        break;
+      }
+      case kViewportToolStateResult: {
+        if (oneof_needs_init) {
+          _this->_impl_.result_.viewport_tool_state_result_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportToolStateResult>(arena, *from._impl_.result_.viewport_tool_state_result_);
+        } else {
+          _this->_impl_.result_.viewport_tool_state_result_->MergeFrom(from._internal_viewport_tool_state_result());
+        }
+        break;
+      }
       case RESULT_NOT_SET:
         break;
     }
@@ -4951,8 +5951,8 @@ void ProtocolResponse::InternalSwap(ProtocolResponse* PROTOBUF_RESTRICT other) {
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.error_, &other->_impl_.error_, arena);
   ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.success_)
-      + sizeof(ProtocolResponse::_impl_.success_)
+      PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.supports_strict_instance_ids_)
+      + sizeof(ProtocolResponse::_impl_.supports_strict_instance_ids_)
       - PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.request_id_)>(
           reinterpret_cast<char*>(&_impl_.request_id_),
           reinterpret_cast<char*>(&other->_impl_.request_id_));
@@ -9308,6 +10308,7 @@ InstantiatePrefabFromYamlRequest::InstantiatePrefabFromYamlRequest(
   _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
       from._internal_metadata_);
   new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  _impl_.strict_instance_ids_ = from._impl_.strict_instance_ids_;
 
   // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.InstantiatePrefabFromYamlRequest)
 }
@@ -9320,6 +10321,7 @@ inline PROTOBUF_NDEBUG_INLINE InstantiatePrefabFromYamlRequest::Impl_::Impl_(
 
 inline void InstantiatePrefabFromYamlRequest::SharedCtor(::_pb::Arena* arena) {
   new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.strict_instance_ids_ = {};
 }
 InstantiatePrefabFromYamlRequest::~InstantiatePrefabFromYamlRequest() {
   // @@protoc_insertion_point(destructor:sailor.editor.v1.InstantiatePrefabFromYamlRequest)
@@ -9370,15 +10372,15 @@ const ::google::protobuf::internal::ClassData* InstantiatePrefabFromYamlRequest:
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 2, 0, 87, 2> InstantiatePrefabFromYamlRequest::_table_ = {
+const ::_pbi::TcParseTable<2, 3, 0, 87, 2> InstantiatePrefabFromYamlRequest::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    2, 8,  // max_field_number, fast_idx_mask
+    3, 24,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4294967292,  // skipmap
+    4294967288,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    2,  // num_field_entries
+    3,  // num_field_entries
     0,  // num_aux_entries
     offsetof(decltype(_table_), field_names),  // no aux_entries
     _class_data_.base(),
@@ -9388,12 +10390,16 @@ const ::_pbi::TcParseTable<1, 2, 0, 87, 2> InstantiatePrefabFromYamlRequest::_ta
     ::_pbi::TcParser::GetTable<::sailor::editor::v1::InstantiatePrefabFromYamlRequest>(),  // to_prefetch
     #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
   }, {{
-    // string parent_instance_id = 2;
-    {::_pbi::TcParser::FastUS1,
-     {18, 63, 0, PROTOBUF_FIELD_OFFSET(InstantiatePrefabFromYamlRequest, _impl_.parent_instance_id_)}},
+    {::_pbi::TcParser::MiniParse, {}},
     // string prefab_yaml = 1;
     {::_pbi::TcParser::FastUS1,
      {10, 63, 0, PROTOBUF_FIELD_OFFSET(InstantiatePrefabFromYamlRequest, _impl_.prefab_yaml_)}},
+    // string parent_instance_id = 2;
+    {::_pbi::TcParser::FastUS1,
+     {18, 63, 0, PROTOBUF_FIELD_OFFSET(InstantiatePrefabFromYamlRequest, _impl_.parent_instance_id_)}},
+    // bool strict_instance_ids = 3;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(InstantiatePrefabFromYamlRequest, _impl_.strict_instance_ids_), 63>(),
+     {24, 63, 0, PROTOBUF_FIELD_OFFSET(InstantiatePrefabFromYamlRequest, _impl_.strict_instance_ids_)}},
   }}, {{
     65535, 65535
   }}, {{
@@ -9403,6 +10409,9 @@ const ::_pbi::TcParseTable<1, 2, 0, 87, 2> InstantiatePrefabFromYamlRequest::_ta
     // string parent_instance_id = 2;
     {PROTOBUF_FIELD_OFFSET(InstantiatePrefabFromYamlRequest, _impl_.parent_instance_id_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // bool strict_instance_ids = 3;
+    {PROTOBUF_FIELD_OFFSET(InstantiatePrefabFromYamlRequest, _impl_.strict_instance_ids_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
   }},
   // no aux_entries
   {{
@@ -9422,6 +10431,7 @@ PROTOBUF_NOINLINE void InstantiatePrefabFromYamlRequest::Clear() {
 
   _impl_.prefab_yaml_.ClearToEmpty();
   _impl_.parent_instance_id_.ClearToEmpty();
+  _impl_.strict_instance_ids_ = false;
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
 }
 
@@ -9454,6 +10464,13 @@ PROTOBUF_NOINLINE void InstantiatePrefabFromYamlRequest::Clear() {
             ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
                 _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.InstantiatePrefabFromYamlRequest.parent_instance_id");
             target = stream->WriteStringMaybeAliased(2, _s, target);
+          }
+
+          // bool strict_instance_ids = 3;
+          if (this_._internal_strict_instance_ids() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                3, this_._internal_strict_instance_ids(), target);
           }
 
           if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
@@ -9491,6 +10508,10 @@ PROTOBUF_NOINLINE void InstantiatePrefabFromYamlRequest::Clear() {
               total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
                                               this_._internal_parent_instance_id());
             }
+            // bool strict_instance_ids = 3;
+            if (this_._internal_strict_instance_ids() != 0) {
+              total_size += 2;
+            }
           }
           return this_.MaybeComputeUnknownFieldsSize(total_size,
                                                      &this_._impl_._cached_size_);
@@ -9510,6 +10531,9 @@ void InstantiatePrefabFromYamlRequest::MergeImpl(::google::protobuf::MessageLite
   if (!from._internal_parent_instance_id().empty()) {
     _this->_internal_set_parent_instance_id(from._internal_parent_instance_id());
   }
+  if (from._internal_strict_instance_ids() != 0) {
+    _this->_impl_.strict_instance_ids_ = from._impl_.strict_instance_ids_;
+  }
   _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
 }
 
@@ -9528,9 +10552,1776 @@ void InstantiatePrefabFromYamlRequest::InternalSwap(InstantiatePrefabFromYamlReq
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.prefab_yaml_, &other->_impl_.prefab_yaml_, arena);
   ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.parent_instance_id_, &other->_impl_.parent_instance_id_, arena);
+        swap(_impl_.strict_instance_ids_, other->_impl_.strict_instance_ids_);
 }
 
 ::google::protobuf::Metadata InstantiatePrefabFromYamlRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class ViewportDropPositionRequest::_Internal {
+ public:
+};
+
+ViewportDropPositionRequest::ViewportDropPositionRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.ViewportDropPositionRequest)
+}
+ViewportDropPositionRequest::ViewportDropPositionRequest(
+    ::google::protobuf::Arena* arena, const ViewportDropPositionRequest& from)
+    : ViewportDropPositionRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE ViewportDropPositionRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void ViewportDropPositionRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, viewport_id_),
+           0,
+           offsetof(Impl_, normalized_y_) -
+               offsetof(Impl_, viewport_id_) +
+               sizeof(Impl_::normalized_y_));
+}
+ViewportDropPositionRequest::~ViewportDropPositionRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.ViewportDropPositionRequest)
+  SharedDtor(*this);
+}
+inline void ViewportDropPositionRequest::SharedDtor(MessageLite& self) {
+  ViewportDropPositionRequest& this_ = static_cast<ViewportDropPositionRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* ViewportDropPositionRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) ViewportDropPositionRequest(arena);
+}
+constexpr auto ViewportDropPositionRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(ViewportDropPositionRequest),
+                                            alignof(ViewportDropPositionRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull ViewportDropPositionRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_ViewportDropPositionRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &ViewportDropPositionRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<ViewportDropPositionRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &ViewportDropPositionRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<ViewportDropPositionRequest>(), &ViewportDropPositionRequest::ByteSizeLong,
+            &ViewportDropPositionRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_._cached_size_),
+        false,
+    },
+    &ViewportDropPositionRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* ViewportDropPositionRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<2, 3, 0, 0, 2> ViewportDropPositionRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    3, 24,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967288,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    3,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportDropPositionRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+    // uint64 viewport_id = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint64_t, offsetof(ViewportDropPositionRequest, _impl_.viewport_id_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.viewport_id_)}},
+    // float normalized_x = 2;
+    {::_pbi::TcParser::FastF32S1,
+     {21, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.normalized_x_)}},
+    // float normalized_y = 3;
+    {::_pbi::TcParser::FastF32S1,
+     {29, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.normalized_y_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // uint64 viewport_id = 1;
+    {PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.viewport_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUInt64)},
+    // float normalized_x = 2;
+    {PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.normalized_x_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float normalized_y = 3;
+    {PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.normalized_y_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void ViewportDropPositionRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.ViewportDropPositionRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&_impl_.viewport_id_, 0, static_cast<::size_t>(
+      reinterpret_cast<char*>(&_impl_.normalized_y_) -
+      reinterpret_cast<char*>(&_impl_.viewport_id_)) + sizeof(_impl_.normalized_y_));
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* ViewportDropPositionRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const ViewportDropPositionRequest& this_ = static_cast<const ViewportDropPositionRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* ViewportDropPositionRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const ViewportDropPositionRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.ViewportDropPositionRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // uint64 viewport_id = 1;
+          if (this_._internal_viewport_id() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteUInt64ToArray(
+                1, this_._internal_viewport_id(), target);
+          }
+
+          // float normalized_x = 2;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_normalized_x()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                2, this_._internal_normalized_x(), target);
+          }
+
+          // float normalized_y = 3;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_normalized_y()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                3, this_._internal_normalized_y(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.ViewportDropPositionRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t ViewportDropPositionRequest::ByteSizeLong(const MessageLite& base) {
+          const ViewportDropPositionRequest& this_ = static_cast<const ViewportDropPositionRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t ViewportDropPositionRequest::ByteSizeLong() const {
+          const ViewportDropPositionRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.ViewportDropPositionRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // uint64 viewport_id = 1;
+            if (this_._internal_viewport_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(
+                  this_._internal_viewport_id());
+            }
+            // float normalized_x = 2;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_normalized_x()) != 0) {
+              total_size += 5;
+            }
+            // float normalized_y = 3;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_normalized_y()) != 0) {
+              total_size += 5;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void ViewportDropPositionRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<ViewportDropPositionRequest*>(&to_msg);
+  auto& from = static_cast<const ViewportDropPositionRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.ViewportDropPositionRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_viewport_id() != 0) {
+    _this->_impl_.viewport_id_ = from._impl_.viewport_id_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_normalized_x()) != 0) {
+    _this->_impl_.normalized_x_ = from._impl_.normalized_x_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_normalized_y()) != 0) {
+    _this->_impl_.normalized_y_ = from._impl_.normalized_y_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void ViewportDropPositionRequest::CopyFrom(const ViewportDropPositionRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.ViewportDropPositionRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void ViewportDropPositionRequest::InternalSwap(ViewportDropPositionRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.normalized_y_)
+      + sizeof(ViewportDropPositionRequest::_impl_.normalized_y_)
+      - PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.viewport_id_)>(
+          reinterpret_cast<char*>(&_impl_.viewport_id_),
+          reinterpret_cast<char*>(&other->_impl_.viewport_id_));
+}
+
+::google::protobuf::Metadata ViewportDropPositionRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class CreateModelGameObjectRequest::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<CreateModelGameObjectRequest>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_._has_bits_);
+};
+
+CreateModelGameObjectRequest::CreateModelGameObjectRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.CreateModelGameObjectRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE CreateModelGameObjectRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::sailor::editor::v1::CreateModelGameObjectRequest& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0},
+        model_file_id_(arena, from.model_file_id_),
+        name_(arena, from.name_),
+        parent_instance_id_(arena, from.parent_instance_id_) {}
+
+CreateModelGameObjectRequest::CreateModelGameObjectRequest(
+    ::google::protobuf::Arena* arena,
+    const CreateModelGameObjectRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  CreateModelGameObjectRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.world_position_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4>(
+                              arena, *from._impl_.world_position_)
+                        : nullptr;
+  _impl_.apply_world_position_ = from._impl_.apply_world_position_;
+
+  // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.CreateModelGameObjectRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE CreateModelGameObjectRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0},
+        model_file_id_(arena),
+        name_(arena),
+        parent_instance_id_(arena) {}
+
+inline void CreateModelGameObjectRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, world_position_),
+           0,
+           offsetof(Impl_, apply_world_position_) -
+               offsetof(Impl_, world_position_) +
+               sizeof(Impl_::apply_world_position_));
+}
+CreateModelGameObjectRequest::~CreateModelGameObjectRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.CreateModelGameObjectRequest)
+  SharedDtor(*this);
+}
+inline void CreateModelGameObjectRequest::SharedDtor(MessageLite& self) {
+  CreateModelGameObjectRequest& this_ = static_cast<CreateModelGameObjectRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.model_file_id_.Destroy();
+  this_._impl_.name_.Destroy();
+  this_._impl_.parent_instance_id_.Destroy();
+  delete this_._impl_.world_position_;
+  this_._impl_.~Impl_();
+}
+
+inline void* CreateModelGameObjectRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) CreateModelGameObjectRequest(arena);
+}
+constexpr auto CreateModelGameObjectRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(CreateModelGameObjectRequest),
+                                            alignof(CreateModelGameObjectRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull CreateModelGameObjectRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_CreateModelGameObjectRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &CreateModelGameObjectRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<CreateModelGameObjectRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &CreateModelGameObjectRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<CreateModelGameObjectRequest>(), &CreateModelGameObjectRequest::ByteSizeLong,
+            &CreateModelGameObjectRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_._cached_size_),
+        false,
+    },
+    &CreateModelGameObjectRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* CreateModelGameObjectRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<3, 5, 1, 89, 2> CreateModelGameObjectRequest::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_._has_bits_),
+    0, // no _extensions_
+    5, 56,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967264,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    5,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::CreateModelGameObjectRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+    // string model_file_id = 1;
+    {::_pbi::TcParser::FastUS1,
+     {10, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.model_file_id_)}},
+    // string name = 2;
+    {::_pbi::TcParser::FastUS1,
+     {18, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.name_)}},
+    // string parent_instance_id = 3;
+    {::_pbi::TcParser::FastUS1,
+     {26, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.parent_instance_id_)}},
+    // bool apply_world_position = 4;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(CreateModelGameObjectRequest, _impl_.apply_world_position_), 63>(),
+     {32, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.apply_world_position_)}},
+    // .sailor.editor.v1.Vector4 world_position = 5;
+    {::_pbi::TcParser::FastMtS1,
+     {42, 0, 0, PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.world_position_)}},
+    {::_pbi::TcParser::MiniParse, {}},
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // string model_file_id = 1;
+    {PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.model_file_id_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // string name = 2;
+    {PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.name_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // string parent_instance_id = 3;
+    {PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.parent_instance_id_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // bool apply_world_position = 4;
+    {PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.apply_world_position_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+    // .sailor.editor.v1.Vector4 world_position = 5;
+    {PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.world_position_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::Vector4>()},
+  }}, {{
+    "\55\15\4\22\0\0\0\0"
+    "sailor.editor.v1.CreateModelGameObjectRequest"
+    "model_file_id"
+    "name"
+    "parent_instance_id"
+  }},
+};
+
+PROTOBUF_NOINLINE void CreateModelGameObjectRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.CreateModelGameObjectRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.model_file_id_.ClearToEmpty();
+  _impl_.name_.ClearToEmpty();
+  _impl_.parent_instance_id_.ClearToEmpty();
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.world_position_ != nullptr);
+    _impl_.world_position_->Clear();
+  }
+  _impl_.apply_world_position_ = false;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* CreateModelGameObjectRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const CreateModelGameObjectRequest& this_ = static_cast<const CreateModelGameObjectRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* CreateModelGameObjectRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const CreateModelGameObjectRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.CreateModelGameObjectRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // string model_file_id = 1;
+          if (!this_._internal_model_file_id().empty()) {
+            const std::string& _s = this_._internal_model_file_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.CreateModelGameObjectRequest.model_file_id");
+            target = stream->WriteStringMaybeAliased(1, _s, target);
+          }
+
+          // string name = 2;
+          if (!this_._internal_name().empty()) {
+            const std::string& _s = this_._internal_name();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.CreateModelGameObjectRequest.name");
+            target = stream->WriteStringMaybeAliased(2, _s, target);
+          }
+
+          // string parent_instance_id = 3;
+          if (!this_._internal_parent_instance_id().empty()) {
+            const std::string& _s = this_._internal_parent_instance_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id");
+            target = stream->WriteStringMaybeAliased(3, _s, target);
+          }
+
+          // bool apply_world_position = 4;
+          if (this_._internal_apply_world_position() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                4, this_._internal_apply_world_position(), target);
+          }
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .sailor.editor.v1.Vector4 world_position = 5;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                5, *this_._impl_.world_position_, this_._impl_.world_position_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.CreateModelGameObjectRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t CreateModelGameObjectRequest::ByteSizeLong(const MessageLite& base) {
+          const CreateModelGameObjectRequest& this_ = static_cast<const CreateModelGameObjectRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t CreateModelGameObjectRequest::ByteSizeLong() const {
+          const CreateModelGameObjectRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.CreateModelGameObjectRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // string model_file_id = 1;
+            if (!this_._internal_model_file_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_model_file_id());
+            }
+            // string name = 2;
+            if (!this_._internal_name().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_name());
+            }
+            // string parent_instance_id = 3;
+            if (!this_._internal_parent_instance_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_parent_instance_id());
+            }
+          }
+           {
+            // .sailor.editor.v1.Vector4 world_position = 5;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.world_position_);
+            }
+          }
+           {
+            // bool apply_world_position = 4;
+            if (this_._internal_apply_world_position() != 0) {
+              total_size += 2;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void CreateModelGameObjectRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<CreateModelGameObjectRequest*>(&to_msg);
+  auto& from = static_cast<const CreateModelGameObjectRequest&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.CreateModelGameObjectRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_model_file_id().empty()) {
+    _this->_internal_set_model_file_id(from._internal_model_file_id());
+  }
+  if (!from._internal_name().empty()) {
+    _this->_internal_set_name(from._internal_name());
+  }
+  if (!from._internal_parent_instance_id().empty()) {
+    _this->_internal_set_parent_instance_id(from._internal_parent_instance_id());
+  }
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.world_position_ != nullptr);
+    if (_this->_impl_.world_position_ == nullptr) {
+      _this->_impl_.world_position_ =
+          ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4>(arena, *from._impl_.world_position_);
+    } else {
+      _this->_impl_.world_position_->MergeFrom(*from._impl_.world_position_);
+    }
+  }
+  if (from._internal_apply_world_position() != 0) {
+    _this->_impl_.apply_world_position_ = from._impl_.apply_world_position_;
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void CreateModelGameObjectRequest::CopyFrom(const CreateModelGameObjectRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.CreateModelGameObjectRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void CreateModelGameObjectRequest::InternalSwap(CreateModelGameObjectRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.model_file_id_, &other->_impl_.model_file_id_, arena);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.name_, &other->_impl_.name_, arena);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.parent_instance_id_, &other->_impl_.parent_instance_id_, arena);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.apply_world_position_)
+      + sizeof(CreateModelGameObjectRequest::_impl_.apply_world_position_)
+      - PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.world_position_)>(
+          reinterpret_cast<char*>(&_impl_.world_position_),
+          reinterpret_cast<char*>(&other->_impl_.world_position_));
+}
+
+::google::protobuf::Metadata CreateModelGameObjectRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class InstantiatePrefabInstanceRequest::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<InstantiatePrefabInstanceRequest>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_._has_bits_);
+};
+
+InstantiatePrefabInstanceRequest::InstantiatePrefabInstanceRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.InstantiatePrefabInstanceRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE InstantiatePrefabInstanceRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::sailor::editor::v1::InstantiatePrefabInstanceRequest& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0},
+        file_id_(arena, from.file_id_),
+        parent_instance_id_(arena, from.parent_instance_id_) {}
+
+InstantiatePrefabInstanceRequest::InstantiatePrefabInstanceRequest(
+    ::google::protobuf::Arena* arena,
+    const InstantiatePrefabInstanceRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  InstantiatePrefabInstanceRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.world_position_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4>(
+                              arena, *from._impl_.world_position_)
+                        : nullptr;
+  _impl_.apply_world_position_ = from._impl_.apply_world_position_;
+
+  // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.InstantiatePrefabInstanceRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE InstantiatePrefabInstanceRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0},
+        file_id_(arena),
+        parent_instance_id_(arena) {}
+
+inline void InstantiatePrefabInstanceRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, world_position_),
+           0,
+           offsetof(Impl_, apply_world_position_) -
+               offsetof(Impl_, world_position_) +
+               sizeof(Impl_::apply_world_position_));
+}
+InstantiatePrefabInstanceRequest::~InstantiatePrefabInstanceRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.InstantiatePrefabInstanceRequest)
+  SharedDtor(*this);
+}
+inline void InstantiatePrefabInstanceRequest::SharedDtor(MessageLite& self) {
+  InstantiatePrefabInstanceRequest& this_ = static_cast<InstantiatePrefabInstanceRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.file_id_.Destroy();
+  this_._impl_.parent_instance_id_.Destroy();
+  delete this_._impl_.world_position_;
+  this_._impl_.~Impl_();
+}
+
+inline void* InstantiatePrefabInstanceRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) InstantiatePrefabInstanceRequest(arena);
+}
+constexpr auto InstantiatePrefabInstanceRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(InstantiatePrefabInstanceRequest),
+                                            alignof(InstantiatePrefabInstanceRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull InstantiatePrefabInstanceRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_InstantiatePrefabInstanceRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &InstantiatePrefabInstanceRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<InstantiatePrefabInstanceRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &InstantiatePrefabInstanceRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<InstantiatePrefabInstanceRequest>(), &InstantiatePrefabInstanceRequest::ByteSizeLong,
+            &InstantiatePrefabInstanceRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_._cached_size_),
+        false,
+    },
+    &InstantiatePrefabInstanceRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* InstantiatePrefabInstanceRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<2, 4, 1, 83, 2> InstantiatePrefabInstanceRequest::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_._has_bits_),
+    0, // no _extensions_
+    4, 24,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967280,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    4,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::InstantiatePrefabInstanceRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .sailor.editor.v1.Vector4 world_position = 4;
+    {::_pbi::TcParser::FastMtS1,
+     {34, 0, 0, PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_.world_position_)}},
+    // string file_id = 1;
+    {::_pbi::TcParser::FastUS1,
+     {10, 63, 0, PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_.file_id_)}},
+    // string parent_instance_id = 2;
+    {::_pbi::TcParser::FastUS1,
+     {18, 63, 0, PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_.parent_instance_id_)}},
+    // bool apply_world_position = 3;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(InstantiatePrefabInstanceRequest, _impl_.apply_world_position_), 63>(),
+     {24, 63, 0, PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_.apply_world_position_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // string file_id = 1;
+    {PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_.file_id_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // string parent_instance_id = 2;
+    {PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_.parent_instance_id_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // bool apply_world_position = 3;
+    {PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_.apply_world_position_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+    // .sailor.editor.v1.Vector4 world_position = 4;
+    {PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_.world_position_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::Vector4>()},
+  }}, {{
+    "\61\7\22\0\0\0\0\0"
+    "sailor.editor.v1.InstantiatePrefabInstanceRequest"
+    "file_id"
+    "parent_instance_id"
+  }},
+};
+
+PROTOBUF_NOINLINE void InstantiatePrefabInstanceRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.InstantiatePrefabInstanceRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.file_id_.ClearToEmpty();
+  _impl_.parent_instance_id_.ClearToEmpty();
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.world_position_ != nullptr);
+    _impl_.world_position_->Clear();
+  }
+  _impl_.apply_world_position_ = false;
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* InstantiatePrefabInstanceRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const InstantiatePrefabInstanceRequest& this_ = static_cast<const InstantiatePrefabInstanceRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* InstantiatePrefabInstanceRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const InstantiatePrefabInstanceRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.InstantiatePrefabInstanceRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // string file_id = 1;
+          if (!this_._internal_file_id().empty()) {
+            const std::string& _s = this_._internal_file_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.InstantiatePrefabInstanceRequest.file_id");
+            target = stream->WriteStringMaybeAliased(1, _s, target);
+          }
+
+          // string parent_instance_id = 2;
+          if (!this_._internal_parent_instance_id().empty()) {
+            const std::string& _s = this_._internal_parent_instance_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.InstantiatePrefabInstanceRequest.parent_instance_id");
+            target = stream->WriteStringMaybeAliased(2, _s, target);
+          }
+
+          // bool apply_world_position = 3;
+          if (this_._internal_apply_world_position() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                3, this_._internal_apply_world_position(), target);
+          }
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .sailor.editor.v1.Vector4 world_position = 4;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                4, *this_._impl_.world_position_, this_._impl_.world_position_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.InstantiatePrefabInstanceRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t InstantiatePrefabInstanceRequest::ByteSizeLong(const MessageLite& base) {
+          const InstantiatePrefabInstanceRequest& this_ = static_cast<const InstantiatePrefabInstanceRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t InstantiatePrefabInstanceRequest::ByteSizeLong() const {
+          const InstantiatePrefabInstanceRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.InstantiatePrefabInstanceRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // string file_id = 1;
+            if (!this_._internal_file_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_file_id());
+            }
+            // string parent_instance_id = 2;
+            if (!this_._internal_parent_instance_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_parent_instance_id());
+            }
+          }
+           {
+            // .sailor.editor.v1.Vector4 world_position = 4;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.world_position_);
+            }
+          }
+           {
+            // bool apply_world_position = 3;
+            if (this_._internal_apply_world_position() != 0) {
+              total_size += 2;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void InstantiatePrefabInstanceRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<InstantiatePrefabInstanceRequest*>(&to_msg);
+  auto& from = static_cast<const InstantiatePrefabInstanceRequest&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.InstantiatePrefabInstanceRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_file_id().empty()) {
+    _this->_internal_set_file_id(from._internal_file_id());
+  }
+  if (!from._internal_parent_instance_id().empty()) {
+    _this->_internal_set_parent_instance_id(from._internal_parent_instance_id());
+  }
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.world_position_ != nullptr);
+    if (_this->_impl_.world_position_ == nullptr) {
+      _this->_impl_.world_position_ =
+          ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4>(arena, *from._impl_.world_position_);
+    } else {
+      _this->_impl_.world_position_->MergeFrom(*from._impl_.world_position_);
+    }
+  }
+  if (from._internal_apply_world_position() != 0) {
+    _this->_impl_.apply_world_position_ = from._impl_.apply_world_position_;
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void InstantiatePrefabInstanceRequest::CopyFrom(const InstantiatePrefabInstanceRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.InstantiatePrefabInstanceRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void InstantiatePrefabInstanceRequest::InternalSwap(InstantiatePrefabInstanceRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.file_id_, &other->_impl_.file_id_, arena);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.parent_instance_id_, &other->_impl_.parent_instance_id_, arena);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_.apply_world_position_)
+      + sizeof(InstantiatePrefabInstanceRequest::_impl_.apply_world_position_)
+      - PROTOBUF_FIELD_OFFSET(InstantiatePrefabInstanceRequest, _impl_.world_position_)>(
+          reinterpret_cast<char*>(&_impl_.world_position_),
+          reinterpret_cast<char*>(&other->_impl_.world_position_));
+}
+
+::google::protobuf::Metadata InstantiatePrefabInstanceRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class ViewportObjectRequest::_Internal {
+ public:
+};
+
+ViewportObjectRequest::ViewportObjectRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.ViewportObjectRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE ViewportObjectRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::sailor::editor::v1::ViewportObjectRequest& from_msg)
+      : instance_id_(arena, from.instance_id_),
+        _cached_size_{0} {}
+
+ViewportObjectRequest::ViewportObjectRequest(
+    ::google::protobuf::Arena* arena,
+    const ViewportObjectRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  ViewportObjectRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  _impl_.viewport_id_ = from._impl_.viewport_id_;
+
+  // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.ViewportObjectRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE ViewportObjectRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : instance_id_(arena),
+        _cached_size_{0} {}
+
+inline void ViewportObjectRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.viewport_id_ = {};
+}
+ViewportObjectRequest::~ViewportObjectRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.ViewportObjectRequest)
+  SharedDtor(*this);
+}
+inline void ViewportObjectRequest::SharedDtor(MessageLite& self) {
+  ViewportObjectRequest& this_ = static_cast<ViewportObjectRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.instance_id_.Destroy();
+  this_._impl_.~Impl_();
+}
+
+inline void* ViewportObjectRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) ViewportObjectRequest(arena);
+}
+constexpr auto ViewportObjectRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(ViewportObjectRequest),
+                                            alignof(ViewportObjectRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull ViewportObjectRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_ViewportObjectRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &ViewportObjectRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<ViewportObjectRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &ViewportObjectRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<ViewportObjectRequest>(), &ViewportObjectRequest::ByteSizeLong,
+            &ViewportObjectRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(ViewportObjectRequest, _impl_._cached_size_),
+        false,
+    },
+    &ViewportObjectRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* ViewportObjectRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<1, 2, 0, 58, 2> ViewportObjectRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    2, 8,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967292,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    2,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportObjectRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // string instance_id = 2;
+    {::_pbi::TcParser::FastUS1,
+     {18, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportObjectRequest, _impl_.instance_id_)}},
+    // uint64 viewport_id = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint64_t, offsetof(ViewportObjectRequest, _impl_.viewport_id_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportObjectRequest, _impl_.viewport_id_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // uint64 viewport_id = 1;
+    {PROTOBUF_FIELD_OFFSET(ViewportObjectRequest, _impl_.viewport_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUInt64)},
+    // string instance_id = 2;
+    {PROTOBUF_FIELD_OFFSET(ViewportObjectRequest, _impl_.instance_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+  }},
+  // no aux_entries
+  {{
+    "\46\0\13\0\0\0\0\0"
+    "sailor.editor.v1.ViewportObjectRequest"
+    "instance_id"
+  }},
+};
+
+PROTOBUF_NOINLINE void ViewportObjectRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.ViewportObjectRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.instance_id_.ClearToEmpty();
+  _impl_.viewport_id_ = ::uint64_t{0u};
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* ViewportObjectRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const ViewportObjectRequest& this_ = static_cast<const ViewportObjectRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* ViewportObjectRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const ViewportObjectRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.ViewportObjectRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // uint64 viewport_id = 1;
+          if (this_._internal_viewport_id() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteUInt64ToArray(
+                1, this_._internal_viewport_id(), target);
+          }
+
+          // string instance_id = 2;
+          if (!this_._internal_instance_id().empty()) {
+            const std::string& _s = this_._internal_instance_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.ViewportObjectRequest.instance_id");
+            target = stream->WriteStringMaybeAliased(2, _s, target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.ViewportObjectRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t ViewportObjectRequest::ByteSizeLong(const MessageLite& base) {
+          const ViewportObjectRequest& this_ = static_cast<const ViewportObjectRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t ViewportObjectRequest::ByteSizeLong() const {
+          const ViewportObjectRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.ViewportObjectRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // string instance_id = 2;
+            if (!this_._internal_instance_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_instance_id());
+            }
+            // uint64 viewport_id = 1;
+            if (this_._internal_viewport_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(
+                  this_._internal_viewport_id());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void ViewportObjectRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<ViewportObjectRequest*>(&to_msg);
+  auto& from = static_cast<const ViewportObjectRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.ViewportObjectRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_instance_id().empty()) {
+    _this->_internal_set_instance_id(from._internal_instance_id());
+  }
+  if (from._internal_viewport_id() != 0) {
+    _this->_impl_.viewport_id_ = from._impl_.viewport_id_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void ViewportObjectRequest::CopyFrom(const ViewportObjectRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.ViewportObjectRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void ViewportObjectRequest::InternalSwap(ViewportObjectRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.instance_id_, &other->_impl_.instance_id_, arena);
+        swap(_impl_.viewport_id_, other->_impl_.viewport_id_);
+}
+
+::google::protobuf::Metadata ViewportObjectRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class PrefabLinkRequest::_Internal {
+ public:
+};
+
+PrefabLinkRequest::PrefabLinkRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.PrefabLinkRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE PrefabLinkRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::sailor::editor::v1::PrefabLinkRequest& from_msg)
+      : instance_id_(arena, from.instance_id_),
+        file_id_(arena, from.file_id_),
+        _cached_size_{0} {}
+
+PrefabLinkRequest::PrefabLinkRequest(
+    ::google::protobuf::Arena* arena,
+    const PrefabLinkRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  PrefabLinkRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+
+  // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.PrefabLinkRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE PrefabLinkRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : instance_id_(arena),
+        file_id_(arena),
+        _cached_size_{0} {}
+
+inline void PrefabLinkRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+}
+PrefabLinkRequest::~PrefabLinkRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.PrefabLinkRequest)
+  SharedDtor(*this);
+}
+inline void PrefabLinkRequest::SharedDtor(MessageLite& self) {
+  PrefabLinkRequest& this_ = static_cast<PrefabLinkRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.instance_id_.Destroy();
+  this_._impl_.file_id_.Destroy();
+  this_._impl_.~Impl_();
+}
+
+inline void* PrefabLinkRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) PrefabLinkRequest(arena);
+}
+constexpr auto PrefabLinkRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(PrefabLinkRequest),
+                                            alignof(PrefabLinkRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull PrefabLinkRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_PrefabLinkRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &PrefabLinkRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<PrefabLinkRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &PrefabLinkRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<PrefabLinkRequest>(), &PrefabLinkRequest::ByteSizeLong,
+            &PrefabLinkRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(PrefabLinkRequest, _impl_._cached_size_),
+        false,
+    },
+    &PrefabLinkRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* PrefabLinkRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<1, 2, 0, 61, 2> PrefabLinkRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    2, 8,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967292,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    2,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::PrefabLinkRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // string file_id = 2;
+    {::_pbi::TcParser::FastUS1,
+     {18, 63, 0, PROTOBUF_FIELD_OFFSET(PrefabLinkRequest, _impl_.file_id_)}},
+    // string instance_id = 1;
+    {::_pbi::TcParser::FastUS1,
+     {10, 63, 0, PROTOBUF_FIELD_OFFSET(PrefabLinkRequest, _impl_.instance_id_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // string instance_id = 1;
+    {PROTOBUF_FIELD_OFFSET(PrefabLinkRequest, _impl_.instance_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // string file_id = 2;
+    {PROTOBUF_FIELD_OFFSET(PrefabLinkRequest, _impl_.file_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+  }},
+  // no aux_entries
+  {{
+    "\42\13\7\0\0\0\0\0"
+    "sailor.editor.v1.PrefabLinkRequest"
+    "instance_id"
+    "file_id"
+  }},
+};
+
+PROTOBUF_NOINLINE void PrefabLinkRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.PrefabLinkRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.instance_id_.ClearToEmpty();
+  _impl_.file_id_.ClearToEmpty();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* PrefabLinkRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const PrefabLinkRequest& this_ = static_cast<const PrefabLinkRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* PrefabLinkRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const PrefabLinkRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.PrefabLinkRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // string instance_id = 1;
+          if (!this_._internal_instance_id().empty()) {
+            const std::string& _s = this_._internal_instance_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.PrefabLinkRequest.instance_id");
+            target = stream->WriteStringMaybeAliased(1, _s, target);
+          }
+
+          // string file_id = 2;
+          if (!this_._internal_file_id().empty()) {
+            const std::string& _s = this_._internal_file_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.PrefabLinkRequest.file_id");
+            target = stream->WriteStringMaybeAliased(2, _s, target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.PrefabLinkRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t PrefabLinkRequest::ByteSizeLong(const MessageLite& base) {
+          const PrefabLinkRequest& this_ = static_cast<const PrefabLinkRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t PrefabLinkRequest::ByteSizeLong() const {
+          const PrefabLinkRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.PrefabLinkRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // string instance_id = 1;
+            if (!this_._internal_instance_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_instance_id());
+            }
+            // string file_id = 2;
+            if (!this_._internal_file_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_file_id());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void PrefabLinkRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<PrefabLinkRequest*>(&to_msg);
+  auto& from = static_cast<const PrefabLinkRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.PrefabLinkRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_instance_id().empty()) {
+    _this->_internal_set_instance_id(from._internal_instance_id());
+  }
+  if (!from._internal_file_id().empty()) {
+    _this->_internal_set_file_id(from._internal_file_id());
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void PrefabLinkRequest::CopyFrom(const PrefabLinkRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.PrefabLinkRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void PrefabLinkRequest::InternalSwap(PrefabLinkRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.instance_id_, &other->_impl_.instance_id_, arena);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.file_id_, &other->_impl_.file_id_, arena);
+}
+
+::google::protobuf::Metadata PrefabLinkRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class ViewportToolStateRequest::_Internal {
+ public:
+};
+
+ViewportToolStateRequest::ViewportToolStateRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.ViewportToolStateRequest)
+}
+ViewportToolStateRequest::ViewportToolStateRequest(
+    ::google::protobuf::Arena* arena, const ViewportToolStateRequest& from)
+    : ViewportToolStateRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE ViewportToolStateRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void ViewportToolStateRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, viewport_id_),
+           0,
+           offsetof(Impl_, space_) -
+               offsetof(Impl_, viewport_id_) +
+               sizeof(Impl_::space_));
+}
+ViewportToolStateRequest::~ViewportToolStateRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.ViewportToolStateRequest)
+  SharedDtor(*this);
+}
+inline void ViewportToolStateRequest::SharedDtor(MessageLite& self) {
+  ViewportToolStateRequest& this_ = static_cast<ViewportToolStateRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* ViewportToolStateRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) ViewportToolStateRequest(arena);
+}
+constexpr auto ViewportToolStateRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(ViewportToolStateRequest),
+                                            alignof(ViewportToolStateRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull ViewportToolStateRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_ViewportToolStateRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &ViewportToolStateRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<ViewportToolStateRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &ViewportToolStateRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<ViewportToolStateRequest>(), &ViewportToolStateRequest::ByteSizeLong,
+            &ViewportToolStateRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(ViewportToolStateRequest, _impl_._cached_size_),
+        false,
+    },
+    &ViewportToolStateRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* ViewportToolStateRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<2, 3, 0, 0, 2> ViewportToolStateRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    3, 24,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967288,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    3,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportToolStateRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+    // uint64 viewport_id = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint64_t, offsetof(ViewportToolStateRequest, _impl_.viewport_id_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportToolStateRequest, _impl_.viewport_id_)}},
+    // .sailor.editor.v1.ViewportTransformOperation operation = 2;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(ViewportToolStateRequest, _impl_.operation_), 63>(),
+     {16, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportToolStateRequest, _impl_.operation_)}},
+    // .sailor.editor.v1.ViewportTransformSpace space = 3;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(ViewportToolStateRequest, _impl_.space_), 63>(),
+     {24, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportToolStateRequest, _impl_.space_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // uint64 viewport_id = 1;
+    {PROTOBUF_FIELD_OFFSET(ViewportToolStateRequest, _impl_.viewport_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUInt64)},
+    // .sailor.editor.v1.ViewportTransformOperation operation = 2;
+    {PROTOBUF_FIELD_OFFSET(ViewportToolStateRequest, _impl_.operation_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+    // .sailor.editor.v1.ViewportTransformSpace space = 3;
+    {PROTOBUF_FIELD_OFFSET(ViewportToolStateRequest, _impl_.space_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void ViewportToolStateRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.ViewportToolStateRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&_impl_.viewport_id_, 0, static_cast<::size_t>(
+      reinterpret_cast<char*>(&_impl_.space_) -
+      reinterpret_cast<char*>(&_impl_.viewport_id_)) + sizeof(_impl_.space_));
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* ViewportToolStateRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const ViewportToolStateRequest& this_ = static_cast<const ViewportToolStateRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* ViewportToolStateRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const ViewportToolStateRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.ViewportToolStateRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // uint64 viewport_id = 1;
+          if (this_._internal_viewport_id() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteUInt64ToArray(
+                1, this_._internal_viewport_id(), target);
+          }
+
+          // .sailor.editor.v1.ViewportTransformOperation operation = 2;
+          if (this_._internal_operation() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                2, this_._internal_operation(), target);
+          }
+
+          // .sailor.editor.v1.ViewportTransformSpace space = 3;
+          if (this_._internal_space() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                3, this_._internal_space(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.ViewportToolStateRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t ViewportToolStateRequest::ByteSizeLong(const MessageLite& base) {
+          const ViewportToolStateRequest& this_ = static_cast<const ViewportToolStateRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t ViewportToolStateRequest::ByteSizeLong() const {
+          const ViewportToolStateRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.ViewportToolStateRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // uint64 viewport_id = 1;
+            if (this_._internal_viewport_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(
+                  this_._internal_viewport_id());
+            }
+            // .sailor.editor.v1.ViewportTransformOperation operation = 2;
+            if (this_._internal_operation() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_operation());
+            }
+            // .sailor.editor.v1.ViewportTransformSpace space = 3;
+            if (this_._internal_space() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_space());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void ViewportToolStateRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<ViewportToolStateRequest*>(&to_msg);
+  auto& from = static_cast<const ViewportToolStateRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.ViewportToolStateRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_viewport_id() != 0) {
+    _this->_impl_.viewport_id_ = from._impl_.viewport_id_;
+  }
+  if (from._internal_operation() != 0) {
+    _this->_impl_.operation_ = from._impl_.operation_;
+  }
+  if (from._internal_space() != 0) {
+    _this->_impl_.space_ = from._impl_.space_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void ViewportToolStateRequest::CopyFrom(const ViewportToolStateRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.ViewportToolStateRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void ViewportToolStateRequest::InternalSwap(ViewportToolStateRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ViewportToolStateRequest, _impl_.space_)
+      + sizeof(ViewportToolStateRequest::_impl_.space_)
+      - PROTOBUF_FIELD_OFFSET(ViewportToolStateRequest, _impl_.viewport_id_)>(
+          reinterpret_cast<char*>(&_impl_.viewport_id_),
+          reinterpret_cast<char*>(&other->_impl_.viewport_id_));
+}
+
+::google::protobuf::Metadata ViewportToolStateRequest::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================
@@ -12196,6 +14987,497 @@ void InstanceIdResult::InternalSwap(InstanceIdResult* PROTOBUF_RESTRICT other) {
 }
 // ===================================================================
 
+class Vector4Result::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<Vector4Result>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(Vector4Result, _impl_._has_bits_);
+};
+
+Vector4Result::Vector4Result(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.Vector4Result)
+}
+inline PROTOBUF_NDEBUG_INLINE Vector4Result::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::sailor::editor::v1::Vector4Result& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0} {}
+
+Vector4Result::Vector4Result(
+    ::google::protobuf::Arena* arena,
+    const Vector4Result& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  Vector4Result* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.value_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4>(
+                              arena, *from._impl_.value_)
+                        : nullptr;
+
+  // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.Vector4Result)
+}
+inline PROTOBUF_NDEBUG_INLINE Vector4Result::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void Vector4Result::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.value_ = {};
+}
+Vector4Result::~Vector4Result() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.Vector4Result)
+  SharedDtor(*this);
+}
+inline void Vector4Result::SharedDtor(MessageLite& self) {
+  Vector4Result& this_ = static_cast<Vector4Result&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  delete this_._impl_.value_;
+  this_._impl_.~Impl_();
+}
+
+inline void* Vector4Result::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) Vector4Result(arena);
+}
+constexpr auto Vector4Result::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(Vector4Result),
+                                            alignof(Vector4Result));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull Vector4Result::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_Vector4Result_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &Vector4Result::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<Vector4Result>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &Vector4Result::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<Vector4Result>(), &Vector4Result::ByteSizeLong,
+            &Vector4Result::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(Vector4Result, _impl_._cached_size_),
+        false,
+    },
+    &Vector4Result::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* Vector4Result::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 1, 0, 2> Vector4Result::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(Vector4Result, _impl_._has_bits_),
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::Vector4Result>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .sailor.editor.v1.Vector4 value = 1;
+    {::_pbi::TcParser::FastMtS1,
+     {10, 0, 0, PROTOBUF_FIELD_OFFSET(Vector4Result, _impl_.value_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .sailor.editor.v1.Vector4 value = 1;
+    {PROTOBUF_FIELD_OFFSET(Vector4Result, _impl_.value_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::Vector4>()},
+  }}, {{
+  }},
+};
+
+PROTOBUF_NOINLINE void Vector4Result::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.Vector4Result)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.value_ != nullptr);
+    _impl_.value_->Clear();
+  }
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* Vector4Result::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const Vector4Result& this_ = static_cast<const Vector4Result&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* Vector4Result::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const Vector4Result& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.Vector4Result)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .sailor.editor.v1.Vector4 value = 1;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                1, *this_._impl_.value_, this_._impl_.value_->GetCachedSize(), target,
+                stream);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.Vector4Result)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t Vector4Result::ByteSizeLong(const MessageLite& base) {
+          const Vector4Result& this_ = static_cast<const Vector4Result&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t Vector4Result::ByteSizeLong() const {
+          const Vector4Result& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.Vector4Result)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .sailor.editor.v1.Vector4 value = 1;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.value_);
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void Vector4Result::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<Vector4Result*>(&to_msg);
+  auto& from = static_cast<const Vector4Result&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.Vector4Result)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.value_ != nullptr);
+    if (_this->_impl_.value_ == nullptr) {
+      _this->_impl_.value_ =
+          ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4>(arena, *from._impl_.value_);
+    } else {
+      _this->_impl_.value_->MergeFrom(*from._impl_.value_);
+    }
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void Vector4Result::CopyFrom(const Vector4Result& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.Vector4Result)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void Vector4Result::InternalSwap(Vector4Result* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  swap(_impl_.value_, other->_impl_.value_);
+}
+
+::google::protobuf::Metadata Vector4Result::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class ViewportToolStateResult::_Internal {
+ public:
+};
+
+ViewportToolStateResult::ViewportToolStateResult(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.ViewportToolStateResult)
+}
+ViewportToolStateResult::ViewportToolStateResult(
+    ::google::protobuf::Arena* arena, const ViewportToolStateResult& from)
+    : ViewportToolStateResult(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE ViewportToolStateResult::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void ViewportToolStateResult::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, operation_),
+           0,
+           offsetof(Impl_, space_) -
+               offsetof(Impl_, operation_) +
+               sizeof(Impl_::space_));
+}
+ViewportToolStateResult::~ViewportToolStateResult() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.ViewportToolStateResult)
+  SharedDtor(*this);
+}
+inline void ViewportToolStateResult::SharedDtor(MessageLite& self) {
+  ViewportToolStateResult& this_ = static_cast<ViewportToolStateResult&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* ViewportToolStateResult::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) ViewportToolStateResult(arena);
+}
+constexpr auto ViewportToolStateResult::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(ViewportToolStateResult),
+                                            alignof(ViewportToolStateResult));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull ViewportToolStateResult::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_ViewportToolStateResult_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &ViewportToolStateResult::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<ViewportToolStateResult>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &ViewportToolStateResult::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<ViewportToolStateResult>(), &ViewportToolStateResult::ByteSizeLong,
+            &ViewportToolStateResult::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(ViewportToolStateResult, _impl_._cached_size_),
+        false,
+    },
+    &ViewportToolStateResult::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* ViewportToolStateResult::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<1, 2, 0, 0, 2> ViewportToolStateResult::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    2, 8,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967292,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    2,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportToolStateResult>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .sailor.editor.v1.ViewportTransformSpace space = 2;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(ViewportToolStateResult, _impl_.space_), 63>(),
+     {16, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportToolStateResult, _impl_.space_)}},
+    // .sailor.editor.v1.ViewportTransformOperation operation = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(ViewportToolStateResult, _impl_.operation_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportToolStateResult, _impl_.operation_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .sailor.editor.v1.ViewportTransformOperation operation = 1;
+    {PROTOBUF_FIELD_OFFSET(ViewportToolStateResult, _impl_.operation_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+    // .sailor.editor.v1.ViewportTransformSpace space = 2;
+    {PROTOBUF_FIELD_OFFSET(ViewportToolStateResult, _impl_.space_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void ViewportToolStateResult::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.ViewportToolStateResult)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  ::memset(&_impl_.operation_, 0, static_cast<::size_t>(
+      reinterpret_cast<char*>(&_impl_.space_) -
+      reinterpret_cast<char*>(&_impl_.operation_)) + sizeof(_impl_.space_));
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* ViewportToolStateResult::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const ViewportToolStateResult& this_ = static_cast<const ViewportToolStateResult&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* ViewportToolStateResult::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const ViewportToolStateResult& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.ViewportToolStateResult)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .sailor.editor.v1.ViewportTransformOperation operation = 1;
+          if (this_._internal_operation() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_operation(), target);
+          }
+
+          // .sailor.editor.v1.ViewportTransformSpace space = 2;
+          if (this_._internal_space() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                2, this_._internal_space(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.ViewportToolStateResult)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t ViewportToolStateResult::ByteSizeLong(const MessageLite& base) {
+          const ViewportToolStateResult& this_ = static_cast<const ViewportToolStateResult&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t ViewportToolStateResult::ByteSizeLong() const {
+          const ViewportToolStateResult& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.ViewportToolStateResult)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // .sailor.editor.v1.ViewportTransformOperation operation = 1;
+            if (this_._internal_operation() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_operation());
+            }
+            // .sailor.editor.v1.ViewportTransformSpace space = 2;
+            if (this_._internal_space() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_space());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void ViewportToolStateResult::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<ViewportToolStateResult*>(&to_msg);
+  auto& from = static_cast<const ViewportToolStateResult&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.ViewportToolStateResult)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_operation() != 0) {
+    _this->_impl_.operation_ = from._impl_.operation_;
+  }
+  if (from._internal_space() != 0) {
+    _this->_impl_.space_ = from._impl_.space_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void ViewportToolStateResult::CopyFrom(const ViewportToolStateResult& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.ViewportToolStateResult)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void ViewportToolStateResult::InternalSwap(ViewportToolStateResult* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ViewportToolStateResult, _impl_.space_)
+      + sizeof(ViewportToolStateResult::_impl_.space_)
+      - PROTOBUF_FIELD_OFFSET(ViewportToolStateResult, _impl_.operation_)>(
+          reinterpret_cast<char*>(&_impl_.operation_),
+          reinterpret_cast<char*>(&other->_impl_.operation_));
+}
+
+::google::protobuf::Metadata ViewportToolStateResult::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
 class Vector4::_Internal {
  public:
 };
@@ -13246,6 +16528,508 @@ void ViewportTransformEvent::InternalSwap(ViewportTransformEvent* PROTOBUF_RESTR
 }
 // ===================================================================
 
+class ViewportAssetDropEvent::_Internal {
+ public:
+};
+
+ViewportAssetDropEvent::ViewportAssetDropEvent(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.ViewportAssetDropEvent)
+}
+inline PROTOBUF_NDEBUG_INLINE ViewportAssetDropEvent::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::sailor::editor::v1::ViewportAssetDropEvent& from_msg)
+      : file_id_(arena, from.file_id_),
+        _cached_size_{0} {}
+
+ViewportAssetDropEvent::ViewportAssetDropEvent(
+    ::google::protobuf::Arena* arena,
+    const ViewportAssetDropEvent& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  ViewportAssetDropEvent* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::memcpy(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, normalized_x_),
+           reinterpret_cast<const char *>(&from._impl_) +
+               offsetof(Impl_, normalized_x_),
+           offsetof(Impl_, normalized_y_) -
+               offsetof(Impl_, normalized_x_) +
+               sizeof(Impl_::normalized_y_));
+
+  // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.ViewportAssetDropEvent)
+}
+inline PROTOBUF_NDEBUG_INLINE ViewportAssetDropEvent::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : file_id_(arena),
+        _cached_size_{0} {}
+
+inline void ViewportAssetDropEvent::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, normalized_x_),
+           0,
+           offsetof(Impl_, normalized_y_) -
+               offsetof(Impl_, normalized_x_) +
+               sizeof(Impl_::normalized_y_));
+}
+ViewportAssetDropEvent::~ViewportAssetDropEvent() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.ViewportAssetDropEvent)
+  SharedDtor(*this);
+}
+inline void ViewportAssetDropEvent::SharedDtor(MessageLite& self) {
+  ViewportAssetDropEvent& this_ = static_cast<ViewportAssetDropEvent&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.file_id_.Destroy();
+  this_._impl_.~Impl_();
+}
+
+inline void* ViewportAssetDropEvent::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) ViewportAssetDropEvent(arena);
+}
+constexpr auto ViewportAssetDropEvent::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(ViewportAssetDropEvent),
+                                            alignof(ViewportAssetDropEvent));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull ViewportAssetDropEvent::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_ViewportAssetDropEvent_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &ViewportAssetDropEvent::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<ViewportAssetDropEvent>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &ViewportAssetDropEvent::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<ViewportAssetDropEvent>(), &ViewportAssetDropEvent::ByteSizeLong,
+            &ViewportAssetDropEvent::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(ViewportAssetDropEvent, _impl_._cached_size_),
+        false,
+    },
+    &ViewportAssetDropEvent::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* ViewportAssetDropEvent::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<2, 3, 0, 55, 2> ViewportAssetDropEvent::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    3, 24,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967288,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    3,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportAssetDropEvent>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+    // string file_id = 1;
+    {::_pbi::TcParser::FastUS1,
+     {10, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportAssetDropEvent, _impl_.file_id_)}},
+    // float normalized_x = 2;
+    {::_pbi::TcParser::FastF32S1,
+     {21, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportAssetDropEvent, _impl_.normalized_x_)}},
+    // float normalized_y = 3;
+    {::_pbi::TcParser::FastF32S1,
+     {29, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportAssetDropEvent, _impl_.normalized_y_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // string file_id = 1;
+    {PROTOBUF_FIELD_OFFSET(ViewportAssetDropEvent, _impl_.file_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // float normalized_x = 2;
+    {PROTOBUF_FIELD_OFFSET(ViewportAssetDropEvent, _impl_.normalized_x_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float normalized_y = 3;
+    {PROTOBUF_FIELD_OFFSET(ViewportAssetDropEvent, _impl_.normalized_y_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+  }},
+  // no aux_entries
+  {{
+    "\47\7\0\0\0\0\0\0"
+    "sailor.editor.v1.ViewportAssetDropEvent"
+    "file_id"
+  }},
+};
+
+PROTOBUF_NOINLINE void ViewportAssetDropEvent::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.ViewportAssetDropEvent)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.file_id_.ClearToEmpty();
+  ::memset(&_impl_.normalized_x_, 0, static_cast<::size_t>(
+      reinterpret_cast<char*>(&_impl_.normalized_y_) -
+      reinterpret_cast<char*>(&_impl_.normalized_x_)) + sizeof(_impl_.normalized_y_));
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* ViewportAssetDropEvent::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const ViewportAssetDropEvent& this_ = static_cast<const ViewportAssetDropEvent&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* ViewportAssetDropEvent::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const ViewportAssetDropEvent& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.ViewportAssetDropEvent)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // string file_id = 1;
+          if (!this_._internal_file_id().empty()) {
+            const std::string& _s = this_._internal_file_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.ViewportAssetDropEvent.file_id");
+            target = stream->WriteStringMaybeAliased(1, _s, target);
+          }
+
+          // float normalized_x = 2;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_normalized_x()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                2, this_._internal_normalized_x(), target);
+          }
+
+          // float normalized_y = 3;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_normalized_y()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                3, this_._internal_normalized_y(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.ViewportAssetDropEvent)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t ViewportAssetDropEvent::ByteSizeLong(const MessageLite& base) {
+          const ViewportAssetDropEvent& this_ = static_cast<const ViewportAssetDropEvent&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t ViewportAssetDropEvent::ByteSizeLong() const {
+          const ViewportAssetDropEvent& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.ViewportAssetDropEvent)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // string file_id = 1;
+            if (!this_._internal_file_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_file_id());
+            }
+            // float normalized_x = 2;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_normalized_x()) != 0) {
+              total_size += 5;
+            }
+            // float normalized_y = 3;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_normalized_y()) != 0) {
+              total_size += 5;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void ViewportAssetDropEvent::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<ViewportAssetDropEvent*>(&to_msg);
+  auto& from = static_cast<const ViewportAssetDropEvent&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.ViewportAssetDropEvent)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_file_id().empty()) {
+    _this->_internal_set_file_id(from._internal_file_id());
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_normalized_x()) != 0) {
+    _this->_impl_.normalized_x_ = from._impl_.normalized_x_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_normalized_y()) != 0) {
+    _this->_impl_.normalized_y_ = from._impl_.normalized_y_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void ViewportAssetDropEvent::CopyFrom(const ViewportAssetDropEvent& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.ViewportAssetDropEvent)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void ViewportAssetDropEvent::InternalSwap(ViewportAssetDropEvent* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.file_id_, &other->_impl_.file_id_, arena);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(ViewportAssetDropEvent, _impl_.normalized_y_)
+      + sizeof(ViewportAssetDropEvent::_impl_.normalized_y_)
+      - PROTOBUF_FIELD_OFFSET(ViewportAssetDropEvent, _impl_.normalized_x_)>(
+          reinterpret_cast<char*>(&_impl_.normalized_x_),
+          reinterpret_cast<char*>(&other->_impl_.normalized_x_));
+}
+
+::google::protobuf::Metadata ViewportAssetDropEvent::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class ViewportToolShortcutEvent::_Internal {
+ public:
+};
+
+ViewportToolShortcutEvent::ViewportToolShortcutEvent(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.ViewportToolShortcutEvent)
+}
+ViewportToolShortcutEvent::ViewportToolShortcutEvent(
+    ::google::protobuf::Arena* arena, const ViewportToolShortcutEvent& from)
+    : ViewportToolShortcutEvent(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE ViewportToolShortcutEvent::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void ViewportToolShortcutEvent::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.key_code_ = {};
+}
+ViewportToolShortcutEvent::~ViewportToolShortcutEvent() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.ViewportToolShortcutEvent)
+  SharedDtor(*this);
+}
+inline void ViewportToolShortcutEvent::SharedDtor(MessageLite& self) {
+  ViewportToolShortcutEvent& this_ = static_cast<ViewportToolShortcutEvent&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* ViewportToolShortcutEvent::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) ViewportToolShortcutEvent(arena);
+}
+constexpr auto ViewportToolShortcutEvent::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(ViewportToolShortcutEvent),
+                                            alignof(ViewportToolShortcutEvent));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull ViewportToolShortcutEvent::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_ViewportToolShortcutEvent_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &ViewportToolShortcutEvent::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<ViewportToolShortcutEvent>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &ViewportToolShortcutEvent::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<ViewportToolShortcutEvent>(), &ViewportToolShortcutEvent::ByteSizeLong,
+            &ViewportToolShortcutEvent::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(ViewportToolShortcutEvent, _impl_._cached_size_),
+        false,
+    },
+    &ViewportToolShortcutEvent::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* ViewportToolShortcutEvent::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> ViewportToolShortcutEvent::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportToolShortcutEvent>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // uint32 key_code = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(ViewportToolShortcutEvent, _impl_.key_code_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportToolShortcutEvent, _impl_.key_code_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // uint32 key_code = 1;
+    {PROTOBUF_FIELD_OFFSET(ViewportToolShortcutEvent, _impl_.key_code_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUInt32)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void ViewportToolShortcutEvent::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.ViewportToolShortcutEvent)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.key_code_ = 0u;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* ViewportToolShortcutEvent::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const ViewportToolShortcutEvent& this_ = static_cast<const ViewportToolShortcutEvent&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* ViewportToolShortcutEvent::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const ViewportToolShortcutEvent& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.ViewportToolShortcutEvent)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // uint32 key_code = 1;
+          if (this_._internal_key_code() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteUInt32ToArray(
+                1, this_._internal_key_code(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.ViewportToolShortcutEvent)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t ViewportToolShortcutEvent::ByteSizeLong(const MessageLite& base) {
+          const ViewportToolShortcutEvent& this_ = static_cast<const ViewportToolShortcutEvent&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t ViewportToolShortcutEvent::ByteSizeLong() const {
+          const ViewportToolShortcutEvent& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.ViewportToolShortcutEvent)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // uint32 key_code = 1;
+            if (this_._internal_key_code() != 0) {
+              total_size += ::_pbi::WireFormatLite::UInt32SizePlusOne(
+                  this_._internal_key_code());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void ViewportToolShortcutEvent::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<ViewportToolShortcutEvent*>(&to_msg);
+  auto& from = static_cast<const ViewportToolShortcutEvent&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.ViewportToolShortcutEvent)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_key_code() != 0) {
+    _this->_impl_.key_code_ = from._impl_.key_code_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void ViewportToolShortcutEvent::CopyFrom(const ViewportToolShortcutEvent& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.ViewportToolShortcutEvent)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void ViewportToolShortcutEvent::InternalSwap(ViewportToolShortcutEvent* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.key_code_, other->_impl_.key_code_);
+}
+
+::google::protobuf::Metadata ViewportToolShortcutEvent::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
 class ViewportEvent::_Internal {
  public:
   static constexpr ::int32_t kOneofCaseOffset =
@@ -13277,6 +17061,32 @@ void ViewportEvent::set_allocated_transform(::sailor::editor::v1::ViewportTransf
     _impl_.payload_.transform_ = transform;
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ViewportEvent.transform)
+}
+void ViewportEvent::set_allocated_asset_drop(::sailor::editor::v1::ViewportAssetDropEvent* asset_drop) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_payload();
+  if (asset_drop) {
+    ::google::protobuf::Arena* submessage_arena = asset_drop->GetArena();
+    if (message_arena != submessage_arena) {
+      asset_drop = ::google::protobuf::internal::GetOwnedMessage(message_arena, asset_drop, submessage_arena);
+    }
+    set_has_asset_drop();
+    _impl_.payload_.asset_drop_ = asset_drop;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ViewportEvent.asset_drop)
+}
+void ViewportEvent::set_allocated_tool_shortcut(::sailor::editor::v1::ViewportToolShortcutEvent* tool_shortcut) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_payload();
+  if (tool_shortcut) {
+    ::google::protobuf::Arena* submessage_arena = tool_shortcut->GetArena();
+    if (message_arena != submessage_arena) {
+      tool_shortcut = ::google::protobuf::internal::GetOwnedMessage(message_arena, tool_shortcut, submessage_arena);
+    }
+    set_has_tool_shortcut();
+    _impl_.payload_.tool_shortcut_ = tool_shortcut;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ViewportEvent.tool_shortcut)
 }
 ViewportEvent::ViewportEvent(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
@@ -13322,6 +17132,12 @@ ViewportEvent::ViewportEvent(
         break;
       case kTransform:
         _impl_.payload_.transform_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportTransformEvent>(arena, *from._impl_.payload_.transform_);
+        break;
+      case kAssetDrop:
+        _impl_.payload_.asset_drop_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportAssetDropEvent>(arena, *from._impl_.payload_.asset_drop_);
+        break;
+      case kToolShortcut:
+        _impl_.payload_.tool_shortcut_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportToolShortcutEvent>(arena, *from._impl_.payload_.tool_shortcut_);
         break;
   }
 
@@ -13377,6 +17193,22 @@ void ViewportEvent::clear_payload() {
       }
       break;
     }
+    case kAssetDrop: {
+      if (GetArena() == nullptr) {
+        delete _impl_.payload_.asset_drop_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.payload_.asset_drop_);
+      }
+      break;
+    }
+    case kToolShortcut: {
+      if (GetArena() == nullptr) {
+        delete _impl_.payload_.tool_shortcut_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.payload_.tool_shortcut_);
+      }
+      break;
+    }
     case PAYLOAD_NOT_SET: {
       break;
     }
@@ -13421,16 +17253,16 @@ const ::google::protobuf::internal::ClassData* ViewportEvent::GetClassData() con
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 4, 2, 0, 2> ViewportEvent::_table_ = {
+const ::_pbi::TcParseTable<1, 6, 4, 0, 2> ViewportEvent::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    11, 8,  // max_field_number, fast_idx_mask
+    13, 8,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4294965756,  // skipmap
+    4294959612,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    4,  // num_field_entries
-    2,  // num_aux_entries
+    6,  // num_field_entries
+    4,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -13460,9 +17292,17 @@ const ::_pbi::TcParseTable<1, 4, 2, 0, 2> ViewportEvent::_table_ = {
     // .sailor.editor.v1.ViewportTransformEvent transform = 11;
     {PROTOBUF_FIELD_OFFSET(ViewportEvent, _impl_.payload_.transform_), _Internal::kOneofCaseOffset + 0, 1,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.ViewportAssetDropEvent asset_drop = 12;
+    {PROTOBUF_FIELD_OFFSET(ViewportEvent, _impl_.payload_.asset_drop_), _Internal::kOneofCaseOffset + 0, 2,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.ViewportToolShortcutEvent tool_shortcut = 13;
+    {PROTOBUF_FIELD_OFFSET(ViewportEvent, _impl_.payload_.tool_shortcut_), _Internal::kOneofCaseOffset + 0, 3,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportSelectionEvent>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportTransformEvent>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportAssetDropEvent>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportToolShortcutEvent>()},
   }}, {{
   }},
 };
@@ -13523,6 +17363,18 @@ PROTOBUF_NOINLINE void ViewportEvent::Clear() {
                   stream);
               break;
             }
+            case kAssetDrop: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  12, *this_._impl_.payload_.asset_drop_, this_._impl_.payload_.asset_drop_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kToolShortcut: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  13, *this_._impl_.payload_.tool_shortcut_, this_._impl_.payload_.tool_shortcut_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -13575,6 +17427,18 @@ PROTOBUF_NOINLINE void ViewportEvent::Clear() {
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.payload_.transform_);
               break;
             }
+            // .sailor.editor.v1.ViewportAssetDropEvent asset_drop = 12;
+            case kAssetDrop: {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.payload_.asset_drop_);
+              break;
+            }
+            // .sailor.editor.v1.ViewportToolShortcutEvent tool_shortcut = 13;
+            case kToolShortcut: {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.payload_.tool_shortcut_);
+              break;
+            }
             case PAYLOAD_NOT_SET: {
               break;
             }
@@ -13624,6 +17488,24 @@ void ViewportEvent::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::g
               ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportTransformEvent>(arena, *from._impl_.payload_.transform_);
         } else {
           _this->_impl_.payload_.transform_->MergeFrom(from._internal_transform());
+        }
+        break;
+      }
+      case kAssetDrop: {
+        if (oneof_needs_init) {
+          _this->_impl_.payload_.asset_drop_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportAssetDropEvent>(arena, *from._impl_.payload_.asset_drop_);
+        } else {
+          _this->_impl_.payload_.asset_drop_->MergeFrom(from._internal_asset_drop());
+        }
+        break;
+      }
+      case kToolShortcut: {
+        if (oneof_needs_init) {
+          _this->_impl_.payload_.tool_shortcut_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportToolShortcutEvent>(arena, *from._impl_.payload_.tool_shortcut_);
+        } else {
+          _this->_impl_.payload_.tool_shortcut_->MergeFrom(from._internal_tool_shortcut());
         }
         break;
       }

--- a/Runtime/Protocol/Generated/editor_engine.pb.h
+++ b/Runtime/Protocol/Generated/editor_engine.pb.h
@@ -71,6 +71,9 @@ extern CountRequestDefaultTypeInternal _CountRequest_default_instance_;
 class CreateGameObjectRequest;
 struct CreateGameObjectRequestDefaultTypeInternal;
 extern CreateGameObjectRequestDefaultTypeInternal _CreateGameObjectRequest_default_instance_;
+class CreateModelGameObjectRequest;
+struct CreateModelGameObjectRequestDefaultTypeInternal;
+extern CreateModelGameObjectRequestDefaultTypeInternal _CreateModelGameObjectRequest_default_instance_;
 class Empty;
 struct EmptyDefaultTypeInternal;
 extern EmptyDefaultTypeInternal _Empty_default_instance_;
@@ -89,6 +92,9 @@ extern InstanceIdResultDefaultTypeInternal _InstanceIdResult_default_instance_;
 class InstantiatePrefabFromYamlRequest;
 struct InstantiatePrefabFromYamlRequestDefaultTypeInternal;
 extern InstantiatePrefabFromYamlRequestDefaultTypeInternal _InstantiatePrefabFromYamlRequest_default_instance_;
+class InstantiatePrefabInstanceRequest;
+struct InstantiatePrefabInstanceRequestDefaultTypeInternal;
+extern InstantiatePrefabInstanceRequestDefaultTypeInternal _InstantiatePrefabInstanceRequest_default_instance_;
 class InstantiatePrefabRequest;
 struct InstantiatePrefabRequestDefaultTypeInternal;
 extern InstantiatePrefabRequestDefaultTypeInternal _InstantiatePrefabRequest_default_instance_;
@@ -98,6 +104,9 @@ extern Int32ResultDefaultTypeInternal _Int32Result_default_instance_;
 class ManagedMutationRevisionRequest;
 struct ManagedMutationRevisionRequestDefaultTypeInternal;
 extern ManagedMutationRevisionRequestDefaultTypeInternal _ManagedMutationRevisionRequest_default_instance_;
+class PrefabLinkRequest;
+struct PrefabLinkRequestDefaultTypeInternal;
+extern PrefabLinkRequestDefaultTypeInternal _PrefabLinkRequest_default_instance_;
 class ProtocolRequest;
 struct ProtocolRequestDefaultTypeInternal;
 extern ProtocolRequestDefaultTypeInternal _ProtocolRequest_default_instance_;
@@ -146,6 +155,15 @@ extern UpdateObjectRequestDefaultTypeInternal _UpdateObjectRequest_default_insta
 class Vector4;
 struct Vector4DefaultTypeInternal;
 extern Vector4DefaultTypeInternal _Vector4_default_instance_;
+class Vector4Result;
+struct Vector4ResultDefaultTypeInternal;
+extern Vector4ResultDefaultTypeInternal _Vector4Result_default_instance_;
+class ViewportAssetDropEvent;
+struct ViewportAssetDropEventDefaultTypeInternal;
+extern ViewportAssetDropEventDefaultTypeInternal _ViewportAssetDropEvent_default_instance_;
+class ViewportDropPositionRequest;
+struct ViewportDropPositionRequestDefaultTypeInternal;
+extern ViewportDropPositionRequestDefaultTypeInternal _ViewportDropPositionRequest_default_instance_;
 class ViewportEvent;
 struct ViewportEventDefaultTypeInternal;
 extern ViewportEventDefaultTypeInternal _ViewportEvent_default_instance_;
@@ -155,12 +173,24 @@ extern ViewportEventBatchResultDefaultTypeInternal _ViewportEventBatchResult_def
 class ViewportIdRequest;
 struct ViewportIdRequestDefaultTypeInternal;
 extern ViewportIdRequestDefaultTypeInternal _ViewportIdRequest_default_instance_;
+class ViewportObjectRequest;
+struct ViewportObjectRequestDefaultTypeInternal;
+extern ViewportObjectRequestDefaultTypeInternal _ViewportObjectRequest_default_instance_;
 class ViewportRectRequest;
 struct ViewportRectRequestDefaultTypeInternal;
 extern ViewportRectRequestDefaultTypeInternal _ViewportRectRequest_default_instance_;
 class ViewportSelectionEvent;
 struct ViewportSelectionEventDefaultTypeInternal;
 extern ViewportSelectionEventDefaultTypeInternal _ViewportSelectionEvent_default_instance_;
+class ViewportToolShortcutEvent;
+struct ViewportToolShortcutEventDefaultTypeInternal;
+extern ViewportToolShortcutEventDefaultTypeInternal _ViewportToolShortcutEvent_default_instance_;
+class ViewportToolStateRequest;
+struct ViewportToolStateRequestDefaultTypeInternal;
+extern ViewportToolStateRequestDefaultTypeInternal _ViewportToolStateRequest_default_instance_;
+class ViewportToolStateResult;
+struct ViewportToolStateResultDefaultTypeInternal;
+extern ViewportToolStateResultDefaultTypeInternal _ViewportToolStateResult_default_instance_;
 class ViewportTransformEvent;
 struct ViewportTransformEventDefaultTypeInternal;
 extern ViewportTransformEventDefaultTypeInternal _ViewportTransformEvent_default_instance_;
@@ -251,6 +281,612 @@ inline bool ViewportTransformSpace_Parse(absl::string_view name, ViewportTransfo
 
 // -------------------------------------------------------------------
 
+class ViewportToolStateResult final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportToolStateResult) */ {
+ public:
+  inline ViewportToolStateResult() : ViewportToolStateResult(nullptr) {}
+  ~ViewportToolStateResult() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(ViewportToolStateResult* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(ViewportToolStateResult));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR ViewportToolStateResult(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline ViewportToolStateResult(const ViewportToolStateResult& from) : ViewportToolStateResult(nullptr, from) {}
+  inline ViewportToolStateResult(ViewportToolStateResult&& from) noexcept
+      : ViewportToolStateResult(nullptr, std::move(from)) {}
+  inline ViewportToolStateResult& operator=(const ViewportToolStateResult& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ViewportToolStateResult& operator=(ViewportToolStateResult&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ViewportToolStateResult& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ViewportToolStateResult* internal_default_instance() {
+    return reinterpret_cast<const ViewportToolStateResult*>(
+        &_ViewportToolStateResult_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 38;
+  friend void swap(ViewportToolStateResult& a, ViewportToolStateResult& b) { a.Swap(&b); }
+  inline void Swap(ViewportToolStateResult* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ViewportToolStateResult* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ViewportToolStateResult* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<ViewportToolStateResult>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const ViewportToolStateResult& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const ViewportToolStateResult& from) { ViewportToolStateResult::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(ViewportToolStateResult* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.ViewportToolStateResult"; }
+
+ protected:
+  explicit ViewportToolStateResult(::google::protobuf::Arena* arena);
+  ViewportToolStateResult(::google::protobuf::Arena* arena, const ViewportToolStateResult& from);
+  ViewportToolStateResult(::google::protobuf::Arena* arena, ViewportToolStateResult&& from) noexcept
+      : ViewportToolStateResult(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kOperationFieldNumber = 1,
+    kSpaceFieldNumber = 2,
+  };
+  // .sailor.editor.v1.ViewportTransformOperation operation = 1;
+  void clear_operation() ;
+  ::sailor::editor::v1::ViewportTransformOperation operation() const;
+  void set_operation(::sailor::editor::v1::ViewportTransformOperation value);
+
+  private:
+  ::sailor::editor::v1::ViewportTransformOperation _internal_operation() const;
+  void _internal_set_operation(::sailor::editor::v1::ViewportTransformOperation value);
+
+  public:
+  // .sailor.editor.v1.ViewportTransformSpace space = 2;
+  void clear_space() ;
+  ::sailor::editor::v1::ViewportTransformSpace space() const;
+  void set_space(::sailor::editor::v1::ViewportTransformSpace value);
+
+  private:
+  ::sailor::editor::v1::ViewportTransformSpace _internal_space() const;
+  void _internal_set_space(::sailor::editor::v1::ViewportTransformSpace value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.ViewportToolStateResult)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      1, 2, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const ViewportToolStateResult& from_msg);
+    int operation_;
+    int space_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ViewportToolStateRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportToolStateRequest) */ {
+ public:
+  inline ViewportToolStateRequest() : ViewportToolStateRequest(nullptr) {}
+  ~ViewportToolStateRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(ViewportToolStateRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(ViewportToolStateRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR ViewportToolStateRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline ViewportToolStateRequest(const ViewportToolStateRequest& from) : ViewportToolStateRequest(nullptr, from) {}
+  inline ViewportToolStateRequest(ViewportToolStateRequest&& from) noexcept
+      : ViewportToolStateRequest(nullptr, std::move(from)) {}
+  inline ViewportToolStateRequest& operator=(const ViewportToolStateRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ViewportToolStateRequest& operator=(ViewportToolStateRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ViewportToolStateRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ViewportToolStateRequest* internal_default_instance() {
+    return reinterpret_cast<const ViewportToolStateRequest*>(
+        &_ViewportToolStateRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 25;
+  friend void swap(ViewportToolStateRequest& a, ViewportToolStateRequest& b) { a.Swap(&b); }
+  inline void Swap(ViewportToolStateRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ViewportToolStateRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ViewportToolStateRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<ViewportToolStateRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const ViewportToolStateRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const ViewportToolStateRequest& from) { ViewportToolStateRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(ViewportToolStateRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.ViewportToolStateRequest"; }
+
+ protected:
+  explicit ViewportToolStateRequest(::google::protobuf::Arena* arena);
+  ViewportToolStateRequest(::google::protobuf::Arena* arena, const ViewportToolStateRequest& from);
+  ViewportToolStateRequest(::google::protobuf::Arena* arena, ViewportToolStateRequest&& from) noexcept
+      : ViewportToolStateRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kViewportIdFieldNumber = 1,
+    kOperationFieldNumber = 2,
+    kSpaceFieldNumber = 3,
+  };
+  // uint64 viewport_id = 1;
+  void clear_viewport_id() ;
+  ::uint64_t viewport_id() const;
+  void set_viewport_id(::uint64_t value);
+
+  private:
+  ::uint64_t _internal_viewport_id() const;
+  void _internal_set_viewport_id(::uint64_t value);
+
+  public:
+  // .sailor.editor.v1.ViewportTransformOperation operation = 2;
+  void clear_operation() ;
+  ::sailor::editor::v1::ViewportTransformOperation operation() const;
+  void set_operation(::sailor::editor::v1::ViewportTransformOperation value);
+
+  private:
+  ::sailor::editor::v1::ViewportTransformOperation _internal_operation() const;
+  void _internal_set_operation(::sailor::editor::v1::ViewportTransformOperation value);
+
+  public:
+  // .sailor.editor.v1.ViewportTransformSpace space = 3;
+  void clear_space() ;
+  ::sailor::editor::v1::ViewportTransformSpace space() const;
+  void set_space(::sailor::editor::v1::ViewportTransformSpace value);
+
+  private:
+  ::sailor::editor::v1::ViewportTransformSpace _internal_space() const;
+  void _internal_set_space(::sailor::editor::v1::ViewportTransformSpace value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.ViewportToolStateRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      2, 3, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const ViewportToolStateRequest& from_msg);
+    ::uint64_t viewport_id_;
+    int operation_;
+    int space_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ViewportToolShortcutEvent final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportToolShortcutEvent) */ {
+ public:
+  inline ViewportToolShortcutEvent() : ViewportToolShortcutEvent(nullptr) {}
+  ~ViewportToolShortcutEvent() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(ViewportToolShortcutEvent* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(ViewportToolShortcutEvent));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR ViewportToolShortcutEvent(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline ViewportToolShortcutEvent(const ViewportToolShortcutEvent& from) : ViewportToolShortcutEvent(nullptr, from) {}
+  inline ViewportToolShortcutEvent(ViewportToolShortcutEvent&& from) noexcept
+      : ViewportToolShortcutEvent(nullptr, std::move(from)) {}
+  inline ViewportToolShortcutEvent& operator=(const ViewportToolShortcutEvent& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ViewportToolShortcutEvent& operator=(ViewportToolShortcutEvent&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ViewportToolShortcutEvent& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ViewportToolShortcutEvent* internal_default_instance() {
+    return reinterpret_cast<const ViewportToolShortcutEvent*>(
+        &_ViewportToolShortcutEvent_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 43;
+  friend void swap(ViewportToolShortcutEvent& a, ViewportToolShortcutEvent& b) { a.Swap(&b); }
+  inline void Swap(ViewportToolShortcutEvent* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ViewportToolShortcutEvent* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ViewportToolShortcutEvent* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<ViewportToolShortcutEvent>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const ViewportToolShortcutEvent& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const ViewportToolShortcutEvent& from) { ViewportToolShortcutEvent::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(ViewportToolShortcutEvent* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.ViewportToolShortcutEvent"; }
+
+ protected:
+  explicit ViewportToolShortcutEvent(::google::protobuf::Arena* arena);
+  ViewportToolShortcutEvent(::google::protobuf::Arena* arena, const ViewportToolShortcutEvent& from);
+  ViewportToolShortcutEvent(::google::protobuf::Arena* arena, ViewportToolShortcutEvent&& from) noexcept
+      : ViewportToolShortcutEvent(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kKeyCodeFieldNumber = 1,
+  };
+  // uint32 key_code = 1;
+  void clear_key_code() ;
+  ::uint32_t key_code() const;
+  void set_key_code(::uint32_t value);
+
+  private:
+  ::uint32_t _internal_key_code() const;
+  void _internal_set_key_code(::uint32_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.ViewportToolShortcutEvent)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const ViewportToolShortcutEvent& from_msg);
+    ::uint32_t key_code_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ViewportSelectionEvent final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportSelectionEvent) */ {
  public:
@@ -310,7 +946,7 @@ class ViewportSelectionEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportSelectionEvent*>(
         &_ViewportSelectionEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 32;
+  static constexpr int kIndexInFileMessages = 40;
   friend void swap(ViewportSelectionEvent& a, ViewportSelectionEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportSelectionEvent* other) {
     if (other == this) return;
@@ -673,6 +1309,214 @@ class ViewportRectRequest final : public ::google::protobuf::Message
 };
 // -------------------------------------------------------------------
 
+class ViewportObjectRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportObjectRequest) */ {
+ public:
+  inline ViewportObjectRequest() : ViewportObjectRequest(nullptr) {}
+  ~ViewportObjectRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(ViewportObjectRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(ViewportObjectRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR ViewportObjectRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline ViewportObjectRequest(const ViewportObjectRequest& from) : ViewportObjectRequest(nullptr, from) {}
+  inline ViewportObjectRequest(ViewportObjectRequest&& from) noexcept
+      : ViewportObjectRequest(nullptr, std::move(from)) {}
+  inline ViewportObjectRequest& operator=(const ViewportObjectRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ViewportObjectRequest& operator=(ViewportObjectRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ViewportObjectRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ViewportObjectRequest* internal_default_instance() {
+    return reinterpret_cast<const ViewportObjectRequest*>(
+        &_ViewportObjectRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 23;
+  friend void swap(ViewportObjectRequest& a, ViewportObjectRequest& b) { a.Swap(&b); }
+  inline void Swap(ViewportObjectRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ViewportObjectRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ViewportObjectRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<ViewportObjectRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const ViewportObjectRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const ViewportObjectRequest& from) { ViewportObjectRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(ViewportObjectRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.ViewportObjectRequest"; }
+
+ protected:
+  explicit ViewportObjectRequest(::google::protobuf::Arena* arena);
+  ViewportObjectRequest(::google::protobuf::Arena* arena, const ViewportObjectRequest& from);
+  ViewportObjectRequest(::google::protobuf::Arena* arena, ViewportObjectRequest&& from) noexcept
+      : ViewportObjectRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kInstanceIdFieldNumber = 2,
+    kViewportIdFieldNumber = 1,
+  };
+  // string instance_id = 2;
+  void clear_instance_id() ;
+  const std::string& instance_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_instance_id(Arg_&& arg, Args_... args);
+  std::string* mutable_instance_id();
+  PROTOBUF_NODISCARD std::string* release_instance_id();
+  void set_allocated_instance_id(std::string* value);
+
+  private:
+  const std::string& _internal_instance_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_instance_id(
+      const std::string& value);
+  std::string* _internal_mutable_instance_id();
+
+  public:
+  // uint64 viewport_id = 1;
+  void clear_viewport_id() ;
+  ::uint64_t viewport_id() const;
+  void set_viewport_id(::uint64_t value);
+
+  private:
+  ::uint64_t _internal_viewport_id() const;
+  void _internal_set_viewport_id(::uint64_t value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.ViewportObjectRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      1, 2, 0,
+      58, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const ViewportObjectRequest& from_msg);
+    ::google::protobuf::internal::ArenaStringPtr instance_id_;
+    ::uint64_t viewport_id_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ViewportIdRequest final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportIdRequest) */ {
  public:
@@ -863,6 +1707,440 @@ class ViewportIdRequest final : public ::google::protobuf::Message
 };
 // -------------------------------------------------------------------
 
+class ViewportDropPositionRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportDropPositionRequest) */ {
+ public:
+  inline ViewportDropPositionRequest() : ViewportDropPositionRequest(nullptr) {}
+  ~ViewportDropPositionRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(ViewportDropPositionRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(ViewportDropPositionRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR ViewportDropPositionRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline ViewportDropPositionRequest(const ViewportDropPositionRequest& from) : ViewportDropPositionRequest(nullptr, from) {}
+  inline ViewportDropPositionRequest(ViewportDropPositionRequest&& from) noexcept
+      : ViewportDropPositionRequest(nullptr, std::move(from)) {}
+  inline ViewportDropPositionRequest& operator=(const ViewportDropPositionRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ViewportDropPositionRequest& operator=(ViewportDropPositionRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ViewportDropPositionRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ViewportDropPositionRequest* internal_default_instance() {
+    return reinterpret_cast<const ViewportDropPositionRequest*>(
+        &_ViewportDropPositionRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 20;
+  friend void swap(ViewportDropPositionRequest& a, ViewportDropPositionRequest& b) { a.Swap(&b); }
+  inline void Swap(ViewportDropPositionRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ViewportDropPositionRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ViewportDropPositionRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<ViewportDropPositionRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const ViewportDropPositionRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const ViewportDropPositionRequest& from) { ViewportDropPositionRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(ViewportDropPositionRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.ViewportDropPositionRequest"; }
+
+ protected:
+  explicit ViewportDropPositionRequest(::google::protobuf::Arena* arena);
+  ViewportDropPositionRequest(::google::protobuf::Arena* arena, const ViewportDropPositionRequest& from);
+  ViewportDropPositionRequest(::google::protobuf::Arena* arena, ViewportDropPositionRequest&& from) noexcept
+      : ViewportDropPositionRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kViewportIdFieldNumber = 1,
+    kNormalizedXFieldNumber = 2,
+    kNormalizedYFieldNumber = 3,
+  };
+  // uint64 viewport_id = 1;
+  void clear_viewport_id() ;
+  ::uint64_t viewport_id() const;
+  void set_viewport_id(::uint64_t value);
+
+  private:
+  ::uint64_t _internal_viewport_id() const;
+  void _internal_set_viewport_id(::uint64_t value);
+
+  public:
+  // float normalized_x = 2;
+  void clear_normalized_x() ;
+  float normalized_x() const;
+  void set_normalized_x(float value);
+
+  private:
+  float _internal_normalized_x() const;
+  void _internal_set_normalized_x(float value);
+
+  public:
+  // float normalized_y = 3;
+  void clear_normalized_y() ;
+  float normalized_y() const;
+  void set_normalized_y(float value);
+
+  private:
+  float _internal_normalized_y() const;
+  void _internal_set_normalized_y(float value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.ViewportDropPositionRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      2, 3, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const ViewportDropPositionRequest& from_msg);
+    ::uint64_t viewport_id_;
+    float normalized_x_;
+    float normalized_y_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ViewportAssetDropEvent final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportAssetDropEvent) */ {
+ public:
+  inline ViewportAssetDropEvent() : ViewportAssetDropEvent(nullptr) {}
+  ~ViewportAssetDropEvent() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(ViewportAssetDropEvent* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(ViewportAssetDropEvent));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR ViewportAssetDropEvent(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline ViewportAssetDropEvent(const ViewportAssetDropEvent& from) : ViewportAssetDropEvent(nullptr, from) {}
+  inline ViewportAssetDropEvent(ViewportAssetDropEvent&& from) noexcept
+      : ViewportAssetDropEvent(nullptr, std::move(from)) {}
+  inline ViewportAssetDropEvent& operator=(const ViewportAssetDropEvent& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ViewportAssetDropEvent& operator=(ViewportAssetDropEvent&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ViewportAssetDropEvent& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ViewportAssetDropEvent* internal_default_instance() {
+    return reinterpret_cast<const ViewportAssetDropEvent*>(
+        &_ViewportAssetDropEvent_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 42;
+  friend void swap(ViewportAssetDropEvent& a, ViewportAssetDropEvent& b) { a.Swap(&b); }
+  inline void Swap(ViewportAssetDropEvent* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ViewportAssetDropEvent* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ViewportAssetDropEvent* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<ViewportAssetDropEvent>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const ViewportAssetDropEvent& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const ViewportAssetDropEvent& from) { ViewportAssetDropEvent::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(ViewportAssetDropEvent* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.ViewportAssetDropEvent"; }
+
+ protected:
+  explicit ViewportAssetDropEvent(::google::protobuf::Arena* arena);
+  ViewportAssetDropEvent(::google::protobuf::Arena* arena, const ViewportAssetDropEvent& from);
+  ViewportAssetDropEvent(::google::protobuf::Arena* arena, ViewportAssetDropEvent&& from) noexcept
+      : ViewportAssetDropEvent(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFileIdFieldNumber = 1,
+    kNormalizedXFieldNumber = 2,
+    kNormalizedYFieldNumber = 3,
+  };
+  // string file_id = 1;
+  void clear_file_id() ;
+  const std::string& file_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_file_id(Arg_&& arg, Args_... args);
+  std::string* mutable_file_id();
+  PROTOBUF_NODISCARD std::string* release_file_id();
+  void set_allocated_file_id(std::string* value);
+
+  private:
+  const std::string& _internal_file_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_file_id(
+      const std::string& value);
+  std::string* _internal_mutable_file_id();
+
+  public:
+  // float normalized_x = 2;
+  void clear_normalized_x() ;
+  float normalized_x() const;
+  void set_normalized_x(float value);
+
+  private:
+  float _internal_normalized_x() const;
+  void _internal_set_normalized_x(float value);
+
+  public:
+  // float normalized_y = 3;
+  void clear_normalized_y() ;
+  float normalized_y() const;
+  void set_normalized_y(float value);
+
+  private:
+  float _internal_normalized_y() const;
+  void _internal_set_normalized_y(float value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.ViewportAssetDropEvent)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      2, 3, 0,
+      55, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const ViewportAssetDropEvent& from_msg);
+    ::google::protobuf::internal::ArenaStringPtr file_id_;
+    float normalized_x_;
+    float normalized_y_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class Vector4 final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.Vector4) */ {
  public:
@@ -922,7 +2200,7 @@ class Vector4 final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4*>(
         &_Vector4_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 31;
+  static constexpr int kIndexInFileMessages = 39;
   friend void swap(Vector4& a, Vector4& b) { a.Swap(&b); }
   inline void Swap(Vector4* other) {
     if (other == this) return;
@@ -1362,7 +2640,7 @@ class UInt64Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt64Result*>(
         &_UInt64Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 26;
+  static constexpr int kIndexInFileMessages = 32;
   friend void swap(UInt64Result& a, UInt64Result& b) { a.Swap(&b); }
   inline void Swap(UInt64Result* other) {
     if (other == this) return;
@@ -1552,7 +2830,7 @@ class UInt32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt32Result*>(
         &_UInt32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 25;
+  static constexpr int kIndexInFileMessages = 31;
   friend void swap(UInt32Result& a, UInt32Result& b) { a.Swap(&b); }
   inline void Swap(UInt32Result* other) {
     if (other == this) return;
@@ -1742,7 +3020,7 @@ class StringResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringResult*>(
         &_StringResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 27;
+  static constexpr int kIndexInFileMessages = 33;
   friend void swap(StringResult& a, StringResult& b) { a.Swap(&b); }
   inline void Swap(StringResult* other) {
     if (other == this) return;
@@ -1950,7 +3228,7 @@ class StringListResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringListResult*>(
         &_StringListResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 28;
+  static constexpr int kIndexInFileMessages = 34;
   friend void swap(StringListResult& a, StringListResult& b) { a.Swap(&b); }
   inline void Swap(StringListResult* other) {
     if (other == this) return;
@@ -2354,7 +3632,7 @@ class ShowMainWindowRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ShowMainWindowRequest*>(
         &_ShowMainWindowRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 21;
+  static constexpr int kIndexInFileMessages = 27;
   friend void swap(ShowMainWindowRequest& a, ShowMainWindowRequest& b) { a.Swap(&b); }
   inline void Swap(ShowMainWindowRequest* other) {
     if (other == this) return;
@@ -2544,7 +3822,7 @@ class SelectionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const SelectionRequest*>(
         &_SelectionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 20;
+  static constexpr int kIndexInFileMessages = 26;
   friend void swap(SelectionRequest& a, SelectionRequest& b) { a.Swap(&b); }
   inline void Swap(SelectionRequest* other) {
     if (other == this) return;
@@ -2972,7 +4250,7 @@ class RenderPathTracedImageRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RenderPathTracedImageRequest*>(
         &_RenderPathTracedImageRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 22;
+  static constexpr int kIndexInFileMessages = 28;
   friend void swap(RenderPathTracedImageRequest& a, RenderPathTracedImageRequest& b) { a.Swap(&b); }
   inline void Swap(RenderPathTracedImageRequest* other) {
     if (other == this) return;
@@ -3961,6 +5239,220 @@ class RemoteViewportHostRequest final : public ::google::protobuf::Message
 };
 // -------------------------------------------------------------------
 
+class PrefabLinkRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.PrefabLinkRequest) */ {
+ public:
+  inline PrefabLinkRequest() : PrefabLinkRequest(nullptr) {}
+  ~PrefabLinkRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(PrefabLinkRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(PrefabLinkRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR PrefabLinkRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline PrefabLinkRequest(const PrefabLinkRequest& from) : PrefabLinkRequest(nullptr, from) {}
+  inline PrefabLinkRequest(PrefabLinkRequest&& from) noexcept
+      : PrefabLinkRequest(nullptr, std::move(from)) {}
+  inline PrefabLinkRequest& operator=(const PrefabLinkRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline PrefabLinkRequest& operator=(PrefabLinkRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const PrefabLinkRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const PrefabLinkRequest* internal_default_instance() {
+    return reinterpret_cast<const PrefabLinkRequest*>(
+        &_PrefabLinkRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 24;
+  friend void swap(PrefabLinkRequest& a, PrefabLinkRequest& b) { a.Swap(&b); }
+  inline void Swap(PrefabLinkRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(PrefabLinkRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  PrefabLinkRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<PrefabLinkRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const PrefabLinkRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const PrefabLinkRequest& from) { PrefabLinkRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(PrefabLinkRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.PrefabLinkRequest"; }
+
+ protected:
+  explicit PrefabLinkRequest(::google::protobuf::Arena* arena);
+  PrefabLinkRequest(::google::protobuf::Arena* arena, const PrefabLinkRequest& from);
+  PrefabLinkRequest(::google::protobuf::Arena* arena, PrefabLinkRequest&& from) noexcept
+      : PrefabLinkRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kInstanceIdFieldNumber = 1,
+    kFileIdFieldNumber = 2,
+  };
+  // string instance_id = 1;
+  void clear_instance_id() ;
+  const std::string& instance_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_instance_id(Arg_&& arg, Args_... args);
+  std::string* mutable_instance_id();
+  PROTOBUF_NODISCARD std::string* release_instance_id();
+  void set_allocated_instance_id(std::string* value);
+
+  private:
+  const std::string& _internal_instance_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_instance_id(
+      const std::string& value);
+  std::string* _internal_mutable_instance_id();
+
+  public:
+  // string file_id = 2;
+  void clear_file_id() ;
+  const std::string& file_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_file_id(Arg_&& arg, Args_... args);
+  std::string* mutable_file_id();
+  PROTOBUF_NODISCARD std::string* release_file_id();
+  void set_allocated_file_id(std::string* value);
+
+  private:
+  const std::string& _internal_file_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_file_id(
+      const std::string& value);
+  std::string* _internal_mutable_file_id();
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.PrefabLinkRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      1, 2, 0,
+      61, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const PrefabLinkRequest& from_msg);
+    ::google::protobuf::internal::ArenaStringPtr instance_id_;
+    ::google::protobuf::internal::ArenaStringPtr file_id_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ManagedMutationRevisionRequest final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.ManagedMutationRevisionRequest) */ {
  public:
@@ -4228,7 +5720,7 @@ class Int32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Int32Result*>(
         &_Int32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 24;
+  static constexpr int kIndexInFileMessages = 30;
   friend void swap(Int32Result& a, Int32Result& b) { a.Swap(&b); }
   inline void Swap(Int32Result* other) {
     if (other == this) return;
@@ -4721,6 +6213,7 @@ class InstantiatePrefabFromYamlRequest final : public ::google::protobuf::Messag
   enum : int {
     kPrefabYamlFieldNumber = 1,
     kParentInstanceIdFieldNumber = 2,
+    kStrictInstanceIdsFieldNumber = 3,
   };
   // string prefab_yaml = 1;
   void clear_prefab_yaml() ;
@@ -4754,12 +6247,22 @@ class InstantiatePrefabFromYamlRequest final : public ::google::protobuf::Messag
   std::string* _internal_mutable_parent_instance_id();
 
   public:
+  // bool strict_instance_ids = 3;
+  void clear_strict_instance_ids() ;
+  bool strict_instance_ids() const;
+  void set_strict_instance_ids(bool value);
+
+  private:
+  bool _internal_strict_instance_ids() const;
+  void _internal_set_strict_instance_ids(bool value);
+
+  public:
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.InstantiatePrefabFromYamlRequest)
  private:
   class _Internal;
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      1, 2, 0,
+      2, 3, 0,
       87, 2>
       _table_;
 
@@ -4779,6 +6282,7 @@ class InstantiatePrefabFromYamlRequest final : public ::google::protobuf::Messag
                           const InstantiatePrefabFromYamlRequest& from_msg);
     ::google::protobuf::internal::ArenaStringPtr prefab_yaml_;
     ::google::protobuf::internal::ArenaStringPtr parent_instance_id_;
+    bool strict_instance_ids_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -4846,7 +6350,7 @@ class InstanceIdResult final : public ::google::protobuf::Message
     return reinterpret_cast<const InstanceIdResult*>(
         &_InstanceIdResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 30;
+  static constexpr int kIndexInFileMessages = 36;
   friend void swap(InstanceIdResult& a, InstanceIdResult& b) { a.Swap(&b); }
   inline void Swap(InstanceIdResult* other) {
     if (other == this) return;
@@ -6197,7 +7701,7 @@ class BoolResult final : public ::google::protobuf::Message
     return reinterpret_cast<const BoolResult*>(
         &_BoolResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 23;
+  static constexpr int kIndexInFileMessages = 29;
   friend void swap(BoolResult& a, BoolResult& b) { a.Swap(&b); }
   inline void Swap(BoolResult* other) {
     if (other == this) return;
@@ -6387,7 +7891,7 @@ class AssetReloadStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const AssetReloadStateResult*>(
         &_AssetReloadStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 29;
+  static constexpr int kIndexInFileMessages = 35;
   friend void swap(AssetReloadStateResult& a, AssetReloadStateResult& b) { a.Swap(&b); }
   inline void Swap(AssetReloadStateResult* other) {
     if (other == this) return;
@@ -6845,7 +8349,7 @@ class ViewportTransformEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportTransformEvent*>(
         &_ViewportTransformEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 33;
+  static constexpr int kIndexInFileMessages = 41;
   friend void swap(ViewportTransformEvent& a, ViewportTransformEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportTransformEvent* other) {
     if (other == this) return;
@@ -7109,6 +8613,1014 @@ class ViewportTransformEvent final : public ::google::protobuf::Message
 };
 // -------------------------------------------------------------------
 
+class Vector4Result final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.Vector4Result) */ {
+ public:
+  inline Vector4Result() : Vector4Result(nullptr) {}
+  ~Vector4Result() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(Vector4Result* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(Vector4Result));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR Vector4Result(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline Vector4Result(const Vector4Result& from) : Vector4Result(nullptr, from) {}
+  inline Vector4Result(Vector4Result&& from) noexcept
+      : Vector4Result(nullptr, std::move(from)) {}
+  inline Vector4Result& operator=(const Vector4Result& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline Vector4Result& operator=(Vector4Result&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const Vector4Result& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const Vector4Result* internal_default_instance() {
+    return reinterpret_cast<const Vector4Result*>(
+        &_Vector4Result_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 37;
+  friend void swap(Vector4Result& a, Vector4Result& b) { a.Swap(&b); }
+  inline void Swap(Vector4Result* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(Vector4Result* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  Vector4Result* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<Vector4Result>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const Vector4Result& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const Vector4Result& from) { Vector4Result::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(Vector4Result* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.Vector4Result"; }
+
+ protected:
+  explicit Vector4Result(::google::protobuf::Arena* arena);
+  Vector4Result(::google::protobuf::Arena* arena, const Vector4Result& from);
+  Vector4Result(::google::protobuf::Arena* arena, Vector4Result&& from) noexcept
+      : Vector4Result(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kValueFieldNumber = 1,
+  };
+  // .sailor.editor.v1.Vector4 value = 1;
+  bool has_value() const;
+  void clear_value() ;
+  const ::sailor::editor::v1::Vector4& value() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::Vector4* release_value();
+  ::sailor::editor::v1::Vector4* mutable_value();
+  void set_allocated_value(::sailor::editor::v1::Vector4* value);
+  void unsafe_arena_set_allocated_value(::sailor::editor::v1::Vector4* value);
+  ::sailor::editor::v1::Vector4* unsafe_arena_release_value();
+
+  private:
+  const ::sailor::editor::v1::Vector4& _internal_value() const;
+  ::sailor::editor::v1::Vector4* _internal_mutable_value();
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.Vector4Result)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 1,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const Vector4Result& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::sailor::editor::v1::Vector4* value_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
+class InstantiatePrefabInstanceRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.InstantiatePrefabInstanceRequest) */ {
+ public:
+  inline InstantiatePrefabInstanceRequest() : InstantiatePrefabInstanceRequest(nullptr) {}
+  ~InstantiatePrefabInstanceRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(InstantiatePrefabInstanceRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(InstantiatePrefabInstanceRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR InstantiatePrefabInstanceRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline InstantiatePrefabInstanceRequest(const InstantiatePrefabInstanceRequest& from) : InstantiatePrefabInstanceRequest(nullptr, from) {}
+  inline InstantiatePrefabInstanceRequest(InstantiatePrefabInstanceRequest&& from) noexcept
+      : InstantiatePrefabInstanceRequest(nullptr, std::move(from)) {}
+  inline InstantiatePrefabInstanceRequest& operator=(const InstantiatePrefabInstanceRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline InstantiatePrefabInstanceRequest& operator=(InstantiatePrefabInstanceRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const InstantiatePrefabInstanceRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const InstantiatePrefabInstanceRequest* internal_default_instance() {
+    return reinterpret_cast<const InstantiatePrefabInstanceRequest*>(
+        &_InstantiatePrefabInstanceRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 22;
+  friend void swap(InstantiatePrefabInstanceRequest& a, InstantiatePrefabInstanceRequest& b) { a.Swap(&b); }
+  inline void Swap(InstantiatePrefabInstanceRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(InstantiatePrefabInstanceRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  InstantiatePrefabInstanceRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<InstantiatePrefabInstanceRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const InstantiatePrefabInstanceRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const InstantiatePrefabInstanceRequest& from) { InstantiatePrefabInstanceRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(InstantiatePrefabInstanceRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.InstantiatePrefabInstanceRequest"; }
+
+ protected:
+  explicit InstantiatePrefabInstanceRequest(::google::protobuf::Arena* arena);
+  InstantiatePrefabInstanceRequest(::google::protobuf::Arena* arena, const InstantiatePrefabInstanceRequest& from);
+  InstantiatePrefabInstanceRequest(::google::protobuf::Arena* arena, InstantiatePrefabInstanceRequest&& from) noexcept
+      : InstantiatePrefabInstanceRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kFileIdFieldNumber = 1,
+    kParentInstanceIdFieldNumber = 2,
+    kWorldPositionFieldNumber = 4,
+    kApplyWorldPositionFieldNumber = 3,
+  };
+  // string file_id = 1;
+  void clear_file_id() ;
+  const std::string& file_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_file_id(Arg_&& arg, Args_... args);
+  std::string* mutable_file_id();
+  PROTOBUF_NODISCARD std::string* release_file_id();
+  void set_allocated_file_id(std::string* value);
+
+  private:
+  const std::string& _internal_file_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_file_id(
+      const std::string& value);
+  std::string* _internal_mutable_file_id();
+
+  public:
+  // string parent_instance_id = 2;
+  void clear_parent_instance_id() ;
+  const std::string& parent_instance_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_parent_instance_id(Arg_&& arg, Args_... args);
+  std::string* mutable_parent_instance_id();
+  PROTOBUF_NODISCARD std::string* release_parent_instance_id();
+  void set_allocated_parent_instance_id(std::string* value);
+
+  private:
+  const std::string& _internal_parent_instance_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_parent_instance_id(
+      const std::string& value);
+  std::string* _internal_mutable_parent_instance_id();
+
+  public:
+  // .sailor.editor.v1.Vector4 world_position = 4;
+  bool has_world_position() const;
+  void clear_world_position() ;
+  const ::sailor::editor::v1::Vector4& world_position() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::Vector4* release_world_position();
+  ::sailor::editor::v1::Vector4* mutable_world_position();
+  void set_allocated_world_position(::sailor::editor::v1::Vector4* value);
+  void unsafe_arena_set_allocated_world_position(::sailor::editor::v1::Vector4* value);
+  ::sailor::editor::v1::Vector4* unsafe_arena_release_world_position();
+
+  private:
+  const ::sailor::editor::v1::Vector4& _internal_world_position() const;
+  ::sailor::editor::v1::Vector4* _internal_mutable_world_position();
+
+  public:
+  // bool apply_world_position = 3;
+  void clear_apply_world_position() ;
+  bool apply_world_position() const;
+  void set_apply_world_position(bool value);
+
+  private:
+  bool _internal_apply_world_position() const;
+  void _internal_set_apply_world_position(bool value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.InstantiatePrefabInstanceRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      2, 4, 1,
+      83, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const InstantiatePrefabInstanceRequest& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::google::protobuf::internal::ArenaStringPtr file_id_;
+    ::google::protobuf::internal::ArenaStringPtr parent_instance_id_;
+    ::sailor::editor::v1::Vector4* world_position_;
+    bool apply_world_position_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
+class CreateModelGameObjectRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.CreateModelGameObjectRequest) */ {
+ public:
+  inline CreateModelGameObjectRequest() : CreateModelGameObjectRequest(nullptr) {}
+  ~CreateModelGameObjectRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(CreateModelGameObjectRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(CreateModelGameObjectRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR CreateModelGameObjectRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline CreateModelGameObjectRequest(const CreateModelGameObjectRequest& from) : CreateModelGameObjectRequest(nullptr, from) {}
+  inline CreateModelGameObjectRequest(CreateModelGameObjectRequest&& from) noexcept
+      : CreateModelGameObjectRequest(nullptr, std::move(from)) {}
+  inline CreateModelGameObjectRequest& operator=(const CreateModelGameObjectRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline CreateModelGameObjectRequest& operator=(CreateModelGameObjectRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const CreateModelGameObjectRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const CreateModelGameObjectRequest* internal_default_instance() {
+    return reinterpret_cast<const CreateModelGameObjectRequest*>(
+        &_CreateModelGameObjectRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 21;
+  friend void swap(CreateModelGameObjectRequest& a, CreateModelGameObjectRequest& b) { a.Swap(&b); }
+  inline void Swap(CreateModelGameObjectRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(CreateModelGameObjectRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  CreateModelGameObjectRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<CreateModelGameObjectRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const CreateModelGameObjectRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const CreateModelGameObjectRequest& from) { CreateModelGameObjectRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(CreateModelGameObjectRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.CreateModelGameObjectRequest"; }
+
+ protected:
+  explicit CreateModelGameObjectRequest(::google::protobuf::Arena* arena);
+  CreateModelGameObjectRequest(::google::protobuf::Arena* arena, const CreateModelGameObjectRequest& from);
+  CreateModelGameObjectRequest(::google::protobuf::Arena* arena, CreateModelGameObjectRequest&& from) noexcept
+      : CreateModelGameObjectRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kModelFileIdFieldNumber = 1,
+    kNameFieldNumber = 2,
+    kParentInstanceIdFieldNumber = 3,
+    kWorldPositionFieldNumber = 5,
+    kApplyWorldPositionFieldNumber = 4,
+  };
+  // string model_file_id = 1;
+  void clear_model_file_id() ;
+  const std::string& model_file_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_model_file_id(Arg_&& arg, Args_... args);
+  std::string* mutable_model_file_id();
+  PROTOBUF_NODISCARD std::string* release_model_file_id();
+  void set_allocated_model_file_id(std::string* value);
+
+  private:
+  const std::string& _internal_model_file_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_model_file_id(
+      const std::string& value);
+  std::string* _internal_mutable_model_file_id();
+
+  public:
+  // string name = 2;
+  void clear_name() ;
+  const std::string& name() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_name(Arg_&& arg, Args_... args);
+  std::string* mutable_name();
+  PROTOBUF_NODISCARD std::string* release_name();
+  void set_allocated_name(std::string* value);
+
+  private:
+  const std::string& _internal_name() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_name(
+      const std::string& value);
+  std::string* _internal_mutable_name();
+
+  public:
+  // string parent_instance_id = 3;
+  void clear_parent_instance_id() ;
+  const std::string& parent_instance_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_parent_instance_id(Arg_&& arg, Args_... args);
+  std::string* mutable_parent_instance_id();
+  PROTOBUF_NODISCARD std::string* release_parent_instance_id();
+  void set_allocated_parent_instance_id(std::string* value);
+
+  private:
+  const std::string& _internal_parent_instance_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_parent_instance_id(
+      const std::string& value);
+  std::string* _internal_mutable_parent_instance_id();
+
+  public:
+  // .sailor.editor.v1.Vector4 world_position = 5;
+  bool has_world_position() const;
+  void clear_world_position() ;
+  const ::sailor::editor::v1::Vector4& world_position() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::Vector4* release_world_position();
+  ::sailor::editor::v1::Vector4* mutable_world_position();
+  void set_allocated_world_position(::sailor::editor::v1::Vector4* value);
+  void unsafe_arena_set_allocated_world_position(::sailor::editor::v1::Vector4* value);
+  ::sailor::editor::v1::Vector4* unsafe_arena_release_world_position();
+
+  private:
+  const ::sailor::editor::v1::Vector4& _internal_world_position() const;
+  ::sailor::editor::v1::Vector4* _internal_mutable_world_position();
+
+  public:
+  // bool apply_world_position = 4;
+  void clear_apply_world_position() ;
+  bool apply_world_position() const;
+  void set_apply_world_position(bool value);
+
+  private:
+  bool _internal_apply_world_position() const;
+  void _internal_set_apply_world_position(bool value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.CreateModelGameObjectRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      3, 5, 1,
+      89, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const CreateModelGameObjectRequest& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::google::protobuf::internal::ArenaStringPtr model_file_id_;
+    ::google::protobuf::internal::ArenaStringPtr name_;
+    ::google::protobuf::internal::ArenaStringPtr parent_instance_id_;
+    ::sailor::editor::v1::Vector4* world_position_;
+    bool apply_world_position_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
+class ViewportEvent final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportEvent) */ {
+ public:
+  inline ViewportEvent() : ViewportEvent(nullptr) {}
+  ~ViewportEvent() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(ViewportEvent* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(ViewportEvent));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR ViewportEvent(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline ViewportEvent(const ViewportEvent& from) : ViewportEvent(nullptr, from) {}
+  inline ViewportEvent(ViewportEvent&& from) noexcept
+      : ViewportEvent(nullptr, std::move(from)) {}
+  inline ViewportEvent& operator=(const ViewportEvent& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ViewportEvent& operator=(ViewportEvent&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ViewportEvent& default_instance() {
+    return *internal_default_instance();
+  }
+  enum PayloadCase {
+    kSelection = 10,
+    kTransform = 11,
+    kAssetDrop = 12,
+    kToolShortcut = 13,
+    PAYLOAD_NOT_SET = 0,
+  };
+  static inline const ViewportEvent* internal_default_instance() {
+    return reinterpret_cast<const ViewportEvent*>(
+        &_ViewportEvent_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 44;
+  friend void swap(ViewportEvent& a, ViewportEvent& b) { a.Swap(&b); }
+  inline void Swap(ViewportEvent* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ViewportEvent* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ViewportEvent* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<ViewportEvent>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const ViewportEvent& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const ViewportEvent& from) { ViewportEvent::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(ViewportEvent* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.ViewportEvent"; }
+
+ protected:
+  explicit ViewportEvent(::google::protobuf::Arena* arena);
+  ViewportEvent(::google::protobuf::Arena* arena, const ViewportEvent& from);
+  ViewportEvent(::google::protobuf::Arena* arena, ViewportEvent&& from) noexcept
+      : ViewportEvent(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kRevisionFieldNumber = 1,
+    kManagedMutationRevisionFieldNumber = 2,
+    kSelectionFieldNumber = 10,
+    kTransformFieldNumber = 11,
+    kAssetDropFieldNumber = 12,
+    kToolShortcutFieldNumber = 13,
+  };
+  // uint64 revision = 1;
+  void clear_revision() ;
+  ::uint64_t revision() const;
+  void set_revision(::uint64_t value);
+
+  private:
+  ::uint64_t _internal_revision() const;
+  void _internal_set_revision(::uint64_t value);
+
+  public:
+  // uint64 managed_mutation_revision = 2;
+  void clear_managed_mutation_revision() ;
+  ::uint64_t managed_mutation_revision() const;
+  void set_managed_mutation_revision(::uint64_t value);
+
+  private:
+  ::uint64_t _internal_managed_mutation_revision() const;
+  void _internal_set_managed_mutation_revision(::uint64_t value);
+
+  public:
+  // .sailor.editor.v1.ViewportSelectionEvent selection = 10;
+  bool has_selection() const;
+  private:
+  bool _internal_has_selection() const;
+
+  public:
+  void clear_selection() ;
+  const ::sailor::editor::v1::ViewportSelectionEvent& selection() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportSelectionEvent* release_selection();
+  ::sailor::editor::v1::ViewportSelectionEvent* mutable_selection();
+  void set_allocated_selection(::sailor::editor::v1::ViewportSelectionEvent* value);
+  void unsafe_arena_set_allocated_selection(::sailor::editor::v1::ViewportSelectionEvent* value);
+  ::sailor::editor::v1::ViewportSelectionEvent* unsafe_arena_release_selection();
+
+  private:
+  const ::sailor::editor::v1::ViewportSelectionEvent& _internal_selection() const;
+  ::sailor::editor::v1::ViewportSelectionEvent* _internal_mutable_selection();
+
+  public:
+  // .sailor.editor.v1.ViewportTransformEvent transform = 11;
+  bool has_transform() const;
+  private:
+  bool _internal_has_transform() const;
+
+  public:
+  void clear_transform() ;
+  const ::sailor::editor::v1::ViewportTransformEvent& transform() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportTransformEvent* release_transform();
+  ::sailor::editor::v1::ViewportTransformEvent* mutable_transform();
+  void set_allocated_transform(::sailor::editor::v1::ViewportTransformEvent* value);
+  void unsafe_arena_set_allocated_transform(::sailor::editor::v1::ViewportTransformEvent* value);
+  ::sailor::editor::v1::ViewportTransformEvent* unsafe_arena_release_transform();
+
+  private:
+  const ::sailor::editor::v1::ViewportTransformEvent& _internal_transform() const;
+  ::sailor::editor::v1::ViewportTransformEvent* _internal_mutable_transform();
+
+  public:
+  // .sailor.editor.v1.ViewportAssetDropEvent asset_drop = 12;
+  bool has_asset_drop() const;
+  private:
+  bool _internal_has_asset_drop() const;
+
+  public:
+  void clear_asset_drop() ;
+  const ::sailor::editor::v1::ViewportAssetDropEvent& asset_drop() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportAssetDropEvent* release_asset_drop();
+  ::sailor::editor::v1::ViewportAssetDropEvent* mutable_asset_drop();
+  void set_allocated_asset_drop(::sailor::editor::v1::ViewportAssetDropEvent* value);
+  void unsafe_arena_set_allocated_asset_drop(::sailor::editor::v1::ViewportAssetDropEvent* value);
+  ::sailor::editor::v1::ViewportAssetDropEvent* unsafe_arena_release_asset_drop();
+
+  private:
+  const ::sailor::editor::v1::ViewportAssetDropEvent& _internal_asset_drop() const;
+  ::sailor::editor::v1::ViewportAssetDropEvent* _internal_mutable_asset_drop();
+
+  public:
+  // .sailor.editor.v1.ViewportToolShortcutEvent tool_shortcut = 13;
+  bool has_tool_shortcut() const;
+  private:
+  bool _internal_has_tool_shortcut() const;
+
+  public:
+  void clear_tool_shortcut() ;
+  const ::sailor::editor::v1::ViewportToolShortcutEvent& tool_shortcut() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportToolShortcutEvent* release_tool_shortcut();
+  ::sailor::editor::v1::ViewportToolShortcutEvent* mutable_tool_shortcut();
+  void set_allocated_tool_shortcut(::sailor::editor::v1::ViewportToolShortcutEvent* value);
+  void unsafe_arena_set_allocated_tool_shortcut(::sailor::editor::v1::ViewportToolShortcutEvent* value);
+  ::sailor::editor::v1::ViewportToolShortcutEvent* unsafe_arena_release_tool_shortcut();
+
+  private:
+  const ::sailor::editor::v1::ViewportToolShortcutEvent& _internal_tool_shortcut() const;
+  ::sailor::editor::v1::ViewportToolShortcutEvent* _internal_mutable_tool_shortcut();
+
+  public:
+  void clear_payload();
+  PayloadCase payload_case() const;
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.ViewportEvent)
+ private:
+  class _Internal;
+  void set_has_selection();
+  void set_has_transform();
+  void set_has_asset_drop();
+  void set_has_tool_shortcut();
+  inline bool has_payload() const;
+  inline void clear_has_payload();
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      1, 6, 4,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const ViewportEvent& from_msg);
+    ::uint64_t revision_;
+    ::uint64_t managed_mutation_revision_;
+    union PayloadUnion {
+      constexpr PayloadUnion() : _constinit_{} {}
+      ::google::protobuf::internal::ConstantInitialized _constinit_;
+      ::sailor::editor::v1::ViewportSelectionEvent* selection_;
+      ::sailor::editor::v1::ViewportTransformEvent* transform_;
+      ::sailor::editor::v1::ViewportAssetDropEvent* asset_drop_;
+      ::sailor::editor::v1::ViewportToolShortcutEvent* tool_shortcut_;
+    } payload_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::uint32_t _oneof_case_[1];
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ProtocolRequest final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.ProtocolRequest) */ {
  public:
@@ -7204,6 +9716,14 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kSerializeEngineTypes = 46,
     kIsEngineMainThreadReady = 47,
     kIsEngineRunning = 48,
+    kResolveViewportDropPosition = 49,
+    kCreateModelGameObject = 50,
+    kInstantiatePrefabInstance = 51,
+    kFocusEditorCamera = 52,
+    kSetPrefabLink = 53,
+    kBreakPrefabLink = 54,
+    kSetViewportToolState = 55,
+    kGetViewportToolState = 56,
     COMMAND_NOT_SET = 0,
   };
   static inline const ProtocolRequest* internal_default_instance() {
@@ -7338,6 +9858,14 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kSerializeEngineTypesFieldNumber = 46,
     kIsEngineMainThreadReadyFieldNumber = 47,
     kIsEngineRunningFieldNumber = 48,
+    kResolveViewportDropPositionFieldNumber = 49,
+    kCreateModelGameObjectFieldNumber = 50,
+    kInstantiatePrefabInstanceFieldNumber = 51,
+    kFocusEditorCameraFieldNumber = 52,
+    kSetPrefabLinkFieldNumber = 53,
+    kBreakPrefabLinkFieldNumber = 54,
+    kSetViewportToolStateFieldNumber = 55,
+    kGetViewportToolStateFieldNumber = 56,
   };
   // uint64 request_id = 2;
   void clear_request_id() ;
@@ -8100,6 +10628,158 @@ class ProtocolRequest final : public ::google::protobuf::Message
   ::sailor::editor::v1::Empty* _internal_mutable_is_engine_running();
 
   public:
+  // .sailor.editor.v1.ViewportDropPositionRequest resolve_viewport_drop_position = 49;
+  bool has_resolve_viewport_drop_position() const;
+  private:
+  bool _internal_has_resolve_viewport_drop_position() const;
+
+  public:
+  void clear_resolve_viewport_drop_position() ;
+  const ::sailor::editor::v1::ViewportDropPositionRequest& resolve_viewport_drop_position() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportDropPositionRequest* release_resolve_viewport_drop_position();
+  ::sailor::editor::v1::ViewportDropPositionRequest* mutable_resolve_viewport_drop_position();
+  void set_allocated_resolve_viewport_drop_position(::sailor::editor::v1::ViewportDropPositionRequest* value);
+  void unsafe_arena_set_allocated_resolve_viewport_drop_position(::sailor::editor::v1::ViewportDropPositionRequest* value);
+  ::sailor::editor::v1::ViewportDropPositionRequest* unsafe_arena_release_resolve_viewport_drop_position();
+
+  private:
+  const ::sailor::editor::v1::ViewportDropPositionRequest& _internal_resolve_viewport_drop_position() const;
+  ::sailor::editor::v1::ViewportDropPositionRequest* _internal_mutable_resolve_viewport_drop_position();
+
+  public:
+  // .sailor.editor.v1.CreateModelGameObjectRequest create_model_game_object = 50;
+  bool has_create_model_game_object() const;
+  private:
+  bool _internal_has_create_model_game_object() const;
+
+  public:
+  void clear_create_model_game_object() ;
+  const ::sailor::editor::v1::CreateModelGameObjectRequest& create_model_game_object() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::CreateModelGameObjectRequest* release_create_model_game_object();
+  ::sailor::editor::v1::CreateModelGameObjectRequest* mutable_create_model_game_object();
+  void set_allocated_create_model_game_object(::sailor::editor::v1::CreateModelGameObjectRequest* value);
+  void unsafe_arena_set_allocated_create_model_game_object(::sailor::editor::v1::CreateModelGameObjectRequest* value);
+  ::sailor::editor::v1::CreateModelGameObjectRequest* unsafe_arena_release_create_model_game_object();
+
+  private:
+  const ::sailor::editor::v1::CreateModelGameObjectRequest& _internal_create_model_game_object() const;
+  ::sailor::editor::v1::CreateModelGameObjectRequest* _internal_mutable_create_model_game_object();
+
+  public:
+  // .sailor.editor.v1.InstantiatePrefabInstanceRequest instantiate_prefab_instance = 51;
+  bool has_instantiate_prefab_instance() const;
+  private:
+  bool _internal_has_instantiate_prefab_instance() const;
+
+  public:
+  void clear_instantiate_prefab_instance() ;
+  const ::sailor::editor::v1::InstantiatePrefabInstanceRequest& instantiate_prefab_instance() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::InstantiatePrefabInstanceRequest* release_instantiate_prefab_instance();
+  ::sailor::editor::v1::InstantiatePrefabInstanceRequest* mutable_instantiate_prefab_instance();
+  void set_allocated_instantiate_prefab_instance(::sailor::editor::v1::InstantiatePrefabInstanceRequest* value);
+  void unsafe_arena_set_allocated_instantiate_prefab_instance(::sailor::editor::v1::InstantiatePrefabInstanceRequest* value);
+  ::sailor::editor::v1::InstantiatePrefabInstanceRequest* unsafe_arena_release_instantiate_prefab_instance();
+
+  private:
+  const ::sailor::editor::v1::InstantiatePrefabInstanceRequest& _internal_instantiate_prefab_instance() const;
+  ::sailor::editor::v1::InstantiatePrefabInstanceRequest* _internal_mutable_instantiate_prefab_instance();
+
+  public:
+  // .sailor.editor.v1.ViewportObjectRequest focus_editor_camera = 52;
+  bool has_focus_editor_camera() const;
+  private:
+  bool _internal_has_focus_editor_camera() const;
+
+  public:
+  void clear_focus_editor_camera() ;
+  const ::sailor::editor::v1::ViewportObjectRequest& focus_editor_camera() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportObjectRequest* release_focus_editor_camera();
+  ::sailor::editor::v1::ViewportObjectRequest* mutable_focus_editor_camera();
+  void set_allocated_focus_editor_camera(::sailor::editor::v1::ViewportObjectRequest* value);
+  void unsafe_arena_set_allocated_focus_editor_camera(::sailor::editor::v1::ViewportObjectRequest* value);
+  ::sailor::editor::v1::ViewportObjectRequest* unsafe_arena_release_focus_editor_camera();
+
+  private:
+  const ::sailor::editor::v1::ViewportObjectRequest& _internal_focus_editor_camera() const;
+  ::sailor::editor::v1::ViewportObjectRequest* _internal_mutable_focus_editor_camera();
+
+  public:
+  // .sailor.editor.v1.PrefabLinkRequest set_prefab_link = 53;
+  bool has_set_prefab_link() const;
+  private:
+  bool _internal_has_set_prefab_link() const;
+
+  public:
+  void clear_set_prefab_link() ;
+  const ::sailor::editor::v1::PrefabLinkRequest& set_prefab_link() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::PrefabLinkRequest* release_set_prefab_link();
+  ::sailor::editor::v1::PrefabLinkRequest* mutable_set_prefab_link();
+  void set_allocated_set_prefab_link(::sailor::editor::v1::PrefabLinkRequest* value);
+  void unsafe_arena_set_allocated_set_prefab_link(::sailor::editor::v1::PrefabLinkRequest* value);
+  ::sailor::editor::v1::PrefabLinkRequest* unsafe_arena_release_set_prefab_link();
+
+  private:
+  const ::sailor::editor::v1::PrefabLinkRequest& _internal_set_prefab_link() const;
+  ::sailor::editor::v1::PrefabLinkRequest* _internal_mutable_set_prefab_link();
+
+  public:
+  // .sailor.editor.v1.InstanceIdRequest break_prefab_link = 54;
+  bool has_break_prefab_link() const;
+  private:
+  bool _internal_has_break_prefab_link() const;
+
+  public:
+  void clear_break_prefab_link() ;
+  const ::sailor::editor::v1::InstanceIdRequest& break_prefab_link() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::InstanceIdRequest* release_break_prefab_link();
+  ::sailor::editor::v1::InstanceIdRequest* mutable_break_prefab_link();
+  void set_allocated_break_prefab_link(::sailor::editor::v1::InstanceIdRequest* value);
+  void unsafe_arena_set_allocated_break_prefab_link(::sailor::editor::v1::InstanceIdRequest* value);
+  ::sailor::editor::v1::InstanceIdRequest* unsafe_arena_release_break_prefab_link();
+
+  private:
+  const ::sailor::editor::v1::InstanceIdRequest& _internal_break_prefab_link() const;
+  ::sailor::editor::v1::InstanceIdRequest* _internal_mutable_break_prefab_link();
+
+  public:
+  // .sailor.editor.v1.ViewportToolStateRequest set_viewport_tool_state = 55;
+  bool has_set_viewport_tool_state() const;
+  private:
+  bool _internal_has_set_viewport_tool_state() const;
+
+  public:
+  void clear_set_viewport_tool_state() ;
+  const ::sailor::editor::v1::ViewportToolStateRequest& set_viewport_tool_state() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportToolStateRequest* release_set_viewport_tool_state();
+  ::sailor::editor::v1::ViewportToolStateRequest* mutable_set_viewport_tool_state();
+  void set_allocated_set_viewport_tool_state(::sailor::editor::v1::ViewportToolStateRequest* value);
+  void unsafe_arena_set_allocated_set_viewport_tool_state(::sailor::editor::v1::ViewportToolStateRequest* value);
+  ::sailor::editor::v1::ViewportToolStateRequest* unsafe_arena_release_set_viewport_tool_state();
+
+  private:
+  const ::sailor::editor::v1::ViewportToolStateRequest& _internal_set_viewport_tool_state() const;
+  ::sailor::editor::v1::ViewportToolStateRequest* _internal_mutable_set_viewport_tool_state();
+
+  public:
+  // .sailor.editor.v1.ViewportIdRequest get_viewport_tool_state = 56;
+  bool has_get_viewport_tool_state() const;
+  private:
+  bool _internal_has_get_viewport_tool_state() const;
+
+  public:
+  void clear_get_viewport_tool_state() ;
+  const ::sailor::editor::v1::ViewportIdRequest& get_viewport_tool_state() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportIdRequest* release_get_viewport_tool_state();
+  ::sailor::editor::v1::ViewportIdRequest* mutable_get_viewport_tool_state();
+  void set_allocated_get_viewport_tool_state(::sailor::editor::v1::ViewportIdRequest* value);
+  void unsafe_arena_set_allocated_get_viewport_tool_state(::sailor::editor::v1::ViewportIdRequest* value);
+  ::sailor::editor::v1::ViewportIdRequest* unsafe_arena_release_get_viewport_tool_state();
+
+  private:
+  const ::sailor::editor::v1::ViewportIdRequest& _internal_get_viewport_tool_state() const;
+  ::sailor::editor::v1::ViewportIdRequest* _internal_mutable_get_viewport_tool_state();
+
+  public:
   void clear_command();
   CommandCase command_case() const;
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.ProtocolRequest)
@@ -8144,12 +10824,20 @@ class ProtocolRequest final : public ::google::protobuf::Message
   void set_has_serialize_engine_types();
   void set_has_is_engine_main_thread_ready();
   void set_has_is_engine_running();
+  void set_has_resolve_viewport_drop_position();
+  void set_has_create_model_game_object();
+  void set_has_instantiate_prefab_instance();
+  void set_has_focus_editor_camera();
+  void set_has_set_prefab_link();
+  void set_has_break_prefab_link();
+  void set_has_set_viewport_tool_state();
+  void set_has_get_viewport_tool_state();
   inline bool has_command() const;
   inline void clear_has_command();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      1, 41, 39,
-      0, 7>
+      1, 49, 47,
+      0, 9>
       _table_;
 
   friend class ::google::protobuf::MessageLite;
@@ -8210,267 +10898,15 @@ class ProtocolRequest final : public ::google::protobuf::Message
       ::sailor::editor::v1::Empty* serialize_engine_types_;
       ::sailor::editor::v1::Empty* is_engine_main_thread_ready_;
       ::sailor::editor::v1::Empty* is_engine_running_;
+      ::sailor::editor::v1::ViewportDropPositionRequest* resolve_viewport_drop_position_;
+      ::sailor::editor::v1::CreateModelGameObjectRequest* create_model_game_object_;
+      ::sailor::editor::v1::InstantiatePrefabInstanceRequest* instantiate_prefab_instance_;
+      ::sailor::editor::v1::ViewportObjectRequest* focus_editor_camera_;
+      ::sailor::editor::v1::PrefabLinkRequest* set_prefab_link_;
+      ::sailor::editor::v1::InstanceIdRequest* break_prefab_link_;
+      ::sailor::editor::v1::ViewportToolStateRequest* set_viewport_tool_state_;
+      ::sailor::editor::v1::ViewportIdRequest* get_viewport_tool_state_;
     } command_;
-    ::google::protobuf::internal::CachedSize _cached_size_;
-    ::uint32_t _oneof_case_[1];
-    PROTOBUF_TSAN_DECLARE_MEMBER
-  };
-  union { Impl_ _impl_; };
-  friend struct ::TableStruct_editor_5fengine_2eproto;
-};
-// -------------------------------------------------------------------
-
-class ViewportEvent final : public ::google::protobuf::Message
-/* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportEvent) */ {
- public:
-  inline ViewportEvent() : ViewportEvent(nullptr) {}
-  ~ViewportEvent() PROTOBUF_FINAL;
-
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-  void operator delete(ViewportEvent* msg, std::destroying_delete_t) {
-    SharedDtor(*msg);
-    ::google::protobuf::internal::SizedDelete(msg, sizeof(ViewportEvent));
-  }
-#endif
-
-  template <typename = void>
-  explicit PROTOBUF_CONSTEXPR ViewportEvent(
-      ::google::protobuf::internal::ConstantInitialized);
-
-  inline ViewportEvent(const ViewportEvent& from) : ViewportEvent(nullptr, from) {}
-  inline ViewportEvent(ViewportEvent&& from) noexcept
-      : ViewportEvent(nullptr, std::move(from)) {}
-  inline ViewportEvent& operator=(const ViewportEvent& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  inline ViewportEvent& operator=(ViewportEvent&& from) noexcept {
-    if (this == &from) return *this;
-    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
-      InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-
-  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
-  }
-  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
-  }
-
-  static const ::google::protobuf::Descriptor* descriptor() {
-    return GetDescriptor();
-  }
-  static const ::google::protobuf::Descriptor* GetDescriptor() {
-    return default_instance().GetMetadata().descriptor;
-  }
-  static const ::google::protobuf::Reflection* GetReflection() {
-    return default_instance().GetMetadata().reflection;
-  }
-  static const ViewportEvent& default_instance() {
-    return *internal_default_instance();
-  }
-  enum PayloadCase {
-    kSelection = 10,
-    kTransform = 11,
-    PAYLOAD_NOT_SET = 0,
-  };
-  static inline const ViewportEvent* internal_default_instance() {
-    return reinterpret_cast<const ViewportEvent*>(
-        &_ViewportEvent_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages = 34;
-  friend void swap(ViewportEvent& a, ViewportEvent& b) { a.Swap(&b); }
-  inline void Swap(ViewportEvent* other) {
-    if (other == this) return;
-    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
-      InternalSwap(other);
-    } else {
-      ::google::protobuf::internal::GenericSwap(this, other);
-    }
-  }
-  void UnsafeArenaSwap(ViewportEvent* other) {
-    if (other == this) return;
-    ABSL_DCHECK(GetArena() == other->GetArena());
-    InternalSwap(other);
-  }
-
-  // implements Message ----------------------------------------------
-
-  ViewportEvent* New(::google::protobuf::Arena* arena = nullptr) const {
-    return ::google::protobuf::Message::DefaultConstruct<ViewportEvent>(arena);
-  }
-  using ::google::protobuf::Message::CopyFrom;
-  void CopyFrom(const ViewportEvent& from);
-  using ::google::protobuf::Message::MergeFrom;
-  void MergeFrom(const ViewportEvent& from) { ViewportEvent::MergeImpl(*this, from); }
-
-  private:
-  static void MergeImpl(
-      ::google::protobuf::MessageLite& to_msg,
-      const ::google::protobuf::MessageLite& from_msg);
-
-  public:
-  bool IsInitialized() const {
-    return true;
-  }
-  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
-  #if defined(PROTOBUF_CUSTOM_VTABLE)
-  private:
-  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
-  static ::uint8_t* _InternalSerialize(
-      const MessageLite& msg, ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream);
-
-  public:
-  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
-    return _InternalSerialize(*this, target, stream);
-  }
-  #else   // PROTOBUF_CUSTOM_VTABLE
-  ::size_t ByteSizeLong() const final;
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
-  #endif  // PROTOBUF_CUSTOM_VTABLE
-  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
-
-  private:
-  void SharedCtor(::google::protobuf::Arena* arena);
-  static void SharedDtor(MessageLite& self);
-  void InternalSwap(ViewportEvent* other);
- private:
-  template <typename T>
-  friend ::absl::string_view(
-      ::google::protobuf::internal::GetAnyMessageName)();
-  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.ViewportEvent"; }
-
- protected:
-  explicit ViewportEvent(::google::protobuf::Arena* arena);
-  ViewportEvent(::google::protobuf::Arena* arena, const ViewportEvent& from);
-  ViewportEvent(::google::protobuf::Arena* arena, ViewportEvent&& from) noexcept
-      : ViewportEvent(arena) {
-    *this = ::std::move(from);
-  }
-  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
-  static void* PlacementNew_(const void*, void* mem,
-                             ::google::protobuf::Arena* arena);
-  static constexpr auto InternalNewImpl_();
-  static const ::google::protobuf::internal::ClassDataFull _class_data_;
-
- public:
-  ::google::protobuf::Metadata GetMetadata() const;
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-  enum : int {
-    kRevisionFieldNumber = 1,
-    kManagedMutationRevisionFieldNumber = 2,
-    kSelectionFieldNumber = 10,
-    kTransformFieldNumber = 11,
-  };
-  // uint64 revision = 1;
-  void clear_revision() ;
-  ::uint64_t revision() const;
-  void set_revision(::uint64_t value);
-
-  private:
-  ::uint64_t _internal_revision() const;
-  void _internal_set_revision(::uint64_t value);
-
-  public:
-  // uint64 managed_mutation_revision = 2;
-  void clear_managed_mutation_revision() ;
-  ::uint64_t managed_mutation_revision() const;
-  void set_managed_mutation_revision(::uint64_t value);
-
-  private:
-  ::uint64_t _internal_managed_mutation_revision() const;
-  void _internal_set_managed_mutation_revision(::uint64_t value);
-
-  public:
-  // .sailor.editor.v1.ViewportSelectionEvent selection = 10;
-  bool has_selection() const;
-  private:
-  bool _internal_has_selection() const;
-
-  public:
-  void clear_selection() ;
-  const ::sailor::editor::v1::ViewportSelectionEvent& selection() const;
-  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportSelectionEvent* release_selection();
-  ::sailor::editor::v1::ViewportSelectionEvent* mutable_selection();
-  void set_allocated_selection(::sailor::editor::v1::ViewportSelectionEvent* value);
-  void unsafe_arena_set_allocated_selection(::sailor::editor::v1::ViewportSelectionEvent* value);
-  ::sailor::editor::v1::ViewportSelectionEvent* unsafe_arena_release_selection();
-
-  private:
-  const ::sailor::editor::v1::ViewportSelectionEvent& _internal_selection() const;
-  ::sailor::editor::v1::ViewportSelectionEvent* _internal_mutable_selection();
-
-  public:
-  // .sailor.editor.v1.ViewportTransformEvent transform = 11;
-  bool has_transform() const;
-  private:
-  bool _internal_has_transform() const;
-
-  public:
-  void clear_transform() ;
-  const ::sailor::editor::v1::ViewportTransformEvent& transform() const;
-  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportTransformEvent* release_transform();
-  ::sailor::editor::v1::ViewportTransformEvent* mutable_transform();
-  void set_allocated_transform(::sailor::editor::v1::ViewportTransformEvent* value);
-  void unsafe_arena_set_allocated_transform(::sailor::editor::v1::ViewportTransformEvent* value);
-  ::sailor::editor::v1::ViewportTransformEvent* unsafe_arena_release_transform();
-
-  private:
-  const ::sailor::editor::v1::ViewportTransformEvent& _internal_transform() const;
-  ::sailor::editor::v1::ViewportTransformEvent* _internal_mutable_transform();
-
-  public:
-  void clear_payload();
-  PayloadCase payload_case() const;
-  // @@protoc_insertion_point(class_scope:sailor.editor.v1.ViewportEvent)
- private:
-  class _Internal;
-  void set_has_selection();
-  void set_has_transform();
-  inline bool has_payload() const;
-  inline void clear_has_payload();
-  friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<
-      1, 4, 2,
-      0, 2>
-      _table_;
-
-  friend class ::google::protobuf::MessageLite;
-  friend class ::google::protobuf::Arena;
-  template <typename T>
-  friend class ::google::protobuf::Arena::InternalHelper;
-  using InternalArenaConstructable_ = void;
-  using DestructorSkippable_ = void;
-  struct Impl_ {
-    inline explicit constexpr Impl_(
-        ::google::protobuf::internal::ConstantInitialized) noexcept;
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena);
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena, const Impl_& from,
-                          const ViewportEvent& from_msg);
-    ::uint64_t revision_;
-    ::uint64_t managed_mutation_revision_;
-    union PayloadUnion {
-      constexpr PayloadUnion() : _constinit_{} {}
-      ::google::protobuf::internal::ConstantInitialized _constinit_;
-      ::sailor::editor::v1::ViewportSelectionEvent* selection_;
-      ::sailor::editor::v1::ViewportTransformEvent* transform_;
-    } payload_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
     PROTOBUF_TSAN_DECLARE_MEMBER
@@ -8539,7 +10975,7 @@ class ViewportEventBatchResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEventBatchResult*>(
         &_ViewportEventBatchResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 35;
+  static constexpr int kIndexInFileMessages = 45;
   friend void swap(ViewportEventBatchResult& a, ViewportEventBatchResult& b) { a.Swap(&b); }
   inline void Swap(ViewportEventBatchResult* other) {
     if (other == this) return;
@@ -8743,6 +11179,8 @@ class ProtocolResponse final : public ::google::protobuf::Message
     kAssetReloadStateResult = 17,
     kInstanceIdResult = 18,
     kViewportEventBatchResult = 19,
+    kVector4Result = 20,
+    kViewportToolStateResult = 21,
     RESULT_NOT_SET = 0,
   };
   static inline const ProtocolResponse* internal_default_instance() {
@@ -8840,6 +11278,7 @@ class ProtocolResponse final : public ::google::protobuf::Message
     kRequestIdFieldNumber = 2,
     kProtocolVersionFieldNumber = 1,
     kSuccessFieldNumber = 3,
+    kSupportsStrictInstanceIdsFieldNumber = 5,
     kEmptyResultFieldNumber = 10,
     kBoolResultFieldNumber = 11,
     kInt32ResultFieldNumber = 12,
@@ -8850,6 +11289,8 @@ class ProtocolResponse final : public ::google::protobuf::Message
     kAssetReloadStateResultFieldNumber = 17,
     kInstanceIdResultFieldNumber = 18,
     kViewportEventBatchResultFieldNumber = 19,
+    kVector4ResultFieldNumber = 20,
+    kViewportToolStateResultFieldNumber = 21,
   };
   // string error = 4;
   void clear_error() ;
@@ -8895,6 +11336,16 @@ class ProtocolResponse final : public ::google::protobuf::Message
   private:
   bool _internal_success() const;
   void _internal_set_success(bool value);
+
+  public:
+  // bool supports_strict_instance_ids = 5;
+  void clear_supports_strict_instance_ids() ;
+  bool supports_strict_instance_ids() const;
+  void set_supports_strict_instance_ids(bool value);
+
+  private:
+  bool _internal_supports_strict_instance_ids() const;
+  void _internal_set_supports_strict_instance_ids(bool value);
 
   public:
   // .sailor.editor.v1.Empty empty_result = 10;
@@ -9087,6 +11538,44 @@ class ProtocolResponse final : public ::google::protobuf::Message
   ::sailor::editor::v1::ViewportEventBatchResult* _internal_mutable_viewport_event_batch_result();
 
   public:
+  // .sailor.editor.v1.Vector4Result vector4_result = 20;
+  bool has_vector4_result() const;
+  private:
+  bool _internal_has_vector4_result() const;
+
+  public:
+  void clear_vector4_result() ;
+  const ::sailor::editor::v1::Vector4Result& vector4_result() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::Vector4Result* release_vector4_result();
+  ::sailor::editor::v1::Vector4Result* mutable_vector4_result();
+  void set_allocated_vector4_result(::sailor::editor::v1::Vector4Result* value);
+  void unsafe_arena_set_allocated_vector4_result(::sailor::editor::v1::Vector4Result* value);
+  ::sailor::editor::v1::Vector4Result* unsafe_arena_release_vector4_result();
+
+  private:
+  const ::sailor::editor::v1::Vector4Result& _internal_vector4_result() const;
+  ::sailor::editor::v1::Vector4Result* _internal_mutable_vector4_result();
+
+  public:
+  // .sailor.editor.v1.ViewportToolStateResult viewport_tool_state_result = 21;
+  bool has_viewport_tool_state_result() const;
+  private:
+  bool _internal_has_viewport_tool_state_result() const;
+
+  public:
+  void clear_viewport_tool_state_result() ;
+  const ::sailor::editor::v1::ViewportToolStateResult& viewport_tool_state_result() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportToolStateResult* release_viewport_tool_state_result();
+  ::sailor::editor::v1::ViewportToolStateResult* mutable_viewport_tool_state_result();
+  void set_allocated_viewport_tool_state_result(::sailor::editor::v1::ViewportToolStateResult* value);
+  void unsafe_arena_set_allocated_viewport_tool_state_result(::sailor::editor::v1::ViewportToolStateResult* value);
+  ::sailor::editor::v1::ViewportToolStateResult* unsafe_arena_release_viewport_tool_state_result();
+
+  private:
+  const ::sailor::editor::v1::ViewportToolStateResult& _internal_viewport_tool_state_result() const;
+  ::sailor::editor::v1::ViewportToolStateResult* _internal_mutable_viewport_tool_state_result();
+
+  public:
   void clear_result();
   ResultCase result_case() const;
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.ProtocolResponse)
@@ -9102,12 +11591,14 @@ class ProtocolResponse final : public ::google::protobuf::Message
   void set_has_asset_reload_state_result();
   void set_has_instance_id_result();
   void set_has_viewport_event_batch_result();
+  void set_has_vector4_result();
+  void set_has_viewport_tool_state_result();
   inline bool has_result() const;
   inline void clear_has_result();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      2, 14, 10,
-      55, 2>
+      3, 17, 12,
+      63, 2>
       _table_;
 
   friend class ::google::protobuf::MessageLite;
@@ -9128,6 +11619,7 @@ class ProtocolResponse final : public ::google::protobuf::Message
     ::uint64_t request_id_;
     ::uint32_t protocol_version_;
     bool success_;
+    bool supports_strict_instance_ids_;
     union ResultUnion {
       constexpr ResultUnion() : _constinit_{} {}
       ::google::protobuf::internal::ConstantInitialized _constinit_;
@@ -9141,6 +11633,8 @@ class ProtocolResponse final : public ::google::protobuf::Message
       ::sailor::editor::v1::AssetReloadStateResult* asset_reload_state_result_;
       ::sailor::editor::v1::InstanceIdResult* instance_id_result_;
       ::sailor::editor::v1::ViewportEventBatchResult* viewport_event_batch_result_;
+      ::sailor::editor::v1::Vector4Result* vector4_result_;
+      ::sailor::editor::v1::ViewportToolStateResult* viewport_tool_state_result_;
     } result_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -12295,6 +14789,638 @@ inline ::sailor::editor::v1::Empty* ProtocolRequest::mutable_is_engine_running()
   return _msg;
 }
 
+// .sailor.editor.v1.ViewportDropPositionRequest resolve_viewport_drop_position = 49;
+inline bool ProtocolRequest::has_resolve_viewport_drop_position() const {
+  return command_case() == kResolveViewportDropPosition;
+}
+inline bool ProtocolRequest::_internal_has_resolve_viewport_drop_position() const {
+  return command_case() == kResolveViewportDropPosition;
+}
+inline void ProtocolRequest::set_has_resolve_viewport_drop_position() {
+  _impl_._oneof_case_[0] = kResolveViewportDropPosition;
+}
+inline void ProtocolRequest::clear_resolve_viewport_drop_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kResolveViewportDropPosition) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.resolve_viewport_drop_position_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.resolve_viewport_drop_position_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::ViewportDropPositionRequest* ProtocolRequest::release_resolve_viewport_drop_position() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
+  if (command_case() == kResolveViewportDropPosition) {
+    clear_has_command();
+    auto* temp = _impl_.command_.resolve_viewport_drop_position_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.resolve_viewport_drop_position_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::ViewportDropPositionRequest& ProtocolRequest::_internal_resolve_viewport_drop_position() const {
+  return command_case() == kResolveViewportDropPosition ? *_impl_.command_.resolve_viewport_drop_position_ : reinterpret_cast<::sailor::editor::v1::ViewportDropPositionRequest&>(::sailor::editor::v1::_ViewportDropPositionRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::ViewportDropPositionRequest& ProtocolRequest::resolve_viewport_drop_position() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
+  return _internal_resolve_viewport_drop_position();
+}
+inline ::sailor::editor::v1::ViewportDropPositionRequest* ProtocolRequest::unsafe_arena_release_resolve_viewport_drop_position() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
+  if (command_case() == kResolveViewportDropPosition) {
+    clear_has_command();
+    auto* temp = _impl_.command_.resolve_viewport_drop_position_;
+    _impl_.command_.resolve_viewport_drop_position_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_resolve_viewport_drop_position(::sailor::editor::v1::ViewportDropPositionRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_resolve_viewport_drop_position();
+    _impl_.command_.resolve_viewport_drop_position_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
+}
+inline ::sailor::editor::v1::ViewportDropPositionRequest* ProtocolRequest::_internal_mutable_resolve_viewport_drop_position() {
+  if (command_case() != kResolveViewportDropPosition) {
+    clear_command();
+    set_has_resolve_viewport_drop_position();
+    _impl_.command_.resolve_viewport_drop_position_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::ViewportDropPositionRequest>(GetArena());
+  }
+  return _impl_.command_.resolve_viewport_drop_position_;
+}
+inline ::sailor::editor::v1::ViewportDropPositionRequest* ProtocolRequest::mutable_resolve_viewport_drop_position() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::ViewportDropPositionRequest* _msg = _internal_mutable_resolve_viewport_drop_position();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
+  return _msg;
+}
+
+// .sailor.editor.v1.CreateModelGameObjectRequest create_model_game_object = 50;
+inline bool ProtocolRequest::has_create_model_game_object() const {
+  return command_case() == kCreateModelGameObject;
+}
+inline bool ProtocolRequest::_internal_has_create_model_game_object() const {
+  return command_case() == kCreateModelGameObject;
+}
+inline void ProtocolRequest::set_has_create_model_game_object() {
+  _impl_._oneof_case_[0] = kCreateModelGameObject;
+}
+inline void ProtocolRequest::clear_create_model_game_object() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kCreateModelGameObject) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.create_model_game_object_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.create_model_game_object_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::CreateModelGameObjectRequest* ProtocolRequest::release_create_model_game_object() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.create_model_game_object)
+  if (command_case() == kCreateModelGameObject) {
+    clear_has_command();
+    auto* temp = _impl_.command_.create_model_game_object_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.create_model_game_object_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::CreateModelGameObjectRequest& ProtocolRequest::_internal_create_model_game_object() const {
+  return command_case() == kCreateModelGameObject ? *_impl_.command_.create_model_game_object_ : reinterpret_cast<::sailor::editor::v1::CreateModelGameObjectRequest&>(::sailor::editor::v1::_CreateModelGameObjectRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::CreateModelGameObjectRequest& ProtocolRequest::create_model_game_object() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.create_model_game_object)
+  return _internal_create_model_game_object();
+}
+inline ::sailor::editor::v1::CreateModelGameObjectRequest* ProtocolRequest::unsafe_arena_release_create_model_game_object() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.create_model_game_object)
+  if (command_case() == kCreateModelGameObject) {
+    clear_has_command();
+    auto* temp = _impl_.command_.create_model_game_object_;
+    _impl_.command_.create_model_game_object_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_create_model_game_object(::sailor::editor::v1::CreateModelGameObjectRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_create_model_game_object();
+    _impl_.command_.create_model_game_object_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.create_model_game_object)
+}
+inline ::sailor::editor::v1::CreateModelGameObjectRequest* ProtocolRequest::_internal_mutable_create_model_game_object() {
+  if (command_case() != kCreateModelGameObject) {
+    clear_command();
+    set_has_create_model_game_object();
+    _impl_.command_.create_model_game_object_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::CreateModelGameObjectRequest>(GetArena());
+  }
+  return _impl_.command_.create_model_game_object_;
+}
+inline ::sailor::editor::v1::CreateModelGameObjectRequest* ProtocolRequest::mutable_create_model_game_object() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::CreateModelGameObjectRequest* _msg = _internal_mutable_create_model_game_object();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.create_model_game_object)
+  return _msg;
+}
+
+// .sailor.editor.v1.InstantiatePrefabInstanceRequest instantiate_prefab_instance = 51;
+inline bool ProtocolRequest::has_instantiate_prefab_instance() const {
+  return command_case() == kInstantiatePrefabInstance;
+}
+inline bool ProtocolRequest::_internal_has_instantiate_prefab_instance() const {
+  return command_case() == kInstantiatePrefabInstance;
+}
+inline void ProtocolRequest::set_has_instantiate_prefab_instance() {
+  _impl_._oneof_case_[0] = kInstantiatePrefabInstance;
+}
+inline void ProtocolRequest::clear_instantiate_prefab_instance() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kInstantiatePrefabInstance) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.instantiate_prefab_instance_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.instantiate_prefab_instance_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::InstantiatePrefabInstanceRequest* ProtocolRequest::release_instantiate_prefab_instance() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.instantiate_prefab_instance)
+  if (command_case() == kInstantiatePrefabInstance) {
+    clear_has_command();
+    auto* temp = _impl_.command_.instantiate_prefab_instance_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.instantiate_prefab_instance_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::InstantiatePrefabInstanceRequest& ProtocolRequest::_internal_instantiate_prefab_instance() const {
+  return command_case() == kInstantiatePrefabInstance ? *_impl_.command_.instantiate_prefab_instance_ : reinterpret_cast<::sailor::editor::v1::InstantiatePrefabInstanceRequest&>(::sailor::editor::v1::_InstantiatePrefabInstanceRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::InstantiatePrefabInstanceRequest& ProtocolRequest::instantiate_prefab_instance() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.instantiate_prefab_instance)
+  return _internal_instantiate_prefab_instance();
+}
+inline ::sailor::editor::v1::InstantiatePrefabInstanceRequest* ProtocolRequest::unsafe_arena_release_instantiate_prefab_instance() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.instantiate_prefab_instance)
+  if (command_case() == kInstantiatePrefabInstance) {
+    clear_has_command();
+    auto* temp = _impl_.command_.instantiate_prefab_instance_;
+    _impl_.command_.instantiate_prefab_instance_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_instantiate_prefab_instance(::sailor::editor::v1::InstantiatePrefabInstanceRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_instantiate_prefab_instance();
+    _impl_.command_.instantiate_prefab_instance_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.instantiate_prefab_instance)
+}
+inline ::sailor::editor::v1::InstantiatePrefabInstanceRequest* ProtocolRequest::_internal_mutable_instantiate_prefab_instance() {
+  if (command_case() != kInstantiatePrefabInstance) {
+    clear_command();
+    set_has_instantiate_prefab_instance();
+    _impl_.command_.instantiate_prefab_instance_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::InstantiatePrefabInstanceRequest>(GetArena());
+  }
+  return _impl_.command_.instantiate_prefab_instance_;
+}
+inline ::sailor::editor::v1::InstantiatePrefabInstanceRequest* ProtocolRequest::mutable_instantiate_prefab_instance() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::InstantiatePrefabInstanceRequest* _msg = _internal_mutable_instantiate_prefab_instance();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.instantiate_prefab_instance)
+  return _msg;
+}
+
+// .sailor.editor.v1.ViewportObjectRequest focus_editor_camera = 52;
+inline bool ProtocolRequest::has_focus_editor_camera() const {
+  return command_case() == kFocusEditorCamera;
+}
+inline bool ProtocolRequest::_internal_has_focus_editor_camera() const {
+  return command_case() == kFocusEditorCamera;
+}
+inline void ProtocolRequest::set_has_focus_editor_camera() {
+  _impl_._oneof_case_[0] = kFocusEditorCamera;
+}
+inline void ProtocolRequest::clear_focus_editor_camera() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kFocusEditorCamera) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.focus_editor_camera_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.focus_editor_camera_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::ViewportObjectRequest* ProtocolRequest::release_focus_editor_camera() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.focus_editor_camera)
+  if (command_case() == kFocusEditorCamera) {
+    clear_has_command();
+    auto* temp = _impl_.command_.focus_editor_camera_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.focus_editor_camera_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::ViewportObjectRequest& ProtocolRequest::_internal_focus_editor_camera() const {
+  return command_case() == kFocusEditorCamera ? *_impl_.command_.focus_editor_camera_ : reinterpret_cast<::sailor::editor::v1::ViewportObjectRequest&>(::sailor::editor::v1::_ViewportObjectRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::ViewportObjectRequest& ProtocolRequest::focus_editor_camera() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.focus_editor_camera)
+  return _internal_focus_editor_camera();
+}
+inline ::sailor::editor::v1::ViewportObjectRequest* ProtocolRequest::unsafe_arena_release_focus_editor_camera() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.focus_editor_camera)
+  if (command_case() == kFocusEditorCamera) {
+    clear_has_command();
+    auto* temp = _impl_.command_.focus_editor_camera_;
+    _impl_.command_.focus_editor_camera_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_focus_editor_camera(::sailor::editor::v1::ViewportObjectRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_focus_editor_camera();
+    _impl_.command_.focus_editor_camera_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.focus_editor_camera)
+}
+inline ::sailor::editor::v1::ViewportObjectRequest* ProtocolRequest::_internal_mutable_focus_editor_camera() {
+  if (command_case() != kFocusEditorCamera) {
+    clear_command();
+    set_has_focus_editor_camera();
+    _impl_.command_.focus_editor_camera_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::ViewportObjectRequest>(GetArena());
+  }
+  return _impl_.command_.focus_editor_camera_;
+}
+inline ::sailor::editor::v1::ViewportObjectRequest* ProtocolRequest::mutable_focus_editor_camera() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::ViewportObjectRequest* _msg = _internal_mutable_focus_editor_camera();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.focus_editor_camera)
+  return _msg;
+}
+
+// .sailor.editor.v1.PrefabLinkRequest set_prefab_link = 53;
+inline bool ProtocolRequest::has_set_prefab_link() const {
+  return command_case() == kSetPrefabLink;
+}
+inline bool ProtocolRequest::_internal_has_set_prefab_link() const {
+  return command_case() == kSetPrefabLink;
+}
+inline void ProtocolRequest::set_has_set_prefab_link() {
+  _impl_._oneof_case_[0] = kSetPrefabLink;
+}
+inline void ProtocolRequest::clear_set_prefab_link() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kSetPrefabLink) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.set_prefab_link_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_prefab_link_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::PrefabLinkRequest* ProtocolRequest::release_set_prefab_link() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.set_prefab_link)
+  if (command_case() == kSetPrefabLink) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_prefab_link_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.set_prefab_link_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::PrefabLinkRequest& ProtocolRequest::_internal_set_prefab_link() const {
+  return command_case() == kSetPrefabLink ? *_impl_.command_.set_prefab_link_ : reinterpret_cast<::sailor::editor::v1::PrefabLinkRequest&>(::sailor::editor::v1::_PrefabLinkRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::PrefabLinkRequest& ProtocolRequest::set_prefab_link() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.set_prefab_link)
+  return _internal_set_prefab_link();
+}
+inline ::sailor::editor::v1::PrefabLinkRequest* ProtocolRequest::unsafe_arena_release_set_prefab_link() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.set_prefab_link)
+  if (command_case() == kSetPrefabLink) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_prefab_link_;
+    _impl_.command_.set_prefab_link_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_set_prefab_link(::sailor::editor::v1::PrefabLinkRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_set_prefab_link();
+    _impl_.command_.set_prefab_link_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.set_prefab_link)
+}
+inline ::sailor::editor::v1::PrefabLinkRequest* ProtocolRequest::_internal_mutable_set_prefab_link() {
+  if (command_case() != kSetPrefabLink) {
+    clear_command();
+    set_has_set_prefab_link();
+    _impl_.command_.set_prefab_link_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::PrefabLinkRequest>(GetArena());
+  }
+  return _impl_.command_.set_prefab_link_;
+}
+inline ::sailor::editor::v1::PrefabLinkRequest* ProtocolRequest::mutable_set_prefab_link() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::PrefabLinkRequest* _msg = _internal_mutable_set_prefab_link();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.set_prefab_link)
+  return _msg;
+}
+
+// .sailor.editor.v1.InstanceIdRequest break_prefab_link = 54;
+inline bool ProtocolRequest::has_break_prefab_link() const {
+  return command_case() == kBreakPrefabLink;
+}
+inline bool ProtocolRequest::_internal_has_break_prefab_link() const {
+  return command_case() == kBreakPrefabLink;
+}
+inline void ProtocolRequest::set_has_break_prefab_link() {
+  _impl_._oneof_case_[0] = kBreakPrefabLink;
+}
+inline void ProtocolRequest::clear_break_prefab_link() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kBreakPrefabLink) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.break_prefab_link_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.break_prefab_link_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::InstanceIdRequest* ProtocolRequest::release_break_prefab_link() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.break_prefab_link)
+  if (command_case() == kBreakPrefabLink) {
+    clear_has_command();
+    auto* temp = _impl_.command_.break_prefab_link_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.break_prefab_link_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::InstanceIdRequest& ProtocolRequest::_internal_break_prefab_link() const {
+  return command_case() == kBreakPrefabLink ? *_impl_.command_.break_prefab_link_ : reinterpret_cast<::sailor::editor::v1::InstanceIdRequest&>(::sailor::editor::v1::_InstanceIdRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::InstanceIdRequest& ProtocolRequest::break_prefab_link() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.break_prefab_link)
+  return _internal_break_prefab_link();
+}
+inline ::sailor::editor::v1::InstanceIdRequest* ProtocolRequest::unsafe_arena_release_break_prefab_link() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.break_prefab_link)
+  if (command_case() == kBreakPrefabLink) {
+    clear_has_command();
+    auto* temp = _impl_.command_.break_prefab_link_;
+    _impl_.command_.break_prefab_link_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_break_prefab_link(::sailor::editor::v1::InstanceIdRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_break_prefab_link();
+    _impl_.command_.break_prefab_link_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.break_prefab_link)
+}
+inline ::sailor::editor::v1::InstanceIdRequest* ProtocolRequest::_internal_mutable_break_prefab_link() {
+  if (command_case() != kBreakPrefabLink) {
+    clear_command();
+    set_has_break_prefab_link();
+    _impl_.command_.break_prefab_link_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::InstanceIdRequest>(GetArena());
+  }
+  return _impl_.command_.break_prefab_link_;
+}
+inline ::sailor::editor::v1::InstanceIdRequest* ProtocolRequest::mutable_break_prefab_link() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::InstanceIdRequest* _msg = _internal_mutable_break_prefab_link();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.break_prefab_link)
+  return _msg;
+}
+
+// .sailor.editor.v1.ViewportToolStateRequest set_viewport_tool_state = 55;
+inline bool ProtocolRequest::has_set_viewport_tool_state() const {
+  return command_case() == kSetViewportToolState;
+}
+inline bool ProtocolRequest::_internal_has_set_viewport_tool_state() const {
+  return command_case() == kSetViewportToolState;
+}
+inline void ProtocolRequest::set_has_set_viewport_tool_state() {
+  _impl_._oneof_case_[0] = kSetViewportToolState;
+}
+inline void ProtocolRequest::clear_set_viewport_tool_state() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kSetViewportToolState) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.set_viewport_tool_state_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_viewport_tool_state_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::ViewportToolStateRequest* ProtocolRequest::release_set_viewport_tool_state() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.set_viewport_tool_state)
+  if (command_case() == kSetViewportToolState) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_viewport_tool_state_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.set_viewport_tool_state_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::ViewportToolStateRequest& ProtocolRequest::_internal_set_viewport_tool_state() const {
+  return command_case() == kSetViewportToolState ? *_impl_.command_.set_viewport_tool_state_ : reinterpret_cast<::sailor::editor::v1::ViewportToolStateRequest&>(::sailor::editor::v1::_ViewportToolStateRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::ViewportToolStateRequest& ProtocolRequest::set_viewport_tool_state() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.set_viewport_tool_state)
+  return _internal_set_viewport_tool_state();
+}
+inline ::sailor::editor::v1::ViewportToolStateRequest* ProtocolRequest::unsafe_arena_release_set_viewport_tool_state() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.set_viewport_tool_state)
+  if (command_case() == kSetViewportToolState) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_viewport_tool_state_;
+    _impl_.command_.set_viewport_tool_state_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_set_viewport_tool_state(::sailor::editor::v1::ViewportToolStateRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_set_viewport_tool_state();
+    _impl_.command_.set_viewport_tool_state_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.set_viewport_tool_state)
+}
+inline ::sailor::editor::v1::ViewportToolStateRequest* ProtocolRequest::_internal_mutable_set_viewport_tool_state() {
+  if (command_case() != kSetViewportToolState) {
+    clear_command();
+    set_has_set_viewport_tool_state();
+    _impl_.command_.set_viewport_tool_state_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::ViewportToolStateRequest>(GetArena());
+  }
+  return _impl_.command_.set_viewport_tool_state_;
+}
+inline ::sailor::editor::v1::ViewportToolStateRequest* ProtocolRequest::mutable_set_viewport_tool_state() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::ViewportToolStateRequest* _msg = _internal_mutable_set_viewport_tool_state();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.set_viewport_tool_state)
+  return _msg;
+}
+
+// .sailor.editor.v1.ViewportIdRequest get_viewport_tool_state = 56;
+inline bool ProtocolRequest::has_get_viewport_tool_state() const {
+  return command_case() == kGetViewportToolState;
+}
+inline bool ProtocolRequest::_internal_has_get_viewport_tool_state() const {
+  return command_case() == kGetViewportToolState;
+}
+inline void ProtocolRequest::set_has_get_viewport_tool_state() {
+  _impl_._oneof_case_[0] = kGetViewportToolState;
+}
+inline void ProtocolRequest::clear_get_viewport_tool_state() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kGetViewportToolState) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.get_viewport_tool_state_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.get_viewport_tool_state_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::ViewportIdRequest* ProtocolRequest::release_get_viewport_tool_state() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.get_viewport_tool_state)
+  if (command_case() == kGetViewportToolState) {
+    clear_has_command();
+    auto* temp = _impl_.command_.get_viewport_tool_state_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.get_viewport_tool_state_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::ViewportIdRequest& ProtocolRequest::_internal_get_viewport_tool_state() const {
+  return command_case() == kGetViewportToolState ? *_impl_.command_.get_viewport_tool_state_ : reinterpret_cast<::sailor::editor::v1::ViewportIdRequest&>(::sailor::editor::v1::_ViewportIdRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::ViewportIdRequest& ProtocolRequest::get_viewport_tool_state() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.get_viewport_tool_state)
+  return _internal_get_viewport_tool_state();
+}
+inline ::sailor::editor::v1::ViewportIdRequest* ProtocolRequest::unsafe_arena_release_get_viewport_tool_state() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.get_viewport_tool_state)
+  if (command_case() == kGetViewportToolState) {
+    clear_has_command();
+    auto* temp = _impl_.command_.get_viewport_tool_state_;
+    _impl_.command_.get_viewport_tool_state_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_get_viewport_tool_state(::sailor::editor::v1::ViewportIdRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_get_viewport_tool_state();
+    _impl_.command_.get_viewport_tool_state_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.get_viewport_tool_state)
+}
+inline ::sailor::editor::v1::ViewportIdRequest* ProtocolRequest::_internal_mutable_get_viewport_tool_state() {
+  if (command_case() != kGetViewportToolState) {
+    clear_command();
+    set_has_get_viewport_tool_state();
+    _impl_.command_.get_viewport_tool_state_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::ViewportIdRequest>(GetArena());
+  }
+  return _impl_.command_.get_viewport_tool_state_;
+}
+inline ::sailor::editor::v1::ViewportIdRequest* ProtocolRequest::mutable_get_viewport_tool_state() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::ViewportIdRequest* _msg = _internal_mutable_get_viewport_tool_state();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.get_viewport_tool_state)
+  return _msg;
+}
+
 inline bool ProtocolRequest::has_command() const {
   return command_case() != COMMAND_NOT_SET;
 }
@@ -12420,6 +15546,28 @@ inline void ProtocolResponse::set_allocated_error(std::string* value) {
     _impl_.error_.Set("", GetArena());
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolResponse.error)
+}
+
+// bool supports_strict_instance_ids = 5;
+inline void ProtocolResponse::clear_supports_strict_instance_ids() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.supports_strict_instance_ids_ = false;
+}
+inline bool ProtocolResponse::supports_strict_instance_ids() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolResponse.supports_strict_instance_ids)
+  return _internal_supports_strict_instance_ids();
+}
+inline void ProtocolResponse::set_supports_strict_instance_ids(bool value) {
+  _internal_set_supports_strict_instance_ids(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ProtocolResponse.supports_strict_instance_ids)
+}
+inline bool ProtocolResponse::_internal_supports_strict_instance_ids() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.supports_strict_instance_ids_;
+}
+inline void ProtocolResponse::_internal_set_supports_strict_instance_ids(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.supports_strict_instance_ids_ = value;
 }
 
 // .sailor.editor.v1.Empty empty_result = 10;
@@ -13209,6 +16357,164 @@ inline ::sailor::editor::v1::ViewportEventBatchResult* ProtocolResponse::_intern
 inline ::sailor::editor::v1::ViewportEventBatchResult* ProtocolResponse::mutable_viewport_event_batch_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
   ::sailor::editor::v1::ViewportEventBatchResult* _msg = _internal_mutable_viewport_event_batch_result();
   // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolResponse.viewport_event_batch_result)
+  return _msg;
+}
+
+// .sailor.editor.v1.Vector4Result vector4_result = 20;
+inline bool ProtocolResponse::has_vector4_result() const {
+  return result_case() == kVector4Result;
+}
+inline bool ProtocolResponse::_internal_has_vector4_result() const {
+  return result_case() == kVector4Result;
+}
+inline void ProtocolResponse::set_has_vector4_result() {
+  _impl_._oneof_case_[0] = kVector4Result;
+}
+inline void ProtocolResponse::clear_vector4_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (result_case() == kVector4Result) {
+    if (GetArena() == nullptr) {
+      delete _impl_.result_.vector4_result_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.result_.vector4_result_);
+    }
+    clear_has_result();
+  }
+}
+inline ::sailor::editor::v1::Vector4Result* ProtocolResponse::release_vector4_result() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolResponse.vector4_result)
+  if (result_case() == kVector4Result) {
+    clear_has_result();
+    auto* temp = _impl_.result_.vector4_result_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.result_.vector4_result_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::Vector4Result& ProtocolResponse::_internal_vector4_result() const {
+  return result_case() == kVector4Result ? *_impl_.result_.vector4_result_ : reinterpret_cast<::sailor::editor::v1::Vector4Result&>(::sailor::editor::v1::_Vector4Result_default_instance_);
+}
+inline const ::sailor::editor::v1::Vector4Result& ProtocolResponse::vector4_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolResponse.vector4_result)
+  return _internal_vector4_result();
+}
+inline ::sailor::editor::v1::Vector4Result* ProtocolResponse::unsafe_arena_release_vector4_result() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolResponse.vector4_result)
+  if (result_case() == kVector4Result) {
+    clear_has_result();
+    auto* temp = _impl_.result_.vector4_result_;
+    _impl_.result_.vector4_result_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolResponse::unsafe_arena_set_allocated_vector4_result(::sailor::editor::v1::Vector4Result* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_result();
+  if (value) {
+    set_has_vector4_result();
+    _impl_.result_.vector4_result_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolResponse.vector4_result)
+}
+inline ::sailor::editor::v1::Vector4Result* ProtocolResponse::_internal_mutable_vector4_result() {
+  if (result_case() != kVector4Result) {
+    clear_result();
+    set_has_vector4_result();
+    _impl_.result_.vector4_result_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::Vector4Result>(GetArena());
+  }
+  return _impl_.result_.vector4_result_;
+}
+inline ::sailor::editor::v1::Vector4Result* ProtocolResponse::mutable_vector4_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::Vector4Result* _msg = _internal_mutable_vector4_result();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolResponse.vector4_result)
+  return _msg;
+}
+
+// .sailor.editor.v1.ViewportToolStateResult viewport_tool_state_result = 21;
+inline bool ProtocolResponse::has_viewport_tool_state_result() const {
+  return result_case() == kViewportToolStateResult;
+}
+inline bool ProtocolResponse::_internal_has_viewport_tool_state_result() const {
+  return result_case() == kViewportToolStateResult;
+}
+inline void ProtocolResponse::set_has_viewport_tool_state_result() {
+  _impl_._oneof_case_[0] = kViewportToolStateResult;
+}
+inline void ProtocolResponse::clear_viewport_tool_state_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (result_case() == kViewportToolStateResult) {
+    if (GetArena() == nullptr) {
+      delete _impl_.result_.viewport_tool_state_result_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.result_.viewport_tool_state_result_);
+    }
+    clear_has_result();
+  }
+}
+inline ::sailor::editor::v1::ViewportToolStateResult* ProtocolResponse::release_viewport_tool_state_result() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolResponse.viewport_tool_state_result)
+  if (result_case() == kViewportToolStateResult) {
+    clear_has_result();
+    auto* temp = _impl_.result_.viewport_tool_state_result_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.result_.viewport_tool_state_result_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::ViewportToolStateResult& ProtocolResponse::_internal_viewport_tool_state_result() const {
+  return result_case() == kViewportToolStateResult ? *_impl_.result_.viewport_tool_state_result_ : reinterpret_cast<::sailor::editor::v1::ViewportToolStateResult&>(::sailor::editor::v1::_ViewportToolStateResult_default_instance_);
+}
+inline const ::sailor::editor::v1::ViewportToolStateResult& ProtocolResponse::viewport_tool_state_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolResponse.viewport_tool_state_result)
+  return _internal_viewport_tool_state_result();
+}
+inline ::sailor::editor::v1::ViewportToolStateResult* ProtocolResponse::unsafe_arena_release_viewport_tool_state_result() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolResponse.viewport_tool_state_result)
+  if (result_case() == kViewportToolStateResult) {
+    clear_has_result();
+    auto* temp = _impl_.result_.viewport_tool_state_result_;
+    _impl_.result_.viewport_tool_state_result_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolResponse::unsafe_arena_set_allocated_viewport_tool_state_result(::sailor::editor::v1::ViewportToolStateResult* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_result();
+  if (value) {
+    set_has_viewport_tool_state_result();
+    _impl_.result_.viewport_tool_state_result_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolResponse.viewport_tool_state_result)
+}
+inline ::sailor::editor::v1::ViewportToolStateResult* ProtocolResponse::_internal_mutable_viewport_tool_state_result() {
+  if (result_case() != kViewportToolStateResult) {
+    clear_result();
+    set_has_viewport_tool_state_result();
+    _impl_.result_.viewport_tool_state_result_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::ViewportToolStateResult>(GetArena());
+  }
+  return _impl_.result_.viewport_tool_state_result_;
+}
+inline ::sailor::editor::v1::ViewportToolStateResult* ProtocolResponse::mutable_viewport_tool_state_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::ViewportToolStateResult* _msg = _internal_mutable_viewport_tool_state_result();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolResponse.viewport_tool_state_result)
   return _msg;
 }
 
@@ -14825,6 +18131,826 @@ inline void InstantiatePrefabFromYamlRequest::set_allocated_parent_instance_id(s
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.InstantiatePrefabFromYamlRequest.parent_instance_id)
 }
 
+// bool strict_instance_ids = 3;
+inline void InstantiatePrefabFromYamlRequest::clear_strict_instance_ids() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.strict_instance_ids_ = false;
+}
+inline bool InstantiatePrefabFromYamlRequest::strict_instance_ids() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.InstantiatePrefabFromYamlRequest.strict_instance_ids)
+  return _internal_strict_instance_ids();
+}
+inline void InstantiatePrefabFromYamlRequest::set_strict_instance_ids(bool value) {
+  _internal_set_strict_instance_ids(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.InstantiatePrefabFromYamlRequest.strict_instance_ids)
+}
+inline bool InstantiatePrefabFromYamlRequest::_internal_strict_instance_ids() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.strict_instance_ids_;
+}
+inline void InstantiatePrefabFromYamlRequest::_internal_set_strict_instance_ids(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.strict_instance_ids_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// ViewportDropPositionRequest
+
+// uint64 viewport_id = 1;
+inline void ViewportDropPositionRequest::clear_viewport_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.viewport_id_ = ::uint64_t{0u};
+}
+inline ::uint64_t ViewportDropPositionRequest::viewport_id() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportDropPositionRequest.viewport_id)
+  return _internal_viewport_id();
+}
+inline void ViewportDropPositionRequest::set_viewport_id(::uint64_t value) {
+  _internal_set_viewport_id(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportDropPositionRequest.viewport_id)
+}
+inline ::uint64_t ViewportDropPositionRequest::_internal_viewport_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.viewport_id_;
+}
+inline void ViewportDropPositionRequest::_internal_set_viewport_id(::uint64_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.viewport_id_ = value;
+}
+
+// float normalized_x = 2;
+inline void ViewportDropPositionRequest::clear_normalized_x() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.normalized_x_ = 0;
+}
+inline float ViewportDropPositionRequest::normalized_x() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportDropPositionRequest.normalized_x)
+  return _internal_normalized_x();
+}
+inline void ViewportDropPositionRequest::set_normalized_x(float value) {
+  _internal_set_normalized_x(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportDropPositionRequest.normalized_x)
+}
+inline float ViewportDropPositionRequest::_internal_normalized_x() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.normalized_x_;
+}
+inline void ViewportDropPositionRequest::_internal_set_normalized_x(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.normalized_x_ = value;
+}
+
+// float normalized_y = 3;
+inline void ViewportDropPositionRequest::clear_normalized_y() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.normalized_y_ = 0;
+}
+inline float ViewportDropPositionRequest::normalized_y() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportDropPositionRequest.normalized_y)
+  return _internal_normalized_y();
+}
+inline void ViewportDropPositionRequest::set_normalized_y(float value) {
+  _internal_set_normalized_y(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportDropPositionRequest.normalized_y)
+}
+inline float ViewportDropPositionRequest::_internal_normalized_y() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.normalized_y_;
+}
+inline void ViewportDropPositionRequest::_internal_set_normalized_y(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.normalized_y_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// CreateModelGameObjectRequest
+
+// string model_file_id = 1;
+inline void CreateModelGameObjectRequest::clear_model_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.model_file_id_.ClearToEmpty();
+}
+inline const std::string& CreateModelGameObjectRequest::model_file_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelGameObjectRequest.model_file_id)
+  return _internal_model_file_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void CreateModelGameObjectRequest::set_model_file_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.model_file_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelGameObjectRequest.model_file_id)
+}
+inline std::string* CreateModelGameObjectRequest::mutable_model_file_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_model_file_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelGameObjectRequest.model_file_id)
+  return _s;
+}
+inline const std::string& CreateModelGameObjectRequest::_internal_model_file_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.model_file_id_.Get();
+}
+inline void CreateModelGameObjectRequest::_internal_set_model_file_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.model_file_id_.Set(value, GetArena());
+}
+inline std::string* CreateModelGameObjectRequest::_internal_mutable_model_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.model_file_id_.Mutable( GetArena());
+}
+inline std::string* CreateModelGameObjectRequest::release_model_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelGameObjectRequest.model_file_id)
+  return _impl_.model_file_id_.Release();
+}
+inline void CreateModelGameObjectRequest::set_allocated_model_file_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.model_file_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.model_file_id_.IsDefault()) {
+    _impl_.model_file_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelGameObjectRequest.model_file_id)
+}
+
+// string name = 2;
+inline void CreateModelGameObjectRequest::clear_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.ClearToEmpty();
+}
+inline const std::string& CreateModelGameObjectRequest::name() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelGameObjectRequest.name)
+  return _internal_name();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void CreateModelGameObjectRequest::set_name(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelGameObjectRequest.name)
+}
+inline std::string* CreateModelGameObjectRequest::mutable_name() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_name();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelGameObjectRequest.name)
+  return _s;
+}
+inline const std::string& CreateModelGameObjectRequest::_internal_name() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.name_.Get();
+}
+inline void CreateModelGameObjectRequest::_internal_set_name(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.Set(value, GetArena());
+}
+inline std::string* CreateModelGameObjectRequest::_internal_mutable_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.name_.Mutable( GetArena());
+}
+inline std::string* CreateModelGameObjectRequest::release_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelGameObjectRequest.name)
+  return _impl_.name_.Release();
+}
+inline void CreateModelGameObjectRequest::set_allocated_name(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.name_.IsDefault()) {
+    _impl_.name_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelGameObjectRequest.name)
+}
+
+// string parent_instance_id = 3;
+inline void CreateModelGameObjectRequest::clear_parent_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.ClearToEmpty();
+}
+inline const std::string& CreateModelGameObjectRequest::parent_instance_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id)
+  return _internal_parent_instance_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void CreateModelGameObjectRequest::set_parent_instance_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id)
+}
+inline std::string* CreateModelGameObjectRequest::mutable_parent_instance_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_parent_instance_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id)
+  return _s;
+}
+inline const std::string& CreateModelGameObjectRequest::_internal_parent_instance_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.parent_instance_id_.Get();
+}
+inline void CreateModelGameObjectRequest::_internal_set_parent_instance_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.Set(value, GetArena());
+}
+inline std::string* CreateModelGameObjectRequest::_internal_mutable_parent_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.parent_instance_id_.Mutable( GetArena());
+}
+inline std::string* CreateModelGameObjectRequest::release_parent_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id)
+  return _impl_.parent_instance_id_.Release();
+}
+inline void CreateModelGameObjectRequest::set_allocated_parent_instance_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.parent_instance_id_.IsDefault()) {
+    _impl_.parent_instance_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id)
+}
+
+// bool apply_world_position = 4;
+inline void CreateModelGameObjectRequest::clear_apply_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.apply_world_position_ = false;
+}
+inline bool CreateModelGameObjectRequest::apply_world_position() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelGameObjectRequest.apply_world_position)
+  return _internal_apply_world_position();
+}
+inline void CreateModelGameObjectRequest::set_apply_world_position(bool value) {
+  _internal_set_apply_world_position(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelGameObjectRequest.apply_world_position)
+}
+inline bool CreateModelGameObjectRequest::_internal_apply_world_position() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.apply_world_position_;
+}
+inline void CreateModelGameObjectRequest::_internal_set_apply_world_position(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.apply_world_position_ = value;
+}
+
+// .sailor.editor.v1.Vector4 world_position = 5;
+inline bool CreateModelGameObjectRequest::has_world_position() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.world_position_ != nullptr);
+  return value;
+}
+inline void CreateModelGameObjectRequest::clear_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.world_position_ != nullptr) _impl_.world_position_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::sailor::editor::v1::Vector4& CreateModelGameObjectRequest::_internal_world_position() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::sailor::editor::v1::Vector4* p = _impl_.world_position_;
+  return p != nullptr ? *p : reinterpret_cast<const ::sailor::editor::v1::Vector4&>(::sailor::editor::v1::_Vector4_default_instance_);
+}
+inline const ::sailor::editor::v1::Vector4& CreateModelGameObjectRequest::world_position() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelGameObjectRequest.world_position)
+  return _internal_world_position();
+}
+inline void CreateModelGameObjectRequest::unsafe_arena_set_allocated_world_position(::sailor::editor::v1::Vector4* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.world_position_);
+  }
+  _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.CreateModelGameObjectRequest.world_position)
+}
+inline ::sailor::editor::v1::Vector4* CreateModelGameObjectRequest::release_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::sailor::editor::v1::Vector4* released = _impl_.world_position_;
+  _impl_.world_position_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::sailor::editor::v1::Vector4* CreateModelGameObjectRequest::unsafe_arena_release_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelGameObjectRequest.world_position)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::sailor::editor::v1::Vector4* temp = _impl_.world_position_;
+  _impl_.world_position_ = nullptr;
+  return temp;
+}
+inline ::sailor::editor::v1::Vector4* CreateModelGameObjectRequest::_internal_mutable_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.world_position_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::Vector4>(GetArena());
+    _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(p);
+  }
+  return _impl_.world_position_;
+}
+inline ::sailor::editor::v1::Vector4* CreateModelGameObjectRequest::mutable_world_position() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::sailor::editor::v1::Vector4* _msg = _internal_mutable_world_position();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelGameObjectRequest.world_position)
+  return _msg;
+}
+inline void CreateModelGameObjectRequest::set_allocated_world_position(::sailor::editor::v1::Vector4* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.world_position_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(value);
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelGameObjectRequest.world_position)
+}
+
+// -------------------------------------------------------------------
+
+// InstantiatePrefabInstanceRequest
+
+// string file_id = 1;
+inline void InstantiatePrefabInstanceRequest::clear_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.ClearToEmpty();
+}
+inline const std::string& InstantiatePrefabInstanceRequest::file_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.InstantiatePrefabInstanceRequest.file_id)
+  return _internal_file_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void InstantiatePrefabInstanceRequest::set_file_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.InstantiatePrefabInstanceRequest.file_id)
+}
+inline std::string* InstantiatePrefabInstanceRequest::mutable_file_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_file_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.InstantiatePrefabInstanceRequest.file_id)
+  return _s;
+}
+inline const std::string& InstantiatePrefabInstanceRequest::_internal_file_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.file_id_.Get();
+}
+inline void InstantiatePrefabInstanceRequest::_internal_set_file_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.Set(value, GetArena());
+}
+inline std::string* InstantiatePrefabInstanceRequest::_internal_mutable_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.file_id_.Mutable( GetArena());
+}
+inline std::string* InstantiatePrefabInstanceRequest::release_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.InstantiatePrefabInstanceRequest.file_id)
+  return _impl_.file_id_.Release();
+}
+inline void InstantiatePrefabInstanceRequest::set_allocated_file_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.file_id_.IsDefault()) {
+    _impl_.file_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.InstantiatePrefabInstanceRequest.file_id)
+}
+
+// string parent_instance_id = 2;
+inline void InstantiatePrefabInstanceRequest::clear_parent_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.ClearToEmpty();
+}
+inline const std::string& InstantiatePrefabInstanceRequest::parent_instance_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.InstantiatePrefabInstanceRequest.parent_instance_id)
+  return _internal_parent_instance_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void InstantiatePrefabInstanceRequest::set_parent_instance_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.InstantiatePrefabInstanceRequest.parent_instance_id)
+}
+inline std::string* InstantiatePrefabInstanceRequest::mutable_parent_instance_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_parent_instance_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.InstantiatePrefabInstanceRequest.parent_instance_id)
+  return _s;
+}
+inline const std::string& InstantiatePrefabInstanceRequest::_internal_parent_instance_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.parent_instance_id_.Get();
+}
+inline void InstantiatePrefabInstanceRequest::_internal_set_parent_instance_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.Set(value, GetArena());
+}
+inline std::string* InstantiatePrefabInstanceRequest::_internal_mutable_parent_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.parent_instance_id_.Mutable( GetArena());
+}
+inline std::string* InstantiatePrefabInstanceRequest::release_parent_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.InstantiatePrefabInstanceRequest.parent_instance_id)
+  return _impl_.parent_instance_id_.Release();
+}
+inline void InstantiatePrefabInstanceRequest::set_allocated_parent_instance_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.parent_instance_id_.IsDefault()) {
+    _impl_.parent_instance_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.InstantiatePrefabInstanceRequest.parent_instance_id)
+}
+
+// bool apply_world_position = 3;
+inline void InstantiatePrefabInstanceRequest::clear_apply_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.apply_world_position_ = false;
+}
+inline bool InstantiatePrefabInstanceRequest::apply_world_position() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.InstantiatePrefabInstanceRequest.apply_world_position)
+  return _internal_apply_world_position();
+}
+inline void InstantiatePrefabInstanceRequest::set_apply_world_position(bool value) {
+  _internal_set_apply_world_position(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.InstantiatePrefabInstanceRequest.apply_world_position)
+}
+inline bool InstantiatePrefabInstanceRequest::_internal_apply_world_position() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.apply_world_position_;
+}
+inline void InstantiatePrefabInstanceRequest::_internal_set_apply_world_position(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.apply_world_position_ = value;
+}
+
+// .sailor.editor.v1.Vector4 world_position = 4;
+inline bool InstantiatePrefabInstanceRequest::has_world_position() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.world_position_ != nullptr);
+  return value;
+}
+inline void InstantiatePrefabInstanceRequest::clear_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.world_position_ != nullptr) _impl_.world_position_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::sailor::editor::v1::Vector4& InstantiatePrefabInstanceRequest::_internal_world_position() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::sailor::editor::v1::Vector4* p = _impl_.world_position_;
+  return p != nullptr ? *p : reinterpret_cast<const ::sailor::editor::v1::Vector4&>(::sailor::editor::v1::_Vector4_default_instance_);
+}
+inline const ::sailor::editor::v1::Vector4& InstantiatePrefabInstanceRequest::world_position() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.InstantiatePrefabInstanceRequest.world_position)
+  return _internal_world_position();
+}
+inline void InstantiatePrefabInstanceRequest::unsafe_arena_set_allocated_world_position(::sailor::editor::v1::Vector4* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.world_position_);
+  }
+  _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.InstantiatePrefabInstanceRequest.world_position)
+}
+inline ::sailor::editor::v1::Vector4* InstantiatePrefabInstanceRequest::release_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::sailor::editor::v1::Vector4* released = _impl_.world_position_;
+  _impl_.world_position_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::sailor::editor::v1::Vector4* InstantiatePrefabInstanceRequest::unsafe_arena_release_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.InstantiatePrefabInstanceRequest.world_position)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::sailor::editor::v1::Vector4* temp = _impl_.world_position_;
+  _impl_.world_position_ = nullptr;
+  return temp;
+}
+inline ::sailor::editor::v1::Vector4* InstantiatePrefabInstanceRequest::_internal_mutable_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.world_position_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::Vector4>(GetArena());
+    _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(p);
+  }
+  return _impl_.world_position_;
+}
+inline ::sailor::editor::v1::Vector4* InstantiatePrefabInstanceRequest::mutable_world_position() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::sailor::editor::v1::Vector4* _msg = _internal_mutable_world_position();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.InstantiatePrefabInstanceRequest.world_position)
+  return _msg;
+}
+inline void InstantiatePrefabInstanceRequest::set_allocated_world_position(::sailor::editor::v1::Vector4* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.world_position_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(value);
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.InstantiatePrefabInstanceRequest.world_position)
+}
+
+// -------------------------------------------------------------------
+
+// ViewportObjectRequest
+
+// uint64 viewport_id = 1;
+inline void ViewportObjectRequest::clear_viewport_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.viewport_id_ = ::uint64_t{0u};
+}
+inline ::uint64_t ViewportObjectRequest::viewport_id() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportObjectRequest.viewport_id)
+  return _internal_viewport_id();
+}
+inline void ViewportObjectRequest::set_viewport_id(::uint64_t value) {
+  _internal_set_viewport_id(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportObjectRequest.viewport_id)
+}
+inline ::uint64_t ViewportObjectRequest::_internal_viewport_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.viewport_id_;
+}
+inline void ViewportObjectRequest::_internal_set_viewport_id(::uint64_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.viewport_id_ = value;
+}
+
+// string instance_id = 2;
+inline void ViewportObjectRequest::clear_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.ClearToEmpty();
+}
+inline const std::string& ViewportObjectRequest::instance_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportObjectRequest.instance_id)
+  return _internal_instance_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void ViewportObjectRequest::set_instance_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportObjectRequest.instance_id)
+}
+inline std::string* ViewportObjectRequest::mutable_instance_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_instance_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ViewportObjectRequest.instance_id)
+  return _s;
+}
+inline const std::string& ViewportObjectRequest::_internal_instance_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.instance_id_.Get();
+}
+inline void ViewportObjectRequest::_internal_set_instance_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.Set(value, GetArena());
+}
+inline std::string* ViewportObjectRequest::_internal_mutable_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.instance_id_.Mutable( GetArena());
+}
+inline std::string* ViewportObjectRequest::release_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ViewportObjectRequest.instance_id)
+  return _impl_.instance_id_.Release();
+}
+inline void ViewportObjectRequest::set_allocated_instance_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.instance_id_.IsDefault()) {
+    _impl_.instance_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ViewportObjectRequest.instance_id)
+}
+
+// -------------------------------------------------------------------
+
+// PrefabLinkRequest
+
+// string instance_id = 1;
+inline void PrefabLinkRequest::clear_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.ClearToEmpty();
+}
+inline const std::string& PrefabLinkRequest::instance_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.PrefabLinkRequest.instance_id)
+  return _internal_instance_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void PrefabLinkRequest::set_instance_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.PrefabLinkRequest.instance_id)
+}
+inline std::string* PrefabLinkRequest::mutable_instance_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_instance_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.PrefabLinkRequest.instance_id)
+  return _s;
+}
+inline const std::string& PrefabLinkRequest::_internal_instance_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.instance_id_.Get();
+}
+inline void PrefabLinkRequest::_internal_set_instance_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.Set(value, GetArena());
+}
+inline std::string* PrefabLinkRequest::_internal_mutable_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.instance_id_.Mutable( GetArena());
+}
+inline std::string* PrefabLinkRequest::release_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.PrefabLinkRequest.instance_id)
+  return _impl_.instance_id_.Release();
+}
+inline void PrefabLinkRequest::set_allocated_instance_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.instance_id_.IsDefault()) {
+    _impl_.instance_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.PrefabLinkRequest.instance_id)
+}
+
+// string file_id = 2;
+inline void PrefabLinkRequest::clear_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.ClearToEmpty();
+}
+inline const std::string& PrefabLinkRequest::file_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.PrefabLinkRequest.file_id)
+  return _internal_file_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void PrefabLinkRequest::set_file_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.PrefabLinkRequest.file_id)
+}
+inline std::string* PrefabLinkRequest::mutable_file_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_file_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.PrefabLinkRequest.file_id)
+  return _s;
+}
+inline const std::string& PrefabLinkRequest::_internal_file_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.file_id_.Get();
+}
+inline void PrefabLinkRequest::_internal_set_file_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.Set(value, GetArena());
+}
+inline std::string* PrefabLinkRequest::_internal_mutable_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.file_id_.Mutable( GetArena());
+}
+inline std::string* PrefabLinkRequest::release_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.PrefabLinkRequest.file_id)
+  return _impl_.file_id_.Release();
+}
+inline void PrefabLinkRequest::set_allocated_file_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.file_id_.IsDefault()) {
+    _impl_.file_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.PrefabLinkRequest.file_id)
+}
+
+// -------------------------------------------------------------------
+
+// ViewportToolStateRequest
+
+// uint64 viewport_id = 1;
+inline void ViewportToolStateRequest::clear_viewport_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.viewport_id_ = ::uint64_t{0u};
+}
+inline ::uint64_t ViewportToolStateRequest::viewport_id() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportToolStateRequest.viewport_id)
+  return _internal_viewport_id();
+}
+inline void ViewportToolStateRequest::set_viewport_id(::uint64_t value) {
+  _internal_set_viewport_id(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportToolStateRequest.viewport_id)
+}
+inline ::uint64_t ViewportToolStateRequest::_internal_viewport_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.viewport_id_;
+}
+inline void ViewportToolStateRequest::_internal_set_viewport_id(::uint64_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.viewport_id_ = value;
+}
+
+// .sailor.editor.v1.ViewportTransformOperation operation = 2;
+inline void ViewportToolStateRequest::clear_operation() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.operation_ = 0;
+}
+inline ::sailor::editor::v1::ViewportTransformOperation ViewportToolStateRequest::operation() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportToolStateRequest.operation)
+  return _internal_operation();
+}
+inline void ViewportToolStateRequest::set_operation(::sailor::editor::v1::ViewportTransformOperation value) {
+  _internal_set_operation(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportToolStateRequest.operation)
+}
+inline ::sailor::editor::v1::ViewportTransformOperation ViewportToolStateRequest::_internal_operation() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::sailor::editor::v1::ViewportTransformOperation>(_impl_.operation_);
+}
+inline void ViewportToolStateRequest::_internal_set_operation(::sailor::editor::v1::ViewportTransformOperation value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.operation_ = value;
+}
+
+// .sailor.editor.v1.ViewportTransformSpace space = 3;
+inline void ViewportToolStateRequest::clear_space() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.space_ = 0;
+}
+inline ::sailor::editor::v1::ViewportTransformSpace ViewportToolStateRequest::space() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportToolStateRequest.space)
+  return _internal_space();
+}
+inline void ViewportToolStateRequest::set_space(::sailor::editor::v1::ViewportTransformSpace value) {
+  _internal_set_space(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportToolStateRequest.space)
+}
+inline ::sailor::editor::v1::ViewportTransformSpace ViewportToolStateRequest::_internal_space() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::sailor::editor::v1::ViewportTransformSpace>(_impl_.space_);
+}
+inline void ViewportToolStateRequest::_internal_set_space(::sailor::editor::v1::ViewportTransformSpace value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.space_ = value;
+}
+
 // -------------------------------------------------------------------
 
 // SelectionRequest
@@ -15495,6 +19621,154 @@ inline void InstanceIdResult::set_allocated_instance_id(std::string* value) {
     _impl_.instance_id_.Set("", GetArena());
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.InstanceIdResult.instance_id)
+}
+
+// -------------------------------------------------------------------
+
+// Vector4Result
+
+// .sailor.editor.v1.Vector4 value = 1;
+inline bool Vector4Result::has_value() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.value_ != nullptr);
+  return value;
+}
+inline void Vector4Result::clear_value() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.value_ != nullptr) _impl_.value_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::sailor::editor::v1::Vector4& Vector4Result::_internal_value() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::sailor::editor::v1::Vector4* p = _impl_.value_;
+  return p != nullptr ? *p : reinterpret_cast<const ::sailor::editor::v1::Vector4&>(::sailor::editor::v1::_Vector4_default_instance_);
+}
+inline const ::sailor::editor::v1::Vector4& Vector4Result::value() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.Vector4Result.value)
+  return _internal_value();
+}
+inline void Vector4Result::unsafe_arena_set_allocated_value(::sailor::editor::v1::Vector4* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.value_);
+  }
+  _impl_.value_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.Vector4Result.value)
+}
+inline ::sailor::editor::v1::Vector4* Vector4Result::release_value() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::sailor::editor::v1::Vector4* released = _impl_.value_;
+  _impl_.value_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::sailor::editor::v1::Vector4* Vector4Result::unsafe_arena_release_value() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.Vector4Result.value)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::sailor::editor::v1::Vector4* temp = _impl_.value_;
+  _impl_.value_ = nullptr;
+  return temp;
+}
+inline ::sailor::editor::v1::Vector4* Vector4Result::_internal_mutable_value() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.value_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::Vector4>(GetArena());
+    _impl_.value_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(p);
+  }
+  return _impl_.value_;
+}
+inline ::sailor::editor::v1::Vector4* Vector4Result::mutable_value() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::sailor::editor::v1::Vector4* _msg = _internal_mutable_value();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.Vector4Result.value)
+  return _msg;
+}
+inline void Vector4Result::set_allocated_value(::sailor::editor::v1::Vector4* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.value_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.value_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(value);
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.Vector4Result.value)
+}
+
+// -------------------------------------------------------------------
+
+// ViewportToolStateResult
+
+// .sailor.editor.v1.ViewportTransformOperation operation = 1;
+inline void ViewportToolStateResult::clear_operation() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.operation_ = 0;
+}
+inline ::sailor::editor::v1::ViewportTransformOperation ViewportToolStateResult::operation() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportToolStateResult.operation)
+  return _internal_operation();
+}
+inline void ViewportToolStateResult::set_operation(::sailor::editor::v1::ViewportTransformOperation value) {
+  _internal_set_operation(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportToolStateResult.operation)
+}
+inline ::sailor::editor::v1::ViewportTransformOperation ViewportToolStateResult::_internal_operation() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::sailor::editor::v1::ViewportTransformOperation>(_impl_.operation_);
+}
+inline void ViewportToolStateResult::_internal_set_operation(::sailor::editor::v1::ViewportTransformOperation value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.operation_ = value;
+}
+
+// .sailor.editor.v1.ViewportTransformSpace space = 2;
+inline void ViewportToolStateResult::clear_space() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.space_ = 0;
+}
+inline ::sailor::editor::v1::ViewportTransformSpace ViewportToolStateResult::space() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportToolStateResult.space)
+  return _internal_space();
+}
+inline void ViewportToolStateResult::set_space(::sailor::editor::v1::ViewportTransformSpace value) {
+  _internal_set_space(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportToolStateResult.space)
+}
+inline ::sailor::editor::v1::ViewportTransformSpace ViewportToolStateResult::_internal_space() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::sailor::editor::v1::ViewportTransformSpace>(_impl_.space_);
+}
+inline void ViewportToolStateResult::_internal_set_space(::sailor::editor::v1::ViewportTransformSpace value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.space_ = value;
 }
 
 // -------------------------------------------------------------------
@@ -16315,6 +20589,128 @@ inline void ViewportTransformEvent::set_allocated_after_scale(::sailor::editor::
 
 // -------------------------------------------------------------------
 
+// ViewportAssetDropEvent
+
+// string file_id = 1;
+inline void ViewportAssetDropEvent::clear_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.ClearToEmpty();
+}
+inline const std::string& ViewportAssetDropEvent::file_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportAssetDropEvent.file_id)
+  return _internal_file_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void ViewportAssetDropEvent::set_file_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportAssetDropEvent.file_id)
+}
+inline std::string* ViewportAssetDropEvent::mutable_file_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_file_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ViewportAssetDropEvent.file_id)
+  return _s;
+}
+inline const std::string& ViewportAssetDropEvent::_internal_file_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.file_id_.Get();
+}
+inline void ViewportAssetDropEvent::_internal_set_file_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.Set(value, GetArena());
+}
+inline std::string* ViewportAssetDropEvent::_internal_mutable_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.file_id_.Mutable( GetArena());
+}
+inline std::string* ViewportAssetDropEvent::release_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ViewportAssetDropEvent.file_id)
+  return _impl_.file_id_.Release();
+}
+inline void ViewportAssetDropEvent::set_allocated_file_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.file_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.file_id_.IsDefault()) {
+    _impl_.file_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ViewportAssetDropEvent.file_id)
+}
+
+// float normalized_x = 2;
+inline void ViewportAssetDropEvent::clear_normalized_x() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.normalized_x_ = 0;
+}
+inline float ViewportAssetDropEvent::normalized_x() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportAssetDropEvent.normalized_x)
+  return _internal_normalized_x();
+}
+inline void ViewportAssetDropEvent::set_normalized_x(float value) {
+  _internal_set_normalized_x(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportAssetDropEvent.normalized_x)
+}
+inline float ViewportAssetDropEvent::_internal_normalized_x() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.normalized_x_;
+}
+inline void ViewportAssetDropEvent::_internal_set_normalized_x(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.normalized_x_ = value;
+}
+
+// float normalized_y = 3;
+inline void ViewportAssetDropEvent::clear_normalized_y() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.normalized_y_ = 0;
+}
+inline float ViewportAssetDropEvent::normalized_y() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportAssetDropEvent.normalized_y)
+  return _internal_normalized_y();
+}
+inline void ViewportAssetDropEvent::set_normalized_y(float value) {
+  _internal_set_normalized_y(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportAssetDropEvent.normalized_y)
+}
+inline float ViewportAssetDropEvent::_internal_normalized_y() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.normalized_y_;
+}
+inline void ViewportAssetDropEvent::_internal_set_normalized_y(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.normalized_y_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// ViewportToolShortcutEvent
+
+// uint32 key_code = 1;
+inline void ViewportToolShortcutEvent::clear_key_code() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.key_code_ = 0u;
+}
+inline ::uint32_t ViewportToolShortcutEvent::key_code() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportToolShortcutEvent.key_code)
+  return _internal_key_code();
+}
+inline void ViewportToolShortcutEvent::set_key_code(::uint32_t value) {
+  _internal_set_key_code(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportToolShortcutEvent.key_code)
+}
+inline ::uint32_t ViewportToolShortcutEvent::_internal_key_code() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.key_code_;
+}
+inline void ViewportToolShortcutEvent::_internal_set_key_code(::uint32_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.key_code_ = value;
+}
+
+// -------------------------------------------------------------------
+
 // ViewportEvent
 
 // uint64 revision = 1;
@@ -16516,6 +20912,164 @@ inline ::sailor::editor::v1::ViewportTransformEvent* ViewportEvent::_internal_mu
 inline ::sailor::editor::v1::ViewportTransformEvent* ViewportEvent::mutable_transform() ABSL_ATTRIBUTE_LIFETIME_BOUND {
   ::sailor::editor::v1::ViewportTransformEvent* _msg = _internal_mutable_transform();
   // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ViewportEvent.transform)
+  return _msg;
+}
+
+// .sailor.editor.v1.ViewportAssetDropEvent asset_drop = 12;
+inline bool ViewportEvent::has_asset_drop() const {
+  return payload_case() == kAssetDrop;
+}
+inline bool ViewportEvent::_internal_has_asset_drop() const {
+  return payload_case() == kAssetDrop;
+}
+inline void ViewportEvent::set_has_asset_drop() {
+  _impl_._oneof_case_[0] = kAssetDrop;
+}
+inline void ViewportEvent::clear_asset_drop() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (payload_case() == kAssetDrop) {
+    if (GetArena() == nullptr) {
+      delete _impl_.payload_.asset_drop_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.payload_.asset_drop_);
+    }
+    clear_has_payload();
+  }
+}
+inline ::sailor::editor::v1::ViewportAssetDropEvent* ViewportEvent::release_asset_drop() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ViewportEvent.asset_drop)
+  if (payload_case() == kAssetDrop) {
+    clear_has_payload();
+    auto* temp = _impl_.payload_.asset_drop_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.payload_.asset_drop_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::ViewportAssetDropEvent& ViewportEvent::_internal_asset_drop() const {
+  return payload_case() == kAssetDrop ? *_impl_.payload_.asset_drop_ : reinterpret_cast<::sailor::editor::v1::ViewportAssetDropEvent&>(::sailor::editor::v1::_ViewportAssetDropEvent_default_instance_);
+}
+inline const ::sailor::editor::v1::ViewportAssetDropEvent& ViewportEvent::asset_drop() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportEvent.asset_drop)
+  return _internal_asset_drop();
+}
+inline ::sailor::editor::v1::ViewportAssetDropEvent* ViewportEvent::unsafe_arena_release_asset_drop() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ViewportEvent.asset_drop)
+  if (payload_case() == kAssetDrop) {
+    clear_has_payload();
+    auto* temp = _impl_.payload_.asset_drop_;
+    _impl_.payload_.asset_drop_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ViewportEvent::unsafe_arena_set_allocated_asset_drop(::sailor::editor::v1::ViewportAssetDropEvent* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_payload();
+  if (value) {
+    set_has_asset_drop();
+    _impl_.payload_.asset_drop_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ViewportEvent.asset_drop)
+}
+inline ::sailor::editor::v1::ViewportAssetDropEvent* ViewportEvent::_internal_mutable_asset_drop() {
+  if (payload_case() != kAssetDrop) {
+    clear_payload();
+    set_has_asset_drop();
+    _impl_.payload_.asset_drop_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::ViewportAssetDropEvent>(GetArena());
+  }
+  return _impl_.payload_.asset_drop_;
+}
+inline ::sailor::editor::v1::ViewportAssetDropEvent* ViewportEvent::mutable_asset_drop() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::ViewportAssetDropEvent* _msg = _internal_mutable_asset_drop();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ViewportEvent.asset_drop)
+  return _msg;
+}
+
+// .sailor.editor.v1.ViewportToolShortcutEvent tool_shortcut = 13;
+inline bool ViewportEvent::has_tool_shortcut() const {
+  return payload_case() == kToolShortcut;
+}
+inline bool ViewportEvent::_internal_has_tool_shortcut() const {
+  return payload_case() == kToolShortcut;
+}
+inline void ViewportEvent::set_has_tool_shortcut() {
+  _impl_._oneof_case_[0] = kToolShortcut;
+}
+inline void ViewportEvent::clear_tool_shortcut() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (payload_case() == kToolShortcut) {
+    if (GetArena() == nullptr) {
+      delete _impl_.payload_.tool_shortcut_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.payload_.tool_shortcut_);
+    }
+    clear_has_payload();
+  }
+}
+inline ::sailor::editor::v1::ViewportToolShortcutEvent* ViewportEvent::release_tool_shortcut() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ViewportEvent.tool_shortcut)
+  if (payload_case() == kToolShortcut) {
+    clear_has_payload();
+    auto* temp = _impl_.payload_.tool_shortcut_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.payload_.tool_shortcut_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::ViewportToolShortcutEvent& ViewportEvent::_internal_tool_shortcut() const {
+  return payload_case() == kToolShortcut ? *_impl_.payload_.tool_shortcut_ : reinterpret_cast<::sailor::editor::v1::ViewportToolShortcutEvent&>(::sailor::editor::v1::_ViewportToolShortcutEvent_default_instance_);
+}
+inline const ::sailor::editor::v1::ViewportToolShortcutEvent& ViewportEvent::tool_shortcut() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportEvent.tool_shortcut)
+  return _internal_tool_shortcut();
+}
+inline ::sailor::editor::v1::ViewportToolShortcutEvent* ViewportEvent::unsafe_arena_release_tool_shortcut() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ViewportEvent.tool_shortcut)
+  if (payload_case() == kToolShortcut) {
+    clear_has_payload();
+    auto* temp = _impl_.payload_.tool_shortcut_;
+    _impl_.payload_.tool_shortcut_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ViewportEvent::unsafe_arena_set_allocated_tool_shortcut(::sailor::editor::v1::ViewportToolShortcutEvent* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_payload();
+  if (value) {
+    set_has_tool_shortcut();
+    _impl_.payload_.tool_shortcut_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ViewportEvent.tool_shortcut)
+}
+inline ::sailor::editor::v1::ViewportToolShortcutEvent* ViewportEvent::_internal_mutable_tool_shortcut() {
+  if (payload_case() != kToolShortcut) {
+    clear_payload();
+    set_has_tool_shortcut();
+    _impl_.payload_.tool_shortcut_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::ViewportToolShortcutEvent>(GetArena());
+  }
+  return _impl_.payload_.tool_shortcut_;
+}
+inline ::sailor::editor::v1::ViewportToolShortcutEvent* ViewportEvent::mutable_tool_shortcut() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::ViewportToolShortcutEvent* _msg = _internal_mutable_tool_shortcut();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ViewportEvent.tool_shortcut)
   return _msg;
 }
 

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -76,6 +76,12 @@ namespace Sailor
 		SAILOR_API static bool SendEditorRemoteViewportInput(uint64_t viewportId, uint32_t kind, float pointerX, float pointerY, float wheelDeltaX, float wheelDeltaY, uint32_t keyCode, uint32_t button, uint32_t modifiers, bool bPressed, bool bFocused, bool bCaptured);
 		SAILOR_API static uint32_t PullEditorMessages(char** messages, uint32_t num);
 		SAILOR_API static uint32_t PullEditorViewportEvents(char** events, uint32_t num);
+		SAILOR_API static bool ResolveEditorViewportDropPosition(
+			float normalizedX,
+			float normalizedY,
+			float& outWorldX,
+			float& outWorldY,
+			float& outWorldZ);
 		SAILOR_API static uint64_t GetEditorManagedMutationRevision(uint32_t kind, const char* strInstanceId);
 		SAILOR_API static uint32_t SerializeCurrentWorld(char** yamlNode);
 		SAILOR_API static uint32_t SerializeEngineTypes(char** yamlNode);
@@ -90,8 +96,38 @@ namespace Sailor
 		SAILOR_API static bool ResetEditorComponentToDefaults(const char* strInstanceId);
 		SAILOR_API static bool AddEditorComponent(const char* strInstanceId, const char* strComponentTypeName, const char* strPreferredInstanceId, char** outInstanceId);
 		SAILOR_API static bool RemoveEditorComponent(const char* strInstanceId);
+		SAILOR_API static bool CreateEditorModelGameObject(
+			const char* strModelFileId,
+			const char* strName,
+			const char* strParentInstanceId,
+			bool bHasWorldPosition,
+			float worldX,
+			float worldY,
+			float worldZ,
+			char** outInstanceId);
 		SAILOR_API static bool InstantiateEditorPrefab(const char* strFileId, const char* strParentInstanceId);
-		SAILOR_API static bool InstantiateEditorPrefabFromYaml(const char* strPrefabYaml, const char* strParentInstanceId);
+		SAILOR_API static bool InstantiateEditorPrefabInstance(
+			const char* strFileId,
+			const char* strParentInstanceId,
+			bool bHasWorldPosition,
+			float worldX,
+			float worldY,
+			float worldZ,
+			char** outInstanceId);
+		SAILOR_API static bool InstantiateEditorPrefabFromYaml(
+			const char* strPrefabYaml,
+			const char* strParentInstanceId);
+		SAILOR_API static bool InstantiateEditorPrefabFromYaml(
+			const char* strPrefabYaml,
+			const char* strParentInstanceId,
+			bool bStrictInstanceIds);
+		SAILOR_API static bool FocusEditorCamera(const char* strInstanceId);
+		SAILOR_API static bool SetEditorPrefabLink(
+			const char* strInstanceId,
+			const char* strFileId);
+		SAILOR_API static bool BreakEditorPrefabLink(const char* strInstanceId);
+		SAILOR_API static bool SetEditorViewportToolState(uint32_t operation, uint32_t space);
+		SAILOR_API static bool GetEditorViewportToolState(uint32_t& outOperation, uint32_t& outSpace);
 		SAILOR_API static bool SetEditorSelection(const char* strSelectionYaml);
 		SAILOR_API static bool RenderPathTracedImage(const char* strOutputPath, const char* strInstanceId, uint32_t height, uint32_t samplesPerPixel, uint32_t maxBounces);
 		SAILOR_API static void ShowMainWindow(bool bShow);

--- a/Runtime/Submodules/Editor.cpp
+++ b/Runtime/Submodules/Editor.cpp
@@ -7,11 +7,13 @@
 #include "ECS/PathTracerECS.h"
 #include "Components/PathTracerProxyComponent.h"
 #include "Components/EditorComponent.h"
+#include "Components/MeshRendererComponent.h"
 #include "Raytracing/PathTracer.h"
 #include "Editor.h"
 #include "Containers/Map.h"
 #include "AssetRegistry/World/WorldPrefabImporter.h"
 #include "AssetRegistry/Prefab/PrefabImporter.h"
+#include "AssetRegistry/Model/ModelImporter.h"
 #include "AssetRegistry/FileId.h"
 #include "Core/Reflection.h"
 #include "Math/Math.h"
@@ -27,6 +29,7 @@
 #include <sstream>
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include "Platform/Win32/Window.h"
 
 using namespace Sailor;
@@ -166,6 +169,43 @@ namespace
 		outParent = parentObject.DynamicCast<GameObject>();
 		return outParent.IsValid();
 	}
+
+	bool TrySetWorldPosition(
+		GameObjectPtr gameObject,
+		const glm::vec3& worldPosition)
+	{
+		if (!gameObject || !Math::AllFinite(worldPosition))
+		{
+			return false;
+		}
+
+		glm::vec3 localPosition = worldPosition;
+		if (const auto& parent = gameObject->GetParent())
+		{
+			glm::mat4 inverseParentMatrix{};
+			if (!TryInvertTransformMatrix(
+					CalculateCurrentWorldMatrix(parent),
+					inverseParentMatrix))
+			{
+				return false;
+			}
+
+			glm::vec4 localHomogeneous =
+				inverseParentMatrix * glm::vec4(worldPosition, 1.0f);
+			if (!Math::AllFinite(localHomogeneous) ||
+				std::abs(localHomogeneous.w) <=
+					std::numeric_limits<float>::epsilon())
+			{
+				return false;
+			}
+
+			localHomogeneous /= localHomogeneous.w;
+			localPosition = glm::vec3(localHomogeneous);
+		}
+
+		gameObject->GetTransformComponent().SetPosition(localPosition);
+		return true;
+	}
 }
 
 Editor::Editor(HWND editorHwnd, uint32_t editorPort, Sailor::Win32::Window* pMainWindow) :
@@ -208,6 +248,32 @@ void Editor::TickViewportTools()
 		m_viewportController->SetManagedMutationRevisions(
 			m_managedSelectionMutationRevision,
 			selectedObjectRevision);
+#if defined(_WIN32)
+		if (m_pMainWindow)
+		{
+			std::string fileId{};
+			float normalizedX = 0.0f;
+			float normalizedY = 0.0f;
+			while (m_pMainWindow->PullEditorViewportAssetDrop(
+				fileId,
+				normalizedX,
+				normalizedY))
+			{
+				m_viewportController->QueueAssetDropEvent(
+					fileId,
+					normalizedX,
+					normalizedY);
+			}
+
+			uint32_t shortcutKeyCode = 0;
+			while (m_pMainWindow->PullEditorViewportToolShortcut(
+				shortcutKeyCode))
+			{
+				m_viewportController->QueueToolShortcutEvent(
+					shortcutKeyCode);
+			}
+		}
+#endif
 		m_viewportController->Tick(*m_world);
 	}
 }
@@ -445,6 +511,10 @@ bool Editor::ReparentObject(const InstanceId& instanceId, const InstanceId& pare
 	}
 
 	gameObject->SetParent(parentGameObject);
+	if (gameObject->GetParent() != parentGameObject)
+	{
+		return false;
+	}
 
 	if (bKeepWorldTransform)
 	{
@@ -485,6 +555,11 @@ bool Editor::CreateGameObject(const InstanceId& parentInstanceId, const Instance
 	if (parentGameObject)
 	{
 		gameObject->SetParent(parentGameObject);
+		if (gameObject->GetParent() != parentGameObject)
+		{
+			m_world->DestroyImmediate(gameObject);
+			return false;
+		}
 	}
 
 	outInstanceId = gameObject->GetInstanceId();
@@ -504,6 +579,12 @@ bool Editor::DestroyObject(const InstanceId& instanceId)
 	auto object = m_world->GetObjectByInstanceId(instanceId.GameObjectId());
 	auto gameObject = object.DynamicCast<GameObject>();
 	if (!gameObject)
+	{
+		return false;
+	}
+
+	if (m_world->IsPrefabLinked(instanceId) &&
+		!m_world->IsPrefabInstanceRoot(instanceId))
 	{
 		return false;
 	}
@@ -620,9 +701,45 @@ bool Editor::RemoveComponent(const InstanceId& instanceId)
 
 bool Editor::InstantiatePrefab(const FileId& prefabId, const InstanceId& parentInstanceId)
 {
-	SAILOR_PROFILE_FUNCTION();
+	InstanceId instanceId{};
+	return InstantiatePrefab(
+		prefabId,
+		parentInstanceId,
+		nullptr,
+		instanceId);
+}
 
-	if (!m_world)
+bool Editor::InstantiatePrefab(
+	const PrefabPtr& prefab,
+	const InstanceId& parentInstanceId)
+{
+	return InstantiatePrefab(prefab, parentInstanceId, false);
+}
+
+bool Editor::InstantiatePrefab(
+	const PrefabPtr& prefab,
+	const InstanceId& parentInstanceId,
+	bool bStrictInstanceIds)
+{
+	InstanceId instanceId{};
+	return InstantiatePrefab(
+		prefab,
+		parentInstanceId,
+		nullptr,
+		instanceId,
+		bStrictInstanceIds);
+}
+
+bool Editor::InstantiatePrefab(
+	const FileId& prefabId,
+	const InstanceId& parentInstanceId,
+	const glm::vec3* worldPosition,
+	InstanceId& outInstanceId)
+{
+	SAILOR_PROFILE_FUNCTION();
+	outInstanceId = InstanceId::Invalid;
+
+	if (!m_world || !prefabId)
 	{
 		return false;
 	}
@@ -634,17 +751,29 @@ bool Editor::InstantiatePrefab(const FileId& prefabId, const InstanceId& parentI
 	}
 
 	PrefabPtr prefab;
-	if (!prefabImporter->LoadPrefab_Immediate(prefabId, prefab) || !prefab || !prefab->IsReady())
+	if (!prefabImporter->LoadPrefab_Immediate(prefabId, prefab) ||
+		!prefab ||
+		!prefab->IsReady())
 	{
 		return false;
 	}
 
-	return InstantiatePrefab(prefab, parentInstanceId);
+	return InstantiatePrefab(
+		prefab,
+		parentInstanceId,
+		worldPosition,
+		outInstanceId);
 }
 
-bool Editor::InstantiatePrefab(const PrefabPtr& prefab, const InstanceId& parentInstanceId)
+bool Editor::InstantiatePrefab(
+	const PrefabPtr& prefab,
+	const InstanceId& parentInstanceId,
+	const glm::vec3* worldPosition,
+	InstanceId& outInstanceId,
+	bool bStrictInstanceIds)
 {
 	SAILOR_PROFILE_FUNCTION();
+	outInstanceId = InstanceId::Invalid;
 
 	if (!m_world || !prefab)
 	{
@@ -657,19 +786,230 @@ bool Editor::InstantiatePrefab(const PrefabPtr& prefab, const InstanceId& parent
 		return false;
 	}
 
-	auto root = m_world->Instantiate(prefab);
+	const bool bDetachedFromPrefabRestore =
+		prefab->IsDetachedFromPrefabRecord();
+	if (bDetachedFromPrefabRestore)
+	{
+		if (!bStrictInstanceIds ||
+			!parentGameObject ||
+			prefab->GetFileId() ||
+			prefab->GetDetachedParentInstanceId() !=
+				parentInstanceId ||
+			!m_world->IsPrefabLinked(parentInstanceId))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot restore detached prefab snapshot: strict ids, an invalid source FileId, and the exact linked parent are required.");
+			return false;
+		}
+	}
+	else if (parentGameObject)
+	{
+		std::string reparentDiagnostic;
+		if (!m_world->CanReparentPrefabObject(
+				InstanceId::Invalid,
+				parentInstanceId,
+				&reparentDiagnostic))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot instantiate prefab under parent '%s': %s.",
+				parentInstanceId.ToString().c_str(),
+				reparentDiagnostic.c_str());
+			return false;
+		}
+	}
+
+	auto root = m_world->Instantiate(prefab, bStrictInstanceIds);
 	if (!root)
+	{
+		return false;
+	}
+
+	if (parentGameObject &&
+		!bDetachedFromPrefabRestore)
+	{
+		root->SetParent(parentGameObject);
+		if (root->GetParent() != parentGameObject)
+		{
+			m_world->DestroyImmediate(root);
+			return false;
+		}
+	}
+	else if (bDetachedFromPrefabRestore &&
+		root->GetParent() != parentGameObject)
+	{
+		m_world->DestroyImmediate(root);
+		return false;
+	}
+
+	if (worldPosition && !TrySetWorldPosition(root, *worldPosition))
+	{
+		m_world->DestroyImmediate(root);
+		return false;
+	}
+
+	outInstanceId = root->GetInstanceId();
+	NotifyManagedObjectMutation(root->GetInstanceId());
+	return true;
+}
+
+bool Editor::CreateModelGameObject(
+	const FileId& modelId,
+	const std::string& name,
+	const InstanceId& parentInstanceId,
+	const glm::vec3* worldPosition,
+	InstanceId& outInstanceId)
+{
+	SAILOR_PROFILE_FUNCTION();
+	outInstanceId = InstanceId::Invalid;
+
+	if (!m_world || !modelId || name.empty())
+	{
+		return false;
+	}
+
+	GameObjectPtr parentGameObject{};
+	if (!ResolveParent(m_world, parentInstanceId, parentGameObject))
+	{
+		return false;
+	}
+
+	auto modelImporter = App::GetSubmodule<ModelImporter>();
+	ModelPtr model{};
+	if (!modelImporter ||
+		!modelImporter->LoadModel_Immediate(modelId, model) ||
+		!model ||
+		!model->IsReady())
+	{
+		return false;
+	}
+
+	auto gameObject = m_world->Instantiate(name);
+	if (!gameObject)
 	{
 		return false;
 	}
 
 	if (parentGameObject)
 	{
-		root->SetParent(parentGameObject);
+		gameObject->SetParent(parentGameObject);
+		if (gameObject->GetParent() != parentGameObject)
+		{
+			m_world->DestroyImmediate(gameObject);
+			return false;
+		}
 	}
 
-	NotifyManagedObjectMutation(root->GetInstanceId());
+	if (worldPosition && !TrySetWorldPosition(gameObject, *worldPosition))
+	{
+		m_world->DestroyImmediate(gameObject);
+		return false;
+	}
+
+	auto meshRenderer = gameObject->AddComponent<MeshRendererComponent>();
+	if (!meshRenderer)
+	{
+		m_world->DestroyImmediate(gameObject);
+		return false;
+	}
+
+	meshRenderer->SetModel(model);
+	outInstanceId = gameObject->GetInstanceId();
+	NotifyManagedObjectMutation(outInstanceId);
 	return true;
+}
+
+bool Editor::ResolveViewportDropPosition(
+	float normalizedX,
+	float normalizedY,
+	glm::vec3& outPosition) const
+{
+	return m_world &&
+		m_viewportController &&
+		m_viewportController->TryResolveDropPosition(
+			*m_world,
+			normalizedX,
+			normalizedY,
+			outPosition);
+}
+
+bool Editor::FocusEditorCamera(const InstanceId& instanceId)
+{
+	return m_world &&
+		m_viewportController &&
+		m_viewportController->FocusCameraOnObject(*m_world, instanceId);
+}
+
+bool Editor::SetPrefabLink(
+	const InstanceId& instanceId,
+	const FileId& prefabId)
+{
+	if (!m_world ||
+		!instanceId.IsGameObjectId() ||
+		!prefabId)
+	{
+		return false;
+	}
+
+	auto root = m_world
+		->GetObjectByInstanceId(instanceId)
+		.DynamicCast<GameObject>();
+	auto prefabImporter = App::GetSubmodule<PrefabImporter>();
+	PrefabPtr prefab{};
+	if (!root ||
+		!prefabImporter ||
+		!prefabImporter->LoadPrefab_Immediate(prefabId, prefab) ||
+		!prefab ||
+		!prefab->IsReady())
+	{
+		return false;
+	}
+
+	std::string diagnostic{};
+	if (!m_world->LinkPrefabInstance(root, prefab, diagnostic))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot link game object '%s' to prefab '%s': %s.",
+			instanceId.ToString().c_str(),
+			prefabId.ToString().c_str(),
+			diagnostic.c_str());
+		return false;
+	}
+
+	NotifyManagedObjectMutation(instanceId);
+	return true;
+}
+
+bool Editor::BreakPrefabLink(const InstanceId& instanceId)
+{
+	if (!m_world ||
+		!instanceId.IsGameObjectId() ||
+		!m_world->BreakPrefabLink(instanceId))
+	{
+		return false;
+	}
+
+	NotifyManagedObjectMutation(instanceId);
+	return true;
+}
+
+bool Editor::SetViewportToolState(
+	EditorViewport::ETransformOperation operation,
+	EditorViewport::ETransformSpace space)
+{
+	return m_viewportController &&
+		m_viewportController->SetTransformToolState(operation, space);
+}
+
+void Editor::GetViewportToolState(
+	EditorViewport::ETransformOperation& outOperation,
+	EditorViewport::ETransformSpace& outSpace) const
+{
+	outOperation = m_viewportController
+		? m_viewportController->GetOperation()
+		: EditorViewport::ETransformOperation::Translate;
+	outSpace = m_viewportController
+		? m_viewportController->GetSpace()
+		: EditorViewport::ETransformSpace::World;
 }
 
 bool Editor::RenderPathTracedImage(const InstanceId& instanceId, const std::string& outputPath, uint32_t height, uint32_t samplesPerPixel, uint32_t maxBounces)
@@ -755,6 +1095,15 @@ YAML::Node Editor::SerializeWorld() const
 	}
 
 	auto prefab = WorldPrefab::FromWorld(m_world);
-	auto node = prefab->Serialize();
-	return node;
+	if (!prefab || !prefab->IsReady())
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot serialize the current world: %s.",
+			prefab
+				? prefab->GetLoadDiagnostic().c_str()
+				: "world serialization did not create a document");
+		return YAML::Node();
+	}
+
+	return prefab->Serialize();
 }

--- a/Runtime/Submodules/Editor.h
+++ b/Runtime/Submodules/Editor.h
@@ -2,6 +2,7 @@
 #include "Core/Submodule.h"
 #include "Memory/UniquePtr.hpp"
 #include <atomic>
+#include <glm/vec3.hpp>
 #include <yaml-cpp/yaml.h>
 #if __has_include(<concurrent_queue.h>)
 #include <concurrent_queue.h>
@@ -22,7 +23,12 @@ namespace Sailor
 	class InstanceId;
 	class Prefab;
 	struct EditorManagedMutationState;
-	namespace EditorViewport { class EditorViewportController; }
+	namespace EditorViewport
+	{
+		enum class ETransformOperation : uint8_t;
+		enum class ETransformSpace : uint8_t;
+		class EditorViewportController;
+	}
 
 	namespace Win32 
 	{
@@ -70,7 +76,45 @@ namespace Sailor
 		bool AddComponent(const class InstanceId& instanceId, const std::string& componentTypeName, const class InstanceId& preferredInstanceId, class InstanceId& outInstanceId);
 		SAILOR_SHARED_API bool RemoveComponent(const class InstanceId& instanceId);
 		bool InstantiatePrefab(const class FileId& prefabId, const class InstanceId& parentInstanceId);
-		bool InstantiatePrefab(const TObjectPtr<Prefab>& prefab, const class InstanceId& parentInstanceId);
+		bool InstantiatePrefab(
+			const TObjectPtr<Prefab>& prefab,
+			const class InstanceId& parentInstanceId);
+		bool InstantiatePrefab(
+			const TObjectPtr<Prefab>& prefab,
+			const class InstanceId& parentInstanceId,
+			bool bStrictInstanceIds);
+		bool InstantiatePrefab(
+			const class FileId& prefabId,
+			const class InstanceId& parentInstanceId,
+			const glm::vec3* worldPosition,
+			class InstanceId& outInstanceId);
+		bool InstantiatePrefab(
+			const TObjectPtr<Prefab>& prefab,
+			const class InstanceId& parentInstanceId,
+			const glm::vec3* worldPosition,
+			class InstanceId& outInstanceId,
+			bool bStrictInstanceIds = false);
+		bool CreateModelGameObject(
+			const class FileId& modelId,
+			const std::string& name,
+			const class InstanceId& parentInstanceId,
+			const glm::vec3* worldPosition,
+			class InstanceId& outInstanceId);
+		bool ResolveViewportDropPosition(
+			float normalizedX,
+			float normalizedY,
+			glm::vec3& outPosition) const;
+		bool FocusEditorCamera(const class InstanceId& instanceId);
+		bool SetPrefabLink(
+			const class InstanceId& instanceId,
+			const class FileId& prefabId);
+		bool BreakPrefabLink(const class InstanceId& instanceId);
+		bool SetViewportToolState(
+			EditorViewport::ETransformOperation operation,
+			EditorViewport::ETransformSpace space);
+		void GetViewportToolState(
+			EditorViewport::ETransformOperation& outOperation,
+			EditorViewport::ETransformSpace& outSpace) const;
 		bool RenderPathTracedImage(const class InstanceId& instanceId, const std::string& outputPath, uint32_t height, uint32_t samplesPerPixel, uint32_t maxBounces);
 
 	protected:

--- a/Runtime/Submodules/Editor.h
+++ b/Runtime/Submodules/Editor.h
@@ -76,10 +76,10 @@ namespace Sailor
 		bool AddComponent(const class InstanceId& instanceId, const std::string& componentTypeName, const class InstanceId& preferredInstanceId, class InstanceId& outInstanceId);
 		SAILOR_SHARED_API bool RemoveComponent(const class InstanceId& instanceId);
 		bool InstantiatePrefab(const class FileId& prefabId, const class InstanceId& parentInstanceId);
-		bool InstantiatePrefab(
+		SAILOR_API bool InstantiatePrefab(
 			const TObjectPtr<Prefab>& prefab,
 			const class InstanceId& parentInstanceId);
-		bool InstantiatePrefab(
+		SAILOR_API bool InstantiatePrefab(
 			const TObjectPtr<Prefab>& prefab,
 			const class InstanceId& parentInstanceId,
 			bool bStrictInstanceIds);

--- a/Tests/AssetMountDiscoveryTests.cpp
+++ b/Tests/AssetMountDiscoveryTests.cpp
@@ -281,6 +281,38 @@ namespace
 		}, "Discovery output should be globally sorted by normalized virtual path");
 	}
 
+	void TestDiscoverySkipsInternalTransactionDirectories()
+	{
+		TempDirectory content("transaction-staging");
+		WriteFile(content.Path("Prefabs/Duck.prefab"), "published source");
+		WriteFile(content.Path("Prefabs/Duck.prefab.asset"), "published metadata");
+		WriteFile(
+			content.Path("Prefabs/.sailor-asset-write-fixture.pending/source.backup"),
+			"old source");
+		WriteFile(
+			content.Path("Prefabs/.sailor-asset-write-fixture.pending/metadata.backup"),
+			"old metadata");
+		WriteFile(
+			content.Path("Prefabs/.sailor-asset-write-fixture.pending/source.backup.asset"),
+			"phantom metadata");
+
+		const AssetMountDiscoveryResult result = DiscoverAssetMountFiles({
+			Mount(content.Get(), EAssetMountKind::Workspace, 10, true)
+		});
+
+		Require(result.m_files.Num() == 2,
+			"An initial registry scan should see only the published final asset pair");
+		FindFile(result, EAssetMountKind::Workspace, "Prefabs/Duck.prefab");
+		FindFile(result, EAssetMountKind::Workspace, "Prefabs/Duck.prefab.asset");
+		Require(std::none_of(
+			result.m_files.begin(),
+			result.m_files.end(),
+			[](const AssetMountDiscoveredFile& file)
+			{
+				return file.m_virtualPath.find(".sailor-") != std::string::npos;
+			}), "Internal transaction staging directories must not enter native discovery");
+	}
+
 	void TestOverlappingRootsAreRejectedInBothDirections()
 	{
 		{
@@ -559,6 +591,7 @@ int main(int argc, char** argv)
 		TestIdenticalRootsAreDeduplicatedToWorkspace();
 		TestInvalidMountRootIsFatal();
 		TestDiscoveryIsSortedByVirtualPath();
+		TestDiscoverySkipsInternalTransactionDirectories();
 		TestOverlappingRootsAreRejectedInBothDirections();
 		TestDiscoverySkipsPhysicalEscapesAndCycles();
 		TestWorkspaceWinsVirtualPathIndependentOfInputOrder();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -502,6 +502,13 @@ add_test(
 )
 
 add_test(
+    NAME Win32EditorAssetDropContract
+    COMMAND ${Python3_EXECUTABLE}
+        ${CMAKE_CURRENT_SOURCE_DIR}/win32_editor_asset_drop_contract_test.py
+        ${PROJECT_SOURCE_DIR}
+)
+
+add_test(
     NAME WorkspaceModuleRuntimeTests
     COMMAND WorkspaceModuleRuntimeTests
         $<TARGET_FILE:WorkspaceModuleFixture>
@@ -542,6 +549,7 @@ set_tests_properties(
     VulkanMemoryCounterContract
     SkyTemperatureTableContract
     ShaderConstantsModeContract
+    Win32EditorAssetDropContract
     PROPERTIES TIMEOUT 30
 )
 

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -12,6 +12,7 @@
 
 #include "Containers/Octree.h"
 #include "AssetRegistry/Prefab/PrefabImporter.h"
+#include "AssetRegistry/World/WorldPrefabImporter.h"
 #include "Components/AnimatorComponent.h"
 #include "Components/Component.h"
 #include "Components/MeshRendererComponent.h"
@@ -39,12 +40,30 @@ namespace Sailor
 		float m_value = 0.0f;
 		ComponentPtr m_dependency;
 	};
+
+	class PrefabMixedDependencyTestComponent final : public Component
+	{
+		SAILOR_REFLECTABLE(PrefabMixedDependencyTestComponent)
+
+	public:
+
+		PrefabMixedDependencyTestComponent() = default;
+
+		ComponentPtr m_sourceDependency;
+		ComponentPtr m_liveDependency;
+	};
 }
 
 REFL_AUTO(
 	type(Sailor::PrefabRollbackTestComponent, bases<Sailor::Component>),
 	field(m_value),
 	field(m_dependency)
+)
+
+REFL_AUTO(
+	type(Sailor::PrefabMixedDependencyTestComponent, bases<Sailor::Component>),
+	field(m_sourceDependency),
+	field(m_liveDependency)
 )
 
 namespace
@@ -162,6 +181,158 @@ namespace
 			systems.Add(TUniquePtr<TransformECS>::Make());
 			systems.Add(TUniquePtr<StaticMeshRendererECS>::Make());
 			return systems;
+		}
+	};
+
+	class PrefabDocumentTestAsset final : public Prefab
+	{
+	public:
+
+		PrefabDocumentTestAsset(const FileId& fileId) :
+			Prefab(fileId) {}
+
+		static PrefabPtr Capture(
+			PrefabTestWorld& world,
+			GameObjectPtr root,
+			const FileId& fileId = FileId::Invalid)
+		{
+			auto result =
+				TObjectPtr<PrefabDocumentTestAsset>::Make(
+					world.GetAllocator(),
+					fileId);
+			SerializeGameObject(
+				root,
+				static_cast<uint32_t>(-1),
+				result->m_components,
+				result->m_gameObjects,
+				nullptr);
+
+			std::string diagnostic;
+			result->m_bIsReady.store(
+				result->ValidateForInstantiation(
+					diagnostic),
+				std::memory_order_release);
+			return result;
+		}
+
+		static bool MarkExpandedLinkedRecord(
+			PrefabPtr prefab,
+			const TMap<InstanceId, InstanceId>& mappings,
+			std::string& outDiagnostic)
+		{
+			auto result =
+				prefab.DynamicCast<
+					PrefabDocumentTestAsset>();
+			if (!result)
+			{
+				outDiagnostic =
+					"the expanded fixture has an unexpected type";
+				return false;
+			}
+
+			result->m_linkedInstanceIds = mappings;
+			result->m_bLinkedInstanceRecord = true;
+			result->m_bExpandedLinkedInstanceRecord =
+				true;
+			result->m_detachedSupplementalInstanceIds.
+				Clear();
+			TSet<InstanceId> mappedLiveIds;
+			for (const auto& mapping : mappings)
+			{
+				mappedLiveIds.Insert(
+					*mapping.m_second);
+			}
+			for (const auto& gameObject :
+				result->m_gameObjects)
+			{
+				if (!mappedLiveIds.Contains(
+						gameObject.m_instanceId))
+				{
+					result->
+						m_detachedSupplementalInstanceIds.
+							Insert(
+								gameObject.m_instanceId);
+				}
+			}
+
+			return result->ValidateForInstantiation(
+				outDiagnostic);
+		}
+	};
+
+	class WorldPrefabDocumentFixture final : public WorldPrefab
+	{
+	public:
+
+		WorldPrefabDocumentFixture() : WorldPrefab(FileId::Invalid) {}
+
+		void AddPrefab(const PrefabPtr& prefab)
+		{
+			m_gameObjects.Add(prefab);
+			m_bIsReady.store(true, std::memory_order_release);
+		}
+
+		static bool Reconcile(
+			const PrefabPtr& expandedPrefab,
+			const PrefabPtr& sourcePrefab,
+			const TMap<InstanceId, InstanceId>& savedSourceToInstanceIds,
+			TSet<InstanceId>& reservedInstanceIds,
+			TMap<InstanceId, InstanceId>& outSourceToInstanceIds,
+			std::string& outDiagnostic)
+		{
+			return ReconcileLinkedInstanceIds(
+				expandedPrefab,
+				sourcePrefab,
+				savedSourceToInstanceIds,
+				reservedInstanceIds,
+				outSourceToInstanceIds,
+				outDiagnostic);
+		}
+
+		static bool BuildUpdatedOverrides(
+			const PrefabPtr& expandedPrefab,
+			const PrefabPtr& sourcePrefab,
+			const PrefabPtr& effectiveBaseline,
+			const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+			TMap<InstanceId, YAML::Node>& outGameObjectOverrides,
+			TMap<InstanceId, ReflectedData>& outComponentOverrides,
+			std::string& outDiagnostic)
+		{
+			return BuildUpdatedLinkedOverrides(
+				expandedPrefab,
+				sourcePrefab,
+				effectiveBaseline,
+				sourceToInstanceIds,
+				outGameObjectOverrides,
+				outComponentOverrides,
+				outDiagnostic);
+		}
+
+		static bool CommitLinkedUpdate(
+			WorldPtr world,
+			const InstanceId& rootInstanceId,
+			const TMap<InstanceId, InstanceId>& sourceToInstanceIds,
+			const PrefabPtr& effectiveBaseline,
+			std::string& outDiagnostic)
+		{
+			TVector<PendingPrefabLinkUpdate> pendingUpdates;
+			PendingPrefabLinkUpdate pendingUpdate;
+			pendingUpdate.m_rootInstanceId = rootInstanceId;
+			pendingUpdate.m_sourceToInstanceIds =
+				sourceToInstanceIds;
+			pendingUpdate.m_effectiveBaseline =
+				effectiveBaseline;
+			pendingUpdates.Add(std::move(pendingUpdate));
+			return CommitLinkedInstanceUpdates(
+				world,
+				pendingUpdates,
+				outDiagnostic);
+		}
+
+		void MarkSerializationFailure(std::string diagnostic)
+		{
+			m_loadDiagnostic = std::move(diagnostic);
+			m_bIsReady.store(false, std::memory_order_release);
 		}
 	};
 
@@ -515,6 +686,10 @@ namespace
 			"an expired world source must invalidate its loaded world prefab");
 		Require(updateBody.find("m_promises.Remove(uid)") != std::string::npos,
 			"an expired world source must invalidate its completed load promise");
+		Require(updateBody.find("dynamic_cast<PrefabAssetInfo*>") != std::string::npos &&
+			updateBody.find("m_loadedWorldPrefabs.Clear()") != std::string::npos &&
+			updateBody.find("m_promises.Clear()") != std::string::npos,
+			"an expired linked prefab source must invalidate cached merged world prefabs");
 	}
 
 	void TestEmptyEditorWorldBootstrapContract()
@@ -749,10 +924,12 @@ namespace
 	YAML::Node MakeReflectedComponent(
 		const std::string& componentInstanceId,
 		const YAML::Node& overrideProperties,
-		bool bIncludeInstanceId = true)
+		bool bIncludeInstanceId = true,
+		const std::string& typeName =
+			PrefabRollbackTestComponent::GetStaticTypeInfo().Name())
 	{
 		YAML::Node component;
-		component["typename"] = PrefabRollbackTestComponent::GetStaticTypeInfo().Name();
+		component["typename"] = typeName;
 		component["overrideProperties"] = overrideProperties;
 		if (bIncludeInstanceId)
 		{
@@ -780,6 +957,1381 @@ namespace
 		PrefabPtr prefab = PrefabPtr::Make(world.GetAllocator(), FileId());
 		prefab->Deserialize(node);
 		return prefab;
+	}
+
+	FileId DeserializeFileId(const char* value)
+	{
+		FileId fileId;
+		fileId.Deserialize(YAML::Node(value));
+		return fileId;
+	}
+
+	InstanceId DeserializeInstanceId(const char* value)
+	{
+		InstanceId instanceId;
+		instanceId.Deserialize(YAML::Node(value));
+		return instanceId;
+	}
+
+	PrefabPtr DeserializePrefab(
+		PrefabTestWorld& world,
+		const FileId& fileId,
+		const YAML::Node& node)
+	{
+		PrefabPtr prefab = PrefabPtr::Make(world.GetAllocator(), fileId);
+		prefab->Deserialize(node);
+		return prefab;
+	}
+
+	void TestLegacyPrefabApiSymbolsRemainAddressable()
+	{
+		using LegacyGetOverridePrefab =
+			bool (Prefab::*)(const PrefabPtr, PrefabPtr) const;
+		using LegacyCreate = PrefabPtr (PrefabImporter::*)();
+		using FileIdCreate =
+			PrefabPtr (PrefabImporter::*)(const FileId&);
+
+		const LegacyGetOverridePrefab legacyGetOverridePrefab =
+			static_cast<LegacyGetOverridePrefab>(
+				&Prefab::GetOverridePrefab);
+		const LegacyCreate legacyCreate =
+			static_cast<LegacyCreate>(&PrefabImporter::Create);
+		const FileIdCreate fileIdCreate =
+			static_cast<FileIdCreate>(&PrefabImporter::Create);
+
+		Require(legacyGetOverridePrefab != nullptr,
+			"the legacy exported Prefab::GetOverridePrefab symbol must remain addressable");
+		Require(legacyCreate != nullptr,
+			"the legacy exported zero-argument PrefabImporter::Create symbol must remain addressable");
+		Require(fileIdCreate != nullptr,
+			"the FileId-aware PrefabImporter::Create overload must remain independently addressable");
+
+		PrefabTestWorld world;
+		const FileId currentFileId =
+			DeserializeFileId(
+				"{11111111-2222-3333-4444-555555555555}");
+		const FileId baseFileId =
+			DeserializeFileId(
+				"{aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee}");
+		PrefabPtr currentPrefab =
+			PrefabPtr::Make(world.GetAllocator(), currentFileId);
+		PrefabPtr basePrefab =
+			PrefabPtr::Make(world.GetAllocator(), baseFileId);
+
+		Require(
+			!(currentPrefab.GetRawPtr()->*legacyGetOverridePrefab)(
+				basePrefab,
+				PrefabPtr{}),
+			"the legacy override API must retain its mismatched-source rejection");
+
+		currentPrefab.DestroyObject(world.GetAllocator());
+		basePrefab.DestroyObject(world.GetAllocator());
+	}
+
+	void TestLinkedPrefabPersistenceAndWorldContract()
+	{
+		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
+		constexpr const char* sourceRootId = "10010010010010010000";
+		constexpr const char* sourceChildId = "20020020020020020000";
+		constexpr const char* sourceDependencyId =
+			"1111111111111111_10010010010010010000";
+		constexpr const char* sourceValueId =
+			"2222222222222222_20020020020020020000";
+		constexpr const char* liveRootId = "30030030030030030000";
+		constexpr const char* liveChildId = "40040040040040040000";
+		constexpr const char* externalParentId = "50050050050050050000";
+		const FileId sourceFileId =
+			DeserializeFileId("{11111111-2222-3333-4444-555555555555}");
+
+		YAML::Node dependencyProperties;
+		dependencyProperties["m_dependency"]["fileId"] = "NullFileId";
+		dependencyProperties["m_dependency"]["instanceId"] = sourceValueId;
+
+		YAML::Node valueProperties;
+		valueProperties["m_value"] = 42.0f;
+
+		YAML::Node components(YAML::NodeType::Sequence);
+		components.push_back(MakeReflectedComponent(
+			sourceDependencyId,
+			dependencyProperties));
+		components.push_back(MakeReflectedComponent(
+			sourceValueId,
+			valueProperties));
+
+		YAML::Node sourceNode = MakePrefabNode({ noParent, 0 });
+		sourceNode["gameObjects"][0]["instanceId"] = sourceRootId;
+		sourceNode["gameObjects"][0]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		sourceNode["gameObjects"][0]["components"].push_back(0);
+		sourceNode["gameObjects"][1]["instanceId"] = sourceChildId;
+		sourceNode["gameObjects"][1]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		sourceNode["gameObjects"][1]["components"].push_back(1);
+		sourceNode["components"] = components;
+
+		PrefabTestWorld world;
+		PrefabPtr sourcePrefab =
+			DeserializePrefab(world, sourceFileId, sourceNode);
+		std::string diagnostic;
+		Require(sourcePrefab->ValidateForInstantiation(diagnostic),
+			"the linked source prefab fixture should be valid: " + diagnostic);
+
+		TMap<InstanceId, InstanceId> sourceToInstanceIds;
+		sourceToInstanceIds[DeserializeInstanceId(sourceRootId)] =
+			DeserializeInstanceId(liveRootId);
+		sourceToInstanceIds[DeserializeInstanceId(sourceChildId)] =
+			DeserializeInstanceId(liveChildId);
+
+		TMap<InstanceId, YAML::Node> gameObjectOverrides;
+		YAML::Node childOverride;
+		childOverride["name"] = "OverriddenChild";
+		childOverride["position"] = glm::vec4(7.0f, 8.0f, 9.0f, 0.0f);
+		gameObjectOverrides[DeserializeInstanceId(sourceChildId)] =
+			childOverride;
+
+		TMap<InstanceId, ReflectedData> componentOverrides;
+		YAML::Node reflectedOverride;
+		reflectedOverride["typename"] =
+			PrefabRollbackTestComponent::GetStaticTypeInfo().Name();
+		reflectedOverride["overrideProperties"]["m_value"] = 99.0f;
+		ReflectedData valueOverride;
+		valueOverride.Deserialize(reflectedOverride);
+		componentOverrides[DeserializeInstanceId(sourceValueId)] =
+			valueOverride;
+
+		const InstanceId parentInstanceId =
+			DeserializeInstanceId(externalParentId);
+		PrefabPtr linkedPrefab =
+			PrefabPtr::Make(world.GetAllocator(), sourceFileId);
+		Require(linkedPrefab->ConfigureLinkedInstance(
+				sourcePrefab,
+				sourceToInstanceIds,
+				parentInstanceId,
+				gameObjectOverrides,
+				componentOverrides,
+				diagnostic),
+			"linked prefab merge should accept stable identities and value overrides: " +
+				diagnostic);
+
+		WorldPrefabDocumentFixture document;
+		document.AddPrefab(linkedPrefab);
+		const YAML::Node serializedWorld = document.Serialize();
+		const YAML::Node serializedLinkedPrefab =
+			serializedWorld["prefabs"][0];
+		Require(
+			serializedLinkedPrefab["fileId"].as<FileId>() == sourceFileId,
+			"linked world serialization should persist the source FileId");
+		Require(
+			serializedLinkedPrefab["instanceIds"] &&
+				serializedLinkedPrefab["parentInstanceId"] &&
+				serializedLinkedPrefab["gameObjectOverrides"] &&
+				serializedLinkedPrefab["componentOverrides"],
+			"linked world serialization should persist identity, parent, and override metadata");
+
+		const TMap<InstanceId, InstanceId> loadedInstanceIds =
+			serializedLinkedPrefab["instanceIds"].as<
+				TMap<InstanceId, InstanceId>>();
+		const TMap<InstanceId, YAML::Node> loadedGameObjectOverrides =
+			serializedLinkedPrefab["gameObjectOverrides"].as<
+				TMap<InstanceId, YAML::Node>>();
+		const TMap<InstanceId, ReflectedData> loadedComponentOverrides =
+			serializedLinkedPrefab["componentOverrides"].as<
+				TMap<InstanceId, ReflectedData>>();
+		const InstanceId loadedParentId =
+			serializedLinkedPrefab["parentInstanceId"].as<InstanceId>();
+
+		PrefabPtr loadedLinkedPrefab =
+			PrefabPtr::Make(world.GetAllocator(), sourceFileId);
+		Require(loadedLinkedPrefab->ConfigureLinkedInstance(
+				sourcePrefab,
+				loadedInstanceIds,
+				loadedParentId,
+				loadedGameObjectOverrides,
+				loadedComponentOverrides,
+				diagnostic),
+			"serialized linked metadata should merge back onto its source prefab: " +
+				diagnostic);
+
+		auto externalParent = world.Instantiate(
+			"ExternalParent",
+			parentInstanceId);
+		Require(static_cast<bool>(externalParent),
+			"the linked instance external parent should accept its persisted identity");
+
+		const size_t objectCountBeforeInstantiation =
+			world.GetGameObjects().Num();
+		auto root = world.Instantiate(loadedLinkedPrefab);
+		Require(static_cast<bool>(root) && root->GetInstanceId() ==
+			DeserializeInstanceId(liveRootId),
+			"linked instantiate should preserve the persisted live root identity");
+		Require(root->GetParent() == externalParent,
+			"linked instantiate should restore its external parent");
+		Require(root->GetChildren().Num() == 1 &&
+			root->GetChildren()[0]->GetInstanceId() ==
+				DeserializeInstanceId(liveChildId),
+			"linked instantiate should preserve every mapped child identity");
+		GameObjectPtr child = root->GetChildren()[0];
+
+		auto sourceComponent =
+			root->GetComponent<PrefabRollbackTestComponent>();
+		auto targetComponent =
+			child->GetComponent<PrefabRollbackTestComponent>();
+		Require(sourceComponent && targetComponent,
+			"linked instantiate should recreate its reflected components");
+		Require(sourceComponent->m_dependency == targetComponent,
+			"linked instantiate should remap internal component references to the live instance");
+		Require(targetComponent->m_value == 99.0f,
+			"linked instantiate should apply the persisted reflected value override");
+		Require(targetComponent->GetInstanceId().ComponentId() ==
+			DeserializeInstanceId(sourceValueId).ComponentId(),
+			"linked component identity should retain the source-local component id");
+		Require(targetComponent->GetInstanceId().GameObjectId() ==
+			child->GetInstanceId(),
+			"linked component identity should embed its mapped live owner");
+		Require(child->GetName() == "OverriddenChild" &&
+			child->GetTransformComponent().GetPosition() ==
+				glm::vec4(7.0f, 8.0f, 9.0f, 1.0f),
+			"linked instantiate should apply name and transform overrides");
+
+		const PrefabInstanceLink* registeredLink = nullptr;
+		Require(world.TryGetPrefabInstance(
+				child->GetInstanceId(),
+				registeredLink) &&
+			registeredLink &&
+			registeredLink->m_sourcePrefabId == sourceFileId,
+			"every linked member should resolve to its registered prefab source");
+
+		ComponentPtr rejectedComponent =
+			TObjectPtr<PrefabRollbackTestComponent>::Make(
+				world.GetAllocator());
+		Require(!root->AddComponentRaw(rejectedComponent),
+			"component additions should be rejected while the prefab is linked");
+		Require(!child->RemoveComponent(targetComponent),
+			"component removals should be rejected while the prefab is linked");
+
+		auto unlinkedObject = world.Instantiate("Unlinked");
+		child->SetParent(unlinkedObject);
+		Require(child->GetParent() == root,
+			"internal linked game objects should reject reparenting");
+		unlinkedObject->SetParent(child);
+		Require(!unlinkedObject->GetParent(),
+			"unlinked game objects should reject parenting inside a linked instance");
+
+		Editor editor(nullptr, 0, nullptr);
+		editor.SetWorld(&world);
+		Require(!editor.DestroyObject(child->GetInstanceId()),
+			"editor deletion should report failure for an internal linked game object");
+
+		world.DestroyImmediate(child);
+		Require(static_cast<bool>(world.GetObjectByInstanceId(
+			DeserializeInstanceId(liveChildId))),
+			"destroying an internal linked game object should be rejected");
+
+		const InstanceId rootIdBeforeBreak = root->GetInstanceId();
+		const InstanceId childIdBeforeBreak = child->GetInstanceId();
+		const glm::vec4 childPositionBeforeBreak =
+			child->GetTransformComponent().GetPosition();
+		Require(world.BreakPrefabLink(childIdBeforeBreak),
+			"breaking a prefab link through any linked member should succeed");
+		Require(!world.IsPrefabLinked(rootIdBeforeBreak) &&
+			root->GetInstanceId() == rootIdBeforeBreak &&
+			child->GetInstanceId() == childIdBeforeBreak &&
+			child->GetTransformComponent().GetPosition() ==
+				childPositionBeforeBreak &&
+			targetComponent->m_value == 99.0f,
+			"breaking a prefab link should preserve all live ids and values");
+
+		ComponentPtr temporaryComponent =
+			TObjectPtr<PrefabRollbackTestComponent>::Make(
+				world.GetAllocator());
+		temporaryComponent = root->AddComponentRaw(temporaryComponent);
+		Require(static_cast<bool>(temporaryComponent),
+			"structural changes should become available after breaking the link");
+		Require(root->RemoveComponent(temporaryComponent),
+			"the temporary post-break component should be removable");
+
+		Require(world.LinkPrefabInstance(
+				root,
+				sourcePrefab,
+				diagnostic),
+			"relink should rebuild the deterministic source-to-live mapping: " +
+				diagnostic);
+		Require(world.IsPrefabLinked(childIdBeforeBreak),
+			"relink should restore linked membership for the whole hierarchy");
+
+		const size_t linkedCountBeforeRejectedInstantiation =
+			world.GetPrefabInstances().Num();
+		const size_t objectCountBeforeRejectedInstantiation =
+			world.GetGameObjects().Num();
+		Require(!world.Instantiate(loadedLinkedPrefab),
+			"stale preferred instance ids should reject a second linked instantiate");
+		Require(world.GetGameObjects().Num() ==
+				objectCountBeforeRejectedInstantiation &&
+			world.GetPrefabInstances().Num() ==
+				linkedCountBeforeRejectedInstantiation,
+			"a rejected stale linked instantiate should roll back world and link state");
+
+		TMap<InstanceId, InstanceId> missingParentMapping;
+		missingParentMapping[DeserializeInstanceId(sourceRootId)] =
+			DeserializeInstanceId("70070070070070070000");
+		missingParentMapping[DeserializeInstanceId(sourceChildId)] =
+			DeserializeInstanceId("80080080080080080000");
+		PrefabPtr missingParentPrefab =
+			PrefabPtr::Make(world.GetAllocator(), sourceFileId);
+		Require(missingParentPrefab->ConfigureLinkedInstance(
+				sourcePrefab,
+				missingParentMapping,
+				DeserializeInstanceId("90090090090090090000"),
+				gameObjectOverrides,
+				componentOverrides,
+				diagnostic),
+			"the missing-parent rollback fixture should merge before instantiation: " +
+				diagnostic);
+		Require(!world.Instantiate(missingParentPrefab),
+			"a linked instance with a missing external parent should be rejected");
+		Require(world.GetGameObjects().Num() ==
+				objectCountBeforeRejectedInstantiation &&
+			world.GetPrefabInstances().Num() ==
+				linkedCountBeforeRejectedInstantiation,
+			"a late missing-parent failure should roll back created objects, components, and link state");
+
+		TMap<InstanceId, InstanceId> incompleteMapping;
+		incompleteMapping[DeserializeInstanceId(sourceRootId)] =
+			DeserializeInstanceId("60060060060060060000");
+		PrefabPtr malformedLinkedPrefab =
+			PrefabPtr::Make(world.GetAllocator(), sourceFileId);
+		Require(!malformedLinkedPrefab->ConfigureLinkedInstance(
+				sourcePrefab,
+				incompleteMapping,
+				InstanceId::Invalid,
+				{},
+				{},
+				diagnostic) &&
+			diagnostic.find("mapping") != std::string::npos,
+			"a malformed linked identity mapping should produce a load diagnostic");
+
+		const FileId staleSourceId =
+			DeserializeFileId("{AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE}");
+		PrefabPtr staleLinkedPrefab =
+			PrefabPtr::Make(world.GetAllocator(), staleSourceId);
+		Require(!staleLinkedPrefab->ConfigureLinkedInstance(
+				sourcePrefab,
+				sourceToInstanceIds,
+				InstanceId::Invalid,
+				{},
+				{},
+				diagnostic) &&
+			diagnostic.find("FileId") != std::string::npos,
+			"a stale or mismatched source prefab should produce a FileId diagnostic");
+
+		Require(world.GetGameObjects().Num() >=
+			objectCountBeforeInstantiation + 3,
+			"the linked persistence fixture should retain its expected live hierarchy");
+		world.Clear();
+	}
+
+	void TestLinkedPrefabBaselineAndSaveFailureContract()
+	{
+		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
+		constexpr const char* sourceRootId =
+			"10010010010010010000";
+		constexpr const char* liveRootId =
+			"30030030030030030000";
+		constexpr const char* sourceComponentId =
+			"1111111111111111_10010010010010010000";
+		constexpr const char* liveComponentId =
+			"1111111111111111_30030030030030030000";
+		const FileId sourceFileId =
+			DeserializeFileId(
+				"{11111111-2222-3333-4444-555555555555}");
+
+		YAML::Node sourceProperties;
+		sourceProperties["m_value"] = 1.0f;
+		sourceProperties["m_payload"]["outer"]["first"] = 1;
+		sourceProperties["m_payload"]["outer"]["second"] = 2;
+		YAML::Node sourceComponents(YAML::NodeType::Sequence);
+		sourceComponents.push_back(MakeReflectedComponent(
+			sourceComponentId,
+			sourceProperties));
+
+		YAML::Node sourceNode = MakePrefabNode({ noParent });
+		sourceNode["gameObjects"][0]["instanceId"] = sourceRootId;
+		sourceNode["gameObjects"][0]["name"] = "SourceV1";
+		sourceNode["gameObjects"][0]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		sourceNode["gameObjects"][0]["components"].push_back(0);
+		sourceNode["components"] = sourceComponents;
+
+		PrefabTestWorld world;
+		PrefabPtr sourcePrefab =
+			DeserializePrefab(world, sourceFileId, sourceNode);
+		TMap<InstanceId, InstanceId> sourceToInstanceIds;
+		sourceToInstanceIds[DeserializeInstanceId(sourceRootId)] =
+			DeserializeInstanceId(liveRootId);
+
+		std::string diagnostic;
+		PrefabPtr linkedPrefab =
+			PrefabPtr::Make(world.GetAllocator(), sourceFileId);
+		Require(linkedPrefab->ConfigureLinkedInstance(
+				sourcePrefab,
+				sourceToInstanceIds,
+				InstanceId::Invalid,
+				{},
+				{},
+				diagnostic),
+			"the baseline fixture should configure a linked instance: " +
+				diagnostic);
+		GameObjectPtr root = world.Instantiate(linkedPrefab);
+		Require(static_cast<bool>(root),
+			"the baseline fixture should instantiate");
+
+		const PrefabInstanceLink* link = nullptr;
+		Require(world.TryGetPrefabInstance(root->GetInstanceId(), link) &&
+			link &&
+			link->m_effectiveBaseline,
+			"linked instances should retain an explicit effective baseline");
+
+		YAML::Node evolvedSourceNode = YAML::Clone(sourceNode);
+		evolvedSourceNode["gameObjects"][0]["name"] = "SourceV2";
+		evolvedSourceNode["gameObjects"][0]["position"] =
+			glm::vec4(5.0f, 6.0f, 7.0f, 0.0f);
+		evolvedSourceNode["components"][0]["overrideProperties"]["m_value"] =
+			10.0f;
+		PrefabPtr evolvedSource =
+			DeserializePrefab(world, sourceFileId, evolvedSourceNode);
+
+		YAML::Node expandedNode = YAML::Clone(sourceNode);
+		expandedNode["gameObjects"][0]["instanceId"] = liveRootId;
+		expandedNode["gameObjects"][0]["position"] =
+			root->GetTransformComponent().GetPosition();
+		expandedNode["gameObjects"][0]["rotation"] =
+			root->GetTransformComponent().GetRotation();
+		expandedNode["gameObjects"][0]["scale"] =
+			root->GetTransformComponent().GetScale();
+		expandedNode["components"][0]["overrideProperties"]["instanceId"] =
+			liveComponentId;
+		YAML::Node reorderedPayload;
+		reorderedPayload["outer"]["second"] = 2;
+		reorderedPayload["outer"]["first"] = 1;
+		expandedNode["components"][0]["overrideProperties"]["m_payload"] =
+			reorderedPayload;
+		PrefabPtr expandedPrefab =
+			DeserializePrefab(world, sourceFileId, expandedNode);
+
+		TMap<InstanceId, YAML::Node> gameObjectOverrides;
+		TMap<InstanceId, ReflectedData> componentOverrides;
+		Require(WorldPrefabDocumentFixture::BuildUpdatedOverrides(
+				expandedPrefab,
+				evolvedSource,
+				link->m_effectiveBaseline,
+				sourceToInstanceIds,
+				gameObjectOverrides,
+				componentOverrides,
+				diagnostic),
+			"source evolution should merge against the captured baseline: " +
+				diagnostic);
+		Require(gameObjectOverrides.IsEmpty() &&
+			componentOverrides.IsEmpty(),
+			"unrelated source changes and reordered map keys must not become instance overrides when the live instance was not edited");
+
+		YAML::Node editedExpandedNode = YAML::Clone(expandedNode);
+		editedExpandedNode["gameObjects"][0]["name"] = "InstanceEdit";
+		editedExpandedNode["components"][0]["overrideProperties"]["m_value"] =
+			3.0f;
+		PrefabPtr editedExpanded =
+			DeserializePrefab(world, sourceFileId, editedExpandedNode);
+		Require(WorldPrefabDocumentFixture::BuildUpdatedOverrides(
+				editedExpanded,
+				evolvedSource,
+				link->m_effectiveBaseline,
+				sourceToInstanceIds,
+				gameObjectOverrides,
+				componentOverrides,
+				diagnostic),
+			"live edits should merge against the captured baseline: " +
+				diagnostic);
+		const InstanceId sourceRoot =
+			DeserializeInstanceId(sourceRootId);
+		const InstanceId sourceComponent =
+			DeserializeInstanceId(sourceComponentId);
+		Require(gameObjectOverrides.ContainsKey(sourceRoot) &&
+			gameObjectOverrides[sourceRoot]["name"].as<std::string>() ==
+				"InstanceEdit" &&
+			componentOverrides.ContainsKey(sourceComponent) &&
+			componentOverrides[sourceComponent].GetProperties()[
+				"m_value"].as<float>() == 3.0f,
+			"edits made after instantiation should become explicit overrides");
+
+		TMap<InstanceId, YAML::Node> priorGameObjectOverrides;
+		YAML::Node priorGameObjectOverride;
+		priorGameObjectOverride["name"] = "PinnedName";
+		priorGameObjectOverrides[sourceRoot] =
+			priorGameObjectOverride;
+		TMap<InstanceId, ReflectedData> priorComponentOverrides;
+		YAML::Node priorComponentOverrideNode;
+		priorComponentOverrideNode["typename"] =
+			PrefabRollbackTestComponent::GetStaticTypeInfo().Name();
+		priorComponentOverrideNode["overrideProperties"]["m_value"] =
+			2.0f;
+		ReflectedData priorComponentOverride;
+		priorComponentOverride.Deserialize(priorComponentOverrideNode);
+		priorComponentOverrides[sourceComponent] =
+			priorComponentOverride;
+
+		PrefabPtr explicitBaseline =
+			PrefabPtr::Make(world.GetAllocator(), sourceFileId);
+		Require(explicitBaseline->ConfigureLinkedInstance(
+				sourcePrefab,
+				sourceToInstanceIds,
+				InstanceId::Invalid,
+				priorGameObjectOverrides,
+				priorComponentOverrides,
+				diagnostic),
+			"the explicit override baseline should configure: " +
+				diagnostic);
+		YAML::Node overriddenExpandedNode = YAML::Clone(expandedNode);
+		overriddenExpandedNode["gameObjects"][0]["name"] =
+			"PinnedName";
+		overriddenExpandedNode["components"][0]["overrideProperties"]["m_value"] =
+			2.0f;
+		PrefabPtr overriddenExpanded =
+			DeserializePrefab(world, sourceFileId, overriddenExpandedNode);
+		Require(WorldPrefabDocumentFixture::BuildUpdatedOverrides(
+				overriddenExpanded,
+				evolvedSource,
+				explicitBaseline,
+				sourceToInstanceIds,
+				gameObjectOverrides,
+				componentOverrides,
+				diagnostic),
+			"existing explicit overrides should merge across source evolution: " +
+				diagnostic);
+		Require(gameObjectOverrides.ContainsKey(sourceRoot) &&
+			gameObjectOverrides[sourceRoot]["name"].as<std::string>() ==
+				"PinnedName" &&
+			componentOverrides.ContainsKey(sourceComponent) &&
+			componentOverrides[sourceComponent].GetProperties()[
+				"m_value"].as<float>() == 2.0f,
+			"existing explicit overrides should survive unrelated source changes");
+
+		WorldPrefabDocumentFixture failedDocument;
+		failedDocument.MarkSerializationFailure(
+			"linked source asset is unavailable");
+		Require(failedDocument.Serialize().IsNull(),
+			"a failed linked world serialization should not emit an empty replacement world");
+		WorldPrefabDocumentFixture nonReadyDocument;
+		Require(nonReadyDocument.Serialize().IsNull(),
+			"a non-ready world document should not emit partial YAML without a diagnostic");
+		const std::filesystem::path failedSavePath =
+			std::filesystem::temp_directory_path() /
+			"sailor-linked-prefab-failed-save.world";
+		{
+			std::ofstream existingScene(
+				failedSavePath,
+				std::ios::binary | std::ios::trunc);
+			existingScene << "existing-scene";
+		}
+		Require(!failedDocument.SaveToFile(
+				failedSavePath.generic_string()) &&
+			ReadText(failedSavePath) == "existing-scene",
+			"a failed linked world document should not overwrite a scene file");
+		std::filesystem::remove(failedSavePath);
+
+		const std::filesystem::path sourceRootPath =
+			SAILOR_TEST_SOURCE_DIR;
+		const std::string editorSource = ReadText(
+			sourceRootPath / "Runtime/Submodules/Editor.cpp");
+		const std::string interopSource = ReadText(
+			sourceRootPath / "Runtime/Editor/EditorInterop.cpp");
+		const std::string worldPrefabSource = ReadText(
+			sourceRootPath /
+				"Runtime/AssetRegistry/World/WorldPrefabImporter.cpp");
+		Require(editorSource.find("!prefab->IsReady()") !=
+				std::string::npos &&
+			editorSource.find("GetLoadDiagnostic()") !=
+				std::string::npos &&
+			interopSource.find("node.IsNull()") !=
+				std::string::npos,
+			"failed world serialization should propagate through Editor and interop as a save failure");
+		Require(worldPrefabSource.find(
+				"preserving its expanded live state as inline data") ==
+				std::string::npos &&
+			worldPrefabSource.find(
+				"res->m_gameObjects.Add(Prefab::FromGameObject(root));") ==
+				std::string::npos,
+			"linked serialization failures must never silently flatten an instance into inline scene data");
+
+		world.Clear();
+	}
+
+	void TestLinkedPrefabSourceStructureEvolutionContract()
+	{
+		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
+		constexpr const char* sourceRootId = "10010010010010010000";
+		constexpr const char* removedSourceChildId =
+			"20020020020020020000";
+		constexpr const char* addedSourceChildId =
+			"AAAAAAAAAAAAAAAAAAAA";
+		constexpr const char* addedSourceGrandchildId =
+			"BBBBBBBBBBBBBBBBBBBB";
+		constexpr const char* liveRootId = "30030030030030030000";
+		constexpr const char* removedLiveChildId =
+			"40040040040040040000";
+		constexpr const char* sourceDependencyId =
+			"1111111111111111_10010010010010010000";
+		constexpr const char* addedSourceValueId =
+			"3333333333333333_BBBBBBBBBBBBBBBBBBBB";
+		const FileId sourceFileId =
+			DeserializeFileId(
+				"{11111111-2222-3333-4444-555555555555}");
+
+		YAML::Node previousSourceNode =
+			MakePrefabNode({ noParent, 0 });
+		previousSourceNode["gameObjects"][0]["instanceId"] =
+			sourceRootId;
+		previousSourceNode["gameObjects"][1]["instanceId"] =
+			removedSourceChildId;
+
+		YAML::Node expandedRecordNode = previousSourceNode;
+		expandedRecordNode["gameObjects"][0]["instanceId"] =
+			liveRootId;
+		expandedRecordNode["gameObjects"][1]["instanceId"] =
+			removedLiveChildId;
+
+		YAML::Node dependencyProperties;
+		dependencyProperties["m_dependency"]["fileId"] = "NullFileId";
+		dependencyProperties["m_dependency"]["instanceId"] =
+			addedSourceValueId;
+		YAML::Node valueProperties;
+		valueProperties["m_value"] = 55.0f;
+		YAML::Node evolvedComponents(YAML::NodeType::Sequence);
+		evolvedComponents.push_back(MakeReflectedComponent(
+			sourceDependencyId,
+			dependencyProperties));
+		evolvedComponents.push_back(MakeReflectedComponent(
+			addedSourceValueId,
+			valueProperties));
+
+		YAML::Node evolvedSourceNode =
+			MakePrefabNode({ noParent, 0, 1 });
+		evolvedSourceNode["gameObjects"][0]["instanceId"] =
+			sourceRootId;
+		evolvedSourceNode["gameObjects"][0]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		evolvedSourceNode["gameObjects"][0]["components"].push_back(0);
+		evolvedSourceNode["gameObjects"][1]["instanceId"] =
+			addedSourceChildId;
+		evolvedSourceNode["gameObjects"][2]["instanceId"] =
+			addedSourceGrandchildId;
+		evolvedSourceNode["gameObjects"][2]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		evolvedSourceNode["gameObjects"][2]["components"].push_back(1);
+		evolvedSourceNode["components"] = evolvedComponents;
+
+		PrefabTestWorld world;
+		PrefabPtr expandedRecord =
+			DeserializePrefab(world, expandedRecordNode);
+		PrefabPtr evolvedSource = DeserializePrefab(
+			world,
+			sourceFileId,
+			evolvedSourceNode);
+		std::string diagnostic;
+		Require(expandedRecord->ValidateForInstantiation(diagnostic) &&
+			evolvedSource->ValidateForInstantiation(diagnostic),
+			"the structural evolution fixtures should be valid: " +
+				diagnostic);
+
+		TMap<InstanceId, InstanceId> savedMappings;
+		savedMappings[DeserializeInstanceId(sourceRootId)] =
+			DeserializeInstanceId(liveRootId);
+		savedMappings[
+			DeserializeInstanceId(removedSourceChildId)] =
+			DeserializeInstanceId(removedLiveChildId);
+
+		TSet<InstanceId> reservedInstanceIds;
+		reservedInstanceIds.Insert(
+			DeserializeInstanceId(liveRootId));
+		reservedInstanceIds.Insert(
+			DeserializeInstanceId(removedLiveChildId));
+		TSet<InstanceId> repeatedReservedInstanceIds =
+			reservedInstanceIds;
+
+		TMap<InstanceId, InstanceId> reconciledMappings;
+		TMap<InstanceId, InstanceId> repeatedMappings;
+		Require(WorldPrefabDocumentFixture::Reconcile(
+				expandedRecord,
+				evolvedSource,
+				savedMappings,
+				reservedInstanceIds,
+				reconciledMappings,
+				diagnostic),
+			"source structural evolution should reconcile linked ids: " +
+				diagnostic);
+		Require(WorldPrefabDocumentFixture::Reconcile(
+				expandedRecord,
+				evolvedSource,
+				savedMappings,
+				repeatedReservedInstanceIds,
+				repeatedMappings,
+				diagnostic),
+			"repeated source reconciliation should succeed: " +
+				diagnostic);
+
+		const InstanceId sourceRoot =
+			DeserializeInstanceId(sourceRootId);
+		const InstanceId removedSourceChild =
+			DeserializeInstanceId(removedSourceChildId);
+		const InstanceId addedSourceChild =
+			DeserializeInstanceId(addedSourceChildId);
+		const InstanceId addedSourceGrandchild =
+			DeserializeInstanceId(addedSourceGrandchildId);
+		Require(reconciledMappings.Num() == 3 &&
+			reconciledMappings.ContainsKey(sourceRoot) &&
+			reconciledMappings[sourceRoot] ==
+				DeserializeInstanceId(liveRootId),
+			"reconciliation should retain the surviving root's live identity");
+		Require(!reconciledMappings.ContainsKey(removedSourceChild),
+			"reconciliation should drop mappings for removed source game objects");
+		Require(reconciledMappings.ContainsKey(addedSourceChild) &&
+			reconciledMappings.ContainsKey(addedSourceGrandchild) &&
+			reconciledMappings[addedSourceChild].IsGameObjectId() &&
+			reconciledMappings[addedSourceGrandchild].IsGameObjectId() &&
+			reconciledMappings[addedSourceChild] !=
+				reconciledMappings[addedSourceGrandchild] &&
+			reconciledMappings[addedSourceChild] !=
+				DeserializeInstanceId(removedLiveChildId) &&
+			reconciledMappings[addedSourceGrandchild] !=
+				DeserializeInstanceId(removedLiveChildId),
+			"new source nodes should receive collision-free canonical live identities");
+		Require(repeatedMappings[addedSourceChild] ==
+				reconciledMappings[addedSourceChild] &&
+			repeatedMappings[addedSourceGrandchild] ==
+				reconciledMappings[addedSourceGrandchild],
+			"new source node identities should be deterministic across repositories and reloads");
+
+		TMap<InstanceId, YAML::Node> survivingOverrides;
+		YAML::Node rootOverride;
+		rootOverride["name"] = "PersistedRootOverride";
+		survivingOverrides[sourceRoot] = rootOverride;
+		PrefabPtr reconciledPrefab =
+			PrefabPtr::Make(world.GetAllocator(), sourceFileId);
+		Require(reconciledPrefab->ConfigureLinkedInstance(
+				evolvedSource,
+				reconciledMappings,
+				InstanceId::Invalid,
+				survivingOverrides,
+				{},
+				diagnostic),
+			"the reconciled evolved prefab should merge surviving overrides: " +
+				diagnostic);
+
+		auto root = world.Instantiate(reconciledPrefab);
+		Require(root && root->GetInstanceId() ==
+				DeserializeInstanceId(liveRootId) &&
+			root->GetName() == "PersistedRootOverride",
+			"evolved linked instantiate should retain surviving ids and overrides");
+		Require(root->GetChildren().Num() == 1,
+			"evolved linked instantiate should add the new source child");
+		GameObjectPtr evolvedChild = root->GetChildren()[0];
+		Require(evolvedChild->GetChildren().Num() == 1,
+			"evolved linked instantiate should add the new source grandchild");
+		GameObjectPtr evolvedGrandchild =
+			evolvedChild->GetChildren()[0];
+		Require(evolvedChild->GetInstanceId() ==
+				reconciledMappings[addedSourceChild] &&
+			evolvedGrandchild->GetInstanceId() ==
+				reconciledMappings[addedSourceGrandchild],
+			"evolved linked instantiate should materialize the new source hierarchy");
+
+		auto dependency =
+			root->GetComponent<PrefabRollbackTestComponent>();
+		auto target = evolvedGrandchild->
+			GetComponent<PrefabRollbackTestComponent>();
+		Require(dependency && target &&
+			dependency->m_dependency == target &&
+			target->m_value == 55.0f,
+			"internal references should resolve through generated ids for new source nodes");
+
+		world.Clear();
+	}
+
+	void TestLinkedPrefabMembershipFollowsEvolvedSourceMapping()
+	{
+		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
+		constexpr const char* sourceRootId =
+			"10010010010010010000";
+		constexpr const char* removedSourceChildId =
+			"20020020020020020000";
+		constexpr const char* liveRootId =
+			"30030030030030030000";
+		constexpr const char* removedLiveChildId =
+			"40040040040040040000";
+		const FileId sourceFileId =
+			DeserializeFileId(
+				"{11111111-2222-3333-4444-555555555555}");
+
+		YAML::Node sourceNode = MakePrefabNode({ noParent, 0 });
+		sourceNode["gameObjects"][0]["instanceId"] =
+			sourceRootId;
+		sourceNode["gameObjects"][1]["instanceId"] =
+			removedSourceChildId;
+
+		PrefabTestWorld world;
+		PrefabPtr sourcePrefab = DeserializePrefab(
+			world,
+			sourceFileId,
+			sourceNode);
+		TMap<InstanceId, InstanceId> initialMappings;
+		initialMappings[DeserializeInstanceId(sourceRootId)] =
+			DeserializeInstanceId(liveRootId);
+		initialMappings[
+			DeserializeInstanceId(removedSourceChildId)] =
+			DeserializeInstanceId(removedLiveChildId);
+
+		std::string diagnostic;
+		PrefabPtr linkedPrefab =
+			PrefabPtr::Make(world.GetAllocator(), sourceFileId);
+		Require(linkedPrefab->ConfigureLinkedInstance(
+				sourcePrefab,
+				initialMappings,
+				InstanceId::Invalid,
+				{},
+				{},
+				diagnostic),
+			"the removed-source membership fixture should configure: " +
+				diagnostic);
+
+		GameObjectPtr root = world.Instantiate(linkedPrefab);
+		Require(root && root->GetChildren().Num() == 1,
+			"the removed-source membership fixture should instantiate");
+		GameObjectPtr removedChild = root->GetChildren()[0];
+		const InstanceId rootInstanceId = root->GetInstanceId();
+		const InstanceId removedChildInstanceId =
+			removedChild->GetInstanceId();
+		Require(world.IsPrefabLinked(rootInstanceId) &&
+			world.IsPrefabLinked(removedChildInstanceId) &&
+			!world.CanModifyPrefabStructure(removedChildInstanceId),
+			"the previous source child should initially be a locked linked member");
+
+		const PrefabInstanceLink* initialLink = nullptr;
+		Require(world.TryGetPrefabInstance(
+				rootInstanceId,
+				initialLink) &&
+			initialLink &&
+			initialLink->m_effectiveBaseline,
+			"the linked fixture should expose its effective baseline");
+
+		TMap<InstanceId, InstanceId> evolvedMappings;
+		evolvedMappings[DeserializeInstanceId(sourceRootId)] =
+			rootInstanceId;
+		Require(WorldPrefabDocumentFixture::CommitLinkedUpdate(
+				&world,
+				rootInstanceId,
+				evolvedMappings,
+				initialLink->m_effectiveBaseline,
+				diagnostic),
+			"committing an evolved source mapping should succeed: " +
+				diagnostic);
+
+		Require(world.IsPrefabLinked(rootInstanceId) &&
+			!world.IsPrefabLinked(removedChildInstanceId) &&
+			world.CanModifyPrefabStructure(removedChildInstanceId),
+			"a live child removed from the source mapping must stop resolving as a linked member");
+
+		ComponentPtr temporaryComponent =
+			TObjectPtr<PrefabRollbackTestComponent>::Make(
+				world.GetAllocator());
+		temporaryComponent =
+			removedChild->AddComponentRaw(temporaryComponent);
+		Require(temporaryComponent &&
+			removedChild->RemoveComponent(temporaryComponent),
+			"the removed-source child should allow structural edits immediately");
+
+		const size_t objectCountBeforeChildCleanup =
+			world.GetGameObjects().Num();
+		world.DestroyImmediate(removedChild);
+		Require(world.GetGameObjects().Num() + 1 ==
+				objectCountBeforeChildCleanup &&
+			!world.GetObjectByInstanceId(removedChildInstanceId),
+			"the removed-source child should be cleaned up exactly once");
+
+		Require(world.BreakPrefabLink(rootInstanceId) &&
+			world.GetPrefabInstances().IsEmpty() &&
+			!world.IsPrefabLinked(rootInstanceId) &&
+			!world.BreakPrefabLink(rootInstanceId),
+			"breaking the surviving root should purge the remaining membership exactly once");
+
+		world.Clear();
+	}
+
+	void TestDetachedSupplementalPrefabPersistenceAndStrictRestore()
+	{
+		constexpr uint32_t noParent =
+			static_cast<uint32_t>(-1);
+		constexpr const char* sourceRootId =
+			"10010010010010010000";
+		constexpr const char* removedSourceChildId =
+			"20020020020020020000";
+		constexpr const char* liveRootId =
+			"30030030030030030000";
+		constexpr const char* removedLiveChildId =
+			"40040040040040040000";
+		constexpr const char* sourceMixedComponentId =
+			"1111111111111111_10010010010010010000";
+		constexpr const char* sourceTargetComponentId =
+			"2222222222222222_10010010010010010000";
+		constexpr const char* removedSourceComponentId =
+			"3333333333333333_20020020020020020000";
+		constexpr const char* removedLiveComponentId =
+			"3333333333333333_40040040040040040000";
+		const FileId sourceFileId =
+			DeserializeFileId(
+				"{11111111-2222-3333-4444-555555555555}");
+		const InstanceId sourceRoot =
+			DeserializeInstanceId(sourceRootId);
+		const InstanceId liveRoot =
+			DeserializeInstanceId(liveRootId);
+		const InstanceId removedLiveChild =
+			DeserializeInstanceId(removedLiveChildId);
+		const InstanceId removedLiveComponent =
+			DeserializeInstanceId(removedLiveComponentId);
+
+		YAML::Node removedComponentProperties;
+		removedComponentProperties["m_value"] = 73.0f;
+		YAML::Node previousSourceComponents(
+			YAML::NodeType::Sequence);
+		previousSourceComponents.push_back(
+			MakeReflectedComponent(
+				removedSourceComponentId,
+				removedComponentProperties));
+		YAML::Node previousSourceNode =
+			MakePrefabNode({ noParent, 0 });
+		previousSourceNode["gameObjects"][0]["instanceId"] =
+			sourceRootId;
+		previousSourceNode["gameObjects"][1]["instanceId"] =
+			removedSourceChildId;
+		previousSourceNode["gameObjects"][1]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		previousSourceNode["gameObjects"][1]["components"].
+			push_back(0);
+		previousSourceNode["components"] =
+			previousSourceComponents;
+
+		YAML::Node expandedRecordNode =
+			YAML::Clone(previousSourceNode);
+		expandedRecordNode["gameObjects"][0]["instanceId"] =
+			liveRootId;
+		expandedRecordNode["gameObjects"][1]["instanceId"] =
+			removedLiveChildId;
+		expandedRecordNode["gameObjects"][1]["name"] =
+			"DetachedEdited";
+		expandedRecordNode["gameObjects"][1]["position"] =
+			glm::vec4(4.0f, 5.0f, 6.0f, 0.0f);
+		expandedRecordNode["components"][0]
+			["overrideProperties"]["instanceId"] =
+			removedLiveComponentId;
+
+		YAML::Node sourceReference;
+		sourceReference["fileId"] = "NullFileId";
+		sourceReference["instanceId"] =
+			sourceTargetComponentId;
+		YAML::Node mixedProperties;
+		mixedProperties["m_sourceDependency"] =
+			sourceReference;
+		YAML::Node targetProperties;
+		targetProperties["m_value"] = 21.0f;
+		YAML::Node evolvedComponents(
+			YAML::NodeType::Sequence);
+		evolvedComponents.push_back(
+			MakeReflectedComponent(
+				sourceMixedComponentId,
+				mixedProperties,
+				true,
+				PrefabMixedDependencyTestComponent::
+					GetStaticTypeInfo().Name()));
+		evolvedComponents.push_back(
+			MakeReflectedComponent(
+				sourceTargetComponentId,
+				targetProperties));
+		YAML::Node evolvedSourceNode =
+			MakePrefabNode({ noParent });
+		evolvedSourceNode["gameObjects"][0]["instanceId"] =
+			sourceRootId;
+		evolvedSourceNode["gameObjects"][0]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		evolvedSourceNode["gameObjects"][0]["components"].
+			push_back(0);
+		evolvedSourceNode["gameObjects"][0]["components"].
+			push_back(1);
+		evolvedSourceNode["components"] =
+			evolvedComponents;
+
+		PrefabTestWorld world;
+		PrefabPtr previousSource = DeserializePrefab(
+			world,
+			sourceFileId,
+			previousSourceNode);
+		PrefabPtr evolvedSource = DeserializePrefab(
+			world,
+			sourceFileId,
+			evolvedSourceNode);
+		PrefabPtr expandedRecord = DeserializePrefab(
+			world,
+			expandedRecordNode);
+		std::string diagnostic;
+		Require(previousSource->ValidateForInstantiation(
+				diagnostic) &&
+			evolvedSource->ValidateForInstantiation(
+				diagnostic) &&
+			expandedRecord->ValidateForInstantiation(
+				diagnostic),
+			"the detached supplemental evolution fixtures should be valid: " +
+				diagnostic);
+
+		TMap<InstanceId, InstanceId> evolvedMappings;
+		evolvedMappings[sourceRoot] = liveRoot;
+
+		YAML::Node liveReference;
+		liveReference["fileId"] = "NullFileId";
+		liveReference["instanceId"] =
+			removedLiveComponentId;
+		YAML::Node mixedOverrideNode;
+		mixedOverrideNode["typename"] =
+			PrefabMixedDependencyTestComponent::
+				GetStaticTypeInfo().Name();
+		mixedOverrideNode["overrideProperties"]
+			["m_liveDependency"] = liveReference;
+		ReflectedData mixedOverride;
+		mixedOverride.Deserialize(mixedOverrideNode);
+		Require(mixedOverride.IsValid(),
+			"the mixed source/live dependency override should be valid");
+		TMap<InstanceId, ReflectedData> componentOverrides;
+		componentOverrides[
+			DeserializeInstanceId(
+				sourceMixedComponentId)] =
+			mixedOverride;
+
+		auto buildLinkedRecord =
+			[&](const PrefabPtr& expanded)
+			{
+				PrefabPtr linked =
+					PrefabPtr::Make(
+						world.GetAllocator(),
+						sourceFileId);
+				Require(linked->ConfigureLinkedInstance(
+						evolvedSource,
+						evolvedMappings,
+						InstanceId::Invalid,
+						{},
+						componentOverrides,
+						diagnostic),
+					"the evolved linked record should configure: " +
+						diagnostic);
+				Require(linked->
+						AppendDetachedSupplementalHierarchy(
+							expanded,
+							diagnostic),
+					"the removed source child should append as supplemental data: " +
+						diagnostic);
+				return linked;
+			};
+
+		const YAML::Node firstPersistedNode =
+			expandedRecord->Serialize();
+		PrefabPtr persistedExpandedRecord =
+			DeserializePrefab(
+				world,
+				YAML::Load(
+					YAML::Dump(
+						firstPersistedNode)));
+		PrefabPtr linkedRecord =
+			buildLinkedRecord(
+				persistedExpandedRecord);
+		GameObjectPtr root =
+			world.Instantiate(linkedRecord, true);
+		Require(root &&
+			root->GetInstanceId() == liveRoot &&
+			root->GetChildren().Num() == 1,
+			"the linked record should restore the mapped root and supplemental child with exact ids");
+		GameObjectPtr detachedChild =
+			root->GetChildren()[0];
+		Require(detachedChild->GetInstanceId() ==
+				removedLiveChild &&
+			detachedChild->GetParent() == root &&
+			detachedChild->GetName() ==
+				"DetachedEdited" &&
+			detachedChild->GetTransformComponent().
+				GetPosition() ==
+				glm::vec4(4.0f, 5.0f, 6.0f, 1.0f),
+			"supplemental hierarchy edits and parent semantics should survive reload");
+		Require(world.IsPrefabLinked(
+				root->GetInstanceId()) &&
+			!world.IsPrefabLinked(
+				detachedChild->GetInstanceId()) &&
+			world.CanModifyPrefabStructure(
+				detachedChild->GetInstanceId()),
+			"supplemental children must remain editable and outside reverse linked membership");
+
+		auto sourceTarget =
+			root->GetComponent<
+				PrefabRollbackTestComponent>();
+		auto mixed =
+			root->GetComponent<
+				PrefabMixedDependencyTestComponent>();
+		auto detachedTarget =
+			detachedChild->GetComponent<
+				PrefabRollbackTestComponent>();
+		Require(sourceTarget &&
+			mixed &&
+			detachedTarget &&
+			sourceTarget->m_value == 21.0f &&
+			detachedTarget->m_value == 73.0f &&
+			mixed->m_sourceDependency ==
+				sourceTarget &&
+			mixed->m_liveDependency ==
+				detachedTarget,
+			"a single component should resolve mixed source and supplemental live aliases");
+
+		PrefabPtr firstSavedExpanded =
+			PrefabDocumentTestAsset::Capture(
+				world,
+				root);
+		Require(PrefabDocumentTestAsset::
+				MarkExpandedLinkedRecord(
+					firstSavedExpanded,
+					evolvedMappings,
+					diagnostic),
+			"the expanded save record should remain valid after linked serialization metadata is attached: " +
+				diagnostic);
+		const std::string firstSavedYaml =
+			YAML::Dump(
+				firstSavedExpanded->Serialize());
+		PrefabPtr secondExpandedRecord =
+			DeserializePrefab(
+				world,
+				YAML::Load(firstSavedYaml));
+		world.Clear();
+
+		PrefabPtr secondLinkedRecord =
+			buildLinkedRecord(
+				secondExpandedRecord);
+		root = world.Instantiate(
+			secondLinkedRecord,
+			true);
+		Require(root &&
+			root->GetChildren().Num() == 1 &&
+			root->GetChildren()[0]->GetInstanceId() ==
+				removedLiveChild,
+			"save-load should preserve the supplemental hierarchy without duplicating source nodes");
+		detachedChild = root->GetChildren()[0];
+		PrefabPtr secondSavedExpanded =
+			PrefabDocumentTestAsset::Capture(
+				world,
+				root);
+		Require(PrefabDocumentTestAsset::
+				MarkExpandedLinkedRecord(
+					secondSavedExpanded,
+					evolvedMappings,
+					diagnostic),
+			"the second expanded save record should retain valid supplemental metadata: " +
+				diagnostic);
+		Require(YAML::Dump(
+				secondSavedExpanded->Serialize()) ==
+				firstSavedYaml,
+			"the expanded linked hierarchy should be stable across save-load-save");
+
+		PrefabPtr detachedSnapshotSource =
+			PrefabDocumentTestAsset::Capture(
+				world,
+				detachedChild);
+		YAML::Node detachedSnapshotNode =
+			detachedSnapshotSource->Serialize();
+		::Serialize(
+			detachedSnapshotNode,
+			"detachedFromPrefab",
+			true);
+		::Serialize(
+			detachedSnapshotNode,
+			"parentInstanceId",
+			liveRoot);
+		PrefabPtr detachedSnapshot =
+			DeserializePrefab(
+				world,
+				YAML::Load(
+					YAML::Dump(
+						detachedSnapshotNode)));
+		Require(detachedSnapshot->
+				ValidateForInstantiation(
+					diagnostic) &&
+			detachedSnapshot->
+				IsDetachedFromPrefabRecord(),
+			"the detached undo snapshot should round-trip its strict restore marker: " +
+				diagnostic);
+
+		Editor editor(nullptr, 0, nullptr);
+		editor.SetWorld(&world);
+		const size_t objectCountBeforeRejectedRestore =
+			world.GetGameObjects().Num();
+		Require(!editor.InstantiatePrefab(
+				detachedSnapshot,
+				liveRoot,
+				false) &&
+			world.GetGameObjects().Num() ==
+				objectCountBeforeRejectedRestore,
+			"a detached snapshot must reject non-strict restore without mutation");
+
+		GameObjectPtr wrongParent =
+			world.Instantiate("WrongParent");
+		Require(wrongParent &&
+			!editor.InstantiatePrefab(
+				detachedSnapshot,
+				wrongParent->GetInstanceId(),
+				true),
+			"a detached snapshot must reject a call-parent mismatch");
+
+		world.DestroyImmediate(detachedChild);
+		const size_t objectCountBeforeRestore =
+			world.GetGameObjects().Num();
+		Require(editor.InstantiatePrefab(
+				detachedSnapshot,
+				liveRoot,
+				true),
+			"strict detached undo should restore below the exact linked parent");
+		GameObjectPtr restoredChild =
+			world.GetObjectByInstanceId(
+				removedLiveChild).
+				DynamicCast<GameObject>();
+		Require(restoredChild &&
+			restoredChild->GetParent() == root &&
+			!world.IsPrefabLinked(
+				removedLiveChild) &&
+			restoredChild->GetComponent<
+				PrefabRollbackTestComponent>()->
+				GetInstanceId() ==
+				removedLiveComponent,
+			"detached undo should restore exact object/component ids without relinking the child");
+		Require(!editor.InstantiatePrefab(
+				detachedSnapshot,
+				liveRoot,
+				true) &&
+			world.GetGameObjects().Num() ==
+				objectCountBeforeRestore + 1,
+			"a detached strict-id collision should be rejected atomically");
+
+		PrefabPtr linkedSnapshotSource =
+			PrefabDocumentTestAsset::Capture(
+				world,
+				root);
+		YAML::Node linkedSnapshotNode =
+			linkedSnapshotSource->Serialize();
+		::Serialize(
+			linkedSnapshotNode,
+			"linkedPrefabSnapshot",
+			true);
+		::Serialize(
+			linkedSnapshotNode,
+			"fileId",
+			sourceFileId);
+		::Serialize(
+			linkedSnapshotNode,
+			"parentInstanceId",
+			InstanceId::Invalid);
+		::Serialize(
+			linkedSnapshotNode,
+			"instanceIds",
+			evolvedMappings);
+		::Serialize(
+			linkedSnapshotNode,
+			"gameObjectOverrides",
+			TMap<InstanceId, YAML::Node>{});
+		::Serialize(
+			linkedSnapshotNode,
+			"componentOverrides",
+			componentOverrides);
+		PrefabPtr linkedSnapshot =
+			DeserializePrefab(
+				world,
+				YAML::Load(
+					YAML::Dump(
+						linkedSnapshotNode)));
+		Require(linkedSnapshot->
+				ValidateForInstantiation(
+					diagnostic) &&
+			linkedSnapshot->
+				IsLinkedPrefabSnapshotRecord() &&
+			linkedSnapshot->
+				GetLinkedSnapshotSourceFileId() ==
+				sourceFileId,
+			"the linked-root undo snapshot should retain its validated source metadata: " +
+				diagnostic);
+
+		const size_t objectCountBeforeDirectReject =
+			world.GetGameObjects().Num();
+		Require(!world.Instantiate(
+				linkedSnapshot,
+				false) &&
+			!world.Instantiate(
+				linkedSnapshot,
+				true) &&
+			world.GetGameObjects().Num() ==
+				objectCountBeforeDirectReject,
+			"linked snapshot markers must never instantiate directly or non-strictly");
+
+		PrefabPtr restoredLinkedRecord =
+			PrefabPtr::Make(
+				world.GetAllocator(),
+				linkedSnapshot->
+					GetLinkedSnapshotSourceFileId());
+		Require(restoredLinkedRecord->
+				ConfigureLinkedInstance(
+					evolvedSource,
+					linkedSnapshot->
+						GetLinkedInstanceIds(),
+					linkedSnapshot->
+						GetLinkedParentInstanceId(),
+					linkedSnapshot->
+						GetLinkedGameObjectOverrides(),
+					linkedSnapshot->
+						GetLinkedComponentOverrides(),
+					diagnostic) &&
+			restoredLinkedRecord->
+				AppendDetachedSupplementalHierarchy(
+					linkedSnapshot,
+					diagnostic),
+			"the strict linked-root restore should resolve source metadata before mutation: " +
+				diagnostic);
+		Require(!editor.InstantiatePrefab(
+				restoredLinkedRecord,
+				InstanceId::Invalid,
+				true) &&
+			world.GetGameObjects().Num() ==
+				objectCountBeforeDirectReject,
+			"a linked-root exact-id collision should fail before partial mutation");
+
+		world.DestroyImmediate(root);
+		Require(editor.InstantiatePrefab(
+				restoredLinkedRecord,
+				InstanceId::Invalid,
+				true),
+			"strict linked-root undo should restore source link and supplemental children together");
+		GameObjectPtr restoredRoot =
+			world.GetObjectByInstanceId(
+				liveRoot).
+				DynamicCast<GameObject>();
+		restoredChild =
+			world.GetObjectByInstanceId(
+				removedLiveChild).
+				DynamicCast<GameObject>();
+		Require(restoredRoot &&
+			restoredChild &&
+			restoredChild->GetParent() ==
+				restoredRoot &&
+			world.IsPrefabLinked(liveRoot) &&
+			!world.IsPrefabLinked(
+				removedLiveChild),
+			"linked-root undo must relink only mapped source nodes and retain supplemental hierarchy");
+
+		world.Clear();
 	}
 
 	void TestRemovingComponentCancelsPendingDependencyResolution()
@@ -1026,6 +2578,252 @@ namespace
 			"the remapped component identity must embed its actual game-object owner");
 		Require(world.GetPendingDependencyCount() == 0,
 			"internally remapped component references must not leak into the pending queue");
+
+		world.Clear();
+	}
+
+	void TestStrictPrefabInstantiationPreservesIdsAndRejectsAtomically()
+	{
+		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
+		constexpr const char* rootId =
+			"10010010010010010000";
+		constexpr const char* childId =
+			"20020020020020020000";
+		constexpr const char* parentId =
+			"30030030030030030000";
+		constexpr const char* sourceComponentId =
+			"1111111111111111_10010010010010010000";
+		constexpr const char* targetComponentId =
+			"2222222222222222_20020020020020020000";
+
+		YAML::Node sourceProperties;
+		sourceProperties["m_dependency"]["fileId"] =
+			"NullFileId";
+		sourceProperties["m_dependency"]["instanceId"] =
+			targetComponentId;
+		YAML::Node targetProperties;
+		targetProperties["m_value"] = 42.0f;
+
+		YAML::Node components(YAML::NodeType::Sequence);
+		components.push_back(MakeReflectedComponent(
+			sourceComponentId,
+			sourceProperties));
+		components.push_back(MakeReflectedComponent(
+			targetComponentId,
+			targetProperties));
+
+		YAML::Node prefabNode = MakePrefabNode({ noParent, 0 });
+		prefabNode["gameObjects"][0]["instanceId"] = rootId;
+		prefabNode["gameObjects"][0]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		prefabNode["gameObjects"][0]["components"].push_back(0);
+		prefabNode["gameObjects"][1]["instanceId"] = childId;
+		prefabNode["gameObjects"][1]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		prefabNode["gameObjects"][1]["components"].push_back(1);
+		prefabNode["components"] = components;
+
+		{
+			PrefabTestWorld world;
+			PrefabPtr prefab = DeserializePrefab(world, prefabNode);
+			GameObjectPtr strictRoot =
+				world.Instantiate(prefab, true);
+			Require(strictRoot &&
+				strictRoot->GetInstanceId() ==
+					DeserializeInstanceId(rootId) &&
+				strictRoot->GetChildren().Num() == 1 &&
+				strictRoot->GetChildren()[0]->GetInstanceId() ==
+					DeserializeInstanceId(childId),
+				"strict prefab instantiate should preserve every saved game object id");
+
+			auto strictSource =
+				strictRoot->GetComponent<
+					PrefabRollbackTestComponent>();
+			auto strictTarget = strictRoot->GetChildren()[0]->
+				GetComponent<PrefabRollbackTestComponent>();
+			Require(strictSource && strictTarget &&
+				strictSource->GetInstanceId() ==
+					DeserializeInstanceId(sourceComponentId) &&
+				strictTarget->GetInstanceId() ==
+					DeserializeInstanceId(targetComponentId) &&
+				strictSource->m_dependency == strictTarget,
+				"strict prefab instantiate should preserve component identities and internal references");
+			Require(world.GetPendingDependencyCount() == 0,
+				"strict internal references should resolve without entering the pending queue");
+
+			world.Clear();
+		}
+
+		{
+			PrefabTestWorld world;
+			const InstanceId desiredRootId =
+				DeserializeInstanceId(rootId);
+			const InstanceId desiredChildId =
+				DeserializeInstanceId(childId);
+			const InstanceId desiredParentId =
+				DeserializeInstanceId(parentId);
+			const InstanceId desiredTargetComponentId =
+				DeserializeInstanceId(targetComponentId);
+			GameObjectPtr existingParent = world.Instantiate(
+				"ExistingParent",
+				desiredParentId);
+			GameObjectPtr childCollision = world.Instantiate(
+				"ExistingChildCollision",
+				desiredChildId);
+			Require(existingParent && childCollision,
+				"the strict collision fixture should preserve its requested ids");
+			childCollision->SetParent(existingParent);
+			ComponentPtr existingComponent =
+				TObjectPtr<PrefabRollbackTestComponent>::Make(
+					world.GetAllocator());
+			existingComponent = childCollision->AddComponentRaw(
+				existingComponent,
+				desiredTargetComponentId);
+			Require(existingComponent &&
+				existingParent->GetChildren().Num() == 1,
+				"the strict collision fixture should contain the occupied child and component ids");
+
+			PrefabPtr prefab =
+				DeserializePrefab(world, prefabNode);
+			const size_t objectCountBeforeReject =
+				world.GetGameObjects().Num();
+			const size_t parentChildCountBeforeReject =
+				existingParent->GetChildren().Num();
+			const size_t pendingCountBeforeReject =
+				world.GetPendingDependencyCount();
+			Require(!world.Instantiate(prefab, true),
+				"strict prefab instantiate should reject a collision on any saved game object id");
+			Require(world.GetGameObjects().Num() ==
+					objectCountBeforeReject &&
+				existingParent->GetChildren().Num() ==
+					parentChildCountBeforeReject &&
+				childCollision->GetParent() == existingParent &&
+				childCollision->GetComponent(0) ==
+					existingComponent &&
+				world.GetPendingDependencyCount() ==
+					pendingCountBeforeReject &&
+				!world.GetObjectByInstanceId(desiredRootId),
+				"a strict child collision must be rejected before the first world, parent, component, or dependency mutation");
+
+			GameObjectPtr remappedRoot =
+				world.Instantiate(prefab);
+			Require(remappedRoot &&
+				remappedRoot->GetInstanceId() ==
+					desiredRootId &&
+				remappedRoot->GetChildren().Num() == 1 &&
+				remappedRoot->GetChildren()[0]->GetInstanceId() !=
+					desiredChildId,
+				"ordinary prefab instantiate should continue remapping only colliding saved ids");
+			auto remappedSource =
+				remappedRoot->GetComponent<
+					PrefabRollbackTestComponent>();
+			auto remappedTarget =
+				remappedRoot->GetChildren()[0]->
+					GetComponent<PrefabRollbackTestComponent>();
+			Require(remappedSource && remappedTarget &&
+				remappedSource->m_dependency == remappedTarget &&
+				remappedTarget->GetInstanceId().ComponentId() ==
+					desiredTargetComponentId.ComponentId() &&
+				remappedTarget->GetInstanceId().GameObjectId() ==
+					remappedRoot->GetChildren()[0]->
+						GetInstanceId(),
+				"ordinary remapping should retain component-local identity and follow the remapped owner");
+
+			world.Clear();
+		}
+	}
+
+	void TestEditorPrefabInstantiationRejectsLinkedParentBeforeMutation()
+	{
+		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
+		constexpr const char* sourceParentId =
+			"10010010010010010000";
+		constexpr const char* liveParentId =
+			"20020020020020020000";
+		constexpr const char* childRootId =
+			"30030030030030030000";
+		constexpr const char* childComponentId =
+			"1111111111111111_30030030030030030000";
+		const FileId sourceFileId =
+			DeserializeFileId(
+				"{11111111-2222-3333-4444-555555555555}");
+
+		PrefabTestWorld world;
+		YAML::Node parentSourceNode =
+			MakePrefabNode({ noParent });
+		parentSourceNode["gameObjects"][0]["instanceId"] =
+			sourceParentId;
+		PrefabPtr parentSource = DeserializePrefab(
+			world,
+			sourceFileId,
+			parentSourceNode);
+
+		TMap<InstanceId, InstanceId> parentMappings;
+		parentMappings[DeserializeInstanceId(sourceParentId)] =
+			DeserializeInstanceId(liveParentId);
+		std::string diagnostic;
+		PrefabPtr linkedParentPrefab =
+			PrefabPtr::Make(world.GetAllocator(), sourceFileId);
+		Require(linkedParentPrefab->ConfigureLinkedInstance(
+				parentSource,
+				parentMappings,
+				InstanceId::Invalid,
+				{},
+				{},
+				diagnostic),
+			"the linked parent fixture should configure: " +
+				diagnostic);
+		GameObjectPtr linkedParent =
+			world.Instantiate(linkedParentPrefab);
+		Require(linkedParent &&
+			world.IsPrefabLinked(linkedParent->GetInstanceId()),
+			"the editor parent rejection fixture should be linked");
+
+		YAML::Node unresolvedProperties;
+		unresolvedProperties["m_dependency"]["fileId"] =
+			"NullFileId";
+		unresolvedProperties["m_dependency"]["instanceId"] =
+			"9999999999999999_AAAAAAAAAAAAAAAAAAAA";
+		YAML::Node childComponents(YAML::NodeType::Sequence);
+		childComponents.push_back(MakeReflectedComponent(
+			childComponentId,
+			unresolvedProperties));
+		YAML::Node childNode = MakePrefabNode({ noParent });
+		childNode["gameObjects"][0]["instanceId"] =
+			childRootId;
+		childNode["gameObjects"][0]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		childNode["gameObjects"][0]["components"].push_back(0);
+		childNode["components"] = childComponents;
+		PrefabPtr childPrefab =
+			DeserializePrefab(world, childNode);
+
+		const size_t objectCountBeforeReject =
+			world.GetGameObjects().Num();
+		const size_t linkCountBeforeReject =
+			world.GetPrefabInstances().Num();
+		const size_t pendingCountBeforeReject =
+			world.GetPendingDependencyCount();
+		const size_t parentChildCountBeforeReject =
+			linkedParent->GetChildren().Num();
+
+		Editor editor(nullptr, 0, nullptr);
+		editor.SetWorld(&world);
+		Require(!editor.InstantiatePrefab(
+				childPrefab,
+				linkedParent->GetInstanceId()),
+			"editor prefab instantiate should reject parenting inside a linked prefab");
+		Require(world.GetGameObjects().Num() ==
+				objectCountBeforeReject &&
+			world.GetPrefabInstances().Num() ==
+				linkCountBeforeReject &&
+			world.GetPendingDependencyCount() ==
+				pendingCountBeforeReject &&
+			linkedParent->GetChildren().Num() ==
+				parentChildCountBeforeReject &&
+			!world.GetObjectByInstanceId(
+				DeserializeInstanceId(childRootId)),
+			"linked-parent rejection must happen before object, link, hierarchy, or dependency mutation");
 
 		world.Clear();
 	}
@@ -1280,7 +3078,15 @@ int main()
 		{ "ExplicitNullMeshReferenceDoesNotRemainPending", TestExplicitNullMeshReferenceDoesNotRemainPending },
 		{ "EditorUpdateReplacesStaleMeshDependencyResolution", TestEditorUpdateReplacesStaleMeshDependencyResolution },
 		{ "EditorUpdatePreservesNewUnresolvedDependency", TestEditorUpdatePreservesNewUnresolvedDependency },
+		{ "LegacyPrefabApiSymbolsRemainAddressable", TestLegacyPrefabApiSymbolsRemainAddressable },
 		{ "PrefabComponentReferencesFollowRemappedOwners", TestPrefabComponentReferencesFollowRemappedOwners },
+		{ "LinkedPrefabPersistenceAndWorldContract", TestLinkedPrefabPersistenceAndWorldContract },
+		{ "LinkedPrefabBaselineAndSaveFailureContract", TestLinkedPrefabBaselineAndSaveFailureContract },
+		{ "LinkedPrefabSourceStructureEvolutionContract", TestLinkedPrefabSourceStructureEvolutionContract },
+		{ "LinkedPrefabMembershipFollowsEvolvedSourceMapping", TestLinkedPrefabMembershipFollowsEvolvedSourceMapping },
+		{ "DetachedSupplementalPrefabPersistenceAndStrictRestore", TestDetachedSupplementalPrefabPersistenceAndStrictRestore },
+		{ "StrictPrefabInstantiationPreservesIdsAndRejectsAtomically", TestStrictPrefabInstantiationPreservesIdsAndRejectsAtomically },
+		{ "EditorPrefabInstantiationRejectsLinkedParentBeforeMutation", TestEditorPrefabInstantiationRejectsLinkedParentBeforeMutation },
 		{ "PrefabTopologyValidationRejectsPartialWorldMutations", TestPrefabTopologyValidationRejectsPartialWorldMutations },
 		{ "PrefabInstantiationRollbackPreservesWorldState", TestPrefabInstantiationRollbackPreservesWorldState },
 	};

--- a/Tests/EditorEngineProtocolTests.cpp
+++ b/Tests/EditorEngineProtocolTests.cpp
@@ -2,12 +2,14 @@
 #include "EditorEngineProtocolLifecycle.h"
 
 #include <chrono>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <condition_variable>
 #include <future>
 #include <iostream>
+#include <limits>
 #include <mutex>
 #include <stdexcept>
 #include <string>
@@ -34,6 +36,7 @@ extern "C"
 namespace
 {
 	using Sailor::Protocol::EEditorEngineTransportStatus;
+	using Sailor::Protocol::EditorEngineProtocolStrictInstanceIdsVersion;
 	using Sailor::Protocol::EditorEngineProtocolMaxPayloadSize;
 	using Sailor::Protocol::EditorEngineProtocolVersion;
 
@@ -41,10 +44,12 @@ namespace
 	constexpr uint32_t c_requestIdField = 2;
 	constexpr uint32_t c_successField = 3;
 	constexpr uint32_t c_errorField = 4;
+	constexpr uint32_t c_supportsStrictInstanceIdsField = 5;
 	constexpr uint32_t c_boolResultField = 11;
 	constexpr uint32_t c_int32ResultField = 12;
 	constexpr uint32_t c_uint64ResultField = 14;
 	constexpr uint32_t c_viewportEventBatchResultField = 19;
+	constexpr uint32_t c_viewportToolStateResultField = 21;
 	constexpr uint32_t c_emptyResultField = 10;
 	constexpr uint32_t c_initializeCommandField = 10;
 	constexpr uint32_t c_startCommandField = 11;
@@ -56,6 +61,7 @@ namespace
 	constexpr uint32_t c_getManagedMutationRevisionCommandField = 33;
 	constexpr uint32_t c_renderPathTracedImageCommandField = 45;
 	constexpr uint32_t c_isEngineRunningCommandField = 48;
+	constexpr uint32_t c_instantiatePrefabFromYamlCommandField = 42;
 
 	void Require(bool condition, const std::string& message)
 	{
@@ -139,6 +145,7 @@ namespace
 		uint32_t m_protocolVersion = 0;
 		uint64_t m_requestId = 0;
 		bool m_success = false;
+		bool m_supportsStrictInstanceIds = false;
 		std::string m_error{};
 		uint32_t m_resultField = 0;
 		bool m_boolResult = false;
@@ -235,6 +242,12 @@ namespace
 				{
 					response.m_success = value != 0;
 				}
+				else if (fieldNumber ==
+					c_supportsStrictInstanceIdsField)
+				{
+					response.m_supportsStrictInstanceIds =
+						value != 0;
+				}
 				continue;
 			}
 
@@ -251,7 +264,8 @@ namespace
 					reinterpret_cast<const char*>(value),
 					static_cast<size_t>(length));
 			}
-			else if (fieldNumber >= 10u && fieldNumber <= 19u)
+			else if (fieldNumber >= 10u &&
+				fieldNumber <= c_viewportToolStateResultField)
 			{
 				response.m_resultField = fieldNumber;
 				response.m_resultPayload.assign(
@@ -300,6 +314,15 @@ namespace
 				return false;
 			}
 			offset += static_cast<size_t>(length);
+			return true;
+		}
+		if (wireType == 5)
+		{
+			if (size - offset < sizeof(uint32_t))
+			{
+				return false;
+			}
+			offset += sizeof(uint32_t);
 			return true;
 		}
 		return false;
@@ -372,12 +395,162 @@ namespace
 		return true;
 	}
 
+	bool TryReadFixed32(
+		const uint8_t* data,
+		size_t size,
+		size_t& offset,
+		uint32_t& outValue)
+	{
+		if (size - offset < sizeof(uint32_t))
+		{
+			return false;
+		}
+
+		outValue =
+			static_cast<uint32_t>(data[offset]) |
+			(static_cast<uint32_t>(data[offset + 1]) << 8u) |
+			(static_cast<uint32_t>(data[offset + 2]) << 16u) |
+			(static_cast<uint32_t>(data[offset + 3]) << 24u);
+		offset += sizeof(uint32_t);
+		return true;
+	}
+
+	bool TryDecodeViewportAssetDrop(
+		const uint8_t* data,
+		size_t size,
+		std::string& outFileId,
+		float& outNormalizedX,
+		float& outNormalizedY)
+	{
+		bool bHasFileId = false;
+		bool bHasNormalizedX = false;
+		bool bHasNormalizedY = false;
+		size_t offset = 0;
+		while (offset < size)
+		{
+			uint64_t key = 0;
+			if (!ReadVarint(data, size, offset, key))
+			{
+				return false;
+			}
+
+			const uint32_t fieldNumber =
+				static_cast<uint32_t>(key >> 3u);
+			const uint32_t wireType =
+				static_cast<uint32_t>(key & 0x7u);
+			if (fieldNumber == 1u)
+			{
+				const uint8_t* value = nullptr;
+				size_t valueSize = 0;
+				if (wireType != 2u ||
+					!TryReadLengthDelimited(
+						data,
+						size,
+						offset,
+						value,
+						valueSize))
+				{
+					return false;
+				}
+				outFileId.assign(
+					reinterpret_cast<const char*>(value),
+					valueSize);
+				bHasFileId = true;
+				continue;
+			}
+
+			if (fieldNumber == 2u || fieldNumber == 3u)
+			{
+				uint32_t bits = 0;
+				if (wireType != 5u ||
+					!TryReadFixed32(data, size, offset, bits))
+				{
+					return false;
+				}
+
+				float value = 0.0f;
+				std::memcpy(&value, &bits, sizeof(value));
+				if (fieldNumber == 2u)
+				{
+					outNormalizedX = value;
+					bHasNormalizedX = true;
+				}
+				else
+				{
+					outNormalizedY = value;
+					bHasNormalizedY = true;
+				}
+				continue;
+			}
+
+			if (!SkipField(data, size, offset, wireType))
+			{
+				return false;
+			}
+		}
+
+		return bHasFileId &&
+			bHasNormalizedX &&
+			bHasNormalizedY;
+	}
+
+	bool TryDecodeViewportToolShortcut(
+		const uint8_t* data,
+		size_t size,
+		uint32_t& outKeyCode)
+	{
+		bool bHasKeyCode = false;
+		size_t offset = 0;
+		while (offset < size)
+		{
+			uint64_t key = 0;
+			if (!ReadVarint(data, size, offset, key))
+			{
+				return false;
+			}
+
+			const uint32_t fieldNumber =
+				static_cast<uint32_t>(key >> 3u);
+			const uint32_t wireType =
+				static_cast<uint32_t>(key & 0x7u);
+			if (fieldNumber == 1u)
+			{
+				uint64_t keyCode = 0;
+				if (wireType != 0u ||
+					!ReadVarint(data, size, offset, keyCode) ||
+					keyCode >
+						static_cast<uint64_t>(
+							std::numeric_limits<uint32_t>::max()))
+				{
+					return false;
+				}
+
+				outKeyCode = static_cast<uint32_t>(keyCode);
+				bHasKeyCode = true;
+				continue;
+			}
+
+			if (!SkipField(data, size, offset, wireType))
+			{
+				return false;
+			}
+		}
+
+		return bHasKeyCode;
+	}
+
 	struct TDecodedViewportEvent
 	{
 		uint64_t m_revision = 0;
 		uint64_t m_managedMutationRevision = 0;
 		bool m_hasSelection = false;
 		std::string m_selectedInstanceId{};
+		bool m_hasAssetDrop = false;
+		std::string m_assetFileId{};
+		float m_normalizedX = 0.0f;
+		float m_normalizedY = 0.0f;
+		bool m_hasToolShortcut = false;
+		uint32_t m_toolShortcutKeyCode = 0;
 	};
 
 	bool TryDecodeViewportEvent(
@@ -433,6 +606,50 @@ namespace
 					return false;
 				}
 				outEvent.m_hasSelection = true;
+				continue;
+			}
+			if (fieldNumber == 12u)
+			{
+				const uint8_t* assetDrop = nullptr;
+				size_t assetDropSize = 0;
+				if (wireType != 2u ||
+					!TryReadLengthDelimited(
+						data,
+						size,
+						offset,
+						assetDrop,
+						assetDropSize) ||
+					!TryDecodeViewportAssetDrop(
+						assetDrop,
+						assetDropSize,
+						outEvent.m_assetFileId,
+						outEvent.m_normalizedX,
+						outEvent.m_normalizedY))
+				{
+					return false;
+				}
+				outEvent.m_hasAssetDrop = true;
+				continue;
+			}
+			if (fieldNumber == 13u)
+			{
+				const uint8_t* toolShortcut = nullptr;
+				size_t toolShortcutSize = 0;
+				if (wireType != 2u ||
+					!TryReadLengthDelimited(
+						data,
+						size,
+						offset,
+						toolShortcut,
+						toolShortcutSize) ||
+					!TryDecodeViewportToolShortcut(
+						toolShortcut,
+						toolShortcutSize,
+						outEvent.m_toolShortcutKeyCode))
+				{
+					return false;
+				}
+				outEvent.m_hasToolShortcut = true;
 				continue;
 			}
 			if (!SkipField(data, size, offset, wireType))
@@ -669,12 +886,13 @@ namespace
 			TProtocolBuffer buffer;
 			const auto response = RequireProtocolResponse(
 				MakeRequest(
-					EditorEngineProtocolVersion + 1u,
+					EditorEngineProtocolStrictInstanceIdsVersion + 1u,
 					17,
 					c_getExitCodeCommandField),
 				buffer);
 			Require(
-				response.m_protocolVersion == EditorEngineProtocolVersion &&
+				response.m_protocolVersion ==
+					EditorEngineProtocolStrictInstanceIdsVersion &&
 				response.m_requestId == 17 &&
 				!response.m_success &&
 				response.m_error.find("version") != std::string::npos &&
@@ -710,6 +928,85 @@ namespace
 				response.m_error.find("command") != std::string::npos &&
 				response.m_resultField == 0,
 				"missing command must return a correlated protocol error");
+		}
+	}
+
+	void TestStrictInstanceIdProtocolGate()
+	{
+		std::string strictInstantiateRequest;
+		AppendVarintField(
+			strictInstantiateRequest,
+			3u,
+			1u);
+
+		{
+			TProtocolBuffer buffer;
+			const auto response = RequireProtocolResponse(
+				MakeRequest(
+					EditorEngineProtocolVersion,
+					24,
+					c_instantiatePrefabFromYamlCommandField,
+					strictInstantiateRequest),
+				buffer);
+			Require(
+				response.m_protocolVersion ==
+					EditorEngineProtocolVersion &&
+				response.m_requestId == 24 &&
+				!response.m_success &&
+				response.m_error.find("Strict instance-id") !=
+					std::string::npos &&
+				response.m_supportsStrictInstanceIds,
+				"v1 strict restore must fail closed while advertising the compatible host capability");
+		}
+
+		{
+			TProtocolBuffer buffer;
+			const auto response = RequireProtocolResponse(
+				MakeRequest(
+					EditorEngineProtocolStrictInstanceIdsVersion,
+					25,
+					c_getExitCodeCommandField),
+				buffer);
+			Require(
+				response.m_protocolVersion ==
+					EditorEngineProtocolStrictInstanceIdsVersion &&
+				response.m_requestId == 25 &&
+				!response.m_success &&
+				response.m_error.find("reserved") !=
+					std::string::npos &&
+				response.m_supportsStrictInstanceIds,
+				"the strict protocol version must reject ordinary v1 commands");
+		}
+
+		{
+			Sailor::Protocol::TEditorEngineProtocolLifecycleGate gate;
+			std::string admissionError;
+			Require(
+				gate.TryBeginInitialization(admissionError),
+				"strict protocol fixture lifecycle must initialize");
+			gate.CompleteInitialization(true);
+			Sailor::Protocol::EditorEngineProtocolDependencies
+				dependencies{};
+			dependencies.m_lifecycleGate = &gate;
+
+			TProtocolBuffer buffer;
+			const auto response = RequireProtocolResponse(
+				MakeRequest(
+					EditorEngineProtocolStrictInstanceIdsVersion,
+					26,
+					c_instantiatePrefabFromYamlCommandField,
+					strictInstantiateRequest),
+				buffer,
+				dependencies);
+			Require(
+				response.m_protocolVersion ==
+					EditorEngineProtocolStrictInstanceIdsVersion &&
+				response.m_requestId == 26 &&
+				response.m_success &&
+				response.m_resultField == c_boolResultField &&
+				!response.m_boolResult &&
+				response.m_supportsStrictInstanceIds,
+				"a capability-compatible host must dispatch a version-gated strict restore request");
 		}
 	}
 
@@ -764,6 +1061,7 @@ namespace
 		Require(
 			response.m_requestId == 30 &&
 			response.m_success &&
+			response.m_supportsStrictInstanceIds &&
 			response.m_error.empty() &&
 			response.m_resultField == c_uint64ResultField,
 			"valid UTF-8 protobuf strings must pass native string validation");
@@ -876,6 +1174,132 @@ namespace
 			event.m_hasSelection &&
 			event.m_selectedInstanceId == "Duck-123",
 			"the valid event following malformed YAML must be preserved");
+	}
+
+	void TestViewportAssetDropEventIsTypedAndValidated()
+	{
+		const std::string fileId =
+			"{12345678-1234-1234-1234-123456789ABC}";
+		TViewportEventSource source{
+			{
+				"kind: assetDrop\n"
+				"revision: 43\n"
+				"managedMutationRevision: 10\n"
+				"fileId: \"" + fileId + "\"\n"
+				"normalizedX: 0.25\n"
+				"normalizedY: 0.75\n",
+				"kind: assetDrop\n"
+				"revision: 44\n"
+				"managedMutationRevision: 10\n"
+				"fileId: \"" + fileId + "\"\n"
+				"normalizedX: 1.5\n"
+				"normalizedY: 0.5\n"
+			}
+		};
+		Sailor::Protocol::EditorEngineProtocolDependencies dependencies{};
+		dependencies.m_context = &source;
+		dependencies.m_pullEditorViewportEvents = PullViewportEvents;
+		Sailor::Protocol::TEditorEngineProtocolLifecycleGate gate;
+		std::string admissionError;
+		Require(
+			gate.TryBeginInitialization(admissionError),
+			"asset-drop adapter test lifecycle must initialize");
+		gate.CompleteInitialization(true);
+		dependencies.m_lifecycleGate = &gate;
+
+		std::string countRequest;
+		AppendVarintField(countRequest, 1u, 2u);
+		TProtocolBuffer buffer;
+		const auto response = RequireProtocolResponse(
+			MakeRequest(
+				EditorEngineProtocolVersion,
+				42,
+				c_pullEditorViewportEventsCommandField,
+				countRequest),
+			buffer,
+			dependencies);
+		Require(
+			response.m_success &&
+				response.m_resultField ==
+					c_viewportEventBatchResultField,
+			"viewport asset-drop response must report protocol success");
+
+		uint32_t numEvents = 0;
+		TDecodedViewportEvent event;
+		Require(
+			TryDecodeViewportEventBatch(
+				response.m_resultPayload,
+				numEvents,
+				event) &&
+				numEvents == 1,
+			"invalid normalized asset-drop events must be filtered");
+		Require(
+			event.m_revision == 43 &&
+				event.m_managedMutationRevision == 10 &&
+				event.m_hasAssetDrop &&
+				event.m_assetFileId == fileId &&
+				std::abs(event.m_normalizedX - 0.25f) < 0.0001f &&
+				std::abs(event.m_normalizedY - 0.75f) < 0.0001f,
+			"valid asset-drop data must survive native typed conversion");
+	}
+
+	void TestViewportToolShortcutEventIsTypedAndValidated()
+	{
+		TViewportEventSource source{
+			{
+				"kind: toolShortcut\n"
+				"revision: 45\n"
+				"managedMutationRevision: 11\n"
+				"keyCode: 87\n",
+				"kind: toolShortcut\n"
+				"revision: 46\n"
+				"managedMutationRevision: 11\n"
+				"keyCode: 88\n"
+			}
+		};
+		Sailor::Protocol::EditorEngineProtocolDependencies dependencies{};
+		dependencies.m_context = &source;
+		dependencies.m_pullEditorViewportEvents = PullViewportEvents;
+		Sailor::Protocol::TEditorEngineProtocolLifecycleGate gate;
+		std::string admissionError;
+		Require(
+			gate.TryBeginInitialization(admissionError),
+			"tool-shortcut adapter test lifecycle must initialize");
+		gate.CompleteInitialization(true);
+		dependencies.m_lifecycleGate = &gate;
+
+		std::string countRequest;
+		AppendVarintField(countRequest, 1u, 2u);
+		TProtocolBuffer buffer;
+		const auto response = RequireProtocolResponse(
+			MakeRequest(
+				EditorEngineProtocolVersion,
+				43,
+				c_pullEditorViewportEventsCommandField,
+				countRequest),
+			buffer,
+			dependencies);
+		Require(
+			response.m_success &&
+				response.m_resultField ==
+					c_viewportEventBatchResultField,
+			"viewport tool-shortcut response must report protocol success");
+
+		uint32_t numEvents = 0;
+		TDecodedViewportEvent event;
+		Require(
+			TryDecodeViewportEventBatch(
+				response.m_resultPayload,
+				numEvents,
+				event) &&
+				numEvents == 1,
+			"unsupported viewport shortcut keys must be filtered");
+		Require(
+			event.m_revision == 45 &&
+				event.m_managedMutationRevision == 11 &&
+				event.m_hasToolShortcut &&
+				event.m_toolShortcutKeyCode == 'W',
+			"valid viewport shortcuts must survive native typed conversion");
 	}
 
 	void TestLifecycleGateDrainsStartAndOperationsBeforeShutdown()
@@ -1560,10 +1984,13 @@ int main()
 		TestOversizedAndMalformedPayloads();
 		TestCommandExceptionIsContainedByTransportBoundary();
 		TestEnvelopeValidation();
+		TestStrictInstanceIdProtocolGate();
 		TestEmbeddedNullIsRejected();
 		TestUtf8StringIsAccepted();
 		TestGetExitCodeRoundTripAndFree();
 		TestMalformedViewportEventDoesNotDiscardValidBatchEvents();
+		TestViewportAssetDropEventIsTypedAndValidated();
+		TestViewportToolShortcutEventIsTypedAndValidated();
 		TestLifecycleGateDrainsStartAndOperationsBeforeShutdown();
 		TestStartAcknowledgesBeforeWorkerExitAndStopJoins();
 		TestImmediateStopAfterStartAcknowledgementCannotBeLost();

--- a/Tests/EditorEngineWebSocketServerTests.cpp
+++ b/Tests/EditorEngineWebSocketServerTests.cpp
@@ -139,6 +139,7 @@ namespace
 		uint64_t m_protocolVersion = 0u;
 		uint64_t m_requestId = 0u;
 		bool m_bSuccess = false;
+		bool m_bSupportsStrictInstanceIds = false;
 		std::string m_error{};
 		uint32_t m_resultField = 0u;
 		std::string m_resultPayload{};
@@ -180,6 +181,11 @@ namespace
 
 				case 3u:
 					outResponse.m_bSuccess = value != 0u;
+					break;
+
+				case 5u:
+					outResponse.m_bSupportsStrictInstanceIds =
+						value != 0u;
 					break;
 
 				default:
@@ -656,8 +662,10 @@ namespace
 			response.m_requestId == requestId,
 			"WebSocket response must preserve the request id");
 		Require(
-			response.m_bSuccess && response.m_error.empty(),
-			"get-exit-code request must succeed");
+			response.m_bSuccess &&
+				response.m_bSupportsStrictInstanceIds &&
+				response.m_error.empty(),
+			"get-exit-code request must succeed and advertise strict restore support");
 		uint64_t exitCode = 1u;
 		Require(
 			response.m_resultField == 12u &&

--- a/Tests/EditorViewportControllerContractTests.cpp
+++ b/Tests/EditorViewportControllerContractTests.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -215,6 +216,297 @@ namespace
 		Require(std::abs(distance) <= c_tolerance, "a ray starting inside an AABB must report zero distance");
 	}
 
+	void TestResolveDropPositionUsesNearestMeshBounds()
+	{
+		const InstanceId nearId = ParseInstanceId("0000000000000010");
+		const InstanceId farId = ParseInstanceId("0000000000000020");
+		const Math::Ray ray(glm::vec3(0.0f, 2.0f, 0.0f), Math::vec3_Forward);
+		const TVector<EditorViewport::PickCandidate> candidates = {
+			{ farId, MakeBounds(glm::vec3(-1.0f, 1.0f, -9.0f), glm::vec3(1.0f, 3.0f, -8.0f)) },
+			{ nearId, MakeBounds(glm::vec3(-1.0f, 1.0f, -4.0f), glm::vec3(1.0f, 3.0f, -3.0f)) },
+		};
+		glm::vec3 position{};
+
+		Require(EditorViewport::TryResolveDropPosition(ray, candidates, position),
+			"a drop ray crossing mesh bounds must resolve successfully");
+		Require(AreVectorsNear(position, glm::vec3(0.0f, 2.0f, -3.0f)),
+			"drop placement must use the nearest mesh AABB before fallback surfaces");
+	}
+
+	void TestResolveDropPositionUsesGroundPlane()
+	{
+		const glm::vec3 origin(2.0f, 4.0f, 3.0f);
+		const glm::vec3 direction = glm::normalize(glm::vec3(1.0f, -2.0f, -1.0f));
+		const Math::Ray ray(origin, direction);
+		const TVector<EditorViewport::PickCandidate> candidates{};
+		glm::vec3 position{};
+		const float planeDistance = -origin.y / direction.y;
+
+		Require(EditorViewport::TryResolveDropPosition(ray, candidates, position),
+			"a drop ray facing the ground plane must resolve successfully");
+		Require(AreVectorsNear(position, origin + direction * planeDistance),
+			"drop placement without mesh hits must intersect the y=0 plane");
+		Require(std::abs(position.y) <= c_tolerance,
+			"ground-plane drop placement must land on y=0");
+	}
+
+	void TestResolveDropPositionUsesFiniteForwardFallback()
+	{
+		const glm::vec3 origin(1.0f, 2.0f, 3.0f);
+		const glm::vec3 direction = glm::normalize(glm::vec3(1.0f, 0.0f, -1.0f));
+		const Math::Ray ray(origin, direction);
+		const TVector<EditorViewport::PickCandidate> candidates{};
+		glm::vec3 position{};
+
+		Require(EditorViewport::TryResolveDropPosition(ray, candidates, position),
+			"a drop ray parallel to the ground plane must still resolve");
+		Require(Math::AllFinite(position),
+			"the forward fallback must remain finite");
+		Require(AreVectorsNear(position, origin + direction * 1000.0f),
+			"the final drop fallback must use a finite forward distance");
+
+		const Math::Ray upwardRay(
+			origin,
+			glm::normalize(glm::vec3(0.0f, 1.0f, -1.0f)));
+		Require(EditorViewport::TryResolveDropPosition(
+			upwardRay,
+			candidates,
+			position),
+			"a ground-plane intersection behind the camera must use the forward fallback");
+		Require(position.y > origin.y,
+			"drop placement must never follow the ray backwards to reach the ground plane");
+	}
+
+	void TestResolveDropPositionRejectsInvalidRay()
+	{
+		const TVector<EditorViewport::PickCandidate> candidates{};
+		glm::vec3 position(4.0f, 5.0f, 6.0f);
+
+		Require(!EditorViewport::TryResolveDropPosition(
+			Math::Ray(glm::vec3(0.0f), glm::vec3(0.0f)),
+			candidates,
+			position),
+			"a zero-length drop ray must be rejected");
+		Require(AreVectorsNear(position, glm::vec3(0.0f)),
+			"a rejected drop ray must not leak a stale position");
+
+		const float nan = std::numeric_limits<float>::quiet_NaN();
+		Require(!EditorViewport::TryResolveDropPosition(
+			Math::Ray(glm::vec3(nan, 0.0f, 0.0f), Math::vec3_Forward),
+			candidates,
+			position),
+			"a non-finite drop ray must be rejected");
+	}
+
+	void TestCalculateFramedCameraPositionPreservesViewDirection()
+	{
+		const Math::AABB bounds(
+			glm::vec3(10.0f, 2.0f, -5.0f),
+			glm::vec3(2.0f, 1.0f, 3.0f));
+		const Math::Transform cameraTransform(
+			glm::vec4(-20.0f, 15.0f, 30.0f, 1.0f),
+			glm::angleAxis(
+				glm::radians(35.0f),
+				glm::normalize(glm::vec3(1.0f, 2.0f, 0.5f))),
+			glm::vec4(1.0f));
+		glm::vec3 position{};
+
+		Require(EditorViewport::TryCalculateFramedCameraPosition(
+			bounds,
+			cameraTransform,
+			70.0f,
+			16.0f / 9.0f,
+			0.1f,
+			position),
+			"valid bounds and camera data must produce a framing position");
+		const glm::vec3 viewDirection =
+			glm::normalize(bounds.GetCenter() - position);
+		Require(AreVectorsNear(
+			viewDirection,
+			glm::normalize(cameraTransform.GetForward())),
+			"camera framing must preserve the current camera view direction");
+		Require(glm::distance(position, bounds.GetCenter()) >
+			glm::length(bounds.GetExtents()),
+			"camera framing must place the camera outside the target bounds");
+	}
+
+	void TestCalculateFramedCameraPositionAccountsForViewportAspect()
+	{
+		const Math::AABB bounds(glm::vec3(0.0f), glm::vec3(1.0f));
+		const Math::Transform cameraTransform(
+			glm::vec4(0.0f),
+			glm::quat(1.0f, 0.0f, 0.0f, 0.0f),
+			glm::vec4(1.0f));
+		glm::vec3 landscapePosition{};
+		glm::vec3 portraitPosition{};
+
+		Require(EditorViewport::TryCalculateFramedCameraPosition(
+			bounds,
+			cameraTransform,
+			60.0f,
+			2.0f,
+			0.1f,
+			landscapePosition),
+			"a landscape viewport must produce a framing position");
+		Require(EditorViewport::TryCalculateFramedCameraPosition(
+			bounds,
+			cameraTransform,
+			60.0f,
+			0.5f,
+			0.1f,
+			portraitPosition),
+			"a portrait viewport must produce a framing position");
+		Require(glm::distance(portraitPosition, bounds.GetCenter()) >
+			glm::distance(landscapePosition, bounds.GetCenter()),
+			"a narrow viewport must frame the same bounds from farther away");
+	}
+
+	void TestCalculateFramedCameraPositionRejectsInvalidInput()
+	{
+		const Math::AABB bounds(glm::vec3(0.0f), glm::vec3(1.0f));
+		const Math::Transform cameraTransform{};
+		const glm::vec3 sentinel(4.0f, 5.0f, 6.0f);
+		glm::vec3 position = sentinel;
+
+		Require(!EditorViewport::TryCalculateFramedCameraPosition(
+			bounds,
+			cameraTransform,
+			0.0f,
+			1.0f,
+			0.1f,
+			position),
+			"a zero camera FOV must be rejected");
+		Require(AreVectorsNear(position, sentinel),
+			"rejected camera framing must leave its output unchanged");
+		Require(!EditorViewport::TryCalculateFramedCameraPosition(
+			bounds,
+			cameraTransform,
+			60.0f,
+			0.0f,
+			0.1f,
+			position),
+			"a zero camera aspect must be rejected");
+		Require(!EditorViewport::TryCalculateFramedCameraPosition(
+			Math::AABB{},
+			cameraTransform,
+			60.0f,
+			1.0f,
+			0.1f,
+			position),
+			"invalid target bounds must be rejected");
+	}
+
+	void TestTransformToolStateIsValidatedAtomically()
+	{
+		EditorViewport::EditorViewportController controller{};
+		Require(controller.GetOperation() == EditorViewport::ETransformOperation::Translate,
+			"the viewport controller must default to the translate tool");
+		Require(controller.GetSpace() == EditorViewport::ETransformSpace::World,
+			"the viewport controller must default to world space");
+		Require(controller.SetTransformToolState(
+			EditorViewport::ETransformOperation::Rotate,
+			EditorViewport::ETransformSpace::Local),
+			"a valid transform tool state must be accepted outside an active drag");
+		Require(controller.GetOperation() == EditorViewport::ETransformOperation::Rotate &&
+			controller.GetSpace() == EditorViewport::ETransformSpace::Local,
+			"accepted operation and space values must be applied together");
+
+		Require(!controller.SetTransformToolState(
+			static_cast<EditorViewport::ETransformOperation>(255),
+			EditorViewport::ETransformSpace::World),
+			"an unknown transform operation must be rejected");
+		Require(controller.GetOperation() == EditorViewport::ETransformOperation::Rotate &&
+			controller.GetSpace() == EditorViewport::ETransformSpace::Local,
+			"a rejected operation must leave the full tool state unchanged");
+		Require(!controller.SetTransformToolState(
+			EditorViewport::ETransformOperation::Scale,
+			static_cast<EditorViewport::ETransformSpace>(255)),
+			"an unknown transform space must be rejected");
+		Require(controller.GetOperation() == EditorViewport::ETransformOperation::Rotate &&
+			controller.GetSpace() == EditorViewport::ETransformSpace::Local,
+			"a rejected space must leave the full tool state unchanged");
+	}
+
+	void TestAssetDropEventUsesValidatedViewportQueue()
+	{
+		EditorViewport::EditorViewportController controller{};
+		controller.SetManagedMutationRevisions(17, 0);
+		Require(controller.QueueAssetDropEvent(
+			"00000000000000ab",
+			0.25f,
+			0.75f),
+			"a finite normalized native asset drop must enter the viewport queue");
+
+		std::string serializedEvent{};
+		Require(controller.PullEvent(serializedEvent),
+			"a queued native asset drop must be observable by the protocol bridge");
+		const YAML::Node event = YAML::Load(serializedEvent);
+		Require(event["kind"].as<std::string>() == "assetDrop",
+			"the viewport queue must identify native asset-drop events");
+		Require(event["revision"].as<uint64_t>() == 1,
+			"the first native asset drop must receive the first event revision");
+		Require(event["managedMutationRevision"].as<uint64_t>() == 17,
+			"native asset drops must carry the current managed mutation revision");
+		Require(event["fileId"].as<std::string>() == "00000000000000ab",
+			"native asset drops must preserve their source FileId");
+		Require(std::abs(event["normalizedX"].as<float>() - 0.25f) <= c_tolerance &&
+			std::abs(event["normalizedY"].as<float>() - 0.75f) <= c_tolerance,
+			"native asset drops must preserve normalized viewport coordinates");
+		Require(!controller.PullEvent(serializedEvent),
+			"pulling the only native asset drop must empty the viewport queue");
+
+		const float nan = std::numeric_limits<float>::quiet_NaN();
+		Require(!controller.QueueAssetDropEvent("", 0.5f, 0.5f),
+			"an empty native asset FileId must be rejected");
+		Require(!controller.QueueAssetDropEvent("asset", nan, 0.5f),
+			"a non-finite native asset-drop coordinate must be rejected");
+		Require(!controller.QueueAssetDropEvent("asset", -0.01f, 0.5f) &&
+			!controller.QueueAssetDropEvent("asset", 0.5f, 1.01f),
+			"native asset-drop coordinates outside the viewport must be rejected");
+		Require(!controller.PullEvent(serializedEvent),
+			"rejected native asset drops must not enter the viewport queue");
+
+		Require(controller.QueueAssetDropEvent("asset", 0.0f, 1.0f),
+			"native asset drops on inclusive viewport edges must be accepted");
+		Require(controller.PullEvent(serializedEvent),
+			"a second valid native asset drop must enter the queue");
+		Require(YAML::Load(serializedEvent)["revision"].as<uint64_t>() == 2,
+			"rejected native asset drops must not consume event revisions");
+	}
+
+	void TestToolShortcutEventUsesValidatedViewportQueue()
+	{
+		EditorViewport::EditorViewportController controller{};
+		controller.SetManagedMutationRevisions(23, 0);
+		const uint32_t supportedKeys[] = { 'Q', 'W', 'E', 'R', 'T' };
+		for (const uint32_t keyCode : supportedKeys)
+		{
+			Require(controller.QueueToolShortcutEvent(keyCode),
+				"supported Win32 viewport shortcuts must enter the viewport queue");
+		}
+		Require(!controller.QueueToolShortcutEvent('X') &&
+			!controller.QueueToolShortcutEvent('w'),
+			"unknown and non-canonical viewport shortcuts must be rejected");
+
+		std::string serializedEvent{};
+		for (size_t index = 0; index < std::size(supportedKeys); ++index)
+		{
+			Require(controller.PullEvent(serializedEvent),
+				"every queued viewport shortcut must remain observable");
+			const YAML::Node event = YAML::Load(serializedEvent);
+			Require(event["kind"].as<std::string>() == "toolShortcut",
+				"viewport shortcut events must use their dedicated event kind");
+			Require(event["revision"].as<uint64_t>() == index + 1,
+				"viewport shortcuts must share the ordered event revision stream");
+			Require(event["managedMutationRevision"].as<uint64_t>() == 23,
+				"viewport shortcuts must carry the current managed mutation revision");
+			Require(event["keyCode"].as<uint32_t>() == supportedKeys[index],
+				"viewport shortcut events must preserve the detected key code");
+		}
+		Require(!controller.PullEvent(serializedEvent),
+			"rejected viewport shortcuts must not enter the event queue");
+	}
+
 	void TestConvertWorldToLocalTransformUnderParent()
 	{
 		const Math::Transform parentTransform(
@@ -372,6 +664,16 @@ int main()
 		{ "BuildWorldRayRejectsInvalidViewport", TestBuildWorldRayRejectsInvalidViewport },
 		{ "PickNearestUsesDistance", TestPickNearestUsesDistance },
 		{ "PickNearestTreatsInsideBoundsAsZeroDistance", TestPickNearestTreatsInsideBoundsAsZeroDistance },
+		{ "ResolveDropPositionUsesNearestMeshBounds", TestResolveDropPositionUsesNearestMeshBounds },
+		{ "ResolveDropPositionUsesGroundPlane", TestResolveDropPositionUsesGroundPlane },
+		{ "ResolveDropPositionUsesFiniteForwardFallback", TestResolveDropPositionUsesFiniteForwardFallback },
+		{ "ResolveDropPositionRejectsInvalidRay", TestResolveDropPositionRejectsInvalidRay },
+		{ "CalculateFramedCameraPositionPreservesViewDirection", TestCalculateFramedCameraPositionPreservesViewDirection },
+		{ "CalculateFramedCameraPositionAccountsForViewportAspect", TestCalculateFramedCameraPositionAccountsForViewportAspect },
+		{ "CalculateFramedCameraPositionRejectsInvalidInput", TestCalculateFramedCameraPositionRejectsInvalidInput },
+			{ "TransformToolStateIsValidatedAtomically", TestTransformToolStateIsValidatedAtomically },
+			{ "AssetDropEventUsesValidatedViewportQueue", TestAssetDropEventUsesValidatedViewportQueue },
+			{ "ToolShortcutEventUsesValidatedViewportQueue", TestToolShortcutEventUsesValidatedViewportQueue },
 		{ "ConvertWorldToLocalTransformUnderParent", TestConvertWorldToLocalTransformUnderParent },
 		{ "ConvertWorldToLocalTransformRejectsSingularParent", TestConvertWorldToLocalTransformRejectsSingularParent },
 		{ "PickNearestBreaksTiesDeterministically", TestPickNearestBreaksTiesDeterministically },

--- a/Tests/win32_editor_asset_drop_contract_test.py
+++ b/Tests/win32_editor_asset_drop_contract_test.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+
+import pathlib
+import re
+import sys
+
+
+def extract_function(source: str, signature: str) -> str:
+    signature_offset = source.find(signature)
+    if signature_offset < 0:
+        raise AssertionError(f"Missing function: {signature}")
+
+    body_offset = source.find("{", signature_offset)
+    if body_offset < 0:
+        raise AssertionError(f"Missing function body: {signature}")
+
+    depth = 0
+    for offset in range(body_offset, len(source)):
+        if source[offset] == "{":
+            depth += 1
+        elif source[offset] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[body_offset:offset + 1]
+
+    raise AssertionError(f"Unterminated function body: {signature}")
+
+
+def require(text: str, fragment: str, message: str) -> None:
+    if fragment not in text:
+        raise AssertionError(message)
+
+
+def require_order(text: str, first: str, second: str, message: str) -> None:
+    first_offset = text.find(first)
+    second_offset = text.find(second)
+    if first_offset < 0 or second_offset < 0 or first_offset >= second_offset:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        raise SystemExit(
+            "usage: win32_editor_asset_drop_contract_test.py <repository root>"
+        )
+
+    repository = pathlib.Path(sys.argv[1]).resolve()
+    window_header = (
+        repository / "Runtime" / "Platform" / "Win32" / "Window.h"
+    ).read_text(encoding="utf-8")
+    window_source = (
+        repository / "Runtime" / "Platform" / "Win32" / "Window.cpp"
+    ).read_text(encoding="utf-8")
+    editor_source = (
+        repository / "Runtime" / "Submodules" / "Editor.cpp"
+    ).read_text(encoding="utf-8")
+    controller_source = (
+        repository / "Runtime" / "Editor" / "EditorViewportController.cpp"
+    ).read_text(encoding="utf-8")
+    managed_payload = (
+        repository / "Editor" / "Scene" / "SceneViewportAssetDropPayload.cs"
+    ).read_text(encoding="utf-8")
+    managed_scene = (
+        repository / "Editor" / "Views" / "SceneView.xaml.cs"
+    ).read_text(encoding="utf-8")
+    protocol_schema = (
+        repository / "Protocol" / "editor_engine.proto"
+    ).read_text(encoding="utf-8")
+    protocol_bridge = (
+        repository / "Lib" / "EditorEngineProtocol.cpp"
+    ).read_text(encoding="utf-8")
+    dll_surfaces = "\n".join(
+        source.read_text(encoding="utf-8")
+        for source in sorted((repository / "Lib").glob("*.cpp"))
+    )
+
+    prefix_pattern = re.compile(
+        r'c_editorAssetDropPrefix\s*=\s*L"SailorEditor\.Asset:"'
+    )
+    if not prefix_pattern.search(window_source):
+        raise AssertionError(
+            "Win32 OLE drops must use the generic SailorEditor.Asset: prefix"
+        )
+    require(
+        managed_payload,
+        'public const string Prefix = "SailorEditor.Asset:";',
+        "managed and native asset-drop payload prefixes must match",
+    )
+    require(
+        window_source,
+        "c_unbracedFileIdLength = 36",
+        "native OLE drops must accept repository FileIds created on macOS/Linux",
+    )
+    require(
+        window_source,
+        "c_bracedFileIdLength = 38",
+        "native OLE drops must accept repository FileIds created on Windows",
+    )
+    require(
+        managed_payload,
+        "public const int UnbracedFileIdLength = 36;",
+        "managed payloads must accept repository FileIds created on macOS/Linux",
+    )
+    require(
+        managed_payload,
+        "public const int BracedFileIdLength = 38;",
+        "managed payloads must accept repository FileIds created on Windows",
+    )
+    native_file_id_validation = extract_function(
+        window_source,
+        "bool IsSerializedFileId(",
+    )
+    require(
+        native_file_id_validation,
+        "fileId.size() == c_bracedFileIdLength",
+        "native payload validation must recognize braced FileIds",
+    )
+    require(
+        native_file_id_validation,
+        "fileId.size() != c_unbracedFileIdLength",
+        "native payload validation must recognize unbraced FileIds",
+    )
+    if "SailorEditor.Model:" in window_source or "SailorEditor.Prefab:" in window_source:
+        raise AssertionError(
+            "the Win32 OLE target must not use type-specific asset prefixes"
+        )
+
+    require(
+        window_header,
+        "void QueueEditorViewportAssetDrop(",
+        "Window must own the native asset-drop queue entrypoint",
+    )
+    require(
+        window_header,
+        "bool PullEditorViewportAssetDrop(",
+        "Window must own the native asset-drop dequeue entrypoint",
+    )
+    require(
+        window_header,
+        "m_editorViewportAssetDropMutex",
+        "Window asset-drop handoff must be synchronized",
+    )
+    require(
+        window_header,
+        "m_pendingEditorViewportAssetDrop",
+        "Window must retain the pending native asset drop",
+    )
+    if re.search(
+        r"SAILOR_(?:SHARED_)?API\s+(?:void|bool)\s+"
+        r"(?:Queue|Pull)EditorViewportAssetDrop",
+        window_header,
+    ):
+        raise AssertionError(
+            "Window asset-drop queue methods must remain internal, not DLL exports"
+        )
+
+    for forbidden in (
+        "QueueEditorViewportAssetDrop",
+        "PullEditorViewportAssetDrop",
+        "QueueEditorViewportToolShortcut",
+        "PullEditorViewportToolShortcut",
+        "SailorEditor.Asset:",
+    ):
+        if forbidden in dll_surfaces:
+            raise AssertionError(
+                "Win32 asset-drop handoff must not add a direct DLL/extern surface"
+            )
+
+    queue = extract_function(
+        window_source,
+        "void Window::QueueEditorViewportAssetDrop(",
+    )
+    pull = extract_function(
+        window_source,
+        "bool Window::PullEditorViewportAssetDrop(",
+    )
+    require(
+        queue,
+        "m_editorViewportAssetDropMutex",
+        "queue writes must hold the Window asset-drop mutex",
+    )
+    require(
+        queue,
+        "m_pendingEditorViewportAssetDrop = EditorViewportAssetDrop",
+        "queue writes must publish one complete asset-drop record",
+    )
+    require(
+        pull,
+        "m_editorViewportAssetDropMutex",
+        "queue reads must hold the Window asset-drop mutex",
+    )
+    require(
+        pull,
+        "m_pendingEditorViewportAssetDrop.reset();",
+        "pulling an asset drop must consume the pending record",
+    )
+
+    tick_viewport_tools = extract_function(
+        editor_source,
+        "void Editor::TickViewportTools()",
+    )
+    require_order(
+        tick_viewport_tools,
+        "PullEditorViewportAssetDrop(",
+        "QueueAssetDropEvent(",
+        "the engine worker must pull Window drops before publishing viewport events",
+    )
+
+    require(
+        window_header,
+        "void QueueEditorViewportToolShortcut(uint32_t keyCode);",
+        "Window must own the native viewport shortcut queue entrypoint",
+    )
+    require(
+        window_header,
+        "bool PullEditorViewportToolShortcut(uint32_t& outKeyCode);",
+        "Window must own the native viewport shortcut dequeue entrypoint",
+    )
+    if re.search(
+        r"SAILOR_(?:SHARED_)?API\s+(?:void|bool)\s+"
+        r"(?:Queue|Pull)EditorViewportToolShortcut",
+        window_header,
+    ):
+        raise AssertionError(
+            "Window viewport shortcut queue methods must remain internal"
+        )
+
+    shortcut_queue = extract_function(
+        window_source,
+        "void Window::QueueEditorViewportToolShortcut(",
+    )
+    shortcut_pull = extract_function(
+        window_source,
+        "bool Window::PullEditorViewportToolShortcut(",
+    )
+    require(
+        shortcut_queue,
+        "m_editorViewportToolShortcutMutex",
+        "viewport shortcut queue writes must be synchronized",
+    )
+    require(
+        shortcut_pull,
+        "m_editorViewportToolShortcutMutex",
+        "viewport shortcut queue reads must be synchronized",
+    )
+    require(
+        shortcut_pull,
+        "m_pendingEditorViewportToolShortcuts.RemoveAt(0);",
+        "pulling a viewport shortcut must consume it",
+    )
+    require(
+        window_source,
+        "(lParam & 0x40000000) == 0",
+        "Win32 key repeat must not emit repeated tool shortcut events",
+    )
+    require_order(
+        tick_viewport_tools,
+        "PullEditorViewportToolShortcut(",
+        "QueueToolShortcutEvent(",
+        "the engine worker must publish native shortcuts through the viewport event queue",
+    )
+    require(
+        controller_source,
+        'event["kind"] = "toolShortcut";',
+        "the controller must publish a dedicated native tool-shortcut event",
+    )
+    require(
+        protocol_schema,
+        "message ViewportToolShortcutEvent {",
+        "the editor protocol must define a typed viewport tool-shortcut event",
+    )
+    require(
+        protocol_schema,
+        "ViewportToolShortcutEvent tool_shortcut = 13;",
+        "the typed viewport tool shortcut must use the additive payload tag 13",
+    )
+    require(
+        protocol_bridge,
+        "outEvent.mutable_tool_shortcut()->set_key_code(keyCode);",
+        "the native protocol bridge must type the shortcut payload",
+    )
+    require(
+        managed_scene,
+        "case EditorViewportToolShortcutEvent shortcutEvent:",
+        "SceneView must consume the typed viewport shortcut event",
+    )
+    require(
+        managed_scene,
+        "await ApplyViewportToolStateSafelyAsync(shortcutState);",
+        "SceneView must apply native shortcuts through the async protocol RPC",
+    )
+    safe_tool_state_apply = extract_function(
+        managed_scene,
+        "async Task ApplyViewportToolStateSafelyAsync(",
+    )
+    if safe_tool_state_apply.count("await RefreshViewportToolStateAsync();") != 2:
+        raise AssertionError(
+            "rejected and exceptional toolbar updates must both reconcile against engine state"
+        )
+    require_order(
+        safe_tool_state_apply[:safe_tool_state_apply.find("catch (Exception ex)")],
+        "if (!await ApplyViewportToolStateAsync(",
+        "await RefreshViewportToolStateAsync();",
+        "rejected toolbar updates must reconcile after the failed RPC",
+    )
+    require_order(
+        safe_tool_state_apply[safe_tool_state_apply.find("catch (Exception ex)"):],
+        "catch (Exception ex)",
+        "await RefreshViewportToolStateAsync();",
+        "exceptional toolbar updates must reconcile after logging the exception",
+    )
+
+    register = extract_function(
+        window_source,
+        "void RegisterEditorViewportDropTarget(",
+    )
+    revoke = extract_function(
+        window_source,
+        "void RevokeEditorViewportDropTarget(",
+    )
+    create = extract_function(window_source, "bool Window::Create(")
+    destroy = extract_function(window_source, "void Window::Destroy()")
+
+    require_order(
+        register,
+        "OleInitialize(nullptr)",
+        "RegisterDragDrop(",
+        "OLE must initialize before registering the viewport drop target",
+    )
+    require(
+        register,
+        "OleUninitialize();",
+        "failed drop-target registration must balance OLE initialization",
+    )
+    require(
+        create,
+        "m_parentHwnd &&",
+        "only embedded editor windows may register the OLE drop target",
+    )
+    require(
+        create,
+        'm_windowClassName.starts_with("SailorEditor")',
+        "OLE registration must be limited to Sailor editor viewport windows",
+    )
+    require(
+        create,
+        "RegisterEditorViewportDropTarget(",
+        "Window creation must register the editor viewport drop target",
+    )
+    require_order(
+        revoke,
+        "RevokeDragDrop(",
+        "dropTarget->Release();",
+        "drop-target revocation must precede releasing the COM object",
+    )
+    require_order(
+        revoke,
+        "dropTarget->Release();",
+        "OleUninitialize();",
+        "OLE teardown must release the registered target before uninitializing",
+    )
+    require_order(
+        destroy,
+        "RevokeEditorViewportDropTarget(",
+        "DestroyWindow(",
+        "Window destruction must revoke OLE registration before destroying the HWND",
+    )
+
+    print("Win32 editor asset-drop contract passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add model/prefab drag-and-drop into the viewport and hierarchy, plus hierarchy focus and GameObject-to-prefab workflows
- add editor-hosted transform gizmo tools and shortcuts through typed WebSocket/protobuf operations
- persist linked prefab identity, overrides, source evolution, supplemental children, strict snapshot restore, and exact undo/redo recovery
- add Win32 child-window OLE drop routing and preserve legacy native ABI overloads
- keep ordinary RPCs on protocol v1 while gating strict instance-ID restore behind negotiated v2 capability

## Safety and compatibility

- prefab writes are transactional and temporary `.sailor-*.pending` files are excluded from asset discovery
- strict restore validates hierarchy IDs, component IDs, parent, source/live aliases, and collisions before mutation
- old hosts fail closed before strict mutations; existing non-strict clients and native overloads remain supported

## Validation

- native Debug: 30/30 CTest
- native Release: 30/30 CTest
- managed contracts Debug and Release: 687/687
- Xcode SailorLib Debug and Release: build succeeded
- MAUI Mac Catalyst arm64 Debug and Release: build succeeded
- Win32 editor asset-drop source contract: passed
- generated C++/C# protocol sources: exact
- live Release smoke: Engine mode and workspace mode, three WebSocket clients connected in each mode
- independent tech review and portability/protocol review: approved

Closes #125