### PR TITLE
Fix ranged inspector slider and component drag handling

### DIFF
--- a/Editor.Tests/NumericRangeEditorInteractionTests.cs
+++ b/Editor.Tests/NumericRangeEditorInteractionTests.cs
@@ -18,6 +18,7 @@ public sealed class NumericRangeEditorInteractionTests
         interaction.EndModelSynchronization();
 
         Assert.Equal(10, displayedValue);
+        Assert.False(decision.ShouldPreview);
         Assert.False(decision.ShouldApply);
         Assert.Equal(25, loadedModelValue);
     }
@@ -33,11 +34,72 @@ public sealed class NumericRangeEditorInteractionTests
         var secondChange = interaction.HandleValueChanged(8);
         var completed = interaction.EndDrag();
 
+        Assert.True(firstChange.ShouldPreview);
         Assert.False(firstChange.ShouldApply);
+        Assert.Equal(4, firstChange.Value);
+        Assert.True(secondChange.ShouldPreview);
         Assert.False(secondChange.ShouldApply);
+        Assert.Equal(8, secondChange.Value);
+        Assert.True(completed.ShouldPreview);
         Assert.True(completed.ShouldApply);
         Assert.Equal(8, completed.Value);
-        Assert.False(interaction.EndDrag().ShouldApply);
+        var duplicateCompletion = interaction.EndDrag();
+        Assert.False(duplicateCompletion.ShouldPreview);
+        Assert.False(duplicateCompletion.ShouldApply);
+    }
+
+    [Fact]
+    public void Drag_PreviewsEveryDisplayedValueWithoutWritingTheModelUntilCompletion()
+    {
+        var interaction = new NumericRangeSliderInteraction(
+            new NumericPropertyRange(0, 10));
+        var previewValues = new List<double>();
+        var modelWrites = new List<double>();
+
+        void Dispatch(NumericRangeSliderDecision decision)
+        {
+            if (decision.ShouldPreview)
+                previewValues.Add(decision.Value);
+
+            if (decision.ShouldApply)
+                modelWrites.Add(decision.Value);
+        }
+
+        interaction.BeginDrag(2);
+        Dispatch(interaction.HandleValueChanged(4));
+        Dispatch(interaction.HandleValueChanged(8));
+
+        Assert.Equal([4, 8], previewValues);
+        Assert.Empty(modelWrites);
+
+        Dispatch(interaction.EndDrag());
+
+        Assert.Equal([4, 8, 8], previewValues);
+        Assert.Equal([8], modelWrites);
+    }
+
+    [Fact]
+    public void ExternalModelSynchronizationDuringDrag_ReplacesThePendingValue()
+    {
+        var interaction = new NumericRangeSliderInteraction(
+            new NumericPropertyRange(0, 10));
+
+        interaction.BeginDrag(2);
+        var preview = interaction.HandleValueChanged(8);
+
+        var displayedValue = interaction.BeginModelSynchronization(4);
+        var synchronizationDecision = interaction.HandleValueChanged(displayedValue);
+        interaction.EndModelSynchronization();
+        var completed = interaction.EndDrag();
+
+        Assert.True(preview.ShouldPreview);
+        Assert.False(preview.ShouldApply);
+        Assert.Equal(4, displayedValue);
+        Assert.False(synchronizationDecision.ShouldPreview);
+        Assert.False(synchronizationDecision.ShouldApply);
+        Assert.True(completed.ShouldPreview);
+        Assert.True(completed.ShouldApply);
+        Assert.Equal(4, completed.Value);
     }
 
     [Fact]
@@ -48,6 +110,7 @@ public sealed class NumericRangeEditorInteractionTests
 
         var decision = interaction.HandleValueChanged(7);
 
+        Assert.True(decision.ShouldPreview);
         Assert.True(decision.ShouldApply);
         Assert.Equal(7, decision.Value);
     }
@@ -59,6 +122,7 @@ public sealed class NumericRangeEditorInteractionTests
             new NumericPropertyRange(0, 10));
 
         var decision = interaction.HandleValueChanged(9.4);
+        Assert.True(decision.ShouldPreview);
         Assert.True(decision.ShouldApply);
 
         var unchangedModelValue = 9;
@@ -67,6 +131,7 @@ public sealed class NumericRangeEditorInteractionTests
         interaction.EndModelSynchronization();
 
         Assert.Equal(9, displayedValue);
+        Assert.False(synchronizationDecision.ShouldPreview);
         Assert.False(synchronizationDecision.ShouldApply);
     }
 

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -634,6 +634,86 @@ public sealed class WorkflowProjectionTests
     }
 
     [Fact]
+    public void ComponentDragGesture_IsScopedToTheNameAndDoesNotCapturePropertyEditors()
+    {
+        var componentTemplateSource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "InspectorView",
+            "ComponentTemplate.cs");
+
+        Assert.Contains(
+            "nameLabel.GestureRecognizers.Add(dragGesture);",
+            componentTemplateSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "props.GestureRecognizers.Add(dragGesture);",
+            componentTemplateSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "header.GestureRecognizers.Add(dragGesture);",
+            componentTemplateSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "dragArgs.Data.Properties[EditorDragDrop.DragItemKey] = component;",
+            componentTemplateSource,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RangedNumericEditors_PreviewSliderValuesWithoutApplyingEntrySetters()
+    {
+        var templatesSource = ReadRepositoryFile(
+            "Editor",
+            "Utility",
+            "Templates.cs");
+
+        var rangedEditors = new[]
+        {
+            Slice(
+                templatesSource,
+                "public static View RangedFloatEditor<TBindingContext>(",
+                "public static View IntEditor<TBindingContext>("),
+            Slice(
+                templatesSource,
+                "public static View RangedIntEditor<TBindingContext>(",
+                "public static View UIntEditor<TBindingContext>("),
+            Slice(
+                templatesSource,
+                "public static View RangedUIntEditor<TBindingContext>(",
+                "static Slider CreateRangeSlider<TBindingContext, TValue>(")
+        };
+
+        foreach (var rangedEditor in rangedEditors)
+        {
+            AssertInOrder(
+                rangedEditor,
+                "var isSynchronizingPreview = false;",
+                "var exactValueEditor = Create",
+                "if (!isSynchronizingPreview)",
+                "previewValue =>",
+                "isSynchronizingPreview = true;",
+                "exactValueEditor.Text = NumericRangeEntryInteraction.Format(previewValue);",
+                "finally",
+                "isSynchronizingPreview = false;");
+        }
+
+        var rangeSlider = Slice(
+            templatesSource,
+            "static Slider CreateRangeSlider<TBindingContext, TValue>(",
+            "static Grid CreateRangedNumericEditor(Slider slider, View exactValueEditor)");
+        AssertInOrder(
+            rangeSlider,
+            "if (decision.ShouldPreview)",
+            "previewValueChanged(convertSliderValue(decision.Value));",
+            "if (decision.ShouldApply",
+            "setter(bindingContext, convertSliderValue(decision.Value));",
+            "var actualValue = getValue(bindingContext);",
+            "previewValueChanged(actualValue);",
+            "current.SynchronizeFromModel(");
+    }
+
+    [Fact]
     public void WorldProjectionRefresh_DropsStaleSelectionBeforePublishing()
     {
         var worldSource = ReadRepositoryFile("Editor", "Services", "WorldService.cs");

--- a/Editor/Utility/NumericRangeEditorInteraction.cs
+++ b/Editor/Utility/NumericRangeEditorInteraction.cs
@@ -5,11 +5,16 @@ using SailorEngine;
 
 namespace SailorEditor.Utility;
 
-public readonly record struct NumericRangeSliderDecision(bool ShouldApply, double Value)
+public readonly record struct NumericRangeSliderDecision(
+    bool ShouldPreview,
+    bool ShouldApply,
+    double Value)
 {
-    public static NumericRangeSliderDecision None { get; } = new(false, 0);
+    public static NumericRangeSliderDecision None { get; } = new(false, false, 0);
 
-    public static NumericRangeSliderDecision Apply(double value) => new(true, value);
+    public static NumericRangeSliderDecision Preview(double value) => new(true, false, value);
+
+    public static NumericRangeSliderDecision Apply(double value) => new(true, true, value);
 }
 
 public sealed class NumericRangeSliderInteraction
@@ -27,7 +32,11 @@ public sealed class NumericRangeSliderInteraction
     public double BeginModelSynchronization(double modelValue)
     {
         modelSynchronizationDepth++;
-        return range.Clamp(modelValue);
+        var displayedValue = range.Clamp(modelValue);
+        if (isDragging)
+            pendingDragValue = displayedValue;
+
+        return displayedValue;
     }
 
     public void EndModelSynchronization()
@@ -53,7 +62,7 @@ public sealed class NumericRangeSliderInteraction
         if (isDragging)
         {
             pendingDragValue = clampedValue;
-            return NumericRangeSliderDecision.None;
+            return NumericRangeSliderDecision.Preview(clampedValue);
         }
 
         return NumericRangeSliderDecision.Apply(clampedValue);

--- a/Editor/Utility/Templates.cs
+++ b/Editor/Utility/Templates.cs
@@ -467,16 +467,35 @@ static class Templates
         NumericPropertyRange range)
         where TBindingContext : class
     {
+        var isSynchronizingPreview = false;
+        var exactValueEditor = CreateFloatEditor(
+            getter,
+            (bindingContext, value) =>
+            {
+                if (!isSynchronizingPreview)
+                    setter(bindingContext, range.Clamp(value));
+            },
+            normalizeOnUnfocus: true);
+
         return CreateRangedNumericEditor(
             CreateRangeSlider(
                 getter,
                 setter,
                 range,
-                value => (float)value),
-            CreateFloatEditor(
-                getter,
-                (bindingContext, value) => setter(bindingContext, range.Clamp(value)),
-                normalizeOnUnfocus: true));
+                value => (float)value,
+                previewValue =>
+                {
+                    isSynchronizingPreview = true;
+                    try
+                    {
+                        exactValueEditor.Text = NumericRangeEntryInteraction.Format(previewValue);
+                    }
+                    finally
+                    {
+                        isSynchronizingPreview = false;
+                    }
+                }),
+            exactValueEditor);
     }
 
     public static View IntEditor<TBindingContext>(Expression<Func<TBindingContext, int>> getter, Action<TBindingContext, int> setter)
@@ -519,16 +538,35 @@ static class Templates
         NumericPropertyRange range)
         where TBindingContext : class
     {
+        var isSynchronizingPreview = false;
+        var exactValueEditor = CreateIntEditor(
+            getter,
+            (bindingContext, value) =>
+            {
+                if (!isSynchronizingPreview)
+                    setter(bindingContext, range.Clamp(value));
+            },
+            normalizeOnUnfocus: true);
+
         return CreateRangedNumericEditor(
             CreateRangeSlider(
                 getter,
                 setter,
                 range,
-                range.SnapInt32),
-            CreateIntEditor(
-                getter,
-                (bindingContext, value) => setter(bindingContext, range.Clamp(value)),
-                normalizeOnUnfocus: true));
+                range.SnapInt32,
+                previewValue =>
+                {
+                    isSynchronizingPreview = true;
+                    try
+                    {
+                        exactValueEditor.Text = NumericRangeEntryInteraction.Format(previewValue);
+                    }
+                    finally
+                    {
+                        isSynchronizingPreview = false;
+                    }
+                }),
+            exactValueEditor);
     }
 
     public static View UIntEditor<TBindingContext>(Expression<Func<TBindingContext, uint>> getter, Action<TBindingContext, uint> setter)
@@ -571,23 +609,43 @@ static class Templates
         NumericPropertyRange range)
         where TBindingContext : class
     {
+        var isSynchronizingPreview = false;
+        var exactValueEditor = CreateUIntEditor(
+            getter,
+            (bindingContext, value) =>
+            {
+                if (!isSynchronizingPreview)
+                    setter(bindingContext, range.Clamp(value));
+            },
+            normalizeOnUnfocus: true);
+
         return CreateRangedNumericEditor(
             CreateRangeSlider(
                 getter,
                 setter,
                 range,
-                range.SnapUInt32),
-            CreateUIntEditor(
-                getter,
-                (bindingContext, value) => setter(bindingContext, range.Clamp(value)),
-                normalizeOnUnfocus: true));
+                range.SnapUInt32,
+                previewValue =>
+                {
+                    isSynchronizingPreview = true;
+                    try
+                    {
+                        exactValueEditor.Text = NumericRangeEntryInteraction.Format(previewValue);
+                    }
+                    finally
+                    {
+                        isSynchronizingPreview = false;
+                    }
+                }),
+            exactValueEditor);
     }
 
     static Slider CreateRangeSlider<TBindingContext, TValue>(
         Expression<Func<TBindingContext, TValue>> getter,
         Action<TBindingContext, TValue> setter,
         NumericPropertyRange range,
-        Func<double, TValue> convertSliderValue)
+        Func<double, TValue> convertSliderValue,
+        Action<TValue> previewValueChanged)
         where TBindingContext : class
     {
         var slider = new NumericRangeSlider(range);
@@ -595,13 +653,18 @@ static class Templates
 
         void ApplyDecision(NumericRangeSlider current, NumericRangeSliderDecision decision)
         {
+            if (decision.ShouldPreview)
+                previewValueChanged(convertSliderValue(decision.Value));
+
             if (decision.ShouldApply &&
                 current.BindingContext is TBindingContext bindingContext)
             {
                 setter(bindingContext, convertSliderValue(decision.Value));
+                var actualValue = getValue(bindingContext);
+                previewValueChanged(actualValue);
                 current.SynchronizeFromModel(
                     System.Convert.ToDouble(
-                        getValue(bindingContext),
+                        actualValue,
                         System.Globalization.CultureInfo.InvariantCulture));
             }
         }

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -44,12 +44,6 @@ public class ComponentTemplate : DataTemplate
                 props.RowDefinitions.Clear();
 
                 props.GestureRecognizers.Clear();
-                var dragGesture = new DragGestureRecognizer();
-                dragGesture.DragStarting += (dragSender, dragArgs) =>
-                {
-                    dragArgs.Data.Properties[EditorDragDrop.DragItemKey] = component;
-                };
-                props.GestureRecognizers.Add(dragGesture);
 
                 var header = new Grid
                 {
@@ -79,6 +73,13 @@ public class ComponentTemplate : DataTemplate
                 var nameLabel = new Label { Text = "DisplayName", VerticalOptions = LayoutOptions.Center, HorizontalTextAlignment = TextAlignment.Start, FontAttributes = FontAttributes.Bold };
                 nameLabel.Behaviors.Add(new DisplayNameBehavior());
                 nameLabel.Text = FormatComponentTypeName(component.Typename.Name);
+
+                var dragGesture = new DragGestureRecognizer();
+                dragGesture.DragStarting += (dragSender, dragArgs) =>
+                {
+                    dragArgs.Data.Properties[EditorDragDrop.DragItemKey] = component;
+                };
+                nameLabel.GestureRecognizers.Add(dragGesture);
 
                 var worldService = MauiProgram.GetService<WorldService>();
                 var contextMenuService = MauiProgram.GetService<EditorContextMenuService>();


### PR DESCRIPTION
## Summary

- Scope component drag-and-drop to the component name so ranged property controls receive pointer input.
- Preview `float`, `int`, and `uint` slider values in the exact numeric field while dragging.
- Keep model updates and undo history to one write when the drag completes.
- Resynchronize both controls from the actual model value after applying a change and avoid stale drag completion after external model synchronization.
- Add focused interaction and source-contract regression coverage.

## Root cause

The component drag recognizer was attached to the entire component property grid, so pointer interaction on a range slider could start component drag-and-drop. The range interaction correctly deferred model writes until drag completion, but it had no separate visual-preview path for the exact value field.

## User impact

Range sliders can now be dragged normally, the exact value shown to the right updates live, and a drag still produces only one model/undo update at completion.

## Validation

- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --configuration Release --no-restore` — 711/711 passed.
- `python3 run_editor.py --skip-engine --config Debug --no-launch` — MacCatalyst Debug build completed with 0 errors.
- Manual macOS validation — slider dragging works and the exact numeric field updates live.
- `git diff HEAD^ HEAD --check` — clean.

## Risk

Low and localized to inspector component gesture routing and ranged numeric editors. Existing out-of-range model values remain preserved in the exact field while only the slider display is clamped.