### PR TITLE
Harden editor prefab and scene workflows

### DIFF
--- a/Editor.Tests/EditorViewportEventContractTests.cs
+++ b/Editor.Tests/EditorViewportEventContractTests.cs
@@ -424,6 +424,33 @@ public sealed class EditorViewportEventContractTests
     }
 
     [Fact]
+    public void ToolShortcutKeys_AlsoReachRuntimeCameraInput()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "SceneView.xaml.cs");
+        var inputHandler = Slice(
+            source,
+            "async Task<NativeViewportInputDispatchResult> ProcessNativeViewportInputAsync(",
+            "void SubscribeToEngineLifecycle()");
+        var shortcutBlock = Slice(
+            inputHandler,
+            "if (input.Kind == NativeSceneViewportInputKind.Key &&",
+            "if (input.Kind ==\n                    NativeSceneViewportInputKind.PointerButton");
+
+        AssertInOrder(
+            inputHandler,
+            "SceneViewportToolShortcuts.TryApply(",
+            "ApplyViewportToolStateAsync(",
+            "viewportAdapter.SendInput(");
+        Assert.DoesNotContain(
+            "return NativeViewportInputDispatchResult.Forwarded;",
+            shortcutBlock,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void NativeInputQueue_ResetsAcrossViewAndBackendLifecycle()
     {
         var source = ReadRepositoryFile("Editor", "Views", "SceneView.xaml.cs");

--- a/Editor.Tests/EngineProtocolClientTests.cs
+++ b/Editor.Tests/EngineProtocolClientTests.cs
@@ -719,7 +719,7 @@ public sealed class EngineProtocolClientTests
                 requests.Add(request);
                 return request.CommandCase switch
                 {
-                    ProtocolRequest.CommandOneofCase.ResolveViewportDropPosition =>
+                    ProtocolRequest.CommandOneofCase.TraceViewportRay =>
                         Success(
                             request,
                             response => response.Vector4Result =
@@ -733,7 +733,6 @@ public sealed class EngineProtocolClientTests
                                         W = 1
                                     }
                                 }),
-                    ProtocolRequest.CommandOneofCase.CreateModelGameObject or
                     ProtocolRequest.CommandOneofCase.InstantiatePrefabInstance =>
                         Success(
                             request,
@@ -764,15 +763,10 @@ public sealed class EngineProtocolClientTests
 
         Assert.Equal(
             new EngineProtocolVector4(1, 2, 3, 1),
-            await client.ResolveViewportDropPositionAsync(
+            await client.TraceViewportRayAsync(
                 1,
                 0.25f,
                 0.75f));
-        Assert.True((await client.CreateModelGameObjectAsync(
-            "{MODEL}",
-            "Duck",
-            "parent",
-            new EngineProtocolVector4(4, 5, 6, 1))).Succeeded);
         Assert.True((await client.InstantiatePrefabInstanceAsync(
             "{PREFAB}",
             string.Empty,
@@ -795,23 +789,11 @@ public sealed class EngineProtocolClientTests
             request =>
             {
                 Assert.Equal(
-                    ProtocolRequest.CommandOneofCase.ResolveViewportDropPosition,
+                    ProtocolRequest.CommandOneofCase.TraceViewportRay,
                     request.CommandCase);
-                Assert.Equal(1ul, request.ResolveViewportDropPosition.ViewportId);
-                Assert.Equal(0.25f, request.ResolveViewportDropPosition.NormalizedX);
-                Assert.Equal(0.75f, request.ResolveViewportDropPosition.NormalizedY);
-            },
-            request =>
-            {
-                Assert.Equal(
-                    ProtocolRequest.CommandOneofCase.CreateModelGameObject,
-                    request.CommandCase);
-                Assert.Equal("{MODEL}", request.CreateModelGameObject.ModelFileId);
-                Assert.Equal("Duck", request.CreateModelGameObject.Name);
-                Assert.Equal("parent", request.CreateModelGameObject.ParentInstanceId);
-                Assert.True(request.CreateModelGameObject.ApplyWorldPosition);
-                Assert.NotNull(request.CreateModelGameObject.WorldPosition);
-                Assert.Equal(4f, request.CreateModelGameObject.WorldPosition.X);
+                Assert.Equal(1ul, request.TraceViewportRay.ViewportId);
+                Assert.Equal(0.25f, request.TraceViewportRay.NormalizedX);
+                Assert.Equal(0.75f, request.TraceViewportRay.NormalizedY);
             },
             request =>
             {
@@ -850,7 +832,6 @@ public sealed class EngineProtocolClientTests
             [
                 EngineProtocolInvocationKind.Interactive,
                 EngineProtocolInvocationKind.Request,
-                EngineProtocolInvocationKind.Request,
                 EngineProtocolInvocationKind.Interactive,
                 EngineProtocolInvocationKind.Request,
                 EngineProtocolInvocationKind.Request,
@@ -865,7 +846,7 @@ public sealed class EngineProtocolClientTests
     [InlineData(0.5f, float.PositiveInfinity)]
     [InlineData(-0.01f, 0.5f)]
     [InlineData(0.5f, 1.01f)]
-    public async Task ViewportDropPosition_RejectsInvalidCoordinates(
+    public async Task ViewportRay_RejectsInvalidCoordinates(
         float normalizedX,
         float normalizedY)
     {
@@ -880,7 +861,7 @@ public sealed class EngineProtocolClientTests
         });
 
         await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
-            client.ResolveViewportDropPositionAsync(
+            client.TraceViewportRayAsync(
                 1,
                 normalizedX,
                 normalizedY));

--- a/Editor.Tests/UiAsyncExceptionSafetyContractTests.cs
+++ b/Editor.Tests/UiAsyncExceptionSafetyContractTests.cs
@@ -114,7 +114,7 @@ public sealed class UiAsyncExceptionSafetyContractTests
     }
 
     [Fact]
-    public void ContentDropHandlers_ObserveAsyncFailures()
+    public void ContentHandlersAndContextCommands_ObserveAsyncFailures()
     {
         var contentSource = ReadRepositoryFile(
             "Editor",
@@ -129,10 +129,29 @@ public sealed class UiAsyncExceptionSafetyContractTests
             "Drop += async",
             contentSource,
             StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "async void OnContentSelectionChanged",
+            contentSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Tapped += async",
+            contentSource,
+            StringComparison.Ordinal);
+        var contextMenu = Slice(
+            contentSource,
+            "void ShowContextMenu(object model)",
+            "static Command CreateContentContextMenuCommand(");
+        Assert.DoesNotMatch(
+            @"new\s+Command\s*\(\s*async",
+            contextMenu);
+        Assert.True(
+            CountOccurrences(
+                contextMenu,
+                "Command = CreateContentContextMenuCommand(") >= 7);
         Assert.True(
             CountOccurrences(
                 contentSource,
-                "RunContentUiAction(") >= 3);
+                "RunContentUiAction(") >= 4);
         AssertInOrder(
             helper,
             "try",

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -152,6 +152,67 @@ public sealed class WorkflowProjectionTests
     }
 
     [Fact]
+    public void HierarchySelectPrefab_OpensContentAndSelectsProjectedAsset()
+    {
+        var hierarchySource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "HierarchyView.xaml.cs");
+        var contentSource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "ContentFolderView.xaml.cs");
+        var assetCommandsSource = ReadRepositoryFile(
+            "Editor",
+            "Commands",
+            "EditorAssetCommands.cs");
+        var hierarchyMenu = Slice(
+            hierarchySource,
+            "MenuFlyout CreateHierarchyContextFlyout(",
+            "static Command CreateContextMenuCommand(");
+        var selectPrefab = Slice(
+            hierarchySource,
+            "async Task SelectPrefabAsync(",
+            "static async Task ExecuteHierarchyActionAsync(");
+        var contentSelection = Slice(
+            contentSource,
+            "void SelectAssetFile(",
+            "void OnContentSelectionChanged(");
+        var openAssetCommand = Slice(
+            assetCommandsSource,
+            "public sealed class OpenAssetCommand",
+            "public sealed class RenameAssetCommand");
+
+        AssertInOrder(
+            hierarchyMenu,
+            "IsPrefabLinked: true",
+            "!string.IsNullOrWhiteSpace(row.PrefabFileId)",
+            "Text = \"Select Prefab\"",
+            "() => SelectPrefabAsync(row.PrefabFileId)",
+            "PrefabRootInstanceId: not null",
+            "Text = \"Break Prefab Link\"");
+        AssertInOrder(
+            selectPrefab,
+            "new FileId(prefabFileId)",
+            ".Assets.TryGetValue(fileId, out var asset)",
+            "asset is not PrefabFile prefab",
+            ".OpenPanelAsync(KnownPanelTypes.Content)",
+            "new OpenAssetCommand(prefab)");
+        Assert.Contains(
+            "OnSelectAssetAction += SelectAssetFile",
+            contentSource,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            contentSelection,
+            "EnsureFolderVisible(file.FolderId);",
+            "contentStore.SelectAsset(file);");
+        Assert.Contains(
+            "SelectObject(assetFile, force: true)",
+            openAssetCommand,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void HierarchyProjection_NestsLinkedRootUnderExternalParent()
     {
         var roots = HierarchyProjectionBuilder.Build(
@@ -313,6 +374,140 @@ public sealed class WorkflowProjectionTests
         Assert.Empty(actions);
         Assert.Same(selectedRow, rows.Single(row => row.IsSelected));
     }
+
+    [Fact]
+    public void ContentRows_AddReorderAndRemoveWithoutResetOrEmptyProjection()
+    {
+        var first = new ContentProjectionTestRow("a", "A");
+        var second = new ContentProjectionTestRow("b", "B");
+        var rows = new ObservableCollection<ContentProjectionTestRow>
+        {
+            first,
+            second,
+        };
+        var actions = new List<NotifyCollectionChangedAction>();
+        var observedCounts = new List<int>();
+        rows.CollectionChanged += (_, args) =>
+        {
+            actions.Add(args.Action);
+            observedCounts.Add(rows.Count);
+        };
+
+        ContentProjectionTestRow[] withPrefab =
+        [
+            first,
+            new("prefab", "Prefab"),
+            second,
+        ];
+        ContentRowReconciler.Reconcile(
+            rows,
+            withPrefab,
+            row => row.Id);
+
+        Assert.Equal(
+            ["a", "prefab", "b"],
+            rows.Select(row => row.Id));
+        Assert.Same(first, rows[0]);
+        Assert.Same(second, rows[2]);
+        Assert.DoesNotContain(
+            NotifyCollectionChangedAction.Reset,
+            actions);
+        Assert.DoesNotContain(0, observedCounts);
+
+        actions.Clear();
+        observedCounts.Clear();
+        ContentRowReconciler.Reconcile(
+            rows,
+            [
+                first,
+                second,
+            ],
+            row => row.Id);
+
+        Assert.Equal(
+            [NotifyCollectionChangedAction.Remove],
+            actions);
+        Assert.Equal(
+            ["a", "b"],
+            rows.Select(row => row.Id));
+        Assert.DoesNotContain(0, observedCounts);
+
+        actions.Clear();
+        observedCounts.Clear();
+        ContentRowReconciler.Reconcile(
+            rows,
+            [
+                new("b", "B updated"),
+                new("a", "A"),
+            ],
+            row => row.Id);
+
+        Assert.Equal(
+            ["b", "a"],
+            rows.Select(row => row.Id));
+        Assert.Equal("B updated", rows[0].Label);
+        Assert.DoesNotContain(
+            NotifyCollectionChangedAction.Reset,
+            actions);
+        Assert.DoesNotContain(0, observedCounts);
+    }
+
+    [Fact]
+    public void ContentRefresh_ClearsInvalidNativeSelectionBeforeRemovingRows()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "ContentFolderView.xaml.cs");
+        var populateRows = Slice(
+            source,
+            "void PopulateRows(ProjectContentProjection projection)",
+            "void AppendChildren(");
+
+        AssertInOrder(
+            populateRows,
+            "var currentSelectedRow =",
+            "suppressSelectionChanged = true;",
+            "ContentList.SelectedItem = null;",
+            "ContentRowReconciler.Reconcile(",
+            "ContentList.SelectedItem =",
+            "suppressSelectionChanged = false;");
+    }
+
+    [Fact]
+    public void ContentContextMenuActions_ReportAsyncFailures()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "ContentFolderView.xaml.cs");
+        var contextMenu = Slice(
+            source,
+            "void ShowContextMenu(object model)",
+            "static Command CreateContentContextMenuCommand(");
+
+        Assert.DoesNotContain(
+            "new Command(async",
+            contextMenu,
+            StringComparison.Ordinal);
+        Assert.True(
+            CountOccurrences(
+                contextMenu,
+                "CreateContentContextMenuCommand(") >= 7,
+            "Every Content context-menu action must use the exception-safe async wrapper.");
+        Assert.Contains(
+            "RunContentUiAction(",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "catch (Exception exception)",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    sealed record ContentProjectionTestRow(
+        string Id,
+        string Label);
 
     [Fact]
     public void InspectorSelectionIdentity_UsesStableValueIdentity()
@@ -607,11 +802,11 @@ public sealed class WorkflowProjectionTests
             destroyCommand,
             StringComparison.Ordinal);
         Assert.Contains(
-            "DestroyObjectAsync(\n                rootInstanceId,",
+            "RequestDestroyObjectAsync(",
             ownedRollback,
             StringComparison.Ordinal);
         Assert.Contains(
-            "RefreshCurrentWorldAsync(",
+            "RefreshAndCheckRootAbsentAsync(",
             ownedRollback,
             StringComparison.Ordinal);
         Assert.DoesNotContain(
@@ -903,6 +1098,10 @@ public sealed class WorkflowProjectionTests
             source,
             "sealed class CreatedHierarchySnapshot",
             "public sealed class CreateModelGameObjectCommand");
+        var createdState = Slice(
+            source,
+            "sealed class CreatedHierarchyCommandState",
+            "public sealed class CreateModelGameObjectCommand");
         var modelCommand = Slice(
             source,
             "public sealed class CreateModelGameObjectCommand",
@@ -970,6 +1169,97 @@ public sealed class WorkflowProjectionTests
             StringComparison.Ordinal);
         Assert.Contains(
             "public ValueTask<CommandResult> UndoAsync(",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RefreshAndClassifyAsync(",
+            createdState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RequestDestroyObjectAsync(",
+            createdState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "postMutation.Projection !=" +
+            "\n            AuthoritativeHierarchyProjection.Absent",
+            createdState,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Created hierarchy was already absent; undo reconciled without another mutation.",
+            createdState,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            modelCommand,
+            "CreateGameObjectAsync(",
+            "AddComponentAsync(",
+            "CommitChangesAsync(",
+            "CommitChangesAsync(",
+            "RefreshCurrentWorldAuthoritativelyAsync(");
+        Assert.Contains(
+            "\"Sailor::MeshRendererComponent\"",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "new ObjectPtr",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "new FileId(_modelFileId.Value)",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "OwnedHierarchyRollback.EnsureAbsentAsync(",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RandomNumberGenerator.GetBytes(10)",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RandomNumberGenerator.GetBytes(8)",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "initialParentId,\n" +
+            "                _ownedGameObjectId,",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "MeshRendererComponentTypeName,\n" +
+            "                ownedComponentId,",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RefreshAndCheckRootAbsentAsync(",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "MatchesFinalProjection(",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "TryResolveWorldPosition(",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "world.ResolveParentInstanceId(gameObject)",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "model.FileId.Value,\n" +
+            "                _modelFileId.Value",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "rollback could not confirm owned GameObject",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "projectedComponents.Count != 1",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "CreateModelGameObjectAsync(",
             modelCommand,
             StringComparison.Ordinal);
         Assert.Contains(
@@ -1073,7 +1363,7 @@ public sealed class WorkflowProjectionTests
             "HierarchyView.xaml.cs");
         var prefabDrop = Slice(
             contentSource,
-            "if (command is CreatePrefabAssetCommand)",
+            "e.Handled = true;",
             "var context = contextProvider.GetCurrentContext");
         var focus = Slice(
             hierarchySource,
@@ -1082,6 +1372,8 @@ public sealed class WorkflowProjectionTests
 
         AssertInOrder(
             prefabDrop,
+            "e.Handled = true;",
+            "await Task.Yield();",
             "CommitPendingChangesAsync()",
             "EditorDragDrop.TryCreateContentDropCommand(");
         AssertInOrder(
@@ -1089,6 +1381,37 @@ public sealed class WorkflowProjectionTests
             "CommitPendingChangesAsync()",
             "gameObjectsById.TryGetValue(",
             "new FocusEditorCameraCommand(");
+    }
+
+    [Fact]
+    public void HierarchyRowGestures_SelectOnSingleTapAndSelectBeforeDoubleTapFocus()
+    {
+        var hierarchySource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "HierarchyView.xaml.cs");
+        var selection = Slice(
+            hierarchySource,
+            "async Task SelectHierarchyRowAsync(",
+            "async void OnHierarchyRootDrop(");
+        var gestures = Slice(
+            hierarchySource,
+            "var selectGesture = new TapGestureRecognizer",
+            "border.BindingContextChanged +=");
+
+        AssertInOrder(
+            selection,
+            "updateCollectionSelection",
+            "SetHierarchySelection(row);",
+            "new SelectObjectCommand(selectedObject: gameObject)");
+        AssertInOrder(
+            gestures,
+            "NumberOfTapsRequired = 1",
+            "SelectHierarchyRowAsync(",
+            "updateCollectionSelection: true",
+            "NumberOfTapsRequired = 2",
+            "SelectHierarchyRowAsync(",
+            "FocusGameObjectAsync(row)");
     }
 
     static void AssertCommitClearsDirtyBeforeDispatch(string source)

--- a/Editor/Commands/EditorWorldCommands.cs
+++ b/Editor/Commands/EditorWorldCommands.cs
@@ -4,6 +4,8 @@ using SailorEditor.Services;
 using SailorEditor.Utility;
 using SailorEditor.ViewModels;
 using SailorEngine;
+using System.Numerics;
+using System.Security.Cryptography;
 using YamlDotNet.Serialization;
 
 namespace SailorEditor.Commands;
@@ -465,54 +467,143 @@ sealed class CreatedHierarchySnapshot
                     StringComparison.Ordinal)) == true;
 }
 
+static class AuthoritativeHierarchyReconciliation
+{
+    public static async Task<(
+        AuthoritativeHierarchyProjection Projection,
+        string? Diagnostic)> RefreshAndClassifyAsync(
+        EngineService engine,
+        WorldService world,
+        CreatedHierarchySnapshot snapshot,
+        InstanceId? parentId)
+    {
+        try
+        {
+            if (!await engine.RefreshCurrentWorldAuthoritativelyAsync(
+                    CancellationToken.None))
+            {
+                return (
+                    AuthoritativeHierarchyProjection.Unavailable,
+                    "authoritative refresh was not published");
+            }
+
+            return (
+                snapshot.ClassifyProjection(world, parentId),
+                null);
+        }
+        catch (Exception exception)
+        {
+            return (
+                AuthoritativeHierarchyProjection.Unavailable,
+                exception.Message);
+        }
+    }
+
+    public static async Task<(
+        bool Available,
+        bool RootAbsent,
+        string? Diagnostic)> RefreshAndCheckRootAbsentAsync(
+        EngineService engine,
+        WorldService world,
+        InstanceId rootInstanceId)
+    {
+        try
+        {
+            if (!await engine.RefreshCurrentWorldAuthoritativelyAsync(
+                    CancellationToken.None))
+            {
+                return (
+                    false,
+                    false,
+                    "authoritative refresh was not published");
+            }
+
+            return (
+                true,
+                !world.TryGetGameObject(rootInstanceId, out _),
+                null);
+        }
+        catch (Exception exception)
+        {
+            return (false, false, exception.Message);
+        }
+    }
+}
+
 static class OwnedHierarchyRollback
 {
+    public static async Task<(
+        bool ConfirmedAbsent,
+        string? Diagnostic)> EnsureAbsentAsync(
+        EngineService engine,
+        WorldService world,
+        InstanceId rootInstanceId)
+    {
+        var probe =
+            await AuthoritativeHierarchyReconciliation
+                .RefreshAndCheckRootAbsentAsync(
+                    engine,
+                    world,
+                    rootInstanceId);
+        if (probe.Available && probe.RootAbsent)
+        {
+            return (true, null);
+        }
+
+        var diagnostic = probe.Diagnostic;
+        for (var attempt = 0; attempt < 2; attempt++)
+        {
+            try
+            {
+                if (!await engine.RequestDestroyObjectAsync(
+                        rootInstanceId,
+                        CancellationToken.None))
+                {
+                    diagnostic =
+                        "the engine rejected the exact-root destroy request";
+                }
+            }
+            catch (Exception exception)
+            {
+                diagnostic = exception.Message;
+            }
+
+            probe =
+                await AuthoritativeHierarchyReconciliation
+                    .RefreshAndCheckRootAbsentAsync(
+                        engine,
+                        world,
+                        rootInstanceId);
+            if (probe.Available && probe.RootAbsent)
+            {
+                return (true, null);
+            }
+
+            diagnostic ??= probe.Diagnostic;
+        }
+
+        return (false, diagnostic);
+    }
+
     public static async Task<CommandResult> FailureAsync(
         EngineService engine,
         WorldService world,
         InstanceId rootInstanceId,
         string failureMessage)
     {
-        string? cleanupDiagnostic = null;
-        var destroyed = false;
-        try
-        {
-            destroyed = await engine.DestroyObjectAsync(
-                rootInstanceId,
-                CancellationToken.None);
-        }
-        catch (Exception exception)
-        {
-            cleanupDiagnostic =
-                $"exact-root destroy failed: {exception.Message}";
-        }
-
-        if (destroyed &&
-            !world.TryGetGameObject(rootInstanceId, out _))
+        var cleanup = await EnsureAbsentAsync(
+            engine,
+            world,
+            rootInstanceId);
+        if (cleanup.ConfirmedAbsent)
         {
             return CommandResult.Failure(failureMessage);
         }
 
-        try
-        {
-            await engine.RefreshCurrentWorldAsync(
-                CancellationToken.None);
-            if (!world.TryGetGameObject(rootInstanceId, out _))
-            {
-                return CommandResult.Failure(failureMessage);
-            }
-        }
-        catch (Exception exception)
-        {
-            cleanupDiagnostic = cleanupDiagnostic is null
-                ? $"exact-root verification failed: {exception.Message}"
-                : $"{cleanupDiagnostic}; exact-root verification failed: {exception.Message}";
-        }
-
         return CommandResult.Failure(
-            cleanupDiagnostic is null
+            string.IsNullOrWhiteSpace(cleanup.Diagnostic)
                 ? $"{failureMessage}; exact-root rollback could not be confirmed"
-                : $"{failureMessage}; exact-root rollback could not be confirmed ({cleanupDiagnostic})");
+                : $"{failureMessage}; exact-root rollback could not be confirmed ({cleanup.Diagnostic})");
     }
 }
 
@@ -810,33 +901,78 @@ sealed class CreatedHierarchyCommandState(
 
         var engine = MauiProgram.GetService<EngineService>();
         var world = MauiProgram.GetService<WorldService>();
-        if (!world.TryGetGameObject(_snapshot.RootInstanceId, out _))
+        var preflight =
+            await AuthoritativeHierarchyReconciliation
+                .RefreshAndClassifyAsync(
+                    engine,
+                    world,
+                    _snapshot,
+                    _parentId);
+        if (preflight.Projection ==
+            AuthoritativeHierarchyProjection.Unavailable)
         {
             return CommandResult.Failure(
-                "Created hierarchy root was not found");
+                $"Destroy created hierarchy failed: authoritative preflight refresh failed{FormatDiagnostic(preflight.Diagnostic)}");
         }
-
-        if (!await engine.DestroyObjectAsync(
-                _snapshot.RootInstanceId,
-                CancellationToken.None))
+        if (preflight.Projection ==
+            AuthoritativeHierarchyProjection.Mismatch)
         {
             return CommandResult.Failure(
-                "Destroy created hierarchy failed");
+                "Destroy created hierarchy failed: the authoritative hierarchy no longer matches the saved snapshot");
+        }
+        if (preflight.Projection ==
+            AuthoritativeHierarchyProjection.Absent)
+        {
+            ClearSelectionIfOwned(_snapshot);
+            return CommandResult.Success(
+                "Created hierarchy was already absent; undo reconciled without another mutation.");
         }
 
-        if (!_snapshot.IsAbsent(world))
+        var response = EngineMutationResponseState.Unknown;
+        string? requestDiagnostic = null;
+        try
         {
+            response = await engine.RequestDestroyObjectAsync(
+                    _snapshot.RootInstanceId,
+                    CancellationToken.None)
+                ? EngineMutationResponseState.Accepted
+                : EngineMutationResponseState.Rejected;
+        }
+        catch (Exception exception)
+        {
+            requestDiagnostic = exception.Message;
+        }
+
+        var postMutation =
+            await AuthoritativeHierarchyReconciliation
+                .RefreshAndClassifyAsync(
+                    engine,
+                    world,
+                    _snapshot,
+                    _parentId);
+        if (postMutation.Projection !=
+            AuthoritativeHierarchyProjection.Absent)
+        {
+            var responseDescription = response switch
+            {
+                EngineMutationResponseState.Accepted =>
+                    "the engine accepted destroy",
+                EngineMutationResponseState.Rejected =>
+                    "the engine rejected destroy",
+                _ => "the destroy response was lost"
+            };
             return CommandResult.Failure(
-                "Destroyed hierarchy is still present in the projection");
+                $"Destroy created hierarchy could not be confirmed absent ({responseDescription})" +
+                FormatDiagnostics(
+                    requestDiagnostic,
+                    postMutation.Diagnostic));
         }
 
-        var selection = MauiProgram.GetService<SelectionService>();
-        if (_snapshot.Contains(selection.SelectedInstanceId))
-        {
-            selection.ClearSelection();
-        }
-
-        return CommandResult.Success();
+        ClearSelectionIfOwned(_snapshot);
+        return CommandResult.Success(
+            response == EngineMutationResponseState.Accepted
+                ? null
+                : "Destroy created hierarchy was reconciled from the authoritative world snapshot.");
     }
 
     async Task<CommandResult> RestoreAsync(string createFailureMessage)
@@ -870,6 +1006,40 @@ sealed class CreatedHierarchyCommandState(
         return result;
     }
 
+    static void ClearSelectionIfOwned(
+        CreatedHierarchySnapshot snapshot)
+    {
+        var selection = MauiProgram.GetService<SelectionService>();
+        if (snapshot.Contains(selection.SelectedInstanceId))
+        {
+            selection.ClearSelection();
+        }
+    }
+
+    static string FormatDiagnostic(string? diagnostic) =>
+        string.IsNullOrWhiteSpace(diagnostic)
+            ? string.Empty
+            : $": {diagnostic}";
+
+    static string FormatDiagnostics(
+        string? requestDiagnostic,
+        string? refreshDiagnostic)
+    {
+        var diagnostics = new List<string>();
+        if (!string.IsNullOrWhiteSpace(requestDiagnostic))
+        {
+            diagnostics.Add($"request: {requestDiagnostic}");
+        }
+        if (!string.IsNullOrWhiteSpace(refreshDiagnostic))
+        {
+            diagnostics.Add($"refresh: {refreshDiagnostic}");
+        }
+
+        return diagnostics.Count == 0
+            ? string.Empty
+            : $" ({string.Join("; ", diagnostics)})";
+    }
+
 }
 
 public sealed class CreateModelGameObjectCommand(
@@ -878,10 +1048,17 @@ public sealed class CreateModelGameObjectCommand(
     GameObject? parent = null,
     Vec4? worldPosition = null) : IUndoableEditorCommand
 {
+    const string MeshRendererComponentTypeName =
+        "Sailor::MeshRendererComponent";
+    const string ModelPropertyName = "model";
+    const float WorldPositionEpsilon = 0.001f;
+
     readonly FileId _modelFileId = modelFile?.FileId;
     readonly InstanceId? _parentId = parent?.InstanceId;
     readonly Vec4? _worldPosition = worldPosition;
     readonly string _objectName = objectName;
+    readonly InstanceId _ownedGameObjectId =
+        CreateCanonicalGameObjectInstanceId();
     readonly CreatedHierarchyCommandState _state = new(
         parent?.InstanceId);
 
@@ -897,14 +1074,8 @@ public sealed class CreateModelGameObjectCommand(
         ActionContext context,
         CancellationToken cancellationToken = default)
     {
-        var engine = MauiProgram.GetService<EngineService>();
         return await _state.ExecuteAsync(
-            () => engine.CreateModelGameObjectAsync(
-                _modelFileId,
-                _objectName,
-                _parentId,
-                _worldPosition,
-                CancellationToken.None),
+            CreateWithGenericOperationsAsync,
             "Create model GameObject failed",
             cancellationToken);
     }
@@ -913,6 +1084,386 @@ public sealed class CreateModelGameObjectCommand(
         ActionContext context,
         CancellationToken cancellationToken = default)
         => _state.UndoAsync(cancellationToken);
+
+    async Task<InstanceId?> CreateWithGenericOperationsAsync()
+    {
+        var engine = MauiProgram.GetService<EngineService>();
+        var world = MauiProgram.GetService<WorldService>();
+        var ownedComponentId =
+            CreateCanonicalComponentInstanceId(
+                _ownedGameObjectId);
+        var creationSubmitted = false;
+        string? failureDiagnostic = null;
+
+        try
+        {
+            var preflight =
+                await AuthoritativeHierarchyReconciliation
+                    .RefreshAndCheckRootAbsentAsync(
+                        engine,
+                        world,
+                        _ownedGameObjectId);
+            if (!preflight.Available || !preflight.RootAbsent)
+            {
+                Console.Error.WriteLine(
+                    "Create model GameObject preflight could not prove the owned instance id absent" +
+                    FormatDiagnostic(preflight.Diagnostic));
+                return null;
+            }
+
+            var initialParentId = _worldPosition is null
+                ? _parentId
+                : null;
+
+            creationSubmitted = true;
+            var createdId = await engine.CreateGameObjectAsync(
+                initialParentId,
+                _ownedGameObjectId,
+                CancellationToken.None);
+            if (!SameInstanceId(
+                    createdId,
+                    _ownedGameObjectId) ||
+                !world.TryGetGameObject(
+                    _ownedGameObjectId,
+                    out _))
+            {
+                throw new InvalidOperationException(
+                    "CreateGameObject did not project the owned GameObject");
+            }
+
+            var componentId = await engine.AddComponentAsync(
+                _ownedGameObjectId,
+                MeshRendererComponentTypeName,
+                ownedComponentId,
+                CancellationToken.None);
+            if (!SameInstanceId(
+                    componentId,
+                    ownedComponentId) ||
+                !world.TryGetGameObject(
+                    _ownedGameObjectId,
+                    out var createdObject) ||
+                !world.TryGetComponent(
+                    ownedComponentId,
+                    out var meshRenderer))
+            {
+                throw new InvalidOperationException(
+                    "AddComponent did not project the owned MeshRenderer");
+            }
+
+            var updatedObject = CloneGameObject(createdObject);
+            updatedObject.Name = _objectName;
+            if (_worldPosition is not null)
+            {
+                updatedObject.Position = new Vec4(_worldPosition);
+            }
+
+            if (!await engine.CommitChangesAsync(
+                    _ownedGameObjectId,
+                    EditorYaml.SerializeGameObject(updatedObject),
+                    CancellationToken.None))
+            {
+                throw new InvalidOperationException(
+                    "ChangeValue failed for GameObject");
+            }
+
+            var updatedMeshRenderer = CloneComponent(meshRenderer);
+            if (!updatedMeshRenderer.OverrideProperties.ContainsKey(
+                    ModelPropertyName))
+            {
+                throw new InvalidOperationException(
+                    "MeshRenderer has no reflected model property");
+            }
+
+            updatedMeshRenderer.OverrideProperties[ModelPropertyName] =
+                new ObjectPtr
+                {
+                    FileId = new FileId(_modelFileId.Value),
+                    InstanceId = new InstanceId(
+                        InstanceId.NullInstanceId)
+                };
+            if (!await engine.CommitChangesAsync(
+                    ownedComponentId,
+                    EditorYaml.SerializeComponent(
+                        updatedMeshRenderer),
+                    CancellationToken.None))
+            {
+                throw new InvalidOperationException(
+                    "ChangeValue failed for MeshRenderer.model");
+            }
+
+            if (_worldPosition is not null &&
+                _parentId is not null &&
+                !_parentId.IsEmpty() &&
+                !await engine.ReparentObjectAsync(
+                    _ownedGameObjectId,
+                    _parentId,
+                    keepWorldTransform: true,
+                    CancellationToken.None))
+            {
+                throw new InvalidOperationException(
+                    "ReparentObject failed");
+            }
+
+            if (!await engine.RefreshCurrentWorldAuthoritativelyAsync(
+                    CancellationToken.None) ||
+                !MatchesFinalProjection(
+                    world,
+                    ownedComponentId))
+            {
+                throw new InvalidOperationException(
+                    "The authoritative result did not match the requested name, parent, world position, component, and model");
+            }
+
+            return _ownedGameObjectId;
+        }
+        catch (Exception exception)
+        {
+            failureDiagnostic = exception.Message;
+        }
+
+        if (!creationSubmitted)
+        {
+            Console.Error.WriteLine(
+                $"Create model GameObject failed: {failureDiagnostic}");
+            return null;
+        }
+
+        var cleanup = await OwnedHierarchyRollback.EnsureAbsentAsync(
+            engine,
+            world,
+            _ownedGameObjectId);
+        if (!cleanup.ConfirmedAbsent ||
+            world.TryGetComponent(ownedComponentId, out _))
+        {
+            throw new InvalidOperationException(
+                $"Create model GameObject failed ({failureDiagnostic}); rollback could not confirm owned GameObject/component absent for '{_ownedGameObjectId.Value}'" +
+                FormatDiagnostic(cleanup.Diagnostic));
+        }
+
+        Console.Error.WriteLine(
+            $"Create model GameObject failed and was rolled back: {failureDiagnostic}");
+        return null;
+    }
+
+    bool MatchesFinalProjection(
+        WorldService world,
+        InstanceId componentId)
+    {
+        if (!world.TryGetGameObject(
+                _ownedGameObjectId,
+                out var gameObject) ||
+            !string.Equals(
+                gameObject.Name,
+                _objectName,
+                StringComparison.Ordinal) ||
+            !SameInstanceId(
+                world.ResolveParentInstanceId(gameObject),
+                _parentId) ||
+            !world.TryGetComponent(
+                componentId,
+                out var meshRenderer) ||
+            !string.Equals(
+                meshRenderer.Typename?.Name,
+                MeshRendererComponentTypeName,
+                StringComparison.Ordinal) ||
+            !SameInstanceId(
+                world.FindOwner(meshRenderer)?.InstanceId,
+                _ownedGameObjectId))
+        {
+            return false;
+        }
+
+        var projectedComponents =
+            world.GetComponents(gameObject);
+        if (projectedComponents.Count != 1 ||
+            !SameInstanceId(
+                projectedComponents[0].InstanceId,
+                componentId) ||
+            !meshRenderer.OverrideProperties.TryGetValue(
+                ModelPropertyName,
+                out var modelValue) ||
+            modelValue is not ObjectPtr model ||
+            model.FileId is null ||
+            !string.Equals(
+                model.FileId.Value,
+                _modelFileId.Value,
+                StringComparison.Ordinal) ||
+            (model.InstanceId is not null &&
+                !model.InstanceId.IsEmpty()))
+        {
+            return false;
+        }
+
+        if (_worldPosition is null)
+        {
+            return IsNear(
+                ToVector3(gameObject.Position),
+                Vector3.Zero);
+        }
+
+        return TryResolveWorldPosition(
+                world,
+                gameObject,
+                out var projectedWorldPosition) &&
+            IsNear(
+                projectedWorldPosition,
+                ToVector3(_worldPosition));
+    }
+
+    static bool TryResolveWorldPosition(
+        WorldService world,
+        GameObject gameObject,
+        out Vector3 worldPosition)
+    {
+        worldPosition = ToVector3(gameObject.Position);
+        var current = gameObject;
+        var visited = new HashSet<string>(
+            StringComparer.Ordinal)
+        {
+            gameObject.InstanceId.Value
+        };
+
+        while (world.ResolveParentInstanceId(current) is
+            { } parentInstanceId)
+        {
+            if (!visited.Add(parentInstanceId.Value) ||
+                !world.TryGetGameObject(
+                    parentInstanceId,
+                    out var parent) ||
+                parent.Position is null ||
+                parent.Rotation is null ||
+                parent.Scale is null)
+            {
+                return false;
+            }
+
+            worldPosition *= new Vector3(
+                parent.Scale.X,
+                parent.Scale.Y,
+                parent.Scale.Z);
+            worldPosition = Vector3.Transform(
+                    worldPosition,
+                    ToQuaternion(parent.Rotation)) +
+                ToVector3(parent.Position);
+            current = parent;
+        }
+
+        return IsFinite(worldPosition);
+    }
+
+    static Quaternion ToQuaternion(Rotation rotation)
+    {
+        var quat = rotation?.Quat ??
+            Quat.FromYawPitchRoll(
+                rotation?.Yaw ?? 0.0f,
+                rotation?.Pitch ?? 0.0f,
+                rotation?.Roll ?? 0.0f);
+        var result = new Quaternion(
+            quat.X,
+            quat.Y,
+            quat.Z,
+            quat.W);
+        return result.LengthSquared() > 0.0f &&
+            IsFinite(result)
+            ? Quaternion.Normalize(result)
+            : Quaternion.Identity;
+    }
+
+    static GameObject CloneGameObject(GameObject gameObject) => new()
+    {
+        Name = gameObject.Name,
+        InstanceId = new InstanceId(gameObject.InstanceId.Value),
+        ParentIndex = gameObject.ParentIndex,
+        Position = new Vec4(gameObject.Position),
+        Rotation = new Rotation(gameObject.Rotation),
+        Scale = new Vec4(gameObject.Scale),
+        ComponentIndices = [.. gameObject.ComponentIndices]
+    };
+
+    static Component CloneComponent(Component component)
+    {
+        var yaml = EditorYaml.SerializeComponent(component);
+        return SerializationUtils.CreateDeserializerBuilder()
+            .WithTypeConverter(new ComponentYamlConverter())
+            .Build()
+            .Deserialize<Component>(yaml);
+    }
+
+    static Vector3 ToVector3(Vec4 value) =>
+        value is null
+            ? new Vector3(
+                float.NaN,
+                float.NaN,
+                float.NaN)
+            : new Vector3(
+                value.X,
+                value.Y,
+                value.Z);
+
+    static bool IsNear(
+        Vector3 actual,
+        Vector3 expected)
+    {
+        return IsFinite(actual) &&
+            IsFinite(expected) &&
+            NearlyEqual(actual.X, expected.X) &&
+            NearlyEqual(actual.Y, expected.Y) &&
+            NearlyEqual(actual.Z, expected.Z);
+    }
+
+    static bool NearlyEqual(
+        float actual,
+        float expected)
+    {
+        var magnitude = MathF.Max(
+            1.0f,
+            MathF.Max(
+                MathF.Abs(actual),
+                MathF.Abs(expected)));
+        return MathF.Abs(actual - expected) <=
+            WorldPositionEpsilon * magnitude;
+    }
+
+    static bool IsFinite(Vector3 value) =>
+        float.IsFinite(value.X) &&
+        float.IsFinite(value.Y) &&
+        float.IsFinite(value.Z);
+
+    static bool IsFinite(Quaternion value) =>
+        float.IsFinite(value.X) &&
+        float.IsFinite(value.Y) &&
+        float.IsFinite(value.Z) &&
+        float.IsFinite(value.W);
+
+    static bool SameInstanceId(
+        InstanceId? left,
+        InstanceId? right)
+    {
+        var leftValue = left is null || left.IsEmpty()
+            ? null
+            : left.Value;
+        var rightValue = right is null || right.IsEmpty()
+            ? null
+            : right.Value;
+        return string.Equals(
+            leftValue,
+            rightValue,
+            StringComparison.Ordinal);
+    }
+
+    static string FormatDiagnostic(string? diagnostic) =>
+        string.IsNullOrWhiteSpace(diagnostic)
+            ? string.Empty
+            : $": {diagnostic}";
+
+    static InstanceId CreateCanonicalGameObjectInstanceId() =>
+        new(Convert.ToHexString(
+            RandomNumberGenerator.GetBytes(10)));
+
+    static InstanceId CreateCanonicalComponentInstanceId(
+        InstanceId owner) =>
+        new(
+            $"{Convert.ToHexString(RandomNumberGenerator.GetBytes(8))}_{owner.Value}");
 }
 
 public sealed class InstantiatePrefabAssetCommand(
@@ -1226,11 +1777,13 @@ public sealed class DestroyGameObjectCommand(GameObject gameObject) : IUndoableE
 
         var engine = MauiProgram.GetService<EngineService>();
         var world = MauiProgram.GetService<WorldService>();
-        var preflight = await RefreshAndClassifyAsync(
-            engine,
-            world,
-            _snapshot,
-            _parentId);
+        var preflight =
+            await AuthoritativeHierarchyReconciliation
+                .RefreshAndClassifyAsync(
+                    engine,
+                    world,
+                    _snapshot,
+                    _parentId);
         if (preflight.Projection ==
             AuthoritativeHierarchyProjection.Unavailable)
         {
@@ -1268,11 +1821,13 @@ public sealed class DestroyGameObjectCommand(GameObject gameObject) : IUndoableE
             requestDiagnostic = exception.Message;
         }
 
-        var postMutation = await RefreshAndClassifyAsync(
-            engine,
-            world,
-            _snapshot,
-            _parentId);
+        var postMutation =
+            await AuthoritativeHierarchyReconciliation
+                .RefreshAndClassifyAsync(
+                    engine,
+                    world,
+                    _snapshot,
+                    _parentId);
         var resolution = HierarchyMutationRecoveryPolicy.ResolveDestroy(
             response,
             postMutation.Projection);
@@ -1305,11 +1860,13 @@ public sealed class DestroyGameObjectCommand(GameObject gameObject) : IUndoableE
                 "Restore deleted hierarchy failed: hierarchy snapshot was not captured");
         }
 
-        var preflight = await RefreshAndClassifyAsync(
-            engine,
-            world,
-            _snapshot,
-            _parentId);
+        var preflight =
+            await AuthoritativeHierarchyReconciliation
+                .RefreshAndClassifyAsync(
+                    engine,
+                    world,
+                    _snapshot,
+                    _parentId);
         if (preflight.Projection ==
             AuthoritativeHierarchyProjection.Unavailable)
         {
@@ -1393,36 +1950,6 @@ public sealed class DestroyGameObjectCommand(GameObject gameObject) : IUndoableE
             out _)
             ? snapshot
             : null;
-    }
-
-    static async Task<(
-        AuthoritativeHierarchyProjection Projection,
-        string? Diagnostic)> RefreshAndClassifyAsync(
-        EngineService engine,
-        WorldService world,
-        CreatedHierarchySnapshot snapshot,
-        InstanceId? parentId)
-    {
-        try
-        {
-            if (!await engine.RefreshCurrentWorldAuthoritativelyAsync(
-                    CancellationToken.None))
-            {
-                return (
-                    AuthoritativeHierarchyProjection.Unavailable,
-                    "authoritative refresh was not published");
-            }
-
-            return (
-                snapshot.ClassifyProjection(world, parentId),
-                null);
-        }
-        catch (Exception exception)
-        {
-            return (
-                AuthoritativeHierarchyProjection.Unavailable,
-                exception.Message);
-        }
     }
 
     CommandResult RecoverySuccess(

--- a/Editor/Protocol/EngineProtocolClient.cs
+++ b/Editor/Protocol/EngineProtocolClient.cs
@@ -682,7 +682,7 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                 .ConfigureAwait(false),
             nameof(ProtocolRequest.InstantiatePrefab));
 
-    public async Task<EngineProtocolVector4> ResolveViewportDropPositionAsync(
+    public async Task<EngineProtocolVector4> TraceViewportRayAsync(
         ulong viewportId,
         float normalizedX,
         float normalizedY,
@@ -694,8 +694,8 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
             (await SendAsync(
                     new ProtocolRequest
                     {
-                        ResolveViewportDropPosition =
-                            new ViewportDropPositionRequest
+                        TraceViewportRay =
+                            new ViewportRayRequest
                             {
                                 ViewportId = viewportId,
                                 NormalizedX = normalizedX,
@@ -704,37 +704,10 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                     },
                     cancellationToken)
                 .ConfigureAwait(false)).Vector4Result,
-            nameof(ProtocolRequest.ResolveViewportDropPosition));
-        return ReadVector4(result.Value, nameof(ProtocolRequest.ResolveViewportDropPosition));
-    }
-
-    public async Task<EngineProtocolCreationResult> CreateModelGameObjectAsync(
-        string modelFileId,
-        string name,
-        string parentInstanceId,
-        EngineProtocolVector4? worldPosition,
-        CancellationToken cancellationToken = default)
-    {
-        var request = new CreateModelGameObjectRequest
-        {
-            ModelFileId = ValidateString(modelFileId, nameof(modelFileId)),
-            Name = ValidateString(name, nameof(name)),
-            ParentInstanceId = ValidateString(
-                parentInstanceId,
-                nameof(parentInstanceId)),
-            ApplyWorldPosition = worldPosition.HasValue
-        };
-        if (worldPosition is { } position)
-        {
-            request.WorldPosition = CreateVector4(position, nameof(worldPosition));
-        }
-
-        return ReadCreation(
-            await SendAsync(
-                    new ProtocolRequest { CreateModelGameObject = request },
-                    cancellationToken)
-                .ConfigureAwait(false),
-            nameof(ProtocolRequest.CreateModelGameObject));
+            nameof(ProtocolRequest.TraceViewportRay));
+        return ReadVector4(
+            result.Value,
+            nameof(ProtocolRequest.TraceViewportRay));
     }
 
     public async Task<EngineProtocolCreationResult> InstantiatePrefabInstanceAsync(
@@ -1130,7 +1103,7 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
             ProtocolRequest.CommandOneofCase.SetRemoteViewportMacHostHandle or
                 ProtocolRequest.CommandOneofCase.SendRemoteViewportInput or
                 ProtocolRequest.CommandOneofCase.PullEditorViewportEvents or
-                ProtocolRequest.CommandOneofCase.ResolveViewportDropPosition or
+                ProtocolRequest.CommandOneofCase.TraceViewportRay or
                 ProtocolRequest.CommandOneofCase.FocusEditorCamera or
                 ProtocolRequest.CommandOneofCase.SetViewportToolState or
                 ProtocolRequest.CommandOneofCase.GetViewportToolState or

--- a/Editor/Protocol/Generated/EditorEngine.cs
+++ b/Editor/Protocol/Generated/EditorEngine.cs
@@ -25,7 +25,7 @@ namespace SailorEditor.Protocol.Generated {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "ChNlZGl0b3JfZW5naW5lLnByb3RvEhBzYWlsb3IuZWRpdG9yLnYxIgcKBUVt",
-            "cHR5IuwZCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
+            "cHR5IsMZCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
             "IAEoDRISCgpyZXF1ZXN0X2lkGAIgASgEEjkKCmluaXRpYWxpemUYCiABKAsy",
             "Iy5zYWlsb3IuZWRpdG9yLnYxLkluaXRpYWxpemVSZXF1ZXN0SAASKAoFc3Rh",
             "cnQYCyABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASJwoEc3RvcBgM",
@@ -84,149 +84,144 @@ namespace SailorEditor.Protocol.Generated {
             "cGVzGC4gASgLMhcuc2FpbG9yLmVkaXRvci52MS5FbXB0eUgAEj4KG2lzX2Vu",
             "Z2luZV9tYWluX3RocmVhZF9yZWFkeRgvIAEoCzIXLnNhaWxvci5lZGl0b3Iu",
             "djEuRW1wdHlIABI0ChFpc19lbmdpbmVfcnVubmluZxgwIAEoCzIXLnNhaWxv",
-            "ci5lZGl0b3IudjEuRW1wdHlIABJXCh5yZXNvbHZlX3ZpZXdwb3J0X2Ryb3Bf",
-            "cG9zaXRpb24YMSABKAsyLS5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0RHJv",
-            "cFBvc2l0aW9uUmVxdWVzdEgAElIKGGNyZWF0ZV9tb2RlbF9nYW1lX29iamVj",
-            "dBgyIAEoCzIuLnNhaWxvci5lZGl0b3IudjEuQ3JlYXRlTW9kZWxHYW1lT2Jq",
-            "ZWN0UmVxdWVzdEgAElkKG2luc3RhbnRpYXRlX3ByZWZhYl9pbnN0YW5jZRgz",
-            "IAEoCzIyLnNhaWxvci5lZGl0b3IudjEuSW5zdGFudGlhdGVQcmVmYWJJbnN0",
-            "YW5jZVJlcXVlc3RIABJGChNmb2N1c19lZGl0b3JfY2FtZXJhGDQgASgLMicu",
-            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydE9iamVjdFJlcXVlc3RIABI+Cg9z",
-            "ZXRfcHJlZmFiX2xpbmsYNSABKAsyIy5zYWlsb3IuZWRpdG9yLnYxLlByZWZh",
-            "YkxpbmtSZXF1ZXN0SAASQAoRYnJlYWtfcHJlZmFiX2xpbmsYNiABKAsyIy5z",
-            "YWlsb3IuZWRpdG9yLnYxLkluc3RhbmNlSWRSZXF1ZXN0SAASTQoXc2V0X3Zp",
-            "ZXdwb3J0X3Rvb2xfc3RhdGUYNyABKAsyKi5zYWlsb3IuZWRpdG9yLnYxLlZp",
-            "ZXdwb3J0VG9vbFN0YXRlUmVxdWVzdEgAEkYKF2dldF92aWV3cG9ydF90b29s",
-            "X3N0YXRlGDggASgLMiMuc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydElkUmVx",
-            "dWVzdEgAQgkKB2NvbW1hbmRKBAgDEApKBAg5EGQilgcKEFByb3RvY29sUmVz",
-            "cG9uc2USGAoQcHJvdG9jb2xfdmVyc2lvbhgBIAEoDRISCgpyZXF1ZXN0X2lk",
-            "GAIgASgEEg8KB3N1Y2Nlc3MYAyABKAgSDQoFZXJyb3IYBCABKAkSJAocc3Vw",
-            "cG9ydHNfc3RyaWN0X2luc3RhbmNlX2lkcxgFIAEoCBIvCgxlbXB0eV9yZXN1",
-            "bHQYCiABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASMwoLYm9vbF9y",
-            "ZXN1bHQYCyABKAsyHC5zYWlsb3IuZWRpdG9yLnYxLkJvb2xSZXN1bHRIABI1",
-            "CgxpbnQzMl9yZXN1bHQYDCABKAsyHS5zYWlsb3IuZWRpdG9yLnYxLkludDMy",
-            "UmVzdWx0SAASNwoNdWludDMyX3Jlc3VsdBgNIAEoCzIeLnNhaWxvci5lZGl0",
-            "b3IudjEuVUludDMyUmVzdWx0SAASNwoNdWludDY0X3Jlc3VsdBgOIAEoCzIe",
-            "LnNhaWxvci5lZGl0b3IudjEuVUludDY0UmVzdWx0SAASNwoNc3RyaW5nX3Jl",
-            "c3VsdBgPIAEoCzIeLnNhaWxvci5lZGl0b3IudjEuU3RyaW5nUmVzdWx0SAAS",
-            "QAoSc3RyaW5nX2xpc3RfcmVzdWx0GBAgASgLMiIuc2FpbG9yLmVkaXRvci52",
-            "MS5TdHJpbmdMaXN0UmVzdWx0SAASTQoZYXNzZXRfcmVsb2FkX3N0YXRlX3Jl",
-            "c3VsdBgRIAEoCzIoLnNhaWxvci5lZGl0b3IudjEuQXNzZXRSZWxvYWRTdGF0",
-            "ZVJlc3VsdEgAEkAKEmluc3RhbmNlX2lkX3Jlc3VsdBgSIAEoCzIiLnNhaWxv",
-            "ci5lZGl0b3IudjEuSW5zdGFuY2VJZFJlc3VsdEgAElEKG3ZpZXdwb3J0X2V2",
-            "ZW50X2JhdGNoX3Jlc3VsdBgTIAEoCzIqLnNhaWxvci5lZGl0b3IudjEuVmll",
-            "d3BvcnRFdmVudEJhdGNoUmVzdWx0SAASOQoOdmVjdG9yNF9yZXN1bHQYFCAB",
-            "KAsyHy5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjRSZXN1bHRIABJPChp2aWV3",
-            "cG9ydF90b29sX3N0YXRlX3Jlc3VsdBgVIAEoCzIpLnNhaWxvci5lZGl0b3Iu",
-            "djEuVmlld3BvcnRUb29sU3RhdGVSZXN1bHRIAEIICgZyZXN1bHRKBAgGEApK",
-            "BAgWEGQiJgoRSW5pdGlhbGl6ZVJlcXVlc3QSEQoJYXJndW1lbnRzGAEgAygJ",
-            "IiEKDENvdW50UmVxdWVzdBIRCgltYXhfY291bnQYASABKA0iIAoNRmlsZUlk",
-            "UmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJIigKEUluc3RhbmNlSWRSZXF1ZXN0",
-            "EhMKC2luc3RhbmNlX2lkGAEgASgJIigKEVZpZXdwb3J0SWRSZXF1ZXN0EhMK",
-            "C3ZpZXdwb3J0X2lkGAEgASgEImAKE1ZpZXdwb3J0UmVjdFJlcXVlc3QSFAoM",
-            "d2luZG93X3Bvc194GAEgASgNEhQKDHdpbmRvd19wb3NfeRgCIAEoDRINCgV3",
-            "aWR0aBgDIAEoDRIOCgZoZWlnaHQYBCABKA0iLAoLU2l6ZVJlcXVlc3QSDQoF",
-            "d2lkdGgYASABKA0SDgoGaGVpZ2h0GAIgASgNIpkBChVSZW1vdGVWaWV3cG9y",
-            "dFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQSFAoMd2luZG93X3Bvc194",
-            "GAIgASgNEhQKDHdpbmRvd19wb3NfeRgDIAEoDRINCgV3aWR0aBgEIAEoDRIO",
-            "CgZoZWlnaHQYBSABKA0SDwoHdmlzaWJsZRgGIAEoCBIPCgdmb2N1c2VkGAcg",
-            "ASgIImUKGVJlbW90ZVZpZXdwb3J0SG9zdFJlcXVlc3QSEwoLdmlld3BvcnRf",
-            "aWQYASABKAQSGAoQaG9zdF9oYW5kbGVfa2luZBgCIAEoDRIZChFob3N0X2hh",
-            "bmRsZV92YWx1ZRgDIAEoBCL8AQoaUmVtb3RlVmlld3BvcnRJbnB1dFJlcXVl",
-            "c3QSEwoLdmlld3BvcnRfaWQYASABKAQSDAoEa2luZBgCIAEoDRIRCglwb2lu",
-            "dGVyX3gYAyABKAISEQoJcG9pbnRlcl95GAQgASgCEhUKDXdoZWVsX2RlbHRh",
-            "X3gYBSABKAISFQoNd2hlZWxfZGVsdGFfeRgGIAEoAhIQCghrZXlfY29kZRgH",
-            "IAEoDRIOCgZidXR0b24YCCABKA0SEQoJbW9kaWZpZXJzGAkgASgNEg8KB3By",
-            "ZXNzZWQYCiABKAgSDwoHZm9jdXNlZBgLIAEoCBIQCghjYXB0dXJlZBgMIAEo",
-            "CCJDCh5NYW5hZ2VkTXV0YXRpb25SZXZpc2lvblJlcXVlc3QSDAoEa2luZBgB",
-            "IAEoDRITCgtpbnN0YW5jZV9pZBgCIAEoCSJAChNVcGRhdGVPYmplY3RSZXF1",
-            "ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEhQKDHlhbWxfY2hhbmdlcxgCIAEo",
-            "CSJmChVSZXBhcmVudE9iamVjdFJlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASAB",
-            "KAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAIgASgJEhwKFGtlZXBfd29ybGRf",
-            "dHJhbnNmb3JtGAMgASgIIlQKF0NyZWF0ZUdhbWVPYmplY3RSZXF1ZXN0EhoK",
-            "EnBhcmVudF9pbnN0YW5jZV9pZBgBIAEoCRIdChVwcmVmZXJyZWRfaW5zdGFu",
-            "Y2VfaWQYAiABKAkiZgoTQWRkQ29tcG9uZW50UmVxdWVzdBITCgtpbnN0YW5j",
-            "ZV9pZBgBIAEoCRIbChNjb21wb25lbnRfdHlwZV9uYW1lGAIgASgJEh0KFXBy",
-            "ZWZlcnJlZF9pbnN0YW5jZV9pZBgDIAEoCSJHChhJbnN0YW50aWF0ZVByZWZh",
-            "YlJlcXVlc3QSDwoHZmlsZV9pZBgBIAEoCRIaChJwYXJlbnRfaW5zdGFuY2Vf",
-            "aWQYAiABKAkicAogSW5zdGFudGlhdGVQcmVmYWJGcm9tWWFtbFJlcXVlc3QS",
-            "EwoLcHJlZmFiX3lhbWwYASABKAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAIg",
-            "ASgJEhsKE3N0cmljdF9pbnN0YW5jZV9pZHMYAyABKAgiXgobVmlld3BvcnRE",
-            "cm9wUG9zaXRpb25SZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhQKDG5v",
-            "cm1hbGl6ZWRfeBgCIAEoAhIUCgxub3JtYWxpemVkX3kYAyABKAIisAEKHENy",
-            "ZWF0ZU1vZGVsR2FtZU9iamVjdFJlcXVlc3QSFQoNbW9kZWxfZmlsZV9pZBgB",
-            "IAEoCRIMCgRuYW1lGAIgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgDIAEo",
-            "CRIcChRhcHBseV93b3JsZF9wb3NpdGlvbhgEIAEoCBIxCg53b3JsZF9wb3Np",
-            "dGlvbhgFIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNCKgAQogSW5z",
-            "dGFudGlhdGVQcmVmYWJJbnN0YW5jZVJlcXVlc3QSDwoHZmlsZV9pZBgBIAEo",
-            "CRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAiABKAkSHAoUYXBwbHlfd29ybGRf",
-            "cG9zaXRpb24YAyABKAgSMQoOd29ybGRfcG9zaXRpb24YBCABKAsyGS5zYWls",
-            "b3IuZWRpdG9yLnYxLlZlY3RvcjQiQQoVVmlld3BvcnRPYmplY3RSZXF1ZXN0",
-            "EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhMKC2luc3RhbmNlX2lkGAIgASgJIjkK",
-            "EVByZWZhYkxpbmtSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEg8KB2Zp",
-            "bGVfaWQYAiABKAkiqQEKGFZpZXdwb3J0VG9vbFN0YXRlUmVxdWVzdBITCgt2",
-            "aWV3cG9ydF9pZBgBIAEoBBI/CglvcGVyYXRpb24YAiABKA4yLC5zYWlsb3Iu",
-            "ZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtT3BlcmF0aW9uEjcKBXNwYWNl",
-            "GAMgASgOMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybVNw",
-            "YWNlIigKEFNlbGVjdGlvblJlcXVlc3QSFAoMaW5zdGFuY2VfaWRzGAEgAygJ",
-            "IiUKFVNob3dNYWluV2luZG93UmVxdWVzdBIMCgRzaG93GAEgASgIIogBChxS",
-            "ZW5kZXJQYXRoVHJhY2VkSW1hZ2VSZXF1ZXN0EhMKC291dHB1dF9wYXRoGAEg",
-            "ASgJEhMKC2luc3RhbmNlX2lkGAIgASgJEg4KBmhlaWdodBgDIAEoDRIZChFz",
-            "YW1wbGVzX3Blcl9waXhlbBgEIAEoDRITCgttYXhfYm91bmNlcxgFIAEoDSIb",
-            "CgpCb29sUmVzdWx0Eg0KBXZhbHVlGAEgASgIIhwKC0ludDMyUmVzdWx0Eg0K",
-            "BXZhbHVlGAEgASgFIh0KDFVJbnQzMlJlc3VsdBINCgV2YWx1ZRgBIAEoDSId",
-            "CgxVSW50NjRSZXN1bHQSDQoFdmFsdWUYASABKAQiMAoMU3RyaW5nUmVzdWx0",
-            "EhEKCWhhc192YWx1ZRgBIAEoCBINCgV2YWx1ZRgCIAEoCSIiChBTdHJpbmdM",
-            "aXN0UmVzdWx0Eg4KBnZhbHVlcxgBIAMoCSKEAQoWQXNzZXRSZWxvYWRTdGF0",
-            "ZVJlc3VsdBIRCglhdmFpbGFibGUYASABKAgSGgoScmVxdWVzdF9nZW5lcmF0",
-            "aW9uGAIgASgEEhwKFGNvbXBsZXRlZF9nZW5lcmF0aW9uGAMgASgEEh0KFXN1",
-            "Y2Nlc3NmdWxfZ2VuZXJhdGlvbhgEIAEoBCI6ChBJbnN0YW5jZUlkUmVzdWx0",
-            "EhEKCXN1Y2NlZWRlZBgBIAEoCBITCgtpbnN0YW5jZV9pZBgCIAEoCSI5Cg1W",
-            "ZWN0b3I0UmVzdWx0EigKBXZhbHVlGAEgASgLMhkuc2FpbG9yLmVkaXRvci52",
-            "MS5WZWN0b3I0IpMBChdWaWV3cG9ydFRvb2xTdGF0ZVJlc3VsdBI/CglvcGVy",
-            "YXRpb24YASABKA4yLC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNm",
-            "b3JtT3BlcmF0aW9uEjcKBXNwYWNlGAIgASgOMiguc2FpbG9yLmVkaXRvci52",
-            "MS5WaWV3cG9ydFRyYW5zZm9ybVNwYWNlIjUKB1ZlY3RvcjQSCQoBeBgBIAEo",
-            "AhIJCgF5GAIgASgCEgkKAXoYAyABKAISCQoBdxgEIAEoAiI2ChZWaWV3cG9y",
-            "dFNlbGVjdGlvbkV2ZW50EhwKFHNlbGVjdGVkX2luc3RhbmNlX2lkGAEgASgJ",
-            "ItYDChZWaWV3cG9ydFRyYW5zZm9ybUV2ZW50EhMKC2luc3RhbmNlX2lkGAEg",
-            "ASgJEj8KCW9wZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmll",
-            "d3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAyABKA4yKC5zYWls",
-            "b3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2USMgoPYmVmb3Jl",
-            "X3Bvc2l0aW9uGAQgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0EjIK",
-            "D2JlZm9yZV9yb3RhdGlvbhgFIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVj",
-            "dG9yNBIvCgxiZWZvcmVfc2NhbGUYBiABKAsyGS5zYWlsb3IuZWRpdG9yLnYx",
-            "LlZlY3RvcjQSMQoOYWZ0ZXJfcG9zaXRpb24YByABKAsyGS5zYWlsb3IuZWRp",
-            "dG9yLnYxLlZlY3RvcjQSMQoOYWZ0ZXJfcm90YXRpb24YCCABKAsyGS5zYWls",
-            "b3IuZWRpdG9yLnYxLlZlY3RvcjQSLgoLYWZ0ZXJfc2NhbGUYCSABKAsyGS5z",
-            "YWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQiVQoWVmlld3BvcnRBc3NldERyb3BF",
-            "dmVudBIPCgdmaWxlX2lkGAEgASgJEhQKDG5vcm1hbGl6ZWRfeBgCIAEoAhIU",
-            "Cgxub3JtYWxpemVkX3kYAyABKAIiLQoZVmlld3BvcnRUb29sU2hvcnRjdXRF",
-            "dmVudBIQCghrZXlfY29kZRgBIAEoDSLZAgoNVmlld3BvcnRFdmVudBIQCghy",
-            "ZXZpc2lvbhgBIAEoBBIhChltYW5hZ2VkX211dGF0aW9uX3JldmlzaW9uGAIg",
-            "ASgEEj0KCXNlbGVjdGlvbhgKIAEoCzIoLnNhaWxvci5lZGl0b3IudjEuVmll",
-            "d3BvcnRTZWxlY3Rpb25FdmVudEgAEj0KCXRyYW5zZm9ybRgLIAEoCzIoLnNh",
-            "aWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1FdmVudEgAEj4KCmFz",
-            "c2V0X2Ryb3AYDCABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0QXNz",
-            "ZXREcm9wRXZlbnRIABJECg10b29sX3Nob3J0Y3V0GA0gASgLMisuc2FpbG9y",
-            "LmVkaXRvci52MS5WaWV3cG9ydFRvb2xTaG9ydGN1dEV2ZW50SABCCQoHcGF5",
-            "bG9hZEoECAMQCiJLChhWaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHQSLwoGZXZl",
-            "bnRzGAEgAygLMh8uc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEV2ZW50KvAB",
-            "ChpWaWV3cG9ydFRyYW5zZm9ybU9wZXJhdGlvbhIsCihWSUVXUE9SVF9UUkFO",
-            "U0ZPUk1fT1BFUkFUSU9OX1VOU1BFQ0lGSUVEEAASJwojVklFV1BPUlRfVFJB",
-            "TlNGT1JNX09QRVJBVElPTl9TRUxFQ1QQARIqCiZWSUVXUE9SVF9UUkFOU0ZP",
-            "Uk1fT1BFUkFUSU9OX1RSQU5TTEFURRACEicKI1ZJRVdQT1JUX1RSQU5TRk9S",
-            "TV9PUEVSQVRJT05fUk9UQVRFEAMSJgoiVklFV1BPUlRfVFJBTlNGT1JNX09Q",
-            "RVJBVElPTl9TQ0FMRRAEKooBChZWaWV3cG9ydFRyYW5zZm9ybVNwYWNlEigK",
-            "JFZJRVdQT1JUX1RSQU5TRk9STV9TUEFDRV9VTlNQRUNJRklFRBAAEiIKHlZJ",
-            "RVdQT1JUX1RSQU5TRk9STV9TUEFDRV9XT1JMRBABEiIKHlZJRVdQT1JUX1RS",
-            "QU5TRk9STV9TUEFDRV9MT0NBTBACQiKqAh9TYWlsb3JFZGl0b3IuUHJvdG9j",
-            "b2wuR2VuZXJhdGVkYgZwcm90bzM="));
+            "ci5lZGl0b3IudjEuRW1wdHlIABJCChJ0cmFjZV92aWV3cG9ydF9yYXkYMSAB",
+            "KAsyJC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0UmF5UmVxdWVzdEgAElkK",
+            "G2luc3RhbnRpYXRlX3ByZWZhYl9pbnN0YW5jZRgzIAEoCzIyLnNhaWxvci5l",
+            "ZGl0b3IudjEuSW5zdGFudGlhdGVQcmVmYWJJbnN0YW5jZVJlcXVlc3RIABJG",
+            "ChNmb2N1c19lZGl0b3JfY2FtZXJhGDQgASgLMicuc2FpbG9yLmVkaXRvci52",
+            "MS5WaWV3cG9ydE9iamVjdFJlcXVlc3RIABI+Cg9zZXRfcHJlZmFiX2xpbmsY",
+            "NSABKAsyIy5zYWlsb3IuZWRpdG9yLnYxLlByZWZhYkxpbmtSZXF1ZXN0SAAS",
+            "QAoRYnJlYWtfcHJlZmFiX2xpbmsYNiABKAsyIy5zYWlsb3IuZWRpdG9yLnYx",
+            "Lkluc3RhbmNlSWRSZXF1ZXN0SAASTQoXc2V0X3ZpZXdwb3J0X3Rvb2xfc3Rh",
+            "dGUYNyABKAsyKi5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VG9vbFN0YXRl",
+            "UmVxdWVzdEgAEkYKF2dldF92aWV3cG9ydF90b29sX3N0YXRlGDggASgLMiMu",
+            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydElkUmVxdWVzdEgAQgkKB2NvbW1h",
+            "bmRKBAgDEApKBAgyEDNKBAg5EGRSGGNyZWF0ZV9tb2RlbF9nYW1lX29iamVj",
+            "dFIecmVzb2x2ZV92aWV3cG9ydF9kcm9wX3Bvc2l0aW9uIpYHChBQcm90b2Nv",
+            "bFJlc3BvbnNlEhgKEHByb3RvY29sX3ZlcnNpb24YASABKA0SEgoKcmVxdWVz",
+            "dF9pZBgCIAEoBBIPCgdzdWNjZXNzGAMgASgIEg0KBWVycm9yGAQgASgJEiQK",
+            "HHN1cHBvcnRzX3N0cmljdF9pbnN0YW5jZV9pZHMYBSABKAgSLwoMZW1wdHlf",
+            "cmVzdWx0GAogASgLMhcuc2FpbG9yLmVkaXRvci52MS5FbXB0eUgAEjMKC2Jv",
+            "b2xfcmVzdWx0GAsgASgLMhwuc2FpbG9yLmVkaXRvci52MS5Cb29sUmVzdWx0",
+            "SAASNQoMaW50MzJfcmVzdWx0GAwgASgLMh0uc2FpbG9yLmVkaXRvci52MS5J",
+            "bnQzMlJlc3VsdEgAEjcKDXVpbnQzMl9yZXN1bHQYDSABKAsyHi5zYWlsb3Iu",
+            "ZWRpdG9yLnYxLlVJbnQzMlJlc3VsdEgAEjcKDXVpbnQ2NF9yZXN1bHQYDiAB",
+            "KAsyHi5zYWlsb3IuZWRpdG9yLnYxLlVJbnQ2NFJlc3VsdEgAEjcKDXN0cmlu",
+            "Z19yZXN1bHQYDyABKAsyHi5zYWlsb3IuZWRpdG9yLnYxLlN0cmluZ1Jlc3Vs",
+            "dEgAEkAKEnN0cmluZ19saXN0X3Jlc3VsdBgQIAEoCzIiLnNhaWxvci5lZGl0",
+            "b3IudjEuU3RyaW5nTGlzdFJlc3VsdEgAEk0KGWFzc2V0X3JlbG9hZF9zdGF0",
+            "ZV9yZXN1bHQYESABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLkFzc2V0UmVsb2Fk",
+            "U3RhdGVSZXN1bHRIABJAChJpbnN0YW5jZV9pZF9yZXN1bHQYEiABKAsyIi5z",
+            "YWlsb3IuZWRpdG9yLnYxLkluc3RhbmNlSWRSZXN1bHRIABJRCht2aWV3cG9y",
+            "dF9ldmVudF9iYXRjaF9yZXN1bHQYEyABKAsyKi5zYWlsb3IuZWRpdG9yLnYx",
+            "LlZpZXdwb3J0RXZlbnRCYXRjaFJlc3VsdEgAEjkKDnZlY3RvcjRfcmVzdWx0",
+            "GBQgASgLMh8uc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0UmVzdWx0SAASTwoa",
+            "dmlld3BvcnRfdG9vbF9zdGF0ZV9yZXN1bHQYFSABKAsyKS5zYWlsb3IuZWRp",
+            "dG9yLnYxLlZpZXdwb3J0VG9vbFN0YXRlUmVzdWx0SABCCAoGcmVzdWx0SgQI",
+            "BhAKSgQIFhBkIiYKEUluaXRpYWxpemVSZXF1ZXN0EhEKCWFyZ3VtZW50cxgB",
+            "IAMoCSIhCgxDb3VudFJlcXVlc3QSEQoJbWF4X2NvdW50GAEgASgNIiAKDUZp",
+            "bGVJZFJlcXVlc3QSDwoHZmlsZV9pZBgBIAEoCSIoChFJbnN0YW5jZUlkUmVx",
+            "dWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCSIoChFWaWV3cG9ydElkUmVxdWVz",
+            "dBITCgt2aWV3cG9ydF9pZBgBIAEoBCJgChNWaWV3cG9ydFJlY3RSZXF1ZXN0",
+            "EhQKDHdpbmRvd19wb3NfeBgBIAEoDRIUCgx3aW5kb3dfcG9zX3kYAiABKA0S",
+            "DQoFd2lkdGgYAyABKA0SDgoGaGVpZ2h0GAQgASgNIiwKC1NpemVSZXF1ZXN0",
+            "Eg0KBXdpZHRoGAEgASgNEg4KBmhlaWdodBgCIAEoDSKZAQoVUmVtb3RlVmll",
+            "d3BvcnRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhQKDHdpbmRvd19w",
+            "b3NfeBgCIAEoDRIUCgx3aW5kb3dfcG9zX3kYAyABKA0SDQoFd2lkdGgYBCAB",
+            "KA0SDgoGaGVpZ2h0GAUgASgNEg8KB3Zpc2libGUYBiABKAgSDwoHZm9jdXNl",
+            "ZBgHIAEoCCJlChlSZW1vdGVWaWV3cG9ydEhvc3RSZXF1ZXN0EhMKC3ZpZXdw",
+            "b3J0X2lkGAEgASgEEhgKEGhvc3RfaGFuZGxlX2tpbmQYAiABKA0SGQoRaG9z",
+            "dF9oYW5kbGVfdmFsdWUYAyABKAQi/AEKGlJlbW90ZVZpZXdwb3J0SW5wdXRS",
+            "ZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEgwKBGtpbmQYAiABKA0SEQoJ",
+            "cG9pbnRlcl94GAMgASgCEhEKCXBvaW50ZXJfeRgEIAEoAhIVCg13aGVlbF9k",
+            "ZWx0YV94GAUgASgCEhUKDXdoZWVsX2RlbHRhX3kYBiABKAISEAoIa2V5X2Nv",
+            "ZGUYByABKA0SDgoGYnV0dG9uGAggASgNEhEKCW1vZGlmaWVycxgJIAEoDRIP",
+            "CgdwcmVzc2VkGAogASgIEg8KB2ZvY3VzZWQYCyABKAgSEAoIY2FwdHVyZWQY",
+            "DCABKAgiQwoeTWFuYWdlZE11dGF0aW9uUmV2aXNpb25SZXF1ZXN0EgwKBGtp",
+            "bmQYASABKA0SEwoLaW5zdGFuY2VfaWQYAiABKAkiQAoTVXBkYXRlT2JqZWN0",
+            "UmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCRIUCgx5YW1sX2NoYW5nZXMY",
+            "AiABKAkiZgoVUmVwYXJlbnRPYmplY3RSZXF1ZXN0EhMKC2luc3RhbmNlX2lk",
+            "GAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIcChRrZWVwX3dv",
+            "cmxkX3RyYW5zZm9ybRgDIAEoCCJUChdDcmVhdGVHYW1lT2JqZWN0UmVxdWVz",
+            "dBIaChJwYXJlbnRfaW5zdGFuY2VfaWQYASABKAkSHQoVcHJlZmVycmVkX2lu",
+            "c3RhbmNlX2lkGAIgASgJImYKE0FkZENvbXBvbmVudFJlcXVlc3QSEwoLaW5z",
+            "dGFuY2VfaWQYASABKAkSGwoTY29tcG9uZW50X3R5cGVfbmFtZRgCIAEoCRId",
+            "ChVwcmVmZXJyZWRfaW5zdGFuY2VfaWQYAyABKAkiRwoYSW5zdGFudGlhdGVQ",
+            "cmVmYWJSZXF1ZXN0Eg8KB2ZpbGVfaWQYASABKAkSGgoScGFyZW50X2luc3Rh",
+            "bmNlX2lkGAIgASgJInAKIEluc3RhbnRpYXRlUHJlZmFiRnJvbVlhbWxSZXF1",
+            "ZXN0EhMKC3ByZWZhYl95YW1sGAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9p",
+            "ZBgCIAEoCRIbChNzdHJpY3RfaW5zdGFuY2VfaWRzGAMgASgIIlUKElZpZXdw",
+            "b3J0UmF5UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIUCgxub3JtYWxp",
+            "emVkX3gYAiABKAISFAoMbm9ybWFsaXplZF95GAMgASgCIqABCiBJbnN0YW50",
+            "aWF0ZVByZWZhYkluc3RhbmNlUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJEhoK",
+            "EnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIcChRhcHBseV93b3JsZF9wb3Np",
+            "dGlvbhgDIAEoCBIxCg53b3JsZF9wb3NpdGlvbhgEIAEoCzIZLnNhaWxvci5l",
+            "ZGl0b3IudjEuVmVjdG9yNCJBChVWaWV3cG9ydE9iamVjdFJlcXVlc3QSEwoL",
+            "dmlld3BvcnRfaWQYASABKAQSEwoLaW5zdGFuY2VfaWQYAiABKAkiOQoRUHJl",
+            "ZmFiTGlua1JlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkSDwoHZmlsZV9p",
+            "ZBgCIAEoCSKpAQoYVmlld3BvcnRUb29sU3RhdGVSZXF1ZXN0EhMKC3ZpZXdw",
+            "b3J0X2lkGAEgASgEEj8KCW9wZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5lZGl0",
+            "b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAyAB",
+            "KA4yKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2Ui",
+            "KAoQU2VsZWN0aW9uUmVxdWVzdBIUCgxpbnN0YW5jZV9pZHMYASADKAkiJQoV",
+            "U2hvd01haW5XaW5kb3dSZXF1ZXN0EgwKBHNob3cYASABKAgiiAEKHFJlbmRl",
+            "clBhdGhUcmFjZWRJbWFnZVJlcXVlc3QSEwoLb3V0cHV0X3BhdGgYASABKAkS",
+            "EwoLaW5zdGFuY2VfaWQYAiABKAkSDgoGaGVpZ2h0GAMgASgNEhkKEXNhbXBs",
+            "ZXNfcGVyX3BpeGVsGAQgASgNEhMKC21heF9ib3VuY2VzGAUgASgNIhsKCkJv",
+            "b2xSZXN1bHQSDQoFdmFsdWUYASABKAgiHAoLSW50MzJSZXN1bHQSDQoFdmFs",
+            "dWUYASABKAUiHQoMVUludDMyUmVzdWx0Eg0KBXZhbHVlGAEgASgNIh0KDFVJ",
+            "bnQ2NFJlc3VsdBINCgV2YWx1ZRgBIAEoBCIwCgxTdHJpbmdSZXN1bHQSEQoJ",
+            "aGFzX3ZhbHVlGAEgASgIEg0KBXZhbHVlGAIgASgJIiIKEFN0cmluZ0xpc3RS",
+            "ZXN1bHQSDgoGdmFsdWVzGAEgAygJIoQBChZBc3NldFJlbG9hZFN0YXRlUmVz",
+            "dWx0EhEKCWF2YWlsYWJsZRgBIAEoCBIaChJyZXF1ZXN0X2dlbmVyYXRpb24Y",
+            "AiABKAQSHAoUY29tcGxldGVkX2dlbmVyYXRpb24YAyABKAQSHQoVc3VjY2Vz",
+            "c2Z1bF9nZW5lcmF0aW9uGAQgASgEIjoKEEluc3RhbmNlSWRSZXN1bHQSEQoJ",
+            "c3VjY2VlZGVkGAEgASgIEhMKC2luc3RhbmNlX2lkGAIgASgJIjkKDVZlY3Rv",
+            "cjRSZXN1bHQSKAoFdmFsdWUYASABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZl",
+            "Y3RvcjQikwEKF1ZpZXdwb3J0VG9vbFN0YXRlUmVzdWx0Ej8KCW9wZXJhdGlv",
+            "bhgBIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1P",
+            "cGVyYXRpb24SNwoFc3BhY2UYAiABKA4yKC5zYWlsb3IuZWRpdG9yLnYxLlZp",
+            "ZXdwb3J0VHJhbnNmb3JtU3BhY2UiNQoHVmVjdG9yNBIJCgF4GAEgASgCEgkK",
+            "AXkYAiABKAISCQoBehgDIAEoAhIJCgF3GAQgASgCIjYKFlZpZXdwb3J0U2Vs",
+            "ZWN0aW9uRXZlbnQSHAoUc2VsZWN0ZWRfaW5zdGFuY2VfaWQYASABKAki1gMK",
+            "FlZpZXdwb3J0VHJhbnNmb3JtRXZlbnQSEwoLaW5zdGFuY2VfaWQYASABKAkS",
+            "PwoJb3BlcmF0aW9uGAIgASgOMiwuc2FpbG9yLmVkaXRvci52MS5WaWV3cG9y",
+            "dFRyYW5zZm9ybU9wZXJhdGlvbhI3CgVzcGFjZRgDIAEoDjIoLnNhaWxvci5l",
+            "ZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1TcGFjZRIyCg9iZWZvcmVfcG9z",
+            "aXRpb24YBCABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQSMgoPYmVm",
+            "b3JlX3JvdGF0aW9uGAUgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0",
+            "Ei8KDGJlZm9yZV9zY2FsZRgGIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVj",
+            "dG9yNBIxCg5hZnRlcl9wb3NpdGlvbhgHIAEoCzIZLnNhaWxvci5lZGl0b3Iu",
+            "djEuVmVjdG9yNBIxCg5hZnRlcl9yb3RhdGlvbhgIIAEoCzIZLnNhaWxvci5l",
+            "ZGl0b3IudjEuVmVjdG9yNBIuCgthZnRlcl9zY2FsZRgJIAEoCzIZLnNhaWxv",
+            "ci5lZGl0b3IudjEuVmVjdG9yNCJVChZWaWV3cG9ydEFzc2V0RHJvcEV2ZW50",
+            "Eg8KB2ZpbGVfaWQYASABKAkSFAoMbm9ybWFsaXplZF94GAIgASgCEhQKDG5v",
+            "cm1hbGl6ZWRfeRgDIAEoAiItChlWaWV3cG9ydFRvb2xTaG9ydGN1dEV2ZW50",
+            "EhAKCGtleV9jb2RlGAEgASgNItkCCg1WaWV3cG9ydEV2ZW50EhAKCHJldmlz",
+            "aW9uGAEgASgEEiEKGW1hbmFnZWRfbXV0YXRpb25fcmV2aXNpb24YAiABKAQS",
+            "PQoJc2VsZWN0aW9uGAogASgLMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9y",
+            "dFNlbGVjdGlvbkV2ZW50SAASPQoJdHJhbnNmb3JtGAsgASgLMiguc2FpbG9y",
+            "LmVkaXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybUV2ZW50SAASPgoKYXNzZXRf",
+            "ZHJvcBgMIAEoCzIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRBc3NldERy",
+            "b3BFdmVudEgAEkQKDXRvb2xfc2hvcnRjdXQYDSABKAsyKy5zYWlsb3IuZWRp",
+            "dG9yLnYxLlZpZXdwb3J0VG9vbFNob3J0Y3V0RXZlbnRIAEIJCgdwYXlsb2Fk",
+            "SgQIAxAKIksKGFZpZXdwb3J0RXZlbnRCYXRjaFJlc3VsdBIvCgZldmVudHMY",
+            "ASADKAsyHy5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0RXZlbnQq8AEKGlZp",
+            "ZXdwb3J0VHJhbnNmb3JtT3BlcmF0aW9uEiwKKFZJRVdQT1JUX1RSQU5TRk9S",
+            "TV9PUEVSQVRJT05fVU5TUEVDSUZJRUQQABInCiNWSUVXUE9SVF9UUkFOU0ZP",
+            "Uk1fT1BFUkFUSU9OX1NFTEVDVBABEioKJlZJRVdQT1JUX1RSQU5TRk9STV9P",
+            "UEVSQVRJT05fVFJBTlNMQVRFEAISJwojVklFV1BPUlRfVFJBTlNGT1JNX09Q",
+            "RVJBVElPTl9ST1RBVEUQAxImCiJWSUVXUE9SVF9UUkFOU0ZPUk1fT1BFUkFU",
+            "SU9OX1NDQUxFEAQqigEKFlZpZXdwb3J0VHJhbnNmb3JtU3BhY2USKAokVklF",
+            "V1BPUlRfVFJBTlNGT1JNX1NQQUNFX1VOU1BFQ0lGSUVEEAASIgoeVklFV1BP",
+            "UlRfVFJBTlNGT1JNX1NQQUNFX1dPUkxEEAESIgoeVklFV1BPUlRfVFJBTlNG",
+            "T1JNX1NQQUNFX0xPQ0FMEAJCIqoCH1NhaWxvckVkaXRvci5Qcm90b2NvbC5H",
+            "ZW5lcmF0ZWRiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::SailorEditor.Protocol.Generated.ViewportTransformOperation), typeof(global::SailorEditor.Protocol.Generated.ViewportTransformSpace), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Empty), global::SailorEditor.Protocol.Generated.Empty.Parser, null, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "ResolveViewportDropPosition", "CreateModelGameObject", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState" }, new[]{ "Command" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState" }, new[]{ "Command" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "SupportsStrictInstanceIds", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult", "Vector4Result", "ViewportToolStateResult" }, new[]{ "Result" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InitializeRequest), global::SailorEditor.Protocol.Generated.InitializeRequest.Parser, new[]{ "Arguments" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CountRequest), global::SailorEditor.Protocol.Generated.CountRequest.Parser, new[]{ "MaxCount" }, null, null, null, null),
@@ -245,8 +240,7 @@ namespace SailorEditor.Protocol.Generated {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.AddComponentRequest), global::SailorEditor.Protocol.Generated.AddComponentRequest.Parser, new[]{ "InstanceId", "ComponentTypeName", "PreferredInstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstantiatePrefabRequest), global::SailorEditor.Protocol.Generated.InstantiatePrefabRequest.Parser, new[]{ "FileId", "ParentInstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstantiatePrefabFromYamlRequest), global::SailorEditor.Protocol.Generated.InstantiatePrefabFromYamlRequest.Parser, new[]{ "PrefabYaml", "ParentInstanceId", "StrictInstanceIds" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest), global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest.Parser, new[]{ "ViewportId", "NormalizedX", "NormalizedY" }, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest), global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest.Parser, new[]{ "ModelFileId", "Name", "ParentInstanceId", "ApplyWorldPosition", "WorldPosition" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportRayRequest), global::SailorEditor.Protocol.Generated.ViewportRayRequest.Parser, new[]{ "ViewportId", "NormalizedX", "NormalizedY" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest), global::SailorEditor.Protocol.Generated.InstantiatePrefabInstanceRequest.Parser, new[]{ "FileId", "ParentInstanceId", "ApplyWorldPosition", "WorldPosition" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportObjectRequest), global::SailorEditor.Protocol.Generated.ViewportObjectRequest.Parser, new[]{ "ViewportId", "InstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.PrefabLinkRequest), global::SailorEditor.Protocol.Generated.PrefabLinkRequest.Parser, new[]{ "InstanceId", "FileId" }, null, null, null, null),
@@ -610,11 +604,8 @@ namespace SailorEditor.Protocol.Generated {
         case CommandOneofCase.IsEngineRunning:
           IsEngineRunning = other.IsEngineRunning.Clone();
           break;
-        case CommandOneofCase.ResolveViewportDropPosition:
-          ResolveViewportDropPosition = other.ResolveViewportDropPosition.Clone();
-          break;
-        case CommandOneofCase.CreateModelGameObject:
-          CreateModelGameObject = other.CreateModelGameObject.Clone();
+        case CommandOneofCase.TraceViewportRay:
+          TraceViewportRay = other.TraceViewportRay.Clone();
           break;
         case CommandOneofCase.InstantiatePrefabInstance:
           InstantiatePrefabInstance = other.InstantiatePrefabInstance.Clone();
@@ -1137,27 +1128,15 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
-    /// <summary>Field number for the "resolve_viewport_drop_position" field.</summary>
-    public const int ResolveViewportDropPositionFieldNumber = 49;
+    /// <summary>Field number for the "trace_viewport_ray" field.</summary>
+    public const int TraceViewportRayFieldNumber = 49;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest ResolveViewportDropPosition {
-      get { return commandCase_ == CommandOneofCase.ResolveViewportDropPosition ? (global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest) command_ : null; }
+    public global::SailorEditor.Protocol.Generated.ViewportRayRequest TraceViewportRay {
+      get { return commandCase_ == CommandOneofCase.TraceViewportRay ? (global::SailorEditor.Protocol.Generated.ViewportRayRequest) command_ : null; }
       set {
         command_ = value;
-        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.ResolveViewportDropPosition;
-      }
-    }
-
-    /// <summary>Field number for the "create_model_game_object" field.</summary>
-    public const int CreateModelGameObjectFieldNumber = 50;
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest CreateModelGameObject {
-      get { return commandCase_ == CommandOneofCase.CreateModelGameObject ? (global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest) command_ : null; }
-      set {
-        command_ = value;
-        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.CreateModelGameObject;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.TraceViewportRay;
       }
     }
 
@@ -1276,8 +1255,7 @@ namespace SailorEditor.Protocol.Generated {
       SerializeEngineTypes = 46,
       IsEngineMainThreadReady = 47,
       IsEngineRunning = 48,
-      ResolveViewportDropPosition = 49,
-      CreateModelGameObject = 50,
+      TraceViewportRay = 49,
       InstantiatePrefabInstance = 51,
       FocusEditorCamera = 52,
       SetPrefabLink = 53,
@@ -1355,8 +1333,7 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(SerializeEngineTypes, other.SerializeEngineTypes)) return false;
       if (!object.Equals(IsEngineMainThreadReady, other.IsEngineMainThreadReady)) return false;
       if (!object.Equals(IsEngineRunning, other.IsEngineRunning)) return false;
-      if (!object.Equals(ResolveViewportDropPosition, other.ResolveViewportDropPosition)) return false;
-      if (!object.Equals(CreateModelGameObject, other.CreateModelGameObject)) return false;
+      if (!object.Equals(TraceViewportRay, other.TraceViewportRay)) return false;
       if (!object.Equals(InstantiatePrefabInstance, other.InstantiatePrefabInstance)) return false;
       if (!object.Equals(FocusEditorCamera, other.FocusEditorCamera)) return false;
       if (!object.Equals(SetPrefabLink, other.SetPrefabLink)) return false;
@@ -1412,8 +1389,7 @@ namespace SailorEditor.Protocol.Generated {
       if (commandCase_ == CommandOneofCase.SerializeEngineTypes) hash ^= SerializeEngineTypes.GetHashCode();
       if (commandCase_ == CommandOneofCase.IsEngineMainThreadReady) hash ^= IsEngineMainThreadReady.GetHashCode();
       if (commandCase_ == CommandOneofCase.IsEngineRunning) hash ^= IsEngineRunning.GetHashCode();
-      if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) hash ^= ResolveViewportDropPosition.GetHashCode();
-      if (commandCase_ == CommandOneofCase.CreateModelGameObject) hash ^= CreateModelGameObject.GetHashCode();
+      if (commandCase_ == CommandOneofCase.TraceViewportRay) hash ^= TraceViewportRay.GetHashCode();
       if (commandCase_ == CommandOneofCase.InstantiatePrefabInstance) hash ^= InstantiatePrefabInstance.GetHashCode();
       if (commandCase_ == CommandOneofCase.FocusEditorCamera) hash ^= FocusEditorCamera.GetHashCode();
       if (commandCase_ == CommandOneofCase.SetPrefabLink) hash ^= SetPrefabLink.GetHashCode();
@@ -1603,13 +1579,9 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(130, 3);
         output.WriteMessage(IsEngineRunning);
       }
-      if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) {
+      if (commandCase_ == CommandOneofCase.TraceViewportRay) {
         output.WriteRawTag(138, 3);
-        output.WriteMessage(ResolveViewportDropPosition);
-      }
-      if (commandCase_ == CommandOneofCase.CreateModelGameObject) {
-        output.WriteRawTag(146, 3);
-        output.WriteMessage(CreateModelGameObject);
+        output.WriteMessage(TraceViewportRay);
       }
       if (commandCase_ == CommandOneofCase.InstantiatePrefabInstance) {
         output.WriteRawTag(154, 3);
@@ -1809,13 +1781,9 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(130, 3);
         output.WriteMessage(IsEngineRunning);
       }
-      if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) {
+      if (commandCase_ == CommandOneofCase.TraceViewportRay) {
         output.WriteRawTag(138, 3);
-        output.WriteMessage(ResolveViewportDropPosition);
-      }
-      if (commandCase_ == CommandOneofCase.CreateModelGameObject) {
-        output.WriteRawTag(146, 3);
-        output.WriteMessage(CreateModelGameObject);
+        output.WriteMessage(TraceViewportRay);
       }
       if (commandCase_ == CommandOneofCase.InstantiatePrefabInstance) {
         output.WriteRawTag(154, 3);
@@ -1974,11 +1942,8 @@ namespace SailorEditor.Protocol.Generated {
       if (commandCase_ == CommandOneofCase.IsEngineRunning) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(IsEngineRunning);
       }
-      if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) {
-        size += 2 + pb::CodedOutputStream.ComputeMessageSize(ResolveViewportDropPosition);
-      }
-      if (commandCase_ == CommandOneofCase.CreateModelGameObject) {
-        size += 2 + pb::CodedOutputStream.ComputeMessageSize(CreateModelGameObject);
+      if (commandCase_ == CommandOneofCase.TraceViewportRay) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(TraceViewportRay);
       }
       if (commandCase_ == CommandOneofCase.InstantiatePrefabInstance) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(InstantiatePrefabInstance);
@@ -2251,17 +2216,11 @@ namespace SailorEditor.Protocol.Generated {
           }
           IsEngineRunning.MergeFrom(other.IsEngineRunning);
           break;
-        case CommandOneofCase.ResolveViewportDropPosition:
-          if (ResolveViewportDropPosition == null) {
-            ResolveViewportDropPosition = new global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest();
+        case CommandOneofCase.TraceViewportRay:
+          if (TraceViewportRay == null) {
+            TraceViewportRay = new global::SailorEditor.Protocol.Generated.ViewportRayRequest();
           }
-          ResolveViewportDropPosition.MergeFrom(other.ResolveViewportDropPosition);
-          break;
-        case CommandOneofCase.CreateModelGameObject:
-          if (CreateModelGameObject == null) {
-            CreateModelGameObject = new global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest();
-          }
-          CreateModelGameObject.MergeFrom(other.CreateModelGameObject);
+          TraceViewportRay.MergeFrom(other.TraceViewportRay);
           break;
         case CommandOneofCase.InstantiatePrefabInstance:
           if (InstantiatePrefabInstance == null) {
@@ -2680,21 +2639,12 @@ namespace SailorEditor.Protocol.Generated {
             break;
           }
           case 394: {
-            global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest();
-            if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) {
-              subBuilder.MergeFrom(ResolveViewportDropPosition);
+            global::SailorEditor.Protocol.Generated.ViewportRayRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportRayRequest();
+            if (commandCase_ == CommandOneofCase.TraceViewportRay) {
+              subBuilder.MergeFrom(TraceViewportRay);
             }
             input.ReadMessage(subBuilder);
-            ResolveViewportDropPosition = subBuilder;
-            break;
-          }
-          case 402: {
-            global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest subBuilder = new global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest();
-            if (commandCase_ == CommandOneofCase.CreateModelGameObject) {
-              subBuilder.MergeFrom(CreateModelGameObject);
-            }
-            input.ReadMessage(subBuilder);
-            CreateModelGameObject = subBuilder;
+            TraceViewportRay = subBuilder;
             break;
           }
           case 410: {
@@ -3130,21 +3080,12 @@ namespace SailorEditor.Protocol.Generated {
             break;
           }
           case 394: {
-            global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportDropPositionRequest();
-            if (commandCase_ == CommandOneofCase.ResolveViewportDropPosition) {
-              subBuilder.MergeFrom(ResolveViewportDropPosition);
+            global::SailorEditor.Protocol.Generated.ViewportRayRequest subBuilder = new global::SailorEditor.Protocol.Generated.ViewportRayRequest();
+            if (commandCase_ == CommandOneofCase.TraceViewportRay) {
+              subBuilder.MergeFrom(TraceViewportRay);
             }
             input.ReadMessage(subBuilder);
-            ResolveViewportDropPosition = subBuilder;
-            break;
-          }
-          case 402: {
-            global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest subBuilder = new global::SailorEditor.Protocol.Generated.CreateModelGameObjectRequest();
-            if (commandCase_ == CommandOneofCase.CreateModelGameObject) {
-              subBuilder.MergeFrom(CreateModelGameObject);
-            }
-            input.ReadMessage(subBuilder);
-            CreateModelGameObject = subBuilder;
+            TraceViewportRay = subBuilder;
             break;
           }
           case 410: {
@@ -8794,16 +8735,16 @@ namespace SailorEditor.Protocol.Generated {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
-  public sealed partial class ViewportDropPositionRequest : pb::IMessage<ViewportDropPositionRequest>
+  public sealed partial class ViewportRayRequest : pb::IMessage<ViewportRayRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
   #endif
   {
-    private static readonly pb::MessageParser<ViewportDropPositionRequest> _parser = new pb::MessageParser<ViewportDropPositionRequest>(() => new ViewportDropPositionRequest());
+    private static readonly pb::MessageParser<ViewportRayRequest> _parser = new pb::MessageParser<ViewportRayRequest>(() => new ViewportRayRequest());
     private pb::UnknownFieldSet _unknownFields;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pb::MessageParser<ViewportDropPositionRequest> Parser { get { return _parser; } }
+    public static pb::MessageParser<ViewportRayRequest> Parser { get { return _parser; } }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
@@ -8819,7 +8760,7 @@ namespace SailorEditor.Protocol.Generated {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ViewportDropPositionRequest() {
+    public ViewportRayRequest() {
       OnConstruction();
     }
 
@@ -8827,7 +8768,7 @@ namespace SailorEditor.Protocol.Generated {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ViewportDropPositionRequest(ViewportDropPositionRequest other) : this() {
+    public ViewportRayRequest(ViewportRayRequest other) : this() {
       viewportId_ = other.viewportId_;
       normalizedX_ = other.normalizedX_;
       normalizedY_ = other.normalizedY_;
@@ -8836,8 +8777,8 @@ namespace SailorEditor.Protocol.Generated {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public ViewportDropPositionRequest Clone() {
-      return new ViewportDropPositionRequest(this);
+    public ViewportRayRequest Clone() {
+      return new ViewportRayRequest(this);
     }
 
     /// <summary>Field number for the "viewport_id" field.</summary>
@@ -8879,12 +8820,12 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public override bool Equals(object other) {
-      return Equals(other as ViewportDropPositionRequest);
+      return Equals(other as ViewportRayRequest);
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(ViewportDropPositionRequest other) {
+    public bool Equals(ViewportRayRequest other) {
       if (ReferenceEquals(other, null)) {
         return false;
       }
@@ -8983,7 +8924,7 @@ namespace SailorEditor.Protocol.Generated {
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(ViewportDropPositionRequest other) {
+    public void MergeFrom(ViewportRayRequest other) {
       if (other == null) {
         return;
       }
@@ -9066,361 +9007,6 @@ namespace SailorEditor.Protocol.Generated {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
-  public sealed partial class CreateModelGameObjectRequest : pb::IMessage<CreateModelGameObjectRequest>
-  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
-      , pb::IBufferMessage
-  #endif
-  {
-    private static readonly pb::MessageParser<CreateModelGameObjectRequest> _parser = new pb::MessageParser<CreateModelGameObjectRequest>(() => new CreateModelGameObjectRequest());
-    private pb::UnknownFieldSet _unknownFields;
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pb::MessageParser<CreateModelGameObjectRequest> Parser { get { return _parser; } }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    pbr::MessageDescriptor pb::IMessage.Descriptor {
-      get { return Descriptor; }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CreateModelGameObjectRequest() {
-      OnConstruction();
-    }
-
-    partial void OnConstruction();
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CreateModelGameObjectRequest(CreateModelGameObjectRequest other) : this() {
-      modelFileId_ = other.modelFileId_;
-      name_ = other.name_;
-      parentInstanceId_ = other.parentInstanceId_;
-      applyWorldPosition_ = other.applyWorldPosition_;
-      worldPosition_ = other.worldPosition_ != null ? other.worldPosition_.Clone() : null;
-      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public CreateModelGameObjectRequest Clone() {
-      return new CreateModelGameObjectRequest(this);
-    }
-
-    /// <summary>Field number for the "model_file_id" field.</summary>
-    public const int ModelFileIdFieldNumber = 1;
-    private string modelFileId_ = "";
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string ModelFileId {
-      get { return modelFileId_; }
-      set {
-        modelFileId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
-      }
-    }
-
-    /// <summary>Field number for the "name" field.</summary>
-    public const int NameFieldNumber = 2;
-    private string name_ = "";
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string Name {
-      get { return name_; }
-      set {
-        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
-      }
-    }
-
-    /// <summary>Field number for the "parent_instance_id" field.</summary>
-    public const int ParentInstanceIdFieldNumber = 3;
-    private string parentInstanceId_ = "";
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public string ParentInstanceId {
-      get { return parentInstanceId_; }
-      set {
-        parentInstanceId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
-      }
-    }
-
-    /// <summary>Field number for the "apply_world_position" field.</summary>
-    public const int ApplyWorldPositionFieldNumber = 4;
-    private bool applyWorldPosition_;
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool ApplyWorldPosition {
-      get { return applyWorldPosition_; }
-      set {
-        applyWorldPosition_ = value;
-      }
-    }
-
-    /// <summary>Field number for the "world_position" field.</summary>
-    public const int WorldPositionFieldNumber = 5;
-    private global::SailorEditor.Protocol.Generated.Vector4 worldPosition_;
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public global::SailorEditor.Protocol.Generated.Vector4 WorldPosition {
-      get { return worldPosition_; }
-      set {
-        worldPosition_ = value;
-      }
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override bool Equals(object other) {
-      return Equals(other as CreateModelGameObjectRequest);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public bool Equals(CreateModelGameObjectRequest other) {
-      if (ReferenceEquals(other, null)) {
-        return false;
-      }
-      if (ReferenceEquals(other, this)) {
-        return true;
-      }
-      if (ModelFileId != other.ModelFileId) return false;
-      if (Name != other.Name) return false;
-      if (ParentInstanceId != other.ParentInstanceId) return false;
-      if (ApplyWorldPosition != other.ApplyWorldPosition) return false;
-      if (!object.Equals(WorldPosition, other.WorldPosition)) return false;
-      return Equals(_unknownFields, other._unknownFields);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override int GetHashCode() {
-      int hash = 1;
-      if (ModelFileId.Length != 0) hash ^= ModelFileId.GetHashCode();
-      if (Name.Length != 0) hash ^= Name.GetHashCode();
-      if (ParentInstanceId.Length != 0) hash ^= ParentInstanceId.GetHashCode();
-      if (ApplyWorldPosition != false) hash ^= ApplyWorldPosition.GetHashCode();
-      if (worldPosition_ != null) hash ^= WorldPosition.GetHashCode();
-      if (_unknownFields != null) {
-        hash ^= _unknownFields.GetHashCode();
-      }
-      return hash;
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public override string ToString() {
-      return pb::JsonFormatter.ToDiagnosticString(this);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void WriteTo(pb::CodedOutputStream output) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
-      output.WriteRawMessage(this);
-    #else
-      if (ModelFileId.Length != 0) {
-        output.WriteRawTag(10);
-        output.WriteString(ModelFileId);
-      }
-      if (Name.Length != 0) {
-        output.WriteRawTag(18);
-        output.WriteString(Name);
-      }
-      if (ParentInstanceId.Length != 0) {
-        output.WriteRawTag(26);
-        output.WriteString(ParentInstanceId);
-      }
-      if (ApplyWorldPosition != false) {
-        output.WriteRawTag(32);
-        output.WriteBool(ApplyWorldPosition);
-      }
-      if (worldPosition_ != null) {
-        output.WriteRawTag(42);
-        output.WriteMessage(WorldPosition);
-      }
-      if (_unknownFields != null) {
-        _unknownFields.WriteTo(output);
-      }
-    #endif
-    }
-
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
-      if (ModelFileId.Length != 0) {
-        output.WriteRawTag(10);
-        output.WriteString(ModelFileId);
-      }
-      if (Name.Length != 0) {
-        output.WriteRawTag(18);
-        output.WriteString(Name);
-      }
-      if (ParentInstanceId.Length != 0) {
-        output.WriteRawTag(26);
-        output.WriteString(ParentInstanceId);
-      }
-      if (ApplyWorldPosition != false) {
-        output.WriteRawTag(32);
-        output.WriteBool(ApplyWorldPosition);
-      }
-      if (worldPosition_ != null) {
-        output.WriteRawTag(42);
-        output.WriteMessage(WorldPosition);
-      }
-      if (_unknownFields != null) {
-        _unknownFields.WriteTo(ref output);
-      }
-    }
-    #endif
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public int CalculateSize() {
-      int size = 0;
-      if (ModelFileId.Length != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeStringSize(ModelFileId);
-      }
-      if (Name.Length != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
-      }
-      if (ParentInstanceId.Length != 0) {
-        size += 1 + pb::CodedOutputStream.ComputeStringSize(ParentInstanceId);
-      }
-      if (ApplyWorldPosition != false) {
-        size += 1 + 1;
-      }
-      if (worldPosition_ != null) {
-        size += 1 + pb::CodedOutputStream.ComputeMessageSize(WorldPosition);
-      }
-      if (_unknownFields != null) {
-        size += _unknownFields.CalculateSize();
-      }
-      return size;
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(CreateModelGameObjectRequest other) {
-      if (other == null) {
-        return;
-      }
-      if (other.ModelFileId.Length != 0) {
-        ModelFileId = other.ModelFileId;
-      }
-      if (other.Name.Length != 0) {
-        Name = other.Name;
-      }
-      if (other.ParentInstanceId.Length != 0) {
-        ParentInstanceId = other.ParentInstanceId;
-      }
-      if (other.ApplyWorldPosition != false) {
-        ApplyWorldPosition = other.ApplyWorldPosition;
-      }
-      if (other.worldPosition_ != null) {
-        if (worldPosition_ == null) {
-          WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
-        }
-        WorldPosition.MergeFrom(other.WorldPosition);
-      }
-      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
-    }
-
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    public void MergeFrom(pb::CodedInputStream input) {
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
-      input.ReadRawMessage(this);
-    #else
-      uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
-          default:
-            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
-            break;
-          case 10: {
-            ModelFileId = input.ReadString();
-            break;
-          }
-          case 18: {
-            Name = input.ReadString();
-            break;
-          }
-          case 26: {
-            ParentInstanceId = input.ReadString();
-            break;
-          }
-          case 32: {
-            ApplyWorldPosition = input.ReadBool();
-            break;
-          }
-          case 42: {
-            if (worldPosition_ == null) {
-              WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
-            }
-            input.ReadMessage(WorldPosition);
-            break;
-          }
-        }
-      }
-    #endif
-    }
-
-    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
-    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
-    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
-    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
-      uint tag;
-      while ((tag = input.ReadTag()) != 0) {
-      if ((tag & 7) == 4) {
-        // Abort on any end group tag.
-        return;
-      }
-      switch(tag) {
-          default:
-            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
-            break;
-          case 10: {
-            ModelFileId = input.ReadString();
-            break;
-          }
-          case 18: {
-            Name = input.ReadString();
-            break;
-          }
-          case 26: {
-            ParentInstanceId = input.ReadString();
-            break;
-          }
-          case 32: {
-            ApplyWorldPosition = input.ReadBool();
-            break;
-          }
-          case 42: {
-            if (worldPosition_ == null) {
-              WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
-            }
-            input.ReadMessage(WorldPosition);
-            break;
-          }
-        }
-      }
-    }
-    #endif
-
-  }
-
-  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class InstantiatePrefabInstanceRequest : pb::IMessage<InstantiatePrefabInstanceRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -9435,7 +9021,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9753,7 +9339,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9988,7 +9574,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10223,7 +9809,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10495,7 +10081,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10682,7 +10268,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10880,7 +10466,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11226,7 +10812,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11424,7 +11010,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11622,7 +11208,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11820,7 +11406,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12018,7 +11604,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12253,7 +11839,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12440,7 +12026,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12749,7 +12335,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12984,7 +12570,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13191,7 +12777,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13426,7 +13012,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13735,7 +13321,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13933,7 +13519,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14481,7 +14067,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14753,7 +14339,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14951,7 +14537,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15425,7 +15011,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -2474,7 +2474,7 @@ namespace SailorEditor.Services
                 cancellationToken);
         }
 
-        public async Task<Vec4?> ResolveViewportDropPositionAsync(
+        public async Task<Vec4?> TraceViewportRayAsync(
             double normalizedX,
             double normalizedY,
             CancellationToken cancellationToken = default)
@@ -2493,7 +2493,7 @@ namespace SailorEditor.Services
             var succeeded = await InvokeRunningInteropAsync(async token =>
                 {
                     resolved =
-                        await protocolClient.ResolveViewportDropPositionAsync(
+                        await protocolClient.TraceViewportRayAsync(
                             SceneViewportId,
                             (float)normalizedX,
                             (float)normalizedY,
@@ -2510,30 +2510,6 @@ namespace SailorEditor.Services
                     W = resolved.W
                 }
                 : null;
-        }
-
-        public Task<InstanceId?> CreateModelGameObjectAsync(
-            FileId modelFileId,
-            string name,
-            InstanceId? parentId = null,
-            Vec4? worldPosition = null,
-            CancellationToken cancellationToken = default)
-        {
-            var position = worldPosition is null
-                ? (EngineProtocolVector4?)null
-                : new EngineProtocolVector4(
-                    worldPosition.X,
-                    worldPosition.Y,
-                    worldPosition.Z,
-                    worldPosition.W);
-            return InvokeCreationInteropAsync(
-                token => protocolClient.CreateModelGameObjectAsync(
-                    modelFileId?.Value ?? string.Empty,
-                    name ?? string.Empty,
-                    parentId?.Value ?? string.Empty,
-                    position,
-                    token),
-                cancellationToken);
         }
 
         public async Task<bool> DestroyObjectAsync(

--- a/Editor/Views/ContentFolderView.xaml.cs
+++ b/Editor/Views/ContentFolderView.xaml.cs
@@ -93,7 +93,7 @@ namespace SailorEditor.Views
             contentStore.SelectAsset(file);
         }
 
-        async void OnContentSelectionChanged(object sender, SelectionChangedEventArgs args)
+        void OnContentSelectionChanged(object sender, SelectionChangedEventArgs args)
         {
             if (suppressSelectionChanged)
             {
@@ -106,7 +106,9 @@ namespace SailorEditor.Views
                 return;
             }
 
-            await SelectRow(row, false);
+            RunContentUiAction(
+                () => SelectRow(row, false),
+                "Select Content item");
         }
 
         async Task SelectRow(ContentListRow row, bool updateCollectionSelection)
@@ -175,6 +177,7 @@ namespace SailorEditor.Views
             }
 
             e.Handled = true;
+            await Task.Yield();
 
             if (requiresConfirmation && target is PrefabFile prefab && source is GameObject gameObject)
             {
@@ -529,8 +532,41 @@ namespace SailorEditor.Views
                 AppendChildren(rows, foldersByParent, assetsByFolder, foldersById, -1, projection.TopLevelDepth, projection);
             }
 
-            ReplaceRows(visibleRows, rows);
-            RestoreSelection();
+            var desiredSelectedRow = rows.FirstOrDefault(
+                row => row.IsSelected);
+            var currentSelectedRow =
+                ContentList.SelectedItem as ContentListRow;
+            var preservesCurrentSelection =
+                currentSelectedRow is not null &&
+                desiredSelectedRow is not null &&
+                string.Equals(
+                    currentSelectedRow.Id,
+                    desiredSelectedRow.Id,
+                    StringComparison.Ordinal) &&
+                EqualityComparer<ContentListRow>.Default.Equals(
+                    currentSelectedRow,
+                    desiredSelectedRow) &&
+                visibleRows.Contains(currentSelectedRow);
+            suppressSelectionChanged = true;
+            try
+            {
+                if (!preservesCurrentSelection &&
+                    currentSelectedRow is not null)
+                {
+                    ContentList.SelectedItem = null;
+                }
+
+                ContentRowReconciler.Reconcile(
+                    visibleRows,
+                    rows,
+                    row => row.Id);
+                ContentList.SelectedItem =
+                    visibleRows.FirstOrDefault(row => row.IsSelected);
+            }
+            finally
+            {
+                suppressSelectionChanged = false;
+            }
         }
 
         void AppendChildren(
@@ -703,32 +739,39 @@ namespace SailorEditor.Views
                 border.GestureRecognizers.Add(dropGesture);
 
                 var singleTap = new TapGestureRecognizer { NumberOfTapsRequired = 1 };
-                singleTap.Tapped += async (_, _) =>
+                singleTap.Tapped += (_, _) =>
                 {
                     if (border.BindingContext is ContentListRow row)
                     {
-                        await SelectRow(row, true);
+                        RunContentUiAction(
+                            () => SelectRow(row, true),
+                            "Select Content item");
                     }
                 };
                 border.GestureRecognizers.Add(singleTap);
 
                 var doubleTap = new TapGestureRecognizer { NumberOfTapsRequired = 2 };
-                doubleTap.Tapped += async (_, _) =>
+                doubleTap.Tapped += (_, _) =>
                 {
                     if (border.BindingContext is not ContentListRow row || !rowModelsById.TryGetValue(row.Id, out var model))
                     {
                         return;
                     }
 
-                    switch (model)
-                    {
-                        case WorldFile worldFile:
-                            await OpenWorldWithConfirmation(worldFile);
-                            break;
-                        case AssetFolder or ProjectContentFolderItem:
-                            ToggleFolder(row);
-                            break;
-                    }
+                    RunContentUiAction(
+                        async () =>
+                        {
+                            switch (model)
+                            {
+                                case WorldFile worldFile:
+                                    await OpenWorldWithConfirmation(worldFile);
+                                    break;
+                                case AssetFolder or ProjectContentFolderItem:
+                                    ToggleFolder(row);
+                                    break;
+                            }
+                        },
+                        "Open Content item");
                 };
                 border.GestureRecognizers.Add(doubleTap);
 
@@ -766,7 +809,9 @@ namespace SailorEditor.Views
                     items.Add(new EditorContextMenuItem
                     {
                         Text = "Duplicate",
-                        Command = new Command(async () => await DuplicateAsset(assetFile))
+                        Command = CreateContentContextMenuCommand(
+                            () => DuplicateAsset(assetFile),
+                            "Duplicate asset")
                     });
                 }
 
@@ -775,7 +820,9 @@ namespace SailorEditor.Views
                     items.Add(new EditorContextMenuItem
                     {
                         Text = "Rename",
-                        Command = new Command(async () => await RenameAsset(assetFile))
+                        Command = CreateContentContextMenuCommand(
+                            () => RenameAsset(assetFile),
+                            "Rename asset")
                     });
                 }
 
@@ -783,7 +830,9 @@ namespace SailorEditor.Views
                 {
                     Text = "Delete",
                     IsDestructive = true,
-                    Command = new Command(async () => await DeleteAsset(assetFile))
+                    Command = CreateContentContextMenuCommand(
+                        () => DeleteAsset(assetFile),
+                        "Delete asset")
                 };
                 items.Add(deleteItem);
                 contextMenu.Show(items.ToArray());
@@ -795,7 +844,9 @@ namespace SailorEditor.Views
                     new EditorContextMenuItem
                     {
                         Text = "Create Folder",
-                        Command = new Command(async () => await CreateFolder(folder))
+                        Command = CreateContentContextMenuCommand(
+                            () => CreateFolder(folder),
+                            "Create folder")
                     }
                 };
                 if (service.CanModifyFolder(folder))
@@ -803,13 +854,17 @@ namespace SailorEditor.Views
                     items.Add(new EditorContextMenuItem
                     {
                         Text = "Rename",
-                        Command = new Command(async () => await RenameFolder(folder))
+                        Command = CreateContentContextMenuCommand(
+                            () => RenameFolder(folder),
+                            "Rename folder")
                     });
                     items.Add(new EditorContextMenuItem
                     {
                         Text = "Delete",
                         IsDestructive = true,
-                        Command = new Command(async () => await DeleteFolder(folder))
+                        Command = CreateContentContextMenuCommand(
+                            () => DeleteFolder(folder),
+                            "Delete folder")
                     });
                 }
                 contextMenu.Show(items.ToArray());
@@ -820,23 +875,21 @@ namespace SailorEditor.Views
                 contextMenu.Show(new EditorContextMenuItem
                 {
                     Text = "Create Folder",
-                    Command = new Command(async () => await CreateFolder(null))
+                    Command = CreateContentContextMenuCommand(
+                        () => CreateFolder(null),
+                        "Create folder")
                 });
             }
         }
 
-        void RestoreSelection()
+        static Command CreateContentContextMenuCommand(
+            Func<Task> action,
+            string operation)
         {
-            var selected = visibleRows.FirstOrDefault(row => row.IsSelected);
-            suppressSelectionChanged = true;
-            try
-            {
-                ContentList.SelectedItem = selected;
-            }
-            finally
-            {
-                suppressSelectionChanged = false;
-            }
+            return new Command(
+                () => RunContentUiAction(
+                    action,
+                    operation));
         }
 
         static void RunContentUiAction(
@@ -934,14 +987,6 @@ namespace SailorEditor.Views
                 int.TryParse(id["folder:".Length..], out folderId);
         }
 
-        static void ReplaceRows(ObservableCollection<ContentListRow> target, IReadOnlyList<ContentListRow> desired)
-        {
-            target.Clear();
-            foreach (var row in desired)
-            {
-                target.Add(row);
-            }
-        }
     }
 
     public sealed record ContentListRow(string Id, int Depth, string Label, string Icon, bool HasChildren, bool IsExpanded, bool IsSelected)

--- a/Editor/Views/HierarchyView.xaml.cs
+++ b/Editor/Views/HierarchyView.xaml.cs
@@ -1,4 +1,5 @@
 using SailorEditor.Commands;
+using SailorEditor.Panels;
 using SailorEditor.Services;
 using SailorEditor.Shell;
 using SailorEditor.Utility;
@@ -6,6 +7,7 @@ using SailorEditor.Workflow;
 using SailorEngine;
 using System.Collections.ObjectModel;
 using GameObject = SailorEditor.ViewModels.GameObject;
+using PrefabFile = SailorEditor.ViewModels.PrefabFile;
 using World = SailorEditor.ViewModels.World;
 
 namespace SailorEditor.Views
@@ -82,19 +84,29 @@ namespace SailorEditor.Views
 
         async void OnHierarchySelectionChanged(object? sender, SelectionChangedEventArgs args)
             => await ExecuteHierarchyActionAsync(
-                () => ApplyHierarchySelectionAsync(args),
+                () => SelectHierarchyRowAsync(
+                    args.CurrentSelection.FirstOrDefault()
+                        as HierarchyListRow,
+                    updateCollectionSelection: false),
                 "Select GameObject");
 
-        async Task ApplyHierarchySelectionAsync(SelectionChangedEventArgs args)
+        async Task SelectHierarchyRowAsync(
+            HierarchyListRow? row,
+            bool updateCollectionSelection)
         {
             if (suppressSelectionChanged)
             {
                 return;
             }
 
-            if (args.CurrentSelection.FirstOrDefault() is not HierarchyListRow row)
+            if (row == null)
             {
                 return;
+            }
+
+            if (updateCollectionSelection)
+            {
+                SetHierarchySelection(row);
             }
 
             if (!gameObjectsById.TryGetValue(row.InstanceId, out var gameObject))
@@ -336,6 +348,23 @@ namespace SailorEditor.Views
                 };
                 border.GestureRecognizers.Add(dropGesture);
 
+                var selectGesture = new TapGestureRecognizer
+                {
+                    NumberOfTapsRequired = 1
+                };
+                selectGesture.Tapped += (_, _) =>
+                {
+                    if (border.BindingContext is HierarchyListRow row)
+                    {
+                        _ = ExecuteHierarchyActionAsync(
+                            () => SelectHierarchyRowAsync(
+                                row,
+                                updateCollectionSelection: true),
+                            "Select GameObject");
+                    }
+                };
+                border.GestureRecognizers.Add(selectGesture);
+
                 var focusGesture = new TapGestureRecognizer
                 {
                     NumberOfTapsRequired = 2
@@ -344,7 +373,15 @@ namespace SailorEditor.Views
                 {
                     if (border.BindingContext is HierarchyListRow row)
                     {
-                        _ = FocusGameObjectAsync(row);
+                        _ = ExecuteHierarchyActionAsync(
+                            async () =>
+                            {
+                                await SelectHierarchyRowAsync(
+                                    row,
+                                    updateCollectionSelection: true);
+                                await FocusGameObjectAsync(row);
+                            },
+                            "Focus GameObject");
                     }
                 };
                 border.GestureRecognizers.Add(focusGesture);
@@ -416,23 +453,39 @@ namespace SailorEditor.Views
             if (row is
                 {
                     IsPrefabLinked: true,
-                    PrefabFileId: not null,
-                    PrefabRootInstanceId: not null
+                    PrefabFileId: not null
                 } &&
-                !string.IsNullOrWhiteSpace(row.PrefabRootInstanceId))
+                !string.IsNullOrWhiteSpace(row.PrefabFileId))
             {
                 items.Insert(
                     2,
                     new EditorContextMenuItem
                     {
-                        Text = "Break Prefab Link",
+                        Text = "Select Prefab",
                         Command = CreateContextMenuCommand(
-                            () => BreakPrefabLinkAsync(
-                                new InstanceId(
-                                    row.PrefabRootInstanceId),
-                                row.PrefabFileId),
-                            "Break Prefab Link")
+                            () => SelectPrefabAsync(row.PrefabFileId),
+                            "Select Prefab")
                     });
+
+                if (row is
+                    {
+                        PrefabRootInstanceId: not null
+                    } &&
+                    !string.IsNullOrWhiteSpace(row.PrefabRootInstanceId))
+                {
+                    items.Insert(
+                        3,
+                        new EditorContextMenuItem
+                        {
+                            Text = "Break Prefab Link",
+                            Command = CreateContextMenuCommand(
+                                () => BreakPrefabLinkAsync(
+                                    new InstanceId(
+                                        row.PrefabRootInstanceId),
+                                    row.PrefabFileId),
+                                "Break Prefab Link")
+                        });
+                }
             }
 
             return contextMenu.CreateFlyout([.. items]);
@@ -548,6 +601,38 @@ namespace SailorEditor.Views
             {
                 throw new InvalidOperationException(
                     result.Message ?? "Break prefab link failed");
+            }
+        }
+
+        async Task SelectPrefabAsync(string prefabFileId)
+        {
+            var fileId = new FileId(prefabFileId);
+            if (!MauiProgram.GetService<AssetsService>()
+                    .Assets.TryGetValue(fileId, out var asset) ||
+                asset is not PrefabFile prefab)
+            {
+                throw new InvalidOperationException(
+                    $"Prefab asset '{prefabFileId}' is not available.");
+            }
+
+            await MauiProgram.GetService<EditorShellHost>()
+                .OpenPanelAsync(KnownPanelTypes.Content);
+
+            var contextProvider =
+                MauiProgram.GetService<IActionContextProvider>();
+            var context = contextProvider.GetCurrentContext(
+                new CommandOrigin(
+                    CommandOriginKind.Menu,
+                    nameof(HierarchyView)));
+            var result = await MauiProgram
+                .GetService<ICommandDispatcher>()
+                .DispatchAsync(
+                    new OpenAssetCommand(prefab),
+                    context);
+            if (!result.Succeeded)
+            {
+                throw new InvalidOperationException(
+                    result.Message ?? "Select prefab failed");
             }
         }
 

--- a/Editor/Views/SceneView.xaml.cs
+++ b/Editor/Views/SceneView.xaml.cs
@@ -231,12 +231,11 @@ namespace SailorEditor.Views
                     input.Pressed,
                     isFocused,
                     GetViewportToolState(),
-                    out var shortcutState) &&
+                    out var shortcutState))
+            {
                 await ApplyViewportToolStateAsync(
                     shortcutState,
-                    cancellationToken))
-            {
-                return NativeViewportInputDispatchResult.Forwarded;
+                    cancellationToken);
             }
 
             if (input.Kind ==
@@ -680,13 +679,13 @@ namespace SailorEditor.Views
             ActionContext context)
         {
             var worldPosition = await engineService
-                .ResolveViewportDropPositionAsync(
+                .TraceViewportRayAsync(
                     normalizedX,
                     normalizedY);
             if (worldPosition is null)
             {
                 return CommandResult.Failure(
-                    "Viewport drop position could not be resolved");
+                    "Viewport ray target could not be resolved");
             }
 
             if (!EditorDragDrop.TryCreateViewportDropCommand(

--- a/Editor/Workflow/WorkflowProjections.cs
+++ b/Editor/Workflow/WorkflowProjections.cs
@@ -115,6 +115,86 @@ public static class HierarchyRowReconciler
     }
 }
 
+public static class ContentRowReconciler
+{
+    public static void Reconcile<T>(
+        ObservableCollection<T> current,
+        IReadOnlyList<T> desired,
+        Func<T, string> getIdentity)
+    {
+        ArgumentNullException.ThrowIfNull(current);
+        ArgumentNullException.ThrowIfNull(desired);
+        ArgumentNullException.ThrowIfNull(getIdentity);
+
+        var desiredIdentities = desired
+            .Select(getIdentity)
+            .ToHashSet(StringComparer.Ordinal);
+        for (var currentIndex = current.Count - 1;
+            currentIndex >= 0;
+            currentIndex--)
+        {
+            if (!desiredIdentities.Contains(
+                    getIdentity(current[currentIndex])))
+            {
+                current.RemoveAt(currentIndex);
+            }
+        }
+
+        for (var desiredIndex = 0; desiredIndex < desired.Count; desiredIndex++)
+        {
+            var desiredRow = desired[desiredIndex];
+            var desiredIdentity = getIdentity(desiredRow);
+            if (desiredIndex < current.Count &&
+                string.Equals(
+                    getIdentity(current[desiredIndex]),
+                    desiredIdentity,
+                    StringComparison.Ordinal))
+            {
+                if (!EqualityComparer<T>.Default.Equals(
+                        current[desiredIndex],
+                        desiredRow))
+                {
+                    current[desiredIndex] = desiredRow;
+                }
+                continue;
+            }
+
+            var existingIndex = -1;
+            for (var currentIndex = desiredIndex + 1;
+                currentIndex < current.Count;
+                currentIndex++)
+            {
+                if (string.Equals(
+                        getIdentity(current[currentIndex]),
+                        desiredIdentity,
+                        StringComparison.Ordinal))
+                {
+                    existingIndex = currentIndex;
+                    break;
+                }
+            }
+
+            if (existingIndex >= 0)
+            {
+                current.Move(existingIndex, desiredIndex);
+                if (!EqualityComparer<T>.Default.Equals(
+                        current[desiredIndex],
+                        desiredRow))
+                {
+                    current[desiredIndex] = desiredRow;
+                }
+            }
+            else
+            {
+                current.Insert(desiredIndex, desiredRow);
+            }
+        }
+
+        while (current.Count > desired.Count)
+            current.RemoveAt(current.Count - 1);
+    }
+}
+
 public static class InspectorSelectionIdentity
 {
     public static bool AreEquivalent(Type? currentType, string? currentId, Type? nextType, string? nextId)

--- a/Lib/EditorEngineProtocol.cpp
+++ b/Lib/EditorEngineProtocol.cpp
@@ -781,11 +781,11 @@ namespace
 		}
 	}
 
-	void DispatchResolveViewportDropPosition(
-		const sailor::editor::v1::ViewportDropPositionRequest& request,
+	void DispatchTraceViewportRay(
+		const sailor::editor::v1::ViewportRayRequest& request,
 		ProtocolResponse& response)
 	{
-		if (request.viewport_id() == 0 ||
+		if (request.viewport_id() != 1u ||
 			!std::isfinite(request.normalized_x()) ||
 			!std::isfinite(request.normalized_y()) ||
 			request.normalized_x() < 0.0f ||
@@ -793,51 +793,26 @@ namespace
 			request.normalized_y() < 0.0f ||
 			request.normalized_y() > 1.0f)
 		{
-			SetError(response, "The viewport drop request is invalid.");
+			SetError(response, "The viewport ray request is invalid.");
 			return;
 		}
 
 		float worldX = 0.0f;
 		float worldY = 0.0f;
 		float worldZ = 0.0f;
-		if (!Sailor::App::ResolveEditorViewportDropPosition(
+		if (!Sailor::App::TraceViewportRay(
+				request.viewport_id(),
 				request.normalized_x(),
 				request.normalized_y(),
 				worldX,
 				worldY,
 				worldZ))
 		{
-			SetError(response, "Failed to resolve the viewport drop position.");
+			SetError(response, "Failed to trace the viewport ray.");
 			return;
 		}
 
 		SetVector4Result(response, worldX, worldY, worldZ, 1.0f);
-	}
-
-	void DispatchCreateModelGameObject(
-		const sailor::editor::v1::CreateModelGameObjectRequest& request,
-		ProtocolResponse& response)
-	{
-		if (request.apply_world_position() &&
-			(!request.has_world_position() ||
-				!IsFiniteVector4(request.world_position())))
-		{
-			SetError(response, "The model world position is invalid.");
-			return;
-		}
-
-		TInteropString instanceId;
-		const Vector4& worldPosition = request.world_position();
-		const bool bSucceeded = Sailor::App::CreateEditorModelGameObject(
-			request.model_file_id().c_str(),
-			request.name().c_str(),
-			request.parent_instance_id().c_str(),
-			request.apply_world_position(),
-			worldPosition.x(),
-			worldPosition.y(),
-			worldPosition.z(),
-			instanceId.GetOutput());
-		SetInstanceIdResult(response, bSucceeded, instanceId.GetValue());
 	}
 
 	void DispatchInstantiatePrefabInstance(
@@ -1207,15 +1182,9 @@ namespace
 				Sailor::App::IsEngineMainThreadReady());
 			break;
 
-		case ProtocolRequest::kResolveViewportDropPosition:
-			DispatchResolveViewportDropPosition(
-				request.resolve_viewport_drop_position(),
-				response);
-			break;
-
-		case ProtocolRequest::kCreateModelGameObject:
-			DispatchCreateModelGameObject(
-				request.create_model_game_object(),
+		case ProtocolRequest::kTraceViewportRay:
+			DispatchTraceViewportRay(
+				request.trace_viewport_ray(),
 				response);
 			break;
 

--- a/Protocol/README.md
+++ b/Protocol/README.md
@@ -51,6 +51,13 @@ blocked regular operation. Shutdown waits for admitted operations to leave the
 Editor worker before destroying the Scheduler, so it must never run as an
 Editor-worker task and attempt to join itself.
 
+`trace_viewport_ray` resolves a finite world-space target for normalized
+top-left viewport coordinates. The current scene viewport chooses the nearest
+ready-mesh world AABB entry, then a forward intersection with the `y=0` plane,
+then a point 1000 units forward. A request fails only when the viewport,
+coordinates, active camera, or resulting ray is invalid; an empty scene is not
+a trace failure.
+
 Compatibility rules:
 
 - Ordinary commands use baseline `protocol_version = 1`. Strict InstanceId

--- a/Protocol/editor_engine.proto
+++ b/Protocol/editor_engine.proto
@@ -51,8 +51,7 @@ message ProtocolRequest {
 		Empty serialize_engine_types = 46;
 		Empty is_engine_main_thread_ready = 47;
 		Empty is_engine_running = 48;
-		ViewportDropPositionRequest resolve_viewport_drop_position = 49;
-		CreateModelGameObjectRequest create_model_game_object = 50;
+		ViewportRayRequest trace_viewport_ray = 49;
 		InstantiatePrefabInstanceRequest instantiate_prefab_instance = 51;
 		ViewportObjectRequest focus_editor_camera = 52;
 		PrefabLinkRequest set_prefab_link = 53;
@@ -62,6 +61,9 @@ message ProtocolRequest {
 	}
 
 	reserved 3 to 9;
+	reserved 50;
+	reserved "create_model_game_object";
+	reserved "resolve_viewport_drop_position";
 	reserved 57 to 99;
 }
 
@@ -192,18 +194,10 @@ message InstantiatePrefabFromYamlRequest {
 	bool strict_instance_ids = 3;
 }
 
-message ViewportDropPositionRequest {
+message ViewportRayRequest {
 	uint64 viewport_id = 1;
 	float normalized_x = 2;
 	float normalized_y = 3;
-}
-
-message CreateModelGameObjectRequest {
-	string model_file_id = 1;
-	string name = 2;
-	string parent_instance_id = 3;
-	bool apply_world_position = 4;
-	Vector4 world_position = 5;
 }
 
 message InstantiatePrefabInstanceRequest {

--- a/Runtime/AssetRegistry/Prefab/PrefabImporter.cpp
+++ b/Runtime/AssetRegistry/Prefab/PrefabImporter.cpp
@@ -19,34 +19,6 @@ using namespace Sailor;
 
 namespace
 {
-	bool TryGetComponentInstanceId(
-		const ReflectedData& reflection,
-		InstanceId& outInstanceId,
-		std::string& outDiagnostic)
-	{
-		if (!reflection.IsValid() || !reflection.GetProperties().ContainsKey("instanceId"))
-		{
-			outDiagnostic = "the reflected component has no valid instanceId";
-			return false;
-		}
-
-		if (!External::TryConvertYaml(
-				reflection.GetProperties()["instanceId"],
-				outInstanceId,
-				outDiagnostic) ||
-			outInstanceId.ComponentId() == InstanceId::Invalid ||
-			outInstanceId.GameObjectId() == InstanceId::Invalid)
-		{
-			if (outDiagnostic.empty())
-			{
-				outDiagnostic = "the reflected component has an invalid instanceId";
-			}
-			return false;
-		}
-
-		return true;
-	}
-
 	bool TryMergeComponentOverride(
 		const ReflectedData& base,
 		const ReflectedData& delta,
@@ -280,26 +252,15 @@ bool Prefab::ValidateForInstantiation(std::string& outDiagnostic) const
 			return false;
 		}
 
-		const auto& properties = reflection.GetProperties();
-		if (!properties.ContainsKey("instanceId"))
-		{
-			outDiagnostic = "reflected component " + std::to_string(componentIndex) +
-				" has no instanceId";
-			return false;
-		}
-
 		InstanceId componentInstanceId;
 		std::string conversionDiagnostic;
-		if (!External::TryConvertYaml(properties["instanceId"], componentInstanceId, conversionDiagnostic) ||
-			componentInstanceId.ComponentId() == InstanceId::Invalid ||
-			componentInstanceId.GameObjectId() == InstanceId::Invalid)
+		if (!Utils::TryGetComponentInstanceId(
+				reflection,
+				componentInstanceId,
+				conversionDiagnostic))
 		{
 			outDiagnostic = "reflected component " + std::to_string(componentIndex) +
-				" has an invalid instanceId";
-			if (!conversionDiagnostic.empty())
-			{
-				outDiagnostic += ": " + conversionDiagnostic;
-			}
+				" has an invalid identity: " + conversionDiagnostic;
 			return false;
 		}
 
@@ -672,7 +633,7 @@ bool Prefab::ConfigureLinkedInstance(
 		{
 			InstanceId componentInstanceId;
 			std::string conversionDiagnostic;
-			if (!TryGetComponentInstanceId(m_components[index], componentInstanceId, conversionDiagnostic))
+			if (!Utils::TryGetComponentInstanceId(m_components[index], componentInstanceId, conversionDiagnostic))
 			{
 				outDiagnostic = conversionDiagnostic;
 				return false;

--- a/Runtime/AssetRegistry/World/WorldPrefabImporter.cpp
+++ b/Runtime/AssetRegistry/World/WorldPrefabImporter.cpp
@@ -22,102 +22,6 @@ using namespace Sailor;
 
 namespace
 {
-	bool AreYamlNodesEqual(const YAML::Node& lhs, const YAML::Node& rhs)
-	{
-		if (lhs.IsDefined() != rhs.IsDefined())
-		{
-			return false;
-		}
-
-		if (!lhs.IsDefined())
-		{
-			return true;
-		}
-
-		if (lhs.Type() != rhs.Type())
-		{
-			return false;
-		}
-
-		switch (lhs.Type())
-		{
-		case YAML::NodeType::Null:
-			return true;
-
-		case YAML::NodeType::Scalar:
-			return lhs.Scalar() == rhs.Scalar();
-
-		case YAML::NodeType::Sequence:
-			if (lhs.size() != rhs.size())
-			{
-				return false;
-			}
-
-			for (size_t index = 0; index < lhs.size(); ++index)
-			{
-				if (!AreYamlNodesEqual(lhs[index], rhs[index]))
-				{
-					return false;
-				}
-			}
-			return true;
-
-		case YAML::NodeType::Map:
-			if (lhs.size() != rhs.size())
-			{
-				return false;
-			}
-
-			{
-				TVector<bool> matchedRightEntries(rhs.size());
-				for (const auto& leftEntry : lhs)
-				{
-					bool bFoundMatch = false;
-					size_t rightIndex = 0;
-					for (const auto& rightEntry : rhs)
-					{
-						if (!matchedRightEntries[rightIndex] &&
-							AreYamlNodesEqual(leftEntry.first, rightEntry.first) &&
-							AreYamlNodesEqual(leftEntry.second, rightEntry.second))
-						{
-							matchedRightEntries[rightIndex] = true;
-							bFoundMatch = true;
-							break;
-						}
-						++rightIndex;
-					}
-
-					if (!bFoundMatch)
-					{
-						return false;
-					}
-				}
-			}
-			return true;
-
-		case YAML::NodeType::Undefined:
-		default:
-			return false;
-		}
-	}
-
-	bool TryGetComponentInstanceId(
-		const ReflectedData& reflection,
-		InstanceId& outInstanceId,
-		std::string& outDiagnostic)
-	{
-		if (!reflection.IsValid() || !reflection.GetProperties().ContainsKey("instanceId"))
-		{
-			outDiagnostic = "a reflected component has no instanceId";
-			return false;
-		}
-
-		return External::TryConvertYaml(
-			reflection.GetProperties()["instanceId"],
-			outInstanceId,
-			outDiagnostic);
-	}
-
 	InstanceId NormalizeInstanceId(
 		const InstanceId& liveInstanceId,
 		const TMap<InstanceId, InstanceId>& instanceToSourceIds)
@@ -461,7 +365,7 @@ void WorldPrefab::Deserialize(const YAML::Node& inData)
 		{
 			InstanceId sourceComponentId;
 			std::string conversionDiagnostic;
-			if (!TryGetComponentInstanceId(
+			if (!Utils::TryGetComponentInstanceId(
 					sourceComponent,
 					sourceComponentId,
 					conversionDiagnostic))
@@ -745,21 +649,21 @@ bool WorldPrefab::BuildLinkedOverrides(
 			gameObjectOverride["name"] = expandedGameObject->m_name;
 		}
 
-		if (!AreYamlNodesEqual(
+		if (!Utils::AreYamlNodesEqual(
 				YAML::Node(expandedGameObject->m_position),
 				YAML::Node(sourceGameObject.m_position)))
 		{
 			gameObjectOverride["position"] = expandedGameObject->m_position;
 		}
 
-		if (!AreYamlNodesEqual(
+		if (!Utils::AreYamlNodesEqual(
 				YAML::Node(expandedGameObject->m_rotation),
 				YAML::Node(sourceGameObject.m_rotation)))
 		{
 			gameObjectOverride["rotation"] = expandedGameObject->m_rotation;
 		}
 
-		if (!AreYamlNodesEqual(
+		if (!Utils::AreYamlNodesEqual(
 				YAML::Node(expandedGameObject->m_scale),
 				YAML::Node(sourceGameObject.m_scale)))
 		{
@@ -778,7 +682,7 @@ bool WorldPrefab::BuildLinkedOverrides(
 			const ReflectedData& sourceReflection =
 				sourcePrefab->m_components[sourceComponentIndex];
 			InstanceId sourceComponentId;
-			if (!TryGetComponentInstanceId(
+			if (!Utils::TryGetComponentInstanceId(
 					sourceReflection,
 					sourceComponentId,
 					outDiagnostic))
@@ -797,7 +701,7 @@ bool WorldPrefab::BuildLinkedOverrides(
 					expandedPrefab->m_components[expandedComponentIndex];
 				InstanceId candidateInstanceId;
 				std::string conversionDiagnostic;
-				if (!TryGetComponentInstanceId(
+				if (!Utils::TryGetComponentInstanceId(
 						candidate,
 						candidateInstanceId,
 						conversionDiagnostic))
@@ -838,7 +742,7 @@ bool WorldPrefab::BuildLinkedOverrides(
 						instanceToSourceIds);
 				if (!sourceReflection.GetProperties().ContainsKey(
 						liveProperty.m_first) ||
-					!AreYamlNodesEqual(
+					!Utils::AreYamlNodesEqual(
 						normalizedLiveValue,
 						sourceReflection.GetProperties()[
 							liveProperty.m_first]))
@@ -997,10 +901,10 @@ bool WorldPrefab::BuildUpdatedLinkedOverrides(
 				{
 					const bool bChangedFromBaseline =
 						bHasBaseline &&
-						!AreYamlNodesEqual(liveValue, baselineValue);
+						!Utils::AreYamlNodesEqual(liveValue, baselineValue);
 					if (bChangedFromBaseline)
 					{
-						if (!AreYamlNodesEqual(liveValue, sourceValue))
+						if (!Utils::AreYamlNodesEqual(liveValue, sourceValue))
 						{
 							gameObjectOverride[propertyName] =
 								YAML::Clone(liveValue);
@@ -1052,7 +956,7 @@ bool WorldPrefab::BuildUpdatedLinkedOverrides(
 			const ReflectedData& sourceReflection =
 				sourcePrefab->m_components[sourceComponentIndex];
 			InstanceId sourceComponentId;
-			if (!TryGetComponentInstanceId(
+			if (!Utils::TryGetComponentInstanceId(
 					sourceReflection,
 					sourceComponentId,
 					outDiagnostic))
@@ -1073,7 +977,7 @@ bool WorldPrefab::BuildUpdatedLinkedOverrides(
 						expandedPrefab->m_components[componentIndex];
 					InstanceId candidateInstanceId;
 					std::string conversionDiagnostic;
-					if (!TryGetComponentInstanceId(
+					if (!Utils::TryGetComponentInstanceId(
 							candidate,
 							candidateInstanceId,
 							conversionDiagnostic))
@@ -1102,7 +1006,7 @@ bool WorldPrefab::BuildUpdatedLinkedOverrides(
 						effectiveBaseline->m_components[componentIndex];
 					InstanceId candidateInstanceId;
 					std::string conversionDiagnostic;
-					if (!TryGetComponentInstanceId(
+					if (!Utils::TryGetComponentInstanceId(
 							candidate,
 							candidateInstanceId,
 							conversionDiagnostic))
@@ -1163,7 +1067,7 @@ bool WorldPrefab::BuildUpdatedLinkedOverrides(
 				const bool bChangedFromBaseline =
 					baselineReflection &&
 					(!bHasBaselineProperty ||
-						!AreYamlNodesEqual(
+						!Utils::AreYamlNodesEqual(
 							normalizedLiveValue,
 							baselineReflection->GetProperties()[
 								liveProperty.m_first]));
@@ -1172,7 +1076,7 @@ bool WorldPrefab::BuildUpdatedLinkedOverrides(
 				{
 					if (!sourceReflection.GetProperties().ContainsKey(
 							liveProperty.m_first) ||
-						!AreYamlNodesEqual(
+						!Utils::AreYamlNodesEqual(
 							normalizedLiveValue,
 							sourceReflection.GetProperties()[
 								liveProperty.m_first]))
@@ -1230,7 +1134,17 @@ bool WorldPrefab::CommitLinkedInstanceUpdates(
 		return false;
 	}
 
-	if (pendingUpdates.Num() != world->m_prefabInstances.Num())
+	size_t numPrefabInstanceRoots = 0;
+	for (const auto& object : world->m_objects)
+	{
+		if (object && object->GetFileId())
+		{
+			++numPrefabInstanceRoots;
+		}
+	}
+
+	if (pendingUpdates.Num() != numPrefabInstanceRoots ||
+		world->m_prefabInstances.Num() != numPrefabInstanceRoots)
 	{
 		outDiagnostic =
 			"the linked prefab set changed before its baselines could be committed";
@@ -1250,6 +1164,33 @@ bool WorldPrefab::CommitLinkedInstanceUpdates(
 			return false;
 		}
 
+		GameObjectPtr root = world->GetObjectByInstanceId(
+			pendingUpdate.m_rootInstanceId).DynamicCast<GameObject>();
+		const PrefabInstanceLink* currentLink = nullptr;
+		std::string baselineDiagnostic;
+		if (!root ||
+			!root->GetFileId() ||
+			!pendingUpdate.m_effectiveBaseline ||
+			pendingUpdate.m_effectiveBaseline->GetFileId() !=
+				root->GetFileId() ||
+			!pendingUpdate.m_effectiveBaseline->
+				ValidateForInstantiation(
+					baselineDiagnostic) ||
+			!world->TryGetPrefabInstance(
+				pendingUpdate.m_rootInstanceId,
+				currentLink) ||
+			!currentLink)
+		{
+			outDiagnostic =
+				"a linked prefab root, source FileId, baseline, or derived metadata changed before commit";
+			if (!baselineDiagnostic.empty())
+			{
+				outDiagnostic += ": " +
+					baselineDiagnostic;
+			}
+			return false;
+		}
+
 		for (const auto& mapping :
 			pendingUpdate.m_sourceToInstanceIds)
 		{
@@ -1266,6 +1207,29 @@ bool WorldPrefab::CommitLinkedInstanceUpdates(
 			if (!world->m_objectsMap.ContainsKey(liveInstanceId))
 			{
 				continue;
+			}
+
+			GameObjectPtr liveObject = world->GetObjectByInstanceId(
+				liveInstanceId).DynamicCast<GameObject>();
+			bool bIsInRootHierarchy = false;
+			for (GameObjectPtr current = liveObject;
+				current;
+				current = current->GetParent())
+			{
+				if (current == root)
+				{
+					bIsInRootHierarchy = true;
+					break;
+				}
+			}
+			if (!liveObject ||
+				!bIsInRootHierarchy ||
+				(liveObject != root &&
+					liveObject->GetFileId()))
+			{
+				outDiagnostic =
+					"a linked prefab mapping references a live object outside its authoritative root";
+				return false;
 			}
 
 			if (nextPrefabInstanceRootsByObject.ContainsKey(
@@ -1323,20 +1287,29 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 
 	TVector<PendingPrefabLinkUpdate> pendingLinkUpdates;
 
-	TSet<InstanceId> linkedRoots;
-	for (const auto& linkEntry : world->GetPrefabInstances())
-	{
-		linkedRoots.Insert(linkEntry.m_first);
-	}
-
 	const auto& gameObjects = world->GetGameObjects();
 	TSet<InstanceId> reservedInstanceIds;
+	TSet<InstanceId> linkedRoots;
+	TVector<GameObjectPtr> linkedRootObjects;
 	for (const auto& gameObject : gameObjects)
 	{
 		if (gameObject)
 		{
 			reservedInstanceIds.Insert(gameObject->GetInstanceId());
+			if (gameObject->GetFileId())
+			{
+				linkedRoots.Insert(gameObject->GetInstanceId());
+				linkedRootObjects.Add(gameObject);
+			}
 		}
+	}
+
+	if (linkedRoots.Num() != world->m_prefabInstances.Num())
+	{
+		res->m_loadDiagnostic =
+			"cannot serialize world: authoritative prefab roots and derived metadata are inconsistent";
+		SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
+		return res;
 	}
 
 	for (const auto& go : gameObjects)
@@ -1354,29 +1327,65 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 		}
 	}
 
-	for (auto linkEntry : world->m_prefabInstances)
+	TSet<InstanceId> validatedLinkedMembers;
+	for (const GameObjectPtr& root : linkedRootObjects)
 	{
-		PrefabInstanceLink& link = *linkEntry.m_second;
-		GameObjectPtr root = world->GetObjectByInstanceId(
-			link.m_rootInstanceId).DynamicCast<GameObject>();
-		if (!root)
+		const InstanceId& rootInstanceId =
+			root->GetInstanceId();
+		const FileId& sourcePrefabId =
+			root->GetFileId();
+		const PrefabInstanceLink* validatedLink = nullptr;
+		if (!world->m_prefabInstances.ContainsKey(
+				rootInstanceId) ||
+			!world->TryGetPrefabInstance(
+				rootInstanceId,
+				validatedLink) ||
+			!validatedLink)
 		{
 			res->m_loadDiagnostic =
 				"cannot serialize linked prefab '" +
-				link.m_sourcePrefabId.ToString() +
-				"': live root '" +
-				link.m_rootInstanceId.ToString() +
-				"' is missing";
+				sourcePrefabId.ToString() +
+				"': its derived runtime metadata is missing or inconsistent";
 			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
 			res->m_gameObjects.Clear();
 			return res;
+		}
+		PrefabInstanceLink& link =
+			world->m_prefabInstances[rootInstanceId];
+		for (const auto& mapping :
+			link.m_sourceToInstanceIds)
+		{
+			const InstanceId& liveInstanceId =
+				*mapping.m_second;
+			if (!world->m_objectsMap.ContainsKey(
+					liveInstanceId))
+			{
+				continue;
+			}
+
+			if (!validatedLinkedMembers.Insert(
+					liveInstanceId) ||
+				!world->m_prefabInstanceRootsByObject.
+					ContainsKey(liveInstanceId) ||
+				world->m_prefabInstanceRootsByObject[
+					liveInstanceId] != rootInstanceId)
+			{
+				res->m_loadDiagnostic =
+					"cannot serialize linked prefab '" +
+					sourcePrefabId.ToString() +
+					"': its derived membership cache is inconsistent";
+				SAILOR_LOG_ERROR("%s.",
+					res->m_loadDiagnostic.c_str());
+				res->m_gameObjects.Clear();
+				return res;
+			}
 		}
 
 		if (!link.m_effectiveBaseline)
 		{
 			res->m_loadDiagnostic =
 				"cannot serialize linked prefab '" +
-				link.m_sourcePrefabId.ToString() +
+				sourcePrefabId.ToString() +
 				"': its effective baseline is unavailable";
 			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
 			res->m_gameObjects.Clear();
@@ -1385,12 +1394,12 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 
 		PrefabPtr sourcePrefab;
 		if (!App::GetSubmodule<PrefabImporter>()->LoadPrefab_Immediate(
-				link.m_sourcePrefabId,
+				sourcePrefabId,
 				sourcePrefab))
 		{
 			res->m_loadDiagnostic =
 				"cannot serialize linked prefab '" +
-				link.m_sourcePrefabId.ToString() +
+				sourcePrefabId.ToString() +
 				"': source asset is unavailable";
 			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
 			res->m_gameObjects.Clear();
@@ -1398,7 +1407,7 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 		}
 
 		PrefabPtr expandedPrefab =
-			Prefab::FromGameObject(root, link.m_sourcePrefabId);
+			Prefab::FromGameObject(root, sourcePrefabId);
 		std::string diagnostic;
 		TMap<InstanceId, InstanceId> reconciledInstanceIds;
 		if (!ReconcileLinkedInstanceIds(
@@ -1411,7 +1420,7 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 		{
 			res->m_loadDiagnostic =
 				"cannot reconcile linked prefab '" +
-				link.m_sourcePrefabId.ToString() +
+				sourcePrefabId.ToString() +
 				"': " +
 				diagnostic;
 			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
@@ -1430,7 +1439,7 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 		{
 			res->m_loadDiagnostic =
 				"cannot serialize linked prefab '" +
-				link.m_sourcePrefabId.ToString() +
+				sourcePrefabId.ToString() +
 				"': " +
 				diagnostic;
 			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
@@ -1441,7 +1450,7 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 		PrefabPtr nextEffectiveBaseline =
 			PrefabPtr::Make(
 				world->GetAllocator(),
-				link.m_sourcePrefabId);
+				sourcePrefabId);
 		nextEffectiveBaseline->m_gameObjects =
 			sourcePrefab->m_gameObjects;
 		nextEffectiveBaseline->m_components =
@@ -1506,7 +1515,7 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 					sourcePrefab->m_components[
 						sourceComponentIndex];
 				InstanceId sourceComponentId;
-				if (!TryGetComponentInstanceId(
+				if (!Utils::TryGetComponentInstanceId(
 						sourceReflection,
 						sourceComponentId,
 						diagnostic))
@@ -1527,7 +1536,7 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 							liveComponentIndex];
 					InstanceId candidateInstanceId;
 					std::string conversionDiagnostic;
-					if (!TryGetComponentInstanceId(
+					if (!Utils::TryGetComponentInstanceId(
 							candidate,
 							candidateInstanceId,
 							conversionDiagnostic))
@@ -1607,7 +1616,7 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 		{
 			res->m_loadDiagnostic =
 				"cannot update linked prefab '" +
-				link.m_sourcePrefabId.ToString() +
+				sourcePrefabId.ToString() +
 				"' baseline: " +
 				diagnostic;
 			SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
@@ -1651,7 +1660,7 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 		{
 			res->m_loadDiagnostic =
 				"cannot validate expanded linked prefab '" +
-				link.m_sourcePrefabId.ToString() +
+				sourcePrefabId.ToString() +
 				"': " +
 				diagnostic;
 			SAILOR_LOG_ERROR("%s.",
@@ -1663,12 +1672,22 @@ WorldPrefabPtr WorldPrefab::FromWorld(WorldPtr world)
 
 		PendingPrefabLinkUpdate pendingUpdate;
 		pendingUpdate.m_rootInstanceId =
-			link.m_rootInstanceId;
+			rootInstanceId;
 		pendingUpdate.m_sourceToInstanceIds =
 			std::move(reconciledInstanceIds);
 		pendingUpdate.m_effectiveBaseline =
 			std::move(nextEffectiveBaseline);
 		pendingLinkUpdates.Add(std::move(pendingUpdate));
+	}
+
+	if (validatedLinkedMembers.Num() !=
+		world->m_prefabInstanceRootsByObject.Num())
+	{
+		res->m_loadDiagnostic =
+			"cannot serialize world: the derived prefab membership cache contains stale entries";
+		SAILOR_LOG_ERROR("%s.", res->m_loadDiagnostic.c_str());
+		res->m_gameObjects.Clear();
+		return res;
 	}
 
 	std::string commitDiagnostic;

--- a/Runtime/Core/Reflection.cpp
+++ b/Runtime/Core/Reflection.cpp
@@ -1,4 +1,5 @@
 #include "Reflection.h"
+#include "Utils.h"
 #include "Containers/Containers.h"
 #include "Components/Component.h"
 #include "Containers/ConcurrentMap.h"
@@ -552,7 +553,24 @@ void ReflectedData::Deserialize(const YAML::Node& inData)
 
 bool ReflectedData::operator==(const ReflectedData& rhs) const
 {
-	return m_typeInfo == rhs.m_typeInfo && m_properties == rhs.m_properties;
+	if (m_typeInfo != rhs.m_typeInfo ||
+		m_properties.Num() != rhs.m_properties.Num())
+	{
+		return false;
+	}
+
+	for (const auto& property : m_properties)
+	{
+		if (!rhs.m_properties.ContainsKey(property.m_first) ||
+			!Utils::AreYamlNodesEqual(
+				*property.m_second,
+				rhs.m_properties[property.m_first]))
+		{
+			return false;
+		}
+	}
+
+	return true;
 }
 
 TMap<std::string, YAML::Node> ReflectedData::GetOverrideProperties() const
@@ -571,9 +589,12 @@ ReflectedData ReflectedData::DiffTo(const ReflectedData& rhs) const
 
 	for (const auto& prop : GetProperties())
 	{
-		if (*prop.m_second != rhs.m_properties[prop.m_first])
+		if (!rhs.m_properties.ContainsKey(prop.m_first) ||
+			!Utils::AreYamlNodesEqual(
+				*prop.m_second,
+				rhs.m_properties[prop.m_first]))
 		{
-			res.m_properties[prop.m_first] = prop.m_second;
+			res.m_properties[prop.m_first] = *prop.m_second;
 		}
 	}
 

--- a/Runtime/Core/Utils.cpp
+++ b/Runtime/Core/Utils.cpp
@@ -23,6 +23,8 @@
 #include <string>
 #include <format>
 #include <chrono>
+#include <limits>
+#include <utility>
 
 #if defined(_WIN32)
 #include <windows.h>
@@ -34,6 +36,238 @@
 using namespace Sailor;
 using namespace Sailor::Utils;
 
+namespace
+{
+	constexpr size_t MaxCanonicalYamlDepth = 64;
+	constexpr size_t MaxCanonicalYamlNodes = 262144;
+	constexpr size_t MaxCanonicalYamlBytes = 64 * 1024 * 1024;
+
+	bool AppendCanonicalText(
+		std::string& destination,
+		const std::string& value,
+		size_t& remainingBytes)
+	{
+		if (value.size() > remainingBytes)
+		{
+			return false;
+		}
+
+		destination.append(value);
+		remainingBytes -= value.size();
+		return true;
+	}
+
+	bool AppendCanonicalCharacter(
+		std::string& destination,
+		char value,
+		size_t& remainingBytes)
+	{
+		if (remainingBytes == 0)
+		{
+			return false;
+		}
+
+		destination.push_back(value);
+		--remainingBytes;
+		return true;
+	}
+
+	bool AppendCanonicalField(
+		std::string& destination,
+		const std::string& value,
+		size_t& remainingBytes)
+	{
+		const std::string length = std::to_string(value.size());
+		return AppendCanonicalText(destination, length, remainingBytes) &&
+			AppendCanonicalCharacter(destination, ':', remainingBytes) &&
+			AppendCanonicalText(destination, value, remainingBytes);
+	}
+
+	bool AppendCanonicalTag(
+		const YAML::Node& node,
+		std::string& destination,
+		EYamlCanonicalizationMode mode,
+		size_t& remainingBytes)
+	{
+		return mode == EYamlCanonicalizationMode::SemanticValue ||
+			AppendCanonicalField(destination, node.Tag(), remainingBytes);
+	}
+
+	bool AppendCanonicalYaml(
+		const YAML::Node& node,
+		std::string& destination,
+		EYamlCanonicalizationMode mode,
+		size_t depth,
+		size_t& remainingNodes,
+		size_t& remainingBytes)
+	{
+		if ((mode == EYamlCanonicalizationMode::StrictDocument &&
+				depth > MaxCanonicalYamlDepth) ||
+			remainingNodes == 0)
+		{
+			return false;
+		}
+		--remainingNodes;
+
+		if (!node.IsDefined())
+		{
+			return AppendCanonicalCharacter(destination, 'U', remainingBytes);
+		}
+
+		switch (node.Type())
+		{
+		case YAML::NodeType::Undefined:
+			return AppendCanonicalCharacter(destination, 'U', remainingBytes);
+		case YAML::NodeType::Null:
+			return AppendCanonicalCharacter(destination, 'N', remainingBytes) &&
+				AppendCanonicalTag(node, destination, mode, remainingBytes);
+		case YAML::NodeType::Scalar:
+			return AppendCanonicalCharacter(destination, 'S', remainingBytes) &&
+				AppendCanonicalTag(node, destination, mode, remainingBytes) &&
+				AppendCanonicalField(destination, node.Scalar(), remainingBytes);
+		case YAML::NodeType::Sequence:
+		{
+			if (mode == EYamlCanonicalizationMode::StrictDocument &&
+				node.size() > remainingNodes)
+			{
+				return false;
+			}
+
+			const std::string numElements = std::to_string(node.size());
+			if (!AppendCanonicalCharacter(destination, 'Q', remainingBytes) ||
+				!AppendCanonicalTag(node, destination, mode, remainingBytes) ||
+				!AppendCanonicalText(destination, numElements, remainingBytes) ||
+				!AppendCanonicalCharacter(destination, ':', remainingBytes))
+			{
+				return false;
+			}
+			for (const YAML::Node& element : node)
+			{
+				std::string canonicalElement;
+				if (!AppendCanonicalYaml(
+						element,
+						canonicalElement,
+						mode,
+						depth + 1,
+						remainingNodes,
+						remainingBytes) ||
+					!AppendCanonicalField(
+						destination,
+						canonicalElement,
+						remainingBytes))
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+		case YAML::NodeType::Map:
+		{
+			if (mode == EYamlCanonicalizationMode::StrictDocument &&
+				node.size() > remainingNodes / 2)
+			{
+				return false;
+			}
+
+			TVector<std::pair<std::string, std::string>> entries;
+			entries.Reserve(node.size());
+			for (const auto& entry : node)
+			{
+				std::string canonicalKey;
+				std::string canonicalValue;
+				if (!AppendCanonicalYaml(
+						entry.first,
+						canonicalKey,
+						mode,
+						depth + 1,
+						remainingNodes,
+						remainingBytes) ||
+					!AppendCanonicalYaml(
+						entry.second,
+						canonicalValue,
+						mode,
+						depth + 1,
+						remainingNodes,
+						remainingBytes))
+				{
+					return false;
+				}
+				entries.Add(std::make_pair(
+					std::move(canonicalKey),
+					std::move(canonicalValue)));
+			}
+
+			std::sort(
+				entries.begin(),
+				entries.end(),
+				[](const auto& lhs, const auto& rhs)
+				{
+					return lhs < rhs;
+				});
+			if (mode == EYamlCanonicalizationMode::StrictDocument)
+			{
+				for (size_t index = 1; index < entries.Num(); ++index)
+				{
+					if (entries[index - 1].first == entries[index].first)
+					{
+						return false;
+					}
+				}
+			}
+
+			const std::string numEntries = std::to_string(entries.Num());
+			if (!AppendCanonicalCharacter(destination, 'M', remainingBytes) ||
+				!AppendCanonicalTag(node, destination, mode, remainingBytes) ||
+				!AppendCanonicalText(destination, numEntries, remainingBytes) ||
+				!AppendCanonicalCharacter(destination, ':', remainingBytes))
+			{
+				return false;
+			}
+			for (const auto& entry : entries)
+			{
+				if (!AppendCanonicalField(
+						destination,
+						entry.first,
+						remainingBytes) ||
+					!AppendCanonicalField(
+						destination,
+						entry.second,
+						remainingBytes))
+				{
+					return false;
+				}
+			}
+			return true;
+		}
+		}
+
+		return false;
+	}
+}
+
+bool Utils::CanonicalizeYaml(
+	const YAML::Node& node,
+	std::string& destination,
+	EYamlCanonicalizationMode mode)
+{
+	destination.clear();
+	const bool bBounded =
+		mode == EYamlCanonicalizationMode::StrictDocument;
+	size_t remainingNodes = bBounded
+		? MaxCanonicalYamlNodes
+		: std::numeric_limits<size_t>::max();
+	size_t remainingBytes = bBounded
+		? MaxCanonicalYamlBytes
+		: std::numeric_limits<size_t>::max();
+	return AppendCanonicalYaml(
+		node,
+		destination,
+		mode,
+		0,
+		remainingNodes,
+		remainingBytes);
+}
+
 bool Utils::AreYamlNodesEqual(const YAML::Node& lhs, const YAML::Node& rhs)
 {
 	if (lhs.IsDefined() != rhs.IsDefined())
@@ -41,76 +275,22 @@ bool Utils::AreYamlNodesEqual(const YAML::Node& lhs, const YAML::Node& rhs)
 		return false;
 	}
 
-	if (!lhs.IsDefined())
+	if (!lhs.IsDefined() || lhs.is(rhs))
 	{
 		return true;
 	}
 
-	if (lhs.Type() != rhs.Type())
-	{
-		return false;
-	}
-
-	switch (lhs.Type())
-	{
-	case YAML::NodeType::Null:
-		return true;
-
-	case YAML::NodeType::Scalar:
-		return lhs.Scalar() == rhs.Scalar();
-
-	case YAML::NodeType::Sequence:
-		if (lhs.size() != rhs.size())
-		{
-			return false;
-		}
-
-		for (size_t index = 0; index < lhs.size(); ++index)
-		{
-			if (!AreYamlNodesEqual(lhs[index], rhs[index]))
-			{
-				return false;
-			}
-		}
-		return true;
-
-	case YAML::NodeType::Map:
-		if (lhs.size() != rhs.size())
-		{
-			return false;
-		}
-
-		{
-			TVector<bool> matchedRightEntries(rhs.size());
-			for (const auto& leftEntry : lhs)
-			{
-				bool bFoundMatch = false;
-				size_t rightIndex = 0;
-				for (const auto& rightEntry : rhs)
-				{
-					if (!matchedRightEntries[rightIndex] &&
-						AreYamlNodesEqual(leftEntry.first, rightEntry.first) &&
-						AreYamlNodesEqual(leftEntry.second, rightEntry.second))
-					{
-						matchedRightEntries[rightIndex] = true;
-						bFoundMatch = true;
-						break;
-					}
-					++rightIndex;
-				}
-
-				if (!bFoundMatch)
-				{
-					return false;
-				}
-			}
-		}
-		return true;
-
-	case YAML::NodeType::Undefined:
-	default:
-		return false;
-	}
+	std::string canonicalLhs;
+	std::string canonicalRhs;
+	return CanonicalizeYaml(
+			lhs,
+			canonicalLhs,
+			EYamlCanonicalizationMode::SemanticValue) &&
+		CanonicalizeYaml(
+			rhs,
+			canonicalRhs,
+			EYamlCanonicalizationMode::SemanticValue) &&
+		canonicalLhs == canonicalRhs;
 }
 
 bool Utils::TryGetComponentInstanceId(

--- a/Runtime/Core/Utils.cpp
+++ b/Runtime/Core/Utils.cpp
@@ -1,4 +1,7 @@
 #include "Utils.h"
+#include "Core/Reflection.h"
+#include "Engine/InstanceId.h"
+#include "YamlExceptionBoundary.h"
 #include <sys/types.h>
 #include <sys/stat.h>
 #if defined(_WIN32)
@@ -30,6 +33,134 @@
 
 using namespace Sailor;
 using namespace Sailor::Utils;
+
+bool Utils::AreYamlNodesEqual(const YAML::Node& lhs, const YAML::Node& rhs)
+{
+	if (lhs.IsDefined() != rhs.IsDefined())
+	{
+		return false;
+	}
+
+	if (!lhs.IsDefined())
+	{
+		return true;
+	}
+
+	if (lhs.Type() != rhs.Type())
+	{
+		return false;
+	}
+
+	switch (lhs.Type())
+	{
+	case YAML::NodeType::Null:
+		return true;
+
+	case YAML::NodeType::Scalar:
+		return lhs.Scalar() == rhs.Scalar();
+
+	case YAML::NodeType::Sequence:
+		if (lhs.size() != rhs.size())
+		{
+			return false;
+		}
+
+		for (size_t index = 0; index < lhs.size(); ++index)
+		{
+			if (!AreYamlNodesEqual(lhs[index], rhs[index]))
+			{
+				return false;
+			}
+		}
+		return true;
+
+	case YAML::NodeType::Map:
+		if (lhs.size() != rhs.size())
+		{
+			return false;
+		}
+
+		{
+			TVector<bool> matchedRightEntries(rhs.size());
+			for (const auto& leftEntry : lhs)
+			{
+				bool bFoundMatch = false;
+				size_t rightIndex = 0;
+				for (const auto& rightEntry : rhs)
+				{
+					if (!matchedRightEntries[rightIndex] &&
+						AreYamlNodesEqual(leftEntry.first, rightEntry.first) &&
+						AreYamlNodesEqual(leftEntry.second, rightEntry.second))
+					{
+						matchedRightEntries[rightIndex] = true;
+						bFoundMatch = true;
+						break;
+					}
+					++rightIndex;
+				}
+
+				if (!bFoundMatch)
+				{
+					return false;
+				}
+			}
+		}
+		return true;
+
+	case YAML::NodeType::Undefined:
+	default:
+		return false;
+	}
+}
+
+bool Utils::TryGetComponentInstanceId(
+	const ReflectedData& reflection,
+	InstanceId& outInstanceId,
+	std::string& outDiagnostic)
+{
+	outInstanceId = InstanceId::Invalid;
+	outDiagnostic.clear();
+
+	if (!reflection.IsValid())
+	{
+		outDiagnostic = "the reflected component is invalid";
+		return false;
+	}
+
+	const auto& properties = reflection.GetProperties();
+	if (!properties.ContainsKey("instanceId"))
+	{
+		outDiagnostic = "the reflected component has no instanceId";
+		return false;
+	}
+
+	InstanceId instanceId;
+	std::string conversionDiagnostic;
+	if (!External::TryConvertYaml(
+			properties["instanceId"],
+			instanceId,
+			conversionDiagnostic))
+	{
+		outDiagnostic = "the reflected component has an invalid instanceId";
+		if (!conversionDiagnostic.empty())
+		{
+			outDiagnostic += ": " + conversionDiagnostic;
+		}
+		return false;
+	}
+
+	if (instanceId.ComponentId() == InstanceId::Invalid ||
+		instanceId.GameObjectId() == InstanceId::Invalid)
+	{
+		outDiagnostic =
+			"the reflected component has an invalid instanceId: "
+			"both component and game-object IDs must be valid";
+		return false;
+	}
+
+	outInstanceId = instanceId;
+	return true;
+}
 
 glm::vec4 Utils::LinearToSRGB(const glm::u8vec4& linearRGB)
 {

--- a/Runtime/Core/Utils.h
+++ b/Runtime/Core/Utils.h
@@ -48,6 +48,16 @@ namespace Sailor
 
 		SAILOR_API void Trim(std::string& s);
 
+		enum class EYamlCanonicalizationMode
+		{
+			SemanticValue,
+			StrictDocument
+		};
+
+		SAILOR_API bool CanonicalizeYaml(
+			const YAML::Node& node,
+			std::string& destination,
+			EYamlCanonicalizationMode mode);
 		SAILOR_API bool AreYamlNodesEqual(const YAML::Node& lhs, const YAML::Node& rhs);
 		SAILOR_API bool TryGetComponentInstanceId(
 			const ReflectedData& reflection,

--- a/Runtime/Core/Utils.h
+++ b/Runtime/Core/Utils.h
@@ -6,8 +6,16 @@
 #include "Containers/Containers.h"
 #include <ctime>
 
+namespace YAML
+{
+	class Node;
+}
+
 namespace Sailor
 {
+	class InstanceId;
+	class ReflectedData;
+
 	namespace Utils
 	{
 		struct WindowSizeAndPosition
@@ -39,6 +47,12 @@ namespace Sailor
 		SAILOR_API void FindAllOccurances(const std::string& str, const std::string& substr, TVector<size_t>& outLocations, size_t startPos = 0, size_t endPos = std::string::npos);
 
 		SAILOR_API void Trim(std::string& s);
+
+		SAILOR_API bool AreYamlNodesEqual(const YAML::Node& lhs, const YAML::Node& rhs);
+		SAILOR_API bool TryGetComponentInstanceId(
+			const ReflectedData& reflection,
+			InstanceId& outInstanceId,
+			std::string& outDiagnostic);
 
 		SAILOR_API void SetThreadName(size_t dwThreadID, const std::string& threadName);
 		SAILOR_API void SetThreadName(const std::string& threadName);

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -197,7 +197,8 @@ uint32_t App::PullEditorViewportEvents(char** events, uint32_t num)
 		});
 }
 
-bool App::ResolveEditorViewportDropPosition(
+bool App::TraceViewportRay(
+	uint64_t viewportId,
 	float normalizedX,
 	float normalizedY,
 	float& outWorldX,
@@ -210,12 +211,18 @@ bool App::ResolveEditorViewportDropPosition(
 
 	return ExecuteOnEngineMainThread<bool>(
 		false,
-		[normalizedX, normalizedY, &outWorldX, &outWorldY, &outWorldZ]()
+		[viewportId,
+			normalizedX,
+			normalizedY,
+			&outWorldX,
+			&outWorldY,
+			&outWorldZ]()
 		{
 			auto editor = GetSubmodule<Editor>();
 			glm::vec3 worldPosition{};
 			if (!editor ||
-				!editor->ResolveViewportDropPosition(
+				!editor->TraceViewportRay(
+					viewportId,
 					normalizedX,
 					normalizedY,
 					worldPosition))
@@ -682,78 +689,6 @@ bool App::RemoveEditorComponent(const char* strInstanceId)
 			InstanceId instanceId;
 			instanceId.Deserialize(YAML::Node(instanceIdValue));
 			return editor->RemoveComponent(instanceId);
-		});
-}
-
-bool App::CreateEditorModelGameObject(
-	const char* strModelFileId,
-	const char* strName,
-	const char* strParentInstanceId,
-	bool bHasWorldPosition,
-	float worldX,
-	float worldY,
-	float worldZ,
-	char** outInstanceId)
-{
-	if (!strModelFileId ||
-		!strName ||
-		strName[0] == '\0' ||
-		!outInstanceId)
-	{
-		return false;
-	}
-
-	outInstanceId[0] = nullptr;
-	const std::string modelFileIdValue = strModelFileId;
-	const std::string name = strName;
-	const std::string parentInstanceIdValue =
-		strParentInstanceId ? strParentInstanceId : "";
-	return ExecuteOnEngineMainThread<bool>(
-		false,
-		[modelFileIdValue,
-			name,
-			parentInstanceIdValue,
-			bHasWorldPosition,
-			worldX,
-			worldY,
-			worldZ,
-			outInstanceId]()
-		{
-			auto editor = GetSubmodule<Editor>();
-			if (!editor)
-			{
-				return false;
-			}
-
-			FileId modelFileId{};
-			modelFileId.Deserialize(YAML::Node(modelFileIdValue));
-			if (!modelFileId)
-			{
-				return false;
-			}
-
-			InstanceId parentInstanceId{};
-			if (!TryParseOptionalParent(
-					parentInstanceIdValue,
-					parentInstanceId))
-			{
-				return false;
-			}
-
-			const glm::vec3 worldPosition(worldX, worldY, worldZ);
-			InstanceId createdInstanceId{};
-			if (!editor->CreateModelGameObject(
-					modelFileId,
-					name,
-					parentInstanceId,
-					bHasWorldPosition ? &worldPosition : nullptr,
-					createdInstanceId))
-			{
-				return false;
-			}
-
-			SetInteropString(createdInstanceId.ToString(), outInstanceId);
-			return true;
 		});
 }
 

--- a/Runtime/Editor/EditorRuntimeBridge.cpp
+++ b/Runtime/Editor/EditorRuntimeBridge.cpp
@@ -871,6 +871,12 @@ bool Sailor::EditorRuntime::HasAppliedEditorRenderArea()
 
 void Sailor::EditorRuntime::PumpEditorRemoteViewportsOnEngineThread()
 {
+	auto* scheduler = App::GetSubmodule<Tasks::Scheduler>();
+	if (!scheduler || !scheduler->IsMainThread())
+	{
+		return;
+	}
+
 	TVector<TSharedPtr<RemoteViewportBinding>> bindings{};
 	{
 		std::lock_guard lock(g_remoteViewportBindingsMutex);
@@ -1042,7 +1048,6 @@ bool App::UpsertEditorRemoteViewport(uint64_t viewportId, uint32_t windowPosX, u
 		RequestEditorInputReset(viewportId);
 	}
 	binding->SetFocused(bFocused);
-	binding->Pump();
 	return true;
 }
 
@@ -1219,7 +1224,6 @@ bool App::RetryEditorRemoteViewport(uint64_t viewportId)
 		binding->m_binding.GetRuntimeSession().GetState() == Sailor::EditorRemote::SessionState::Lost)
 	{
 		binding->m_binding.Create();
-		binding->Pump();
 	}
 	return true;
 }

--- a/Runtime/Editor/EditorViewportController.cpp
+++ b/Runtime/Editor/EditorViewportController.cpp
@@ -255,7 +255,7 @@ bool EditorViewport::TryPickNearest(
 	return outInstanceId.IsGameObjectId();
 }
 
-bool EditorViewport::TryResolveDropPosition(
+bool EditorViewport::TryResolveRayTarget(
 	const Math::Ray& ray,
 	const TVector<PickCandidate>& candidates,
 	glm::vec3& outPosition)
@@ -598,7 +598,7 @@ bool EditorViewportController::QueueToolShortcutEvent(uint32_t keyCode)
 	return true;
 }
 
-bool EditorViewportController::TryResolveDropPosition(
+bool EditorViewportController::TraceViewportRay(
 	World& world,
 	float normalizedX,
 	float normalizedY,
@@ -645,7 +645,7 @@ bool EditorViewportController::TryResolveDropPosition(
 		}
 	}
 
-	return EditorViewport::TryResolveDropPosition(
+	return EditorViewport::TryResolveRayTarget(
 		ray,
 		candidates,
 		outPosition);

--- a/Runtime/Editor/EditorViewportController.h
+++ b/Runtime/Editor/EditorViewportController.h
@@ -50,7 +50,7 @@ namespace Sailor
 			InstanceId& outInstanceId,
 			float& outDistance);
 
-		SAILOR_API bool TryResolveDropPosition(
+		SAILOR_API bool TryResolveRayTarget(
 			const Math::Ray& ray,
 			const TVector<PickCandidate>& candidates,
 			glm::vec3& outPosition);
@@ -100,7 +100,7 @@ namespace Sailor
 				float normalizedX,
 				float normalizedY);
 			SAILOR_API bool QueueToolShortcutEvent(uint32_t keyCode);
-			SAILOR_API bool TryResolveDropPosition(
+			SAILOR_API bool TraceViewportRay(
 				World& world,
 				float normalizedX,
 				float normalizedY,

--- a/Runtime/Engine/GameObject.cpp
+++ b/Runtime/Engine/GameObject.cpp
@@ -154,7 +154,7 @@ void GameObject::DrawEditorSelectedGizmo()
 		}
 		else
 		{
-			GetWorld()->GetDebugContext()->DrawSphere(selectionBounds.GetCenter(), 1.0f, selectionColor);
+			GetWorld()->GetDebugContext()->DrawSphere(selectionBounds.GetCenter(), 10.0f, selectionColor);
 		}
 	}
 

--- a/Runtime/Engine/World.cpp
+++ b/Runtime/Engine/World.cpp
@@ -5,6 +5,7 @@
 #include "AssetRegistry/World/WorldPrefabImporter.h"
 #include "Containers/Set.h"
 #include "Core/LogMacros.h"
+#include "Core/Utils.h"
 #include "YamlExceptionBoundary.h"
 #include <Components/TestComponent.h>
 #include <ECS/TransformECS.h>
@@ -114,29 +115,87 @@ bool World::TryGetPrefabInstance(
 	const PrefabInstanceLink*& outLink) const
 {
 	outLink = nullptr;
-	if (!m_prefabInstanceRootsByObject.ContainsKey(objectInstanceId))
+	GameObjectPtr object = GetObjectByInstanceId(
+		objectInstanceId).DynamicCast<GameObject>();
+	if (!object)
 	{
 		return false;
 	}
 
-	const InstanceId& rootInstanceId = m_prefabInstanceRootsByObject[objectInstanceId];
+	InstanceId rootInstanceId;
+	if (object->GetFileId())
+	{
+		rootInstanceId = objectInstanceId;
+	}
+	else if (m_prefabInstanceRootsByObject.ContainsKey(
+			objectInstanceId))
+	{
+		rootInstanceId =
+			m_prefabInstanceRootsByObject[objectInstanceId];
+	}
+	else
+	{
+		return false;
+	}
+
 	if (!m_prefabInstances.ContainsKey(rootInstanceId))
 	{
 		return false;
 	}
 
-	outLink = &m_prefabInstances[rootInstanceId];
+	GameObjectPtr root = GetObjectByInstanceId(
+		rootInstanceId).DynamicCast<GameObject>();
+	const PrefabInstanceLink& link =
+		m_prefabInstances[rootInstanceId];
+	if (!root ||
+		!root->GetFileId() ||
+		link.m_rootInstanceId != rootInstanceId ||
+		!link.m_effectiveBaseline ||
+		link.m_effectiveBaseline->GetFileId() !=
+			root->GetFileId() ||
+		!m_prefabInstanceRootsByObject.ContainsKey(
+			objectInstanceId) ||
+		m_prefabInstanceRootsByObject[objectInstanceId] !=
+			rootInstanceId)
+	{
+		return false;
+	}
+
+	bool bContainsObject = false;
+	bool bContainsRoot = false;
+	for (const auto& mapping : link.m_sourceToInstanceIds)
+	{
+		bContainsObject |= *mapping.m_second ==
+			objectInstanceId;
+		bContainsRoot |= *mapping.m_second ==
+			rootInstanceId;
+	}
+
+	if (!bContainsObject || !bContainsRoot)
+	{
+		return false;
+	}
+
+	outLink = &link;
 	return true;
 }
 
 bool World::IsPrefabLinked(const InstanceId& objectInstanceId) const
 {
-	return m_prefabInstanceRootsByObject.ContainsKey(objectInstanceId);
+	if (IsPrefabInstanceRoot(objectInstanceId))
+	{
+		return true;
+	}
+
+	const PrefabInstanceLink* link = nullptr;
+	return TryGetPrefabInstance(objectInstanceId, link);
 }
 
 bool World::IsPrefabInstanceRoot(const InstanceId& objectInstanceId) const
 {
-	return m_prefabInstances.ContainsKey(objectInstanceId);
+	GameObjectPtr object = GetObjectByInstanceId(
+		objectInstanceId).DynamicCast<GameObject>();
+	return object && object->GetFileId();
 }
 
 bool World::RegisterPrefabInstance(
@@ -173,7 +232,10 @@ bool World::RegisterPrefabInstance(
 		return false;
 	}
 
-	if (m_prefabInstances.ContainsKey(root->GetInstanceId()))
+	if (root->GetFileId() ||
+		m_prefabInstances.ContainsKey(root->GetInstanceId()) ||
+		m_prefabInstanceRootsByObject.ContainsKey(
+			root->GetInstanceId()))
 	{
 		outDiagnostic = "the prefab instance root is already linked";
 		return false;
@@ -183,16 +245,21 @@ bool World::RegisterPrefabInstance(
 	for (const auto& mapping : sourceToInstanceIds)
 	{
 		const InstanceId& liveInstanceId = *mapping.m_second;
+		GameObjectPtr liveGameObject =
+			GetObjectByInstanceId(
+				liveInstanceId).DynamicCast<GameObject>();
 		if (!mapping.m_first.IsGameObjectId() ||
 			!liveInstanceId.IsGameObjectId() ||
 			!liveInstanceIds.Insert(liveInstanceId) ||
-			!m_objectsMap.ContainsKey(liveInstanceId))
+			!liveGameObject ||
+			(liveGameObject != root &&
+				liveGameObject->GetFileId()))
 		{
 			outDiagnostic = "the prefab link contains an invalid, duplicate, or missing game object";
 			return false;
 		}
 
-		for (GameObjectPtr current = GetObjectByInstanceId(liveInstanceId).DynamicCast<GameObject>();
+		for (GameObjectPtr current = liveGameObject;
 			current;
 			current = current->GetParent())
 		{
@@ -222,7 +289,6 @@ bool World::RegisterPrefabInstance(
 	}
 
 	PrefabInstanceLink link;
-	link.m_sourcePrefabId = sourcePrefabId;
 	link.m_rootInstanceId = root->GetInstanceId();
 	link.m_sourceToInstanceIds = sourceToInstanceIds;
 	link.m_effectiveBaseline =
@@ -282,6 +348,8 @@ bool World::RegisterPrefabInstance(
 		m_prefabInstanceRootsByObject[*mapping.m_second] = link.m_rootInstanceId;
 	}
 
+	// The root FileId is the authoritative prefab-link marker. Publish it only
+	// after the derived metadata and membership cache are complete.
 	root->m_fileId = sourcePrefabId;
 	return true;
 }
@@ -483,8 +551,8 @@ bool World::LinkPrefabInstance(
 			const ReflectedData& sourceReflection = sourcePrefab->m_components[componentIndex];
 			InstanceId sourceComponentId;
 			std::string conversionDiagnostic;
-			if (!External::TryConvertYaml(
-					sourceReflection.GetProperties()["instanceId"],
+			if (!Utils::TryGetComponentInstanceId(
+					sourceReflection,
 					sourceComponentId,
 					conversionDiagnostic))
 			{
@@ -575,12 +643,45 @@ bool World::BreakPrefabLink(
 	const InstanceId& objectInstanceId,
 	PrefabInstanceLink* outPreviousLink)
 {
-	if (!m_prefabInstanceRootsByObject.ContainsKey(objectInstanceId))
+	if (outPreviousLink)
+	{
+		*outPreviousLink = {};
+	}
+
+	GameObjectPtr object = GetObjectByInstanceId(
+		objectInstanceId).DynamicCast<GameObject>();
+	if (!object)
 	{
 		return false;
 	}
 
-	const InstanceId rootInstanceId = m_prefabInstanceRootsByObject[objectInstanceId];
+	InstanceId rootInstanceId;
+	if (object->GetFileId())
+	{
+		rootInstanceId = objectInstanceId;
+	}
+	else
+	{
+		const PrefabInstanceLink* link = nullptr;
+		if (!TryGetPrefabInstance(objectInstanceId, link) ||
+			!link)
+		{
+			return false;
+		}
+		rootInstanceId = link->m_rootInstanceId;
+	}
+
+	GameObjectPtr root = GetObjectByInstanceId(
+		rootInstanceId).DynamicCast<GameObject>();
+	if (!root || !root->GetFileId())
+	{
+		return false;
+	}
+
+	// Clear the authoritative marker first. Any observation while the derived
+	// caches are being purged sees an unlinked root.
+	root->m_fileId = FileId::Invalid;
+
 	auto purgeRootMembership = [this, &rootInstanceId]()
 		{
 			TVector<InstanceId> memberInstanceIds;
@@ -601,25 +702,18 @@ bool World::BreakPrefabLink(
 			}
 		};
 
-	if (!m_prefabInstances.ContainsKey(rootInstanceId))
+	if (m_prefabInstances.ContainsKey(rootInstanceId))
 	{
-		purgeRootMembership();
-		return false;
-	}
-
-	const PrefabInstanceLink previousLink = m_prefabInstances[rootInstanceId];
-	if (outPreviousLink)
-	{
-		*outPreviousLink = previousLink;
+		const PrefabInstanceLink previousLink =
+			m_prefabInstances[rootInstanceId];
+		if (outPreviousLink)
+		{
+			*outPreviousLink = previousLink;
+		}
 	}
 
 	purgeRootMembership();
 	m_prefabInstances.Remove(rootInstanceId);
-
-	if (GameObjectPtr root = GetObjectByInstanceId(rootInstanceId).DynamicCast<GameObject>())
-	{
-		root->m_fileId = FileId::Invalid;
-	}
 
 	return true;
 }
@@ -641,17 +735,14 @@ bool World::CanReparentPrefabObject(
 	const InstanceId& parentInstanceId,
 	std::string* outDiagnostic) const
 {
-	if (IsPrefabLinked(objectInstanceId))
+	if (IsPrefabLinked(objectInstanceId) &&
+		!IsPrefabInstanceRoot(objectInstanceId))
 	{
-		const InstanceId& rootInstanceId = m_prefabInstanceRootsByObject[objectInstanceId];
-		if (rootInstanceId != objectInstanceId)
+		if (outDiagnostic)
 		{
-			if (outDiagnostic)
-			{
-				*outDiagnostic = "internal linked prefab game objects cannot be reparented";
-			}
-			return false;
+			*outDiagnostic = "internal linked prefab game objects cannot be reparented";
 		}
+		return false;
 	}
 
 	if (parentInstanceId && IsPrefabLinked(parentInstanceId))
@@ -880,9 +971,8 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 					prefab->m_components[componentIndex];
 				InstanceId sourceComponentId;
 				std::string conversionDiagnostic;
-				if (!External::TryConvertYaml(
-						reflection.GetProperties()[
-							"instanceId"],
+				if (!Utils::TryGetComponentInstanceId(
+						reflection,
 						sourceComponentId,
 						conversionDiagnostic))
 				{
@@ -985,8 +1075,8 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 					prefab->m_components[componentIndex];
 				InstanceId sourceComponentId;
 				std::string conversionDiagnostic;
-				if (!External::TryConvertYaml(
-						reflection.GetProperties()["instanceId"],
+				if (!Utils::TryGetComponentInstanceId(
+						reflection,
 						sourceComponentId,
 						conversionDiagnostic))
 				{
@@ -1097,8 +1187,8 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 			const ReflectedData& reflection = prefab->m_components[componentIndex];
 			InstanceId oldInstanceId;
 			std::string conversionDiagnostic;
-			if (!External::TryConvertYaml(
-					reflection.GetProperties()["instanceId"],
+			if (!Utils::TryGetComponentInstanceId(
+					reflection,
 					oldInstanceId,
 					conversionDiagnostic))
 			{
@@ -1238,7 +1328,6 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 		else
 		{
 			root = go;
-			root->m_fileId = prefab->GetFileId();
 		}
 	}
 

--- a/Runtime/Engine/World.h
+++ b/Runtime/Engine/World.h
@@ -23,9 +23,10 @@ namespace Sailor
 
 	typedef uint8_t EWorldBehaviourMask;
 
+	// Runtime-only data derived for a linked prefab root. The source asset is
+	// authoritative only on the live root GameObject::GetFileId().
 	struct PrefabInstanceLink final
 	{
-		FileId m_sourcePrefabId{};
 		InstanceId m_rootInstanceId{};
 		TMap<InstanceId, InstanceId> m_sourceToInstanceIds{};
 		PrefabPtr m_effectiveBaseline{};

--- a/Runtime/Protocol/Generated/editor_engine.pb.cc
+++ b/Runtime/Protocol/Generated/editor_engine.pb.cc
@@ -161,6 +161,33 @@ struct ViewportRectRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportRectRequestDefaultTypeInternal _ViewportRectRequest_default_instance_;
 
+inline constexpr ViewportRayRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : viewport_id_{::uint64_t{0u}},
+        normalized_x_{0},
+        normalized_y_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR ViewportRayRequest::ViewportRayRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct ViewportRayRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR ViewportRayRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~ViewportRayRequestDefaultTypeInternal() {}
+  union {
+    ViewportRayRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportRayRequestDefaultTypeInternal _ViewportRayRequest_default_instance_;
+
 inline constexpr ViewportObjectRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : instance_id_(
@@ -213,33 +240,6 @@ struct ViewportIdRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportIdRequestDefaultTypeInternal _ViewportIdRequest_default_instance_;
-
-inline constexpr ViewportDropPositionRequest::Impl_::Impl_(
-    ::_pbi::ConstantInitialized) noexcept
-      : viewport_id_{::uint64_t{0u}},
-        normalized_x_{0},
-        normalized_y_{0},
-        _cached_size_{0} {}
-
-template <typename>
-PROTOBUF_CONSTEXPR ViewportDropPositionRequest::ViewportDropPositionRequest(::_pbi::ConstantInitialized)
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-    : ::google::protobuf::Message(_class_data_.base()),
-#else   // PROTOBUF_CUSTOM_VTABLE
-    : ::google::protobuf::Message(),
-#endif  // PROTOBUF_CUSTOM_VTABLE
-      _impl_(::_pbi::ConstantInitialized()) {
-}
-struct ViewportDropPositionRequestDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR ViewportDropPositionRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
-  ~ViewportDropPositionRequestDefaultTypeInternal() {}
-  union {
-    ViewportDropPositionRequest _instance;
-  };
-};
-
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
-    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 ViewportDropPositionRequestDefaultTypeInternal _ViewportDropPositionRequest_default_instance_;
 
 inline constexpr ViewportAssetDropEvent::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -1167,41 +1167,6 @@ struct InstantiatePrefabInstanceRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 InstantiatePrefabInstanceRequestDefaultTypeInternal _InstantiatePrefabInstanceRequest_default_instance_;
 
-inline constexpr CreateModelGameObjectRequest::Impl_::Impl_(
-    ::_pbi::ConstantInitialized) noexcept
-      : _cached_size_{0},
-        model_file_id_(
-            &::google::protobuf::internal::fixed_address_empty_string,
-            ::_pbi::ConstantInitialized()),
-        name_(
-            &::google::protobuf::internal::fixed_address_empty_string,
-            ::_pbi::ConstantInitialized()),
-        parent_instance_id_(
-            &::google::protobuf::internal::fixed_address_empty_string,
-            ::_pbi::ConstantInitialized()),
-        world_position_{nullptr},
-        apply_world_position_{false} {}
-
-template <typename>
-PROTOBUF_CONSTEXPR CreateModelGameObjectRequest::CreateModelGameObjectRequest(::_pbi::ConstantInitialized)
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-    : ::google::protobuf::Message(_class_data_.base()),
-#else   // PROTOBUF_CUSTOM_VTABLE
-    : ::google::protobuf::Message(),
-#endif  // PROTOBUF_CUSTOM_VTABLE
-      _impl_(::_pbi::ConstantInitialized()) {
-}
-struct CreateModelGameObjectRequestDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR CreateModelGameObjectRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
-  ~CreateModelGameObjectRequestDefaultTypeInternal() {}
-  union {
-    CreateModelGameObjectRequest _instance;
-  };
-};
-
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
-    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 CreateModelGameObjectRequestDefaultTypeInternal _CreateModelGameObjectRequest_default_instance_;
-
 inline constexpr ViewportEvent::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : revision_{::uint64_t{0u}},
@@ -1342,7 +1307,6 @@ const ::uint32_t
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolRequest, _impl_.protocol_version_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolRequest, _impl_.request_id_),
-        ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
@@ -1603,34 +1567,16 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabFromYamlRequest, _impl_.parent_instance_id_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabFromYamlRequest, _impl_.strict_instance_ids_),
         ~0u,  // no _has_bits_
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportDropPositionRequest, _internal_metadata_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportRayRequest, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
         ~0u,  // no _weak_field_map_
         ~0u,  // no _inlined_string_donated_
         ~0u,  // no _split_
         ~0u,  // no sizeof(Split)
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportDropPositionRequest, _impl_.viewport_id_),
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportDropPositionRequest, _impl_.normalized_x_),
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportDropPositionRequest, _impl_.normalized_y_),
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_._has_bits_),
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _internal_metadata_),
-        ~0u,  // no _extensions_
-        ~0u,  // no _oneof_case_
-        ~0u,  // no _weak_field_map_
-        ~0u,  // no _inlined_string_donated_
-        ~0u,  // no _split_
-        ~0u,  // no sizeof(Split)
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_.model_file_id_),
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_.name_),
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_.parent_instance_id_),
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_.apply_world_position_),
-        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelGameObjectRequest, _impl_.world_position_),
-        ~0u,
-        ~0u,
-        ~0u,
-        ~0u,
-        0,
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportRayRequest, _impl_.viewport_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportRayRequest, _impl_.normalized_x_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportRayRequest, _impl_.normalized_y_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabInstanceRequest, _impl_._has_bits_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabInstanceRequest, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -1903,50 +1849,49 @@ static const ::_pbi::MigrationSchema
     schemas[] ABSL_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
         {0, -1, -1, sizeof(::sailor::editor::v1::Empty)},
         {8, -1, -1, sizeof(::sailor::editor::v1::ProtocolRequest)},
-        {66, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
-        {92, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
-        {101, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
-        {110, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
-        {119, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
-        {128, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
-        {137, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
-        {149, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
-        {159, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
-        {174, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
-        {185, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
-        {205, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
-        {215, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
-        {225, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
-        {236, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
-        {246, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
-        {257, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
-        {267, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
-        {278, -1, -1, sizeof(::sailor::editor::v1::ViewportDropPositionRequest)},
-        {289, 302, -1, sizeof(::sailor::editor::v1::CreateModelGameObjectRequest)},
-        {307, 319, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
-        {323, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
-        {333, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
-        {343, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
-        {354, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
-        {363, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
-        {372, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
-        {385, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
-        {394, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
-        {403, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
-        {412, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
-        {421, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
-        {431, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
-        {440, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
-        {452, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
-        {462, 471, -1, sizeof(::sailor::editor::v1::Vector4Result)},
-        {472, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
-        {482, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
-        {494, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
-        {503, 520, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
-        {529, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
-        {540, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
-        {549, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
-        {564, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
+        {65, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
+        {91, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
+        {100, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
+        {109, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
+        {118, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
+        {127, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
+        {136, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
+        {148, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
+        {158, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
+        {173, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
+        {184, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
+        {204, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
+        {214, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
+        {224, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
+        {235, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
+        {245, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
+        {256, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
+        {266, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
+        {277, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
+        {288, 300, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
+        {304, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
+        {314, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
+        {324, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
+        {335, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
+        {344, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
+        {353, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
+        {366, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
+        {375, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
+        {384, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
+        {393, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
+        {402, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
+        {412, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
+        {421, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
+        {433, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
+        {443, 452, -1, sizeof(::sailor::editor::v1::Vector4Result)},
+        {453, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
+        {463, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
+        {475, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
+        {484, 501, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
+        {510, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
+        {521, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
+        {530, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
+        {545, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_Empty_default_instance_._instance,
@@ -1969,8 +1914,7 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_AddComponentRequest_default_instance_._instance,
     &::sailor::editor::v1::_InstantiatePrefabRequest_default_instance_._instance,
     &::sailor::editor::v1::_InstantiatePrefabFromYamlRequest_default_instance_._instance,
-    &::sailor::editor::v1::_ViewportDropPositionRequest_default_instance_._instance,
-    &::sailor::editor::v1::_CreateModelGameObjectRequest_default_instance_._instance,
+    &::sailor::editor::v1::_ViewportRayRequest_default_instance_._instance,
     &::sailor::editor::v1::_InstantiatePrefabInstanceRequest_default_instance_._instance,
     &::sailor::editor::v1::_ViewportObjectRequest_default_instance_._instance,
     &::sailor::editor::v1::_PrefabLinkRequest_default_instance_._instance,
@@ -1999,7 +1943,7 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
     protodesc_cold) = {
     "\n\023editor_engine.proto\022\020sailor.editor.v1\""
-    "\007\n\005Empty\"\354\031\n\017ProtocolRequest\022\030\n\020protocol"
+    "\007\n\005Empty\"\303\031\n\017ProtocolRequest\022\030\n\020protocol"
     "_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\0229\n\nin"
     "itialize\030\n \001(\0132#.sailor.editor.v1.Initia"
     "lizeRequestH\000\022(\n\005start\030\013 \001(\0132\027.sailor.ed"
@@ -2066,173 +2010,167 @@ const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SE
     "\000\022>\n\033is_engine_main_thread_ready\030/ \001(\0132\027"
     ".sailor.editor.v1.EmptyH\000\0224\n\021is_engine_r"
     "unning\0300 \001(\0132\027.sailor.editor.v1.EmptyH\000\022"
-    "W\n\036resolve_viewport_drop_position\0301 \001(\0132"
-    "-.sailor.editor.v1.ViewportDropPositionR"
-    "equestH\000\022R\n\030create_model_game_object\0302 \001"
-    "(\0132..sailor.editor.v1.CreateModelGameObj"
-    "ectRequestH\000\022Y\n\033instantiate_prefab_insta"
-    "nce\0303 \001(\01322.sailor.editor.v1.Instantiate"
-    "PrefabInstanceRequestH\000\022F\n\023focus_editor_"
-    "camera\0304 \001(\0132\'.sailor.editor.v1.Viewport"
-    "ObjectRequestH\000\022>\n\017set_prefab_link\0305 \001(\013"
-    "2#.sailor.editor.v1.PrefabLinkRequestH\000\022"
-    "@\n\021break_prefab_link\0306 \001(\0132#.sailor.edit"
-    "or.v1.InstanceIdRequestH\000\022M\n\027set_viewpor"
-    "t_tool_state\0307 \001(\0132*.sailor.editor.v1.Vi"
-    "ewportToolStateRequestH\000\022F\n\027get_viewport"
-    "_tool_state\0308 \001(\0132#.sailor.editor.v1.Vie"
-    "wportIdRequestH\000B\t\n\007commandJ\004\010\003\020\nJ\004\0109\020d\""
-    "\226\007\n\020ProtocolResponse\022\030\n\020protocol_version"
-    "\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\022\017\n\007success\030\003 "
-    "\001(\010\022\r\n\005error\030\004 \001(\t\022$\n\034supports_strict_in"
-    "stance_ids\030\005 \001(\010\022/\n\014empty_result\030\n \001(\0132\027"
-    ".sailor.editor.v1.EmptyH\000\0223\n\013bool_result"
-    "\030\013 \001(\0132\034.sailor.editor.v1.BoolResultH\000\0225"
-    "\n\014int32_result\030\014 \001(\0132\035.sailor.editor.v1."
-    "Int32ResultH\000\0227\n\ruint32_result\030\r \001(\0132\036.s"
-    "ailor.editor.v1.UInt32ResultH\000\0227\n\ruint64"
-    "_result\030\016 \001(\0132\036.sailor.editor.v1.UInt64R"
-    "esultH\000\0227\n\rstring_result\030\017 \001(\0132\036.sailor."
-    "editor.v1.StringResultH\000\022@\n\022string_list_"
-    "result\030\020 \001(\0132\".sailor.editor.v1.StringLi"
-    "stResultH\000\022M\n\031asset_reload_state_result\030"
-    "\021 \001(\0132(.sailor.editor.v1.AssetReloadStat"
-    "eResultH\000\022@\n\022instance_id_result\030\022 \001(\0132\"."
-    "sailor.editor.v1.InstanceIdResultH\000\022Q\n\033v"
-    "iewport_event_batch_result\030\023 \001(\0132*.sailo"
-    "r.editor.v1.ViewportEventBatchResultH\000\0229"
-    "\n\016vector4_result\030\024 \001(\0132\037.sailor.editor.v"
-    "1.Vector4ResultH\000\022O\n\032viewport_tool_state"
-    "_result\030\025 \001(\0132).sailor.editor.v1.Viewpor"
-    "tToolStateResultH\000B\010\n\006resultJ\004\010\006\020\nJ\004\010\026\020d"
-    "\"&\n\021InitializeRequest\022\021\n\targuments\030\001 \003(\t"
-    "\"!\n\014CountRequest\022\021\n\tmax_count\030\001 \001(\r\" \n\rF"
-    "ileIdRequest\022\017\n\007file_id\030\001 \001(\t\"(\n\021Instanc"
-    "eIdRequest\022\023\n\013instance_id\030\001 \001(\t\"(\n\021Viewp"
-    "ortIdRequest\022\023\n\013viewport_id\030\001 \001(\004\"`\n\023Vie"
-    "wportRectRequest\022\024\n\014window_pos_x\030\001 \001(\r\022\024"
-    "\n\014window_pos_y\030\002 \001(\r\022\r\n\005width\030\003 \001(\r\022\016\n\006h"
-    "eight\030\004 \001(\r\",\n\013SizeRequest\022\r\n\005width\030\001 \001("
-    "\r\022\016\n\006height\030\002 \001(\r\"\231\001\n\025RemoteViewportRequ"
-    "est\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014window_pos_x"
-    "\030\002 \001(\r\022\024\n\014window_pos_y\030\003 \001(\r\022\r\n\005width\030\004 "
-    "\001(\r\022\016\n\006height\030\005 \001(\r\022\017\n\007visible\030\006 \001(\010\022\017\n\007"
-    "focused\030\007 \001(\010\"e\n\031RemoteViewportHostReque"
-    "st\022\023\n\013viewport_id\030\001 \001(\004\022\030\n\020host_handle_k"
-    "ind\030\002 \001(\r\022\031\n\021host_handle_value\030\003 \001(\004\"\374\001\n"
-    "\032RemoteViewportInputRequest\022\023\n\013viewport_"
-    "id\030\001 \001(\004\022\014\n\004kind\030\002 \001(\r\022\021\n\tpointer_x\030\003 \001("
-    "\002\022\021\n\tpointer_y\030\004 \001(\002\022\025\n\rwheel_delta_x\030\005 "
-    "\001(\002\022\025\n\rwheel_delta_y\030\006 \001(\002\022\020\n\010key_code\030\007"
-    " \001(\r\022\016\n\006button\030\010 \001(\r\022\021\n\tmodifiers\030\t \001(\r\022"
-    "\017\n\007pressed\030\n \001(\010\022\017\n\007focused\030\013 \001(\010\022\020\n\010cap"
-    "tured\030\014 \001(\010\"C\n\036ManagedMutationRevisionRe"
-    "quest\022\014\n\004kind\030\001 \001(\r\022\023\n\013instance_id\030\002 \001(\t"
-    "\"@\n\023UpdateObjectRequest\022\023\n\013instance_id\030\001"
-    " \001(\t\022\024\n\014yaml_changes\030\002 \001(\t\"f\n\025ReparentOb"
-    "jectRequest\022\023\n\013instance_id\030\001 \001(\t\022\032\n\022pare"
-    "nt_instance_id\030\002 \001(\t\022\034\n\024keep_world_trans"
-    "form\030\003 \001(\010\"T\n\027CreateGameObjectRequest\022\032\n"
-    "\022parent_instance_id\030\001 \001(\t\022\035\n\025preferred_i"
-    "nstance_id\030\002 \001(\t\"f\n\023AddComponentRequest\022"
-    "\023\n\013instance_id\030\001 \001(\t\022\033\n\023component_type_n"
-    "ame\030\002 \001(\t\022\035\n\025preferred_instance_id\030\003 \001(\t"
-    "\"G\n\030InstantiatePrefabRequest\022\017\n\007file_id\030"
-    "\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\"p\n Ins"
-    "tantiatePrefabFromYamlRequest\022\023\n\013prefab_"
-    "yaml\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\033"
-    "\n\023strict_instance_ids\030\003 \001(\010\"^\n\033ViewportD"
-    "ropPositionRequest\022\023\n\013viewport_id\030\001 \001(\004\022"
-    "\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 "
-    "\001(\002\"\260\001\n\034CreateModelGameObjectRequest\022\025\n\r"
-    "model_file_id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\032\n\022par"
-    "ent_instance_id\030\003 \001(\t\022\034\n\024apply_world_pos"
-    "ition\030\004 \001(\010\0221\n\016world_position\030\005 \001(\0132\031.sa"
-    "ilor.editor.v1.Vector4\"\240\001\n InstantiatePr"
-    "efabInstanceRequest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022"
-    "parent_instance_id\030\002 \001(\t\022\034\n\024apply_world_"
-    "position\030\003 \001(\010\0221\n\016world_position\030\004 \001(\0132\031"
-    ".sailor.editor.v1.Vector4\"A\n\025ViewportObj"
-    "ectRequest\022\023\n\013viewport_id\030\001 \001(\004\022\023\n\013insta"
-    "nce_id\030\002 \001(\t\"9\n\021PrefabLinkRequest\022\023\n\013ins"
-    "tance_id\030\001 \001(\t\022\017\n\007file_id\030\002 \001(\t\"\251\001\n\030View"
-    "portToolStateRequest\022\023\n\013viewport_id\030\001 \001("
-    "\004\022\?\n\toperation\030\002 \001(\0162,.sailor.editor.v1."
-    "ViewportTransformOperation\0227\n\005space\030\003 \001("
-    "\0162(.sailor.editor.v1.ViewportTransformSp"
-    "ace\"(\n\020SelectionRequest\022\024\n\014instance_ids\030"
-    "\001 \003(\t\"%\n\025ShowMainWindowRequest\022\014\n\004show\030\001"
-    " \001(\010\"\210\001\n\034RenderPathTracedImageRequest\022\023\n"
-    "\013output_path\030\001 \001(\t\022\023\n\013instance_id\030\002 \001(\t\022"
-    "\016\n\006height\030\003 \001(\r\022\031\n\021samples_per_pixel\030\004 \001"
-    "(\r\022\023\n\013max_bounces\030\005 \001(\r\"\033\n\nBoolResult\022\r\n"
-    "\005value\030\001 \001(\010\"\034\n\013Int32Result\022\r\n\005value\030\001 \001"
-    "(\005\"\035\n\014UInt32Result\022\r\n\005value\030\001 \001(\r\"\035\n\014UIn"
-    "t64Result\022\r\n\005value\030\001 \001(\004\"0\n\014StringResult"
-    "\022\021\n\thas_value\030\001 \001(\010\022\r\n\005value\030\002 \001(\t\"\"\n\020St"
-    "ringListResult\022\016\n\006values\030\001 \003(\t\"\204\001\n\026Asset"
-    "ReloadStateResult\022\021\n\tavailable\030\001 \001(\010\022\032\n\022"
-    "request_generation\030\002 \001(\004\022\034\n\024completed_ge"
-    "neration\030\003 \001(\004\022\035\n\025successful_generation\030"
-    "\004 \001(\004\":\n\020InstanceIdResult\022\021\n\tsucceeded\030\001"
-    " \001(\010\022\023\n\013instance_id\030\002 \001(\t\"9\n\rVector4Resu"
-    "lt\022(\n\005value\030\001 \001(\0132\031.sailor.editor.v1.Vec"
-    "tor4\"\223\001\n\027ViewportToolStateResult\022\?\n\toper"
-    "ation\030\001 \001(\0162,.sailor.editor.v1.ViewportT"
-    "ransformOperation\0227\n\005space\030\002 \001(\0162(.sailo"
-    "r.editor.v1.ViewportTransformSpace\"5\n\007Ve"
-    "ctor4\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n\001z\030\003 \001(\002\022\t"
-    "\n\001w\030\004 \001(\002\"6\n\026ViewportSelectionEvent\022\034\n\024s"
-    "elected_instance_id\030\001 \001(\t\"\326\003\n\026ViewportTr"
-    "ansformEvent\022\023\n\013instance_id\030\001 \001(\t\022\?\n\tope"
-    "ration\030\002 \001(\0162,.sailor.editor.v1.Viewport"
-    "TransformOperation\0227\n\005space\030\003 \001(\0162(.sail"
-    "or.editor.v1.ViewportTransformSpace\0222\n\017b"
-    "efore_position\030\004 \001(\0132\031.sailor.editor.v1."
-    "Vector4\0222\n\017before_rotation\030\005 \001(\0132\031.sailo"
-    "r.editor.v1.Vector4\022/\n\014before_scale\030\006 \001("
-    "\0132\031.sailor.editor.v1.Vector4\0221\n\016after_po"
-    "sition\030\007 \001(\0132\031.sailor.editor.v1.Vector4\022"
-    "1\n\016after_rotation\030\010 \001(\0132\031.sailor.editor."
-    "v1.Vector4\022.\n\013after_scale\030\t \001(\0132\031.sailor"
-    ".editor.v1.Vector4\"U\n\026ViewportAssetDropE"
-    "vent\022\017\n\007file_id\030\001 \001(\t\022\024\n\014normalized_x\030\002 "
-    "\001(\002\022\024\n\014normalized_y\030\003 \001(\002\"-\n\031ViewportToo"
-    "lShortcutEvent\022\020\n\010key_code\030\001 \001(\r\"\331\002\n\rVie"
-    "wportEvent\022\020\n\010revision\030\001 \001(\004\022!\n\031managed_"
-    "mutation_revision\030\002 \001(\004\022=\n\tselection\030\n \001"
-    "(\0132(.sailor.editor.v1.ViewportSelectionE"
-    "ventH\000\022=\n\ttransform\030\013 \001(\0132(.sailor.edito"
-    "r.v1.ViewportTransformEventH\000\022>\n\nasset_d"
-    "rop\030\014 \001(\0132(.sailor.editor.v1.ViewportAss"
-    "etDropEventH\000\022D\n\rtool_shortcut\030\r \001(\0132+.s"
-    "ailor.editor.v1.ViewportToolShortcutEven"
-    "tH\000B\t\n\007payloadJ\004\010\003\020\n\"K\n\030ViewportEventBat"
-    "chResult\022/\n\006events\030\001 \003(\0132\037.sailor.editor"
-    ".v1.ViewportEvent*\360\001\n\032ViewportTransformO"
-    "peration\022,\n(VIEWPORT_TRANSFORM_OPERATION"
-    "_UNSPECIFIED\020\000\022\'\n#VIEWPORT_TRANSFORM_OPE"
-    "RATION_SELECT\020\001\022*\n&VIEWPORT_TRANSFORM_OP"
-    "ERATION_TRANSLATE\020\002\022\'\n#VIEWPORT_TRANSFOR"
-    "M_OPERATION_ROTATE\020\003\022&\n\"VIEWPORT_TRANSFO"
-    "RM_OPERATION_SCALE\020\004*\212\001\n\026ViewportTransfo"
-    "rmSpace\022(\n$VIEWPORT_TRANSFORM_SPACE_UNSP"
-    "ECIFIED\020\000\022\"\n\036VIEWPORT_TRANSFORM_SPACE_WO"
-    "RLD\020\001\022\"\n\036VIEWPORT_TRANSFORM_SPACE_LOCAL\020"
-    "\002B\"\252\002\037SailorEditor.Protocol.Generatedb\006p"
-    "roto3"
+    "B\n\022trace_viewport_ray\0301 \001(\0132$.sailor.edi"
+    "tor.v1.ViewportRayRequestH\000\022Y\n\033instantia"
+    "te_prefab_instance\0303 \001(\01322.sailor.editor"
+    ".v1.InstantiatePrefabInstanceRequestH\000\022F"
+    "\n\023focus_editor_camera\0304 \001(\0132\'.sailor.edi"
+    "tor.v1.ViewportObjectRequestH\000\022>\n\017set_pr"
+    "efab_link\0305 \001(\0132#.sailor.editor.v1.Prefa"
+    "bLinkRequestH\000\022@\n\021break_prefab_link\0306 \001("
+    "\0132#.sailor.editor.v1.InstanceIdRequestH\000"
+    "\022M\n\027set_viewport_tool_state\0307 \001(\0132*.sail"
+    "or.editor.v1.ViewportToolStateRequestH\000\022"
+    "F\n\027get_viewport_tool_state\0308 \001(\0132#.sailo"
+    "r.editor.v1.ViewportIdRequestH\000B\t\n\007comma"
+    "ndJ\004\010\003\020\nJ\004\0102\0203J\004\0109\020dR\030create_model_game_"
+    "objectR\036resolve_viewport_drop_position\"\226"
+    "\007\n\020ProtocolResponse\022\030\n\020protocol_version\030"
+    "\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\022\017\n\007success\030\003 \001"
+    "(\010\022\r\n\005error\030\004 \001(\t\022$\n\034supports_strict_ins"
+    "tance_ids\030\005 \001(\010\022/\n\014empty_result\030\n \001(\0132\027."
+    "sailor.editor.v1.EmptyH\000\0223\n\013bool_result\030"
+    "\013 \001(\0132\034.sailor.editor.v1.BoolResultH\000\0225\n"
+    "\014int32_result\030\014 \001(\0132\035.sailor.editor.v1.I"
+    "nt32ResultH\000\0227\n\ruint32_result\030\r \001(\0132\036.sa"
+    "ilor.editor.v1.UInt32ResultH\000\0227\n\ruint64_"
+    "result\030\016 \001(\0132\036.sailor.editor.v1.UInt64Re"
+    "sultH\000\0227\n\rstring_result\030\017 \001(\0132\036.sailor.e"
+    "ditor.v1.StringResultH\000\022@\n\022string_list_r"
+    "esult\030\020 \001(\0132\".sailor.editor.v1.StringLis"
+    "tResultH\000\022M\n\031asset_reload_state_result\030\021"
+    " \001(\0132(.sailor.editor.v1.AssetReloadState"
+    "ResultH\000\022@\n\022instance_id_result\030\022 \001(\0132\".s"
+    "ailor.editor.v1.InstanceIdResultH\000\022Q\n\033vi"
+    "ewport_event_batch_result\030\023 \001(\0132*.sailor"
+    ".editor.v1.ViewportEventBatchResultH\000\0229\n"
+    "\016vector4_result\030\024 \001(\0132\037.sailor.editor.v1"
+    ".Vector4ResultH\000\022O\n\032viewport_tool_state_"
+    "result\030\025 \001(\0132).sailor.editor.v1.Viewport"
+    "ToolStateResultH\000B\010\n\006resultJ\004\010\006\020\nJ\004\010\026\020d\""
+    "&\n\021InitializeRequest\022\021\n\targuments\030\001 \003(\t\""
+    "!\n\014CountRequest\022\021\n\tmax_count\030\001 \001(\r\" \n\rFi"
+    "leIdRequest\022\017\n\007file_id\030\001 \001(\t\"(\n\021Instance"
+    "IdRequest\022\023\n\013instance_id\030\001 \001(\t\"(\n\021Viewpo"
+    "rtIdRequest\022\023\n\013viewport_id\030\001 \001(\004\"`\n\023View"
+    "portRectRequest\022\024\n\014window_pos_x\030\001 \001(\r\022\024\n"
+    "\014window_pos_y\030\002 \001(\r\022\r\n\005width\030\003 \001(\r\022\016\n\006he"
+    "ight\030\004 \001(\r\",\n\013SizeRequest\022\r\n\005width\030\001 \001(\r"
+    "\022\016\n\006height\030\002 \001(\r\"\231\001\n\025RemoteViewportReque"
+    "st\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014window_pos_x\030"
+    "\002 \001(\r\022\024\n\014window_pos_y\030\003 \001(\r\022\r\n\005width\030\004 \001"
+    "(\r\022\016\n\006height\030\005 \001(\r\022\017\n\007visible\030\006 \001(\010\022\017\n\007f"
+    "ocused\030\007 \001(\010\"e\n\031RemoteViewportHostReques"
+    "t\022\023\n\013viewport_id\030\001 \001(\004\022\030\n\020host_handle_ki"
+    "nd\030\002 \001(\r\022\031\n\021host_handle_value\030\003 \001(\004\"\374\001\n\032"
+    "RemoteViewportInputRequest\022\023\n\013viewport_i"
+    "d\030\001 \001(\004\022\014\n\004kind\030\002 \001(\r\022\021\n\tpointer_x\030\003 \001(\002"
+    "\022\021\n\tpointer_y\030\004 \001(\002\022\025\n\rwheel_delta_x\030\005 \001"
+    "(\002\022\025\n\rwheel_delta_y\030\006 \001(\002\022\020\n\010key_code\030\007 "
+    "\001(\r\022\016\n\006button\030\010 \001(\r\022\021\n\tmodifiers\030\t \001(\r\022\017"
+    "\n\007pressed\030\n \001(\010\022\017\n\007focused\030\013 \001(\010\022\020\n\010capt"
+    "ured\030\014 \001(\010\"C\n\036ManagedMutationRevisionReq"
+    "uest\022\014\n\004kind\030\001 \001(\r\022\023\n\013instance_id\030\002 \001(\t\""
+    "@\n\023UpdateObjectRequest\022\023\n\013instance_id\030\001 "
+    "\001(\t\022\024\n\014yaml_changes\030\002 \001(\t\"f\n\025ReparentObj"
+    "ectRequest\022\023\n\013instance_id\030\001 \001(\t\022\032\n\022paren"
+    "t_instance_id\030\002 \001(\t\022\034\n\024keep_world_transf"
+    "orm\030\003 \001(\010\"T\n\027CreateGameObjectRequest\022\032\n\022"
+    "parent_instance_id\030\001 \001(\t\022\035\n\025preferred_in"
+    "stance_id\030\002 \001(\t\"f\n\023AddComponentRequest\022\023"
+    "\n\013instance_id\030\001 \001(\t\022\033\n\023component_type_na"
+    "me\030\002 \001(\t\022\035\n\025preferred_instance_id\030\003 \001(\t\""
+    "G\n\030InstantiatePrefabRequest\022\017\n\007file_id\030\001"
+    " \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\"p\n Inst"
+    "antiatePrefabFromYamlRequest\022\023\n\013prefab_y"
+    "aml\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\033\n"
+    "\023strict_instance_ids\030\003 \001(\010\"U\n\022ViewportRa"
+    "yRequest\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014normali"
+    "zed_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 \001(\002\"\240\001\n In"
+    "stantiatePrefabInstanceRequest\022\017\n\007file_i"
+    "d\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\034\n\024a"
+    "pply_world_position\030\003 \001(\010\0221\n\016world_posit"
+    "ion\030\004 \001(\0132\031.sailor.editor.v1.Vector4\"A\n\025"
+    "ViewportObjectRequest\022\023\n\013viewport_id\030\001 \001"
+    "(\004\022\023\n\013instance_id\030\002 \001(\t\"9\n\021PrefabLinkReq"
+    "uest\022\023\n\013instance_id\030\001 \001(\t\022\017\n\007file_id\030\002 \001"
+    "(\t\"\251\001\n\030ViewportToolStateRequest\022\023\n\013viewp"
+    "ort_id\030\001 \001(\004\022\?\n\toperation\030\002 \001(\0162,.sailor"
+    ".editor.v1.ViewportTransformOperation\0227\n"
+    "\005space\030\003 \001(\0162(.sailor.editor.v1.Viewport"
+    "TransformSpace\"(\n\020SelectionRequest\022\024\n\014in"
+    "stance_ids\030\001 \003(\t\"%\n\025ShowMainWindowReques"
+    "t\022\014\n\004show\030\001 \001(\010\"\210\001\n\034RenderPathTracedImag"
+    "eRequest\022\023\n\013output_path\030\001 \001(\t\022\023\n\013instanc"
+    "e_id\030\002 \001(\t\022\016\n\006height\030\003 \001(\r\022\031\n\021samples_pe"
+    "r_pixel\030\004 \001(\r\022\023\n\013max_bounces\030\005 \001(\r\"\033\n\nBo"
+    "olResult\022\r\n\005value\030\001 \001(\010\"\034\n\013Int32Result\022\r"
+    "\n\005value\030\001 \001(\005\"\035\n\014UInt32Result\022\r\n\005value\030\001"
+    " \001(\r\"\035\n\014UInt64Result\022\r\n\005value\030\001 \001(\004\"0\n\014S"
+    "tringResult\022\021\n\thas_value\030\001 \001(\010\022\r\n\005value\030"
+    "\002 \001(\t\"\"\n\020StringListResult\022\016\n\006values\030\001 \003("
+    "\t\"\204\001\n\026AssetReloadStateResult\022\021\n\tavailabl"
+    "e\030\001 \001(\010\022\032\n\022request_generation\030\002 \001(\004\022\034\n\024c"
+    "ompleted_generation\030\003 \001(\004\022\035\n\025successful_"
+    "generation\030\004 \001(\004\":\n\020InstanceIdResult\022\021\n\t"
+    "succeeded\030\001 \001(\010\022\023\n\013instance_id\030\002 \001(\t\"9\n\r"
+    "Vector4Result\022(\n\005value\030\001 \001(\0132\031.sailor.ed"
+    "itor.v1.Vector4\"\223\001\n\027ViewportToolStateRes"
+    "ult\022\?\n\toperation\030\001 \001(\0162,.sailor.editor.v"
+    "1.ViewportTransformOperation\0227\n\005space\030\002 "
+    "\001(\0162(.sailor.editor.v1.ViewportTransform"
+    "Space\"5\n\007Vector4\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t"
+    "\n\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n\026ViewportSelectio"
+    "nEvent\022\034\n\024selected_instance_id\030\001 \001(\t\"\326\003\n"
+    "\026ViewportTransformEvent\022\023\n\013instance_id\030\001"
+    " \001(\t\022\?\n\toperation\030\002 \001(\0162,.sailor.editor."
+    "v1.ViewportTransformOperation\0227\n\005space\030\003"
+    " \001(\0162(.sailor.editor.v1.ViewportTransfor"
+    "mSpace\0222\n\017before_position\030\004 \001(\0132\031.sailor"
+    ".editor.v1.Vector4\0222\n\017before_rotation\030\005 "
+    "\001(\0132\031.sailor.editor.v1.Vector4\022/\n\014before"
+    "_scale\030\006 \001(\0132\031.sailor.editor.v1.Vector4\022"
+    "1\n\016after_position\030\007 \001(\0132\031.sailor.editor."
+    "v1.Vector4\0221\n\016after_rotation\030\010 \001(\0132\031.sai"
+    "lor.editor.v1.Vector4\022.\n\013after_scale\030\t \001"
+    "(\0132\031.sailor.editor.v1.Vector4\"U\n\026Viewpor"
+    "tAssetDropEvent\022\017\n\007file_id\030\001 \001(\t\022\024\n\014norm"
+    "alized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 \001(\002\"-\n\031"
+    "ViewportToolShortcutEvent\022\020\n\010key_code\030\001 "
+    "\001(\r\"\331\002\n\rViewportEvent\022\020\n\010revision\030\001 \001(\004\022"
+    "!\n\031managed_mutation_revision\030\002 \001(\004\022=\n\tse"
+    "lection\030\n \001(\0132(.sailor.editor.v1.Viewpor"
+    "tSelectionEventH\000\022=\n\ttransform\030\013 \001(\0132(.s"
+    "ailor.editor.v1.ViewportTransformEventH\000"
+    "\022>\n\nasset_drop\030\014 \001(\0132(.sailor.editor.v1."
+    "ViewportAssetDropEventH\000\022D\n\rtool_shortcu"
+    "t\030\r \001(\0132+.sailor.editor.v1.ViewportToolS"
+    "hortcutEventH\000B\t\n\007payloadJ\004\010\003\020\n\"K\n\030Viewp"
+    "ortEventBatchResult\022/\n\006events\030\001 \003(\0132\037.sa"
+    "ilor.editor.v1.ViewportEvent*\360\001\n\032Viewpor"
+    "tTransformOperation\022,\n(VIEWPORT_TRANSFOR"
+    "M_OPERATION_UNSPECIFIED\020\000\022\'\n#VIEWPORT_TR"
+    "ANSFORM_OPERATION_SELECT\020\001\022*\n&VIEWPORT_T"
+    "RANSFORM_OPERATION_TRANSLATE\020\002\022\'\n#VIEWPO"
+    "RT_TRANSFORM_OPERATION_ROTATE\020\003\022&\n\"VIEWP"
+    "ORT_TRANSFORM_OPERATION_SCALE\020\004*\212\001\n\026View"
+    "portTransformSpace\022(\n$VIEWPORT_TRANSFORM"
+    "_SPACE_UNSPECIFIED\020\000\022\"\n\036VIEWPORT_TRANSFO"
+    "RM_SPACE_WORLD\020\001\022\"\n\036VIEWPORT_TRANSFORM_S"
+    "PACE_LOCAL\020\002B\"\252\002\037SailorEditor.Protocol.G"
+    "eneratedb\006proto3"
 };
 static ::absl::once_flag descriptor_table_editor_5fengine_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_editor_5fengine_2eproto = {
     false,
     false,
-    8885,
+    8656,
     descriptor_table_protodef_editor_5fengine_2eproto,
     "editor_engine.proto",
     &descriptor_table_editor_5fengine_2eproto_once,
     nullptr,
     0,
-    46,
+    45,
     schemas,
     file_default_instances,
     TableStruct_editor_5fengine_2eproto::offsets,
@@ -2878,31 +2816,18 @@ void ProtocolRequest::set_allocated_is_engine_running(::sailor::editor::v1::Empt
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.is_engine_running)
 }
-void ProtocolRequest::set_allocated_resolve_viewport_drop_position(::sailor::editor::v1::ViewportDropPositionRequest* resolve_viewport_drop_position) {
+void ProtocolRequest::set_allocated_trace_viewport_ray(::sailor::editor::v1::ViewportRayRequest* trace_viewport_ray) {
   ::google::protobuf::Arena* message_arena = GetArena();
   clear_command();
-  if (resolve_viewport_drop_position) {
-    ::google::protobuf::Arena* submessage_arena = resolve_viewport_drop_position->GetArena();
+  if (trace_viewport_ray) {
+    ::google::protobuf::Arena* submessage_arena = trace_viewport_ray->GetArena();
     if (message_arena != submessage_arena) {
-      resolve_viewport_drop_position = ::google::protobuf::internal::GetOwnedMessage(message_arena, resolve_viewport_drop_position, submessage_arena);
+      trace_viewport_ray = ::google::protobuf::internal::GetOwnedMessage(message_arena, trace_viewport_ray, submessage_arena);
     }
-    set_has_resolve_viewport_drop_position();
-    _impl_.command_.resolve_viewport_drop_position_ = resolve_viewport_drop_position;
+    set_has_trace_viewport_ray();
+    _impl_.command_.trace_viewport_ray_ = trace_viewport_ray;
   }
-  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
-}
-void ProtocolRequest::set_allocated_create_model_game_object(::sailor::editor::v1::CreateModelGameObjectRequest* create_model_game_object) {
-  ::google::protobuf::Arena* message_arena = GetArena();
-  clear_command();
-  if (create_model_game_object) {
-    ::google::protobuf::Arena* submessage_arena = create_model_game_object->GetArena();
-    if (message_arena != submessage_arena) {
-      create_model_game_object = ::google::protobuf::internal::GetOwnedMessage(message_arena, create_model_game_object, submessage_arena);
-    }
-    set_has_create_model_game_object();
-    _impl_.command_.create_model_game_object_ = create_model_game_object;
-  }
-  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.create_model_game_object)
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.trace_viewport_ray)
 }
 void ProtocolRequest::set_allocated_instantiate_prefab_instance(::sailor::editor::v1::InstantiatePrefabInstanceRequest* instantiate_prefab_instance) {
   ::google::protobuf::Arena* message_arena = GetArena();
@@ -3138,11 +3063,8 @@ ProtocolRequest::ProtocolRequest(
       case kIsEngineRunning:
         _impl_.command_.is_engine_running_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Empty>(arena, *from._impl_.command_.is_engine_running_);
         break;
-      case kResolveViewportDropPosition:
-        _impl_.command_.resolve_viewport_drop_position_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportDropPositionRequest>(arena, *from._impl_.command_.resolve_viewport_drop_position_);
-        break;
-      case kCreateModelGameObject:
-        _impl_.command_.create_model_game_object_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::CreateModelGameObjectRequest>(arena, *from._impl_.command_.create_model_game_object_);
+      case kTraceViewportRay:
+        _impl_.command_.trace_viewport_ray_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportRayRequest>(arena, *from._impl_.command_.trace_viewport_ray_);
         break;
       case kInstantiatePrefabInstance:
         _impl_.command_.instantiate_prefab_instance_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::InstantiatePrefabInstanceRequest>(arena, *from._impl_.command_.instantiate_prefab_instance_);
@@ -3512,19 +3434,11 @@ void ProtocolRequest::clear_command() {
       }
       break;
     }
-    case kResolveViewportDropPosition: {
+    case kTraceViewportRay: {
       if (GetArena() == nullptr) {
-        delete _impl_.command_.resolve_viewport_drop_position_;
+        delete _impl_.command_.trace_viewport_ray_;
       } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
-        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.resolve_viewport_drop_position_);
-      }
-      break;
-    }
-    case kCreateModelGameObject: {
-      if (GetArena() == nullptr) {
-        delete _impl_.command_.create_model_game_object_;
-      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
-        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.create_model_game_object_);
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.trace_viewport_ray_);
       }
       break;
     }
@@ -3620,7 +3534,7 @@ const ::google::protobuf::internal::ClassData* ProtocolRequest::GetClassData() c
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
+const ::_pbi::TcParseTable<1, 48, 46, 0, 9> ProtocolRequest::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
@@ -3628,8 +3542,8 @@ const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
     offsetof(decltype(_table_), field_lookup_table),
     508,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    49,  // num_field_entries
-    47,  // num_aux_entries
+    48,  // num_field_entries
+    46,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -3646,7 +3560,7 @@ const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
      {8, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.protocol_version_)}},
   }}, {{
     33, 0, 2,
-    0, 25, 65280, 41,
+    0, 25, 65282, 41,
     65535, 65535
   }}, {{
     // uint32 protocol_version = 1;
@@ -3772,29 +3686,26 @@ const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
     // .sailor.editor.v1.Empty is_engine_running = 48;
     {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.is_engine_running_), _Internal::kOneofCaseOffset + 0, 38,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
-    // .sailor.editor.v1.ViewportDropPositionRequest resolve_viewport_drop_position = 49;
-    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.resolve_viewport_drop_position_), _Internal::kOneofCaseOffset + 0, 39,
-    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
-    // .sailor.editor.v1.CreateModelGameObjectRequest create_model_game_object = 50;
-    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.create_model_game_object_), _Internal::kOneofCaseOffset + 0, 40,
+    // .sailor.editor.v1.ViewportRayRequest trace_viewport_ray = 49;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.trace_viewport_ray_), _Internal::kOneofCaseOffset + 0, 39,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
     // .sailor.editor.v1.InstantiatePrefabInstanceRequest instantiate_prefab_instance = 51;
-    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.instantiate_prefab_instance_), _Internal::kOneofCaseOffset + 0, 41,
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.instantiate_prefab_instance_), _Internal::kOneofCaseOffset + 0, 40,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
     // .sailor.editor.v1.ViewportObjectRequest focus_editor_camera = 52;
-    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.focus_editor_camera_), _Internal::kOneofCaseOffset + 0, 42,
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.focus_editor_camera_), _Internal::kOneofCaseOffset + 0, 41,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
     // .sailor.editor.v1.PrefabLinkRequest set_prefab_link = 53;
-    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_prefab_link_), _Internal::kOneofCaseOffset + 0, 43,
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_prefab_link_), _Internal::kOneofCaseOffset + 0, 42,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
     // .sailor.editor.v1.InstanceIdRequest break_prefab_link = 54;
-    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.break_prefab_link_), _Internal::kOneofCaseOffset + 0, 44,
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.break_prefab_link_), _Internal::kOneofCaseOffset + 0, 43,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
     // .sailor.editor.v1.ViewportToolStateRequest set_viewport_tool_state = 55;
-    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_viewport_tool_state_), _Internal::kOneofCaseOffset + 0, 45,
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_viewport_tool_state_), _Internal::kOneofCaseOffset + 0, 44,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
     // .sailor.editor.v1.ViewportIdRequest get_viewport_tool_state = 56;
-    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.get_viewport_tool_state_), _Internal::kOneofCaseOffset + 0, 46,
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.get_viewport_tool_state_), _Internal::kOneofCaseOffset + 0, 45,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InitializeRequest>()},
@@ -3836,8 +3747,7 @@ const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
-    {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportDropPositionRequest>()},
-    {::_pbi::TcParser::GetTable<::sailor::editor::v1::CreateModelGameObjectRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportRayRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InstantiatePrefabInstanceRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportObjectRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::PrefabLinkRequest>()},
@@ -4126,15 +4036,9 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
                   stream);
               break;
             }
-            case kResolveViewportDropPosition: {
+            case kTraceViewportRay: {
               target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
-                  49, *this_._impl_.command_.resolve_viewport_drop_position_, this_._impl_.command_.resolve_viewport_drop_position_->GetCachedSize(), target,
-                  stream);
-              break;
-            }
-            case kCreateModelGameObject: {
-              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
-                  50, *this_._impl_.command_.create_model_game_object_, this_._impl_.command_.create_model_game_object_->GetCachedSize(), target,
+                  49, *this_._impl_.command_.trace_viewport_ray_, this_._impl_.command_.trace_viewport_ray_->GetCachedSize(), target,
                   stream);
               break;
             }
@@ -4448,16 +4352,10 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.is_engine_running_);
               break;
             }
-            // .sailor.editor.v1.ViewportDropPositionRequest resolve_viewport_drop_position = 49;
-            case kResolveViewportDropPosition: {
+            // .sailor.editor.v1.ViewportRayRequest trace_viewport_ray = 49;
+            case kTraceViewportRay: {
               total_size += 2 +
-                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.resolve_viewport_drop_position_);
-              break;
-            }
-            // .sailor.editor.v1.CreateModelGameObjectRequest create_model_game_object = 50;
-            case kCreateModelGameObject: {
-              total_size += 2 +
-                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.create_model_game_object_);
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.trace_viewport_ray_);
               break;
             }
             // .sailor.editor.v1.InstantiatePrefabInstanceRequest instantiate_prefab_instance = 51;
@@ -4881,21 +4779,12 @@ void ProtocolRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const :
         }
         break;
       }
-      case kResolveViewportDropPosition: {
+      case kTraceViewportRay: {
         if (oneof_needs_init) {
-          _this->_impl_.command_.resolve_viewport_drop_position_ =
-              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportDropPositionRequest>(arena, *from._impl_.command_.resolve_viewport_drop_position_);
+          _this->_impl_.command_.trace_viewport_ray_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportRayRequest>(arena, *from._impl_.command_.trace_viewport_ray_);
         } else {
-          _this->_impl_.command_.resolve_viewport_drop_position_->MergeFrom(from._internal_resolve_viewport_drop_position());
-        }
-        break;
-      }
-      case kCreateModelGameObject: {
-        if (oneof_needs_init) {
-          _this->_impl_.command_.create_model_game_object_ =
-              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::CreateModelGameObjectRequest>(arena, *from._impl_.command_.create_model_game_object_);
-        } else {
-          _this->_impl_.command_.create_model_game_object_->MergeFrom(from._internal_create_model_game_object());
+          _this->_impl_.command_.trace_viewport_ray_->MergeFrom(from._internal_trace_viewport_ray());
         }
         break;
       }
@@ -10560,30 +10449,30 @@ void InstantiatePrefabFromYamlRequest::InternalSwap(InstantiatePrefabFromYamlReq
 }
 // ===================================================================
 
-class ViewportDropPositionRequest::_Internal {
+class ViewportRayRequest::_Internal {
  public:
 };
 
-ViewportDropPositionRequest::ViewportDropPositionRequest(::google::protobuf::Arena* arena)
+ViewportRayRequest::ViewportRayRequest(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
 #else   // PROTOBUF_CUSTOM_VTABLE
     : ::google::protobuf::Message(arena) {
 #endif  // PROTOBUF_CUSTOM_VTABLE
   SharedCtor(arena);
-  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.ViewportDropPositionRequest)
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.ViewportRayRequest)
 }
-ViewportDropPositionRequest::ViewportDropPositionRequest(
-    ::google::protobuf::Arena* arena, const ViewportDropPositionRequest& from)
-    : ViewportDropPositionRequest(arena) {
+ViewportRayRequest::ViewportRayRequest(
+    ::google::protobuf::Arena* arena, const ViewportRayRequest& from)
+    : ViewportRayRequest(arena) {
   MergeFrom(from);
 }
-inline PROTOBUF_NDEBUG_INLINE ViewportDropPositionRequest::Impl_::Impl_(
+inline PROTOBUF_NDEBUG_INLINE ViewportRayRequest::Impl_::Impl_(
     ::google::protobuf::internal::InternalVisibility visibility,
     ::google::protobuf::Arena* arena)
       : _cached_size_{0} {}
 
-inline void ViewportDropPositionRequest::SharedCtor(::_pb::Arena* arena) {
+inline void ViewportRayRequest::SharedCtor(::_pb::Arena* arena) {
   new (&_impl_) Impl_(internal_visibility(), arena);
   ::memset(reinterpret_cast<char *>(&_impl_) +
                offsetof(Impl_, viewport_id_),
@@ -10592,54 +10481,54 @@ inline void ViewportDropPositionRequest::SharedCtor(::_pb::Arena* arena) {
                offsetof(Impl_, viewport_id_) +
                sizeof(Impl_::normalized_y_));
 }
-ViewportDropPositionRequest::~ViewportDropPositionRequest() {
-  // @@protoc_insertion_point(destructor:sailor.editor.v1.ViewportDropPositionRequest)
+ViewportRayRequest::~ViewportRayRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.ViewportRayRequest)
   SharedDtor(*this);
 }
-inline void ViewportDropPositionRequest::SharedDtor(MessageLite& self) {
-  ViewportDropPositionRequest& this_ = static_cast<ViewportDropPositionRequest&>(self);
+inline void ViewportRayRequest::SharedDtor(MessageLite& self) {
+  ViewportRayRequest& this_ = static_cast<ViewportRayRequest&>(self);
   this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
   ABSL_DCHECK(this_.GetArena() == nullptr);
   this_._impl_.~Impl_();
 }
 
-inline void* ViewportDropPositionRequest::PlacementNew_(const void*, void* mem,
+inline void* ViewportRayRequest::PlacementNew_(const void*, void* mem,
                                         ::google::protobuf::Arena* arena) {
-  return ::new (mem) ViewportDropPositionRequest(arena);
+  return ::new (mem) ViewportRayRequest(arena);
 }
-constexpr auto ViewportDropPositionRequest::InternalNewImpl_() {
-  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(ViewportDropPositionRequest),
-                                            alignof(ViewportDropPositionRequest));
+constexpr auto ViewportRayRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(ViewportRayRequest),
+                                            alignof(ViewportRayRequest));
 }
 PROTOBUF_CONSTINIT
 PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::google::protobuf::internal::ClassDataFull ViewportDropPositionRequest::_class_data_ = {
+const ::google::protobuf::internal::ClassDataFull ViewportRayRequest::_class_data_ = {
     ::google::protobuf::internal::ClassData{
-        &_ViewportDropPositionRequest_default_instance_._instance,
+        &_ViewportRayRequest_default_instance_._instance,
         &_table_.header,
         nullptr,  // OnDemandRegisterArenaDtor
         nullptr,  // IsInitialized
-        &ViewportDropPositionRequest::MergeImpl,
-        ::google::protobuf::Message::GetNewImpl<ViewportDropPositionRequest>(),
+        &ViewportRayRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<ViewportRayRequest>(),
 #if defined(PROTOBUF_CUSTOM_VTABLE)
-        &ViewportDropPositionRequest::SharedDtor,
-        ::google::protobuf::Message::GetClearImpl<ViewportDropPositionRequest>(), &ViewportDropPositionRequest::ByteSizeLong,
-            &ViewportDropPositionRequest::_InternalSerialize,
+        &ViewportRayRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<ViewportRayRequest>(), &ViewportRayRequest::ByteSizeLong,
+            &ViewportRayRequest::_InternalSerialize,
 #endif  // PROTOBUF_CUSTOM_VTABLE
-        PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_._cached_size_),
+        PROTOBUF_FIELD_OFFSET(ViewportRayRequest, _impl_._cached_size_),
         false,
     },
-    &ViewportDropPositionRequest::kDescriptorMethods,
+    &ViewportRayRequest::kDescriptorMethods,
     &descriptor_table_editor_5fengine_2eproto,
     nullptr,  // tracker
 };
-const ::google::protobuf::internal::ClassData* ViewportDropPositionRequest::GetClassData() const {
+const ::google::protobuf::internal::ClassData* ViewportRayRequest::GetClassData() const {
   ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
   ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<2, 3, 0, 0, 2> ViewportDropPositionRequest::_table_ = {
+const ::_pbi::TcParseTable<2, 3, 0, 0, 2> ViewportRayRequest::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
@@ -10654,30 +10543,30 @@ const ::_pbi::TcParseTable<2, 3, 0, 0, 2> ViewportDropPositionRequest::_table_ =
     nullptr,  // post_loop_handler
     ::_pbi::TcParser::GenericFallback,  // fallback
     #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
-    ::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportDropPositionRequest>(),  // to_prefetch
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportRayRequest>(),  // to_prefetch
     #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
   }, {{
     {::_pbi::TcParser::MiniParse, {}},
     // uint64 viewport_id = 1;
-    {::_pbi::TcParser::SingularVarintNoZag1<::uint64_t, offsetof(ViewportDropPositionRequest, _impl_.viewport_id_), 63>(),
-     {8, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.viewport_id_)}},
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint64_t, offsetof(ViewportRayRequest, _impl_.viewport_id_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportRayRequest, _impl_.viewport_id_)}},
     // float normalized_x = 2;
     {::_pbi::TcParser::FastF32S1,
-     {21, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.normalized_x_)}},
+     {21, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportRayRequest, _impl_.normalized_x_)}},
     // float normalized_y = 3;
     {::_pbi::TcParser::FastF32S1,
-     {29, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.normalized_y_)}},
+     {29, 63, 0, PROTOBUF_FIELD_OFFSET(ViewportRayRequest, _impl_.normalized_y_)}},
   }}, {{
     65535, 65535
   }}, {{
     // uint64 viewport_id = 1;
-    {PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.viewport_id_), 0, 0,
+    {PROTOBUF_FIELD_OFFSET(ViewportRayRequest, _impl_.viewport_id_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kUInt64)},
     // float normalized_x = 2;
-    {PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.normalized_x_), 0, 0,
+    {PROTOBUF_FIELD_OFFSET(ViewportRayRequest, _impl_.normalized_x_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
     // float normalized_y = 3;
-    {PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.normalized_y_), 0, 0,
+    {PROTOBUF_FIELD_OFFSET(ViewportRayRequest, _impl_.normalized_y_), 0, 0,
     (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
   }},
   // no aux_entries
@@ -10685,8 +10574,8 @@ const ::_pbi::TcParseTable<2, 3, 0, 0, 2> ViewportDropPositionRequest::_table_ =
   }},
 };
 
-PROTOBUF_NOINLINE void ViewportDropPositionRequest::Clear() {
-// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.ViewportDropPositionRequest)
+PROTOBUF_NOINLINE void ViewportRayRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.ViewportRayRequest)
   ::google::protobuf::internal::TSanWrite(&_impl_);
   ::uint32_t cached_has_bits = 0;
   // Prevent compiler warnings about cached_has_bits being unused
@@ -10699,17 +10588,17 @@ PROTOBUF_NOINLINE void ViewportDropPositionRequest::Clear() {
 }
 
 #if defined(PROTOBUF_CUSTOM_VTABLE)
-        ::uint8_t* ViewportDropPositionRequest::_InternalSerialize(
+        ::uint8_t* ViewportRayRequest::_InternalSerialize(
             const MessageLite& base, ::uint8_t* target,
             ::google::protobuf::io::EpsCopyOutputStream* stream) {
-          const ViewportDropPositionRequest& this_ = static_cast<const ViewportDropPositionRequest&>(base);
+          const ViewportRayRequest& this_ = static_cast<const ViewportRayRequest&>(base);
 #else   // PROTOBUF_CUSTOM_VTABLE
-        ::uint8_t* ViewportDropPositionRequest::_InternalSerialize(
+        ::uint8_t* ViewportRayRequest::_InternalSerialize(
             ::uint8_t* target,
             ::google::protobuf::io::EpsCopyOutputStream* stream) const {
-          const ViewportDropPositionRequest& this_ = *this;
+          const ViewportRayRequest& this_ = *this;
 #endif  // PROTOBUF_CUSTOM_VTABLE
-          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.ViewportDropPositionRequest)
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.ViewportRayRequest)
           ::uint32_t cached_has_bits = 0;
           (void)cached_has_bits;
 
@@ -10739,18 +10628,18 @@ PROTOBUF_NOINLINE void ViewportDropPositionRequest::Clear() {
                 ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
                     this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
           }
-          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.ViewportDropPositionRequest)
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.ViewportRayRequest)
           return target;
         }
 
 #if defined(PROTOBUF_CUSTOM_VTABLE)
-        ::size_t ViewportDropPositionRequest::ByteSizeLong(const MessageLite& base) {
-          const ViewportDropPositionRequest& this_ = static_cast<const ViewportDropPositionRequest&>(base);
+        ::size_t ViewportRayRequest::ByteSizeLong(const MessageLite& base) {
+          const ViewportRayRequest& this_ = static_cast<const ViewportRayRequest&>(base);
 #else   // PROTOBUF_CUSTOM_VTABLE
-        ::size_t ViewportDropPositionRequest::ByteSizeLong() const {
-          const ViewportDropPositionRequest& this_ = *this;
+        ::size_t ViewportRayRequest::ByteSizeLong() const {
+          const ViewportRayRequest& this_ = *this;
 #endif  // PROTOBUF_CUSTOM_VTABLE
-          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.ViewportDropPositionRequest)
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.ViewportRayRequest)
           ::size_t total_size = 0;
 
           ::uint32_t cached_has_bits = 0;
@@ -10777,10 +10666,10 @@ PROTOBUF_NOINLINE void ViewportDropPositionRequest::Clear() {
                                                      &this_._impl_._cached_size_);
         }
 
-void ViewportDropPositionRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
-  auto* const _this = static_cast<ViewportDropPositionRequest*>(&to_msg);
-  auto& from = static_cast<const ViewportDropPositionRequest&>(from_msg);
-  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.ViewportDropPositionRequest)
+void ViewportRayRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<ViewportRayRequest*>(&to_msg);
+  auto& from = static_cast<const ViewportRayRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.ViewportRayRequest)
   ABSL_DCHECK_NE(&from, _this);
   ::uint32_t cached_has_bits = 0;
   (void) cached_has_bits;
@@ -10797,404 +10686,26 @@ void ViewportDropPositionRequest::MergeImpl(::google::protobuf::MessageLite& to_
   _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
 }
 
-void ViewportDropPositionRequest::CopyFrom(const ViewportDropPositionRequest& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.ViewportDropPositionRequest)
+void ViewportRayRequest::CopyFrom(const ViewportRayRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.ViewportRayRequest)
   if (&from == this) return;
   Clear();
   MergeFrom(from);
 }
 
 
-void ViewportDropPositionRequest::InternalSwap(ViewportDropPositionRequest* PROTOBUF_RESTRICT other) {
+void ViewportRayRequest::InternalSwap(ViewportRayRequest* PROTOBUF_RESTRICT other) {
   using std::swap;
   _internal_metadata_.InternalSwap(&other->_internal_metadata_);
   ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.normalized_y_)
-      + sizeof(ViewportDropPositionRequest::_impl_.normalized_y_)
-      - PROTOBUF_FIELD_OFFSET(ViewportDropPositionRequest, _impl_.viewport_id_)>(
+      PROTOBUF_FIELD_OFFSET(ViewportRayRequest, _impl_.normalized_y_)
+      + sizeof(ViewportRayRequest::_impl_.normalized_y_)
+      - PROTOBUF_FIELD_OFFSET(ViewportRayRequest, _impl_.viewport_id_)>(
           reinterpret_cast<char*>(&_impl_.viewport_id_),
           reinterpret_cast<char*>(&other->_impl_.viewport_id_));
 }
 
-::google::protobuf::Metadata ViewportDropPositionRequest::GetMetadata() const {
-  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
-}
-// ===================================================================
-
-class CreateModelGameObjectRequest::_Internal {
- public:
-  using HasBits =
-      decltype(std::declval<CreateModelGameObjectRequest>()._impl_._has_bits_);
-  static constexpr ::int32_t kHasBitsOffset =
-      8 * PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_._has_bits_);
-};
-
-CreateModelGameObjectRequest::CreateModelGameObjectRequest(::google::protobuf::Arena* arena)
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-    : ::google::protobuf::Message(arena, _class_data_.base()) {
-#else   // PROTOBUF_CUSTOM_VTABLE
-    : ::google::protobuf::Message(arena) {
-#endif  // PROTOBUF_CUSTOM_VTABLE
-  SharedCtor(arena);
-  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.CreateModelGameObjectRequest)
-}
-inline PROTOBUF_NDEBUG_INLINE CreateModelGameObjectRequest::Impl_::Impl_(
-    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
-    const Impl_& from, const ::sailor::editor::v1::CreateModelGameObjectRequest& from_msg)
-      : _has_bits_{from._has_bits_},
-        _cached_size_{0},
-        model_file_id_(arena, from.model_file_id_),
-        name_(arena, from.name_),
-        parent_instance_id_(arena, from.parent_instance_id_) {}
-
-CreateModelGameObjectRequest::CreateModelGameObjectRequest(
-    ::google::protobuf::Arena* arena,
-    const CreateModelGameObjectRequest& from)
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-    : ::google::protobuf::Message(arena, _class_data_.base()) {
-#else   // PROTOBUF_CUSTOM_VTABLE
-    : ::google::protobuf::Message(arena) {
-#endif  // PROTOBUF_CUSTOM_VTABLE
-  CreateModelGameObjectRequest* const _this = this;
-  (void)_this;
-  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
-      from._internal_metadata_);
-  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
-  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
-  _impl_.world_position_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4>(
-                              arena, *from._impl_.world_position_)
-                        : nullptr;
-  _impl_.apply_world_position_ = from._impl_.apply_world_position_;
-
-  // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.CreateModelGameObjectRequest)
-}
-inline PROTOBUF_NDEBUG_INLINE CreateModelGameObjectRequest::Impl_::Impl_(
-    ::google::protobuf::internal::InternalVisibility visibility,
-    ::google::protobuf::Arena* arena)
-      : _cached_size_{0},
-        model_file_id_(arena),
-        name_(arena),
-        parent_instance_id_(arena) {}
-
-inline void CreateModelGameObjectRequest::SharedCtor(::_pb::Arena* arena) {
-  new (&_impl_) Impl_(internal_visibility(), arena);
-  ::memset(reinterpret_cast<char *>(&_impl_) +
-               offsetof(Impl_, world_position_),
-           0,
-           offsetof(Impl_, apply_world_position_) -
-               offsetof(Impl_, world_position_) +
-               sizeof(Impl_::apply_world_position_));
-}
-CreateModelGameObjectRequest::~CreateModelGameObjectRequest() {
-  // @@protoc_insertion_point(destructor:sailor.editor.v1.CreateModelGameObjectRequest)
-  SharedDtor(*this);
-}
-inline void CreateModelGameObjectRequest::SharedDtor(MessageLite& self) {
-  CreateModelGameObjectRequest& this_ = static_cast<CreateModelGameObjectRequest&>(self);
-  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
-  ABSL_DCHECK(this_.GetArena() == nullptr);
-  this_._impl_.model_file_id_.Destroy();
-  this_._impl_.name_.Destroy();
-  this_._impl_.parent_instance_id_.Destroy();
-  delete this_._impl_.world_position_;
-  this_._impl_.~Impl_();
-}
-
-inline void* CreateModelGameObjectRequest::PlacementNew_(const void*, void* mem,
-                                        ::google::protobuf::Arena* arena) {
-  return ::new (mem) CreateModelGameObjectRequest(arena);
-}
-constexpr auto CreateModelGameObjectRequest::InternalNewImpl_() {
-  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(CreateModelGameObjectRequest),
-                                            alignof(CreateModelGameObjectRequest));
-}
-PROTOBUF_CONSTINIT
-PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::google::protobuf::internal::ClassDataFull CreateModelGameObjectRequest::_class_data_ = {
-    ::google::protobuf::internal::ClassData{
-        &_CreateModelGameObjectRequest_default_instance_._instance,
-        &_table_.header,
-        nullptr,  // OnDemandRegisterArenaDtor
-        nullptr,  // IsInitialized
-        &CreateModelGameObjectRequest::MergeImpl,
-        ::google::protobuf::Message::GetNewImpl<CreateModelGameObjectRequest>(),
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-        &CreateModelGameObjectRequest::SharedDtor,
-        ::google::protobuf::Message::GetClearImpl<CreateModelGameObjectRequest>(), &CreateModelGameObjectRequest::ByteSizeLong,
-            &CreateModelGameObjectRequest::_InternalSerialize,
-#endif  // PROTOBUF_CUSTOM_VTABLE
-        PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_._cached_size_),
-        false,
-    },
-    &CreateModelGameObjectRequest::kDescriptorMethods,
-    &descriptor_table_editor_5fengine_2eproto,
-    nullptr,  // tracker
-};
-const ::google::protobuf::internal::ClassData* CreateModelGameObjectRequest::GetClassData() const {
-  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
-  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
-  return _class_data_.base();
-}
-PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<3, 5, 1, 89, 2> CreateModelGameObjectRequest::_table_ = {
-  {
-    PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_._has_bits_),
-    0, // no _extensions_
-    5, 56,  // max_field_number, fast_idx_mask
-    offsetof(decltype(_table_), field_lookup_table),
-    4294967264,  // skipmap
-    offsetof(decltype(_table_), field_entries),
-    5,  // num_field_entries
-    1,  // num_aux_entries
-    offsetof(decltype(_table_), aux_entries),
-    _class_data_.base(),
-    nullptr,  // post_loop_handler
-    ::_pbi::TcParser::GenericFallback,  // fallback
-    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
-    ::_pbi::TcParser::GetTable<::sailor::editor::v1::CreateModelGameObjectRequest>(),  // to_prefetch
-    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
-  }, {{
-    {::_pbi::TcParser::MiniParse, {}},
-    // string model_file_id = 1;
-    {::_pbi::TcParser::FastUS1,
-     {10, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.model_file_id_)}},
-    // string name = 2;
-    {::_pbi::TcParser::FastUS1,
-     {18, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.name_)}},
-    // string parent_instance_id = 3;
-    {::_pbi::TcParser::FastUS1,
-     {26, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.parent_instance_id_)}},
-    // bool apply_world_position = 4;
-    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(CreateModelGameObjectRequest, _impl_.apply_world_position_), 63>(),
-     {32, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.apply_world_position_)}},
-    // .sailor.editor.v1.Vector4 world_position = 5;
-    {::_pbi::TcParser::FastMtS1,
-     {42, 0, 0, PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.world_position_)}},
-    {::_pbi::TcParser::MiniParse, {}},
-    {::_pbi::TcParser::MiniParse, {}},
-  }}, {{
-    65535, 65535
-  }}, {{
-    // string model_file_id = 1;
-    {PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.model_file_id_), -1, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
-    // string name = 2;
-    {PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.name_), -1, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
-    // string parent_instance_id = 3;
-    {PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.parent_instance_id_), -1, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
-    // bool apply_world_position = 4;
-    {PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.apply_world_position_), -1, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
-    // .sailor.editor.v1.Vector4 world_position = 5;
-    {PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.world_position_), _Internal::kHasBitsOffset + 0, 0,
-    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
-  }}, {{
-    {::_pbi::TcParser::GetTable<::sailor::editor::v1::Vector4>()},
-  }}, {{
-    "\55\15\4\22\0\0\0\0"
-    "sailor.editor.v1.CreateModelGameObjectRequest"
-    "model_file_id"
-    "name"
-    "parent_instance_id"
-  }},
-};
-
-PROTOBUF_NOINLINE void CreateModelGameObjectRequest::Clear() {
-// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.CreateModelGameObjectRequest)
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  ::uint32_t cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  _impl_.model_file_id_.ClearToEmpty();
-  _impl_.name_.ClearToEmpty();
-  _impl_.parent_instance_id_.ClearToEmpty();
-  cached_has_bits = _impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000001u) {
-    ABSL_DCHECK(_impl_.world_position_ != nullptr);
-    _impl_.world_position_->Clear();
-  }
-  _impl_.apply_world_position_ = false;
-  _impl_._has_bits_.Clear();
-  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
-}
-
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-        ::uint8_t* CreateModelGameObjectRequest::_InternalSerialize(
-            const MessageLite& base, ::uint8_t* target,
-            ::google::protobuf::io::EpsCopyOutputStream* stream) {
-          const CreateModelGameObjectRequest& this_ = static_cast<const CreateModelGameObjectRequest&>(base);
-#else   // PROTOBUF_CUSTOM_VTABLE
-        ::uint8_t* CreateModelGameObjectRequest::_InternalSerialize(
-            ::uint8_t* target,
-            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
-          const CreateModelGameObjectRequest& this_ = *this;
-#endif  // PROTOBUF_CUSTOM_VTABLE
-          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.CreateModelGameObjectRequest)
-          ::uint32_t cached_has_bits = 0;
-          (void)cached_has_bits;
-
-          // string model_file_id = 1;
-          if (!this_._internal_model_file_id().empty()) {
-            const std::string& _s = this_._internal_model_file_id();
-            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.CreateModelGameObjectRequest.model_file_id");
-            target = stream->WriteStringMaybeAliased(1, _s, target);
-          }
-
-          // string name = 2;
-          if (!this_._internal_name().empty()) {
-            const std::string& _s = this_._internal_name();
-            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.CreateModelGameObjectRequest.name");
-            target = stream->WriteStringMaybeAliased(2, _s, target);
-          }
-
-          // string parent_instance_id = 3;
-          if (!this_._internal_parent_instance_id().empty()) {
-            const std::string& _s = this_._internal_parent_instance_id();
-            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
-                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id");
-            target = stream->WriteStringMaybeAliased(3, _s, target);
-          }
-
-          // bool apply_world_position = 4;
-          if (this_._internal_apply_world_position() != 0) {
-            target = stream->EnsureSpace(target);
-            target = ::_pbi::WireFormatLite::WriteBoolToArray(
-                4, this_._internal_apply_world_position(), target);
-          }
-
-          cached_has_bits = this_._impl_._has_bits_[0];
-          // .sailor.editor.v1.Vector4 world_position = 5;
-          if (cached_has_bits & 0x00000001u) {
-            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
-                5, *this_._impl_.world_position_, this_._impl_.world_position_->GetCachedSize(), target,
-                stream);
-          }
-
-          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
-            target =
-                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
-                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
-          }
-          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.CreateModelGameObjectRequest)
-          return target;
-        }
-
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-        ::size_t CreateModelGameObjectRequest::ByteSizeLong(const MessageLite& base) {
-          const CreateModelGameObjectRequest& this_ = static_cast<const CreateModelGameObjectRequest&>(base);
-#else   // PROTOBUF_CUSTOM_VTABLE
-        ::size_t CreateModelGameObjectRequest::ByteSizeLong() const {
-          const CreateModelGameObjectRequest& this_ = *this;
-#endif  // PROTOBUF_CUSTOM_VTABLE
-          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.CreateModelGameObjectRequest)
-          ::size_t total_size = 0;
-
-          ::uint32_t cached_has_bits = 0;
-          // Prevent compiler warnings about cached_has_bits being unused
-          (void)cached_has_bits;
-
-          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
-           {
-            // string model_file_id = 1;
-            if (!this_._internal_model_file_id().empty()) {
-              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
-                                              this_._internal_model_file_id());
-            }
-            // string name = 2;
-            if (!this_._internal_name().empty()) {
-              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
-                                              this_._internal_name());
-            }
-            // string parent_instance_id = 3;
-            if (!this_._internal_parent_instance_id().empty()) {
-              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
-                                              this_._internal_parent_instance_id());
-            }
-          }
-           {
-            // .sailor.editor.v1.Vector4 world_position = 5;
-            cached_has_bits = this_._impl_._has_bits_[0];
-            if (cached_has_bits & 0x00000001u) {
-              total_size += 1 +
-                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.world_position_);
-            }
-          }
-           {
-            // bool apply_world_position = 4;
-            if (this_._internal_apply_world_position() != 0) {
-              total_size += 2;
-            }
-          }
-          return this_.MaybeComputeUnknownFieldsSize(total_size,
-                                                     &this_._impl_._cached_size_);
-        }
-
-void CreateModelGameObjectRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
-  auto* const _this = static_cast<CreateModelGameObjectRequest*>(&to_msg);
-  auto& from = static_cast<const CreateModelGameObjectRequest&>(from_msg);
-  ::google::protobuf::Arena* arena = _this->GetArena();
-  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.CreateModelGameObjectRequest)
-  ABSL_DCHECK_NE(&from, _this);
-  ::uint32_t cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if (!from._internal_model_file_id().empty()) {
-    _this->_internal_set_model_file_id(from._internal_model_file_id());
-  }
-  if (!from._internal_name().empty()) {
-    _this->_internal_set_name(from._internal_name());
-  }
-  if (!from._internal_parent_instance_id().empty()) {
-    _this->_internal_set_parent_instance_id(from._internal_parent_instance_id());
-  }
-  cached_has_bits = from._impl_._has_bits_[0];
-  if (cached_has_bits & 0x00000001u) {
-    ABSL_DCHECK(from._impl_.world_position_ != nullptr);
-    if (_this->_impl_.world_position_ == nullptr) {
-      _this->_impl_.world_position_ =
-          ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4>(arena, *from._impl_.world_position_);
-    } else {
-      _this->_impl_.world_position_->MergeFrom(*from._impl_.world_position_);
-    }
-  }
-  if (from._internal_apply_world_position() != 0) {
-    _this->_impl_.apply_world_position_ = from._impl_.apply_world_position_;
-  }
-  _this->_impl_._has_bits_[0] |= cached_has_bits;
-  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
-}
-
-void CreateModelGameObjectRequest::CopyFrom(const CreateModelGameObjectRequest& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.CreateModelGameObjectRequest)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-
-void CreateModelGameObjectRequest::InternalSwap(CreateModelGameObjectRequest* PROTOBUF_RESTRICT other) {
-  using std::swap;
-  auto* arena = GetArena();
-  ABSL_DCHECK_EQ(arena, other->GetArena());
-  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
-  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.model_file_id_, &other->_impl_.model_file_id_, arena);
-  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.name_, &other->_impl_.name_, arena);
-  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.parent_instance_id_, &other->_impl_.parent_instance_id_, arena);
-  ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.apply_world_position_)
-      + sizeof(CreateModelGameObjectRequest::_impl_.apply_world_position_)
-      - PROTOBUF_FIELD_OFFSET(CreateModelGameObjectRequest, _impl_.world_position_)>(
-          reinterpret_cast<char*>(&_impl_.world_position_),
-          reinterpret_cast<char*>(&other->_impl_.world_position_));
-}
-
-::google::protobuf::Metadata CreateModelGameObjectRequest::GetMetadata() const {
+::google::protobuf::Metadata ViewportRayRequest::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/Runtime/Protocol/Generated/editor_engine.pb.h
+++ b/Runtime/Protocol/Generated/editor_engine.pb.h
@@ -71,9 +71,6 @@ extern CountRequestDefaultTypeInternal _CountRequest_default_instance_;
 class CreateGameObjectRequest;
 struct CreateGameObjectRequestDefaultTypeInternal;
 extern CreateGameObjectRequestDefaultTypeInternal _CreateGameObjectRequest_default_instance_;
-class CreateModelGameObjectRequest;
-struct CreateModelGameObjectRequestDefaultTypeInternal;
-extern CreateModelGameObjectRequestDefaultTypeInternal _CreateModelGameObjectRequest_default_instance_;
 class Empty;
 struct EmptyDefaultTypeInternal;
 extern EmptyDefaultTypeInternal _Empty_default_instance_;
@@ -161,9 +158,6 @@ extern Vector4ResultDefaultTypeInternal _Vector4Result_default_instance_;
 class ViewportAssetDropEvent;
 struct ViewportAssetDropEventDefaultTypeInternal;
 extern ViewportAssetDropEventDefaultTypeInternal _ViewportAssetDropEvent_default_instance_;
-class ViewportDropPositionRequest;
-struct ViewportDropPositionRequestDefaultTypeInternal;
-extern ViewportDropPositionRequestDefaultTypeInternal _ViewportDropPositionRequest_default_instance_;
 class ViewportEvent;
 struct ViewportEventDefaultTypeInternal;
 extern ViewportEventDefaultTypeInternal _ViewportEvent_default_instance_;
@@ -176,6 +170,9 @@ extern ViewportIdRequestDefaultTypeInternal _ViewportIdRequest_default_instance_
 class ViewportObjectRequest;
 struct ViewportObjectRequestDefaultTypeInternal;
 extern ViewportObjectRequestDefaultTypeInternal _ViewportObjectRequest_default_instance_;
+class ViewportRayRequest;
+struct ViewportRayRequestDefaultTypeInternal;
+extern ViewportRayRequestDefaultTypeInternal _ViewportRayRequest_default_instance_;
 class ViewportRectRequest;
 struct ViewportRectRequestDefaultTypeInternal;
 extern ViewportRectRequestDefaultTypeInternal _ViewportRectRequest_default_instance_;
@@ -340,7 +337,7 @@ class ViewportToolStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateResult*>(
         &_ViewportToolStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 38;
+  static constexpr int kIndexInFileMessages = 37;
   friend void swap(ViewportToolStateResult& a, ViewportToolStateResult& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateResult* other) {
     if (other == this) return;
@@ -542,7 +539,7 @@ class ViewportToolStateRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateRequest*>(
         &_ViewportToolStateRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 25;
+  static constexpr int kIndexInFileMessages = 24;
   friend void swap(ViewportToolStateRequest& a, ViewportToolStateRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateRequest* other) {
     if (other == this) return;
@@ -756,7 +753,7 @@ class ViewportToolShortcutEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolShortcutEvent*>(
         &_ViewportToolShortcutEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 43;
+  static constexpr int kIndexInFileMessages = 42;
   friend void swap(ViewportToolShortcutEvent& a, ViewportToolShortcutEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportToolShortcutEvent* other) {
     if (other == this) return;
@@ -946,7 +943,7 @@ class ViewportSelectionEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportSelectionEvent*>(
         &_ViewportSelectionEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 40;
+  static constexpr int kIndexInFileMessages = 39;
   friend void swap(ViewportSelectionEvent& a, ViewportSelectionEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportSelectionEvent* other) {
     if (other == this) return;
@@ -1309,6 +1306,220 @@ class ViewportRectRequest final : public ::google::protobuf::Message
 };
 // -------------------------------------------------------------------
 
+class ViewportRayRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportRayRequest) */ {
+ public:
+  inline ViewportRayRequest() : ViewportRayRequest(nullptr) {}
+  ~ViewportRayRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(ViewportRayRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(ViewportRayRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR ViewportRayRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline ViewportRayRequest(const ViewportRayRequest& from) : ViewportRayRequest(nullptr, from) {}
+  inline ViewportRayRequest(ViewportRayRequest&& from) noexcept
+      : ViewportRayRequest(nullptr, std::move(from)) {}
+  inline ViewportRayRequest& operator=(const ViewportRayRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline ViewportRayRequest& operator=(ViewportRayRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const ViewportRayRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const ViewportRayRequest* internal_default_instance() {
+    return reinterpret_cast<const ViewportRayRequest*>(
+        &_ViewportRayRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 20;
+  friend void swap(ViewportRayRequest& a, ViewportRayRequest& b) { a.Swap(&b); }
+  inline void Swap(ViewportRayRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(ViewportRayRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  ViewportRayRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<ViewportRayRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const ViewportRayRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const ViewportRayRequest& from) { ViewportRayRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(ViewportRayRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.ViewportRayRequest"; }
+
+ protected:
+  explicit ViewportRayRequest(::google::protobuf::Arena* arena);
+  ViewportRayRequest(::google::protobuf::Arena* arena, const ViewportRayRequest& from);
+  ViewportRayRequest(::google::protobuf::Arena* arena, ViewportRayRequest&& from) noexcept
+      : ViewportRayRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kViewportIdFieldNumber = 1,
+    kNormalizedXFieldNumber = 2,
+    kNormalizedYFieldNumber = 3,
+  };
+  // uint64 viewport_id = 1;
+  void clear_viewport_id() ;
+  ::uint64_t viewport_id() const;
+  void set_viewport_id(::uint64_t value);
+
+  private:
+  ::uint64_t _internal_viewport_id() const;
+  void _internal_set_viewport_id(::uint64_t value);
+
+  public:
+  // float normalized_x = 2;
+  void clear_normalized_x() ;
+  float normalized_x() const;
+  void set_normalized_x(float value);
+
+  private:
+  float _internal_normalized_x() const;
+  void _internal_set_normalized_x(float value);
+
+  public:
+  // float normalized_y = 3;
+  void clear_normalized_y() ;
+  float normalized_y() const;
+  void set_normalized_y(float value);
+
+  private:
+  float _internal_normalized_y() const;
+  void _internal_set_normalized_y(float value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.ViewportRayRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      2, 3, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const ViewportRayRequest& from_msg);
+    ::uint64_t viewport_id_;
+    float normalized_x_;
+    float normalized_y_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ViewportObjectRequest final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportObjectRequest) */ {
  public:
@@ -1368,7 +1579,7 @@ class ViewportObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportObjectRequest*>(
         &_ViewportObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 23;
+  static constexpr int kIndexInFileMessages = 22;
   friend void swap(ViewportObjectRequest& a, ViewportObjectRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportObjectRequest* other) {
     if (other == this) return;
@@ -1707,220 +1918,6 @@ class ViewportIdRequest final : public ::google::protobuf::Message
 };
 // -------------------------------------------------------------------
 
-class ViewportDropPositionRequest final : public ::google::protobuf::Message
-/* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportDropPositionRequest) */ {
- public:
-  inline ViewportDropPositionRequest() : ViewportDropPositionRequest(nullptr) {}
-  ~ViewportDropPositionRequest() PROTOBUF_FINAL;
-
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-  void operator delete(ViewportDropPositionRequest* msg, std::destroying_delete_t) {
-    SharedDtor(*msg);
-    ::google::protobuf::internal::SizedDelete(msg, sizeof(ViewportDropPositionRequest));
-  }
-#endif
-
-  template <typename = void>
-  explicit PROTOBUF_CONSTEXPR ViewportDropPositionRequest(
-      ::google::protobuf::internal::ConstantInitialized);
-
-  inline ViewportDropPositionRequest(const ViewportDropPositionRequest& from) : ViewportDropPositionRequest(nullptr, from) {}
-  inline ViewportDropPositionRequest(ViewportDropPositionRequest&& from) noexcept
-      : ViewportDropPositionRequest(nullptr, std::move(from)) {}
-  inline ViewportDropPositionRequest& operator=(const ViewportDropPositionRequest& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  inline ViewportDropPositionRequest& operator=(ViewportDropPositionRequest&& from) noexcept {
-    if (this == &from) return *this;
-    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
-      InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-
-  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
-  }
-  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
-  }
-
-  static const ::google::protobuf::Descriptor* descriptor() {
-    return GetDescriptor();
-  }
-  static const ::google::protobuf::Descriptor* GetDescriptor() {
-    return default_instance().GetMetadata().descriptor;
-  }
-  static const ::google::protobuf::Reflection* GetReflection() {
-    return default_instance().GetMetadata().reflection;
-  }
-  static const ViewportDropPositionRequest& default_instance() {
-    return *internal_default_instance();
-  }
-  static inline const ViewportDropPositionRequest* internal_default_instance() {
-    return reinterpret_cast<const ViewportDropPositionRequest*>(
-        &_ViewportDropPositionRequest_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages = 20;
-  friend void swap(ViewportDropPositionRequest& a, ViewportDropPositionRequest& b) { a.Swap(&b); }
-  inline void Swap(ViewportDropPositionRequest* other) {
-    if (other == this) return;
-    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
-      InternalSwap(other);
-    } else {
-      ::google::protobuf::internal::GenericSwap(this, other);
-    }
-  }
-  void UnsafeArenaSwap(ViewportDropPositionRequest* other) {
-    if (other == this) return;
-    ABSL_DCHECK(GetArena() == other->GetArena());
-    InternalSwap(other);
-  }
-
-  // implements Message ----------------------------------------------
-
-  ViewportDropPositionRequest* New(::google::protobuf::Arena* arena = nullptr) const {
-    return ::google::protobuf::Message::DefaultConstruct<ViewportDropPositionRequest>(arena);
-  }
-  using ::google::protobuf::Message::CopyFrom;
-  void CopyFrom(const ViewportDropPositionRequest& from);
-  using ::google::protobuf::Message::MergeFrom;
-  void MergeFrom(const ViewportDropPositionRequest& from) { ViewportDropPositionRequest::MergeImpl(*this, from); }
-
-  private:
-  static void MergeImpl(
-      ::google::protobuf::MessageLite& to_msg,
-      const ::google::protobuf::MessageLite& from_msg);
-
-  public:
-  bool IsInitialized() const {
-    return true;
-  }
-  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
-  #if defined(PROTOBUF_CUSTOM_VTABLE)
-  private:
-  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
-  static ::uint8_t* _InternalSerialize(
-      const MessageLite& msg, ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream);
-
-  public:
-  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
-    return _InternalSerialize(*this, target, stream);
-  }
-  #else   // PROTOBUF_CUSTOM_VTABLE
-  ::size_t ByteSizeLong() const final;
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
-  #endif  // PROTOBUF_CUSTOM_VTABLE
-  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
-
-  private:
-  void SharedCtor(::google::protobuf::Arena* arena);
-  static void SharedDtor(MessageLite& self);
-  void InternalSwap(ViewportDropPositionRequest* other);
- private:
-  template <typename T>
-  friend ::absl::string_view(
-      ::google::protobuf::internal::GetAnyMessageName)();
-  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.ViewportDropPositionRequest"; }
-
- protected:
-  explicit ViewportDropPositionRequest(::google::protobuf::Arena* arena);
-  ViewportDropPositionRequest(::google::protobuf::Arena* arena, const ViewportDropPositionRequest& from);
-  ViewportDropPositionRequest(::google::protobuf::Arena* arena, ViewportDropPositionRequest&& from) noexcept
-      : ViewportDropPositionRequest(arena) {
-    *this = ::std::move(from);
-  }
-  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
-  static void* PlacementNew_(const void*, void* mem,
-                             ::google::protobuf::Arena* arena);
-  static constexpr auto InternalNewImpl_();
-  static const ::google::protobuf::internal::ClassDataFull _class_data_;
-
- public:
-  ::google::protobuf::Metadata GetMetadata() const;
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-  enum : int {
-    kViewportIdFieldNumber = 1,
-    kNormalizedXFieldNumber = 2,
-    kNormalizedYFieldNumber = 3,
-  };
-  // uint64 viewport_id = 1;
-  void clear_viewport_id() ;
-  ::uint64_t viewport_id() const;
-  void set_viewport_id(::uint64_t value);
-
-  private:
-  ::uint64_t _internal_viewport_id() const;
-  void _internal_set_viewport_id(::uint64_t value);
-
-  public:
-  // float normalized_x = 2;
-  void clear_normalized_x() ;
-  float normalized_x() const;
-  void set_normalized_x(float value);
-
-  private:
-  float _internal_normalized_x() const;
-  void _internal_set_normalized_x(float value);
-
-  public:
-  // float normalized_y = 3;
-  void clear_normalized_y() ;
-  float normalized_y() const;
-  void set_normalized_y(float value);
-
-  private:
-  float _internal_normalized_y() const;
-  void _internal_set_normalized_y(float value);
-
-  public:
-  // @@protoc_insertion_point(class_scope:sailor.editor.v1.ViewportDropPositionRequest)
- private:
-  class _Internal;
-  friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<
-      2, 3, 0,
-      0, 2>
-      _table_;
-
-  friend class ::google::protobuf::MessageLite;
-  friend class ::google::protobuf::Arena;
-  template <typename T>
-  friend class ::google::protobuf::Arena::InternalHelper;
-  using InternalArenaConstructable_ = void;
-  using DestructorSkippable_ = void;
-  struct Impl_ {
-    inline explicit constexpr Impl_(
-        ::google::protobuf::internal::ConstantInitialized) noexcept;
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena);
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena, const Impl_& from,
-                          const ViewportDropPositionRequest& from_msg);
-    ::uint64_t viewport_id_;
-    float normalized_x_;
-    float normalized_y_;
-    ::google::protobuf::internal::CachedSize _cached_size_;
-    PROTOBUF_TSAN_DECLARE_MEMBER
-  };
-  union { Impl_ _impl_; };
-  friend struct ::TableStruct_editor_5fengine_2eproto;
-};
-// -------------------------------------------------------------------
-
 class ViewportAssetDropEvent final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportAssetDropEvent) */ {
  public:
@@ -1980,7 +1977,7 @@ class ViewportAssetDropEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportAssetDropEvent*>(
         &_ViewportAssetDropEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 42;
+  static constexpr int kIndexInFileMessages = 41;
   friend void swap(ViewportAssetDropEvent& a, ViewportAssetDropEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportAssetDropEvent* other) {
     if (other == this) return;
@@ -2200,7 +2197,7 @@ class Vector4 final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4*>(
         &_Vector4_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 39;
+  static constexpr int kIndexInFileMessages = 38;
   friend void swap(Vector4& a, Vector4& b) { a.Swap(&b); }
   inline void Swap(Vector4* other) {
     if (other == this) return;
@@ -2640,7 +2637,7 @@ class UInt64Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt64Result*>(
         &_UInt64Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 32;
+  static constexpr int kIndexInFileMessages = 31;
   friend void swap(UInt64Result& a, UInt64Result& b) { a.Swap(&b); }
   inline void Swap(UInt64Result* other) {
     if (other == this) return;
@@ -2830,7 +2827,7 @@ class UInt32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt32Result*>(
         &_UInt32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 31;
+  static constexpr int kIndexInFileMessages = 30;
   friend void swap(UInt32Result& a, UInt32Result& b) { a.Swap(&b); }
   inline void Swap(UInt32Result* other) {
     if (other == this) return;
@@ -3020,7 +3017,7 @@ class StringResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringResult*>(
         &_StringResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 33;
+  static constexpr int kIndexInFileMessages = 32;
   friend void swap(StringResult& a, StringResult& b) { a.Swap(&b); }
   inline void Swap(StringResult* other) {
     if (other == this) return;
@@ -3228,7 +3225,7 @@ class StringListResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringListResult*>(
         &_StringListResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 34;
+  static constexpr int kIndexInFileMessages = 33;
   friend void swap(StringListResult& a, StringListResult& b) { a.Swap(&b); }
   inline void Swap(StringListResult* other) {
     if (other == this) return;
@@ -3632,7 +3629,7 @@ class ShowMainWindowRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ShowMainWindowRequest*>(
         &_ShowMainWindowRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 27;
+  static constexpr int kIndexInFileMessages = 26;
   friend void swap(ShowMainWindowRequest& a, ShowMainWindowRequest& b) { a.Swap(&b); }
   inline void Swap(ShowMainWindowRequest* other) {
     if (other == this) return;
@@ -3822,7 +3819,7 @@ class SelectionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const SelectionRequest*>(
         &_SelectionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 26;
+  static constexpr int kIndexInFileMessages = 25;
   friend void swap(SelectionRequest& a, SelectionRequest& b) { a.Swap(&b); }
   inline void Swap(SelectionRequest* other) {
     if (other == this) return;
@@ -4250,7 +4247,7 @@ class RenderPathTracedImageRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RenderPathTracedImageRequest*>(
         &_RenderPathTracedImageRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 28;
+  static constexpr int kIndexInFileMessages = 27;
   friend void swap(RenderPathTracedImageRequest& a, RenderPathTracedImageRequest& b) { a.Swap(&b); }
   inline void Swap(RenderPathTracedImageRequest* other) {
     if (other == this) return;
@@ -5298,7 +5295,7 @@ class PrefabLinkRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const PrefabLinkRequest*>(
         &_PrefabLinkRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 24;
+  static constexpr int kIndexInFileMessages = 23;
   friend void swap(PrefabLinkRequest& a, PrefabLinkRequest& b) { a.Swap(&b); }
   inline void Swap(PrefabLinkRequest* other) {
     if (other == this) return;
@@ -5720,7 +5717,7 @@ class Int32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Int32Result*>(
         &_Int32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 30;
+  static constexpr int kIndexInFileMessages = 29;
   friend void swap(Int32Result& a, Int32Result& b) { a.Swap(&b); }
   inline void Swap(Int32Result* other) {
     if (other == this) return;
@@ -6350,7 +6347,7 @@ class InstanceIdResult final : public ::google::protobuf::Message
     return reinterpret_cast<const InstanceIdResult*>(
         &_InstanceIdResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 36;
+  static constexpr int kIndexInFileMessages = 35;
   friend void swap(InstanceIdResult& a, InstanceIdResult& b) { a.Swap(&b); }
   inline void Swap(InstanceIdResult* other) {
     if (other == this) return;
@@ -7701,7 +7698,7 @@ class BoolResult final : public ::google::protobuf::Message
     return reinterpret_cast<const BoolResult*>(
         &_BoolResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 29;
+  static constexpr int kIndexInFileMessages = 28;
   friend void swap(BoolResult& a, BoolResult& b) { a.Swap(&b); }
   inline void Swap(BoolResult* other) {
     if (other == this) return;
@@ -7891,7 +7888,7 @@ class AssetReloadStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const AssetReloadStateResult*>(
         &_AssetReloadStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 35;
+  static constexpr int kIndexInFileMessages = 34;
   friend void swap(AssetReloadStateResult& a, AssetReloadStateResult& b) { a.Swap(&b); }
   inline void Swap(AssetReloadStateResult* other) {
     if (other == this) return;
@@ -8349,7 +8346,7 @@ class ViewportTransformEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportTransformEvent*>(
         &_ViewportTransformEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 41;
+  static constexpr int kIndexInFileMessages = 40;
   friend void swap(ViewportTransformEvent& a, ViewportTransformEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportTransformEvent* other) {
     if (other == this) return;
@@ -8672,7 +8669,7 @@ class Vector4Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4Result*>(
         &_Vector4Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 37;
+  static constexpr int kIndexInFileMessages = 36;
   friend void swap(Vector4Result& a, Vector4Result& b) { a.Swap(&b); }
   inline void Swap(Vector4Result* other) {
     if (other == this) return;
@@ -8868,7 +8865,7 @@ class InstantiatePrefabInstanceRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabInstanceRequest*>(
         &_InstantiatePrefabInstanceRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 22;
+  static constexpr int kIndexInFileMessages = 21;
   friend void swap(InstantiatePrefabInstanceRequest& a, InstantiatePrefabInstanceRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabInstanceRequest* other) {
     if (other == this) return;
@@ -9053,268 +9050,6 @@ class InstantiatePrefabInstanceRequest final : public ::google::protobuf::Messag
 };
 // -------------------------------------------------------------------
 
-class CreateModelGameObjectRequest final : public ::google::protobuf::Message
-/* @@protoc_insertion_point(class_definition:sailor.editor.v1.CreateModelGameObjectRequest) */ {
- public:
-  inline CreateModelGameObjectRequest() : CreateModelGameObjectRequest(nullptr) {}
-  ~CreateModelGameObjectRequest() PROTOBUF_FINAL;
-
-#if defined(PROTOBUF_CUSTOM_VTABLE)
-  void operator delete(CreateModelGameObjectRequest* msg, std::destroying_delete_t) {
-    SharedDtor(*msg);
-    ::google::protobuf::internal::SizedDelete(msg, sizeof(CreateModelGameObjectRequest));
-  }
-#endif
-
-  template <typename = void>
-  explicit PROTOBUF_CONSTEXPR CreateModelGameObjectRequest(
-      ::google::protobuf::internal::ConstantInitialized);
-
-  inline CreateModelGameObjectRequest(const CreateModelGameObjectRequest& from) : CreateModelGameObjectRequest(nullptr, from) {}
-  inline CreateModelGameObjectRequest(CreateModelGameObjectRequest&& from) noexcept
-      : CreateModelGameObjectRequest(nullptr, std::move(from)) {}
-  inline CreateModelGameObjectRequest& operator=(const CreateModelGameObjectRequest& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  inline CreateModelGameObjectRequest& operator=(CreateModelGameObjectRequest&& from) noexcept {
-    if (this == &from) return *this;
-    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
-      InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-
-  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
-  }
-  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
-  }
-
-  static const ::google::protobuf::Descriptor* descriptor() {
-    return GetDescriptor();
-  }
-  static const ::google::protobuf::Descriptor* GetDescriptor() {
-    return default_instance().GetMetadata().descriptor;
-  }
-  static const ::google::protobuf::Reflection* GetReflection() {
-    return default_instance().GetMetadata().reflection;
-  }
-  static const CreateModelGameObjectRequest& default_instance() {
-    return *internal_default_instance();
-  }
-  static inline const CreateModelGameObjectRequest* internal_default_instance() {
-    return reinterpret_cast<const CreateModelGameObjectRequest*>(
-        &_CreateModelGameObjectRequest_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages = 21;
-  friend void swap(CreateModelGameObjectRequest& a, CreateModelGameObjectRequest& b) { a.Swap(&b); }
-  inline void Swap(CreateModelGameObjectRequest* other) {
-    if (other == this) return;
-    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
-      InternalSwap(other);
-    } else {
-      ::google::protobuf::internal::GenericSwap(this, other);
-    }
-  }
-  void UnsafeArenaSwap(CreateModelGameObjectRequest* other) {
-    if (other == this) return;
-    ABSL_DCHECK(GetArena() == other->GetArena());
-    InternalSwap(other);
-  }
-
-  // implements Message ----------------------------------------------
-
-  CreateModelGameObjectRequest* New(::google::protobuf::Arena* arena = nullptr) const {
-    return ::google::protobuf::Message::DefaultConstruct<CreateModelGameObjectRequest>(arena);
-  }
-  using ::google::protobuf::Message::CopyFrom;
-  void CopyFrom(const CreateModelGameObjectRequest& from);
-  using ::google::protobuf::Message::MergeFrom;
-  void MergeFrom(const CreateModelGameObjectRequest& from) { CreateModelGameObjectRequest::MergeImpl(*this, from); }
-
-  private:
-  static void MergeImpl(
-      ::google::protobuf::MessageLite& to_msg,
-      const ::google::protobuf::MessageLite& from_msg);
-
-  public:
-  bool IsInitialized() const {
-    return true;
-  }
-  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
-  #if defined(PROTOBUF_CUSTOM_VTABLE)
-  private:
-  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
-  static ::uint8_t* _InternalSerialize(
-      const MessageLite& msg, ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream);
-
-  public:
-  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
-    return _InternalSerialize(*this, target, stream);
-  }
-  #else   // PROTOBUF_CUSTOM_VTABLE
-  ::size_t ByteSizeLong() const final;
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target,
-      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
-  #endif  // PROTOBUF_CUSTOM_VTABLE
-  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
-
-  private:
-  void SharedCtor(::google::protobuf::Arena* arena);
-  static void SharedDtor(MessageLite& self);
-  void InternalSwap(CreateModelGameObjectRequest* other);
- private:
-  template <typename T>
-  friend ::absl::string_view(
-      ::google::protobuf::internal::GetAnyMessageName)();
-  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.CreateModelGameObjectRequest"; }
-
- protected:
-  explicit CreateModelGameObjectRequest(::google::protobuf::Arena* arena);
-  CreateModelGameObjectRequest(::google::protobuf::Arena* arena, const CreateModelGameObjectRequest& from);
-  CreateModelGameObjectRequest(::google::protobuf::Arena* arena, CreateModelGameObjectRequest&& from) noexcept
-      : CreateModelGameObjectRequest(arena) {
-    *this = ::std::move(from);
-  }
-  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
-  static void* PlacementNew_(const void*, void* mem,
-                             ::google::protobuf::Arena* arena);
-  static constexpr auto InternalNewImpl_();
-  static const ::google::protobuf::internal::ClassDataFull _class_data_;
-
- public:
-  ::google::protobuf::Metadata GetMetadata() const;
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-  enum : int {
-    kModelFileIdFieldNumber = 1,
-    kNameFieldNumber = 2,
-    kParentInstanceIdFieldNumber = 3,
-    kWorldPositionFieldNumber = 5,
-    kApplyWorldPositionFieldNumber = 4,
-  };
-  // string model_file_id = 1;
-  void clear_model_file_id() ;
-  const std::string& model_file_id() const;
-  template <typename Arg_ = const std::string&, typename... Args_>
-  void set_model_file_id(Arg_&& arg, Args_... args);
-  std::string* mutable_model_file_id();
-  PROTOBUF_NODISCARD std::string* release_model_file_id();
-  void set_allocated_model_file_id(std::string* value);
-
-  private:
-  const std::string& _internal_model_file_id() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_model_file_id(
-      const std::string& value);
-  std::string* _internal_mutable_model_file_id();
-
-  public:
-  // string name = 2;
-  void clear_name() ;
-  const std::string& name() const;
-  template <typename Arg_ = const std::string&, typename... Args_>
-  void set_name(Arg_&& arg, Args_... args);
-  std::string* mutable_name();
-  PROTOBUF_NODISCARD std::string* release_name();
-  void set_allocated_name(std::string* value);
-
-  private:
-  const std::string& _internal_name() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_name(
-      const std::string& value);
-  std::string* _internal_mutable_name();
-
-  public:
-  // string parent_instance_id = 3;
-  void clear_parent_instance_id() ;
-  const std::string& parent_instance_id() const;
-  template <typename Arg_ = const std::string&, typename... Args_>
-  void set_parent_instance_id(Arg_&& arg, Args_... args);
-  std::string* mutable_parent_instance_id();
-  PROTOBUF_NODISCARD std::string* release_parent_instance_id();
-  void set_allocated_parent_instance_id(std::string* value);
-
-  private:
-  const std::string& _internal_parent_instance_id() const;
-  inline PROTOBUF_ALWAYS_INLINE void _internal_set_parent_instance_id(
-      const std::string& value);
-  std::string* _internal_mutable_parent_instance_id();
-
-  public:
-  // .sailor.editor.v1.Vector4 world_position = 5;
-  bool has_world_position() const;
-  void clear_world_position() ;
-  const ::sailor::editor::v1::Vector4& world_position() const;
-  PROTOBUF_NODISCARD ::sailor::editor::v1::Vector4* release_world_position();
-  ::sailor::editor::v1::Vector4* mutable_world_position();
-  void set_allocated_world_position(::sailor::editor::v1::Vector4* value);
-  void unsafe_arena_set_allocated_world_position(::sailor::editor::v1::Vector4* value);
-  ::sailor::editor::v1::Vector4* unsafe_arena_release_world_position();
-
-  private:
-  const ::sailor::editor::v1::Vector4& _internal_world_position() const;
-  ::sailor::editor::v1::Vector4* _internal_mutable_world_position();
-
-  public:
-  // bool apply_world_position = 4;
-  void clear_apply_world_position() ;
-  bool apply_world_position() const;
-  void set_apply_world_position(bool value);
-
-  private:
-  bool _internal_apply_world_position() const;
-  void _internal_set_apply_world_position(bool value);
-
-  public:
-  // @@protoc_insertion_point(class_scope:sailor.editor.v1.CreateModelGameObjectRequest)
- private:
-  class _Internal;
-  friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<
-      3, 5, 1,
-      89, 2>
-      _table_;
-
-  friend class ::google::protobuf::MessageLite;
-  friend class ::google::protobuf::Arena;
-  template <typename T>
-  friend class ::google::protobuf::Arena::InternalHelper;
-  using InternalArenaConstructable_ = void;
-  using DestructorSkippable_ = void;
-  struct Impl_ {
-    inline explicit constexpr Impl_(
-        ::google::protobuf::internal::ConstantInitialized) noexcept;
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena);
-    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                          ::google::protobuf::Arena* arena, const Impl_& from,
-                          const CreateModelGameObjectRequest& from_msg);
-    ::google::protobuf::internal::HasBits<1> _has_bits_;
-    ::google::protobuf::internal::CachedSize _cached_size_;
-    ::google::protobuf::internal::ArenaStringPtr model_file_id_;
-    ::google::protobuf::internal::ArenaStringPtr name_;
-    ::google::protobuf::internal::ArenaStringPtr parent_instance_id_;
-    ::sailor::editor::v1::Vector4* world_position_;
-    bool apply_world_position_;
-    PROTOBUF_TSAN_DECLARE_MEMBER
-  };
-  union { Impl_ _impl_; };
-  friend struct ::TableStruct_editor_5fengine_2eproto;
-};
-// -------------------------------------------------------------------
-
 class ViewportEvent final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportEvent) */ {
  public:
@@ -9381,7 +9116,7 @@ class ViewportEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEvent*>(
         &_ViewportEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 44;
+  static constexpr int kIndexInFileMessages = 43;
   friend void swap(ViewportEvent& a, ViewportEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportEvent* other) {
     if (other == this) return;
@@ -9716,8 +9451,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kSerializeEngineTypes = 46,
     kIsEngineMainThreadReady = 47,
     kIsEngineRunning = 48,
-    kResolveViewportDropPosition = 49,
-    kCreateModelGameObject = 50,
+    kTraceViewportRay = 49,
     kInstantiatePrefabInstance = 51,
     kFocusEditorCamera = 52,
     kSetPrefabLink = 53,
@@ -9858,8 +9592,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kSerializeEngineTypesFieldNumber = 46,
     kIsEngineMainThreadReadyFieldNumber = 47,
     kIsEngineRunningFieldNumber = 48,
-    kResolveViewportDropPositionFieldNumber = 49,
-    kCreateModelGameObjectFieldNumber = 50,
+    kTraceViewportRayFieldNumber = 49,
     kInstantiatePrefabInstanceFieldNumber = 51,
     kFocusEditorCameraFieldNumber = 52,
     kSetPrefabLinkFieldNumber = 53,
@@ -10628,42 +10361,23 @@ class ProtocolRequest final : public ::google::protobuf::Message
   ::sailor::editor::v1::Empty* _internal_mutable_is_engine_running();
 
   public:
-  // .sailor.editor.v1.ViewportDropPositionRequest resolve_viewport_drop_position = 49;
-  bool has_resolve_viewport_drop_position() const;
+  // .sailor.editor.v1.ViewportRayRequest trace_viewport_ray = 49;
+  bool has_trace_viewport_ray() const;
   private:
-  bool _internal_has_resolve_viewport_drop_position() const;
+  bool _internal_has_trace_viewport_ray() const;
 
   public:
-  void clear_resolve_viewport_drop_position() ;
-  const ::sailor::editor::v1::ViewportDropPositionRequest& resolve_viewport_drop_position() const;
-  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportDropPositionRequest* release_resolve_viewport_drop_position();
-  ::sailor::editor::v1::ViewportDropPositionRequest* mutable_resolve_viewport_drop_position();
-  void set_allocated_resolve_viewport_drop_position(::sailor::editor::v1::ViewportDropPositionRequest* value);
-  void unsafe_arena_set_allocated_resolve_viewport_drop_position(::sailor::editor::v1::ViewportDropPositionRequest* value);
-  ::sailor::editor::v1::ViewportDropPositionRequest* unsafe_arena_release_resolve_viewport_drop_position();
+  void clear_trace_viewport_ray() ;
+  const ::sailor::editor::v1::ViewportRayRequest& trace_viewport_ray() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::ViewportRayRequest* release_trace_viewport_ray();
+  ::sailor::editor::v1::ViewportRayRequest* mutable_trace_viewport_ray();
+  void set_allocated_trace_viewport_ray(::sailor::editor::v1::ViewportRayRequest* value);
+  void unsafe_arena_set_allocated_trace_viewport_ray(::sailor::editor::v1::ViewportRayRequest* value);
+  ::sailor::editor::v1::ViewportRayRequest* unsafe_arena_release_trace_viewport_ray();
 
   private:
-  const ::sailor::editor::v1::ViewportDropPositionRequest& _internal_resolve_viewport_drop_position() const;
-  ::sailor::editor::v1::ViewportDropPositionRequest* _internal_mutable_resolve_viewport_drop_position();
-
-  public:
-  // .sailor.editor.v1.CreateModelGameObjectRequest create_model_game_object = 50;
-  bool has_create_model_game_object() const;
-  private:
-  bool _internal_has_create_model_game_object() const;
-
-  public:
-  void clear_create_model_game_object() ;
-  const ::sailor::editor::v1::CreateModelGameObjectRequest& create_model_game_object() const;
-  PROTOBUF_NODISCARD ::sailor::editor::v1::CreateModelGameObjectRequest* release_create_model_game_object();
-  ::sailor::editor::v1::CreateModelGameObjectRequest* mutable_create_model_game_object();
-  void set_allocated_create_model_game_object(::sailor::editor::v1::CreateModelGameObjectRequest* value);
-  void unsafe_arena_set_allocated_create_model_game_object(::sailor::editor::v1::CreateModelGameObjectRequest* value);
-  ::sailor::editor::v1::CreateModelGameObjectRequest* unsafe_arena_release_create_model_game_object();
-
-  private:
-  const ::sailor::editor::v1::CreateModelGameObjectRequest& _internal_create_model_game_object() const;
-  ::sailor::editor::v1::CreateModelGameObjectRequest* _internal_mutable_create_model_game_object();
+  const ::sailor::editor::v1::ViewportRayRequest& _internal_trace_viewport_ray() const;
+  ::sailor::editor::v1::ViewportRayRequest* _internal_mutable_trace_viewport_ray();
 
   public:
   // .sailor.editor.v1.InstantiatePrefabInstanceRequest instantiate_prefab_instance = 51;
@@ -10824,8 +10538,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
   void set_has_serialize_engine_types();
   void set_has_is_engine_main_thread_ready();
   void set_has_is_engine_running();
-  void set_has_resolve_viewport_drop_position();
-  void set_has_create_model_game_object();
+  void set_has_trace_viewport_ray();
   void set_has_instantiate_prefab_instance();
   void set_has_focus_editor_camera();
   void set_has_set_prefab_link();
@@ -10836,7 +10549,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
   inline void clear_has_command();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      1, 49, 47,
+      1, 48, 46,
       0, 9>
       _table_;
 
@@ -10898,8 +10611,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
       ::sailor::editor::v1::Empty* serialize_engine_types_;
       ::sailor::editor::v1::Empty* is_engine_main_thread_ready_;
       ::sailor::editor::v1::Empty* is_engine_running_;
-      ::sailor::editor::v1::ViewportDropPositionRequest* resolve_viewport_drop_position_;
-      ::sailor::editor::v1::CreateModelGameObjectRequest* create_model_game_object_;
+      ::sailor::editor::v1::ViewportRayRequest* trace_viewport_ray_;
       ::sailor::editor::v1::InstantiatePrefabInstanceRequest* instantiate_prefab_instance_;
       ::sailor::editor::v1::ViewportObjectRequest* focus_editor_camera_;
       ::sailor::editor::v1::PrefabLinkRequest* set_prefab_link_;
@@ -10975,7 +10687,7 @@ class ViewportEventBatchResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEventBatchResult*>(
         &_ViewportEventBatchResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 45;
+  static constexpr int kIndexInFileMessages = 44;
   friend void swap(ViewportEventBatchResult& a, ViewportEventBatchResult& b) { a.Swap(&b); }
   inline void Swap(ViewportEventBatchResult* other) {
     if (other == this) return;
@@ -14789,161 +14501,82 @@ inline ::sailor::editor::v1::Empty* ProtocolRequest::mutable_is_engine_running()
   return _msg;
 }
 
-// .sailor.editor.v1.ViewportDropPositionRequest resolve_viewport_drop_position = 49;
-inline bool ProtocolRequest::has_resolve_viewport_drop_position() const {
-  return command_case() == kResolveViewportDropPosition;
+// .sailor.editor.v1.ViewportRayRequest trace_viewport_ray = 49;
+inline bool ProtocolRequest::has_trace_viewport_ray() const {
+  return command_case() == kTraceViewportRay;
 }
-inline bool ProtocolRequest::_internal_has_resolve_viewport_drop_position() const {
-  return command_case() == kResolveViewportDropPosition;
+inline bool ProtocolRequest::_internal_has_trace_viewport_ray() const {
+  return command_case() == kTraceViewportRay;
 }
-inline void ProtocolRequest::set_has_resolve_viewport_drop_position() {
-  _impl_._oneof_case_[0] = kResolveViewportDropPosition;
+inline void ProtocolRequest::set_has_trace_viewport_ray() {
+  _impl_._oneof_case_[0] = kTraceViewportRay;
 }
-inline void ProtocolRequest::clear_resolve_viewport_drop_position() {
+inline void ProtocolRequest::clear_trace_viewport_ray() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (command_case() == kResolveViewportDropPosition) {
+  if (command_case() == kTraceViewportRay) {
     if (GetArena() == nullptr) {
-      delete _impl_.command_.resolve_viewport_drop_position_;
+      delete _impl_.command_.trace_viewport_ray_;
     } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
-      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.resolve_viewport_drop_position_);
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.trace_viewport_ray_);
     }
     clear_has_command();
   }
 }
-inline ::sailor::editor::v1::ViewportDropPositionRequest* ProtocolRequest::release_resolve_viewport_drop_position() {
-  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
-  if (command_case() == kResolveViewportDropPosition) {
+inline ::sailor::editor::v1::ViewportRayRequest* ProtocolRequest::release_trace_viewport_ray() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.trace_viewport_ray)
+  if (command_case() == kTraceViewportRay) {
     clear_has_command();
-    auto* temp = _impl_.command_.resolve_viewport_drop_position_;
+    auto* temp = _impl_.command_.trace_viewport_ray_;
     if (GetArena() != nullptr) {
       temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
     }
-    _impl_.command_.resolve_viewport_drop_position_ = nullptr;
+    _impl_.command_.trace_viewport_ray_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
-inline const ::sailor::editor::v1::ViewportDropPositionRequest& ProtocolRequest::_internal_resolve_viewport_drop_position() const {
-  return command_case() == kResolveViewportDropPosition ? *_impl_.command_.resolve_viewport_drop_position_ : reinterpret_cast<::sailor::editor::v1::ViewportDropPositionRequest&>(::sailor::editor::v1::_ViewportDropPositionRequest_default_instance_);
+inline const ::sailor::editor::v1::ViewportRayRequest& ProtocolRequest::_internal_trace_viewport_ray() const {
+  return command_case() == kTraceViewportRay ? *_impl_.command_.trace_viewport_ray_ : reinterpret_cast<::sailor::editor::v1::ViewportRayRequest&>(::sailor::editor::v1::_ViewportRayRequest_default_instance_);
 }
-inline const ::sailor::editor::v1::ViewportDropPositionRequest& ProtocolRequest::resolve_viewport_drop_position() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
-  return _internal_resolve_viewport_drop_position();
+inline const ::sailor::editor::v1::ViewportRayRequest& ProtocolRequest::trace_viewport_ray() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.trace_viewport_ray)
+  return _internal_trace_viewport_ray();
 }
-inline ::sailor::editor::v1::ViewportDropPositionRequest* ProtocolRequest::unsafe_arena_release_resolve_viewport_drop_position() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
-  if (command_case() == kResolveViewportDropPosition) {
+inline ::sailor::editor::v1::ViewportRayRequest* ProtocolRequest::unsafe_arena_release_trace_viewport_ray() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.trace_viewport_ray)
+  if (command_case() == kTraceViewportRay) {
     clear_has_command();
-    auto* temp = _impl_.command_.resolve_viewport_drop_position_;
-    _impl_.command_.resolve_viewport_drop_position_ = nullptr;
+    auto* temp = _impl_.command_.trace_viewport_ray_;
+    _impl_.command_.trace_viewport_ray_ = nullptr;
     return temp;
   } else {
     return nullptr;
   }
 }
-inline void ProtocolRequest::unsafe_arena_set_allocated_resolve_viewport_drop_position(::sailor::editor::v1::ViewportDropPositionRequest* value) {
+inline void ProtocolRequest::unsafe_arena_set_allocated_trace_viewport_ray(::sailor::editor::v1::ViewportRayRequest* value) {
   // We rely on the oneof clear method to free the earlier contents
   // of this oneof. We can directly use the pointer we're given to
   // set the new value.
   clear_command();
   if (value) {
-    set_has_resolve_viewport_drop_position();
-    _impl_.command_.resolve_viewport_drop_position_ = value;
+    set_has_trace_viewport_ray();
+    _impl_.command_.trace_viewport_ray_ = value;
   }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.trace_viewport_ray)
 }
-inline ::sailor::editor::v1::ViewportDropPositionRequest* ProtocolRequest::_internal_mutable_resolve_viewport_drop_position() {
-  if (command_case() != kResolveViewportDropPosition) {
+inline ::sailor::editor::v1::ViewportRayRequest* ProtocolRequest::_internal_mutable_trace_viewport_ray() {
+  if (command_case() != kTraceViewportRay) {
     clear_command();
-    set_has_resolve_viewport_drop_position();
-    _impl_.command_.resolve_viewport_drop_position_ =
-        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::ViewportDropPositionRequest>(GetArena());
+    set_has_trace_viewport_ray();
+    _impl_.command_.trace_viewport_ray_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::ViewportRayRequest>(GetArena());
   }
-  return _impl_.command_.resolve_viewport_drop_position_;
+  return _impl_.command_.trace_viewport_ray_;
 }
-inline ::sailor::editor::v1::ViewportDropPositionRequest* ProtocolRequest::mutable_resolve_viewport_drop_position() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  ::sailor::editor::v1::ViewportDropPositionRequest* _msg = _internal_mutable_resolve_viewport_drop_position();
-  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.resolve_viewport_drop_position)
-  return _msg;
-}
-
-// .sailor.editor.v1.CreateModelGameObjectRequest create_model_game_object = 50;
-inline bool ProtocolRequest::has_create_model_game_object() const {
-  return command_case() == kCreateModelGameObject;
-}
-inline bool ProtocolRequest::_internal_has_create_model_game_object() const {
-  return command_case() == kCreateModelGameObject;
-}
-inline void ProtocolRequest::set_has_create_model_game_object() {
-  _impl_._oneof_case_[0] = kCreateModelGameObject;
-}
-inline void ProtocolRequest::clear_create_model_game_object() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (command_case() == kCreateModelGameObject) {
-    if (GetArena() == nullptr) {
-      delete _impl_.command_.create_model_game_object_;
-    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
-      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.create_model_game_object_);
-    }
-    clear_has_command();
-  }
-}
-inline ::sailor::editor::v1::CreateModelGameObjectRequest* ProtocolRequest::release_create_model_game_object() {
-  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.create_model_game_object)
-  if (command_case() == kCreateModelGameObject) {
-    clear_has_command();
-    auto* temp = _impl_.command_.create_model_game_object_;
-    if (GetArena() != nullptr) {
-      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
-    }
-    _impl_.command_.create_model_game_object_ = nullptr;
-    return temp;
-  } else {
-    return nullptr;
-  }
-}
-inline const ::sailor::editor::v1::CreateModelGameObjectRequest& ProtocolRequest::_internal_create_model_game_object() const {
-  return command_case() == kCreateModelGameObject ? *_impl_.command_.create_model_game_object_ : reinterpret_cast<::sailor::editor::v1::CreateModelGameObjectRequest&>(::sailor::editor::v1::_CreateModelGameObjectRequest_default_instance_);
-}
-inline const ::sailor::editor::v1::CreateModelGameObjectRequest& ProtocolRequest::create_model_game_object() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.create_model_game_object)
-  return _internal_create_model_game_object();
-}
-inline ::sailor::editor::v1::CreateModelGameObjectRequest* ProtocolRequest::unsafe_arena_release_create_model_game_object() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.create_model_game_object)
-  if (command_case() == kCreateModelGameObject) {
-    clear_has_command();
-    auto* temp = _impl_.command_.create_model_game_object_;
-    _impl_.command_.create_model_game_object_ = nullptr;
-    return temp;
-  } else {
-    return nullptr;
-  }
-}
-inline void ProtocolRequest::unsafe_arena_set_allocated_create_model_game_object(::sailor::editor::v1::CreateModelGameObjectRequest* value) {
-  // We rely on the oneof clear method to free the earlier contents
-  // of this oneof. We can directly use the pointer we're given to
-  // set the new value.
-  clear_command();
-  if (value) {
-    set_has_create_model_game_object();
-    _impl_.command_.create_model_game_object_ = value;
-  }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.create_model_game_object)
-}
-inline ::sailor::editor::v1::CreateModelGameObjectRequest* ProtocolRequest::_internal_mutable_create_model_game_object() {
-  if (command_case() != kCreateModelGameObject) {
-    clear_command();
-    set_has_create_model_game_object();
-    _impl_.command_.create_model_game_object_ =
-        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::CreateModelGameObjectRequest>(GetArena());
-  }
-  return _impl_.command_.create_model_game_object_;
-}
-inline ::sailor::editor::v1::CreateModelGameObjectRequest* ProtocolRequest::mutable_create_model_game_object() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  ::sailor::editor::v1::CreateModelGameObjectRequest* _msg = _internal_mutable_create_model_game_object();
-  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.create_model_game_object)
+inline ::sailor::editor::v1::ViewportRayRequest* ProtocolRequest::mutable_trace_viewport_ray() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::ViewportRayRequest* _msg = _internal_mutable_trace_viewport_ray();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.trace_viewport_ray)
   return _msg;
 }
 
@@ -18155,338 +17788,72 @@ inline void InstantiatePrefabFromYamlRequest::_internal_set_strict_instance_ids(
 
 // -------------------------------------------------------------------
 
-// ViewportDropPositionRequest
+// ViewportRayRequest
 
 // uint64 viewport_id = 1;
-inline void ViewportDropPositionRequest::clear_viewport_id() {
+inline void ViewportRayRequest::clear_viewport_id() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.viewport_id_ = ::uint64_t{0u};
 }
-inline ::uint64_t ViewportDropPositionRequest::viewport_id() const {
-  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportDropPositionRequest.viewport_id)
+inline ::uint64_t ViewportRayRequest::viewport_id() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportRayRequest.viewport_id)
   return _internal_viewport_id();
 }
-inline void ViewportDropPositionRequest::set_viewport_id(::uint64_t value) {
+inline void ViewportRayRequest::set_viewport_id(::uint64_t value) {
   _internal_set_viewport_id(value);
-  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportDropPositionRequest.viewport_id)
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportRayRequest.viewport_id)
 }
-inline ::uint64_t ViewportDropPositionRequest::_internal_viewport_id() const {
+inline ::uint64_t ViewportRayRequest::_internal_viewport_id() const {
   ::google::protobuf::internal::TSanRead(&_impl_);
   return _impl_.viewport_id_;
 }
-inline void ViewportDropPositionRequest::_internal_set_viewport_id(::uint64_t value) {
+inline void ViewportRayRequest::_internal_set_viewport_id(::uint64_t value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.viewport_id_ = value;
 }
 
 // float normalized_x = 2;
-inline void ViewportDropPositionRequest::clear_normalized_x() {
+inline void ViewportRayRequest::clear_normalized_x() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.normalized_x_ = 0;
 }
-inline float ViewportDropPositionRequest::normalized_x() const {
-  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportDropPositionRequest.normalized_x)
+inline float ViewportRayRequest::normalized_x() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportRayRequest.normalized_x)
   return _internal_normalized_x();
 }
-inline void ViewportDropPositionRequest::set_normalized_x(float value) {
+inline void ViewportRayRequest::set_normalized_x(float value) {
   _internal_set_normalized_x(value);
-  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportDropPositionRequest.normalized_x)
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportRayRequest.normalized_x)
 }
-inline float ViewportDropPositionRequest::_internal_normalized_x() const {
+inline float ViewportRayRequest::_internal_normalized_x() const {
   ::google::protobuf::internal::TSanRead(&_impl_);
   return _impl_.normalized_x_;
 }
-inline void ViewportDropPositionRequest::_internal_set_normalized_x(float value) {
+inline void ViewportRayRequest::_internal_set_normalized_x(float value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.normalized_x_ = value;
 }
 
 // float normalized_y = 3;
-inline void ViewportDropPositionRequest::clear_normalized_y() {
+inline void ViewportRayRequest::clear_normalized_y() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.normalized_y_ = 0;
 }
-inline float ViewportDropPositionRequest::normalized_y() const {
-  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportDropPositionRequest.normalized_y)
+inline float ViewportRayRequest::normalized_y() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ViewportRayRequest.normalized_y)
   return _internal_normalized_y();
 }
-inline void ViewportDropPositionRequest::set_normalized_y(float value) {
+inline void ViewportRayRequest::set_normalized_y(float value) {
   _internal_set_normalized_y(value);
-  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportDropPositionRequest.normalized_y)
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.ViewportRayRequest.normalized_y)
 }
-inline float ViewportDropPositionRequest::_internal_normalized_y() const {
+inline float ViewportRayRequest::_internal_normalized_y() const {
   ::google::protobuf::internal::TSanRead(&_impl_);
   return _impl_.normalized_y_;
 }
-inline void ViewportDropPositionRequest::_internal_set_normalized_y(float value) {
+inline void ViewportRayRequest::_internal_set_normalized_y(float value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.normalized_y_ = value;
-}
-
-// -------------------------------------------------------------------
-
-// CreateModelGameObjectRequest
-
-// string model_file_id = 1;
-inline void CreateModelGameObjectRequest::clear_model_file_id() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.model_file_id_.ClearToEmpty();
-}
-inline const std::string& CreateModelGameObjectRequest::model_file_id() const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelGameObjectRequest.model_file_id)
-  return _internal_model_file_id();
-}
-template <typename Arg_, typename... Args_>
-inline PROTOBUF_ALWAYS_INLINE void CreateModelGameObjectRequest::set_model_file_id(Arg_&& arg,
-                                                     Args_... args) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.model_file_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
-  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelGameObjectRequest.model_file_id)
-}
-inline std::string* CreateModelGameObjectRequest::mutable_model_file_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  std::string* _s = _internal_mutable_model_file_id();
-  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelGameObjectRequest.model_file_id)
-  return _s;
-}
-inline const std::string& CreateModelGameObjectRequest::_internal_model_file_id() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.model_file_id_.Get();
-}
-inline void CreateModelGameObjectRequest::_internal_set_model_file_id(const std::string& value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.model_file_id_.Set(value, GetArena());
-}
-inline std::string* CreateModelGameObjectRequest::_internal_mutable_model_file_id() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  return _impl_.model_file_id_.Mutable( GetArena());
-}
-inline std::string* CreateModelGameObjectRequest::release_model_file_id() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelGameObjectRequest.model_file_id)
-  return _impl_.model_file_id_.Release();
-}
-inline void CreateModelGameObjectRequest::set_allocated_model_file_id(std::string* value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.model_file_id_.SetAllocated(value, GetArena());
-  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.model_file_id_.IsDefault()) {
-    _impl_.model_file_id_.Set("", GetArena());
-  }
-  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelGameObjectRequest.model_file_id)
-}
-
-// string name = 2;
-inline void CreateModelGameObjectRequest::clear_name() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.name_.ClearToEmpty();
-}
-inline const std::string& CreateModelGameObjectRequest::name() const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelGameObjectRequest.name)
-  return _internal_name();
-}
-template <typename Arg_, typename... Args_>
-inline PROTOBUF_ALWAYS_INLINE void CreateModelGameObjectRequest::set_name(Arg_&& arg,
-                                                     Args_... args) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.name_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
-  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelGameObjectRequest.name)
-}
-inline std::string* CreateModelGameObjectRequest::mutable_name() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  std::string* _s = _internal_mutable_name();
-  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelGameObjectRequest.name)
-  return _s;
-}
-inline const std::string& CreateModelGameObjectRequest::_internal_name() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.name_.Get();
-}
-inline void CreateModelGameObjectRequest::_internal_set_name(const std::string& value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.name_.Set(value, GetArena());
-}
-inline std::string* CreateModelGameObjectRequest::_internal_mutable_name() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  return _impl_.name_.Mutable( GetArena());
-}
-inline std::string* CreateModelGameObjectRequest::release_name() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelGameObjectRequest.name)
-  return _impl_.name_.Release();
-}
-inline void CreateModelGameObjectRequest::set_allocated_name(std::string* value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.name_.SetAllocated(value, GetArena());
-  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.name_.IsDefault()) {
-    _impl_.name_.Set("", GetArena());
-  }
-  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelGameObjectRequest.name)
-}
-
-// string parent_instance_id = 3;
-inline void CreateModelGameObjectRequest::clear_parent_instance_id() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.parent_instance_id_.ClearToEmpty();
-}
-inline const std::string& CreateModelGameObjectRequest::parent_instance_id() const
-    ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id)
-  return _internal_parent_instance_id();
-}
-template <typename Arg_, typename... Args_>
-inline PROTOBUF_ALWAYS_INLINE void CreateModelGameObjectRequest::set_parent_instance_id(Arg_&& arg,
-                                                     Args_... args) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.parent_instance_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
-  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id)
-}
-inline std::string* CreateModelGameObjectRequest::mutable_parent_instance_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  std::string* _s = _internal_mutable_parent_instance_id();
-  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id)
-  return _s;
-}
-inline const std::string& CreateModelGameObjectRequest::_internal_parent_instance_id() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.parent_instance_id_.Get();
-}
-inline void CreateModelGameObjectRequest::_internal_set_parent_instance_id(const std::string& value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.parent_instance_id_.Set(value, GetArena());
-}
-inline std::string* CreateModelGameObjectRequest::_internal_mutable_parent_instance_id() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  return _impl_.parent_instance_id_.Mutable( GetArena());
-}
-inline std::string* CreateModelGameObjectRequest::release_parent_instance_id() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id)
-  return _impl_.parent_instance_id_.Release();
-}
-inline void CreateModelGameObjectRequest::set_allocated_parent_instance_id(std::string* value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.parent_instance_id_.SetAllocated(value, GetArena());
-  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.parent_instance_id_.IsDefault()) {
-    _impl_.parent_instance_id_.Set("", GetArena());
-  }
-  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelGameObjectRequest.parent_instance_id)
-}
-
-// bool apply_world_position = 4;
-inline void CreateModelGameObjectRequest::clear_apply_world_position() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.apply_world_position_ = false;
-}
-inline bool CreateModelGameObjectRequest::apply_world_position() const {
-  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelGameObjectRequest.apply_world_position)
-  return _internal_apply_world_position();
-}
-inline void CreateModelGameObjectRequest::set_apply_world_position(bool value) {
-  _internal_set_apply_world_position(value);
-  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelGameObjectRequest.apply_world_position)
-}
-inline bool CreateModelGameObjectRequest::_internal_apply_world_position() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  return _impl_.apply_world_position_;
-}
-inline void CreateModelGameObjectRequest::_internal_set_apply_world_position(bool value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  _impl_.apply_world_position_ = value;
-}
-
-// .sailor.editor.v1.Vector4 world_position = 5;
-inline bool CreateModelGameObjectRequest::has_world_position() const {
-  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
-  PROTOBUF_ASSUME(!value || _impl_.world_position_ != nullptr);
-  return value;
-}
-inline void CreateModelGameObjectRequest::clear_world_position() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (_impl_.world_position_ != nullptr) _impl_.world_position_->Clear();
-  _impl_._has_bits_[0] &= ~0x00000001u;
-}
-inline const ::sailor::editor::v1::Vector4& CreateModelGameObjectRequest::_internal_world_position() const {
-  ::google::protobuf::internal::TSanRead(&_impl_);
-  const ::sailor::editor::v1::Vector4* p = _impl_.world_position_;
-  return p != nullptr ? *p : reinterpret_cast<const ::sailor::editor::v1::Vector4&>(::sailor::editor::v1::_Vector4_default_instance_);
-}
-inline const ::sailor::editor::v1::Vector4& CreateModelGameObjectRequest::world_position() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelGameObjectRequest.world_position)
-  return _internal_world_position();
-}
-inline void CreateModelGameObjectRequest::unsafe_arena_set_allocated_world_position(::sailor::editor::v1::Vector4* value) {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (GetArena() == nullptr) {
-    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.world_position_);
-  }
-  _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(value);
-  if (value != nullptr) {
-    _impl_._has_bits_[0] |= 0x00000001u;
-  } else {
-    _impl_._has_bits_[0] &= ~0x00000001u;
-  }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.CreateModelGameObjectRequest.world_position)
-}
-inline ::sailor::editor::v1::Vector4* CreateModelGameObjectRequest::release_world_position() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-
-  _impl_._has_bits_[0] &= ~0x00000001u;
-  ::sailor::editor::v1::Vector4* released = _impl_.world_position_;
-  _impl_.world_position_ = nullptr;
-  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
-    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
-    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
-    if (GetArena() == nullptr) {
-      delete old;
-    }
-  } else {
-    if (GetArena() != nullptr) {
-      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
-    }
-  }
-  return released;
-}
-inline ::sailor::editor::v1::Vector4* CreateModelGameObjectRequest::unsafe_arena_release_world_position() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelGameObjectRequest.world_position)
-
-  _impl_._has_bits_[0] &= ~0x00000001u;
-  ::sailor::editor::v1::Vector4* temp = _impl_.world_position_;
-  _impl_.world_position_ = nullptr;
-  return temp;
-}
-inline ::sailor::editor::v1::Vector4* CreateModelGameObjectRequest::_internal_mutable_world_position() {
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (_impl_.world_position_ == nullptr) {
-    auto* p = ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::Vector4>(GetArena());
-    _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(p);
-  }
-  return _impl_.world_position_;
-}
-inline ::sailor::editor::v1::Vector4* CreateModelGameObjectRequest::mutable_world_position() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  _impl_._has_bits_[0] |= 0x00000001u;
-  ::sailor::editor::v1::Vector4* _msg = _internal_mutable_world_position();
-  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelGameObjectRequest.world_position)
-  return _msg;
-}
-inline void CreateModelGameObjectRequest::set_allocated_world_position(::sailor::editor::v1::Vector4* value) {
-  ::google::protobuf::Arena* message_arena = GetArena();
-  ::google::protobuf::internal::TSanWrite(&_impl_);
-  if (message_arena == nullptr) {
-    delete (_impl_.world_position_);
-  }
-
-  if (value != nullptr) {
-    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
-    if (message_arena != submessage_arena) {
-      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
-    }
-    _impl_._has_bits_[0] |= 0x00000001u;
-  } else {
-    _impl_._has_bits_[0] &= ~0x00000001u;
-  }
-
-  _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(value);
-  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelGameObjectRequest.world_position)
 }
 
 // -------------------------------------------------------------------

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -76,7 +76,8 @@ namespace Sailor
 		SAILOR_API static bool SendEditorRemoteViewportInput(uint64_t viewportId, uint32_t kind, float pointerX, float pointerY, float wheelDeltaX, float wheelDeltaY, uint32_t keyCode, uint32_t button, uint32_t modifiers, bool bPressed, bool bFocused, bool bCaptured);
 		SAILOR_API static uint32_t PullEditorMessages(char** messages, uint32_t num);
 		SAILOR_API static uint32_t PullEditorViewportEvents(char** events, uint32_t num);
-		SAILOR_API static bool ResolveEditorViewportDropPosition(
+		SAILOR_API static bool TraceViewportRay(
+			uint64_t viewportId,
 			float normalizedX,
 			float normalizedY,
 			float& outWorldX,
@@ -96,15 +97,6 @@ namespace Sailor
 		SAILOR_API static bool ResetEditorComponentToDefaults(const char* strInstanceId);
 		SAILOR_API static bool AddEditorComponent(const char* strInstanceId, const char* strComponentTypeName, const char* strPreferredInstanceId, char** outInstanceId);
 		SAILOR_API static bool RemoveEditorComponent(const char* strInstanceId);
-		SAILOR_API static bool CreateEditorModelGameObject(
-			const char* strModelFileId,
-			const char* strName,
-			const char* strParentInstanceId,
-			bool bHasWorldPosition,
-			float worldX,
-			float worldY,
-			float worldZ,
-			char** outInstanceId);
 		SAILOR_API static bool InstantiateEditorPrefab(const char* strFileId, const char* strParentInstanceId);
 		SAILOR_API static bool InstantiateEditorPrefabInstance(
 			const char* strFileId,

--- a/Runtime/Submodules/Editor.cpp
+++ b/Runtime/Submodules/Editor.cpp
@@ -7,13 +7,11 @@
 #include "ECS/PathTracerECS.h"
 #include "Components/PathTracerProxyComponent.h"
 #include "Components/EditorComponent.h"
-#include "Components/MeshRendererComponent.h"
 #include "Raytracing/PathTracer.h"
 #include "Editor.h"
 #include "Containers/Map.h"
 #include "AssetRegistry/World/WorldPrefabImporter.h"
 #include "AssetRegistry/Prefab/PrefabImporter.h"
-#include "AssetRegistry/Model/ModelImporter.h"
 #include "AssetRegistry/FileId.h"
 #include "Core/Reflection.h"
 #include "Math/Math.h"
@@ -44,6 +42,8 @@ namespace Sailor
 
 namespace
 {
+	constexpr uint64_t c_primaryEditorViewportId = 1u;
+
 	bool IsDescendantOf(GameObjectPtr object, GameObjectPtr possibleParent)
 	{
 		for (auto current = object; current.IsValid(); current = current->GetParent())
@@ -852,80 +852,16 @@ bool Editor::InstantiatePrefab(
 	return true;
 }
 
-bool Editor::CreateModelGameObject(
-	const FileId& modelId,
-	const std::string& name,
-	const InstanceId& parentInstanceId,
-	const glm::vec3* worldPosition,
-	InstanceId& outInstanceId)
-{
-	SAILOR_PROFILE_FUNCTION();
-	outInstanceId = InstanceId::Invalid;
-
-	if (!m_world || !modelId || name.empty())
-	{
-		return false;
-	}
-
-	GameObjectPtr parentGameObject{};
-	if (!ResolveParent(m_world, parentInstanceId, parentGameObject))
-	{
-		return false;
-	}
-
-	auto modelImporter = App::GetSubmodule<ModelImporter>();
-	ModelPtr model{};
-	if (!modelImporter ||
-		!modelImporter->LoadModel_Immediate(modelId, model) ||
-		!model ||
-		!model->IsReady())
-	{
-		return false;
-	}
-
-	auto gameObject = m_world->Instantiate(name);
-	if (!gameObject)
-	{
-		return false;
-	}
-
-	if (parentGameObject)
-	{
-		gameObject->SetParent(parentGameObject);
-		if (gameObject->GetParent() != parentGameObject)
-		{
-			m_world->DestroyImmediate(gameObject);
-			return false;
-		}
-	}
-
-	if (worldPosition && !TrySetWorldPosition(gameObject, *worldPosition))
-	{
-		m_world->DestroyImmediate(gameObject);
-		return false;
-	}
-
-	auto meshRenderer = gameObject->AddComponent<MeshRendererComponent>();
-	if (!meshRenderer)
-	{
-		m_world->DestroyImmediate(gameObject);
-		return false;
-	}
-
-	meshRenderer->SetModel(model);
-	outInstanceId = gameObject->GetInstanceId();
-	NotifyManagedObjectMutation(outInstanceId);
-	return true;
-}
-
-bool Editor::ResolveViewportDropPosition(
+bool Editor::TraceViewportRay(
+	uint64_t viewportId,
 	float normalizedX,
 	float normalizedY,
 	glm::vec3& outPosition) const
 {
-	return m_world &&
+	return viewportId == c_primaryEditorViewportId &&
+		m_world &&
 		m_viewportController &&
-		m_viewportController->TryResolveDropPosition(
+		m_viewportController->TraceViewportRay(
 			*m_world,
 			normalizedX,
 			normalizedY,

--- a/Runtime/Submodules/Editor.h
+++ b/Runtime/Submodules/Editor.h
@@ -94,13 +94,8 @@ namespace Sailor
 			const glm::vec3* worldPosition,
 			class InstanceId& outInstanceId,
 			bool bStrictInstanceIds = false);
-		bool CreateModelGameObject(
-			const class FileId& modelId,
-			const std::string& name,
-			const class InstanceId& parentInstanceId,
-			const glm::vec3* worldPosition,
-			class InstanceId& outInstanceId);
-		bool ResolveViewportDropPosition(
+		bool TraceViewportRay(
+			uint64_t viewportId,
 			float normalizedX,
 			float normalizedY,
 			glm::vec3& outPosition) const;

--- a/Runtime/Workspace/WorkspaceModuleManager.cpp
+++ b/Runtime/Workspace/WorkspaceModuleManager.cpp
@@ -3,6 +3,7 @@
 
 #include "Components/Component.h"
 #include "Core/Reflection.h"
+#include "Core/Utils.h"
 #include "Workspace/WorkspaceModuleApi.h"
 
 #include <algorithm>
@@ -176,9 +177,6 @@ namespace
 	};
 
 	using EditorTypeSchemas = TMap<std::string, EditorTypeSchema>;
-	constexpr size_t MaxCanonicalYamlDepth = 64;
-	constexpr size_t MaxCanonicalYamlNodes = 262144;
-	constexpr size_t MaxCanonicalYamlBytes = 64 * 1024 * 1024;
 
 	bool IndexMetadataEntries(
 		const YAML::Node& entries,
@@ -311,169 +309,9 @@ namespace
 		return false;
 	}
 
-	bool AppendCanonicalText(
-		std::string& destination,
-		const std::string& value,
-		size_t& remainingBytes)
-	{
-		if (value.size() > remainingBytes)
-		{
-			return false;
-		}
-
-		destination.append(value);
-		remainingBytes -= value.size();
-		return true;
-	}
-
-	bool AppendCanonicalCharacter(
-		std::string& destination,
-		char value,
-		size_t& remainingBytes)
-	{
-		if (remainingBytes == 0)
-		{
-			return false;
-		}
-
-		destination.push_back(value);
-		--remainingBytes;
-		return true;
-	}
-
-	bool AppendCanonicalField(
-		std::string& destination,
-		const std::string& value,
-		size_t& remainingBytes)
-	{
-		const std::string length = std::to_string(value.size());
-		return AppendCanonicalText(destination, length, remainingBytes) &&
-			AppendCanonicalCharacter(destination, ':', remainingBytes) &&
-			AppendCanonicalText(destination, value, remainingBytes);
-	}
-
-	bool AppendCanonicalYaml(
-		const YAML::Node& node,
-		std::string& destination,
-		size_t depth,
-		size_t& remainingNodes,
-		size_t& remainingBytes)
-	{
-		if (depth > MaxCanonicalYamlDepth || remainingNodes == 0)
-		{
-			return false;
-		}
-		--remainingNodes;
-
-		switch (node.Type())
-		{
-		case YAML::NodeType::Undefined:
-			return AppendCanonicalCharacter(destination, 'U', remainingBytes);
-		case YAML::NodeType::Null:
-			return AppendCanonicalCharacter(destination, 'N', remainingBytes) &&
-				AppendCanonicalField(destination, node.Tag(), remainingBytes);
-		case YAML::NodeType::Scalar:
-			return AppendCanonicalCharacter(destination, 'S', remainingBytes) &&
-				AppendCanonicalField(destination, node.Tag(), remainingBytes) &&
-				AppendCanonicalField(destination, node.Scalar(), remainingBytes);
-		case YAML::NodeType::Sequence:
-		{
-			const std::string numElements = std::to_string(node.size());
-			if (!AppendCanonicalCharacter(destination, 'Q', remainingBytes) ||
-				!AppendCanonicalField(destination, node.Tag(), remainingBytes) ||
-				!AppendCanonicalText(destination, numElements, remainingBytes) ||
-				!AppendCanonicalCharacter(destination, ':', remainingBytes))
-			{
-				return false;
-			}
-			for (const YAML::Node& element : node)
-			{
-				std::string canonicalElement;
-				if (!AppendCanonicalYaml(
-					element,
-					canonicalElement,
-					depth + 1,
-					remainingNodes,
-					remainingBytes) ||
-					!AppendCanonicalField(destination, canonicalElement, remainingBytes))
-				{
-					return false;
-				}
-			}
-			return true;
-		}
-		case YAML::NodeType::Map:
-		{
-			TVector<std::pair<std::string, std::string>> entries;
-			entries.Reserve(node.size());
-			for (const auto& entry : node)
-			{
-				std::string canonicalKey;
-				std::string canonicalValue;
-				if (!AppendCanonicalYaml(
-					entry.first,
-					canonicalKey,
-					depth + 1,
-					remainingNodes,
-					remainingBytes) ||
-					!AppendCanonicalYaml(
-						entry.second,
-						canonicalValue,
-						depth + 1,
-						remainingNodes,
-						remainingBytes))
-				{
-					return false;
-				}
-				entries.Add(std::make_pair(std::move(canonicalKey), std::move(canonicalValue)));
-			}
-
-			std::sort(entries.begin(), entries.end(), [](const auto& lhs, const auto& rhs)
-				{
-					return lhs.first < rhs.first;
-				});
-			for (size_t index = 1; index < entries.Num(); ++index)
-			{
-				if (entries[index - 1].first == entries[index].first)
-				{
-					return false;
-				}
-			}
-
-			const std::string numEntries = std::to_string(entries.Num());
-			if (!AppendCanonicalCharacter(destination, 'M', remainingBytes) ||
-				!AppendCanonicalField(destination, node.Tag(), remainingBytes) ||
-				!AppendCanonicalText(destination, numEntries, remainingBytes) ||
-				!AppendCanonicalCharacter(destination, ':', remainingBytes))
-			{
-				return false;
-			}
-			for (const auto& entry : entries)
-			{
-				if (!AppendCanonicalField(destination, entry.first, remainingBytes) ||
-					!AppendCanonicalField(destination, entry.second, remainingBytes))
-				{
-					return false;
-				}
-			}
-			return true;
-		}
-		}
-
-		return false;
-	}
-
-	bool CanonicalizeYaml(const YAML::Node& node, std::string& destination)
-	{
-		destination.clear();
-		size_t remainingNodes = MaxCanonicalYamlNodes;
-		size_t remainingBytes = MaxCanonicalYamlBytes;
-		return AppendCanonicalYaml(node, destination, 0, remainingNodes, remainingBytes);
-	}
-
 	bool HasUniqueScalarStringKeys(const YAML::Node& node)
 	{
-		if (!node.IsMap() || node.size() > MaxCanonicalYamlNodes)
+		if (!node.IsMap())
 		{
 			return false;
 		}
@@ -498,10 +336,16 @@ namespace
 		const YAML::Node canonicalDefaultValues = YAML::Load(collected.m_canonicalDefaultValues);
 		std::string canonicalMetadata;
 		std::string canonicalDescriptor;
-		if (!HasUniqueScalarStringKeys(defaultValues) ||
+		if (!Utils::CanonicalizeYaml(
+				defaultValues,
+				canonicalMetadata,
+				Utils::EYamlCanonicalizationMode::StrictDocument) ||
+			!Utils::CanonicalizeYaml(
+				canonicalDefaultValues,
+				canonicalDescriptor,
+				Utils::EYamlCanonicalizationMode::StrictDocument) ||
+			!HasUniqueScalarStringKeys(defaultValues) ||
 			!HasUniqueScalarStringKeys(canonicalDefaultValues) ||
-			!CanonicalizeYaml(defaultValues, canonicalMetadata) ||
-			!CanonicalizeYaml(canonicalDefaultValues, canonicalDescriptor) ||
 			canonicalMetadata != canonicalDescriptor)
 		{
 			outError = "Workspace metadata defaults for '" + collected.m_typeName +

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -172,6 +172,17 @@ namespace
 
 		PrefabTestWorld() : World("PrefabRollbackTests", 0, CreateEcs()) {}
 		size_t GetPendingDependencyCount() const { return GetNumPendingDependencyResolutions(); }
+		bool RemovePrefabMetadataForTest(
+			const InstanceId& rootInstanceId)
+		{
+			if (!m_prefabInstances.ContainsKey(rootInstanceId))
+			{
+				return false;
+			}
+
+			m_prefabInstances.Remove(rootInstanceId);
+			return true;
+		}
 
 	private:
 
@@ -1198,8 +1209,11 @@ namespace
 				child->GetInstanceId(),
 				registeredLink) &&
 			registeredLink &&
-			registeredLink->m_sourcePrefabId == sourceFileId,
-			"every linked member should resolve to its registered prefab source");
+			registeredLink->m_effectiveBaseline &&
+			registeredLink->m_effectiveBaseline->GetFileId() ==
+				root->GetFileId() &&
+			root->GetFileId() == sourceFileId,
+			"the root FileId should be authoritative while linked members resolve through matching derived metadata");
 
 		ComponentPtr rejectedComponent =
 			TObjectPtr<PrefabRollbackTestComponent>::Make(
@@ -1234,6 +1248,7 @@ namespace
 		Require(world.BreakPrefabLink(childIdBeforeBreak),
 			"breaking a prefab link through any linked member should succeed");
 		Require(!world.IsPrefabLinked(rootIdBeforeBreak) &&
+			!root->GetFileId() &&
 			root->GetInstanceId() == rootIdBeforeBreak &&
 			child->GetInstanceId() == childIdBeforeBreak &&
 			child->GetTransformComponent().GetPosition() ==
@@ -1256,8 +1271,9 @@ namespace
 				diagnostic),
 			"relink should rebuild the deterministic source-to-live mapping: " +
 				diagnostic);
-		Require(world.IsPrefabLinked(childIdBeforeBreak),
-			"relink should restore linked membership for the whole hierarchy");
+		Require(root->GetFileId() == sourceFileId &&
+			world.IsPrefabLinked(childIdBeforeBreak),
+			"relink should restore the authoritative source FileId and derived membership");
 
 		const size_t linkedCountBeforeRejectedInstantiation =
 			world.GetPrefabInstances().Num();
@@ -1860,6 +1876,65 @@ namespace
 			!world.IsPrefabLinked(rootInstanceId) &&
 			!world.BreakPrefabLink(rootInstanceId),
 			"breaking the surviving root should purge the remaining membership exactly once");
+
+		world.Clear();
+	}
+
+	void TestPrefabRootFileIdRemainsAuthoritativeWhenDerivedMetadataIsMissing()
+	{
+		constexpr uint32_t noParent =
+			static_cast<uint32_t>(-1);
+		const FileId sourceFileId =
+			DeserializeFileId(
+				"{11111111-2222-3333-4444-666666666666}");
+
+		PrefabTestWorld world;
+		PrefabPtr sourcePrefab = DeserializePrefab(
+			world,
+			sourceFileId,
+			MakePrefabNode({ noParent, 0 }));
+		std::string diagnostic;
+		Require(sourcePrefab->ValidateForInstantiation(
+				diagnostic),
+			"the FileId-authority fixture should be valid: " +
+				diagnostic);
+
+		GameObjectPtr root = world.Instantiate(sourcePrefab);
+		Require(root &&
+			root->GetChildren().Num() == 1 &&
+			root->GetFileId() == sourceFileId &&
+			world.IsPrefabInstanceRoot(root->GetInstanceId()) &&
+			world.IsPrefabLinked(root->GetInstanceId()),
+			"a non-empty root FileId should establish the prefab link");
+		GameObjectPtr child = root->GetChildren()[0];
+		Require(world.IsPrefabLinked(child->GetInstanceId()),
+			"a mapped source child should initially resolve through derived membership");
+
+		Require(world.RemovePrefabMetadataForTest(
+				root->GetInstanceId()),
+			"the fixture should remove only derived prefab metadata");
+		const PrefabInstanceLink* missingLink = nullptr;
+		Require(root->GetFileId() == sourceFileId &&
+			world.IsPrefabInstanceRoot(root->GetInstanceId()) &&
+			world.IsPrefabLinked(root->GetInstanceId()) &&
+			!world.TryGetPrefabInstance(
+				root->GetInstanceId(),
+				missingLink) &&
+			!world.IsPrefabLinked(child->GetInstanceId()),
+			"missing derived metadata must not erase the authoritative root link or create a valid child membership");
+
+		Require(world.BreakPrefabLink(root->GetInstanceId()) &&
+			!root->GetFileId() &&
+			!world.IsPrefabLinked(root->GetInstanceId()) &&
+			world.LinkPrefabInstance(
+				root,
+				sourcePrefab,
+				diagnostic),
+			"break should clear the authoritative FileId and stale caches so the hierarchy can be relinked: " +
+				diagnostic);
+		Require(root->GetFileId() == sourceFileId &&
+			world.IsPrefabLinked(child->GetInstanceId()),
+			"relink should republish the source FileId after rebuilding derived membership");
 
 		world.Clear();
 	}
@@ -3084,6 +3159,7 @@ int main()
 		{ "LinkedPrefabBaselineAndSaveFailureContract", TestLinkedPrefabBaselineAndSaveFailureContract },
 		{ "LinkedPrefabSourceStructureEvolutionContract", TestLinkedPrefabSourceStructureEvolutionContract },
 		{ "LinkedPrefabMembershipFollowsEvolvedSourceMapping", TestLinkedPrefabMembershipFollowsEvolvedSourceMapping },
+		{ "PrefabRootFileIdRemainsAuthoritativeWhenDerivedMetadataIsMissing", TestPrefabRootFileIdRemainsAuthoritativeWhenDerivedMetadataIsMissing },
 		{ "DetachedSupplementalPrefabPersistenceAndStrictRestore", TestDetachedSupplementalPrefabPersistenceAndStrictRestore },
 		{ "StrictPrefabInstantiationPreservesIdsAndRejectsAtomically", TestStrictPrefabInstantiationPreservesIdsAndRejectsAtomically },
 		{ "EditorPrefabInstantiationRejectsLinkedParentBeforeMutation", TestEditorPrefabInstantiationRejectsLinkedParentBeforeMutation },

--- a/Tests/EditorViewportControllerContractTests.cpp
+++ b/Tests/EditorViewportControllerContractTests.cpp
@@ -216,7 +216,7 @@ namespace
 		Require(std::abs(distance) <= c_tolerance, "a ray starting inside an AABB must report zero distance");
 	}
 
-	void TestResolveDropPositionUsesNearestMeshBounds()
+	void TestResolveRayTargetUsesNearestMeshBounds()
 	{
 		const InstanceId nearId = ParseInstanceId("0000000000000010");
 		const InstanceId farId = ParseInstanceId("0000000000000020");
@@ -227,13 +227,13 @@ namespace
 		};
 		glm::vec3 position{};
 
-		Require(EditorViewport::TryResolveDropPosition(ray, candidates, position),
-			"a drop ray crossing mesh bounds must resolve successfully");
+		Require(EditorViewport::TryResolveRayTarget(ray, candidates, position),
+			"a viewport ray crossing mesh bounds must resolve successfully");
 		Require(AreVectorsNear(position, glm::vec3(0.0f, 2.0f, -3.0f)),
 			"drop placement must use the nearest mesh AABB before fallback surfaces");
 	}
 
-	void TestResolveDropPositionUsesGroundPlane()
+	void TestResolveRayTargetUsesGroundPlane()
 	{
 		const glm::vec3 origin(2.0f, 4.0f, 3.0f);
 		const glm::vec3 direction = glm::normalize(glm::vec3(1.0f, -2.0f, -1.0f));
@@ -242,15 +242,15 @@ namespace
 		glm::vec3 position{};
 		const float planeDistance = -origin.y / direction.y;
 
-		Require(EditorViewport::TryResolveDropPosition(ray, candidates, position),
-			"a drop ray facing the ground plane must resolve successfully");
+		Require(EditorViewport::TryResolveRayTarget(ray, candidates, position),
+			"a viewport ray facing the ground plane must resolve successfully");
 		Require(AreVectorsNear(position, origin + direction * planeDistance),
 			"drop placement without mesh hits must intersect the y=0 plane");
 		Require(std::abs(position.y) <= c_tolerance,
 			"ground-plane drop placement must land on y=0");
 	}
 
-	void TestResolveDropPositionUsesFiniteForwardFallback()
+	void TestResolveRayTargetUsesFiniteForwardFallback()
 	{
 		const glm::vec3 origin(1.0f, 2.0f, 3.0f);
 		const glm::vec3 direction = glm::normalize(glm::vec3(1.0f, 0.0f, -1.0f));
@@ -258,8 +258,8 @@ namespace
 		const TVector<EditorViewport::PickCandidate> candidates{};
 		glm::vec3 position{};
 
-		Require(EditorViewport::TryResolveDropPosition(ray, candidates, position),
-			"a drop ray parallel to the ground plane must still resolve");
+		Require(EditorViewport::TryResolveRayTarget(ray, candidates, position),
+			"a viewport ray parallel to the ground plane must still resolve");
 		Require(Math::AllFinite(position),
 			"the forward fallback must remain finite");
 		Require(AreVectorsNear(position, origin + direction * 1000.0f),
@@ -268,7 +268,7 @@ namespace
 		const Math::Ray upwardRay(
 			origin,
 			glm::normalize(glm::vec3(0.0f, 1.0f, -1.0f)));
-		Require(EditorViewport::TryResolveDropPosition(
+		Require(EditorViewport::TryResolveRayTarget(
 			upwardRay,
 			candidates,
 			position),
@@ -277,12 +277,12 @@ namespace
 			"drop placement must never follow the ray backwards to reach the ground plane");
 	}
 
-	void TestResolveDropPositionRejectsInvalidRay()
+	void TestResolveRayTargetRejectsInvalidRay()
 	{
 		const TVector<EditorViewport::PickCandidate> candidates{};
 		glm::vec3 position(4.0f, 5.0f, 6.0f);
 
-		Require(!EditorViewport::TryResolveDropPosition(
+		Require(!EditorViewport::TryResolveRayTarget(
 			Math::Ray(glm::vec3(0.0f), glm::vec3(0.0f)),
 			candidates,
 			position),
@@ -291,7 +291,7 @@ namespace
 			"a rejected drop ray must not leak a stale position");
 
 		const float nan = std::numeric_limits<float>::quiet_NaN();
-		Require(!EditorViewport::TryResolveDropPosition(
+		Require(!EditorViewport::TryResolveRayTarget(
 			Math::Ray(glm::vec3(nan, 0.0f, 0.0f), Math::vec3_Forward),
 			candidates,
 			position),
@@ -664,10 +664,10 @@ int main()
 		{ "BuildWorldRayRejectsInvalidViewport", TestBuildWorldRayRejectsInvalidViewport },
 		{ "PickNearestUsesDistance", TestPickNearestUsesDistance },
 		{ "PickNearestTreatsInsideBoundsAsZeroDistance", TestPickNearestTreatsInsideBoundsAsZeroDistance },
-		{ "ResolveDropPositionUsesNearestMeshBounds", TestResolveDropPositionUsesNearestMeshBounds },
-		{ "ResolveDropPositionUsesGroundPlane", TestResolveDropPositionUsesGroundPlane },
-		{ "ResolveDropPositionUsesFiniteForwardFallback", TestResolveDropPositionUsesFiniteForwardFallback },
-		{ "ResolveDropPositionRejectsInvalidRay", TestResolveDropPositionRejectsInvalidRay },
+		{ "ResolveRayTargetUsesNearestMeshBounds", TestResolveRayTargetUsesNearestMeshBounds },
+		{ "ResolveRayTargetUsesGroundPlane", TestResolveRayTargetUsesGroundPlane },
+		{ "ResolveRayTargetUsesFiniteForwardFallback", TestResolveRayTargetUsesFiniteForwardFallback },
+		{ "ResolveRayTargetRejectsInvalidRay", TestResolveRayTargetRejectsInvalidRay },
 		{ "CalculateFramedCameraPositionPreservesViewDirection", TestCalculateFramedCameraPositionPreservesViewDirection },
 		{ "CalculateFramedCameraPositionAccountsForViewportAspect", TestCalculateFramedCameraPositionAccountsForViewportAspect },
 		{ "CalculateFramedCameraPositionRejectsInvalidInput", TestCalculateFramedCameraPositionRejectsInvalidInput },

--- a/Tests/InstanceIdContractTests.cpp
+++ b/Tests/InstanceIdContractTests.cpp
@@ -1,4 +1,6 @@
 #include "Engine/InstanceId.h"
+#include "Core/Reflection.h"
+#include "Core/Utils.h"
 
 #include <algorithm>
 #include <cctype>
@@ -9,6 +11,19 @@
 #include <utility>
 
 using namespace Sailor;
+
+namespace Sailor
+{
+	struct ComponentIdentityReflectionFixture
+	{
+		InstanceId m_instanceId;
+	};
+}
+
+REFL_AUTO(
+	type(Sailor::ComponentIdentityReflectionFixture),
+	field(m_instanceId)
+)
 
 namespace
 {
@@ -33,6 +48,13 @@ namespace
 			{
 				return std::isxdigit(character) != 0;
 			});
+	}
+
+	ReflectedData MakeComponentReflection(const YAML::Node& properties)
+	{
+		return Reflection::CreateReflectedData(
+			TypeInfo::Get<ComponentIdentityReflectionFixture>(),
+			properties);
 	}
 
 	void TestGeneratedGameObjectIdsUseCanonicalFormat()
@@ -128,6 +150,112 @@ namespace
 				"a malformed component ID must not expose an otherwise valid parent suffix");
 		}
 	}
+
+	void TestYamlNodeEqualityIsStructuralAndMapOrderIndependent()
+	{
+		const YAML::Node lhs = YAML::Load(
+			"{ transform: { position: [1, 2, 3], enabled: true }, name: Duck }");
+		const YAML::Node reordered = YAML::Load(
+			"{ name: Duck, transform: { enabled: true, position: [1, 2, 3] } }");
+		const YAML::Node reorderedSequence = YAML::Load(
+			"{ name: Duck, transform: { enabled: true, position: [3, 2, 1] } }");
+		const YAML::Node changedValue = YAML::Load(
+			"{ name: Goose, transform: { enabled: true, position: [1, 2, 3] } }");
+
+		Require(Utils::AreYamlNodesEqual(lhs, reordered),
+			"YAML map equality must ignore insertion order at every nesting level");
+		Require(!Utils::AreYamlNodesEqual(lhs, reorderedSequence),
+			"YAML sequence equality must preserve element order");
+		Require(!Utils::AreYamlNodesEqual(lhs, changedValue),
+			"YAML scalar changes must make structurally similar nodes unequal");
+
+		const YAML::Node undefined(YAML::NodeType::Undefined);
+		const YAML::Node anotherUndefined(YAML::NodeType::Undefined);
+		const YAML::Node nullNode(YAML::NodeType::Null);
+		Require(Utils::AreYamlNodesEqual(undefined, anotherUndefined),
+			"two undefined YAML nodes must compare equal");
+		Require(!Utils::AreYamlNodesEqual(undefined, nullNode),
+			"undefined and explicit null YAML nodes must remain distinct");
+	}
+
+	void TestReflectedComponentIdentityUsesStrictSharedValidation()
+	{
+		const std::string validIdentity =
+			"FFF4417DA65649588B6B279D47D0EC3E_0123456789ABCDEFFFFF";
+		YAML::Node validProperties(YAML::NodeType::Map);
+		validProperties["instanceId"] = validIdentity;
+
+		InstanceId parsedIdentity = Parse("1111111111111111_10010010010010010000");
+		std::string diagnostic = "stale diagnostic";
+		Require(Utils::TryGetComponentInstanceId(
+				MakeComponentReflection(validProperties),
+				parsedIdentity,
+				diagnostic),
+			"a reflected component with valid component and owner IDs must be accepted");
+		Require(parsedIdentity == Parse(validIdentity),
+			"shared component identity parsing must preserve the complete instanceId");
+		Require(diagnostic.empty(),
+			"a successful component identity parse must clear stale diagnostics");
+
+		const std::string malformedIdentities[] = {
+			"0123456789ABCDEFFFFF",
+			"FFF4417DA65649588B6B279D47D0EC3E_invalid-owner",
+			"invalid-component_0123456789ABCDEFFFFF"
+		};
+		for (const std::string& malformedIdentity : malformedIdentities)
+		{
+			YAML::Node malformedProperties(YAML::NodeType::Map);
+			malformedProperties["instanceId"] = malformedIdentity;
+			parsedIdentity = Parse(validIdentity);
+			diagnostic.clear();
+			Require(!Utils::TryGetComponentInstanceId(
+					MakeComponentReflection(malformedProperties),
+					parsedIdentity,
+					diagnostic),
+				"a component identity must be rejected when either embedded ID is invalid");
+			Require(parsedIdentity == InstanceId::Invalid,
+				"a rejected reflected identity must not leak a partially valid InstanceId");
+			Require(diagnostic.find("component and game-object IDs") != std::string::npos,
+				"malformed embedded IDs must produce the shared structural diagnostic");
+		}
+
+		YAML::Node missingProperties(YAML::NodeType::Map);
+		parsedIdentity = Parse(validIdentity);
+		Require(!Utils::TryGetComponentInstanceId(
+				MakeComponentReflection(missingProperties),
+				parsedIdentity,
+				diagnostic),
+			"a reflected component without instanceId must be rejected");
+		Require(diagnostic == "the reflected component has no instanceId",
+			"a missing component identity must produce the shared diagnostic");
+		Require(parsedIdentity == InstanceId::Invalid,
+			"a missing reflected identity must clear the output InstanceId");
+
+		YAML::Node invalidYamlProperties(YAML::NodeType::Map);
+		invalidYamlProperties["instanceId"]["nested"] = true;
+		parsedIdentity = Parse(validIdentity);
+		Require(!Utils::TryGetComponentInstanceId(
+				MakeComponentReflection(invalidYamlProperties),
+				parsedIdentity,
+				diagnostic),
+			"a non-scalar component instanceId must be rejected through the YAML exception boundary");
+		Require(diagnostic.find("the reflected component has an invalid instanceId") == 0,
+			"a YAML conversion failure must produce the shared invalid-identity diagnostic");
+		Require(parsedIdentity == InstanceId::Invalid,
+			"a failed YAML conversion must clear the output InstanceId");
+
+		ReflectedData invalidReflection;
+		parsedIdentity = Parse(validIdentity);
+		Require(!Utils::TryGetComponentInstanceId(
+				invalidReflection,
+				parsedIdentity,
+				diagnostic),
+			"an invalid reflected component must be rejected");
+		Require(diagnostic == "the reflected component is invalid",
+			"an invalid reflection must produce the shared diagnostic");
+		Require(parsedIdentity == InstanceId::Invalid,
+			"an invalid reflection must clear the output InstanceId");
+	}
 }
 
 int main()
@@ -138,6 +266,8 @@ int main()
 		{ "MalformedDirectGameObjectIdsAreRejected", TestMalformedDirectGameObjectIdsAreRejected },
 		{ "ComponentIdsResolveLegacyAndCanonicalParents", TestComponentIdsResolveLegacyAndCanonicalParents },
 		{ "MalformedComponentIdsAreRejected", TestMalformedComponentIdsAreRejected },
+		{ "YamlNodeEqualityIsStructuralAndMapOrderIndependent", TestYamlNodeEqualityIsStructuralAndMapOrderIndependent },
+		{ "ReflectedComponentIdentityUsesStrictSharedValidation", TestReflectedComponentIdentityUsesStrictSharedValidation },
 	};
 
 	for (const auto& test : tests)

--- a/Tests/InstanceIdContractTests.cpp
+++ b/Tests/InstanceIdContractTests.cpp
@@ -161,21 +161,164 @@ namespace
 			"{ name: Duck, transform: { enabled: true, position: [3, 2, 1] } }");
 		const YAML::Node changedValue = YAML::Load(
 			"{ name: Goose, transform: { enabled: true, position: [1, 2, 3] } }");
+		YAML::Node programmatic;
+		programmatic["name"] = "Duck";
+		programmatic["transform"]["enabled"] = true;
+		programmatic["transform"]["position"].push_back(1);
+		programmatic["transform"]["position"].push_back(2);
+		programmatic["transform"]["position"].push_back(3);
 
 		Require(Utils::AreYamlNodesEqual(lhs, reordered),
 			"YAML map equality must ignore insertion order at every nesting level");
+		Require(Utils::AreYamlNodesEqual(lhs, programmatic),
+			"semantic YAML equality must ignore parser-specific tags");
 		Require(!Utils::AreYamlNodesEqual(lhs, reorderedSequence),
 			"YAML sequence equality must preserve element order");
 		Require(!Utils::AreYamlNodesEqual(lhs, changedValue),
 			"YAML scalar changes must make structurally similar nodes unequal");
 
+		std::string canonicalLhs;
+		std::string canonicalReordered;
+		Require(Utils::CanonicalizeYaml(
+				lhs,
+				canonicalLhs,
+				Utils::EYamlCanonicalizationMode::SemanticValue),
+			"semantic YAML canonicalization must accept ordinary maps");
+		Require(Utils::CanonicalizeYaml(
+				reordered,
+				canonicalReordered,
+				Utils::EYamlCanonicalizationMode::SemanticValue),
+			"semantic YAML canonicalization must accept reordered maps");
+		Require(canonicalLhs == canonicalReordered,
+			"semantic YAML canonicalization must be map-order independent");
+
+		std::string strictCanonicalLhs;
+		std::string strictCanonicalReordered;
+		Require(Utils::CanonicalizeYaml(
+				lhs,
+				strictCanonicalLhs,
+				Utils::EYamlCanonicalizationMode::StrictDocument) &&
+			Utils::CanonicalizeYaml(
+				reordered,
+				strictCanonicalReordered,
+				Utils::EYamlCanonicalizationMode::StrictDocument) &&
+			strictCanonicalLhs == strictCanonicalReordered,
+			"strict YAML canonicalization must be map-order independent");
+
+		YAML::Node duplicateKeys(YAML::NodeType::Map);
+		duplicateKeys.force_insert("name", "Duck");
+		duplicateKeys.force_insert("name", "Duck");
+		std::string canonicalDuplicateKeys;
+		Require(Utils::CanonicalizeYaml(
+				duplicateKeys,
+				canonicalDuplicateKeys,
+				Utils::EYamlCanonicalizationMode::SemanticValue),
+			"semantic YAML canonicalization must preserve duplicate pairs");
+		Require(!Utils::CanonicalizeYaml(
+				duplicateKeys,
+				canonicalDuplicateKeys,
+				Utils::EYamlCanonicalizationMode::StrictDocument),
+			"strict YAML canonicalization must reject duplicate keys");
+
+		YAML::Node nestedDuplicateKeys(YAML::NodeType::Map);
+		nestedDuplicateKeys.force_insert("name", "Duck");
+		nestedDuplicateKeys.force_insert("name", "Goose");
+		YAML::Node nestedDuplicateDocument;
+		nestedDuplicateDocument["object"] = nestedDuplicateKeys;
+		Require(!Utils::CanonicalizeYaml(
+				nestedDuplicateDocument,
+				canonicalDuplicateKeys,
+				Utils::EYamlCanonicalizationMode::StrictDocument),
+			"strict YAML canonicalization must reject nested duplicate keys");
+
+		YAML::Node taggedAsset("Duck");
+		taggedAsset.SetTag("!asset");
+		YAML::Node taggedModel("Duck");
+		taggedModel.SetTag("!model");
+		Require(Utils::AreYamlNodesEqual(taggedAsset, taggedModel),
+			"semantic YAML equality must ignore explicit tags");
+		std::string canonicalTaggedAsset;
+		std::string canonicalTaggedModel;
+		Require(Utils::CanonicalizeYaml(
+				taggedAsset,
+				canonicalTaggedAsset,
+				Utils::EYamlCanonicalizationMode::StrictDocument) &&
+			Utils::CanonicalizeYaml(
+				taggedModel,
+				canonicalTaggedModel,
+				Utils::EYamlCanonicalizationMode::StrictDocument) &&
+			canonicalTaggedAsset != canonicalTaggedModel,
+			"strict YAML canonicalization must preserve explicit tags");
+
+		std::string deepYaml;
+		for (size_t depth = 0; depth < 66; ++depth)
+		{
+			deepYaml += "{ child: ";
+		}
+		deepYaml += "Duck";
+		deepYaml.append(66, '}');
+		const YAML::Node deepNode = YAML::Load(deepYaml);
+		const YAML::Node clonedDeepNode = YAML::Clone(deepNode);
+		Require(Utils::AreYamlNodesEqual(deepNode, clonedDeepNode),
+			"semantic YAML equality must preserve the previous unbounded value semantics");
+		Require(!Utils::CanonicalizeYaml(
+				deepNode,
+				canonicalLhs,
+				Utils::EYamlCanonicalizationMode::StrictDocument),
+			"strict YAML canonicalization must enforce its depth limit");
+
 		const YAML::Node undefined(YAML::NodeType::Undefined);
 		const YAML::Node anotherUndefined(YAML::NodeType::Undefined);
 		const YAML::Node nullNode(YAML::NodeType::Null);
+		const YAML::Node emptyMap = YAML::Load("{}");
+		const YAML::Node anotherEmptyMap = YAML::Load("{}");
+		const YAML::Node missing = emptyMap["missing"];
+		const YAML::Node anotherMissing = anotherEmptyMap["missing"];
 		Require(Utils::AreYamlNodesEqual(undefined, anotherUndefined),
 			"two undefined YAML nodes must compare equal");
+		Require(Utils::AreYamlNodesEqual(missing, anotherMissing),
+			"invalid nodes from missing const lookups must compare as undefined");
 		Require(!Utils::AreYamlNodesEqual(undefined, nullNode),
 			"undefined and explicit null YAML nodes must remain distinct");
+	}
+
+	void TestReflectedDataEqualityUsesSemanticYamlValues()
+	{
+		const std::string componentId =
+			"FFF4417DA65649588B6B279D47D0EC3E_0123456789ABCDEFFFFF";
+		const YAML::Node lhsProperties = YAML::Load(
+			"{ instanceId: " + componentId +
+			", settings: { enabled: true, values: [1, 2, 3] } }");
+		YAML::Node equivalentProperties;
+		equivalentProperties["settings"]["values"].push_back(1);
+		equivalentProperties["settings"]["values"].push_back(2);
+		equivalentProperties["settings"]["values"].push_back(3);
+		equivalentProperties["settings"]["enabled"] = true;
+		equivalentProperties["instanceId"] = componentId;
+		const YAML::Node changedProperties = YAML::Load(
+			"{ instanceId: " + componentId +
+			", settings: { enabled: false, values: [1, 2, 3] } }");
+
+		const ReflectedData lhs = MakeComponentReflection(lhsProperties);
+		const ReflectedData equivalent =
+			MakeComponentReflection(equivalentProperties);
+		const ReflectedData changed =
+			MakeComponentReflection(changedProperties);
+
+		Require(lhs == equivalent,
+			"reflected equality must compare YAML values instead of node identity");
+		Require(!(lhs == changed),
+			"reflected equality must reject changed YAML values");
+		Require(lhs.DiffTo(equivalent).GetProperties().Num() == 0,
+			"reflected diff must omit independently allocated equal YAML values");
+		const ReflectedData changedDiff = lhs.DiffTo(changed);
+		Require(changedDiff.GetProperties().Num() == 1 &&
+				changedDiff.GetProperties().ContainsKey("settings"),
+			"reflected diff must retain only structurally changed YAML values");
+		Require(Utils::AreYamlNodesEqual(
+				changedDiff.GetProperties()["settings"],
+				lhs.GetProperties()["settings"]),
+			"reflected diff must retain the changed property's YAML value");
 	}
 
 	void TestReflectedComponentIdentityUsesStrictSharedValidation()
@@ -267,6 +410,7 @@ int main()
 		{ "ComponentIdsResolveLegacyAndCanonicalParents", TestComponentIdsResolveLegacyAndCanonicalParents },
 		{ "MalformedComponentIdsAreRejected", TestMalformedComponentIdsAreRejected },
 		{ "YamlNodeEqualityIsStructuralAndMapOrderIndependent", TestYamlNodeEqualityIsStructuralAndMapOrderIndependent },
+		{ "ReflectedDataEqualityUsesSemanticYamlValues", TestReflectedDataEqualityUsesSemanticYamlValues },
 		{ "ReflectedComponentIdentityUsesStrictSharedValidation", TestReflectedComponentIdentityUsesStrictSharedValidation },
 	};
 

--- a/Tests/RemoteViewportRuntimeTests.cpp
+++ b/Tests/RemoteViewportRuntimeTests.cpp
@@ -620,6 +620,70 @@ namespace
 				"Runtime/Submodules/EditorRemote/RemoteViewportMacNativeBridge.mm");
 
 		RequireRemoteViewportBindingLockOrder(bridgeSource);
+		const size_t enginePumpBegin = bridgeSource.find(
+			"void Sailor::EditorRuntime::PumpEditorRemoteViewportsOnEngineThread()");
+		const size_t setViewportBegin = bridgeSource.find(
+			"void App::SetEditorViewport(",
+			enginePumpBegin);
+		Require(
+			enginePumpBegin != std::string::npos &&
+				setViewportBegin > enginePumpBegin,
+			"engine-owned remote viewport pump source must be bounded");
+		const std::string enginePumpBody = bridgeSource.substr(
+			enginePumpBegin,
+			setViewportBegin - enginePumpBegin);
+		const size_t schedulerLookup = enginePumpBody.find(
+			"App::GetSubmodule<Tasks::Scheduler>()");
+		const size_t mainThreadGuard = enginePumpBody.find(
+			"if (!scheduler || !scheduler->IsMainThread())",
+			schedulerLookup);
+		const size_t pumpBinding = enginePumpBody.find(
+			"binding->Pump();",
+			mainThreadGuard);
+		Require(
+			schedulerLookup != std::string::npos &&
+				mainThreadGuard > schedulerLookup &&
+				pumpBinding > mainThreadGuard &&
+				CountOccurrences(enginePumpBody, "binding->Pump();") == 1,
+			"remote viewport frame acquisition must be release-guarded and pumped exactly once from the engine main thread");
+
+		const size_t upsertViewportBegin = bridgeSource.find(
+			"bool App::UpsertEditorRemoteViewport(",
+			setViewportBegin);
+		const size_t destroyViewportBegin = bridgeSource.find(
+			"bool App::DestroyEditorRemoteViewport(",
+			upsertViewportBegin);
+		Require(
+			upsertViewportBegin != std::string::npos &&
+				destroyViewportBegin > upsertViewportBegin,
+			"remote viewport upsert source must be bounded");
+		const std::string upsertViewportBody = bridgeSource.substr(
+			upsertViewportBegin,
+			destroyViewportBegin - upsertViewportBegin);
+		Require(
+			upsertViewportBody.find("binding->Pump();") ==
+				std::string::npos,
+			"protocol-thread viewport upsert must defer frame acquisition to the engine main-thread pump");
+
+		const size_t retryViewportBegin = bridgeSource.find(
+			"bool App::RetryEditorRemoteViewport(",
+			destroyViewportBegin);
+		const size_t setMacHostBeginForPumpContract = bridgeSource.find(
+			"bool App::SetEditorRemoteViewportMacHostHandle(",
+			retryViewportBegin);
+		Require(
+			retryViewportBegin != std::string::npos &&
+				setMacHostBeginForPumpContract > retryViewportBegin,
+			"remote viewport retry source must be bounded");
+		const std::string retryViewportBody = bridgeSource.substr(
+			retryViewportBegin,
+			setMacHostBeginForPumpContract - retryViewportBegin);
+		Require(
+			retryViewportBody.find("binding->Pump();") ==
+				std::string::npos &&
+				CountOccurrences(bridgeSource, "binding->Pump();") == 1,
+			"protocol-thread viewport retry must defer frame acquisition and the engine main-thread boundary must remain the sole binding pump owner");
+
 		const size_t bindNativeLayerBegin = macNativeBridgeSource.find(
 			"Failure BindMacNativeLayer(");
 		const size_t bindNativeLayerEnd = macNativeBridgeSource.find(
@@ -896,8 +960,8 @@ namespace
 		const std::string selectedGizmoBody = gameObjectSource.substr(selectedGizmoBegin, selectedGizmoEnd - selectedGizmoBegin);
 		Require(selectedGizmoBody.find("if (bUsesMeshBounds)") != std::string::npos &&
 			selectedGizmoBody.find("DrawAABB(selectionBounds, selectionColor)") != std::string::npos &&
-			selectedGizmoBody.find("DrawSphere(selectionBounds.GetCenter(), 1.0f, selectionColor)") != std::string::npos,
-			"selected empty GameObjects must draw a unit center sphere without changing mesh selection bounds");
+			selectedGizmoBody.find("DrawSphere(selectionBounds.GetCenter(), 10.0f, selectionColor)") != std::string::npos,
+			"selected empty GameObjects must draw a radius-10 center sphere without changing mesh selection bounds");
 		const size_t viewportTickBegin = viewportControllerSource.find("void EditorViewportController::Tick(World& world)");
 		const size_t viewportResetBegin = viewportControllerSource.find("void EditorViewportController::Reset()", viewportTickBegin);
 		Require(viewportTickBegin != std::string::npos && viewportResetBegin > viewportTickBegin &&


### PR DESCRIPTION
## What changed

- Replaced the bespoke model-drop creation RPC with the existing generic editor operations: create a GameObject, add a MeshRenderer, commit its fields, optionally reparent it, and verify the authoritative world projection. Undo and rollback now own canonical GameObject/component IDs and reconcile lost, rejected, partial, and already-applied mutations.
- Generalized viewport placement to `TraceViewportRay`, reserved the removed protocol fields, and synchronized the checked-in C# and C++ protobuf outputs.
- Made the live prefab root `FileId` authoritative while keeping prefab-instance metadata derived. Nested prefab loading, overrides, strict component InstanceIds, break-link behavior, world save validation, and snapshot restoration now share stricter contracts and reject inconsistent state atomically.
- Centralized structural YAML comparison and reflected component InstanceId parsing in the existing runtime utilities.
- Stabilized Hierarchy and Content interaction: single-click selection, select-before-focus, identity-based Content row reconciliation, exception-safe async UI actions, prefab delete/save flows, and a new `Select Prefab` context action that opens and selects the source asset in Content.
- Kept camera input flowing through editor shortcuts, increased the selected empty-GameObject marker radius to 10, and constrained remote viewport frame pumping to the engine main thread.

## Why

The previous implementation split authority across specialized RPCs, transient editor projections, and derived prefab caches. That made partial mutations difficult to undo, allowed malformed or stale prefab state to survive until save/load, and duplicated functionality already available through the editor command protocol. Remote viewport setup could also pump rendering work from the protocol thread while asset reload replaced frame-graph resources, causing the prefab-save crash observed during live testing.

## Impact

Model and prefab workflows now use reusable protocol primitives, carry stable ownership through undo/redo, and fail before publishing ambiguous state. Hierarchy and Content selection no longer depend on destructive collection resets, linked objects can navigate directly to their prefab asset, and rendering resources have a single thread owner during editor communication.

## Validation

- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --no-restore --verbosity minimal` — 693/693 passed.
- Release native contract build plus CTest for `EcsLifecycleContractTests`, `EditorViewportControllerContractTests`, `InstanceIdContractTests`, and `RemoteViewportRuntimeTests` — 4/4 executables passed (73 focused contract cases).
- Checked-in C# and C++ protobuf outputs match fresh generated outputs.
- `python3 build_editor.py --config Release --runtime maccatalyst-arm64` — succeeded.
- Release editor startup and local WebSocket transport verified.
- Prefab save/overwrite smoke completed without the previous crash.
- `git diff --check` — clean.