### PR TITLE
Fix SkyComponent contract test linkage

### DIFF
--- a/.github/vcpkg-ports/tinygltf/portfile.cmake
+++ b/.github/vcpkg-ports/tinygltf/portfile.cmake
@@ -1,0 +1,15 @@
+# Header-only library
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO syoyo/tinygltf
+    REF 26422192e2908a562b641175dde18489824e609e # v2.9.6
+    SHA512 ff80b49c01c4b1ad636e5c5651c5bd04ee3058cc068f0858ebe401c113aeeadb3db43bac7f987b6a2073d8cbe5de65da28e909fb5041839127695ddcd960295d
+    HEAD_REF master
+)
+
+# Put the licence file where vcpkg expects it
+# Copy the tinygltf header files and fix the path to json
+vcpkg_replace_string("${SOURCE_PATH}/tiny_gltf.h" "#include \"json.hpp\"" "#include <nlohmann/json.hpp>")
+file(INSTALL "${SOURCE_PATH}/tiny_gltf.h" DESTINATION "${CURRENT_PACKAGES_DIR}/include")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/.github/vcpkg-ports/tinygltf/vcpkg.json
+++ b/.github/vcpkg-ports/tinygltf/vcpkg.json
@@ -1,0 +1,10 @@
+{
+  "name": "tinygltf",
+  "version": "2.9.6",
+  "description": "A header only C++11 glTF 2.0 library.",
+  "homepage": "https://github.com/syoyo/tinygltf",
+  "dependencies": [
+    "nlohmann-json",
+    "stb"
+  ]
+}

--- a/Runtime/FrameGraph/SkyNode.h
+++ b/Runtime/FrameGraph/SkyNode.h
@@ -72,7 +72,7 @@ namespace Sailor::Framegraph
 			mat4 m_starsModelView{};
 		};
 
-		void ConsumePendingSkyParams();
+		SAILOR_API void ConsumePendingSkyParams();
 
 		mutable SpinLock m_skyParamsLock;
 		SkyParameters m_skyParams{};


### PR DESCRIPTION
## What changed

- Export `SkyNode::ConsumePendingSkyParams()` from the Runtime DLL.
- Add a Windows vcpkg overlay for `tinygltf 2.9.6`, pinned to the verified release commit archive.

## Why

`SkyComponentContractTests` exposes the protected mailbox consumer through a test subclass. The out-of-line method was present in `SailorLib` but absent from the Windows import library, causing MSVC `LNK2019` and clang-cl/lld undefined-symbol failures.

During validation, GitHub changed the generated `v2.9.6` tag archive checksum. The overlay keeps the same source tree and API while pinning the full upstream commit and its verified archive hash.

## Validation

- Release build of `SkyComponentContractTests`
- `ctest -C Release -R '^SkyComponentContractTests$' --output-on-failure`
- Isolated vcpkg installation of the `tinygltf` overlay
- `git diff --check`
