### PR TITLE
Add model hierarchy instances and lazy asset metadata loading

### DIFF
--- a/Editor.Tests/AssetCacheIndexStoreTests.cs
+++ b/Editor.Tests/AssetCacheIndexStoreTests.cs
@@ -1,0 +1,106 @@
+using SailorEditor.Services;
+
+public class AssetCacheIndexStoreTests
+{
+    [Fact]
+    public void Parse_LoadsStrictV1IndexWithoutReadingAssetSidecars()
+    {
+        var sourcePath = Path.GetFullPath(Path.Combine(
+            Path.GetTempPath(),
+            "Sailor Asset Index",
+            "Duck.glb"));
+        var result = AssetCacheIndexStore.Parse(
+            "AssetCache.yaml",
+            CreateCacheYaml(sourcePath),
+            "workspace-test");
+
+        Assert.Equal(AssetCacheIndexStatus.Loaded, result.Status);
+        var entry = Assert.Single(result.Entries!);
+        Assert.Equal("{ASSET-ID}", entry.FileId);
+        Assert.Equal(sourcePath, entry.SourcePath);
+        Assert.Equal("Duck.glb.asset", entry.MetadataFilename);
+        Assert.Equal("Sailor::ModelAssetInfo", entry.AssetInfoType);
+    }
+
+    [Fact]
+    public void Parse_RejectsOlderOrNewerCacheVersions()
+    {
+        var yaml = CreateCacheYaml(Path.GetFullPath("Duck.glb"))
+            .Replace("cacheVersion: 1", "cacheVersion: 2", StringComparison.Ordinal);
+
+        var result = AssetCacheIndexStore.Parse(
+            "AssetCache.yaml",
+            yaml,
+            "workspace-test");
+
+        Assert.Equal(AssetCacheIndexStatus.UnsupportedVersion, result.Status);
+        Assert.Null(result.Entries);
+    }
+
+    [Fact]
+    public void Parse_RejectsUnknownLegacyEntryFields()
+    {
+        var yaml = CreateCacheYaml(
+            Path.GetFullPath("Duck.glb"),
+            "metadataPath: Duck.glb.asset");
+
+        var result = AssetCacheIndexStore.Parse(
+            "AssetCache.yaml",
+            yaml,
+            "workspace-test");
+
+        Assert.Equal(AssetCacheIndexStatus.Corrupt, result.Status);
+        Assert.Contains("metadataPath", result.Diagnostic, StringComparison.Ordinal);
+    }
+
+    static string CreateCacheYaml(
+        string sourcePath,
+        string? extraEntryField = null)
+    {
+        var escapedSourcePath = sourcePath
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal);
+        var payload = $$"""
+            assetCache:
+              assets:
+                "{ASSET-ID}":
+                  fileId: "{ASSET-ID}"
+                  assetImportTime: 1
+                  sourcePath: "{{escapedSourcePath}}"
+                  sourceRevision:
+                    modificationTimeNanoseconds: 2
+                    fileSize: 3
+                    contentHash: 0
+                  metadataFilename: Duck.glb.asset
+                  metadataRevision:
+                    modificationTimeNanoseconds: 4
+                    fileSize: 5
+                    contentHash: 0
+                  assetInfoType: Sailor::ModelAssetInfo
+            """;
+        if (!string.IsNullOrWhiteSpace(extraEntryField))
+        {
+            payload = payload.Replace(
+                "      assetInfoType: Sailor::ModelAssetInfo",
+                $"      assetInfoType: Sailor::ModelAssetInfo{Environment.NewLine}      {extraEntryField}",
+                StringComparison.Ordinal);
+        }
+
+        var escapedPayload = payload
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("\"", "\\\"", StringComparison.Ordinal)
+            .Replace("\r", "", StringComparison.Ordinal)
+            .Replace("\n", "\\n", StringComparison.Ordinal);
+
+        return $$"""
+            cacheVersion: 1
+            payloadVersion: 1
+            cacheKind: asset-cache
+            workspaceId: workspace-test
+            engineVersion: 0.1
+            buildIdentity: test
+            producerIdentity: asset-cache-v1
+            payload: "{{escapedPayload}}"
+            """;
+    }
+}

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -39,6 +39,7 @@
     <Compile Include="ProjectContentMutationReloadPolicyTests.cs" />
     <Compile Include="RepositoryAssetSidecarContractTests.cs" />
     <Compile Include="AssetInfoSerializationSourceContractTests.cs" />
+    <Compile Include="AssetCacheIndexStoreTests.cs" />
     <Compile Include="WorkspaceManifestTests.cs" />
     <Compile Include="WorkspaceGeneratedProjectStateTests.cs" />
     <Compile Include="WorkspaceLifecycleTests.cs" />
@@ -152,6 +153,7 @@
     <Compile Include="..\Editor\Services\LatestSceneViewportState.cs" Link="Services\LatestSceneViewportState.cs" />
     <Compile Include="..\Editor\Services\LatestQueuedCommand.cs" Link="Services\LatestQueuedCommand.cs" />
     <Compile Include="..\Editor\Services\EditorTypeCacheStore.cs" Link="Services\EditorTypeCacheStore.cs" />
+    <Compile Include="..\Editor\Services\AssetCacheIndexStore.cs" Link="Services\AssetCacheIndexStore.cs" />
     <Compile Include="..\Editor\Commands\EditorCommandRuntime.cs" Link="Commands\EditorCommandRuntime.cs" />
   </ItemGroup>
 </Project>

--- a/Editor.Tests/EngineLaunchContractTests.cs
+++ b/Editor.Tests/EngineLaunchContractTests.cs
@@ -31,6 +31,7 @@ public class EngineLaunchContractTests
             Path.GetRelativePath(contentDirectory, Path.Combine(cacheDirectory, "Temp.world")),
             context.TempWorldRuntimePath);
         Assert.Equal(Path.Combine(cacheDirectory, "EditorTypes.yaml"), context.EditorTypesCacheFilePath);
+        Assert.Equal(Path.Combine(cacheDirectory, "AssetCache.yaml"), context.AssetCacheFilePath);
     }
 
     [Theory]
@@ -54,6 +55,7 @@ public class EngineLaunchContractTests
         Assert.Equal(Path.Combine(Path.GetFullPath(fallbackRoot), "Content"), context.ContentDirectory);
         Assert.Equal(Path.Combine(Path.GetFullPath(fallbackRoot), "Cache"), context.CacheDirectory);
         Assert.Equal(Path.Combine(Path.GetFullPath(fallbackRoot), "Cache", "EditorTypes.yaml"), context.EditorTypesCacheFilePath);
+        Assert.Equal(Path.Combine(Path.GetFullPath(fallbackRoot), "Cache", "AssetCache.yaml"), context.AssetCacheFilePath);
         Assert.StartsWith("legacy-root:", context.WorkspaceIdentity, StringComparison.Ordinal);
     }
 

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -978,9 +978,11 @@ public sealed class EngineLifecycleTests
         var reflectionSource = ReadRepositoryFile("Runtime", "Core", "Reflection.cpp");
 
         Assert.Contains(
-            "\"Sailor::ShaderAssetInfo\" when string.Equals(extension, \".glsl\", StringComparison.OrdinalIgnoreCase) => new ShaderLibraryFile()",
+            "\"Sailor::ShaderAssetInfo\" when string.Equals(",
             assetsSource,
             StringComparison.Ordinal);
+        Assert.Contains("\".glsl\"", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("=> new ShaderLibraryFile()", assetsSource, StringComparison.Ordinal);
         Assert.Contains(
             "\"Sailor::ShaderAssetInfo\" => new ShaderFile()",
             assetsSource,
@@ -1000,6 +1002,44 @@ public sealed class EngineLifecycleTests
             "ProjectContentInternalPathPolicy.IsTransactionDirectory(directory)",
             assetsSource,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AssetProjection_LoadsFoldersAndMetadataLazilyOffTheUiThread()
+    {
+        var assetsSource = ReadRepositoryFile("Editor", "Services", "AssetsService.cs");
+        var assetFileSource = ReadRepositoryFile("Editor", "ViewModels", "AssetFile.cs");
+        var selectionSource = ReadRepositoryFile("Editor", "Services", "SelectionService.cs");
+        var contentViewSource = ReadRepositoryFile("Editor", "Views", "ContentFolderView.xaml.cs");
+        var cacheIndexSource = ReadRepositoryFile("Editor", "Services", "AssetCacheIndexStore.cs");
+
+        var addRootStart = assetsSource.IndexOf(
+            "public void AddProjectRoot(EngineLaunchContext launchContext)",
+            StringComparison.Ordinal);
+        var watcherStart = assetsSource.IndexOf(
+            "void ConfigureContentWatchers",
+            addRootStart,
+            StringComparison.Ordinal);
+        Assert.True(addRootStart >= 0 && watcherStart > addRootStart);
+        var addRootBody = assetsSource[addRootStart..watcherStart];
+        Assert.Contains("AddContentRootFolder(", addRootBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReadDirectory(", addRootBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("ReadAssetFile(", addRootBody, StringComparison.Ordinal);
+
+        Assert.Contains("public async Task EnsureFolderLoadedAsync(", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("() => ReadDirectoryLevel(folder)", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("await Task.Run(", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("IsLoaded = false", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("await service.EnsureFolderLoadedAsync(folderId)", contentViewSource, StringComparison.Ordinal);
+        Assert.Contains("public async Task EnsureMetadataLoadedAsync(", assetFileSource, StringComparison.Ordinal);
+        Assert.Contains("await Task.Run(Revert, cancellationToken)", assetFileSource, StringComparison.Ordinal);
+        Assert.Contains("await selectedAssetFile.EnsureMetadataLoadedAsync(", selectionSource, StringComparison.Ordinal);
+        Assert.Contains("QueueAssetCacheIndexLoad(launchContext, contentGeneration)", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("MergeAssetCacheIndex(result.Entries!)", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("Files.Add(file)", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("Assets[file.FileId] = file", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("producerIdentity", cacheIndexSource, StringComparison.Ordinal);
+        Assert.Contains("asset-cache-v1", cacheIndexSource, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/Editor.Tests/EngineProtocolClientTests.cs
+++ b/Editor.Tests/EngineProtocolClientTests.cs
@@ -167,6 +167,111 @@ public sealed class EngineProtocolClientTests
     }
 
     [Fact]
+    public async Task CreateModelInstanceAsync_SendsAtomicCreationRequest()
+    {
+        ProtocolRequest? capturedRequest = null;
+        var client = CreateClient(request =>
+        {
+            capturedRequest = request;
+            return Success(
+                request,
+                response => response.InstanceIdResult =
+                    new InstanceIdResult
+                    {
+                        Succeeded = true,
+                        InstanceId = "ROOT-ID"
+                    });
+        });
+        var worldPosition = new EngineProtocolVector4(
+            1.0f,
+            2.0f,
+            3.0f,
+            1.0f);
+
+        var result = await client.CreateModelInstanceAsync(
+            "MODEL-ID",
+            "Bistro",
+            "PARENT-ID",
+            createHierarchy: true,
+            worldPosition,
+            "ROOT-ID");
+
+        Assert.True(result.Succeeded);
+        Assert.Equal("ROOT-ID", result.InstanceId);
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(
+            ProtocolRequest.CommandOneofCase.CreateModelInstance,
+            capturedRequest.CommandCase);
+        var request = capturedRequest.CreateModelInstance;
+        Assert.Equal("MODEL-ID", request.ModelFileId);
+        Assert.Equal("Bistro", request.Name);
+        Assert.Equal("PARENT-ID", request.ParentInstanceId);
+        Assert.True(request.CreateHierarchy);
+        Assert.True(request.ApplyWorldPosition);
+        Assert.Equal(1.0f, request.WorldPosition.X);
+        Assert.Equal(2.0f, request.WorldPosition.Y);
+        Assert.Equal(3.0f, request.WorldPosition.Z);
+        Assert.Equal(1.0f, request.WorldPosition.W);
+        Assert.Equal("ROOT-ID", request.PreferredInstanceId);
+    }
+
+    [Fact]
+    public async Task CreateModelInstanceAsync_FlatModeOmitsWorldPosition()
+    {
+        ProtocolRequest? capturedRequest = null;
+        var client = CreateClient(request =>
+        {
+            capturedRequest = request;
+            return Success(
+                request,
+                response => response.InstanceIdResult =
+                    new InstanceIdResult());
+        });
+
+        await client.CreateModelInstanceAsync(
+            "MODEL-ID",
+            "Bistro",
+            string.Empty,
+            createHierarchy: false,
+            worldPosition: null,
+            "ROOT-ID");
+
+        Assert.NotNull(capturedRequest);
+        var request = capturedRequest.CreateModelInstance;
+        Assert.False(request.CreateHierarchy);
+        Assert.False(request.ApplyWorldPosition);
+        Assert.Null(request.WorldPosition);
+    }
+
+    [Fact]
+    public async Task CreateModelInstanceAsync_RejectsInvalidWorldPosition()
+    {
+        var invokeCount = 0;
+        var client = CreateClient(request =>
+        {
+            invokeCount++;
+            return Success(
+                request,
+                response => response.EmptyResult = new Empty());
+        });
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            client.CreateModelInstanceAsync(
+                "MODEL-ID",
+                "Bistro",
+                string.Empty,
+                createHierarchy: true,
+                new EngineProtocolVector4(
+                    float.NaN,
+                    0.0f,
+                    0.0f,
+                    1.0f),
+                "ROOT-ID"));
+
+        Assert.Equal(0, invokeCount);
+    }
+
+    [Fact]
     public async Task InvokeAsync_RejectsMalformedTransportResponse()
     {
         var client = CreateRawClient(_ => [0xFF]);
@@ -925,6 +1030,34 @@ public sealed class EngineProtocolClientTests
                 "preferred"),
             () => client.CreateGameObjectAsync(
                 "parent",
+                "preferred\0id"),
+            () => client.CreateModelInstanceAsync(
+                "model\0id",
+                "Bistro",
+                "parent",
+                true,
+                null,
+                "preferred"),
+            () => client.CreateModelInstanceAsync(
+                "model",
+                "Bis\0tro",
+                "parent",
+                true,
+                null,
+                "preferred"),
+            () => client.CreateModelInstanceAsync(
+                "model",
+                "Bistro",
+                "parent\0id",
+                true,
+                null,
+                "preferred"),
+            () => client.CreateModelInstanceAsync(
+                "model",
+                "Bistro",
+                "parent",
+                true,
+                null,
                 "preferred\0id"),
             () => client.DestroyObjectAsync("object\0id"),
             () => client.ResetComponentToDefaultsAsync(

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -279,6 +279,23 @@ public sealed class WorkflowProjectionTests
             populate,
             StringComparison.Ordinal);
 
+        AssertInOrder(
+            populate,
+            "foreach (var component in prefab.Components)",
+            "component.Initialize();",
+            "foreach (var go in prefab.GameObjects)");
+        Assert.Equal(1, CountOccurrences(populate, "component.Initialize();"));
+
+        var worldConverter = ReadRepositoryFile(
+            "Editor",
+            "ViewModels",
+            "World.cs");
+        var readYaml = Slice(
+            worldConverter,
+            "public object ReadYaml(",
+            "public void WriteYaml(");
+        Assert.DoesNotContain(".Initialize();", readYaml, StringComparison.Ordinal);
+
         Assert.Contains(
             "FileId = FileId is null",
             prefabSource,
@@ -1375,21 +1392,24 @@ public sealed class WorkflowProjectionTests
             StringComparison.Ordinal);
         AssertInOrder(
             modelCommand,
-            "CreateGameObjectAsync(",
-            "AddComponentAsync(",
-            "CommitChangesAsync(",
-            "CommitChangesAsync(",
-            "RefreshCurrentWorldAuthoritativelyAsync(");
+            "RefreshAndCheckRootAbsentAsync(",
+            "RequestCreateModelInstanceAsync(",
+            "RefreshCurrentWorldAuthoritativelyAsync(",
+            "MatchesRootProjection(");
         Assert.Contains(
-            "\"Sailor::MeshRendererComponent\"",
+            "bool recreateHierarchy = true",
             modelCommand,
             StringComparison.Ordinal);
         Assert.Contains(
-            "new ObjectPtr",
+            "_recreateHierarchy,",
             modelCommand,
             StringComparison.Ordinal);
         Assert.Contains(
-            "new FileId(_modelFileId.Value)",
+            "_worldPosition,",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "_ownedGameObjectId,",
             modelCommand,
             StringComparison.Ordinal);
         Assert.Contains(
@@ -1401,28 +1421,6 @@ public sealed class WorkflowProjectionTests
             modelCommand,
             StringComparison.Ordinal);
         Assert.Contains(
-            "RandomNumberGenerator.GetBytes(8)",
-            modelCommand,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "initialParentId,\n" +
-            "                _ownedGameObjectId,",
-            modelCommand,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "MeshRendererComponentTypeName,\n" +
-            "                ownedComponentId,",
-            modelCommand,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "RefreshAndCheckRootAbsentAsync(",
-            modelCommand,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "MatchesFinalProjection(",
-            modelCommand,
-            StringComparison.Ordinal);
-        Assert.Contains(
             "TryResolveWorldPosition(",
             modelCommand,
             StringComparison.Ordinal);
@@ -1431,26 +1429,127 @@ public sealed class WorkflowProjectionTests
             modelCommand,
             StringComparison.Ordinal);
         Assert.Contains(
-            "model.FileId.Value,\n" +
-            "                _modelFileId.Value",
-            modelCommand,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "rollback could not confirm owned GameObject",
-            modelCommand,
-            StringComparison.Ordinal);
-        Assert.Contains(
-            "projectedComponents.Count != 1",
+            "_lastCreationFailureDiagnostic",
             modelCommand,
             StringComparison.Ordinal);
         Assert.DoesNotContain(
-            "CreateModelGameObjectAsync(",
+            "RequestCreateGameObjectAsync(",
             modelCommand,
             StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "RequestAddComponentAsync(",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "CommitChangesAsync(",
+            modelCommand,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "GetModelHierarchyAsync(",
+            modelCommand,
+            StringComparison.Ordinal);
+
         Assert.Contains(
             "public ValueTask<CommandResult> UndoAsync(",
             prefabCommand,
             StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ModelInstanceProtocol_CreatesHierarchyAtomicallyInsideEngine()
+    {
+        var protocol = ReadRepositoryFile(
+            "Protocol",
+            "editor_engine.proto");
+        var client = ReadRepositoryFile(
+            "Editor",
+            "Protocol",
+            "EngineProtocolClient.cs");
+        var service = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "EngineService.cs");
+        var protocolAdapter = ReadRepositoryFile(
+            "Lib",
+            "EditorEngineProtocol.cpp");
+        var interop = ReadRepositoryFile(
+            "Runtime",
+            "Editor",
+            "EditorInterop.cpp");
+        var runtimeEditor = ReadRepositoryFile(
+            "Runtime",
+            "Submodules",
+            "Editor.cpp");
+        var createRuntime = Slice(
+            runtimeEditor,
+            "bool Editor::CreateModelInstance(",
+            "bool Editor::DestroyObject(");
+        var createInterop = Slice(
+            interop,
+            "bool App::CreateEditorModelInstance(",
+            "bool App::DestroyEditorObject(");
+
+        Assert.Contains(
+            "CreateModelInstanceRequest create_model_instance = 58;",
+            protocol,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "bool create_hierarchy = 4;",
+            protocol,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "CreateModelInstance = request",
+            client,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "RequestCreateModelInstanceAsync(",
+            service,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "case ProtocolRequest::kCreateModelInstance:",
+            protocolAdapter,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            createInterop,
+            "LoadModel_Immediate(modelFileId, model)",
+            "ExecuteOnEngineMainThread<bool>(",
+            "editor->CreateModelInstance(");
+        AssertInOrder(
+            createRuntime,
+            "LoadDefaultMaterials(",
+            "m_world->Instantiate(name",
+            "root->SetParent(parentGameObject)",
+            "TrySetWorldPosition(root, *worldPosition)",
+            "bCreateHierarchy && IsEditableModelHierarchyValid(*model)");
+        Assert.Contains(
+            "Model::AllMeshes,",
+            createRuntime,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "rendererData.GetMaterials() = defaultMaterials;",
+            runtimeEditor,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "modelNode.m_parentIndex >= 0",
+            createRuntime,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "modelNode.m_meshIndex,",
+            createRuntime,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "transform.SetPosition(",
+            createRuntime,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "rollback();",
+            createRuntime,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            createRuntime,
+            "outInstanceId = root->GetInstanceId();",
+            "NotifyManagedObjectMutation(outInstanceId);",
+            "return true;");
     }
 
     [Fact]

--- a/Editor/Commands/EditorWorldCommands.cs
+++ b/Editor/Commands/EditorWorldCommands.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using SailorEditor.History;
+using SailorEditor.Protocol;
 using SailorEditor.Services;
 using SailorEditor.Utility;
 using SailorEditor.ViewModels;
@@ -12,11 +13,35 @@ namespace SailorEditor.Commands;
 
 public static class EditorYaml
 {
-    public static string SerializeGameObject(GameObject gameObject) => SerializationUtils.CreateSerializerBuilder().Build().Serialize(gameObject);
+    [ThreadStatic]
+    static ISerializer gameObjectSerializer;
 
-    public static string SerializeComponent(Component component) => SerializationUtils.CreateSerializerBuilder().WithTypeConverter(new ComponentYamlConverter()).Build().Serialize(component);
+    [ThreadStatic]
+    static ISerializer componentSerializer;
+
+    [ThreadStatic]
+    static ISerializer prefabSerializer;
+
+    public static string SerializeGameObject(GameObject gameObject) =>
+        (gameObjectSerializer ??= SerializationUtils
+            .CreateSerializerBuilder()
+            .Build())
+        .Serialize(gameObject);
+
+    public static string SerializeComponent(Component component) =>
+        (componentSerializer ??= SerializationUtils
+            .CreateSerializerBuilder()
+            .WithTypeConverter(new ComponentYamlConverter())
+            .Build())
+        .Serialize(component);
 
     public static string SerializePrefab(Prefab prefab)
+    {
+        prefabSerializer ??= CreatePrefabSerializer();
+        return prefabSerializer.Serialize(prefab);
+    }
+
+    static ISerializer CreatePrefabSerializer()
     {
         IYamlTypeConverter[] commonConverters =
         [
@@ -31,7 +56,7 @@ public static class EditorYaml
         foreach (var converter in commonConverters)
             serializerBuilder.WithTypeConverter(converter);
 
-        return serializerBuilder.Build().Serialize(prefab);
+        return serializerBuilder.Build();
     }
 }
 
@@ -1046,24 +1071,24 @@ public sealed class CreateModelGameObjectCommand(
     AssetFile modelFile,
     string objectName,
     GameObject? parent = null,
-    Vec4? worldPosition = null) : IUndoableEditorCommand
+    Vec4? worldPosition = null,
+    bool recreateHierarchy = true) : IUndoableEditorCommand
 {
-    const string MeshRendererComponentTypeName =
-        "Sailor::MeshRendererComponent";
-    const string ModelPropertyName = "model";
     const float WorldPositionEpsilon = 0.001f;
 
     readonly FileId _modelFileId = modelFile?.FileId;
     readonly InstanceId? _parentId = parent?.InstanceId;
     readonly Vec4? _worldPosition = worldPosition;
     readonly string _objectName = objectName;
+    readonly bool _recreateHierarchy = recreateHierarchy;
     readonly InstanceId _ownedGameObjectId =
         CreateCanonicalGameObjectInstanceId();
     readonly CreatedHierarchyCommandState _state = new(
         parent?.InstanceId);
+    string? _lastCreationFailureDiagnostic;
 
     public string Name => nameof(CreateModelGameObjectCommand);
-    public string Description => $"Create {_objectName}";
+    public string Description => "Create " + _objectName;
     public IHistoryMergePolicy? MergePolicy => null;
     public bool CanExecute(ActionContext context) =>
         _modelFileId is not null &&
@@ -1074,10 +1099,24 @@ public sealed class CreateModelGameObjectCommand(
         ActionContext context,
         CancellationToken cancellationToken = default)
     {
-        return await _state.ExecuteAsync(
-            CreateWithGenericOperationsAsync,
+        _lastCreationFailureDiagnostic = null;
+        var result = await _state.ExecuteAsync(
+            CreateOnEngineAsync,
             "Create model GameObject failed",
             cancellationToken);
+        if (!result.Succeeded &&
+            !string.IsNullOrWhiteSpace(
+                _lastCreationFailureDiagnostic))
+        {
+            return result with
+            {
+                Message =
+                    "Create model GameObject failed: " +
+                    _lastCreationFailureDiagnostic
+            };
+        }
+
+        return result;
     }
 
     public ValueTask<CommandResult> UndoAsync(
@@ -1085,13 +1124,10 @@ public sealed class CreateModelGameObjectCommand(
         CancellationToken cancellationToken = default)
         => _state.UndoAsync(cancellationToken);
 
-    async Task<InstanceId?> CreateWithGenericOperationsAsync()
+    async Task<InstanceId?> CreateOnEngineAsync()
     {
         var engine = MauiProgram.GetService<EngineService>();
         var world = MauiProgram.GetService<WorldService>();
-        var ownedComponentId =
-            CreateCanonicalComponentInstanceId(
-                _ownedGameObjectId);
         var creationSubmitted = false;
         string? failureDiagnostic = null;
 
@@ -1105,126 +1141,67 @@ public sealed class CreateModelGameObjectCommand(
                         _ownedGameObjectId);
             if (!preflight.Available || !preflight.RootAbsent)
             {
+                _lastCreationFailureDiagnostic =
+                    "preflight could not prove the owned instance id absent" +
+                    FormatDiagnostic(preflight.Diagnostic);
                 Console.Error.WriteLine(
-                    "Create model GameObject preflight could not prove the owned instance id absent" +
-                    FormatDiagnostic(preflight.Diagnostic));
+                    "Create model GameObject failed: " +
+                    _lastCreationFailureDiagnostic);
                 return null;
             }
 
-            var initialParentId = _worldPosition is null
-                ? _parentId
-                : null;
-
             creationSubmitted = true;
-            var createdId = await engine.CreateGameObjectAsync(
-                initialParentId,
-                _ownedGameObjectId,
-                CancellationToken.None);
+            var createdId =
+                await engine.RequestCreateModelInstanceAsync(
+                    _modelFileId,
+                    _objectName,
+                    _parentId,
+                    _recreateHierarchy,
+                    _worldPosition,
+                    _ownedGameObjectId,
+                    CancellationToken.None);
             if (!SameInstanceId(
                     createdId,
-                    _ownedGameObjectId) ||
-                !world.TryGetGameObject(
-                    _ownedGameObjectId,
-                    out _))
+                    _ownedGameObjectId))
             {
                 throw new InvalidOperationException(
-                    "CreateGameObject did not project the owned GameObject");
+                    "CreateModelInstance returned '" +
+                    (createdId?.Value ?? "<null>") +
+                    "', expected owned root '" +
+                    _ownedGameObjectId.Value +
+                    "'");
             }
 
-            var componentId = await engine.AddComponentAsync(
-                _ownedGameObjectId,
-                MeshRendererComponentTypeName,
-                ownedComponentId,
-                CancellationToken.None);
-            if (!SameInstanceId(
-                    componentId,
-                    ownedComponentId) ||
-                !world.TryGetGameObject(
-                    _ownedGameObjectId,
-                    out var createdObject) ||
-                !world.TryGetComponent(
-                    ownedComponentId,
-                    out var meshRenderer))
+            if (!await engine
+                    .RefreshCurrentWorldAuthoritativelyAsync(
+                        CancellationToken.None))
             {
                 throw new InvalidOperationException(
-                    "AddComponent did not project the owned MeshRenderer");
+                    "authoritative refresh failed after model instance creation");
             }
-
-            var updatedObject = CloneGameObject(createdObject);
-            updatedObject.Name = _objectName;
-            if (_worldPosition is not null)
-            {
-                updatedObject.Position = new Vec4(_worldPosition);
-            }
-
-            if (!await engine.CommitChangesAsync(
-                    _ownedGameObjectId,
-                    EditorYaml.SerializeGameObject(updatedObject),
-                    CancellationToken.None))
-            {
-                throw new InvalidOperationException(
-                    "ChangeValue failed for GameObject");
-            }
-
-            var updatedMeshRenderer = CloneComponent(meshRenderer);
-            if (!updatedMeshRenderer.OverrideProperties.ContainsKey(
-                    ModelPropertyName))
-            {
-                throw new InvalidOperationException(
-                    "MeshRenderer has no reflected model property");
-            }
-
-            updatedMeshRenderer.OverrideProperties[ModelPropertyName] =
-                new ObjectPtr
-                {
-                    FileId = new FileId(_modelFileId.Value),
-                    InstanceId = new InstanceId(
-                        InstanceId.NullInstanceId)
-                };
-            if (!await engine.CommitChangesAsync(
-                    ownedComponentId,
-                    EditorYaml.SerializeComponent(
-                        updatedMeshRenderer),
-                    CancellationToken.None))
-            {
-                throw new InvalidOperationException(
-                    "ChangeValue failed for MeshRenderer.model");
-            }
-
-            if (_worldPosition is not null &&
-                _parentId is not null &&
-                !_parentId.IsEmpty() &&
-                !await engine.ReparentObjectAsync(
-                    _ownedGameObjectId,
-                    _parentId,
-                    keepWorldTransform: true,
-                    CancellationToken.None))
-            {
-                throw new InvalidOperationException(
-                    "ReparentObject failed");
-            }
-
-            if (!await engine.RefreshCurrentWorldAuthoritativelyAsync(
-                    CancellationToken.None) ||
-                !MatchesFinalProjection(
+            if (!MatchesRootProjection(
                     world,
-                    ownedComponentId))
+                    out var projectionDiagnostic))
             {
                 throw new InvalidOperationException(
-                    "The authoritative result did not match the requested name, parent, world position, component, and model");
+                    "authoritative model instance mismatch: " +
+                    projectionDiagnostic);
             }
 
+            _lastCreationFailureDiagnostic = null;
             return _ownedGameObjectId;
         }
         catch (Exception exception)
         {
             failureDiagnostic = exception.Message;
+            _lastCreationFailureDiagnostic = failureDiagnostic;
         }
 
         if (!creationSubmitted)
         {
             Console.Error.WriteLine(
-                $"Create model GameObject failed: {failureDiagnostic}");
+                "Create model GameObject failed: " +
+                failureDiagnostic);
             return null;
         }
 
@@ -1232,82 +1209,87 @@ public sealed class CreateModelGameObjectCommand(
             engine,
             world,
             _ownedGameObjectId);
-        if (!cleanup.ConfirmedAbsent ||
-            world.TryGetComponent(ownedComponentId, out _))
+        if (!cleanup.ConfirmedAbsent)
         {
             throw new InvalidOperationException(
-                $"Create model GameObject failed ({failureDiagnostic}); rollback could not confirm owned GameObject/component absent for '{_ownedGameObjectId.Value}'" +
+                "Create model GameObject failed (" +
+                failureDiagnostic +
+                "); rollback could not confirm the owned hierarchy absent for '" +
+                _ownedGameObjectId.Value +
+                "'" +
                 FormatDiagnostic(cleanup.Diagnostic));
         }
 
         Console.Error.WriteLine(
-            $"Create model GameObject failed and was rolled back: {failureDiagnostic}");
+            "Create model GameObject failed and was rolled back: " +
+            failureDiagnostic);
         return null;
     }
 
-    bool MatchesFinalProjection(
+    bool MatchesRootProjection(
         WorldService world,
-        InstanceId componentId)
+        out string? diagnostic)
     {
+        diagnostic = null;
         if (!world.TryGetGameObject(
                 _ownedGameObjectId,
-                out var gameObject) ||
-            !string.Equals(
-                gameObject.Name,
-                _objectName,
-                StringComparison.Ordinal) ||
-            !SameInstanceId(
-                world.ResolveParentInstanceId(gameObject),
-                _parentId) ||
-            !world.TryGetComponent(
-                componentId,
-                out var meshRenderer) ||
-            !string.Equals(
-                meshRenderer.Typename?.Name,
-                MeshRendererComponentTypeName,
-                StringComparison.Ordinal) ||
-            !SameInstanceId(
-                world.FindOwner(meshRenderer)?.InstanceId,
-                _ownedGameObjectId))
+                out var gameObject))
         {
+            diagnostic = "root GameObject is absent";
             return false;
         }
-
-        var projectedComponents =
-            world.GetComponents(gameObject);
-        if (projectedComponents.Count != 1 ||
-            !SameInstanceId(
-                projectedComponents[0].InstanceId,
-                componentId) ||
-            !meshRenderer.OverrideProperties.TryGetValue(
-                ModelPropertyName,
-                out var modelValue) ||
-            modelValue is not ObjectPtr model ||
-            model.FileId is null ||
-            !string.Equals(
-                model.FileId.Value,
-                _modelFileId.Value,
-                StringComparison.Ordinal) ||
-            (model.InstanceId is not null &&
-                !model.InstanceId.IsEmpty()))
+        if (!string.Equals(
+                gameObject.Name,
+                _objectName,
+                StringComparison.Ordinal))
         {
+            diagnostic =
+                "root name is '" +
+                gameObject.Name +
+                "', expected '" +
+                _objectName +
+                "'";
+            return false;
+        }
+        if (!SameInstanceId(
+                world.ResolveParentInstanceId(gameObject),
+                _parentId))
+        {
+            diagnostic = "root parent does not match the drop target";
             return false;
         }
 
         if (_worldPosition is null)
         {
-            return IsNear(
-                ToVector3(gameObject.Position),
-                Vector3.Zero);
+            if (!IsNear(
+                    ToVector3(gameObject.Position),
+                    Vector3.Zero))
+            {
+                diagnostic = "root local position is not zero";
+                return false;
+            }
+
+            return true;
         }
 
-        return TryResolveWorldPosition(
+        if (!TryResolveWorldPosition(
                 world,
                 gameObject,
-                out var projectedWorldPosition) &&
-            IsNear(
+                out var projectedWorldPosition))
+        {
+            diagnostic = "root world position could not be resolved";
+            return false;
+        }
+        if (!IsNear(
                 projectedWorldPosition,
-                ToVector3(_worldPosition));
+                ToVector3(_worldPosition)))
+        {
+            diagnostic =
+                "root world position does not match the drop position";
+            return false;
+        }
+
+        return true;
     }
 
     static bool TryResolveWorldPosition(
@@ -1369,26 +1351,6 @@ public sealed class CreateModelGameObjectCommand(
             : Quaternion.Identity;
     }
 
-    static GameObject CloneGameObject(GameObject gameObject) => new()
-    {
-        Name = gameObject.Name,
-        InstanceId = new InstanceId(gameObject.InstanceId.Value),
-        ParentIndex = gameObject.ParentIndex,
-        Position = new Vec4(gameObject.Position),
-        Rotation = new Rotation(gameObject.Rotation),
-        Scale = new Vec4(gameObject.Scale),
-        ComponentIndices = [.. gameObject.ComponentIndices]
-    };
-
-    static Component CloneComponent(Component component)
-    {
-        var yaml = EditorYaml.SerializeComponent(component);
-        return SerializationUtils.CreateDeserializerBuilder()
-            .WithTypeConverter(new ComponentYamlConverter())
-            .Build()
-            .Deserialize<Component>(yaml);
-    }
-
     static Vector3 ToVector3(Vec4 value) =>
         value is null
             ? new Vector3(
@@ -1402,14 +1364,12 @@ public sealed class CreateModelGameObjectCommand(
 
     static bool IsNear(
         Vector3 actual,
-        Vector3 expected)
-    {
-        return IsFinite(actual) &&
-            IsFinite(expected) &&
-            NearlyEqual(actual.X, expected.X) &&
-            NearlyEqual(actual.Y, expected.Y) &&
-            NearlyEqual(actual.Z, expected.Z);
-    }
+        Vector3 expected) =>
+        IsFinite(actual) &&
+        IsFinite(expected) &&
+        NearlyEqual(actual.X, expected.X) &&
+        NearlyEqual(actual.Y, expected.Y) &&
+        NearlyEqual(actual.Z, expected.Z);
 
     static bool NearlyEqual(
         float actual,
@@ -1454,16 +1414,11 @@ public sealed class CreateModelGameObjectCommand(
     static string FormatDiagnostic(string? diagnostic) =>
         string.IsNullOrWhiteSpace(diagnostic)
             ? string.Empty
-            : $": {diagnostic}";
+            : ": " + diagnostic;
 
     static InstanceId CreateCanonicalGameObjectInstanceId() =>
         new(Convert.ToHexString(
             RandomNumberGenerator.GetBytes(10)));
-
-    static InstanceId CreateCanonicalComponentInstanceId(
-        InstanceId owner) =>
-        new(
-            $"{Convert.ToHexString(RandomNumberGenerator.GetBytes(8))}_{owner.Value}");
 }
 
 public sealed class InstantiatePrefabAssetCommand(

--- a/Editor/Controls/FileIdSelectBehavior.cs
+++ b/Editor/Controls/FileIdSelectBehavior.cs
@@ -9,9 +9,17 @@ namespace SailorEditor.Controls;
 public class FileIdSelectBehavior : Behavior<Label>
 {
     private Label _associatedLabel;
+    private AssetsService _assetsService;
+    private TapGestureRecognizer _tapGestureRecognizer;
 
     public static readonly BindableProperty BoundPropertyProperty =
-        BindableProperty.Create(nameof(BoundProperty), typeof(object), typeof(FileIdDragAndDropBehaviour), null, BindingMode.TwoWay);
+        BindableProperty.Create(
+            nameof(BoundProperty),
+            typeof(object),
+            typeof(FileIdSelectBehavior),
+            null,
+            BindingMode.TwoWay,
+            propertyChanged: OnBoundPropertyChanged);
 
     public object BoundProperty
     {
@@ -27,16 +35,30 @@ public class FileIdSelectBehavior : Behavior<Label>
         _associatedLabel.BindingContextChanged += OnBindingContextChanged;
 
         BindingContext = _associatedLabel.BindingContext;
+        _assetsService = MauiProgram.GetService<AssetsService>();
+        _assetsService.Changed += OnAssetsChanged;
 
-        var tapGestureRecognizer = new TapGestureRecognizer();
-        tapGestureRecognizer.Tapped += OnLabelTapped;
-        bindable.GestureRecognizers.Add(tapGestureRecognizer);
+        _tapGestureRecognizer = new TapGestureRecognizer();
+        _tapGestureRecognizer.Tapped += OnLabelTapped;
+        bindable.GestureRecognizers.Add(_tapGestureRecognizer);
+        RefreshLabel();
     }
 
     protected override void OnDetachingFrom(Label bindable)
     {
         base.OnDetachingFrom(bindable);
 
+        if (_assetsService is not null)
+        {
+            _assetsService.Changed -= OnAssetsChanged;
+            _assetsService = null;
+        }
+        if (_tapGestureRecognizer is not null)
+        {
+            _tapGestureRecognizer.Tapped -= OnLabelTapped;
+            bindable.GestureRecognizers.Remove(_tapGestureRecognizer);
+            _tapGestureRecognizer = null;
+        }
         _associatedLabel.BindingContextChanged -= OnBindingContextChanged;
         _associatedLabel = null;
     }
@@ -58,7 +80,46 @@ public class FileIdSelectBehavior : Behavior<Label>
 
     private void OnBindingContextChanged(object sender, System.EventArgs e)
     {
-        var bindingContext = _associatedLabel.BindingContext;
         BindingContext = _associatedLabel.BindingContext;
+        RefreshLabel();
+    }
+
+    static void OnBoundPropertyChanged(
+        BindableObject bindable,
+        object oldValue,
+        object newValue)
+        => ((FileIdSelectBehavior)bindable).RefreshLabel();
+
+    void OnAssetsChanged()
+    {
+        if (MainThread.IsMainThread)
+        {
+            RefreshLabel();
+        }
+        else
+        {
+            MainThread.BeginInvokeOnMainThread(RefreshLabel);
+        }
+    }
+
+    void RefreshLabel()
+    {
+        if (_associatedLabel is null)
+        {
+            return;
+        }
+
+        var fileId = BoundProperty as FileId ??
+            (BoundProperty as Observable<FileId>)?.Value;
+        if (fileId is null || fileId.IsEmpty())
+        {
+            _associatedLabel.Text = FileId.NullFileId;
+            return;
+        }
+
+        _associatedLabel.Text =
+            _assetsService?.Assets.TryGetValue(fileId, out var asset) == true
+                ? asset.DisplayName
+                : fileId.Value;
     }
 }

--- a/Editor/Protocol/EngineProtocolClient.cs
+++ b/Editor/Protocol/EngineProtocolClient.cs
@@ -596,6 +596,48 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                 .ConfigureAwait(false),
             nameof(ProtocolRequest.CreateGameObject));
 
+    public async Task<EngineProtocolCreationResult> CreateModelInstanceAsync(
+        string modelFileId,
+        string name,
+        string parentInstanceId,
+        bool createHierarchy,
+        EngineProtocolVector4? worldPosition,
+        string preferredInstanceId,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new CreateModelInstanceRequest
+        {
+            ModelFileId = ValidateString(
+                modelFileId,
+                nameof(modelFileId)),
+            Name = ValidateString(name, nameof(name)),
+            ParentInstanceId = ValidateString(
+                parentInstanceId,
+                nameof(parentInstanceId)),
+            CreateHierarchy = createHierarchy,
+            ApplyWorldPosition = worldPosition.HasValue,
+            PreferredInstanceId = ValidateString(
+                preferredInstanceId,
+                nameof(preferredInstanceId))
+        };
+        if (worldPosition is { } position)
+        {
+            request.WorldPosition = CreateVector4(
+                position,
+                nameof(worldPosition));
+        }
+
+        return ReadCreation(
+            await SendAsync(
+                    new ProtocolRequest
+                    {
+                        CreateModelInstance = request
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.CreateModelInstance));
+    }
+
     public async Task<bool> DestroyObjectAsync(
         string instanceId,
         CancellationToken cancellationToken = default)

--- a/Editor/Protocol/Generated/EditorEngine.cs
+++ b/Editor/Protocol/Generated/EditorEngine.cs
@@ -25,7 +25,7 @@ namespace SailorEditor.Protocol.Generated {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "ChNlZGl0b3JfZW5naW5lLnByb3RvEhBzYWlsb3IuZWRpdG9yLnYxIgcKBUVt",
-            "cHR5IvwZCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
+            "cHR5IssaCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
             "IAEoDRISCgpyZXF1ZXN0X2lkGAIgASgEEjkKCmluaXRpYWxpemUYCiABKAsy",
             "Iy5zYWlsb3IuZWRpdG9yLnYxLkluaXRpYWxpemVSZXF1ZXN0SAASKAoFc3Rh",
             "cnQYCyABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASJwoEc3RvcBgM",
@@ -97,136 +97,144 @@ namespace SailorEditor.Protocol.Generated {
             "UmVxdWVzdEgAEkYKF2dldF92aWV3cG9ydF90b29sX3N0YXRlGDggASgLMiMu",
             "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydElkUmVxdWVzdEgAEjcKDHVwZGF0",
             "ZV9hc3NldBg5IAEoCzIfLnNhaWxvci5lZGl0b3IudjEuRmlsZUlkUmVxdWVz",
-            "dEgAQgkKB2NvbW1hbmRKBAgDEApKBAgyEDNKBAg6EGRSGGNyZWF0ZV9tb2Rl",
-            "bF9nYW1lX29iamVjdFIecmVzb2x2ZV92aWV3cG9ydF9kcm9wX3Bvc2l0aW9u",
-            "IpYHChBQcm90b2NvbFJlc3BvbnNlEhgKEHByb3RvY29sX3ZlcnNpb24YASAB",
-            "KA0SEgoKcmVxdWVzdF9pZBgCIAEoBBIPCgdzdWNjZXNzGAMgASgIEg0KBWVy",
-            "cm9yGAQgASgJEiQKHHN1cHBvcnRzX3N0cmljdF9pbnN0YW5jZV9pZHMYBSAB",
-            "KAgSLwoMZW1wdHlfcmVzdWx0GAogASgLMhcuc2FpbG9yLmVkaXRvci52MS5F",
-            "bXB0eUgAEjMKC2Jvb2xfcmVzdWx0GAsgASgLMhwuc2FpbG9yLmVkaXRvci52",
-            "MS5Cb29sUmVzdWx0SAASNQoMaW50MzJfcmVzdWx0GAwgASgLMh0uc2FpbG9y",
-            "LmVkaXRvci52MS5JbnQzMlJlc3VsdEgAEjcKDXVpbnQzMl9yZXN1bHQYDSAB",
-            "KAsyHi5zYWlsb3IuZWRpdG9yLnYxLlVJbnQzMlJlc3VsdEgAEjcKDXVpbnQ2",
-            "NF9yZXN1bHQYDiABKAsyHi5zYWlsb3IuZWRpdG9yLnYxLlVJbnQ2NFJlc3Vs",
-            "dEgAEjcKDXN0cmluZ19yZXN1bHQYDyABKAsyHi5zYWlsb3IuZWRpdG9yLnYx",
-            "LlN0cmluZ1Jlc3VsdEgAEkAKEnN0cmluZ19saXN0X3Jlc3VsdBgQIAEoCzIi",
-            "LnNhaWxvci5lZGl0b3IudjEuU3RyaW5nTGlzdFJlc3VsdEgAEk0KGWFzc2V0",
-            "X3JlbG9hZF9zdGF0ZV9yZXN1bHQYESABKAsyKC5zYWlsb3IuZWRpdG9yLnYx",
-            "LkFzc2V0UmVsb2FkU3RhdGVSZXN1bHRIABJAChJpbnN0YW5jZV9pZF9yZXN1",
-            "bHQYEiABKAsyIi5zYWlsb3IuZWRpdG9yLnYxLkluc3RhbmNlSWRSZXN1bHRI",
-            "ABJRCht2aWV3cG9ydF9ldmVudF9iYXRjaF9yZXN1bHQYEyABKAsyKi5zYWls",
-            "b3IuZWRpdG9yLnYxLlZpZXdwb3J0RXZlbnRCYXRjaFJlc3VsdEgAEjkKDnZl",
-            "Y3RvcjRfcmVzdWx0GBQgASgLMh8uc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0",
-            "UmVzdWx0SAASTwoadmlld3BvcnRfdG9vbF9zdGF0ZV9yZXN1bHQYFSABKAsy",
-            "KS5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VG9vbFN0YXRlUmVzdWx0SABC",
-            "CAoGcmVzdWx0SgQIBhAKSgQIFhBkIiYKEUluaXRpYWxpemVSZXF1ZXN0EhEK",
-            "CWFyZ3VtZW50cxgBIAMoCSIhCgxDb3VudFJlcXVlc3QSEQoJbWF4X2NvdW50",
-            "GAEgASgNIiAKDUZpbGVJZFJlcXVlc3QSDwoHZmlsZV9pZBgBIAEoCSIoChFJ",
-            "bnN0YW5jZUlkUmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCSIoChFWaWV3",
-            "cG9ydElkUmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBCJgChNWaWV3cG9y",
-            "dFJlY3RSZXF1ZXN0EhQKDHdpbmRvd19wb3NfeBgBIAEoDRIUCgx3aW5kb3df",
-            "cG9zX3kYAiABKA0SDQoFd2lkdGgYAyABKA0SDgoGaGVpZ2h0GAQgASgNIiwK",
-            "C1NpemVSZXF1ZXN0Eg0KBXdpZHRoGAEgASgNEg4KBmhlaWdodBgCIAEoDSKZ",
-            "AQoVUmVtb3RlVmlld3BvcnRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgE",
-            "EhQKDHdpbmRvd19wb3NfeBgCIAEoDRIUCgx3aW5kb3dfcG9zX3kYAyABKA0S",
-            "DQoFd2lkdGgYBCABKA0SDgoGaGVpZ2h0GAUgASgNEg8KB3Zpc2libGUYBiAB",
-            "KAgSDwoHZm9jdXNlZBgHIAEoCCJlChlSZW1vdGVWaWV3cG9ydEhvc3RSZXF1",
-            "ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhgKEGhvc3RfaGFuZGxlX2tpbmQY",
-            "AiABKA0SGQoRaG9zdF9oYW5kbGVfdmFsdWUYAyABKAQi/AEKGlJlbW90ZVZp",
-            "ZXdwb3J0SW5wdXRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEgwKBGtp",
-            "bmQYAiABKA0SEQoJcG9pbnRlcl94GAMgASgCEhEKCXBvaW50ZXJfeRgEIAEo",
-            "AhIVCg13aGVlbF9kZWx0YV94GAUgASgCEhUKDXdoZWVsX2RlbHRhX3kYBiAB",
-            "KAISEAoIa2V5X2NvZGUYByABKA0SDgoGYnV0dG9uGAggASgNEhEKCW1vZGlm",
-            "aWVycxgJIAEoDRIPCgdwcmVzc2VkGAogASgIEg8KB2ZvY3VzZWQYCyABKAgS",
-            "EAoIY2FwdHVyZWQYDCABKAgiQwoeTWFuYWdlZE11dGF0aW9uUmV2aXNpb25S",
-            "ZXF1ZXN0EgwKBGtpbmQYASABKA0SEwoLaW5zdGFuY2VfaWQYAiABKAkiQAoT",
-            "VXBkYXRlT2JqZWN0UmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCRIUCgx5",
-            "YW1sX2NoYW5nZXMYAiABKAkiZgoVUmVwYXJlbnRPYmplY3RSZXF1ZXN0EhMK",
-            "C2luc3RhbmNlX2lkGAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEo",
-            "CRIcChRrZWVwX3dvcmxkX3RyYW5zZm9ybRgDIAEoCCJUChdDcmVhdGVHYW1l",
-            "T2JqZWN0UmVxdWVzdBIaChJwYXJlbnRfaW5zdGFuY2VfaWQYASABKAkSHQoV",
-            "cHJlZmVycmVkX2luc3RhbmNlX2lkGAIgASgJImYKE0FkZENvbXBvbmVudFJl",
-            "cXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkSGwoTY29tcG9uZW50X3R5cGVf",
-            "bmFtZRgCIAEoCRIdChVwcmVmZXJyZWRfaW5zdGFuY2VfaWQYAyABKAkiRwoY",
-            "SW5zdGFudGlhdGVQcmVmYWJSZXF1ZXN0Eg8KB2ZpbGVfaWQYASABKAkSGgoS",
-            "cGFyZW50X2luc3RhbmNlX2lkGAIgASgJInAKIEluc3RhbnRpYXRlUHJlZmFi",
-            "RnJvbVlhbWxSZXF1ZXN0EhMKC3ByZWZhYl95YW1sGAEgASgJEhoKEnBhcmVu",
-            "dF9pbnN0YW5jZV9pZBgCIAEoCRIbChNzdHJpY3RfaW5zdGFuY2VfaWRzGAMg",
-            "ASgIIlUKElZpZXdwb3J0UmF5UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEo",
-            "BBIUCgxub3JtYWxpemVkX3gYAiABKAISFAoMbm9ybWFsaXplZF95GAMgASgC",
-            "IqABCiBJbnN0YW50aWF0ZVByZWZhYkluc3RhbmNlUmVxdWVzdBIPCgdmaWxl",
-            "X2lkGAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIcChRhcHBs",
-            "eV93b3JsZF9wb3NpdGlvbhgDIAEoCBIxCg53b3JsZF9wb3NpdGlvbhgEIAEo",
-            "CzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNCJBChVWaWV3cG9ydE9iamVj",
-            "dFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQSEwoLaW5zdGFuY2VfaWQY",
-            "AiABKAkiOQoRUHJlZmFiTGlua1JlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASAB",
-            "KAkSDwoHZmlsZV9pZBgCIAEoCSKpAQoYVmlld3BvcnRUb29sU3RhdGVSZXF1",
-            "ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEj8KCW9wZXJhdGlvbhgCIAEoDjIs",
-            "LnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24S",
-            "NwoFc3BhY2UYAyABKA4yKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJh",
-            "bnNmb3JtU3BhY2UiKAoQU2VsZWN0aW9uUmVxdWVzdBIUCgxpbnN0YW5jZV9p",
-            "ZHMYASADKAkiJQoVU2hvd01haW5XaW5kb3dSZXF1ZXN0EgwKBHNob3cYASAB",
-            "KAgiiAEKHFJlbmRlclBhdGhUcmFjZWRJbWFnZVJlcXVlc3QSEwoLb3V0cHV0",
-            "X3BhdGgYASABKAkSEwoLaW5zdGFuY2VfaWQYAiABKAkSDgoGaGVpZ2h0GAMg",
-            "ASgNEhkKEXNhbXBsZXNfcGVyX3BpeGVsGAQgASgNEhMKC21heF9ib3VuY2Vz",
-            "GAUgASgNIhsKCkJvb2xSZXN1bHQSDQoFdmFsdWUYASABKAgiHAoLSW50MzJS",
-            "ZXN1bHQSDQoFdmFsdWUYASABKAUiHQoMVUludDMyUmVzdWx0Eg0KBXZhbHVl",
-            "GAEgASgNIh0KDFVJbnQ2NFJlc3VsdBINCgV2YWx1ZRgBIAEoBCIwCgxTdHJp",
-            "bmdSZXN1bHQSEQoJaGFzX3ZhbHVlGAEgASgIEg0KBXZhbHVlGAIgASgJIiIK",
-            "EFN0cmluZ0xpc3RSZXN1bHQSDgoGdmFsdWVzGAEgAygJIoQBChZBc3NldFJl",
-            "bG9hZFN0YXRlUmVzdWx0EhEKCWF2YWlsYWJsZRgBIAEoCBIaChJyZXF1ZXN0",
-            "X2dlbmVyYXRpb24YAiABKAQSHAoUY29tcGxldGVkX2dlbmVyYXRpb24YAyAB",
-            "KAQSHQoVc3VjY2Vzc2Z1bF9nZW5lcmF0aW9uGAQgASgEIjoKEEluc3RhbmNl",
-            "SWRSZXN1bHQSEQoJc3VjY2VlZGVkGAEgASgIEhMKC2luc3RhbmNlX2lkGAIg",
-            "ASgJIjkKDVZlY3RvcjRSZXN1bHQSKAoFdmFsdWUYASABKAsyGS5zYWlsb3Iu",
-            "ZWRpdG9yLnYxLlZlY3RvcjQikwEKF1ZpZXdwb3J0VG9vbFN0YXRlUmVzdWx0",
-            "Ej8KCW9wZXJhdGlvbhgBIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmlld3Bv",
-            "cnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAiABKA4yKC5zYWlsb3Iu",
-            "ZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2UiNQoHVmVjdG9yNBIJ",
-            "CgF4GAEgASgCEgkKAXkYAiABKAISCQoBehgDIAEoAhIJCgF3GAQgASgCIjYK",
-            "FlZpZXdwb3J0U2VsZWN0aW9uRXZlbnQSHAoUc2VsZWN0ZWRfaW5zdGFuY2Vf",
-            "aWQYASABKAki1gMKFlZpZXdwb3J0VHJhbnNmb3JtRXZlbnQSEwoLaW5zdGFu",
-            "Y2VfaWQYASABKAkSPwoJb3BlcmF0aW9uGAIgASgOMiwuc2FpbG9yLmVkaXRv",
-            "ci52MS5WaWV3cG9ydFRyYW5zZm9ybU9wZXJhdGlvbhI3CgVzcGFjZRgDIAEo",
-            "DjIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1TcGFjZRIy",
-            "Cg9iZWZvcmVfcG9zaXRpb24YBCABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZl",
-            "Y3RvcjQSMgoPYmVmb3JlX3JvdGF0aW9uGAUgASgLMhkuc2FpbG9yLmVkaXRv",
-            "ci52MS5WZWN0b3I0Ei8KDGJlZm9yZV9zY2FsZRgGIAEoCzIZLnNhaWxvci5l",
-            "ZGl0b3IudjEuVmVjdG9yNBIxCg5hZnRlcl9wb3NpdGlvbhgHIAEoCzIZLnNh",
-            "aWxvci5lZGl0b3IudjEuVmVjdG9yNBIxCg5hZnRlcl9yb3RhdGlvbhgIIAEo",
-            "CzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNBIuCgthZnRlcl9zY2FsZRgJ",
-            "IAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNCJVChZWaWV3cG9ydEFz",
-            "c2V0RHJvcEV2ZW50Eg8KB2ZpbGVfaWQYASABKAkSFAoMbm9ybWFsaXplZF94",
-            "GAIgASgCEhQKDG5vcm1hbGl6ZWRfeRgDIAEoAiItChlWaWV3cG9ydFRvb2xT",
-            "aG9ydGN1dEV2ZW50EhAKCGtleV9jb2RlGAEgASgNItkCCg1WaWV3cG9ydEV2",
-            "ZW50EhAKCHJldmlzaW9uGAEgASgEEiEKGW1hbmFnZWRfbXV0YXRpb25fcmV2",
-            "aXNpb24YAiABKAQSPQoJc2VsZWN0aW9uGAogASgLMiguc2FpbG9yLmVkaXRv",
-            "ci52MS5WaWV3cG9ydFNlbGVjdGlvbkV2ZW50SAASPQoJdHJhbnNmb3JtGAsg",
-            "ASgLMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybUV2ZW50",
-            "SAASPgoKYXNzZXRfZHJvcBgMIAEoCzIoLnNhaWxvci5lZGl0b3IudjEuVmll",
-            "d3BvcnRBc3NldERyb3BFdmVudEgAEkQKDXRvb2xfc2hvcnRjdXQYDSABKAsy",
-            "Ky5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VG9vbFNob3J0Y3V0RXZlbnRI",
-            "AEIJCgdwYXlsb2FkSgQIAxAKIksKGFZpZXdwb3J0RXZlbnRCYXRjaFJlc3Vs",
-            "dBIvCgZldmVudHMYASADKAsyHy5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0",
-            "RXZlbnQq8AEKGlZpZXdwb3J0VHJhbnNmb3JtT3BlcmF0aW9uEiwKKFZJRVdQ",
-            "T1JUX1RSQU5TRk9STV9PUEVSQVRJT05fVU5TUEVDSUZJRUQQABInCiNWSUVX",
-            "UE9SVF9UUkFOU0ZPUk1fT1BFUkFUSU9OX1NFTEVDVBABEioKJlZJRVdQT1JU",
-            "X1RSQU5TRk9STV9PUEVSQVRJT05fVFJBTlNMQVRFEAISJwojVklFV1BPUlRf",
-            "VFJBTlNGT1JNX09QRVJBVElPTl9ST1RBVEUQAxImCiJWSUVXUE9SVF9UUkFO",
-            "U0ZPUk1fT1BFUkFUSU9OX1NDQUxFEAQqigEKFlZpZXdwb3J0VHJhbnNmb3Jt",
-            "U3BhY2USKAokVklFV1BPUlRfVFJBTlNGT1JNX1NQQUNFX1VOU1BFQ0lGSUVE",
-            "EAASIgoeVklFV1BPUlRfVFJBTlNGT1JNX1NQQUNFX1dPUkxEEAESIgoeVklF",
-            "V1BPUlRfVFJBTlNGT1JNX1NQQUNFX0xPQ0FMEAJCIqoCH1NhaWxvckVkaXRv",
-            "ci5Qcm90b2NvbC5HZW5lcmF0ZWRiBnByb3RvMw=="));
+            "dEgAEk0KFWNyZWF0ZV9tb2RlbF9pbnN0YW5jZRg6IAEoCzIsLnNhaWxvci5l",
+            "ZGl0b3IudjEuQ3JlYXRlTW9kZWxJbnN0YW5jZVJlcXVlc3RIAEIJCgdjb21t",
+            "YW5kSgQIAxAKSgQIMhAzSgQIOxBkUhhjcmVhdGVfbW9kZWxfZ2FtZV9vYmpl",
+            "Y3RSHnJlc29sdmVfdmlld3BvcnRfZHJvcF9wb3NpdGlvbiKWBwoQUHJvdG9j",
+            "b2xSZXNwb25zZRIYChBwcm90b2NvbF92ZXJzaW9uGAEgASgNEhIKCnJlcXVl",
+            "c3RfaWQYAiABKAQSDwoHc3VjY2VzcxgDIAEoCBINCgVlcnJvchgEIAEoCRIk",
+            "ChxzdXBwb3J0c19zdHJpY3RfaW5zdGFuY2VfaWRzGAUgASgIEi8KDGVtcHR5",
+            "X3Jlc3VsdBgKIAEoCzIXLnNhaWxvci5lZGl0b3IudjEuRW1wdHlIABIzCgti",
+            "b29sX3Jlc3VsdBgLIAEoCzIcLnNhaWxvci5lZGl0b3IudjEuQm9vbFJlc3Vs",
+            "dEgAEjUKDGludDMyX3Jlc3VsdBgMIAEoCzIdLnNhaWxvci5lZGl0b3IudjEu",
+            "SW50MzJSZXN1bHRIABI3Cg11aW50MzJfcmVzdWx0GA0gASgLMh4uc2FpbG9y",
+            "LmVkaXRvci52MS5VSW50MzJSZXN1bHRIABI3Cg11aW50NjRfcmVzdWx0GA4g",
+            "ASgLMh4uc2FpbG9yLmVkaXRvci52MS5VSW50NjRSZXN1bHRIABI3Cg1zdHJp",
+            "bmdfcmVzdWx0GA8gASgLMh4uc2FpbG9yLmVkaXRvci52MS5TdHJpbmdSZXN1",
+            "bHRIABJAChJzdHJpbmdfbGlzdF9yZXN1bHQYECABKAsyIi5zYWlsb3IuZWRp",
+            "dG9yLnYxLlN0cmluZ0xpc3RSZXN1bHRIABJNChlhc3NldF9yZWxvYWRfc3Rh",
+            "dGVfcmVzdWx0GBEgASgLMiguc2FpbG9yLmVkaXRvci52MS5Bc3NldFJlbG9h",
+            "ZFN0YXRlUmVzdWx0SAASQAoSaW5zdGFuY2VfaWRfcmVzdWx0GBIgASgLMiIu",
+            "c2FpbG9yLmVkaXRvci52MS5JbnN0YW5jZUlkUmVzdWx0SAASUQobdmlld3Bv",
+            "cnRfZXZlbnRfYmF0Y2hfcmVzdWx0GBMgASgLMiouc2FpbG9yLmVkaXRvci52",
+            "MS5WaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHRIABI5Cg52ZWN0b3I0X3Jlc3Vs",
+            "dBgUIAEoCzIfLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNFJlc3VsdEgAEk8K",
+            "GnZpZXdwb3J0X3Rvb2xfc3RhdGVfcmVzdWx0GBUgASgLMikuc2FpbG9yLmVk",
+            "aXRvci52MS5WaWV3cG9ydFRvb2xTdGF0ZVJlc3VsdEgAQggKBnJlc3VsdEoE",
+            "CAYQCkoECBYQZCImChFJbml0aWFsaXplUmVxdWVzdBIRCglhcmd1bWVudHMY",
+            "ASADKAkiIQoMQ291bnRSZXF1ZXN0EhEKCW1heF9jb3VudBgBIAEoDSIgCg1G",
+            "aWxlSWRSZXF1ZXN0Eg8KB2ZpbGVfaWQYASABKAki5wEKGkNyZWF0ZU1vZGVs",
+            "SW5zdGFuY2VSZXF1ZXN0EhUKDW1vZGVsX2ZpbGVfaWQYASABKAkSDAoEbmFt",
+            "ZRgCIAEoCRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAyABKAkSGAoQY3JlYXRl",
+            "X2hpZXJhcmNoeRgEIAEoCBIcChRhcHBseV93b3JsZF9wb3NpdGlvbhgFIAEo",
+            "CBIxCg53b3JsZF9wb3NpdGlvbhgGIAEoCzIZLnNhaWxvci5lZGl0b3IudjEu",
+            "VmVjdG9yNBIdChVwcmVmZXJyZWRfaW5zdGFuY2VfaWQYByABKAkiKAoRSW5z",
+            "dGFuY2VJZFJlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkiKAoRVmlld3Bv",
+            "cnRJZFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQiYAoTVmlld3BvcnRS",
+            "ZWN0UmVxdWVzdBIUCgx3aW5kb3dfcG9zX3gYASABKA0SFAoMd2luZG93X3Bv",
+            "c195GAIgASgNEg0KBXdpZHRoGAMgASgNEg4KBmhlaWdodBgEIAEoDSIsCgtT",
+            "aXplUmVxdWVzdBINCgV3aWR0aBgBIAEoDRIOCgZoZWlnaHQYAiABKA0imQEK",
+            "FVJlbW90ZVZpZXdwb3J0UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIU",
+            "Cgx3aW5kb3dfcG9zX3gYAiABKA0SFAoMd2luZG93X3Bvc195GAMgASgNEg0K",
+            "BXdpZHRoGAQgASgNEg4KBmhlaWdodBgFIAEoDRIPCgd2aXNpYmxlGAYgASgI",
+            "Eg8KB2ZvY3VzZWQYByABKAgiZQoZUmVtb3RlVmlld3BvcnRIb3N0UmVxdWVz",
+            "dBITCgt2aWV3cG9ydF9pZBgBIAEoBBIYChBob3N0X2hhbmRsZV9raW5kGAIg",
+            "ASgNEhkKEWhvc3RfaGFuZGxlX3ZhbHVlGAMgASgEIvwBChpSZW1vdGVWaWV3",
+            "cG9ydElucHV0UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIMCgRraW5k",
+            "GAIgASgNEhEKCXBvaW50ZXJfeBgDIAEoAhIRCglwb2ludGVyX3kYBCABKAIS",
+            "FQoNd2hlZWxfZGVsdGFfeBgFIAEoAhIVCg13aGVlbF9kZWx0YV95GAYgASgC",
+            "EhAKCGtleV9jb2RlGAcgASgNEg4KBmJ1dHRvbhgIIAEoDRIRCgltb2RpZmll",
+            "cnMYCSABKA0SDwoHcHJlc3NlZBgKIAEoCBIPCgdmb2N1c2VkGAsgASgIEhAK",
+            "CGNhcHR1cmVkGAwgASgIIkMKHk1hbmFnZWRNdXRhdGlvblJldmlzaW9uUmVx",
+            "dWVzdBIMCgRraW5kGAEgASgNEhMKC2luc3RhbmNlX2lkGAIgASgJIkAKE1Vw",
+            "ZGF0ZU9iamVjdFJlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkSFAoMeWFt",
+            "bF9jaGFuZ2VzGAIgASgJImYKFVJlcGFyZW50T2JqZWN0UmVxdWVzdBITCgtp",
+            "bnN0YW5jZV9pZBgBIAEoCRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAiABKAkS",
+            "HAoUa2VlcF93b3JsZF90cmFuc2Zvcm0YAyABKAgiVAoXQ3JlYXRlR2FtZU9i",
+            "amVjdFJlcXVlc3QSGgoScGFyZW50X2luc3RhbmNlX2lkGAEgASgJEh0KFXBy",
+            "ZWZlcnJlZF9pbnN0YW5jZV9pZBgCIAEoCSJmChNBZGRDb21wb25lbnRSZXF1",
+            "ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEhsKE2NvbXBvbmVudF90eXBlX25h",
+            "bWUYAiABKAkSHQoVcHJlZmVycmVkX2luc3RhbmNlX2lkGAMgASgJIkcKGElu",
+            "c3RhbnRpYXRlUHJlZmFiUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJEhoKEnBh",
+            "cmVudF9pbnN0YW5jZV9pZBgCIAEoCSJwCiBJbnN0YW50aWF0ZVByZWZhYkZy",
+            "b21ZYW1sUmVxdWVzdBITCgtwcmVmYWJfeWFtbBgBIAEoCRIaChJwYXJlbnRf",
+            "aW5zdGFuY2VfaWQYAiABKAkSGwoTc3RyaWN0X2luc3RhbmNlX2lkcxgDIAEo",
+            "CCJVChJWaWV3cG9ydFJheVJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQS",
+            "FAoMbm9ybWFsaXplZF94GAIgASgCEhQKDG5vcm1hbGl6ZWRfeRgDIAEoAiKg",
+            "AQogSW5zdGFudGlhdGVQcmVmYWJJbnN0YW5jZVJlcXVlc3QSDwoHZmlsZV9p",
+            "ZBgBIAEoCRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAiABKAkSHAoUYXBwbHlf",
+            "d29ybGRfcG9zaXRpb24YAyABKAgSMQoOd29ybGRfcG9zaXRpb24YBCABKAsy",
+            "GS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQiQQoVVmlld3BvcnRPYmplY3RS",
+            "ZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhMKC2luc3RhbmNlX2lkGAIg",
+            "ASgJIjkKEVByZWZhYkxpbmtSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJ",
+            "Eg8KB2ZpbGVfaWQYAiABKAkiqQEKGFZpZXdwb3J0VG9vbFN0YXRlUmVxdWVz",
+            "dBITCgt2aWV3cG9ydF9pZBgBIAEoBBI/CglvcGVyYXRpb24YAiABKA4yLC5z",
+            "YWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtT3BlcmF0aW9uEjcK",
+            "BXNwYWNlGAMgASgOMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5z",
+            "Zm9ybVNwYWNlIigKEFNlbGVjdGlvblJlcXVlc3QSFAoMaW5zdGFuY2VfaWRz",
+            "GAEgAygJIiUKFVNob3dNYWluV2luZG93UmVxdWVzdBIMCgRzaG93GAEgASgI",
+            "IogBChxSZW5kZXJQYXRoVHJhY2VkSW1hZ2VSZXF1ZXN0EhMKC291dHB1dF9w",
+            "YXRoGAEgASgJEhMKC2luc3RhbmNlX2lkGAIgASgJEg4KBmhlaWdodBgDIAEo",
+            "DRIZChFzYW1wbGVzX3Blcl9waXhlbBgEIAEoDRITCgttYXhfYm91bmNlcxgF",
+            "IAEoDSIbCgpCb29sUmVzdWx0Eg0KBXZhbHVlGAEgASgIIhwKC0ludDMyUmVz",
+            "dWx0Eg0KBXZhbHVlGAEgASgFIh0KDFVJbnQzMlJlc3VsdBINCgV2YWx1ZRgB",
+            "IAEoDSIdCgxVSW50NjRSZXN1bHQSDQoFdmFsdWUYASABKAQiMAoMU3RyaW5n",
+            "UmVzdWx0EhEKCWhhc192YWx1ZRgBIAEoCBINCgV2YWx1ZRgCIAEoCSIiChBT",
+            "dHJpbmdMaXN0UmVzdWx0Eg4KBnZhbHVlcxgBIAMoCSKEAQoWQXNzZXRSZWxv",
+            "YWRTdGF0ZVJlc3VsdBIRCglhdmFpbGFibGUYASABKAgSGgoScmVxdWVzdF9n",
+            "ZW5lcmF0aW9uGAIgASgEEhwKFGNvbXBsZXRlZF9nZW5lcmF0aW9uGAMgASgE",
+            "Eh0KFXN1Y2Nlc3NmdWxfZ2VuZXJhdGlvbhgEIAEoBCI6ChBJbnN0YW5jZUlk",
+            "UmVzdWx0EhEKCXN1Y2NlZWRlZBgBIAEoCBITCgtpbnN0YW5jZV9pZBgCIAEo",
+            "CSI5Cg1WZWN0b3I0UmVzdWx0EigKBXZhbHVlGAEgASgLMhkuc2FpbG9yLmVk",
+            "aXRvci52MS5WZWN0b3I0IpMBChdWaWV3cG9ydFRvb2xTdGF0ZVJlc3VsdBI/",
+            "CglvcGVyYXRpb24YASABKA4yLC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0",
+            "VHJhbnNmb3JtT3BlcmF0aW9uEjcKBXNwYWNlGAIgASgOMiguc2FpbG9yLmVk",
+            "aXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybVNwYWNlIjUKB1ZlY3RvcjQSCQoB",
+            "eBgBIAEoAhIJCgF5GAIgASgCEgkKAXoYAyABKAISCQoBdxgEIAEoAiI2ChZW",
+            "aWV3cG9ydFNlbGVjdGlvbkV2ZW50EhwKFHNlbGVjdGVkX2luc3RhbmNlX2lk",
+            "GAEgASgJItYDChZWaWV3cG9ydFRyYW5zZm9ybUV2ZW50EhMKC2luc3RhbmNl",
+            "X2lkGAEgASgJEj8KCW9wZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5lZGl0b3Iu",
+            "djEuVmlld3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAyABKA4y",
+            "KC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2USMgoP",
+            "YmVmb3JlX3Bvc2l0aW9uGAQgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0",
+            "b3I0EjIKD2JlZm9yZV9yb3RhdGlvbhgFIAEoCzIZLnNhaWxvci5lZGl0b3Iu",
+            "djEuVmVjdG9yNBIvCgxiZWZvcmVfc2NhbGUYBiABKAsyGS5zYWlsb3IuZWRp",
+            "dG9yLnYxLlZlY3RvcjQSMQoOYWZ0ZXJfcG9zaXRpb24YByABKAsyGS5zYWls",
+            "b3IuZWRpdG9yLnYxLlZlY3RvcjQSMQoOYWZ0ZXJfcm90YXRpb24YCCABKAsy",
+            "GS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQSLgoLYWZ0ZXJfc2NhbGUYCSAB",
+            "KAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQiVQoWVmlld3BvcnRBc3Nl",
+            "dERyb3BFdmVudBIPCgdmaWxlX2lkGAEgASgJEhQKDG5vcm1hbGl6ZWRfeBgC",
+            "IAEoAhIUCgxub3JtYWxpemVkX3kYAyABKAIiLQoZVmlld3BvcnRUb29sU2hv",
+            "cnRjdXRFdmVudBIQCghrZXlfY29kZRgBIAEoDSLZAgoNVmlld3BvcnRFdmVu",
+            "dBIQCghyZXZpc2lvbhgBIAEoBBIhChltYW5hZ2VkX211dGF0aW9uX3Jldmlz",
+            "aW9uGAIgASgEEj0KCXNlbGVjdGlvbhgKIAEoCzIoLnNhaWxvci5lZGl0b3Iu",
+            "djEuVmlld3BvcnRTZWxlY3Rpb25FdmVudEgAEj0KCXRyYW5zZm9ybRgLIAEo",
+            "CzIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1FdmVudEgA",
+            "Ej4KCmFzc2V0X2Ryb3AYDCABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdw",
+            "b3J0QXNzZXREcm9wRXZlbnRIABJECg10b29sX3Nob3J0Y3V0GA0gASgLMisu",
+            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRvb2xTaG9ydGN1dEV2ZW50SABC",
+            "CQoHcGF5bG9hZEoECAMQCiJLChhWaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHQS",
+            "LwoGZXZlbnRzGAEgAygLMh8uc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEV2",
+            "ZW50KvABChpWaWV3cG9ydFRyYW5zZm9ybU9wZXJhdGlvbhIsCihWSUVXUE9S",
+            "VF9UUkFOU0ZPUk1fT1BFUkFUSU9OX1VOU1BFQ0lGSUVEEAASJwojVklFV1BP",
+            "UlRfVFJBTlNGT1JNX09QRVJBVElPTl9TRUxFQ1QQARIqCiZWSUVXUE9SVF9U",
+            "UkFOU0ZPUk1fT1BFUkFUSU9OX1RSQU5TTEFURRACEicKI1ZJRVdQT1JUX1RS",
+            "QU5TRk9STV9PUEVSQVRJT05fUk9UQVRFEAMSJgoiVklFV1BPUlRfVFJBTlNG",
+            "T1JNX09QRVJBVElPTl9TQ0FMRRAEKooBChZWaWV3cG9ydFRyYW5zZm9ybVNw",
+            "YWNlEigKJFZJRVdQT1JUX1RSQU5TRk9STV9TUEFDRV9VTlNQRUNJRklFRBAA",
+            "EiIKHlZJRVdQT1JUX1RSQU5TRk9STV9TUEFDRV9XT1JMRBABEiIKHlZJRVdQ",
+            "T1JUX1RSQU5TRk9STV9TUEFDRV9MT0NBTBACQiKqAh9TYWlsb3JFZGl0b3Iu",
+            "UHJvdG9jb2wuR2VuZXJhdGVkYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::SailorEditor.Protocol.Generated.ViewportTransformOperation), typeof(global::SailorEditor.Protocol.Generated.ViewportTransformSpace), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Empty), global::SailorEditor.Protocol.Generated.Empty.Parser, null, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset" }, new[]{ "Command" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset", "CreateModelInstance" }, new[]{ "Command" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "SupportsStrictInstanceIds", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult", "Vector4Result", "ViewportToolStateResult" }, new[]{ "Result" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InitializeRequest), global::SailorEditor.Protocol.Generated.InitializeRequest.Parser, new[]{ "Arguments" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CountRequest), global::SailorEditor.Protocol.Generated.CountRequest.Parser, new[]{ "MaxCount" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.FileIdRequest), global::SailorEditor.Protocol.Generated.FileIdRequest.Parser, new[]{ "FileId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CreateModelInstanceRequest), global::SailorEditor.Protocol.Generated.CreateModelInstanceRequest.Parser, new[]{ "ModelFileId", "Name", "ParentInstanceId", "CreateHierarchy", "ApplyWorldPosition", "WorldPosition", "PreferredInstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstanceIdRequest), global::SailorEditor.Protocol.Generated.InstanceIdRequest.Parser, new[]{ "InstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportIdRequest), global::SailorEditor.Protocol.Generated.ViewportIdRequest.Parser, new[]{ "ViewportId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportRectRequest), global::SailorEditor.Protocol.Generated.ViewportRectRequest.Parser, new[]{ "WindowPosX", "WindowPosY", "Width", "Height" }, null, null, null, null),
@@ -628,6 +636,9 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case CommandOneofCase.UpdateAsset:
           UpdateAsset = other.UpdateAsset.Clone();
+          break;
+        case CommandOneofCase.CreateModelInstance:
+          CreateModelInstance = other.CreateModelInstance.Clone();
           break;
       }
 
@@ -1228,6 +1239,18 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "create_model_instance" field.</summary>
+    public const int CreateModelInstanceFieldNumber = 58;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.CreateModelInstanceRequest CreateModelInstance {
+      get { return commandCase_ == CommandOneofCase.CreateModelInstance ? (global::SailorEditor.Protocol.Generated.CreateModelInstanceRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.CreateModelInstance;
+      }
+    }
+
     private object command_;
     /// <summary>Enum of possible cases for the "command" oneof.</summary>
     public enum CommandOneofCase {
@@ -1279,6 +1302,7 @@ namespace SailorEditor.Protocol.Generated {
       SetViewportToolState = 55,
       GetViewportToolState = 56,
       UpdateAsset = 57,
+      CreateModelInstance = 58,
     }
     private CommandOneofCase commandCase_ = CommandOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1358,6 +1382,7 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(SetViewportToolState, other.SetViewportToolState)) return false;
       if (!object.Equals(GetViewportToolState, other.GetViewportToolState)) return false;
       if (!object.Equals(UpdateAsset, other.UpdateAsset)) return false;
+      if (!object.Equals(CreateModelInstance, other.CreateModelInstance)) return false;
       if (CommandCase != other.CommandCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -1415,6 +1440,7 @@ namespace SailorEditor.Protocol.Generated {
       if (commandCase_ == CommandOneofCase.SetViewportToolState) hash ^= SetViewportToolState.GetHashCode();
       if (commandCase_ == CommandOneofCase.GetViewportToolState) hash ^= GetViewportToolState.GetHashCode();
       if (commandCase_ == CommandOneofCase.UpdateAsset) hash ^= UpdateAsset.GetHashCode();
+      if (commandCase_ == CommandOneofCase.CreateModelInstance) hash ^= CreateModelInstance.GetHashCode();
       hash ^= (int) commandCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -1630,6 +1656,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(202, 3);
         output.WriteMessage(UpdateAsset);
       }
+      if (commandCase_ == CommandOneofCase.CreateModelInstance) {
+        output.WriteRawTag(210, 3);
+        output.WriteMessage(CreateModelInstance);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1836,6 +1866,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(202, 3);
         output.WriteMessage(UpdateAsset);
       }
+      if (commandCase_ == CommandOneofCase.CreateModelInstance) {
+        output.WriteRawTag(210, 3);
+        output.WriteMessage(CreateModelInstance);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -1992,6 +2026,9 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (commandCase_ == CommandOneofCase.UpdateAsset) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(UpdateAsset);
+      }
+      if (commandCase_ == CommandOneofCase.CreateModelInstance) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(CreateModelInstance);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -2293,6 +2330,12 @@ namespace SailorEditor.Protocol.Generated {
             UpdateAsset = new global::SailorEditor.Protocol.Generated.FileIdRequest();
           }
           UpdateAsset.MergeFrom(other.UpdateAsset);
+          break;
+        case CommandOneofCase.CreateModelInstance:
+          if (CreateModelInstance == null) {
+            CreateModelInstance = new global::SailorEditor.Protocol.Generated.CreateModelInstanceRequest();
+          }
+          CreateModelInstance.MergeFrom(other.CreateModelInstance);
           break;
       }
 
@@ -2746,6 +2789,15 @@ namespace SailorEditor.Protocol.Generated {
             UpdateAsset = subBuilder;
             break;
           }
+          case 466: {
+            global::SailorEditor.Protocol.Generated.CreateModelInstanceRequest subBuilder = new global::SailorEditor.Protocol.Generated.CreateModelInstanceRequest();
+            if (commandCase_ == CommandOneofCase.CreateModelInstance) {
+              subBuilder.MergeFrom(CreateModelInstance);
+            }
+            input.ReadMessage(subBuilder);
+            CreateModelInstance = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -3194,6 +3246,15 @@ namespace SailorEditor.Protocol.Generated {
             }
             input.ReadMessage(subBuilder);
             UpdateAsset = subBuilder;
+            break;
+          }
+          case 466: {
+            global::SailorEditor.Protocol.Generated.CreateModelInstanceRequest subBuilder = new global::SailorEditor.Protocol.Generated.CreateModelInstanceRequest();
+            if (commandCase_ == CommandOneofCase.CreateModelInstance) {
+              subBuilder.MergeFrom(CreateModelInstance);
+            }
+            input.ReadMessage(subBuilder);
+            CreateModelInstance = subBuilder;
             break;
           }
         }
@@ -4796,6 +4857,435 @@ namespace SailorEditor.Protocol.Generated {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class CreateModelInstanceRequest : pb::IMessage<CreateModelInstanceRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<CreateModelInstanceRequest> _parser = new pb::MessageParser<CreateModelInstanceRequest>(() => new CreateModelInstanceRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<CreateModelInstanceRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[6]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public CreateModelInstanceRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public CreateModelInstanceRequest(CreateModelInstanceRequest other) : this() {
+      modelFileId_ = other.modelFileId_;
+      name_ = other.name_;
+      parentInstanceId_ = other.parentInstanceId_;
+      createHierarchy_ = other.createHierarchy_;
+      applyWorldPosition_ = other.applyWorldPosition_;
+      worldPosition_ = other.worldPosition_ != null ? other.worldPosition_.Clone() : null;
+      preferredInstanceId_ = other.preferredInstanceId_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public CreateModelInstanceRequest Clone() {
+      return new CreateModelInstanceRequest(this);
+    }
+
+    /// <summary>Field number for the "model_file_id" field.</summary>
+    public const int ModelFileIdFieldNumber = 1;
+    private string modelFileId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string ModelFileId {
+      get { return modelFileId_; }
+      set {
+        modelFileId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "name" field.</summary>
+    public const int NameFieldNumber = 2;
+    private string name_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Name {
+      get { return name_; }
+      set {
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "parent_instance_id" field.</summary>
+    public const int ParentInstanceIdFieldNumber = 3;
+    private string parentInstanceId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string ParentInstanceId {
+      get { return parentInstanceId_; }
+      set {
+        parentInstanceId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "create_hierarchy" field.</summary>
+    public const int CreateHierarchyFieldNumber = 4;
+    private bool createHierarchy_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool CreateHierarchy {
+      get { return createHierarchy_; }
+      set {
+        createHierarchy_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "apply_world_position" field.</summary>
+    public const int ApplyWorldPositionFieldNumber = 5;
+    private bool applyWorldPosition_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool ApplyWorldPosition {
+      get { return applyWorldPosition_; }
+      set {
+        applyWorldPosition_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "world_position" field.</summary>
+    public const int WorldPositionFieldNumber = 6;
+    private global::SailorEditor.Protocol.Generated.Vector4 worldPosition_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.Vector4 WorldPosition {
+      get { return worldPosition_; }
+      set {
+        worldPosition_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "preferred_instance_id" field.</summary>
+    public const int PreferredInstanceIdFieldNumber = 7;
+    private string preferredInstanceId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string PreferredInstanceId {
+      get { return preferredInstanceId_; }
+      set {
+        preferredInstanceId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as CreateModelInstanceRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(CreateModelInstanceRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (ModelFileId != other.ModelFileId) return false;
+      if (Name != other.Name) return false;
+      if (ParentInstanceId != other.ParentInstanceId) return false;
+      if (CreateHierarchy != other.CreateHierarchy) return false;
+      if (ApplyWorldPosition != other.ApplyWorldPosition) return false;
+      if (!object.Equals(WorldPosition, other.WorldPosition)) return false;
+      if (PreferredInstanceId != other.PreferredInstanceId) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (ModelFileId.Length != 0) hash ^= ModelFileId.GetHashCode();
+      if (Name.Length != 0) hash ^= Name.GetHashCode();
+      if (ParentInstanceId.Length != 0) hash ^= ParentInstanceId.GetHashCode();
+      if (CreateHierarchy != false) hash ^= CreateHierarchy.GetHashCode();
+      if (ApplyWorldPosition != false) hash ^= ApplyWorldPosition.GetHashCode();
+      if (worldPosition_ != null) hash ^= WorldPosition.GetHashCode();
+      if (PreferredInstanceId.Length != 0) hash ^= PreferredInstanceId.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (ModelFileId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(ModelFileId);
+      }
+      if (Name.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Name);
+      }
+      if (ParentInstanceId.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(ParentInstanceId);
+      }
+      if (CreateHierarchy != false) {
+        output.WriteRawTag(32);
+        output.WriteBool(CreateHierarchy);
+      }
+      if (ApplyWorldPosition != false) {
+        output.WriteRawTag(40);
+        output.WriteBool(ApplyWorldPosition);
+      }
+      if (worldPosition_ != null) {
+        output.WriteRawTag(50);
+        output.WriteMessage(WorldPosition);
+      }
+      if (PreferredInstanceId.Length != 0) {
+        output.WriteRawTag(58);
+        output.WriteString(PreferredInstanceId);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (ModelFileId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(ModelFileId);
+      }
+      if (Name.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Name);
+      }
+      if (ParentInstanceId.Length != 0) {
+        output.WriteRawTag(26);
+        output.WriteString(ParentInstanceId);
+      }
+      if (CreateHierarchy != false) {
+        output.WriteRawTag(32);
+        output.WriteBool(CreateHierarchy);
+      }
+      if (ApplyWorldPosition != false) {
+        output.WriteRawTag(40);
+        output.WriteBool(ApplyWorldPosition);
+      }
+      if (worldPosition_ != null) {
+        output.WriteRawTag(50);
+        output.WriteMessage(WorldPosition);
+      }
+      if (PreferredInstanceId.Length != 0) {
+        output.WriteRawTag(58);
+        output.WriteString(PreferredInstanceId);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (ModelFileId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ModelFileId);
+      }
+      if (Name.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+      }
+      if (ParentInstanceId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ParentInstanceId);
+      }
+      if (CreateHierarchy != false) {
+        size += 1 + 1;
+      }
+      if (ApplyWorldPosition != false) {
+        size += 1 + 1;
+      }
+      if (worldPosition_ != null) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(WorldPosition);
+      }
+      if (PreferredInstanceId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(PreferredInstanceId);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(CreateModelInstanceRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.ModelFileId.Length != 0) {
+        ModelFileId = other.ModelFileId;
+      }
+      if (other.Name.Length != 0) {
+        Name = other.Name;
+      }
+      if (other.ParentInstanceId.Length != 0) {
+        ParentInstanceId = other.ParentInstanceId;
+      }
+      if (other.CreateHierarchy != false) {
+        CreateHierarchy = other.CreateHierarchy;
+      }
+      if (other.ApplyWorldPosition != false) {
+        ApplyWorldPosition = other.ApplyWorldPosition;
+      }
+      if (other.worldPosition_ != null) {
+        if (worldPosition_ == null) {
+          WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
+        }
+        WorldPosition.MergeFrom(other.WorldPosition);
+      }
+      if (other.PreferredInstanceId.Length != 0) {
+        PreferredInstanceId = other.PreferredInstanceId;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            ModelFileId = input.ReadString();
+            break;
+          }
+          case 18: {
+            Name = input.ReadString();
+            break;
+          }
+          case 26: {
+            ParentInstanceId = input.ReadString();
+            break;
+          }
+          case 32: {
+            CreateHierarchy = input.ReadBool();
+            break;
+          }
+          case 40: {
+            ApplyWorldPosition = input.ReadBool();
+            break;
+          }
+          case 50: {
+            if (worldPosition_ == null) {
+              WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
+            }
+            input.ReadMessage(WorldPosition);
+            break;
+          }
+          case 58: {
+            PreferredInstanceId = input.ReadString();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            ModelFileId = input.ReadString();
+            break;
+          }
+          case 18: {
+            Name = input.ReadString();
+            break;
+          }
+          case 26: {
+            ParentInstanceId = input.ReadString();
+            break;
+          }
+          case 32: {
+            CreateHierarchy = input.ReadBool();
+            break;
+          }
+          case 40: {
+            ApplyWorldPosition = input.ReadBool();
+            break;
+          }
+          case 50: {
+            if (worldPosition_ == null) {
+              WorldPosition = new global::SailorEditor.Protocol.Generated.Vector4();
+            }
+            input.ReadMessage(WorldPosition);
+            break;
+          }
+          case 58: {
+            PreferredInstanceId = input.ReadString();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class InstanceIdRequest : pb::IMessage<InstanceIdRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -4810,7 +5300,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[6]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[7]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5008,7 +5498,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[7]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[8]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5206,7 +5696,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[8]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[9]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5515,7 +6005,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[9]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[10]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -5750,7 +6240,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[10]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[11]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6170,7 +6660,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[11]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[12]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6442,7 +6932,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[12]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[13]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7047,7 +7537,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[13]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[14]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7282,7 +7772,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[14]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[15]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7517,7 +8007,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[15]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[16]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7789,7 +8279,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[16]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[17]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8024,7 +8514,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[17]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[18]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8296,7 +8786,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[18]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[19]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8531,7 +9021,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[19]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8803,7 +9293,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9075,7 +9565,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9393,7 +9883,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9628,7 +10118,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9863,7 +10353,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10135,7 +10625,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10322,7 +10812,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10520,7 +11010,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10866,7 +11356,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11064,7 +11554,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11262,7 +11752,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11460,7 +11950,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11658,7 +12148,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11893,7 +12383,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12080,7 +12570,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12389,7 +12879,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12624,7 +13114,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12831,7 +13321,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13066,7 +13556,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13375,7 +13865,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13573,7 +14063,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14121,7 +14611,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14393,7 +14883,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14591,7 +15081,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15065,7 +15555,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/Editor/Services/AssetCacheIndexStore.cs
+++ b/Editor/Services/AssetCacheIndexStore.cs
@@ -1,0 +1,330 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text;
+using YamlDotNet.Core;
+using YamlDotNet.RepresentationModel;
+
+namespace SailorEditor.Services;
+
+internal enum AssetCacheIndexStatus
+{
+    Missing,
+    Loaded,
+    Corrupt,
+    UnsupportedVersion,
+    IoFailure
+}
+
+internal sealed record AssetCacheIndexEntry(
+    string FileId,
+    string SourcePath,
+    string MetadataFilename,
+    string AssetInfoType);
+
+internal sealed record AssetCacheIndexLoadResult(
+    AssetCacheIndexStatus Status,
+    string Diagnostic,
+    IReadOnlyList<AssetCacheIndexEntry>? Entries = null)
+{
+    public bool Succeeded => Status == AssetCacheIndexStatus.Loaded && Entries is not null;
+}
+
+internal sealed class AssetCacheIndexStore
+{
+    internal const int CurrentCacheVersion = 1;
+    internal const int CurrentPayloadVersion = 1;
+    internal const string CacheKind = "asset-cache";
+    internal const string ProducerIdentity = "asset-cache-v1";
+
+    static readonly string[] EnvelopeFields =
+    [
+        "cacheVersion",
+        "payloadVersion",
+        "cacheKind",
+        "workspaceId",
+        "engineVersion",
+        "buildIdentity",
+        "producerIdentity",
+        "payload"
+    ];
+
+    static readonly string[] EntryFields =
+    [
+        "fileId",
+        "assetImportTime",
+        "sourcePath",
+        "sourceRevision",
+        "metadataFilename",
+        "metadataRevision",
+        "assetInfoType"
+    ];
+
+    static readonly UTF8Encoding Utf8WithoutBom = new(false, true);
+
+    public AssetCacheIndexLoadResult Load(
+        string cacheFilePath,
+        string expectedWorkspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        var fullPath = Path.GetFullPath(cacheFilePath);
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var yaml = File.ReadAllText(fullPath, Utf8WithoutBom);
+            return Parse(fullPath, yaml, expectedWorkspaceId, cancellationToken);
+        }
+        catch (FileNotFoundException)
+        {
+            return Missing(fullPath);
+        }
+        catch (DirectoryNotFoundException)
+        {
+            return Missing(fullPath);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (DecoderFallbackException exception)
+        {
+            return Corrupt(fullPath, $"The file is not valid UTF-8: {exception.Message}");
+        }
+        catch (Exception exception)
+        {
+            return new AssetCacheIndexLoadResult(
+                AssetCacheIndexStatus.IoFailure,
+                $"Cannot read asset cache index '{fullPath}': {exception.Message}");
+        }
+    }
+
+    internal static AssetCacheIndexLoadResult Parse(
+        string cacheFilePath,
+        string yaml,
+        string expectedWorkspaceId,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var envelope = ReadStrictFields(
+                RequireMapping(LoadSingleDocument(yaml).RootNode, "Asset cache envelope"),
+                "Asset cache envelope");
+
+            if (!TryReadVersion(envelope, "cacheVersion", out var cacheVersion) ||
+                cacheVersion != CurrentCacheVersion)
+            {
+                return Unsupported(
+                    cacheFilePath,
+                    $"cacheVersion must be {CurrentCacheVersion}.");
+            }
+            if (!TryReadVersion(envelope, "payloadVersion", out var payloadVersion) ||
+                payloadVersion != CurrentPayloadVersion)
+            {
+                return Unsupported(
+                    cacheFilePath,
+                    $"payloadVersion must be {CurrentPayloadVersion}.");
+            }
+
+            RequireExactFields(envelope, EnvelopeFields, "Asset cache envelope");
+            RequireScalar(envelope, "cacheKind", CacheKind);
+            RequireScalar(envelope, "producerIdentity", ProducerIdentity);
+            RequireScalar(envelope, "workspaceId", expectedWorkspaceId);
+            _ = RequireScalar(envelope, "engineVersion");
+            _ = RequireScalar(envelope, "buildIdentity");
+            var payload = RequireScalar(envelope, "payload");
+
+            var payloadRoot = ReadStrictFields(
+                RequireMapping(LoadSingleDocument(payload).RootNode, "Asset cache payload"),
+                "Asset cache payload");
+            RequireExactFields(payloadRoot, ["assetCache"], "Asset cache payload");
+            var cacheRoot = ReadStrictFields(
+                RequireMapping(payloadRoot["assetCache"], "assetCache"),
+                "assetCache");
+            RequireExactFields(cacheRoot, ["assets"], "assetCache");
+            var assets = RequireMapping(cacheRoot["assets"], "assetCache.assets");
+
+            var entries = new List<AssetCacheIndexEntry>(assets.Children.Count);
+            var fileIds = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var pair in assets.Children)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var mapFileId = RequireScalar(pair.Key, "assetCache.assets key");
+                var fields = ReadStrictFields(
+                    RequireMapping(pair.Value, $"assetCache.assets.{mapFileId}"),
+                    $"assetCache.assets.{mapFileId}");
+                RequireExactFields(fields, EntryFields, $"assetCache.assets.{mapFileId}");
+
+                var fileId = RequireScalar(fields, "fileId");
+                var sourcePath = RequireScalar(fields, "sourcePath");
+                var metadataFilename = RequireScalar(fields, "metadataFilename");
+                var assetInfoType = RequireScalar(fields, "assetInfoType");
+                _ = RequireScalar(fields, "assetImportTime");
+                ValidateRevision(fields["sourceRevision"], "sourceRevision");
+                ValidateRevision(fields["metadataRevision"], "metadataRevision");
+
+                if (!string.Equals(fileId, mapFileId, StringComparison.Ordinal) ||
+                    !fileIds.Add(fileId))
+                {
+                    throw new InvalidDataException(
+                        $"Asset cache entry '{mapFileId}' has a duplicate or mismatched fileId.");
+                }
+                if (!string.Equals(
+                        Path.GetFileName(metadataFilename),
+                        metadataFilename,
+                        StringComparison.Ordinal))
+                {
+                    throw new InvalidDataException(
+                        $"Asset cache entry '{mapFileId}' metadataFilename must be a filename.");
+                }
+
+                entries.Add(new AssetCacheIndexEntry(
+                    fileId,
+                    Path.GetFullPath(sourcePath),
+                    metadataFilename,
+                    assetInfoType));
+            }
+
+            return new AssetCacheIndexLoadResult(
+                AssetCacheIndexStatus.Loaded,
+                $"Loaded {entries.Count.ToString(CultureInfo.InvariantCulture)} asset cache index entries from '{cacheFilePath}'.",
+                entries);
+        }
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception exception) when (exception is YamlException or InvalidDataException or IOException or ArgumentException or NotSupportedException)
+        {
+            return Corrupt(cacheFilePath, exception.Message);
+        }
+    }
+
+    static void ValidateRevision(YamlNode node, string fieldName)
+    {
+        var fields = ReadStrictFields(RequireMapping(node, fieldName), fieldName);
+        RequireExactFields(
+            fields,
+            ["modificationTimeNanoseconds", "fileSize", "contentHash"],
+            fieldName);
+        _ = RequireScalar(fields, "modificationTimeNanoseconds");
+        _ = RequireScalar(fields, "fileSize");
+        _ = RequireScalar(fields, "contentHash");
+    }
+
+    static YamlDocument LoadSingleDocument(string yaml)
+    {
+        if (string.IsNullOrWhiteSpace(yaml))
+        {
+            throw new InvalidDataException("The YAML document is empty.");
+        }
+
+        var stream = new YamlStream();
+        using var reader = new StringReader(yaml);
+        stream.Load(reader);
+        if (stream.Documents.Count != 1)
+        {
+            throw new InvalidDataException("The YAML input must contain exactly one document.");
+        }
+        return stream.Documents[0];
+    }
+
+    static YamlMappingNode RequireMapping(YamlNode node, string name)
+        => node as YamlMappingNode
+            ?? throw new InvalidDataException($"{name} must be a mapping.");
+
+    static Dictionary<string, YamlNode> ReadStrictFields(
+        YamlMappingNode mapping,
+        string name)
+    {
+        var result = new Dictionary<string, YamlNode>(StringComparer.Ordinal);
+        foreach (var pair in mapping.Children)
+        {
+            var fieldName = RequireScalar(pair.Key, $"{name} field name");
+            if (!result.TryAdd(fieldName, pair.Value))
+            {
+                throw new InvalidDataException($"{name} contains duplicate field '{fieldName}'.");
+            }
+        }
+        return result;
+    }
+
+    static void RequireExactFields(
+        IReadOnlyDictionary<string, YamlNode> fields,
+        IReadOnlyCollection<string> requiredFields,
+        string name)
+    {
+        foreach (var requiredField in requiredFields)
+        {
+            if (!fields.ContainsKey(requiredField))
+            {
+                throw new InvalidDataException($"{name} is missing required field '{requiredField}'.");
+            }
+        }
+        if (fields.Count != requiredFields.Count)
+        {
+            var unknown = fields.Keys
+                .Except(requiredFields, StringComparer.Ordinal)
+                .OrderBy(value => value, StringComparer.Ordinal)
+                .First();
+            throw new InvalidDataException($"{name} contains unknown field '{unknown}'.");
+        }
+    }
+
+    static bool TryReadVersion(
+        IReadOnlyDictionary<string, YamlNode> fields,
+        string fieldName,
+        out int version)
+    {
+        version = 0;
+        return fields.TryGetValue(fieldName, out var node) &&
+            int.TryParse(
+                (node as YamlScalarNode)?.Value,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out version);
+    }
+
+    static string RequireScalar(
+        IReadOnlyDictionary<string, YamlNode> fields,
+        string fieldName,
+        string? expectedValue = null)
+    {
+        if (!fields.TryGetValue(fieldName, out var node))
+        {
+            throw new InvalidDataException($"Required field '{fieldName}' is missing.");
+        }
+        var value = RequireScalar(node, fieldName);
+        if (expectedValue is not null &&
+            !string.Equals(value, expectedValue, StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"Field '{fieldName}' must be '{expectedValue}', found '{value}'.");
+        }
+        return value;
+    }
+
+    static string RequireScalar(YamlNode node, string name)
+    {
+        if (node is not YamlScalarNode scalar || string.IsNullOrWhiteSpace(scalar.Value))
+        {
+            throw new InvalidDataException($"{name} must be a non-empty scalar.");
+        }
+        return scalar.Value;
+    }
+
+    static AssetCacheIndexLoadResult Missing(string cacheFilePath)
+        => new(
+            AssetCacheIndexStatus.Missing,
+            $"Asset cache index is missing: '{cacheFilePath}'.");
+
+    static AssetCacheIndexLoadResult Unsupported(string cacheFilePath, string reason)
+        => new(
+            AssetCacheIndexStatus.UnsupportedVersion,
+            $"Asset cache index '{cacheFilePath}' is unsupported: {reason}");
+
+    static AssetCacheIndexLoadResult Corrupt(string cacheFilePath, string reason)
+        => new(
+            AssetCacheIndexStatus.Corrupt,
+            $"Asset cache index '{cacheFilePath}' is corrupt: {reason}");
+}

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -27,13 +27,17 @@ namespace SailorEditor.Services
         readonly object _watcherLock = new();
         readonly List<FileSystemWatcher> _contentWatchers = [];
         readonly SemaphoreSlim _assetSaveLock = new(1, 1);
+        readonly SemaphoreSlim _folderLoadLock = new(1, 1);
+        readonly AssetCacheIndexStore _assetCacheIndexStore = new();
         EngineLaunchContext? _activeLaunchContext;
         CancellationTokenSource? _pendingFilesystemReload;
+        CancellationTokenSource? _assetCacheIndexLoadCancellation;
         ProjectContentFolderIdAllocator _folderIdAllocator = new();
         HashSet<string> _visitedDirectories = new(ProjectContentPathPolicy.PathComparer);
         int _nextAssetId = 1;
         int _assetOverrideCount;
         long _workspaceEpoch;
+        long _contentGeneration;
 
         public event Action? Changed;
 
@@ -56,7 +60,7 @@ namespace SailorEditor.Services
             AddProjectRoot(engineService.GetLaunchContext());
         }
 
-        void HandleAssetReloadCompleted(AssetReloadCompletion completion)
+        async void HandleAssetReloadCompleted(AssetReloadCompletion completion)
         {
             if (!completion.Succeeded || _activeLaunchContext is null)
             {
@@ -67,18 +71,22 @@ namespace SailorEditor.Services
             {
                 var selectionService = MauiProgram.GetService<SelectionService>();
                 var selectedAssetId = (selectionService.SelectedItem as AssetFile)?.FileId;
-                Refresh();
-                if (selectedAssetId is not null && !selectedAssetId.IsEmpty())
+                await RefreshAsync();
+                await MainThread.InvokeOnMainThreadAsync(() =>
                 {
+                    if (selectedAssetId is null || selectedAssetId.IsEmpty())
+                    {
+                        return;
+                    }
+
                     if (Assets.TryGetValue(selectedAssetId, out var refreshedAsset))
                     {
                         selectionService.SelectObject(refreshedAsset, force: true);
+                        return;
                     }
-                    else
-                    {
-                        selectionService.ClearSelection();
-                    }
-                }
+
+                    selectionService.ClearSelection();
+                });
             }
             catch (Exception exception)
             {
@@ -573,12 +581,105 @@ namespace SailorEditor.Services
             if (_activeLaunchContext is null)
                 return;
 
+            var loadedFolders = Folders
+                .Where(folder => folder.IsLoaded)
+                .Select(folder => (folder.ProjectRootId, folder.FullPath))
+                .OrderBy(folder => folder.FullPath.Count(character => character == Path.DirectorySeparatorChar))
+                .ToArray();
             AddProjectRoot(_activeLaunchContext);
+            foreach (var loadedFolder in loadedFolders)
+            {
+                var folder = Folders.FirstOrDefault(candidate =>
+                    candidate.ProjectRootId == loadedFolder.ProjectRootId &&
+                    ProjectContentPathPolicy.IsSamePath(candidate.FullPath, loadedFolder.FullPath));
+                if (folder is not null)
+                {
+                    MergeFolderSnapshot(folder, ReadDirectoryLevel(folder));
+                }
+            }
+            Changed?.Invoke();
+        }
+
+        public async Task RefreshAsync(CancellationToken cancellationToken = default)
+        {
+            if (_activeLaunchContext is null)
+            {
+                return;
+            }
+
+            var launchContext = _activeLaunchContext;
+            var loadedFolders = Folders
+                .Where(folder => folder.IsLoaded)
+                .Select(folder => (folder.ProjectRootId, folder.FullPath))
+                .OrderBy(folder => folder.FullPath.Count(character => character == Path.DirectorySeparatorChar))
+                .ToArray();
+            await MainThread.InvokeOnMainThreadAsync(() => AddProjectRoot(launchContext));
+            foreach (var loadedFolder in loadedFolders)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var folderId = await MainThread.InvokeOnMainThreadAsync(() =>
+                    Folders.FirstOrDefault(candidate =>
+                        candidate.ProjectRootId == loadedFolder.ProjectRootId &&
+                        ProjectContentPathPolicy.IsSamePath(candidate.FullPath, loadedFolder.FullPath))?.Id);
+                if (folderId is not null)
+                {
+                    await EnsureFolderLoadedAsync(folderId.Value, cancellationToken).ConfigureAwait(false);
+                }
+            }
+        }
+
+        public async Task EnsureFolderLoadedAsync(
+            int folderId,
+            CancellationToken cancellationToken = default)
+        {
+            var generation = Interlocked.Read(ref _contentGeneration);
+            var folder = await MainThread.InvokeOnMainThreadAsync(() =>
+                Folders.FirstOrDefault(candidate => candidate.Id == folderId));
+            if (folder is null || folder.IsLoaded)
+            {
+                return;
+            }
+
+            await _folderLoadLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                folder = await MainThread.InvokeOnMainThreadAsync(() =>
+                    Folders.FirstOrDefault(candidate => candidate.Id == folderId));
+                if (folder is null || folder.IsLoaded ||
+                    generation != Interlocked.Read(ref _contentGeneration))
+                {
+                    return;
+                }
+
+                var snapshot = await Task.Run(
+                    () => ReadDirectoryLevel(folder),
+                    cancellationToken).ConfigureAwait(false);
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    if (generation != Interlocked.Read(ref _contentGeneration))
+                    {
+                        return;
+                    }
+                    var liveFolder = Folders.FirstOrDefault(candidate => candidate.Id == folderId);
+                    if (liveFolder is null || liveFolder.IsLoaded)
+                    {
+                        return;
+                    }
+                    MergeFolderSnapshot(liveFolder, snapshot);
+                    Changed?.Invoke();
+                });
+            }
+            finally
+            {
+                _folderLoadLock.Release();
+            }
         }
 
         public void ResetForWorkspaceChange()
         {
             Interlocked.Increment(ref _workspaceEpoch);
+            Interlocked.Increment(ref _contentGeneration);
+            CancelAssetCacheIndexLoad();
             DisposeContentWatchers();
             Root = new ProjectRoot { Name = string.Empty, Id = ActiveProjectRootId };
             Folders = [];
@@ -599,6 +700,12 @@ namespace SailorEditor.Services
 
             ArgumentNullException.ThrowIfNull(launchContext);
             var launchContextChanged = _activeLaunchContext is null || _activeLaunchContext != launchContext;
+            if (launchContextChanged)
+            {
+                Interlocked.Increment(ref _workspaceEpoch);
+            }
+            var contentGeneration = Interlocked.Increment(ref _contentGeneration);
+            CancelAssetCacheIndexLoad();
             var requestedRoot = Path.GetFullPath(launchContext.ContentDirectory);
             if (!Directory.Exists(requestedRoot))
             {
@@ -631,13 +738,11 @@ namespace SailorEditor.Services
                 var engineRoot = new ProjectRoot { Name = "Engine Content", Id = EngineProjectRootId };
 
                 AddContentRootFolder(engineRoot, ProjectContentFolderIds.EngineContentRootId, _engineContentDirectory, isReadOnly: false);
-                ReadDirectory(engineRoot, _engineContentDirectory, _engineContentDirectory, ProjectContentFolderIds.EngineContentRootId, useRootedFolderIds: true, isReadOnly: false);
             }
             else if (ProjectContentPathPolicy.IsSamePath(CurrentProjectRootPath, _engineContentDirectory))
             {
                 var workspaceRoot = new ProjectRoot { Name = "Content", Id = ActiveProjectRootId };
                 AddContentRootFolder(workspaceRoot, ProjectContentFolderIds.ContentRootId, CurrentProjectRootPath, isReadOnly: false);
-                ReadDirectory(workspaceRoot, CurrentProjectRootPath, CurrentProjectRootPath, ProjectContentFolderIds.ContentRootId, useRootedFolderIds: true, isReadOnly: false);
             }
             else
             {
@@ -646,9 +751,6 @@ namespace SailorEditor.Services
 
                 AddContentRootFolder(workspaceRoot, ProjectContentFolderIds.ContentRootId, CurrentProjectRootPath, isReadOnly: false);
                 AddContentRootFolder(engineRoot, ProjectContentFolderIds.EngineContentRootId, _engineContentDirectory, isReadOnly: true);
-
-                ReadDirectory(engineRoot, _engineContentDirectory, _engineContentDirectory, ProjectContentFolderIds.EngineContentRootId, useRootedFolderIds: true, isReadOnly: true);
-                ReadDirectory(workspaceRoot, CurrentProjectRootPath, CurrentProjectRootPath, ProjectContentFolderIds.ContentRootId, useRootedFolderIds: true, isReadOnly: false);
             }
 
             if (_assetOverrideCount > 0)
@@ -660,7 +762,81 @@ namespace SailorEditor.Services
             }
 
             Changed?.Invoke();
+            QueueAssetCacheIndexLoad(launchContext, contentGeneration);
         }
+
+        void QueueAssetCacheIndexLoad(
+            EngineLaunchContext launchContext,
+            long contentGeneration)
+        {
+            var cancellation = new CancellationTokenSource();
+            var previous = Interlocked.Exchange(
+                ref _assetCacheIndexLoadCancellation,
+                cancellation);
+            previous?.Cancel();
+            _ = LoadAssetCacheIndexAsync(
+                launchContext,
+                contentGeneration,
+                cancellation);
+        }
+
+        async Task LoadAssetCacheIndexAsync(
+            EngineLaunchContext launchContext,
+            long contentGeneration,
+            CancellationTokenSource cancellation)
+        {
+            try
+            {
+                var result = await Task.Run(
+                    () => _assetCacheIndexStore.Load(
+                        launchContext.AssetCacheFilePath,
+                        launchContext.WorkspaceIdentity,
+                        cancellation.Token),
+                    cancellation.Token).ConfigureAwait(false);
+                if (!result.Succeeded)
+                {
+                    if (result.Status is not AssetCacheIndexStatus.Missing)
+                    {
+                        Console.WriteLine($"[AssetsService] {result.Diagnostic}");
+                    }
+                    return;
+                }
+
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    if (cancellation.IsCancellationRequested ||
+                        contentGeneration != Interlocked.Read(ref _contentGeneration) ||
+                        _activeLaunchContext != launchContext)
+                    {
+                        return;
+                    }
+
+                    MergeAssetCacheIndex(result.Entries!);
+                    Changed?.Invoke();
+                });
+            }
+            catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+            {
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(
+                    $"[AssetsService] Failed to load asset cache index: {exception.Message}");
+            }
+            finally
+            {
+                Interlocked.CompareExchange(
+                    ref _assetCacheIndexLoadCancellation,
+                    null,
+                    cancellation);
+                cancellation.Dispose();
+            }
+        }
+
+        void CancelAssetCacheIndexLoad()
+            => Interlocked.Exchange(
+                ref _assetCacheIndexLoadCancellation,
+                null)?.Cancel();
 
         void ConfigureContentWatchers(EngineLaunchContext launchContext)
         {
@@ -762,6 +938,7 @@ namespace SailorEditor.Services
         public void Dispose()
         {
             _engineService.OnAssetReloadCompleted -= HandleAssetReloadCompleted;
+            CancelAssetCacheIndexLoad();
             DisposeContentWatchers();
         }
 
@@ -774,8 +951,227 @@ namespace SailorEditor.Services
                 Id = folderId,
                 ParentFolderId = -1,
                 FullPath = rootPath,
-                IsReadOnly = isReadOnly
+                IsReadOnly = isReadOnly,
+                IsLoaded = false,
+                HasChildren = DirectoryMayContainAssets(rootPath)
             });
+        }
+
+        private sealed record FolderLoadSnapshot(
+            IReadOnlyList<AssetFolder> Folders,
+            IReadOnlyList<AssetFile> Files);
+
+        private void MergeAssetCacheIndex(
+            IReadOnlyList<AssetCacheIndexEntry> entries)
+        {
+            foreach (var entry in entries)
+            {
+                if (!TryResolveAssetIndexLocation(
+                        entry,
+                        out var projectRootId,
+                        out var isReadOnly))
+                {
+                    continue;
+                }
+
+                var fileId = new FileId(entry.FileId);
+                var sourceFile = new FileInfo(entry.SourcePath);
+                var indexedFilename = Path.GetFileNameWithoutExtension(
+                    entry.MetadataFilename);
+                var metadataFile = new FileInfo(
+                    Path.Combine(sourceFile.DirectoryName!, entry.MetadataFilename));
+                if (Assets.TryGetValue(fileId, out var existing))
+                {
+                    if ((existing.AssetInfo is not null &&
+                         ProjectContentPathPolicy.IsSamePath(
+                             existing.AssetInfo.FullName,
+                             metadataFile.FullName)) ||
+                        !ProjectContentAssetResolutionPolicy.ShouldReplace(
+                            existing.IsReadOnly,
+                            isReadOnly))
+                    {
+                        continue;
+                    }
+                }
+
+                var indexedAsset = CreateAssetFile(
+                    entry.AssetInfoType,
+                    Path.GetExtension(indexedFilename));
+                indexedAsset.Id = _nextAssetId++;
+                indexedAsset.DisplayName = indexedFilename;
+                indexedAsset.FolderId = -1;
+                indexedAsset.ProjectRootId = projectRootId;
+                indexedAsset.AssetInfo = metadataFile;
+                indexedAsset.Asset = sourceFile;
+                indexedAsset.OwnsSourceFile = string.Equals(
+                    metadataFile.FullName,
+                    sourceFile.FullName + ".asset",
+                    ProjectContentPathPolicy.PathComparison);
+                indexedAsset.FileId = fileId;
+                indexedAsset.Filename = new FileId(indexedFilename);
+                indexedAsset.IsDirty = false;
+                indexedAsset.IsReadOnly = isReadOnly;
+                indexedAsset.IsMetadataLoaded = false;
+                Assets[fileId] = indexedAsset;
+            }
+        }
+
+        private bool TryResolveAssetIndexLocation(
+            AssetCacheIndexEntry entry,
+            out int projectRootId,
+            out bool isReadOnly)
+        {
+            projectRootId = ActiveProjectRootId;
+            isReadOnly = false;
+            if (ProjectContentPathPolicy.IsInsideRoot(
+                    CurrentProjectRootPath,
+                    entry.SourcePath))
+            {
+                return true;
+            }
+
+            if (CurrentProjectMode == EditorProjectMode.Workspace &&
+                ProjectContentPathPolicy.IsInsideRoot(
+                    _engineContentDirectory,
+                    entry.SourcePath))
+            {
+                projectRootId = EngineProjectRootId;
+                isReadOnly = true;
+                return true;
+            }
+
+            return false;
+        }
+
+        private FolderLoadSnapshot ReadDirectoryLevel(AssetFolder parentFolder)
+        {
+            var folders = new List<AssetFolder>();
+            var files = new List<AssetFile>();
+            var rootPath = parentFolder.ProjectRootId == EngineProjectRootId
+                ? _engineContentDirectory
+                : CurrentProjectRootPath;
+            var directoryPath = ProjectContentPathPolicy.NormalizeRoot(parentFolder.FullPath);
+            if (!Directory.Exists(directoryPath) ||
+                !ProjectContentPathPolicy.IsInsideRoot(rootPath, directoryPath))
+            {
+                return new FolderLoadSnapshot(folders, files);
+            }
+
+            foreach (var directory in Directory.GetDirectories(directoryPath)
+                .Order(ProjectContentPathPolicy.PathComparer))
+            {
+                if (ProjectContentInternalPathPolicy.IsTransactionDirectory(directory))
+                {
+                    continue;
+                }
+                var canonicalChildPath = ProjectContentPathPolicy.NormalizeRoot(directory);
+                if (!ProjectContentPathPolicy.IsInsideRoot(rootPath, canonicalChildPath))
+                {
+                    continue;
+                }
+                var relativeDirectoryPath = Path.GetRelativePath(rootPath, canonicalChildPath);
+                folders.Add(new AssetFolder
+                {
+                    ProjectRootId = parentFolder.ProjectRootId,
+                    Name = Path.GetFileName(canonicalChildPath),
+                    Id = _folderIdAllocator.Allocate(
+                        parentFolder.ProjectRootId,
+                        relativeDirectoryPath,
+                        useRootedFolderIds: true),
+                    ParentFolderId = parentFolder.Id,
+                    FullPath = canonicalChildPath,
+                    IsReadOnly = parentFolder.IsReadOnly,
+                    IsLoaded = false,
+                    HasChildren = DirectoryMayContainAssets(canonicalChildPath)
+                });
+            }
+
+            foreach (var file in Directory.GetFiles(directoryPath)
+                .Order(ProjectContentPathPolicy.PathComparer))
+            {
+                if (!ProjectContentPathPolicy.IsInsideRoot(rootPath, file) ||
+                    !string.Equals(Path.GetExtension(file), ".asset", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+                try
+                {
+                    var asset = ReadAssetFile(
+                        new FileInfo(file),
+                        parentFolder.Id,
+                        parentFolder.ProjectRootId,
+                        parentFolder.IsReadOnly);
+                    if (asset.FileId is not null && !asset.FileId.IsEmpty())
+                    {
+                        files.Add(asset);
+                    }
+                }
+                catch (Exception exception)
+                {
+                    Console.WriteLine(exception);
+                }
+            }
+
+            return new FolderLoadSnapshot(folders, files);
+        }
+
+        private void MergeFolderSnapshot(
+            AssetFolder parentFolder,
+            FolderLoadSnapshot snapshot)
+        {
+            foreach (var folder in snapshot.Folders)
+            {
+                if (!Folders.Any(candidate =>
+                    candidate.ProjectRootId == folder.ProjectRootId &&
+                    ProjectContentPathPolicy.IsSamePath(candidate.FullPath, folder.FullPath)))
+                {
+                    Folders.Add(folder);
+                }
+            }
+
+            foreach (var file in snapshot.Files)
+            {
+                Files.Add(file);
+                if (Assets.TryGetValue(file.FileId, out var existing))
+                {
+                    var bSameMetadata = existing.AssetInfo is not null &&
+                        file.AssetInfo is not null &&
+                        ProjectContentPathPolicy.IsSamePath(
+                            existing.AssetInfo.FullName,
+                            file.AssetInfo.FullName);
+                    if (bSameMetadata || ProjectContentAssetResolutionPolicy.ShouldReplace(
+                        existing.IsReadOnly,
+                        file.IsReadOnly))
+                    {
+                        Assets[file.FileId] = file;
+                    }
+                    if (!bSameMetadata)
+                    {
+                        _assetOverrideCount++;
+                    }
+                }
+                else
+                {
+                    Assets.Add(file.FileId, file);
+                }
+            }
+            parentFolder.IsLoaded = true;
+            parentFolder.HasChildren = snapshot.Folders.Count > 0 || snapshot.Files.Count > 0;
+        }
+
+        private static bool DirectoryMayContainAssets(string directoryPath)
+        {
+            try
+            {
+                return Directory.EnumerateFileSystemEntries(directoryPath).Any(path =>
+                    Directory.Exists(path)
+                        ? !ProjectContentInternalPathPolicy.IsTransactionDirectory(path)
+                        : string.Equals(Path.GetExtension(path), ".asset", StringComparison.OrdinalIgnoreCase));
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         public bool CanModifyAsset(AssetFile? assetFile)
@@ -898,7 +1294,8 @@ namespace SailorEditor.Services
 
         private AssetFile ReadAssetFile(FileInfo assetInfo, int parentFolderId, int projectRootId, bool isReadOnly)
         {
-            var declaredFilename = TryReadScalar(assetInfo, "filename");
+            var identity = ReadAssetMetadataIdentity(assetInfo);
+            var declaredFilename = identity.Filename;
             if (!AssetSourcePathContract.TryResolve(
                     assetInfo.FullName,
                     declaredFilename,
@@ -910,40 +1307,8 @@ namespace SailorEditor.Services
             FileInfo assetFile = new(sourceResolution.SourcePath);
 
             var extension = sourceResolution.AssetExtension;
-            var assetInfoType = TryReadScalar(assetInfo, "assetInfoType");
-
-            var engineTypes = MauiProgram.GetService<EngineService>()?.EngineTypes;
-            AssetType assetType = null;
-            if (!string.IsNullOrEmpty(assetInfoType))
-            {
-                engineTypes?.AssetTypes?.TryGetValue(assetInfoType, out assetType);
-            }
-
-            if (assetType == null)
-            {
-                engineTypes?.AssetTypesByExtension?.TryGetValue(extension.TrimStart('.').ToLowerInvariant(), out assetType);
-            }
-
-            if (string.IsNullOrEmpty(assetInfoType) && assetType != null)
-            {
-                assetInfoType = assetType.Name;
-            }
-
-            AssetFile newAssetFile = assetInfoType switch
-            {
-                "Sailor::TextureAssetInfo" => new TextureFile(),
-                "Sailor::ModelAssetInfo" => new ModelFile(),
-                "Sailor::AnimationAssetInfo" => new AnimationFile(),
-                "Sailor::PrefabAssetInfo" => new PrefabFile(),
-                "Sailor::WorldPrefabAssetInfo" => new WorldFile(),
-                "Sailor::ShaderAssetInfo" when string.Equals(extension, ".glsl", StringComparison.OrdinalIgnoreCase) => new ShaderLibraryFile(),
-                "Sailor::ShaderAssetInfo" => new ShaderFile(),
-                "Sailor::MaterialAssetInfo" => new MaterialFile(),
-                "Sailor::FrameGraphAssetInfo" => new FrameGraphFile(),
-                _ => CreateAssetFileByExtension(extension)
-            };
-
-            newAssetFile.AssetInfoTypeName = assetInfoType;
+            var assetInfoType = identity.AssetInfoType;
+            AssetFile newAssetFile = CreateAssetFile(assetInfoType, extension);
 
             newAssetFile.Id = _nextAssetId++;
             newAssetFile.DisplayName = assetFile.Name;
@@ -952,13 +1317,90 @@ namespace SailorEditor.Services
             newAssetFile.AssetInfo = assetInfo;
             newAssetFile.Asset = assetFile;
             newAssetFile.OwnsSourceFile = sourceResolution.OwnsSourceFile;
-            newAssetFile.AssetType = assetType;
+            newAssetFile.FileId = new FileId(identity.FileId);
+            newAssetFile.Filename = new FileId(identity.Filename);
             newAssetFile.IsDirty = false;
             newAssetFile.IsReadOnly = isReadOnly;
-
-            _ = newAssetFile.Revert();
+            newAssetFile.IsMetadataLoaded = false;
 
             return newAssetFile;
+        }
+
+        private static AssetFile CreateAssetFile(
+            string assetInfoType,
+            string extension)
+        {
+            var engineTypes = MauiProgram.GetService<EngineService>()?.EngineTypes;
+            AssetType assetType = null;
+            if (!string.IsNullOrEmpty(assetInfoType))
+            {
+                engineTypes?.AssetTypes?.TryGetValue(assetInfoType, out assetType);
+            }
+            if (assetType == null)
+            {
+                engineTypes?.AssetTypesByExtension?.TryGetValue(
+                    extension.TrimStart('.').ToLowerInvariant(),
+                    out assetType);
+            }
+            if (string.IsNullOrEmpty(assetInfoType) && assetType != null)
+            {
+                assetInfoType = assetType.Name;
+            }
+
+            AssetFile assetFile = assetInfoType switch
+            {
+                "Sailor::TextureAssetInfo" => new TextureFile(),
+                "Sailor::ModelAssetInfo" => new ModelFile(),
+                "Sailor::AnimationAssetInfo" => new AnimationFile(),
+                "Sailor::PrefabAssetInfo" => new PrefabFile(),
+                "Sailor::WorldPrefabAssetInfo" => new WorldFile(),
+                "Sailor::ShaderAssetInfo" when string.Equals(
+                    extension,
+                    ".glsl",
+                    StringComparison.OrdinalIgnoreCase) => new ShaderLibraryFile(),
+                "Sailor::ShaderAssetInfo" => new ShaderFile(),
+                "Sailor::MaterialAssetInfo" => new MaterialFile(),
+                "Sailor::FrameGraphAssetInfo" => new FrameGraphFile(),
+                _ => CreateAssetFileByExtension(extension)
+            };
+            assetFile.AssetInfoTypeName = assetInfoType;
+            assetFile.AssetType = assetType;
+            return assetFile;
+        }
+
+        private sealed record AssetMetadataIdentity(
+            string FileId,
+            string Filename,
+            string AssetInfoType);
+
+        private static AssetMetadataIdentity ReadAssetMetadataIdentity(FileInfo assetInfo)
+        {
+            using var reader = new StreamReader(assetInfo.FullName);
+            var yaml = new YamlStream();
+            yaml.Load(reader);
+            if (yaml.Documents.Count == 0 ||
+                yaml.Documents[0].RootNode is not YamlMappingNode root)
+            {
+                throw new InvalidDataException($"Asset metadata root must be a map: {assetInfo.FullName}");
+            }
+
+            static string ReadScalar(YamlMappingNode root, string name)
+                => root.Children.TryGetValue(new YamlScalarNode(name), out var node) &&
+                    node is YamlScalarNode scalar
+                    ? scalar.Value ?? string.Empty
+                    : string.Empty;
+
+            var fileId = ReadScalar(root, "fileId");
+            var filename = ReadScalar(root, "filename");
+            if (string.IsNullOrWhiteSpace(fileId) || string.IsNullOrWhiteSpace(filename))
+            {
+                throw new InvalidDataException($"Asset metadata requires fileId and filename: {assetInfo.FullName}");
+            }
+
+            return new AssetMetadataIdentity(
+                fileId,
+                filename,
+                ReadScalar(root, "assetInfoType"));
         }
 
         private static AssetFile CreateAssetFileByExtension(string extension) => extension switch

--- a/Editor/Services/EngineLaunchContract.cs
+++ b/Editor/Services/EngineLaunchContract.cs
@@ -26,6 +26,7 @@ public sealed record EngineLaunchContext(
     public string TempWorldFilePath => Path.Combine(CacheDirectory, "Temp.world");
     public string TempWorldRuntimePath => Path.GetRelativePath(ContentDirectory, TempWorldFilePath);
     public string EditorTypesCacheFilePath => Path.Combine(CacheDirectory, "EditorTypes.yaml");
+    public string AssetCacheFilePath => Path.Combine(CacheDirectory, "AssetCache.yaml");
 
     public IReadOnlyList<string> BuildArguments(string? world, IEnumerable<string>? extraArguments = null)
     {

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -2418,6 +2418,7 @@ namespace SailorEditor.Services
 
         async Task<InstanceId?> InvokeCreationInteropAsync(
             Func<CancellationToken, Task<EngineProtocolCreationResult>> interop,
+            bool refreshWorld,
             CancellationToken cancellationToken)
         {
             var creationResult = default(EngineProtocolCreationResult);
@@ -2439,8 +2440,11 @@ namespace SailorEditor.Services
 
             var createdInstanceId =
                 new InstanceId(creationResult.InstanceId);
-            await RefreshCurrentWorldAsync(
-                cancellationToken).ConfigureAwait(false);
+            if (refreshWorld)
+            {
+                await RefreshCurrentWorldAsync(
+                    cancellationToken).ConfigureAwait(false);
+            }
             return createdInstanceId;
         }
 
@@ -2481,8 +2485,47 @@ namespace SailorEditor.Services
                     stringParentId,
                     stringPreferredInstanceId,
                     token),
+                refreshWorld: true,
                 cancellationToken);
         }
+
+        internal Task<InstanceId?> RequestCreateGameObjectAsync(
+            InstanceId? parentId,
+            InstanceId preferredInstanceId,
+            CancellationToken cancellationToken = default)
+            => InvokeCreationInteropAsync(
+                token => protocolClient.CreateGameObjectAsync(
+                    parentId?.Value ?? string.Empty,
+                    preferredInstanceId?.Value ?? string.Empty,
+                    token),
+                refreshWorld: false,
+                cancellationToken);
+
+        internal Task<InstanceId?> RequestCreateModelInstanceAsync(
+            FileId modelFileId,
+            string name,
+            InstanceId? parentId,
+            bool createHierarchy,
+            Vec4? worldPosition,
+            InstanceId preferredInstanceId,
+            CancellationToken cancellationToken = default)
+            => InvokeCreationInteropAsync(
+                token => protocolClient.CreateModelInstanceAsync(
+                    modelFileId.Value,
+                    name,
+                    parentId?.Value ?? string.Empty,
+                    createHierarchy,
+                    worldPosition is null
+                        ? null
+                        : new EngineProtocolVector4(
+                            worldPosition.X,
+                            worldPosition.Y,
+                            worldPosition.Z,
+                            worldPosition.W),
+                    preferredInstanceId.Value,
+                    token),
+                refreshWorld: false,
+                cancellationToken);
 
         public async Task<Vec4?> TraceViewportRayAsync(
             double normalizedX,
@@ -2585,8 +2628,23 @@ namespace SailorEditor.Services
                     componentTypeName ?? string.Empty,
                     stringPreferredInstanceId,
                     token),
+                refreshWorld: true,
                 cancellationToken);
         }
+
+        internal Task<InstanceId?> RequestAddComponentAsync(
+            InstanceId instanceId,
+            string componentTypeName,
+            InstanceId preferredInstanceId,
+            CancellationToken cancellationToken = default)
+            => InvokeCreationInteropAsync(
+                token => protocolClient.AddComponentAsync(
+                    instanceId?.Value ?? string.Empty,
+                    componentTypeName ?? string.Empty,
+                    preferredInstanceId?.Value ?? string.Empty,
+                    token),
+                refreshWorld: false,
+                cancellationToken);
 
         public async Task<bool> RemoveComponentAsync(
             InstanceId instanceId,
@@ -2650,6 +2708,7 @@ namespace SailorEditor.Services
                     parentId?.Value ?? string.Empty,
                     position,
                     token),
+                refreshWorld: true,
                 cancellationToken);
         }
 

--- a/Editor/Services/SelectionService.cs
+++ b/Editor/Services/SelectionService.cs
@@ -101,6 +101,11 @@ namespace SailorEditor.Services
             {
                 if (obj is AssetFile selectedAssetFile)
                 {
+                    await selectedAssetFile.EnsureMetadataLoadedAsync(requestCancellation.Token);
+                    if (!IsCurrentRequest(requestVersion, requestEpoch, requestCancellation.Token))
+                    {
+                        return;
+                    }
                     await selectedAssetFile.PrepareInspectorResources().WaitAsync(requestCancellation.Token);
                     if (!IsCurrentRequest(requestVersion, requestEpoch, requestCancellation.Token))
                     {

--- a/Editor/Services/WorldService.cs
+++ b/Editor/Services/WorldService.cs
@@ -746,42 +746,75 @@ namespace SailorEditor.Services
         public IEnumerable<GameObject> EnumerateSubHierarchy(GameObject root)
         {
             var prefab = Current.Prefabs[root.PrefabIndex];
-            yield return root;
-
             var rootIndex = prefab.GameObjects.IndexOf(root);
-            foreach (var child in prefab.GameObjects.Where(go => go.ParentIndex == rootIndex))
+            if (rootIndex < 0)
             {
-                foreach (var descendant in EnumerateSubHierarchy(child))
-                {
-                    yield return descendant;
-                }
+                yield break;
+            }
+
+            var childrenByParent = new List<int>[prefab.GameObjects.Count];
+            for (int i = 0; i < prefab.GameObjects.Count; i++)
+            {
+                var parentIndex = prefab.GameObjects[i].ParentIndex;
+                if (parentIndex >= (uint)prefab.GameObjects.Count)
+                    continue;
+
+                childrenByParent[(int)parentIndex] ??= [];
+                childrenByParent[(int)parentIndex].Add(i);
+            }
+
+            var pending = new Stack<int>();
+            var visited = new HashSet<int>();
+            pending.Push(rootIndex);
+            while (pending.TryPop(out var index))
+            {
+                if (!visited.Add(index))
+                    continue;
+
+                yield return prefab.GameObjects[index];
+
+                var children = childrenByParent[index];
+                if (children is null)
+                    continue;
+
+                for (int i = children.Count - 1; i >= 0; i--)
+                    pending.Push(children[i]);
             }
         }
 
         public Prefab CreatePrefabFromSubHierarchy(GameObject root, out List<InstanceId> externalSceneRefs)
         {
             var sourcePrefab = Current.Prefabs[root.PrefabIndex];
+            var sourceObjectIndicesByObject = sourcePrefab.GameObjects
+                .Select((gameObject, index) => new { gameObject, index })
+                .ToDictionary(entry => entry.gameObject, entry => entry.index);
             var sourceObjects = EnumerateSubHierarchy(root).ToList();
-            var sourceObjectIndices = sourceObjects.Select(go => sourcePrefab.GameObjects.IndexOf(go)).ToHashSet();
-            var sourceComponents = sourceObjects
+            var sourceObjectIndices = sourceObjects
+                .Select(gameObject => sourceObjectIndicesByObject[gameObject])
+                .ToHashSet();
+            var sourceComponentIndices = sourceObjects
                 .SelectMany(go => go.ComponentIndices)
                 .Distinct()
                 .OrderBy(index => index)
-                .Select(index => sourcePrefab.Components[index])
                 .ToList();
 
-            var componentIndexMap = sourceComponents
-                .Select((component, index) => new { component, index })
-                .ToDictionary(x => sourcePrefab.Components.IndexOf(x.component), x => x.index);
+            var componentIndexMap = sourceComponentIndices
+                .Select((sourceIndex, index) => new { sourceIndex, index })
+                .ToDictionary(entry => entry.sourceIndex, entry => entry.index);
 
             var sourceObjectIndexMap = sourceObjects
-                .Select((go, index) => new { sourceIndex = sourcePrefab.GameObjects.IndexOf(go), index })
-                .ToDictionary(x => x.sourceIndex, x => x.index);
+                .Select((gameObject, index) => new
+                {
+                    sourceIndex = sourceObjectIndicesByObject[gameObject],
+                    index
+                })
+                .ToDictionary(entry => entry.sourceIndex, entry => entry.index);
 
             var prefab = new Prefab();
-            foreach (var component in sourceComponents)
+            foreach (var componentIndex in sourceComponentIndices)
             {
-                prefab.Components.Add(CloneComponent(component));
+                prefab.Components.Add(CloneComponent(
+                    sourcePrefab.Components[componentIndex]));
             }
 
             foreach (var go in sourceObjects)
@@ -845,6 +878,14 @@ namespace SailorEditor.Services
                 var newPrefab = (Prefab)prefab.Clone();
                 newPrefab.GameObjects.Clear();
                 newPrefab.Components.Clear();
+
+                foreach (var component in prefab.Components)
+                {
+                    component.Initialize();
+                    componentsDict[component.InstanceId] = component;
+                    newPrefab.Components.Add(component);
+                }
+
                 foreach (var go in prefab.GameObjects)
                 {
                     var gameObject = go;
@@ -855,12 +896,8 @@ namespace SailorEditor.Services
                     foreach (var i in go.ComponentIndices ?? [])
                     {
                         var component = prefab.Components[i];
-                        component.Initialize();
-                        componentsDict[component.InstanceId] = component;
                         componentOwnersDict[component.InstanceId] = gameObject;
                         component.DisplayName = $"{go.DisplayName} ({component.Typename.Name})";
-
-                        newPrefab.Components.Add(component);
                     }
 
                     newPrefab.GameObjects.Add(gameObject);
@@ -1086,15 +1123,65 @@ namespace SailorEditor.Services
 
         static Component CloneComponent(Component component)
         {
-            var yaml = SerializationUtils.CreateSerializerBuilder()
-                .WithTypeConverter(new ComponentYamlConverter())
-                .Build()
-                .Serialize(component);
+            var clone = new Component
+            {
+                DisplayName = component.DisplayName,
+                Typename = component.Typename
+            };
 
-            return SerializationUtils.CreateDeserializerBuilder()
-                .WithTypeConverter(new ComponentYamlConverter())
-                .Build()
-                .Deserialize<Component>(yaml);
+            foreach (var property in component.OverrideProperties)
+            {
+                clone.OverrideProperties[property.Key] =
+                    CloneComponentProperty(property.Value);
+            }
+
+            foreach (var property in component.PreservedReadOnlyProperties)
+            {
+                clone.PreservedReadOnlyProperties[property.Key] =
+                    property.Value;
+            }
+
+            return clone;
+        }
+
+        static ObservableObject CloneComponentProperty(
+            ObservableObject property)
+        {
+            if (property is Observable<FileId> fileId)
+            {
+                return new Observable<FileId>(
+                    (FileId)fileId.Value.Clone());
+            }
+
+            if (property is Observable<InstanceId> instanceId)
+            {
+                return new Observable<InstanceId>(
+                    (InstanceId)instanceId.Value.Clone());
+            }
+
+            if (property is ObservableFileIdList fileIds)
+            {
+                return new ObservableFileIdList(fileIds.Values.Select(
+                    fileId => (FileId)fileId.Value.Clone()));
+            }
+
+            if (property is ObjectPtr objectPtr)
+            {
+                return new ObjectPtr
+                {
+                    FileId = (FileId)objectPtr.FileId.Clone(),
+                    InstanceId = (InstanceId)objectPtr.InstanceId.Clone()
+                };
+            }
+
+            if (property is ICloneable cloneable &&
+                cloneable.Clone() is ObservableObject clone)
+            {
+                return clone;
+            }
+
+            throw new InvalidOperationException(
+                $"Cannot clone component property '{property.GetType().Name}'.");
         }
 
         static GameObject DeserializeGameObject(string yaml)

--- a/Editor/Utility/Templates.cs
+++ b/Editor/Utility/Templates.cs
@@ -261,8 +261,15 @@ static class Templates
             if (fileOpen != null)
             {
                 var AssetService = MauiProgram.GetService<AssetsService>();
-                var asset = AssetService.Files.Find((el) => el.Asset.FullName == fileOpen.FullPath);
-                setter((TBindingContext)(sender as Button).BindingContext, asset.FileId is FileId id ? id : default);
+                var asset = AssetService.Assets.Values.FirstOrDefault(el =>
+                    el.Asset is not null &&
+                    string.Equals(
+                        el.Asset.FullName,
+                        fileOpen.FullPath,
+                        StringComparison.Ordinal));
+                setter(
+                    (TBindingContext)(sender as Button).BindingContext,
+                    asset?.FileId is FileId id ? id : default);
             }
         };
 

--- a/Editor/ViewModels/AssetFile.cs
+++ b/Editor/ViewModels/AssetFile.cs
@@ -24,6 +24,8 @@ public partial class AssetFile : ObservableObject, ICloneable
         "metadataPath"
     };
 
+    readonly SemaphoreSlim metadataLoadLock = new(1, 1);
+
     public AssetFile()
     {
         PropertyChanged += (s, args) =>
@@ -111,6 +113,7 @@ public partial class AssetFile : ObservableObject, ICloneable
                 LoadAssetPropertiesFromAssetInfo();
                 DisplayName = Filename;
                 IsLoaded = false;
+                IsMetadataLoaded = true;
             });
         }
         catch (Exception ex)
@@ -120,6 +123,28 @@ public partial class AssetFile : ObservableObject, ICloneable
 
         ResetDirtyState();
         return Task.CompletedTask;
+    }
+
+    public async Task EnsureMetadataLoadedAsync(CancellationToken cancellationToken = default)
+    {
+        if (IsMetadataLoaded)
+        {
+            return;
+        }
+
+        await metadataLoadLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (!IsMetadataLoaded)
+            {
+                await Task.Run(Revert, cancellationToken).ConfigureAwait(false);
+                IsMetadataLoaded = true;
+            }
+        }
+        finally
+        {
+            metadataLoadLock.Release();
+        }
     }
 
     protected void RunWithoutDirtyTracking(Action action)
@@ -568,6 +593,9 @@ public partial class AssetFile : ObservableObject, ICloneable
     public object Clone() => new AssetFile();
 
     public bool IsLoaded { get; set; }
+
+    [YamlIgnore]
+    public bool IsMetadataLoaded { get; set; }
 
     [YamlIgnore]
     public bool IsReadOnly { get; set; }

--- a/Editor/ViewModels/AssetFolder.cs
+++ b/Editor/ViewModels/AssetFolder.cs
@@ -8,4 +8,6 @@ public class AssetFolder
     public int ProjectRootId { get; set; }
     public string FullPath { get; set; } = string.Empty;
     public bool IsReadOnly { get; set; }
+    public bool IsLoaded { get; set; }
+    public bool HasChildren { get; set; }
 }

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -171,18 +171,18 @@ public partial class Component : ObservableObject, ICloneable, IInspectorEditabl
 
 public class ComponentYamlConverter : IYamlTypeConverter
 {
+    readonly IDeserializer bufferedDeserializer = SerializationUtils
+        .CreateDeserializerBuilder()
+        .Build();
+    readonly ISerializer bufferedSerializer = SerializationUtils
+        .CreateSerializerBuilder()
+        .Build();
+
     public bool Accepts(Type type) => type == typeof(Component);
 
     public object ReadYaml(IParser parser, Type type)
     {
-        var deserializer = SerializationUtils.CreateDeserializerBuilder()
-            .WithTypeConverter(new ObservableDictionaryConverter<string, PropertyBase>())
-            .WithTypeConverter(new ComponentTypeYamlConverter())
-            .WithTypeConverter(new ComponentYamlConverter())
-            .Build();
-
-        var serializer = SerializationUtils.CreateSerializerBuilder().Build();
-        var document = deserializer.Deserialize<EditorComponentYamlContract>(parser) ??
+        var document = bufferedDeserializer.Deserialize<EditorComponentYamlContract>(parser) ??
             throw new YamlException("A component YAML document is required.");
         if (string.IsNullOrWhiteSpace(document.Typename))
             throw new YamlException("A component typename must be a non-empty scalar.");
@@ -213,22 +213,22 @@ public class ComponentYamlConverter : IYamlTypeConverter
             var scalar = Convert.ToString(property.Value, CultureInfo.InvariantCulture) ?? string.Empty;
             ObservableObject value = propType switch
             {
-                RotationProperty => DeserializeBuffered<Rotation>(property.Value, serializer, deserializer),
-                Vec4Property => DeserializeBuffered<Vec4>(property.Value, serializer, deserializer),
-                Vec3Property => DeserializeBuffered<Vec3>(property.Value, serializer, deserializer),
-                Vec2Property => DeserializeBuffered<Vec2>(property.Value, serializer, deserializer),
+                RotationProperty => DeserializeBuffered<Rotation>(property.Value, bufferedSerializer, bufferedDeserializer),
+                Vec4Property => DeserializeBuffered<Vec4>(property.Value, bufferedSerializer, bufferedDeserializer),
+                Vec3Property => DeserializeBuffered<Vec3>(property.Value, bufferedSerializer, bufferedDeserializer),
+                Vec2Property => DeserializeBuffered<Vec2>(property.Value, bufferedSerializer, bufferedDeserializer),
                 FileIdProperty => new Observable<FileId>(scalar),
                 Property<List<FileId>> => DeserializeFileIdList(
                     property.Value,
-                    serializer,
-                    deserializer),
+                    bufferedSerializer,
+                    bufferedDeserializer),
                 InstanceIdProperty => new Observable<InstanceId>(scalar),
                 FloatProperty => new Observable<float>((float)EditorComponentScalarCodec.Parse(
                     EditorComponentScalarKind.Float,
                     scalar)),
                 ObjectPtrProperty => property.Value is null
                     ? new ObjectPtr()
-                    : DeserializeBuffered<ObjectPtr>(property.Value, serializer, deserializer),
+                    : DeserializeBuffered<ObjectPtr>(property.Value, bufferedSerializer, bufferedDeserializer),
                 EnumProperty enumProperty => new Observable<string>(ParseEnumOverride(
                     catalog,
                     componentType,
@@ -308,9 +308,6 @@ public class ComponentYamlConverter : IYamlTypeConverter
 
     public void WriteYaml(IEmitter emitter, object value, Type type)
     {
-        var serializer = SerializationUtils.CreateSerializerBuilder()            
-            .Build();
-
         var component = (Component)value;
 
         emitter.Emit(new MappingStart(null, null, false, MappingStyle.Block));
@@ -405,7 +402,7 @@ public class ComponentYamlConverter : IYamlTypeConverter
         foreach (var kvp in component.PreservedReadOnlyProperties)
         {
             emitter.Emit(new Scalar(null, kvp.Key));
-            serializer.Serialize(emitter, kvp.Value);
+            bufferedSerializer.Serialize(emitter, kvp.Value);
         }
 
         emitter.Emit(new MappingEnd());

--- a/Editor/ViewModels/World.cs
+++ b/Editor/ViewModels/World.cs
@@ -77,21 +77,7 @@ public class WorldYamlConverter : IYamlTypeConverter
                 }))
             .Build();
 
-        var world = deserializer.Deserialize<World>(parser);
-
-        foreach (var prefab in world.Prefabs)
-        {
-            foreach (var gameObject in prefab.GameObjects)
-            {
-                gameObject.Initialize();
-                foreach (var component in prefab.Components)
-                {
-                    component.Initialize();
-                }
-            }
-        }
-
-        return world;
+        return deserializer.Deserialize<World>(parser);
     }
 
     public void WriteYaml(IEmitter emitter, object value, Type type)

--- a/Editor/Views/ContentFolderView.xaml.cs
+++ b/Editor/Views/ContentFolderView.xaml.cs
@@ -470,7 +470,7 @@ namespace SailorEditor.Views
             }
         }
 
-        void ToggleFolder(ContentListRow row)
+        async Task ToggleFolder(ContentListRow row)
         {
             if (row.Id == RootRowId)
             {
@@ -490,6 +490,7 @@ namespace SailorEditor.Views
             }
             else
             {
+                await service.EnsureFolderLoadedAsync(folderId);
                 expandedFolderIds.Add(folderId);
             }
 
@@ -590,7 +591,8 @@ namespace SailorEditor.Views
                         depth,
                         folder.Name,
                         folder.IsReadOnly ? "lock_24.png" : isExpanded ? "folder_open_24.png" : "folder_24.png",
-                        HasChildren(foldersByParent, assetsByFolder, folder.Id),
+                        HasChildren(foldersByParent, assetsByFolder, folder.Id) ||
+                            (!folder.IsLoaded && folder.HasChildren),
                         isExpanded,
                         projection.State.SelectedAssetPath is null
                             && projection.State.SelectedAssetFileId is null
@@ -641,7 +643,9 @@ namespace SailorEditor.Views
                 {
                     if (expandLabel.BindingContext is ContentListRow { HasChildren: true } row)
                     {
-                        ToggleFolder(row);
+                        RunContentUiAction(
+                            () => ToggleFolder(row),
+                            "Expand Content folder");
                     }
                 };
                 expandLabel.GestureRecognizers.Add(expandTap);
@@ -767,7 +771,7 @@ namespace SailorEditor.Views
                                     await OpenWorldWithConfirmation(worldFile);
                                     break;
                                 case AssetFolder or ProjectContentFolderItem:
-                                    ToggleFolder(row);
+                                    await ToggleFolder(row);
                                     break;
                             }
                         },

--- a/Editor/Views/Elements/FileIdEditor.xaml
+++ b/Editor/Views/Elements/FileIdEditor.xaml
@@ -31,7 +31,11 @@
         VerticalOptions="Center"
         HorizontalOptions="Start"
         Margin="10,0,0,0"
-        Grid.Column="3"/>
+        Grid.Column="3">
+            <Label.Behaviors>
+                <controls:FileIdSelectBehavior BoundProperty="{Binding FileId}"/>
+            </Label.Behaviors>
+        </Label>
     </Grid>
     
 </ContentView>

--- a/Editor/Views/Elements/FileIdEditor.xaml.cs
+++ b/Editor/Views/Elements/FileIdEditor.xaml.cs
@@ -75,7 +75,12 @@ public class FileIdEditorViewModel : ObservableObject
         if (fileOpen != null)
         {
             var assetService = MauiProgram.GetService<AssetsService>();
-            var asset = assetService.Files.Find(el => el.Asset.FullName == fileOpen.FullPath);
+            var asset = assetService.Assets.Values.FirstOrDefault(el =>
+                el.Asset is not null &&
+                string.Equals(
+                    el.Asset.FullName,
+                    fileOpen.FullPath,
+                    StringComparison.Ordinal));
             FileId = asset?.FileId ?? default;
             System.Diagnostics.Debug.WriteLine($"FileIdEditorViewModel: File selected {FileId}");
         }

--- a/Lib/EditorEngineProtocol.cpp
+++ b/Lib/EditorEngineProtocol.cpp
@@ -761,6 +761,38 @@ namespace
 		}
 	}
 
+	void DispatchCreateModelInstance(
+		const sailor::editor::v1::CreateModelInstanceRequest& request,
+		ProtocolResponse& response)
+	{
+		if (request.model_file_id().empty() ||
+			request.name().empty() ||
+			(request.apply_world_position() &&
+				(!request.has_world_position() ||
+					!std::isfinite(request.world_position().x()) ||
+					!std::isfinite(request.world_position().y()) ||
+					!std::isfinite(request.world_position().z()))))
+		{
+			SetError(response, "The model instance request is invalid.");
+			return;
+		}
+
+		TInteropString instanceId;
+		const auto& worldPosition = request.world_position();
+		const bool bSucceeded = Sailor::App::CreateEditorModelInstance(
+			request.model_file_id().c_str(),
+			request.name().c_str(),
+			request.parent_instance_id().c_str(),
+			request.create_hierarchy(),
+			request.apply_world_position(),
+			worldPosition.x(),
+			worldPosition.y(),
+			worldPosition.z(),
+			request.preferred_instance_id().c_str(),
+			instanceId.GetOutput());
+		SetInstanceIdResult(response, bSucceeded, instanceId.GetValue());
+	}
+
 	void DispatchAddComponent(
 		const sailor::editor::v1::AddComponentRequest& request,
 		ProtocolResponse& response)
@@ -914,6 +946,12 @@ namespace
 			SetBoolResult(
 				response,
 				Sailor::App::UpdateAsset(request.update_asset().file_id().c_str()));
+			break;
+
+		case ProtocolRequest::kCreateModelInstance:
+			DispatchCreateModelInstance(
+				request.create_model_instance(),
+				response);
 			break;
 
 		case ProtocolRequest::kGetAssetReloadState:

--- a/Protocol/README.md
+++ b/Protocol/README.md
@@ -65,6 +65,16 @@ same source (for example, the assets generated from one glTF file). It does not
 scan Content or wait for unrelated Worker, RHI, or Render work. Commands that
 change Content topology still use `request_asset_reload`.
 
+`create_model_instance` performs one atomic Engine-side model drop. With
+`create_hierarchy = true`, the Engine creates the asset root and the editable
+parent-before-child glTF hierarchy, applies each node's local TRS, and attaches
+one mesh renderer using the source mesh index to every mesh node. With
+`create_hierarchy = false`, or when skinning/non-decomposable node transforms
+make an editable hierarchy unsafe, it creates one GameObject with one mesh
+renderer using `meshIndex = -1` for the complete model. World mutation is
+marshalled from the Editor worker to the Engine main thread; any failure rolls
+back the owned root recursively before the command reports failure.
+
 Compatibility rules:
 
 - Ordinary commands use baseline `protocol_version = 1`. Strict InstanceId

--- a/Protocol/editor_engine.proto
+++ b/Protocol/editor_engine.proto
@@ -59,13 +59,14 @@ message ProtocolRequest {
 		ViewportToolStateRequest set_viewport_tool_state = 55;
 		ViewportIdRequest get_viewport_tool_state = 56;
 		FileIdRequest update_asset = 57;
+		CreateModelInstanceRequest create_model_instance = 58;
 	}
 
 	reserved 3 to 9;
 	reserved 50;
 	reserved "create_model_game_object";
 	reserved "resolve_viewport_drop_position";
-	reserved 58 to 99;
+	reserved 59 to 99;
 }
 
 message ProtocolResponse {
@@ -104,6 +105,16 @@ message CountRequest {
 
 message FileIdRequest {
 	string file_id = 1;
+}
+
+message CreateModelInstanceRequest {
+	string model_file_id = 1;
+	string name = 2;
+	string parent_instance_id = 3;
+	bool create_hierarchy = 4;
+	bool apply_world_position = 5;
+	Vector4 world_position = 6;
+	string preferred_instance_id = 7;
 }
 
 message InstanceIdRequest {

--- a/Runtime/AssetRegistry/AssetCache.cpp
+++ b/Runtime/AssetRegistry/AssetCache.cpp
@@ -20,8 +20,8 @@ using namespace Sailor;
 namespace
 {
 	constexpr const char* AssetCacheKind = "asset-cache";
-	constexpr const char* AssetCacheProducer = "asset-cache-v2";
-	constexpr uint32_t AssetCachePayloadVersion = 2;
+	constexpr const char* AssetCacheProducer = "asset-cache-v1";
+	constexpr uint32_t AssetCachePayloadVersion = 1;
 
 	std::string NormalizeSourcePath(const std::string& sourcePath)
 	{
@@ -175,20 +175,35 @@ YAML::Node AssetCache::AssetCacheData::Entry::Serialize() const
 	sourceRevision["fileSize"] = m_sourceRevision.m_fileSize;
 	sourceRevision["contentHash"] = m_sourceRevision.m_contentHash;
 	result["sourceRevision"] = sourceRevision;
+	result["metadataFilename"] = m_metadataFilename;
+	YAML::Node metadataRevision(YAML::NodeType::Map);
+	metadataRevision["modificationTimeNanoseconds"] = m_metadataRevision.m_modificationTimeNanoseconds;
+	metadataRevision["fileSize"] = m_metadataRevision.m_fileSize;
+	metadataRevision["contentHash"] = m_metadataRevision.m_contentHash;
+	result["metadataRevision"] = metadataRevision;
+	result["assetInfoType"] = m_assetInfoType;
 	return result;
 }
 
 void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 {
-	m_fileId = FileId();
-	m_assetImportTime = 0;
-	m_sourcePath.clear();
-	m_sourceRevision = {};
+	auto reset = [&]()
+	{
+		m_fileId = FileId();
+		m_assetImportTime = 0;
+		m_sourcePath.clear();
+		m_sourceRevision = {};
+		m_metadataFilename.clear();
+		m_metadataRevision = {};
+		m_assetInfoType.clear();
+	};
+	reset();
+	bool bValid = false;
 	std::string yamlDiagnostic;
-	if (!Sailor::External::GuardYamlExceptions(
+	const bool bDeserialized = Sailor::External::GuardYamlExceptions(
 		[&]()
 		{
-			if (!inData.IsMap() || inData.size() != 4)
+			if (!inData.IsMap() || inData.size() != 7)
 			{
 				return;
 			}
@@ -219,20 +234,41 @@ void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 			m_sourceRevision.m_fileSize = fileSize.as<uint64_t>();
 			m_sourceRevision.m_contentHash = contentHash.as<uint64_t>();
 			m_sourceRevision.m_bIsValid = true;
-			if (m_sourcePath.empty() || !m_fileId || m_assetImportTime <= 0)
+			const YAML::Node metadataFilename = inData["metadataFilename"];
+			const YAML::Node metadataRevision = inData["metadataRevision"];
+			const YAML::Node assetInfoType = inData["assetInfoType"];
+			if (!metadataFilename.IsScalar() || !metadataRevision.IsMap() ||
+				metadataRevision.size() != 3 || !assetInfoType.IsScalar())
 			{
-				m_fileId = FileId();
-				m_assetImportTime = 0;
-				m_sourcePath.clear();
-				m_sourceRevision = {};
+				return;
 			}
+			const YAML::Node metadataModificationTime = metadataRevision["modificationTimeNanoseconds"];
+			const YAML::Node metadataFileSize = metadataRevision["fileSize"];
+			const YAML::Node metadataContentHash = metadataRevision["contentHash"];
+			if (!metadataModificationTime.IsScalar() || !metadataFileSize.IsScalar() ||
+				!metadataContentHash.IsScalar())
+			{
+				return;
+			}
+			m_metadataFilename = metadataFilename.as<std::string>();
+			m_metadataRevision.m_modificationTimeNanoseconds = metadataModificationTime.as<int64_t>();
+			m_metadataRevision.m_fileSize = metadataFileSize.as<uint64_t>();
+			m_metadataRevision.m_contentHash = metadataContentHash.as<uint64_t>();
+			m_metadataRevision.m_bIsValid = true;
+			m_assetInfoType = assetInfoType.as<std::string>();
+			if (m_sourcePath.empty() || m_metadataFilename.empty() ||
+				std::filesystem::path(m_metadataFilename).filename() != m_metadataFilename ||
+				m_assetInfoType.empty() ||
+				!m_fileId || m_assetImportTime <= 0)
+			{
+				return;
+			}
+			bValid = true;
 		},
-		yamlDiagnostic))
+		yamlDiagnostic);
+	if (!bDeserialized || !bValid)
 	{
-		m_fileId = FileId();
-		m_assetImportTime = 0;
-		m_sourcePath.clear();
-		m_sourceRevision = {};
+		reset();
 	}
 }
 
@@ -311,10 +347,10 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 		}
 
 		const YAML::Node entryNode = serializedEntry.second;
-		if (!entryNode.IsMap() || entryNode.size() != 4)
+		if (!entryNode.IsMap() || entryNode.size() != 7)
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId +
-				"' must contain exactly fileId, assetImportTime, sourcePath, and sourceRevision.";
+				"' must contain exactly the asset watermark and lazy metadata index fields.";
 			return false;
 		}
 
@@ -370,6 +406,42 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 			return false;
 		}
 		entry.m_sourcePath = NormalizeSourcePath(serializedSourcePath);
+		YAML::Node metadataFilename;
+		YAML::Node metadataRevision;
+		YAML::Node assetInfoType;
+		if (!ReadRequiredField(entryNode, "metadataFilename", metadataFilename, outDiagnostic) ||
+			!ReadRequiredField(entryNode, "metadataRevision", metadataRevision, outDiagnostic) ||
+			!ReadRequiredField(entryNode, "assetInfoType", assetInfoType, outDiagnostic) ||
+			!metadataFilename.IsScalar() || !metadataRevision.IsMap() ||
+			metadataRevision.size() != 3 || !assetInfoType.IsScalar())
+		{
+			return false;
+		}
+		YAML::Node metadataModificationTime;
+		YAML::Node metadataFileSize;
+		YAML::Node metadataContentHash;
+		if (!ReadRequiredField(metadataRevision, "modificationTimeNanoseconds", metadataModificationTime, outDiagnostic) ||
+			!ReadRequiredField(metadataRevision, "fileSize", metadataFileSize, outDiagnostic) ||
+			!ReadRequiredField(metadataRevision, "contentHash", metadataContentHash, outDiagnostic) ||
+			!metadataModificationTime.IsScalar() || !metadataFileSize.IsScalar() ||
+			!metadataContentHash.IsScalar())
+		{
+			return false;
+		}
+		entry.m_metadataFilename = metadataFilename.as<std::string>();
+		entry.m_metadataRevision.m_modificationTimeNanoseconds = metadataModificationTime.as<int64_t>();
+		entry.m_metadataRevision.m_fileSize = metadataFileSize.as<uint64_t>();
+		entry.m_metadataRevision.m_contentHash = metadataContentHash.as<uint64_t>();
+		entry.m_metadataRevision.m_bIsValid = true;
+		entry.m_assetInfoType = assetInfoType.as<std::string>();
+		if (entry.m_metadataFilename.empty() ||
+			std::filesystem::path(entry.m_metadataFilename).filename() != entry.m_metadataFilename ||
+			entry.m_assetInfoType.empty())
+		{
+			outDiagnostic = "Asset cache entry '" + serializedFileId +
+				"' contains an incomplete lazy metadata index.";
+			return false;
+		}
 		if (!entry.m_fileId || entry.m_fileId != fileId)
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId + "' has a mismatched fileId field.";
@@ -675,17 +747,27 @@ bool AssetCache::Update(const AssetInfo* info)
 		info->GetFileId(),
 		info->GetAssetImportTime(),
 		sourcePath,
-		info->m_importedSourceRevision);
+		info->m_importedSourceRevision,
+		std::filesystem::path(info->GetMetaFilepath()).filename().string(),
+		info->m_metadataRevision,
+		info->GetAssetInfoType());
 }
 
 bool AssetCache::Update(
 	const FileId& id,
 	std::time_t assetImportTime,
 	const std::string& sourcePath,
-	const FileRevision& sourceRevision)
+	const FileRevision& sourceRevision,
+	const std::string& metadataFilename,
+	const FileRevision& metadataRevision,
+	const std::string& assetInfoType)
 {
 	std::string normalizedSourcePath = NormalizeSourcePath(sourcePath);
-	if (!id || assetImportTime <= 0 || normalizedSourcePath.empty() || !sourceRevision.m_bIsValid)
+	const bool bValidMetadataFilename = !metadataFilename.empty() &&
+		std::filesystem::path(metadataFilename).filename() == metadataFilename;
+	if (!id || assetImportTime <= 0 || normalizedSourcePath.empty() ||
+		!sourceRevision.m_bIsValid || !bValidMetadataFilename ||
+		!metadataRevision.m_bIsValid || assetInfoType.empty())
 	{
 		Remove(id);
 		return false;
@@ -707,12 +789,18 @@ bool AssetCache::Update(
 	const bool bChanged = entry.m_fileId != id ||
 		entry.m_assetImportTime != assetImportTime ||
 		entry.m_sourcePath != normalizedSourcePath ||
-		entry.m_sourceRevision != sourceRevision;
+		entry.m_sourceRevision != sourceRevision ||
+		entry.m_metadataFilename != metadataFilename ||
+		entry.m_metadataRevision != metadataRevision ||
+		entry.m_assetInfoType != assetInfoType;
 	m_bIsDirty |= bChanged;
 	entry.m_fileId = id;
 	entry.m_assetImportTime = assetImportTime;
 	entry.m_sourcePath = std::move(normalizedSourcePath);
 	entry.m_sourceRevision = sourceRevision;
+	entry.m_metadataFilename = metadataFilename;
+	entry.m_metadataRevision = metadataRevision;
+	entry.m_assetInfoType = assetInfoType;
 	return bChanged;
 }
 

--- a/Runtime/AssetRegistry/AssetCache.h
+++ b/Runtime/AssetRegistry/AssetCache.h
@@ -55,13 +55,19 @@ namespace Sailor
 				std::time_t m_assetImportTime{};
 				std::string m_sourcePath;
 				FileRevision m_sourceRevision{};
+				std::string m_metadataFilename;
+				FileRevision m_metadataRevision{};
+				std::string m_assetInfoType;
 
 				SAILOR_API bool operator==(const Entry& rhs) const
 				{
 					return m_fileId == rhs.m_fileId &&
 						m_assetImportTime == rhs.m_assetImportTime &&
 						m_sourcePath == rhs.m_sourcePath &&
-						m_sourceRevision == rhs.m_sourceRevision;
+						m_sourceRevision == rhs.m_sourceRevision &&
+						m_metadataFilename == rhs.m_metadataFilename &&
+						m_metadataRevision == rhs.m_metadataRevision &&
+						m_assetInfoType == rhs.m_assetInfoType;
 				}
 
 				SAILOR_API virtual YAML::Node Serialize() const override;
@@ -89,7 +95,10 @@ namespace Sailor
 			const FileId& id,
 			std::time_t assetImportTime,
 			const std::string& sourcePath,
-			const FileRevision& sourceRevision);
+			const FileRevision& sourceRevision,
+			const std::string& metadataFilename,
+			const FileRevision& metadataRevision,
+			const std::string& assetInfoType);
 		SAILOR_API bool RestoreAssetImportTime(
 			class AssetInfo* info,
 			const FileRevision& sourceRevision) const;

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -32,6 +32,8 @@
 
 using namespace Sailor;
 
+bool Sailor::g_bUseLazyAssetInfoLoading = false;
+
 namespace
 {
 	std::atomic<uint64_t> g_nextAssetProcessingGeneration = 0;
@@ -451,7 +453,10 @@ void AssetRegistry::CacheAsset(const AssetInfoPtr info)
 		info->GetFileId(),
 		info->GetAssetImportTime(),
 		info->GetAssetFilepath(),
-		sourceRevision);
+		sourceRevision,
+		std::filesystem::path(info->GetMetaFilepath()).filename().string(),
+		info->m_metadataRevision,
+		info->GetAssetInfoType());
 }
 
 AssetRegistry::AssetProcessingToken AssetRegistry::BeginAssetProcessing(AssetInfoPtr info)
@@ -469,15 +474,28 @@ AssetRegistry::AssetProcessingToken AssetRegistry::BeginAssetProcessing(AssetInf
 	// cannot safely decide which concurrently captured revision is newer.
 	token.m_fileId = info->GetFileId();
 	token.m_sourcePath = info->GetAssetFilepath();
+	const std::string metadataFilename =
+		std::filesystem::path(info->GetMetaFilepath()).filename().string();
+	FileRevision metadataRevision;
+	const bool bHasMetadataRevision = Utils::TryGetFileRevision(
+		info->GetMetaFilepath(),
+		metadataRevision);
+	const std::string assetInfoType = info->GetAssetInfoType();
 	m_assetCache.Remove(token.m_fileId);
 	const bool bRetryWatermarkPersisted =
 		m_assetCache.SaveCache();
 	token.m_assetImportTime = Utils::GetFileModificationTime(token.m_sourcePath);
-	if (token.m_assetImportTime <= 0 ||
+	if (token.m_assetImportTime <= 0 || !bHasMetadataRevision ||
+		metadataFilename.empty() || assetInfoType.empty() ||
 		!Utils::TryGetFileRevision(token.m_sourcePath, token.m_sourceRevision))
 	{
 		m_assetProcessingStates[token.m_fileId] =
-			AssetProcessingState{ token, true };
+			AssetProcessingState{
+				token,
+				metadataFilename,
+				assetInfoType,
+				true
+			};
 		m_bScanProcessingFailed |= m_bScanProcessingActive;
 		SAILOR_LOG_ERROR(
 			"Cannot capture asset processing revision after invalidating its cache watermark: %s",
@@ -487,7 +505,12 @@ AssetRegistry::AssetProcessingToken AssetRegistry::BeginAssetProcessing(AssetInf
 	if (!bRetryWatermarkPersisted)
 	{
 		m_assetProcessingStates[token.m_fileId] =
-			AssetProcessingState{ token, true };
+			AssetProcessingState{
+				token,
+				metadataFilename,
+				assetInfoType,
+				true
+			};
 		m_bScanProcessingFailed |= m_bScanProcessingActive;
 		SAILOR_LOG_ERROR(
 			"Cannot start retry-safe asset processing because its invalidated cache watermark was not persisted: %s",
@@ -505,7 +528,12 @@ AssetRegistry::AssetProcessingToken AssetRegistry::BeginAssetProcessing(AssetInf
 
 	info->m_assetImportTime = token.m_assetImportTime;
 	info->m_importedSourceRevision = token.m_sourceRevision;
-	m_assetProcessingStates[token.m_fileId] = AssetProcessingState{ token, false };
+	m_assetProcessingStates[token.m_fileId] = AssetProcessingState{
+		token,
+		metadataFilename,
+		assetInfoType,
+		false
+	};
 	return token;
 }
 
@@ -551,11 +579,29 @@ void AssetRegistry::CompleteAssetProcessing(
 	}
 
 	const AssetProcessingToken acknowledgedToken = processingState.Value().m_token;
+	const std::filesystem::path metadataPath =
+		std::filesystem::path(acknowledgedToken.m_sourcePath).parent_path() /
+		processingState.Value().m_metadataFilename;
+	FileRevision currentMetadataRevision;
+	if (!Utils::TryGetFileRevision(
+			metadataPath.string(),
+			currentMetadataRevision))
+	{
+		processingState.Value().m_bRejected = true;
+		m_bScanProcessingFailed |= m_bScanProcessingActive;
+		SAILOR_LOG_ERROR(
+			"Asset metadata disappeared while its source was being processed: %s",
+			metadataPath.string().c_str());
+		return;
+	}
 	m_assetCache.Update(
 		acknowledgedToken.m_fileId,
 		acknowledgedToken.m_assetImportTime,
 		acknowledgedToken.m_sourcePath,
-		acknowledgedToken.m_sourceRevision);
+		acknowledgedToken.m_sourceRevision,
+		processingState.Value().m_metadataFilename,
+		currentMetadataRevision,
+		processingState.Value().m_assetInfoType);
 	if (!m_assetCache.SaveCache())
 	{
 		m_assetCache.Remove(acknowledgedToken.m_fileId);
@@ -747,6 +793,17 @@ IAssetInfoHandler* AssetRegistry::GetAssetInfoHandler(
 bool AssetRegistry::ScanContentFolder()
 {
 	SAILOR_PROFILE_FUNCTION();
+	bool bHasLazyIndex = false;
+	if (g_bUseLazyAssetInfoLoading)
+	{
+		std::lock_guard<std::mutex> cacheLock(m_assetCache.m_cacheMutex);
+		bHasLazyIndex = m_assetCache.m_cache.m_data.Num() > 0;
+	}
+	if (bHasLazyIndex)
+	{
+		return ScanContentFolderLazy();
+	}
+
 	AssetScanSourceRevisionCache sourceRevisionCache;
 	AssetScanSourceRevisionScope sourceRevisionScope(sourceRevisionCache);
 	{
@@ -1319,6 +1376,462 @@ bool AssetRegistry::ScanContentFolder()
 	m_assetCache.Prune(liveAssetIds);
 	m_assetCache.SaveCache();
 	return true;
+}
+
+bool AssetRegistry::ScanContentFolderLazy()
+{
+	SAILOR_PROFILE_FUNCTION();
+	{
+		std::lock_guard<std::mutex> lock(m_assetProcessingMutex);
+		m_scanProcessingTasks.Clear();
+		m_bCollectScanProcessingTasks = true;
+		m_bScanProcessingActive = true;
+		m_bScanProcessingFailed = false;
+	}
+
+	const AssetMountDiscoveryResult discovery = DiscoverAssetMountFiles(m_contentMounts);
+	for (const AssetMountDiagnostic& diagnostic : discovery.m_diagnostics)
+	{
+		if (diagnostic.m_code == EAssetMountDiagnosticCode::InvalidMountRoot ||
+			diagnostic.m_code == EAssetMountDiagnosticCode::OverlappingMountRoot)
+		{
+			SAILOR_LOG_ERROR("%s", diagnostic.m_message.c_str());
+		}
+		else
+		{
+			SAILOR_LOG("%s", diagnostic.m_message.c_str());
+		}
+	}
+	if (discovery.HasFatalErrors())
+	{
+		std::lock_guard<std::mutex> lock(m_assetProcessingMutex);
+		m_bCollectScanProcessingTasks = false;
+		m_bScanProcessingFailed = true;
+		return false;
+	}
+
+	AssetScanSourceRevisionCache revisionCache;
+	AssetScanSourceRevisionScope revisionScope(revisionCache);
+	TVector<AssetMountCandidate> sourceCandidates;
+	TSet<std::string> activeSourcePaths;
+	for (const AssetMountDiscoveredFile& file : discovery.m_files)
+	{
+		if (Extension(file.m_virtualPath) != MetaFileExtension)
+		{
+			const std::string physicalPathKey = PathKey(file.m_physicalPath);
+			activeSourcePaths.Insert(physicalPathKey);
+			sourceCandidates.Add({
+				file.m_mount,
+				file.m_physicalPath,
+				file.m_virtualPath,
+				physicalPathKey
+			});
+		}
+	}
+	const AssetMountResolutionResult sourceResolution =
+		ResolveAssetMountCandidates(std::move(sourceCandidates));
+	for (const AssetMountDiagnostic& diagnostic : sourceResolution.GetDiagnostics())
+	{
+		SAILOR_LOG("%s", diagnostic.m_message.c_str());
+	}
+
+	TMap<std::string, AssetReadLocation> stagedContentWinners;
+	TMap<std::string, std::string> effectiveVirtualPathsByPhysicalPath;
+	for (const AssetMountCandidate& candidate : sourceResolution.GetCandidates())
+	{
+		const AssetMountCandidate* winner =
+			sourceResolution.FindByVirtualPath(candidate.m_virtualPath);
+		if (winner == nullptr || PathKey(winner->m_physicalPath) != PathKey(candidate.m_physicalPath))
+		{
+			continue;
+		}
+
+		AssetReadLocation location{
+			candidate.m_physicalPath,
+			candidate.m_virtualPath,
+			candidate.m_mount.m_kind,
+			candidate.m_mount.m_bWritable
+		};
+		if (!revisionCache.TryGet(
+				location.m_physicalPath.generic_string(),
+				location.m_revision))
+		{
+			continue;
+		}
+		const std::string virtualPathKey = VirtualPathKey(location.m_virtualPath);
+		stagedContentWinners[virtualPathKey] = location;
+		effectiveVirtualPathsByPhysicalPath[PathKey(location.m_physicalPath)] =
+			virtualPathKey;
+	}
+	TMap<std::string, std::string> effectiveContentChanges;
+	if (!m_contentFileWinners.IsEmpty())
+	{
+		for (const auto& previousWinner : m_contentFileWinners)
+		{
+			const auto stagedWinner = stagedContentWinners.Find(previousWinner.m_first);
+			if (stagedWinner == stagedContentWinners.end() ||
+				!SameEffectiveContent(*previousWinner.m_second, stagedWinner.Value()))
+			{
+				effectiveContentChanges[previousWinner.m_first] =
+					previousWinner.m_second->m_virtualPath;
+			}
+		}
+		for (const auto& stagedWinner : stagedContentWinners)
+		{
+			const auto previousWinner = m_contentFileWinners.Find(stagedWinner.m_first);
+			if (previousWinner == m_contentFileWinners.end() ||
+				!SameEffectiveContent(previousWinner.Value(), *stagedWinner.m_second))
+			{
+				effectiveContentChanges[stagedWinner.m_first] =
+					stagedWinner.m_second->m_virtualPath;
+			}
+		}
+	}
+
+	TVector<std::pair<FileId, LazyAssetInfoRecord>> cachedRecords;
+	{
+		std::lock_guard<std::mutex> cacheLock(m_assetCache.m_cacheMutex);
+		cachedRecords.Reserve(m_assetCache.m_cache.m_data.Num());
+		for (const auto& cached : m_assetCache.m_cache.m_data)
+		{
+			const AssetCache::AssetCacheData::Entry& entry = cached.m_second;
+			cachedRecords.Emplace(
+				cached.m_first,
+				LazyAssetInfoRecord{
+					entry.m_sourcePath,
+					entry.m_sourceRevision,
+					entry.m_metadataFilename,
+					entry.m_metadataRevision,
+					entry.m_assetInfoType
+				});
+		}
+	}
+
+	TMap<FileId, LazyAssetInfoRecord> stagedLazyAssetInfos;
+	TVector<FileId> expiredAssetIds;
+	TSet<std::string> indexedPrimarySourcePaths;
+	TSet<std::string> indexedMetadataPaths;
+	TSet<FileId> liveAssetIds;
+	for (const auto& cached : cachedRecords)
+	{
+		const FileId& fileId = cached.first;
+		const LazyAssetInfoRecord& record = cached.second;
+		const std::string sourcePathKey = PathKey(record.m_sourcePath);
+		if (!activeSourcePaths.Contains(sourcePathKey))
+		{
+			continue;
+		}
+
+		FileRevision currentSourceRevision;
+		if (!revisionCache.TryGet(record.m_sourcePath, currentSourceRevision))
+		{
+			continue;
+		}
+		const std::filesystem::path metadataPath =
+			std::filesystem::path(record.m_sourcePath).parent_path() /
+			record.m_metadataFilename;
+		FileRevision currentMetadataRevision;
+		if (!revisionCache.TryGet(metadataPath.string(), currentMetadataRevision))
+		{
+			continue;
+		}
+
+		indexedMetadataPaths.Insert(PathKey(metadataPath));
+		liveAssetIds.Insert(fileId);
+		if (!m_loadedAssetInfo.ContainsKey(fileId))
+		{
+			stagedLazyAssetInfos[fileId] = record;
+		}
+		if (PathKey(metadataPath) ==
+			PathKey(record.m_sourcePath + "." + MetaFileExtension))
+		{
+			indexedPrimarySourcePaths.Insert(sourcePathKey);
+		}
+
+		const bool bSourceExpired =
+			currentSourceRevision != record.m_sourceRevision;
+		const bool bMetadataExpired =
+			currentMetadataRevision != record.m_metadataRevision;
+		if (bSourceExpired || bMetadataExpired)
+		{
+			expiredAssetIds.Add(fileId);
+		}
+	}
+
+	TVector<FileId> staleLoadedAssetIds;
+	for (const auto& loaded : m_loadedAssetInfo)
+	{
+		AssetInfoPtr info = *loaded.m_second;
+		FileRevision sourceRevision;
+		FileRevision metadataRevision;
+		if (info == nullptr ||
+			!activeSourcePaths.Contains(PathKey(info->GetAssetFilepath())) ||
+			!revisionCache.TryGet(info->GetAssetFilepath(), sourceRevision) ||
+			!revisionCache.TryGet(info->GetMetaFilepath(), metadataRevision))
+		{
+			staleLoadedAssetIds.Add(loaded.m_first);
+			continue;
+		}
+		liveAssetIds.Insert(loaded.m_first);
+		indexedMetadataPaths.Insert(PathKey(info->GetMetaFilepath()));
+		if (PathKey(info->GetMetaFilepath()) ==
+			PathKey(info->GetAssetFilepath() + "." + MetaFileExtension))
+		{
+			indexedPrimarySourcePaths.Insert(PathKey(info->GetAssetFilepath()));
+		}
+	}
+	for (const FileId& staleAssetId : staleLoadedAssetIds)
+	{
+		auto stale = m_loadedAssetInfo.Find(staleAssetId);
+		if (stale != m_loadedAssetInfo.end())
+		{
+			delete stale.Value();
+			m_loadedAssetInfo.Remove(staleAssetId);
+		}
+	}
+
+	{
+		std::lock_guard<std::recursive_mutex> lazyLock(m_lazyAssetInfoMutex);
+		m_lazyAssetInfos = std::move(stagedLazyAssetInfos);
+		m_contentMounts = discovery.m_mounts;
+		m_contentFileWinners = std::move(stagedContentWinners);
+		m_fileIds.Clear();
+		m_physicalFileIds.Clear();
+
+		for (const auto& lazy : m_lazyAssetInfos)
+		{
+			const LazyAssetInfoRecord& record = *lazy.m_second;
+			const std::filesystem::path metadataPath =
+				std::filesystem::path(record.m_sourcePath).parent_path() /
+				record.m_metadataFilename;
+			if (record.m_metadataFilename.empty() ||
+				PathKey(metadataPath) !=
+					PathKey(record.m_sourcePath + "." + MetaFileExtension))
+			{
+				continue;
+			}
+			const auto virtualPath = effectiveVirtualPathsByPhysicalPath.Find(
+				PathKey(record.m_sourcePath));
+			if (virtualPath != effectiveVirtualPathsByPhysicalPath.end())
+			{
+				m_fileIds[virtualPath.Value()] = lazy.m_first;
+				m_physicalFileIds[PathKey(record.m_sourcePath)] = lazy.m_first;
+			}
+		}
+		for (const auto& loaded : m_loadedAssetInfo)
+		{
+			AssetInfoPtr info = *loaded.m_second;
+			if (info == nullptr || !activeSourcePaths.Contains(PathKey(info->GetAssetFilepath())))
+			{
+				continue;
+			}
+			if (PathKey(info->GetMetaFilepath()) ==
+				PathKey(info->GetAssetFilepath() + "." + MetaFileExtension))
+			{
+				const auto virtualPath = effectiveVirtualPathsByPhysicalPath.Find(
+					PathKey(info->GetAssetFilepath()));
+				if (virtualPath != effectiveVirtualPathsByPhysicalPath.end())
+				{
+					m_physicalFileIds[PathKey(info->GetAssetFilepath())] = loaded.m_first;
+					m_fileIds[virtualPath.Value()] = loaded.m_first;
+				}
+			}
+		}
+	}
+
+	bool bSucceeded = true;
+	TSet<std::string> handledEffectiveContentChanges;
+	for (const FileId& expiredAssetId : expiredAssetIds)
+	{
+		const bool bWasLoaded = m_loadedAssetInfo.ContainsKey(expiredAssetId);
+		AssetInfoPtr info = bWasLoaded
+			? m_loadedAssetInfo[expiredAssetId]
+			: GetAssetInfoPtr_Internal(expiredAssetId);
+		if (info == nullptr || (bWasLoaded && !UpdateAsset(expiredAssetId)))
+		{
+			bSucceeded = false;
+			if (!bWasLoaded)
+			{
+				liveAssetIds.Remove(expiredAssetId);
+				std::lock_guard<std::recursive_mutex> lazyLock(m_lazyAssetInfoMutex);
+				m_lazyAssetInfos.Remove(expiredAssetId);
+			}
+			continue;
+		}
+
+		if (Extension(info->GetAssetFilepath()) == "glsl")
+		{
+			const auto virtualPath = effectiveVirtualPathsByPhysicalPath.Find(
+				PathKey(info->GetAssetFilepath()));
+			if (virtualPath != effectiveVirtualPathsByPhysicalPath.end())
+			{
+				handledEffectiveContentChanges.Insert(virtualPath.Value());
+			}
+		}
+	}
+
+	for (const auto& winner : m_contentFileWinners)
+	{
+		const AssetReadLocation& location = *winner.m_second;
+		if (indexedPrimarySourcePaths.Contains(PathKey(location.m_physicalPath)))
+		{
+			continue;
+		}
+		const FileId& importedId = LoadFile(location.m_virtualPath);
+		if (importedId)
+		{
+			liveAssetIds.Insert(importedId);
+			if (Extension(location.m_physicalPath.string()) == "glsl")
+			{
+				handledEffectiveContentChanges.Insert(winner.m_first);
+			}
+		}
+		else
+		{
+			bSucceeded = false;
+		}
+	}
+
+	for (const AssetMountDiscoveredFile& metadataFile : discovery.m_files)
+	{
+		if (Extension(metadataFile.m_virtualPath) != MetaFileExtension ||
+			indexedMetadataPaths.Contains(PathKey(metadataFile.m_physicalPath)))
+		{
+			continue;
+		}
+
+		std::string fileIdString;
+		std::string filename;
+		std::string assetInfoType;
+		std::string metadataError;
+		if (!ReadMetadataIdentity(
+				metadataFile.m_physicalPath,
+				fileIdString,
+				filename,
+				assetInfoType,
+				metadataError))
+		{
+			SAILOR_LOG_ERROR(
+				"Invalid new asset metadata '%s': %s.",
+				metadataFile.m_physicalPath.string().c_str(),
+				metadataError.c_str());
+			continue;
+		}
+
+		std::error_code sourceError;
+		const std::filesystem::path sourcePath =
+			std::filesystem::weakly_canonical(
+				metadataFile.m_physicalPath.parent_path() / filename,
+				sourceError);
+		if (sourceError || !activeSourcePaths.Contains(PathKey(sourcePath)))
+		{
+			SAILOR_LOG_ERROR(
+				"New asset metadata references a missing source and was skipped: %s",
+				metadataFile.m_physicalPath.string().c_str());
+			continue;
+		}
+
+		const bool bPrimary = PathKey(metadataFile.m_physicalPath) ==
+			PathKey(sourcePath.string() + "." + MetaFileExtension);
+		if (bPrimary)
+		{
+			// Primary metadata is loaded by the source import path above.
+			continue;
+		}
+
+		const FileId fileId = ParseFileId(fileIdString);
+		if (!fileId)
+		{
+			SAILOR_LOG_ERROR(
+				"New secondary metadata contains an invalid FileId: %s",
+				metadataFile.m_physicalPath.string().c_str());
+			continue;
+		}
+		AssetInfoPtr existingInfo = GetAssetInfoPtr_Internal(fileId);
+		if (existingInfo != nullptr)
+		{
+			if (PathKey(existingInfo->GetMetaFilepath()) !=
+				PathKey(metadataFile.m_physicalPath))
+			{
+				SAILOR_LOG_ERROR(
+					"New secondary metadata collides with an active FileId and was skipped: %s",
+					metadataFile.m_physicalPath.string().c_str());
+			}
+			continue;
+		}
+
+		std::filesystem::path handlerPath(metadataFile.m_virtualPath);
+		handlerPath.replace_extension();
+		IAssetInfoHandler* handler = GetAssetInfoHandler(
+			Extension(handlerPath.string()),
+			assetInfoType,
+			false);
+		if (handler == nullptr)
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot find a handler for new secondary metadata: %s",
+				metadataFile.m_physicalPath.string().c_str());
+			continue;
+		}
+
+		AssetInfoPtr info = handler->LoadAssetInfo(
+			metadataFile.m_physicalPath.string(),
+			metadataFile.m_virtualPath,
+			metadataFile.m_mount.m_kind,
+			metadataFile.m_mount.m_bWritable,
+			false,
+			false);
+		if (info == nullptr || info->GetFileId() != fileId ||
+			PathKey(info->GetAssetFilepath()) != PathKey(sourcePath))
+		{
+			delete info;
+			SAILOR_LOG_ERROR(
+				"New secondary metadata failed identity validation: %s",
+				metadataFile.m_physicalPath.string().c_str());
+			continue;
+		}
+
+		m_loadedAssetInfo[fileId] = info;
+		handler->NotifyUpdateAssetInfo(info);
+		CacheAsset(info);
+		liveAssetIds.Insert(fileId);
+		indexedMetadataPaths.Insert(PathKey(metadataFile.m_physicalPath));
+	}
+
+	for (const auto& loaded : m_loadedAssetInfo)
+	{
+		AssetInfoPtr info = *loaded.m_second;
+		FileRevision metadataRevision;
+		if (info != nullptr &&
+			activeSourcePaths.Contains(PathKey(info->GetAssetFilepath())) &&
+			revisionCache.TryGet(info->GetMetaFilepath(), metadataRevision))
+		{
+			liveAssetIds.Insert(loaded.m_first);
+		}
+	}
+	for (const auto& effectiveChange : effectiveContentChanges)
+	{
+		if (handledEffectiveContentChanges.Contains(effectiveChange.m_first) ||
+			Extension(*effectiveChange.m_second) != "glsl")
+		{
+			continue;
+		}
+		for (IAssetRegistryContentListener* listener : m_contentListeners)
+		{
+			if (listener != nullptr)
+			{
+				TrackScanProcessingTask(
+					listener->OnEffectiveContentChanged(*effectiveChange.m_second));
+			}
+		}
+	}
+	m_assetCache.Prune(liveAssetIds);
+	m_assetCache.SaveCache();
+	{
+		std::lock_guard<std::mutex> lock(m_assetProcessingMutex);
+		m_bCollectScanProcessingTasks = false;
+	}
+	return bSucceeded;
 }
 
 bool AssetRegistry::UpdateAsset(const FileId& fileId)
@@ -1924,6 +2437,10 @@ const FileId& AssetRegistry::LoadFile(const std::string& requestedPath)
 	}
 
 	m_loadedAssetInfo[fileId] = assetInfo;
+	{
+		std::lock_guard<std::recursive_mutex> lazyLock(m_lazyAssetInfoMutex);
+		m_lazyAssetInfos.Remove(fileId);
+	}
 	m_physicalFileIds[PathKey(location.m_physicalPath)] = fileId;
 	if (IsSafeVirtualPath(location.m_virtualPath))
 	{
@@ -1958,7 +2475,193 @@ AssetInfoPtr AssetRegistry::GetAssetInfoPtr_Internal(FileId uid) const
 	SAILOR_PROFILE_FUNCTION();
 
 	auto it = m_loadedAssetInfo.Find(uid);
-	return it != m_loadedAssetInfo.end() ? it.Value() : nullptr;
+	if (it != m_loadedAssetInfo.end())
+	{
+		return it.Value();
+	}
+	return g_bUseLazyAssetInfoLoading
+		? MaterializeLazyAssetInfo(uid)
+		: nullptr;
+}
+
+AssetInfoPtr AssetRegistry::MaterializeLazyAssetInfo(FileId uid) const
+{
+	std::lock_guard<std::recursive_mutex> lazyLock(m_lazyAssetInfoMutex);
+	auto loaded = m_loadedAssetInfo.Find(uid);
+	if (loaded != m_loadedAssetInfo.end())
+	{
+		return loaded.Value();
+	}
+
+	auto lazy = m_lazyAssetInfos.Find(uid);
+	if (lazy == m_lazyAssetInfos.end())
+	{
+		return nullptr;
+	}
+	const LazyAssetInfoRecord record = lazy.Value();
+	if (record.m_metadataFilename.empty() || record.m_assetInfoType.empty())
+	{
+		return nullptr;
+	}
+
+	const std::filesystem::path sourcePath(record.m_sourcePath);
+	const std::filesystem::path metadataPath =
+		sourcePath.parent_path() / record.m_metadataFilename;
+	FileRevision currentMetadataRevision;
+	if (!Utils::TryGetFileRevision(metadataPath.string(), currentMetadataRevision))
+	{
+		return nullptr;
+	}
+	const bool bMetadataChanged =
+		currentMetadataRevision != record.m_metadataRevision;
+	std::string resolvedAssetInfoType = record.m_assetInfoType;
+	if (bMetadataChanged)
+	{
+		std::string fileId;
+		std::string filename;
+		std::string assetInfoType;
+		std::string metadataError;
+		if (!ReadMetadataIdentity(
+				metadataPath,
+				fileId,
+				filename,
+				assetInfoType,
+				metadataError) ||
+			ParseFileId(fileId) != uid ||
+			PathKey(metadataPath.parent_path() / filename) != PathKey(sourcePath))
+		{
+			SAILOR_LOG_ERROR(
+				"Changed lazy asset metadata no longer matches its cached identity: %s",
+				metadataPath.string().c_str());
+			return nullptr;
+		}
+		resolvedAssetInfoType = std::move(assetInfoType);
+	}
+	const AssetMountDescriptor* metadataMount = nullptr;
+	for (const AssetMountDescriptor& mount : m_contentMounts)
+	{
+		if (IsInside(mount.m_root, metadataPath))
+		{
+			metadataMount = &mount;
+			break;
+		}
+	}
+	if (metadataMount == nullptr)
+	{
+		SAILOR_LOG_ERROR(
+			"Lazy asset metadata is outside active Content mounts: %s",
+			metadataPath.string().c_str());
+		return nullptr;
+	}
+
+	const bool bPrimary = PathKey(metadataPath) ==
+		PathKey(record.m_sourcePath + "." + MetaFileExtension);
+	std::filesystem::path metadataAssetPath = metadataPath;
+	const std::string handlerExtension = bPrimary
+		? Extension(record.m_sourcePath)
+		: Extension(metadataAssetPath.replace_extension().generic_string());
+	AssetRegistry* registry = const_cast<AssetRegistry*>(this);
+	IAssetInfoHandler* handler = registry->GetAssetInfoHandler(
+		handlerExtension,
+		resolvedAssetInfoType,
+		bPrimary);
+	if (handler == nullptr)
+	{
+		return nullptr;
+	}
+
+	const std::string virtualMetadataPath = metadataPath
+		.lexically_relative(metadataMount->m_root)
+		.generic_string();
+	AssetInfoPtr info = handler->LoadAssetInfo(
+		metadataPath.string(),
+		virtualMetadataPath,
+		metadataMount->m_kind,
+		metadataMount->m_bWritable,
+		false,
+		false);
+	if (info == nullptr || info->GetFileId() != uid ||
+		PathKey(info->GetAssetFilepath()) != PathKey(sourcePath))
+	{
+		delete info;
+		SAILOR_LOG_ERROR(
+			"Lazy asset metadata no longer matches its cache index: %s",
+			metadataPath.string().c_str());
+		return nullptr;
+	}
+
+	registry->m_loadedAssetInfo[uid] = info;
+	registry->m_lazyAssetInfos.Remove(uid);
+	info->m_bPendingWasExpired |= bMetadataChanged;
+	if (bPrimary)
+	{
+		const std::string virtualSourcePath = sourcePath
+			.lexically_relative(metadataMount->m_root)
+			.generic_string();
+		const std::string virtualSourcePathKey =
+			VirtualPathKey(virtualSourcePath);
+		const auto effectiveWinner = registry->m_contentFileWinners.Find(
+			virtualSourcePathKey);
+		if (effectiveWinner != registry->m_contentFileWinners.end() &&
+			PathKey(effectiveWinner.Value().m_physicalPath) == PathKey(sourcePath))
+		{
+			registry->m_physicalFileIds[PathKey(record.m_sourcePath)] = uid;
+			registry->m_fileIds[virtualSourcePathKey] = uid;
+		}
+	}
+	handler->NotifyUpdateAssetInfo(info);
+	registry->CacheAsset(info);
+	return info;
+}
+
+void AssetRegistry::GetLazyAssetInfoIds(
+	const std::string& assetInfoType,
+	TVector<FileId>& outIds) const
+{
+	outIds.Clear();
+	std::lock_guard<std::recursive_mutex> lazyLock(m_lazyAssetInfoMutex);
+	for (const auto& lazy : m_lazyAssetInfos)
+	{
+		if (lazy.m_second->m_assetInfoType == assetInfoType)
+		{
+			outIds.Add(lazy.m_first);
+		}
+	}
+}
+
+void AssetRegistry::GetAssetInfoIdsByTypeAndSource(
+	const std::string& assetInfoType,
+	const std::string& sourcePath,
+	TVector<FileId>& outIds) const
+{
+	outIds.Clear();
+	TSet<FileId> resultIds;
+	const std::string sourcePathKey = PathKey(sourcePath);
+	for (const auto& loaded : m_loadedAssetInfo)
+	{
+		AssetInfoPtr info = *loaded.m_second;
+		if (info != nullptr && info->GetAssetInfoType() == assetInfoType &&
+			PathKey(info->GetAssetFilepath()) == sourcePathKey)
+		{
+			resultIds.Insert(loaded.m_first);
+		}
+	}
+	{
+		std::lock_guard<std::recursive_mutex> lazyLock(m_lazyAssetInfoMutex);
+		for (const auto& lazy : m_lazyAssetInfos)
+		{
+			if (lazy.m_second->m_assetInfoType == assetInfoType &&
+				PathKey(lazy.m_second->m_sourcePath) == sourcePathKey)
+			{
+				resultIds.Insert(lazy.m_first);
+			}
+		}
+	}
+	outIds.Reserve(resultIds.Num());
+	for (const FileId& fileId : resultIds)
+	{
+		outIds.Add(fileId);
+	}
 }
 
 AssetInfoPtr AssetRegistry::GetAssetInfoPtr_Internal(const std::string& assetFilepath) const
@@ -1979,6 +2682,15 @@ AssetInfoPtr AssetRegistry::GetAssetInfoPtr_Internal(const std::string& assetFil
 		if (physicalId != m_physicalFileIds.end())
 		{
 			return GetAssetInfoPtr_Internal(physicalId.Value());
+		}
+		if (g_bUseLazyAssetInfoLoading)
+		{
+			AssetRegistry* registry = const_cast<AssetRegistry*>(this);
+			const FileId& loadedId = registry->LoadFile(assetFilepath);
+			if (loadedId)
+			{
+				return GetAssetInfoPtr_Internal(loadedId);
+			}
 		}
 	}
 	return nullptr;

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -19,7 +19,7 @@ namespace Sailor
 {
 	class AssetInfo;
 	using AssetInfoPtr = AssetInfo*;
-	SAILOR_API extern bool g_bUseLazyAssetInfoLoading;
+	SAILOR_SHARED_API extern bool g_bUseLazyAssetInfoLoading;
 
 	enum class EAssetType;
 

--- a/Runtime/AssetRegistry/AssetRegistry.h
+++ b/Runtime/AssetRegistry/AssetRegistry.h
@@ -19,6 +19,7 @@ namespace Sailor
 {
 	class AssetInfo;
 	using AssetInfoPtr = AssetInfo*;
+	SAILOR_API extern bool g_bUseLazyAssetInfoLoading;
 
 	enum class EAssetType;
 
@@ -187,12 +188,30 @@ namespace Sailor
 		void GetAllAssetInfos(TVector<FileId>& outAssetInfos) const
 		{
 			outAssetInfos.Clear();
+			TSet<FileId> resultIds;
 			for (const auto& assetInfo : m_loadedAssetInfo)
 			{
 				if (dynamic_cast<TAssetInfo*>(*assetInfo.m_second))
 				{
-					outAssetInfos.Add(assetInfo.m_first);
+					resultIds.Insert(assetInfo.m_first);
 				}
+			}
+
+			if (g_bUseLazyAssetInfoLoading)
+			{
+				TAssetInfo assetInfoTypeProbe;
+				TVector<FileId> lazyIds;
+				GetLazyAssetInfoIds(assetInfoTypeProbe.GetAssetInfoType(), lazyIds);
+				for (const FileId& lazyId : lazyIds)
+				{
+					resultIds.Insert(lazyId);
+				}
+			}
+
+			outAssetInfos.Reserve(resultIds.Num());
+			for (const FileId& fileId : resultIds)
+			{
+				outAssetInfos.Add(fileId);
 			}
 		}
 
@@ -231,6 +250,15 @@ namespace Sailor
 
 		SAILOR_API AssetInfoPtr GetAssetInfoPtr_Internal(FileId uid) const;
 		SAILOR_API AssetInfoPtr GetAssetInfoPtr_Internal(const std::string& assetFilepath) const;
+		bool ScanContentFolderLazy();
+		AssetInfoPtr MaterializeLazyAssetInfo(FileId uid) const;
+		void GetLazyAssetInfoIds(
+			const std::string& assetInfoType,
+			TVector<FileId>& outIds) const;
+		void GetAssetInfoIdsByTypeAndSource(
+			const std::string& assetInfoType,
+			const std::string& sourcePath,
+			TVector<FileId>& outIds) const;
 		bool RestoreAssetImportTime(
 			AssetInfoPtr info,
 			const FileRevision& sourceRevision);
@@ -251,9 +279,21 @@ namespace Sailor
 		TVector<AssetMountDescriptor> m_contentMounts;
 		TMap<std::string, AssetReadLocation> m_contentFileWinners;
 		TVector<IAssetRegistryContentListener*> m_contentListeners;
+		struct LazyAssetInfoRecord final
+		{
+			std::string m_sourcePath;
+			FileRevision m_sourceRevision{};
+			std::string m_metadataFilename;
+			FileRevision m_metadataRevision{};
+			std::string m_assetInfoType;
+		};
+		mutable std::recursive_mutex m_lazyAssetInfoMutex;
+		mutable TMap<FileId, LazyAssetInfoRecord> m_lazyAssetInfos;
 		struct AssetProcessingState final
 		{
 			AssetProcessingToken m_token;
+			std::string m_metadataFilename;
+			std::string m_assetInfoType;
 			bool m_bRejected = false;
 		};
 		std::mutex m_assetProcessingMutex;

--- a/Runtime/AssetRegistry/Model/GltfImporterUtils.h
+++ b/Runtime/AssetRegistry/Model/GltfImporterUtils.h
@@ -2,6 +2,7 @@
 
 #include "Containers/Vector.h"
 #include "Core/Defines.h"
+#include "Math/Transform.h"
 #include "RHI/Types.h"
 
 #include <glm/mat4x4.hpp>
@@ -60,6 +61,19 @@ namespace Sailor::GltfImporterUtils
 		glm::vec3 m_bakedVolumeScale{ 1.0f };
 	};
 
+	struct SceneNode
+	{
+		std::string m_name;
+		int32_t m_sourceNodeIndex = -1;
+		int32_t m_parentIndex = -1;
+		int32_t m_meshIndex = -1;
+		int32_t m_skinIndex = -1;
+		Math::Transform m_localTransform{};
+		glm::mat4 m_localMatrix{ 1.0f };
+		glm::mat4 m_worldMatrix{ 1.0f };
+		bool m_bTransformDecomposable = true;
+	};
+
 	SAILOR_SHARED_API MeshInstanceTransforms ResolveMeshInstanceTransforms(
 		const MeshInstance& instance,
 		float unitScale);
@@ -93,4 +107,9 @@ namespace Sailor::GltfImporterUtils
 	SAILOR_SHARED_API bool CollectMeshInstances(
 		const tinygltf::Model& model,
 		TVector<MeshInstance>& outInstances);
+
+	SAILOR_SHARED_API bool CollectSceneNodes(
+		const tinygltf::Model& model,
+		float unitScale,
+		TVector<SceneNode>& outNodes);
 }

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -2332,11 +2332,17 @@ bool GltfImporterUtils::TryComposeNodeMatrix(
 	return IsFiniteGltfMatrix(outMatrix);
 }
 
-bool GltfImporterUtils::CollectMeshInstances(
+bool GltfImporterUtils::CollectSceneNodes(
 	const tinygltf::Model& model,
-	TVector<MeshInstance>& outInstances)
+	float unitScale,
+	TVector<SceneNode>& outNodes)
 {
-	outInstances.Clear();
+	outNodes.Clear();
+	if (!std::isfinite(unitScale))
+	{
+		return false;
+	}
+
 	if (model.meshes.size() >
 		static_cast<size_t>(std::numeric_limits<int32_t>::max()) ||
 		model.nodes.size() >
@@ -2347,12 +2353,15 @@ bool GltfImporterUtils::CollectMeshInstances(
 
 	if (model.nodes.empty())
 	{
-		outInstances.Reserve(model.meshes.size());
+		outNodes.Reserve(model.meshes.size());
 		for (size_t meshIndex = 0; meshIndex < model.meshes.size(); ++meshIndex)
 		{
-			MeshInstance instance{};
-			instance.m_meshIndex = static_cast<int32_t>(meshIndex);
-			outInstances.Add(std::move(instance));
+			SceneNode node{};
+			node.m_name = model.meshes[meshIndex].name.empty() ?
+				"Mesh_" + std::to_string(meshIndex) :
+				model.meshes[meshIndex].name;
+			node.m_meshIndex = static_cast<int32_t>(meshIndex);
+			outNodes.Add(std::move(node));
 		}
 		return true;
 	}
@@ -2361,13 +2370,14 @@ bool GltfImporterUtils::CollectMeshInstances(
 	struct PendingNode
 	{
 		int32_t m_nodeIndex = -1;
-		glm::mat4 m_parentTransform{ 1.0f };
+		int32_t m_parentIndex = -1;
+		glm::mat4 m_parentWorldMatrix{ 1.0f };
 		bool m_bExit = false;
 	};
 	auto traverseRoot = [&](int32_t rootNode) -> bool
 		{
 			TVector<PendingNode> pendingNodes;
-			pendingNodes.Add({ rootNode, glm::mat4(1.0f), false });
+			pendingNodes.Add({ rootNode, -1, glm::mat4(1.0f), false });
 			while (!pendingNodes.IsEmpty())
 			{
 				PendingNode pending = std::move(*pendingNodes.Last());
@@ -2392,7 +2402,7 @@ bool GltfImporterUtils::CollectMeshInstances(
 				}
 				if (state == 2)
 				{
-					continue;
+					return false;
 				}
 
 				state = 1;
@@ -2404,9 +2414,14 @@ bool GltfImporterUtils::CollectMeshInstances(
 					return false;
 				}
 
-				const glm::mat4 worldTransform =
-					pending.m_parentTransform * localTransform;
-				if (!IsFiniteGltfMatrix(worldTransform))
+				glm::mat4 scaledLocalMatrix = localTransform;
+				scaledLocalMatrix[3].x *= unitScale;
+				scaledLocalMatrix[3].y *= unitScale;
+				scaledLocalMatrix[3].z *= unitScale;
+				const glm::mat4 worldMatrix =
+					pending.m_parentWorldMatrix * scaledLocalMatrix;
+				if (!IsFiniteGltfMatrix(scaledLocalMatrix) ||
+					!IsFiniteGltfMatrix(worldMatrix))
 				{
 					return false;
 				}
@@ -2421,18 +2436,47 @@ bool GltfImporterUtils::CollectMeshInstances(
 					return false;
 				}
 
-				if (node.mesh >= 0)
+				SceneNode sceneNode{};
+				sceneNode.m_name = node.name.empty() ?
+					"Node_" + std::to_string(pending.m_nodeIndex) :
+					node.name;
+				sceneNode.m_sourceNodeIndex = pending.m_nodeIndex;
+				sceneNode.m_parentIndex = pending.m_parentIndex;
+				sceneNode.m_meshIndex = node.mesh;
+				sceneNode.m_skinIndex = node.skin;
+				sceneNode.m_localMatrix = scaledLocalMatrix;
+				sceneNode.m_worldMatrix = worldMatrix;
+				sceneNode.m_localTransform =
+					Math::Transform::FromMatrix(scaledLocalMatrix);
+
+				const glm::mat4 reconstructed =
+					sceneNode.m_localTransform.Matrix();
+				float maxDifference = 0.0f;
+				float maxMagnitude = 1.0f;
+				for (int32_t column = 0; column < 4; ++column)
 				{
-					MeshInstance instance{};
-					instance.m_nodeIndex = pending.m_nodeIndex;
-					instance.m_meshIndex = node.mesh;
-					instance.m_skinIndex = node.skin;
-					instance.m_worldTransform = worldTransform;
-					outInstances.Add(std::move(instance));
+					for (int32_t row = 0; row < 4; ++row)
+					{
+						maxDifference = (std::max)(
+							maxDifference,
+							std::abs(
+								reconstructed[column][row] -
+								scaledLocalMatrix[column][row]));
+						maxMagnitude = (std::max)(
+							maxMagnitude,
+							std::abs(scaledLocalMatrix[column][row]));
+					}
 				}
+				sceneNode.m_bTransformDecomposable =
+					maxDifference <= maxMagnitude * 1e-4f;
+
+				const int32_t outputNodeIndex =
+					static_cast<int32_t>(outNodes.Num());
+				outNodes.Add(std::move(sceneNode));
 
 				pendingNodes.Add({
 					pending.m_nodeIndex,
+					pending.m_parentIndex,
 					glm::mat4(1.0f),
 					true
 				});
@@ -2440,7 +2484,8 @@ bool GltfImporterUtils::CollectMeshInstances(
 				{
 					pendingNodes.Add({
 						node.children[child - 1],
-						worldTransform,
+						outputNodeIndex,
+						worldMatrix,
 						false
 					});
 				}
@@ -2466,7 +2511,7 @@ bool GltfImporterUtils::CollectMeshInstances(
 		{
 			if (!traverseRoot(rootNode))
 			{
-				outInstances.Clear();
+				outNodes.Clear();
 				return false;
 			}
 		}
@@ -2495,7 +2540,7 @@ bool GltfImporterUtils::CollectMeshInstances(
 				bTraversedRoot = true;
 				if (!traverseRoot(static_cast<int32_t>(nodeIndex)))
 				{
-					outInstances.Clear();
+					outNodes.Clear();
 					return false;
 				}
 			}
@@ -2504,8 +2549,38 @@ bool GltfImporterUtils::CollectMeshInstances(
 
 	if (!bTraversedRoot)
 	{
-		outInstances.Clear();
+		outNodes.Clear();
 		return false;
+	}
+
+	return true;
+}
+
+bool GltfImporterUtils::CollectMeshInstances(
+	const tinygltf::Model& model,
+	TVector<MeshInstance>& outInstances)
+{
+	outInstances.Clear();
+	TVector<SceneNode> nodes;
+	if (!CollectSceneNodes(model, 1.0f, nodes))
+	{
+		return false;
+	}
+
+	outInstances.Reserve(nodes.Num());
+	for (const SceneNode& node : nodes)
+	{
+		if (node.m_meshIndex < 0)
+		{
+			continue;
+		}
+
+		MeshInstance instance{};
+		instance.m_nodeIndex = node.m_sourceNodeIndex;
+		instance.m_meshIndex = node.m_meshIndex;
+		instance.m_skinIndex = node.m_skinIndex;
+		instance.m_worldTransform = node.m_worldMatrix;
+		outInstances.Add(std::move(instance));
 	}
 
 	return true;
@@ -2597,8 +2672,127 @@ void Model::Deserialize(const YAML::Node& inData)
 	DESERIALIZE_PROPERTY(inData, m_fileId);
 }
 
+bool Model::IsSourceMeshIndexValid(int32_t meshIndex) const
+{
+	return meshIndex >= 0 &&
+		static_cast<size_t>(meshIndex) < m_sourceMeshes.Num() &&
+		!m_sourceMeshes[static_cast<size_t>(meshIndex)].m_renderMeshIndices.IsEmpty();
+}
+
+const Math::AABB& Model::GetBoundsAABB(int32_t meshIndex) const
+{
+	if (meshIndex == AllMeshes)
+	{
+		return m_boundsAabb;
+	}
+
+	static const Math::AABB emptyBounds{};
+	return IsSourceMeshIndexValid(meshIndex) ?
+		m_sourceMeshes[static_cast<size_t>(meshIndex)].m_bounds :
+		emptyBounds;
+}
+
+bool Model::HasBLAS(int32_t meshIndex) const
+{
+	if (meshIndex == AllMeshes)
+	{
+		return HasBLAS();
+	}
+
+	return meshIndex >= 0 &&
+		static_cast<size_t>(meshIndex) < m_sourceMeshBlases.Num() &&
+		m_sourceMeshBlases[static_cast<size_t>(meshIndex)].IsValid();
+}
+
+const TSharedPtr<Raytracing::BVH>& Model::GetBLAS(int32_t meshIndex) const
+{
+	if (meshIndex == AllMeshes)
+	{
+		return m_blas;
+	}
+
+	static const TSharedPtr<Raytracing::BVH> emptyBlas{};
+	return meshIndex >= 0 &&
+		static_cast<size_t>(meshIndex) < m_sourceMeshBlases.Num() ?
+		m_sourceMeshBlases[static_cast<size_t>(meshIndex)].m_blas :
+		emptyBlas;
+}
+
+const TVector<Math::Triangle>& Model::GetBLASTriangles(
+	int32_t meshIndex) const
+{
+	if (meshIndex == AllMeshes)
+	{
+		return m_blasTriangles;
+	}
+
+	static const TVector<Math::Triangle> emptyTriangles{};
+	return meshIndex >= 0 &&
+		static_cast<size_t>(meshIndex) < m_sourceMeshBlases.Num() ?
+		m_sourceMeshBlases[static_cast<size_t>(meshIndex)].m_triangles :
+		emptyTriangles;
+}
+
+bool Model::CollectRenderData(
+	int32_t meshIndex,
+	TVector<RHI::RHIMeshPtr>& outMeshes,
+	TVector<glm::mat4>& outModelMatrices,
+	Math::AABB& outBounds) const
+{
+	outMeshes.Clear();
+	outModelMatrices.Clear();
+	outBounds = Math::AABB();
+
+	if (meshIndex == AllMeshes)
+	{
+		outMeshes.Reserve(m_renderInstances.Num());
+		outModelMatrices.Reserve(m_renderInstances.Num());
+		for (const RenderInstance& instance : m_renderInstances)
+		{
+			if (instance.m_renderMeshIndex >= m_meshes.Num() ||
+				!m_meshes[instance.m_renderMeshIndex])
+			{
+				continue;
+			}
+
+			const RHI::RHIMeshPtr& mesh =
+				m_meshes[instance.m_renderMeshIndex];
+			outMeshes.Add(mesh);
+			outModelMatrices.Add(instance.m_modelMatrix);
+			Math::AABB instanceBounds = mesh->m_bounds;
+			instanceBounds.Apply(instance.m_modelMatrix);
+			outBounds.Extend(instanceBounds);
+		}
+	}
+	else if (IsSourceMeshIndexValid(meshIndex))
+	{
+		const SourceMesh& sourceMesh =
+			m_sourceMeshes[static_cast<size_t>(meshIndex)];
+		outMeshes.Reserve(sourceMesh.m_renderMeshIndices.Num());
+		outModelMatrices.Reserve(sourceMesh.m_renderMeshIndices.Num());
+		for (uint32_t renderMeshIndex : sourceMesh.m_renderMeshIndices)
+		{
+			if (renderMeshIndex >= m_meshes.Num() ||
+				!m_meshes[renderMeshIndex])
+			{
+				continue;
+			}
+
+			outMeshes.Add(m_meshes[renderMeshIndex]);
+			outModelMatrices.Add(glm::mat4(1.0f));
+		}
+		outBounds = sourceMesh.m_bounds;
+	}
+
+	return !outMeshes.IsEmpty() &&
+		outMeshes.Num() == outModelMatrices.Num() &&
+		outBounds.IsValid();
+}
+
 void Model::Flush()
 {
+	m_bGpuReady.store(false, std::memory_order_release);
+
 	if (m_meshes.Num() == 0)
 	{
 		m_bIsReady.store(false, std::memory_order_release);
@@ -2619,12 +2813,13 @@ void Model::Flush()
 	m_bIsReady.store(true, std::memory_order_release);
 }
 
-bool Model::BuildBLAS()
+bool Model::BuildBLASData(
+	const TVector<RenderInstance>& blasInstances,
+	BLASData& outData) const
 {
-	m_blas.Clear();
-	m_blasTriangles.Clear();
+	outData = BLASData{};
 
-	if (m_cpuMeshes.Num() == 0)
+	if (m_cpuMeshes.Num() == 0 || blasInstances.IsEmpty())
 	{
 		return false;
 	}
@@ -2632,8 +2827,13 @@ bool Model::BuildBLAS()
 	size_t expectedNumTriangles = 0;
 	constexpr size_t maxNumTriangles =
 		(static_cast<size_t>(std::numeric_limits<uint32_t>::max()) + 1) / 2;
-	for (const auto& mesh : m_cpuMeshes)
+	for (const RenderInstance& instance : blasInstances)
 	{
+		if (instance.m_renderMeshIndex >= m_cpuMeshes.Num())
+		{
+			return false;
+		}
+		const MeshCpuData& mesh = m_cpuMeshes[instance.m_renderMeshIndex];
 		if (mesh.m_indices.Num() % 3 != 0)
 		{
 			return false;
@@ -2653,10 +2853,24 @@ bool Model::BuildBLAS()
 		return false;
 	}
 
-	m_blasTriangles.Reserve(expectedNumTriangles);
+	outData.m_triangles.Reserve(expectedNumTriangles);
 
-	for (const auto& mesh : m_cpuMeshes)
+	for (const RenderInstance& instance : blasInstances)
 	{
+		const MeshCpuData& mesh = m_cpuMeshes[instance.m_renderMeshIndex];
+		const glm::mat3 linearMatrix(instance.m_modelMatrix);
+		glm::mat3 normalMatrix = linearMatrix;
+		const float determinant = glm::determinant(linearMatrix);
+		if (std::isfinite(determinant) && determinant != 0.0f)
+		{
+			const glm::mat3 inverseTranspose =
+				glm::transpose(glm::inverse(linearMatrix));
+			if (IsFiniteGltfMatrix(inverseTranspose))
+			{
+				normalMatrix = inverseTranspose;
+			}
+		}
+
 		for (size_t i = 0; i + 2 < mesh.m_indices.Num(); i += 3)
 		{
 			const uint32_t i0 = mesh.m_indices[i + 0];
@@ -2666,18 +2880,30 @@ bool Model::BuildBLAS()
 				i1 >= mesh.m_vertices.Num() ||
 				i2 >= mesh.m_vertices.Num())
 			{
-				m_blasTriangles.Clear();
+				outData.m_triangles.Clear();
 				return false;
 			}
 
 			auto v0 = mesh.m_vertices[i0];
 			auto v1 = mesh.m_vertices[i1];
 			auto v2 = mesh.m_vertices[i2];
+			auto applyInstanceTransform = [&](auto& vertex)
+				{
+					vertex.m_position = glm::vec3(
+						instance.m_modelMatrix *
+						glm::vec4(vertex.m_position, 1.0f));
+					vertex.m_normal = normalMatrix * vertex.m_normal;
+					vertex.m_tangent = linearMatrix * vertex.m_tangent;
+					vertex.m_bitangent = linearMatrix * vertex.m_bitangent;
+				};
+			applyInstanceTransform(v0);
+			applyInstanceTransform(v1);
+			applyInstanceTransform(v2);
 			if (!Math::AllFinite(v0.m_position) ||
 				!Math::AllFinite(v1.m_position) ||
 				!Math::AllFinite(v2.m_position))
 			{
-				m_blasTriangles.Clear();
+				outData.m_triangles.Clear();
 				return false;
 			}
 
@@ -2689,7 +2915,7 @@ bool Model::BuildBLAS()
 				!Math::AllFinite(triangleNormal) ||
 				!std::isfinite(glm::dot(triangleNormal, triangleNormal)))
 			{
-				m_blasTriangles.Clear();
+				outData.m_triangles.Clear();
 				return false;
 			}
 
@@ -2706,7 +2932,7 @@ bool Model::BuildBLAS()
 				!Math::AllFinite(v1.m_bitangent) ||
 				!Math::AllFinite(v2.m_bitangent))
 			{
-				m_blasTriangles.Clear();
+				outData.m_triangles.Clear();
 				return false;
 			}
 
@@ -2743,21 +2969,71 @@ bool Model::BuildBLAS()
 				tri.m_vertices[2] / 3.0f;
 			if (!Math::AllFinite(tri.m_centroid))
 			{
-				m_blasTriangles.Clear();
+				outData.m_triangles.Clear();
 				return false;
 			}
 
-			m_blasTriangles.Add(tri);
+			outData.m_triangles.Add(tri);
 		}
 	}
 
-	if (m_blasTriangles.Num() == 0)
+	if (outData.m_triangles.Num() == 0)
 	{
 		return false;
 	}
 
-	m_blas = TSharedPtr<Raytracing::BVH>::Make((uint32_t)m_blasTriangles.Num());
-	m_blas->BuildBVH(m_blasTriangles);
+	outData.m_blas = TSharedPtr<Raytracing::BVH>::Make(
+		static_cast<uint32_t>(outData.m_triangles.Num()));
+	outData.m_blas->BuildBVH(outData.m_triangles);
+	return true;
+}
+
+bool Model::BuildBLAS()
+{
+	m_blas.Clear();
+	m_blasTriangles.Clear();
+	m_sourceMeshBlases.Clear();
+
+	TVector<RenderInstance> fullInstances = m_renderInstances;
+	if (fullInstances.IsEmpty())
+	{
+		fullInstances.Reserve(m_cpuMeshes.Num());
+		for (size_t meshIndex = 0; meshIndex < m_cpuMeshes.Num(); ++meshIndex)
+		{
+			RenderInstance instance{};
+			instance.m_renderMeshIndex = static_cast<uint32_t>(meshIndex);
+			fullInstances.Add(std::move(instance));
+		}
+	}
+
+	BLASData fullBlas;
+	if (!BuildBLASData(fullInstances, fullBlas))
+	{
+		return false;
+	}
+
+	m_blas = std::move(fullBlas.m_blas);
+	m_blasTriangles = std::move(fullBlas.m_triangles);
+	m_sourceMeshBlases.Resize(m_sourceMeshes.Num());
+	for (size_t sourceMeshIndex = 0;
+		sourceMeshIndex < m_sourceMeshes.Num();
+		++sourceMeshIndex)
+	{
+		TVector<RenderInstance> sourceInstances;
+		const SourceMesh& sourceMesh = m_sourceMeshes[sourceMeshIndex];
+		sourceInstances.Reserve(sourceMesh.m_renderMeshIndices.Num());
+		for (uint32_t renderMeshIndex : sourceMesh.m_renderMeshIndices)
+		{
+			RenderInstance instance{};
+			instance.m_renderMeshIndex = renderMeshIndex;
+			sourceInstances.Add(std::move(instance));
+		}
+
+		BuildBLASData(
+			sourceInstances,
+			m_sourceMeshBlases[sourceMeshIndex]);
+	}
+
 	return true;
 }
 
@@ -2771,6 +3047,7 @@ void Model::ProceedCpuMeshes(bool bShouldGenerateBLAS, bool bShouldKeepCpuBuffer
 	{
 		m_blas.Clear();
 		m_blasTriangles.Clear();
+		m_sourceMeshBlases.Clear();
 	}
 
 	if (!bShouldKeepCpuBuffers)
@@ -2781,9 +3058,17 @@ void Model::ProceedCpuMeshes(bool bShouldGenerateBLAS, bool bShouldKeepCpuBuffer
 
 bool Model::IsReady() const
 {
-	if (!m_bIsReady.load(std::memory_order_acquire))
+	if (!IsStructurallyReady())
 	{
 		return false;
+	}
+
+	// GPU upload completion is monotonic until the next Flush(). Large editable
+	// model hierarchies can reference one Model from thousands of renderers, so
+	// rescanning every RHIMesh for every component would be O(N^2) per frame.
+	if (m_bGpuReady.load(std::memory_order_acquire))
+	{
+		return true;
 	}
 
 	for (const auto& mesh : m_meshes)
@@ -2794,7 +3079,13 @@ bool Model::IsReady() const
 		}
 	}
 
+	m_bGpuReady.store(true, std::memory_order_release);
 	return true;
+}
+
+bool Model::IsStructurallyReady() const
+{
+	return m_bIsReady.load(std::memory_order_acquire);
 }
 
 ModelImporter::ModelImporter(ModelAssetInfoHandler* infoHandler)
@@ -3047,6 +3338,17 @@ bool ModelImporter::GenerateFingerprint(
 	{
 		SAILOR_LOG_ERROR(
 			"Cannot prepare model fingerprint: %s",
+			assetFilepath.c_str());
+		return false;
+	}
+	TVector<GltfImporterUtils::SceneNode> sceneNodes;
+	if (!GltfImporterUtils::CollectSceneNodes(
+			gltfModel,
+			unitScale,
+			sceneNodes))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot resolve model fingerprint hierarchy: %s",
 			assetFilepath.c_str());
 		return false;
 	}
@@ -3339,16 +3641,20 @@ bool ModelImporter::GenerateFingerprint(
 		}
 		previewMaterials[i] = std::move(material);
 	}
-	gltfModel = tinygltf::Model();
-
 	ModelPtr model = ModelPtr::Make(allocator, fileId);
 	model->m_boundsAabb = boundsAabb;
 	model->m_boundsSphere = boundsSphere;
 	model->m_inverseBind = std::move(inverseBind);
 	model->m_cpuMeshes.Reserve(parsedMeshes.Num());
+	model->m_sourceMeshes.Resize(gltfModel.meshes.size());
 
 	for (MeshContext& mesh : parsedMeshes)
 	{
+		if (!mesh.HasGeometry())
+		{
+			continue;
+		}
+
 		Model::MeshCpuData cpuMesh{};
 		cpuMesh.m_vertices = std::move(mesh.outVertices);
 		for (auto& vertex : cpuMesh.m_vertices)
@@ -3358,8 +3664,22 @@ bool ModelImporter::GenerateFingerprint(
 		cpuMesh.m_indices = std::move(mesh.outIndices);
 		cpuMesh.m_bounds = mesh.bounds;
 		cpuMesh.m_materialIndex = mesh.materialIndex;
+		const uint32_t renderMeshIndex =
+			static_cast<uint32_t>(model->m_cpuMeshes.Num());
 		model->m_cpuMeshes.Add(std::move(cpuMesh));
+		if (mesh.sourceMeshIndex >= 0 &&
+			static_cast<size_t>(mesh.sourceMeshIndex) <
+				model->m_sourceMeshes.Num())
+		{
+			auto& sourceMesh = model->m_sourceMeshes[
+				static_cast<size_t>(mesh.sourceMeshIndex)];
+			sourceMesh.m_renderMeshIndices.Add(renderMeshIndex);
+			sourceMesh.m_bounds.Extend(mesh.bounds);
+		}
 	}
+
+	PopulateModelSceneHierarchy(*model, sceneNodes);
+	gltfModel = tinygltf::Model();
 
 	if (!model->BuildBLAS())
 	{
@@ -4379,7 +4699,10 @@ bool ModelImporter::UpdateGeneratedMaterialProperties(
 		};
 
 	TVector<FileId> registeredTextureIds;
-	assetRegistry->GetAllAssetInfos<TextureAssetInfo>(registeredTextureIds);
+	assetRegistry->GetAssetInfoIdsByTypeAndSource(
+		"Sailor::TextureAssetInfo",
+		assetInfo->GetAssetFilepath(),
+		registeredTextureIds);
 	TMap<int32_t, FileId> textureIdsByGltfIndex;
 	for (const FileId& registeredTextureId : registeredTextureIds)
 	{
@@ -4656,6 +4979,54 @@ bool ModelImporter::UpdateGeneratedMaterialProperties(
 	return bSucceeded;
 }
 
+void ModelImporter::PopulateModelSceneHierarchy(
+	Model& model,
+	TVector<GltfImporterUtils::SceneNode>& sourceNodes)
+{
+	model.m_nodes.Clear();
+	model.m_renderInstances.Clear();
+	model.m_bSupportsEditableHierarchy = true;
+	model.m_nodes.Reserve(sourceNodes.Num());
+	for (auto& sourceNode : sourceNodes)
+	{
+		Model::Node node{};
+		node.m_name = std::move(sourceNode.m_name);
+		node.m_sourceNodeIndex = sourceNode.m_sourceNodeIndex;
+		node.m_parentIndex = sourceNode.m_parentIndex;
+		node.m_meshIndex = sourceNode.m_meshIndex;
+		node.m_skinIndex = sourceNode.m_skinIndex;
+		node.m_localTransform = sourceNode.m_localTransform;
+		node.m_localMatrix = sourceNode.m_localMatrix;
+		node.m_worldMatrix = sourceNode.m_worldMatrix;
+		node.m_bTransformDecomposable =
+			sourceNode.m_bTransformDecomposable;
+		model.m_bSupportsEditableHierarchy &=
+			node.m_bTransformDecomposable && node.m_skinIndex < 0;
+		model.m_nodes.Add(std::move(node));
+	}
+
+	for (size_t nodeIndex = 0; nodeIndex < model.m_nodes.Num(); ++nodeIndex)
+	{
+		const Model::Node& node = model.m_nodes[nodeIndex];
+		if (!model.IsSourceMeshIndexValid(node.m_meshIndex))
+		{
+			continue;
+		}
+
+		const Model::SourceMesh& sourceMesh = model.m_sourceMeshes[
+			static_cast<size_t>(node.m_meshIndex)];
+		for (uint32_t renderMeshIndex : sourceMesh.m_renderMeshIndices)
+		{
+			Model::RenderInstance instance{};
+			instance.m_renderMeshIndex = renderMeshIndex;
+			instance.m_nodeIndex = static_cast<int32_t>(nodeIndex);
+			instance.m_modelMatrix = node.m_skinIndex >= 0 ?
+				glm::mat4(1.0f) : node.m_worldMatrix;
+			model.m_renderInstances.Add(std::move(instance));
+		}
+	}
+}
+
 Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel)
 {
 	SAILOR_PROFILE_FUNCTION();
@@ -4702,6 +5073,8 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 		{
 			TVector<MeshContext> m_parsedMeshes;
 			TVector<glm::mat4> m_inverseBind;
+			TVector<GltfImporterUtils::SceneNode> m_sceneNodes;
+			TVector<std::string> m_sourceMeshNames;
 			tinygltf::Model m_gltfModel;
 			bool m_bIsImported = false;
 			bool m_bShouldKeepCpuBuffers = false;
@@ -4723,6 +5096,30 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 					boundsSphere,
 					pData->m_inverseBind,
 					&pData->m_gltfModel);
+				if (pData->m_bIsImported)
+				{
+					pData->m_bIsImported =
+						GltfImporterUtils::CollectSceneNodes(
+							pData->m_gltfModel,
+							pAssetInfo->GetUnitScale(),
+							pData->m_sceneNodes);
+				}
+				if (pData->m_bIsImported)
+				{
+					pData->m_sourceMeshNames.Reserve(
+						pData->m_gltfModel.meshes.size());
+					for (size_t meshIndex = 0;
+						meshIndex < pData->m_gltfModel.meshes.size();
+						++meshIndex)
+					{
+						const std::string& sourceName =
+							pData->m_gltfModel.meshes[meshIndex].name;
+						pData->m_sourceMeshNames.Add(
+							sourceName.empty() ?
+								"Mesh_" + std::to_string(meshIndex) :
+								sourceName);
+					}
+				}
 				return pData;
 			});
 		auto migrationTask = loadDataTask->Then(
@@ -4748,7 +5145,20 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 					{
 						pModel->m_meshes.Clear();
 						pModel->m_cpuMeshes.Clear();
+						pModel->m_nodes.Clear();
+						pModel->m_sourceMeshes.Clear();
+						pModel->m_renderInstances.Clear();
+						pModel->m_bSupportsEditableHierarchy = true;
 						pModel->m_meshes.Reserve(pData->m_parsedMeshes.Num());
+						pModel->m_sourceMeshes.Resize(
+							pData->m_sourceMeshNames.Num());
+						for (size_t sourceMeshIndex = 0;
+							sourceMeshIndex < pData->m_sourceMeshNames.Num();
+							++sourceMeshIndex)
+						{
+							pModel->m_sourceMeshes[sourceMeshIndex].m_name =
+								std::move(pData->m_sourceMeshNames[sourceMeshIndex]);
+						}
 						if (pData->m_bShouldKeepCpuBuffers || pData->m_bShouldGenerateBLAS)
 						{
 							pModel->m_cpuMeshes.Reserve(pData->m_parsedMeshes.Num());
@@ -4776,7 +5186,20 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 								mesh.outVertices.GetData(), sizeof(RHI::VertexP3N3T3B3UV2C4I4W4) * mesh.outVertices.Num(),
 								mesh.outIndices.GetData(), sizeof(uint32_t) * mesh.outIndices.Num());
 
+							const uint32_t renderMeshIndex =
+								static_cast<uint32_t>(pModel->m_meshes.Num());
 							pModel->m_meshes.Emplace(pMesh);
+							if (mesh.sourceMeshIndex >= 0 &&
+								static_cast<size_t>(mesh.sourceMeshIndex) <
+									pModel->m_sourceMeshes.Num())
+							{
+								Model::SourceMesh& sourceMesh =
+									pModel->m_sourceMeshes[
+										static_cast<size_t>(mesh.sourceMeshIndex)];
+								sourceMesh.m_renderMeshIndices.Add(
+									renderMeshIndex);
+								sourceMesh.m_bounds.Extend(mesh.bounds);
+							}
 
 							if (pData->m_bShouldKeepCpuBuffers || pData->m_bShouldGenerateBLAS)
 							{
@@ -4788,6 +5211,10 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 								pModel->m_cpuMeshes.Add(std::move(cpuMesh));
 							}
 						}
+
+						ModelImporter::PopulateModelSceneHierarchy(
+							*pModel,
+							pData->m_sceneNodes);
 
 						pModel->m_inverseBind = std::move(pData->m_inverseBind);
 						pModel->ProceedCpuMeshes(pData->m_bShouldGenerateBLAS, pData->m_bShouldKeepCpuBuffers);
@@ -4817,6 +5244,12 @@ bool ModelImporter::LoadModel_Immediate(FileId uid, ModelPtr& outModel)
 	SAILOR_PROFILE_FUNCTION();
 
 	auto task = LoadModel(uid, outModel);
+	if (!task)
+	{
+		outModel = nullptr;
+		return false;
+	}
+
 	task->Wait();
 	return task->GetResult().IsValid();
 }
@@ -5056,151 +5489,97 @@ bool ModelImporter::ImportModel(
 
 	const bool bHasMeshQuantization =
 		HasGltfExtension(gltfModel, "KHR_mesh_quantization");
-	TVector<GltfImporterUtils::MeshInstance> meshInstances;
-	if (!GltfImporterUtils::CollectMeshInstances(
+	TVector<GltfImporterUtils::SceneNode> sceneNodes;
+	if (!GltfImporterUtils::CollectSceneNodes(
 			gltfModel,
-			meshInstances))
+			unitScale,
+			sceneNodes))
 	{
 		SAILOR_LOG_ERROR(
-			"Cannot resolve glTF mesh instances: %s",
+			"Cannot resolve glTF scene hierarchy: %s",
 			assetFilepath.c_str());
 		return false;
 	}
-
-	const size_t materialBatchCount =
-		(std::max)(static_cast<size_t>(1), gltfModel.materials.size());
-	TVector<MeshContext> batchedMeshContexts;
-	TVector<uint32_t> meshPrimitiveOffsets;
-	size_t initialPrimitiveContextCount = 0;
-	if (bShouldBatchByMaterial)
+	for (const GltfImporterUtils::SceneNode& node : sceneNodes)
 	{
-		batchedMeshContexts.Resize(materialBatchCount);
-		for (size_t materialIndex = 0;
-			materialIndex < materialBatchCount;
-			++materialIndex)
-		{
-			batchedMeshContexts[materialIndex].materialIndex =
-				materialIndex < gltfModel.materials.size() ?
-					static_cast<int32_t>(materialIndex) : -1;
-			batchedMeshContexts[materialIndex].materialSlot =
-				static_cast<uint32_t>(materialIndex);
-		}
-	}
-	else
-	{
-		meshPrimitiveOffsets.Resize(gltfModel.meshes.size());
-		uint32_t primitiveCount = 0;
-		for (size_t meshIndex = 0;
-			meshIndex < gltfModel.meshes.size();
-			++meshIndex)
-		{
-			const tinygltf::Mesh& mesh = gltfModel.meshes[meshIndex];
-			meshPrimitiveOffsets[meshIndex] = primitiveCount;
-			if (mesh.primitives.size() >
-				std::numeric_limits<uint32_t>::max() - primitiveCount)
-			{
-				return false;
-			}
-			primitiveCount +=
-				static_cast<uint32_t>(mesh.primitives.size());
-		}
-
-		initialPrimitiveContextCount = primitiveCount;
-		outParsedMeshes.Resize(initialPrimitiveContextCount);
-		for (size_t meshIndex = 0;
-			meshIndex < gltfModel.meshes.size();
-			++meshIndex)
-		{
-			const tinygltf::Mesh& mesh = gltfModel.meshes[meshIndex];
-			for (size_t primitiveIndex = 0;
-				primitiveIndex < mesh.primitives.size();
-				++primitiveIndex)
-			{
-				const int32_t materialIndex =
-					mesh.primitives[primitiveIndex].material;
-				const uint32_t materialSlot =
-					meshPrimitiveOffsets[meshIndex] +
-					static_cast<uint32_t>(primitiveIndex);
-				outParsedMeshes[materialSlot].materialIndex = materialIndex >= 0 &&
-					static_cast<size_t>(materialIndex) <
-						gltfModel.materials.size() ? materialIndex : -1;
-				outParsedMeshes[materialSlot].materialSlot = materialSlot;
-			}
-		}
-	}
-
-	auto areVolumeScalesEquivalent = [](const glm::vec3& lhs,
-		const glm::vec3& rhs)
-		{
-			const glm::vec3 tolerance = glm::max(
-				glm::max(glm::abs(lhs), glm::abs(rhs)) * 1e-5f,
-				glm::vec3(1e-6f));
-			return glm::all(glm::lessThanEqual(glm::abs(lhs - rhs), tolerance));
-		};
-	auto resolveMeshContext = [&areVolumeScalesEquivalent](
-		TVector<MeshContext>& contexts,
-		size_t baseIndex,
-		size_t initialContextCount,
-		int32_t materialIndex,
-		uint32_t materialSlot,
-		const glm::vec3& bakedVolumeScale) -> MeshContext*
-		{
-			MeshContext* context = &contexts[baseIndex];
-			if (!context->HasGeometry() ||
-				areVolumeScalesEquivalent(
-					context->bakedVolumeScale,
-					bakedVolumeScale))
-			{
-				context->materialIndex = materialIndex;
-				context->materialSlot = materialSlot;
-				context->bakedVolumeScale = bakedVolumeScale;
-				return context;
-			}
-
-			for (size_t contextIndex = initialContextCount;
-				contextIndex < contexts.Num();
-				++contextIndex)
-			{
-				MeshContext& candidate = contexts[contextIndex];
-				if (candidate.materialSlot == materialSlot &&
-					candidate.materialIndex == materialIndex &&
-					areVolumeScalesEquivalent(
-						candidate.bakedVolumeScale,
-						bakedVolumeScale))
-				{
-					return &candidate;
-				}
-			}
-
-			MeshContext splitContext;
-			splitContext.materialIndex = materialIndex;
-			splitContext.materialSlot = materialSlot;
-			splitContext.bakedVolumeScale = bakedVolumeScale;
-			contexts.Emplace(std::move(splitContext));
-			return &*contexts.Last();
-		};
-
-	for (const GltfImporterUtils::MeshInstance& instance : meshInstances)
-	{
-		if (instance.m_skinIndex > 0)
+		if (node.m_skinIndex > 0)
 		{
 			SAILOR_LOG_ERROR(
 				"Cannot import unsupported active glTF skin index %d; only skin 0 is supported: %s",
-				instance.m_skinIndex,
+				node.m_skinIndex,
 				assetFilepath.c_str());
 			return false;
 		}
+	}
 
-		const size_t meshIndex = static_cast<size_t>(instance.m_meshIndex);
+	TVector<size_t> meshContextOffsets(gltfModel.meshes.size());
+	TVector<size_t> meshContextCounts(gltfModel.meshes.size());
+	for (size_t meshIndex = 0;
+		meshIndex < gltfModel.meshes.size();
+		++meshIndex)
+	{
 		const tinygltf::Mesh& mesh = gltfModel.meshes[meshIndex];
-		// glTF explicitly ignores the mesh-node transform for skinned meshes.
-		// Static mesh instances are flattened into Model geometry because Sailor
-		// has one world transform for the complete Model.
-		const GltfImporterUtils::MeshInstanceTransforms transforms =
-			GltfImporterUtils::ResolveMeshInstanceTransforms(instance, unitScale);
-		const glm::mat4& geometryTransform = transforms.m_geometryTransform;
-		const glm::mat3& directionTransform = transforms.m_directionTransform;
-		const glm::vec3& bakedVolumeScale = transforms.m_bakedVolumeScale;
+		meshContextOffsets[meshIndex] = outParsedMeshes.Num();
+		for (size_t primitiveIndex = 0;
+			primitiveIndex < mesh.primitives.size();
+			++primitiveIndex)
+		{
+			const int32_t materialIndex =
+				mesh.primitives[primitiveIndex].material >= 0 &&
+				static_cast<size_t>(mesh.primitives[primitiveIndex].material) <
+					gltfModel.materials.size() ?
+					mesh.primitives[primitiveIndex].material : -1;
+			bool bHasContext = false;
+			if (bShouldBatchByMaterial)
+			{
+				for (size_t contextIndex = meshContextOffsets[meshIndex];
+					contextIndex < outParsedMeshes.Num();
+					++contextIndex)
+				{
+					if (outParsedMeshes[contextIndex].materialIndex ==
+						materialIndex)
+					{
+						bHasContext = true;
+						break;
+					}
+				}
+			}
+
+			if (!bHasContext)
+			{
+				if (outParsedMeshes.Num() >
+					static_cast<size_t>(
+						std::numeric_limits<uint32_t>::max()))
+				{
+					return false;
+				}
+
+				MeshContext context{};
+				context.materialIndex = materialIndex;
+				context.materialSlot = bShouldBatchByMaterial ?
+					(materialIndex >= 0 ?
+						static_cast<uint32_t>(materialIndex) : 0u) :
+					static_cast<uint32_t>(outParsedMeshes.Num());
+				context.sourceMeshIndex = static_cast<int32_t>(meshIndex);
+				outParsedMeshes.Add(std::move(context));
+			}
+		}
+
+		meshContextCounts[meshIndex] =
+			outParsedMeshes.Num() - meshContextOffsets[meshIndex];
+	}
+
+	for (size_t meshIndex = 0;
+		meshIndex < gltfModel.meshes.size();
+		++meshIndex)
+	{
+		const tinygltf::Mesh& mesh = gltfModel.meshes[meshIndex];
+		const glm::mat4 geometryTransform =
+			glm::scale(glm::mat4(1.0f), glm::vec3(unitScale));
+		const glm::mat3 directionTransform = glm::mat3(
+			glm::scale(
+				glm::mat4(1.0f),
+				glm::vec3(unitScale < 0.0f ? -1.0f : 1.0f)));
 		const float transformDeterminant =
 			glm::determinant(directionTransform);
 		if (!std::isfinite(transformDeterminant))
@@ -5516,27 +5895,36 @@ bool ModelImporter::ImportModel(
 			MeshContext* pMeshContext = nullptr;
 			if (bShouldBatchByMaterial)
 			{
-				const size_t batchIndex = materialIndex >= 0 ?
-					static_cast<size_t>(materialIndex) : 0;
-				pMeshContext = resolveMeshContext(
-					batchedMeshContexts,
-					batchIndex,
-					materialBatchCount,
-					materialIndex,
-					static_cast<uint32_t>(batchIndex),
-					bakedVolumeScale);
+				const size_t contextEnd = meshContextOffsets[meshIndex] +
+					meshContextCounts[meshIndex];
+				for (size_t contextIndex = meshContextOffsets[meshIndex];
+					contextIndex < contextEnd;
+					++contextIndex)
+				{
+					if (outParsedMeshes[contextIndex].materialIndex ==
+						materialIndex)
+					{
+						pMeshContext = &outParsedMeshes[contextIndex];
+						break;
+					}
+				}
 			}
 			else
 			{
-				const size_t primitiveContextIndex =
-					meshPrimitiveOffsets[meshIndex] + primitiveIndex;
-				pMeshContext = resolveMeshContext(
-					outParsedMeshes,
-					primitiveContextIndex,
-					initialPrimitiveContextCount,
-					materialIndex,
-					static_cast<uint32_t>(primitiveContextIndex),
-					bakedVolumeScale);
+				const size_t contextIndex =
+					meshContextOffsets[meshIndex] + primitiveIndex;
+				if (contextIndex < outParsedMeshes.Num())
+				{
+					pMeshContext = &outParsedMeshes[contextIndex];
+				}
+			}
+
+			if (pMeshContext == nullptr)
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot resolve glTF source mesh context: %s",
+					assetFilepath.c_str());
+				return false;
 			}
 
 			const size_t existingVertices = pMeshContext != nullptr ?
@@ -5561,7 +5949,6 @@ bool ModelImporter::ImportModel(
 			for (const auto& vertex : localVertices)
 			{
 				pMeshContext->outVertices.Add(vertex);
-				outBoundsAabb.Extend(vertex.m_position);
 				pMeshContext->bounds.Extend(vertex.m_position);
 			}
 
@@ -5600,12 +5987,40 @@ bool ModelImporter::ImportModel(
 		}
 	}
 
-	if (bShouldBatchByMaterial)
+	TVector<Math::AABB> sourceMeshBounds(gltfModel.meshes.size());
+	for (const MeshContext& meshContext : outParsedMeshes)
 	{
-		for (auto& meshContext : batchedMeshContexts)
+		if (meshContext.HasGeometry() &&
+			meshContext.sourceMeshIndex >= 0 &&
+			static_cast<size_t>(meshContext.sourceMeshIndex) <
+				sourceMeshBounds.Num())
 		{
-			outParsedMeshes.Emplace(std::move(meshContext));
+			sourceMeshBounds[
+				static_cast<size_t>(meshContext.sourceMeshIndex)]
+				.Extend(meshContext.bounds);
 		}
+	}
+
+	for (const GltfImporterUtils::SceneNode& node : sceneNodes)
+	{
+		if (node.m_meshIndex < 0 ||
+			static_cast<size_t>(node.m_meshIndex) >=
+				sourceMeshBounds.Num())
+		{
+			continue;
+		}
+
+		Math::AABB instanceBounds =
+			sourceMeshBounds[static_cast<size_t>(node.m_meshIndex)];
+		if (!instanceBounds.IsValid())
+		{
+			continue;
+		}
+		if (node.m_skinIndex < 0)
+		{
+			instanceBounds.Apply(node.m_worldMatrix);
+		}
+		outBoundsAabb.Extend(instanceBounds);
 	}
 
 	bool bImported =

--- a/Runtime/AssetRegistry/Model/ModelImporter.h
+++ b/Runtime/AssetRegistry/Model/ModelImporter.h
@@ -20,6 +20,7 @@
 #include "RHI/Material.h"
 #include "RHI/VertexDescription.h"
 #include "Math/Bounds.h"
+#include "Math/Transform.h"
 #include "Raytracing/BVH.h"
 #include <glm/mat4x4.hpp>
 #include "Core/YamlSerializable.h"
@@ -34,17 +35,62 @@ namespace tinygltf
 
 namespace Sailor
 {
+	namespace GltfImporterUtils
+	{
+		struct SceneNode;
+	}
+
 	using ModelPtr = TObjectPtr<class Model>;
 
 	class Model : public Object, public IYamlSerializable
 	{
 	public:
+		static constexpr int32_t AllMeshes = -1;
+
 		struct MeshCpuData
 		{
 			TVector<RHI::VertexP3N3T3B3UV2C4I4W4> m_vertices;
 			TVector<uint32_t> m_indices;
 			Math::AABB m_bounds{};
 			int32_t m_materialIndex = -1;
+		};
+
+		struct Node
+		{
+			std::string m_name;
+			int32_t m_sourceNodeIndex = -1;
+			int32_t m_parentIndex = -1;
+			int32_t m_meshIndex = -1;
+			int32_t m_skinIndex = -1;
+			Math::Transform m_localTransform{};
+			glm::mat4 m_localMatrix{ 1.0f };
+			glm::mat4 m_worldMatrix{ 1.0f };
+			bool m_bTransformDecomposable = true;
+		};
+
+		struct SourceMesh
+		{
+			std::string m_name;
+			TVector<uint32_t> m_renderMeshIndices;
+			Math::AABB m_bounds{};
+		};
+
+		struct RenderInstance
+		{
+			uint32_t m_renderMeshIndex = 0;
+			int32_t m_nodeIndex = -1;
+			glm::mat4 m_modelMatrix{ 1.0f };
+		};
+
+		struct BLASData
+		{
+			TSharedPtr<Raytracing::BVH> m_blas{};
+			TVector<Math::Triangle> m_triangles{};
+
+			bool IsValid() const
+			{
+				return m_blas.IsValid() && !m_triangles.IsEmpty();
+			}
 		};
 
 		SAILOR_API Model(FileId uid, TVector<RHI::RHIMeshPtr> meshes = {}) :
@@ -54,14 +100,28 @@ namespace Sailor
 
 		SAILOR_API const TVector<RHI::RHIMeshPtr>& GetMeshes() const { return m_meshes; }
 		SAILOR_API TVector<RHI::RHIMeshPtr>& GetMeshes() { return m_meshes; }
+		SAILOR_API const TVector<Node>& GetNodes() const { return m_nodes; }
+		SAILOR_API const TVector<SourceMesh>& GetSourceMeshes() const { return m_sourceMeshes; }
+		SAILOR_API const TVector<RenderInstance>& GetRenderInstances() const { return m_renderInstances; }
+		SAILOR_API bool SupportsEditableHierarchy() const { return m_bSupportsEditableHierarchy; }
+		SAILOR_API bool IsSourceMeshIndexValid(int32_t meshIndex) const;
+		SAILOR_API bool CollectRenderData(
+			int32_t meshIndex,
+			TVector<RHI::RHIMeshPtr>& outMeshes,
+			TVector<glm::mat4>& outModelMatrices,
+			Math::AABB& outBounds) const;
 
 		// Should be triggered after mesh/material changes
 		SAILOR_API void Flush();
 
+		// The model hierarchy and RHIMesh objects are available after the importer
+		// task completes, while their GPU uploads may still be in flight.
+		SAILOR_API bool IsStructurallyReady() const;
 		SAILOR_API virtual bool IsReady() const override;
 		SAILOR_API virtual ~Model() = default;
 
 		SAILOR_API const Math::AABB& GetBoundsAABB() const { return m_boundsAabb; }
+		SAILOR_API const Math::AABB& GetBoundsAABB(int32_t meshIndex) const;
 		SAILOR_API const Math::Sphere& GetBoundsSphere() const { return m_boundsSphere; }
 		SAILOR_API const TVector<glm::mat4>& GetInverseBind() const { return m_inverseBind; }
 		SAILOR_API TVector<glm::mat4>& GetInverseBind() { return m_inverseBind; }
@@ -70,8 +130,11 @@ namespace Sailor
 		SAILOR_API bool HasCpuMeshes() const { return m_cpuMeshes.Num() > 0; }
 		SAILOR_API bool BuildBLAS();
 		SAILOR_API bool HasBLAS() const { return m_blas.IsValid() && m_blasTriangles.Num() > 0; }
+		SAILOR_API bool HasBLAS(int32_t meshIndex) const;
 		SAILOR_API const TSharedPtr<Raytracing::BVH>& GetBLAS() const { return m_blas; }
+		SAILOR_API const TSharedPtr<Raytracing::BVH>& GetBLAS(int32_t meshIndex) const;
 		SAILOR_API const TVector<Math::Triangle>& GetBLASTriangles() const { return m_blasTriangles; }
+		SAILOR_API const TVector<Math::Triangle>& GetBLASTriangles(int32_t meshIndex) const;
 
 		SAILOR_API virtual YAML::Node Serialize() const override;
 		SAILOR_API virtual void Deserialize(const YAML::Node& inData) override;
@@ -79,15 +142,24 @@ namespace Sailor
 	private:
 
 		SAILOR_API void ProceedCpuMeshes(bool bShouldGenerateBLAS, bool bShouldKeepCpuBuffers);
+		bool BuildBLASData(
+			const TVector<RenderInstance>& instances,
+			BLASData& outData) const;
 
 	protected:
 
 		TVector<RHI::RHIMeshPtr> m_meshes;
+		TVector<Node> m_nodes;
+		TVector<SourceMesh> m_sourceMeshes;
+		TVector<RenderInstance> m_renderInstances;
+		bool m_bSupportsEditableHierarchy = true;
 		std::atomic<bool> m_bIsReady{};
+		mutable std::atomic<bool> m_bGpuReady{};
 		TVector<glm::mat4> m_inverseBind;
 		TVector<MeshCpuData> m_cpuMeshes;
 		TSharedPtr<Raytracing::BVH> m_blas{};
 		TVector<Math::Triangle> m_blasTriangles{};
+		TVector<BLASData> m_sourceMeshBlases{};
 
 		Math::AABB m_boundsAabb;
 		Math::Sphere m_boundsSphere;
@@ -108,6 +180,7 @@ namespace Sailor
 			int32_t materialIndex = -1;
 			uint32_t materialSlot = (std::numeric_limits<uint32_t>::max)();
 			glm::vec3 bakedVolumeScale{ 1.0f };
+			int32_t sourceMeshIndex = -1;
 
 			bool HasGeometry() const
 			{
@@ -160,6 +233,9 @@ namespace Sailor
 			Math::Sphere& outBoundsSphere,
 			TVector<glm::mat4>& outInverseBind,
 			tinygltf::Model* outGltfModel = nullptr);
+		static void PopulateModelSceneHierarchy(
+			Model& model,
+			TVector<GltfImporterUtils::SceneNode>& sourceNodes);
 		static bool GenerateFingerprint(
 			const FileId& fileId,
 			const std::string& assetFilepath,

--- a/Runtime/Components/MeshRendererComponent.cpp
+++ b/Runtime/Components/MeshRendererComponent.cpp
@@ -12,6 +12,7 @@ void MeshRendererComponent::Initialize()
 	m_handle = ecs->RegisterComponent();
 
 	GetData().SetOwner(GetOwner());
+	GetData().SetMeshIndex(m_meshIndex);
 }
 
 void MeshRendererComponent::BeginPlay()
@@ -41,6 +42,15 @@ void MeshRendererComponent::SetModel(const ModelPtr& model)
 {
 	GetData().SetModel(model);
 	RebuildMaterials();
+}
+
+void MeshRendererComponent::SetMeshIndex(int32_t meshIndex)
+{
+	m_meshIndex = meshIndex;
+	if (m_handle != ECS::InvalidIndex)
+	{
+		GetData().SetMeshIndex(meshIndex);
+	}
 }
 
 void MeshRendererComponent::SetOverrideMaterials(const TVector<FileId>& overrideMaterials)

--- a/Runtime/Components/MeshRendererComponent.h
+++ b/Runtime/Components/MeshRendererComponent.h
@@ -24,6 +24,8 @@ namespace Sailor
 		SAILOR_API const ModelPtr& GetModel() const { return GetData().GetModel(); }
 		SAILOR_API void SetModel(const ModelPtr& model);
 		SAILOR_API bool LoadModel(const std::string& path);
+		SAILOR_API int32_t GetMeshIndex() const { return m_meshIndex; }
+		SAILOR_API void SetMeshIndex(int32_t meshIndex);
 		SAILOR_API const TVector<FileId>& GetOverrideMaterials() const { return m_overrideMaterials; }
 		SAILOR_API void SetOverrideMaterials(const TVector<FileId>& overrideMaterials);
 
@@ -37,6 +39,7 @@ namespace Sailor
 		void RebuildMaterials();
 
 		size_t m_handle = (size_t)(-1);
+		int32_t m_meshIndex = Model::AllMeshes;
 		TVector<FileId> m_overrideMaterials;
 	};
 }
@@ -48,6 +51,8 @@ REFL_AUTO(
 
 	func(GetModel, property("model"), SkipCDO()),
 	func(SetModel, property("model"), SkipCDO()),
+	func(GetMeshIndex, property("meshIndex")),
+	func(SetMeshIndex, property("meshIndex")),
 
 	func(GetOverrideMaterials, property("overrideMaterials")),
 	func(SetOverrideMaterials, property("overrideMaterials"))

--- a/Runtime/ECS/PathTracerECS.cpp
+++ b/Runtime/ECS/PathTracerECS.cpp
@@ -42,8 +42,11 @@ Tasks::ITaskPtr PathTracerECS::Tick(float deltaTime)
 
 		auto pMeshRenderer = pOwnerGameObject->GetComponent<MeshRendererComponent>();
 		ModelPtr pModel = pMeshRenderer ? pMeshRenderer->GetModel() : ModelPtr();
+		const int32_t meshIndex = pMeshRenderer ?
+			pMeshRenderer->GetMeshIndex() : Model::AllMeshes;
 		const FileId modelFileId = pModel ? pModel->GetFileId() : FileId();
-		if (modelFileId != data.m_modelFileId)
+		if (modelFileId != data.m_modelFileId ||
+			meshIndex != data.m_meshIndex)
 		{
 			data.m_bNeedsRebuild = true;
 		}
@@ -63,16 +66,18 @@ Tasks::ITaskPtr PathTracerECS::Tick(float deltaTime)
 			data.m_inverseWorldMatrix = glm::inverse(data.m_worldMatrix);
 		}
 
-		if (bNeedsUpdate && pModel && !pModel->HasBLAS() && pModel->HasCpuMeshes())
+		if (bNeedsUpdate && pModel &&
+			!pModel->HasBLAS(meshIndex) && pModel->HasCpuMeshes())
 		{
 			pModel->BuildBLAS();
 		}
 
-		if (!pModel || !pModel->IsReady() || !pModel->HasBLAS())
+		if (!pModel || !pModel->IsReady() || !pModel->HasBLAS(meshIndex))
 		{
 			// Model loading is async; keep rebuild pending until BLAS is available.
 			data.m_bNeedsRebuild = true;
 			data.m_modelFileId = modelFileId;
+			data.m_meshIndex = meshIndex;
 			if (m_proxyOctree.Contains(componentHandle))
 			{
 				m_proxyOctree.Remove(componentHandle);
@@ -80,7 +85,7 @@ Tasks::ITaskPtr PathTracerECS::Tick(float deltaTime)
 			continue;
 		}
 
-		data.m_worldBounds = pModel->GetBoundsAABB();
+		data.m_worldBounds = pModel->GetBoundsAABB(meshIndex);
 		data.m_worldBounds.Apply(data.m_worldMatrix);
 
 		if (data.m_worldBounds.IsValid())
@@ -106,6 +111,7 @@ Tasks::ITaskPtr PathTracerECS::Tick(float deltaTime)
 
 		Raytracing::PathTracer::TLASInstance instance{};
 		instance.m_model = pModel;
+		instance.m_meshIndex = meshIndex;
 		instance.m_worldBounds = data.m_worldBounds;
 		instance.m_worldMatrix = data.m_worldMatrix;
 		instance.m_inverseWorldMatrix = data.m_inverseWorldMatrix;
@@ -129,6 +135,7 @@ Tasks::ITaskPtr PathTracerECS::Tick(float deltaTime)
 			data.m_bNeedsRebuild = false;
 			data.m_bIsDirty = false;
 			data.m_modelFileId = modelFileId;
+			data.m_meshIndex = meshIndex;
 			data.m_frameLastChange = ownerTransform.GetFrameLastChange();
 		}
 	}

--- a/Runtime/ECS/PathTracerECS.h
+++ b/Runtime/ECS/PathTracerECS.h
@@ -55,6 +55,7 @@ namespace Sailor
 			m_worldMatrix = glm::mat4(1.0f);
 			m_inverseWorldMatrix = glm::mat4(1.0f);
 			m_modelFileId = FileId();
+			m_meshIndex = -1;
 			m_bNeedsRebuild = true;
 			m_frameLastChange = 0;
 			m_bIsDirty = false;
@@ -70,6 +71,7 @@ namespace Sailor
 		glm::mat4 m_worldMatrix{ 1.0f };
 		glm::mat4 m_inverseWorldMatrix{ 1.0f };
 		FileId m_modelFileId{};
+		int32_t m_meshIndex = -1;
 		bool m_bNeedsRebuild = true;
 
 		friend class PathTracerECS;

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -11,6 +11,51 @@
 using namespace Sailor;
 using namespace Sailor::Tasks;
 
+namespace
+{
+	bool HasRenderableSelection(const StaticMeshRendererData& data)
+	{
+		const ModelPtr& model = data.GetModel();
+		return model && model->IsReady() &&
+			model->GetBoundsAABB(data.GetMeshIndex()).IsValid();
+	}
+
+	bool CollectComponentRenderData(
+		const StaticMeshRendererData& data,
+		const glm::mat4& ownerWorldMatrix,
+		TVector<RHI::RHIMeshPtr>& outMeshes,
+		TVector<glm::mat4>& outWorldMatrices,
+		Math::AABB& outWorldBounds)
+	{
+		if (!HasRenderableSelection(data))
+		{
+			return false;
+		}
+
+		TVector<glm::mat4> modelMatrices;
+		Math::AABB modelBounds;
+		if (!data.GetModel()->CollectRenderData(
+				data.GetMeshIndex(),
+				outMeshes,
+				modelMatrices,
+				modelBounds))
+		{
+			return false;
+		}
+
+		outWorldMatrices.Clear();
+		outWorldMatrices.Reserve(modelMatrices.Num());
+		for (const glm::mat4& modelMatrix : modelMatrices)
+		{
+			outWorldMatrices.Add(ownerWorldMatrix * modelMatrix);
+		}
+
+		outWorldBounds = modelBounds;
+		outWorldBounds.Apply(ownerWorldMatrix);
+		return outWorldBounds.IsValid();
+	}
+}
+
 void StaticMeshRendererECS::BeginPlay()
 {
 	m_sceneViewProxiesCache = RHI::RHISceneViewPtr::Make();
@@ -50,7 +95,23 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 	{
 		auto& data = m_components[index];
 		GameObjectPtr ownerGameObject = data.m_owner.StaticCast<GameObject>();
-		const bool bHasRenderableModel = data.GetModel() && data.GetModel()->IsReady() && data.GetModel()->GetBoundsAABB().IsValid();
+		const ModelPtr& model = data.GetModel();
+		const bool bInvalidMeshIndex = model && model->IsReady() &&
+			data.GetMeshIndex() != Model::AllMeshes &&
+			!model->IsSourceMeshIndexValid(data.GetMeshIndex());
+		if (bInvalidMeshIndex && !data.m_bInvalidMeshIndexReported)
+		{
+			SAILOR_LOG(
+				"MeshRenderer ignored invalid glTF mesh index %d for model %s.",
+				data.GetMeshIndex(),
+				model->GetFileId().ToString().c_str());
+			data.m_bInvalidMeshIndexReported = true;
+		}
+		else if (!bInvalidMeshIndex)
+		{
+			data.m_bInvalidMeshIndexReported = false;
+		}
+		const bool bHasRenderableModel = HasRenderableSelection(data);
 		const bool bShouldBeStationary = data.m_bIsActive && ownerGameObject && bHasRenderableModel &&
 			ownerGameObject->GetMobilityType() == EMobilityType::Stationary;
 
@@ -72,7 +133,7 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			{
 				auto& data = m_components[index];
 				GameObjectPtr ownerGameObject = data.m_owner.StaticCast<GameObject>();
-				const bool bHasRenderableModel = data.GetModel() && data.GetModel()->IsReady() && data.GetModel()->GetBoundsAABB().IsValid();
+				const bool bHasRenderableModel = HasRenderableSelection(data);
 				bool bHasRenderableMaterials = !data.GetMaterials().IsEmpty();
 				for (const auto& material : data.GetMaterials())
 				{
@@ -127,13 +188,22 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 
 					EMobilityType mobilityType = ownerGameObject->GetMobilityType();
 
-					if (mobilityType == EMobilityType::Stationary && data.m_bIsActive && data.GetModel() && data.GetModel()->IsReady())
+					if (mobilityType == EMobilityType::Stationary &&
+						data.m_bIsActive && HasRenderableSelection(data))
 					{
 						const auto& ownerTransform = ownerGameObject->GetTransformComponent();
-						Math::AABB adjustedBounds = data.GetModel()->GetBoundsAABB();
+						Math::AABB adjustedBounds;
+						TVector<RHI::RHIMeshPtr> selectedMeshes;
+						TVector<glm::mat4> selectedMatrices;
 
 						// Should we update only when transform changed?
-						if ((data.m_bIsDirty || data.m_frameLastChange == 0 || ownerTransform.GetFrameLastChange() > data.m_frameLastChange) && adjustedBounds.IsValid())
+						if ((data.m_bIsDirty || data.m_frameLastChange == 0 || ownerTransform.GetFrameLastChange() > data.m_frameLastChange) &&
+							CollectComponentRenderData(
+								data,
+								ownerTransform.GetCachedWorldMatrix(),
+								selectedMeshes,
+								selectedMatrices,
+								adjustedBounds))
 						{
 							RHI::RHIMeshProxy proxy;
 							proxy.m_staticMeshEcs = GetComponentIndex(&data);
@@ -146,8 +216,6 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 							{
 								data.m_skeletonOffset = StaticMeshRendererData::InvalidSkeletonOffset;
 							}
-
-							adjustedBounds.Apply(proxy.m_worldMatrix);
 
 							temp.Emplace(TPair(std::move(proxy), std::move(adjustedBounds)));
 
@@ -210,10 +278,13 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 
 				EMobilityType mobilityType = ownerGameObject->GetMobilityType();
 
-				if (mobilityType == EMobilityType::Static && data.m_bIsActive && data.GetModel() && data.GetModel()->IsReady())
+				if (mobilityType == EMobilityType::Static &&
+					data.m_bIsActive && HasRenderableSelection(data))
 				{
 					const auto& ownerTransform = ownerGameObject->GetTransformComponent();
-					Math::AABB adjustedBounds = data.GetModel()->GetBoundsAABB();
+					Math::AABB adjustedBounds;
+					TVector<RHI::RHIMeshPtr> selectedMeshes;
+					TVector<glm::mat4> selectedMatrices;
 					bool bMaterialsReady = !data.GetMaterials().IsEmpty();
 					bool bMaterialsChanged =
 						data.m_materialContentRevisions.Num() != data.GetMaterials().Num();
@@ -232,7 +303,13 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 					}
 
 					if ((data.m_bIsDirty || bMaterialsChanged || ownerTransform.GetFrameLastChange() > data.m_frameLastChange) &&
-						adjustedBounds.IsValid() && bMaterialsReady)
+						bMaterialsReady &&
+						CollectComponentRenderData(
+							data,
+							ownerTransform.GetCachedWorldMatrix(),
+							selectedMeshes,
+							selectedMatrices,
+							adjustedBounds))
 					{
 						data.m_materialContentRevisions.Resize(data.GetMaterials().Num());
 						for (size_t i = 0; i < data.GetMaterials().Num(); ++i)
@@ -253,9 +330,9 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 							data.m_skeletonOffset = StaticMeshRendererData::InvalidSkeletonOffset;
 						}
 						proxy.m_skeletonOffset = data.m_skeletonOffset;
-						proxy.m_meshes = data.GetModel()->GetMeshes();
-						proxy.m_worldAabb = data.GetModel()->GetBoundsAABB();
-						proxy.m_worldAabb.Apply(proxy.m_worldMatrix);
+						proxy.m_meshes = std::move(selectedMeshes);
+						proxy.m_meshModelMatrices = std::move(selectedMatrices);
+						proxy.m_worldAabb = adjustedBounds;
 						proxy.m_bCastShadows = data.ShouldCastShadow();
 
 						proxy.m_overrideMaterials.Clear();
@@ -291,7 +368,6 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 #endif
 						}
 
-						adjustedBounds.Apply(proxy.m_worldMatrix);
 						m_sceneViewProxiesCache->m_staticOctree.Update(glm::vec4(adjustedBounds.GetCenter(), 1), adjustedBounds.GetExtents(), proxy);
 
 						data.m_frameLastChange = ownerTransform.GetFrameLastChange();

--- a/Runtime/ECS/StaticMeshRendererECS.h
+++ b/Runtime/ECS/StaticMeshRendererECS.h
@@ -25,9 +25,20 @@ namespace Sailor
 		SAILOR_API __forceinline void SetModel(const ModelPtr& model)
 		{
 			m_model = model;
+			m_bInvalidMeshIndexReported = false;
 			if (!m_model)
 			{
 				m_materials.Clear();
+			}
+		}
+		SAILOR_API __forceinline int32_t GetMeshIndex() const { return m_meshIndex; }
+		SAILOR_API __forceinline void SetMeshIndex(int32_t meshIndex)
+		{
+			if (m_meshIndex != meshIndex)
+			{
+				m_meshIndex = meshIndex;
+				m_bInvalidMeshIndexReported = false;
+				MarkDirty();
 			}
 		}
 
@@ -40,6 +51,8 @@ namespace Sailor
 		TVector<MaterialPtr> m_materials;
 		TVector<uint64_t> m_materialContentRevisions;
 		uint32_t m_skeletonOffset = InvalidSkeletonOffset;
+		int32_t m_meshIndex = -1;
+		bool m_bInvalidMeshIndexReported = false;
 
 		friend class StaticMeshRendererECS;
 	};

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -2,6 +2,7 @@
 
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/FileId.h"
+#include "AssetRegistry/Model/ModelImporter.h"
 #include "AssetRegistry/Prefab/PrefabImporter.h"
 #include "AssetRegistry/World/WorldPrefabImporter.h"
 #include "Core/Reflection.h"
@@ -574,6 +575,93 @@ bool App::CreateEditorGameObject(
 
 			InstanceId createdInstanceId;
 			if (!editor->CreateGameObject(parentInstanceId, preferredInstanceId, createdInstanceId))
+			{
+				return false;
+			}
+
+			SetInteropString(createdInstanceId.ToString(), outInstanceId);
+			return true;
+		});
+}
+
+bool App::CreateEditorModelInstance(
+	const char* strModelFileId,
+	const char* strName,
+	const char* strParentInstanceId,
+	bool bCreateHierarchy,
+	bool bHasWorldPosition,
+	float worldX,
+	float worldY,
+	float worldZ,
+	const char* strPreferredInstanceId,
+	char** outInstanceId)
+{
+	if (!strModelFileId || !strName || !outInstanceId)
+	{
+		return false;
+	}
+
+	outInstanceId[0] = nullptr;
+	FileId modelFileId;
+	modelFileId.Deserialize(YAML::Node(strModelFileId));
+	auto modelImporter = GetSubmodule<ModelImporter>();
+	ModelPtr model;
+	if (!modelFileId ||
+		!modelImporter ||
+		!modelImporter->LoadModel_Immediate(modelFileId, model) ||
+		!model ||
+		!model->IsStructurallyReady())
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot create editor model instance '%s': model '%s' could not be loaded.",
+			strName,
+			strModelFileId);
+		return false;
+	}
+
+	const std::string name = strName;
+	const std::string parentInstanceIdValue = strParentInstanceId ? strParentInstanceId : "";
+	const std::string preferredInstanceIdValue = strPreferredInstanceId ? strPreferredInstanceId : "";
+	return ExecuteOnEngineMainThread<bool>(false, [
+		model,
+		name,
+		parentInstanceIdValue,
+		preferredInstanceIdValue,
+		bCreateHierarchy,
+		bHasWorldPosition,
+		worldX,
+		worldY,
+		worldZ,
+		outInstanceId]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			if (!editor)
+			{
+				return false;
+			}
+
+			InstanceId parentInstanceId;
+			if (!TryParseOptionalParent(parentInstanceIdValue, parentInstanceId))
+			{
+				return false;
+			}
+
+			InstanceId preferredInstanceId;
+			if (!TryParseOptionalGameObjectId(preferredInstanceIdValue, preferredInstanceId))
+			{
+				return false;
+			}
+
+			const glm::vec3 worldPosition(worldX, worldY, worldZ);
+			InstanceId createdInstanceId;
+			if (!editor->CreateModelInstance(
+					model,
+					name,
+					parentInstanceId,
+					bCreateHierarchy,
+					bHasWorldPosition ? &worldPosition : nullptr,
+					preferredInstanceId,
+					createdInstanceId))
 			{
 				return false;
 			}

--- a/Runtime/Editor/EditorViewportController.cpp
+++ b/Runtime/Editor/EditorViewportController.cpp
@@ -447,12 +447,13 @@ bool EditorViewport::ResolveGameObjectBounds(
 	{
 		auto meshRenderer = component.DynamicCast<MeshRendererComponent>();
 		const ModelPtr model = meshRenderer ? meshRenderer->GetModel() : ModelPtr{};
-		if (!model || !model->IsReady() || !model->GetBoundsAABB().IsValid())
+		if (!model || !model->IsReady())
 		{
 			continue;
 		}
 
-		Math::AABB meshBounds = model->GetBoundsAABB();
+		Math::AABB meshBounds =
+			model->GetBoundsAABB(meshRenderer->GetMeshIndex());
 		meshBounds.Apply(worldMatrix);
 		if (!meshBounds.IsValid())
 		{

--- a/Runtime/Engine/InstanceId.cpp
+++ b/Runtime/Engine/InstanceId.cpp
@@ -72,7 +72,7 @@ InstanceId::InstanceId(const InstanceId& inComponentId, const InstanceId& inGame
 	if (inGameObjectId)
 	{
 		std::string combinedId = inComponentId.ToString() + "_" + inGameObjectId.ToString();
-		m_instanceId = StringHash::Runtime(combinedId);
+		Assign(combinedId);
 	}
 	else
 	{
@@ -82,7 +82,7 @@ InstanceId::InstanceId(const InstanceId& inComponentId, const InstanceId& inGame
 
 void InstanceId::Deserialize(const YAML::Node& inData)
 {
-	m_instanceId = StringHash::Runtime(inData.as<std::string>());
+	Assign(inData.as<std::string>());
 }
 
 const std::string& InstanceId::ToString() const
@@ -111,7 +111,7 @@ InstanceId InstanceId::GenerateNewInstanceId()
 		<< std::setw(16) << randomNumber
 		<< std::setw(4) << randomSuffix;
 
-	newInstanceId.m_instanceId = StringHash::Runtime(ss.str());
+	newInstanceId.Assign(ss.str());
 
 	return newInstanceId;
 }
@@ -134,12 +134,12 @@ InstanceId InstanceId::GenerateNewComponentId(const InstanceId& gameObjectId)
 	std::snprintf(buffer, sizeof(buffer), "%016llX", static_cast<unsigned long long>(randomNumber));
 #endif
 
-	newComponentInstanceId.m_instanceId = StringHash::Runtime(buffer);
+	newComponentInstanceId.Assign(buffer);
 
 	if (gameObjectId)
 	{
 		std::string combinedId = newComponentInstanceId.ToString() + "_" + gameObjectId.ToString();
-		newComponentInstanceId.m_instanceId = StringHash::Runtime(combinedId);
+		newComponentInstanceId.Assign(combinedId);
 	}
 
 	return newComponentInstanceId;
@@ -147,23 +147,23 @@ InstanceId InstanceId::GenerateNewComponentId(const InstanceId& gameObjectId)
 
 bool InstanceId::IsGameObjectId() const
 {
-	return IsHexGameObjectId(m_instanceId.ToString());
+	return m_kind == EKind::GameObject;
 }
 
 InstanceId InstanceId::GameObjectId() const
 {
-	const std::string& idString = m_instanceId.ToString();
-	std::string_view componentIdString;
-	std::string_view gameObjectIdString;
-	if (SplitComponentInstanceId(idString, componentIdString, gameObjectIdString))
-	{
-		InstanceId id{};
-		id.m_instanceId = StringHash::Runtime(std::string(gameObjectIdString));
-		return id;
-	}
-	else if (idString.find('_') == std::string::npos && IsGameObjectId())
+	if (m_kind == EKind::GameObject)
 	{
 		return *this;
+	}
+
+	if (m_kind == EKind::Component)
+	{
+		InstanceId result;
+		result.m_instanceId = m_gameObjectId;
+		result.m_gameObjectId = m_gameObjectId;
+		result.m_kind = EKind::GameObject;
+		return result;
 	}
 
 	return InstanceId::Invalid;
@@ -171,15 +171,42 @@ InstanceId InstanceId::GameObjectId() const
 
 InstanceId InstanceId::ComponentId() const
 {
-	const std::string& idString = m_instanceId.ToString();
-	std::string_view componentIdString;
-	std::string_view gameObjectIdString;
-	if (SplitComponentInstanceId(idString, componentIdString, gameObjectIdString))
+	if (m_kind == EKind::Component)
 	{
-		InstanceId id{};
-		id.m_instanceId = StringHash::Runtime(std::string(componentIdString));
-		return id;
+		InstanceId result;
+		result.m_instanceId = m_componentId;
+		if (m_bStandaloneComponentIsGameObjectId)
+		{
+			result.m_gameObjectId = m_componentId;
+			result.m_kind = EKind::GameObject;
+		}
+		return result;
 	}
 
 	return InstanceId::Invalid;
+}
+
+void InstanceId::Assign(std::string_view value)
+{
+	m_instanceId = StringHash::Runtime(value);
+	m_gameObjectId = {};
+	m_componentId = {};
+	m_kind = EKind::Invalid;
+	m_bStandaloneComponentIsGameObjectId = false;
+
+	std::string_view componentId;
+	std::string_view gameObjectId;
+	if (SplitComponentInstanceId(value, componentId, gameObjectId))
+	{
+		m_componentId = StringHash::Runtime(componentId);
+		m_gameObjectId = StringHash::Runtime(gameObjectId);
+		m_kind = EKind::Component;
+		m_bStandaloneComponentIsGameObjectId = IsHexGameObjectId(componentId);
+	}
+	else if (value.find('_') == std::string_view::npos &&
+		IsHexGameObjectId(value))
+	{
+		m_gameObjectId = m_instanceId;
+		m_kind = EKind::GameObject;
+	}
 }

--- a/Runtime/Engine/InstanceId.h
+++ b/Runtime/Engine/InstanceId.h
@@ -50,7 +50,20 @@ namespace Sailor
 
 	protected:
 
+		enum class EKind : uint8_t
+		{
+			Invalid,
+			GameObject,
+			Component
+		};
+
+		void Assign(std::string_view value);
+
 		StringHash m_instanceId = "NullInstanceId"_h;
+		StringHash m_gameObjectId{};
+		StringHash m_componentId{};
+		EKind m_kind = EKind::Invalid;
+		bool m_bStandaloneComponentIsGameObjectId = false;
 	};
 }
 
@@ -65,8 +78,7 @@ namespace std
 	{
 		SAILOR_API std::size_t operator()(const Sailor::InstanceId& p) const
 		{
-			std::hash<std::string> h;
-			return h(p.ToString());
+			return p.GetHash();
 		}
 	};
 }

--- a/Runtime/FrameGraph/DepthPrepassNode.cpp
+++ b/Runtime/FrameGraph/DepthPrepassNode.cpp
@@ -106,8 +106,12 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						continue;
 					}
 
+					const glm::mat4& meshWorldMatrix =
+						proxy.m_meshModelMatrices.Num() > i ?
+							proxy.m_meshModelMatrices[i] :
+							proxy.m_worldMatrix;
 					DepthPrepassNode::PerInstanceData data;
-					data.model = proxy.m_worldMatrix;
+					data.model = meshWorldMatrix;
 					data.skeletonOffset = proxy.m_skeletonOffset;
 					data.bIsCulled = 0;
 					data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -327,8 +327,12 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 							shaderBinding = material->GetBindings()->GetShaderBindings()["material"];
 						}
 
+						const glm::mat4& meshWorldMatrix =
+							proxy.m_meshModelMatrices.Num() > i ?
+								proxy.m_meshModelMatrices[i] :
+								proxy.m_worldMatrix;
 						RenderSceneNode::PerInstanceData data;
-						data.model = proxy.m_worldMatrix;
+						data.model = meshWorldMatrix;
 						data.skeletonOffset = proxy.m_skeletonOffset;
 						data.materialInstance = shaderBinding.IsValid() ? shaderBinding->GetStorageInstanceIndex() : 0;
 						data.bIsCulled = 0;
@@ -359,7 +363,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 
 						if (bBackToFront)
 						{
-							const glm::vec4 worldCenter = proxy.m_worldMatrix *
+							const glm::vec4 worldCenter = meshWorldMatrix *
 								glm::vec4(mesh->m_bounds.GetCenter(), 1.0f);
 							const glm::vec4 viewCenter = sceneViewSnapshot.m_camera->GetViewMatrix() *
 								worldCenter;

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -146,8 +146,12 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 						continue;
 					}
 
+					const glm::mat4& meshWorldMatrix =
+						proxy.m_meshModelMatrices.Num() > i ?
+							proxy.m_meshModelMatrices[i] :
+							proxy.m_worldMatrix;
 					ShadowPrepassNode::PerInstanceData data;
-					data.model = proxy.m_worldMatrix;
+					data.model = meshWorldMatrix;
 
 					RHIBatch batch(depthMaterial, mesh);
 

--- a/Runtime/Protocol/Generated/editor_engine.pb.cc
+++ b/Runtime/Protocol/Generated/editor_engine.pb.cc
@@ -1167,6 +1167,45 @@ struct InstantiatePrefabInstanceRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 InstantiatePrefabInstanceRequestDefaultTypeInternal _InstantiatePrefabInstanceRequest_default_instance_;
 
+inline constexpr CreateModelInstanceRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : _cached_size_{0},
+        model_file_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        name_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        parent_instance_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        preferred_instance_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        world_position_{nullptr},
+        create_hierarchy_{false},
+        apply_world_position_{false} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR CreateModelInstanceRequest::CreateModelInstanceRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct CreateModelInstanceRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR CreateModelInstanceRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~CreateModelInstanceRequestDefaultTypeInternal() {}
+  union {
+    CreateModelInstanceRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 CreateModelInstanceRequestDefaultTypeInternal _CreateModelInstanceRequest_default_instance_;
+
 inline constexpr ViewportEvent::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : revision_{::uint64_t{0u}},
@@ -1354,6 +1393,7 @@ const ::uint32_t
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolRequest, _impl_.command_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _internal_metadata_),
@@ -1408,6 +1448,28 @@ const ::uint32_t
         ~0u,  // no _split_
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::FileIdRequest, _impl_.file_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelInstanceRequest, _impl_._has_bits_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelInstanceRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelInstanceRequest, _impl_.model_file_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelInstanceRequest, _impl_.name_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelInstanceRequest, _impl_.parent_instance_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelInstanceRequest, _impl_.create_hierarchy_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelInstanceRequest, _impl_.apply_world_position_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelInstanceRequest, _impl_.world_position_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::CreateModelInstanceRequest, _impl_.preferred_instance_id_),
+        ~0u,
+        ~0u,
+        ~0u,
+        ~0u,
+        ~0u,
+        0,
+        ~0u,
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstanceIdRequest, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -1850,49 +1912,50 @@ static const ::_pbi::MigrationSchema
     schemas[] ABSL_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
         {0, -1, -1, sizeof(::sailor::editor::v1::Empty)},
         {8, -1, -1, sizeof(::sailor::editor::v1::ProtocolRequest)},
-        {66, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
-        {92, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
-        {101, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
-        {110, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
-        {119, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
-        {128, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
-        {137, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
-        {149, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
-        {159, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
-        {174, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
-        {185, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
-        {205, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
-        {215, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
-        {225, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
-        {236, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
-        {246, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
-        {257, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
-        {267, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
-        {278, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
-        {289, 301, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
-        {305, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
-        {315, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
-        {325, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
-        {336, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
-        {345, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
-        {354, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
-        {367, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
-        {376, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
-        {385, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
-        {394, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
-        {403, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
-        {413, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
-        {422, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
-        {434, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
-        {444, 453, -1, sizeof(::sailor::editor::v1::Vector4Result)},
-        {454, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
-        {464, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
-        {476, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
-        {485, 502, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
-        {511, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
-        {522, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
-        {531, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
-        {546, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
+        {67, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
+        {93, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
+        {102, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
+        {111, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
+        {120, 135, -1, sizeof(::sailor::editor::v1::CreateModelInstanceRequest)},
+        {142, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
+        {151, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
+        {160, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
+        {172, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
+        {182, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
+        {197, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
+        {208, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
+        {228, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
+        {238, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
+        {248, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
+        {259, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
+        {269, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
+        {280, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
+        {290, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
+        {301, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
+        {312, 324, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
+        {328, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
+        {338, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
+        {348, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
+        {359, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
+        {368, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
+        {377, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
+        {390, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
+        {399, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
+        {408, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
+        {417, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
+        {426, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
+        {436, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
+        {445, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
+        {457, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
+        {467, 476, -1, sizeof(::sailor::editor::v1::Vector4Result)},
+        {477, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
+        {487, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
+        {499, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
+        {508, 525, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
+        {534, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
+        {545, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
+        {554, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
+        {569, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_Empty_default_instance_._instance,
@@ -1901,6 +1964,7 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_InitializeRequest_default_instance_._instance,
     &::sailor::editor::v1::_CountRequest_default_instance_._instance,
     &::sailor::editor::v1::_FileIdRequest_default_instance_._instance,
+    &::sailor::editor::v1::_CreateModelInstanceRequest_default_instance_._instance,
     &::sailor::editor::v1::_InstanceIdRequest_default_instance_._instance,
     &::sailor::editor::v1::_ViewportIdRequest_default_instance_._instance,
     &::sailor::editor::v1::_ViewportRectRequest_default_instance_._instance,
@@ -1944,7 +2008,7 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
     protodesc_cold) = {
     "\n\023editor_engine.proto\022\020sailor.editor.v1\""
-    "\007\n\005Empty\"\374\031\n\017ProtocolRequest\022\030\n\020protocol"
+    "\007\n\005Empty\"\313\032\n\017ProtocolRequest\022\030\n\020protocol"
     "_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\0229\n\nin"
     "itialize\030\n \001(\0132#.sailor.editor.v1.Initia"
     "lizeRequestH\000\022(\n\005start\030\013 \001(\0132\027.sailor.ed"
@@ -2025,154 +2089,162 @@ const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SE
     "F\n\027get_viewport_tool_state\0308 \001(\0132#.sailo"
     "r.editor.v1.ViewportIdRequestH\000\0227\n\014updat"
     "e_asset\0309 \001(\0132\037.sailor.editor.v1.FileIdR"
-    "equestH\000B\t\n\007commandJ\004\010\003\020\nJ\004\0102\0203J\004\010:\020dR\030c"
-    "reate_model_game_objectR\036resolve_viewpor"
-    "t_drop_position\"\226\007\n\020ProtocolResponse\022\030\n\020"
-    "protocol_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001"
-    "(\004\022\017\n\007success\030\003 \001(\010\022\r\n\005error\030\004 \001(\t\022$\n\034su"
-    "pports_strict_instance_ids\030\005 \001(\010\022/\n\014empt"
-    "y_result\030\n \001(\0132\027.sailor.editor.v1.EmptyH"
-    "\000\0223\n\013bool_result\030\013 \001(\0132\034.sailor.editor.v"
-    "1.BoolResultH\000\0225\n\014int32_result\030\014 \001(\0132\035.s"
-    "ailor.editor.v1.Int32ResultH\000\0227\n\ruint32_"
-    "result\030\r \001(\0132\036.sailor.editor.v1.UInt32Re"
-    "sultH\000\0227\n\ruint64_result\030\016 \001(\0132\036.sailor.e"
-    "ditor.v1.UInt64ResultH\000\0227\n\rstring_result"
-    "\030\017 \001(\0132\036.sailor.editor.v1.StringResultH\000"
-    "\022@\n\022string_list_result\030\020 \001(\0132\".sailor.ed"
-    "itor.v1.StringListResultH\000\022M\n\031asset_relo"
-    "ad_state_result\030\021 \001(\0132(.sailor.editor.v1"
-    ".AssetReloadStateResultH\000\022@\n\022instance_id"
-    "_result\030\022 \001(\0132\".sailor.editor.v1.Instanc"
-    "eIdResultH\000\022Q\n\033viewport_event_batch_resu"
-    "lt\030\023 \001(\0132*.sailor.editor.v1.ViewportEven"
-    "tBatchResultH\000\0229\n\016vector4_result\030\024 \001(\0132\037"
-    ".sailor.editor.v1.Vector4ResultH\000\022O\n\032vie"
-    "wport_tool_state_result\030\025 \001(\0132).sailor.e"
-    "ditor.v1.ViewportToolStateResultH\000B\010\n\006re"
-    "sultJ\004\010\006\020\nJ\004\010\026\020d\"&\n\021InitializeRequest\022\021\n"
-    "\targuments\030\001 \003(\t\"!\n\014CountRequest\022\021\n\tmax_"
-    "count\030\001 \001(\r\" \n\rFileIdRequest\022\017\n\007file_id\030"
-    "\001 \001(\t\"(\n\021InstanceIdRequest\022\023\n\013instance_i"
-    "d\030\001 \001(\t\"(\n\021ViewportIdRequest\022\023\n\013viewport"
-    "_id\030\001 \001(\004\"`\n\023ViewportRectRequest\022\024\n\014wind"
-    "ow_pos_x\030\001 \001(\r\022\024\n\014window_pos_y\030\002 \001(\r\022\r\n\005"
-    "width\030\003 \001(\r\022\016\n\006height\030\004 \001(\r\",\n\013SizeReque"
-    "st\022\r\n\005width\030\001 \001(\r\022\016\n\006height\030\002 \001(\r\"\231\001\n\025Re"
-    "moteViewportRequest\022\023\n\013viewport_id\030\001 \001(\004"
-    "\022\024\n\014window_pos_x\030\002 \001(\r\022\024\n\014window_pos_y\030\003"
-    " \001(\r\022\r\n\005width\030\004 \001(\r\022\016\n\006height\030\005 \001(\r\022\017\n\007v"
-    "isible\030\006 \001(\010\022\017\n\007focused\030\007 \001(\010\"e\n\031RemoteV"
-    "iewportHostRequest\022\023\n\013viewport_id\030\001 \001(\004\022"
-    "\030\n\020host_handle_kind\030\002 \001(\r\022\031\n\021host_handle"
-    "_value\030\003 \001(\004\"\374\001\n\032RemoteViewportInputRequ"
-    "est\022\023\n\013viewport_id\030\001 \001(\004\022\014\n\004kind\030\002 \001(\r\022\021"
-    "\n\tpointer_x\030\003 \001(\002\022\021\n\tpointer_y\030\004 \001(\002\022\025\n\r"
-    "wheel_delta_x\030\005 \001(\002\022\025\n\rwheel_delta_y\030\006 \001"
-    "(\002\022\020\n\010key_code\030\007 \001(\r\022\016\n\006button\030\010 \001(\r\022\021\n\t"
-    "modifiers\030\t \001(\r\022\017\n\007pressed\030\n \001(\010\022\017\n\007focu"
-    "sed\030\013 \001(\010\022\020\n\010captured\030\014 \001(\010\"C\n\036ManagedMu"
-    "tationRevisionRequest\022\014\n\004kind\030\001 \001(\r\022\023\n\013i"
-    "nstance_id\030\002 \001(\t\"@\n\023UpdateObjectRequest\022"
-    "\023\n\013instance_id\030\001 \001(\t\022\024\n\014yaml_changes\030\002 \001"
-    "(\t\"f\n\025ReparentObjectRequest\022\023\n\013instance_"
-    "id\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\034\n\024"
-    "keep_world_transform\030\003 \001(\010\"T\n\027CreateGame"
-    "ObjectRequest\022\032\n\022parent_instance_id\030\001 \001("
-    "\t\022\035\n\025preferred_instance_id\030\002 \001(\t\"f\n\023AddC"
-    "omponentRequest\022\023\n\013instance_id\030\001 \001(\t\022\033\n\023"
-    "component_type_name\030\002 \001(\t\022\035\n\025preferred_i"
-    "nstance_id\030\003 \001(\t\"G\n\030InstantiatePrefabReq"
-    "uest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_instance"
-    "_id\030\002 \001(\t\"p\n InstantiatePrefabFromYamlRe"
-    "quest\022\023\n\013prefab_yaml\030\001 \001(\t\022\032\n\022parent_ins"
-    "tance_id\030\002 \001(\t\022\033\n\023strict_instance_ids\030\003 "
-    "\001(\010\"U\n\022ViewportRayRequest\022\023\n\013viewport_id"
-    "\030\001 \001(\004\022\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normaliz"
-    "ed_y\030\003 \001(\002\"\240\001\n InstantiatePrefabInstance"
-    "Request\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_insta"
-    "nce_id\030\002 \001(\t\022\034\n\024apply_world_position\030\003 \001"
-    "(\010\0221\n\016world_position\030\004 \001(\0132\031.sailor.edit"
-    "or.v1.Vector4\"A\n\025ViewportObjectRequest\022\023"
-    "\n\013viewport_id\030\001 \001(\004\022\023\n\013instance_id\030\002 \001(\t"
-    "\"9\n\021PrefabLinkRequest\022\023\n\013instance_id\030\001 \001"
-    "(\t\022\017\n\007file_id\030\002 \001(\t\"\251\001\n\030ViewportToolStat"
-    "eRequest\022\023\n\013viewport_id\030\001 \001(\004\022\?\n\toperati"
-    "on\030\002 \001(\0162,.sailor.editor.v1.ViewportTran"
-    "sformOperation\0227\n\005space\030\003 \001(\0162(.sailor.e"
-    "ditor.v1.ViewportTransformSpace\"(\n\020Selec"
-    "tionRequest\022\024\n\014instance_ids\030\001 \003(\t\"%\n\025Sho"
-    "wMainWindowRequest\022\014\n\004show\030\001 \001(\010\"\210\001\n\034Ren"
-    "derPathTracedImageRequest\022\023\n\013output_path"
-    "\030\001 \001(\t\022\023\n\013instance_id\030\002 \001(\t\022\016\n\006height\030\003 "
-    "\001(\r\022\031\n\021samples_per_pixel\030\004 \001(\r\022\023\n\013max_bo"
-    "unces\030\005 \001(\r\"\033\n\nBoolResult\022\r\n\005value\030\001 \001(\010"
-    "\"\034\n\013Int32Result\022\r\n\005value\030\001 \001(\005\"\035\n\014UInt32"
-    "Result\022\r\n\005value\030\001 \001(\r\"\035\n\014UInt64Result\022\r\n"
-    "\005value\030\001 \001(\004\"0\n\014StringResult\022\021\n\thas_valu"
-    "e\030\001 \001(\010\022\r\n\005value\030\002 \001(\t\"\"\n\020StringListResu"
-    "lt\022\016\n\006values\030\001 \003(\t\"\204\001\n\026AssetReloadStateR"
-    "esult\022\021\n\tavailable\030\001 \001(\010\022\032\n\022request_gene"
-    "ration\030\002 \001(\004\022\034\n\024completed_generation\030\003 \001"
-    "(\004\022\035\n\025successful_generation\030\004 \001(\004\":\n\020Ins"
-    "tanceIdResult\022\021\n\tsucceeded\030\001 \001(\010\022\023\n\013inst"
-    "ance_id\030\002 \001(\t\"9\n\rVector4Result\022(\n\005value\030"
-    "\001 \001(\0132\031.sailor.editor.v1.Vector4\"\223\001\n\027Vie"
-    "wportToolStateResult\022\?\n\toperation\030\001 \001(\0162"
-    ",.sailor.editor.v1.ViewportTransformOper"
-    "ation\0227\n\005space\030\002 \001(\0162(.sailor.editor.v1."
-    "ViewportTransformSpace\"5\n\007Vector4\022\t\n\001x\030\001"
-    " \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n"
-    "\026ViewportSelectionEvent\022\034\n\024selected_inst"
-    "ance_id\030\001 \001(\t\"\326\003\n\026ViewportTransformEvent"
-    "\022\023\n\013instance_id\030\001 \001(\t\022\?\n\toperation\030\002 \001(\016"
-    "2,.sailor.editor.v1.ViewportTransformOpe"
-    "ration\0227\n\005space\030\003 \001(\0162(.sailor.editor.v1"
-    ".ViewportTransformSpace\0222\n\017before_positi"
-    "on\030\004 \001(\0132\031.sailor.editor.v1.Vector4\0222\n\017b"
-    "efore_rotation\030\005 \001(\0132\031.sailor.editor.v1."
-    "Vector4\022/\n\014before_scale\030\006 \001(\0132\031.sailor.e"
-    "ditor.v1.Vector4\0221\n\016after_position\030\007 \001(\013"
-    "2\031.sailor.editor.v1.Vector4\0221\n\016after_rot"
-    "ation\030\010 \001(\0132\031.sailor.editor.v1.Vector4\022."
-    "\n\013after_scale\030\t \001(\0132\031.sailor.editor.v1.V"
-    "ector4\"U\n\026ViewportAssetDropEvent\022\017\n\007file"
-    "_id\030\001 \001(\t\022\024\n\014normalized_x\030\002 \001(\002\022\024\n\014norma"
-    "lized_y\030\003 \001(\002\"-\n\031ViewportToolShortcutEve"
-    "nt\022\020\n\010key_code\030\001 \001(\r\"\331\002\n\rViewportEvent\022\020"
-    "\n\010revision\030\001 \001(\004\022!\n\031managed_mutation_rev"
-    "ision\030\002 \001(\004\022=\n\tselection\030\n \001(\0132(.sailor."
-    "editor.v1.ViewportSelectionEventH\000\022=\n\ttr"
-    "ansform\030\013 \001(\0132(.sailor.editor.v1.Viewpor"
-    "tTransformEventH\000\022>\n\nasset_drop\030\014 \001(\0132(."
-    "sailor.editor.v1.ViewportAssetDropEventH"
-    "\000\022D\n\rtool_shortcut\030\r \001(\0132+.sailor.editor"
-    ".v1.ViewportToolShortcutEventH\000B\t\n\007paylo"
-    "adJ\004\010\003\020\n\"K\n\030ViewportEventBatchResult\022/\n\006"
-    "events\030\001 \003(\0132\037.sailor.editor.v1.Viewport"
-    "Event*\360\001\n\032ViewportTransformOperation\022,\n("
-    "VIEWPORT_TRANSFORM_OPERATION_UNSPECIFIED"
-    "\020\000\022\'\n#VIEWPORT_TRANSFORM_OPERATION_SELEC"
-    "T\020\001\022*\n&VIEWPORT_TRANSFORM_OPERATION_TRAN"
-    "SLATE\020\002\022\'\n#VIEWPORT_TRANSFORM_OPERATION_"
-    "ROTATE\020\003\022&\n\"VIEWPORT_TRANSFORM_OPERATION"
-    "_SCALE\020\004*\212\001\n\026ViewportTransformSpace\022(\n$V"
-    "IEWPORT_TRANSFORM_SPACE_UNSPECIFIED\020\000\022\"\n"
-    "\036VIEWPORT_TRANSFORM_SPACE_WORLD\020\001\022\"\n\036VIE"
-    "WPORT_TRANSFORM_SPACE_LOCAL\020\002B\"\252\002\037Sailor"
-    "Editor.Protocol.Generatedb\006proto3"
+    "equestH\000\022M\n\025create_model_instance\030: \001(\0132"
+    ",.sailor.editor.v1.CreateModelInstanceRe"
+    "questH\000B\t\n\007commandJ\004\010\003\020\nJ\004\0102\0203J\004\010;\020dR\030cr"
+    "eate_model_game_objectR\036resolve_viewport"
+    "_drop_position\"\226\007\n\020ProtocolResponse\022\030\n\020p"
+    "rotocol_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001("
+    "\004\022\017\n\007success\030\003 \001(\010\022\r\n\005error\030\004 \001(\t\022$\n\034sup"
+    "ports_strict_instance_ids\030\005 \001(\010\022/\n\014empty"
+    "_result\030\n \001(\0132\027.sailor.editor.v1.EmptyH\000"
+    "\0223\n\013bool_result\030\013 \001(\0132\034.sailor.editor.v1"
+    ".BoolResultH\000\0225\n\014int32_result\030\014 \001(\0132\035.sa"
+    "ilor.editor.v1.Int32ResultH\000\0227\n\ruint32_r"
+    "esult\030\r \001(\0132\036.sailor.editor.v1.UInt32Res"
+    "ultH\000\0227\n\ruint64_result\030\016 \001(\0132\036.sailor.ed"
+    "itor.v1.UInt64ResultH\000\0227\n\rstring_result\030"
+    "\017 \001(\0132\036.sailor.editor.v1.StringResultH\000\022"
+    "@\n\022string_list_result\030\020 \001(\0132\".sailor.edi"
+    "tor.v1.StringListResultH\000\022M\n\031asset_reloa"
+    "d_state_result\030\021 \001(\0132(.sailor.editor.v1."
+    "AssetReloadStateResultH\000\022@\n\022instance_id_"
+    "result\030\022 \001(\0132\".sailor.editor.v1.Instance"
+    "IdResultH\000\022Q\n\033viewport_event_batch_resul"
+    "t\030\023 \001(\0132*.sailor.editor.v1.ViewportEvent"
+    "BatchResultH\000\0229\n\016vector4_result\030\024 \001(\0132\037."
+    "sailor.editor.v1.Vector4ResultH\000\022O\n\032view"
+    "port_tool_state_result\030\025 \001(\0132).sailor.ed"
+    "itor.v1.ViewportToolStateResultH\000B\010\n\006res"
+    "ultJ\004\010\006\020\nJ\004\010\026\020d\"&\n\021InitializeRequest\022\021\n\t"
+    "arguments\030\001 \003(\t\"!\n\014CountRequest\022\021\n\tmax_c"
+    "ount\030\001 \001(\r\" \n\rFileIdRequest\022\017\n\007file_id\030\001"
+    " \001(\t\"\347\001\n\032CreateModelInstanceRequest\022\025\n\rm"
+    "odel_file_id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\032\n\022pare"
+    "nt_instance_id\030\003 \001(\t\022\030\n\020create_hierarchy"
+    "\030\004 \001(\010\022\034\n\024apply_world_position\030\005 \001(\010\0221\n\016"
+    "world_position\030\006 \001(\0132\031.sailor.editor.v1."
+    "Vector4\022\035\n\025preferred_instance_id\030\007 \001(\t\"("
+    "\n\021InstanceIdRequest\022\023\n\013instance_id\030\001 \001(\t"
+    "\"(\n\021ViewportIdRequest\022\023\n\013viewport_id\030\001 \001"
+    "(\004\"`\n\023ViewportRectRequest\022\024\n\014window_pos_"
+    "x\030\001 \001(\r\022\024\n\014window_pos_y\030\002 \001(\r\022\r\n\005width\030\003"
+    " \001(\r\022\016\n\006height\030\004 \001(\r\",\n\013SizeRequest\022\r\n\005w"
+    "idth\030\001 \001(\r\022\016\n\006height\030\002 \001(\r\"\231\001\n\025RemoteVie"
+    "wportRequest\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014win"
+    "dow_pos_x\030\002 \001(\r\022\024\n\014window_pos_y\030\003 \001(\r\022\r\n"
+    "\005width\030\004 \001(\r\022\016\n\006height\030\005 \001(\r\022\017\n\007visible\030"
+    "\006 \001(\010\022\017\n\007focused\030\007 \001(\010\"e\n\031RemoteViewport"
+    "HostRequest\022\023\n\013viewport_id\030\001 \001(\004\022\030\n\020host"
+    "_handle_kind\030\002 \001(\r\022\031\n\021host_handle_value\030"
+    "\003 \001(\004\"\374\001\n\032RemoteViewportInputRequest\022\023\n\013"
+    "viewport_id\030\001 \001(\004\022\014\n\004kind\030\002 \001(\r\022\021\n\tpoint"
+    "er_x\030\003 \001(\002\022\021\n\tpointer_y\030\004 \001(\002\022\025\n\rwheel_d"
+    "elta_x\030\005 \001(\002\022\025\n\rwheel_delta_y\030\006 \001(\002\022\020\n\010k"
+    "ey_code\030\007 \001(\r\022\016\n\006button\030\010 \001(\r\022\021\n\tmodifie"
+    "rs\030\t \001(\r\022\017\n\007pressed\030\n \001(\010\022\017\n\007focused\030\013 \001"
+    "(\010\022\020\n\010captured\030\014 \001(\010\"C\n\036ManagedMutationR"
+    "evisionRequest\022\014\n\004kind\030\001 \001(\r\022\023\n\013instance"
+    "_id\030\002 \001(\t\"@\n\023UpdateObjectRequest\022\023\n\013inst"
+    "ance_id\030\001 \001(\t\022\024\n\014yaml_changes\030\002 \001(\t\"f\n\025R"
+    "eparentObjectRequest\022\023\n\013instance_id\030\001 \001("
+    "\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\034\n\024keep_wo"
+    "rld_transform\030\003 \001(\010\"T\n\027CreateGameObjectR"
+    "equest\022\032\n\022parent_instance_id\030\001 \001(\t\022\035\n\025pr"
+    "eferred_instance_id\030\002 \001(\t\"f\n\023AddComponen"
+    "tRequest\022\023\n\013instance_id\030\001 \001(\t\022\033\n\023compone"
+    "nt_type_name\030\002 \001(\t\022\035\n\025preferred_instance"
+    "_id\030\003 \001(\t\"G\n\030InstantiatePrefabRequest\022\017\n"
+    "\007file_id\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001"
+    "(\t\"p\n InstantiatePrefabFromYamlRequest\022\023"
+    "\n\013prefab_yaml\030\001 \001(\t\022\032\n\022parent_instance_i"
+    "d\030\002 \001(\t\022\033\n\023strict_instance_ids\030\003 \001(\010\"U\n\022"
+    "ViewportRayRequest\022\023\n\013viewport_id\030\001 \001(\004\022"
+    "\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 "
+    "\001(\002\"\240\001\n InstantiatePrefabInstanceRequest"
+    "\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_instance_id\030"
+    "\002 \001(\t\022\034\n\024apply_world_position\030\003 \001(\010\0221\n\016w"
+    "orld_position\030\004 \001(\0132\031.sailor.editor.v1.V"
+    "ector4\"A\n\025ViewportObjectRequest\022\023\n\013viewp"
+    "ort_id\030\001 \001(\004\022\023\n\013instance_id\030\002 \001(\t\"9\n\021Pre"
+    "fabLinkRequest\022\023\n\013instance_id\030\001 \001(\t\022\017\n\007f"
+    "ile_id\030\002 \001(\t\"\251\001\n\030ViewportToolStateReques"
+    "t\022\023\n\013viewport_id\030\001 \001(\004\022\?\n\toperation\030\002 \001("
+    "\0162,.sailor.editor.v1.ViewportTransformOp"
+    "eration\0227\n\005space\030\003 \001(\0162(.sailor.editor.v"
+    "1.ViewportTransformSpace\"(\n\020SelectionReq"
+    "uest\022\024\n\014instance_ids\030\001 \003(\t\"%\n\025ShowMainWi"
+    "ndowRequest\022\014\n\004show\030\001 \001(\010\"\210\001\n\034RenderPath"
+    "TracedImageRequest\022\023\n\013output_path\030\001 \001(\t\022"
+    "\023\n\013instance_id\030\002 \001(\t\022\016\n\006height\030\003 \001(\r\022\031\n\021"
+    "samples_per_pixel\030\004 \001(\r\022\023\n\013max_bounces\030\005"
+    " \001(\r\"\033\n\nBoolResult\022\r\n\005value\030\001 \001(\010\"\034\n\013Int"
+    "32Result\022\r\n\005value\030\001 \001(\005\"\035\n\014UInt32Result\022"
+    "\r\n\005value\030\001 \001(\r\"\035\n\014UInt64Result\022\r\n\005value\030"
+    "\001 \001(\004\"0\n\014StringResult\022\021\n\thas_value\030\001 \001(\010"
+    "\022\r\n\005value\030\002 \001(\t\"\"\n\020StringListResult\022\016\n\006v"
+    "alues\030\001 \003(\t\"\204\001\n\026AssetReloadStateResult\022\021"
+    "\n\tavailable\030\001 \001(\010\022\032\n\022request_generation\030"
+    "\002 \001(\004\022\034\n\024completed_generation\030\003 \001(\004\022\035\n\025s"
+    "uccessful_generation\030\004 \001(\004\":\n\020InstanceId"
+    "Result\022\021\n\tsucceeded\030\001 \001(\010\022\023\n\013instance_id"
+    "\030\002 \001(\t\"9\n\rVector4Result\022(\n\005value\030\001 \001(\0132\031"
+    ".sailor.editor.v1.Vector4\"\223\001\n\027ViewportTo"
+    "olStateResult\022\?\n\toperation\030\001 \001(\0162,.sailo"
+    "r.editor.v1.ViewportTransformOperation\0227"
+    "\n\005space\030\002 \001(\0162(.sailor.editor.v1.Viewpor"
+    "tTransformSpace\"5\n\007Vector4\022\t\n\001x\030\001 \001(\002\022\t\n"
+    "\001y\030\002 \001(\002\022\t\n\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n\026Viewpo"
+    "rtSelectionEvent\022\034\n\024selected_instance_id"
+    "\030\001 \001(\t\"\326\003\n\026ViewportTransformEvent\022\023\n\013ins"
+    "tance_id\030\001 \001(\t\022\?\n\toperation\030\002 \001(\0162,.sail"
+    "or.editor.v1.ViewportTransformOperation\022"
+    "7\n\005space\030\003 \001(\0162(.sailor.editor.v1.Viewpo"
+    "rtTransformSpace\0222\n\017before_position\030\004 \001("
+    "\0132\031.sailor.editor.v1.Vector4\0222\n\017before_r"
+    "otation\030\005 \001(\0132\031.sailor.editor.v1.Vector4"
+    "\022/\n\014before_scale\030\006 \001(\0132\031.sailor.editor.v"
+    "1.Vector4\0221\n\016after_position\030\007 \001(\0132\031.sail"
+    "or.editor.v1.Vector4\0221\n\016after_rotation\030\010"
+    " \001(\0132\031.sailor.editor.v1.Vector4\022.\n\013after"
+    "_scale\030\t \001(\0132\031.sailor.editor.v1.Vector4\""
+    "U\n\026ViewportAssetDropEvent\022\017\n\007file_id\030\001 \001"
+    "(\t\022\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normalized_y"
+    "\030\003 \001(\002\"-\n\031ViewportToolShortcutEvent\022\020\n\010k"
+    "ey_code\030\001 \001(\r\"\331\002\n\rViewportEvent\022\020\n\010revis"
+    "ion\030\001 \001(\004\022!\n\031managed_mutation_revision\030\002"
+    " \001(\004\022=\n\tselection\030\n \001(\0132(.sailor.editor."
+    "v1.ViewportSelectionEventH\000\022=\n\ttransform"
+    "\030\013 \001(\0132(.sailor.editor.v1.ViewportTransf"
+    "ormEventH\000\022>\n\nasset_drop\030\014 \001(\0132(.sailor."
+    "editor.v1.ViewportAssetDropEventH\000\022D\n\rto"
+    "ol_shortcut\030\r \001(\0132+.sailor.editor.v1.Vie"
+    "wportToolShortcutEventH\000B\t\n\007payloadJ\004\010\003\020"
+    "\n\"K\n\030ViewportEventBatchResult\022/\n\006events\030"
+    "\001 \003(\0132\037.sailor.editor.v1.ViewportEvent*\360"
+    "\001\n\032ViewportTransformOperation\022,\n(VIEWPOR"
+    "T_TRANSFORM_OPERATION_UNSPECIFIED\020\000\022\'\n#V"
+    "IEWPORT_TRANSFORM_OPERATION_SELECT\020\001\022*\n&"
+    "VIEWPORT_TRANSFORM_OPERATION_TRANSLATE\020\002"
+    "\022\'\n#VIEWPORT_TRANSFORM_OPERATION_ROTATE\020"
+    "\003\022&\n\"VIEWPORT_TRANSFORM_OPERATION_SCALE\020"
+    "\004*\212\001\n\026ViewportTransformSpace\022(\n$VIEWPORT"
+    "_TRANSFORM_SPACE_UNSPECIFIED\020\000\022\"\n\036VIEWPO"
+    "RT_TRANSFORM_SPACE_WORLD\020\001\022\"\n\036VIEWPORT_T"
+    "RANSFORM_SPACE_LOCAL\020\002B\"\252\002\037SailorEditor."
+    "Protocol.Generatedb\006proto3"
 };
 static ::absl::once_flag descriptor_table_editor_5fengine_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_editor_5fengine_2eproto = {
     false,
     false,
-    8713,
+    9026,
     descriptor_table_protodef_editor_5fengine_2eproto,
     "editor_engine.proto",
     &descriptor_table_editor_5fengine_2eproto_once,
     nullptr,
     0,
-    45,
+    46,
     schemas,
     file_default_instances,
     TableStruct_editor_5fengine_2eproto::offsets,
@@ -2922,6 +2994,19 @@ void ProtocolRequest::set_allocated_update_asset(::sailor::editor::v1::FileIdReq
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.update_asset)
 }
+void ProtocolRequest::set_allocated_create_model_instance(::sailor::editor::v1::CreateModelInstanceRequest* create_model_instance) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (create_model_instance) {
+    ::google::protobuf::Arena* submessage_arena = create_model_instance->GetArena();
+    if (message_arena != submessage_arena) {
+      create_model_instance = ::google::protobuf::internal::GetOwnedMessage(message_arena, create_model_instance, submessage_arena);
+    }
+    set_has_create_model_instance();
+    _impl_.command_.create_model_instance_ = create_model_instance;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.create_model_instance)
+}
 ProtocolRequest::ProtocolRequest(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
@@ -3101,6 +3186,9 @@ ProtocolRequest::ProtocolRequest(
         break;
       case kUpdateAsset:
         _impl_.command_.update_asset_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::FileIdRequest>(arena, *from._impl_.command_.update_asset_);
+        break;
+      case kCreateModelInstance:
+        _impl_.command_.create_model_instance_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::CreateModelInstanceRequest>(arena, *from._impl_.command_.create_model_instance_);
         break;
   }
 
@@ -3516,6 +3604,14 @@ void ProtocolRequest::clear_command() {
       }
       break;
     }
+    case kCreateModelInstance: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.create_model_instance_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.create_model_instance_);
+      }
+      break;
+    }
     case COMMAND_NOT_SET: {
       break;
     }
@@ -3560,16 +3656,16 @@ const ::google::protobuf::internal::ClassData* ProtocolRequest::GetClassData() c
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
+const ::_pbi::TcParseTable<1, 50, 48, 0, 9> ProtocolRequest::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    57, 8,  // max_field_number, fast_idx_mask
+    58, 8,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
     508,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    49,  // num_field_entries
-    47,  // num_aux_entries
+    50,  // num_field_entries
+    48,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -3586,7 +3682,7 @@ const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
      {8, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.protocol_version_)}},
   }}, {{
     33, 0, 2,
-    0, 25, 65026, 41,
+    0, 25, 64514, 41,
     65535, 65535
   }}, {{
     // uint32 protocol_version = 1;
@@ -3736,6 +3832,9 @@ const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
     // .sailor.editor.v1.FileIdRequest update_asset = 57;
     {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.update_asset_), _Internal::kOneofCaseOffset + 0, 46,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.CreateModelInstanceRequest create_model_instance = 58;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.create_model_instance_), _Internal::kOneofCaseOffset + 0, 47,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InitializeRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
@@ -3784,6 +3883,7 @@ const ::_pbi::TcParseTable<1, 49, 47, 0, 9> ProtocolRequest::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportToolStateRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportIdRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::FileIdRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::CreateModelInstanceRequest>()},
   }}, {{
   }},
 };
@@ -4114,6 +4214,12 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
                   stream);
               break;
             }
+            case kCreateModelInstance: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  58, *this_._impl_.command_.create_model_instance_, this_._impl_.command_.create_model_instance_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -4434,6 +4540,12 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
             case kUpdateAsset: {
               total_size += 2 +
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.update_asset_);
+              break;
+            }
+            // .sailor.editor.v1.CreateModelInstanceRequest create_model_instance = 58;
+            case kCreateModelInstance: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.create_model_instance_);
               break;
             }
             case COMMAND_NOT_SET: {
@@ -4890,6 +5002,15 @@ void ProtocolRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const :
               ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::FileIdRequest>(arena, *from._impl_.command_.update_asset_);
         } else {
           _this->_impl_.command_.update_asset_->MergeFrom(from._internal_update_asset());
+        }
+        break;
+      }
+      case kCreateModelInstance: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.create_model_instance_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::CreateModelInstanceRequest>(arena, *from._impl_.command_.create_model_instance_);
+        } else {
+          _this->_impl_.command_.create_model_instance_->MergeFrom(from._internal_create_model_instance());
         }
         break;
       }
@@ -6582,6 +6703,438 @@ void FileIdRequest::InternalSwap(FileIdRequest* PROTOBUF_RESTRICT other) {
 }
 
 ::google::protobuf::Metadata FileIdRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class CreateModelInstanceRequest::_Internal {
+ public:
+  using HasBits =
+      decltype(std::declval<CreateModelInstanceRequest>()._impl_._has_bits_);
+  static constexpr ::int32_t kHasBitsOffset =
+      8 * PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_._has_bits_);
+};
+
+CreateModelInstanceRequest::CreateModelInstanceRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.CreateModelInstanceRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE CreateModelInstanceRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::sailor::editor::v1::CreateModelInstanceRequest& from_msg)
+      : _has_bits_{from._has_bits_},
+        _cached_size_{0},
+        model_file_id_(arena, from.model_file_id_),
+        name_(arena, from.name_),
+        parent_instance_id_(arena, from.parent_instance_id_),
+        preferred_instance_id_(arena, from.preferred_instance_id_) {}
+
+CreateModelInstanceRequest::CreateModelInstanceRequest(
+    ::google::protobuf::Arena* arena,
+    const CreateModelInstanceRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  CreateModelInstanceRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::uint32_t cached_has_bits = _impl_._has_bits_[0];
+  _impl_.world_position_ = (cached_has_bits & 0x00000001u) ? ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4>(
+                              arena, *from._impl_.world_position_)
+                        : nullptr;
+  ::memcpy(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, create_hierarchy_),
+           reinterpret_cast<const char *>(&from._impl_) +
+               offsetof(Impl_, create_hierarchy_),
+           offsetof(Impl_, apply_world_position_) -
+               offsetof(Impl_, create_hierarchy_) +
+               sizeof(Impl_::apply_world_position_));
+
+  // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.CreateModelInstanceRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE CreateModelInstanceRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0},
+        model_file_id_(arena),
+        name_(arena),
+        parent_instance_id_(arena),
+        preferred_instance_id_(arena) {}
+
+inline void CreateModelInstanceRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, world_position_),
+           0,
+           offsetof(Impl_, apply_world_position_) -
+               offsetof(Impl_, world_position_) +
+               sizeof(Impl_::apply_world_position_));
+}
+CreateModelInstanceRequest::~CreateModelInstanceRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.CreateModelInstanceRequest)
+  SharedDtor(*this);
+}
+inline void CreateModelInstanceRequest::SharedDtor(MessageLite& self) {
+  CreateModelInstanceRequest& this_ = static_cast<CreateModelInstanceRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.model_file_id_.Destroy();
+  this_._impl_.name_.Destroy();
+  this_._impl_.parent_instance_id_.Destroy();
+  this_._impl_.preferred_instance_id_.Destroy();
+  delete this_._impl_.world_position_;
+  this_._impl_.~Impl_();
+}
+
+inline void* CreateModelInstanceRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) CreateModelInstanceRequest(arena);
+}
+constexpr auto CreateModelInstanceRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(CreateModelInstanceRequest),
+                                            alignof(CreateModelInstanceRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull CreateModelInstanceRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_CreateModelInstanceRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &CreateModelInstanceRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<CreateModelInstanceRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &CreateModelInstanceRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<CreateModelInstanceRequest>(), &CreateModelInstanceRequest::ByteSizeLong,
+            &CreateModelInstanceRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_._cached_size_),
+        false,
+    },
+    &CreateModelInstanceRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* CreateModelInstanceRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<3, 7, 1, 108, 2> CreateModelInstanceRequest::_table_ = {
+  {
+    PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_._has_bits_),
+    0, // no _extensions_
+    7, 56,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967168,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    7,  // num_field_entries
+    1,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::CreateModelInstanceRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+    // string model_file_id = 1;
+    {::_pbi::TcParser::FastUS1,
+     {10, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.model_file_id_)}},
+    // string name = 2;
+    {::_pbi::TcParser::FastUS1,
+     {18, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.name_)}},
+    // string parent_instance_id = 3;
+    {::_pbi::TcParser::FastUS1,
+     {26, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.parent_instance_id_)}},
+    // bool create_hierarchy = 4;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(CreateModelInstanceRequest, _impl_.create_hierarchy_), 63>(),
+     {32, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.create_hierarchy_)}},
+    // bool apply_world_position = 5;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(CreateModelInstanceRequest, _impl_.apply_world_position_), 63>(),
+     {40, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.apply_world_position_)}},
+    // .sailor.editor.v1.Vector4 world_position = 6;
+    {::_pbi::TcParser::FastMtS1,
+     {50, 0, 0, PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.world_position_)}},
+    // string preferred_instance_id = 7;
+    {::_pbi::TcParser::FastUS1,
+     {58, 63, 0, PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.preferred_instance_id_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // string model_file_id = 1;
+    {PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.model_file_id_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // string name = 2;
+    {PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.name_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // string parent_instance_id = 3;
+    {PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.parent_instance_id_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // bool create_hierarchy = 4;
+    {PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.create_hierarchy_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+    // bool apply_world_position = 5;
+    {PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.apply_world_position_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+    // .sailor.editor.v1.Vector4 world_position = 6;
+    {PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.world_position_), _Internal::kHasBitsOffset + 0, 0,
+    (0 | ::_fl::kFcOptional | ::_fl::kMessage | ::_fl::kTvTable)},
+    // string preferred_instance_id = 7;
+    {PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.preferred_instance_id_), -1, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::Vector4>()},
+  }}, {{
+    "\53\15\4\22\0\0\0\25"
+    "sailor.editor.v1.CreateModelInstanceRequest"
+    "model_file_id"
+    "name"
+    "parent_instance_id"
+    "preferred_instance_id"
+  }},
+};
+
+PROTOBUF_NOINLINE void CreateModelInstanceRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.CreateModelInstanceRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.model_file_id_.ClearToEmpty();
+  _impl_.name_.ClearToEmpty();
+  _impl_.parent_instance_id_.ClearToEmpty();
+  _impl_.preferred_instance_id_.ClearToEmpty();
+  cached_has_bits = _impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(_impl_.world_position_ != nullptr);
+    _impl_.world_position_->Clear();
+  }
+  ::memset(&_impl_.create_hierarchy_, 0, static_cast<::size_t>(
+      reinterpret_cast<char*>(&_impl_.apply_world_position_) -
+      reinterpret_cast<char*>(&_impl_.create_hierarchy_)) + sizeof(_impl_.apply_world_position_));
+  _impl_._has_bits_.Clear();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* CreateModelInstanceRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const CreateModelInstanceRequest& this_ = static_cast<const CreateModelInstanceRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* CreateModelInstanceRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const CreateModelInstanceRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.CreateModelInstanceRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // string model_file_id = 1;
+          if (!this_._internal_model_file_id().empty()) {
+            const std::string& _s = this_._internal_model_file_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.CreateModelInstanceRequest.model_file_id");
+            target = stream->WriteStringMaybeAliased(1, _s, target);
+          }
+
+          // string name = 2;
+          if (!this_._internal_name().empty()) {
+            const std::string& _s = this_._internal_name();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.CreateModelInstanceRequest.name");
+            target = stream->WriteStringMaybeAliased(2, _s, target);
+          }
+
+          // string parent_instance_id = 3;
+          if (!this_._internal_parent_instance_id().empty()) {
+            const std::string& _s = this_._internal_parent_instance_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.CreateModelInstanceRequest.parent_instance_id");
+            target = stream->WriteStringMaybeAliased(3, _s, target);
+          }
+
+          // bool create_hierarchy = 4;
+          if (this_._internal_create_hierarchy() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                4, this_._internal_create_hierarchy(), target);
+          }
+
+          // bool apply_world_position = 5;
+          if (this_._internal_apply_world_position() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                5, this_._internal_apply_world_position(), target);
+          }
+
+          cached_has_bits = this_._impl_._has_bits_[0];
+          // .sailor.editor.v1.Vector4 world_position = 6;
+          if (cached_has_bits & 0x00000001u) {
+            target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                6, *this_._impl_.world_position_, this_._impl_.world_position_->GetCachedSize(), target,
+                stream);
+          }
+
+          // string preferred_instance_id = 7;
+          if (!this_._internal_preferred_instance_id().empty()) {
+            const std::string& _s = this_._internal_preferred_instance_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.CreateModelInstanceRequest.preferred_instance_id");
+            target = stream->WriteStringMaybeAliased(7, _s, target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.CreateModelInstanceRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t CreateModelInstanceRequest::ByteSizeLong(const MessageLite& base) {
+          const CreateModelInstanceRequest& this_ = static_cast<const CreateModelInstanceRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t CreateModelInstanceRequest::ByteSizeLong() const {
+          const CreateModelInstanceRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.CreateModelInstanceRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // string model_file_id = 1;
+            if (!this_._internal_model_file_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_model_file_id());
+            }
+            // string name = 2;
+            if (!this_._internal_name().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_name());
+            }
+            // string parent_instance_id = 3;
+            if (!this_._internal_parent_instance_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_parent_instance_id());
+            }
+            // string preferred_instance_id = 7;
+            if (!this_._internal_preferred_instance_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_preferred_instance_id());
+            }
+          }
+           {
+            // .sailor.editor.v1.Vector4 world_position = 6;
+            cached_has_bits = this_._impl_._has_bits_[0];
+            if (cached_has_bits & 0x00000001u) {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.world_position_);
+            }
+          }
+           {
+            // bool create_hierarchy = 4;
+            if (this_._internal_create_hierarchy() != 0) {
+              total_size += 2;
+            }
+            // bool apply_world_position = 5;
+            if (this_._internal_apply_world_position() != 0) {
+              total_size += 2;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void CreateModelInstanceRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<CreateModelInstanceRequest*>(&to_msg);
+  auto& from = static_cast<const CreateModelInstanceRequest&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.CreateModelInstanceRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_model_file_id().empty()) {
+    _this->_internal_set_model_file_id(from._internal_model_file_id());
+  }
+  if (!from._internal_name().empty()) {
+    _this->_internal_set_name(from._internal_name());
+  }
+  if (!from._internal_parent_instance_id().empty()) {
+    _this->_internal_set_parent_instance_id(from._internal_parent_instance_id());
+  }
+  if (!from._internal_preferred_instance_id().empty()) {
+    _this->_internal_set_preferred_instance_id(from._internal_preferred_instance_id());
+  }
+  cached_has_bits = from._impl_._has_bits_[0];
+  if (cached_has_bits & 0x00000001u) {
+    ABSL_DCHECK(from._impl_.world_position_ != nullptr);
+    if (_this->_impl_.world_position_ == nullptr) {
+      _this->_impl_.world_position_ =
+          ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Vector4>(arena, *from._impl_.world_position_);
+    } else {
+      _this->_impl_.world_position_->MergeFrom(*from._impl_.world_position_);
+    }
+  }
+  if (from._internal_create_hierarchy() != 0) {
+    _this->_impl_.create_hierarchy_ = from._impl_.create_hierarchy_;
+  }
+  if (from._internal_apply_world_position() != 0) {
+    _this->_impl_.apply_world_position_ = from._impl_.apply_world_position_;
+  }
+  _this->_impl_._has_bits_[0] |= cached_has_bits;
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void CreateModelInstanceRequest::CopyFrom(const CreateModelInstanceRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.CreateModelInstanceRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void CreateModelInstanceRequest::InternalSwap(CreateModelInstanceRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_._has_bits_[0], other->_impl_._has_bits_[0]);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.model_file_id_, &other->_impl_.model_file_id_, arena);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.name_, &other->_impl_.name_, arena);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.parent_instance_id_, &other->_impl_.parent_instance_id_, arena);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.preferred_instance_id_, &other->_impl_.preferred_instance_id_, arena);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.apply_world_position_)
+      + sizeof(CreateModelInstanceRequest::_impl_.apply_world_position_)
+      - PROTOBUF_FIELD_OFFSET(CreateModelInstanceRequest, _impl_.world_position_)>(
+          reinterpret_cast<char*>(&_impl_.world_position_),
+          reinterpret_cast<char*>(&other->_impl_.world_position_));
+}
+
+::google::protobuf::Metadata CreateModelInstanceRequest::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/Runtime/Protocol/Generated/editor_engine.pb.h
+++ b/Runtime/Protocol/Generated/editor_engine.pb.h
@@ -71,6 +71,9 @@ extern CountRequestDefaultTypeInternal _CountRequest_default_instance_;
 class CreateGameObjectRequest;
 struct CreateGameObjectRequestDefaultTypeInternal;
 extern CreateGameObjectRequestDefaultTypeInternal _CreateGameObjectRequest_default_instance_;
+class CreateModelInstanceRequest;
+struct CreateModelInstanceRequestDefaultTypeInternal;
+extern CreateModelInstanceRequestDefaultTypeInternal _CreateModelInstanceRequest_default_instance_;
 class Empty;
 struct EmptyDefaultTypeInternal;
 extern EmptyDefaultTypeInternal _Empty_default_instance_;
@@ -337,7 +340,7 @@ class ViewportToolStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateResult*>(
         &_ViewportToolStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 37;
+  static constexpr int kIndexInFileMessages = 38;
   friend void swap(ViewportToolStateResult& a, ViewportToolStateResult& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateResult* other) {
     if (other == this) return;
@@ -539,7 +542,7 @@ class ViewportToolStateRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateRequest*>(
         &_ViewportToolStateRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 24;
+  static constexpr int kIndexInFileMessages = 25;
   friend void swap(ViewportToolStateRequest& a, ViewportToolStateRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateRequest* other) {
     if (other == this) return;
@@ -753,7 +756,7 @@ class ViewportToolShortcutEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolShortcutEvent*>(
         &_ViewportToolShortcutEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 42;
+  static constexpr int kIndexInFileMessages = 43;
   friend void swap(ViewportToolShortcutEvent& a, ViewportToolShortcutEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportToolShortcutEvent* other) {
     if (other == this) return;
@@ -943,7 +946,7 @@ class ViewportSelectionEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportSelectionEvent*>(
         &_ViewportSelectionEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 39;
+  static constexpr int kIndexInFileMessages = 40;
   friend void swap(ViewportSelectionEvent& a, ViewportSelectionEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportSelectionEvent* other) {
     if (other == this) return;
@@ -1139,7 +1142,7 @@ class ViewportRectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportRectRequest*>(
         &_ViewportRectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 8;
+  static constexpr int kIndexInFileMessages = 9;
   friend void swap(ViewportRectRequest& a, ViewportRectRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportRectRequest* other) {
     if (other == this) return;
@@ -1365,7 +1368,7 @@ class ViewportRayRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportRayRequest*>(
         &_ViewportRayRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 20;
+  static constexpr int kIndexInFileMessages = 21;
   friend void swap(ViewportRayRequest& a, ViewportRayRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportRayRequest* other) {
     if (other == this) return;
@@ -1579,7 +1582,7 @@ class ViewportObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportObjectRequest*>(
         &_ViewportObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 22;
+  static constexpr int kIndexInFileMessages = 23;
   friend void swap(ViewportObjectRequest& a, ViewportObjectRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportObjectRequest* other) {
     if (other == this) return;
@@ -1787,7 +1790,7 @@ class ViewportIdRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportIdRequest*>(
         &_ViewportIdRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 7;
+  static constexpr int kIndexInFileMessages = 8;
   friend void swap(ViewportIdRequest& a, ViewportIdRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportIdRequest* other) {
     if (other == this) return;
@@ -1977,7 +1980,7 @@ class ViewportAssetDropEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportAssetDropEvent*>(
         &_ViewportAssetDropEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 41;
+  static constexpr int kIndexInFileMessages = 42;
   friend void swap(ViewportAssetDropEvent& a, ViewportAssetDropEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportAssetDropEvent* other) {
     if (other == this) return;
@@ -2197,7 +2200,7 @@ class Vector4 final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4*>(
         &_Vector4_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 38;
+  static constexpr int kIndexInFileMessages = 39;
   friend void swap(Vector4& a, Vector4& b) { a.Swap(&b); }
   inline void Swap(Vector4* other) {
     if (other == this) return;
@@ -2423,7 +2426,7 @@ class UpdateObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const UpdateObjectRequest*>(
         &_UpdateObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 14;
+  static constexpr int kIndexInFileMessages = 15;
   friend void swap(UpdateObjectRequest& a, UpdateObjectRequest& b) { a.Swap(&b); }
   inline void Swap(UpdateObjectRequest* other) {
     if (other == this) return;
@@ -2637,7 +2640,7 @@ class UInt64Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt64Result*>(
         &_UInt64Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 31;
+  static constexpr int kIndexInFileMessages = 32;
   friend void swap(UInt64Result& a, UInt64Result& b) { a.Swap(&b); }
   inline void Swap(UInt64Result* other) {
     if (other == this) return;
@@ -2827,7 +2830,7 @@ class UInt32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt32Result*>(
         &_UInt32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 30;
+  static constexpr int kIndexInFileMessages = 31;
   friend void swap(UInt32Result& a, UInt32Result& b) { a.Swap(&b); }
   inline void Swap(UInt32Result* other) {
     if (other == this) return;
@@ -3017,7 +3020,7 @@ class StringResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringResult*>(
         &_StringResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 32;
+  static constexpr int kIndexInFileMessages = 33;
   friend void swap(StringResult& a, StringResult& b) { a.Swap(&b); }
   inline void Swap(StringResult* other) {
     if (other == this) return;
@@ -3225,7 +3228,7 @@ class StringListResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringListResult*>(
         &_StringListResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 33;
+  static constexpr int kIndexInFileMessages = 34;
   friend void swap(StringListResult& a, StringListResult& b) { a.Swap(&b); }
   inline void Swap(StringListResult* other) {
     if (other == this) return;
@@ -3427,7 +3430,7 @@ class SizeRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const SizeRequest*>(
         &_SizeRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 9;
+  static constexpr int kIndexInFileMessages = 10;
   friend void swap(SizeRequest& a, SizeRequest& b) { a.Swap(&b); }
   inline void Swap(SizeRequest* other) {
     if (other == this) return;
@@ -3629,7 +3632,7 @@ class ShowMainWindowRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ShowMainWindowRequest*>(
         &_ShowMainWindowRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 26;
+  static constexpr int kIndexInFileMessages = 27;
   friend void swap(ShowMainWindowRequest& a, ShowMainWindowRequest& b) { a.Swap(&b); }
   inline void Swap(ShowMainWindowRequest* other) {
     if (other == this) return;
@@ -3819,7 +3822,7 @@ class SelectionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const SelectionRequest*>(
         &_SelectionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 25;
+  static constexpr int kIndexInFileMessages = 26;
   friend void swap(SelectionRequest& a, SelectionRequest& b) { a.Swap(&b); }
   inline void Swap(SelectionRequest* other) {
     if (other == this) return;
@@ -4021,7 +4024,7 @@ class ReparentObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ReparentObjectRequest*>(
         &_ReparentObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 15;
+  static constexpr int kIndexInFileMessages = 16;
   friend void swap(ReparentObjectRequest& a, ReparentObjectRequest& b) { a.Swap(&b); }
   inline void Swap(ReparentObjectRequest* other) {
     if (other == this) return;
@@ -4247,7 +4250,7 @@ class RenderPathTracedImageRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RenderPathTracedImageRequest*>(
         &_RenderPathTracedImageRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 27;
+  static constexpr int kIndexInFileMessages = 28;
   friend void swap(RenderPathTracedImageRequest& a, RenderPathTracedImageRequest& b) { a.Swap(&b); }
   inline void Swap(RenderPathTracedImageRequest* other) {
     if (other == this) return;
@@ -4497,7 +4500,7 @@ class RemoteViewportRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportRequest*>(
         &_RemoteViewportRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 10;
+  static constexpr int kIndexInFileMessages = 11;
   friend void swap(RemoteViewportRequest& a, RemoteViewportRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportRequest* other) {
     if (other == this) return;
@@ -4759,7 +4762,7 @@ class RemoteViewportInputRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportInputRequest*>(
         &_RemoteViewportInputRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 12;
+  static constexpr int kIndexInFileMessages = 13;
   friend void swap(RemoteViewportInputRequest& a, RemoteViewportInputRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportInputRequest* other) {
     if (other == this) return;
@@ -5081,7 +5084,7 @@ class RemoteViewportHostRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportHostRequest*>(
         &_RemoteViewportHostRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 11;
+  static constexpr int kIndexInFileMessages = 12;
   friend void swap(RemoteViewportHostRequest& a, RemoteViewportHostRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportHostRequest* other) {
     if (other == this) return;
@@ -5295,7 +5298,7 @@ class PrefabLinkRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const PrefabLinkRequest*>(
         &_PrefabLinkRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 23;
+  static constexpr int kIndexInFileMessages = 24;
   friend void swap(PrefabLinkRequest& a, PrefabLinkRequest& b) { a.Swap(&b); }
   inline void Swap(PrefabLinkRequest* other) {
     if (other == this) return;
@@ -5509,7 +5512,7 @@ class ManagedMutationRevisionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ManagedMutationRevisionRequest*>(
         &_ManagedMutationRevisionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 13;
+  static constexpr int kIndexInFileMessages = 14;
   friend void swap(ManagedMutationRevisionRequest& a, ManagedMutationRevisionRequest& b) { a.Swap(&b); }
   inline void Swap(ManagedMutationRevisionRequest* other) {
     if (other == this) return;
@@ -5717,7 +5720,7 @@ class Int32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Int32Result*>(
         &_Int32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 29;
+  static constexpr int kIndexInFileMessages = 30;
   friend void swap(Int32Result& a, Int32Result& b) { a.Swap(&b); }
   inline void Swap(Int32Result* other) {
     if (other == this) return;
@@ -5907,7 +5910,7 @@ class InstantiatePrefabRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const InstantiatePrefabRequest*>(
         &_InstantiatePrefabRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 18;
+  static constexpr int kIndexInFileMessages = 19;
   friend void swap(InstantiatePrefabRequest& a, InstantiatePrefabRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabRequest* other) {
     if (other == this) return;
@@ -6121,7 +6124,7 @@ class InstantiatePrefabFromYamlRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabFromYamlRequest*>(
         &_InstantiatePrefabFromYamlRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 19;
+  static constexpr int kIndexInFileMessages = 20;
   friend void swap(InstantiatePrefabFromYamlRequest& a, InstantiatePrefabFromYamlRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabFromYamlRequest* other) {
     if (other == this) return;
@@ -6347,7 +6350,7 @@ class InstanceIdResult final : public ::google::protobuf::Message
     return reinterpret_cast<const InstanceIdResult*>(
         &_InstanceIdResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 35;
+  static constexpr int kIndexInFileMessages = 36;
   friend void swap(InstanceIdResult& a, InstanceIdResult& b) { a.Swap(&b); }
   inline void Swap(InstanceIdResult* other) {
     if (other == this) return;
@@ -6555,7 +6558,7 @@ class InstanceIdRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const InstanceIdRequest*>(
         &_InstanceIdRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 6;
+  static constexpr int kIndexInFileMessages = 7;
   friend void swap(InstanceIdRequest& a, InstanceIdRequest& b) { a.Swap(&b); }
   inline void Swap(InstanceIdRequest* other) {
     if (other == this) return;
@@ -7294,7 +7297,7 @@ class CreateGameObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const CreateGameObjectRequest*>(
         &_CreateGameObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 16;
+  static constexpr int kIndexInFileMessages = 17;
   friend void swap(CreateGameObjectRequest& a, CreateGameObjectRequest& b) { a.Swap(&b); }
   inline void Swap(CreateGameObjectRequest* other) {
     if (other == this) return;
@@ -7698,7 +7701,7 @@ class BoolResult final : public ::google::protobuf::Message
     return reinterpret_cast<const BoolResult*>(
         &_BoolResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 28;
+  static constexpr int kIndexInFileMessages = 29;
   friend void swap(BoolResult& a, BoolResult& b) { a.Swap(&b); }
   inline void Swap(BoolResult* other) {
     if (other == this) return;
@@ -7888,7 +7891,7 @@ class AssetReloadStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const AssetReloadStateResult*>(
         &_AssetReloadStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 34;
+  static constexpr int kIndexInFileMessages = 35;
   friend void swap(AssetReloadStateResult& a, AssetReloadStateResult& b) { a.Swap(&b); }
   inline void Swap(AssetReloadStateResult* other) {
     if (other == this) return;
@@ -8114,7 +8117,7 @@ class AddComponentRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const AddComponentRequest*>(
         &_AddComponentRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 17;
+  static constexpr int kIndexInFileMessages = 18;
   friend void swap(AddComponentRequest& a, AddComponentRequest& b) { a.Swap(&b); }
   inline void Swap(AddComponentRequest* other) {
     if (other == this) return;
@@ -8346,7 +8349,7 @@ class ViewportTransformEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportTransformEvent*>(
         &_ViewportTransformEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 40;
+  static constexpr int kIndexInFileMessages = 41;
   friend void swap(ViewportTransformEvent& a, ViewportTransformEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportTransformEvent* other) {
     if (other == this) return;
@@ -8669,7 +8672,7 @@ class Vector4Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4Result*>(
         &_Vector4Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 36;
+  static constexpr int kIndexInFileMessages = 37;
   friend void swap(Vector4Result& a, Vector4Result& b) { a.Swap(&b); }
   inline void Swap(Vector4Result* other) {
     if (other == this) return;
@@ -8865,7 +8868,7 @@ class InstantiatePrefabInstanceRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabInstanceRequest*>(
         &_InstantiatePrefabInstanceRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 21;
+  static constexpr int kIndexInFileMessages = 22;
   friend void swap(InstantiatePrefabInstanceRequest& a, InstantiatePrefabInstanceRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabInstanceRequest* other) {
     if (other == this) return;
@@ -9050,6 +9053,298 @@ class InstantiatePrefabInstanceRequest final : public ::google::protobuf::Messag
 };
 // -------------------------------------------------------------------
 
+class CreateModelInstanceRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.CreateModelInstanceRequest) */ {
+ public:
+  inline CreateModelInstanceRequest() : CreateModelInstanceRequest(nullptr) {}
+  ~CreateModelInstanceRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(CreateModelInstanceRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(CreateModelInstanceRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR CreateModelInstanceRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline CreateModelInstanceRequest(const CreateModelInstanceRequest& from) : CreateModelInstanceRequest(nullptr, from) {}
+  inline CreateModelInstanceRequest(CreateModelInstanceRequest&& from) noexcept
+      : CreateModelInstanceRequest(nullptr, std::move(from)) {}
+  inline CreateModelInstanceRequest& operator=(const CreateModelInstanceRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline CreateModelInstanceRequest& operator=(CreateModelInstanceRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const CreateModelInstanceRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const CreateModelInstanceRequest* internal_default_instance() {
+    return reinterpret_cast<const CreateModelInstanceRequest*>(
+        &_CreateModelInstanceRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 6;
+  friend void swap(CreateModelInstanceRequest& a, CreateModelInstanceRequest& b) { a.Swap(&b); }
+  inline void Swap(CreateModelInstanceRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(CreateModelInstanceRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  CreateModelInstanceRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<CreateModelInstanceRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const CreateModelInstanceRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const CreateModelInstanceRequest& from) { CreateModelInstanceRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(CreateModelInstanceRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.CreateModelInstanceRequest"; }
+
+ protected:
+  explicit CreateModelInstanceRequest(::google::protobuf::Arena* arena);
+  CreateModelInstanceRequest(::google::protobuf::Arena* arena, const CreateModelInstanceRequest& from);
+  CreateModelInstanceRequest(::google::protobuf::Arena* arena, CreateModelInstanceRequest&& from) noexcept
+      : CreateModelInstanceRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kModelFileIdFieldNumber = 1,
+    kNameFieldNumber = 2,
+    kParentInstanceIdFieldNumber = 3,
+    kPreferredInstanceIdFieldNumber = 7,
+    kWorldPositionFieldNumber = 6,
+    kCreateHierarchyFieldNumber = 4,
+    kApplyWorldPositionFieldNumber = 5,
+  };
+  // string model_file_id = 1;
+  void clear_model_file_id() ;
+  const std::string& model_file_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_model_file_id(Arg_&& arg, Args_... args);
+  std::string* mutable_model_file_id();
+  PROTOBUF_NODISCARD std::string* release_model_file_id();
+  void set_allocated_model_file_id(std::string* value);
+
+  private:
+  const std::string& _internal_model_file_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_model_file_id(
+      const std::string& value);
+  std::string* _internal_mutable_model_file_id();
+
+  public:
+  // string name = 2;
+  void clear_name() ;
+  const std::string& name() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_name(Arg_&& arg, Args_... args);
+  std::string* mutable_name();
+  PROTOBUF_NODISCARD std::string* release_name();
+  void set_allocated_name(std::string* value);
+
+  private:
+  const std::string& _internal_name() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_name(
+      const std::string& value);
+  std::string* _internal_mutable_name();
+
+  public:
+  // string parent_instance_id = 3;
+  void clear_parent_instance_id() ;
+  const std::string& parent_instance_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_parent_instance_id(Arg_&& arg, Args_... args);
+  std::string* mutable_parent_instance_id();
+  PROTOBUF_NODISCARD std::string* release_parent_instance_id();
+  void set_allocated_parent_instance_id(std::string* value);
+
+  private:
+  const std::string& _internal_parent_instance_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_parent_instance_id(
+      const std::string& value);
+  std::string* _internal_mutable_parent_instance_id();
+
+  public:
+  // string preferred_instance_id = 7;
+  void clear_preferred_instance_id() ;
+  const std::string& preferred_instance_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_preferred_instance_id(Arg_&& arg, Args_... args);
+  std::string* mutable_preferred_instance_id();
+  PROTOBUF_NODISCARD std::string* release_preferred_instance_id();
+  void set_allocated_preferred_instance_id(std::string* value);
+
+  private:
+  const std::string& _internal_preferred_instance_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_preferred_instance_id(
+      const std::string& value);
+  std::string* _internal_mutable_preferred_instance_id();
+
+  public:
+  // .sailor.editor.v1.Vector4 world_position = 6;
+  bool has_world_position() const;
+  void clear_world_position() ;
+  const ::sailor::editor::v1::Vector4& world_position() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::Vector4* release_world_position();
+  ::sailor::editor::v1::Vector4* mutable_world_position();
+  void set_allocated_world_position(::sailor::editor::v1::Vector4* value);
+  void unsafe_arena_set_allocated_world_position(::sailor::editor::v1::Vector4* value);
+  ::sailor::editor::v1::Vector4* unsafe_arena_release_world_position();
+
+  private:
+  const ::sailor::editor::v1::Vector4& _internal_world_position() const;
+  ::sailor::editor::v1::Vector4* _internal_mutable_world_position();
+
+  public:
+  // bool create_hierarchy = 4;
+  void clear_create_hierarchy() ;
+  bool create_hierarchy() const;
+  void set_create_hierarchy(bool value);
+
+  private:
+  bool _internal_create_hierarchy() const;
+  void _internal_set_create_hierarchy(bool value);
+
+  public:
+  // bool apply_world_position = 5;
+  void clear_apply_world_position() ;
+  bool apply_world_position() const;
+  void set_apply_world_position(bool value);
+
+  private:
+  bool _internal_apply_world_position() const;
+  void _internal_set_apply_world_position(bool value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.CreateModelInstanceRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      3, 7, 1,
+      108, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const CreateModelInstanceRequest& from_msg);
+    ::google::protobuf::internal::HasBits<1> _has_bits_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::google::protobuf::internal::ArenaStringPtr model_file_id_;
+    ::google::protobuf::internal::ArenaStringPtr name_;
+    ::google::protobuf::internal::ArenaStringPtr parent_instance_id_;
+    ::google::protobuf::internal::ArenaStringPtr preferred_instance_id_;
+    ::sailor::editor::v1::Vector4* world_position_;
+    bool create_hierarchy_;
+    bool apply_world_position_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ViewportEvent final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportEvent) */ {
  public:
@@ -9116,7 +9411,7 @@ class ViewportEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEvent*>(
         &_ViewportEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 43;
+  static constexpr int kIndexInFileMessages = 44;
   friend void swap(ViewportEvent& a, ViewportEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportEvent* other) {
     if (other == this) return;
@@ -9459,6 +9754,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kSetViewportToolState = 55,
     kGetViewportToolState = 56,
     kUpdateAsset = 57,
+    kCreateModelInstance = 58,
     COMMAND_NOT_SET = 0,
   };
   static inline const ProtocolRequest* internal_default_instance() {
@@ -9601,6 +9897,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kSetViewportToolStateFieldNumber = 55,
     kGetViewportToolStateFieldNumber = 56,
     kUpdateAssetFieldNumber = 57,
+    kCreateModelInstanceFieldNumber = 58,
   };
   // uint64 request_id = 2;
   void clear_request_id() ;
@@ -10515,6 +10812,25 @@ class ProtocolRequest final : public ::google::protobuf::Message
   ::sailor::editor::v1::FileIdRequest* _internal_mutable_update_asset();
 
   public:
+  // .sailor.editor.v1.CreateModelInstanceRequest create_model_instance = 58;
+  bool has_create_model_instance() const;
+  private:
+  bool _internal_has_create_model_instance() const;
+
+  public:
+  void clear_create_model_instance() ;
+  const ::sailor::editor::v1::CreateModelInstanceRequest& create_model_instance() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::CreateModelInstanceRequest* release_create_model_instance();
+  ::sailor::editor::v1::CreateModelInstanceRequest* mutable_create_model_instance();
+  void set_allocated_create_model_instance(::sailor::editor::v1::CreateModelInstanceRequest* value);
+  void unsafe_arena_set_allocated_create_model_instance(::sailor::editor::v1::CreateModelInstanceRequest* value);
+  ::sailor::editor::v1::CreateModelInstanceRequest* unsafe_arena_release_create_model_instance();
+
+  private:
+  const ::sailor::editor::v1::CreateModelInstanceRequest& _internal_create_model_instance() const;
+  ::sailor::editor::v1::CreateModelInstanceRequest* _internal_mutable_create_model_instance();
+
+  public:
   void clear_command();
   CommandCase command_case() const;
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.ProtocolRequest)
@@ -10567,11 +10883,12 @@ class ProtocolRequest final : public ::google::protobuf::Message
   void set_has_set_viewport_tool_state();
   void set_has_get_viewport_tool_state();
   void set_has_update_asset();
+  void set_has_create_model_instance();
   inline bool has_command() const;
   inline void clear_has_command();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      1, 49, 47,
+      1, 50, 48,
       0, 9>
       _table_;
 
@@ -10641,6 +10958,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
       ::sailor::editor::v1::ViewportToolStateRequest* set_viewport_tool_state_;
       ::sailor::editor::v1::ViewportIdRequest* get_viewport_tool_state_;
       ::sailor::editor::v1::FileIdRequest* update_asset_;
+      ::sailor::editor::v1::CreateModelInstanceRequest* create_model_instance_;
     } command_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -10710,7 +11028,7 @@ class ViewportEventBatchResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEventBatchResult*>(
         &_ViewportEventBatchResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 44;
+  static constexpr int kIndexInFileMessages = 45;
   friend void swap(ViewportEventBatchResult& a, ViewportEventBatchResult& b) { a.Swap(&b); }
   inline void Swap(ViewportEventBatchResult* other) {
     if (other == this) return;
@@ -15156,6 +15474,85 @@ inline ::sailor::editor::v1::FileIdRequest* ProtocolRequest::mutable_update_asse
   return _msg;
 }
 
+// .sailor.editor.v1.CreateModelInstanceRequest create_model_instance = 58;
+inline bool ProtocolRequest::has_create_model_instance() const {
+  return command_case() == kCreateModelInstance;
+}
+inline bool ProtocolRequest::_internal_has_create_model_instance() const {
+  return command_case() == kCreateModelInstance;
+}
+inline void ProtocolRequest::set_has_create_model_instance() {
+  _impl_._oneof_case_[0] = kCreateModelInstance;
+}
+inline void ProtocolRequest::clear_create_model_instance() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kCreateModelInstance) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.create_model_instance_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.create_model_instance_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::CreateModelInstanceRequest* ProtocolRequest::release_create_model_instance() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.create_model_instance)
+  if (command_case() == kCreateModelInstance) {
+    clear_has_command();
+    auto* temp = _impl_.command_.create_model_instance_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.create_model_instance_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::CreateModelInstanceRequest& ProtocolRequest::_internal_create_model_instance() const {
+  return command_case() == kCreateModelInstance ? *_impl_.command_.create_model_instance_ : reinterpret_cast<::sailor::editor::v1::CreateModelInstanceRequest&>(::sailor::editor::v1::_CreateModelInstanceRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::CreateModelInstanceRequest& ProtocolRequest::create_model_instance() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.create_model_instance)
+  return _internal_create_model_instance();
+}
+inline ::sailor::editor::v1::CreateModelInstanceRequest* ProtocolRequest::unsafe_arena_release_create_model_instance() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.create_model_instance)
+  if (command_case() == kCreateModelInstance) {
+    clear_has_command();
+    auto* temp = _impl_.command_.create_model_instance_;
+    _impl_.command_.create_model_instance_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_create_model_instance(::sailor::editor::v1::CreateModelInstanceRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_create_model_instance();
+    _impl_.command_.create_model_instance_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.create_model_instance)
+}
+inline ::sailor::editor::v1::CreateModelInstanceRequest* ProtocolRequest::_internal_mutable_create_model_instance() {
+  if (command_case() != kCreateModelInstance) {
+    clear_command();
+    set_has_create_model_instance();
+    _impl_.command_.create_model_instance_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::CreateModelInstanceRequest>(GetArena());
+  }
+  return _impl_.command_.create_model_instance_;
+}
+inline ::sailor::editor::v1::CreateModelInstanceRequest* ProtocolRequest::mutable_create_model_instance() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::CreateModelInstanceRequest* _msg = _internal_mutable_create_model_instance();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.create_model_instance)
+  return _msg;
+}
+
 inline bool ProtocolRequest::has_command() const {
   return command_case() != COMMAND_NOT_SET;
 }
@@ -16406,6 +16803,342 @@ inline void FileIdRequest::set_allocated_file_id(std::string* value) {
     _impl_.file_id_.Set("", GetArena());
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.FileIdRequest.file_id)
+}
+
+// -------------------------------------------------------------------
+
+// CreateModelInstanceRequest
+
+// string model_file_id = 1;
+inline void CreateModelInstanceRequest::clear_model_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.model_file_id_.ClearToEmpty();
+}
+inline const std::string& CreateModelInstanceRequest::model_file_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelInstanceRequest.model_file_id)
+  return _internal_model_file_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void CreateModelInstanceRequest::set_model_file_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.model_file_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelInstanceRequest.model_file_id)
+}
+inline std::string* CreateModelInstanceRequest::mutable_model_file_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_model_file_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelInstanceRequest.model_file_id)
+  return _s;
+}
+inline const std::string& CreateModelInstanceRequest::_internal_model_file_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.model_file_id_.Get();
+}
+inline void CreateModelInstanceRequest::_internal_set_model_file_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.model_file_id_.Set(value, GetArena());
+}
+inline std::string* CreateModelInstanceRequest::_internal_mutable_model_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.model_file_id_.Mutable( GetArena());
+}
+inline std::string* CreateModelInstanceRequest::release_model_file_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelInstanceRequest.model_file_id)
+  return _impl_.model_file_id_.Release();
+}
+inline void CreateModelInstanceRequest::set_allocated_model_file_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.model_file_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.model_file_id_.IsDefault()) {
+    _impl_.model_file_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelInstanceRequest.model_file_id)
+}
+
+// string name = 2;
+inline void CreateModelInstanceRequest::clear_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.ClearToEmpty();
+}
+inline const std::string& CreateModelInstanceRequest::name() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelInstanceRequest.name)
+  return _internal_name();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void CreateModelInstanceRequest::set_name(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelInstanceRequest.name)
+}
+inline std::string* CreateModelInstanceRequest::mutable_name() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_name();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelInstanceRequest.name)
+  return _s;
+}
+inline const std::string& CreateModelInstanceRequest::_internal_name() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.name_.Get();
+}
+inline void CreateModelInstanceRequest::_internal_set_name(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.Set(value, GetArena());
+}
+inline std::string* CreateModelInstanceRequest::_internal_mutable_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.name_.Mutable( GetArena());
+}
+inline std::string* CreateModelInstanceRequest::release_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelInstanceRequest.name)
+  return _impl_.name_.Release();
+}
+inline void CreateModelInstanceRequest::set_allocated_name(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.name_.IsDefault()) {
+    _impl_.name_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelInstanceRequest.name)
+}
+
+// string parent_instance_id = 3;
+inline void CreateModelInstanceRequest::clear_parent_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.ClearToEmpty();
+}
+inline const std::string& CreateModelInstanceRequest::parent_instance_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelInstanceRequest.parent_instance_id)
+  return _internal_parent_instance_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void CreateModelInstanceRequest::set_parent_instance_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelInstanceRequest.parent_instance_id)
+}
+inline std::string* CreateModelInstanceRequest::mutable_parent_instance_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_parent_instance_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelInstanceRequest.parent_instance_id)
+  return _s;
+}
+inline const std::string& CreateModelInstanceRequest::_internal_parent_instance_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.parent_instance_id_.Get();
+}
+inline void CreateModelInstanceRequest::_internal_set_parent_instance_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.Set(value, GetArena());
+}
+inline std::string* CreateModelInstanceRequest::_internal_mutable_parent_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.parent_instance_id_.Mutable( GetArena());
+}
+inline std::string* CreateModelInstanceRequest::release_parent_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelInstanceRequest.parent_instance_id)
+  return _impl_.parent_instance_id_.Release();
+}
+inline void CreateModelInstanceRequest::set_allocated_parent_instance_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parent_instance_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.parent_instance_id_.IsDefault()) {
+    _impl_.parent_instance_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelInstanceRequest.parent_instance_id)
+}
+
+// bool create_hierarchy = 4;
+inline void CreateModelInstanceRequest::clear_create_hierarchy() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.create_hierarchy_ = false;
+}
+inline bool CreateModelInstanceRequest::create_hierarchy() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelInstanceRequest.create_hierarchy)
+  return _internal_create_hierarchy();
+}
+inline void CreateModelInstanceRequest::set_create_hierarchy(bool value) {
+  _internal_set_create_hierarchy(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelInstanceRequest.create_hierarchy)
+}
+inline bool CreateModelInstanceRequest::_internal_create_hierarchy() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.create_hierarchy_;
+}
+inline void CreateModelInstanceRequest::_internal_set_create_hierarchy(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.create_hierarchy_ = value;
+}
+
+// bool apply_world_position = 5;
+inline void CreateModelInstanceRequest::clear_apply_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.apply_world_position_ = false;
+}
+inline bool CreateModelInstanceRequest::apply_world_position() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelInstanceRequest.apply_world_position)
+  return _internal_apply_world_position();
+}
+inline void CreateModelInstanceRequest::set_apply_world_position(bool value) {
+  _internal_set_apply_world_position(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelInstanceRequest.apply_world_position)
+}
+inline bool CreateModelInstanceRequest::_internal_apply_world_position() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.apply_world_position_;
+}
+inline void CreateModelInstanceRequest::_internal_set_apply_world_position(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.apply_world_position_ = value;
+}
+
+// .sailor.editor.v1.Vector4 world_position = 6;
+inline bool CreateModelInstanceRequest::has_world_position() const {
+  bool value = (_impl_._has_bits_[0] & 0x00000001u) != 0;
+  PROTOBUF_ASSUME(!value || _impl_.world_position_ != nullptr);
+  return value;
+}
+inline void CreateModelInstanceRequest::clear_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.world_position_ != nullptr) _impl_.world_position_->Clear();
+  _impl_._has_bits_[0] &= ~0x00000001u;
+}
+inline const ::sailor::editor::v1::Vector4& CreateModelInstanceRequest::_internal_world_position() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  const ::sailor::editor::v1::Vector4* p = _impl_.world_position_;
+  return p != nullptr ? *p : reinterpret_cast<const ::sailor::editor::v1::Vector4&>(::sailor::editor::v1::_Vector4_default_instance_);
+}
+inline const ::sailor::editor::v1::Vector4& CreateModelInstanceRequest::world_position() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelInstanceRequest.world_position)
+  return _internal_world_position();
+}
+inline void CreateModelInstanceRequest::unsafe_arena_set_allocated_world_position(::sailor::editor::v1::Vector4* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (GetArena() == nullptr) {
+    delete reinterpret_cast<::google::protobuf::MessageLite*>(_impl_.world_position_);
+  }
+  _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(value);
+  if (value != nullptr) {
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.CreateModelInstanceRequest.world_position)
+}
+inline ::sailor::editor::v1::Vector4* CreateModelInstanceRequest::release_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::sailor::editor::v1::Vector4* released = _impl_.world_position_;
+  _impl_.world_position_ = nullptr;
+  if (::google::protobuf::internal::DebugHardenForceCopyInRelease()) {
+    auto* old = reinterpret_cast<::google::protobuf::MessageLite*>(released);
+    released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    if (GetArena() == nullptr) {
+      delete old;
+    }
+  } else {
+    if (GetArena() != nullptr) {
+      released = ::google::protobuf::internal::DuplicateIfNonNull(released);
+    }
+  }
+  return released;
+}
+inline ::sailor::editor::v1::Vector4* CreateModelInstanceRequest::unsafe_arena_release_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelInstanceRequest.world_position)
+
+  _impl_._has_bits_[0] &= ~0x00000001u;
+  ::sailor::editor::v1::Vector4* temp = _impl_.world_position_;
+  _impl_.world_position_ = nullptr;
+  return temp;
+}
+inline ::sailor::editor::v1::Vector4* CreateModelInstanceRequest::_internal_mutable_world_position() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (_impl_.world_position_ == nullptr) {
+    auto* p = ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::Vector4>(GetArena());
+    _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(p);
+  }
+  return _impl_.world_position_;
+}
+inline ::sailor::editor::v1::Vector4* CreateModelInstanceRequest::mutable_world_position() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  _impl_._has_bits_[0] |= 0x00000001u;
+  ::sailor::editor::v1::Vector4* _msg = _internal_mutable_world_position();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelInstanceRequest.world_position)
+  return _msg;
+}
+inline void CreateModelInstanceRequest::set_allocated_world_position(::sailor::editor::v1::Vector4* value) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (message_arena == nullptr) {
+    delete (_impl_.world_position_);
+  }
+
+  if (value != nullptr) {
+    ::google::protobuf::Arena* submessage_arena = (value)->GetArena();
+    if (message_arena != submessage_arena) {
+      value = ::google::protobuf::internal::GetOwnedMessage(message_arena, value, submessage_arena);
+    }
+    _impl_._has_bits_[0] |= 0x00000001u;
+  } else {
+    _impl_._has_bits_[0] &= ~0x00000001u;
+  }
+
+  _impl_.world_position_ = reinterpret_cast<::sailor::editor::v1::Vector4*>(value);
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelInstanceRequest.world_position)
+}
+
+// string preferred_instance_id = 7;
+inline void CreateModelInstanceRequest::clear_preferred_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.preferred_instance_id_.ClearToEmpty();
+}
+inline const std::string& CreateModelInstanceRequest::preferred_instance_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.CreateModelInstanceRequest.preferred_instance_id)
+  return _internal_preferred_instance_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void CreateModelInstanceRequest::set_preferred_instance_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.preferred_instance_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.CreateModelInstanceRequest.preferred_instance_id)
+}
+inline std::string* CreateModelInstanceRequest::mutable_preferred_instance_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_preferred_instance_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.CreateModelInstanceRequest.preferred_instance_id)
+  return _s;
+}
+inline const std::string& CreateModelInstanceRequest::_internal_preferred_instance_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.preferred_instance_id_.Get();
+}
+inline void CreateModelInstanceRequest::_internal_set_preferred_instance_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.preferred_instance_id_.Set(value, GetArena());
+}
+inline std::string* CreateModelInstanceRequest::_internal_mutable_preferred_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.preferred_instance_id_.Mutable( GetArena());
+}
+inline std::string* CreateModelInstanceRequest::release_preferred_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.CreateModelInstanceRequest.preferred_instance_id)
+  return _impl_.preferred_instance_id_.Release();
+}
+inline void CreateModelInstanceRequest::set_allocated_preferred_instance_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.preferred_instance_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.preferred_instance_id_.IsDefault()) {
+    _impl_.preferred_instance_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.CreateModelInstanceRequest.preferred_instance_id)
 }
 
 // -------------------------------------------------------------------

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -95,7 +95,23 @@ TVector<RHISceneViewProxy> RHISceneView::TraceScene(const Math::Frustum& frustum
 					RHISceneViewProxy viewProxy;
 					viewProxy.m_staticMeshEcs = meshProxy.m_staticMeshEcs;
 					viewProxy.m_worldMatrix = meshProxy.m_worldMatrix;
-					viewProxy.m_meshes = ecsData.GetModel()->GetMeshes();
+					TVector<glm::mat4> modelMatrices;
+					Math::AABB modelBounds;
+					if (!ecsData.GetModel()->CollectRenderData(
+							ecsData.GetMeshIndex(),
+							viewProxy.m_meshes,
+							modelMatrices,
+							modelBounds))
+					{
+						continue;
+					}
+					viewProxy.m_meshModelMatrices.Reserve(
+						modelMatrices.Num());
+					for (const glm::mat4& modelMatrix : modelMatrices)
+					{
+						viewProxy.m_meshModelMatrices.Add(
+							meshProxy.m_worldMatrix * modelMatrix);
+					}
 					viewProxy.m_skeletonOffset = ecsData.GetSkeletonOffset();
 					viewProxy.m_overrideMaterials.Clear();
 					viewProxy.m_renderQueueTags.Clear();
@@ -104,7 +120,7 @@ TVector<RHISceneViewProxy> RHISceneView::TraceScene(const Math::Frustum& frustum
 #endif
 					viewProxy.m_frame = ecsData.GetFrameLastChange();
 					viewProxy.m_bCastShadows = ecsData.ShouldCastShadow();
-					viewProxy.m_worldAabb = ecsData.GetModel()->GetBoundsAABB();
+					viewProxy.m_worldAabb = modelBounds;
 					viewProxy.m_worldAabb.Apply(viewProxy.m_worldMatrix);
 
 					viewProxy.m_overrideMaterials.Resize(viewProxy.m_meshes.Num());

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -49,6 +49,7 @@ namespace Sailor::RHI
 		size_t m_frame{};
 
 		TVector<RHIMeshPtr> m_meshes;
+		TVector<glm::mat4> m_meshModelMatrices;
 		TVector<RHIMaterialPtr> m_overrideMaterials;
 		TVector<size_t> m_renderQueueTags;
 #if defined(__APPLE__)

--- a/Runtime/Raytracing/PathTracer.cpp
+++ b/Runtime/Raytracing/PathTracer.cpp
@@ -1378,7 +1378,9 @@ bool PathTracer::IntersectScene(const Math::Ray& worldRay, TLASHit& outHit, floa
 				return;
 			}
 			const auto& instance = m_tlasInstances[idx];
-			if (!instance.m_model || !instance.m_model->HasBLAS() || !instance.m_worldBounds.IsValid())
+			if (!instance.m_model ||
+				!instance.m_model->HasBLAS(instance.m_meshIndex) ||
+				!instance.m_worldBounds.IsValid())
 			{
 				return;
 			}
@@ -1397,7 +1399,11 @@ bool PathTracer::IntersectScene(const Math::Ray& worldRay, TLASHit& outHit, floa
 
 			Math::Ray localRay(localOrigin, glm::normalize(localDirRaw));
 			Math::RaycastHit localHit{};
-			if (!instance.m_model->GetBLAS()->IntersectBVH(localRay, localHit, 0, FLT_MAX))
+			if (!instance.m_model->GetBLAS(instance.m_meshIndex)->IntersectBVH(
+					localRay,
+					localHit,
+					0,
+					FLT_MAX))
 			{
 				return;
 			}
@@ -1414,7 +1420,8 @@ bool PathTracer::IntersectScene(const Math::Ray& worldRay, TLASHit& outHit, floa
 				return;
 			}
 
-			const auto& localTri = instance.m_model->GetBLASTriangles()[localHit.m_triangleIndex];
+			const auto& localTri = instance.m_model
+				->GetBLASTriangles(instance.m_meshIndex)[localHit.m_triangleIndex];
 			const glm::mat3 normalMatrix = glm::mat3(glm::transpose(instance.m_inverseWorldMatrix));
 			const vec3 localNormal = localHit.m_barycentricCoordinate.x * localTri.m_normals[0] +
 				localHit.m_barycentricCoordinate.y * localTri.m_normals[1] +
@@ -1445,7 +1452,8 @@ bool PathTracer::IntersectScene(const Math::Ray& worldRay, TLASHit& outHit, floa
 const Math::Triangle& PathTracer::GetTriangle(const TLASHit& hit) const
 {
 	const auto& instance = m_tlasInstances[hit.m_instanceIndex];
-	return instance.m_model->GetBLASTriangles()[hit.m_triangleIndex];
+	return instance.m_model
+		->GetBLASTriangles(instance.m_meshIndex)[hit.m_triangleIndex];
 }
 
 void PathTracer::GetShadingBasis(const TLASHit& hit, vec3& outNormal, vec3& outTangent, vec3& outBitangent) const
@@ -1515,7 +1523,8 @@ uint32_t PathTracer::ResolveMaterialIndex(const TLASHit& hit) const
 	}
 
 	const auto& instance = m_tlasInstances[hit.m_instanceIndex];
-	const auto& tri = instance.m_model->GetBLASTriangles()[hit.m_triangleIndex];
+	const auto& tri = instance.m_model
+		->GetBLASTriangles(instance.m_meshIndex)[hit.m_triangleIndex];
 	const int32_t idx = instance.m_materialBaseOffset + (int32_t)tri.m_materialIndex;
 	return (uint32_t)(std::max)(0, (std::min)(idx, (int32_t)m_materials.Num() - 1));
 }

--- a/Runtime/Raytracing/PathTracer.h
+++ b/Runtime/Raytracing/PathTracer.h
@@ -22,6 +22,7 @@ namespace Sailor::Raytracing
 		struct TLASInstance
 		{
 			ModelPtr m_model{};
+			int32_t m_meshIndex = -1;
 			Math::AABB m_worldBounds{};
 			glm::mat4 m_worldMatrix{ 1.0f };
 			glm::mat4 m_inverseWorldMatrix{ 1.0f };

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -389,6 +389,7 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 
 	s_pInstance = new App();
 	s_pInstance->m_args = params;
+	g_bUseLazyAssetInfoLoading = params.m_bIsEditor;
 
 #if defined(_WIN32)
 	Win32::ConsoleWindow::Initialize(false);

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -94,6 +94,17 @@ namespace Sailor
 		SAILOR_API static bool UpdateEditorObject(const char* strInstanceId, const char* strYamlNode);
 		SAILOR_API static bool ReparentEditorObject(const char* strInstanceId, const char* strParentInstanceId, bool bKeepWorldTransform);
 		SAILOR_API static bool CreateEditorGameObject(const char* strParentInstanceId, const char* strPreferredInstanceId, char** outInstanceId);
+		SAILOR_API static bool CreateEditorModelInstance(
+			const char* strModelFileId,
+			const char* strName,
+			const char* strParentInstanceId,
+			bool bCreateHierarchy,
+			bool bHasWorldPosition,
+			float worldX,
+			float worldY,
+			float worldZ,
+			const char* strPreferredInstanceId,
+			char** outInstanceId);
 		SAILOR_API static bool DestroyEditorObject(const char* strInstanceId);
 		SAILOR_API static bool ResetEditorComponentToDefaults(const char* strInstanceId);
 		SAILOR_API static bool AddEditorComponent(const char* strInstanceId, const char* strComponentTypeName, const char* strPreferredInstanceId, char** outInstanceId);

--- a/Runtime/Submodules/Editor.cpp
+++ b/Runtime/Submodules/Editor.cpp
@@ -7,12 +7,14 @@
 #include "ECS/PathTracerECS.h"
 #include "Components/PathTracerProxyComponent.h"
 #include "Components/EditorComponent.h"
+#include "Components/MeshRendererComponent.h"
 #include "Raytracing/PathTracer.h"
 #include "Editor.h"
 #include "Containers/Map.h"
 #include "AssetRegistry/World/WorldPrefabImporter.h"
 #include "AssetRegistry/Prefab/PrefabImporter.h"
 #include "AssetRegistry/FileId.h"
+#include "AssetRegistry/Model/ModelImporter.h"
 #include "Core/Reflection.h"
 #include "Math/Math.h"
 #include "Math/Transform.h"
@@ -204,6 +206,63 @@ namespace
 		}
 
 		gameObject->GetTransformComponent().SetPosition(localPosition);
+		return true;
+	}
+
+	bool IsEditableModelHierarchyValid(const Model& model)
+	{
+		if (!model.SupportsEditableHierarchy() || model.GetNodes().IsEmpty())
+		{
+			return false;
+		}
+
+		const auto& nodes = model.GetNodes();
+		for (uint32_t nodeIndex = 0; nodeIndex < nodes.Num(); ++nodeIndex)
+		{
+			const auto& node = nodes[nodeIndex];
+			const auto& transform = node.m_localTransform;
+			const glm::vec4 rotation(
+				transform.m_rotation.x,
+				transform.m_rotation.y,
+				transform.m_rotation.z,
+				transform.m_rotation.w);
+			if (node.m_parentIndex < -1 ||
+				node.m_parentIndex >= static_cast<int32_t>(nodeIndex) ||
+				node.m_meshIndex < Model::AllMeshes ||
+				(node.m_meshIndex >= 0 &&
+					!model.IsSourceMeshIndexValid(node.m_meshIndex)) ||
+				node.m_skinIndex >= 0 ||
+				!Math::AllFinite(transform.m_position) ||
+				!Math::AllFinite(rotation) ||
+				!Math::AllFinite(transform.m_scale) ||
+				glm::dot(rotation, rotation) <= 0.000001f)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	bool AttachModelRenderer(
+		GameObjectPtr gameObject,
+		const ModelPtr& model,
+		int32_t meshIndex,
+		const TVector<MaterialPtr>& defaultMaterials)
+	{
+		auto meshRenderer = gameObject
+			? gameObject->AddComponent<MeshRendererComponent>()
+			: MeshRendererComponentPtr{};
+		if (!meshRenderer)
+		{
+			return false;
+		}
+
+		meshRenderer->SetMeshIndex(meshIndex);
+		auto& rendererData = meshRenderer->GetData();
+		rendererData.SetModel(model);
+		rendererData.GetMaterials() = defaultMaterials;
+		rendererData.MarkDirty();
 		return true;
 	}
 }
@@ -563,6 +622,175 @@ bool Editor::CreateGameObject(const InstanceId& parentInstanceId, const Instance
 	}
 
 	outInstanceId = gameObject->GetInstanceId();
+	NotifyManagedObjectMutation(outInstanceId);
+	return true;
+}
+
+bool Editor::CreateModelInstance(
+	const ModelPtr& model,
+	const std::string& name,
+	const InstanceId& parentInstanceId,
+	bool bCreateHierarchy,
+	const glm::vec3* worldPosition,
+	const InstanceId& preferredInstanceId,
+	InstanceId& outInstanceId)
+{
+	SAILOR_PROFILE_FUNCTION();
+	outInstanceId = InstanceId::Invalid;
+
+	if (!m_world || !model || !model->IsStructurallyReady() || name.empty())
+	{
+		SAILOR_LOG_ERROR("Cannot create model instance '%s': invalid world, model, or name.", name.c_str());
+		return false;
+	}
+
+	GameObjectPtr parentGameObject;
+	if (!ResolveParent(m_world, parentInstanceId, parentGameObject))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot create model instance '%s': parent '%s' is invalid.",
+			name.c_str(),
+			parentInstanceId.ToString().c_str());
+		return false;
+	}
+
+	// Bulk hierarchy creation must not rebuild the same model material table for
+	// every mesh node. Bistro-scale models can otherwise create hundreds of
+	// thousands of duplicate material-load task joins in one engine update.
+	TVector<MaterialPtr> defaultMaterials;
+	if (model->GetFileId())
+	{
+		if (auto* modelImporter = App::GetSubmodule<ModelImporter>())
+		{
+			modelImporter->LoadDefaultMaterials(
+				model->GetFileId(),
+				defaultMaterials);
+		}
+	}
+
+	auto root = preferredInstanceId
+		? m_world->Instantiate(name, preferredInstanceId)
+		: m_world->Instantiate(name);
+	if (!root)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot create model instance '%s': root '%s' could not be instantiated.",
+			name.c_str(),
+			preferredInstanceId.ToString().c_str());
+		return false;
+	}
+
+	const auto rollback = [this, &root]()
+		{
+			m_world->DestroyImmediate(root);
+		};
+
+	if (parentGameObject)
+	{
+		root->SetParent(parentGameObject);
+		if (root->GetParent() != parentGameObject)
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot create model instance '%s': root could not be parented to '%s'.",
+				name.c_str(),
+				parentInstanceId.ToString().c_str());
+			rollback();
+			return false;
+		}
+	}
+
+	if (worldPosition && !TrySetWorldPosition(root, *worldPosition))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot create model instance '%s': world position could not be resolved.",
+			name.c_str());
+		rollback();
+		return false;
+	}
+
+	const bool bCreateEditableHierarchy =
+		bCreateHierarchy && IsEditableModelHierarchyValid(*model);
+	if (!bCreateEditableHierarchy)
+	{
+		if (!AttachModelRenderer(
+				root,
+				model,
+				Model::AllMeshes,
+				defaultMaterials))
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot create model instance '%s': root MeshRendererComponent could not be created.",
+				name.c_str());
+			rollback();
+			return false;
+		}
+	}
+	else
+	{
+		const auto& modelNodes = model->GetNodes();
+		TVector<GameObjectPtr> createdNodes;
+		createdNodes.Reserve(modelNodes.Num());
+		for (uint32_t nodeIndex = 0; nodeIndex < modelNodes.Num(); ++nodeIndex)
+		{
+			const auto& modelNode = modelNodes[nodeIndex];
+			const std::string nodeName = modelNode.m_name.empty()
+				? "Node_" + std::to_string(modelNode.m_sourceNodeIndex)
+				: modelNode.m_name;
+			auto node = m_world->Instantiate(nodeName);
+			if (!node)
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot create model instance '%s': node %u ('%s') could not be instantiated.",
+					name.c_str(),
+					nodeIndex,
+					nodeName.c_str());
+				rollback();
+				return false;
+			}
+
+			const GameObjectPtr& nodeParent = modelNode.m_parentIndex >= 0
+				? createdNodes[static_cast<uint32_t>(modelNode.m_parentIndex)]
+				: root;
+			node->SetParent(nodeParent);
+			if (node->GetParent() != nodeParent)
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot create model instance '%s': node %u ('%s') could not be parented to source parent %d.",
+					name.c_str(),
+					nodeIndex,
+					nodeName.c_str(),
+					modelNode.m_parentIndex);
+				m_world->DestroyImmediate(node);
+				rollback();
+				return false;
+			}
+
+			auto& transform = node->GetTransformComponent();
+			transform.SetPosition(glm::vec3(modelNode.m_localTransform.m_position));
+			transform.SetRotation(modelNode.m_localTransform.m_rotation);
+			transform.SetScale(modelNode.m_localTransform.m_scale);
+			if (modelNode.m_meshIndex >= 0 &&
+				!AttachModelRenderer(
+					node,
+					model,
+					modelNode.m_meshIndex,
+					defaultMaterials))
+			{
+				SAILOR_LOG_ERROR(
+					"Cannot create model instance '%s': node %u ('%s') MeshRendererComponent for source mesh %d could not be created.",
+					name.c_str(),
+					nodeIndex,
+					nodeName.c_str(),
+					modelNode.m_meshIndex);
+				rollback();
+				return false;
+			}
+
+			createdNodes.Add(std::move(node));
+		}
+	}
+
+	outInstanceId = root->GetInstanceId();
 	NotifyManagedObjectMutation(outInstanceId);
 	return true;
 }

--- a/Runtime/Submodules/Editor.h
+++ b/Runtime/Submodules/Editor.h
@@ -72,7 +72,7 @@ namespace Sailor
 		SAILOR_SHARED_API bool UpdateObject(const class InstanceId& instanceId, const std::string& strYamlNode);
 		SAILOR_API bool ReparentObject(const class InstanceId& instanceId, const class InstanceId& parentInstanceId, bool bKeepWorldTransform);
 		bool CreateGameObject(const class InstanceId& parentInstanceId, const class InstanceId& preferredInstanceId, class InstanceId& outInstanceId);
-		bool CreateModelInstance(
+		SAILOR_SHARED_API bool CreateModelInstance(
 			const TObjectPtr<Model>& model,
 			const std::string& name,
 			const class InstanceId& parentInstanceId,

--- a/Runtime/Submodules/Editor.h
+++ b/Runtime/Submodules/Editor.h
@@ -22,6 +22,7 @@ namespace Sailor
 	class TObjectPtr;
 	class InstanceId;
 	class Prefab;
+	class Model;
 	struct EditorManagedMutationState;
 	namespace EditorViewport
 	{
@@ -71,6 +72,14 @@ namespace Sailor
 		SAILOR_SHARED_API bool UpdateObject(const class InstanceId& instanceId, const std::string& strYamlNode);
 		SAILOR_API bool ReparentObject(const class InstanceId& instanceId, const class InstanceId& parentInstanceId, bool bKeepWorldTransform);
 		bool CreateGameObject(const class InstanceId& parentInstanceId, const class InstanceId& preferredInstanceId, class InstanceId& outInstanceId);
+		bool CreateModelInstance(
+			const TObjectPtr<Model>& model,
+			const std::string& name,
+			const class InstanceId& parentInstanceId,
+			bool bCreateHierarchy,
+			const glm::vec3* worldPosition,
+			const class InstanceId& preferredInstanceId,
+			class InstanceId& outInstanceId);
 		SAILOR_SHARED_API bool DestroyObject(const class InstanceId& instanceId);
 		bool ResetComponentToDefaults(const class InstanceId& instanceId);
 		bool AddComponent(const class InstanceId& instanceId, const std::string& componentTypeName, const class InstanceId& preferredInstanceId, class InstanceId& outInstanceId);

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -19,6 +19,7 @@
 #include <fstream>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -42,6 +43,22 @@ namespace
 		using AssetCache::TryDeserializeAssetCachePayload;
 		using AssetCache::Update;
 		using AssetCache::RestoreAssetImportTime;
+
+		bool Update(
+			const FileId& id,
+			std::time_t assetImportTime,
+			const std::string& sourcePath,
+			const FileRevision& sourceRevision)
+		{
+			return AssetCache::Update(
+				id,
+				assetImportTime,
+				sourcePath,
+				sourceRevision,
+				std::filesystem::path(sourcePath).filename().string() + ".asset",
+				sourceRevision,
+				"Sailor::AssetInfo");
+		}
 	};
 
 	class TempDirectory final
@@ -69,6 +86,24 @@ namespace
 
 	private:
 		std::filesystem::path m_path;
+	};
+
+	class LazyAssetInfoLoadingScope final
+	{
+	public:
+		explicit LazyAssetInfoLoadingScope(bool bEnabled) :
+			m_bPrevious(g_bUseLazyAssetInfoLoading)
+		{
+			g_bUseLazyAssetInfoLoading = bEnabled;
+		}
+
+		~LazyAssetInfoLoadingScope()
+		{
+			g_bUseLazyAssetInfoLoading = m_bPrevious;
+		}
+
+	private:
+		bool m_bPrevious = false;
 	};
 
 	class TestAssetInfo final : public AssetInfo
@@ -422,6 +457,10 @@ namespace
 		entry.m_assetImportTime = assetImportTime;
 		entry.m_sourcePath = sourcePath;
 		entry.m_sourceRevision = MakeRevision();
+		entry.m_metadataFilename =
+			std::filesystem::path(sourcePath).filename().string() + ".asset";
+		entry.m_metadataRevision = MakeRevision();
+		entry.m_assetInfoType = "Sailor::AssetInfo";
 		result.m_data.Insert(fileId, std::move(entry));
 		return result;
 	}
@@ -540,6 +579,143 @@ namespace
 			"the targeted update handler should register for raw assets");
 	}
 
+	void TestLazyScanDefersUnchangedMetadataMaterialization()
+	{
+		LazyAssetInfoLoadingScope lazyLoading(true);
+		TempDirectory directory("lazy-materialization");
+		const Workspace::WorkspaceContext workspaceContext =
+			CreateWorkspaceContext(directory);
+		WriteScanAssetFixture(workspaceContext);
+		{
+			AssetRegistry registry(workspaceContext);
+			TestAssetInfoHandler handler;
+			RegisterRawHandler(registry, handler);
+			Require(registry.ScanContentFolder(),
+				"the empty v1 cache should be built by the existing eager scan");
+		}
+
+		const std::filesystem::path cachePath =
+			workspaceContext.GetCache() / "AssetCache.yaml";
+		std::ifstream cacheFile(cachePath, std::ios::binary);
+		const std::string cacheContents{
+			std::istreambuf_iterator<char>(cacheFile),
+			std::istreambuf_iterator<char>()};
+		Require(cacheContents.find("producerIdentity: asset-cache-v1") != std::string::npos &&
+			cacheContents.find("payloadVersion: 1") != std::string::npos &&
+			cacheContents.find("asset-cache-v2") == std::string::npos,
+			"the rebuilt cache must use only the strict asset-cache-v1 identity");
+
+		uint32_t numMetadataLoads = 0;
+		AssetRegistry registry(workspaceContext);
+		TestAssetInfoHandler handler;
+		handler.m_onLoad = [&]() { ++numMetadataLoads; };
+		RegisterRawHandler(registry, handler);
+		Require(registry.ScanContentFolder(),
+			"the current v1 cache should initialize the lazy registry index");
+		Require(numMetadataLoads == 0,
+			"an unchanged lazy scan must not read asset metadata");
+
+		AssetInfoPtr materialized = registry.GetAssetInfoPtr(
+			(workspaceContext.GetContent() / "Retry.raw").string());
+		Require(materialized != nullptr && numMetadataLoads == 1,
+			"the first concrete lookup should materialize exactly one AssetInfo proxy");
+		Require(registry.GetAssetInfoPtr(materialized->GetFileId()) == materialized &&
+			numMetadataLoads == 1,
+			"subsequent lookups should reuse the materialized AssetInfo");
+	}
+
+	void TestV2EnvelopeIsResetInsteadOfMigrated()
+	{
+		TempDirectory directory("reject-v2");
+		const Workspace::WorkspaceContext workspaceContext =
+			CreateWorkspaceContext(directory);
+		const FileId oldFileId = MakeFileId("{ASSET-CACHE-OLD-V2}");
+		const auto oldPayload = TestAssetCache::SerializeAssetCachePayload(
+			MakeCache(
+				oldFileId.ToString(),
+				(workspaceContext.GetContent() / "Old.mat").string(),
+				10));
+		const Workspace::WorkspaceCacheIdentity oldIdentity =
+			Workspace::MakeWorkspaceCacheIdentity(
+				"asset-cache",
+				"asset-cache-v2",
+				2,
+				workspaceContext);
+		std::string oldEnvelope;
+		std::string diagnostic;
+		Require(Workspace::SerializeWorkspaceCacheEnvelope(
+			oldIdentity,
+			oldPayload,
+			oldEnvelope,
+			diagnostic),
+			"the old-version rejection fixture should serialize: " + diagnostic);
+		WriteFile(
+			workspaceContext.GetCache() / "AssetCache.yaml",
+			oldEnvelope);
+
+		AssetCache cache;
+		cache.Initialize(workspaceContext);
+		Require(
+			cache.GetLastLoadResult().m_status ==
+				Workspace::EWorkspaceCacheLoadStatus::UnsupportedVersion,
+			"an asset-cache-v2 envelope must be rejected instead of migrated");
+		Require(!cache.Contains(oldFileId),
+			"resetting the unsupported envelope must not publish old cache entries");
+
+		std::ifstream cacheFile(
+			workspaceContext.GetCache() / "AssetCache.yaml",
+			std::ios::binary);
+		const std::string rebuiltEnvelope{
+			std::istreambuf_iterator<char>(cacheFile),
+			std::istreambuf_iterator<char>()};
+		Require(rebuiltEnvelope.find("producerIdentity: asset-cache-v1") != std::string::npos &&
+			rebuiltEnvelope.find("payloadVersion: 1") != std::string::npos &&
+			rebuiltEnvelope.find("asset-cache-v2") == std::string::npos,
+			"the unsupported cache must be replaced directly with an empty strict v1 envelope");
+	}
+
+	void TestLazyScanLoadsOnlyNewSecondaryMetadata()
+	{
+		LazyAssetInfoLoadingScope lazyLoading(true);
+		TempDirectory directory("lazy-new-secondary");
+		const Workspace::WorkspaceContext workspaceContext =
+			CreateWorkspaceContext(directory);
+		WriteFile(
+			workspaceContext.GetContent() / "Shared.raw",
+			"source");
+		WriteFile(
+			workspaceContext.GetContent() / "Shared.raw.asset",
+			"fileId: '{LAZY-PRIMARY}'\n"
+			"filename: Shared.raw\n"
+			"testValue: 1\n");
+		{
+			AssetRegistry registry(workspaceContext);
+			TargetedUpdateAssetInfoHandler handler;
+			RegisterTargetedUpdateHandler(registry, handler);
+			Require(registry.ScanContentFolder(),
+				"the initial primary asset should build the strict v1 index");
+		}
+
+		WriteFile(
+			workspaceContext.GetContent() / "Shared.raw2.asset",
+			"fileId: '{LAZY-SECONDARY}'\n"
+			"filename: Shared.raw\n"
+			"testValue: 2\n");
+		AssetRegistry registry(workspaceContext);
+		TargetedUpdateAssetInfoHandler handler;
+		RecordingTargetedUpdateListener listener;
+		handler.Subscribe(&listener);
+		RegisterTargetedUpdateHandler(registry, handler);
+		Require(registry.ScanContentFolder(),
+			"the lazy scan should register new secondary metadata");
+		Require(listener.m_updatedFileIds.size() == 1 &&
+			listener.m_updatedFileIds[0] == MakeFileId("{LAZY-SECONDARY}"),
+			"the lazy scan should read only the newly discovered secondary AssetInfo");
+		Require(registry.GetAssetInfoPtr(
+				MakeFileId("{LAZY-SECONDARY}")) != nullptr,
+			"the new secondary AssetInfo should be immediately resolvable");
+	}
+
 	void TestPayloadRoundTrip()
 	{
 		const FileId fileId = MakeFileId("{ASSET-CACHE-ROUNDTRIP}");
@@ -549,14 +725,15 @@ namespace
 			40);
 		const std::string payload = TestAssetCache::SerializeAssetCachePayload(source);
 		const YAML::Node serializedEntry = YAML::Load(payload)["assetCache"]["assets"][fileId.ToString()];
-		Require(serializedEntry.IsMap() && serializedEntry.size() == 4,
-			"persisted asset cache entries must contain exactly four fields");
+		Require(serializedEntry.IsMap() && serializedEntry.size() == 7,
+			"persisted asset cache v1 entries must contain the watermark and lazy index fields");
 		const YAML::Node serializedRevision = serializedEntry["sourceRevision"];
 		Require(serializedRevision.IsMap() && serializedRevision.size() == 3,
 			"persisted source revisions must contain mtime, size, and content hash");
 		Require(payload.find("metadataLoadTime") == std::string::npos &&
-			payload.find("metadataPath") == std::string::npos,
-			"runtime metadata state must never be serialized into the asset cache");
+			payload.find("metadataPath") == std::string::npos &&
+			serializedEntry["metadataFilename"].as<std::string>() == "Test.mat.asset",
+			"the cache must persist only the colocated metadata filename, never runtime metadata state or a metadata path");
 
 		TestAssetCache::CacheData loaded;
 		std::string diagnostic;
@@ -591,24 +768,24 @@ namespace
 		Require(loaded.m_data.Num() == 0, "empty asset payload should remain empty");
 	}
 
-	void TestLegacyTimestampOnlyPayloadIsRejected()
+	void TestPreV1PayloadIsRejected()
 	{
-		const std::string legacyPayload =
+		const std::string preV1Payload =
 			"assetCache:\n"
 			"  assets:\n"
-			"    '{ASSET-CACHE-V1}':\n"
-			"      fileId: '{ASSET-CACHE-V1}'\n"
+			"    '{ASSET-CACHE-PRE-V1}':\n"
+			"      fileId: '{ASSET-CACHE-PRE-V1}'\n"
 			"      assetImportTime: 7\n"
 			"      sourcePath: '/workspace/Content/Test.mat'\n";
 		TestAssetCache::CacheData destination;
 		std::string diagnostic;
 		Require(!TestAssetCache::TryDeserializeAssetCachePayload(
-			legacyPayload,
+			preV1Payload,
 			destination,
 			diagnostic),
-			"a v1 timestamp-only entry must not be accepted as a v2 exact source revision");
-		Require(diagnostic.find("sourceRevision") != std::string::npos,
-			"the legacy payload diagnostic should name the missing source revision");
+			"a pre-v1 entry must not be accepted by the strict v1 cache schema");
+		Require(!diagnostic.empty(),
+			"the rejected pre-v1 payload should return an actionable diagnostic");
 	}
 
 	void TestCorruptPayloadDoesNotPartiallyPublish()
@@ -629,7 +806,13 @@ namespace
 			"      sourceRevision:\n"
 			"        modificationTimeNanoseconds: 1\n"
 			"        fileSize: 2\n"
-			"        contentHash: 3\n";
+			"        contentHash: 3\n"
+			"      metadataFilename: Test.mat.asset\n"
+			"      metadataRevision:\n"
+			"        modificationTimeNanoseconds: 1\n"
+			"        fileSize: 2\n"
+			"        contentHash: 3\n"
+			"      assetInfoType: Sailor::MaterialAssetInfo\n";
 		std::string diagnostic;
 		Require(
 			!TestAssetCache::TryDeserializeAssetCachePayload(corruptPayload, destination, diagnostic),
@@ -651,7 +834,13 @@ namespace
 			"      sourceRevision:\n"
 			"        modificationTimeNanoseconds: 1\n"
 			"        fileSize: 2\n"
-			"        contentHash: 3\n";
+			"        contentHash: 3\n"
+			"      metadataFilename: Test.mat.asset\n"
+			"      metadataRevision:\n"
+			"        modificationTimeNanoseconds: 1\n"
+			"        fileSize: 2\n"
+			"        contentHash: 3\n"
+			"      assetInfoType: Sailor::MaterialAssetInfo\n";
 
 		TestAssetCache::CacheData destination;
 		std::string diagnostic;
@@ -679,7 +868,13 @@ namespace
 			"      sourceRevision:\n"
 			"        modificationTimeNanoseconds: 1\n"
 			"        fileSize: 2\n"
-			"        contentHash: 3\n";
+			"        contentHash: 3\n"
+			"      metadataFilename: Test.mat.asset\n"
+			"      metadataRevision:\n"
+			"        modificationTimeNanoseconds: 1\n"
+			"        fileSize: 2\n"
+			"        contentHash: 3\n"
+			"      assetInfoType: Sailor::MaterialAssetInfo\n";
 		const YAML::Node node = YAML::Load(corruptPayload)["assetCache"];
 
 		try
@@ -1094,19 +1289,21 @@ namespace
 		Require(info.IsMetaExpired(),
 			"a newer metadata file must remain detectable through runtime AssetInfo state");
 		Require(!cache.Update(&info),
-			"metadata load time changes must not dirty the persisted asset cache");
+			"an unloaded metadata change must not advance the persisted lazy index");
 		info.SetProcessingTimes(
 			importedSourceTime,
 			info.GetMetaLastModificationTime());
 		Require(!info.IsMetaExpired(),
 			"advancing runtime metadata load time should acknowledge the loaded metadata");
+		Require(cache.Update(&info),
+			"the loaded metadata revision should advance the persisted v1 lazy index");
 
 		std::filesystem::remove(metadataPath);
 		Require(info.IsMetaExpired(), "a missing metadata file should expire runtime AssetInfo state");
 		Require(!cache.IsExpired(&info),
 			"missing metadata must not be represented as a persisted cache timestamp or path");
 		Require(!cache.Update(&info),
-			"missing metadata must not dirty or remove persisted source import state");
+			"missing metadata must not advance or remove the last loaded v1 index state");
 		Require(!cache.IsExpired(&info),
 			"runtime metadata validity must remain independent from persisted source import state");
 	}
@@ -1799,7 +1996,13 @@ namespace
 			"      sourceRevision:\n"
 			"        modificationTimeNanoseconds: 1\n"
 			"        fileSize: 2\n"
-			"        contentHash: 3\n";
+			"        contentHash: 3\n"
+			"      metadataFilename: Test.mat.asset\n"
+			"      metadataRevision:\n"
+			"        modificationTimeNanoseconds: 1\n"
+			"        fileSize: 2\n"
+			"        contentHash: 3\n"
+			"      assetInfoType: Sailor::MaterialAssetInfo\n";
 		const std::string invalidPayloads[] =
 		{
 			prefix + "      metadataLoadTime: 2\n",
@@ -1890,7 +2093,10 @@ int main()
 	{
 		TestPayloadRoundTrip();
 		TestEmptyPayloadRoundTrip();
-		TestLegacyTimestampOnlyPayloadIsRejected();
+		TestPreV1PayloadIsRejected();
+		TestV2EnvelopeIsResetInsteadOfMigrated();
+		TestLazyScanDefersUnchangedMetadataMaterialization();
+		TestLazyScanLoadsOnlyNewSecondaryMetadata();
 		TestCorruptPayloadDoesNotPartiallyPublish();
 		TestMismatchedEntryIdentityIsCorrupt();
 		TestDirectDeserializeDoesNotThrowOnCorruptData();

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -195,6 +195,47 @@ namespace
 		}
 	};
 
+	class EditorModelInstanceTestModel final : public Model
+	{
+	public:
+
+		EditorModelInstanceTestModel() : Model(FileId::Invalid) {}
+
+		void SetHierarchy(TVector<Node> nodes, bool bSupportsEditableHierarchy)
+		{
+			m_nodes = std::move(nodes);
+			for (const auto& node : m_nodes)
+			{
+				if (node.m_meshIndex >= 0 &&
+					static_cast<uint32_t>(node.m_meshIndex) >=
+						m_sourceMeshes.Num())
+				{
+					m_sourceMeshes.Resize(
+						static_cast<uint32_t>(node.m_meshIndex) + 1);
+				}
+
+				if (node.m_meshIndex >= 0)
+				{
+					auto& sourceMesh = m_sourceMeshes[
+						static_cast<uint32_t>(node.m_meshIndex)];
+					if (sourceMesh.m_renderMeshIndices.IsEmpty())
+					{
+						sourceMesh.m_renderMeshIndices.Add(0);
+					}
+				}
+			}
+			m_bSupportsEditableHierarchy = bSupportsEditableHierarchy;
+			m_bIsReady.store(true, std::memory_order_release);
+		}
+
+		bool IsReady() const override
+		{
+			return m_bSimulatePendingGpuUpload ? false : Model::IsReady();
+		}
+
+		bool m_bSimulatePendingGpuUpload = false;
+	};
+
 	class PrefabDocumentTestAsset final : public Prefab
 	{
 	public:
@@ -400,6 +441,142 @@ namespace
 
 		const size_t second = system.RegisterComponent();
 		Require(second != reused, "a duplicate free-list entry must not hand out an active slot twice");
+	}
+
+	void TestEditorModelInstanceCreatesHierarchyOrFlatRenderer()
+	{
+		PrefabTestWorld world;
+		Editor editor(nullptr, 0, nullptr);
+		editor.SetWorld(&world);
+
+		auto model = TObjectPtr<EditorModelInstanceTestModel>::Make(
+			world.GetAllocator());
+		TVector<Model::Node> nodes;
+		Model::Node pivot;
+		pivot.m_name = "Pivot";
+		pivot.m_sourceNodeIndex = 3;
+		pivot.m_parentIndex = -1;
+		pivot.m_localTransform.m_position = glm::vec4(1.0f, 2.0f, 3.0f, 1.0f);
+		nodes.Add(pivot);
+
+		Model::Node firstMesh;
+		firstMesh.m_name = "FirstMesh";
+		firstMesh.m_sourceNodeIndex = 4;
+		firstMesh.m_parentIndex = 0;
+		firstMesh.m_meshIndex = 7;
+		firstMesh.m_localTransform.m_position = glm::vec4(4.0f, 5.0f, 6.0f, 1.0f);
+		nodes.Add(firstMesh);
+
+		Model::Node repeatedMesh = firstMesh;
+		repeatedMesh.m_name = "RepeatedMesh";
+		repeatedMesh.m_sourceNodeIndex = 5;
+		repeatedMesh.m_localTransform.m_position = glm::vec4(-4.0f, -5.0f, -6.0f, 1.0f);
+		nodes.Add(repeatedMesh);
+		model->SetHierarchy(std::move(nodes), true);
+		model->m_bSimulatePendingGpuUpload = true;
+
+		const InstanceId hierarchyRootId = InstanceId::GenerateNewInstanceId();
+		InstanceId createdRootId;
+		Require(
+			editor.CreateModelInstance(
+				model,
+				"HierarchyModel",
+				InstanceId::Invalid,
+				true,
+				nullptr,
+				hierarchyRootId,
+				createdRootId) &&
+			createdRootId == hierarchyRootId,
+			"hierarchy model creation must accept pending GPU uploads and preserve the preferred root id");
+
+		auto hierarchyRoot = world
+			.GetObjectByInstanceId(hierarchyRootId)
+			.DynamicCast<GameObject>();
+		Require(
+			hierarchyRoot &&
+			hierarchyRoot->GetName() == "HierarchyModel" &&
+			!hierarchyRoot->GetComponent<MeshRendererComponent>() &&
+			hierarchyRoot->GetChildren().Num() == 1,
+			"editable model creation must use an asset root without a mesh renderer");
+		auto pivotObject = hierarchyRoot->GetChildren()[0];
+		Require(
+			pivotObject->GetName() == "Pivot" &&
+			pivotObject->GetChildren().Num() == 2 &&
+			pivotObject->GetTransformComponent().GetPosition().x == 1.0f,
+			"editable model creation must preserve the node parent and local transform");
+		for (const auto& meshObject : pivotObject->GetChildren())
+		{
+			auto meshRenderer = meshObject->GetComponent<MeshRendererComponent>();
+			Require(
+				meshRenderer &&
+				meshRenderer->GetModel() == model &&
+				meshRenderer->GetMeshIndex() == 7,
+				"repeated source-mesh references must create independent renderers with the same source mesh index");
+		}
+
+		const InstanceId flatRootId = InstanceId::GenerateNewInstanceId();
+		Require(
+			editor.CreateModelInstance(
+				model,
+				"FlatModel",
+				InstanceId::Invalid,
+				false,
+				nullptr,
+				flatRootId,
+				createdRootId) &&
+			createdRootId == flatRootId,
+			"flat model creation must preserve the preferred root id");
+		auto flatRoot = world
+			.GetObjectByInstanceId(flatRootId)
+			.DynamicCast<GameObject>();
+		auto flatRenderer = flatRoot
+			? flatRoot->GetComponent<MeshRendererComponent>()
+			: MeshRendererComponentPtr{};
+		Require(
+			flatRoot &&
+			flatRoot->GetChildren().IsEmpty() &&
+			flatRenderer &&
+			flatRenderer->GetModel() == model &&
+			flatRenderer->GetMeshIndex() == Model::AllMeshes,
+			"flat model creation must attach the complete model at meshIndex -1");
+
+		auto largeModel = TObjectPtr<EditorModelInstanceTestModel>::Make(
+			world.GetAllocator());
+		TVector<Model::Node> largeNodes;
+		constexpr uint32_t c_numLargeNodes = 1696;
+		constexpr uint32_t c_numLargeMeshNodes = 1532;
+		largeNodes.Reserve(c_numLargeNodes);
+		for (uint32_t nodeIndex = 0; nodeIndex < c_numLargeNodes; ++nodeIndex)
+		{
+			Model::Node node;
+			node.m_name = "LargeNode_" + std::to_string(nodeIndex);
+			node.m_sourceNodeIndex = nodeIndex;
+			node.m_parentIndex = -1;
+			node.m_meshIndex = nodeIndex < c_numLargeMeshNodes ? 0 : Model::AllMeshes;
+			largeNodes.Add(std::move(node));
+		}
+		largeModel->SetHierarchy(std::move(largeNodes), true);
+
+		const InstanceId largeRootId = InstanceId::GenerateNewInstanceId();
+		Require(
+			editor.CreateModelInstance(
+				largeModel,
+				"LargeHierarchyModel",
+				InstanceId::Invalid,
+				true,
+				nullptr,
+				largeRootId,
+				createdRootId) &&
+			createdRootId == largeRootId,
+			"Bistro-scale hierarchy creation must preserve the preferred root id");
+		auto largeRoot = world
+			.GetObjectByInstanceId(largeRootId)
+			.DynamicCast<GameObject>();
+		Require(
+			largeRoot && largeRoot->GetChildren().Num() == c_numLargeNodes,
+			"Bistro-scale hierarchy creation must keep every source node");
+
+		world.Clear();
 	}
 
 	void TestPreferredEditorInstanceIdsArePreserved()
@@ -3349,6 +3526,7 @@ int main()
 {
 	const std::pair<const char*, std::function<void()>> tests[] = {
 		{ "ComponentSlotsAreResetAndFreedOnce", TestComponentSlotsAreResetAndFreedOnce },
+		{ "EditorModelInstanceCreatesHierarchyOrFlatRenderer", TestEditorModelInstanceCreatesHierarchyOrFlatRenderer },
 		{ "PreferredEditorInstanceIdsArePreserved", TestPreferredEditorInstanceIdsArePreserved },
 		{ "TransformParentCleanupPreservesPendingReparent", TestTransformParentCleanupPreservesPendingReparent },
 		{ "EditorKeepWorldReparentUsesCurrentTransforms", TestEditorKeepWorldReparentUsesCurrentTransforms },

--- a/Tests/EditorEngineProtocolTests.cpp
+++ b/Tests/EditorEngineProtocolTests.cpp
@@ -1,5 +1,6 @@
 #include "EditorEngineProtocolInternal.h"
 #include "EditorEngineProtocolLifecycle.h"
+#include "Protocol/Generated/editor_engine.pb.h"
 
 #include <chrono>
 #include <cmath>
@@ -62,6 +63,7 @@ namespace
 	constexpr uint32_t c_renderPathTracedImageCommandField = 45;
 	constexpr uint32_t c_isEngineRunningCommandField = 48;
 	constexpr uint32_t c_instantiatePrefabFromYamlCommandField = 42;
+	constexpr uint32_t c_createModelInstanceCommandField = 58;
 
 	void Require(bool condition, const std::string& message)
 	{
@@ -1008,6 +1010,26 @@ namespace
 				response.m_supportsStrictInstanceIds,
 				"a capability-compatible host must dispatch a version-gated strict restore request");
 		}
+	}
+
+	void TestModelInstanceWireContract()
+	{
+		static_assert(
+			sailor::editor::v1::ProtocolRequest::
+				kCreateModelInstanceFieldNumber ==
+			c_createModelInstanceCommandField);
+		static_assert(
+			sailor::editor::v1::CreateModelInstanceRequest::
+				kModelFileIdFieldNumber == 1);
+		static_assert(
+			sailor::editor::v1::CreateModelInstanceRequest::
+				kCreateHierarchyFieldNumber == 4);
+		static_assert(
+			sailor::editor::v1::CreateModelInstanceRequest::
+				kWorldPositionFieldNumber == 6);
+		static_assert(
+			sailor::editor::v1::CreateModelInstanceRequest::
+				kPreferredInstanceIdFieldNumber == 7);
 	}
 
 	void TestEmbeddedNullIsRejected()
@@ -1985,6 +2007,7 @@ int main()
 		TestCommandExceptionIsContainedByTransportBoundary();
 		TestEnvelopeValidation();
 		TestStrictInstanceIdProtocolGate();
+		TestModelInstanceWireContract();
 		TestEmbeddedNullIsRejected();
 		TestUtf8StringIsAccepted();
 		TestGetExitCodeRoundTripAndFree();

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -254,6 +254,94 @@ namespace
 			"a pending material slot must not discard later ready meshes from the depth pass");
 	}
 
+	void TestModelHierarchyRenderPropagationContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string sceneViewSource = ReadText(
+			sourceRoot / "Runtime/RHI/SceneView.cpp");
+		const std::string traceBody = ExtractFunctionBody(
+			sceneViewSource,
+			"TVector<RHISceneViewProxy> RHISceneView::TraceScene(");
+		Require(traceBody.find("CollectRenderData(") != std::string::npos &&
+			traceBody.find("meshProxy.m_worldMatrix * modelMatrix") !=
+				std::string::npos &&
+			traceBody.find("viewProxy.m_meshModelMatrices.Add(") !=
+				std::string::npos,
+			"stationary proxies must expand model hierarchy instances into aligned world matrices");
+
+		const std::string staticMeshSource = ReadText(
+			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
+		const std::string collectBody = ExtractFunctionBody(
+			staticMeshSource,
+			"bool CollectComponentRenderData(");
+		Require(collectBody.find("data.GetMeshIndex()") != std::string::npos &&
+			collectBody.find("ownerWorldMatrix * modelMatrix") !=
+				std::string::npos,
+			"static proxies must resolve the selected source mesh and compose its owner transform");
+		Require(staticMeshSource.find(
+			"proxy.m_meshModelMatrices = std::move(selectedMatrices)") !=
+				std::string::npos,
+			"cached static proxies must retain one world matrix per selected render part");
+
+		const struct
+		{
+			const char* m_path;
+			const char* m_signature;
+			const char* m_label;
+		} frameGraphPasses[] = {
+			{
+				"Runtime/FrameGraph/RenderSceneNode.cpp",
+				"Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(",
+				"raster"
+			},
+			{
+				"Runtime/FrameGraph/DepthPrepassNode.cpp",
+				"Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(",
+				"depth"
+			},
+			{
+				"Runtime/FrameGraph/ShadowPrepassNode.cpp",
+				"void ShadowPrepassNode::Process(",
+				"shadow"
+			}
+		};
+		for (const auto& pass : frameGraphPasses)
+		{
+			const std::string source = ReadText(sourceRoot / pass.m_path);
+			const std::string body = ExtractFunctionBody(
+				source,
+				pass.m_signature);
+			Require(body.find("proxy.m_meshModelMatrices[i]") !=
+					std::string::npos &&
+				body.find("data.model = meshWorldMatrix") !=
+					std::string::npos,
+				std::string(pass.m_label) +
+					" pass must consume the selected render part world matrix");
+		}
+
+		const std::string pathTracerEcsSource = ReadText(
+			sourceRoot / "Runtime/ECS/PathTracerECS.cpp");
+		const std::string pathTracerTick = ExtractFunctionBody(
+			pathTracerEcsSource,
+			"Tasks::ITaskPtr PathTracerECS::Tick(");
+		Require(pathTracerTick.find("pMeshRenderer->GetMeshIndex()") !=
+				std::string::npos &&
+			pathTracerTick.find("pModel->HasBLAS(meshIndex)") !=
+				std::string::npos &&
+			pathTracerTick.find("instance.m_meshIndex = meshIndex") !=
+				std::string::npos,
+			"path-tracer ECS must publish the selected source mesh and its matching BLAS");
+
+		const std::string pathTracerSource = ReadText(
+			sourceRoot / "Runtime/Raytracing/PathTracer.cpp");
+		Require(pathTracerSource.find(
+			"GetBLAS(instance.m_meshIndex)") != std::string::npos &&
+			pathTracerSource.find(
+				"GetBLASTriangles(instance.m_meshIndex)") !=
+				std::string::npos,
+			"path tracing must intersect and shade the same selected source-mesh geometry");
+	}
+
 	void TestGpuCullingShaderSafetyContract()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -1114,6 +1202,7 @@ int main()
 		{ "GpuCullingRangeAndSynchronizationContract", TestGpuCullingRangeAndSynchronizationContract },
 		{ "BatchTextureBindingIdentityContract", TestBatchTextureBindingIdentityContract },
 		{ "SceneViewProxyMaterialAlignmentContract", TestSceneViewProxyMaterialAlignmentContract },
+		{ "ModelHierarchyRenderPropagationContract", TestModelHierarchyRenderPropagationContract },
 		{ "GpuCullingShaderSafetyContract", TestGpuCullingShaderSafetyContract },
 		{ "ForwardPlusTileSynchronizationContract", TestForwardPlusTileSynchronizationContract },
 		{ "VulkanMemoryBarrierRecordsPipelineBarrier", TestVulkanMemoryBarrierRecordsPipelineBarrier },

--- a/Tests/InstanceIdContractTests.cpp
+++ b/Tests/InstanceIdContractTests.cpp
@@ -119,6 +119,8 @@ namespace
 				const InstanceId component(componentPart, parent);
 				Require(!component.IsGameObjectId(), "a component ID must not be classified as a direct game-object ID");
 				Require(component.ComponentId() == componentPart, "component IDs must preserve legacy 16- or 32-character prefixes");
+				Require(component.ComponentId().IsGameObjectId() == componentPart.IsGameObjectId(),
+					"extracted component prefixes must preserve their standalone classification");
 				Require(component.GameObjectId() == parent, "component IDs must resolve their legacy or canonical parent suffix");
 			}
 		}

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -4,6 +4,7 @@
 #include "Core/Utils.h"
 #include "Raytracing/MaterialUtils.h"
 #include "Raytracing/PathTracer.h"
+#include "Components/MeshRendererComponent.h"
 
 #include <cmath>
 #include <filesystem>
@@ -23,11 +24,14 @@ using namespace Sailor;
 
 namespace
 {
+	Model::MeshCpuData MakeTriangleMesh(uint32_t thirdIndex);
+
 	class ControllableMesh final : public RHI::RHIMesh
 	{
 	public:
 		bool IsReady() const override
 		{
+			++m_numIsReadyCalls;
 			return m_bReady;
 		}
 
@@ -36,8 +40,95 @@ namespace
 			m_bReady = bReady;
 		}
 
+		uint32_t GetNumIsReadyCalls() const
+		{
+			return m_numIsReadyCalls;
+		}
+
 	private:
 		bool m_bReady = false;
+		mutable uint32_t m_numIsReadyCalls = 0;
+	};
+
+	class HierarchyModelProbe final : public Model
+	{
+	public:
+		HierarchyModelProbe() : Model(FileId{})
+		{
+		}
+
+		void Configure()
+		{
+			auto firstRenderMesh = RHI::RHIMeshPtr::Make();
+			firstRenderMesh->m_bounds = Math::AABB(
+				glm::vec3(0.5f, 0.5f, 0.0f),
+				glm::vec3(0.5f, 0.5f, 0.0f));
+			firstRenderMesh->m_materialIndex = 3;
+			auto secondRenderMesh = RHI::RHIMeshPtr::Make();
+			secondRenderMesh->m_bounds = Math::AABB(
+				glm::vec3(10.5f, 0.5f, 0.0f),
+				glm::vec3(0.5f, 0.5f, 0.0f));
+			secondRenderMesh->m_materialIndex = 7;
+			m_meshes = {
+				std::move(firstRenderMesh),
+				std::move(secondRenderMesh)
+			};
+
+			m_cpuMeshes = {
+				MakeTriangleMesh(2),
+				MakeTriangleMesh(2)
+			};
+			for (auto& vertex : m_cpuMeshes[1].m_vertices)
+			{
+				vertex.m_position.x += 10.0f;
+			}
+
+			m_sourceMeshes.Resize(2);
+			m_sourceMeshes[0].m_renderMeshIndices = { 0 };
+			m_sourceMeshes[0].m_bounds = Math::AABB(
+				glm::vec3(0.5f, 0.5f, 0.0f),
+				glm::vec3(0.5f, 0.5f, 0.0f));
+			m_sourceMeshes[1].m_renderMeshIndices = { 1 };
+			m_sourceMeshes[1].m_bounds = Math::AABB(
+				glm::vec3(10.5f, 0.5f, 0.0f),
+				glm::vec3(0.5f, 0.5f, 0.0f));
+
+			RenderInstance first{};
+			first.m_renderMeshIndex = 0;
+			first.m_modelMatrix = glm::translate(
+				glm::mat4(1.0f),
+				glm::vec3(2.0f, 0.0f, 0.0f));
+			m_renderInstances.Add(first);
+			RenderInstance repeated = first;
+			repeated.m_modelMatrix = glm::translate(
+				glm::mat4(1.0f),
+				glm::vec3(4.0f, 0.0f, 0.0f));
+			m_renderInstances.Add(repeated);
+			RenderInstance second{};
+			second.m_renderMeshIndex = 1;
+			m_renderInstances.Add(second);
+		}
+
+		void ConfigureSparseSourceMeshes()
+		{
+			auto renderMesh = RHI::RHIMeshPtr::Make();
+			renderMesh->m_bounds = Math::AABB(
+				glm::vec3(0.5f, 0.5f, 0.0f),
+				glm::vec3(0.5f, 0.5f, 0.0f));
+			renderMesh->m_materialIndex = 5;
+			m_meshes = { std::move(renderMesh) };
+
+			m_cpuMeshes = { MakeTriangleMesh(2) };
+			m_sourceMeshes.Resize(3);
+			m_sourceMeshes[2].m_renderMeshIndices = { 0 };
+			m_sourceMeshes[2].m_bounds = Math::AABB(
+				glm::vec3(0.5f, 0.5f, 0.0f),
+				glm::vec3(0.5f, 0.5f, 0.0f));
+
+			RenderInstance instance{};
+			instance.m_renderMeshIndex = 0;
+			m_renderInstances = { std::move(instance) };
+		}
 	};
 
 	class PathTracerBasisProbe final : public Raytracing::PathTracer
@@ -152,6 +243,22 @@ namespace
 		secondMesh->SetReady(true);
 		Require(model.IsReady(),
 			"the model must become ready without another Flush once all uploads finish");
+		const uint32_t firstMeshReadyChecks = firstMesh->GetNumIsReadyCalls();
+		const uint32_t secondMeshReadyChecks = secondMesh->GetNumIsReadyCalls();
+		Require(model.IsReady(),
+			"a completed model must remain ready");
+		Require(
+			firstMesh->GetNumIsReadyCalls() == firstMeshReadyChecks &&
+				secondMesh->GetNumIsReadyCalls() == secondMeshReadyChecks,
+			"a completed model must not rescan every GPU mesh");
+
+		model.Flush();
+		Require(model.IsReady(),
+			"a flushed model with completed uploads must become ready again");
+		Require(
+			firstMesh->GetNumIsReadyCalls() > firstMeshReadyChecks &&
+				secondMesh->GetNumIsReadyCalls() > secondMeshReadyChecks,
+			"Flush must invalidate the cached GPU readiness");
 
 		Model emptyModel(FileId{});
 		emptyModel.Flush();
@@ -482,7 +589,7 @@ uniformsFloat:
 			"legacyMaterialPath",
 			"defaultMaterials[materialIndex]",
 			"std::filesystem::equivalent",
-			"GetAllAssetInfos<TextureAssetInfo>",
+			"GetAssetInfoIdsByTypeAndSource",
 			"TMap<int32_t, FileId> textureIdsByGltfIndex",
 			"ModelImporter::CreateTextureAsset(",
 			"generatedTextureVirtualPath",
@@ -611,6 +718,32 @@ uniformsFloat:
 		Require(mesh.ResolveMaterialIndex(0, 0) ==
 			(std::numeric_limits<size_t>::max)(),
 			"material resolution without materials must remain invalid");
+
+		const std::filesystem::path sourceRoot =
+			std::filesystem::path(__FILE__).parent_path().parent_path();
+		const std::string importer = ReadText(
+			sourceRoot /
+			"Runtime/AssetRegistry/Model/ModelImporter.cpp");
+		const size_t sourceMeshContextOffset = importer.find(
+			"context.materialSlot = bShouldBatchByMaterial ?");
+		Require(sourceMeshContextOffset != std::string::npos,
+			"source mesh contexts must distinguish batched material indices from primitive slots");
+		const size_t sourceMeshContextEnd = importer.find(
+			"context.sourceMeshIndex =",
+			sourceMeshContextOffset);
+		Require(sourceMeshContextEnd != std::string::npos,
+			"source mesh material-slot assignment must remain bounded");
+		const std::string materialSlotAssignment = importer.substr(
+			sourceMeshContextOffset,
+			sourceMeshContextEnd - sourceMeshContextOffset);
+		Require(materialSlotAssignment.find(
+				"static_cast<uint32_t>(materialIndex)") !=
+				std::string::npos,
+			"material-batched source meshes must retain glTF material indices");
+		Require(materialSlotAssignment.find(
+				"static_cast<uint32_t>(outParsedMeshes.Num())") !=
+				std::string::npos,
+			"unbatched source meshes must retain global primitive material slots");
 	}
 
 	void TestDefaultMaterialLoadingPreservesSourceSlots()
@@ -920,6 +1053,128 @@ uniformsFloat:
 			"all extreme-range triangles must be retained");
 	}
 
+	void TestBuildBlasRetainsSourceMeshSubsets()
+	{
+		HierarchyModelProbe model;
+		model.Configure();
+		Require(model.BuildBLAS(),
+			"hierarchical model geometry must build a complete BLAS");
+		Require(model.GetBLASTriangles().Num() == 3,
+			"complete BLAS must retain repeated scene-node instances");
+		Require(model.HasBLAS(0) && model.HasBLAS(1),
+			"each source mesh must have an independently addressable BLAS");
+		Require(!model.HasBLAS(2) && !model.HasBLAS(Model::AllMeshes - 1),
+			"invalid source mesh selections must not resolve a BLAS");
+		Require(model.GetBLASTriangles(0).Num() == 1 &&
+			model.GetBLASTriangles(1).Num() == 1,
+			"source BLAS data must contain geometry once, independent of scene instances");
+		RequireVec3Near(
+			model.GetBLASTriangles(0)[0].m_vertices[0],
+			glm::vec3(0.0f),
+			"source mesh BLAS must remain in node-local space");
+		RequireVec3Near(
+			model.GetBLASTriangles()[0].m_vertices[0],
+			glm::vec3(2.0f, 0.0f, 0.0f),
+			"complete model BLAS must apply the first node transform");
+		RequireVec3Near(
+			model.GetBLASTriangles()[1].m_vertices[0],
+			glm::vec3(4.0f, 0.0f, 0.0f),
+			"complete model BLAS must apply repeated-node transforms independently");
+	}
+
+	void TestCollectRenderDataSelectsSourceMeshByGltfIndex()
+	{
+		HierarchyModelProbe model;
+		model.Configure();
+		TVector<RHI::RHIMeshPtr> meshes;
+		TVector<glm::mat4> matrices;
+		Math::AABB bounds;
+
+		Require(model.CollectRenderData(
+				Model::AllMeshes,
+				meshes,
+				matrices,
+				bounds),
+			"full-model selection must resolve active scene instances");
+		Require(meshes.Num() == 3 && matrices.Num() == 3,
+			"full-model selection must preserve repeated source-mesh nodes");
+		Require(meshes[0] == meshes[1] && meshes[0] != meshes[2],
+			"repeated nodes must reference one uploaded source mesh");
+		Require(meshes[0]->m_materialIndex == 3 &&
+			meshes[2]->m_materialIndex == 7,
+			"source material slots must remain attached to render meshes");
+		RequireVec3Near(glm::vec3(matrices[0][3]),
+			glm::vec3(2.0f, 0.0f, 0.0f),
+			"first full-model instance must retain its node transform");
+		RequireVec3Near(glm::vec3(matrices[1][3]),
+			glm::vec3(4.0f, 0.0f, 0.0f),
+			"repeated full-model instance must retain its own node transform");
+		RequireVec3Near(bounds.m_min,
+			glm::vec3(2.0f, 0.0f, 0.0f),
+			"full-model bounds must include the first transformed instance");
+		RequireVec3Near(bounds.m_max,
+			glm::vec3(11.0f, 1.0f, 0.0f),
+			"full-model bounds must include every transformed instance");
+
+		Require(model.CollectRenderData(0, meshes, matrices, bounds),
+			"source mesh zero must be selectable by glTF mesh index");
+		Require(meshes.Num() == 1 && matrices.Num() == 1 &&
+			meshes[0]->m_materialIndex == 3,
+			"one source selection must return only its render parts");
+		RequireVec3Near(glm::vec3(matrices[0][3]), glm::vec3(0.0f),
+			"source selection must stay local to its owning GameObject");
+		RequireVec3Near(bounds.m_min, glm::vec3(0.0f),
+			"source selection must use local source bounds");
+		RequireVec3Near(model.GetBoundsAABB(0).m_min,
+			glm::vec3(0.0f),
+			"source mesh zero must expose only its own local bounds");
+		RequireVec3Near(model.GetBoundsAABB(1).m_min,
+			glm::vec3(10.0f, 0.0f, 0.0f),
+			"source mesh one must expose independently addressable local bounds");
+		Require(!model.GetBoundsAABB(2).IsValid(),
+			"invalid source mesh selections must not fall back to full-model bounds");
+		Require(!model.CollectRenderData(2, meshes, matrices, bounds) &&
+			meshes.IsEmpty() && matrices.IsEmpty(),
+			"out-of-range glTF mesh indices must fail closed");
+	}
+
+	void TestEmptySourceMeshesDoNotCompactGltfIndices()
+	{
+		HierarchyModelProbe model;
+		model.ConfigureSparseSourceMeshes();
+		Require(!model.IsSourceMeshIndexValid(0) &&
+			!model.IsSourceMeshIndexValid(1) &&
+			model.IsSourceMeshIndexValid(2),
+			"empty source meshes must retain their glTF index slots");
+
+		TVector<RHI::RHIMeshPtr> meshes;
+		TVector<glm::mat4> matrices;
+		Math::AABB bounds;
+		Require(model.CollectRenderData(2, meshes, matrices, bounds) &&
+			meshes.Num() == 1 && matrices.Num() == 1 &&
+			meshes[0]->m_materialIndex == 5,
+			"a later non-empty glTF mesh must remain selectable by its source index");
+		Require(!model.CollectRenderData(1, meshes, matrices, bounds) &&
+			meshes.IsEmpty() && matrices.IsEmpty(),
+			"selecting an empty source mesh must render nothing without aliasing a later mesh");
+
+		Require(model.BuildBLAS() &&
+			!model.HasBLAS(0) &&
+			!model.HasBLAS(1) &&
+			model.HasBLAS(2),
+			"path-tracer source BLAS slots must preserve the same sparse glTF indices");
+	}
+
+	void TestMeshRendererMeshIndexDefaultsWithoutEcsOwner()
+	{
+		MeshRendererComponent component;
+		Require(component.GetMeshIndex() == Model::AllMeshes,
+			"MeshRenderer meshIndex CDO value must select the complete model");
+		component.SetMeshIndex(7);
+		Require(component.GetMeshIndex() == 7,
+			"MeshRenderer must retain meshIndex before ECS initialization");
+	}
+
 	void TestCollectMeshInstancesUsesActiveSceneHierarchy()
 	{
 		tinygltf::Model model;
@@ -996,6 +1251,107 @@ uniformsFloat:
 				glm::vec4(0.0f, 0.0f, 0.0f, 1.0f)),
 			glm::vec3(-8.0f, 0.0f, 0.0f),
 			"node matrix must take precedence over TRS properties");
+	}
+
+	void TestCollectSceneNodesPreservesEditableHierarchy()
+	{
+		tinygltf::Model model;
+		model.meshes.resize(1);
+		model.meshes[0].name = "SharedMesh";
+		model.nodes.resize(3);
+		model.nodes[0].name = "Root";
+		model.nodes[0].translation = { 10.0, 0.0, 0.0 };
+		model.nodes[0].children = { 1 };
+		model.nodes[1].name = "Child";
+		model.nodes[1].mesh = 0;
+		model.nodes[1].translation = { 0.0, 2.0, 0.0 };
+		model.nodes[1].scale = { 2.0, 1.0, 1.0 };
+		model.nodes[2].mesh = 0;
+		model.nodes[2].translation = { -3.0, 0.0, 0.0 };
+		model.nodes[2].scale = { -1.0, 2.0, 0.5 };
+		tinygltf::Scene scene;
+		scene.nodes = { 0, 2 };
+		model.scenes.push_back(std::move(scene));
+		model.defaultScene = 0;
+
+		TVector<GltfImporterUtils::SceneNode> nodes;
+		Require(GltfImporterUtils::CollectSceneNodes(model, 2.0f, nodes),
+			"active glTF scene must expose an editable node hierarchy");
+		Require(nodes.Num() == 3,
+			"all active scene nodes, including empty transform nodes, must be retained");
+		Require(nodes[0].m_sourceNodeIndex == 0 &&
+			nodes[0].m_parentIndex == -1 &&
+			nodes[0].m_meshIndex == -1 &&
+			nodes[0].m_name == "Root",
+			"root node identity and empty-mesh state must be preserved");
+		Require(nodes[1].m_sourceNodeIndex == 1 &&
+			nodes[1].m_parentIndex == 0 &&
+			nodes[1].m_meshIndex == 0 &&
+			nodes[1].m_name == "Child",
+			"child parent and source mesh indices must remain stable");
+		Require(nodes[2].m_parentIndex == -1 &&
+			nodes[2].m_meshIndex == 0,
+			"multiple roots may reference the same source mesh independently");
+		RequireVec3Near(
+			glm::vec3(nodes[0].m_localTransform.m_position),
+			glm::vec3(20.0f, 0.0f, 0.0f),
+			"model unit scale must apply to root local translation");
+		RequireVec3Near(
+			glm::vec3(nodes[1].m_localTransform.m_position),
+			glm::vec3(0.0f, 4.0f, 0.0f),
+			"model unit scale must apply once to child local translation");
+		RequireVec3Near(
+			glm::vec3(nodes[1].m_worldMatrix[3]),
+			glm::vec3(20.0f, 4.0f, 0.0f),
+			"scaled local transforms must compose into the original scene layout");
+		Require(nodes[0].m_bTransformDecomposable &&
+			nodes[1].m_bTransformDecomposable &&
+			nodes[2].m_bTransformDecomposable,
+			"ordinary TRS nodes must be safe to expose as editable GameObjects");
+		Require(
+			nodes[2].m_localTransform.m_scale.x *
+				nodes[2].m_localTransform.m_scale.y *
+				nodes[2].m_localTransform.m_scale.z < 0.0f,
+			"mirrored node transforms must retain one negative scale axis");
+		RequireVec3Near(
+			glm::vec3(nodes[2].m_localTransform.Matrix() *
+				glm::vec4(1.0f)),
+			glm::vec3(nodes[2].m_localMatrix * glm::vec4(1.0f)),
+			"mirrored non-uniform TRS must round-trip through editable hierarchy data");
+
+		tinygltf::Model shearedModel;
+		shearedModel.meshes.resize(1);
+		shearedModel.nodes.resize(1);
+		shearedModel.nodes[0].mesh = 0;
+		shearedModel.nodes[0].matrix = {
+			1.0, 0.0, 0.0, 0.0,
+			0.5, 1.0, 0.0, 0.0,
+			0.0, 0.0, 1.0, 0.0,
+			0.0, 0.0, 0.0, 1.0
+		};
+		tinygltf::Scene shearedScene;
+		shearedScene.nodes = { 0 };
+		shearedModel.scenes.push_back(std::move(shearedScene));
+		shearedModel.defaultScene = 0;
+		Require(GltfImporterUtils::CollectSceneNodes(
+				shearedModel,
+				1.0f,
+				nodes) &&
+			!nodes[0].m_bTransformDecomposable,
+			"sheared matrices must force the full-model fallback instead of losing transform data");
+
+		tinygltf::Model legacyModel;
+		legacyModel.meshes.resize(2);
+		legacyModel.meshes[1].name = "NamedMesh";
+		Require(GltfImporterUtils::CollectSceneNodes(
+				legacyModel,
+				3.0f,
+				nodes) &&
+			nodes.Num() == 2 &&
+			nodes[0].m_name == "Mesh_0" &&
+			nodes[1].m_name == "NamedMesh" &&
+			nodes[0].m_sourceNodeIndex == -1,
+			"mesh-only assets must receive stable synthetic hierarchy nodes");
 	}
 
 	void TestUnitScaleDoesNotShrinkImportedDirections()
@@ -1129,7 +1485,12 @@ int main()
 		{ "BuildBlasRejectsIncompleteAndNonFiniteGeometry", TestBuildBlasRejectsIncompleteAndNonFiniteGeometry },
 		{ "BuildBlasSanitizesExtremeVertexFrames", TestBuildBlasSanitizesExtremeVertexFrames },
 		{ "BuildBlasHandlesExtremeCentroidRange", TestBuildBlasHandlesExtremeCentroidRange },
+		{ "BuildBlasRetainsSourceMeshSubsets", TestBuildBlasRetainsSourceMeshSubsets },
+		{ "CollectRenderDataSelectsSourceMeshByGltfIndex", TestCollectRenderDataSelectsSourceMeshByGltfIndex },
+		{ "EmptySourceMeshesDoNotCompactGltfIndices", TestEmptySourceMeshesDoNotCompactGltfIndices },
+		{ "MeshRendererMeshIndexDefaultsWithoutEcsOwner", TestMeshRendererMeshIndexDefaultsWithoutEcsOwner },
 		{ "CollectMeshInstancesUsesActiveSceneHierarchy", TestCollectMeshInstancesUsesActiveSceneHierarchy },
+		{ "CollectSceneNodesPreservesEditableHierarchy", TestCollectSceneNodesPreservesEditableHierarchy },
 		{ "UnitScaleDoesNotShrinkImportedDirections", TestUnitScaleDoesNotShrinkImportedDirections },
 		{ "CollectMeshInstancesRejectsCyclesAndPreservesLegacyMeshes", TestCollectMeshInstancesRejectsCyclesAndPreservesLegacyMeshes },
 		{ "CollectMeshInstancesHandlesDeepHierarchyIteratively", TestCollectMeshInstancesHandlesDeepHierarchyIteratively }

--- a/Tests/RemoteViewportRuntimeTests.cpp
+++ b/Tests/RemoteViewportRuntimeTests.cpp
@@ -950,6 +950,14 @@ namespace
 		const std::string selectionTickBody = viewportControllerSource.substr(selectionTickBegin, queueSelectionBegin - selectionTickBegin);
 		Require(selectionTickBody.find("DoesSubmittedGizmoOwnPointer(") != std::string::npos,
 			"scene selection must ignore stale ImGuizmo hover or drag state from a frame without a submitted gizmo");
+		const size_t resolveBoundsBegin = viewportControllerSource.find("bool EditorViewport::ResolveGameObjectBounds(");
+		const size_t viewportTickBegin = viewportControllerSource.find("void EditorViewportController::Tick(World& world)", resolveBoundsBegin);
+		Require(resolveBoundsBegin != std::string::npos && viewportTickBegin > resolveBoundsBegin,
+			"viewport object bounds resolution must be bounded");
+		const std::string resolveBoundsBody = viewportControllerSource.substr(resolveBoundsBegin, viewportTickBegin - resolveBoundsBegin);
+		Require(resolveBoundsBody.find("model->GetBoundsAABB(meshRenderer->GetMeshIndex())") != std::string::npos &&
+			resolveBoundsBody.find("model->GetBoundsAABB();") == std::string::npos,
+			"viewport selection and picking must use the selected glTF source mesh bounds instead of full-model bounds");
 		Require(selectionTickBody.find("ResolveGameObjectBounds(gameObject, bounds, bUsesMeshBounds) &&") != std::string::npos &&
 			selectionTickBody.find("bUsesMeshBounds)") != std::string::npos,
 			"viewport picking must exclude empty-object selection fallback bounds");
@@ -962,7 +970,6 @@ namespace
 			selectedGizmoBody.find("DrawAABB(selectionBounds, selectionColor)") != std::string::npos &&
 			selectedGizmoBody.find("DrawSphere(selectionBounds.GetCenter(), 10.0f, selectionColor)") != std::string::npos,
 			"selected empty GameObjects must draw a radius-10 center sphere without changing mesh selection bounds");
-		const size_t viewportTickBegin = viewportControllerSource.find("void EditorViewportController::Tick(World& world)");
 		const size_t viewportResetBegin = viewportControllerSource.find("void EditorViewportController::Reset()", viewportTickBegin);
 		Require(viewportTickBegin != std::string::npos && viewportResetBegin > viewportTickBegin &&
 			viewportControllerSource.substr(viewportTickBegin, viewportResetBegin - viewportTickBegin).find("ResetImGuizmoInteractionState();") != std::string::npos,


### PR DESCRIPTION
## Summary

- preserve glTF scene nodes, transforms, per-source-mesh bounds, render instances, and per-mesh BLAS data during model import
- add a reusable `CreateModelInstance` editor protocol command that can create either the imported hierarchy or one GameObject for the complete model
- propagate mesh indices through MeshRenderer, raster rendering, shadows, depth, GPU culling, and path tracing
- introduce strict AssetCache v1 metadata and lazy AssetInfo materialization in the runtime
- load editor content folders and asset metadata on demand while using `AssetCache.yaml` as the lightweight FileId lookup index
- resolve inspector FileId fields through the cache, then load the real `.asset` metadata before building typed inspector properties

## Why

Large imported models should preserve their source hierarchy and transforms without blocking the editor or collapsing all mesh bounds into one object. Startup should also avoid eagerly parsing every asset sidecar: the runtime and editor can index assets from the cache and materialize metadata only when an asset or folder is actually used.

## Behavior

- model drops can recreate the source hierarchy or instantiate all meshes on one GameObject
- each MeshRenderer can address one source mesh and receives the correct bounds/materials
- InstanceId component ownership remains resolvable across serialized scenes and prefabs
- the editor starts with lightweight asset records; opening a folder replaces those records with real files in the content projection
- selecting an asset loads its sidecar and applies reflected types, so FileId properties are no longer presented as raw strings
- no `Content/**` files are included in this PR

## Validation

- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --no-restore` — 725 passed
- `python3 build_editor.py --config Release` — succeeded, 0 errors
- native Debug CTest suite — 34/34 passed
- Release editor/engine live smoke — editor started successfully and local WebSocket host accepted connections
- `git diff --cached --check` — clean before commit

## Risk

The change touches model import, ECS render registration, asset registry startup, editor protocol generation, and editor content projection. The PR is intentionally left as a draft for architecture and runtime review.