### PR TITLE
Harden asset import, targeted updates, and Vulkan frame resources

### DIFF
--- a/Content/DefaultRenderer.renderer
+++ b/Content/DefaultRenderer.renderer
@@ -375,13 +375,6 @@ frame:
 #  - src: Secondary
 #  - dst: BackBuffer
 
-############################
-- name: Blit
-############################
-  renderTargets:
-  - src: Main
-  - dst: EditorOutput
-
 #############################
 #- name: PostProcess
 #############################
@@ -399,8 +392,15 @@ frame:
 - name: DebugDraw
 ############################
   renderTargets:
-  - color: EditorOutput
+  - color: Main
   - depthStencil: DepthBuffer
+
+############################
+- name: Blit
+############################
+  renderTargets:
+  - src: Main
+  - dst: EditorOutput
 
 #############################
 - name: RenderImGui

--- a/Content/DefaultRenderer.renderer
+++ b/Content/DefaultRenderer.renderer
@@ -35,6 +35,7 @@ renderTargets:
   width: ViewportWidth
   height: ViewportHeight
   bIsSurface: false
+  bGenerateMips: true
 
 - name: EditorOutput
   format: B8G8R8A8_UNORM
@@ -304,11 +305,27 @@ frame:
   - depthHighZ: DepthHighZ
 
 ############################
-- name: DebugDraw
+- name: Blit
 ############################
+  string:
+  - GenerateMips: true
+  renderTargets:
+  - src: Main
+  - dst: Secondary
+
+############################
+- name: RenderScene
+############################
+  string:
+  - Tag: Transparent
+  - Sorting: BackToFront
+  - GPUCulling: false
   renderTargets:
   - color: Main
   - depthStencil: DepthBuffer
+  - depthHighZ: DepthHighZ
+  - transmissionFramebuffer: Secondary
+
   
 ##############################
 - name: Bloom
@@ -350,7 +367,7 @@ frame:
   - color: Main
   - depthSampler: DepthBuffer
   - colorSampler: Secondary
-  
+
 #############################
 #- name: Blit
 #############################
@@ -377,6 +394,13 @@ frame:
 #  - color: BackBuffer
 #  - depthStencil: DepthBuffer
 #  - colorSampler: Secondary
+
+############################
+- name: DebugDraw
+############################
+  renderTargets:
+  - color: EditorOutput
+  - depthStencil: DepthBuffer
 
 #############################
 - name: RenderImGui

--- a/Content/EditorRenderer.renderer
+++ b/Content/EditorRenderer.renderer
@@ -379,13 +379,6 @@ frame:
 #  - src: Secondary
 #  - dst: BackBuffer
 
-############################
-- name: Blit
-############################
-  renderTargets:
-  - src: Main
-  - dst: EditorOutput
-
 #############################
 #- name: PostProcess
 #############################
@@ -403,8 +396,15 @@ frame:
 - name: DebugDraw
 ############################
   renderTargets:
-  - color: EditorOutput
+  - color: Main
   - depthStencil: DepthBuffer
+
+############################
+- name: Blit
+############################
+  renderTargets:
+  - src: Main
+  - dst: EditorOutput
 
 #############################
 - name: RenderImGui

--- a/Content/EditorRenderer.renderer
+++ b/Content/EditorRenderer.renderer
@@ -40,6 +40,7 @@ renderTargets:
   width: ViewportWidth
   height: ViewportHeight
   bIsSurface: false
+  bGenerateMips: true
 
 - name: EditorOutput
   format: B8G8R8A8_UNORM
@@ -309,12 +310,27 @@ frame:
   - depthHighZ: DepthHighZ
 
 ############################
-- name: DebugDraw
+- name: Blit
 ############################
+  string:
+  - GenerateMips: true
+  renderTargets:
+  - src: Main
+  - dst: Secondary
+
+############################
+- name: RenderScene
+############################
+  string:
+  - Tag: Transparent
+  - Sorting: BackToFront
+  - GPUCulling: false
   renderTargets:
   - color: Main
   - depthStencil: DepthBuffer
-  
+  - depthHighZ: DepthHighZ
+  - transmissionFramebuffer: Secondary
+
 ##############################
 - name: Bloom
 ##############################
@@ -382,6 +398,13 @@ frame:
 #  - color: BackBuffer
 #  - depthStencil: DepthBuffer
 #  - colorSampler: Secondary
+
+############################
+- name: DebugDraw
+############################
+  renderTargets:
+  - color: EditorOutput
+  - depthStencil: DepthBuffer
 
 #############################
 - name: RenderImGui

--- a/Content/Shaders/ComputeDepthHighZ.shader
+++ b/Content/Shaders/ComputeDepthHighZ.shader
@@ -9,7 +9,7 @@ glslCompute: |
   // Inspired by https://vkguide.dev/docs/gpudriven/compute_culling/
 
   layout(set = 0, binding = 0) uniform sampler2D inputDepth;
-  layout(set = 0, binding = 1, rgba16f) uniform writeonly image2D outputDepth;
+  layout(set = 0, binding = 1, r32f) uniform writeonly image2D outputDepth;
   
   layout(std430, push_constant) uniform Constants
   {
@@ -21,9 +21,29 @@ glslCompute: |
   layout(local_size_x = GROUP_SIZE, local_size_y = GROUP_SIZE) in;
   void main()
   {
-    uvec2 pos = gl_GlobalInvocationID.xy;
-    
-    // Sampler is set up to do min reduction, so this computes the minimum depth of a 2x2 texel quad
-    float depth = texture(inputDepth, (vec2(pos) + vec2(0.5)) / PushConstants.outputSize).x;
-    imageStore(outputDepth, ivec2(pos), vec4(depth));
+    ivec2 pos = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 outputSize = min(ivec2(PushConstants.outputSize), imageSize(outputDepth));
+
+    if (any(greaterThanEqual(pos, outputSize)))
+    {
+      return;
+    }
+
+    ivec2 inputSize = textureSize(inputDepth, 0);
+    ivec2 sourceBegin = (pos * inputSize) / outputSize;
+    ivec2 sourceEnd = (((pos + ivec2(1)) * inputSize) + outputSize - ivec2(1)) / outputSize;
+    sourceEnd = min(sourceEnd, inputSize);
+
+    // Explicitly reduce the complete source footprint. This keeps odd-sized
+    // mips conservative instead of dropping the last source row or column.
+    float depth = texelFetch(inputDepth, sourceBegin, 0).x;
+    for (int y = sourceBegin.y; y < sourceEnd.y; ++y)
+    {
+      for (int x = sourceBegin.x; x < sourceEnd.x; ++x)
+      {
+        depth = min(depth, texelFetch(inputDepth, ivec2(x, y), 0).x);
+      }
+    }
+
+    imageStore(outputDepth, pos, vec4(depth));
   }

--- a/Content/Shaders/ComputeLightCulling.shader
+++ b/Content/Shaders/ComputeLightCulling.shader
@@ -8,36 +8,36 @@ glslCommon: |
   #version 460
   #extension GL_ARB_separate_shader_objects : enable
 glslCompute: |
-  layout(local_size_x = LIGHTS_CULLING_TILE_SIZE, local_size_y = LIGHTS_CULLING_TILE_SIZE, local_size_z = 1) in;  
+  layout(local_size_x = LIGHTS_CULLING_TILE_SIZE, local_size_y = LIGHTS_CULLING_TILE_SIZE, local_size_z = 1) in;
   layout(push_constant) uniform Constants
   {
     mat4 invViewProjection;
     ivec2 viewportSize;
-    ivec2 numTiles;	
+    ivec2 numTiles;
     int lightsNum;
   } PushConstants;
-  
+
   layout(std430, set = 0, binding = 0) readonly buffer LightDataSSBO
-  {	
-  	LightData instance[];
+  {
+      LightData instance[];
   } light;
-  
+
   layout(std430, set = 1, binding = 0) buffer CulledLightsSSBO
   {
       uint indices[];
   } culledLights;
-  
+
   layout(std430, set = 1, binding = 1) writeonly buffer LightsGridSSBO
   {
       LightsGrid instance[];
   } lightsGrid;
-  
+
   layout(set = 1, binding = 2) uniform sampler2D sceneDepth;
-  
+
   layout(set = 2, binding = 0) uniform FrameData
   {
       mat4 view;
-      mat4 projection;	
+      mat4 projection;
       mat4 invProjection;
       vec4 cameraPosition;
       ivec2 viewportSize;
@@ -45,20 +45,20 @@ glslCompute: |
       float currentTime;
       float deltaTime;
   } frame;
-  
+
   shared ViewFrustum frustum;
   shared int lightCountForTile;
   shared uint minDepthInt;
   shared uint maxDepthInt;
   shared uint candidateIndices[LIGHTS_CANDIDATES_PER_TILE];
   shared float candidateImpact[LIGHTS_CANDIDATES_PER_TILE];
-  
+
   // Construct view frustum
   ViewFrustum CreateFrustum(ivec2 tileId)
-  {	
-  	vec3 eyePos = vec3(0,0,0);
-  	vec4 screenSpace[5];
-  
+  {
+      vec3 eyePos = vec3(0,0,0);
+      vec4 screenSpace[5];
+
       // Top left point
       screenSpace[0] = vec4(tileId.xy * LIGHTS_CULLING_TILE_SIZE, -1.0f, 1.0f );
       // Top right point
@@ -67,19 +67,19 @@ glslCompute: |
       screenSpace[2] = vec4(vec2(tileId.x, tileId.y + 1) * LIGHTS_CULLING_TILE_SIZE, -1.0f, 1.0f );
       // Bottom right point
       screenSpace[3] = vec4(vec2(tileId.x + 1, tileId.y + 1) * LIGHTS_CULLING_TILE_SIZE, -1.0f, 1.0f );
-  	
-  	  // Center point
+
+        // Center point
       screenSpace[4] = (screenSpace[0] + screenSpace[3]) * 0.5f;
-  	
+
       vec3 viewSpace[5];
       // Now convert the screen space points to view space
-      for ( int i = 0; i < 5; i++ ) 
+      for ( int i = 0; i < 5; i++ )
       {
-          viewSpace[i] = ScreenSpaceToViewSpace(screenSpace[i], frame.viewportSize, frame.invProjection).xyz;		
+          viewSpace[i] = ScreenSpaceToViewSpace(screenSpace[i], frame.viewportSize, frame.invProjection).xyz;
       }
-  
+
     ViewFrustum frustum;
-  
+
     // Left plane
     frustum.planes[0] = ComputePlane(eyePos, viewSpace[2], viewSpace[0]);
     // Right plane
@@ -88,158 +88,157 @@ glslCompute: |
     frustum.planes[2] = ComputePlane(eyePos, viewSpace[0], viewSpace[1]);
     // Bottom plane
     frustum.planes[3] = ComputePlane(eyePos, viewSpace[3], viewSpace[2]);
-  	
-  	frustum.center = viewSpace[4].xy;
-  	
-  	return frustum;
+
+      frustum.center = viewSpace[4].xy;
+
+      return frustum;
   }
-  
+
   void main()
   {
-  	ivec2 location = ivec2(gl_GlobalInvocationID.xy);
-  	ivec2 itemID = ivec2(gl_LocalInvocationID.xy);
-  	ivec2 tileId = ivec2(gl_WorkGroupID.xy);
-  	ivec2 tileNumber = ivec2(gl_NumWorkGroups.xy);
-  	uint tileIndex = tileId.y * tileNumber.x + tileId.x;
-  	
-  	if(gl_GlobalInvocationID.xy == vec2(0,0))
-  	{
-  		culledLights.indices[0] = 0;
-  	}
-  
-  	if (gl_LocalInvocationIndex == 0)
-  	{
-  		maxDepthInt = 0;
-  		minDepthInt = 0xFFFFFFFF;
-  		lightCountForTile = 0;
-  	}
-  	
-  	barrier();	
-  	
-  	vec2 uv = vec2(gl_GlobalInvocationID.xy + vec2(0.5, 0.5))/ PushConstants.viewportSize;
-  	uv.y = 1 - uv.y;
-  	float linearDepth = texture(sceneDepth, uv).x;
-  	
-  	// Convert depth to uint so we can do atomic min and max comparisons between the threads
-  	uint depthInt = floatBitsToUint(linearDepth);
-  	atomicMax(maxDepthInt, depthInt);
-  	atomicMin(minDepthInt, depthInt);
-  	
-  	barrier();
-  	
-  	if (gl_LocalInvocationIndex == 0)
-  	{
-  		frustum = CreateFrustum(tileId);		
-  	}
-  	
-  	barrier();
-  
-  	// Step 3: Cull lights.
-  	// Parallelize the threads against the lights now.
-  	// Can handle 256 simultaniously. Anymore lights than that and additional passes are performed
-  	uint threadCount = LIGHTS_CULLING_TILE_SIZE * LIGHTS_CULLING_TILE_SIZE;
-  	uint passCount = (PushConstants.lightsNum + threadCount - 1) / threadCount;
-  	
-  	for (uint i = 0; i < passCount; i++)
-  	{
-  		// Get the lightIndex to test for this thread / pass. If the index is >= light count, then this thread can stop testing lights
-  		uint lightIndex = i * threadCount + gl_LocalInvocationIndex;
-  		if (lightIndex >= PushConstants.lightsNum || lightCountForTile >= LIGHTS_CANDIDATES_PER_TILE) 
-  		{
-  			break;
-  		}
-  
+      ivec2 location = ivec2(gl_GlobalInvocationID.xy);
+      ivec2 itemID = ivec2(gl_LocalInvocationID.xy);
+      ivec2 tileId = ivec2(gl_WorkGroupID.xy);
+      ivec2 tileNumber = ivec2(gl_NumWorkGroups.xy);
+      uint tileIndex = tileId.y * tileNumber.x + tileId.x;
+
+      if (gl_LocalInvocationIndex == 0)
+      {
+          maxDepthInt = 0;
+          minDepthInt = 0xFFFFFFFF;
+          lightCountForTile = 0;
+      }
+
+      barrier();
+
+    const bool isInsideViewport = all(lessThan(location, PushConstants.viewportSize));
+    if (isInsideViewport)
+    {
+        vec2 uv = vec2(gl_GlobalInvocationID.xy + vec2(0.5, 0.5)) / PushConstants.viewportSize;
+        uv.y = 1 - uv.y;
+        float linearDepth = texture(sceneDepth, uv).x;
+
+        // Convert depth to uint so we can do atomic min and max comparisons between the threads
+        uint depthInt = floatBitsToUint(linearDepth);
+        atomicMax(maxDepthInt, depthInt);
+        atomicMin(minDepthInt, depthInt);
+    }
+
+      barrier();
+
+      if (gl_LocalInvocationIndex == 0)
+      {
+          frustum = CreateFrustum(tileId);
+      }
+
+      barrier();
+
+      // Step 3: Cull lights.
+      // Parallelize the threads against the lights now.
+      // Can handle 256 simultaniously. Anymore lights than that and additional passes are performed
+      uint threadCount = LIGHTS_CULLING_TILE_SIZE * LIGHTS_CULLING_TILE_SIZE;
+      uint passCount = (PushConstants.lightsNum + threadCount - 1) / threadCount;
+
+      for (uint i = 0; i < passCount; i++)
+      {
+          // Get the lightIndex to test for this thread / pass. If the index is >= light count, then this thread can stop testing lights
+          uint lightIndex = i * threadCount + gl_LocalInvocationIndex;
+          if (lightIndex >= PushConstants.lightsNum || lightCountForTile >= LIGHTS_CANDIDATES_PER_TILE)
+          {
+              break;
+          }
+
           if(light.instance[lightIndex].type == INVALID_LIGHT_TYPE)
           {
               continue;
           }
 
-  		// Directional light
-  		if(light.instance[lightIndex].type == 0)
-  		{
-  			uint offset = atomicAdd(lightCountForTile, 1);
-  			if(offset < LIGHTS_CANDIDATES_PER_TILE)
-  			{
-  				candidateIndices[offset] = int(lightIndex);
-  				candidateImpact[offset] = 0.0f;
-  				continue;
-  			}
-  		}
-  		
-  		float radius = light.instance[lightIndex].bounds.x; 
-  		vec4 lightPosViewSpace = frame.view * vec4(light.instance[lightIndex].worldPosition, 1);
-  		lightPosViewSpace /= lightPosViewSpace.w;
-  		
-  		// Reverse Z
-  		lightPosViewSpace.z *= -1;
-  		
-  		float zFar = uintBitsToFloat(maxDepthInt);
-  		float zNear = uintBitsToFloat(minDepthInt);
-  		
-  		// Add extra bounds
-  		const float diff = zFar - zNear;
-  		zFar -= diff;
-  		zNear += diff;
-  		
-  		// If greater than zero, then it is a visible light
-  		if (SphereFrustumOverlaps(lightPosViewSpace.xyz, radius, frustum, zNear, zFar)) 
-  		{
-  			// Add index to the shared array of visible indices
-  			uint offset = atomicAdd(lightCountForTile, 1);
-  			if(offset < LIGHTS_CANDIDATES_PER_TILE)
-  			{
-  				candidateIndices[offset] = int(lightIndex);
-  				candidateImpact[offset] = length(lightPosViewSpace.xyz - vec3(frustum.center.xy, (zFar + zNear) * 0.5));
-  			}
-  		}
-  	}
-  	barrier();
-  
-  	if(gl_LocalInvocationIndex == 0)
-  	{
-  		uint numCandidates = min(lightCountForTile, LIGHTS_CANDIDATES_PER_TILE);
-  		
-  		// Sort by distance
-  		if(numCandidates > LIGHTS_PER_TILE)
-  		{
-  			uint numSorted = LIGHTS_PER_TILE;
-  
-  			for(uint i = 0; i < numCandidates-1; i++)
-  			{
-  				for(uint j = 0; j < numCandidates - i - 1; j++)
-  				{
-  					if(candidateImpact[j] < candidateImpact[j+1])
-  					{
-  						float value = candidateImpact[j];
-  						candidateImpact[j] = candidateImpact[j+1];
-  						candidateImpact[j+1] = value;
-  						
-  						uint index = candidateIndices[j];
-  						candidateIndices[j] = candidateIndices[j+1];
-  						candidateIndices[j+1] = index;
-  					}
-  				}
-  				
-  				--numSorted;
-  				
-  				if(numSorted == 0)
-  				{
-  					break;
-  				}
-  			}
-  		}
-  		
-  		// Fill lightsGrid
-  		const uint numLights = min(numCandidates, LIGHTS_PER_TILE);		
-  		const uint offset = atomicAdd(culledLights.indices[0], numLights) + 1;
-  		
-  		lightsGrid.instance[tileIndex].num = numLights;
-  		lightsGrid.instance[tileIndex].offset = offset;
-  		
-  		// Copy calculated data
-  		for(uint i = 0; i < numLights; i++)
-  		{
-  			culledLights.indices[offset + i] = candidateIndices[numCandidates - i - 1];
-  		}
-  	}
+          // Directional light
+          if(light.instance[lightIndex].type == 0)
+          {
+              uint offset = atomicAdd(lightCountForTile, 1);
+              if(offset < LIGHTS_CANDIDATES_PER_TILE)
+              {
+                  candidateIndices[offset] = int(lightIndex);
+                  candidateImpact[offset] = 0.0f;
+                  continue;
+              }
+          }
+
+          float radius = light.instance[lightIndex].bounds.x;
+          vec4 lightPosViewSpace = frame.view * vec4(light.instance[lightIndex].worldPosition, 1);
+          lightPosViewSpace /= lightPosViewSpace.w;
+
+          // Reverse Z
+          lightPosViewSpace.z *= -1;
+
+          float zFar = uintBitsToFloat(maxDepthInt);
+          float zNear = uintBitsToFloat(minDepthInt);
+
+          // Add extra bounds
+          const float diff = zFar - zNear;
+          zFar -= diff;
+          zNear += diff;
+
+          // If greater than zero, then it is a visible light
+          if (SphereFrustumOverlaps(lightPosViewSpace.xyz, radius, frustum, zNear, zFar))
+          {
+              // Add index to the shared array of visible indices
+              uint offset = atomicAdd(lightCountForTile, 1);
+              if(offset < LIGHTS_CANDIDATES_PER_TILE)
+              {
+                  candidateIndices[offset] = int(lightIndex);
+                  candidateImpact[offset] = length(lightPosViewSpace.xyz - vec3(frustum.center.xy, (zFar + zNear) * 0.5));
+              }
+          }
+      }
+      barrier();
+
+      if(gl_LocalInvocationIndex == 0)
+      {
+          uint numCandidates = min(lightCountForTile, LIGHTS_CANDIDATES_PER_TILE);
+
+          // Sort by distance
+          if(numCandidates > LIGHTS_PER_TILE)
+          {
+              uint numSorted = LIGHTS_PER_TILE;
+
+              for(uint i = 0; i < numCandidates-1; i++)
+              {
+                  for(uint j = 0; j < numCandidates - i - 1; j++)
+                  {
+                      if(candidateImpact[j] < candidateImpact[j+1])
+                      {
+                          float value = candidateImpact[j];
+                          candidateImpact[j] = candidateImpact[j+1];
+                          candidateImpact[j+1] = value;
+
+                          uint index = candidateIndices[j];
+                          candidateIndices[j] = candidateIndices[j+1];
+                          candidateIndices[j+1] = index;
+                      }
+                  }
+
+                  --numSorted;
+
+                  if(numSorted == 0)
+                  {
+                      break;
+                  }
+              }
+          }
+
+          // Fill lightsGrid
+        const uint numLights = min(numCandidates, LIGHTS_PER_TILE);
+        const uint offset = tileIndex * LIGHTS_PER_TILE;
+
+          lightsGrid.instance[tileIndex].num = numLights;
+          lightsGrid.instance[tileIndex].offset = offset;
+
+          // Copy calculated data
+          for(uint i = 0; i < numLights; i++)
+          {
+              culledLights.indices[offset + i] = candidateIndices[numCandidates - i - 1];
+          }
+      }
   }

--- a/Content/Shaders/ComputeMeshCulling.shader
+++ b/Content/Shaders/ComputeMeshCulling.shader
@@ -15,6 +15,8 @@ glslCompute: |
     uint numBatches;
     uint numInstances;
     uint firstInstanceIndex;
+    uint phase;
+    uint enableOcclusion;
   } PushConstants;
   
   struct PerInstanceData
@@ -61,6 +63,26 @@ glslCompute: |
   
   shared ViewFrustum frustum;
 
+  float ConservativeSphereScale(mat4 model)
+  {
+    vec3 column0 = abs(model[0].xyz);
+    vec3 column1 = abs(model[1].xyz);
+    vec3 column2 = abs(model[2].xyz);
+
+    float matrixOneNorm = max(max(
+      column0.x + column0.y + column0.z,
+      column1.x + column1.y + column1.z),
+      column2.x + column2.y + column2.z);
+    float matrixInfinityNorm = max(max(
+      column0.x + column1.x + column2.x,
+      column0.y + column1.y + column2.y),
+      column0.z + column1.z + column2.z);
+
+    // The spectral norm is bounded by sqrt(||M||1 * ||M||inf). Unlike using
+    // only model[0], this remains conservative for non-uniform scale and shear.
+    return sqrt(matrixOneNorm * matrixInfinityNorm);
+  }
+
   bool OcclusionCulling(uint instanceIndex)
   {
     ivec2 depthHighZSize = textureSize(depthHighZ, 0);
@@ -70,25 +92,47 @@ glslCompute: |
     center.xyz /= center.w;
     center.z *= -1.0f;
     
-    float lossyScale = length(data.instance[instanceIndex].model[0].xyz);
-    float radius = sphereBounds.w * lossyScale;
+    float radius = sphereBounds.w * ConservativeSphereScale(data.instance[instanceIndex].model);
     
     vec4 aabb;
     if (ProjectSphere(center.xyz, radius, frame.cameraZNearZFar.x, frame.projection[0][0], frame.projection[1][1], aabb))
     {   
-      float width = (aabb.z - aabb.x) * depthHighZSize.x;
-      float height = (aabb.w - aabb.y) * depthHighZSize.y;
+      vec4 clippedAabb = clamp(aabb, vec4(0.0), vec4(1.0));
+      float width = max((clippedAabb.z - clippedAabb.x) * depthHighZSize.x, 1.0);
+      float height = max((clippedAabb.w - clippedAabb.y) * depthHighZSize.y, 1.0);
     
-      //find the mipmap level that will match the screen size of the sphere
-      float level = floor(log2(max(width, height)));
+      // Pick a mip whose texel covers the whole projected sphere and clamp it
+      // to the actual pyramid. A lower mip can miss an occluder discontinuity.
+      float maxLevel = float(max(textureQueryLevels(depthHighZ) - 1, 0));
+      float level = clamp(ceil(log2(max(width, height))), 0.0, maxLevel);
     
-      //sample the depth pyramid at that specific level
-      vec2 uv = (aabb.xy + aabb.zw) * 0.5;
-      float depth = textureLod(depthHighZ, uv, level).x;
+      // The projected rectangle can cross a mip texel boundary even when its
+      // dimensions fit one texel. Reduce every touched texel so a single center
+      // sample cannot reject geometry at an occluder edge.
+      int mipLevel = int(level);
+      ivec2 mipSize = textureSize(depthHighZ, mipLevel);
+      ivec2 texelBegin = clamp(
+        ivec2(floor(clippedAabb.xy * vec2(mipSize))),
+        ivec2(0),
+        mipSize - ivec2(1));
+      ivec2 texelEnd = clamp(
+        ivec2(ceil(clippedAabb.zw * vec2(mipSize))) - ivec2(1),
+        texelBegin,
+        mipSize - ivec2(1));
+
+      float depth = texelFetch(depthHighZ, texelBegin, mipLevel).x;
+      for (int y = texelBegin.y; y <= texelEnd.y; ++y)
+      {
+        for (int x = texelBegin.x; x <= texelEnd.x; ++x)
+        {
+          depth = min(depth, texelFetch(depthHighZ, ivec2(x, y), mipLevel).x);
+        }
+      }
     
       float depthSphere = frame.cameraZNearZFar.x / (center.z - radius);
     
-      //if the depth of the sphere is in front of the depth pyramid value, then the object is visible
+      // Reverse-Z: the sphere is occluded only when its nearest depth is still
+      // behind the farthest occluder depth stored for the selected footprint.
       return depthSphere < depth;
     }
     
@@ -103,8 +147,7 @@ glslCompute: |
     center.xyz /= center.w;
     center.z *= -1.0f;
 
-    float lossyScale = length(data.instance[instanceIndex].model[0].xyz);
-    float radius = sphereBounds.w * lossyScale;
+    float radius = sphereBounds.w * ConservativeSphereScale(data.instance[instanceIndex].model);
 
     bool bIsCulled = !SphereFrustumOverlaps(center.xyz, radius, frustum, frame.cameraZNearZFar.y, frame.cameraZNearZFar.x);
   
@@ -113,53 +156,41 @@ glslCompute: |
   
   layout(local_size_x = GPU_CULLING_GROUP_SIZE) in;
   void main()
-  { 
-    // Step 1: Calculate View Frustum
-    if (gl_LocalInvocationIndex == 0)
-    {
-        frustum = CreateViewFrustum(frame.viewportSize, frame.invProjection);
-    }
-    
-    barrier();
-   
-    // Step 2: Perform culling (split instances by threads)
+  {
     uint globalIndex = gl_GlobalInvocationID.x;
-    uint threadCount = gl_NumWorkGroups.x * GPU_CULLING_GROUP_SIZE;
-    uint instancePerThread = (PushConstants.numInstances + threadCount - 1) / threadCount;
-    uint instanceEnd = PushConstants.firstInstanceIndex + PushConstants.numInstances;
-        
-    for (uint i = 0; i < instancePerThread; i++)
+
+    if (PushConstants.phase == 0)
     {
-        uint instanceId = PushConstants.firstInstanceIndex + i + globalIndex * instancePerThread;
-        
-        if(instanceId >= instanceEnd)
-        {
-            break;
-        }
-        
+      // Step 1: Calculate View Frustum
+      if (gl_LocalInvocationIndex == 0)
+      {
+        frustum = CreateViewFrustum(frame.viewportSize, frame.invProjection);
+      }
+
+      barrier();
+
+      // Step 2: Perform culling. Compaction is a separate dispatch because a
+      // GLSL workgroup barrier cannot synchronize multiple workgroups.
+      if (globalIndex < PushConstants.numInstances)
+      {
+        uint instanceId = PushConstants.firstInstanceIndex + globalIndex;
+
+        bool bIsCulled = FrustumCulling(instanceId);
         #ifdef OCCLUSION_CULLING
-          bool bIsCulled = FrustumCulling(instanceId) || OcclusionCulling(instanceId);
-        #else
-          bool bIsCulled = FrustumCulling(instanceId);
+          if (!bIsCulled && PushConstants.enableOcclusion != 0u)
+          {
+            bIsCulled = OcclusionCulling(instanceId);
+          }
         #endif
         
-        data.instance[instanceId].isCulled = bIsCulled ? 1 : 0;
+        data.instance[instanceId].isCulled = bIsCulled ? 1u : 0u;
+      }
     }
-
-    barrier();
-    
-    // Step3: Remove empty draw calls (split batches per threads)
-    uint batchPerThread = (PushConstants.numBatches + threadCount - 1) / threadCount;
-    
-    for (uint j = 0; j < batchPerThread; j++)
+    else if (globalIndex < PushConstants.numBatches)
     {
-        uint batchId = j + globalIndex * batchPerThread;
-        
-        if(batchId >= PushConstants.numBatches)
-        {
-            break;
-        }
-        
+        // Step 3: Compact visible instances and update the matching indirect
+        // command after the host-side shader-write barrier.
+        uint batchId = globalIndex;
         uint readIndex = drawIndexedIndirect.batches[batchId].firstInstance;
         uint writeIndex = readIndex;
         
@@ -177,5 +208,5 @@ glslCompute: |
         }
 
         drawIndexedIndirect.batches[batchId].instanceCount = writeIndex - drawIndexedIndirect.batches[batchId].firstInstance;
-    }    
+    }
   }

--- a/Content/Shaders/ComputeMeshCulling.shader
+++ b/Content/Shaders/ComputeMeshCulling.shader
@@ -27,6 +27,7 @@ glslCompute: |
       uint skeletonOffset;
       uint isCulled;
       uint padding;
+      vec4 bakedVolumeScale;
   };
   
   struct DrawIndexedIndirectData

--- a/Content/Shaders/Debug.shader
+++ b/Content/Shaders/Debug.shader
@@ -121,17 +121,15 @@ glslFragment: |
   #elif defined(LIGHT_TILES)
     outColor = vec4(texture(linearDepthSampler, fragTexcoord).r / 50000);
   
-    vec2 numTiles = floor(frame.viewportSize / LIGHTS_CULLING_TILE_SIZE);
-    vec2 screenUv = vec2(gl_FragCoord.x, frame.viewportSize.y - gl_FragCoord.y);
-    ivec2 tileId = ivec2(screenUv) / LIGHTS_CULLING_TILE_SIZE;
-    
-    ivec2 mod = ivec2(frame.viewportSize.x % LIGHTS_CULLING_TILE_SIZE, frame.viewportSize.y % LIGHTS_CULLING_TILE_SIZE);
-    ivec2 padding = ivec2(min(1, mod.x), min(1, mod.y));
-    
-    uint tileIndex = uint(tileId.y * (numTiles.x + padding.x) + tileId.x);
-  
-    const uint offset = lightsGrid.instance[tileIndex].offset;
-    const uint numLights = lightsGrid.instance[tileIndex].num;
+    const uint tileIndex = GetLightTileIndex(gl_FragCoord.xy, frame.viewportSize);
+    const uint gridLength = uint(lightsGrid.instance.length());
+    const bool hasLightTile = tileIndex < gridLength;
+    const uint offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0;
+    const uint listLength = uint(culledLights.indices.length());
+    const uint availableLights = offset < listLength ? listLength - offset : 0;
+    const uint numLights = hasLightTile ? min(
+        min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE)),
+        availableLights) : 0;
     
     for(int i = 0; i < numLights; i++)
     {

--- a/Content/Shaders/DepthOnly.shader
+++ b/Content/Shaders/DepthOnly.shader
@@ -41,6 +41,7 @@ glslVertex: |
       uint skeletonOffset;
       uint isCulled;
       uint padding;
+      vec4 bakedVolumeScale;
   };
   
   layout(std430, set = 1, binding = 0) readonly buffer PerInstanceDataSSBO

--- a/Content/Shaders/ImGuiUI.shader
+++ b/Content/Shaders/ImGuiUI.shader
@@ -1,6 +1,6 @@
 ---
 colorAttachments :
-- B8G8R8A8_SRGB
+- B8G8R8A8_UNORM
 
 glslCommon: |
   #version 450 core

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -1,5 +1,10 @@
 const float EVSM_C1 = 40.0f;
 const float EVSM_C2 = 40.0f;
+const float EVSM_MIN_SLOPE_BIAS = 0.05f;
+const float EVSM_DEPTH_BIAS_SCALE = 0.003f;
+const uint SHADOW_TYPE_NONE = 0u;
+const uint SHADOW_TYPE_PCF = 1u;
+const uint SHADOW_TYPE_EVSM = 2u;
 
 layout(std430)
 struct LightData
@@ -221,7 +226,7 @@ float ManualPCF(sampler2D shadowMap, vec3 projCoords, float currentDepth, float 
    for(int i = 0; i < samples; ++i)
    {
        vec2 offset = poissonDisk[i] * radius * texelSize;
-       float pcfDepth = texture(shadowMap, projCoords.xy + offset).r * 0.5 + 0.5; 
+       float pcfDepth = texture(shadowMap, projCoords.xy + offset).r;
        shadow += currentDepth + bias > pcfDepth ? 1.0 : 0.0;
    }
 
@@ -276,17 +281,16 @@ float Chebyshev(vec2 moments, float currentDepth, float minVariance, float linst
 float ShadowCalculation_Pcf(sampler2D shadowMap, vec4 fragPosLightSpace, float bias, int cascadeLayer)
 {
   vec3 projCoords = fragPosLightSpace.xyz / fragPosLightSpace.w;
-  projCoords = projCoords * 0.5 + 0.5;
+  projCoords.xy = projCoords.xy * 0.5 + 0.5;
   projCoords.y = 1.0f - projCoords.y;
   
   if(projCoords.x > 1.0f || projCoords.y > 1.0f ||
      projCoords.x < 0.0f || projCoords.y < 0.0f ||
-     projCoords.z < 0.5f)
+     projCoords.z < 0.0f || projCoords.z > 1.0f)
   {
     return 1.0f;
   }
   
-  const float closestDepth = texture(shadowMap, projCoords.xy).r * 0.5 + 0.5;
   const float currentDepth = projCoords.z;
   
   //float shadow = currentDepth + bias > closestDepth ? 1.0 : 0.0;
@@ -302,17 +306,46 @@ float ShadowCalculation_Evsm(sampler2D shadowMap, vec4 fragPosLightSpace, float 
   
   if(projCoords.x > 1.0f || projCoords.y > 1.0f ||
      projCoords.x < 0.0f || projCoords.y < 0.0f ||
-     projCoords.z < 0.0f)
+     projCoords.z < 0.0f || projCoords.z > 1.0f)
   {
     return 1.0f;
   }
   
   vec4 shadow = texture(shadowMap, projCoords.xy);// > 0.39 ? 1.0f : 0.0f;
-  const float currentDepth = exp(EVSM_C1 * (projCoords.z + 0.003 * bias * pow(0.5, cascadeLayer)));
-  const float negCurrentDepth = -exp(-EVSM_C2 * (projCoords.z + 0.0001 * bias));
+  const float biasedDepth =
+    projCoords.z + EVSM_DEPTH_BIAS_SCALE * bias * pow(0.5f, cascadeLayer);
+  const float currentDepth = exp(EVSM_C1 * biasedDepth);
+  const float negCurrentDepth = -exp(-EVSM_C2 * biasedDepth);
   
   float posValue = Chebyshev(shadow.xy, currentDepth, 0.01, 0);
   float negValue = Chebyshev(shadow.zw, negCurrentDepth, 0, 0) * (cascadeLayer > 2 ? 0 : 1);
   
   return clamp(1 - max(posValue, negValue), 0, 1);
+}
+
+float CalculateDirectionalShadow(
+  uint shadowType,
+  sampler2D shadowMap,
+  vec4 fragPosLightSpace,
+  vec3 surfaceNormal,
+  vec3 surfaceToLightDirection,
+  int cascadeLayer)
+{
+  if (shadowType == SHADOW_TYPE_NONE)
+  {
+    return 1.0f;
+  }
+
+  const float slope = 1.0f - clamp(dot(surfaceNormal, surfaceToLightDirection), 0.0f, 1.0f);
+  if (shadowType == SHADOW_TYPE_EVSM && cascadeLayer == 0)
+  {
+    return ShadowCalculation_Evsm(
+      shadowMap,
+      fragPosLightSpace,
+      max(slope, EVSM_MIN_SLOPE_BIAS) * (1.0f + cascadeLayer),
+      cascadeLayer);
+  }
+
+  const float bias = max(0.000075f * slope, 0.000005f);
+  return ShadowCalculation_Pcf(shadowMap, fragPosLightSpace, bias, cascadeLayer);
 }

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -23,6 +23,22 @@ struct LightsGrid
   uint num;
 }; 
 
+uint GetLightTileIndex(vec2 fragmentPosition, ivec2 viewportSize)
+{
+  const ivec2 safeViewportSize = max(viewportSize, ivec2(1));
+  const ivec2 numTiles =
+    (safeViewportSize + ivec2(LIGHTS_CULLING_TILE_SIZE - 1)) /
+    LIGHTS_CULLING_TILE_SIZE;
+  const vec2 screenPosition = vec2(
+    fragmentPosition.x,
+    float(safeViewportSize.y) - fragmentPosition.y);
+  const ivec2 tileId = clamp(
+    ivec2(screenPosition) / LIGHTS_CULLING_TILE_SIZE,
+    ivec2(0),
+    numTiles - ivec2(1));
+  return uint(tileId.y * numTiles.x + tileId.x);
+}
+
 // Importance sample GGX normal distribution function for a fixed roughness value.
 // This returns normalized half-vector between Li & Lo.
 // For derivation see: http://blog.tobias-franke.eu/2014/03/30/notes_on_importance_sampling.html
@@ -42,11 +58,11 @@ vec3 SampleGGX(float u1, float u2, float roughness)
 // Uses Disney's reparametrization of alpha = roughness^2.
 float NdfGGX(float cosLh, float roughness)
 {
-  float alpha   = roughness * roughness;
+  float alpha   = max(roughness * roughness, 0.001);
   float alphaSq = alpha * alpha;
 
   float denom = (cosLh * cosLh) * (alphaSq - 1.0) + 1.0;
-  return alphaSq / (PI * denom * denom);
+  return alphaSq / max(PI * denom * denom, 1e-7);
 }
 
 // Single term for separable Schlick-GGX below.

--- a/Content/Shaders/MotionBlur.shader
+++ b/Content/Shaders/MotionBlur.shader
@@ -81,7 +81,7 @@ glslFragment: |
       velocity.x = min(1, velocity.x) * data.intensity;
       velocity.y = min(1, velocity.y) * data.intensity;
       
-      vec3 color = texture(colorSampler, fragTexcoord).xyz;
+      vec3 color = textureLod(colorSampler, fragTexcoord, 0.0).xyz;
       vec2 texCoord = fragTexcoord;
       
       if(length(velocity) <= 0.0001)
@@ -93,7 +93,7 @@ glslFragment: |
       for(int i = 1; i < int(data.samples); ++i) 
       {
           texCoord = clamp(texCoord + velocity, 0.0, 1.0);
-          vec3 currentColor = texture(colorSampler, texCoord).xyz;
+          vec3 currentColor = textureLod(colorSampler, texCoord, 0.0).xyz;
           color += currentColor;
       }
       

--- a/Content/Shaders/Simple.shader
+++ b/Content/Shaders/Simple.shader
@@ -24,7 +24,12 @@ glslVertex: |
   struct PerInstanceData
   {
   	mat4 model;
+    vec4 sphereBounds;
   	uint materialInstance;
+    uint skeletonOffset;
+    uint isCulled;
+    uint padding;
+    vec4 bakedVolumeScale;
   };
   
   struct MaterialData
@@ -61,7 +66,7 @@ glslVertex: |
   	LightData instance[];
   } light;
   
-  layout(std140, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
+  layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {
   	PerInstanceData instance[];
   } data;

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -321,18 +321,13 @@ glslFragment: |
         attenuation = 1.0;
       
         const int cascadeLayer = min(SelectCascade(frame.view, worldPos, frame.cameraZNearZFar), NUM_CSM_CASCADES - 1);
-        
-        // EVSM only for the first cascade
-        if(light.shadowType == 2 && cascadeLayer == 0)
-        {
-          const float bias = (1.0 - dot(normal, light.direction)) * (1 + cascadeLayer);
-          shadow = ShadowCalculation_Evsm(shadowMaps[cascadeLayer], lightsMatrices.instance[cascadeLayer] * vec4(worldPos, 1.0f), bias, cascadeLayer);
-        }
-        else
-        {
-          const float bias = max(0.000075 * (1.0 - dot(normal, light.direction)), 0.000005);   
-          shadow = ShadowCalculation_Pcf(shadowMaps[cascadeLayer], lightsMatrices.instance[cascadeLayer] * vec4(worldPos, 1.0f), bias, cascadeLayer);    
-        }
+        shadow = CalculateDirectionalShadow(
+          light.shadowType,
+          shadowMaps[cascadeLayer],
+          lightsMatrices.instance[cascadeLayer] * vec4(worldPos, 1.0f),
+          normal,
+          -light.direction,
+          cascadeLayer);
     }
     // Point light
     else if(light.type == 1)

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -128,17 +128,38 @@ glslVertex: |
   
   void main() 
   {
-    vec4 vertexPosition = data.instance[gl_InstanceIndex].model * vec4(inPosition, 1.0);
+    mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
+    vec4 vertexPosition = modelMatrix * vec4(inPosition, 1.0);
     vout.worldPosition = vertexPosition.xyz / vertexPosition.w;
 
-    gl_Position = frame.projection * (frame.view * (data.instance[gl_InstanceIndex].model * vec4(inPosition, 1.0)));
-    vec4 worldNormal = data.instance[gl_InstanceIndex].model * vec4(inNormal, 0.0);
+    gl_Position = frame.projection * (frame.view * vertexPosition);
+
+    mat3 linearMatrix = mat3(modelMatrix);
+    mat3 normalMatrix = transpose(inverse(linearMatrix));
+    vec3 normal = normalize(normalMatrix * inNormal);
+
+    vec3 tangent = linearMatrix * inTangent;
+    tangent -= normal * dot(normal, tangent);
+    float tangentLengthSquared = dot(tangent, tangent);
+    if(tangentLengthSquared > 1e-8)
+    {
+      tangent *= inversesqrt(tangentLengthSquared);
+    }
+    else
+    {
+      vec3 fallbackAxis = abs(normal.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
+      tangent = normalize(cross(fallbackAxis, normal));
+    }
+
+    vec3 transformedBitangent = linearMatrix * inBitangent;
+    float handedness = dot(cross(normal, tangent), transformedBitangent) < 0.0 ? -1.0 : 1.0;
+    vec3 bitangent = normalize(cross(normal, tangent)) * handedness;
 
     vout.color = inColor;
-    vout.normal = normalize(worldNormal.xyz);
+    vout.normal = normal;
     vout.texcoord = inTexcoord;
     materialInstance = data.instance[gl_InstanceIndex].materialInstance;
-    vout.tangentBasis = mat3(data.instance[gl_InstanceIndex].model) * mat3(inTangent, inBitangent, inNormal);
+    vout.tangentBasis = mat3(tangent, bitangent, normal);
   }
 
 glslFragment: |

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -40,6 +40,7 @@ glslVertex: |
       uint skeletonOffset;
       uint isCulled;
       uint padding;
+      vec4 bakedVolumeScale;
   };
   
   struct MaterialData
@@ -89,7 +90,7 @@ glslVertex: |
   
   layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
   {
-      uint indices[];
+      uint indices[MAX_TEXTURES_IN_SCENE];
   } culledLights;
   
   layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
@@ -124,7 +125,15 @@ glslVertex: |
       MaterialData instance[];
   } material;
   
+  #if defined(SAILOR_TEXTURE_REMAP)
+  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
+  {
+      uint indices[MAX_TEXTURES_IN_SCENE];
+  } textureSamplerRemap;
+  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
+  #else
   layout(set=4, binding=0) uniform sampler2D textureSamplers[];
+  #endif
   
   void main() 
   {
@@ -185,6 +194,7 @@ glslFragment: |
       uint skeletonOffset;
       uint isCulled;
       uint padding;
+      vec4 bakedVolumeScale;
   };
   
   struct MaterialData
@@ -274,7 +284,24 @@ glslFragment: |
   //layout(set=3, binding=3) uniform sampler2D normalSampler;
   //layout(set=3, binding=4) uniform sampler2D roughnessSampler;
   
+  #if defined(SAILOR_TEXTURE_REMAP)
+  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
+  {
+      uint indices[];
+  } textureSamplerRemap;
+  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
+  #else
   layout(set=4, binding=0) uniform sampler2D textureSamplers[];
+  #endif
+
+  uint ResolveTextureSamplerIndex(uint globalTextureIndex)
+  {
+  #if defined(SAILOR_TEXTURE_REMAP)
+      return textureSamplerRemap.indices[globalTextureIndex];
+  #else
+      return globalTextureIndex;
+  #endif
+  }
   
   MaterialData GetMaterialData()
   {
@@ -407,12 +434,12 @@ glslFragment: |
     const vec2 viewportUv = gl_FragCoord.xy * rcp(frame.viewportSize);
     
     MaterialData material = GetMaterialData();
-    material.albedo = material.albedo * texture(textureSamplers[nonuniformEXT(material.albedoSampler)], vin.texcoord) * vin.color;
-    material.metallic = material.metallic * texture(textureSamplers[nonuniformEXT(material.metalnessSampler)], vin.texcoord).r;
-    material.roughness = material.roughness * texture(textureSamplers[nonuniformEXT(material.roughnessSampler)], vin.texcoord).r;
+    material.albedo = material.albedo * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.albedoSampler))], vin.texcoord) * vin.color;
+    material.metallic = material.metallic * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.metalnessSampler))], vin.texcoord).r;
+    material.roughness = material.roughness * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.roughnessSampler))], vin.texcoord).r;
     material.ao = texture(g_aoSampler, viewportUv).r;
     
-    vec3 normal = normalize(2.0 * texture(textureSamplers[nonuniformEXT(material.normalSampler)], vin.texcoord).rgb - 1.0);    
+    vec3 normal = normalize(2.0 * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.normalSampler))], vin.texcoord).rgb - 1.0);
     normal = normalize(vin.tangentBasis * normal);
     
     //outColor.xyz = AmbientLighting(material, vin.normal, vin.worldPosition, viewDirection);
@@ -437,26 +464,26 @@ glslFragment: |
     //outColor.xyz += vec3(texture(g_envCubemap, R).xyz);
     //outColor.xyz *= max(0.1, dot(normalize(-vec3(-0.3, -0.5, 0.1)), vin.normal.xyz)) * 0.5;
   
-    vec2 numTiles = floor(frame.viewportSize / LIGHTS_CULLING_TILE_SIZE);
-    vec2 screenUv = vec2(gl_FragCoord.x, frame.viewportSize.y - gl_FragCoord.y);
-    ivec2 tileId = ivec2(screenUv) / LIGHTS_CULLING_TILE_SIZE;
-    
-    ivec2 mod = ivec2(frame.viewportSize.x % LIGHTS_CULLING_TILE_SIZE, frame.viewportSize.y % LIGHTS_CULLING_TILE_SIZE);
-    ivec2 padding = ivec2(min(1, mod.x), min(1, mod.y));
-    
-    uint tileIndex = uint(tileId.y * (numTiles.x + padding.x) + tileId.x);
-  
-    const uint offset = lightsGrid.instance[tileIndex].offset;
-    const uint numLights = lightsGrid.instance[tileIndex].num;
+    const uint tileIndex = GetLightTileIndex(gl_FragCoord.xy, frame.viewportSize);
+    const uint gridLength = uint(lightsGrid.instance.length());
+    const bool hasLightTile = tileIndex < gridLength;
+    const uint offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0;
+    const uint listLength = uint(culledLights.indices.length());
+    const uint availableLights = offset < listLength ? listLength - offset : 0;
+    const uint numLights = hasLightTile ? min(
+        min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE)),
+        availableLights) : 0;
     
     outColor.xyz = AmbientLighting(material, F0, Lr, normal, cosLo);
     
     for(int i = 0; i < numLights; i++)
     {
         uint index = culledLights.indices[offset + i];
-        if(index == uint(-1))
+        if(index == uint(-1) ||
+            index >= uint(light.instance.length()) ||
+            light.instance[index].type == INVALID_LIGHT_TYPE)
         {
-            break;
+            continue;
         }
     
         outColor.xyz += CalculateLighting(light.instance[index], material, F0, -viewDirection, cosLo, normal, vin.worldPosition);

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -9,6 +9,7 @@ defines:
  - SKINNING
  - CLEAR_COAT
  - SHEEN
+ - TRANSMISSION
 
 glslCommon: |
   #version 460
@@ -37,6 +38,9 @@ glslVertex: |
     vec3 normal;
     vec4 color;
     mat3 tangentBasis;
+  #ifdef TRANSMISSION
+    flat vec3 modelScale;
+  #endif
   } vout;
   
   struct PerInstanceData
@@ -78,6 +82,16 @@ glslVertex: |
     uint clearcoatNormalSampler;
     uint sheenColorSampler;
     uint sheenRoughnessSampler;
+
+  #ifdef TRANSMISSION
+    float transmissionFactor;
+    uint transmissionSampler;
+    float thicknessFactor;
+    float attenuationDistance;
+    float indexOfRefraction;
+    uint thicknessSampler;
+    vec4 attenuationColor;
+  #endif
   };
 
   struct BoneData
@@ -165,6 +179,13 @@ glslVertex: |
   void main()
   {
     mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
+  #ifdef TRANSMISSION
+    mat3 instanceLinearMatrix = mat3(modelMatrix);
+    vout.modelScale = vec3(
+      length(instanceLinearMatrix[0]),
+      length(instanceLinearMatrix[1]),
+      length(instanceLinearMatrix[2]));
+  #endif
   #ifdef SKINNING
     uint offset = data.instance[gl_InstanceIndex].skeletonOffset;
 
@@ -224,6 +245,9 @@ glslFragment: |
     vec3 normal;
     vec4 color;
     mat3 tangentBasis;
+  #ifdef TRANSMISSION
+    flat vec3 modelScale;
+  #endif
   } vin;
   
   layout(location=0) out vec4 outColor;
@@ -265,6 +289,16 @@ glslFragment: |
     uint clearcoatNormalSampler;
     uint sheenColorSampler;
     uint sheenRoughnessSampler;
+
+  #ifdef TRANSMISSION
+    float transmissionFactor;
+    uint transmissionSampler;
+    float thicknessFactor;
+    float attenuationDistance;
+    float indexOfRefraction;
+    uint thicknessSampler;
+    vec4 attenuationColor;
+  #endif
   };
   
   layout(set = 0, binding = 0) uniform FrameData
@@ -322,6 +356,9 @@ glslFragment: |
   
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
   layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  #ifdef TRANSMISSION
+  layout(set=1, binding=10) uniform sampler2D g_transmissionFramebufferSampler;
+  #endif
   
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {
@@ -340,30 +377,94 @@ glslFragment: |
   
   layout(set=4, binding=0) uniform sampler2D textureSamplers[];
   
-  #ifdef SKINNING
-  layout(std430, set = 5, binding = 0) readonly buffer BoneMatricesSSBO
-  {
-      BoneData instance[];
-  } bones;
-  #endif 
-  
   MaterialData GetMaterialData()
   {
       return material.instance[materialInstance];
   }
   
   const float Epsilon = 0.00001;
+
+  #ifdef TRANSMISSION
+  float ApplyIorToRoughness(float roughness, float ior)
+  {
+    return roughness * clamp(ior * 2.0 - 2.0, 0.0, 1.0);
+  }
+
+  float NdfGGXAlpha(float cosLh, float alphaRoughness)
+  {
+    float alphaSq = alphaRoughness * alphaRoughness;
+    float denominator = cosLh * cosLh * (alphaSq - 1.0) + 1.0;
+    return alphaSq / max(PI * denominator * denominator, Epsilon);
+  }
+
+  float VisibilityGGXAlpha(float cosLi, float cosLo, float alphaRoughness)
+  {
+    float alphaSq = alphaRoughness * alphaRoughness;
+    float ggxV = cosLi * sqrt(cosLo * cosLo * (1.0 - alphaSq) + alphaSq);
+    float ggxL = cosLo * sqrt(cosLi * cosLi * (1.0 - alphaSq) + alphaSq);
+    float ggx = ggxV + ggxL;
+    return ggx > Epsilon ? 0.5 / ggx : 0.0;
+  }
+
+  vec3 GetRefractionDirection(
+    vec3 normal,
+    vec3 view,
+    float ior)
+  {
+    vec3 refractedDirection = refract(-view, normalize(normal), 1.0 / ior);
+    float refractedLengthSquared = dot(refractedDirection, refractedDirection);
+    if(refractedLengthSquared <= Epsilon)
+    {
+      return vec3(0.0);
+    }
+
+    return refractedDirection * inversesqrt(refractedLengthSquared);
+  }
+
+  vec3 GetVolumeTransmissionRay(
+    vec3 refractedDirection,
+    float thickness,
+    vec3 modelScale)
+  {
+    return refractedDirection * thickness * modelScale;
+  }
+
+  vec3 GetVolumeAttenuation(
+    float transmissionDistance,
+    vec3 attenuationColor,
+    float attenuationDistance)
+  {
+    if(transmissionDistance <= Epsilon ||
+      attenuationDistance >= 3.402823466e+38)
+    {
+      return vec3(1.0);
+    }
+
+    float attenuationExponent = transmissionDistance /
+      max(attenuationDistance, Epsilon);
+    bvec3 fullyAbsorbed = lessThanEqual(attenuationColor, vec3(0.0));
+    vec3 attenuation = pow(
+      max(attenuationColor, vec3(Epsilon)),
+      vec3(attenuationExponent));
+    return mix(attenuation, vec3(0.0), fullyAbsorbed);
+  }
+  #endif
+
   vec3 CalculateLighting(LightData light, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
   {
     float falloff = 1.0f;
-    float attenuation = 1.0;
     float shadow = 1.0f;
+    vec3 pointToLight = light.type == 0 ?
+      -light.direction :
+      light.worldPosition - worldPos;
+    float pointToLightLengthSquared = dot(pointToLight, pointToLight);
+    vec3 Li = pointToLightLengthSquared > Epsilon ?
+      pointToLight * inversesqrt(pointToLightLengthSquared) :
+      vec3(0.0);
     
     // Directional light
     if(light.type == 0)
     {
-        attenuation = 1.0;
-      
         const int cascadeLayer = min(SelectCascade(frame.view, worldPos, frame.cameraZNearZFar), NUM_CSM_CASCADES - 1);
         
         // EVSM only for the first cascade
@@ -382,7 +483,7 @@ glslFragment: |
     else if(light.type == 1)
     {
       // Attenuation
-      const float distance    = length(light.worldPosition - worldPos);
+      const float distance    = length(pointToLight);
       const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
       falloff         = attenuation * (1 - pow(clamp(distance / light.bounds.x, 0,1), 2));
     }
@@ -390,12 +491,12 @@ glslFragment: |
     else if(light.type == 2)
     {
       // Attenuation
-      vec3 lightDir = normalize(light.worldPosition - worldPos);
+      vec3 lightDir = Li;
       float epsilon   = light.cutOff.x - light.cutOff.y;
       float theta = dot(lightDir, normalize(-light.direction));
-      const float distance    = length(light.worldPosition - worldPos);
+      const float distance    = length(pointToLight);
       const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
-      falloff         = attenuation * clamp((theta - light.cutOff.y) / epsilon, 0.0, 1.0);      
+      falloff         = attenuation * clamp((theta - light.cutOff.y) / max(epsilon, Epsilon), 0.0, 1.0);
       
       if(theta < light.cutOff.y)
       {
@@ -403,11 +504,14 @@ glslFragment: |
       }
     }
     
-    vec3 Li = -light.direction;
     vec3 Lradiance = light.intensity;
 
     // Half-vector between Li and Lo.
-    vec3 Lh = normalize(Li + Lo);
+    vec3 halfVector = Li + Lo;
+    float halfVectorLengthSquared = dot(halfVector, halfVector);
+    vec3 Lh = halfVectorLengthSquared > Epsilon ?
+      halfVector * inversesqrt(halfVectorLengthSquared) :
+      normal;
 
     // Calculate angles between surface normal and various light vectors.
     float cosLi = max(0.0, dot(normal, Li));
@@ -424,6 +528,9 @@ glslFragment: |
     // Metals on the other hand either reflect or absorb energy, so diffuse contribution is always zero.
     // To be energy conserving we must scale diffuse BRDF contribution based on Fresnel factor & metalness.
     vec3 kd = mix(vec3(1.0) - F, vec3(0.0), material.metallicFactor);
+  #ifdef TRANSMISSION
+    kd *= 1.0 - material.transmissionFactor;
+  #endif
 
     // Lambert diffuse BRDF.
     // We don't scale by 1/PI for lighting & material units to be more convenient.
@@ -433,8 +540,127 @@ glslFragment: |
     // Cook-Torrance specular microfacet BRDF.
     vec3 specularBRDF = (F * D * G) / max(Epsilon, 4.0 * cosLi * cosLo);
 
+    vec3 directLighting =
+      (diffuseBRDF + specularBRDF) * Lradiance * cosLi * falloff;
+
+  #ifdef TRANSMISSION
+    vec3 refractionNormal = gl_FrontFacing ? normal : -normal;
+    vec3 refractionDirection = GetRefractionDirection(
+      refractionNormal,
+      Lo,
+      material.indexOfRefraction);
+    vec3 transmissionRay = GetVolumeTransmissionRay(
+      refractionDirection,
+      material.thicknessFactor,
+      vin.modelScale);
+    float transmissionRayLength = length(transmissionRay);
+    float canTransmit = step(Epsilon, dot(
+      refractionDirection,
+      refractionDirection));
+    float dielectricTransmission = material.transmissionFactor *
+      (1.0 - clamp(material.metallicFactor, 0.0, 1.0));
+
+    if(canTransmit > 0.0 &&
+      dielectricTransmission > Epsilon)
+    {
+      vec3 exitPointToLight = light.type == 0 ?
+        -light.direction :
+        light.worldPosition - (worldPos + transmissionRay);
+      float exitPointToLightLength = length(exitPointToLight);
+      if(exitPointToLightLength > Epsilon)
+      {
+        vec3 transmissionLi = exitPointToLight / exitPointToLightLength;
+        vec3 mirroredLiVector =
+          transmissionLi +
+          2.0 * refractionNormal *
+            dot(-transmissionLi, refractionNormal);
+        float mirroredLiLengthSquared = dot(
+          mirroredLiVector,
+          mirroredLiVector);
+        if(mirroredLiLengthSquared > Epsilon)
+        {
+          vec3 mirroredLi = mirroredLiVector *
+            inversesqrt(mirroredLiLengthSquared);
+          vec3 transmissionHalfVector = mirroredLi + Lo;
+          float transmissionHalfLengthSquared = dot(
+            transmissionHalfVector,
+            transmissionHalfVector);
+          if(transmissionHalfLengthSquared > Epsilon)
+          {
+            vec3 transmissionH = transmissionHalfVector *
+              inversesqrt(transmissionHalfLengthSquared);
+            float alphaRoughness = ApplyIorToRoughness(
+              material.roughnessFactor * material.roughnessFactor,
+              material.indexOfRefraction);
+            float transmissionDistribution = NdfGGXAlpha(
+              clamp(dot(refractionNormal, transmissionH), 0.0, 1.0),
+              max(alphaRoughness, Epsilon));
+            float transmissionCosLi = clamp(
+              dot(refractionNormal, mirroredLi),
+              0.0,
+              1.0);
+            float transmissionCosLo = clamp(
+              dot(refractionNormal, Lo),
+              0.0,
+              1.0);
+            float transmissionVisibility = VisibilityGGXAlpha(
+              transmissionCosLi,
+              transmissionCosLo,
+              max(alphaRoughness, Epsilon));
+            float dielectricFresnel =
+              (material.indexOfRefraction - 1.0) /
+              (material.indexOfRefraction + 1.0);
+            vec3 transmissionFresnel = FresnelSchlick(
+              vec3(dielectricFresnel * dielectricFresnel),
+              clamp(abs(dot(Lo, transmissionH)), 0.0, 1.0));
+
+            float transmissionFalloff = falloff;
+            if(light.type == 1)
+            {
+              float attenuation = 1.0 /
+                (light.attenuation.x +
+                  light.attenuation.y * exitPointToLightLength +
+                  light.attenuation.z *
+                    exitPointToLightLength * exitPointToLightLength);
+              transmissionFalloff = attenuation *
+                (1.0 - pow(clamp(
+                  exitPointToLightLength / light.bounds.x,
+                  0.0,
+                  1.0), 2.0));
+            }
+            else if(light.type == 2)
+            {
+              float attenuation = 1.0 /
+                (light.attenuation.x +
+                  light.attenuation.y * exitPointToLightLength +
+                  light.attenuation.z *
+                    exitPointToLightLength * exitPointToLightLength);
+              float coneRange = light.cutOff.x - light.cutOff.y;
+              float coneCos = dot(
+                transmissionLi,
+                normalize(-light.direction));
+              transmissionFalloff = attenuation * clamp(
+                (coneCos - light.cutOff.y) / max(coneRange, Epsilon),
+                0.0,
+                1.0);
+            }
+
+            vec3 volumeAttenuation = GetVolumeAttenuation(
+              transmissionRayLength,
+              material.attenuationColor.rgb,
+              material.attenuationDistance);
+            directLighting += material.baseColorFactor.rgb *
+              transmissionDistribution * transmissionVisibility *
+              volumeAttenuation * (vec3(1.0) - transmissionFresnel) *
+              dielectricTransmission * Lradiance * transmissionFalloff;
+          }
+        }
+      }
+    }
+  #endif
+
     // Total contribution for this light.
-    return shadow * ((diffuseBRDF + specularBRDF) * Lradiance * cosLi) * falloff;    
+    return shadow * directLighting;
   }
   
   vec3 AmbientLighting(MaterialData material, vec3 F0, vec3 Lr, vec3 normal, float cosLo)
@@ -450,6 +676,9 @@ glslFragment: |
     
     // Get diffuse contribution factor (as with direct lighting).
     vec3 kd = mix(vec3(1.0) - F, vec3(0.0), material.metallicFactor);
+  #ifdef TRANSMISSION
+    kd *= 1.0 - material.transmissionFactor;
+  #endif
     
     // Irradiance map contains exitant radiance assuming Lambertian BRDF, no need to scale by 1/PI here either.
     vec3 diffuseIBL = kd * material.baseColorFactor.xyz * irradiance;
@@ -486,10 +715,20 @@ glslFragment: |
         falloff = attenuation;
     }
 
-    vec3 Li = -light.direction;
+    vec3 pointToLight = light.type == 0 ?
+      -light.direction :
+      light.worldPosition - worldPos;
+    float pointToLightLengthSquared = dot(pointToLight, pointToLight);
+    vec3 Li = pointToLightLengthSquared > Epsilon ?
+      pointToLight * inversesqrt(pointToLightLengthSquared) :
+      vec3(0.0);
     vec3 Lradiance = light.intensity;
 
-    vec3 Lh = normalize(Li + Lo);
+    vec3 halfVector = Li + Lo;
+    float halfVectorLengthSquared = dot(halfVector, halfVector);
+    vec3 Lh = halfVectorLengthSquared > Epsilon ?
+      halfVector * inversesqrt(halfVectorLengthSquared) :
+      normal;
     float cosLi = max(0.0, dot(normal, Li));
     float cosLh = max(0.0, dot(normal, Lh));
 
@@ -527,10 +766,20 @@ glslFragment: |
         falloff = attenuation;
     }
 
-    vec3 Li = -light.direction;
+    vec3 pointToLight = light.type == 0 ?
+      -light.direction :
+      light.worldPosition - worldPos;
+    float pointToLightLengthSquared = dot(pointToLight, pointToLight);
+    vec3 Li = pointToLightLengthSquared > Epsilon ?
+      pointToLight * inversesqrt(pointToLightLengthSquared) :
+      vec3(0.0);
     vec3 Lradiance = light.intensity;
 
-    vec3 Lh = normalize(Li + Lo);
+    vec3 halfVector = Li + Lo;
+    float halfVectorLengthSquared = dot(halfVector, halfVector);
+    vec3 Lh = halfVectorLengthSquared > Epsilon ?
+      halfVector * inversesqrt(halfVectorLengthSquared) :
+      normal;
     float cosLi = max(0.0, dot(normal, Li));
     float cosLh = max(0.0, dot(normal, Lh));
 
@@ -607,6 +856,21 @@ glslFragment: |
       material.sheenRoughnessFactor = material.sheenRoughnessFactor * texture(textureSamplers[nonuniformEXT(material.sheenRoughnessSampler)], vin.texcoord).g;
     }
   #endif
+  #ifdef TRANSMISSION
+    material.transmissionFactor = clamp(material.transmissionFactor, 0.0, 1.0);
+    if(material.transmissionSampler != 0)
+    {
+      material.transmissionFactor *= texture(textureSamplers[nonuniformEXT(material.transmissionSampler)], vin.texcoord).r;
+    }
+    material.thicknessFactor = max(material.thicknessFactor, 0.0);
+    if(material.thicknessSampler != 0)
+    {
+      material.thicknessFactor *= texture(textureSamplers[nonuniformEXT(material.thicknessSampler)], vin.texcoord).g;
+    }
+    material.indexOfRefraction = max(material.indexOfRefraction, 1.0);
+    material.attenuationDistance = max(material.attenuationDistance, Epsilon);
+    material.attenuationColor = clamp(material.attenuationColor, vec4(0.0), vec4(1.0));
+  #endif
 
     vec3 normal;
     if(material.normalSampler != 0)
@@ -642,7 +906,12 @@ glslFragment: |
     vec3 Lr = 2.0 * cosLo * normal + viewDirection;
     
     // Fresnel reflectance at normal incidence (for metals use albedo color).
+  #ifdef TRANSMISSION
+    float iorFresnel = (material.indexOfRefraction - 1.0) / (material.indexOfRefraction + 1.0);
+    vec3 F0 = mix(vec3(iorFresnel * iorFresnel), material.baseColorFactor.xyz, material.metallicFactor);
+  #else
     vec3 F0 = mix(Fdielectric, material.baseColorFactor.xyz, material.metallicFactor);
+  #endif
     
   #ifdef ALPHA_CUTOUT
     if(material.baseColorFactor.a < material.alphaCutoff)
@@ -690,6 +959,91 @@ glslFragment: |
         outColor.xyz += SheenLighting(light.instance[index], material.sheenRoughnessFactor, material.sheenColorFactor.rgb, -viewDirection, cosLo, normal, vin.worldPosition);
   #endif
     }
+
+  #ifdef TRANSMISSION
+    float dielectricFresnel =
+      (material.indexOfRefraction - 1.0) /
+      (material.indexOfRefraction + 1.0);
+    vec3 dielectricF0 = vec3(dielectricFresnel * dielectricFresnel);
+    vec2 transmissionBrdf = texture(
+      g_brdfSampler,
+      clamp(vec2(cosLo, material.roughnessFactor), vec2(0.0), vec2(1.0))).rg;
+    vec3 transmissionFresnel = clamp(
+      dielectricF0 * transmissionBrdf.x + transmissionBrdf.y,
+      vec3(0.0),
+      vec3(1.0));
+    vec3 refractionNormal = gl_FrontFacing ? normal : -normal;
+    vec3 refractionDirection = GetRefractionDirection(
+      refractionNormal,
+      -viewDirection,
+      material.indexOfRefraction);
+    vec3 transmissionRay = GetVolumeTransmissionRay(
+      refractionDirection,
+      material.thicknessFactor,
+      vin.modelScale);
+    float canTransmit = step(Epsilon, dot(
+      refractionDirection,
+      refractionDirection));
+    vec4 exitClip = frame.projection * frame.view * vec4(vin.worldPosition + transmissionRay, 1.0);
+    vec2 transmissionUv = viewportUv;
+    float transmissionUvWeight = 0.0;
+    if(exitClip.w > Epsilon)
+    {
+      vec2 exitNdc = exitClip.xy / exitClip.w;
+      vec2 exitUv = vec2(
+        exitNdc.x * 0.5 + 0.5,
+        0.5 - exitNdc.y * 0.5);
+      float exitEdgeDistance = min(
+        min(exitUv.x, 1.0 - exitUv.x),
+        min(exitUv.y, 1.0 - exitUv.y));
+      transmissionUvWeight = smoothstep(0.0, 0.025, exitEdgeDistance);
+      transmissionUv = clamp(exitUv, vec2(0.0), vec2(1.0));
+    }
+
+    float transmissionDistance = length(transmissionRay);
+    vec3 volumeAttenuation = GetVolumeAttenuation(
+      transmissionDistance,
+      material.attenuationColor.rgb,
+      material.attenuationDistance);
+
+    float transmissionRoughness = ApplyIorToRoughness(
+      material.roughnessFactor,
+      material.indexOfRefraction);
+    int transmissionMipCount = textureQueryLevels(g_transmissionFramebufferSampler);
+    float transmissionFramebufferWidth = float(max(
+      textureSize(g_transmissionFramebufferSampler, 0).x,
+      1));
+    float transmissionLod = clamp(
+      log2(transmissionFramebufferWidth) * transmissionRoughness,
+      0.0,
+      float(max(transmissionMipCount - 1, 0)));
+    vec3 framebufferRadiance = textureLod(
+      g_transmissionFramebufferSampler,
+      transmissionUv,
+      transmissionLod).rgb;
+    int transmissionEnvMipCount = textureQueryLevels(g_envCubemap);
+    float transmissionEnvLod = transmissionRoughness *
+      float(max(transmissionEnvMipCount - 1, 0));
+    vec3 environmentDirection = mix(
+      -viewDirection,
+      refractionDirection,
+      canTransmit);
+    vec3 environmentRadiance = textureLod(
+      g_envCubemap,
+      environmentDirection,
+      transmissionEnvLod).rgb;
+    vec3 transmittedColor = mix(
+      environmentRadiance,
+      framebufferRadiance,
+      transmissionUvWeight);
+    transmittedColor *= material.baseColorFactor.rgb * volumeAttenuation;
+    float dielectricTransmission = material.transmissionFactor *
+      (1.0 - clamp(material.metallicFactor, 0.0, 1.0)) *
+      canTransmit;
+    outColor.xyz += transmittedColor *
+      (vec3(1.0) - transmissionFresnel) *
+      dielectricTransmission;
+  #endif
 
     outColor.a = material.baseColorFactor.a;    
   }

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -184,13 +184,29 @@ glslVertex: |
 
     gl_Position = frame.projection * (frame.view * vertexPosition);
 
-    vec3 normal = (modelMatrix * vec4(inNormal, 0.0)).xyz;
-    vec3 tangent = (modelMatrix * vec4(inTangent, 0.0)).xyz;
-    vec3 bitangent = (modelMatrix * vec4(inBitangent, 0.0)).xyz;
+    mat3 linearMatrix = mat3(modelMatrix);
+    mat3 normalMatrix = transpose(inverse(linearMatrix));
+    vec3 normal = normalize(normalMatrix * inNormal);
 
-    mat3 normalMatrix = transpose(inverse(mat3(modelMatrix)));
-    vout.normal = normalize(normalMatrix * normal);
-    vout.tangentBasis = normalMatrix * mat3(tangent, bitangent, normal);
+    vec3 tangent = linearMatrix * inTangent;
+    tangent -= normal * dot(normal, tangent);
+    float tangentLengthSquared = dot(tangent, tangent);
+    if(tangentLengthSquared > 1e-8)
+    {
+      tangent *= inversesqrt(tangentLengthSquared);
+    }
+    else
+    {
+      vec3 fallbackAxis = abs(normal.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
+      tangent = normalize(cross(fallbackAxis, normal));
+    }
+
+    vec3 transformedBitangent = linearMatrix * inBitangent;
+    float handedness = dot(cross(normal, tangent), transformedBitangent) < 0.0 ? -1.0 : 1.0;
+    vec3 bitangent = normalize(cross(normal, tangent)) * handedness;
+
+    vout.normal = normal;
+    vout.tangentBasis = mat3(tangent, bitangent, normal);
 
     vout.color = inColor;
     vout.texcoord = inTexcoord;
@@ -595,7 +611,8 @@ glslFragment: |
     vec3 normal;
     if(material.normalSampler != 0)
     {
-      normal = normalize(2.0 * texture(textureSamplers[nonuniformEXT(material.normalSampler)], vin.texcoord).rgb - 1.0) * material.normalScale;
+      normal = 2.0 * texture(textureSamplers[nonuniformEXT(material.normalSampler)], vin.texcoord).rgb - 1.0;
+      normal.xy *= material.normalScale;
       normal = normalize(vin.tangentBasis * normal);
     }
     else
@@ -607,7 +624,8 @@ glslFragment: |
     vec3 clearcoatNormal = normal;
     if(material.clearcoatNormalSampler != 0)
     {
-      clearcoatNormal = normalize(2.0 * texture(textureSamplers[nonuniformEXT(material.clearcoatNormalSampler)], vin.texcoord).rgb - 1.0) * material.clearcoatNormalScale;
+      clearcoatNormal = 2.0 * texture(textureSamplers[nonuniformEXT(material.clearcoatNormalSampler)], vin.texcoord).rgb - 1.0;
+      clearcoatNormal.xy *= material.clearcoatNormalScale;
       clearcoatNormal = normalize(vin.tangentBasis * clearcoatNormal);
     }
     float cosLoCC = max(0.0, dot(clearcoatNormal, -viewDirection));

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -51,6 +51,7 @@ glslVertex: |
     uint skeletonOffset;
     uint isCulled;
     uint padding;
+    vec4 bakedVolumeScale;
   };
   
   struct MaterialData
@@ -132,7 +133,7 @@ glslVertex: |
   
   layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
   {
-      uint indices[];
+      uint indices[MAX_TEXTURES_IN_SCENE];
   } culledLights;
   
   layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
@@ -167,7 +168,15 @@ glslVertex: |
       MaterialData instance[];
   } material;
   
+  #if defined(SAILOR_TEXTURE_REMAP)
+  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
+  {
+      uint indices[MAX_TEXTURES_IN_SCENE];
+  } textureSamplerRemap;
+  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
+  #else
   layout(set=4, binding=0) uniform sampler2D textureSamplers[];
+  #endif
 
   #ifdef SKINNING
   layout(std430, set = 5, binding = 0) readonly buffer BoneMatricesSSBO
@@ -184,7 +193,8 @@ glslVertex: |
     vout.modelScale = vec3(
       length(instanceLinearMatrix[0]),
       length(instanceLinearMatrix[1]),
-      length(instanceLinearMatrix[2]));
+      length(instanceLinearMatrix[2])) *
+      data.instance[gl_InstanceIndex].bakedVolumeScale.xyz;
   #endif
   #ifdef SKINNING
     uint offset = data.instance[gl_InstanceIndex].skeletonOffset;
@@ -257,7 +267,10 @@ glslFragment: |
       mat4 model;
       vec4 sphereBounds;
       uint materialInstance;
+      uint skeletonOffset;
       uint isCulled;
+      uint padding;
+      vec4 bakedVolumeScale;
   };
   
   struct MaterialData
@@ -375,7 +388,28 @@ glslFragment: |
   //layout(set=3, binding=3) uniform sampler2D normalSampler;
   //layout(set=3, binding=4) uniform sampler2D roughnessSampler;
   
+  #if defined(SAILOR_TEXTURE_REMAP)
+  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
+  {
+      uint indices[];
+  } textureSamplerRemap;
+  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
+  #else
   layout(set=4, binding=0) uniform sampler2D textureSamplers[];
+  #endif
+
+  uint ResolveTextureSamplerIndex(uint globalTextureIndex)
+  {
+  #if defined(SAILOR_TEXTURE_REMAP)
+      if(globalTextureIndex >= MAX_TEXTURES_IN_SCENE)
+      {
+        return 0;
+      }
+      return textureSamplerRemap.indices[globalTextureIndex];
+  #else
+      return globalTextureIndex;
+  #endif
+  }
   
   MaterialData GetMaterialData()
   {
@@ -811,13 +845,13 @@ glslFragment: |
     MaterialData material = GetMaterialData();
     if(material.baseColorSampler != 0)
     {
-      material.baseColorFactor = material.baseColorFactor * texture(textureSamplers[nonuniformEXT(material.baseColorSampler)], vin.texcoord);
+      material.baseColorFactor = material.baseColorFactor * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.baseColorSampler))], vin.texcoord);
     }
     material.baseColorFactor *= vin.color;
 
     if(material.ormSampler != 0)
     {
-      vec4 orm = texture(textureSamplers[nonuniformEXT(material.ormSampler)], vin.texcoord);
+      vec4 orm = texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.ormSampler))], vin.texcoord);
       material.metallicFactor = material.metallicFactor * orm.b;
       material.roughnessFactor = material.roughnessFactor * orm.g;
     }
@@ -825,7 +859,7 @@ glslFragment: |
     float occlusion = texture(g_aoSampler, viewportUv).r;
     if(material.occlusionSampler != 0)
     {
-      float occlusionTex = texture(textureSamplers[nonuniformEXT(material.occlusionSampler)], vin.texcoord).r;
+      float occlusionTex = texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.occlusionSampler))], vin.texcoord).r;
       float mixed = mix(1.0, occlusionTex, material.occlusionStrength);
       occlusion = min(occlusion, mixed);
     }
@@ -833,39 +867,39 @@ glslFragment: |
 
     if(material.emissiveSampler != 0)
     {
-      material.emissiveFactor = material.emissiveFactor * texture(textureSamplers[nonuniformEXT(material.emissiveSampler)], vin.texcoord);
+      material.emissiveFactor = material.emissiveFactor * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.emissiveSampler))], vin.texcoord);
     }
 
   #ifdef CLEAR_COAT
     if(material.clearcoatSampler != 0)
     {
-      material.clearcoatFactor = material.clearcoatFactor * texture(textureSamplers[nonuniformEXT(material.clearcoatSampler)], vin.texcoord).r;
+      material.clearcoatFactor = material.clearcoatFactor * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.clearcoatSampler))], vin.texcoord).r;
     }
     if(material.clearcoatRoughnessSampler != 0)
     {
-      material.clearcoatRoughnessFactor = material.clearcoatRoughnessFactor * texture(textureSamplers[nonuniformEXT(material.clearcoatRoughnessSampler)], vin.texcoord).g;
+      material.clearcoatRoughnessFactor = material.clearcoatRoughnessFactor * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.clearcoatRoughnessSampler))], vin.texcoord).g;
     }
   #endif
   #ifdef SHEEN
     if(material.sheenColorSampler != 0)
     {
-      material.sheenColorFactor.rgb = material.sheenColorFactor.rgb * texture(textureSamplers[nonuniformEXT(material.sheenColorSampler)], vin.texcoord).rgb;
+      material.sheenColorFactor.rgb = material.sheenColorFactor.rgb * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.sheenColorSampler))], vin.texcoord).rgb;
     }
     if(material.sheenRoughnessSampler != 0)
     {
-      material.sheenRoughnessFactor = material.sheenRoughnessFactor * texture(textureSamplers[nonuniformEXT(material.sheenRoughnessSampler)], vin.texcoord).g;
+      material.sheenRoughnessFactor = material.sheenRoughnessFactor * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.sheenRoughnessSampler))], vin.texcoord).g;
     }
   #endif
   #ifdef TRANSMISSION
     material.transmissionFactor = clamp(material.transmissionFactor, 0.0, 1.0);
     if(material.transmissionSampler != 0)
     {
-      material.transmissionFactor *= texture(textureSamplers[nonuniformEXT(material.transmissionSampler)], vin.texcoord).r;
+      material.transmissionFactor *= texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.transmissionSampler))], vin.texcoord).r;
     }
     material.thicknessFactor = max(material.thicknessFactor, 0.0);
     if(material.thicknessSampler != 0)
     {
-      material.thicknessFactor *= texture(textureSamplers[nonuniformEXT(material.thicknessSampler)], vin.texcoord).g;
+      material.thicknessFactor *= texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.thicknessSampler))], vin.texcoord).g;
     }
     material.indexOfRefraction = max(material.indexOfRefraction, 1.0);
     material.attenuationDistance = max(material.attenuationDistance, Epsilon);
@@ -875,7 +909,7 @@ glslFragment: |
     vec3 normal;
     if(material.normalSampler != 0)
     {
-      normal = 2.0 * texture(textureSamplers[nonuniformEXT(material.normalSampler)], vin.texcoord).rgb - 1.0;
+      normal = 2.0 * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.normalSampler))], vin.texcoord).rgb - 1.0;
       normal.xy *= material.normalScale;
       normal = normalize(vin.tangentBasis * normal);
     }
@@ -888,7 +922,7 @@ glslFragment: |
     vec3 clearcoatNormal = normal;
     if(material.clearcoatNormalSampler != 0)
     {
-      clearcoatNormal = 2.0 * texture(textureSamplers[nonuniformEXT(material.clearcoatNormalSampler)], vin.texcoord).rgb - 1.0;
+      clearcoatNormal = 2.0 * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.clearcoatNormalSampler))], vin.texcoord).rgb - 1.0;
       clearcoatNormal.xy *= material.clearcoatNormalScale;
       clearcoatNormal = normalize(vin.tangentBasis * clearcoatNormal);
     }
@@ -923,17 +957,15 @@ glslFragment: |
     //outColor.xyz += vec3(texture(g_envCubemap, R).xyz);
     //outColor.xyz *= max(0.1, dot(normalize(-vec3(-0.3, -0.5, 0.1)), vin.normal.xyz)) * 0.5;
   
-    vec2 numTiles = floor(frame.viewportSize / LIGHTS_CULLING_TILE_SIZE);
-    vec2 screenUv = vec2(gl_FragCoord.x, frame.viewportSize.y - gl_FragCoord.y);
-    ivec2 tileId = ivec2(screenUv) / LIGHTS_CULLING_TILE_SIZE;
-    
-    ivec2 mod = ivec2(frame.viewportSize.x % LIGHTS_CULLING_TILE_SIZE, frame.viewportSize.y % LIGHTS_CULLING_TILE_SIZE);
-    ivec2 padding = ivec2(min(1, mod.x), min(1, mod.y));
-    
-    uint tileIndex = uint(tileId.y * (numTiles.x + padding.x) + tileId.x);
-  
-    const uint offset = lightsGrid.instance[tileIndex].offset;
-    const uint numLights = lightsGrid.instance[tileIndex].num;
+    const uint tileIndex = GetLightTileIndex(gl_FragCoord.xy, frame.viewportSize);
+    const uint gridLength = uint(lightsGrid.instance.length());
+    const bool hasLightTile = tileIndex < gridLength;
+    const uint offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0;
+    const uint listLength = uint(culledLights.indices.length());
+    const uint availableLights = offset < listLength ? listLength - offset : 0;
+    const uint numLights = hasLightTile ? min(
+        min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE)),
+        availableLights) : 0;
     
     outColor.xyz += AmbientLighting(material, F0, Lr, normal, cosLo);
   #ifdef CLEAR_COAT
@@ -946,9 +978,11 @@ glslFragment: |
     for(int i = 0; i < numLights; i++)
     {
         uint index = culledLights.indices[offset + i];
-        if(index == uint(-1))
+        if(index == uint(-1) ||
+            index >= uint(light.instance.length()) ||
+            light.instance[index].type == INVALID_LIGHT_TYPE)
         {
-            break;
+            continue;
         }
     
         outColor.xyz += CalculateLighting(light.instance[index], material, F0, -viewDirection, cosLo, normal, vin.worldPosition);

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -500,18 +500,13 @@ glslFragment: |
     if(light.type == 0)
     {
         const int cascadeLayer = min(SelectCascade(frame.view, worldPos, frame.cameraZNearZFar), NUM_CSM_CASCADES - 1);
-        
-        // EVSM only for the first cascade
-        if(light.shadowType == 2 && cascadeLayer == 0)
-        {
-          const float bias = (1.0 - dot(normal, light.direction)) * (1 + cascadeLayer);
-          shadow = ShadowCalculation_Evsm(shadowMaps[cascadeLayer], lightsMatrices.instance[cascadeLayer] * vec4(worldPos, 1.0f), bias, cascadeLayer);
-        }
-        else
-        {
-          const float bias = max(0.000075 * (1.0 - dot(normal, light.direction)), 0.000005);   
-          shadow = ShadowCalculation_Pcf(shadowMaps[cascadeLayer], lightsMatrices.instance[cascadeLayer] * vec4(worldPos, 1.0f), bias, cascadeLayer);    
-        }
+        shadow = CalculateDirectionalShadow(
+          light.shadowType,
+          shadowMaps[cascadeLayer],
+          lightsMatrices.instance[cascadeLayer] * vec4(worldPos, 1.0f),
+          normal,
+          Li,
+          cascadeLayer);
     }
     // Point light
     else if(light.type == 1)
@@ -740,7 +735,13 @@ glslFragment: |
     if(light.type == 0)
     {
         const int cascadeLayer = min(SelectCascade(frame.view, worldPos, frame.cameraZNearZFar), NUM_CSM_CASCADES - 1);
-        shadow = ShadowCalculation_Pcf(shadowMaps[cascadeLayer], lightsMatrices.instance[cascadeLayer] * vec4(worldPos, 1.0f), 0.000075, cascadeLayer);
+        shadow = CalculateDirectionalShadow(
+          light.shadowType,
+          shadowMaps[cascadeLayer],
+          lightsMatrices.instance[cascadeLayer] * vec4(worldPos, 1.0f),
+          normal,
+          -light.direction,
+          cascadeLayer);
     }
     else if(light.type == 1 || light.type == 2)
     {
@@ -791,7 +792,13 @@ glslFragment: |
     if(light.type == 0)
     {
         const int cascadeLayer = min(SelectCascade(frame.view, worldPos, frame.cameraZNearZFar), NUM_CSM_CASCADES - 1);
-        shadow = ShadowCalculation_Pcf(shadowMaps[cascadeLayer], lightsMatrices.instance[cascadeLayer] * vec4(worldPos, 1.0f), 0.000075, cascadeLayer);
+        shadow = CalculateDirectionalShadow(
+          light.shadowType,
+          shadowMaps[cascadeLayer],
+          lightsMatrices.instance[cascadeLayer] * vec4(worldPos, 1.0f),
+          normal,
+          -light.direction,
+          cascadeLayer);
     }
     else if(light.type == 1 || light.type == 2)
     {

--- a/Content/Shaders/Unlit.shader
+++ b/Content/Shaders/Unlit.shader
@@ -39,6 +39,7 @@ glslVertex: |
       uint skeletonOffset;
       uint isCulled;
       uint padding;
+      vec4 bakedVolumeScale;
   };
   
   struct MaterialData
@@ -88,7 +89,7 @@ glslVertex: |
   
   layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
   {
-      uint indices[];
+      uint indices[MAX_TEXTURES_IN_SCENE];
   } culledLights;
   
   layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
@@ -123,7 +124,15 @@ glslVertex: |
       MaterialData instance[];
   } material;
   
+  #if defined(SAILOR_TEXTURE_REMAP)
+  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
+  {
+      uint indices[MAX_TEXTURES_IN_SCENE];
+  } textureSamplerRemap;
+  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
+  #else
   layout(set=4, binding=0) uniform sampler2D textureSamplers[];
+  #endif
   
   void main() 
   {
@@ -172,6 +181,7 @@ glslFragment: |
       uint skeletonOffset;
       uint isCulled;
       uint padding;
+      vec4 bakedVolumeScale;
   };
   
   struct MaterialData
@@ -256,7 +266,15 @@ glslFragment: |
       MaterialData instance[];
   } material;
   
+  #if defined(SAILOR_TEXTURE_REMAP)
+  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
+  {
+      uint indices[];
+  } textureSamplerRemap;
+  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
+  #else
   layout(set=4, binding=0) uniform sampler2D textureSamplers[];
+  #endif
   
   MaterialData GetMaterialData()
   {

--- a/Editor.Tests/EditorEngineProtocolTests.cs
+++ b/Editor.Tests/EditorEngineProtocolTests.cs
@@ -29,6 +29,27 @@ public sealed class EditorEngineProtocolTests
     }
 
     [Fact]
+    public void UpdateAssetRoundTrip_PreservesFileId()
+    {
+        var request = new ProtocolRequest
+        {
+            ProtocolVersion = 1,
+            RequestId = 57,
+            UpdateAsset = new FileIdRequest
+            {
+                FileId = "{01234567-89AB-CDEF-0123-456789ABCDEF}"
+            }
+        };
+
+        var parsed = ProtocolRequest.Parser.ParseFrom(request.ToByteArray());
+
+        Assert.Equal(ProtocolRequest.CommandOneofCase.UpdateAsset, parsed.CommandCase);
+        Assert.Equal(
+            "{01234567-89AB-CDEF-0123-456789ABCDEF}",
+            parsed.UpdateAsset.FileId);
+    }
+
+    [Fact]
     public void ResponseRoundTrip_PreservesTypedViewportEvent()
     {
         var response = new ProtocolResponse
@@ -96,6 +117,7 @@ public sealed class EditorEngineProtocolTests
             47,
             ProtocolRequest.IsEngineMainThreadReadyFieldNumber);
         Assert.Equal(48, ProtocolRequest.IsEngineRunningFieldNumber);
+        Assert.Equal(57, ProtocolRequest.UpdateAssetFieldNumber);
         Assert.Equal(10, ProtocolResponse.EmptyResultFieldNumber);
         Assert.Equal(19, ProtocolResponse.ViewportEventBatchResultFieldNumber);
     }

--- a/Editor.Tests/EditorViewportEventContractTests.cs
+++ b/Editor.Tests/EditorViewportEventContractTests.cs
@@ -508,6 +508,10 @@ public sealed class EditorViewportEventContractTests
             secondaryDrag,
             "case UIGestureRecognizerState.Changed:",
             "case UIGestureRecognizerState.Ended:");
+        var uiKitMotion = Slice(
+            source,
+            "bool PrepareUIKitPointerMotion(CGPoint point)",
+            "void ClearActivePointerState()");
         var mouseAttachment = Slice(
             source,
             "void AttachMouseInput()",
@@ -581,14 +585,13 @@ public sealed class EditorViewportEventContractTests
             "TryUsePointerMotionSource(PointerMotionSource.UIKit)",
             secondaryDragBegan,
             StringComparison.Ordinal);
-        Assert.Contains(
+        Assert.Contains("PrepareUIKitPointerMotion(point)", secondaryDragChanged, StringComparison.Ordinal);
+        AssertInOrder(
+            uiKitMotion,
+            "pointerMotionSource == PointerMotionSource.GameController",
             "pointerMotionSource = PointerMotionSource.UIKit;",
-            secondaryDragChanged,
-            StringComparison.Ordinal);
-        Assert.DoesNotContain(
-            "TryUsePointerMotionSource(PointerMotionSource.UIKit)",
-            secondaryDragChanged,
-            StringComparison.Ordinal);
+            "RecordPointerSample(point);",
+            "return !switchedFromGameController;");
         Assert.Contains("queuedPointerActivityRevision", buttonHandler, StringComparison.Ordinal);
         Assert.Contains("if (!isAttachedToWindow || isDisposed)", source, StringComparison.Ordinal);
         Assert.Contains("protected override void Dispose(bool disposing)", source, StringComparison.Ordinal);

--- a/Editor.Tests/EditorViewportEventContractTests.cs
+++ b/Editor.Tests/EditorViewportEventContractTests.cs
@@ -487,12 +487,35 @@ public sealed class EditorViewportEventContractTests
             "Platforms",
             "MacCatalyst",
             "NativeSceneViewportHandler.MacCatalyst.cs");
+        var infoPlist = ReadRepositoryFile(
+            "Editor",
+            "Platforms",
+            "MacCatalyst",
+            "Info.plist");
+        var project = ReadRepositoryFile("Editor", "SailorEditor.csproj");
         var buttonHandler = Slice(source, "void HandleMouseButtonChanged", "void RecordPointerSample");
         var windowLifecycle = Slice(source, "public override void WillMoveToWindow", "protected override void Dispose");
         var touches = Slice(source, "public override void TouchesBegan", "public override void PressesBegan");
+        var secondaryDrag = Slice(
+            source,
+            "void HandleViewportSecondaryPointerDrag(",
+            "void PublishTouchMove(");
+        var secondaryDragBegan = Slice(
+            secondaryDrag,
+            "case UIGestureRecognizerState.Began:",
+            "case UIGestureRecognizerState.Changed:");
+        var secondaryDragChanged = Slice(
+            secondaryDrag,
+            "case UIGestureRecognizerState.Changed:",
+            "case UIGestureRecognizerState.Ended:");
+        var mouseAttachment = Slice(
+            source,
+            "void AttachMouseInput()",
+            "void ReleaseMouseInput()");
 
         AssertInOrder(
             buttonHandler,
+            "TryRecordSystemPointerSample();",
             "SceneViewportPointerRouting.ShouldAcceptMouseButton(",
             "QueueFocusReleaseIfPointerRemainsOutside();",
             "if (!IsFirstResponder)",
@@ -509,12 +532,63 @@ public sealed class EditorViewportEventContractTests
             "ReleaseInputObservers();");
         Assert.Contains("ReferenceEquals(mouseInputOwner, this)", source, StringComparison.Ordinal);
         Assert.Contains("releaseInput = releasedOwner.DetachMouseInputForReplacement();", source, StringComparison.Ordinal);
-        Assert.Contains("activeMouseModifiers != NativeSceneViewportInputModifier.None", touches, StringComparison.Ordinal);
+        Assert.Contains("activeLocalPointerModifier = ResolvePointerModifier(evt);", touches, StringComparison.Ordinal);
+        Assert.DoesNotContain("activeMouseModifiers != NativeSceneViewportInputModifier.None", touches, StringComparison.Ordinal);
+        Assert.Contains("TryUsePointerMotionSource(PointerMotionSource.UIKit)", source, StringComparison.Ordinal);
+        Assert.Contains("TryUsePointerMotionSource(PointerMotionSource.GameController)", source, StringComparison.Ordinal);
+        Assert.Contains("HasPointerMoved(point)", source, StringComparison.Ordinal);
+        Assert.Contains("deltaX == 0.0f && deltaY == 0.0f", source, StringComparison.Ordinal);
+        Assert.Contains("SecondaryPointerDragGestureRecognizer", source, StringComparison.Ordinal);
+        Assert.Contains("public override bool ShouldReceive(UIEvent evt)", source, StringComparison.Ordinal);
+        Assert.Contains("public override void TouchesBegan(NSSet touches, UIEvent evt)", source, StringComparison.Ordinal);
+        Assert.Contains("public override void TouchesMoved(NSSet touches, UIEvent evt)", source, StringComparison.Ordinal);
+        Assert.Contains("public override void TouchesEnded(NSSet touches, UIEvent evt)", source, StringComparison.Ordinal);
+        Assert.Contains("public override void TouchesCancelled(NSSet touches, UIEvent evt)", source, StringComparison.Ordinal);
+        Assert.Contains("(evt.ButtonMask & UIEventButtonMask.Secondary) != 0", source, StringComparison.Ordinal);
+        Assert.Contains("HandleViewportSecondaryPointerDrag", source, StringComparison.Ordinal);
+        Assert.Contains("<key>UIApplicationSupportsIndirectInputEvents</key>", infoPlist, StringComparison.Ordinal);
+        Assert.Contains("<true/>", infoPlist, StringComparison.Ordinal);
+        Assert.Contains("<ApplicationManifest Condition=", project, StringComparison.Ordinal);
+        Assert.Contains("Platforms\\MacCatalyst\\Info.plist</ApplicationManifest>", project, StringComparison.Ordinal);
+        Assert.Contains("PublishLocalPointerButton(point, modifier, true)", source, StringComparison.Ordinal);
+        Assert.Contains("PublishLocalPointerButton(point, modifier, false)", source, StringComparison.Ordinal);
         Assert.Contains("PublishTouchButton(touches, activeLocalPointerModifier, false);", touches, StringComparison.Ordinal);
         Assert.Contains("Trackpads can provide GCMouse motion without", touches, StringComparison.Ordinal);
-        Assert.Contains("mouseInput.MouseMovedHandler = HandleMouseMoved;", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("ObserveDidBecomeCurrent", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("ObserveDidStopBeingCurrent", source, StringComparison.Ordinal);
+        Assert.Contains("foreach (var mouse in GCMouse.Mice)", mouseAttachment, StringComparison.Ordinal);
+        Assert.Contains("input.MouseMovedHandler = HandleMouseMoved;", source, StringComparison.Ordinal);
+        Assert.Contains("mouse.HandlerQueue = DispatchQueue.MainQueue;", mouseAttachment, StringComparison.Ordinal);
+        AssertInOrder(
+            mouseAttachment,
+            "releasedOwner.Publish(captureInput);",
+            "SynchronizePressedMouseButtons(attachedInput);");
+        Assert.Contains("input.LeftButton.IsPressed", mouseAttachment, StringComparison.Ordinal);
+        Assert.Contains("input.RightButton.IsPressed", mouseAttachment, StringComparison.Ordinal);
+        Assert.Contains("input.MiddleButton?.IsPressed == true", mouseAttachment, StringComparison.Ordinal);
+        Assert.Contains("new CGEvent((CGEventSource?)null)", source, StringComparison.Ordinal);
+        Assert.Contains("window.ConvertPointFromCoordinateSpace(", source, StringComparison.Ordinal);
+        Assert.Contains("window.HitTest(windowPoint, null)", source, StringComparison.Ordinal);
+        Assert.Contains("ConvertPointFromView(windowPoint, window)", source, StringComparison.Ordinal);
+        Assert.Contains("RecordPointerSample(localPoint);", source, StringComparison.Ordinal);
         Assert.Contains("(deltaX * sensitivity) / scale", source, StringComparison.Ordinal);
         Assert.Contains("(deltaY * sensitivity) / scale", source, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "pointerMotionSource = PointerMotionSource.UIKit;",
+            secondaryDragBegan,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "TryUsePointerMotionSource(PointerMotionSource.UIKit)",
+            secondaryDragBegan,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "pointerMotionSource = PointerMotionSource.UIKit;",
+            secondaryDragChanged,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "TryUsePointerMotionSource(PointerMotionSource.UIKit)",
+            secondaryDragChanged,
+            StringComparison.Ordinal);
         Assert.Contains("queuedPointerActivityRevision", buttonHandler, StringComparison.Ordinal);
         Assert.Contains("if (!isAttachedToWindow || isDisposed)", source, StringComparison.Ordinal);
         Assert.Contains("protected override void Dispose(bool disposing)", source, StringComparison.Ordinal);

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -887,6 +887,91 @@ public sealed class EngineLifecycleTests
     }
 
     [Fact]
+    public void ExistingAssetSave_UsesTargetedUpdateWithoutScanningContent()
+    {
+        var controlPanelSource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "InspectorView",
+            "ControlPanelView.xaml.cs");
+        var assetsSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "AssetsService.cs");
+        var worldSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "WorldService.cs");
+        var engineServiceSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "EngineService.cs");
+        var protocolClientSource = ReadRepositoryFile(
+            "Editor",
+            "Protocol",
+            "EngineProtocolClient.cs");
+        var protocolDispatcherSource = ReadRepositoryFile(
+            "Lib",
+            "EditorEngineProtocol.cpp");
+        var nativeSource = ReadRepositoryFile("Runtime", "Sailor.cpp");
+
+        Assert.Contains(
+            "assetsService.SaveAssetAsync(assetFile)",
+            controlPanelSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "RequestAssetReloadAsync",
+            controlPanelSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "public async Task<bool> SaveExistingAssetAsync(",
+            assetsSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "return await _engineService.UpdateAssetAsync(",
+            assetsSource,
+            StringComparison.Ordinal);
+        var existingWorldSaveStart = worldSource.IndexOf(
+            "async Task<SceneSaveResult> SaveExistingWorldAsync(",
+            StringComparison.Ordinal);
+        var existingWorldSaveEnd = worldSource.IndexOf(
+            "async Task<SceneSaveResult> SaveCurrentWorldAsAsync(",
+            existingWorldSaveStart,
+            StringComparison.Ordinal);
+        Assert.True(existingWorldSaveStart >= 0);
+        Assert.True(existingWorldSaveEnd > existingWorldSaveStart);
+        Assert.Contains(
+            "assetsService.SaveExistingAssetAsync(",
+            worldSource[existingWorldSaveStart..existingWorldSaveEnd],
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "protocolClient.UpdateAssetAsync(stringId, token)",
+            engineServiceSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "UpdateAsset = new FileIdRequest",
+            protocolClientSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "case ProtocolRequest::kUpdateAsset:",
+            protocolDispatcherSource,
+            StringComparison.Ordinal);
+
+        var updateAssetStart = nativeSource.IndexOf(
+            "bool App::UpdateAsset(",
+            StringComparison.Ordinal);
+        var updateAssetEnd = nativeSource.IndexOf(
+            "\nbool App::",
+            updateAssetStart + 1,
+            StringComparison.Ordinal);
+        Assert.True(updateAssetStart >= 0);
+        Assert.True(updateAssetEnd > updateAssetStart);
+        var updateAssetBody = nativeSource[updateAssetStart..updateAssetEnd];
+        Assert.DoesNotContain("ScanContentFolder", updateAssetBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("WaitIdle", updateAssetBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void AssetProjection_TreatsGlslAsShaderLibraryDespiteSharedNativeAssetInfoType()
     {
         var assetsSource = ReadRepositoryFile("Editor", "Services", "AssetsService.cs");

--- a/Editor.Tests/EngineProtocolClientTests.cs
+++ b/Editor.Tests/EngineProtocolClientTests.cs
@@ -144,6 +144,29 @@ public sealed class EngineProtocolClientTests
     }
 
     [Fact]
+    public async Task UpdateAssetAsync_SendsExactFileId()
+    {
+        ProtocolRequest? capturedRequest = null;
+        var client = CreateClient(request =>
+        {
+            capturedRequest = request;
+            return Success(
+                request,
+                response => response.BoolResult =
+                    new BoolResult { Value = true });
+        });
+        const string fileId = "{01234567-89AB-CDEF-0123-456789ABCDEF}";
+
+        Assert.True(await client.UpdateAssetAsync(fileId));
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(
+            ProtocolRequest.CommandOneofCase.UpdateAsset,
+            capturedRequest.CommandCase);
+        Assert.Equal(fileId, capturedRequest.UpdateAsset.FileId);
+    }
+
+    [Fact]
     public async Task InvokeAsync_RejectsMalformedTransportResponse()
     {
         var client = CreateRawClient(_ => [0xFF]);

--- a/Editor.Tests/ProtocolAsyncContractTests.cs
+++ b/Editor.Tests/ProtocolAsyncContractTests.cs
@@ -138,6 +138,7 @@ public sealed class ProtocolAsyncContractTests
             "Stop",
             "Shutdown",
             "RequestAssetReload",
+            "UpdateAsset",
             "GetAssetReloadState",
             "GetExitCode",
             "IsEngineMainThreadReady",

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -706,6 +706,15 @@ public sealed class WorkflowProjectionTests
             componentTemplateSource,
             StringComparison.Ordinal);
         Assert.Contains(
+            "foreach (var property in EnumerateInspectorProperties(component))",
+            componentTemplateSource,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            componentTemplateSource,
+            "TryGetValue(\"model\"",
+            "TryGetValue(\"overrideMaterials\"",
+            "if (property.Key is \"model\" or \"overrideMaterials\")");
+        Assert.Contains(
             "propertyName == \"overrideMaterials\"",
             componentTemplateSource,
             StringComparison.Ordinal);
@@ -725,6 +734,22 @@ public sealed class WorkflowProjectionTests
         Assert.Contains(
             "public static View FileIdListEditor(",
             templatesSource,
+            StringComparison.Ordinal);
+        var fileIdListEditorSource = Slice(
+            templatesSource,
+            "public static View FileIdListEditor(",
+            "public static View InstanceIdEditor<");
+        Assert.Contains(
+            "var listEditor = new VerticalStackLayout",
+            fileIdListEditorSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "BindableLayout.SetItemsSource(listEditor, fileIds.Values);",
+            fileIdListEditorSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "CollectionView",
+            fileIdListEditorSource,
             StringComparison.Ordinal);
         Assert.Contains(
             "fileIds.Values.Add(new Observable<FileId>(new FileId()))",

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -661,6 +661,86 @@ public sealed class WorkflowProjectionTests
     }
 
     [Fact]
+    public void ComponentFileIdLists_RoundTripAndUseAReusableInspectorEditor()
+    {
+        var componentSource = ReadRepositoryFile(
+            "Editor",
+            "ViewModels",
+            "Component.cs");
+        var componentTemplateSource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "InspectorView",
+            "ComponentTemplate.cs");
+        var assetTemplateSource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "InspectorView",
+            "AssetFileTemplate.xaml.cs");
+        var templatesSource = ReadRepositoryFile(
+            "Editor",
+            "Utility",
+            "Templates.cs");
+        var assetFileSource = ReadRepositoryFile(
+            "Editor",
+            "ViewModels",
+            "AssetFile.cs");
+
+        Assert.Contains(
+            "Property<List<FileId>> => DeserializeFileIdList(",
+            componentSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "case ObservableFileIdList assetIds:",
+            componentSource,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            componentSource,
+            "case ObservableFileIdList assetIds:",
+            "new SequenceStart",
+            "fileIdConverter.WriteYaml(",
+            "new SequenceEnd");
+
+        Assert.Contains(
+            "ObservableFileIdList fileIds => Templates.FileIdListEditor(",
+            componentTemplateSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "propertyName == \"overrideMaterials\"",
+            componentTemplateSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "typeof(MaterialFile)",
+            componentTemplateSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "return Templates.FileIdListEditor(fileIds);",
+            assetTemplateSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "static View CreateFileIdListEditor(",
+            assetTemplateSource,
+            StringComparison.Ordinal);
+
+        Assert.Contains(
+            "public static View FileIdListEditor(",
+            templatesSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "fileIds.Values.Add(new Observable<FileId>(new FileId()))",
+            templatesSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Values.CollectionChanged += ValuesCollectionChanged;",
+            assetFileSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Values.ItemChanged += ValuesItemChanged;",
+            assetFileSource,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void RangedNumericEditors_PreviewSliderValuesWithoutApplyingEntrySetters()
     {
         var templatesSource = ReadRepositoryFile(

--- a/Editor/Platforms/MacCatalyst/Info.plist
+++ b/Editor/Platforms/MacCatalyst/Info.plist
@@ -11,6 +11,8 @@
 	<array>
 		<string>arm64</string>
 	</array>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Editor/Platforms/MacCatalyst/NativeSceneViewportHandler.MacCatalyst.cs
+++ b/Editor/Platforms/MacCatalyst/NativeSceneViewportHandler.MacCatalyst.cs
@@ -525,16 +525,12 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
 
                 case UIGestureRecognizerState.Changed:
                     if ((activeMouseModifiers & modifier) == 0 ||
-                        !HasPointerMoved(point))
+                        !HasPointerMoved(point) ||
+                        !PrepareUIKitPointerMotion(point))
                     {
                         return;
                     }
 
-                    // A physical mouse can report only the gesture begin via
-                    // UIKit and continue with GCMouse deltas. Claim UIKit only
-                    // after the local gesture delivers actual movement.
-                    pointerMotionSource = PointerMotionSource.UIKit;
-                    activeGameControllerInput = null;
                     PublishPointer(
                         NativeSceneViewportInputKind.PointerMove,
                         point,
@@ -567,14 +563,10 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
             if (TryGetTouchPoint(touches, out var point))
             {
                 if (activeLocalPointerModifier != NativeSceneViewportInputModifier.None &&
-                    !HasPointerMoved(point))
+                    (!HasPointerMoved(point) ||
+                        !PrepareUIKitPointerMotion(point)))
                 {
                     return;
-                }
-                if (activeLocalPointerModifier != NativeSceneViewportInputModifier.None)
-                {
-                    pointerMotionSource = PointerMotionSource.UIKit;
-                    activeGameControllerInput = null;
                 }
                 RecordPointerSample(point);
                 PublishPointer(NativeSceneViewportInputKind.PointerMove, point, 0, false);
@@ -1093,6 +1085,22 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                 pointerMotionSource = source;
             }
             return pointerMotionSource == source;
+        }
+
+        bool PrepareUIKitPointerMotion(CGPoint point)
+        {
+            var switchedFromGameController =
+                pointerMotionSource == PointerMotionSource.GameController;
+            pointerMotionSource = PointerMotionSource.UIKit;
+            activeGameControllerInput = null;
+            if (switchedFromGameController)
+            {
+                // UIKit reports an absolute point while GCMouse reports
+                // deltas. Rebase once when UIKit takes over so the two
+                // coordinate streams cannot create a false first movement.
+                RecordPointerSample(point);
+            }
+            return !switchedFromGameController;
         }
 
         void ClearActivePointerState()

--- a/Editor/Platforms/MacCatalyst/NativeSceneViewportHandler.MacCatalyst.cs
+++ b/Editor/Platforms/MacCatalyst/NativeSceneViewportHandler.MacCatalyst.cs
@@ -1,6 +1,7 @@
 #if MACCATALYST
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using CoreAnimation;
 using CoreGraphics;
@@ -169,18 +170,98 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
 
     sealed class NativeSceneViewportPlatformView : UIView
     {
+        enum PointerMotionSource
+        {
+            None,
+            UIKit,
+            GameController
+        }
+
+        sealed class SecondaryPointerDragGestureRecognizer : UIGestureRecognizer
+        {
+            readonly Action<UIGestureRecognizerState, CGPoint> publish;
+            CGPoint lastPoint;
+
+            public SecondaryPointerDragGestureRecognizer(
+                Action<UIGestureRecognizerState, CGPoint> publish)
+            {
+                this.publish = publish;
+            }
+
+            public override bool ShouldReceive(UIEvent evt)
+            {
+                var accepted =
+                    (evt.ButtonMask & UIEventButtonMask.Secondary) != 0;
+                return accepted;
+            }
+
+            public override void TouchesBegan(NSSet touches, UIEvent evt)
+            {
+                if (!TryGetPoint(touches, out lastPoint))
+                {
+                    State = UIGestureRecognizerState.Failed;
+                    return;
+                }
+
+                State = UIGestureRecognizerState.Began;
+                publish(UIGestureRecognizerState.Began, lastPoint);
+            }
+
+            public override void TouchesMoved(NSSet touches, UIEvent evt)
+            {
+                if (TryGetPoint(touches, out var point))
+                {
+                    lastPoint = point;
+                }
+
+                State = UIGestureRecognizerState.Changed;
+                publish(UIGestureRecognizerState.Changed, lastPoint);
+            }
+
+            public override void TouchesEnded(NSSet touches, UIEvent evt)
+            {
+                if (TryGetPoint(touches, out var point))
+                {
+                    lastPoint = point;
+                }
+
+                publish(UIGestureRecognizerState.Ended, lastPoint);
+                State = UIGestureRecognizerState.Ended;
+            }
+
+            public override void TouchesCancelled(NSSet touches, UIEvent evt)
+            {
+                publish(UIGestureRecognizerState.Cancelled, lastPoint);
+                State = UIGestureRecognizerState.Cancelled;
+            }
+
+            bool TryGetPoint(NSSet touches, out CGPoint point)
+            {
+                if (touches.AnyObject is UITouch touch)
+                {
+                    point = touch.LocationInView(View);
+                    return true;
+                }
+
+                point = lastPoint;
+                return false;
+            }
+        }
+
         static readonly object inputOwnershipGate = new();
         static NativeSceneViewportPlatformView? mouseInputOwner;
         static NativeSceneViewportPlatformView? keyboardInputOwner;
 
         readonly WeakReference<NativeSceneViewportHandler> owner;
         GCKeyboardInput? keyboardInput;
-        GCMouseInput? mouseInput;
+        readonly Dictionary<nint, GCMouseInput> mouseInputs = new();
         NSObject? keyboardDidConnectToken;
         NSObject? keyboardDidDisconnectToken;
         NSObject? mouseDidConnectToken;
         NSObject? mouseDidDisconnectToken;
         readonly UIHoverGestureRecognizer hoverGesture;
+        readonly SecondaryPointerDragGestureRecognizer secondaryPointerDragGesture;
+        GCMouseInput? activeGameControllerInput;
         NativeSceneViewportInputModifier activeMouseModifiers = NativeSceneViewportInputModifier.None;
         NativeSceneViewportInputModifier activeKeyboardModifiers = NativeSceneViewportInputModifier.None;
         NativeSceneViewportInputModifier activeLocalPointerModifier = NativeSceneViewportInputModifier.None;
@@ -189,8 +270,11 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
         bool isAttachedToWindow;
         bool isDisposed;
         bool isInputFocused;
+        PointerMotionSource pointerMotionSource;
         long pointerActivityRevision;
         CGPoint lastPointerSample;
+
+        bool HasMouseInputs => mouseInputs.Count != 0;
 
         public NativeSceneViewportPlatformView(NativeSceneViewportHandler handler)
         {
@@ -200,6 +284,15 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
 
             hoverGesture = new UIHoverGestureRecognizer(this, new Selector("handleViewportHover:"));
             AddGestureRecognizer(hoverGesture);
+
+            secondaryPointerDragGesture = new SecondaryPointerDragGestureRecognizer(
+                HandleViewportSecondaryPointerDrag)
+            {
+                CancelsTouchesInView = false,
+                DelaysTouchesBegan = false,
+                DelaysTouchesEnded = false
+            };
+            AddGestureRecognizer(secondaryPointerDragGesture);
         }
 
         public override bool CanBecomeFirstResponder => true;
@@ -234,21 +327,20 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
 
         public override void TouchesBegan(NSSet touches, UIEvent? evt)
         {
-            if (mouseInput != null &&
-                activeMouseModifiers != NativeSceneViewportInputModifier.None)
-            {
-                base.TouchesBegan(touches, evt);
-                return;
-            }
-
             activeLocalPointerModifier = ResolvePointerModifier(evt);
+            if (activeLocalPointerModifier != NativeSceneViewportInputModifier.None &&
+                (activeMouseModifiers & activeLocalPointerModifier) == 0)
+            {
+                pointerMotionSource = PointerMotionSource.None;
+            }
             PublishTouchButton(touches, activeLocalPointerModifier, true);
             base.TouchesBegan(touches, evt);
         }
 
         public override void TouchesMoved(NSSet touches, UIEvent? evt)
         {
-            if (mouseInput != null)
+            if (activeLocalPointerModifier == NativeSceneViewportInputModifier.None &&
+                HasMouseInputs)
             {
                 base.TouchesMoved(touches, evt);
                 return;
@@ -260,7 +352,7 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
 
         public override void TouchesEnded(NSSet touches, UIEvent? evt)
         {
-            if (mouseInput != null)
+            if (HasMouseInputs)
             {
                 // The same UIKit sequence that recovered a press must also
                 // release it. Trackpads can provide GCMouse motion without
@@ -278,7 +370,7 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
 
         public override void TouchesCancelled(NSSet touches, UIEvent? evt)
         {
-            if (mouseInput != null)
+            if (HasMouseInputs)
             {
                 activeLocalPointerModifier = NativeSceneViewportInputModifier.None;
                 ReleaseActivePointerState();
@@ -363,6 +455,8 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                 DisconnectInput();
                 RemoveGestureRecognizer(hoverGesture);
                 hoverGesture.Dispose();
+                RemoveGestureRecognizer(secondaryPointerDragGesture);
+                secondaryPointerDragGesture.Dispose();
             }
 
             base.Dispose(disposing);
@@ -376,6 +470,10 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                 UIGestureRecognizerState.Failed)
             {
                 hasActiveHover = false;
+                if (pointerMotionSource == PointerMotionSource.UIKit)
+                {
+                    pointerMotionSource = PointerMotionSource.None;
+                }
                 if (activeMouseModifiers == NativeSceneViewportInputModifier.None)
                 {
                     ResetPointerSample();
@@ -389,20 +487,95 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
             }
 
             hasActiveHover = true;
-            if (!SceneViewportPointerRouting.ShouldPublishHoverMove(activeMouseModifiers))
+            var point = gesture.LocationInView(this);
+            if (SceneViewportPointerRouting.ShouldPublishHoverMove(activeMouseModifiers))
+            {
+                pointerMotionSource = PointerMotionSource.None;
+            }
+            else if (!HasPointerMoved(point) ||
+                !TryUsePointerMotionSource(PointerMotionSource.UIKit))
             {
                 return;
             }
 
-            var point = gesture.LocationInView(this);
             RecordPointerSample(point);
             PublishPointer(NativeSceneViewportInputKind.PointerMove, point, 0, false);
+        }
+
+        void HandleViewportSecondaryPointerDrag(
+            UIGestureRecognizerState state,
+            CGPoint point)
+        {
+            const NativeSceneViewportInputModifier modifier =
+                NativeSceneViewportInputModifier.MouseRight;
+            switch (state)
+            {
+                case UIGestureRecognizerState.Began:
+                    activeLocalPointerModifier = modifier;
+                    if ((activeMouseModifiers & modifier) == 0 &&
+                        !PublishLocalPointerButton(point, modifier, true))
+                    {
+                        activeLocalPointerModifier = NativeSceneViewportInputModifier.None;
+                        pointerMotionSource = PointerMotionSource.None;
+                        return;
+                    }
+
+                    RecordPointerSample(point);
+                    break;
+
+                case UIGestureRecognizerState.Changed:
+                    if ((activeMouseModifiers & modifier) == 0 ||
+                        !HasPointerMoved(point))
+                    {
+                        return;
+                    }
+
+                    // A physical mouse can report only the gesture begin via
+                    // UIKit and continue with GCMouse deltas. Claim UIKit only
+                    // after the local gesture delivers actual movement.
+                    pointerMotionSource = PointerMotionSource.UIKit;
+                    activeGameControllerInput = null;
+                    PublishPointer(
+                        NativeSceneViewportInputKind.PointerMove,
+                        point,
+                        0,
+                        false);
+                    break;
+
+                case UIGestureRecognizerState.Ended:
+                case UIGestureRecognizerState.Cancelled:
+                case UIGestureRecognizerState.Failed:
+                    if (activeLocalPointerModifier == modifier &&
+                        (activeMouseModifiers & modifier) != 0)
+                    {
+                        PublishLocalPointerButton(point, modifier, false);
+                    }
+                    if (activeLocalPointerModifier == modifier)
+                    {
+                        activeLocalPointerModifier = NativeSceneViewportInputModifier.None;
+                    }
+                    if (pointerMotionSource == PointerMotionSource.UIKit)
+                    {
+                        pointerMotionSource = PointerMotionSource.None;
+                    }
+                    break;
+            }
         }
 
         void PublishTouchMove(NSSet touches)
         {
             if (TryGetTouchPoint(touches, out var point))
             {
+                if (activeLocalPointerModifier != NativeSceneViewportInputModifier.None &&
+                    !HasPointerMoved(point))
+                {
+                    return;
+                }
+                if (activeLocalPointerModifier != NativeSceneViewportInputModifier.None)
+                {
+                    pointerMotionSource = PointerMotionSource.UIKit;
+                    activeGameControllerInput = null;
+                }
                 RecordPointerSample(point);
                 PublishPointer(NativeSceneViewportInputKind.PointerMove, point, 0, false);
             }
@@ -419,6 +592,19 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                 return;
             }
 
+            PublishLocalPointerButton(point, modifier, pressed);
+        }
+
+        bool PublishLocalPointerButton(
+            CGPoint point,
+            NativeSceneViewportInputModifier modifier,
+            bool pressed)
+        {
+            if (modifier == NativeSceneViewportInputModifier.None)
+            {
+                return false;
+            }
+
             RecordPointerSample(point);
             if (!SceneViewportPointerRouting.ShouldAcceptMouseButton(
                 pressed,
@@ -427,7 +613,7 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                 activeMouseModifiers,
                 modifier))
             {
-                return;
+                return false;
             }
 
             if (pressed)
@@ -435,13 +621,18 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                 FocusInput();
                 if (!IsFirstResponder)
                 {
-                    return;
+                    return false;
                 }
                 activeMouseModifiers |= modifier;
             }
             else
             {
                 activeMouseModifiers &= ~modifier;
+                if (activeMouseModifiers == NativeSceneViewportInputModifier.None)
+                {
+                    pointerMotionSource = PointerMotionSource.None;
+                    activeGameControllerInput = null;
+                }
             }
 
             PublishPointer(
@@ -456,6 +647,7 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
             {
                 ResetPointerSample();
             }
+            return true;
         }
 
         bool TryGetTouchPoint(NSSet touches, out CGPoint point)
@@ -498,8 +690,19 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                 return;
             }
 
+            var availableInputs = new Dictionary<nint, GCMouseInput>();
+            foreach (var mouse in GCMouse.Mice)
+            {
+                mouse.HandlerQueue = DispatchQueue.MainQueue;
+                if (mouse.MouseInput is { } input)
+                {
+                    availableInputs[(nint)input.Handle] = input;
+                }
+            }
+
             NativeSceneViewportPlatformView? releasedOwner = null;
             NativeSceneViewportInputEvent? releaseInput = null;
+            var attachedInputs = new List<GCMouseInput>();
             lock (inputOwnershipGate)
             {
                 if (!isAttachedToWindow || isDisposed)
@@ -507,51 +710,155 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                     return;
                 }
 
-                var input = GCMouse.Current?.MouseInput;
-                if (ReferenceEquals(input, mouseInput) &&
-                    ReferenceEquals(mouseInputOwner, this))
+                if (availableInputs.Count != 0 &&
+                    mouseInputOwner != null &&
+                    !ReferenceEquals(mouseInputOwner, this))
                 {
-                    return;
+                    releasedOwner = mouseInputOwner;
+                    releaseInput = releasedOwner.DetachMouseInputForReplacement();
+                    mouseInputOwner = null;
+                }
+
+                if (availableInputs.Count != 0 && mouseInputOwner == null)
+                {
+                    mouseInputOwner = this;
                 }
 
                 if (ReferenceEquals(mouseInputOwner, this))
                 {
-                    releasedOwner = this;
-                    releaseInput = DetachMouseInputForReplacement();
-                    mouseInputOwner = null;
-                }
-                else
-                {
-                    mouseInput = null;
-                    activeLocalPointerModifier = NativeSceneViewportInputModifier.None;
-                    ResetPointerSample();
-                }
-
-                if (input != null)
-                {
-                    if (mouseInputOwner != null &&
-                        !ReferenceEquals(mouseInputOwner, this))
+                    var removedInputs = new List<nint>();
+                    var lostActiveInput = false;
+                    foreach (var pair in mouseInputs)
                     {
-                        releasedOwner = mouseInputOwner;
-                        releaseInput = releasedOwner.DetachMouseInputForReplacement();
+                        if (availableInputs.ContainsKey(pair.Key))
+                        {
+                            continue;
+                        }
+
+                        lostActiveInput |= ReferenceEquals(
+                            activeGameControllerInput,
+                            pair.Value);
+                        UnbindMouseInput(pair.Value);
+                        removedInputs.Add(pair.Key);
                     }
 
-                    mouseInputOwner = this;
-                    mouseInput = input;
-                    mouseInput.LeftButton.PressedChangedHandler = (_, _, pressed) => HandleMouseButtonChanged(0, NativeSceneViewportInputModifier.MouseLeft, pressed);
-                    mouseInput.RightButton.PressedChangedHandler = (_, _, pressed) => HandleMouseButtonChanged(1, NativeSceneViewportInputModifier.MouseRight, pressed);
-                    if (mouseInput.MiddleButton != null)
+                    foreach (var inputId in removedInputs)
                     {
-                        mouseInput.MiddleButton.PressedChangedHandler = (_, _, pressed) => HandleMouseButtonChanged(2, NativeSceneViewportInputModifier.MouseMiddle, pressed);
+                        mouseInputs.Remove(inputId);
                     }
-                    mouseInput.MouseMovedHandler = HandleMouseMoved;
-                    mouseInput.Scroll.ValueChangedHandler = HandleMouseScroll;
+
+                    if (lostActiveInput)
+                    {
+                        releasedOwner = this;
+                        releaseInput = CreatePointerCaptureReleaseInput();
+                        ClearActivePointerState();
+                    }
+
+                    foreach (var pair in availableInputs)
+                    {
+                        if (mouseInputs.ContainsKey(pair.Key))
+                        {
+                            continue;
+                        }
+
+                        BindMouseInput(pair.Value);
+                        mouseInputs.Add(pair.Key, pair.Value);
+                        attachedInputs.Add(pair.Value);
+                    }
+
+                    if (mouseInputs.Count == 0)
+                    {
+                        mouseInputOwner = null;
+                    }
                 }
             }
 
             if (releasedOwner != null && releaseInput is { } captureInput)
             {
                 releasedOwner.Publish(captureInput);
+            }
+            foreach (var attachedInput in attachedInputs)
+            {
+                SynchronizePressedMouseButtons(attachedInput);
+            }
+        }
+
+        void BindMouseInput(GCMouseInput input)
+        {
+            input.LeftButton.PressedChangedHandler = (_, _, pressed) =>
+                HandleMouseButtonChanged(
+                    input,
+                    0,
+                    NativeSceneViewportInputModifier.MouseLeft,
+                    pressed);
+            input.RightButton.PressedChangedHandler = (_, _, pressed) =>
+                HandleMouseButtonChanged(
+                    input,
+                    1,
+                    NativeSceneViewportInputModifier.MouseRight,
+                    pressed);
+            if (input.MiddleButton != null)
+            {
+                input.MiddleButton.PressedChangedHandler = (_, _, pressed) =>
+                    HandleMouseButtonChanged(
+                        input,
+                        2,
+                        NativeSceneViewportInputModifier.MouseMiddle,
+                        pressed);
+            }
+            input.MouseMovedHandler = HandleMouseMoved;
+            input.Scroll.ValueChangedHandler = HandleMouseScroll;
+        }
+
+        static void UnbindMouseInput(GCMouseInput input)
+        {
+            input.LeftButton.PressedChangedHandler = null;
+            input.RightButton.PressedChangedHandler = null;
+            if (input.MiddleButton != null)
+            {
+                input.MiddleButton.PressedChangedHandler = null;
+            }
+            input.MouseMovedHandler = null;
+            input.Scroll.ValueChangedHandler = null;
+        }
+
+        void SynchronizePressedMouseButtons(GCMouseInput input)
+        {
+            lock (inputOwnershipGate)
+            {
+                if (!isAttachedToWindow ||
+                    isDisposed ||
+                    !ReferenceEquals(mouseInputOwner, this) ||
+                    !mouseInputs.TryGetValue((nint)input.Handle, out var attachedInput) ||
+                    !ReferenceEquals(attachedInput, input))
+                {
+                    return;
+                }
+            }
+
+            if (input.LeftButton.IsPressed)
+            {
+                HandleMouseButtonChanged(
+                    input,
+                    0,
+                    NativeSceneViewportInputModifier.MouseLeft,
+                    true);
+            }
+            if (input.RightButton.IsPressed)
+            {
+                HandleMouseButtonChanged(
+                    input,
+                    1,
+                    NativeSceneViewportInputModifier.MouseRight,
+                    true);
+            }
+            if (input.MiddleButton?.IsPressed == true)
+            {
+                HandleMouseButtonChanged(
+                    input,
+                    2,
+                    NativeSceneViewportInputModifier.MouseMiddle,
+                    true);
             }
         }
 
@@ -567,9 +874,8 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                 }
                 else
                 {
-                    mouseInput = null;
-                    activeLocalPointerModifier = NativeSceneViewportInputModifier.None;
-                    ResetPointerSample();
+                    mouseInputs.Clear();
+                    ClearActivePointerState();
                 }
             }
 
@@ -582,34 +888,30 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
         NativeSceneViewportInputEvent? DetachMouseInputForReplacement()
         {
             var releaseInput = CreatePointerCaptureReleaseInput();
-            activeMouseModifiers = NativeSceneViewportInputModifier.None;
-            if (mouseInput != null)
+            foreach (var input in mouseInputs.Values)
             {
-                mouseInput.LeftButton.PressedChangedHandler = null;
-                mouseInput.RightButton.PressedChangedHandler = null;
-                if (mouseInput.MiddleButton != null)
-                {
-                    mouseInput.MiddleButton.PressedChangedHandler = null;
-                }
-                mouseInput.MouseMovedHandler = null;
-                mouseInput.Scroll.ValueChangedHandler = null;
+                UnbindMouseInput(input);
             }
 
-            mouseInput = null;
-            activeLocalPointerModifier = NativeSceneViewportInputModifier.None;
-            ResetPointerSample();
+            mouseInputs.Clear();
+            ClearActivePointerState();
             return releaseInput;
         }
 
-        void HandleMouseMoved(GCMouseInput _, float deltaX, float deltaY)
+        void HandleMouseMoved(GCMouseInput input, float deltaX, float deltaY)
         {
             if (!SceneViewportPointerRouting.ShouldPublishCapturedMove(
                 hasPointerSample,
-                activeMouseModifiers))
+                activeMouseModifiers) ||
+                (deltaX == 0.0f && deltaY == 0.0f) ||
+                (activeGameControllerInput != null &&
+                    !ReferenceEquals(activeGameControllerInput, input)) ||
+                !TryUsePointerMotionSource(PointerMotionSource.GameController))
             {
                 return;
             }
 
+            activeGameControllerInput ??= input;
             var sensitivity = 1.0;
             if ((activeMouseModifiers & NativeSceneViewportInputModifier.MouseRight) != 0 &&
                 owner.TryGetTarget(out var handler))
@@ -628,17 +930,35 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
             PublishPointer(NativeSceneViewportInputKind.PointerMove, point, 0, false);
         }
 
-        void HandleMouseButtonChanged(uint button, NativeSceneViewportInputModifier modifier, bool pressed)
+        void HandleMouseButtonChanged(
+            GCMouseInput input,
+            uint button,
+            NativeSceneViewportInputModifier modifier,
+            bool pressed)
         {
+            if (!pressed &&
+                activeGameControllerInput != null &&
+                !ReferenceEquals(activeGameControllerInput, input))
+            {
+                return;
+            }
+
+            var hasLocalHit = hasActiveHover;
+            if (pressed &&
+                activeMouseModifiers == NativeSceneViewportInputModifier.None &&
+                (!hasLocalHit || !hasPointerSample))
+            {
+                hasLocalHit = TryRecordSystemPointerSample();
+            }
             if (!SceneViewportPointerRouting.ShouldAcceptMouseButton(
                 pressed,
-                hasLocalHit: hasActiveHover,
+                hasLocalHit,
                 hasPointerSample,
                 activeMouseModifiers,
                 modifier))
             {
                 if (pressed &&
-                    !hasActiveHover &&
+                    !hasLocalHit &&
                     activeMouseModifiers == NativeSceneViewportInputModifier.None)
                 {
                     QueueFocusReleaseIfPointerRemainsOutside();
@@ -657,6 +977,11 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                     }
                 }
 
+                if (activeMouseModifiers == NativeSceneViewportInputModifier.None)
+                {
+                    pointerMotionSource = PointerMotionSource.None;
+                    activeGameControllerInput = input;
+                }
                 activeMouseModifiers |= modifier;
                 PublishPointer(NativeSceneViewportInputKind.PointerButton, lastPointerSample, button, true, activeMouseModifiers);
             }
@@ -664,11 +989,46 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
             {
                 activeMouseModifiers &= ~modifier;
                 PublishPointer(NativeSceneViewportInputKind.PointerButton, lastPointerSample, button, false, activeMouseModifiers);
+                if (activeMouseModifiers == NativeSceneViewportInputModifier.None)
+                {
+                    pointerMotionSource = PointerMotionSource.None;
+                    activeGameControllerInput = null;
+                }
                 if (!hasActiveHover && activeMouseModifiers == NativeSceneViewportInputModifier.None)
                 {
                     ResetPointerSample();
                 }
             }
+        }
+
+        bool TryRecordSystemPointerSample()
+        {
+            var window = Window;
+            if (window == null)
+            {
+                return false;
+            }
+
+            using var currentEvent = new CGEvent((CGEventSource?)null);
+            var screen = window.Screen ?? UIScreen.MainScreen;
+            var windowPoint = window.ConvertPointFromCoordinateSpace(
+                currentEvent.Location,
+                screen.CoordinateSpace);
+            var hitView = window.HitTest(windowPoint, null);
+            if (!ReferenceEquals(hitView, this) &&
+                !(hitView?.IsDescendantOfView(this) ?? false))
+            {
+                return false;
+            }
+
+            var localPoint = ConvertPointFromView(windowPoint, window);
+            if (!Bounds.Contains(localPoint))
+            {
+                return false;
+            }
+
+            RecordPointerSample(localPoint);
+            return true;
         }
 
         void QueueFocusReleaseIfPointerRemainsOutside()
@@ -721,11 +1081,36 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
             lastPointerSample = CGPoint.Empty;
         }
 
+        bool HasPointerMoved(CGPoint point) =>
+            !hasPointerSample ||
+            Math.Abs((double)(point.X - lastPointerSample.X)) > 0.0001 ||
+            Math.Abs((double)(point.Y - lastPointerSample.Y)) > 0.0001;
+
+        bool TryUsePointerMotionSource(PointerMotionSource source)
+        {
+            if (pointerMotionSource == PointerMotionSource.None)
+            {
+                pointerMotionSource = source;
+            }
+            return pointerMotionSource == source;
+        }
+
+        void ClearActivePointerState()
+        {
+            activeMouseModifiers = NativeSceneViewportInputModifier.None;
+            activeLocalPointerModifier = NativeSceneViewportInputModifier.None;
+            activeGameControllerInput = null;
+            pointerMotionSource = PointerMotionSource.None;
+            ResetPointerSample();
+        }
+
         void ReleaseActivePointerState()
         {
             var releaseInput = CreatePointerCaptureReleaseInput();
             activeMouseModifiers = NativeSceneViewportInputModifier.None;
             activeLocalPointerModifier = NativeSceneViewportInputModifier.None;
+            activeGameControllerInput = null;
+            pointerMotionSource = PointerMotionSource.None;
             if (releaseInput is not { } captureInput)
             {
                 return;

--- a/Editor/Protocol/EngineProtocolClient.cs
+++ b/Editor/Protocol/EngineProtocolClient.cs
@@ -161,6 +161,22 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                 cancellationToken).ConfigureAwait(false),
             nameof(ProtocolRequest.RequestAssetReload));
 
+    public async Task<bool> UpdateAssetAsync(
+        string fileId,
+        CancellationToken cancellationToken = default)
+        => ReadBool(
+            await SendAsync(
+                    new ProtocolRequest
+                    {
+                        UpdateAsset = new FileIdRequest
+                        {
+                            FileId = ValidateString(fileId, nameof(fileId))
+                        }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.UpdateAsset));
+
     public async Task<EngineProtocolAssetReloadState> GetAssetReloadStateAsync(
         CancellationToken cancellationToken = default)
     {

--- a/Editor/Protocol/Generated/EditorEngine.cs
+++ b/Editor/Protocol/Generated/EditorEngine.cs
@@ -25,7 +25,7 @@ namespace SailorEditor.Protocol.Generated {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "ChNlZGl0b3JfZW5naW5lLnByb3RvEhBzYWlsb3IuZWRpdG9yLnYxIgcKBUVt",
-            "cHR5IsMZCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
+            "cHR5IvwZCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
             "IAEoDRISCgpyZXF1ZXN0X2lkGAIgASgEEjkKCmluaXRpYWxpemUYCiABKAsy",
             "Iy5zYWlsb3IuZWRpdG9yLnYxLkluaXRpYWxpemVSZXF1ZXN0SAASKAoFc3Rh",
             "cnQYCyABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASJwoEc3RvcBgM",
@@ -95,133 +95,134 @@ namespace SailorEditor.Protocol.Generated {
             "Lkluc3RhbmNlSWRSZXF1ZXN0SAASTQoXc2V0X3ZpZXdwb3J0X3Rvb2xfc3Rh",
             "dGUYNyABKAsyKi5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VG9vbFN0YXRl",
             "UmVxdWVzdEgAEkYKF2dldF92aWV3cG9ydF90b29sX3N0YXRlGDggASgLMiMu",
-            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydElkUmVxdWVzdEgAQgkKB2NvbW1h",
-            "bmRKBAgDEApKBAgyEDNKBAg5EGRSGGNyZWF0ZV9tb2RlbF9nYW1lX29iamVj",
-            "dFIecmVzb2x2ZV92aWV3cG9ydF9kcm9wX3Bvc2l0aW9uIpYHChBQcm90b2Nv",
-            "bFJlc3BvbnNlEhgKEHByb3RvY29sX3ZlcnNpb24YASABKA0SEgoKcmVxdWVz",
-            "dF9pZBgCIAEoBBIPCgdzdWNjZXNzGAMgASgIEg0KBWVycm9yGAQgASgJEiQK",
-            "HHN1cHBvcnRzX3N0cmljdF9pbnN0YW5jZV9pZHMYBSABKAgSLwoMZW1wdHlf",
-            "cmVzdWx0GAogASgLMhcuc2FpbG9yLmVkaXRvci52MS5FbXB0eUgAEjMKC2Jv",
-            "b2xfcmVzdWx0GAsgASgLMhwuc2FpbG9yLmVkaXRvci52MS5Cb29sUmVzdWx0",
-            "SAASNQoMaW50MzJfcmVzdWx0GAwgASgLMh0uc2FpbG9yLmVkaXRvci52MS5J",
-            "bnQzMlJlc3VsdEgAEjcKDXVpbnQzMl9yZXN1bHQYDSABKAsyHi5zYWlsb3Iu",
-            "ZWRpdG9yLnYxLlVJbnQzMlJlc3VsdEgAEjcKDXVpbnQ2NF9yZXN1bHQYDiAB",
-            "KAsyHi5zYWlsb3IuZWRpdG9yLnYxLlVJbnQ2NFJlc3VsdEgAEjcKDXN0cmlu",
-            "Z19yZXN1bHQYDyABKAsyHi5zYWlsb3IuZWRpdG9yLnYxLlN0cmluZ1Jlc3Vs",
-            "dEgAEkAKEnN0cmluZ19saXN0X3Jlc3VsdBgQIAEoCzIiLnNhaWxvci5lZGl0",
-            "b3IudjEuU3RyaW5nTGlzdFJlc3VsdEgAEk0KGWFzc2V0X3JlbG9hZF9zdGF0",
-            "ZV9yZXN1bHQYESABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLkFzc2V0UmVsb2Fk",
-            "U3RhdGVSZXN1bHRIABJAChJpbnN0YW5jZV9pZF9yZXN1bHQYEiABKAsyIi5z",
-            "YWlsb3IuZWRpdG9yLnYxLkluc3RhbmNlSWRSZXN1bHRIABJRCht2aWV3cG9y",
-            "dF9ldmVudF9iYXRjaF9yZXN1bHQYEyABKAsyKi5zYWlsb3IuZWRpdG9yLnYx",
-            "LlZpZXdwb3J0RXZlbnRCYXRjaFJlc3VsdEgAEjkKDnZlY3RvcjRfcmVzdWx0",
-            "GBQgASgLMh8uc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0UmVzdWx0SAASTwoa",
-            "dmlld3BvcnRfdG9vbF9zdGF0ZV9yZXN1bHQYFSABKAsyKS5zYWlsb3IuZWRp",
-            "dG9yLnYxLlZpZXdwb3J0VG9vbFN0YXRlUmVzdWx0SABCCAoGcmVzdWx0SgQI",
-            "BhAKSgQIFhBkIiYKEUluaXRpYWxpemVSZXF1ZXN0EhEKCWFyZ3VtZW50cxgB",
-            "IAMoCSIhCgxDb3VudFJlcXVlc3QSEQoJbWF4X2NvdW50GAEgASgNIiAKDUZp",
-            "bGVJZFJlcXVlc3QSDwoHZmlsZV9pZBgBIAEoCSIoChFJbnN0YW5jZUlkUmVx",
-            "dWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCSIoChFWaWV3cG9ydElkUmVxdWVz",
-            "dBITCgt2aWV3cG9ydF9pZBgBIAEoBCJgChNWaWV3cG9ydFJlY3RSZXF1ZXN0",
-            "EhQKDHdpbmRvd19wb3NfeBgBIAEoDRIUCgx3aW5kb3dfcG9zX3kYAiABKA0S",
-            "DQoFd2lkdGgYAyABKA0SDgoGaGVpZ2h0GAQgASgNIiwKC1NpemVSZXF1ZXN0",
-            "Eg0KBXdpZHRoGAEgASgNEg4KBmhlaWdodBgCIAEoDSKZAQoVUmVtb3RlVmll",
-            "d3BvcnRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhQKDHdpbmRvd19w",
-            "b3NfeBgCIAEoDRIUCgx3aW5kb3dfcG9zX3kYAyABKA0SDQoFd2lkdGgYBCAB",
-            "KA0SDgoGaGVpZ2h0GAUgASgNEg8KB3Zpc2libGUYBiABKAgSDwoHZm9jdXNl",
-            "ZBgHIAEoCCJlChlSZW1vdGVWaWV3cG9ydEhvc3RSZXF1ZXN0EhMKC3ZpZXdw",
-            "b3J0X2lkGAEgASgEEhgKEGhvc3RfaGFuZGxlX2tpbmQYAiABKA0SGQoRaG9z",
-            "dF9oYW5kbGVfdmFsdWUYAyABKAQi/AEKGlJlbW90ZVZpZXdwb3J0SW5wdXRS",
-            "ZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEgwKBGtpbmQYAiABKA0SEQoJ",
-            "cG9pbnRlcl94GAMgASgCEhEKCXBvaW50ZXJfeRgEIAEoAhIVCg13aGVlbF9k",
-            "ZWx0YV94GAUgASgCEhUKDXdoZWVsX2RlbHRhX3kYBiABKAISEAoIa2V5X2Nv",
-            "ZGUYByABKA0SDgoGYnV0dG9uGAggASgNEhEKCW1vZGlmaWVycxgJIAEoDRIP",
-            "CgdwcmVzc2VkGAogASgIEg8KB2ZvY3VzZWQYCyABKAgSEAoIY2FwdHVyZWQY",
-            "DCABKAgiQwoeTWFuYWdlZE11dGF0aW9uUmV2aXNpb25SZXF1ZXN0EgwKBGtp",
-            "bmQYASABKA0SEwoLaW5zdGFuY2VfaWQYAiABKAkiQAoTVXBkYXRlT2JqZWN0",
-            "UmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCRIUCgx5YW1sX2NoYW5nZXMY",
-            "AiABKAkiZgoVUmVwYXJlbnRPYmplY3RSZXF1ZXN0EhMKC2luc3RhbmNlX2lk",
-            "GAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIcChRrZWVwX3dv",
-            "cmxkX3RyYW5zZm9ybRgDIAEoCCJUChdDcmVhdGVHYW1lT2JqZWN0UmVxdWVz",
-            "dBIaChJwYXJlbnRfaW5zdGFuY2VfaWQYASABKAkSHQoVcHJlZmVycmVkX2lu",
-            "c3RhbmNlX2lkGAIgASgJImYKE0FkZENvbXBvbmVudFJlcXVlc3QSEwoLaW5z",
-            "dGFuY2VfaWQYASABKAkSGwoTY29tcG9uZW50X3R5cGVfbmFtZRgCIAEoCRId",
-            "ChVwcmVmZXJyZWRfaW5zdGFuY2VfaWQYAyABKAkiRwoYSW5zdGFudGlhdGVQ",
-            "cmVmYWJSZXF1ZXN0Eg8KB2ZpbGVfaWQYASABKAkSGgoScGFyZW50X2luc3Rh",
-            "bmNlX2lkGAIgASgJInAKIEluc3RhbnRpYXRlUHJlZmFiRnJvbVlhbWxSZXF1",
-            "ZXN0EhMKC3ByZWZhYl95YW1sGAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9p",
-            "ZBgCIAEoCRIbChNzdHJpY3RfaW5zdGFuY2VfaWRzGAMgASgIIlUKElZpZXdw",
-            "b3J0UmF5UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIUCgxub3JtYWxp",
-            "emVkX3gYAiABKAISFAoMbm9ybWFsaXplZF95GAMgASgCIqABCiBJbnN0YW50",
-            "aWF0ZVByZWZhYkluc3RhbmNlUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJEhoK",
-            "EnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIcChRhcHBseV93b3JsZF9wb3Np",
-            "dGlvbhgDIAEoCBIxCg53b3JsZF9wb3NpdGlvbhgEIAEoCzIZLnNhaWxvci5l",
-            "ZGl0b3IudjEuVmVjdG9yNCJBChVWaWV3cG9ydE9iamVjdFJlcXVlc3QSEwoL",
-            "dmlld3BvcnRfaWQYASABKAQSEwoLaW5zdGFuY2VfaWQYAiABKAkiOQoRUHJl",
-            "ZmFiTGlua1JlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkSDwoHZmlsZV9p",
-            "ZBgCIAEoCSKpAQoYVmlld3BvcnRUb29sU3RhdGVSZXF1ZXN0EhMKC3ZpZXdw",
-            "b3J0X2lkGAEgASgEEj8KCW9wZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5lZGl0",
-            "b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAyAB",
-            "KA4yKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2Ui",
-            "KAoQU2VsZWN0aW9uUmVxdWVzdBIUCgxpbnN0YW5jZV9pZHMYASADKAkiJQoV",
-            "U2hvd01haW5XaW5kb3dSZXF1ZXN0EgwKBHNob3cYASABKAgiiAEKHFJlbmRl",
-            "clBhdGhUcmFjZWRJbWFnZVJlcXVlc3QSEwoLb3V0cHV0X3BhdGgYASABKAkS",
-            "EwoLaW5zdGFuY2VfaWQYAiABKAkSDgoGaGVpZ2h0GAMgASgNEhkKEXNhbXBs",
-            "ZXNfcGVyX3BpeGVsGAQgASgNEhMKC21heF9ib3VuY2VzGAUgASgNIhsKCkJv",
-            "b2xSZXN1bHQSDQoFdmFsdWUYASABKAgiHAoLSW50MzJSZXN1bHQSDQoFdmFs",
-            "dWUYASABKAUiHQoMVUludDMyUmVzdWx0Eg0KBXZhbHVlGAEgASgNIh0KDFVJ",
-            "bnQ2NFJlc3VsdBINCgV2YWx1ZRgBIAEoBCIwCgxTdHJpbmdSZXN1bHQSEQoJ",
-            "aGFzX3ZhbHVlGAEgASgIEg0KBXZhbHVlGAIgASgJIiIKEFN0cmluZ0xpc3RS",
-            "ZXN1bHQSDgoGdmFsdWVzGAEgAygJIoQBChZBc3NldFJlbG9hZFN0YXRlUmVz",
-            "dWx0EhEKCWF2YWlsYWJsZRgBIAEoCBIaChJyZXF1ZXN0X2dlbmVyYXRpb24Y",
-            "AiABKAQSHAoUY29tcGxldGVkX2dlbmVyYXRpb24YAyABKAQSHQoVc3VjY2Vz",
-            "c2Z1bF9nZW5lcmF0aW9uGAQgASgEIjoKEEluc3RhbmNlSWRSZXN1bHQSEQoJ",
-            "c3VjY2VlZGVkGAEgASgIEhMKC2luc3RhbmNlX2lkGAIgASgJIjkKDVZlY3Rv",
-            "cjRSZXN1bHQSKAoFdmFsdWUYASABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZl",
-            "Y3RvcjQikwEKF1ZpZXdwb3J0VG9vbFN0YXRlUmVzdWx0Ej8KCW9wZXJhdGlv",
-            "bhgBIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1P",
-            "cGVyYXRpb24SNwoFc3BhY2UYAiABKA4yKC5zYWlsb3IuZWRpdG9yLnYxLlZp",
-            "ZXdwb3J0VHJhbnNmb3JtU3BhY2UiNQoHVmVjdG9yNBIJCgF4GAEgASgCEgkK",
-            "AXkYAiABKAISCQoBehgDIAEoAhIJCgF3GAQgASgCIjYKFlZpZXdwb3J0U2Vs",
-            "ZWN0aW9uRXZlbnQSHAoUc2VsZWN0ZWRfaW5zdGFuY2VfaWQYASABKAki1gMK",
-            "FlZpZXdwb3J0VHJhbnNmb3JtRXZlbnQSEwoLaW5zdGFuY2VfaWQYASABKAkS",
-            "PwoJb3BlcmF0aW9uGAIgASgOMiwuc2FpbG9yLmVkaXRvci52MS5WaWV3cG9y",
-            "dFRyYW5zZm9ybU9wZXJhdGlvbhI3CgVzcGFjZRgDIAEoDjIoLnNhaWxvci5l",
-            "ZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1TcGFjZRIyCg9iZWZvcmVfcG9z",
-            "aXRpb24YBCABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQSMgoPYmVm",
-            "b3JlX3JvdGF0aW9uGAUgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0",
-            "Ei8KDGJlZm9yZV9zY2FsZRgGIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVj",
-            "dG9yNBIxCg5hZnRlcl9wb3NpdGlvbhgHIAEoCzIZLnNhaWxvci5lZGl0b3Iu",
-            "djEuVmVjdG9yNBIxCg5hZnRlcl9yb3RhdGlvbhgIIAEoCzIZLnNhaWxvci5l",
-            "ZGl0b3IudjEuVmVjdG9yNBIuCgthZnRlcl9zY2FsZRgJIAEoCzIZLnNhaWxv",
-            "ci5lZGl0b3IudjEuVmVjdG9yNCJVChZWaWV3cG9ydEFzc2V0RHJvcEV2ZW50",
-            "Eg8KB2ZpbGVfaWQYASABKAkSFAoMbm9ybWFsaXplZF94GAIgASgCEhQKDG5v",
-            "cm1hbGl6ZWRfeRgDIAEoAiItChlWaWV3cG9ydFRvb2xTaG9ydGN1dEV2ZW50",
-            "EhAKCGtleV9jb2RlGAEgASgNItkCCg1WaWV3cG9ydEV2ZW50EhAKCHJldmlz",
-            "aW9uGAEgASgEEiEKGW1hbmFnZWRfbXV0YXRpb25fcmV2aXNpb24YAiABKAQS",
-            "PQoJc2VsZWN0aW9uGAogASgLMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9y",
-            "dFNlbGVjdGlvbkV2ZW50SAASPQoJdHJhbnNmb3JtGAsgASgLMiguc2FpbG9y",
-            "LmVkaXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybUV2ZW50SAASPgoKYXNzZXRf",
-            "ZHJvcBgMIAEoCzIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRBc3NldERy",
-            "b3BFdmVudEgAEkQKDXRvb2xfc2hvcnRjdXQYDSABKAsyKy5zYWlsb3IuZWRp",
-            "dG9yLnYxLlZpZXdwb3J0VG9vbFNob3J0Y3V0RXZlbnRIAEIJCgdwYXlsb2Fk",
-            "SgQIAxAKIksKGFZpZXdwb3J0RXZlbnRCYXRjaFJlc3VsdBIvCgZldmVudHMY",
-            "ASADKAsyHy5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0RXZlbnQq8AEKGlZp",
-            "ZXdwb3J0VHJhbnNmb3JtT3BlcmF0aW9uEiwKKFZJRVdQT1JUX1RSQU5TRk9S",
-            "TV9PUEVSQVRJT05fVU5TUEVDSUZJRUQQABInCiNWSUVXUE9SVF9UUkFOU0ZP",
-            "Uk1fT1BFUkFUSU9OX1NFTEVDVBABEioKJlZJRVdQT1JUX1RSQU5TRk9STV9P",
-            "UEVSQVRJT05fVFJBTlNMQVRFEAISJwojVklFV1BPUlRfVFJBTlNGT1JNX09Q",
-            "RVJBVElPTl9ST1RBVEUQAxImCiJWSUVXUE9SVF9UUkFOU0ZPUk1fT1BFUkFU",
-            "SU9OX1NDQUxFEAQqigEKFlZpZXdwb3J0VHJhbnNmb3JtU3BhY2USKAokVklF",
-            "V1BPUlRfVFJBTlNGT1JNX1NQQUNFX1VOU1BFQ0lGSUVEEAASIgoeVklFV1BP",
-            "UlRfVFJBTlNGT1JNX1NQQUNFX1dPUkxEEAESIgoeVklFV1BPUlRfVFJBTlNG",
-            "T1JNX1NQQUNFX0xPQ0FMEAJCIqoCH1NhaWxvckVkaXRvci5Qcm90b2NvbC5H",
-            "ZW5lcmF0ZWRiBnByb3RvMw=="));
+            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydElkUmVxdWVzdEgAEjcKDHVwZGF0",
+            "ZV9hc3NldBg5IAEoCzIfLnNhaWxvci5lZGl0b3IudjEuRmlsZUlkUmVxdWVz",
+            "dEgAQgkKB2NvbW1hbmRKBAgDEApKBAgyEDNKBAg6EGRSGGNyZWF0ZV9tb2Rl",
+            "bF9nYW1lX29iamVjdFIecmVzb2x2ZV92aWV3cG9ydF9kcm9wX3Bvc2l0aW9u",
+            "IpYHChBQcm90b2NvbFJlc3BvbnNlEhgKEHByb3RvY29sX3ZlcnNpb24YASAB",
+            "KA0SEgoKcmVxdWVzdF9pZBgCIAEoBBIPCgdzdWNjZXNzGAMgASgIEg0KBWVy",
+            "cm9yGAQgASgJEiQKHHN1cHBvcnRzX3N0cmljdF9pbnN0YW5jZV9pZHMYBSAB",
+            "KAgSLwoMZW1wdHlfcmVzdWx0GAogASgLMhcuc2FpbG9yLmVkaXRvci52MS5F",
+            "bXB0eUgAEjMKC2Jvb2xfcmVzdWx0GAsgASgLMhwuc2FpbG9yLmVkaXRvci52",
+            "MS5Cb29sUmVzdWx0SAASNQoMaW50MzJfcmVzdWx0GAwgASgLMh0uc2FpbG9y",
+            "LmVkaXRvci52MS5JbnQzMlJlc3VsdEgAEjcKDXVpbnQzMl9yZXN1bHQYDSAB",
+            "KAsyHi5zYWlsb3IuZWRpdG9yLnYxLlVJbnQzMlJlc3VsdEgAEjcKDXVpbnQ2",
+            "NF9yZXN1bHQYDiABKAsyHi5zYWlsb3IuZWRpdG9yLnYxLlVJbnQ2NFJlc3Vs",
+            "dEgAEjcKDXN0cmluZ19yZXN1bHQYDyABKAsyHi5zYWlsb3IuZWRpdG9yLnYx",
+            "LlN0cmluZ1Jlc3VsdEgAEkAKEnN0cmluZ19saXN0X3Jlc3VsdBgQIAEoCzIi",
+            "LnNhaWxvci5lZGl0b3IudjEuU3RyaW5nTGlzdFJlc3VsdEgAEk0KGWFzc2V0",
+            "X3JlbG9hZF9zdGF0ZV9yZXN1bHQYESABKAsyKC5zYWlsb3IuZWRpdG9yLnYx",
+            "LkFzc2V0UmVsb2FkU3RhdGVSZXN1bHRIABJAChJpbnN0YW5jZV9pZF9yZXN1",
+            "bHQYEiABKAsyIi5zYWlsb3IuZWRpdG9yLnYxLkluc3RhbmNlSWRSZXN1bHRI",
+            "ABJRCht2aWV3cG9ydF9ldmVudF9iYXRjaF9yZXN1bHQYEyABKAsyKi5zYWls",
+            "b3IuZWRpdG9yLnYxLlZpZXdwb3J0RXZlbnRCYXRjaFJlc3VsdEgAEjkKDnZl",
+            "Y3RvcjRfcmVzdWx0GBQgASgLMh8uc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0",
+            "UmVzdWx0SAASTwoadmlld3BvcnRfdG9vbF9zdGF0ZV9yZXN1bHQYFSABKAsy",
+            "KS5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VG9vbFN0YXRlUmVzdWx0SABC",
+            "CAoGcmVzdWx0SgQIBhAKSgQIFhBkIiYKEUluaXRpYWxpemVSZXF1ZXN0EhEK",
+            "CWFyZ3VtZW50cxgBIAMoCSIhCgxDb3VudFJlcXVlc3QSEQoJbWF4X2NvdW50",
+            "GAEgASgNIiAKDUZpbGVJZFJlcXVlc3QSDwoHZmlsZV9pZBgBIAEoCSIoChFJ",
+            "bnN0YW5jZUlkUmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCSIoChFWaWV3",
+            "cG9ydElkUmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBCJgChNWaWV3cG9y",
+            "dFJlY3RSZXF1ZXN0EhQKDHdpbmRvd19wb3NfeBgBIAEoDRIUCgx3aW5kb3df",
+            "cG9zX3kYAiABKA0SDQoFd2lkdGgYAyABKA0SDgoGaGVpZ2h0GAQgASgNIiwK",
+            "C1NpemVSZXF1ZXN0Eg0KBXdpZHRoGAEgASgNEg4KBmhlaWdodBgCIAEoDSKZ",
+            "AQoVUmVtb3RlVmlld3BvcnRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgE",
+            "EhQKDHdpbmRvd19wb3NfeBgCIAEoDRIUCgx3aW5kb3dfcG9zX3kYAyABKA0S",
+            "DQoFd2lkdGgYBCABKA0SDgoGaGVpZ2h0GAUgASgNEg8KB3Zpc2libGUYBiAB",
+            "KAgSDwoHZm9jdXNlZBgHIAEoCCJlChlSZW1vdGVWaWV3cG9ydEhvc3RSZXF1",
+            "ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhgKEGhvc3RfaGFuZGxlX2tpbmQY",
+            "AiABKA0SGQoRaG9zdF9oYW5kbGVfdmFsdWUYAyABKAQi/AEKGlJlbW90ZVZp",
+            "ZXdwb3J0SW5wdXRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEgwKBGtp",
+            "bmQYAiABKA0SEQoJcG9pbnRlcl94GAMgASgCEhEKCXBvaW50ZXJfeRgEIAEo",
+            "AhIVCg13aGVlbF9kZWx0YV94GAUgASgCEhUKDXdoZWVsX2RlbHRhX3kYBiAB",
+            "KAISEAoIa2V5X2NvZGUYByABKA0SDgoGYnV0dG9uGAggASgNEhEKCW1vZGlm",
+            "aWVycxgJIAEoDRIPCgdwcmVzc2VkGAogASgIEg8KB2ZvY3VzZWQYCyABKAgS",
+            "EAoIY2FwdHVyZWQYDCABKAgiQwoeTWFuYWdlZE11dGF0aW9uUmV2aXNpb25S",
+            "ZXF1ZXN0EgwKBGtpbmQYASABKA0SEwoLaW5zdGFuY2VfaWQYAiABKAkiQAoT",
+            "VXBkYXRlT2JqZWN0UmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCRIUCgx5",
+            "YW1sX2NoYW5nZXMYAiABKAkiZgoVUmVwYXJlbnRPYmplY3RSZXF1ZXN0EhMK",
+            "C2luc3RhbmNlX2lkGAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEo",
+            "CRIcChRrZWVwX3dvcmxkX3RyYW5zZm9ybRgDIAEoCCJUChdDcmVhdGVHYW1l",
+            "T2JqZWN0UmVxdWVzdBIaChJwYXJlbnRfaW5zdGFuY2VfaWQYASABKAkSHQoV",
+            "cHJlZmVycmVkX2luc3RhbmNlX2lkGAIgASgJImYKE0FkZENvbXBvbmVudFJl",
+            "cXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkSGwoTY29tcG9uZW50X3R5cGVf",
+            "bmFtZRgCIAEoCRIdChVwcmVmZXJyZWRfaW5zdGFuY2VfaWQYAyABKAkiRwoY",
+            "SW5zdGFudGlhdGVQcmVmYWJSZXF1ZXN0Eg8KB2ZpbGVfaWQYASABKAkSGgoS",
+            "cGFyZW50X2luc3RhbmNlX2lkGAIgASgJInAKIEluc3RhbnRpYXRlUHJlZmFi",
+            "RnJvbVlhbWxSZXF1ZXN0EhMKC3ByZWZhYl95YW1sGAEgASgJEhoKEnBhcmVu",
+            "dF9pbnN0YW5jZV9pZBgCIAEoCRIbChNzdHJpY3RfaW5zdGFuY2VfaWRzGAMg",
+            "ASgIIlUKElZpZXdwb3J0UmF5UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEo",
+            "BBIUCgxub3JtYWxpemVkX3gYAiABKAISFAoMbm9ybWFsaXplZF95GAMgASgC",
+            "IqABCiBJbnN0YW50aWF0ZVByZWZhYkluc3RhbmNlUmVxdWVzdBIPCgdmaWxl",
+            "X2lkGAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIcChRhcHBs",
+            "eV93b3JsZF9wb3NpdGlvbhgDIAEoCBIxCg53b3JsZF9wb3NpdGlvbhgEIAEo",
+            "CzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNCJBChVWaWV3cG9ydE9iamVj",
+            "dFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQSEwoLaW5zdGFuY2VfaWQY",
+            "AiABKAkiOQoRUHJlZmFiTGlua1JlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASAB",
+            "KAkSDwoHZmlsZV9pZBgCIAEoCSKpAQoYVmlld3BvcnRUb29sU3RhdGVSZXF1",
+            "ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEj8KCW9wZXJhdGlvbhgCIAEoDjIs",
+            "LnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24S",
+            "NwoFc3BhY2UYAyABKA4yKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJh",
+            "bnNmb3JtU3BhY2UiKAoQU2VsZWN0aW9uUmVxdWVzdBIUCgxpbnN0YW5jZV9p",
+            "ZHMYASADKAkiJQoVU2hvd01haW5XaW5kb3dSZXF1ZXN0EgwKBHNob3cYASAB",
+            "KAgiiAEKHFJlbmRlclBhdGhUcmFjZWRJbWFnZVJlcXVlc3QSEwoLb3V0cHV0",
+            "X3BhdGgYASABKAkSEwoLaW5zdGFuY2VfaWQYAiABKAkSDgoGaGVpZ2h0GAMg",
+            "ASgNEhkKEXNhbXBsZXNfcGVyX3BpeGVsGAQgASgNEhMKC21heF9ib3VuY2Vz",
+            "GAUgASgNIhsKCkJvb2xSZXN1bHQSDQoFdmFsdWUYASABKAgiHAoLSW50MzJS",
+            "ZXN1bHQSDQoFdmFsdWUYASABKAUiHQoMVUludDMyUmVzdWx0Eg0KBXZhbHVl",
+            "GAEgASgNIh0KDFVJbnQ2NFJlc3VsdBINCgV2YWx1ZRgBIAEoBCIwCgxTdHJp",
+            "bmdSZXN1bHQSEQoJaGFzX3ZhbHVlGAEgASgIEg0KBXZhbHVlGAIgASgJIiIK",
+            "EFN0cmluZ0xpc3RSZXN1bHQSDgoGdmFsdWVzGAEgAygJIoQBChZBc3NldFJl",
+            "bG9hZFN0YXRlUmVzdWx0EhEKCWF2YWlsYWJsZRgBIAEoCBIaChJyZXF1ZXN0",
+            "X2dlbmVyYXRpb24YAiABKAQSHAoUY29tcGxldGVkX2dlbmVyYXRpb24YAyAB",
+            "KAQSHQoVc3VjY2Vzc2Z1bF9nZW5lcmF0aW9uGAQgASgEIjoKEEluc3RhbmNl",
+            "SWRSZXN1bHQSEQoJc3VjY2VlZGVkGAEgASgIEhMKC2luc3RhbmNlX2lkGAIg",
+            "ASgJIjkKDVZlY3RvcjRSZXN1bHQSKAoFdmFsdWUYASABKAsyGS5zYWlsb3Iu",
+            "ZWRpdG9yLnYxLlZlY3RvcjQikwEKF1ZpZXdwb3J0VG9vbFN0YXRlUmVzdWx0",
+            "Ej8KCW9wZXJhdGlvbhgBIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmlld3Bv",
+            "cnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAiABKA4yKC5zYWlsb3Iu",
+            "ZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2UiNQoHVmVjdG9yNBIJ",
+            "CgF4GAEgASgCEgkKAXkYAiABKAISCQoBehgDIAEoAhIJCgF3GAQgASgCIjYK",
+            "FlZpZXdwb3J0U2VsZWN0aW9uRXZlbnQSHAoUc2VsZWN0ZWRfaW5zdGFuY2Vf",
+            "aWQYASABKAki1gMKFlZpZXdwb3J0VHJhbnNmb3JtRXZlbnQSEwoLaW5zdGFu",
+            "Y2VfaWQYASABKAkSPwoJb3BlcmF0aW9uGAIgASgOMiwuc2FpbG9yLmVkaXRv",
+            "ci52MS5WaWV3cG9ydFRyYW5zZm9ybU9wZXJhdGlvbhI3CgVzcGFjZRgDIAEo",
+            "DjIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1TcGFjZRIy",
+            "Cg9iZWZvcmVfcG9zaXRpb24YBCABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZl",
+            "Y3RvcjQSMgoPYmVmb3JlX3JvdGF0aW9uGAUgASgLMhkuc2FpbG9yLmVkaXRv",
+            "ci52MS5WZWN0b3I0Ei8KDGJlZm9yZV9zY2FsZRgGIAEoCzIZLnNhaWxvci5l",
+            "ZGl0b3IudjEuVmVjdG9yNBIxCg5hZnRlcl9wb3NpdGlvbhgHIAEoCzIZLnNh",
+            "aWxvci5lZGl0b3IudjEuVmVjdG9yNBIxCg5hZnRlcl9yb3RhdGlvbhgIIAEo",
+            "CzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNBIuCgthZnRlcl9zY2FsZRgJ",
+            "IAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNCJVChZWaWV3cG9ydEFz",
+            "c2V0RHJvcEV2ZW50Eg8KB2ZpbGVfaWQYASABKAkSFAoMbm9ybWFsaXplZF94",
+            "GAIgASgCEhQKDG5vcm1hbGl6ZWRfeRgDIAEoAiItChlWaWV3cG9ydFRvb2xT",
+            "aG9ydGN1dEV2ZW50EhAKCGtleV9jb2RlGAEgASgNItkCCg1WaWV3cG9ydEV2",
+            "ZW50EhAKCHJldmlzaW9uGAEgASgEEiEKGW1hbmFnZWRfbXV0YXRpb25fcmV2",
+            "aXNpb24YAiABKAQSPQoJc2VsZWN0aW9uGAogASgLMiguc2FpbG9yLmVkaXRv",
+            "ci52MS5WaWV3cG9ydFNlbGVjdGlvbkV2ZW50SAASPQoJdHJhbnNmb3JtGAsg",
+            "ASgLMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybUV2ZW50",
+            "SAASPgoKYXNzZXRfZHJvcBgMIAEoCzIoLnNhaWxvci5lZGl0b3IudjEuVmll",
+            "d3BvcnRBc3NldERyb3BFdmVudEgAEkQKDXRvb2xfc2hvcnRjdXQYDSABKAsy",
+            "Ky5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VG9vbFNob3J0Y3V0RXZlbnRI",
+            "AEIJCgdwYXlsb2FkSgQIAxAKIksKGFZpZXdwb3J0RXZlbnRCYXRjaFJlc3Vs",
+            "dBIvCgZldmVudHMYASADKAsyHy5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0",
+            "RXZlbnQq8AEKGlZpZXdwb3J0VHJhbnNmb3JtT3BlcmF0aW9uEiwKKFZJRVdQ",
+            "T1JUX1RSQU5TRk9STV9PUEVSQVRJT05fVU5TUEVDSUZJRUQQABInCiNWSUVX",
+            "UE9SVF9UUkFOU0ZPUk1fT1BFUkFUSU9OX1NFTEVDVBABEioKJlZJRVdQT1JU",
+            "X1RSQU5TRk9STV9PUEVSQVRJT05fVFJBTlNMQVRFEAISJwojVklFV1BPUlRf",
+            "VFJBTlNGT1JNX09QRVJBVElPTl9ST1RBVEUQAxImCiJWSUVXUE9SVF9UUkFO",
+            "U0ZPUk1fT1BFUkFUSU9OX1NDQUxFEAQqigEKFlZpZXdwb3J0VHJhbnNmb3Jt",
+            "U3BhY2USKAokVklFV1BPUlRfVFJBTlNGT1JNX1NQQUNFX1VOU1BFQ0lGSUVE",
+            "EAASIgoeVklFV1BPUlRfVFJBTlNGT1JNX1NQQUNFX1dPUkxEEAESIgoeVklF",
+            "V1BPUlRfVFJBTlNGT1JNX1NQQUNFX0xPQ0FMEAJCIqoCH1NhaWxvckVkaXRv",
+            "ci5Qcm90b2NvbC5HZW5lcmF0ZWRiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::SailorEditor.Protocol.Generated.ViewportTransformOperation), typeof(global::SailorEditor.Protocol.Generated.ViewportTransformSpace), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Empty), global::SailorEditor.Protocol.Generated.Empty.Parser, null, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState" }, new[]{ "Command" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset" }, new[]{ "Command" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "SupportsStrictInstanceIds", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult", "Vector4Result", "ViewportToolStateResult" }, new[]{ "Result" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InitializeRequest), global::SailorEditor.Protocol.Generated.InitializeRequest.Parser, new[]{ "Arguments" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CountRequest), global::SailorEditor.Protocol.Generated.CountRequest.Parser, new[]{ "MaxCount" }, null, null, null, null),
@@ -624,6 +625,9 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case CommandOneofCase.GetViewportToolState:
           GetViewportToolState = other.GetViewportToolState.Clone();
+          break;
+        case CommandOneofCase.UpdateAsset:
+          UpdateAsset = other.UpdateAsset.Clone();
           break;
       }
 
@@ -1212,6 +1216,18 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "update_asset" field.</summary>
+    public const int UpdateAssetFieldNumber = 57;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.FileIdRequest UpdateAsset {
+      get { return commandCase_ == CommandOneofCase.UpdateAsset ? (global::SailorEditor.Protocol.Generated.FileIdRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.UpdateAsset;
+      }
+    }
+
     private object command_;
     /// <summary>Enum of possible cases for the "command" oneof.</summary>
     public enum CommandOneofCase {
@@ -1262,6 +1278,7 @@ namespace SailorEditor.Protocol.Generated {
       BreakPrefabLink = 54,
       SetViewportToolState = 55,
       GetViewportToolState = 56,
+      UpdateAsset = 57,
     }
     private CommandOneofCase commandCase_ = CommandOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1340,6 +1357,7 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(BreakPrefabLink, other.BreakPrefabLink)) return false;
       if (!object.Equals(SetViewportToolState, other.SetViewportToolState)) return false;
       if (!object.Equals(GetViewportToolState, other.GetViewportToolState)) return false;
+      if (!object.Equals(UpdateAsset, other.UpdateAsset)) return false;
       if (CommandCase != other.CommandCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -1396,6 +1414,7 @@ namespace SailorEditor.Protocol.Generated {
       if (commandCase_ == CommandOneofCase.BreakPrefabLink) hash ^= BreakPrefabLink.GetHashCode();
       if (commandCase_ == CommandOneofCase.SetViewportToolState) hash ^= SetViewportToolState.GetHashCode();
       if (commandCase_ == CommandOneofCase.GetViewportToolState) hash ^= GetViewportToolState.GetHashCode();
+      if (commandCase_ == CommandOneofCase.UpdateAsset) hash ^= UpdateAsset.GetHashCode();
       hash ^= (int) commandCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -1607,6 +1626,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(194, 3);
         output.WriteMessage(GetViewportToolState);
       }
+      if (commandCase_ == CommandOneofCase.UpdateAsset) {
+        output.WriteRawTag(202, 3);
+        output.WriteMessage(UpdateAsset);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1809,6 +1832,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(194, 3);
         output.WriteMessage(GetViewportToolState);
       }
+      if (commandCase_ == CommandOneofCase.UpdateAsset) {
+        output.WriteRawTag(202, 3);
+        output.WriteMessage(UpdateAsset);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -1962,6 +1989,9 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (commandCase_ == CommandOneofCase.GetViewportToolState) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetViewportToolState);
+      }
+      if (commandCase_ == CommandOneofCase.UpdateAsset) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(UpdateAsset);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -2257,6 +2287,12 @@ namespace SailorEditor.Protocol.Generated {
             GetViewportToolState = new global::SailorEditor.Protocol.Generated.ViewportIdRequest();
           }
           GetViewportToolState.MergeFrom(other.GetViewportToolState);
+          break;
+        case CommandOneofCase.UpdateAsset:
+          if (UpdateAsset == null) {
+            UpdateAsset = new global::SailorEditor.Protocol.Generated.FileIdRequest();
+          }
+          UpdateAsset.MergeFrom(other.UpdateAsset);
           break;
       }
 
@@ -2701,6 +2737,15 @@ namespace SailorEditor.Protocol.Generated {
             GetViewportToolState = subBuilder;
             break;
           }
+          case 458: {
+            global::SailorEditor.Protocol.Generated.FileIdRequest subBuilder = new global::SailorEditor.Protocol.Generated.FileIdRequest();
+            if (commandCase_ == CommandOneofCase.UpdateAsset) {
+              subBuilder.MergeFrom(UpdateAsset);
+            }
+            input.ReadMessage(subBuilder);
+            UpdateAsset = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -3140,6 +3185,15 @@ namespace SailorEditor.Protocol.Generated {
             }
             input.ReadMessage(subBuilder);
             GetViewportToolState = subBuilder;
+            break;
+          }
+          case 458: {
+            global::SailorEditor.Protocol.Generated.FileIdRequest subBuilder = new global::SailorEditor.Protocol.Generated.FileIdRequest();
+            if (commandCase_ == CommandOneofCase.UpdateAsset) {
+              subBuilder.MergeFrom(UpdateAsset);
+            }
+            input.ReadMessage(subBuilder);
+            UpdateAsset = subBuilder;
             break;
           }
         }

--- a/Editor/SailorEditor.csproj
+++ b/Editor/SailorEditor.csproj
@@ -27,6 +27,7 @@
 
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">11.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">15.0</SupportedOSPlatformVersion>
+		<ApplicationManifest Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">Platforms\MacCatalyst\Info.plist</ApplicationManifest>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'android'">21.0</SupportedOSPlatformVersion>
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -26,6 +26,7 @@ namespace SailorEditor.Services
         readonly ProjectContentFileOperations _fileOperations = new();
         readonly object _watcherLock = new();
         readonly List<FileSystemWatcher> _contentWatchers = [];
+        readonly SemaphoreSlim _assetSaveLock = new(1, 1);
         EngineLaunchContext? _activeLaunchContext;
         CancellationTokenSource? _pendingFilesystemReload;
         ProjectContentFolderIdAllocator _folderIdAllocator = new();
@@ -83,6 +84,77 @@ namespace SailorEditor.Services
             {
                 Console.WriteLine(
                     $"[AssetsService] Failed to refresh after asset reload generation {completion.Generation}: {exception.Message}");
+            }
+        }
+
+        public Task<bool> SaveAssetAsync(
+            AssetFile assetFile,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(assetFile);
+            return SaveExistingAssetAsync(
+                assetFile.FileId,
+                assetFile.Save,
+                cancellationToken);
+        }
+
+        public async Task<bool> SaveExistingAssetAsync(
+            FileId fileId,
+            Func<Task> saveAsync,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(fileId);
+            ArgumentNullException.ThrowIfNull(saveAsync);
+            if (fileId.IsEmpty())
+            {
+                return false;
+            }
+
+            await _assetSaveLock.WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+            try
+            {
+                (FileSystemWatcher Watcher, bool Enabled)[] watcherStates;
+                lock (_watcherLock)
+                {
+                    watcherStates = _contentWatchers
+                        .Select(watcher =>
+                            (watcher, watcher.EnableRaisingEvents))
+                        .ToArray();
+                    foreach (var watcherState in watcherStates)
+                    {
+                        watcherState.Watcher.EnableRaisingEvents = false;
+                    }
+                }
+
+                try
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    await saveAsync().ConfigureAwait(false);
+                }
+                finally
+                {
+                    lock (_watcherLock)
+                    {
+                        foreach (var watcherState in watcherStates)
+                        {
+                            if (_contentWatchers.Contains(watcherState.Watcher))
+                            {
+                                watcherState.Watcher.EnableRaisingEvents =
+                                    watcherState.Enabled;
+                            }
+                        }
+                    }
+                }
+
+                return await _engineService.UpdateAssetAsync(
+                        fileId,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            finally
+            {
+                _assetSaveLock.Release();
             }
         }
 

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -2233,6 +2233,16 @@ namespace SailorEditor.Services
                 cancellationToken);
         }
 
+        public Task<bool> UpdateAssetAsync(
+            FileId fileId,
+            CancellationToken cancellationToken = default)
+        {
+            var stringId = fileId?.Value ?? string.Empty;
+            return InvokeRunningInteropAsync(
+                token => protocolClient.UpdateAssetAsync(stringId, token),
+                cancellationToken: cancellationToken);
+        }
+
         public async Task<bool> RequestAssetReloadAsync(CancellationToken cancellationToken = default)
         {
             var generation = Volatile.Read(ref engineGeneration);

--- a/Editor/Services/WorldService.cs
+++ b/Editor/Services/WorldService.cs
@@ -418,19 +418,20 @@ namespace SailorEditor.Services
                 if (string.IsNullOrWhiteSpace(serializedWorld))
                     return new SceneSaveResult(SceneSaveOutcome.Failed, Error: "The native world could not be serialized.");
 
-                await File.WriteAllTextAsync(
-                    worldAsset.Asset.FullName,
-                    serializedWorld,
-                    cancellationToken);
-                worldAsset.IsDirty = false;
-                if (!await engineService.RequestAssetReloadAsync(
+                if (!await assetsService.SaveExistingAssetAsync(
+                        worldAsset.FileId,
+                        () => File.WriteAllTextAsync(
+                            worldAsset.Asset.FullName,
+                            serializedWorld,
+                            cancellationToken),
                         cancellationToken))
                 {
                     return new SceneSaveResult(
                         SceneSaveOutcome.Failed,
                         worldAsset.Asset.FullName,
-                        "The scene was saved, but the native registry rejected the reload.");
+                        "The scene was saved, but the native registry rejected its targeted update.");
                 }
+                worldAsset.IsDirty = false;
                 assetsService.Refresh();
                 CurrentWorldAsset = assetsService.Assets.TryGetValue(worldAsset.FileId, out var refreshed)
                     ? refreshed as WorldFile ?? worldAsset

--- a/Editor/Utility/Templates.cs
+++ b/Editor/Utility/Templates.cs
@@ -353,6 +353,73 @@ static class Templates
         return grid;
     }
 
+    public static View FileIdListEditor(
+        ObservableFileIdList fileIds,
+        Type supportedType = null)
+    {
+        var listEditor = new CollectionView
+        {
+            ItemsSource = fileIds.Values,
+            HorizontalOptions = LayoutOptions.Fill,
+            ItemTemplate = new DataTemplate(() =>
+            {
+                var row = new Grid
+                {
+                    ColumnDefinitions =
+                    {
+                        new ColumnDefinition { Width = GridLength.Auto },
+                        new ColumnDefinition { Width = GridLength.Star }
+                    },
+                    ColumnSpacing = InspectorFieldSpacing,
+                    HorizontalOptions = LayoutOptions.Fill
+                };
+
+                row.BindingContextChanged += (sender, args) =>
+                {
+                    row.Children.Clear();
+                    if (row.BindingContext is not Observable<FileId> fileId)
+                    {
+                        return;
+                    }
+
+                    var removeButton = new Button { Text = "-" };
+                    removeButton.Clicked += (buttonSender, clickArgs) =>
+                        fileIds.Values.Remove(fileId);
+
+                    row.Add(removeButton, 0, 0);
+                    row.Add(
+                        FileIdEditor(
+                            fileId,
+                            nameof(Observable<FileId>.Value),
+                            static (Observable<FileId> vm) => vm.Value,
+                            static (vm, value) => vm.Value = value,
+                            supportedType),
+                        1,
+                        0);
+                };
+
+                return row;
+            })
+        };
+
+        var addButton = new Button { Text = "+" };
+        addButton.Clicked += (sender, args) =>
+            fileIds.Values.Add(new Observable<FileId>(new FileId()));
+
+        var clearButton = new Button { Text = "Clear" };
+        clearButton.Clicked += (sender, args) => fileIds.Values.Clear();
+
+        return new VerticalStackLayout
+        {
+            HorizontalOptions = LayoutOptions.Fill,
+            Children =
+            {
+                new HorizontalStackLayout { Children = { addButton, clearButton } },
+                listEditor
+            }
+        };
+    }
+
     public static View InstanceIdEditor<TBindingContext>(object bindingContext, string bindingPath, Expression<Func<TBindingContext, InstanceId>> getter, Action<TBindingContext, InstanceId> setter, string expectedTypename = "")
         where TBindingContext : class
     {

--- a/Editor/Utility/Templates.cs
+++ b/Editor/Utility/Templates.cs
@@ -357,11 +357,15 @@ static class Templates
         ObservableFileIdList fileIds,
         Type supportedType = null)
     {
-        var listEditor = new CollectionView
+        var listEditor = new VerticalStackLayout
         {
-            ItemsSource = fileIds.Values,
             HorizontalOptions = LayoutOptions.Fill,
-            ItemTemplate = new DataTemplate(() =>
+            Spacing = InspectorFieldSpacing
+        };
+        BindableLayout.SetItemsSource(listEditor, fileIds.Values);
+        BindableLayout.SetItemTemplate(
+            listEditor,
+            new DataTemplate(() =>
             {
                 var row = new Grid
                 {
@@ -399,8 +403,7 @@ static class Templates
                 };
 
                 return row;
-            })
-        };
+            }));
 
         var addButton = new Button { Text = "+" };
         addButton.Clicked += (sender, args) =>

--- a/Editor/ViewModels/AssetFile.cs
+++ b/Editor/ViewModels/AssetFile.cs
@@ -647,6 +647,15 @@ public partial class ObservableFileIdList : ObservableObject
         Values.ItemChanged += ValuesItemChanged;
     }
 
+    public ObservableFileIdList(IEnumerable<FileId> values) : this()
+    {
+        foreach (var value in values)
+        {
+            Values.Add(new Observable<FileId>(
+                value ?? new FileId()));
+        }
+    }
+
     public ObservableList<Observable<FileId>> Values { get; } = [];
 
     void ValuesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -218,6 +218,10 @@ public class ComponentYamlConverter : IYamlTypeConverter
                 Vec3Property => DeserializeBuffered<Vec3>(property.Value, serializer, deserializer),
                 Vec2Property => DeserializeBuffered<Vec2>(property.Value, serializer, deserializer),
                 FileIdProperty => new Observable<FileId>(scalar),
+                Property<List<FileId>> => DeserializeFileIdList(
+                    property.Value,
+                    serializer,
+                    deserializer),
                 InstanceIdProperty => new Observable<InstanceId>(scalar),
                 FloatProperty => new Observable<float>((float)EditorComponentScalarCodec.Parse(
                     EditorComponentScalarKind.Float,
@@ -287,6 +291,21 @@ public class ComponentYamlConverter : IYamlTypeConverter
     static T DeserializeBuffered<T>(object value, ISerializer serializer, IDeserializer deserializer)
         => deserializer.Deserialize<T>(serializer.Serialize(value));
 
+    static ObservableFileIdList DeserializeFileIdList(
+        object? value,
+        ISerializer serializer,
+        IDeserializer deserializer)
+    {
+        if (value is null)
+            return new ObservableFileIdList();
+
+        return new ObservableFileIdList(
+            DeserializeBuffered<List<FileId>>(
+                value,
+                serializer,
+                deserializer) ?? []);
+    }
+
     public void WriteYaml(IEmitter emitter, object value, Type type)
     {
         var serializer = SerializationUtils.CreateSerializerBuilder()            
@@ -335,6 +354,17 @@ public class ComponentYamlConverter : IYamlTypeConverter
                     break;
                 case Observable<FileId> assetId:
                     fileIdConverter.WriteYaml(emitter, assetId.Value, typeof(FileId));
+                    break;
+                case ObservableFileIdList assetIds:
+                    emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
+                    foreach (var assetId in assetIds.Values)
+                    {
+                        fileIdConverter.WriteYaml(
+                            emitter,
+                            assetId.Value ?? new FileId(),
+                            typeof(FileId));
+                    }
+                    emitter.Emit(new SequenceEnd());
                     break;
                 case Observable<InstanceId> id:
                     instanceIdConverter.WriteYaml(emitter, id.Value, typeof(InstanceId));

--- a/Editor/Views/InspectorView/AssetFileTemplate.xaml.cs
+++ b/Editor/Views/InspectorView/AssetFileTemplate.xaml.cs
@@ -126,7 +126,7 @@ public partial class AssetFileTemplate : DataTemplate
 
         if ((property is Property<List<FileId>> || value is ObservableFileIdList) && value is ObservableFileIdList fileIds)
         {
-            return CreateFileIdListEditor(fileIds);
+            return Templates.FileIdListEditor(fileIds);
         }
 
         if (value is Observable<string> observableString)
@@ -176,47 +176,4 @@ public partial class AssetFileTemplate : DataTemplate
         return editor;
     }
 
-    static View CreateFileIdListEditor(ObservableFileIdList fileIds)
-    {
-        var listEditor = new CollectionView
-        {
-            ItemsSource = fileIds.Values,
-            ItemTemplate = new DataTemplate(() =>
-            {
-                var row = new HorizontalStackLayout { Spacing = 4 };
-                row.BindingContextChanged += (sender, args) =>
-                {
-                    row.Children.Clear();
-                    if (row.BindingContext is not Observable<FileId> fileId)
-                    {
-                        return;
-                    }
-
-                    var removeButton = new Button { Text = "-" };
-                    removeButton.Clicked += (buttonSender, clickArgs) => fileIds.Values.Remove(fileId);
-                    row.Children.Add(removeButton);
-                    row.Children.Add(Templates.FileIdEditor(fileId, nameof(Observable<FileId>.Value),
-                        static (Observable<FileId> vm) => vm.Value,
-                        static (vm, value) => vm.Value = value));
-                };
-
-                return row;
-            })
-        };
-
-        var addButton = new Button { Text = "+" };
-        addButton.Clicked += (sender, args) => fileIds.Values.Add(new Observable<FileId>(FileId.NullFileId));
-
-        var clearButton = new Button { Text = "Clear" };
-        clearButton.Clicked += (sender, args) => fileIds.Values.Clear();
-
-        return new VerticalStackLayout
-        {
-            Children =
-            {
-                new HorizontalStackLayout { Children = { addButton, clearButton } },
-                listEditor
-            }
-        };
-    }
 }

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -215,6 +215,11 @@ public class ComponentTemplate : DataTemplate
                                 Vec3 vec3 => Templates.Vec3Editor((Component vm) => vec3),
                                 Vec2 vec2 => Templates.Vec2Editor((Component vm) => vec2),
                                 Observable<FileId> observableFileId => Templates.FileIdEditor(component.OverrideProperties[property.Key], nameof(Observable<FileId>.Value), (Observable<FileId> vm) => vm.Value, (vm, value) => vm.Value = value),
+                                ObservableFileIdList fileIds => Templates.FileIdListEditor(
+                                    fileIds,
+                                    ResolveFileIdListSupportedType(
+                                        component,
+                                        property.Key)),
                                 Observable<InstanceId> observableInstanceId => Templates.InstanceIdEditor(component.OverrideProperties[property.Key], nameof(Observable<InstanceId>.Value), (Observable<InstanceId> vm) => vm.Value, (vm, value) => vm.Value = value),
                                 _ => new Label { Text = "Unsupported property type" }
                             };
@@ -234,6 +239,16 @@ public class ComponentTemplate : DataTemplate
         return !string.IsNullOrWhiteSpace(typeName) && typeName.StartsWith(prefix, StringComparison.Ordinal)
             ? typeName[prefix.Length..]
             : typeName;
+    }
+
+    static Type ResolveFileIdListSupportedType(
+        Component component,
+        string propertyName)
+    {
+        return component.Typename.Name == "Sailor::MeshRendererComponent" &&
+            propertyName == "overrideMaterials"
+            ? typeof(MaterialFile)
+            : null;
     }
 
     static Command CreateContextMenuCommand(

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -1,4 +1,5 @@
-﻿using SailorEditor;
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using SailorEditor;
 using SailorEditor.Helpers;
 using SailorEditor.Services;
 using SailorEditor.Shell;
@@ -141,7 +142,7 @@ public class ComponentTemplate : DataTemplate
 
                 var engineTypes = MauiProgram.GetService<EngineService>().EngineTypes;
 
-                foreach (var property in component.OverrideProperties)
+                foreach (var property in EnumerateInspectorProperties(component))
                 {
                     // Internal info
                     if (property.Key == "fileId" || property.Key == "instanceId")
@@ -239,6 +240,40 @@ public class ComponentTemplate : DataTemplate
         return !string.IsNullOrWhiteSpace(typeName) && typeName.StartsWith(prefix, StringComparison.Ordinal)
             ? typeName[prefix.Length..]
             : typeName;
+    }
+
+    static IEnumerable<KeyValuePair<string, ObservableObject>> EnumerateInspectorProperties(
+        Component component)
+    {
+        if (component.Typename.Name != "Sailor::MeshRendererComponent")
+        {
+            foreach (var property in component.OverrideProperties)
+            {
+                yield return property;
+            }
+
+            yield break;
+        }
+
+        if (component.OverrideProperties.TryGetValue("model", out var model))
+        {
+            yield return new KeyValuePair<string, ObservableObject>("model", model);
+        }
+
+        if (component.OverrideProperties.TryGetValue("overrideMaterials", out var overrideMaterials))
+        {
+            yield return new KeyValuePair<string, ObservableObject>("overrideMaterials", overrideMaterials);
+        }
+
+        foreach (var property in component.OverrideProperties)
+        {
+            if (property.Key is "model" or "overrideMaterials")
+            {
+                continue;
+            }
+
+            yield return property;
+        }
     }
 
     static Type ResolveFileIdListSupportedType(

--- a/Editor/Views/InspectorView/ControlPanelView.xaml.cs
+++ b/Editor/Views/InspectorView/ControlPanelView.xaml.cs
@@ -24,13 +24,11 @@ public partial class ControlPanelView : ContentView
     {
         if (sender is Button { BindingContext: AssetFile assetFile })
         {
-            await Task.Yield();
-            await assetFile.Save();
-            var engineService = MauiProgram.GetService<EngineService>();
-            if (!await engineService.RequestAssetReloadAsync())
+            var assetsService = MauiProgram.GetService<AssetsService>();
+            if (!await assetsService.SaveAssetAsync(assetFile))
             {
-                engineService.PushConsoleMessage(
-                    $"Asset was saved, but native reload did not commit: {assetFile.AssetInfo.FullName}");
+                MauiProgram.GetService<EngineService>().PushConsoleMessage(
+                    $"Asset was saved, but its targeted native update did not commit: {assetFile.AssetInfo.FullName}");
             }
         }
     }

--- a/Lib/CMakeLists.txt
+++ b/Lib/CMakeLists.txt
@@ -19,6 +19,12 @@ set(SAILOR_MISSING_DEPS "")
 set(SAILOR_CONFIGURED_WITH_DEPENDENCY_STUBS OFF)
 
 # External dependencies
+find_package(draco CONFIG QUIET)
+if(NOT draco_FOUND)
+	list(APPEND SAILOR_MISSING_DEPS "draco")
+	sailor_create_stub_target(draco::draco)
+endif()
+
 find_package(yaml-cpp CONFIG QUIET)
 if(NOT yaml-cpp_FOUND)
 	list(APPEND SAILOR_MISSING_DEPS "yaml-cpp")
@@ -69,6 +75,12 @@ find_package(magic_enum CONFIG QUIET)
 if(NOT magic_enum_FOUND)
 	list(APPEND SAILOR_MISSING_DEPS "magic_enum")
 	sailor_create_stub_target(magic_enum::magic_enum)
+endif()
+
+find_package(meshoptimizer CONFIG QUIET)
+if(NOT meshoptimizer_FOUND)
+	list(APPEND SAILOR_MISSING_DEPS "meshoptimizer")
+	sailor_create_stub_target(meshoptimizer::meshoptimizer)
 endif()
 
 find_package(glm CONFIG QUIET)
@@ -220,10 +232,12 @@ target_link_libraries(SailorLib PUBLIC
   unofficial::spirv-reflect
 )
 target_link_libraries(SailorLib PRIVATE
-  imguizmo::imguizmo
-  ixwebsocket::ixwebsocket
-  protobuf::libprotobuf
-  ${CMAKE_DL_LIBS}
+	draco::draco
+	imguizmo::imguizmo
+	ixwebsocket::ixwebsocket
+	meshoptimizer::meshoptimizer
+	protobuf::libprotobuf
+	${CMAKE_DL_LIBS}
 )
 
 find_path(REFL_CPP_INCLUDE_DIRS "refl.hpp")
@@ -267,6 +281,12 @@ target_compile_definitions(SailorLib PUBLIC NOMINMAX)
 target_compile_definitions(SailorLib PUBLIC $<$<CONFIG:Release>:_SHIPPING>)
 target_compile_definitions(SailorLib PRIVATE SAILOR_BUILD_CONFIG="$<CONFIG>")
 target_compile_definitions(SailorLib PRIVATE SAILOR_ENGINE_VERSION="${PROJECT_VERSION}")
+if(draco_FOUND)
+	target_compile_definitions(SailorLib PRIVATE SAILOR_HAS_DRACO)
+endif()
+if(meshoptimizer_FOUND)
+	target_compile_definitions(SailorLib PRIVATE SAILOR_HAS_MESHOPT)
+endif()
 
 if(SAILOR_BUILD_TESTS)
   target_compile_definitions(SailorLib PUBLIC $<BUILD_INTERFACE:SAILOR_SHADER_CACHE_TEST_HOOKS>)

--- a/Lib/EditorEngineProtocol.cpp
+++ b/Lib/EditorEngineProtocol.cpp
@@ -910,6 +910,12 @@ namespace
 			SetBoolResult(response, Sailor::App::RequestAssetReload());
 			break;
 
+		case ProtocolRequest::kUpdateAsset:
+			SetBoolResult(
+				response,
+				Sailor::App::UpdateAsset(request.update_asset().file_id().c_str()));
+			break;
+
 		case ProtocolRequest::kGetAssetReloadState:
 		{
 			uint64_t requestGeneration = 0;

--- a/Protocol/README.md
+++ b/Protocol/README.md
@@ -58,6 +58,13 @@ then a point 1000 units forward. A request fails only when the viewport,
 coordinates, active camera, or resulting ray is invalid; an empty scene is not
 a trace failure.
 
+`update_asset` revalidates one registered `FileId` against its metadata,
+source-file, and cache revisions. A metadata-only edit reloads that exact
+AssetInfo; a changed source reloads every registered AssetInfo backed by the
+same source (for example, the assets generated from one glTF file). It does not
+scan Content or wait for unrelated Worker, RHI, or Render work. Commands that
+change Content topology still use `request_asset_reload`.
+
 Compatibility rules:
 
 - Ordinary commands use baseline `protocol_version = 1`. Strict InstanceId

--- a/Protocol/editor_engine.proto
+++ b/Protocol/editor_engine.proto
@@ -58,13 +58,14 @@ message ProtocolRequest {
 		InstanceIdRequest break_prefab_link = 54;
 		ViewportToolStateRequest set_viewport_tool_state = 55;
 		ViewportIdRequest get_viewport_tool_state = 56;
+		FileIdRequest update_asset = 57;
 	}
 
 	reserved 3 to 9;
 	reserved 50;
 	reserved "create_model_game_object";
 	reserved "resolve_viewport_drop_position";
-	reserved 57 to 99;
+	reserved 58 to 99;
 }
 
 message ProtocolResponse {

--- a/Runtime/AssetRegistry/Animation/AnimationImporter.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationImporter.cpp
@@ -1,12 +1,385 @@
 #include "AnimationImporter.h"
 #include "AssetRegistry/AssetRegistry.h"
+#include "AssetRegistry/Model/GltfImporterUtils.h"
 #include <tiny_gltf.h>
-#include <glm/gtc/type_ptr.hpp>
 #include <glm/gtc/matrix_transform.hpp>
 #include <glm/gtx/quaternion.hpp>
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
 #include "Math/Transform.h"
+#include "Math/Math.h"
 
 using namespace Sailor;
+
+namespace
+{
+	struct GltfFloatAccessorView
+	{
+		const tinygltf::Accessor* m_accessor = nullptr;
+		const uint8_t* m_data = nullptr;
+		size_t m_stride = 0;
+		size_t m_componentCount = 0;
+		const uint8_t* m_sparseIndices = nullptr;
+		const uint8_t* m_sparseValues = nullptr;
+		size_t m_sparseCount = 0;
+		size_t m_sparseIndexStride = 0;
+		size_t m_sparseValueStride = 0;
+		int32_t m_sparseIndexComponentType = -1;
+	};
+
+	bool IsAccessorRangeValid(
+		size_t offset,
+		size_t stride,
+		size_t count,
+		size_t elementSize,
+		size_t bufferSize)
+	{
+		if (count == 0)
+		{
+			return offset <= bufferSize;
+		}
+
+		if (offset > bufferSize || elementSize > bufferSize - offset)
+		{
+			return false;
+		}
+
+		return count == 1 ||
+			(stride >= elementSize &&
+			 count - 1 <= (bufferSize - offset - elementSize) / stride);
+	}
+
+	bool HasUnsupportedBufferViewCompression(
+		const tinygltf::BufferView& bufferView)
+	{
+		return bufferView.extensions.find("EXT_meshopt_compression") !=
+				bufferView.extensions.end() ||
+			bufferView.extensions.find("KHR_meshopt_compression") !=
+				bufferView.extensions.end();
+	}
+
+	bool TryGetBufferViewData(
+		const tinygltf::Model& model,
+		int32_t bufferViewIndex,
+		size_t byteOffset,
+		size_t stride,
+		size_t count,
+		size_t elementSize,
+		const uint8_t*& outData)
+	{
+		outData = nullptr;
+		if (bufferViewIndex < 0 ||
+			static_cast<size_t>(bufferViewIndex) >= model.bufferViews.size())
+		{
+			return false;
+		}
+
+		const tinygltf::BufferView& bufferView =
+			model.bufferViews[bufferViewIndex];
+		if (bufferView.buffer < 0 ||
+			static_cast<size_t>(bufferView.buffer) >= model.buffers.size() ||
+			HasUnsupportedBufferViewCompression(bufferView) ||
+			!IsAccessorRangeValid(
+				byteOffset,
+				stride,
+				count,
+				elementSize,
+				bufferView.byteLength))
+		{
+			return false;
+		}
+
+		const tinygltf::Buffer& buffer = model.buffers[bufferView.buffer];
+		if (bufferView.byteOffset > buffer.data.size() ||
+			bufferView.byteLength > buffer.data.size() - bufferView.byteOffset)
+		{
+			return false;
+		}
+
+		outData = buffer.data.data() + bufferView.byteOffset + byteOffset;
+		return true;
+	}
+
+	template<typename T>
+	T ReadUnaligned(const uint8_t* data)
+	{
+		T value{};
+		std::memcpy(&value, data, sizeof(T));
+		return value;
+	}
+
+	bool TryReadSparseIndex(
+		const GltfFloatAccessorView& view,
+		size_t sparseElement,
+		uint32_t& outIndex)
+	{
+		if (sparseElement >= view.m_sparseCount)
+		{
+			return false;
+		}
+
+		const uint8_t* data = view.m_sparseIndices +
+			sparseElement * view.m_sparseIndexStride;
+		switch (view.m_sparseIndexComponentType)
+		{
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE:
+			outIndex = ReadUnaligned<uint8_t>(data);
+			return true;
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
+			outIndex = ReadUnaligned<uint16_t>(data);
+			return true;
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
+			outIndex = ReadUnaligned<uint32_t>(data);
+			return true;
+		default:
+			return false;
+		}
+	}
+
+	bool TryGetFloatAccessorView(
+		const tinygltf::Model& model,
+		int32_t accessorIndex,
+		int32_t expectedType,
+		size_t requiredCount,
+		GltfFloatAccessorView& outView)
+	{
+		outView = {};
+		if (accessorIndex < 0 ||
+			static_cast<size_t>(accessorIndex) >= model.accessors.size())
+		{
+			return false;
+		}
+
+		const tinygltf::Accessor& accessor = model.accessors[accessorIndex];
+		if (accessor.componentType != TINYGLTF_COMPONENT_TYPE_FLOAT ||
+			accessor.normalized ||
+			accessor.type != expectedType ||
+			accessor.count == 0 ||
+			accessor.count < requiredCount ||
+			(!accessor.sparse.isSparse && accessor.bufferView < 0) ||
+			(accessor.bufferView < 0 && accessor.byteOffset != 0))
+		{
+			return false;
+		}
+
+		const int32_t componentCount = tinygltf::GetNumComponentsInType(
+			static_cast<uint32_t>(accessor.type));
+		if (componentCount <= 0 ||
+			static_cast<size_t>(componentCount) >
+				std::numeric_limits<size_t>::max() / sizeof(float))
+		{
+			return false;
+		}
+
+		const size_t elementSize =
+			static_cast<size_t>(componentCount) * sizeof(float);
+		size_t stride = elementSize;
+		const uint8_t* data = nullptr;
+		if (accessor.bufferView >= 0)
+		{
+			if (static_cast<size_t>(accessor.bufferView) >=
+				model.bufferViews.size())
+			{
+				return false;
+			}
+
+			const tinygltf::BufferView& bufferView =
+				model.bufferViews[accessor.bufferView];
+			stride = bufferView.byteStride > 0 ?
+				static_cast<size_t>(bufferView.byteStride) : elementSize;
+			if (stride < elementSize || stride % sizeof(float) != 0 ||
+				!TryGetBufferViewData(
+					model,
+					accessor.bufferView,
+					accessor.byteOffset,
+					stride,
+					accessor.count,
+					elementSize,
+					data))
+			{
+				return false;
+			}
+		}
+
+		outView.m_accessor = &accessor;
+		outView.m_data = data;
+		outView.m_stride = stride;
+		outView.m_componentCount = static_cast<size_t>(componentCount);
+		if (!accessor.sparse.isSparse)
+		{
+			return true;
+		}
+
+		if (accessor.sparse.count <= 0 ||
+			static_cast<size_t>(accessor.sparse.count) > accessor.count)
+		{
+			return false;
+		}
+
+		const int32_t sparseIndexComponentType =
+			accessor.sparse.indices.componentType;
+		const int32_t sparseIndexSize = tinygltf::GetComponentSizeInBytes(
+			static_cast<uint32_t>(sparseIndexComponentType));
+		if (sparseIndexSize <= 0 ||
+			(sparseIndexComponentType != TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE &&
+			 sparseIndexComponentType != TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT &&
+			 sparseIndexComponentType != TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT) ||
+			accessor.sparse.indices.bufferView < 0 ||
+			accessor.sparse.values.bufferView < 0 ||
+			static_cast<size_t>(accessor.sparse.indices.bufferView) >=
+				model.bufferViews.size() ||
+			static_cast<size_t>(accessor.sparse.values.bufferView) >=
+				model.bufferViews.size())
+		{
+			return false;
+		}
+
+		const size_t sparseCount =
+			static_cast<size_t>(accessor.sparse.count);
+		const tinygltf::BufferView& sparseIndicesView =
+			model.bufferViews[accessor.sparse.indices.bufferView];
+		const tinygltf::BufferView& sparseValuesView =
+			model.bufferViews[accessor.sparse.values.bufferView];
+		const size_t sparseIndexStride = sparseIndicesView.byteStride > 0 ?
+			static_cast<size_t>(sparseIndicesView.byteStride) :
+			static_cast<size_t>(sparseIndexSize);
+		const size_t sparseValueStride = sparseValuesView.byteStride > 0 ?
+			static_cast<size_t>(sparseValuesView.byteStride) : elementSize;
+		if (sparseIndexStride < static_cast<size_t>(sparseIndexSize) ||
+			sparseValueStride < elementSize ||
+			!TryGetBufferViewData(
+				model,
+				accessor.sparse.indices.bufferView,
+				accessor.sparse.indices.byteOffset,
+				sparseIndexStride,
+				sparseCount,
+				static_cast<size_t>(sparseIndexSize),
+				outView.m_sparseIndices) ||
+			!TryGetBufferViewData(
+				model,
+				accessor.sparse.values.bufferView,
+				accessor.sparse.values.byteOffset,
+				sparseValueStride,
+				sparseCount,
+				elementSize,
+				outView.m_sparseValues))
+		{
+			return false;
+		}
+
+		outView.m_sparseCount = sparseCount;
+		outView.m_sparseIndexStride = sparseIndexStride;
+		outView.m_sparseValueStride = sparseValueStride;
+		outView.m_sparseIndexComponentType = sparseIndexComponentType;
+
+		uint32_t previousIndex = 0;
+		for (size_t i = 0; i < sparseCount; ++i)
+		{
+			uint32_t sparseIndex = 0;
+			if (!TryReadSparseIndex(outView, i, sparseIndex) ||
+				sparseIndex >= accessor.count ||
+				(i > 0 && sparseIndex <= previousIndex))
+			{
+				return false;
+			}
+			previousIndex = sparseIndex;
+		}
+
+		return true;
+	}
+
+	const uint8_t* GetAccessorElementData(
+		const GltfFloatAccessorView& view,
+		size_t elementIndex)
+	{
+		if (view.m_accessor == nullptr ||
+			elementIndex >= view.m_accessor->count)
+		{
+			return nullptr;
+		}
+
+		size_t left = 0;
+		size_t right = view.m_sparseCount;
+		while (left < right)
+		{
+			const size_t middle = left + (right - left) / 2;
+			uint32_t sparseIndex = 0;
+			if (!TryReadSparseIndex(view, middle, sparseIndex))
+			{
+				return nullptr;
+			}
+
+			if (sparseIndex < elementIndex)
+			{
+				left = middle + 1;
+			}
+			else
+			{
+				right = middle;
+			}
+		}
+
+		if (left < view.m_sparseCount)
+		{
+			uint32_t sparseIndex = 0;
+			if (TryReadSparseIndex(view, left, sparseIndex) &&
+				sparseIndex == elementIndex)
+			{
+				return view.m_sparseValues + left * view.m_sparseValueStride;
+			}
+		}
+
+		return view.m_data != nullptr ?
+			view.m_data + elementIndex * view.m_stride : nullptr;
+	}
+
+	bool TryReadAccessorFloat(
+		const GltfFloatAccessorView& view,
+		size_t elementIndex,
+		size_t componentIndex,
+		float& outValue)
+	{
+		if (view.m_accessor == nullptr ||
+			elementIndex >= view.m_accessor->count ||
+			componentIndex >= view.m_componentCount)
+		{
+			return false;
+		}
+
+		const uint8_t* data = GetAccessorElementData(view, elementIndex);
+		outValue = data != nullptr ?
+			ReadUnaligned<float>(data + componentIndex * sizeof(float)) : 0.0f;
+		return std::isfinite(outValue);
+	}
+
+	enum class EAnimationTarget : uint8_t
+	{
+		Translation,
+		Rotation,
+		Scale
+	};
+
+	struct PreparedAnimationChannel
+	{
+		GltfFloatAccessorView m_output;
+		size_t m_targetNode = 0;
+		size_t m_sampleCount = 0;
+		EAnimationTarget m_target = EAnimationTarget::Translation;
+		bool m_bCubicSpline = false;
+	};
+
+	bool IsTransformFinite(const Math::Transform& transform)
+	{
+		return Math::AllFinite(transform.m_position) &&
+			Math::AllFinite(transform.m_scale) &&
+			std::isfinite(transform.m_rotation.x) &&
+			std::isfinite(transform.m_rotation.y) &&
+			std::isfinite(transform.m_rotation.z) &&
+			std::isfinite(transform.m_rotation.w);
+	}
+}
 
 AnimationImporter::AnimationImporter(AnimationAssetInfoHandler* infoHandler)
 {
@@ -100,12 +473,14 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 	if (auto info = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr<AnimationAssetInfoPtr>(uid))
 	{
 		tinygltf::Model gltfModel;
-		tinygltf::TinyGLTF loader;
 		std::string err, warn;
 
-		bool parsed = (Utils::GetFileExtension(info->GetAssetFilepath()) == "glb") ?
-			loader.LoadBinaryFromFile(&gltfModel, &err, &warn, info->GetAssetFilepath().c_str()) :
-			loader.LoadASCIIFromFile(&gltfModel, &err, &warn, info->GetAssetFilepath().c_str());
+		const bool parsed = GltfImporterUtils::LoadModel(
+			info->GetAssetFilepath(),
+			true,
+			gltfModel,
+			err,
+			warn);
 
 		if (!parsed)
 		{
@@ -114,113 +489,323 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 
 		if (!gltfModel.animations.empty() && !gltfModel.skins.empty())
 		{
-			uint32_t animIndex = (uint32_t)info->GetAnimationIndex();
-			uint32_t skinIndex = (uint32_t)info->GetSkinIndex();
-
-			if (animIndex >= gltfModel.animations.size() || skinIndex >= gltfModel.skins.size())
+			const int32_t sourceAnimationIndex = info->GetAnimationIndex();
+			const int32_t sourceSkinIndex = info->GetSkinIndex();
+			if (sourceAnimationIndex < 0 || sourceSkinIndex < 0 ||
+				static_cast<size_t>(sourceAnimationIndex) >=
+					gltfModel.animations.size() ||
+				static_cast<size_t>(sourceSkinIndex) >= gltfModel.skins.size())
 			{
 				return false;
 			}
 
+			const size_t animIndex =
+				static_cast<size_t>(sourceAnimationIndex);
+			const size_t skinIndex = static_cast<size_t>(sourceSkinIndex);
 			const auto& gltfAnim = gltfModel.animations[animIndex];
 			const auto& gltfSkin = gltfModel.skins[skinIndex];
+			const size_t numBones = gltfSkin.joints.size();
+			const size_t numNodes = gltfModel.nodes.size();
+			constexpr size_t MaxVectorElements =
+				(static_cast<size_t>(std::numeric_limits<uint32_t>::max()) + 1) / 2;
+			if (numBones == 0 ||
+				numBones > MaxVectorElements ||
+				numNodes > MaxVectorElements ||
+				numNodes > static_cast<size_t>(std::numeric_limits<int32_t>::max()) ||
+				gltfAnim.samplers.size() > MaxVectorElements ||
+				gltfAnim.channels.size() > MaxVectorElements)
+			{
+				return false;
+			}
 
-			size_t numBones = gltfSkin.joints.size();
-			const tinygltf::Accessor& timeAccessor = gltfModel.accessors[gltfAnim.samplers[0].input];
-			size_t numFrames = timeAccessor.count;
+			for (int32_t joint : gltfSkin.joints)
+			{
+				if (joint < 0 || static_cast<size_t>(joint) >= numNodes)
+				{
+					return false;
+				}
+			}
 
-			anim->m_numBones = (uint32_t)numBones;
-			anim->m_numFrames = (uint32_t)numFrames;
-			anim->m_fps = 30.0f;
+			size_t numFrames = 0;
+			for (const auto& sampler : gltfAnim.samplers)
+			{
+				GltfFloatAccessorView inputView;
+				if (TryGetFloatAccessorView(
+					gltfModel,
+					sampler.input,
+					TINYGLTF_TYPE_SCALAR,
+					1,
+					inputView) &&
+					inputView.m_accessor->count <= MaxVectorElements)
+				{
+					numFrames = inputView.m_accessor->count;
+					break;
+				}
+			}
+
+			if (numFrames == 0 || numFrames > MaxVectorElements / numBones)
+			{
+				return false;
+			}
 
 			TVector<Math::Transform> framesData;
 			framesData.Resize(numFrames * numBones);
 
-			TVector<int> parents(gltfModel.nodes.size(), -1);
-			for (size_t i = 0; i < gltfModel.nodes.size(); ++i)
+			TVector<int32_t> parents;
+			parents.Resize(numNodes);
+			for (size_t i = 0; i < numNodes; ++i)
+			{
+				parents[i] = -1;
+			}
+
+			for (size_t i = 0; i < numNodes; ++i)
 			{
 				const auto& node = gltfModel.nodes[i];
-				for (int child : node.children)
+				for (int32_t child : node.children)
 				{
-					parents[child] = (int)i;
+					if (child >= 0 &&
+						static_cast<size_t>(child) < numNodes &&
+						static_cast<size_t>(child) != i &&
+						parents[child] < 0)
+					{
+						parents[child] = static_cast<int32_t>(i);
+					}
 				}
 			}
 
-			TVector<Math::Transform> base(gltfModel.nodes.size());
-			for (size_t i = 0; i < gltfModel.nodes.size(); ++i)
+			TVector<Math::Transform> base(numNodes);
+			for (size_t i = 0; i < numNodes; ++i)
 			{
 				const auto& n = gltfModel.nodes[i];
-				if (n.translation.size() == 3) base[i].m_position = glm::vec4(n.translation[0], n.translation[1], n.translation[2], 1.0f);
-				if (n.rotation.size() == 4) base[i].m_rotation = glm::quat((float)n.rotation[3], (float)n.rotation[0], (float)n.rotation[1], (float)n.rotation[2]);
-				if (n.scale.size() == 3) base[i].m_scale = glm::vec4(n.scale[0], n.scale[1], n.scale[2], 1.0f);
-			}
-
-			TVector<TVector<Math::Transform>> transforms(numFrames);
-			for (uint32_t i = 0; i < numFrames; i++)
-			{
-				transforms[i].AddRange(base);
-			}
-
-			for (const auto& channel : gltfAnim.channels)
-			{
-				const auto& sampler = gltfAnim.samplers[channel.sampler];
-				//const auto& inAcc = gltfModel.accessors[sampler.input];
-				//const auto& inView = gltfModel.bufferViews[inAcc.bufferView];
-				//const float* inData = reinterpret_cast<const float*>(&gltfModel.buffers[inView.buffer].data[inView.byteOffset + inAcc.byteOffset]);
-
-				const auto& outAcc = gltfModel.accessors[sampler.output];
-				const auto& outView = gltfModel.bufferViews[outAcc.bufferView];
-				const float* outData = reinterpret_cast<const float*>(&gltfModel.buffers[outView.buffer].data[outView.byteOffset + outAcc.byteOffset]);
-
-				for (size_t f = 0; f < numFrames; ++f)
+				if (n.translation.size() == 3)
 				{
-					size_t offset = f * ((channel.target_path == "rotation") ? 4 : 3);
-					auto& nodeTrs = transforms[f][channel.target_node];
+					const glm::vec4 translation(
+						static_cast<float>(n.translation[0]),
+						static_cast<float>(n.translation[1]),
+						static_cast<float>(n.translation[2]),
+						1.0f);
+					if (Math::AllFinite(translation))
+					{
+						base[i].m_position = translation;
+					}
+				}
 
-					if (channel.target_path == "translation")
+				if (n.rotation.size() == 4)
+				{
+					glm::quat rotation(
+						static_cast<float>(n.rotation[3]),
+						static_cast<float>(n.rotation[0]),
+						static_cast<float>(n.rotation[1]),
+						static_cast<float>(n.rotation[2]));
+					const float lengthSquared = glm::dot(rotation, rotation);
+					if (std::isfinite(lengthSquared) &&
+						lengthSquared > std::numeric_limits<float>::epsilon())
 					{
-						nodeTrs.m_position = glm::vec4(glm::make_vec3(outData + offset), 1.0f);
+						base[i].m_rotation = glm::normalize(rotation);
 					}
-					else if (channel.target_path == "rotation")
+				}
+
+				if (n.scale.size() == 3)
+				{
+					const glm::vec4 scale(
+						static_cast<float>(n.scale[0]),
+						static_cast<float>(n.scale[1]),
+						static_cast<float>(n.scale[2]),
+						1.0f);
+					if (Math::AllFinite(scale))
 					{
-						nodeTrs.m_rotation = glm::quat(outData[offset + 3], outData[offset], outData[offset + 1], outData[offset + 2]);
-					}
-					else if (channel.target_path == "scale")
-					{
-						nodeTrs.m_scale = glm::vec4(glm::make_vec3(outData + offset), 1.0f);
+						base[i].m_scale = scale;
 					}
 				}
 			}
 
-			auto compose = [&](uint32_t nodeIndex, const TVector<Math::Transform>& local, TVector<Math::Transform>& global)
+			TVector<PreparedAnimationChannel> preparedChannels;
+			preparedChannels.Reserve(gltfAnim.channels.size());
+			for (const auto& channel : gltfAnim.channels)
+			{
+				if (channel.sampler < 0 ||
+					static_cast<size_t>(channel.sampler) >= gltfAnim.samplers.size() ||
+					channel.target_node < 0 ||
+					static_cast<size_t>(channel.target_node) >= numNodes)
 				{
-					global[nodeIndex] = local[nodeIndex];
-					if (parents[nodeIndex] >= 0)
-					{
-						const Math::Transform& parent = global[parents[nodeIndex]];
-						global[nodeIndex].m_position = parent.TransformPosition(global[nodeIndex].m_position);
-						global[nodeIndex].m_rotation = parent.m_rotation * global[nodeIndex].m_rotation;
-						global[nodeIndex].m_scale.x *= parent.m_scale.x;
-						global[nodeIndex].m_scale.y *= parent.m_scale.y;
-						global[nodeIndex].m_scale.z *= parent.m_scale.z;
-					}
-				};
+					continue;
+				}
+
+				const auto& sampler = gltfAnim.samplers[channel.sampler];
+				GltfFloatAccessorView inputView;
+				if (!TryGetFloatAccessorView(
+					gltfModel,
+					sampler.input,
+					TINYGLTF_TYPE_SCALAR,
+					1,
+					inputView) ||
+					inputView.m_accessor->count > MaxVectorElements)
+				{
+					continue;
+				}
+				const size_t sampleCount = inputView.m_accessor->count;
+
+				PreparedAnimationChannel prepared;
+				int32_t outputType = TINYGLTF_TYPE_VEC3;
+				if (channel.target_path == "translation")
+				{
+					prepared.m_target = EAnimationTarget::Translation;
+				}
+				else if (channel.target_path == "rotation")
+				{
+					prepared.m_target = EAnimationTarget::Rotation;
+					outputType = TINYGLTF_TYPE_VEC4;
+				}
+				else if (channel.target_path == "scale")
+				{
+					prepared.m_target = EAnimationTarget::Scale;
+				}
+				else
+				{
+					continue;
+				}
+
+				prepared.m_bCubicSpline = sampler.interpolation == "CUBICSPLINE";
+				if (!prepared.m_bCubicSpline &&
+					!sampler.interpolation.empty() &&
+					sampler.interpolation != "LINEAR" &&
+					sampler.interpolation != "STEP")
+				{
+					continue;
+				}
+
+				if (prepared.m_bCubicSpline &&
+					sampleCount > std::numeric_limits<size_t>::max() / 3)
+				{
+					continue;
+				}
+
+				const size_t outputCount = prepared.m_bCubicSpline ?
+					sampleCount * 3 : sampleCount;
+				if (!TryGetFloatAccessorView(
+					gltfModel,
+					sampler.output,
+					outputType,
+					outputCount,
+					prepared.m_output) ||
+					prepared.m_output.m_accessor->count != outputCount)
+				{
+					continue;
+				}
+
+				prepared.m_targetNode =
+					static_cast<size_t>(channel.target_node);
+				prepared.m_sampleCount = sampleCount;
+				preparedChannels.Add(prepared);
+			}
 
 			for (size_t f = 0; f < numFrames; ++f)
 			{
-				TVector<Math::Transform> global(gltfModel.nodes.size());
-				for (size_t i = 0; i < gltfModel.nodes.size(); ++i)
+				TVector<Math::Transform> local(base);
+				for (const auto& channel : preparedChannels)
 				{
-					compose((uint32_t)i, transforms[f], global);
+					const size_t sample =
+						(std::min)(f, channel.m_sampleCount - 1);
+					const size_t outputElement = channel.m_bCubicSpline ?
+						sample * 3 + 1 : sample;
+					const size_t componentCount =
+						channel.m_target == EAnimationTarget::Rotation ? 4 : 3;
+					float values[4]{};
+					bool bValid = true;
+					for (size_t component = 0;
+						component < componentCount;
+						++component)
+					{
+						bValid &= TryReadAccessorFloat(
+							channel.m_output,
+							outputElement,
+							component,
+							values[component]);
+					}
+
+					if (!bValid)
+					{
+						continue;
+					}
+
+					Math::Transform& target = local[channel.m_targetNode];
+					if (channel.m_target == EAnimationTarget::Translation)
+					{
+						target.m_position = glm::vec4(
+							values[0], values[1], values[2], 1.0f);
+					}
+					else if (channel.m_target == EAnimationTarget::Scale)
+					{
+						target.m_scale = glm::vec4(
+							values[0], values[1], values[2], 1.0f);
+					}
+					else
+					{
+						glm::quat rotation(
+							values[3], values[0], values[1], values[2]);
+						const float lengthSquared = glm::dot(rotation, rotation);
+						if (std::isfinite(lengthSquared) &&
+							lengthSquared > std::numeric_limits<float>::epsilon())
+						{
+							target.m_rotation = glm::normalize(rotation);
+						}
+					}
+				}
+
+				TVector<Math::Transform> global(numNodes);
+				TVector<uint8_t> composeState(numNodes);
+				auto compose = [&](auto&& self, size_t nodeIndex) -> bool
+				{
+					if (composeState[nodeIndex] == 2)
+					{
+						return IsTransformFinite(global[nodeIndex]);
+					}
+					if (composeState[nodeIndex] == 1)
+					{
+						global[nodeIndex] = local[nodeIndex];
+						composeState[nodeIndex] = 2;
+						return false;
+					}
+
+					composeState[nodeIndex] = 1;
+					Math::Transform composed = local[nodeIndex];
+					const int32_t parentIndex = parents[nodeIndex];
+					if (parentIndex >= 0 &&
+						self(self, static_cast<size_t>(parentIndex)))
+					{
+						const Math::Transform& parent =
+							global[static_cast<size_t>(parentIndex)];
+						composed.m_position =
+							parent.TransformPosition(composed.m_position);
+						composed.m_rotation =
+							parent.m_rotation * composed.m_rotation;
+						composed.m_scale.x *= parent.m_scale.x;
+						composed.m_scale.y *= parent.m_scale.y;
+						composed.m_scale.z *= parent.m_scale.z;
+					}
+
+					global[nodeIndex] = IsTransformFinite(composed) ?
+						composed : local[nodeIndex];
+					composeState[nodeIndex] = 2;
+					return IsTransformFinite(global[nodeIndex]);
+				};
+
+				for (size_t i = 0; i < numNodes; ++i)
+				{
+					compose(compose, i);
 				}
 
 				for (size_t j = 0; j < numBones; ++j)
 				{
-					uint32_t nodeIndex = gltfSkin.joints[j];
+					const size_t nodeIndex =
+						static_cast<size_t>(gltfSkin.joints[j]);
 					framesData[f * numBones + j] = global[nodeIndex];
 				}
 			}
 
+			anim->m_numBones = static_cast<uint32_t>(numBones);
+			anim->m_numFrames = static_cast<uint32_t>(numFrames);
+			anim->m_fps = 30.0f;
 			anim->m_frames = std::move(framesData);
 		}
 	}

--- a/Runtime/AssetRegistry/AssetCache.cpp
+++ b/Runtime/AssetRegistry/AssetCache.cpp
@@ -242,7 +242,8 @@ YAML::Node AssetCache::AssetCacheData::Serialize() const
 	YAML::Node assets(YAML::NodeType::Map);
 	for (const auto& entry : m_data)
 	{
-		assets[entry.m_first] = entry.m_second;
+		// FileIds are unique in m_data, so avoid YAML's linear key lookup for every entry.
+		assets.force_insert(entry.m_first.ToString(), entry.m_second.Serialize());
 	}
 	result["assets"] = assets;
 	return result;

--- a/Runtime/AssetRegistry/AssetInfo.cpp
+++ b/Runtime/AssetRegistry/AssetInfo.cpp
@@ -1,5 +1,6 @@
 #include "AssetRegistry/AssetInfo.h"
 #include "AssetRegistry/AssetRegistry.h"
+#include "AssetRegistry/AssetScanSourceRevisionCache.h"
 #include <filesystem>
 #include <fstream>
 #include "Core/Utils.h"
@@ -85,6 +86,17 @@ namespace
 		RemoveFileIfContentsMatch(filepath, outContents.substr(0, written));
 		return false;
 	}
+
+	bool TryGetSourceRevision(
+		const std::string& filepath,
+		FileRevision& outRevision)
+	{
+		AssetScanSourceRevisionCache* sourceRevisionCache =
+			GetActiveAssetScanSourceRevisionCache();
+		return sourceRevisionCache != nullptr ?
+			sourceRevisionCache->TryGet(filepath, outRevision)
+			: Utils::TryGetFileRevision(filepath, outRevision);
+	}
 }
 
 std::string AssetInfo::GetAssetInfoType() const
@@ -129,7 +141,7 @@ AssetInfo::AssetInfo()
 bool AssetInfo::IsAssetExpired() const
 {
 	FileRevision currentRevision;
-	if (!Utils::TryGetFileRevision(GetAssetFilepath(), currentRevision))
+	if (!TryGetSourceRevision(GetAssetFilepath(), currentRevision))
 	{
 		return true;
 	}
@@ -480,7 +492,7 @@ bool IAssetInfoHandler::ReloadAssetInfo(
 	}
 	FileRevision sourceRevision;
 	const std::string sourceFilepath = assetInfo->GetAssetFilepath();
-	if (!Utils::TryGetFileRevision(sourceFilepath, sourceRevision))
+	if (!TryGetSourceRevision(sourceFilepath, sourceRevision))
 	{
 		if (bHadLoadedIdentity)
 		{

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -1495,6 +1495,203 @@ bool AssetRegistry::UpdateAsset(const FileId& fileId)
 	return bSucceeded && bCacheSaved;
 }
 
+FileId AssetRegistry::RegisterGeneratedSecondaryAssetInfo(
+	const std::filesystem::path& metadataPath)
+{
+	if (m_scheduler != nullptr && !m_scheduler->IsMainThread())
+	{
+		SAILOR_LOG_ERROR(
+			"Generated secondary asset metadata may only be registered from the main thread: %s",
+			metadataPath.generic_string().c_str());
+		return FileId::Invalid;
+	}
+
+	std::error_code pathError;
+	const std::filesystem::path canonicalMetadataPath =
+		std::filesystem::weakly_canonical(metadataPath, pathError);
+	if (pathError ||
+		!std::filesystem::is_regular_file(canonicalMetadataPath, pathError) ||
+		pathError)
+	{
+		SAILOR_LOG_ERROR(
+			"Generated secondary asset metadata is not a regular file: %s",
+			metadataPath.generic_string().c_str());
+		return FileId::Invalid;
+	}
+
+	const AssetMountDescriptor* metadataMount = nullptr;
+	for (const AssetMountDescriptor& mount : m_contentMounts)
+	{
+		if (mount.m_kind == EAssetMountKind::Workspace &&
+			mount.m_bWritable &&
+			IsInside(mount.m_root, canonicalMetadataPath))
+		{
+			metadataMount = &mount;
+			break;
+		}
+	}
+	if (metadataMount == nullptr)
+	{
+		SAILOR_LOG_ERROR(
+			"Generated secondary asset metadata must be inside the writable workspace Content mount: %s",
+			canonicalMetadataPath.generic_string().c_str());
+		return FileId::Invalid;
+	}
+
+	std::string fileIdString;
+	std::string filename;
+	std::string assetInfoType;
+	std::string metadataError;
+	if (!ReadMetadataIdentity(
+			canonicalMetadataPath,
+			fileIdString,
+			filename,
+			assetInfoType,
+			metadataError))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot register generated secondary asset metadata '%s': %s.",
+			canonicalMetadataPath.generic_string().c_str(),
+			metadataError.c_str());
+		return FileId::Invalid;
+	}
+
+	pathError.clear();
+	const std::filesystem::path canonicalSourcePath =
+		std::filesystem::weakly_canonical(
+			canonicalMetadataPath.parent_path() / filename,
+			pathError);
+	if (pathError ||
+		!std::filesystem::is_regular_file(canonicalSourcePath, pathError) ||
+		pathError ||
+		!IsInside(metadataMount->m_root, canonicalSourcePath))
+	{
+		SAILOR_LOG_ERROR(
+			"Generated secondary asset metadata '%s' references an invalid source '%s'.",
+			canonicalMetadataPath.generic_string().c_str(),
+			filename.c_str());
+		return FileId::Invalid;
+	}
+
+	const FileId expectedFileId = ParseFileId(fileIdString);
+	if (!expectedFileId)
+	{
+		SAILOR_LOG_ERROR(
+			"Generated secondary asset metadata contains an invalid FileId: %s",
+			canonicalMetadataPath.generic_string().c_str());
+		return FileId::Invalid;
+	}
+
+	auto existingAssetInfo = m_loadedAssetInfo.Find(expectedFileId);
+	if (existingAssetInfo != m_loadedAssetInfo.end())
+	{
+		if (existingAssetInfo.Value() != nullptr &&
+			PathKey(existingAssetInfo.Value()->GetMetaFilepath()) ==
+				PathKey(canonicalMetadataPath))
+		{
+			AssetInfoPtr existingInfo = existingAssetInfo.Value();
+			// A caller may have atomically replaced the metadata within the same
+			// filesystem timestamp tick. Always reload this explicit registration.
+			IAssetInfoHandler* existingHandler = existingInfo->GetHandler();
+			const bool bHadPendingUpdate =
+				existingInfo->m_bPendingUpdateNotification;
+			const bool bHadPendingWasExpired =
+				existingInfo->m_bPendingWasExpired;
+			const bool bHadPendingImport =
+				existingInfo->m_bPendingImportNotification;
+			if (existingHandler == nullptr ||
+				!existingHandler->ReloadAssetInfo(
+					existingInfo,
+					false,
+					false))
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot refresh generated secondary asset metadata: %s",
+					canonicalMetadataPath.generic_string().c_str());
+				return FileId::Invalid;
+			}
+			existingInfo->m_bPendingUpdateNotification =
+				bHadPendingUpdate;
+			existingInfo->m_bPendingWasExpired =
+				bHadPendingWasExpired;
+			existingInfo->m_bPendingImportNotification =
+				bHadPendingImport;
+			return expectedFileId;
+		}
+
+		SAILOR_LOG_ERROR(
+			"Generated secondary asset metadata '%s' collides with an active FileId.",
+			canonicalMetadataPath.generic_string().c_str());
+		return FileId::Invalid;
+	}
+
+	for (const auto& loadedAsset : m_loadedAssetInfo)
+	{
+		if (loadedAsset.m_second != nullptr &&
+			*loadedAsset.m_second != nullptr &&
+			PathKey((*loadedAsset.m_second)->GetMetaFilepath()) ==
+				PathKey(canonicalMetadataPath))
+		{
+			SAILOR_LOG_ERROR(
+				"Generated secondary asset metadata path is already registered with another FileId: %s",
+				canonicalMetadataPath.generic_string().c_str());
+			return FileId::Invalid;
+		}
+	}
+
+	const std::string virtualMetadataPath = canonicalMetadataPath
+		.lexically_relative(metadataMount->m_root)
+		.generic_string();
+	if (!IsSafeVirtualPath(virtualMetadataPath))
+	{
+		SAILOR_LOG_ERROR(
+			"Generated secondary asset metadata has an unsafe virtual path: %s",
+			virtualMetadataPath.c_str());
+		return FileId::Invalid;
+	}
+
+	const std::string handlerPath = std::filesystem::path(virtualMetadataPath)
+		.replace_extension()
+		.generic_string();
+	IAssetInfoHandler* handler = GetAssetInfoHandler(
+		Extension(handlerPath),
+		assetInfoType,
+		false);
+	if (handler == nullptr)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot find an asset info handler for generated metadata: %s",
+			canonicalMetadataPath.generic_string().c_str());
+		return FileId::Invalid;
+	}
+
+	AssetInfoPtr assetInfo = handler->LoadAssetInfo(
+		canonicalMetadataPath.string(),
+		virtualMetadataPath,
+		metadataMount->m_kind,
+		metadataMount->m_bWritable,
+		false,
+		false);
+	if (assetInfo == nullptr ||
+		assetInfo->GetFileId() != expectedFileId ||
+		PathKey(assetInfo->GetMetaFilepath()) !=
+			PathKey(canonicalMetadataPath) ||
+		PathKey(assetInfo->GetAssetFilepath()) != PathKey(canonicalSourcePath))
+	{
+		delete assetInfo;
+		SAILOR_LOG_ERROR(
+			"Generated secondary asset metadata failed identity or path validation: %s",
+			canonicalMetadataPath.generic_string().c_str());
+		return FileId::Invalid;
+	}
+
+	assetInfo->m_bPendingUpdateNotification = false;
+	assetInfo->m_bPendingWasExpired = false;
+	assetInfo->m_bPendingImportNotification = false;
+	m_loadedAssetInfo[expectedFileId] = assetInfo;
+	return expectedFileId;
+}
+
 bool AssetRegistry::RegisterAssetInfoHandler(
 	const TVector<std::string>& supportedExtensions,
 	IAssetInfoHandler* assetInfoHandler)

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -291,13 +291,25 @@ std::string AssetRegistry::GetCacheFolder()
 }
 
 AssetRegistry::AssetRegistry() :
-	AssetRegistry(App::GetWorkspaceContext())
+	AssetRegistry(
+		App::GetWorkspaceContext(),
+		App::GetSubmodule<Tasks::Scheduler>())
 {
 }
 
 AssetRegistry::AssetRegistry(
 	const Workspace::WorkspaceContext& workspaceContext) :
-	m_workspaceContext(workspaceContext)
+	AssetRegistry(
+		workspaceContext,
+		App::GetSubmodule<Tasks::Scheduler>())
+{
+}
+
+AssetRegistry::AssetRegistry(
+	const Workspace::WorkspaceContext& workspaceContext,
+	Tasks::Scheduler* scheduler) :
+	m_workspaceContext(workspaceContext),
+	m_scheduler(scheduler)
 {
 	m_contentMounts =
 	{
@@ -1188,7 +1200,7 @@ bool AssetRegistry::ScanContentFolder()
 		}
 	}
 
-	if (Tasks::Scheduler* scheduler = App::GetSubmodule<Tasks::Scheduler>())
+	if (Tasks::Scheduler* scheduler = m_scheduler)
 	{
 		if (!scheduler->IsMainThread())
 		{

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -1,4 +1,5 @@
 #include "AssetRegistry/AssetRegistry.h"
+#include "AssetRegistry/AssetScanSourceRevisionCache.h"
 #include "Containers/Containers.h"
 
 #include "AssetRegistry/Animation/AnimationAssetInfo.h"
@@ -34,6 +35,7 @@ using namespace Sailor;
 namespace
 {
 	std::atomic<uint64_t> g_nextAssetProcessingGeneration = 0;
+	thread_local AssetScanSourceRevisionCache* g_activeSourceRevisionCache = nullptr;
 
 	struct StagedAssetRecord final
 	{
@@ -305,6 +307,83 @@ AssetRegistry::AssetRegistry(
 	m_assetCache.Initialize(m_workspaceContext);
 }
 
+bool AssetScanSourceRevisionCache::TryGet(
+	const std::string& physicalSourcePath,
+	FileRevision& outRevision)
+{
+	const std::string key = PathKey(physicalSourcePath);
+	std::lock_guard<std::mutex> lock(m_mutex);
+	Entry* cached = nullptr;
+	if (m_entries.Find(key, cached) && cached != nullptr)
+	{
+		outRevision = cached->m_revision;
+		return cached->m_bSucceeded;
+	}
+
+	Entry entry;
+	entry.m_physicalPath = physicalSourcePath;
+	entry.m_bSucceeded = Utils::TryGetFileRevision(
+		physicalSourcePath,
+		entry.m_revision);
+	outRevision = entry.m_revision;
+	m_entries[key] = entry;
+	return entry.m_bSucceeded;
+}
+
+bool AssetScanSourceRevisionCache::ValidateAll(
+	std::string& outChangedPhysicalPath) const
+{
+	outChangedPhysicalPath.clear();
+	TVector<Entry> entries;
+	{
+		std::lock_guard<std::mutex> lock(m_mutex);
+		entries.Reserve(m_entries.Num());
+		for (const auto& cached : m_entries)
+		{
+			entries.Emplace(*cached.m_second);
+		}
+	}
+
+	for (const Entry& entry : entries)
+	{
+		FileRevision currentRevision;
+		const bool bSucceeded = Utils::TryGetFileRevision(
+			entry.m_physicalPath,
+			currentRevision);
+		if (bSucceeded != entry.m_bSucceeded ||
+			(bSucceeded && currentRevision != entry.m_revision))
+		{
+			outChangedPhysicalPath = entry.m_physicalPath;
+			return false;
+		}
+	}
+
+	return true;
+}
+
+void AssetScanSourceRevisionCache::Reset()
+{
+	std::lock_guard<std::mutex> lock(m_mutex);
+	m_entries.Clear();
+}
+
+AssetScanSourceRevisionScope::AssetScanSourceRevisionScope(
+	AssetScanSourceRevisionCache& cache) noexcept :
+	m_previous(g_activeSourceRevisionCache)
+{
+	g_activeSourceRevisionCache = &cache;
+}
+
+AssetScanSourceRevisionScope::~AssetScanSourceRevisionScope() noexcept
+{
+	g_activeSourceRevisionCache = m_previous;
+}
+
+AssetScanSourceRevisionCache* Sailor::GetActiveAssetScanSourceRevisionCache() noexcept
+{
+	return g_activeSourceRevisionCache;
+}
+
 bool AssetRegistry::RestoreAssetImportTime(
 	AssetInfoPtr info,
 	const FileRevision& sourceRevision)
@@ -336,7 +415,31 @@ void AssetRegistry::CacheAsset(const AssetInfoPtr info)
 	}
 	// Keep the gate locked through Update so BeginAssetProcessing cannot publish
 	// a pending revision between the state check and the cache acknowledgement.
-	m_assetCache.Update(info);
+	AssetScanSourceRevisionCache* sourceRevisionCache =
+		GetActiveAssetScanSourceRevisionCache();
+	if (sourceRevisionCache == nullptr)
+	{
+		m_assetCache.Update(info);
+		return;
+	}
+
+	FileRevision sourceRevision;
+	if (!sourceRevisionCache->TryGet(info->GetAssetFilepath(), sourceRevision))
+	{
+		m_assetCache.Remove(info->GetFileId());
+		return;
+	}
+	if (!info->m_importedSourceRevision.m_bIsValid ||
+		info->m_importedSourceRevision != sourceRevision)
+	{
+		m_assetCache.Remove(info->GetFileId());
+		return;
+	}
+	m_assetCache.Update(
+		info->GetFileId(),
+		info->GetAssetImportTime(),
+		info->GetAssetFilepath(),
+		sourceRevision);
 }
 
 AssetRegistry::AssetProcessingToken AssetRegistry::BeginAssetProcessing(AssetInfoPtr info)
@@ -632,6 +735,8 @@ IAssetInfoHandler* AssetRegistry::GetAssetInfoHandler(
 bool AssetRegistry::ScanContentFolder()
 {
 	SAILOR_PROFILE_FUNCTION();
+	AssetScanSourceRevisionCache sourceRevisionCache;
+	AssetScanSourceRevisionScope sourceRevisionScope(sourceRevisionCache);
 	{
 		std::lock_guard<std::mutex> lock(m_assetProcessingMutex);
 		m_scanProcessingTasks.Clear();
@@ -837,7 +942,7 @@ bool AssetRegistry::ScanContentFolder()
 			record.m_candidate.m_mount.m_kind,
 			record.m_candidate.m_mount.m_bWritable
 		};
-		if (!Utils::TryGetFileRevision(
+		if (!sourceRevisionCache.TryGet(
 				location.m_physicalPath.generic_string(),
 				location.m_revision))
 		{
@@ -1048,7 +1153,9 @@ bool AssetRegistry::ScanContentFolder()
 	for (const auto& stagedAsset : stagedAssetInfos)
 	{
 		AssetInfoPtr assetInfo = *stagedAsset.m_second;
-		if (assetInfo == nullptr || assetInfo->IsAssetExpired() || assetInfo->IsMetaExpired())
+		if (assetInfo == nullptr ||
+			assetInfo->IsAssetExpired() ||
+			assetInfo->IsMetaExpired())
 		{
 			const std::string changedPath = assetInfo == nullptr
 				? std::string("<null asset info>")
@@ -1098,6 +1205,32 @@ bool AssetRegistry::ScanContentFolder()
 		});
 	}
 
+	for (const auto& stagedAsset : stagedAssetInfos)
+	{
+		AssetInfoPtr assetInfo = *stagedAsset.m_second;
+		if (assetInfo == nullptr || assetInfo->IsMetaExpired())
+		{
+			const std::string changedMetadataPath = assetInfo == nullptr
+				? std::string("<null asset info>")
+				: assetInfo->GetMetaFilepath();
+			rollbackStaging();
+			SAILOR_LOG_ERROR(
+				"Asset metadata changed during the pre-commit wait; preserving the previous registry generation: %s",
+				changedMetadataPath.c_str());
+			return false;
+		}
+	}
+
+	std::string changedSourcePath;
+	if (!sourceRevisionCache.ValidateAll(changedSourcePath))
+	{
+		rollbackStaging();
+		SAILOR_LOG_ERROR(
+			"Asset source changed during staged load; preserving the previous registry generation: %s",
+			changedSourcePath.c_str());
+		return false;
+	}
+
 	TMap<FileId, AssetInfoPtr> previousAssetInfos = std::move(m_loadedAssetInfo);
 	m_loadedAssetInfo = std::move(stagedAssetInfos);
 	m_fileIds = std::move(stagedFileIds);
@@ -1110,6 +1243,10 @@ bool AssetRegistry::ScanContentFolder()
 		m_bCollectScanProcessingTasks = true;
 		m_bScanProcessingActive = true;
 	}
+	// Listener callbacks can change a source. Start a fresh commit snapshot so
+	// cache acknowledgements still inspect each shared source once and only record
+	// the post-callback revision when it matches the imported revision.
+	sourceRevisionCache.Reset();
 
 	for (const PendingAssetNotification& pending : pendingNotifications)
 	{
@@ -1170,6 +1307,180 @@ bool AssetRegistry::ScanContentFolder()
 	m_assetCache.Prune(liveAssetIds);
 	m_assetCache.SaveCache();
 	return true;
+}
+
+bool AssetRegistry::UpdateAsset(const FileId& fileId)
+{
+	SAILOR_PROFILE_FUNCTION();
+
+	AssetInfoPtr targetAssetInfo = GetAssetInfoPtr_Internal(fileId);
+	if (targetAssetInfo == nullptr)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot update an unregistered asset: %s",
+			fileId.ToString().c_str());
+		return false;
+	}
+
+	auto isCurrentProcessingPending = [this](AssetInfoPtr assetInfo)
+		{
+			if (assetInfo == nullptr)
+			{
+				return false;
+			}
+
+			FileRevision currentSourceRevision;
+			if (!Utils::TryGetFileRevision(
+					assetInfo->GetAssetFilepath(),
+					currentSourceRevision))
+			{
+				return false;
+			}
+
+			std::lock_guard<std::mutex> lock(m_assetProcessingMutex);
+			auto processingState = m_assetProcessingStates.Find(
+				assetInfo->GetFileId());
+			if (processingState == m_assetProcessingStates.end() ||
+				processingState.Value().m_bRejected)
+			{
+				return false;
+			}
+
+			const AssetProcessingToken& token =
+				processingState.Value().m_token;
+			return token &&
+				token.m_fileId == assetInfo->GetFileId() &&
+				PathKey(token.m_sourcePath) ==
+					PathKey(assetInfo->GetAssetFilepath()) &&
+				token.m_sourceRevision == currentSourceRevision &&
+				assetInfo->m_importedSourceRevision ==
+					currentSourceRevision;
+		};
+
+	struct AssetExpirationState final
+	{
+		bool m_bMetadataExpired = false;
+		bool m_bSourceExpired = false;
+		bool m_bCacheExpired = false;
+
+		explicit operator bool() const noexcept
+		{
+			return m_bMetadataExpired ||
+				m_bSourceExpired ||
+				m_bCacheExpired;
+		}
+	};
+
+	auto getExpirationState = [this](AssetInfoPtr assetInfo)
+		{
+			AssetExpirationState result;
+			if (assetInfo != nullptr)
+			{
+				result.m_bMetadataExpired = assetInfo->IsMetaExpired();
+				result.m_bSourceExpired = assetInfo->IsAssetExpired();
+				result.m_bCacheExpired = IsAssetExpired(assetInfo);
+			}
+			return result;
+		};
+
+	const std::string sharedSourcePath =
+		PathKey(targetAssetInfo->GetAssetFilepath());
+	const FileRevision initialTargetSourceRevision =
+		targetAssetInfo->m_importedSourceRevision;
+	TVector<AssetInfoPtr> assetsToUpdate;
+	assetsToUpdate.Add(targetAssetInfo);
+	bool bSharedSourceFamilyAdded = false;
+	auto addSharedSourceFamily = [&]()
+		{
+			if (bSharedSourceFamilyAdded)
+			{
+				return;
+			}
+
+			bSharedSourceFamilyAdded = true;
+			for (const auto& loadedAsset : m_loadedAssetInfo)
+			{
+				AssetInfoPtr assetInfo = *loadedAsset.m_second;
+				if (assetInfo != nullptr &&
+					assetInfo != targetAssetInfo &&
+					PathKey(assetInfo->GetAssetFilepath()) ==
+						sharedSourcePath)
+				{
+					assetsToUpdate.Add(assetInfo);
+				}
+			}
+		};
+
+	bool bReloadedAny = false;
+	bool bSucceeded = true;
+	for (size_t index = 0; index < assetsToUpdate.Num(); ++index)
+	{
+		AssetInfoPtr assetInfo = assetsToUpdate[index];
+		const AssetExpirationState expiration =
+			getExpirationState(assetInfo);
+		if (!expiration)
+		{
+			continue;
+		}
+
+		if (assetInfo == targetAssetInfo &&
+			expiration.m_bSourceExpired)
+		{
+			addSharedSourceFamily();
+		}
+
+		if (!expiration.m_bMetadataExpired &&
+			!expiration.m_bSourceExpired &&
+			expiration.m_bCacheExpired &&
+			isCurrentProcessingPending(assetInfo))
+		{
+			continue;
+		}
+
+		IAssetInfoHandler* handler = assetInfo->GetHandler();
+		if (handler == nullptr ||
+			!handler->ReloadAssetInfo(assetInfo, true, false))
+		{
+			SAILOR_LOG_ERROR(
+				"Asset update failed; preserving the previous live asset where possible: %s",
+				assetInfo->GetMetaFilepath().c_str());
+			bSucceeded = false;
+			break;
+		}
+
+		CacheAsset(assetInfo);
+		bReloadedAny = true;
+		if (assetInfo == targetAssetInfo &&
+			assetInfo->m_importedSourceRevision !=
+				initialTargetSourceRevision)
+		{
+			addSharedSourceFamily();
+		}
+	}
+
+	for (AssetInfoPtr assetInfo : assetsToUpdate)
+	{
+		if (!bSucceeded)
+		{
+			break;
+		}
+
+		const AssetExpirationState expiration =
+			getExpirationState(assetInfo);
+		if (expiration.m_bMetadataExpired ||
+			expiration.m_bSourceExpired ||
+			(expiration.m_bCacheExpired &&
+				!isCurrentProcessingPending(assetInfo)))
+		{
+			SAILOR_LOG_ERROR(
+				"Asset changed while its targeted update was being committed: %s",
+				assetInfo->GetAssetFilepath().c_str());
+			bSucceeded = false;
+		}
+	}
+
+	const bool bCacheSaved = !bReloadedAny || m_assetCache.SaveCache();
+	return bSucceeded && bCacheSaved;
 }
 
 bool AssetRegistry::RegisterAssetInfoHandler(

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -79,6 +79,9 @@ namespace Sailor
 		SAILOR_API AssetRegistry();
 		SAILOR_API explicit AssetRegistry(
 			const Workspace::WorkspaceContext& workspaceContext);
+		SAILOR_API AssetRegistry(
+			const Workspace::WorkspaceContext& workspaceContext,
+			Tasks::Scheduler* scheduler);
 		SAILOR_API virtual ~AssetRegistry() override;
 
 		template<typename TBinaryType, typename TFilepath>
@@ -259,6 +262,7 @@ namespace Sailor
 		bool m_bCollectScanProcessingTasks = false;
 		bool m_bScanProcessingActive = false;
 		bool m_bScanProcessingFailed = false;
+		Tasks::Scheduler* m_scheduler = nullptr;
 
 		AssetCache m_assetCache;
 

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -165,6 +165,7 @@ namespace Sailor
 		}
 
 		SAILOR_API bool ScanContentFolder();
+		SAILOR_API bool UpdateAsset(const FileId& fileId);
 		SAILOR_API const FileId& GetOrLoadFile(const std::string& filepath);
 
 		template<typename TAssetInfoPtr = AssetInfoPtr>

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -266,6 +266,12 @@ namespace Sailor
 
 		AssetCache m_assetCache;
 
+	private:
+
+		FileId RegisterGeneratedSecondaryAssetInfo(
+			const std::filesystem::path& metadataPath);
+
 		friend class IAssetInfoHandler;
+		friend class ModelImporter;
 	};
 }

--- a/Runtime/AssetRegistry/AssetScanSourceRevisionCache.h
+++ b/Runtime/AssetRegistry/AssetScanSourceRevisionCache.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "Core/Defines.h"
+#include "Core/FileRevision.h"
+#include "Containers/Map.h"
+
+#include <mutex>
+#include <string>
+
+namespace Sailor
+{
+	// A scan-local snapshot. Every physical source revision is captured once while
+	// staging and once more immediately before the staged generation is committed.
+	class AssetScanSourceRevisionCache final
+	{
+	public:
+		SAILOR_API bool TryGet(
+			const std::string& physicalSourcePath,
+			FileRevision& outRevision);
+		SAILOR_API bool ValidateAll(
+			std::string& outChangedPhysicalPath) const;
+		SAILOR_API void Reset();
+
+	private:
+		struct Entry final
+		{
+			std::string m_physicalPath;
+			FileRevision m_revision{};
+			bool m_bSucceeded = false;
+		};
+
+		mutable std::mutex m_mutex;
+		TMap<std::string, Entry> m_entries;
+	};
+
+	class AssetScanSourceRevisionScope final
+	{
+	public:
+		explicit AssetScanSourceRevisionScope(
+			AssetScanSourceRevisionCache& cache) noexcept;
+		~AssetScanSourceRevisionScope() noexcept;
+
+		AssetScanSourceRevisionScope(
+			const AssetScanSourceRevisionScope&) = delete;
+		AssetScanSourceRevisionScope& operator=(
+			const AssetScanSourceRevisionScope&) = delete;
+
+	private:
+		AssetScanSourceRevisionCache* m_previous = nullptr;
+	};
+
+	AssetScanSourceRevisionCache* GetActiveAssetScanSourceRevisionCache() noexcept;
+}

--- a/Runtime/AssetRegistry/Material/MaterialImporter.cpp
+++ b/Runtime/AssetRegistry/Material/MaterialImporter.cpp
@@ -653,63 +653,57 @@ Tasks::TaskPtr<MaterialPtr> MaterialImporter::LoadMaterial(FileId uid, MaterialP
 		const FileId uid = pMaterial->GetFileId();
 		const string assetFilename = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(uid)->GetAssetFilepath();
 
-		promise = Tasks::CreateTaskWithResult<MaterialPtr>("Load material",
-			[pLoadShader, pMaterial, pMaterialAsset, assetFilename = assetFilename]() mutable
+		promise = Tasks::CreateTaskWithResult<MaterialPtr>("Load material RHI resource",
+			[pMaterial, assetFilename]() mutable
 			{
-				// We're updating rhi on worker thread during load since we have no deps
-				auto updateRHI = Tasks::CreateTask("Update material RHI resource", [=]() mutable
-					{
-						if (pMaterial->GetShader()->IsReady())
-						{
-							pMaterial->UpdateRHIResource();
-							pMaterial->ForcelyUpdateUniforms();
-
-							// TODO: Optimize
-							auto rhiMaterials = pMaterial->GetRHIMaterials().GetValues();
-							for (const auto& rhi : rhiMaterials)
-							{
-								RHI::Renderer::GetDriver()->SetDebugName(rhi, assetFilename);
-							}
-						}
-
-					}, EThreadType::RHI);
-
-				// Preload textures
-				for (const auto& sampler : pMaterialAsset->GetSamplers())
+				if (pMaterial->GetShader()->IsReady())
 				{
-					TexturePtr pTexture;
+					pMaterial->UpdateRHIResource();
+					pMaterial->ForcelyUpdateUniforms();
 
-					if (auto loadTextureTask = App::GetSubmodule<TextureImporter>()->LoadTexture(*sampler.m_second, pTexture))
+					// TODO: Optimize
+					auto rhiMaterials = pMaterial->GetRHIMaterials().GetValues();
+					for (const auto& rhi : rhiMaterials)
 					{
-						auto updateSampler = loadTextureTask->Then(
-							[=](TexturePtr texture) mutable
-							{
-								if (texture)
-								{
-									pMaterial->SetSampler(sampler.m_first, texture);
-									texture->AddHotReloadDependentObject(pMaterial);
-								}
-							}, "Set material texture binding", EThreadType::Render);
-
-						updateRHI->Join(updateSampler);
+						RHI::Renderer::GetDriver()->SetDebugName(rhi, assetFilename);
 					}
 				}
 
-				for (const auto& uniform : pMaterialAsset->GetUniformsVec4())
-				{
-					pMaterial->SetUniform(uniform.m_first, *uniform.m_second);
-				}
-
-				for (const auto& uniform : pMaterialAsset->GetUniformsFloat())
-				{
-					pMaterial->SetUniform(uniform.m_first, *uniform.m_second);
-				}
-
-				updateRHI->Join(pLoadShader);
-				updateRHI->Run();
-
 				return pMaterial;
-			});
+			}, EThreadType::RHI);
+
+		// Preload textures
+		for (const auto& sampler : pMaterialAsset->GetSamplers())
+		{
+			TexturePtr pTexture;
+
+			if (auto loadTextureTask = App::GetSubmodule<TextureImporter>()->LoadTexture(*sampler.m_second, pTexture))
+			{
+				auto updateSampler = loadTextureTask->Then(
+					[=](TexturePtr texture) mutable
+					{
+						if (texture)
+						{
+							pMaterial->SetSampler(sampler.m_first, texture);
+							texture->AddHotReloadDependentObject(pMaterial);
+						}
+					}, "Set material texture binding", EThreadType::Render);
+
+				promise->Join(updateSampler);
+			}
+		}
+
+		for (const auto& uniform : pMaterialAsset->GetUniformsVec4())
+		{
+			pMaterial->SetUniform(uniform.m_first, *uniform.m_second);
+		}
+
+		for (const auto& uniform : pMaterialAsset->GetUniformsFloat())
+		{
+			pMaterial->SetUniform(uniform.m_first, *uniform.m_second);
+		}
+
+		promise->Join(pLoadShader);
 
 		outMaterial = loadedMaterial = pMaterial;
 

--- a/Runtime/AssetRegistry/Material/MaterialImporter.cpp
+++ b/Runtime/AssetRegistry/Material/MaterialImporter.cpp
@@ -14,6 +14,7 @@
 #include <filesystem>
 #include <fstream>
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 
 #include "RHI/Renderer.h"
@@ -217,52 +218,95 @@ void Material::UpdateRHIResource()
 
 void Material::UpdateUniforms(RHI::RHICommandListPtr cmdList)
 {
-	// TODO: Remove boilerplate
+	TMap<std::string, TVector<uint8_t>> bindingData;
+
+	auto writeParameter = [this, &bindingData](
+		const std::string& parameterName,
+		const void* value,
+		size_t valueSize)
+		{
+			if (!m_commonShaderBindings->HasParameter(parameterName))
+			{
+				return;
+			}
+
+			std::string bindingName;
+			std::string variableName;
+			RHI::RHIShaderBindingSet::ParseParameter(
+				parameterName,
+				bindingName,
+				variableName);
+
+			RHI::RHIShaderBindingPtr& binding =
+				m_commonShaderBindings->GetOrAddShaderBinding(bindingName);
+			RHI::ShaderLayoutBindingMember memberLayout;
+			if (!binding->FindVariableInUniformBuffer(
+				variableName,
+				memberLayout))
+			{
+				return;
+			}
+
+			const size_t bindingSize = (std::max)(
+				static_cast<size_t>(binding->GetLayout().m_size),
+				static_cast<size_t>(binding->GetLayout().m_paddedSize));
+			if (bindingSize == 0 ||
+				value == nullptr ||
+				valueSize > memberLayout.m_size ||
+				memberLayout.m_absoluteOffset > bindingSize ||
+				valueSize > bindingSize - memberLayout.m_absoluteOffset)
+			{
+				ensure(false,
+					"Cannot pack material parameter %s",
+					parameterName.c_str());
+				return;
+			}
+
+			TVector<uint8_t>& data = bindingData[bindingName];
+			if (data.IsEmpty())
+			{
+				// Value-initialize the complete reflected block. Optional material
+				// fields which are absent from the asset must remain deterministic
+				// zeros instead of retaining data from a recycled SSBO allocation.
+				data.Resize(bindingSize);
+			}
+
+			std::memcpy(
+				data.GetData() + memberLayout.m_absoluteOffset,
+				value,
+				valueSize);
+		};
+
 	for (auto& uniform : m_uniformsVec4)
 	{
-		if (m_commonShaderBindings->HasParameter(uniform.m_first))
-		{
-			std::string outBinding;
-			std::string outVariable;
-
-			RHI::RHIShaderBindingSet::ParseParameter(uniform.m_first, outBinding, outVariable);
-			RHI::RHIShaderBindingPtr& binding = m_commonShaderBindings->GetOrAddShaderBinding(outBinding);
-
-			const glm::vec4 value = uniform.m_second;
-			RHI::Renderer::GetDriverCommands()->UpdateShaderBindingVariable(cmdList, binding, outVariable, &value, sizeof(value));
-		}
+		const glm::vec4 value = uniform.m_second;
+		writeParameter(uniform.m_first, &value, sizeof(value));
 	}
 
 	for (auto& uniform : m_uniformsFloat)
 	{
-		if (m_commonShaderBindings->HasParameter(uniform.m_first))
-		{
-			std::string outBinding;
-			std::string outVariable;
-
-			RHI::RHIShaderBindingSet::ParseParameter(uniform.m_first, outBinding, outVariable);
-			RHI::RHIShaderBindingPtr& binding = m_commonShaderBindings->GetOrAddShaderBinding(outBinding);
-
-			const float value = uniform.m_second;
-			RHI::Renderer::GetDriverCommands()->UpdateShaderBindingVariable(cmdList, binding, outVariable, &value, sizeof(value));
-		}
+		const float value = uniform.m_second;
+		writeParameter(uniform.m_first, &value, sizeof(value));
 	}
 
 	for (auto& sampler : m_samplers)
 	{
 		const std::string parameterName = "material." + sampler.m_first;
+		const uint32_t value = static_cast<uint32_t>(
+			App::GetSubmodule<TextureImporter>()->GetTextureIndex(
+				sampler.m_second->GetFileId()));
+		writeParameter(parameterName, &value, sizeof(value));
+	}
 
-		if (m_commonShaderBindings->HasParameter(parameterName))
-		{
-			std::string outBinding;
-			std::string outVariable;
-
-			RHI::RHIShaderBindingSet::ParseParameter(parameterName, outBinding, outVariable);
-			RHI::RHIShaderBindingPtr& binding = m_commonShaderBindings->GetOrAddShaderBinding(outBinding);
-
-			const uint32_t value = (uint32_t)App::GetSubmodule<TextureImporter>()->GetTextureIndex(sampler.m_second->GetFileId());
-			RHI::Renderer::GetDriverCommands()->UpdateShaderBindingVariable(cmdList, binding, outVariable, &value, sizeof(value));
-		}
+	for (const auto& data : bindingData)
+	{
+		RHI::RHIShaderBindingPtr& binding =
+			m_commonShaderBindings->GetOrAddShaderBinding(data.m_first);
+		RHI::Renderer::GetDriverCommands()->UpdateShaderBinding(
+			cmdList,
+			binding,
+			data.m_second->GetData(),
+			data.m_second->Num());
 	}
 }
 
@@ -348,6 +392,7 @@ void MaterialAsset::Deserialize(const YAML::Node& outData)
 	::Deserialize(outData, "shaderUid", m_pData->m_shader);
 	::Deserialize(outData, "renderQueue", renderQueue);
 
+	m_pData->m_renderQueue = renderQueue;
 	const size_t tag = GetHash(renderQueue);
 	m_pData->m_renderState = RHI::RenderState(bEnableDepthTest, bEnableZWrite, depthBias, bCustomDepthShader, cullMode, blendMode, fillMode, tag, bSupportMultisampling);
 }

--- a/Runtime/AssetRegistry/Material/MaterialImporter.cpp
+++ b/Runtime/AssetRegistry/Material/MaterialImporter.cpp
@@ -57,6 +57,9 @@ Tasks::ITaskPtr Material::OnHotReload()
 
 	auto updateRHI = Tasks::CreateTask("Update material RHI resource", [=, this]
 		{
+			// Dependency hot reload tasks are joined before this task executes, so
+			// publish the revision only after their material-visible data is ready.
+			AdvanceContentRevision();
 			UpdateRHIResource();
 			ForcelyUpdateUniforms();
 		}, EThreadType::Render);
@@ -68,12 +71,14 @@ void Material::ClearSamplers()
 {
 	SAILOR_PROFILE_FUNCTION();
 	m_samplers.Clear();
+	AdvanceContentRevision();
 }
 
 void Material::ClearUniforms()
 {
 	m_uniformsVec4.Clear();
 	m_uniformsFloat.Clear();
+	AdvanceContentRevision();
 }
 
 void Material::SetSampler(const std::string& name, TexturePtr value)
@@ -86,6 +91,7 @@ void Material::SetSampler(const std::string& name, TexturePtr value)
 		m_samplers.Unlock(name);
 
 		m_bIsDirty = true;
+		AdvanceContentRevision();
 	}
 }
 
@@ -97,6 +103,7 @@ void Material::SetUniform(const std::string& name, float value)
 	m_uniformsFloat.Unlock(name);
 
 	m_bIsDirty = true;
+	AdvanceContentRevision();
 }
 
 void Material::SetUniform(const std::string& name, glm::vec4 value)
@@ -107,6 +114,7 @@ void Material::SetUniform(const std::string& name, glm::vec4 value)
 	m_uniformsVec4.Unlock(name);
 
 	m_bIsDirty = true;
+	AdvanceContentRevision();
 }
 
 RHI::RHIMaterialPtr Material::GetOrAddRHI(RHI::RHIVertexDescriptionPtr vertexDescription)

--- a/Runtime/AssetRegistry/Material/MaterialImporter.h
+++ b/Runtime/AssetRegistry/Material/MaterialImporter.h
@@ -33,6 +33,7 @@ namespace Sailor
 
 		SAILOR_API virtual bool IsReady() const override;
 		SAILOR_API bool IsDirty() const { return m_bIsDirty.load(); }
+		SAILOR_API uint64_t GetContentRevision() const { return m_contentRevision.load(std::memory_order_acquire); }
 
 		SAILOR_API virtual Tasks::ITaskPtr OnHotReload() override;
 
@@ -58,17 +59,27 @@ namespace Sailor
 		SAILOR_API void SetSampler(const std::string& name, TexturePtr value);
 		SAILOR_API void SetUniform(const std::string& name, glm::vec4 value);
 		SAILOR_API void SetUniform(const std::string& name, float value);
-		SAILOR_API void SetShader(ShaderSetPtr shader) { m_shader = shader; }
-		SAILOR_API void SetRenderState(const RHI::RenderState& renderState) { m_renderState = renderState; }
+		SAILOR_API void SetShader(ShaderSetPtr shader)
+		{
+			m_shader = shader;
+			AdvanceContentRevision();
+		}
+		SAILOR_API void SetRenderState(const RHI::RenderState& renderState)
+		{
+			m_renderState = renderState;
+			AdvanceContentRevision();
+		}
 
 		SAILOR_API ShaderSetPtr GetShader() const { return m_shader; }
 
 	protected:
 
+		void AdvanceContentRevision() { m_contentRevision.fetch_add(1, std::memory_order_release); }
 		void ForcelyUpdateUniforms();
 		void UpdateUniforms(RHI::RHICommandListPtr cmdList);
 
 		std::atomic<bool> m_bIsDirty{};
+		std::atomic<uint64_t> m_contentRevision{};
 
 		ShaderSetPtr m_shader{};
 		RHI::RHIShaderBindingSetPtr m_commonShaderBindings{};

--- a/Runtime/AssetRegistry/Model/GltfImporterUtils.h
+++ b/Runtime/AssetRegistry/Model/GltfImporterUtils.h
@@ -4,6 +4,7 @@
 #include "Core/Defines.h"
 
 #include <glm/mat4x4.hpp>
+#include <glm/mat3x3.hpp>
 
 #include <cstdint>
 #include <string>
@@ -23,6 +24,16 @@ namespace Sailor::GltfImporterUtils
 		int32_t m_skinIndex = -1;
 		glm::mat4 m_worldTransform{ 1.0f };
 	};
+
+	struct MeshInstanceTransforms
+	{
+		glm::mat4 m_geometryTransform{ 1.0f };
+		glm::mat3 m_directionTransform{ 1.0f };
+	};
+
+	SAILOR_SHARED_API MeshInstanceTransforms ResolveMeshInstanceTransforms(
+		const MeshInstance& instance,
+		float unitScale);
 
 	SAILOR_SHARED_API bool LoadModel(
 		const std::string& assetFilepath,

--- a/Runtime/AssetRegistry/Model/GltfImporterUtils.h
+++ b/Runtime/AssetRegistry/Model/GltfImporterUtils.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Containers/Vector.h"
+#include "Core/Defines.h"
+
+#include <glm/mat4x4.hpp>
+
+#include <cstdint>
+#include <string>
+
+namespace tinygltf
+{
+	class Model;
+	class Node;
+}
+
+namespace Sailor::GltfImporterUtils
+{
+	struct MeshInstance
+	{
+		int32_t m_nodeIndex = -1;
+		int32_t m_meshIndex = -1;
+		int32_t m_skinIndex = -1;
+		glm::mat4 m_worldTransform{ 1.0f };
+	};
+
+	SAILOR_SHARED_API bool LoadModel(
+		const std::string& assetFilepath,
+		bool bImagesAsIs,
+		tinygltf::Model& outModel,
+		std::string& outError,
+		std::string& outWarning);
+
+	SAILOR_SHARED_API bool TryComposeNodeMatrix(
+		const tinygltf::Node& node,
+		glm::mat4& outMatrix);
+
+	SAILOR_SHARED_API bool CollectMeshInstances(
+		const tinygltf::Model& model,
+		TVector<MeshInstance>& outInstances);
+}

--- a/Runtime/AssetRegistry/Model/GltfImporterUtils.h
+++ b/Runtime/AssetRegistry/Model/GltfImporterUtils.h
@@ -2,21 +2,49 @@
 
 #include "Containers/Vector.h"
 #include "Core/Defines.h"
+#include "RHI/Types.h"
 
 #include <glm/mat4x4.hpp>
 #include <glm/mat3x3.hpp>
+#include <glm/vec3.hpp>
 
+#include <yaml-cpp/yaml.h>
+
+#include <cstddef>
 #include <cstdint>
+#include <limits>
 #include <string>
 
 namespace tinygltf
 {
+	class Material;
 	class Model;
 	class Node;
 }
 
 namespace Sailor::GltfImporterUtils
 {
+	struct MaterialAlphaModeSettings
+	{
+		const char* m_renderQueue = "Opaque";
+		bool m_bEnableZWrite = true;
+		bool m_bAlphaCutout = false;
+		RHI::EBlendMode m_blendMode = RHI::EBlendMode::None;
+	};
+
+	struct MaterialTransmissionSettings
+	{
+		float m_factor = 0.0f;
+		int32_t m_textureIndex = -1;
+		float m_thicknessFactor = 0.0f;
+		int32_t m_thicknessTextureIndex = -1;
+		glm::vec3 m_attenuationColor = glm::vec3(1.0f);
+		float m_attenuationDistance = (std::numeric_limits<float>::max)();
+		float m_indexOfRefraction = 1.5f;
+
+		bool IsEnabled() const { return m_factor > 0.0f; }
+	};
+
 	struct MeshInstance
 	{
 		int32_t m_nodeIndex = -1;
@@ -34,6 +62,21 @@ namespace Sailor::GltfImporterUtils
 	SAILOR_SHARED_API MeshInstanceTransforms ResolveMeshInstanceTransforms(
 		const MeshInstance& instance,
 		float unitScale);
+
+	SAILOR_SHARED_API MaterialAlphaModeSettings ResolveMaterialAlphaMode(
+		const std::string& alphaMode,
+		bool bHasTransmission = false);
+
+	SAILOR_SHARED_API MaterialTransmissionSettings ResolveMaterialTransmission(
+		const tinygltf::Material& material,
+		size_t numTextures,
+		float unitScale = 1.0f);
+
+	// Updates only the material properties owned by the glTF alpha/transmission
+	// import path. All other authored material properties remain untouched.
+	SAILOR_SHARED_API bool MergeGeneratedMaterialProperties(
+		YAML::Node& inOutMaterial,
+		const YAML::Node& generatedProperties);
 
 	SAILOR_SHARED_API bool LoadModel(
 		const std::string& assetFilepath,

--- a/Runtime/AssetRegistry/Model/GltfImporterUtils.h
+++ b/Runtime/AssetRegistry/Model/GltfImporterUtils.h
@@ -57,6 +57,7 @@ namespace Sailor::GltfImporterUtils
 	{
 		glm::mat4 m_geometryTransform{ 1.0f };
 		glm::mat3 m_directionTransform{ 1.0f };
+		glm::vec3 m_bakedVolumeScale{ 1.0f };
 	};
 
 	SAILOR_SHARED_API MeshInstanceTransforms ResolveMeshInstanceTransforms(

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -5648,22 +5648,25 @@ Tasks::TaskPtr<bool> ModelImporter::LoadDefaultMaterials(FileId uid, TVector<Mat
 	if (ModelAssetInfoPtr modelInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr<ModelAssetInfoPtr>(uid))
 	{
 		Tasks::TaskPtr<bool> loadingFinished = Tasks::CreateTaskWithResult<bool>("Load Default Materials", []() { return true; });
+		const TVector<FileId>& defaultMaterials = modelInfo->GetDefaultMaterials();
+		outMaterials.Resize(defaultMaterials.Num());
 
-		for (auto& assetInfo : modelInfo->GetDefaultMaterials())
+		for (size_t materialIndex = 0; materialIndex < defaultMaterials.Num(); ++materialIndex)
 		{
 			MaterialPtr material;
 			Tasks::ITaskPtr loadMaterial;
-			if (assetInfo && (loadMaterial = App::GetSubmodule<MaterialImporter>()->LoadMaterial(assetInfo, material)))
+			const FileId& materialFileId = defaultMaterials[materialIndex];
+			if (materialFileId && (loadMaterial = App::GetSubmodule<MaterialImporter>()->LoadMaterial(materialFileId, material)))
 			{
 				if (material)
 				{
-					outMaterials.Add(material);
+					// Preserve the glTF material slot even if an adjacent generated
+					// material is temporarily unavailable. RHIMesh::m_materialIndex
+					// refers to this original slot and must never address a compacted
+					// list.
+					outMaterials[materialIndex] = material;
 					//TODO: Add hot reloading dependency
 					loadingFinished->Join(loadMaterial);
-				}
-				else
-				{
-					//TODO: push missing material
 				}
 			}
 		}

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -4709,7 +4709,7 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 		};
 
 		auto loadDataTask = Tasks::CreateTaskWithResult<TSharedPtr<Data>>("Load model",
-			[this, pAssetInfo, &boundsAabb, &boundsSphere]()
+			[pAssetInfo, &boundsAabb, &boundsSphere]()
 			{
 				TSharedPtr<Data> pData = TSharedPtr<Data>::Make();
 				pData->m_bShouldKeepCpuBuffers = pAssetInfo->ShouldKeepCpuBuffers();

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -1,12 +1,22 @@
 #include <filesystem>
 #include <fstream>
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstring>
 #include <iostream>
+#include <limits>
+#include <mutex>
+#include <sstream>
 #include <string>
 
+#include <nlohmann/json.hpp>
+
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/quaternion.hpp>
+
 #include "ModelImporter.h"
+#include "GltfImporterUtils.h"
 #include "AssetRegistry/FileId.h"
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/Material/MaterialImporter.h"
@@ -14,51 +24,2170 @@
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "ModelAssetInfo.h"
 #include "Core/Utils.h"
+#include "Math/Math.h"
 #include "RHI/VertexDescription.h"
 #include "RHI/Types.h"
 #include "RHI/Renderer.h"
+#include "Raytracing/MaterialUtils.h"
 #include "Raytracing/PathTracer.h"
 #include "Memory/ObjectAllocator.hpp"
+#include "Memory/UniquePtr.hpp"
+#include "Workspace/WorkspaceCacheContract.h"
 
 #ifndef TINYGLTF_IMPLEMENTATION
 #define TINYGLTF_IMPLEMENTATION
 #include <tiny_gltf.h>
 #endif
 
+#if defined(SAILOR_HAS_DRACO)
+#include <draco/compression/decode.h>
+#endif
+
+#if defined(SAILOR_HAS_MESHOPT)
+#include <meshoptimizer.h>
+#endif
+
 using namespace Sailor;
 
 namespace
 {
-	bool IsUsableDirection(const glm::vec3& value)
+	constexpr uint64_t MaxMeshoptPlaceholderBytes = 256ull * 1024ull * 1024ull;
+	constexpr size_t MaxFingerprintDecodedImageBytes =
+		256ull * 1024ull * 1024ull;
+	constexpr size_t MaxFingerprintEncodedImageBytes =
+		4ull * 1024ull * 1024ull;
+	constexpr int32_t MaxFingerprintTextureDimension = 256;
+	constexpr int32_t FingerprintImageDimension = 256;
+
+	bool IsFiniteGltfMatrix(const glm::mat4& matrix)
 	{
-		return std::isfinite(value.x) &&
-			std::isfinite(value.y) &&
-			std::isfinite(value.z) &&
-			glm::dot(value, value) > 1e-8f;
+		for (int32_t column = 0; column < 4; ++column)
+		{
+			if (!Math::AllFinite(matrix[column]))
+			{
+				return false;
+			}
+		}
+
+		return true;
 	}
 
-	void SanitizeFingerprintVertex(
+	bool IsFiniteGltfMatrix(const glm::mat3& matrix)
+	{
+		for (int32_t column = 0; column < 3; ++column)
+		{
+			if (!Math::AllFinite(matrix[column]))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	struct FingerprintRequest
+	{
+		uint64_t m_generation = 0;
+		FileRevision m_sourceRevision{};
+	};
+
+	struct FingerprintTaskChain
+	{
+		std::mutex m_mutex;
+		uint64_t m_nextRequestGeneration = 0;
+		TMap<FileId, FingerprintRequest> m_requests;
+	};
+
+	struct ActiveFingerprintRequest
+	{
+		uint64_t m_generation = 0;
+		FileRevision m_sourceRevision{};
+		bool m_bValid = false;
+	};
+
+	thread_local ActiveFingerprintRequest g_activeFingerprintRequest;
+
+	class ActiveFingerprintRequestScope final
+	{
+	public:
+		ActiveFingerprintRequestScope(
+			uint64_t generation,
+			const FileRevision& sourceRevision) :
+			m_previous(g_activeFingerprintRequest)
+		{
+			g_activeFingerprintRequest = {
+				generation,
+				sourceRevision,
+				true
+			};
+		}
+
+		~ActiveFingerprintRequestScope()
+		{
+			g_activeFingerprintRequest = m_previous;
+		}
+
+	private:
+		ActiveFingerprintRequest m_previous{};
+	};
+
+	FingerprintTaskChain& GetFingerprintTaskChain()
+	{
+		static FingerprintTaskChain taskChain;
+		return taskChain;
+	}
+
+	class StbiImageData final
+	{
+	public:
+		explicit StbiImageData(stbi_uc* data = nullptr) noexcept :
+			m_data(data)
+		{
+		}
+
+		~StbiImageData()
+		{
+			Clear();
+		}
+
+		StbiImageData(const StbiImageData&) = delete;
+		StbiImageData& operator=(const StbiImageData&) = delete;
+
+		stbi_uc* GetData() const noexcept
+		{
+			return m_data;
+		}
+
+		explicit operator bool() const noexcept
+		{
+			return m_data != nullptr;
+		}
+
+		void Clear() noexcept
+		{
+			if (m_data != nullptr)
+			{
+				stbi_image_free(m_data);
+				m_data = nullptr;
+			}
+		}
+
+	private:
+		stbi_uc* m_data = nullptr;
+	};
+
+	std::filesystem::path GetFingerprintPath(const FileId& fileId)
+	{
+		const std::filesystem::path filename = fileId.ToString() + ".png";
+		if (!fileId || filename != filename.filename())
+		{
+			return {};
+		}
+
+		return std::filesystem::path(AssetRegistry::GetCacheFolder()) /
+			"Fingerprints" /
+			filename;
+	}
+
+	bool IsFingerprintRequestCurrent(
+		const FileId& fileId,
+		uint64_t generation,
+		const FileRevision& sourceRevision)
+	{
+		FingerprintTaskChain& taskChain = GetFingerprintTaskChain();
+		const std::lock_guard<std::mutex> lock(taskChain.m_mutex);
+		FingerprintRequest* request = nullptr;
+		return taskChain.m_requests.Find(fileId, request) &&
+			request != nullptr &&
+			request->m_generation == generation &&
+			request->m_sourceRevision == sourceRevision;
+	}
+
+	struct EncodedFingerprint
+	{
+		TVector<uint8_t> m_bytes;
+		bool m_bValid = true;
+	};
+
+	void AppendEncodedFingerprintBytes(
+		void* context,
+		void* data,
+		int32_t size) noexcept
+	{
+		EncodedFingerprint* encoded =
+			static_cast<EncodedFingerprint*>(context);
+		if (encoded == nullptr ||
+			!encoded->m_bValid ||
+			data == nullptr ||
+			size <= 0 ||
+			encoded->m_bytes.Num() > MaxFingerprintEncodedImageBytes ||
+			static_cast<size_t>(size) >
+				MaxFingerprintEncodedImageBytes -
+				encoded->m_bytes.Num())
+		{
+			if (encoded != nullptr)
+			{
+				encoded->m_bValid = false;
+			}
+			return;
+		}
+
+		const size_t previousSize = encoded->m_bytes.Num();
+		encoded->m_bytes.Resize(
+			previousSize + static_cast<size_t>(size));
+		std::memcpy(
+			encoded->m_bytes.GetData() + previousSize,
+			data,
+			static_cast<size_t>(size));
+	}
+
+	bool TryMultiplySize(size_t lhs, size_t rhs, size_t& outResult)
+	{
+		if (lhs != 0 && rhs > std::numeric_limits<size_t>::max() / lhs)
+		{
+			return false;
+		}
+
+		outResult = lhs * rhs;
+		return true;
+	}
+
+	bool TryCalculateFingerprintTextureSize(
+		int32_t sourceWidth,
+		int32_t sourceHeight,
+		int32_t& outWidth,
+		int32_t& outHeight,
+		size_t& outBytes)
+	{
+		if (sourceWidth <= 0 || sourceHeight <= 0)
+		{
+			return false;
+		}
+
+		outWidth = sourceWidth;
+		outHeight = sourceHeight;
+		if (sourceWidth > MaxFingerprintTextureDimension ||
+			sourceHeight > MaxFingerprintTextureDimension)
+		{
+			if (sourceWidth >= sourceHeight)
+			{
+				outWidth = MaxFingerprintTextureDimension;
+				outHeight = static_cast<int32_t>((std::max)(
+					uint64_t{ 1 },
+					(static_cast<uint64_t>(sourceHeight) *
+						MaxFingerprintTextureDimension +
+						static_cast<uint64_t>(sourceWidth) / 2) /
+						static_cast<uint64_t>(sourceWidth)));
+			}
+			else
+			{
+				outHeight = MaxFingerprintTextureDimension;
+				outWidth = static_cast<int32_t>((std::max)(
+					uint64_t{ 1 },
+					(static_cast<uint64_t>(sourceWidth) *
+						MaxFingerprintTextureDimension +
+						static_cast<uint64_t>(sourceHeight) / 2) /
+						static_cast<uint64_t>(sourceHeight)));
+			}
+		}
+
+		size_t pixelCount = 0;
+		return outWidth > 0 && outHeight > 0 &&
+			outWidth <= MaxFingerprintTextureDimension &&
+			outHeight <= MaxFingerprintTextureDimension &&
+			TryMultiplySize(
+				static_cast<size_t>(outWidth),
+				static_cast<size_t>(outHeight),
+				pixelCount) &&
+			TryMultiplySize(pixelCount, sizeof(u8vec4), outBytes);
+	}
+
+	bool LoadAsciiWithMeshoptPlaceholders(
+		tinygltf::TinyGLTF& loader,
+		tinygltf::Model& model,
+		std::string& error,
+		std::string& warning,
+		const std::string& assetFilepath,
+		bool& outHandled)
+	{
+		outHandled = false;
+		std::ifstream input(assetFilepath, std::ios::binary);
+		if (!input.is_open())
+		{
+			return false;
+		}
+
+		const std::string source{
+			std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>()};
+		if (source.find("meshopt_compression") == std::string::npos)
+		{
+			return false;
+		}
+
+		nlohmann::json document = nlohmann::json::parse(
+			source,
+			nullptr,
+			false);
+		if (document.is_discarded())
+		{
+			error = "Cannot parse glTF JSON for meshopt fallback.";
+			return false;
+		}
+
+		if (!document.contains("buffers") ||
+			!document["buffers"].is_array())
+		{
+			return false;
+		}
+
+		TVector<size_t> placeholderBuffers;
+		auto& buffers = document["buffers"];
+		for (size_t i = 0; i < buffers.size(); ++i)
+		{
+			auto& buffer = buffers[i];
+			if (!buffer.is_object() || buffer.contains("uri") ||
+				!buffer.contains("byteLength") ||
+				!buffer["byteLength"].is_number_integer() ||
+				!buffer.contains("extensions") ||
+				!buffer["extensions"].is_object())
+			{
+				continue;
+			}
+
+			const auto& extensions = buffer["extensions"];
+			const nlohmann::json* meshoptExtension = nullptr;
+			if (extensions.contains("EXT_meshopt_compression"))
+			{
+				meshoptExtension = &extensions["EXT_meshopt_compression"];
+			}
+			else if (extensions.contains("KHR_meshopt_compression"))
+			{
+				meshoptExtension = &extensions["KHR_meshopt_compression"];
+			}
+
+			if (meshoptExtension == nullptr ||
+				!meshoptExtension->is_object() ||
+				!meshoptExtension->contains("fallback") ||
+				!(*meshoptExtension)["fallback"].is_boolean() ||
+				!(*meshoptExtension)["fallback"].get<bool>())
+			{
+				continue;
+			}
+
+			uint64_t byteLength = 0;
+			if (buffer["byteLength"].is_number_unsigned())
+			{
+				byteLength = buffer["byteLength"].get<uint64_t>();
+			}
+			else
+			{
+				const int64_t signedByteLength =
+					buffer["byteLength"].get<int64_t>();
+				if (signedByteLength > 0)
+				{
+					byteLength = static_cast<uint64_t>(signedByteLength);
+				}
+			}
+
+			if (byteLength == 0 ||
+				byteLength > MaxMeshoptPlaceholderBytes ||
+				byteLength > std::numeric_limits<unsigned int>::max())
+			{
+				error = "Invalid meshopt fallback buffer size.";
+				outHandled = true;
+				return false;
+			}
+
+			TVector<uint8_t> placeholder;
+			placeholder.Resize(static_cast<size_t>(byteLength));
+			buffer["uri"] =
+				"data:application/octet-stream;base64," +
+				tinygltf::base64_encode(
+					placeholder.GetData(),
+					static_cast<unsigned int>(placeholder.Num()));
+			placeholderBuffers.Add(i);
+		}
+
+		if (placeholderBuffers.IsEmpty())
+		{
+			return false;
+		}
+
+		outHandled = true;
+		const std::string patchedSource = document.dump();
+		if (patchedSource.size() > std::numeric_limits<unsigned int>::max())
+		{
+			error = "Patched glTF document is too large.";
+			return false;
+		}
+
+		const bool loaded = loader.LoadASCIIFromString(
+			&model,
+			&error,
+			&warning,
+			patchedSource.data(),
+			static_cast<unsigned int>(patchedSource.size()),
+			std::filesystem::path(assetFilepath).parent_path().string());
+		if (loaded)
+		{
+			for (size_t bufferIndex : placeholderBuffers)
+			{
+				if (bufferIndex < model.buffers.size())
+				{
+					model.buffers[bufferIndex].data.clear();
+				}
+			}
+		}
+
+		return loaded;
+	}
+
+	struct GltfAccessorView
+	{
+		const tinygltf::Accessor* m_accessor = nullptr;
+		const uint8_t* m_data = nullptr;
+		size_t m_stride = 0;
+		size_t m_componentSize = 0;
+		size_t m_componentCount = 0;
+		const uint8_t* m_sparseIndices = nullptr;
+		const uint8_t* m_sparseValues = nullptr;
+		size_t m_sparseCount = 0;
+		size_t m_sparseIndexStride = 0;
+		size_t m_sparseValueStride = 0;
+		int32_t m_sparseIndexComponentType = -1;
+	};
+
+	bool IsAccessorRangeValid(
+		size_t offset,
+		size_t stride,
+		size_t count,
+		size_t elementSize,
+		size_t bufferSize)
+	{
+		if (count == 0)
+		{
+			return offset <= bufferSize;
+		}
+
+		if (offset > bufferSize || elementSize > bufferSize - offset)
+		{
+			return false;
+		}
+
+		if (count <= 1)
+		{
+			return true;
+		}
+
+		return stride > 0 &&
+			count - 1 <= (bufferSize - offset - elementSize) / stride;
+	}
+
+	bool HasUnsupportedBufferViewCompression(
+		const tinygltf::BufferView& bufferView)
+	{
+		return bufferView.extensions.find("EXT_meshopt_compression") !=
+				bufferView.extensions.end() ||
+			bufferView.extensions.find("KHR_meshopt_compression") !=
+				bufferView.extensions.end();
+	}
+
+	bool TryGetBufferViewData(
+		const tinygltf::Model& model,
+		int32_t bufferViewIndex,
+		size_t byteOffset,
+		size_t stride,
+		size_t count,
+		size_t elementSize,
+		const uint8_t*& outData)
+	{
+		outData = nullptr;
+		if (bufferViewIndex < 0 ||
+			static_cast<size_t>(bufferViewIndex) >= model.bufferViews.size())
+		{
+			return false;
+		}
+
+		const tinygltf::BufferView& bufferView =
+			model.bufferViews[bufferViewIndex];
+		if (bufferView.buffer < 0 ||
+			static_cast<size_t>(bufferView.buffer) >= model.buffers.size() ||
+			HasUnsupportedBufferViewCompression(bufferView) ||
+			!IsAccessorRangeValid(
+				byteOffset,
+				stride,
+				count,
+				elementSize,
+				bufferView.byteLength))
+		{
+			return false;
+		}
+
+		const tinygltf::Buffer& buffer = model.buffers[bufferView.buffer];
+		if (bufferView.byteOffset > buffer.data.size() ||
+			bufferView.byteLength > buffer.data.size() - bufferView.byteOffset)
+		{
+			return false;
+		}
+
+		outData = buffer.data.data() + bufferView.byteOffset + byteOffset;
+		return true;
+	}
+
+	template<typename T>
+	T ReadUnaligned(const uint8_t* data)
+	{
+		T value{};
+		std::memcpy(&value, data, sizeof(T));
+		return value;
+	}
+
+	bool TryReadSparseIndex(
+		const GltfAccessorView& view,
+		size_t sparseElement,
+		uint32_t& outIndex)
+	{
+		const uint8_t* data = view.m_sparseIndices +
+			sparseElement * view.m_sparseIndexStride;
+		switch (view.m_sparseIndexComponentType)
+		{
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE:
+			outIndex = ReadUnaligned<uint8_t>(data);
+			return true;
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
+			outIndex = ReadUnaligned<uint16_t>(data);
+			return true;
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
+			outIndex = ReadUnaligned<uint32_t>(data);
+			return true;
+		default:
+			return false;
+		}
+	}
+
+	bool TryGetAccessorView(
+		const tinygltf::Model& model,
+		int32_t accessorIndex,
+		int32_t expectedType,
+		size_t requiredCount,
+		GltfAccessorView& outView)
+	{
+		outView = {};
+		if (accessorIndex < 0 ||
+			static_cast<size_t>(accessorIndex) >= model.accessors.size())
+		{
+			return false;
+		}
+
+		const tinygltf::Accessor& accessor = model.accessors[accessorIndex];
+		if (accessor.count == 0 ||
+			accessor.count < requiredCount ||
+			(expectedType >= 0 && accessor.type != expectedType) ||
+			(!accessor.sparse.isSparse && accessor.bufferView < 0) ||
+			(accessor.bufferView < 0 && accessor.byteOffset != 0))
+		{
+			return false;
+		}
+
+		const int32_t componentSize = tinygltf::GetComponentSizeInBytes(
+			static_cast<uint32_t>(accessor.componentType));
+		const int32_t componentCount = tinygltf::GetNumComponentsInType(
+			static_cast<uint32_t>(accessor.type));
+		if (componentSize <= 0 || componentCount <= 0)
+		{
+			return false;
+		}
+
+		const size_t elementSize =
+			static_cast<size_t>(componentSize) *
+			static_cast<size_t>(componentCount);
+		size_t stride = elementSize;
+		const uint8_t* data = nullptr;
+		if (accessor.bufferView >= 0)
+		{
+			if (static_cast<size_t>(accessor.bufferView) >=
+				model.bufferViews.size())
+			{
+				return false;
+			}
+
+			const tinygltf::BufferView& bufferView =
+				model.bufferViews[accessor.bufferView];
+			const int32_t accessorStride = accessor.ByteStride(bufferView);
+			if (accessorStride <= 0 ||
+				static_cast<size_t>(accessorStride) < elementSize)
+			{
+				return false;
+			}
+
+			stride = static_cast<size_t>(accessorStride);
+			if (!TryGetBufferViewData(
+					model,
+					accessor.bufferView,
+					accessor.byteOffset,
+					stride,
+					accessor.count,
+					elementSize,
+					data))
+			{
+				return false;
+			}
+		}
+
+		outView.m_accessor = &accessor;
+		outView.m_data = data;
+		outView.m_stride = stride;
+		outView.m_componentSize = static_cast<size_t>(componentSize);
+		outView.m_componentCount = static_cast<size_t>(componentCount);
+
+		if (!accessor.sparse.isSparse)
+		{
+			return true;
+		}
+
+		if (accessor.sparse.count <= 0 ||
+			static_cast<size_t>(accessor.sparse.count) > accessor.count)
+		{
+			return false;
+		}
+
+		const int32_t sparseIndexSize = tinygltf::GetComponentSizeInBytes(
+			static_cast<uint32_t>(accessor.sparse.indices.componentType));
+		if (sparseIndexSize <= 0 ||
+			(accessor.sparse.indices.componentType !=
+				TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE &&
+			 accessor.sparse.indices.componentType !=
+				TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT &&
+			 accessor.sparse.indices.componentType !=
+				TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT))
+		{
+			return false;
+		}
+
+		const size_t sparseCount =
+			static_cast<size_t>(accessor.sparse.count);
+		if (accessor.sparse.indices.bufferView < 0 ||
+			accessor.sparse.values.bufferView < 0 ||
+			static_cast<size_t>(accessor.sparse.indices.bufferView) >=
+				model.bufferViews.size() ||
+			static_cast<size_t>(accessor.sparse.values.bufferView) >=
+				model.bufferViews.size())
+		{
+			return false;
+		}
+
+		const tinygltf::BufferView& sparseIndicesView =
+			model.bufferViews[accessor.sparse.indices.bufferView];
+		const tinygltf::BufferView& sparseValuesView =
+			model.bufferViews[accessor.sparse.values.bufferView];
+		const size_t sparseIndexStride = sparseIndicesView.byteStride > 0 ?
+			static_cast<size_t>(sparseIndicesView.byteStride) :
+			static_cast<size_t>(sparseIndexSize);
+		const size_t sparseValueStride = sparseValuesView.byteStride > 0 ?
+			static_cast<size_t>(sparseValuesView.byteStride) : elementSize;
+		if (sparseIndexStride < static_cast<size_t>(sparseIndexSize) ||
+			sparseValueStride < elementSize ||
+			!TryGetBufferViewData(
+				model,
+				accessor.sparse.indices.bufferView,
+				accessor.sparse.indices.byteOffset,
+				sparseIndexStride,
+				sparseCount,
+				static_cast<size_t>(sparseIndexSize),
+				outView.m_sparseIndices) ||
+			!TryGetBufferViewData(
+				model,
+				accessor.sparse.values.bufferView,
+				accessor.sparse.values.byteOffset,
+				sparseValueStride,
+				sparseCount,
+				elementSize,
+				outView.m_sparseValues))
+		{
+			return false;
+		}
+
+		outView.m_sparseCount = sparseCount;
+		outView.m_sparseIndexStride = sparseIndexStride;
+		outView.m_sparseValueStride = sparseValueStride;
+		outView.m_sparseIndexComponentType =
+			accessor.sparse.indices.componentType;
+
+		uint32_t previousIndex = 0;
+		for (size_t i = 0; i < sparseCount; ++i)
+		{
+			uint32_t sparseIndex = 0;
+			if (!TryReadSparseIndex(outView, i, sparseIndex) ||
+				sparseIndex >= accessor.count ||
+				(i > 0 && sparseIndex <= previousIndex))
+			{
+				return false;
+			}
+			previousIndex = sparseIndex;
+		}
+
+		return true;
+	}
+
+	const uint8_t* GetAccessorElementData(
+		const GltfAccessorView& view,
+		size_t elementIndex)
+	{
+		size_t left = 0;
+		size_t right = view.m_sparseCount;
+		while (left < right)
+		{
+			const size_t middle = left + (right - left) / 2;
+			uint32_t sparseIndex = 0;
+			if (!TryReadSparseIndex(view, middle, sparseIndex))
+			{
+				return nullptr;
+			}
+
+			if (sparseIndex < elementIndex)
+			{
+				left = middle + 1;
+			}
+			else
+			{
+				right = middle;
+			}
+		}
+
+		if (left < view.m_sparseCount)
+		{
+			uint32_t sparseIndex = 0;
+			if (TryReadSparseIndex(view, left, sparseIndex) &&
+				sparseIndex == elementIndex)
+			{
+				return view.m_sparseValues + left * view.m_sparseValueStride;
+			}
+		}
+
+		return view.m_data != nullptr ?
+			view.m_data + elementIndex * view.m_stride : nullptr;
+	}
+
+	float ReadAccessorFloat(
+		const GltfAccessorView& view,
+		size_t elementIndex,
+		size_t componentIndex)
+	{
+		const uint8_t* elementData = GetAccessorElementData(view, elementIndex);
+		if (elementData == nullptr)
+		{
+			return 0.0f;
+		}
+		const uint8_t* data =
+			elementData + componentIndex * view.m_componentSize;
+		const bool bNormalized = view.m_accessor->normalized;
+
+		switch (view.m_accessor->componentType)
+		{
+		case TINYGLTF_COMPONENT_TYPE_BYTE:
+		{
+			const int8_t value = ReadUnaligned<int8_t>(data);
+			return bNormalized ?
+				(std::max)(static_cast<float>(value) / 127.0f, -1.0f) :
+				static_cast<float>(value);
+		}
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE:
+		{
+			const uint8_t value = ReadUnaligned<uint8_t>(data);
+			return bNormalized ?
+				static_cast<float>(value) / 255.0f :
+				static_cast<float>(value);
+		}
+		case TINYGLTF_COMPONENT_TYPE_SHORT:
+		{
+			const int16_t value = ReadUnaligned<int16_t>(data);
+			return bNormalized ?
+				(std::max)(static_cast<float>(value) / 32767.0f, -1.0f) :
+				static_cast<float>(value);
+		}
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
+		{
+			const uint16_t value = ReadUnaligned<uint16_t>(data);
+			return bNormalized ?
+				static_cast<float>(value) / 65535.0f :
+				static_cast<float>(value);
+		}
+		case TINYGLTF_COMPONENT_TYPE_INT:
+		{
+			const int32_t value = ReadUnaligned<int32_t>(data);
+			return bNormalized ?
+				static_cast<float>((std::max)(
+					static_cast<double>(value) / 2147483647.0,
+					-1.0)) :
+				static_cast<float>(value);
+		}
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
+		{
+			const uint32_t value = ReadUnaligned<uint32_t>(data);
+			return bNormalized ?
+				static_cast<float>(
+					static_cast<double>(value) / 4294967295.0) :
+				static_cast<float>(value);
+		}
+		case TINYGLTF_COMPONENT_TYPE_FLOAT:
+			return ReadUnaligned<float>(data);
+		case TINYGLTF_COMPONENT_TYPE_DOUBLE:
+			return static_cast<float>(ReadUnaligned<double>(data));
+		default:
+			return 0.0f;
+		}
+	}
+
+	bool TryReadAccessorIndex(
+		const GltfAccessorView& view,
+		size_t elementIndex,
+		uint32_t& outIndex)
+	{
+		const uint8_t* data = GetAccessorElementData(view, elementIndex);
+		if (data == nullptr)
+		{
+			outIndex = 0;
+			return true;
+		}
+		switch (view.m_accessor->componentType)
+		{
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE:
+			outIndex = ReadUnaligned<uint8_t>(data);
+			return true;
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
+			outIndex = ReadUnaligned<uint16_t>(data);
+			return true;
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
+			outIndex = ReadUnaligned<uint32_t>(data);
+			return true;
+		default:
+			return false;
+		}
+	}
+
+#if defined(SAILOR_HAS_DRACO)
+	bool IsDracoAttributeLayoutValid(
+		const draco::PointAttribute& attribute)
+	{
+		const int32_t dataTypeLength =
+			draco::DataTypeLength(attribute.data_type());
+		const draco::DataBuffer* buffer = attribute.buffer();
+		const int64_t byteOffset = attribute.byte_offset();
+		const int64_t byteStride = attribute.byte_stride();
+		if (dataTypeLength <= 0 || buffer == nullptr ||
+			attribute.num_components() == 0 || attribute.size() == 0 ||
+			byteOffset < 0 || byteStride < 0)
+		{
+			return false;
+		}
+
+		const uint64_t elementSize =
+			static_cast<uint64_t>(dataTypeLength) *
+			static_cast<uint64_t>(attribute.num_components());
+		const uint64_t offset = static_cast<uint64_t>(byteOffset);
+		const uint64_t stride = static_cast<uint64_t>(byteStride);
+		const uint64_t lastIndex =
+			static_cast<uint64_t>(attribute.size() - 1);
+		if (stride < elementSize ||
+			lastIndex > (std::numeric_limits<uint64_t>::max() - offset) /
+				stride)
+		{
+			return false;
+		}
+
+		const uint64_t lastElementOffset = offset + lastIndex * stride;
+		if (elementSize >
+				std::numeric_limits<uint64_t>::max() - lastElementOffset ||
+			lastElementOffset + elementSize >
+				static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) ||
+			lastElementOffset + elementSize >
+				static_cast<uint64_t>(buffer->data_size()))
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	template<typename T>
+	bool DecodeDracoIndices(
+		const draco::Mesh& mesh,
+		size_t pointCount,
+		TVector<uint8_t>& outData)
+	{
+		const size_t indexCount =
+			static_cast<size_t>(mesh.num_faces()) * 3;
+		outData.Resize(indexCount * sizeof(T));
+		size_t outputIndex = 0;
+		for (draco::FaceIndex faceIndex(0);
+			faceIndex < mesh.num_faces();
+			++faceIndex)
+		{
+			const draco::Mesh::Face& face = mesh.face(faceIndex);
+			for (size_t corner = 0; corner < 3; ++corner)
+			{
+				const uint64_t index =
+					static_cast<uint64_t>(face[corner].value());
+				if (index >= pointCount ||
+					index > std::numeric_limits<T>::max())
+				{
+					return false;
+				}
+
+				const T value = static_cast<T>(index);
+				std::memcpy(
+					outData.GetData() + outputIndex * sizeof(T),
+					&value,
+					sizeof(value));
+				++outputIndex;
+			}
+		}
+
+		return true;
+	}
+
+	template<typename T>
+	bool DecodeDracoAttribute(
+		const draco::Mesh& mesh,
+		const draco::PointAttribute& attribute,
+		size_t componentCount,
+		TVector<uint8_t>& outData)
+	{
+		const size_t pointCount =
+			static_cast<size_t>(mesh.num_points());
+		if (!attribute.is_mapping_identity() &&
+			attribute.indices_map_size() < pointCount)
+		{
+			return false;
+		}
+		if (!IsDracoAttributeLayoutValid(attribute))
+		{
+			return false;
+		}
+
+		const size_t elementSize = componentCount * sizeof(T);
+		outData.Resize(pointCount * elementSize);
+		std::array<T, 4> values{};
+		for (size_t point = 0; point < pointCount; ++point)
+		{
+			const draco::AttributeValueIndex valueIndex =
+				attribute.mapped_index(draco::PointIndex(
+					static_cast<draco::PointIndex::ValueType>(point)));
+			const uint64_t rawValueIndex =
+				static_cast<uint64_t>(valueIndex.value());
+			if (rawValueIndex >= attribute.size() ||
+				!attribute.ConvertValue<T>(
+					valueIndex,
+					static_cast<int8_t>(componentCount),
+					values.data()))
+			{
+				return false;
+			}
+
+			std::memcpy(
+				outData.GetData() + point * elementSize,
+				values.data(),
+				elementSize);
+		}
+
+		return true;
+	}
+
+	bool DecodeDracoAttribute(
+		int32_t componentType,
+		const draco::Mesh& mesh,
+		const draco::PointAttribute& attribute,
+		size_t componentCount,
+		TVector<uint8_t>& outData)
+	{
+		switch (componentType)
+		{
+		case TINYGLTF_COMPONENT_TYPE_BYTE:
+			return DecodeDracoAttribute<int8_t>(
+				mesh, attribute, componentCount, outData);
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE:
+			return DecodeDracoAttribute<uint8_t>(
+				mesh, attribute, componentCount, outData);
+		case TINYGLTF_COMPONENT_TYPE_SHORT:
+			return DecodeDracoAttribute<int16_t>(
+				mesh, attribute, componentCount, outData);
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
+			return DecodeDracoAttribute<uint16_t>(
+				mesh, attribute, componentCount, outData);
+		case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
+			return DecodeDracoAttribute<uint32_t>(
+				mesh, attribute, componentCount, outData);
+		case TINYGLTF_COMPONENT_TYPE_FLOAT:
+			return DecodeDracoAttribute<float>(
+				mesh, attribute, componentCount, outData);
+		default:
+			return false;
+		}
+	}
+#endif
+
+	bool DecodeDracoPrimitives(
+		tinygltf::Model& model,
+		std::string& outError)
+	{
+		outError.clear();
+#if defined(SAILOR_HAS_DRACO)
+		TMap<size_t, TUniquePtr<draco::Mesh>> decodedMeshes;
+#endif
+		for (tinygltf::Mesh& gltfMesh : model.meshes)
+		{
+			for (tinygltf::Primitive& primitive : gltfMesh.primitives)
+			{
+				auto extensionIt = primitive.extensions.find(
+					"KHR_draco_mesh_compression");
+				if (extensionIt == primitive.extensions.end())
+				{
+					continue;
+				}
+
+#if defined(SAILOR_HAS_DRACO)
+				const tinygltf::Value& extension = extensionIt->second;
+				if (primitive.mode != TINYGLTF_MODE_TRIANGLES ||
+					primitive.indices < 0 ||
+					!extension.IsObject() ||
+					!extension.Has("bufferView") ||
+					!extension.Get("bufferView").IsInt() ||
+					extension.Get("bufferView").Get<int>() < 0 ||
+					!extension.Has("attributes") ||
+					!extension.Get("attributes").IsObject())
+				{
+					outError = "Invalid Draco primitive metadata.";
+					return false;
+				}
+
+				const size_t compressedViewIndex = static_cast<size_t>(
+					extension.Get("bufferView").Get<int>());
+				if (compressedViewIndex >= model.bufferViews.size())
+				{
+					outError = "Draco buffer view is out of range.";
+					return false;
+				}
+
+				const tinygltf::BufferView& compressedView =
+					model.bufferViews[compressedViewIndex];
+				if (compressedView.buffer < 0 ||
+					static_cast<size_t>(compressedView.buffer) >=
+						model.buffers.size())
+				{
+					outError = "Draco source buffer is out of range.";
+					return false;
+				}
+
+				const tinygltf::Buffer& compressedBuffer =
+					model.buffers[compressedView.buffer];
+				if (compressedView.byteLength == 0 ||
+					compressedView.byteLength > static_cast<size_t>(
+						std::numeric_limits<int64_t>::max()) ||
+					compressedView.byteOffset > compressedBuffer.data.size() ||
+					compressedView.byteLength >
+						compressedBuffer.data.size() - compressedView.byteOffset)
+				{
+					outError = "Draco source data is out of range.";
+					return false;
+				}
+
+				TUniquePtr<draco::Mesh>* decodedMeshPtr = nullptr;
+				if (!decodedMeshes.Find(
+					compressedViewIndex,
+					decodedMeshPtr))
+				{
+					draco::DecoderBuffer decoderBuffer;
+					decoderBuffer.Init(
+						reinterpret_cast<const char*>(
+							compressedBuffer.data.data() +
+							compressedView.byteOffset),
+						compressedView.byteLength);
+					draco::Decoder decoder;
+					auto decodedMesh =
+						TUniquePtr<draco::Mesh>::Make();
+					const draco::Status decodeStatus =
+						decoder.DecodeBufferToGeometry(
+							&decoderBuffer,
+							decodedMesh.GetRawPtr());
+					if (!decodeStatus.ok())
+					{
+						outError = "Cannot decode Draco mesh: " +
+							decodeStatus.error_msg_string();
+						return false;
+					}
+
+					if (!decodedMesh)
+					{
+						outError = "Cannot decode Draco mesh.";
+						return false;
+					}
+
+					decodedMeshes[compressedViewIndex] =
+						std::move(decodedMesh);
+					if (!decodedMeshes.Find(
+						compressedViewIndex,
+						decodedMeshPtr))
+					{
+						outError = "Cannot cache decoded Draco mesh.";
+						return false;
+					}
+				}
+
+				if (decodedMeshPtr == nullptr || !(*decodedMeshPtr))
+				{
+					outError = "Decoded Draco mesh is unavailable.";
+					return false;
+				}
+				const draco::Mesh& decodedMesh =
+					*decodedMeshPtr->GetRawPtr();
+				const size_t pointCount =
+					static_cast<size_t>(decodedMesh.num_points());
+				const size_t faceCount =
+					static_cast<size_t>(decodedMesh.num_faces());
+				if (pointCount == 0 || faceCount == 0 ||
+					pointCount > std::numeric_limits<uint32_t>::max() ||
+					faceCount > std::numeric_limits<size_t>::max() / 3)
+				{
+					outError = "Invalid decoded Draco mesh size.";
+					return false;
+				}
+
+				if (primitive.indices >= 0)
+				{
+					if (static_cast<size_t>(primitive.indices) >=
+						model.accessors.size())
+					{
+						outError = "Draco index accessor is out of range.";
+						return false;
+					}
+
+					tinygltf::Accessor& accessor =
+						model.accessors[primitive.indices];
+					if (accessor.type != TINYGLTF_TYPE_SCALAR ||
+						accessor.normalized || accessor.sparse.isSparse ||
+						accessor.count != faceCount * 3)
+					{
+						outError = "Invalid Draco index accessor.";
+						return false;
+					}
+
+					TVector<uint8_t> decodedIndices;
+					bool bIndicesDecoded = false;
+					switch (accessor.componentType)
+					{
+					case TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE:
+						bIndicesDecoded = DecodeDracoIndices<uint8_t>(
+							decodedMesh, pointCount, decodedIndices);
+						break;
+					case TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT:
+						bIndicesDecoded = DecodeDracoIndices<uint16_t>(
+							decodedMesh, pointCount, decodedIndices);
+						break;
+					case TINYGLTF_COMPONENT_TYPE_UNSIGNED_INT:
+						bIndicesDecoded = DecodeDracoIndices<uint32_t>(
+							decodedMesh, pointCount, decodedIndices);
+						break;
+					default:
+						break;
+					}
+
+					if (!bIndicesDecoded || decodedIndices.IsEmpty() ||
+						decodedIndices.Num() >
+							std::numeric_limits<int>::max())
+					{
+						outError = "Cannot decode Draco indices.";
+						return false;
+					}
+
+					tinygltf::Buffer decodedBuffer;
+					decodedBuffer.data.assign(
+						decodedIndices.GetData(),
+						decodedIndices.GetData() + decodedIndices.Num());
+					model.buffers.emplace_back(std::move(decodedBuffer));
+					tinygltf::BufferView decodedView;
+					decodedView.buffer =
+						static_cast<int>(model.buffers.size() - 1);
+					decodedView.byteLength =
+						model.buffers.back().data.size();
+					decodedView.target = TINYGLTF_TARGET_ELEMENT_ARRAY_BUFFER;
+					model.bufferViews.emplace_back(std::move(decodedView));
+					accessor.bufferView =
+						static_cast<int>(model.bufferViews.size() - 1);
+					accessor.byteOffset = 0;
+					accessor.count = faceCount * 3;
+				}
+
+				const tinygltf::Value::Object attributes =
+					extension.Get("attributes").Get<tinygltf::Value::Object>();
+				for (const auto& [semantic, attributeValue] : attributes)
+				{
+					if (!attributeValue.IsInt() ||
+						attributeValue.Get<int>() < 0)
+					{
+						outError = "Invalid Draco attribute identifier.";
+						return false;
+					}
+
+					const auto primitiveAttribute =
+						primitive.attributes.find(semantic);
+					if (primitiveAttribute == primitive.attributes.end() ||
+						primitiveAttribute->second < 0 ||
+						static_cast<size_t>(primitiveAttribute->second) >=
+							model.accessors.size())
+					{
+						outError = "Draco attribute accessor is out of range.";
+						return false;
+					}
+
+					tinygltf::Accessor& accessor =
+						model.accessors[primitiveAttribute->second];
+					const int32_t componentSize =
+						tinygltf::GetComponentSizeInBytes(
+							static_cast<uint32_t>(accessor.componentType));
+					const int32_t componentCount =
+						tinygltf::GetNumComponentsInType(
+							static_cast<uint32_t>(accessor.type));
+					if (componentSize <= 0 || componentCount <= 0 ||
+						componentCount > 4 ||
+						accessor.sparse.isSparse ||
+						accessor.count != pointCount ||
+						pointCount > std::numeric_limits<size_t>::max() /
+							(static_cast<size_t>(componentSize) *
+							 static_cast<size_t>(componentCount)))
+					{
+						outError = "Invalid Draco attribute accessor.";
+						return false;
+					}
+
+					const draco::PointAttribute* attribute =
+						decodedMesh.GetAttributeByUniqueId(static_cast<uint32_t>(
+							attributeValue.Get<int>()));
+					if (attribute == nullptr ||
+						attribute->num_components() != componentCount)
+					{
+						outError = "Draco attribute is missing or incompatible.";
+						return false;
+					}
+
+					TVector<uint8_t> decodedAttribute;
+					if (!DecodeDracoAttribute(
+							accessor.componentType,
+							decodedMesh,
+							*attribute,
+							static_cast<size_t>(componentCount),
+							decodedAttribute) ||
+						decodedAttribute.IsEmpty() ||
+						decodedAttribute.Num() >
+							std::numeric_limits<int>::max())
+					{
+						outError = "Cannot decode Draco attribute.";
+						return false;
+					}
+
+					tinygltf::Buffer decodedBuffer;
+					decodedBuffer.data.assign(
+						decodedAttribute.GetData(),
+						decodedAttribute.GetData() + decodedAttribute.Num());
+					model.buffers.emplace_back(std::move(decodedBuffer));
+					tinygltf::BufferView decodedView;
+					decodedView.buffer =
+						static_cast<int>(model.buffers.size() - 1);
+					decodedView.byteLength =
+						model.buffers.back().data.size();
+					decodedView.byteStride = 0;
+					decodedView.target = TINYGLTF_TARGET_ARRAY_BUFFER;
+					model.bufferViews.emplace_back(std::move(decodedView));
+					accessor.bufferView =
+						static_cast<int>(model.bufferViews.size() - 1);
+					accessor.byteOffset = 0;
+					accessor.count = pointCount;
+				}
+
+				primitive.extensions.erase(extensionIt);
+#else
+				outError = "Draco decoder is unavailable.";
+				return false;
+#endif
+			}
+		}
+
+		return true;
+	}
+
+	bool HasGltfExtension(
+		const tinygltf::Model& model,
+		const char* extension)
+	{
+		return std::find(
+			model.extensionsUsed.begin(),
+			model.extensionsUsed.end(),
+			extension) != model.extensionsUsed.end() ||
+			std::find(
+				model.extensionsRequired.begin(),
+				model.extensionsRequired.end(),
+				extension) != model.extensionsRequired.end();
+	}
+
+	bool HasBufferViewFallback(
+		const tinygltf::Model& model,
+		const tinygltf::BufferView& bufferView)
+	{
+		if (bufferView.buffer < 0 ||
+			static_cast<size_t>(bufferView.buffer) >= model.buffers.size())
+		{
+			return false;
+		}
+
+		const tinygltf::Buffer& buffer = model.buffers[bufferView.buffer];
+		return bufferView.byteOffset <= buffer.data.size() &&
+			bufferView.byteLength <= buffer.data.size() - bufferView.byteOffset;
+	}
+
+	bool TryGetMeshoptSize(
+		const tinygltf::Value& extension,
+		const char* property,
+		size_t& outValue,
+		bool bRequired)
+	{
+		outValue = 0;
+		if (!extension.IsObject() || !extension.Has(property))
+		{
+			return !bRequired;
+		}
+
+		const tinygltf::Value& value = extension.Get(property);
+		if (!value.IsInt() || value.Get<int>() < 0)
+		{
+			return false;
+		}
+
+		outValue = static_cast<size_t>(value.Get<int>());
+		return true;
+	}
+
+	template<typename T>
+	int32_t SignExtendMeshoptColor(T value)
+	{
+		constexpr uint32_t numBits = sizeof(T) * 8;
+		constexpr uint32_t signBit = 1u << (numBits - 1);
+		constexpr uint32_t range = 1u << numBits;
+		const uint32_t raw = static_cast<uint32_t>(value);
+		return (raw & signBit) != 0 ?
+			static_cast<int32_t>(raw - range) :
+			static_cast<int32_t>(raw);
+	}
+
+	template<typename T>
+	bool DecodeMeshoptColorFilter(T* data, size_t count)
+	{
+		const double maxValue =
+			static_cast<double>(std::numeric_limits<T>::max());
+		for (size_t i = 0; i < count; ++i)
+		{
+			const size_t offset = i * 4;
+			int32_t alphaScale = static_cast<int32_t>(data[offset + 3]);
+			alphaScale |= alphaScale >> 1;
+			alphaScale |= alphaScale >> 2;
+			alphaScale |= alphaScale >> 4;
+			alphaScale |= alphaScale >> 8;
+			if (alphaScale <= 0)
+			{
+				return false;
+			}
+
+			const int32_t y = static_cast<int32_t>(data[offset]);
+			const int32_t co =
+				SignExtendMeshoptColor(data[offset + 1]);
+			const int32_t cg =
+				SignExtendMeshoptColor(data[offset + 2]);
+			const int32_t red = y + co - cg;
+			const int32_t green = y + cg;
+			const int32_t blue = y - co - cg;
+			const int32_t encodedAlpha =
+				static_cast<int32_t>(data[offset + 3]);
+			const int32_t alpha =
+				((encodedAlpha << 1) & alphaScale) |
+				(encodedAlpha & 1);
+			const double scale = maxValue / alphaScale;
+			auto decodeComponent = [&](int32_t component)
+				{
+					const double decoded =
+						static_cast<double>(component) * scale + 0.5;
+					return static_cast<T>(std::clamp(
+						decoded,
+						0.0,
+						maxValue));
+				};
+
+			data[offset] = decodeComponent(red);
+			data[offset + 1] = decodeComponent(green);
+			data[offset + 2] = decodeComponent(blue);
+			data[offset + 3] = decodeComponent(alpha);
+		}
+
+		return true;
+	}
+
+	bool DecodeMeshoptBufferViews(
+		tinygltf::Model& model,
+		std::string& outError)
+	{
+		outError.clear();
+		for (tinygltf::BufferView& bufferView : model.bufferViews)
+		{
+			auto extensionIt =
+				bufferView.extensions.find("EXT_meshopt_compression");
+			if (extensionIt == bufferView.extensions.end())
+			{
+				extensionIt =
+					bufferView.extensions.find("KHR_meshopt_compression");
+			}
+
+			if (extensionIt == bufferView.extensions.end())
+			{
+				continue;
+			}
+
+			const std::string extensionName = extensionIt->first;
+			const tinygltf::Value extension = extensionIt->second;
+			const bool bHasFallback =
+				HasBufferViewFallback(model, bufferView);
+			auto useFallbackOrFail = [&](const char* reason)
+				{
+					if (bHasFallback)
+					{
+						bufferView.extensions.erase(extensionName);
+						return true;
+					}
+
+					outError = reason;
+					return false;
+				};
+
+			size_t sourceBufferIndex = 0;
+			size_t sourceOffset = 0;
+			size_t sourceLength = 0;
+			size_t stride = 0;
+			size_t count = 0;
+			if (!TryGetMeshoptSize(
+					extension,
+					"buffer",
+					sourceBufferIndex,
+					true) ||
+				!TryGetMeshoptSize(
+					extension,
+					"byteOffset",
+					sourceOffset,
+					false) ||
+				!TryGetMeshoptSize(
+					extension,
+					"byteLength",
+					sourceLength,
+					true) ||
+				!TryGetMeshoptSize(
+					extension,
+					"byteStride",
+					stride,
+					true) ||
+				!TryGetMeshoptSize(
+					extension,
+					"count",
+					count,
+					true) ||
+				sourceLength == 0 || stride == 0 || count == 0 ||
+				count > std::numeric_limits<size_t>::max() / stride ||
+				count * stride != bufferView.byteLength ||
+				sourceBufferIndex >= model.buffers.size())
+			{
+				if (useFallbackOrFail("Invalid meshopt buffer-view metadata."))
+				{
+					continue;
+				}
+				return false;
+			}
+
+			const tinygltf::Buffer& sourceBuffer =
+				model.buffers[sourceBufferIndex];
+			if (sourceOffset > sourceBuffer.data.size() ||
+				sourceLength > sourceBuffer.data.size() - sourceOffset)
+			{
+				if (useFallbackOrFail("Meshopt source data is out of range."))
+				{
+					continue;
+				}
+				return false;
+			}
+
+			if (!extension.Has("mode") ||
+				!extension.Get("mode").IsString())
+			{
+				if (useFallbackOrFail("Meshopt compression mode is missing."))
+				{
+					continue;
+				}
+				return false;
+			}
+
+			const std::string& mode =
+				extension.Get("mode").Get<std::string>();
+			std::string filter = "NONE";
+			if (extension.Has("filter"))
+			{
+				if (!extension.Get("filter").IsString())
+				{
+					if (useFallbackOrFail("Invalid meshopt compression filter."))
+					{
+						continue;
+					}
+					return false;
+				}
+				filter = extension.Get("filter").Get<std::string>();
+			}
+
+			const bool bAttributesLayoutValid =
+				mode == "ATTRIBUTES" &&
+				stride >= 4 && stride <= 256 && stride % 4 == 0;
+			const bool bTrianglesLayoutValid =
+				mode == "TRIANGLES" && count % 3 == 0 &&
+				(stride == 2 || stride == 4);
+			const bool bIndicesLayoutValid =
+				mode == "INDICES" && (stride == 2 || stride == 4);
+			const bool bFilterLayoutValid =
+				(filter == "NONE" &&
+				 (bAttributesLayoutValid ||
+				  bTrianglesLayoutValid ||
+				  bIndicesLayoutValid)) ||
+				(mode == "ATTRIBUTES" &&
+				 ((filter == "OCTAHEDRAL" && (stride == 4 || stride == 8)) ||
+				  (filter == "QUATERNION" && stride == 8) ||
+				  (filter == "EXPONENTIAL" && stride % 4 == 0) ||
+				  (filter == "COLOR" && (stride == 4 || stride == 8))));
+			if (!bFilterLayoutValid)
+			{
+				if (useFallbackOrFail("Invalid meshopt mode, filter, or layout."))
+				{
+					continue;
+				}
+				return false;
+			}
+
+#if defined(SAILOR_HAS_MESHOPT)
+			TVector<uint8_t> decoded;
+			decoded.Resize(bufferView.byteLength);
+			const uint8_t* source =
+				sourceBuffer.data.data() + sourceOffset;
+			int decodeResult = -1;
+			if (mode == "ATTRIBUTES")
+			{
+				decodeResult = meshopt_decodeVertexBuffer(
+					decoded.GetData(),
+					count,
+					stride,
+					source,
+					sourceLength);
+			}
+			else if (mode == "TRIANGLES")
+			{
+				decodeResult = meshopt_decodeIndexBuffer(
+					decoded.GetData(),
+					count,
+					stride,
+					source,
+					sourceLength);
+			}
+			else if (mode == "INDICES")
+			{
+				decodeResult = meshopt_decodeIndexSequence(
+					decoded.GetData(),
+					count,
+					stride,
+					source,
+					sourceLength);
+			}
+
+			if (decodeResult != 0)
+			{
+				if (useFallbackOrFail("Cannot decode meshopt buffer view."))
+				{
+					continue;
+				}
+				return false;
+			}
+
+			if (filter == "OCTAHEDRAL")
+			{
+				meshopt_decodeFilterOct(decoded.GetData(), count, stride);
+			}
+			else if (filter == "QUATERNION")
+			{
+				meshopt_decodeFilterQuat(decoded.GetData(), count, stride);
+			}
+			else if (filter == "EXPONENTIAL")
+			{
+				meshopt_decodeFilterExp(decoded.GetData(), count, stride);
+			}
+			else if (filter == "COLOR")
+			{
+				const bool bColorDecoded = stride == 4 ?
+					DecodeMeshoptColorFilter(
+						reinterpret_cast<uint8_t*>(decoded.GetData()),
+						count) :
+					DecodeMeshoptColorFilter(
+						reinterpret_cast<uint16_t*>(decoded.GetData()),
+						count);
+				if (!bColorDecoded)
+				{
+					if (useFallbackOrFail("Cannot decode meshopt color filter."))
+					{
+						continue;
+					}
+					return false;
+				}
+			}
+			else if (filter != "NONE")
+			{
+				if (useFallbackOrFail("Unsupported meshopt compression filter."))
+				{
+					continue;
+				}
+				return false;
+			}
+
+			if (bufferView.buffer < 0 ||
+				static_cast<size_t>(bufferView.buffer) >= model.buffers.size() ||
+				bufferView.byteOffset >
+					std::numeric_limits<size_t>::max() - bufferView.byteLength)
+			{
+				if (useFallbackOrFail("Invalid meshopt destination buffer."))
+				{
+					continue;
+				}
+				return false;
+			}
+
+			tinygltf::Buffer& destinationBuffer =
+				model.buffers[bufferView.buffer];
+			const size_t destinationEnd =
+				bufferView.byteOffset + bufferView.byteLength;
+			if (destinationBuffer.data.size() < destinationEnd)
+			{
+				destinationBuffer.data.resize(destinationEnd);
+			}
+			std::memcpy(
+				destinationBuffer.data.data() + bufferView.byteOffset,
+				decoded.GetData(),
+				decoded.Num());
+			bufferView.extensions.erase(extensionName);
+#else
+			if (useFallbackOrFail("Meshopt decoder is unavailable."))
+			{
+				continue;
+			}
+			return false;
+#endif
+		}
+
+		return true;
+	}
+
+	bool IsFloatAccessor(const tinygltf::Accessor& accessor)
+	{
+		return accessor.componentType == TINYGLTF_COMPONENT_TYPE_FLOAT &&
+			!accessor.normalized;
+	}
+
+	bool IsPositionAccessorSupported(
+		const tinygltf::Accessor& accessor,
+		bool bHasMeshQuantization)
+	{
+		if (IsFloatAccessor(accessor))
+		{
+			return true;
+		}
+
+		return bHasMeshQuantization &&
+			(accessor.componentType == TINYGLTF_COMPONENT_TYPE_BYTE ||
+			 accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE ||
+			 accessor.componentType == TINYGLTF_COMPONENT_TYPE_SHORT ||
+			 accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT);
+	}
+
+	bool IsDirectionAccessorSupported(
+		const tinygltf::Accessor& accessor,
+		bool bHasMeshQuantization)
+	{
+		return IsFloatAccessor(accessor) ||
+			(bHasMeshQuantization && accessor.normalized &&
+			 (accessor.componentType == TINYGLTF_COMPONENT_TYPE_BYTE ||
+			  accessor.componentType == TINYGLTF_COMPONENT_TYPE_SHORT));
+	}
+
+	bool IsTexcoordAccessorSupported(
+		const tinygltf::Accessor& accessor,
+		bool bHasMeshQuantization)
+	{
+		if (IsFloatAccessor(accessor))
+		{
+			return true;
+		}
+
+		if (accessor.normalized &&
+			(accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE ||
+			 accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT))
+		{
+			return true;
+		}
+
+		return bHasMeshQuantization &&
+			(accessor.componentType == TINYGLTF_COMPONENT_TYPE_BYTE ||
+			 accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE ||
+			 accessor.componentType == TINYGLTF_COMPONENT_TYPE_SHORT ||
+			 accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT);
+	}
+
+	bool IsColorAccessorSupported(const tinygltf::Accessor& accessor)
+	{
+		return IsFloatAccessor(accessor) ||
+			(accessor.normalized &&
+			 (accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE ||
+			  accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT));
+	}
+
+	bool IsJointsAccessorSupported(const tinygltf::Accessor& accessor)
+	{
+		return !accessor.normalized &&
+			(accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE ||
+			 accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT);
+	}
+
+	bool IsWeightsAccessorSupported(const tinygltf::Accessor& accessor)
+	{
+		return IsFloatAccessor(accessor) ||
+			(accessor.normalized &&
+			 (accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE ||
+			  accessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT));
+	}
+
+	bool TryNormalizeDirection(
+		const glm::vec3& value,
+		glm::vec3& outDirection)
+	{
+		const glm::vec3 source = value;
+		outDirection = glm::vec3(0.0f);
+		if (!Math::AllFinite(source))
+		{
+			return false;
+		}
+
+		const float maxComponent = (std::max)(
+			std::abs(source.x),
+			(std::max)(std::abs(source.y), std::abs(source.z)));
+		if (maxComponent <= 1e-4f)
+		{
+			return false;
+		}
+
+		const glm::vec3 scaled = source / maxComponent;
+		const float lengthSquared = glm::dot(scaled, scaled);
+		if (!std::isfinite(lengthSquared) || lengthSquared <= 0.0f)
+		{
+			return false;
+		}
+
+		outDirection = scaled / std::sqrt(lengthSquared);
+		return Math::AllFinite(outDirection);
+	}
+
+	void SanitizeVertexFrame(
 		Sailor::RHI::VertexP3N3T3B3UV2C4I4W4& vertex)
 	{
-		const glm::vec3 normal = IsUsableDirection(vertex.m_normal) ?
-			glm::normalize(vertex.m_normal) :
-			glm::vec3(0.0f, 1.0f, 0.0f);
+		glm::vec3 normal;
+		if (!TryNormalizeDirection(vertex.m_normal, normal))
+		{
+			normal = glm::vec3(0.0f, 1.0f, 0.0f);
+		}
 
-		glm::vec3 tangent =
-			vertex.m_tangent - normal * glm::dot(vertex.m_tangent, normal);
-		if (!IsUsableDirection(tangent))
+		glm::vec3 tangentInput;
+		glm::vec3 tangent(0.0f);
+		if (TryNormalizeDirection(vertex.m_tangent, tangentInput))
+		{
+			TryNormalizeDirection(
+				tangentInput - normal * glm::dot(tangentInput, normal),
+				tangent);
+		}
+
+		if (!TryNormalizeDirection(tangent, tangent))
 		{
 			const glm::vec3 axis = std::abs(normal.y) < 0.999f ?
 				glm::vec3(0.0f, 1.0f, 0.0f) :
 				glm::vec3(1.0f, 0.0f, 0.0f);
-			tangent = glm::cross(axis, normal);
+			if (!TryNormalizeDirection(glm::cross(axis, normal), tangent))
+			{
+				tangent = glm::vec3(1.0f, 0.0f, 0.0f);
+			}
+		}
+
+		glm::vec3 sourceBitangent;
+		const float handedness =
+			TryNormalizeDirection(vertex.m_bitangent, sourceBitangent) &&
+			glm::dot(
+				glm::cross(normal, tangent),
+				sourceBitangent) < 0.0f ? -1.0f : 1.0f;
+
+		glm::vec3 bitangent;
+		if (!TryNormalizeDirection(glm::cross(normal, tangent), bitangent))
+		{
+			bitangent = glm::vec3(0.0f, 0.0f, 1.0f);
 		}
 
 		vertex.m_normal = normal;
-		vertex.m_tangent = glm::normalize(tangent);
-		vertex.m_bitangent =
-			glm::normalize(glm::cross(normal, vertex.m_tangent));
+		vertex.m_tangent = tangent;
+		vertex.m_bitangent = bitangent * handedness;
 	}
+}
+
+bool GltfImporterUtils::TryComposeNodeMatrix(
+	const tinygltf::Node& node,
+	glm::mat4& outMatrix)
+{
+	outMatrix = glm::mat4(1.0f);
+	auto tryConvert = [](double value, float& outValue)
+		{
+			if (!std::isfinite(value) ||
+				value > std::numeric_limits<float>::max() ||
+				value < -std::numeric_limits<float>::max())
+			{
+				return false;
+			}
+
+			outValue = static_cast<float>(value);
+			return true;
+		};
+	if (!node.matrix.empty())
+	{
+		if (node.matrix.size() != 16)
+		{
+			return false;
+		}
+
+		for (int32_t column = 0; column < 4; ++column)
+		{
+			for (int32_t row = 0; row < 4; ++row)
+			{
+				if (!tryConvert(
+					node.matrix[static_cast<size_t>(column * 4 + row)],
+					outMatrix[column][row]))
+				{
+					return false;
+				}
+			}
+		}
+
+		return IsFiniteGltfMatrix(outMatrix);
+	}
+
+	if ((!node.translation.empty() && node.translation.size() != 3) ||
+		(!node.rotation.empty() && node.rotation.size() != 4) ||
+		(!node.scale.empty() && node.scale.size() != 3))
+	{
+		return false;
+	}
+
+	glm::vec3 translation(0.0f);
+	glm::vec3 scale(1.0f);
+	glm::quat rotation(1.0f, 0.0f, 0.0f, 0.0f);
+	for (int32_t component = 0; component < 3; ++component)
+	{
+		if ((!node.translation.empty() &&
+				!tryConvert(
+					node.translation[static_cast<size_t>(component)],
+					translation[component])) ||
+			(!node.scale.empty() &&
+				!tryConvert(
+					node.scale[static_cast<size_t>(component)],
+					scale[component])))
+		{
+			return false;
+		}
+	}
+
+	if (!node.rotation.empty())
+	{
+		if (!tryConvert(node.rotation[3], rotation.w) ||
+			!tryConvert(node.rotation[0], rotation.x) ||
+			!tryConvert(node.rotation[1], rotation.y) ||
+			!tryConvert(node.rotation[2], rotation.z))
+		{
+			return false;
+		}
+
+		const float lengthSquared = glm::dot(rotation, rotation);
+		if (!std::isfinite(lengthSquared) ||
+			lengthSquared <= std::numeric_limits<float>::epsilon())
+		{
+			return false;
+		}
+		rotation *= glm::inversesqrt(lengthSquared);
+	}
+
+	outMatrix = glm::translate(glm::mat4(1.0f), translation) *
+		glm::mat4_cast(rotation) *
+		glm::scale(glm::mat4(1.0f), scale);
+	return IsFiniteGltfMatrix(outMatrix);
+}
+
+bool GltfImporterUtils::CollectMeshInstances(
+	const tinygltf::Model& model,
+	TVector<MeshInstance>& outInstances)
+{
+	outInstances.Clear();
+	if (model.meshes.size() >
+		static_cast<size_t>(std::numeric_limits<int32_t>::max()) ||
+		model.nodes.size() >
+		static_cast<size_t>(std::numeric_limits<int32_t>::max()))
+	{
+		return false;
+	}
+
+	if (model.nodes.empty())
+	{
+		outInstances.Reserve(model.meshes.size());
+		for (size_t meshIndex = 0; meshIndex < model.meshes.size(); ++meshIndex)
+		{
+			MeshInstance instance{};
+			instance.m_meshIndex = static_cast<int32_t>(meshIndex);
+			outInstances.Add(std::move(instance));
+		}
+		return true;
+	}
+
+	TVector<uint8_t> traversalState(model.nodes.size());
+	struct PendingNode
+	{
+		int32_t m_nodeIndex = -1;
+		glm::mat4 m_parentTransform{ 1.0f };
+		bool m_bExit = false;
+	};
+	auto traverseRoot = [&](int32_t rootNode) -> bool
+		{
+			TVector<PendingNode> pendingNodes;
+			pendingNodes.Add({ rootNode, glm::mat4(1.0f), false });
+			while (!pendingNodes.IsEmpty())
+			{
+				PendingNode pending = std::move(*pendingNodes.Last());
+				pendingNodes.RemoveLast();
+				if (pending.m_nodeIndex < 0 ||
+					static_cast<size_t>(pending.m_nodeIndex) >=
+						model.nodes.size())
+				{
+					return false;
+				}
+
+				uint8_t& state = traversalState[
+					static_cast<size_t>(pending.m_nodeIndex)];
+				if (pending.m_bExit)
+				{
+					state = 2;
+					continue;
+				}
+				if (state == 1)
+				{
+					return false;
+				}
+				if (state == 2)
+				{
+					continue;
+				}
+
+				state = 1;
+				const tinygltf::Node& node = model.nodes[
+					static_cast<size_t>(pending.m_nodeIndex)];
+				glm::mat4 localTransform(1.0f);
+				if (!TryComposeNodeMatrix(node, localTransform))
+				{
+					return false;
+				}
+
+				const glm::mat4 worldTransform =
+					pending.m_parentTransform * localTransform;
+				if (!IsFiniteGltfMatrix(worldTransform))
+				{
+					return false;
+				}
+
+				if (node.mesh < -1 ||
+					(node.mesh >= 0 &&
+						static_cast<size_t>(node.mesh) >= model.meshes.size()) ||
+					node.skin < -1 ||
+					(node.skin >= 0 &&
+						static_cast<size_t>(node.skin) >= model.skins.size()))
+				{
+					return false;
+				}
+
+				if (node.mesh >= 0)
+				{
+					MeshInstance instance{};
+					instance.m_nodeIndex = pending.m_nodeIndex;
+					instance.m_meshIndex = node.mesh;
+					instance.m_skinIndex = node.skin;
+					instance.m_worldTransform = worldTransform;
+					outInstances.Add(std::move(instance));
+				}
+
+				pendingNodes.Add({
+					pending.m_nodeIndex,
+					glm::mat4(1.0f),
+					true
+				});
+				for (size_t child = node.children.size(); child > 0; --child)
+				{
+					pendingNodes.Add({
+						node.children[child - 1],
+						worldTransform,
+						false
+					});
+				}
+			}
+
+			return true;
+		};
+
+	bool bTraversedRoot = false;
+	if (!model.scenes.empty())
+	{
+		const int32_t sceneIndex = model.defaultScene >= 0 ?
+			model.defaultScene : 0;
+		if (sceneIndex < 0 ||
+			static_cast<size_t>(sceneIndex) >= model.scenes.size())
+		{
+			return false;
+		}
+
+		bTraversedRoot = true;
+		for (int32_t rootNode :
+			model.scenes[static_cast<size_t>(sceneIndex)].nodes)
+		{
+			if (!traverseRoot(rootNode))
+			{
+				outInstances.Clear();
+				return false;
+			}
+		}
+	}
+	else
+	{
+		TVector<uint8_t> hasParent(model.nodes.size());
+		for (const tinygltf::Node& node : model.nodes)
+		{
+			for (int32_t childIndex : node.children)
+			{
+				if (childIndex < 0 ||
+					static_cast<size_t>(childIndex) >= model.nodes.size() ||
+					hasParent[static_cast<size_t>(childIndex)] != 0)
+				{
+					return false;
+				}
+				hasParent[static_cast<size_t>(childIndex)] = 1;
+			}
+		}
+
+		for (size_t nodeIndex = 0; nodeIndex < model.nodes.size(); ++nodeIndex)
+		{
+			if (hasParent[nodeIndex] == 0)
+			{
+				bTraversedRoot = true;
+				if (!traverseRoot(static_cast<int32_t>(nodeIndex)))
+				{
+					outInstances.Clear();
+					return false;
+				}
+			}
+		}
+	}
+
+	if (!bTraversedRoot)
+	{
+		outInstances.Clear();
+		return false;
+	}
+
+	return true;
+}
+
+bool GltfImporterUtils::LoadModel(
+	const std::string& assetFilepath,
+	bool bImagesAsIs,
+	tinygltf::Model& outModel,
+	std::string& outError,
+	std::string& outWarning)
+{
+	outModel = tinygltf::Model();
+	outError.clear();
+	outWarning.clear();
+
+	tinygltf::TinyGLTF loader;
+	if (bImagesAsIs)
+	{
+		loader.SetImagesAsIs(true);
+	}
+
+	const bool bIsGlb =
+		Utils::GetFileExtension(assetFilepath.c_str()) == "glb";
+	const bool bLoadedNormally = bIsGlb ?
+		loader.LoadBinaryFromFile(
+			&outModel,
+			&outError,
+			&outWarning,
+			assetFilepath.c_str()) :
+		loader.LoadASCIIFromFile(
+			&outModel,
+			&outError,
+			&outWarning,
+			assetFilepath.c_str());
+
+	bool bParsed = bLoadedNormally;
+	if (!bParsed && !bIsGlb)
+	{
+		tinygltf::Model patchedModel;
+		std::string patchedError;
+		std::string patchedWarning;
+		bool bHandled = false;
+		bParsed = LoadAsciiWithMeshoptPlaceholders(
+			loader,
+			patchedModel,
+			patchedError,
+			patchedWarning,
+			assetFilepath,
+			bHandled);
+		if (bHandled)
+		{
+			outModel = std::move(patchedModel);
+			outError = std::move(patchedError);
+			outWarning = std::move(patchedWarning);
+		}
+	}
+
+	if (!bParsed)
+	{
+		return false;
+	}
+
+	std::string decodeError;
+	if (!DecodeDracoPrimitives(outModel, decodeError))
+	{
+		outError = "Cannot decode Draco primitives: " + decodeError;
+		return false;
+	}
+
+	if (!DecodeMeshoptBufferViews(outModel, decodeError))
+	{
+		outError = "Cannot decode glTF buffer views: " + decodeError;
+		return false;
+	}
+
+	return true;
 }
 
 YAML::Node Model::Serialize() const
@@ -77,20 +2206,22 @@ void Model::Flush()
 {
 	if (m_meshes.Num() == 0)
 	{
-		m_bIsReady = false;
+		m_bIsReady.store(false, std::memory_order_release);
 		return;
 	}
 
 	for (const auto& mesh : m_meshes)
 	{
-		if (!mesh) // || !mesh->IsReady())
+		if (!mesh)
 		{
-			m_bIsReady = false;
+			m_bIsReady.store(false, std::memory_order_release);
 			return;
 		}
 	}
 
-	m_bIsReady = true;
+	// Flush publishes a structurally complete model. GPU uploads are asynchronous,
+	// so IsReady() also checks every RHIMesh until its upload fence is finished.
+	m_bIsReady.store(true, std::memory_order_release);
 }
 
 bool Model::BuildBLAS()
@@ -104,9 +2235,22 @@ bool Model::BuildBLAS()
 	}
 
 	size_t expectedNumTriangles = 0;
+	constexpr size_t maxNumTriangles =
+		(static_cast<size_t>(std::numeric_limits<uint32_t>::max()) + 1) / 2;
 	for (const auto& mesh : m_cpuMeshes)
 	{
-		expectedNumTriangles += mesh.m_indices.Num() / 3;
+		if (mesh.m_indices.Num() % 3 != 0)
+		{
+			return false;
+		}
+
+		const size_t meshTriangles = mesh.m_indices.Num() / 3;
+		if (meshTriangles > maxNumTriangles - expectedNumTriangles)
+		{
+			return false;
+		}
+
+		expectedNumTriangles += meshTriangles;
 	}
 
 	if (expectedNumTriangles == 0)
@@ -123,37 +2267,90 @@ bool Model::BuildBLAS()
 			const uint32_t i0 = mesh.m_indices[i + 0];
 			const uint32_t i1 = mesh.m_indices[i + 1];
 			const uint32_t i2 = mesh.m_indices[i + 2];
+			if (i0 >= mesh.m_vertices.Num() ||
+				i1 >= mesh.m_vertices.Num() ||
+				i2 >= mesh.m_vertices.Num())
+			{
+				m_blasTriangles.Clear();
+				return false;
+			}
 
-			const auto& v0 = mesh.m_vertices[i0];
-			const auto& v1 = mesh.m_vertices[i1];
-			const auto& v2 = mesh.m_vertices[i2];
+			auto v0 = mesh.m_vertices[i0];
+			auto v1 = mesh.m_vertices[i1];
+			auto v2 = mesh.m_vertices[i2];
+			if (!Math::AllFinite(v0.m_position) ||
+				!Math::AllFinite(v1.m_position) ||
+				!Math::AllFinite(v2.m_position))
+			{
+				m_blasTriangles.Clear();
+				return false;
+			}
+
+			const glm::vec3 edge1 = v1.m_position - v0.m_position;
+			const glm::vec3 edge2 = v2.m_position - v0.m_position;
+			const glm::vec3 triangleNormal = glm::cross(edge1, edge2);
+			if (!Math::AllFinite(edge1) ||
+				!Math::AllFinite(edge2) ||
+				!Math::AllFinite(triangleNormal) ||
+				!std::isfinite(glm::dot(triangleNormal, triangleNormal)))
+			{
+				m_blasTriangles.Clear();
+				return false;
+			}
+
+			SanitizeVertexFrame(v0);
+			SanitizeVertexFrame(v1);
+			SanitizeVertexFrame(v2);
+			if (!Math::AllFinite(v0.m_normal) ||
+				!Math::AllFinite(v1.m_normal) ||
+				!Math::AllFinite(v2.m_normal) ||
+				!Math::AllFinite(v0.m_tangent) ||
+				!Math::AllFinite(v1.m_tangent) ||
+				!Math::AllFinite(v2.m_tangent) ||
+				!Math::AllFinite(v0.m_bitangent) ||
+				!Math::AllFinite(v1.m_bitangent) ||
+				!Math::AllFinite(v2.m_bitangent))
+			{
+				m_blasTriangles.Clear();
+				return false;
+			}
 
 			Math::Triangle tri{};
 			tri.m_vertices[0] = v0.m_position;
 			tri.m_vertices[1] = v1.m_position;
 			tri.m_vertices[2] = v2.m_position;
 
-			tri.m_normals[0] = glm::normalize(v0.m_normal);
-			tri.m_normals[1] = glm::normalize(v1.m_normal);
-			tri.m_normals[2] = glm::normalize(v2.m_normal);
+			tri.m_normals[0] = v0.m_normal;
+			tri.m_normals[1] = v1.m_normal;
+			tri.m_normals[2] = v2.m_normal;
 
-			tri.m_tangent[0] = glm::normalize(v0.m_tangent);
-			tri.m_tangent[1] = glm::normalize(v1.m_tangent);
-			tri.m_tangent[2] = glm::normalize(v2.m_tangent);
+			tri.m_tangent[0] = v0.m_tangent;
+			tri.m_tangent[1] = v1.m_tangent;
+			tri.m_tangent[2] = v2.m_tangent;
 
-			tri.m_bitangent[0] = glm::normalize(v0.m_bitangent);
-			tri.m_bitangent[1] = glm::normalize(v1.m_bitangent);
-			tri.m_bitangent[2] = glm::normalize(v2.m_bitangent);
+			tri.m_bitangent[0] = v0.m_bitangent;
+			tri.m_bitangent[1] = v1.m_bitangent;
+			tri.m_bitangent[2] = v2.m_bitangent;
 
-			tri.m_uvs[0] = v0.m_texcoord;
-			tri.m_uvs[1] = v1.m_texcoord;
-			tri.m_uvs[2] = v2.m_texcoord;
+			tri.m_uvs[0] = Math::AllFinite(v0.m_texcoord) ?
+				v0.m_texcoord : glm::vec2(0.0f);
+			tri.m_uvs[1] = Math::AllFinite(v1.m_texcoord) ?
+				v1.m_texcoord : glm::vec2(0.0f);
+			tri.m_uvs[2] = Math::AllFinite(v2.m_texcoord) ?
+				v2.m_texcoord : glm::vec2(0.0f);
 			tri.m_uvs2[0] = tri.m_uvs[0];
 			tri.m_uvs2[1] = tri.m_uvs[1];
 			tri.m_uvs2[2] = tri.m_uvs[2];
 
 			tri.m_materialIndex = static_cast<uint8_t>((std::max)(0, (std::min)(mesh.m_materialIndex, 255)));
-			tri.m_centroid = (tri.m_vertices[0] + tri.m_vertices[1] + tri.m_vertices[2]) / 3.0f;
+			tri.m_centroid = tri.m_vertices[0] / 3.0f +
+				tri.m_vertices[1] / 3.0f +
+				tri.m_vertices[2] / 3.0f;
+			if (!Math::AllFinite(tri.m_centroid))
+			{
+				m_blasTriangles.Clear();
+				return false;
+			}
 
 			m_blasTriangles.Add(tri);
 		}
@@ -175,6 +2372,11 @@ void Model::ProceedCpuMeshes(bool bShouldGenerateBLAS, bool bShouldKeepCpuBuffer
 	{
 		BuildBLAS();
 	}
+	else
+	{
+		m_blas.Clear();
+		m_blasTriangles.Clear();
+	}
 
 	if (!bShouldKeepCpuBuffers)
 	{
@@ -184,7 +2386,20 @@ void Model::ProceedCpuMeshes(bool bShouldGenerateBLAS, bool bShouldKeepCpuBuffer
 
 bool Model::IsReady() const
 {
-	return m_bIsReady;
+	if (!m_bIsReady.load(std::memory_order_acquire))
+	{
+		return false;
+	}
+
+	for (const auto& mesh : m_meshes)
+	{
+		if (!mesh || !mesh->IsReady())
+		{
+			return false;
+		}
+	}
+
+	return true;
 }
 
 ModelImporter::ModelImporter(ModelAssetInfoHandler* infoHandler)
@@ -206,20 +2421,59 @@ void ModelImporter::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
 {
 	SAILOR_PROFILE_FUNCTION();
 	SAILOR_PROFILE_TEXT(assetInfo->GetAssetFilepath().c_str());
+	auto areGeneratedAssetsValid = [](
+		const TVector<FileId>& fileIds,
+		bool bRequireUniqueFileIds)
+		{
+			AssetRegistry* assetRegistry = App::GetSubmodule<AssetRegistry>();
+			if (assetRegistry == nullptr)
+			{
+				return false;
+			}
+
+			TSet<FileId> uniqueFileIds;
+			for (const FileId& fileId : fileIds)
+			{
+				if (!fileId ||
+					(bRequireUniqueFileIds &&
+						uniqueFileIds.Contains(fileId)) ||
+					assetRegistry->GetAssetInfoPtr(fileId) == nullptr)
+				{
+					return false;
+				}
+				uniqueFileIds.Insert(fileId);
+			}
+			return true;
+		};
 
 	if (ModelAssetInfoPtr modelAssetInfo = dynamic_cast<ModelAssetInfoPtr>(assetInfo))
 	{
 		if (modelAssetInfo->IsWritable())
 		{
-			if (bWasExpired && modelAssetInfo->ShouldGenerateMaterials() && modelAssetInfo->GetDefaultMaterials().Num() == 0)
+			const TVector<FileId>& materials =
+				modelAssetInfo->GetDefaultMaterials();
+			const bool bMaterialsNeedRepair =
+				materials.Num() > 0 &&
+				!areGeneratedAssetsValid(
+					materials,
+					modelAssetInfo->ShouldBatchByMaterial());
+			if (modelAssetInfo->ShouldGenerateMaterials() &&
+				((bWasExpired && materials.Num() == 0) ||
+					bMaterialsNeedRepair) &&
+				GenerateMaterialAssets(modelAssetInfo))
 			{
-				GenerateMaterialAssets(modelAssetInfo);
 				assetInfo->SaveMetaFile();
 			}
 
-			if (bWasExpired && modelAssetInfo->GetAnimations().Num() == 0)
+			const TVector<FileId>& animations =
+				modelAssetInfo->GetAnimations();
+			const bool bAnimationsNeedRepair =
+				animations.Num() > 0 &&
+				!areGeneratedAssetsValid(animations, true);
+			if (((bWasExpired && animations.Num() == 0) ||
+				bAnimationsNeedRepair) &&
+				GenerateAnimationAssets(modelAssetInfo))
 			{
-				GenerateAnimationAssets(modelAssetInfo);
 				assetInfo->SaveMetaFile();
 			}
 		}
@@ -242,20 +2496,21 @@ void ModelImporter::OnImportAsset(AssetInfoPtr assetInfo)
 	if (modelAssetInfo->IsWritable())
 	{
 		if (modelAssetInfo->ShouldGenerateMaterials() &&
-			modelAssetInfo->GetDefaultMaterials().Num() == 0)
+			modelAssetInfo->GetDefaultMaterials().Num() == 0 &&
+			GenerateMaterialAssets(modelAssetInfo))
 		{
-			GenerateMaterialAssets(modelAssetInfo);
 			assetInfo->SaveMetaFile();
 		}
 
-		if (modelAssetInfo->GetAnimations().Num() == 0)
+		if (modelAssetInfo->GetAnimations().Num() == 0 &&
+			GenerateAnimationAssets(modelAssetInfo))
 		{
-			GenerateAnimationAssets(modelAssetInfo);
 			assetInfo->SaveMetaFile();
 		}
 	}
 
 	GenerateFingerprintAsync(modelAssetInfo);
+
 }
 
 void ModelImporter::GenerateFingerprintAsync(ModelAssetInfoPtr modelAssetInfo)
@@ -266,8 +2521,8 @@ void ModelImporter::GenerateFingerprintAsync(ModelAssetInfoPtr modelAssetInfo)
 	}
 
 	const FileId fileId = modelAssetInfo->GetFileId();
-	const std::filesystem::path filename = fileId.ToString() + ".png";
-	if (filename != filename.filename())
+	const std::filesystem::path outputPath = GetFingerprintPath(fileId);
+	if (outputPath.empty())
 	{
 		SAILOR_LOG_ERROR(
 			"Cannot generate fingerprint for invalid FileId: %s",
@@ -278,10 +2533,43 @@ void ModelImporter::GenerateFingerprintAsync(ModelAssetInfoPtr modelAssetInfo)
 	const std::string assetFilepath = modelAssetInfo->GetAssetFilepath();
 	const float unitScale = modelAssetInfo->GetUnitScale();
 	const bool bShouldBatchByMaterial = modelAssetInfo->ShouldBatchByMaterial();
-	const std::string outputPath =
-		(std::filesystem::path(AssetRegistry::GetCacheFolder()) /
-			"Fingerprints" /
-			filename).string();
+	FileRevision sourceRevision;
+	if (!Utils::TryGetFileRevision(assetFilepath, sourceRevision))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot capture model source revision for fingerprint: %s",
+			assetFilepath.c_str());
+		return;
+	}
+
+	if (App::GetSubmodule<Tasks::Scheduler>() == nullptr)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot schedule model fingerprint without a task scheduler: %s",
+			assetFilepath.c_str());
+		return;
+	}
+
+	FingerprintTaskChain& taskChain = GetFingerprintTaskChain();
+	uint64_t generation = 0;
+	{
+		const std::lock_guard<std::mutex> lock(taskChain.m_mutex);
+		generation = ++taskChain.m_nextRequestGeneration;
+		taskChain.m_requests[fileId] = {
+			generation,
+			sourceRevision
+		};
+
+		std::error_code removeError;
+		std::filesystem::remove(outputPath, removeError);
+		if (removeError)
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot invalidate previous model fingerprint '%s': %s",
+				outputPath.string().c_str(),
+				removeError.message().c_str());
+		}
+	}
 
 	Tasks::CreateTask(
 		"Generate model fingerprint",
@@ -290,17 +2578,43 @@ void ModelImporter::GenerateFingerprintAsync(ModelAssetInfoPtr modelAssetInfo)
 			assetFilepath,
 			unitScale,
 			bShouldBatchByMaterial,
-			outputPath
+			outputPath,
+			generation,
+			sourceRevision
 		]()
 		{
-			GenerateFingerprint(
+			if (IsFingerprintRequestCurrent(
 				fileId,
-				assetFilepath,
-				unitScale,
-				bShouldBatchByMaterial,
-				outputPath);
+				generation,
+				sourceRevision))
+			{
+				const ActiveFingerprintRequestScope requestScope(
+					generation,
+					sourceRevision);
+				GenerateFingerprint(
+					fileId,
+					assetFilepath,
+					unitScale,
+					bShouldBatchByMaterial,
+					outputPath.string());
+			}
+
+			FingerprintTaskChain& completedTaskChain =
+				GetFingerprintTaskChain();
+			const std::lock_guard<std::mutex> completedLock(
+				completedTaskChain.m_mutex);
+			FingerprintRequest* completedRequest = nullptr;
+			if (completedTaskChain.m_requests.Find(
+				fileId,
+				completedRequest) &&
+				completedRequest != nullptr &&
+				completedRequest->m_generation == generation &&
+				completedRequest->m_sourceRevision == sourceRevision)
+			{
+				completedTaskChain.m_requests.Remove(fileId);
+			}
 		},
-		EThreadType::Worker)->Run();
+		EThreadType::Background)->Run();
 }
 
 bool ModelImporter::GenerateFingerprint(
@@ -335,109 +2649,181 @@ bool ModelImporter::GenerateFingerprint(
 
 	ObjectAllocatorPtr allocator =
 		ObjectAllocatorPtr::Make(EAllocationPolicy::SharedMemory_MultiThreaded);
-	TVector<MaterialPtr> previewMaterials(gltfModel.materials.size());
-	TMap<int32_t, TexturePtr> previewTextures;
+	const size_t previewMaterialCount = (std::min)(
+		gltfModel.materials.size(),
+		size_t{ 256 });
+	TVector<MaterialPtr> previewMaterials(previewMaterialCount);
+	TMap<int32_t, int32_t> previewTextureSources;
+	TMap<int32_t, TexturePtr> previewImages;
+
+	auto resolvePreviewImageSource = [&](int32_t textureIndex) -> int32_t
+		{
+			int32_t* cachedSource = nullptr;
+			if (previewTextureSources.Find(textureIndex, cachedSource) &&
+				cachedSource != nullptr)
+			{
+				return *cachedSource;
+			}
+
+			int32_t imageIndex = -1;
+			if (textureIndex >= 0 &&
+				static_cast<size_t>(textureIndex) < gltfModel.textures.size())
+			{
+				const tinygltf::Texture& sourceTexture =
+					gltfModel.textures[textureIndex];
+				if (sourceTexture.source >= 0 &&
+					static_cast<size_t>(sourceTexture.source) <
+						gltfModel.images.size())
+				{
+					imageIndex = sourceTexture.source;
+				}
+			}
+
+			previewTextureSources[textureIndex] = imageIndex;
+			return imageIndex;
+		};
 
 	auto loadPreviewTexture = [&](int32_t textureIndex) -> TexturePtr
 		{
+			const int32_t imageIndex =
+				resolvePreviewImageSource(textureIndex);
+			if (imageIndex < 0)
+			{
+				return TexturePtr();
+			}
+
 			TexturePtr* cachedTexture = nullptr;
-			if (previewTextures.Find(textureIndex, cachedTexture) &&
+			if (previewImages.Find(imageIndex, cachedTexture) &&
 				cachedTexture != nullptr)
 			{
 				return *cachedTexture;
 			}
 
-			if (textureIndex < 0 ||
-				static_cast<size_t>(textureIndex) >= gltfModel.textures.size())
-			{
-				return TexturePtr();
-			}
-
-			const tinygltf::Texture& sourceTexture =
-				gltfModel.textures[textureIndex];
-			if (sourceTexture.source < 0 ||
-				static_cast<size_t>(sourceTexture.source) >=
-					gltfModel.images.size())
-			{
-				return TexturePtr();
-			}
-
 			const tinygltf::Image& image =
-				gltfModel.images[sourceTexture.source];
-			if (image.width <= 0 ||
-				image.height <= 0 ||
-				image.component <= 0 ||
-				(image.bits != 8 && image.bits != 16))
+				gltfModel.images[imageIndex];
+			auto cacheFailure = [&]() -> TexturePtr
+				{
+					previewImages[imageIndex] = TexturePtr();
+					return TexturePtr();
+				};
+
+			if (!image.as_is ||
+				image.image.empty() ||
+				image.image.size() >
+					static_cast<size_t>(std::numeric_limits<int>::max()))
 			{
-				return TexturePtr();
+				return cacheFailure();
 			}
 
-			const size_t pixelCount =
-				static_cast<size_t>(image.width) *
-				static_cast<size_t>(image.height);
-			const size_t bytesPerChannel =
-				static_cast<size_t>(image.bits / 8);
-			const size_t requiredBytes =
-				pixelCount *
-				static_cast<size_t>(image.component) *
-				bytesPerChannel;
-			if (requiredBytes > image.image.size())
+			int32_t sourceWidth = 0;
+			int32_t sourceHeight = 0;
+			int32_t sourceChannels = 0;
+			if (!stbi_info_from_memory(
+				image.image.data(),
+				static_cast<int>(image.image.size()),
+				&sourceWidth,
+				&sourceHeight,
+				&sourceChannels) ||
+				sourceWidth <= 0 ||
+				sourceHeight <= 0 ||
+				sourceChannels <= 0)
 			{
-				return TexturePtr();
+				return cacheFailure();
 			}
 
+			size_t sourcePixelCount = 0;
+			size_t decodedBytes = 0;
+			if (!TryMultiplySize(
+				static_cast<size_t>(sourceWidth),
+				static_cast<size_t>(sourceHeight),
+				sourcePixelCount) ||
+				!TryMultiplySize(
+					sourcePixelCount,
+					static_cast<size_t>(STBI_rgb_alpha),
+					decodedBytes) ||
+				decodedBytes > MaxFingerprintDecodedImageBytes)
+			{
+				return cacheFailure();
+			}
+
+			int32_t decodedWidth = 0;
+			int32_t decodedHeight = 0;
+			int32_t decodedChannels = 0;
+			StbiImageData decodedPixels(stbi_load_from_memory(
+					image.image.data(),
+					static_cast<int>(image.image.size()),
+					&decodedWidth,
+					&decodedHeight,
+					&decodedChannels,
+					STBI_rgb_alpha));
+			if (!decodedPixels ||
+				decodedWidth != sourceWidth ||
+				decodedHeight != sourceHeight)
+			{
+				return cacheFailure();
+			}
+
+			int32_t previewWidth = 0;
+			int32_t previewHeight = 0;
+			size_t previewBytes = 0;
+			if (!TryCalculateFingerprintTextureSize(
+				decodedWidth,
+				decodedHeight,
+				previewWidth,
+				previewHeight,
+				previewBytes))
+			{
+				return cacheFailure();
+			}
+
+			TVector<uint8_t> previewPixels;
+			previewPixels.Resize(previewBytes);
+			u8vec4* destination = reinterpret_cast<u8vec4*>(
+				previewPixels.GetData());
+			for (int32_t y = 0; y < previewHeight; ++y)
+			{
+				const size_t sourceY = (std::min)(
+					static_cast<size_t>(decodedHeight - 1),
+					static_cast<size_t>(
+						(static_cast<uint64_t>(y) * decodedHeight) /
+						previewHeight));
+				for (int32_t x = 0; x < previewWidth; ++x)
+				{
+					const size_t sourceX = (std::min)(
+						static_cast<size_t>(decodedWidth - 1),
+						static_cast<size_t>(
+							(static_cast<uint64_t>(x) * decodedWidth) /
+							previewWidth));
+					const size_t sourceOffset =
+						(sourceY * static_cast<size_t>(decodedWidth) +
+							sourceX) *
+						static_cast<size_t>(STBI_rgb_alpha);
+					const size_t destinationIndex =
+						static_cast<size_t>(y) *
+							static_cast<size_t>(previewWidth) +
+						static_cast<size_t>(x);
+					destination[destinationIndex] = u8vec4(
+						decodedPixels.GetData()[sourceOffset + 0],
+						decodedPixels.GetData()[sourceOffset + 1],
+						decodedPixels.GetData()[sourceOffset + 2],
+						decodedPixels.GetData()[sourceOffset + 3]);
+				}
+			}
+
+			decodedPixels.Clear();
 			TexturePtr texture = TexturePtr::Make(
 				allocator,
 				FileId::CreateNewFileId());
-			texture->m_decodedData.Resize(
-				pixelCount * sizeof(u8vec4));
-			texture->m_width = image.width;
-			texture->m_height = image.height;
+			texture->m_decodedData = std::move(previewPixels);
+			texture->m_width = previewWidth;
+			texture->m_height = previewHeight;
 			texture->m_mipLevels = 1;
 
-			auto readChannel = [&](size_t pixel, int32_t channel) -> uint8_t
-				{
-					const size_t offset =
-						(pixel * static_cast<size_t>(image.component) +
-							static_cast<size_t>(channel)) *
-						bytesPerChannel;
-					if (image.bits == 8)
-					{
-						return image.image[offset];
-					}
-
-					uint16_t value = 0;
-					std::memcpy(
-						&value,
-						image.image.data() + offset,
-						sizeof(value));
-					return static_cast<uint8_t>(value / 257u);
-				};
-
-			u8vec4* pixels = reinterpret_cast<u8vec4*>(
-				texture->m_decodedData.GetData());
-			for (size_t i = 0; i < pixelCount; i++)
-			{
-				const uint8_t r = readChannel(i, 0);
-				const uint8_t g = image.component >= 3 ?
-					readChannel(i, 1) :
-					r;
-				const uint8_t b = image.component >= 3 ?
-					readChannel(i, 2) :
-					r;
-				const uint8_t a = image.component == 2 ?
-					readChannel(i, 1) :
-					(image.component >= 4 ?
-						readChannel(i, 3) :
-						255u);
-				pixels[i] = u8vec4(r, g, b, a);
-			}
-
-			previewTextures[textureIndex] = texture;
+			previewImages[imageIndex] = texture;
 			return texture;
 		};
 
-	for (size_t i = 0; i < gltfModel.materials.size(); i++)
+	for (size_t i = 0; i < previewMaterialCount; i++)
 	{
 		const tinygltf::Material& sourceMaterial =
 			gltfModel.materials[i];
@@ -518,6 +2904,7 @@ bool ModelImporter::GenerateFingerprint(
 			sourceMaterial.occlusionTexture.index);
 		previewMaterials[i] = std::move(material);
 	}
+	gltfModel = tinygltf::Model();
 
 	ModelPtr model = ModelPtr::Make(allocator, fileId);
 	model->m_boundsAabb = boundsAabb;
@@ -531,7 +2918,7 @@ bool ModelImporter::GenerateFingerprint(
 		cpuMesh.m_vertices = std::move(mesh.outVertices);
 		for (auto& vertex : cpuMesh.m_vertices)
 		{
-			SanitizeFingerprintVertex(vertex);
+			SanitizeVertexFrame(vertex);
 		}
 		cpuMesh.m_indices = std::move(mesh.outIndices);
 		cpuMesh.m_bounds = mesh.bounds;
@@ -565,8 +2952,7 @@ bool ModelImporter::GenerateFingerprint(
 
 	const float radius = (std::max)(boundsSphere.m_radius, 0.1f);
 	Raytracing::PathTracer::Params params{};
-	params.m_output = outputPath;
-	params.m_height = 256;
+	params.m_height = FingerprintImageDimension;
 	params.m_numSamples = 1;
 	params.m_numAmbientSamples = 1;
 	params.m_maxBounces = 1;
@@ -581,16 +2967,119 @@ bool ModelImporter::GenerateFingerprint(
 	params.m_runtimeAspectRatio = 1.0f;
 	params.m_bRunTasksInline = true;
 
-	std::error_code error;
-	std::filesystem::create_directories(
-		std::filesystem::path(outputPath).parent_path(),
-		error);
-	if (error || !pathTracer.RenderPreparedScene(params))
+	if (!pathTracer.RenderPreparedScene(params))
 	{
 		SAILOR_LOG_ERROR(
-			"Cannot save model fingerprint '%s': %s",
+			"Cannot render model fingerprint: %s",
+			assetFilepath.c_str());
+		return false;
+	}
+
+	const glm::uvec2 extent = pathTracer.GetLastRenderedExtent();
+	const TVector<u8vec4>& renderedImage =
+		pathTracer.GetLastRenderedImage();
+	size_t expectedPixelCount = 0;
+	if (extent.x != FingerprintImageDimension ||
+		extent.y != FingerprintImageDimension ||
+		!TryMultiplySize(
+			static_cast<size_t>(extent.x),
+			static_cast<size_t>(extent.y),
+			expectedPixelCount) ||
+		renderedImage.Num() != expectedPixelCount)
+	{
+		SAILOR_LOG_ERROR(
+			"Model fingerprint renderer returned an invalid image: %s",
+			assetFilepath.c_str());
+		return false;
+	}
+
+	EncodedFingerprint encoded;
+	const int32_t channels = 4;
+	if (!stbi_write_png_to_func(
+		AppendEncodedFingerprintBytes,
+		&encoded,
+		static_cast<int32_t>(extent.x),
+		static_cast<int32_t>(extent.y),
+		channels,
+		renderedImage.GetData(),
+		static_cast<int32_t>(extent.x) * channels) ||
+		!encoded.m_bValid ||
+		encoded.m_bytes.IsEmpty() ||
+		encoded.m_bytes.Num() > MaxFingerprintEncodedImageBytes)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot encode model fingerprint: %s",
+			assetFilepath.c_str());
+		return false;
+	}
+
+	int32_t encodedWidth = 0;
+	int32_t encodedHeight = 0;
+	int32_t encodedChannels = 0;
+	if (!stbi_info_from_memory(
+		encoded.m_bytes.GetData(),
+		static_cast<int>(encoded.m_bytes.Num()),
+		&encodedWidth,
+		&encodedHeight,
+		&encodedChannels) ||
+		encodedWidth != FingerprintImageDimension ||
+		encodedHeight != FingerprintImageDimension ||
+		encodedChannels <= 0)
+	{
+		SAILOR_LOG_ERROR(
+			"Encoded model fingerprint is invalid: %s",
+			assetFilepath.c_str());
+		return false;
+	}
+
+	if (!g_activeFingerprintRequest.m_bValid)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot publish a model fingerprint without request context: %s",
+			assetFilepath.c_str());
+		return false;
+	}
+
+	FileRevision currentSourceRevision;
+	if (!Utils::TryGetFileRevision(
+		assetFilepath,
+		currentSourceRevision) ||
+		currentSourceRevision !=
+			g_activeFingerprintRequest.m_sourceRevision)
+	{
+		SAILOR_LOG(
+			"Discarded stale model fingerprint: %s",
+			assetFilepath.c_str());
+		return false;
+	}
+
+	FingerprintTaskChain& taskChain = GetFingerprintTaskChain();
+	const std::lock_guard<std::mutex> lock(taskChain.m_mutex);
+	FingerprintRequest* request = nullptr;
+	if (!taskChain.m_requests.Find(fileId, request) ||
+		request == nullptr ||
+		request->m_generation !=
+			g_activeFingerprintRequest.m_generation ||
+		request->m_sourceRevision !=
+			g_activeFingerprintRequest.m_sourceRevision)
+	{
+		SAILOR_LOG(
+			"Discarded superseded model fingerprint: %s",
+			assetFilepath.c_str());
+		return false;
+	}
+
+	std::string diagnostic;
+	if (!Workspace::AtomicReplaceWorkspaceCacheBinary(
+		std::filesystem::path(outputPath),
+		encoded.m_bytes.GetData(),
+		static_cast<uint64_t>(encoded.m_bytes.Num()),
+		diagnostic))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot atomically publish model fingerprint '%s': %s",
 			outputPath.c_str(),
-			error.message().c_str());
+			diagnostic.c_str());
 		return false;
 	}
 
@@ -619,9 +3108,28 @@ FileId CreateTextureAsset(const std::string& filepath,
 		filtration,
 		bShouldKeepCpuBuffers);
 
-	std::ofstream assetFile(filepath);
-	assetFile << newTexture;
-	assetFile.close();
+	std::ostringstream serialized;
+	serialized << newTexture;
+	if (!serialized)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot serialize generated texture metadata: %s",
+			filepath.c_str());
+		return {};
+	}
+
+	std::string diagnostic;
+	if (!Workspace::AtomicReplaceWorkspaceCacheText(
+			std::filesystem::path(filepath),
+			serialized.str(),
+			diagnostic))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot save generated texture metadata '%s': %s",
+			filepath.c_str(),
+			diagnostic.c_str());
+		return {};
+	}
 
 	return newFileId;
 }
@@ -639,64 +3147,98 @@ FileId CreateAnimationAsset(const std::string& filepath,
 		animationIndex,
 		skinIndex);
 
-	std::ofstream assetFile(filepath);
-	assetFile << newAnimation;
-	assetFile.close();
+	std::ostringstream serialized;
+	serialized << newAnimation;
+	if (!serialized)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot serialize generated animation metadata: %s",
+			filepath.c_str());
+		return {};
+	}
+
+	std::string diagnostic;
+	if (!Workspace::AtomicReplaceWorkspaceCacheText(
+			std::filesystem::path(filepath),
+			serialized.str(),
+			diagnostic))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot save generated animation metadata '%s': %s",
+			filepath.c_str(),
+			diagnostic.c_str());
+		return {};
+	}
 
 	return newFileId;
 }
 
-void ModelImporter::GenerateAnimationAssets(ModelAssetInfoPtr assetInfo)
+bool ModelImporter::GenerateAnimationAssets(ModelAssetInfoPtr assetInfo)
 {
 	SAILOR_PROFILE_FUNCTION();
 
 	tinygltf::Model gltfModel;
-	tinygltf::TinyGLTF loader;
 	std::string err, warn;
+	const bool bGltfParsed = GltfImporterUtils::LoadModel(
+		assetInfo->GetAssetFilepath(),
+		true,
+		gltfModel,
+		err,
+		warn);
 
-	const bool bIsGlb = Utils::GetFileExtension(assetInfo->GetAssetFilepath().c_str()) == "glb";
-	const bool bGltfParsed = bIsGlb ?
-		loader.LoadBinaryFromFile(&gltfModel, &err, &warn, assetInfo->GetAssetFilepath().c_str()) :
-		loader.LoadASCIIFromFile(&gltfModel, &err, &warn, assetInfo->GetAssetFilepath().c_str());
-
-	if (!bGltfParsed || gltfModel.animations.empty())
+	if (!bGltfParsed)
 	{
-		return;
+		return false;
+	}
+
+	if (gltfModel.animations.empty())
+	{
+		const bool bChanged = assetInfo->GetAnimations().Num() > 0;
+		assetInfo->GetAnimations().Clear();
+		return bChanged;
 	}
 
 	const std::string animationsFolder = Utils::GetFileFolder(assetInfo->GetRelativeAssetFilepath());
+	TVector<FileId> generatedAnimations;
+	generatedAnimations.Reserve(gltfModel.animations.size());
 
 	for (size_t i = 0; i < gltfModel.animations.size(); ++i)
 	{
-		const auto& anim = gltfModel.animations[i];
-		std::string name = !anim.name.empty() ? anim.name : ("animation" + std::to_string(i));
 		std::filesystem::path outputPath;
 		if (!App::GetSubmodule<AssetRegistry>()->ResolveWorkspaceContentPathForWrite(
-				animationsFolder + assetInfo->GetAssetFilename() + "_" + name + ".anim.asset",
+				animationsFolder + assetInfo->GetAssetFilename() +
+					"_animation_" + std::to_string(i) + ".anim.asset",
 				outputPath))
 		{
 			SAILOR_LOG_ERROR("Cannot resolve generated animation output for %s.", assetInfo->GetAssetFilepath().c_str());
-			continue;
+			return false;
 		}
-		FileId id = CreateAnimationAsset(outputPath.string(),
+		const FileId id = CreateAnimationAsset(outputPath.string(),
 			assetInfo->GetAssetFilename(), (uint32_t)i, 0);
-		assetInfo->GetAnimations().Add(id);
+		if (!id)
+		{
+			return false;
+		}
+		generatedAnimations.Add(id);
 	}
+
+	assetInfo->GetAnimations() = std::move(generatedAnimations);
+	return true;
 }
 
-void ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
+bool ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 {
 	SAILOR_PROFILE_FUNCTION();
 
 	tinygltf::Model gltfModel;
-	tinygltf::TinyGLTF loader;
 	std::string err;
 	std::string warn;
-
-	const bool bIsGlb = Utils::GetFileExtension(assetInfo->GetAssetFilepath().c_str()) == "glb";
-	const bool bGltfParsed = bIsGlb ?
-		loader.LoadBinaryFromFile(&gltfModel, &err, &warn, assetInfo->GetAssetFilepath().c_str())
-		: loader.LoadASCIIFromFile(&gltfModel, &err, &warn, assetInfo->GetAssetFilepath().c_str());
+	const bool bGltfParsed = GltfImporterUtils::LoadModel(
+		assetInfo->GetAssetFilepath(),
+		true,
+		gltfModel,
+		err,
+		warn);
 
 	if (!err.empty())
 	{
@@ -710,7 +3252,7 @@ void ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 
 	if (!bGltfParsed)
 	{
-		return;
+		return false;
 	}
 
 	const std::string texturesFolder = Utils::GetFileFolder(assetInfo->GetRelativeAssetFilepath());
@@ -726,11 +3268,12 @@ void ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 
 		std::filesystem::path materialNamePath;
 		if (!App::GetSubmodule<AssetRegistry>()->ResolveWorkspaceContentPathForWrite(
-				texturesFolder + assetInfo->GetAssetFilename() + "_" + data.m_name,
+				texturesFolder + assetInfo->GetAssetFilename() +
+					"_material_" + std::to_string(i),
 				materialNamePath))
 		{
 			SAILOR_LOG_ERROR("Cannot resolve generated material output for %s.", assetInfo->GetAssetFilepath().c_str());
-			continue;
+			return false;
 		}
 		const std::string materialName = materialNamePath.string();
 
@@ -764,65 +3307,157 @@ void ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 				CreateTextureAsset(materialName + "_occlusionTexture.png.asset", assetInfo->GetAssetFilename(), material.occlusionTexture.index, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 		}
 
+		auto tryReadNumberProperty = [](
+			const tinygltf::Value& object,
+			const char* property,
+			double& outValue)
+			{
+				if (!object.IsObject() || !object.Has(property))
+				{
+					return false;
+				}
+
+				const tinygltf::Value& value = object.Get(property);
+				if (!value.IsNumber())
+				{
+					return false;
+				}
+
+				const double parsedValue = value.GetNumberAsDouble();
+				if (!std::isfinite(parsedValue) ||
+					parsedValue > std::numeric_limits<float>::max() ||
+					parsedValue < -std::numeric_limits<float>::max())
+				{
+					return false;
+				}
+
+				outValue = parsedValue;
+				return true;
+			};
+
+		auto tryReadTextureIndex = [&gltfModel](
+			const tinygltf::Value& object,
+			const char* property,
+			int32_t& outIndex)
+			{
+				if (!object.IsObject() || !object.Has(property))
+				{
+					return false;
+				}
+
+				const tinygltf::Value& textureInfo = object.Get(property);
+				if (!textureInfo.IsObject() || !textureInfo.Has("index"))
+				{
+					return false;
+				}
+
+				const tinygltf::Value& indexValue = textureInfo.Get("index");
+				if (!indexValue.IsInt())
+				{
+					return false;
+				}
+
+				const int32_t index = indexValue.GetNumberAsInt();
+				if (index < 0 ||
+					static_cast<size_t>(index) >= gltfModel.textures.size())
+				{
+					return false;
+				}
+
+				outIndex = index;
+				return true;
+			};
+
+		auto tryReadVec3Property = [](
+			const tinygltf::Value& object,
+			const char* property,
+			glm::vec3& outValue)
+			{
+				if (!object.IsObject() || !object.Has(property))
+				{
+					return false;
+				}
+
+				const tinygltf::Value& array = object.Get(property);
+				if (!array.IsArray() || array.ArrayLen() < 3)
+				{
+					return false;
+				}
+
+				glm::vec3 parsedValue(0.0f);
+				for (size_t component = 0; component < 3; ++component)
+				{
+					const tinygltf::Value& value = array.Get(component);
+					if (!value.IsNumber())
+					{
+						return false;
+					}
+
+					const double parsedComponent = value.GetNumberAsDouble();
+					if (!std::isfinite(parsedComponent) ||
+						parsedComponent > std::numeric_limits<float>::max() ||
+						parsedComponent < -std::numeric_limits<float>::max())
+					{
+						return false;
+					}
+					parsedValue[static_cast<int32_t>(component)] =
+						static_cast<float>(parsedComponent);
+				}
+
+				outValue = parsedValue;
+				return true;
+			};
+
+		int32_t textureIndex = -1;
 		auto ccIt = material.extensions.find("KHR_materials_clearcoat");
-		if (ccIt != material.extensions.end())
+		if (ccIt != material.extensions.end() && ccIt->second.IsObject())
 		{
 			const tinygltf::Value& cc = ccIt->second;
 
 			double ccFactor = 0.0;
-			if (cc.Has("clearcoatFactor"))
-				ccFactor = cc.Get("clearcoatFactor").GetNumberAsDouble();
+			tryReadNumberProperty(cc, "clearcoatFactor", ccFactor);
 
 			double ccRoughness = 0.0;
-			if (cc.Has("clearcoatRoughnessFactor"))
-				ccRoughness = cc.Get("clearcoatRoughnessFactor").GetNumberAsDouble();
+			tryReadNumberProperty(
+				cc,
+				"clearcoatRoughnessFactor",
+				ccRoughness);
 
 			data.m_uniformsFloat.Add("material.clearcoatFactor", (float)ccFactor);
 			data.m_uniformsFloat.Add("material.clearcoatRoughnessFactor", (float)ccRoughness);
 
-			if (cc.Has("clearcoatTexture"))
+			textureIndex = -1;
+			if (tryReadTextureIndex(cc, "clearcoatTexture", textureIndex))
 			{
-				const tinygltf::Value& tex = cc.Get("clearcoatTexture");
-				if (tex.Has("index"))
-				{
-					int idx = tex.Get("index").Get<int>();
-					if (idx != -1)
-					{
-						data.m_samplers.Add("clearcoatSampler",
-							CreateTextureAsset(materialName + "_clearcoatTexture.png.asset", assetInfo->GetAssetFilename(), idx, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
-					}
-				}
+				data.m_samplers.Add("clearcoatSampler",
+					CreateTextureAsset(materialName + "_clearcoatTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 			}
 
-			if (cc.Has("clearcoatRoughnessTexture"))
+			textureIndex = -1;
+			if (tryReadTextureIndex(
+				cc,
+				"clearcoatRoughnessTexture",
+				textureIndex))
 			{
-				const tinygltf::Value& tex = cc.Get("clearcoatRoughnessTexture");
-				if (tex.Has("index"))
-				{
-					int idx = tex.Get("index").Get<int>();
-					if (idx != -1)
-					{
-						data.m_samplers.Add("clearcoatRoughnessSampler",
-							CreateTextureAsset(materialName + "_clearcoatRoughnessTexture.png.asset", assetInfo->GetAssetFilename(), idx, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
-					}
-				}
+				data.m_samplers.Add("clearcoatRoughnessSampler",
+					CreateTextureAsset(materialName + "_clearcoatRoughnessTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 			}
 
-			if (cc.Has("clearcoatNormalTexture"))
+			if (cc.Has("clearcoatNormalTexture") &&
+				cc.Get("clearcoatNormalTexture").IsObject())
 			{
 				const tinygltf::Value& tex = cc.Get("clearcoatNormalTexture");
 				double scale = 1.0;
-				if (tex.Has("scale"))
-					scale = tex.Get("scale").GetNumberAsDouble();
+				tryReadNumberProperty(tex, "scale", scale);
 
-				if (tex.Has("index"))
+				textureIndex = -1;
+				if (tryReadTextureIndex(
+					cc,
+					"clearcoatNormalTexture",
+					textureIndex))
 				{
-					int idx = tex.Get("index").Get<int>();
-					if (idx != -1)
-					{
-						data.m_samplers.Add("clearcoatNormalSampler",
-							CreateTextureAsset(materialName + "_clearcoatNormalTexture.png.asset", assetInfo->GetAssetFilename(), idx, true, RHI::ETextureFormat::R8G8B8A8_UNORM, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
-					}
+					data.m_samplers.Add("clearcoatNormalSampler",
+						CreateTextureAsset(materialName + "_clearcoatNormalTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_UNORM, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 				}
 				data.m_uniformsFloat.Add("material.clearcoatNormalScale", (float)scale);
 			}
@@ -831,52 +3466,41 @@ void ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 		}
 
 		auto sheenIt = material.extensions.find("KHR_materials_sheen");
-		if (sheenIt != material.extensions.end())
+		if (sheenIt != material.extensions.end() &&
+			sheenIt->second.IsObject())
 		{
 			const tinygltf::Value& sheen = sheenIt->second;
 
 			glm::vec3 color = glm::vec3(0.0f);
-			if (sheen.Has("sheenColorFactor"))
-			{
-				auto arr = sheen.Get("sheenColorFactor").Get<tinygltf::Value::Array>();
-				color = glm::vec3((float)arr[0].GetNumberAsDouble(), (float)arr[1].GetNumberAsDouble(), (float)arr[2].GetNumberAsDouble());
-			}
+			tryReadVec3Property(sheen, "sheenColorFactor", color);
 
 			double roughness = 0.0;
-			if (sheen.Has("sheenRoughnessFactor"))
-			{
-				roughness = sheen.Get("sheenRoughnessFactor").GetNumberAsDouble();
-			}
+			tryReadNumberProperty(
+				sheen,
+				"sheenRoughnessFactor",
+				roughness);
 
 			data.m_uniformsVec4.Add("material.sheenColorFactor", glm::vec4(color, 0.0f));
 			data.m_uniformsFloat.Add("material.sheenRoughnessFactor", (float)roughness);
 
-			if (sheen.Has("sheenColorTexture"))
+			textureIndex = -1;
+			if (tryReadTextureIndex(
+				sheen,
+				"sheenColorTexture",
+				textureIndex))
 			{
-				const tinygltf::Value& tex = sheen.Get("sheenColorTexture");
-				if (tex.Has("index"))
-				{
-					int idx = tex.Get("index").Get<int>();
-					if (idx != -1)
-					{
-						data.m_samplers.Add("sheenColorSampler",
-							CreateTextureAsset(materialName + "_sheenColorTexture.png.asset", assetInfo->GetAssetFilename(), idx, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
-					}
-				}
+				data.m_samplers.Add("sheenColorSampler",
+					CreateTextureAsset(materialName + "_sheenColorTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 			}
 
-			if (sheen.Has("sheenRoughnessTexture"))
+			textureIndex = -1;
+			if (tryReadTextureIndex(
+				sheen,
+				"sheenRoughnessTexture",
+				textureIndex))
 			{
-				const tinygltf::Value& tex = sheen.Get("sheenRoughnessTexture");
-				if (tex.Has("index"))
-				{
-					int idx = tex.Get("index").Get<int>();
-					if (idx != -1)
-					{
-						data.m_samplers.Add("sheenRoughnessSampler",
-							CreateTextureAsset(materialName + "_sheenRoughnessTexture.png.asset", assetInfo->GetAssetFilename(), idx, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
-					}
-				}
+				data.m_samplers.Add("sheenRoughnessSampler",
+					CreateTextureAsset(materialName + "_sheenRoughnessTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 			}
 
 			data.m_shaderDefines.Add("SHEEN");
@@ -917,45 +3541,80 @@ void ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 			RHI::EFillMode::Fill);
 
 		data.m_shader = App::GetSubmodule<AssetRegistry>()->GetOrLoadFile("Shaders/Standard_glTF.shader");
-	}
-
-	TVector<FileId> materialFiles;
-
-	for (const auto& material : materials)
-	{
-		std::filesystem::path materialsFolder;
-		if (!App::GetSubmodule<AssetRegistry>()->ResolveWorkspaceContentPathForWrite(
-				texturesFolder + "materials",
-				materialsFolder))
+		for (const auto& sampler : data.m_samplers)
 		{
-			SAILOR_LOG_ERROR("Cannot resolve generated materials folder for %s.", assetInfo->GetAssetFilepath().c_str());
-			continue;
-		}
-		std::filesystem::create_directories(materialsFolder);
-
-		FileId materialFileId = App::GetSubmodule<MaterialImporter>()->CreateMaterialAsset(
-			(materialsFolder / (material.m_name + ".mat")).string(),
-			material);
-		materialFiles.Add(materialFileId);
-	}
-
-	if (assetInfo->ShouldBatchByMaterial())
-	{
-		for (const auto& materialFileId : materialFiles)
-		{
-			assetInfo->GetDefaultMaterials().Add(materialFileId);
-		}
-	}
-	else
-	{
-		for (const auto& mesh : gltfModel.meshes)
-		{
-			for (const auto& primitive : mesh.primitives)
+			if (sampler.m_second == nullptr || !*sampler.m_second)
 			{
-				assetInfo->GetDefaultMaterials().Add(materialFiles[primitive.material]);
+				SAILOR_LOG_ERROR(
+					"Cannot create generated texture metadata for %s.",
+					assetInfo->GetAssetFilepath().c_str());
+				return false;
 			}
 		}
 	}
+
+	std::filesystem::path materialsFolder;
+	if (!App::GetSubmodule<AssetRegistry>()->ResolveWorkspaceContentPathForWrite(
+			texturesFolder + "materials",
+			materialsFolder))
+	{
+		SAILOR_LOG_ERROR("Cannot resolve generated materials folder for %s.", assetInfo->GetAssetFilepath().c_str());
+		return false;
+	}
+	std::error_code directoryError;
+	std::filesystem::create_directories(materialsFolder, directoryError);
+	if (directoryError)
+	{
+		SAILOR_LOG_ERROR("Cannot create generated materials folder for %s: %s",
+			assetInfo->GetAssetFilepath().c_str(),
+			directoryError.message().c_str());
+		return false;
+	}
+
+	TVector<FileId> materialFiles;
+	materialFiles.Reserve(materials.Num());
+	for (size_t i = 0; i < materials.Num(); ++i)
+	{
+		const MaterialAsset::Data& material = materials[i];
+
+		const FileId materialFileId = App::GetSubmodule<MaterialImporter>()->CreateMaterialAsset(
+			(materialsFolder /
+				(assetInfo->GetAssetFilename() + "_material_" +
+					std::to_string(i) + ".mat")).string(),
+			material);
+		if (!materialFileId)
+		{
+			return false;
+		}
+		materialFiles.Add(materialFileId);
+	}
+
+	TVector<FileId> generatedMaterials;
+	if (assetInfo->ShouldBatchByMaterial())
+	{
+		generatedMaterials = std::move(materialFiles);
+	}
+	else
+	{
+		for (const tinygltf::Mesh& mesh : gltfModel.meshes)
+		{
+			for (const tinygltf::Primitive& primitive : mesh.primitives)
+			{
+				if (primitive.material < 0 ||
+					static_cast<size_t>(primitive.material) >= materialFiles.Num())
+				{
+					SAILOR_LOG_ERROR(
+						"Cannot resolve primitive material for %s.",
+						assetInfo->GetAssetFilepath().c_str());
+					return false;
+				}
+				generatedMaterials.Add(materialFiles[primitive.material]);
+			}
+		}
+	}
+
+	assetInfo->GetDefaultMaterials() = std::move(generatedMaterials);
+	return true;
 }
 
 Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel)
@@ -970,7 +3629,9 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 	// Check loaded assets
 	if (loadedModel)
 	{
-		const bool bNeedCpuBuffers = pAssetInfo && pAssetInfo->ShouldKeepCpuBuffers() && !loadedModel->HasCpuMeshes();
+		const bool bNeedCpuBuffers = pAssetInfo &&
+			pAssetInfo->ShouldKeepCpuBuffers() &&
+			!loadedModel->HasCpuMeshes();
 		if (bNeedCpuBuffers && !promise)
 		{
 			loadedModel = nullptr;
@@ -1027,11 +3688,20 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 							pModel->m_cpuMeshes.Reserve(pData->m_parsedMeshes.Num());
 						}
 
-						for (auto& mesh : pData->m_parsedMeshes)
+						for (size_t meshIndex = 0;
+							meshIndex < pData->m_parsedMeshes.Num();
+							++meshIndex)
 						{
+							auto& mesh = pData->m_parsedMeshes[meshIndex];
+							if (!mesh.HasGeometry())
+							{
+								continue;
+							}
+
 							RHI::RHIMeshPtr pMesh = RHI::Renderer::GetDriver()->CreateMesh();
 							pMesh->m_vertexDescription = RHI::Renderer::GetDriver()->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4I4W4>();
 							pMesh->m_bounds = mesh.bounds;
+							pMesh->m_materialIndex = static_cast<uint32_t>(meshIndex);
 							RHI::Renderer::GetDriver()->UpdateMesh(pMesh,
 								mesh.outVertices.GetData(), sizeof(RHI::VertexP3N3T3B3UV2C4I4W4) * mesh.outVertices.Num(),
 								mesh.outIndices.GetData(), sizeof(uint32_t) * mesh.outIndices.Num());
@@ -1056,13 +3726,13 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 					return pModel;
 				}, "Update RHI Meshes", EThreadType::RHI)->ToTaskWithResult();
 
-			outModel = loadedModel = pModel;
-			promise->Run();
+		outModel = loadedModel = pModel;
+		promise->Run();
 
-			m_loadedModels.Unlock(uid);
-			m_promises.Unlock(uid);
+		m_loadedModels.Unlock(uid);
+		m_promises.Unlock(uid);
 
-			return promise;
+		return promise;
 	}
 
 	outModel = nullptr;
@@ -1081,35 +3751,9 @@ bool ModelImporter::LoadModel_Immediate(FileId uid, ModelPtr& outModel)
 	return task->GetResult().IsValid();
 }
 
-void CalculateTangentBitangent(vec3& outTangent, vec3& outBitangent, const vec3* vert, const vec2* uv)
-{
-	vec3 edge1 = vert[1] - vert[0];
-	vec3 edge2 = vert[2] - vert[0];
-
-	vec2 deltaUV1 = uv[1] - uv[0];
-	vec2 deltaUV2 = uv[2] - uv[0];
-
-	float denominator = deltaUV1.x * deltaUV2.y - deltaUV2.x * deltaUV1.y;
-	if (abs(denominator) < 1e-6f)
-	{
-		return;
-	}
-
-	float f = 1.0f / denominator;
-
-	outTangent = vec3(
-		f * (deltaUV2.y * edge1.x - deltaUV1.y * edge2.x),
-		f * (deltaUV2.y * edge1.y - deltaUV1.y * edge2.y),
-		f * (deltaUV2.y * edge1.z - deltaUV1.y * edge2.z)
-	);
-
-	vec3 normal = cross(edge1, edge2);
-	outBitangent = normalize(cross(normal, outTangent));
-	outTangent = normalize(outTangent);
-}
 static glm::vec3 CalculateNormal(const glm::vec3& v0, const glm::vec3& v1, const glm::vec3& v2)
 {
-	return glm::normalize(glm::cross(v1 - v0, v2 - v0));
+	return Math::SafeNormalize(glm::cross(v1 - v0, v2 - v0));
 }
 
 static void GenerateTangents(ModelImporter::MeshContext& meshContext,
@@ -1133,8 +3777,9 @@ static void GenerateTangents(ModelImporter::MeshContext& meshContext,
 					meshContext.outVertices[idx1].m_texcoord,
 					meshContext.outVertices[idx2].m_texcoord };
 
-			glm::vec3 t, b;
-			CalculateTangentBitangent(t, b, verts, uvs);
+				glm::vec3 t(0.0f);
+				glm::vec3 b(0.0f);
+				Raytracing::GenerateTangentBitangent(t, b, verts, uvs);
 
 			tangents[idx0 - vertexOffset] += t;
 			tangents[idx1 - vertexOffset] += t;
@@ -1168,8 +3813,10 @@ static void GenerateTangents(ModelImporter::MeshContext& meshContext,
 
 	for (uint32_t i = 0; i < vertexCount; ++i)
 	{
-		meshContext.outVertices[vertexOffset + i].m_tangent = glm::normalize(tangents[i]);
-		meshContext.outVertices[vertexOffset + i].m_bitangent = glm::normalize(bitangents[i]);
+		meshContext.outVertices[vertexOffset + i].m_tangent =
+			Math::SafeNormalize(tangents[i]);
+		meshContext.outVertices[vertexOffset + i].m_bitangent =
+			Math::SafeNormalize(bitangents[i]);
 	}
 }
 
@@ -1214,7 +3861,8 @@ static void GenerateNormals(ModelImporter::MeshContext& meshContext,
 
 	for (uint32_t i = 0; i < vertexCount; ++i)
 	{
-		meshContext.outVertices[vertexOffset + i].m_normal = glm::normalize(normals[i]);
+		meshContext.outVertices[vertexOffset + i].m_normal =
+			Math::SafeNormalize(normals[i], glm::vec3(0.0f, 1.0f, 0.0f));
 	}
 }
 
@@ -1241,14 +3889,29 @@ bool ModelImporter::ImportModel(
 	TVector<glm::mat4>& outInverseBind,
 	tinygltf::Model* outGltfModel)
 {
+	outParsedMeshes.Clear();
+	outBoundsAabb = Math::AABB();
+	outBoundsSphere = Math::Sphere();
+	outInverseBind.Clear();
+	if (outGltfModel != nullptr)
+	{
+		*outGltfModel = tinygltf::Model();
+	}
+
+	if (!std::isfinite(unitScale))
+	{
+		return false;
+	}
+
 	tinygltf::Model gltfModel;
-	tinygltf::TinyGLTF loader;
 	std::string err;
 	std::string warn;
-
-	const bool bGltfParsed = (Utils::GetFileExtension(assetFilepath.c_str()) == "glb") ?
-		loader.LoadBinaryFromFile(&gltfModel, &err, &warn, assetFilepath.c_str())
-		: loader.LoadASCIIFromFile(&gltfModel, &err, &warn, assetFilepath.c_str());
+	const bool bGltfParsed = GltfImporterUtils::LoadModel(
+		assetFilepath,
+		true,
+		gltfModel,
+		err,
+		warn);
 
 	if (!err.empty())
 	{
@@ -1265,292 +3928,530 @@ bool ModelImporter::ImportModel(
 		return false;
 	}
 
-	outBoundsAabb.m_max = glm::vec3(std::numeric_limits<float>::lowest());
-	outBoundsAabb.m_min = glm::vec3(std::numeric_limits<float>::max());
-
-	outInverseBind.Clear();
+	TVector<glm::mat4> parsedInverseBind;
 	if (!gltfModel.skins.empty())
 	{
 		const auto& gltfSkin = gltfModel.skins[0];
-		size_t numBones = gltfSkin.joints.size();
-		outInverseBind.Resize(numBones);
+		const size_t numBones = gltfSkin.joints.size();
+		parsedInverseBind.Resize(numBones);
+		for (size_t i = 0; i < numBones; ++i)
+		{
+			parsedInverseBind[i] = glm::mat4(1.0f);
+		}
 
+		GltfAccessorView inverseBindView;
 		if (gltfSkin.inverseBindMatrices >= 0)
 		{
-			const auto& accessor = gltfModel.accessors[gltfSkin.inverseBindMatrices];
-			const auto& view = gltfModel.bufferViews[accessor.bufferView];
-			const float* data = reinterpret_cast<const float*>(&gltfModel.buffers[view.buffer].data[view.byteOffset + accessor.byteOffset]);
+			if (!TryGetAccessorView(
+				gltfModel,
+				gltfSkin.inverseBindMatrices,
+				TINYGLTF_TYPE_MAT4,
+				numBones,
+				inverseBindView) ||
+				!IsFloatAccessor(*inverseBindView.m_accessor))
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot import invalid inverse-bind accessor: %s",
+					assetFilepath.c_str());
+				return false;
+			}
+
 			for (size_t i = 0; i < numBones; ++i)
 			{
-				outInverseBind[i] = glm::make_mat4(data + i * 16);
+				for (size_t component = 0; component < 16; ++component)
+				{
+					parsedInverseBind[i][static_cast<int32_t>(component / 4)]
+						[static_cast<int32_t>(component % 4)] =
+						ReadAccessorFloat(inverseBindView, i, component);
+				}
+
+				for (int32_t column = 0; column < 4; ++column)
+				{
+					if (!Math::AllFinite(parsedInverseBind[i][column]))
+					{
+						SAILOR_LOG_ERROR(
+							"Cannot import non-finite inverse-bind matrix: %s",
+							assetFilepath.c_str());
+						return false;
+					}
+				}
 			}
-		}
-		else
-		{
-			for (size_t i = 0; i < numBones; ++i) outInverseBind[i] = glm::mat4(1.0f);
 		}
 	}
 
-	// At least one batch
-	TVector<MeshContext> batchedMeshContexts(std::max<size_t>(1, gltfModel.materials.size()));
-
-	for (const auto& mesh : gltfModel.meshes)
+	if (gltfModel.materials.size() == std::numeric_limits<size_t>::max())
 	{
-		for (const auto& primitive : mesh.primitives)
-		{
-			MeshContext* pMeshContext = nullptr;
-			uint32_t startIndex = 0;
-			uint32_t indicesStart = 0;
+		return false;
+	}
 
-			if (bShouldBatchByMaterial)
+	const bool bHasMeshQuantization =
+		HasGltfExtension(gltfModel, "KHR_mesh_quantization");
+	TVector<GltfImporterUtils::MeshInstance> meshInstances;
+	if (!GltfImporterUtils::CollectMeshInstances(
+			gltfModel,
+			meshInstances))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot resolve glTF mesh instances: %s",
+			assetFilepath.c_str());
+		return false;
+	}
+
+	const size_t materialBatchCount =
+		(std::max)(static_cast<size_t>(1), gltfModel.materials.size());
+	TVector<MeshContext> batchedMeshContexts;
+	TVector<uint32_t> meshPrimitiveOffsets;
+	if (bShouldBatchByMaterial)
+	{
+		batchedMeshContexts.Resize(materialBatchCount);
+	}
+	else
+	{
+		meshPrimitiveOffsets.Resize(gltfModel.meshes.size());
+		uint32_t primitiveCount = 0;
+		for (size_t meshIndex = 0;
+			meshIndex < gltfModel.meshes.size();
+			++meshIndex)
+		{
+			const tinygltf::Mesh& mesh = gltfModel.meshes[meshIndex];
+			meshPrimitiveOffsets[meshIndex] = primitiveCount;
+			if (mesh.primitives.size() >
+				std::numeric_limits<uint32_t>::max() - primitiveCount)
 			{
-				pMeshContext = &batchedMeshContexts[std::max(primitive.material, 0)];
-				startIndex = (uint32_t)pMeshContext->outVertices.Num();
-				indicesStart = (uint32_t)pMeshContext->outIndices.Num();
-				pMeshContext->materialIndex = primitive.material;
+				return false;
+			}
+			primitiveCount +=
+				static_cast<uint32_t>(mesh.primitives.size());
+		}
+
+		outParsedMeshes.Resize(primitiveCount);
+		for (size_t meshIndex = 0;
+			meshIndex < gltfModel.meshes.size();
+			++meshIndex)
+		{
+			const tinygltf::Mesh& mesh = gltfModel.meshes[meshIndex];
+			for (size_t primitiveIndex = 0;
+				primitiveIndex < mesh.primitives.size();
+				++primitiveIndex)
+			{
+				const int32_t materialIndex =
+					mesh.primitives[primitiveIndex].material;
+				outParsedMeshes[
+					meshPrimitiveOffsets[meshIndex] + primitiveIndex]
+					.materialIndex = materialIndex >= 0 &&
+					static_cast<size_t>(materialIndex) <
+						gltfModel.materials.size() ? materialIndex : -1;
+			}
+		}
+	}
+
+	for (const GltfImporterUtils::MeshInstance& instance : meshInstances)
+	{
+		if (instance.m_skinIndex > 0)
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot import unsupported active glTF skin index %d; only skin 0 is supported: %s",
+				instance.m_skinIndex,
+				assetFilepath.c_str());
+			return false;
+		}
+
+		const size_t meshIndex = static_cast<size_t>(instance.m_meshIndex);
+		const tinygltf::Mesh& mesh = gltfModel.meshes[meshIndex];
+		// glTF explicitly ignores the mesh-node transform for skinned meshes.
+		// Static mesh instances are flattened into Model geometry because Sailor
+		// has one world transform for the complete Model.
+		const glm::mat4 geometryTransform =
+			glm::scale(glm::mat4(1.0f), glm::vec3(unitScale)) *
+			(instance.m_skinIndex >= 0 ?
+				glm::mat4(1.0f) : instance.m_worldTransform);
+		const glm::mat3 directionTransform(geometryTransform);
+		const float transformDeterminant =
+			glm::determinant(directionTransform);
+		if (!std::isfinite(transformDeterminant))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot import glTF mesh instance with invalid transform: %s",
+				assetFilepath.c_str());
+			return false;
+		}
+
+		const bool bReverseWinding = transformDeterminant < 0.0f;
+		glm::mat3 normalTransform = directionTransform;
+		if (transformDeterminant != 0.0f)
+		{
+			const glm::mat3 inverseTranspose =
+				glm::transpose(glm::inverse(directionTransform));
+			if (IsFiniteGltfMatrix(inverseTranspose))
+			{
+				normalTransform = inverseTranspose;
+			}
+		}
+
+		for (size_t primitiveIndex = 0;
+			primitiveIndex < mesh.primitives.size();
+			++primitiveIndex)
+		{
+			const tinygltf::Primitive& primitive =
+				mesh.primitives[primitiveIndex];
+			const int32_t materialIndex = primitive.material >= 0 &&
+				static_cast<size_t>(primitive.material) < gltfModel.materials.size() ?
+				primitive.material : -1;
+			MeshContext* pPrimitiveMeshContext = nullptr;
+			if (!bShouldBatchByMaterial)
+			{
+				pPrimitiveMeshContext = &outParsedMeshes[
+					meshPrimitiveOffsets[meshIndex] + primitiveIndex];
+			}
+
+			if (primitive.mode != TINYGLTF_MODE_TRIANGLES)
+			{
+				SAILOR_LOG(
+					"Skipping non-triangle glTF primitive in %s.",
+					assetFilepath.c_str());
+				continue;
+			}
+
+			const auto positionIt = primitive.attributes.find("POSITION");
+			GltfAccessorView positionView;
+			if (positionIt == primitive.attributes.end() ||
+				!TryGetAccessorView(
+					gltfModel,
+					positionIt->second,
+					TINYGLTF_TYPE_VEC3,
+					1,
+					positionView) ||
+				positionView.m_accessor->count >
+					std::numeric_limits<uint32_t>::max() ||
+				!IsPositionAccessorSupported(
+					*positionView.m_accessor,
+					bHasMeshQuantization))
+			{
+				SAILOR_LOG_ERROR(
+					"Skipping glTF primitive with unsupported POSITION accessor: %s",
+					assetFilepath.c_str());
+				continue;
+			}
+
+			const size_t vertexCount = positionView.m_accessor->count;
+			auto tryGetAttribute = [&](const char* semantic,
+				int32_t expectedType,
+				GltfAccessorView& outView)
+				{
+					const auto it = primitive.attributes.find(semantic);
+					return it != primitive.attributes.end() &&
+						TryGetAccessorView(
+							gltfModel,
+							it->second,
+							expectedType,
+							vertexCount,
+							outView) &&
+						outView.m_accessor->count == vertexCount;
+				};
+
+			GltfAccessorView normalView;
+			GltfAccessorView texcoordView;
+			GltfAccessorView tangentView;
+			GltfAccessorView colorView;
+			GltfAccessorView jointsView;
+			GltfAccessorView weightsView;
+
+			const bool bNormalsPresent =
+				primitive.attributes.find("NORMAL") !=
+				primitive.attributes.end();
+			const bool bTexcoordsPresent =
+				primitive.attributes.find("TEXCOORD_0") !=
+				primitive.attributes.end();
+			const bool bTangentsPresent =
+				primitive.attributes.find("TANGENT") !=
+				primitive.attributes.end();
+			const bool bJointsPresent =
+				primitive.attributes.find("JOINTS_0") !=
+				primitive.attributes.end();
+			const bool bWeightsPresent =
+				primitive.attributes.find("WEIGHTS_0") !=
+				primitive.attributes.end();
+
+			const bool bHasNormals = bNormalsPresent &&
+				tryGetAttribute("NORMAL", TINYGLTF_TYPE_VEC3, normalView);
+			const bool bHasTexcoords = bTexcoordsPresent &&
+				tryGetAttribute("TEXCOORD_0", TINYGLTF_TYPE_VEC2, texcoordView);
+			const bool bHasTangents = bTangentsPresent &&
+				tryGetAttribute("TANGENT", TINYGLTF_TYPE_VEC4, tangentView);
+			const bool bHasJoints = bJointsPresent &&
+				tryGetAttribute("JOINTS_0", TINYGLTF_TYPE_VEC4, jointsView);
+			const bool bHasWeights = bWeightsPresent &&
+				tryGetAttribute("WEIGHTS_0", TINYGLTF_TYPE_VEC4, weightsView);
+
+			const auto colorIt = primitive.attributes.find("COLOR_0");
+			const bool bColorPresent = colorIt != primitive.attributes.end();
+			const bool bHasColor = bColorPresent &&
+				TryGetAccessorView(
+					gltfModel,
+					colorIt->second,
+					-1,
+					vertexCount,
+					colorView) &&
+				colorView.m_accessor->count == vertexCount &&
+				(colorView.m_accessor->type == TINYGLTF_TYPE_VEC3 ||
+					colorView.m_accessor->type == TINYGLTF_TYPE_VEC4);
+
+			if ((bNormalsPresent &&
+				 (!bHasNormals ||
+				  !IsDirectionAccessorSupported(
+					  *normalView.m_accessor,
+					  bHasMeshQuantization))) ||
+				(bTexcoordsPresent &&
+				 (!bHasTexcoords ||
+				  !IsTexcoordAccessorSupported(
+					  *texcoordView.m_accessor,
+					  bHasMeshQuantization))) ||
+				(bTangentsPresent &&
+				 (!bHasTangents ||
+				  !IsDirectionAccessorSupported(
+					  *tangentView.m_accessor,
+					  bHasMeshQuantization))) ||
+				(bColorPresent &&
+				 (!bHasColor ||
+				  !IsColorAccessorSupported(*colorView.m_accessor))) ||
+				bJointsPresent != bWeightsPresent ||
+				(bJointsPresent &&
+				 (!bHasJoints || !bHasWeights ||
+				  !IsJointsAccessorSupported(*jointsView.m_accessor) ||
+				  !IsWeightsAccessorSupported(*weightsView.m_accessor))))
+			{
+				SAILOR_LOG_ERROR(
+					"Skipping glTF primitive with invalid vertex attributes: %s",
+					assetFilepath.c_str());
+				continue;
+			}
+
+			TVector<uint32_t> localIndices;
+			if (primitive.indices >= 0)
+			{
+				GltfAccessorView indexView;
+				if (!TryGetAccessorView(
+						gltfModel,
+						primitive.indices,
+						TINYGLTF_TYPE_SCALAR,
+						1,
+						indexView) ||
+					indexView.m_accessor->count >
+						std::numeric_limits<uint32_t>::max() ||
+					indexView.m_accessor->normalized)
+				{
+					SAILOR_LOG_ERROR(
+						"Skipping glTF primitive with unsupported index accessor: %s",
+						assetFilepath.c_str());
+					continue;
+				}
+
+				localIndices.Reserve(indexView.m_accessor->count);
+				bool bIndicesValid = true;
+				for (size_t i = 0; i < indexView.m_accessor->count; ++i)
+				{
+					uint32_t index = 0;
+					if (!TryReadAccessorIndex(indexView, i, index) ||
+						index >= vertexCount)
+					{
+						bIndicesValid = false;
+						break;
+					}
+
+					localIndices.Add(index);
+				}
+
+				if (!bIndicesValid)
+				{
+					SAILOR_LOG_ERROR(
+						"Skipping glTF primitive with out-of-range indices: %s",
+						assetFilepath.c_str());
+					continue;
+				}
 			}
 			else
 			{
-				outParsedMeshes.Add(MeshContext());
-				pMeshContext = &(*outParsedMeshes.Last());
-				indicesStart = (uint32_t)pMeshContext->outIndices.Num();
-				pMeshContext->materialIndex = primitive.material;
-			}
-
-			const tinygltf::Accessor& posAccessor = gltfModel.accessors[primitive.attributes.find("POSITION")->second];
-			const tinygltf::BufferView& posView = gltfModel.bufferViews[std::max(0, posAccessor.bufferView)];
-			const float* posData = reinterpret_cast<const float*>(&gltfModel.buffers[posView.buffer].data[posView.byteOffset + posAccessor.byteOffset]);
-
-
-			const tinygltf::Accessor* normAccessor = nullptr;
-			const tinygltf::BufferView* normView = nullptr;
-			const float* normData = nullptr;
-
-			if (primitive.attributes.find("NORMAL") != primitive.attributes.end())
-			{
-				normAccessor = &gltfModel.accessors[primitive.attributes.find("NORMAL")->second];
-				normView = &gltfModel.bufferViews[(std::max)(0, normAccessor->bufferView)];
-				normData = reinterpret_cast<const float*>(&gltfModel.buffers[normView->buffer].data[normView->byteOffset + normAccessor->byteOffset]);
-			}
-
-			const bool bGenerateNormals = normData == nullptr;
-
-			const tinygltf::Accessor* texAccessor = nullptr;
-			const tinygltf::BufferView* texView = nullptr;
-			const float* texData = nullptr;
-
-			if (primitive.attributes.find("TEXCOORD_0") != primitive.attributes.end())
-			{
-				texAccessor = &gltfModel.accessors[primitive.attributes.find("TEXCOORD_0")->second];
-				texView = &gltfModel.bufferViews[std::max(0, texAccessor->bufferView)];
-				texData = reinterpret_cast<const float*>(&gltfModel.buffers[texView->buffer].data[texView->byteOffset + texAccessor->byteOffset]);
-			}
-
-			const tinygltf::Accessor* tanAccessor = nullptr;
-			const tinygltf::BufferView* tanView = nullptr;
-			const float* tanData = nullptr;
-
-			if (primitive.attributes.find("TANGENT") != primitive.attributes.end())
-			{
-				tanAccessor = &gltfModel.accessors[primitive.attributes.find("TANGENT")->second];
-				tanView = &gltfModel.bufferViews[std::max(0, tanAccessor->bufferView)];
-				tanData = reinterpret_cast<const float*>(&gltfModel.buffers[tanView->buffer].data[tanView->byteOffset + tanAccessor->byteOffset]);
-			}
-
-			const bool bGenerateTangents = tanData == nullptr;
-
-			const tinygltf::Accessor* colAccessor = nullptr;
-			const tinygltf::BufferView* colView = nullptr;
-			const float* colData = nullptr;
-
-			const tinygltf::Accessor* jointsAccessor = nullptr;
-			const tinygltf::BufferView* jointsView = nullptr;
-			const unsigned char* jointsData8 = nullptr;
-			const unsigned short* jointsData16 = nullptr;
-			const unsigned int* jointsData32 = nullptr;
-
-			const tinygltf::Accessor* weightsAccessor = nullptr;
-			const tinygltf::BufferView* weightsView = nullptr;
-			const float* weightsDataF = nullptr;
-			const unsigned char* weightsData8 = nullptr;
-			const unsigned short* weightsData16 = nullptr;
-
-			if (primitive.attributes.find("COLOR_0") != primitive.attributes.end())
-			{
-				colAccessor = &gltfModel.accessors[primitive.attributes.find("COLOR_0")->second];
-				colView = &gltfModel.bufferViews[std::max(0, colAccessor->bufferView)];
-				colData = reinterpret_cast<const float*>(&gltfModel.buffers[colView->buffer].data[colView->byteOffset + colAccessor->byteOffset]);
-			}
-
-			if (primitive.attributes.find("JOINTS_0") != primitive.attributes.end())
-			{
-				jointsAccessor = &gltfModel.accessors[primitive.attributes.find("JOINTS_0")->second];
-				jointsView = &gltfModel.bufferViews[std::max(0, jointsAccessor->bufferView)];
-				const unsigned char* ptr = reinterpret_cast<const unsigned char*>(&gltfModel.buffers[jointsView->buffer].data[jointsView->byteOffset + jointsAccessor->byteOffset]);
-				if (jointsAccessor->componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE)
+				localIndices.Reserve(vertexCount);
+				for (uint32_t i = 0; i < vertexCount; ++i)
 				{
-					jointsData8 = ptr;
-				}
-				else if (jointsAccessor->componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT)
-				{
-					jointsData16 = reinterpret_cast<const unsigned short*>(ptr);
-				}
-				else
-				{
-					jointsData32 = reinterpret_cast<const unsigned int*>(ptr);
+					localIndices.Add(i);
 				}
 			}
 
-			if (primitive.attributes.find("WEIGHTS_0") != primitive.attributes.end())
+			if (localIndices.Num() == 0 || localIndices.Num() % 3 != 0)
 			{
-				weightsAccessor = &gltfModel.accessors[primitive.attributes.find("WEIGHTS_0")->second];
-				weightsView = &gltfModel.bufferViews[std::max(0, weightsAccessor->bufferView)];
-				const unsigned char* ptr = reinterpret_cast<const unsigned char*>(&gltfModel.buffers[weightsView->buffer].data[weightsView->byteOffset + weightsAccessor->byteOffset]);
-				if (weightsAccessor->componentType == TINYGLTF_COMPONENT_TYPE_FLOAT)
+				SAILOR_LOG_ERROR(
+					"Skipping glTF primitive with invalid triangle indices: %s",
+					assetFilepath.c_str());
+				continue;
+			}
+			if (bReverseWinding)
+			{
+				for (size_t i = 0; i < localIndices.Num(); i += 3)
 				{
-					weightsDataF = reinterpret_cast<const float*>(ptr);
-				}
-				else if (weightsAccessor->componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_BYTE)
-				{
-					weightsData8 = ptr;
-				}
-				else if (weightsAccessor->componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT)
-				{
-					weightsData16 = reinterpret_cast<const unsigned short*>(ptr);
+					std::swap(localIndices[i + 1], localIndices[i + 2]);
 				}
 			}
 
-			const uint32_t colSize = (colAccessor && colAccessor->type == TINYGLTF_PARAMETER_TYPE_FLOAT_VEC3) ? 3 : 4;
-
-			for (size_t i = 0; i < posAccessor.count; ++i)
+			TVector<RHI::VertexP3N3T3B3UV2C4I4W4> localVertices;
+			localVertices.Reserve(vertexCount);
+			bool bVerticesValid = true;
+			for (size_t i = 0; i < vertexCount; ++i)
 			{
-				Sailor::RHI::VertexP3N3T3B3UV2C4I4W4 vertex{};
+				RHI::VertexP3N3T3B3UV2C4I4W4 vertex{};
+				const glm::vec3 sourcePosition(
+					ReadAccessorFloat(positionView, i, 0),
+					ReadAccessorFloat(positionView, i, 1),
+					ReadAccessorFloat(positionView, i, 2));
+				vertex.m_position = glm::vec3(
+					geometryTransform * glm::vec4(sourcePosition, 1.0f));
+				const glm::vec3 sourceNormal = bHasNormals ?
+					glm::vec3(
+						ReadAccessorFloat(normalView, i, 0),
+						ReadAccessorFloat(normalView, i, 1),
+						ReadAccessorFloat(normalView, i, 2)) :
+					glm::vec3(0.0f);
+				vertex.m_normal = normalTransform * sourceNormal;
+				vertex.m_texcoord = bHasTexcoords ?
+					glm::vec2(
+						ReadAccessorFloat(texcoordView, i, 0),
+						ReadAccessorFloat(texcoordView, i, 1)) :
+					glm::vec2(0.0f);
+				const glm::vec3 sourceTangent = bHasTangents ?
+					glm::vec3(
+						ReadAccessorFloat(tangentView, i, 0),
+						ReadAccessorFloat(tangentView, i, 1),
+						ReadAccessorFloat(tangentView, i, 2)) :
+					glm::vec3(0.0f);
+				vertex.m_tangent = directionTransform * sourceTangent;
+				vertex.m_bitangent = bHasTangents && bHasNormals ?
+					directionTransform *
+						(glm::cross(sourceNormal, sourceTangent) *
+							ReadAccessorFloat(tangentView, i, 3)) :
+					glm::vec3(0.0f);
+				vertex.m_color = glm::vec4(1.0f);
+				if (bHasColor)
+				{
+					vertex.m_color = glm::vec4(
+						ReadAccessorFloat(colorView, i, 0),
+						ReadAccessorFloat(colorView, i, 1),
+						ReadAccessorFloat(colorView, i, 2),
+						colorView.m_accessor->type == TINYGLTF_TYPE_VEC4 ?
+							ReadAccessorFloat(colorView, i, 3) :
+							1.0f);
+				}
+
 				vertex.m_boneIds = glm::ivec4(0);
+				if (bHasJoints)
+				{
+					for (size_t component = 0; component < 4; ++component)
+					{
+						vertex.m_boneIds[static_cast<int32_t>(component)] =
+							static_cast<int32_t>(
+							ReadAccessorFloat(jointsView, i, component));
+					}
+				}
+
 				vertex.m_boneWeights = glm::vec4(0.0f);
-				vertex.m_position = glm::make_vec3(posData + i * 3) * unitScale;
-
-				if (normData)
+				if (bHasWeights)
 				{
-					vertex.m_normal = glm::make_vec3(normData + i * 3);
-				}
-				else
-				{
-					vertex.m_normal = glm::vec3(0.0f);
-				}
-
-				if (colData)
-				{
-					vertex.m_color.x = colData[i * colSize];
-					vertex.m_color.y = colData[i * colSize + 1];
-					vertex.m_color.z = colData[i * colSize + 2];
-					vertex.m_color.w = colSize == 4 ? colData[i * 3 + 3] : 1.0f;
-				}
-				else
-				{
-					vertex.m_color = glm::vec4(1.0f);
-				}
-
-				if (texData)
-				{
-					vertex.m_texcoord = glm::make_vec2(texData + i * 2);
-				}
-
-				if (tanData)
-				{
-					vertex.m_tangent = glm::make_vec3(tanData + i * 3);
-				}
-				else
-				{
-					vertex.m_tangent = glm::vec3(0.0f);
-				}
-
-				vertex.m_bitangent = glm::vec3(0.0f);
-
-				if (jointsAccessor)
-				{
-					if (jointsData8)
+					for (size_t component = 0; component < 4; ++component)
 					{
-						const unsigned char* d = jointsData8 + i * 4;
-						vertex.m_boneIds = glm::ivec4(d[0], d[1], d[2], d[3]);
-					}
-					else if (jointsData16)
-					{
-						const unsigned short* d = jointsData16 + i * 4;
-						vertex.m_boneIds = glm::ivec4(d[0], d[1], d[2], d[3]);
-					}
-					else if (jointsData32)
-					{
-						const unsigned int* d = jointsData32 + i * 4;
-						vertex.m_boneIds = glm::ivec4(d[0], d[1], d[2], d[3]);
+						vertex.m_boneWeights[static_cast<int32_t>(component)] =
+							ReadAccessorFloat(weightsView, i, component);
 					}
 				}
 
-				if (weightsAccessor)
+				if (!Math::AllFinite(vertex.m_position) ||
+					!Math::AllFinite(vertex.m_normal) ||
+					!Math::AllFinite(vertex.m_texcoord) ||
+					!Math::AllFinite(vertex.m_tangent) ||
+					!Math::AllFinite(vertex.m_bitangent) ||
+					!Math::AllFinite(vertex.m_color) ||
+					!Math::AllFinite(vertex.m_boneWeights))
 				{
-					if (weightsDataF)
-					{
-						vertex.m_boneWeights = glm::make_vec4(weightsDataF + i * 4);
-					}
-					else if (weightsData8)
-					{
-						const unsigned char* d = weightsData8 + i * 4;
-						vertex.m_boneWeights = glm::vec4(d[0], d[1], d[2], d[3]) / 255.0f;
-					}
-					else if (weightsData16)
-					{
-						const unsigned short* d = weightsData16 + i * 4;
-						vertex.m_boneWeights = glm::vec4(d[0], d[1], d[2], d[3]) / 65535.0f;
-					}
+					bVerticesValid = false;
+					break;
 				}
 
+				localVertices.Add(vertex);
+			}
+
+			if (!bVerticesValid)
+			{
+				SAILOR_LOG_ERROR(
+					"Skipping glTF primitive with non-finite vertices: %s",
+					assetFilepath.c_str());
+				continue;
+			}
+
+			MeshContext* pMeshContext = pPrimitiveMeshContext;
+			if (bShouldBatchByMaterial)
+			{
+				const size_t batchIndex = materialIndex >= 0 ?
+					static_cast<size_t>(materialIndex) : 0;
+				pMeshContext = &batchedMeshContexts[batchIndex];
+			}
+
+			const size_t existingVertices = pMeshContext != nullptr ?
+				pMeshContext->outVertices.Num() : 0;
+			const size_t existingIndices = pMeshContext != nullptr ?
+				pMeshContext->outIndices.Num() : 0;
+			const size_t maxMeshElements =
+				std::numeric_limits<uint32_t>::max();
+			if (vertexCount > maxMeshElements - existingVertices ||
+				localIndices.Num() > maxMeshElements - existingIndices)
+			{
+				SAILOR_LOG_ERROR(
+					"Skipping oversized glTF primitive: %s",
+					assetFilepath.c_str());
+				continue;
+			}
+
+			const uint32_t startIndex =
+				static_cast<uint32_t>(pMeshContext->outVertices.Num());
+			const uint32_t indicesStart =
+				static_cast<uint32_t>(pMeshContext->outIndices.Num());
+			pMeshContext->materialIndex = materialIndex;
+
+			for (const auto& vertex : localVertices)
+			{
 				pMeshContext->outVertices.Add(vertex);
 				outBoundsAabb.Extend(vertex.m_position);
 				pMeshContext->bounds.Extend(vertex.m_position);
 			}
 
-			uint32_t indexCount = 0;
-			if (primitive.indices >= 0)
+			for (uint32_t index : localIndices)
 			{
-				const tinygltf::Accessor& indexAccessor = gltfModel.accessors[primitive.indices];
-				const tinygltf::BufferView& indexView = gltfModel.bufferViews[std::max(0, indexAccessor.bufferView)];
-
-				for (size_t i = 0; i < indexAccessor.count; ++i)
-				{
-					uint32_t index = indexAccessor.componentType == TINYGLTF_COMPONENT_TYPE_UNSIGNED_SHORT ?
-						(uint32_t)(reinterpret_cast<const uint16_t*>(&gltfModel.buffers[indexView.buffer].data[indexView.byteOffset + indexAccessor.byteOffset])[i])
-						: reinterpret_cast<const uint32_t*>(&gltfModel.buffers[indexView.buffer].data[indexView.byteOffset + indexAccessor.byteOffset])[i];
-
-					pMeshContext->outIndices.Add(index + startIndex);
-				}
-				indexCount = (uint32_t)indexAccessor.count;
-			}
-			else
-			{
-				// Always generate the index buffer
-				// Assume TRIANGLES mode
-				for (uint32_t i = 0; i < posAccessor.count; ++i)
-				{
-					pMeshContext->outIndices.Add(startIndex + i);
-				}
-				indexCount = (uint32_t)posAccessor.count;
+				pMeshContext->outIndices.Add(startIndex + index);
 			}
 
-			if (bGenerateNormals)
+			const uint32_t indexCount =
+				static_cast<uint32_t>(localIndices.Num());
+			if (!bHasNormals)
 			{
-				GenerateNormals(*pMeshContext, startIndex, (uint32_t)posAccessor.count, indicesStart, indexCount);
+				GenerateNormals(
+					*pMeshContext,
+					startIndex,
+					static_cast<uint32_t>(vertexCount),
+					indicesStart,
+					indexCount);
 			}
 
-			if (bGenerateTangents || bGenerateNormals)
+			if (!bHasTangents || !bHasNormals)
 			{
-				GenerateTangents(*pMeshContext, startIndex, (uint32_t)posAccessor.count, indicesStart, indexCount);
+				GenerateTangents(
+					*pMeshContext,
+					startIndex,
+					static_cast<uint32_t>(vertexCount),
+					indicesStart,
+					indexCount);
 			}
-			else
+
+			for (size_t i = 0; i < vertexCount; ++i)
 			{
-				for (size_t i = 0; i < posAccessor.count; ++i)
-				{
-					auto& v = pMeshContext->outVertices[startIndex + i];
-					v.m_bitangent = glm::cross(v.m_normal, v.m_tangent);
-				}
+				SanitizeVertexFrame(
+					pMeshContext->outVertices[startIndex + i]);
 			}
 		}
 	}
@@ -1559,19 +4460,41 @@ bool ModelImporter::ImportModel(
 	{
 		for (auto& meshContext : batchedMeshContexts)
 		{
-			outParsedMeshes.Emplace(meshContext);
+			outParsedMeshes.Emplace(std::move(meshContext));
 		}
 	}
 
-	outBoundsSphere.m_center = 0.5f * (outBoundsAabb.m_min + outBoundsAabb.m_max);
-	outBoundsSphere.m_radius = glm::distance(outBoundsAabb.m_max, outBoundsSphere.m_center);
+	bool bImported =
+		outParsedMeshes.Num() > 0 && outBoundsAabb.IsValid();
+	if (bImported)
+	{
+		outBoundsSphere.m_center =
+			0.5f * outBoundsAabb.m_min + 0.5f * outBoundsAabb.m_max;
+		outBoundsSphere.m_radius =
+			glm::distance(outBoundsAabb.m_max, outBoundsSphere.m_center);
+		bImported = Math::AllFinite(outBoundsSphere.m_center) &&
+			std::isfinite(outBoundsSphere.m_radius);
+	}
 
-	if (outGltfModel != nullptr)
+	if (!bImported)
+	{
+		outParsedMeshes.Clear();
+		outBoundsAabb = Math::AABB();
+		outBoundsSphere = Math::Sphere();
+		outInverseBind.Clear();
+	}
+
+	if (outGltfModel != nullptr && bImported)
 	{
 		*outGltfModel = std::move(gltfModel);
 	}
 
-	return true;
+	if (bImported)
+	{
+		outInverseBind = std::move(parsedInverseBind);
+	}
+
+	return bImported;
 }
 
 Tasks::TaskPtr<bool> ModelImporter::LoadDefaultMaterials(FileId uid, TVector<MaterialPtr>& outMaterials)

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -5,6 +5,7 @@
 #include <cmath>
 #include <cstring>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <mutex>
 #include <sstream>
@@ -24,6 +25,7 @@
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "ModelAssetInfo.h"
 #include "Core/Utils.h"
+#include "YamlExceptionBoundary.h"
 #include "Math/Math.h"
 #include "RHI/VertexDescription.h"
 #include "RHI/Types.h"
@@ -1863,6 +1865,378 @@ GltfImporterUtils::MeshInstanceTransforms GltfImporterUtils::ResolveMeshInstance
 	return result;
 }
 
+GltfImporterUtils::MaterialAlphaModeSettings GltfImporterUtils::ResolveMaterialAlphaMode(
+	const std::string& alphaMode,
+	bool bHasTransmission)
+{
+	if (bHasTransmission)
+	{
+		return {
+			"Transparent",
+			false,
+			alphaMode == "MASK",
+			alphaMode == "BLEND" ?
+				RHI::EBlendMode::AlphaBlending :
+				RHI::EBlendMode::None
+		};
+	}
+
+	if (alphaMode == "BLEND")
+	{
+		return {
+			"Transparent",
+			false,
+			false,
+			RHI::EBlendMode::AlphaBlending
+		};
+	}
+
+	if (alphaMode == "MASK")
+	{
+		return {
+			"Masked",
+			true,
+			true,
+			RHI::EBlendMode::None
+		};
+	}
+
+	return {};
+}
+
+GltfImporterUtils::MaterialTransmissionSettings GltfImporterUtils::ResolveMaterialTransmission(
+	const tinygltf::Material& material,
+	size_t numTextures,
+	float unitScale)
+{
+	MaterialTransmissionSettings result;
+	auto tryReadFiniteNumber = [](
+		const tinygltf::Value& object,
+		const char* property,
+		double& outValue)
+		{
+			if (!object.IsObject() || !object.Has(property))
+			{
+				return false;
+			}
+
+			const tinygltf::Value& value = object.Get(property);
+			if (!value.IsNumber())
+			{
+				return false;
+			}
+
+			const double parsedValue = value.GetNumberAsDouble();
+			if (!std::isfinite(parsedValue) ||
+				parsedValue > std::numeric_limits<float>::max() ||
+				parsedValue < -std::numeric_limits<float>::max())
+			{
+				return false;
+			}
+
+			outValue = parsedValue;
+			return true;
+		};
+
+	auto tryReadTextureIndex = [numTextures](
+		const tinygltf::Value& object,
+		const char* property,
+		int32_t& outIndex)
+		{
+			if (!object.IsObject() || !object.Has(property))
+			{
+				return false;
+			}
+
+			const tinygltf::Value& textureInfo = object.Get(property);
+			if (!textureInfo.IsObject() || !textureInfo.Has("index"))
+			{
+				return false;
+			}
+
+			const tinygltf::Value& indexValue = textureInfo.Get("index");
+			if (!indexValue.IsInt())
+			{
+				return false;
+			}
+
+			const int32_t index = indexValue.GetNumberAsInt();
+			if (index < 0 || static_cast<size_t>(index) >= numTextures)
+			{
+				return false;
+			}
+
+			outIndex = index;
+			return true;
+		};
+
+	const auto extensionIt = material.extensions.find(
+		"KHR_materials_transmission");
+	if (extensionIt == material.extensions.end() ||
+		!extensionIt->second.IsObject())
+	{
+		return result;
+	}
+
+	const tinygltf::Value& extension = extensionIt->second;
+	double parsedValue = 0.0;
+	if (tryReadFiniteNumber(
+			extension,
+			"transmissionFactor",
+			parsedValue))
+	{
+		result.m_factor = static_cast<float>(std::clamp(
+			parsedValue,
+			0.0,
+			1.0));
+	}
+
+	tryReadTextureIndex(
+		extension,
+		"transmissionTexture",
+		result.m_textureIndex);
+
+	const auto volumeIt = material.extensions.find(
+		"KHR_materials_volume");
+	if (volumeIt != material.extensions.end() &&
+		volumeIt->second.IsObject())
+	{
+		const tinygltf::Value& volume = volumeIt->second;
+		if (tryReadFiniteNumber(
+				volume,
+				"thicknessFactor",
+				parsedValue))
+		{
+			result.m_thicknessFactor = static_cast<float>(
+				(std::max)(0.0, parsedValue));
+		}
+
+		tryReadTextureIndex(
+			volume,
+			"thicknessTexture",
+			result.m_thicknessTextureIndex);
+
+		if (tryReadFiniteNumber(
+				volume,
+				"attenuationDistance",
+				parsedValue) &&
+			parsedValue > 0.0)
+		{
+			result.m_attenuationDistance = static_cast<float>(
+				parsedValue);
+		}
+
+		if (volume.Has("attenuationColor"))
+		{
+			const tinygltf::Value& color = volume.Get(
+				"attenuationColor");
+			if (color.IsArray() && color.ArrayLen() >= 3)
+			{
+				glm::vec3 parsedColor(1.0f);
+				bool bValidColor = true;
+				for (size_t component = 0; component < 3; ++component)
+				{
+					const tinygltf::Value& value = color.Get(component);
+					if (!value.IsNumber() ||
+						!std::isfinite(value.GetNumberAsDouble()))
+					{
+						bValidColor = false;
+						break;
+					}
+
+					parsedColor[static_cast<int32_t>(component)] =
+						static_cast<float>(std::clamp(
+							value.GetNumberAsDouble(),
+							0.0,
+							1.0));
+				}
+
+				if (bValidColor)
+				{
+					result.m_attenuationColor = parsedColor;
+				}
+			}
+		}
+	}
+
+	const auto iorIt = material.extensions.find("KHR_materials_ior");
+	if (iorIt != material.extensions.end() &&
+		tryReadFiniteNumber(iorIt->second, "ior", parsedValue))
+	{
+		result.m_indexOfRefraction = static_cast<float>(
+			(std::max)(1.0, parsedValue));
+	}
+
+	const double lengthScale = std::isfinite(unitScale) ?
+		std::abs(static_cast<double>(unitScale)) :
+		1.0;
+	auto scaleLength = [lengthScale](float value)
+		{
+			return static_cast<float>((std::min)(
+				static_cast<double>((std::numeric_limits<float>::max)()),
+				static_cast<double>(value) * lengthScale));
+		};
+
+	result.m_thicknessFactor = scaleLength(result.m_thicknessFactor);
+	if (result.m_attenuationDistance <
+		(std::numeric_limits<float>::max)())
+	{
+		result.m_attenuationDistance = scaleLength(
+			result.m_attenuationDistance);
+	}
+
+	return result;
+}
+
+bool GltfImporterUtils::MergeGeneratedMaterialProperties(
+	YAML::Node& inOutMaterial,
+	const YAML::Node& generatedProperties)
+{
+	if (!inOutMaterial.IsMap() || !generatedProperties.IsMap())
+	{
+		return false;
+	}
+
+	YAML::Node merged = YAML::Clone(inOutMaterial);
+	for (const char* property : {
+		"renderQueue",
+		"bEnableZWrite",
+		"bCustomDepthShader",
+		"blendMode" })
+	{
+		if (!generatedProperties[property] ||
+			!generatedProperties[property].IsScalar())
+		{
+			return false;
+		}
+		merged[property] = YAML::Clone(generatedProperties[property]);
+	}
+
+	auto isManagedDefine = [](const std::string& define)
+		{
+			return define == "TRANSMISSION" || define == "ALPHA_CUTOUT";
+		};
+
+	YAML::Node mergedDefines(YAML::NodeType::Sequence);
+	const YAML::Node existingDefines = merged["defines"];
+	if (existingDefines && !existingDefines.IsNull())
+	{
+		if (!existingDefines.IsSequence())
+		{
+			return false;
+		}
+
+		for (const YAML::Node& defineNode : existingDefines)
+		{
+			if (!defineNode.IsScalar())
+			{
+				return false;
+			}
+
+			const std::string define = defineNode.as<std::string>();
+			if (!isManagedDefine(define))
+			{
+				mergedDefines.push_back(define);
+			}
+		}
+	}
+
+	const YAML::Node generatedDefines = generatedProperties["defines"];
+	if (generatedDefines && !generatedDefines.IsNull())
+	{
+		if (!generatedDefines.IsSequence())
+		{
+			return false;
+		}
+
+		bool bHasTransmission = false;
+		bool bHasAlphaCutout = false;
+		for (const YAML::Node& defineNode : generatedDefines)
+		{
+			if (!defineNode.IsScalar())
+			{
+				return false;
+			}
+
+			const std::string define = defineNode.as<std::string>();
+			if (define == "TRANSMISSION" && !bHasTransmission)
+			{
+				mergedDefines.push_back(define);
+				bHasTransmission = true;
+			}
+			else if (define == "ALPHA_CUTOUT" && !bHasAlphaCutout)
+			{
+				mergedDefines.push_back(define);
+				bHasAlphaCutout = true;
+			}
+		}
+	}
+	merged["defines"] = mergedDefines.size() > 0 ?
+		mergedDefines : YAML::Node();
+
+	struct ManagedPropertyGroup final
+	{
+		const char* m_group;
+		const char* const* m_properties;
+		size_t m_numProperties;
+	};
+
+	static const char* FloatProperties[] = {
+		"material.alphaCutoff",
+		"material.transmissionFactor",
+		"material.thicknessFactor",
+		"material.attenuationDistance",
+		"material.indexOfRefraction"
+	};
+	static const char* Vec4Properties[] = {
+		"material.attenuationColor"
+	};
+	static const char* SamplerProperties[] = {
+		"transmissionSampler",
+		"thicknessSampler"
+	};
+	const ManagedPropertyGroup groups[] = {
+		{ "uniformsFloat", FloatProperties, std::size(FloatProperties) },
+		{ "uniformsVec4", Vec4Properties, std::size(Vec4Properties) },
+		{ "samplers", SamplerProperties, std::size(SamplerProperties) }
+	};
+
+	for (const ManagedPropertyGroup& group : groups)
+	{
+		YAML::Node targetGroup = merged[group.m_group];
+		const YAML::Node generatedGroup = generatedProperties[group.m_group];
+		if ((targetGroup && !targetGroup.IsNull() && !targetGroup.IsMap()) ||
+			(generatedGroup && !generatedGroup.IsNull() &&
+				!generatedGroup.IsMap()))
+		{
+			return false;
+		}
+
+		if (!targetGroup || targetGroup.IsNull())
+		{
+			targetGroup = YAML::Node(YAML::NodeType::Map);
+			merged[group.m_group] = targetGroup;
+		}
+
+		for (size_t index = 0; index < group.m_numProperties; ++index)
+		{
+			const char* property = group.m_properties[index];
+			if (generatedGroup && generatedGroup[property])
+			{
+				targetGroup[property] = YAML::Clone(
+					generatedGroup[property]);
+			}
+			else
+			{
+				targetGroup.remove(property);
+			}
+		}
+	}
+
+	inOutMaterial = std::move(merged);
+	return true;
+}
+
 bool GltfImporterUtils::TryComposeNodeMatrix(
 	const tinygltf::Node& node,
 	glm::mat4& outMatrix)
@@ -2473,12 +2847,21 @@ void ModelImporter::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
 				!areGeneratedAssetsValid(
 					materials,
 					modelAssetInfo->ShouldBatchByMaterial());
-			if (modelAssetInfo->ShouldGenerateMaterials() &&
+			const bool bShouldRegenerateMaterials =
+				modelAssetInfo->ShouldGenerateMaterials() &&
 				((bWasExpired && materials.Num() == 0) ||
-					bMaterialsNeedRepair) &&
+					bMaterialsNeedRepair);
+			if (bShouldRegenerateMaterials &&
 				GenerateMaterialAssets(modelAssetInfo))
 			{
 				assetInfo->SaveMetaFile();
+			}
+			else if (modelAssetInfo->ShouldGenerateMaterials() &&
+				bWasExpired &&
+				materials.Num() > 0 &&
+				!bMaterialsNeedRepair)
+			{
+				UpdateGeneratedMaterialProperties(modelAssetInfo);
 			}
 
 			const TVector<FileId>& animations =
@@ -2843,28 +3226,30 @@ bool ModelImporter::GenerateFingerprint(
 	{
 		const tinygltf::Material& sourceMaterial =
 			gltfModel.materials[i];
-		const bool bIsTransparent =
-			sourceMaterial.alphaMode == "BLEND";
-		const bool bIsMasked =
-			sourceMaterial.alphaMode == "MASK";
-		const std::string renderQueue = bIsTransparent ?
-			"Transparent" :
-			(bIsMasked ? "Masked" : "Opaque");
+		const auto transmissionSettings =
+			GltfImporterUtils::ResolveMaterialTransmission(
+				sourceMaterial,
+				gltfModel.textures.size(),
+				unitScale);
+		const auto alphaModeSettings =
+			GltfImporterUtils::ResolveMaterialAlphaMode(
+				sourceMaterial.alphaMode,
+				transmissionSettings.IsEnabled());
 
 		MaterialPtr material = MaterialPtr::Make(
 			allocator,
 			FileId::CreateNewFileId());
 		material->SetRenderState(RHI::RenderState(
 			true,
-			!bIsTransparent,
+			alphaModeSettings.m_bEnableZWrite,
 			0.0f,
-			bIsMasked,
+			alphaModeSettings.m_bAlphaCutout,
 			sourceMaterial.doubleSided ?
 				RHI::ECullMode::None :
 				RHI::ECullMode::Back,
-			RHI::EBlendMode::None,
+			alphaModeSettings.m_blendMode,
 			RHI::EFillMode::Fill,
-			GetHash(renderQueue)));
+			GetHash(alphaModeSettings.m_renderQueue)));
 
 		const auto& pbr = sourceMaterial.pbrMetallicRoughness;
 		material->SetUniform(
@@ -2890,6 +3275,26 @@ bool ModelImporter::GenerateFingerprint(
 		material->SetUniform(
 			"material.alphaCutoff",
 			static_cast<float>(sourceMaterial.alphaCutoff));
+		if (transmissionSettings.IsEnabled())
+		{
+			material->SetUniform(
+				"material.transmissionFactor",
+				transmissionSettings.m_factor);
+			material->SetUniform(
+				"material.thicknessFactor",
+				transmissionSettings.m_thicknessFactor);
+			material->SetUniform(
+				"material.attenuationDistance",
+				transmissionSettings.m_attenuationDistance);
+			material->SetUniform(
+				"material.indexOfRefraction",
+				transmissionSettings.m_indexOfRefraction);
+			material->SetUniform(
+				"material.attenuationColor",
+				glm::vec4(
+					transmissionSettings.m_attenuationColor,
+					1.0f));
+		}
 
 		auto bindTexture = [&](
 			const char* samplerName,
@@ -2918,6 +3323,15 @@ bool ModelImporter::GenerateFingerprint(
 		bindTexture(
 			"occlusionSampler",
 			sourceMaterial.occlusionTexture.index);
+		if (transmissionSettings.IsEnabled())
+		{
+			bindTexture(
+				"transmissionSampler",
+				transmissionSettings.m_textureIndex);
+			bindTexture(
+				"thicknessSampler",
+				transmissionSettings.m_thicknessTextureIndex);
+		}
 		previewMaterials[i] = std::move(material);
 	}
 	gltfModel = tinygltf::Model();
@@ -3101,6 +3515,21 @@ bool ModelImporter::GenerateFingerprint(
 
 	SAILOR_LOG("Generated model fingerprint: %s", outputPath.c_str());
 	return true;
+}
+
+static bool TryLoadYamlFile(
+	const std::filesystem::path& filepath,
+	YAML::Node& outDocument,
+	std::string& outDiagnostic)
+{
+	std::string payload;
+	if (!AssetRegistry::ReadAllTextFile(filepath.string(), payload))
+	{
+		outDiagnostic = "cannot read the file";
+		return false;
+	}
+
+	return External::TryLoadYaml(payload, outDocument, outDiagnostic);
 }
 
 FileId CreateTextureAsset(const std::string& filepath,
@@ -3314,13 +3743,13 @@ bool ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 		if (material.pbrMetallicRoughness.metallicRoughnessTexture.index != -1)
 		{
 			data.m_samplers.Add("ormSampler",
-				CreateTextureAsset(materialName + "_ormTexture.png.asset", assetInfo->GetAssetFilename(), material.pbrMetallicRoughness.metallicRoughnessTexture.index, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
+				CreateTextureAsset(materialName + "_ormTexture.png.asset", assetInfo->GetAssetFilename(), material.pbrMetallicRoughness.metallicRoughnessTexture.index, true, RHI::ETextureFormat::R8G8B8A8_UNORM, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 		}
 
 		if (material.occlusionTexture.index != -1)
 		{
 			data.m_samplers.Add("occlusionSampler",
-				CreateTextureAsset(materialName + "_occlusionTexture.png.asset", assetInfo->GetAssetFilename(), material.occlusionTexture.index, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
+				CreateTextureAsset(materialName + "_occlusionTexture.png.asset", assetInfo->GetAssetFilename(), material.occlusionTexture.index, true, RHI::ETextureFormat::R8G8B8A8_UNORM, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 		}
 
 		auto tryReadNumberProperty = [](
@@ -3424,6 +3853,43 @@ bool ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 				return true;
 			};
 
+		const auto transmissionSettings =
+			GltfImporterUtils::ResolveMaterialTransmission(
+				material,
+				gltfModel.textures.size(),
+				assetInfo->GetUnitScale());
+		if (transmissionSettings.IsEnabled())
+		{
+			data.m_uniformsFloat.Add(
+				"material.transmissionFactor",
+				transmissionSettings.m_factor);
+			data.m_uniformsFloat.Add(
+				"material.thicknessFactor",
+				transmissionSettings.m_thicknessFactor);
+			data.m_uniformsFloat.Add(
+				"material.attenuationDistance",
+				transmissionSettings.m_attenuationDistance);
+			data.m_uniformsFloat.Add(
+				"material.indexOfRefraction",
+				transmissionSettings.m_indexOfRefraction);
+			data.m_uniformsVec4.Add(
+				"material.attenuationColor",
+				glm::vec4(
+					transmissionSettings.m_attenuationColor,
+					1.0f));
+			if (transmissionSettings.m_textureIndex >= 0)
+			{
+				data.m_samplers.Add("transmissionSampler",
+					CreateTextureAsset(materialName + "_transmissionTexture.png.asset", assetInfo->GetAssetFilename(), transmissionSettings.m_textureIndex, true, RHI::ETextureFormat::R8G8B8A8_UNORM, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
+			}
+			if (transmissionSettings.m_thicknessTextureIndex >= 0)
+			{
+				data.m_samplers.Add("thicknessSampler",
+					CreateTextureAsset(materialName + "_thicknessTexture.png.asset", assetInfo->GetAssetFilename(), transmissionSettings.m_thicknessTextureIndex, true, RHI::ETextureFormat::R8G8B8A8_UNORM, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
+			}
+			data.m_shaderDefines.Add("TRANSMISSION");
+		}
+
 		int32_t textureIndex = -1;
 		auto ccIt = material.extensions.find("KHR_materials_clearcoat");
 		if (ccIt != material.extensions.end() && ccIt->second.IsObject())
@@ -3446,7 +3912,7 @@ bool ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 			if (tryReadTextureIndex(cc, "clearcoatTexture", textureIndex))
 			{
 				data.m_samplers.Add("clearcoatSampler",
-					CreateTextureAsset(materialName + "_clearcoatTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
+					CreateTextureAsset(materialName + "_clearcoatTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_UNORM, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 			}
 
 			textureIndex = -1;
@@ -3456,7 +3922,7 @@ bool ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 				textureIndex))
 			{
 				data.m_samplers.Add("clearcoatRoughnessSampler",
-					CreateTextureAsset(materialName + "_clearcoatRoughnessTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
+					CreateTextureAsset(materialName + "_clearcoatRoughnessTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_UNORM, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 			}
 
 			if (cc.Has("clearcoatNormalTexture") &&
@@ -3516,7 +3982,7 @@ bool ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 				textureIndex))
 			{
 				data.m_samplers.Add("sheenRoughnessSampler",
-					CreateTextureAsset(materialName + "_sheenRoughnessTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_SRGB, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
+					CreateTextureAsset(materialName + "_sheenRoughnessTexture.png.asset", assetInfo->GetAssetFilename(), textureIndex, true, RHI::ETextureFormat::R8G8B8A8_UNORM, RHI::ETextureClamping::Repeat, RHI::ETextureFiltration::Linear, assetInfo->ShouldKeepCpuBuffers()));
 			}
 
 			data.m_shaderDefines.Add("SHEEN");
@@ -3538,23 +4004,25 @@ bool ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 		data.m_uniformsFloat.Add("material.alphaCutoff", (float)material.alphaCutoff);
 		data.m_uniformsFloat.Add("material.occlusionStrength", (float)material.occlusionTexture.strength);
 
-		const bool bIsTransparent = material.alphaMode == "BLEND";
-		const bool bIsMasked = material.alphaMode == "MASK";
+		const auto alphaModeSettings =
+			GltfImporterUtils::ResolveMaterialAlphaMode(
+				material.alphaMode,
+				transmissionSettings.IsEnabled());
+		data.m_renderQueue = alphaModeSettings.m_renderQueue;
 
-		data.m_renderQueue = bIsTransparent ? "Transparent" : "Opaque";
-
-		if (bIsMasked)
+		if (alphaModeSettings.m_bAlphaCutout)
 		{
-			data.m_renderQueue = "Masked";
 			data.m_shaderDefines.Add("ALPHA_CUTOUT");
 		}
 
 		data.m_renderState = RHI::RenderState(true,
-			!bIsTransparent,
-			0.0f, bIsMasked,
+			alphaModeSettings.m_bEnableZWrite,
+			0.0f,
+			alphaModeSettings.m_bAlphaCutout,
 			material.doubleSided ? RHI::ECullMode::None : RHI::ECullMode::Back,
-			RHI::EBlendMode::None,
-			RHI::EFillMode::Fill);
+			alphaModeSettings.m_blendMode,
+			RHI::EFillMode::Fill,
+			GetHash(data.m_renderQueue));
 
 		data.m_shader = App::GetSubmodule<AssetRegistry>()->GetOrLoadFile("Shaders/Standard_glTF.shader");
 		for (const auto& sampler : data.m_samplers)
@@ -3630,7 +4098,445 @@ bool ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 	}
 
 	assetInfo->GetDefaultMaterials() = std::move(generatedMaterials);
+	bool& bMigrationComplete =
+		m_generatedMaterialMigrationComplete.At_Lock(
+			assetInfo->GetFileId(),
+			false);
+	bMigrationComplete = true;
+	m_generatedMaterialMigrationComplete.Unlock(assetInfo->GetFileId());
 	return true;
+}
+
+bool ModelImporter::UpdateGeneratedMaterialProperties(
+	ModelAssetInfoPtr assetInfo)
+{
+	SAILOR_PROFILE_FUNCTION();
+	if (assetInfo == nullptr || !assetInfo->IsWritable())
+	{
+		return false;
+	}
+
+	tinygltf::Model gltfModel;
+	std::string error;
+	std::string warning;
+	if (!GltfImporterUtils::LoadModel(
+			assetInfo->GetAssetFilepath(),
+			true,
+			gltfModel,
+			error,
+			warning))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot update generated materials for %s: %s",
+			assetInfo->GetAssetFilepath().c_str(),
+			error.c_str());
+		return false;
+	}
+
+	if (!warning.empty())
+	{
+		SAILOR_LOG(
+			"Parsing gltf %s warning: %s",
+			assetInfo->GetAssetFilepath().c_str(),
+			warning.c_str());
+	}
+
+	const FileId modelId = assetInfo->GetFileId();
+	bool& bMigrationComplete = m_generatedMaterialMigrationComplete.At_Lock(
+		modelId,
+		false);
+	const bool bUpdated = UpdateGeneratedMaterialProperties(
+		assetInfo,
+		gltfModel);
+	bMigrationComplete = bUpdated;
+	m_generatedMaterialMigrationComplete.Unlock(modelId);
+	return bUpdated;
+}
+
+bool ModelImporter::UpdateGeneratedMaterialPropertiesOnDemand(
+	ModelAssetInfoPtr assetInfo,
+	const tinygltf::Model& gltfModel)
+{
+	if (assetInfo == nullptr ||
+		!assetInfo->IsWritable() ||
+		!assetInfo->ShouldGenerateMaterials() ||
+		assetInfo->GetDefaultMaterials().IsEmpty())
+	{
+		return true;
+	}
+
+	const FileId modelId = assetInfo->GetFileId();
+	bool& bMigrationComplete = m_generatedMaterialMigrationComplete.At_Lock(
+		modelId,
+		false);
+	if (bMigrationComplete)
+	{
+		m_generatedMaterialMigrationComplete.Unlock(modelId);
+		return true;
+	}
+
+	const bool bUpdated = UpdateGeneratedMaterialProperties(
+		assetInfo,
+		gltfModel);
+	bMigrationComplete = bUpdated;
+	m_generatedMaterialMigrationComplete.Unlock(modelId);
+	return bUpdated;
+}
+
+bool ModelImporter::UpdateGeneratedMaterialProperties(
+	ModelAssetInfoPtr assetInfo,
+	const tinygltf::Model& gltfModel)
+{
+	SAILOR_PROFILE_FUNCTION();
+	if (assetInfo == nullptr || !assetInfo->IsWritable())
+	{
+		return false;
+	}
+
+	AssetRegistry* assetRegistry = App::GetSubmodule<AssetRegistry>();
+	if (assetRegistry == nullptr)
+	{
+		return false;
+	}
+
+	const std::string relativeFolder = Utils::GetFileFolder(
+		assetInfo->GetRelativeAssetFilepath());
+	std::filesystem::path materialsFolder;
+	if (!assetRegistry->ResolveWorkspaceContentPathForWrite(
+			relativeFolder + "materials",
+			materialsFolder))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot resolve generated materials folder for %s.",
+			assetInfo->GetAssetFilepath().c_str());
+		return false;
+	}
+
+	auto sanitizeLegacyMaterialStem = [](const std::string& materialName,
+		size_t materialIndex)
+		{
+			std::string result = materialName.empty() ?
+				("material" + std::to_string(materialIndex)) :
+				materialName;
+			constexpr const char* InvalidFilenameCharacters =
+				"<>:\"/\\|?*";
+			for (char& character : result)
+			{
+				if (static_cast<unsigned char>(character) < 32 ||
+					std::strchr(InvalidFilenameCharacters, character) !=
+						nullptr)
+				{
+					character = '_';
+				}
+			}
+			while (!result.empty() &&
+				(result.back() == '.' || result.back() == ' '))
+			{
+				result.back() = '_';
+			}
+			return result.empty() ?
+				("material" + std::to_string(materialIndex)) :
+				result;
+		};
+
+	auto findOwnedMaterial = [assetInfo, assetRegistry](
+		size_t materialIndex,
+		const std::filesystem::path& indexedPath,
+		const std::filesystem::path& legacyPath,
+		MaterialAssetInfoPtr& outMaterialInfo)
+		{
+			auto tryMatch = [assetRegistry,
+				&indexedPath,
+				&legacyPath,
+				&outMaterialInfo](const FileId& materialId)
+			{
+				MaterialAssetInfoPtr materialInfo =
+					assetRegistry->GetAssetInfoPtr<MaterialAssetInfoPtr>(
+						materialId);
+				if (materialInfo == nullptr ||
+					!materialInfo->IsWritable())
+				{
+					return false;
+				}
+
+				for (const std::filesystem::path& candidate : {
+					indexedPath,
+					legacyPath })
+				{
+					std::error_code equivalentError;
+					if (std::filesystem::equivalent(
+							candidate,
+							materialInfo->GetAssetFilepath(),
+							equivalentError) &&
+						!equivalentError)
+					{
+						outMaterialInfo = materialInfo;
+						return true;
+					}
+				}
+				return false;
+			};
+
+			const TVector<FileId>& defaultMaterials =
+				assetInfo->GetDefaultMaterials();
+			if (assetInfo->ShouldBatchByMaterial())
+			{
+				// Batched models retain the direct glTF material ordering. Requiring
+				// both the position and a known generated path avoids claiming a
+				// separately authored replacement material.
+				return materialIndex < defaultMaterials.Num() &&
+					tryMatch(defaultMaterials[materialIndex]);
+			}
+
+			for (const FileId& materialId : defaultMaterials)
+			{
+				if (tryMatch(materialId))
+				{
+					return true;
+				}
+			}
+
+			return false;
+		};
+
+	TVector<FileId> registeredTextureIds;
+	assetRegistry->GetAllAssetInfos<TextureAssetInfo>(registeredTextureIds);
+	TMap<int32_t, FileId> textureIdsByGltfIndex;
+	for (const FileId& registeredTextureId : registeredTextureIds)
+	{
+		TextureAssetInfoPtr textureInfo =
+			assetRegistry->GetAssetInfoPtr<TextureAssetInfoPtr>(
+				registeredTextureId);
+		if (textureInfo == nullptr ||
+			textureInfo->GetGlbTextureIndex() < 0 ||
+			textureInfo->GetFormat() !=
+				RHI::ETextureFormat::R8G8B8A8_UNORM ||
+			textureInfo->GetClamping() !=
+				RHI::ETextureClamping::Repeat ||
+			textureInfo->GetFiltration() !=
+				RHI::ETextureFiltration::Linear ||
+			!textureInfo->ShouldGenerateMips())
+		{
+			continue;
+		}
+
+		std::error_code sourceError;
+		if (std::filesystem::equivalent(
+				textureInfo->GetAssetFilepath(),
+				assetInfo->GetAssetFilepath(),
+				sourceError) &&
+			!sourceError)
+		{
+			textureIdsByGltfIndex.Insert(
+				textureInfo->GetGlbTextureIndex(),
+				registeredTextureId);
+		}
+	}
+	TSet<FileId> updatedMaterialIds;
+	bool bSucceeded = true;
+	for (size_t materialIndex = 0;
+		materialIndex < gltfModel.materials.size();
+		++materialIndex)
+	{
+		const std::string generatedStem =
+			assetInfo->GetAssetFilename() + "_material_" +
+			std::to_string(materialIndex);
+		const std::filesystem::path indexedMaterialPath =
+			materialsFolder / (generatedStem + ".mat");
+		const std::string legacyMaterialStem =
+			sanitizeLegacyMaterialStem(
+				gltfModel.materials[materialIndex].name,
+				materialIndex);
+		const std::filesystem::path legacyMaterialPath =
+			materialsFolder / (legacyMaterialStem + ".mat");
+		MaterialAssetInfoPtr materialInfo = nullptr;
+		if (!findOwnedMaterial(
+				materialIndex,
+				indexedMaterialPath,
+				legacyMaterialPath,
+				materialInfo))
+		{
+			// A default material may be replaced with a separately authored asset.
+			// Do not infer ownership from its position in the model's material list.
+			SAILOR_LOG(
+				"Skipped non-generated material while updating %s: %s",
+				assetInfo->GetAssetFilepath().c_str(),
+				indexedMaterialPath.string().c_str());
+			continue;
+		}
+
+		const tinygltf::Material& sourceMaterial =
+			gltfModel.materials[materialIndex];
+		const auto transmission =
+			GltfImporterUtils::ResolveMaterialTransmission(
+				sourceMaterial,
+				gltfModel.textures.size(),
+				assetInfo->GetUnitScale());
+		const auto alphaMode = GltfImporterUtils::ResolveMaterialAlphaMode(
+			sourceMaterial.alphaMode,
+			transmission.IsEnabled());
+		YAML::Node generatedProperties(YAML::NodeType::Map);
+		generatedProperties["renderQueue"] = alphaMode.m_renderQueue;
+		generatedProperties["bEnableZWrite"] =
+			alphaMode.m_bEnableZWrite;
+		generatedProperties["bCustomDepthShader"] =
+			alphaMode.m_bAlphaCutout;
+		::Serialize(
+			generatedProperties,
+			"blendMode",
+			alphaMode.m_blendMode);
+
+		YAML::Node generatedDefines(YAML::NodeType::Sequence);
+		if (transmission.IsEnabled())
+		{
+			generatedDefines.push_back("TRANSMISSION");
+		}
+		if (alphaMode.m_bAlphaCutout)
+		{
+			generatedDefines.push_back("ALPHA_CUTOUT");
+		}
+		generatedProperties["defines"] = generatedDefines;
+		generatedProperties["uniformsFloat"]["material.alphaCutoff"] =
+			static_cast<float>(sourceMaterial.alphaCutoff);
+
+		if (transmission.IsEnabled())
+		{
+			generatedProperties["uniformsFloat"]
+				["material.transmissionFactor"] = transmission.m_factor;
+			generatedProperties["uniformsFloat"]
+				["material.thicknessFactor"] =
+					transmission.m_thicknessFactor;
+			generatedProperties["uniformsFloat"]
+				["material.attenuationDistance"] =
+					transmission.m_attenuationDistance;
+			generatedProperties["uniformsFloat"]
+				["material.indexOfRefraction"] =
+					transmission.m_indexOfRefraction;
+			generatedProperties["uniformsVec4"]
+				["material.attenuationColor"] = glm::vec4(
+					transmission.m_attenuationColor,
+					1.0f);
+
+			auto addGeneratedSampler = [assetInfo,
+				&generatedProperties,
+				&textureIdsByGltfIndex](
+					const char* samplerName,
+					int32_t textureIndex)
+				{
+					if (textureIndex < 0)
+					{
+						return;
+					}
+
+					const FileId* registeredTextureId = nullptr;
+					const FileId textureFileId =
+						textureIdsByGltfIndex.Find(
+							textureIndex,
+							registeredTextureId) &&
+						registeredTextureId != nullptr ?
+							*registeredTextureId : FileId();
+
+					if (!textureFileId)
+					{
+						SAILOR_LOG(
+							"Cannot migrate generated glTF %s for %s: no registered "
+							"same-source texture for glTF index %d; scalar "
+							"transmission remains active.",
+							samplerName,
+							assetInfo->GetAssetFilepath().c_str(),
+							textureIndex);
+						return;
+					}
+
+					generatedProperties["samplers"][samplerName] =
+						textureFileId;
+				};
+
+			addGeneratedSampler(
+				"transmissionSampler",
+				transmission.m_textureIndex);
+			addGeneratedSampler(
+				"thicknessSampler",
+				transmission.m_thicknessTextureIndex);
+		}
+
+		YAML::Node materialDocument;
+		std::string diagnostic;
+		if (!TryLoadYamlFile(
+				materialInfo->GetAssetFilepath(),
+				materialDocument,
+				diagnostic))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot read generated material '%s': %s",
+				materialInfo->GetAssetFilepath().c_str(),
+				diagnostic.c_str());
+			bSucceeded = false;
+			continue;
+		}
+
+		const YAML::Node previousDocument = YAML::Clone(materialDocument);
+		bool bMerged = false;
+		const bool bYamlHandled = External::GuardYamlExceptions(
+			[&materialDocument, &generatedProperties, &bMerged]()
+			{
+				bMerged = GltfImporterUtils::MergeGeneratedMaterialProperties(
+					materialDocument,
+					generatedProperties);
+			},
+			diagnostic);
+		if (!bYamlHandled || !bMerged)
+		{
+			if (diagnostic.empty())
+			{
+				diagnostic = "material YAML has an incompatible structure";
+			}
+			SAILOR_LOG_ERROR(
+				"Cannot migrate generated material '%s': %s",
+				materialInfo->GetAssetFilepath().c_str(),
+				diagnostic.c_str());
+			bSucceeded = false;
+			continue;
+		}
+
+		if (Utils::AreYamlNodesEqual(previousDocument, materialDocument))
+		{
+			continue;
+		}
+
+		std::string serializedMaterial;
+		if (!External::TryDumpYaml(
+				materialDocument,
+				serializedMaterial,
+				diagnostic) ||
+			!Workspace::AtomicReplaceWorkspaceCacheText(
+				materialInfo->GetAssetFilepath(),
+				serializedMaterial,
+				diagnostic))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot save migrated material '%s': %s",
+				materialInfo->GetAssetFilepath().c_str(),
+				diagnostic.c_str());
+			bSucceeded = false;
+			continue;
+		}
+
+		updatedMaterialIds.Insert(materialInfo->GetFileId());
+	}
+
+	for (const FileId& materialId : updatedMaterialIds)
+	{
+		if (!assetRegistry->UpdateAsset(materialId))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot reload migrated generated material: %s",
+				materialId.ToString().c_str());
+			bSucceeded = false;
+		}
+	}
+
+	return bSucceeded;
 }
 
 Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel)
@@ -3685,12 +4591,27 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 		};
 
 		promise = Tasks::CreateTaskWithResult<TSharedPtr<Data>>("Load model",
-			[pAssetInfo, &boundsAabb, &boundsSphere]()
+			[this, pAssetInfo, &boundsAabb, &boundsSphere]()
 			{
 				TSharedPtr<Data> pData = TSharedPtr<Data>::Make();
 				pData->m_bShouldKeepCpuBuffers = pAssetInfo->ShouldKeepCpuBuffers();
 				pData->m_bShouldGenerateBLAS = pAssetInfo->ShouldGenerateBLAS();
-				pData->m_bIsImported = ImportModel(pAssetInfo, pData->m_parsedMeshes, boundsAabb, boundsSphere, pData->m_inverseBind);
+				tinygltf::Model gltfModel;
+				pData->m_bIsImported = ImportModel(
+					pAssetInfo->GetAssetFilepath(),
+					pAssetInfo->GetUnitScale(),
+					pAssetInfo->ShouldBatchByMaterial(),
+					pData->m_parsedMeshes,
+					boundsAabb,
+					boundsSphere,
+					pData->m_inverseBind,
+					&gltfModel);
+				if (pData->m_bIsImported)
+				{
+					UpdateGeneratedMaterialPropertiesOnDemand(
+						pAssetInfo,
+						gltfModel);
+				}
 				return pData;
 			})->Then<ModelPtr>([pModel](TSharedPtr<Data> pData) mutable
 				{

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -1847,6 +1847,22 @@ namespace
 	}
 }
 
+GltfImporterUtils::MeshInstanceTransforms GltfImporterUtils::ResolveMeshInstanceTransforms(
+	const MeshInstance& instance,
+	float unitScale)
+{
+	const glm::mat4 sourceTransform = instance.m_skinIndex >= 0 ?
+		glm::mat4(1.0f) : instance.m_worldTransform;
+	const float directionScale = unitScale < 0.0f ? -1.0f : 1.0f;
+
+	MeshInstanceTransforms result;
+	result.m_geometryTransform =
+		glm::scale(glm::mat4(1.0f), glm::vec3(unitScale)) * sourceTransform;
+	result.m_directionTransform = glm::mat3(
+		glm::scale(glm::mat4(1.0f), glm::vec3(directionScale)) * sourceTransform);
+	return result;
+}
+
 bool GltfImporterUtils::TryComposeNodeMatrix(
 	const tinygltf::Node& node,
 	glm::mat4& outMatrix)
@@ -4061,11 +4077,10 @@ bool ModelImporter::ImportModel(
 		// glTF explicitly ignores the mesh-node transform for skinned meshes.
 		// Static mesh instances are flattened into Model geometry because Sailor
 		// has one world transform for the complete Model.
-		const glm::mat4 geometryTransform =
-			glm::scale(glm::mat4(1.0f), glm::vec3(unitScale)) *
-			(instance.m_skinIndex >= 0 ?
-				glm::mat4(1.0f) : instance.m_worldTransform);
-		const glm::mat3 directionTransform(geometryTransform);
+		const GltfImporterUtils::MeshInstanceTransforms transforms =
+			GltfImporterUtils::ResolveMeshInstanceTransforms(instance, unitScale);
+		const glm::mat4& geometryTransform = transforms.m_geometryTransform;
+		const glm::mat3& directionTransform = transforms.m_directionTransform;
 		const float transformDeterminant =
 			glm::determinant(directionTransform);
 		if (!std::isfinite(transformDeterminant))

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -1862,6 +1862,11 @@ GltfImporterUtils::MeshInstanceTransforms GltfImporterUtils::ResolveMeshInstance
 		glm::scale(glm::mat4(1.0f), glm::vec3(unitScale)) * sourceTransform;
 	result.m_directionTransform = glm::mat3(
 		glm::scale(glm::mat4(1.0f), glm::vec3(directionScale)) * sourceTransform);
+	const glm::mat3 sourceLinear(sourceTransform);
+	result.m_bakedVolumeScale = glm::vec3(
+		glm::length(sourceLinear[0]),
+		glm::length(sourceLinear[1]),
+		glm::length(sourceLinear[2]));
 	return result;
 }
 
@@ -3385,7 +3390,7 @@ bool ModelImporter::GenerateFingerprint(
 	params.m_height = FingerprintImageDimension;
 	params.m_numSamples = 1;
 	params.m_numAmbientSamples = 1;
-	params.m_maxBounces = 1;
+	params.m_maxBounces = 4;
 	params.m_msaa = 1;
 	params.m_ambient = vec3(0.08f);
 	params.m_rayBiasScale = 3e-4f;
@@ -3532,21 +3537,87 @@ static bool TryLoadYamlFile(
 	return External::TryLoadYaml(payload, outDocument, outDiagnostic);
 }
 
-FileId CreateTextureAsset(const std::string& filepath,
-	const std::string& glbFilename,
-	uint32_t glbTextureIndex,
-	bool bShouldGenerateMips = true,
-	RHI::EFormat format = RHI::EFormat::R8G8B8A8_SRGB,
-	RHI::ETextureClamping clamping = RHI::ETextureClamping::Repeat,
-	RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear,
-	bool bShouldKeepCpuBuffers = false)
+FileId ModelImporter::CreateTextureAsset(const std::string& filepath,
+	const std::string& sourceFilename,
+	uint32_t sourceTextureIndex,
+	bool bShouldGenerateMips,
+	RHI::EFormat format,
+	RHI::ETextureClamping clamping,
+	RHI::ETextureFiltration filtration,
+	bool bShouldKeepCpuBuffers)
 {
-	FileId newFileId = FileId::CreateNewFileId();
+	AssetRegistry* assetRegistry = App::GetSubmodule<AssetRegistry>();
+	if (assetRegistry == nullptr)
+	{
+		return FileId::Invalid;
+	}
+
+	std::error_code statusError;
+	const std::filesystem::file_status metadataStatus =
+		std::filesystem::symlink_status(filepath, statusError);
+	if (statusError == std::errc::no_such_file_or_directory ||
+		statusError == std::errc::not_a_directory)
+	{
+		statusError.clear();
+	}
+	if (statusError)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot inspect generated texture metadata path '%s': %s",
+			filepath.c_str(),
+			statusError.message().c_str());
+		return FileId::Invalid;
+	}
+
+	const bool bMetadataExists = std::filesystem::exists(metadataStatus);
+	if (bMetadataExists &&
+		!std::filesystem::is_regular_file(metadataStatus))
+	{
+		SAILOR_LOG_ERROR(
+			"Generated texture metadata path is not a regular file: %s",
+			filepath.c_str());
+		return FileId::Invalid;
+	}
+
+	FileId fileId = bMetadataExists ?
+		assetRegistry->RegisterGeneratedSecondaryAssetInfo(filepath) :
+		FileId::CreateNewFileId();
+	if (!fileId)
+	{
+		return FileId::Invalid;
+	}
+
+	if (bMetadataExists)
+	{
+		TextureAssetInfoPtr existingTextureInfo =
+			assetRegistry->GetAssetInfoPtr<TextureAssetInfoPtr>(fileId);
+		if (existingTextureInfo == nullptr ||
+			existingTextureInfo->GetAssetFilename() != sourceFilename ||
+			existingTextureInfo->GetGlbTextureIndex() !=
+				static_cast<int32_t>(sourceTextureIndex))
+		{
+			SAILOR_LOG_ERROR(
+				"Existing generated texture metadata is incompatible: %s",
+				filepath.c_str());
+			return FileId::Invalid;
+		}
+
+		if (existingTextureInfo->ShouldGenerateMips() ==
+				bShouldGenerateMips &&
+			existingTextureInfo->GetFormat() == format &&
+			existingTextureInfo->GetClamping() == clamping &&
+			existingTextureInfo->GetFiltration() == filtration &&
+			existingTextureInfo->ShouldKeepCpuBuffers() ==
+				bShouldKeepCpuBuffers)
+		{
+			return fileId;
+		}
+	}
 
 	YAML::Node newTexture = GeneratedModelAssetMetadata::CreateTexture(
-		newFileId,
-		glbFilename,
-		glbTextureIndex,
+		fileId,
+		sourceFilename,
+		sourceTextureIndex,
 		bShouldGenerateMips,
 		format,
 		clamping,
@@ -3576,7 +3647,15 @@ FileId CreateTextureAsset(const std::string& filepath,
 		return {};
 	}
 
-	return newFileId;
+	if (assetRegistry->RegisterGeneratedSecondaryAssetInfo(filepath) != fileId)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot register generated texture metadata for immediate model processing: %s",
+			filepath.c_str());
+		return FileId::Invalid;
+	}
+
+	return fileId;
 }
 
 FileId CreateAnimationAsset(const std::string& filepath,
@@ -4418,9 +4497,14 @@ bool ModelImporter::UpdateGeneratedMaterialProperties(
 					1.0f);
 
 			auto addGeneratedSampler = [assetInfo,
+				assetRegistry,
+				materialIndex,
+				&relativeFolder,
 				&generatedProperties,
-				&textureIdsByGltfIndex](
+				&textureIdsByGltfIndex,
+				&bSucceeded](
 					const char* samplerName,
+					const char* assetSuffix,
 					int32_t textureIndex)
 				{
 					if (textureIndex < 0)
@@ -4429,7 +4513,7 @@ bool ModelImporter::UpdateGeneratedMaterialProperties(
 					}
 
 					const FileId* registeredTextureId = nullptr;
-					const FileId textureFileId =
+					FileId textureFileId =
 						textureIdsByGltfIndex.Find(
 							textureIndex,
 							registeredTextureId) &&
@@ -4438,14 +4522,45 @@ bool ModelImporter::UpdateGeneratedMaterialProperties(
 
 					if (!textureFileId)
 					{
-						SAILOR_LOG(
-							"Cannot migrate generated glTF %s for %s: no registered "
-							"same-source texture for glTF index %d; scalar "
-							"transmission remains active.",
-							samplerName,
-							assetInfo->GetAssetFilepath().c_str(),
-							textureIndex);
-						return;
+						std::filesystem::path generatedTexturePath;
+						const std::string generatedTextureVirtualPath =
+							relativeFolder + assetInfo->GetAssetFilename() +
+							"_material_" + std::to_string(materialIndex) + "_" +
+							assetSuffix + ".png.asset";
+						if (!assetRegistry->ResolveWorkspaceContentPathForWrite(
+								generatedTextureVirtualPath,
+								generatedTexturePath))
+						{
+							SAILOR_LOG_ERROR(
+								"Cannot resolve generated glTF %s for %s.",
+								samplerName,
+								assetInfo->GetAssetFilepath().c_str());
+							bSucceeded = false;
+							return;
+						}
+
+						textureFileId = ModelImporter::CreateTextureAsset(
+							generatedTexturePath.string(),
+							assetInfo->GetAssetFilename(),
+							static_cast<uint32_t>(textureIndex),
+							true,
+							RHI::ETextureFormat::R8G8B8A8_UNORM,
+							RHI::ETextureClamping::Repeat,
+							RHI::ETextureFiltration::Linear,
+							assetInfo->ShouldKeepCpuBuffers());
+						if (!textureFileId)
+						{
+							SAILOR_LOG_ERROR(
+								"Cannot create generated glTF %s for %s.",
+								samplerName,
+								assetInfo->GetAssetFilepath().c_str());
+							bSucceeded = false;
+							return;
+						}
+
+						textureIdsByGltfIndex.Insert(
+							textureIndex,
+							textureFileId);
 					}
 
 					generatedProperties["samplers"][samplerName] =
@@ -4454,9 +4569,11 @@ bool ModelImporter::UpdateGeneratedMaterialProperties(
 
 			addGeneratedSampler(
 				"transmissionSampler",
+				"transmissionTexture",
 				transmission.m_textureIndex);
 			addGeneratedSampler(
 				"thicknessSampler",
+				"thicknessTexture",
 				transmission.m_thicknessTextureIndex);
 		}
 
@@ -4585,18 +4702,18 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 		{
 			TVector<MeshContext> m_parsedMeshes;
 			TVector<glm::mat4> m_inverseBind;
+			tinygltf::Model m_gltfModel;
 			bool m_bIsImported = false;
 			bool m_bShouldKeepCpuBuffers = false;
 			bool m_bShouldGenerateBLAS = false;
 		};
 
-		promise = Tasks::CreateTaskWithResult<TSharedPtr<Data>>("Load model",
+		auto loadDataTask = Tasks::CreateTaskWithResult<TSharedPtr<Data>>("Load model",
 			[this, pAssetInfo, &boundsAabb, &boundsSphere]()
 			{
 				TSharedPtr<Data> pData = TSharedPtr<Data>::Make();
 				pData->m_bShouldKeepCpuBuffers = pAssetInfo->ShouldKeepCpuBuffers();
 				pData->m_bShouldGenerateBLAS = pAssetInfo->ShouldGenerateBLAS();
-				tinygltf::Model gltfModel;
 				pData->m_bIsImported = ImportModel(
 					pAssetInfo->GetAssetFilepath(),
 					pAssetInfo->GetUnitScale(),
@@ -4605,15 +4722,27 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 					boundsAabb,
 					boundsSphere,
 					pData->m_inverseBind,
-					&gltfModel);
-				if (pData->m_bIsImported)
-				{
-					UpdateGeneratedMaterialPropertiesOnDemand(
-						pAssetInfo,
-						gltfModel);
-				}
+					&pData->m_gltfModel);
 				return pData;
-			})->Then<ModelPtr>([pModel](TSharedPtr<Data> pData) mutable
+			});
+		auto migrationTask = loadDataTask->Then(
+				[this, pAssetInfo, uid](TSharedPtr<Data> pData)
+				{
+					if (pData->m_bIsImported)
+					{
+						UpdateGeneratedMaterialPropertiesOnDemand(
+							pAssetInfo,
+							pData->m_gltfModel);
+					}
+					pData->m_gltfModel = tinygltf::Model();
+					m_generatedMaterialMigrationTasks.Remove(uid);
+				},
+				"Migrate generated model materials",
+				EThreadType::Main);
+		m_generatedMaterialMigrationTasks.At_Lock(uid, nullptr) = migrationTask;
+		m_generatedMaterialMigrationTasks.Unlock(uid);
+
+		promise = loadDataTask->Then<ModelPtr>([pModel](TSharedPtr<Data> pData) mutable
 				{
 					if (pData->m_bIsImported)
 					{
@@ -4638,7 +4767,11 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 							RHI::RHIMeshPtr pMesh = RHI::Renderer::GetDriver()->CreateMesh();
 							pMesh->m_vertexDescription = RHI::Renderer::GetDriver()->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4I4W4>();
 							pMesh->m_bounds = mesh.bounds;
-							pMesh->m_materialIndex = static_cast<uint32_t>(meshIndex);
+							pMesh->m_materialIndex = mesh.materialSlot !=
+								(std::numeric_limits<uint32_t>::max)() ?
+									mesh.materialSlot :
+									static_cast<uint32_t>(meshIndex);
+							pMesh->m_bakedVolumeScale = mesh.bakedVolumeScale;
 							RHI::Renderer::GetDriver()->UpdateMesh(pMesh,
 								mesh.outVertices.GetData(), sizeof(RHI::VertexP3N3T3B3UV2C4I4W4) * mesh.outVertices.Num(),
 								mesh.outIndices.GetData(), sizeof(uint32_t) * mesh.outIndices.Num());
@@ -4938,9 +5071,20 @@ bool ModelImporter::ImportModel(
 		(std::max)(static_cast<size_t>(1), gltfModel.materials.size());
 	TVector<MeshContext> batchedMeshContexts;
 	TVector<uint32_t> meshPrimitiveOffsets;
+	size_t initialPrimitiveContextCount = 0;
 	if (bShouldBatchByMaterial)
 	{
 		batchedMeshContexts.Resize(materialBatchCount);
+		for (size_t materialIndex = 0;
+			materialIndex < materialBatchCount;
+			++materialIndex)
+		{
+			batchedMeshContexts[materialIndex].materialIndex =
+				materialIndex < gltfModel.materials.size() ?
+					static_cast<int32_t>(materialIndex) : -1;
+			batchedMeshContexts[materialIndex].materialSlot =
+				static_cast<uint32_t>(materialIndex);
+		}
 	}
 	else
 	{
@@ -4961,7 +5105,8 @@ bool ModelImporter::ImportModel(
 				static_cast<uint32_t>(mesh.primitives.size());
 		}
 
-		outParsedMeshes.Resize(primitiveCount);
+		initialPrimitiveContextCount = primitiveCount;
+		outParsedMeshes.Resize(initialPrimitiveContextCount);
 		for (size_t meshIndex = 0;
 			meshIndex < gltfModel.meshes.size();
 			++meshIndex)
@@ -4973,14 +5118,67 @@ bool ModelImporter::ImportModel(
 			{
 				const int32_t materialIndex =
 					mesh.primitives[primitiveIndex].material;
-				outParsedMeshes[
-					meshPrimitiveOffsets[meshIndex] + primitiveIndex]
-					.materialIndex = materialIndex >= 0 &&
+				const uint32_t materialSlot =
+					meshPrimitiveOffsets[meshIndex] +
+					static_cast<uint32_t>(primitiveIndex);
+				outParsedMeshes[materialSlot].materialIndex = materialIndex >= 0 &&
 					static_cast<size_t>(materialIndex) <
 						gltfModel.materials.size() ? materialIndex : -1;
+				outParsedMeshes[materialSlot].materialSlot = materialSlot;
 			}
 		}
 	}
+
+	auto areVolumeScalesEquivalent = [](const glm::vec3& lhs,
+		const glm::vec3& rhs)
+		{
+			const glm::vec3 tolerance = glm::max(
+				glm::max(glm::abs(lhs), glm::abs(rhs)) * 1e-5f,
+				glm::vec3(1e-6f));
+			return glm::all(glm::lessThanEqual(glm::abs(lhs - rhs), tolerance));
+		};
+	auto resolveMeshContext = [&areVolumeScalesEquivalent](
+		TVector<MeshContext>& contexts,
+		size_t baseIndex,
+		size_t initialContextCount,
+		int32_t materialIndex,
+		uint32_t materialSlot,
+		const glm::vec3& bakedVolumeScale) -> MeshContext*
+		{
+			MeshContext* context = &contexts[baseIndex];
+			if (!context->HasGeometry() ||
+				areVolumeScalesEquivalent(
+					context->bakedVolumeScale,
+					bakedVolumeScale))
+			{
+				context->materialIndex = materialIndex;
+				context->materialSlot = materialSlot;
+				context->bakedVolumeScale = bakedVolumeScale;
+				return context;
+			}
+
+			for (size_t contextIndex = initialContextCount;
+				contextIndex < contexts.Num();
+				++contextIndex)
+			{
+				MeshContext& candidate = contexts[contextIndex];
+				if (candidate.materialSlot == materialSlot &&
+					candidate.materialIndex == materialIndex &&
+					areVolumeScalesEquivalent(
+						candidate.bakedVolumeScale,
+						bakedVolumeScale))
+				{
+					return &candidate;
+				}
+			}
+
+			MeshContext splitContext;
+			splitContext.materialIndex = materialIndex;
+			splitContext.materialSlot = materialSlot;
+			splitContext.bakedVolumeScale = bakedVolumeScale;
+			contexts.Emplace(std::move(splitContext));
+			return &*contexts.Last();
+		};
 
 	for (const GltfImporterUtils::MeshInstance& instance : meshInstances)
 	{
@@ -5002,6 +5200,7 @@ bool ModelImporter::ImportModel(
 			GltfImporterUtils::ResolveMeshInstanceTransforms(instance, unitScale);
 		const glm::mat4& geometryTransform = transforms.m_geometryTransform;
 		const glm::mat3& directionTransform = transforms.m_directionTransform;
+		const glm::vec3& bakedVolumeScale = transforms.m_bakedVolumeScale;
 		const float transformDeterminant =
 			glm::determinant(directionTransform);
 		if (!std::isfinite(transformDeterminant))
@@ -5033,13 +5232,6 @@ bool ModelImporter::ImportModel(
 			const int32_t materialIndex = primitive.material >= 0 &&
 				static_cast<size_t>(primitive.material) < gltfModel.materials.size() ?
 				primitive.material : -1;
-			MeshContext* pPrimitiveMeshContext = nullptr;
-			if (!bShouldBatchByMaterial)
-			{
-				pPrimitiveMeshContext = &outParsedMeshes[
-					meshPrimitiveOffsets[meshIndex] + primitiveIndex];
-			}
-
 			if (primitive.mode != TINYGLTF_MODE_TRIANGLES)
 			{
 				SAILOR_LOG(
@@ -5321,12 +5513,30 @@ bool ModelImporter::ImportModel(
 				continue;
 			}
 
-			MeshContext* pMeshContext = pPrimitiveMeshContext;
+			MeshContext* pMeshContext = nullptr;
 			if (bShouldBatchByMaterial)
 			{
 				const size_t batchIndex = materialIndex >= 0 ?
 					static_cast<size_t>(materialIndex) : 0;
-				pMeshContext = &batchedMeshContexts[batchIndex];
+				pMeshContext = resolveMeshContext(
+					batchedMeshContexts,
+					batchIndex,
+					materialBatchCount,
+					materialIndex,
+					static_cast<uint32_t>(batchIndex),
+					bakedVolumeScale);
+			}
+			else
+			{
+				const size_t primitiveContextIndex =
+					meshPrimitiveOffsets[meshIndex] + primitiveIndex;
+				pMeshContext = resolveMeshContext(
+					outParsedMeshes,
+					primitiveContextIndex,
+					initialPrimitiveContextCount,
+					materialIndex,
+					static_cast<uint32_t>(primitiveContextIndex),
+					bakedVolumeScale);
 			}
 
 			const size_t existingVertices = pMeshContext != nullptr ?
@@ -5348,8 +5558,6 @@ bool ModelImporter::ImportModel(
 				static_cast<uint32_t>(pMeshContext->outVertices.Num());
 			const uint32_t indicesStart =
 				static_cast<uint32_t>(pMeshContext->outIndices.Num());
-			pMeshContext->materialIndex = materialIndex;
-
 			for (const auto& vertex : localVertices)
 			{
 				pMeshContext->outVertices.Add(vertex);

--- a/Runtime/AssetRegistry/Model/ModelImporter.h
+++ b/Runtime/AssetRegistry/Model/ModelImporter.h
@@ -128,6 +128,14 @@ namespace Sailor
 	protected:
 
 		SAILOR_API bool GenerateMaterialAssets(ModelAssetInfoPtr assetInfo);
+		bool UpdateGeneratedMaterialProperties(
+			ModelAssetInfoPtr assetInfo);
+		bool UpdateGeneratedMaterialProperties(
+			ModelAssetInfoPtr assetInfo,
+			const tinygltf::Model& gltfModel);
+		bool UpdateGeneratedMaterialPropertiesOnDemand(
+			ModelAssetInfoPtr assetInfo,
+			const tinygltf::Model& gltfModel);
 		SAILOR_API bool GenerateAnimationAssets(ModelAssetInfoPtr assetInfo);
 		static bool ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext>& outParsedMeshes, Math::AABB& outBoundsAabb, Math::Sphere& outBoundsSphere, TVector<glm::mat4>& outInverseBind);
 		static bool ImportModel(
@@ -149,6 +157,7 @@ namespace Sailor
 
 		TConcurrentMap<FileId, Tasks::TaskPtr<ModelPtr>> m_promises;
 		TConcurrentMap<FileId, ModelPtr> m_loadedModels;
+		TConcurrentMap<FileId, bool> m_generatedMaterialMigrationComplete;
 
 		ObjectAllocatorPtr m_allocator;
 	};

--- a/Runtime/AssetRegistry/Model/ModelImporter.h
+++ b/Runtime/AssetRegistry/Model/ModelImporter.h
@@ -25,6 +25,8 @@
 #include "Core/YamlSerializable.h"
 #include "Core/Reflection.h"
 
+#include <limits>
+
 namespace tinygltf
 {
 	class Model;
@@ -104,6 +106,8 @@ namespace Sailor
 			TVector<uint32_t> outIndices;
 			Math::AABB bounds{};
 			int32_t materialIndex = -1;
+			uint32_t materialSlot = (std::numeric_limits<uint32_t>::max)();
+			glm::vec3 bakedVolumeScale{ 1.0f };
 
 			bool HasGeometry() const
 			{
@@ -136,6 +140,15 @@ namespace Sailor
 		bool UpdateGeneratedMaterialPropertiesOnDemand(
 			ModelAssetInfoPtr assetInfo,
 			const tinygltf::Model& gltfModel);
+		static FileId CreateTextureAsset(
+			const std::string& filepath,
+			const std::string& sourceFilename,
+			uint32_t sourceTextureIndex,
+			bool bShouldGenerateMips = true,
+			RHI::EFormat format = RHI::EFormat::R8G8B8A8_SRGB,
+			RHI::ETextureClamping clamping = RHI::ETextureClamping::Repeat,
+			RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear,
+			bool bShouldKeepCpuBuffers = false);
 		SAILOR_API bool GenerateAnimationAssets(ModelAssetInfoPtr assetInfo);
 		static bool ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext>& outParsedMeshes, Math::AABB& outBoundsAabb, Math::Sphere& outBoundsSphere, TVector<glm::mat4>& outInverseBind);
 		static bool ImportModel(
@@ -158,6 +171,7 @@ namespace Sailor
 		TConcurrentMap<FileId, Tasks::TaskPtr<ModelPtr>> m_promises;
 		TConcurrentMap<FileId, ModelPtr> m_loadedModels;
 		TConcurrentMap<FileId, bool> m_generatedMaterialMigrationComplete;
+		TConcurrentMap<FileId, Tasks::ITaskPtr> m_generatedMaterialMigrationTasks;
 
 		ObjectAllocatorPtr m_allocator;
 	};

--- a/Runtime/AssetRegistry/Model/ModelImporter.h
+++ b/Runtime/AssetRegistry/Model/ModelImporter.h
@@ -104,6 +104,11 @@ namespace Sailor
 			TVector<uint32_t> outIndices;
 			Math::AABB bounds{};
 			int32_t materialIndex = -1;
+
+			bool HasGeometry() const
+			{
+				return !outVertices.IsEmpty() && !outIndices.IsEmpty();
+			}
 		};
 
 		SAILOR_API ModelImporter(ModelAssetInfoHandler* infoHandler);
@@ -122,8 +127,8 @@ namespace Sailor
 
 	protected:
 
-		SAILOR_API void GenerateMaterialAssets(ModelAssetInfoPtr assetInfo);
-		SAILOR_API void GenerateAnimationAssets(ModelAssetInfoPtr assetInfo);
+		SAILOR_API bool GenerateMaterialAssets(ModelAssetInfoPtr assetInfo);
+		SAILOR_API bool GenerateAnimationAssets(ModelAssetInfoPtr assetInfo);
 		static bool ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext>& outParsedMeshes, Math::AABB& outBoundsAabb, Math::Sphere& outBoundsSphere, TVector<glm::mat4>& outInverseBind);
 		static bool ImportModel(
 			const std::string& assetFilepath,

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -189,7 +189,6 @@ std::string GenerateConstantsLibrary(uint32_t version)
 	stream << "#define MAX_SHADOWS_IN_VIEW " << LightingECS::MaxShadowsInView << "\n";
 	stream << "#define MAX_TEXTURES_IN_SCENE " << TextureImporter::MaxTexturesInScene << "\n";
 	stream << "#define NUM_CSM_CASCADES " << LightingECS::NumCascades << "\n";
-
 	stream << "const float ShadowCascadeLevels[" << LightingECS::NumCascades << "] = { ";
 
 	for (uint32_t i = 0; i < LightingECS::NumCascades; i++)

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -368,6 +368,10 @@ bool ShaderCompiler::ForceCompilePermutation(ShaderAssetInfoPtr assetInfo, uint3
 	vertexDefines.Add("VERTEX");
 	fragmentDefines.Add("FRAGMENT");
 	computeDefines.Add("COMPUTE");
+#if defined(__APPLE__)
+	vertexDefines.Add("SAILOR_TEXTURE_REMAP");
+	fragmentDefines.Add("SAILOR_TEXTURE_REMAP");
+#endif
 
 	if (pShader->ContainsVertex())
 	{

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -173,6 +173,8 @@ std::string GenerateConstantsLibrary(uint32_t version)
 	stream << "#define DefaultColorBinding " << RHI::RHIVertexDescription::DefaultColorBinding << "\n";
 	stream << "#define DefaultTangentBinding " << RHI::RHIVertexDescription::DefaultTangentBinding << "\n";
 	stream << "#define DefaultBitangentBinding " << RHI::RHIVertexDescription::DefaultBitangentBinding << "\n";
+	stream << "#define DefaultBoneIdsBinding " << RHI::RHIVertexDescription::DefaultBoneIdsBinding << "\n";
+	stream << "#define DefaultBoneWeightsBinding " << RHI::RHIVertexDescription::DefaultBoneWeightsBinding << "\n";
 
 	stream << "\n" << "// Tile Lighting" << "\n";
 	stream << "#define LIGHTS_CULLING_TILE_SIZE " << LightCullingNode::TileSize << "\n";

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.h
@@ -116,7 +116,7 @@ namespace Sailor
 
 	public:
 		// Bump whenever generated shader source or compiled artifact semantics change.
-		static constexpr uint32_t CacheProducerVersion = 5;
+		static constexpr uint32_t CacheProducerVersion = 6;
 
 		SAILOR_API ShaderCompiler(ShaderAssetInfoHandler* infoHandler);
 

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.h
@@ -116,7 +116,7 @@ namespace Sailor
 
 	public:
 		// Bump whenever generated shader source or compiled artifact semantics change.
-		static constexpr uint32_t CacheProducerVersion = 7;
+		static constexpr uint32_t CacheProducerVersion = 8;
 
 		SAILOR_API ShaderCompiler(ShaderAssetInfoHandler* infoHandler);
 

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.h
@@ -116,7 +116,7 @@ namespace Sailor
 
 	public:
 		// Bump whenever generated shader source or compiled artifact semantics change.
-		static constexpr uint32_t CacheProducerVersion = 6;
+		static constexpr uint32_t CacheProducerVersion = 7;
 
 		SAILOR_API ShaderCompiler(ShaderAssetInfoHandler* infoHandler);
 

--- a/Runtime/AssetRegistry/Shader/ShaderDependencyFingerprint.h
+++ b/Runtime/AssetRegistry/Shader/ShaderDependencyFingerprint.h
@@ -57,8 +57,6 @@ namespace Sailor
 			appendString(file.m_winnerIdentity);
 			appendUint64(file.m_mountKind);
 			appendUint64(static_cast<uint64_t>(file.m_revision.m_modificationTimeNanoseconds));
-			appendUint64(file.m_revision.m_fileSize);
-			appendUint64(file.m_revision.m_contentHash);
 		}
 
 		return hash == 0 ? 1 : hash;

--- a/Runtime/AssetRegistry/Texture/TextureImporter.cpp
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.cpp
@@ -240,41 +240,41 @@ Tasks::TaskPtr<TexturePtr> TextureImporter::GetLoadPromise(FileId uid)
 
 TextureImporter::TextureSamplersSnapshot TextureImporter::GetTextureSamplersSnapshot(const TVector<uint32_t>& requestedIndices) const
 {
-	std::lock_guard<std::mutex> lock(m_textureSamplersMutex);
 	TextureSamplersSnapshot snapshot;
 	snapshot.m_slots.Reserve(requestedIndices.Num());
+	m_textureSamplersLock.Lock();
 
-	if (!m_textureSamplersBindings)
+	if (m_textureSamplersBindings)
 	{
-		return snapshot;
-	}
-
-	const auto& shaderBindings = m_textureSamplersBindings->GetShaderBindings();
-	const auto textureSamplers = shaderBindings.Find("textureSamplers");
-	const TVector<RHI::RHITexturePtr>* textures = nullptr;
-	if (textureSamplers != shaderBindings.end() && textureSamplers->m_second)
-	{
-		textures = &textureSamplers->m_second->GetTextureBindings();
-	}
-
-	for (const uint32_t requestedIndex : requestedIndices)
-	{
-		TextureSamplerSlotSnapshot slot;
-		slot.m_index = requestedIndex;
-		if (requestedIndex < m_textureSamplerSlotRevisions.Num())
+		const auto& shaderBindings = m_textureSamplersBindings->GetShaderBindings();
+		const auto textureSamplers = shaderBindings.Find("textureSamplers");
+		const TVector<RHI::RHITexturePtr>* textures = nullptr;
+		if (textureSamplers != shaderBindings.end() && textureSamplers->m_second)
 		{
-			slot.m_contentRevision = m_textureSamplerSlotRevisions[requestedIndex];
+			textures = &textureSamplers->m_second->GetTextureBindings();
 		}
 
-		if (textures && requestedIndex < textures->Num())
+		for (const uint32_t requestedIndex : requestedIndices)
 		{
-			slot.m_texture = (*textures)[requestedIndex];
+			TextureSamplerSlotSnapshot slot;
+			slot.m_index = requestedIndex;
+			if (requestedIndex < m_textureSamplerSlotRevisions.Num())
+			{
+				slot.m_contentRevision = m_textureSamplerSlotRevisions[requestedIndex];
+			}
+
+			if (textures && requestedIndex < textures->Num())
+			{
+				slot.m_texture = (*textures)[requestedIndex];
+			}
+
+			snapshot.m_slots.Emplace(std::move(slot));
 		}
 
-		snapshot.m_slots.Emplace(std::move(slot));
+		snapshot.m_descriptorRevision = m_textureSamplersBindings->GetDescriptorRevision();
 	}
 
-	snapshot.m_descriptorRevision = m_textureSamplersBindings->GetDescriptorRevision();
+	m_textureSamplersLock.Unlock();
 	return snapshot;
 }
 
@@ -286,23 +286,26 @@ bool TextureImporter::RegisterTextureSamplerBinding(RHI::RHITexturePtr texture, 
 		return false;
 	}
 
-	std::lock_guard<std::mutex> lock(m_textureSamplersMutex);
+	m_textureSamplersLock.Lock();
 	const size_t nextIndex = m_textureSamplersCurrentIndex.load(std::memory_order_relaxed);
-	if (!IsUserTextureSamplerIndexValid(nextIndex))
+	const bool bCanRegister = IsUserTextureSamplerIndexValid(nextIndex);
+	bool bRegistered = false;
+	if (bCanRegister)
 	{
-		return false;
+		outIndex = nextIndex;
+		bRegistered = UpdateTextureSamplerBindingLocked(
+			texture,
+			static_cast<uint32_t>(nextIndex));
+		if (bRegistered)
+		{
+			// Publish the next free slot only after the native descriptor write and slot
+			// revision have both succeeded. A failed write can therefore be retried.
+			m_textureSamplersCurrentIndex.store(nextIndex + 1, std::memory_order_release);
+		}
 	}
 
-	outIndex = nextIndex;
-	if (!UpdateTextureSamplerBindingLocked(texture, static_cast<uint32_t>(nextIndex)))
-	{
-		return false;
-	}
-
-	// Publish the next free slot only after the native descriptor write and slot
-	// revision have both succeeded. A failed write can therefore be retried.
-	m_textureSamplersCurrentIndex.store(nextIndex + 1, std::memory_order_release);
-	return true;
+	m_textureSamplersLock.Unlock();
+	return bRegistered;
 }
 
 bool TextureImporter::UpdateTextureSamplerBinding(RHI::RHITexturePtr texture, uint32_t index)
@@ -312,8 +315,10 @@ bool TextureImporter::UpdateTextureSamplerBinding(RHI::RHITexturePtr texture, ui
 		return false;
 	}
 
-	std::lock_guard<std::mutex> lock(m_textureSamplersMutex);
-	return UpdateTextureSamplerBindingLocked(std::move(texture), index);
+	m_textureSamplersLock.Lock();
+	const bool bUpdated = UpdateTextureSamplerBindingLocked(std::move(texture), index);
+	m_textureSamplersLock.Unlock();
+	return bUpdated;
 }
 
 bool TextureImporter::UpdateTextureSamplerBindingLocked(RHI::RHITexturePtr texture, uint32_t index)

--- a/Runtime/AssetRegistry/Texture/TextureImporter.cpp
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.cpp
@@ -64,22 +64,93 @@ bool ExtractTextureFromGLB(const std::string& filePath, int32_t textureIndex, Sa
 
 	TVector<char> jsonChunk(jsonChunkHeader.chunkLength);
 	file.read(jsonChunk.GetData(), jsonChunkHeader.chunkLength);
-	nlohmann::json gltfJson = nlohmann::json::parse(
+	const nlohmann::json gltfJson = nlohmann::json::parse(
 		jsonChunk.GetData(),
-		jsonChunk.GetData() + jsonChunk.Num());
+		jsonChunk.GetData() + jsonChunk.Num(),
+		nullptr,
+		false);
 
-	if (textureIndex < 0 || textureIndex >= gltfJson["textures"].size())
+	if (gltfJson.is_discarded() || !gltfJson.is_object())
 	{
-		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Invalid texture index");
+		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Invalid JSON: %s", filePath.c_str());
 		return false;
 	}
 
-	int32_t imageIndex = gltfJson["textures"][textureIndex]["source"];
-	int32_t bufferViewIndex = gltfJson["images"][imageIndex]["bufferView"];
-	const auto& bufferView = gltfJson["bufferViews"][bufferViewIndex];
-	//int32_t bufferIndex = bufferView["buffer"];
-	int32_t byteOffset = bufferView["byteOffset"];
-	int32_t byteLength = bufferView["byteLength"];
+	auto tryGetNonNegativeInteger = [](const nlohmann::json& value, uint64_t& outValue)
+		{
+			if (value.is_number_unsigned())
+			{
+				outValue = value.get<uint64_t>();
+				return true;
+			}
+
+			if (value.is_number_integer())
+			{
+				const int64_t signedValue = value.get<int64_t>();
+				if (signedValue >= 0)
+				{
+					outValue = static_cast<uint64_t>(signedValue);
+					return true;
+				}
+			}
+
+			return false;
+		};
+
+	const auto texturesIt = gltfJson.find("textures");
+	const auto imagesIt = gltfJson.find("images");
+	const auto bufferViewsIt = gltfJson.find("bufferViews");
+	if (texturesIt == gltfJson.end() || !texturesIt->is_array() ||
+		imagesIt == gltfJson.end() || !imagesIt->is_array() ||
+		bufferViewsIt == gltfJson.end() || !bufferViewsIt->is_array() ||
+		textureIndex < 0 || static_cast<size_t>(textureIndex) >= texturesIt->size())
+	{
+		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Invalid texture index %d: %s", textureIndex, filePath.c_str());
+		return false;
+	}
+
+	const auto& texture = (*texturesIt)[static_cast<size_t>(textureIndex)];
+	const auto sourceIt = texture.is_object() ? texture.find("source") : texture.end();
+	uint64_t imageIndex = 0;
+	if (!texture.is_object() || sourceIt == texture.end() ||
+		!tryGetNonNegativeInteger(*sourceIt, imageIndex) || imageIndex >= imagesIt->size())
+	{
+		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Invalid image source for texture %d: %s", textureIndex, filePath.c_str());
+		return false;
+	}
+
+	const auto& image = (*imagesIt)[static_cast<size_t>(imageIndex)];
+	const auto bufferViewIt = image.is_object() ? image.find("bufferView") : image.end();
+	uint64_t bufferViewIndex = 0;
+	if (!image.is_object() || bufferViewIt == image.end() ||
+		!tryGetNonNegativeInteger(*bufferViewIt, bufferViewIndex) || bufferViewIndex >= bufferViewsIt->size())
+	{
+		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Invalid image buffer view for texture %d: %s", textureIndex, filePath.c_str());
+		return false;
+	}
+
+	const auto& bufferView = (*bufferViewsIt)[static_cast<size_t>(bufferViewIndex)];
+	if (!bufferView.is_object())
+	{
+		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Invalid buffer view for texture %d: %s", textureIndex, filePath.c_str());
+		return false;
+	}
+
+	uint64_t byteOffset = 0;
+	const auto byteOffsetIt = bufferView.find("byteOffset");
+	if (byteOffsetIt != bufferView.end() && !tryGetNonNegativeInteger(*byteOffsetIt, byteOffset))
+	{
+		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Invalid byte offset for texture %d: %s", textureIndex, filePath.c_str());
+		return false;
+	}
+
+	uint64_t byteLength = 0;
+	const auto byteLengthIt = bufferView.find("byteLength");
+	if (byteLengthIt == bufferView.end() || !tryGetNonNegativeInteger(*byteLengthIt, byteLength) || byteLength == 0)
+	{
+		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Invalid byte length for texture %d: %s", textureIndex, filePath.c_str());
+		return false;
+	}
 
 	file.seekg(sizeof(GLBHeader) + sizeof(GLBChunkHeader) + jsonChunkHeader.chunkLength, std::ios::beg);
 
@@ -91,15 +162,21 @@ bool ExtractTextureFromGLB(const std::string& filePath, int32_t textureIndex, Sa
 		return false;
 	}
 
-	if (byteOffset + byteLength > (int32_t)binChunkHeader.chunkLength)
+	if (byteOffset > binChunkHeader.chunkLength || byteLength > binChunkHeader.chunkLength - byteOffset)
 	{
-		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Invalid buffer view");
+		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Invalid buffer view range for texture %d: %s", textureIndex, filePath.c_str());
 		return false;
 	}
 
-	file.seekg(byteOffset, std::ios::cur);
-	outTexture.Resize(byteLength);
-	file.read(reinterpret_cast<char*>(&outTexture[0]), byteLength);
+	file.seekg(static_cast<std::streamoff>(byteOffset), std::ios::cur);
+	outTexture.Resize(static_cast<size_t>(byteLength));
+	file.read(reinterpret_cast<char*>(&outTexture[0]), static_cast<std::streamsize>(byteLength));
+	if (!file)
+	{
+		outTexture.Clear();
+		SAILOR_LOG_ERROR("Failed to extract texture from GLB, Cannot read texture %d: %s", textureIndex, filePath.c_str());
+		return false;
+	}
 
 	return true;
 }
@@ -126,6 +203,9 @@ TextureImporter::TextureImporter(TextureAssetInfoHandler* infoHandler)
 
 	auto textures = driver->AddSamplerToShaderBindings(m_textureSamplersBindings, "textureSamplers", defaultTextures, 0, true, static_cast<uint32_t>(MaxTexturesInScene));
 	m_textureSamplersBindings->RecalculateCompatibility();
+
+	m_textureSamplerSlotRevisions.Resize(1);
+	m_textureSamplerSlotRevisions[0] = m_textureSamplersBindings->GetDescriptorRevision();
 }
 
 TextureImporter::~TextureImporter()
@@ -156,6 +236,103 @@ Tasks::TaskPtr<TexturePtr> TextureImporter::GetLoadPromise(FileId uid)
 	}
 
 	return Tasks::TaskPtr<TexturePtr>();
+}
+
+TextureImporter::TextureSamplersSnapshot TextureImporter::GetTextureSamplersSnapshot(const TVector<uint32_t>& requestedIndices) const
+{
+	std::lock_guard<std::mutex> lock(m_textureSamplersMutex);
+	TextureSamplersSnapshot snapshot;
+	snapshot.m_slots.Reserve(requestedIndices.Num());
+
+	if (!m_textureSamplersBindings)
+	{
+		return snapshot;
+	}
+
+	const auto& shaderBindings = m_textureSamplersBindings->GetShaderBindings();
+	const auto textureSamplers = shaderBindings.Find("textureSamplers");
+	const TVector<RHI::RHITexturePtr>* textures = nullptr;
+	if (textureSamplers != shaderBindings.end() && textureSamplers->m_second)
+	{
+		textures = &textureSamplers->m_second->GetTextureBindings();
+	}
+
+	for (const uint32_t requestedIndex : requestedIndices)
+	{
+		TextureSamplerSlotSnapshot slot;
+		slot.m_index = requestedIndex;
+		if (requestedIndex < m_textureSamplerSlotRevisions.Num())
+		{
+			slot.m_contentRevision = m_textureSamplerSlotRevisions[requestedIndex];
+		}
+
+		if (textures && requestedIndex < textures->Num())
+		{
+			slot.m_texture = (*textures)[requestedIndex];
+		}
+
+		snapshot.m_slots.Emplace(std::move(slot));
+	}
+
+	snapshot.m_descriptorRevision = m_textureSamplersBindings->GetDescriptorRevision();
+	return snapshot;
+}
+
+bool TextureImporter::RegisterTextureSamplerBinding(RHI::RHITexturePtr texture, size_t& outIndex)
+{
+	outIndex = 0;
+	if (!texture)
+	{
+		return false;
+	}
+
+	std::lock_guard<std::mutex> lock(m_textureSamplersMutex);
+	const size_t nextIndex = m_textureSamplersCurrentIndex.load(std::memory_order_relaxed);
+	if (!IsUserTextureSamplerIndexValid(nextIndex))
+	{
+		return false;
+	}
+
+	outIndex = nextIndex;
+	if (!UpdateTextureSamplerBindingLocked(texture, static_cast<uint32_t>(nextIndex)))
+	{
+		return false;
+	}
+
+	// Publish the next free slot only after the native descriptor write and slot
+	// revision have both succeeded. A failed write can therefore be retried.
+	m_textureSamplersCurrentIndex.store(nextIndex + 1, std::memory_order_release);
+	return true;
+}
+
+bool TextureImporter::UpdateTextureSamplerBinding(RHI::RHITexturePtr texture, uint32_t index)
+{
+	if (!IsUserTextureSamplerIndexValid(index) || !texture)
+	{
+		return false;
+	}
+
+	std::lock_guard<std::mutex> lock(m_textureSamplersMutex);
+	return UpdateTextureSamplerBindingLocked(std::move(texture), index);
+}
+
+bool TextureImporter::UpdateTextureSamplerBindingLocked(RHI::RHITexturePtr texture, uint32_t index)
+{
+	const uint64_t previousRevision = m_textureSamplersBindings->GetDescriptorRevision();
+	RHI::Renderer::GetDriver()->UpdateShaderBinding(m_textureSamplersBindings, "textureSamplers", texture, index);
+	const uint64_t currentRevision = m_textureSamplersBindings->GetDescriptorRevision();
+
+	if (currentRevision == previousRevision)
+	{
+		return false;
+	}
+
+	if (m_textureSamplerSlotRevisions.Num() <= index)
+	{
+		m_textureSamplerSlotRevisions.Resize(index + 1);
+	}
+	m_textureSamplerSlotRevisions[index] = currentRevision;
+	return true;
 }
 
 void TextureImporter::OnUpdateAssetInfo(AssetInfoPtr inAssetInfo, bool bWasExpired)
@@ -200,8 +377,7 @@ void TextureImporter::OnUpdateAssetInfo(AssetInfoPtr inAssetInfo, bool bWasExpir
 						size_t index = m_textureSamplersIndices.At_Lock(assetInfo->GetFileId());
 						m_textureSamplersIndices.Unlock(assetInfo->GetFileId());
 
-						RHI::Renderer::GetDriver()->UpdateShaderBinding(m_textureSamplersBindings, "textureSamplers", pTexture->m_rhiTexture, (uint32_t)index);
-						return true;
+						return UpdateTextureSamplerBinding(pTexture->m_rhiTexture, static_cast<uint32_t>(index));
 					}
 					return false;
 				}, EThreadType::RHI)->Run();
@@ -399,12 +575,24 @@ Tasks::TaskPtr<TexturePtr> TextureImporter::LoadTexture(FileId uid, TexturePtr& 
 
 						RHI::Renderer::GetDriver()->SetDebugName(pTexture->m_rhiTexture, pAssetInfo->GetAssetFilepath());
 
-						size_t index = m_textureSamplersCurrentIndex++;
-
-						m_textureSamplersIndices.At_Lock(pAssetInfo->GetFileId()) = index;
-						m_textureSamplersIndices.Unlock(pAssetInfo->GetFileId());
-
-						RHI::Renderer::GetDriver()->UpdateShaderBinding(m_textureSamplersBindings, "textureSamplers", pTexture->m_rhiTexture, (uint32_t)index);
+						size_t index = 0;
+						if (RegisterTextureSamplerBinding(pTexture->m_rhiTexture, index))
+						{
+							m_textureSamplersIndices.At_Lock(pAssetInfo->GetFileId()) = index;
+							m_textureSamplersIndices.Unlock(pAssetInfo->GetFileId());
+						}
+						else if (index == 0)
+						{
+							SAILOR_LOG_ERROR("Cannot register texture sampler '%s': the scene texture capacity of %zu user textures is exhausted.",
+								pAssetInfo->GetAssetFilepath().c_str(),
+								MaxUserTexturesInScene);
+						}
+						else
+						{
+							SAILOR_LOG_ERROR("Cannot register texture sampler '%s' at index %zu: descriptor update failed.",
+								pAssetInfo->GetAssetFilepath().c_str(),
+								index);
+						}
 					}
 
 					return pTexture;

--- a/Runtime/AssetRegistry/Texture/TextureImporter.cpp
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <fstream>
 #include <algorithm>
+#include <cstring>
 #include <iostream>
 #include "Tasks/Scheduler.h"
 #include "RHI/Texture.h"
@@ -179,6 +180,107 @@ bool ExtractTextureFromGLB(const std::string& filePath, int32_t textureIndex, Sa
 	}
 
 	return true;
+}
+
+namespace
+{
+	int32_t ResolveGltfTextureImageIndex(const tinygltf::Texture& texture)
+	{
+		if (texture.source >= 0)
+		{
+			return texture.source;
+		}
+
+		// Some texture formats keep their image source in an extension instead of
+		// the core texture.source field. Extraction remains format-agnostic here;
+		// stb_image decides below whether the encoded bytes can be decoded.
+		constexpr const char* ImageSourceExtensions[] = {
+			"KHR_texture_basisu",
+			"EXT_texture_webp",
+			"MSFT_texture_dds"
+		};
+		for (const char* extensionName : ImageSourceExtensions)
+		{
+			const auto extensionIt = texture.extensions.find(extensionName);
+			if (extensionIt == texture.extensions.end() ||
+				!extensionIt->second.IsObject() ||
+				!extensionIt->second.Has("source"))
+			{
+				continue;
+			}
+
+			const tinygltf::Value& source = extensionIt->second.Get("source");
+			if (source.IsInt())
+			{
+				return source.GetNumberAsInt();
+			}
+		}
+
+		return -1;
+	}
+
+	bool ExtractTextureFromGltf(
+		const std::string& filePath,
+		int32_t textureIndex,
+		Sailor::TextureImporter::ByteCode& outTexture,
+		std::string& outDiagnostic)
+	{
+		outTexture.Clear();
+		outDiagnostic.clear();
+
+		tinygltf::TinyGLTF loader;
+		loader.SetImagesAsIs(true);
+
+		tinygltf::Model gltfModel;
+		std::string error;
+		std::string warning;
+		if (!loader.LoadASCIIFromFile(
+				&gltfModel,
+				&error,
+				&warning,
+				filePath.c_str()))
+		{
+			outDiagnostic = !error.empty() ? error : warning;
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = "tinygltf could not load the source document";
+			}
+			return false;
+		}
+
+		if (textureIndex < 0 ||
+			static_cast<size_t>(textureIndex) >= gltfModel.textures.size())
+		{
+			outDiagnostic = "texture index is outside the glTF textures array";
+			return false;
+		}
+
+		const int32_t imageIndex = ResolveGltfTextureImageIndex(
+			gltfModel.textures[static_cast<size_t>(textureIndex)]);
+		if (imageIndex < 0 ||
+			static_cast<size_t>(imageIndex) >= gltfModel.images.size())
+		{
+			outDiagnostic = "texture does not reference a valid glTF image";
+			return false;
+		}
+
+		const tinygltf::Image& image =
+			gltfModel.images[static_cast<size_t>(imageIndex)];
+		if (image.image.empty())
+		{
+			outDiagnostic = warning.empty() ?
+				"referenced glTF image contains no encoded bytes" :
+				warning;
+			return false;
+		}
+
+		outTexture.Resize(image.image.size());
+		memcpy(
+			outTexture.GetData(),
+			image.image.data(),
+			image.image.size());
+		return true;
+	}
 }
 
 bool Texture::IsReady() const
@@ -411,15 +513,35 @@ bool TextureImporter::ImportTexture(FileId uid, ByteCode& decodedData, int32_t& 
 
 		if (assetInfo->StoredInGlb())
 		{
-			const bool bIsGlb = Utils::GetFileExtension(assetInfo->GetAssetFilepath().c_str()) == "glb";
+			const std::string extension =
+				Utils::GetFileExtension(assetInfo->GetAssetFilepath().c_str());
+			const bool bIsGlb = extension == "glb";
+			const bool bIsGltf = extension == "gltf";
 
-			if (!bIsGlb || (assetInfo->GetGlbTextureIndex() == -1))
+			if ((!bIsGlb && !bIsGltf) ||
+				assetInfo->GetGlbTextureIndex() == -1)
 			{
 				return false;
 			}
 
 			ByteCode rawBuffer;
-			const bool bExtracted = ExtractTextureFromGLB(assetInfo->GetAssetFilepath().c_str(), assetInfo->GetGlbTextureIndex(), rawBuffer);
+			std::string extractionDiagnostic;
+			const bool bExtracted = bIsGlb ?
+				ExtractTextureFromGLB(
+					assetInfo->GetAssetFilepath().c_str(),
+					assetInfo->GetGlbTextureIndex(),
+					rawBuffer) :
+				ExtractTextureFromGltf(
+					assetInfo->GetAssetFilepath(),
+					assetInfo->GetGlbTextureIndex(),
+					rawBuffer,
+					extractionDiagnostic);
+			if (!bExtracted && extractionDiagnostic.empty())
+			{
+				extractionDiagnostic = bIsGlb ?
+					"GLB extraction failed" :
+					"glTF extraction failed";
+			}
 
 			if (bExtracted)
 			{
@@ -452,8 +574,12 @@ bool TextureImporter::ImportTexture(FileId uid, ByteCode& decodedData, int32_t& 
 			}
 			else
 			{
-				const auto msg = "Cannot extract texture from glb! " + uid.ToString();
-				SAILOR_LOG_ERROR("%s", msg.c_str());
+				SAILOR_LOG_ERROR(
+					"Cannot extract texture %d from model source '%s' for asset %s: %s",
+					assetInfo->GetGlbTextureIndex(),
+					assetInfo->GetAssetFilepath().c_str(),
+					uid.ToString().c_str(),
+					extractionDiagnostic.c_str());
 			}
 
 			return false;

--- a/Runtime/AssetRegistry/Texture/TextureImporter.h
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Core/Defines.h"
+#include <mutex>
 #include <string>
 #include "Containers/Vector.h"
 #include "Containers/ConcurrentMap.h"
@@ -51,10 +52,29 @@ namespace Sailor
 	class TextureImporter final : public TSubmodule<TextureImporter>, public IAssetInfoHandlerListener, public IAssetFactory
 	{
 	public:
+		struct TextureSamplerSlotSnapshot
+		{
+			uint32_t m_index = 0;
+			uint64_t m_contentRevision = 0;
+			RHI::RHITexturePtr m_texture;
+		};
+
+		struct TextureSamplersSnapshot
+		{
+			uint64_t m_descriptorRevision = 0;
+			TVector<TextureSamplerSlotSnapshot> m_slots;
+		};
 
 		// Keep this in sync with runtime descriptor allocation on macOS/MoltenVK.
 		// 262144 overflows Metal argument-buffer validation in current path.
-		static const size_t MaxTexturesInScene = 8192;
+		// Slot zero is reserved for the default texture.
+		static constexpr size_t MaxTexturesInScene = 8192;
+		static constexpr size_t MaxUserTexturesInScene = MaxTexturesInScene - 1;
+
+		static constexpr bool IsUserTextureSamplerIndexValid(size_t index) noexcept
+		{
+			return index > 0 && index < MaxTexturesInScene;
+		}
 
 		using ByteCode = TVector<uint8_t>;
 
@@ -77,6 +97,7 @@ namespace Sailor
 		SAILOR_API virtual void CollectGarbage() override;
 
 		SAILOR_API RHI::RHIShaderBindingSetPtr GetTextureSamplersBindingSet() { return m_textureSamplersBindings; }
+		SAILOR_API TextureSamplersSnapshot GetTextureSamplersSnapshot(const TVector<uint32_t>& requestedIndices) const;
 		SAILOR_API size_t GetTextureIndex(FileId uid);
 		SAILOR_API size_t GetTextureSamplersCount() const { return m_textureSamplersCurrentIndex.load(); }
 
@@ -86,12 +107,17 @@ namespace Sailor
 		std::atomic<size_t> m_textureSamplersCurrentIndex = 0;
 		RHI::RHIShaderBindingSetPtr m_textureSamplersBindings{};
 		TConcurrentMap<FileId, size_t> m_textureSamplersIndices{};
+		TVector<uint64_t> m_textureSamplerSlotRevisions{};
+		mutable std::mutex m_textureSamplersMutex;
 
 		TConcurrentMap<FileId, Tasks::TaskPtr<TexturePtr>> m_promises{};
 		TConcurrentMap<FileId, TexturePtr> m_loadedTextures{};
 
 		Memory::ObjectAllocatorPtr m_allocator;
 
+		bool RegisterTextureSamplerBinding(RHI::RHITexturePtr texture, size_t& outIndex);
+		bool UpdateTextureSamplerBinding(RHI::RHITexturePtr texture, uint32_t index);
+		bool UpdateTextureSamplerBindingLocked(RHI::RHITexturePtr texture, uint32_t index);
 		SAILOR_API bool IsTextureLoaded(FileId uid) const;
 		SAILOR_API static bool ImportTexture(FileId uid, ByteCode& decodedData, int32_t& width, int32_t& height, uint32_t& mipLevels);
 	};

--- a/Runtime/AssetRegistry/Texture/TextureImporter.h
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.h
@@ -1,9 +1,9 @@
 #pragma once
 #include "Core/Defines.h"
-#include <mutex>
 #include <string>
 #include "Containers/Vector.h"
 #include "Containers/ConcurrentMap.h"
+#include "Core/SpinLock.h"
 #include "Core/Submodule.h"
 #include "Engine/Types.h"
 #include "Memory/SharedPtr.hpp"
@@ -108,7 +108,7 @@ namespace Sailor
 		RHI::RHIShaderBindingSetPtr m_textureSamplersBindings{};
 		TConcurrentMap<FileId, size_t> m_textureSamplersIndices{};
 		TVector<uint64_t> m_textureSamplerSlotRevisions{};
-		mutable std::mutex m_textureSamplersMutex;
+		mutable SpinLock m_textureSamplersLock;
 
 		TConcurrentMap<FileId, Tasks::TaskPtr<TexturePtr>> m_promises{};
 		TConcurrentMap<FileId, TexturePtr> m_loadedTextures{};

--- a/Runtime/Components/EditorComponent.cpp
+++ b/Runtime/Components/EditorComponent.cpp
@@ -20,6 +20,14 @@ using namespace Sailor::Tasks;
 
 void EditorComponent::EditorTick(float deltaTime)
 {
+	auto& transform = GetOwner()->GetTransformComponent();
+	auto syncViewAngles = [&]()
+	{
+		const vec3 forward = transform.GetTransform().GetForward();
+		m_yaw = glm::degrees(glm::atan(forward.x, -forward.z));
+		m_pitch = glm::degrees(glm::asin(glm::clamp(forward.y, -1.0f, 1.0f)));
+	};
+
 	if (!m_bInited)
 	{
 		auto& debugContext = GetWorld()->GetDebugContext();
@@ -48,18 +56,22 @@ void EditorComponent::EditorTick(float deltaTime)
 		}
 
 		debugContext->DrawOrigin(glm::vec4(0, 0, 0, 1), glm::mat4(1), 1000.0f, maxDuration);
+		syncViewAngles();
+		m_lastCursorPos = GetWorld()->GetInput().GetCursorPos();
 		m_bInited = true;
 		return;
 	}
 
-	auto& transform = GetOwner()->GetTransformComponent();
 	const vec3 cameraViewDirection = transform.GetRotation() * Math::vec4_Forward;
 
 	const float sensitivity = 1500;
 
 	const bool bNavigatingViewport = GetWorld()->GetInput().IsKeyDown(VK_RBUTTON);
-	const bool bStartedNavigatingViewport = bNavigatingViewport && !m_bWasNavigatingViewport;
 	const glm::ivec2 cursorPos = GetWorld()->GetInput().GetCursorPos();
+	if (!bNavigatingViewport)
+	{
+		syncViewAngles();
+	}
 	if (bNavigatingViewport)
 	{
 		glm::vec3 delta = glm::vec3(0.0f, 0.0f, 0.0f);
@@ -92,17 +104,10 @@ void EditorComponent::EditorTick(float deltaTime)
 			transform.SetPosition(transform.GetPosition() + shift);
 		}
 
-		if (bStartedNavigatingViewport)
-		{
-			const vec3 forward = transform.GetTransform().GetForward();
-			m_yaw = glm::degrees(glm::atan(forward.x, -forward.z));
-			m_pitch = glm::degrees(glm::asin(glm::clamp(forward.y, -1.0f, 1.0f)));
-			m_lastCursorPos = cursorPos;
-		}
-		else
+		const vec2 deltaCursorPos = cursorPos - m_lastCursorPos;
+		if (deltaCursorPos != vec2(0.0f))
 		{
 			constexpr float rotationDegreesPerPixel = 0.2f;
-			const vec2 deltaCursorPos = cursorPos - m_lastCursorPos;
 			const vec2 rotationDelta = deltaCursorPos * rotationDegreesPerPixel;
 
 			m_yaw += rotationDelta.x;
@@ -115,7 +120,6 @@ void EditorComponent::EditorTick(float deltaTime)
 		}
 	}
 
-	m_bWasNavigatingViewport = bNavigatingViewport;
 	m_lastCursorPos = cursorPos;
 
 }

--- a/Runtime/Components/EditorComponent.cpp
+++ b/Runtime/Components/EditorComponent.cpp
@@ -58,6 +58,8 @@ void EditorComponent::EditorTick(float deltaTime)
 	const float sensitivity = 1500;
 
 	const bool bNavigatingViewport = GetWorld()->GetInput().IsKeyDown(VK_RBUTTON);
+	const bool bStartedNavigatingViewport = bNavigatingViewport && !m_bWasNavigatingViewport;
+	const glm::ivec2 cursorPos = GetWorld()->GetInput().GetCursorPos();
 	if (bNavigatingViewport)
 	{
 		glm::vec3 delta = glm::vec3(0.0f, 0.0f, 0.0f);
@@ -90,14 +92,17 @@ void EditorComponent::EditorTick(float deltaTime)
 			transform.SetPosition(transform.GetPosition() + shift);
 		}
 
-		if (GetWorld()->GetInput().IsKeyPressed(VK_RBUTTON))
+		if (bStartedNavigatingViewport)
 		{
-			m_lastCursorPos = GetWorld()->GetInput().GetCursorPos();
+			const vec3 forward = transform.GetTransform().GetForward();
+			m_yaw = glm::degrees(glm::atan(forward.x, -forward.z));
+			m_pitch = glm::degrees(glm::asin(glm::clamp(forward.y, -1.0f, 1.0f)));
+			m_lastCursorPos = cursorPos;
 		}
 		else
 		{
 			constexpr float rotationDegreesPerPixel = 0.2f;
-			const vec2 deltaCursorPos = GetWorld()->GetInput().GetCursorPos() - m_lastCursorPos;
+			const vec2 deltaCursorPos = cursorPos - m_lastCursorPos;
 			const vec2 rotationDelta = deltaCursorPos * rotationDegreesPerPixel;
 
 			m_yaw += rotationDelta.x;
@@ -110,6 +115,7 @@ void EditorComponent::EditorTick(float deltaTime)
 		}
 	}
 
-	m_lastCursorPos = GetWorld()->GetInput().GetCursorPos();
+	m_bWasNavigatingViewport = bNavigatingViewport;
+	m_lastCursorPos = cursorPos;
 
 }

--- a/Runtime/Components/EditorComponent.h
+++ b/Runtime/Components/EditorComponent.h
@@ -25,6 +25,7 @@ namespace Sailor
 	protected:
 
 		bool m_bInited = false;
+		bool m_bWasNavigatingViewport = false;
 		float m_yaw = 0.0f;
 		float m_pitch = 0.0f;
 

--- a/Runtime/Components/EditorComponent.h
+++ b/Runtime/Components/EditorComponent.h
@@ -25,7 +25,6 @@ namespace Sailor
 	protected:
 
 		bool m_bInited = false;
-		bool m_bWasNavigatingViewport = false;
 		float m_yaw = 0.0f;
 		float m_pitch = 0.0f;
 

--- a/Runtime/Components/MeshRendererComponent.cpp
+++ b/Runtime/Components/MeshRendererComponent.cpp
@@ -1,6 +1,7 @@
 #include "Components/MeshRendererComponent.h"
 #include "Engine/GameObject.h"
 #include "ECS/StaticMeshRendererECS.h"
+#include "AssetRegistry/Material/MaterialImporter.h"
 
 using namespace Sailor;
 using namespace Sailor::Tasks;
@@ -39,12 +40,66 @@ void MeshRendererComponent::EndPlay()
 void MeshRendererComponent::SetModel(const ModelPtr& model)
 {
 	GetData().SetModel(model);
-	GetData().MarkDirty();
+	RebuildMaterials();
+}
 
-	if (model && model->GetFileId())
+void MeshRendererComponent::SetOverrideMaterials(const TVector<FileId>& overrideMaterials)
+{
+	m_overrideMaterials = overrideMaterials;
+	RebuildMaterials();
+}
+
+void MeshRendererComponent::RebuildMaterials()
+{
+	auto& materials = GetMaterials();
+	materials.Clear();
+
+	const ModelPtr& model = GetModel();
+	if (!model || !model->GetFileId())
 	{
-		App::GetSubmodule<ModelImporter>()->LoadDefaultMaterials(model->GetFileId(), GetMaterials());
+		GetData().MarkDirty();
+		return;
 	}
+
+	if (auto* modelImporter = App::GetSubmodule<ModelImporter>())
+	{
+		modelImporter->LoadDefaultMaterials(model->GetFileId(), materials);
+	}
+
+	if (auto* materialImporter = App::GetSubmodule<MaterialImporter>())
+	{
+		for (size_t materialIndex = 0; materialIndex < m_overrideMaterials.Num(); ++materialIndex)
+		{
+			const FileId& materialFileId = m_overrideMaterials[materialIndex];
+			if (!materialFileId)
+			{
+				continue;
+			}
+
+			MaterialPtr overrideMaterial;
+			if (!materialImporter->LoadMaterial(materialFileId, overrideMaterial) || !overrideMaterial)
+			{
+				continue;
+			}
+
+			if (materialIndex >= materials.Num())
+			{
+				const size_t firstNewSlot = materials.Num();
+				const MaterialPtr fallbackMaterial = materials.IsEmpty()
+					? overrideMaterial
+					: *materials.Last();
+				materials.Resize(materialIndex + 1);
+				for (size_t slot = firstNewSlot; slot <= materialIndex; ++slot)
+				{
+					materials[slot] = fallbackMaterial;
+				}
+			}
+
+			materials[materialIndex] = overrideMaterial;
+		}
+	}
+
+	GetData().MarkDirty();
 }
 
 bool MeshRendererComponent::LoadModel(const std::string& path)

--- a/Runtime/Components/MeshRendererComponent.h
+++ b/Runtime/Components/MeshRendererComponent.h
@@ -24,6 +24,8 @@ namespace Sailor
 		SAILOR_API const ModelPtr& GetModel() const { return GetData().GetModel(); }
 		SAILOR_API void SetModel(const ModelPtr& model);
 		SAILOR_API bool LoadModel(const std::string& path);
+		SAILOR_API const TVector<FileId>& GetOverrideMaterials() const { return m_overrideMaterials; }
+		SAILOR_API void SetOverrideMaterials(const TVector<FileId>& overrideMaterials);
 
 		SAILOR_API __forceinline TVector<MaterialPtr>& GetMaterials() { return GetData().GetMaterials(); }
 		SAILOR_API __forceinline StaticMeshRendererData& GetData();
@@ -32,7 +34,10 @@ namespace Sailor
 
 	protected:
 
+		void RebuildMaterials();
+
 		size_t m_handle = (size_t)(-1);
+		TVector<FileId> m_overrideMaterials;
 	};
 }
 
@@ -42,5 +47,8 @@ REFL_AUTO(
 	type(Sailor::MeshRendererComponent, bases<Sailor::Component>),
 
 	func(GetModel, property("model"), SkipCDO()),
-	func(SetModel, property("model"), SkipCDO())
+	func(SetModel, property("model"), SkipCDO()),
+
+	func(GetOverrideMaterials, property("overrideMaterials")),
+	func(SetOverrideMaterials, property("overrideMaterials"))
 )

--- a/Runtime/Components/TestComponent.cpp
+++ b/Runtime/Components/TestComponent.cpp
@@ -169,7 +169,7 @@ void TestComponent::Tick(float deltaTime)
 
 	ImGui::Begin("Performance");
 	ImGui::Text("CPU: %.1f fps (%.2f ms)", cpuFps, cpuFrameMs);
-	ImGui::Text("GPU: %u fps", rendererStats.m_gpuFps);
+	ImGui::Text("GPU: %u fps", rendererStats.m_gpuFps.load(std::memory_order_relaxed));
 	ImGui::Text("GPU memory: %zu / %zu MB", gpuHeapUsageMb, gpuHeapBudgetMb);
 	ImGui::Text("Submitted cmd buffers: %u", rendererStats.m_numSubmittedCommandBuffers);
 	ImGui::End();

--- a/Runtime/Containers/Vector.h
+++ b/Runtime/Containers/Vector.h
@@ -737,7 +737,7 @@ namespace Sailor
 			}
 		}
 
-		__forceinline void ConstructElements(size_t index, const TElementType& firstElement, size_t count = 1) requires IsCopyConstructible<TElementType>
+		__forceinline void ConstructElements(size_t index, const TElementType& firstElement, size_t count) requires IsCopyConstructible<TElementType>
 		{
 			for (size_t i = 0; i < count; i++)
 			{

--- a/Runtime/Core/FileRevision.h
+++ b/Runtime/Core/FileRevision.h
@@ -17,8 +17,6 @@ namespace Sailor
 		bool operator==(const FileRevision& rhs) const noexcept
 		{
 			return m_modificationTimeNanoseconds == rhs.m_modificationTimeNanoseconds &&
-				m_fileSize == rhs.m_fileSize &&
-				m_contentHash == rhs.m_contentHash &&
 				m_bIsValid == rhs.m_bIsValid;
 		}
 

--- a/Runtime/Core/Submodule.h
+++ b/Runtime/Core/Submodule.h
@@ -5,7 +5,7 @@
 namespace Sailor
 {
 	// Used to generate typeId
-	class SAILOR_API SubmoduleBase
+	class SAILOR_SHARED_API SubmoduleBase
 	{
 	public:
 		static constexpr int32_t InvalidSubmoduleTypeId = -1;

--- a/Runtime/Core/Utils.cpp
+++ b/Runtime/Core/Utils.cpp
@@ -13,12 +13,10 @@
 #endif
 
 #include <algorithm> 
-#include <array>
 #include <functional> 
 #include <cctype>
 
 #include <filesystem>
-#include <fstream>
 #include <sstream>
 #include <string>
 #include <format>
@@ -651,58 +649,17 @@ bool Utils::TryGetFileRevision(
 		return false;
 	}
 
-	const auto modificationTimeBefore = std::filesystem::last_write_time(path, error);
+	const auto modificationTime = std::filesystem::last_write_time(path, error);
 	if (error)
 	{
 		return false;
 	}
-	const uint64_t fileSizeBefore = std::filesystem::file_size(path, error);
-	if (error)
-	{
-		return false;
-	}
-
-	std::ifstream stream(path, std::ios::binary);
-	if (!stream.is_open())
-	{
-		return false;
-	}
-
-	// FNV-1a is deterministic across platforms and sufficient for change detection.
-	constexpr uint64_t OffsetBasis = 14695981039346656037ull;
-	constexpr uint64_t Prime = 1099511628211ull;
-	uint64_t contentHash = OffsetBasis;
-	std::array<char, 64 * 1024> buffer{};
-	while (stream)
-	{
-		stream.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
-		const std::streamsize bytesRead = stream.gcount();
-		for (std::streamsize i = 0; i < bytesRead; ++i)
-		{
-			contentHash ^= static_cast<unsigned char>(buffer[static_cast<size_t>(i)]);
-			contentHash *= Prime;
-		}
-	}
-	if (stream.bad())
-	{
-		return false;
-	}
-
-	const auto modificationTimeAfter = std::filesystem::last_write_time(path, error);
-	if (error)
-	{
-		return false;
-	}
-	const uint64_t fileSizeAfter = std::filesystem::file_size(path, error);
-	if (error || modificationTimeBefore != modificationTimeAfter || fileSizeBefore != fileSizeAfter)
-	{
-		return false;
-	}
-
 	outRevision.m_modificationTimeNanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(
-		modificationTimeAfter.time_since_epoch()).count();
-	outRevision.m_fileSize = fileSizeAfter;
-	outRevision.m_contentHash = contentHash;
+		modificationTime.time_since_epoch()).count();
+	outRevision.m_fileSize = 0;
+	// Content hashing made every registry scan read all source assets in full.
+	// The filesystem timestamp is sufficient for runtime change detection.
+	outRevision.m_contentHash = 0;
 	outRevision.m_bIsValid = true;
 	return true;
 }

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -11,17 +11,31 @@
 using namespace Sailor;
 using namespace Sailor::Tasks;
 
+namespace
+{
+	bool AreMatricesExactlyEqual(const glm::mat4& lhs, const glm::mat4& rhs)
+	{
+		for (glm::length_t column = 0; column < lhs.length(); ++column)
+		{
+			for (glm::length_t row = 0; row < lhs[column].length(); ++row)
+			{
+				if (lhs[column][row] != rhs[column][row])
+				{
+					return false;
+				}
+			}
+		}
+
+		return true;
+	}
+}
+
 bool CSMLightState::Equals(const CSMLightState& rhs) const
 {
-	const float CameraPosDelta = 15.0f;
-	const float CameraRotationDelta = 0.9995f;
-
 	if (m_componentIndex != rhs.m_componentIndex ||
+		m_shadowType != rhs.m_shadowType ||
 		m_snapshot.Num() != rhs.m_snapshot.Num() ||
-		glm::distance(m_cameraTransform.m_position, rhs.m_cameraTransform.m_position) > CameraPosDelta ||
-		glm::dot(m_cameraTransform.GetForward(), rhs.m_cameraTransform.GetForward()) < CameraRotationDelta ||
-		m_lightTransform.m_position != rhs.m_lightTransform.m_position ||
-		m_lightTransform.m_rotation != rhs.m_lightTransform.m_rotation)
+		!AreMatricesExactlyEqual(m_lightMatrix, rhs.m_lightMatrix))
 	{
 		return false;
 	}
@@ -289,8 +303,7 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 			// through m_internalCommandsList, so they must participate in invalidation.
 			CSMLightState snapshot{};
 			snapshot.m_componentIndex = directionalLight.m_index;
-			snapshot.m_cameraTransform = cameraTransform;
-			snapshot.m_lightTransform = directionalLight.m_lightTransform;
+			snapshot.m_shadowType = cascade.m_shadowType;
 			snapshot.m_lightMatrix = lightMatrix;
 			snapshot.m_snapshot.Reserve(cascade.m_meshList.Num());
 

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -284,6 +284,21 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 			// For EVSM only 1st cascade is EVSM
 			cascade.m_shadowType = k > 0 ? RHI::EShadowType::PCF : directionalLight.m_shadowType;
 
+			// Track every caster that affects this cascade before removing draw-call
+			// duplicates. Casters removed below are still rendered into this shadow map
+			// through m_internalCommandsList, so they must participate in invalidation.
+			CSMLightState snapshot{};
+			snapshot.m_componentIndex = directionalLight.m_index;
+			snapshot.m_cameraTransform = cameraTransform;
+			snapshot.m_lightTransform = directionalLight.m_lightTransform;
+			snapshot.m_lightMatrix = lightMatrix;
+			snapshot.m_snapshot.Reserve(cascade.m_meshList.Num());
+
+			for (const auto& m : cascade.m_meshList)
+			{
+				snapshot.m_snapshot.Add({ m.m_staticMeshEcs, m.m_frame });
+			}
+
 			if (k > 0)
 			{
 				int32_t shift = -1;
@@ -311,19 +326,6 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 						cascade.m_internalCommandsList.Add(alreadyPlacedPasses + shift);
 					}
 				}
-			}
-
-			// Track changes
-			CSMLightState snapshot{};
-			snapshot.m_componentIndex = directionalLight.m_index;
-			snapshot.m_cameraTransform = cameraTransform;
-			snapshot.m_lightTransform = directionalLight.m_lightTransform;
-			snapshot.m_lightMatrix = lightMatrix;
-			snapshot.m_snapshot.Reserve(cascade.m_meshList.Num());
-
-			for (const auto& m : cascade.m_meshList)
-			{
-				snapshot.m_snapshot.Add({ m.m_staticMeshEcs, m.m_frame });
 			}
 
 			if (snapshotIndex < m_csmSnapshots.Num())

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -36,9 +36,8 @@ namespace Sailor
 	struct CSMLightState
 	{
 		uint32_t m_componentIndex = 0;
+		RHI::EShadowType m_shadowType = RHI::EShadowType::None;
 		glm::mat4 m_lightMatrix{};
-		Math::Transform m_cameraTransform{};
-		Math::Transform m_lightTransform{};
 
 		// <Mesh ECS Index, LastFrameChanged>
 		TVector<TPair<size_t, size_t>> m_snapshot{};
@@ -68,7 +67,7 @@ namespace Sailor
 		// EVSM is based on https://www.cg.tuwien.ac.at/research/publications/2013/ADORJAN-2013-ASE/ADORJAN-2013-ASE-thesis.pdf
 		// Also handy paper: https://dl.acm.org/doi/pdf/10.5555/1375714.1375739
 		static constexpr uint32_t NumCascades = 4;
-		static constexpr float ShadowCascadeLevels[NumCascades] = { 1.0f / 20.0f, 1.0f / 10.0f, 1.0f / 3.0f, 1.0f / 2.0f };
+		static constexpr float ShadowCascadeLevels[NumCascades] = { 1.0f / 20.0f, 1.0f / 10.0f, 1.0f / 3.0f, 1.0f };
 		static constexpr glm::ivec2 ShadowCascadeResolutions[NumCascades] = { {4096,4096}, {4096,4096}, {4096,4096}, {4096,4096} };
 		static constexpr glm::ivec2 ShadowCascadeBlur[NumCascades] = { glm::vec2(2, 5), glm::vec2(1, 4), glm::vec2(1, 3), glm::vec2(1, 2) };
 

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -42,7 +42,7 @@ namespace Sailor
 		// <Mesh ECS Index, LastFrameChanged>
 		TVector<TPair<size_t, size_t>> m_snapshot{};
 
-		bool Equals(const CSMLightState& rhs) const;
+		SAILOR_API bool Equals(const CSMLightState& rhs) const;
 	};
 
 	class LightingECS final : public ECS::TSystem<LightingECS, LightData>

--- a/Runtime/ECS/PathTracerECS.cpp
+++ b/Runtime/ECS/PathTracerECS.cpp
@@ -145,5 +145,3 @@ void PathTracerECS::CopySceneView(RHI::RHISceneViewPtr& outSceneView)
 	outSceneView->m_pathTracerMaterials = m_pathTracerMaterialsCache;
 	outSceneView->m_pathTracerLights = m_pathTracerLightsCache;
 }
-
-

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -242,6 +242,8 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 						proxy.m_bCastShadows = data.ShouldCastShadow();
 
 						proxy.m_overrideMaterials.Clear();
+						proxy.m_renderQueueTags.Clear();
+						proxy.m_renderQueueTags.Reserve(proxy.m_meshes.Num());
 #if defined(__APPLE__)
 						proxy.m_materialTextureSamplers.Clear();
 						proxy.m_materialTextureSamplers.Reserve(proxy.m_meshes.Num());
@@ -253,6 +255,7 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 								proxy.m_meshes[i]->ResolveMaterialIndex(
 									i, data.GetMaterials().Num());
 							auto& material = data.GetMaterials()[materialIndex];
+							proxy.m_renderQueueTags.Add(material->GetRenderState().GetTag());
 							proxy.m_overrideMaterials.Add(material->GetOrAddRHI(proxy.m_meshes[i]->m_vertexDescription));
 #if defined(__APPLE__)
 							TSet<uint32_t> requestedTextures;

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -215,14 +215,31 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 					const auto& ownerTransform = ownerGameObject->GetTransformComponent();
 					Math::AABB adjustedBounds = data.GetModel()->GetBoundsAABB();
 					bool bMaterialsReady = !data.GetMaterials().IsEmpty();
+					bool bMaterialsChanged =
+						data.m_materialContentRevisions.Num() != data.GetMaterials().Num();
+					size_t materialIndex = 0;
 					for (const auto& material : data.GetMaterials())
 					{
 						bMaterialsReady &= material && material->IsReady();
+						const uint64_t materialContentRevision =
+							material ? material->GetContentRevision() : 0ull;
+						if (!bMaterialsChanged &&
+							data.m_materialContentRevisions[materialIndex] != materialContentRevision)
+						{
+							bMaterialsChanged = true;
+						}
+						++materialIndex;
 					}
 
-					if ((data.m_bIsDirty || ownerTransform.GetFrameLastChange() > data.m_frameLastChange) &&
+					if ((data.m_bIsDirty || bMaterialsChanged || ownerTransform.GetFrameLastChange() > data.m_frameLastChange) &&
 						adjustedBounds.IsValid() && bMaterialsReady)
 					{
+						data.m_materialContentRevisions.Resize(data.GetMaterials().Num());
+						for (size_t i = 0; i < data.GetMaterials().Num(); ++i)
+						{
+							data.m_materialContentRevisions[i] = data.GetMaterials()[i]->GetContentRevision();
+						}
+
 						RHI::RHISceneViewProxy proxy;
 						proxy.m_staticMeshEcs = index;
 						proxy.m_worldMatrix = ownerTransform.GetCachedWorldMatrix();

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -226,6 +226,7 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 						RHI::RHISceneViewProxy proxy;
 						proxy.m_staticMeshEcs = index;
 						proxy.m_worldMatrix = ownerTransform.GetCachedWorldMatrix();
+						proxy.m_frame = ownerTransform.GetFrameLastChange();
 						if (auto animator = ownerGameObject->GetComponent<AnimatorComponent>())
 						{
 							data.m_skeletonOffset = animator->GetSkeletonOffset();
@@ -248,7 +249,9 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 #endif
 						for (size_t i = 0; i < proxy.m_meshes.Num(); i++)
 						{
-							size_t materialIndex = (std::min)(i, data.GetMaterials().Num() - 1);
+							const size_t materialIndex =
+								proxy.m_meshes[i]->ResolveMaterialIndex(
+									i, data.GetMaterials().Num());
 							auto& material = data.GetMaterials()[materialIndex];
 							proxy.m_overrideMaterials.Add(material->GetOrAddRHI(proxy.m_meshes[i]->m_vertexDescription));
 #if defined(__APPLE__)

--- a/Runtime/ECS/StaticMeshRendererECS.h
+++ b/Runtime/ECS/StaticMeshRendererECS.h
@@ -38,6 +38,7 @@ namespace Sailor
 
 		ModelPtr m_model;
 		TVector<MaterialPtr> m_materials;
+		TVector<uint64_t> m_materialContentRevisions;
 		uint32_t m_skeletonOffset = InvalidSkeletonOffset;
 
 		friend class StaticMeshRendererECS;

--- a/Runtime/Editor/EditorRuntimeBridge.cpp
+++ b/Runtime/Editor/EditorRuntimeBridge.cpp
@@ -131,7 +131,11 @@ namespace
 		commands->EndCommandList(cmd);
 
 		auto fence = RHI::RHIFencePtr::Make();
-		driver->SubmitCommandList(cmd, fence);
+		if (!driver->SubmitCommandList(cmd, fence))
+		{
+			SAILOR_LOG_ERROR("EditorRuntimeBridge: viewport readback submission failed.");
+			return nullptr;
+		}
 		fence->Wait();
 		fence->ClearDependencies();
 		fence->ClearObservables();

--- a/Runtime/Engine/EngineLoop.cpp
+++ b/Runtime/Engine/EngineLoop.cpp
@@ -16,6 +16,8 @@
 #include "RHI/CommandList.h"
 #include "RHI/Renderer.h"
 
+#include <imgui.h>
+#include <cstdio>
 #include <thread>
 #include <chrono>
 
@@ -23,6 +25,26 @@ using namespace Sailor;
 
 namespace
 {
+	void DrawViewportStatsOverlay(uint32_t cpuFps, uint32_t gpuFps, uint32_t numBatches, uint32_t numInstances)
+	{
+		const ImGuiIO& io = ImGui::GetIO();
+		if (io.DisplaySize.x <= 0.0f || io.DisplaySize.y <= 0.0f)
+		{
+			return;
+		}
+
+		char text[128];
+		std::snprintf(text, sizeof(text), "CPU %u FPS\nGPU %u FPS\nBatches %u\nInstances %u", cpuFps, gpuFps, numBatches, numInstances);
+
+		constexpr float Margin = 10.0f;
+		const ImVec2 textSize = ImGui::CalcTextSize(text);
+		const ImVec2 position(
+			std::max(Margin, io.DisplaySize.x - textSize.x - Margin),
+			Margin);
+
+		ImGui::GetForegroundDrawList()->AddText(position, IM_COL32(160, 160, 160, 255), text);
+	}
+
 	void EnsureEditorWorldInfrastructure(const TSharedPtr<World>& world)
 	{
 		GameObjectPtr firstCamera;
@@ -174,6 +196,17 @@ void EngineLoop::ProcessCpuFrame(FrameState& currentInputState)
 	for (auto& world : m_worlds)
 	{
 		world->Tick(currentInputState);
+	}
+
+	const auto renderer = App::GetSubmodule<RHI::Renderer>();
+	if (renderer)
+	{
+		const auto& stats = renderer->GetStats();
+		DrawViewportStatsOverlay(
+			m_cpuFps,
+			stats.m_gpuFps.load(std::memory_order_relaxed),
+			stats.m_numBatches.load(std::memory_order_relaxed),
+			stats.m_numInstances.load(std::memory_order_relaxed));
 	}
 
 	auto& task = currentInputState.GetDrawImGuiTask();

--- a/Runtime/Engine/EngineLoop.cpp
+++ b/Runtime/Engine/EngineLoop.cpp
@@ -5,6 +5,7 @@
 #include "AssetRegistry/Model/ModelImporter.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "AssetRegistry/Material/MaterialImporter.h"
+#include "AssetRegistry/FrameGraph/FrameGraphImporter.h"
 
 #include "Engine/GameObject.h"
 #include "Components/MeshRendererComponent.h"
@@ -15,6 +16,7 @@
 #include "RHI/Types.h"
 #include "RHI/CommandList.h"
 #include "RHI/Renderer.h"
+#include "RHI/Texture.h"
 
 #include <imgui.h>
 #include <cstdio>
@@ -210,6 +212,25 @@ void EngineLoop::ProcessCpuFrame(FrameState& currentInputState)
 	}
 
 	auto& task = currentInputState.GetDrawImGuiTask();
+	RHI::EFormat imguiColorFormat = renderer ?
+		renderer->GetColorFormat() :
+		RHI::EFormat::B8G8R8A8_SRGB;
+	if (renderer)
+	{
+		if (auto frameGraph = renderer->GetFrameGraph())
+		{
+			if (auto rhiFrameGraph = frameGraph->GetRHI())
+			{
+				if (const auto renderImGuiNode = rhiFrameGraph->GetGraphNode("RenderImGui"))
+				{
+					if (const auto colorAttachment = renderImGuiNode->GetResolvedAttachment("color"))
+					{
+						imguiColorFormat = colorAttachment->GetFormat();
+					}
+				}
+			}
+		}
+	}
 
 	{
 		SAILOR_PROFILE_SCOPE("Record ImGui Update Command List");
@@ -226,8 +247,7 @@ void EngineLoop::ProcessCpuFrame(FrameState& currentInputState)
 		{
 			auto cmdList = RHI::Renderer::GetDriver()->CreateCommandList(true, RHI::ECommandListQueue::Graphics);
 			RHI::Renderer::GetDriver()->SetDebugName(cmdList, "Record ImGui Draw Command List");
-			// Default swapchain format
-			RHI::Renderer::GetDriverCommands()->BeginSecondaryCommandList(cmdList, false, false, RHI::EFormat::B8G8R8A8_SRGB);
+			RHI::Renderer::GetDriverCommands()->BeginSecondaryCommandList(cmdList, false, false, imguiColorFormat);
 			App::GetSubmodule<ImGuiApi>()->RenderFrame(cmdList);
 			RHI::Renderer::GetDriverCommands()->EndCommandList(cmdList);
 

--- a/Runtime/FrameGraph/BaseFrameGraphNode.h
+++ b/Runtime/FrameGraph/BaseFrameGraphNode.h
@@ -33,17 +33,25 @@ namespace Sailor::Framegraph
 		SAILOR_API virtual Sailor::Tasks::TaskPtr<void, void> Prepare(RHI::RHIFrameGraphPtr frameGraph, const RHI::RHISceneViewSnapshot& sceneView) { return Sailor::Tasks::TaskPtr<void, void>(); }
 		SAILOR_API virtual void Process(RHI::RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView) = 0;
 		SAILOR_API virtual void Clear() = 0;
+		SAILOR_API virtual RHI::DrawCallStats GetDrawCallStats() const { return m_drawCallStats; }
 
 		SAILOR_API const std::string& GetTag() const { return m_tag; }
 		SAILOR_API void SetTag(const std::string& tag) { m_tag = tag; }
 
 	protected:
+		void ResetDrawCallStats() { m_drawCallStats = {}; }
+		void RecordDrawCallStats(uint32_t numInstances)
+		{
+			m_drawCallStats.m_numBatches++;
+			m_drawCallStats.m_numInstances += numInstances;
+		}
 
 		TMap<std::string, std::string> m_stringParams;
 		TMap<std::string, glm::vec4> m_vectorParams;
 		TMap<std::string, float> m_floatParams;
 		TMap<std::string, RHI::RHIResourcePtr> m_resourceParams;
 		TMap<std::string, std::string> m_unresolvedResourceParams;
+		RHI::DrawCallStats m_drawCallStats{};
 
 		std::string m_tag{};
 	};

--- a/Runtime/FrameGraph/BlitNode.cpp
+++ b/Runtime/FrameGraph/BlitNode.cpp
@@ -37,12 +37,7 @@ void BlitNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr trans
 		}
 	}
 
-	if (!m_pShader || !m_pShader->IsReady())
-	{
-		return;
-	}
-
-	if (!m_blitToMsaaTargetMaterial)
+	if (m_pShader && m_pShader->IsReady() && !m_blitToMsaaTargetMaterial)
 	{
 		m_shaderBindings = driver->CreateShaderBindings();
 		RHI::RHIVertexDescriptionPtr vertexDescription = driver->GetOrAddVertexDescription<RHI::VertexP3N3UV2C4>();
@@ -86,13 +81,21 @@ void BlitNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr trans
 	commands->ImageMemoryBarrier(commandList, src, RHI::EImageLayout::TransferSrcOptimal);
 	commands->ImageMemoryBarrier(commandList, dst, RHI::EImageLayout::TransferDstOptimal);
 
-	commands->BlitImage(commandList, src, dst, srcRegion, dstRegion, bIsDepthFormat ? ETextureFiltration::Nearest : ETextureFiltration::Linear);
+	const bool bResolvedBlitSuccessful = commands->BlitImage(
+		commandList,
+		src,
+		dst,
+		srcRegion,
+		dstRegion,
+		bIsDepthFormat ?
+			ETextureFiltration::Nearest :
+			ETextureFiltration::Linear);
 
 	// Blit to MSAA targets
 	RHISurfacePtr dstSurface = GetRHIResource("dst").DynamicCast<RHISurface>();
 	if (dstSurface && dstSurface->NeedsResolve())
 	{
-		bool bBlitIsSuccesful = false;
+		bool bMsaaBlitSuccessful = false;
 
 		// First try to blit MSAA src to MSAA dst
 		if (RHISurfacePtr srcSurface = GetRHIResource("src").DynamicCast<RHISurface>())
@@ -105,12 +108,12 @@ void BlitNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr trans
 				commands->ImageMemoryBarrier(commandList, src2, RHI::EImageLayout::TransferSrcOptimal);
 				commands->ImageMemoryBarrier(commandList, dst2, RHI::EImageLayout::TransferDstOptimal);
 
-				bBlitIsSuccesful = commands->BlitImage(commandList, src2, dst2, srcRegion, dstRegion);
+				bMsaaBlitSuccessful = commands->BlitImage(commandList, src2, dst2, srcRegion, dstRegion);
 			}
 		}
 
 		// If no success blit texture src to MSAA dst
-		if (!bBlitIsSuccesful)
+		if (!bMsaaBlitSuccessful && m_blitToMsaaTargetMaterial)
 		{
 			auto target = dstSurface->GetTarget();
 
@@ -121,6 +124,16 @@ void BlitNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr trans
 			BlitRaw(commandList, frameGraph, sceneView, src, dstSurface->GetTarget());
 		}
 	}
+
+	std::string generateMips;
+	if (bResolvedBlitSuccessful &&
+		dst->HasMipMaps() &&
+		TryGetString("GenerateMips", generateMips) &&
+		generateMips == "true")
+	{
+		commands->GenerateMipMaps(commandList, dst);
+	}
+
 	commands->EndDebugRegion(commandList);
 }
 

--- a/Runtime/FrameGraph/BlitNode.cpp
+++ b/Runtime/FrameGraph/BlitNode.cpp
@@ -21,6 +21,7 @@ const char* BlitNode::m_name = "Blit";
 void BlitNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	ResetDrawCallStats();
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
@@ -166,6 +167,7 @@ void BlitNode::BlitRaw(RHI::RHICommandListPtr commandList,
 		0, 1.0f);
 
 	commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+	RecordDrawCallStats(1);
 	commands->EndRenderPass(commandList);
 }
 

--- a/Runtime/FrameGraph/CPUPathTracerNode.cpp
+++ b/Runtime/FrameGraph/CPUPathTracerNode.cpp
@@ -189,6 +189,7 @@ const char* CPUPathTracerNode::m_name = "CPUPathTracerNode";
 void CPUPathTracerNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	ResetDrawCallStats();
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
@@ -610,6 +611,7 @@ void CPUPathTracerNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 		glm::vec2((float)dst->GetExtent().x, (float)dst->GetExtent().y),
 		0.0f, 1.0f);
 	commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+	RecordDrawCallStats(1);
 	commands->EndRenderPass(commandList);
 	commands->EndDebugRegion(commandList);
 }

--- a/Runtime/FrameGraph/DebugDrawNode.cpp
+++ b/Runtime/FrameGraph/DebugDrawNode.cpp
@@ -1,5 +1,6 @@
 #include "DebugDrawNode.h"
 #include "RHI/SceneView.h"
+#include "RHI/CommandList.h"
 #include "RHI/Renderer.h"
 #include "RHI/Shader.h"
 #include "RHI/Surface.h"
@@ -19,6 +20,7 @@ const char* DebugDrawNode::m_name = "DebugDraw";
 void DebugDrawNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	ResetDrawCallStats();
 
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
 
@@ -55,6 +57,8 @@ void DebugDrawNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr 
 		commands->EndDebugRegion(commandList);
 		return;
 	}
+
+	m_drawCallStats += debugDrawCommandList->GetRecordedDrawCallStats();
 
 	if (colorAttachmentSurface)
 	{

--- a/Runtime/FrameGraph/DepthPrepassNode.cpp
+++ b/Runtime/FrameGraph/DepthPrepassNode.cpp
@@ -104,6 +104,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 					data.skeletonOffset = proxy.m_skeletonOffset;
 					data.bIsCulled = 0;
 					data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+					data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
 
 					if (bRequiredCustomDepth)
 					{

--- a/Runtime/FrameGraph/DepthPrepassNode.cpp
+++ b/Runtime/FrameGraph/DepthPrepassNode.cpp
@@ -9,6 +9,8 @@
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "AssetRegistry/AssetRegistry.h"
 
+#include <limits>
+
 using namespace Sailor;
 using namespace Sailor::RHI;
 
@@ -63,15 +65,20 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 			m_numMeshes = 0;
 			m_drawCalls.Clear();
 			m_batches.Clear();
+			Framegraph::Details::EvictTextureBindingCache(m_textureBindingCache, sceneViewSnapshot.m_frame);
 
 			for (auto& proxy : sceneViewSnapshot.m_proxies)
 			{
 				for (size_t i = 0; i < proxy.m_meshes.Num(); i++)
 				{
 					const bool bHasMaterial = proxy.GetMaterials().Num() > i;
-					if (!bHasMaterial || proxy.GetMaterials()[i] == nullptr)
+					if (!bHasMaterial)
 					{
 						break;
+					}
+					if (proxy.GetMaterials()[i] == nullptr)
+					{
+						continue;
 					}
 
 					if (proxy.GetMaterials()[i]->GetRenderState().GetTag() != QueueTagHash)
@@ -121,6 +128,33 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 					}
 
 					RHIBatch batch(depthMaterial, mesh);
+					if (bRequiredCustomDepth)
+					{
+						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
+#if defined(__APPLE__)
+						TSet<uint32_t> requestedTextures;
+						if (proxy.m_materialTextureSamplers.Num() > i)
+						{
+							requestedTextures = proxy.m_materialTextureSamplers[i];
+						}
+						else
+						{
+							requestedTextures.Insert(0u);
+						}
+						batch.m_textureBindings = Framegraph::Details::GetTextureBindingSet(
+							m_textureBindingCache,
+							requestedTextures,
+							sceneViewSnapshot.m_frame,
+							supportedMeshesPerBatch);
+#else
+						batch.m_textureBindings = App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
+#endif
+						batch.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
+						if (!batch.m_textureBindings)
+						{
+							continue;
+						}
+					}
 
 					m_drawCalls[batch][mesh].Add(data);
 					m_batches.Insert(batch);
@@ -245,7 +279,6 @@ void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 		}
 	}
 
-	auto textureSamplers = App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
 	auto shaderBindingsByMaterial = [&](const RHIBatch& batch)
 		{
 			auto material = batch.m_material;
@@ -253,7 +286,7 @@ void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 
 			if (material->GetRenderState().IsRequiredCustomDepthShader())
 			{
-				sets = TVector<RHIShaderBindingSetPtr>({ sceneView.m_frameBindings, sceneView.m_rhiLightsData, m_perInstanceData , material->GetBindings(), textureSamplers });
+				sets = TVector<RHIShaderBindingSetPtr>({ sceneView.m_frameBindings, sceneView.m_rhiLightsData, m_perInstanceData, material->GetBindings(), batch.m_textureBindings });
 			}
 
 			if (sceneView.m_boneMatrices)
@@ -302,7 +335,9 @@ void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 	{
 		m_drawCallStats = RHIRecordDrawCall(0, (uint32_t)vecBatches.Num(), vecBatches, commandList, transferCommandList, shaderBindingsByMaterial, m_drawCalls, storageIndex, m_indirectBuffers[0],
 			glm::ivec4(0, depthAttachment->GetExtent().y, depthAttachment->GetExtent().x, -depthAttachment->GetExtent().y),
-			glm::uvec4(0, 0, depthAttachment->GetExtent().x, depthAttachment->GetExtent().y));
+			glm::uvec4(0, 0, depthAttachment->GetExtent().x, depthAttachment->GetExtent().y),
+			glm::vec2(0.0f, 1.0f),
+			&m_cullingIndirectBufferBinding[0]);
 	}
 	commands->EndRenderPass(commandList);
 
@@ -314,4 +349,5 @@ void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 void DepthPrepassNode::Clear()
 {
 	m_perInstanceData.Clear();
+	m_textureBindingCache.Clear();
 }

--- a/Runtime/FrameGraph/DepthPrepassNode.cpp
+++ b/Runtime/FrameGraph/DepthPrepassNode.cpp
@@ -137,6 +137,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	m_drawCallStats = {};
 	m_syncSharedResources.Lock();
 
 	const std::string QueueTag = GetString("Tag");
@@ -284,7 +285,7 @@ void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 #ifdef _DEBUG
 		cullingComputeShader = m_pComputeMeshCullingShader->GetDebugComputeShaderRHI();
 #endif
-		RHIRecordDrawCallGPUCulling(0,
+		m_drawCallStats = RHIRecordDrawCallGPUCulling(0,
 			(uint32_t)vecBatches.Num(), vecBatches,
 			commandList, transferCommandList,
 			shaderBindingsByMaterial,
@@ -298,7 +299,7 @@ void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 	}
 	else
 	{
-		RHIRecordDrawCall(0, (uint32_t)vecBatches.Num(), vecBatches, commandList, transferCommandList, shaderBindingsByMaterial, m_drawCalls, storageIndex, m_indirectBuffers[0],
+		m_drawCallStats = RHIRecordDrawCall(0, (uint32_t)vecBatches.Num(), vecBatches, commandList, transferCommandList, shaderBindingsByMaterial, m_drawCalls, storageIndex, m_indirectBuffers[0],
 			glm::ivec4(0, depthAttachment->GetExtent().y, depthAttachment->GetExtent().x, -depthAttachment->GetExtent().y),
 			glm::uvec4(0, 0, depthAttachment->GetExtent().x, depthAttachment->GetExtent().y));
 	}

--- a/Runtime/FrameGraph/DepthPrepassNode.h
+++ b/Runtime/FrameGraph/DepthPrepassNode.h
@@ -6,6 +6,7 @@
 #include "RHI/Batch.hpp"
 #include "FrameGraph/BaseFrameGraphNode.h"
 #include "FrameGraph/FrameGraphNode.h"
+#include "FrameGraph/RenderSceneTextureCache.h"
 
 namespace Sailor
 {
@@ -58,6 +59,7 @@ namespace Sailor
 		TVector<RHI::RHIShaderBindingSetPtr> m_cullingIndirectBufferBinding;
 		ShaderSetPtr m_pComputeMeshCullingShader{};
 		RHI::RHIShaderBindingSetPtr m_computeMeshCullingBindings{};
+		Framegraph::TextureBindingCache m_textureBindingCache;
 
 		static const char* m_name;
 	};

--- a/Runtime/FrameGraph/DepthPrepassNode.h
+++ b/Runtime/FrameGraph/DepthPrepassNode.h
@@ -22,6 +22,7 @@ namespace Sailor
 			uint32_t skeletonOffset = 0;
 			uint32_t bIsCulled = 0;
 			uint32_t padding = 0;
+			vec4 bakedVolumeScale = vec4(1.0f);
 
 			bool operator==(const PerInstanceData& rhs) const { return this->materialInstance == rhs.materialInstance && this->model == rhs.model; }
 

--- a/Runtime/FrameGraph/DepthPrepassNode.h
+++ b/Runtime/FrameGraph/DepthPrepassNode.h
@@ -61,7 +61,7 @@ namespace Sailor
 		RHI::RHIShaderBindingSetPtr m_computeMeshCullingBindings{};
 		Framegraph::TextureBindingCache m_textureBindingCache;
 
-		static const char* m_name;
+		SAILOR_SHARED_API static const char* m_name;
 	};
 
 	namespace Framegraph

--- a/Runtime/FrameGraph/EyeAdaptationNode.cpp
+++ b/Runtime/FrameGraph/EyeAdaptationNode.cpp
@@ -29,6 +29,12 @@ void EyeAdaptationNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 	commands->BeginDebugRegion(commandList, GetName(), DebugContext::Color_CmdCompute);
 
 	RHI::RHITexturePtr target = GetResolvedAttachment("color");
+	RHI::RHITexturePtr colorTarget = target;
+	if (RHI::RHIRenderTargetPtr renderTarget = target.DynamicCast<RHI::RHIRenderTarget>();
+		renderTarget && renderTarget->GetMipLevels() > 0)
+	{
+		colorTarget = renderTarget->GetMipLayer(0);
+	}
 
 	if (!m_pComputeHistogramShader)
 	{
@@ -112,7 +118,7 @@ void EyeAdaptationNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 	if (!m_pToneMappingShader || !m_pToneMappingShader->IsReady() ||
 		!m_pComputeHistogramShader || !m_pComputeHistogramShader->IsReady() ||
 		!m_pComputeAverageShader || !m_pComputeAverageShader->IsReady() ||
-		!target)
+		!colorTarget)
 	{
 		return;
 	}
@@ -182,7 +188,7 @@ void EyeAdaptationNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 			{ m_computeAverageShaderBindings },
 			&pushConstantsAverage, sizeof(float) * 4);
 		commands->ImageMemoryBarrier(commandList, m_averageLuminance, EImageLayout::ShaderReadOnlyOptimal);
-		commands->ImageMemoryBarrier(commandList, target, EImageLayout::ColorAttachmentOptimal);
+		commands->ImageMemoryBarrier(commandList, colorTarget, EImageLayout::ColorAttachmentOptimal);
 	}
 
 	auto fullResolutionBinding = m_shaderBindings->GetOrAddShaderBinding("colorSampler")->GetTextureBinding();
@@ -191,9 +197,9 @@ void EyeAdaptationNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 	auto mesh = frameGraph->GetFullscreenNdcQuad();
 
 	commands->BeginRenderPass(commandList,
-		TVector<RHI::RHITexturePtr>{target},
+		TVector<RHI::RHITexturePtr>{colorTarget},
 		nullptr,
-		glm::vec4(0, 0, target->GetExtent().x, target->GetExtent().y),
+		glm::vec4(0, 0, colorTarget->GetExtent().x, colorTarget->GetExtent().y),
 		glm::ivec2(0, 0),
 		false,
 		glm::vec4(0.0f),
@@ -206,9 +212,9 @@ void EyeAdaptationNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 	commands->BindMaterial(commandList, m_postEffectMaterial);
 	commands->SetViewport(commandList,
 		0, 0,
-		(float)target->GetExtent().x, (float)target->GetExtent().y,
+		(float)colorTarget->GetExtent().x, (float)colorTarget->GetExtent().y,
 		glm::vec2(0, 0),
-		glm::vec2(target->GetExtent().x, target->GetExtent().y),
+		glm::vec2(colorTarget->GetExtent().x, colorTarget->GetExtent().y),
 		0, 1.0f);
 
 	commands->BindVertexBuffer(commandList, mesh->m_vertexBuffer, 0);

--- a/Runtime/FrameGraph/EyeAdaptationNode.cpp
+++ b/Runtime/FrameGraph/EyeAdaptationNode.cpp
@@ -22,6 +22,7 @@ const char* EyeAdaptationNode::m_name = "EyeAdaptation";
 void EyeAdaptationNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	ResetDrawCallStats();
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
@@ -215,6 +216,7 @@ void EyeAdaptationNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 	commands->BindShaderBindings(commandList, m_postEffectMaterial, { sceneView.m_frameBindings,  m_shaderBindings });
 
 	commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+	RecordDrawCallStats(1);
 	commands->EndRenderPass(commandList);
 
 	commands->EndDebugRegion(commandList);

--- a/Runtime/FrameGraph/LightCullingNode.cpp
+++ b/Runtime/FrameGraph/LightCullingNode.cpp
@@ -56,18 +56,26 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 		pushConstants.m_numTiles.x = (depthAttachment->GetExtent().x - 1) / (int32_t)TileSize + 1;
 		pushConstants.m_numTiles.y = (depthAttachment->GetExtent().y - 1) / (int32_t)TileSize + 1;
 
-		if (!m_culledLights)
+		const bool bBindingsOutdated = !m_culledLights ||
+			m_boundLightsData != sceneView.m_rhiLightsData ||
+			m_boundDepthAttachment != depthAttachment ||
+			m_bindingsViewportSize != pushConstants.m_viewportSize;
+		if (bBindingsOutdated)
 		{
 			const size_t numTiles = pushConstants.m_numTiles.x * pushConstants.m_numTiles.y;
 
 			m_culledLights = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
 			RHI::RHIShaderBindingPtr culledLightsSSBO = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_culledLights, "culledLights", sizeof(uint32_t) * numTiles * LightsPerTile, 1, 0, true);
-			RHI::RHIShaderBindingPtr lightsGridSSBO = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_culledLights, "lightsGrid", sizeof(uint32_t) * (numTiles * 2 + 1), 1, 1, true);
+			RHI::RHIShaderBindingPtr lightsGridSSBO = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_culledLights, "lightsGrid", sizeof(uint32_t) * numTiles * 2, 1, 1, true);
 			RHI::RHIShaderBindingPtr depthSampler = Sailor::RHI::Renderer::GetDriver()->AddSamplerToShaderBindings(m_culledLights, "sceneDepth", depthAttachment, 2);
 
 			auto shaderBindingSet = sceneView.m_rhiLightsData;
 			Sailor::RHI::Renderer::GetDriver()->AddShaderBinding(shaderBindingSet, culledLightsSSBO, "culledLights", 1);
 			Sailor::RHI::Renderer::GetDriver()->AddShaderBinding(shaderBindingSet, lightsGridSSBO, "lightsGrid", 2);
+
+			m_boundLightsData = sceneView.m_rhiLightsData;
+			m_boundDepthAttachment = depthAttachment;
+			m_bindingsViewportSize = pushConstants.m_viewportSize;
 		}
 
 		commands->ImageMemoryBarrier(commandList, depthAttachment, RHI::EImageLayout::ShaderReadOnlyOptimal);
@@ -75,6 +83,9 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 			pushConstants.m_numTiles.x, pushConstants.m_numTiles.y, 1,
 			{ sceneView.m_rhiLightsData, m_culledLights, sceneView.m_frameBindings },
 			&pushConstants, sizeof(PushConstants));
+		commands->MemoryBarrier(commandList,
+			static_cast<EAccessFlags>(EAccessBit::ShaderWrite_Bit),
+			static_cast<EAccessFlags>(EAccessBit::ShaderRead_Bit));
 	}
 
 	commands->EndDebugRegion(commandList);
@@ -84,4 +95,7 @@ void LightCullingNode::Clear()
 {
 	m_pComputeShader.Clear();
 	m_culledLights.Clear();
+	m_boundLightsData.Clear();
+	m_boundDepthAttachment.Clear();
+	m_bindingsViewportSize = {};
 }

--- a/Runtime/FrameGraph/LightCullingNode.h
+++ b/Runtime/FrameGraph/LightCullingNode.h
@@ -34,6 +34,9 @@ namespace Sailor::Framegraph
 
 		ShaderSetPtr m_pComputeShader{};
 		RHI::RHIShaderBindingSetPtr m_culledLights;
+		RHI::RHIShaderBindingSetPtr m_boundLightsData;
+		RHI::RHITexturePtr m_boundDepthAttachment;
+		glm::ivec2 m_bindingsViewportSize{};
 	};
 
 	template class TFrameGraphNode<LightCullingNode>;

--- a/Runtime/FrameGraph/LinearizeDepthNode.cpp
+++ b/Runtime/FrameGraph/LinearizeDepthNode.cpp
@@ -22,6 +22,7 @@ const char* LinearizeDepthNode::m_name = "LinearizeDepth";
 void LinearizeDepthNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	ResetDrawCallStats();
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
@@ -103,6 +104,7 @@ void LinearizeDepthNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandLis
 	const uint32_t vertexOffset = (uint32_t)mesh->m_vertexBuffer->GetOffset() / (uint32_t)mesh->m_vertexDescription->GetVertexStride();
 
 	commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+	RecordDrawCallStats(1);
 	commands->EndRenderPass(commandList);
 
 	commands->EndDebugRegion(commandList);

--- a/Runtime/FrameGraph/ParticlesNode.cpp
+++ b/Runtime/FrameGraph/ParticlesNode.cpp
@@ -96,7 +96,20 @@ void ParticlesNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr 
 			App::GetSubmodule<MaterialImporter>()->LoadMaterial(materialFileId->GetFileId(), shadowCasterMaterial);
 		}
 
-		m_mesh = model->IsReady() ? *model->GetMeshes().First() : nullptr;
+		if (!model || !model->IsReady())
+		{
+			return;
+		}
+
+		const auto& meshes = model->GetMeshes();
+		if (meshes.IsEmpty() || !meshes[0] ||
+			materials.IsEmpty() || !materials[0] ||
+			!shadowCasterMaterial)
+		{
+			return;
+		}
+
+		m_mesh = meshes[0];
 
 		m_material = materials[0]->GetOrAddRHI(m_mesh->m_vertexDescription);
 		m_shadowMaterial = shadowCasterMaterial->GetOrAddRHI(m_mesh->m_vertexDescription);

--- a/Runtime/FrameGraph/ParticlesNode.cpp
+++ b/Runtime/FrameGraph/ParticlesNode.cpp
@@ -26,6 +26,7 @@ const char* ParticlesNode::m_name = "ExperimentalParticles";
 void ParticlesNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	ResetDrawCallStats();
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
@@ -234,6 +235,7 @@ void ParticlesNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr 
 		commands->BindVertexBuffer(commandList, m_mesh->m_vertexBuffer, 0);
 		commands->BindIndexBuffer(commandList, m_mesh->m_indexBuffer, 0);
 		commands->DrawIndexed(commandList, m_mesh->GetIndexCount(), m_numInstances, m_mesh->GetFirstIndex(), m_mesh->GetVertexOffset(), 0);
+		RecordDrawCallStats(m_numInstances);
 
 		commands->EndRenderPass(commandList);
 		commands->ImageMemoryBarrier(commandList, m_shadowMap, EImageLayout::ShaderReadOnlyOptimal);
@@ -265,6 +267,7 @@ void ParticlesNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr 
 	commands->BindVertexBuffer(commandList, m_mesh->m_vertexBuffer, 0);
 	commands->BindIndexBuffer(commandList, m_mesh->m_indexBuffer, 0);
 	commands->DrawIndexed(commandList, m_mesh->GetIndexCount(), m_numInstances, m_mesh->GetFirstIndex(), m_mesh->GetVertexOffset(), 0);
+	RecordDrawCallStats(m_numInstances);
 	commands->EndRenderPass(commandList);
 
 	commands->EndDebugRegion(commandList);

--- a/Runtime/FrameGraph/PostProcessNode.cpp
+++ b/Runtime/FrameGraph/PostProcessNode.cpp
@@ -22,6 +22,7 @@ const char* PostProcessNode::m_name = "PostProcess";
 void PostProcessNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	ResetDrawCallStats();
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
@@ -216,6 +217,7 @@ void PostProcessNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 		0, 1.0f);
 
 	commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+	RecordDrawCallStats(1);
 	commands->EndRenderPass(commandList);
 
 	commands->EndDebugRegion(commandList);

--- a/Runtime/FrameGraph/RHIFrameGraph.cpp
+++ b/Runtime/FrameGraph/RHIFrameGraph.cpp
@@ -101,6 +101,7 @@ bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 	RHISemaphorePtr& outWaitSemaphore)
 {
 	SAILOR_PROFILE_FUNCTION();
+	m_drawCallStats = {};
 
 	auto renderer = App::GetSubmodule<RHI::Renderer>();
 	auto& driver = RHI::Renderer::GetDriver();
@@ -255,6 +256,7 @@ bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 		for (auto& node : m_graph)
 		{
 			node->Process(frameRefPtr, transferCmdList, cmdList, snapshot);
+			m_drawCallStats += node->GetDrawCallStats();
 
 			const uint32_t numRecordedCommands = transferCmdList->GetNumRecordedCommands() + cmdList->GetNumRecordedCommands();
 			const uint32_t gpuCost = transferCmdList->GetGPUCost() + cmdList->GetGPUCost();

--- a/Runtime/FrameGraph/RHIFrameGraph.cpp
+++ b/Runtime/FrameGraph/RHIFrameGraph.cpp
@@ -168,6 +168,38 @@ bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 		}
 	}
 
+	bool bHasTransmissionFramebuffer = false;
+	for (const auto& node : m_graph)
+	{
+		if (node && node->GetResolvedAttachment("transmissionFramebuffer"))
+		{
+			bHasTransmissionFramebuffer = true;
+			break;
+		}
+	}
+
+	constexpr const char* transmissionSamplerName =
+		"g_transmissionFramebufferSampler";
+	if (!bHasTransmissionFramebuffer &&
+		rhiSceneView->m_rhiLightsData->HasBinding(transmissionSamplerName))
+	{
+		RHI::RHITexturePtr defaultTexture =
+			renderer->GetDriver()->GetDefaultTexture();
+		RHI::RHIShaderBindingPtr& transmissionBinding =
+			rhiSceneView->m_rhiLightsData->GetOrAddShaderBinding(
+				transmissionSamplerName);
+		if (defaultTexture &&
+			transmissionBinding->GetTextureBinding() != defaultTexture)
+		{
+			renderer->GetDriver()->AddSamplerToShaderBindings(
+				rhiSceneView->m_rhiLightsData,
+				transmissionSamplerName,
+				defaultTexture,
+				10);
+			bShouldRecalculateCompatibility = true;
+		}
+	}
+
 	if (bShouldRecalculateCompatibility)
 	{
 		rhiSceneView->m_rhiLightsData->RecalculateCompatibility();

--- a/Runtime/FrameGraph/RHIFrameGraph.cpp
+++ b/Runtime/FrameGraph/RHIFrameGraph.cpp
@@ -9,6 +9,8 @@
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "Tasks/Tasks.h"
 
+#include <atomic>
+
 using namespace Sailor;
 using namespace Sailor::RHI;
 
@@ -92,7 +94,7 @@ TVector<Sailor::Tasks::TaskPtr<void, void>> RHIFrameGraph::Prepare(RHI::RHIScene
 	return res;
 }
 
-void RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
+bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 	TVector<RHI::RHICommandListPtr>& outTransferCommandLists,
 	TVector<RHI::RHICommandListPtr>& outCommandLists,
 	RHISemaphorePtr inSignalSemaphore,
@@ -103,6 +105,7 @@ void RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 	auto renderer = App::GetSubmodule<RHI::Renderer>();
 	auto& driver = RHI::Renderer::GetDriver();
 	auto driverCommands = renderer->GetDriverCommands();
+	RHISemaphorePtr frameGraphChainSemaphore = inSignalSemaphore;
 
 	if (!m_postEffectPlane)
 	{
@@ -191,7 +194,8 @@ void RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 		}
 		driverCommands->EndDebugRegion(transferCmdList);
 
-		RHI::RHISemaphorePtr chainSemaphore = inSignalSemaphore;
+		RHI::RHISemaphorePtr chainSemaphore = frameGraphChainSemaphore;
+		auto submitsSucceeded = TSharedPtr<std::atomic_bool>::Make(true);
 
 		TVector<Tasks::ITaskPtr> tasks;
 		tasks.Reserve(2);
@@ -275,9 +279,18 @@ void RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 					auto submitCmdList1 = Tasks::CreateTask("Submit chaining cmd lists",
 						[=]()
 						{
+							if (!submitsSucceeded->load(std::memory_order_acquire))
+							{
+								return;
+							}
+
 							auto fence = RHIFencePtr::Make();
 							RHI::Renderer::GetDriver()->SetDebugName(fence, std::format("Submit chaining cmd lists"));
-							RHI::Renderer::GetDriver()->SubmitCommandList(transferCmdList, fence, newChainSemaphore, chainSemaphore);
+							if (!RHI::Renderer::GetDriver()->SubmitCommandList(transferCmdList, fence, newChainSemaphore, chainSemaphore))
+							{
+								SAILOR_LOG_ERROR("RHIFrameGraph::Process: failed to submit a chained transfer command buffer.");
+								submitsSucceeded->store(false, std::memory_order_release);
+							}
 						}, EThreadType::RHI);
 
 					if (tasks.Num() > 0)
@@ -293,9 +306,18 @@ void RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 					auto submitCmdList2 = Tasks::CreateTask("Submit chaining cmd lists",
 						[=]()
 						{
+							if (!submitsSucceeded->load(std::memory_order_acquire))
+							{
+								return;
+							}
+
 							auto fence = RHIFencePtr::Make();
 							RHI::Renderer::GetDriver()->SetDebugName(fence, std::format("Submit chaining cmd lists"));
-							RHI::Renderer::GetDriver()->SubmitCommandList(cmdList, fence, chainSemaphore, newChainSemaphore);
+							if (!RHI::Renderer::GetDriver()->SubmitCommandList(cmdList, fence, chainSemaphore, newChainSemaphore))
+							{
+								SAILOR_LOG_ERROR("RHIFrameGraph::Process: failed to submit a chained graphics command buffer.");
+								submitsSucceeded->store(false, std::memory_order_release);
+							}
 						}, EThreadType::RHI);
 
 					submitCmdList2->Join(submitCmdList1);
@@ -338,12 +360,22 @@ void RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 			}
 		}
 
+		if (!submitsSucceeded->load(std::memory_order_acquire))
+		{
+			m_lastFrameGpuStats = driver->FinishGpuTracking();
+			outWaitSemaphore.Clear();
+			return false;
+		}
+
 		m_lastFrameGpuStats = driver->FinishGpuTracking();
 
-		outWaitSemaphore = chainSemaphore;
+		frameGraphChainSemaphore = chainSemaphore;
 		outCommandLists.Emplace(std::move(cmdList));
 		outTransferCommandLists.Emplace(transferCmdList);
 	}
+
+	outWaitSemaphore = frameGraphChainSemaphore;
+	return true;
 }
 
 RHI::RHITexturePtr RHIFrameGraph::GetSampler(const std::string& name)

--- a/Runtime/FrameGraph/RHIFrameGraph.h
+++ b/Runtime/FrameGraph/RHIFrameGraph.h
@@ -48,7 +48,7 @@ namespace Sailor::RHI
 
 		SAILOR_API TVector<Sailor::Tasks::TaskPtr<void, void>> Prepare(RHI::RHISceneViewPtr rhiSceneView);
 
-		SAILOR_API void Process(RHI::RHISceneViewPtr rhiSceneView,
+		SAILOR_API bool Process(RHI::RHISceneViewPtr rhiSceneView,
 			TVector<RHI::RHICommandListPtr>& outTransferCommandLists,
 			TVector<RHI::RHICommandListPtr>& outSecondaryCommandLists,
 			RHISemaphorePtr inSignalSemaphore,

--- a/Runtime/FrameGraph/RHIFrameGraph.h
+++ b/Runtime/FrameGraph/RHIFrameGraph.h
@@ -33,6 +33,7 @@ namespace Sailor::RHI
 		SAILOR_API RHI::RHISurfacePtr GetSurface(const std::string& name);
 
 		SAILOR_API RHI::RHIMeshPtr GetFullscreenNdcQuad() { return m_postEffectPlane; }
+		SAILOR_API RHI::DrawCallStats GetDrawCallStats() const { return m_drawCallStats; }
 
 		template<typename T>
 		void SetValue(const std::string& name, T value)
@@ -73,6 +74,7 @@ namespace Sailor::RHI
 		RHI::UboFrameData m_prevFrameData{};
 
 		GpuStats m_lastFrameGpuStats{};
+		RHI::DrawCallStats m_drawCallStats{};
 	};
 
 	using RHIFrameGraphPtr = TRefPtr<RHIFrameGraph>;

--- a/Runtime/FrameGraph/RenderImGuiNode.cpp
+++ b/Runtime/FrameGraph/RenderImGuiNode.cpp
@@ -21,6 +21,7 @@ const char* RenderImGuiNode::m_name = "RenderImGui";
 void RenderImGuiNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	ResetDrawCallStats();
 
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
 	commands->BeginDebugRegion(commandList, GetName(), DebugContext::Color_CmdDebug);
@@ -45,8 +46,16 @@ void RenderImGuiNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 		while (!sceneView.m_drawImGui->IsFinished());
 	}
 
+	auto imguiCommandList = sceneView.m_drawImGui->GetResult();
+	if (!imguiCommandList)
+	{
+		commands->EndDebugRegion(commandList);
+		return;
+	}
+
+	m_drawCallStats += imguiCommandList->GetRecordedDrawCallStats();
 	commands->RenderSecondaryCommandBuffers(commandList,
-		{ sceneView.m_drawImGui->GetResult() },
+		{ imguiCommandList },
 		TVector<RHI::RHITexturePtr>{ colorAttachment },
 		depthAttachment,
 		glm::vec4(0, 0, colorAttachment->GetExtent().x, colorAttachment->GetExtent().y),

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -11,6 +11,7 @@
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "AssetRegistry/AssetRegistry.h"
 
+#include <cmath>
 #include <limits>
 #include <mutex>
 
@@ -57,9 +58,9 @@ uint32_t RenderSceneNode::CalculatePlannedTextureSlotCount(const TVector<uint32_
 
 RHI::ESortingOrder RenderSceneNode::GetSortingOrder() const
 {
-	const std::string& sortOrder = GetString("Sorting");
+	std::string sortOrder;
 
-	if (!sortOrder.empty())
+	if (TryGetString("Sorting", sortOrder))
 	{
 		return magic_enum::enum_cast<RHI::ESortingOrder>(sortOrder).value_or(RHI::ESortingOrder::FrontToBack);
 	}
@@ -231,6 +232,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 
 	const std::string QueueTag = GetString("Tag");
 	const size_t QueueTagHash = GetHash(QueueTag);
+	const bool bBackToFront = GetSortingOrder() == RHI::ESortingOrder::BackToFront;
 
 	auto res = Tasks::CreateTask("Prepare RenderSceneNode  " + std::to_string(sceneView.m_frame),
 		[=, this, holdRhiResources = frameGraph, &syncSharedResources = m_syncSharedResources, &sceneViewSnapshot = sceneView]() mutable {
@@ -240,6 +242,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 			m_numMeshes = 0;
 			m_drawCalls.Clear();
 			m_batches.Clear();
+			m_orderedDrawItems.Clear();
 			EvictTextureBindingCache(sceneViewSnapshot.m_frame);
 
 			SAILOR_PROFILE_SCOPE("Filter sceneView by tag");
@@ -301,18 +304,250 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 #endif
 						batch.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
 
-						m_drawCalls[batch][mesh].Add(data);
-						m_batches.Insert(batch);
+						if (bBackToFront)
+						{
+							const glm::vec4 worldCenter = proxy.m_worldMatrix *
+								glm::vec4(mesh->m_bounds.GetCenter(), 1.0f);
+							const glm::vec4 viewCenter = sceneViewSnapshot.m_camera->GetViewMatrix() *
+								worldCenter;
+
+							OrderedDrawItem item;
+							item.m_batch = std::move(batch);
+							item.m_mesh = mesh;
+							item.m_instanceData = data;
+							item.m_cameraDepth = std::isfinite(viewCenter.z) ?
+								-viewCenter.z :
+								-(std::numeric_limits<float>::max)();
+							item.m_staticMeshEcs = proxy.m_staticMeshEcs;
+							item.m_meshIndex = i;
+							m_orderedDrawItems.Emplace(std::move(item));
+						}
+						else
+						{
+							m_drawCalls[batch][mesh].Add(data);
+							m_batches.Insert(batch);
+						}
 
 						m_numMeshes++;
 					}
 				}
 			}
 
+			if (bBackToFront)
+			{
+				m_orderedDrawItems.Sort([](const OrderedDrawItem& lhs, const OrderedDrawItem& rhs)
+					{
+						if (lhs.m_cameraDepth != rhs.m_cameraDepth)
+						{
+							return lhs.m_cameraDepth > rhs.m_cameraDepth;
+						}
+
+						if (lhs.m_staticMeshEcs != rhs.m_staticMeshEcs)
+						{
+							return lhs.m_staticMeshEcs < rhs.m_staticMeshEcs;
+						}
+
+						return lhs.m_meshIndex < rhs.m_meshIndex;
+					});
+			}
+
 			syncSharedResources.Unlock();
 		}, EThreadType::RHI);
 
 	return res;
+}
+
+void RenderSceneNode::ProcessBackToFront(RHIFrameGraphPtr frameGraph,
+	RHI::RHICommandListPtr transferCommandList,
+	RHI::RHICommandListPtr commandList,
+	const RHI::RHISceneViewSnapshot& sceneView,
+	const RHI::RHIShaderBindingPtr& storageBinding,
+	const std::string& queueTag)
+{
+	if (m_orderedDrawItems.IsEmpty())
+	{
+		return;
+	}
+
+	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
+	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
+
+	RHI::RHISurfacePtr colorAttachment = GetRHIResource("color").DynamicCast<RHI::RHISurface>();
+	RHI::RHITexturePtr depthAttachment = GetRHIResource("depthStencil").DynamicCast<RHI::RHITexture>();
+	if (!depthAttachment)
+	{
+		depthAttachment = frameGraph->GetRenderTarget("DepthBuffer");
+	}
+
+	if (!colorAttachment || !depthAttachment)
+	{
+		return;
+	}
+
+	TVector<PerInstanceData> gpuMatricesData;
+	gpuMatricesData.Reserve(m_orderedDrawItems.Num());
+
+	TVector<RHI::DrawIndexedIndirectData> indirectCommands;
+	indirectCommands.Reserve(m_orderedDrawItems.Num());
+
+	const uint32_t firstStorageInstance = storageBinding->GetStorageInstanceIndex();
+	for (uint32_t i = 0; i < m_orderedDrawItems.Num(); i++)
+	{
+		const OrderedDrawItem& item = m_orderedDrawItems[i];
+		gpuMatricesData.Add(item.m_instanceData);
+
+		RHI::DrawIndexedIndirectData command{};
+		command.m_indexCount = item.m_mesh->GetIndexCount();
+		command.m_instanceCount = 1u;
+		command.m_firstIndex = item.m_mesh->GetFirstIndex();
+		command.m_vertexOffset = item.m_mesh->GetVertexOffset();
+		command.m_firstInstance = firstStorageInstance + i;
+		indirectCommands.Emplace(std::move(command));
+	}
+
+	commands->UpdateShaderBinding(transferCommandList,
+		storageBinding,
+		gpuMatricesData.GetData(),
+		sizeof(PerInstanceData) * gpuMatricesData.Num(),
+		0);
+
+	if (m_indirectBuffers.IsEmpty())
+	{
+		m_indirectBuffers.Resize(1);
+	}
+
+	const size_t indirectBufferSize =
+		sizeof(RHI::DrawIndexedIndirectData) * indirectCommands.Num();
+	if (!m_indirectBuffers[0].IsValid() ||
+		m_indirectBuffers[0]->GetSize() < indirectBufferSize)
+	{
+		constexpr size_t IndirectBufferSlack = 256;
+		m_indirectBuffers[0] = driver->CreateIndirectBuffer(
+			indirectBufferSize + IndirectBufferSlack);
+	}
+
+	commands->UpdateBuffer(transferCommandList,
+		m_indirectBuffers[0],
+		indirectCommands.GetData(),
+		indirectBufferSize,
+		0);
+
+	const auto viewport = glm::ivec4(0,
+		colorAttachment->GetTarget()->GetExtent().y,
+		colorAttachment->GetTarget()->GetExtent().x,
+		-colorAttachment->GetTarget()->GetExtent().y);
+	const auto scissor = glm::uvec4(0,
+		0,
+		colorAttachment->GetTarget()->GetExtent().x,
+		colorAttachment->GetTarget()->GetExtent().y);
+
+	commands->BeginDebugRegion(commandList,
+		std::string(GetName()) + " QueueTag:" + queueTag + " BackToFront",
+		DebugContext::Color_CmdGraphics);
+	commands->ImageMemoryBarrier(commandList,
+		colorAttachment->GetTarget(),
+		EImageLayout::ColorAttachmentOptimal);
+
+	const auto depthAttachmentLayout = RHI::IsDepthStencilFormat(depthAttachment->GetFormat()) ?
+		EImageLayout::DepthStencilAttachmentOptimal :
+		EImageLayout::DepthAttachmentOptimal;
+	commands->ImageMemoryBarrier(commandList,
+		depthAttachment,
+		depthAttachmentLayout);
+
+	commands->BeginRenderPass(commandList,
+		TVector<RHI::RHISurfacePtr>{ colorAttachment },
+		depthAttachment,
+		glm::vec4(0,
+			0,
+			colorAttachment->GetTarget()->GetExtent().x,
+			colorAttachment->GetTarget()->GetExtent().y),
+		glm::ivec2(0, 0),
+		false,
+		glm::vec4(0.0f),
+		0.0f,
+		true);
+
+#if defined(_WIN32)
+	constexpr uint32_t MaxMeshesPerIndirectBatch = 16384u;
+#else
+	constexpr uint32_t MaxMeshesPerIndirectBatch = 128u;
+#endif
+
+	uint32_t runBegin = 0;
+	while (runBegin < m_orderedDrawItems.Num())
+	{
+		const OrderedDrawItem& firstItem = m_orderedDrawItems[runBegin];
+		uint32_t runLimit = (std::max)(1u,
+			(std::min)(MaxMeshesPerIndirectBatch,
+				firstItem.m_batch.m_supportedMeshesPerBatch));
+		uint32_t runEnd = runBegin + 1u;
+		while (runEnd < m_orderedDrawItems.Num())
+		{
+			const OrderedDrawItem& nextItem = m_orderedDrawItems[runEnd];
+			if (!(firstItem.m_batch == nextItem.m_batch))
+			{
+				break;
+			}
+
+			const uint32_t nextLimit = (std::max)(1u,
+				(std::min)(MaxMeshesPerIndirectBatch,
+					nextItem.m_batch.m_supportedMeshesPerBatch));
+			runLimit = (std::min)(runLimit, nextLimit);
+			if (runEnd - runBegin >= runLimit)
+			{
+				break;
+			}
+
+			runEnd++;
+		}
+
+		const RHIBatch& batch = firstItem.m_batch;
+		TVector<RHIShaderBindingSetPtr> shaderBindings({
+			sceneView.m_frameBindings,
+			sceneView.m_rhiLightsData,
+			m_perInstanceData,
+			batch.m_material->GetBindings(),
+			batch.m_textureBindings });
+		if (sceneView.m_boneMatrices)
+		{
+			shaderBindings.Add(sceneView.m_boneMatrices);
+		}
+
+		commands->BindMaterial(commandList, batch.m_material);
+		commands->SetViewport(commandList,
+			(float)viewport.x,
+			(float)viewport.y,
+			(float)viewport.z,
+			(float)viewport.w,
+			glm::vec2(scissor.x, scissor.y),
+			glm::vec2(scissor.z, scissor.w),
+			0.0f,
+			1.0f);
+		commands->BindShaderBindings(commandList,
+			batch.m_material,
+			shaderBindings);
+		commands->BindVertexBuffer(commandList,
+			batch.m_mesh->m_vertexBuffer,
+			0);
+		commands->BindIndexBuffer(commandList,
+			batch.m_mesh->m_indexBuffer,
+			0);
+
+		const uint32_t runSize = runEnd - runBegin;
+		commands->DrawIndexedIndirect(commandList,
+			m_indirectBuffers[0],
+			sizeof(RHI::DrawIndexedIndirectData) * runBegin,
+			runSize,
+			sizeof(RHI::DrawIndexedIndirectData));
+		m_drawCallStats.m_numBatches++;
+		m_drawCallStats.m_numInstances += runSize;
+
+		runBegin = runEnd;
+	}
+
+	commands->EndRenderPass(commandList);
+	commands->EndDebugRegion(commandList);
 }
 
 /*
@@ -361,10 +596,40 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 		}
 	}
 
+	RHI::RHITexturePtr transmissionFramebuffer =
+		GetResolvedAttachment("transmissionFramebuffer");
+	if (transmissionFramebuffer)
+	{
+		auto rhiLightsData = sceneView.m_rhiLightsData;
+		constexpr const char* transmissionSamplerName =
+			"g_transmissionFramebufferSampler";
+		RHI::RHIShaderBindingPtr& transmissionBinding =
+			rhiLightsData->GetOrAddShaderBinding(
+				transmissionSamplerName);
+		if (transmissionBinding->GetTextureBinding() !=
+			transmissionFramebuffer)
+		{
+			driver->AddSamplerToShaderBindings(
+				rhiLightsData,
+				transmissionSamplerName,
+				transmissionFramebuffer,
+				10);
+			rhiLightsData->RecalculateCompatibility();
+		}
+	}
+
 	if (m_numMeshes == 0)
 	{
 		m_syncSharedResources.Unlock();
 		return;
+	}
+
+	if (transmissionFramebuffer)
+	{
+		commands->ImageMemoryBarrier(
+			commandList,
+			transmissionFramebuffer,
+			RHI::EImageLayout::ShaderReadOnlyOptimal);
 	}
 
 	if (!m_perInstanceData || m_sizePerInstanceData < sizeof(RenderSceneNode::PerInstanceData) * m_numMeshes)
@@ -377,6 +642,17 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 	}
 
 	RHI::RHIShaderBindingPtr storageBinding = m_perInstanceData->GetOrAddShaderBinding("data");
+	if (GetSortingOrder() == RHI::ESortingOrder::BackToFront)
+	{
+		ProcessBackToFront(frameGraph,
+			transferCommandList,
+			commandList,
+			sceneView,
+			storageBinding,
+			QueueTag);
+		m_syncSharedResources.Unlock();
+		return;
+	}
 
 	{
 		SAILOR_PROFILE_SCOPE("Prepare command list");
@@ -661,6 +937,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 
 void RenderSceneNode::Clear()
 {
+	m_orderedDrawItems.Clear();
 	m_indirectBuffers.Clear();
 	m_perInstanceData.Clear();
 #if defined(__APPLE__)

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -11,10 +11,10 @@
 #include "RHI/Buffer.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "AssetRegistry/AssetRegistry.h"
+#include "Core/SpinLock.h"
 
 #include <cmath>
 #include <limits>
-#include <mutex>
 
 using namespace Sailor;
 using namespace Sailor::RHI;
@@ -832,7 +832,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 		}
 
 		commands->BeginDebugRegion(commandList, std::string(GetName()) + " QueueTag:" + QueueTag, DebugContext::Color_CmdGraphics);
-		std::mutex transferCommandListMutex;
+		SpinLock transferCommandListLock;
 
 		for (uint32_t i = 0; i < secondaryCommandLists.Num(); i++)
 		{
@@ -869,7 +869,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 							glm::vec2(0.0f, 1.0f),
 							cullingComputeShader, m_cullingIndirectBufferBinding[i + 1],
 							{ m_computeMeshCullingBindings , m_perInstanceData, m_cullingIndirectBufferBinding[i + 1], sceneView.m_frameBindings },
-							&transferCommandListMutex);
+							&transferCommandListLock);
 					}
 					else
 					{
@@ -885,7 +885,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 							scissor,
 							glm::vec2(0.0f, 1.0f),
 							&m_cullingIndirectBufferBinding[i + 1],
-							&transferCommandListMutex);
+							&transferCommandListLock);
 					}
 
 					commands->EndCommandList(cmdList);
@@ -935,7 +935,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 					glm::vec2(0.0f, 1.0f),
 					cullingComputeShader, m_cullingIndirectBufferBinding[0],
 					{ m_computeMeshCullingBindings , m_perInstanceData, m_cullingIndirectBufferBinding[0], sceneView.m_frameBindings },
-					&transferCommandListMutex);
+					&transferCommandListLock);
 			}
 			else
 			{
@@ -951,7 +951,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 					scissor,
 					glm::vec2(0.0f, 1.0f),
 					&m_cullingIndirectBufferBinding[0],
-					&transferCommandListMutex);
+					&transferCommandListLock);
 			}
 
 			commands->EndRenderPass(commandList);

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -285,6 +285,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 						data.materialInstance = shaderBinding.IsValid() ? shaderBinding->GetStorageInstanceIndex() : 0;
 						data.bIsCulled = 0;
 						data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+						data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
 
 						RHI::RHIBatch batch(material, mesh);
 						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -11,6 +11,9 @@
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "AssetRegistry/AssetRegistry.h"
 
+#include <limits>
+#include <mutex>
+
 using namespace Sailor;
 using namespace Sailor::RHI;
 using namespace Sailor::Framegraph;
@@ -18,6 +21,28 @@ using namespace Sailor::Framegraph;
 #ifndef _SAILOR_IMPORT_
 const char* RenderSceneNode::m_name = "RenderScene";
 #endif
+
+bool Details::CanReuseRenderSceneTextureBindings(
+	uint64_t cachedSourceRevision,
+	uint64_t currentSourceRevision,
+	bool bHasCachedBindings,
+	const TVector<uint64_t>* cachedSlotRevisions,
+	const TVector<uint64_t>* currentSlotRevisions)
+{
+	if (!bHasCachedBindings)
+	{
+		return false;
+	}
+
+	if (cachedSourceRevision == currentSourceRevision)
+	{
+		return true;
+	}
+
+	return cachedSlotRevisions &&
+		currentSlotRevisions &&
+		*cachedSlotRevisions == *currentSlotRevisions;
+}
 
 uint32_t RenderSceneNode::CalculatePlannedTextureSlotCount(const TVector<uint32_t>& requestedTextures)
 {
@@ -56,6 +81,10 @@ RHIShaderBindingSetPtr RenderSceneNode::GetTextureBindingSet(const TSet<uint32_t
 #if defined(__APPLE__)
 	TextureBindingCacheKey key;
 	key.m_requestedTextures = requestedTextures.ToVector();
+	key.m_requestedTextures.RemoveAll([](uint32_t textureIndex)
+		{
+			return textureIndex >= TextureImporter::MaxTexturesInScene;
+		});
 
 	if (key.m_requestedTextures.IsEmpty())
 	{
@@ -68,35 +97,56 @@ RHIShaderBindingSetPtr RenderSceneNode::GetTextureBindingSet(const TSet<uint32_t
 	}
 
 	key.m_requestedTextures.Sort();
+	const uint64_t currentSourceDescriptorRevision = globalTextureSet ? globalTextureSet->GetDescriptorRevision() : 0;
+	TextureBindingCacheEntry* cachedEntry = nullptr;
+	m_textureBindingCache.Find(key, cachedEntry);
 
-	if (m_textureBindingCache.ContainsKey(key))
+	if (cachedEntry && Details::CanReuseRenderSceneTextureBindings(
+		cachedEntry->m_sourceDescriptorRevision,
+		currentSourceDescriptorRevision,
+		cachedEntry->m_textureBindings.IsValid()))
 	{
-		auto& entry = m_textureBindingCache[key];
-		entry.m_lastUsedFrame = frame;
+		cachedEntry->m_lastUsedFrame = frame;
 #ifdef _DEBUG
-		if (entry.m_textureBindings)
+		if (cachedEntry->m_textureBindings)
 		{
-			const auto shaderBinding = entry.m_textureBindings->GetOrAddShaderBinding("textureSamplers");
+			const auto shaderBinding = cachedEntry->m_textureBindings->GetOrAddShaderBinding("textureSamplers");
 			const uint32_t actualTextureCount = static_cast<uint32_t>(shaderBinding->GetTextureBindings().Num());
 			const uint32_t actualLayoutCount = shaderBinding->GetLayout().m_arrayCount;
-			check(actualTextureCount == entry.m_textureSetSize);
-			check(actualLayoutCount == entry.m_textureSetSize);
+			check(actualTextureCount == cachedEntry->m_textureSetSize);
+			check(actualLayoutCount == cachedEntry->m_textureSetSize);
 		}
 #endif
-		outSupportedMeshesPerBatch = (std::max)(1u, MaxTextureSlotsPerBatch / (std::max)(1u, entry.m_textureSetSize));
-		return entry.m_textureBindings;
+		outSupportedMeshesPerBatch = (std::max)(1u, MaxTextureSlotsPerBatch / (std::max)(1u, cachedEntry->m_textureSetSize));
+		return cachedEntry->m_textureBindings;
 	}
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
-	RHIShaderBindingSetPtr localTextureSet = driver->CreateShaderBindings();
-	TVector<RHITexturePtr> localTextures;
+	const auto sourceSnapshot = textureImporter->GetTextureSamplersSnapshot(key.m_requestedTextures);
+	TVector<uint64_t> currentSlotRevisions;
+	currentSlotRevisions.Reserve(sourceSnapshot.m_slots.Num());
+	for (const auto& slot : sourceSnapshot.m_slots)
+	{
+		currentSlotRevisions.Emplace(slot.m_contentRevision);
+	}
 
+	if (cachedEntry && Details::CanReuseRenderSceneTextureBindings(
+		cachedEntry->m_sourceDescriptorRevision,
+		sourceSnapshot.m_descriptorRevision,
+		cachedEntry->m_textureBindings.IsValid(),
+		&cachedEntry->m_sourceSlotRevisions,
+		&currentSlotRevisions))
+	{
+		cachedEntry->m_sourceDescriptorRevision = sourceSnapshot.m_descriptorRevision;
+		cachedEntry->m_lastUsedFrame = frame;
+		outSupportedMeshesPerBatch = (std::max)(1u, MaxTextureSlotsPerBatch / (std::max)(1u, cachedEntry->m_textureSetSize));
+		return cachedEntry->m_textureBindings;
+	}
+
+	TVector<RHITexturePtr> localTextures;
 	const uint32_t plannedTextureSlots = CalculatePlannedTextureSlotCount(key.m_requestedTextures);
 	localTextures.AddDefault(plannedTextureSlots);
 
-	auto sourceBinding = globalTextureSet ? globalTextureSet->GetOrAddShaderBinding("textureSamplers") : nullptr;
-	TVector<RHITexturePtr> emptyTextures;
-	const auto& sourceTextures = sourceBinding ? sourceBinding->GetTextureBindings() : emptyTextures;
 	RHITexturePtr defaultTexture = driver->GetDefaultTexture();
 
 	for (uint32_t textureIndex = 0; textureIndex < localTextures.Num(); textureIndex++)
@@ -104,16 +154,33 @@ RHIShaderBindingSetPtr RenderSceneNode::GetTextureBindingSet(const TSet<uint32_t
 		localTextures[textureIndex] = defaultTexture;
 	}
 
-	for (const uint32_t globalTextureIndex : key.m_requestedTextures)
+	for (const auto& slot : sourceSnapshot.m_slots)
 	{
-		if (globalTextureIndex < localTextures.Num() && globalTextureIndex < sourceTextures.Num() && sourceTextures[globalTextureIndex].IsValid())
+		if (slot.m_index < localTextures.Num() && slot.m_texture.IsValid())
 		{
-			localTextures[globalTextureIndex] = sourceTextures[globalTextureIndex];
+			localTextures[slot.m_index] = slot.m_texture;
 		}
 	}
 
+	RHIShaderBindingSetPtr localTextureSet = driver->CreateShaderBindings();
+
 	driver->AddSamplerToShaderBindings(localTextureSet, "textureSamplers", localTextures, 0, true, plannedTextureSlots);
 	localTextureSet->RecalculateCompatibility();
+
+#if defined(SAILOR_BUILD_WITH_VULKAN)
+	if (!localTextureSet->m_vulkan.m_descriptorSet || !localTextureSet->m_vulkan.m_descriptorSet->IsCompiled())
+	{
+		if (cachedEntry)
+		{
+			cachedEntry->m_lastUsedFrame = frame;
+			outSupportedMeshesPerBatch = (std::max)(1u, MaxTextureSlotsPerBatch / (std::max)(1u, cachedEntry->m_textureSetSize));
+			return cachedEntry->m_textureBindings;
+		}
+
+		outSupportedMeshesPerBatch = 1u;
+		return nullptr;
+	}
+#endif
 
 #ifdef _DEBUG
 	if (const auto localBinding = localTextureSet->GetOrAddShaderBinding("textureSamplers"))
@@ -129,6 +196,8 @@ RHIShaderBindingSetPtr RenderSceneNode::GetTextureBindingSet(const TSet<uint32_t
 	entry.m_textureBindings = localTextureSet;
 	entry.m_textureSetSize = plannedTextureSlots;
 	entry.m_lastUsedFrame = frame;
+	entry.m_sourceDescriptorRevision = sourceSnapshot.m_descriptorRevision;
+	entry.m_sourceSlotRevisions = std::move(currentSlotRevisions);
 
 	outSupportedMeshesPerBatch = (std::max)(1u, MaxTextureSlotsPerBatch / (std::max)(1u, entry.m_textureSetSize));
 	return entry.m_textureBindings;
@@ -423,6 +492,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 			};
 
 		commands->BeginDebugRegion(commandList, std::string(GetName()) + " QueueTag:" + QueueTag, DebugContext::Color_CmdGraphics);
+		std::mutex transferCommandListMutex;
 
 		for (uint32_t i = 0; i < secondaryCommandLists.Num(); i++)
 		{
@@ -458,7 +528,8 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 							scissor,
 							glm::vec2(0.0f, 1.0f),
 							cullingComputeShader, m_cullingIndirectBufferBinding[i + 1],
-							{ m_computeMeshCullingBindings , m_perInstanceData, m_cullingIndirectBufferBinding[i + 1], sceneView.m_frameBindings });
+							{ m_computeMeshCullingBindings , m_perInstanceData, m_cullingIndirectBufferBinding[i + 1], sceneView.m_frameBindings },
+							&transferCommandListMutex);
 					}
 					else
 					{
@@ -471,7 +542,9 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 							storageIndex,
 							m_indirectBuffers[i + 1],
 							viewport,
-							scissor);
+							scissor,
+							glm::vec2(0.0f, 1.0f),
+							&transferCommandListMutex);
 					}
 
 					commands->EndCommandList(cmdList);
@@ -485,6 +558,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 		if (gpuMatricesData.Num() > 0)
 		{
 			SAILOR_PROFILE_SCOPE("Fill transfer command list with matrices data");
+			std::lock_guard<std::mutex> transferCommandListLock(transferCommandListMutex);
 			commands->UpdateShaderBinding(transferCommandList, storageBinding,
 				gpuMatricesData.GetData(),
 				sizeof(PerInstanceData) * gpuMatricesData.Num(),
@@ -529,7 +603,8 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 					scissor,
 					glm::vec2(0.0f, 1.0f),
 					cullingComputeShader, m_cullingIndirectBufferBinding[0],
-					{ m_computeMeshCullingBindings , m_perInstanceData, m_cullingIndirectBufferBinding[0], sceneView.m_frameBindings });
+					{ m_computeMeshCullingBindings , m_perInstanceData, m_cullingIndirectBufferBinding[0], sceneView.m_frameBindings },
+					&transferCommandListMutex);
 			}
 			else
 			{
@@ -542,7 +617,9 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 					storageIndex,
 					m_indirectBuffers[0],
 					viewport,
-					scissor);
+					scissor,
+					glm::vec2(0.0f, 1.0f),
+					&transferCommandListMutex);
 			}
 
 			commands->EndRenderPass(commandList);

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -8,6 +8,7 @@
 #include "RHI/Types.h"
 #include "RHI/VertexDescription.h"
 #include "RHI/CommandList.h"
+#include "RHI/Buffer.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "AssetRegistry/AssetRegistry.h"
 
@@ -45,15 +46,32 @@ bool Details::CanReuseRenderSceneTextureBindings(
 		*cachedSlotRevisions == *currentSlotRevisions;
 }
 
-uint32_t RenderSceneNode::CalculatePlannedTextureSlotCount(const TVector<uint32_t>& requestedTextures)
+TVector<uint32_t> Details::BuildDenseTextureRemap(
+	const TVector<uint32_t>& globalTextureIndices)
 {
-	if (requestedTextures.IsEmpty())
+	uint32_t maxTextureIndex = 0u;
+	for (const uint32_t textureIndex : globalTextureIndices)
 	{
-		return 1u;
+		maxTextureIndex = (std::max)(maxTextureIndex, textureIndex);
 	}
 
-	const uint32_t maxTextureIndex = *std::max_element(requestedTextures.begin(), requestedTextures.end());
-	return (std::max)(1u, maxTextureIndex + 1u);
+	TVector<uint32_t> globalToLocal;
+	globalToLocal.AddDefault(static_cast<size_t>(maxTextureIndex) + 1u);
+
+	uint32_t nextLocalIndex = 1u;
+	for (const uint32_t textureIndex : globalTextureIndices)
+	{
+		if (textureIndex == 0u ||
+			textureIndex >= globalToLocal.Num() ||
+			globalToLocal[textureIndex] != 0u)
+		{
+			continue;
+		}
+
+		globalToLocal[textureIndex] = nextLocalIndex++;
+	}
+
+	return globalToLocal;
 }
 
 RHI::ESortingOrder RenderSceneNode::GetSortingOrder() const
@@ -68,7 +86,11 @@ RHI::ESortingOrder RenderSceneNode::GetSortingOrder() const
 	return RHI::ESortingOrder::FrontToBack;
 }
 
-RHIShaderBindingSetPtr RenderSceneNode::GetTextureBindingSet(const TSet<uint32_t>& requestedTextures, uint64_t frame, uint32_t& outSupportedMeshesPerBatch)
+RHIShaderBindingSetPtr Details::GetTextureBindingSet(
+	TextureBindingCache& textureBindingCache,
+	const TSet<uint32_t>& requestedTextures,
+	uint64_t frame,
+	uint32_t& outSupportedMeshesPerBatch)
 {
 	auto textureImporter = App::GetSubmodule<TextureImporter>();
 	if (!textureImporter)
@@ -100,7 +122,7 @@ RHIShaderBindingSetPtr RenderSceneNode::GetTextureBindingSet(const TSet<uint32_t
 	key.m_requestedTextures.Sort();
 	const uint64_t currentSourceDescriptorRevision = globalTextureSet ? globalTextureSet->GetDescriptorRevision() : 0;
 	TextureBindingCacheEntry* cachedEntry = nullptr;
-	m_textureBindingCache.Find(key, cachedEntry);
+	textureBindingCache.Find(key, cachedEntry);
 
 	if (cachedEntry && Details::CanReuseRenderSceneTextureBindings(
 		cachedEntry->m_sourceDescriptorRevision,
@@ -144,28 +166,51 @@ RHIShaderBindingSetPtr RenderSceneNode::GetTextureBindingSet(const TSet<uint32_t
 		return cachedEntry->m_textureBindings;
 	}
 
-	TVector<RHITexturePtr> localTextures;
-	const uint32_t plannedTextureSlots = CalculatePlannedTextureSlotCount(key.m_requestedTextures);
-	localTextures.AddDefault(plannedTextureSlots);
-
 	RHITexturePtr defaultTexture = driver->GetDefaultTexture();
-
-	for (uint32_t textureIndex = 0; textureIndex < localTextures.Num(); textureIndex++)
-	{
-		localTextures[textureIndex] = defaultTexture;
-	}
+	TVector<RHITexturePtr> localTextures{ defaultTexture };
+	TVector<uint32_t> globalToLocal =
+		Details::BuildDenseTextureRemap(key.m_requestedTextures);
+	globalToLocal.Resize(TextureImporter::MaxTexturesInScene);
 
 	for (const auto& slot : sourceSnapshot.m_slots)
 	{
-		if (slot.m_index < localTextures.Num() && slot.m_texture.IsValid())
+		if (slot.m_index != 0u)
 		{
-			localTextures[slot.m_index] = slot.m_texture;
+			localTextures.Add(slot.m_texture.IsValid() ?
+				slot.m_texture :
+				defaultTexture);
 		}
 	}
+	const uint32_t denseTextureCount =
+		static_cast<uint32_t>(localTextures.Num());
 
 	RHIShaderBindingSetPtr localTextureSet = driver->CreateShaderBindings();
+	const size_t remapBufferSize =
+		globalToLocal.Num() * sizeof(uint32_t);
+	RHI::RHIBufferPtr remapBuffer = driver->CreateBuffer(
+		remapBufferSize,
+		RHI::EBufferUsageBit::StorageBuffer_Bit,
+		RHI::EMemoryPropertyBit::HostVisible |
+			RHI::EMemoryPropertyBit::HostCoherent);
+	if (!remapBuffer || !remapBuffer->GetPointer())
+	{
+		outSupportedMeshesPerBatch = 1u;
+		return cachedEntry ? cachedEntry->m_textureBindings : nullptr;
+	}
+	memcpy(remapBuffer->GetPointer(), globalToLocal.GetData(), remapBufferSize);
 
-	driver->AddSamplerToShaderBindings(localTextureSet, "textureSamplers", localTextures, 0, true, plannedTextureSlots);
+	driver->AddBufferToShaderBindings(
+		localTextureSet,
+		remapBuffer,
+		"textureSamplerRemap",
+		0);
+	driver->AddSamplerToShaderBindings(
+		localTextureSet,
+		"textureSamplers",
+		localTextures,
+		1,
+		true,
+		denseTextureCount);
 	localTextureSet->RecalculateCompatibility();
 
 #if defined(SAILOR_BUILD_WITH_VULKAN)
@@ -188,14 +233,15 @@ RHIShaderBindingSetPtr RenderSceneNode::GetTextureBindingSet(const TSet<uint32_t
 	{
 		const uint32_t actualTextureCount = static_cast<uint32_t>(localBinding->GetTextureBindings().Num());
 		const uint32_t actualLayoutCount = localBinding->GetLayout().m_arrayCount;
-		check(actualTextureCount == plannedTextureSlots);
-		check(actualLayoutCount == plannedTextureSlots);
+		check(actualTextureCount == denseTextureCount);
+		check(actualLayoutCount == denseTextureCount);
 	}
 #endif
 
-	auto& entry = m_textureBindingCache[key];
+	auto& entry = textureBindingCache[key];
 	entry.m_textureBindings = localTextureSet;
-	entry.m_textureSetSize = plannedTextureSlots;
+	entry.m_textureRemapBuffer = remapBuffer;
+	entry.m_textureSetSize = denseTextureCount;
 	entry.m_lastUsedFrame = frame;
 	entry.m_sourceDescriptorRevision = sourceSnapshot.m_descriptorRevision;
 	entry.m_sourceSlotRevisions = std::move(currentSlotRevisions);
@@ -208,11 +254,13 @@ RHIShaderBindingSetPtr RenderSceneNode::GetTextureBindingSet(const TSet<uint32_t
 #endif
 }
 
-void RenderSceneNode::EvictTextureBindingCache(uint64_t frame)
+void Details::EvictTextureBindingCache(
+	TextureBindingCache& textureBindingCache,
+	uint64_t frame)
 {
 	TVector<TextureBindingCacheKey> expiredEntries;
 
-	for (const auto& entry : m_textureBindingCache)
+	for (const auto& entry : textureBindingCache)
 	{
 		if (frame > entry.Second()->m_lastUsedFrame && frame - entry.Second()->m_lastUsedFrame > MaxTextureBindingCacheUnusedFrames)
 		{
@@ -222,7 +270,7 @@ void RenderSceneNode::EvictTextureBindingCache(uint64_t frame)
 
 	for (const auto& key : expiredEntries)
 	{
-		m_textureBindingCache.Remove(key);
+		textureBindingCache.Remove(key);
 	}
 }
 
@@ -243,7 +291,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 			m_drawCalls.Clear();
 			m_batches.Clear();
 			m_orderedDrawItems.Clear();
-			EvictTextureBindingCache(sceneViewSnapshot.m_frame);
+			Details::EvictTextureBindingCache(m_textureBindingCache, sceneViewSnapshot.m_frame);
 
 			SAILOR_PROFILE_SCOPE("Filter sceneView by tag");
 
@@ -299,7 +347,11 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 						{
 							requestedTextures.Insert(0u);
 						}
-						batch.m_textureBindings = GetTextureBindingSet(requestedTextures, sceneViewSnapshot.m_frame, supportedMeshesPerBatch);
+						batch.m_textureBindings = Details::GetTextureBindingSet(
+							m_textureBindingCache,
+							requestedTextures,
+							sceneViewSnapshot.m_frame,
+							supportedMeshesPerBatch);
 #else
 						batch.m_textureBindings = App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
 #endif
@@ -832,6 +884,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 							viewport,
 							scissor,
 							glm::vec2(0.0f, 1.0f),
+							&m_cullingIndirectBufferBinding[i + 1],
 							&transferCommandListMutex);
 					}
 
@@ -897,6 +950,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 					viewport,
 					scissor,
 					glm::vec2(0.0f, 1.0f),
+					&m_cullingIndirectBufferBinding[0],
 					&transferCommandListMutex);
 			}
 

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -321,6 +321,7 @@ https://developer.nvidia.com/vulkan-shader-resource-binding
 void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	m_drawCallStats = {};
 	m_syncSharedResources.Lock();
 
 	std::string temp;
@@ -432,6 +433,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 		}
 
 		TVector<RHICommandListPtr> secondaryCommandLists(m_batches.Num() > numThreads ? (numThreads - 1) : 0);
+		TVector<RHI::DrawCallStats> secondaryDrawCallStats(secondaryCommandLists.Num());
 		TVector<Tasks::ITaskPtr> tasks;
 
 		auto vecBatches = m_batches.ToVector();
@@ -491,6 +493,15 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 				return sets;
 			};
 
+		if (gpuMatricesData.Num() > 0)
+		{
+			SAILOR_PROFILE_SCOPE("Fill transfer command list with matrices data");
+			commands->UpdateShaderBinding(transferCommandList, storageBinding,
+				gpuMatricesData.GetData(),
+				sizeof(PerInstanceData) * gpuMatricesData.Num(),
+				0);
+		}
+
 		commands->BeginDebugRegion(commandList, std::string(GetName()) + " QueueTag:" + QueueTag, DebugContext::Color_CmdGraphics);
 		std::mutex transferCommandListMutex;
 
@@ -516,7 +527,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 
 					if (bCanDispatchCulling)
 					{
-						RHIRecordDrawCallGPUCulling(start,
+						secondaryDrawCallStats[i] = RHIRecordDrawCallGPUCulling(start,
 							end,
 							vecBatches,
 							cmdList, transferCommandList,
@@ -533,7 +544,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 					}
 					else
 					{
-						RHIRecordDrawCall(start,
+						secondaryDrawCallStats[i] = RHIRecordDrawCall(start,
 							end,
 							vecBatches,
 							cmdList, transferCommandList,
@@ -553,16 +564,6 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 
 			task->Run();
 			tasks.Add(task);
-		}
-
-		if (gpuMatricesData.Num() > 0)
-		{
-			SAILOR_PROFILE_SCOPE("Fill transfer command list with matrices data");
-			std::lock_guard<std::mutex> transferCommandListLock(transferCommandListMutex);
-			commands->UpdateShaderBinding(transferCommandList, storageBinding,
-				gpuMatricesData.GetData(),
-				sizeof(PerInstanceData) * gpuMatricesData.Num(),
-				0);
 		}
 
 		commands->ImageMemoryBarrier(commandList, colorAttachment->GetTarget(), EImageLayout::ColorAttachmentOptimal);
@@ -591,7 +592,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 
 			if (bCanDispatchCulling)
 			{
-				RHIRecordDrawCallGPUCulling((uint32_t)secondaryCommandLists.Num() * (uint32_t)materialsPerThread,
+				m_drawCallStats += RHIRecordDrawCallGPUCulling((uint32_t)secondaryCommandLists.Num() * (uint32_t)materialsPerThread,
 					(uint32_t)vecBatches.Num(),
 					vecBatches,
 					commandList, transferCommandList,
@@ -608,7 +609,7 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 			}
 			else
 			{
-				RHIRecordDrawCall((uint32_t)secondaryCommandLists.Num() * (uint32_t)materialsPerThread,
+				m_drawCallStats += RHIRecordDrawCall((uint32_t)secondaryCommandLists.Num() * (uint32_t)materialsPerThread,
 					(uint32_t)vecBatches.Num(),
 					vecBatches,
 					commandList, transferCommandList,
@@ -630,6 +631,11 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 			for (auto& task : tasks)
 			{
 				task->Wait();
+			}
+
+			for (const RHI::DrawCallStats& drawCallStats : secondaryDrawCallStats)
+			{
+				m_drawCallStats += drawCallStats;
 			}
 		}
 

--- a/Runtime/FrameGraph/RenderSceneNode.h
+++ b/Runtime/FrameGraph/RenderSceneNode.h
@@ -5,6 +5,7 @@
 #include "RHI/Types.h"
 #include "FrameGraph/BaseFrameGraphNode.h"
 #include "FrameGraph/FrameGraphNode.h"
+#include "FrameGraph/RenderSceneTextureCache.h"
 #include "RHI/Batch.hpp"
 
 namespace Sailor::Framegraph
@@ -66,6 +67,8 @@ namespace Sailor::Framegraph
 			RHI::RHIShaderBindingSetPtr m_textureBindings;
 			uint32_t m_textureSetSize = 1;
 			uint64_t m_lastUsedFrame = 0;
+			uint64_t m_sourceDescriptorRevision = 0;
+			TVector<uint64_t> m_sourceSlotRevisions;
 		};
 
 		RHI::RHIShaderBindingSetPtr GetTextureBindingSet(const TSet<uint32_t>& requestedTextures, uint64_t frame, uint32_t& outSupportedMeshesPerBatch);

--- a/Runtime/FrameGraph/RenderSceneNode.h
+++ b/Runtime/FrameGraph/RenderSceneNode.h
@@ -60,7 +60,7 @@ namespace Sailor::Framegraph
 			const RHI::RHIShaderBindingPtr& storageBinding,
 			const std::string& queueTag);
 
-		static const char* m_name;
+		SAILOR_SHARED_API static const char* m_name;
 
 		uint32_t m_numMeshes = 0;
 		SpinLock m_syncSharedResources;

--- a/Runtime/FrameGraph/RenderSceneNode.h
+++ b/Runtime/FrameGraph/RenderSceneNode.h
@@ -53,43 +53,12 @@ namespace Sailor::Framegraph
 			size_t m_meshIndex = 0;
 		};
 
-		// macOS/MoltenVK has a much tighter practical limit on bound texture descriptors.
-		// We cache texture binding sets and split batches so they fit those limits.
-		struct TextureBindingCacheKey
-		{
-			TVector<uint32_t> m_requestedTextures;
-
-			bool operator==(const TextureBindingCacheKey& rhs) const { return m_requestedTextures == rhs.m_requestedTextures; }
-
-			size_t GetHash() const
-			{
-				size_t hash = 0;
-				for (const uint32_t textureIndex : m_requestedTextures)
-				{
-					HashCombine(hash, textureIndex);
-				}
-				return hash;
-			}
-		};
-
-		struct TextureBindingCacheEntry
-		{
-			RHI::RHIShaderBindingSetPtr m_textureBindings;
-			uint32_t m_textureSetSize = 1;
-			uint64_t m_lastUsedFrame = 0;
-			uint64_t m_sourceDescriptorRevision = 0;
-			TVector<uint64_t> m_sourceSlotRevisions;
-		};
-
-		RHI::RHIShaderBindingSetPtr GetTextureBindingSet(const TSet<uint32_t>& requestedTextures, uint64_t frame, uint32_t& outSupportedMeshesPerBatch);
 		void ProcessBackToFront(RHI::RHIFrameGraphPtr frameGraph,
 			RHI::RHICommandListPtr transferCommandList,
 			RHI::RHICommandListPtr commandList,
 			const RHI::RHISceneViewSnapshot& sceneView,
 			const RHI::RHIShaderBindingPtr& storageBinding,
 			const std::string& queueTag);
-		void EvictTextureBindingCache(uint64_t frame);
-		static uint32_t CalculatePlannedTextureSlotCount(const TVector<uint32_t>& requestedTextures);
 
 		static const char* m_name;
 
@@ -109,12 +78,7 @@ namespace Sailor::Framegraph
 		RHI::RHIShaderBindingSetPtr m_computeMeshCullingBindings{};
 
 		// Shared cache across platforms; macOS relies on it most because of descriptor pressure.
-		TMap<TextureBindingCacheKey, TextureBindingCacheEntry> m_textureBindingCache;
-
-		// macOS/MoltenVK has a much tighter practical limit on the amount of bound texture descriptors.
-		// RenderScene uses these constants to keep batch-local texture sets within stable limits.
-		static constexpr uint32_t MaxTextureSlotsPerBatch = 1024u;
-		static constexpr uint64_t MaxTextureBindingCacheUnusedFrames = 5u;
+		TextureBindingCache m_textureBindingCache;
 	};
 
 	template class TFrameGraphNode<RenderSceneNode>;

--- a/Runtime/FrameGraph/RenderSceneNode.h
+++ b/Runtime/FrameGraph/RenderSceneNode.h
@@ -42,6 +42,15 @@ namespace Sailor::Framegraph
 		SAILOR_API RHI::ESortingOrder GetSortingOrder() const;
 
 	protected:
+		struct OrderedDrawItem
+		{
+			RHI::RHIBatch m_batch;
+			RHI::RHIMeshPtr m_mesh;
+			PerInstanceData m_instanceData;
+			float m_cameraDepth = 0.0f;
+			size_t m_staticMeshEcs = 0;
+			size_t m_meshIndex = 0;
+		};
 
 		// macOS/MoltenVK has a much tighter practical limit on bound texture descriptors.
 		// We cache texture binding sets and split batches so they fit those limits.
@@ -72,6 +81,12 @@ namespace Sailor::Framegraph
 		};
 
 		RHI::RHIShaderBindingSetPtr GetTextureBindingSet(const TSet<uint32_t>& requestedTextures, uint64_t frame, uint32_t& outSupportedMeshesPerBatch);
+		void ProcessBackToFront(RHI::RHIFrameGraphPtr frameGraph,
+			RHI::RHICommandListPtr transferCommandList,
+			RHI::RHICommandListPtr commandList,
+			const RHI::RHISceneViewSnapshot& sceneView,
+			const RHI::RHIShaderBindingPtr& storageBinding,
+			const std::string& queueTag);
 		void EvictTextureBindingCache(uint64_t frame);
 		static uint32_t CalculatePlannedTextureSlotCount(const TVector<uint32_t>& requestedTextures);
 
@@ -81,6 +96,7 @@ namespace Sailor::Framegraph
 		SpinLock m_syncSharedResources;
 		RHI::TDrawCalls<PerInstanceData> m_drawCalls;
 		TSet<RHI::RHIBatch> m_batches;
+		TVector<OrderedDrawItem> m_orderedDrawItems;
 		TVector<RHI::RHIBufferPtr> m_indirectBuffers;
 
 		RHI::RHIShaderBindingSetPtr m_perInstanceData;

--- a/Runtime/FrameGraph/RenderSceneNode.h
+++ b/Runtime/FrameGraph/RenderSceneNode.h
@@ -24,6 +24,7 @@ namespace Sailor::Framegraph
 			uint32_t skeletonOffset = 0;
 			uint32_t bIsCulled = 0;
 			uint32_t padding = 0;
+			vec4 bakedVolumeScale = vec4(1.0f);
 
 			bool operator==(const PerInstanceData& rhs) const { return this->materialInstance == rhs.materialInstance && this->model == rhs.model; }
 

--- a/Runtime/FrameGraph/RenderSceneTextureCache.h
+++ b/Runtime/FrameGraph/RenderSceneTextureCache.h
@@ -1,9 +1,60 @@
 #pragma once
 #include "Core/Defines.h"
+#include "Containers/Map.h"
+#include "Containers/Set.h"
 #include "Containers/Vector.h"
+#include "RHI/Types.h"
+
+namespace Sailor::Framegraph
+{
+	struct TextureBindingCacheKey
+	{
+		TVector<uint32_t> m_requestedTextures;
+
+		bool operator==(const TextureBindingCacheKey& rhs) const { return m_requestedTextures == rhs.m_requestedTextures; }
+
+		size_t GetHash() const
+		{
+			size_t hash = 0;
+			for (const uint32_t textureIndex : m_requestedTextures)
+			{
+				HashCombine(hash, textureIndex);
+			}
+			return hash;
+		}
+	};
+
+	struct TextureBindingCacheEntry
+	{
+		RHI::RHIShaderBindingSetPtr m_textureBindings;
+		RHI::RHIBufferPtr m_textureRemapBuffer;
+		uint32_t m_textureSetSize = 1;
+		uint64_t m_lastUsedFrame = 0;
+		uint64_t m_sourceDescriptorRevision = 0;
+		TVector<uint64_t> m_sourceSlotRevisions;
+	};
+
+	using TextureBindingCache = TMap<TextureBindingCacheKey, TextureBindingCacheEntry>;
+}
 
 namespace Sailor::Framegraph::Details
 {
+	static constexpr uint32_t MaxTextureSlotsPerBatch = 1024u;
+	static constexpr uint64_t MaxTextureBindingCacheUnusedFrames = 5u;
+
+	SAILOR_API RHI::RHIShaderBindingSetPtr GetTextureBindingSet(
+		TextureBindingCache& cache,
+		const TSet<uint32_t>& requestedTextures,
+		uint64_t frame,
+		uint32_t& outSupportedMeshesPerBatch);
+
+	SAILOR_API void EvictTextureBindingCache(
+		TextureBindingCache& cache,
+		uint64_t frame);
+
+	SAILOR_API TVector<uint32_t> BuildDenseTextureRemap(
+		const TVector<uint32_t>& globalTextureIndices);
+
 	SAILOR_API bool CanReuseRenderSceneTextureBindings(
 		uint64_t cachedSourceRevision,
 		uint64_t currentSourceRevision,

--- a/Runtime/FrameGraph/RenderSceneTextureCache.h
+++ b/Runtime/FrameGraph/RenderSceneTextureCache.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "Core/Defines.h"
+#include "Containers/Vector.h"
+
+namespace Sailor::Framegraph::Details
+{
+	SAILOR_API bool CanReuseRenderSceneTextureBindings(
+		uint64_t cachedSourceRevision,
+		uint64_t currentSourceRevision,
+		bool bHasCachedBindings,
+		const TVector<uint64_t>* cachedSlotRevisions = nullptr,
+		const TVector<uint64_t>* currentSlotRevisions = nullptr);
+}

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -79,13 +79,21 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 
 	RHIShaderBindingPtr blurDataBinding = m_pBlurShaderBindings->GetOrAddShaderBinding("data");
 
-	if (!m_lightMatrices)
+	if (sceneView.m_shadowMapsToUpdate.Num() == 0)
 	{
-		auto shaderBindingSet = sceneView.m_rhiLightsData;
-		m_lightMatrices = shaderBindingSet->GetOrAddShaderBinding("lightsMatrices");
+		return;
 	}
 
-	if (sceneView.m_shadowMapsToUpdate.Num() == 0)
+	auto shaderBindingSet = sceneView.m_rhiLightsData;
+	if (!shaderBindingSet || !shaderBindingSet->HasBinding("lightsMatrices"))
+	{
+		return;
+	}
+
+	// A scene/world switch replaces the lighting binding set. Always resolve the
+	// target from the current snapshot instead of retaining the previous world.
+	m_lightMatrices = shaderBindingSet->GetOrAddShaderBinding("lightsMatrices");
+	if (!m_lightMatrices || !m_lightMatrices->IsBind())
 	{
 		return;
 	}
@@ -151,62 +159,58 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 			}
 		}
 
-		if (numMeshes == 0)
-		{
-			return;
-		}
-
-		if (!m_perInstanceData || m_sizePerInstanceData < sizeof(ShadowPrepassNode::PerInstanceData) * numMeshes)
-		{
-			SAILOR_PROFILE_SCOPE("Create storage for matrices");
-			m_perInstanceData = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
-			Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_perInstanceData, "data", sizeof(ShadowPrepassNode::PerInstanceData), numMeshes, 0);
-			m_sizePerInstanceData = sizeof(ShadowPrepassNode::PerInstanceData) * numMeshes;
-		}
-
-		RHI::RHIShaderBindingPtr storageBinding = m_perInstanceData->GetOrAddShaderBinding("data");
-
 		TVector<ShadowPrepassNode::PerInstanceData> gpuMatricesData(numMeshes);
 		TVector<TVector<RHIBatch>> passes(NumShadowPasses);
 		TVector<TVector<uint32_t>> passIndices(NumShadowPasses);
+		RHI::RHIShaderBindingPtr storageBinding;
 
+		if (numMeshes > 0)
 		{
-			SAILOR_PROFILE_SCOPE("Calculate SSBO offsets");
-			size_t ssboIndex = 0;
-			for (uint32_t i = 0; i < NumShadowPasses; i++)
+			if (!m_perInstanceData || m_sizePerInstanceData < sizeof(ShadowPrepassNode::PerInstanceData) * numMeshes)
 			{
-				auto vecBatches = batches[i].ToVector();
-				if (vecBatches.Num() == 0)
-				{
-					continue;
-				}
-
-				TVector<uint32_t> storageIndex(vecBatches.Num());
-				for (uint32_t j = 0; j < vecBatches.Num(); j++)
-				{
-					bool bIsInited = false;
-					for (const auto& instancedDrawCall : drawCalls[i][vecBatches[j]])
-					{
-						auto& matrices = *instancedDrawCall.Second();
-
-						memcpy(&gpuMatricesData[ssboIndex], matrices.GetData(), sizeof(ShadowPrepassNode::PerInstanceData) * matrices.Num());
-
-						if (!bIsInited)
-						{
-							storageIndex[j] = storageBinding->GetStorageInstanceIndex() + (uint32_t)ssboIndex;
-							bIsInited = true;
-						}
-						ssboIndex += matrices.Num();
-					}
-				}
-
-				passIndices[i] = std::move(storageIndex);
-				passes[i] = std::move(vecBatches);
+				SAILOR_PROFILE_SCOPE("Create storage for matrices");
+				m_perInstanceData = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
+				Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_perInstanceData, "data", sizeof(ShadowPrepassNode::PerInstanceData), numMeshes, 0);
+				m_sizePerInstanceData = sizeof(ShadowPrepassNode::PerInstanceData) * numMeshes;
 			}
-		}
 
-		if (gpuMatricesData.Num() > 0)
-		{
+			storageBinding = m_perInstanceData->GetOrAddShaderBinding("data");
+
+			{
+				SAILOR_PROFILE_SCOPE("Calculate SSBO offsets");
+				size_t ssboIndex = 0;
+				for (uint32_t i = 0; i < NumShadowPasses; i++)
+				{
+					auto vecBatches = batches[i].ToVector();
+					if (vecBatches.Num() == 0)
+					{
+						continue;
+					}
+
+					TVector<uint32_t> storageIndex(vecBatches.Num());
+					for (uint32_t j = 0; j < vecBatches.Num(); j++)
+					{
+						bool bIsInited = false;
+						for (const auto& instancedDrawCall : drawCalls[i][vecBatches[j]])
+						{
+							auto& matrices = *instancedDrawCall.Second();
+
+							memcpy(&gpuMatricesData[ssboIndex], matrices.GetData(), sizeof(ShadowPrepassNode::PerInstanceData) * matrices.Num());
+
+							if (!bIsInited)
+							{
+								storageIndex[j] = storageBinding->GetStorageInstanceIndex() + (uint32_t)ssboIndex;
+								bIsInited = true;
+							}
+							ssboIndex += matrices.Num();
+						}
+					}
+
+					passIndices[i] = std::move(storageIndex);
+					passes[i] = std::move(vecBatches);
+				}
+			}
+
 			SAILOR_PROFILE_SCOPE("Fill transfer command list with matrices data");
 			commands->UpdateShaderBinding(transferCommandList, storageBinding,
 				gpuMatricesData.GetData(),
@@ -248,22 +252,47 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 				commands->ImageMemoryBarrier(commandList, shadowPass.m_shadowMap, EImageLayout::ColorAttachmentOptimal);
 				commands->ImageMemoryBarrier(commandList, depthAttachment, depthAttachmentLayout);
 
+				// The shadow target stores either raw PCF depth or EVSM moments. With
+				// reverse Z, an empty texel represents depth zero. EVSM must encode
+				// that value instead of clearing all four moments to zero.
+				const glm::vec4 shadowClearValue = shadowPass.m_shadowType == EShadowType::EVSM ?
+					glm::vec4(1.0f, 1.0f, -1.0f, 1.0f) :
+					glm::vec4(0.0f);
+
 				commands->BeginRenderPass(commandList,
 					TVector<RHI::RHITexturePtr>{ shadowPass.m_shadowMap },
 					depthAttachment,
 					glm::vec4(0, 0, shadowPass.m_shadowMap->GetExtent().x, shadowPass.m_shadowMap->GetExtent().y),
 					glm::ivec2(0, 0),
 					true,
-					glm::vec4(0.0f),
+					shadowClearValue,
 					0.0f,
 					false,
 					true);
 
-				auto& defaultDescription = driver->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4>();
-
-				commands->PushConstants(commandList, GetOrAddShadowMaterial(defaultDescription, shadowPass.m_shadowType), 64, &sceneView.m_shadowMapsToUpdate[index].m_lightMatrix);
-
+				RHI::RHIMaterialPtr pushConstantsMaterial;
 				if (passes[index].Num() > 0)
+				{
+					pushConstantsMaterial = passes[index][0].m_material;
+				}
+				else
+				{
+					for (uint32_t dependencyPass : shadowPass.m_internalCommandsList)
+					{
+						if (passes[dependencyPass].Num() > 0)
+						{
+							pushConstantsMaterial = passes[dependencyPass][0].m_material;
+							break;
+						}
+					}
+				}
+
+				if (pushConstantsMaterial)
+				{
+					commands->PushConstants(commandList, pushConstantsMaterial, 64, &shadowPass.m_lightMatrix);
+				}
+
+				if (pushConstantsMaterial && passes[index].Num() > 0)
 				{
 					m_drawCallStats += RHIRecordDrawCall(0, (uint32_t)passes[index].Num(), passes[index], commandList, transferCommandList, shaderBindingsByMaterial, drawCalls[index], passIndices[index], m_indirectBuffers[index],
 						glm::ivec4(0, shadowPass.m_shadowMap->GetExtent().y, shadowPass.m_shadowMap->GetExtent().x, -shadowPass.m_shadowMap->GetExtent().y),
@@ -275,7 +304,7 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 				{
 					const uint32_t numBatches = (uint32_t)passes[dependencyPass].Num();
 
-					if (numBatches > 0)
+					if (pushConstantsMaterial && numBatches > 0)
 					{
 						m_drawCallStats += RHIDrawCall(0, numBatches, passes[dependencyPass], commandList, shaderBindingsByMaterial,
 							drawCalls[dependencyPass], m_indirectBuffers[dependencyPass],
@@ -375,6 +404,11 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 
 					driver->ReleaseTemporaryRenderTarget(blurAttachment);
 				}
+
+				// Lighting samples every completed shadow map later in the same
+				// graphics command list. Publish the color writes explicitly for both
+				// the direct PCF path and the final EVSM blur pass.
+				commands->ImageMemoryBarrier(commandList, shadowPass.m_shadowMap, EImageLayout::ShaderReadOnlyOptimal);
 
 				driver->ReleaseTemporaryRenderTarget(depthAttachment);
 

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -98,6 +98,8 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 		TVector<TSet<RHIBatch>> batches(NumShadowPasses);
 
 		uint32_t numMeshes = 0;
+		const size_t opaqueQueueTag = GetHash(std::string("Opaque"));
+		const size_t maskedQueueTag = GetHash(std::string("Masked"));
 
 		SAILOR_PROFILE_SCOPE("Filter sceneView by tag");
 
@@ -106,9 +108,20 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 			const auto& shadowPass = sceneView.m_shadowMapsToUpdate[passIndex];
 			for (auto& proxy : shadowPass.m_meshList)
 			{
+				if (!proxy.m_bCastShadows)
+				{
+					continue;
+				}
+
 				for (size_t i = 0; i < proxy.m_meshes.Num(); i++)
 				{
-					if (!proxy.m_bCastShadows)
+					if (proxy.m_renderQueueTags.Num() <= i)
+					{
+						continue;
+					}
+
+					const size_t renderQueueTag = proxy.m_renderQueueTags[i];
+					if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
 					{
 						continue;
 					}

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -76,7 +76,7 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 		RHI::Renderer::GetDriverCommands()->UpdateShaderBinding(transferCommandList, blurDataBinding, &blurData, sizeof(glm::vec4) * 3);
 	}
 
-	RHIShaderBindingPtr blurDataBinding = driver->AddBufferToShaderBindings(m_pBlurShaderBindings, "data", sizeof(glm::vec4) * 3, 0, RHI::EShaderBindingType::UniformBuffer);
+	RHIShaderBindingPtr blurDataBinding = m_pBlurShaderBindings->GetOrAddShaderBinding("data");
 
 	if (!m_lightMatrices)
 	{

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -47,6 +47,7 @@ RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddShadowMaterial(RHI::RHIVertexDesc
 void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	m_drawCallStats = {};
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
@@ -251,7 +252,7 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 
 				if (passes[index].Num() > 0)
 				{
-					RHIRecordDrawCall(0, (uint32_t)passes[index].Num(), passes[index], commandList, transferCommandList, shaderBindingsByMaterial, drawCalls[index], passIndices[index], m_indirectBuffers[index],
+					m_drawCallStats += RHIRecordDrawCall(0, (uint32_t)passes[index].Num(), passes[index], commandList, transferCommandList, shaderBindingsByMaterial, drawCalls[index], passIndices[index], m_indirectBuffers[index],
 						glm::ivec4(0, shadowPass.m_shadowMap->GetExtent().y, shadowPass.m_shadowMap->GetExtent().x, -shadowPass.m_shadowMap->GetExtent().y),
 						glm::uvec4(0, 0, shadowPass.m_shadowMap->GetExtent().x, shadowPass.m_shadowMap->GetExtent().y),
 						glm::vec2(0.0f, 1.0f));
@@ -263,7 +264,7 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 
 					if (numBatches > 0)
 					{
-						RHIDrawCall(0, numBatches, passes[dependencyPass], commandList, shaderBindingsByMaterial,
+						m_drawCallStats += RHIDrawCall(0, numBatches, passes[dependencyPass], commandList, shaderBindingsByMaterial,
 							drawCalls[dependencyPass], m_indirectBuffers[dependencyPass],
 							glm::ivec4(0, shadowPass.m_shadowMap->GetExtent().y, shadowPass.m_shadowMap->GetExtent().x, -shadowPass.m_shadowMap->GetExtent().y),
 							glm::uvec4(0, 0, shadowPass.m_shadowMap->GetExtent().x, shadowPass.m_shadowMap->GetExtent().y),
@@ -317,6 +318,8 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 							0, 1.0f);
 
 						commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+						m_drawCallStats.m_numBatches++;
+						m_drawCallStats.m_numInstances++;
 						commands->EndRenderPass(commandList);
 
 						commands->ImageMemoryBarrier(commandList, shadowPass.m_shadowMap, EImageLayout::ColorAttachmentOptimal);
@@ -351,6 +354,8 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 							0, 1.0f);
 
 						commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+						m_drawCallStats.m_numBatches++;
+						m_drawCallStats.m_numInstances++;
 						commands->EndRenderPass(commandList);
 					}
 					commands->EndDebugRegion(commandList);

--- a/Runtime/FrameGraph/SkyNode.cpp
+++ b/Runtime/FrameGraph/SkyNode.cpp
@@ -261,6 +261,7 @@ void SkyNode::SetLocation(float latitudeDegrees, float longitudeDegrees)
 
 void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
+	ResetDrawCallStats();
 	ConsumePendingSkyParams();
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
@@ -621,6 +622,7 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 			0, 1.0f);
 
 		commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+		RecordDrawCallStats(1);
 		commands->EndRenderPass(commandList);
 	}
 	commands->EndDebugRegion(commandList);
@@ -657,6 +659,7 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 			commands->PushConstants(commandList, m_pCloudsMaterial, sizeof(uint32_t), &m_ditherPatternIndex);
 
 			commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+			RecordDrawCallStats(1);
 			commands->EndRenderPass(commandList);
 
 			commands->ImageMemoryBarrier(commandList, m_pSkyTexture, m_pSkyTexture->GetDefaultLayout());
@@ -697,6 +700,7 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 		commands->BindShaderBindings(commandList, m_pSunMaterial, { sceneView.m_frameBindings, m_pShaderBindings });
 
 		commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+		RecordDrawCallStats(1);
 		commands->EndRenderPass(commandList);
 
 		commands->ImageMemoryBarrier(commandList, m_pCloudsTexture, m_pCloudsTexture->GetDefaultLayout());
@@ -734,6 +738,7 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 		commands->BindShaderBindings(commandList, m_pComposeMaterial, { sceneView.m_frameBindings, m_pShaderBindings });
 
 		commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+		RecordDrawCallStats(1);
 		commands->EndRenderPass(commandList);
 
 		commands->ImageMemoryBarrier(commandList, m_pSkyTexture, m_pSkyTexture->GetDefaultLayout());
@@ -781,6 +786,7 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 		commands->SetDefaultViewport(commandList);
 
 		commands->DrawIndexed(commandList, (uint32_t)m_starsMesh->m_indexBuffer->GetSize() / sizeof(uint32_t), 1u, 0u, 0u, 0u);
+		RecordDrawCallStats(1);
 
 		commands->BeginDebugRegion(commandList, "Blit Clouds", DebugContext::Color_CmdPostProcess);
 		{
@@ -790,6 +796,7 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 			commands->BindMaterial(commandList, m_pBlitCloudsMaterial);
 			commands->BindShaderBindings(commandList, m_pBlitCloudsMaterial, { sceneView.m_frameBindings, m_pBlitCloudsBindings });
 			commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+			RecordDrawCallStats(1);
 		}
 		commands->EndDebugRegion(commandList);
 
@@ -798,6 +805,7 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 			commands->BindMaterial(commandList, m_pSunShaftsMaterial);
 			commands->BindShaderBindings(commandList, m_pSunShaftsMaterial, { sceneView.m_frameBindings, m_pShaderBindings });
 			commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+			RecordDrawCallStats(1);
 		}
 		commands->EndDebugRegion(commandList);
 
@@ -856,6 +864,7 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 					0, 1.0f);
 
 				commands->DrawIndexed(commandList, 6, 1, firstIndex, vertexOffset, 0);
+				RecordDrawCallStats(1);
 				commands->EndRenderPass(commandList);
 			}
 			else

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
@@ -1383,13 +1383,16 @@ bool VulkanApi::IsCompatible(const VulkanPipelineLayoutPtr& pipelineLayout, cons
 	const VulkanDescriptorSetLayoutPtr& layout = pipelineLayout->m_descriptionSetLayouts[binding];
 	const VulkanDescriptorSetLayoutPtr& descriptorSetLayout = descriptorSet->GetDescriptorSetLayout();
 
-	// A descriptor set with a variable-count binding (textureSamplers[] here) is
-	// allocated against its complete layout up front. When that layout is
-	// structurally compatible with the pipeline, populated texture slots do not
-	// participate in compatibility and must not be scanned.
-	if (layout->HasVariableDescriptorBinding() &&
-		descriptorSetLayout &&
-		*layout == *descriptorSetLayout)
+	// vkCmdBindDescriptorSets requires the native descriptor set layout to be
+	// identical to the corresponding pipeline layout. A variable descriptor
+	// allocation may contain fewer descriptors than its layout upper bound, but
+	// the layout's descriptorCount itself must still match.
+	if (!descriptorSetLayout || !(*layout == *descriptorSetLayout))
+	{
+		return false;
+	}
+
+	if (layout->HasVariableDescriptorBinding())
 	{
 		return true;
 	}
@@ -1431,26 +1434,12 @@ bool VulkanApi::IsCompatible(const VulkanPipelineLayoutPtr& pipelineLayout, cons
 			}
 		}
 
-		const bool bIsVariableDescriptorBinding = layout->HasVariableDescriptorBinding() &&
-			layout->GetVariableDescriptorBinding() == (int32_t)layoutBinding.binding;
-
-		if (bIsVariableDescriptorBinding)
-		{
-			if (matchedDescriptors == 0 || matchedDescriptors > layoutBinding.descriptorCount)
-			{
-				return false;
-			}
-
-			expectedDescriptorsCount += matchedDescriptors;
-		}
-		else if (matchedDescriptors != layoutBinding.descriptorCount)
+		if (matchedDescriptors != layoutBinding.descriptorCount)
 		{
 			return false;
 		}
-		else
-		{
-			expectedDescriptorsCount += layoutBinding.descriptorCount;
-		}
+
+		expectedDescriptorsCount += layoutBinding.descriptorCount;
 	}
 
 	return descriptorSet->m_descriptors.Num() == expectedDescriptorsCount;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
@@ -1381,6 +1381,18 @@ bool VulkanApi::IsCompatible(const VulkanPipelineLayoutPtr& pipelineLayout, cons
 	}
 
 	const VulkanDescriptorSetLayoutPtr& layout = pipelineLayout->m_descriptionSetLayouts[binding];
+	const VulkanDescriptorSetLayoutPtr& descriptorSetLayout = descriptorSet->GetDescriptorSetLayout();
+
+	// A descriptor set with a variable-count binding (textureSamplers[] here) is
+	// allocated against its complete layout up front. When that layout is
+	// structurally compatible with the pipeline, populated texture slots do not
+	// participate in compatibility and must not be scanned.
+	if (layout->HasVariableDescriptorBinding() &&
+		descriptorSetLayout &&
+		*layout == *descriptorSetLayout)
+	{
+		return true;
+	}
 
 	for (const VulkanDescriptorPtr& descriptor : descriptorSet->m_descriptors)
 	{

--- a/Runtime/GraphicsDriver/Vulkan/VulkanBuffer.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanBuffer.cpp
@@ -43,18 +43,18 @@ void VulkanBuffer::Compile()
 
 	const auto& queues = m_device->GetQueueFamilies();
 
-	uint32_t queueFamily[] = { queues.m_graphicsFamily.value() };
 	uint32_t queueFamilies[] = { queues.m_graphicsFamily.value(), queues.m_transferFamily.value() };
 
-	if (m_sharingMode == VK_SHARING_MODE_CONCURRENT)
+	if (m_sharingMode == VK_SHARING_MODE_CONCURRENT && queueFamilies[0] != queueFamilies[1])
 	{
 		bufferInfo.queueFamilyIndexCount = 2;
 		bufferInfo.pQueueFamilyIndices = queueFamilies;
 	}
 	else
 	{
-		bufferInfo.queueFamilyIndexCount = 1;
-		bufferInfo.pQueueFamilyIndices = queueFamily;
+		bufferInfo.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+		bufferInfo.queueFamilyIndexCount = 0;
+		bufferInfo.pQueueFamilyIndices = nullptr;
 	}
 
 	VK_CHECK(vkCreateBuffer(*m_device, &bufferInfo, nullptr, &m_buffer));

--- a/Runtime/GraphicsDriver/Vulkan/VulkanBuffer.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanBuffer.cpp
@@ -43,11 +43,30 @@ void VulkanBuffer::Compile()
 
 	const auto& queues = m_device->GetQueueFamilies();
 
-	uint32_t queueFamilies[] = { queues.m_graphicsFamily.value(), queues.m_transferFamily.value() };
+	uint32_t queueFamilies[] = {
+		queues.m_graphicsFamily.value(),
+		queues.m_transferFamily.value(),
+		queues.m_computeFamily.value()
+	};
+	uint32_t numQueueFamilies = 1;
 
-	if (m_sharingMode == VK_SHARING_MODE_CONCURRENT && queueFamilies[0] != queueFamilies[1])
+	for (uint32_t i = 1; i < NUM_ELEMENTS(queueFamilies); ++i)
 	{
-		bufferInfo.queueFamilyIndexCount = 2;
+		bool bAlreadyIncluded = false;
+		for (uint32_t j = 0; j < numQueueFamilies; ++j)
+		{
+			bAlreadyIncluded |= queueFamilies[j] == queueFamilies[i];
+		}
+
+		if (!bAlreadyIncluded)
+		{
+			queueFamilies[numQueueFamilies++] = queueFamilies[i];
+		}
+	}
+
+	if (m_sharingMode == VK_SHARING_MODE_CONCURRENT && numQueueFamilies > 1)
+	{
+		bufferInfo.queueFamilyIndexCount = numQueueFamilies;
 		bufferInfo.pQueueFamilyIndices = queueFamilies;
 	}
 	else

--- a/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
@@ -698,6 +698,12 @@ void VulkanCommandBuffer::BindPipeline(VulkanGraphicsPipelinePtr pipeline)
 
 void VulkanCommandBuffer::BindPipeline(VulkanComputePipelinePtr pipeline)
 {
+	if (!pipeline || !pipeline->IsCompiled())
+	{
+		SAILOR_LOG_ERROR("VulkanCommandBuffer::BindPipeline: compute pipeline is unavailable.");
+		return;
+	}
+
 	m_rhiDependecies.Insert(pipeline);
 	vkCmdBindPipeline(m_commandBuffer, VK_PIPELINE_BIND_POINT_COMPUTE, *pipeline);
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
@@ -822,6 +822,13 @@ void VulkanCommandBuffer::Blit(VulkanImagePtr srcImage, VkImageLayout srcImageLa
 
 void VulkanCommandBuffer::GenerateMipMaps(VulkanImagePtr image)
 {
+	constexpr VkImageLayout finalLayout =
+		VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
+	constexpr VkAccessFlags finalAccess = VK_ACCESS_SHADER_READ_BIT;
+	constexpr VkPipelineStageFlags finalStage =
+		VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT |
+		VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
+
 	if (!image->GetDevice()->IsMipsSupported(image->m_format))
 	{
 		SAILOR_LOG("Blit is not supported");
@@ -877,12 +884,12 @@ void VulkanCommandBuffer::GenerateMipMaps(VulkanImagePtr image)
 			VK_FILTER_LINEAR);
 
 		barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
-		barrier.newLayout = image->m_defaultLayout;
+		barrier.newLayout = finalLayout;
 		barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
-		barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+		barrier.dstAccessMask = finalAccess;
 
 		vkCmdPipelineBarrier(m_commandBuffer,
-			VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
+			VK_PIPELINE_STAGE_TRANSFER_BIT, finalStage, 0,
 			0, nullptr,
 			0, nullptr,
 			1, &barrier);
@@ -905,12 +912,12 @@ void VulkanCommandBuffer::GenerateMipMaps(VulkanImagePtr image)
 
 	barrier.subresourceRange.baseMipLevel = image->m_mipLevels - 1;
 	barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-	barrier.newLayout = image->m_defaultLayout;
+	barrier.newLayout = finalLayout;
 	barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
-	barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+	barrier.dstAccessMask = finalAccess;
 
 	vkCmdPipelineBarrier(m_commandBuffer,
-		VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, 0,
+		VK_PIPELINE_STAGE_TRANSFER_BIT, finalStage, 0,
 		0, nullptr,
 		0, nullptr,
 		1, &barrier);
@@ -933,6 +940,8 @@ VkAccessFlags VulkanCommandBuffer::GetAccessFlags(VkImageLayout layout)
 		return 0;
 	case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
 		return VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT;
+	case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+		return VK_ACCESS_SHADER_READ_BIT;
 	default:
 		return 0;
 	}
@@ -952,6 +961,8 @@ VkPipelineStageFlags VulkanCommandBuffer::GetPipelineStage(VkImageLayout layout)
 		return VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
 	case VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL:
 		return VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+	case VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL:
+		return VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT;
 	default:
 		return VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
 	}

--- a/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
@@ -959,7 +959,81 @@ VkPipelineStageFlags VulkanCommandBuffer::GetPipelineStage(VkImageLayout layout)
 
 void VulkanCommandBuffer::MemoryBarrier(VkAccessFlags srcAccess, VkAccessFlags dstAccess)
 {
-	//TODO:
+	const uint32_t queueFamilyIndex = m_commandPool->GetQueueFamilyIndex();
+	const auto& queueFamilies = m_device->GetQueueFamilies();
+	const bool bSupportsGraphics = queueFamilies.m_graphicsFamily.has_value() &&
+		queueFamilyIndex == queueFamilies.m_graphicsFamily.value();
+	const bool bSupportsCompute = queueFamilies.m_computeFamily.has_value() &&
+		queueFamilyIndex == queueFamilies.m_computeFamily.value();
+
+	const VkPipelineStageFlags shaderStages =
+		(bSupportsGraphics ? VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT : 0) |
+		(bSupportsCompute ? VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT : 0);
+
+	auto resolvePipelineStages = [shaderStages](VkAccessFlags access, bool bSource)
+		{
+			VkPipelineStageFlags stages = 0;
+
+			if (access & VK_ACCESS_INDIRECT_COMMAND_READ_BIT)
+			{
+				stages |= VK_PIPELINE_STAGE_DRAW_INDIRECT_BIT;
+			}
+			if (access & (VK_ACCESS_INDEX_READ_BIT | VK_ACCESS_VERTEX_ATTRIBUTE_READ_BIT))
+			{
+				stages |= VK_PIPELINE_STAGE_VERTEX_INPUT_BIT;
+			}
+			if (access & (VK_ACCESS_UNIFORM_READ_BIT | VK_ACCESS_SHADER_READ_BIT | VK_ACCESS_SHADER_WRITE_BIT))
+			{
+				stages |= shaderStages;
+			}
+			if (access & VK_ACCESS_INPUT_ATTACHMENT_READ_BIT)
+			{
+				stages |= VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
+			}
+			if (access & (VK_ACCESS_COLOR_ATTACHMENT_READ_BIT | VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT))
+			{
+				stages |= VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+			}
+			if (access & (VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT))
+			{
+				stages |= VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT;
+			}
+			if (access & (VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_TRANSFER_WRITE_BIT))
+			{
+				stages |= VK_PIPELINE_STAGE_TRANSFER_BIT;
+			}
+			if (access & (VK_ACCESS_HOST_READ_BIT | VK_ACCESS_HOST_WRITE_BIT))
+			{
+				stages |= VK_PIPELINE_STAGE_HOST_BIT;
+			}
+			if (access & (VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT))
+			{
+				stages |= VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+			}
+
+			if (stages == 0)
+			{
+				stages = bSource ? VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT : VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+			}
+
+			return stages;
+		};
+
+	VkMemoryBarrier barrier{};
+	barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+	barrier.srcAccessMask = srcAccess;
+	barrier.dstAccessMask = dstAccess;
+
+	vkCmdPipelineBarrier(m_commandBuffer,
+		resolvePipelineStages(srcAccess, true),
+		resolvePipelineStages(dstAccess, false),
+		0,
+		1, &barrier,
+		0, nullptr,
+		0, nullptr);
+
+	m_numRecordedCommands++;
+	m_gpuCost += 1;
 }
 
 void VulkanCommandBuffer::ImageMemoryBarrier(VulkanImageViewPtr image,

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDescriptors.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDescriptors.cpp
@@ -308,22 +308,42 @@ bool VulkanDescriptorSet::LikelyContains(VkDescriptorSetLayoutBinding layout) co
 
 bool VulkanDescriptorSet::ReferencesImageView(uint32_t binding, uint32_t arrayElement, const VulkanImageViewPtr& imageView) const
 {
+	auto referencesImageView = [&imageView](const VulkanDescriptorPtr& descriptor)
+		{
+			if (const auto* combinedImage = dynamic_cast<const VulkanDescriptorCombinedImage*>(descriptor.GetRawPtr()))
+			{
+				return combinedImage->GetImageView() == imageView;
+			}
+
+			if (const auto* storageImage = dynamic_cast<const VulkanDescriptorStorageImage*>(descriptor.GetRawPtr()))
+			{
+				return storageImage->GetImageView() == imageView;
+			}
+
+			return false;
+		};
+
+	if (arrayElement < m_descriptors.Num())
+	{
+		const VulkanDescriptorPtr& candidate = m_descriptors[arrayElement];
+		if (candidate &&
+			candidate->GetBinding() == binding &&
+			candidate->GetArrayElement() == arrayElement)
+		{
+			return referencesImageView(candidate);
+		}
+	}
+
 	for (const VulkanDescriptorPtr& descriptor : m_descriptors)
 	{
-		if (descriptor->GetBinding() != binding || descriptor->GetArrayElement() != arrayElement)
+		if (!descriptor ||
+			descriptor->GetBinding() != binding ||
+			descriptor->GetArrayElement() != arrayElement)
 		{
 			continue;
 		}
 
-		if (const auto* combinedImage = dynamic_cast<const VulkanDescriptorCombinedImage*>(descriptor.GetRawPtr()))
-		{
-			return combinedImage->GetImageView() == imageView;
-		}
-
-		if (const auto* storageImage = dynamic_cast<const VulkanDescriptorStorageImage*>(descriptor.GetRawPtr()))
-		{
-			return storageImage->GetImageView() == imageView;
-		}
+		return referencesImageView(descriptor);
 	}
 
 	return false;
@@ -517,6 +537,13 @@ bool VulkanDescriptorSet::TryCompile()
 		// referenced by a recorded or submitted command buffer.
 		m_descriptorPoolPage = std::move(descriptorPoolPage);
 		m_descriptorPool.Clear();
+
+		if (m_descriptorSetLayout->HasVariableDescriptorBinding())
+		{
+			// Store the count actually used by vkAllocateDescriptorSets. The
+			// requested count may have been clamped to the layout's upper bound.
+			m_variableDescriptorCount = variableDescriptorCount;
+		}
 	}
 
 	TVector<VkWriteDescriptorSet> descriptorsWrite(m_descriptors.Num());

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDescriptors.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDescriptors.cpp
@@ -83,7 +83,8 @@ VulkanDescriptorSetLayout::~VulkanDescriptorSetLayout()
 
 bool VulkanDescriptorSetLayout::operator==(const VulkanDescriptorSetLayout& rhs) const
 {
-	return this->m_descriptorSetLayoutBindings == rhs.m_descriptorSetLayoutBindings;
+	return m_variableDescriptorBinding == rhs.m_variableDescriptorBinding &&
+		m_descriptorSetLayoutBindings == rhs.m_descriptorSetLayoutBindings;
 }
 
 size_t VulkanDescriptorSetLayout::GetHash() const
@@ -164,31 +165,125 @@ void VulkanDescriptorSetLayout::Release()
 	}
 }
 
+VulkanDescriptorPoolPage::VulkanDescriptorPoolPage(VulkanDevicePtr pDevice, VkDescriptorPool descriptorPool) :
+	m_device(pDevice),
+	m_descriptorPool(descriptorPool)
+{
+}
+
+VulkanDescriptorPoolPage::~VulkanDescriptorPoolPage()
+{
+	if (m_descriptorPool)
+	{
+		vkDestroyDescriptorPool(*m_device, m_descriptorPool, nullptr);
+		m_descriptorPool = VK_NULL_HANDLE;
+	}
+}
+
 VulkanDescriptorPool::VulkanDescriptorPool(VulkanDevicePtr pDevice, uint32_t maxSets,
 	const TVector<VkDescriptorPoolSize>& descriptorPoolSizes) :
-	m_device(pDevice)
+	m_device(pDevice),
+	m_maxSets(maxSets),
+	m_descriptorPoolSizes(descriptorPoolSizes)
 {
+	VK_CHECK(CreatePool());
+}
+
+VkResult VulkanDescriptorPool::CreatePool(const TVector<VkDescriptorPoolSize>* descriptorRequirements)
+{
+	if (descriptorRequirements != nullptr)
+	{
+		for (const VkDescriptorPoolSize& requirement : *descriptorRequirements)
+		{
+			const uint32_t blockCapacity = std::max(requirement.descriptorCount, m_maxSets);
+			const size_t index = m_descriptorPoolSizes.FindIf(
+				[&requirement](const VkDescriptorPoolSize& poolSize)
+				{
+					return poolSize.type == requirement.type;
+				});
+
+			if (index == static_cast<size_t>(-1))
+			{
+				m_descriptorPoolSizes.Add(VkDescriptorPoolSize{
+					requirement.type,
+					blockCapacity });
+			}
+			else
+			{
+				m_descriptorPoolSizes[index].descriptorCount = std::max(
+					m_descriptorPoolSizes[index].descriptorCount,
+					blockCapacity);
+			}
+		}
+	}
+
+	const TVector<VkDescriptorPoolSize> descriptorPoolSizes = m_descriptorPoolSizes;
+
 	VkDescriptorPoolCreateInfo poolInfo = {};
 	poolInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
 	poolInfo.poolSizeCount = static_cast<uint32_t>(descriptorPoolSizes.Num());
 	poolInfo.pPoolSizes = descriptorPoolSizes.GetData();
-	poolInfo.maxSets = maxSets;
-	poolInfo.flags = VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT;
+	poolInfo.maxSets = m_maxSets;
+	poolInfo.flags = 0;
 	if (m_device->IsDescriptorUpdateAfterBindSupported())
 	{
 		poolInfo.flags |= VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT;
 	}
 	poolInfo.pNext = nullptr;
 
-	VK_CHECK(vkCreateDescriptorPool(*m_device, &poolInfo, nullptr, &m_descriptorPool));
+	VkDescriptorPool descriptorPool = VK_NULL_HANDLE;
+	const VkResult result = vkCreateDescriptorPool(*m_device, &poolInfo, nullptr, &descriptorPool);
+	if (result == VK_SUCCESS)
+	{
+		m_currentPage = VulkanDescriptorPoolPagePtr::Make(m_device, descriptorPool);
+	}
+
+	return result;
+}
+
+VkResult VulkanDescriptorPool::AllocateDescriptorSet(VkDescriptorSetAllocateInfo allocateInfo,
+	const TVector<VkDescriptorPoolSize>& descriptorRequirements,
+	VkDescriptorSet& outDescriptorSet,
+	VulkanDescriptorPoolPagePtr& outPoolPage)
+{
+	m_lock.Lock();
+
+	outDescriptorSet = VK_NULL_HANDLE;
+	outPoolPage.Clear();
+	VkResult result = m_currentPage ? VK_SUCCESS : CreatePool();
+	if (result == VK_SUCCESS)
+	{
+		allocateInfo.descriptorPool = *m_currentPage;
+		result = vkAllocateDescriptorSets(*m_device, &allocateInfo, &outDescriptorSet);
+		if (result == VK_SUCCESS)
+		{
+			outPoolPage = m_currentPage;
+		}
+	}
+
+	if (result == VK_ERROR_OUT_OF_POOL_MEMORY || result == VK_ERROR_FRAGMENTED_POOL)
+	{
+		outDescriptorSet = VK_NULL_HANDLE;
+		outPoolPage.Clear();
+		result = CreatePool(&descriptorRequirements);
+		if (result == VK_SUCCESS)
+		{
+			allocateInfo.descriptorPool = *m_currentPage;
+			result = vkAllocateDescriptorSets(*m_device, &allocateInfo, &outDescriptorSet);
+			if (result == VK_SUCCESS)
+			{
+				outPoolPage = m_currentPage;
+			}
+		}
+	}
+
+	m_lock.Unlock();
+	return result;
 }
 
 VulkanDescriptorPool::~VulkanDescriptorPool()
 {
-	if (m_descriptorPool)
-	{
-		vkDestroyDescriptorPool(*m_device, m_descriptorPool, nullptr);
-	}
+	m_currentPage.Clear();
 }
 
 VulkanDescriptorSet::VulkanDescriptorSet(VulkanDevicePtr pDevice,
@@ -211,6 +306,29 @@ bool VulkanDescriptorSet::LikelyContains(VkDescriptorSetLayoutBinding layout) co
 	return (m_compatibilityHashCode & hashCode) == hashCode;
 }
 
+bool VulkanDescriptorSet::ReferencesImageView(uint32_t binding, uint32_t arrayElement, const VulkanImageViewPtr& imageView) const
+{
+	for (const VulkanDescriptorPtr& descriptor : m_descriptors)
+	{
+		if (descriptor->GetBinding() != binding || descriptor->GetArrayElement() != arrayElement)
+		{
+			continue;
+		}
+
+		if (const auto* combinedImage = dynamic_cast<const VulkanDescriptorCombinedImage*>(descriptor.GetRawPtr()))
+		{
+			return combinedImage->GetImageView() == imageView;
+		}
+
+		if (const auto* storageImage = dynamic_cast<const VulkanDescriptorStorageImage*>(descriptor.GetRawPtr()))
+		{
+			return storageImage->GetImageView() == imageView;
+		}
+	}
+
+	return false;
+}
+
 void VulkanDescriptorSet::RecalculateCompatibility()
 {
 	m_compatibilityHashCode = 0;
@@ -223,54 +341,81 @@ void VulkanDescriptorSet::RecalculateCompatibility()
 	}
 }
 
-void VulkanDescriptorSet::UpdateDescriptor(uint32_t index)
+bool VulkanDescriptorSet::UpdateDescriptor(VulkanDescriptorPtr descriptor)
 {
-	VkWriteDescriptorSet descriptorWrite{};
-
-	m_descriptors[index]->Apply(descriptorWrite);
-	descriptorWrite.dstSet = m_descriptorSet;
-
-#ifdef _DEBUG
-	const auto* variableLayoutBinding = m_descriptorSetLayout->HasVariableDescriptorBinding() ?
-		FindLayoutBinding(m_descriptorSetLayout, static_cast<uint32_t>(m_descriptorSetLayout->GetVariableDescriptorBinding()), descriptorWrite.descriptorType) :
-		nullptr;
-	const uint32_t variableDescriptorCount = variableLayoutBinding ?
-		(std::min)(variableLayoutBinding->descriptorCount, (std::max)(1u, m_variableDescriptorCount)) :
-		(std::max)(1u, m_variableDescriptorCount);
-
-	bool bValid = true;
-	switch (descriptorWrite.descriptorType)
+	if (!m_descriptorSet || !descriptor)
 	{
-	case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-		bValid = (descriptorWrite.pImageInfo != nullptr) && (descriptorWrite.pImageInfo->imageView != VK_NULL_HANDLE) && (descriptorWrite.pImageInfo->sampler != VK_NULL_HANDLE);
-		break;
-	case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-	case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-	case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT:
-		bValid = (descriptorWrite.pImageInfo != nullptr) && (descriptorWrite.pImageInfo->imageView != VK_NULL_HANDLE);
-		break;
-	case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-	case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-	case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC:
-	case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC:
-		bValid = (descriptorWrite.pBufferInfo != nullptr) && (descriptorWrite.pBufferInfo->buffer != VK_NULL_HANDLE);
-		break;
-	case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER:
-	case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER:
-		bValid = (descriptorWrite.pTexelBufferView != nullptr) && (*descriptorWrite.pTexelBufferView != VK_NULL_HANDLE);
-		break;
-	default:
-		break;
+		return false;
 	}
 
-	bValid = bValid && ValidateDescriptorWrite(m_descriptorSetLayout, descriptorWrite, variableDescriptorCount, "VulkanDescriptorSet::UpdateDescriptor");
-	check(bValid);
-#endif
+	VkWriteDescriptorSet descriptorWrite{};
+	descriptor->Apply(descriptorWrite);
+	descriptorWrite.dstSet = m_descriptorSet;
+
+	if (!ValidateDescriptorWrite(
+		m_descriptorSetLayout,
+		descriptorWrite,
+		(std::max)(1u, m_variableDescriptorCount),
+		"VulkanDescriptorSet::UpdateDescriptor"))
+	{
+		return false;
+	}
+
+	size_t descriptorIndex = static_cast<size_t>(-1);
+	if (descriptor->GetArrayElement() < m_descriptors.Num())
+	{
+		const VulkanDescriptorPtr& candidate = m_descriptors[descriptor->GetArrayElement()];
+		if (candidate &&
+			candidate->GetBinding() == descriptor->GetBinding() &&
+			candidate->GetArrayElement() == descriptor->GetArrayElement() &&
+			candidate->GetType() == descriptor->GetType())
+		{
+			descriptorIndex = descriptor->GetArrayElement();
+		}
+	}
+
+	if (descriptorIndex == static_cast<size_t>(-1) &&
+		!m_descriptors.IsEmpty() &&
+		descriptor->GetArrayElement() == m_descriptors.Num() &&
+		m_descriptors[m_descriptors.Num() - 1]->GetBinding() == descriptor->GetBinding() &&
+		m_descriptors[m_descriptors.Num() - 1]->GetArrayElement() + 1 == descriptor->GetArrayElement() &&
+		m_descriptors[m_descriptors.Num() - 1]->GetType() == descriptor->GetType())
+	{
+		descriptorIndex = m_descriptors.Num();
+	}
+
+	if (descriptorIndex == static_cast<size_t>(-1))
+	{
+		descriptorIndex = m_descriptors.FindIf(
+			[&descriptor](const VulkanDescriptorPtr& candidate)
+			{
+				return candidate &&
+					candidate->GetBinding() == descriptor->GetBinding() &&
+					candidate->GetArrayElement() == descriptor->GetArrayElement() &&
+					candidate->GetType() == descriptor->GetType();
+			});
+	}
+
+	// UPDATE_UNUSED_WHILE_PENDING only permits changing a slot that pending
+	// command buffers do not use. Replacing an existing descriptor requires an
+	// immutable replacement set (handled by the caller's fallback path).
+	if (descriptorIndex != static_cast<size_t>(-1) && descriptorIndex != m_descriptors.Num())
+	{
+		return false;
+	}
 
 	vkUpdateDescriptorSets(*m_device, 1, &descriptorWrite, 0, nullptr);
+	m_descriptors.Emplace(std::move(descriptor));
+
+	return true;
 }
 
 void VulkanDescriptorSet::Compile()
+{
+	TryCompile();
+}
+
+bool VulkanDescriptorSet::TryCompile()
 {
 	uint32_t variableDescriptorCount = std::max(1u, m_variableDescriptorCount);
 
@@ -279,6 +424,12 @@ void VulkanDescriptorSet::Compile()
 		m_descriptorSetLayout->Compile();
 
 		VkDescriptorSetLayout vkdescriptorSetLayout = *m_descriptorSetLayout;
+		if (!vkdescriptorSetLayout || !m_descriptorPool || !m_device)
+		{
+			SAILOR_LOG_ERROR("VulkanDescriptorSet::TryCompile: descriptor layout, pool, or device is unavailable.");
+			return false;
+		}
+
 		VkDescriptorSetVariableDescriptorCountAllocateInfo variableDescriptorCountInfo{};
 		if (m_descriptorSetLayout->HasVariableDescriptorBinding())
 		{
@@ -306,9 +457,34 @@ void VulkanDescriptorSet::Compile()
 			}
 		}
 
+		TVector<VkDescriptorPoolSize> descriptorRequirements;
+		for (const VkDescriptorSetLayoutBinding& layoutBinding : m_descriptorSetLayout->m_descriptorSetLayoutBindings)
+		{
+			const uint32_t descriptorCount = GetEffectiveDescriptorCount(
+				m_descriptorSetLayout,
+				layoutBinding,
+				variableDescriptorCount);
+			const size_t requirementIndex = descriptorRequirements.FindIf(
+				[&layoutBinding](const VkDescriptorPoolSize& requirement)
+				{
+					return requirement.type == layoutBinding.descriptorType;
+				});
+
+			if (requirementIndex == static_cast<size_t>(-1))
+			{
+				descriptorRequirements.Add(VkDescriptorPoolSize{
+					layoutBinding.descriptorType,
+					descriptorCount });
+			}
+			else
+			{
+				descriptorRequirements[requirementIndex].descriptorCount += descriptorCount;
+			}
+		}
+
 		VkDescriptorSetAllocateInfo descriptSetAllocateInfo = {};
 		descriptSetAllocateInfo.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
-		descriptSetAllocateInfo.descriptorPool = *m_descriptorPool;
+		descriptSetAllocateInfo.descriptorPool = VK_NULL_HANDLE;
 		descriptSetAllocateInfo.descriptorSetCount = 1;
 		descriptSetAllocateInfo.pSetLayouts = &vkdescriptorSetLayout;
 		descriptSetAllocateInfo.pNext = nullptr;
@@ -321,9 +497,26 @@ void VulkanDescriptorSet::Compile()
 			descriptSetAllocateInfo.pNext = &variableDescriptorCountInfo;
 		}
 
-		VK_CHECK(vkAllocateDescriptorSets(*m_device, &descriptSetAllocateInfo, &m_descriptorSet));
+		VulkanDescriptorPoolPagePtr descriptorPoolPage;
+		const VkResult allocationResult = m_descriptorPool->AllocateDescriptorSet(
+			descriptSetAllocateInfo,
+			descriptorRequirements,
+			m_descriptorSet,
+			descriptorPoolPage);
+		if (allocationResult != VK_SUCCESS || !m_descriptorSet)
+		{
+			SAILOR_LOG_ERROR("VulkanDescriptorSet::TryCompile: vkAllocateDescriptorSets failed. result=%d, descriptors=%zu, variableCount=%u",
+				static_cast<int32_t>(allocationResult),
+				m_descriptors.Num(),
+				variableDescriptorCount);
+			m_descriptorSet = VK_NULL_HANDLE;
+			return false;
+		}
 
-		m_currentThreadId = GetCurrentThreadId();
+		// Keep the exact pool page alive for as long as this descriptor set can be
+		// referenced by a recorded or submitted command buffer.
+		m_descriptorPoolPage = std::move(descriptorPoolPage);
+		m_descriptorPool.Clear();
 	}
 
 	TVector<VkWriteDescriptorSet> descriptorsWrite(m_descriptors.Num());
@@ -386,37 +579,15 @@ void VulkanDescriptorSet::Compile()
 	{
 		vkUpdateDescriptorSets(*m_device, static_cast<uint32_t>(validWrites.Num()), validWrites.GetData(), 0, nullptr);
 	}
+
+	return true;
 }
 
 void VulkanDescriptorSet::Release()
 {
-	DWORD currentThreadId = GetCurrentThreadId();
-
-	auto scheduler = App::GetSubmodule<Tasks::Scheduler>();
-	if (m_currentThreadId == currentThreadId || !scheduler || !scheduler->HasThread(m_currentThreadId))
-	{
-		vkFreeDescriptorSets(*m_device, *m_descriptorPool, 1, &m_descriptorSet);
-	}
-	else
-	{
-		check(m_descriptorPool.IsValid());
-		check(m_device.IsValid());
-
-		auto pReleaseResource = Tasks::CreateTask("Release descriptor set",
-			[
-				duplicatedPool = std::move(m_descriptorPool),
-					duplicatedSet = std::move(m_descriptorSet),
-					duplicatedDevice = std::move(m_device)
-			]() mutable
-			{
-				if (duplicatedSet && duplicatedDevice && duplicatedPool)
-				{
-					vkFreeDescriptorSets(*duplicatedDevice, *duplicatedPool, 1, &duplicatedSet);
-				}
-			});
-
-				scheduler->Run(pReleaseResource, m_currentThreadId);
-	}
+	m_descriptorSet = VK_NULL_HANDLE;
+	m_descriptors.Clear();
+	m_descriptorPoolPage.Clear();
 }
 
 VulkanDescriptorSet::~VulkanDescriptorSet()

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDescriptors.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDescriptors.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "VulkanApi.h"
+#include "Core/SpinLock.h"
 #include "Memory/RefPtr.hpp"
 #include "VulkanDevice.h"
 #include "RHI/Types.h"
@@ -8,6 +9,9 @@ namespace Sailor::GraphicsDriver::Vulkan
 {
 	class VulkanSampler;
 	class VulkanImageView;
+	class VulkanDescriptorPoolPage;
+
+	using VulkanDescriptorPoolPagePtr = TRefPtr<VulkanDescriptorPoolPage>;
 
 	class VulkanDescriptorSetLayout : public RHI::RHIResource, public RHI::IExplicitInitialization
 	{
@@ -39,18 +43,40 @@ namespace Sailor::GraphicsDriver::Vulkan
 		int32_t m_variableDescriptorBinding = -1;
 	};
 
+	class VulkanDescriptorPoolPage final : public RHI::RHIResource
+	{
+	public:
+		SAILOR_API VulkanDescriptorPoolPage(VulkanDevicePtr pDevice, VkDescriptorPool descriptorPool);
+
+		SAILOR_API operator VkDescriptorPool() const { return m_descriptorPool; }
+
+	protected:
+		SAILOR_API virtual ~VulkanDescriptorPoolPage() override;
+
+		VulkanDevicePtr m_device;
+		VkDescriptorPool m_descriptorPool{ VK_NULL_HANDLE };
+	};
+
 	class VulkanDescriptorPool : public RHI::RHIResource
 	{
 	public:
 		SAILOR_API VulkanDescriptorPool(VulkanDevicePtr pDevice, uint32_t maxSets, const TVector<VkDescriptorPoolSize>& descriptorPoolSizes);
 
-		SAILOR_API operator VkDescriptorPool() const { return m_descriptorPool; }
+		SAILOR_API operator VkDescriptorPool() const { return m_currentPage ? static_cast<VkDescriptorPool>(*m_currentPage) : VK_NULL_HANDLE; }
+		SAILOR_API VkResult AllocateDescriptorSet(VkDescriptorSetAllocateInfo allocateInfo,
+			const TVector<VkDescriptorPoolSize>& descriptorRequirements,
+			VkDescriptorSet& outDescriptorSet,
+			VulkanDescriptorPoolPagePtr& outPoolPage);
 
 	protected:
 		SAILOR_API virtual ~VulkanDescriptorPool();
+		SAILOR_API VkResult CreatePool(const TVector<VkDescriptorPoolSize>* descriptorRequirements = nullptr);
 
-		VkDescriptorPool m_descriptorPool;
+		VulkanDescriptorPoolPagePtr m_currentPage;
 		VulkanDevicePtr m_device;
+		uint32_t m_maxSets = 0;
+		TVector<VkDescriptorPoolSize> m_descriptorPoolSizes;
+		SpinLock m_lock;
 	};
 
 	class VulkanDescriptor : public RHI::RHIResource, public RHI::IStateModifier<VkWriteDescriptorSet>
@@ -102,6 +128,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API void SetImageView(VulkanImageViewPtr imageView);
 
 		SAILOR_API virtual void Apply(VkWriteDescriptorSet& writeDescriptorSet) const override;
+		SAILOR_API VulkanImageViewPtr GetImageView() const { return m_imageView; }
 
 	protected:
 
@@ -122,6 +149,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API void SetImageView(VulkanImageViewPtr imageView);
 
 		SAILOR_API virtual void Apply(VkWriteDescriptorSet& writeDescriptorSet) const override;
+		SAILOR_API VulkanImageViewPtr GetImageView() const { return m_imageView; }
 
 	protected:
 
@@ -145,15 +173,18 @@ namespace Sailor::GraphicsDriver::Vulkan
 		VulkanDescriptorSetLayoutPtr m_setLayout;
 		TVector<VulkanDescriptorPtr> m_descriptors;
 
-		SAILOR_API void UpdateDescriptor(uint32_t index);
-
+		SAILOR_API bool UpdateDescriptor(VulkanDescriptorPtr descriptor);
+		SAILOR_API bool TryCompile();
 		SAILOR_API virtual void Compile() override;
 		SAILOR_API virtual void Release() override;
 
 		SAILOR_API VkDescriptorSet* GetHandle() { return &m_descriptorSet; }
 		SAILOR_API operator VkDescriptorSet() const { return m_descriptorSet; }
+		SAILOR_API bool IsCompiled() const { return m_descriptorSet != VK_NULL_HANDLE; }
+		SAILOR_API uint32_t GetVariableDescriptorCount() const { return m_variableDescriptorCount; }
+		SAILOR_API bool ReferencesImageView(uint32_t binding, uint32_t arrayElement, const VulkanImageViewPtr& imageView) const;
 
-		SAILOR_API VulkanDescriptorSetLayoutPtr GetDescriptorSetLayout() { return m_descriptorSetLayout; }
+		SAILOR_API const VulkanDescriptorSetLayoutPtr& GetDescriptorSetLayout() const { return m_descriptorSetLayout; }
 		SAILOR_API bool LikelyContains(VkDescriptorSetLayoutBinding layout) const;
 
 	protected:
@@ -166,13 +197,12 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API void RecalculateCompatibility();
 
 		VulkanDevicePtr m_device{};
-		VkDescriptorSet m_descriptorSet{};
+		VkDescriptorSet m_descriptorSet{ VK_NULL_HANDLE };
 		VulkanDescriptorPoolPtr m_descriptorPool{};
+		VulkanDescriptorPoolPagePtr m_descriptorPoolPage{};
 		VulkanDescriptorSetLayoutPtr m_descriptorSetLayout{};
 
 		size_t m_compatibilityHashCode = 0;
 		uint32_t m_variableDescriptorCount = 0;
-
-		DWORD m_currentThreadId = 0;
 	};
 }

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
@@ -231,7 +231,6 @@ void VulkanDevice::BeginConditionalDestroy()
 	}
 
 	m_renderFinishedSemaphores.Clear();
-	m_sceneViewMainResolvedSemaphores.Clear();
 	m_imageAvailableSemaphores.Clear();
 	m_syncImages.Clear();
 	m_syncFences.Clear();
@@ -475,16 +474,10 @@ TUniquePtr<ThreadContext> VulkanDevice::CreateThreadContext()
 
 	auto descriptorSizes = TVector
 	{
-#if defined(__APPLE__)
-		// MoltenVK is strict about descriptor pool capacities; keep generous headroom on macOS.
 		VulkanApi::CreateDescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1024),
 		VulkanApi::CreateDescriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 8192),
 		VulkanApi::CreateDescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 4096),
 		VulkanApi::CreateDescriptorPoolSize(VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1024)
-#else
-		VulkanApi::CreateDescriptorPoolSize(VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 32),
-		VulkanApi::CreateDescriptorPoolSize(VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 64)
-#endif
 	};
 
 	context->m_descriptorPool = VulkanDescriptorPoolPtr::Make(VulkanDevicePtr(this), 8192, descriptorSizes);
@@ -505,7 +498,6 @@ void VulkanDevice::CreateFrameSyncSemaphores()
 	{
 		m_imageAvailableSemaphores.Add(VulkanSemaphorePtr::Make(VulkanDevicePtr(this)));
 		m_renderFinishedSemaphores.Add(VulkanSemaphorePtr::Make(VulkanDevicePtr(this)));
-		m_sceneViewMainResolvedSemaphores.Add(VulkanSemaphorePtr::Make(VulkanDevicePtr(this)));
 		m_syncFences.Add(VulkanFencePtr::Make(VulkanDevicePtr(this), VK_FENCE_CREATE_SIGNALED_BIT));
 	}
 }
@@ -601,7 +593,8 @@ void VulkanDevice::CreateLogicalDevice(VkPhysicalDevice physicalDevice)
 	TVector<VkDeviceQueueCreateInfo> queueCreateInfos;
 	TSet<uint32_t> uniqueQueueFamilies = { m_queueFamilies.m_graphicsFamily.value(),
 		m_queueFamilies.m_presentFamily.value(),
-		m_queueFamilies.m_transferFamily.value() };
+		m_queueFamilies.m_transferFamily.value(),
+		m_queueFamilies.m_computeFamily.value() };
 
 	float queuePriority = 1.0f;
 
@@ -807,22 +800,38 @@ void VulkanDevice::CreateLogicalDevice(VkPhysicalDevice physicalDevice)
 		SAILOR_LOG_ERROR("Failed to load Vulkan dynamic rendering end function pointers.");
 	}
 
-	// Create queues
-	VkQueue presentQueue;
-	vkGetDeviceQueue(m_device, m_queueFamilies.m_presentFamily.value(), 0, &presentQueue);
-	m_presentQueue = VulkanQueuePtr::Make(presentQueue, m_queueFamilies.m_presentFamily.value(), 0);
+	// A VkQueue requires external synchronization. Queue families commonly alias
+	// the same family/index on MoltenVK, so all aliases must share one wrapper and
+	// therefore one submission lock.
+	auto getOrCreateQueue = [this](uint32_t queueFamilyIndex) -> VulkanQueuePtr
+		{
+			constexpr uint32_t queueIndex = 0;
+			const VulkanQueuePtr queues[] = {
+				m_graphicsQueue,
+				m_computeQueue,
+				m_transferQueue,
+				m_presentQueue
+			};
 
-	VkQueue graphicsQueue;
-	vkGetDeviceQueue(m_device, m_queueFamilies.m_graphicsFamily.value(), 0, &graphicsQueue);
-	m_graphicsQueue = VulkanQueuePtr::Make(graphicsQueue, m_queueFamilies.m_graphicsFamily.value(), 0);
+			for (const VulkanQueuePtr& queue : queues)
+			{
+				if (queue.IsValid() &&
+					queue->QueueFamilyIndex() == queueFamilyIndex &&
+					queue->QueueIndex() == queueIndex)
+				{
+					return queue;
+				}
+			}
 
-	VkQueue transferQueue;
-	vkGetDeviceQueue(m_device, m_queueFamilies.m_transferFamily.value(), 0, &transferQueue);
-	m_transferQueue = VulkanQueuePtr::Make(transferQueue, m_queueFamilies.m_transferFamily.value(), 0);
+			VkQueue queue = VK_NULL_HANDLE;
+			vkGetDeviceQueue(m_device, queueFamilyIndex, queueIndex, &queue);
+			return VulkanQueuePtr::Make(queue, queueFamilyIndex, queueIndex);
+		};
 
-	VkQueue computeQueue;
-	vkGetDeviceQueue(m_device, m_queueFamilies.m_computeFamily.value(), 0, &computeQueue);
-	m_computeQueue = VulkanQueuePtr::Make(computeQueue, m_queueFamilies.m_computeFamily.value(), 0);
+	m_graphicsQueue = getOrCreateQueue(m_queueFamilies.m_graphicsFamily.value());
+	m_computeQueue = getOrCreateQueue(m_queueFamilies.m_computeFamily.value());
+	m_transferQueue = getOrCreateQueue(m_queueFamilies.m_transferFamily.value());
+	m_presentQueue = getOrCreateQueue(m_queueFamilies.m_presentFamily.value());
 }
 
 void VulkanDevice::CreateWin32Surface(const Platform::Window* viewport)
@@ -1052,63 +1061,49 @@ bool VulkanDevice::PresentFrame(const FrameState& state, const TVector<VulkanCom
 	waitSemaphores.Add(*m_imageAvailableSemaphores[m_currentFrame]);
 
 	///////////////////////////////////////////////////
-	VkResult presentResult = VK_SUCCESS;
-	VkResult submitResult = VK_SUCCESS;
-	if (commandBuffers.Num() > 0)
+	VkSubmitInfo submitInfo{};
+	submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+
+	submitInfo.waitSemaphoreCount = static_cast<uint32_t>(waitSemaphores.Num());
+	submitInfo.pWaitSemaphores = &waitSemaphores[0];
+
+	VkPipelineStageFlags* waitStages = reinterpret_cast<VkPipelineStageFlags*>(_malloca(waitSemaphores.Num() * sizeof(VkPipelineStageFlags)));
+
+	for (uint32_t i = 0; i < semaphoresToWait.Num(); i++)
 	{
-		VkSubmitInfo submitInfo{};
-		submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+		waitStages[i] = semaphoresToWait[i]->PipelineStageFlags();
+	}
+	waitStages[waitSemaphores.Num() - 1] = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
 
-		submitInfo.waitSemaphoreCount = static_cast<uint32_t>(waitSemaphores.Num());
-		submitInfo.pWaitSemaphores = &waitSemaphores[0];
+	submitInfo.pWaitDstStageMask = waitStages;
 
-		VkPipelineStageFlags* waitStages = reinterpret_cast<VkPipelineStageFlags*>(_malloca(waitSemaphores.Num() * sizeof(VkPipelineStageFlags)));
+	// A zero-command submit is intentional: it still consumes the acquired-image
+	// and frame-chain semaphores before they are reused.
+	submitInfo.commandBufferCount = static_cast<uint32_t>(commandBuffers.Num());
+	submitInfo.pCommandBuffers = commandBuffers.Num() > 0 ? &commandBuffers[0] : nullptr;
 
-		for (uint32_t i = 0; i < waitSemaphores.Num(); i++)
-		{
-			waitStages[i] = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
-		}
+	VkSemaphore signalSemaphores[] = { *m_renderFinishedSemaphores[m_currentFrame] };
+	submitInfo.signalSemaphoreCount = 1;
+	submitInfo.pSignalSemaphores = signalSemaphores;
 
-		submitInfo.pWaitDstStageMask = waitStages;
+	m_syncFences[m_currentFrame]->Reset();
 
-		submitInfo.commandBufferCount = static_cast<uint32_t>(commandBuffers.Num());
-		submitInfo.pCommandBuffers = &commandBuffers[0];
+	//TODO: Transfer queue for transfer family command lists
+	const VkResult submitResult = m_graphicsQueue->Submit(submitInfo, m_syncFences[m_currentFrame]);
 
-		m_lastSubmittedRenderFinishedSemaphore = m_renderFinishedSemaphores[m_currentFrame];
-		m_lastSubmittedSceneViewMainResolvedSemaphore = m_sceneViewMainResolvedSemaphores[m_currentFrame];
-		VkSemaphore signalSemaphores[] = { *m_lastSubmittedRenderFinishedSemaphore, *m_lastSubmittedSceneViewMainResolvedSemaphore };
-		submitInfo.signalSemaphoreCount = 2;
-		submitInfo.pSignalSemaphores = signalSemaphores;
+	m_numSubmittedCommandBuffersAcc += (uint32_t)commandBuffers.Num();
 
-		m_syncFences[m_currentFrame]->Reset();
+	_freea(waitStages);
 
-		//TODO: Transfer queue for transfer family command lists
-		submitResult = m_graphicsQueue->Submit(submitInfo, m_syncFences[m_currentFrame]);
-
-		m_numSubmittedCommandBuffersAcc += (uint32_t)commandBuffers.Num();
-
-		_freea(waitStages);
-
+	VkResult presentResult = VK_SUCCESS;
+	if (submitResult == VK_SUCCESS)
+	{
 		VkPresentInfoKHR presentInfo{};
 		presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
 
 		presentInfo.waitSemaphoreCount = 1;
 		presentInfo.pWaitSemaphores = signalSemaphores;
 
-		VkSwapchainKHR swapChains[] = { *m_swapchain };
-		presentInfo.swapchainCount = 1;
-		presentInfo.pSwapchains = swapChains;
-		presentInfo.pImageIndices = &m_currentSwapchainImageIndex;
-		presentInfo.pResults = nullptr; // Optional
-
-		presentResult = m_presentQueue->Present(presentInfo);
-	}
-	else
-	{
-		VkPresentInfoKHR presentInfo{};
-		presentInfo.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
-
-		presentInfo.waitSemaphoreCount = 0;
 		VkSwapchainKHR swapChains[] = { *m_swapchain };
 		presentInfo.swapchainCount = 1;
 		presentInfo.pSwapchains = swapChains;
@@ -1143,6 +1138,19 @@ bool VulkanDevice::PresentFrame(const FrameState& state, const TVector<VulkanCom
 
 bool VulkanDevice::SubmitFrameWithoutPresent(const TVector<VulkanCommandBufferPtr>& primaryCommandBuffers, const TVector<VulkanSemaphorePtr>& semaphoresToWait)
 {
+	// AcquireNextImage normally waits this fence before a frame slot is reused.
+	// When there is no swapchain image, preserve the same invariant before
+	// releasing the slot dependencies or resetting its fence.
+	const VkResult previousFrameResult = m_syncFences[m_currentFrame]->Wait();
+	if (previousFrameResult != VK_SUCCESS)
+	{
+		if (previousFrameResult == VK_ERROR_DEVICE_LOST)
+		{
+			m_bIsDeviceLost = true;
+		}
+		return false;
+	}
+
 	m_frameDeps[m_currentFrame].Clear();
 
 	TVector<VkCommandBuffer> commandBuffers;
@@ -1166,14 +1174,6 @@ bool VulkanDevice::SubmitFrameWithoutPresent(const TVector<VulkanCommandBufferPt
 		}
 	}
 
-	if (commandBuffers.Num() == 0)
-	{
-		m_currentFrame = (m_currentFrame + 1) % VulkanApi::MaxFramesInFlight;
-		m_numSubmittedCommandBuffers = m_numSubmittedCommandBuffersAcc;
-		m_numSubmittedCommandBuffersAcc = 0;
-		return true;
-	}
-
 	VkSubmitInfo submitInfo{};
 	submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
 	submitInfo.waitSemaphoreCount = static_cast<uint32_t>(waitSemaphores.Num());
@@ -1183,12 +1183,12 @@ bool VulkanDevice::SubmitFrameWithoutPresent(const TVector<VulkanCommandBufferPt
 		reinterpret_cast<VkPipelineStageFlags*>(_malloca(waitSemaphores.Num() * sizeof(VkPipelineStageFlags))) : nullptr;
 	for (uint32_t i = 0; i < waitSemaphores.Num(); i++)
 	{
-		waitStages[i] = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
+		waitStages[i] = semaphoresToWait[i]->PipelineStageFlags();
 	}
 
 	submitInfo.pWaitDstStageMask = waitStages;
 	submitInfo.commandBufferCount = static_cast<uint32_t>(commandBuffers.Num());
-	submitInfo.pCommandBuffers = &commandBuffers[0];
+	submitInfo.pCommandBuffers = commandBuffers.Num() > 0 ? &commandBuffers[0] : nullptr;
 	submitInfo.signalSemaphoreCount = 0;
 	submitInfo.pSignalSemaphores = nullptr;
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
@@ -63,8 +63,6 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 		SAILOR_API VulkanImageViewPtr GetBackBuffer() const;
 		SAILOR_API VulkanImageViewPtr GetDepthBuffer() const;
-		SAILOR_API VulkanSemaphorePtr GetLastSubmittedRenderFinishedSemaphore() const { return m_lastSubmittedRenderFinishedSemaphore; }
-		SAILOR_API VulkanSemaphorePtr GetLastSubmittedSceneViewMainResolvedSemaphore() const { return m_lastSubmittedSceneViewMainResolvedSemaphore; }
 
 		SAILOR_API bool PresentFrame(const FrameState& state, const TVector<VulkanCommandBufferPtr>& primaryCommandBuffers, const TVector<VulkanSemaphorePtr>& waitSemaphores);
 		SAILOR_API bool SubmitFrameWithoutPresent(const TVector<VulkanCommandBufferPtr>& primaryCommandBuffers, const TVector<VulkanSemaphorePtr>& waitSemaphores);
@@ -201,9 +199,6 @@ namespace Sailor::GraphicsDriver::Vulkan
 		// Frame sync
 		TVector<VulkanSemaphorePtr> m_imageAvailableSemaphores;
 		TVector<VulkanSemaphorePtr> m_renderFinishedSemaphores;
-		TVector<VulkanSemaphorePtr> m_sceneViewMainResolvedSemaphores;
-		VulkanSemaphorePtr m_lastSubmittedRenderFinishedSemaphore;
-		VulkanSemaphorePtr m_lastSubmittedSceneViewMainResolvedSemaphore;
 		TVector<VulkanFencePtr> m_syncFences;
 		TVector<VulkanFencePtr> m_syncImages;
 		size_t m_currentFrame = 0;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -150,28 +150,6 @@ uint32_t VulkanGraphicsDriver::GetNumSubmittedCommandBuffers() const
 	return m_vkInstance->GetMainDevice()->GetNumSubmittedCommandBufers();
 }
 
-VkSemaphore VulkanGraphicsDriver::GetLastSubmittedRenderFinishedSemaphoreHandle() const
-{
-	if (!m_bIsInitialized || !m_vkInstance || !m_vkInstance->GetMainDevice())
-	{
-		return VK_NULL_HANDLE;
-	}
-
-	const auto semaphore = m_vkInstance->GetMainDevice()->GetLastSubmittedRenderFinishedSemaphore();
-	return semaphore ? static_cast<VkSemaphore>(*semaphore) : VK_NULL_HANDLE;
-}
-
-VkSemaphore VulkanGraphicsDriver::GetLastSubmittedSceneViewMainResolvedSemaphoreHandle() const
-{
-	if (!m_bIsInitialized || !m_vkInstance || !m_vkInstance->GetMainDevice())
-	{
-		return VK_NULL_HANDLE;
-	}
-
-	const auto semaphore = m_vkInstance->GetMainDevice()->GetLastSubmittedSceneViewMainResolvedSemaphore();
-	return semaphore ? static_cast<VkSemaphore>(*semaphore) : VK_NULL_HANDLE;
-}
-
 bool VulkanGraphicsDriver::ShouldFixLostDevice(const Win32::Window* pViewport)
 {
 	if (!m_bIsInitialized || !m_vkInstance || !m_vkInstance->GetMainDevice())
@@ -227,6 +205,7 @@ TVector<bool> VulkanGraphicsDriver::IsCompatible(VulkanPipelineLayoutPtr layout,
 
 TVector<uint32_t> VulkanGraphicsDriver::CollectOptionalVariableDescriptorCount(const TVector<VulkanShaderStagePtr>& shaders, const TVector<RHI::RHIShaderBindingSetPtr>& shaderBindingSets) const
 {
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 	TVector<uint32_t> res;
 
 	for (const auto& shader : shaders)
@@ -386,9 +365,17 @@ void VulkanGraphicsDriver::WaitIdle()
 	m_vkInstance->WaitIdle();
 }
 
-void VulkanGraphicsDriver::SubmitCommandList(RHI::RHICommandListPtr commandList, RHI::RHIFencePtr fence, RHI::RHISemaphorePtr signalSemaphore, RHI::RHISemaphorePtr waitSemaphore)
+bool VulkanGraphicsDriver::SubmitCommandList(RHI::RHICommandListPtr commandList, RHI::RHIFencePtr fence, RHI::RHISemaphorePtr signalSemaphore, RHI::RHISemaphorePtr waitSemaphore)
 {
 	SAILOR_PROFILE_FUNCTION();
+	if (!commandList ||
+		!commandList->m_vulkan.m_commandBuffer ||
+		!m_vkInstance ||
+		!m_vkInstance->GetMainDevice())
+	{
+		SAILOR_LOG_ERROR("VulkanGraphicsDriver::SubmitCommandList: command list or Vulkan device is unavailable.");
+		return false;
+	}
 
 	//if we have fence and that is null we should create device resource
 	if (fence && !fence->m_vulkan.m_fence)
@@ -416,7 +403,16 @@ void VulkanGraphicsDriver::SubmitCommandList(RHI::RHICommandListPtr commandList,
 		}
 	}
 
-	m_vkInstance->GetMainDevice()->SubmitCommandBuffer(commandList->m_vulkan.m_commandBuffer, fence ? fence->m_vulkan.m_fence : nullptr, signal, wait);
+	const bool bSubmitted = m_vkInstance->GetMainDevice()->SubmitCommandBuffer(
+		commandList->m_vulkan.m_commandBuffer,
+		fence ? fence->m_vulkan.m_fence : nullptr,
+		signal,
+		wait);
+	if (!bSubmitted)
+	{
+		SAILOR_LOG_ERROR("VulkanGraphicsDriver::SubmitCommandList: vkQueueSubmit failed.");
+		return false;
+	}
 
 	if (fence)
 	{
@@ -428,6 +424,8 @@ void VulkanGraphicsDriver::SubmitCommandList(RHI::RHICommandListPtr commandList,
 		// We should remove fence after execution
 		TrackPendingCommandList_ThreadSafe(fence);
 	}
+
+	return true;
 }
 
 RHI::RHISemaphorePtr VulkanGraphicsDriver::CreateWaitSemaphore()
@@ -1131,9 +1129,10 @@ RHI::RHISurfacePtr VulkanGraphicsDriver::CreateSurface(
 	return  RHI::RHISurfacePtr::Make(target, resolved, bNeedsResolved);
 }
 
-void VulkanGraphicsDriver::UpdateDescriptorSet(RHI::RHIShaderBindingSetPtr bindings)
+bool VulkanGraphicsDriver::UpdateDescriptorSet(RHI::RHIShaderBindingSetPtr bindings)
 {
 	SAILOR_PROFILE_FUNCTION();
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 
 	auto device = m_vkInstance->GetMainDevice();
 	TVector<VulkanDescriptorPtr> descriptors;
@@ -1176,14 +1175,17 @@ void VulkanGraphicsDriver::UpdateDescriptorSet(RHI::RHIShaderBindingSetPtr bindi
 				{
 					variableDescriptorBinding = static_cast<int32_t>(binding.m_second->m_vulkan.m_descriptorSetLayout.binding);
 					const uint32_t plannedTextureSlots = (std::max)(1u, binding.m_second->GetLayout().m_arrayCount);
-					const uint32_t actualTextureSlots = static_cast<uint32_t>(binding.m_second->GetTextureBindings().Num());
 #ifdef _DEBUG
+					const uint32_t actualTextureSlots = static_cast<uint32_t>(binding.m_second->GetTextureBindings().Num());
 					if (actualTextureSlots > plannedTextureSlots)
 					{
 						check(false);
 					}
 #endif
-					variableDescriptorCount = std::max(variableDescriptorCount, (std::min)(plannedTextureSlots, actualTextureSlots));
+					// Allocate the complete bindless array once. Subsequent streaming updates
+					// write a single descriptor slot instead of recreating progressively larger
+					// immutable sets.
+					variableDescriptorCount = std::max(variableDescriptorCount, plannedTextureSlots);
 				}
 
 				descriptionSetLayouts.Add(binding.m_second->m_vulkan.m_descriptorSetLayout);
@@ -1208,19 +1210,28 @@ void VulkanGraphicsDriver::UpdateDescriptorSet(RHI::RHIShaderBindingSetPtr bindi
 
 	// Should we just update descriptor set instead of recreation?
 	// VK_KHR_descriptor_update_template
-	bindings->m_vulkan.m_descriptorSet = VulkanDescriptorSetPtr::Make(device,
+	auto descriptorSet = VulkanDescriptorSetPtr::Make(device,
 		device->GetCurrentThreadContext().m_descriptorPool,
 		VulkanDescriptorSetLayoutPtr::Make(device, descriptionSetLayouts, variableDescriptorBinding),
 		descriptors,
 		variableDescriptorCount);
 
-	bindings->m_vulkan.m_descriptorSet->Compile();
+	if (!descriptorSet->TryCompile())
+	{
+		SAILOR_LOG_ERROR("VulkanGraphicsDriver::UpdateDescriptorSet: cannot compile descriptor set.");
+		return false;
+	}
+
+	bindings->m_vulkan.m_descriptorSet = descriptorSet;
+	bindings->AdvanceDescriptorRevision();
 
 #ifndef _SHIPPING
-	VkDescriptorSet handleSet = *bindings->m_vulkan.m_descriptorSet;
+	VkDescriptorSet handleSet = *descriptorSet;
 	static uint32_t s_debugIterator = 0;
 	m_vkInstance->GetMainDevice()->SetDebugName(VkObjectType::VK_OBJECT_TYPE_DESCRIPTOR_SET, (uint64_t)handleSet, std::format("ShaderBinding's Descriptor Set {}", s_debugIterator++));
 #endif 
+
+	return true;
 }
 
 RHI::RHIMaterialPtr VulkanGraphicsDriver::CreateMaterial(const RHI::RHIVertexDescriptionPtr& vertexDescription, RHI::EPrimitiveTopology topology, const RHI::RenderState& renderState, const Sailor::ShaderSetPtr& shader)
@@ -1518,6 +1529,7 @@ RHI::RHIShaderBindingSetPtr VulkanGraphicsDriver::CreateShaderBindings()
 
 RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddShaderBinding(RHI::RHIShaderBindingSetPtr& pShaderBindings, const RHI::RHIShaderBindingPtr& binding, const std::string& name, uint32_t shaderBinding)
 {
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 	auto& pBinding = pShaderBindings->GetOrAddShaderBinding(name);
 
 	pBinding->m_vulkan = binding->m_vulkan;
@@ -1539,6 +1551,7 @@ RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddShaderBinding(RHI::RHIShaderBi
 RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddBufferToShaderBindings(RHI::RHIShaderBindingSetPtr& pShaderBindings, RHI::RHIBufferPtr buffer, const std::string& name, uint32_t shaderBinding)
 {
 	SAILOR_PROFILE_FUNCTION();
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 
 	auto device = m_vkInstance->GetMainDevice();
 
@@ -1582,6 +1595,7 @@ RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddBufferToShaderBindings(RHI::RH
 RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddSsboToShaderBindings(RHI::RHIShaderBindingSetPtr& pShaderBindings, const std::string& name, size_t elementSize, size_t numElements, uint32_t shaderBinding, bool bBindSsboWithOffset)
 {
 	SAILOR_PROFILE_FUNCTION();
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 
 	auto device = m_vkInstance->GetMainDevice();
 
@@ -1640,6 +1654,7 @@ RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddSsboToShaderBindings(RHI::RHIS
 RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddBufferToShaderBindings(RHI::RHIShaderBindingSetPtr& pShaderBindings, const std::string& name, size_t size, uint32_t shaderBinding, RHI::EShaderBindingType bufferType)
 {
 	SAILOR_PROFILE_FUNCTION();
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 
 	auto device = m_vkInstance->GetMainDevice();
 
@@ -1693,12 +1708,14 @@ RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddBufferToShaderBindings(RHI::RH
 
 RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddSamplerToShaderBindings(RHI::RHIShaderBindingSetPtr& pShaderBindings, const std::string& name, RHI::RHITexturePtr texture, uint32_t shaderBinding, bool bVariableDescriptorCount, uint32_t variableDescriptorUpperBound)
 {
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 	return AddSamplerToShaderBindings(pShaderBindings, name, TVector<RHI::RHITexturePtr>{ texture }, shaderBinding, bVariableDescriptorCount, variableDescriptorUpperBound);
 }
 
 RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddSamplerToShaderBindings(RHI::RHIShaderBindingSetPtr& pShaderBindings, const std::string& name, const TVector<RHI::RHITexturePtr>& array, uint32_t shaderBinding, bool bVariableDescriptorCount, uint32_t variableDescriptorUpperBound)
 {
 	SAILOR_PROFILE_FUNCTION();
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 
 	auto device = m_vkInstance->GetMainDevice();
 	RHI::RHIShaderBindingPtr binding = pShaderBindings->GetOrAddShaderBinding(name);
@@ -1723,12 +1740,14 @@ RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddSamplerToShaderBindings(RHI::R
 
 RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddStorageImageToShaderBindings(RHI::RHIShaderBindingSetPtr& pShaderBindings, const std::string& name, RHI::RHITexturePtr texture, uint32_t shaderBinding)
 {
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 	return AddStorageImageToShaderBindings(pShaderBindings, name, TVector<RHI::RHITexturePtr>{ texture }, shaderBinding);
 }
 
 RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddStorageImageToShaderBindings(RHI::RHIShaderBindingSetPtr& pShaderBindings, const std::string& name, const TVector<RHI::RHITexturePtr>& array, uint32_t shaderBinding)
 {
 	SAILOR_PROFILE_FUNCTION();
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 
 	auto device = m_vkInstance->GetMainDevice();
 	RHI::RHIShaderBindingPtr binding = pShaderBindings->GetOrAddShaderBinding(name);
@@ -1752,8 +1771,9 @@ RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddStorageImageToShaderBindings(R
 void VulkanGraphicsDriver::UpdateShaderBinding(RHI::RHIShaderBindingSetPtr bindings, const std::string& parameter, RHI::RHITexturePtr value, uint32_t dstArrayElement)
 {
 	SAILOR_PROFILE_FUNCTION();
-
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 	auto device = m_vkInstance->GetMainDevice();
+
 	const auto& layoutBindings = bindings->GetLayoutBindings();
 
 	auto index = layoutBindings.FindIf([&parameter](const RHI::ShaderLayoutBinding& shaderLayoutBinding)
@@ -1773,52 +1793,55 @@ void VulkanGraphicsDriver::UpdateShaderBinding(RHI::RHIShaderBindingSetPtr bindi
 		}
 
 		auto textureBinding = bindings->GetOrAddShaderBinding(parameter);
-
-		if (bindings->m_vulkan.m_descriptorSet != nullptr)
+		const auto& currentTextures = textureBinding->GetTextureBindings();
+		if (dstArrayElement < currentTextures.Num() &&
+			currentTextures[dstArrayElement] == value &&
+			bindings->m_vulkan.m_descriptorSet &&
+			bindings->m_vulkan.m_descriptorSet->IsCompiled() &&
+			bindings->m_vulkan.m_descriptorSet->ReferencesImageView(
+				textureBinding->GetLayout().m_binding,
+				dstArrayElement,
+				value->m_vulkan.m_imageView))
 		{
-			auto cmpFunc = [=](const VulkanDescriptorPtr& descriptor)
-				{
-					return descriptor->GetBinding() == layoutBindings[index].m_binding && descriptor->GetArrayElement() == dstArrayElement;
-				};
+			return;
+		}
 
-			auto& descriptors = bindings->m_vulkan.m_descriptorSet->m_descriptors;
+		const auto& layout = layoutBindings[index];
+		auto descriptorSet = bindings->m_vulkan.m_descriptorSet;
+		const bool bIsUnusedDescriptorSlot = dstArrayElement >= currentTextures.Num();
+		if (bIsUnusedDescriptorSlot &&
+			layout.m_bVariableDescriptorCount &&
+			device->IsDescriptorUpdateAfterBindSupported() &&
+			descriptorSet &&
+			descriptorSet->IsCompiled() &&
+			dstArrayElement < descriptorSet->GetVariableDescriptorCount())
+		{
+			auto descriptor = VulkanDescriptorCombinedImagePtr::Make(
+				layout.m_binding,
+				dstArrayElement,
+				device->GetSamplers()->GetSampler(
+					value->GetFiltration(),
+					value->GetClamping(),
+					value->HasMipMaps(),
+					value->GetSamplerReduction()),
+				value->m_vulkan.m_imageView);
 
-			uint32_t arrayIndex = dstArrayElement;
-			bool bFound = false;
-
-			// Firstly we fast check by index, 95% that we hit
-			if (dstArrayElement < descriptors.Num() && cmpFunc(descriptors[dstArrayElement]))
+			if (descriptorSet->UpdateDescriptor(descriptor))
 			{
-				bFound = true;
-			}
-			else
-			{
-				auto descrIt = std::find_if(descriptors.begin(), descriptors.end(), cmpFunc);
-				if (descrIt != descriptors.end())
-				{
-					arrayIndex = (uint32_t)(descrIt - descriptors.begin());
-					bFound = true;
-				}
-			}
-
-			if (bFound)
-			{
-				// Should we fully recreate descriptorSet to avoid race condition?
 				textureBinding->SetTextureBinding(dstArrayElement, value);
-
-				descriptors[arrayIndex] = VulkanDescriptorCombinedImagePtr::Make(layoutBindings[index].m_binding,
-					dstArrayElement,
-					device->GetSamplers()->GetSampler(value->GetFiltration(), value->GetClamping(), value->HasMipMaps(), value->GetSamplerReduction()),
-					value->m_vulkan.m_imageView);
-
-				bindings->m_vulkan.m_descriptorSet->UpdateDescriptor(arrayIndex);
-				bindings->RecalculateCompatibility();
+				bindings->AdvanceDescriptorRevision();
 				return;
 			}
 		}
 
-		// Add or grow texture binding array and recreate descriptor set.
-		auto textures = textureBinding->GetTextureBindings();
+		// Descriptor sets may already be referenced by recorded or submitted command
+		// buffers. Keep them immutable and allocate a new set for every texture update;
+		// the command buffer dependency keeps the previous set and its resources alive.
+		const auto previousTextures = currentTextures;
+		auto textures = previousTextures;
+		const auto previousDescriptorLayout = textureBinding->m_vulkan.m_descriptorSetLayout;
+		const auto previousLayout = textureBinding->GetLayout();
+		const auto previousLayoutBindings = bindings->GetLayoutBindings();
 		const uint32_t newSize = std::max<uint32_t>(dstArrayElement + 1, static_cast<uint32_t>(textures.Num()));
 		if (textures.Num() != newSize)
 		{
@@ -1833,17 +1856,23 @@ void VulkanGraphicsDriver::UpdateShaderBinding(RHI::RHIShaderBindingSetPtr bindi
 		}
 		textures[dstArrayElement] = value;
 
-		auto layout = layoutBindings[index];
-		if (!layout.m_bVariableDescriptorCount)
+		auto fallbackLayout = layout;
+		if (!fallbackLayout.m_bVariableDescriptorCount)
 		{
-			layout.m_arrayCount = static_cast<uint32_t>(textures.Num());
+			fallbackLayout.m_arrayCount = static_cast<uint32_t>(textures.Num());
 		}
 		textureBinding->SetTextureBindings(textures);
-		textureBinding->m_vulkan.m_descriptorSetLayout = VulkanApi::CreateDescriptorSetLayoutBinding(layout.m_binding, (VkDescriptorType)layout.m_type,
-			layout.m_bVariableDescriptorCount ? glm::max(1u, layout.m_arrayCount) : layout.m_arrayCount);
-		textureBinding->SetLayout(layout);
-		bindings->UpdateLayoutShaderBinding(layout);
-		UpdateDescriptorSet(bindings);
+		textureBinding->m_vulkan.m_descriptorSetLayout = VulkanApi::CreateDescriptorSetLayoutBinding(fallbackLayout.m_binding, (VkDescriptorType)fallbackLayout.m_type,
+			fallbackLayout.m_bVariableDescriptorCount ? glm::max(1u, fallbackLayout.m_arrayCount) : fallbackLayout.m_arrayCount);
+		textureBinding->SetLayout(fallbackLayout);
+		bindings->UpdateLayoutShaderBinding(fallbackLayout);
+		if (!UpdateDescriptorSet(bindings))
+		{
+			textureBinding->SetTextureBindings(previousTextures);
+			textureBinding->m_vulkan.m_descriptorSetLayout = previousDescriptorLayout;
+			textureBinding->SetLayout(previousLayout);
+			bindings->SetLayoutShaderBindings(previousLayoutBindings);
+		}
 
 		return;
 	}
@@ -1854,7 +1883,7 @@ VulkanComputePipelinePtr VulkanGraphicsDriver::GetOrAddComputePipeline(RHI::RHIS
 {
 	auto& computePipeline = m_cachedComputePipelines.At_Lock(computeShader);
 
-	if (!computePipeline)
+	if (!computePipeline || !computePipeline->IsCompiled())
 	{
 		auto device = m_vkInstance->GetMainDevice();
 
@@ -1881,13 +1910,23 @@ VulkanComputePipelinePtr VulkanGraphicsDriver::GetOrAddComputePipeline(RHI::RHIS
 		}
 
 		auto pipelineLayout = VulkanPipelineLayoutPtr::Make(device, descriptorSetLayouts, bindings, pushConstants, 0);
-		computePipeline = VulkanComputePipelinePtr::Make(device, pipelineLayout, computeShader->m_vulkan.m_shader);
-		computePipeline->Compile();
+		auto newComputePipeline = VulkanComputePipelinePtr::Make(device, pipelineLayout, computeShader->m_vulkan.m_shader);
+		if (newComputePipeline->Compile())
+		{
+			computePipeline = std::move(newComputePipeline);
+		}
+		else
+		{
+			computePipeline.Clear();
+		}
 	}
 
+	// Copy the cached reference while its bucket is still locked. A concurrent
+	// cache clear must not invalidate the map value before the return copy.
+	VulkanComputePipelinePtr result = computePipeline;
 	m_cachedComputePipelines.Unlock(computeShader);
 
-	return computePipeline;
+	return result;
 }
 
 RHI::RHITexturePtr VulkanGraphicsDriver::GetOrAddMsaaFramebufferRenderTarget(RHI::EFormat textureFormat, glm::ivec2 extent)
@@ -2427,6 +2466,16 @@ void VulkanGraphicsDriver::UpdateShaderBinding(RHI::RHICommandListPtr cmd, RHI::
 void VulkanGraphicsDriver::UpdateBuffer(RHI::RHICommandListPtr cmd, RHI::RHIBufferPtr buffer, const void* pData, size_t size, size_t offset)
 {
 	SAILOR_PROFILE_FUNCTION();
+	if (size == 0)
+	{
+		return;
+	}
+	if (!buffer || pData == nullptr)
+	{
+		SAILOR_LOG_ERROR(
+			"VulkanGraphicsDriver::UpdateBuffer: invalid buffer upload.");
+		return;
+	}
 
 	if (buffer->GetUsage() & RHI::EBufferUsageBit::IndirectBuffer_Bit)
 	{
@@ -2443,6 +2492,17 @@ void VulkanGraphicsDriver::UpdateBuffer(RHI::RHICommandListPtr cmd, RHI::RHIBuff
 void VulkanGraphicsDriver::Update(RHI::RHICommandListPtr cmd, VulkanBufferMemoryPtr bufferPtr, const void* data, size_t size, size_t offset)
 {
 	SAILOR_PROFILE_FUNCTION();
+	if (size == 0)
+	{
+		return;
+	}
+	if (!cmd || !bufferPtr.m_buffer || data == nullptr)
+	{
+		SAILOR_LOG_ERROR(
+			"VulkanGraphicsDriver::Update: invalid buffer upload.");
+		return;
+	}
+
 	auto dstBuffer = bufferPtr.m_buffer;
 	auto device = m_vkInstance->GetMainDevice();
 
@@ -2543,6 +2603,14 @@ void VulkanGraphicsDriver::UpdateShaderBindingVariable(RHI::RHICommandListPtr cm
 
 void VulkanGraphicsDriver::UpdateMesh(RHI::RHIMeshPtr mesh, const void* pVertices, size_t vertexBuffer, const void* pIndices, size_t indexBuffer)
 {
+	if (!mesh || pVertices == nullptr || vertexBuffer == 0 ||
+		pIndices == nullptr || indexBuffer == 0)
+	{
+		SAILOR_LOG_ERROR(
+			"VulkanGraphicsDriver::UpdateMesh: refusing an empty mesh upload.");
+		return;
+	}
+
 	auto device = m_vkInstance->GetMainDevice();
 
 	const VkDeviceSize bufferSize = vertexBuffer;
@@ -2606,8 +2674,14 @@ void VulkanGraphicsDriver::Dispatch(RHI::RHICommandListPtr cmd,
 	const void* pPushConstantsData,
 	uint32_t sizePushConstantsData)
 {
-	check(computeShader->GetStage() == RHI::EShaderStage::Compute);
+	if (!cmd || !cmd->m_vulkan.m_commandBuffer ||
+		!computeShader || !computeShader->m_vulkan.m_shader)
+	{
+		SAILOR_LOG_ERROR("VulkanGraphicsDriver::Dispatch: command list or compute shader is unavailable.");
+		return;
+	}
 
+	check(computeShader->GetStage() == RHI::EShaderStage::Compute);
 	if (computeShader->GetStage() != RHI::EShaderStage::Compute)
 	{
 		return;
@@ -2616,7 +2690,19 @@ void VulkanGraphicsDriver::Dispatch(RHI::RHICommandListPtr cmd,
 	TVector<VulkanShaderStagePtr> vulkanShaders{ computeShader->m_vulkan.m_shader };
 	const TVector<uint32_t> optionalVariableDescriptorCount = this->CollectOptionalVariableDescriptorCount(vulkanShaders, bindings);
 	VulkanComputePipelinePtr computePipeline = GetOrAddComputePipeline(computeShader, sizePushConstantsData, &optionalVariableDescriptorCount);
+	if (!computePipeline || !computePipeline->IsCompiled())
+	{
+		SAILOR_LOG_ERROR("VulkanGraphicsDriver::Dispatch: compute pipeline is unavailable.");
+		return;
+	}
 	const TVector<VulkanDescriptorSetPtr>& sets = GetCompatibleDescriptorSets(computePipeline->m_layout, bindings);
+	if (sets.Num() != computePipeline->m_layout->m_descriptionSetLayouts.Num())
+	{
+		SAILOR_LOG_ERROR("VulkanGraphicsDriver::Dispatch: cannot bind the complete descriptor set list. expected=%zu, actual=%zu",
+			computePipeline->m_layout->m_descriptionSetLayouts.Num(),
+			sets.Num());
+		return;
+	}
 
 	if (pPushConstantsData && sizePushConstantsData > 0)
 	{
@@ -2688,6 +2774,7 @@ void VulkanGraphicsDriver::SetDefaultViewport(RHI::RHICommandListPtr cmd)
 TVector<VulkanDescriptorSetPtr> VulkanGraphicsDriver::GetCompatibleDescriptorSets(VulkanPipelineLayoutPtr layout, const TVector<RHI::RHIShaderBindingSetPtr>& shaderBindings)
 {
 	SAILOR_PROFILE_FUNCTION();
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 
 	TVector<VulkanDescriptorSetPtr> descriptorSets;
 	descriptorSets.Reserve(shaderBindings.Num());
@@ -2706,19 +2793,25 @@ TVector<VulkanDescriptorSetPtr> VulkanGraphicsDriver::GetCompatibleDescriptorSet
 
 		if (bIsCompatible[i])
 		{
-			descriptorSets.Add(shaderBindings[i]->m_vulkan.m_descriptorSet);
+			const auto& compatibleDescriptorSet = shaderBindings[i]->m_vulkan.m_descriptorSet;
+			if (!compatibleDescriptorSet || !compatibleDescriptorSet->IsCompiled())
+			{
+				SAILOR_LOG_ERROR("VulkanGraphicsDriver::GetCompatibleDescriptorSets: compatible descriptor set is unavailable. set=%u", i);
+				return {};
+			}
+
+			descriptorSets.Add(compatibleDescriptorSet);
 			continue;
 		}
 
 		CachedDescriptorSet cache = CachedDescriptorSet(layout, shaderBindings[i]);
 
-		// Flush lifetime
-		auto& cachedDS = m_cachedDescriptorSets.At_Lock(cache);
-		cachedDS.m_second = 0;
-		VulkanDescriptorSetPtr& cachedDescriptorSet = cachedDS.m_first;
+		auto& cached = m_cachedDescriptorSets.At_Lock(cache);
+		VulkanDescriptorSetPtr& cachedDescriptorSet = cached.m_first;
 
-		if (cachedDescriptorSet.IsValid())
+		if (cachedDescriptorSet.IsValid() && cachedDescriptorSet->IsCompiled())
 		{
+			cached.m_second = 0;
 			descriptorSets.Add(cachedDescriptorSet);
 			m_cachedDescriptorSets.Unlock(cache);
 			continue;
@@ -2881,21 +2974,26 @@ TVector<VulkanDescriptorSetPtr> VulkanGraphicsDriver::GetCompatibleDescriptorSet
 				descriptors,
 				variableDescriptorCount);
 		}
+		{
+			SAILOR_PROFILE_SCOPE("Compile new descriptor sets");
+			if (!descriptorSet->TryCompile())
+			{
+				m_cachedDescriptorSets.Unlock(cache);
+				return {};
+			}
+
+			descriptorSets.Add(descriptorSet);
+
+			cachedDescriptorSet = descriptorSets[i];
+			m_cachedDescriptorSets.Unlock(cache);
+		}
+
 #ifndef _SHIPPING
 		if (VkDescriptorSet handleSet = *descriptorSet)
 		{
 			m_vkInstance->GetMainDevice()->SetDebugName(VkObjectType::VK_OBJECT_TYPE_DESCRIPTOR_SET, (uint64_t)handleSet, "Compatible Cache Descriptor Set");
 		}
 #endif
-
-		{
-			SAILOR_PROFILE_SCOPE("Compile new descriptor sets");
-			descriptorSet->Compile();
-			descriptorSets.Add(descriptorSet);
-
-			cachedDescriptorSet = descriptorSets[i];
-			m_cachedDescriptorSets.Unlock(cache);
-		}
 	}
 
 	return descriptorSets;
@@ -2903,7 +3001,10 @@ TVector<VulkanDescriptorSetPtr> VulkanGraphicsDriver::GetCompatibleDescriptorSet
 
 bool VulkanGraphicsDriver::CachedDescriptorSet::IsExpired() const
 {
-	return !m_layout.IsShared() || !m_binding.IsShared() || m_initialCompatibility != m_binding->GetCompatibilityHashCode();
+	return !m_layout.IsShared() ||
+		!m_binding.IsShared() ||
+		m_initialCompatibility != m_binding->GetCompatibilityHashCode() ||
+		m_initialDescriptorRevision != m_binding->GetDescriptorRevision();
 }
 
 VulkanGraphicsDriver::CachedDescriptorSet& VulkanGraphicsDriver::CachedDescriptorSet::operator=(const CachedDescriptorSet& rhs)
@@ -2911,19 +3012,25 @@ VulkanGraphicsDriver::CachedDescriptorSet& VulkanGraphicsDriver::CachedDescripto
 	m_layout = rhs.m_layout;
 	m_binding = rhs.m_binding;
 
-	m_initialCompatibility = m_binding->GetCompatibilityHashCode();
+	m_initialCompatibility = rhs.m_initialCompatibility;
+	m_initialDescriptorRevision = rhs.m_initialDescriptorRevision;
 
 	return *this;
 }
 
 bool VulkanGraphicsDriver::CachedDescriptorSet::operator==(const CachedDescriptorSet& rhs) const
 {
-	return m_layout == rhs.m_layout && m_binding == rhs.m_binding && m_initialCompatibility == m_binding->GetCompatibilityHashCode();
+	return m_layout == rhs.m_layout &&
+		m_binding == rhs.m_binding &&
+		m_initialCompatibility == rhs.m_initialCompatibility &&
+		m_initialDescriptorRevision == rhs.m_initialDescriptorRevision;
 }
 
 size_t VulkanGraphicsDriver::CachedDescriptorSet::GetHash() const
 {
-	return m_initialCompatibility;
+	size_t hash = 0;
+	HashCombine(hash, m_layout, m_binding, m_initialCompatibility, m_initialDescriptorRevision);
+	return hash;
 }
 
 VulkanGraphicsDriver::CachedDescriptorSet::CachedDescriptorSet(const VulkanPipelineLayoutPtr& material, const RHI::RHIShaderBindingSetPtr& binding) noexcept :
@@ -2931,6 +3038,7 @@ VulkanGraphicsDriver::CachedDescriptorSet::CachedDescriptorSet(const VulkanPipel
 	m_binding(binding)
 {
 	m_initialCompatibility = m_binding->GetCompatibilityHashCode();
+	m_initialDescriptorRevision = m_binding->GetDescriptorRevision();
 }
 
 void VulkanGraphicsDriver::BindShaderBindings(RHI::RHICommandListPtr cmd, RHI::RHIMaterialPtr material, const TVector<RHI::RHIShaderBindingSetPtr>& bindings)
@@ -2938,6 +3046,14 @@ void VulkanGraphicsDriver::BindShaderBindings(RHI::RHICommandListPtr cmd, RHI::R
 	SAILOR_PROFILE_FUNCTION();
 
 	const TVector<VulkanDescriptorSetPtr>& sets = GetCompatibleDescriptorSets(material->m_vulkan.m_pipelines[0]->m_layout, bindings);
+	if (sets.Num() != material->m_vulkan.m_pipelines[0]->m_layout->m_descriptionSetLayouts.Num())
+	{
+		SAILOR_LOG_ERROR("VulkanGraphicsDriver::BindShaderBindings: cannot bind the complete descriptor set list. expected=%zu, actual=%zu",
+			material->m_vulkan.m_pipelines[0]->m_layout->m_descriptionSetLayouts.Num(),
+			sets.Num());
+		return;
+	}
+
 	cmd->m_vulkan.m_commandBuffer->BindDescriptorSet(material->m_vulkan.m_pipelines[0]->m_layout, sets, VK_PIPELINE_BIND_POINT_GRAPHICS);
 
 	// Need to handle ShaderBindingSet, since it auto destructs all bindings and buffers
@@ -2989,22 +3105,26 @@ bool VulkanGraphicsDriver::FitsDefaultViewport(RHI::RHICommandListPtr cmd)
 void VulkanGraphicsDriver::CollectGarbage_RenderThread()
 {
 	SAILOR_PROFILE_FUNCTION();
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 
 	m_cachedDescriptorSets.LockAll();
 	TSet<CachedDescriptorSet> toRemove;
 
 	for (auto& batch : m_cachedDescriptorSets)
 	{
-		if (!batch.m_second.m_first || batch.m_first.IsExpired() || ++batch.m_second.m_second > CachedDescriptorSetLifeTimeInFrames)
+		if (!batch.m_second.m_first ||
+			batch.m_first.IsExpired() ||
+			++batch.m_second.m_second > CachedDescriptorSetLifeTimeInFrames)
 		{
 			toRemove.Insert(batch.m_first);
 		}
 	}
 
-	for (const auto& remove : toRemove)
+	for (const CachedDescriptorSet& remove : toRemove)
 	{
 		m_cachedDescriptorSets.ForcelyRemove(remove);
 	}
+
 	m_cachedDescriptorSets.UnlockAll();
 }
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -205,7 +205,6 @@ TVector<bool> VulkanGraphicsDriver::IsCompatible(VulkanPipelineLayoutPtr layout,
 
 TVector<uint32_t> VulkanGraphicsDriver::CollectOptionalVariableDescriptorCount(const TVector<VulkanShaderStagePtr>& shaders, const TVector<RHI::RHIShaderBindingSetPtr>& shaderBindingSets) const
 {
-	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
 	TVector<uint32_t> res;
 
 	for (const auto& shader : shaders)
@@ -231,22 +230,54 @@ TVector<uint32_t> VulkanGraphicsDriver::CollectOptionalVariableDescriptorCount(c
 						continue;
 					}
 
-					const auto& layoutBindings = shaderBindingSet->GetLayoutBindings();
-					const size_t index = layoutBindings.FindIf([&](const auto& layout)
+					// Layout metadata can contain reflection entries for descriptor sets
+					// owned elsewhere. Query the bindings actually owned by this set so a
+					// material set cannot shadow the global texture-sampler set.
+					const auto& runtimeBindings = shaderBindingSet->GetShaderBindings();
+					const auto runtimeBindingIt = runtimeBindings.Find(reflectedBinding.m_name);
+					if (runtimeBindingIt == runtimeBindings.end() || !runtimeBindingIt->m_second)
 					{
-						return layout.m_binding == reflectedBinding.m_binding &&
-							layout.m_type == reflectedBinding.m_type &&
-							layout.m_bVariableDescriptorCount;
-					});
+						continue;
+					}
 
-					if (index != size_t(-1))
+					const auto& runtimeLayout = runtimeBindingIt->m_second->GetLayout();
+					if (runtimeLayout.m_binding == reflectedBinding.m_binding &&
+						runtimeLayout.m_type == reflectedBinding.m_type &&
+						runtimeLayout.m_bVariableDescriptorCount)
 					{
-						res[reflectedBinding.m_set] = std::max(1u, layoutBindings[index].m_arrayCount);
-						break;
+						res[reflectedBinding.m_set] = std::max(
+							res[reflectedBinding.m_set],
+							std::max(1u, runtimeLayout.m_arrayCount));
 					}
 				}
 			}
 		}
+	}
+
+	return res;
+}
+
+TVector<uint32_t> VulkanGraphicsDriver::CollectPublishedVariableDescriptorCounts(const TVector<RHI::RHIShaderBindingSetPtr>& shaderBindingSets) const
+{
+	TVector<uint32_t> res;
+	for (uint32_t set = 0; set < shaderBindingSets.Num(); set++)
+	{
+		if (!shaderBindingSets[set])
+		{
+			continue;
+		}
+
+		const uint32_t count = shaderBindingSets[set]->GetVariableDescriptorCount();
+		if (count == 0)
+		{
+			continue;
+		}
+
+		if (res.Num() <= set)
+		{
+			res.Resize(set + 1);
+		}
+		res[set] = count;
 	}
 
 	return res;
@@ -1223,6 +1254,7 @@ bool VulkanGraphicsDriver::UpdateDescriptorSet(RHI::RHIShaderBindingSetPtr bindi
 	}
 
 	bindings->m_vulkan.m_descriptorSet = descriptorSet;
+	bindings->SetVariableDescriptorCount(descriptorSet->GetVariableDescriptorCount());
 	bindings->AdvanceDescriptorRevision();
 
 #ifndef _SHIPPING
@@ -1719,6 +1751,40 @@ RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddSamplerToShaderBindings(RHI::R
 
 	auto device = m_vkInstance->GetMainDevice();
 	RHI::RHIShaderBindingPtr binding = pShaderBindings->GetOrAddShaderBinding(name);
+	const uint32_t publishedVariableDescriptorCount = pShaderBindings->GetVariableDescriptorCount();
+	if (publishedVariableDescriptorCount > 0)
+	{
+		const auto& existingLayouts = pShaderBindings->GetLayoutBindings();
+		const size_t variableLayoutIndex = existingLayouts.FindIf(
+			[](const RHI::ShaderLayoutBinding& candidate)
+			{
+				return candidate.m_bVariableDescriptorCount;
+			});
+		const bool bUpdatesPublishedVariableBinding =
+			variableLayoutIndex != static_cast<size_t>(-1) &&
+			existingLayouts[variableLayoutIndex].m_name == name;
+
+		if ((bVariableDescriptorCount && !bUpdatesPublishedVariableBinding) ||
+			(!bVariableDescriptorCount && bUpdatesPublishedVariableBinding) ||
+			(bUpdatesPublishedVariableBinding && array.Num() > publishedVariableDescriptorCount))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot change a published variable descriptor layout '%s'. allocated=%u, requested=%zu, variable=%d",
+				name.c_str(),
+				publishedVariableDescriptorCount,
+				array.Num(),
+				bVariableDescriptorCount ? 1 : 0);
+			return nullptr;
+		}
+
+		// Variable descriptor capacities are immutable after the first native set
+		// is published. This keeps the lock-free count snapshot coherent with the
+		// descriptor set used by concurrent dispatches.
+		if (bUpdatesPublishedVariableBinding)
+		{
+			variableDescriptorUpperBound = publishedVariableDescriptorCount;
+		}
+	}
 
 	RHI::ShaderLayoutBinding layout;
 	layout.m_binding = shaderBinding;
@@ -1807,6 +1873,16 @@ void VulkanGraphicsDriver::UpdateShaderBinding(RHI::RHIShaderBindingSetPtr bindi
 		}
 
 		const auto& layout = layoutBindings[index];
+		if (layout.m_bVariableDescriptorCount && dstArrayElement >= layout.m_arrayCount)
+		{
+			SAILOR_LOG_ERROR(
+				"Variable descriptor array '%s' is out of capacity. index=%u, capacity=%u",
+				parameter.c_str(),
+				dstArrayElement,
+				layout.m_arrayCount);
+			return;
+		}
+
 		auto descriptorSet = bindings->m_vulkan.m_descriptorSet;
 		const bool bIsUnusedDescriptorSlot = dstArrayElement >= currentTextures.Num();
 		if (bIsUnusedDescriptorSlot &&
@@ -1862,16 +1938,24 @@ void VulkanGraphicsDriver::UpdateShaderBinding(RHI::RHIShaderBindingSetPtr bindi
 			fallbackLayout.m_arrayCount = static_cast<uint32_t>(textures.Num());
 		}
 		textureBinding->SetTextureBindings(textures);
-		textureBinding->m_vulkan.m_descriptorSetLayout = VulkanApi::CreateDescriptorSetLayoutBinding(fallbackLayout.m_binding, (VkDescriptorType)fallbackLayout.m_type,
-			fallbackLayout.m_bVariableDescriptorCount ? glm::max(1u, fallbackLayout.m_arrayCount) : fallbackLayout.m_arrayCount);
-		textureBinding->SetLayout(fallbackLayout);
-		bindings->UpdateLayoutShaderBinding(fallbackLayout);
+		if (!fallbackLayout.m_bVariableDescriptorCount)
+		{
+			textureBinding->m_vulkan.m_descriptorSetLayout = VulkanApi::CreateDescriptorSetLayoutBinding(
+				fallbackLayout.m_binding,
+				(VkDescriptorType)fallbackLayout.m_type,
+				fallbackLayout.m_arrayCount);
+			textureBinding->SetLayout(fallbackLayout);
+			bindings->UpdateLayoutShaderBinding(fallbackLayout);
+		}
 		if (!UpdateDescriptorSet(bindings))
 		{
 			textureBinding->SetTextureBindings(previousTextures);
-			textureBinding->m_vulkan.m_descriptorSetLayout = previousDescriptorLayout;
-			textureBinding->SetLayout(previousLayout);
-			bindings->SetLayoutShaderBindings(previousLayoutBindings);
+			if (!fallbackLayout.m_bVariableDescriptorCount)
+			{
+				textureBinding->m_vulkan.m_descriptorSetLayout = previousDescriptorLayout;
+				textureBinding->SetLayout(previousLayout);
+				bindings->SetLayoutShaderBindings(previousLayoutBindings);
+			}
 		}
 
 		return;
@@ -1881,7 +1965,8 @@ void VulkanGraphicsDriver::UpdateShaderBinding(RHI::RHIShaderBindingSetPtr bindi
 VulkanComputePipelinePtr VulkanGraphicsDriver::GetOrAddComputePipeline(RHI::RHIShaderPtr computeShader, uint32_t sizePushConstantsData,
 	const TVector<uint32_t>* optionalVariableDescriptorCount)
 {
-	auto& computePipeline = m_cachedComputePipelines.At_Lock(computeShader);
+	const ComputePipelineCacheKey cacheKey(computeShader, sizePushConstantsData, optionalVariableDescriptorCount);
+	auto& computePipeline = m_cachedComputePipelines.At_Lock(cacheKey);
 
 	if (!computePipeline || !computePipeline->IsCompiled())
 	{
@@ -1924,7 +2009,7 @@ VulkanComputePipelinePtr VulkanGraphicsDriver::GetOrAddComputePipeline(RHI::RHIS
 	// Copy the cached reference while its bucket is still locked. A concurrent
 	// cache clear must not invalidate the map value before the return copy.
 	VulkanComputePipelinePtr result = computePipeline;
-	m_cachedComputePipelines.Unlock(computeShader);
+	m_cachedComputePipelines.Unlock(cacheKey);
 
 	return result;
 }
@@ -2687,9 +2772,9 @@ void VulkanGraphicsDriver::Dispatch(RHI::RHICommandListPtr cmd,
 		return;
 	}
 
-	TVector<VulkanShaderStagePtr> vulkanShaders{ computeShader->m_vulkan.m_shader };
-	const TVector<uint32_t> optionalVariableDescriptorCount = this->CollectOptionalVariableDescriptorCount(vulkanShaders, bindings);
-	VulkanComputePipelinePtr computePipeline = GetOrAddComputePipeline(computeShader, sizePushConstantsData, &optionalVariableDescriptorCount);
+	const TVector<uint32_t> optionalVariableDescriptorCount = CollectPublishedVariableDescriptorCounts(bindings);
+	const TVector<uint32_t>* variableDescriptorCounts = optionalVariableDescriptorCount.IsEmpty() ? nullptr : &optionalVariableDescriptorCount;
+	VulkanComputePipelinePtr computePipeline = GetOrAddComputePipeline(computeShader, sizePushConstantsData, variableDescriptorCounts);
 	if (!computePipeline || !computePipeline->IsCompiled())
 	{
 		SAILOR_LOG_ERROR("VulkanGraphicsDriver::Dispatch: compute pipeline is unavailable.");
@@ -3082,6 +3167,7 @@ void VulkanGraphicsDriver::DrawIndexedIndirect(RHI::RHICommandListPtr cmd, RHI::
 void VulkanGraphicsDriver::DrawIndexed(RHI::RHICommandListPtr cmd, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, uint32_t vertexOffset, uint32_t firstInstance)
 {
 	cmd->m_vulkan.m_commandBuffer->DrawIndexed(indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
+	cmd->RecordDrawCallStats(instanceCount);
 }
 
 bool VulkanGraphicsDriver::FitsViewport(RHI::RHICommandListPtr cmd, float x, float y, float width, float height, glm::vec2 scissorOffset, glm::vec2 scissorExtent, float minDepth, float maxDepth)

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -74,7 +74,11 @@ void VulkanGraphicsDriver::Initialize(Win32::Window* pViewport, RHI::EMsaaSample
 		VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT,
 		6);
 
-	m_defaultTexture = RHI::RHITexturePtr::Make(RHI::ETextureFiltration::Linear, RHI::ETextureClamping::Repeat, false, RHI::EImageLayout::PresentSrc);
+	m_defaultTexture = RHI::RHITexturePtr::Make(
+		RHI::ETextureFiltration::Linear,
+		RHI::ETextureClamping::Repeat,
+		false,
+		RHI::EImageLayout::ShaderReadOnlyOptimal);
 
 	m_vkDefaultTexture = VulkanApi::CreateImageView(m_vkInstance->GetMainDevice(), defaultImage, VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT);
 	m_vkDefaultCubemap = VulkanApi::CreateImageView(m_vkInstance->GetMainDevice(), defaultCubemap, VkImageAspectFlagBits::VK_IMAGE_ASPECT_COLOR_BIT);
@@ -320,6 +324,9 @@ void VulkanGraphicsDriver::RefreshSwapchainTargets()
 
 	m_depthStencilBuffer->m_vulkan.m_imageView = depthBufferView;
 	m_depthStencilBuffer->m_vulkan.m_image = depthBufferView->m_image;
+	m_depthStencilBuffer->ForceSetDefaultLayout(
+		static_cast<RHI::EImageLayout>(
+			depthBufferView->GetImage()->m_defaultLayout));
 	m_depthStencilBuffer->m_depthAspect.Clear();
 	m_depthStencilBuffer->m_stencilAspect.Clear();
 
@@ -841,6 +848,13 @@ RHI::RHITexturePtr VulkanGraphicsDriver::CreateTexture(
 			(VkImageLayout)layout,
 			flags,
 			arrayLayers);
+
+		RHI::Renderer::GetDriverCommands()->ImageMemoryBarrier(
+			cmdList,
+			outTexture,
+			format,
+			RHI::EImageLayout::Undefined,
+			layout);
 	}
 
 	RHI::Renderer::GetDriverCommands()->EndCommandList(cmdList);
@@ -2023,16 +2037,24 @@ RHI::RHITexturePtr VulkanGraphicsDriver::GetOrAddMsaaFramebufferRenderTarget(RHI
 	}
 
 	auto device = m_vkInstance->GetMainDevice();
+	const bool bIsDepthFormat = RHI::IsDepthFormat(textureFormat);
+	const RHI::EImageLayout defaultLayout = bIsDepthFormat ?
+		(RHI::IsDepthStencilFormat(textureFormat) ?
+			RHI::EImageLayout::DepthStencilAttachmentOptimal :
+			RHI::EImageLayout::DepthAttachmentOptimal) :
+		RHI::EImageLayout::ColorAttachmentOptimal;
 
-	RHI::RHITexturePtr target = RHI::RHITexturePtr::Make(RHI::ETextureFiltration::Linear, RHI::ETextureClamping::Clamp, false);
+	RHI::RHITexturePtr target = RHI::RHITexturePtr::Make(
+		RHI::ETextureFiltration::Linear,
+		RHI::ETextureClamping::Clamp,
+		false,
+		defaultLayout);
 
 	VkExtent3D vkExtent;
 	vkExtent.width = extent.x;
 	vkExtent.height = extent.y;
 	vkExtent.depth = 1;
 
-	const bool bIsDepthFormat = textureFormat == RHI::EFormat::D16_UNORM || textureFormat == RHI::EFormat::D32_SFLOAT || textureFormat == RHI::EFormat::X8_D24_UNORM_PACK32 ||
-		textureFormat == RHI::EFormat::D32_SFLOAT_S8_UINT;
 	const auto usage = (uint32_t)(VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
 		(!bIsDepthFormat ? VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT : VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT));
 
@@ -2044,10 +2066,29 @@ RHI::RHITexturePtr VulkanGraphicsDriver::GetOrAddMsaaFramebufferRenderTarget(RHI
 		VK_IMAGE_TILING_OPTIMAL,
 		usage,
 		(VkSharingMode)VkSharingMode::VK_SHARING_MODE_EXCLUSIVE,
-		device->GetCurrentMsaaSamples());
+		device->GetCurrentMsaaSamples(),
+		static_cast<VkImageLayout>(defaultLayout));
 
 	target->m_vulkan.m_imageView = VulkanImageViewPtr::Make(device, target->m_vulkan.m_image);
 	target->m_vulkan.m_imageView->Compile();
+
+	RHI::RHICommandListPtr cmdList = CreateCommandList(
+		false,
+		RHI::ECommandListQueue::Graphics);
+	SetDebugName(cmdList, "Initialize cached MSAA render target");
+	BeginCommandList(cmdList, true);
+	ImageMemoryBarrier(
+		cmdList,
+		target,
+		textureFormat,
+		RHI::EImageLayout::Undefined,
+		defaultLayout);
+	EndCommandList(cmdList);
+
+	RHI::RHIFencePtr initializationFence = RHI::RHIFencePtr::Make();
+	SetDebugName(initializationFence, "Initialize cached MSAA render target");
+	TrackDelayedInitialization(target.GetRawPtr(), initializationFence);
+	SubmitCommandList(cmdList, initializationFence);
 
 	m_cachedMsaaRenderTargets.At_Lock(hash) = target;
 	m_cachedMsaaRenderTargets.Unlock(hash);
@@ -2072,12 +2113,8 @@ void VulkanGraphicsDriver::GenerateMipMaps(RHI::RHICommandListPtr cmd, RHI::RHIT
 
 	cmd->m_vulkan.m_commandBuffer->GenerateMipMaps(target->m_vulkan.m_image);
 
-	if (bShouldOptimizeBarriers)
-	{
-		// Hack to fit the internal layout
-		cmd->m_vulkan.m_commandBuffer->GetImageBarriers()[vkHandle] = TPair(target, (RHI::EImageLayout)target->m_vulkan.m_image->m_defaultLayout);
-		//ImageMemoryBarrier(cmd, target, target->GetDefaultLayout());
-	}
+	cmd->m_vulkan.m_commandBuffer->GetImageBarriers()[vkHandle] =
+		TPair(target, RHI::EImageLayout::ShaderReadOnlyOptimal);
 }
 
 void VulkanGraphicsDriver::ConvertEquirect2Cubemap(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr equirect, RHI::RHICubemapPtr cubemap)
@@ -2158,7 +2195,9 @@ void VulkanGraphicsDriver::ImageMemoryBarrier(RHI::RHICommandListPtr cmd, RHI::R
 	VkImage vkHandle = *image->m_vulkan.m_image;
 	if (!imageBarriers.ContainsKey(vkHandle))
 	{
-		imageBarriers[vkHandle] = TPair(image, (RHI::EImageLayout)image->m_vulkan.m_image->m_initialLayout);
+		// Engine-owned images are initialized before publication and every
+		// command list restores them to their current default layout.
+		imageBarriers[vkHandle] = TPair(image, image->GetDefaultLayout());
 	}
 
 	RHI::EImageLayout oldLayout = imageBarriers[vkHandle].Second();

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -227,6 +227,9 @@ TVector<uint32_t> VulkanGraphicsDriver::CollectOptionalVariableDescriptorCount(c
 					res.Resize(reflectedBinding.m_set + 1);
 				}
 
+#if defined(__APPLE__)
+				bool bFoundRuntimeCapacity = false;
+#endif
 				for (const auto& shaderBindingSet : shaderBindingSets)
 				{
 					if (!shaderBindingSet)
@@ -249,11 +252,40 @@ TVector<uint32_t> VulkanGraphicsDriver::CollectOptionalVariableDescriptorCount(c
 						runtimeLayout.m_type == reflectedBinding.m_type &&
 						runtimeLayout.m_bVariableDescriptorCount)
 					{
+#if defined(__APPLE__)
+						bFoundRuntimeCapacity = true;
+#endif
+						uint32_t runtimeDescriptorCount =
+							(std::max)(1u, runtimeLayout.m_arrayCount);
+#if defined(__APPLE__)
+						// Metal argument buffers have a substantially smaller practical
+						// sampled-image limit than Vulkan's global texture registry. Render
+						// batches provide compatible local descriptor sets, so the pipeline
+						// layout only needs the largest supported batch-local array.
+						if (runtimeLayout.m_type == RHI::EShaderBindingType::CombinedImageSampler)
+						{
+							runtimeDescriptorCount = (std::min)(runtimeDescriptorCount, 1024u);
+						}
+#endif
 						res[reflectedBinding.m_set] = std::max(
 							res[reflectedBinding.m_set],
-							std::max(1u, runtimeLayout.m_arrayCount));
+							runtimeDescriptorCount);
 					}
 				}
+#if defined(__APPLE__)
+				if (!bFoundRuntimeCapacity &&
+					reflectedBinding.m_type ==
+						RHI::EShaderBindingType::CombinedImageSampler &&
+					reflectedBinding.m_name == "textureSamplers")
+				{
+					// Apple render passes bind dense material-local texture arrays. The
+					// global registry intentionally keeps its legacy binding for other
+					// shaders, so it cannot provide the remapped binding's capacity here.
+					res[reflectedBinding.m_set] = (std::max)(
+						res[reflectedBinding.m_set],
+						1024u);
+				}
+#endif
 			}
 		}
 	}
@@ -1300,6 +1332,15 @@ RHI::RHIMaterialPtr VulkanGraphicsDriver::CreateMaterial(const RHI::RHIVertexDes
 	VulkanApi::CreateDescriptorSetLayouts(device, { shader->GetDebugVertexShaderRHI()->m_vulkan.m_shader, shader->GetDebugFragmentShaderRHI()->m_vulkan.m_shader },
 		descriptorSetLayouts, bindings);
 
+	// Material-owned parameters live exclusively in descriptor set 3. Keep
+	// frame, per-instance and pass-local bindings out of the material set even
+	// when they use the same descriptor type and binding number.
+	constexpr uint32_t MaterialDescriptorSet = 3u;
+	bindings.RemoveAll([=](const auto& binding)
+		{
+			return binding.m_set != MaterialDescriptorSet;
+		});
+
 	auto shaderBindings = CreateShaderBindings();
 
 	{
@@ -1309,12 +1350,6 @@ RHI::RHIMaterialPtr VulkanGraphicsDriver::CreateMaterial(const RHI::RHIVertexDes
 		for (uint32_t i = 0; i < bindings.Num(); i++)
 		{
 			auto& layoutBinding = bindings[i];
-			if (layoutBinding.m_set == 0 || layoutBinding.m_set == 1 || layoutBinding.m_set == 2)
-			{
-				// We skip 0 layout, it is frameData and would be binded in a different way
-				// Also we skip 1 layout, that is per instance data and would be binded in a different way
-				continue;
-			}
 			const auto& layoutBindings = descriptorSetLayouts[layoutBinding.m_set]->m_descriptorSetLayoutBindings;
 
 			auto it = layoutBindings.FindIf([&layoutBinding](const auto& bind) { return bind.binding == layoutBinding.m_binding; });
@@ -1649,8 +1684,7 @@ RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddSsboToShaderBindings(RHI::RHIS
 
 	TSharedPtr<VulkanBufferAllocator> allocator = GetGeneralSsboAllocator();
 
-	const size_t p = 16 - elementSize % 16;
-	const size_t paddedSize = elementSize + p;
+	const size_t paddedSize = SsboLayout::AlignSsboElementSize(elementSize);
 
 	size_t alignment = paddedSize;
 
@@ -1708,8 +1742,7 @@ RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddBufferToShaderBindings(RHI::RH
 	TSharedPtr<VulkanBufferAllocator> allocator;
 
 	// TODO: rewrite strictly according to std430
-	const size_t p = 16 - size % 16;
-	const size_t paddedSize = size + p;
+	const size_t paddedSize = SsboLayout::AlignSsboElementSize(size);
 
 	if (bufferType == RHI::EShaderBindingType::StorageBuffer)
 	{
@@ -3009,7 +3042,15 @@ TVector<VulkanDescriptorSetPtr> VulkanGraphicsDriver::GetCompatibleDescriptorSet
 								check(false);
 							}
 #endif
-							const uint32_t emittedTextureSlots = (std::min)(matchedLayoutBinding.descriptorCount, actualTextureSlots);
+							uint32_t emittedTextureSlots = (std::min)(matchedLayoutBinding.descriptorCount, actualTextureSlots);
+#if defined(__APPLE__)
+							// MoltenVK lowers a runtime sampler array to a fixed-size Metal
+							// argument-buffer array using the pipeline layout's upper bound.
+							// Allocating a smaller variable descriptor count leaves that Metal
+							// array undersized even though Vulkan considers the set valid.
+							// Keep unused slots partially bound, but allocate the complete array.
+							emittedTextureSlots = matchedLayoutBinding.descriptorCount;
+#endif
 							variableDescriptorCount = std::max(variableDescriptorCount, (std::max)(1u, emittedTextureSlots));
 						}
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -20,6 +20,19 @@
 
 namespace Sailor::GraphicsDriver::Vulkan
 {
+	namespace SsboLayout
+	{
+		constexpr size_t SsboElementAlignment = 16u;
+
+		constexpr size_t AlignSsboElementSize(size_t elementSize) noexcept
+		{
+			const size_t remainder = elementSize % SsboElementAlignment;
+			return remainder == 0u ?
+				elementSize :
+				elementSize + SsboElementAlignment - remainder;
+		}
+	}
+
 	class VulkanGraphicsDriver : public RHI::IGraphicsDriver, public RHI::IGraphicsDriverCommands
 	{
 	public:

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -263,6 +263,40 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API const TConcurrentMap<std::string, TSharedPtr<VulkanBufferAllocator>>& GetUniformBufferAllocators() const { return m_uniformBuffers; }
 
 	protected:
+		TVector<uint32_t> CollectPublishedVariableDescriptorCounts(const TVector<RHI::RHIShaderBindingSetPtr>& shaderBindingSets) const;
+
+		class ComputePipelineCacheKey
+		{
+			RHI::RHIShaderPtr m_shader{};
+			uint32_t m_pushConstantsSize = 0;
+			TVector<uint32_t> m_variableDescriptorCounts;
+
+		public:
+			ComputePipelineCacheKey() = default;
+			ComputePipelineCacheKey(const RHI::RHIShaderPtr& shader, uint32_t pushConstantsSize, const TVector<uint32_t>* variableDescriptorCounts) :
+				m_shader(shader),
+				m_pushConstantsSize(pushConstantsSize > 4 ? 256u : 0u),
+				m_variableDescriptorCounts(variableDescriptorCounts ? *variableDescriptorCounts : TVector<uint32_t>{})
+			{}
+
+			bool operator==(const ComputePipelineCacheKey& rhs) const
+			{
+				return m_shader == rhs.m_shader &&
+					m_pushConstantsSize == rhs.m_pushConstantsSize &&
+					m_variableDescriptorCounts == rhs.m_variableDescriptorCounts;
+			}
+
+			size_t GetHash() const
+			{
+				size_t hash = 0;
+				HashCombine(hash, m_shader, m_pushConstantsSize);
+				for (const uint32_t count : m_variableDescriptorCounts)
+				{
+					HashCombine(hash, count);
+				}
+				return hash;
+			}
+		};
 
 		const uint32_t CachedDescriptorSetLifeTimeInFrames = 3;
 		class CachedDescriptorSet
@@ -306,7 +340,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		// Cached MSAA render targets to support MSAA for rendering to framebuffer
 		TConcurrentMap<size_t, RHI::RHITexturePtr> m_cachedMsaaRenderTargets{};
 
-		TConcurrentMap<RHI::RHIShaderPtr, VulkanComputePipelinePtr> m_cachedComputePipelines{};
+		TConcurrentMap<ComputePipelineCacheKey, VulkanComputePipelinePtr> m_cachedComputePipelines{};
 		TConcurrentMap<CachedDescriptorSet, TPair<VulkanDescriptorSetPtr, uint32_t>> m_cachedDescriptorSets{ 24 };
 		mutable std::recursive_mutex m_descriptorUpdateMutex;
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -310,16 +310,16 @@ namespace Sailor::GraphicsDriver::Vulkan
 		public:
 
 			CachedDescriptorSet() = default;
-			CachedDescriptorSet& operator=(const CachedDescriptorSet& rhs);
-			CachedDescriptorSet(const VulkanPipelineLayoutPtr& material, const RHI::RHIShaderBindingSetPtr& bindings) noexcept;
+			SAILOR_SHARED_API CachedDescriptorSet& operator=(const CachedDescriptorSet& rhs);
+			SAILOR_SHARED_API CachedDescriptorSet(const VulkanPipelineLayoutPtr& material, const RHI::RHIShaderBindingSetPtr& bindings) noexcept;
 
-			bool operator==(const CachedDescriptorSet& rhs) const;
+			SAILOR_SHARED_API bool operator==(const CachedDescriptorSet& rhs) const;
 
 			VulkanPipelineLayoutPtr& GetLayout() { return m_layout; }
 			RHI::RHIShaderBindingSetPtr& GetBinding() { return m_binding; }
 
-			bool IsExpired() const;
-			size_t GetHash() const;
+			SAILOR_SHARED_API bool IsExpired() const;
+			SAILOR_SHARED_API size_t GetHash() const;
 		};
 
 		SAILOR_API bool UpdateDescriptorSet(RHI::RHIShaderBindingSetPtr bindings);

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -14,6 +14,7 @@
 #include "GraphicsDriver/Vulkan/VulkanDevice.h"
 #include "Platform/Win32/Window.h"
 #include "Containers/ConcurrentMap.h"
+#include <mutex>
 
 #ifdef SAILOR_BUILD_WITH_VULKAN
 
@@ -39,8 +40,6 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API virtual bool AcquireNextImage() override;
 		SAILOR_API virtual bool PresentFrame(const class FrameState& state, const TVector<RHI::RHICommandListPtr>& primaryCommandBuffers, const TVector<RHI::RHISemaphorePtr>& waitSemaphores) const override;
 		SAILOR_API virtual bool SubmitFrameWithoutPresent(const TVector<RHI::RHICommandListPtr>& primaryCommandBuffers, const TVector<RHI::RHISemaphorePtr>& waitSemaphores) override;
-		SAILOR_API VkSemaphore GetLastSubmittedRenderFinishedSemaphoreHandle() const;
-		SAILOR_API VkSemaphore GetLastSubmittedSceneViewMainResolvedSemaphoreHandle() const;
 
 		SAILOR_API virtual void SetDebugName(RHI::RHIResourcePtr resource, const std::string& name) override;
 
@@ -107,7 +106,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API virtual RHI::RHIMaterialPtr CreateMaterial(const RHI::RHIVertexDescriptionPtr& vertexDescription, RHI::EPrimitiveTopology topology, const RHI::RenderState& renderState, const Sailor::ShaderSetPtr& shader, const RHI::RHIShaderBindingSetPtr& shaderBindigs) override;
 		SAILOR_API virtual void UpdateMesh(RHI::RHIMeshPtr mesh, const void* pVertices, size_t vertexBuffer, const void* pIndices, size_t indexBuffer) override;
 
-		SAILOR_API virtual void SubmitCommandList(RHI::RHICommandListPtr commandList, RHI::RHIFencePtr fence = nullptr, RHI::RHISemaphorePtr signalSemaphore = nullptr, RHI::RHISemaphorePtr waitSemaphore = nullptr) override;
+		SAILOR_API virtual bool SubmitCommandList(RHI::RHICommandListPtr commandList, RHI::RHIFencePtr fence = nullptr, RHI::RHISemaphorePtr signalSemaphore = nullptr, RHI::RHISemaphorePtr waitSemaphore = nullptr) override;
 
 		// Shader binding set
 		SAILOR_API virtual RHI::RHIShaderBindingSetPtr CreateShaderBindings() override;
@@ -272,6 +271,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 			RHI::RHIShaderBindingSetPtr m_binding{};
 			size_t m_initialCompatibility = 0;
+			uint64_t m_initialDescriptorRevision = 0;
 
 		public:
 
@@ -288,7 +288,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 			size_t GetHash() const;
 		};
 
-		SAILOR_API void UpdateDescriptorSet(RHI::RHIShaderBindingSetPtr bindings);
+		SAILOR_API bool UpdateDescriptorSet(RHI::RHIShaderBindingSetPtr bindings);
 		SAILOR_API void RefreshSwapchainTargets();
 
 		// The resources that are used as default
@@ -308,6 +308,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 		TConcurrentMap<RHI::RHIShaderPtr, VulkanComputePipelinePtr> m_cachedComputePipelines{};
 		TConcurrentMap<CachedDescriptorSet, TPair<VulkanDescriptorSetPtr, uint32_t>> m_cachedDescriptorSets{ 24 };
+		mutable std::recursive_mutex m_descriptorUpdateMutex;
 
 			GraphicsDriver::Vulkan::VulkanApi* m_vkInstance{};
 			bool m_bIsInitialized = false;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanPipeline.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanPipeline.cpp
@@ -180,13 +180,18 @@ void VulkanComputePipeline::Release()
 	}
 }
 
-void VulkanComputePipeline::Compile()
+bool VulkanComputePipeline::Compile()
 {
 	SAILOR_PROFILE_FUNCTION();
 
 	if (m_pipeline)
 	{
-		return;
+		return true;
+	}
+	if (!m_layout || !m_stage)
+	{
+		SAILOR_LOG_ERROR("VulkanComputePipeline::Compile: pipeline layout or shader stage is unavailable.");
+		return false;
 	}
 
 	m_layout->Compile();
@@ -207,5 +212,13 @@ void VulkanComputePipeline::Compile()
 
 	pipelineInfo.stage = shaderStageCreateInfo;
 
-	VK_CHECK(vkCreateComputePipelines(*m_pDevice, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &m_pipeline));
+	const VkResult result = vkCreateComputePipelines(*m_pDevice, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &m_pipeline);
+	if (result != VK_SUCCESS || m_pipeline == VK_NULL_HANDLE)
+	{
+		m_pipeline = VK_NULL_HANDLE;
+		SAILOR_LOG_ERROR("VulkanComputePipeline::Compile: vkCreateComputePipelines failed with VkResult %d.", static_cast<int32_t>(result));
+		return false;
+	}
+
+	return true;
 }

--- a/Runtime/GraphicsDriver/Vulkan/VulkanPipeline.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanPipeline.h
@@ -91,8 +91,9 @@ namespace Sailor::GraphicsDriver::Vulkan
 		VulkanShaderStagePtr m_stage;
 		VulkanPipelineLayoutPtr m_layout;
 
-		void Compile();
+		bool Compile();
 		void Release();
+		bool IsCompiled() const { return m_pipeline != VK_NULL_HANDLE; }
 
 		operator VkPipeline() const { return m_pipeline; }
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanSemaphore.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanSemaphore.h
@@ -11,7 +11,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 	public:
 
-		SAILOR_API VulkanSemaphore(VulkanDevicePtr device, VkPipelineStageFlags pipelineStageFlags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, void* pNextCreateInfo = nullptr);
+		SAILOR_API VulkanSemaphore(VulkanDevicePtr device, VkPipelineStageFlags pipelineStageFlags = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, void* pNextCreateInfo = nullptr);
 
 		SAILOR_API operator VkSemaphore() const { return m_semaphore; }
 
@@ -23,7 +23,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API virtual ~VulkanSemaphore();
 
 		VkSemaphore m_semaphore;
-		VkPipelineStageFlags m_pipelineStageFlags = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT;
+		VkPipelineStageFlags m_pipelineStageFlags = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
 
 		VulkanDevicePtr m_device;
 	};

--- a/Runtime/GraphicsDriver/Vulkan/VulkanShaderModule.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanShaderModule.cpp
@@ -157,7 +157,6 @@ void VulkanShaderStage::ReflectDescriptorSetBindings(const RHI::ShaderByteCode& 
 			rhiBinding.m_textureType = (RHI::ETextureType)reflBinding.image.dim;
 
 			uint32_t membersSize = 0;
-			uint32_t maxMemberSize = 0;
 
 			// We handle UBO as POD
 			SpvReflectBlockVariable* blockContent = reflBinding.block.members;
@@ -186,8 +185,6 @@ void VulkanShaderStage::ReflectDescriptorSetBindings(const RHI::ShaderByteCode& 
 				membersSize = std::max(
 					membersSize,
 					blockContent[i].offset + blockContent[i].size);
-				maxMemberSize = std::max(maxMemberSize, blockContent[i].padded_size);
-
 				if (member.m_type == RHI::EShaderBindingMemberType::Array && blockContent[i].type_description)
 				{
 					const auto& typeFlags = blockContent[i].type_description->type_flags;
@@ -221,14 +218,10 @@ void VulkanShaderStage::ReflectDescriptorSetBindings(const RHI::ShaderByteCode& 
 			{
 				//We store 1 instance size in binding
 				rhiBinding.m_size = membersSize;
-				rhiBinding.m_paddedSize = reflBinding.block.members[0].padded_size;
-
-				if (maxMemberSize > 0)
-				{
-					// std430 array allignment
-					uint32_t allignment = 16 - reflBinding.block.members[0].padded_size % 16;
-					rhiBinding.m_paddedSize += allignment != maxMemberSize ? allignment : 0;
-				}
+				const SpvReflectBlockVariable& reflectedArray =
+					reflBinding.block.members[0];
+				rhiBinding.m_paddedSize =
+					SsboLayout::ResolveSsboArrayStride(reflectedArray);
 			}
 		}
 	}

--- a/Runtime/GraphicsDriver/Vulkan/VulkanShaderModule.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanShaderModule.cpp
@@ -175,8 +175,7 @@ void VulkanShaderStage::ReflectDescriptorSetBindings(const RHI::ShaderByteCode& 
 				RHI::ShaderLayoutBindingMember member;
 
 				member.m_name = blockContent[i].name ? std::string(blockContent[i].name) : "";
-				// Should we handle absolute offset in this way?
-				member.m_absoluteOffset = membersSize;// +blockContent[i].absolute_offset;
+				member.m_absoluteOffset = blockContent[i].offset;
 				member.m_size = blockContent[i].size;
 				member.m_type = (RHI::EShaderBindingMemberType)(blockContent[i].type_description->op);
 				member.m_arrayDimensions = blockContent[i].array.dims_count;
@@ -184,7 +183,9 @@ void VulkanShaderStage::ReflectDescriptorSetBindings(const RHI::ShaderByteCode& 
 				member.m_arrayCount = blockContent[i].array.dims[0];
 				member.m_arrayStride = blockContent[i].array.stride;
 
-				membersSize += blockContent[i].padded_size;
+				membersSize = std::max(
+					membersSize,
+					blockContent[i].offset + blockContent[i].size);
 				maxMemberSize = std::max(maxMemberSize, blockContent[i].padded_size);
 
 				if (member.m_type == RHI::EShaderBindingMemberType::Array && blockContent[i].type_description)

--- a/Runtime/GraphicsDriver/Vulkan/VulkanShaderModule.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanShaderModule.h
@@ -9,6 +9,35 @@
 
 namespace Sailor::GraphicsDriver::Vulkan
 {
+	namespace SsboLayout
+	{
+		constexpr uint32_t ResolveSsboArrayStride(
+			uint32_t reflectedBlockArrayStride,
+			uint32_t reflectedTypeArrayStride,
+			uint32_t reflectedPaddedSize) noexcept
+		{
+			return reflectedBlockArrayStride != 0u ?
+				reflectedBlockArrayStride :
+				(reflectedTypeArrayStride != 0u ?
+					reflectedTypeArrayStride :
+					reflectedPaddedSize);
+		}
+
+		inline uint32_t ResolveSsboArrayStride(
+			const SpvReflectBlockVariable& reflectedArray) noexcept
+		{
+			const uint32_t reflectedTypeArrayStride =
+				reflectedArray.type_description ?
+				reflectedArray.type_description->traits.array.stride :
+				0u;
+
+			return ResolveSsboArrayStride(
+				reflectedArray.array.stride,
+				reflectedTypeArrayStride,
+				reflectedArray.padded_size);
+		}
+	}
+
 	class VulkanShaderModule;
 
 	class VulkanShaderStage : public RHI::RHIResource, public RHI::IExplicitInitialization, public RHI::IStateModifier<VkPipelineShaderStageCreateInfo>

--- a/Runtime/Math/Bounds.cpp
+++ b/Runtime/Math/Bounds.cpp
@@ -95,15 +95,18 @@ glm::mat4 Frustum::CalculateOrthoMatrixByView(const glm::mat4& view, float zMult
 		maxZ = std::max(maxZ, trf.z);
 	}
 
-	// TODO: Redo
-	minZ = minZ < 0 ? minZ * zMult : minZ / zMult;
-	maxZ = maxZ < 0 ? maxZ / zMult : maxZ * zMult;
+	// Extend the fitted depth interval relative to its own center. Scaling the
+	// absolute coordinates made the cascade depend on which side of the light's
+	// origin the camera happened to be on.
+	const float zPadding = 0.5f * (maxZ - minZ) * (zMult - 1.0f);
+	minZ -= zPadding;
+	maxZ += zPadding;
 
 	const float zFar = -minZ;
 	const float zNear = -maxZ;
 
 	// Viewport settings, we want to handle all shadows with the reversed Z
-	const glm::mat4 lightProjection = glm::orthoRH_NO(minX, maxX, minY, maxY, zFar, zNear);
+	const glm::mat4 lightProjection = glm::orthoRH_ZO(minX, maxX, minY, maxY, zFar, zNear);
 
 	return lightProjection;
 }
@@ -112,30 +115,31 @@ void Frustum::CalculateCorners(const glm::mat4& matrix, bool bReverseZ)
 {
 	const auto inv = glm::inverse(matrix);
 
-	const float reverseZ = bReverseZ ? -1.0f : 1.0f;
+	const float farDepth = bReverseZ ? 0.0f : 1.0f;
+	const float nearDepth = bReverseZ ? 1.0f : 0.0f;
 
-	glm::vec4 pt = inv * glm::vec4(1.0f, 1.0f, reverseZ * 1.0f, 1.0f);
+	glm::vec4 pt = inv * glm::vec4(1.0f, 1.0f, farDepth, 1.0f);
 	m_corners[0] = vec3(pt / pt.w);
 
-	pt = inv * glm::vec4(-1.0f, 1.0f, reverseZ * 1.0f, 1.0f);
+	pt = inv * glm::vec4(-1.0f, 1.0f, farDepth, 1.0f);
 	m_corners[1] = vec3(pt / pt.w);
 
-	pt = inv * glm::vec4(-1.0f, -1.0f, reverseZ * 1.0f, 1.0f);
+	pt = inv * glm::vec4(-1.0f, -1.0f, farDepth, 1.0f);
 	m_corners[2] = vec3(pt / pt.w);
 
-	pt = inv * glm::vec4(1.0f, -1.0f, reverseZ * 1.0f, 1.0f);
+	pt = inv * glm::vec4(1.0f, -1.0f, farDepth, 1.0f);
 	m_corners[3] = vec3(pt / pt.w);
 
-	pt = inv * glm::vec4(1.0f, 1.0f, reverseZ * -1.0f, 1.0f);
+	pt = inv * glm::vec4(1.0f, 1.0f, nearDepth, 1.0f);
 	m_corners[4] = vec3(pt / pt.w);
 
-	pt = inv * glm::vec4(-1.0f, 1.0f, reverseZ * -1.0f, 1.0f);
+	pt = inv * glm::vec4(-1.0f, 1.0f, nearDepth, 1.0f);
 	m_corners[5] = vec3(pt / pt.w);
 
-	pt = inv * glm::vec4(-1.0f, -1.0f, reverseZ * -1.0f, 1.0f);
+	pt = inv * glm::vec4(-1.0f, -1.0f, nearDepth, 1.0f);
 	m_corners[6] = vec3(pt / pt.w);
 
-	pt = inv * glm::vec4(1.0f, -1.0f, reverseZ * -1.0f, 1.0f);
+	pt = inv * glm::vec4(1.0f, -1.0f, nearDepth, 1.0f);
 	m_corners[7] = vec3(pt / pt.w);
 }
 

--- a/Runtime/Protocol/Generated/editor_engine.pb.cc
+++ b/Runtime/Protocol/Generated/editor_engine.pb.cc
@@ -1353,6 +1353,7 @@ const ::uint32_t
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolRequest, _impl_.command_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _internal_metadata_),
@@ -1849,49 +1850,49 @@ static const ::_pbi::MigrationSchema
     schemas[] ABSL_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
         {0, -1, -1, sizeof(::sailor::editor::v1::Empty)},
         {8, -1, -1, sizeof(::sailor::editor::v1::ProtocolRequest)},
-        {65, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
-        {91, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
-        {100, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
-        {109, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
-        {118, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
-        {127, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
-        {136, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
-        {148, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
-        {158, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
-        {173, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
-        {184, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
-        {204, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
-        {214, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
-        {224, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
-        {235, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
-        {245, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
-        {256, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
-        {266, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
-        {277, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
-        {288, 300, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
-        {304, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
-        {314, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
-        {324, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
-        {335, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
-        {344, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
-        {353, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
-        {366, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
-        {375, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
-        {384, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
-        {393, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
-        {402, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
-        {412, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
-        {421, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
-        {433, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
-        {443, 452, -1, sizeof(::sailor::editor::v1::Vector4Result)},
-        {453, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
-        {463, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
-        {475, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
-        {484, 501, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
-        {510, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
-        {521, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
-        {530, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
-        {545, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
+        {66, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
+        {92, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
+        {101, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
+        {110, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
+        {119, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
+        {128, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
+        {137, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
+        {149, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
+        {159, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
+        {174, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
+        {185, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
+        {205, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
+        {215, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
+        {225, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
+        {236, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
+        {246, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
+        {257, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
+        {267, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
+        {278, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
+        {289, 301, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
+        {305, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
+        {315, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
+        {325, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
+        {336, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
+        {345, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
+        {354, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
+        {367, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
+        {376, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
+        {385, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
+        {394, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
+        {403, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
+        {413, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
+        {422, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
+        {434, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
+        {444, 453, -1, sizeof(::sailor::editor::v1::Vector4Result)},
+        {454, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
+        {464, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
+        {476, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
+        {485, 502, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
+        {511, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
+        {522, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
+        {531, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
+        {546, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_Empty_default_instance_._instance,
@@ -1943,7 +1944,7 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
     protodesc_cold) = {
     "\n\023editor_engine.proto\022\020sailor.editor.v1\""
-    "\007\n\005Empty\"\303\031\n\017ProtocolRequest\022\030\n\020protocol"
+    "\007\n\005Empty\"\374\031\n\017ProtocolRequest\022\030\n\020protocol"
     "_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\0229\n\nin"
     "itialize\030\n \001(\0132#.sailor.editor.v1.Initia"
     "lizeRequestH\000\022(\n\005start\030\013 \001(\0132\027.sailor.ed"
@@ -2022,149 +2023,150 @@ const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SE
     "\022M\n\027set_viewport_tool_state\0307 \001(\0132*.sail"
     "or.editor.v1.ViewportToolStateRequestH\000\022"
     "F\n\027get_viewport_tool_state\0308 \001(\0132#.sailo"
-    "r.editor.v1.ViewportIdRequestH\000B\t\n\007comma"
-    "ndJ\004\010\003\020\nJ\004\0102\0203J\004\0109\020dR\030create_model_game_"
-    "objectR\036resolve_viewport_drop_position\"\226"
-    "\007\n\020ProtocolResponse\022\030\n\020protocol_version\030"
-    "\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\022\017\n\007success\030\003 \001"
-    "(\010\022\r\n\005error\030\004 \001(\t\022$\n\034supports_strict_ins"
-    "tance_ids\030\005 \001(\010\022/\n\014empty_result\030\n \001(\0132\027."
-    "sailor.editor.v1.EmptyH\000\0223\n\013bool_result\030"
-    "\013 \001(\0132\034.sailor.editor.v1.BoolResultH\000\0225\n"
-    "\014int32_result\030\014 \001(\0132\035.sailor.editor.v1.I"
-    "nt32ResultH\000\0227\n\ruint32_result\030\r \001(\0132\036.sa"
-    "ilor.editor.v1.UInt32ResultH\000\0227\n\ruint64_"
-    "result\030\016 \001(\0132\036.sailor.editor.v1.UInt64Re"
-    "sultH\000\0227\n\rstring_result\030\017 \001(\0132\036.sailor.e"
-    "ditor.v1.StringResultH\000\022@\n\022string_list_r"
-    "esult\030\020 \001(\0132\".sailor.editor.v1.StringLis"
-    "tResultH\000\022M\n\031asset_reload_state_result\030\021"
-    " \001(\0132(.sailor.editor.v1.AssetReloadState"
-    "ResultH\000\022@\n\022instance_id_result\030\022 \001(\0132\".s"
-    "ailor.editor.v1.InstanceIdResultH\000\022Q\n\033vi"
-    "ewport_event_batch_result\030\023 \001(\0132*.sailor"
-    ".editor.v1.ViewportEventBatchResultH\000\0229\n"
-    "\016vector4_result\030\024 \001(\0132\037.sailor.editor.v1"
-    ".Vector4ResultH\000\022O\n\032viewport_tool_state_"
-    "result\030\025 \001(\0132).sailor.editor.v1.Viewport"
-    "ToolStateResultH\000B\010\n\006resultJ\004\010\006\020\nJ\004\010\026\020d\""
-    "&\n\021InitializeRequest\022\021\n\targuments\030\001 \003(\t\""
-    "!\n\014CountRequest\022\021\n\tmax_count\030\001 \001(\r\" \n\rFi"
-    "leIdRequest\022\017\n\007file_id\030\001 \001(\t\"(\n\021Instance"
-    "IdRequest\022\023\n\013instance_id\030\001 \001(\t\"(\n\021Viewpo"
-    "rtIdRequest\022\023\n\013viewport_id\030\001 \001(\004\"`\n\023View"
-    "portRectRequest\022\024\n\014window_pos_x\030\001 \001(\r\022\024\n"
-    "\014window_pos_y\030\002 \001(\r\022\r\n\005width\030\003 \001(\r\022\016\n\006he"
-    "ight\030\004 \001(\r\",\n\013SizeRequest\022\r\n\005width\030\001 \001(\r"
-    "\022\016\n\006height\030\002 \001(\r\"\231\001\n\025RemoteViewportReque"
-    "st\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014window_pos_x\030"
-    "\002 \001(\r\022\024\n\014window_pos_y\030\003 \001(\r\022\r\n\005width\030\004 \001"
-    "(\r\022\016\n\006height\030\005 \001(\r\022\017\n\007visible\030\006 \001(\010\022\017\n\007f"
-    "ocused\030\007 \001(\010\"e\n\031RemoteViewportHostReques"
-    "t\022\023\n\013viewport_id\030\001 \001(\004\022\030\n\020host_handle_ki"
-    "nd\030\002 \001(\r\022\031\n\021host_handle_value\030\003 \001(\004\"\374\001\n\032"
-    "RemoteViewportInputRequest\022\023\n\013viewport_i"
-    "d\030\001 \001(\004\022\014\n\004kind\030\002 \001(\r\022\021\n\tpointer_x\030\003 \001(\002"
-    "\022\021\n\tpointer_y\030\004 \001(\002\022\025\n\rwheel_delta_x\030\005 \001"
-    "(\002\022\025\n\rwheel_delta_y\030\006 \001(\002\022\020\n\010key_code\030\007 "
-    "\001(\r\022\016\n\006button\030\010 \001(\r\022\021\n\tmodifiers\030\t \001(\r\022\017"
-    "\n\007pressed\030\n \001(\010\022\017\n\007focused\030\013 \001(\010\022\020\n\010capt"
-    "ured\030\014 \001(\010\"C\n\036ManagedMutationRevisionReq"
-    "uest\022\014\n\004kind\030\001 \001(\r\022\023\n\013instance_id\030\002 \001(\t\""
-    "@\n\023UpdateObjectRequest\022\023\n\013instance_id\030\001 "
-    "\001(\t\022\024\n\014yaml_changes\030\002 \001(\t\"f\n\025ReparentObj"
-    "ectRequest\022\023\n\013instance_id\030\001 \001(\t\022\032\n\022paren"
-    "t_instance_id\030\002 \001(\t\022\034\n\024keep_world_transf"
-    "orm\030\003 \001(\010\"T\n\027CreateGameObjectRequest\022\032\n\022"
-    "parent_instance_id\030\001 \001(\t\022\035\n\025preferred_in"
-    "stance_id\030\002 \001(\t\"f\n\023AddComponentRequest\022\023"
-    "\n\013instance_id\030\001 \001(\t\022\033\n\023component_type_na"
-    "me\030\002 \001(\t\022\035\n\025preferred_instance_id\030\003 \001(\t\""
-    "G\n\030InstantiatePrefabRequest\022\017\n\007file_id\030\001"
-    " \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\"p\n Inst"
-    "antiatePrefabFromYamlRequest\022\023\n\013prefab_y"
-    "aml\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\033\n"
-    "\023strict_instance_ids\030\003 \001(\010\"U\n\022ViewportRa"
-    "yRequest\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014normali"
-    "zed_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 \001(\002\"\240\001\n In"
-    "stantiatePrefabInstanceRequest\022\017\n\007file_i"
-    "d\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\034\n\024a"
-    "pply_world_position\030\003 \001(\010\0221\n\016world_posit"
-    "ion\030\004 \001(\0132\031.sailor.editor.v1.Vector4\"A\n\025"
-    "ViewportObjectRequest\022\023\n\013viewport_id\030\001 \001"
-    "(\004\022\023\n\013instance_id\030\002 \001(\t\"9\n\021PrefabLinkReq"
-    "uest\022\023\n\013instance_id\030\001 \001(\t\022\017\n\007file_id\030\002 \001"
-    "(\t\"\251\001\n\030ViewportToolStateRequest\022\023\n\013viewp"
-    "ort_id\030\001 \001(\004\022\?\n\toperation\030\002 \001(\0162,.sailor"
-    ".editor.v1.ViewportTransformOperation\0227\n"
-    "\005space\030\003 \001(\0162(.sailor.editor.v1.Viewport"
-    "TransformSpace\"(\n\020SelectionRequest\022\024\n\014in"
-    "stance_ids\030\001 \003(\t\"%\n\025ShowMainWindowReques"
-    "t\022\014\n\004show\030\001 \001(\010\"\210\001\n\034RenderPathTracedImag"
-    "eRequest\022\023\n\013output_path\030\001 \001(\t\022\023\n\013instanc"
-    "e_id\030\002 \001(\t\022\016\n\006height\030\003 \001(\r\022\031\n\021samples_pe"
-    "r_pixel\030\004 \001(\r\022\023\n\013max_bounces\030\005 \001(\r\"\033\n\nBo"
-    "olResult\022\r\n\005value\030\001 \001(\010\"\034\n\013Int32Result\022\r"
-    "\n\005value\030\001 \001(\005\"\035\n\014UInt32Result\022\r\n\005value\030\001"
-    " \001(\r\"\035\n\014UInt64Result\022\r\n\005value\030\001 \001(\004\"0\n\014S"
-    "tringResult\022\021\n\thas_value\030\001 \001(\010\022\r\n\005value\030"
-    "\002 \001(\t\"\"\n\020StringListResult\022\016\n\006values\030\001 \003("
-    "\t\"\204\001\n\026AssetReloadStateResult\022\021\n\tavailabl"
-    "e\030\001 \001(\010\022\032\n\022request_generation\030\002 \001(\004\022\034\n\024c"
-    "ompleted_generation\030\003 \001(\004\022\035\n\025successful_"
-    "generation\030\004 \001(\004\":\n\020InstanceIdResult\022\021\n\t"
-    "succeeded\030\001 \001(\010\022\023\n\013instance_id\030\002 \001(\t\"9\n\r"
-    "Vector4Result\022(\n\005value\030\001 \001(\0132\031.sailor.ed"
-    "itor.v1.Vector4\"\223\001\n\027ViewportToolStateRes"
-    "ult\022\?\n\toperation\030\001 \001(\0162,.sailor.editor.v"
-    "1.ViewportTransformOperation\0227\n\005space\030\002 "
-    "\001(\0162(.sailor.editor.v1.ViewportTransform"
-    "Space\"5\n\007Vector4\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t"
-    "\n\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n\026ViewportSelectio"
-    "nEvent\022\034\n\024selected_instance_id\030\001 \001(\t\"\326\003\n"
-    "\026ViewportTransformEvent\022\023\n\013instance_id\030\001"
-    " \001(\t\022\?\n\toperation\030\002 \001(\0162,.sailor.editor."
-    "v1.ViewportTransformOperation\0227\n\005space\030\003"
-    " \001(\0162(.sailor.editor.v1.ViewportTransfor"
-    "mSpace\0222\n\017before_position\030\004 \001(\0132\031.sailor"
-    ".editor.v1.Vector4\0222\n\017before_rotation\030\005 "
-    "\001(\0132\031.sailor.editor.v1.Vector4\022/\n\014before"
-    "_scale\030\006 \001(\0132\031.sailor.editor.v1.Vector4\022"
-    "1\n\016after_position\030\007 \001(\0132\031.sailor.editor."
-    "v1.Vector4\0221\n\016after_rotation\030\010 \001(\0132\031.sai"
-    "lor.editor.v1.Vector4\022.\n\013after_scale\030\t \001"
-    "(\0132\031.sailor.editor.v1.Vector4\"U\n\026Viewpor"
-    "tAssetDropEvent\022\017\n\007file_id\030\001 \001(\t\022\024\n\014norm"
-    "alized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 \001(\002\"-\n\031"
-    "ViewportToolShortcutEvent\022\020\n\010key_code\030\001 "
-    "\001(\r\"\331\002\n\rViewportEvent\022\020\n\010revision\030\001 \001(\004\022"
-    "!\n\031managed_mutation_revision\030\002 \001(\004\022=\n\tse"
-    "lection\030\n \001(\0132(.sailor.editor.v1.Viewpor"
-    "tSelectionEventH\000\022=\n\ttransform\030\013 \001(\0132(.s"
-    "ailor.editor.v1.ViewportTransformEventH\000"
-    "\022>\n\nasset_drop\030\014 \001(\0132(.sailor.editor.v1."
-    "ViewportAssetDropEventH\000\022D\n\rtool_shortcu"
-    "t\030\r \001(\0132+.sailor.editor.v1.ViewportToolS"
-    "hortcutEventH\000B\t\n\007payloadJ\004\010\003\020\n\"K\n\030Viewp"
-    "ortEventBatchResult\022/\n\006events\030\001 \003(\0132\037.sa"
-    "ilor.editor.v1.ViewportEvent*\360\001\n\032Viewpor"
-    "tTransformOperation\022,\n(VIEWPORT_TRANSFOR"
-    "M_OPERATION_UNSPECIFIED\020\000\022\'\n#VIEWPORT_TR"
-    "ANSFORM_OPERATION_SELECT\020\001\022*\n&VIEWPORT_T"
-    "RANSFORM_OPERATION_TRANSLATE\020\002\022\'\n#VIEWPO"
-    "RT_TRANSFORM_OPERATION_ROTATE\020\003\022&\n\"VIEWP"
-    "ORT_TRANSFORM_OPERATION_SCALE\020\004*\212\001\n\026View"
-    "portTransformSpace\022(\n$VIEWPORT_TRANSFORM"
-    "_SPACE_UNSPECIFIED\020\000\022\"\n\036VIEWPORT_TRANSFO"
-    "RM_SPACE_WORLD\020\001\022\"\n\036VIEWPORT_TRANSFORM_S"
-    "PACE_LOCAL\020\002B\"\252\002\037SailorEditor.Protocol.G"
-    "eneratedb\006proto3"
+    "r.editor.v1.ViewportIdRequestH\000\0227\n\014updat"
+    "e_asset\0309 \001(\0132\037.sailor.editor.v1.FileIdR"
+    "equestH\000B\t\n\007commandJ\004\010\003\020\nJ\004\0102\0203J\004\010:\020dR\030c"
+    "reate_model_game_objectR\036resolve_viewpor"
+    "t_drop_position\"\226\007\n\020ProtocolResponse\022\030\n\020"
+    "protocol_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001"
+    "(\004\022\017\n\007success\030\003 \001(\010\022\r\n\005error\030\004 \001(\t\022$\n\034su"
+    "pports_strict_instance_ids\030\005 \001(\010\022/\n\014empt"
+    "y_result\030\n \001(\0132\027.sailor.editor.v1.EmptyH"
+    "\000\0223\n\013bool_result\030\013 \001(\0132\034.sailor.editor.v"
+    "1.BoolResultH\000\0225\n\014int32_result\030\014 \001(\0132\035.s"
+    "ailor.editor.v1.Int32ResultH\000\0227\n\ruint32_"
+    "result\030\r \001(\0132\036.sailor.editor.v1.UInt32Re"
+    "sultH\000\0227\n\ruint64_result\030\016 \001(\0132\036.sailor.e"
+    "ditor.v1.UInt64ResultH\000\0227\n\rstring_result"
+    "\030\017 \001(\0132\036.sailor.editor.v1.StringResultH\000"
+    "\022@\n\022string_list_result\030\020 \001(\0132\".sailor.ed"
+    "itor.v1.StringListResultH\000\022M\n\031asset_relo"
+    "ad_state_result\030\021 \001(\0132(.sailor.editor.v1"
+    ".AssetReloadStateResultH\000\022@\n\022instance_id"
+    "_result\030\022 \001(\0132\".sailor.editor.v1.Instanc"
+    "eIdResultH\000\022Q\n\033viewport_event_batch_resu"
+    "lt\030\023 \001(\0132*.sailor.editor.v1.ViewportEven"
+    "tBatchResultH\000\0229\n\016vector4_result\030\024 \001(\0132\037"
+    ".sailor.editor.v1.Vector4ResultH\000\022O\n\032vie"
+    "wport_tool_state_result\030\025 \001(\0132).sailor.e"
+    "ditor.v1.ViewportToolStateResultH\000B\010\n\006re"
+    "sultJ\004\010\006\020\nJ\004\010\026\020d\"&\n\021InitializeRequest\022\021\n"
+    "\targuments\030\001 \003(\t\"!\n\014CountRequest\022\021\n\tmax_"
+    "count\030\001 \001(\r\" \n\rFileIdRequest\022\017\n\007file_id\030"
+    "\001 \001(\t\"(\n\021InstanceIdRequest\022\023\n\013instance_i"
+    "d\030\001 \001(\t\"(\n\021ViewportIdRequest\022\023\n\013viewport"
+    "_id\030\001 \001(\004\"`\n\023ViewportRectRequest\022\024\n\014wind"
+    "ow_pos_x\030\001 \001(\r\022\024\n\014window_pos_y\030\002 \001(\r\022\r\n\005"
+    "width\030\003 \001(\r\022\016\n\006height\030\004 \001(\r\",\n\013SizeReque"
+    "st\022\r\n\005width\030\001 \001(\r\022\016\n\006height\030\002 \001(\r\"\231\001\n\025Re"
+    "moteViewportRequest\022\023\n\013viewport_id\030\001 \001(\004"
+    "\022\024\n\014window_pos_x\030\002 \001(\r\022\024\n\014window_pos_y\030\003"
+    " \001(\r\022\r\n\005width\030\004 \001(\r\022\016\n\006height\030\005 \001(\r\022\017\n\007v"
+    "isible\030\006 \001(\010\022\017\n\007focused\030\007 \001(\010\"e\n\031RemoteV"
+    "iewportHostRequest\022\023\n\013viewport_id\030\001 \001(\004\022"
+    "\030\n\020host_handle_kind\030\002 \001(\r\022\031\n\021host_handle"
+    "_value\030\003 \001(\004\"\374\001\n\032RemoteViewportInputRequ"
+    "est\022\023\n\013viewport_id\030\001 \001(\004\022\014\n\004kind\030\002 \001(\r\022\021"
+    "\n\tpointer_x\030\003 \001(\002\022\021\n\tpointer_y\030\004 \001(\002\022\025\n\r"
+    "wheel_delta_x\030\005 \001(\002\022\025\n\rwheel_delta_y\030\006 \001"
+    "(\002\022\020\n\010key_code\030\007 \001(\r\022\016\n\006button\030\010 \001(\r\022\021\n\t"
+    "modifiers\030\t \001(\r\022\017\n\007pressed\030\n \001(\010\022\017\n\007focu"
+    "sed\030\013 \001(\010\022\020\n\010captured\030\014 \001(\010\"C\n\036ManagedMu"
+    "tationRevisionRequest\022\014\n\004kind\030\001 \001(\r\022\023\n\013i"
+    "nstance_id\030\002 \001(\t\"@\n\023UpdateObjectRequest\022"
+    "\023\n\013instance_id\030\001 \001(\t\022\024\n\014yaml_changes\030\002 \001"
+    "(\t\"f\n\025ReparentObjectRequest\022\023\n\013instance_"
+    "id\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\034\n\024"
+    "keep_world_transform\030\003 \001(\010\"T\n\027CreateGame"
+    "ObjectRequest\022\032\n\022parent_instance_id\030\001 \001("
+    "\t\022\035\n\025preferred_instance_id\030\002 \001(\t\"f\n\023AddC"
+    "omponentRequest\022\023\n\013instance_id\030\001 \001(\t\022\033\n\023"
+    "component_type_name\030\002 \001(\t\022\035\n\025preferred_i"
+    "nstance_id\030\003 \001(\t\"G\n\030InstantiatePrefabReq"
+    "uest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_instance"
+    "_id\030\002 \001(\t\"p\n InstantiatePrefabFromYamlRe"
+    "quest\022\023\n\013prefab_yaml\030\001 \001(\t\022\032\n\022parent_ins"
+    "tance_id\030\002 \001(\t\022\033\n\023strict_instance_ids\030\003 "
+    "\001(\010\"U\n\022ViewportRayRequest\022\023\n\013viewport_id"
+    "\030\001 \001(\004\022\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normaliz"
+    "ed_y\030\003 \001(\002\"\240\001\n InstantiatePrefabInstance"
+    "Request\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_insta"
+    "nce_id\030\002 \001(\t\022\034\n\024apply_world_position\030\003 \001"
+    "(\010\0221\n\016world_position\030\004 \001(\0132\031.sailor.edit"
+    "or.v1.Vector4\"A\n\025ViewportObjectRequest\022\023"
+    "\n\013viewport_id\030\001 \001(\004\022\023\n\013instance_id\030\002 \001(\t"
+    "\"9\n\021PrefabLinkRequest\022\023\n\013instance_id\030\001 \001"
+    "(\t\022\017\n\007file_id\030\002 \001(\t\"\251\001\n\030ViewportToolStat"
+    "eRequest\022\023\n\013viewport_id\030\001 \001(\004\022\?\n\toperati"
+    "on\030\002 \001(\0162,.sailor.editor.v1.ViewportTran"
+    "sformOperation\0227\n\005space\030\003 \001(\0162(.sailor.e"
+    "ditor.v1.ViewportTransformSpace\"(\n\020Selec"
+    "tionRequest\022\024\n\014instance_ids\030\001 \003(\t\"%\n\025Sho"
+    "wMainWindowRequest\022\014\n\004show\030\001 \001(\010\"\210\001\n\034Ren"
+    "derPathTracedImageRequest\022\023\n\013output_path"
+    "\030\001 \001(\t\022\023\n\013instance_id\030\002 \001(\t\022\016\n\006height\030\003 "
+    "\001(\r\022\031\n\021samples_per_pixel\030\004 \001(\r\022\023\n\013max_bo"
+    "unces\030\005 \001(\r\"\033\n\nBoolResult\022\r\n\005value\030\001 \001(\010"
+    "\"\034\n\013Int32Result\022\r\n\005value\030\001 \001(\005\"\035\n\014UInt32"
+    "Result\022\r\n\005value\030\001 \001(\r\"\035\n\014UInt64Result\022\r\n"
+    "\005value\030\001 \001(\004\"0\n\014StringResult\022\021\n\thas_valu"
+    "e\030\001 \001(\010\022\r\n\005value\030\002 \001(\t\"\"\n\020StringListResu"
+    "lt\022\016\n\006values\030\001 \003(\t\"\204\001\n\026AssetReloadStateR"
+    "esult\022\021\n\tavailable\030\001 \001(\010\022\032\n\022request_gene"
+    "ration\030\002 \001(\004\022\034\n\024completed_generation\030\003 \001"
+    "(\004\022\035\n\025successful_generation\030\004 \001(\004\":\n\020Ins"
+    "tanceIdResult\022\021\n\tsucceeded\030\001 \001(\010\022\023\n\013inst"
+    "ance_id\030\002 \001(\t\"9\n\rVector4Result\022(\n\005value\030"
+    "\001 \001(\0132\031.sailor.editor.v1.Vector4\"\223\001\n\027Vie"
+    "wportToolStateResult\022\?\n\toperation\030\001 \001(\0162"
+    ",.sailor.editor.v1.ViewportTransformOper"
+    "ation\0227\n\005space\030\002 \001(\0162(.sailor.editor.v1."
+    "ViewportTransformSpace\"5\n\007Vector4\022\t\n\001x\030\001"
+    " \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n"
+    "\026ViewportSelectionEvent\022\034\n\024selected_inst"
+    "ance_id\030\001 \001(\t\"\326\003\n\026ViewportTransformEvent"
+    "\022\023\n\013instance_id\030\001 \001(\t\022\?\n\toperation\030\002 \001(\016"
+    "2,.sailor.editor.v1.ViewportTransformOpe"
+    "ration\0227\n\005space\030\003 \001(\0162(.sailor.editor.v1"
+    ".ViewportTransformSpace\0222\n\017before_positi"
+    "on\030\004 \001(\0132\031.sailor.editor.v1.Vector4\0222\n\017b"
+    "efore_rotation\030\005 \001(\0132\031.sailor.editor.v1."
+    "Vector4\022/\n\014before_scale\030\006 \001(\0132\031.sailor.e"
+    "ditor.v1.Vector4\0221\n\016after_position\030\007 \001(\013"
+    "2\031.sailor.editor.v1.Vector4\0221\n\016after_rot"
+    "ation\030\010 \001(\0132\031.sailor.editor.v1.Vector4\022."
+    "\n\013after_scale\030\t \001(\0132\031.sailor.editor.v1.V"
+    "ector4\"U\n\026ViewportAssetDropEvent\022\017\n\007file"
+    "_id\030\001 \001(\t\022\024\n\014normalized_x\030\002 \001(\002\022\024\n\014norma"
+    "lized_y\030\003 \001(\002\"-\n\031ViewportToolShortcutEve"
+    "nt\022\020\n\010key_code\030\001 \001(\r\"\331\002\n\rViewportEvent\022\020"
+    "\n\010revision\030\001 \001(\004\022!\n\031managed_mutation_rev"
+    "ision\030\002 \001(\004\022=\n\tselection\030\n \001(\0132(.sailor."
+    "editor.v1.ViewportSelectionEventH\000\022=\n\ttr"
+    "ansform\030\013 \001(\0132(.sailor.editor.v1.Viewpor"
+    "tTransformEventH\000\022>\n\nasset_drop\030\014 \001(\0132(."
+    "sailor.editor.v1.ViewportAssetDropEventH"
+    "\000\022D\n\rtool_shortcut\030\r \001(\0132+.sailor.editor"
+    ".v1.ViewportToolShortcutEventH\000B\t\n\007paylo"
+    "adJ\004\010\003\020\n\"K\n\030ViewportEventBatchResult\022/\n\006"
+    "events\030\001 \003(\0132\037.sailor.editor.v1.Viewport"
+    "Event*\360\001\n\032ViewportTransformOperation\022,\n("
+    "VIEWPORT_TRANSFORM_OPERATION_UNSPECIFIED"
+    "\020\000\022\'\n#VIEWPORT_TRANSFORM_OPERATION_SELEC"
+    "T\020\001\022*\n&VIEWPORT_TRANSFORM_OPERATION_TRAN"
+    "SLATE\020\002\022\'\n#VIEWPORT_TRANSFORM_OPERATION_"
+    "ROTATE\020\003\022&\n\"VIEWPORT_TRANSFORM_OPERATION"
+    "_SCALE\020\004*\212\001\n\026ViewportTransformSpace\022(\n$V"
+    "IEWPORT_TRANSFORM_SPACE_UNSPECIFIED\020\000\022\"\n"
+    "\036VIEWPORT_TRANSFORM_SPACE_WORLD\020\001\022\"\n\036VIE"
+    "WPORT_TRANSFORM_SPACE_LOCAL\020\002B\"\252\002\037Sailor"
+    "Editor.Protocol.Generatedb\006proto3"
 };
 static ::absl::once_flag descriptor_table_editor_5fengine_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_editor_5fengine_2eproto = {
     false,
     false,
-    8656,
+    8713,
     descriptor_table_protodef_editor_5fengine_2eproto,
     "editor_engine.proto",
     &descriptor_table_editor_5fengine_2eproto_once,
@@ -2907,6 +2909,19 @@ void ProtocolRequest::set_allocated_get_viewport_tool_state(::sailor::editor::v1
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.get_viewport_tool_state)
 }
+void ProtocolRequest::set_allocated_update_asset(::sailor::editor::v1::FileIdRequest* update_asset) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (update_asset) {
+    ::google::protobuf::Arena* submessage_arena = update_asset->GetArena();
+    if (message_arena != submessage_arena) {
+      update_asset = ::google::protobuf::internal::GetOwnedMessage(message_arena, update_asset, submessage_arena);
+    }
+    set_has_update_asset();
+    _impl_.command_.update_asset_ = update_asset;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.update_asset)
+}
 ProtocolRequest::ProtocolRequest(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
@@ -3083,6 +3098,9 @@ ProtocolRequest::ProtocolRequest(
         break;
       case kGetViewportToolState:
         _impl_.command_.get_viewport_tool_state_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportIdRequest>(arena, *from._impl_.command_.get_viewport_tool_state_);
+        break;
+      case kUpdateAsset:
+        _impl_.command_.update_asset_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::FileIdRequest>(arena, *from._impl_.command_.update_asset_);
         break;
   }
 
@@ -3490,6 +3508,14 @@ void ProtocolRequest::clear_command() {
       }
       break;
     }
+    case kUpdateAsset: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.update_asset_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.update_asset_);
+      }
+      break;
+    }
     case COMMAND_NOT_SET: {
       break;
     }
@@ -3534,16 +3560,16 @@ const ::google::protobuf::internal::ClassData* ProtocolRequest::GetClassData() c
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 48, 46, 0, 9> ProtocolRequest::_table_ = {
+const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    56, 8,  // max_field_number, fast_idx_mask
+    57, 8,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
     508,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    48,  // num_field_entries
-    46,  // num_aux_entries
+    49,  // num_field_entries
+    47,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -3560,7 +3586,7 @@ const ::_pbi::TcParseTable<1, 48, 46, 0, 9> ProtocolRequest::_table_ = {
      {8, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.protocol_version_)}},
   }}, {{
     33, 0, 2,
-    0, 25, 65282, 41,
+    0, 25, 65026, 41,
     65535, 65535
   }}, {{
     // uint32 protocol_version = 1;
@@ -3707,6 +3733,9 @@ const ::_pbi::TcParseTable<1, 48, 46, 0, 9> ProtocolRequest::_table_ = {
     // .sailor.editor.v1.ViewportIdRequest get_viewport_tool_state = 56;
     {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.get_viewport_tool_state_), _Internal::kOneofCaseOffset + 0, 45,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.FileIdRequest update_asset = 57;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.update_asset_), _Internal::kOneofCaseOffset + 0, 46,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InitializeRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
@@ -3754,6 +3783,7 @@ const ::_pbi::TcParseTable<1, 48, 46, 0, 9> ProtocolRequest::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InstanceIdRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportToolStateRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportIdRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::FileIdRequest>()},
   }}, {{
   }},
 };
@@ -4078,6 +4108,12 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
                   stream);
               break;
             }
+            case kUpdateAsset: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  57, *this_._impl_.command_.update_asset_, this_._impl_.command_.update_asset_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -4392,6 +4428,12 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
             case kGetViewportToolState: {
               total_size += 2 +
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.get_viewport_tool_state_);
+              break;
+            }
+            // .sailor.editor.v1.FileIdRequest update_asset = 57;
+            case kUpdateAsset: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.update_asset_);
               break;
             }
             case COMMAND_NOT_SET: {
@@ -4839,6 +4881,15 @@ void ProtocolRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const :
               ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportIdRequest>(arena, *from._impl_.command_.get_viewport_tool_state_);
         } else {
           _this->_impl_.command_.get_viewport_tool_state_->MergeFrom(from._internal_get_viewport_tool_state());
+        }
+        break;
+      }
+      case kUpdateAsset: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.update_asset_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::FileIdRequest>(arena, *from._impl_.command_.update_asset_);
+        } else {
+          _this->_impl_.command_.update_asset_->MergeFrom(from._internal_update_asset());
         }
         break;
       }

--- a/Runtime/Protocol/Generated/editor_engine.pb.h
+++ b/Runtime/Protocol/Generated/editor_engine.pb.h
@@ -9458,6 +9458,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kBreakPrefabLink = 54,
     kSetViewportToolState = 55,
     kGetViewportToolState = 56,
+    kUpdateAsset = 57,
     COMMAND_NOT_SET = 0,
   };
   static inline const ProtocolRequest* internal_default_instance() {
@@ -9599,6 +9600,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kBreakPrefabLinkFieldNumber = 54,
     kSetViewportToolStateFieldNumber = 55,
     kGetViewportToolStateFieldNumber = 56,
+    kUpdateAssetFieldNumber = 57,
   };
   // uint64 request_id = 2;
   void clear_request_id() ;
@@ -10494,6 +10496,25 @@ class ProtocolRequest final : public ::google::protobuf::Message
   ::sailor::editor::v1::ViewportIdRequest* _internal_mutable_get_viewport_tool_state();
 
   public:
+  // .sailor.editor.v1.FileIdRequest update_asset = 57;
+  bool has_update_asset() const;
+  private:
+  bool _internal_has_update_asset() const;
+
+  public:
+  void clear_update_asset() ;
+  const ::sailor::editor::v1::FileIdRequest& update_asset() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::FileIdRequest* release_update_asset();
+  ::sailor::editor::v1::FileIdRequest* mutable_update_asset();
+  void set_allocated_update_asset(::sailor::editor::v1::FileIdRequest* value);
+  void unsafe_arena_set_allocated_update_asset(::sailor::editor::v1::FileIdRequest* value);
+  ::sailor::editor::v1::FileIdRequest* unsafe_arena_release_update_asset();
+
+  private:
+  const ::sailor::editor::v1::FileIdRequest& _internal_update_asset() const;
+  ::sailor::editor::v1::FileIdRequest* _internal_mutable_update_asset();
+
+  public:
   void clear_command();
   CommandCase command_case() const;
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.ProtocolRequest)
@@ -10545,11 +10566,12 @@ class ProtocolRequest final : public ::google::protobuf::Message
   void set_has_break_prefab_link();
   void set_has_set_viewport_tool_state();
   void set_has_get_viewport_tool_state();
+  void set_has_update_asset();
   inline bool has_command() const;
   inline void clear_has_command();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      1, 48, 46,
+      1, 49, 47,
       0, 9>
       _table_;
 
@@ -10618,6 +10640,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
       ::sailor::editor::v1::InstanceIdRequest* break_prefab_link_;
       ::sailor::editor::v1::ViewportToolStateRequest* set_viewport_tool_state_;
       ::sailor::editor::v1::ViewportIdRequest* get_viewport_tool_state_;
+      ::sailor::editor::v1::FileIdRequest* update_asset_;
     } command_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -15051,6 +15074,85 @@ inline ::sailor::editor::v1::ViewportIdRequest* ProtocolRequest::_internal_mutab
 inline ::sailor::editor::v1::ViewportIdRequest* ProtocolRequest::mutable_get_viewport_tool_state() ABSL_ATTRIBUTE_LIFETIME_BOUND {
   ::sailor::editor::v1::ViewportIdRequest* _msg = _internal_mutable_get_viewport_tool_state();
   // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.get_viewport_tool_state)
+  return _msg;
+}
+
+// .sailor.editor.v1.FileIdRequest update_asset = 57;
+inline bool ProtocolRequest::has_update_asset() const {
+  return command_case() == kUpdateAsset;
+}
+inline bool ProtocolRequest::_internal_has_update_asset() const {
+  return command_case() == kUpdateAsset;
+}
+inline void ProtocolRequest::set_has_update_asset() {
+  _impl_._oneof_case_[0] = kUpdateAsset;
+}
+inline void ProtocolRequest::clear_update_asset() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kUpdateAsset) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.update_asset_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.update_asset_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::FileIdRequest* ProtocolRequest::release_update_asset() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.update_asset)
+  if (command_case() == kUpdateAsset) {
+    clear_has_command();
+    auto* temp = _impl_.command_.update_asset_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.update_asset_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::FileIdRequest& ProtocolRequest::_internal_update_asset() const {
+  return command_case() == kUpdateAsset ? *_impl_.command_.update_asset_ : reinterpret_cast<::sailor::editor::v1::FileIdRequest&>(::sailor::editor::v1::_FileIdRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::FileIdRequest& ProtocolRequest::update_asset() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.update_asset)
+  return _internal_update_asset();
+}
+inline ::sailor::editor::v1::FileIdRequest* ProtocolRequest::unsafe_arena_release_update_asset() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.update_asset)
+  if (command_case() == kUpdateAsset) {
+    clear_has_command();
+    auto* temp = _impl_.command_.update_asset_;
+    _impl_.command_.update_asset_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_update_asset(::sailor::editor::v1::FileIdRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_update_asset();
+    _impl_.command_.update_asset_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.update_asset)
+}
+inline ::sailor::editor::v1::FileIdRequest* ProtocolRequest::_internal_mutable_update_asset() {
+  if (command_case() != kUpdateAsset) {
+    clear_command();
+    set_has_update_asset();
+    _impl_.command_.update_asset_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::FileIdRequest>(GetArena());
+  }
+  return _impl_.command_.update_asset_;
+}
+inline ::sailor::editor::v1::FileIdRequest* ProtocolRequest::mutable_update_asset() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::FileIdRequest* _msg = _internal_mutable_update_asset();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.update_asset)
   return _msg;
 }
 

--- a/Runtime/RHI/Batch.hpp
+++ b/Runtime/RHI/Batch.hpp
@@ -58,7 +58,7 @@ namespace Sailor::RHI
 	using TDrawCalls = TMap<RHIBatch, TMap<RHI::RHIMeshPtr, TVector<TPerInstanceData>>>;
 
 	template<typename TPerInstanceData>
-	void RHIRecordDrawCallGPUCulling(uint32_t start,
+	DrawCallStats RHIRecordDrawCallGPUCulling(uint32_t start,
 		uint32_t end,
 		const TVector<RHIBatch>& vecBatches,
 		RHI::RHICommandListPtr graphicsCmdList,
@@ -76,6 +76,11 @@ namespace Sailor::RHI
 		std::mutex* transferCommandListMutex = nullptr)
 	{
 		SAILOR_PROFILE_FUNCTION();
+		DrawCallStats stats;
+		if (start >= end || end > vecBatches.Num() || end > storageIndex.Num())
+		{
+			return stats;
+		}
 
 		auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 		auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
@@ -93,7 +98,16 @@ namespace Sailor::RHI
 			indirectCommandBuffer.Clear();
 			indirectCommandBuffer = driver->CreateIndirectBuffer(indirectBufferSize + slack);
 
-			auto binding = Sailor::RHI::Renderer::GetDriver()->AddBufferToShaderBindings(indirectCommandBufferBinding,
+			Sailor::RHI::Renderer::GetDriver()->AddBufferToShaderBindings(indirectCommandBufferBinding,
+				indirectCommandBuffer,
+				"drawIndexedIndirect",
+				0);
+		}
+		else if (!indirectCommandBufferBinding->HasBinding("drawIndexedIndirect"))
+		{
+			// The buffer can have been allocated by the non-culling path. In that case
+			// its storage-buffer descriptor still has to be created before dispatch.
+			Sailor::RHI::Renderer::GetDriver()->AddBufferToShaderBindings(indirectCommandBufferBinding,
 				indirectCommandBuffer,
 				"drawIndexedIndirect",
 				0);
@@ -103,7 +117,7 @@ namespace Sailor::RHI
 		RHIBufferPtr prevVertexBuffer = nullptr;
 		RHIBufferPtr prevIndexBuffer = nullptr;
 
-		uint32_t firstInstanceIndex = storageIndex[0];
+		uint32_t firstInstanceIndex = storageIndex[start];
 		uint32_t totalNumInstances = 0;
 		uint32_t totalNumBatches = 0;
 
@@ -175,6 +189,7 @@ namespace Sailor::RHI
 					commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
 				}
 				commands->DrawIndexedIndirect(graphicsCmdList, indirectCommandBuffer, indirectBufferOffset, (uint32_t)drawIndirect.Num(), sizeof(RHI::DrawIndexedIndirectData));
+				stats.m_numBatches++;
 				indirectBufferOffset += bufferSize;
 				drawIndirect.Clear();
 				meshesInCurrentBatch = 0;
@@ -213,19 +228,41 @@ namespace Sailor::RHI
 			uint32_t m_numBatches = 0;
 			uint32_t m_numInstances = 0;
 			uint32_t m_firstInstanceIndex = 0;
+			uint32_t m_phase = 0;
+			uint32_t m_bEnableOcclusion = 0;
 		};
 
 		PushConstants constants{};
 		constants.m_numBatches = totalNumBatches;
 		constants.m_numInstances = totalNumInstances;
 		constants.m_firstInstanceIndex = firstInstanceIndex;
+		// The Hi-Z texture belongs to the previous frame, while the frame and
+		// instance transforms are current. Occlusion is not conservative until
+		// matching camera/object history is supplied; frustum culling remains on.
+		constants.m_bEnableOcclusion = 0;
+		stats.m_numInstances = totalNumInstances;
 
 		auto recordCullingDispatch = [&]()
 			{
 				commands->BeginDebugRegion(transferCmdList, "GPU Culling", DebugContext::Color_CmdCompute);
-				const uint32_t maxWorkItems = (std::max)(constants.m_numBatches, constants.m_numInstances);
-				const uint32_t dispatchGroupsX = (std::max)(1u, (maxWorkItems + RHI::Renderer::GPUCullingGroupSize - 1u) / RHI::Renderer::GPUCullingGroupSize);
-				commands->Dispatch(transferCmdList, computeCullingShader, dispatchGroupsX, 1, 1, cullingDistpatchBindings, &constants, sizeof(constants));
+
+				const EAccessFlags uploadWrites = static_cast<EAccessFlags>(EAccessBit::TransferWrite_Bit) |
+					static_cast<EAccessFlags>(EAccessBit::HostWrite_Bit);
+				const EAccessFlags shaderReadWrite = static_cast<EAccessFlags>(EAccessBit::ShaderRead_Bit) |
+					static_cast<EAccessFlags>(EAccessBit::ShaderWrite_Bit);
+				commands->MemoryBarrier(transferCmdList, uploadWrites, shaderReadWrite);
+
+				constants.m_phase = 0;
+				const uint32_t cullingGroupsX = (std::max)(1u, (constants.m_numInstances + RHI::Renderer::GPUCullingGroupSize - 1u) / RHI::Renderer::GPUCullingGroupSize);
+				commands->Dispatch(transferCmdList, computeCullingShader, cullingGroupsX, 1, 1, cullingDistpatchBindings, &constants, sizeof(constants));
+
+				commands->MemoryBarrier(transferCmdList,
+					static_cast<EAccessFlags>(EAccessBit::ShaderWrite_Bit),
+					shaderReadWrite);
+
+				constants.m_phase = 1;
+				const uint32_t compactionGroupsX = (std::max)(1u, (constants.m_numBatches + RHI::Renderer::GPUCullingGroupSize - 1u) / RHI::Renderer::GPUCullingGroupSize);
+				commands->Dispatch(transferCmdList, computeCullingShader, compactionGroupsX, 1, 1, cullingDistpatchBindings, &constants, sizeof(constants));
 				commands->EndDebugRegion(transferCmdList);
 			};
 
@@ -238,10 +275,12 @@ namespace Sailor::RHI
 		{
 			recordCullingDispatch();
 		}
+
+		return stats;
 	}
 
 	template<typename TPerInstanceData>
-	void RHIRecordDrawCall(uint32_t start,
+	DrawCallStats RHIRecordDrawCall(uint32_t start,
 		uint32_t end,
 		const TVector<RHIBatch>& vecBatches,
 		RHI::RHICommandListPtr cmdList,
@@ -256,6 +295,7 @@ namespace Sailor::RHI
 		std::mutex* transferCommandListMutex = nullptr)
 	{
 		SAILOR_PROFILE_FUNCTION();
+		DrawCallStats stats;
 
 		auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 		auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
@@ -333,6 +373,7 @@ namespace Sailor::RHI
 				drawIndirect.Emplace(std::move(data));
 
 				ssboOffset += (uint32_t)matrices.Num();
+				stats.m_numInstances += (uint32_t)matrices.Num();
 			}
 
 			const size_t bufferSize = sizeof(RHI::DrawIndexedIndirectData) * drawIndirect.Num();
@@ -346,13 +387,16 @@ namespace Sailor::RHI
 				commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
 			}
 			commands->DrawIndexedIndirect(cmdList, indirectCommandBuffer, indirectBufferOffset, (uint32_t)drawIndirect.Num(), sizeof(RHI::DrawIndexedIndirectData));
+			stats.m_numBatches++;
 
 			indirectBufferOffset += bufferSize;
 		}
+
+		return stats;
 	}
 
 	template<typename TPerInstanceData>
-	void RHIDrawCall(uint32_t start,
+	DrawCallStats RHIDrawCall(uint32_t start,
 		uint32_t end,
 		const TVector<RHIBatch>& vecBatches,
 		RHI::RHICommandListPtr cmdList,
@@ -364,6 +408,7 @@ namespace Sailor::RHI
 		glm::vec2 depthRange = glm::vec2(0.0f, 1.0f))
 	{
 		SAILOR_PROFILE_FUNCTION();
+		DrawCallStats stats;
 
 		auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
 
@@ -377,6 +422,10 @@ namespace Sailor::RHI
 			auto& material = vecBatches[j].m_material;
 			auto& mesh = vecBatches[j].m_mesh;
 			auto& drawCall = drawCalls[vecBatches[j]];
+			for (const auto& instancedDrawCall : drawCall)
+			{
+				stats.m_numInstances += (uint32_t)instancedDrawCall.Second()->Num();
+			}
 
 			if (prevMaterial != material)
 			{
@@ -409,8 +458,11 @@ namespace Sailor::RHI
 
 			const size_t bufferSize = sizeof(RHI::DrawIndexedIndirectData) * drawCall.Num();
 			commands->DrawIndexedIndirect(cmdList, indirectCommandBuffer, indirectBufferOffset, (uint32_t)drawCall.Num(), sizeof(RHI::DrawIndexedIndirectData));
+			stats.m_numBatches++;
 
 			indirectBufferOffset += bufferSize;
 		}
+
+		return stats;
 	}
 };

--- a/Runtime/RHI/Batch.hpp
+++ b/Runtime/RHI/Batch.hpp
@@ -8,6 +8,7 @@
 #include "RHI/Texture.h"
 #include "RHI/RenderTarget.h"
 #include <limits>
+#include <mutex>
 
 using namespace GraphicsDriver::Vulkan;
 
@@ -71,7 +72,8 @@ namespace Sailor::RHI
 		glm::vec2 depthRange,
 		RHIShaderPtr computeCullingShader,
 		RHIShaderBindingSetPtr& indirectCommandBufferBinding,
-		const TVector<RHIShaderBindingSetPtr>& cullingDistpatchBindings)
+		const TVector<RHIShaderBindingSetPtr>& cullingDistpatchBindings,
+		std::mutex* transferCommandListMutex = nullptr)
 	{
 		SAILOR_PROFILE_FUNCTION();
 
@@ -163,7 +165,15 @@ namespace Sailor::RHI
 				}
 
 				const size_t bufferSize = sizeof(RHI::DrawIndexedIndirectData) * drawIndirect.Num();
-				commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
+				if (transferCommandListMutex)
+				{
+					std::lock_guard<std::mutex> transferCommandListLock(*transferCommandListMutex);
+					commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
+				}
+				else
+				{
+					commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
+				}
 				commands->DrawIndexedIndirect(graphicsCmdList, indirectCommandBuffer, indirectBufferOffset, (uint32_t)drawIndirect.Num(), sizeof(RHI::DrawIndexedIndirectData));
 				indirectBufferOffset += bufferSize;
 				drawIndirect.Clear();
@@ -210,13 +220,24 @@ namespace Sailor::RHI
 		constants.m_numInstances = totalNumInstances;
 		constants.m_firstInstanceIndex = firstInstanceIndex;
 
-		commands->BeginDebugRegion(transferCmdList, "GPU Culling", DebugContext::Color_CmdCompute);
+		auto recordCullingDispatch = [&]()
+			{
+				commands->BeginDebugRegion(transferCmdList, "GPU Culling", DebugContext::Color_CmdCompute);
+				const uint32_t maxWorkItems = (std::max)(constants.m_numBatches, constants.m_numInstances);
+				const uint32_t dispatchGroupsX = (std::max)(1u, (maxWorkItems + RHI::Renderer::GPUCullingGroupSize - 1u) / RHI::Renderer::GPUCullingGroupSize);
+				commands->Dispatch(transferCmdList, computeCullingShader, dispatchGroupsX, 1, 1, cullingDistpatchBindings, &constants, sizeof(constants));
+				commands->EndDebugRegion(transferCmdList);
+			};
+
+		if (transferCommandListMutex)
 		{
-			const uint32_t maxWorkItems = (std::max)(constants.m_numBatches, constants.m_numInstances);
-			const uint32_t dispatchGroupsX = (std::max)(1u, (maxWorkItems + RHI::Renderer::GPUCullingGroupSize - 1u) / RHI::Renderer::GPUCullingGroupSize);
-			commands->Dispatch(transferCmdList, computeCullingShader, dispatchGroupsX, 1, 1, cullingDistpatchBindings, &constants, sizeof(constants));
+			std::lock_guard<std::mutex> transferCommandListLock(*transferCommandListMutex);
+			recordCullingDispatch();
 		}
-		commands->EndDebugRegion(transferCmdList);
+		else
+		{
+			recordCullingDispatch();
+		}
 	}
 
 	template<typename TPerInstanceData>
@@ -231,7 +252,8 @@ namespace Sailor::RHI
 		RHIBufferPtr& indirectCommandBuffer,
 		glm::ivec4 viewport,
 		glm::uvec4 scissors,
-		glm::vec2 depthRange = glm::vec2(0.0f, 1.0f))
+		glm::vec2 depthRange = glm::vec2(0.0f, 1.0f),
+		std::mutex* transferCommandListMutex = nullptr)
 	{
 		SAILOR_PROFILE_FUNCTION();
 
@@ -314,7 +336,15 @@ namespace Sailor::RHI
 			}
 
 			const size_t bufferSize = sizeof(RHI::DrawIndexedIndirectData) * drawIndirect.Num();
-			commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
+			if (transferCommandListMutex)
+			{
+				std::lock_guard<std::mutex> transferCommandListLock(*transferCommandListMutex);
+				commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
+			}
+			else
+			{
+				commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
+			}
 			commands->DrawIndexedIndirect(cmdList, indirectCommandBuffer, indirectBufferOffset, (uint32_t)drawIndirect.Num(), sizeof(RHI::DrawIndexedIndirectData));
 
 			indirectBufferOffset += bufferSize;

--- a/Runtime/RHI/Batch.hpp
+++ b/Runtime/RHI/Batch.hpp
@@ -1,4 +1,5 @@
 #pragma once
+#include "Core/SpinLock.h"
 #include "Containers/Map.h"
 #include "RHI/Types.h"
 #include "RHI/VertexDescription.h"
@@ -8,7 +9,6 @@
 #include "RHI/Texture.h"
 #include "RHI/RenderTarget.h"
 #include <limits>
-#include <mutex>
 
 using namespace GraphicsDriver::Vulkan;
 
@@ -73,7 +73,7 @@ namespace Sailor::RHI
 		RHIShaderPtr computeCullingShader,
 		RHIShaderBindingSetPtr& indirectCommandBufferBinding,
 		const TVector<RHIShaderBindingSetPtr>& cullingDistpatchBindings,
-		std::mutex* transferCommandListMutex = nullptr)
+		SpinLock* transferCommandListLock = nullptr)
 	{
 		SAILOR_PROFILE_FUNCTION();
 		DrawCallStats stats;
@@ -184,10 +184,11 @@ namespace Sailor::RHI
 				}
 
 				const size_t bufferSize = sizeof(RHI::DrawIndexedIndirectData) * drawIndirect.Num();
-				if (transferCommandListMutex)
+				if (transferCommandListLock)
 				{
-					std::lock_guard<std::mutex> transferCommandListLock(*transferCommandListMutex);
+					transferCommandListLock->Lock();
 					commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
+					transferCommandListLock->Unlock();
 				}
 				else
 				{
@@ -271,10 +272,11 @@ namespace Sailor::RHI
 				commands->EndDebugRegion(transferCmdList);
 			};
 
-		if (transferCommandListMutex)
+		if (transferCommandListLock)
 		{
-			std::lock_guard<std::mutex> transferCommandListLock(*transferCommandListMutex);
+			transferCommandListLock->Lock();
 			recordCullingDispatch();
+			transferCommandListLock->Unlock();
 		}
 		else
 		{
@@ -298,7 +300,7 @@ namespace Sailor::RHI
 		glm::uvec4 scissors,
 		glm::vec2 depthRange = glm::vec2(0.0f, 1.0f),
 		RHIShaderBindingSetPtr* indirectCommandBufferBinding = nullptr,
-		std::mutex* transferCommandListMutex = nullptr)
+		SpinLock* transferCommandListLock = nullptr)
 	{
 		SAILOR_PROFILE_FUNCTION();
 		DrawCallStats stats;
@@ -400,10 +402,11 @@ namespace Sailor::RHI
 			}
 
 			const size_t bufferSize = sizeof(RHI::DrawIndexedIndirectData) * drawIndirect.Num();
-			if (transferCommandListMutex)
+			if (transferCommandListLock)
 			{
-				std::lock_guard<std::mutex> transferCommandListLock(*transferCommandListMutex);
+				transferCommandListLock->Lock();
 				commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
+				transferCommandListLock->Unlock();
 			}
 			else
 			{

--- a/Runtime/RHI/Batch.hpp
+++ b/Runtime/RHI/Batch.hpp
@@ -114,6 +114,7 @@ namespace Sailor::RHI
 		}
 
 		RHIMaterialPtr prevMaterial = nullptr;
+		RHIShaderBindingSetPtr prevTextureBindings = nullptr;
 		RHIBufferPtr prevVertexBuffer = nullptr;
 		RHIBufferPtr prevIndexBuffer = nullptr;
 
@@ -134,10 +135,10 @@ namespace Sailor::RHI
 			auto& mesh = vecBatches[j].m_mesh;
 			auto& drawCall = drawCalls[vecBatches[j]];
 
-			if (prevMaterial != material)
+			const bool bMaterialChanged = prevMaterial != material;
+			const bool bTextureBindingsChanged = prevTextureBindings != vecBatches[j].m_textureBindings;
+			if (bMaterialChanged)
 			{
-				TVector<RHIShaderBindingSetPtr> sets = shaderBindings(vecBatches[j]);
-
 				commands->BindMaterial(graphicsCmdList, material);
 				commands->SetViewport(graphicsCmdList, (float)viewport.x, (float)viewport.y,
 					(float)viewport.z,
@@ -146,9 +147,13 @@ namespace Sailor::RHI
 					glm::vec2(scissors.z, scissors.w),
 					depthRange.x,
 					depthRange.y);
-
-				commands->BindShaderBindings(graphicsCmdList, material, sets);
 				prevMaterial = material;
+			}
+			if (bMaterialChanged || bTextureBindingsChanged)
+			{
+				TVector<RHIShaderBindingSetPtr> sets = shaderBindings(vecBatches[j]);
+				commands->BindShaderBindings(graphicsCmdList, material, sets);
+				prevTextureBindings = vecBatches[j].m_textureBindings;
 			}
 
 			if (prevVertexBuffer != mesh->m_vertexBuffer)
@@ -292,6 +297,7 @@ namespace Sailor::RHI
 		glm::ivec4 viewport,
 		glm::uvec4 scissors,
 		glm::vec2 depthRange = glm::vec2(0.0f, 1.0f),
+		RHIShaderBindingSetPtr* indirectCommandBufferBinding = nullptr,
 		std::mutex* transferCommandListMutex = nullptr)
 	{
 		SAILOR_PROFILE_FUNCTION();
@@ -312,9 +318,22 @@ namespace Sailor::RHI
 
 			indirectCommandBuffer.Clear();
 			indirectCommandBuffer = driver->CreateIndirectBuffer(indirectBufferSize + slack);
+
+			// The same indirect buffer is used by the optional GPU-culling path.
+			// Keep its storage descriptor synchronized when streaming adds enough
+			// draw calls to grow the buffer while culling is temporarily unavailable.
+			if (indirectCommandBufferBinding && *indirectCommandBufferBinding)
+			{
+				driver->AddBufferToShaderBindings(
+					*indirectCommandBufferBinding,
+					indirectCommandBuffer,
+					"drawIndexedIndirect",
+					0);
+			}
 		}
 
 		RHIMaterialPtr prevMaterial = nullptr;
+		RHIShaderBindingSetPtr prevTextureBindings = nullptr;
 		RHIBufferPtr prevVertexBuffer = nullptr;
 		RHIBufferPtr prevIndexBuffer = nullptr;
 
@@ -325,10 +344,10 @@ namespace Sailor::RHI
 			auto& mesh = vecBatches[j].m_mesh;
 			auto& drawCall = drawCalls[vecBatches[j]];
 
-			if (prevMaterial != material)
+			const bool bMaterialChanged = prevMaterial != material;
+			const bool bTextureBindingsChanged = prevTextureBindings != vecBatches[j].m_textureBindings;
+			if (bMaterialChanged)
 			{
-				TVector<RHIShaderBindingSetPtr> sets = shaderBindings(vecBatches[j]);
-
 				commands->BindMaterial(cmdList, material);
 				commands->SetViewport(cmdList, (float)viewport.x, (float)viewport.y,
 					(float)viewport.z,
@@ -337,9 +356,13 @@ namespace Sailor::RHI
 					glm::vec2(scissors.z, scissors.w),
 					depthRange.x,
 					depthRange.y);
-
-				commands->BindShaderBindings(cmdList, material, sets);
 				prevMaterial = material;
+			}
+			if (bMaterialChanged || bTextureBindingsChanged)
+			{
+				TVector<RHIShaderBindingSetPtr> sets = shaderBindings(vecBatches[j]);
+				commands->BindShaderBindings(cmdList, material, sets);
+				prevTextureBindings = vecBatches[j].m_textureBindings;
 			}
 
 			if (prevVertexBuffer != mesh->m_vertexBuffer)
@@ -413,6 +436,7 @@ namespace Sailor::RHI
 		auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
 
 		RHIMaterialPtr prevMaterial = nullptr;
+		RHIShaderBindingSetPtr prevTextureBindings = nullptr;
 		RHIBufferPtr prevVertexBuffer = nullptr;
 		RHIBufferPtr prevIndexBuffer = nullptr;
 
@@ -427,10 +451,10 @@ namespace Sailor::RHI
 				stats.m_numInstances += (uint32_t)instancedDrawCall.Second()->Num();
 			}
 
-			if (prevMaterial != material)
+			const bool bMaterialChanged = prevMaterial != material;
+			const bool bTextureBindingsChanged = prevTextureBindings != vecBatches[j].m_textureBindings;
+			if (bMaterialChanged)
 			{
-				TVector<RHIShaderBindingSetPtr> sets = shaderBindings(vecBatches[j]);
-
 				commands->BindMaterial(cmdList, material);
 				commands->SetViewport(cmdList, (float)viewport.x, (float)viewport.y,
 					(float)viewport.z,
@@ -439,9 +463,13 @@ namespace Sailor::RHI
 					glm::vec2(scissors.z, scissors.w),
 					depthRange.x,
 					depthRange.y);
-
-				commands->BindShaderBindings(cmdList, material, sets);
 				prevMaterial = material;
+			}
+			if (bMaterialChanged || bTextureBindingsChanged)
+			{
+				TVector<RHIShaderBindingSetPtr> sets = shaderBindings(vecBatches[j]);
+				commands->BindShaderBindings(cmdList, material, sets);
+				prevTextureBindings = vecBatches[j].m_textureBindings;
 			}
 
 			if (prevVertexBuffer != mesh->m_vertexBuffer)

--- a/Runtime/RHI/Buffer.h
+++ b/Runtime/RHI/Buffer.h
@@ -10,7 +10,7 @@ namespace Sailor::RHI
 	public:
 
 		RHIBuffer(EBufferUsageFlags usage, EMemoryPropertyFlags memoryProperty) : m_usage(usage), m_memoryProperty(memoryProperty) {}
-		virtual ~RHIBuffer();
+		SAILOR_API virtual ~RHIBuffer();
 
 #if defined(SAILOR_BUILD_WITH_VULKAN)
 		using VulkanBufferAllocator = TBlockAllocator<Sailor::Memory::GlobalVulkanBufferAllocator, VulkanBufferMemoryPtr>;

--- a/Runtime/RHI/CommandList.h
+++ b/Runtime/RHI/CommandList.h
@@ -23,9 +23,16 @@ namespace Sailor::RHI
 		RHI::ECommandListQueue GetQueue() const { return m_queue; }
 		SAILOR_API uint32_t GetGPUCost() const;
 		SAILOR_API uint32_t GetNumRecordedCommands() const;
+		SAILOR_API DrawCallStats GetRecordedDrawCallStats() const { return m_recordedDrawCallStats; }
+		SAILOR_API void RecordDrawCallStats(uint32_t numInstances)
+		{
+			m_recordedDrawCallStats.m_numBatches++;
+			m_recordedDrawCallStats.m_numInstances += numInstances;
+		}
 
 	protected:
 
 		RHI::ECommandListQueue m_queue = RHI::ECommandListQueue::Graphics;
+		DrawCallStats m_recordedDrawCallStats{};
 	};
 };

--- a/Runtime/RHI/DebugContext.cpp
+++ b/Runtime/RHI/DebugContext.cpp
@@ -379,20 +379,51 @@ void DebugContext::UpdateDebugMesh(RHI::RHICommandListPtr transferCmdList)
 	m_bShouldUpdateMeshThisFrame = false;
 }
 
+DebugContext::DrawSnapshot DebugContext::GetDrawSnapshot() const
+{
+	DrawSnapshot snapshot;
+	if (m_numRenderedVertices == 0 ||
+		!m_cachedMesh ||
+		!m_cachedMesh->IsReady() ||
+		!m_cachedMesh->m_vertexBuffer ||
+		!m_cachedMesh->m_indexBuffer ||
+		!m_material)
+	{
+		return snapshot;
+	}
+
+	snapshot.m_vertexBuffer = m_cachedMesh->m_vertexBuffer;
+	snapshot.m_indexBuffer = m_cachedMesh->m_indexBuffer;
+	snapshot.m_material = m_material;
+	snapshot.m_numVertices = m_numRenderedVertices;
+	return snapshot;
+}
+
 void DebugContext::DrawDebugMesh(RHI::RHICommandListPtr secondaryDrawCmdList, const glm::mat4x4& viewProjection) const
 {
-	if (m_numRenderedVertices == 0 || !m_cachedMesh || !m_cachedMesh->IsReady())
+	DrawDebugMesh(secondaryDrawCmdList, viewProjection, GetDrawSnapshot());
+}
+
+void DebugContext::DrawDebugMesh(
+	RHI::RHICommandListPtr secondaryDrawCmdList,
+	const glm::mat4x4& viewProjection,
+	const DrawSnapshot& snapshot) const
+{
+	if (!snapshot.m_vertexBuffer ||
+		!snapshot.m_indexBuffer ||
+		!snapshot.m_material ||
+		snapshot.m_numVertices == 0)
 	{
 		return;
 	}
 
 	auto commands = RHI::Renderer::GetDriverCommands();
 
-	commands->BindMaterial(secondaryDrawCmdList, m_material);
+	commands->BindMaterial(secondaryDrawCmdList, snapshot.m_material);
 	commands->SetDefaultViewport(secondaryDrawCmdList);
-	commands->BindVertexBuffer(secondaryDrawCmdList, m_cachedMesh->m_vertexBuffer, m_cachedMesh->m_vertexBuffer->GetOffset());
-	commands->BindIndexBuffer(secondaryDrawCmdList, m_cachedMesh->m_indexBuffer, m_cachedMesh->m_indexBuffer->GetOffset());
-	commands->PushConstants(secondaryDrawCmdList, m_material, sizeof(viewProjection), &viewProjection);
+	commands->BindVertexBuffer(secondaryDrawCmdList, snapshot.m_vertexBuffer, snapshot.m_vertexBuffer->GetOffset());
+	commands->BindIndexBuffer(secondaryDrawCmdList, snapshot.m_indexBuffer, snapshot.m_indexBuffer->GetOffset());
+	commands->PushConstants(secondaryDrawCmdList, snapshot.m_material, sizeof(viewProjection), &viewProjection);
 	//commands->BindShaderBindings(secondaryDrawCmdList, m_material, { frameBindings /*m_material->GetBindings()*/ });
-	commands->DrawIndexed(secondaryDrawCmdList, (uint32_t)m_numRenderedVertices, 1, 0, 0, 0);
+	commands->DrawIndexed(secondaryDrawCmdList, snapshot.m_numVertices, 1, 0, 0, 0);
 }

--- a/Runtime/RHI/DebugContext.cpp
+++ b/Runtime/RHI/DebugContext.cpp
@@ -160,26 +160,22 @@ void DebugContext::DrawFrustum(const Math::Frustum& frustum, const glm::vec4 col
 void DebugContext::DrawLightCascades(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float duration)
 {	
 	TVector<Math::Frustum> cascades;
-	Math::Frustum cameraFrustum{};
-
-	cameraFrustum.ExtractFrustumPlanes(cameraWorld, aspect, fovY, zNear, zFar * LightingECS::ShadowCascadeLevels[0]);
-	cascades.Add(cameraFrustum);
-
-	cameraFrustum.ExtractFrustumPlanes(cameraWorld, aspect, fovY,
-		zFar * LightingECS::ShadowCascadeLevels[0],
-		zFar * LightingECS::ShadowCascadeLevels[1]);
-	cascades.Add(cameraFrustum);
-
-	cameraFrustum.ExtractFrustumPlanes(cameraWorld, aspect, fovY,
-		zFar * LightingECS::ShadowCascadeLevels[1],
-		zFar * LightingECS::ShadowCascadeLevels[2]);
-	cascades.Add(cameraFrustum);
+	cascades.Reserve(LightingECS::NumCascades);
+	for (uint32_t i = 0; i < LightingECS::NumCascades; i++)
+	{
+		Math::Frustum cameraFrustum{};
+		const float cascadeNear = i == 0 ? zNear : zFar * LightingECS::ShadowCascadeLevels[i - 1];
+		const float cascadeFar = zFar * LightingECS::ShadowCascadeLevels[i];
+		cameraFrustum.ExtractFrustumPlanes(cameraWorld, aspect, fovY, cascadeNear, cascadeFar);
+		cascades.Emplace(std::move(cameraFrustum));
+	}
 
 	constexpr float zMult = 10.0f;
 
 	TVector<glm::vec4> colors{ glm::vec4(1.0f, 0.0f, 0.5f, 1.0f),
 		glm::vec4(0.7f, 0.6f, 0.5f, 1.0f),
-		glm::vec4(1.0f, 0.10f, 0.25f, 1.0f) };
+		glm::vec4(1.0f, 0.10f, 0.25f, 1.0f),
+		glm::vec4(0.25f, 0.55f, 1.0f, 1.0f) };
 
 	for (uint32_t i = 0; i < cascades.Num(); i++)
 	{
@@ -187,35 +183,7 @@ void DebugContext::DrawLightCascades(const glm::mat4& lightView, const glm::mat4
 
 		DrawFrustum(cascadeFrustum, glm::vec4(0, 1, 0, 1), duration);
 
-		const TVector<glm::vec3> corners = cascadeFrustum.GetCorners();
-
-		float minX = std::numeric_limits<float>::max();
-		float maxX = std::numeric_limits<float>::lowest();
-		float minY = std::numeric_limits<float>::max();
-		float maxY = std::numeric_limits<float>::lowest();
-		float minZ = std::numeric_limits<float>::max();
-		float maxZ = std::numeric_limits<float>::lowest();
-
-		for (const auto& v : corners)
-		{
-			const auto trf = lightView * glm::vec4(v, 1);
-			minX = std::min(minX, trf.x);
-			maxX = std::max(maxX, trf.x);
-			minY = std::min(minY, trf.y);
-			maxY = std::max(maxY, trf.y);
-			minZ = std::min(minZ, trf.z);
-			maxZ = std::max(maxZ, trf.z);
-		}
-
-		// TODO: Redo
-		minZ = minZ < 0 ? minZ * zMult : minZ / zMult;
-		maxZ = maxZ < 0 ? maxZ / zMult : maxZ * zMult;
-
-		const float zFar = -minZ;
-		const float zNear = -maxZ;
-
-		// Viewport settings, we want to handle all shadows with the reversed Z
-		const glm::mat4 lightProjection = glm::orthoRH_NO(minX, maxX, minY, maxY, zFar, zNear);
+		const glm::mat4 lightProjection = cascadeFrustum.CalculateOrthoMatrixByView(lightView, zMult);
 
 		// Create matrix and get all extents
 		const glm::mat4 lightViewProjection = lightProjection * lightView;
@@ -223,10 +191,10 @@ void DebugContext::DrawLightCascades(const glm::mat4& lightView, const glm::mat4
 
 		TVector<glm::vec3> orthoCorners;
 
-		orthoCorners.Add(invLightViewProjection * glm::vec4(-1,  1, -1, 1));
-		orthoCorners.Add(invLightViewProjection * glm::vec4( 1,  1, -1, 1));
-		orthoCorners.Add(invLightViewProjection * glm::vec4(1, -1, -1, 1));
-		orthoCorners.Add(invLightViewProjection * glm::vec4(-1, -1, -1, 1));
+		orthoCorners.Add(invLightViewProjection * glm::vec4(-1,  1, 0, 1));
+		orthoCorners.Add(invLightViewProjection * glm::vec4( 1,  1, 0, 1));
+		orthoCorners.Add(invLightViewProjection * glm::vec4(1, -1, 0, 1));
+		orthoCorners.Add(invLightViewProjection * glm::vec4(-1, -1, 0, 1));
 
 		orthoCorners.Add(invLightViewProjection * glm::vec4(-1,  1, 1, 1));
 		orthoCorners.Add(invLightViewProjection * glm::vec4( 1,  1, 1, 1));		

--- a/Runtime/RHI/DebugContext.h
+++ b/Runtime/RHI/DebugContext.h
@@ -25,6 +25,13 @@ namespace Sailor::RHI
 	class DebugContext
 	{
 	public:
+		struct DrawSnapshot
+		{
+			RHIBufferPtr m_vertexBuffer{};
+			RHIBufferPtr m_indexBuffer{};
+			RHIMaterialPtr m_material{};
+			uint32_t m_numVertices = 0;
+		};
 
 		static constexpr glm::vec4 Color_Inactive = glm::vec4(0.66f, 0.66f, 0.66f, 0.66f);
 		static constexpr glm::vec4 Color_CmdTransfer = glm::vec4(0.85f, 0.85f, 1.0f, 0.85f);
@@ -43,7 +50,9 @@ namespace Sailor::RHI
 		SAILOR_API void DrawLightCascades(const glm::mat4& lightView, const glm::mat4& cameraWorldTransform, float aspect, float fovY, float zNear, float zFar, float duration = 0.0f);
 		SAILOR_API void DrawPlane(const Math::Plane& plane, float size, const glm::vec4 color = { 0.0f, 1.0f, 0.3f, 0.0f }, float duration = 0.0f);
 		SAILOR_API void Tick(RHI::RHICommandListPtr transferCmd, float deltaTime);
+		SAILOR_API DrawSnapshot GetDrawSnapshot() const;
 		SAILOR_API void DrawDebugMesh(RHI::RHICommandListPtr secondaryDrawCmdList, const glm::mat4x4& viewProjection) const;
+		SAILOR_API void DrawDebugMesh(RHI::RHICommandListPtr secondaryDrawCmdList, const glm::mat4x4& viewProjection, const DrawSnapshot& snapshot) const;
 
 	protected:
 

--- a/Runtime/RHI/GraphicsDriver.cpp
+++ b/Runtime/RHI/GraphicsDriver.cpp
@@ -7,12 +7,21 @@
 #include "Mesh.h"
 #include "VertexDescription.h"
 #include "Tasks/Scheduler.h"
+#include "Core/LogMacros.h"
 
 using namespace Sailor;
 using namespace Sailor::RHI;
 
 void IGraphicsDriver::UpdateMesh(RHI::RHIMeshPtr mesh, const void* pVertices, size_t vertexBuffer, const void* pIndices, size_t indexBuffer)
 {
+	if (!mesh || pVertices == nullptr || vertexBuffer == 0 ||
+		pIndices == nullptr || indexBuffer == 0)
+	{
+		SAILOR_LOG_ERROR(
+			"IGraphicsDriver::UpdateMesh: refusing an empty mesh upload.");
+		return;
+	}
+
 	const VkDeviceSize bufferSize = vertexBuffer;
 	const VkDeviceSize indexBufferSize = indexBuffer;
 
@@ -83,11 +92,11 @@ void IGraphicsDriver::TrackDelayedInitialization(IDelayedInitialization* pResour
 {
 	auto resource = dynamic_cast<RHIResource*>(pResource);
 
+	// Publish the dependency before the fence can visit the resource.
+	pResource->AddDependency(handle);
+
 	// Fence should notify res, when cmd list is finished
 	handle->AddObservable(resource);
-
-	// Res should hold fences to track dependencies
-	pResource->AddDependency(handle);
 }
 
 void IGraphicsDriver::TrackPendingCommandList_ThreadSafe(RHIFencePtr handle)
@@ -105,8 +114,14 @@ void IGraphicsDriver::SubmitCommandList_Immediate(RHICommandListPtr commandList)
 	RHIFencePtr fence = RHIFencePtr::Make();
 	RHI::Renderer::GetDriver()->SetDebugName(fence, "SubmitCommandList_Immediate");
 
-	SubmitCommandList(commandList, fence);
-	fence->Wait();
+	if (SubmitCommandList(commandList, fence))
+	{
+		fence->Wait();
+	}
+	else
+	{
+		SAILOR_LOG_ERROR("IGraphicsDriver::SubmitCommandList_Immediate: command list submission failed.");
+	}
 }
 
 RHIVertexDescriptionPtr& IGraphicsDriver::GetOrAddVertexDescription(VertexAttributeBits bits)

--- a/Runtime/RHI/GraphicsDriver.h
+++ b/Runtime/RHI/GraphicsDriver.h
@@ -149,7 +149,7 @@ namespace Sailor::RHI
 		SAILOR_API virtual RHIMaterialPtr CreateMaterial(const RHI::RHIVertexDescriptionPtr& vertexDescription, RHI::EPrimitiveTopology topology, const RHI::RenderState& renderState, const Sailor::ShaderSetPtr& shader) = 0;
 		SAILOR_API virtual RHIMaterialPtr CreateMaterial(const RHI::RHIVertexDescriptionPtr& vertexDescription, RHI::EPrimitiveTopology topology, const RHI::RenderState& renderState, const Sailor::ShaderSetPtr& shader, const RHI::RHIShaderBindingSetPtr& shaderBindigs) = 0;
 
-		SAILOR_API virtual void SubmitCommandList(RHICommandListPtr commandList, RHIFencePtr fence = nullptr, RHISemaphorePtr signalSemaphore = nullptr, RHISemaphorePtr waitSemaphore = nullptr) = 0;
+		SAILOR_API virtual bool SubmitCommandList(RHICommandListPtr commandList, RHIFencePtr fence = nullptr, RHISemaphorePtr signalSemaphore = nullptr, RHISemaphorePtr waitSemaphore = nullptr) = 0;
 
 		// Shader binding set
 		SAILOR_API virtual RHIShaderBindingSetPtr CreateShaderBindings() = 0;

--- a/Runtime/RHI/Material.h
+++ b/Runtime/RHI/Material.h
@@ -39,6 +39,8 @@ namespace Sailor::RHI
 		SAILOR_API void RecalculateCompatibility();
 		SAILOR_API uint64_t GetDescriptorRevision() const { return m_descriptorRevision.load(std::memory_order_acquire); }
 		SAILOR_API void AdvanceDescriptorRevision() { m_descriptorRevision.fetch_add(1, std::memory_order_release); }
+		SAILOR_API uint32_t GetVariableDescriptorCount() const { return m_variableDescriptorCount.load(std::memory_order_acquire); }
+		SAILOR_API void SetVariableDescriptorCount(uint32_t count) { m_variableDescriptorCount.store(count, std::memory_order_release); }
 
 	protected:
 
@@ -49,6 +51,7 @@ namespace Sailor::RHI
 		bool m_bNeedsStorageBuffer = false;
 		size_t m_compatibilityHashCode = 0;
 		std::atomic<uint64_t> m_descriptorRevision{ 0 };
+		std::atomic<uint32_t> m_variableDescriptorCount{ 0 };
 	};
 
 	class RHIMaterial : public RHIResource

--- a/Runtime/RHI/Material.h
+++ b/Runtime/RHI/Material.h
@@ -4,6 +4,7 @@
 #include "Containers/Map.h"
 #include "GraphicsDriver/Vulkan/VulkanApi.h"
 #include "GraphicsDriver/Vulkan/VulkanPipeline.h"
+#include <atomic>
 
 namespace Sailor::RHI
 {
@@ -36,6 +37,8 @@ namespace Sailor::RHI
 
 		SAILOR_API size_t GetCompatibilityHashCode() const { return m_compatibilityHashCode; }
 		SAILOR_API void RecalculateCompatibility();
+		SAILOR_API uint64_t GetDescriptorRevision() const { return m_descriptorRevision.load(std::memory_order_acquire); }
+		SAILOR_API void AdvanceDescriptorRevision() { m_descriptorRevision.fetch_add(1, std::memory_order_release); }
 
 	protected:
 
@@ -45,6 +48,7 @@ namespace Sailor::RHI
 		TConcurrentMap<std::string, RHI::RHIShaderBindingPtr> m_shaderBindings;
 		bool m_bNeedsStorageBuffer = false;
 		size_t m_compatibilityHashCode = 0;
+		std::atomic<uint64_t> m_descriptorRevision{ 0 };
 	};
 
 	class RHIMaterial : public RHIResource

--- a/Runtime/RHI/Mesh.cpp
+++ b/Runtime/RHI/Mesh.cpp
@@ -13,7 +13,7 @@ bool RHIMesh::IsReady() const
 {
 	return m_vertexBuffer && m_indexBuffer && 
 		m_vertexBuffer->GetSize() > 0 && m_indexBuffer->GetSize() > 0 
-		&& m_dependencies.Num() == 0;
+		&& IDelayedInitialization::IsReady();
 }
 
 uint32_t RHIMesh::GetIndexCount() const
@@ -29,4 +29,18 @@ uint32_t RHIMesh::GetFirstIndex() const
 uint32_t RHIMesh::GetVertexOffset() const
 {
 	return m_vertexBuffer->GetOffset() / (uint32_t)m_vertexDescription->GetVertexStride();
+}
+
+size_t RHIMesh::ResolveMaterialIndex(
+	size_t meshIndex,
+	size_t numMaterials) const
+{
+	if (numMaterials == 0)
+	{
+		return (std::numeric_limits<size_t>::max)();
+	}
+
+	return m_materialIndex < numMaterials ?
+		static_cast<size_t>(m_materialIndex) :
+		(std::min)(meshIndex, numMaterials - 1);
 }

--- a/Runtime/RHI/Mesh.h
+++ b/Runtime/RHI/Mesh.h
@@ -24,6 +24,7 @@ namespace Sailor::RHI
 		RHIVertexDescriptionPtr m_vertexDescription{};
 		Math::AABB m_bounds{};
 		uint32_t m_materialIndex = (std::numeric_limits<uint32_t>::max)();
+		glm::vec3 m_bakedVolumeScale{ 1.0f };
 
 		SAILOR_API virtual bool IsReady() const override;
 

--- a/Runtime/RHI/Mesh.h
+++ b/Runtime/RHI/Mesh.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <limits>
+
 #include "Memory/RefPtr.hpp"
 #include "Types.h"
 #include "Math/Math.h"
@@ -13,11 +15,15 @@ namespace Sailor::RHI
 		SAILOR_API uint32_t GetIndexCount() const;
 		SAILOR_API uint32_t GetFirstIndex() const;
 		SAILOR_API uint32_t GetVertexOffset() const;
+		SAILOR_API size_t ResolveMaterialIndex(
+			size_t meshIndex,
+			size_t numMaterials) const;
 
 		RHIBufferPtr m_vertexBuffer{};
 		RHIBufferPtr m_indexBuffer{};
 		RHIVertexDescriptionPtr m_vertexDescription{};
 		Math::AABB m_bounds{};
+		uint32_t m_materialIndex = (std::numeric_limits<uint32_t>::max)();
 
 		SAILOR_API virtual bool IsReady() const override;
 

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -406,6 +406,7 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 				{
 					RHISemaphorePtr chainSemaphore{};
 					bool bFrameSubmitsSucceeded = updateFrameRHI(chainSemaphore);
+					DrawCallStats drawCallStats;
 
 					if (bFrameSubmitsSucceeded && !m_bFrameGraphOutdated && !m_pViewport->IsIconic())
 					{
@@ -429,6 +430,7 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 						else
 						{
 							chainSemaphore = frameGraphChainSemaphore;
+							drawCallStats = rhiFrameGraph->GetDrawCallStats();
 						}
 					}
 
@@ -471,14 +473,24 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 						}
 					}
 
-					if (bFrameSubmitsSucceeded && bHasSwapchainImage && m_driverInstance->PresentFrame(frame, primaryCommandLists, waitFrameUpdate))
+					bool bFrameCompleted = false;
+					if (bFrameSubmitsSucceeded)
 					{
+						bFrameCompleted = bHasSwapchainImage
+							? m_driverInstance->PresentFrame(frame, primaryCommandLists, waitFrameUpdate)
+							: App::HasEditor() && m_driverInstance->SubmitFrameWithoutPresent(primaryCommandLists, waitFrameUpdate);
+					}
+
+					if (bFrameCompleted)
+					{
+						m_stats.m_numBatches.store(drawCallStats.m_numBatches, std::memory_order_relaxed);
+						m_stats.m_numInstances.store(drawCallStats.m_numInstances, std::memory_order_relaxed);
 						totalFramesCount++;
 						timer.Stop();
 
 						if (timer.ResultAccumulatedMs() > 1000)
 						{
-							m_stats.m_gpuFps = totalFramesCount;
+							m_stats.m_gpuFps.store(totalFramesCount, std::memory_order_relaxed);
 							totalFramesCount = 0;
 							timer.Clear();
 #if defined(SAILOR_BUILD_WITH_VULKAN)
@@ -495,11 +507,9 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 					}
 					else
 					{
-						if (!bFrameSubmitsSucceeded ||
-							!(App::HasEditor() && !bHasSwapchainImage && m_driverInstance->SubmitFrameWithoutPresent(primaryCommandLists, waitFrameUpdate)))
-						{
-							m_stats.m_gpuFps = 0;
-						}
+						m_stats.m_gpuFps.store(0u, std::memory_order_relaxed);
+						m_stats.m_numBatches.store(0u, std::memory_order_relaxed);
+						m_stats.m_numInstances.store(0u, std::memory_order_relaxed);
 					}
 				}
 				else

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -33,6 +33,7 @@ void IDelayedInitialization::TraceVisit(class TRefPtr<RHIResource> visitor, bool
 	{
 		if (fence->IsFinished())
 		{
+			m_dependenciesLock.Lock();
 			auto it = std::find_if(m_dependencies.begin(), m_dependencies.end(),
 				[&fence](const auto& lhs)
 				{
@@ -45,13 +46,17 @@ void IDelayedInitialization::TraceVisit(class TRefPtr<RHIResource> visitor, bool
 				m_dependencies.RemoveLast();
 				bShouldRemoveFromList = true;
 			}
+			m_dependenciesLock.Unlock();
 		}
 	}
 }
 
 bool IDelayedInitialization::IsReady() const
 {
-	return m_dependencies.Num() == 0;
+	m_dependenciesLock.Lock();
+	const bool bIsReady = m_dependencies.IsEmpty();
+	m_dependenciesLock.Unlock();
+	return bIsReady;
 }
 
 Renderer::Renderer(Win32::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool bIsDebug)
@@ -368,34 +373,41 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 
 				TVector<RHI::RHICommandListPtr> primaryCommandLists;
 				TVector<RHI::RHICommandListPtr> transferCommandLists;
-				TVector<RHISemaphorePtr> waitFrameUpdate;
 
 				static uint32_t totalFramesCount = 0U;
 
-				auto updateFrameRHI = [&frameInstance = frameInstance, &waitFrameUpdate = waitFrameUpdate]()
+				auto updateFrameRHI = [&frameInstance = frameInstance](RHISemaphorePtr& inOutChainSemaphore)
 					{
 						SAILOR_PROFILE_SCOPE("Submit & Wait frame command lists");
 						for (uint32_t i = 0; i < frameInstance.NumCommandLists; i++)
 						{
 							if (auto pCommandList = frameInstance.GetCommandBuffer(i))
 							{
-								auto newWaitSemaphore = GetDriver()->CreateWaitSemaphore();
-								GetDriver()->SetDebugName(newWaitSemaphore, std::format("frameInstance CommandBuffer {}", i));
+								auto signalSemaphore = GetDriver()->CreateWaitSemaphore();
+								auto fence = RHIFencePtr::Make();
+								GetDriver()->SetDebugName(signalSemaphore, std::format("frameInstance CommandBuffer {}", i));
+								GetDriver()->SetDebugName(fence, std::format("frameInstance CommandBuffer {}", i));
 
-								waitFrameUpdate.Add(newWaitSemaphore);
-								GetDriver()->SubmitCommandList(pCommandList, RHIFencePtr::Make(), *(waitFrameUpdate.end() - 1));
+								if (!GetDriver()->SubmitCommandList(pCommandList, fence, signalSemaphore, inOutChainSemaphore))
+								{
+									SAILOR_LOG_ERROR("Renderer::PushFrame: failed to submit frame command buffer %u.", i);
+									return false;
+								}
+
+								inOutChainSemaphore = signalSemaphore;
 							}
 						}
+
+						return true;
 					};
 
 				const bool bHasSwapchainImage = m_driverInstance->AcquireNextImage();
 				if (bHasSwapchainImage || App::HasEditor())
 				{
 					RHISemaphorePtr chainSemaphore{};
+					bool bFrameSubmitsSucceeded = updateFrameRHI(chainSemaphore);
 
-					updateFrameRHI();
-
-					if (!m_bFrameGraphOutdated && !m_pViewport->IsIconic())
+					if (bFrameSubmitsSucceeded && !m_bFrameGraphOutdated && !m_pViewport->IsIconic())
 					{
 						if (!App::HasEditor())
 						{
@@ -403,31 +415,63 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 							rhiFrameGraph->SetRenderTarget("DepthBuffer", m_driverInstance->GetDepthBuffer());
 						}
 
-						RHISemaphorePtr signalSemaphore{};
-
-						if (waitFrameUpdate.Num() > 0)
+						RHISemaphorePtr frameGraphChainSemaphore = chainSemaphore;
+						if (!rhiFrameGraph->Process(
+							rhiSceneView,
+							transferCommandLists,
+							primaryCommandLists,
+							chainSemaphore,
+							frameGraphChainSemaphore))
 						{
-							signalSemaphore = *(waitFrameUpdate.end() - 1);
-							waitFrameUpdate.RemoveLast();
+							SAILOR_LOG_ERROR("Renderer::PushFrame: FrameGraph command buffer submission failed.");
+							bFrameSubmitsSucceeded = false;
 						}
-						rhiFrameGraph->Process(rhiSceneView, transferCommandLists, primaryCommandLists, signalSemaphore, chainSemaphore);
+						else
+						{
+							chainSemaphore = frameGraphChainSemaphore;
+						}
 					}
 
+					if (bFrameSubmitsSucceeded)
 					{
 						SAILOR_PROFILE_SCOPE("Submit transfer command lists");
-
 						uint32_t i = 0;
 						for (auto& cmdList : transferCommandLists)
 						{
-							auto newWaitSemaphore = GetDriver()->CreateWaitSemaphore();
-							GetDriver()->SetDebugName(newWaitSemaphore, std::format("rhiFrameGraph TransferCommandList {}", i++));
+							auto signalSemaphore = GetDriver()->CreateWaitSemaphore();
+							auto fence = RHIFencePtr::Make();
+							GetDriver()->SetDebugName(signalSemaphore, std::format("rhiFrameGraph TransferCommandList {}", i));
+							GetDriver()->SetDebugName(fence, std::format("rhiFrameGraph TransferCommandList {}", i));
 
-							waitFrameUpdate.AddUnique(newWaitSemaphore);
-							GetDriver()->SubmitCommandList(cmdList, RHIFencePtr::Make(), *(waitFrameUpdate.end() - 1), chainSemaphore);
+							if (!GetDriver()->SubmitCommandList(cmdList, fence, signalSemaphore, chainSemaphore))
+							{
+								SAILOR_LOG_ERROR("Renderer::PushFrame: failed to submit FrameGraph transfer command buffer %u.", i);
+								bFrameSubmitsSucceeded = false;
+								break;
+							}
+
+							chainSemaphore = signalSemaphore;
+							i++;
 						}
 					}
 
-					if (bHasSwapchainImage && m_driverInstance->PresentFrame(frame, primaryCommandLists, waitFrameUpdate))
+					TVector<RHISemaphorePtr> waitFrameUpdate;
+					if (bFrameSubmitsSucceeded && chainSemaphore)
+					{
+						waitFrameUpdate.Add(chainSemaphore);
+					}
+
+					if (!bFrameSubmitsSucceeded && bHasSwapchainImage)
+					{
+						TVector<RHICommandListPtr> noCommandLists;
+						TVector<RHISemaphorePtr> noWaitSemaphores;
+						if (!m_driverInstance->PresentFrame(frame, noCommandLists, noWaitSemaphores))
+						{
+							SAILOR_LOG_ERROR("Renderer::PushFrame: failed to release an acquired swapchain image after a submit failure.");
+						}
+					}
+
+					if (bFrameSubmitsSucceeded && bHasSwapchainImage && m_driverInstance->PresentFrame(frame, primaryCommandLists, waitFrameUpdate))
 					{
 						totalFramesCount++;
 						timer.Stop();
@@ -451,7 +495,8 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 					}
 					else
 					{
-						if (!(App::HasEditor() && !bHasSwapchainImage && m_driverInstance->SubmitFrameWithoutPresent(primaryCommandLists, waitFrameUpdate)))
+						if (!bFrameSubmitsSucceeded ||
+							!(App::HasEditor() && !bHasSwapchainImage && m_driverInstance->SubmitFrameWithoutPresent(primaryCommandLists, waitFrameUpdate)))
 						{
 							m_stats.m_gpuFps = 0;
 						}
@@ -459,7 +504,8 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 				}
 				else
 				{
-					updateFrameRHI();
+					RHISemaphorePtr chainSemaphore;
+					updateFrameRHI(chainSemaphore);
 				}
 
 				{

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -98,6 +98,7 @@ TVector<RHISceneViewProxy> RHISceneView::TraceScene(const Math::Frustum& frustum
 					viewProxy.m_meshes = ecsData.GetModel()->GetMeshes();
 					viewProxy.m_skeletonOffset = ecsData.GetSkeletonOffset();
 					viewProxy.m_overrideMaterials.Clear();
+					viewProxy.m_renderQueueTags.Clear();
 #if defined(__APPLE__)
 					viewProxy.m_materialTextureSamplers.Clear();
 #endif
@@ -107,6 +108,7 @@ TVector<RHISceneViewProxy> RHISceneView::TraceScene(const Math::Frustum& frustum
 					viewProxy.m_worldAabb.Apply(viewProxy.m_worldMatrix);
 
 					viewProxy.m_overrideMaterials.Reserve(viewProxy.m_meshes.Num());
+					viewProxy.m_renderQueueTags.Reserve(viewProxy.m_meshes.Num());
 #if defined(__APPLE__)
 					viewProxy.m_materialTextureSamplers.Reserve(viewProxy.m_meshes.Num());
 					auto textureImporter = App::GetSubmodule<TextureImporter>();
@@ -120,6 +122,7 @@ TVector<RHISceneViewProxy> RHISceneView::TraceScene(const Math::Frustum& frustum
 								i, ecsData.GetMaterials().Num());
 
 						auto& material = ecsData.GetMaterials()[materialIndex];
+						viewProxy.m_renderQueueTags.Add(material ? material->GetRenderState().GetTag() : 0u);
 						if (material && material->IsReady() && !bSkipMaterials)
 						{
 							viewProxy.m_overrideMaterials.Add(material->GetOrAddRHI(viewProxy.m_meshes[i]->m_vertexDescription));

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -17,6 +17,7 @@ using namespace Sailor::RHI;
 void RHISceneView::PrepareDebugDrawCommandLists(WorldPtr world)
 {
 	m_debugDraw.Reserve(m_cameras.Num());
+	const DebugContext::DrawSnapshot debugDrawSnapshot = world->GetDebugContext()->GetDrawSnapshot();
 
 	// TODO: Check the sync between CPUFrame and Recording
 	for (const auto& camera : m_cameras)
@@ -29,7 +30,7 @@ void RHISceneView::PrepareDebugDrawCommandLists(WorldPtr world)
 				Sailor::RHI::Renderer::GetDriver()->SetDebugName(secondaryCmdList, "Draw Debug Mesh");
 				auto commands = App::GetSubmodule<Renderer>()->GetDriverCommands();
 				commands->BeginSecondaryCommandList(secondaryCmdList, false, true);
-				world->GetDebugContext()->DrawDebugMesh(secondaryCmdList, matrix);
+				world->GetDebugContext()->DrawDebugMesh(secondaryCmdList, matrix, debugDrawSnapshot);
 				commands->EndCommandList(secondaryCmdList);
 
 				return secondaryCmdList;
@@ -114,7 +115,9 @@ TVector<RHISceneViewProxy> RHISceneView::TraceScene(const Math::Frustum& frustum
 
 					for (size_t i = 0; i < viewProxy.m_meshes.Num(); i++)
 					{
-						size_t materialIndex = (std::min)(i, ecsData.GetMaterials().Num() - 1);
+						const size_t materialIndex =
+							viewProxy.m_meshes[i]->ResolveMaterialIndex(
+								i, ecsData.GetMaterials().Num());
 
 						auto& material = ecsData.GetMaterials()[materialIndex];
 						if (material && material->IsReady() && !bSkipMaterials)

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -107,10 +107,10 @@ TVector<RHISceneViewProxy> RHISceneView::TraceScene(const Math::Frustum& frustum
 					viewProxy.m_worldAabb = ecsData.GetModel()->GetBoundsAABB();
 					viewProxy.m_worldAabb.Apply(viewProxy.m_worldMatrix);
 
-					viewProxy.m_overrideMaterials.Reserve(viewProxy.m_meshes.Num());
+					viewProxy.m_overrideMaterials.Resize(viewProxy.m_meshes.Num());
 					viewProxy.m_renderQueueTags.Reserve(viewProxy.m_meshes.Num());
 #if defined(__APPLE__)
-					viewProxy.m_materialTextureSamplers.Reserve(viewProxy.m_meshes.Num());
+					viewProxy.m_materialTextureSamplers.Resize(viewProxy.m_meshes.Num());
 					auto textureImporter = App::GetSubmodule<TextureImporter>();
 #endif
 					// TODO: Should we check AABB for each mesh in model?
@@ -123,13 +123,14 @@ TVector<RHISceneViewProxy> RHISceneView::TraceScene(const Math::Frustum& frustum
 
 						auto& material = ecsData.GetMaterials()[materialIndex];
 						viewProxy.m_renderQueueTags.Add(material ? material->GetRenderState().GetTag() : 0u);
+#if defined(__APPLE__)
+						auto& requestedTextures = viewProxy.m_materialTextureSamplers[i];
+						requestedTextures.Insert(0u);
+#endif
 						if (material && material->IsReady() && !bSkipMaterials)
 						{
-							viewProxy.m_overrideMaterials.Add(material->GetOrAddRHI(viewProxy.m_meshes[i]->m_vertexDescription));
+							viewProxy.m_overrideMaterials[i] = material->GetOrAddRHI(viewProxy.m_meshes[i]->m_vertexDescription);
 #if defined(__APPLE__)
-							TSet<uint32_t> requestedTextures;
-							requestedTextures.Insert(0u);
-
 							if (textureImporter)
 							{
 								for (const auto& sampler : material->GetSamplers())
@@ -138,8 +139,6 @@ TVector<RHISceneViewProxy> RHISceneView::TraceScene(const Math::Frustum& frustum
 									requestedTextures.Insert(textureIndex);
 								}
 							}
-
-							viewProxy.m_materialTextureSamplers.Add(std::move(requestedTextures));
 #endif
 						}
 					}

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -50,6 +50,7 @@ namespace Sailor::RHI
 
 		TVector<RHIMeshPtr> m_meshes;
 		TVector<RHIMaterialPtr> m_overrideMaterials;
+		TVector<size_t> m_renderQueueTags;
 #if defined(__APPLE__)
 		TVector<TSet<uint32_t>> m_materialTextureSamplers;
 #endif

--- a/Runtime/RHI/Shader.h
+++ b/Runtime/RHI/Shader.h
@@ -49,7 +49,15 @@ namespace Sailor::RHI
 			return 0;
 		}
 
-		SAILOR_API void SetTextureBinding(uint32_t index, RHI::RHITexturePtr textureBinding) { m_textureBinding[index] = textureBinding; }
+		SAILOR_API void SetTextureBinding(uint32_t index, RHI::RHITexturePtr textureBinding)
+		{
+			if (m_textureBinding.Num() <= index)
+			{
+				m_textureBinding.Resize(static_cast<size_t>(index) + 1);
+			}
+
+			m_textureBinding[index] = std::move(textureBinding);
+		}
 		
 		SAILOR_API void SetTextureBindings(const TVector<RHITexturePtr>& textureBinding) { m_textureBinding = textureBinding; }
 		SAILOR_API void SetLayout(const ShaderLayoutBinding& layout) { m_bindingLayout = layout; }

--- a/Runtime/RHI/Texture.cpp
+++ b/Runtime/RHI/Texture.cpp
@@ -5,6 +5,8 @@
 #include "GraphicsDriver/Vulkan/VulkanImage.h"
 #include "GraphicsDriver/Vulkan/VulkanImageView.h"
 
+#include <algorithm>
+
 using namespace Sailor;
 using namespace Sailor::RHI;
 using namespace Sailor::GraphicsDriver::Vulkan;
@@ -17,7 +19,14 @@ glm::ivec2 RHITexture::GetExtent() const
 	}
 
 	const uint32_t baseMipLevel = m_vulkan.m_imageView->m_subresourceRange.baseMipLevel;
-	return glm::vec2(m_vulkan.m_image->m_extent.width, m_vulkan.m_image->m_extent.height) / powf(2, static_cast<float>(baseMipLevel));
+	auto getMipDimension = [baseMipLevel](uint32_t baseDimension)
+		{
+			return baseMipLevel < 32u ? (std::max)(1u, baseDimension >> baseMipLevel) : 1u;
+		};
+
+	return glm::ivec2(
+		getMipDimension(m_vulkan.m_image->m_extent.width),
+		getMipDimension(m_vulkan.m_image->m_extent.height));
 }
 
 EFormat RHITexture::GetFormat() const

--- a/Runtime/RHI/Types.h
+++ b/Runtime/RHI/Types.h
@@ -802,9 +802,24 @@ namespace Sailor::RHI
 		TMap<RHI::RHITexturePtr, TMap<RHI::EImageLayout, uint32_t>> m_barriers;
 	};
 
+	struct DrawCallStats
+	{
+		uint32_t m_numBatches = 0u;
+		uint32_t m_numInstances = 0u;
+
+		DrawCallStats& operator+=(const DrawCallStats& rhs)
+		{
+			m_numBatches += rhs.m_numBatches;
+			m_numInstances += rhs.m_numInstances;
+			return *this;
+		}
+	};
+
 	struct Stats
 	{
-		uint32_t m_gpuFps;
+		std::atomic<uint32_t> m_gpuFps = 0u;
+		std::atomic<uint32_t> m_numBatches = 0u;
+		std::atomic<uint32_t> m_numInstances = 0u;
 		size_t m_gpuHeapBudget;
 		size_t m_gpuHeapUsage;
 		uint32_t m_numSubmittedCommandBuffers;

--- a/Runtime/RHI/Types.h
+++ b/Runtime/RHI/Types.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Core/Defines.h"
+#include "Core/SpinLock.h"
 #include "Memory/RefPtr.hpp"
 #include "Memory/SharedPtr.hpp"
 #include "Math/Math.h"
@@ -836,17 +837,22 @@ namespace Sailor::RHI
 
 		void AddDependency(TRefPtr<RHIResource> dependency)
 		{
+			m_dependenciesLock.Lock();
 			m_dependencies.Add(std::move(dependency));
+			m_dependenciesLock.Unlock();
 		}
 
 		void ClearDependencies()
 		{
+			m_dependenciesLock.Lock();
 			m_dependencies.Clear();
+			m_dependenciesLock.Unlock();
 		}
 
 		virtual ~IDependent() = default;
 
 	protected:
+		mutable SpinLock m_dependenciesLock;
 		TVector<TRefPtr<RHIResource>> m_dependencies;
 	};
 

--- a/Runtime/Raytracing/BVH.cpp
+++ b/Runtime/Raytracing/BVH.cpp
@@ -7,6 +7,10 @@
 #include "Math/Bounds.h"
 #include "Core/StringHash.h"
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
 using namespace Sailor;
 using namespace Sailor::Math;
 using namespace Sailor::Raytracing;
@@ -19,11 +23,11 @@ float BVH::FindBestSplitPlane(const BVHNode& node, const TVector<Math::Triangle>
 
 	const uint32_t NumBins = 8;
 
-	float bestCost = std::numeric_limits<float>::max();
+	float bestCost = std::numeric_limits<float>::infinity();
 	for (uint32_t a = 0; a < 3; a++)
 	{
 		float boundsMin = std::numeric_limits<float>::max();
-		float boundsMax = -30000000.0f;
+		float boundsMax = std::numeric_limits<float>::lowest();
 
 		for (uint32_t i = 0; i < node.m_triCount; i++)
 		{
@@ -32,18 +36,30 @@ float BVH::FindBestSplitPlane(const BVHNode& node, const TVector<Math::Triangle>
 			boundsMax = std::max(boundsMax, triangle.m_centroid[a]);
 		}
 
-		if (boundsMin == boundsMax)
+		const double boundsExtent =
+			static_cast<double>(boundsMax) - static_cast<double>(boundsMin);
+		if (!std::isfinite(boundsExtent) || boundsExtent <= 0.0)
 		{
 			continue;
 		}
 
 		Bin bin[NumBins];
-		float scale = NumBins / (boundsMax - boundsMin);
+		const double binScale = static_cast<double>(NumBins) / boundsExtent;
 		for (uint i = 0; i < node.m_triCount; i++)
 		{
 			const Math::Triangle& triangle = tris[m_triIdx[node.m_leftFirst + i]];
-			int32_t binIdx = std::min((int32_t)NumBins - 1,
-				(int32_t)((triangle.m_centroid[a] - boundsMin) * scale));
+			const double scaledCentroid =
+				(static_cast<double>(triangle.m_centroid[a]) -
+				 static_cast<double>(boundsMin)) * binScale;
+			if (!std::isfinite(scaledCentroid))
+			{
+				continue;
+			}
+
+			const int32_t binIdx = static_cast<int32_t>(std::clamp(
+				scaledCentroid,
+				0.0,
+				static_cast<double>(NumBins - 1)));
 			bin[binIdx].m_triCount++;
 			bin[binIdx].m_bounds.Extend(triangle.m_vertices[0]);
 			bin[binIdx].m_bounds.Extend(triangle.m_vertices[1]);
@@ -71,14 +87,16 @@ float BVH::FindBestSplitPlane(const BVHNode& node, const TVector<Math::Triangle>
 			rightArea[NumBins - 2 - i] = rightBox.Area();
 		}
 
-		scale = (boundsMax - boundsMin) / NumBins;
 		for (int32_t i = 0; i < NumBins - 1; i++)
 		{
 			float planeCost = leftCount[i] * leftArea[i] + rightCount[i] * rightArea[i];
-			if (planeCost < bestCost)
+			if (std::isfinite(planeCost) && planeCost < bestCost)
 			{
 				outAxis = a;
-				outSplitPos = boundsMin + scale * (i + 1);
+				outSplitPos = static_cast<float>(
+					static_cast<double>(boundsMin) +
+					boundsExtent / static_cast<double>(NumBins) *
+					static_cast<double>(i + 1));
 				bestCost = planeCost;
 			}
 		}
@@ -228,7 +246,7 @@ void BVH::Subdivide(uint32_t nodeIdx, const TVector<Math::Triangle>& tris)
 	float splitCost = FindBestSplitPlane(node, tris, axis, splitPos);
 
 	float nosplitCost = node.CalculateCost();
-	if (splitCost >= nosplitCost)
+	if (!std::isfinite(splitCost) || splitCost >= nosplitCost)
 	{
 		return;
 	}

--- a/Runtime/Raytracing/MaterialUtils.cpp
+++ b/Runtime/Raytracing/MaterialUtils.cpp
@@ -48,15 +48,17 @@ void Raytracing::GenerateTangentBitangent(
 
 	float f = 1.0f / denominator;
 
-	outTangent = vec3(
+	outTangent = SafeNormalize(vec3(
 		f * (deltaUV2.y * edge1.x - deltaUV1.y * edge2.x),
 		f * (deltaUV2.y * edge1.y - deltaUV1.y * edge2.y),
 		f * (deltaUV2.y * edge1.z - deltaUV1.y * edge2.z)
-	);
+	));
 
-	vec3 normal = cross(edge1, edge2);
-	outBitangent = normalize(cross(normal, outTangent));
-	outTangent = normalize(outTangent);
+	outBitangent = SafeNormalize(vec3(
+		f * (-deltaUV2.x * edge1.x + deltaUV1.x * edge2.x),
+		f * (-deltaUV2.x * edge1.y + deltaUV1.x * edge2.y),
+		f * (-deltaUV2.x * edge1.z + deltaUV1.x * edge2.z)
+	));
 }
 //
 //void Raytracing::ProcessMesh_Assimp(aiMesh* mesh, TVector<Triangle>& outScene, const aiScene* scene, const glm::mat4& matrix)

--- a/Runtime/Raytracing/MaterialUtils.h
+++ b/Runtime/Raytracing/MaterialUtils.h
@@ -164,6 +164,7 @@ namespace Sailor::Raytracing
 		bool HasSpecularTexture() const { return m_specularColorIndex != u8(-1); }
 		bool HasOcclusionTexture() const { return m_occlusionIndex != u8(-1); }
 		bool HasTransmissionTexture() const { return m_transmissionIndex != u8(-1); }
+		bool HasThicknessTexture() const { return m_thicknessIndex != u8(-1); }
 
 		u8 m_baseColorIndex = u8(-1);
 		u8 m_ambientIndex = u8(-1);
@@ -175,6 +176,7 @@ namespace Sailor::Raytracing
 		u8 m_metallicIndex = u8(-1);
 		u8 m_occlusionIndex = u8(-1);
 		u8 m_transmissionIndex = u8(-1);
+		u8 m_thicknessIndex = u8(-1);
 		u8 m_specularColorIndex = u8(-1);
 
 		BlendMode m_blendMode = BlendMode::Opaque;

--- a/Runtime/Raytracing/PathTracer.cpp
+++ b/Runtime/Raytracing/PathTracer.cpp
@@ -6,6 +6,7 @@
 #include "Math/Bounds.h"
 #include "Core/StringHash.h"
 #include "AssetRegistry/AssetRegistry.h"
+#include "AssetRegistry/Model/GltfImporterUtils.h"
 #include "AssetRegistry/Model/ModelImporter.h"
 #include "AssetRegistry/Model/ModelAssetInfo.h"
 #include "AssetRegistry/Material/MaterialImporter.h"
@@ -13,8 +14,6 @@
 #include "AssetRegistry/Texture/TextureAssetInfo.h"
 #include "RHI/Texture.h"
 #include <glm/gtc/random.hpp>
-#include <glm/gtx/matrix_transform_2d.hpp>
-#include <glm/gtc/quaternion.hpp>
 #include <algorithm>
 #include <functional>
 #include <thread>
@@ -101,53 +100,6 @@ namespace
 		float m_hFov = DefaultHfov;
 	};
 
-	glm::mat4 ComposeNodeMatrix(const tinygltf::Node& node)
-	{
-		if (node.matrix.size() == 16)
-		{
-			glm::mat4 m(1.0f);
-			for (int32_t col = 0; col < 4; col++)
-			{
-				for (int32_t row = 0; row < 4; row++)
-				{
-					m[col][row] = static_cast<float>(node.matrix[col * 4 + row]);
-				}
-			}
-			return m;
-		}
-
-		glm::vec3 translation(0.0f);
-		glm::vec3 scale(1.0f);
-		glm::quat rotation(1.0f, 0.0f, 0.0f, 0.0f);
-
-		if (node.translation.size() == 3)
-		{
-			translation = glm::vec3(
-				static_cast<float>(node.translation[0]),
-				static_cast<float>(node.translation[1]),
-				static_cast<float>(node.translation[2]));
-		}
-
-		if (node.scale.size() == 3)
-		{
-			scale = glm::vec3(
-				static_cast<float>(node.scale[0]),
-				static_cast<float>(node.scale[1]),
-				static_cast<float>(node.scale[2]));
-		}
-
-		if (node.rotation.size() == 4)
-		{
-			rotation = glm::quat(
-				static_cast<float>(node.rotation[3]),
-				static_cast<float>(node.rotation[0]),
-				static_cast<float>(node.rotation[1]),
-				static_cast<float>(node.rotation[2]));
-		}
-
-		return glm::translate(glm::mat4(1.0f), translation) * glm::mat4_cast(rotation) * glm::scale(glm::mat4(1.0f), scale);
-	}
-
 	void ResolveViewAndDirectionalLights(const tinygltf::Model& gltfModel, const PathTracer::Params& params, const Math::Sphere& sceneBounds, PathTracerView& outView, TVector<DirectionalLight>& outLights)
 	{
 		const vec3 sceneCenter = sceneBounds.m_center;
@@ -177,7 +129,14 @@ namespace
 			}
 
 			const tinygltf::Node& node = gltfModel.nodes[nodeIndex];
-			const glm::mat4 world = parentMatrix * ComposeNodeMatrix(node);
+			glm::mat4 localTransform(1.0f);
+			if (!GltfImporterUtils::TryComposeNodeMatrix(
+					node,
+					localTransform))
+			{
+				return;
+			}
+			const glm::mat4 world = parentMatrix * localTransform;
 
 			if (node.camera >= 0 && node.camera < (int32_t)gltfModel.cameras.size())
 			{
@@ -1427,10 +1386,48 @@ void PathTracer::GetShadingBasis(const TLASHit& hit, vec3& outNormal, vec3& outT
 		hit.m_hit.m_barycentricCoordinate.z * tri.m_bitangent[2];
 
 	const auto& instance = m_tlasInstances[hit.m_instanceIndex];
+	const glm::mat3 linearMatrix = glm::mat3(instance.m_worldMatrix);
 	const glm::mat3 normalMatrix = glm::mat3(glm::transpose(instance.m_inverseWorldMatrix));
-	outNormal = glm::normalize(normalMatrix * localNormal);
-	outTangent = glm::normalize(normalMatrix * localTangent);
-	outBitangent = glm::normalize(normalMatrix * localBitangent);
+	outNormal = Math::SafeNormalize(
+		normalMatrix * localNormal,
+		Math::vec3_Up);
+
+	const vec3 transformedTangent = linearMatrix * localTangent;
+	outTangent = Math::SafeNormalize(
+		transformedTangent - outNormal * glm::dot(outNormal, transformedTangent));
+	if (outTangent == Math::vec3_Zero)
+	{
+		const vec3 fallbackAxis = std::abs(outNormal.y) < 0.999f ?
+			Math::vec3_Up : Math::vec3_Right;
+		outTangent = Math::SafeNormalize(
+			glm::cross(fallbackAxis, outNormal),
+			Math::vec3_Right);
+	}
+
+	const vec3 transformedBitangent = linearMatrix * localBitangent;
+	const vec3 canonicalBitangent = Math::SafeNormalize(
+		glm::cross(outNormal, outTangent),
+		Math::vec3_Forward);
+	const float handedness =
+		glm::dot(canonicalBitangent, transformedBitangent) < 0.0f ?
+		-1.0f : 1.0f;
+	outBitangent = canonicalBitangent * handedness;
+}
+
+bool PathTracer::OrientShadingBasisAgainstRay(
+	const vec3& rayDirection,
+	vec3& inOutNormal,
+	vec3& inOutBitangent)
+{
+	const bool bIsOppositeRay =
+		glm::dot(inOutNormal, rayDirection) < 0.0f;
+	if (!bIsOppositeRay)
+	{
+		inOutNormal *= -1.0f;
+		inOutBitangent *= -1.0f;
+	}
+
+	return bIsOppositeRay;
 }
 
 uint32_t PathTracer::ResolveMaterialIndex(const TLASHit& hit) const
@@ -1511,11 +1508,10 @@ vec3 PathTracer::Raytrace(const Math::Ray& ray, uint32_t bounceLimit, uint32_t i
 		vec3 faceNormal{}, tangent{}, bitangent{};
 		GetShadingBasis(hit, faceNormal, tangent, bitangent);
 
-		const bool bIsOppositeRay = dot(faceNormal, ray.GetDirection()) < 0.0f;
-		if (!bIsOppositeRay)
-		{
-			faceNormal *= -1.0f;
-		}
+		const bool bIsOppositeRay = OrientShadingBasisAgainstRay(
+			ray.GetDirection(),
+			faceNormal,
+			bitangent);
 
 		const mat3 tbn(tangent, bitangent, faceNormal);
 

--- a/Runtime/Raytracing/PathTracer.cpp
+++ b/Runtime/Raytracing/PathTracer.cpp
@@ -537,7 +537,11 @@ namespace
 		size_t hash = 1469598103934665603ull;
 		for (const auto& material : materials)
 		{
-			const size_t value = material ? material.GetHash() : 0;
+			size_t value = material ? material.GetHash() : 0;
+			if (material)
+			{
+				HashCombine(value, material->GetContentRevision());
+			}
 			hash ^= value + 0x9e3779b97f4a7c15ull + (hash << 6) + (hash >> 2);
 		}
 		return hash;
@@ -1540,15 +1544,7 @@ bool PathTracer::IsThickVolumeAtHit(
 		return false;
 	}
 
-	float thickness = material.m_thicknessFactor;
-	if (material.HasThicknessTexture())
-	{
-		thickness *=
-			m_textures[material.m_thicknessIndex]->Sample<vec3>(
-				uvTransformed).g;
-	}
-
-	return thickness > 0.0f;
+	return material.m_thicknessFactor > 0.0f;
 }
 
 vec3 PathTracer::TraceSky(vec3 startPoint, vec3 toLight, const PathTracer::Params& params, float currentIor, uint32_t ignoreInstance, uint32_t ignoreTriangle) const
@@ -1642,7 +1638,7 @@ vec3 PathTracer::Raytrace(const Math::Ray& ray, uint32_t bounceLimit, uint32_t i
 
 		const bool bFullMetallic = sample.m_orm.z == 1.0f;
 		const bool bHasTransmission = !bFullMetallic && sample.m_transmission > 0.0f;
-		const bool bThickVolume = bHasTransmission && sample.m_thicknessFactor > 0.0f;
+		const bool bThickVolume = bHasTransmission && material.m_thicknessFactor > 0.0f;
 
 		if (!bIsOppositeRay && bThickVolume)
 		{

--- a/Runtime/Raytracing/PathTracer.cpp
+++ b/Runtime/Raytracing/PathTracer.cpp
@@ -15,6 +15,7 @@
 #include "RHI/Texture.h"
 #include <glm/gtc/random.hpp>
 #include <algorithm>
+#include <cmath>
 #include <functional>
 #include <thread>
 
@@ -89,6 +90,45 @@ namespace
 	{
 		const vec3 bias = ComputeRayOriginBias(worldPoint, geometricNormal, biasBase, biasScale);
 		return worldPoint + (glm::dot(rayDirection, geometricNormal) >= 0.0f ? bias : -bias);
+	}
+
+	__forceinline vec2 ResolveHitTextureCoordinates(
+		const Math::Triangle& triangle,
+		const Math::RaycastHit& hit)
+	{
+		return hit.m_barycentricCoordinate.x * triangle.m_uvs[0] +
+			hit.m_barycentricCoordinate.y * triangle.m_uvs[1] +
+			hit.m_barycentricCoordinate.z * triangle.m_uvs[2];
+	}
+
+	__forceinline vec3 CalculateVolumeAttenuation(
+		const vec3& attenuationColor,
+		float attenuationDistance,
+		float transmissionDistance)
+	{
+		if (transmissionDistance <= 0.0f ||
+			attenuationDistance <= 0.0f ||
+			!std::isfinite(attenuationDistance) ||
+			attenuationDistance >= (std::numeric_limits<float>::max)())
+		{
+			return vec3(1.0f);
+		}
+
+		const float exponent = transmissionDistance /
+			(std::max)(attenuationDistance, std::numeric_limits<float>::epsilon());
+		vec3 result(1.0f);
+		for (uint32_t component = 0; component < 3; ++component)
+		{
+			const float sourceColor = attenuationColor[component];
+			const float color = std::isfinite(sourceColor) ?
+				glm::clamp(sourceColor, 0.0f, 1.0f) :
+				1.0f;
+			result[component] = color <= 0.0f ?
+				0.0f :
+				std::pow(color, exponent);
+		}
+
+		return result;
 	}
 
 	struct PathTracerView
@@ -371,37 +411,66 @@ namespace
 
 			glm::vec4 baseColorFactor(1.0f);
 			glm::vec4 emissiveFactor(0.0f);
+			glm::vec4 attenuationColor(1.0f);
 			float roughness = 1.0f;
 			float metallic = 1.0f;
 			float alphaCutoff = 0.5f;
 			float normalScale = 1.0f;
+			float transmission = 0.0f;
+			float thickness = 0.0f;
+			float attenuationDistance = (std::numeric_limits<float>::max)();
+			float indexOfRefraction = 1.5f;
 
 			ReadUniformValue(pMaterial->GetUniformsVec4(), "material.baseColorFactor", baseColorFactor);
 			ReadUniformValue(pMaterial->GetUniformsVec4(), "material.albedo", baseColorFactor);
 			ReadUniformValue(pMaterial->GetUniformsVec4(), "material.emissiveFactor", emissiveFactor);
 			ReadUniformValue(pMaterial->GetUniformsVec4(), "material.emissive", emissiveFactor);
 			ReadUniformValue(pMaterial->GetUniformsVec4(), "material.emission", emissiveFactor);
+			ReadUniformValue(pMaterial->GetUniformsVec4(), "material.attenuationColor", attenuationColor);
 			ReadUniformValue(pMaterial->GetUniformsFloat(), "material.roughnessFactor", roughness);
 			ReadUniformValue(pMaterial->GetUniformsFloat(), "material.roughness", roughness);
 			ReadUniformValue(pMaterial->GetUniformsFloat(), "material.metallicFactor", metallic);
 			ReadUniformValue(pMaterial->GetUniformsFloat(), "material.metallic", metallic);
 			ReadUniformValue(pMaterial->GetUniformsFloat(), "material.alphaCutoff", alphaCutoff);
 			ReadUniformValue(pMaterial->GetUniformsFloat(), "material.normalScale", normalScale);
+			ReadUniformValue(pMaterial->GetUniformsFloat(), "material.transmissionFactor", transmission);
+			ReadUniformValue(pMaterial->GetUniformsFloat(), "material.thicknessFactor", thickness);
+			ReadUniformValue(pMaterial->GetUniformsFloat(), "material.attenuationDistance", attenuationDistance);
+			ReadUniformValue(pMaterial->GetUniformsFloat(), "material.indexOfRefraction", indexOfRefraction);
 
 			outMaterial.m_baseColorFactor = baseColorFactor;
 			outMaterial.m_emissiveFactor = glm::vec3(emissiveFactor);
 			outMaterial.m_roughnessFactor = roughness;
 			outMaterial.m_metallicFactor = metallic;
 			outMaterial.m_alphaCutoff = alphaCutoff;
+			outMaterial.m_transmissionFactor = std::isfinite(transmission) ?
+				glm::clamp(transmission, 0.0f, 1.0f) :
+				0.0f;
+			outMaterial.m_thicknessFactor = std::isfinite(thickness) ?
+				(std::max)(0.0f, thickness) :
+				0.0f;
+			outMaterial.m_attenuationDistance =
+				std::isfinite(attenuationDistance) && attenuationDistance > 0.0f ?
+				attenuationDistance :
+				(std::numeric_limits<float>::max)();
+			for (uint32_t component = 0; component < 3; ++component)
+			{
+				const float value = attenuationColor[component];
+				outMaterial.m_attenuationColor[component] =
+					std::isfinite(value) ?
+					glm::clamp(value, 0.0f, 1.0f) :
+					1.0f;
+			}
+			outMaterial.m_indexOfRefraction = std::isfinite(indexOfRefraction) ?
+				(std::max)(1.0f, indexOfRefraction) :
+				1.5f;
 
-			const size_t renderQueueTag = pMaterial->GetRenderState().GetTag();
-			const size_t transparentTag = GetHash(std::string("Transparent"));
-			const size_t maskedTag = GetHash(std::string("Masked"));
-			if (renderQueueTag == transparentTag)
+			const RHI::RenderState& renderState = pMaterial->GetRenderState();
+			if (renderState.GetBlendMode() != RHI::EBlendMode::None)
 			{
 				outMaterial.m_blendMode = BlendMode::Blend;
 			}
-			else if (renderQueueTag == maskedTag)
+			else if (renderState.IsRequiredCustomDepthShader())
 			{
 				outMaterial.m_blendMode = BlendMode::Mask;
 			}
@@ -450,6 +519,10 @@ namespace
 				else if (samplerName == "transmissionSampler")
 				{
 					bAllTexturesResolved &= addTexture(pTexture, false, false, 3, outMaterial.m_transmissionIndex);
+				}
+				else if (samplerName == "thicknessSampler")
+				{
+					bAllTexturesResolved &= addTexture(pTexture, false, false, 3, outMaterial.m_thicknessIndex);
 				}
 			}
 
@@ -1443,6 +1516,41 @@ uint32_t PathTracer::ResolveMaterialIndex(const TLASHit& hit) const
 	return (uint32_t)(std::max)(0, (std::min)(idx, (int32_t)m_materials.Num() - 1));
 }
 
+bool PathTracer::IsThickVolumeAtHit(
+	const TLASHit& hit,
+	uint32_t materialIndex) const
+{
+	const auto& material = m_materials[materialIndex];
+	const vec2 uv = ResolveHitTextureCoordinates(
+		GetTriangle(hit),
+		hit.m_hit);
+	const vec2 uvTransformed =
+		material.m_uvTransform * vec3(uv, 1.0f);
+
+	float transmission = material.m_transmissionFactor;
+	if (material.HasTransmissionTexture())
+	{
+		transmission *=
+			m_textures[material.m_transmissionIndex]->Sample<vec3>(
+				uvTransformed).r;
+	}
+
+	if (transmission <= 0.0f)
+	{
+		return false;
+	}
+
+	float thickness = material.m_thicknessFactor;
+	if (material.HasThicknessTexture())
+	{
+		thickness *=
+			m_textures[material.m_thicknessIndex]->Sample<vec3>(
+				uvTransformed).g;
+	}
+
+	return thickness > 0.0f;
+}
+
 vec3 PathTracer::TraceSky(vec3 startPoint, vec3 toLight, const PathTracer::Params& params, float currentIor, uint32_t ignoreInstance, uint32_t ignoreTriangle) const
 {
 	vec3 att = vec3(1, 1, 1);
@@ -1463,7 +1571,8 @@ vec3 PathTracer::TraceSky(vec3 startPoint, vec3 toLight, const PathTracer::Param
 		GetShadingBasis(hitLight, shadingNormal, shadingTangent, shadingBitangent);
 
 		const bool bHitOpposite = dot(toLight, shadingNormal) < 0.0f;
-		const bool bHitThickVolume = material.m_transmissionFactor > 0.0f && material.m_thicknessFactor > 0.0f;
+		const bool bHitThickVolume =
+			IsThickVolumeAtHit(hitLight, materialIndex);
 
 		if (!bHitThickVolume)
 		{
@@ -1480,8 +1589,10 @@ vec3 PathTracer::TraceSky(vec3 startPoint, vec3 toLight, const PathTracer::Param
 
 		if (!bHitOpposite)
 		{
-			const vec3 c = -log(material.m_attenuationColor) / material.m_attenuationDistance;
-			att *= glm::exp(-c * distance);
+			att *= CalculateVolumeAttenuation(
+				material.m_attenuationColor,
+				material.m_attenuationDistance,
+				distance);
 		}
 
 		startPoint = hitLight.m_hit.m_point;
@@ -1515,9 +1626,7 @@ vec3 PathTracer::Raytrace(const Math::Ray& ray, uint32_t bounceLimit, uint32_t i
 
 		const mat3 tbn(tangent, bitangent, faceNormal);
 
-		const vec2 uv = hit.m_hit.m_barycentricCoordinate.x * tri.m_uvs[0] +
-			hit.m_hit.m_barycentricCoordinate.y * tri.m_uvs[1] +
-			hit.m_hit.m_barycentricCoordinate.z * tri.m_uvs[2];
+		const vec2 uv = ResolveHitTextureCoordinates(tri, hit.m_hit);
 
 		const uint32_t materialIndex = ResolveMaterialIndex(hit);
 		const auto material = m_materials[materialIndex];
@@ -1533,7 +1642,7 @@ vec3 PathTracer::Raytrace(const Math::Ray& ray, uint32_t bounceLimit, uint32_t i
 
 		const bool bFullMetallic = sample.m_orm.z == 1.0f;
 		const bool bHasTransmission = !bFullMetallic && sample.m_transmission > 0.0f;
-		const bool bThickVolume = bHasTransmission && material.m_thicknessFactor > 0.0f;
+		const bool bThickVolume = bHasTransmission && sample.m_thicknessFactor > 0.0f;
 
 		if (!bIsOppositeRay && bThickVolume)
 		{
@@ -1689,9 +1798,10 @@ vec3 PathTracer::Raytrace(const Math::Ray& ray, uint32_t bounceLimit, uint32_t i
 					if (bIsOppositeRay && bTransmissionRay && bThickVolume)
 					{
 						const float distance = glm::length(hitLight.m_hit.m_point - hit.m_hit.m_point);
-						const vec3 c = -log(material.m_attenuationColor) / material.m_attenuationDistance;
-
-						lightAttenuation = glm::exp(-c * distance);
+						lightAttenuation = CalculateVolumeAttenuation(
+							material.m_attenuationColor,
+							material.m_attenuationDistance,
+							distance);
 					}
 
 					vec3 raytraced = vec3(0, 0, 0);
@@ -1707,15 +1817,21 @@ vec3 PathTracer::Raytrace(const Math::Ray& ray, uint32_t bounceLimit, uint32_t i
 					indirect += value;
 
 					// Ambient 2, Sky is reachable
-					const auto& hitMaterial = m_materials[ResolveMaterialIndex(hitLight)];
-					if (!bThickVolume && hitMaterial.m_transmissionFactor > 0.0f && hitMaterial.m_thicknessFactor > 0.0f)
+					if (!bThickVolume)
 					{
-						vec3 att = TraceSky(rayToLight.GetOrigin(), rayToLight.GetDirection(), params, environmentIor, hitLight.m_instanceIndex, hitLight.m_triangleIndex);
-
-						if (att != vec3(0, 0, 0))
+						const uint32_t hitMaterialIndex =
+							ResolveMaterialIndex(hitLight);
+						if (IsThickVolumeAtHit(
+							hitLight,
+							hitMaterialIndex))
 						{
-							ambient2 += value * att;
-							avgPdfLambert += pdf;
+							vec3 att = TraceSky(rayToLight.GetOrigin(), rayToLight.GetDirection(), params, environmentIor, hitLight.m_instanceIndex, hitLight.m_triangleIndex);
+
+							if (att != vec3(0, 0, 0))
+							{
+								ambient2 += value * att;
+								avgPdfLambert += pdf;
+							}
 						}
 					}
 				}
@@ -1825,6 +1941,11 @@ LightingModel::SampledData PathTracer::GetMaterialData(const size_t& materialInd
 	if (material.HasTransmissionTexture())
 	{
 		res.m_transmission *= m_textures[material.m_transmissionIndex]->Sample<vec3>(uv).r;
+	}
+
+	if (material.HasThicknessTexture())
+	{
+		res.m_thicknessFactor *= m_textures[material.m_thicknessIndex]->Sample<vec3>(uv).g;
 	}
 
 	if (material.m_blendMode == BlendMode::Mask)

--- a/Runtime/Raytracing/PathTracer.h
+++ b/Runtime/Raytracing/PathTracer.h
@@ -91,6 +91,9 @@ namespace Sailor::Raytracing
 			vec3& inOutNormal,
 			vec3& inOutBitangent);
 		uint32_t ResolveMaterialIndex(const TLASHit& hit) const;
+		bool IsThickVolumeAtHit(
+			const TLASHit& hit,
+			uint32_t materialIndex) const;
 
 		vec3 TraceSky(vec3 startPoint, vec3 toLight, const PathTracer::Params& params, float currentIor,
 			uint32_t ignoreInstance, uint32_t ignoreTriangle) const;

--- a/Runtime/Raytracing/PathTracer.h
+++ b/Runtime/Raytracing/PathTracer.h
@@ -85,8 +85,8 @@ namespace Sailor::Raytracing
 		bool IntersectScene(const Math::Ray& worldRay, TLASHit& outHit, float maxRayLength = FLT_MAX,
 			uint32_t ignoreInstance = (uint32_t)-1, uint32_t ignoreTriangle = (uint32_t)-1) const;
 		const Math::Triangle& GetTriangle(const TLASHit& hit) const;
-		void GetShadingBasis(const TLASHit& hit, vec3& outNormal, vec3& outTangent, vec3& outBitangent) const;
-		static bool OrientShadingBasisAgainstRay(
+		SAILOR_SHARED_API void GetShadingBasis(const TLASHit& hit, vec3& outNormal, vec3& outTangent, vec3& outBitangent) const;
+		SAILOR_SHARED_API static bool OrientShadingBasisAgainstRay(
 			const vec3& rayDirection,
 			vec3& inOutNormal,
 			vec3& inOutBitangent);

--- a/Runtime/Raytracing/PathTracer.h
+++ b/Runtime/Raytracing/PathTracer.h
@@ -86,6 +86,10 @@ namespace Sailor::Raytracing
 			uint32_t ignoreInstance = (uint32_t)-1, uint32_t ignoreTriangle = (uint32_t)-1) const;
 		const Math::Triangle& GetTriangle(const TLASHit& hit) const;
 		void GetShadingBasis(const TLASHit& hit, vec3& outNormal, vec3& outTangent, vec3& outBitangent) const;
+		static bool OrientShadingBasisAgainstRay(
+			const vec3& rayDirection,
+			vec3& inOutNormal,
+			vec3& inOutBitangent);
 		uint32_t ResolveMaterialIndex(const TLASHit& hit) const;
 
 		vec3 TraceSky(vec3 startPoint, vec3 toLight, const PathTracer::Params& params, float currentIor,

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -793,7 +793,7 @@ void App::Start()
 
 			char Buff[256];
 			SAILOR_SNPRINTF(Buff, sizeof(Buff), "Sailor FPS: %u, GPU FPS: %u, CPU FPS: %u, VRAM Usage: %.2f/%.2fmb, CmdLists: %u", frameCounter,
-				stats.m_gpuFps,
+				stats.m_gpuFps.load(std::memory_order_relaxed),
 				(uint32_t)pEngineLoop->GetCpuFps(),
 				(float)stats.m_gpuHeapUsage / (1024.0f * 1024.0f),
 				(float)stats.m_gpuHeapBudget / (1024.0f * 1024.0f),

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -7,6 +7,7 @@
 #include "AssetRegistry/Animation/AnimationImporter.h"
 #include "AssetRegistry/Animation/AnimationAssetInfo.h"
 #include "AssetRegistry/Material/MaterialImporter.h"
+#include "AssetRegistry/FrameGraph/FrameGraphAssetInfo.h"
 #include "AssetRegistry/FrameGraph/FrameGraphImporter.h"
 #include "AssetRegistry/Prefab/PrefabImporter.h"
 #include "AssetRegistry/World/WorldPrefabImporter.h"
@@ -869,6 +870,49 @@ bool App::RequestAssetReload()
 
 	QueueAssetReloadTaskLocked(scheduler);
 	return true;
+}
+
+bool App::UpdateAsset(const char* strFileId)
+{
+	if (strFileId == nullptr || strFileId[0] == '\0')
+	{
+		return false;
+	}
+
+	const std::string fileIdValue = strFileId;
+	return ExecuteOnEngineMainThread<bool>(false, [fileIdValue]()
+		{
+			AssetRegistry* assetRegistry = GetSubmodule<AssetRegistry>();
+			if (assetRegistry == nullptr)
+			{
+				return false;
+			}
+
+			FileId fileId;
+			fileId.Deserialize(YAML::Node(fileIdValue));
+			if (!fileId)
+			{
+				return false;
+			}
+
+			FrameGraphAssetInfoPtr frameGraphAssetInfo =
+				assetRegistry->GetAssetInfoPtr<FrameGraphAssetInfoPtr>(fileId);
+			const bool bRefreshFrameGraph =
+				frameGraphAssetInfo != nullptr &&
+				(frameGraphAssetInfo->IsMetaExpired() ||
+					frameGraphAssetInfo->IsAssetExpired() ||
+					assetRegistry->IsAssetExpired(frameGraphAssetInfo));
+			const bool bUpdated = assetRegistry->UpdateAsset(fileId);
+			if (bUpdated && bRefreshFrameGraph)
+			{
+				if (Renderer* renderer = GetSubmodule<Renderer>())
+				{
+					renderer->RefreshFrameGraph();
+				}
+			}
+
+			return bUpdated;
+		});
 }
 
 bool App::GetAssetReloadState(

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -58,6 +58,7 @@ namespace Sailor
 		SAILOR_API static void Shutdown();
 		SAILOR_API static bool IsEngineMainThreadReady();
 		SAILOR_API static bool RequestAssetReload();
+		SAILOR_API static bool UpdateAsset(const char* strFileId);
 		SAILOR_API static bool GetAssetReloadState(
 			uint64_t& outRequestGeneration,
 			uint64_t& outCompletedGeneration,

--- a/Runtime/Tasks/Scheduler.cpp
+++ b/Runtime/Tasks/Scheduler.cpp
@@ -290,7 +290,7 @@ Scheduler::~Scheduler()
 		worker->Join();
 	}
 
-	App::GetSubmodule<Tasks::Scheduler>()->ProcessTasksOnMainThread();
+	ProcessTasksOnMainThread();
 
 	for (auto worker : m_workerThreads)
 	{

--- a/Runtime/Tasks/Scheduler.cpp
+++ b/Runtime/Tasks/Scheduler.cpp
@@ -200,7 +200,7 @@ void Scheduler::Initialize()
 
 	const unsigned coresCount = std::thread::hardware_concurrency();
 	const unsigned numRHIThreads = RHIThreadsNum;
-	const unsigned numReservedThreads = 3u + numRHIThreads;
+	const unsigned numReservedThreads = 4u + numRHIThreads;
 	const unsigned numThreads = coresCount > numReservedThreads
 		? coresCount - numReservedThreads
 		: 1u;
@@ -252,6 +252,16 @@ void Scheduler::Initialize()
 	m_threadTypes[m_editorThreadId] = EThreadType::Editor;
 	m_workerThreads.Emplace(newEditorThread);
 
+	WorkerThread* newBackgroundThread = new WorkerThread(
+		"Background Thread",
+		EThreadType::Background,
+		m_refreshCondVar[(uint32_t)EThreadType::Background],
+		m_queueMutex[(uint32_t)EThreadType::Background],
+		m_pSharedTaskQueue[(uint32_t)EThreadType::Background]);
+
+	m_threadTypes[newBackgroundThread->GetThreadId()] = EThreadType::Background;
+	m_workerThreads.Emplace(newBackgroundThread);
+
 	SAILOR_LOG("Initialize Tasks::Scheduler. Cores count: %d, Worker threads count: %zd", coresCount, m_workerThreads.Num());
 }
 
@@ -273,6 +283,7 @@ Scheduler::~Scheduler()
 	NotifyWorkerThread(EThreadType::Render, true);
 	NotifyWorkerThread(EThreadType::RHI, true);
 	NotifyWorkerThread(EThreadType::Editor, true);
+	NotifyWorkerThread(EThreadType::Background, true);
 
 	for (auto& worker : m_workerThreads)
 	{

--- a/Runtime/Tasks/Scheduler.h
+++ b/Runtime/Tasks/Scheduler.h
@@ -37,7 +37,11 @@ namespace Sailor
 
 		// Serialized Editor protocol work. This is a dedicated worker,
 		// not part of the general-purpose Worker pool.
-		Editor = 4
+		Editor = 4,
+
+		// Best-effort work that must not delay explicit WaitIdle sets.
+		// A single dedicated worker processes this queue serially.
+		Background = 5
 	};
 
 	namespace Tasks

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -1504,7 +1504,9 @@ namespace
 			initialCache.Contains(fileId),
 			"the initial scan should persist its source watermark");
 
-		WriteFile(sourcePath, "source-v2-with-another-size");
+		RewriteFileWithNewRevision(
+			sourcePath,
+			"source-v2-with-another-size");
 		{
 			AssetRegistry registry(workspaceContext);
 			TestAssetInfoHandler handler;
@@ -1512,7 +1514,9 @@ namespace
 			listener.m_onExpiredUpdate =
 				[&](AssetInfoPtr)
 				{
-					WriteFile(sourcePath, "source-mutated-by-listener");
+					RewriteFileWithNewRevision(
+						sourcePath,
+						"source-mutated-by-listener");
 				};
 			handler.Subscribe(&listener);
 			RegisterRawHandler(registry, handler);
@@ -1611,7 +1615,9 @@ namespace
 
 		handler.m_onLoad = [&]()
 			{
-				WriteFile(sourcePath, "source-mutated-during-staging");
+				RewriteFileWithNewRevision(
+					sourcePath,
+					"source-mutated-during-staging");
 			};
 		Require(
 			!registry.ScanContentFolder(),
@@ -1680,7 +1686,7 @@ namespace
 								[&]()
 								{
 									bMetadataMutatedDuringWait = true;
-									WriteFile(
+									RewriteFileWithNewRevision(
 										metadataPath,
 										"fileId: '{ASSET-CACHE-IMPORT-CONTRACT}'\n"
 										"filename: Retry.raw\n"
@@ -1782,7 +1788,7 @@ namespace
 				Require(
 					static_cast<bool>(token),
 					"the source mutation fixture should begin processing");
-				WriteFile(
+				RewriteFileWithNewRevision(
 					info->GetAssetFilepath(),
 					"source-mutated-after-begin");
 				registry.CompleteAssetProcessing(token, true);

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -1645,45 +1645,25 @@ namespace
 		const std::filesystem::path metadataPath =
 			workspaceContext.GetContent() / "Retry.raw.asset";
 
-		Require(App::GetInstance() == nullptr,
-			"the deterministic pre-commit test requires an isolated App instance");
-		const std::string missingWorkspace =
-			directory.Path("MissingWorkspace").generic_string();
-		const char* appArgs[] = {
-			"AssetCacheContractTests",
-			"--noconsole",
-			"--workspace",
-			missingWorkspace.c_str()
-		};
-		App::Initialize(appArgs, static_cast<int32_t>(std::size(appArgs)));
-
-		try
+		bool bMetadataMutatedDuringWait = false;
+		Tasks::Scheduler scheduler;
+		scheduler.AttachCurrentThreadAsMainThread();
 		{
-			Require(App::GetInstance() != nullptr,
-				"the isolated App instance should be available to register a scheduler");
-			Require(App::GetSubmodule<Tasks::Scheduler>() == nullptr,
-				"the intentionally invalid workspace must stop App initialization before scheduler startup");
-			Tasks::Scheduler* scheduler = App::AddSubmodule(
-				TSubmodule<Tasks::Scheduler>::Make());
-			scheduler->AttachCurrentThreadAsMainThread();
+			AssetRegistry registry(workspaceContext, &scheduler);
+			TestAssetInfoHandler handler;
+			RegisterRawHandler(registry, handler);
+			Require(
+				registry.ScanContentFolder(),
+				"the initial registry generation should commit");
+			AssetInfoPtr previousInfo = registry.GetAssetInfoPtr(sourcePath.string());
+			Require(previousInfo != nullptr,
+				"the initial registry generation should expose the fixture asset");
 
-			{
-				AssetRegistry registry(workspaceContext);
-				TestAssetInfoHandler handler;
-				RegisterRawHandler(registry, handler);
-				Require(
-					registry.ScanContentFolder(),
-					"the initial registry generation should commit");
-				AssetInfoPtr previousInfo = registry.GetAssetInfoPtr(sourcePath.string());
-				Require(previousInfo != nullptr,
-					"the initial registry generation should expose the fixture asset");
-
-				bool bMetadataMutatedDuringWait = false;
-				handler.m_onLoad = [&]()
-					{
-						Tasks::ITaskPtr mutationTask =
-							TSharedPtr<TestMainThreadTask>::Make(
-								[&]()
+			handler.m_onLoad = [&]()
+				{
+					Tasks::ITaskPtr mutationTask =
+						TSharedPtr<TestMainThreadTask>::Make(
+							[&]()
 								{
 									bMetadataMutatedDuringWait = true;
 									RewriteFileWithNewRevision(
@@ -1693,34 +1673,26 @@ namespace
 										"testValue: 8\n"
 										"lateValue: 1\n");
 								});
-						scheduler->Run(mutationTask);
-						Require(!bMetadataMutatedDuringWait,
-							"the metadata mutation must remain queued until the pre-commit wait");
-					};
+					scheduler.Run(mutationTask);
+					Require(!bMetadataMutatedDuringWait,
+						"the metadata mutation must remain queued until the pre-commit wait");
+				};
 
-				Require(
-					!registry.ScanContentFolder(),
-					"a metadata mutation during the pre-commit wait must reject the new generation");
-				Require(bMetadataMutatedDuringWait,
-					"the metadata mutation must execute inside the pre-commit wait");
-				Require(
-					registry.GetAssetInfoPtr(sourcePath.string()) == previousInfo,
-					"a rejected staged generation must preserve the previous asset info");
+			Require(
+				!registry.ScanContentFolder(),
+				"a metadata mutation during the pre-commit wait must reject the new generation");
+			Require(bMetadataMutatedDuringWait,
+				"the metadata mutation must execute inside the pre-commit wait");
+			Require(
+				registry.GetAssetInfoPtr(sourcePath.string()) == previousInfo,
+				"a rejected staged generation must preserve the previous asset info");
 
-				Require(
-					registry.ScanContentFolder(),
-					"the next stable scan should accept the changed metadata");
-				Require(
-					registry.GetAssetInfoPtr(sourcePath.string()) != nullptr,
-					"the stable retry must publish the asset again");
-			}
-
-			App::Shutdown();
-		}
-		catch (...)
-		{
-			App::Shutdown();
-			throw;
+			Require(
+				registry.ScanContentFolder(),
+				"the next stable scan should accept the changed metadata");
+			Require(
+				registry.GetAssetInfoPtr(sourcePath.string()) != nullptr,
+				"the stable retry must publish the asset again");
 		}
 	}
 

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -1,4 +1,5 @@
 #include "AssetRegistry/AssetCache.h"
+#include "AssetRegistry/AssetScanSourceRevisionCache.h"
 #include "AssetRegistry/Animation/AnimationAssetInfo.h"
 #include "AssetRegistry/AssetInfo.h"
 #include "AssetRegistry/AssetRegistry.h"
@@ -10,6 +11,7 @@
 #include "AssetRegistry/Shader/ShaderAssetInfo.h"
 #include "AssetRegistry/Texture/TextureAssetInfo.h"
 #include "AssetRegistry/World/WorldPrefabAssetInfo.h"
+#include "Tasks/Scheduler.h"
 
 #include <chrono>
 #include <ctime>
@@ -179,8 +181,16 @@ namespace
 				info->GetAssetLastModificationTime(),
 				info->GetMetaLastModificationTime());
 			info->SetPendingUpdate(true);
+			std::function<void()> onLoad;
+			onLoad.swap(m_onLoad);
+			if (onLoad)
+			{
+				onLoad();
+			}
 			return info;
 		}
+
+		mutable std::function<void()> m_onLoad;
 
 	protected:
 		AssetInfoPtr CreateAssetInfo() const override
@@ -195,6 +205,114 @@ namespace
 			result.Deserialize(YAML::Node("{ASSET-CACHE-IMPORT-CONTRACT}"));
 			return result;
 		}
+	};
+
+	class TargetedUpdateAssetInfo final : public AssetInfo
+	{
+	public:
+		explicit TargetedUpdateAssetInfo(IAssetInfoHandler* handler) :
+			m_handler(handler)
+		{
+		}
+
+		YAML::Node Serialize() const override
+		{
+			YAML::Node result(YAML::NodeType::Map);
+			result["fileId"] = m_fileId;
+			result["filename"] = m_assetFilename;
+			result["testValue"] = m_testValue;
+			return result;
+		}
+
+		void Deserialize(const YAML::Node& inData) override
+		{
+			m_fileId = inData["fileId"].as<FileId>();
+			m_assetFilename = inData["filename"].as<std::string>();
+			m_testValue = inData["testValue"].as<int32_t>();
+		}
+
+		IAssetInfoHandler* GetHandler() override
+		{
+			return m_handler;
+		}
+
+		int32_t GetTestValue() const noexcept
+		{
+			return m_testValue;
+		}
+
+	private:
+		IAssetInfoHandler* m_handler = nullptr;
+		int32_t m_testValue = 0;
+	};
+
+	class TargetedUpdateAssetInfoHandler final : public IAssetInfoHandler
+	{
+	public:
+		void GetDefaultMeta(YAML::Node& outDefaultYaml) const override
+		{
+			outDefaultYaml = YAML::Node(YAML::NodeType::Map);
+		}
+
+	protected:
+		AssetInfoPtr CreateAssetInfo() const override
+		{
+			return new TargetedUpdateAssetInfo(
+				const_cast<TargetedUpdateAssetInfoHandler*>(this));
+		}
+	};
+
+	class RecordingTargetedUpdateListener final : public IAssetInfoHandlerListener
+	{
+	public:
+		void OnUpdateAssetInfo(
+			AssetInfoPtr assetInfo,
+			bool bWasExpired) override
+		{
+			m_updatedFileIds.emplace_back(assetInfo->GetFileId());
+			m_expirationFlags.emplace_back(bWasExpired);
+			if (m_onUpdate)
+			{
+				m_onUpdate(assetInfo, bWasExpired);
+			}
+		}
+
+		void OnImportAsset(AssetInfoPtr) override
+		{
+		}
+
+		void Clear()
+		{
+			m_updatedFileIds.clear();
+			m_expirationFlags.clear();
+		}
+
+		std::vector<FileId> m_updatedFileIds;
+		std::vector<bool> m_expirationFlags;
+		std::function<void(AssetInfoPtr, bool)> m_onUpdate;
+	};
+
+	class TestMainThreadTask final : public Tasks::ITask
+	{
+	public:
+		explicit TestMainThreadTask(std::function<void()> callback) :
+			ITask("Asset cache pre-commit metadata mutation", EThreadType::Main),
+			m_callback(std::move(callback))
+		{
+		}
+
+		void Execute() override
+		{
+			m_state |= StateMask::IsStartedBit;
+			if (m_callback)
+			{
+				m_callback();
+			}
+			m_state |= StateMask::IsFinishedBit;
+		}
+
+	private:
+		std::function<void()> m_callback;
 	};
 
 	void Require(bool condition, const std::string& message)
@@ -315,6 +433,23 @@ namespace
 		stream << content;
 	}
 
+	void RewriteFileWithNewRevision(
+		const std::filesystem::path& path,
+		const std::string& content)
+	{
+		const std::filesystem::file_time_type previousWriteTime =
+			std::filesystem::last_write_time(path);
+		WriteFile(path, content);
+		std::error_code timestampError;
+		std::filesystem::last_write_time(
+			path,
+			previousWriteTime + std::chrono::seconds(2),
+			timestampError);
+		Require(
+			!timestampError,
+			"the targeted update fixture must advance the file revision");
+	}
+
 	Workspace::WorkspaceContext CreateWorkspaceContext(
 		const TempDirectory& directory)
 	{
@@ -364,6 +499,24 @@ namespace
 			"lateValue: 1\n");
 	}
 
+	void WriteTargetedUpdateFixture(
+		const Workspace::WorkspaceContext& workspaceContext)
+	{
+		WriteFile(
+			workspaceContext.GetContent() / "Shared.raw",
+			"shared-source-v1");
+		WriteFile(
+			workspaceContext.GetContent() / "Shared.raw.asset",
+			"fileId: '{TARGETED-UPDATE-PRIMARY}'\n"
+			"filename: Shared.raw\n"
+			"testValue: 1\n");
+		WriteFile(
+			workspaceContext.GetContent() / "Shared.raw2.asset",
+			"fileId: '{TARGETED-UPDATE-SECONDARY}'\n"
+			"filename: Shared.raw\n"
+			"testValue: 2\n");
+	}
+
 	void RegisterRawHandler(
 		AssetRegistry& registry,
 		TestAssetInfoHandler& handler)
@@ -373,6 +526,18 @@ namespace
 		Require(
 			registry.RegisterAssetInfoHandler(extensions, &handler),
 			"the scan fixture handler should register for raw assets");
+	}
+
+	void RegisterTargetedUpdateHandler(
+		AssetRegistry& registry,
+		TargetedUpdateAssetInfoHandler& handler)
+	{
+		TVector<std::string> extensions;
+		extensions.Add("raw");
+		extensions.Add("raw2");
+		Require(
+			registry.RegisterAssetInfoHandler(extensions, &handler),
+			"the targeted update handler should register for raw assets");
 	}
 
 	void TestPayloadRoundTrip()
@@ -403,8 +568,14 @@ namespace
 		Require(entry.m_fileId == fileId, "round-tripped entry identity should match its map key");
 		Require(entry.m_assetImportTime == 40, "round-tripped asset import time should be preserved");
 		Require(!entry.m_sourcePath.empty(), "round-tripped source path should be normalized");
-		Require(entry.m_sourceRevision == MakeRevision(),
-			"round-tripped exact source revision should be preserved");
+		const FileRevision expectedRevision = MakeRevision();
+		Require(
+			entry.m_sourceRevision.m_modificationTimeNanoseconds ==
+				expectedRevision.m_modificationTimeNanoseconds &&
+			entry.m_sourceRevision.m_fileSize == expectedRevision.m_fileSize &&
+			entry.m_sourceRevision.m_contentHash == expectedRevision.m_contentHash &&
+			entry.m_sourceRevision.m_bIsValid == expectedRevision.m_bIsValid,
+			"round-tripped serialized source revision fields should be preserved");
 	}
 
 	void TestEmptyPayloadRoundTrip()
@@ -678,9 +849,11 @@ namespace
 			info.GetAssetLastModificationTime(),
 			info.GetMetaLastModificationTime());
 		WriteFile(sourcePath, "source-v2");
-		std::filesystem::last_write_time(sourcePath, initialSourceTime);
+		std::filesystem::last_write_time(
+			sourcePath,
+			initialSourceTime + std::chrono::seconds(2));
 		Require(info.IsAssetExpired(),
-			"a same-timestamp raw content change should expire by runtime revision");
+			"a newer raw source timestamp should expire the runtime revision");
 
 		TestAssetInfoHandler handler;
 		RecordingAssetListener listener;
@@ -729,9 +902,11 @@ namespace
 			"fileId: '{ASSET-CACHE-META-EXPIRED}'\n"
 			"testValue: 9\n"
 			"lateValue: 1\n");
-		std::filesystem::last_write_time(metadataPath, initialMetadataTime);
+		std::filesystem::last_write_time(
+			metadataPath,
+			initialMetadataTime + std::chrono::seconds(2));
 		Require(info.IsMetaExpired(),
-			"same-timestamp metadata content changes should expire by runtime revision");
+			"a newer metadata timestamp should expire the runtime revision");
 
 		TestAssetInfoHandler handler;
 		RecordingAssetListener listener;
@@ -802,9 +977,11 @@ namespace
 		Require(cache.IsDirty(), "a no-op update must not clear an already dirty cache");
 		Require(cache.Update(fileId, 91, sourcePath, sourceRevision),
 			"a later successful asset import should change the source watermark");
-		Require(cache.Update(fileId, 91, sourcePath, MakeRevision(123456789, 64, 42)),
-			"a changed content hash should change the exact source revision");
-		Require(cache.Update(fileId, 91, sourcePath + ".moved", MakeRevision(123456789, 64, 42)),
+		Require(!cache.Update(fileId, 91, sourcePath, MakeRevision(123456789, 64, 42)),
+			"content hash changes must not affect timestamp-based source revisions");
+		Require(!cache.Update(fileId, 91, sourcePath, MakeRevision(123456789, 128, 42)),
+			"file size changes must not affect timestamp-based source revisions");
+		Require(cache.Update(fileId, 91, sourcePath + ".moved", MakeRevision(123456789, 128, 42)),
 			"a source path change should change the cache");
 	}
 
@@ -905,15 +1082,10 @@ namespace
 
 		WriteFile(sourcePath, "source-v4");
 		std::filesystem::last_write_time(sourcePath, backdatedTime);
-		Require(cache.IsExpired(&info),
-			"a same-timestamp same-size content change must expire by content hash");
-		info.SetProcessingTimes(
-			info.GetAssetLastModificationTime(),
-			info.GetMetaLastModificationTime());
-		Require(cache.Update(&info),
-			"the same-timestamp content revision should be acknowledgeable");
 		Require(!cache.IsExpired(&info),
-			"the processed same-timestamp revision should become current");
+			"a same-timestamp same-size edit remains current without content hashing");
+		Require(!cache.Update(&info),
+			"a same-timestamp source revision should remain unchanged");
 		const std::time_t importedSourceTime = info.GetAssetImportTime();
 
 		std::filesystem::last_write_time(metadataPath, initialTime + std::chrono::seconds(4));
@@ -1083,6 +1255,273 @@ namespace
 			"the current successful completion should acknowledge its source revision");
 	}
 
+	void TestTargetedAssetUpdateScopeAndFailureContract()
+	{
+		TempDirectory directory("targeted-asset-update");
+		const Workspace::WorkspaceContext workspaceContext =
+			CreateWorkspaceContext(directory);
+		WriteTargetedUpdateFixture(workspaceContext);
+
+		AssetRegistry registry(workspaceContext);
+		TargetedUpdateAssetInfoHandler handler;
+		RecordingTargetedUpdateListener listener;
+		handler.Subscribe(&listener);
+		RegisterTargetedUpdateHandler(registry, handler);
+		Require(
+			registry.ScanContentFolder() &&
+				registry.CompleteScanProcessing(),
+			"the targeted update fixture should load");
+
+		const FileId primaryId =
+			MakeFileId("{TARGETED-UPDATE-PRIMARY}");
+		const FileId secondaryId =
+			MakeFileId("{TARGETED-UPDATE-SECONDARY}");
+		auto* primaryInfo = registry.GetAssetInfoPtr<
+			TargetedUpdateAssetInfo*>(primaryId);
+		auto* secondaryInfo = registry.GetAssetInfoPtr<
+			TargetedUpdateAssetInfo*>(secondaryId);
+		Require(
+			primaryInfo != nullptr && secondaryInfo != nullptr,
+			"both AssetInfos sharing one source should be registered");
+
+		listener.Clear();
+		RewriteFileWithNewRevision(
+			workspaceContext.GetContent() / "Shared.raw.asset",
+			"fileId: '{TARGETED-UPDATE-PRIMARY}'\n"
+			"filename: Shared.raw\n"
+			"testValue: 11\n");
+		Require(
+			registry.UpdateAsset(primaryId),
+			"a valid metadata-only targeted update should succeed");
+		Require(
+			listener.m_updatedFileIds ==
+				std::vector<FileId>{ primaryId } &&
+				listener.m_expirationFlags ==
+					std::vector<bool>{ true },
+			"metadata-only updates must notify exactly the requested AssetInfo");
+		Require(
+			primaryInfo->GetTestValue() == 11 &&
+				secondaryInfo->GetTestValue() == 2,
+			"metadata-only updates must not mutate a sibling AssetInfo");
+
+		listener.Clear();
+		Require(
+			registry.UpdateAsset(primaryId) &&
+				listener.m_updatedFileIds.empty(),
+			"an already-current targeted asset should be a successful no-op");
+
+		RewriteFileWithNewRevision(
+			workspaceContext.GetContent() / "Shared.raw",
+			"shared-source-v2");
+		Require(
+			registry.UpdateAsset(primaryId),
+			"a shared source update should succeed for its whole AssetInfo family");
+		Require(
+			listener.m_updatedFileIds ==
+				std::vector<FileId>{ primaryId, secondaryId } &&
+				listener.m_expirationFlags ==
+					std::vector<bool>{ true, true },
+			"a changed source must notify every AssetInfo that references it");
+		Require(
+			!primaryInfo->IsAssetExpired() &&
+				!secondaryInfo->IsAssetExpired() &&
+				!registry.IsAssetExpired(primaryInfo) &&
+				!registry.IsAssetExpired(secondaryInfo),
+			"the shared source family should commit one current revision");
+
+		listener.Clear();
+		RewriteFileWithNewRevision(
+			workspaceContext.GetContent() / "Shared.raw2.asset",
+			"fileId: '{TARGETED-UPDATE-SECONDARY}'\n"
+			"filename: Shared.raw\n"
+			"testValue: invalid\n");
+		Require(
+			!registry.UpdateAsset(secondaryId),
+			"an invalid targeted metadata reload must report failure");
+		Require(
+			secondaryInfo->GetTestValue() == 2 &&
+				listener.m_updatedFileIds.empty(),
+			"a rejected targeted reload must preserve the live AssetInfo");
+		Require(
+			!registry.UpdateAsset(
+				MakeFileId("{TARGETED-UPDATE-UNKNOWN}")),
+			"an unregistered FileId must report targeted update failure");
+	}
+
+	void TestTargetedAssetUpdateCoalescesCurrentProcessing()
+	{
+		TempDirectory directory("targeted-processing-coalescing");
+		const Workspace::WorkspaceContext workspaceContext =
+			CreateWorkspaceContext(directory);
+		WriteTargetedUpdateFixture(workspaceContext);
+
+		AssetRegistry registry(workspaceContext);
+		TargetedUpdateAssetInfoHandler handler;
+		RecordingTargetedUpdateListener listener;
+		handler.Subscribe(&listener);
+		RegisterTargetedUpdateHandler(registry, handler);
+		Require(
+			registry.ScanContentFolder() &&
+				registry.CompleteScanProcessing(),
+			"the targeted processing fixture should load");
+
+		const FileId primaryId =
+			MakeFileId("{TARGETED-UPDATE-PRIMARY}");
+		AssetInfoPtr primaryInfo = registry.GetAssetInfoPtr(primaryId);
+		Require(
+			primaryInfo != nullptr,
+			"the targeted processing fixture should expose its primary AssetInfo");
+		listener.Clear();
+
+		const AssetRegistry::AssetProcessingToken activeToken =
+			registry.BeginAssetProcessing(primaryInfo);
+		Require(
+			static_cast<bool>(activeToken),
+			"the targeted asset should begin asynchronous processing");
+		Require(
+			registry.UpdateAsset(primaryId) &&
+				listener.m_updatedFileIds.empty(),
+			"a duplicate targeted request must coalesce with current processing");
+
+		registry.CompleteAssetProcessing(activeToken, false);
+		AssetRegistry::AssetProcessingToken retryToken;
+		listener.m_onUpdate =
+			[&](AssetInfoPtr assetInfo, bool bWasExpired)
+			{
+				Require(
+					bWasExpired,
+					"a rejected processing attempt must remain expired for retry");
+				retryToken = registry.BeginAssetProcessing(assetInfo);
+				Require(
+					static_cast<bool>(retryToken),
+					"the rejected processing attempt should start a new generation");
+				registry.CompleteAssetProcessing(retryToken, true);
+			};
+		Require(
+			registry.UpdateAsset(primaryId),
+			"a rejected processing attempt should be retried by a targeted update");
+		Require(
+			retryToken &&
+				retryToken.m_generation != activeToken.m_generation &&
+				listener.m_updatedFileIds ==
+					std::vector<FileId>{ primaryId },
+			"the retry must publish one new processing generation");
+	}
+
+	void TestScanSourceRevisionCacheIsPhysicalAndPerScan()
+	{
+		TempDirectory directory("scan-source-revision-cache");
+		const std::filesystem::path engineSource =
+			directory.Path("Engine/Content/Shared.glb");
+		const std::filesystem::path workspaceSource =
+			directory.Path("Workspace/Content/Shared.glb");
+		const std::filesystem::path missingSource =
+			directory.Path("Workspace/Content/Missing.glb");
+		WriteFile(engineSource, "engine-source");
+		WriteFile(workspaceSource, "workspace-source-v1");
+
+		AssetScanSourceRevisionCache scanSnapshot;
+		FileRevision engineRevision;
+		FileRevision workspaceRevision;
+		FileRevision memoizedWorkspaceRevision;
+		FileRevision missingRevision;
+		Require(
+			scanSnapshot.TryGet(engineSource.generic_string(), engineRevision) &&
+				scanSnapshot.TryGet(workspaceSource.generic_string(), workspaceRevision),
+			"one scan should capture both physical mount sources");
+		Require(
+			engineRevision != workspaceRevision,
+			"equal virtual paths in different mounts must keep independent physical revisions");
+		Require(
+			!scanSnapshot.TryGet(missingSource.generic_string(), missingRevision),
+			"a missing source should be memoized as a failed scan observation");
+
+		WriteFile(workspaceSource, "workspace-source-v2-with-another-size");
+		WriteFile(missingSource, "appeared-during-scan");
+		const std::filesystem::path equivalentWorkspacePath =
+			workspaceSource.parent_path() / "." / workspaceSource.filename();
+		Require(
+			scanSnapshot.TryGet(
+				equivalentWorkspacePath.generic_string(),
+				memoizedWorkspaceRevision) &&
+				memoizedWorkspaceRevision == workspaceRevision,
+			"one scan should reuse its first source revision for equivalent physical paths");
+		Require(
+			!scanSnapshot.TryGet(missingSource.generic_string(), missingRevision),
+			"a source that appears mid-scan should remain absent from that scan snapshot");
+		std::string changedPath;
+		Require(
+			!scanSnapshot.ValidateAll(changedPath) &&
+				!changedPath.empty(),
+			"commit validation must reject a source snapshot changed during staging");
+
+		AssetScanSourceRevisionCache nextScanSnapshot;
+		FileRevision nextWorkspaceRevision;
+		Require(
+			nextScanSnapshot.TryGet(
+				workspaceSource.generic_string(),
+				nextWorkspaceRevision) &&
+				nextWorkspaceRevision != workspaceRevision,
+			"a new scan must observe a changed physical source revision");
+		Require(
+			nextScanSnapshot.TryGet(missingSource.generic_string(), missingRevision),
+			"a new scan must retry a source that was missing from the previous snapshot");
+	}
+
+	void TestPostCallbackSourceMismatchInvalidatesPriorWatermark()
+	{
+		TempDirectory directory("post-callback-source-mismatch");
+		const Workspace::WorkspaceContext workspaceContext =
+			CreateWorkspaceContext(directory);
+		WriteScanAssetFixture(workspaceContext);
+		const FileId fileId =
+			MakeFileId("{ASSET-CACHE-IMPORT-CONTRACT}");
+		const std::filesystem::path sourcePath =
+			workspaceContext.GetContent() / "Retry.raw";
+
+		{
+			AssetRegistry registry(workspaceContext);
+			TestAssetInfoHandler handler;
+			RegisterRawHandler(registry, handler);
+			Require(
+				registry.ScanContentFolder(),
+				"the initial source watermark should commit");
+		}
+
+		AssetCache initialCache;
+		initialCache.Initialize(workspaceContext);
+		Require(
+			initialCache.Contains(fileId),
+			"the initial scan should persist its source watermark");
+
+		WriteFile(sourcePath, "source-v2-with-another-size");
+		{
+			AssetRegistry registry(workspaceContext);
+			TestAssetInfoHandler handler;
+			RecordingAssetListener listener;
+			listener.m_onExpiredUpdate =
+				[&](AssetInfoPtr)
+				{
+					WriteFile(sourcePath, "source-mutated-by-listener");
+				};
+			handler.Subscribe(&listener);
+			RegisterRawHandler(registry, handler);
+			Require(
+				registry.ScanContentFolder(),
+				"the registry generation should commit before the listener mutation is acknowledged");
+			Require(
+				!listener.m_events.empty() &&
+					listener.m_events[0] == "update:true",
+				"the changed source should dispatch an expired update");
+		}
+
+		AssetCache restartedCache;
+		restartedCache.Initialize(workspaceContext);
+		Require(
+			!restartedCache.Contains(fileId),
+			"a post-callback source mismatch must remove the prior cache watermark");
+	}
+
 	void TestRejectedBeginFailsScanAndResetsOnNextScan()
 	{
 		TempDirectory directory("rejected-begin-scan");
@@ -1139,6 +1578,134 @@ namespace
 		Require(
 			registry.CompleteScanProcessing(),
 			"scan processing failure state must reset for the next successful scan");
+	}
+
+	void TestSourceMutationDuringStagingPreservesPreviousGeneration()
+	{
+		TempDirectory directory("source-mutation-during-staging");
+		const Workspace::WorkspaceContext workspaceContext =
+			CreateWorkspaceContext(directory);
+		WriteScanAssetFixture(workspaceContext);
+		const std::filesystem::path sourcePath =
+			workspaceContext.GetContent() / "Retry.raw";
+
+		AssetRegistry registry(workspaceContext);
+		TestAssetInfoHandler handler;
+		RegisterRawHandler(registry, handler);
+		Require(
+			registry.ScanContentFolder(),
+			"the initial registry generation should commit");
+		AssetInfoPtr previousInfo = registry.GetAssetInfoPtr(sourcePath.string());
+		Require(previousInfo != nullptr,
+			"the initial registry generation should expose the fixture asset");
+
+		handler.m_onLoad = [&]()
+			{
+				WriteFile(sourcePath, "source-mutated-during-staging");
+			};
+		Require(
+			!registry.ScanContentFolder(),
+			"a source mutation during staging must reject the new generation");
+		Require(
+			registry.GetAssetInfoPtr(sourcePath.string()) == previousInfo,
+			"a rejected staged generation must preserve the previous asset info");
+
+		Require(
+			registry.ScanContentFolder(),
+			"the next stable scan should accept the changed source");
+		Require(
+			registry.GetAssetInfoPtr(sourcePath.string()) != nullptr,
+			"the stable retry must publish the asset again");
+	}
+
+	void TestMetadataMutationDuringPreCommitWaitPreservesPreviousGeneration()
+	{
+		TempDirectory directory("metadata-mutation-during-pre-commit-wait");
+		const Workspace::WorkspaceContext workspaceContext =
+			CreateWorkspaceContext(directory);
+		WriteScanAssetFixture(workspaceContext);
+		const std::filesystem::path sourcePath =
+			workspaceContext.GetContent() / "Retry.raw";
+		const std::filesystem::path metadataPath =
+			workspaceContext.GetContent() / "Retry.raw.asset";
+
+		Require(App::GetInstance() == nullptr,
+			"the deterministic pre-commit test requires an isolated App instance");
+		const std::string missingWorkspace =
+			directory.Path("MissingWorkspace").generic_string();
+		const char* appArgs[] = {
+			"AssetCacheContractTests",
+			"--noconsole",
+			"--workspace",
+			missingWorkspace.c_str()
+		};
+		App::Initialize(appArgs, static_cast<int32_t>(std::size(appArgs)));
+
+		try
+		{
+			Require(App::GetInstance() != nullptr,
+				"the isolated App instance should be available to register a scheduler");
+			Require(App::GetSubmodule<Tasks::Scheduler>() == nullptr,
+				"the intentionally invalid workspace must stop App initialization before scheduler startup");
+			Tasks::Scheduler* scheduler = App::AddSubmodule(
+				TSubmodule<Tasks::Scheduler>::Make());
+			scheduler->AttachCurrentThreadAsMainThread();
+
+			{
+				AssetRegistry registry(workspaceContext);
+				TestAssetInfoHandler handler;
+				RegisterRawHandler(registry, handler);
+				Require(
+					registry.ScanContentFolder(),
+					"the initial registry generation should commit");
+				AssetInfoPtr previousInfo = registry.GetAssetInfoPtr(sourcePath.string());
+				Require(previousInfo != nullptr,
+					"the initial registry generation should expose the fixture asset");
+
+				bool bMetadataMutatedDuringWait = false;
+				handler.m_onLoad = [&]()
+					{
+						Tasks::ITaskPtr mutationTask =
+							TSharedPtr<TestMainThreadTask>::Make(
+								[&]()
+								{
+									bMetadataMutatedDuringWait = true;
+									WriteFile(
+										metadataPath,
+										"fileId: '{ASSET-CACHE-IMPORT-CONTRACT}'\n"
+										"filename: Retry.raw\n"
+										"testValue: 8\n"
+										"lateValue: 1\n");
+								});
+						scheduler->Run(mutationTask);
+						Require(!bMetadataMutatedDuringWait,
+							"the metadata mutation must remain queued until the pre-commit wait");
+					};
+
+				Require(
+					!registry.ScanContentFolder(),
+					"a metadata mutation during the pre-commit wait must reject the new generation");
+				Require(bMetadataMutatedDuringWait,
+					"the metadata mutation must execute inside the pre-commit wait");
+				Require(
+					registry.GetAssetInfoPtr(sourcePath.string()) == previousInfo,
+					"a rejected staged generation must preserve the previous asset info");
+
+				Require(
+					registry.ScanContentFolder(),
+					"the next stable scan should accept the changed metadata");
+				Require(
+					registry.GetAssetInfoPtr(sourcePath.string()) != nullptr,
+					"the stable retry must publish the asset again");
+			}
+
+			App::Shutdown();
+		}
+		catch (...)
+		{
+			App::Shutdown();
+			throw;
+		}
 	}
 
 	void TestSynchronousFailedCompletionFailsScan()
@@ -1354,6 +1921,12 @@ int main()
 		TestRemovingFailedProcessingWatermarkForcesRetry();
 		TestInvalidatedProcessingWatermarkPersistsAcrossCacheInstances();
 		TestAssetProcessingSuccessAndStaleCompletionContract();
+		TestTargetedAssetUpdateScopeAndFailureContract();
+		TestTargetedAssetUpdateCoalescesCurrentProcessing();
+		TestScanSourceRevisionCacheIsPhysicalAndPerScan();
+		TestPostCallbackSourceMismatchInvalidatesPriorWatermark();
+		TestSourceMutationDuringStagingPreservesPreviousGeneration();
+		TestMetadataMutationDuringPreCommitWaitPreservesPreviousGeneration();
 		TestRejectedBeginFailsScanAndResetsOnNextScan();
 		TestSynchronousFailedCompletionFailsScan();
 		TestSourceMutationRejectsCompletionAndFailsScan();

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -1419,6 +1419,14 @@ namespace
 			directory.Path("Workspace/Content/Missing.glb");
 		WriteFile(engineSource, "engine-source");
 		WriteFile(workspaceSource, "workspace-source-v1");
+		std::error_code timestampError;
+		std::filesystem::last_write_time(
+			workspaceSource,
+			std::filesystem::last_write_time(engineSource) + std::chrono::seconds(2),
+			timestampError);
+		Require(
+			!timestampError,
+			"the physical source fixture must use distinct file revisions");
 
 		AssetScanSourceRevisionCache scanSnapshot;
 		FileRevision engineRevision;
@@ -1436,7 +1444,9 @@ namespace
 			!scanSnapshot.TryGet(missingSource.generic_string(), missingRevision),
 			"a missing source should be memoized as a failed scan observation");
 
-		WriteFile(workspaceSource, "workspace-source-v2-with-another-size");
+		RewriteFileWithNewRevision(
+			workspaceSource,
+			"workspace-source-v2-with-another-size");
 		WriteFile(missingSource, "appeared-during-scan");
 		const std::filesystem::path equivalentWorkspacePath =
 			workspaceSource.parent_path() / "." / workspaceSource.filename();

--- a/Tests/BoundsContractTests.cpp
+++ b/Tests/BoundsContractTests.cpp
@@ -27,6 +27,13 @@ namespace
 			std::abs(lhs.z - rhs.z) <= epsilon;
 	}
 
+	float ProjectDepth(const glm::mat4& projectionView, const glm::vec3& point)
+	{
+		const glm::vec4 clip = projectionView * glm::vec4(point, 1.0f);
+		Require(std::abs(clip.w) > 0.000001f, "projected point must have a valid homogeneous coordinate");
+		return clip.z / clip.w;
+	}
+
 	void TestValidityRejectsSentinelAndInvertedBounds()
 	{
 		const Math::AABB defaultBounds;
@@ -72,6 +79,39 @@ namespace
 		Require(IsNear(bounds.m_max, glm::vec3(-8.0f, -18.0f, -28.0f)),
 			"transformed all-negative maximum must include every corner");
 	}
+
+	void TestReversedShadowProjectionUsesZeroToOneDepth()
+	{
+		Math::Frustum cameraSlice;
+		const glm::mat4 cameraWorld = glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, 100.0f));
+		cameraSlice.ExtractFrustumPlanes(cameraWorld, 16.0f / 9.0f, 60.0f, 1.0f, 10.0f);
+
+		const glm::mat4 shadowProjection = cameraSlice.CalculateOrthoMatrixByView(glm::mat4(1.0f), 10.0f);
+		for (const glm::vec3& corner : cameraSlice.GetCorners())
+		{
+			const float depth = ProjectDepth(shadowProjection, corner);
+			Require(std::isfinite(depth) && depth >= -0.0001f && depth <= 1.0001f,
+				"every fitted shadow-cascade corner must remain inside Vulkan's zero-to-one depth range");
+		}
+	}
+
+	void TestReverseZFrustumCornersUseZeroToOneDepth()
+	{
+		const glm::mat4 projection = glm::orthoRH_ZO(-2.0f, 2.0f, -3.0f, 3.0f, 100.0f, 1.0f);
+		const Math::Frustum frustum(projection);
+
+		for (uint32_t i = 0; i < 4; i++)
+		{
+			Require(std::abs(ProjectDepth(projection, frustum.GetCorners()[i])) <= 0.0001f,
+				"reverse-Z far corners must be reconstructed from the Vulkan depth-zero plane");
+		}
+
+		for (uint32_t i = 4; i < 8; i++)
+		{
+			Require(std::abs(ProjectDepth(projection, frustum.GetCorners()[i]) - 1.0f) <= 0.0001f,
+				"reverse-Z near corners must be reconstructed from the Vulkan depth-one plane");
+		}
+	}
 }
 
 int main()
@@ -80,6 +120,8 @@ int main()
 		{ "ValidityRejectsSentinelAndInvertedBounds", TestValidityRejectsSentinelAndInvertedBounds },
 		{ "ValidityRejectsNonFiniteBounds", TestValidityRejectsNonFiniteBounds },
 		{ "TransformPreservesAllNegativeBounds", TestTransformPreservesAllNegativeBounds },
+		{ "ReversedShadowProjectionUsesZeroToOneDepth", TestReversedShadowProjectionUsesZeroToOneDepth },
+		{ "ReverseZFrustumCornersUseZeroToOneDepth", TestReverseZFrustumCornersUseZeroToOneDepth },
 	};
 
 	for (const auto& test : tests)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -63,6 +63,14 @@ add_executable(BoundsContractTests
     BoundsContractTests.cpp
 )
 
+add_executable(ModelImporterContractTests
+    ModelImporterContractTests.cpp
+)
+
+add_executable(VulkanDescriptorCacheTests
+    VulkanDescriptorCacheTests.cpp
+)
+
 add_executable(EditorViewportControllerContractTests
     EditorViewportControllerContractTests.cpp
 )
@@ -196,6 +204,11 @@ target_compile_features(SmartPointerTests PRIVATE cxx_std_20)
 target_compile_features(InstanceIdContractTests PRIVATE cxx_std_20)
 target_compile_features(EcsLifecycleContractTests PRIVATE cxx_std_20)
 target_compile_features(BoundsContractTests PRIVATE cxx_std_20)
+target_compile_features(ModelImporterContractTests PRIVATE cxx_std_20)
+target_compile_features(VulkanDescriptorCacheTests PRIVATE cxx_std_20)
+target_compile_definitions(VulkanDescriptorCacheTests PRIVATE
+    SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
+)
 target_compile_features(EditorViewportControllerContractTests PRIVATE cxx_std_20)
 target_compile_features(SkyComponentContractTests PRIVATE cxx_std_20)
 target_compile_definitions(SkyComponentContractTests PRIVATE
@@ -245,6 +258,8 @@ target_link_libraries(SmartPointerTests PRIVATE Sailor::Runtime)
 target_link_libraries(InstanceIdContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(EcsLifecycleContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(BoundsContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(ModelImporterContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(VulkanDescriptorCacheTests PRIVATE Sailor::Runtime)
 target_link_libraries(EditorViewportControllerContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(SkyComponentContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(AssetMountDiscoveryTests PRIVATE Sailor::Runtime)
@@ -288,6 +303,8 @@ if(WIN32)
     sailor_stage_workspace_test_runtime(ShaderCacheArtifactTests)
     sailor_stage_workspace_test_runtime(EcsLifecycleContractTests)
     sailor_stage_workspace_test_runtime(BoundsContractTests)
+    sailor_stage_workspace_test_runtime(ModelImporterContractTests)
+    sailor_stage_workspace_test_runtime(VulkanDescriptorCacheTests)
     sailor_stage_workspace_test_runtime(EditorViewportControllerContractTests)
     sailor_stage_workspace_test_runtime(SkyComponentContractTests)
     sailor_stage_workspace_test_runtime(RemoteViewportRuntimeTests)
@@ -335,6 +352,12 @@ target_include_directories(EcsLifecycleContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(BoundsContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(ModelImporterContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(VulkanDescriptorCacheTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(EditorViewportControllerContractTests PRIVATE
@@ -461,6 +484,16 @@ add_test(
 )
 
 add_test(
+    NAME ModelImporterContractTests
+    COMMAND ModelImporterContractTests
+)
+
+add_test(
+    NAME VulkanDescriptorCacheTests
+    COMMAND VulkanDescriptorCacheTests
+)
+
+add_test(
     NAME EditorViewportControllerContractTests
     COMMAND EditorViewportControllerContractTests
 )
@@ -564,6 +597,8 @@ set_tests_properties(
     InstanceIdContractTests
     EcsLifecycleContractTests
     BoundsContractTests
+    ModelImporterContractTests
+    VulkanDescriptorCacheTests
     EditorViewportControllerContractTests
     SkyComponentContractTests
     EditorEngineProtocolTests

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -63,6 +63,10 @@ add_executable(BoundsContractTests
     BoundsContractTests.cpp
 )
 
+add_executable(GpuCullingContractTests
+    GpuCullingContractTests.cpp
+)
+
 add_executable(ModelImporterContractTests
     ModelImporterContractTests.cpp
 )
@@ -204,6 +208,10 @@ target_compile_features(SmartPointerTests PRIVATE cxx_std_20)
 target_compile_features(InstanceIdContractTests PRIVATE cxx_std_20)
 target_compile_features(EcsLifecycleContractTests PRIVATE cxx_std_20)
 target_compile_features(BoundsContractTests PRIVATE cxx_std_20)
+target_compile_features(GpuCullingContractTests PRIVATE cxx_std_20)
+target_compile_definitions(GpuCullingContractTests PRIVATE
+    SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
+)
 target_compile_features(ModelImporterContractTests PRIVATE cxx_std_20)
 target_compile_features(VulkanDescriptorCacheTests PRIVATE cxx_std_20)
 target_compile_definitions(VulkanDescriptorCacheTests PRIVATE
@@ -258,6 +266,7 @@ target_link_libraries(SmartPointerTests PRIVATE Sailor::Runtime)
 target_link_libraries(InstanceIdContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(EcsLifecycleContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(BoundsContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(GpuCullingContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(ModelImporterContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(VulkanDescriptorCacheTests PRIVATE Sailor::Runtime)
 target_link_libraries(EditorViewportControllerContractTests PRIVATE Sailor::Runtime)
@@ -303,6 +312,7 @@ if(WIN32)
     sailor_stage_workspace_test_runtime(ShaderCacheArtifactTests)
     sailor_stage_workspace_test_runtime(EcsLifecycleContractTests)
     sailor_stage_workspace_test_runtime(BoundsContractTests)
+    sailor_stage_workspace_test_runtime(GpuCullingContractTests)
     sailor_stage_workspace_test_runtime(ModelImporterContractTests)
     sailor_stage_workspace_test_runtime(VulkanDescriptorCacheTests)
     sailor_stage_workspace_test_runtime(EditorViewportControllerContractTests)
@@ -352,6 +362,9 @@ target_include_directories(EcsLifecycleContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(BoundsContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(GpuCullingContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(ModelImporterContractTests PRIVATE
@@ -484,6 +497,11 @@ add_test(
 )
 
 add_test(
+    NAME GpuCullingContractTests
+    COMMAND GpuCullingContractTests
+)
+
+add_test(
     NAME ModelImporterContractTests
     COMMAND ModelImporterContractTests
 )
@@ -597,6 +615,7 @@ set_tests_properties(
     InstanceIdContractTests
     EcsLifecycleContractTests
     BoundsContractTests
+    GpuCullingContractTests
     ModelImporterContractTests
     VulkanDescriptorCacheTests
     EditorViewportControllerContractTests

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -611,6 +611,54 @@ namespace
 		Require(data.GetMaterials().IsEmpty(), "clearing a model should clear its stale material overrides");
 	}
 
+	void TestStaticMeshProxyPublishesTransformRevisionForShadowInvalidation()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string rendererEcsSource = ReadText(
+			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
+		const size_t staticUpdateBegin = rendererEcsSource.find(
+			"StaticMeshRendererECS:Update Static Objects");
+		const size_t copySceneViewBegin = rendererEcsSource.find(
+			"void StaticMeshRendererECS::CopySceneView", staticUpdateBegin);
+		Require(staticUpdateBegin != std::string::npos &&
+			copySceneViewBegin > staticUpdateBegin,
+			"static mesh renderer must expose a bounded static-proxy update path");
+
+		const std::string staticUpdateBody = rendererEcsSource.substr(
+			staticUpdateBegin, copySceneViewBegin - staticUpdateBegin);
+		Require(staticUpdateBody.find(
+			"proxy.m_frame = ownerTransform.GetFrameLastChange();") !=
+			std::string::npos,
+			"static mesh proxies must publish transform revisions so moving shadow casters invalidate cached CSM passes");
+	}
+
+	void TestCsmSnapshotTracksCastersBeforeDependencyFiltering()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string lightingEcsSource = ReadText(
+			sourceRoot / "Runtime/ECS/LightingECS.cpp");
+		const size_t prepareCsmBegin = lightingEcsSource.find(
+			"LightingECS::PrepareCSMPasses");
+		const size_t fillLightingBegin = lightingEcsSource.find(
+			"void LightingECS::FillLightingData", prepareCsmBegin);
+		Require(prepareCsmBegin != std::string::npos &&
+			fillLightingBegin > prepareCsmBegin,
+			"lighting ECS must expose a bounded CSM preparation path");
+
+		const std::string prepareCsmBody = lightingEcsSource.substr(
+			prepareCsmBegin, fillLightingBegin - prepareCsmBegin);
+		const size_t traceScene = prepareCsmBody.find(
+			"cascade.m_meshList = sceneView->TraceScene");
+		const size_t captureCaster = prepareCsmBody.find(
+			"snapshot.m_snapshot.Add({ m.m_staticMeshEcs, m.m_frame });");
+		const size_t filterDependency = prepareCsmBody.find(
+			"cascade.m_meshList.RemoveAll");
+		Require(traceScene != std::string::npos &&
+			captureCaster > traceScene &&
+			filterDependency > captureCaster,
+			"CSM invalidation snapshots must capture the complete traced caster list before dependency draw-call filtering");
+	}
+
 	void TestAnimationGpuBoneLayoutContract()
 	{
 		const uint32_t invalidOffset = AnimatorComponentData::InvalidGpuOffset;
@@ -975,6 +1023,111 @@ namespace
 		FileId fileId;
 		fileId.Deserialize(YAML::Node(value));
 		return fileId;
+	}
+
+	void TestMeshRendererMaterialOverridesAreReflectedAndPersisted()
+	{
+		auto areOverridesEquivalent = [](const TVector<FileId>& lhs, const TVector<FileId>& rhs)
+			{
+				if (lhs.Num() != rhs.Num())
+				{
+					return false;
+				}
+
+				for (size_t materialIndex = 0; materialIndex < lhs.Num(); ++materialIndex)
+				{
+					if (static_cast<bool>(lhs[materialIndex]) != static_cast<bool>(rhs[materialIndex]) ||
+						(lhs[materialIndex] && lhs[materialIndex] != rhs[materialIndex]))
+					{
+						return false;
+					}
+				}
+
+				return true;
+			};
+
+		const auto& properties = MeshRendererComponent::GetStaticTypeInfo().Properties();
+		Require(properties.ContainsKey("overrideMaterials") &&
+			properties["overrideMaterials"] == "List<FileId>",
+			"mesh renderer material overrides must be exported as an editable FileId list");
+
+		PrefabTestWorld world;
+		auto root = world.Instantiate("MaterialOverrides");
+		auto meshRenderer = root->AddComponent<MeshRendererComponent>();
+		Require(meshRenderer->GetOverrideMaterials().IsEmpty(),
+			"a mesh renderer must not copy model defaults into its authored material overrides");
+		const ReflectedData defaultReflection = meshRenderer->GetReflectedData();
+		const bool bHasDefaultOverrides =
+			defaultReflection.GetProperties().ContainsKey("overrideMaterials");
+		const YAML::Node defaultOverrides = bHasDefaultOverrides
+			? defaultReflection.GetProperties()["overrideMaterials"]
+			: YAML::Node();
+		Require(!bHasDefaultOverrides || defaultOverrides.IsNull() ||
+			(defaultOverrides.IsSequence() && defaultOverrides.size() == 0),
+			"a mesh renderer must omit or serialize its default material override list as empty: " +
+			YAML::Dump(defaultOverrides));
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string componentSource = ReadText(
+			sourceRoot / "Runtime/Components/MeshRendererComponent.cpp");
+		const size_t rebuildBegin = componentSource.find(
+			"void MeshRendererComponent::RebuildMaterials()");
+		const size_t rebuildEnd = componentSource.find(
+			"bool MeshRendererComponent::LoadModel", rebuildBegin);
+		Require(rebuildBegin != std::string::npos && rebuildEnd != std::string::npos,
+			"mesh renderer must expose its material rebuild path");
+		const std::string rebuildBody = componentSource.substr(
+			rebuildBegin, rebuildEnd - rebuildBegin);
+		Require(rebuildBody.find("LoadDefaultMaterials(model->GetFileId(), materials)") != std::string::npos,
+			"an empty override list must continue resolving the model's default runtime materials");
+		Require(rebuildBody.find("m_overrideMaterials = modelInfo->GetDefaultMaterials()") == std::string::npos,
+			"model defaults must not become serialized component overrides");
+
+		const FileId firstMaterial =
+			DeserializeFileId("{11111111-AAAA-BBBB-CCCC-111111111111}");
+		const FileId secondMaterial =
+			DeserializeFileId("{22222222-AAAA-BBBB-CCCC-222222222222}");
+		TVector<FileId> overrides{ firstMaterial, FileId::Invalid, secondMaterial };
+
+		meshRenderer->SetOverrideMaterials(overrides);
+		Require(meshRenderer->GetOverrideMaterials() == overrides,
+			"assigning material overrides must preserve their slot order and inherited gaps");
+		Require(meshRenderer->GetData().IsDirty(),
+			"assigning material overrides must invalidate the renderer ECS data");
+
+		const ReflectedData reflection = meshRenderer->GetReflectedData();
+		Require(reflection.GetProperties().ContainsKey("overrideMaterials"),
+			"mesh renderer reflection must contain material overrides");
+		const YAML::Node& reflectedOverrides =
+			reflection.GetProperties()["overrideMaterials"];
+		Require(reflectedOverrides.IsSequence(),
+			"mesh renderer reflection must serialize material overrides as a sequence: " +
+			YAML::Dump(reflectedOverrides));
+		Require(areOverridesEquivalent(
+				reflectedOverrides.as<TVector<FileId>>(), overrides),
+			"mesh renderer reflection must serialize every override material slot: " +
+			YAML::Dump(reflectedOverrides));
+
+		PrefabPtr captured = PrefabDocumentTestAsset::Capture(world, root);
+		const YAML::Node serializedPrefab = captured->Serialize();
+		world.DestroyImmediate(root);
+
+		PrefabPtr restoredPrefab = DeserializePrefab(world, serializedPrefab);
+		auto restoredRoot = world.Instantiate(restoredPrefab, true);
+		Require(static_cast<bool>(restoredRoot),
+			"a prefab containing material overrides must survive a YAML round trip");
+		auto restoredRenderer = restoredRoot->GetComponent<MeshRendererComponent>();
+		Require(restoredRenderer && areOverridesEquivalent(
+			restoredRenderer->GetOverrideMaterials(), overrides),
+			"prefab instantiation must restore component-owned material overrides");
+
+		restoredRenderer->SetModel(ModelPtr());
+		Require(areOverridesEquivalent(
+			restoredRenderer->GetOverrideMaterials(), overrides),
+			"an unresolved or null model must not discard serialized material overrides");
+		Require(restoredRenderer->GetMaterials().IsEmpty(),
+			"a null model must clear resolved runtime materials while preserving override IDs");
+		world.Clear();
 	}
 
 	InstanceId DeserializeInstanceId(const char* value)
@@ -3143,6 +3296,9 @@ int main()
 		{ "EditorKeepWorldReparentRejectsShearedCandidateWithoutMutation", TestEditorKeepWorldReparentRejectsShearedCandidateWithoutMutation },
 		{ "OctreeRelocationPreservesElementCount", TestOctreeRelocationPreservesElementCount },
 		{ "ClearingMeshModelAlsoClearsMaterials", TestClearingMeshModelAlsoClearsMaterials },
+		{ "StaticMeshProxyPublishesTransformRevisionForShadowInvalidation", TestStaticMeshProxyPublishesTransformRevisionForShadowInvalidation },
+		{ "CsmSnapshotTracksCastersBeforeDependencyFiltering", TestCsmSnapshotTracksCastersBeforeDependencyFiltering },
+		{ "MeshRendererMaterialOverridesAreReflectedAndPersisted", TestMeshRendererMaterialOverridesAreReflectedAndPersisted },
 		{ "AnimationGpuBoneLayoutContract", TestAnimationGpuBoneLayoutContract },
 		{ "ExpiredWorldPrefabInvalidatesLoadedCacheContract", TestExpiredWorldPrefabInvalidatesLoadedCacheContract },
 		{ "EmptyEditorWorldBootstrapContract", TestEmptyEditorWorldBootstrapContract },

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -695,6 +695,31 @@ namespace
 			"CSM invalidation snapshots must capture the complete traced caster list before dependency draw-call filtering");
 	}
 
+	void TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves()
+	{
+		Require(std::abs(LightingECS::ShadowCascadeLevels[LightingECS::NumCascades - 1] - 1.0f) <= 0.0001f,
+			"the last shadow cascade must reach the camera far plane");
+
+		const glm::mat4 cachedLightMatrix(1.0f);
+		glm::mat4 movedLightMatrix = cachedLightMatrix;
+		movedLightMatrix[3].x = 0.01f;
+
+		CSMLightState cachedState{};
+		cachedState.m_componentIndex = 7u;
+		cachedState.m_shadowType = RHI::EShadowType::PCF;
+		cachedState.m_lightMatrix = cachedLightMatrix;
+		cachedState.m_snapshot.Add({ 11u, 19u });
+
+		CSMLightState movedState{};
+		movedState.m_componentIndex = cachedState.m_componentIndex;
+		movedState.m_shadowType = cachedState.m_shadowType;
+		movedState.m_lightMatrix = movedLightMatrix;
+		movedState.m_snapshot.Add({ 11u, 19u });
+
+		Require(!movedState.Equals(cachedState),
+			"a changed cascade projection must invalidate the cached shadow map even for camera motion below the old threshold");
+	}
+
 	void TestAnimationGpuBoneLayoutContract()
 	{
 		const uint32_t invalidOffset = AnimatorComponentData::InvalidGpuOffset;
@@ -3335,6 +3360,7 @@ int main()
 		{ "StaticMeshProxyPublishesTransformRevisionForShadowInvalidation", TestStaticMeshProxyPublishesTransformRevisionForShadowInvalidation },
 		{ "StaticMeshProxyTracksMaterialContentRevisions", TestStaticMeshProxyTracksMaterialContentRevisions },
 		{ "CsmSnapshotTracksCastersBeforeDependencyFiltering", TestCsmSnapshotTracksCastersBeforeDependencyFiltering },
+		{ "CsmSnapshotInvalidatesWhenCascadeProjectionMoves", TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves },
 		{ "MeshRendererMaterialOverridesAreReflectedAndPersisted", TestMeshRendererMaterialOverridesAreReflectedAndPersisted },
 		{ "AnimationGpuBoneLayoutContract", TestAnimationGpuBoneLayoutContract },
 		{ "ExpiredWorldPrefabInvalidatesLoadedCacheContract", TestExpiredWorldPrefabInvalidatesLoadedCacheContract },

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -632,6 +632,42 @@ namespace
 			"static mesh proxies must publish transform revisions so moving shadow casters invalidate cached CSM passes");
 	}
 
+	void TestStaticMeshProxyTracksMaterialContentRevisions()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string rendererEcsHeader = ReadText(
+			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.h");
+		Require(rendererEcsHeader.find("TVector<uint64_t> m_materialContentRevisions;") !=
+			std::string::npos,
+			"static mesh renderer data must retain the material revisions represented by its cached proxy");
+
+		const std::string rendererEcsSource = ReadText(
+			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
+		const size_t staticUpdateBegin = rendererEcsSource.find(
+			"StaticMeshRendererECS:Update Static Objects");
+		const size_t copySceneViewBegin = rendererEcsSource.find(
+			"void StaticMeshRendererECS::CopySceneView", staticUpdateBegin);
+		Require(staticUpdateBegin != std::string::npos &&
+			copySceneViewBegin > staticUpdateBegin,
+			"static mesh renderer must expose a bounded static-proxy update path");
+
+		const std::string staticUpdateBody = rendererEcsSource.substr(
+			staticUpdateBegin, copySceneViewBegin - staticUpdateBegin);
+		const size_t captureCurrentRevision = staticUpdateBody.find(
+			"material->GetContentRevision()");
+		const size_t compareCachedRevisions = staticUpdateBody.find(
+			"data.m_materialContentRevisions[materialIndex] != materialContentRevision");
+		const size_t rebuildForChangedMaterial = staticUpdateBody.find(
+			"data.m_bIsDirty || bMaterialsChanged ||");
+		const size_t cacheRebuiltRevisions = staticUpdateBody.find(
+			"data.m_materialContentRevisions[i] = data.GetMaterials()[i]->GetContentRevision();");
+		Require(captureCurrentRevision != std::string::npos &&
+			compareCachedRevisions > captureCurrentRevision &&
+			rebuildForChangedMaterial > compareCachedRevisions &&
+			cacheRebuiltRevisions > rebuildForChangedMaterial,
+			"a same-pointer material mutation must rebuild the static proxy before caching its new content revision");
+	}
+
 	void TestCsmSnapshotTracksCastersBeforeDependencyFiltering()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -3297,6 +3333,7 @@ int main()
 		{ "OctreeRelocationPreservesElementCount", TestOctreeRelocationPreservesElementCount },
 		{ "ClearingMeshModelAlsoClearsMaterials", TestClearingMeshModelAlsoClearsMaterials },
 		{ "StaticMeshProxyPublishesTransformRevisionForShadowInvalidation", TestStaticMeshProxyPublishesTransformRevisionForShadowInvalidation },
+		{ "StaticMeshProxyTracksMaterialContentRevisions", TestStaticMeshProxyTracksMaterialContentRevisions },
 		{ "CsmSnapshotTracksCastersBeforeDependencyFiltering", TestCsmSnapshotTracksCastersBeforeDependencyFiltering },
 		{ "MeshRendererMaterialOverridesAreReflectedAndPersisted", TestMeshRendererMaterialOverridesAreReflectedAndPersisted },
 		{ "AnimationGpuBoneLayoutContract", TestAnimationGpuBoneLayoutContract },

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -1,9 +1,14 @@
 #include "GraphicsDriver/Vulkan/VulkanImage.h"
 #include "GraphicsDriver/Vulkan/VulkanImageView.h"
 #include "GraphicsDriver/Vulkan/VulkanCommandBuffer.h"
+#include "AssetRegistry/Material/MaterialImporter.h"
+#include "AssetRegistry/Texture/TextureImporter.h"
+#include "FrameGraph/DepthPrepassNode.h"
+#include "FrameGraph/RenderSceneNode.h"
 #include "Raytracing/MaterialUtils.h"
 #include "RHI/Texture.h"
 
+#include <cmath>
 #include <filesystem>
 #include <fstream>
 #include <functional>
@@ -137,6 +142,99 @@ namespace
 			highZShader.find("sourceEnd") != std::string::npos &&
 			highZShader.find("texelFetch") != std::string::npos,
 			"odd-sized Hi-Z mips must explicitly reduce their complete source footprint");
+	}
+
+	void TestForwardPlusTileSynchronizationContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string cullingShader = ReadText(
+			sourceRoot / "Content/Shaders/ComputeLightCulling.shader");
+		Require(cullingShader.find(
+				"const uint offset = tileIndex * LIGHTS_PER_TILE") !=
+				std::string::npos,
+			"each Forward+ tile must own a deterministic light-list range");
+		Require(cullingShader.find("culledLights.indices[0]") ==
+				std::string::npos &&
+			cullingShader.find("atomicAdd(culledLights") ==
+				std::string::npos,
+			"Forward+ light-list allocation must not race across workgroups");
+		Require(cullingShader.find("const bool isInsideViewport") !=
+				std::string::npos &&
+			cullingShader.find("if (isInsideViewport)") !=
+				std::string::npos,
+			"partial Forward+ tiles must not sample outside the viewport");
+
+		const std::string lightCullingSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/LightCullingNode.cpp");
+		const std::string processBody = ExtractFunctionBody(
+			lightCullingSource,
+			"void LightCullingNode::Process(");
+		const size_t dispatchOffset = processBody.find("commands->Dispatch(");
+		const size_t barrierOffset = processBody.find(
+			"commands->MemoryBarrier(",
+			dispatchOffset);
+		Require(dispatchOffset != std::string::npos &&
+			barrierOffset != std::string::npos &&
+			processBody.find("EAccessBit::ShaderWrite_Bit", barrierOffset) !=
+				std::string::npos &&
+			processBody.find("EAccessBit::ShaderRead_Bit", barrierOffset) !=
+				std::string::npos,
+			"fragment lighting must wait for Forward+ compute shader writes");
+		Require(processBody.find("m_boundLightsData != sceneView.m_rhiLightsData") !=
+				std::string::npos &&
+			processBody.find("m_boundDepthAttachment != depthAttachment") !=
+				std::string::npos &&
+			processBody.find("m_bindingsViewportSize != pushConstants.m_viewportSize") !=
+				std::string::npos,
+			"Forward+ buffers must be recreated when their resource identity or extent changes");
+
+		const std::string lightingLibrary = ReadText(
+			sourceRoot / "Content/Shaders/Lighting.glsl");
+		Require(lightingLibrary.find("uint GetLightTileIndex(") !=
+				std::string::npos &&
+			lightingLibrary.find("const ivec2 tileId = clamp(") !=
+				std::string::npos,
+			"Forward+ consumers must clamp screen coordinates to the tile grid");
+		Require(lightingLibrary.find(
+				"max(roughness * roughness, 0.001)") !=
+				std::string::npos &&
+			lightingLibrary.find(
+				"max(PI * denom * denom, 1e-7)") !=
+				std::string::npos,
+			"zero-roughness GGX must remain finite");
+
+		for (const std::filesystem::path shaderPath : {
+			sourceRoot / "Content/Shaders/Standard.shader",
+			sourceRoot / "Content/Shaders/Standard_glTF.shader",
+			sourceRoot / "Content/Shaders/Debug.shader" })
+		{
+			const std::string shader = ReadText(shaderPath);
+			Require(shader.find(
+					"GetLightTileIndex(gl_FragCoord.xy, frame.viewportSize)") !=
+					std::string::npos &&
+				shader.find(
+					"min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE))") !=
+					std::string::npos &&
+				shader.find("lightsGrid.instance.length()") !=
+					std::string::npos &&
+				shader.find("culledLights.indices.length()") !=
+					std::string::npos,
+				"Forward+ shader must use the shared bounded tile lookup: " +
+					shaderPath.generic_string());
+		}
+
+		for (const std::filesystem::path shaderPath : {
+			sourceRoot / "Content/Shaders/Standard.shader",
+			sourceRoot / "Content/Shaders/Standard_glTF.shader" })
+		{
+			const std::string shader = ReadText(shaderPath);
+			Require(shader.find("light.instance.length()") !=
+					std::string::npos &&
+				shader.find("light.instance[index].type == INVALID_LIGHT_TYPE") !=
+					std::string::npos,
+				"Forward+ lighting must reject invalid light indices: " +
+					shaderPath.generic_string());
+		}
 	}
 
 	void TestVulkanMemoryBarrierRecordsPipelineBarrier()
@@ -369,6 +467,167 @@ namespace
 			"RenderScene must bind the exact transmission attachment that it samples");
 	}
 
+	void TestBakedVolumeScalePerInstanceLayoutContract()
+	{
+		Framegraph::RenderSceneNode::PerInstanceData renderInstance{};
+		DepthPrepassNode::PerInstanceData depthInstance{};
+		const size_t renderScaleOffset = static_cast<size_t>(
+			reinterpret_cast<const uint8_t*>(&renderInstance.bakedVolumeScale) -
+			reinterpret_cast<const uint8_t*>(&renderInstance));
+		const size_t depthScaleOffset = static_cast<size_t>(
+			reinterpret_cast<const uint8_t*>(&depthInstance.bakedVolumeScale) -
+			reinterpret_cast<const uint8_t*>(&depthInstance));
+
+		Require(sizeof(renderInstance) == sizeof(depthInstance) &&
+			renderScaleOffset == depthScaleOffset &&
+			renderScaleOffset == 96u &&
+			sizeof(renderInstance) == 112u &&
+			renderScaleOffset + sizeof(vec4) == sizeof(renderInstance),
+			"render, depth, and compute passes must share the 112-byte std430 per-instance stride");
+
+		RHI::RHIMesh mesh;
+		Require(mesh.m_bakedVolumeScale == glm::vec3(1.0f) &&
+			renderInstance.bakedVolumeScale == glm::vec4(1.0f) &&
+			depthInstance.bakedVolumeScale == glm::vec4(1.0f),
+			"procedural and legacy meshes must default to an identity baked volume scale");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::pair<std::filesystem::path, size_t> sharedShaders[] = {
+			{ sourceRoot / "Content/Shaders/ComputeMeshCulling.shader", 1u },
+			{ sourceRoot / "Content/Shaders/DepthOnly.shader", 1u },
+			{ sourceRoot / "Content/Shaders/Simple.shader", 1u },
+			{ sourceRoot / "Content/Shaders/Standard.shader", 2u },
+			{ sourceRoot / "Content/Shaders/Standard_glTF.shader", 2u },
+			{ sourceRoot / "Content/Shaders/Unlit.shader", 2u }
+		};
+		for (const auto& [shaderPath, expectedLayoutCount] : sharedShaders)
+		{
+			const std::string shader = ReadText(shaderPath);
+			size_t layoutCount = 0;
+			size_t searchOffset = 0;
+			while ((searchOffset = shader.find(
+				"struct PerInstanceData",
+				searchOffset)) != std::string::npos)
+			{
+				const size_t layoutEnd = shader.find("};", searchOffset);
+				Require(layoutEnd != std::string::npos,
+					"shared per-instance shader layout must remain balanced: " +
+						shaderPath.generic_string());
+				const std::string layout = shader.substr(
+					searchOffset,
+					layoutEnd - searchOffset);
+				size_t memberOffset = 0;
+				for (const char* member : {
+					"mat4 model;",
+					"vec4 sphereBounds;",
+					"uint materialInstance;",
+					"uint skeletonOffset;",
+					"uint isCulled;",
+					"uint padding;",
+					"vec4 bakedVolumeScale;" })
+				{
+					memberOffset = layout.find(member, memberOffset);
+					Require(memberOffset != std::string::npos,
+						"shared per-instance shader layouts must preserve the 112-byte std430 member order: " +
+							shaderPath.generic_string());
+					memberOffset += std::char_traits<char>::length(member);
+				}
+
+				++layoutCount;
+				searchOffset = layoutEnd + 2u;
+			}
+			Require(layoutCount == expectedLayoutCount,
+				"every shared per-instance shader stage must use the common std430 layout: " +
+					shaderPath.generic_string());
+		}
+
+		const std::string gltfShader = ReadText(
+			sourceRoot / "Content/Shaders/Standard_glTF.shader");
+		Require(gltfShader.find(
+				"data.instance[gl_InstanceIndex].bakedVolumeScale.xyz") !=
+				std::string::npos,
+			"glTF transmission must combine runtime and baked node scale");
+
+		const std::string renderSceneSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RenderSceneNode.cpp");
+		const std::string depthPrepassSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/DepthPrepassNode.cpp");
+		Require(renderSceneSource.find(
+				"vec4(mesh->m_bakedVolumeScale, 1.0f)") !=
+				std::string::npos &&
+			depthPrepassSource.find(
+				"vec4(mesh->m_bakedVolumeScale, 1.0f)") !=
+				std::string::npos,
+			"render and depth passes must upload each RHIMesh baked volume scale");
+	}
+
+	void TestPostProcessPingPongMipIsolationContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string motionBlur = ReadText(
+			sourceRoot / "Content/Shaders/MotionBlur.shader");
+		const size_t firstBaseMipSample = motionBlur.find(
+			"textureLod(colorSampler");
+		const size_t secondBaseMipSample = motionBlur.find(
+			"textureLod(colorSampler",
+			firstBaseMipSample == std::string::npos ? 0u : firstBaseMipSample + 1u);
+		Require(firstBaseMipSample != std::string::npos &&
+			secondBaseMipSample != std::string::npos &&
+			motionBlur.find("texture(colorSampler") == std::string::npos,
+			"motion blur must sample only the tone-mapped base mip after Secondary was used as an HDR transmission snapshot");
+
+		const std::string eyeAdaptationSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/EyeAdaptationNode.cpp");
+		const std::string eyeAdaptationBody = ExtractFunctionBody(
+			eyeAdaptationSource,
+			"void EyeAdaptationNode::Process(");
+		Require(eyeAdaptationBody.find("GetMipLayer(0)") !=
+				std::string::npos &&
+			eyeAdaptationBody.find(
+				"TVector<RHI::RHITexturePtr>{colorTarget}") !=
+				std::string::npos,
+			"eye adaptation must overwrite Secondary through its base-mip attachment view");
+
+		for (const std::filesystem::path rendererPath : {
+			sourceRoot / "Content/DefaultRenderer.renderer",
+			sourceRoot / "Content/EditorRenderer.renderer" })
+		{
+			const std::string renderer = ReadText(rendererPath);
+			const size_t motionBlurOffset = renderer.find(
+				"- shader: Shaders/MotionBlur.shader");
+			const size_t debugDrawOffset = renderer.find(
+				"- name: DebugDraw",
+				motionBlurOffset);
+			const size_t outputBlitOffset = renderer.find(
+				"- name: Blit",
+				debugDrawOffset);
+			const size_t renderImGuiOffset = renderer.find(
+				"- name: RenderImGui",
+				outputBlitOffset);
+			Require(motionBlurOffset != std::string::npos &&
+				debugDrawOffset != std::string::npos &&
+				outputBlitOffset != std::string::npos &&
+				renderImGuiOffset != std::string::npos,
+				"the post-process, debug overlay, and final output sequence must be explicit");
+
+			const std::string debugDraw = renderer.substr(
+				debugDrawOffset,
+				outputBlitOffset - debugDrawOffset);
+			Require(debugDraw.find("- color: Main") !=
+					std::string::npos,
+				"DebugDraw must use the HDR-compatible Main surface after MotionBlur");
+
+			const std::string outputBlit = renderer.substr(
+				outputBlitOffset,
+				renderImGuiOffset - outputBlitOffset);
+			Require(outputBlit.find("- src: Main") !=
+					std::string::npos &&
+				outputBlit.find("- dst: EditorOutput") !=
+					std::string::npos,
+				"the final blit must preserve the post-MotionBlur debug overlay");
+		}
+	}
+
 	void TestTransparentBackToFrontOrderingContract()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -459,6 +718,44 @@ namespace
 			"the configured sorting order must select the ordered rendering path");
 	}
 
+	void TestShadowCasterRenderQueueContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string shadowSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
+		const std::string processBody = ExtractFunctionBody(
+			shadowSource,
+			"void ShadowPrepassNode::Process(");
+
+		Require(processBody.find("GetHash(std::string(\"Opaque\"))") !=
+				std::string::npos &&
+			processBody.find("GetHash(std::string(\"Masked\"))") !=
+				std::string::npos &&
+			processBody.find("renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag") !=
+				std::string::npos,
+			"the shadow pass must accept only Opaque and Masked render queues");
+		Require(processBody.find("proxy.m_renderQueueTags[i]") !=
+				std::string::npos,
+			"shadow filtering must use lightweight queue metadata instead of material bindings");
+
+		const std::string sceneViewSource = ReadText(
+			sourceRoot / "Runtime/RHI/SceneView.cpp");
+		const std::string traceSceneBody = ExtractFunctionBody(
+			sceneViewSource,
+			"TVector<RHISceneViewProxy> RHISceneView::TraceScene(");
+		Require(traceSceneBody.find("m_renderQueueTags.Add") !=
+				std::string::npos &&
+			traceSceneBody.find("material->GetRenderState().GetTag()") !=
+				std::string::npos,
+			"shadow traces that skip RHI materials must still publish per-mesh render queues");
+
+		const std::string staticMeshSource = ReadText(
+			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
+		Require(staticMeshSource.find("proxy.m_renderQueueTags.Add(material->GetRenderState().GetTag())") !=
+				std::string::npos,
+			"cached static proxies must publish the same per-mesh render queues");
+	}
+
 	void TestPathTracerThicknessSamplerContract()
 	{
 		Raytracing::Material material{};
@@ -503,11 +800,13 @@ namespace
 		const std::string raytraceBody = ExtractFunctionBody(
 			pathTracerSource,
 			"vec3 PathTracer::Raytrace(");
-		Require(raytraceBody.find("sample.m_thicknessFactor > 0.0f") !=
+		Require(raytraceBody.find("material.m_thicknessFactor > 0.0f") !=
+				std::string::npos &&
+			raytraceBody.find("sample.m_thicknessFactor > 0.0f") ==
 				std::string::npos &&
 			raytraceBody.find("IsThickVolumeAtHit") !=
 				std::string::npos,
-			"primary and ambient thick-volume decisions must use texture-modulated thickness");
+			"thick-volume classification must use the scalar factor while sampled thickness remains available for attenuation");
 
 		const std::string traceSkyBody = ExtractFunctionBody(
 			pathTracerSource,
@@ -526,16 +825,68 @@ namespace
 				std::string::npos &&
 			thickVolumeBody.find("Sample<vec3>") != std::string::npos &&
 			thickVolumeBody.find(".r") != std::string::npos &&
-			thickVolumeBody.find("HasThicknessTexture()") !=
+			thickVolumeBody.find("HasThicknessTexture()") ==
 				std::string::npos &&
-			thickVolumeBody.find(".g") != std::string::npos &&
+			thickVolumeBody.find(".g") == std::string::npos &&
+			thickVolumeBody.find("material.m_thicknessFactor > 0.0f") !=
+				std::string::npos &&
 			thickVolumeBody.find("GetMaterialData") == std::string::npos,
-			"the hit predicate must sample only transmission red and thickness green");
-		Require(pathTracerSource.find("material.m_thicknessFactor > 0.0f") ==
-				std::string::npos &&
-			pathTracerSource.find("hitMaterial.m_thicknessFactor > 0.0f") ==
+			"the hit predicate must let transmission texture gate the ray without letting thickness texture change the volume type");
+	}
+
+	void TestPathTracerMaterialContentRevisionContract()
+	{
+		auto allocator = Memory::ObjectAllocatorPtr::Make(
+			Memory::EAllocationPolicy::SharedMemory_MultiThreaded);
+		MaterialPtr material = MaterialPtr::Make(allocator, FileId::Invalid);
+		TexturePtr texture = TexturePtr::Make(allocator, FileId::Invalid);
+
+		uint64_t revision = material->GetContentRevision();
+		material->SetUniform("material.transmissionFactor", 1.0f);
+		Require(material->GetContentRevision() > revision,
+			"changing a scalar uniform must advance the material content revision");
+
+		revision = material->GetContentRevision();
+		material->SetUniform("material.attenuationColor", glm::vec4(0.9f, 0.6f, 0.1f, 1.0f));
+		Require(material->GetContentRevision() > revision,
+			"changing a vector uniform must advance the material content revision");
+
+		revision = material->GetContentRevision();
+		material->SetSampler("thicknessSampler", texture);
+		Require(material->GetContentRevision() > revision,
+			"changing a sampler must advance the material content revision");
+
+		revision = material->GetContentRevision();
+		material->SetRenderState(RHI::RenderState(
+			true,
+			true,
+			0.0f,
+			false,
+			RHI::ECullMode::Back,
+			RHI::EBlendMode::None,
+			RHI::EFillMode::Fill,
+			GetHash(std::string("Transparent"))));
+		Require(material->GetContentRevision() > revision,
+			"changing render state must advance the material content revision");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string pathTracerSource = ReadText(
+			sourceRoot / "Runtime/Raytracing/PathTracer.cpp");
+		const std::string signatureBody = ExtractFunctionBody(
+			pathTracerSource,
+			"size_t ComputeMaterialsSignature(");
+		Require(signatureBody.find("GetContentRevision()") !=
 				std::string::npos,
-			"no thick-volume decision may bypass texture-modulated thickness");
+			"the path-tracing cache signature must include same-pointer material mutations");
+
+		const std::string materialSource = ReadText(
+			sourceRoot / "Runtime/AssetRegistry/Material/MaterialImporter.cpp");
+		const std::string hotReloadBody = ExtractFunctionBody(
+			materialSource,
+			"Tasks::ITaskPtr Material::OnHotReload(");
+		Require(hotReloadBody.find("AdvanceContentRevision()") !=
+				std::string::npos,
+			"dependency hot reloads must invalidate the cached CPU material and texture snapshot");
 	}
 }
 
@@ -545,13 +896,18 @@ int main()
 		{ "MipExtentUsesVulkanFloorAndClamp", TestMipExtentUsesVulkanFloorAndClamp },
 		{ "GpuCullingRangeAndSynchronizationContract", TestGpuCullingRangeAndSynchronizationContract },
 		{ "GpuCullingShaderSafetyContract", TestGpuCullingShaderSafetyContract },
+		{ "ForwardPlusTileSynchronizationContract", TestForwardPlusTileSynchronizationContract },
 		{ "VulkanMemoryBarrierRecordsPipelineBarrier", TestVulkanMemoryBarrierRecordsPipelineBarrier },
 		{ "ShaderReadOnlyBarrierSynchronizesShaderSampling", TestShaderReadOnlyBarrierSynchronizesShaderSampling },
 		{ "CommandListImageTrackingPreservesPublishedContents", TestCommandListImageTrackingPreservesPublishedContents },
 		{ "TransmissionFramebufferMipContract", TestTransmissionFramebufferMipContract },
 		{ "TransmissionFramebufferBindingUsesNodeAttachment", TestTransmissionFramebufferBindingUsesNodeAttachment },
+		{ "BakedVolumeScalePerInstanceLayoutContract", TestBakedVolumeScalePerInstanceLayoutContract },
+		{ "PostProcessPingPongMipIsolationContract", TestPostProcessPingPongMipIsolationContract },
 		{ "TransparentBackToFrontOrderingContract", TestTransparentBackToFrontOrderingContract },
+		{ "ShadowCasterRenderQueueContract", TestShadowCasterRenderQueueContract },
 		{ "PathTracerThicknessSamplerContract", TestPathTracerThicknessSamplerContract },
+		{ "PathTracerMaterialContentRevisionContract", TestPathTracerMaterialContentRevisionContract },
 	};
 
 	for (const auto& test : tests)

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -1,5 +1,7 @@
 #include "GraphicsDriver/Vulkan/VulkanImage.h"
 #include "GraphicsDriver/Vulkan/VulkanImageView.h"
+#include "GraphicsDriver/Vulkan/VulkanCommandBuffer.h"
+#include "Raytracing/MaterialUtils.h"
 #include "RHI/Texture.h"
 
 #include <filesystem>
@@ -156,6 +158,385 @@ namespace
 		Require(bufferSource.find("queues.m_computeFamily.value()") != std::string::npos,
 			"concurrently shared culling buffers must include a dedicated compute queue family");
 	}
+
+	void TestShaderReadOnlyBarrierSynchronizesShaderSampling()
+	{
+		const VkAccessFlags shaderReadAccess =
+			VulkanCommandBuffer::GetAccessFlags(
+				VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+		Require((shaderReadAccess & VK_ACCESS_SHADER_READ_BIT) != 0,
+			"shader-read image layouts must wait for prior image writes");
+
+		const VkPipelineStageFlags shaderReadStages =
+			VulkanCommandBuffer::GetPipelineStage(
+				VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+		Require((shaderReadStages & VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT) != 0,
+			"shader-read image layouts must synchronize graphics shader stages");
+	}
+
+	void TestCommandListImageTrackingPreservesPublishedContents()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string driverSource = ReadText(
+			sourceRoot /
+			"Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp");
+		const std::string barrierBody = ExtractFunctionBody(
+			driverSource,
+			"void VulkanGraphicsDriver::ImageMemoryBarrier(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr image, RHI::EImageLayout newLayout)");
+
+		Require(barrierBody.find("image->GetDefaultLayout()") !=
+			std::string::npos,
+			"a new command list must begin from the layout restored by the previous command list");
+		Require(barrierBody.find("m_initialLayout") ==
+			std::string::npos,
+			"published image contents must not be discarded as if every command list were first use");
+
+		const std::string createTextureBody = ExtractFunctionBody(
+			driverSource,
+			"RHI::RHITexturePtr VulkanGraphicsDriver::CreateTexture(");
+		Require(createTextureBody.find("RHI::EImageLayout::Undefined") !=
+			std::string::npos &&
+			createTextureBody.find("ImageMemoryBarrier") !=
+			std::string::npos,
+			"empty textures must be initialized before their default layout is assumed");
+
+		const std::string createMsaaBody = ExtractFunctionBody(
+			driverSource,
+			"RHI::RHITexturePtr VulkanGraphicsDriver::GetOrAddMsaaFramebufferRenderTarget(");
+		Require(createMsaaBody.find("defaultLayout") !=
+			std::string::npos &&
+			createMsaaBody.find("RHI::EImageLayout::Undefined") !=
+			std::string::npos &&
+			createMsaaBody.find("ImageMemoryBarrier") !=
+			std::string::npos,
+			"cached MSAA targets must be initialized in their declared attachment layout");
+	}
+
+	void TestTransmissionFramebufferMipContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		for (const std::filesystem::path rendererPath : {
+			sourceRoot / "Content/DefaultRenderer.renderer",
+			sourceRoot / "Content/EditorRenderer.renderer" })
+		{
+			const std::string renderer = ReadText(rendererPath);
+			const size_t secondaryOffset = renderer.find("- name: Secondary");
+			const size_t nextTargetOffset = renderer.find(
+				"- name:", secondaryOffset + 1u);
+			const std::string secondary = renderer.substr(
+				secondaryOffset,
+				nextTargetOffset - secondaryOffset);
+			Require(secondary.find("bGenerateMips: true") !=
+				std::string::npos,
+				"the transmission snapshot must allocate a mip chain");
+			Require(secondary.find("maxMipLevel:") ==
+				std::string::npos,
+				"the transmission snapshot must retain its complete mip chain");
+
+			const size_t snapshotOffset = renderer.find("- src: Main");
+			const size_t transparentOffset = renderer.find(
+				"- Tag: Transparent",
+				snapshotOffset);
+			const std::string snapshot = renderer.substr(
+				snapshotOffset > 128u ? snapshotOffset - 128u : 0u,
+				transparentOffset -
+					(snapshotOffset > 128u ? snapshotOffset - 128u : 0u));
+			Require(snapshot.find("GenerateMips: true") !=
+				std::string::npos,
+				"only the opaque snapshot blit should request mip generation");
+		}
+
+		const std::string blitSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/BlitNode.cpp");
+		const std::string blitBody = ExtractFunctionBody(
+			blitSource,
+			"void BlitNode::Process(");
+		Require(blitBody.find("TryGetString(\"GenerateMips\"") !=
+			std::string::npos &&
+			blitBody.find("bResolvedBlitSuccessful") !=
+			std::string::npos &&
+			blitBody.find("commands->GenerateMipMaps(commandList, dst)") !=
+			std::string::npos,
+			"snapshot mip generation must be explicit and require a valid base level");
+
+		const std::string shader = ReadText(
+			sourceRoot / "Content/Shaders/Standard_glTF.shader");
+		Require(shader.find("textureQueryLevels(g_transmissionFramebufferSampler)") !=
+			std::string::npos &&
+			shader.find("log2(transmissionFramebufferWidth)") !=
+			std::string::npos &&
+			shader.find("textureLod(") != std::string::npos &&
+			shader.find("transmissionRoughness") != std::string::npos,
+			"transmission roughness must select the opaque snapshot mip");
+		Require(shader.find("canTransmit") != std::string::npos &&
+			shader.find("GetRefractionDirection") != std::string::npos &&
+			shader.find("transmissionBrdf") != std::string::npos,
+			"transmission must reject total internal reflection independently of volume thickness and use the reflected IBL Fresnel model");
+		Require(shader.find("dot(transmissionRay, transmissionRay)") ==
+				std::string::npos &&
+			shader.find("transmissionRayLength > Epsilon") ==
+				std::string::npos,
+			"zero-thickness surfaces must retain transmission while volume attenuation remains disabled");
+		Require(shader.find("exitEdgeDistance") !=
+				std::string::npos &&
+			shader.find("environmentRadiance") != std::string::npos &&
+			shader.find("framebufferRadiance") != std::string::npos &&
+			shader.find("transmissionUvWeight") != std::string::npos,
+			"off-screen refraction must smoothly fall back from the opaque framebuffer to environment radiance");
+		Require(shader.find("return refractedDirection * thickness * modelScale") !=
+				std::string::npos &&
+			shader.find("flat vec3 modelScale") != std::string::npos,
+			"volume transmission must include runtime instance scale");
+		Require(shader.find("NdfGGXAlpha") != std::string::npos &&
+			shader.find("VisibilityGGXAlpha") != std::string::npos &&
+			shader.find("transmissionFalloff") != std::string::npos,
+			"punctual lights must contribute a rough dielectric transmission BTDF");
+
+		const std::string shaderCompilerSource = ReadText(
+			sourceRoot /
+			"Runtime/AssetRegistry/Shader/ShaderCompiler.cpp");
+		Require(shaderCompilerSource.find("DefaultBoneIdsBinding") !=
+				std::string::npos &&
+			shaderCompilerSource.find("DefaultBoneWeightsBinding") !=
+				std::string::npos,
+			"generated shader constants must include the skinned vertex bindings");
+		const std::string shaderCompilerHeader = ReadText(
+			sourceRoot /
+			"Runtime/AssetRegistry/Shader/ShaderCompiler.h");
+		const size_t cacheVersionOffset = shaderCompilerHeader.find(
+			"CacheProducerVersion =");
+		Require(cacheVersionOffset != std::string::npos &&
+			std::stoul(shaderCompilerHeader.substr(
+				shaderCompilerHeader.find('=', cacheVersionOffset) + 1u)) >= 6u,
+			"the constants cache version must regenerate existing libraries with the skinned bindings");
+		const size_t fragmentStage = shader.find("glslFragment: |");
+		Require(fragmentStage != std::string::npos &&
+			shader.find("BoneMatricesSSBO", fragmentStage) ==
+				std::string::npos,
+			"the fragment SKINNING permutation must not redeclare vertex-only bone data");
+
+		const std::string commandBufferSource = ReadText(
+			sourceRoot /
+			"Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp");
+		const std::string generateMipsBody = ExtractFunctionBody(
+			commandBufferSource,
+			"void VulkanCommandBuffer::GenerateMipMaps(");
+		Require(generateMipsBody.find(
+			"VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL") !=
+			std::string::npos,
+			"generated mip levels must end in a shader-readable layout");
+		const std::string driverSource = ReadText(
+			sourceRoot /
+			"Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp");
+		const std::string driverMipsBody = ExtractFunctionBody(
+			driverSource,
+			"void VulkanGraphicsDriver::GenerateMipMaps(");
+		Require(driverMipsBody.find("ShaderReadOnlyOptimal") !=
+			std::string::npos,
+			"the command-list layout tracker must match mip generation");
+	}
+
+	void TestTransmissionFramebufferBindingUsesNodeAttachment()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string frameGraphSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RHIFrameGraph.cpp");
+		const std::string frameGraphBody = ExtractFunctionBody(
+			frameGraphSource,
+			"bool RHIFrameGraph::Process(");
+		Require(frameGraphBody.find("GetRenderTarget(\"Secondary\")") ==
+			std::string::npos,
+			"transmission bindings must not depend on a hardcoded render-target name");
+		Require(frameGraphBody.find(
+				"node->GetResolvedAttachment(\"transmissionFramebuffer\")") !=
+				std::string::npos &&
+			frameGraphBody.find("GetDefaultTexture()") !=
+				std::string::npos,
+			"a graph without a transmission attachment must replace a stale texture binding");
+
+		const std::string renderSceneSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RenderSceneNode.cpp");
+		const std::string renderSceneBody = ExtractFunctionBody(
+			renderSceneSource,
+			"void RenderSceneNode::Process(");
+		Require(renderSceneBody.find(
+				"GetResolvedAttachment(\"transmissionFramebuffer\")") !=
+				std::string::npos &&
+			renderSceneBody.find("g_transmissionFramebufferSampler") !=
+				std::string::npos &&
+			renderSceneBody.find("AddSamplerToShaderBindings") !=
+				std::string::npos,
+			"RenderScene must bind the exact transmission attachment that it samples");
+	}
+
+	void TestTransparentBackToFrontOrderingContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		for (const std::filesystem::path rendererPath : {
+			sourceRoot / "Content/DefaultRenderer.renderer",
+			sourceRoot / "Content/EditorRenderer.renderer" })
+		{
+			const std::string renderer = ReadText(rendererPath);
+			const size_t transparentOffset = renderer.find(
+				"- Tag: Transparent");
+			Require(transparentOffset != std::string::npos,
+				"the renderer must contain a Transparent scene pass");
+			const size_t renderTargetsOffset = renderer.find(
+				"renderTargets:",
+				transparentOffset);
+			Require(renderTargetsOffset != std::string::npos,
+				"the Transparent pass must declare render targets");
+			const std::string settings = renderer.substr(
+				transparentOffset,
+				renderTargetsOffset - transparentOffset);
+			Require(settings.find("- Sorting: BackToFront") !=
+					std::string::npos,
+				"transparent rendering must explicitly request back-to-front sorting");
+			Require(settings.find("- GPUCulling: false") !=
+					std::string::npos,
+				"the ordered Transparent path must not use order-destroying GPU batch compaction");
+		}
+
+		const std::string renderSceneSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RenderSceneNode.cpp");
+		const std::string sortingBody = ExtractFunctionBody(
+			renderSceneSource,
+			"RHI::ESortingOrder RenderSceneNode::GetSortingOrder() const");
+		Require(sortingBody.find("TryGetString(\"Sorting\"") !=
+				std::string::npos &&
+			sortingBody.find("\n\tGetString(\"Sorting\"") ==
+				std::string::npos,
+			"render nodes without an explicit sorting parameter must retain the default order safely");
+		const std::string prepareBody = ExtractFunctionBody(
+			renderSceneSource,
+			"Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(");
+		Require(prepareBody.find("m_orderedDrawItems.Emplace") !=
+				std::string::npos &&
+			prepareBody.find("GetViewMatrix()") !=
+				std::string::npos &&
+			prepareBody.find("-viewCenter.z") !=
+				std::string::npos,
+			"each transparent mesh instance must retain camera-space center depth");
+		Require(prepareBody.find("m_orderedDrawItems.Sort") !=
+				std::string::npos &&
+			prepareBody.find("lhs.m_cameraDepth > rhs.m_cameraDepth") !=
+				std::string::npos &&
+			prepareBody.find("lhs.m_staticMeshEcs < rhs.m_staticMeshEcs") !=
+				std::string::npos &&
+			prepareBody.find("lhs.m_meshIndex < rhs.m_meshIndex") !=
+				std::string::npos,
+			"transparent instances must use deterministic far-to-near ordering");
+
+		const std::string orderedBody = ExtractFunctionBody(
+			renderSceneSource,
+			"void RenderSceneNode::ProcessBackToFront(");
+		Require(orderedBody.find("gpuMatricesData.Add(item.m_instanceData)") !=
+				std::string::npos &&
+			orderedBody.find("command.m_instanceCount = 1u") !=
+				std::string::npos &&
+			orderedBody.find("firstStorageInstance + i") !=
+				std::string::npos,
+			"the instance SSBO and indirect commands must share sorted indices");
+		Require(orderedBody.find("firstItem.m_batch == nextItem.m_batch") !=
+				std::string::npos &&
+			orderedBody.find("commands->DrawIndexedIndirect") !=
+				std::string::npos,
+			"only adjacent compatible transparent items may be combined into an MDI run");
+		Require(orderedBody.find("BeginSecondaryCommandList") ==
+				std::string::npos &&
+			orderedBody.find("RHIRecordDrawCallGPUCulling") ==
+				std::string::npos,
+			"back-to-front rendering must remain sequential on the primary command list");
+
+		const std::string processBody = ExtractFunctionBody(
+			renderSceneSource,
+			"void RenderSceneNode::Process(");
+		Require(processBody.find(
+				"GetSortingOrder() == RHI::ESortingOrder::BackToFront") !=
+				std::string::npos &&
+			processBody.find("ProcessBackToFront(") !=
+				std::string::npos,
+			"the configured sorting order must select the ordered rendering path");
+	}
+
+	void TestPathTracerThicknessSamplerContract()
+	{
+		Raytracing::Material material{};
+		Require(!material.HasThicknessTexture(),
+			"a path-tracing material must default to no thickness texture");
+		material.m_thicknessIndex = 0;
+		material.m_thicknessFactor = 2.0f;
+		Require(material.HasThicknessTexture(),
+			"a valid thickness texture slot must be detected");
+
+		Raytracing::CombinedSampler2D sampler;
+		sampler.Initialize<vec3>(1u, 1u, 3u);
+		sampler.SetPixel(0u, 0u, vec3(0.25f, 0.4f, 0.75f));
+		const float sampledThickness = material.m_thicknessFactor *
+			sampler.Sample<vec3>(vec2(0.5f)).g;
+		Require(std::abs(sampledThickness - 0.8f) < 0.0001f,
+			"glTF thickness must use the texture's green channel");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string pathTracerSource = ReadText(
+			sourceRoot / "Runtime/Raytracing/PathTracer.cpp");
+		const std::string materialBuilderBody = ExtractFunctionBody(
+			pathTracerSource,
+			"bool BuildRaytracingMaterialsFromRuntimeMaterials(");
+		Require(materialBuilderBody.find("samplerName == \"thicknessSampler\"") !=
+				std::string::npos &&
+			materialBuilderBody.find("outMaterial.m_thicknessIndex") !=
+				std::string::npos,
+			"runtime thickness samplers must be copied into path-tracing materials");
+
+		const std::string materialDataBody = ExtractFunctionBody(
+			pathTracerSource,
+			"LightingModel::SampledData PathTracer::GetMaterialData(");
+		Require(materialDataBody.find("HasThicknessTexture()") !=
+				std::string::npos &&
+			materialDataBody.find("m_thicknessIndex") !=
+				std::string::npos &&
+			materialDataBody.find("Sample<vec3>(uv).g") !=
+				std::string::npos,
+			"path-traced thickness must multiply the factor by the sampled glTF green channel");
+
+		const std::string raytraceBody = ExtractFunctionBody(
+			pathTracerSource,
+			"vec3 PathTracer::Raytrace(");
+		Require(raytraceBody.find("sample.m_thicknessFactor > 0.0f") !=
+				std::string::npos &&
+			raytraceBody.find("IsThickVolumeAtHit") !=
+				std::string::npos,
+			"primary and ambient thick-volume decisions must use texture-modulated thickness");
+
+		const std::string traceSkyBody = ExtractFunctionBody(
+			pathTracerSource,
+			"vec3 PathTracer::TraceSky(");
+		Require(traceSkyBody.find("IsThickVolumeAtHit") !=
+				std::string::npos &&
+			traceSkyBody.find("GetMaterialData") == std::string::npos,
+			"sky traversal must use the lightweight thick-volume hit sampler");
+
+		const std::string thickVolumeBody = ExtractFunctionBody(
+			pathTracerSource,
+			"bool PathTracer::IsThickVolumeAtHit(");
+		Require(thickVolumeBody.find("ResolveHitTextureCoordinates") !=
+				std::string::npos &&
+			thickVolumeBody.find("HasTransmissionTexture()") !=
+				std::string::npos &&
+			thickVolumeBody.find("Sample<vec3>") != std::string::npos &&
+			thickVolumeBody.find(".r") != std::string::npos &&
+			thickVolumeBody.find("HasThicknessTexture()") !=
+				std::string::npos &&
+			thickVolumeBody.find(".g") != std::string::npos &&
+			thickVolumeBody.find("GetMaterialData") == std::string::npos,
+			"the hit predicate must sample only transmission red and thickness green");
+		Require(pathTracerSource.find("material.m_thicknessFactor > 0.0f") ==
+				std::string::npos &&
+			pathTracerSource.find("hitMaterial.m_thicknessFactor > 0.0f") ==
+				std::string::npos,
+			"no thick-volume decision may bypass texture-modulated thickness");
+	}
 }
 
 int main()
@@ -165,6 +546,12 @@ int main()
 		{ "GpuCullingRangeAndSynchronizationContract", TestGpuCullingRangeAndSynchronizationContract },
 		{ "GpuCullingShaderSafetyContract", TestGpuCullingShaderSafetyContract },
 		{ "VulkanMemoryBarrierRecordsPipelineBarrier", TestVulkanMemoryBarrierRecordsPipelineBarrier },
+		{ "ShaderReadOnlyBarrierSynchronizesShaderSampling", TestShaderReadOnlyBarrierSynchronizesShaderSampling },
+		{ "CommandListImageTrackingPreservesPublishedContents", TestCommandListImageTrackingPreservesPublishedContents },
+		{ "TransmissionFramebufferMipContract", TestTransmissionFramebufferMipContract },
+		{ "TransmissionFramebufferBindingUsesNodeAttachment", TestTransmissionFramebufferBindingUsesNodeAttachment },
+		{ "TransparentBackToFrontOrderingContract", TestTransparentBackToFrontOrderingContract },
+		{ "PathTracerThicknessSamplerContract", TestPathTracerThicknessSamplerContract },
 	};
 
 	for (const auto& test : tests)

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -896,6 +896,83 @@ namespace
 			"cached static proxies must publish the same per-mesh render queues");
 	}
 
+	void TestShadowDepthRangeContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string lightingSource = ReadText(
+			sourceRoot / "Content/Shaders/Lighting.glsl");
+
+		Require(lightingSource.find("projCoords.xy = projCoords.xy * 0.5 + 0.5;") !=
+				std::string::npos,
+			"shadow sampling must remap only XY from clip space to texture coordinates");
+		Require(lightingSource.find("projCoords = projCoords * 0.5 + 0.5;") ==
+				std::string::npos,
+			"Vulkan zero-to-one shadow depth must not be remapped as OpenGL depth");
+		Require(lightingSource.find("float pcfDepth = texture(shadowMap, projCoords.xy + offset).r;") !=
+				std::string::npos &&
+			lightingSource.find("texture(shadowMap, projCoords.xy + offset).r * 0.5 + 0.5") ==
+				std::string::npos,
+			"PCF must compare raw reverse-Z Vulkan depth values");
+		Require(lightingSource.find("projCoords.z < 0.0f || projCoords.z > 1.0f") !=
+				std::string::npos,
+			"shadow sampling must reject coordinates outside Vulkan's zero-to-one depth range");
+		Require(lightingSource.find("shadowType == SHADOW_TYPE_NONE") !=
+				std::string::npos &&
+			lightingSource.find("dot(surfaceNormal, surfaceToLightDirection)") !=
+				std::string::npos,
+			"directional shadow sampling must skip disabled shadows and derive slope bias from the direction toward the light");
+		Require(lightingSource.find("max(slope, EVSM_MIN_SLOPE_BIAS)") !=
+				std::string::npos &&
+			lightingSource.find("const float biasedDepth =") !=
+				std::string::npos &&
+			lightingSource.find("exp(EVSM_C1 * biasedDepth)") !=
+				std::string::npos &&
+			lightingSource.find("-exp(-EVSM_C2 * biasedDepth)") !=
+				std::string::npos,
+			"both EVSM warps must use the same non-zero receiver depth bias to avoid self-shadowing bands");
+
+		const std::string boundsSource = ReadText(
+			sourceRoot / "Runtime/Math/Bounds.cpp");
+		const std::string projectionBody = ExtractFunctionBody(
+			boundsSource,
+			"glm::mat4 Frustum::CalculateOrthoMatrixByView(");
+		Require(projectionBody.find("glm::orthoRH_ZO") != std::string::npos &&
+			projectionBody.find("glm::orthoRH_NO") == std::string::npos,
+			"shadow cascade projection and shader sampling must use the same Vulkan depth range");
+
+		const std::string shadowPassSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
+		const std::string processBody = ExtractFunctionBody(
+			shadowPassSource,
+			"void ShadowPrepassNode::Process(");
+		Require(processBody.find("shadowPass.m_shadowType == EShadowType::EVSM") !=
+				std::string::npos &&
+			processBody.find("glm::vec4(1.0f, 1.0f, -1.0f, 1.0f)") !=
+				std::string::npos,
+			"empty reverse-Z EVSM texels must be cleared to the moments encoded for depth zero");
+		const std::string finalShadowBarrier =
+			"commands->ImageMemoryBarrier(commandList, shadowPass.m_shadowMap, EImageLayout::ShaderReadOnlyOptimal);";
+		const size_t finalShadowBarrierOffset = processBody.rfind(finalShadowBarrier);
+		const size_t blurReleaseOffset = processBody.find("driver->ReleaseTemporaryRenderTarget(blurAttachment);");
+		const size_t depthReleaseOffset = processBody.find("driver->ReleaseTemporaryRenderTarget(depthAttachment);");
+		Require(finalShadowBarrierOffset != std::string::npos &&
+			blurReleaseOffset != std::string::npos &&
+			depthReleaseOffset != std::string::npos &&
+			blurReleaseOffset < finalShadowBarrierOffset &&
+			finalShadowBarrierOffset < depthReleaseOffset,
+			"completed PCF and EVSM shadow targets must be published for shader reads in the same graphics command list");
+
+		const std::string standardSource = ReadText(
+			sourceRoot / "Content/Shaders/Standard.shader");
+		const std::string gltfSource = ReadText(
+			sourceRoot / "Content/Shaders/Standard_glTF.shader");
+		Require(standardSource.find("CalculateDirectionalShadow(") != std::string::npos &&
+			gltfSource.find("CalculateDirectionalShadow(") != std::string::npos &&
+			standardSource.find("dot(normal, light.direction)") == std::string::npos &&
+			gltfSource.find("dot(normal, light.direction)") == std::string::npos,
+			"all lit material paths must use the shared reverse-Z shadow and slope-bias calculation");
+	}
+
 	void TestPathTracerThicknessSamplerContract()
 	{
 		Raytracing::Material material{};
@@ -1048,6 +1125,7 @@ int main()
 		{ "PostProcessPingPongMipIsolationContract", TestPostProcessPingPongMipIsolationContract },
 		{ "TransparentBackToFrontOrderingContract", TestTransparentBackToFrontOrderingContract },
 		{ "ShadowCasterRenderQueueContract", TestShadowCasterRenderQueueContract },
+		{ "ShadowDepthRangeContract", TestShadowDepthRangeContract },
 		{ "PathTracerThicknessSamplerContract", TestPathTracerThicknessSamplerContract },
 		{ "PathTracerMaterialContentRevisionContract", TestPathTracerMaterialContentRevisionContract },
 	};

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -1,0 +1,185 @@
+#include "GraphicsDriver/Vulkan/VulkanImage.h"
+#include "GraphicsDriver/Vulkan/VulkanImageView.h"
+#include "RHI/Texture.h"
+
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+using namespace Sailor;
+using namespace Sailor::GraphicsDriver::Vulkan;
+
+namespace
+{
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	std::string ReadText(const std::filesystem::path& path)
+	{
+		std::ifstream input(path, std::ios::binary);
+		Require(input.is_open(), "test source should be readable: " + path.generic_string());
+		return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+	}
+
+	std::string ExtractFunctionBody(const std::string& source, const std::string& signature)
+	{
+		const size_t signatureOffset = source.find(signature);
+		Require(signatureOffset != std::string::npos, "function signature should exist: " + signature);
+
+		const size_t bodyOffset = source.find('{', signatureOffset + signature.size());
+		Require(bodyOffset != std::string::npos, "function body should exist: " + signature);
+
+		size_t depth = 0;
+		for (size_t offset = bodyOffset; offset < source.size(); ++offset)
+		{
+			if (source[offset] == '{')
+			{
+				++depth;
+			}
+			else if (source[offset] == '}' && --depth == 0)
+			{
+				return source.substr(bodyOffset, offset - bodyOffset + 1);
+			}
+		}
+
+		throw std::runtime_error("function body should be balanced: " + signature);
+	}
+
+	RHI::RHITexturePtr MakeMipTexture(uint32_t width, uint32_t height, uint32_t baseMipLevel)
+	{
+		auto image = VulkanImagePtr::Make(VulkanDevicePtr{});
+		image->m_extent = { width, height, 1u };
+		image->m_mipLevels = baseMipLevel + 1u;
+		image->m_arrayLayers = 1u;
+
+		auto imageView = VulkanImageViewPtr::Make(VulkanDevicePtr{}, image);
+		imageView->m_subresourceRange.baseMipLevel = baseMipLevel;
+		imageView->m_subresourceRange.levelCount = 1u;
+
+		auto texture = RHI::RHITexturePtr::Make(
+			RHI::ETextureFiltration::Nearest,
+			RHI::ETextureClamping::Clamp,
+			true);
+		texture->m_vulkan.m_image = image;
+		texture->m_vulkan.m_imageView = imageView;
+		return texture;
+	}
+
+	void TestMipExtentUsesVulkanFloorAndClamp()
+	{
+		Require(MakeMipTexture(1919u, 1079u, 1u)->GetExtent() == glm::ivec2(959, 539),
+			"odd mip dimensions must use Vulkan integer floor semantics");
+		Require(MakeMipTexture(3u, 5u, 1u)->GetExtent() == glm::ivec2(1, 2),
+			"both odd dimensions must be halved independently");
+		Require(MakeMipTexture(3u, 5u, 2u)->GetExtent() == glm::ivec2(1, 1),
+			"the final mip must clamp both dimensions to one");
+		Require(MakeMipTexture(1u, 720u, 9u)->GetExtent() == glm::ivec2(1, 1),
+			"a one-pixel dimension must never become zero");
+	}
+
+	void TestGpuCullingRangeAndSynchronizationContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string batchHeader = ReadText(sourceRoot / "Runtime/RHI/Batch.hpp");
+		const std::string cullingBody = ExtractFunctionBody(batchHeader, "DrawCallStats RHIRecordDrawCallGPUCulling(");
+
+		Require(cullingBody.find("storageIndex[start]") != std::string::npos,
+			"a partitioned culling dispatch must start from its requested batch range");
+		Require(cullingBody.find("storageIndex[0]") == std::string::npos,
+			"a secondary partition must not cull the first partition's instances");
+		Require(cullingBody.find("constants.m_phase = 0") != std::string::npos &&
+			cullingBody.find("constants.m_phase = 1") != std::string::npos,
+			"culling and indirect compaction must be recorded as separate dispatch phases");
+		Require(cullingBody.find("EAccessBit::ShaderWrite_Bit") != std::string::npos &&
+			cullingBody.find("commands->MemoryBarrier") != std::string::npos,
+			"the compaction dispatch must wait for culling shader writes");
+		Require(cullingBody.find("m_bEnableOcclusion = 0") != std::string::npos,
+			"previous-frame Hi-Z must not cull current-frame transforms");
+	}
+
+	void TestGpuCullingShaderSafetyContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string cullingShader = ReadText(sourceRoot / "Content/Shaders/ComputeMeshCulling.shader");
+		const std::string highZShader = ReadText(sourceRoot / "Content/Shaders/ComputeDepthHighZ.shader");
+
+		Require(cullingShader.find("PushConstants.phase == 0") != std::string::npos &&
+			cullingShader.find("globalIndex < PushConstants.numBatches") != std::string::npos,
+			"the shader must keep culling and compaction in distinct dispatch phases");
+		Require(cullingShader.find("column0") != std::string::npos &&
+			cullingShader.find("column1") != std::string::npos &&
+			cullingShader.find("column2") != std::string::npos,
+			"sphere scaling must account for every transformed basis vector");
+		Require(cullingShader.find("textureQueryLevels(depthHighZ)") != std::string::npos &&
+			cullingShader.find("ceil(log2") != std::string::npos,
+			"occlusion LOD selection must cover the projected bounds and clamp to the pyramid");
+		Require(cullingShader.find("texelBegin") != std::string::npos &&
+			cullingShader.find("texelEnd") != std::string::npos &&
+			cullingShader.find("texelFetch") != std::string::npos,
+			"occlusion must reduce every mip texel touched by projected bounds");
+		Require(highZShader.find("binding = 1, r32f") != std::string::npos,
+			"the storage image format must match the R32_SFLOAT Hi-Z render target");
+		Require(highZShader.find("greaterThanEqual(pos, outputSize)") != std::string::npos,
+			"rounded-up dispatch groups must guard storage-image writes");
+		Require(highZShader.find("sourceBegin") != std::string::npos &&
+			highZShader.find("sourceEnd") != std::string::npos &&
+			highZShader.find("texelFetch") != std::string::npos,
+			"odd-sized Hi-Z mips must explicitly reduce their complete source footprint");
+	}
+
+	void TestVulkanMemoryBarrierRecordsPipelineBarrier()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string commandBufferSource = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp");
+		const std::string barrierBody = ExtractFunctionBody(
+			commandBufferSource,
+			"void VulkanCommandBuffer::MemoryBarrier(");
+
+		Require(barrierBody.find("vkCmdPipelineBarrier") != std::string::npos,
+			"the RHI buffer barrier must record a Vulkan pipeline barrier");
+		Require(barrierBody.find("VkMemoryBarrier") != std::string::npos,
+			"the Vulkan barrier must carry the requested access masks");
+
+		const std::string bufferSource = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanBuffer.cpp");
+		Require(bufferSource.find("queues.m_computeFamily.value()") != std::string::npos,
+			"concurrently shared culling buffers must include a dedicated compute queue family");
+	}
+}
+
+int main()
+{
+	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "MipExtentUsesVulkanFloorAndClamp", TestMipExtentUsesVulkanFloorAndClamp },
+		{ "GpuCullingRangeAndSynchronizationContract", TestGpuCullingRangeAndSynchronizationContract },
+		{ "GpuCullingShaderSafetyContract", TestGpuCullingShaderSafetyContract },
+		{ "VulkanMemoryBarrierRecordsPipelineBarrier", TestVulkanMemoryBarrierRecordsPipelineBarrier },
+	};
+
+	for (const auto& test : tests)
+	{
+		try
+		{
+			test.second();
+			std::cout << "[PASS] " << test.first << std::endl;
+		}
+		catch (const std::exception& error)
+		{
+			std::cerr << "[FAIL] " << test.first << ": " << error.what() << std::endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -6,6 +6,9 @@
 #include "FrameGraph/DepthPrepassNode.h"
 #include "FrameGraph/RenderSceneNode.h"
 #include "Raytracing/MaterialUtils.h"
+#include "RHI/Buffer.h"
+#include "RHI/Material.h"
+#include "RHI/Mesh.h"
 #include "RHI/Texture.h"
 
 #include <cmath>
@@ -23,6 +26,12 @@ using namespace Sailor::GraphicsDriver::Vulkan;
 
 namespace
 {
+	class RenderSceneNodeProbe : public Framegraph::RenderSceneNode
+	{
+	public:
+		using TextureBindingCacheKeyProbe = TextureBindingCacheKey;
+	};
+
 	void Require(bool condition, const std::string& message)
 	{
 		if (!condition)
@@ -112,6 +121,137 @@ namespace
 			"the compaction dispatch must wait for culling shader writes");
 		Require(cullingBody.find("m_bEnableOcclusion = 0") != std::string::npos,
 			"previous-frame Hi-Z must not cull current-frame transforms");
+
+		const std::string fallbackBody = ExtractFunctionBody(
+			batchHeader,
+			"DrawCallStats RHIRecordDrawCall(");
+		Require(fallbackBody.find(
+			"driver->AddBufferToShaderBindings(") != std::string::npos &&
+			fallbackBody.find(
+				"*indirectCommandBufferBinding") != std::string::npos,
+			"the fallback draw path must update the GPU-culling descriptor when its shared indirect buffer grows");
+	}
+
+	void TestBatchTextureBindingIdentityContract()
+	{
+		using TextureBindingCacheKey = RenderSceneNodeProbe::TextureBindingCacheKeyProbe;
+
+		TextureBindingCacheKey firstTextureSet;
+		firstTextureSet.m_requestedTextures = { 0u, 4u, 8u };
+		TextureBindingCacheKey secondTextureSet;
+		secondTextureSet.m_requestedTextures = { 0u, 5u, 8u };
+
+		TMap<TextureBindingCacheKey, uint32_t> textureBindingCache;
+		Require(textureBindingCache.Insert(firstTextureSet, 1u),
+			"the first texture binding cache key should be inserted");
+		Require(textureBindingCache.Insert(secondTextureSet, 2u),
+			"a different equal-sized texture binding cache key must not collapse into the first");
+		Require(textureBindingCache.Num() == 2,
+			"texture sets with the same count and layout capacity must retain distinct cache identities");
+
+		const auto materialBindings = RHI::RHIShaderBindingSetPtr::Make();
+		auto material = RHI::RHIMaterialPtr::Make(
+			RHI::RenderState{},
+			RHI::RHIShaderPtr{},
+			RHI::RHIShaderPtr{});
+		material->SetBindings(materialBindings);
+
+		const RHI::EBufferUsageFlags bufferUsage =
+			RHI::EBufferUsageBit::VertexBuffer_Bit |
+			RHI::EBufferUsageBit::IndexBuffer_Bit;
+		const auto meshBuffer = RHI::RHIBufferPtr::Make(
+			bufferUsage,
+			RHI::EMemoryPropertyBit::DeviceLocal);
+		auto mesh = RHI::RHIMeshPtr::Make();
+		mesh->m_vertexBuffer = meshBuffer;
+		mesh->m_indexBuffer = meshBuffer;
+
+		RHI::RHIBatch firstBatch(material, mesh);
+		RHI::RHIBatch secondBatch(material, mesh);
+		firstBatch.m_textureBindings = RHI::RHIShaderBindingSetPtr::Make();
+		secondBatch.m_textureBindings = RHI::RHIShaderBindingSetPtr::Make();
+		firstBatch.m_textureBindings->SetVariableDescriptorCount(8u);
+		secondBatch.m_textureBindings->SetVariableDescriptorCount(8u);
+
+		TSet<RHI::RHIBatch> batches;
+		Require(batches.Insert(firstBatch),
+			"the first texture-binding batch should be inserted");
+		Require(batches.Insert(secondBatch),
+			"a different equal-sized texture-binding batch must not collapse into the first");
+		Require(batches.Num() == 2,
+			"batch identity must include the texture binding set handle, not its descriptor count");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string batchHeader = ReadText(sourceRoot / "Runtime/RHI/Batch.hpp");
+		Require(batchHeader.find("m_textureBindings == rhs.m_textureBindings") != std::string::npos &&
+			batchHeader.find("HashCombine(hash, m_textureBindings)") != std::string::npos,
+			"render batches must include the texture binding set in equality and hashing");
+
+		const char* drawFunctions[] = {
+			"DrawCallStats RHIRecordDrawCallGPUCulling(",
+			"DrawCallStats RHIRecordDrawCall(",
+			"DrawCallStats RHIDrawCall("
+		};
+
+		for (const char* drawFunction : drawFunctions)
+		{
+			const std::string drawBody = ExtractFunctionBody(batchHeader, drawFunction);
+			Require(drawBody.find("prevTextureBindings != vecBatches[j].m_textureBindings") != std::string::npos,
+				std::string(drawFunction) +
+				" must detect a texture descriptor set change independently of the material pointer");
+
+			const std::string rebindBody = ExtractFunctionBody(
+				drawBody,
+				"if (bMaterialChanged || bTextureBindingsChanged)");
+			Require(rebindBody.find("commands->BindShaderBindings") != std::string::npos &&
+				rebindBody.find("prevTextureBindings = vecBatches[j].m_textureBindings") != std::string::npos,
+				std::string(drawFunction) +
+				" must rebind and remember a different texture descriptor set");
+		}
+	}
+
+	void TestSceneViewProxyMaterialAlignmentContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string sceneViewSource = ReadText(sourceRoot / "Runtime/RHI/SceneView.cpp");
+		const std::string traceBody = ExtractFunctionBody(
+			sceneViewSource,
+			"TVector<RHISceneViewProxy> RHISceneView::TraceScene(");
+
+		const size_t materialSlotsOffset = traceBody.find(
+			"viewProxy.m_overrideMaterials.Resize(viewProxy.m_meshes.Num())");
+		const size_t textureSlotsOffset = traceBody.find(
+			"viewProxy.m_materialTextureSamplers.Resize(viewProxy.m_meshes.Num())");
+		const size_t readyMaterialOffset = traceBody.find(
+			"if (material && material->IsReady() && !bSkipMaterials)");
+		Require(materialSlotsOffset != std::string::npos &&
+			textureSlotsOffset != std::string::npos &&
+			readyMaterialOffset != std::string::npos &&
+			materialSlotsOffset < readyMaterialOffset &&
+			textureSlotsOffset < readyMaterialOffset,
+			"stationary scene proxies must allocate one material and texture slot per mesh before testing asynchronous readiness");
+
+		const std::string readyMaterialBody = ExtractFunctionBody(
+			traceBody,
+			"if (material && material->IsReady() && !bSkipMaterials)");
+		Require(readyMaterialBody.find(
+			"viewProxy.m_overrideMaterials[i] = material->GetOrAddRHI") != std::string::npos,
+			"a ready stationary material must fill its original mesh slot");
+		Require(traceBody.find(
+			"auto& requestedTextures = viewProxy.m_materialTextureSamplers[i]") != std::string::npos,
+			"stationary texture indices must be written into the original mesh slot");
+
+		const std::string depthSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/DepthPrepassNode.cpp");
+		const std::string depthPrepareBody = ExtractFunctionBody(
+			depthSource,
+			"Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(");
+		const std::string pendingMaterialBody = ExtractFunctionBody(
+			depthPrepareBody,
+			"if (proxy.GetMaterials()[i] == nullptr)");
+		Require(pendingMaterialBody.find("continue;") != std::string::npos &&
+			pendingMaterialBody.find("break;") == std::string::npos,
+			"a pending material slot must not discard later ready meshes from the depth pass");
 	}
 
 	void TestGpuCullingShaderSafetyContract()
@@ -895,6 +1035,8 @@ int main()
 	const std::pair<const char*, std::function<void()>> tests[] = {
 		{ "MipExtentUsesVulkanFloorAndClamp", TestMipExtentUsesVulkanFloorAndClamp },
 		{ "GpuCullingRangeAndSynchronizationContract", TestGpuCullingRangeAndSynchronizationContract },
+		{ "BatchTextureBindingIdentityContract", TestBatchTextureBindingIdentityContract },
+		{ "SceneViewProxyMaterialAlignmentContract", TestSceneViewProxyMaterialAlignmentContract },
 		{ "GpuCullingShaderSafetyContract", TestGpuCullingShaderSafetyContract },
 		{ "ForwardPlusTileSynchronizationContract", TestForwardPlusTileSynchronizationContract },
 		{ "VulkanMemoryBarrierRecordsPipelineBarrier", TestVulkanMemoryBarrierRecordsPipelineBarrier },

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -1,0 +1,629 @@
+#include "AssetRegistry/Model/ModelImporter.h"
+#include "AssetRegistry/Model/GltfImporterUtils.h"
+#include "Raytracing/MaterialUtils.h"
+#include "Raytracing/PathTracer.h"
+
+#include <cmath>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+#include <glm/gtc/matrix_transform.hpp>
+#include <tiny_gltf.h>
+
+using namespace Sailor;
+
+namespace
+{
+	class ControllableMesh final : public RHI::RHIMesh
+	{
+	public:
+		bool IsReady() const override
+		{
+			return m_bReady;
+		}
+
+		void SetReady(bool bReady)
+		{
+			m_bReady = bReady;
+		}
+
+	private:
+		bool m_bReady = false;
+	};
+
+	class PathTracerBasisProbe final : public Raytracing::PathTracer
+	{
+	public:
+		void Evaluate(
+			const ModelPtr& model,
+			const glm::mat4& worldMatrix,
+			glm::vec3& outNormal,
+			glm::vec3& outTangent,
+			glm::vec3& outBitangent)
+		{
+			m_tlasInstances.Clear();
+			TLASInstance instance{};
+			instance.m_model = model;
+			instance.m_worldMatrix = worldMatrix;
+			instance.m_inverseWorldMatrix = glm::inverse(worldMatrix);
+			m_tlasInstances.Add(std::move(instance));
+
+			TLASHit hit{};
+			hit.m_instanceIndex = 0;
+			hit.m_triangleIndex = 0;
+			hit.m_hit.m_barycentricCoordinate = glm::vec3(1.0f, 0.0f, 0.0f);
+			GetShadingBasis(hit, outNormal, outTangent, outBitangent);
+		}
+
+		bool OrientAgainstRay(
+			const glm::vec3& rayDirection,
+			glm::vec3& inOutNormal,
+			glm::vec3& inOutBitangent)
+		{
+			return OrientShadingBasisAgainstRay(
+				rayDirection,
+				inOutNormal,
+				inOutBitangent);
+		}
+	};
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	RHI::VertexP3N3T3B3UV2C4I4W4 MakeVertex(const glm::vec3& position)
+	{
+		RHI::VertexP3N3T3B3UV2C4I4W4 vertex{};
+		vertex.m_position = position;
+		vertex.m_normal = glm::vec3(0.0f, 0.0f, 1.0f);
+		vertex.m_tangent = glm::vec3(1.0f, 0.0f, 0.0f);
+		vertex.m_bitangent = glm::vec3(0.0f, 1.0f, 0.0f);
+		return vertex;
+	}
+
+	bool NearlyEqual(float lhs, float rhs, float epsilon = 0.0001f)
+	{
+		return std::abs(lhs - rhs) <= epsilon;
+	}
+
+	void RequireVec3Near(
+		const glm::vec3& actual,
+		const glm::vec3& expected,
+		const std::string& message)
+	{
+		Require(
+			NearlyEqual(actual.x, expected.x) &&
+				NearlyEqual(actual.y, expected.y) &&
+				NearlyEqual(actual.z, expected.z),
+			message);
+	}
+
+	Model::MeshCpuData MakeTriangleMesh(uint32_t thirdIndex)
+	{
+		Model::MeshCpuData mesh;
+		mesh.m_vertices = {
+			MakeVertex(glm::vec3(0.0f, 0.0f, 0.0f)),
+			MakeVertex(glm::vec3(1.0f, 0.0f, 0.0f)),
+			MakeVertex(glm::vec3(0.0f, 1.0f, 0.0f))
+		};
+		mesh.m_indices = { 0, 1, thirdIndex };
+		return mesh;
+	}
+
+	void TestModelReadinessTracksMeshUploads()
+	{
+		auto firstMesh = TRefPtr<ControllableMesh>::Make();
+		auto secondMesh = TRefPtr<ControllableMesh>::Make();
+		Model model(
+			FileId{},
+			TVector<RHI::RHIMeshPtr>{ firstMesh, secondMesh });
+
+		model.Flush();
+		Require(!model.IsReady(),
+			"a structurally complete model must wait for every mesh upload");
+
+		firstMesh->SetReady(true);
+		Require(!model.IsReady(),
+			"one completed mesh upload must not publish the whole model");
+
+		secondMesh->SetReady(true);
+		Require(model.IsReady(),
+			"the model must become ready without another Flush once all uploads finish");
+
+		Model emptyModel(FileId{});
+		emptyModel.Flush();
+		Require(!emptyModel.IsReady(),
+			"an empty model must remain unavailable");
+
+		Model modelWithNullMesh(
+			FileId{},
+			TVector<RHI::RHIMeshPtr>{ RHI::RHIMeshPtr{} });
+		modelWithNullMesh.Flush();
+		Require(!modelWithNullMesh.IsReady(),
+			"a model with a null mesh must remain unavailable");
+	}
+
+	void TestMeshContextRejectsEmptyGpuUploads()
+	{
+		ModelImporter::MeshContext emptyMesh;
+		Require(!emptyMesh.HasGeometry(),
+			"an empty mesh context must not reach the GPU upload path");
+
+		emptyMesh.outVertices.Add(MakeVertex(glm::vec3(0.0f)));
+		Require(!emptyMesh.HasGeometry(),
+			"vertices without indices must not reach the GPU upload path");
+
+		emptyMesh.outIndices = { 0, 0, 0 };
+		Require(emptyMesh.HasGeometry(),
+			"a mesh context with vertices and indices must remain uploadable");
+	}
+
+	void TestCompactedMeshesRetainMaterialSlots()
+	{
+		RHI::RHIMesh mesh;
+		Require(mesh.ResolveMaterialIndex(1, 3) == 1,
+			"generated meshes must retain positional material fallback");
+
+		mesh.m_materialIndex = 2;
+		Require(mesh.ResolveMaterialIndex(0, 3) == 2,
+			"a compacted mesh must retain its original material slot");
+		Require(mesh.ResolveMaterialIndex(0, 0) ==
+			(std::numeric_limits<size_t>::max)(),
+			"material resolution without materials must remain invalid");
+	}
+
+	void TestGeneratedTangentsPreserveMirroredUvHandedness()
+	{
+		const glm::vec3 vertices[] = {
+			glm::vec3(0.0f, 0.0f, 0.0f),
+			glm::vec3(1.0f, 0.0f, 0.0f),
+			glm::vec3(0.0f, 1.0f, 0.0f)
+		};
+		const glm::vec2 regularUvs[] = {
+			glm::vec2(0.0f, 0.0f),
+			glm::vec2(1.0f, 0.0f),
+			glm::vec2(0.0f, 1.0f)
+		};
+		const glm::vec2 mirroredUvs[] = {
+			glm::vec2(0.0f, 0.0f),
+			glm::vec2(-1.0f, 0.0f),
+			glm::vec2(0.0f, 1.0f)
+		};
+		const glm::vec3 normal(0.0f, 0.0f, 1.0f);
+
+		glm::vec3 tangent(0.0f);
+		glm::vec3 bitangent(0.0f);
+		Raytracing::GenerateTangentBitangent(
+			tangent,
+			bitangent,
+			vertices,
+			regularUvs);
+		RequireVec3Near(tangent, glm::vec3(1.0f, 0.0f, 0.0f),
+			"regular UVs must produce the expected tangent");
+		RequireVec3Near(bitangent, glm::vec3(0.0f, 1.0f, 0.0f),
+			"regular UVs must produce the expected bitangent");
+		Require(glm::dot(glm::cross(normal, tangent), bitangent) > 0.0f,
+			"regular UVs must retain positive tangent-space handedness");
+
+		tangent = glm::vec3(0.0f);
+		bitangent = glm::vec3(0.0f);
+		Raytracing::GenerateTangentBitangent(
+			tangent,
+			bitangent,
+			vertices,
+			mirroredUvs);
+		RequireVec3Near(tangent, glm::vec3(-1.0f, 0.0f, 0.0f),
+			"mirrored UVs must produce the mirrored tangent");
+		RequireVec3Near(bitangent, glm::vec3(0.0f, 1.0f, 0.0f),
+			"mirrored UVs must retain the UV-derived bitangent");
+		Require(glm::dot(glm::cross(normal, tangent), bitangent) < 0.0f,
+			"mirrored UVs must retain negative tangent-space handedness");
+	}
+
+	void TestPathTracerTransformsShadingBasisCorrectly()
+	{
+		const glm::vec3 localNormal = glm::normalize(glm::vec3(1.0f, 0.0f, 1.0f));
+		const glm::vec3 localTangent = glm::normalize(glm::vec3(1.0f, 0.0f, -1.0f));
+		const glm::vec3 localBitangent = -glm::normalize(
+			glm::cross(localNormal, localTangent));
+
+		auto allocator = Memory::ObjectAllocatorPtr::Make(
+			Memory::EAllocationPolicy::LocalMemory_SingleThread);
+		ModelPtr model = ModelPtr::Make(allocator, FileId{});
+		Model::MeshCpuData mesh = MakeTriangleMesh(2);
+		for (auto& vertex : mesh.m_vertices)
+		{
+			vertex.m_normal = localNormal;
+			vertex.m_tangent = localTangent;
+			vertex.m_bitangent = localBitangent;
+		}
+		model->GetCpuMeshes().Add(std::move(mesh));
+		Require(model->BuildBLAS(),
+			"path tracer basis fixture must build its BLAS");
+
+		const glm::mat4 worldMatrix = glm::scale(
+			glm::mat4(1.0f),
+			glm::vec3(2.0f, 1.0f, 0.5f));
+		const glm::mat3 linearMatrix(worldMatrix);
+		const glm::mat3 normalMatrix = glm::transpose(glm::inverse(linearMatrix));
+		const glm::vec3 expectedNormal = glm::normalize(normalMatrix * localNormal);
+		const glm::vec3 transformedTangent = linearMatrix * localTangent;
+		const glm::vec3 expectedTangent = glm::normalize(
+			transformedTangent - expectedNormal *
+				glm::dot(expectedNormal, transformedTangent));
+		const glm::vec3 transformedBitangent = linearMatrix * localBitangent;
+		const float expectedHandedness = glm::dot(
+			glm::cross(expectedNormal, expectedTangent),
+			transformedBitangent) < 0.0f ? -1.0f : 1.0f;
+		const glm::vec3 expectedBitangent = glm::normalize(
+			glm::cross(expectedNormal, expectedTangent)) * expectedHandedness;
+
+		PathTracerBasisProbe pathTracer;
+		glm::vec3 actualNormal(0.0f);
+		glm::vec3 actualTangent(0.0f);
+		glm::vec3 actualBitangent(0.0f);
+		pathTracer.Evaluate(
+			model,
+			worldMatrix,
+			actualNormal,
+			actualTangent,
+			actualBitangent);
+
+		RequireVec3Near(actualNormal, expectedNormal,
+			"path tracer normals must use the inverse-transpose world transform");
+		RequireVec3Near(actualTangent, expectedTangent,
+			"path tracer tangents must use the linear world transform and Gram-Schmidt");
+		RequireVec3Near(actualBitangent, expectedBitangent,
+			"path tracer bitangents must retain tangent-space handedness");
+		Require(NearlyEqual(glm::dot(actualNormal, actualTangent), 0.0f) &&
+			NearlyEqual(glm::dot(actualNormal, actualBitangent), 0.0f) &&
+			NearlyEqual(glm::dot(actualTangent, actualBitangent), 0.0f),
+			"path tracer world-space TBN must remain orthogonal under non-uniform scale");
+
+		const glm::vec3 frontNormal = actualNormal;
+		const glm::vec3 frontTangent = actualTangent;
+		const glm::vec3 frontBitangent = actualBitangent;
+		Require(!pathTracer.OrientAgainstRay(
+				frontNormal,
+				actualNormal,
+				actualBitangent),
+			"a ray traveling with the shading normal must hit the back face");
+		RequireVec3Near(actualNormal, -frontNormal,
+			"back-face orientation must flip the shading normal");
+		RequireVec3Near(actualTangent, frontTangent,
+			"back-face orientation must preserve the tangent direction");
+		RequireVec3Near(actualBitangent, -frontBitangent,
+			"back-face orientation must flip the bitangent with the normal");
+		Require(
+			glm::dot(
+				glm::cross(actualNormal, actualTangent),
+				actualBitangent) *
+			glm::dot(
+				glm::cross(frontNormal, frontTangent),
+				frontBitangent) > 0.0f,
+			"back-face orientation must preserve tangent-space handedness");
+	}
+
+	void TestBuildBlasRejectsOutOfRangeIndicesAtomically()
+	{
+		Model model(FileId{});
+		model.GetCpuMeshes() = {
+			MakeTriangleMesh(2),
+			MakeTriangleMesh(3)
+		};
+
+		Require(!model.BuildBLAS(),
+			"BLAS construction must reject a mesh with an out-of-range index");
+		Require(!model.HasBLAS(),
+			"a rejected mesh must not retain a BLAS");
+		Require(model.GetBLASTriangles().Num() == 0,
+			"a rejected mesh must not retain triangles from earlier valid meshes");
+		Require(!model.BuildBLAS(),
+			"repeated BLAS construction on malformed geometry must remain safe");
+		Require(!model.HasBLAS() && model.GetBLASTriangles().Num() == 0,
+			"repeated rejection must preserve clean BLAS state");
+	}
+
+	void TestBuildBlasRecoversAfterGeometryIsCorrected()
+	{
+		Model model(FileId{});
+		model.GetCpuMeshes() = { MakeTriangleMesh(3) };
+		Require(!model.BuildBLAS(),
+			"the malformed geometry precondition must be rejected");
+
+		model.GetCpuMeshes() = { MakeTriangleMesh(2), MakeTriangleMesh(2) };
+		Require(model.BuildBLAS(),
+			"BLAS construction must recover after geometry is corrected");
+		Require(model.HasBLAS(),
+			"corrected geometry must produce a BLAS");
+		Require(model.GetBLASTriangles().Num() == 2,
+			"both corrected triangles must be included");
+	}
+
+	void TestBuildBlasIgnoresEmptyMeshes()
+	{
+		Model model(FileId{});
+		model.GetCpuMeshes() = {
+			Model::MeshCpuData(),
+			MakeTriangleMesh(2)
+		};
+		Require(model.BuildBLAS(),
+			"an empty mesh must not prevent valid geometry from building");
+		Require(model.GetBLASTriangles().Num() == 1,
+			"only the valid mesh must contribute a triangle");
+
+		model.GetCpuMeshes() = { Model::MeshCpuData() };
+		Require(!model.BuildBLAS(),
+			"a model containing only empty meshes must be rejected");
+		Require(!model.HasBLAS() && model.GetBLASTriangles().Num() == 0,
+			"an empty model must leave BLAS state clean");
+		Require(!model.GetBLAS().IsValid(),
+			"a failed rebuild must release the previous BLAS");
+	}
+
+	void TestBuildBlasRejectsIncompleteAndNonFiniteGeometry()
+	{
+		Model model(FileId{});
+		Model::MeshCpuData incomplete = MakeTriangleMesh(2);
+		incomplete.m_indices.Add(0);
+		model.GetCpuMeshes() = { std::move(incomplete) };
+		Require(!model.BuildBLAS(),
+			"BLAS construction must reject an incomplete triangle");
+		Require(!model.HasBLAS() && model.GetBLASTriangles().Num() == 0,
+			"an incomplete triangle must leave BLAS state clean");
+
+		Model::MeshCpuData nonFinite = MakeTriangleMesh(2);
+		nonFinite.m_vertices[0].m_position.x =
+			std::numeric_limits<float>::quiet_NaN();
+		model.GetCpuMeshes() = { std::move(nonFinite) };
+		Require(!model.BuildBLAS(),
+			"BLAS construction must reject non-finite positions");
+		Require(!model.HasBLAS() && model.GetBLASTriangles().Num() == 0,
+			"non-finite geometry must leave BLAS state clean");
+	}
+
+	void TestBuildBlasSanitizesExtremeVertexFrames()
+	{
+		Model model(FileId{});
+		Model::MeshCpuData mesh = MakeTriangleMesh(2);
+		const float maxValue = std::numeric_limits<float>::max();
+		for (auto& vertex : mesh.m_vertices)
+		{
+			vertex.m_normal = glm::vec3(maxValue);
+			vertex.m_tangent = glm::vec3(maxValue, -maxValue, 0.0f);
+			vertex.m_bitangent = glm::vec3(0.0f, maxValue, -maxValue);
+		}
+		model.GetCpuMeshes() = { std::move(mesh) };
+
+		Require(model.BuildBLAS(),
+			"finite extreme vertex frames must be sanitized safely");
+		Require(model.GetBLASTriangles().Num() == 1,
+			"the sanitized triangle must be retained");
+		const auto& triangle = model.GetBLASTriangles()[0];
+		for (size_t i = 0; i < 3; ++i)
+		{
+			Require(
+				std::isfinite(triangle.m_normals[i].x) &&
+				std::isfinite(triangle.m_normals[i].y) &&
+				std::isfinite(triangle.m_normals[i].z) &&
+				std::isfinite(triangle.m_tangent[i].x) &&
+				std::isfinite(triangle.m_tangent[i].y) &&
+				std::isfinite(triangle.m_tangent[i].z) &&
+				std::isfinite(triangle.m_bitangent[i].x) &&
+				std::isfinite(triangle.m_bitangent[i].y) &&
+				std::isfinite(triangle.m_bitangent[i].z),
+				"sanitized vertex frames must remain finite");
+		}
+	}
+
+	void TestBuildBlasHandlesExtremeCentroidRange()
+	{
+		Model model(FileId{});
+		Model::MeshCpuData mesh;
+		const float extremes[] = {
+			std::numeric_limits<float>::lowest(),
+			std::numeric_limits<float>::max(),
+			-1.0f,
+			0.0f,
+			1.0f
+		};
+
+		for (float position : extremes)
+		{
+			const uint32_t firstVertex =
+				static_cast<uint32_t>(mesh.m_vertices.Num());
+			for (size_t i = 0; i < 3; ++i)
+			{
+				mesh.m_vertices.Add(MakeVertex(glm::vec3(position, 0.0f, 0.0f)));
+				mesh.m_indices.Add(firstVertex + static_cast<uint32_t>(i));
+			}
+		}
+		model.GetCpuMeshes() = { std::move(mesh) };
+
+		Require(model.BuildBLAS(),
+			"finite extreme centroid ranges must not corrupt BVH binning");
+		Require(model.GetBLASTriangles().Num() == 5,
+			"all extreme-range triangles must be retained");
+	}
+
+	void TestCollectMeshInstancesUsesActiveSceneHierarchy()
+	{
+		tinygltf::Model model;
+		model.meshes.resize(1);
+		model.nodes.resize(4);
+
+		model.nodes[0].translation = { 10.0, 0.0, 0.0 };
+		model.nodes[0].children = { 1 };
+		model.nodes[1].mesh = 0;
+		model.nodes[1].translation = { 0.0, 2.0, 0.0 };
+		model.nodes[1].rotation = {
+			0.0,
+			0.0,
+			0.7071067811865475,
+			0.7071067811865476
+		};
+		model.nodes[1].scale = { 2.0, 1.0, 1.0 };
+
+		model.nodes[2].mesh = 0;
+		model.nodes[2].translation = { 100.0, 0.0, 0.0 };
+		model.nodes[2].matrix = {
+			1.0, 0.0, 0.0, 0.0,
+			0.0, 1.0, 0.0, 0.0,
+			0.0, 0.0, 1.0, 0.0,
+			-4.0, 0.0, 0.0, 1.0
+		};
+
+		model.nodes[3].mesh = 0;
+		model.nodes[3].translation = { 1000.0, 0.0, 0.0 };
+
+		tinygltf::Scene scene;
+		scene.nodes = { 0, 2 };
+		model.scenes.push_back(std::move(scene));
+		model.defaultScene = 0;
+
+		TVector<GltfImporterUtils::MeshInstance> instances;
+		Require(
+			GltfImporterUtils::CollectMeshInstances(model, instances),
+			"valid active-scene hierarchy must be traversed");
+		Require(instances.Num() == 2,
+			"one mesh resource referenced by two active nodes must emit two instances");
+		Require(instances[0].m_nodeIndex == 1 &&
+			instances[0].m_meshIndex == 0 &&
+			instances[0].m_skinIndex == -1,
+			"mesh instance must retain its source node, mesh, and skin indices");
+		Require(instances[1].m_nodeIndex == 2 &&
+			instances[1].m_meshIndex == 0,
+			"matrix-authored mesh node must be emitted in active-scene order");
+
+		const glm::mat4 unitScale =
+			glm::scale(glm::mat4(1.0f), glm::vec3(2.0f));
+		const glm::mat4 firstGeometryTransform =
+			unitScale * instances[0].m_worldTransform;
+		RequireVec3Near(
+			glm::vec3(firstGeometryTransform *
+				glm::vec4(0.0f, 0.0f, 0.0f, 1.0f)),
+			glm::vec3(20.0f, 4.0f, 0.0f),
+			"parent and child translations must accumulate and receive unit scale");
+		RequireVec3Near(
+			glm::vec3(firstGeometryTransform *
+				glm::vec4(1.0f, 0.0f, 0.0f, 1.0f)),
+			glm::vec3(20.0f, 8.0f, 0.0f),
+			"node TRS must use glTF translation-rotation-scale order");
+		RequireVec3Near(
+			glm::vec3(firstGeometryTransform *
+				glm::vec4(0.0f, 1.0f, 0.0f, 1.0f)),
+			glm::vec3(18.0f, 4.0f, 0.0f),
+			"non-uniform node scale and rotation must compose correctly");
+
+		const glm::mat4 secondGeometryTransform =
+			unitScale * instances[1].m_worldTransform;
+		RequireVec3Near(
+			glm::vec3(secondGeometryTransform *
+				glm::vec4(0.0f, 0.0f, 0.0f, 1.0f)),
+			glm::vec3(-8.0f, 0.0f, 0.0f),
+			"node matrix must take precedence over TRS properties");
+	}
+
+	void TestCollectMeshInstancesRejectsCyclesAndPreservesLegacyMeshes()
+	{
+		tinygltf::Model cyclicModel;
+		cyclicModel.meshes.resize(1);
+		cyclicModel.nodes.resize(2);
+		cyclicModel.nodes[0].mesh = 0;
+		cyclicModel.nodes[0].children = { 1 };
+		cyclicModel.nodes[1].children = { 0 };
+		tinygltf::Scene cyclicScene;
+		cyclicScene.nodes = { 0 };
+		cyclicModel.scenes.push_back(std::move(cyclicScene));
+		cyclicModel.defaultScene = 0;
+
+		TVector<GltfImporterUtils::MeshInstance> instances;
+		Require(
+			!GltfImporterUtils::CollectMeshInstances(cyclicModel, instances),
+			"cyclic glTF node hierarchies must be rejected");
+		Require(instances.IsEmpty(),
+			"failed traversal must not retain partial mesh instances");
+
+		tinygltf::Model legacyModel;
+		legacyModel.meshes.resize(2);
+		Require(
+			GltfImporterUtils::CollectMeshInstances(legacyModel, instances),
+			"mesh-only glTF assets must retain legacy import support");
+		Require(instances.Num() == 2 &&
+			instances[0].m_meshIndex == 0 &&
+			instances[1].m_meshIndex == 1,
+			"mesh-only assets must emit one identity instance per mesh resource");
+	}
+
+	void TestCollectMeshInstancesHandlesDeepHierarchyIteratively()
+	{
+		constexpr size_t NumNodes = 8192;
+		tinygltf::Model model;
+		model.meshes.resize(1);
+		model.nodes.resize(NumNodes);
+		for (size_t nodeIndex = 0; nodeIndex + 1 < NumNodes; ++nodeIndex)
+		{
+			model.nodes[nodeIndex].children = {
+				static_cast<int32_t>(nodeIndex + 1)
+			};
+		}
+		model.nodes[NumNodes - 1].mesh = 0;
+		tinygltf::Scene scene;
+		scene.nodes = { 0 };
+		model.scenes.push_back(std::move(scene));
+		model.defaultScene = 0;
+
+		TVector<GltfImporterUtils::MeshInstance> instances;
+		Require(
+			GltfImporterUtils::CollectMeshInstances(model, instances),
+			"deep valid glTF hierarchies must not overflow the native stack");
+		Require(instances.Num() == 1 &&
+			instances[0].m_nodeIndex == static_cast<int32_t>(NumNodes - 1),
+			"deep hierarchy traversal must reach the leaf mesh node");
+	}
+}
+
+int main()
+{
+	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "ModelReadinessTracksMeshUploads", TestModelReadinessTracksMeshUploads },
+		{ "MeshContextRejectsEmptyGpuUploads", TestMeshContextRejectsEmptyGpuUploads },
+		{ "CompactedMeshesRetainMaterialSlots", TestCompactedMeshesRetainMaterialSlots },
+		{ "GeneratedTangentsPreserveMirroredUvHandedness", TestGeneratedTangentsPreserveMirroredUvHandedness },
+		{ "PathTracerTransformsShadingBasisCorrectly", TestPathTracerTransformsShadingBasisCorrectly },
+		{ "BuildBlasRejectsOutOfRangeIndicesAtomically", TestBuildBlasRejectsOutOfRangeIndicesAtomically },
+		{ "BuildBlasRecoversAfterGeometryIsCorrected", TestBuildBlasRecoversAfterGeometryIsCorrected },
+		{ "BuildBlasIgnoresEmptyMeshes", TestBuildBlasIgnoresEmptyMeshes },
+		{ "BuildBlasRejectsIncompleteAndNonFiniteGeometry", TestBuildBlasRejectsIncompleteAndNonFiniteGeometry },
+		{ "BuildBlasSanitizesExtremeVertexFrames", TestBuildBlasSanitizesExtremeVertexFrames },
+		{ "BuildBlasHandlesExtremeCentroidRange", TestBuildBlasHandlesExtremeCentroidRange },
+		{ "CollectMeshInstancesUsesActiveSceneHierarchy", TestCollectMeshInstancesUsesActiveSceneHierarchy },
+		{ "CollectMeshInstancesRejectsCyclesAndPreservesLegacyMeshes", TestCollectMeshInstancesRejectsCyclesAndPreservesLegacyMeshes },
+		{ "CollectMeshInstancesHandlesDeepHierarchyIteratively", TestCollectMeshInstancesHandlesDeepHierarchyIteratively }
+	};
+
+	for (const auto& test : tests)
+	{
+		try
+		{
+			test.second();
+			std::cout << "[PASS] " << test.first << std::endl;
+		}
+		catch (const std::exception& error)
+		{
+			std::cerr << "[FAIL] " << test.first << ": "
+				<< error.what() << std::endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -484,7 +484,8 @@ uniformsFloat:
 			"std::filesystem::equivalent",
 			"GetAllAssetInfos<TextureAssetInfo>",
 			"TMap<int32_t, FileId> textureIdsByGltfIndex",
-			"transmission remains active.",
+			"ModelImporter::CreateTextureAsset(",
+			"generatedTextureVirtualPath",
 			"m_generatedMaterialMigrationComplete.At_Lock",
 			"assetRegistry->UpdateAsset(materialId)",
 			"AtomicReplaceWorkspaceCacheText" })
@@ -493,6 +494,29 @@ uniformsFloat:
 				"generated material migration lost its ownership/reload contract: " +
 					contract);
 		}
+
+		const size_t textureHelperBegin = importer.find(
+			"FileId ModelImporter::CreateTextureAsset(");
+		const size_t textureHelperEnd = importer.find(
+			"FileId CreateAnimationAsset(",
+			textureHelperBegin);
+		Require(textureHelperBegin != std::string::npos &&
+			textureHelperEnd != std::string::npos,
+			"generated texture identity helper must remain present");
+		const std::string textureHelper = importer.substr(
+			textureHelperBegin,
+			textureHelperEnd - textureHelperBegin);
+		Require(textureHelper.find(
+				"assetRegistry->RegisterGeneratedSecondaryAssetInfo(filepath)") !=
+				std::string::npos &&
+			textureHelper.find("FileId::CreateNewFileId()") !=
+				std::string::npos &&
+			textureHelper.find("existingTextureInfo->GetGlbTextureIndex()") !=
+				std::string::npos &&
+			textureHelper.find("AtomicReplaceWorkspaceCacheText") !=
+				std::string::npos,
+			"generated texture updates must reuse a compatible existing FileId "
+			"and allocate only a genuinely new secondary asset");
 
 		const size_t customSkipBegin = migration.find(
 			"if (!findOwnedMaterial(");
@@ -521,12 +545,15 @@ uniformsFloat:
 		const std::string loadModel = importer.substr(
 			loadModelBegin,
 			loadModelEnd - loadModelBegin);
-		Require(loadModel.find("&gltfModel") != std::string::npos &&
+		Require(loadModel.find("&pData->m_gltfModel") != std::string::npos &&
 			loadModel.find(
 				"UpdateGeneratedMaterialPropertiesOnDemand") !=
-				std::string::npos,
+				std::string::npos &&
+			loadModel.find("EThreadType::Main") != std::string::npos &&
+			loadModel.find(
+				"m_generatedMaterialMigrationTasks") != std::string::npos,
 			"unchanged legacy materials must migrate on demand from the "
-			"already parsed model without a startup GLB scan");
+			"already parsed model on the main thread without blocking RHI upload");
 	}
 
 	void TestGltfMaterialTextureColorSpaces()
@@ -951,6 +978,10 @@ uniformsFloat:
 		const auto transforms =
 			GltfImporterUtils::ResolveMeshInstanceTransforms(instance, 10000.0f);
 		RequireVec3Near(
+			transforms.m_bakedVolumeScale,
+			glm::vec3(2.0f, 1.0f, 0.5f),
+			"baked glTF node scale must survive vertex flattening without inheriting unit scale");
+		RequireVec3Near(
 			glm::vec3(transforms.m_geometryTransform * glm::vec4(1.0f, 0.0f, 0.0f, 1.0f)),
 			glm::vec3(0.0f, 20000.0f, 0.0f),
 			"unit scale must still affect imported positions");
@@ -971,6 +1002,18 @@ uniformsFloat:
 		Require(
 			glm::determinant(mirroredTransforms.m_directionTransform) < 0.0f,
 			"negative unit scale must retain mirrored winding without scaling directions");
+		RequireVec3Near(
+			mirroredTransforms.m_bakedVolumeScale,
+			transforms.m_bakedVolumeScale,
+			"model unit-scale sign must not be applied twice to volume thickness");
+
+		instance.m_skinIndex = 0;
+		const auto skinnedTransforms =
+			GltfImporterUtils::ResolveMeshInstanceTransforms(instance, 10000.0f);
+		RequireVec3Near(
+			skinnedTransforms.m_bakedVolumeScale,
+			glm::vec3(1.0f),
+			"skinned meshes must not retain a node transform that is not baked into their vertices");
 	}
 
 	void TestCollectMeshInstancesRejectsCyclesAndPreservesLegacyMeshes()

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -613,6 +613,39 @@ uniformsFloat:
 			"material resolution without materials must remain invalid");
 	}
 
+	void TestDefaultMaterialLoadingPreservesSourceSlots()
+	{
+		const std::filesystem::path sourceRoot =
+			std::filesystem::path(__FILE__).parent_path().parent_path();
+		const std::string importer = ReadText(
+			sourceRoot /
+			"Runtime/AssetRegistry/Model/ModelImporter.cpp");
+		const size_t functionOffset = importer.find(
+			"Tasks::TaskPtr<bool> ModelImporter::LoadDefaultMaterials(");
+		Require(functionOffset != std::string::npos,
+			"default material loading implementation must remain present");
+		const size_t functionEnd = importer.find(
+			"\nbool ModelImporter::LoadAsset(",
+			functionOffset);
+		Require(functionEnd != std::string::npos,
+			"default material loading implementation must remain bounded");
+		const std::string function = importer.substr(
+			functionOffset,
+			functionEnd - functionOffset);
+
+		Require(function.find(
+				"outMaterials.Resize(defaultMaterials.Num())") !=
+				std::string::npos,
+			"default material loading must reserve every original glTF material slot");
+		Require(function.find(
+				"outMaterials[materialIndex] = material") !=
+				std::string::npos,
+			"successfully loaded materials must be assigned to their original glTF slots");
+		Require(function.find("outMaterials.Add(material)") ==
+				std::string::npos,
+			"missing default materials must not compact and shift later material slots");
+	}
+
 	void TestGeneratedTangentsPreserveMirroredUvHandedness()
 	{
 		const glm::vec3 vertices[] = {
@@ -1087,6 +1120,7 @@ int main()
 		{ "GeneratedMaterialMigrationRecognizesLegacyOwnership", TestGeneratedMaterialMigrationRecognizesLegacyOwnership },
 		{ "GltfMaterialTextureColorSpaces", TestGltfMaterialTextureColorSpaces },
 		{ "CompactedMeshesRetainMaterialSlots", TestCompactedMeshesRetainMaterialSlots },
+		{ "DefaultMaterialLoadingPreservesSourceSlots", TestDefaultMaterialLoadingPreservesSourceSlots },
 		{ "GeneratedTangentsPreserveMirroredUvHandedness", TestGeneratedTangentsPreserveMirroredUvHandedness },
 		{ "PathTracerTransformsShadingBasisCorrectly", TestPathTracerTransformsShadingBasisCorrectly },
 		{ "BuildBlasRejectsOutOfRangeIndicesAtomically", TestBuildBlasRejectsOutOfRangeIndicesAtomically },

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -1,11 +1,16 @@
 #include "AssetRegistry/Model/ModelImporter.h"
 #include "AssetRegistry/Model/GltfImporterUtils.h"
+#include "AssetRegistry/Material/MaterialImporter.h"
+#include "Core/Utils.h"
 #include "Raytracing/MaterialUtils.h"
 #include "Raytracing/PathTracer.h"
 
 #include <cmath>
+#include <filesystem>
+#include <fstream>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <stdexcept>
 #include <string>
@@ -77,6 +82,16 @@ namespace
 		{
 			throw std::runtime_error(message);
 		}
+	}
+
+	std::string ReadText(const std::filesystem::path& path)
+	{
+		std::ifstream input(path, std::ios::binary);
+		Require(input.is_open(),
+			"test source should be readable: " + path.generic_string());
+		return std::string(
+			std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>());
 	}
 
 	RHI::VertexP3N3T3B3UV2C4I4W4 MakeVertex(const glm::vec3& position)
@@ -164,6 +179,397 @@ namespace
 		emptyMesh.outIndices = { 0, 0, 0 };
 		Require(emptyMesh.HasGeometry(),
 			"a mesh context with vertices and indices must remain uploadable");
+	}
+
+	void TestGltfAlphaModesResolveRenderState()
+	{
+		const auto transparent =
+			GltfImporterUtils::ResolveMaterialAlphaMode("BLEND");
+		Require(std::string(transparent.m_renderQueue) == "Transparent",
+			"glTF BLEND materials must use the Transparent queue");
+		Require(!transparent.m_bEnableZWrite,
+			"glTF BLEND materials must not write depth");
+		Require(!transparent.m_bAlphaCutout,
+			"glTF BLEND materials must not use the alpha-cutout path");
+		Require(transparent.m_blendMode == RHI::EBlendMode::AlphaBlending,
+			"glTF BLEND materials must enable alpha blending");
+
+		const auto masked =
+			GltfImporterUtils::ResolveMaterialAlphaMode("MASK");
+		Require(std::string(masked.m_renderQueue) == "Masked",
+			"glTF MASK materials must use the Masked queue");
+		Require(masked.m_bEnableZWrite && masked.m_bAlphaCutout,
+			"glTF MASK materials must write depth through the cutout path");
+		Require(masked.m_blendMode == RHI::EBlendMode::None,
+			"glTF MASK materials must not enable alpha blending");
+
+		for (const std::string alphaMode : { "OPAQUE", "", "UNKNOWN" })
+		{
+			const auto opaque =
+				GltfImporterUtils::ResolveMaterialAlphaMode(alphaMode);
+			Require(std::string(opaque.m_renderQueue) == "Opaque",
+				"non-BLEND glTF materials must default to the Opaque queue");
+			Require(opaque.m_bEnableZWrite && !opaque.m_bAlphaCutout,
+				"opaque glTF materials must retain the default depth path");
+			Require(opaque.m_blendMode == RHI::EBlendMode::None,
+				"opaque glTF materials must not enable blending");
+		}
+
+		const auto transmission =
+			GltfImporterUtils::ResolveMaterialAlphaMode("OPAQUE", true);
+		Require(std::string(transmission.m_renderQueue) == "Transparent",
+			"glTF transmission materials must use the Transparent queue");
+		Require(!transmission.m_bEnableZWrite &&
+			!transmission.m_bAlphaCutout,
+			"opaque glTF transmission must not write depth or use alpha cutout");
+		Require(transmission.m_blendMode == RHI::EBlendMode::None,
+			"glTF transmission must compose the opaque framebuffer without alpha blending");
+
+		const auto blendedTransmission =
+			GltfImporterUtils::ResolveMaterialAlphaMode("BLEND", true);
+		Require(blendedTransmission.m_blendMode ==
+			RHI::EBlendMode::AlphaBlending,
+			"alpha coverage must retain alpha blending when combined with transmission");
+
+		const auto maskedTransmission =
+			GltfImporterUtils::ResolveMaterialAlphaMode("MASK", true);
+		Require(maskedTransmission.m_bAlphaCutout &&
+			!maskedTransmission.m_bEnableZWrite,
+			"masked transmission must retain cutout without writing depth");
+	}
+
+	void TestMaterialAssetRetainsRenderQueue()
+	{
+		YAML::Node source;
+		source["renderQueue"] = "Transparent";
+
+		MaterialAsset materialAsset;
+		materialAsset.Deserialize(source);
+
+		Require(materialAsset.GetRenderQueue() == "Transparent",
+			"material deserialization must retain its authored render queue");
+		Require(materialAsset.GetRenderState().GetTag() ==
+			GetHash(std::string("Transparent")),
+			"material render state tag must match the retained render queue");
+	}
+
+	void TestGltfTransmissionExtensionResolvesMaterialFields()
+	{
+		tinygltf::Material material;
+		Require(!GltfImporterUtils::ResolveMaterialTransmission(
+			material,
+			2).IsEnabled(),
+			"materials without KHR_materials_transmission must remain disabled");
+
+		tinygltf::Value::Object textureInfo;
+		textureInfo.emplace("index", tinygltf::Value(1));
+		tinygltf::Value::Object extension;
+		extension.emplace("transmissionFactor", tinygltf::Value(1.25));
+		extension.emplace(
+			"transmissionTexture",
+			tinygltf::Value(std::move(textureInfo)));
+		material.extensions["KHR_materials_transmission"] =
+			tinygltf::Value(std::move(extension));
+
+		const auto transmission =
+			GltfImporterUtils::ResolveMaterialTransmission(material, 2);
+		Require(transmission.IsEnabled() && transmission.m_factor == 1.0f,
+			"glTF transmission factor must be enabled and clamped to one");
+		Require(transmission.m_textureIndex == 1,
+			"valid glTF transmission textures must retain their index");
+		Require(transmission.m_thicknessFactor == 0.0f &&
+			transmission.m_thicknessTextureIndex == -1 &&
+			transmission.m_attenuationColor == glm::vec3(1.0f) &&
+			transmission.m_attenuationDistance ==
+				(std::numeric_limits<float>::max)() &&
+			transmission.m_indexOfRefraction == 1.5f,
+			"transmission materials must retain glTF volume and IOR defaults");
+
+		tinygltf::Value::Object thicknessTexture;
+		thicknessTexture.emplace("index", tinygltf::Value(0));
+		tinygltf::Value::Array attenuationColor{
+			tinygltf::Value(0.25),
+			tinygltf::Value(0.5),
+			tinygltf::Value(0.75)
+		};
+		tinygltf::Value::Object volumeExtension;
+		volumeExtension.emplace("thicknessFactor", tinygltf::Value(0.22));
+		volumeExtension.emplace(
+			"thicknessTexture",
+			tinygltf::Value(std::move(thicknessTexture)));
+		volumeExtension.emplace(
+			"attenuationColor",
+			tinygltf::Value(std::move(attenuationColor)));
+		volumeExtension.emplace("attenuationDistance", tinygltf::Value(2.0));
+		material.extensions["KHR_materials_volume"] =
+			tinygltf::Value(std::move(volumeExtension));
+
+		tinygltf::Value::Object iorExtension;
+		iorExtension.emplace("ior", tinygltf::Value(1.33));
+		material.extensions["KHR_materials_ior"] =
+			tinygltf::Value(std::move(iorExtension));
+
+		const auto volumeTransmission =
+			GltfImporterUtils::ResolveMaterialTransmission(material, 2);
+		Require(std::abs(volumeTransmission.m_thicknessFactor - 0.22f) <
+			0.0001f,
+			"glTF volume thickness must be imported");
+		Require(volumeTransmission.m_thicknessTextureIndex == 0,
+			"valid glTF thickness textures must retain their index");
+		Require(volumeTransmission.m_attenuationColor ==
+			glm::vec3(0.25f, 0.5f, 0.75f),
+			"glTF attenuation color must be imported");
+		Require(volumeTransmission.m_attenuationDistance == 2.0f,
+			"glTF attenuation distance must be imported");
+		Require(std::abs(volumeTransmission.m_indexOfRefraction - 1.33f) <
+			0.0001f,
+			"glTF index of refraction must be imported");
+
+		const auto scaledVolumeTransmission =
+			GltfImporterUtils::ResolveMaterialTransmission(
+				material,
+				2,
+				10000.0f);
+		Require(std::abs(scaledVolumeTransmission.m_thicknessFactor -
+			2200.0f) < 0.01f,
+			"glTF volume thickness must follow the model unit scale");
+		Require(std::abs(scaledVolumeTransmission.m_attenuationDistance -
+			20000.0f) < 0.01f,
+			"glTF attenuation distance must follow the model unit scale");
+
+		const auto invalidTexture =
+			GltfImporterUtils::ResolveMaterialTransmission(material, 1);
+		Require(invalidTexture.m_textureIndex == -1,
+			"out-of-range glTF transmission textures must be ignored");
+	}
+
+	void TestGeneratedMaterialMigrationPreservesAuthoredProperties()
+	{
+		YAML::Node material = YAML::Load(R"(
+renderQueue: Opaque
+bEnableZWrite: true
+bCustomDepthShader: true
+blendMode: AlphaBlending
+cullMode: Front
+shaderUid: custom-shader
+defines:
+- CLEAR_COAT
+- CUSTOM_FEATURE
+- ALPHA_CUTOUT
+uniformsFloat:
+  material.roughnessFactor: 0.37
+  material.alphaCutoff: 0.1
+  material.transmissionFactor: 0.25
+uniformsVec4:
+  material.baseColorFactor: [0.1, 0.2, 0.3, 1.0]
+  material.attenuationColor: [1.0, 0.0, 0.0, 1.0]
+samplers:
+  baseColorSampler: authored-base-color
+  transmissionSampler: stale-transmission
+  thicknessSampler: stale-thickness
+)");
+		YAML::Node generated = YAML::Load(R"(
+renderQueue: Transparent
+bEnableZWrite: false
+bCustomDepthShader: false
+blendMode: None
+defines:
+- TRANSMISSION
+uniformsFloat:
+  material.alphaCutoff: 0.5
+  material.transmissionFactor: 1.0
+  material.thicknessFactor: 2.0
+  material.attenuationDistance: 4.0
+  material.indexOfRefraction: 1.5
+uniformsVec4:
+  material.attenuationColor: [0.8, 0.8, 0.8, 1.0]
+samplers:
+  transmissionSampler: generated-transmission
+)");
+
+		Require(GltfImporterUtils::MergeGeneratedMaterialProperties(
+			material,
+			generated),
+			"valid generated material properties must be mergeable");
+		Require(material["renderQueue"].as<std::string>() == "Transparent" &&
+			!material["bEnableZWrite"].as<bool>() &&
+			!material["bCustomDepthShader"].as<bool>() &&
+			material["blendMode"].as<std::string>() == "None",
+			"alpha and transmission render state must follow the glTF source");
+		Require(material["cullMode"].as<std::string>() == "Front" &&
+			material["shaderUid"].as<std::string>() == "custom-shader",
+			"unrelated authored render and shader properties must be preserved");
+		Require(material["uniformsFloat"]["material.roughnessFactor"]
+			.as<float>() == 0.37f &&
+			material["uniformsFloat"]["material.transmissionFactor"]
+			.as<float>() == 1.0f &&
+			material["uniformsFloat"]["material.alphaCutoff"]
+			.as<float>() == 0.5f,
+			"migration must replace only importer-owned scalar uniforms");
+		Require(material["samplers"]["baseColorSampler"].as<std::string>() ==
+			"authored-base-color" &&
+			material["samplers"]["transmissionSampler"].as<std::string>() ==
+				"generated-transmission" &&
+			!material["samplers"]["thicknessSampler"],
+			"migration must preserve authored samplers and remove stale managed samplers");
+
+		bool bHasClearCoat = false;
+		bool bHasCustomFeature = false;
+		bool bHasTransmission = false;
+		bool bHasAlphaCutout = false;
+		for (const YAML::Node& define : material["defines"])
+		{
+			const std::string value = define.as<std::string>();
+			bHasClearCoat |= value == "CLEAR_COAT";
+			bHasCustomFeature |= value == "CUSTOM_FEATURE";
+			bHasTransmission |= value == "TRANSMISSION";
+			bHasAlphaCutout |= value == "ALPHA_CUTOUT";
+		}
+		Require(bHasClearCoat && bHasCustomFeature && bHasTransmission &&
+			!bHasAlphaCutout,
+			"migration must preserve unrelated defines and replace managed defines");
+
+		YAML::Node opaqueGenerated = YAML::Load(R"(
+renderQueue: Opaque
+bEnableZWrite: true
+bCustomDepthShader: false
+blendMode: None
+defines: []
+uniformsFloat:
+  material.alphaCutoff: 0.25
+)");
+		Require(GltfImporterUtils::MergeGeneratedMaterialProperties(
+			material,
+			opaqueGenerated),
+			"transmission removal must be mergeable");
+		Require(!material["uniformsFloat"]["material.transmissionFactor"] &&
+			!material["uniformsFloat"]["material.thicknessFactor"] &&
+			!material["uniformsVec4"]["material.attenuationColor"] &&
+			!material["samplers"]["transmissionSampler"],
+			"removing the glTF extension must remove stale managed properties");
+
+		YAML::Node malformed = YAML::Load("defines: INVALID");
+		const YAML::Node malformedBefore = YAML::Clone(malformed);
+		Require(!GltfImporterUtils::MergeGeneratedMaterialProperties(
+			malformed,
+			generated) &&
+			Utils::AreYamlNodesEqual(malformed, malformedBefore),
+			"malformed authored YAML must be rejected without partial mutation");
+	}
+
+	void TestGeneratedMaterialMigrationRecognizesLegacyOwnership()
+	{
+		const std::filesystem::path sourceRoot =
+			std::filesystem::path(__FILE__).parent_path().parent_path();
+		const std::string importer = ReadText(
+			sourceRoot /
+			"Runtime/AssetRegistry/Model/ModelImporter.cpp");
+		const size_t migrationBegin = importer.find(
+			"bool ModelImporter::UpdateGeneratedMaterialProperties(");
+		const size_t migrationEnd = importer.find(
+			"Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel",
+			migrationBegin);
+		Require(migrationBegin != std::string::npos &&
+			migrationEnd != std::string::npos,
+			"generated material migration implementation must remain present");
+		const std::string migration = importer.substr(
+			migrationBegin,
+			migrationEnd - migrationBegin);
+
+		for (const std::string contract : {
+			"sanitizeLegacyMaterialStem",
+			"gltfModel.materials[materialIndex].name",
+			"legacyMaterialPath",
+			"defaultMaterials[materialIndex]",
+			"std::filesystem::equivalent",
+			"GetAllAssetInfos<TextureAssetInfo>",
+			"TMap<int32_t, FileId> textureIdsByGltfIndex",
+			"transmission remains active.",
+			"m_generatedMaterialMigrationComplete.At_Lock",
+			"assetRegistry->UpdateAsset(materialId)",
+			"AtomicReplaceWorkspaceCacheText" })
+		{
+			Require(migration.find(contract) != std::string::npos,
+				"generated material migration lost its ownership/reload contract: " +
+					contract);
+		}
+
+		const size_t customSkipBegin = migration.find(
+			"if (!findOwnedMaterial(");
+		const size_t customSkipEnd = migration.find(
+			"const tinygltf::Material& sourceMaterial",
+			customSkipBegin);
+		Require(customSkipBegin != std::string::npos &&
+			customSkipEnd != std::string::npos,
+			"custom material ownership check must remain present");
+		const std::string customSkip = migration.substr(
+			customSkipBegin,
+			customSkipEnd - customSkipBegin);
+		Require(customSkip.find("continue;") != std::string::npos &&
+			customSkip.find("bSucceeded = false") == std::string::npos,
+			"preserving a custom replacement is a successful skip and must not "
+			"leave on-demand migration retrying forever");
+
+		const size_t loadModelBegin = importer.find(
+			"Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(");
+		const size_t loadModelEnd = importer.find(
+			"bool ModelImporter::LoadModel_Immediate(",
+			loadModelBegin);
+		Require(loadModelBegin != std::string::npos &&
+			loadModelEnd != std::string::npos,
+			"model load implementation must remain present");
+		const std::string loadModel = importer.substr(
+			loadModelBegin,
+			loadModelEnd - loadModelBegin);
+		Require(loadModel.find("&gltfModel") != std::string::npos &&
+			loadModel.find(
+				"UpdateGeneratedMaterialPropertiesOnDemand") !=
+				std::string::npos,
+			"unchanged legacy materials must migrate on demand from the "
+			"already parsed model without a startup GLB scan");
+	}
+
+	void TestGltfMaterialTextureColorSpaces()
+	{
+		const std::filesystem::path sourceRoot =
+			std::filesystem::path(__FILE__).parent_path().parent_path();
+		const std::string importer = ReadText(
+			sourceRoot /
+			"Runtime/AssetRegistry/Model/ModelImporter.cpp");
+
+		for (const std::string textureSuffix : {
+			"_ormTexture.png.asset",
+			"_occlusionTexture.png.asset",
+			"_clearcoatTexture.png.asset",
+			"_clearcoatRoughnessTexture.png.asset",
+			"_sheenRoughnessTexture.png.asset" })
+		{
+			const size_t textureOffset = importer.find(textureSuffix);
+			Require(textureOffset != std::string::npos,
+				"glTF data texture generation should remain present: " +
+				textureSuffix);
+			const size_t lineEnd = importer.find('\n', textureOffset);
+			Require(importer.substr(textureOffset, lineEnd - textureOffset)
+				.find("R8G8B8A8_UNORM") != std::string::npos,
+				"glTF scalar/data textures must bypass sRGB decoding: " +
+				textureSuffix);
+		}
+
+		for (const std::string textureSuffix : {
+			"_baseColorTexture.png.asset",
+			"_emissionTexture.png.asset",
+			"_sheenColorTexture.png.asset" })
+		{
+			const size_t textureOffset = importer.find(textureSuffix);
+			Require(textureOffset != std::string::npos,
+				"glTF color texture generation should remain present: " +
+				textureSuffix);
+			const size_t lineEnd = importer.find('\n', textureOffset);
+			Require(importer.substr(textureOffset, lineEnd - textureOffset)
+				.find("R8G8B8A8_SRGB") != std::string::npos,
+				"glTF color textures must retain sRGB decoding: " +
+				textureSuffix);
+		}
 	}
 
 	void TestCompactedMeshesRetainMaterialSlots()
@@ -631,6 +1037,12 @@ int main()
 	const std::pair<const char*, std::function<void()>> tests[] = {
 		{ "ModelReadinessTracksMeshUploads", TestModelReadinessTracksMeshUploads },
 		{ "MeshContextRejectsEmptyGpuUploads", TestMeshContextRejectsEmptyGpuUploads },
+		{ "GltfAlphaModesResolveRenderState", TestGltfAlphaModesResolveRenderState },
+		{ "MaterialAssetRetainsRenderQueue", TestMaterialAssetRetainsRenderQueue },
+		{ "GltfTransmissionExtensionResolvesMaterialFields", TestGltfTransmissionExtensionResolvesMaterialFields },
+		{ "GeneratedMaterialMigrationPreservesAuthoredProperties", TestGeneratedMaterialMigrationPreservesAuthoredProperties },
+		{ "GeneratedMaterialMigrationRecognizesLegacyOwnership", TestGeneratedMaterialMigrationRecognizesLegacyOwnership },
+		{ "GltfMaterialTextureColorSpaces", TestGltfMaterialTextureColorSpaces },
 		{ "CompactedMeshesRetainMaterialSlots", TestCompactedMeshesRetainMaterialSlots },
 		{ "GeneratedTangentsPreserveMirroredUvHandedness", TestGeneratedTangentsPreserveMirroredUvHandedness },
 		{ "PathTracerTransformsShadingBasisCorrectly", TestPathTracerTransformsShadingBasisCorrectly },

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -532,6 +532,41 @@ namespace
 			"node matrix must take precedence over TRS properties");
 	}
 
+	void TestUnitScaleDoesNotShrinkImportedDirections()
+	{
+		GltfImporterUtils::MeshInstance instance;
+		glm::mat4 quarterTurn(1.0f);
+		quarterTurn[0] = glm::vec4(0.0f, 1.0f, 0.0f, 0.0f);
+		quarterTurn[1] = glm::vec4(-1.0f, 0.0f, 0.0f, 0.0f);
+		instance.m_worldTransform =
+			quarterTurn *
+			glm::scale(glm::mat4(1.0f), glm::vec3(2.0f, 1.0f, 0.5f));
+
+		const auto transforms =
+			GltfImporterUtils::ResolveMeshInstanceTransforms(instance, 10000.0f);
+		RequireVec3Near(
+			glm::vec3(transforms.m_geometryTransform * glm::vec4(1.0f, 0.0f, 0.0f, 1.0f)),
+			glm::vec3(0.0f, 20000.0f, 0.0f),
+			"unit scale must still affect imported positions");
+
+		const glm::mat3 normalTransform =
+			glm::transpose(glm::inverse(transforms.m_directionTransform));
+		const glm::vec3 importedNormal = normalTransform * glm::vec3(0.0f, 0.0f, 1.0f);
+		Require(
+			glm::length(importedNormal) > 1.0f,
+			"large unit scale must not shrink imported normals below the sanitizer threshold");
+		RequireVec3Near(
+			glm::normalize(importedNormal),
+			glm::vec3(0.0f, 0.0f, 1.0f),
+			"node transforms must still be applied to imported normals");
+
+		const auto mirroredTransforms =
+			GltfImporterUtils::ResolveMeshInstanceTransforms(instance, -10000.0f);
+		Require(
+			glm::determinant(mirroredTransforms.m_directionTransform) < 0.0f,
+			"negative unit scale must retain mirrored winding without scaling directions");
+	}
+
 	void TestCollectMeshInstancesRejectsCyclesAndPreservesLegacyMeshes()
 	{
 		tinygltf::Model cyclicModel;
@@ -606,6 +641,7 @@ int main()
 		{ "BuildBlasSanitizesExtremeVertexFrames", TestBuildBlasSanitizesExtremeVertexFrames },
 		{ "BuildBlasHandlesExtremeCentroidRange", TestBuildBlasHandlesExtremeCentroidRange },
 		{ "CollectMeshInstancesUsesActiveSceneHierarchy", TestCollectMeshInstancesUsesActiveSceneHierarchy },
+		{ "UnitScaleDoesNotShrinkImportedDirections", TestUnitScaleDoesNotShrinkImportedDirections },
 		{ "CollectMeshInstancesRejectsCyclesAndPreservesLegacyMeshes", TestCollectMeshInstancesRejectsCyclesAndPreservesLegacyMeshes },
 		{ "CollectMeshInstancesHandlesDeepHierarchyIteratively", TestCollectMeshInstancesHandlesDeepHierarchyIteratively }
 	};

--- a/Tests/RemoteViewportRuntimeTests.cpp
+++ b/Tests/RemoteViewportRuntimeTests.cpp
@@ -979,10 +979,16 @@ namespace
 			"Mac modifier keys must reach ImGui selection suppression");
 		Require(macInputSource.find("SceneViewportPointerRouting.ShouldPublishHoverMove(activeMouseModifiers)") != std::string::npos &&
 			macInputSource.find("SceneViewportPointerRouting.ShouldPublishCapturedMove(") != std::string::npos &&
+			macInputSource.find("TryUsePointerMotionSource(PointerMotionSource.UIKit)") != std::string::npos &&
+			macInputSource.find("TryUsePointerMotionSource(PointerMotionSource.GameController)") != std::string::npos &&
+			macInputSource.find("HasPointerMoved(point)") != std::string::npos &&
+			macInputSource.find("deltaX == 0.0f && deltaY == 0.0f") != std::string::npos &&
+			macInputSource.find("ObserveDidBecomeCurrent") != std::string::npos &&
+			macInputSource.find("ObserveDidStopBeingCurrent") != std::string::npos &&
 			macInputSource.find("(deltaX * sensitivity) / scale") != std::string::npos &&
 			macInputSource.find("PublishTouchButton(touches, activeLocalPointerModifier, false);") != std::string::npos &&
 			macInputSource.find("activeMouseModifiers | activeKeyboardModifiers") != std::string::npos,
-			"Mac pointer input must arbitrate hover and captured motion, normalize Retina deltas, release local trackpad presses, and preserve keyboard modifiers");
+			"Mac pointer input must arbitrate hover, GameController, and UIKit fallback motion, normalize Retina deltas, release local presses, and preserve keyboard modifiers");
 	}
 
 }

--- a/Tests/RemoteViewportRuntimeTests.cpp
+++ b/Tests/RemoteViewportRuntimeTests.cpp
@@ -983,8 +983,9 @@ namespace
 			macInputSource.find("TryUsePointerMotionSource(PointerMotionSource.GameController)") != std::string::npos &&
 			macInputSource.find("HasPointerMoved(point)") != std::string::npos &&
 			macInputSource.find("deltaX == 0.0f && deltaY == 0.0f") != std::string::npos &&
-			macInputSource.find("ObserveDidBecomeCurrent") != std::string::npos &&
-			macInputSource.find("ObserveDidStopBeingCurrent") != std::string::npos &&
+			macInputSource.find("ObserveDidBecomeCurrent") == std::string::npos &&
+			macInputSource.find("ObserveDidStopBeingCurrent") == std::string::npos &&
+			macInputSource.find("foreach (var mouse in GCMouse.Mice)") != std::string::npos &&
 			macInputSource.find("(deltaX * sensitivity) / scale") != std::string::npos &&
 			macInputSource.find("PublishTouchButton(touches, activeLocalPointerModifier, false);") != std::string::npos &&
 			macInputSource.find("activeMouseModifiers | activeKeyboardModifiers") != std::string::npos,

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -897,7 +897,7 @@ namespace
 		return dependency;
 	}
 
-	void TestShaderDependencyFingerprintTracksExactRevisionAndWinner()
+	void TestShaderDependencyFingerprintTracksTimestampAndWinner()
 	{
 		TVector<ShaderDependencyFile> baselineDependencies;
 		baselineDependencies.Add(Dependency(
@@ -921,9 +921,10 @@ namespace
 			"identical shader dependency snapshots should have a stable non-zero fingerprint");
 
 		TVector<ShaderDependencyFile> sameTimestampEdit = baselineDependencies;
+		sameTimestampEdit[1].m_revision.m_fileSize = 256;
 		sameTimestampEdit[1].m_revision.m_contentHash = 0x3333333333333333ull;
-		Require(CalculateShaderDependencyFingerprint(sameTimestampEdit) != baseline,
-			"same-timestamp, same-size GLSL edits should invalidate the shader fingerprint");
+		Require(CalculateShaderDependencyFingerprint(sameTimestampEdit) == baseline,
+			"file size and content hash must not affect timestamp-based shader fingerprints");
 
 		TVector<ShaderDependencyFile> backdatedEdit = baselineDependencies;
 		backdatedEdit[1].m_revision.m_modificationTimeNanoseconds = 1000000000ll;
@@ -1117,7 +1118,7 @@ int main()
 		TestIoFailureQuarantineIsReadOnlyAndSessionOnly();
 		TestRuntimeArtifactIoFailureEntersReadOnlyQuarantine();
 		TestShaderCompilerFailureLifecycle();
-		TestShaderDependencyFingerprintTracksExactRevisionAndWinner();
+		TestShaderDependencyFingerprintTracksTimestampAndWinner();
 		TestMissingYamlIncludeFailsWithoutPartialSource();
 		TestShaderSourceNormalization();
 		TestShaderSourceRewritePreservesFileIdentity();

--- a/Tests/VulkanDescriptorCacheTests.cpp
+++ b/Tests/VulkanDescriptorCacheTests.cpp
@@ -1,0 +1,426 @@
+#include "GraphicsDriver/Vulkan/VulkanGraphicsDriver.h"
+#include "GraphicsDriver/Vulkan/VulkanPipeline.h"
+#include "GraphicsDriver/Vulkan/VulkanDevice.h"
+#include "FrameGraph/RenderSceneTextureCache.h"
+#include "AssetRegistry/Texture/TextureImporter.h"
+#include "RHI/Material.h"
+#include "RHI/Shader.h"
+#include "RHI/Texture.h"
+
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <iterator>
+#include <cctype>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+using namespace Sailor;
+using namespace Sailor::GraphicsDriver::Vulkan;
+
+namespace
+{
+	class VulkanGraphicsDriverProbe final : public VulkanGraphicsDriver
+	{
+	public:
+		using DescriptorCacheKey = CachedDescriptorSet;
+	};
+
+	class VulkanDescriptorSetOwnershipProbe final : public VulkanDescriptorSet
+	{
+	public:
+		using DescriptorPoolMemberType = decltype(m_descriptorPool);
+		using DescriptorPoolPageMemberType = decltype(m_descriptorPoolPage);
+	};
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	std::string ReadText(const std::filesystem::path& path)
+	{
+		std::ifstream input(path, std::ios::binary);
+		Require(input.is_open(), "test source should be readable: " + path.generic_string());
+		return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+	}
+
+	std::string ExtractFunctionBody(const std::string& source, const std::string& signature)
+	{
+		const size_t signatureOffset = source.find(signature);
+		Require(signatureOffset != std::string::npos,
+			"function signature should exist: " + signature);
+
+		const size_t bodyOffset = source.find('{', signatureOffset + signature.size());
+		Require(bodyOffset != std::string::npos,
+			"function body should exist: " + signature);
+
+		size_t depth = 0;
+		for (size_t offset = bodyOffset; offset < source.size(); ++offset)
+		{
+			if (source[offset] == '{')
+			{
+				++depth;
+			}
+			else if (source[offset] == '}' && --depth == 0)
+			{
+				return source.substr(bodyOffset, offset - bodyOffset + 1);
+			}
+		}
+
+		throw std::runtime_error("function body should be balanced: " + signature);
+	}
+
+	std::string RemoveWhitespace(const std::string& value)
+	{
+		std::string result;
+		result.reserve(value.size());
+		for (const unsigned char character : value)
+		{
+			if (!std::isspace(character))
+			{
+				result.push_back(static_cast<char>(character));
+			}
+		}
+		return result;
+	}
+
+	RHI::RHITexturePtr MakeTexture()
+	{
+		return RHI::RHITexturePtr::Make(
+			RHI::ETextureFiltration::Linear,
+			RHI::ETextureClamping::Repeat,
+			false);
+	}
+
+	void SetTextureCount(
+		RHI::RHIShaderBindingSetPtr bindings,
+		uint32_t textureCount)
+	{
+		auto& textureBinding =
+			bindings->GetOrAddShaderBinding("textureSamplers");
+		TVector<RHI::RHITexturePtr> textures;
+		textures.Reserve(textureCount);
+		for (uint32_t i = 0; i < textureCount; ++i)
+		{
+			textures.Add(MakeTexture());
+		}
+
+		textureBinding->SetTextureBindings(textures);
+		bindings->RecalculateCompatibility();
+	}
+
+	void TestDescriptorCacheKeyKeepsItsCompatibilitySnapshot()
+	{
+		using DescriptorCacheKey =
+			VulkanGraphicsDriverProbe::DescriptorCacheKey;
+
+		VulkanPipelineLayoutPtr layout = VulkanPipelineLayoutPtr::Make();
+		RHI::RHIShaderBindingSetPtr bindings =
+			RHI::RHIShaderBindingSetPtr::Make();
+		SetTextureCount(bindings, 1);
+
+		DescriptorCacheKey oldKey(layout, bindings);
+		const DescriptorCacheKey oldKeyCopy = oldKey;
+		const size_t oldHash = oldKey.GetHash();
+
+		TConcurrentMap<DescriptorCacheKey, uint32_t> cache;
+		cache.At_Lock(oldKey) = 7u;
+		cache.Unlock(oldKey);
+		Require(cache.Num() == 1,
+			"the descriptor cache fixture must contain the original key");
+
+		SetTextureCount(bindings, 2);
+		Require(oldKey.IsExpired(),
+			"a key must expire when its binding compatibility changes");
+		Require(oldKey.GetHash() == oldHash &&
+			oldKeyCopy.GetHash() == oldHash,
+			"an expired key must retain its original hash");
+		Require(oldKey == oldKeyCopy,
+			"copies of an immutable key must remain equal after the binding changes");
+
+		DescriptorCacheKey assignedKey;
+		assignedKey = oldKey;
+		Require(assignedKey.GetHash() == oldHash && assignedKey == oldKey,
+			"copy assignment must preserve the captured compatibility value");
+
+		const DescriptorCacheKey currentKey(layout, bindings);
+		Require(!(currentKey == oldKey) && !(oldKey == currentKey),
+			"keys captured before and after a compatibility change must differ symmetrically");
+
+		Require(cache.Remove(oldKeyCopy),
+			"an expired descriptor cache entry must remain removable by its immutable key");
+		Require(cache.IsEmpty(),
+			"removing the expired descriptor cache key must release its map entry");
+	}
+
+	void TestDescriptorCacheKeyTracksDescriptorRevision()
+	{
+		using DescriptorCacheKey =
+			VulkanGraphicsDriverProbe::DescriptorCacheKey;
+
+		VulkanPipelineLayoutPtr layout = VulkanPipelineLayoutPtr::Make();
+		RHI::RHIShaderBindingSetPtr bindings =
+			RHI::RHIShaderBindingSetPtr::Make();
+		SetTextureCount(bindings, 2);
+		bindings->AdvanceDescriptorRevision();
+
+		const DescriptorCacheKey oldKey(layout, bindings);
+		const DescriptorCacheKey oldKeyCopy = oldKey;
+		const size_t oldHash = oldKey.GetHash();
+
+		bindings->AdvanceDescriptorRevision();
+		Require(oldKey.IsExpired(),
+			"a key must expire when descriptor contents get a new revision");
+		Require(oldKey.GetHash() == oldHash && oldKeyCopy.GetHash() == oldHash,
+			"an expired key must retain its captured descriptor revision");
+
+		const DescriptorCacheKey currentKey(layout, bindings);
+		Require(!(currentKey == oldKey) && !(oldKey == currentKey),
+			"keys from different descriptor revisions must differ symmetrically");
+	}
+
+	void TestTextureSamplerUpdatesUseSynchronizedSnapshot()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string importerHeader = ReadText(
+			sourceRoot / "Runtime/AssetRegistry/Texture/TextureImporter.h");
+		const std::string importerSource = ReadText(
+			sourceRoot / "Runtime/AssetRegistry/Texture/TextureImporter.cpp");
+		const std::string snapshotBody = ExtractFunctionBody(
+			importerSource,
+			"TextureImporter::TextureSamplersSnapshot TextureImporter::GetTextureSamplersSnapshot(");
+		const std::string updateBody = ExtractFunctionBody(
+			importerSource,
+			"bool TextureImporter::UpdateTextureSamplerBinding(");
+		const std::string hotReloadBody = ExtractFunctionBody(
+			importerSource,
+			"void TextureImporter::OnUpdateAssetInfo(");
+		const std::string loadBody = ExtractFunctionBody(
+			importerSource,
+			"Tasks::TaskPtr<TexturePtr> TextureImporter::LoadTexture(");
+
+		Require(importerHeader.find("TextureSamplersSnapshot") != std::string::npos &&
+			importerHeader.find("mutable std::mutex m_textureSamplersMutex") != std::string::npos,
+			"texture sampler contents and descriptor revision must be captured under one importer lock");
+		Require(snapshotBody.find("m_textureSamplersMutex") != std::string::npos &&
+			updateBody.find("m_textureSamplersMutex") != std::string::npos,
+			"texture sampler reads and writes must share the importer lock");
+		Require(hotReloadBody.find("UpdateTextureSamplerBinding(") != std::string::npos &&
+			loadBody.find("RegisterTextureSamplerBinding(") != std::string::npos,
+			"all global texture sampler writers must use the synchronized update path");
+	}
+
+	void TestRenderSceneTextureCacheTracksRequestedSlotRevisions()
+	{
+		const TVector<uint64_t> cachedSlotRevisions{ 11u, 29u, 47u };
+		const TVector<uint64_t> unchangedSlotRevisions = cachedSlotRevisions;
+		const TVector<uint64_t> changedSlotRevisions{ 11u, 30u, 47u };
+		const TVector<uint64_t> missingSlotRevision{ 11u, 29u };
+
+		Require(Framegraph::Details::CanReuseRenderSceneTextureBindings(1, 1, true),
+			"an unchanged source revision must be a direct texture cache hit");
+		Require(!Framegraph::Details::CanReuseRenderSceneTextureBindings(1, 1, false),
+			"a matching revision must not manufacture a missing cached binding");
+		Require(!Framegraph::Details::CanReuseRenderSceneTextureBindings(1, 2, true),
+			"a newer source revision without slot snapshots must require revalidation");
+		Require(Framegraph::Details::CanReuseRenderSceneTextureBindings(
+			1, 2, true, &cachedSlotRevisions, &unchangedSlotRevisions),
+			"an unrelated global update must reuse bindings whose requested slots are unchanged");
+		Require(!Framegraph::Details::CanReuseRenderSceneTextureBindings(
+			1, 2, true, &cachedSlotRevisions, &changedSlotRevisions),
+			"a changed requested slot must invalidate the local descriptor set");
+		Require(!Framegraph::Details::CanReuseRenderSceneTextureBindings(
+			1, 2, true, &cachedSlotRevisions, &missingSlotRevision),
+			"a missing requested-slot revision must invalidate the local descriptor set");
+		Require(!Framegraph::Details::CanReuseRenderSceneTextureBindings(
+			1, 2, true, nullptr, &unchangedSlotRevisions),
+			"both requested-slot snapshots are required for revision revalidation");
+	}
+
+	void TestTextureSamplerCapacityReservesDefaultSlot()
+	{
+		Require(TextureImporter::MaxTexturesInScene == 8192,
+			"the bindless texture array must expose 8192 total slots");
+		Require(TextureImporter::MaxUserTexturesInScene == 8191,
+			"slot zero must leave exactly 8191 slots for imported textures");
+		Require(!TextureImporter::IsUserTextureSamplerIndexValid(0),
+			"slot zero must remain reserved for the default texture");
+		Require(TextureImporter::IsUserTextureSamplerIndexValid(1) &&
+			TextureImporter::IsUserTextureSamplerIndexValid(8191),
+			"all user texture slots from one through 8191 must be valid");
+		Require(!TextureImporter::IsUserTextureSamplerIndexValid(8192),
+			"the first index past the full descriptor array must be rejected");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string importerSource = ReadText(
+			sourceRoot / "Runtime/AssetRegistry/Texture/TextureImporter.cpp");
+		const std::string registerBindingBody = ExtractFunctionBody(
+			importerSource,
+			"bool TextureImporter::RegisterTextureSamplerBinding(");
+		const size_t updateOffset = registerBindingBody.find("UpdateTextureSamplerBindingLocked(");
+		const size_t publishOffset = registerBindingBody.find("m_textureSamplersCurrentIndex.store(");
+		Require(registerBindingBody.find("IsUserTextureSamplerIndexValid(") != std::string::npos,
+			"the runtime index allocator must enforce the public 8191-slot boundary contract");
+		Require(updateOffset != std::string::npos &&
+			publishOffset != std::string::npos &&
+			updateOffset < publishOffset,
+			"a texture sampler index must be published only after its descriptor write succeeds");
+	}
+
+	void TestGlobalTextureSamplerUsesFixedCapacityInPlaceUpdates()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string driverSource = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp");
+		const std::string descriptorsHeader = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanDescriptors.h");
+		const std::string descriptorsSource = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanDescriptors.cpp");
+		const std::string updateSetBody = ExtractFunctionBody(
+			driverSource,
+			"bool VulkanGraphicsDriver::UpdateDescriptorSet(");
+		const std::string updateBindingBody = ExtractFunctionBody(
+			driverSource,
+			"void VulkanGraphicsDriver::UpdateShaderBinding(");
+		const std::string updateDescriptorBody = ExtractFunctionBody(
+			descriptorsSource,
+			"bool VulkanDescriptorSet::UpdateDescriptor(");
+		const std::string normalizedUpdateSetBody = RemoveWhitespace(updateSetBody);
+		const std::string normalizedUpdateDescriptorBody = RemoveWhitespace(updateDescriptorBody);
+
+		Require(updateSetBody.find("plannedTextureSlots") != std::string::npos &&
+			updateSetBody.find("variableDescriptorCount") != std::string::npos &&
+			(normalizedUpdateSetBody.find("variableDescriptorCount=std::max(variableDescriptorCount,plannedTextureSlots)") != std::string::npos ||
+				normalizedUpdateSetBody.find("variableDescriptorCount=(std::max)(variableDescriptorCount,plannedTextureSlots)") != std::string::npos ||
+				normalizedUpdateSetBody.find("variableDescriptorCount=plannedTextureSlots") != std::string::npos),
+			"the first bindless set allocation must reserve the full declared texture capacity");
+		Require(descriptorsHeader.find("UpdateDescriptor(VulkanDescriptorPtr descriptor)") != std::string::npos,
+			"descriptor sets must expose a single-descriptor in-place update operation");
+		Require(updateBindingBody.find("IsDescriptorUpdateAfterBindSupported()") != std::string::npos &&
+			updateBindingBody.find("bIsUnusedDescriptorSlot") != std::string::npos &&
+			updateBindingBody.find("m_bVariableDescriptorCount") != std::string::npos &&
+			updateBindingBody.find("UpdateDescriptor(") != std::string::npos &&
+			updateBindingBody.find("AdvanceDescriptorRevision()") != std::string::npos &&
+			updateBindingBody.find("const auto previousTextures = currentTextures") != std::string::npos &&
+			updateBindingBody.find("SetTextureBindings(previousTextures)") != std::string::npos,
+			"unused variable sampler slots must use update-after-bind and advance the source revision");
+		Require(updateDescriptorBody.find("descriptor->Apply(") != std::string::npos &&
+			normalizedUpdateDescriptorBody.find("vkUpdateDescriptorSets(*m_device,1,") != std::string::npos &&
+			updateDescriptorBody.find("UPDATE_UNUSED_WHILE_PENDING") != std::string::npos &&
+			updateDescriptorBody.find("RecalculateCompatibility()") == std::string::npos &&
+			updateBindingBody.find("RecalculateCompatibility()") == std::string::npos &&
+			descriptorsHeader.find("m_retiredDescriptors") == std::string::npos,
+			"an in-place texture update must write exactly one unused slot without rescanning compatibility or retaining replaced resources");
+	}
+
+	void TestVariableDescriptorCompatibilityUsesItsFixedLayout()
+	{
+		const VkDescriptorSetLayoutBinding textureLayout =
+			VulkanApi::CreateDescriptorSetLayoutBinding(
+				0,
+				VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+				static_cast<uint32_t>(TextureImporter::MaxTexturesInScene));
+
+		VulkanDescriptorSetLayoutPtr descriptorLayout =
+			VulkanDescriptorSetLayoutPtr::Make(
+				VulkanDevicePtr{},
+				TVector<VkDescriptorSetLayoutBinding>{ textureLayout },
+				0);
+		VulkanDescriptorSetLayoutPtr pipelineDescriptorLayout =
+			VulkanDescriptorSetLayoutPtr::Make(
+				VulkanDevicePtr{},
+				TVector<VkDescriptorSetLayoutBinding>{ textureLayout },
+				0);
+		VulkanDescriptorSetPtr descriptorSet = VulkanDescriptorSetPtr::Make(
+			VulkanDevicePtr{},
+			VulkanDescriptorPoolPtr{},
+			descriptorLayout,
+			TVector<VulkanDescriptorPtr>{},
+			static_cast<uint32_t>(TextureImporter::MaxTexturesInScene));
+		VulkanPipelineLayoutPtr pipelineLayout = VulkanPipelineLayoutPtr::Make();
+		pipelineLayout->m_descriptionSetLayouts.Add(pipelineDescriptorLayout);
+
+		Require(VulkanApi::IsCompatible(pipelineLayout, descriptorSet, 0),
+			"a fixed variable descriptor layout must be compatible without scanning populated texture slots");
+	}
+
+	void TestDescriptorPoolsUseSmartOwnership()
+	{
+		Require((std::is_same_v<decltype(ThreadContext::m_descriptorPool), VulkanDescriptorPoolPtr>),
+			"each Vulkan thread context must retain its descriptor pool through a smart pointer");
+		Require((std::is_same_v<VulkanDescriptorSetOwnershipProbe::DescriptorPoolMemberType, VulkanDescriptorPoolPtr>),
+			"descriptor allocation must receive smart descriptor-pool ownership");
+		Require((std::is_same_v<VulkanDescriptorSetOwnershipProbe::DescriptorPoolPageMemberType, VulkanDescriptorPoolPagePtr>),
+			"a descriptor set must retain its exact native pool page through a smart pointer");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string descriptorsSource = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanDescriptors.cpp");
+		const std::string compileBody = ExtractFunctionBody(
+			descriptorsSource,
+			"bool VulkanDescriptorSet::TryCompile(");
+		const std::string releaseBody = ExtractFunctionBody(
+			descriptorsSource,
+			"void VulkanDescriptorSet::Release(");
+		const std::string poolPageDestructorBody = ExtractFunctionBody(
+			descriptorsSource,
+			"VulkanDescriptorPoolPage::~VulkanDescriptorPoolPage(");
+
+		Require(compileBody.find("m_descriptorPool->AllocateDescriptorSet(") != std::string::npos &&
+			compileBody.find("m_descriptorPoolPage") != std::string::npos &&
+			compileBody.find("m_descriptorPool.Clear()") != std::string::npos,
+			"descriptor sets must keep their allocated pool page while releasing the thread pool manager");
+		Require(releaseBody.find("vkFreeDescriptorSets") == std::string::npos,
+			"individual descriptor sets must not directly free page-owned native handles");
+		Require(releaseBody.find("m_descriptorPoolPage.Clear()") != std::string::npos,
+			"descriptor-set release must relinquish its smart pool-page ownership");
+		Require(poolPageDestructorBody.find("vkDestroyDescriptorPool") != std::string::npos,
+			"the last smart reference to a pool page must destroy its native pool");
+	}
+}
+
+int main()
+{
+	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "DescriptorCacheKeyKeepsItsCompatibilitySnapshot",
+			TestDescriptorCacheKeyKeepsItsCompatibilitySnapshot },
+		{ "DescriptorCacheKeyTracksDescriptorRevision",
+			TestDescriptorCacheKeyTracksDescriptorRevision },
+		{ "TextureSamplerUpdatesUseSynchronizedSnapshot",
+			TestTextureSamplerUpdatesUseSynchronizedSnapshot },
+		{ "RenderSceneTextureCacheTracksRequestedSlotRevisions",
+			TestRenderSceneTextureCacheTracksRequestedSlotRevisions },
+		{ "TextureSamplerCapacityReservesDefaultSlot",
+			TestTextureSamplerCapacityReservesDefaultSlot },
+		{ "GlobalTextureSamplerUsesFixedCapacityInPlaceUpdates",
+			TestGlobalTextureSamplerUsesFixedCapacityInPlaceUpdates },
+		{ "VariableDescriptorCompatibilityUsesItsFixedLayout",
+			TestVariableDescriptorCompatibilityUsesItsFixedLayout },
+		{ "DescriptorPoolsUseSmartOwnership",
+			TestDescriptorPoolsUseSmartOwnership },
+	};
+
+	for (const auto& test : tests)
+	{
+		try
+		{
+			test.second();
+			std::cout << "[PASS] " << test.first << std::endl;
+		}
+		catch (const std::exception& error)
+		{
+			std::cerr << "[FAIL] " << test.first << ": "
+				<< error.what() << std::endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/Tests/VulkanDescriptorCacheTests.cpp
+++ b/Tests/VulkanDescriptorCacheTests.cpp
@@ -1,6 +1,7 @@
 #include "GraphicsDriver/Vulkan/VulkanGraphicsDriver.h"
 #include "GraphicsDriver/Vulkan/VulkanPipeline.h"
 #include "GraphicsDriver/Vulkan/VulkanDevice.h"
+#include "GraphicsDriver/Vulkan/VulkanShaderModule.h"
 #include "FrameGraph/RenderSceneTextureCache.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "RHI/Material.h"
@@ -115,6 +116,42 @@ namespace
 
 		textureBinding->SetTextureBindings(textures);
 		bindings->RecalculateCompatibility();
+	}
+
+	void TestSsboElementAlignmentPreservesStd430Stride()
+	{
+		Require(SsboLayout::AlignSsboElementSize(112u) == 112u,
+			"an already aligned PerInstanceData stride must not gain a phantom 16-byte gap");
+		Require(SsboLayout::AlignSsboElementSize(96u) == 96u,
+			"legacy aligned std430 strides must remain unchanged");
+		Require(SsboLayout::AlignSsboElementSize(100u) == 112u,
+			"an unaligned SSBO element size must round up to the next 16-byte boundary");
+
+		SpvReflectTypeDescription reflectedType{};
+		SpvReflectBlockVariable reflectedArray{};
+		reflectedArray.type_description = &reflectedType;
+
+		reflectedArray.array.stride = 112u;
+		reflectedType.traits.array.stride = 144u;
+		reflectedArray.padded_size = 132u;
+		Require(SsboLayout::ResolveSsboArrayStride(reflectedArray) == 112u,
+			"SPIR-V runtime-array stride must remain the authoritative SSBO instance stride");
+
+		reflectedArray.array.stride = 0u;
+		reflectedType.traits.array.stride = 112u;
+		reflectedArray.padded_size = 112u;
+		Require(SsboLayout::ResolveSsboArrayStride(reflectedArray) == 112u,
+			"PerInstanceData must use its reflected type-array stride");
+
+		reflectedType.traits.array.stride = 144u;
+		reflectedArray.padded_size = 132u;
+		Require(SsboLayout::ResolveSsboArrayStride(reflectedArray) == 144u,
+			"MaterialData must use its reflected type-array stride instead of its unpadded member size");
+
+		reflectedType.traits.array.stride = 0u;
+		reflectedArray.padded_size = 112u;
+		Require(SsboLayout::ResolveSsboArrayStride(reflectedArray) == 112u,
+			"non-array storage blocks must fall back to their reflected padded size");
 	}
 
 	void TestDescriptorCacheKeyKeepsItsCompatibilitySnapshot()
@@ -321,6 +358,92 @@ namespace
 			"both requested-slot snapshots are required for revision revalidation");
 	}
 
+	void TestRenderSceneTextureBindingsUseDenseLocalIndices()
+	{
+		const TVector<uint32_t> globalTextureIndices{
+			0u,
+			7u,
+			42u,
+			383u,
+			42u };
+		const TVector<uint32_t> remap =
+			Framegraph::Details::BuildDenseTextureRemap(
+				globalTextureIndices);
+
+		Require(remap.Num() == 384u,
+			"the remap must address the largest global texture index");
+		Require(remap[0] == 0u &&
+			remap[7] == 1u &&
+			remap[42] == 2u &&
+			remap[383] == 3u,
+			"requested global texture indices must map to deterministic dense slots");
+		Require(remap[1] == 0u && remap[382] == 0u,
+			"unrequested global texture slots must resolve to the default local texture");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string renderSceneSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RenderSceneNode.cpp");
+		const std::string depthPrepassSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/DepthPrepassNode.cpp");
+		const std::string gltfShader = ReadText(
+			sourceRoot / "Content/Shaders/Standard_glTF.shader");
+		const std::string shaderCompilerSource = ReadText(
+			sourceRoot /
+			"Runtime/AssetRegistry/Shader/ShaderCompiler.cpp");
+		const std::string vulkanDriverSource = ReadText(
+			sourceRoot /
+			"Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp");
+		const std::string compatibleDescriptorSetsBody = ExtractFunctionBody(
+			vulkanDriverSource,
+			"TVector<VulkanDescriptorSetPtr> VulkanGraphicsDriver::GetCompatibleDescriptorSets(");
+
+		Require(renderSceneSource.find(
+			"BuildDenseTextureRemap(key.m_requestedTextures)") !=
+			std::string::npos &&
+			renderSceneSource.find(
+				"\"textureSamplerRemap\",") !=
+				std::string::npos,
+			"render batches must bind a dense global-to-local texture remap");
+		Require(depthPrepassSource.find(
+			"batch.m_textureBindings = Framegraph::Details::GetTextureBindingSet(") !=
+			std::string::npos &&
+			depthPrepassSource.find(
+				"material->GetBindings(), batch.m_textureBindings") !=
+				std::string::npos &&
+			depthPrepassSource.find(
+				"material->GetBindings(), textureSamplers") ==
+				std::string::npos,
+			"custom depth batches must use their dense texture bindings instead of the legacy global set");
+		Require(gltfShader.find(
+			"ResolveTextureSamplerIndex(material.baseColorSampler)") !=
+			std::string::npos &&
+			gltfShader.find(
+				"layout(set=4, binding=1) uniform sampler2D textureSamplers[];") !=
+				std::string::npos,
+			"glTF shaders must resolve global sampler ids before indexing the dense descriptor array");
+		Require(shaderCompilerSource.find(
+			"vertexDefines.Add(\"SAILOR_TEXTURE_REMAP\")") !=
+			std::string::npos &&
+			shaderCompilerSource.find(
+				"fragmentDefines.Add(\"SAILOR_TEXTURE_REMAP\")") !=
+				std::string::npos,
+			"Apple shader permutations must use the dense texture-remap ABI");
+		Require(vulkanDriverSource.find(
+			"return binding.m_set != MaterialDescriptorSet;") !=
+			std::string::npos &&
+			vulkanDriverSource.find(
+				"constexpr uint32_t MaterialDescriptorSet = 3u;") !=
+				std::string::npos,
+			"material bindings must exclude the pass-local texture remap buffer from descriptor set 4");
+		Require(renderSceneSource.find(
+			"localTextures.Resize(MaxTextureSlotsPerBatch)") ==
+				std::string::npos &&
+			compatibleDescriptorSetsBody.find(
+				"emittedTextureSlots = matchedLayoutBinding.descriptorCount;") !=
+				std::string::npos,
+			"Apple batch sets must write only dense textures while allocating the complete Metal argument-buffer array");
+	}
+
 	void TestTextureSamplerCapacityReservesDefaultSlot()
 	{
 		Require(TextureImporter::MaxTexturesInScene == 8192,
@@ -442,6 +565,53 @@ namespace
 			"a fixed variable descriptor layout must be compatible without scanning populated texture slots");
 	}
 
+	void TestVariableDescriptorCompatibilityRejectsDifferentLayoutCapacity()
+	{
+		constexpr uint32_t LocalTextureCapacity = 4u;
+		const VkDescriptorSetLayoutBinding localTextureLayout =
+			VulkanApi::CreateDescriptorSetLayoutBinding(
+				0,
+				VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+				LocalTextureCapacity);
+		const VkDescriptorSetLayoutBinding pipelineTextureLayout =
+			VulkanApi::CreateDescriptorSetLayoutBinding(
+				0,
+				VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
+				static_cast<uint32_t>(TextureImporter::MaxTexturesInScene));
+
+		VulkanDescriptorSetLayoutPtr descriptorLayout =
+			VulkanDescriptorSetLayoutPtr::Make(
+				VulkanDevicePtr{},
+				TVector<VkDescriptorSetLayoutBinding>{ localTextureLayout },
+				0);
+		VulkanDescriptorSetLayoutPtr pipelineDescriptorLayout =
+			VulkanDescriptorSetLayoutPtr::Make(
+				VulkanDevicePtr{},
+				TVector<VkDescriptorSetLayoutBinding>{ pipelineTextureLayout },
+				0);
+
+		TVector<VulkanDescriptorPtr> localDescriptors;
+		for (uint32_t index = 0; index < LocalTextureCapacity; ++index)
+		{
+			localDescriptors.Add(VulkanDescriptorPtr::Make(
+				0,
+				index,
+				VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER));
+		}
+
+		VulkanDescriptorSetPtr descriptorSet = VulkanDescriptorSetPtr::Make(
+			VulkanDevicePtr{},
+			VulkanDescriptorPoolPtr{},
+			descriptorLayout,
+			std::move(localDescriptors),
+			LocalTextureCapacity);
+		VulkanPipelineLayoutPtr pipelineLayout = VulkanPipelineLayoutPtr::Make();
+		pipelineLayout->m_descriptionSetLayouts.Add(pipelineDescriptorLayout);
+
+		Require(!VulkanApi::IsCompatible(pipelineLayout, descriptorSet, 0),
+			"a populated variable descriptor set must not bind against a pipeline layout with a different descriptorCount");
+	}
+
 	void TestShaderReflectionUsesDeclaredMemberOffsets()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -461,6 +631,10 @@ namespace
 			"member.m_absoluteOffset=membersSize") ==
 			std::string::npos,
 			"shader reflection must not infer offsets by summing member sizes");
+		Require(reflectionBody.find(
+			"SsboLayout::ResolveSsboArrayStride(reflectedArray)") !=
+			std::string::npos,
+			"SSBO reflection must use the SPIR-V runtime-array stride without adding phantom padding");
 	}
 
 	void TestMaterialUniformUploadInitializesCompleteReflectedBlocks()
@@ -490,6 +664,66 @@ namespace
 		Require(updateBody.find("UpdateShaderBindingVariable(") ==
 			std::string::npos,
 			"material fields must not be uploaded separately after the zero initialization");
+	}
+
+	void TestMaterialLoadPromiseCoversRhiInitialization()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string materialSource = ReadText(
+			sourceRoot /
+			"Runtime/AssetRegistry/Material/MaterialImporter.cpp");
+		const std::string loadBody = RemoveWhitespace(
+			ExtractFunctionBody(
+				materialSource,
+				"Tasks::TaskPtr<MaterialPtr> MaterialImporter::LoadMaterial("));
+
+		const size_t createPromise = loadBody.find(
+			"promise=Tasks::CreateTaskWithResult<MaterialPtr>(");
+		const size_t updateRhi = loadBody.find(
+			"pMaterial->UpdateRHIResource();",
+			createPromise);
+		const size_t updateUniforms = loadBody.find(
+			"pMaterial->ForcelyUpdateUniforms();",
+			updateRhi);
+		const size_t returnMaterial = loadBody.find(
+			"returnpMaterial;",
+			updateUniforms);
+		const size_t rhiThread = loadBody.find(
+			"},EThreadType::RHI);",
+			returnMaterial);
+		const size_t loadTexture = loadBody.find(
+			"LoadTexture(",
+			rhiThread);
+		const size_t joinSampler = loadBody.find(
+			"promise->Join(updateSampler);",
+			loadTexture);
+		const size_t joinShader = loadBody.find(
+			"promise->Join(pLoadShader);",
+			joinSampler);
+		const size_t runPromise = loadBody.find(
+			"promise->Run();",
+			joinShader);
+
+		Require(createPromise != std::string::npos &&
+			updateRhi != std::string::npos &&
+			updateUniforms != std::string::npos &&
+			returnMaterial != std::string::npos &&
+			rhiThread != std::string::npos &&
+			createPromise < updateRhi &&
+			updateRhi < updateUniforms &&
+			updateUniforms < returnMaterial &&
+			returnMaterial < rhiThread,
+			"the returned material promise must own the final RHI initialization");
+		Require(loadTexture != std::string::npos &&
+			joinSampler != std::string::npos &&
+			joinShader != std::string::npos &&
+			runPromise != std::string::npos &&
+			loadTexture < joinSampler &&
+			joinSampler < joinShader &&
+			joinShader < runPromise,
+			"the material promise must wait for texture and shader dependencies before it runs");
+		Require(loadBody.find("updateRHI->Run()") == std::string::npos,
+			"material loading must not return before a nested RHI task completes");
 	}
 
 	void TestDescriptorPoolsUseSmartOwnership()
@@ -530,6 +764,8 @@ namespace
 int main()
 {
 	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "SsboElementAlignmentPreservesStd430Stride",
+			TestSsboElementAlignmentPreservesStd430Stride },
 		{ "DescriptorCacheKeyKeepsItsCompatibilitySnapshot",
 			TestDescriptorCacheKeyKeepsItsCompatibilitySnapshot },
 		{ "DescriptorCacheKeyTracksDescriptorRevision",
@@ -542,16 +778,22 @@ int main()
 			TestVariableDescriptorCountCollectionUsesPublishedSnapshots },
 		{ "RenderSceneTextureCacheTracksRequestedSlotRevisions",
 			TestRenderSceneTextureCacheTracksRequestedSlotRevisions },
+		{ "RenderSceneTextureBindingsUseDenseLocalIndices",
+			TestRenderSceneTextureBindingsUseDenseLocalIndices },
 		{ "TextureSamplerCapacityReservesDefaultSlot",
 			TestTextureSamplerCapacityReservesDefaultSlot },
 		{ "GlobalTextureSamplerUsesFixedCapacityInPlaceUpdates",
 			TestGlobalTextureSamplerUsesFixedCapacityInPlaceUpdates },
 		{ "VariableDescriptorCompatibilityUsesItsFixedLayout",
 			TestVariableDescriptorCompatibilityUsesItsFixedLayout },
+		{ "VariableDescriptorCompatibilityRejectsDifferentLayoutCapacity",
+			TestVariableDescriptorCompatibilityRejectsDifferentLayoutCapacity },
 		{ "ShaderReflectionUsesDeclaredMemberOffsets",
 			TestShaderReflectionUsesDeclaredMemberOffsets },
 		{ "MaterialUniformUploadInitializesCompleteReflectedBlocks",
 			TestMaterialUniformUploadInitializesCompleteReflectedBlocks },
+		{ "MaterialLoadPromiseCoversRhiInitialization",
+			TestMaterialLoadPromiseCoversRhiInitialization },
 		{ "DescriptorPoolsUseSmartOwnership",
 			TestDescriptorPoolsUseSmartOwnership },
 	};

--- a/Tests/VulkanDescriptorCacheTests.cpp
+++ b/Tests/VulkanDescriptorCacheTests.cpp
@@ -218,6 +218,35 @@ namespace
 			"all global texture sampler writers must use the synchronized update path");
 	}
 
+	void TestGeneratedGltfTexturesReuseTheirExistingAssetIds()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string importerSource = ReadText(
+			sourceRoot / "Runtime/AssetRegistry/Texture/TextureImporter.cpp");
+		const std::string extractBody = ExtractFunctionBody(
+			importerSource,
+			"bool ExtractTextureFromGltf(");
+		const std::string importBody = ExtractFunctionBody(
+			importerSource,
+			"bool TextureImporter::ImportTexture(");
+
+		Require(extractBody.find("loader.SetImagesAsIs(true)") != std::string::npos &&
+			extractBody.find("loader.LoadASCIIFromFile(") != std::string::npos &&
+			extractBody.find("gltfModel.textures") != std::string::npos &&
+			extractBody.find("ResolveGltfTextureImageIndex(") != std::string::npos &&
+			extractBody.find("gltfModel.images") != std::string::npos &&
+			extractBody.find("image.image") != std::string::npos,
+			"generated glTF textures must extract encoded data URI, bufferView, or external image bytes through tinygltf");
+		Require(importBody.find("const bool bIsGltf = extension == \"gltf\"") != std::string::npos &&
+			importBody.find("ExtractTextureFromGltf(") != std::string::npos &&
+			importBody.find("ExtractTextureFromGLB(") != std::string::npos,
+			"texture import must support generated textures from glTF while retaining the established GLB path");
+		Require(extractBody.find("FileId") == std::string::npos &&
+			extractBody.find("CreateTextureAsset") == std::string::npos &&
+			extractBody.find("AssetRegistry") == std::string::npos,
+			"extracting an existing secondary texture must not allocate or replace its asset identity");
+	}
+
 	void TestVariableDescriptorCountCollectionUsesPublishedSnapshots()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -507,6 +536,8 @@ int main()
 			TestDescriptorCacheKeyTracksDescriptorRevision },
 		{ "TextureSamplerUpdatesUseSynchronizedSnapshot",
 			TestTextureSamplerUpdatesUseSynchronizedSnapshot },
+		{ "GeneratedGltfTexturesReuseTheirExistingAssetIds",
+			TestGeneratedGltfTexturesReuseTheirExistingAssetIds },
 		{ "VariableDescriptorCountCollectionUsesPublishedSnapshots",
 			TestVariableDescriptorCountCollectionUsesPublishedSnapshots },
 		{ "RenderSceneTextureCacheTracksRequestedSlotRevisions",

--- a/Tests/VulkanDescriptorCacheTests.cpp
+++ b/Tests/VulkanDescriptorCacheTests.cpp
@@ -207,11 +207,11 @@ namespace
 			"Tasks::TaskPtr<TexturePtr> TextureImporter::LoadTexture(");
 
 		Require(importerHeader.find("TextureSamplersSnapshot") != std::string::npos &&
-			importerHeader.find("mutable std::mutex m_textureSamplersMutex") != std::string::npos,
-			"texture sampler contents and descriptor revision must be captured under one importer lock");
-		Require(snapshotBody.find("m_textureSamplersMutex") != std::string::npos &&
-			updateBody.find("m_textureSamplersMutex") != std::string::npos,
-			"texture sampler reads and writes must share the importer lock");
+			importerHeader.find("mutable SpinLock m_textureSamplersLock") != std::string::npos,
+			"texture sampler contents and descriptor revision must be captured under one importer spin lock");
+		Require(snapshotBody.find("m_textureSamplersLock") != std::string::npos &&
+			updateBody.find("m_textureSamplersLock") != std::string::npos,
+			"texture sampler reads and writes must share the importer spin lock");
 		Require(hotReloadBody.find("UpdateTextureSamplerBinding(") != std::string::npos &&
 			loadBody.find("RegisterTextureSamplerBinding(") != std::string::npos,
 			"all global texture sampler writers must use the synchronized update path");

--- a/Tests/VulkanDescriptorCacheTests.cpp
+++ b/Tests/VulkanDescriptorCacheTests.cpp
@@ -413,6 +413,56 @@ namespace
 			"a fixed variable descriptor layout must be compatible without scanning populated texture slots");
 	}
 
+	void TestShaderReflectionUsesDeclaredMemberOffsets()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string shaderModuleSource = ReadText(
+			sourceRoot /
+			"Runtime/GraphicsDriver/Vulkan/VulkanShaderModule.cpp");
+		const std::string reflectionBody = RemoveWhitespace(
+			ExtractFunctionBody(
+				shaderModuleSource,
+				"void VulkanShaderStage::ReflectDescriptorSetBindings("));
+
+		Require(reflectionBody.find(
+			"member.m_absoluteOffset=blockContent[i].offset;") !=
+			std::string::npos,
+			"named uniform writes must use SPIR-V member offsets instead of repacking aligned fields");
+		Require(reflectionBody.find(
+			"member.m_absoluteOffset=membersSize") ==
+			std::string::npos,
+			"shader reflection must not infer offsets by summing member sizes");
+	}
+
+	void TestMaterialUniformUploadInitializesCompleteReflectedBlocks()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string materialSource = ReadText(
+			sourceRoot /
+			"Runtime/AssetRegistry/Material/MaterialImporter.cpp");
+		const std::string updateBody = RemoveWhitespace(
+			ExtractFunctionBody(
+				materialSource,
+				"void Material::UpdateUniforms("));
+
+		const size_t initializeBlock = updateBody.find(
+			"data.Resize(bindingSize);");
+		const size_t writeMember = updateBody.find(
+			"std::memcpy(data.GetData()+memberLayout.m_absoluteOffset,");
+		const size_t uploadBlock = updateBody.find(
+			"UpdateShaderBinding(cmdList,binding,data.m_second->GetData(),data.m_second->Num())");
+
+		Require(initializeBlock != std::string::npos &&
+			writeMember != std::string::npos &&
+			uploadBlock != std::string::npos &&
+			initializeBlock < writeMember &&
+			writeMember < uploadBlock,
+			"material uploads must zero complete reflected blocks before packing present values into one upload");
+		Require(updateBody.find("UpdateShaderBindingVariable(") ==
+			std::string::npos,
+			"material fields must not be uploaded separately after the zero initialization");
+	}
+
 	void TestDescriptorPoolsUseSmartOwnership()
 	{
 		Require((std::is_same_v<decltype(ThreadContext::m_descriptorPool), VulkanDescriptorPoolPtr>),
@@ -467,6 +517,10 @@ int main()
 			TestGlobalTextureSamplerUsesFixedCapacityInPlaceUpdates },
 		{ "VariableDescriptorCompatibilityUsesItsFixedLayout",
 			TestVariableDescriptorCompatibilityUsesItsFixedLayout },
+		{ "ShaderReflectionUsesDeclaredMemberOffsets",
+			TestShaderReflectionUsesDeclaredMemberOffsets },
+		{ "MaterialUniformUploadInitializesCompleteReflectedBlocks",
+			TestMaterialUniformUploadInitializesCompleteReflectedBlocks },
 		{ "DescriptorPoolsUseSmartOwnership",
 			TestDescriptorPoolsUseSmartOwnership },
 	};

--- a/Tests/VulkanDescriptorCacheTests.cpp
+++ b/Tests/VulkanDescriptorCacheTests.cpp
@@ -27,6 +27,7 @@ namespace
 	{
 	public:
 		using DescriptorCacheKey = CachedDescriptorSet;
+		using ComputeCacheKey = ComputePipelineCacheKey;
 	};
 
 	class VulkanDescriptorSetOwnershipProbe final : public VulkanDescriptorSet
@@ -217,6 +218,53 @@ namespace
 			"all global texture sampler writers must use the synchronized update path");
 	}
 
+	void TestVariableDescriptorCountCollectionUsesPublishedSnapshots()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string driverSource = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp");
+		const std::string collectBody = ExtractFunctionBody(
+			driverSource,
+			"TVector<uint32_t> VulkanGraphicsDriver::CollectOptionalVariableDescriptorCount(");
+		const std::string publishedCollectBody = ExtractFunctionBody(
+			driverSource,
+			"TVector<uint32_t> VulkanGraphicsDriver::CollectPublishedVariableDescriptorCounts(");
+		const std::string dispatchBody = ExtractFunctionBody(
+			driverSource,
+			"void VulkanGraphicsDriver::Dispatch(");
+		const std::string pipelineBody = ExtractFunctionBody(
+			driverSource,
+			"VulkanComputePipelinePtr VulkanGraphicsDriver::GetOrAddComputePipeline(");
+
+		Require(collectBody.find("m_descriptorUpdateMutex") == std::string::npos &&
+			collectBody.find("GetLayoutBindings()") == std::string::npos &&
+			collectBody.find("GetShaderBindings()") != std::string::npos &&
+			collectBody.find("reflectedBinding.m_name") != std::string::npos,
+			"variable descriptor counts must use immutable owned bindings without the global descriptor mutex");
+		Require(publishedCollectBody.find("m_descriptorUpdateMutex") == std::string::npos &&
+			publishedCollectBody.find("GetVariableDescriptorCount()") != std::string::npos &&
+			publishedCollectBody.find("GetLayoutBindings()") == std::string::npos &&
+			publishedCollectBody.find("GetShaderBindings()") == std::string::npos,
+			"dispatch must read only the published per-set descriptor capacities");
+		Require(dispatchBody.find("CollectPublishedVariableDescriptorCounts(bindings)") != std::string::npos &&
+			pipelineBody.find("CollectOptionalVariableDescriptorCount(") == std::string::npos &&
+			pipelineBody.find("ComputePipelineCacheKey") != std::string::npos,
+			"dispatch must use lock-free per-set counts and include them in the compute-pipeline cache key");
+
+		using ComputeCacheKey = VulkanGraphicsDriverProbe::ComputeCacheKey;
+		RHI::RHIShaderPtr shader = RHI::RHIShaderPtr::Make(RHI::EShaderStage::Compute);
+		const TVector<uint32_t> counts{ 0u, 8192u };
+		const TVector<uint32_t> otherCounts{ 0u, 1024u };
+		const ComputeCacheKey eightBytePushConstants(shader, 8u, &counts);
+		const ComputeCacheKey sixteenBytePushConstants(shader, 16u, &counts);
+		const ComputeCacheKey differentDescriptorCount(shader, 8u, &otherCounts);
+		Require(eightBytePushConstants == sixteenBytePushConstants &&
+			eightBytePushConstants.GetHash() == sixteenBytePushConstants.GetHash(),
+			"equivalent 256-byte Vulkan push-constant ranges must share one compute pipeline");
+		Require(!(eightBytePushConstants == differentDescriptorCount),
+			"different variable descriptor capacities must use different compute pipelines");
+	}
+
 	void TestRenderSceneTextureCacheTracksRequestedSlotRevisions()
 	{
 		const TVector<uint64_t> cachedSlotRevisions{ 11u, 29u, 47u };
@@ -292,6 +340,9 @@ namespace
 		const std::string updateDescriptorBody = ExtractFunctionBody(
 			descriptorsSource,
 			"bool VulkanDescriptorSet::UpdateDescriptor(");
+		const std::string referencesImageViewBody = ExtractFunctionBody(
+			descriptorsSource,
+			"bool VulkanDescriptorSet::ReferencesImageView(");
 		const std::string normalizedUpdateSetBody = RemoveWhitespace(updateSetBody);
 		const std::string normalizedUpdateDescriptorBody = RemoveWhitespace(updateDescriptorBody);
 
@@ -311,6 +362,8 @@ namespace
 			updateBindingBody.find("const auto previousTextures = currentTextures") != std::string::npos &&
 			updateBindingBody.find("SetTextureBindings(previousTextures)") != std::string::npos,
 			"unused variable sampler slots must use update-after-bind and advance the source revision");
+		Require(updateBindingBody.find("dstArrayElement >= layout.m_arrayCount") != std::string::npos,
+			"variable descriptor writes past the immutable allocation must be rejected before CPU state changes");
 		Require(updateDescriptorBody.find("descriptor->Apply(") != std::string::npos &&
 			normalizedUpdateDescriptorBody.find("vkUpdateDescriptorSets(*m_device,1,") != std::string::npos &&
 			updateDescriptorBody.find("UPDATE_UNUSED_WHILE_PENDING") != std::string::npos &&
@@ -318,6 +371,15 @@ namespace
 			updateBindingBody.find("RecalculateCompatibility()") == std::string::npos &&
 			descriptorsHeader.find("m_retiredDescriptors") == std::string::npos,
 			"an in-place texture update must write exactly one unused slot without rescanning compatibility or retaining replaced resources");
+
+		const size_t directDescriptorLookup = referencesImageViewBody.find(
+			"arrayElement < m_descriptors.Num()");
+		const size_t linearDescriptorFallback = referencesImageViewBody.find(
+			"for (const VulkanDescriptorPtr& descriptor : m_descriptors)");
+		Require(directDescriptorLookup != std::string::npos &&
+			linearDescriptorFallback != std::string::npos &&
+			directDescriptorLookup < linearDescriptorFallback,
+			"bindless image-view lookup must use its array element before the general linear fallback");
 	}
 
 	void TestVariableDescriptorCompatibilityUsesItsFixedLayout()
@@ -395,6 +457,8 @@ int main()
 			TestDescriptorCacheKeyTracksDescriptorRevision },
 		{ "TextureSamplerUpdatesUseSynchronizedSnapshot",
 			TestTextureSamplerUpdatesUseSynchronizedSnapshot },
+		{ "VariableDescriptorCountCollectionUsesPublishedSnapshots",
+			TestVariableDescriptorCountCollectionUsesPublishedSnapshots },
 		{ "RenderSceneTextureCacheTracksRequestedSlotRevisions",
 			TestRenderSceneTextureCacheTracksRequestedSlotRevisions },
 		{ "TextureSamplerCapacityReservesDefaultSlot",

--- a/update_deps.py
+++ b/update_deps.py
@@ -75,11 +75,13 @@ def main() -> int:
     else:
         triplet = 'x64-linux'
     packages = [
+        'draco',
         'glm',
         'imgui[win32-binding]' if system == 'Windows' else 'imgui',
         'imguizmo',
         'ixwebsocket[core]',
         'magic-enum',
+        'meshoptimizer',
         'nlohmann-json',
         'protobuf',
         'refl-cpp',


### PR DESCRIPTION
## Summary

- harden glTF and animation import with bounded accessor reads, sparse data, Draco/meshoptimizer decoding, active-scene hierarchy transforms, import-time unit scale, BLAS validation, and stale-safe fingerprint generation
- add targeted `FileId` asset updates across the Editor/WebSocket/Engine boundary, with timestamp-based revision checks and transactional registry publication
- expose component-owned MeshRenderer material overrides while preserving model defaults and imported material-slot identity
- stabilize bindless texture descriptors, per-slot revalidation, descriptor-pool lifetime, frame submission, and asynchronous render command recording
- propagate static-mesh transform changes into cached CSM state before cascade dependency filtering
- add a dedicated back-to-front Transparent framegraph pass and screen-space transmission framebuffer snapshot
- import and render `KHR_materials_transmission`, `KHR_materials_volume`, and `KHR_materials_ior`, including thickness, attenuation, rough refraction, environment fallback, and path-tracer parity
- migrate importer-owned legacy generated materials on demand while preserving authored fields and custom material replacements
- regenerate complete shader vertex bindings for SKINNING permutations and fix the Windows `TVector<uint64_t>::Resize(1)` overload ambiguity

## Why

The previous paths combined several failure modes: Editor Save retraced the whole Content tree, large source files were read for revision hashes, malformed or compressed glTF data could escape validation, model node transforms and material slots could be lost, and Vulkan descriptor/frame lifetime gaps could produce stale textures or hangs. Transparent glTF materials also lacked a real ordered pass and transmission sampled no opaque-scene snapshot; simply adding uniforms could not produce correct refraction.

## Impact

- existing asset saves refresh only the selected asset or its shared-source family
- model import accepts a wider glTF corpus while rejecting invalid geometry before GPU upload
- explicit material overrides remain authored separately from model defaults
- bindless texture growth uses fixed capacity and targeted writes instead of recreating sets from 1..N
- failed submissions and asynchronous recording paths fail safely instead of waiting on unsignaled work
- moving static casters invalidate every affected CSM cascade during interaction
- transparent meshes are sorted per mesh in camera-space back-to-front order while adjacent compatible draws can still use MDI
- generated glTF transmission materials enter the Transparent queue, disable depth writes, and receive reflected optional uniforms by name under `TRANSMISSION`
- the opaque scene is copied before Transparent rendering and exposed through the exact declared framegraph attachment, with a shader-readable mip chain for rough refraction
- old generated `Pawn_Top_White`-style materials are upgraded when their model is loaded without a startup content scan or second GLB parse

## Scope

The PR includes C++/tests plus the required engine-owned renderer graphs and `Standard_glTF.shader`. It does not include the local 1.6 GB glTF corpus, project/sample scene state, generated `.asset` metadata, fingerprints, cache files, or generated `Constants.glsl`.

## Validation

- `cmake --build build-mac-vcpkg --config Release --parallel` — all 48 targets built
- `ctest --test-dir build-mac-vcpkg -C Release --output-on-failure` — 34/34 passed
- Debug targets built: `SailorLib`, `ModelImporterContractTests`, `GpuCullingContractTests`, `VulkanDescriptorCacheTests`
- Debug contract executables passed: 21 model-import, 10 framegraph/culling, and 11 Vulkan descriptor tests
- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj -c Release --no-restore` — 717/717 passed
- `Standard_glTF.shader` compiled with `glslc` in base and combined `TRANSMISSION + SKINNING + CLEAR_COAT + SHEEN + ALPHA_CUTOUT` vertex/fragment permutations
- live Release engine smoke loaded `Editor.world`, invalidated shader cache v5 -> v6, regenerated bone bindings, initialized Vulkan, loaded the ABeautifulGame scene, and rendered without shader/runtime errors
- real legacy GLB material verification: `Pawn_Top_White` migrated to Transparent, `ZWrite=false`, `TRANSMISSION`, factor/thickness/attenuation/IOR
- `git diff --check` passed

## Review notes

This remains a draft. No merge is requested. The full-resolution transmission snapshot is currently an always-present functional baseline; visibility-based gating can be handled as a follow-up optimization after visual review.
