### PR TITLE
[Animation] Add animation controller runtime and Editor graph

### DIFF
--- a/Editor.Tests/EditorDragDropRoutingTests.cs
+++ b/Editor.Tests/EditorDragDropRoutingTests.cs
@@ -40,6 +40,35 @@ public sealed class EditorDragDropRoutingTests
         Assert.Equal(fileId, result);
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void TryResolveAssetFileId_EnforcesAnimatorAssetTypes(bool controllerField)
+    {
+        var expectedFileId = new FileId(controllerField ? "{CONTROLLER}" : "{ANIMSET}");
+        var wrongFileId = new FileId("{MATERIAL}");
+        AssetFile expectedAsset = controllerField
+            ? new AnimationControllerFile { FileId = expectedFileId }
+            : new AnimationSetFile { FileId = expectedFileId };
+        var wrongAsset = new MaterialFile { FileId = wrongFileId };
+        var supportedType = controllerField
+            ? typeof(AnimationControllerFile)
+            : typeof(AnimationSetFile);
+
+        Assert.True(EditorDragDrop.TryResolveAssetFileId(
+            expectedAsset,
+            supportedType,
+            id => id == expectedFileId ? expectedAsset : null,
+            out var resolvedExpected));
+        Assert.Equal(expectedFileId, resolvedExpected);
+
+        Assert.False(EditorDragDrop.TryResolveAssetFileId(
+            wrongAsset,
+            supportedType,
+            id => id == wrongFileId ? wrongAsset : null,
+            out _));
+    }
+
     [Fact]
     public void TryCreateContentDropCommand_RoutesPrefabOverwriteThroughSingleCommand()
     {

--- a/Editor.Tests/EditorDragDropTestStubs.cs
+++ b/Editor.Tests/EditorDragDropTestStubs.cs
@@ -40,6 +40,8 @@ namespace SailorEditor.ViewModels
     public sealed class MaterialFile : AssetFile;
     public sealed class TextureFile : AssetFile;
     public sealed class ModelFile : AssetFile;
+    public sealed class AnimationControllerFile : AssetFile;
+    public sealed class AnimationSetFile : AssetFile;
     public sealed class PrefabFile : AssetFile;
     public sealed class AssetFolder
     {

--- a/Editor.Tests/EditorViewportEventContractTests.cs
+++ b/Editor.Tests/EditorViewportEventContractTests.cs
@@ -519,7 +519,7 @@ public sealed class EditorViewportEventContractTests
 
         AssertInOrder(
             buttonHandler,
-            "TryRecordSystemPointerSample();",
+            "var hasLocalHit = hasActiveHover;",
             "SceneViewportPointerRouting.ShouldAcceptMouseButton(",
             "QueueFocusReleaseIfPointerRemainsOutside();",
             "if (!IsFirstResponder)",
@@ -570,11 +570,8 @@ public sealed class EditorViewportEventContractTests
         Assert.Contains("input.LeftButton.IsPressed", mouseAttachment, StringComparison.Ordinal);
         Assert.Contains("input.RightButton.IsPressed", mouseAttachment, StringComparison.Ordinal);
         Assert.Contains("input.MiddleButton?.IsPressed == true", mouseAttachment, StringComparison.Ordinal);
-        Assert.Contains("new CGEvent((CGEventSource?)null)", source, StringComparison.Ordinal);
-        Assert.Contains("window.ConvertPointFromCoordinateSpace(", source, StringComparison.Ordinal);
-        Assert.Contains("window.HitTest(windowPoint, null)", source, StringComparison.Ordinal);
-        Assert.Contains("ConvertPointFromView(windowPoint, window)", source, StringComparison.Ordinal);
-        Assert.Contains("RecordPointerSample(localPoint);", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("new CGEvent((CGEventSource?)null)", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("TryRecordSystemPointerSample", source, StringComparison.Ordinal);
         Assert.Contains("(deltaX * sensitivity) / scale", source, StringComparison.Ordinal);
         Assert.Contains("(deltaY * sensitivity) / scale", source, StringComparison.Ordinal);
         Assert.DoesNotContain(
@@ -640,6 +637,14 @@ public sealed class EditorViewportEventContractTests
         Assert.DoesNotContain("workspaceResetInProgress", localProjection, StringComparison.Ordinal);
         Assert.Contains(
             "IsWorkspaceResetInProgress => Volatile.Read(ref workspaceResetInProgress) != 0",
+            selectionSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "AssetFile assetFile => assetFile.FileId?.Value",
+            selectionSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "snapshot.Kind is SelectionTargetKind.GameObject or",
             selectionSource,
             StringComparison.Ordinal);
 

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -674,6 +674,15 @@ public sealed class EngineLifecycleTests
             "\"Sailor::AnimationSet\" => typeof(AnimationSetFile)",
             source,
             StringComparison.Ordinal);
+        Assert.Contains(
+            "const string objectPtrPrefix = \"TObjectPtr<\"",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "return engineType[objectPtrPrefix.Length..^1]",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("N6Sailor10TObjectPtr", source, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1033,7 +1042,7 @@ public sealed class EngineLifecycleTests
     }
 
     [Fact]
-    public void AnimationAssetCreation_SuppressesWatcherAndRefreshesOnUiThread()
+    public void AnimationAssetCreation_PublishesPairBeforeBackgroundEngineReload()
     {
         var source = ReadRepositoryFile(
             "Editor",
@@ -1043,7 +1052,7 @@ public sealed class EngineLifecycleTests
             "public async Task<AssetFile?> CreateAnimationAssetAsync(",
             StringComparison.Ordinal);
         var createEnd = source.IndexOf(
-            "static string CreateAnimationControllerSource()",
+            "AssetFile? FindAssetBySourcePath(",
             createStart,
             StringComparison.Ordinal);
         Assert.True(createStart >= 0);
@@ -1053,11 +1062,17 @@ public sealed class EngineLifecycleTests
         var disableWatchers = createBody.IndexOf(
             "watcherState.Watcher.EnableRaisingEvents = false;",
             StringComparison.Ordinal);
-        var moveSource = createBody.IndexOf(
-            "File.Move(temporaryPath, sourcePath);",
+        var writePair = createBody.IndexOf(
+            "_fileOperations.BeginWriteAssetPair(",
             StringComparison.Ordinal);
-        var requestReload = createBody.IndexOf(
-            "_engineService.RequestAssetReloadAsync(cancellationToken)",
+        var publishOnUiThread = createBody.IndexOf(
+            "PublishCreatedAnimationAsset(",
+            StringComparison.Ordinal);
+        var commit = createBody.IndexOf(
+            "transaction.Commit()",
+            StringComparison.Ordinal);
+        var queueReload = createBody.IndexOf(
+            "QueueAnimationAssetReload();",
             StringComparison.Ordinal);
         var restoreWatchers = createBody.IndexOf(
             "watcherState.Watcher.EnableRaisingEvents =",
@@ -1068,16 +1083,22 @@ public sealed class EngineLifecycleTests
             StringComparison.Ordinal);
 
         Assert.True(disableWatchers >= 0);
-        Assert.True(moveSource > disableWatchers);
-        Assert.True(requestReload > moveSource);
-        Assert.True(restoreWatchers > requestReload);
+        Assert.True(writePair > disableWatchers);
+        Assert.True(restoreWatchers > writePair);
         Assert.True(uiRefresh > restoreWatchers);
+        Assert.True(publishOnUiThread > uiRefresh);
+        Assert.True(commit > publishOnUiThread);
+        Assert.True(queueReload > commit);
         Assert.Contains(
-            "var created = FindAssetBySourcePath(sourcePath);",
+            "SerializeAnimationAssetInfo(",
             createBody,
             StringComparison.Ordinal);
         Assert.Contains(
-            "if (created is null)",
+            "transaction.Rollback();",
+            createBody,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "await _engineService.RequestAssetReloadAsync",
             createBody,
             StringComparison.Ordinal);
     }
@@ -1145,6 +1166,10 @@ public sealed class EngineLifecycleTests
         Assert.Contains("public async Task EnsureMetadataLoadedAsync(", assetFileSource, StringComparison.Ordinal);
         Assert.Contains("await Task.Run(Revert, cancellationToken)", assetFileSource, StringComparison.Ordinal);
         Assert.Contains("await selectedAssetFile.EnsureMetadataLoadedAsync(", selectionSource, StringComparison.Ordinal);
+        Assert.Contains("public async Task<AssetFile?> ResolveAssetAsync(", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("await Volatile.Read(ref _assetCacheIndexLoadTask)", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("await EnsureAssetDirectoryLoadedAsync(", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("await service.ResolveAssetAsync(file.FileId)", contentViewSource, StringComparison.Ordinal);
         Assert.Contains("QueueAssetCacheIndexLoad(launchContext, contentGeneration)", assetsSource, StringComparison.Ordinal);
         Assert.Contains("MergeAssetCacheIndex(result.Entries!)", assetsSource, StringComparison.Ordinal);
         Assert.Contains("Files.Add(file)", assetsSource, StringComparison.Ordinal);

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -991,6 +991,98 @@ public sealed class EngineLifecycleTests
     }
 
     [Fact]
+    public void AnimationControllerYaml_IsStrictAndAppliedAtomically()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "ViewModels",
+            "AnimationControllerFile.cs");
+
+        Assert.Contains(
+            "Unknown animation parameter type",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "Unknown animation condition operation",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains("!Enum.IsDefined(type)", source, StringComparison.Ordinal);
+        Assert.Contains("!Enum.IsDefined(operation)", source, StringComparison.Ordinal);
+
+        var loadStart = source.IndexOf(
+            "void LoadControllerRoot(YamlMappingNode root)",
+            StringComparison.Ordinal);
+        var loadEnd = source.IndexOf(
+            "void SaveControllerSource()",
+            loadStart,
+            StringComparison.Ordinal);
+        Assert.True(loadStart >= 0);
+        Assert.True(loadEnd > loadStart);
+        var loadBody = source[loadStart..loadEnd];
+        var parseTransitions = loadBody.IndexOf(
+            "var transitions = ReadList(",
+            StringComparison.Ordinal);
+        var commitDefaultState = loadBody.IndexOf(
+            "DefaultStateId = defaultStateId;",
+            StringComparison.Ordinal);
+        Assert.True(parseTransitions >= 0);
+        Assert.True(commitDefaultState > parseTransitions);
+        Assert.Contains("Parameters = parameters;", loadBody, StringComparison.Ordinal);
+        Assert.Contains("States = states;", loadBody, StringComparison.Ordinal);
+        Assert.Contains("Transitions = transitions;", loadBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AnimationAssetCreation_SuppressesWatcherAndRefreshesOnUiThread()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "AssetsService.cs");
+        var createStart = source.IndexOf(
+            "public async Task<AssetFile?> CreateAnimationAssetAsync(",
+            StringComparison.Ordinal);
+        var createEnd = source.IndexOf(
+            "static string CreateAnimationControllerSource()",
+            createStart,
+            StringComparison.Ordinal);
+        Assert.True(createStart >= 0);
+        Assert.True(createEnd > createStart);
+        var createBody = source[createStart..createEnd];
+
+        var disableWatchers = createBody.IndexOf(
+            "watcherState.Watcher.EnableRaisingEvents = false;",
+            StringComparison.Ordinal);
+        var moveSource = createBody.IndexOf(
+            "File.Move(temporaryPath, sourcePath);",
+            StringComparison.Ordinal);
+        var requestReload = createBody.IndexOf(
+            "_engineService.RequestAssetReloadAsync(cancellationToken)",
+            StringComparison.Ordinal);
+        var restoreWatchers = createBody.IndexOf(
+            "watcherState.Watcher.EnableRaisingEvents =",
+            disableWatchers + 1,
+            StringComparison.Ordinal);
+        var uiRefresh = createBody.IndexOf(
+            "MainThread.InvokeOnMainThreadAsync",
+            StringComparison.Ordinal);
+
+        Assert.True(disableWatchers >= 0);
+        Assert.True(moveSource > disableWatchers);
+        Assert.True(requestReload > moveSource);
+        Assert.True(restoreWatchers > requestReload);
+        Assert.True(uiRefresh > restoreWatchers);
+        Assert.Contains(
+            "var created = FindAssetBySourcePath(sourcePath);",
+            createBody,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "if (created is null)",
+            createBody,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void AssetProjection_TreatsGlslAsShaderLibraryDespiteSharedNativeAssetInfoType()
     {
         var assetsSource = ReadRepositoryFile("Editor", "Services", "AssetsService.cs");

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -658,6 +658,25 @@ public sealed class EngineLifecycleTests
     }
 
     [Fact]
+    public void AnimatorAssetPointers_AreMappedToTypedEditorAssets()
+    {
+        var source = ReadRepositoryFile("Editor", "Utility", "EngineTypes.cs");
+
+        Assert.Contains(
+            "\"Sailor::Animation\" => typeof(AnimationFile)",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "\"Sailor::AnimationController\" => typeof(AnimationControllerFile)",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "\"Sailor::AnimationSet\" => typeof(AnimationSetFile)",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CreateEditorWorld_IsRoutedThroughTheSharedProtocolAbi()
     {
         var managedSource = ReadRepositoryFile("Editor", "Services", "EngineService.cs");

--- a/Editor.Tests/EngineProtocolClientTests.cs
+++ b/Editor.Tests/EngineProtocolClientTests.cs
@@ -167,6 +167,73 @@ public sealed class EngineProtocolClientTests
     }
 
     [Fact]
+    public async Task AnimatorParameters_UseTypedProtocolValues()
+    {
+        var requests = new List<ProtocolRequest>();
+        var client = CreateClient(request =>
+        {
+            requests.Add(request);
+            return Success(
+                request,
+                response => response.BoolResult =
+                    new BoolResult { Value = true });
+        });
+
+        Assert.True(await client.SetAnimatorFloatAsync("component", "Speed", 1.5f));
+        Assert.True(await client.SetAnimatorIntAsync("component", "Mode", 2));
+        Assert.True(await client.SetAnimatorBoolAsync("component", "Grounded", true));
+        Assert.True(await client.SetAnimatorTriggerAsync("component", "Jump", false));
+        Assert.True(await client.SetAnimatorTriggerAsync("component", "Jump", true));
+
+        Assert.All(requests, request => Assert.Equal(
+            ProtocolRequest.CommandOneofCase.SetAnimatorParameter,
+            request.CommandCase));
+        Assert.Equal(
+            [
+                AnimatorParameterRequest.ValueOneofCase.FloatValue,
+                AnimatorParameterRequest.ValueOneofCase.IntValue,
+                AnimatorParameterRequest.ValueOneofCase.BoolValue,
+                AnimatorParameterRequest.ValueOneofCase.Trigger,
+                AnimatorParameterRequest.ValueOneofCase.ResetTrigger
+            ],
+            requests.Select(request => request.SetAnimatorParameter.ValueCase));
+        Assert.Equal(1.5f, requests[0].SetAnimatorParameter.FloatValue);
+        Assert.Equal(2, requests[1].SetAnimatorParameter.IntValue);
+        Assert.True(requests[2].SetAnimatorParameter.BoolValue);
+    }
+
+    [Fact]
+    public async Task GetAnimatorStateAsync_ReadsTransitionState()
+    {
+        var client = CreateClient(request => Success(
+            request,
+            response => response.AnimatorStateResult = new AnimatorStateResult
+            {
+                HasController = true,
+                ControllerRevision = 7,
+                ActiveStateId = 11,
+                ActiveStateName = "Idle",
+                ActiveStateTime = 0.5f,
+                Transitioning = true,
+                DestinationStateId = 12,
+                DestinationStateName = "Run",
+                DestinationStateTime = 0.1f,
+                TransitionAlpha = 0.25f
+            }));
+
+        var state = await client.GetAnimatorStateAsync("component");
+
+        Assert.True(state.HasController);
+        Assert.Equal(7ul, state.ControllerRevision);
+        Assert.Equal(11ul, state.ActiveStateId);
+        Assert.Equal("Idle", state.ActiveStateName);
+        Assert.True(state.IsTransitioning);
+        Assert.Equal(12ul, state.DestinationStateId);
+        Assert.Equal("Run", state.DestinationStateName);
+        Assert.Equal(0.25f, state.TransitionAlpha);
+    }
+
+    [Fact]
     public async Task CreateModelInstanceAsync_SendsAtomicCreationRequest()
     {
         ProtocolRequest? capturedRequest = null;

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -16,6 +16,7 @@ public sealed class WorkflowProjectionTests
         store.Select("go-root", SelectionTargetKind.GameObject);
         store.Select("go-root", SelectionTargetKind.GameObject);
         store.Select("cmp-1", SelectionTargetKind.Component);
+        store.Select("asset-1", SelectionTargetKind.Asset);
         store.Clear();
         store.Clear();
 
@@ -23,6 +24,7 @@ public sealed class WorkflowProjectionTests
             snapshots,
             snapshot => Assert.Equal(new SelectionSnapshot("go-root", SelectionTargetKind.GameObject), snapshot),
             snapshot => Assert.Equal(new SelectionSnapshot("cmp-1", SelectionTargetKind.Component), snapshot),
+            snapshot => Assert.Equal(new SelectionSnapshot("asset-1", SelectionTargetKind.Asset), snapshot),
             snapshot => Assert.Equal(SelectionSnapshot.Empty, snapshot));
     }
 
@@ -204,8 +206,9 @@ public sealed class WorkflowProjectionTests
             StringComparison.Ordinal);
         AssertInOrder(
             contentSelection,
-            "EnsureFolderVisible(file.FolderId);",
-            "contentStore.SelectAsset(file);");
+            "await service.ResolveAssetAsync(file.FileId)",
+            "EnsureFolderVisible(resolved.FolderId);",
+            "contentStore.SelectAsset(resolved);");
         Assert.Contains(
             "SelectObject(assetFile, force: true)",
             openAssetCommand,

--- a/Editor/Commands/AnimationControllerCommands.cs
+++ b/Editor/Commands/AnimationControllerCommands.cs
@@ -1,0 +1,76 @@
+using SailorEditor.ViewModels;
+using SailorEditor.Content;
+
+namespace SailorEditor.Commands;
+
+public sealed class EditAnimationControllerCommand(
+    AnimationControllerFile controller,
+    string before,
+    string after,
+    string description) : IUndoableEditorCommand
+{
+    public string Name => nameof(EditAnimationControllerCommand);
+    public string Description => description;
+
+    public bool CanExecute(ActionContext context) =>
+        controller is not null && !controller.IsReadOnly &&
+        !string.IsNullOrWhiteSpace(before) &&
+        !string.IsNullOrWhiteSpace(after);
+
+    public Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(Apply(after));
+    }
+
+    public ValueTask<CommandResult> UndoAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return ValueTask.FromResult(Apply(before));
+    }
+
+    CommandResult Apply(string document)
+    {
+        try
+        {
+            if (string.Equals(
+                    controller.CaptureDocument(),
+                    document,
+                    StringComparison.Ordinal) ||
+                controller.ApplyDocument(document))
+            {
+                return CommandResult.Success();
+            }
+            return CommandResult.Failure("Animation controller document is invalid.");
+        }
+        catch (Exception exception)
+        {
+            return CommandResult.Failure(exception.Message);
+        }
+    }
+}
+
+public sealed class CreateAnimationAssetCommand(
+    AssetFolder? folder,
+    bool createSet) : IEditorCommand
+{
+    public string Name => nameof(CreateAnimationAssetCommand);
+
+    public bool CanExecute(ActionContext context) =>
+        MauiProgram.GetService<Services.AssetsService>().CanCreateFolder(folder);
+
+    public async Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var asset = await MauiProgram.GetService<Services.AssetsService>()
+            .CreateAnimationAssetAsync(folder, createSet, cancellationToken);
+        return asset is null
+            ? CommandResult.Failure($"Unable to create animation {(createSet ? "set" : "controller")}.")
+            : CommandResult.Success(value: asset.FileId);
+    }
+}

--- a/Editor/Controls/AnimationControllerGraphView.cs
+++ b/Editor/Controls/AnimationControllerGraphView.cs
@@ -1,0 +1,307 @@
+using SailorEditor.ViewModels;
+using SailorEditor.Utility;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace SailorEditor.Controls;
+
+public sealed class AnimationControllerGraphView : GraphicsView, IDrawable
+{
+    const float NodeWidth = 150.0f;
+    const float NodeHeight = 58.0f;
+    const float Padding = 8.0f;
+
+    AnimationControllerFile? controller;
+    AnimationControllerFile? subscribedController;
+    ObservableList<AnimationControllerState>? subscribedStates;
+    ObservableList<AnimationControllerTransition>? subscribedTransitions;
+    AnimationControllerState? draggedState;
+    PointF dragOffset;
+    string? dragBefore;
+
+    public AnimationControllerGraphView()
+    {
+        Drawable = this;
+        BackgroundColor = Color.FromArgb("#171A1F");
+        StartInteraction += OnStartInteraction;
+        DragInteraction += OnDragInteraction;
+        EndInteraction += OnEndInteraction;
+        BindingContextChanged += (_, _) => BindController(BindingContext as AnimationControllerFile);
+    }
+
+    public event Action<AnimationControllerState?>? StateSelected;
+    public event Action<string, string, string>? DocumentEdited;
+
+    public AnimationControllerState? SelectedState { get; private set; }
+    public ulong PreviewActiveStateId { get; set; }
+
+    public void SelectState(AnimationControllerState? state)
+    {
+        SelectedState = state;
+        StateSelected?.Invoke(state);
+        Invalidate();
+    }
+
+    public void Detach()
+    {
+        Unsubscribe();
+        controller = null;
+        BindingContext = null;
+    }
+
+    public void Draw(ICanvas canvas, RectF dirtyRect)
+    {
+        canvas.FillColor = Color.FromArgb("#171A1F");
+        canvas.FillRectangle(dirtyRect);
+        DrawGrid(canvas, dirtyRect);
+        if (controller is null)
+        {
+            return;
+        }
+
+        foreach (var transition in controller.Transitions)
+        {
+            var from = controller.States.FirstOrDefault(state => state.Id == transition.FromStateId);
+            var to = controller.States.FirstOrDefault(state => state.Id == transition.ToStateId);
+            if (from is null || to is null)
+            {
+                continue;
+            }
+            DrawTransition(canvas, from, to);
+        }
+
+        foreach (var state in controller.States)
+        {
+            DrawState(canvas, state);
+        }
+    }
+
+    void BindController(AnimationControllerFile? value)
+    {
+        if (ReferenceEquals(controller, value))
+        {
+            return;
+        }
+        Unsubscribe();
+        controller = value;
+        SelectedState = null;
+        Subscribe(controller);
+        Invalidate();
+    }
+
+    void Subscribe(AnimationControllerFile? value)
+    {
+        if (value is null)
+        {
+            return;
+        }
+        subscribedController = value;
+        subscribedStates = value.States;
+        subscribedTransitions = value.Transitions;
+        subscribedController.DocumentReplaced += OnDocumentReplaced;
+        subscribedStates.CollectionChanged += OnCollectionChanged;
+        subscribedTransitions.CollectionChanged += OnCollectionChanged;
+        foreach (var state in subscribedStates)
+        {
+            state.PropertyChanged += OnItemChanged;
+        }
+        foreach (var transition in subscribedTransitions)
+        {
+            transition.PropertyChanged += OnItemChanged;
+        }
+    }
+
+    void Unsubscribe()
+    {
+        if (subscribedController is null ||
+            subscribedStates is null ||
+            subscribedTransitions is null)
+        {
+            return;
+        }
+        subscribedController.DocumentReplaced -= OnDocumentReplaced;
+        subscribedStates.CollectionChanged -= OnCollectionChanged;
+        subscribedTransitions.CollectionChanged -= OnCollectionChanged;
+        foreach (var state in subscribedStates)
+        {
+            state.PropertyChanged -= OnItemChanged;
+        }
+        foreach (var transition in subscribedTransitions)
+        {
+            transition.PropertyChanged -= OnItemChanged;
+        }
+        subscribedController = null;
+        subscribedStates = null;
+        subscribedTransitions = null;
+    }
+
+    void OnDocumentReplaced()
+    {
+        Unsubscribe();
+        Subscribe(controller);
+        if (SelectedState is not null)
+        {
+            SelectedState = controller?.States.FirstOrDefault(state => state.Id == SelectedState.Id);
+            StateSelected?.Invoke(SelectedState);
+        }
+        Invalidate();
+    }
+
+    void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs args)
+    {
+        if (args.OldItems is not null)
+        {
+            foreach (INotifyPropertyChanged item in args.OldItems)
+            {
+                item.PropertyChanged -= OnItemChanged;
+            }
+        }
+        if (args.NewItems is not null)
+        {
+            foreach (INotifyPropertyChanged item in args.NewItems)
+            {
+                item.PropertyChanged += OnItemChanged;
+            }
+        }
+        Invalidate();
+    }
+
+    void OnItemChanged(object? sender, PropertyChangedEventArgs args) => Invalidate();
+
+    void OnStartInteraction(object? sender, TouchEventArgs args)
+    {
+        if (controller is null || args.Touches.Length == 0)
+        {
+            return;
+        }
+        var point = args.Touches[0];
+        draggedState = controller.States.LastOrDefault(state => StateRect(state).Contains(point));
+        SelectState(draggedState);
+        if (draggedState is null)
+        {
+            return;
+        }
+        dragOffset = new PointF(point.X - draggedState.EditorX, point.Y - draggedState.EditorY);
+        dragBefore = controller.CaptureDocument();
+    }
+
+    void OnDragInteraction(object? sender, TouchEventArgs args)
+    {
+        if (controller is null || draggedState is null || args.Touches.Length == 0)
+        {
+            return;
+        }
+        var point = args.Touches[0];
+        draggedState.EditorX = Math.Max(Padding, point.X - dragOffset.X);
+        draggedState.EditorY = Math.Max(Padding, point.Y - dragOffset.Y);
+        Invalidate();
+    }
+
+    void OnEndInteraction(object? sender, TouchEventArgs args)
+    {
+        if (controller is not null && draggedState is not null && dragBefore is not null)
+        {
+            var after = controller.CaptureDocument();
+            if (!string.Equals(dragBefore, after, StringComparison.Ordinal))
+            {
+                DocumentEdited?.Invoke(dragBefore, after, "Move animation state");
+            }
+        }
+        draggedState = null;
+        dragBefore = null;
+    }
+
+    void DrawGrid(ICanvas canvas, RectF bounds)
+    {
+        canvas.StrokeColor = Color.FromArgb("#252A32");
+        canvas.StrokeSize = 1.0f;
+        const float grid = 24.0f;
+        for (var x = 0.0f; x < bounds.Right; x += grid)
+        {
+            canvas.DrawLine(x, bounds.Top, x, bounds.Bottom);
+        }
+        for (var y = 0.0f; y < bounds.Bottom; y += grid)
+        {
+            canvas.DrawLine(bounds.Left, y, bounds.Right, y);
+        }
+    }
+
+    void DrawTransition(
+        ICanvas canvas,
+        AnimationControllerState from,
+        AnimationControllerState to)
+    {
+        var start = new PointF(from.EditorX + NodeWidth * 0.5f, from.EditorY + NodeHeight * 0.5f);
+        var end = new PointF(to.EditorX + NodeWidth * 0.5f, to.EditorY + NodeHeight * 0.5f);
+        var delta = new PointF(end.X - start.X, end.Y - start.Y);
+        var length = MathF.Sqrt(delta.X * delta.X + delta.Y * delta.Y);
+        if (length < 1.0f)
+        {
+            return;
+        }
+        var direction = new PointF(delta.X / length, delta.Y / length);
+        var normal = new PointF(-direction.Y, direction.X);
+        start = new PointF(start.X + direction.X * NodeWidth * 0.45f, start.Y + direction.Y * NodeHeight * 0.45f);
+        end = new PointF(end.X - direction.X * NodeWidth * 0.45f, end.Y - direction.Y * NodeHeight * 0.45f);
+
+        canvas.StrokeColor = Color.FromArgb("#8C98A8");
+        canvas.StrokeSize = 2.0f;
+        canvas.DrawLine(start, end);
+        const float arrow = 8.0f;
+        canvas.DrawLine(
+            end,
+            new PointF(
+                end.X - direction.X * arrow + normal.X * arrow * 0.55f,
+                end.Y - direction.Y * arrow + normal.Y * arrow * 0.55f));
+        canvas.DrawLine(
+            end,
+            new PointF(
+                end.X - direction.X * arrow - normal.X * arrow * 0.55f,
+                end.Y - direction.Y * arrow - normal.Y * arrow * 0.55f));
+    }
+
+    void DrawState(ICanvas canvas, AnimationControllerState state)
+    {
+        var rect = StateRect(state);
+        var isDefault = controller?.DefaultStateId == state.Id;
+        var isSelected = ReferenceEquals(SelectedState, state);
+        var isActive = PreviewActiveStateId == state.Id;
+        canvas.FillColor = isActive
+            ? Color.FromArgb("#365E46")
+            : isSelected
+                ? Color.FromArgb("#344A67")
+                : Color.FromArgb("#252B34");
+        canvas.FillRoundedRectangle(rect, 6.0f);
+        canvas.StrokeColor = isDefault
+            ? Color.FromArgb("#E0B45A")
+            : isSelected
+                ? Color.FromArgb("#74A5E8")
+                : Color.FromArgb("#56606E");
+        canvas.StrokeSize = isDefault || isSelected ? 2.0f : 1.0f;
+        canvas.DrawRoundedRectangle(rect, 6.0f);
+
+        canvas.FontColor = Colors.White;
+        canvas.FontSize = 13.0f;
+        canvas.DrawString(
+            state.Name ?? string.Empty,
+            rect.X + 8.0f,
+            rect.Y + 6.0f,
+            rect.Width - 16.0f,
+            20.0f,
+            HorizontalAlignment.Left,
+            VerticalAlignment.Center);
+        canvas.FontColor = Color.FromArgb("#AAB2BE");
+        canvas.FontSize = 11.0f;
+        canvas.DrawString(
+            state.Clip ?? string.Empty,
+            rect.X + 8.0f,
+            rect.Y + 30.0f,
+            rect.Width - 16.0f,
+            18.0f,
+            HorizontalAlignment.Left,
+            VerticalAlignment.Center);
+    }
+
+    static RectF StateRect(AnimationControllerState state) =>
+        new(state.EditorX, state.EditorY, NodeWidth, NodeHeight);
+}

--- a/Editor/Controls/FileIdSelectBehavior.cs
+++ b/Editor/Controls/FileIdSelectBehavior.cs
@@ -63,18 +63,29 @@ public class FileIdSelectBehavior : Behavior<Label>
         _associatedLabel = null;
     }
 
-    private void OnLabelTapped(object sender, EventArgs e)
+    private async void OnLabelTapped(object sender, EventArgs e)
     {
-        if (BoundProperty != null)
+        var fileId = BoundProperty as FileId ??
+            (BoundProperty as Observable<FileId>)?.Value;
+        if (fileId is null || fileId.IsEmpty())
         {
-            if (BoundProperty is FileId fileId)
+            return;
+        }
+
+        try
+        {
+            var asset = await MauiProgram.GetService<AssetsService>()
+                .ResolveAssetAsync(fileId);
+            if (asset is not null)
             {
-                var assets = MauiProgram.GetService<AssetsService>().Assets;
-                if (assets.TryGetValue(fileId, out var asset))
-                {
-                    MauiProgram.GetService<SelectionService>().SelectObject(asset);
-                }
+                await MauiProgram.GetService<SelectionService>()
+                    .SelectObjectAsync(asset);
             }
+        }
+        catch (Exception exception)
+        {
+            Console.WriteLine(
+                $"[FileIdSelectBehavior] Failed to select asset '{fileId}': {exception.Message}");
         }
     }
 

--- a/Editor/Platforms/MacCatalyst/NativeSceneViewportHandler.MacCatalyst.cs
+++ b/Editor/Platforms/MacCatalyst/NativeSceneViewportHandler.MacCatalyst.cs
@@ -936,12 +936,6 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
             }
 
             var hasLocalHit = hasActiveHover;
-            if (pressed &&
-                activeMouseModifiers == NativeSceneViewportInputModifier.None &&
-                (!hasLocalHit || !hasPointerSample))
-            {
-                hasLocalHit = TryRecordSystemPointerSample();
-            }
             if (!SceneViewportPointerRouting.ShouldAcceptMouseButton(
                 pressed,
                 hasLocalHit,
@@ -991,36 +985,6 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
                     ResetPointerSample();
                 }
             }
-        }
-
-        bool TryRecordSystemPointerSample()
-        {
-            var window = Window;
-            if (window == null)
-            {
-                return false;
-            }
-
-            using var currentEvent = new CGEvent((CGEventSource?)null);
-            var screen = window.Screen ?? UIScreen.MainScreen;
-            var windowPoint = window.ConvertPointFromCoordinateSpace(
-                currentEvent.Location,
-                screen.CoordinateSpace);
-            var hitView = window.HitTest(windowPoint, null);
-            if (!ReferenceEquals(hitView, this) &&
-                !(hitView?.IsDescendantOfView(this) ?? false))
-            {
-                return false;
-            }
-
-            var localPoint = ConvertPointFromView(windowPoint, window);
-            if (!Bounds.Contains(localPoint))
-            {
-                return false;
-            }
-
-            RecordPointerSample(localPoint);
-            return true;
         }
 
         void QueueFocusReleaseIfPointerRemainsOutside()

--- a/Editor/Protocol/EngineProtocolClient.cs
+++ b/Editor/Protocol/EngineProtocolClient.cs
@@ -36,6 +36,18 @@ internal readonly record struct EngineProtocolViewportToolState(
     ViewportTransformOperation Operation,
     ViewportTransformSpace Space);
 
+internal readonly record struct EngineProtocolAnimatorState(
+    bool HasController,
+    ulong ControllerRevision,
+    ulong ActiveStateId,
+    string ActiveStateName,
+    float ActiveStateTime,
+    bool IsTransitioning,
+    ulong DestinationStateId,
+    string DestinationStateName,
+    float DestinationStateTime,
+    float TransitionAlpha);
+
 internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
 {
     internal const uint ProtocolVersion = 1;
@@ -176,6 +188,115 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                     cancellationToken)
                 .ConfigureAwait(false),
             nameof(ProtocolRequest.UpdateAsset));
+
+    public Task<bool> SetAnimatorFloatAsync(
+        string instanceId,
+        string name,
+        float value,
+        CancellationToken cancellationToken = default)
+    {
+        if (!float.IsFinite(value))
+        {
+            throw new ArgumentOutOfRangeException(nameof(value));
+        }
+        return SetAnimatorParameterAsync(
+            new AnimatorParameterRequest
+            {
+                InstanceId = ValidateString(instanceId, nameof(instanceId)),
+                Name = ValidateString(name, nameof(name)),
+                FloatValue = value
+            },
+            cancellationToken);
+    }
+
+    public Task<bool> SetAnimatorIntAsync(
+        string instanceId,
+        string name,
+        int value,
+        CancellationToken cancellationToken = default) =>
+        SetAnimatorParameterAsync(
+            new AnimatorParameterRequest
+            {
+                InstanceId = ValidateString(instanceId, nameof(instanceId)),
+                Name = ValidateString(name, nameof(name)),
+                IntValue = value
+            },
+            cancellationToken);
+
+    public Task<bool> SetAnimatorBoolAsync(
+        string instanceId,
+        string name,
+        bool value,
+        CancellationToken cancellationToken = default) =>
+        SetAnimatorParameterAsync(
+            new AnimatorParameterRequest
+            {
+                InstanceId = ValidateString(instanceId, nameof(instanceId)),
+                Name = ValidateString(name, nameof(name)),
+                BoolValue = value
+            },
+            cancellationToken);
+
+    public Task<bool> SetAnimatorTriggerAsync(
+        string instanceId,
+        string name,
+        bool reset,
+        CancellationToken cancellationToken = default)
+    {
+        var request = new AnimatorParameterRequest
+        {
+            InstanceId = ValidateString(instanceId, nameof(instanceId)),
+            Name = ValidateString(name, nameof(name))
+        };
+        if (reset)
+        {
+            request.ResetTrigger = new Empty();
+        }
+        else
+        {
+            request.Trigger = new Empty();
+        }
+        return SetAnimatorParameterAsync(request, cancellationToken);
+    }
+
+    async Task<bool> SetAnimatorParameterAsync(
+        AnimatorParameterRequest request,
+        CancellationToken cancellationToken) =>
+        ReadBool(
+            await SendAsync(
+                    new ProtocolRequest { SetAnimatorParameter = request },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.SetAnimatorParameter));
+
+    public async Task<EngineProtocolAnimatorState> GetAnimatorStateAsync(
+        string instanceId,
+        CancellationToken cancellationToken = default)
+    {
+        var result = RequireResult<AnimatorStateResult>(
+            (await SendAsync(
+                    new ProtocolRequest
+                    {
+                        GetAnimatorState = new InstanceIdRequest
+                        {
+                            InstanceId = ValidateString(instanceId, nameof(instanceId))
+                        }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false)).AnimatorStateResult,
+            nameof(ProtocolRequest.GetAnimatorState));
+        return new EngineProtocolAnimatorState(
+            result.HasController,
+            result.ControllerRevision,
+            result.ActiveStateId,
+            result.ActiveStateName,
+            result.ActiveStateTime,
+            result.Transitioning,
+            result.DestinationStateId,
+            result.DestinationStateName,
+            result.DestinationStateTime,
+            result.TransitionAlpha);
+    }
 
     public async Task<EngineProtocolAssetReloadState> GetAssetReloadStateAsync(
         CancellationToken cancellationToken = default)

--- a/Editor/Protocol/Generated/EditorEngine.cs
+++ b/Editor/Protocol/Generated/EditorEngine.cs
@@ -25,7 +25,7 @@ namespace SailorEditor.Protocol.Generated {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "ChNlZGl0b3JfZW5naW5lLnByb3RvEhBzYWlsb3IuZWRpdG9yLnYxIgcKBUVt",
-            "cHR5IssaCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
+            "cHR5ItwbCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
             "IAEoDRISCgpyZXF1ZXN0X2lkGAIgASgEEjkKCmluaXRpYWxpemUYCiABKAsy",
             "Iy5zYWlsb3IuZWRpdG9yLnYxLkluaXRpYWxpemVSZXF1ZXN0SAASKAoFc3Rh",
             "cnQYCyABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASJwoEc3RvcBgM",
@@ -98,63 +98,73 @@ namespace SailorEditor.Protocol.Generated {
             "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydElkUmVxdWVzdEgAEjcKDHVwZGF0",
             "ZV9hc3NldBg5IAEoCzIfLnNhaWxvci5lZGl0b3IudjEuRmlsZUlkUmVxdWVz",
             "dEgAEk0KFWNyZWF0ZV9tb2RlbF9pbnN0YW5jZRg6IAEoCzIsLnNhaWxvci5l",
-            "ZGl0b3IudjEuQ3JlYXRlTW9kZWxJbnN0YW5jZVJlcXVlc3RIAEIJCgdjb21t",
-            "YW5kSgQIAxAKSgQIMhAzSgQIOxBkUhhjcmVhdGVfbW9kZWxfZ2FtZV9vYmpl",
-            "Y3RSHnJlc29sdmVfdmlld3BvcnRfZHJvcF9wb3NpdGlvbiKWBwoQUHJvdG9j",
-            "b2xSZXNwb25zZRIYChBwcm90b2NvbF92ZXJzaW9uGAEgASgNEhIKCnJlcXVl",
-            "c3RfaWQYAiABKAQSDwoHc3VjY2VzcxgDIAEoCBINCgVlcnJvchgEIAEoCRIk",
-            "ChxzdXBwb3J0c19zdHJpY3RfaW5zdGFuY2VfaWRzGAUgASgIEi8KDGVtcHR5",
-            "X3Jlc3VsdBgKIAEoCzIXLnNhaWxvci5lZGl0b3IudjEuRW1wdHlIABIzCgti",
-            "b29sX3Jlc3VsdBgLIAEoCzIcLnNhaWxvci5lZGl0b3IudjEuQm9vbFJlc3Vs",
-            "dEgAEjUKDGludDMyX3Jlc3VsdBgMIAEoCzIdLnNhaWxvci5lZGl0b3IudjEu",
-            "SW50MzJSZXN1bHRIABI3Cg11aW50MzJfcmVzdWx0GA0gASgLMh4uc2FpbG9y",
-            "LmVkaXRvci52MS5VSW50MzJSZXN1bHRIABI3Cg11aW50NjRfcmVzdWx0GA4g",
-            "ASgLMh4uc2FpbG9yLmVkaXRvci52MS5VSW50NjRSZXN1bHRIABI3Cg1zdHJp",
-            "bmdfcmVzdWx0GA8gASgLMh4uc2FpbG9yLmVkaXRvci52MS5TdHJpbmdSZXN1",
-            "bHRIABJAChJzdHJpbmdfbGlzdF9yZXN1bHQYECABKAsyIi5zYWlsb3IuZWRp",
-            "dG9yLnYxLlN0cmluZ0xpc3RSZXN1bHRIABJNChlhc3NldF9yZWxvYWRfc3Rh",
-            "dGVfcmVzdWx0GBEgASgLMiguc2FpbG9yLmVkaXRvci52MS5Bc3NldFJlbG9h",
-            "ZFN0YXRlUmVzdWx0SAASQAoSaW5zdGFuY2VfaWRfcmVzdWx0GBIgASgLMiIu",
-            "c2FpbG9yLmVkaXRvci52MS5JbnN0YW5jZUlkUmVzdWx0SAASUQobdmlld3Bv",
-            "cnRfZXZlbnRfYmF0Y2hfcmVzdWx0GBMgASgLMiouc2FpbG9yLmVkaXRvci52",
-            "MS5WaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHRIABI5Cg52ZWN0b3I0X3Jlc3Vs",
-            "dBgUIAEoCzIfLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNFJlc3VsdEgAEk8K",
-            "GnZpZXdwb3J0X3Rvb2xfc3RhdGVfcmVzdWx0GBUgASgLMikuc2FpbG9yLmVk",
-            "aXRvci52MS5WaWV3cG9ydFRvb2xTdGF0ZVJlc3VsdEgAQggKBnJlc3VsdEoE",
-            "CAYQCkoECBYQZCImChFJbml0aWFsaXplUmVxdWVzdBIRCglhcmd1bWVudHMY",
-            "ASADKAkiIQoMQ291bnRSZXF1ZXN0EhEKCW1heF9jb3VudBgBIAEoDSIgCg1G",
-            "aWxlSWRSZXF1ZXN0Eg8KB2ZpbGVfaWQYASABKAki5wEKGkNyZWF0ZU1vZGVs",
-            "SW5zdGFuY2VSZXF1ZXN0EhUKDW1vZGVsX2ZpbGVfaWQYASABKAkSDAoEbmFt",
-            "ZRgCIAEoCRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAyABKAkSGAoQY3JlYXRl",
-            "X2hpZXJhcmNoeRgEIAEoCBIcChRhcHBseV93b3JsZF9wb3NpdGlvbhgFIAEo",
-            "CBIxCg53b3JsZF9wb3NpdGlvbhgGIAEoCzIZLnNhaWxvci5lZGl0b3IudjEu",
-            "VmVjdG9yNBIdChVwcmVmZXJyZWRfaW5zdGFuY2VfaWQYByABKAkiKAoRSW5z",
-            "dGFuY2VJZFJlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkiKAoRVmlld3Bv",
-            "cnRJZFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQiYAoTVmlld3BvcnRS",
-            "ZWN0UmVxdWVzdBIUCgx3aW5kb3dfcG9zX3gYASABKA0SFAoMd2luZG93X3Bv",
-            "c195GAIgASgNEg0KBXdpZHRoGAMgASgNEg4KBmhlaWdodBgEIAEoDSIsCgtT",
-            "aXplUmVxdWVzdBINCgV3aWR0aBgBIAEoDRIOCgZoZWlnaHQYAiABKA0imQEK",
-            "FVJlbW90ZVZpZXdwb3J0UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIU",
-            "Cgx3aW5kb3dfcG9zX3gYAiABKA0SFAoMd2luZG93X3Bvc195GAMgASgNEg0K",
-            "BXdpZHRoGAQgASgNEg4KBmhlaWdodBgFIAEoDRIPCgd2aXNpYmxlGAYgASgI",
-            "Eg8KB2ZvY3VzZWQYByABKAgiZQoZUmVtb3RlVmlld3BvcnRIb3N0UmVxdWVz",
-            "dBITCgt2aWV3cG9ydF9pZBgBIAEoBBIYChBob3N0X2hhbmRsZV9raW5kGAIg",
-            "ASgNEhkKEWhvc3RfaGFuZGxlX3ZhbHVlGAMgASgEIvwBChpSZW1vdGVWaWV3",
-            "cG9ydElucHV0UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIMCgRraW5k",
-            "GAIgASgNEhEKCXBvaW50ZXJfeBgDIAEoAhIRCglwb2ludGVyX3kYBCABKAIS",
-            "FQoNd2hlZWxfZGVsdGFfeBgFIAEoAhIVCg13aGVlbF9kZWx0YV95GAYgASgC",
-            "EhAKCGtleV9jb2RlGAcgASgNEg4KBmJ1dHRvbhgIIAEoDRIRCgltb2RpZmll",
-            "cnMYCSABKA0SDwoHcHJlc3NlZBgKIAEoCBIPCgdmb2N1c2VkGAsgASgIEhAK",
-            "CGNhcHR1cmVkGAwgASgIIkMKHk1hbmFnZWRNdXRhdGlvblJldmlzaW9uUmVx",
-            "dWVzdBIMCgRraW5kGAEgASgNEhMKC2luc3RhbmNlX2lkGAIgASgJIkAKE1Vw",
-            "ZGF0ZU9iamVjdFJlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkSFAoMeWFt",
-            "bF9jaGFuZ2VzGAIgASgJImYKFVJlcGFyZW50T2JqZWN0UmVxdWVzdBITCgtp",
-            "bnN0YW5jZV9pZBgBIAEoCRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAiABKAkS",
-            "HAoUa2VlcF93b3JsZF90cmFuc2Zvcm0YAyABKAgiVAoXQ3JlYXRlR2FtZU9i",
-            "amVjdFJlcXVlc3QSGgoScGFyZW50X2luc3RhbmNlX2lkGAEgASgJEh0KFXBy",
-            "ZWZlcnJlZF9pbnN0YW5jZV9pZBgCIAEoCSJmChNBZGRDb21wb25lbnRSZXF1",
-            "ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEhsKE2NvbXBvbmVudF90eXBlX25h",
-            "bWUYAiABKAkSHQoVcHJlZmVycmVkX2luc3RhbmNlX2lkGAMgASgJIkcKGElu",
+            "ZGl0b3IudjEuQ3JlYXRlTW9kZWxJbnN0YW5jZVJlcXVlc3RIABJMChZzZXRf",
+            "YW5pbWF0b3JfcGFyYW1ldGVyGDsgASgLMiouc2FpbG9yLmVkaXRvci52MS5B",
+            "bmltYXRvclBhcmFtZXRlclJlcXVlc3RIABJBChJnZXRfYW5pbWF0b3Jfc3Rh",
+            "dGUYPCABKAsyIy5zYWlsb3IuZWRpdG9yLnYxLkluc3RhbmNlSWRSZXF1ZXN0",
+            "SABCCQoHY29tbWFuZEoECAMQCkoECDIQM0oECD0QZFIYY3JlYXRlX21vZGVs",
+            "X2dhbWVfb2JqZWN0Uh5yZXNvbHZlX3ZpZXdwb3J0X2Ryb3BfcG9zaXRpb24i",
+            "3gcKEFByb3RvY29sUmVzcG9uc2USGAoQcHJvdG9jb2xfdmVyc2lvbhgBIAEo",
+            "DRISCgpyZXF1ZXN0X2lkGAIgASgEEg8KB3N1Y2Nlc3MYAyABKAgSDQoFZXJy",
+            "b3IYBCABKAkSJAocc3VwcG9ydHNfc3RyaWN0X2luc3RhbmNlX2lkcxgFIAEo",
+            "CBIvCgxlbXB0eV9yZXN1bHQYCiABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVt",
+            "cHR5SAASMwoLYm9vbF9yZXN1bHQYCyABKAsyHC5zYWlsb3IuZWRpdG9yLnYx",
+            "LkJvb2xSZXN1bHRIABI1CgxpbnQzMl9yZXN1bHQYDCABKAsyHS5zYWlsb3Iu",
+            "ZWRpdG9yLnYxLkludDMyUmVzdWx0SAASNwoNdWludDMyX3Jlc3VsdBgNIAEo",
+            "CzIeLnNhaWxvci5lZGl0b3IudjEuVUludDMyUmVzdWx0SAASNwoNdWludDY0",
+            "X3Jlc3VsdBgOIAEoCzIeLnNhaWxvci5lZGl0b3IudjEuVUludDY0UmVzdWx0",
+            "SAASNwoNc3RyaW5nX3Jlc3VsdBgPIAEoCzIeLnNhaWxvci5lZGl0b3IudjEu",
+            "U3RyaW5nUmVzdWx0SAASQAoSc3RyaW5nX2xpc3RfcmVzdWx0GBAgASgLMiIu",
+            "c2FpbG9yLmVkaXRvci52MS5TdHJpbmdMaXN0UmVzdWx0SAASTQoZYXNzZXRf",
+            "cmVsb2FkX3N0YXRlX3Jlc3VsdBgRIAEoCzIoLnNhaWxvci5lZGl0b3IudjEu",
+            "QXNzZXRSZWxvYWRTdGF0ZVJlc3VsdEgAEkAKEmluc3RhbmNlX2lkX3Jlc3Vs",
+            "dBgSIAEoCzIiLnNhaWxvci5lZGl0b3IudjEuSW5zdGFuY2VJZFJlc3VsdEgA",
+            "ElEKG3ZpZXdwb3J0X2V2ZW50X2JhdGNoX3Jlc3VsdBgTIAEoCzIqLnNhaWxv",
+            "ci5lZGl0b3IudjEuVmlld3BvcnRFdmVudEJhdGNoUmVzdWx0SAASOQoOdmVj",
+            "dG9yNF9yZXN1bHQYFCABKAsyHy5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjRS",
+            "ZXN1bHRIABJPChp2aWV3cG9ydF90b29sX3N0YXRlX3Jlc3VsdBgVIAEoCzIp",
+            "LnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUb29sU3RhdGVSZXN1bHRIABJG",
+            "ChVhbmltYXRvcl9zdGF0ZV9yZXN1bHQYFiABKAsyJS5zYWlsb3IuZWRpdG9y",
+            "LnYxLkFuaW1hdG9yU3RhdGVSZXN1bHRIAEIICgZyZXN1bHRKBAgGEApKBAgX",
+            "EGQiJgoRSW5pdGlhbGl6ZVJlcXVlc3QSEQoJYXJndW1lbnRzGAEgAygJIiEK",
+            "DENvdW50UmVxdWVzdBIRCgltYXhfY291bnQYASABKA0iIAoNRmlsZUlkUmVx",
+            "dWVzdBIPCgdmaWxlX2lkGAEgASgJIucBChpDcmVhdGVNb2RlbEluc3RhbmNl",
+            "UmVxdWVzdBIVCg1tb2RlbF9maWxlX2lkGAEgASgJEgwKBG5hbWUYAiABKAkS",
+            "GgoScGFyZW50X2luc3RhbmNlX2lkGAMgASgJEhgKEGNyZWF0ZV9oaWVyYXJj",
+            "aHkYBCABKAgSHAoUYXBwbHlfd29ybGRfcG9zaXRpb24YBSABKAgSMQoOd29y",
+            "bGRfcG9zaXRpb24YBiABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQS",
+            "HQoVcHJlZmVycmVkX2luc3RhbmNlX2lkGAcgASgJIigKEUluc3RhbmNlSWRS",
+            "ZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJIigKEVZpZXdwb3J0SWRSZXF1",
+            "ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEImAKE1ZpZXdwb3J0UmVjdFJlcXVl",
+            "c3QSFAoMd2luZG93X3Bvc194GAEgASgNEhQKDHdpbmRvd19wb3NfeRgCIAEo",
+            "DRINCgV3aWR0aBgDIAEoDRIOCgZoZWlnaHQYBCABKA0iLAoLU2l6ZVJlcXVl",
+            "c3QSDQoFd2lkdGgYASABKA0SDgoGaGVpZ2h0GAIgASgNIpkBChVSZW1vdGVW",
+            "aWV3cG9ydFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQSFAoMd2luZG93",
+            "X3Bvc194GAIgASgNEhQKDHdpbmRvd19wb3NfeRgDIAEoDRINCgV3aWR0aBgE",
+            "IAEoDRIOCgZoZWlnaHQYBSABKA0SDwoHdmlzaWJsZRgGIAEoCBIPCgdmb2N1",
+            "c2VkGAcgASgIImUKGVJlbW90ZVZpZXdwb3J0SG9zdFJlcXVlc3QSEwoLdmll",
+            "d3BvcnRfaWQYASABKAQSGAoQaG9zdF9oYW5kbGVfa2luZBgCIAEoDRIZChFo",
+            "b3N0X2hhbmRsZV92YWx1ZRgDIAEoBCL8AQoaUmVtb3RlVmlld3BvcnRJbnB1",
+            "dFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQSDAoEa2luZBgCIAEoDRIR",
+            "Cglwb2ludGVyX3gYAyABKAISEQoJcG9pbnRlcl95GAQgASgCEhUKDXdoZWVs",
+            "X2RlbHRhX3gYBSABKAISFQoNd2hlZWxfZGVsdGFfeRgGIAEoAhIQCghrZXlf",
+            "Y29kZRgHIAEoDRIOCgZidXR0b24YCCABKA0SEQoJbW9kaWZpZXJzGAkgASgN",
+            "Eg8KB3ByZXNzZWQYCiABKAgSDwoHZm9jdXNlZBgLIAEoCBIQCghjYXB0dXJl",
+            "ZBgMIAEoCCJDCh5NYW5hZ2VkTXV0YXRpb25SZXZpc2lvblJlcXVlc3QSDAoE",
+            "a2luZBgBIAEoDRITCgtpbnN0YW5jZV9pZBgCIAEoCSJAChNVcGRhdGVPYmpl",
+            "Y3RSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEhQKDHlhbWxfY2hhbmdl",
+            "cxgCIAEoCSJmChVSZXBhcmVudE9iamVjdFJlcXVlc3QSEwoLaW5zdGFuY2Vf",
+            "aWQYASABKAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAIgASgJEhwKFGtlZXBf",
+            "d29ybGRfdHJhbnNmb3JtGAMgASgIIlQKF0NyZWF0ZUdhbWVPYmplY3RSZXF1",
+            "ZXN0EhoKEnBhcmVudF9pbnN0YW5jZV9pZBgBIAEoCRIdChVwcmVmZXJyZWRf",
+            "aW5zdGFuY2VfaWQYAiABKAkiZgoTQWRkQ29tcG9uZW50UmVxdWVzdBITCgtp",
+            "bnN0YW5jZV9pZBgBIAEoCRIbChNjb21wb25lbnRfdHlwZV9uYW1lGAIgASgJ",
+            "Eh0KFXByZWZlcnJlZF9pbnN0YW5jZV9pZBgDIAEoCSLmAQoYQW5pbWF0b3JQ",
+            "YXJhbWV0ZXJSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEgwKBG5hbWUY",
+            "AiABKAkSFQoLZmxvYXRfdmFsdWUYAyABKAJIABITCglpbnRfdmFsdWUYBCAB",
+            "KBFIABIUCgpib29sX3ZhbHVlGAUgASgISAASKgoHdHJpZ2dlchgGIAEoCzIX",
+            "LnNhaWxvci5lZGl0b3IudjEuRW1wdHlIABIwCg1yZXNldF90cmlnZ2VyGAcg",
+            "ASgLMhcuc2FpbG9yLmVkaXRvci52MS5FbXB0eUgAQgcKBXZhbHVlIkcKGElu",
             "c3RhbnRpYXRlUHJlZmFiUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJEhoKEnBh",
             "cmVudF9pbnN0YW5jZV9pZBgCIAEoCSJwCiBJbnN0YW50aWF0ZVByZWZhYkZy",
             "b21ZYW1sUmVxdWVzdBITCgtwcmVmYWJfeWFtbBgBIAEoCRIaChJwYXJlbnRf",
@@ -189,48 +199,55 @@ namespace SailorEditor.Protocol.Generated {
             "aXRvci52MS5WZWN0b3I0IpMBChdWaWV3cG9ydFRvb2xTdGF0ZVJlc3VsdBI/",
             "CglvcGVyYXRpb24YASABKA4yLC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0",
             "VHJhbnNmb3JtT3BlcmF0aW9uEjcKBXNwYWNlGAIgASgOMiguc2FpbG9yLmVk",
-            "aXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybVNwYWNlIjUKB1ZlY3RvcjQSCQoB",
-            "eBgBIAEoAhIJCgF5GAIgASgCEgkKAXoYAyABKAISCQoBdxgEIAEoAiI2ChZW",
-            "aWV3cG9ydFNlbGVjdGlvbkV2ZW50EhwKFHNlbGVjdGVkX2luc3RhbmNlX2lk",
-            "GAEgASgJItYDChZWaWV3cG9ydFRyYW5zZm9ybUV2ZW50EhMKC2luc3RhbmNl",
-            "X2lkGAEgASgJEj8KCW9wZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5lZGl0b3Iu",
-            "djEuVmlld3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAyABKA4y",
-            "KC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2USMgoP",
-            "YmVmb3JlX3Bvc2l0aW9uGAQgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0",
-            "b3I0EjIKD2JlZm9yZV9yb3RhdGlvbhgFIAEoCzIZLnNhaWxvci5lZGl0b3Iu",
-            "djEuVmVjdG9yNBIvCgxiZWZvcmVfc2NhbGUYBiABKAsyGS5zYWlsb3IuZWRp",
-            "dG9yLnYxLlZlY3RvcjQSMQoOYWZ0ZXJfcG9zaXRpb24YByABKAsyGS5zYWls",
-            "b3IuZWRpdG9yLnYxLlZlY3RvcjQSMQoOYWZ0ZXJfcm90YXRpb24YCCABKAsy",
-            "GS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQSLgoLYWZ0ZXJfc2NhbGUYCSAB",
-            "KAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQiVQoWVmlld3BvcnRBc3Nl",
-            "dERyb3BFdmVudBIPCgdmaWxlX2lkGAEgASgJEhQKDG5vcm1hbGl6ZWRfeBgC",
-            "IAEoAhIUCgxub3JtYWxpemVkX3kYAyABKAIiLQoZVmlld3BvcnRUb29sU2hv",
-            "cnRjdXRFdmVudBIQCghrZXlfY29kZRgBIAEoDSLZAgoNVmlld3BvcnRFdmVu",
-            "dBIQCghyZXZpc2lvbhgBIAEoBBIhChltYW5hZ2VkX211dGF0aW9uX3Jldmlz",
-            "aW9uGAIgASgEEj0KCXNlbGVjdGlvbhgKIAEoCzIoLnNhaWxvci5lZGl0b3Iu",
-            "djEuVmlld3BvcnRTZWxlY3Rpb25FdmVudEgAEj0KCXRyYW5zZm9ybRgLIAEo",
-            "CzIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1FdmVudEgA",
-            "Ej4KCmFzc2V0X2Ryb3AYDCABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdw",
-            "b3J0QXNzZXREcm9wRXZlbnRIABJECg10b29sX3Nob3J0Y3V0GA0gASgLMisu",
-            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRvb2xTaG9ydGN1dEV2ZW50SABC",
-            "CQoHcGF5bG9hZEoECAMQCiJLChhWaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHQS",
-            "LwoGZXZlbnRzGAEgAygLMh8uc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEV2",
-            "ZW50KvABChpWaWV3cG9ydFRyYW5zZm9ybU9wZXJhdGlvbhIsCihWSUVXUE9S",
-            "VF9UUkFOU0ZPUk1fT1BFUkFUSU9OX1VOU1BFQ0lGSUVEEAASJwojVklFV1BP",
-            "UlRfVFJBTlNGT1JNX09QRVJBVElPTl9TRUxFQ1QQARIqCiZWSUVXUE9SVF9U",
-            "UkFOU0ZPUk1fT1BFUkFUSU9OX1RSQU5TTEFURRACEicKI1ZJRVdQT1JUX1RS",
-            "QU5TRk9STV9PUEVSQVRJT05fUk9UQVRFEAMSJgoiVklFV1BPUlRfVFJBTlNG",
-            "T1JNX09QRVJBVElPTl9TQ0FMRRAEKooBChZWaWV3cG9ydFRyYW5zZm9ybVNw",
-            "YWNlEigKJFZJRVdQT1JUX1RSQU5TRk9STV9TUEFDRV9VTlNQRUNJRklFRBAA",
-            "EiIKHlZJRVdQT1JUX1RSQU5TRk9STV9TUEFDRV9XT1JMRBABEiIKHlZJRVdQ",
-            "T1JUX1RSQU5TRk9STV9TUEFDRV9MT0NBTBACQiKqAh9TYWlsb3JFZGl0b3Iu",
-            "UHJvdG9jb2wuR2VuZXJhdGVkYgZwcm90bzM="));
+            "aXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybVNwYWNlIqgCChNBbmltYXRvclN0",
+            "YXRlUmVzdWx0EhYKDmhhc19jb250cm9sbGVyGAEgASgIEhsKE2NvbnRyb2xs",
+            "ZXJfcmV2aXNpb24YAiABKAQSFwoPYWN0aXZlX3N0YXRlX2lkGAMgASgEEhkK",
+            "EWFjdGl2ZV9zdGF0ZV9uYW1lGAQgASgJEhkKEWFjdGl2ZV9zdGF0ZV90aW1l",
+            "GAUgASgCEhUKDXRyYW5zaXRpb25pbmcYBiABKAgSHAoUZGVzdGluYXRpb25f",
+            "c3RhdGVfaWQYByABKAQSHgoWZGVzdGluYXRpb25fc3RhdGVfbmFtZRgIIAEo",
+            "CRIeChZkZXN0aW5hdGlvbl9zdGF0ZV90aW1lGAkgASgCEhgKEHRyYW5zaXRp",
+            "b25fYWxwaGEYCiABKAIiNQoHVmVjdG9yNBIJCgF4GAEgASgCEgkKAXkYAiAB",
+            "KAISCQoBehgDIAEoAhIJCgF3GAQgASgCIjYKFlZpZXdwb3J0U2VsZWN0aW9u",
+            "RXZlbnQSHAoUc2VsZWN0ZWRfaW5zdGFuY2VfaWQYASABKAki1gMKFlZpZXdw",
+            "b3J0VHJhbnNmb3JtRXZlbnQSEwoLaW5zdGFuY2VfaWQYASABKAkSPwoJb3Bl",
+            "cmF0aW9uGAIgASgOMiwuc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5z",
+            "Zm9ybU9wZXJhdGlvbhI3CgVzcGFjZRgDIAEoDjIoLnNhaWxvci5lZGl0b3Iu",
+            "djEuVmlld3BvcnRUcmFuc2Zvcm1TcGFjZRIyCg9iZWZvcmVfcG9zaXRpb24Y",
+            "BCABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQSMgoPYmVmb3JlX3Jv",
+            "dGF0aW9uGAUgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0Ei8KDGJl",
+            "Zm9yZV9zY2FsZRgGIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNBIx",
+            "Cg5hZnRlcl9wb3NpdGlvbhgHIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVj",
+            "dG9yNBIxCg5hZnRlcl9yb3RhdGlvbhgIIAEoCzIZLnNhaWxvci5lZGl0b3Iu",
+            "djEuVmVjdG9yNBIuCgthZnRlcl9zY2FsZRgJIAEoCzIZLnNhaWxvci5lZGl0",
+            "b3IudjEuVmVjdG9yNCJVChZWaWV3cG9ydEFzc2V0RHJvcEV2ZW50Eg8KB2Zp",
+            "bGVfaWQYASABKAkSFAoMbm9ybWFsaXplZF94GAIgASgCEhQKDG5vcm1hbGl6",
+            "ZWRfeRgDIAEoAiItChlWaWV3cG9ydFRvb2xTaG9ydGN1dEV2ZW50EhAKCGtl",
+            "eV9jb2RlGAEgASgNItkCCg1WaWV3cG9ydEV2ZW50EhAKCHJldmlzaW9uGAEg",
+            "ASgEEiEKGW1hbmFnZWRfbXV0YXRpb25fcmV2aXNpb24YAiABKAQSPQoJc2Vs",
+            "ZWN0aW9uGAogASgLMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFNlbGVj",
+            "dGlvbkV2ZW50SAASPQoJdHJhbnNmb3JtGAsgASgLMiguc2FpbG9yLmVkaXRv",
+            "ci52MS5WaWV3cG9ydFRyYW5zZm9ybUV2ZW50SAASPgoKYXNzZXRfZHJvcBgM",
+            "IAEoCzIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRBc3NldERyb3BFdmVu",
+            "dEgAEkQKDXRvb2xfc2hvcnRjdXQYDSABKAsyKy5zYWlsb3IuZWRpdG9yLnYx",
+            "LlZpZXdwb3J0VG9vbFNob3J0Y3V0RXZlbnRIAEIJCgdwYXlsb2FkSgQIAxAK",
+            "IksKGFZpZXdwb3J0RXZlbnRCYXRjaFJlc3VsdBIvCgZldmVudHMYASADKAsy",
+            "Hy5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0RXZlbnQq8AEKGlZpZXdwb3J0",
+            "VHJhbnNmb3JtT3BlcmF0aW9uEiwKKFZJRVdQT1JUX1RSQU5TRk9STV9PUEVS",
+            "QVRJT05fVU5TUEVDSUZJRUQQABInCiNWSUVXUE9SVF9UUkFOU0ZPUk1fT1BF",
+            "UkFUSU9OX1NFTEVDVBABEioKJlZJRVdQT1JUX1RSQU5TRk9STV9PUEVSQVRJ",
+            "T05fVFJBTlNMQVRFEAISJwojVklFV1BPUlRfVFJBTlNGT1JNX09QRVJBVElP",
+            "Tl9ST1RBVEUQAxImCiJWSUVXUE9SVF9UUkFOU0ZPUk1fT1BFUkFUSU9OX1ND",
+            "QUxFEAQqigEKFlZpZXdwb3J0VHJhbnNmb3JtU3BhY2USKAokVklFV1BPUlRf",
+            "VFJBTlNGT1JNX1NQQUNFX1VOU1BFQ0lGSUVEEAASIgoeVklFV1BPUlRfVFJB",
+            "TlNGT1JNX1NQQUNFX1dPUkxEEAESIgoeVklFV1BPUlRfVFJBTlNGT1JNX1NQ",
+            "QUNFX0xPQ0FMEAJCIqoCH1NhaWxvckVkaXRvci5Qcm90b2NvbC5HZW5lcmF0",
+            "ZWRiBnByb3RvMw=="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::SailorEditor.Protocol.Generated.ViewportTransformOperation), typeof(global::SailorEditor.Protocol.Generated.ViewportTransformSpace), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Empty), global::SailorEditor.Protocol.Generated.Empty.Parser, null, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset", "CreateModelInstance" }, new[]{ "Command" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "SupportsStrictInstanceIds", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult", "Vector4Result", "ViewportToolStateResult" }, new[]{ "Result" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset", "CreateModelInstance", "SetAnimatorParameter", "GetAnimatorState" }, new[]{ "Command" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "SupportsStrictInstanceIds", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult", "Vector4Result", "ViewportToolStateResult", "AnimatorStateResult" }, new[]{ "Result" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InitializeRequest), global::SailorEditor.Protocol.Generated.InitializeRequest.Parser, new[]{ "Arguments" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CountRequest), global::SailorEditor.Protocol.Generated.CountRequest.Parser, new[]{ "MaxCount" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.FileIdRequest), global::SailorEditor.Protocol.Generated.FileIdRequest.Parser, new[]{ "FileId" }, null, null, null, null),
@@ -247,6 +264,7 @@ namespace SailorEditor.Protocol.Generated {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ReparentObjectRequest), global::SailorEditor.Protocol.Generated.ReparentObjectRequest.Parser, new[]{ "InstanceId", "ParentInstanceId", "KeepWorldTransform" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CreateGameObjectRequest), global::SailorEditor.Protocol.Generated.CreateGameObjectRequest.Parser, new[]{ "ParentInstanceId", "PreferredInstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.AddComponentRequest), global::SailorEditor.Protocol.Generated.AddComponentRequest.Parser, new[]{ "InstanceId", "ComponentTypeName", "PreferredInstanceId" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.AnimatorParameterRequest), global::SailorEditor.Protocol.Generated.AnimatorParameterRequest.Parser, new[]{ "InstanceId", "Name", "FloatValue", "IntValue", "BoolValue", "Trigger", "ResetTrigger" }, new[]{ "Value" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstantiatePrefabRequest), global::SailorEditor.Protocol.Generated.InstantiatePrefabRequest.Parser, new[]{ "FileId", "ParentInstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstantiatePrefabFromYamlRequest), global::SailorEditor.Protocol.Generated.InstantiatePrefabFromYamlRequest.Parser, new[]{ "PrefabYaml", "ParentInstanceId", "StrictInstanceIds" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportRayRequest), global::SailorEditor.Protocol.Generated.ViewportRayRequest.Parser, new[]{ "ViewportId", "NormalizedX", "NormalizedY" }, null, null, null, null),
@@ -267,6 +285,7 @@ namespace SailorEditor.Protocol.Generated {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InstanceIdResult), global::SailorEditor.Protocol.Generated.InstanceIdResult.Parser, new[]{ "Succeeded", "InstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Vector4Result), global::SailorEditor.Protocol.Generated.Vector4Result.Parser, new[]{ "Value" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportToolStateResult), global::SailorEditor.Protocol.Generated.ViewportToolStateResult.Parser, new[]{ "Operation", "Space" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.AnimatorStateResult), global::SailorEditor.Protocol.Generated.AnimatorStateResult.Parser, new[]{ "HasController", "ControllerRevision", "ActiveStateId", "ActiveStateName", "ActiveStateTime", "Transitioning", "DestinationStateId", "DestinationStateName", "DestinationStateTime", "TransitionAlpha" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Vector4), global::SailorEditor.Protocol.Generated.Vector4.Parser, new[]{ "X", "Y", "Z", "W" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportSelectionEvent), global::SailorEditor.Protocol.Generated.ViewportSelectionEvent.Parser, new[]{ "SelectedInstanceId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportTransformEvent), global::SailorEditor.Protocol.Generated.ViewportTransformEvent.Parser, new[]{ "InstanceId", "Operation", "Space", "BeforePosition", "BeforeRotation", "BeforeScale", "AfterPosition", "AfterRotation", "AfterScale" }, null, null, null, null),
@@ -639,6 +658,12 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case CommandOneofCase.CreateModelInstance:
           CreateModelInstance = other.CreateModelInstance.Clone();
+          break;
+        case CommandOneofCase.SetAnimatorParameter:
+          SetAnimatorParameter = other.SetAnimatorParameter.Clone();
+          break;
+        case CommandOneofCase.GetAnimatorState:
+          GetAnimatorState = other.GetAnimatorState.Clone();
           break;
       }
 
@@ -1251,6 +1276,30 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "set_animator_parameter" field.</summary>
+    public const int SetAnimatorParameterFieldNumber = 59;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.AnimatorParameterRequest SetAnimatorParameter {
+      get { return commandCase_ == CommandOneofCase.SetAnimatorParameter ? (global::SailorEditor.Protocol.Generated.AnimatorParameterRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.SetAnimatorParameter;
+      }
+    }
+
+    /// <summary>Field number for the "get_animator_state" field.</summary>
+    public const int GetAnimatorStateFieldNumber = 60;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.InstanceIdRequest GetAnimatorState {
+      get { return commandCase_ == CommandOneofCase.GetAnimatorState ? (global::SailorEditor.Protocol.Generated.InstanceIdRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.GetAnimatorState;
+      }
+    }
+
     private object command_;
     /// <summary>Enum of possible cases for the "command" oneof.</summary>
     public enum CommandOneofCase {
@@ -1303,6 +1352,8 @@ namespace SailorEditor.Protocol.Generated {
       GetViewportToolState = 56,
       UpdateAsset = 57,
       CreateModelInstance = 58,
+      SetAnimatorParameter = 59,
+      GetAnimatorState = 60,
     }
     private CommandOneofCase commandCase_ = CommandOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1383,6 +1434,8 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(GetViewportToolState, other.GetViewportToolState)) return false;
       if (!object.Equals(UpdateAsset, other.UpdateAsset)) return false;
       if (!object.Equals(CreateModelInstance, other.CreateModelInstance)) return false;
+      if (!object.Equals(SetAnimatorParameter, other.SetAnimatorParameter)) return false;
+      if (!object.Equals(GetAnimatorState, other.GetAnimatorState)) return false;
       if (CommandCase != other.CommandCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -1441,6 +1494,8 @@ namespace SailorEditor.Protocol.Generated {
       if (commandCase_ == CommandOneofCase.GetViewportToolState) hash ^= GetViewportToolState.GetHashCode();
       if (commandCase_ == CommandOneofCase.UpdateAsset) hash ^= UpdateAsset.GetHashCode();
       if (commandCase_ == CommandOneofCase.CreateModelInstance) hash ^= CreateModelInstance.GetHashCode();
+      if (commandCase_ == CommandOneofCase.SetAnimatorParameter) hash ^= SetAnimatorParameter.GetHashCode();
+      if (commandCase_ == CommandOneofCase.GetAnimatorState) hash ^= GetAnimatorState.GetHashCode();
       hash ^= (int) commandCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -1660,6 +1715,14 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(210, 3);
         output.WriteMessage(CreateModelInstance);
       }
+      if (commandCase_ == CommandOneofCase.SetAnimatorParameter) {
+        output.WriteRawTag(218, 3);
+        output.WriteMessage(SetAnimatorParameter);
+      }
+      if (commandCase_ == CommandOneofCase.GetAnimatorState) {
+        output.WriteRawTag(226, 3);
+        output.WriteMessage(GetAnimatorState);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1870,6 +1933,14 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(210, 3);
         output.WriteMessage(CreateModelInstance);
       }
+      if (commandCase_ == CommandOneofCase.SetAnimatorParameter) {
+        output.WriteRawTag(218, 3);
+        output.WriteMessage(SetAnimatorParameter);
+      }
+      if (commandCase_ == CommandOneofCase.GetAnimatorState) {
+        output.WriteRawTag(226, 3);
+        output.WriteMessage(GetAnimatorState);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -2029,6 +2100,12 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (commandCase_ == CommandOneofCase.CreateModelInstance) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(CreateModelInstance);
+      }
+      if (commandCase_ == CommandOneofCase.SetAnimatorParameter) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(SetAnimatorParameter);
+      }
+      if (commandCase_ == CommandOneofCase.GetAnimatorState) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetAnimatorState);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -2337,6 +2414,18 @@ namespace SailorEditor.Protocol.Generated {
           }
           CreateModelInstance.MergeFrom(other.CreateModelInstance);
           break;
+        case CommandOneofCase.SetAnimatorParameter:
+          if (SetAnimatorParameter == null) {
+            SetAnimatorParameter = new global::SailorEditor.Protocol.Generated.AnimatorParameterRequest();
+          }
+          SetAnimatorParameter.MergeFrom(other.SetAnimatorParameter);
+          break;
+        case CommandOneofCase.GetAnimatorState:
+          if (GetAnimatorState == null) {
+            GetAnimatorState = new global::SailorEditor.Protocol.Generated.InstanceIdRequest();
+          }
+          GetAnimatorState.MergeFrom(other.GetAnimatorState);
+          break;
       }
 
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -2798,6 +2887,24 @@ namespace SailorEditor.Protocol.Generated {
             CreateModelInstance = subBuilder;
             break;
           }
+          case 474: {
+            global::SailorEditor.Protocol.Generated.AnimatorParameterRequest subBuilder = new global::SailorEditor.Protocol.Generated.AnimatorParameterRequest();
+            if (commandCase_ == CommandOneofCase.SetAnimatorParameter) {
+              subBuilder.MergeFrom(SetAnimatorParameter);
+            }
+            input.ReadMessage(subBuilder);
+            SetAnimatorParameter = subBuilder;
+            break;
+          }
+          case 482: {
+            global::SailorEditor.Protocol.Generated.InstanceIdRequest subBuilder = new global::SailorEditor.Protocol.Generated.InstanceIdRequest();
+            if (commandCase_ == CommandOneofCase.GetAnimatorState) {
+              subBuilder.MergeFrom(GetAnimatorState);
+            }
+            input.ReadMessage(subBuilder);
+            GetAnimatorState = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -3257,6 +3364,24 @@ namespace SailorEditor.Protocol.Generated {
             CreateModelInstance = subBuilder;
             break;
           }
+          case 474: {
+            global::SailorEditor.Protocol.Generated.AnimatorParameterRequest subBuilder = new global::SailorEditor.Protocol.Generated.AnimatorParameterRequest();
+            if (commandCase_ == CommandOneofCase.SetAnimatorParameter) {
+              subBuilder.MergeFrom(SetAnimatorParameter);
+            }
+            input.ReadMessage(subBuilder);
+            SetAnimatorParameter = subBuilder;
+            break;
+          }
+          case 482: {
+            global::SailorEditor.Protocol.Generated.InstanceIdRequest subBuilder = new global::SailorEditor.Protocol.Generated.InstanceIdRequest();
+            if (commandCase_ == CommandOneofCase.GetAnimatorState) {
+              subBuilder.MergeFrom(GetAnimatorState);
+            }
+            input.ReadMessage(subBuilder);
+            GetAnimatorState = subBuilder;
+            break;
+          }
         }
       }
     }
@@ -3340,6 +3465,9 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case ResultOneofCase.ViewportToolStateResult:
           ViewportToolStateResult = other.ViewportToolStateResult.Clone();
+          break;
+        case ResultOneofCase.AnimatorStateResult:
+          AnimatorStateResult = other.AnimatorStateResult.Clone();
           break;
       }
 
@@ -3556,6 +3684,18 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "animator_state_result" field.</summary>
+    public const int AnimatorStateResultFieldNumber = 22;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.AnimatorStateResult AnimatorStateResult {
+      get { return resultCase_ == ResultOneofCase.AnimatorStateResult ? (global::SailorEditor.Protocol.Generated.AnimatorStateResult) result_ : null; }
+      set {
+        result_ = value;
+        resultCase_ = value == null ? ResultOneofCase.None : ResultOneofCase.AnimatorStateResult;
+      }
+    }
+
     private object result_;
     /// <summary>Enum of possible cases for the "result" oneof.</summary>
     public enum ResultOneofCase {
@@ -3572,6 +3712,7 @@ namespace SailorEditor.Protocol.Generated {
       ViewportEventBatchResult = 19,
       Vector4Result = 20,
       ViewportToolStateResult = 21,
+      AnimatorStateResult = 22,
     }
     private ResultOneofCase resultCase_ = ResultOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3619,6 +3760,7 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(ViewportEventBatchResult, other.ViewportEventBatchResult)) return false;
       if (!object.Equals(Vector4Result, other.Vector4Result)) return false;
       if (!object.Equals(ViewportToolStateResult, other.ViewportToolStateResult)) return false;
+      if (!object.Equals(AnimatorStateResult, other.AnimatorStateResult)) return false;
       if (ResultCase != other.ResultCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -3644,6 +3786,7 @@ namespace SailorEditor.Protocol.Generated {
       if (resultCase_ == ResultOneofCase.ViewportEventBatchResult) hash ^= ViewportEventBatchResult.GetHashCode();
       if (resultCase_ == ResultOneofCase.Vector4Result) hash ^= Vector4Result.GetHashCode();
       if (resultCase_ == ResultOneofCase.ViewportToolStateResult) hash ^= ViewportToolStateResult.GetHashCode();
+      if (resultCase_ == ResultOneofCase.AnimatorStateResult) hash ^= AnimatorStateResult.GetHashCode();
       hash ^= (int) resultCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -3731,6 +3874,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(170, 1);
         output.WriteMessage(ViewportToolStateResult);
       }
+      if (resultCase_ == ResultOneofCase.AnimatorStateResult) {
+        output.WriteRawTag(178, 1);
+        output.WriteMessage(AnimatorStateResult);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -3809,6 +3956,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(170, 1);
         output.WriteMessage(ViewportToolStateResult);
       }
+      if (resultCase_ == ResultOneofCase.AnimatorStateResult) {
+        output.WriteRawTag(178, 1);
+        output.WriteMessage(AnimatorStateResult);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -3869,6 +4020,9 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (resultCase_ == ResultOneofCase.ViewportToolStateResult) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(ViewportToolStateResult);
+      }
+      if (resultCase_ == ResultOneofCase.AnimatorStateResult) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(AnimatorStateResult);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -3969,6 +4123,12 @@ namespace SailorEditor.Protocol.Generated {
             ViewportToolStateResult = new global::SailorEditor.Protocol.Generated.ViewportToolStateResult();
           }
           ViewportToolStateResult.MergeFrom(other.ViewportToolStateResult);
+          break;
+        case ResultOneofCase.AnimatorStateResult:
+          if (AnimatorStateResult == null) {
+            AnimatorStateResult = new global::SailorEditor.Protocol.Generated.AnimatorStateResult();
+          }
+          AnimatorStateResult.MergeFrom(other.AnimatorStateResult);
           break;
       }
 
@@ -4119,6 +4279,15 @@ namespace SailorEditor.Protocol.Generated {
             ViewportToolStateResult = subBuilder;
             break;
           }
+          case 178: {
+            global::SailorEditor.Protocol.Generated.AnimatorStateResult subBuilder = new global::SailorEditor.Protocol.Generated.AnimatorStateResult();
+            if (resultCase_ == ResultOneofCase.AnimatorStateResult) {
+              subBuilder.MergeFrom(AnimatorStateResult);
+            }
+            input.ReadMessage(subBuilder);
+            AnimatorStateResult = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -4264,6 +4433,15 @@ namespace SailorEditor.Protocol.Generated {
             }
             input.ReadMessage(subBuilder);
             ViewportToolStateResult = subBuilder;
+            break;
+          }
+          case 178: {
+            global::SailorEditor.Protocol.Generated.AnimatorStateResult subBuilder = new global::SailorEditor.Protocol.Generated.AnimatorStateResult();
+            if (resultCase_ == ResultOneofCase.AnimatorStateResult) {
+              subBuilder.MergeFrom(AnimatorStateResult);
+            }
+            input.ReadMessage(subBuilder);
+            AnimatorStateResult = subBuilder;
             break;
           }
         }
@@ -8772,6 +8950,536 @@ namespace SailorEditor.Protocol.Generated {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class AnimatorParameterRequest : pb::IMessage<AnimatorParameterRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<AnimatorParameterRequest> _parser = new pb::MessageParser<AnimatorParameterRequest>(() => new AnimatorParameterRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<AnimatorParameterRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[19]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public AnimatorParameterRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public AnimatorParameterRequest(AnimatorParameterRequest other) : this() {
+      instanceId_ = other.instanceId_;
+      name_ = other.name_;
+      switch (other.ValueCase) {
+        case ValueOneofCase.FloatValue:
+          FloatValue = other.FloatValue;
+          break;
+        case ValueOneofCase.IntValue:
+          IntValue = other.IntValue;
+          break;
+        case ValueOneofCase.BoolValue:
+          BoolValue = other.BoolValue;
+          break;
+        case ValueOneofCase.Trigger:
+          Trigger = other.Trigger.Clone();
+          break;
+        case ValueOneofCase.ResetTrigger:
+          ResetTrigger = other.ResetTrigger.Clone();
+          break;
+      }
+
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public AnimatorParameterRequest Clone() {
+      return new AnimatorParameterRequest(this);
+    }
+
+    /// <summary>Field number for the "instance_id" field.</summary>
+    public const int InstanceIdFieldNumber = 1;
+    private string instanceId_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string InstanceId {
+      get { return instanceId_; }
+      set {
+        instanceId_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "name" field.</summary>
+    public const int NameFieldNumber = 2;
+    private string name_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string Name {
+      get { return name_; }
+      set {
+        name_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "float_value" field.</summary>
+    public const int FloatValueFieldNumber = 3;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public float FloatValue {
+      get { return HasFloatValue ? (float) value_ : 0F; }
+      set {
+        value_ = value;
+        valueCase_ = ValueOneofCase.FloatValue;
+      }
+    }
+    /// <summary>Gets whether the "float_value" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasFloatValue {
+      get { return valueCase_ == ValueOneofCase.FloatValue; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "float_value" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearFloatValue() {
+      if (HasFloatValue) {
+        ClearValue();
+      }
+    }
+
+    /// <summary>Field number for the "int_value" field.</summary>
+    public const int IntValueFieldNumber = 4;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int IntValue {
+      get { return HasIntValue ? (int) value_ : 0; }
+      set {
+        value_ = value;
+        valueCase_ = ValueOneofCase.IntValue;
+      }
+    }
+    /// <summary>Gets whether the "int_value" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasIntValue {
+      get { return valueCase_ == ValueOneofCase.IntValue; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "int_value" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearIntValue() {
+      if (HasIntValue) {
+        ClearValue();
+      }
+    }
+
+    /// <summary>Field number for the "bool_value" field.</summary>
+    public const int BoolValueFieldNumber = 5;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool BoolValue {
+      get { return HasBoolValue ? (bool) value_ : false; }
+      set {
+        value_ = value;
+        valueCase_ = ValueOneofCase.BoolValue;
+      }
+    }
+    /// <summary>Gets whether the "bool_value" field is set</summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasBoolValue {
+      get { return valueCase_ == ValueOneofCase.BoolValue; }
+    }
+    /// <summary> Clears the value of the oneof if it's currently set to "bool_value" </summary>
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearBoolValue() {
+      if (HasBoolValue) {
+        ClearValue();
+      }
+    }
+
+    /// <summary>Field number for the "trigger" field.</summary>
+    public const int TriggerFieldNumber = 6;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.Empty Trigger {
+      get { return valueCase_ == ValueOneofCase.Trigger ? (global::SailorEditor.Protocol.Generated.Empty) value_ : null; }
+      set {
+        value_ = value;
+        valueCase_ = value == null ? ValueOneofCase.None : ValueOneofCase.Trigger;
+      }
+    }
+
+    /// <summary>Field number for the "reset_trigger" field.</summary>
+    public const int ResetTriggerFieldNumber = 7;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.Empty ResetTrigger {
+      get { return valueCase_ == ValueOneofCase.ResetTrigger ? (global::SailorEditor.Protocol.Generated.Empty) value_ : null; }
+      set {
+        value_ = value;
+        valueCase_ = value == null ? ValueOneofCase.None : ValueOneofCase.ResetTrigger;
+      }
+    }
+
+    private object value_;
+    /// <summary>Enum of possible cases for the "value" oneof.</summary>
+    public enum ValueOneofCase {
+      None = 0,
+      FloatValue = 3,
+      IntValue = 4,
+      BoolValue = 5,
+      Trigger = 6,
+      ResetTrigger = 7,
+    }
+    private ValueOneofCase valueCase_ = ValueOneofCase.None;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ValueOneofCase ValueCase {
+      get { return valueCase_; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void ClearValue() {
+      valueCase_ = ValueOneofCase.None;
+      value_ = null;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as AnimatorParameterRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(AnimatorParameterRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (InstanceId != other.InstanceId) return false;
+      if (Name != other.Name) return false;
+      if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(FloatValue, other.FloatValue)) return false;
+      if (IntValue != other.IntValue) return false;
+      if (BoolValue != other.BoolValue) return false;
+      if (!object.Equals(Trigger, other.Trigger)) return false;
+      if (!object.Equals(ResetTrigger, other.ResetTrigger)) return false;
+      if (ValueCase != other.ValueCase) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (InstanceId.Length != 0) hash ^= InstanceId.GetHashCode();
+      if (Name.Length != 0) hash ^= Name.GetHashCode();
+      if (HasFloatValue) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(FloatValue);
+      if (HasIntValue) hash ^= IntValue.GetHashCode();
+      if (HasBoolValue) hash ^= BoolValue.GetHashCode();
+      if (valueCase_ == ValueOneofCase.Trigger) hash ^= Trigger.GetHashCode();
+      if (valueCase_ == ValueOneofCase.ResetTrigger) hash ^= ResetTrigger.GetHashCode();
+      hash ^= (int) valueCase_;
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (InstanceId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(InstanceId);
+      }
+      if (Name.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Name);
+      }
+      if (HasFloatValue) {
+        output.WriteRawTag(29);
+        output.WriteFloat(FloatValue);
+      }
+      if (HasIntValue) {
+        output.WriteRawTag(32);
+        output.WriteSInt32(IntValue);
+      }
+      if (HasBoolValue) {
+        output.WriteRawTag(40);
+        output.WriteBool(BoolValue);
+      }
+      if (valueCase_ == ValueOneofCase.Trigger) {
+        output.WriteRawTag(50);
+        output.WriteMessage(Trigger);
+      }
+      if (valueCase_ == ValueOneofCase.ResetTrigger) {
+        output.WriteRawTag(58);
+        output.WriteMessage(ResetTrigger);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (InstanceId.Length != 0) {
+        output.WriteRawTag(10);
+        output.WriteString(InstanceId);
+      }
+      if (Name.Length != 0) {
+        output.WriteRawTag(18);
+        output.WriteString(Name);
+      }
+      if (HasFloatValue) {
+        output.WriteRawTag(29);
+        output.WriteFloat(FloatValue);
+      }
+      if (HasIntValue) {
+        output.WriteRawTag(32);
+        output.WriteSInt32(IntValue);
+      }
+      if (HasBoolValue) {
+        output.WriteRawTag(40);
+        output.WriteBool(BoolValue);
+      }
+      if (valueCase_ == ValueOneofCase.Trigger) {
+        output.WriteRawTag(50);
+        output.WriteMessage(Trigger);
+      }
+      if (valueCase_ == ValueOneofCase.ResetTrigger) {
+        output.WriteRawTag(58);
+        output.WriteMessage(ResetTrigger);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (InstanceId.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(InstanceId);
+      }
+      if (Name.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(Name);
+      }
+      if (HasFloatValue) {
+        size += 1 + 4;
+      }
+      if (HasIntValue) {
+        size += 1 + pb::CodedOutputStream.ComputeSInt32Size(IntValue);
+      }
+      if (HasBoolValue) {
+        size += 1 + 1;
+      }
+      if (valueCase_ == ValueOneofCase.Trigger) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(Trigger);
+      }
+      if (valueCase_ == ValueOneofCase.ResetTrigger) {
+        size += 1 + pb::CodedOutputStream.ComputeMessageSize(ResetTrigger);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(AnimatorParameterRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.InstanceId.Length != 0) {
+        InstanceId = other.InstanceId;
+      }
+      if (other.Name.Length != 0) {
+        Name = other.Name;
+      }
+      switch (other.ValueCase) {
+        case ValueOneofCase.FloatValue:
+          FloatValue = other.FloatValue;
+          break;
+        case ValueOneofCase.IntValue:
+          IntValue = other.IntValue;
+          break;
+        case ValueOneofCase.BoolValue:
+          BoolValue = other.BoolValue;
+          break;
+        case ValueOneofCase.Trigger:
+          if (Trigger == null) {
+            Trigger = new global::SailorEditor.Protocol.Generated.Empty();
+          }
+          Trigger.MergeFrom(other.Trigger);
+          break;
+        case ValueOneofCase.ResetTrigger:
+          if (ResetTrigger == null) {
+            ResetTrigger = new global::SailorEditor.Protocol.Generated.Empty();
+          }
+          ResetTrigger.MergeFrom(other.ResetTrigger);
+          break;
+      }
+
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 10: {
+            InstanceId = input.ReadString();
+            break;
+          }
+          case 18: {
+            Name = input.ReadString();
+            break;
+          }
+          case 29: {
+            FloatValue = input.ReadFloat();
+            break;
+          }
+          case 32: {
+            IntValue = input.ReadSInt32();
+            break;
+          }
+          case 40: {
+            BoolValue = input.ReadBool();
+            break;
+          }
+          case 50: {
+            global::SailorEditor.Protocol.Generated.Empty subBuilder = new global::SailorEditor.Protocol.Generated.Empty();
+            if (valueCase_ == ValueOneofCase.Trigger) {
+              subBuilder.MergeFrom(Trigger);
+            }
+            input.ReadMessage(subBuilder);
+            Trigger = subBuilder;
+            break;
+          }
+          case 58: {
+            global::SailorEditor.Protocol.Generated.Empty subBuilder = new global::SailorEditor.Protocol.Generated.Empty();
+            if (valueCase_ == ValueOneofCase.ResetTrigger) {
+              subBuilder.MergeFrom(ResetTrigger);
+            }
+            input.ReadMessage(subBuilder);
+            ResetTrigger = subBuilder;
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 10: {
+            InstanceId = input.ReadString();
+            break;
+          }
+          case 18: {
+            Name = input.ReadString();
+            break;
+          }
+          case 29: {
+            FloatValue = input.ReadFloat();
+            break;
+          }
+          case 32: {
+            IntValue = input.ReadSInt32();
+            break;
+          }
+          case 40: {
+            BoolValue = input.ReadBool();
+            break;
+          }
+          case 50: {
+            global::SailorEditor.Protocol.Generated.Empty subBuilder = new global::SailorEditor.Protocol.Generated.Empty();
+            if (valueCase_ == ValueOneofCase.Trigger) {
+              subBuilder.MergeFrom(Trigger);
+            }
+            input.ReadMessage(subBuilder);
+            Trigger = subBuilder;
+            break;
+          }
+          case 58: {
+            global::SailorEditor.Protocol.Generated.Empty subBuilder = new global::SailorEditor.Protocol.Generated.Empty();
+            if (valueCase_ == ValueOneofCase.ResetTrigger) {
+              subBuilder.MergeFrom(ResetTrigger);
+            }
+            input.ReadMessage(subBuilder);
+            ResetTrigger = subBuilder;
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class InstantiatePrefabRequest : pb::IMessage<InstantiatePrefabRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -8786,7 +9494,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[19]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9021,7 +9729,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9293,7 +10001,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9565,7 +10273,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9883,7 +10591,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10118,7 +10826,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10353,7 +11061,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10625,7 +11333,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10812,7 +11520,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11010,7 +11718,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11356,7 +12064,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11554,7 +12262,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11752,7 +12460,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11950,7 +12658,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12148,7 +12856,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12383,7 +13091,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12570,7 +13278,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12879,7 +13587,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13114,7 +13822,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13321,7 +14029,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13542,6 +14250,537 @@ namespace SailorEditor.Protocol.Generated {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class AnimatorStateResult : pb::IMessage<AnimatorStateResult>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<AnimatorStateResult> _parser = new pb::MessageParser<AnimatorStateResult>(() => new AnimatorStateResult());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<AnimatorStateResult> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public AnimatorStateResult() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public AnimatorStateResult(AnimatorStateResult other) : this() {
+      hasController_ = other.hasController_;
+      controllerRevision_ = other.controllerRevision_;
+      activeStateId_ = other.activeStateId_;
+      activeStateName_ = other.activeStateName_;
+      activeStateTime_ = other.activeStateTime_;
+      transitioning_ = other.transitioning_;
+      destinationStateId_ = other.destinationStateId_;
+      destinationStateName_ = other.destinationStateName_;
+      destinationStateTime_ = other.destinationStateTime_;
+      transitionAlpha_ = other.transitionAlpha_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public AnimatorStateResult Clone() {
+      return new AnimatorStateResult(this);
+    }
+
+    /// <summary>Field number for the "has_controller" field.</summary>
+    public const int HasControllerFieldNumber = 1;
+    private bool hasController_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool HasController {
+      get { return hasController_; }
+      set {
+        hasController_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "controller_revision" field.</summary>
+    public const int ControllerRevisionFieldNumber = 2;
+    private ulong controllerRevision_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ulong ControllerRevision {
+      get { return controllerRevision_; }
+      set {
+        controllerRevision_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "active_state_id" field.</summary>
+    public const int ActiveStateIdFieldNumber = 3;
+    private ulong activeStateId_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ulong ActiveStateId {
+      get { return activeStateId_; }
+      set {
+        activeStateId_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "active_state_name" field.</summary>
+    public const int ActiveStateNameFieldNumber = 4;
+    private string activeStateName_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string ActiveStateName {
+      get { return activeStateName_; }
+      set {
+        activeStateName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "active_state_time" field.</summary>
+    public const int ActiveStateTimeFieldNumber = 5;
+    private float activeStateTime_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public float ActiveStateTime {
+      get { return activeStateTime_; }
+      set {
+        activeStateTime_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "transitioning" field.</summary>
+    public const int TransitioningFieldNumber = 6;
+    private bool transitioning_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Transitioning {
+      get { return transitioning_; }
+      set {
+        transitioning_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "destination_state_id" field.</summary>
+    public const int DestinationStateIdFieldNumber = 7;
+    private ulong destinationStateId_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public ulong DestinationStateId {
+      get { return destinationStateId_; }
+      set {
+        destinationStateId_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "destination_state_name" field.</summary>
+    public const int DestinationStateNameFieldNumber = 8;
+    private string destinationStateName_ = "";
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public string DestinationStateName {
+      get { return destinationStateName_; }
+      set {
+        destinationStateName_ = pb::ProtoPreconditions.CheckNotNull(value, "value");
+      }
+    }
+
+    /// <summary>Field number for the "destination_state_time" field.</summary>
+    public const int DestinationStateTimeFieldNumber = 9;
+    private float destinationStateTime_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public float DestinationStateTime {
+      get { return destinationStateTime_; }
+      set {
+        destinationStateTime_ = value;
+      }
+    }
+
+    /// <summary>Field number for the "transition_alpha" field.</summary>
+    public const int TransitionAlphaFieldNumber = 10;
+    private float transitionAlpha_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public float TransitionAlpha {
+      get { return transitionAlpha_; }
+      set {
+        transitionAlpha_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as AnimatorStateResult);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(AnimatorStateResult other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (HasController != other.HasController) return false;
+      if (ControllerRevision != other.ControllerRevision) return false;
+      if (ActiveStateId != other.ActiveStateId) return false;
+      if (ActiveStateName != other.ActiveStateName) return false;
+      if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(ActiveStateTime, other.ActiveStateTime)) return false;
+      if (Transitioning != other.Transitioning) return false;
+      if (DestinationStateId != other.DestinationStateId) return false;
+      if (DestinationStateName != other.DestinationStateName) return false;
+      if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(DestinationStateTime, other.DestinationStateTime)) return false;
+      if (!pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.Equals(TransitionAlpha, other.TransitionAlpha)) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (HasController != false) hash ^= HasController.GetHashCode();
+      if (ControllerRevision != 0UL) hash ^= ControllerRevision.GetHashCode();
+      if (ActiveStateId != 0UL) hash ^= ActiveStateId.GetHashCode();
+      if (ActiveStateName.Length != 0) hash ^= ActiveStateName.GetHashCode();
+      if (ActiveStateTime != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(ActiveStateTime);
+      if (Transitioning != false) hash ^= Transitioning.GetHashCode();
+      if (DestinationStateId != 0UL) hash ^= DestinationStateId.GetHashCode();
+      if (DestinationStateName.Length != 0) hash ^= DestinationStateName.GetHashCode();
+      if (DestinationStateTime != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(DestinationStateTime);
+      if (TransitionAlpha != 0F) hash ^= pbc::ProtobufEqualityComparers.BitwiseSingleEqualityComparer.GetHashCode(TransitionAlpha);
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (HasController != false) {
+        output.WriteRawTag(8);
+        output.WriteBool(HasController);
+      }
+      if (ControllerRevision != 0UL) {
+        output.WriteRawTag(16);
+        output.WriteUInt64(ControllerRevision);
+      }
+      if (ActiveStateId != 0UL) {
+        output.WriteRawTag(24);
+        output.WriteUInt64(ActiveStateId);
+      }
+      if (ActiveStateName.Length != 0) {
+        output.WriteRawTag(34);
+        output.WriteString(ActiveStateName);
+      }
+      if (ActiveStateTime != 0F) {
+        output.WriteRawTag(45);
+        output.WriteFloat(ActiveStateTime);
+      }
+      if (Transitioning != false) {
+        output.WriteRawTag(48);
+        output.WriteBool(Transitioning);
+      }
+      if (DestinationStateId != 0UL) {
+        output.WriteRawTag(56);
+        output.WriteUInt64(DestinationStateId);
+      }
+      if (DestinationStateName.Length != 0) {
+        output.WriteRawTag(66);
+        output.WriteString(DestinationStateName);
+      }
+      if (DestinationStateTime != 0F) {
+        output.WriteRawTag(77);
+        output.WriteFloat(DestinationStateTime);
+      }
+      if (TransitionAlpha != 0F) {
+        output.WriteRawTag(85);
+        output.WriteFloat(TransitionAlpha);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (HasController != false) {
+        output.WriteRawTag(8);
+        output.WriteBool(HasController);
+      }
+      if (ControllerRevision != 0UL) {
+        output.WriteRawTag(16);
+        output.WriteUInt64(ControllerRevision);
+      }
+      if (ActiveStateId != 0UL) {
+        output.WriteRawTag(24);
+        output.WriteUInt64(ActiveStateId);
+      }
+      if (ActiveStateName.Length != 0) {
+        output.WriteRawTag(34);
+        output.WriteString(ActiveStateName);
+      }
+      if (ActiveStateTime != 0F) {
+        output.WriteRawTag(45);
+        output.WriteFloat(ActiveStateTime);
+      }
+      if (Transitioning != false) {
+        output.WriteRawTag(48);
+        output.WriteBool(Transitioning);
+      }
+      if (DestinationStateId != 0UL) {
+        output.WriteRawTag(56);
+        output.WriteUInt64(DestinationStateId);
+      }
+      if (DestinationStateName.Length != 0) {
+        output.WriteRawTag(66);
+        output.WriteString(DestinationStateName);
+      }
+      if (DestinationStateTime != 0F) {
+        output.WriteRawTag(77);
+        output.WriteFloat(DestinationStateTime);
+      }
+      if (TransitionAlpha != 0F) {
+        output.WriteRawTag(85);
+        output.WriteFloat(TransitionAlpha);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (HasController != false) {
+        size += 1 + 1;
+      }
+      if (ControllerRevision != 0UL) {
+        size += 1 + pb::CodedOutputStream.ComputeUInt64Size(ControllerRevision);
+      }
+      if (ActiveStateId != 0UL) {
+        size += 1 + pb::CodedOutputStream.ComputeUInt64Size(ActiveStateId);
+      }
+      if (ActiveStateName.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(ActiveStateName);
+      }
+      if (ActiveStateTime != 0F) {
+        size += 1 + 4;
+      }
+      if (Transitioning != false) {
+        size += 1 + 1;
+      }
+      if (DestinationStateId != 0UL) {
+        size += 1 + pb::CodedOutputStream.ComputeUInt64Size(DestinationStateId);
+      }
+      if (DestinationStateName.Length != 0) {
+        size += 1 + pb::CodedOutputStream.ComputeStringSize(DestinationStateName);
+      }
+      if (DestinationStateTime != 0F) {
+        size += 1 + 4;
+      }
+      if (TransitionAlpha != 0F) {
+        size += 1 + 4;
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(AnimatorStateResult other) {
+      if (other == null) {
+        return;
+      }
+      if (other.HasController != false) {
+        HasController = other.HasController;
+      }
+      if (other.ControllerRevision != 0UL) {
+        ControllerRevision = other.ControllerRevision;
+      }
+      if (other.ActiveStateId != 0UL) {
+        ActiveStateId = other.ActiveStateId;
+      }
+      if (other.ActiveStateName.Length != 0) {
+        ActiveStateName = other.ActiveStateName;
+      }
+      if (other.ActiveStateTime != 0F) {
+        ActiveStateTime = other.ActiveStateTime;
+      }
+      if (other.Transitioning != false) {
+        Transitioning = other.Transitioning;
+      }
+      if (other.DestinationStateId != 0UL) {
+        DestinationStateId = other.DestinationStateId;
+      }
+      if (other.DestinationStateName.Length != 0) {
+        DestinationStateName = other.DestinationStateName;
+      }
+      if (other.DestinationStateTime != 0F) {
+        DestinationStateTime = other.DestinationStateTime;
+      }
+      if (other.TransitionAlpha != 0F) {
+        TransitionAlpha = other.TransitionAlpha;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            HasController = input.ReadBool();
+            break;
+          }
+          case 16: {
+            ControllerRevision = input.ReadUInt64();
+            break;
+          }
+          case 24: {
+            ActiveStateId = input.ReadUInt64();
+            break;
+          }
+          case 34: {
+            ActiveStateName = input.ReadString();
+            break;
+          }
+          case 45: {
+            ActiveStateTime = input.ReadFloat();
+            break;
+          }
+          case 48: {
+            Transitioning = input.ReadBool();
+            break;
+          }
+          case 56: {
+            DestinationStateId = input.ReadUInt64();
+            break;
+          }
+          case 66: {
+            DestinationStateName = input.ReadString();
+            break;
+          }
+          case 77: {
+            DestinationStateTime = input.ReadFloat();
+            break;
+          }
+          case 85: {
+            TransitionAlpha = input.ReadFloat();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            HasController = input.ReadBool();
+            break;
+          }
+          case 16: {
+            ControllerRevision = input.ReadUInt64();
+            break;
+          }
+          case 24: {
+            ActiveStateId = input.ReadUInt64();
+            break;
+          }
+          case 34: {
+            ActiveStateName = input.ReadString();
+            break;
+          }
+          case 45: {
+            ActiveStateTime = input.ReadFloat();
+            break;
+          }
+          case 48: {
+            Transitioning = input.ReadBool();
+            break;
+          }
+          case 56: {
+            DestinationStateId = input.ReadUInt64();
+            break;
+          }
+          case 66: {
+            DestinationStateName = input.ReadString();
+            break;
+          }
+          case 77: {
+            DestinationStateTime = input.ReadFloat();
+            break;
+          }
+          case 85: {
+            TransitionAlpha = input.ReadFloat();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class Vector4 : pb::IMessage<Vector4>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -13556,7 +14795,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13865,7 +15104,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14063,7 +15302,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14611,7 +15850,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14883,7 +16122,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15081,7 +16320,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[46]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15555,7 +16794,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[47]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -189,6 +189,169 @@ namespace SailorEditor.Services
             return Path.Combine(CurrentProjectRootPath, Path.Combine(parts.ToArray()));
         }
 
+        public async Task<AssetFile?> CreateAnimationAssetAsync(
+            AssetFolder? targetFolder,
+            bool createSet,
+            CancellationToken cancellationToken = default)
+        {
+            if (!TryGetWritableDestinationDirectory(
+                    targetFolder,
+                    out var destinationDirectory))
+            {
+                return null;
+            }
+
+            var extension = createSet ? ".animset" : ".animcontroller";
+            var baseName = createSet ? "New Animation Set" : "New Animation Controller";
+            var filename = GetUniqueAssetName(
+                destinationDirectory,
+                baseName,
+                extension);
+            var sourcePath = Path.Combine(destinationDirectory, filename);
+            var temporaryPath = Path.Combine(
+                destinationDirectory,
+                $".{filename}.{Guid.NewGuid():N}.tmp");
+
+            await _assetSaveLock.WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+            try
+            {
+                (FileSystemWatcher Watcher, bool Enabled)[] watcherStates;
+                lock (_watcherLock)
+                {
+                    watcherStates = _contentWatchers
+                        .Select(watcher =>
+                            (watcher, watcher.EnableRaisingEvents))
+                        .ToArray();
+                    foreach (var watcherState in watcherStates)
+                    {
+                        watcherState.Watcher.EnableRaisingEvents = false;
+                    }
+                }
+
+                try
+                {
+                    var source = createSet
+                        ? CreateAnimationSetSource()
+                        : CreateAnimationControllerSource();
+                    await File.WriteAllTextAsync(
+                            temporaryPath,
+                            source,
+                            cancellationToken)
+                        .ConfigureAwait(false);
+                    File.Move(temporaryPath, sourcePath);
+
+                    if (!await _engineService.RequestAssetReloadAsync(cancellationToken)
+                            .ConfigureAwait(false))
+                    {
+                        File.Delete(sourcePath);
+                        return null;
+                    }
+                }
+                finally
+                {
+                    lock (_watcherLock)
+                    {
+                        foreach (var watcherState in watcherStates)
+                        {
+                            if (_contentWatchers.Contains(watcherState.Watcher))
+                            {
+                                watcherState.Watcher.EnableRaisingEvents =
+                                    watcherState.Enabled;
+                            }
+                        }
+                    }
+                }
+
+                return await MainThread.InvokeOnMainThreadAsync(() =>
+                {
+                    var created = FindAssetBySourcePath(sourcePath);
+                    if (created is null)
+                    {
+                        Refresh();
+                        created = FindAssetBySourcePath(sourcePath);
+                    }
+                    return created;
+                });
+            }
+            catch
+            {
+                if (File.Exists(temporaryPath))
+                {
+                    File.Delete(temporaryPath);
+                }
+                throw;
+            }
+            finally
+            {
+                _assetSaveLock.Release();
+            }
+        }
+
+        AssetFile? FindAssetBySourcePath(string sourcePath) =>
+            Files.FirstOrDefault(asset =>
+                asset.Asset is not null &&
+                ProjectContentPathPolicy.IsSamePath(
+                    asset.Asset.FullName,
+                    sourcePath));
+
+        static string CreateAnimationControllerSource()
+        {
+            var stateId = BitConverter.ToUInt64(
+                System.Security.Cryptography.RandomNumberGenerator.GetBytes(
+                    sizeof(ulong)));
+            if (stateId == 0)
+            {
+                stateId = 1;
+            }
+            var root = new YamlMappingNode
+            {
+                { "version", "1" },
+                { "defaultState", stateId.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+                { "parameters", new YamlSequenceNode() },
+                {
+                    "states",
+                    new YamlSequenceNode
+                    {
+                        new YamlMappingNode
+                        {
+                            { "id", stateId.ToString(System.Globalization.CultureInfo.InvariantCulture) },
+                            { "name", "State" },
+                            { "clip", "Animation" },
+                            { "speed", "1" },
+                            { "loop", "true" },
+                            {
+                                "editor",
+                                new YamlMappingNode
+                                {
+                                    { "x", "32" },
+                                    { "y", "32" }
+                                }
+                            }
+                        }
+                    }
+                },
+                { "transitions", new YamlSequenceNode() }
+            };
+            return SaveYaml(root);
+        }
+
+        static string CreateAnimationSetSource() => SaveYaml(
+            new YamlMappingNode
+            {
+                { "version", "1" },
+                { "clips", new YamlSequenceNode() }
+            });
+
+        static string SaveYaml(YamlMappingNode root)
+        {
+            var yaml = new YamlStream(new YamlDocument(root));
+            using var writer = new StringWriter(
+                System.Globalization.CultureInfo.InvariantCulture);
+            yaml.Save(writer, false);
+            return writer.ToString();
+        }
+
         public PrefabFile? CreatePrefabAsset(
             AssetFolder? targetFolder,
             GameObject root,
@@ -1352,6 +1515,8 @@ namespace SailorEditor.Services
                 "Sailor::TextureAssetInfo" => new TextureFile(),
                 "Sailor::ModelAssetInfo" => new ModelFile(),
                 "Sailor::AnimationAssetInfo" => new AnimationFile(),
+                "Sailor::AnimationControllerAssetInfo" => new AnimationControllerFile(),
+                "Sailor::AnimationSetAssetInfo" => new AnimationSetFile(),
                 "Sailor::PrefabAssetInfo" => new PrefabFile(),
                 "Sailor::WorldPrefabAssetInfo" => new WorldFile(),
                 "Sailor::ShaderAssetInfo" when string.Equals(
@@ -1408,6 +1573,8 @@ namespace SailorEditor.Services
             ".png" or ".jpg" or ".tga" or ".bmp" or ".dds" or ".hdr" => new TextureFile(),
             ".obj" or ".gltf" or ".glb" => new ModelFile(),
             ".anim" => new AnimationFile(),
+            ".animcontroller" => new AnimationControllerFile(),
+            ".animset" => new AnimationSetFile(),
             ".prefab" => new PrefabFile(),
             ".world" => new WorldFile(),
             ".shader" => new ShaderFile(),

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -29,6 +29,7 @@ namespace SailorEditor.Services
         readonly SemaphoreSlim _assetSaveLock = new(1, 1);
         readonly SemaphoreSlim _folderLoadLock = new(1, 1);
         readonly AssetCacheIndexStore _assetCacheIndexStore = new();
+        Task _assetCacheIndexLoadTask = Task.CompletedTask;
         EngineLaunchContext? _activeLaunchContext;
         CancellationTokenSource? _pendingFilesystemReload;
         CancellationTokenSource? _assetCacheIndexLoadCancellation;
@@ -208,14 +209,21 @@ namespace SailorEditor.Services
                 baseName,
                 extension);
             var sourcePath = Path.Combine(destinationDirectory, filename);
-            var temporaryPath = Path.Combine(
-                destinationDirectory,
-                $".{filename}.{Guid.NewGuid():N}.tmp");
+            var fileId = new FileId(
+                Guid.NewGuid().ToString().ToUpperInvariant());
+            var sourceContents = createSet
+                ? CreateAnimationSetSource()
+                : CreateAnimationControllerSource();
+            var metadataContents = SerializeAnimationAssetInfo(
+                fileId,
+                filename,
+                createSet);
 
             await _assetSaveLock.WaitAsync(cancellationToken)
                 .ConfigureAwait(false);
             try
             {
+                ProjectContentAssetWriteTransaction transaction;
                 (FileSystemWatcher Watcher, bool Enabled)[] watcherStates;
                 lock (_watcherLock)
                 {
@@ -231,22 +239,13 @@ namespace SailorEditor.Services
 
                 try
                 {
-                    var source = createSet
-                        ? CreateAnimationSetSource()
-                        : CreateAnimationControllerSource();
-                    await File.WriteAllTextAsync(
-                            temporaryPath,
-                            source,
-                            cancellationToken)
-                        .ConfigureAwait(false);
-                    File.Move(temporaryPath, sourcePath);
-
-                    if (!await _engineService.RequestAssetReloadAsync(cancellationToken)
-                            .ConfigureAwait(false))
-                    {
-                        File.Delete(sourcePath);
-                        return null;
-                    }
+                    transaction = _fileOperations.BeginWriteAssetPair(
+                        CurrentProjectRootPath,
+                        sourcePath,
+                        sourceContents,
+                        metadataContents,
+                        fileId.Value,
+                        overwrite: false);
                 }
                 finally
                 {
@@ -263,24 +262,41 @@ namespace SailorEditor.Services
                     }
                 }
 
-                return await MainThread.InvokeOnMainThreadAsync(() =>
+                if (!transaction.Result.Succeeded)
                 {
-                    var created = FindAssetBySourcePath(sourcePath);
-                    if (created is null)
-                    {
-                        Refresh();
-                        created = FindAssetBySourcePath(sourcePath);
-                    }
-                    return created;
-                });
-            }
-            catch
-            {
-                if (File.Exists(temporaryPath))
-                {
-                    File.Delete(temporaryPath);
+                    return null;
                 }
-                throw;
+
+                AssetFile? created;
+                try
+                {
+                    created = await MainThread.InvokeOnMainThreadAsync(() =>
+                        PublishCreatedAnimationAsset(
+                            sourcePath,
+                            targetFolder,
+                            fileId));
+                }
+                catch
+                {
+                    transaction.Rollback();
+                    throw;
+                }
+
+                if (created is null)
+                {
+                    transaction.Rollback();
+                    return null;
+                }
+
+                var commit = transaction.Commit();
+                if (!commit.Succeeded)
+                {
+                    await MainThread.InvokeOnMainThreadAsync(Refresh);
+                    return null;
+                }
+
+                QueueAnimationAssetReload();
+                return created;
             }
             finally
             {
@@ -294,6 +310,77 @@ namespace SailorEditor.Services
                 ProjectContentPathPolicy.IsSamePath(
                     asset.Asset.FullName,
                     sourcePath));
+
+        AssetFile? PublishCreatedAnimationAsset(
+            string sourcePath,
+            AssetFolder? targetFolder,
+            FileId expectedFileId)
+        {
+            var created = FindAssetBySourcePath(sourcePath);
+            if (created is not null)
+            {
+                return created;
+            }
+
+            var destinationDirectory = Path.GetDirectoryName(sourcePath);
+            var liveFolder = targetFolder;
+            if (liveFolder is null ||
+                string.IsNullOrWhiteSpace(destinationDirectory) ||
+                !ProjectContentPathPolicy.IsSamePath(
+                    liveFolder.FullPath,
+                    destinationDirectory))
+            {
+                liveFolder = Folders.FirstOrDefault(folder =>
+                    !string.IsNullOrWhiteSpace(destinationDirectory) &&
+                    ProjectContentPathPolicy.IsSamePath(
+                        folder.FullPath,
+                        destinationDirectory));
+            }
+
+            var projectRootId = liveFolder?.ProjectRootId ??
+                (CurrentProjectMode == EditorProjectMode.Engine
+                    ? EngineProjectRootId
+                    : ActiveProjectRootId);
+            var asset = ReadAssetFile(
+                new FileInfo(sourcePath + ".asset"),
+                liveFolder?.Id ?? -1,
+                projectRootId,
+                isReadOnly: false);
+            if (asset.FileId is null || !asset.FileId.Equals(expectedFileId))
+            {
+                return null;
+            }
+
+            Files.Add(asset);
+            Assets[expectedFileId] = asset;
+            if (liveFolder is not null)
+            {
+                liveFolder.HasChildren = true;
+            }
+            Changed?.Invoke();
+            return asset;
+        }
+
+        void QueueAnimationAssetReload()
+            => _ = ReloadCreatedAnimationAssetAsync();
+
+        async Task ReloadCreatedAnimationAssetAsync()
+        {
+            try
+            {
+                if (!await _engineService.RequestAssetReloadAsync()
+                        .ConfigureAwait(false))
+                {
+                    Console.WriteLine(
+                        "[AssetsService] Engine did not register a newly created animation asset.");
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(
+                    $"[AssetsService] Failed to register a newly created animation asset: {exception.Message}");
+            }
+        }
 
         static string CreateAnimationControllerSource()
         {
@@ -341,6 +428,22 @@ namespace SailorEditor.Services
             {
                 { "version", "1" },
                 { "clips", new YamlSequenceNode() }
+            });
+
+        static string SerializeAnimationAssetInfo(
+            FileId fileId,
+            string filename,
+            bool createSet) => SaveYaml(
+            new YamlMappingNode
+            {
+                {
+                    "assetInfoType",
+                    createSet
+                        ? "Sailor::AnimationSetAssetInfo"
+                        : "Sailor::AnimationControllerAssetInfo"
+                },
+                { "fileId", fileId.Value },
+                { "filename", filename }
             });
 
         static string SaveYaml(YamlMappingNode root)
@@ -838,6 +941,108 @@ namespace SailorEditor.Services
             }
         }
 
+        public async Task<AssetFile?> ResolveAssetAsync(
+            FileId fileId,
+            CancellationToken cancellationToken = default)
+        {
+            if (fileId is null || fileId.IsEmpty())
+            {
+                return null;
+            }
+
+            var asset = await MainThread.InvokeOnMainThreadAsync(() =>
+                Assets.TryGetValue(fileId, out var current) ? current : null);
+            if (asset is null)
+            {
+                await Volatile.Read(ref _assetCacheIndexLoadTask)
+                    .WaitAsync(cancellationToken)
+                    .ConfigureAwait(false);
+                asset = await MainThread.InvokeOnMainThreadAsync(() =>
+                    Assets.TryGetValue(fileId, out var current) ? current : null);
+            }
+
+            if (asset is null)
+            {
+                return null;
+            }
+
+            var assetDirectory = asset.AssetInfo?.DirectoryName ??
+                asset.Asset?.DirectoryName;
+            if (string.IsNullOrWhiteSpace(assetDirectory))
+            {
+                return asset;
+            }
+
+            await EnsureAssetDirectoryLoadedAsync(
+                    assetDirectory,
+                    asset.IsReadOnly,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return await MainThread.InvokeOnMainThreadAsync(() =>
+                Assets.TryGetValue(fileId, out var current) ? current : asset);
+        }
+
+        async Task EnsureAssetDirectoryLoadedAsync(
+            string assetDirectory,
+            bool isReadOnly,
+            CancellationToken cancellationToken)
+        {
+            var targetDirectory = ProjectContentPathPolicy.NormalizeRoot(
+                assetDirectory);
+            var rootFolder = await MainThread.InvokeOnMainThreadAsync(() =>
+                Folders
+                    .Where(folder =>
+                        folder.ParentFolderId == -1 &&
+                        folder.IsReadOnly == isReadOnly &&
+                        ProjectContentPathPolicy.IsInsideRoot(
+                            folder.FullPath,
+                            targetDirectory))
+                    .OrderByDescending(folder => folder.FullPath.Length)
+                    .FirstOrDefault());
+            if (rootFolder is null)
+            {
+                return;
+            }
+
+            var relativeDirectory = Path.GetRelativePath(
+                rootFolder.FullPath,
+                targetDirectory);
+            var pathSegments = relativeDirectory == "."
+                ? Array.Empty<string>()
+                : relativeDirectory.Split(
+                    [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+                    StringSplitOptions.RemoveEmptyEntries);
+            var currentFolder = rootFolder;
+            var currentPath = ProjectContentPathPolicy.NormalizeRoot(
+                rootFolder.FullPath);
+            foreach (var pathSegment in pathSegments)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await EnsureFolderLoadedAsync(
+                        currentFolder.Id,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+
+                currentPath = ProjectContentPathPolicy.NormalizeRoot(
+                    Path.Combine(currentPath, pathSegment));
+                currentFolder = await MainThread.InvokeOnMainThreadAsync(() =>
+                    Folders.FirstOrDefault(folder =>
+                        folder.ParentFolderId == currentFolder.Id &&
+                        ProjectContentPathPolicy.IsSamePath(
+                            folder.FullPath,
+                            currentPath)));
+                if (currentFolder is null)
+                {
+                    return;
+                }
+            }
+
+            await EnsureFolderLoadedAsync(
+                    currentFolder.Id,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         public void ResetForWorkspaceChange()
         {
             Interlocked.Increment(ref _workspaceEpoch);
@@ -937,10 +1142,11 @@ namespace SailorEditor.Services
                 ref _assetCacheIndexLoadCancellation,
                 cancellation);
             previous?.Cancel();
-            _ = LoadAssetCacheIndexAsync(
+            var loadTask = LoadAssetCacheIndexAsync(
                 launchContext,
                 contentGeneration,
                 cancellation);
+            Volatile.Write(ref _assetCacheIndexLoadTask, loadTask);
         }
 
         async Task LoadAssetCacheIndexAsync(

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -2243,6 +2243,72 @@ namespace SailorEditor.Services
                 cancellationToken: cancellationToken);
         }
 
+        public Task<bool> SetAnimatorFloatAsync(
+            InstanceId instanceId,
+            string name,
+            float value,
+            CancellationToken cancellationToken = default) =>
+            InvokeRunningInteropAsync(
+                token => protocolClient.SetAnimatorFloatAsync(
+                    instanceId?.Value ?? string.Empty,
+                    name,
+                    value,
+                    token),
+                cancellationToken: cancellationToken);
+
+        public Task<bool> SetAnimatorIntAsync(
+            InstanceId instanceId,
+            string name,
+            int value,
+            CancellationToken cancellationToken = default) =>
+            InvokeRunningInteropAsync(
+                token => protocolClient.SetAnimatorIntAsync(
+                    instanceId?.Value ?? string.Empty,
+                    name,
+                    value,
+                    token),
+                cancellationToken: cancellationToken);
+
+        public Task<bool> SetAnimatorBoolAsync(
+            InstanceId instanceId,
+            string name,
+            bool value,
+            CancellationToken cancellationToken = default) =>
+            InvokeRunningInteropAsync(
+                token => protocolClient.SetAnimatorBoolAsync(
+                    instanceId?.Value ?? string.Empty,
+                    name,
+                    value,
+                    token),
+                cancellationToken: cancellationToken);
+
+        public Task<bool> SetAnimatorTriggerAsync(
+            InstanceId instanceId,
+            string name,
+            bool reset = false,
+            CancellationToken cancellationToken = default) =>
+            InvokeRunningInteropAsync(
+                token => protocolClient.SetAnimatorTriggerAsync(
+                    instanceId?.Value ?? string.Empty,
+                    name,
+                    reset,
+                    token),
+                cancellationToken: cancellationToken);
+
+        public async Task<EngineProtocolAnimatorState?> GetAnimatorStateAsync(
+            InstanceId instanceId,
+            CancellationToken cancellationToken = default)
+        {
+            if (!IsInteropRunning() || instanceId is null || instanceId.IsEmpty())
+            {
+                return null;
+            }
+            return await protocolClient.GetAnimatorStateAsync(
+                    instanceId.Value,
+                    cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         public async Task<bool> RequestAssetReloadAsync(CancellationToken cancellationToken = default)
         {
             var generation = Volatile.Read(ref engineGeneration);

--- a/Editor/Services/SelectionService.cs
+++ b/Editor/Services/SelectionService.cs
@@ -26,7 +26,9 @@ namespace SailorEditor.Services
             _selectionStore.Changed += snapshot =>
             {
                 var selectedId = InstanceId.NullInstanceId;
-                if (!string.IsNullOrWhiteSpace(snapshot.SelectedId))
+                if ((snapshot.Kind is SelectionTargetKind.GameObject or
+                        SelectionTargetKind.Component) &&
+                    !string.IsNullOrWhiteSpace(snapshot.SelectedId))
                 {
                     selectedId = new InstanceId(snapshot.SelectedId);
                 }
@@ -73,6 +75,11 @@ namespace SailorEditor.Services
         }
 
         public async void SelectObject(ObservableObject obj, bool force = false)
+            => await SelectObjectAsync(obj, force);
+
+        public async Task SelectObjectAsync(
+            ObservableObject obj,
+            bool force = false)
         {
             if (IsWorkspaceChangeInProgress)
                 return;
@@ -270,6 +277,7 @@ namespace SailorEditor.Services
         {
             GameObject gameObject => gameObject.InstanceId?.Value,
             Component component => component.InstanceId?.Value,
+            AssetFile assetFile => assetFile.FileId?.Value,
             _ => null,
         };
 

--- a/Editor/Utility/EngineTypes.cs
+++ b/Editor/Utility/EngineTypes.cs
@@ -11,7 +11,6 @@ using System.Globalization;
 using YamlDotNet.Serialization.NamingConventions;
 using SailorEngine;
 using System.Xml.Linq;
-using System.Text.RegularExpressions;
 using SailorEditor.Helpers;
 using SailorEditor.Utility;
 using System.ComponentModel;
@@ -222,22 +221,14 @@ namespace SailorEngine
 
         static string GetGenericTypeName(string engineType)
         {
-            var genericMatch = Regex.Match(engineType, @"<(.+?)>");
-            if (genericMatch.Success)
+            const string objectPtrPrefix = "TObjectPtr<";
+            if (engineType.StartsWith(objectPtrPrefix, StringComparison.Ordinal) &&
+                engineType.EndsWith('>'))
             {
-                return genericMatch.Groups[1].Value;
+                return engineType[objectPtrPrefix.Length..^1];
             }
 
-            return engineType switch
-            {
-                "N6Sailor10TObjectPtrINS_5ModelEEE" => "Sailor::Model",
-                "N6Sailor10TObjectPtrINS_7TextureEEE" => "Sailor::Texture",
-                "N6Sailor10TObjectPtrINS_8MaterialEEE" => "Sailor::Material",
-                "N6Sailor10TObjectPtrINS_6ShaderEEE" => "Sailor::Shader",
-                "N6Sailor10TObjectPtrINS_9AnimationEEE" => "Sailor::Animation",
-                "N6Sailor10TObjectPtrINS_21MeshRendererComponentEEE" => "Sailor::MeshRendererComponent",
-                _ => ""
-            };
+            return "";
         }
 
         public static EngineTypes FromYaml(string yamlContent)

--- a/Editor/Utility/EngineTypes.cs
+++ b/Editor/Utility/EngineTypes.cs
@@ -191,6 +191,12 @@ namespace SailorEngine
                 "class Sailor::Material" => typeof(MaterialFile),
                 "Sailor::Shader" => typeof(ShaderFile),
                 "class Sailor::Shader" => typeof(ShaderFile),
+                "Sailor::Animation" => typeof(AnimationFile),
+                "class Sailor::Animation" => typeof(AnimationFile),
+                "Sailor::AnimationController" => typeof(AnimationControllerFile),
+                "class Sailor::AnimationController" => typeof(AnimationControllerFile),
+                "Sailor::AnimationSet" => typeof(AnimationSetFile),
+                "class Sailor::AnimationSet" => typeof(AnimationSetFile),
                 _ => null
             };
 

--- a/Editor/ViewModels/AnimationControllerFile.cs
+++ b/Editor/ViewModels/AnimationControllerFile.cs
@@ -325,10 +325,15 @@ public partial class AnimationControllerFile : AssetFile
 
     void LoadControllerRoot(YamlMappingNode root)
     {
-        DefaultStateId = ReadUInt64(root, "defaultState");
-        Parameters = ReadList(root, "parameters", AnimationControllerParameter.FromYaml);
-        States = ReadList(root, "states", AnimationControllerState.FromYaml);
-        Transitions = ReadList(root, "transitions", AnimationControllerTransition.FromYaml);
+        var defaultStateId = ReadUInt64(root, "defaultState");
+        var parameters = ReadList(root, "parameters", AnimationControllerParameter.FromYaml);
+        var states = ReadList(root, "states", AnimationControllerState.FromYaml);
+        var transitions = ReadList(root, "transitions", AnimationControllerTransition.FromYaml);
+
+        DefaultStateId = defaultStateId;
+        Parameters = parameters;
+        States = states;
+        Transitions = transitions;
         TrackList(Parameters, nameof(Parameters));
         TrackList(States, nameof(States));
         TrackList(Transitions, nameof(Transitions));
@@ -500,9 +505,16 @@ public partial class AnimationControllerParameter : ObservableObject
 
     public static AnimationControllerParameter FromYaml(YamlMappingNode node)
     {
-        _ = Enum.TryParse<AnimationControllerParameterType>(
-            AnimationControllerFile.ReadString(node, "type", "Float"),
-            out var type);
+        var serializedType = AnimationControllerFile.ReadString(node, "type", "Float");
+        if (!Enum.TryParse<AnimationControllerParameterType>(
+                serializedType,
+                ignoreCase: false,
+                out var type) ||
+            !Enum.IsDefined(type))
+        {
+            throw new InvalidDataException(
+                $"Unknown animation parameter type '{serializedType}'.");
+        }
         var result = new AnimationControllerParameter
         {
             Id = AnimationControllerFile.ReadUInt64(node, "id"),
@@ -625,9 +637,19 @@ public partial class AnimationControllerCondition : ObservableObject
 
     public static AnimationControllerCondition FromYaml(YamlMappingNode node)
     {
-        _ = Enum.TryParse<AnimationControllerConditionOperation>(
-            AnimationControllerFile.ReadString(node, "operation", "Equal"),
-            out var operation);
+        var serializedOperation = AnimationControllerFile.ReadString(
+            node,
+            "operation",
+            "Equal");
+        if (!Enum.TryParse<AnimationControllerConditionOperation>(
+                serializedOperation,
+                ignoreCase: false,
+                out var operation) ||
+            !Enum.IsDefined(operation))
+        {
+            throw new InvalidDataException(
+                $"Unknown animation condition operation '{serializedOperation}'.");
+        }
         return new AnimationControllerCondition
         {
             ParameterId = AnimationControllerFile.ReadUInt64(node, "parameter"),

--- a/Editor/ViewModels/AnimationControllerFile.cs
+++ b/Editor/ViewModels/AnimationControllerFile.cs
@@ -1,0 +1,831 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using SailorEngine;
+using SailorEditor.Utility;
+using System.ComponentModel;
+using System.Globalization;
+using System.Security.Cryptography;
+using YamlDotNet.RepresentationModel;
+
+namespace SailorEditor.ViewModels;
+
+public enum AnimationControllerParameterType
+{
+    Float,
+    Int,
+    Bool,
+    Trigger
+}
+
+public enum AnimationControllerConditionOperation
+{
+    Equal,
+    NotEqual,
+    Less,
+    LessOrEqual,
+    Greater,
+    GreaterOrEqual,
+    IsSet
+}
+
+public partial class AnimationControllerFile : AssetFile
+{
+    public event Action? DocumentReplaced;
+
+    public ObservableList<AnimationControllerParameter> Parameters { get; private set; } = [];
+    public ObservableList<AnimationControllerState> States { get; private set; } = [];
+    public ObservableList<AnimationControllerTransition> Transitions { get; private set; } = [];
+
+    public ulong DefaultStateId { get; private set; }
+
+    public override Task Save()
+    {
+        EnsureWritable();
+        ValidateDocument();
+        if (!string.IsNullOrEmpty(LoadWarning))
+        {
+            throw new InvalidDataException(LoadWarning);
+        }
+
+        SaveControllerSource();
+        return base.Save();
+    }
+
+    public override Task Revert()
+    {
+        try
+        {
+            RunWithoutDirtyTracking(() =>
+            {
+                LoadAssetPropertiesFromAssetInfo();
+                LoadControllerSource();
+                DisplayName = Asset.Name;
+                IsLoaded = false;
+            });
+        }
+        catch (Exception exception)
+        {
+            SetLoadError(exception);
+        }
+
+        ResetDirtyState();
+        DocumentReplaced?.Invoke();
+        return Task.CompletedTask;
+    }
+
+    public string CaptureDocument()
+    {
+        var stream = new YamlStream(new YamlDocument(BuildControllerYaml()));
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        stream.Save(writer, false);
+        return writer.ToString();
+    }
+
+    public bool ApplyDocument(string yaml, bool markDirty = true)
+    {
+        var stream = new YamlStream();
+        using var reader = new StringReader(yaml ?? string.Empty);
+        stream.Load(reader);
+        if (stream.Documents.Count != 1 ||
+            stream.Documents[0].RootNode is not YamlMappingNode root)
+        {
+            return false;
+        }
+
+        RunWithoutDirtyTracking(() => LoadControllerRoot(root));
+        if (markDirty)
+        {
+            MarkDirty(nameof(States));
+        }
+        else
+        {
+            ResetDirtyState();
+        }
+        DocumentReplaced?.Invoke();
+        return true;
+    }
+
+    public AnimationControllerState AddState(double x = 32.0, double y = 32.0)
+    {
+        var id = CreateStableId();
+        var state = new AnimationControllerState
+        {
+            Id = id,
+            Name = GetUniqueName("State", States.Select(item => item.Name)),
+            Clip = "Animation",
+            EditorX = (float)x,
+            EditorY = (float)y
+        };
+        States.Add(state);
+        if (DefaultStateId == 0)
+        {
+            DefaultStateId = id;
+        }
+        ValidateDocument();
+        return state;
+    }
+
+    public bool RemoveState(AnimationControllerState? state)
+    {
+        if (state is null || !States.Remove(state))
+        {
+            return false;
+        }
+
+        foreach (var transition in Transitions
+            .Where(item => item.FromStateId == state.Id || item.ToStateId == state.Id)
+            .ToArray())
+        {
+            Transitions.Remove(transition);
+        }
+        if (DefaultStateId == state.Id)
+        {
+            DefaultStateId = States.FirstOrDefault()?.Id ?? 0;
+        }
+        ValidateDocument();
+        return true;
+    }
+
+    public void SetDefaultState(AnimationControllerState? state)
+    {
+        if (state is not null && States.Contains(state))
+        {
+            DefaultStateId = state.Id;
+            MarkDirty(nameof(DefaultStateId));
+            ValidateDocument();
+        }
+    }
+
+    public AnimationControllerParameter AddParameter(
+        AnimationControllerParameterType type = AnimationControllerParameterType.Float)
+    {
+        var parameter = new AnimationControllerParameter
+        {
+            Id = CreateStableId(),
+            Name = GetUniqueName("Parameter", Parameters.Select(item => item.Name)),
+            Type = type
+        };
+        Parameters.Add(parameter);
+        ValidateDocument();
+        return parameter;
+    }
+
+    public bool RemoveParameter(AnimationControllerParameter? parameter)
+    {
+        if (parameter is null || !Parameters.Remove(parameter))
+        {
+            return false;
+        }
+
+        foreach (var transition in Transitions)
+        {
+            foreach (var condition in transition.Conditions
+                .Where(item => item.ParameterId == parameter.Id)
+                .ToArray())
+            {
+                transition.Conditions.Remove(condition);
+            }
+        }
+        ValidateDocument();
+        return true;
+    }
+
+    public AnimationControllerTransition? AddTransition(
+        AnimationControllerState? from,
+        AnimationControllerState? to)
+    {
+        if (from is null || to is null || !States.Contains(from) || !States.Contains(to))
+        {
+            return null;
+        }
+
+        var transition = new AnimationControllerTransition
+        {
+            Id = CreateStableId(),
+            FromStateId = from.Id,
+            ToStateId = to.Id
+        };
+        Transitions.Add(transition);
+        ValidateDocument();
+        return transition;
+    }
+
+    public bool RemoveTransition(AnimationControllerTransition? transition)
+    {
+        var removed = transition is not null && Transitions.Remove(transition);
+        if (removed)
+        {
+            ValidateDocument();
+        }
+        return removed;
+    }
+
+    public AnimationControllerCondition? AddCondition(
+        AnimationControllerTransition? transition,
+        AnimationControllerParameter? parameter)
+    {
+        if (transition is null || parameter is null ||
+            !Transitions.Contains(transition) || !Parameters.Contains(parameter))
+        {
+            return null;
+        }
+
+        var condition = new AnimationControllerCondition
+        {
+            ParameterId = parameter.Id,
+            Operation = parameter.Type == AnimationControllerParameterType.Trigger
+                ? AnimationControllerConditionOperation.IsSet
+                : AnimationControllerConditionOperation.Equal
+        };
+        transition.Conditions.Add(condition);
+        ValidateDocument();
+        return condition;
+    }
+
+    public void ValidateDocument()
+    {
+        var errors = new List<string>();
+        if (States.Count == 0)
+        {
+            errors.Add("The controller must contain at least one state.");
+        }
+        if (States.All(state => state.Id != DefaultStateId))
+        {
+            errors.Add("Default state is missing.");
+        }
+        AddDuplicateErrors(
+            Parameters.Select(parameter => parameter.Id),
+            "Parameter stable IDs must be non-zero and unique.",
+            errors);
+        AddDuplicateErrors(
+            Parameters.Select(parameter => parameter.Name),
+            "Parameter names must be non-empty and unique.",
+            errors);
+        AddDuplicateErrors(
+            States.Select(state => state.Id),
+            "State stable IDs must be non-zero and unique.",
+            errors);
+        AddDuplicateErrors(
+            States.Select(state => state.Name),
+            "State names must be non-empty and unique.",
+            errors);
+        AddDuplicateErrors(
+            Transitions.Select(transition => transition.Id),
+            "Transition stable IDs must be non-zero and unique.",
+            errors);
+
+        var stateIds = States.Select(state => state.Id).ToHashSet();
+        var parameters = new Dictionary<ulong, AnimationControllerParameter>();
+        foreach (var parameter in Parameters)
+        {
+            parameters.TryAdd(parameter.Id, parameter);
+        }
+        foreach (var state in States)
+        {
+            if (string.IsNullOrWhiteSpace(state.Clip) || state.Speed <= 0.0f ||
+                !float.IsFinite(state.Speed) || !float.IsFinite(state.EditorX) ||
+                !float.IsFinite(state.EditorY))
+            {
+                errors.Add($"State '{state.Name}' requires a clip slot and finite positive speed/position.");
+            }
+        }
+        foreach (var transition in Transitions)
+        {
+            if (!stateIds.Contains(transition.FromStateId) ||
+                !stateIds.Contains(transition.ToStateId) ||
+                transition.Duration < 0.0f || !float.IsFinite(transition.Duration) ||
+                transition.ExitTime is < 0.0f or > 1.0f || !float.IsFinite(transition.ExitTime))
+            {
+                errors.Add($"Transition {transition.Id} contains invalid states or timing.");
+            }
+            foreach (var condition in transition.Conditions)
+            {
+                if (!parameters.TryGetValue(condition.ParameterId, out var parameter) ||
+                    !IsOperationValid(parameter.Type, condition.Operation))
+                {
+                    errors.Add($"Transition {transition.Id} contains an invalid typed condition.");
+                }
+            }
+        }
+
+        LoadWarning = string.Join(Environment.NewLine, errors.Distinct());
+    }
+
+    void LoadControllerSource()
+    {
+        var stream = new YamlStream();
+        using var reader = new StreamReader(Asset.FullName);
+        stream.Load(reader);
+        if (stream.Documents.Count != 1 ||
+            stream.Documents[0].RootNode is not YamlMappingNode root)
+        {
+            throw new InvalidDataException($"Animation controller must contain one YAML mapping: {Asset.FullName}");
+        }
+        LoadControllerRoot(root);
+    }
+
+    void LoadControllerRoot(YamlMappingNode root)
+    {
+        DefaultStateId = ReadUInt64(root, "defaultState");
+        Parameters = ReadList(root, "parameters", AnimationControllerParameter.FromYaml);
+        States = ReadList(root, "states", AnimationControllerState.FromYaml);
+        Transitions = ReadList(root, "transitions", AnimationControllerTransition.FromYaml);
+        TrackList(Parameters, nameof(Parameters));
+        TrackList(States, nameof(States));
+        TrackList(Transitions, nameof(Transitions));
+        ValidateDocument();
+        OnPropertyChanged(nameof(Parameters));
+        OnPropertyChanged(nameof(States));
+        OnPropertyChanged(nameof(Transitions));
+        OnPropertyChanged(nameof(DefaultStateId));
+    }
+
+    void SaveControllerSource()
+    {
+        var stream = new YamlStream(new YamlDocument(BuildControllerYaml()));
+        using var writer = new StreamWriter(new FileStream(Asset.FullName, FileMode.Create));
+        stream.Save(writer, false);
+    }
+
+    YamlMappingNode BuildControllerYaml() => new()
+    {
+        { "version", "1" },
+        { "defaultState", DefaultStateId.ToString(CultureInfo.InvariantCulture) },
+        { "parameters", WriteList(Parameters, item => item.ToYaml()) },
+        { "states", WriteList(States, item => item.ToYaml()) },
+        { "transitions", WriteList(Transitions, item => item.ToYaml()) }
+    };
+
+    void TrackList<T>(ObservableList<T> list, string propertyName)
+        where T : INotifyPropertyChanged
+    {
+        list.CollectionChanged += (_, _) =>
+        {
+            MarkDirty(propertyName);
+            ValidateDocument();
+        };
+        list.ItemChanged += (_, _) =>
+        {
+            MarkDirty(propertyName);
+            ValidateDocument();
+        };
+    }
+
+    ulong CreateStableId()
+    {
+        var existing = Parameters.Select(item => item.Id)
+            .Concat(States.Select(item => item.Id))
+            .Concat(Transitions.Select(item => item.Id))
+            .ToHashSet();
+        ulong id;
+        do
+        {
+            id = BitConverter.ToUInt64(
+                RandomNumberGenerator.GetBytes(sizeof(ulong)));
+        } while (id == 0 || existing.Contains(id));
+        return id;
+    }
+
+    static ObservableList<T> ReadList<T>(
+        YamlMappingNode root,
+        string key,
+        Func<YamlMappingNode, T> factory)
+        where T : INotifyPropertyChanged
+    {
+        var result = new ObservableList<T>();
+        if (root.Children.TryGetValue(new YamlScalarNode(key), out var value) &&
+            value is YamlSequenceNode sequence)
+        {
+            foreach (var node in sequence.Children.OfType<YamlMappingNode>())
+            {
+                result.Add(factory(node));
+            }
+        }
+        return result;
+    }
+
+    static YamlSequenceNode WriteList<T>(
+        IEnumerable<T> values,
+        Func<T, YamlMappingNode> serialize)
+    {
+        var result = new YamlSequenceNode();
+        foreach (var value in values)
+        {
+            result.Add(serialize(value));
+        }
+        return result;
+    }
+
+    static void AddDuplicateErrors<T>(
+        IEnumerable<T> values,
+        string message,
+        ICollection<string> errors)
+    {
+        var materialized = values.ToArray();
+        if (materialized.Any(value => value is null ||
+                value is string text && string.IsNullOrWhiteSpace(text) ||
+                value is ulong id && id == 0) ||
+            materialized.Distinct().Count() != materialized.Length)
+        {
+            errors.Add(message);
+        }
+    }
+
+    static bool IsOperationValid(
+        AnimationControllerParameterType type,
+        AnimationControllerConditionOperation operation) => type switch
+    {
+        AnimationControllerParameterType.Trigger => operation == AnimationControllerConditionOperation.IsSet,
+        AnimationControllerParameterType.Bool => operation is AnimationControllerConditionOperation.Equal or AnimationControllerConditionOperation.NotEqual,
+        _ => operation != AnimationControllerConditionOperation.IsSet
+    };
+
+    static string GetUniqueName(string prefix, IEnumerable<string> existing)
+    {
+        var names = existing.ToHashSet(StringComparer.Ordinal);
+        if (!names.Contains(prefix))
+        {
+            return prefix;
+        }
+        for (var index = 2; ; ++index)
+        {
+            var candidate = $"{prefix} {index}";
+            if (!names.Contains(candidate))
+            {
+                return candidate;
+            }
+        }
+    }
+
+    internal static string ReadString(YamlMappingNode node, string key, string fallback = "") =>
+        node.Children.TryGetValue(new YamlScalarNode(key), out var value) &&
+        value is YamlScalarNode scalar ? scalar.Value ?? fallback : fallback;
+
+    internal static ulong ReadUInt64(YamlMappingNode node, string key, ulong fallback = 0) =>
+        ulong.TryParse(ReadString(node, key), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ? value : fallback;
+
+    internal static int ReadInt(YamlMappingNode node, string key, int fallback = 0) =>
+        int.TryParse(ReadString(node, key), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ? value : fallback;
+
+    internal static float ReadFloat(YamlMappingNode node, string key, float fallback = 0.0f) =>
+        float.TryParse(ReadString(node, key), NumberStyles.Float, CultureInfo.InvariantCulture, out var value) ? value : fallback;
+
+    internal static bool ReadBool(YamlMappingNode node, string key, bool fallback = false) =>
+        bool.TryParse(ReadString(node, key), out var value) ? value : fallback;
+
+    internal static YamlScalarNode Scalar(ulong value) => new(value.ToString(CultureInfo.InvariantCulture));
+    internal static YamlScalarNode Scalar(int value) => new(value.ToString(CultureInfo.InvariantCulture));
+    internal static YamlScalarNode Scalar(float value) => new(value.ToString("R", CultureInfo.InvariantCulture));
+    internal static YamlScalarNode Scalar(bool value) => new(value ? "true" : "false");
+}
+
+public partial class AnimationControllerParameter : ObservableObject
+{
+    [ObservableProperty]
+    ulong id;
+
+    [ObservableProperty]
+    string name = string.Empty;
+
+    [ObservableProperty]
+    AnimationControllerParameterType type;
+
+    [ObservableProperty]
+    float defaultFloat;
+
+    [ObservableProperty]
+    int defaultInt;
+
+    [ObservableProperty]
+    bool defaultBool;
+
+    public static AnimationControllerParameter FromYaml(YamlMappingNode node)
+    {
+        _ = Enum.TryParse<AnimationControllerParameterType>(
+            AnimationControllerFile.ReadString(node, "type", "Float"),
+            out var type);
+        var result = new AnimationControllerParameter
+        {
+            Id = AnimationControllerFile.ReadUInt64(node, "id"),
+            Name = AnimationControllerFile.ReadString(node, "name"),
+            Type = type
+        };
+        switch (type)
+        {
+            case AnimationControllerParameterType.Float:
+                result.DefaultFloat = AnimationControllerFile.ReadFloat(node, "default");
+                break;
+            case AnimationControllerParameterType.Int:
+                result.DefaultInt = AnimationControllerFile.ReadInt(node, "default");
+                break;
+            case AnimationControllerParameterType.Bool:
+                result.DefaultBool = AnimationControllerFile.ReadBool(node, "default");
+                break;
+        }
+        return result;
+    }
+
+    public YamlMappingNode ToYaml()
+    {
+        var result = new YamlMappingNode
+        {
+            { "id", AnimationControllerFile.Scalar(Id) },
+            { "name", Name ?? string.Empty },
+            { "type", Type.ToString() }
+        };
+        switch (Type)
+        {
+            case AnimationControllerParameterType.Float:
+                result.Add("default", AnimationControllerFile.Scalar(DefaultFloat));
+                break;
+            case AnimationControllerParameterType.Int:
+                result.Add("default", AnimationControllerFile.Scalar(DefaultInt));
+                break;
+            case AnimationControllerParameterType.Bool:
+                result.Add("default", AnimationControllerFile.Scalar(DefaultBool));
+                break;
+        }
+        return result;
+    }
+}
+
+public partial class AnimationControllerState : ObservableObject
+{
+    [ObservableProperty]
+    ulong id;
+
+    [ObservableProperty]
+    string name = string.Empty;
+
+    [ObservableProperty]
+    string clip = string.Empty;
+
+    [ObservableProperty]
+    float speed = 1.0f;
+
+    [ObservableProperty]
+    bool loop = true;
+
+    [ObservableProperty]
+    float editorX;
+
+    [ObservableProperty]
+    float editorY;
+
+    public static AnimationControllerState FromYaml(YamlMappingNode node)
+    {
+        var editor = node.Children.TryGetValue(new YamlScalarNode("editor"), out var value)
+            ? value as YamlMappingNode
+            : null;
+        return new AnimationControllerState
+        {
+            Id = AnimationControllerFile.ReadUInt64(node, "id"),
+            Name = AnimationControllerFile.ReadString(node, "name"),
+            Clip = AnimationControllerFile.ReadString(node, "clip"),
+            Speed = AnimationControllerFile.ReadFloat(node, "speed", 1.0f),
+            Loop = AnimationControllerFile.ReadBool(node, "loop", true),
+            EditorX = editor is null ? 0.0f : AnimationControllerFile.ReadFloat(editor, "x"),
+            EditorY = editor is null ? 0.0f : AnimationControllerFile.ReadFloat(editor, "y")
+        };
+    }
+
+    public YamlMappingNode ToYaml() => new()
+    {
+        { "id", AnimationControllerFile.Scalar(Id) },
+        { "name", Name ?? string.Empty },
+        { "clip", Clip ?? string.Empty },
+        { "speed", AnimationControllerFile.Scalar(Speed) },
+        { "loop", AnimationControllerFile.Scalar(Loop) },
+        {
+            "editor",
+            new YamlMappingNode
+            {
+                { "x", AnimationControllerFile.Scalar(EditorX) },
+                { "y", AnimationControllerFile.Scalar(EditorY) }
+            }
+        }
+    };
+}
+
+public partial class AnimationControllerCondition : ObservableObject
+{
+    [ObservableProperty]
+    ulong parameterId;
+
+    [ObservableProperty]
+    AnimationControllerConditionOperation operation;
+
+    [ObservableProperty]
+    float floatValue;
+
+    [ObservableProperty]
+    int intValue;
+
+    [ObservableProperty]
+    bool boolValue;
+
+    public static AnimationControllerCondition FromYaml(YamlMappingNode node)
+    {
+        _ = Enum.TryParse<AnimationControllerConditionOperation>(
+            AnimationControllerFile.ReadString(node, "operation", "Equal"),
+            out var operation);
+        return new AnimationControllerCondition
+        {
+            ParameterId = AnimationControllerFile.ReadUInt64(node, "parameter"),
+            Operation = operation,
+            FloatValue = AnimationControllerFile.ReadFloat(node, "floatValue"),
+            IntValue = AnimationControllerFile.ReadInt(node, "intValue"),
+            BoolValue = AnimationControllerFile.ReadBool(node, "boolValue")
+        };
+    }
+
+    public YamlMappingNode ToYaml() => new()
+    {
+        { "parameter", AnimationControllerFile.Scalar(ParameterId) },
+        { "operation", Operation.ToString() },
+        { "floatValue", AnimationControllerFile.Scalar(FloatValue) },
+        { "intValue", AnimationControllerFile.Scalar(IntValue) },
+        { "boolValue", AnimationControllerFile.Scalar(BoolValue) }
+    };
+}
+
+public partial class AnimationControllerTransition : ObservableObject
+{
+    public AnimationControllerTransition()
+    {
+        Conditions.CollectionChanged += (_, _) => OnPropertyChanged(nameof(Conditions));
+        Conditions.ItemChanged += (_, _) => OnPropertyChanged(nameof(Conditions));
+    }
+
+    [ObservableProperty]
+    ulong id;
+
+    [ObservableProperty]
+    ulong fromStateId;
+
+    [ObservableProperty]
+    ulong toStateId;
+
+    [ObservableProperty]
+    int priority;
+
+    [ObservableProperty]
+    float duration = 0.2f;
+
+    [ObservableProperty]
+    bool hasExitTime;
+
+    [ObservableProperty]
+    float exitTime;
+
+    public ObservableList<AnimationControllerCondition> Conditions { get; } = [];
+
+    public static AnimationControllerTransition FromYaml(YamlMappingNode node)
+    {
+        var result = new AnimationControllerTransition
+        {
+            Id = AnimationControllerFile.ReadUInt64(node, "id"),
+            FromStateId = AnimationControllerFile.ReadUInt64(node, "from"),
+            ToStateId = AnimationControllerFile.ReadUInt64(node, "to"),
+            Priority = AnimationControllerFile.ReadInt(node, "priority"),
+            Duration = AnimationControllerFile.ReadFloat(node, "duration", 0.2f),
+            HasExitTime = AnimationControllerFile.ReadBool(node, "hasExitTime"),
+            ExitTime = AnimationControllerFile.ReadFloat(node, "exitTime")
+        };
+        if (node.Children.TryGetValue(new YamlScalarNode("conditions"), out var value) &&
+            value is YamlSequenceNode sequence)
+        {
+            foreach (var condition in sequence.Children.OfType<YamlMappingNode>())
+            {
+                result.Conditions.Add(AnimationControllerCondition.FromYaml(condition));
+            }
+        }
+        return result;
+    }
+
+    public YamlMappingNode ToYaml()
+    {
+        var conditions = new YamlSequenceNode();
+        foreach (var condition in Conditions)
+        {
+            conditions.Add(condition.ToYaml());
+        }
+        return new YamlMappingNode
+        {
+            { "id", AnimationControllerFile.Scalar(Id) },
+            { "from", AnimationControllerFile.Scalar(FromStateId) },
+            { "to", AnimationControllerFile.Scalar(ToStateId) },
+            { "priority", AnimationControllerFile.Scalar(Priority) },
+            { "duration", AnimationControllerFile.Scalar(Duration) },
+            { "hasExitTime", AnimationControllerFile.Scalar(HasExitTime) },
+            { "exitTime", AnimationControllerFile.Scalar(ExitTime) },
+            { "conditions", conditions }
+        };
+    }
+}
+
+public partial class AnimationSetFile : AssetFile
+{
+    public ObservableList<AnimationSetClip> Clips { get; private set; } = [];
+
+    public override Task Save()
+    {
+        EnsureWritable();
+        var duplicateSlots = Clips
+            .GroupBy(clip => clip.Slot, StringComparer.Ordinal)
+            .Any(group => string.IsNullOrWhiteSpace(group.Key) || group.Count() > 1);
+        if (duplicateSlots || Clips.Any(clip => clip.Animation is null || clip.Animation.IsEmpty()))
+        {
+            throw new InvalidDataException("Animation set slots must be unique and reference an animation FileId.");
+        }
+        SaveSetSource();
+        return base.Save();
+    }
+
+    public override Task Revert()
+    {
+        try
+        {
+            RunWithoutDirtyTracking(() =>
+            {
+                LoadAssetPropertiesFromAssetInfo();
+                LoadSetSource();
+                DisplayName = Asset.Name;
+                IsLoaded = false;
+            });
+        }
+        catch (Exception exception)
+        {
+            SetLoadError(exception);
+        }
+        ResetDirtyState();
+        return Task.CompletedTask;
+    }
+
+    public AnimationSetClip AddClip()
+    {
+        var clip = new AnimationSetClip { Slot = "Animation" };
+        Clips.Add(clip);
+        return clip;
+    }
+
+    void LoadSetSource()
+    {
+        var stream = new YamlStream();
+        using var reader = new StreamReader(Asset.FullName);
+        stream.Load(reader);
+        var root = stream.Documents.Count == 1
+            ? stream.Documents[0].RootNode as YamlMappingNode
+            : null;
+        if (root is null)
+        {
+            throw new InvalidDataException($"Animation set must contain one YAML mapping: {Asset.FullName}");
+        }
+
+        Clips = [];
+        if (root.Children.TryGetValue(new YamlScalarNode("clips"), out var value) &&
+            value is YamlSequenceNode sequence)
+        {
+            foreach (var node in sequence.Children.OfType<YamlMappingNode>())
+            {
+                Clips.Add(new AnimationSetClip
+                {
+                    Slot = AnimationControllerFile.ReadString(node, "slot"),
+                    Animation = new FileId(AnimationControllerFile.ReadString(node, "animation"))
+                });
+            }
+        }
+        Clips.CollectionChanged += (_, _) => MarkDirty(nameof(Clips));
+        Clips.ItemChanged += (_, _) => MarkDirty(nameof(Clips));
+        OnPropertyChanged(nameof(Clips));
+    }
+
+    void SaveSetSource()
+    {
+        var clips = new YamlSequenceNode();
+        foreach (var clip in Clips)
+        {
+            clips.Add(new YamlMappingNode
+            {
+                { "slot", clip.Slot ?? string.Empty },
+                { "animation", clip.Animation?.Value ?? FileId.NullFileId }
+            });
+        }
+        var root = new YamlMappingNode
+        {
+            { "version", "1" },
+            { "clips", clips }
+        };
+        var stream = new YamlStream(new YamlDocument(root));
+        using var writer = new StreamWriter(new FileStream(Asset.FullName, FileMode.Create));
+        stream.Save(writer, false);
+    }
+}
+
+public partial class AnimationSetClip : ObservableObject
+{
+    [ObservableProperty]
+    string slot = string.Empty;
+
+    [ObservableProperty]
+    FileId animation = new();
+}

--- a/Editor/ViewModels/AssetFile.cs
+++ b/Editor/ViewModels/AssetFile.cs
@@ -389,6 +389,8 @@ public partial class AssetFile : ObservableObject, ICloneable
         var inferredType = this switch
         {
             AnimationFile => "Sailor::AnimationAssetInfo",
+            AnimationControllerFile => "Sailor::AnimationControllerAssetInfo",
+            AnimationSetFile => "Sailor::AnimationSetAssetInfo",
             FrameGraphFile => "Sailor::FrameGraphAssetInfo",
             MaterialFile => "Sailor::MaterialAssetInfo",
             ModelFile => "Sailor::ModelAssetInfo",

--- a/Editor/Views/ContentFolderView.xaml.cs
+++ b/Editor/Views/ContentFolderView.xaml.cs
@@ -446,6 +446,33 @@ namespace SailorEditor.Views
             }
         }
 
+        async Task CreateAnimationAsset(
+            AssetFolder? parentFolder,
+            bool createSet)
+        {
+            var result = await dispatcher.DispatchAsync(
+                new CreateAnimationAssetCommand(parentFolder, createSet),
+                contextProvider.GetCurrentContext(
+                    new CommandOrigin(
+                        CommandOriginKind.Panel,
+                        nameof(CreateAnimationAsset))));
+            if (!result.Succeeded)
+            {
+                await Application.Current.MainPage.DisplayAlert(
+                    "Create animation asset failed",
+                    result.Message ?? "Unable to create the animation asset.",
+                    "OK");
+                return;
+            }
+
+            if (result.Value is FileId fileId &&
+                service.Assets.TryGetValue(fileId, out var asset))
+            {
+                MauiProgram.GetService<SelectionService>()
+                    .SelectObject(asset, force: true);
+            }
+        }
+
         async Task DeleteFolder(AssetFolder folder)
         {
             var confirmed = await Application.Current.MainPage.DisplayAlert(
@@ -851,6 +878,20 @@ namespace SailorEditor.Views
                         Command = CreateContentContextMenuCommand(
                             () => CreateFolder(folder),
                             "Create folder")
+                    },
+                    new EditorContextMenuItem
+                    {
+                        Text = "Create Animation Controller",
+                        Command = CreateContentContextMenuCommand(
+                            () => CreateAnimationAsset(folder, false),
+                            "Create animation controller")
+                    },
+                    new EditorContextMenuItem
+                    {
+                        Text = "Create Animation Set",
+                        Command = CreateContentContextMenuCommand(
+                            () => CreateAnimationAsset(folder, true),
+                            "Create animation set")
                     }
                 };
                 if (service.CanModifyFolder(folder))
@@ -876,13 +917,28 @@ namespace SailorEditor.Views
             else if (model is ProjectContentFolderItem { IsRoot: true, IsReadOnly: false } &&
                 service.CanCreateFolder(null))
             {
-                contextMenu.Show(new EditorContextMenuItem
-                {
-                    Text = "Create Folder",
-                    Command = CreateContentContextMenuCommand(
-                        () => CreateFolder(null),
-                        "Create folder")
-                });
+                contextMenu.Show(
+                    new EditorContextMenuItem
+                    {
+                        Text = "Create Folder",
+                        Command = CreateContentContextMenuCommand(
+                            () => CreateFolder(null),
+                            "Create folder")
+                    },
+                    new EditorContextMenuItem
+                    {
+                        Text = "Create Animation Controller",
+                        Command = CreateContentContextMenuCommand(
+                            () => CreateAnimationAsset(null, false),
+                            "Create animation controller")
+                    },
+                    new EditorContextMenuItem
+                    {
+                        Text = "Create Animation Set",
+                        Command = CreateContentContextMenuCommand(
+                            () => CreateAnimationAsset(null, true),
+                            "Create animation set")
+                    });
             }
         }
 

--- a/Editor/Views/ContentFolderView.xaml.cs
+++ b/Editor/Views/ContentFolderView.xaml.cs
@@ -72,7 +72,7 @@ namespace SailorEditor.Views
             PopulateRows(contentStore.Projection);
         }
 
-        void SelectAssetFile(ObservableObject obj)
+        async void SelectAssetFile(ObservableObject obj)
         {
             if (obj is not AssetFile file || file.FileId is null || file.FileId.IsEmpty())
             {
@@ -89,8 +89,26 @@ namespace SailorEditor.Views
                 return;
             }
 
-            EnsureFolderVisible(file.FolderId);
-            contentStore.SelectAsset(file);
+            try
+            {
+                var resolved = await service.ResolveAssetAsync(file.FileId);
+                var selected = MauiProgram.GetService<SelectionService>()
+                    .SelectedItem as AssetFile;
+                if (resolved is null ||
+                    selected?.FileId is null ||
+                    !selected.FileId.Equals(file.FileId))
+                {
+                    return;
+                }
+
+                EnsureFolderVisible(resolved.FolderId);
+                contentStore.SelectAsset(resolved);
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(
+                    $"[ContentFolderView] Failed to reveal asset '{file.FileId}': {exception.Message}");
+            }
         }
 
         void OnContentSelectionChanged(object sender, SelectionChangedEventArgs args)

--- a/Editor/Views/InspectorView.xaml
+++ b/Editor/Views/InspectorView.xaml
@@ -24,6 +24,8 @@
             <local:MaterialFileTemplate x:Key="MaterialFileTemplate" />
             <local:ModelFileTemplate x:Key="ModelFileTemplate" />
             <local:FrameGraphFileTemplate x:Key="FrameGraphFileTemplate" />
+            <local:AnimationControllerFileTemplate x:Key="AnimationControllerFileTemplate" />
+            <local:AnimationSetFileTemplate x:Key="AnimationSetFileTemplate" />
             <local:GameObjectTemplate x:Key="GameObjectTemplate" />
 
             <local:InspectorTemplateSelector x:Key="InspectorTemplateSelector"
@@ -33,6 +35,8 @@
                                           MaterialFileTemplate ="{StaticResource MaterialFileTemplate}"
                                           ModelFileTemplate ="{StaticResource ModelFileTemplate}"
                                           FrameGraphFileTemplate="{StaticResource FrameGraphFileTemplate}"
+                                          AnimationControllerFileTemplate="{StaticResource AnimationControllerFileTemplate}"
+                                          AnimationSetFileTemplate="{StaticResource AnimationSetFileTemplate}"
                                           ShaderLibraryFileTemplate="{StaticResource ShaderLibraryFileTemplate}"
                                           GameObjectTemplate ="{StaticResource GameObjectTemplate}"/>
         </ResourceDictionary>

--- a/Editor/Views/InspectorView/AnimationControllerFileTemplate.cs
+++ b/Editor/Views/InspectorView/AnimationControllerFileTemplate.cs
@@ -34,6 +34,8 @@ sealed class AnimationControllerEditorPanel : VerticalStackLayout
     ContentView? stateEditorHost;
     IDispatcherTimer? previewTimer;
     AnimationControllerState? selectedState;
+    string? previewAnimatorInstanceId;
+    int previewGeneration;
     bool rebuilding;
 
     public AnimationControllerEditorPanel()
@@ -46,6 +48,10 @@ sealed class AnimationControllerEditorPanel : VerticalStackLayout
 
     void Bind(AnimationControllerFile? value)
     {
+        if (!ReferenceEquals(controller, value))
+        {
+            previewAnimatorInstanceId = null;
+        }
         if (controller is not null)
         {
             controller.DocumentReplaced -= OnDocumentReplaced;
@@ -81,6 +87,7 @@ sealed class AnimationControllerEditorPanel : VerticalStackLayout
             stateEditorHost = null;
             previewTimer?.Stop();
             previewTimer = null;
+            ++previewGeneration;
             Children.Clear();
             if (controller is null)
             {
@@ -215,96 +222,218 @@ sealed class AnimationControllerEditorPanel : VerticalStackLayout
     View BuildPreview()
     {
         var panel = Card();
-        panel.Children.Add(SectionLabel("Preview"));
-        var models = MauiProgram.GetService<AssetsService>().Files.OfType<ModelFile>().ToArray();
-        var modelPicker = new Picker
+        var header = new HorizontalStackLayout { Spacing = 8 };
+        header.Children.Add(SectionLabel("Live Preview"));
+        header.Children.Add(Button("Refresh Targets", Build));
+        panel.Children.Add(header);
+        var targets = FindPreviewTargets();
+        var targetPicker = new Picker
         {
-            Title = "Preview model",
-            ItemsSource = models,
-            ItemDisplayBinding = new Binding(nameof(ModelFile.DisplayName))
+            Title = "Animator in the current scene",
+            ItemsSource = targets,
+            ItemDisplayBinding = new Binding(nameof(AnimationControllerPreviewTarget.DisplayName))
         };
-        var fingerprint = new Image
-        {
-            HeightRequest = 180,
-            WidthRequest = 260,
-            Aspect = Aspect.AspectFit,
-            HorizontalOptions = LayoutOptions.Start
-        };
-        modelPicker.SelectedIndexChanged += async (_, _) =>
-        {
-            if (modelPicker.SelectedItem is ModelFile model)
-            {
-                await model.LoadDependentResources();
-                fingerprint.Source = model.Fingerprint;
-            }
-            else
-            {
-                fingerprint.Source = null;
-            }
-        };
-        panel.Children.Add(modelPicker);
-        panel.Children.Add(fingerprint);
+        targetPicker.SelectedItem = targets.FirstOrDefault(target =>
+                string.Equals(
+                    target.Animator.InstanceId?.Value,
+                    previewAnimatorInstanceId,
+                    StringComparison.Ordinal)) ??
+            targets.FirstOrDefault();
+        panel.Children.Add(targetPicker);
 
-        var statePicker = new Picker
+        var stateLabel = new Label
         {
-            Title = "State",
-            ItemsSource = controller!.States,
-            ItemDisplayBinding = new Binding(nameof(AnimationControllerState.Name)),
-            SelectedItem = selectedState ?? controller.States.FirstOrDefault()
+            Text = targets.Count == 0
+                ? "Assign this controller and an Animation Set to an AnimatorComponent in the current scene."
+                : "Waiting for runtime state...",
+            FontSize = 11,
+            TextColor = Color.FromArgb("#AAB2BE")
         };
-        var time = new Slider { Minimum = 0.0, Maximum = 1.0, Value = 0.0 };
-        var timeLabel = new Label { Text = "Normalized time 0.000", FontSize = 11 };
-        var timer = Dispatcher.CreateTimer();
-        previewTimer = timer;
-        timer.Interval = TimeSpan.FromMilliseconds(16);
-        timer.Tick += (_, _) =>
-        {
-            time.Value = (time.Value + 0.016) % 1.0;
-        };
-        var play = new Button { Text = "Play" };
-        play.Clicked += (_, _) =>
-        {
-            if (timer.IsRunning)
-            {
-                timer.Stop();
-                play.Text = "Play";
-            }
-            else
-            {
-                timer.Start();
-                play.Text = "Pause";
-            }
-        };
-        statePicker.SelectedIndexChanged += (_, _) =>
-        {
-            if (statePicker.SelectedItem is AnimationControllerState state)
-            {
-                selectedState = state;
-                if (graph is not null)
-                {
-                    graph.PreviewActiveStateId = state.Id;
-                    graph.Invalidate();
-                }
-            }
-        };
-        time.ValueChanged += (_, args) =>
-        {
-            timeLabel.Text = $"Normalized time {args.NewValue:F3}";
-        };
-        panel.Children.Add(statePicker);
-        panel.Children.Add(new HorizontalStackLayout
-        {
-            Spacing = 8,
-            Children = { play, timeLabel }
-        });
-        panel.Children.Add(time);
+        panel.Children.Add(stateLabel);
+
+        var runtimeParameters = new ContentView();
+        panel.Children.Add(runtimeParameters);
         panel.Children.Add(new Label
         {
-            Text = "Preview uses the selected model fingerprint; runtime state and parameters are evaluated independently per Animator.",
+            Text = "The selected Animator is evaluated by the Engine and rendered in Scene View. Runtime controls do not change authored parameter defaults.",
             FontSize = 11,
             TextColor = Color.FromArgb("#929AA5")
         });
+
+        var timer = Dispatcher.CreateTimer();
+        previewTimer = timer;
+        timer.Interval = TimeSpan.FromMilliseconds(100);
+        var generation = previewGeneration;
+        var requestPending = false;
+
+        async Task RefreshRuntimeStateAsync()
+        {
+            if (requestPending ||
+                generation != previewGeneration ||
+                targetPicker.SelectedItem is not AnimationControllerPreviewTarget target ||
+                target.Animator.InstanceId is null ||
+                target.Animator.InstanceId.IsEmpty())
+            {
+                return;
+            }
+            requestPending = true;
+            try
+            {
+                var state = await MauiProgram.GetService<EngineService>()
+                    .GetAnimatorStateAsync(target.Animator.InstanceId);
+                if (generation != previewGeneration ||
+                    !ReferenceEquals(targetPicker.SelectedItem, target))
+                {
+                    return;
+                }
+                if (state is null)
+                {
+                    stateLabel.Text = "Engine is not running.";
+                    SetPreviewState(0);
+                }
+                else if (!state.Value.HasController)
+                {
+                    stateLabel.Text = "The runtime Animator has no valid controller/set.";
+                    SetPreviewState(0);
+                }
+                else
+                {
+                    stateLabel.Text = state.Value.IsTransitioning
+                        ? $"{state.Value.ActiveStateName} → {state.Value.DestinationStateName}  {state.Value.TransitionAlpha:P0}"
+                        : $"{state.Value.ActiveStateName}  {state.Value.ActiveStateTime:F2}s";
+                    SetPreviewState(state.Value.ActiveStateId);
+                }
+            }
+            catch (Exception exception)
+            {
+                if (generation == previewGeneration)
+                {
+                    stateLabel.Text = exception.Message;
+                    SetPreviewState(0);
+                }
+            }
+            finally
+            {
+                requestPending = false;
+            }
+        }
+
+        void BindTarget()
+        {
+            if (targetPicker.SelectedItem is AnimationControllerPreviewTarget target)
+            {
+                previewAnimatorInstanceId = target.Animator.InstanceId?.Value;
+                runtimeParameters.Content = BuildRuntimeParameterControls(target, stateLabel);
+                stateLabel.Text = target.HasAnimationSet
+                    ? "Waiting for runtime state..."
+                    : "The selected Animator has no Animation Set.";
+            }
+            else
+            {
+                previewAnimatorInstanceId = null;
+                runtimeParameters.Content = null;
+                stateLabel.Text = "Assign this controller and an Animation Set to an AnimatorComponent in the current scene.";
+            }
+            SetPreviewState(0);
+            _ = RefreshRuntimeStateAsync();
+        }
+
+        targetPicker.SelectedIndexChanged += (_, _) => BindTarget();
+        timer.Tick += (_, _) => _ = RefreshRuntimeStateAsync();
+        panel.Loaded += (_, _) =>
+        {
+            if (ReferenceEquals(previewTimer, timer))
+            {
+                timer.Start();
+                _ = RefreshRuntimeStateAsync();
+            }
+        };
+        panel.Unloaded += (_, _) => timer.Stop();
+        BindTarget();
         return panel;
+    }
+
+    List<AnimationControllerPreviewTarget> FindPreviewTargets()
+    {
+        var result = new List<AnimationControllerPreviewTarget>();
+        if (controller?.FileId is null || controller.FileId.IsEmpty())
+        {
+            return result;
+        }
+
+        var worldService = MauiProgram.GetService<WorldService>();
+        foreach (var prefab in worldService.Current.Prefabs)
+        {
+            foreach (var gameObject in prefab.GameObjects)
+            {
+                foreach (var component in worldService.GetComponents(gameObject))
+                {
+                    if (!string.Equals(
+                            component.Typename?.Name,
+                            "Sailor::AnimatorComponent",
+                            StringComparison.Ordinal) ||
+                        !AnimatorRuntimeControls.ReferencesAsset(
+                            component,
+                            "controller",
+                            controller.FileId))
+                    {
+                        continue;
+                    }
+
+                    result.Add(new AnimationControllerPreviewTarget(
+                        gameObject,
+                        component,
+                        AnimatorRuntimeControls.HasAssignedAsset(
+                            component,
+                            "animationSet")));
+                }
+            }
+        }
+        return result;
+    }
+
+    View BuildRuntimeParameterControls(
+        AnimationControllerPreviewTarget target,
+        Label statusLabel)
+    {
+        var parameters = new VerticalStackLayout { Spacing = 4 };
+        if (!target.HasAnimationSet)
+        {
+            return parameters;
+        }
+
+        foreach (var parameter in controller!.Parameters)
+        {
+            var editor = AnimatorRuntimeControls.CreateParameterEditor(
+                target.Animator,
+                parameter,
+                message => statusLabel.Text = message);
+            parameters.Children.Add(Labeled(parameter.Name, editor));
+        }
+        return parameters;
+    }
+
+    void SetPreviewState(ulong stateId)
+    {
+        if (graph is null || graph.PreviewActiveStateId == stateId)
+        {
+            return;
+        }
+        graph.PreviewActiveStateId = stateId;
+        graph.Invalidate();
+    }
+
+    sealed class AnimationControllerPreviewTarget(
+        GameObject gameObject,
+        Component animator,
+        bool hasAnimationSet)
+    {
+        public GameObject GameObject { get; } = gameObject;
+        public Component Animator { get; } = animator;
+        public bool HasAnimationSet { get; } = hasAnimationSet;
+        public string DisplayName { get; } = hasAnimationSet
+            ? gameObject.Name
+            : $"{gameObject.Name} (missing Animation Set)";
     }
 
     string GetUniqueStateName(string baseName)

--- a/Editor/Views/InspectorView/AnimationControllerFileTemplate.cs
+++ b/Editor/Views/InspectorView/AnimationControllerFileTemplate.cs
@@ -1,0 +1,765 @@
+using SailorEditor.Commands;
+using SailorEditor.Controls;
+using SailorEditor.Helpers;
+using SailorEditor.Services;
+using SailorEditor.ViewModels;
+using SailorEditor.Utility;
+using SailorEngine;
+using System.Globalization;
+
+namespace SailorEditor;
+
+public sealed class AnimationControllerFileTemplate : DataTemplate
+{
+    public AnimationControllerFileTemplate()
+    {
+        LoadTemplate = static () => new AnimationControllerEditorPanel();
+    }
+}
+
+public sealed class AnimationSetFileTemplate : DataTemplate
+{
+    public AnimationSetFileTemplate()
+    {
+        LoadTemplate = static () => new AnimationSetEditorPanel();
+    }
+}
+
+sealed class AnimationControllerEditorPanel : VerticalStackLayout
+{
+    readonly ICommandDispatcher dispatcher;
+    readonly IActionContextProvider contextProvider;
+    AnimationControllerFile? controller;
+    AnimationControllerGraphView? graph;
+    ContentView? stateEditorHost;
+    IDispatcherTimer? previewTimer;
+    AnimationControllerState? selectedState;
+    bool rebuilding;
+
+    public AnimationControllerEditorPanel()
+    {
+        Spacing = 10;
+        dispatcher = MauiProgram.GetService<ICommandDispatcher>();
+        contextProvider = MauiProgram.GetService<IActionContextProvider>();
+        BindingContextChanged += (_, _) => Bind(BindingContext as AnimationControllerFile);
+    }
+
+    void Bind(AnimationControllerFile? value)
+    {
+        if (controller is not null)
+        {
+            controller.DocumentReplaced -= OnDocumentReplaced;
+        }
+        controller = value;
+        if (controller is not null)
+        {
+            controller.DocumentReplaced += OnDocumentReplaced;
+        }
+        Build();
+    }
+
+    void OnDocumentReplaced()
+    {
+        if (controller is null)
+        {
+            return;
+        }
+        if (selectedState is not null)
+        {
+            selectedState = controller.States.FirstOrDefault(state => state.Id == selectedState.Id);
+        }
+        Build();
+    }
+
+    void Build()
+    {
+        rebuilding = true;
+        try
+        {
+            graph?.Detach();
+            graph = null;
+            stateEditorHost = null;
+            previewTimer?.Stop();
+            previewTimer = null;
+            Children.Clear();
+            if (controller is null)
+            {
+                return;
+            }
+
+            Children.Add(new Views.ControlPanelView { BindingContext = controller });
+            Children.Add(SectionLabel("State Machine"));
+
+            var graphToolbar = new HorizontalStackLayout { Spacing = 6 };
+            graphToolbar.Children.Add(Button("Add State", () =>
+            {
+                AnimationControllerState? state = null;
+                ApplyMutation("Add animation state", () =>
+                {
+                    var offset = 24.0 * controller.States.Count;
+                    state = controller.AddState(32.0 + offset, 32.0 + offset);
+                });
+                selectedState = state;
+                Build();
+            }));
+            graphToolbar.Children.Add(Button("Set Default", () =>
+            {
+                if (selectedState is not null)
+                {
+                    ApplyMutation("Set default animation state", () => controller.SetDefaultState(selectedState));
+                    Build();
+                }
+            }));
+            graphToolbar.Children.Add(Button("Delete State", () =>
+            {
+                if (selectedState is not null)
+                {
+                    ApplyMutation("Delete animation state", () => controller.RemoveState(selectedState));
+                    selectedState = null;
+                    Build();
+                }
+            }));
+            Children.Add(graphToolbar);
+
+            graph = new AnimationControllerGraphView
+            {
+                BindingContext = controller,
+                HeightRequest = 420,
+                MinimumWidthRequest = 480,
+                HorizontalOptions = LayoutOptions.Fill
+            };
+            graph.SelectState(selectedState);
+            graph.StateSelected += state =>
+            {
+                selectedState = state;
+                if (stateEditorHost is not null)
+                {
+                    stateEditorHost.Content = state is null ? null : BuildStateEditor(state);
+                }
+            };
+            graph.DocumentEdited += DispatchDocumentEdit;
+            var graphDrop = new DropGestureRecognizer();
+            graphDrop.DragOver += (_, args) =>
+            {
+                args.AcceptedOperation = args.Data.Properties.TryGetValue(
+                        EditorDragDrop.DragItemKey,
+                        out var source) && source is AnimationFile
+                    ? DataPackageOperation.Copy
+                    : DataPackageOperation.None;
+            };
+            graphDrop.Drop += (_, args) =>
+            {
+                if (!args.Data.Properties.TryGetValue(
+                        EditorDragDrop.DragItemKey,
+                        out var source) || source is not AnimationFile animation)
+                {
+                    return;
+                }
+
+                args.Handled = true;
+                var position = args.GetPosition(graph) ?? new Point(32.0, 32.0);
+                AnimationControllerState? addedState = null;
+                ApplyMutation("Create animation state from clip", () =>
+                {
+                    var slot = GetAnimationSlotName(animation);
+                    addedState = controller.AddState(position.X, position.Y);
+                    addedState.Name = GetUniqueStateName(slot);
+                    addedState.Clip = slot;
+                    selectedState = addedState;
+                });
+            };
+            graph.GestureRecognizers.Add(graphDrop);
+            Children.Add(graph);
+
+            stateEditorHost = new ContentView
+            {
+                Content = selectedState is null ? null : BuildStateEditor(selectedState)
+            };
+            Children.Add(stateEditorHost);
+
+            Children.Add(new Label
+            {
+                Text = "Drop an Animation asset onto the graph to create a clip state.",
+                FontSize = 11,
+                TextColor = Color.FromArgb("#929AA5")
+            });
+
+            Children.Add(BuildPreview());
+            Children.Add(BuildParameters());
+            Children.Add(BuildTransitions());
+        }
+        finally
+        {
+            rebuilding = false;
+        }
+    }
+
+    View BuildStateEditor(AnimationControllerState state)
+    {
+        var panel = Card();
+        panel.Children.Add(SectionLabel(
+            state.Id == controller!.DefaultStateId
+                ? $"{state.Name} (Default)"
+                : state.Name));
+        panel.Children.Add(Labeled("Name", TextEntry(state.Name, value =>
+            ApplyMutation("Rename animation state", () => state.Name = value))));
+        panel.Children.Add(Labeled("Clip slot", TextEntry(state.Clip, value =>
+            ApplyMutation("Change animation clip slot", () => state.Clip = value))));
+        panel.Children.Add(Labeled("Speed", FloatEntry(state.Speed, value =>
+            ApplyMutation("Change animation state speed", () => state.Speed = value))));
+        panel.Children.Add(Labeled("Loop", Check(state.Loop, value =>
+            ApplyMutation("Change animation state loop", () => state.Loop = value))));
+        return panel;
+    }
+
+    View BuildPreview()
+    {
+        var panel = Card();
+        panel.Children.Add(SectionLabel("Preview"));
+        var models = MauiProgram.GetService<AssetsService>().Files.OfType<ModelFile>().ToArray();
+        var modelPicker = new Picker
+        {
+            Title = "Preview model",
+            ItemsSource = models,
+            ItemDisplayBinding = new Binding(nameof(ModelFile.DisplayName))
+        };
+        var fingerprint = new Image
+        {
+            HeightRequest = 180,
+            WidthRequest = 260,
+            Aspect = Aspect.AspectFit,
+            HorizontalOptions = LayoutOptions.Start
+        };
+        modelPicker.SelectedIndexChanged += async (_, _) =>
+        {
+            if (modelPicker.SelectedItem is ModelFile model)
+            {
+                await model.LoadDependentResources();
+                fingerprint.Source = model.Fingerprint;
+            }
+            else
+            {
+                fingerprint.Source = null;
+            }
+        };
+        panel.Children.Add(modelPicker);
+        panel.Children.Add(fingerprint);
+
+        var statePicker = new Picker
+        {
+            Title = "State",
+            ItemsSource = controller!.States,
+            ItemDisplayBinding = new Binding(nameof(AnimationControllerState.Name)),
+            SelectedItem = selectedState ?? controller.States.FirstOrDefault()
+        };
+        var time = new Slider { Minimum = 0.0, Maximum = 1.0, Value = 0.0 };
+        var timeLabel = new Label { Text = "Normalized time 0.000", FontSize = 11 };
+        var timer = Dispatcher.CreateTimer();
+        previewTimer = timer;
+        timer.Interval = TimeSpan.FromMilliseconds(16);
+        timer.Tick += (_, _) =>
+        {
+            time.Value = (time.Value + 0.016) % 1.0;
+        };
+        var play = new Button { Text = "Play" };
+        play.Clicked += (_, _) =>
+        {
+            if (timer.IsRunning)
+            {
+                timer.Stop();
+                play.Text = "Play";
+            }
+            else
+            {
+                timer.Start();
+                play.Text = "Pause";
+            }
+        };
+        statePicker.SelectedIndexChanged += (_, _) =>
+        {
+            if (statePicker.SelectedItem is AnimationControllerState state)
+            {
+                selectedState = state;
+                if (graph is not null)
+                {
+                    graph.PreviewActiveStateId = state.Id;
+                    graph.Invalidate();
+                }
+            }
+        };
+        time.ValueChanged += (_, args) =>
+        {
+            timeLabel.Text = $"Normalized time {args.NewValue:F3}";
+        };
+        panel.Children.Add(statePicker);
+        panel.Children.Add(new HorizontalStackLayout
+        {
+            Spacing = 8,
+            Children = { play, timeLabel }
+        });
+        panel.Children.Add(time);
+        panel.Children.Add(new Label
+        {
+            Text = "Preview uses the selected model fingerprint; runtime state and parameters are evaluated independently per Animator.",
+            FontSize = 11,
+            TextColor = Color.FromArgb("#929AA5")
+        });
+        return panel;
+    }
+
+    string GetUniqueStateName(string baseName)
+    {
+        var usedNames = controller!.States
+            .Select(state => state.Name)
+            .ToHashSet(StringComparer.Ordinal);
+        if (!usedNames.Contains(baseName))
+        {
+            return baseName;
+        }
+        for (var index = 2; ; ++index)
+        {
+            var candidate = $"{baseName} {index}";
+            if (!usedNames.Contains(candidate))
+            {
+                return candidate;
+            }
+        }
+    }
+
+    static string GetAnimationSlotName(AnimationFile animation)
+    {
+        var filename = animation.AssetInfo?.Name ?? animation.DisplayName ?? "Animation";
+        if (filename.EndsWith(".asset", StringComparison.OrdinalIgnoreCase))
+        {
+            filename = Path.GetFileNameWithoutExtension(filename);
+        }
+        if (filename.EndsWith(".anim", StringComparison.OrdinalIgnoreCase))
+        {
+            filename = Path.GetFileNameWithoutExtension(filename);
+        }
+        var separator = filename.LastIndexOf('_');
+        return separator >= 0 && separator + 1 < filename.Length
+            ? filename[(separator + 1)..]
+            : filename;
+    }
+
+    View BuildParameters()
+    {
+        var panel = Card();
+        var header = new HorizontalStackLayout { Spacing = 8 };
+        header.Children.Add(SectionLabel("Parameters"));
+        header.Children.Add(Button("+", () =>
+        {
+            ApplyMutation("Add animation parameter", () => controller!.AddParameter());
+            Build();
+        }));
+        panel.Children.Add(header);
+
+        foreach (var parameter in controller!.Parameters)
+        {
+            var row = new Grid
+            {
+                ColumnDefinitions =
+                {
+                    new ColumnDefinition { Width = 28 },
+                    new ColumnDefinition { Width = GridLength.Star },
+                    new ColumnDefinition { Width = 100 },
+                    new ColumnDefinition { Width = 100 }
+                },
+                ColumnSpacing = 5
+            };
+            var remove = Button("-", () =>
+            {
+                ApplyMutation("Delete animation parameter", () => controller.RemoveParameter(parameter));
+                Build();
+            });
+            row.Add(remove, 0);
+            row.Add(TextEntry(parameter.Name, value =>
+                ApplyMutation("Rename animation parameter", () => parameter.Name = value)), 1);
+            var type = EnumPicker(parameter.Type, value =>
+                ApplyMutation("Change animation parameter type", () => parameter.Type = value));
+            row.Add(type, 2);
+            row.Add(ParameterDefaultEditor(parameter), 3);
+            panel.Children.Add(row);
+        }
+        return panel;
+    }
+
+    View ParameterDefaultEditor(AnimationControllerParameter parameter) => parameter.Type switch
+    {
+        AnimationControllerParameterType.Float => FloatEntry(parameter.DefaultFloat, value =>
+            ApplyMutation("Change animation parameter default", () => parameter.DefaultFloat = value)),
+        AnimationControllerParameterType.Int => IntEntry(parameter.DefaultInt, value =>
+            ApplyMutation("Change animation parameter default", () => parameter.DefaultInt = value)),
+        AnimationControllerParameterType.Bool => Check(parameter.DefaultBool, value =>
+            ApplyMutation("Change animation parameter default", () => parameter.DefaultBool = value)),
+        _ => new Label { Text = "one-shot", VerticalTextAlignment = TextAlignment.Center }
+    };
+
+    View BuildTransitions()
+    {
+        var panel = Card();
+        panel.Children.Add(SectionLabel("Transitions (priority, then authored order)"));
+        var from = StatePicker(controller!.States.FirstOrDefault());
+        var to = StatePicker(controller.States.Skip(1).FirstOrDefault() ?? controller.States.FirstOrDefault());
+        var add = Button("Add Transition", () =>
+        {
+            if (from.SelectedItem is AnimationControllerState fromState &&
+                to.SelectedItem is AnimationControllerState toState)
+            {
+                ApplyMutation("Add animation transition", () => controller.AddTransition(fromState, toState));
+                Build();
+            }
+        });
+        panel.Children.Add(new HorizontalStackLayout
+        {
+            Spacing = 5,
+            Children = { from, new Label { Text = "→", VerticalTextAlignment = TextAlignment.Center }, to, add }
+        });
+
+        foreach (var transition in controller.Transitions)
+        {
+            panel.Children.Add(BuildTransition(transition));
+        }
+        return panel;
+    }
+
+    View BuildTransition(AnimationControllerTransition transition)
+    {
+        var panel = Card(Color.FromArgb("#20252C"));
+        var from = controller!.States.FirstOrDefault(state => state.Id == transition.FromStateId);
+        var to = controller.States.FirstOrDefault(state => state.Id == transition.ToStateId);
+        var header = new HorizontalStackLayout { Spacing = 7 };
+        header.Children.Add(new Label
+        {
+            Text = $"{from?.Name ?? "Missing"} → {to?.Name ?? "Missing"}",
+            FontAttributes = FontAttributes.Bold,
+            VerticalTextAlignment = TextAlignment.Center
+        });
+        header.Children.Add(Button("Delete", () =>
+        {
+            ApplyMutation("Delete animation transition", () => controller.RemoveTransition(transition));
+            Build();
+        }));
+        panel.Children.Add(header);
+        panel.Children.Add(Labeled("Priority", IntEntry(transition.Priority, value =>
+            ApplyMutation("Change transition priority", () => transition.Priority = value))));
+        panel.Children.Add(Labeled("Crossfade seconds", FloatEntry(transition.Duration, value =>
+            ApplyMutation("Change transition duration", () => transition.Duration = value))));
+        panel.Children.Add(Labeled("Has exit time", Check(transition.HasExitTime, value =>
+            ApplyMutation("Change transition exit time mode", () => transition.HasExitTime = value))));
+        panel.Children.Add(Labeled("Normalized exit", FloatEntry(transition.ExitTime, value =>
+            ApplyMutation("Change transition exit time", () => transition.ExitTime = value))));
+
+        var addCondition = Button("Add AND Condition", () =>
+        {
+            var parameter = controller.Parameters.FirstOrDefault();
+            if (parameter is not null)
+            {
+                ApplyMutation("Add transition condition", () => controller.AddCondition(transition, parameter));
+                Build();
+            }
+        });
+        addCondition.IsEnabled = controller.Parameters.Count > 0;
+        panel.Children.Add(addCondition);
+        foreach (var condition in transition.Conditions)
+        {
+            panel.Children.Add(BuildCondition(transition, condition));
+        }
+        return panel;
+    }
+
+    View BuildCondition(
+        AnimationControllerTransition transition,
+        AnimationControllerCondition condition)
+    {
+        var row = new HorizontalStackLayout { Spacing = 5 };
+        row.Children.Add(Button("-", () =>
+        {
+            ApplyMutation("Delete transition condition", () => transition.Conditions.Remove(condition));
+            Build();
+        }));
+        var parameterPicker = new Picker
+        {
+            WidthRequest = 120,
+            ItemsSource = controller!.Parameters,
+            ItemDisplayBinding = new Binding(nameof(AnimationControllerParameter.Name)),
+            SelectedItem = controller.Parameters.FirstOrDefault(parameter => parameter.Id == condition.ParameterId)
+        };
+        parameterPicker.SelectedIndexChanged += (_, _) =>
+        {
+            if (!rebuilding && parameterPicker.SelectedItem is AnimationControllerParameter parameter)
+            {
+                ApplyMutation("Change transition condition parameter", () =>
+                {
+                    condition.ParameterId = parameter.Id;
+                    condition.Operation = parameter.Type == AnimationControllerParameterType.Trigger
+                        ? AnimationControllerConditionOperation.IsSet
+                        : AnimationControllerConditionOperation.Equal;
+                });
+                Build();
+            }
+        };
+        row.Children.Add(parameterPicker);
+        row.Children.Add(EnumPicker(condition.Operation, value =>
+            ApplyMutation("Change transition condition operation", () => condition.Operation = value)));
+
+        var parameterType = (parameterPicker.SelectedItem as AnimationControllerParameter)?.Type;
+        row.Children.Add(parameterType switch
+        {
+            AnimationControllerParameterType.Float => FloatEntry(condition.FloatValue, value =>
+                ApplyMutation("Change transition condition value", () => condition.FloatValue = value)),
+            AnimationControllerParameterType.Int => IntEntry(condition.IntValue, value =>
+                ApplyMutation("Change transition condition value", () => condition.IntValue = value)),
+            AnimationControllerParameterType.Bool => Check(condition.BoolValue, value =>
+                ApplyMutation("Change transition condition value", () => condition.BoolValue = value)),
+            _ => new Label { Text = "set", VerticalTextAlignment = TextAlignment.Center }
+        });
+        return row;
+    }
+
+    void ApplyMutation(string description, Action mutation)
+    {
+        if (controller is null)
+        {
+            return;
+        }
+        var before = controller.CaptureDocument();
+        mutation();
+        controller.ValidateDocument();
+        var after = controller.CaptureDocument();
+        if (!string.Equals(before, after, StringComparison.Ordinal))
+        {
+            DispatchDocumentEdit(before, after, description);
+        }
+    }
+
+    async void DispatchDocumentEdit(string before, string after, string description)
+    {
+        if (controller is null ||
+            string.Equals(before, after, StringComparison.Ordinal))
+        {
+            return;
+        }
+        try
+        {
+            var result = await dispatcher.DispatchAsync(
+                new EditAnimationControllerCommand(controller, before, after, description),
+                contextProvider.GetCurrentContext(
+                    new CommandOrigin(CommandOriginKind.Panel, nameof(AnimationControllerEditorPanel))));
+            if (!result.Succeeded)
+            {
+                controller.ApplyDocument(before);
+                MauiProgram.GetService<EngineService>().PushConsoleMessage(
+                    result.Message ?? $"{description} failed.");
+            }
+        }
+        catch (Exception exception)
+        {
+            controller.ApplyDocument(before);
+            MauiProgram.GetService<EngineService>().PushConsoleMessage(exception.Message);
+        }
+    }
+
+    Picker StatePicker(AnimationControllerState? selected) => new()
+    {
+        WidthRequest = 120,
+        ItemsSource = controller!.States,
+        ItemDisplayBinding = new Binding(nameof(AnimationControllerState.Name)),
+        SelectedItem = selected
+    };
+
+    static Picker EnumPicker<T>(T selected, Action<T> changed)
+        where T : struct, Enum
+    {
+        var picker = new Picker
+        {
+            WidthRequest = 118,
+            ItemsSource = Enum.GetValues<T>(),
+            SelectedItem = selected
+        };
+        picker.SelectedIndexChanged += (_, _) =>
+        {
+            if (picker.SelectedItem is T value && !EqualityComparer<T>.Default.Equals(value, selected))
+            {
+                changed(value);
+            }
+        };
+        return picker;
+    }
+
+    static Entry TextEntry(string value, Action<string> changed)
+    {
+        var entry = new Entry { Text = value ?? string.Empty, ReturnType = ReturnType.Done };
+        entry.Unfocused += (_, _) =>
+        {
+            if (!string.Equals(entry.Text, value, StringComparison.Ordinal))
+            {
+                changed(entry.Text ?? string.Empty);
+            }
+        };
+        entry.Completed += (_, _) => entry.Unfocus();
+        return entry;
+    }
+
+    static Entry FloatEntry(float value, Action<float> changed)
+    {
+        var entry = new Entry
+        {
+            Text = value.ToString("R", CultureInfo.InvariantCulture),
+            Keyboard = Keyboard.Numeric,
+            WidthRequest = 100,
+            ReturnType = ReturnType.Done
+        };
+        entry.Unfocused += (_, _) =>
+        {
+            if (float.TryParse(entry.Text, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed) && parsed != value)
+            {
+                changed(parsed);
+            }
+        };
+        entry.Completed += (_, _) => entry.Unfocus();
+        return entry;
+    }
+
+    static Entry IntEntry(int value, Action<int> changed)
+    {
+        var entry = new Entry
+        {
+            Text = value.ToString(CultureInfo.InvariantCulture),
+            Keyboard = Keyboard.Numeric,
+            WidthRequest = 90,
+            ReturnType = ReturnType.Done
+        };
+        entry.Unfocused += (_, _) =>
+        {
+            if (int.TryParse(entry.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed) && parsed != value)
+            {
+                changed(parsed);
+            }
+        };
+        entry.Completed += (_, _) => entry.Unfocus();
+        return entry;
+    }
+
+    static CheckBox Check(bool value, Action<bool> changed)
+    {
+        var check = new CheckBox { IsChecked = value };
+        check.CheckedChanged += (_, args) =>
+        {
+            if (args.Value != value)
+            {
+                changed(args.Value);
+            }
+        };
+        return check;
+    }
+
+    static Button Button(string text, Action clicked)
+    {
+        var button = new Button { Text = text, HeightRequest = 32, Padding = new Thickness(8, 2) };
+        button.Clicked += (_, _) => clicked();
+        return button;
+    }
+
+    static Label SectionLabel(string text) => new()
+    {
+        Text = text,
+        FontAttributes = FontAttributes.Bold,
+        VerticalTextAlignment = TextAlignment.Center
+    };
+
+    static View Labeled(string label, View editor) => new Grid
+    {
+        ColumnDefinitions =
+        {
+            new ColumnDefinition { Width = 150 },
+            new ColumnDefinition { Width = GridLength.Star }
+        },
+        Children =
+        {
+            new Label { Text = label, VerticalTextAlignment = TextAlignment.Center },
+            editor
+        }
+    }.Apply(grid => Grid.SetColumn(editor, 1));
+
+    static VerticalStackLayout Card(Color? color = null) => new()
+    {
+        Spacing = 6,
+        Padding = 8,
+        BackgroundColor = color ?? Color.FromArgb("#1D2229")
+    };
+}
+
+sealed class AnimationSetEditorPanel : VerticalStackLayout
+{
+    AnimationSetFile? set;
+
+    public AnimationSetEditorPanel()
+    {
+        Spacing = 8;
+        BindingContextChanged += (_, _) =>
+        {
+            set = BindingContext as AnimationSetFile;
+            Build();
+        };
+    }
+
+    void Build()
+    {
+        Children.Clear();
+        if (set is null)
+        {
+            return;
+        }
+        Children.Add(new Views.ControlPanelView { BindingContext = set });
+        Children.Add(new Label { Text = "Clip Slots", FontAttributes = FontAttributes.Bold });
+        var add = new Button { Text = "Add Slot" };
+        add.Clicked += (_, _) =>
+        {
+            set.AddClip();
+            Build();
+        };
+        Children.Add(add);
+        foreach (var clip in set.Clips)
+        {
+            var row = new Grid
+            {
+                ColumnDefinitions =
+                {
+                    new ColumnDefinition { Width = 28 },
+                    new ColumnDefinition { Width = 140 },
+                    new ColumnDefinition { Width = GridLength.Star }
+                },
+                ColumnSpacing = 5
+            };
+            var remove = new Button { Text = "-" };
+            remove.Clicked += (_, _) =>
+            {
+                set.Clips.Remove(clip);
+                Build();
+            };
+            var slot = new Entry { Text = clip.Slot, Placeholder = "logical slot" };
+            slot.TextChanged += (_, args) => clip.Slot = args.NewTextValue ?? string.Empty;
+            var animation = Templates.FileIdEditor(
+                clip,
+                nameof(AnimationSetClip.Animation),
+                static (AnimationSetClip value) => value.Animation,
+                static (value, fileId) => value.Animation = fileId,
+                typeof(AnimationFile));
+            row.Add(remove, 0);
+            row.Add(slot, 1);
+            row.Add(animation, 2);
+            Children.Add(row);
+        }
+    }
+}
+
+static class AnimationControllerEditorViewExtensions
+{
+    public static T Apply<T>(this T value, Action<T> action)
+    {
+        action(value);
+        return value;
+    }
+}

--- a/Editor/Views/InspectorView/AnimatorRuntimeControls.cs
+++ b/Editor/Views/InspectorView/AnimatorRuntimeControls.cs
@@ -1,0 +1,201 @@
+using SailorEditor.Services;
+using SailorEditor.ViewModels;
+using SailorEngine;
+using System.Globalization;
+
+namespace SailorEditor;
+
+static class AnimatorRuntimeControls
+{
+    public static AnimationControllerFile? ResolveController(Component component)
+    {
+        if (!TryGetAssignedFileId(component, "controller", out var controllerId))
+        {
+            return null;
+        }
+        return MauiProgram.GetService<AssetsService>().Assets
+            .TryGetValue(controllerId, out var asset)
+            ? asset as AnimationControllerFile
+            : null;
+    }
+
+    public static bool ReferencesAsset(
+        Component component,
+        string propertyName,
+        FileId fileId) =>
+        TryGetAssignedFileId(component, propertyName, out var assignedId) &&
+        string.Equals(assignedId.Value, fileId.Value, StringComparison.Ordinal);
+
+    public static bool HasAssignedAsset(
+        Component component,
+        string propertyName) =>
+        TryGetAssignedFileId(component, propertyName, out _);
+
+    public static View CreateParameterEditor(
+        Component component,
+        AnimationControllerParameter parameter,
+        Action<string>? reportError = null) => parameter.Type switch
+    {
+        AnimationControllerParameterType.Float =>
+            CreateFloatEditor(component, parameter, reportError),
+        AnimationControllerParameterType.Int =>
+            CreateIntEditor(component, parameter, reportError),
+        AnimationControllerParameterType.Bool =>
+            CreateBoolEditor(component, parameter, reportError),
+        AnimationControllerParameterType.Trigger =>
+            CreateTriggerEditor(component, parameter, reportError),
+        _ => new Label { Text = "Unsupported parameter" }
+    };
+
+    static View CreateFloatEditor(
+        Component component,
+        AnimationControllerParameter parameter,
+        Action<string>? reportError)
+    {
+        var entry = new Entry
+        {
+            Text = parameter.DefaultFloat.ToString("R", CultureInfo.InvariantCulture),
+            Keyboard = Keyboard.Numeric,
+            ReturnType = ReturnType.Done
+        };
+        entry.Completed += (_, _) => entry.Unfocus();
+        entry.Unfocused += (_, _) =>
+        {
+            if (float.TryParse(
+                    entry.Text,
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out var value))
+            {
+                RunUpdate(
+                    component,
+                    parameter.Name,
+                    instanceId => MauiProgram.GetService<EngineService>()
+                        .SetAnimatorFloatAsync(instanceId, parameter.Name, value),
+                    reportError);
+            }
+        };
+        return entry;
+    }
+
+    static View CreateIntEditor(
+        Component component,
+        AnimationControllerParameter parameter,
+        Action<string>? reportError)
+    {
+        var entry = new Entry
+        {
+            Text = parameter.DefaultInt.ToString(CultureInfo.InvariantCulture),
+            Keyboard = Keyboard.Numeric,
+            ReturnType = ReturnType.Done
+        };
+        entry.Completed += (_, _) => entry.Unfocus();
+        entry.Unfocused += (_, _) =>
+        {
+            if (int.TryParse(
+                    entry.Text,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var value))
+            {
+                RunUpdate(
+                    component,
+                    parameter.Name,
+                    instanceId => MauiProgram.GetService<EngineService>()
+                        .SetAnimatorIntAsync(instanceId, parameter.Name, value),
+                    reportError);
+            }
+        };
+        return entry;
+    }
+
+    static View CreateBoolEditor(
+        Component component,
+        AnimationControllerParameter parameter,
+        Action<string>? reportError)
+    {
+        var check = new CheckBox { IsChecked = parameter.DefaultBool };
+        check.CheckedChanged += (_, args) => RunUpdate(
+            component,
+            parameter.Name,
+            instanceId => MauiProgram.GetService<EngineService>()
+                .SetAnimatorBoolAsync(instanceId, parameter.Name, args.Value),
+            reportError);
+        return check;
+    }
+
+    static View CreateTriggerEditor(
+        Component component,
+        AnimationControllerParameter parameter,
+        Action<string>? reportError)
+    {
+        var fire = new Button { Text = "Fire", HeightRequest = 30 };
+        fire.Clicked += (_, _) => RunUpdate(
+            component,
+            parameter.Name,
+            instanceId => MauiProgram.GetService<EngineService>()
+                .SetAnimatorTriggerAsync(instanceId, parameter.Name),
+            reportError);
+        return fire;
+    }
+
+    static void RunUpdate(
+        Component component,
+        string parameterName,
+        Func<InstanceId, Task<bool>> update,
+        Action<string>? reportError)
+    {
+        _ = RunUpdateAsync(component, parameterName, update, reportError);
+    }
+
+    static async Task RunUpdateAsync(
+        Component component,
+        string parameterName,
+        Func<InstanceId, Task<bool>> update,
+        Action<string>? reportError)
+    {
+        try
+        {
+            if (component.InstanceId is null || component.InstanceId.IsEmpty() ||
+                !await update(component.InstanceId))
+            {
+                ReportError(
+                    $"Runtime rejected parameter '{parameterName}'.",
+                    reportError);
+            }
+        }
+        catch (Exception exception)
+        {
+            ReportError(exception.Message, reportError);
+        }
+    }
+
+    static void ReportError(string message, Action<string>? reportError)
+    {
+        if (reportError is not null)
+        {
+            reportError(message);
+        }
+        else
+        {
+            MauiProgram.GetService<EngineService>().PushConsoleMessage(message);
+        }
+    }
+
+    static bool TryGetAssignedFileId(
+        Component component,
+        string propertyName,
+        out FileId fileId)
+    {
+        if (component.OverrideProperties.TryGetValue(propertyName, out var value) &&
+            value is ObjectPtr pointer &&
+            pointer.FileId is not null &&
+            !pointer.FileId.IsEmpty())
+        {
+            fileId = pointer.FileId;
+            return true;
+        }
+        fileId = null!;
+        return false;
+    }
+}

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -268,23 +268,14 @@ public class ComponentTemplate : DataTemplate
         Templates.AddGridRow(props, stateLabel, GridLength.Auto);
         Grid.SetColumnSpan(stateLabel, props.ColumnDefinitions.Count);
 
-        var controllerFile = ResolveAnimationController(component);
+        var controllerFile = AnimatorRuntimeControls.ResolveController(component);
         if (controllerFile is not null)
         {
             foreach (var parameter in controllerFile.Parameters)
             {
-                View editor = parameter.Type switch
-                {
-                    AnimationControllerParameterType.Float =>
-                        CreateRuntimeFloatEditor(component, parameter),
-                    AnimationControllerParameterType.Int =>
-                        CreateRuntimeIntEditor(component, parameter),
-                    AnimationControllerParameterType.Bool =>
-                        CreateRuntimeBoolEditor(component, parameter),
-                    AnimationControllerParameterType.Trigger =>
-                        CreateRuntimeTriggerEditor(component, parameter),
-                    _ => new Label { Text = "Unsupported parameter" }
-                };
+                var editor = AnimatorRuntimeControls.CreateParameterEditor(
+                    component,
+                    parameter);
                 Templates.AddGridRowWithLabel(
                     props,
                     parameter.Name,
@@ -326,94 +317,6 @@ public class ComponentTemplate : DataTemplate
             }
         };
         return timer;
-    }
-
-    static AnimationControllerFile ResolveAnimationController(Component component)
-    {
-        if (!component.OverrideProperties.TryGetValue("controller", out var value) ||
-            value is not ObjectPtr controller || controller.FileId is null ||
-            controller.FileId.IsEmpty())
-        {
-            return null;
-        }
-        return MauiProgram.GetService<AssetsService>().Assets
-            .TryGetValue(controller.FileId, out var asset)
-            ? asset as AnimationControllerFile
-            : null;
-    }
-
-    static View CreateRuntimeFloatEditor(
-        Component component,
-        AnimationControllerParameter parameter)
-    {
-        var entry = new Entry
-        {
-            Text = parameter.DefaultFloat.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            Keyboard = Keyboard.Numeric,
-            ReturnType = ReturnType.Done
-        };
-        entry.Completed += (_, _) => entry.Unfocus();
-        entry.Unfocused += (_, _) =>
-        {
-            if (float.TryParse(
-                    entry.Text,
-                    System.Globalization.NumberStyles.Float,
-                    System.Globalization.CultureInfo.InvariantCulture,
-                    out var value))
-            {
-                _ = MauiProgram.GetService<EngineService>()
-                    .SetAnimatorFloatAsync(component.InstanceId, parameter.Name, value);
-            }
-        };
-        return entry;
-    }
-
-    static View CreateRuntimeIntEditor(
-        Component component,
-        AnimationControllerParameter parameter)
-    {
-        var entry = new Entry
-        {
-            Text = parameter.DefaultInt.ToString(System.Globalization.CultureInfo.InvariantCulture),
-            Keyboard = Keyboard.Numeric,
-            ReturnType = ReturnType.Done
-        };
-        entry.Completed += (_, _) => entry.Unfocus();
-        entry.Unfocused += (_, _) =>
-        {
-            if (int.TryParse(entry.Text, out var value))
-            {
-                _ = MauiProgram.GetService<EngineService>()
-                    .SetAnimatorIntAsync(component.InstanceId, parameter.Name, value);
-            }
-        };
-        return entry;
-    }
-
-    static View CreateRuntimeBoolEditor(
-        Component component,
-        AnimationControllerParameter parameter)
-    {
-        var check = new CheckBox { IsChecked = parameter.DefaultBool };
-        check.CheckedChanged += (_, args) =>
-        {
-            _ = MauiProgram.GetService<EngineService>()
-                .SetAnimatorBoolAsync(component.InstanceId, parameter.Name, args.Value);
-        };
-        return check;
-    }
-
-    static View CreateRuntimeTriggerEditor(
-        Component component,
-        AnimationControllerParameter parameter)
-    {
-        var fire = new Button { Text = "Fire", HeightRequest = 30 };
-        fire.Clicked += (_, _) =>
-        {
-            _ = MauiProgram.GetService<EngineService>()
-                .SetAnimatorTriggerAsync(component.InstanceId, parameter.Name);
-        };
-        return fire;
     }
 
     static string FormatComponentTypeName(string typeName)

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -30,9 +30,14 @@ public class ComponentTemplate : DataTemplate
                 HorizontalOptions = LayoutOptions.Fill,
                 MinimumWidthRequest = 0
             };
+            IDispatcherTimer? animatorRuntimeTimer = null;
+            props.Loaded += (_, _) => animatorRuntimeTimer?.Start();
+            props.Unloaded += (_, _) => animatorRuntimeTimer?.Stop();
 
             props.BindingContextChanged += (sender, args) =>
             {
+                animatorRuntimeTimer?.Stop();
+                animatorRuntimeTimer = null;
                 if (((Grid)sender).BindingContext is not Component component)
                 {
                     props.Children.Clear();
@@ -228,10 +233,187 @@ public class ComponentTemplate : DataTemplate
 
                     Templates.AddGridRowWithLabel(props, property.Key, propertyEditor, GridLength.Auto);
                 }
+
+                if (component.Typename.Name == "Sailor::AnimatorComponent")
+                {
+                    animatorRuntimeTimer = AddAnimatorRuntimeControls(props, component);
+                    if (props.IsLoaded)
+                    {
+                        animatorRuntimeTimer.Start();
+                    }
+                }
             };
 
             return props;
         };
+    }
+
+    static IDispatcherTimer AddAnimatorRuntimeControls(Grid props, Component component)
+    {
+        var heading = new Label
+        {
+            Text = "Runtime Controller",
+            FontAttributes = FontAttributes.Bold,
+            Margin = new Thickness(0, 8, 0, 0)
+        };
+        Templates.AddGridRow(props, heading, GridLength.Auto);
+        Grid.SetColumnSpan(heading, props.ColumnDefinitions.Count);
+
+        var stateLabel = new Label
+        {
+            Text = "No controller",
+            TextColor = Color.FromArgb("#929AA5"),
+            FontSize = 11
+        };
+        Templates.AddGridRow(props, stateLabel, GridLength.Auto);
+        Grid.SetColumnSpan(stateLabel, props.ColumnDefinitions.Count);
+
+        var controllerFile = ResolveAnimationController(component);
+        if (controllerFile is not null)
+        {
+            foreach (var parameter in controllerFile.Parameters)
+            {
+                View editor = parameter.Type switch
+                {
+                    AnimationControllerParameterType.Float =>
+                        CreateRuntimeFloatEditor(component, parameter),
+                    AnimationControllerParameterType.Int =>
+                        CreateRuntimeIntEditor(component, parameter),
+                    AnimationControllerParameterType.Bool =>
+                        CreateRuntimeBoolEditor(component, parameter),
+                    AnimationControllerParameterType.Trigger =>
+                        CreateRuntimeTriggerEditor(component, parameter),
+                    _ => new Label { Text = "Unsupported parameter" }
+                };
+                Templates.AddGridRowWithLabel(
+                    props,
+                    parameter.Name,
+                    editor,
+                    GridLength.Auto);
+            }
+        }
+
+        var timer = props.Dispatcher.CreateTimer();
+        timer.Interval = TimeSpan.FromMilliseconds(100);
+        var stateRequestPending = false;
+        timer.Tick += async (_, _) =>
+        {
+            if (stateRequestPending || component.InstanceId is null || component.InstanceId.IsEmpty())
+            {
+                return;
+            }
+            stateRequestPending = true;
+            try
+            {
+                var state = await MauiProgram.GetService<EngineService>()
+                    .GetAnimatorStateAsync(component.InstanceId);
+                if (state is null || !state.Value.HasController)
+                {
+                    stateLabel.Text = "No controller";
+                    return;
+                }
+                stateLabel.Text = state.Value.IsTransitioning
+                    ? $"{state.Value.ActiveStateName} → {state.Value.DestinationStateName}  {state.Value.TransitionAlpha:P0}"
+                    : $"{state.Value.ActiveStateName}  {state.Value.ActiveStateTime:F2}s";
+            }
+            catch (Exception exception)
+            {
+                stateLabel.Text = exception.Message;
+            }
+            finally
+            {
+                stateRequestPending = false;
+            }
+        };
+        return timer;
+    }
+
+    static AnimationControllerFile ResolveAnimationController(Component component)
+    {
+        if (!component.OverrideProperties.TryGetValue("controller", out var value) ||
+            value is not ObjectPtr controller || controller.FileId is null ||
+            controller.FileId.IsEmpty())
+        {
+            return null;
+        }
+        return MauiProgram.GetService<AssetsService>().Assets
+            .TryGetValue(controller.FileId, out var asset)
+            ? asset as AnimationControllerFile
+            : null;
+    }
+
+    static View CreateRuntimeFloatEditor(
+        Component component,
+        AnimationControllerParameter parameter)
+    {
+        var entry = new Entry
+        {
+            Text = parameter.DefaultFloat.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            Keyboard = Keyboard.Numeric,
+            ReturnType = ReturnType.Done
+        };
+        entry.Completed += (_, _) => entry.Unfocus();
+        entry.Unfocused += (_, _) =>
+        {
+            if (float.TryParse(
+                    entry.Text,
+                    System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var value))
+            {
+                _ = MauiProgram.GetService<EngineService>()
+                    .SetAnimatorFloatAsync(component.InstanceId, parameter.Name, value);
+            }
+        };
+        return entry;
+    }
+
+    static View CreateRuntimeIntEditor(
+        Component component,
+        AnimationControllerParameter parameter)
+    {
+        var entry = new Entry
+        {
+            Text = parameter.DefaultInt.ToString(System.Globalization.CultureInfo.InvariantCulture),
+            Keyboard = Keyboard.Numeric,
+            ReturnType = ReturnType.Done
+        };
+        entry.Completed += (_, _) => entry.Unfocus();
+        entry.Unfocused += (_, _) =>
+        {
+            if (int.TryParse(entry.Text, out var value))
+            {
+                _ = MauiProgram.GetService<EngineService>()
+                    .SetAnimatorIntAsync(component.InstanceId, parameter.Name, value);
+            }
+        };
+        return entry;
+    }
+
+    static View CreateRuntimeBoolEditor(
+        Component component,
+        AnimationControllerParameter parameter)
+    {
+        var check = new CheckBox { IsChecked = parameter.DefaultBool };
+        check.CheckedChanged += (_, args) =>
+        {
+            _ = MauiProgram.GetService<EngineService>()
+                .SetAnimatorBoolAsync(component.InstanceId, parameter.Name, args.Value);
+        };
+        return check;
+    }
+
+    static View CreateRuntimeTriggerEditor(
+        Component component,
+        AnimationControllerParameter parameter)
+    {
+        var fire = new Button { Text = "Fire", HeightRequest = 30 };
+        fire.Clicked += (_, _) =>
+        {
+            _ = MauiProgram.GetService<EngineService>()
+                .SetAnimatorTriggerAsync(component.InstanceId, parameter.Name);
+        };
+        return fire;
     }
 
     static string FormatComponentTypeName(string typeName)

--- a/Editor/Views/InspectorView/InspectorTemplateSelector.cs
+++ b/Editor/Views/InspectorView/InspectorTemplateSelector.cs
@@ -10,6 +10,8 @@ public class InspectorTemplateSelector : DataTemplateSelector
     public DataTemplate ShaderLibraryFileTemplate { get; set; }
     public DataTemplate MaterialFileTemplate { get; set; }
     public DataTemplate FrameGraphFileTemplate { get; set; }
+    public DataTemplate AnimationControllerFileTemplate { get; set; }
+    public DataTemplate AnimationSetFileTemplate { get; set; }
     public DataTemplate GameObjectTemplate { get; set; }
 
     protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
@@ -22,6 +24,8 @@ public class InspectorTemplateSelector : DataTemplateSelector
             ModelFile => ModelFileTemplate,
             MaterialFile => MaterialFileTemplate,
             FrameGraphFile => FrameGraphFileTemplate,
+            AnimationControllerFile => AnimationControllerFileTemplate,
+            AnimationSetFile => AnimationSetFileTemplate,
             AnimationFile => AssetFileTemplate,
             PrefabFile => AssetFileTemplate,
             WorldFile => AssetFileTemplate,

--- a/Lib/EditorEngineProtocol.cpp
+++ b/Lib/EditorEngineProtocol.cpp
@@ -913,6 +913,96 @@ namespace
 			Sailor::App::SetEditorSelection(serializedSelection.c_str()));
 	}
 
+	void DispatchAnimatorParameter(
+		const sailor::editor::v1::AnimatorParameterRequest& request,
+		ProtocolResponse& response)
+	{
+		uint32_t valueKind = 0;
+		float floatValue = 0.0f;
+		int32_t intValue = 0;
+		bool boolValue = false;
+		switch (request.value_case())
+		{
+		case sailor::editor::v1::AnimatorParameterRequest::kFloatValue:
+			valueKind = 1;
+			floatValue = request.float_value();
+			break;
+		case sailor::editor::v1::AnimatorParameterRequest::kIntValue:
+			valueKind = 2;
+			intValue = request.int_value();
+			break;
+		case sailor::editor::v1::AnimatorParameterRequest::kBoolValue:
+			valueKind = 3;
+			boolValue = request.bool_value();
+			break;
+		case sailor::editor::v1::AnimatorParameterRequest::kTrigger:
+			valueKind = 4;
+			break;
+		case sailor::editor::v1::AnimatorParameterRequest::kResetTrigger:
+			valueKind = 5;
+			break;
+		case sailor::editor::v1::AnimatorParameterRequest::VALUE_NOT_SET:
+			SetError(response, "Animator parameter value is not set.");
+			return;
+		}
+
+		SetBoolResult(
+			response,
+			Sailor::App::SetEditorAnimatorParameter(
+				request.instance_id().c_str(),
+				request.name().c_str(),
+				valueKind,
+				floatValue,
+				intValue,
+				boolValue));
+	}
+
+	void DispatchAnimatorState(
+		const sailor::editor::v1::InstanceIdRequest& request,
+		ProtocolResponse& response)
+	{
+		bool bHasController = false;
+		uint64_t controllerRevision = 0;
+		uint64_t activeStateId = 0;
+		float activeStateTime = 0.0f;
+		bool bTransitioning = false;
+		uint64_t destinationStateId = 0;
+		float destinationStateTime = 0.0f;
+		float transitionAlpha = 0.0f;
+		TInteropString activeStateName;
+		TInteropString destinationStateName;
+		if (!Sailor::App::GetEditorAnimatorState(
+				request.instance_id().c_str(),
+				bHasController,
+				controllerRevision,
+				activeStateId,
+				activeStateName.GetOutput(),
+				activeStateTime,
+				bTransitioning,
+				destinationStateId,
+				destinationStateName.GetOutput(),
+				destinationStateTime,
+				transitionAlpha))
+		{
+			SetError(response, "Animator component was not found.");
+			return;
+		}
+
+		SetSuccess(response);
+		auto* result = response.mutable_animator_state_result();
+		result->set_has_controller(bHasController);
+		result->set_controller_revision(controllerRevision);
+		result->set_active_state_id(activeStateId);
+		result->set_active_state_name(activeStateName.GetValue() ? activeStateName.GetValue() : "");
+		result->set_active_state_time(activeStateTime);
+		result->set_transitioning(bTransitioning);
+		result->set_destination_state_id(destinationStateId);
+		result->set_destination_state_name(
+			destinationStateName.GetValue() ? destinationStateName.GetValue() : "");
+		result->set_destination_state_time(destinationStateTime);
+		result->set_transition_alpha(transitionAlpha);
+	}
+
 	void DispatchRequest(
 		const ProtocolRequest& request,
 		ProtocolResponse& response,
@@ -952,6 +1042,14 @@ namespace
 			DispatchCreateModelInstance(
 				request.create_model_instance(),
 				response);
+			break;
+
+		case ProtocolRequest::kSetAnimatorParameter:
+			DispatchAnimatorParameter(request.set_animator_parameter(), response);
+			break;
+
+		case ProtocolRequest::kGetAnimatorState:
+			DispatchAnimatorState(request.get_animator_state(), response);
 			break;
 
 		case ProtocolRequest::kGetAssetReloadState:

--- a/Protocol/README.md
+++ b/Protocol/README.md
@@ -65,6 +65,14 @@ same source (for example, the assets generated from one glTF file). It does not
 scan Content or wait for unrelated Worker, RHI, or Render work. Commands that
 change Content topology still use `request_asset_reload`.
 
+`set_animator_parameter` updates one runtime Animator instance using a typed
+Float, Int, Bool, Trigger, or ResetTrigger value. `get_animator_state` returns
+the active state, optional destination state, controller revision, state clocks,
+and crossfade alpha for Editor preview and diagnostics. Both commands identify
+the component by its full `InstanceId`, execute through the regular Editor
+worker, and marshal to the Engine main thread. They never persist runtime
+parameter values into scene or controller YAML.
+
 `create_model_instance` performs one atomic Engine-side model drop. With
 `create_hierarchy = true`, the Engine creates the asset root and the editable
 parent-before-child glTF hierarchy, applies each node's local TRS, and attaches

--- a/Protocol/editor_engine.proto
+++ b/Protocol/editor_engine.proto
@@ -60,13 +60,15 @@ message ProtocolRequest {
 		ViewportIdRequest get_viewport_tool_state = 56;
 		FileIdRequest update_asset = 57;
 		CreateModelInstanceRequest create_model_instance = 58;
+		AnimatorParameterRequest set_animator_parameter = 59;
+		InstanceIdRequest get_animator_state = 60;
 	}
 
 	reserved 3 to 9;
 	reserved 50;
 	reserved "create_model_game_object";
 	reserved "resolve_viewport_drop_position";
-	reserved 59 to 99;
+	reserved 61 to 99;
 }
 
 message ProtocolResponse {
@@ -89,10 +91,11 @@ message ProtocolResponse {
 		ViewportEventBatchResult viewport_event_batch_result = 19;
 		Vector4Result vector4_result = 20;
 		ViewportToolStateResult viewport_tool_state_result = 21;
+		AnimatorStateResult animator_state_result = 22;
 	}
 
 	reserved 6 to 9;
-	reserved 22 to 99;
+	reserved 23 to 99;
 }
 
 message InitializeRequest {
@@ -195,6 +198,19 @@ message AddComponentRequest {
 	string preferred_instance_id = 3;
 }
 
+message AnimatorParameterRequest {
+	string instance_id = 1;
+	string name = 2;
+
+	oneof value {
+		float float_value = 3;
+		sint32 int_value = 4;
+		bool bool_value = 5;
+		Empty trigger = 6;
+		Empty reset_trigger = 7;
+	}
+}
+
 message InstantiatePrefabRequest {
 	string file_id = 1;
 	string parent_instance_id = 2;
@@ -295,6 +311,19 @@ message Vector4Result {
 message ViewportToolStateResult {
 	ViewportTransformOperation operation = 1;
 	ViewportTransformSpace space = 2;
+}
+
+message AnimatorStateResult {
+	bool has_controller = 1;
+	uint64 controller_revision = 2;
+	uint64 active_state_id = 3;
+	string active_state_name = 4;
+	float active_state_time = 5;
+	bool transitioning = 6;
+	uint64 destination_state_id = 7;
+	string destination_state_name = 8;
+	float destination_state_time = 9;
+	float transition_alpha = 10;
 }
 
 enum ViewportTransformOperation {

--- a/Runtime/AssetRegistry/Animation/AnimationClipSampler.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationClipSampler.cpp
@@ -1,0 +1,230 @@
+#include "AnimationClipSampler.h"
+#include "Math/Math.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+using namespace Sailor;
+
+namespace
+{
+	bool IsQuaternionFinite(const glm::quat& value)
+	{
+		return std::isfinite(value.x) &&
+			std::isfinite(value.y) &&
+			std::isfinite(value.z) &&
+			std::isfinite(value.w);
+	}
+
+	size_t GetValueIndex(uint32_t keyframe, EAnimationInterpolation interpolation)
+	{
+		return interpolation == EAnimationInterpolation::CubicSpline ?
+			static_cast<size_t>(keyframe) * 3 + 1 : keyframe;
+	}
+
+	bool HasExpectedValueCount(
+		const TVector<float>& timestamps,
+		const TVector<glm::vec4>& values,
+		EAnimationInterpolation interpolation)
+	{
+		const size_t multiplier = interpolation == EAnimationInterpolation::CubicSpline ? 3 : 1;
+		return timestamps.Num() <= (std::numeric_limits<size_t>::max)() / multiplier &&
+			values.Num() == timestamps.Num() * multiplier;
+	}
+
+	glm::vec4 CubicHermite(
+		const glm::vec4& first,
+		const glm::vec4& firstOutTangent,
+		const glm::vec4& second,
+		const glm::vec4& secondInTangent,
+		float alpha,
+		float duration)
+	{
+		const float alpha2 = alpha * alpha;
+		const float alpha3 = alpha2 * alpha;
+		const float h00 = 2.0f * alpha3 - 3.0f * alpha2 + 1.0f;
+		const float h10 = alpha3 - 2.0f * alpha2 + alpha;
+		const float h01 = -2.0f * alpha3 + 3.0f * alpha2;
+		const float h11 = alpha3 - alpha2;
+		return h00 * first +
+			h10 * duration * firstOutTangent +
+			h01 * second +
+			h11 * duration * secondInTangent;
+	}
+}
+
+bool AnimationClipSampler::ValidateTimestamps(const TVector<float>& timestamps)
+{
+	if (timestamps.IsEmpty())
+	{
+		return false;
+	}
+
+	float previous = timestamps[0];
+	if (!std::isfinite(previous) || previous < 0.0f)
+	{
+		return false;
+	}
+
+	for (size_t i = 1; i < timestamps.Num(); ++i)
+	{
+		const float current = timestamps[i];
+		if (!std::isfinite(current) || current <= previous)
+		{
+			return false;
+		}
+		previous = current;
+	}
+
+	return true;
+}
+
+bool AnimationClipSampler::ResolveKeyframeSpan(
+	const TVector<float>& timestamps,
+	float time,
+	AnimationKeyframeSpan& outSpan)
+{
+	outSpan = {};
+	if (!ValidateTimestamps(timestamps) || !std::isfinite(time))
+	{
+		return false;
+	}
+
+	if (time <= timestamps[0] || timestamps.Num() == 1)
+	{
+		return true;
+	}
+
+	const uint32_t last = static_cast<uint32_t>(timestamps.Num() - 1);
+	if (time >= timestamps[last])
+	{
+		outSpan.m_first = last;
+		outSpan.m_second = last;
+		return true;
+	}
+
+	uint32_t left = 1;
+	uint32_t right = last;
+	while (left < right)
+	{
+		const uint32_t middle = left + (right - left) / 2;
+		if (timestamps[middle] <= time)
+		{
+			left = middle + 1;
+		}
+		else
+		{
+			right = middle;
+		}
+	}
+
+	outSpan.m_first = left - 1;
+	outSpan.m_second = left;
+	outSpan.m_duration = timestamps[left] - timestamps[left - 1];
+	outSpan.m_alpha = std::clamp(
+		(time - timestamps[left - 1]) / outSpan.m_duration,
+		0.0f,
+		1.0f);
+	return true;
+}
+
+bool AnimationClipSampler::SampleVector(
+	const TVector<float>& timestamps,
+	const TVector<glm::vec4>& values,
+	EAnimationInterpolation interpolation,
+	float time,
+	glm::vec4& outValue)
+{
+	AnimationKeyframeSpan span;
+	if (!HasExpectedValueCount(timestamps, values, interpolation) ||
+		!ResolveKeyframeSpan(timestamps, time, span))
+	{
+		return false;
+	}
+
+	const size_t firstValue = GetValueIndex(span.m_first, interpolation);
+	if (span.m_first == span.m_second || interpolation == EAnimationInterpolation::Step)
+	{
+		outValue = values[firstValue];
+	}
+	else if (interpolation == EAnimationInterpolation::Linear)
+	{
+		outValue = glm::mix(values[firstValue], values[span.m_second], span.m_alpha);
+	}
+	else
+	{
+		const size_t firstBase = static_cast<size_t>(span.m_first) * 3;
+		const size_t secondBase = static_cast<size_t>(span.m_second) * 3;
+		outValue = CubicHermite(
+			values[firstBase + 1],
+			values[firstBase + 2],
+			values[secondBase + 1],
+			values[secondBase],
+			span.m_alpha,
+			span.m_duration);
+	}
+
+	return Math::AllFinite(outValue);
+}
+
+bool AnimationClipSampler::SampleRotation(
+	const TVector<float>& timestamps,
+	const TVector<glm::vec4>& values,
+	EAnimationInterpolation interpolation,
+	float time,
+	glm::quat& outValue)
+{
+	AnimationKeyframeSpan span;
+	if (!HasExpectedValueCount(timestamps, values, interpolation) ||
+		!ResolveKeyframeSpan(timestamps, time, span))
+	{
+		return false;
+	}
+
+	const auto toQuaternion = [](const glm::vec4& value)
+	{
+		return glm::quat(value.w, value.x, value.y, value.z);
+	};
+	const auto normalize = [](const glm::quat& value, glm::quat& out)
+	{
+		const float lengthSquared = glm::dot(value, value);
+		if (!std::isfinite(lengthSquared) ||
+			lengthSquared <= std::numeric_limits<float>::epsilon())
+		{
+			return false;
+		}
+		out = glm::normalize(value);
+		return IsQuaternionFinite(out);
+	};
+
+	const size_t firstValue = GetValueIndex(span.m_first, interpolation);
+	if (span.m_first == span.m_second || interpolation == EAnimationInterpolation::Step)
+	{
+		return normalize(toQuaternion(values[firstValue]), outValue);
+	}
+
+	if (interpolation == EAnimationInterpolation::Linear)
+	{
+		glm::quat first;
+		glm::quat second;
+		if (!normalize(toQuaternion(values[firstValue]), first) ||
+			!normalize(toQuaternion(values[span.m_second]), second))
+		{
+			return false;
+		}
+		outValue = glm::slerp(first, second, span.m_alpha);
+		return IsQuaternionFinite(outValue);
+	}
+
+	const size_t firstBase = static_cast<size_t>(span.m_first) * 3;
+	const size_t secondBase = static_cast<size_t>(span.m_second) * 3;
+	const glm::vec4 value = CubicHermite(
+		values[firstBase + 1],
+		values[firstBase + 2],
+		values[secondBase + 1],
+		values[secondBase],
+		span.m_alpha,
+		span.m_duration);
+	return normalize(toQuaternion(value), outValue);
+}

--- a/Runtime/AssetRegistry/Animation/AnimationClipSampler.h
+++ b/Runtime/AssetRegistry/Animation/AnimationClipSampler.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "Core/Defines.h"
+#include "Memory/LockFreeHeapAllocator.h"
+#include "Containers/Vector.h"
+#include <glm/vec4.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+namespace Sailor
+{
+	enum class EAnimationInterpolation : uint8_t
+	{
+		Linear,
+		Step,
+		CubicSpline
+	};
+
+	struct AnimationKeyframeSpan
+	{
+		uint32_t m_first = 0;
+		uint32_t m_second = 0;
+		float m_alpha = 0.0f;
+		float m_duration = 0.0f;
+	};
+
+	class AnimationClipSampler final
+	{
+	public:
+		SAILOR_API static bool ValidateTimestamps(const TVector<float>& timestamps);
+		SAILOR_API static bool ResolveKeyframeSpan(
+			const TVector<float>& timestamps,
+			float time,
+			AnimationKeyframeSpan& outSpan);
+
+		SAILOR_API static bool SampleVector(
+			const TVector<float>& timestamps,
+			const TVector<glm::vec4>& values,
+			EAnimationInterpolation interpolation,
+			float time,
+			glm::vec4& outValue);
+
+		SAILOR_API static bool SampleRotation(
+			const TVector<float>& timestamps,
+			const TVector<glm::vec4>& values,
+			EAnimationInterpolation interpolation,
+			float time,
+			glm::quat& outValue);
+	};
+}

--- a/Runtime/AssetRegistry/Animation/AnimationController.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationController.cpp
@@ -1,0 +1,873 @@
+#include "AnimationController.h"
+#include "Math/Math.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+using namespace Sailor;
+
+namespace
+{
+	const char* ToString(EAnimationParameterType type)
+	{
+		switch (type)
+		{
+		case EAnimationParameterType::Float: return "Float";
+		case EAnimationParameterType::Int: return "Int";
+		case EAnimationParameterType::Bool: return "Bool";
+		case EAnimationParameterType::Trigger: return "Trigger";
+		}
+		return "Float";
+	}
+
+	const char* ToString(EAnimationConditionOperation operation)
+	{
+		switch (operation)
+		{
+		case EAnimationConditionOperation::Equal: return "Equal";
+		case EAnimationConditionOperation::NotEqual: return "NotEqual";
+		case EAnimationConditionOperation::Less: return "Less";
+		case EAnimationConditionOperation::LessOrEqual: return "LessOrEqual";
+		case EAnimationConditionOperation::Greater: return "Greater";
+		case EAnimationConditionOperation::GreaterOrEqual: return "GreaterOrEqual";
+		case EAnimationConditionOperation::IsSet: return "IsSet";
+		}
+		return "Equal";
+	}
+
+	EAnimationParameterType ParseParameterType(const YAML::Node& node)
+	{
+		const std::string value = node.as<std::string>("Float");
+		if (value == "Int") return EAnimationParameterType::Int;
+		if (value == "Bool") return EAnimationParameterType::Bool;
+		if (value == "Trigger") return EAnimationParameterType::Trigger;
+		return EAnimationParameterType::Float;
+	}
+
+	EAnimationConditionOperation ParseConditionOperation(const YAML::Node& node)
+	{
+		const std::string value = node.as<std::string>("Equal");
+		if (value == "NotEqual") return EAnimationConditionOperation::NotEqual;
+		if (value == "Less") return EAnimationConditionOperation::Less;
+		if (value == "LessOrEqual") return EAnimationConditionOperation::LessOrEqual;
+		if (value == "Greater") return EAnimationConditionOperation::Greater;
+		if (value == "GreaterOrEqual") return EAnimationConditionOperation::GreaterOrEqual;
+		if (value == "IsSet") return EAnimationConditionOperation::IsSet;
+		return EAnimationConditionOperation::Equal;
+	}
+
+	void AddError(TVector<std::string>* errors, const std::string& error)
+	{
+		if (errors)
+		{
+			errors->Add(error);
+		}
+	}
+
+	bool IsOperationValid(
+		EAnimationParameterType type,
+		EAnimationConditionOperation operation)
+	{
+		if (type == EAnimationParameterType::Trigger)
+		{
+			return operation == EAnimationConditionOperation::IsSet;
+		}
+		if (type == EAnimationParameterType::Bool)
+		{
+			return operation == EAnimationConditionOperation::Equal ||
+				operation == EAnimationConditionOperation::NotEqual;
+		}
+		return operation != EAnimationConditionOperation::IsSet;
+	}
+}
+
+YAML::Node AnimationControllerAsset::Serialize() const
+{
+	YAML::Node result;
+	result["version"] = m_version;
+	result["defaultState"] = m_defaultStateId;
+
+	for (const auto& parameter : m_parameters)
+	{
+		YAML::Node serialized;
+		serialized["id"] = parameter.m_id;
+		serialized["name"] = parameter.m_name;
+		serialized["type"] = ToString(parameter.m_type);
+		switch (parameter.m_type)
+		{
+		case EAnimationParameterType::Float:
+			serialized["default"] = parameter.m_defaultFloat;
+			break;
+		case EAnimationParameterType::Int:
+			serialized["default"] = parameter.m_defaultInt;
+			break;
+		case EAnimationParameterType::Bool:
+			serialized["default"] = parameter.m_defaultBool;
+			break;
+		case EAnimationParameterType::Trigger:
+			break;
+		}
+		result["parameters"].push_back(serialized);
+	}
+
+	for (const auto& state : m_states)
+	{
+		YAML::Node serialized;
+		serialized["id"] = state.m_id;
+		serialized["name"] = state.m_name;
+		serialized["clip"] = state.m_clipSlot;
+		serialized["speed"] = state.m_speed;
+		serialized["loop"] = state.m_bLoop;
+		serialized["editor"]["x"] = state.m_editorX;
+		serialized["editor"]["y"] = state.m_editorY;
+		result["states"].push_back(serialized);
+	}
+
+	for (const auto& transition : m_transitions)
+	{
+		YAML::Node serialized;
+		serialized["id"] = transition.m_id;
+		serialized["from"] = transition.m_fromStateId;
+		serialized["to"] = transition.m_toStateId;
+		serialized["priority"] = transition.m_priority;
+		serialized["duration"] = transition.m_duration;
+		serialized["hasExitTime"] = transition.m_bHasExitTime;
+		serialized["exitTime"] = transition.m_exitTime;
+		serialized["conditions"] = YAML::Node(YAML::NodeType::Sequence);
+		for (const auto& condition : transition.m_conditions)
+		{
+			YAML::Node serializedCondition;
+			serializedCondition["parameter"] = condition.m_parameterId;
+			serializedCondition["operation"] = ToString(condition.m_operation);
+			serializedCondition["floatValue"] = condition.m_floatValue;
+			serializedCondition["intValue"] = condition.m_intValue;
+			serializedCondition["boolValue"] = condition.m_boolValue;
+			serialized["conditions"].push_back(serializedCondition);
+		}
+		result["transitions"].push_back(serialized);
+	}
+
+	return result;
+}
+
+void AnimationControllerAsset::Deserialize(const YAML::Node& inData)
+{
+	m_version = inData["version"].as<uint32_t>(1);
+	m_defaultStateId = inData["defaultState"].as<AnimationControllerNodeId>(
+		InvalidAnimationControllerNodeId);
+	m_parameters.Clear();
+	m_states.Clear();
+	m_transitions.Clear();
+
+	const YAML::Node parameters = inData["parameters"];
+	if (parameters.IsSequence())
+	{
+		m_parameters.Reserve(parameters.size());
+		for (const auto& serialized : parameters)
+		{
+			AnimationParameterDefinition parameter;
+			parameter.m_id = serialized["id"].as<AnimationControllerNodeId>(
+				InvalidAnimationControllerNodeId);
+			parameter.m_name = serialized["name"].as<std::string>("");
+			parameter.m_type = ParseParameterType(serialized["type"]);
+			switch (parameter.m_type)
+			{
+			case EAnimationParameterType::Float:
+				parameter.m_defaultFloat = serialized["default"].as<float>(0.0f);
+				break;
+			case EAnimationParameterType::Int:
+				parameter.m_defaultInt = serialized["default"].as<int32_t>(0);
+				break;
+			case EAnimationParameterType::Bool:
+				parameter.m_defaultBool = serialized["default"].as<bool>(false);
+				break;
+			case EAnimationParameterType::Trigger:
+				break;
+			}
+			m_parameters.Add(std::move(parameter));
+		}
+	}
+
+	const YAML::Node states = inData["states"];
+	if (states.IsSequence())
+	{
+		m_states.Reserve(states.size());
+		for (const auto& serialized : states)
+		{
+			AnimationStateDefinition state;
+			state.m_id = serialized["id"].as<AnimationControllerNodeId>(
+				InvalidAnimationControllerNodeId);
+			state.m_name = serialized["name"].as<std::string>("");
+			state.m_clipSlot = serialized["clip"].as<std::string>("");
+			state.m_speed = serialized["speed"].as<float>(1.0f);
+			state.m_bLoop = serialized["loop"].as<bool>(true);
+			const YAML::Node editor = serialized["editor"];
+			state.m_editorX = editor["x"].as<float>(0.0f);
+			state.m_editorY = editor["y"].as<float>(0.0f);
+			m_states.Add(std::move(state));
+		}
+	}
+
+	const YAML::Node transitions = inData["transitions"];
+	if (transitions.IsSequence())
+	{
+		m_transitions.Reserve(transitions.size());
+		for (const auto& serialized : transitions)
+		{
+			AnimationTransitionDefinition transition;
+			transition.m_id = serialized["id"].as<AnimationControllerNodeId>(
+				InvalidAnimationControllerNodeId);
+			transition.m_fromStateId = serialized["from"].as<AnimationControllerNodeId>(
+				InvalidAnimationControllerNodeId);
+			transition.m_toStateId = serialized["to"].as<AnimationControllerNodeId>(
+				InvalidAnimationControllerNodeId);
+			transition.m_priority = serialized["priority"].as<int32_t>(0);
+			transition.m_duration = serialized["duration"].as<float>(0.2f);
+			transition.m_bHasExitTime = serialized["hasExitTime"].as<bool>(false);
+			transition.m_exitTime = serialized["exitTime"].as<float>(0.0f);
+
+			YAML::Node conditions;
+			for (const auto& field : serialized)
+			{
+				if (field.first.as<std::string>("") == "conditions")
+				{
+					conditions = field.second;
+					break;
+				}
+			}
+			if (conditions.IsSequence())
+			{
+				transition.m_conditions.Reserve(conditions.size());
+				for (const auto& serializedCondition : conditions)
+				{
+					AnimationTransitionCondition condition;
+					condition.m_parameterId = serializedCondition["parameter"].as<AnimationControllerNodeId>(
+						InvalidAnimationControllerNodeId);
+					condition.m_operation = ParseConditionOperation(serializedCondition["operation"]);
+					condition.m_floatValue = serializedCondition["floatValue"].as<float>(0.0f);
+					condition.m_intValue = serializedCondition["intValue"].as<int32_t>(0);
+					condition.m_boolValue = serializedCondition["boolValue"].as<bool>(false);
+					transition.m_conditions.Add(std::move(condition));
+				}
+			}
+			m_transitions.Add(std::move(transition));
+		}
+	}
+}
+
+YAML::Node AnimationSetAsset::Serialize() const
+{
+	YAML::Node result;
+	result["version"] = m_version;
+	for (const auto& entry : m_entries)
+	{
+		YAML::Node serialized;
+		serialized["slot"] = entry.m_slot;
+		serialized["animation"] = entry.m_animation.Serialize();
+		result["clips"].push_back(serialized);
+	}
+	return result;
+}
+
+void AnimationSetAsset::Deserialize(const YAML::Node& inData)
+{
+	m_version = inData["version"].as<uint32_t>(1);
+	m_entries.Clear();
+	const YAML::Node entries = inData["clips"];
+	if (!entries.IsSequence())
+	{
+		return;
+	}
+
+	m_entries.Reserve(entries.size());
+	for (const auto& serialized : entries)
+	{
+		AnimationSetEntry entry;
+		entry.m_slot = serialized["slot"].as<std::string>("");
+		if (serialized["animation"])
+		{
+			entry.m_animation = serialized["animation"].as<FileId>();
+		}
+		m_entries.Add(std::move(entry));
+	}
+}
+
+bool AnimationController::Initialize(
+	const AnimationControllerAsset& asset,
+	TVector<std::string>* outErrors)
+{
+	TVector<AnimationParameterDefinition> previousParameters = m_parameters;
+	TVector<AnimationStateDefinition> previousStates = m_states;
+	TVector<AnimationTransitionDefinition> previousTransitions = m_transitions;
+	const uint32_t previousDefaultStateIndex = m_defaultStateIndex;
+
+	m_parameters = asset.GetParameters();
+	m_states = asset.GetStates();
+	m_transitions = asset.GetTransitions();
+	m_defaultStateIndex = (std::numeric_limits<uint32_t>::max)();
+
+	const int32_t defaultStateIndex = FindStateIndex(asset.GetDefaultStateId());
+	if (defaultStateIndex >= 0)
+	{
+		m_defaultStateIndex = static_cast<uint32_t>(defaultStateIndex);
+	}
+
+	if (!Validate(outErrors))
+	{
+		m_parameters = std::move(previousParameters);
+		m_states = std::move(previousStates);
+		m_transitions = std::move(previousTransitions);
+		m_defaultStateIndex = previousDefaultStateIndex;
+		return false;
+	}
+
+	for (auto& transition : m_transitions)
+	{
+		transition.m_fromStateIndex = static_cast<uint32_t>(FindStateIndex(transition.m_fromStateId));
+		transition.m_toStateIndex = static_cast<uint32_t>(FindStateIndex(transition.m_toStateId));
+		for (auto& condition : transition.m_conditions)
+		{
+			condition.m_parameterIndex = static_cast<uint32_t>(FindParameterIndex(condition.m_parameterId));
+		}
+	}
+	++m_revision;
+
+	return true;
+}
+
+bool AnimationController::Validate(TVector<std::string>* outErrors) const
+{
+	if (outErrors)
+	{
+		outErrors->Clear();
+	}
+	bool bValid = true;
+
+	if (m_states.IsEmpty())
+	{
+		AddError(outErrors, "The controller must contain at least one state.");
+		bValid = false;
+	}
+	if (m_defaultStateIndex >= m_states.Num())
+	{
+		AddError(outErrors, "The controller default state does not exist.");
+		bValid = false;
+	}
+
+	for (size_t i = 0; i < m_parameters.Num(); ++i)
+	{
+		const auto& parameter = m_parameters[i];
+		if (parameter.m_id == InvalidAnimationControllerNodeId || parameter.m_name.empty())
+		{
+			AddError(outErrors, "Animation parameters require a stable id and name.");
+			bValid = false;
+		}
+		if (parameter.m_type == EAnimationParameterType::Float &&
+			!std::isfinite(parameter.m_defaultFloat))
+		{
+			AddError(outErrors, "Float parameter defaults must be finite.");
+			bValid = false;
+		}
+		for (size_t j = 0; j < i; ++j)
+		{
+			if (m_parameters[j].m_id == parameter.m_id ||
+				m_parameters[j].m_name == parameter.m_name)
+			{
+				AddError(outErrors, "Animation parameter ids and names must be unique.");
+				bValid = false;
+				break;
+			}
+		}
+	}
+
+	for (size_t i = 0; i < m_states.Num(); ++i)
+	{
+		const auto& state = m_states[i];
+		if (state.m_id == InvalidAnimationControllerNodeId ||
+			state.m_name.empty() || state.m_clipSlot.empty())
+		{
+			AddError(outErrors, "Animation states require a stable id, name, and clip slot.");
+			bValid = false;
+		}
+		if (!std::isfinite(state.m_speed) || state.m_speed <= 0.0f ||
+			!std::isfinite(state.m_editorX) || !std::isfinite(state.m_editorY))
+		{
+			AddError(outErrors, "Animation state speed and editor position must be finite, with speed greater than zero.");
+			bValid = false;
+		}
+		for (size_t j = 0; j < i; ++j)
+		{
+			if (m_states[j].m_id == state.m_id || m_states[j].m_name == state.m_name)
+			{
+				AddError(outErrors, "Animation state ids and names must be unique.");
+				bValid = false;
+				break;
+			}
+		}
+	}
+
+	for (size_t i = 0; i < m_transitions.Num(); ++i)
+	{
+		const auto& transition = m_transitions[i];
+		if (transition.m_id == InvalidAnimationControllerNodeId ||
+			FindStateIndex(transition.m_fromStateId) < 0 ||
+			FindStateIndex(transition.m_toStateId) < 0)
+		{
+			AddError(outErrors, "Animation transitions require a stable id and valid source and destination states.");
+			bValid = false;
+		}
+		if (!std::isfinite(transition.m_duration) || transition.m_duration < 0.0f ||
+			!std::isfinite(transition.m_exitTime) || transition.m_exitTime < 0.0f ||
+			transition.m_exitTime > 1.0f)
+		{
+			AddError(outErrors, "Animation transition duration and normalized exit time are invalid.");
+			bValid = false;
+		}
+		for (size_t j = 0; j < i; ++j)
+		{
+			if (m_transitions[j].m_id == transition.m_id)
+			{
+				AddError(outErrors, "Animation transition ids must be unique.");
+				bValid = false;
+				break;
+			}
+		}
+
+		for (const auto& condition : transition.m_conditions)
+		{
+			const int32_t parameterIndex = FindParameterIndex(condition.m_parameterId);
+			if (parameterIndex < 0)
+			{
+				AddError(outErrors, "Animation transition conditions must reference an existing parameter.");
+				bValid = false;
+				continue;
+			}
+
+			const auto& parameter = m_parameters[static_cast<size_t>(parameterIndex)];
+			if (!IsOperationValid(parameter.m_type, condition.m_operation) ||
+				(parameter.m_type == EAnimationParameterType::Float &&
+				 !std::isfinite(condition.m_floatValue)))
+			{
+				AddError(outErrors, "Animation transition condition operation does not match its parameter type.");
+				bValid = false;
+			}
+		}
+	}
+
+	return bValid;
+}
+
+int32_t AnimationController::FindStateIndex(AnimationControllerNodeId stateId) const
+{
+	for (size_t i = 0; i < m_states.Num(); ++i)
+	{
+		if (m_states[i].m_id == stateId)
+		{
+			return static_cast<int32_t>(i);
+		}
+	}
+	return -1;
+}
+
+int32_t AnimationController::FindParameterIndex(AnimationControllerNodeId parameterId) const
+{
+	for (size_t i = 0; i < m_parameters.Num(); ++i)
+	{
+		if (m_parameters[i].m_id == parameterId)
+		{
+			return static_cast<int32_t>(i);
+		}
+	}
+	return -1;
+}
+
+int32_t AnimationController::FindParameterIndex(const std::string& name) const
+{
+	for (size_t i = 0; i < m_parameters.Num(); ++i)
+	{
+		if (m_parameters[i].m_name == name)
+		{
+			return static_cast<int32_t>(i);
+		}
+	}
+	return -1;
+}
+
+bool AnimationSet::Initialize(
+	const AnimationSetAsset& asset,
+	TVector<std::string>* outErrors)
+{
+	if (outErrors)
+	{
+		outErrors->Clear();
+	}
+	TVector<AnimationSetEntry> entries = asset.GetEntries();
+	bool bValid = true;
+	for (size_t i = 0; i < entries.Num(); ++i)
+	{
+		if (entries[i].m_slot.empty() || !entries[i].m_animation)
+		{
+			AddError(outErrors, "Animation set entries require a slot name and animation FileId.");
+			bValid = false;
+		}
+		for (size_t j = 0; j < i; ++j)
+		{
+			if (entries[j].m_slot == entries[i].m_slot)
+			{
+				AddError(outErrors, "Animation set slot names must be unique.");
+				bValid = false;
+				break;
+			}
+		}
+	}
+	if (bValid)
+	{
+		m_entries = std::move(entries);
+		++m_revision;
+	}
+	return bValid;
+}
+
+const FileId* AnimationSet::FindAnimation(const std::string& slot) const
+{
+	for (const auto& entry : m_entries)
+	{
+		if (entry.m_slot == slot)
+		{
+			return &entry.m_animation;
+		}
+	}
+	return nullptr;
+}
+
+bool AnimationControllerInstance::SetController(const AnimationControllerPtr& controller)
+{
+	m_controller = controller;
+	m_parameterValues.Clear();
+	m_parameterIds.Clear();
+	m_activeStateIndex = InvalidIndex;
+	m_destinationStateIndex = InvalidIndex;
+	m_activeStateTime = 0.0f;
+	m_destinationStateTime = 0.0f;
+	m_transitionElapsed = 0.0f;
+	m_transitionDuration = 0.0f;
+	m_activeStateId = InvalidAnimationControllerNodeId;
+	m_destinationStateId = InvalidAnimationControllerNodeId;
+	m_controllerRevision = m_controller ? m_controller->GetRevision() : 0;
+
+	if (!m_controller || m_controller->GetStates().IsEmpty())
+	{
+		return false;
+	}
+
+	m_parameterValues.Resize(m_controller->GetParameters().Num());
+	m_parameterIds.Resize(m_controller->GetParameters().Num());
+	for (size_t i = 0; i < m_controller->GetParameters().Num(); ++i)
+	{
+		const auto& definition = m_controller->GetParameters()[i];
+		auto& value = m_parameterValues[i];
+		m_parameterIds[i] = definition.m_id;
+		value.m_floatValue = definition.m_defaultFloat;
+		value.m_intValue = definition.m_defaultInt;
+		value.m_boolValue = definition.m_type == EAnimationParameterType::Trigger ?
+			false : definition.m_defaultBool;
+	}
+	m_activeStateIndex = m_controller->GetDefaultStateIndex();
+	if (m_activeStateIndex < m_controller->GetStates().Num())
+	{
+		m_activeStateId = m_controller->GetStates()[m_activeStateIndex].m_id;
+	}
+	return m_activeStateIndex < m_controller->GetStates().Num();
+}
+
+void AnimationControllerInstance::Reset()
+{
+	SetController(m_controller);
+}
+
+void AnimationControllerInstance::Tick(float deltaTime, float activeClipDuration)
+{
+	if (!SynchronizeController() || !IsValid() || !std::isfinite(deltaTime) || deltaTime < 0.0f)
+	{
+		return;
+	}
+
+	const auto& states = m_controller->GetStates();
+	if (IsTransitioning())
+	{
+		m_activeStateTime += deltaTime * states[m_activeStateIndex].m_speed;
+		m_destinationStateTime += deltaTime * states[m_destinationStateIndex].m_speed;
+		m_transitionElapsed += deltaTime;
+		if (m_transitionDuration <= 0.0f || m_transitionElapsed >= m_transitionDuration)
+		{
+			CompleteTransition();
+		}
+		return;
+	}
+
+	m_activeStateTime += deltaTime * states[m_activeStateIndex].m_speed;
+	TryBeginTransition(activeClipDuration);
+}
+
+bool AnimationControllerInstance::SetFloat(const std::string& name, float value)
+{
+	if (!std::isfinite(value))
+	{
+		return false;
+	}
+	AnimationParameterValue parameter;
+	parameter.m_floatValue = value;
+	return SetParameter(name, EAnimationParameterType::Float, parameter);
+}
+
+bool AnimationControllerInstance::SetInt(const std::string& name, int32_t value)
+{
+	AnimationParameterValue parameter;
+	parameter.m_intValue = value;
+	return SetParameter(name, EAnimationParameterType::Int, parameter);
+}
+
+bool AnimationControllerInstance::SetBool(const std::string& name, bool value)
+{
+	AnimationParameterValue parameter;
+	parameter.m_boolValue = value;
+	return SetParameter(name, EAnimationParameterType::Bool, parameter);
+}
+
+bool AnimationControllerInstance::SetTrigger(const std::string& name)
+{
+	AnimationParameterValue parameter;
+	parameter.m_boolValue = true;
+	return SetParameter(name, EAnimationParameterType::Trigger, parameter);
+}
+
+bool AnimationControllerInstance::ResetTrigger(const std::string& name)
+{
+	AnimationParameterValue parameter;
+	parameter.m_boolValue = false;
+	return SetParameter(name, EAnimationParameterType::Trigger, parameter);
+}
+
+float AnimationControllerInstance::GetTransitionAlpha() const
+{
+	if (!IsTransitioning())
+	{
+		return 0.0f;
+	}
+	if (m_transitionDuration <= 0.0f)
+	{
+		return 1.0f;
+	}
+	return std::clamp(m_transitionElapsed / m_transitionDuration, 0.0f, 1.0f);
+}
+
+bool AnimationControllerInstance::SetParameter(
+	const std::string& name,
+	EAnimationParameterType type,
+	const AnimationParameterValue& value)
+{
+	if (!SynchronizeController())
+	{
+		return false;
+	}
+	const int32_t parameterIndex = m_controller->FindParameterIndex(name);
+	if (parameterIndex < 0 ||
+		m_controller->GetParameters()[static_cast<size_t>(parameterIndex)].m_type != type)
+	{
+		return false;
+	}
+	m_parameterValues[static_cast<size_t>(parameterIndex)] = value;
+	return true;
+}
+
+bool AnimationControllerInstance::AreConditionsMet(
+	const AnimationTransitionDefinition& transition) const
+{
+	for (const auto& condition : transition.m_conditions)
+	{
+		if (condition.m_parameterIndex >= m_parameterValues.Num())
+		{
+			return false;
+		}
+		const auto& definition = m_controller->GetParameters()[condition.m_parameterIndex];
+		const auto& value = m_parameterValues[condition.m_parameterIndex];
+		bool bConditionMet = false;
+
+		switch (definition.m_type)
+		{
+		case EAnimationParameterType::Float:
+		{
+			const float epsilon = std::numeric_limits<float>::epsilon() * 4.0f;
+			const bool bEqual = std::abs(value.m_floatValue - condition.m_floatValue) <= epsilon;
+			switch (condition.m_operation)
+			{
+			case EAnimationConditionOperation::Equal: bConditionMet = bEqual; break;
+			case EAnimationConditionOperation::NotEqual: bConditionMet = !bEqual; break;
+			case EAnimationConditionOperation::Less: bConditionMet = value.m_floatValue < condition.m_floatValue; break;
+			case EAnimationConditionOperation::LessOrEqual: bConditionMet = value.m_floatValue <= condition.m_floatValue; break;
+			case EAnimationConditionOperation::Greater: bConditionMet = value.m_floatValue > condition.m_floatValue; break;
+			case EAnimationConditionOperation::GreaterOrEqual: bConditionMet = value.m_floatValue >= condition.m_floatValue; break;
+			case EAnimationConditionOperation::IsSet: break;
+			}
+			break;
+		}
+		case EAnimationParameterType::Int:
+			switch (condition.m_operation)
+			{
+			case EAnimationConditionOperation::Equal: bConditionMet = value.m_intValue == condition.m_intValue; break;
+			case EAnimationConditionOperation::NotEqual: bConditionMet = value.m_intValue != condition.m_intValue; break;
+			case EAnimationConditionOperation::Less: bConditionMet = value.m_intValue < condition.m_intValue; break;
+			case EAnimationConditionOperation::LessOrEqual: bConditionMet = value.m_intValue <= condition.m_intValue; break;
+			case EAnimationConditionOperation::Greater: bConditionMet = value.m_intValue > condition.m_intValue; break;
+			case EAnimationConditionOperation::GreaterOrEqual: bConditionMet = value.m_intValue >= condition.m_intValue; break;
+			case EAnimationConditionOperation::IsSet: break;
+			}
+			break;
+		case EAnimationParameterType::Bool:
+			bConditionMet = condition.m_operation == EAnimationConditionOperation::Equal ?
+				value.m_boolValue == condition.m_boolValue :
+				value.m_boolValue != condition.m_boolValue;
+			break;
+		case EAnimationParameterType::Trigger:
+			bConditionMet = value.m_boolValue;
+			break;
+		}
+
+		if (!bConditionMet)
+		{
+			return false;
+		}
+	}
+	return true;
+}
+
+void AnimationControllerInstance::ConsumeTriggers(
+	const AnimationTransitionDefinition& transition)
+{
+	for (const auto& condition : transition.m_conditions)
+	{
+		if (condition.m_parameterIndex < m_parameterValues.Num() &&
+			m_controller->GetParameters()[condition.m_parameterIndex].m_type ==
+				EAnimationParameterType::Trigger)
+		{
+			m_parameterValues[condition.m_parameterIndex].m_boolValue = false;
+		}
+	}
+}
+
+void AnimationControllerInstance::TryBeginTransition(float activeClipDuration)
+{
+	const AnimationTransitionDefinition* selected = nullptr;
+	for (const auto& transition : m_controller->GetTransitions())
+	{
+		if (transition.m_fromStateIndex != m_activeStateIndex)
+		{
+			continue;
+		}
+
+		const float normalizedTime = activeClipDuration > 0.0f ?
+			m_activeStateTime / activeClipDuration : 0.0f;
+		if ((transition.m_bHasExitTime && normalizedTime < transition.m_exitTime) ||
+			!AreConditionsMet(transition))
+		{
+			continue;
+		}
+
+		if (!selected || transition.m_priority > selected->m_priority)
+		{
+			selected = &transition;
+		}
+	}
+
+	if (!selected)
+	{
+		return;
+	}
+
+	m_destinationStateIndex = selected->m_toStateIndex;
+	m_destinationStateId = selected->m_toStateId;
+	m_destinationStateTime = 0.0f;
+	m_transitionElapsed = 0.0f;
+	m_transitionDuration = selected->m_duration;
+	ConsumeTriggers(*selected);
+	if (m_transitionDuration <= 0.0f)
+	{
+		CompleteTransition();
+	}
+}
+
+void AnimationControllerInstance::CompleteTransition()
+{
+	if (!IsTransitioning())
+	{
+		return;
+	}
+	m_activeStateIndex = m_destinationStateIndex;
+	m_activeStateId = m_destinationStateId;
+	m_activeStateTime = m_destinationStateTime;
+	m_destinationStateIndex = InvalidIndex;
+	m_destinationStateId = InvalidAnimationControllerNodeId;
+	m_destinationStateTime = 0.0f;
+	m_transitionElapsed = 0.0f;
+	m_transitionDuration = 0.0f;
+}
+
+bool AnimationControllerInstance::SynchronizeController()
+{
+	if (!m_controller)
+	{
+		return false;
+	}
+	if (m_controllerRevision == m_controller->GetRevision())
+	{
+		return true;
+	}
+
+	TVector<AnimationParameterValue> previousValues = m_parameterValues;
+	TVector<AnimationControllerNodeId> previousIds = m_parameterIds;
+	m_parameterValues.Clear();
+	m_parameterIds.Clear();
+	m_parameterValues.Resize(m_controller->GetParameters().Num());
+	m_parameterIds.Resize(m_controller->GetParameters().Num());
+	for (size_t i = 0; i < m_controller->GetParameters().Num(); ++i)
+	{
+		const auto& definition = m_controller->GetParameters()[i];
+		auto& value = m_parameterValues[i];
+		value.m_floatValue = definition.m_defaultFloat;
+		value.m_intValue = definition.m_defaultInt;
+		value.m_boolValue = definition.m_type == EAnimationParameterType::Trigger ?
+			false : definition.m_defaultBool;
+		m_parameterIds[i] = definition.m_id;
+		for (size_t previousIndex = 0; previousIndex < previousIds.Num(); ++previousIndex)
+		{
+			if (previousIds[previousIndex] == definition.m_id)
+			{
+				value = previousValues[previousIndex];
+				break;
+			}
+		}
+	}
+
+	const int32_t activeStateIndex = m_controller->FindStateIndex(m_activeStateId);
+	m_activeStateIndex = activeStateIndex >= 0 ?
+		static_cast<uint32_t>(activeStateIndex) : m_controller->GetDefaultStateIndex();
+	if (m_activeStateIndex >= m_controller->GetStates().Num())
+	{
+		return false;
+	}
+	m_activeStateId = m_controller->GetStates()[m_activeStateIndex].m_id;
+
+	const int32_t destinationStateIndex = m_controller->FindStateIndex(m_destinationStateId);
+	m_destinationStateIndex = destinationStateIndex >= 0 ?
+		static_cast<uint32_t>(destinationStateIndex) : InvalidIndex;
+	if (m_destinationStateIndex == InvalidIndex)
+	{
+		m_destinationStateId = InvalidAnimationControllerNodeId;
+		m_destinationStateTime = 0.0f;
+		m_transitionElapsed = 0.0f;
+		m_transitionDuration = 0.0f;
+	}
+	m_controllerRevision = m_controller->GetRevision();
+	return true;
+}

--- a/Runtime/AssetRegistry/Animation/AnimationController.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationController.cpp
@@ -17,8 +17,9 @@ namespace
 		case EAnimationParameterType::Int: return "Int";
 		case EAnimationParameterType::Bool: return "Bool";
 		case EAnimationParameterType::Trigger: return "Trigger";
+		case EAnimationParameterType::Invalid: return "Invalid";
 		}
-		return "Float";
+		return "Invalid";
 	}
 
 	const char* ToString(EAnimationConditionOperation operation)
@@ -32,29 +33,42 @@ namespace
 		case EAnimationConditionOperation::Greater: return "Greater";
 		case EAnimationConditionOperation::GreaterOrEqual: return "GreaterOrEqual";
 		case EAnimationConditionOperation::IsSet: return "IsSet";
+		case EAnimationConditionOperation::Invalid: return "Invalid";
 		}
-		return "Equal";
+		return "Invalid";
 	}
 
 	EAnimationParameterType ParseParameterType(const YAML::Node& node)
 	{
-		const std::string value = node.as<std::string>("Float");
+		if (!node || node.IsNull())
+		{
+			return EAnimationParameterType::Float;
+		}
+
+		const std::string value = node.as<std::string>();
+		if (value == "Float") return EAnimationParameterType::Float;
 		if (value == "Int") return EAnimationParameterType::Int;
 		if (value == "Bool") return EAnimationParameterType::Bool;
 		if (value == "Trigger") return EAnimationParameterType::Trigger;
-		return EAnimationParameterType::Float;
+		return EAnimationParameterType::Invalid;
 	}
 
 	EAnimationConditionOperation ParseConditionOperation(const YAML::Node& node)
 	{
-		const std::string value = node.as<std::string>("Equal");
+		if (!node || node.IsNull())
+		{
+			return EAnimationConditionOperation::Equal;
+		}
+
+		const std::string value = node.as<std::string>();
+		if (value == "Equal") return EAnimationConditionOperation::Equal;
 		if (value == "NotEqual") return EAnimationConditionOperation::NotEqual;
 		if (value == "Less") return EAnimationConditionOperation::Less;
 		if (value == "LessOrEqual") return EAnimationConditionOperation::LessOrEqual;
 		if (value == "Greater") return EAnimationConditionOperation::Greater;
 		if (value == "GreaterOrEqual") return EAnimationConditionOperation::GreaterOrEqual;
 		if (value == "IsSet") return EAnimationConditionOperation::IsSet;
-		return EAnimationConditionOperation::Equal;
+		return EAnimationConditionOperation::Invalid;
 	}
 
 	void AddError(TVector<std::string>* errors, const std::string& error)
@@ -69,6 +83,11 @@ namespace
 		EAnimationParameterType type,
 		EAnimationConditionOperation operation)
 	{
+		if (type == EAnimationParameterType::Invalid ||
+			operation == EAnimationConditionOperation::Invalid)
+		{
+			return false;
+		}
 		if (type == EAnimationParameterType::Trigger)
 		{
 			return operation == EAnimationConditionOperation::IsSet;
@@ -106,6 +125,7 @@ YAML::Node AnimationControllerAsset::Serialize() const
 			serialized["default"] = parameter.m_defaultBool;
 			break;
 		case EAnimationParameterType::Trigger:
+		case EAnimationParameterType::Invalid:
 			break;
 		}
 		result["parameters"].push_back(serialized);
@@ -183,6 +203,7 @@ void AnimationControllerAsset::Deserialize(const YAML::Node& inData)
 				parameter.m_defaultBool = serialized["default"].as<bool>(false);
 				break;
 			case EAnimationParameterType::Trigger:
+			case EAnimationParameterType::Invalid:
 				break;
 			}
 			m_parameters.Add(std::move(parameter));
@@ -361,6 +382,11 @@ bool AnimationController::Validate(TVector<std::string>* outErrors) const
 		if (parameter.m_id == InvalidAnimationControllerNodeId || parameter.m_name.empty())
 		{
 			AddError(outErrors, "Animation parameters require a stable id and name.");
+			bValid = false;
+		}
+		if (parameter.m_type == EAnimationParameterType::Invalid)
+		{
+			AddError(outErrors, "Animation parameter type is unknown.");
 			bValid = false;
 		}
 		if (parameter.m_type == EAnimationParameterType::Float &&
@@ -712,6 +738,7 @@ bool AnimationControllerInstance::AreConditionsMet(
 			case EAnimationConditionOperation::Greater: bConditionMet = value.m_floatValue > condition.m_floatValue; break;
 			case EAnimationConditionOperation::GreaterOrEqual: bConditionMet = value.m_floatValue >= condition.m_floatValue; break;
 			case EAnimationConditionOperation::IsSet: break;
+			case EAnimationConditionOperation::Invalid: break;
 			}
 			break;
 		}
@@ -725,6 +752,7 @@ bool AnimationControllerInstance::AreConditionsMet(
 			case EAnimationConditionOperation::Greater: bConditionMet = value.m_intValue > condition.m_intValue; break;
 			case EAnimationConditionOperation::GreaterOrEqual: bConditionMet = value.m_intValue >= condition.m_intValue; break;
 			case EAnimationConditionOperation::IsSet: break;
+			case EAnimationConditionOperation::Invalid: break;
 			}
 			break;
 		case EAnimationParameterType::Bool:
@@ -734,6 +762,8 @@ bool AnimationControllerInstance::AreConditionsMet(
 			break;
 		case EAnimationParameterType::Trigger:
 			bConditionMet = value.m_boolValue;
+			break;
+		case EAnimationParameterType::Invalid:
 			break;
 		}
 
@@ -859,6 +889,7 @@ bool AnimationControllerInstance::SynchronizeController()
 	}
 
 	const int32_t activeStateIndex = m_controller->FindStateIndex(m_activeStateId);
+	const bool bActiveStateWasRemoved = activeStateIndex < 0;
 	m_activeStateIndex = activeStateIndex >= 0 ?
 		static_cast<uint32_t>(activeStateIndex) : m_controller->GetDefaultStateIndex();
 	if (m_activeStateIndex >= m_controller->GetStates().Num())
@@ -866,9 +897,13 @@ bool AnimationControllerInstance::SynchronizeController()
 		return false;
 	}
 	m_activeStateId = m_controller->GetStates()[m_activeStateIndex].m_id;
+	if (bActiveStateWasRemoved)
+	{
+		m_activeStateTime = 0.0f;
+	}
 
 	const int32_t destinationStateIndex = m_controller->FindStateIndex(m_destinationStateId);
-	m_destinationStateIndex = destinationStateIndex >= 0 ?
+	m_destinationStateIndex = !bActiveStateWasRemoved && destinationStateIndex >= 0 ?
 		static_cast<uint32_t>(destinationStateIndex) : InvalidIndex;
 	if (m_destinationStateIndex == InvalidIndex)
 	{

--- a/Runtime/AssetRegistry/Animation/AnimationController.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationController.cpp
@@ -546,6 +546,7 @@ bool AnimationControllerInstance::SetController(const AnimationControllerPtr& co
 	m_controller = controller;
 	m_parameterValues.Clear();
 	m_parameterIds.Clear();
+	m_parameterTypes.Clear();
 	m_activeStateIndex = InvalidIndex;
 	m_destinationStateIndex = InvalidIndex;
 	m_activeStateTime = 0.0f;
@@ -563,11 +564,13 @@ bool AnimationControllerInstance::SetController(const AnimationControllerPtr& co
 
 	m_parameterValues.Resize(m_controller->GetParameters().Num());
 	m_parameterIds.Resize(m_controller->GetParameters().Num());
+	m_parameterTypes.Resize(m_controller->GetParameters().Num());
 	for (size_t i = 0; i < m_controller->GetParameters().Num(); ++i)
 	{
 		const auto& definition = m_controller->GetParameters()[i];
 		auto& value = m_parameterValues[i];
 		m_parameterIds[i] = definition.m_id;
+		m_parameterTypes[i] = definition.m_type;
 		value.m_floatValue = definition.m_defaultFloat;
 		value.m_intValue = definition.m_defaultInt;
 		value.m_boolValue = definition.m_type == EAnimationParameterType::Trigger ?
@@ -826,10 +829,13 @@ bool AnimationControllerInstance::SynchronizeController()
 
 	TVector<AnimationParameterValue> previousValues = m_parameterValues;
 	TVector<AnimationControllerNodeId> previousIds = m_parameterIds;
+	TVector<EAnimationParameterType> previousTypes = m_parameterTypes;
 	m_parameterValues.Clear();
 	m_parameterIds.Clear();
+	m_parameterTypes.Clear();
 	m_parameterValues.Resize(m_controller->GetParameters().Num());
 	m_parameterIds.Resize(m_controller->GetParameters().Num());
+	m_parameterTypes.Resize(m_controller->GetParameters().Num());
 	for (size_t i = 0; i < m_controller->GetParameters().Num(); ++i)
 	{
 		const auto& definition = m_controller->GetParameters()[i];
@@ -839,9 +845,12 @@ bool AnimationControllerInstance::SynchronizeController()
 		value.m_boolValue = definition.m_type == EAnimationParameterType::Trigger ?
 			false : definition.m_defaultBool;
 		m_parameterIds[i] = definition.m_id;
+		m_parameterTypes[i] = definition.m_type;
 		for (size_t previousIndex = 0; previousIndex < previousIds.Num(); ++previousIndex)
 		{
-			if (previousIds[previousIndex] == definition.m_id)
+			if (previousIds[previousIndex] == definition.m_id &&
+				previousIndex < previousTypes.Num() &&
+				previousTypes[previousIndex] == definition.m_type)
 			{
 				value = previousValues[previousIndex];
 				break;

--- a/Runtime/AssetRegistry/Animation/AnimationController.h
+++ b/Runtime/AssetRegistry/Animation/AnimationController.h
@@ -216,6 +216,7 @@ namespace Sailor
 		AnimationControllerPtr m_controller;
 		TVector<AnimationParameterValue> m_parameterValues;
 		TVector<AnimationControllerNodeId> m_parameterIds;
+		TVector<EAnimationParameterType> m_parameterTypes;
 		uint32_t m_activeStateIndex = InvalidIndex;
 		uint32_t m_destinationStateIndex = InvalidIndex;
 		AnimationControllerNodeId m_activeStateId = InvalidAnimationControllerNodeId;

--- a/Runtime/AssetRegistry/Animation/AnimationController.h
+++ b/Runtime/AssetRegistry/Animation/AnimationController.h
@@ -20,7 +20,8 @@ namespace Sailor
 		Float,
 		Int,
 		Bool,
-		Trigger
+		Trigger,
+		Invalid = 0xff
 	};
 
 	enum class EAnimationConditionOperation : uint8_t
@@ -31,7 +32,8 @@ namespace Sailor
 		LessOrEqual,
 		Greater,
 		GreaterOrEqual,
-		IsSet
+		IsSet,
+		Invalid = 0xff
 	};
 
 	struct AnimationParameterDefinition
@@ -200,7 +202,7 @@ namespace Sailor
 		uint32_t GetDestinationStateIndex() const { return m_destinationStateIndex; }
 		float GetActiveStateTime() const { return m_activeStateTime; }
 		float GetDestinationStateTime() const { return m_destinationStateTime; }
-		float GetTransitionAlpha() const;
+		SAILOR_API float GetTransitionAlpha() const;
 		const AnimationControllerPtr& GetController() const { return m_controller; }
 
 		static constexpr uint32_t InvalidIndex = (std::numeric_limits<uint32_t>::max)();

--- a/Runtime/AssetRegistry/Animation/AnimationController.h
+++ b/Runtime/AssetRegistry/Animation/AnimationController.h
@@ -1,0 +1,229 @@
+#pragma once
+
+#include "AssetRegistry/FileId.h"
+#include "Containers/Vector.h"
+#include "Core/YamlSerializable.h"
+#include "Engine/Object.h"
+#include "Memory/LockFreeHeapAllocator.h"
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+namespace Sailor
+{
+	using AnimationControllerNodeId = uint64_t;
+	static constexpr AnimationControllerNodeId InvalidAnimationControllerNodeId = 0;
+
+	enum class EAnimationParameterType : uint8_t
+	{
+		Float,
+		Int,
+		Bool,
+		Trigger
+	};
+
+	enum class EAnimationConditionOperation : uint8_t
+	{
+		Equal,
+		NotEqual,
+		Less,
+		LessOrEqual,
+		Greater,
+		GreaterOrEqual,
+		IsSet
+	};
+
+	struct AnimationParameterDefinition
+	{
+		AnimationControllerNodeId m_id = InvalidAnimationControllerNodeId;
+		std::string m_name;
+		EAnimationParameterType m_type = EAnimationParameterType::Float;
+		float m_defaultFloat = 0.0f;
+		int32_t m_defaultInt = 0;
+		bool m_defaultBool = false;
+	};
+
+	struct AnimationStateDefinition
+	{
+		AnimationControllerNodeId m_id = InvalidAnimationControllerNodeId;
+		std::string m_name;
+		std::string m_clipSlot;
+		float m_speed = 1.0f;
+		bool m_bLoop = true;
+		float m_editorX = 0.0f;
+		float m_editorY = 0.0f;
+	};
+
+	struct AnimationTransitionCondition
+	{
+		AnimationControllerNodeId m_parameterId = InvalidAnimationControllerNodeId;
+		EAnimationConditionOperation m_operation = EAnimationConditionOperation::Equal;
+		float m_floatValue = 0.0f;
+		int32_t m_intValue = 0;
+		bool m_boolValue = false;
+
+		uint32_t m_parameterIndex = (std::numeric_limits<uint32_t>::max)();
+	};
+
+	struct AnimationTransitionDefinition
+	{
+		AnimationControllerNodeId m_id = InvalidAnimationControllerNodeId;
+		AnimationControllerNodeId m_fromStateId = InvalidAnimationControllerNodeId;
+		AnimationControllerNodeId m_toStateId = InvalidAnimationControllerNodeId;
+		int32_t m_priority = 0;
+		float m_duration = 0.2f;
+		bool m_bHasExitTime = false;
+		float m_exitTime = 0.0f;
+		TVector<AnimationTransitionCondition> m_conditions;
+
+		uint32_t m_fromStateIndex = (std::numeric_limits<uint32_t>::max)();
+		uint32_t m_toStateIndex = (std::numeric_limits<uint32_t>::max)();
+	};
+
+	struct AnimationSetEntry
+	{
+		std::string m_slot;
+		FileId m_animation;
+	};
+
+	class AnimationControllerAsset final : public IYamlSerializable
+	{
+	public:
+		SAILOR_API YAML::Node Serialize() const override;
+		SAILOR_API void Deserialize(const YAML::Node& inData) override;
+
+		TVector<AnimationParameterDefinition>& GetParameters() { return m_parameters; }
+		const TVector<AnimationParameterDefinition>& GetParameters() const { return m_parameters; }
+		TVector<AnimationStateDefinition>& GetStates() { return m_states; }
+		const TVector<AnimationStateDefinition>& GetStates() const { return m_states; }
+		TVector<AnimationTransitionDefinition>& GetTransitions() { return m_transitions; }
+		const TVector<AnimationTransitionDefinition>& GetTransitions() const { return m_transitions; }
+
+		AnimationControllerNodeId GetDefaultStateId() const { return m_defaultStateId; }
+		void SetDefaultStateId(AnimationControllerNodeId stateId) { m_defaultStateId = stateId; }
+
+	private:
+		uint32_t m_version = 1;
+		AnimationControllerNodeId m_defaultStateId = InvalidAnimationControllerNodeId;
+		TVector<AnimationParameterDefinition> m_parameters;
+		TVector<AnimationStateDefinition> m_states;
+		TVector<AnimationTransitionDefinition> m_transitions;
+	};
+
+	class AnimationSetAsset final : public IYamlSerializable
+	{
+	public:
+		SAILOR_API YAML::Node Serialize() const override;
+		SAILOR_API void Deserialize(const YAML::Node& inData) override;
+
+		TVector<AnimationSetEntry>& GetEntries() { return m_entries; }
+		const TVector<AnimationSetEntry>& GetEntries() const { return m_entries; }
+
+	private:
+		uint32_t m_version = 1;
+		TVector<AnimationSetEntry> m_entries;
+	};
+
+	class AnimationController final : public Object
+	{
+	public:
+		SAILOR_API explicit AnimationController(FileId uid) : Object(uid) {}
+
+		SAILOR_API bool Initialize(
+			const AnimationControllerAsset& asset,
+			TVector<std::string>* outErrors = nullptr);
+		SAILOR_API bool Validate(TVector<std::string>* outErrors = nullptr) const;
+
+		SAILOR_API int32_t FindStateIndex(AnimationControllerNodeId stateId) const;
+		SAILOR_API int32_t FindParameterIndex(AnimationControllerNodeId parameterId) const;
+		SAILOR_API int32_t FindParameterIndex(const std::string& name) const;
+
+		const TVector<AnimationParameterDefinition>& GetParameters() const { return m_parameters; }
+		const TVector<AnimationStateDefinition>& GetStates() const { return m_states; }
+		const TVector<AnimationTransitionDefinition>& GetTransitions() const { return m_transitions; }
+		uint32_t GetDefaultStateIndex() const { return m_defaultStateIndex; }
+		uint64_t GetRevision() const { return m_revision; }
+
+	private:
+		TVector<AnimationParameterDefinition> m_parameters;
+		TVector<AnimationStateDefinition> m_states;
+		TVector<AnimationTransitionDefinition> m_transitions;
+		uint32_t m_defaultStateIndex = 0;
+		uint64_t m_revision = 0;
+	};
+
+	using AnimationControllerPtr = TObjectPtr<AnimationController>;
+
+	class AnimationSet final : public Object
+	{
+	public:
+		SAILOR_API explicit AnimationSet(FileId uid) : Object(uid) {}
+
+		SAILOR_API bool Initialize(
+			const AnimationSetAsset& asset,
+			TVector<std::string>* outErrors = nullptr);
+		SAILOR_API const FileId* FindAnimation(const std::string& slot) const;
+		const TVector<AnimationSetEntry>& GetEntries() const { return m_entries; }
+		uint64_t GetRevision() const { return m_revision; }
+
+	private:
+		TVector<AnimationSetEntry> m_entries;
+		uint64_t m_revision = 0;
+	};
+
+	using AnimationSetPtr = TObjectPtr<AnimationSet>;
+
+	struct AnimationParameterValue
+	{
+		float m_floatValue = 0.0f;
+		int32_t m_intValue = 0;
+		bool m_boolValue = false;
+	};
+
+	class AnimationControllerInstance final
+	{
+	public:
+		SAILOR_API bool SetController(const AnimationControllerPtr& controller);
+		SAILOR_API void Reset();
+		SAILOR_API void Tick(float deltaTime, float activeClipDuration);
+
+		SAILOR_API bool SetFloat(const std::string& name, float value);
+		SAILOR_API bool SetInt(const std::string& name, int32_t value);
+		SAILOR_API bool SetBool(const std::string& name, bool value);
+		SAILOR_API bool SetTrigger(const std::string& name);
+		SAILOR_API bool ResetTrigger(const std::string& name);
+
+		bool IsValid() const { return m_controller && !m_controller->GetStates().IsEmpty(); }
+		bool IsTransitioning() const { return m_destinationStateIndex != InvalidIndex; }
+		uint32_t GetActiveStateIndex() const { return m_activeStateIndex; }
+		uint32_t GetDestinationStateIndex() const { return m_destinationStateIndex; }
+		float GetActiveStateTime() const { return m_activeStateTime; }
+		float GetDestinationStateTime() const { return m_destinationStateTime; }
+		float GetTransitionAlpha() const;
+		const AnimationControllerPtr& GetController() const { return m_controller; }
+
+		static constexpr uint32_t InvalidIndex = (std::numeric_limits<uint32_t>::max)();
+
+	private:
+		bool SetParameter(const std::string& name, EAnimationParameterType type, const AnimationParameterValue& value);
+		bool AreConditionsMet(const AnimationTransitionDefinition& transition) const;
+		void ConsumeTriggers(const AnimationTransitionDefinition& transition);
+		void TryBeginTransition(float activeClipDuration);
+		void CompleteTransition();
+		bool SynchronizeController();
+
+		AnimationControllerPtr m_controller;
+		TVector<AnimationParameterValue> m_parameterValues;
+		TVector<AnimationControllerNodeId> m_parameterIds;
+		uint32_t m_activeStateIndex = InvalidIndex;
+		uint32_t m_destinationStateIndex = InvalidIndex;
+		AnimationControllerNodeId m_activeStateId = InvalidAnimationControllerNodeId;
+		AnimationControllerNodeId m_destinationStateId = InvalidAnimationControllerNodeId;
+		uint64_t m_controllerRevision = 0;
+		float m_activeStateTime = 0.0f;
+		float m_destinationStateTime = 0.0f;
+		float m_transitionElapsed = 0.0f;
+		float m_transitionDuration = 0.0f;
+	};
+}

--- a/Runtime/AssetRegistry/Animation/AnimationControllerAssetInfo.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationControllerAssetInfo.cpp
@@ -1,0 +1,82 @@
+#include "AnimationControllerAssetInfo.h"
+#include "AnimationControllerImporter.h"
+#include "AssetRegistry/AssetRegistry.h"
+
+using namespace Sailor;
+
+YAML::Node AnimationControllerAssetInfo::Serialize() const
+{
+	return SerializeReflectedAssetInfo(*this);
+}
+
+void AnimationControllerAssetInfo::Deserialize(const YAML::Node& inData)
+{
+	DeserializeReflectedAssetInfo(*this, inData);
+}
+
+YAML::Node AnimationSetAssetInfo::Serialize() const
+{
+	return SerializeReflectedAssetInfo(*this);
+}
+
+void AnimationSetAssetInfo::Deserialize(const YAML::Node& inData)
+{
+	DeserializeReflectedAssetInfo(*this, inData);
+}
+
+AnimationControllerAssetInfoHandler::AnimationControllerAssetInfoHandler(
+	AssetRegistry* assetRegistry)
+{
+	m_supportedExtensions.Emplace("animcontroller");
+	assetRegistry->RegisterAssetInfoHandler(m_supportedExtensions, this);
+}
+
+void AnimationControllerAssetInfoHandler::GetDefaultMeta(
+	YAML::Node& outDefaultYaml) const
+{
+	AnimationControllerAssetInfo defaultObject;
+	outDefaultYaml = defaultObject.Serialize();
+}
+
+AssetInfoPtr AnimationControllerAssetInfoHandler::CreateAssetInfo() const
+{
+	return new AnimationControllerAssetInfo();
+}
+
+IAssetFactory* AnimationControllerAssetInfoHandler::GetFactory()
+{
+	return App::GetSubmodule<AnimationControllerImporter>();
+}
+
+IAssetInfoHandler* AnimationControllerAssetInfo::GetHandler()
+{
+	return App::GetSubmodule<AnimationControllerAssetInfoHandler>();
+}
+
+AnimationSetAssetInfoHandler::AnimationSetAssetInfoHandler(
+	AssetRegistry* assetRegistry)
+{
+	m_supportedExtensions.Emplace("animset");
+	assetRegistry->RegisterAssetInfoHandler(m_supportedExtensions, this);
+}
+
+void AnimationSetAssetInfoHandler::GetDefaultMeta(YAML::Node& outDefaultYaml) const
+{
+	AnimationSetAssetInfo defaultObject;
+	outDefaultYaml = defaultObject.Serialize();
+}
+
+AssetInfoPtr AnimationSetAssetInfoHandler::CreateAssetInfo() const
+{
+	return new AnimationSetAssetInfo();
+}
+
+IAssetFactory* AnimationSetAssetInfoHandler::GetFactory()
+{
+	return App::GetSubmodule<AnimationControllerImporter>();
+}
+
+IAssetInfoHandler* AnimationSetAssetInfo::GetHandler()
+{
+	return App::GetSubmodule<AnimationSetAssetInfoHandler>();
+}

--- a/Runtime/AssetRegistry/Animation/AnimationControllerAssetInfo.h
+++ b/Runtime/AssetRegistry/Animation/AnimationControllerAssetInfo.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "AssetRegistry/AssetInfo.h"
+
+namespace Sailor
+{
+	class AnimationControllerAssetInfo final : public AssetInfo
+	{
+		SAILOR_REFLECTABLE(AnimationControllerAssetInfo)
+
+	public:
+		SAILOR_API YAML::Node Serialize() const override;
+		SAILOR_API void Deserialize(const YAML::Node& inData) override;
+		SAILOR_API IAssetInfoHandler* GetHandler() override;
+	};
+
+	class AnimationSetAssetInfo final : public AssetInfo
+	{
+		SAILOR_REFLECTABLE(AnimationSetAssetInfo)
+
+	public:
+		SAILOR_API YAML::Node Serialize() const override;
+		SAILOR_API void Deserialize(const YAML::Node& inData) override;
+		SAILOR_API IAssetInfoHandler* GetHandler() override;
+	};
+
+	using AnimationControllerAssetInfoPtr = AnimationControllerAssetInfo*;
+	using AnimationSetAssetInfoPtr = AnimationSetAssetInfo*;
+
+	class AnimationControllerAssetInfoHandler final :
+		public TSubmodule<AnimationControllerAssetInfoHandler>,
+		public IAssetInfoHandler
+	{
+	public:
+		SAILOR_API explicit AnimationControllerAssetInfoHandler(AssetRegistry* assetRegistry);
+		SAILOR_API void GetDefaultMeta(YAML::Node& outDefaultYaml) const override;
+		SAILOR_API AssetInfoPtr CreateAssetInfo() const override;
+		SAILOR_API IAssetFactory* GetFactory() override;
+	};
+
+	class AnimationSetAssetInfoHandler final :
+		public TSubmodule<AnimationSetAssetInfoHandler>,
+		public IAssetInfoHandler
+	{
+	public:
+		SAILOR_API explicit AnimationSetAssetInfoHandler(AssetRegistry* assetRegistry);
+		SAILOR_API void GetDefaultMeta(YAML::Node& outDefaultYaml) const override;
+		SAILOR_API AssetInfoPtr CreateAssetInfo() const override;
+		SAILOR_API IAssetFactory* GetFactory() override;
+	};
+}
+
+REFL_AUTO(
+	type(Sailor::AnimationControllerAssetInfo, bases<Sailor::AssetInfo>),
+	field(m_fileId),
+	field(m_assetFilename)
+)
+
+REFL_AUTO(
+	type(Sailor::AnimationSetAssetInfo, bases<Sailor::AssetInfo>),
+	field(m_fileId),
+	field(m_assetFilename)
+)

--- a/Runtime/AssetRegistry/Animation/AnimationControllerImporter.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationControllerImporter.cpp
@@ -1,0 +1,258 @@
+#include "AnimationControllerImporter.h"
+#include "AssetRegistry/AssetRegistry.h"
+#include "YamlExceptionBoundary.h"
+
+using namespace Sailor;
+
+namespace
+{
+	template<typename TAsset>
+	bool ReadYamlAsset(FileId uid, TAsset& outAsset, TVector<std::string>& outErrors)
+	{
+		outErrors.Clear();
+		AssetInfoPtr assetInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(uid);
+		if (!assetInfo)
+		{
+			outErrors.Add("Asset metadata was not found.");
+			return false;
+		}
+
+		std::string source;
+		if (!AssetRegistry::ReadAllTextFile(assetInfo->GetAssetFilepath(), source))
+		{
+			outErrors.Add("Asset source could not be read.");
+			return false;
+		}
+
+		YAML::Node document;
+		std::string diagnostic;
+		if (!External::TryLoadYaml(source, document, diagnostic) ||
+			!External::GuardYamlExceptions(
+				[&outAsset, &document]()
+				{
+					outAsset.Deserialize(document);
+				},
+				diagnostic))
+		{
+			outErrors.Add("YAML: " + diagnostic);
+			return false;
+		}
+		return true;
+	}
+}
+
+AnimationControllerImporter::AnimationControllerImporter(
+	AnimationControllerAssetInfoHandler* controllerInfoHandler,
+	AnimationSetAssetInfoHandler* setInfoHandler)
+{
+	m_allocator = Memory::ObjectAllocatorPtr::Make(
+		Memory::EAllocationPolicy::SharedMemory_MultiThreaded);
+	controllerInfoHandler->Subscribe(this);
+	setInfoHandler->Subscribe(this);
+}
+
+AnimationControllerImporter::~AnimationControllerImporter()
+{
+	for (auto& controller : m_loadedControllers)
+	{
+		controller.m_second.DestroyObject(m_allocator);
+	}
+	for (auto& set : m_loadedSets)
+	{
+		set.m_second.DestroyObject(m_allocator);
+	}
+}
+
+void AnimationControllerImporter::OnImportAsset(AssetInfoPtr)
+{
+}
+
+void AnimationControllerImporter::OnUpdateAssetInfo(
+	AssetInfoPtr assetInfo,
+	bool bWasExpired)
+{
+	if (!bWasExpired || !assetInfo)
+	{
+		return;
+	}
+
+	const FileId uid = assetInfo->GetFileId();
+	if (auto controllerIt = m_loadedControllers.Find(uid);
+		controllerIt != m_loadedControllers.end())
+	{
+		AnimationControllerAsset definition;
+		TVector<std::string> errors;
+		if (ReadControllerAsset(uid, definition, errors) &&
+			(*controllerIt).m_second->Initialize(definition, &errors))
+		{
+#ifdef SAILOR_EDITOR
+			(*controllerIt).m_second->TraceHotReload(nullptr);
+#endif
+		}
+		else
+		{
+			LogErrors(uid, "animation controller", errors);
+		}
+	}
+
+	if (auto setIt = m_loadedSets.Find(uid); setIt != m_loadedSets.end())
+	{
+		AnimationSetAsset definition;
+		TVector<std::string> errors;
+		if (ReadAnimationSetAsset(uid, definition, errors) &&
+			(*setIt).m_second->Initialize(definition, &errors))
+		{
+#ifdef SAILOR_EDITOR
+			(*setIt).m_second->TraceHotReload(nullptr);
+#endif
+		}
+		else
+		{
+			LogErrors(uid, "animation set", errors);
+		}
+	}
+}
+
+bool AnimationControllerImporter::LoadAsset(
+	FileId uid,
+	TObjectPtr<Object>& out,
+	bool)
+{
+	AssetInfoPtr assetInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(uid);
+	if (dynamic_cast<AnimationControllerAssetInfoPtr>(assetInfo))
+	{
+		AnimationControllerPtr controller;
+		const bool bLoaded = LoadController_Immediate(uid, controller);
+		out = controller;
+		return bLoaded;
+	}
+	if (dynamic_cast<AnimationSetAssetInfoPtr>(assetInfo))
+	{
+		AnimationSetPtr set;
+		const bool bLoaded = LoadAnimationSet_Immediate(uid, set);
+		out = set;
+		return bLoaded;
+	}
+	out.Clear();
+	return false;
+}
+
+bool AnimationControllerImporter::LoadController_Immediate(
+	FileId uid,
+	AnimationControllerPtr& outController)
+{
+	if (auto it = m_loadedControllers.Find(uid); it != m_loadedControllers.end())
+	{
+		outController = (*it).m_second;
+		return true;
+	}
+
+	AnimationControllerAsset definition;
+	TVector<std::string> errors;
+	if (!ReadControllerAsset(uid, definition, errors))
+	{
+		LogErrors(uid, "animation controller", errors);
+		return false;
+	}
+
+	auto controller = AnimationControllerPtr::Make(m_allocator, uid);
+	if (!controller->Initialize(definition, &errors))
+	{
+		LogErrors(uid, "animation controller", errors);
+		controller.DestroyObject(m_allocator);
+		return false;
+	}
+
+	auto& cached = m_loadedControllers.At_Lock(uid, AnimationControllerPtr{});
+	if (!cached)
+	{
+		cached = controller;
+	}
+	else
+	{
+		controller.DestroyObject(m_allocator);
+	}
+	outController = cached;
+	m_loadedControllers.Unlock(uid);
+	return true;
+}
+
+bool AnimationControllerImporter::LoadAnimationSet_Immediate(
+	FileId uid,
+	AnimationSetPtr& outSet)
+{
+	if (auto it = m_loadedSets.Find(uid); it != m_loadedSets.end())
+	{
+		outSet = (*it).m_second;
+		return true;
+	}
+
+	AnimationSetAsset definition;
+	TVector<std::string> errors;
+	if (!ReadAnimationSetAsset(uid, definition, errors))
+	{
+		LogErrors(uid, "animation set", errors);
+		return false;
+	}
+
+	auto set = AnimationSetPtr::Make(m_allocator, uid);
+	if (!set->Initialize(definition, &errors))
+	{
+		LogErrors(uid, "animation set", errors);
+		set.DestroyObject(m_allocator);
+		return false;
+	}
+
+	auto& cached = m_loadedSets.At_Lock(uid, AnimationSetPtr{});
+	if (!cached)
+	{
+		cached = set;
+	}
+	else
+	{
+		set.DestroyObject(m_allocator);
+	}
+	outSet = cached;
+	m_loadedSets.Unlock(uid);
+	return true;
+}
+
+void AnimationControllerImporter::CollectGarbage()
+{
+}
+
+bool AnimationControllerImporter::ReadControllerAsset(
+	FileId uid,
+	AnimationControllerAsset& outAsset,
+	TVector<std::string>& outErrors) const
+{
+	return ReadYamlAsset(uid, outAsset, outErrors);
+}
+
+bool AnimationControllerImporter::ReadAnimationSetAsset(
+	FileId uid,
+	AnimationSetAsset& outAsset,
+	TVector<std::string>& outErrors) const
+{
+	return ReadYamlAsset(uid, outAsset, outErrors);
+}
+
+void AnimationControllerImporter::LogErrors(
+	FileId uid,
+	const char* assetKind,
+	const TVector<std::string>& errors) const
+{
+	if (errors.IsEmpty())
+	{
+		SAILOR_LOG_ERROR("Cannot load %s '%s'.", assetKind, uid.ToString().c_str());
+		return;
+	}
+	for (const auto& error : errors)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot load %s '%s': %s",
+			assetKind,
+			uid.ToString().c_str(),
+			error.c_str());
+	}
+}

--- a/Runtime/AssetRegistry/Animation/AnimationControllerImporter.h
+++ b/Runtime/AssetRegistry/Animation/AnimationControllerImporter.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "AnimationController.h"
+#include "AnimationControllerAssetInfo.h"
+#include "AssetRegistry/AssetFactory.h"
+#include "Containers/ConcurrentMap.h"
+#include "Core/Submodule.h"
+#include "Memory/ObjectAllocator.hpp"
+
+namespace Sailor
+{
+	class AnimationControllerImporter final :
+		public TSubmodule<AnimationControllerImporter>,
+		public IAssetInfoHandlerListener,
+		public IAssetFactory
+	{
+	public:
+		SAILOR_API AnimationControllerImporter(
+			AnimationControllerAssetInfoHandler* controllerInfoHandler,
+			AnimationSetAssetInfoHandler* setInfoHandler);
+		SAILOR_API ~AnimationControllerImporter() override;
+
+		SAILOR_API void OnImportAsset(AssetInfoPtr assetInfo) override;
+		SAILOR_API void OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired) override;
+		SAILOR_API bool LoadAsset(FileId uid, TObjectPtr<Object>& out, bool bImmediate = true) override;
+
+		SAILOR_API bool LoadController_Immediate(
+			FileId uid,
+			AnimationControllerPtr& outController);
+		SAILOR_API bool LoadAnimationSet_Immediate(
+			FileId uid,
+			AnimationSetPtr& outSet);
+		SAILOR_API void CollectGarbage() override;
+
+	private:
+		bool ReadControllerAsset(
+			FileId uid,
+			AnimationControllerAsset& outAsset,
+			TVector<std::string>& outErrors) const;
+		bool ReadAnimationSetAsset(
+			FileId uid,
+			AnimationSetAsset& outAsset,
+			TVector<std::string>& outErrors) const;
+		void LogErrors(FileId uid, const char* assetKind, const TVector<std::string>& errors) const;
+
+		TConcurrentMap<FileId, AnimationControllerPtr> m_loadedControllers;
+		TConcurrentMap<FileId, AnimationSetPtr> m_loadedSets;
+		Memory::ObjectAllocatorPtr m_allocator;
+	};
+}

--- a/Runtime/AssetRegistry/Animation/AnimationImporter.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationImporter.cpp
@@ -1,4 +1,5 @@
 #include "AnimationImporter.h"
+#include "AnimationClipSampler.h"
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/Model/GltfImporterUtils.h"
 #include <tiny_gltf.h>
@@ -363,11 +364,11 @@ namespace
 
 	struct PreparedAnimationChannel
 	{
-		GltfFloatAccessorView m_output;
+		TVector<float> m_timestamps;
+		TVector<glm::vec4> m_values;
 		size_t m_targetNode = 0;
-		size_t m_sampleCount = 0;
 		EAnimationTarget m_target = EAnimationTarget::Translation;
-		bool m_bCubicSpline = false;
+		EAnimationInterpolation m_interpolation = EAnimationInterpolation::Linear;
 	};
 
 	bool IsTransformFinite(const Math::Transform& transform)
@@ -526,31 +527,6 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 				}
 			}
 
-			size_t numFrames = 0;
-			for (const auto& sampler : gltfAnim.samplers)
-			{
-				GltfFloatAccessorView inputView;
-				if (TryGetFloatAccessorView(
-					gltfModel,
-					sampler.input,
-					TINYGLTF_TYPE_SCALAR,
-					1,
-					inputView) &&
-					inputView.m_accessor->count <= MaxVectorElements)
-				{
-					numFrames = inputView.m_accessor->count;
-					break;
-				}
-			}
-
-			if (numFrames == 0 || numFrames > MaxVectorElements / numBones)
-			{
-				return false;
-			}
-
-			TVector<Math::Transform> framesData;
-			framesData.Resize(numFrames * numBones);
-
 			TVector<int32_t> parents;
 			parents.Resize(numNodes);
 			for (size_t i = 0; i < numNodes; ++i)
@@ -621,6 +597,8 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 
 			TVector<PreparedAnimationChannel> preparedChannels;
 			preparedChannels.Reserve(gltfAnim.channels.size());
+			float animationDuration = 0.0f;
+			size_t maxSourceSampleCount = 0;
 			for (const auto& channel : gltfAnim.channels)
 			{
 				if (channel.sampler < 0 ||
@@ -646,6 +624,21 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 				const size_t sampleCount = inputView.m_accessor->count;
 
 				PreparedAnimationChannel prepared;
+				prepared.m_timestamps.Resize(sampleCount);
+				bool bValid = true;
+				for (size_t sample = 0; sample < sampleCount; ++sample)
+				{
+					bValid &= TryReadAccessorFloat(
+						inputView,
+						sample,
+						0,
+						prepared.m_timestamps[sample]);
+				}
+				if (!bValid || !AnimationClipSampler::ValidateTimestamps(prepared.m_timestamps))
+				{
+					continue;
+				}
+
 				int32_t outputType = TINYGLTF_TYPE_VEC3;
 				if (channel.target_path == "translation")
 				{
@@ -665,89 +658,141 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 					continue;
 				}
 
-				prepared.m_bCubicSpline = sampler.interpolation == "CUBICSPLINE";
-				if (!prepared.m_bCubicSpline &&
-					!sampler.interpolation.empty() &&
-					sampler.interpolation != "LINEAR" &&
-					sampler.interpolation != "STEP")
+				if (sampler.interpolation.empty() || sampler.interpolation == "LINEAR")
+				{
+					prepared.m_interpolation = EAnimationInterpolation::Linear;
+				}
+				else if (sampler.interpolation == "STEP")
+				{
+					prepared.m_interpolation = EAnimationInterpolation::Step;
+				}
+				else if (sampler.interpolation == "CUBICSPLINE")
+				{
+					prepared.m_interpolation = EAnimationInterpolation::CubicSpline;
+				}
+				else
 				{
 					continue;
 				}
 
-				if (prepared.m_bCubicSpline &&
+				const bool bCubicSpline =
+					prepared.m_interpolation == EAnimationInterpolation::CubicSpline;
+				if (bCubicSpline &&
 					sampleCount > std::numeric_limits<size_t>::max() / 3)
 				{
 					continue;
 				}
 
-				const size_t outputCount = prepared.m_bCubicSpline ?
+				const size_t outputCount = bCubicSpline ?
 					sampleCount * 3 : sampleCount;
+				GltfFloatAccessorView outputView;
 				if (!TryGetFloatAccessorView(
 					gltfModel,
 					sampler.output,
 					outputType,
 					outputCount,
-					prepared.m_output) ||
-					prepared.m_output.m_accessor->count != outputCount)
+					outputView) ||
+					outputView.m_accessor->count != outputCount)
+				{
+					continue;
+				}
+
+				prepared.m_values.Resize(outputCount);
+				const size_t componentCount =
+					prepared.m_target == EAnimationTarget::Rotation ? 4 : 3;
+				bValid = true;
+				for (size_t element = 0; element < outputCount; ++element)
+				{
+					glm::vec4 value(0.0f);
+					for (size_t component = 0; component < componentCount; ++component)
+					{
+						bValid &= TryReadAccessorFloat(
+							outputView,
+							element,
+							component,
+							value[static_cast<glm::length_t>(component)]);
+					}
+					prepared.m_values[element] = value;
+				}
+				if (!bValid)
 				{
 					continue;
 				}
 
 				prepared.m_targetNode =
 					static_cast<size_t>(channel.target_node);
-				prepared.m_sampleCount = sampleCount;
+				animationDuration = (std::max)(
+					animationDuration,
+					prepared.m_timestamps[prepared.m_timestamps.Num() - 1]);
+				maxSourceSampleCount = (std::max)(maxSourceSampleCount, sampleCount);
 				preparedChannels.Add(prepared);
 			}
 
+			if (preparedChannels.IsEmpty() || !std::isfinite(animationDuration))
+			{
+				return false;
+			}
+
+			constexpr float TargetSamplingFps = 30.0f;
+			const double targetIntervals = std::ceil(
+				static_cast<double>(animationDuration) * TargetSamplingFps);
+			if (!std::isfinite(targetIntervals) ||
+				targetIntervals > static_cast<double>(MaxVectorElements - 1))
+			{
+				return false;
+			}
+
+			const size_t numIntervals = (std::max)(
+				static_cast<size_t>(targetIntervals),
+				maxSourceSampleCount - 1);
+			const size_t numFrames = numIntervals + 1;
+			if (numFrames > MaxVectorElements / numBones)
+			{
+				return false;
+			}
+
+			TVector<Math::Transform> framesData;
+			framesData.Resize(numFrames * numBones);
+			const float samplingFps = animationDuration > 0.0f ?
+				static_cast<float>(numIntervals) / animationDuration : TargetSamplingFps;
+
 			for (size_t f = 0; f < numFrames; ++f)
 			{
+				const float sampleTime = (std::min)(
+					static_cast<float>(f) / samplingFps,
+					animationDuration);
 				TVector<Math::Transform> local(base);
 				for (const auto& channel : preparedChannels)
 				{
-					const size_t sample =
-						(std::min)(f, channel.m_sampleCount - 1);
-					const size_t outputElement = channel.m_bCubicSpline ?
-						sample * 3 + 1 : sample;
-					const size_t componentCount =
-						channel.m_target == EAnimationTarget::Rotation ? 4 : 3;
-					float values[4]{};
-					bool bValid = true;
-					for (size_t component = 0;
-						component < componentCount;
-						++component)
-					{
-						bValid &= TryReadAccessorFloat(
-							channel.m_output,
-							outputElement,
-							component,
-							values[component]);
-					}
-
-					if (!bValid)
-					{
-						continue;
-					}
-
 					Math::Transform& target = local[channel.m_targetNode];
-					if (channel.m_target == EAnimationTarget::Translation)
+					if (channel.m_target == EAnimationTarget::Rotation)
 					{
-						target.m_position = glm::vec4(
-							values[0], values[1], values[2], 1.0f);
-					}
-					else if (channel.m_target == EAnimationTarget::Scale)
-					{
-						target.m_scale = glm::vec4(
-							values[0], values[1], values[2], 1.0f);
+						AnimationClipSampler::SampleRotation(
+							channel.m_timestamps,
+							channel.m_values,
+							channel.m_interpolation,
+							sampleTime,
+							target.m_rotation);
 					}
 					else
 					{
-						glm::quat rotation(
-							values[3], values[0], values[1], values[2]);
-						const float lengthSquared = glm::dot(rotation, rotation);
-						if (std::isfinite(lengthSquared) &&
-							lengthSquared > std::numeric_limits<float>::epsilon())
+						glm::vec4 value;
+						if (AnimationClipSampler::SampleVector(
+							channel.m_timestamps,
+							channel.m_values,
+							channel.m_interpolation,
+							sampleTime,
+							value))
 						{
-							target.m_rotation = glm::normalize(rotation);
+							value.w = 1.0f;
+							if (channel.m_target == EAnimationTarget::Translation)
+							{
+								target.m_position = value;
+							}
+							else
+							{
+								target.m_scale = value;
+							}
 						}
 					}
 				}
@@ -805,7 +850,8 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 
 			anim->m_numBones = static_cast<uint32_t>(numBones);
 			anim->m_numFrames = static_cast<uint32_t>(numFrames);
-			anim->m_fps = 30.0f;
+			anim->m_fps = samplingFps;
+			anim->m_duration = animationDuration;
 			anim->m_frames = std::move(framesData);
 		}
 	}

--- a/Runtime/AssetRegistry/Animation/AnimationImporter.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationImporter.cpp
@@ -380,6 +380,33 @@ namespace
 			std::isfinite(transform.m_rotation.z) &&
 			std::isfinite(transform.m_rotation.w);
 	}
+
+	bool IsMatrixFinite(const glm::mat4& matrix)
+	{
+		for (glm::length_t column = 0; column < 4; ++column)
+		{
+			if (!Math::AllFinite(matrix[column]))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
+	void AddSkeletonHashByte(uint64_t& hash, uint8_t value)
+	{
+		constexpr uint64_t FnvPrime = 1099511628211ull;
+		hash ^= value;
+		hash *= FnvPrime;
+	}
+
+	void AddSkeletonHashUint32(uint64_t& hash, uint32_t value)
+	{
+		for (uint32_t shift = 0; shift < 32; shift += 8)
+		{
+			AddSkeletonHashByte(hash, static_cast<uint8_t>((value >> shift) & 0xff));
+		}
+	}
 }
 
 AnimationImporter::AnimationImporter(AnimationAssetInfoHandler* infoHandler)
@@ -394,6 +421,27 @@ AnimationImporter::~AnimationImporter()
 	for (auto& anim : m_loadedAnimations)
 	{
 		anim.m_second.DestroyObject(m_allocator);
+	}
+}
+
+void AnimationImporter::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
+{
+	if (!bWasExpired || !assetInfo)
+	{
+		return;
+	}
+
+	const FileId uid = assetInfo->GetFileId();
+	if (auto animationIt = m_loadedAnimations.Find(uid);
+		animationIt != m_loadedAnimations.end())
+	{
+		AnimationPtr animation = (*animationIt).m_second;
+		if (animation && ImportAnimation(uid, animation))
+		{
+#ifdef SAILOR_EDITOR
+			animation->TraceHotReload(nullptr);
+#endif
+		}
 	}
 }
 
@@ -549,6 +597,53 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 				}
 			}
 
+			TVector<int32_t> boneIndexByNode;
+			boneIndexByNode.Resize(numNodes);
+			for (size_t nodeIndex = 0; nodeIndex < numNodes; ++nodeIndex)
+			{
+				boneIndexByNode[nodeIndex] = -1;
+			}
+			for (size_t boneIndex = 0; boneIndex < numBones; ++boneIndex)
+			{
+				boneIndexByNode[static_cast<size_t>(gltfSkin.joints[boneIndex])] =
+					static_cast<int32_t>(boneIndex);
+			}
+
+			TVector<int32_t> parentBoneIndices;
+			parentBoneIndices.Resize(numBones);
+			for (size_t boneIndex = 0; boneIndex < numBones; ++boneIndex)
+			{
+				int32_t parentNode = parents[static_cast<size_t>(gltfSkin.joints[boneIndex])];
+				int32_t parentBone = -1;
+				for (size_t depth = 0; parentNode >= 0 && depth < numNodes; ++depth)
+				{
+					parentBone = boneIndexByNode[static_cast<size_t>(parentNode)];
+					if (parentBone >= 0)
+					{
+						break;
+					}
+					parentNode = parents[static_cast<size_t>(parentNode)];
+				}
+				parentBoneIndices[boneIndex] = parentBone;
+			}
+
+			constexpr uint64_t FnvOffsetBasis = 14695981039346656037ull;
+			uint64_t skeletonSignature = FnvOffsetBasis;
+			AddSkeletonHashUint32(skeletonSignature, static_cast<uint32_t>(numBones));
+			for (size_t boneIndex = 0; boneIndex < numBones; ++boneIndex)
+			{
+				AddSkeletonHashUint32(
+					skeletonSignature,
+					static_cast<uint32_t>(parentBoneIndices[boneIndex] + 1));
+				const auto& jointNode = gltfModel.nodes[
+					static_cast<size_t>(gltfSkin.joints[boneIndex])];
+				for (char character : jointNode.name)
+				{
+					AddSkeletonHashByte(skeletonSignature, static_cast<uint8_t>(character));
+				}
+				AddSkeletonHashByte(skeletonSignature, 0);
+			}
+
 			TVector<Math::Transform> base(numNodes);
 			for (size_t i = 0; i < numNodes; ++i)
 			{
@@ -594,6 +689,77 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 					}
 				}
 			}
+
+			auto composeGlobalTransforms = [numNodes, &parents](
+				const TVector<Math::Transform>& local,
+				TVector<Math::Transform>& global)
+			{
+				global.Resize(numNodes);
+				TVector<uint8_t> composeState(numNodes);
+				auto compose = [&](auto&& self, size_t nodeIndex) -> bool
+				{
+					if (composeState[nodeIndex] == 2)
+					{
+						return IsTransformFinite(global[nodeIndex]);
+					}
+					if (composeState[nodeIndex] == 1)
+					{
+						global[nodeIndex] = local[nodeIndex];
+						composeState[nodeIndex] = 2;
+						return false;
+					}
+
+					composeState[nodeIndex] = 1;
+					Math::Transform composed = local[nodeIndex];
+					const int32_t parentIndex = parents[nodeIndex];
+					if (parentIndex >= 0 && self(self, static_cast<size_t>(parentIndex)))
+					{
+						const Math::Transform& parent = global[static_cast<size_t>(parentIndex)];
+						composed.m_position = parent.TransformPosition(composed.m_position);
+						composed.m_rotation = parent.m_rotation * composed.m_rotation;
+						composed.m_scale.x *= parent.m_scale.x;
+						composed.m_scale.y *= parent.m_scale.y;
+						composed.m_scale.z *= parent.m_scale.z;
+					}
+
+					global[nodeIndex] = IsTransformFinite(composed) ? composed : local[nodeIndex];
+					composeState[nodeIndex] = 2;
+					return IsTransformFinite(global[nodeIndex]);
+				};
+
+				for (size_t nodeIndex = 0; nodeIndex < numNodes; ++nodeIndex)
+				{
+					compose(compose, nodeIndex);
+				}
+			};
+
+			auto buildLocalBonePose = [&gltfSkin, &parentBoneIndices](
+				const TVector<Math::Transform>& global,
+				TVector<Math::Transform>& outPose,
+				size_t poseOffset)
+			{
+				for (size_t boneIndex = 0; boneIndex < parentBoneIndices.Num(); ++boneIndex)
+				{
+					const size_t nodeIndex = static_cast<size_t>(gltfSkin.joints[boneIndex]);
+					glm::mat4 localMatrix = global[nodeIndex].Matrix();
+					const int32_t parentBoneIndex = parentBoneIndices[boneIndex];
+					if (parentBoneIndex >= 0)
+					{
+						const size_t parentNodeIndex = static_cast<size_t>(
+							gltfSkin.joints[static_cast<size_t>(parentBoneIndex)]);
+						localMatrix = glm::inverse(global[parentNodeIndex].Matrix()) * localMatrix;
+					}
+					Math::Transform localTransform = IsMatrixFinite(localMatrix) ?
+						Math::Transform::FromMatrix(localMatrix) : Math::Transform::Identity;
+					outPose[poseOffset + boneIndex] = IsTransformFinite(localTransform) ?
+						localTransform : Math::Transform::Identity;
+				}
+			};
+
+			TVector<Math::Transform> baseGlobal;
+			composeGlobalTransforms(base, baseGlobal);
+			TVector<Math::Transform> restPose(numBones);
+			buildLocalBonePose(baseGlobal, restPose, 0);
 
 			TVector<PreparedAnimationChannel> preparedChannels;
 			preparedChannels.Reserve(gltfAnim.channels.size());
@@ -797,55 +963,9 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 					}
 				}
 
-				TVector<Math::Transform> global(numNodes);
-				TVector<uint8_t> composeState(numNodes);
-				auto compose = [&](auto&& self, size_t nodeIndex) -> bool
-				{
-					if (composeState[nodeIndex] == 2)
-					{
-						return IsTransformFinite(global[nodeIndex]);
-					}
-					if (composeState[nodeIndex] == 1)
-					{
-						global[nodeIndex] = local[nodeIndex];
-						composeState[nodeIndex] = 2;
-						return false;
-					}
-
-					composeState[nodeIndex] = 1;
-					Math::Transform composed = local[nodeIndex];
-					const int32_t parentIndex = parents[nodeIndex];
-					if (parentIndex >= 0 &&
-						self(self, static_cast<size_t>(parentIndex)))
-					{
-						const Math::Transform& parent =
-							global[static_cast<size_t>(parentIndex)];
-						composed.m_position =
-							parent.TransformPosition(composed.m_position);
-						composed.m_rotation =
-							parent.m_rotation * composed.m_rotation;
-						composed.m_scale.x *= parent.m_scale.x;
-						composed.m_scale.y *= parent.m_scale.y;
-						composed.m_scale.z *= parent.m_scale.z;
-					}
-
-					global[nodeIndex] = IsTransformFinite(composed) ?
-						composed : local[nodeIndex];
-					composeState[nodeIndex] = 2;
-					return IsTransformFinite(global[nodeIndex]);
-				};
-
-				for (size_t i = 0; i < numNodes; ++i)
-				{
-					compose(compose, i);
-				}
-
-				for (size_t j = 0; j < numBones; ++j)
-				{
-					const size_t nodeIndex =
-						static_cast<size_t>(gltfSkin.joints[j]);
-					framesData[f * numBones + j] = global[nodeIndex];
-				}
+				TVector<Math::Transform> global;
+				composeGlobalTransforms(local, global);
+				buildLocalBonePose(global, framesData, f * numBones);
 			}
 
 			anim->m_numBones = static_cast<uint32_t>(numBones);
@@ -853,9 +973,13 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 			anim->m_fps = samplingFps;
 			anim->m_duration = animationDuration;
 			anim->m_frames = std::move(framesData);
+			anim->m_restPose = std::move(restPose);
+			anim->m_parentBoneIndices = std::move(parentBoneIndices);
+			anim->m_skeletonSignature = skeletonSignature;
 		}
 	}
 
+	++anim->m_revision;
 	outAnimation = anim;
 	return true;
 }

--- a/Runtime/AssetRegistry/Animation/AnimationImporter.h
+++ b/Runtime/AssetRegistry/Animation/AnimationImporter.h
@@ -24,6 +24,7 @@ namespace Sailor
 		uint32_t m_numFrames = 0;
 		uint32_t m_numBones = 0;
 		float m_fps = 30.0f;
+		float m_duration = 0.0f;
 	};
 
 	using AnimationPtr = TObjectPtr<Animation>;

--- a/Runtime/AssetRegistry/Animation/AnimationImporter.h
+++ b/Runtime/AssetRegistry/Animation/AnimationImporter.h
@@ -21,10 +21,14 @@ namespace Sailor
 		SAILOR_API Animation(FileId uid) : Object(uid) {}
 
 		TVector<Math::Transform> m_frames;
+		TVector<Math::Transform> m_restPose;
+		TVector<int32_t> m_parentBoneIndices;
 		uint32_t m_numFrames = 0;
 		uint32_t m_numBones = 0;
 		float m_fps = 30.0f;
 		float m_duration = 0.0f;
+		uint64_t m_skeletonSignature = 0;
+		uint64_t m_revision = 0;
 	};
 
 	using AnimationPtr = TObjectPtr<Animation>;
@@ -36,7 +40,7 @@ namespace Sailor
 		SAILOR_API virtual ~AnimationImporter() override;
 
 		SAILOR_API virtual void OnImportAsset(AssetInfoPtr assetInfo) override {}
-		SAILOR_API virtual void OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired) override {}
+		SAILOR_API virtual void OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired) override;
 
 		SAILOR_API bool LoadAsset(FileId uid, TObjectPtr<Object>& out, bool bImmediate = true) override;
 		SAILOR_API Tasks::TaskPtr<AnimationPtr> LoadAnimation(FileId uid, AnimationPtr& outAnimation);

--- a/Runtime/AssetRegistry/Animation/AnimationPose.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationPose.cpp
@@ -1,0 +1,150 @@
+#include "AnimationPose.h"
+#include "Math/Math.h"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace Sailor;
+
+bool AnimationPose::Sample(
+	const AnimationPtr& animation,
+	float time,
+	bool bLoop,
+	TVector<Math::Transform>& outLocalPose,
+	uint32_t& outFrameIndex,
+	float& outLerp)
+{
+	if (!animation || !std::isfinite(time) ||
+		animation->m_numFrames == 0 || animation->m_numBones == 0 ||
+		animation->m_frames.Num() !=
+			static_cast<size_t>(animation->m_numFrames) * animation->m_numBones)
+	{
+		return false;
+	}
+
+	const float lastFrame = static_cast<float>(animation->m_numFrames - 1);
+	float frame = time * animation->m_fps;
+	if (bLoop && lastFrame > 0.0f)
+	{
+		frame = std::fmod(frame, lastFrame);
+		if (frame < 0.0f)
+		{
+			frame += lastFrame;
+		}
+	}
+	else
+	{
+		frame = std::clamp(frame, 0.0f, lastFrame);
+	}
+
+	outFrameIndex = (std::min)(
+		static_cast<uint32_t>(std::floor(frame)),
+		animation->m_numFrames - 1);
+	outLerp = frame - std::floor(frame);
+	const uint32_t nextFrame = (std::min)(
+		outFrameIndex + 1,
+		animation->m_numFrames - 1);
+	if (outLocalPose.Num() != animation->m_numBones)
+	{
+		outLocalPose.Resize(animation->m_numBones);
+	}
+	for (uint32_t boneIndex = 0; boneIndex < animation->m_numBones; ++boneIndex)
+	{
+		const Math::Transform& from = animation->m_frames[
+			static_cast<size_t>(outFrameIndex) * animation->m_numBones + boneIndex];
+		const Math::Transform& to = animation->m_frames[
+			static_cast<size_t>(nextFrame) * animation->m_numBones + boneIndex];
+		outLocalPose[boneIndex] = Math::Lerp(from, to, outLerp);
+	}
+	return true;
+}
+
+bool AnimationPose::ComposeLocalPose(
+	const TVector<Math::Transform>& localPose,
+	const TVector<int32_t>& parentBoneIndices,
+	TVector<glm::mat4>& outGlobalMatrices,
+	TVector<uint8_t>& scratchComposeState)
+{
+	if (localPose.IsEmpty() ||
+		(!parentBoneIndices.IsEmpty() && parentBoneIndices.Num() != localPose.Num()))
+	{
+		return false;
+	}
+
+	outGlobalMatrices.Resize(localPose.Num());
+	scratchComposeState.Resize(localPose.Num());
+	for (auto& state : scratchComposeState)
+	{
+		state = 0;
+	}
+
+	bool bValid = true;
+	auto composeBone = [&](auto&& self, size_t boneIndex) -> void
+	{
+		if (scratchComposeState[boneIndex] == 2)
+		{
+			return;
+		}
+		const glm::mat4 localMatrix = localPose[boneIndex].Matrix();
+		if (scratchComposeState[boneIndex] == 1)
+		{
+			outGlobalMatrices[boneIndex] = localMatrix;
+			scratchComposeState[boneIndex] = 2;
+			bValid = false;
+			return;
+		}
+
+		scratchComposeState[boneIndex] = 1;
+		const int32_t parentBoneIndex = parentBoneIndices.IsEmpty() ?
+			-1 : parentBoneIndices[boneIndex];
+		if (parentBoneIndex >= 0)
+		{
+			if (static_cast<size_t>(parentBoneIndex) >= localPose.Num() ||
+				static_cast<size_t>(parentBoneIndex) == boneIndex)
+			{
+				outGlobalMatrices[boneIndex] = localMatrix;
+				bValid = false;
+			}
+			else
+			{
+				self(self, static_cast<size_t>(parentBoneIndex));
+				outGlobalMatrices[boneIndex] =
+					outGlobalMatrices[static_cast<size_t>(parentBoneIndex)] * localMatrix;
+			}
+		}
+		else
+		{
+			outGlobalMatrices[boneIndex] = localMatrix;
+		}
+		scratchComposeState[boneIndex] = 2;
+	};
+
+	for (size_t boneIndex = 0; boneIndex < localPose.Num(); ++boneIndex)
+	{
+		composeBone(composeBone, boneIndex);
+	}
+	return bValid;
+}
+
+bool AnimationPose::BlendLocalPoses(
+	const TVector<Math::Transform>& from,
+	const TVector<Math::Transform>& to,
+	float alpha,
+	TVector<Math::Transform>& outPose)
+{
+	if (from.IsEmpty() || from.Num() != to.Num() || !std::isfinite(alpha))
+	{
+		return false;
+	}
+
+	alpha = std::clamp(alpha, 0.0f, 1.0f);
+	if (outPose.Num() != from.Num())
+	{
+		outPose.Resize(from.Num());
+	}
+	for (size_t boneIndex = 0; boneIndex < from.Num(); ++boneIndex)
+	{
+		outPose[boneIndex] = Math::Lerp(from[boneIndex], to[boneIndex], alpha);
+	}
+	return true;
+}

--- a/Runtime/AssetRegistry/Animation/AnimationPose.h
+++ b/Runtime/AssetRegistry/Animation/AnimationPose.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "AnimationImporter.h"
+#include "Containers/Vector.h"
+
+#include <glm/mat4x4.hpp>
+
+namespace Sailor::AnimationPose
+{
+	SAILOR_API bool Sample(
+		const AnimationPtr& animation,
+		float time,
+		bool bLoop,
+		TVector<Math::Transform>& outLocalPose,
+		uint32_t& outFrameIndex,
+		float& outLerp);
+
+	SAILOR_API bool ComposeLocalPose(
+		const TVector<Math::Transform>& localPose,
+		const TVector<int32_t>& parentBoneIndices,
+		TVector<glm::mat4>& outGlobalMatrices,
+		TVector<uint8_t>& scratchComposeState);
+
+	SAILOR_API bool BlendLocalPoses(
+		const TVector<Math::Transform>& from,
+		const TVector<Math::Transform>& to,
+		float alpha,
+		TVector<Math::Transform>& outPose);
+}

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -3,6 +3,7 @@
 #include "Containers/Containers.h"
 
 #include "AssetRegistry/Animation/AnimationAssetInfo.h"
+#include "AssetRegistry/Animation/AnimationControllerAssetInfo.h"
 #include "AssetRegistry/AssetInfo.h"
 #include "AssetRegistry/FrameGraph/FrameGraphAssetInfo.h"
 #include "AssetRegistry/Material/MaterialAssetInfo.h"
@@ -758,6 +759,14 @@ IAssetInfoHandler* AssetRegistry::GetAssetInfoHandler(
 	if (assetInfoType == "Sailor::AnimationAssetInfo")
 	{
 		return App::GetSubmodule<AnimationAssetInfoHandler>();
+	}
+	if (assetInfoType == "Sailor::AnimationControllerAssetInfo")
+	{
+		return App::GetSubmodule<AnimationControllerAssetInfoHandler>();
+	}
+	if (assetInfoType == "Sailor::AnimationSetAssetInfo")
+	{
+		return App::GetSubmodule<AnimationSetAssetInfoHandler>();
 	}
 	if (assetInfoType == "Sailor::FrameGraphAssetInfo")
 	{

--- a/Runtime/AssetRegistry/Material/MaterialImporter.cpp
+++ b/Runtime/AssetRegistry/Material/MaterialImporter.cpp
@@ -139,7 +139,9 @@ RHI::RHIMaterialPtr Material::GetOrAddRHI(RHI::RHIVertexDescriptionPtr vertexDes
 			}
 			else
 			{
-				// We cannot create RHI material
+				SAILOR_LOG_ERROR("Cannot create RHI material %s for vertex attribute identity %llu.",
+					GetFileId().ToString().c_str(),
+					static_cast<unsigned long long>(vertexDescription->GetVertexAttributeBits()));
 				return nullptr;
 			}
 		}
@@ -165,7 +167,12 @@ void Material::UpdateRHIResource()
 	m_commonShaderBindings.Clear();
 
 	// Create base material
-	GetOrAddRHI(RHI::Renderer::GetDriver()->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4I4W4>());
+	if (!GetOrAddRHI(RHI::Renderer::GetDriver()->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4I4W4>()))
+	{
+		m_bIsDirty = true;
+		SAILOR_LOG_ERROR("Cannot update RHI resource for material %s.", GetFileId().ToString().c_str());
+		return;
+	}
 
 	{
 		SAILOR_PROFILE_SCOPE("Update samplers");
@@ -226,6 +233,11 @@ void Material::UpdateRHIResource()
 
 void Material::UpdateUniforms(RHI::RHICommandListPtr cmdList)
 {
+	if (!m_commonShaderBindings)
+	{
+		return;
+	}
+
 	TMap<std::string, TVector<uint8_t>> bindingData;
 
 	auto writeParameter = [this, &bindingData](
@@ -320,6 +332,11 @@ void Material::UpdateUniforms(RHI::RHICommandListPtr cmdList)
 
 void Material::ForcelyUpdateUniforms()
 {
+	if (!m_commonShaderBindings)
+	{
+		return;
+	}
+
 	RHI::RHICommandListPtr cmdList;
 	{
 		SAILOR_PROFILE_SCOPE("Create command list");

--- a/Runtime/Components/AnimatorComponent.cpp
+++ b/Runtime/Components/AnimatorComponent.cpp
@@ -38,6 +38,41 @@ void AnimatorComponent::SetAnimation(const AnimationPtr& animation)
 	GetOwner()->GetWorld()->GetECS<AnimationECS>()->SetAnimation(m_handle, animation);
 }
 
+void AnimatorComponent::SetController(const AnimationControllerPtr& controller)
+{
+	GetOwner()->GetWorld()->GetECS<AnimationECS>()->SetController(m_handle, controller);
+}
+
+void AnimatorComponent::SetAnimationSet(const AnimationSetPtr& animationSet)
+{
+	GetOwner()->GetWorld()->GetECS<AnimationECS>()->SetAnimationSet(m_handle, animationSet);
+}
+
+bool AnimatorComponent::SetFloat(const std::string& name, float value)
+{
+	return GetData().GetControllerInstance().SetFloat(name, value);
+}
+
+bool AnimatorComponent::SetInt(const std::string& name, int32_t value)
+{
+	return GetData().GetControllerInstance().SetInt(name, value);
+}
+
+bool AnimatorComponent::SetBool(const std::string& name, bool value)
+{
+	return GetData().GetControllerInstance().SetBool(name, value);
+}
+
+bool AnimatorComponent::SetTrigger(const std::string& name)
+{
+	return GetData().GetControllerInstance().SetTrigger(name);
+}
+
+bool AnimatorComponent::ResetTrigger(const std::string& name)
+{
+	return GetData().GetControllerInstance().ResetTrigger(name);
+}
+
 void AnimatorComponent::Play()
 {
 	GetData().m_bIsPlaying = true;

--- a/Runtime/Components/AnimatorComponent.h
+++ b/Runtime/Components/AnimatorComponent.h
@@ -17,6 +17,16 @@ namespace Sailor
 
 		SAILOR_API const AnimationPtr& GetAnimation() const { return GetData().GetAnimation(); }
 		SAILOR_API void SetAnimation(const AnimationPtr& animation);
+		SAILOR_API const AnimationControllerPtr& GetController() const { return GetData().GetController(); }
+		SAILOR_API void SetController(const AnimationControllerPtr& controller);
+		SAILOR_API const AnimationSetPtr& GetAnimationSet() const { return GetData().GetAnimationSet(); }
+		SAILOR_API void SetAnimationSet(const AnimationSetPtr& animationSet);
+
+		SAILOR_API bool SetFloat(const std::string& name, float value);
+		SAILOR_API bool SetInt(const std::string& name, int32_t value);
+		SAILOR_API bool SetBool(const std::string& name, bool value);
+		SAILOR_API bool SetTrigger(const std::string& name);
+		SAILOR_API bool ResetTrigger(const std::string& name);
 
 		SAILOR_API void Play();
 		SAILOR_API void Stop();
@@ -37,5 +47,11 @@ using namespace Sailor::Attributes;
 REFL_AUTO(
 	type(Sailor::AnimatorComponent, bases<Sailor::Component>),
 	func(SetAnimation, property("animation"), SkipCDO()),
-	func(GetAnimation, property("animation"), SkipCDO())
+	func(GetAnimation, property("animation"), SkipCDO()),
+
+	func(SetController, property("controller"), SkipCDO()),
+	func(GetController, property("controller"), SkipCDO()),
+
+	func(SetAnimationSet, property("animationSet"), SkipCDO()),
+	func(GetAnimationSet, property("animationSet"), SkipCDO())
 )

--- a/Runtime/Core/Reflection.cpp
+++ b/Runtime/Core/Reflection.cpp
@@ -7,6 +7,7 @@
 #include "Engine/GameObject.h"
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/Animation/AnimationAssetInfo.h"
+#include "AssetRegistry/Animation/AnimationControllerAssetInfo.h"
 #include "AssetRegistry/AssetInfo.h"
 #include "AssetRegistry/FrameGraph/FrameGraphAssetInfo.h"
 #include "AssetRegistry/Material/MaterialAssetInfo.h"
@@ -90,6 +91,8 @@ namespace
 		nodes.Add(ExportAssetInfoType<TextureAssetInfo>("Sailor::TextureAssetInfo", { "png", "bmp", "tga", "jpg", "gif", "psd", "dds", "hdr" }));
 		nodes.Add(ExportAssetInfoType<ModelAssetInfo>("Sailor::ModelAssetInfo", { "glb", "gltf" }));
 		nodes.Add(ExportAssetInfoType<AnimationAssetInfo>("Sailor::AnimationAssetInfo", { "anim" }));
+		nodes.Add(ExportAssetInfoType<AnimationControllerAssetInfo>("Sailor::AnimationControllerAssetInfo", { "animcontroller" }));
+		nodes.Add(ExportAssetInfoType<AnimationSetAssetInfo>("Sailor::AnimationSetAssetInfo", { "animset" }));
 		nodes.Add(ExportAssetInfoType<MaterialAssetInfo>("Sailor::MaterialAssetInfo", { "mat" }));
 		nodes.Add(ExportAssetInfoType<ShaderAssetInfo>("Sailor::ShaderAssetInfo", { "shader", "glsl" }));
 		nodes.Add(ExportAssetInfoType<FrameGraphAssetInfo>("Sailor::FrameGraphAssetInfo", { "renderer" }));

--- a/Runtime/Core/Reflection.h
+++ b/Runtime/Core/Reflection.h
@@ -10,6 +10,7 @@
 #include "RHI/Types.h"
 #include "YamlSerializable.h"
 #include <limits>
+#include <string_view>
 #include <vector>
 
 using refl::reflect;
@@ -253,17 +254,8 @@ namespace Sailor
 			}
 			else if constexpr (IsObjectPtr<PropertyType>)
 			{
-				using ElementType = TemplateParameter_t<PropertyType>;
-				if constexpr (requires { ElementType::GetStaticTypeInfo(); })
-				{
-					return "TObjectPtr<" +
-						ElementType::GetStaticTypeInfo().Name() +
-						">";
-				}
-				else
-				{
-					return typeid(PropertyType).name();
-				}
+				using ElementType = std::remove_cv_t<TemplateParameter_t<PropertyType>>;
+				return "TObjectPtr<" + GetCanonicalCppTypeName<ElementType>() + ">";
 			}
 			else
 			{
@@ -272,6 +264,45 @@ namespace Sailor
 		}
 
 	private:
+		template<typename T>
+		static std::string GetCanonicalCppTypeName()
+		{
+#if defined(_MSC_VER)
+			const std::string_view signature = __FUNCSIG__;
+			constexpr std::string_view marker = "GetCanonicalCppTypeName<";
+			const size_t begin = signature.find(marker);
+			const size_t end = signature.rfind(">(void)");
+			if (begin == std::string_view::npos || end == std::string_view::npos)
+			{
+				return {};
+			}
+			std::string_view typeName = signature.substr(begin + marker.size(), end - begin - marker.size());
+#elif defined(__clang__) || defined(__GNUC__)
+			const std::string_view signature = __PRETTY_FUNCTION__;
+			constexpr std::string_view marker = "T = ";
+			const size_t begin = signature.find(marker);
+			const size_t end = signature.find_first_of(";]", begin + marker.size());
+			if (begin == std::string_view::npos || end == std::string_view::npos)
+			{
+				return {};
+			}
+			std::string_view typeName = signature.substr(begin + marker.size(), end - begin - marker.size());
+#else
+#error Unsupported compiler for stable reflected C++ type names
+#endif
+
+			constexpr std::string_view prefixes[] = { "class ", "struct ", "enum " };
+			for (const std::string_view prefix : prefixes)
+			{
+				if (typeName.starts_with(prefix))
+				{
+					typeName.remove_prefix(prefix.size());
+					break;
+				}
+			}
+
+			return std::string(typeName);
+		}
 
 		std::string m_name;
 		std::string m_base;

--- a/Runtime/ECS/AnimationECS.cpp
+++ b/Runtime/ECS/AnimationECS.cpp
@@ -3,6 +3,7 @@
 #include "RHI/Renderer.h"
 #include "RHI/Shader.h"
 #include "AssetRegistry/Animation/AnimationImporter.h"
+#include "AssetRegistry/Animation/AnimationPose.h"
 #include "Components/MeshRendererComponent.h"
 #include <algorithm>
 #include <cmath>
@@ -86,14 +87,140 @@ void AnimationECS::SetAnimation(size_t componentIndex, const TObjectPtr<Animatio
 	}
 
 	auto& data = GetComponentData(componentIndex);
+	const uint32_t previousBonesCount = data.GetBonesCount();
 	data.GetAnimation() = animation;
-	data.SetBonesCount(animation ? animation->m_numBones : 0);
+	data.m_animationRevision = animation ? animation->m_revision : 0;
+	const bool bControllerActive = data.m_controllerInstance.IsValid() &&
+		data.m_animationSet && !data.m_controllerAnimations.IsEmpty();
+	if (!bControllerActive)
+	{
+		data.SetBonesCount(animation ? animation->m_numBones : 0);
+		data.m_skeletonSignature = animation ? animation->m_skeletonSignature : 0;
+	}
 	data.m_currentFrame = 0.0f;
 	data.m_frameIndex = 0;
 	data.m_lerp = 0.0f;
 	data.MarkDirty();
 
-	InvalidateGpuLayout();
+	if (previousBonesCount != data.GetBonesCount())
+	{
+		InvalidateGpuLayout();
+	}
+	else
+	{
+		MarkMeshSkeletonDirty(data.m_owner.StaticCast<GameObject>());
+	}
+}
+
+void AnimationECS::SetController(
+	size_t componentIndex,
+	const AnimationControllerPtr& controller)
+{
+	if (!IsComponentRegistered(componentIndex))
+	{
+		return;
+	}
+	GetComponentData(componentIndex).m_controller = controller;
+	RefreshController(componentIndex, true);
+}
+
+void AnimationECS::SetAnimationSet(
+	size_t componentIndex,
+	const AnimationSetPtr& animationSet)
+{
+	if (!IsComponentRegistered(componentIndex))
+	{
+		return;
+	}
+	GetComponentData(componentIndex).m_animationSet = animationSet;
+	RefreshController(componentIndex, false);
+}
+
+void AnimationECS::RefreshController(size_t componentIndex, bool bResetInstance)
+{
+	if (!IsComponentRegistered(componentIndex))
+	{
+		return;
+	}
+
+	auto& data = GetComponentData(componentIndex);
+	const uint32_t previousBonesCount = data.GetBonesCount();
+	if (bResetInstance)
+	{
+		data.m_controllerInstance.SetController(data.m_controller);
+	}
+	else if (data.m_controllerInstance.GetController() != data.m_controller)
+	{
+		data.m_controllerInstance.SetController(data.m_controller);
+	}
+	else if (data.m_controller)
+	{
+		data.m_controllerInstance.Tick(0.0f, 0.0f);
+	}
+
+	data.m_controllerRevision = data.m_controller ? data.m_controller->GetRevision() : 0;
+	data.m_animationSetRevision = data.m_animationSet ? data.m_animationSet->GetRevision() : 0;
+	data.m_animationRevision = data.m_animation ? data.m_animation->m_revision : 0;
+	data.m_controllerAnimations.Clear();
+	data.m_controllerAnimationRevisions.Clear();
+
+	uint32_t controllerBonesCount = 0;
+	uint64_t controllerSkeletonSignature = 0;
+	if (data.m_controllerInstance.IsValid() && data.m_animationSet)
+	{
+		const auto& states = data.m_controller->GetStates();
+		data.m_controllerAnimations.Resize(states.Num());
+		data.m_controllerAnimationRevisions.Resize(states.Num());
+		auto* animationImporter = App::GetSubmodule<AnimationImporter>();
+		for (size_t stateIndex = 0; stateIndex < states.Num(); ++stateIndex)
+		{
+			const FileId* animationId = data.m_animationSet->FindAnimation(
+				states[stateIndex].m_clipSlot);
+			AnimationPtr animation;
+			if (animationImporter && animationId && *animationId)
+			{
+				animationImporter->LoadAnimation_Immediate(*animationId, animation);
+			}
+			if (animation && animation->m_numBones > 0 &&
+				animation->m_parentBoneIndices.Num() == animation->m_numBones &&
+				animation->m_restPose.Num() == animation->m_numBones)
+			{
+				if (controllerBonesCount == 0)
+				{
+					controllerBonesCount = animation->m_numBones;
+					controllerSkeletonSignature = animation->m_skeletonSignature;
+				}
+				else if (animation->m_numBones != controllerBonesCount ||
+					animation->m_skeletonSignature != controllerSkeletonSignature)
+				{
+					SAILOR_LOG_ERROR(
+						"Animation controller '%s' state '%s' uses an incompatible skeleton.",
+						data.m_controller->GetFileId().ToString().c_str(),
+						states[stateIndex].m_name.c_str());
+					animation.Clear();
+				}
+			}
+			data.m_controllerAnimations[stateIndex] = animation;
+			data.m_controllerAnimationRevisions[stateIndex] = animation ? animation->m_revision : 0;
+		}
+	}
+
+	data.SetBonesCount(controllerBonesCount > 0 ?
+		controllerBonesCount : (data.m_animation ? data.m_animation->m_numBones : 0));
+	data.m_skeletonSignature = controllerBonesCount > 0 ?
+		controllerSkeletonSignature : (data.m_animation ? data.m_animation->m_skeletonSignature : 0);
+	data.m_currentFrame = 0.0f;
+	data.m_frameIndex = 0;
+	data.m_lerp = 0.0f;
+	data.MarkDirty();
+	if (previousBonesCount != data.GetBonesCount())
+	{
+		InvalidateGpuLayout();
+	}
+	else
+	{
+		MarkMeshSkeletonDirty(data.m_owner.StaticCast<GameObject>());
+	}
 }
 
 void AnimationECS::OnComponentUnregistered(size_t, AnimatorComponentData&)
@@ -103,6 +230,32 @@ void AnimationECS::OnComponentUnregistered(size_t, AnimatorComponentData&)
 
 Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 {
+	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
+	{
+		auto& data = m_components[componentIndex];
+		bool bAnimationChanged = data.m_animation &&
+			data.m_animationRevision != data.m_animation->m_revision;
+		if (!bAnimationChanged &&
+			data.m_controllerAnimationRevisions.Num() == data.m_controllerAnimations.Num())
+		{
+			for (size_t stateIndex = 0; stateIndex < data.m_controllerAnimations.Num(); ++stateIndex)
+			{
+				const auto& animation = data.m_controllerAnimations[stateIndex];
+				if (animation && data.m_controllerAnimationRevisions[stateIndex] != animation->m_revision)
+				{
+					bAnimationChanged = true;
+					break;
+				}
+			}
+		}
+		if ((data.m_controller && data.m_controllerRevision != data.m_controller->GetRevision()) ||
+			(data.m_animationSet && data.m_animationSetRevision != data.m_animationSet->GetRevision()) ||
+			bAnimationChanged)
+		{
+			RefreshController(componentIndex, false);
+		}
+	}
+
 	auto renderer = App::GetSubmodule<RHI::Renderer>();
 	auto commands = renderer->GetDriverCommands();
 	auto cmdList = GetWorld()->GetCommandList();
@@ -115,10 +268,9 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 			continue;
 		}
 
-		const auto& animation = data.GetAnimation();
-		const bool bHasValidBoneRange = animation && animation->m_numFrames > 0 && animation->m_numBones > 0 &&
-			data.GetBonesCount() == animation->m_numBones &&
-			data.m_gpuOffset <= BonesMaxNum && animation->m_numBones <= BonesMaxNum - data.m_gpuOffset;
+		const uint32_t bonesCount = data.GetBonesCount();
+		const bool bHasValidBoneRange = bonesCount > 0 &&
+			data.m_gpuOffset <= BonesMaxNum && bonesCount <= BonesMaxNum - data.m_gpuOffset;
 		if (!bHasValidBoneRange)
 		{
 			InvalidateGpuLayout();
@@ -134,89 +286,175 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 		}
 
 		GameObjectPtr owner = data.m_owner.StaticCast<GameObject>();
-		if (!owner || !data.GetAnimation() || data.GetAnimation()->m_numFrames == 0 || data.GetAnimation()->m_numBones == 0)
+		if (!owner || data.GetBonesCount() == 0)
 		{
 			continue;
 		}
 
-		const auto& anim = *data.GetAnimation();
-		data.SetBonesCount(anim.m_numBones);
-		const float lastFrame = static_cast<float>(anim.m_numFrames - 1);
-
-		if (data.m_bIsPlaying)
+		bool bSampled = false;
+		AnimationPtr skeletonAnimation;
+		const bool bUseController = data.m_controllerInstance.IsValid() &&
+			data.m_animationSet &&
+			data.m_controllerAnimations.Num() == data.m_controller->GetStates().Num();
+		if (bUseController)
 		{
-			float frameAdvance = deltaTime * anim.m_fps * data.m_playSpeed * (data.m_bForward ? 1.0f : -1.0f);
-			data.m_currentFrame += frameAdvance;
+			uint32_t activeStateIndex = data.m_controllerInstance.GetActiveStateIndex();
+			AnimationPtr activeAnimation = activeStateIndex < data.m_controllerAnimations.Num() ?
+				data.m_controllerAnimations[activeStateIndex] : AnimationPtr{};
+			const float activeDuration = activeAnimation ? activeAnimation->m_duration : 0.0f;
+			const float controllerDelta = data.m_bIsPlaying ?
+				deltaTime * (std::max)(data.m_playSpeed, 0.0f) : 0.0f;
+			data.m_controllerInstance.Tick(controllerDelta, activeDuration);
 
-			if (data.m_playMode == EAnimationPlayMode::Repeat)
+			activeStateIndex = data.m_controllerInstance.GetActiveStateIndex();
+			activeAnimation = activeStateIndex < data.m_controllerAnimations.Num() ?
+				data.m_controllerAnimations[activeStateIndex] : AnimationPtr{};
+			if (activeAnimation && activeAnimation->m_numBones == data.GetBonesCount())
 			{
-				if (lastFrame > 0.0f)
+				skeletonAnimation = activeAnimation;
+				bSampled = AnimationPose::Sample(
+					activeAnimation,
+					data.m_controllerInstance.GetActiveStateTime(),
+					data.m_controller->GetStates()[activeStateIndex].m_bLoop,
+					data.m_currentSkeleton,
+					data.m_frameIndex,
+					data.m_lerp);
+			}
+
+			if (bSampled && data.m_controllerInstance.IsTransitioning())
+			{
+				const uint32_t destinationStateIndex =
+					data.m_controllerInstance.GetDestinationStateIndex();
+				AnimationPtr destinationAnimation = destinationStateIndex < data.m_controllerAnimations.Num() ?
+					data.m_controllerAnimations[destinationStateIndex] : AnimationPtr{};
+				uint32_t blendFrameIndex = 0;
+				float blendLerp = 0.0f;
+				if (destinationAnimation &&
+					destinationAnimation->m_numBones == data.GetBonesCount() &&
+					AnimationPose::Sample(
+						destinationAnimation,
+						data.m_controllerInstance.GetDestinationStateTime(),
+						data.m_controller->GetStates()[destinationStateIndex].m_bLoop,
+						data.m_blendSkeleton,
+						blendFrameIndex,
+						blendLerp))
 				{
-					data.m_currentFrame = std::fmod(data.m_currentFrame, lastFrame);
-					if (data.m_currentFrame < 0.0f)
+					const float alpha = data.m_controllerInstance.GetTransitionAlpha();
+					AnimationPose::BlendLocalPoses(
+						data.m_currentSkeleton,
+						data.m_blendSkeleton,
+						alpha,
+						data.m_currentSkeleton);
+				}
+			}
+		}
+		else if (data.GetAnimation() && data.GetAnimation()->m_numBones == data.GetBonesCount())
+		{
+			const auto& anim = *data.GetAnimation();
+			skeletonAnimation = data.GetAnimation();
+			const float lastFrame = static_cast<float>(anim.m_numFrames - 1);
+
+			if (data.m_bIsPlaying)
+			{
+				float frameAdvance = deltaTime * anim.m_fps * data.m_playSpeed * (data.m_bForward ? 1.0f : -1.0f);
+				data.m_currentFrame += frameAdvance;
+
+				if (data.m_playMode == EAnimationPlayMode::Repeat)
+				{
+					if (lastFrame > 0.0f)
 					{
-						data.m_currentFrame += lastFrame;
+						data.m_currentFrame = std::fmod(data.m_currentFrame, lastFrame);
+						if (data.m_currentFrame < 0.0f)
+						{
+							data.m_currentFrame += lastFrame;
+						}
+					}
+					else
+					{
+						data.m_currentFrame = 0.0f;
 					}
 				}
-				else
+				else if (data.m_playMode == EAnimationPlayMode::Once)
 				{
-					data.m_currentFrame = 0.0f;
+					if (data.m_currentFrame >= lastFrame)
+					{
+						data.m_currentFrame = lastFrame;
+						data.m_bIsPlaying = false;
+					}
+					else if (data.m_currentFrame <= 0.0f && frameAdvance < 0.0f)
+					{
+						data.m_currentFrame = 0.0f;
+						data.m_bIsPlaying = false;
+					}
+				}
+				else if (data.m_playMode == EAnimationPlayMode::PingPong)
+				{
+					if (data.m_bForward && data.m_currentFrame >= lastFrame)
+					{
+						data.m_currentFrame = lastFrame;
+						data.m_bForward = false;
+					}
+					else if (!data.m_bForward && data.m_currentFrame <= 0.0f)
+					{
+						data.m_currentFrame = 0.0f;
+						data.m_bForward = true;
+					}
 				}
 			}
-			else if (data.m_playMode == EAnimationPlayMode::Once)
+
+			bSampled = AnimationPose::Sample(
+				data.GetAnimation(),
+				data.m_currentFrame / anim.m_fps,
+				false,
+				data.m_currentSkeleton,
+				data.m_frameIndex,
+				data.m_lerp);
+		}
+
+		if (!bSampled)
+		{
+			if (!skeletonAnimation && bUseController)
 			{
-				if (data.m_currentFrame >= lastFrame)
+				for (const auto& animation : data.m_controllerAnimations)
 				{
-					data.m_currentFrame = lastFrame;
-					data.m_bIsPlaying = false;
-				}
-				else if (data.m_currentFrame <= 0.0f && frameAdvance < 0.0f)
-				{
-					data.m_currentFrame = 0.0f;
-					data.m_bIsPlaying = false;
+					if (animation && animation->m_numBones == data.GetBonesCount())
+					{
+						skeletonAnimation = animation;
+						break;
+					}
 				}
 			}
-			else if (data.m_playMode == EAnimationPlayMode::PingPong)
+			if (!skeletonAnimation && data.m_animation &&
+				data.m_animation->m_numBones == data.GetBonesCount())
 			{
-				if (data.m_bForward && data.m_currentFrame >= lastFrame)
+				skeletonAnimation = data.m_animation;
+			}
+			if (data.m_currentSkeleton.Num() != data.GetBonesCount())
+			{
+				data.m_currentSkeleton.Resize(data.GetBonesCount());
+			}
+			if (skeletonAnimation &&
+				skeletonAnimation->m_restPose.Num() == data.GetBonesCount())
+			{
+				data.m_currentSkeleton = skeletonAnimation->m_restPose;
+			}
+			else
+			{
+				for (auto& transform : data.m_currentSkeleton)
 				{
-					data.m_currentFrame = lastFrame;
-					data.m_bForward = false;
-				}
-				else if (!data.m_bForward && data.m_currentFrame <= 0.0f)
-				{
-					data.m_currentFrame = 0.0f;
-					data.m_bForward = true;
+					transform = Math::Transform{};
 				}
 			}
 		}
 
-		data.m_frameIndex = (std::min)(
-			static_cast<uint32_t>(floor(data.m_currentFrame)),
-			anim.m_numFrames - 1);
-		data.m_lerp = data.m_currentFrame - floor(data.m_currentFrame);
-
 		if (data.m_gpuOffset == AnimatorComponentData::InvalidGpuOffset)
 		{
-			if (!TryAllocateBoneRange(anim.m_numBones, m_nextBoneOffset, data.m_gpuOffset))
+			if (!TryAllocateBoneRange(data.GetBonesCount(), m_nextBoneOffset, data.m_gpuOffset))
 			{
 				continue;
 			}
 
 			MarkMeshSkeletonDirty(data.m_owner.StaticCast<GameObject>());
-		}
-
-		if (data.m_currentSkeleton.Num() != anim.m_numBones)
-		{
-			data.m_currentSkeleton.Resize(anim.m_numBones);
-		}
-
-		uint32_t nextFrame = (std::min)(data.m_frameIndex + 1, anim.m_numFrames - 1);
-		for (uint32_t i = 0; i < anim.m_numBones; i++)
-		{
-			const Math::Transform& a = anim.m_frames[data.m_frameIndex * anim.m_numBones + i];
-			const Math::Transform& b = anim.m_frames[nextFrame * anim.m_numBones + i];
-			data.m_currentSkeleton[i] = Math::Lerp(a, b, data.m_lerp);
 		}
 
 		ModelPtr model;
@@ -225,16 +463,33 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 			model = mesh->GetModel();
 		}
 
-		TVector<glm::mat4> matrices(data.m_currentSkeleton.Num());
+		if (data.m_currentMatrices.Num() != data.m_currentSkeleton.Num())
+		{
+			data.m_currentMatrices.Resize(data.m_currentSkeleton.Num());
+			data.m_globalMatrices.Resize(data.m_currentSkeleton.Num());
+			data.m_composeState.Resize(data.m_currentSkeleton.Num());
+		}
+		TVector<int32_t> rootBoneIndices;
+		const TVector<int32_t>* parentBoneIndices = skeletonAnimation ?
+			&skeletonAnimation->m_parentBoneIndices : nullptr;
+		if (!parentBoneIndices || parentBoneIndices->Num() != data.m_currentSkeleton.Num())
+		{
+			parentBoneIndices = &rootBoneIndices;
+		}
+		AnimationPose::ComposeLocalPose(
+			data.m_currentSkeleton,
+			*parentBoneIndices,
+			data.m_globalMatrices,
+			data.m_composeState);
 		for (uint32_t i = 0; i < data.m_currentSkeleton.Num(); ++i)
 		{
 			const glm::mat4 bind = model && model->GetInverseBind().Num() > i ? model->GetInverseBind()[i] : glm::mat4(1.0f);
-			matrices[i] = data.m_currentSkeleton[i].Matrix() * bind;
+			data.m_currentMatrices[i] = data.m_globalMatrices[i] * bind;
 		}
 
 		commands->UpdateShaderBinding(cmdList, m_bonesBuffer,
-			matrices.GetData(),
-			sizeof(glm::mat4) * matrices.Num(),
+			data.m_currentMatrices.GetData(),
+			sizeof(glm::mat4) * data.m_currentMatrices.Num(),
 			m_bonesBuffer->GetBufferOffset() + sizeof(glm::mat4) * data.m_gpuOffset);
 	}
 

--- a/Runtime/ECS/AnimationECS.cpp
+++ b/Runtime/ECS/AnimationECS.cpp
@@ -177,13 +177,35 @@ void AnimationECS::RefreshController(size_t componentIndex, bool bResetInstance)
 			const FileId* animationId = data.m_animationSet->FindAnimation(
 				states[stateIndex].m_clipSlot);
 			AnimationPtr animation;
-			if (animationImporter && animationId && *animationId)
+			if (!animationId || !*animationId)
 			{
-				animationImporter->LoadAnimation_Immediate(*animationId, animation);
+				SAILOR_LOG_ERROR(
+					"Animation controller '%s' state '%s' has no clip for slot '%s'.",
+					data.m_controller->GetFileId().ToString().c_str(),
+					states[stateIndex].m_name.c_str(),
+					states[stateIndex].m_clipSlot.c_str());
 			}
-			if (animation && animation->m_numBones > 0 &&
-				animation->m_parentBoneIndices.Num() == animation->m_numBones &&
-				animation->m_restPose.Num() == animation->m_numBones)
+			else if (!animationImporter ||
+				!animationImporter->LoadAnimation_Immediate(*animationId, animation))
+			{
+				SAILOR_LOG_ERROR(
+					"Animation controller '%s' state '%s' cannot load clip '%s'.",
+					data.m_controller->GetFileId().ToString().c_str(),
+					states[stateIndex].m_name.c_str(),
+					animationId->ToString().c_str());
+			}
+			if (animation &&
+				(animation->m_numBones == 0 ||
+				 animation->m_parentBoneIndices.Num() != animation->m_numBones ||
+				 animation->m_restPose.Num() != animation->m_numBones))
+			{
+				SAILOR_LOG_ERROR(
+					"Animation controller '%s' state '%s' has invalid skeleton data.",
+					data.m_controller->GetFileId().ToString().c_str(),
+					states[stateIndex].m_name.c_str());
+				animation.Clear();
+			}
+			if (animation)
 			{
 				if (controllerBonesCount == 0)
 				{

--- a/Runtime/ECS/AnimationECS.cpp
+++ b/Runtime/ECS/AnimationECS.cpp
@@ -4,6 +4,7 @@
 #include "RHI/Shader.h"
 #include "AssetRegistry/Animation/AnimationImporter.h"
 #include "Components/MeshRendererComponent.h"
+#include <algorithm>
 #include <cmath>
 #include <limits>
 #include "Math/Transform.h"
@@ -140,6 +141,7 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 
 		const auto& anim = *data.GetAnimation();
 		data.SetBonesCount(anim.m_numBones);
+		const float lastFrame = static_cast<float>(anim.m_numFrames - 1);
 
 		if (data.m_bIsPlaying)
 		{
@@ -148,21 +150,37 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 
 			if (data.m_playMode == EAnimationPlayMode::Repeat)
 			{
-				data.m_currentFrame = std::fmod(std::max(data.m_currentFrame, 0.0f), (float)anim.m_numFrames);
+				if (lastFrame > 0.0f)
+				{
+					data.m_currentFrame = std::fmod(data.m_currentFrame, lastFrame);
+					if (data.m_currentFrame < 0.0f)
+					{
+						data.m_currentFrame += lastFrame;
+					}
+				}
+				else
+				{
+					data.m_currentFrame = 0.0f;
+				}
 			}
 			else if (data.m_playMode == EAnimationPlayMode::Once)
 			{
-				if (data.m_currentFrame >= anim.m_numFrames - 1)
+				if (data.m_currentFrame >= lastFrame)
 				{
-					data.m_currentFrame = (float)(anim.m_numFrames - 1);
+					data.m_currentFrame = lastFrame;
+					data.m_bIsPlaying = false;
+				}
+				else if (data.m_currentFrame <= 0.0f && frameAdvance < 0.0f)
+				{
+					data.m_currentFrame = 0.0f;
 					data.m_bIsPlaying = false;
 				}
 			}
 			else if (data.m_playMode == EAnimationPlayMode::PingPong)
 			{
-				if (data.m_bForward && data.m_currentFrame >= anim.m_numFrames - 1)
+				if (data.m_bForward && data.m_currentFrame >= lastFrame)
 				{
-					data.m_currentFrame = (float)(anim.m_numFrames - 1);
+					data.m_currentFrame = lastFrame;
 					data.m_bForward = false;
 				}
 				else if (!data.m_bForward && data.m_currentFrame <= 0.0f)
@@ -173,7 +191,9 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 			}
 		}
 
-		data.m_frameIndex = (uint32_t)floor(data.m_currentFrame) % anim.m_numFrames;
+		data.m_frameIndex = (std::min)(
+			static_cast<uint32_t>(floor(data.m_currentFrame)),
+			anim.m_numFrames - 1);
 		data.m_lerp = data.m_currentFrame - floor(data.m_currentFrame);
 
 		if (data.m_gpuOffset == AnimatorComponentData::InvalidGpuOffset)
@@ -191,7 +211,7 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 			data.m_currentSkeleton.Resize(anim.m_numBones);
 		}
 
-		uint32_t nextFrame = (data.m_frameIndex + 1) % anim.m_numFrames;
+		uint32_t nextFrame = (std::min)(data.m_frameIndex + 1, anim.m_numFrames - 1);
 		for (uint32_t i = 0; i < anim.m_numBones; i++)
 		{
 			const Math::Transform& a = anim.m_frames[data.m_frameIndex * anim.m_numBones + i];

--- a/Runtime/ECS/AnimationECS.h
+++ b/Runtime/ECS/AnimationECS.h
@@ -7,6 +7,7 @@
 #include "RHI/SceneView.h"
 #include "RHI/Types.h"
 #include "Math/Transform.h"
+#include "AssetRegistry/Animation/AnimationController.h"
 
 namespace Sailor
 {
@@ -19,6 +20,10 @@ namespace Sailor
 
 		SAILOR_API __forceinline TObjectPtr<Animation>& GetAnimation() { return m_animation; }
 		SAILOR_API __forceinline const TObjectPtr<Animation>& GetAnimation() const { return m_animation; }
+		SAILOR_API __forceinline const AnimationControllerPtr& GetController() const { return m_controller; }
+		SAILOR_API __forceinline const AnimationSetPtr& GetAnimationSet() const { return m_animationSet; }
+		SAILOR_API __forceinline AnimationControllerInstance& GetControllerInstance() { return m_controllerInstance; }
+		SAILOR_API __forceinline const AnimationControllerInstance& GetControllerInstance() const { return m_controllerInstance; }
 
 		SAILOR_API __forceinline uint32_t GetBonesCount() const { return m_bonesCount; }
 		SAILOR_API __forceinline void SetBonesCount(uint32_t numBones) { m_bonesCount = numBones; }
@@ -27,6 +32,10 @@ namespace Sailor
 		float m_lerp = 0.0f;
 		uint32_t m_gpuOffset = InvalidGpuOffset;
 		TVector<Math::Transform> m_currentSkeleton;
+		TVector<Math::Transform> m_blendSkeleton;
+		TVector<glm::mat4> m_currentMatrices;
+		TVector<glm::mat4> m_globalMatrices;
+		TVector<uint8_t> m_composeState;
 
 		bool m_bIsPlaying = true;
 		float m_playSpeed = 1.0f;
@@ -37,6 +46,15 @@ namespace Sailor
 	protected:
 
 		TObjectPtr<Animation> m_animation;
+		AnimationControllerPtr m_controller;
+		AnimationSetPtr m_animationSet;
+		AnimationControllerInstance m_controllerInstance;
+		TVector<TObjectPtr<Animation>> m_controllerAnimations;
+		TVector<uint64_t> m_controllerAnimationRevisions;
+		uint64_t m_animationRevision = 0;
+		uint64_t m_controllerRevision = 0;
+		uint64_t m_animationSetRevision = 0;
+		uint64_t m_skeletonSignature = 0;
 		uint32_t m_bonesCount = 0;
 
 		friend class AnimationECS;
@@ -54,6 +72,8 @@ namespace Sailor
 		virtual Tasks::ITaskPtr Tick(float deltaTime) override;
 
 		void SetAnimation(size_t componentIndex, const TObjectPtr<Animation>& animation);
+		void SetController(size_t componentIndex, const AnimationControllerPtr& controller);
+		void SetAnimationSet(size_t componentIndex, const AnimationSetPtr& animationSet);
 		void InvalidateGpuLayout();
 
 		static bool TryAllocateBoneRange(uint32_t numBones, uint32_t& nextBoneOffset, uint32_t& outGpuOffset);
@@ -67,6 +87,7 @@ namespace Sailor
 	protected:
 
 		virtual void OnComponentUnregistered(size_t index, AnimatorComponentData& component) override;
+		void RefreshController(size_t componentIndex, bool bResetInstance);
 
 		RHI::RHIShaderBindingSetPtr m_bonesBinding{};
 		RHI::RHIShaderBindingPtr m_bonesBuffer{};

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -8,7 +8,9 @@
 #include "Core/Reflection.h"
 #include "Engine/EngineLoop.h"
 #include "Engine/World.h"
+#include "Engine/GameObject.h"
 #include "Engine/InstanceId.h"
+#include "Components/AnimatorComponent.h"
 #include "Editor/EditorViewportController.h"
 #include "Submodules/Editor.h"
 #include "Workspace/WorkspaceModuleManager.h"
@@ -136,6 +138,35 @@ namespace
 		case EditorViewport::ETransformSpace::Local: return 2;
 		default: return 0;
 		}
+	}
+
+	AnimatorComponent* FindEditorAnimator(
+		Editor* editor,
+		const InstanceId& componentInstanceId)
+	{
+		if (!editor || !editor->GetWorld() ||
+			componentInstanceId.ComponentId() == InstanceId::Invalid)
+		{
+			return nullptr;
+		}
+
+		auto gameObject = editor->GetWorld()
+			->GetObjectByInstanceId(componentInstanceId.GameObjectId())
+			.DynamicCast<GameObject>();
+		if (!gameObject)
+		{
+			return nullptr;
+		}
+
+		for (auto component : gameObject->GetComponents())
+		{
+			if (component &&
+				component->GetInstanceId() == componentInstanceId)
+			{
+				return component.DynamicCast<AnimatorComponent>().GetRawPtr();
+			}
+		}
+		return nullptr;
 	}
 }
 
@@ -508,6 +539,136 @@ bool App::UpdateEditorObject(const char* strInstanceId, const char* strYamlNode)
 			InstanceId instanceId;
 			instanceId.Deserialize(YAML::Node(instanceIdValue));
 			return editor->UpdateObject(instanceId, yamlValue);
+		});
+}
+
+bool App::SetEditorAnimatorParameter(
+	const char* strInstanceId,
+	const char* strName,
+	uint32_t valueKind,
+	float floatValue,
+	int32_t intValue,
+	bool boolValue)
+{
+	if (!strInstanceId || !strName || strName[0] == '\0')
+	{
+		return false;
+	}
+
+	const std::string instanceIdValue = strInstanceId;
+	const std::string name = strName;
+	return ExecuteOnEngineMainThread<bool>(false,
+		[instanceIdValue, name, valueKind, floatValue, intValue, boolValue]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			InstanceId instanceId;
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+			auto* animator = FindEditorAnimator(editor, instanceId);
+			if (!animator)
+			{
+				return false;
+			}
+
+			switch (valueKind)
+			{
+			case 1: return animator->SetFloat(name, floatValue);
+			case 2: return animator->SetInt(name, intValue);
+			case 3: return animator->SetBool(name, boolValue);
+			case 4: return animator->SetTrigger(name);
+			case 5: return animator->ResetTrigger(name);
+			default: return false;
+			}
+		});
+}
+
+bool App::GetEditorAnimatorState(
+	const char* strInstanceId,
+	bool& outHasController,
+	uint64_t& outControllerRevision,
+	uint64_t& outActiveStateId,
+	char** outActiveStateName,
+	float& outActiveStateTime,
+	bool& outTransitioning,
+	uint64_t& outDestinationStateId,
+	char** outDestinationStateName,
+	float& outDestinationStateTime,
+	float& outTransitionAlpha)
+{
+	outHasController = false;
+	outControllerRevision = 0;
+	outActiveStateId = InvalidAnimationControllerNodeId;
+	outActiveStateTime = 0.0f;
+	outTransitioning = false;
+	outDestinationStateId = InvalidAnimationControllerNodeId;
+	outDestinationStateTime = 0.0f;
+	outTransitionAlpha = 0.0f;
+	if (!strInstanceId || !outActiveStateName || !outDestinationStateName)
+	{
+		return false;
+	}
+	outActiveStateName[0] = nullptr;
+	outDestinationStateName[0] = nullptr;
+
+	const std::string instanceIdValue = strInstanceId;
+	return ExecuteOnEngineMainThread<bool>(false,
+		[instanceIdValue,
+			&outHasController,
+			&outControllerRevision,
+			&outActiveStateId,
+			outActiveStateName,
+			&outActiveStateTime,
+			&outTransitioning,
+			&outDestinationStateId,
+			outDestinationStateName,
+			&outDestinationStateTime,
+			&outTransitionAlpha]()
+		{
+			auto editor = GetSubmodule<Editor>();
+			InstanceId instanceId;
+			instanceId.Deserialize(YAML::Node(instanceIdValue));
+			auto* animator = FindEditorAnimator(editor, instanceId);
+			if (!animator)
+			{
+				return false;
+			}
+
+			const auto& instance = animator->GetData().GetControllerInstance();
+			const auto& controller = instance.GetController();
+			outHasController = controller && instance.IsValid();
+			if (!outHasController)
+			{
+				SetInteropString({}, outActiveStateName);
+				SetInteropString({}, outDestinationStateName);
+				return true;
+			}
+
+			outControllerRevision = controller->GetRevision();
+			const auto& states = controller->GetStates();
+			const uint32_t activeStateIndex = instance.GetActiveStateIndex();
+			if (activeStateIndex < states.Num())
+			{
+				outActiveStateId = states[activeStateIndex].m_id;
+				SetInteropString(states[activeStateIndex].m_name, outActiveStateName);
+			}
+			else
+			{
+				SetInteropString({}, outActiveStateName);
+			}
+			outActiveStateTime = instance.GetActiveStateTime();
+			outTransitioning = instance.IsTransitioning();
+			const uint32_t destinationStateIndex = instance.GetDestinationStateIndex();
+			if (outTransitioning && destinationStateIndex < states.Num())
+			{
+				outDestinationStateId = states[destinationStateIndex].m_id;
+				SetInteropString(states[destinationStateIndex].m_name, outDestinationStateName);
+				outDestinationStateTime = instance.GetDestinationStateTime();
+				outTransitionAlpha = instance.GetTransitionAlpha();
+			}
+			else
+			{
+				SetInteropString({}, outDestinationStateName);
+			}
+			return true;
 		});
 }
 

--- a/Runtime/Engine/EngineLoop.cpp
+++ b/Runtime/Engine/EngineLoop.cpp
@@ -164,7 +164,7 @@ void EngineLoop::ProcessPendingWorldExits()
 
 		if (renderer && renderer->IsInitialized())
 		{
-			renderer->GetDriver()->WaitIdle();
+			renderer->WaitIdle();
 			renderer->RemoveSceneView(world);
 		}
 

--- a/Runtime/FrameGraph/DepthPrepassNode.cpp
+++ b/Runtime/FrameGraph/DepthPrepassNode.cpp
@@ -18,16 +18,22 @@ using namespace Sailor::RHI;
 const char* DepthPrepassNode::m_name = "DepthPrepass";
 #endif
 
-RHI::RHIMaterialPtr DepthPrepassNode::GetOrAddDepthMaterial(RHI::RHIVertexDescriptionPtr vertexDescription)
+RHI::RHIMaterialPtr DepthPrepassNode::GetOrAddDepthMaterial(RHI::RHIVertexDescriptionPtr vertexDescription, bool bSkinned)
 {
-	auto& material = m_depthOnlyMaterials[vertexDescription->GetVertexAttributeBits()];
+	auto& materials = bSkinned ? m_skinnedDepthOnlyMaterials : m_depthOnlyMaterials;
+	auto& material = materials[vertexDescription->GetVertexAttributeBits()];
 
 	if (!material)
 	{
 		auto shaderFileId = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr("Shaders/DepthOnly.shader");
 		ShaderSetPtr pShader;
+		TVector<std::string> defines;
+		if (bSkinned)
+		{
+			defines.Add("SKINNING");
+		}
 
-		if (App::GetSubmodule<ShaderCompiler>()->LoadShader_Immediate(shaderFileId->GetFileId(), pShader) && pShader->IsReady())
+		if (App::GetSubmodule<ShaderCompiler>()->LoadShader_Immediate(shaderFileId->GetFileId(), pShader, defines) && pShader->IsReady())
 		{
 			RenderState renderState = RHI::RenderState(true, true, 0.0f, false, ECullMode::Back, EBlendMode::None, EFillMode::Fill, GetHash(std::string("DepthOnly")), true);
 			material = RHI::Renderer::GetDriver()->CreateMaterial(vertexDescription, RHI::EPrimitiveTopology::TriangleList, renderState, pShader);
@@ -88,7 +94,11 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 
 					const auto& mesh = proxy.m_meshes[i];
 
-					auto depthMaterial = GetOrAddDepthMaterial(mesh->m_vertexDescription);
+					const bool bSkinned =
+						proxy.m_skeletonOffset != (std::numeric_limits<uint32_t>::max)() &&
+						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
+						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
+					auto depthMaterial = GetOrAddDepthMaterial(mesh->m_vertexDescription, bSkinned);
 
 					const bool bRequiredCustomDepth = proxy.GetMaterials()[i]->GetRenderState().IsRequiredCustomDepthShader();
 					if (bRequiredCustomDepth)
@@ -112,7 +122,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 							proxy.m_worldMatrix;
 					DepthPrepassNode::PerInstanceData data;
 					data.model = meshWorldMatrix;
-					data.skeletonOffset = proxy.m_skeletonOffset;
+					data.skeletonOffset = bSkinned ? proxy.m_skeletonOffset : (std::numeric_limits<uint32_t>::max)();
 					data.bIsCulled = 0;
 					data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
 					data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
@@ -293,7 +303,10 @@ void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 				sets = TVector<RHIShaderBindingSetPtr>({ sceneView.m_frameBindings, sceneView.m_rhiLightsData, m_perInstanceData, material->GetBindings(), batch.m_textureBindings });
 			}
 
-			if (sceneView.m_boneMatrices)
+			const bool bSkinned =
+				batch.m_mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
+				batch.m_mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
+			if (bSkinned && sceneView.m_boneMatrices)
 			{
 				sets.Add(sceneView.m_boneMatrices);
 			}

--- a/Runtime/FrameGraph/DepthPrepassNode.h
+++ b/Runtime/FrameGraph/DepthPrepassNode.h
@@ -49,10 +49,11 @@ namespace Sailor
 		TSet<RHI::RHIBatch> m_batches;
 
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_depthOnlyMaterials;
+		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedDepthOnlyMaterials;
 		RHI::RHIShaderBindingSetPtr m_perInstanceData;
 		size_t m_sizePerInstanceData = 0;
 
-		RHI::RHIMaterialPtr GetOrAddDepthMaterial(RHI::RHIVertexDescriptionPtr vertex);
+		RHI::RHIMaterialPtr GetOrAddDepthMaterial(RHI::RHIVertexDescriptionPtr vertex, bool bSkinned);
 		TVector<RHI::RHIBufferPtr> m_indirectBuffers;
 
 		// Culling

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -10,6 +10,8 @@
 #include "AssetRegistry/AssetRegistry.h"
 #include "ECS/LightingECS.h"
 
+#include <limits>
+
 using namespace Sailor;
 using namespace Sailor::RHI;
 
@@ -17,9 +19,12 @@ using namespace Sailor::RHI;
 const char* ShadowPrepassNode::m_name = "ShadowPrepass";
 #endif
 
-RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddShadowMaterial(RHI::RHIVertexDescriptionPtr vertexDescription, RHI::EShadowType shadowType)
+RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddShadowMaterial(RHI::RHIVertexDescriptionPtr vertexDescription, RHI::EShadowType shadowType, bool bSkinned)
 {
-	auto& material = shadowType == EShadowType::EVSM ? m_shadowMaterials_Evsm[vertexDescription->GetVertexAttributeBits()] : m_shadowMaterials_Pcf[vertexDescription->GetVertexAttributeBits()];
+	auto& materials = shadowType == EShadowType::EVSM ?
+		(bSkinned ? m_skinnedShadowMaterials_Evsm : m_shadowMaterials_Evsm) :
+		(bSkinned ? m_skinnedShadowMaterials_Pcf : m_shadowMaterials_Pcf);
+	auto& material = materials[vertexDescription->GetVertexAttributeBits()];
 
 	if (!material)
 	{
@@ -30,6 +35,10 @@ RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddShadowMaterial(RHI::RHIVertexDesc
 		if (shadowType == EShadowType::EVSM)
 		{
 			defines.Add("EVSM");
+		}
+		if (bSkinned)
+		{
+			defines.Add("SKINNING");
 		}
 
 		if (App::GetSubmodule<ShaderCompiler>()->LoadShader_Immediate(shaderFileId->GetFileId(), pShader, defines))
@@ -135,7 +144,11 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 					}
 
 					const auto& mesh = proxy.m_meshes[i];
-					auto depthMaterial = GetOrAddShadowMaterial(mesh->m_vertexDescription, shadowPass.m_shadowType);
+					const bool bSkinned =
+						proxy.m_skeletonOffset != (std::numeric_limits<uint32_t>::max)() &&
+						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
+						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
+					auto depthMaterial = GetOrAddShadowMaterial(mesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned);
 
 					const bool bIsDepthMaterialReady = depthMaterial &&
 						depthMaterial->GetVertexShader() &&
@@ -152,6 +165,7 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 							proxy.m_worldMatrix;
 					ShadowPrepassNode::PerInstanceData data;
 					data.model = meshWorldMatrix;
+					data.skeletonOffset = bSkinned ? proxy.m_skeletonOffset : (std::numeric_limits<uint32_t>::max)();
 
 					RHIBatch batch(depthMaterial, mesh);
 
@@ -229,8 +243,14 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 
 		auto shaderBindingsByMaterial = [&](const RHIBatch& batch)
 			{
-				auto material = batch.m_material;
 				TVector<RHIShaderBindingSetPtr> sets({ sceneView.m_frameBindings, m_perInstanceData });
+				const bool bSkinned =
+					batch.m_mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
+					batch.m_mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
+				if (bSkinned && sceneView.m_boneMatrices)
+				{
+					sets.Add(sceneView.m_boneMatrices);
+				}
 				return sets;
 			};
 
@@ -430,6 +450,8 @@ void ShadowPrepassNode::Clear()
 	m_perInstanceData.Clear();
 	m_shadowMaterials_Pcf.Clear();
 	m_shadowMaterials_Evsm.Clear();
+	m_skinnedShadowMaterials_Pcf.Clear();
+	m_skinnedShadowMaterials_Evsm.Clear();
 }
 
 glm::mat4 ShadowPrepassNode::CalculateLightProjectionMatrix(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float zMult)

--- a/Runtime/FrameGraph/ShadowPrepassNode.h
+++ b/Runtime/FrameGraph/ShadowPrepassNode.h
@@ -15,6 +15,10 @@ namespace Sailor
 		struct PerInstanceData
 		{
 			glm::mat4 model;
+			uint32_t skeletonOffset = 0;
+			uint32_t padding0 = 0;
+			uint32_t padding1 = 0;
+			uint32_t padding2 = 0;
 
 			bool operator==(const PerInstanceData& rhs) const { return this->model == model; }
 
@@ -44,8 +48,10 @@ namespace Sailor
 		// Shadow caster material
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_shadowMaterials_Evsm{};
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_shadowMaterials_Pcf{};
+		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedShadowMaterials_Evsm{};
+		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedShadowMaterials_Pcf{};
 
-		RHI::RHIMaterialPtr GetOrAddShadowMaterial(RHI::RHIVertexDescriptionPtr vertex, RHI::EShadowType shadowType);
+		RHI::RHIMaterialPtr GetOrAddShadowMaterial(RHI::RHIVertexDescriptionPtr vertex, RHI::EShadowType shadowType, bool bSkinned);
 
 		// Record drawcalls
 		size_t m_sizePerInstanceData = 0;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
@@ -87,6 +87,7 @@ void VulkanCommandBuffer::BeginCommandList(VkCommandBufferUsageFlags flags)
 
 	m_numRecordedCommands = 0;
 	m_gpuCost = 0;
+	m_bGraphicsPipelineBound = false;
 
 	ClearDependencies();
 }
@@ -94,6 +95,7 @@ void VulkanCommandBuffer::BeginCommandList(VkCommandBufferUsageFlags flags)
 void VulkanCommandBuffer::BeginSecondaryCommandList(const TVector<VkFormat>& colorAttachments, VkFormat depthStencilAttachment, VkCommandBufferUsageFlags flags, VkRenderingFlags inheritanceFlags, bool bSupportMultisampling)
 {
 	ClearDependencies();
+	m_bGraphicsPipelineBound = false;
 
 	//TODO: Pass inheritanceFlags
 	const bool bHasStencil = depthStencilAttachment != VkFormat::VK_FORMAT_UNDEFINED && (VulkanApi::ComputeAspectFlagsForFormat(depthStencilAttachment) & VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -128,6 +130,7 @@ void VulkanCommandBuffer::BeginSecondaryCommandList(const TVector<VkFormat>& col
 void VulkanCommandBuffer::BeginSecondaryCommandList(VulkanRenderPassPtr renderPass, uint32_t subpassIndex, VkCommandBufferUsageFlags flags)
 {
 	ClearDependencies();
+	m_bGraphicsPipelineBound = false;
 
 	// We can omit framebuffer for now
 	VkCommandBufferInheritanceInfo inheritanceInfo{};
@@ -689,8 +692,16 @@ void VulkanCommandBuffer::PushConstants(VulkanPipelineLayoutPtr pipelineLayout, 
 
 void VulkanCommandBuffer::BindPipeline(VulkanGraphicsPipelinePtr pipeline)
 {
+	if (!pipeline || !pipeline->IsCompiled())
+	{
+		m_bGraphicsPipelineBound = false;
+		SAILOR_LOG_ERROR("VulkanCommandBuffer::BindPipeline: graphics pipeline is unavailable.");
+		return;
+	}
+
 	m_rhiDependecies.Insert(pipeline);
 	vkCmdBindPipeline(m_commandBuffer, VK_PIPELINE_BIND_POINT_GRAPHICS, *pipeline);
+	m_bGraphicsPipelineBound = true;
 
 	m_numRecordedCommands++;
 	m_gpuCost += 1;
@@ -721,6 +732,11 @@ void VulkanCommandBuffer::Dispatch(uint32_t groupX, uint32_t groupY, uint32_t gr
 
 void VulkanCommandBuffer::DrawIndexedIndirect(VulkanBufferMemoryPtr buffer, VkDeviceSize offset, uint32_t drawCount, uint32_t stride)
 {
+	if (!m_bGraphicsPipelineBound)
+	{
+		return;
+	}
+
 	m_rhiDependecies.Insert(buffer.m_buffer);
 	vkCmdDrawIndexedIndirect(m_commandBuffer, *buffer.m_buffer, buffer.m_offset + offset, drawCount, stride);
 
@@ -730,6 +746,11 @@ void VulkanCommandBuffer::DrawIndexedIndirect(VulkanBufferMemoryPtr buffer, VkDe
 
 void VulkanCommandBuffer::DrawIndexed(uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, uint32_t vertexOffset, uint32_t firstInstance)
 {
+	if (!m_bGraphicsPipelineBound)
+	{
+		return;
+	}
+
 	vkCmdDrawIndexed(m_commandBuffer, indexCount, instanceCount, firstIndex, vertexOffset, firstInstance);
 
 	m_numRecordedCommands++;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.h
@@ -155,6 +155,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		DWORD m_currentThreadId = 0;
 
 		bool m_bIsRecorded = false;
+		bool m_bGraphicsPipelineBound = false;
 
 		// We're tracking only viewport due to scissor almost never changed
 		bool m_bHasViewport = false;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -1498,7 +1498,10 @@ RHI::RHIMaterialPtr VulkanGraphicsDriver::CreateMaterial(const RHI::RHIVertexDes
 		0);
 
 	pipeline->m_renderPass = device->GetRenderPass();
-	pipeline->Compile();
+	if (!pipeline->Compile())
+	{
+		return nullptr;
+	}
 
 	res->m_vulkan.m_pipelines.Emplace(std::move(pipeline));
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanPipeline.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanPipeline.cpp
@@ -104,13 +104,13 @@ void VulkanGraphicsPipeline::Release()
 	}
 }
 
-void VulkanGraphicsPipeline::Compile()
+bool VulkanGraphicsPipeline::Compile()
 {
 	SAILOR_PROFILE_FUNCTION();
 
 	if (m_pipeline)
 	{
-		return;
+		return true;
 	}
 
 	m_layout->Compile();
@@ -144,8 +144,17 @@ void VulkanGraphicsPipeline::Compile()
 
 	ApplyStates(pipelineInfo);
 
-	VK_CHECK(vkCreateGraphicsPipelines(*m_pDevice, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &m_pipeline));
+	const VkResult result = vkCreateGraphicsPipelines(*m_pDevice, VK_NULL_HANDLE, 1, &pipelineInfo, nullptr, &m_pipeline);
 	_freea(shaderStageCreateInfo);
+
+	if (result != VK_SUCCESS || m_pipeline == VK_NULL_HANDLE)
+	{
+		m_pipeline = VK_NULL_HANDLE;
+		SAILOR_LOG_ERROR("VulkanGraphicsPipeline::Compile: vkCreateGraphicsPipelines failed with VkResult %d.", static_cast<int32_t>(result));
+		return false;
+	}
+
+	return true;
 }
 
 void VulkanGraphicsPipeline::ApplyStates(VkGraphicsPipelineCreateInfo& pipelineInfo) const

--- a/Runtime/GraphicsDriver/Vulkan/VulkanPipeline.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanPipeline.h
@@ -63,8 +63,9 @@ namespace Sailor::GraphicsDriver::Vulkan
 		VulkanRenderPassPtr m_renderPass;
 		uint32_t m_subpass;
 
-		void Compile();
+		bool Compile();
 		void Release();
+		bool IsCompiled() const { return m_pipeline != VK_NULL_HANDLE; }
 
 		operator VkPipeline() const { return m_pipeline; }
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanPipileneStates.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanPipileneStates.cpp
@@ -265,7 +265,29 @@ const TVector<VulkanPipelineStatePtr>& VulkanPipelineStateBuilder::BuildPipeline
 
 	// We don't expect collisions in the dictionary
 	size_t hashCode = 0;
-	Sailor::HashCombine(hashCode, renderState, topology, depthStencilFormat);
+	Sailor::HashCombine(hashCode,
+		renderState,
+		topology,
+		depthStencilFormat,
+		vertexDescription->GetVertexStride());
+
+	for (const auto& attribute : vertexDescription->GetAttributeDescriptions())
+	{
+		Sailor::HashCombine(hashCode,
+			attribute.m_location,
+			attribute.m_binding,
+			attribute.m_format,
+			attribute.m_offset);
+	}
+
+	TVector<uint32_t> orderedVertexAttributeBindings =
+		vertexAttributeBindings.ToVector();
+	orderedVertexAttributeBindings.Sort();
+	Sailor::HashCombine(hashCode, orderedVertexAttributeBindings.Num());
+	for (const uint32_t binding : orderedVertexAttributeBindings)
+	{
+		Sailor::HashCombine(hashCode, binding);
+	}
 
 	for (const auto& colorAttachmentFormat : colorAttachmentFormats)
 	{

--- a/Runtime/Protocol/Generated/editor_engine.pb.cc
+++ b/Runtime/Protocol/Generated/editor_engine.pb.cc
@@ -1042,6 +1042,44 @@ struct AssetReloadStateResultDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AssetReloadStateResultDefaultTypeInternal _AssetReloadStateResult_default_instance_;
 
+inline constexpr AnimatorStateResult::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : active_state_name_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        destination_state_name_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        controller_revision_{::uint64_t{0u}},
+        active_state_id_{::uint64_t{0u}},
+        has_controller_{false},
+        transitioning_{false},
+        active_state_time_{0},
+        destination_state_id_{::uint64_t{0u}},
+        destination_state_time_{0},
+        transition_alpha_{0},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR AnimatorStateResult::AnimatorStateResult(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct AnimatorStateResultDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR AnimatorStateResultDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~AnimatorStateResultDefaultTypeInternal() {}
+  union {
+    AnimatorStateResult _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AnimatorStateResultDefaultTypeInternal _AnimatorStateResult_default_instance_;
+
 inline constexpr AddComponentRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : instance_id_(
@@ -1205,6 +1243,38 @@ struct CreateModelInstanceRequestDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 CreateModelInstanceRequestDefaultTypeInternal _CreateModelInstanceRequest_default_instance_;
+
+inline constexpr AnimatorParameterRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : instance_id_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        name_(
+            &::google::protobuf::internal::fixed_address_empty_string,
+            ::_pbi::ConstantInitialized()),
+        value_{},
+        _cached_size_{0},
+        _oneof_case_{} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR AnimatorParameterRequest::AnimatorParameterRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct AnimatorParameterRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR AnimatorParameterRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~AnimatorParameterRequestDefaultTypeInternal() {}
+  union {
+    AnimatorParameterRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 AnimatorParameterRequestDefaultTypeInternal _AnimatorParameterRequest_default_instance_;
 
 inline constexpr ViewportEvent::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
@@ -1394,6 +1464,8 @@ const ::uint32_t
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolRequest, _impl_.command_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _internal_metadata_),
@@ -1408,6 +1480,7 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _impl_.success_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _impl_.error_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _impl_.supports_strict_instance_ids_),
+        ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
@@ -1608,6 +1681,22 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AddComponentRequest, _impl_.instance_id_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AddComponentRequest, _impl_.component_type_name_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AddComponentRequest, _impl_.preferred_instance_id_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorParameterRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorParameterRequest, _impl_._oneof_case_[0]),
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorParameterRequest, _impl_.instance_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorParameterRequest, _impl_.name_),
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorParameterRequest, _impl_.value_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::InstantiatePrefabRequest, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -1816,6 +1905,24 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolStateResult, _impl_.operation_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ViewportToolStateResult, _impl_.space_),
         ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _impl_.has_controller_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _impl_.controller_revision_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _impl_.active_state_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _impl_.active_state_name_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _impl_.active_state_time_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _impl_.transitioning_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _impl_.destination_state_id_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _impl_.destination_state_name_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _impl_.destination_state_time_),
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorStateResult, _impl_.transition_alpha_),
+        ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::Vector4, _internal_metadata_),
         ~0u,  // no _extensions_
         ~0u,  // no _oneof_case_
@@ -1912,50 +2019,52 @@ static const ::_pbi::MigrationSchema
     schemas[] ABSL_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
         {0, -1, -1, sizeof(::sailor::editor::v1::Empty)},
         {8, -1, -1, sizeof(::sailor::editor::v1::ProtocolRequest)},
-        {67, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
-        {93, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
-        {102, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
-        {111, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
-        {120, 135, -1, sizeof(::sailor::editor::v1::CreateModelInstanceRequest)},
-        {142, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
-        {151, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
-        {160, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
-        {172, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
-        {182, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
-        {197, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
-        {208, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
-        {228, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
-        {238, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
-        {248, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
-        {259, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
-        {269, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
-        {280, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
-        {290, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
-        {301, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
-        {312, 324, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
-        {328, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
-        {338, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
-        {348, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
-        {359, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
-        {368, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
-        {377, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
-        {390, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
-        {399, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
-        {408, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
-        {417, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
-        {426, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
-        {436, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
-        {445, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
-        {457, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
-        {467, 476, -1, sizeof(::sailor::editor::v1::Vector4Result)},
-        {477, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
-        {487, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
-        {499, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
-        {508, 525, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
-        {534, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
-        {545, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
-        {554, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
-        {569, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
+        {69, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
+        {96, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
+        {105, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
+        {114, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
+        {123, 138, -1, sizeof(::sailor::editor::v1::CreateModelInstanceRequest)},
+        {145, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
+        {154, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
+        {163, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
+        {175, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
+        {185, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
+        {200, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
+        {211, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
+        {231, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
+        {241, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
+        {251, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
+        {262, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
+        {272, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
+        {283, -1, -1, sizeof(::sailor::editor::v1::AnimatorParameterRequest)},
+        {299, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
+        {309, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
+        {320, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
+        {331, 343, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
+        {347, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
+        {357, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
+        {367, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
+        {378, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
+        {387, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
+        {396, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
+        {409, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
+        {418, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
+        {427, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
+        {436, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
+        {445, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
+        {455, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
+        {464, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
+        {476, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
+        {486, 495, -1, sizeof(::sailor::editor::v1::Vector4Result)},
+        {496, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
+        {506, -1, -1, sizeof(::sailor::editor::v1::AnimatorStateResult)},
+        {524, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
+        {536, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
+        {545, 562, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
+        {571, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
+        {582, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
+        {591, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
+        {606, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_Empty_default_instance_._instance,
@@ -1977,6 +2086,7 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_ReparentObjectRequest_default_instance_._instance,
     &::sailor::editor::v1::_CreateGameObjectRequest_default_instance_._instance,
     &::sailor::editor::v1::_AddComponentRequest_default_instance_._instance,
+    &::sailor::editor::v1::_AnimatorParameterRequest_default_instance_._instance,
     &::sailor::editor::v1::_InstantiatePrefabRequest_default_instance_._instance,
     &::sailor::editor::v1::_InstantiatePrefabFromYamlRequest_default_instance_._instance,
     &::sailor::editor::v1::_ViewportRayRequest_default_instance_._instance,
@@ -1997,6 +2107,7 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_InstanceIdResult_default_instance_._instance,
     &::sailor::editor::v1::_Vector4Result_default_instance_._instance,
     &::sailor::editor::v1::_ViewportToolStateResult_default_instance_._instance,
+    &::sailor::editor::v1::_AnimatorStateResult_default_instance_._instance,
     &::sailor::editor::v1::_Vector4_default_instance_._instance,
     &::sailor::editor::v1::_ViewportSelectionEvent_default_instance_._instance,
     &::sailor::editor::v1::_ViewportTransformEvent_default_instance_._instance,
@@ -2008,7 +2119,7 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
     protodesc_cold) = {
     "\n\023editor_engine.proto\022\020sailor.editor.v1\""
-    "\007\n\005Empty\"\313\032\n\017ProtocolRequest\022\030\n\020protocol"
+    "\007\n\005Empty\"\334\033\n\017ProtocolRequest\022\030\n\020protocol"
     "_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\0229\n\nin"
     "itialize\030\n \001(\0132#.sailor.editor.v1.Initia"
     "lizeRequestH\000\022(\n\005start\030\013 \001(\0132\027.sailor.ed"
@@ -2091,160 +2202,179 @@ const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SE
     "e_asset\0309 \001(\0132\037.sailor.editor.v1.FileIdR"
     "equestH\000\022M\n\025create_model_instance\030: \001(\0132"
     ",.sailor.editor.v1.CreateModelInstanceRe"
-    "questH\000B\t\n\007commandJ\004\010\003\020\nJ\004\0102\0203J\004\010;\020dR\030cr"
-    "eate_model_game_objectR\036resolve_viewport"
-    "_drop_position\"\226\007\n\020ProtocolResponse\022\030\n\020p"
-    "rotocol_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001("
-    "\004\022\017\n\007success\030\003 \001(\010\022\r\n\005error\030\004 \001(\t\022$\n\034sup"
-    "ports_strict_instance_ids\030\005 \001(\010\022/\n\014empty"
-    "_result\030\n \001(\0132\027.sailor.editor.v1.EmptyH\000"
-    "\0223\n\013bool_result\030\013 \001(\0132\034.sailor.editor.v1"
-    ".BoolResultH\000\0225\n\014int32_result\030\014 \001(\0132\035.sa"
-    "ilor.editor.v1.Int32ResultH\000\0227\n\ruint32_r"
-    "esult\030\r \001(\0132\036.sailor.editor.v1.UInt32Res"
-    "ultH\000\0227\n\ruint64_result\030\016 \001(\0132\036.sailor.ed"
-    "itor.v1.UInt64ResultH\000\0227\n\rstring_result\030"
-    "\017 \001(\0132\036.sailor.editor.v1.StringResultH\000\022"
-    "@\n\022string_list_result\030\020 \001(\0132\".sailor.edi"
-    "tor.v1.StringListResultH\000\022M\n\031asset_reloa"
-    "d_state_result\030\021 \001(\0132(.sailor.editor.v1."
-    "AssetReloadStateResultH\000\022@\n\022instance_id_"
-    "result\030\022 \001(\0132\".sailor.editor.v1.Instance"
-    "IdResultH\000\022Q\n\033viewport_event_batch_resul"
-    "t\030\023 \001(\0132*.sailor.editor.v1.ViewportEvent"
-    "BatchResultH\000\0229\n\016vector4_result\030\024 \001(\0132\037."
-    "sailor.editor.v1.Vector4ResultH\000\022O\n\032view"
-    "port_tool_state_result\030\025 \001(\0132).sailor.ed"
-    "itor.v1.ViewportToolStateResultH\000B\010\n\006res"
-    "ultJ\004\010\006\020\nJ\004\010\026\020d\"&\n\021InitializeRequest\022\021\n\t"
-    "arguments\030\001 \003(\t\"!\n\014CountRequest\022\021\n\tmax_c"
-    "ount\030\001 \001(\r\" \n\rFileIdRequest\022\017\n\007file_id\030\001"
-    " \001(\t\"\347\001\n\032CreateModelInstanceRequest\022\025\n\rm"
-    "odel_file_id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\032\n\022pare"
-    "nt_instance_id\030\003 \001(\t\022\030\n\020create_hierarchy"
-    "\030\004 \001(\010\022\034\n\024apply_world_position\030\005 \001(\010\0221\n\016"
-    "world_position\030\006 \001(\0132\031.sailor.editor.v1."
-    "Vector4\022\035\n\025preferred_instance_id\030\007 \001(\t\"("
-    "\n\021InstanceIdRequest\022\023\n\013instance_id\030\001 \001(\t"
-    "\"(\n\021ViewportIdRequest\022\023\n\013viewport_id\030\001 \001"
-    "(\004\"`\n\023ViewportRectRequest\022\024\n\014window_pos_"
-    "x\030\001 \001(\r\022\024\n\014window_pos_y\030\002 \001(\r\022\r\n\005width\030\003"
-    " \001(\r\022\016\n\006height\030\004 \001(\r\",\n\013SizeRequest\022\r\n\005w"
-    "idth\030\001 \001(\r\022\016\n\006height\030\002 \001(\r\"\231\001\n\025RemoteVie"
-    "wportRequest\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014win"
-    "dow_pos_x\030\002 \001(\r\022\024\n\014window_pos_y\030\003 \001(\r\022\r\n"
-    "\005width\030\004 \001(\r\022\016\n\006height\030\005 \001(\r\022\017\n\007visible\030"
-    "\006 \001(\010\022\017\n\007focused\030\007 \001(\010\"e\n\031RemoteViewport"
-    "HostRequest\022\023\n\013viewport_id\030\001 \001(\004\022\030\n\020host"
-    "_handle_kind\030\002 \001(\r\022\031\n\021host_handle_value\030"
-    "\003 \001(\004\"\374\001\n\032RemoteViewportInputRequest\022\023\n\013"
-    "viewport_id\030\001 \001(\004\022\014\n\004kind\030\002 \001(\r\022\021\n\tpoint"
-    "er_x\030\003 \001(\002\022\021\n\tpointer_y\030\004 \001(\002\022\025\n\rwheel_d"
-    "elta_x\030\005 \001(\002\022\025\n\rwheel_delta_y\030\006 \001(\002\022\020\n\010k"
-    "ey_code\030\007 \001(\r\022\016\n\006button\030\010 \001(\r\022\021\n\tmodifie"
-    "rs\030\t \001(\r\022\017\n\007pressed\030\n \001(\010\022\017\n\007focused\030\013 \001"
-    "(\010\022\020\n\010captured\030\014 \001(\010\"C\n\036ManagedMutationR"
-    "evisionRequest\022\014\n\004kind\030\001 \001(\r\022\023\n\013instance"
-    "_id\030\002 \001(\t\"@\n\023UpdateObjectRequest\022\023\n\013inst"
-    "ance_id\030\001 \001(\t\022\024\n\014yaml_changes\030\002 \001(\t\"f\n\025R"
-    "eparentObjectRequest\022\023\n\013instance_id\030\001 \001("
-    "\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\034\n\024keep_wo"
-    "rld_transform\030\003 \001(\010\"T\n\027CreateGameObjectR"
-    "equest\022\032\n\022parent_instance_id\030\001 \001(\t\022\035\n\025pr"
-    "eferred_instance_id\030\002 \001(\t\"f\n\023AddComponen"
-    "tRequest\022\023\n\013instance_id\030\001 \001(\t\022\033\n\023compone"
-    "nt_type_name\030\002 \001(\t\022\035\n\025preferred_instance"
-    "_id\030\003 \001(\t\"G\n\030InstantiatePrefabRequest\022\017\n"
-    "\007file_id\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001"
-    "(\t\"p\n InstantiatePrefabFromYamlRequest\022\023"
-    "\n\013prefab_yaml\030\001 \001(\t\022\032\n\022parent_instance_i"
-    "d\030\002 \001(\t\022\033\n\023strict_instance_ids\030\003 \001(\010\"U\n\022"
-    "ViewportRayRequest\022\023\n\013viewport_id\030\001 \001(\004\022"
-    "\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 "
-    "\001(\002\"\240\001\n InstantiatePrefabInstanceRequest"
-    "\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_instance_id\030"
-    "\002 \001(\t\022\034\n\024apply_world_position\030\003 \001(\010\0221\n\016w"
-    "orld_position\030\004 \001(\0132\031.sailor.editor.v1.V"
-    "ector4\"A\n\025ViewportObjectRequest\022\023\n\013viewp"
-    "ort_id\030\001 \001(\004\022\023\n\013instance_id\030\002 \001(\t\"9\n\021Pre"
-    "fabLinkRequest\022\023\n\013instance_id\030\001 \001(\t\022\017\n\007f"
-    "ile_id\030\002 \001(\t\"\251\001\n\030ViewportToolStateReques"
-    "t\022\023\n\013viewport_id\030\001 \001(\004\022\?\n\toperation\030\002 \001("
-    "\0162,.sailor.editor.v1.ViewportTransformOp"
-    "eration\0227\n\005space\030\003 \001(\0162(.sailor.editor.v"
-    "1.ViewportTransformSpace\"(\n\020SelectionReq"
-    "uest\022\024\n\014instance_ids\030\001 \003(\t\"%\n\025ShowMainWi"
-    "ndowRequest\022\014\n\004show\030\001 \001(\010\"\210\001\n\034RenderPath"
-    "TracedImageRequest\022\023\n\013output_path\030\001 \001(\t\022"
-    "\023\n\013instance_id\030\002 \001(\t\022\016\n\006height\030\003 \001(\r\022\031\n\021"
-    "samples_per_pixel\030\004 \001(\r\022\023\n\013max_bounces\030\005"
-    " \001(\r\"\033\n\nBoolResult\022\r\n\005value\030\001 \001(\010\"\034\n\013Int"
-    "32Result\022\r\n\005value\030\001 \001(\005\"\035\n\014UInt32Result\022"
-    "\r\n\005value\030\001 \001(\r\"\035\n\014UInt64Result\022\r\n\005value\030"
-    "\001 \001(\004\"0\n\014StringResult\022\021\n\thas_value\030\001 \001(\010"
-    "\022\r\n\005value\030\002 \001(\t\"\"\n\020StringListResult\022\016\n\006v"
-    "alues\030\001 \003(\t\"\204\001\n\026AssetReloadStateResult\022\021"
-    "\n\tavailable\030\001 \001(\010\022\032\n\022request_generation\030"
-    "\002 \001(\004\022\034\n\024completed_generation\030\003 \001(\004\022\035\n\025s"
-    "uccessful_generation\030\004 \001(\004\":\n\020InstanceId"
-    "Result\022\021\n\tsucceeded\030\001 \001(\010\022\023\n\013instance_id"
-    "\030\002 \001(\t\"9\n\rVector4Result\022(\n\005value\030\001 \001(\0132\031"
-    ".sailor.editor.v1.Vector4\"\223\001\n\027ViewportTo"
-    "olStateResult\022\?\n\toperation\030\001 \001(\0162,.sailo"
-    "r.editor.v1.ViewportTransformOperation\0227"
-    "\n\005space\030\002 \001(\0162(.sailor.editor.v1.Viewpor"
-    "tTransformSpace\"5\n\007Vector4\022\t\n\001x\030\001 \001(\002\022\t\n"
-    "\001y\030\002 \001(\002\022\t\n\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n\026Viewpo"
-    "rtSelectionEvent\022\034\n\024selected_instance_id"
-    "\030\001 \001(\t\"\326\003\n\026ViewportTransformEvent\022\023\n\013ins"
-    "tance_id\030\001 \001(\t\022\?\n\toperation\030\002 \001(\0162,.sail"
-    "or.editor.v1.ViewportTransformOperation\022"
-    "7\n\005space\030\003 \001(\0162(.sailor.editor.v1.Viewpo"
-    "rtTransformSpace\0222\n\017before_position\030\004 \001("
-    "\0132\031.sailor.editor.v1.Vector4\0222\n\017before_r"
-    "otation\030\005 \001(\0132\031.sailor.editor.v1.Vector4"
-    "\022/\n\014before_scale\030\006 \001(\0132\031.sailor.editor.v"
-    "1.Vector4\0221\n\016after_position\030\007 \001(\0132\031.sail"
-    "or.editor.v1.Vector4\0221\n\016after_rotation\030\010"
-    " \001(\0132\031.sailor.editor.v1.Vector4\022.\n\013after"
-    "_scale\030\t \001(\0132\031.sailor.editor.v1.Vector4\""
-    "U\n\026ViewportAssetDropEvent\022\017\n\007file_id\030\001 \001"
-    "(\t\022\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normalized_y"
-    "\030\003 \001(\002\"-\n\031ViewportToolShortcutEvent\022\020\n\010k"
-    "ey_code\030\001 \001(\r\"\331\002\n\rViewportEvent\022\020\n\010revis"
-    "ion\030\001 \001(\004\022!\n\031managed_mutation_revision\030\002"
-    " \001(\004\022=\n\tselection\030\n \001(\0132(.sailor.editor."
-    "v1.ViewportSelectionEventH\000\022=\n\ttransform"
-    "\030\013 \001(\0132(.sailor.editor.v1.ViewportTransf"
-    "ormEventH\000\022>\n\nasset_drop\030\014 \001(\0132(.sailor."
-    "editor.v1.ViewportAssetDropEventH\000\022D\n\rto"
-    "ol_shortcut\030\r \001(\0132+.sailor.editor.v1.Vie"
-    "wportToolShortcutEventH\000B\t\n\007payloadJ\004\010\003\020"
-    "\n\"K\n\030ViewportEventBatchResult\022/\n\006events\030"
-    "\001 \003(\0132\037.sailor.editor.v1.ViewportEvent*\360"
-    "\001\n\032ViewportTransformOperation\022,\n(VIEWPOR"
-    "T_TRANSFORM_OPERATION_UNSPECIFIED\020\000\022\'\n#V"
-    "IEWPORT_TRANSFORM_OPERATION_SELECT\020\001\022*\n&"
-    "VIEWPORT_TRANSFORM_OPERATION_TRANSLATE\020\002"
-    "\022\'\n#VIEWPORT_TRANSFORM_OPERATION_ROTATE\020"
-    "\003\022&\n\"VIEWPORT_TRANSFORM_OPERATION_SCALE\020"
-    "\004*\212\001\n\026ViewportTransformSpace\022(\n$VIEWPORT"
-    "_TRANSFORM_SPACE_UNSPECIFIED\020\000\022\"\n\036VIEWPO"
-    "RT_TRANSFORM_SPACE_WORLD\020\001\022\"\n\036VIEWPORT_T"
-    "RANSFORM_SPACE_LOCAL\020\002B\"\252\002\037SailorEditor."
-    "Protocol.Generatedb\006proto3"
+    "questH\000\022L\n\026set_animator_parameter\030; \001(\0132"
+    "*.sailor.editor.v1.AnimatorParameterRequ"
+    "estH\000\022A\n\022get_animator_state\030< \001(\0132#.sail"
+    "or.editor.v1.InstanceIdRequestH\000B\t\n\007comm"
+    "andJ\004\010\003\020\nJ\004\0102\0203J\004\010=\020dR\030create_model_game"
+    "_objectR\036resolve_viewport_drop_position\""
+    "\336\007\n\020ProtocolResponse\022\030\n\020protocol_version"
+    "\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\022\017\n\007success\030\003 "
+    "\001(\010\022\r\n\005error\030\004 \001(\t\022$\n\034supports_strict_in"
+    "stance_ids\030\005 \001(\010\022/\n\014empty_result\030\n \001(\0132\027"
+    ".sailor.editor.v1.EmptyH\000\0223\n\013bool_result"
+    "\030\013 \001(\0132\034.sailor.editor.v1.BoolResultH\000\0225"
+    "\n\014int32_result\030\014 \001(\0132\035.sailor.editor.v1."
+    "Int32ResultH\000\0227\n\ruint32_result\030\r \001(\0132\036.s"
+    "ailor.editor.v1.UInt32ResultH\000\0227\n\ruint64"
+    "_result\030\016 \001(\0132\036.sailor.editor.v1.UInt64R"
+    "esultH\000\0227\n\rstring_result\030\017 \001(\0132\036.sailor."
+    "editor.v1.StringResultH\000\022@\n\022string_list_"
+    "result\030\020 \001(\0132\".sailor.editor.v1.StringLi"
+    "stResultH\000\022M\n\031asset_reload_state_result\030"
+    "\021 \001(\0132(.sailor.editor.v1.AssetReloadStat"
+    "eResultH\000\022@\n\022instance_id_result\030\022 \001(\0132\"."
+    "sailor.editor.v1.InstanceIdResultH\000\022Q\n\033v"
+    "iewport_event_batch_result\030\023 \001(\0132*.sailo"
+    "r.editor.v1.ViewportEventBatchResultH\000\0229"
+    "\n\016vector4_result\030\024 \001(\0132\037.sailor.editor.v"
+    "1.Vector4ResultH\000\022O\n\032viewport_tool_state"
+    "_result\030\025 \001(\0132).sailor.editor.v1.Viewpor"
+    "tToolStateResultH\000\022F\n\025animator_state_res"
+    "ult\030\026 \001(\0132%.sailor.editor.v1.AnimatorSta"
+    "teResultH\000B\010\n\006resultJ\004\010\006\020\nJ\004\010\027\020d\"&\n\021Init"
+    "ializeRequest\022\021\n\targuments\030\001 \003(\t\"!\n\014Coun"
+    "tRequest\022\021\n\tmax_count\030\001 \001(\r\" \n\rFileIdReq"
+    "uest\022\017\n\007file_id\030\001 \001(\t\"\347\001\n\032CreateModelIns"
+    "tanceRequest\022\025\n\rmodel_file_id\030\001 \001(\t\022\014\n\004n"
+    "ame\030\002 \001(\t\022\032\n\022parent_instance_id\030\003 \001(\t\022\030\n"
+    "\020create_hierarchy\030\004 \001(\010\022\034\n\024apply_world_p"
+    "osition\030\005 \001(\010\0221\n\016world_position\030\006 \001(\0132\031."
+    "sailor.editor.v1.Vector4\022\035\n\025preferred_in"
+    "stance_id\030\007 \001(\t\"(\n\021InstanceIdRequest\022\023\n\013"
+    "instance_id\030\001 \001(\t\"(\n\021ViewportIdRequest\022\023"
+    "\n\013viewport_id\030\001 \001(\004\"`\n\023ViewportRectReque"
+    "st\022\024\n\014window_pos_x\030\001 \001(\r\022\024\n\014window_pos_y"
+    "\030\002 \001(\r\022\r\n\005width\030\003 \001(\r\022\016\n\006height\030\004 \001(\r\",\n"
+    "\013SizeRequest\022\r\n\005width\030\001 \001(\r\022\016\n\006height\030\002 "
+    "\001(\r\"\231\001\n\025RemoteViewportRequest\022\023\n\013viewpor"
+    "t_id\030\001 \001(\004\022\024\n\014window_pos_x\030\002 \001(\r\022\024\n\014wind"
+    "ow_pos_y\030\003 \001(\r\022\r\n\005width\030\004 \001(\r\022\016\n\006height\030"
+    "\005 \001(\r\022\017\n\007visible\030\006 \001(\010\022\017\n\007focused\030\007 \001(\010\""
+    "e\n\031RemoteViewportHostRequest\022\023\n\013viewport"
+    "_id\030\001 \001(\004\022\030\n\020host_handle_kind\030\002 \001(\r\022\031\n\021h"
+    "ost_handle_value\030\003 \001(\004\"\374\001\n\032RemoteViewpor"
+    "tInputRequest\022\023\n\013viewport_id\030\001 \001(\004\022\014\n\004ki"
+    "nd\030\002 \001(\r\022\021\n\tpointer_x\030\003 \001(\002\022\021\n\tpointer_y"
+    "\030\004 \001(\002\022\025\n\rwheel_delta_x\030\005 \001(\002\022\025\n\rwheel_d"
+    "elta_y\030\006 \001(\002\022\020\n\010key_code\030\007 \001(\r\022\016\n\006button"
+    "\030\010 \001(\r\022\021\n\tmodifiers\030\t \001(\r\022\017\n\007pressed\030\n \001"
+    "(\010\022\017\n\007focused\030\013 \001(\010\022\020\n\010captured\030\014 \001(\010\"C\n"
+    "\036ManagedMutationRevisionRequest\022\014\n\004kind\030"
+    "\001 \001(\r\022\023\n\013instance_id\030\002 \001(\t\"@\n\023UpdateObje"
+    "ctRequest\022\023\n\013instance_id\030\001 \001(\t\022\024\n\014yaml_c"
+    "hanges\030\002 \001(\t\"f\n\025ReparentObjectRequest\022\023\n"
+    "\013instance_id\030\001 \001(\t\022\032\n\022parent_instance_id"
+    "\030\002 \001(\t\022\034\n\024keep_world_transform\030\003 \001(\010\"T\n\027"
+    "CreateGameObjectRequest\022\032\n\022parent_instan"
+    "ce_id\030\001 \001(\t\022\035\n\025preferred_instance_id\030\002 \001"
+    "(\t\"f\n\023AddComponentRequest\022\023\n\013instance_id"
+    "\030\001 \001(\t\022\033\n\023component_type_name\030\002 \001(\t\022\035\n\025p"
+    "referred_instance_id\030\003 \001(\t\"\346\001\n\030AnimatorP"
+    "arameterRequest\022\023\n\013instance_id\030\001 \001(\t\022\014\n\004"
+    "name\030\002 \001(\t\022\025\n\013float_value\030\003 \001(\002H\000\022\023\n\tint"
+    "_value\030\004 \001(\021H\000\022\024\n\nbool_value\030\005 \001(\010H\000\022*\n\007"
+    "trigger\030\006 \001(\0132\027.sailor.editor.v1.EmptyH\000"
+    "\0220\n\rreset_trigger\030\007 \001(\0132\027.sailor.editor."
+    "v1.EmptyH\000B\007\n\005value\"G\n\030InstantiatePrefab"
+    "Request\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_insta"
+    "nce_id\030\002 \001(\t\"p\n InstantiatePrefabFromYam"
+    "lRequest\022\023\n\013prefab_yaml\030\001 \001(\t\022\032\n\022parent_"
+    "instance_id\030\002 \001(\t\022\033\n\023strict_instance_ids"
+    "\030\003 \001(\010\"U\n\022ViewportRayRequest\022\023\n\013viewport"
+    "_id\030\001 \001(\004\022\024\n\014normalized_x\030\002 \001(\002\022\024\n\014norma"
+    "lized_y\030\003 \001(\002\"\240\001\n InstantiatePrefabInsta"
+    "nceRequest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_in"
+    "stance_id\030\002 \001(\t\022\034\n\024apply_world_position\030"
+    "\003 \001(\010\0221\n\016world_position\030\004 \001(\0132\031.sailor.e"
+    "ditor.v1.Vector4\"A\n\025ViewportObjectReques"
+    "t\022\023\n\013viewport_id\030\001 \001(\004\022\023\n\013instance_id\030\002 "
+    "\001(\t\"9\n\021PrefabLinkRequest\022\023\n\013instance_id\030"
+    "\001 \001(\t\022\017\n\007file_id\030\002 \001(\t\"\251\001\n\030ViewportToolS"
+    "tateRequest\022\023\n\013viewport_id\030\001 \001(\004\022\?\n\toper"
+    "ation\030\002 \001(\0162,.sailor.editor.v1.ViewportT"
+    "ransformOperation\0227\n\005space\030\003 \001(\0162(.sailo"
+    "r.editor.v1.ViewportTransformSpace\"(\n\020Se"
+    "lectionRequest\022\024\n\014instance_ids\030\001 \003(\t\"%\n\025"
+    "ShowMainWindowRequest\022\014\n\004show\030\001 \001(\010\"\210\001\n\034"
+    "RenderPathTracedImageRequest\022\023\n\013output_p"
+    "ath\030\001 \001(\t\022\023\n\013instance_id\030\002 \001(\t\022\016\n\006height"
+    "\030\003 \001(\r\022\031\n\021samples_per_pixel\030\004 \001(\r\022\023\n\013max"
+    "_bounces\030\005 \001(\r\"\033\n\nBoolResult\022\r\n\005value\030\001 "
+    "\001(\010\"\034\n\013Int32Result\022\r\n\005value\030\001 \001(\005\"\035\n\014UIn"
+    "t32Result\022\r\n\005value\030\001 \001(\r\"\035\n\014UInt64Result"
+    "\022\r\n\005value\030\001 \001(\004\"0\n\014StringResult\022\021\n\thas_v"
+    "alue\030\001 \001(\010\022\r\n\005value\030\002 \001(\t\"\"\n\020StringListR"
+    "esult\022\016\n\006values\030\001 \003(\t\"\204\001\n\026AssetReloadSta"
+    "teResult\022\021\n\tavailable\030\001 \001(\010\022\032\n\022request_g"
+    "eneration\030\002 \001(\004\022\034\n\024completed_generation\030"
+    "\003 \001(\004\022\035\n\025successful_generation\030\004 \001(\004\":\n\020"
+    "InstanceIdResult\022\021\n\tsucceeded\030\001 \001(\010\022\023\n\013i"
+    "nstance_id\030\002 \001(\t\"9\n\rVector4Result\022(\n\005val"
+    "ue\030\001 \001(\0132\031.sailor.editor.v1.Vector4\"\223\001\n\027"
+    "ViewportToolStateResult\022\?\n\toperation\030\001 \001"
+    "(\0162,.sailor.editor.v1.ViewportTransformO"
+    "peration\0227\n\005space\030\002 \001(\0162(.sailor.editor."
+    "v1.ViewportTransformSpace\"\250\002\n\023AnimatorSt"
+    "ateResult\022\026\n\016has_controller\030\001 \001(\010\022\033\n\023con"
+    "troller_revision\030\002 \001(\004\022\027\n\017active_state_i"
+    "d\030\003 \001(\004\022\031\n\021active_state_name\030\004 \001(\t\022\031\n\021ac"
+    "tive_state_time\030\005 \001(\002\022\025\n\rtransitioning\030\006"
+    " \001(\010\022\034\n\024destination_state_id\030\007 \001(\004\022\036\n\026de"
+    "stination_state_name\030\010 \001(\t\022\036\n\026destinatio"
+    "n_state_time\030\t \001(\002\022\030\n\020transition_alpha\030\n"
+    " \001(\002\"5\n\007Vector4\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n"
+    "\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n\026ViewportSelection"
+    "Event\022\034\n\024selected_instance_id\030\001 \001(\t\"\326\003\n\026"
+    "ViewportTransformEvent\022\023\n\013instance_id\030\001 "
+    "\001(\t\022\?\n\toperation\030\002 \001(\0162,.sailor.editor.v"
+    "1.ViewportTransformOperation\0227\n\005space\030\003 "
+    "\001(\0162(.sailor.editor.v1.ViewportTransform"
+    "Space\0222\n\017before_position\030\004 \001(\0132\031.sailor."
+    "editor.v1.Vector4\0222\n\017before_rotation\030\005 \001"
+    "(\0132\031.sailor.editor.v1.Vector4\022/\n\014before_"
+    "scale\030\006 \001(\0132\031.sailor.editor.v1.Vector4\0221"
+    "\n\016after_position\030\007 \001(\0132\031.sailor.editor.v"
+    "1.Vector4\0221\n\016after_rotation\030\010 \001(\0132\031.sail"
+    "or.editor.v1.Vector4\022.\n\013after_scale\030\t \001("
+    "\0132\031.sailor.editor.v1.Vector4\"U\n\026Viewport"
+    "AssetDropEvent\022\017\n\007file_id\030\001 \001(\t\022\024\n\014norma"
+    "lized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 \001(\002\"-\n\031V"
+    "iewportToolShortcutEvent\022\020\n\010key_code\030\001 \001"
+    "(\r\"\331\002\n\rViewportEvent\022\020\n\010revision\030\001 \001(\004\022!"
+    "\n\031managed_mutation_revision\030\002 \001(\004\022=\n\tsel"
+    "ection\030\n \001(\0132(.sailor.editor.v1.Viewport"
+    "SelectionEventH\000\022=\n\ttransform\030\013 \001(\0132(.sa"
+    "ilor.editor.v1.ViewportTransformEventH\000\022"
+    ">\n\nasset_drop\030\014 \001(\0132(.sailor.editor.v1.V"
+    "iewportAssetDropEventH\000\022D\n\rtool_shortcut"
+    "\030\r \001(\0132+.sailor.editor.v1.ViewportToolSh"
+    "ortcutEventH\000B\t\n\007payloadJ\004\010\003\020\n\"K\n\030Viewpo"
+    "rtEventBatchResult\022/\n\006events\030\001 \003(\0132\037.sai"
+    "lor.editor.v1.ViewportEvent*\360\001\n\032Viewport"
+    "TransformOperation\022,\n(VIEWPORT_TRANSFORM"
+    "_OPERATION_UNSPECIFIED\020\000\022\'\n#VIEWPORT_TRA"
+    "NSFORM_OPERATION_SELECT\020\001\022*\n&VIEWPORT_TR"
+    "ANSFORM_OPERATION_TRANSLATE\020\002\022\'\n#VIEWPOR"
+    "T_TRANSFORM_OPERATION_ROTATE\020\003\022&\n\"VIEWPO"
+    "RT_TRANSFORM_OPERATION_SCALE\020\004*\212\001\n\026Viewp"
+    "ortTransformSpace\022(\n$VIEWPORT_TRANSFORM_"
+    "SPACE_UNSPECIFIED\020\000\022\"\n\036VIEWPORT_TRANSFOR"
+    "M_SPACE_WORLD\020\001\022\"\n\036VIEWPORT_TRANSFORM_SP"
+    "ACE_LOCAL\020\002B\"\252\002\037SailorEditor.Protocol.Ge"
+    "neratedb\006proto3"
 };
 static ::absl::once_flag descriptor_table_editor_5fengine_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_editor_5fengine_2eproto = {
     false,
     false,
-    9026,
+    9775,
     descriptor_table_protodef_editor_5fengine_2eproto,
     "editor_engine.proto",
     &descriptor_table_editor_5fengine_2eproto_once,
     nullptr,
     0,
-    46,
+    48,
     schemas,
     file_default_instances,
     TableStruct_editor_5fengine_2eproto::offsets,
@@ -3007,6 +3137,32 @@ void ProtocolRequest::set_allocated_create_model_instance(::sailor::editor::v1::
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.create_model_instance)
 }
+void ProtocolRequest::set_allocated_set_animator_parameter(::sailor::editor::v1::AnimatorParameterRequest* set_animator_parameter) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (set_animator_parameter) {
+    ::google::protobuf::Arena* submessage_arena = set_animator_parameter->GetArena();
+    if (message_arena != submessage_arena) {
+      set_animator_parameter = ::google::protobuf::internal::GetOwnedMessage(message_arena, set_animator_parameter, submessage_arena);
+    }
+    set_has_set_animator_parameter();
+    _impl_.command_.set_animator_parameter_ = set_animator_parameter;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.set_animator_parameter)
+}
+void ProtocolRequest::set_allocated_get_animator_state(::sailor::editor::v1::InstanceIdRequest* get_animator_state) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (get_animator_state) {
+    ::google::protobuf::Arena* submessage_arena = get_animator_state->GetArena();
+    if (message_arena != submessage_arena) {
+      get_animator_state = ::google::protobuf::internal::GetOwnedMessage(message_arena, get_animator_state, submessage_arena);
+    }
+    set_has_get_animator_state();
+    _impl_.command_.get_animator_state_ = get_animator_state;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.get_animator_state)
+}
 ProtocolRequest::ProtocolRequest(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
@@ -3189,6 +3345,12 @@ ProtocolRequest::ProtocolRequest(
         break;
       case kCreateModelInstance:
         _impl_.command_.create_model_instance_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::CreateModelInstanceRequest>(arena, *from._impl_.command_.create_model_instance_);
+        break;
+      case kSetAnimatorParameter:
+        _impl_.command_.set_animator_parameter_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::AnimatorParameterRequest>(arena, *from._impl_.command_.set_animator_parameter_);
+        break;
+      case kGetAnimatorState:
+        _impl_.command_.get_animator_state_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::InstanceIdRequest>(arena, *from._impl_.command_.get_animator_state_);
         break;
   }
 
@@ -3612,6 +3774,22 @@ void ProtocolRequest::clear_command() {
       }
       break;
     }
+    case kSetAnimatorParameter: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.set_animator_parameter_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_animator_parameter_);
+      }
+      break;
+    }
+    case kGetAnimatorState: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.get_animator_state_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.get_animator_state_);
+      }
+      break;
+    }
     case COMMAND_NOT_SET: {
       break;
     }
@@ -3656,16 +3834,16 @@ const ::google::protobuf::internal::ClassData* ProtocolRequest::GetClassData() c
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 50, 48, 0, 9> ProtocolRequest::_table_ = {
+const ::_pbi::TcParseTable<1, 52, 50, 0, 9> ProtocolRequest::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    58, 8,  // max_field_number, fast_idx_mask
+    60, 8,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
     508,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    50,  // num_field_entries
-    48,  // num_aux_entries
+    52,  // num_field_entries
+    50,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -3682,7 +3860,7 @@ const ::_pbi::TcParseTable<1, 50, 48, 0, 9> ProtocolRequest::_table_ = {
      {8, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.protocol_version_)}},
   }}, {{
     33, 0, 2,
-    0, 25, 64514, 41,
+    0, 25, 61442, 41,
     65535, 65535
   }}, {{
     // uint32 protocol_version = 1;
@@ -3835,6 +4013,12 @@ const ::_pbi::TcParseTable<1, 50, 48, 0, 9> ProtocolRequest::_table_ = {
     // .sailor.editor.v1.CreateModelInstanceRequest create_model_instance = 58;
     {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.create_model_instance_), _Internal::kOneofCaseOffset + 0, 47,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.AnimatorParameterRequest set_animator_parameter = 59;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_animator_parameter_), _Internal::kOneofCaseOffset + 0, 48,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.InstanceIdRequest get_animator_state = 60;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.get_animator_state_), _Internal::kOneofCaseOffset + 0, 49,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InitializeRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
@@ -3884,6 +4068,8 @@ const ::_pbi::TcParseTable<1, 50, 48, 0, 9> ProtocolRequest::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportIdRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::FileIdRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::CreateModelInstanceRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::AnimatorParameterRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::InstanceIdRequest>()},
   }}, {{
   }},
 };
@@ -4220,6 +4406,18 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
                   stream);
               break;
             }
+            case kSetAnimatorParameter: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  59, *this_._impl_.command_.set_animator_parameter_, this_._impl_.command_.set_animator_parameter_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kGetAnimatorState: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  60, *this_._impl_.command_.get_animator_state_, this_._impl_.command_.get_animator_state_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -4546,6 +4744,18 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
             case kCreateModelInstance: {
               total_size += 2 +
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.create_model_instance_);
+              break;
+            }
+            // .sailor.editor.v1.AnimatorParameterRequest set_animator_parameter = 59;
+            case kSetAnimatorParameter: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.set_animator_parameter_);
+              break;
+            }
+            // .sailor.editor.v1.InstanceIdRequest get_animator_state = 60;
+            case kGetAnimatorState: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.get_animator_state_);
               break;
             }
             case COMMAND_NOT_SET: {
@@ -5014,6 +5224,24 @@ void ProtocolRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const :
         }
         break;
       }
+      case kSetAnimatorParameter: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.set_animator_parameter_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::AnimatorParameterRequest>(arena, *from._impl_.command_.set_animator_parameter_);
+        } else {
+          _this->_impl_.command_.set_animator_parameter_->MergeFrom(from._internal_set_animator_parameter());
+        }
+        break;
+      }
+      case kGetAnimatorState: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.get_animator_state_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::InstanceIdRequest>(arena, *from._impl_.command_.get_animator_state_);
+        } else {
+          _this->_impl_.command_.get_animator_state_->MergeFrom(from._internal_get_animator_state());
+        }
+        break;
+      }
       case COMMAND_NOT_SET:
         break;
     }
@@ -5209,6 +5437,19 @@ void ProtocolResponse::set_allocated_viewport_tool_state_result(::sailor::editor
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolResponse.viewport_tool_state_result)
 }
+void ProtocolResponse::set_allocated_animator_state_result(::sailor::editor::v1::AnimatorStateResult* animator_state_result) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_result();
+  if (animator_state_result) {
+    ::google::protobuf::Arena* submessage_arena = animator_state_result->GetArena();
+    if (message_arena != submessage_arena) {
+      animator_state_result = ::google::protobuf::internal::GetOwnedMessage(message_arena, animator_state_result, submessage_arena);
+    }
+    set_has_animator_state_result();
+    _impl_.result_.animator_state_result_ = animator_state_result;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolResponse.animator_state_result)
+}
 ProtocolResponse::ProtocolResponse(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
@@ -5284,6 +5525,9 @@ ProtocolResponse::ProtocolResponse(
         break;
       case kViewportToolStateResult:
         _impl_.result_.viewport_tool_state_result_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportToolStateResult>(arena, *from._impl_.result_.viewport_tool_state_result_);
+        break;
+      case kAnimatorStateResult:
+        _impl_.result_.animator_state_result_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::AnimatorStateResult>(arena, *from._impl_.result_.animator_state_result_);
         break;
   }
 
@@ -5421,6 +5665,14 @@ void ProtocolResponse::clear_result() {
       }
       break;
     }
+    case kAnimatorStateResult: {
+      if (GetArena() == nullptr) {
+        delete _impl_.result_.animator_state_result_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.result_.animator_state_result_);
+      }
+      break;
+    }
     case RESULT_NOT_SET: {
       break;
     }
@@ -5465,16 +5717,16 @@ const ::google::protobuf::internal::ClassData* ProtocolResponse::GetClassData() 
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<3, 17, 12, 63, 2> ProtocolResponse::_table_ = {
+const ::_pbi::TcParseTable<3, 18, 13, 63, 2> ProtocolResponse::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    21, 56,  // max_field_number, fast_idx_mask
+    22, 56,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4292870624,  // skipmap
+    4290773472,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    17,  // num_field_entries
-    12,  // num_aux_entries
+    18,  // num_field_entries
+    13,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -5555,6 +5807,9 @@ const ::_pbi::TcParseTable<3, 17, 12, 63, 2> ProtocolResponse::_table_ = {
     // .sailor.editor.v1.ViewportToolStateResult viewport_tool_state_result = 21;
     {PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.result_.viewport_tool_state_result_), _Internal::kOneofCaseOffset + 0, 11,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.AnimatorStateResult animator_state_result = 22;
+    {PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.result_.animator_state_result_), _Internal::kOneofCaseOffset + 0, 12,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::BoolResult>()},
@@ -5568,6 +5823,7 @@ const ::_pbi::TcParseTable<3, 17, 12, 63, 2> ProtocolResponse::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportEventBatchResult>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Vector4Result>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportToolStateResult>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::AnimatorStateResult>()},
   }}, {{
     "\41\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
     "sailor.editor.v1.ProtocolResponse"
@@ -5714,6 +5970,12 @@ PROTOBUF_NOINLINE void ProtocolResponse::Clear() {
                   stream);
               break;
             }
+            case kAnimatorStateResult: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  22, *this_._impl_.result_.animator_state_result_, this_._impl_.result_.animator_state_result_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -5837,6 +6099,12 @@ PROTOBUF_NOINLINE void ProtocolResponse::Clear() {
             case kViewportToolStateResult: {
               total_size += 2 +
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.result_.viewport_tool_state_result_);
+              break;
+            }
+            // .sailor.editor.v1.AnimatorStateResult animator_state_result = 22;
+            case kAnimatorStateResult: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.result_.animator_state_result_);
               break;
             }
             case RESULT_NOT_SET: {
@@ -5987,6 +6255,15 @@ void ProtocolResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const 
               ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::ViewportToolStateResult>(arena, *from._impl_.result_.viewport_tool_state_result_);
         } else {
           _this->_impl_.result_.viewport_tool_state_result_->MergeFrom(from._internal_viewport_tool_state_result());
+        }
+        break;
+      }
+      case kAnimatorStateResult: {
+        if (oneof_needs_init) {
+          _this->_impl_.result_.animator_state_result_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::AnimatorStateResult>(arena, *from._impl_.result_.animator_state_result_);
+        } else {
+          _this->_impl_.result_.animator_state_result_->MergeFrom(from._internal_animator_state_result());
         }
         break;
       }
@@ -10504,6 +10781,492 @@ void AddComponentRequest::InternalSwap(AddComponentRequest* PROTOBUF_RESTRICT ot
 }
 
 ::google::protobuf::Metadata AddComponentRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class AnimatorParameterRequest::_Internal {
+ public:
+  static constexpr ::int32_t kOneofCaseOffset =
+      PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::AnimatorParameterRequest, _impl_._oneof_case_);
+};
+
+void AnimatorParameterRequest::set_allocated_trigger(::sailor::editor::v1::Empty* trigger) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_value();
+  if (trigger) {
+    ::google::protobuf::Arena* submessage_arena = trigger->GetArena();
+    if (message_arena != submessage_arena) {
+      trigger = ::google::protobuf::internal::GetOwnedMessage(message_arena, trigger, submessage_arena);
+    }
+    set_has_trigger();
+    _impl_.value_.trigger_ = trigger;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.AnimatorParameterRequest.trigger)
+}
+void AnimatorParameterRequest::set_allocated_reset_trigger(::sailor::editor::v1::Empty* reset_trigger) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_value();
+  if (reset_trigger) {
+    ::google::protobuf::Arena* submessage_arena = reset_trigger->GetArena();
+    if (message_arena != submessage_arena) {
+      reset_trigger = ::google::protobuf::internal::GetOwnedMessage(message_arena, reset_trigger, submessage_arena);
+    }
+    set_has_reset_trigger();
+    _impl_.value_.reset_trigger_ = reset_trigger;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.AnimatorParameterRequest.reset_trigger)
+}
+AnimatorParameterRequest::AnimatorParameterRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.AnimatorParameterRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE AnimatorParameterRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::sailor::editor::v1::AnimatorParameterRequest& from_msg)
+      : instance_id_(arena, from.instance_id_),
+        name_(arena, from.name_),
+        value_{},
+        _cached_size_{0},
+        _oneof_case_{from._oneof_case_[0]} {}
+
+AnimatorParameterRequest::AnimatorParameterRequest(
+    ::google::protobuf::Arena* arena,
+    const AnimatorParameterRequest& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  AnimatorParameterRequest* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  switch (value_case()) {
+    case VALUE_NOT_SET:
+      break;
+      case kFloatValue:
+        _impl_.value_.float_value_ = from._impl_.value_.float_value_;
+        break;
+      case kIntValue:
+        _impl_.value_.int_value_ = from._impl_.value_.int_value_;
+        break;
+      case kBoolValue:
+        _impl_.value_.bool_value_ = from._impl_.value_.bool_value_;
+        break;
+      case kTrigger:
+        _impl_.value_.trigger_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Empty>(arena, *from._impl_.value_.trigger_);
+        break;
+      case kResetTrigger:
+        _impl_.value_.reset_trigger_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Empty>(arena, *from._impl_.value_.reset_trigger_);
+        break;
+  }
+
+  // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.AnimatorParameterRequest)
+}
+inline PROTOBUF_NDEBUG_INLINE AnimatorParameterRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : instance_id_(arena),
+        name_(arena),
+        value_{},
+        _cached_size_{0},
+        _oneof_case_{} {}
+
+inline void AnimatorParameterRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+}
+AnimatorParameterRequest::~AnimatorParameterRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.AnimatorParameterRequest)
+  SharedDtor(*this);
+}
+inline void AnimatorParameterRequest::SharedDtor(MessageLite& self) {
+  AnimatorParameterRequest& this_ = static_cast<AnimatorParameterRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.instance_id_.Destroy();
+  this_._impl_.name_.Destroy();
+  if (this_.has_value()) {
+    this_.clear_value();
+  }
+  this_._impl_.~Impl_();
+}
+
+void AnimatorParameterRequest::clear_value() {
+// @@protoc_insertion_point(one_of_clear_start:sailor.editor.v1.AnimatorParameterRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  switch (value_case()) {
+    case kFloatValue: {
+      // No need to clear
+      break;
+    }
+    case kIntValue: {
+      // No need to clear
+      break;
+    }
+    case kBoolValue: {
+      // No need to clear
+      break;
+    }
+    case kTrigger: {
+      if (GetArena() == nullptr) {
+        delete _impl_.value_.trigger_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.value_.trigger_);
+      }
+      break;
+    }
+    case kResetTrigger: {
+      if (GetArena() == nullptr) {
+        delete _impl_.value_.reset_trigger_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.value_.reset_trigger_);
+      }
+      break;
+    }
+    case VALUE_NOT_SET: {
+      break;
+    }
+  }
+  _impl_._oneof_case_[0] = VALUE_NOT_SET;
+}
+
+
+inline void* AnimatorParameterRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) AnimatorParameterRequest(arena);
+}
+constexpr auto AnimatorParameterRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(AnimatorParameterRequest),
+                                            alignof(AnimatorParameterRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull AnimatorParameterRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_AnimatorParameterRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &AnimatorParameterRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<AnimatorParameterRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &AnimatorParameterRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<AnimatorParameterRequest>(), &AnimatorParameterRequest::ByteSizeLong,
+            &AnimatorParameterRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(AnimatorParameterRequest, _impl_._cached_size_),
+        false,
+    },
+    &AnimatorParameterRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* AnimatorParameterRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<1, 7, 2, 65, 2> AnimatorParameterRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    7, 8,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967168,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    7,  // num_field_entries
+    2,  // num_aux_entries
+    offsetof(decltype(_table_), aux_entries),
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::AnimatorParameterRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // string name = 2;
+    {::_pbi::TcParser::FastUS1,
+     {18, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorParameterRequest, _impl_.name_)}},
+    // string instance_id = 1;
+    {::_pbi::TcParser::FastUS1,
+     {10, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorParameterRequest, _impl_.instance_id_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // string instance_id = 1;
+    {PROTOBUF_FIELD_OFFSET(AnimatorParameterRequest, _impl_.instance_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // string name = 2;
+    {PROTOBUF_FIELD_OFFSET(AnimatorParameterRequest, _impl_.name_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // float float_value = 3;
+    {PROTOBUF_FIELD_OFFSET(AnimatorParameterRequest, _impl_.value_.float_value_), _Internal::kOneofCaseOffset + 0, 0,
+    (0 | ::_fl::kFcOneof | ::_fl::kFloat)},
+    // sint32 int_value = 4;
+    {PROTOBUF_FIELD_OFFSET(AnimatorParameterRequest, _impl_.value_.int_value_), _Internal::kOneofCaseOffset + 0, 0,
+    (0 | ::_fl::kFcOneof | ::_fl::kSInt32)},
+    // bool bool_value = 5;
+    {PROTOBUF_FIELD_OFFSET(AnimatorParameterRequest, _impl_.value_.bool_value_), _Internal::kOneofCaseOffset + 0, 0,
+    (0 | ::_fl::kFcOneof | ::_fl::kBool)},
+    // .sailor.editor.v1.Empty trigger = 6;
+    {PROTOBUF_FIELD_OFFSET(AnimatorParameterRequest, _impl_.value_.trigger_), _Internal::kOneofCaseOffset + 0, 0,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.Empty reset_trigger = 7;
+    {PROTOBUF_FIELD_OFFSET(AnimatorParameterRequest, _impl_.value_.reset_trigger_), _Internal::kOneofCaseOffset + 0, 1,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+  }}, {{
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
+  }}, {{
+    "\51\13\4\0\0\0\0\0"
+    "sailor.editor.v1.AnimatorParameterRequest"
+    "instance_id"
+    "name"
+  }},
+};
+
+PROTOBUF_NOINLINE void AnimatorParameterRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.AnimatorParameterRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.instance_id_.ClearToEmpty();
+  _impl_.name_.ClearToEmpty();
+  clear_value();
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* AnimatorParameterRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const AnimatorParameterRequest& this_ = static_cast<const AnimatorParameterRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* AnimatorParameterRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const AnimatorParameterRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.AnimatorParameterRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // string instance_id = 1;
+          if (!this_._internal_instance_id().empty()) {
+            const std::string& _s = this_._internal_instance_id();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.AnimatorParameterRequest.instance_id");
+            target = stream->WriteStringMaybeAliased(1, _s, target);
+          }
+
+          // string name = 2;
+          if (!this_._internal_name().empty()) {
+            const std::string& _s = this_._internal_name();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.AnimatorParameterRequest.name");
+            target = stream->WriteStringMaybeAliased(2, _s, target);
+          }
+
+          switch (this_.value_case()) {
+            case kFloatValue: {
+              target = stream->EnsureSpace(target);
+              target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                  3, this_._internal_float_value(), target);
+              break;
+            }
+            case kIntValue: {
+              target = stream->EnsureSpace(target);
+              target = ::_pbi::WireFormatLite::WriteSInt32ToArray(
+                  4, this_._internal_int_value(), target);
+              break;
+            }
+            case kBoolValue: {
+              target = stream->EnsureSpace(target);
+              target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                  5, this_._internal_bool_value(), target);
+              break;
+            }
+            case kTrigger: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  6, *this_._impl_.value_.trigger_, this_._impl_.value_.trigger_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kResetTrigger: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  7, *this_._impl_.value_.reset_trigger_, this_._impl_.value_.reset_trigger_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            default:
+              break;
+          }
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.AnimatorParameterRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t AnimatorParameterRequest::ByteSizeLong(const MessageLite& base) {
+          const AnimatorParameterRequest& this_ = static_cast<const AnimatorParameterRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t AnimatorParameterRequest::ByteSizeLong() const {
+          const AnimatorParameterRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.AnimatorParameterRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // string instance_id = 1;
+            if (!this_._internal_instance_id().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_instance_id());
+            }
+            // string name = 2;
+            if (!this_._internal_name().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_name());
+            }
+          }
+          switch (this_.value_case()) {
+            // float float_value = 3;
+            case kFloatValue: {
+              total_size += 5;
+              break;
+            }
+            // sint32 int_value = 4;
+            case kIntValue: {
+              total_size += ::_pbi::WireFormatLite::SInt32SizePlusOne(
+                  this_._internal_int_value());
+              break;
+            }
+            // bool bool_value = 5;
+            case kBoolValue: {
+              total_size += 2;
+              break;
+            }
+            // .sailor.editor.v1.Empty trigger = 6;
+            case kTrigger: {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.value_.trigger_);
+              break;
+            }
+            // .sailor.editor.v1.Empty reset_trigger = 7;
+            case kResetTrigger: {
+              total_size += 1 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.value_.reset_trigger_);
+              break;
+            }
+            case VALUE_NOT_SET: {
+              break;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void AnimatorParameterRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<AnimatorParameterRequest*>(&to_msg);
+  auto& from = static_cast<const AnimatorParameterRequest&>(from_msg);
+  ::google::protobuf::Arena* arena = _this->GetArena();
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.AnimatorParameterRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_instance_id().empty()) {
+    _this->_internal_set_instance_id(from._internal_instance_id());
+  }
+  if (!from._internal_name().empty()) {
+    _this->_internal_set_name(from._internal_name());
+  }
+  if (const uint32_t oneof_from_case = from._impl_._oneof_case_[0]) {
+    const uint32_t oneof_to_case = _this->_impl_._oneof_case_[0];
+    const bool oneof_needs_init = oneof_to_case != oneof_from_case;
+    if (oneof_needs_init) {
+      if (oneof_to_case != 0) {
+        _this->clear_value();
+      }
+      _this->_impl_._oneof_case_[0] = oneof_from_case;
+    }
+
+    switch (oneof_from_case) {
+      case kFloatValue: {
+        _this->_impl_.value_.float_value_ = from._impl_.value_.float_value_;
+        break;
+      }
+      case kIntValue: {
+        _this->_impl_.value_.int_value_ = from._impl_.value_.int_value_;
+        break;
+      }
+      case kBoolValue: {
+        _this->_impl_.value_.bool_value_ = from._impl_.value_.bool_value_;
+        break;
+      }
+      case kTrigger: {
+        if (oneof_needs_init) {
+          _this->_impl_.value_.trigger_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Empty>(arena, *from._impl_.value_.trigger_);
+        } else {
+          _this->_impl_.value_.trigger_->MergeFrom(from._internal_trigger());
+        }
+        break;
+      }
+      case kResetTrigger: {
+        if (oneof_needs_init) {
+          _this->_impl_.value_.reset_trigger_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Empty>(arena, *from._impl_.value_.reset_trigger_);
+        } else {
+          _this->_impl_.value_.reset_trigger_->MergeFrom(from._internal_reset_trigger());
+        }
+        break;
+      }
+      case VALUE_NOT_SET:
+        break;
+    }
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void AnimatorParameterRequest::CopyFrom(const AnimatorParameterRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.AnimatorParameterRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void AnimatorParameterRequest::InternalSwap(AnimatorParameterRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.instance_id_, &other->_impl_.instance_id_, arena);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.name_, &other->_impl_.name_, arena);
+  swap(_impl_.value_, other->_impl_.value_);
+  swap(_impl_._oneof_case_[0], other->_impl_._oneof_case_[0]);
+}
+
+::google::protobuf::Metadata AnimatorParameterRequest::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================
@@ -15589,6 +16352,457 @@ void ViewportToolStateResult::InternalSwap(ViewportToolStateResult* PROTOBUF_RES
 }
 
 ::google::protobuf::Metadata ViewportToolStateResult::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class AnimatorStateResult::_Internal {
+ public:
+};
+
+AnimatorStateResult::AnimatorStateResult(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.AnimatorStateResult)
+}
+inline PROTOBUF_NDEBUG_INLINE AnimatorStateResult::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility, ::google::protobuf::Arena* arena,
+    const Impl_& from, const ::sailor::editor::v1::AnimatorStateResult& from_msg)
+      : active_state_name_(arena, from.active_state_name_),
+        destination_state_name_(arena, from.destination_state_name_),
+        _cached_size_{0} {}
+
+AnimatorStateResult::AnimatorStateResult(
+    ::google::protobuf::Arena* arena,
+    const AnimatorStateResult& from)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  AnimatorStateResult* const _this = this;
+  (void)_this;
+  _internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(
+      from._internal_metadata_);
+  new (&_impl_) Impl_(internal_visibility(), arena, from._impl_, from);
+  ::memcpy(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, controller_revision_),
+           reinterpret_cast<const char *>(&from._impl_) +
+               offsetof(Impl_, controller_revision_),
+           offsetof(Impl_, transition_alpha_) -
+               offsetof(Impl_, controller_revision_) +
+               sizeof(Impl_::transition_alpha_));
+
+  // @@protoc_insertion_point(copy_constructor:sailor.editor.v1.AnimatorStateResult)
+}
+inline PROTOBUF_NDEBUG_INLINE AnimatorStateResult::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : active_state_name_(arena),
+        destination_state_name_(arena),
+        _cached_size_{0} {}
+
+inline void AnimatorStateResult::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  ::memset(reinterpret_cast<char *>(&_impl_) +
+               offsetof(Impl_, controller_revision_),
+           0,
+           offsetof(Impl_, transition_alpha_) -
+               offsetof(Impl_, controller_revision_) +
+               sizeof(Impl_::transition_alpha_));
+}
+AnimatorStateResult::~AnimatorStateResult() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.AnimatorStateResult)
+  SharedDtor(*this);
+}
+inline void AnimatorStateResult::SharedDtor(MessageLite& self) {
+  AnimatorStateResult& this_ = static_cast<AnimatorStateResult&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.active_state_name_.Destroy();
+  this_._impl_.destination_state_name_.Destroy();
+  this_._impl_.~Impl_();
+}
+
+inline void* AnimatorStateResult::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) AnimatorStateResult(arena);
+}
+constexpr auto AnimatorStateResult::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::CopyInit(sizeof(AnimatorStateResult),
+                                            alignof(AnimatorStateResult));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull AnimatorStateResult::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_AnimatorStateResult_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &AnimatorStateResult::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<AnimatorStateResult>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &AnimatorStateResult::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<AnimatorStateResult>(), &AnimatorStateResult::ByteSizeLong,
+            &AnimatorStateResult::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_._cached_size_),
+        false,
+    },
+    &AnimatorStateResult::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* AnimatorStateResult::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<4, 10, 0, 92, 2> AnimatorStateResult::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    10, 120,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294966272,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    10,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::AnimatorStateResult>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    {::_pbi::TcParser::MiniParse, {}},
+    // bool has_controller = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(AnimatorStateResult, _impl_.has_controller_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.has_controller_)}},
+    // uint64 controller_revision = 2;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint64_t, offsetof(AnimatorStateResult, _impl_.controller_revision_), 63>(),
+     {16, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.controller_revision_)}},
+    // uint64 active_state_id = 3;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint64_t, offsetof(AnimatorStateResult, _impl_.active_state_id_), 63>(),
+     {24, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.active_state_id_)}},
+    // string active_state_name = 4;
+    {::_pbi::TcParser::FastUS1,
+     {34, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.active_state_name_)}},
+    // float active_state_time = 5;
+    {::_pbi::TcParser::FastF32S1,
+     {45, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.active_state_time_)}},
+    // bool transitioning = 6;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(AnimatorStateResult, _impl_.transitioning_), 63>(),
+     {48, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.transitioning_)}},
+    // uint64 destination_state_id = 7;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint64_t, offsetof(AnimatorStateResult, _impl_.destination_state_id_), 63>(),
+     {56, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.destination_state_id_)}},
+    // string destination_state_name = 8;
+    {::_pbi::TcParser::FastUS1,
+     {66, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.destination_state_name_)}},
+    // float destination_state_time = 9;
+    {::_pbi::TcParser::FastF32S1,
+     {77, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.destination_state_time_)}},
+    // float transition_alpha = 10;
+    {::_pbi::TcParser::FastF32S1,
+     {85, 63, 0, PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.transition_alpha_)}},
+    {::_pbi::TcParser::MiniParse, {}},
+    {::_pbi::TcParser::MiniParse, {}},
+    {::_pbi::TcParser::MiniParse, {}},
+    {::_pbi::TcParser::MiniParse, {}},
+    {::_pbi::TcParser::MiniParse, {}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // bool has_controller = 1;
+    {PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.has_controller_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+    // uint64 controller_revision = 2;
+    {PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.controller_revision_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUInt64)},
+    // uint64 active_state_id = 3;
+    {PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.active_state_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUInt64)},
+    // string active_state_name = 4;
+    {PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.active_state_name_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // float active_state_time = 5;
+    {PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.active_state_time_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // bool transitioning = 6;
+    {PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.transitioning_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+    // uint64 destination_state_id = 7;
+    {PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.destination_state_id_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUInt64)},
+    // string destination_state_name = 8;
+    {PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.destination_state_name_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kUtf8String | ::_fl::kRepAString)},
+    // float destination_state_time = 9;
+    {PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.destination_state_time_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+    // float transition_alpha = 10;
+    {PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.transition_alpha_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kFloat)},
+  }},
+  // no aux_entries
+  {{
+    "\44\0\0\0\21\0\0\0\26\0\0\0\0\0\0\0"
+    "sailor.editor.v1.AnimatorStateResult"
+    "active_state_name"
+    "destination_state_name"
+  }},
+};
+
+PROTOBUF_NOINLINE void AnimatorStateResult::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.AnimatorStateResult)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.active_state_name_.ClearToEmpty();
+  _impl_.destination_state_name_.ClearToEmpty();
+  ::memset(&_impl_.controller_revision_, 0, static_cast<::size_t>(
+      reinterpret_cast<char*>(&_impl_.transition_alpha_) -
+      reinterpret_cast<char*>(&_impl_.controller_revision_)) + sizeof(_impl_.transition_alpha_));
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* AnimatorStateResult::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const AnimatorStateResult& this_ = static_cast<const AnimatorStateResult&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* AnimatorStateResult::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const AnimatorStateResult& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.AnimatorStateResult)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // bool has_controller = 1;
+          if (this_._internal_has_controller() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                1, this_._internal_has_controller(), target);
+          }
+
+          // uint64 controller_revision = 2;
+          if (this_._internal_controller_revision() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteUInt64ToArray(
+                2, this_._internal_controller_revision(), target);
+          }
+
+          // uint64 active_state_id = 3;
+          if (this_._internal_active_state_id() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteUInt64ToArray(
+                3, this_._internal_active_state_id(), target);
+          }
+
+          // string active_state_name = 4;
+          if (!this_._internal_active_state_name().empty()) {
+            const std::string& _s = this_._internal_active_state_name();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.AnimatorStateResult.active_state_name");
+            target = stream->WriteStringMaybeAliased(4, _s, target);
+          }
+
+          // float active_state_time = 5;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_active_state_time()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                5, this_._internal_active_state_time(), target);
+          }
+
+          // bool transitioning = 6;
+          if (this_._internal_transitioning() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                6, this_._internal_transitioning(), target);
+          }
+
+          // uint64 destination_state_id = 7;
+          if (this_._internal_destination_state_id() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteUInt64ToArray(
+                7, this_._internal_destination_state_id(), target);
+          }
+
+          // string destination_state_name = 8;
+          if (!this_._internal_destination_state_name().empty()) {
+            const std::string& _s = this_._internal_destination_state_name();
+            ::google::protobuf::internal::WireFormatLite::VerifyUtf8String(
+                _s.data(), static_cast<int>(_s.length()), ::google::protobuf::internal::WireFormatLite::SERIALIZE, "sailor.editor.v1.AnimatorStateResult.destination_state_name");
+            target = stream->WriteStringMaybeAliased(8, _s, target);
+          }
+
+          // float destination_state_time = 9;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_destination_state_time()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                9, this_._internal_destination_state_time(), target);
+          }
+
+          // float transition_alpha = 10;
+          if (::absl::bit_cast<::uint32_t>(this_._internal_transition_alpha()) != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteFloatToArray(
+                10, this_._internal_transition_alpha(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.AnimatorStateResult)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t AnimatorStateResult::ByteSizeLong(const MessageLite& base) {
+          const AnimatorStateResult& this_ = static_cast<const AnimatorStateResult&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t AnimatorStateResult::ByteSizeLong() const {
+          const AnimatorStateResult& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.AnimatorStateResult)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+          ::_pbi::Prefetch5LinesFrom7Lines(&this_);
+           {
+            // string active_state_name = 4;
+            if (!this_._internal_active_state_name().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_active_state_name());
+            }
+            // string destination_state_name = 8;
+            if (!this_._internal_destination_state_name().empty()) {
+              total_size += 1 + ::google::protobuf::internal::WireFormatLite::StringSize(
+                                              this_._internal_destination_state_name());
+            }
+            // uint64 controller_revision = 2;
+            if (this_._internal_controller_revision() != 0) {
+              total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(
+                  this_._internal_controller_revision());
+            }
+            // uint64 active_state_id = 3;
+            if (this_._internal_active_state_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(
+                  this_._internal_active_state_id());
+            }
+            // bool has_controller = 1;
+            if (this_._internal_has_controller() != 0) {
+              total_size += 2;
+            }
+            // bool transitioning = 6;
+            if (this_._internal_transitioning() != 0) {
+              total_size += 2;
+            }
+            // float active_state_time = 5;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_active_state_time()) != 0) {
+              total_size += 5;
+            }
+            // uint64 destination_state_id = 7;
+            if (this_._internal_destination_state_id() != 0) {
+              total_size += ::_pbi::WireFormatLite::UInt64SizePlusOne(
+                  this_._internal_destination_state_id());
+            }
+            // float destination_state_time = 9;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_destination_state_time()) != 0) {
+              total_size += 5;
+            }
+            // float transition_alpha = 10;
+            if (::absl::bit_cast<::uint32_t>(this_._internal_transition_alpha()) != 0) {
+              total_size += 5;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void AnimatorStateResult::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<AnimatorStateResult*>(&to_msg);
+  auto& from = static_cast<const AnimatorStateResult&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.AnimatorStateResult)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (!from._internal_active_state_name().empty()) {
+    _this->_internal_set_active_state_name(from._internal_active_state_name());
+  }
+  if (!from._internal_destination_state_name().empty()) {
+    _this->_internal_set_destination_state_name(from._internal_destination_state_name());
+  }
+  if (from._internal_controller_revision() != 0) {
+    _this->_impl_.controller_revision_ = from._impl_.controller_revision_;
+  }
+  if (from._internal_active_state_id() != 0) {
+    _this->_impl_.active_state_id_ = from._impl_.active_state_id_;
+  }
+  if (from._internal_has_controller() != 0) {
+    _this->_impl_.has_controller_ = from._impl_.has_controller_;
+  }
+  if (from._internal_transitioning() != 0) {
+    _this->_impl_.transitioning_ = from._impl_.transitioning_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_active_state_time()) != 0) {
+    _this->_impl_.active_state_time_ = from._impl_.active_state_time_;
+  }
+  if (from._internal_destination_state_id() != 0) {
+    _this->_impl_.destination_state_id_ = from._impl_.destination_state_id_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_destination_state_time()) != 0) {
+    _this->_impl_.destination_state_time_ = from._impl_.destination_state_time_;
+  }
+  if (::absl::bit_cast<::uint32_t>(from._internal_transition_alpha()) != 0) {
+    _this->_impl_.transition_alpha_ = from._impl_.transition_alpha_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void AnimatorStateResult::CopyFrom(const AnimatorStateResult& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.AnimatorStateResult)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void AnimatorStateResult::InternalSwap(AnimatorStateResult* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  auto* arena = GetArena();
+  ABSL_DCHECK_EQ(arena, other->GetArena());
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.active_state_name_, &other->_impl_.active_state_name_, arena);
+  ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.destination_state_name_, &other->_impl_.destination_state_name_, arena);
+  ::google::protobuf::internal::memswap<
+      PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.transition_alpha_)
+      + sizeof(AnimatorStateResult::_impl_.transition_alpha_)
+      - PROTOBUF_FIELD_OFFSET(AnimatorStateResult, _impl_.controller_revision_)>(
+          reinterpret_cast<char*>(&_impl_.controller_revision_),
+          reinterpret_cast<char*>(&other->_impl_.controller_revision_));
+}
+
+::google::protobuf::Metadata AnimatorStateResult::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/Runtime/Protocol/Generated/editor_engine.pb.h
+++ b/Runtime/Protocol/Generated/editor_engine.pb.h
@@ -59,6 +59,12 @@ namespace v1 {
 class AddComponentRequest;
 struct AddComponentRequestDefaultTypeInternal;
 extern AddComponentRequestDefaultTypeInternal _AddComponentRequest_default_instance_;
+class AnimatorParameterRequest;
+struct AnimatorParameterRequestDefaultTypeInternal;
+extern AnimatorParameterRequestDefaultTypeInternal _AnimatorParameterRequest_default_instance_;
+class AnimatorStateResult;
+struct AnimatorStateResultDefaultTypeInternal;
+extern AnimatorStateResultDefaultTypeInternal _AnimatorStateResult_default_instance_;
 class AssetReloadStateResult;
 struct AssetReloadStateResultDefaultTypeInternal;
 extern AssetReloadStateResultDefaultTypeInternal _AssetReloadStateResult_default_instance_;
@@ -340,7 +346,7 @@ class ViewportToolStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateResult*>(
         &_ViewportToolStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 38;
+  static constexpr int kIndexInFileMessages = 39;
   friend void swap(ViewportToolStateResult& a, ViewportToolStateResult& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateResult* other) {
     if (other == this) return;
@@ -542,7 +548,7 @@ class ViewportToolStateRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateRequest*>(
         &_ViewportToolStateRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 25;
+  static constexpr int kIndexInFileMessages = 26;
   friend void swap(ViewportToolStateRequest& a, ViewportToolStateRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateRequest* other) {
     if (other == this) return;
@@ -756,7 +762,7 @@ class ViewportToolShortcutEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolShortcutEvent*>(
         &_ViewportToolShortcutEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 43;
+  static constexpr int kIndexInFileMessages = 45;
   friend void swap(ViewportToolShortcutEvent& a, ViewportToolShortcutEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportToolShortcutEvent* other) {
     if (other == this) return;
@@ -946,7 +952,7 @@ class ViewportSelectionEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportSelectionEvent*>(
         &_ViewportSelectionEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 40;
+  static constexpr int kIndexInFileMessages = 42;
   friend void swap(ViewportSelectionEvent& a, ViewportSelectionEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportSelectionEvent* other) {
     if (other == this) return;
@@ -1368,7 +1374,7 @@ class ViewportRayRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportRayRequest*>(
         &_ViewportRayRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 21;
+  static constexpr int kIndexInFileMessages = 22;
   friend void swap(ViewportRayRequest& a, ViewportRayRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportRayRequest* other) {
     if (other == this) return;
@@ -1582,7 +1588,7 @@ class ViewportObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportObjectRequest*>(
         &_ViewportObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 23;
+  static constexpr int kIndexInFileMessages = 24;
   friend void swap(ViewportObjectRequest& a, ViewportObjectRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportObjectRequest* other) {
     if (other == this) return;
@@ -1980,7 +1986,7 @@ class ViewportAssetDropEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportAssetDropEvent*>(
         &_ViewportAssetDropEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 42;
+  static constexpr int kIndexInFileMessages = 44;
   friend void swap(ViewportAssetDropEvent& a, ViewportAssetDropEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportAssetDropEvent* other) {
     if (other == this) return;
@@ -2200,7 +2206,7 @@ class Vector4 final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4*>(
         &_Vector4_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 39;
+  static constexpr int kIndexInFileMessages = 41;
   friend void swap(Vector4& a, Vector4& b) { a.Swap(&b); }
   inline void Swap(Vector4* other) {
     if (other == this) return;
@@ -2640,7 +2646,7 @@ class UInt64Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt64Result*>(
         &_UInt64Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 32;
+  static constexpr int kIndexInFileMessages = 33;
   friend void swap(UInt64Result& a, UInt64Result& b) { a.Swap(&b); }
   inline void Swap(UInt64Result* other) {
     if (other == this) return;
@@ -2830,7 +2836,7 @@ class UInt32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt32Result*>(
         &_UInt32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 31;
+  static constexpr int kIndexInFileMessages = 32;
   friend void swap(UInt32Result& a, UInt32Result& b) { a.Swap(&b); }
   inline void Swap(UInt32Result* other) {
     if (other == this) return;
@@ -3020,7 +3026,7 @@ class StringResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringResult*>(
         &_StringResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 33;
+  static constexpr int kIndexInFileMessages = 34;
   friend void swap(StringResult& a, StringResult& b) { a.Swap(&b); }
   inline void Swap(StringResult* other) {
     if (other == this) return;
@@ -3228,7 +3234,7 @@ class StringListResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringListResult*>(
         &_StringListResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 34;
+  static constexpr int kIndexInFileMessages = 35;
   friend void swap(StringListResult& a, StringListResult& b) { a.Swap(&b); }
   inline void Swap(StringListResult* other) {
     if (other == this) return;
@@ -3632,7 +3638,7 @@ class ShowMainWindowRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ShowMainWindowRequest*>(
         &_ShowMainWindowRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 27;
+  static constexpr int kIndexInFileMessages = 28;
   friend void swap(ShowMainWindowRequest& a, ShowMainWindowRequest& b) { a.Swap(&b); }
   inline void Swap(ShowMainWindowRequest* other) {
     if (other == this) return;
@@ -3822,7 +3828,7 @@ class SelectionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const SelectionRequest*>(
         &_SelectionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 26;
+  static constexpr int kIndexInFileMessages = 27;
   friend void swap(SelectionRequest& a, SelectionRequest& b) { a.Swap(&b); }
   inline void Swap(SelectionRequest* other) {
     if (other == this) return;
@@ -4250,7 +4256,7 @@ class RenderPathTracedImageRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RenderPathTracedImageRequest*>(
         &_RenderPathTracedImageRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 28;
+  static constexpr int kIndexInFileMessages = 29;
   friend void swap(RenderPathTracedImageRequest& a, RenderPathTracedImageRequest& b) { a.Swap(&b); }
   inline void Swap(RenderPathTracedImageRequest* other) {
     if (other == this) return;
@@ -5298,7 +5304,7 @@ class PrefabLinkRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const PrefabLinkRequest*>(
         &_PrefabLinkRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 24;
+  static constexpr int kIndexInFileMessages = 25;
   friend void swap(PrefabLinkRequest& a, PrefabLinkRequest& b) { a.Swap(&b); }
   inline void Swap(PrefabLinkRequest* other) {
     if (other == this) return;
@@ -5720,7 +5726,7 @@ class Int32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Int32Result*>(
         &_Int32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 30;
+  static constexpr int kIndexInFileMessages = 31;
   friend void swap(Int32Result& a, Int32Result& b) { a.Swap(&b); }
   inline void Swap(Int32Result* other) {
     if (other == this) return;
@@ -5910,7 +5916,7 @@ class InstantiatePrefabRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const InstantiatePrefabRequest*>(
         &_InstantiatePrefabRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 19;
+  static constexpr int kIndexInFileMessages = 20;
   friend void swap(InstantiatePrefabRequest& a, InstantiatePrefabRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabRequest* other) {
     if (other == this) return;
@@ -6124,7 +6130,7 @@ class InstantiatePrefabFromYamlRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabFromYamlRequest*>(
         &_InstantiatePrefabFromYamlRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 20;
+  static constexpr int kIndexInFileMessages = 21;
   friend void swap(InstantiatePrefabFromYamlRequest& a, InstantiatePrefabFromYamlRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabFromYamlRequest* other) {
     if (other == this) return;
@@ -6350,7 +6356,7 @@ class InstanceIdResult final : public ::google::protobuf::Message
     return reinterpret_cast<const InstanceIdResult*>(
         &_InstanceIdResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 36;
+  static constexpr int kIndexInFileMessages = 37;
   friend void swap(InstanceIdResult& a, InstanceIdResult& b) { a.Swap(&b); }
   inline void Swap(InstanceIdResult* other) {
     if (other == this) return;
@@ -7701,7 +7707,7 @@ class BoolResult final : public ::google::protobuf::Message
     return reinterpret_cast<const BoolResult*>(
         &_BoolResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 29;
+  static constexpr int kIndexInFileMessages = 30;
   friend void swap(BoolResult& a, BoolResult& b) { a.Swap(&b); }
   inline void Swap(BoolResult* other) {
     if (other == this) return;
@@ -7891,7 +7897,7 @@ class AssetReloadStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const AssetReloadStateResult*>(
         &_AssetReloadStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 35;
+  static constexpr int kIndexInFileMessages = 36;
   friend void swap(AssetReloadStateResult& a, AssetReloadStateResult& b) { a.Swap(&b); }
   inline void Swap(AssetReloadStateResult* other) {
     if (other == this) return;
@@ -8050,6 +8056,316 @@ class AssetReloadStateResult final : public ::google::protobuf::Message
     ::uint64_t completed_generation_;
     ::uint64_t successful_generation_;
     bool available_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
+class AnimatorStateResult final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.AnimatorStateResult) */ {
+ public:
+  inline AnimatorStateResult() : AnimatorStateResult(nullptr) {}
+  ~AnimatorStateResult() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(AnimatorStateResult* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(AnimatorStateResult));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR AnimatorStateResult(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline AnimatorStateResult(const AnimatorStateResult& from) : AnimatorStateResult(nullptr, from) {}
+  inline AnimatorStateResult(AnimatorStateResult&& from) noexcept
+      : AnimatorStateResult(nullptr, std::move(from)) {}
+  inline AnimatorStateResult& operator=(const AnimatorStateResult& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline AnimatorStateResult& operator=(AnimatorStateResult&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const AnimatorStateResult& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const AnimatorStateResult* internal_default_instance() {
+    return reinterpret_cast<const AnimatorStateResult*>(
+        &_AnimatorStateResult_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 40;
+  friend void swap(AnimatorStateResult& a, AnimatorStateResult& b) { a.Swap(&b); }
+  inline void Swap(AnimatorStateResult* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(AnimatorStateResult* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  AnimatorStateResult* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<AnimatorStateResult>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const AnimatorStateResult& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const AnimatorStateResult& from) { AnimatorStateResult::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(AnimatorStateResult* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.AnimatorStateResult"; }
+
+ protected:
+  explicit AnimatorStateResult(::google::protobuf::Arena* arena);
+  AnimatorStateResult(::google::protobuf::Arena* arena, const AnimatorStateResult& from);
+  AnimatorStateResult(::google::protobuf::Arena* arena, AnimatorStateResult&& from) noexcept
+      : AnimatorStateResult(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kActiveStateNameFieldNumber = 4,
+    kDestinationStateNameFieldNumber = 8,
+    kControllerRevisionFieldNumber = 2,
+    kActiveStateIdFieldNumber = 3,
+    kHasControllerFieldNumber = 1,
+    kTransitioningFieldNumber = 6,
+    kActiveStateTimeFieldNumber = 5,
+    kDestinationStateIdFieldNumber = 7,
+    kDestinationStateTimeFieldNumber = 9,
+    kTransitionAlphaFieldNumber = 10,
+  };
+  // string active_state_name = 4;
+  void clear_active_state_name() ;
+  const std::string& active_state_name() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_active_state_name(Arg_&& arg, Args_... args);
+  std::string* mutable_active_state_name();
+  PROTOBUF_NODISCARD std::string* release_active_state_name();
+  void set_allocated_active_state_name(std::string* value);
+
+  private:
+  const std::string& _internal_active_state_name() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_active_state_name(
+      const std::string& value);
+  std::string* _internal_mutable_active_state_name();
+
+  public:
+  // string destination_state_name = 8;
+  void clear_destination_state_name() ;
+  const std::string& destination_state_name() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_destination_state_name(Arg_&& arg, Args_... args);
+  std::string* mutable_destination_state_name();
+  PROTOBUF_NODISCARD std::string* release_destination_state_name();
+  void set_allocated_destination_state_name(std::string* value);
+
+  private:
+  const std::string& _internal_destination_state_name() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_destination_state_name(
+      const std::string& value);
+  std::string* _internal_mutable_destination_state_name();
+
+  public:
+  // uint64 controller_revision = 2;
+  void clear_controller_revision() ;
+  ::uint64_t controller_revision() const;
+  void set_controller_revision(::uint64_t value);
+
+  private:
+  ::uint64_t _internal_controller_revision() const;
+  void _internal_set_controller_revision(::uint64_t value);
+
+  public:
+  // uint64 active_state_id = 3;
+  void clear_active_state_id() ;
+  ::uint64_t active_state_id() const;
+  void set_active_state_id(::uint64_t value);
+
+  private:
+  ::uint64_t _internal_active_state_id() const;
+  void _internal_set_active_state_id(::uint64_t value);
+
+  public:
+  // bool has_controller = 1;
+  void clear_has_controller() ;
+  bool has_controller() const;
+  void set_has_controller(bool value);
+
+  private:
+  bool _internal_has_controller() const;
+  void _internal_set_has_controller(bool value);
+
+  public:
+  // bool transitioning = 6;
+  void clear_transitioning() ;
+  bool transitioning() const;
+  void set_transitioning(bool value);
+
+  private:
+  bool _internal_transitioning() const;
+  void _internal_set_transitioning(bool value);
+
+  public:
+  // float active_state_time = 5;
+  void clear_active_state_time() ;
+  float active_state_time() const;
+  void set_active_state_time(float value);
+
+  private:
+  float _internal_active_state_time() const;
+  void _internal_set_active_state_time(float value);
+
+  public:
+  // uint64 destination_state_id = 7;
+  void clear_destination_state_id() ;
+  ::uint64_t destination_state_id() const;
+  void set_destination_state_id(::uint64_t value);
+
+  private:
+  ::uint64_t _internal_destination_state_id() const;
+  void _internal_set_destination_state_id(::uint64_t value);
+
+  public:
+  // float destination_state_time = 9;
+  void clear_destination_state_time() ;
+  float destination_state_time() const;
+  void set_destination_state_time(float value);
+
+  private:
+  float _internal_destination_state_time() const;
+  void _internal_set_destination_state_time(float value);
+
+  public:
+  // float transition_alpha = 10;
+  void clear_transition_alpha() ;
+  float transition_alpha() const;
+  void set_transition_alpha(float value);
+
+  private:
+  float _internal_transition_alpha() const;
+  void _internal_set_transition_alpha(float value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.AnimatorStateResult)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      4, 10, 0,
+      92, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const AnimatorStateResult& from_msg);
+    ::google::protobuf::internal::ArenaStringPtr active_state_name_;
+    ::google::protobuf::internal::ArenaStringPtr destination_state_name_;
+    ::uint64_t controller_revision_;
+    ::uint64_t active_state_id_;
+    bool has_controller_;
+    bool transitioning_;
+    float active_state_time_;
+    ::uint64_t destination_state_id_;
+    float destination_state_time_;
+    float transition_alpha_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -8349,7 +8665,7 @@ class ViewportTransformEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportTransformEvent*>(
         &_ViewportTransformEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 41;
+  static constexpr int kIndexInFileMessages = 43;
   friend void swap(ViewportTransformEvent& a, ViewportTransformEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportTransformEvent* other) {
     if (other == this) return;
@@ -8672,7 +8988,7 @@ class Vector4Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4Result*>(
         &_Vector4Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 37;
+  static constexpr int kIndexInFileMessages = 38;
   friend void swap(Vector4Result& a, Vector4Result& b) { a.Swap(&b); }
   inline void Swap(Vector4Result* other) {
     if (other == this) return;
@@ -8868,7 +9184,7 @@ class InstantiatePrefabInstanceRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabInstanceRequest*>(
         &_InstantiatePrefabInstanceRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 22;
+  static constexpr int kIndexInFileMessages = 23;
   friend void swap(InstantiatePrefabInstanceRequest& a, InstantiatePrefabInstanceRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabInstanceRequest* other) {
     if (other == this) return;
@@ -9345,6 +9661,323 @@ class CreateModelInstanceRequest final : public ::google::protobuf::Message
 };
 // -------------------------------------------------------------------
 
+class AnimatorParameterRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.AnimatorParameterRequest) */ {
+ public:
+  inline AnimatorParameterRequest() : AnimatorParameterRequest(nullptr) {}
+  ~AnimatorParameterRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(AnimatorParameterRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(AnimatorParameterRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR AnimatorParameterRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline AnimatorParameterRequest(const AnimatorParameterRequest& from) : AnimatorParameterRequest(nullptr, from) {}
+  inline AnimatorParameterRequest(AnimatorParameterRequest&& from) noexcept
+      : AnimatorParameterRequest(nullptr, std::move(from)) {}
+  inline AnimatorParameterRequest& operator=(const AnimatorParameterRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline AnimatorParameterRequest& operator=(AnimatorParameterRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const AnimatorParameterRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  enum ValueCase {
+    kFloatValue = 3,
+    kIntValue = 4,
+    kBoolValue = 5,
+    kTrigger = 6,
+    kResetTrigger = 7,
+    VALUE_NOT_SET = 0,
+  };
+  static inline const AnimatorParameterRequest* internal_default_instance() {
+    return reinterpret_cast<const AnimatorParameterRequest*>(
+        &_AnimatorParameterRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 19;
+  friend void swap(AnimatorParameterRequest& a, AnimatorParameterRequest& b) { a.Swap(&b); }
+  inline void Swap(AnimatorParameterRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(AnimatorParameterRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  AnimatorParameterRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<AnimatorParameterRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const AnimatorParameterRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const AnimatorParameterRequest& from) { AnimatorParameterRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(AnimatorParameterRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.AnimatorParameterRequest"; }
+
+ protected:
+  explicit AnimatorParameterRequest(::google::protobuf::Arena* arena);
+  AnimatorParameterRequest(::google::protobuf::Arena* arena, const AnimatorParameterRequest& from);
+  AnimatorParameterRequest(::google::protobuf::Arena* arena, AnimatorParameterRequest&& from) noexcept
+      : AnimatorParameterRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kInstanceIdFieldNumber = 1,
+    kNameFieldNumber = 2,
+    kFloatValueFieldNumber = 3,
+    kIntValueFieldNumber = 4,
+    kBoolValueFieldNumber = 5,
+    kTriggerFieldNumber = 6,
+    kResetTriggerFieldNumber = 7,
+  };
+  // string instance_id = 1;
+  void clear_instance_id() ;
+  const std::string& instance_id() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_instance_id(Arg_&& arg, Args_... args);
+  std::string* mutable_instance_id();
+  PROTOBUF_NODISCARD std::string* release_instance_id();
+  void set_allocated_instance_id(std::string* value);
+
+  private:
+  const std::string& _internal_instance_id() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_instance_id(
+      const std::string& value);
+  std::string* _internal_mutable_instance_id();
+
+  public:
+  // string name = 2;
+  void clear_name() ;
+  const std::string& name() const;
+  template <typename Arg_ = const std::string&, typename... Args_>
+  void set_name(Arg_&& arg, Args_... args);
+  std::string* mutable_name();
+  PROTOBUF_NODISCARD std::string* release_name();
+  void set_allocated_name(std::string* value);
+
+  private:
+  const std::string& _internal_name() const;
+  inline PROTOBUF_ALWAYS_INLINE void _internal_set_name(
+      const std::string& value);
+  std::string* _internal_mutable_name();
+
+  public:
+  // float float_value = 3;
+  bool has_float_value() const;
+  void clear_float_value() ;
+  float float_value() const;
+  void set_float_value(float value);
+
+  private:
+  float _internal_float_value() const;
+  void _internal_set_float_value(float value);
+
+  public:
+  // sint32 int_value = 4;
+  bool has_int_value() const;
+  void clear_int_value() ;
+  ::int32_t int_value() const;
+  void set_int_value(::int32_t value);
+
+  private:
+  ::int32_t _internal_int_value() const;
+  void _internal_set_int_value(::int32_t value);
+
+  public:
+  // bool bool_value = 5;
+  bool has_bool_value() const;
+  void clear_bool_value() ;
+  bool bool_value() const;
+  void set_bool_value(bool value);
+
+  private:
+  bool _internal_bool_value() const;
+  void _internal_set_bool_value(bool value);
+
+  public:
+  // .sailor.editor.v1.Empty trigger = 6;
+  bool has_trigger() const;
+  private:
+  bool _internal_has_trigger() const;
+
+  public:
+  void clear_trigger() ;
+  const ::sailor::editor::v1::Empty& trigger() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::Empty* release_trigger();
+  ::sailor::editor::v1::Empty* mutable_trigger();
+  void set_allocated_trigger(::sailor::editor::v1::Empty* value);
+  void unsafe_arena_set_allocated_trigger(::sailor::editor::v1::Empty* value);
+  ::sailor::editor::v1::Empty* unsafe_arena_release_trigger();
+
+  private:
+  const ::sailor::editor::v1::Empty& _internal_trigger() const;
+  ::sailor::editor::v1::Empty* _internal_mutable_trigger();
+
+  public:
+  // .sailor.editor.v1.Empty reset_trigger = 7;
+  bool has_reset_trigger() const;
+  private:
+  bool _internal_has_reset_trigger() const;
+
+  public:
+  void clear_reset_trigger() ;
+  const ::sailor::editor::v1::Empty& reset_trigger() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::Empty* release_reset_trigger();
+  ::sailor::editor::v1::Empty* mutable_reset_trigger();
+  void set_allocated_reset_trigger(::sailor::editor::v1::Empty* value);
+  void unsafe_arena_set_allocated_reset_trigger(::sailor::editor::v1::Empty* value);
+  ::sailor::editor::v1::Empty* unsafe_arena_release_reset_trigger();
+
+  private:
+  const ::sailor::editor::v1::Empty& _internal_reset_trigger() const;
+  ::sailor::editor::v1::Empty* _internal_mutable_reset_trigger();
+
+  public:
+  void clear_value();
+  ValueCase value_case() const;
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.AnimatorParameterRequest)
+ private:
+  class _Internal;
+  void set_has_float_value();
+  void set_has_int_value();
+  void set_has_bool_value();
+  void set_has_trigger();
+  void set_has_reset_trigger();
+  inline bool has_value() const;
+  inline void clear_has_value();
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      1, 7, 2,
+      65, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const AnimatorParameterRequest& from_msg);
+    ::google::protobuf::internal::ArenaStringPtr instance_id_;
+    ::google::protobuf::internal::ArenaStringPtr name_;
+    union ValueUnion {
+      constexpr ValueUnion() : _constinit_{} {}
+      ::google::protobuf::internal::ConstantInitialized _constinit_;
+      float float_value_;
+      ::int32_t int_value_;
+      bool bool_value_;
+      ::sailor::editor::v1::Empty* trigger_;
+      ::sailor::editor::v1::Empty* reset_trigger_;
+    } value_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    ::uint32_t _oneof_case_[1];
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class ViewportEvent final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.ViewportEvent) */ {
  public:
@@ -9411,7 +10044,7 @@ class ViewportEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEvent*>(
         &_ViewportEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 44;
+  static constexpr int kIndexInFileMessages = 46;
   friend void swap(ViewportEvent& a, ViewportEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportEvent* other) {
     if (other == this) return;
@@ -9755,6 +10388,8 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kGetViewportToolState = 56,
     kUpdateAsset = 57,
     kCreateModelInstance = 58,
+    kSetAnimatorParameter = 59,
+    kGetAnimatorState = 60,
     COMMAND_NOT_SET = 0,
   };
   static inline const ProtocolRequest* internal_default_instance() {
@@ -9898,6 +10533,8 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kGetViewportToolStateFieldNumber = 56,
     kUpdateAssetFieldNumber = 57,
     kCreateModelInstanceFieldNumber = 58,
+    kSetAnimatorParameterFieldNumber = 59,
+    kGetAnimatorStateFieldNumber = 60,
   };
   // uint64 request_id = 2;
   void clear_request_id() ;
@@ -10831,6 +11468,44 @@ class ProtocolRequest final : public ::google::protobuf::Message
   ::sailor::editor::v1::CreateModelInstanceRequest* _internal_mutable_create_model_instance();
 
   public:
+  // .sailor.editor.v1.AnimatorParameterRequest set_animator_parameter = 59;
+  bool has_set_animator_parameter() const;
+  private:
+  bool _internal_has_set_animator_parameter() const;
+
+  public:
+  void clear_set_animator_parameter() ;
+  const ::sailor::editor::v1::AnimatorParameterRequest& set_animator_parameter() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::AnimatorParameterRequest* release_set_animator_parameter();
+  ::sailor::editor::v1::AnimatorParameterRequest* mutable_set_animator_parameter();
+  void set_allocated_set_animator_parameter(::sailor::editor::v1::AnimatorParameterRequest* value);
+  void unsafe_arena_set_allocated_set_animator_parameter(::sailor::editor::v1::AnimatorParameterRequest* value);
+  ::sailor::editor::v1::AnimatorParameterRequest* unsafe_arena_release_set_animator_parameter();
+
+  private:
+  const ::sailor::editor::v1::AnimatorParameterRequest& _internal_set_animator_parameter() const;
+  ::sailor::editor::v1::AnimatorParameterRequest* _internal_mutable_set_animator_parameter();
+
+  public:
+  // .sailor.editor.v1.InstanceIdRequest get_animator_state = 60;
+  bool has_get_animator_state() const;
+  private:
+  bool _internal_has_get_animator_state() const;
+
+  public:
+  void clear_get_animator_state() ;
+  const ::sailor::editor::v1::InstanceIdRequest& get_animator_state() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::InstanceIdRequest* release_get_animator_state();
+  ::sailor::editor::v1::InstanceIdRequest* mutable_get_animator_state();
+  void set_allocated_get_animator_state(::sailor::editor::v1::InstanceIdRequest* value);
+  void unsafe_arena_set_allocated_get_animator_state(::sailor::editor::v1::InstanceIdRequest* value);
+  ::sailor::editor::v1::InstanceIdRequest* unsafe_arena_release_get_animator_state();
+
+  private:
+  const ::sailor::editor::v1::InstanceIdRequest& _internal_get_animator_state() const;
+  ::sailor::editor::v1::InstanceIdRequest* _internal_mutable_get_animator_state();
+
+  public:
   void clear_command();
   CommandCase command_case() const;
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.ProtocolRequest)
@@ -10884,11 +11559,13 @@ class ProtocolRequest final : public ::google::protobuf::Message
   void set_has_get_viewport_tool_state();
   void set_has_update_asset();
   void set_has_create_model_instance();
+  void set_has_set_animator_parameter();
+  void set_has_get_animator_state();
   inline bool has_command() const;
   inline void clear_has_command();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      1, 50, 48,
+      1, 52, 50,
       0, 9>
       _table_;
 
@@ -10959,6 +11636,8 @@ class ProtocolRequest final : public ::google::protobuf::Message
       ::sailor::editor::v1::ViewportIdRequest* get_viewport_tool_state_;
       ::sailor::editor::v1::FileIdRequest* update_asset_;
       ::sailor::editor::v1::CreateModelInstanceRequest* create_model_instance_;
+      ::sailor::editor::v1::AnimatorParameterRequest* set_animator_parameter_;
+      ::sailor::editor::v1::InstanceIdRequest* get_animator_state_;
     } command_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -11028,7 +11707,7 @@ class ViewportEventBatchResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEventBatchResult*>(
         &_ViewportEventBatchResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 45;
+  static constexpr int kIndexInFileMessages = 47;
   friend void swap(ViewportEventBatchResult& a, ViewportEventBatchResult& b) { a.Swap(&b); }
   inline void Swap(ViewportEventBatchResult* other) {
     if (other == this) return;
@@ -11234,6 +11913,7 @@ class ProtocolResponse final : public ::google::protobuf::Message
     kViewportEventBatchResult = 19,
     kVector4Result = 20,
     kViewportToolStateResult = 21,
+    kAnimatorStateResult = 22,
     RESULT_NOT_SET = 0,
   };
   static inline const ProtocolResponse* internal_default_instance() {
@@ -11344,6 +12024,7 @@ class ProtocolResponse final : public ::google::protobuf::Message
     kViewportEventBatchResultFieldNumber = 19,
     kVector4ResultFieldNumber = 20,
     kViewportToolStateResultFieldNumber = 21,
+    kAnimatorStateResultFieldNumber = 22,
   };
   // string error = 4;
   void clear_error() ;
@@ -11629,6 +12310,25 @@ class ProtocolResponse final : public ::google::protobuf::Message
   ::sailor::editor::v1::ViewportToolStateResult* _internal_mutable_viewport_tool_state_result();
 
   public:
+  // .sailor.editor.v1.AnimatorStateResult animator_state_result = 22;
+  bool has_animator_state_result() const;
+  private:
+  bool _internal_has_animator_state_result() const;
+
+  public:
+  void clear_animator_state_result() ;
+  const ::sailor::editor::v1::AnimatorStateResult& animator_state_result() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::AnimatorStateResult* release_animator_state_result();
+  ::sailor::editor::v1::AnimatorStateResult* mutable_animator_state_result();
+  void set_allocated_animator_state_result(::sailor::editor::v1::AnimatorStateResult* value);
+  void unsafe_arena_set_allocated_animator_state_result(::sailor::editor::v1::AnimatorStateResult* value);
+  ::sailor::editor::v1::AnimatorStateResult* unsafe_arena_release_animator_state_result();
+
+  private:
+  const ::sailor::editor::v1::AnimatorStateResult& _internal_animator_state_result() const;
+  ::sailor::editor::v1::AnimatorStateResult* _internal_mutable_animator_state_result();
+
+  public:
   void clear_result();
   ResultCase result_case() const;
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.ProtocolResponse)
@@ -11646,11 +12346,12 @@ class ProtocolResponse final : public ::google::protobuf::Message
   void set_has_viewport_event_batch_result();
   void set_has_vector4_result();
   void set_has_viewport_tool_state_result();
+  void set_has_animator_state_result();
   inline bool has_result() const;
   inline void clear_has_result();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      3, 17, 12,
+      3, 18, 13,
       63, 2>
       _table_;
 
@@ -11688,6 +12389,7 @@ class ProtocolResponse final : public ::google::protobuf::Message
       ::sailor::editor::v1::ViewportEventBatchResult* viewport_event_batch_result_;
       ::sailor::editor::v1::Vector4Result* vector4_result_;
       ::sailor::editor::v1::ViewportToolStateResult* viewport_tool_state_result_;
+      ::sailor::editor::v1::AnimatorStateResult* animator_state_result_;
     } result_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -15553,6 +16255,164 @@ inline ::sailor::editor::v1::CreateModelInstanceRequest* ProtocolRequest::mutabl
   return _msg;
 }
 
+// .sailor.editor.v1.AnimatorParameterRequest set_animator_parameter = 59;
+inline bool ProtocolRequest::has_set_animator_parameter() const {
+  return command_case() == kSetAnimatorParameter;
+}
+inline bool ProtocolRequest::_internal_has_set_animator_parameter() const {
+  return command_case() == kSetAnimatorParameter;
+}
+inline void ProtocolRequest::set_has_set_animator_parameter() {
+  _impl_._oneof_case_[0] = kSetAnimatorParameter;
+}
+inline void ProtocolRequest::clear_set_animator_parameter() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kSetAnimatorParameter) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.set_animator_parameter_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_animator_parameter_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::AnimatorParameterRequest* ProtocolRequest::release_set_animator_parameter() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.set_animator_parameter)
+  if (command_case() == kSetAnimatorParameter) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_animator_parameter_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.set_animator_parameter_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::AnimatorParameterRequest& ProtocolRequest::_internal_set_animator_parameter() const {
+  return command_case() == kSetAnimatorParameter ? *_impl_.command_.set_animator_parameter_ : reinterpret_cast<::sailor::editor::v1::AnimatorParameterRequest&>(::sailor::editor::v1::_AnimatorParameterRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::AnimatorParameterRequest& ProtocolRequest::set_animator_parameter() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.set_animator_parameter)
+  return _internal_set_animator_parameter();
+}
+inline ::sailor::editor::v1::AnimatorParameterRequest* ProtocolRequest::unsafe_arena_release_set_animator_parameter() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.set_animator_parameter)
+  if (command_case() == kSetAnimatorParameter) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_animator_parameter_;
+    _impl_.command_.set_animator_parameter_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_set_animator_parameter(::sailor::editor::v1::AnimatorParameterRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_set_animator_parameter();
+    _impl_.command_.set_animator_parameter_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.set_animator_parameter)
+}
+inline ::sailor::editor::v1::AnimatorParameterRequest* ProtocolRequest::_internal_mutable_set_animator_parameter() {
+  if (command_case() != kSetAnimatorParameter) {
+    clear_command();
+    set_has_set_animator_parameter();
+    _impl_.command_.set_animator_parameter_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::AnimatorParameterRequest>(GetArena());
+  }
+  return _impl_.command_.set_animator_parameter_;
+}
+inline ::sailor::editor::v1::AnimatorParameterRequest* ProtocolRequest::mutable_set_animator_parameter() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::AnimatorParameterRequest* _msg = _internal_mutable_set_animator_parameter();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.set_animator_parameter)
+  return _msg;
+}
+
+// .sailor.editor.v1.InstanceIdRequest get_animator_state = 60;
+inline bool ProtocolRequest::has_get_animator_state() const {
+  return command_case() == kGetAnimatorState;
+}
+inline bool ProtocolRequest::_internal_has_get_animator_state() const {
+  return command_case() == kGetAnimatorState;
+}
+inline void ProtocolRequest::set_has_get_animator_state() {
+  _impl_._oneof_case_[0] = kGetAnimatorState;
+}
+inline void ProtocolRequest::clear_get_animator_state() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kGetAnimatorState) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.get_animator_state_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.get_animator_state_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::InstanceIdRequest* ProtocolRequest::release_get_animator_state() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.get_animator_state)
+  if (command_case() == kGetAnimatorState) {
+    clear_has_command();
+    auto* temp = _impl_.command_.get_animator_state_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.get_animator_state_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::InstanceIdRequest& ProtocolRequest::_internal_get_animator_state() const {
+  return command_case() == kGetAnimatorState ? *_impl_.command_.get_animator_state_ : reinterpret_cast<::sailor::editor::v1::InstanceIdRequest&>(::sailor::editor::v1::_InstanceIdRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::InstanceIdRequest& ProtocolRequest::get_animator_state() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.get_animator_state)
+  return _internal_get_animator_state();
+}
+inline ::sailor::editor::v1::InstanceIdRequest* ProtocolRequest::unsafe_arena_release_get_animator_state() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.get_animator_state)
+  if (command_case() == kGetAnimatorState) {
+    clear_has_command();
+    auto* temp = _impl_.command_.get_animator_state_;
+    _impl_.command_.get_animator_state_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_get_animator_state(::sailor::editor::v1::InstanceIdRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_get_animator_state();
+    _impl_.command_.get_animator_state_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.get_animator_state)
+}
+inline ::sailor::editor::v1::InstanceIdRequest* ProtocolRequest::_internal_mutable_get_animator_state() {
+  if (command_case() != kGetAnimatorState) {
+    clear_command();
+    set_has_get_animator_state();
+    _impl_.command_.get_animator_state_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::InstanceIdRequest>(GetArena());
+  }
+  return _impl_.command_.get_animator_state_;
+}
+inline ::sailor::editor::v1::InstanceIdRequest* ProtocolRequest::mutable_get_animator_state() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::InstanceIdRequest* _msg = _internal_mutable_get_animator_state();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.get_animator_state)
+  return _msg;
+}
+
 inline bool ProtocolRequest::has_command() const {
   return command_case() != COMMAND_NOT_SET;
 }
@@ -16647,6 +17507,85 @@ inline ::sailor::editor::v1::ViewportToolStateResult* ProtocolResponse::_interna
 inline ::sailor::editor::v1::ViewportToolStateResult* ProtocolResponse::mutable_viewport_tool_state_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
   ::sailor::editor::v1::ViewportToolStateResult* _msg = _internal_mutable_viewport_tool_state_result();
   // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolResponse.viewport_tool_state_result)
+  return _msg;
+}
+
+// .sailor.editor.v1.AnimatorStateResult animator_state_result = 22;
+inline bool ProtocolResponse::has_animator_state_result() const {
+  return result_case() == kAnimatorStateResult;
+}
+inline bool ProtocolResponse::_internal_has_animator_state_result() const {
+  return result_case() == kAnimatorStateResult;
+}
+inline void ProtocolResponse::set_has_animator_state_result() {
+  _impl_._oneof_case_[0] = kAnimatorStateResult;
+}
+inline void ProtocolResponse::clear_animator_state_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (result_case() == kAnimatorStateResult) {
+    if (GetArena() == nullptr) {
+      delete _impl_.result_.animator_state_result_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.result_.animator_state_result_);
+    }
+    clear_has_result();
+  }
+}
+inline ::sailor::editor::v1::AnimatorStateResult* ProtocolResponse::release_animator_state_result() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolResponse.animator_state_result)
+  if (result_case() == kAnimatorStateResult) {
+    clear_has_result();
+    auto* temp = _impl_.result_.animator_state_result_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.result_.animator_state_result_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::AnimatorStateResult& ProtocolResponse::_internal_animator_state_result() const {
+  return result_case() == kAnimatorStateResult ? *_impl_.result_.animator_state_result_ : reinterpret_cast<::sailor::editor::v1::AnimatorStateResult&>(::sailor::editor::v1::_AnimatorStateResult_default_instance_);
+}
+inline const ::sailor::editor::v1::AnimatorStateResult& ProtocolResponse::animator_state_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolResponse.animator_state_result)
+  return _internal_animator_state_result();
+}
+inline ::sailor::editor::v1::AnimatorStateResult* ProtocolResponse::unsafe_arena_release_animator_state_result() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolResponse.animator_state_result)
+  if (result_case() == kAnimatorStateResult) {
+    clear_has_result();
+    auto* temp = _impl_.result_.animator_state_result_;
+    _impl_.result_.animator_state_result_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolResponse::unsafe_arena_set_allocated_animator_state_result(::sailor::editor::v1::AnimatorStateResult* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_result();
+  if (value) {
+    set_has_animator_state_result();
+    _impl_.result_.animator_state_result_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolResponse.animator_state_result)
+}
+inline ::sailor::editor::v1::AnimatorStateResult* ProtocolResponse::_internal_mutable_animator_state_result() {
+  if (result_case() != kAnimatorStateResult) {
+    clear_result();
+    set_has_animator_state_result();
+    _impl_.result_.animator_state_result_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::AnimatorStateResult>(GetArena());
+  }
+  return _impl_.result_.animator_state_result_;
+}
+inline ::sailor::editor::v1::AnimatorStateResult* ProtocolResponse::mutable_animator_state_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::AnimatorStateResult* _msg = _internal_mutable_animator_state_result();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolResponse.animator_state_result)
   return _msg;
 }
 
@@ -18401,6 +19340,372 @@ inline void AddComponentRequest::set_allocated_preferred_instance_id(std::string
 
 // -------------------------------------------------------------------
 
+// AnimatorParameterRequest
+
+// string instance_id = 1;
+inline void AnimatorParameterRequest::clear_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.ClearToEmpty();
+}
+inline const std::string& AnimatorParameterRequest::instance_id() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorParameterRequest.instance_id)
+  return _internal_instance_id();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void AnimatorParameterRequest::set_instance_id(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorParameterRequest.instance_id)
+}
+inline std::string* AnimatorParameterRequest::mutable_instance_id() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_instance_id();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.AnimatorParameterRequest.instance_id)
+  return _s;
+}
+inline const std::string& AnimatorParameterRequest::_internal_instance_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.instance_id_.Get();
+}
+inline void AnimatorParameterRequest::_internal_set_instance_id(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.Set(value, GetArena());
+}
+inline std::string* AnimatorParameterRequest::_internal_mutable_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.instance_id_.Mutable( GetArena());
+}
+inline std::string* AnimatorParameterRequest::release_instance_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.AnimatorParameterRequest.instance_id)
+  return _impl_.instance_id_.Release();
+}
+inline void AnimatorParameterRequest::set_allocated_instance_id(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.instance_id_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.instance_id_.IsDefault()) {
+    _impl_.instance_id_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.AnimatorParameterRequest.instance_id)
+}
+
+// string name = 2;
+inline void AnimatorParameterRequest::clear_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.ClearToEmpty();
+}
+inline const std::string& AnimatorParameterRequest::name() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorParameterRequest.name)
+  return _internal_name();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void AnimatorParameterRequest::set_name(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorParameterRequest.name)
+}
+inline std::string* AnimatorParameterRequest::mutable_name() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_name();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.AnimatorParameterRequest.name)
+  return _s;
+}
+inline const std::string& AnimatorParameterRequest::_internal_name() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.name_.Get();
+}
+inline void AnimatorParameterRequest::_internal_set_name(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.Set(value, GetArena());
+}
+inline std::string* AnimatorParameterRequest::_internal_mutable_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.name_.Mutable( GetArena());
+}
+inline std::string* AnimatorParameterRequest::release_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.AnimatorParameterRequest.name)
+  return _impl_.name_.Release();
+}
+inline void AnimatorParameterRequest::set_allocated_name(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.name_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.name_.IsDefault()) {
+    _impl_.name_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.AnimatorParameterRequest.name)
+}
+
+// float float_value = 3;
+inline bool AnimatorParameterRequest::has_float_value() const {
+  return value_case() == kFloatValue;
+}
+inline void AnimatorParameterRequest::set_has_float_value() {
+  _impl_._oneof_case_[0] = kFloatValue;
+}
+inline void AnimatorParameterRequest::clear_float_value() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (value_case() == kFloatValue) {
+    _impl_.value_.float_value_ = 0;
+    clear_has_value();
+  }
+}
+inline float AnimatorParameterRequest::float_value() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorParameterRequest.float_value)
+  return _internal_float_value();
+}
+inline void AnimatorParameterRequest::set_float_value(float value) {
+  if (value_case() != kFloatValue) {
+    clear_value();
+    set_has_float_value();
+  }
+  _impl_.value_.float_value_ = value;
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorParameterRequest.float_value)
+}
+inline float AnimatorParameterRequest::_internal_float_value() const {
+  if (value_case() == kFloatValue) {
+    return _impl_.value_.float_value_;
+  }
+  return 0;
+}
+
+// sint32 int_value = 4;
+inline bool AnimatorParameterRequest::has_int_value() const {
+  return value_case() == kIntValue;
+}
+inline void AnimatorParameterRequest::set_has_int_value() {
+  _impl_._oneof_case_[0] = kIntValue;
+}
+inline void AnimatorParameterRequest::clear_int_value() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (value_case() == kIntValue) {
+    _impl_.value_.int_value_ = 0;
+    clear_has_value();
+  }
+}
+inline ::int32_t AnimatorParameterRequest::int_value() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorParameterRequest.int_value)
+  return _internal_int_value();
+}
+inline void AnimatorParameterRequest::set_int_value(::int32_t value) {
+  if (value_case() != kIntValue) {
+    clear_value();
+    set_has_int_value();
+  }
+  _impl_.value_.int_value_ = value;
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorParameterRequest.int_value)
+}
+inline ::int32_t AnimatorParameterRequest::_internal_int_value() const {
+  if (value_case() == kIntValue) {
+    return _impl_.value_.int_value_;
+  }
+  return 0;
+}
+
+// bool bool_value = 5;
+inline bool AnimatorParameterRequest::has_bool_value() const {
+  return value_case() == kBoolValue;
+}
+inline void AnimatorParameterRequest::set_has_bool_value() {
+  _impl_._oneof_case_[0] = kBoolValue;
+}
+inline void AnimatorParameterRequest::clear_bool_value() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (value_case() == kBoolValue) {
+    _impl_.value_.bool_value_ = false;
+    clear_has_value();
+  }
+}
+inline bool AnimatorParameterRequest::bool_value() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorParameterRequest.bool_value)
+  return _internal_bool_value();
+}
+inline void AnimatorParameterRequest::set_bool_value(bool value) {
+  if (value_case() != kBoolValue) {
+    clear_value();
+    set_has_bool_value();
+  }
+  _impl_.value_.bool_value_ = value;
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorParameterRequest.bool_value)
+}
+inline bool AnimatorParameterRequest::_internal_bool_value() const {
+  if (value_case() == kBoolValue) {
+    return _impl_.value_.bool_value_;
+  }
+  return false;
+}
+
+// .sailor.editor.v1.Empty trigger = 6;
+inline bool AnimatorParameterRequest::has_trigger() const {
+  return value_case() == kTrigger;
+}
+inline bool AnimatorParameterRequest::_internal_has_trigger() const {
+  return value_case() == kTrigger;
+}
+inline void AnimatorParameterRequest::set_has_trigger() {
+  _impl_._oneof_case_[0] = kTrigger;
+}
+inline void AnimatorParameterRequest::clear_trigger() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (value_case() == kTrigger) {
+    if (GetArena() == nullptr) {
+      delete _impl_.value_.trigger_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.value_.trigger_);
+    }
+    clear_has_value();
+  }
+}
+inline ::sailor::editor::v1::Empty* AnimatorParameterRequest::release_trigger() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.AnimatorParameterRequest.trigger)
+  if (value_case() == kTrigger) {
+    clear_has_value();
+    auto* temp = _impl_.value_.trigger_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.value_.trigger_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::Empty& AnimatorParameterRequest::_internal_trigger() const {
+  return value_case() == kTrigger ? *_impl_.value_.trigger_ : reinterpret_cast<::sailor::editor::v1::Empty&>(::sailor::editor::v1::_Empty_default_instance_);
+}
+inline const ::sailor::editor::v1::Empty& AnimatorParameterRequest::trigger() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorParameterRequest.trigger)
+  return _internal_trigger();
+}
+inline ::sailor::editor::v1::Empty* AnimatorParameterRequest::unsafe_arena_release_trigger() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.AnimatorParameterRequest.trigger)
+  if (value_case() == kTrigger) {
+    clear_has_value();
+    auto* temp = _impl_.value_.trigger_;
+    _impl_.value_.trigger_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void AnimatorParameterRequest::unsafe_arena_set_allocated_trigger(::sailor::editor::v1::Empty* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_value();
+  if (value) {
+    set_has_trigger();
+    _impl_.value_.trigger_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.AnimatorParameterRequest.trigger)
+}
+inline ::sailor::editor::v1::Empty* AnimatorParameterRequest::_internal_mutable_trigger() {
+  if (value_case() != kTrigger) {
+    clear_value();
+    set_has_trigger();
+    _impl_.value_.trigger_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::Empty>(GetArena());
+  }
+  return _impl_.value_.trigger_;
+}
+inline ::sailor::editor::v1::Empty* AnimatorParameterRequest::mutable_trigger() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::Empty* _msg = _internal_mutable_trigger();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.AnimatorParameterRequest.trigger)
+  return _msg;
+}
+
+// .sailor.editor.v1.Empty reset_trigger = 7;
+inline bool AnimatorParameterRequest::has_reset_trigger() const {
+  return value_case() == kResetTrigger;
+}
+inline bool AnimatorParameterRequest::_internal_has_reset_trigger() const {
+  return value_case() == kResetTrigger;
+}
+inline void AnimatorParameterRequest::set_has_reset_trigger() {
+  _impl_._oneof_case_[0] = kResetTrigger;
+}
+inline void AnimatorParameterRequest::clear_reset_trigger() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (value_case() == kResetTrigger) {
+    if (GetArena() == nullptr) {
+      delete _impl_.value_.reset_trigger_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.value_.reset_trigger_);
+    }
+    clear_has_value();
+  }
+}
+inline ::sailor::editor::v1::Empty* AnimatorParameterRequest::release_reset_trigger() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.AnimatorParameterRequest.reset_trigger)
+  if (value_case() == kResetTrigger) {
+    clear_has_value();
+    auto* temp = _impl_.value_.reset_trigger_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.value_.reset_trigger_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::Empty& AnimatorParameterRequest::_internal_reset_trigger() const {
+  return value_case() == kResetTrigger ? *_impl_.value_.reset_trigger_ : reinterpret_cast<::sailor::editor::v1::Empty&>(::sailor::editor::v1::_Empty_default_instance_);
+}
+inline const ::sailor::editor::v1::Empty& AnimatorParameterRequest::reset_trigger() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorParameterRequest.reset_trigger)
+  return _internal_reset_trigger();
+}
+inline ::sailor::editor::v1::Empty* AnimatorParameterRequest::unsafe_arena_release_reset_trigger() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.AnimatorParameterRequest.reset_trigger)
+  if (value_case() == kResetTrigger) {
+    clear_has_value();
+    auto* temp = _impl_.value_.reset_trigger_;
+    _impl_.value_.reset_trigger_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void AnimatorParameterRequest::unsafe_arena_set_allocated_reset_trigger(::sailor::editor::v1::Empty* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_value();
+  if (value) {
+    set_has_reset_trigger();
+    _impl_.value_.reset_trigger_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.AnimatorParameterRequest.reset_trigger)
+}
+inline ::sailor::editor::v1::Empty* AnimatorParameterRequest::_internal_mutable_reset_trigger() {
+  if (value_case() != kResetTrigger) {
+    clear_value();
+    set_has_reset_trigger();
+    _impl_.value_.reset_trigger_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::Empty>(GetArena());
+  }
+  return _impl_.value_.reset_trigger_;
+}
+inline ::sailor::editor::v1::Empty* AnimatorParameterRequest::mutable_reset_trigger() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::Empty* _msg = _internal_mutable_reset_trigger();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.AnimatorParameterRequest.reset_trigger)
+  return _msg;
+}
+
+inline bool AnimatorParameterRequest::has_value() const {
+  return value_case() != VALUE_NOT_SET;
+}
+inline void AnimatorParameterRequest::clear_has_value() {
+  _impl_._oneof_case_[0] = VALUE_NOT_SET;
+}
+inline AnimatorParameterRequest::ValueCase AnimatorParameterRequest::value_case() const {
+  return AnimatorParameterRequest::ValueCase(_impl_._oneof_case_[0]);
+}
+// -------------------------------------------------------------------
+
 // InstantiatePrefabRequest
 
 // string file_id = 1;
@@ -19971,6 +21276,282 @@ inline ::sailor::editor::v1::ViewportTransformSpace ViewportToolStateResult::_in
 inline void ViewportToolStateResult::_internal_set_space(::sailor::editor::v1::ViewportTransformSpace value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.space_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// AnimatorStateResult
+
+// bool has_controller = 1;
+inline void AnimatorStateResult::clear_has_controller() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.has_controller_ = false;
+}
+inline bool AnimatorStateResult::has_controller() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorStateResult.has_controller)
+  return _internal_has_controller();
+}
+inline void AnimatorStateResult::set_has_controller(bool value) {
+  _internal_set_has_controller(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorStateResult.has_controller)
+}
+inline bool AnimatorStateResult::_internal_has_controller() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.has_controller_;
+}
+inline void AnimatorStateResult::_internal_set_has_controller(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.has_controller_ = value;
+}
+
+// uint64 controller_revision = 2;
+inline void AnimatorStateResult::clear_controller_revision() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.controller_revision_ = ::uint64_t{0u};
+}
+inline ::uint64_t AnimatorStateResult::controller_revision() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorStateResult.controller_revision)
+  return _internal_controller_revision();
+}
+inline void AnimatorStateResult::set_controller_revision(::uint64_t value) {
+  _internal_set_controller_revision(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorStateResult.controller_revision)
+}
+inline ::uint64_t AnimatorStateResult::_internal_controller_revision() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.controller_revision_;
+}
+inline void AnimatorStateResult::_internal_set_controller_revision(::uint64_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.controller_revision_ = value;
+}
+
+// uint64 active_state_id = 3;
+inline void AnimatorStateResult::clear_active_state_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.active_state_id_ = ::uint64_t{0u};
+}
+inline ::uint64_t AnimatorStateResult::active_state_id() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorStateResult.active_state_id)
+  return _internal_active_state_id();
+}
+inline void AnimatorStateResult::set_active_state_id(::uint64_t value) {
+  _internal_set_active_state_id(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorStateResult.active_state_id)
+}
+inline ::uint64_t AnimatorStateResult::_internal_active_state_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.active_state_id_;
+}
+inline void AnimatorStateResult::_internal_set_active_state_id(::uint64_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.active_state_id_ = value;
+}
+
+// string active_state_name = 4;
+inline void AnimatorStateResult::clear_active_state_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.active_state_name_.ClearToEmpty();
+}
+inline const std::string& AnimatorStateResult::active_state_name() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorStateResult.active_state_name)
+  return _internal_active_state_name();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void AnimatorStateResult::set_active_state_name(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.active_state_name_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorStateResult.active_state_name)
+}
+inline std::string* AnimatorStateResult::mutable_active_state_name() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_active_state_name();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.AnimatorStateResult.active_state_name)
+  return _s;
+}
+inline const std::string& AnimatorStateResult::_internal_active_state_name() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.active_state_name_.Get();
+}
+inline void AnimatorStateResult::_internal_set_active_state_name(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.active_state_name_.Set(value, GetArena());
+}
+inline std::string* AnimatorStateResult::_internal_mutable_active_state_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.active_state_name_.Mutable( GetArena());
+}
+inline std::string* AnimatorStateResult::release_active_state_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.AnimatorStateResult.active_state_name)
+  return _impl_.active_state_name_.Release();
+}
+inline void AnimatorStateResult::set_allocated_active_state_name(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.active_state_name_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.active_state_name_.IsDefault()) {
+    _impl_.active_state_name_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.AnimatorStateResult.active_state_name)
+}
+
+// float active_state_time = 5;
+inline void AnimatorStateResult::clear_active_state_time() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.active_state_time_ = 0;
+}
+inline float AnimatorStateResult::active_state_time() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorStateResult.active_state_time)
+  return _internal_active_state_time();
+}
+inline void AnimatorStateResult::set_active_state_time(float value) {
+  _internal_set_active_state_time(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorStateResult.active_state_time)
+}
+inline float AnimatorStateResult::_internal_active_state_time() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.active_state_time_;
+}
+inline void AnimatorStateResult::_internal_set_active_state_time(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.active_state_time_ = value;
+}
+
+// bool transitioning = 6;
+inline void AnimatorStateResult::clear_transitioning() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.transitioning_ = false;
+}
+inline bool AnimatorStateResult::transitioning() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorStateResult.transitioning)
+  return _internal_transitioning();
+}
+inline void AnimatorStateResult::set_transitioning(bool value) {
+  _internal_set_transitioning(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorStateResult.transitioning)
+}
+inline bool AnimatorStateResult::_internal_transitioning() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.transitioning_;
+}
+inline void AnimatorStateResult::_internal_set_transitioning(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.transitioning_ = value;
+}
+
+// uint64 destination_state_id = 7;
+inline void AnimatorStateResult::clear_destination_state_id() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.destination_state_id_ = ::uint64_t{0u};
+}
+inline ::uint64_t AnimatorStateResult::destination_state_id() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorStateResult.destination_state_id)
+  return _internal_destination_state_id();
+}
+inline void AnimatorStateResult::set_destination_state_id(::uint64_t value) {
+  _internal_set_destination_state_id(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorStateResult.destination_state_id)
+}
+inline ::uint64_t AnimatorStateResult::_internal_destination_state_id() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.destination_state_id_;
+}
+inline void AnimatorStateResult::_internal_set_destination_state_id(::uint64_t value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.destination_state_id_ = value;
+}
+
+// string destination_state_name = 8;
+inline void AnimatorStateResult::clear_destination_state_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.destination_state_name_.ClearToEmpty();
+}
+inline const std::string& AnimatorStateResult::destination_state_name() const
+    ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorStateResult.destination_state_name)
+  return _internal_destination_state_name();
+}
+template <typename Arg_, typename... Args_>
+inline PROTOBUF_ALWAYS_INLINE void AnimatorStateResult::set_destination_state_name(Arg_&& arg,
+                                                     Args_... args) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.destination_state_name_.Set(static_cast<Arg_&&>(arg), args..., GetArena());
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorStateResult.destination_state_name)
+}
+inline std::string* AnimatorStateResult::mutable_destination_state_name() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  std::string* _s = _internal_mutable_destination_state_name();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.AnimatorStateResult.destination_state_name)
+  return _s;
+}
+inline const std::string& AnimatorStateResult::_internal_destination_state_name() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.destination_state_name_.Get();
+}
+inline void AnimatorStateResult::_internal_set_destination_state_name(const std::string& value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.destination_state_name_.Set(value, GetArena());
+}
+inline std::string* AnimatorStateResult::_internal_mutable_destination_state_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  return _impl_.destination_state_name_.Mutable( GetArena());
+}
+inline std::string* AnimatorStateResult::release_destination_state_name() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.AnimatorStateResult.destination_state_name)
+  return _impl_.destination_state_name_.Release();
+}
+inline void AnimatorStateResult::set_allocated_destination_state_name(std::string* value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.destination_state_name_.SetAllocated(value, GetArena());
+  if (::google::protobuf::internal::DebugHardenForceCopyDefaultString() && _impl_.destination_state_name_.IsDefault()) {
+    _impl_.destination_state_name_.Set("", GetArena());
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.AnimatorStateResult.destination_state_name)
+}
+
+// float destination_state_time = 9;
+inline void AnimatorStateResult::clear_destination_state_time() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.destination_state_time_ = 0;
+}
+inline float AnimatorStateResult::destination_state_time() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorStateResult.destination_state_time)
+  return _internal_destination_state_time();
+}
+inline void AnimatorStateResult::set_destination_state_time(float value) {
+  _internal_set_destination_state_time(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorStateResult.destination_state_time)
+}
+inline float AnimatorStateResult::_internal_destination_state_time() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.destination_state_time_;
+}
+inline void AnimatorStateResult::_internal_set_destination_state_time(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.destination_state_time_ = value;
+}
+
+// float transition_alpha = 10;
+inline void AnimatorStateResult::clear_transition_alpha() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.transition_alpha_ = 0;
+}
+inline float AnimatorStateResult::transition_alpha() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.AnimatorStateResult.transition_alpha)
+  return _internal_transition_alpha();
+}
+inline void AnimatorStateResult::set_transition_alpha(float value) {
+  _internal_set_transition_alpha(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.AnimatorStateResult.transition_alpha)
+}
+inline float AnimatorStateResult::_internal_transition_alpha() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.transition_alpha_;
+}
+inline void AnimatorStateResult::_internal_set_transition_alpha(float value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.transition_alpha_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/Runtime/RHI/Material.cpp
+++ b/Runtime/RHI/Material.cpp
@@ -12,8 +12,10 @@ using namespace Sailor::GraphicsDriver::Vulkan;
 GraphicsDriver::Vulkan::VulkanGraphicsPipelinePtr RHIMaterial::Vulkan::GetOrAddPipeline(const TVector<VkFormat>& colorAttachments, VkFormat depthStencilAttachment)
 {
 	SAILOR_PROFILE_FUNCTION();
+	m_pipelinesLock.Lock();
 
 	uint32_t stateIndex = 0;
+	const VkFormat stencilAttachmentFormat = (VulkanApi::ComputeAspectFlagsForFormat(depthStencilAttachment) & VK_IMAGE_ASPECT_STENCIL_BIT) ? depthStencilAttachment : VK_FORMAT_UNDEFINED;
 
 	for (auto& p : m_pipelines)
 	{
@@ -22,9 +24,11 @@ GraphicsDriver::Vulkan::VulkanGraphicsPipelinePtr RHIMaterial::Vulkan::GetOrAddP
 		{
 			if (const auto pDynamicState = state.DynamicCast<GraphicsDriver::Vulkan::VulkanStateDynamicRendering>())
 			{
-				if (pDynamicState->Fits(colorAttachments, depthStencilAttachment, depthStencilAttachment))
+				if (pDynamicState->Fits(colorAttachments, depthStencilAttachment, stencilAttachmentFormat))
 				{
-					return p;
+					auto result = p;
+					m_pipelinesLock.Unlock();
+					return result;
 				}
 
 				break;
@@ -38,8 +42,6 @@ GraphicsDriver::Vulkan::VulkanGraphicsPipelinePtr RHIMaterial::Vulkan::GetOrAddP
 
 	TVector<VulkanPipelineStatePtr> states = m_pipelines[0]->m_pipelineStates;
 
-	const VkFormat stencilAttachmentFormat = (VulkanApi::ComputeAspectFlagsForFormat(depthStencilAttachment) & VK_IMAGE_ASPECT_STENCIL_BIT) ? depthStencilAttachment : VK_FORMAT_UNDEFINED;
-
 	states[stateIndex] = GraphicsDriver::Vulkan::VulkanStateDynamicRenderingPtr::Make(colorAttachments, depthStencilAttachment, stencilAttachmentFormat);
 
 	GraphicsDriver::Vulkan::VulkanGraphicsPipelinePtr pipeline = VulkanGraphicsPipelinePtr::Make(device,
@@ -49,11 +51,17 @@ GraphicsDriver::Vulkan::VulkanGraphicsPipelinePtr RHIMaterial::Vulkan::GetOrAddP
 		0);
 
 	pipeline->m_renderPass = device->GetRenderPass();
-	pipeline->Compile();
+	if (!pipeline->Compile())
+	{
+		m_pipelinesLock.Unlock();
+		return nullptr;
+	}
 
 	m_pipelines.Emplace(std::move(pipeline));
 
-	return *m_pipelines.Last();
+	auto result = *m_pipelines.Last();
+	m_pipelinesLock.Unlock();
+	return result;
 }
 
 void RHIShaderBindingSet::RecalculateCompatibility()

--- a/Runtime/RHI/Material.h
+++ b/Runtime/RHI/Material.h
@@ -62,6 +62,7 @@ namespace Sailor::RHI
 		{
 			GraphicsDriver::Vulkan::VulkanGraphicsPipelinePtr GetOrAddPipeline(const TVector<VkFormat>& colorAttachments, VkFormat depthStencilAttachment);
 			TVector<GraphicsDriver::Vulkan::VulkanGraphicsPipelinePtr> m_pipelines{};
+			SpinLock m_pipelinesLock;
 
 		} m_vulkan{};
 #endif

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -564,3 +564,17 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 
 	return true;
 }
+
+void Renderer::WaitIdle()
+{
+	if (m_previousRenderFrame.IsValid())
+	{
+		m_previousRenderFrame->Wait();
+		m_previousRenderFrame.Clear();
+	}
+
+	if (m_driverInstance)
+	{
+		m_driverInstance->WaitIdle();
+	}
+}

--- a/Runtime/RHI/Renderer.h
+++ b/Runtime/RHI/Renderer.h
@@ -43,6 +43,7 @@ namespace Sailor::RHI
 
 		SAILOR_API void FixLostDevice();
 		SAILOR_API bool PushFrame(const Sailor::FrameState& frame);
+		SAILOR_API void WaitIdle();
 
 		SAILOR_API const Stats& GetStats() const { return m_stats; }
 

--- a/Runtime/RHI/VertexDescription.cpp
+++ b/Runtime/RHI/VertexDescription.cpp
@@ -14,7 +14,15 @@ void RHIVertexDescription::AddAttribute(uint32_t location, uint32_t binding, EFo
 	attribute.m_format = format;
 	attribute.m_offset = offset;
 
-	SetAttributeFormat(m_bits, binding, format);
+	SetAttributeFormat(m_bits, location, format);
 
 	m_attributes.Emplace(attribute);
+}
+
+bool RHIVertexDescription::HasAttribute(uint32_t location) const
+{
+	return m_attributes.FindIf([location](const AttributeDescription& attribute)
+		{
+			return attribute.m_location == location;
+		}) != -1;
 }

--- a/Runtime/RHI/VertexDescription.h
+++ b/Runtime/RHI/VertexDescription.h
@@ -31,6 +31,7 @@ namespace Sailor::RHI
 		SAILOR_API size_t GetVertexStride() const { return m_vertexStride; }
 
 		SAILOR_API void AddAttribute(uint32_t location, uint32_t binding, EFormat format, uint32_t offset);
+		SAILOR_API bool HasAttribute(uint32_t location) const;
 
 		SAILOR_API const TVector<AttributeDescription>& GetAttributeDescriptions() const { return m_attributes; }
 		SAILOR_API const VertexAttributeBits& GetVertexAttributeBits() const { return m_bits; }

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -708,6 +708,13 @@ void App::Start()
 			EditorRuntime::DrainEditorRemoteViewportInputOnEngineThread();
 		}
 
+		if (!pEngineLoop->GetWorlds().IsEmpty() &&
+			currentFrame.GetWorld() != pEngineLoop->GetWorld().GetRawPtr())
+		{
+			bCanCreateNewFrame = true;
+			bFirstFrame = true;
+		}
+
 		if (systemInputState.IsKeyPressed(VK_ESCAPE) || !pMainWindow->IsParentWindowValid())
 		{
 			Stop();

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -6,6 +6,8 @@
 #include "AssetRegistry/Model/ModelImporter.h"
 #include "AssetRegistry/Animation/AnimationImporter.h"
 #include "AssetRegistry/Animation/AnimationAssetInfo.h"
+#include "AssetRegistry/Animation/AnimationControllerAssetInfo.h"
+#include "AssetRegistry/Animation/AnimationControllerImporter.h"
 #include "AssetRegistry/Material/MaterialImporter.h"
 #include "AssetRegistry/FrameGraph/FrameGraphAssetInfo.h"
 #include "AssetRegistry/FrameGraph/FrameGraphImporter.h"
@@ -485,6 +487,8 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	auto shaderInfoHandler = s_pInstance->AddSubmodule(TSubmodule<ShaderAssetInfoHandler>::Make(assetRegistry));
 	auto modelInfoHandler = s_pInstance->AddSubmodule(TSubmodule<ModelAssetInfoHandler>::Make(assetRegistry));
 	auto animationInfoHandler = s_pInstance->AddSubmodule(TSubmodule<AnimationAssetInfoHandler>::Make(assetRegistry));
+	auto animationControllerInfoHandler = s_pInstance->AddSubmodule(TSubmodule<AnimationControllerAssetInfoHandler>::Make(assetRegistry));
+	auto animationSetInfoHandler = s_pInstance->AddSubmodule(TSubmodule<AnimationSetAssetInfoHandler>::Make(assetRegistry));
 	auto materialInfoHandler = s_pInstance->AddSubmodule(TSubmodule<MaterialAssetInfoHandler>::Make(assetRegistry));
 	auto frameGraphInfoHandler = s_pInstance->AddSubmodule(TSubmodule<FrameGraphAssetInfoHandler>::Make(assetRegistry));
 	auto prefabInfoHandler = s_pInstance->AddSubmodule(TSubmodule<PrefabAssetInfoHandler>::Make(assetRegistry));
@@ -494,6 +498,7 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	s_pInstance->AddSubmodule(TSubmodule<ShaderCompiler>::Make(shaderInfoHandler));
 	s_pInstance->AddSubmodule(TSubmodule<ModelImporter>::Make(modelInfoHandler));
 	s_pInstance->AddSubmodule(TSubmodule<AnimationImporter>::Make(animationInfoHandler));
+	s_pInstance->AddSubmodule(TSubmodule<AnimationControllerImporter>::Make(animationControllerInfoHandler, animationSetInfoHandler));
 	s_pInstance->AddSubmodule(TSubmodule<MaterialImporter>::Make(materialInfoHandler));
 	s_pInstance->AddSubmodule(TSubmodule<FrameGraphImporter>::Make(frameGraphInfoHandler));
 	s_pInstance->AddSubmodule(TSubmodule<ECS::ECSFactory>::Make());
@@ -1084,6 +1089,7 @@ void App::Shutdown()
 	RemoveSubmodule<MaterialImporter>();
 	RemoveSubmodule<ModelImporter>();
 	RemoveSubmodule<AnimationImporter>();
+	RemoveSubmodule<AnimationControllerImporter>();
 	RemoveSubmodule<ShaderCompiler>();
 	RemoveSubmodule<TextureImporter>();
 	RemoveSubmodule<PrefabImporter>();

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -92,6 +92,25 @@ namespace Sailor
 		SAILOR_API static bool LoadEditorWorld(const char* strFileId);
 		SAILOR_API static bool CreateEditorWorld();
 		SAILOR_API static bool UpdateEditorObject(const char* strInstanceId, const char* strYamlNode);
+		SAILOR_API static bool SetEditorAnimatorParameter(
+			const char* strInstanceId,
+			const char* strName,
+			uint32_t valueKind,
+			float floatValue,
+			int32_t intValue,
+			bool boolValue);
+		SAILOR_API static bool GetEditorAnimatorState(
+			const char* strInstanceId,
+			bool& outHasController,
+			uint64_t& outControllerRevision,
+			uint64_t& outActiveStateId,
+			char** outActiveStateName,
+			float& outActiveStateTime,
+			bool& outTransitioning,
+			uint64_t& outDestinationStateId,
+			char** outDestinationStateName,
+			float& outDestinationStateTime,
+			float& outTransitionAlpha);
 		SAILOR_API static bool ReparentEditorObject(const char* strInstanceId, const char* strParentInstanceId, bool bKeepWorldTransform);
 		SAILOR_API static bool CreateEditorGameObject(const char* strParentInstanceId, const char* strPreferredInstanceId, char** outInstanceId);
 		SAILOR_API static bool CreateEditorModelInstance(

--- a/Tests/AnimationSamplingContractTests.cpp
+++ b/Tests/AnimationSamplingContractTests.cpp
@@ -1,4 +1,7 @@
 #include "AssetRegistry/Animation/AnimationClipSampler.h"
+#include "AssetRegistry/Animation/AnimationController.h"
+#include "AssetRegistry/Animation/AnimationPose.h"
+#include "Memory/ObjectAllocator.hpp"
 
 #include <cmath>
 #include <functional>
@@ -144,6 +147,313 @@ namespace
 			NearlyEqual(glm::length(sampled), 1.0f),
 			"CUBICSPLINE quaternion output must be normalized after Hermite interpolation");
 	}
+
+	AnimationControllerAsset MakeControllerAsset()
+	{
+		AnimationControllerAsset asset;
+		asset.SetDefaultStateId(100);
+		asset.GetParameters() = {
+			AnimationParameterDefinition{
+				.m_id = 1,
+				.m_name = "Speed",
+				.m_type = EAnimationParameterType::Float
+			},
+			AnimationParameterDefinition{
+				.m_id = 2,
+				.m_name = "Grounded",
+				.m_type = EAnimationParameterType::Bool,
+				.m_defaultBool = true
+			},
+			AnimationParameterDefinition{
+				.m_id = 3,
+				.m_name = "Mode",
+				.m_type = EAnimationParameterType::Int
+			},
+			AnimationParameterDefinition{
+				.m_id = 4,
+				.m_name = "Jump",
+				.m_type = EAnimationParameterType::Trigger
+			}
+		};
+		asset.GetStates() = {
+			AnimationStateDefinition{
+				.m_id = 100,
+				.m_name = "Idle",
+				.m_clipSlot = "Idle",
+				.m_editorX = 10.0f,
+				.m_editorY = 20.0f
+			},
+			AnimationStateDefinition{
+				.m_id = 200,
+				.m_name = "Walk",
+				.m_clipSlot = "Walk"
+			},
+			AnimationStateDefinition{
+				.m_id = 300,
+				.m_name = "Jump",
+				.m_clipSlot = "Jump",
+				.m_bLoop = false
+			}
+		};
+
+		AnimationTransitionDefinition walk;
+		walk.m_id = 1000;
+		walk.m_fromStateId = 100;
+		walk.m_toStateId = 200;
+		walk.m_priority = 1;
+		walk.m_duration = 0.2f;
+		walk.m_conditions = {
+			AnimationTransitionCondition{
+				.m_parameterId = 1,
+				.m_operation = EAnimationConditionOperation::Greater,
+				.m_floatValue = 0.5f
+			},
+			AnimationTransitionCondition{
+				.m_parameterId = 2,
+				.m_operation = EAnimationConditionOperation::Equal,
+				.m_boolValue = true
+			},
+			AnimationTransitionCondition{
+				.m_parameterId = 3,
+				.m_operation = EAnimationConditionOperation::Equal,
+				.m_intValue = 2
+			}
+		};
+
+		AnimationTransitionDefinition jump;
+		jump.m_id = 1001;
+		jump.m_fromStateId = 100;
+		jump.m_toStateId = 300;
+		jump.m_priority = 10;
+		jump.m_duration = 0.2f;
+		jump.m_conditions = {
+			AnimationTransitionCondition{
+				.m_parameterId = 4,
+				.m_operation = EAnimationConditionOperation::IsSet
+			}
+		};
+
+		AnimationTransitionDefinition returnToIdle;
+		returnToIdle.m_id = 1002;
+		returnToIdle.m_fromStateId = 300;
+		returnToIdle.m_toStateId = 100;
+		returnToIdle.m_priority = 0;
+		returnToIdle.m_duration = 0.0f;
+		returnToIdle.m_bHasExitTime = true;
+		returnToIdle.m_exitTime = 0.5f;
+
+		asset.GetTransitions() = {
+			std::move(walk),
+			std::move(jump),
+			std::move(returnToIdle)
+		};
+		return asset;
+	}
+
+	void TestAnimationControllerSerializationAndValidation()
+	{
+		AnimationControllerAsset source = MakeControllerAsset();
+		AnimationControllerAsset roundTrip;
+		roundTrip.Deserialize(source.Serialize());
+
+		Require(roundTrip.GetDefaultStateId() == 100 &&
+			roundTrip.GetParameters().Num() == 4 &&
+			roundTrip.GetStates().Num() == 3 &&
+			roundTrip.GetTransitions().Num() == 3,
+			"animation controller YAML must retain graph structure and stable ids");
+		Require(NearlyEqual(roundTrip.GetStates()[0].m_editorX, 10.0f) &&
+			NearlyEqual(roundTrip.GetStates()[0].m_editorY, 20.0f),
+			"animation controller YAML must retain source-controlled editor layout");
+
+		auto allocator = Memory::ObjectAllocatorPtr::Make(
+			Memory::EAllocationPolicy::SharedMemory_MultiThreaded);
+		auto controller = AnimationControllerPtr::Make(allocator, FileId{});
+		TVector<std::string> errors;
+		Require(controller->Initialize(roundTrip, &errors) && errors.IsEmpty(),
+			"a valid controller graph must compile without diagnostics");
+
+		roundTrip.GetStates()[1].m_id = 100;
+		Require(!controller->Initialize(roundTrip, &errors) && !errors.IsEmpty(),
+			"duplicate state ids must produce validation diagnostics");
+
+		AnimationSetAsset setSource;
+		setSource.GetEntries().Add({ "Idle", FileId::CreateNewFileId() });
+		AnimationSetAsset setRoundTrip;
+		setRoundTrip.Deserialize(setSource.Serialize());
+		Require(setRoundTrip.GetEntries().Num() == 1 &&
+			setRoundTrip.GetEntries()[0].m_slot == "Idle" &&
+			setRoundTrip.GetEntries()[0].m_animation ==
+				setSource.GetEntries()[0].m_animation,
+			"animation set YAML must retain logical slots and clip FileIds");
+		auto animationSet = AnimationSetPtr::Make(allocator, FileId{});
+		Require(animationSet->Initialize(setRoundTrip, &errors),
+			"a valid animation set must compile without diagnostics");
+		setRoundTrip.GetEntries().Add(setRoundTrip.GetEntries()[0]);
+		Require(!animationSet->Initialize(setRoundTrip, &errors) && !errors.IsEmpty(),
+			"duplicate animation set slots must produce validation diagnostics");
+		animationSet.DestroyObject(allocator);
+		controller.DestroyObject(allocator);
+	}
+
+	void TestAnimationControllerTransitionsAndIndependentInstances()
+	{
+		auto allocator = Memory::ObjectAllocatorPtr::Make(
+			Memory::EAllocationPolicy::SharedMemory_MultiThreaded);
+		auto controller = AnimationControllerPtr::Make(allocator, FileId{});
+		AnimationControllerAsset asset = MakeControllerAsset();
+		Require(controller->Initialize(asset),
+			"controller fixture must compile");
+
+		AnimationControllerInstance first;
+		AnimationControllerInstance second;
+		Require(first.SetController(controller) && second.SetController(controller),
+			"each Animator must create an independent controller instance");
+		Require(first.SetFloat("Speed", 1.0f) &&
+			first.SetBool("Grounded", true) &&
+			first.SetInt("Mode", 2) &&
+			first.SetTrigger("Jump"),
+			"typed controller parameters must accept matching values");
+		Require(!first.SetFloat("Mode", 1.0f) &&
+			!first.SetTrigger("Missing"),
+			"typed controller parameters must reject mismatched or missing fields");
+
+		first.Tick(0.0f, 1.0f);
+		Require(first.IsTransitioning() &&
+			first.GetDestinationStateIndex() == 2,
+			"the highest-priority eligible transition must win deterministically");
+		Require(!second.IsTransitioning() && second.GetActiveStateIndex() == 0,
+			"shared controller assets must not share mutable state or parameters");
+
+		first.Tick(0.1f, 1.0f);
+		Require(NearlyEqual(first.GetTransitionAlpha(), 0.5f),
+			"crossfade progress must advance independently from state clocks");
+		first.Tick(0.1f, 1.0f);
+		Require(!first.IsTransitioning() && first.GetActiveStateIndex() == 2,
+			"crossfade completion must promote the destination state");
+
+		first.Tick(0.29f, 1.0f);
+		Require(first.GetActiveStateIndex() == 2,
+			"normalized exit-time transitions must not fire early");
+		first.Tick(0.01f, 1.0f);
+		Require(first.GetActiveStateIndex() == 0 && !first.IsTransitioning(),
+			"zero-duration transitions must complete at the normalized exit time");
+
+		first.SetFloat("Speed", 0.0f);
+		first.Tick(0.0f, 1.0f);
+		Require(first.GetActiveStateIndex() == 0 && !first.IsTransitioning(),
+			"a trigger must be consumed only by the transition that selected it");
+
+		first = AnimationControllerInstance{};
+		second = AnimationControllerInstance{};
+		controller.DestroyObject(allocator);
+	}
+
+	void TestAnimationControllerHotReloadPreservesStableState()
+	{
+		auto allocator = Memory::ObjectAllocatorPtr::Make(
+			Memory::EAllocationPolicy::SharedMemory_MultiThreaded);
+		auto controller = AnimationControllerPtr::Make(allocator, FileId{});
+		AnimationControllerAsset asset = MakeControllerAsset();
+		asset.GetTransitions()[0].m_duration = 0.0f;
+		Require(controller->Initialize(asset),
+			"controller fixture must compile before hot reload");
+
+		AnimationControllerInstance instance;
+		Require(instance.SetController(controller) &&
+			instance.SetFloat("Speed", 1.0f) &&
+			instance.SetBool("Grounded", true) &&
+			instance.SetInt("Mode", 2),
+			"controller instance must accept initial typed values");
+		instance.Tick(0.0f, 1.0f);
+		Require(controller->GetStates()[instance.GetActiveStateIndex()].m_id == 200,
+			"fixture must enter the stable Walk state before reload");
+
+		std::swap(asset.GetStates()[0], asset.GetStates()[1]);
+		std::swap(asset.GetParameters()[0], asset.GetParameters()[3]);
+		const uint64_t previousRevision = controller->GetRevision();
+		Require(controller->Initialize(asset) &&
+			controller->GetRevision() == previousRevision + 1,
+			"a valid hot reload must publish one new controller revision");
+		instance.Tick(0.0f, 1.0f);
+		Require(controller->GetStates()[instance.GetActiveStateIndex()].m_id == 200,
+			"hot reload must preserve the active state by stable id rather than array index");
+		Require(instance.SetFloat("Speed", 0.25f) && instance.SetTrigger("Jump"),
+			"hot reload must rebind typed parameters after source order changes");
+
+		asset.GetStates()[1].m_id = asset.GetStates()[0].m_id;
+		TVector<std::string> errors;
+		Require(!controller->Initialize(asset, &errors) &&
+			controller->GetRevision() == previousRevision + 1 &&
+			controller->GetStates()[instance.GetActiveStateIndex()].m_id == 200,
+			"an invalid hot reload must retain the last valid immutable runtime graph");
+
+		instance = AnimationControllerInstance{};
+		controller.DestroyObject(allocator);
+	}
+
+	void TestLocalPoseSamplingAndComposition()
+	{
+		auto allocator = Memory::ObjectAllocatorPtr::Make(
+			Memory::EAllocationPolicy::SharedMemory_MultiThreaded);
+		auto animation = AnimationPtr::Make(allocator, FileId{});
+		animation->m_numFrames = 2;
+		animation->m_numBones = 2;
+		animation->m_fps = 1.0f;
+		animation->m_duration = 1.0f;
+		animation->m_parentBoneIndices = { -1, 0 };
+		animation->m_frames = {
+			Math::Transform(glm::vec4(0.0f, 0.0f, 0.0f, 1.0f)),
+			Math::Transform(glm::vec4(1.0f, 0.0f, 0.0f, 1.0f)),
+			Math::Transform(glm::vec4(2.0f, 0.0f, 0.0f, 1.0f)),
+			Math::Transform(glm::vec4(1.0f, 0.0f, 0.0f, 1.0f))
+		};
+
+		TVector<Math::Transform> localPose;
+		uint32_t frameIndex = 0;
+		float lerp = 0.0f;
+		Require(AnimationPose::Sample(
+			animation,
+			0.5f,
+			false,
+			localPose,
+			frameIndex,
+			lerp) &&
+			frameIndex == 0 && NearlyEqual(lerp, 0.5f),
+			"pose sampling must interpolate baked local-space frames by clip time");
+
+		TVector<glm::mat4> globalMatrices;
+		TVector<uint8_t> composeState;
+		Require(AnimationPose::ComposeLocalPose(
+			localPose,
+			animation->m_parentBoneIndices,
+			globalMatrices,
+			composeState),
+			"a valid local bone hierarchy must compose successfully");
+		Require(NearlyEqual(globalMatrices[0][3].x, 1.0f) &&
+			NearlyEqual(globalMatrices[1][3].x, 2.0f),
+			"child matrices must inherit their sampled parent transform exactly once");
+
+		TVector<Math::Transform> destinationPose = localPose;
+		destinationPose[0].m_position.x = 3.0f;
+		TVector<Math::Transform> blendedPose;
+		Require(AnimationPose::BlendLocalPoses(
+			localPose,
+			destinationPose,
+			0.5f,
+			blendedPose) &&
+			NearlyEqual(blendedPose[0].m_position.x, 2.0f),
+			"crossfades must blend sampled local TRS poses before hierarchy composition");
+
+		animation->m_parentBoneIndices = { 1, 0 };
+		Require(!AnimationPose::ComposeLocalPose(
+			localPose,
+			animation->m_parentBoneIndices,
+			globalMatrices,
+			composeState),
+			"cyclic skeletons must be diagnosed without unbounded recursion");
+
+		animation.DestroyObject(allocator);
+	}
 }
 
 int main()
@@ -152,7 +462,11 @@ int main()
 		{ "TimestampValidationAndNonUniformSpan", TestTimestampValidationAndNonUniformSpan },
 		{ "LinearAndStepVectorSampling", TestLinearAndStepVectorSampling },
 		{ "CubicSplineSamplingScalesTangentsByInterval", TestCubicSplineSamplingScalesTangentsByInterval },
-		{ "RotationSamplingProducesNormalizedShortestPath", TestRotationSamplingProducesNormalizedShortestPath }
+		{ "RotationSamplingProducesNormalizedShortestPath", TestRotationSamplingProducesNormalizedShortestPath },
+		{ "AnimationControllerSerializationAndValidation", TestAnimationControllerSerializationAndValidation },
+		{ "AnimationControllerTransitionsAndIndependentInstances", TestAnimationControllerTransitionsAndIndependentInstances },
+		{ "AnimationControllerHotReloadPreservesStableState", TestAnimationControllerHotReloadPreservesStableState },
+		{ "LocalPoseSamplingAndComposition", TestLocalPoseSamplingAndComposition }
 	};
 
 	for (const auto& test : tests)

--- a/Tests/AnimationSamplingContractTests.cpp
+++ b/Tests/AnimationSamplingContractTests.cpp
@@ -343,8 +343,37 @@ namespace
 		Require(first.GetActiveStateIndex() == 0 && !first.IsTransitioning(),
 			"a trigger must be consumed only by the transition that selected it");
 
+		AnimationStateDefinition alternateJump;
+		alternateJump.m_id = 400;
+		alternateJump.m_name = "Alternate Jump";
+		alternateJump.m_clipSlot = "AlternateJump";
+		asset.GetStates().Add(alternateJump);
+		AnimationTransitionDefinition authoredLater;
+		authoredLater.m_id = 1003;
+		authoredLater.m_fromStateId = 100;
+		authoredLater.m_toStateId = 400;
+		authoredLater.m_priority = 10;
+		authoredLater.m_conditions = {
+			AnimationTransitionCondition{
+				.m_parameterId = 4,
+				.m_operation = EAnimationConditionOperation::IsSet
+			}
+		};
+		asset.GetTransitions().Add(std::move(authoredLater));
+		Require(controller->Initialize(asset),
+			"equal-priority transition fixture must compile");
+		AnimationControllerInstance authoredOrder;
+		Require(authoredOrder.SetController(controller) &&
+			authoredOrder.SetTrigger("Jump"),
+			"equal-priority transition fixture must accept its trigger");
+		authoredOrder.Tick(0.0f, 1.0f);
+		Require(authoredOrder.IsTransitioning() &&
+			controller->GetStates()[authoredOrder.GetDestinationStateIndex()].m_id == 300,
+			"equal-priority transitions must select the first authored transition deterministically");
+
 		first = AnimationControllerInstance{};
 		second = AnimationControllerInstance{};
+		authoredOrder = AnimationControllerInstance{};
 		controller.DestroyObject(allocator);
 	}
 

--- a/Tests/AnimationSamplingContractTests.cpp
+++ b/Tests/AnimationSamplingContractTests.cpp
@@ -265,10 +265,30 @@ namespace
 			NearlyEqual(roundTrip.GetStates()[0].m_editorY, 20.0f),
 			"animation controller YAML must retain source-controlled editor layout");
 
+		YAML::Node invalidParameterType = source.Serialize();
+		invalidParameterType["parameters"][0]["type"] = "Vector";
+		AnimationControllerAsset invalidParameterAsset;
+		invalidParameterAsset.Deserialize(invalidParameterType);
+		Require(invalidParameterAsset.GetParameters()[0].m_type ==
+			EAnimationParameterType::Invalid,
+			"unknown animation parameter types must not become Float");
+
+		YAML::Node invalidConditionOperation = source.Serialize();
+		invalidConditionOperation["transitions"][0]["conditions"][0]["operation"] = "Approximate";
+		AnimationControllerAsset invalidOperationAsset;
+		invalidOperationAsset.Deserialize(invalidConditionOperation);
+		Require(invalidOperationAsset.GetTransitions()[0].m_conditions[0].m_operation ==
+			EAnimationConditionOperation::Invalid,
+			"unknown animation condition operations must not become Equal");
+
 		auto allocator = Memory::ObjectAllocatorPtr::Make(
 			Memory::EAllocationPolicy::SharedMemory_MultiThreaded);
 		auto controller = AnimationControllerPtr::Make(allocator, FileId{});
 		TVector<std::string> errors;
+		Require(!controller->Initialize(invalidParameterAsset, &errors) && !errors.IsEmpty(),
+			"unknown animation parameter types must fail graph validation");
+		Require(!controller->Initialize(invalidOperationAsset, &errors) && !errors.IsEmpty(),
+			"unknown animation condition operations must fail graph validation");
 		Require(controller->Initialize(roundTrip, &errors) && errors.IsEmpty(),
 			"a valid controller graph must compile without diagnostics");
 
@@ -448,6 +468,27 @@ namespace
 			controller->GetRevision() == lastValidRevision &&
 			controller->GetStates()[instance.GetActiveStateIndex()].m_id == 100,
 			"an invalid hot reload must retain the last valid immutable runtime graph");
+
+		Require(instance.SetController(controller) && instance.SetBool("Speed", false),
+			"active-state reset fixture must restart the last valid controller");
+		instance.Tick(0.75f, 1.0f);
+		Require(NearlyEqual(instance.GetActiveStateTime(), 0.75f),
+			"active-state reset fixture must accumulate playback time");
+
+		AnimationControllerAsset fallbackAsset;
+		fallbackAsset.SetDefaultStateId(300);
+		fallbackAsset.GetStates().Add(AnimationStateDefinition{
+			.m_id = 300,
+			.m_name = "Fallback",
+			.m_clipSlot = "Fallback"
+		});
+		Require(controller->Initialize(fallbackAsset),
+			"a hot reload may remove the previously active state");
+		instance.Tick(0.0f, 1.0f);
+		Require(controller->GetStates()[instance.GetActiveStateIndex()].m_id == 300 &&
+			NearlyEqual(instance.GetActiveStateTime(), 0.0f) &&
+			!instance.IsTransitioning(),
+			"a removed active state must fall back with a fresh clock and no stale transition");
 
 		instance = AnimationControllerInstance{};
 		controller.DestroyObject(allocator);

--- a/Tests/AnimationSamplingContractTests.cpp
+++ b/Tests/AnimationSamplingContractTests.cpp
@@ -1,0 +1,174 @@
+#include "AssetRegistry/Animation/AnimationClipSampler.h"
+
+#include <cmath>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+using namespace Sailor;
+
+namespace
+{
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	bool NearlyEqual(float lhs, float rhs, float epsilon = 0.0001f)
+	{
+		return std::abs(lhs - rhs) <= epsilon;
+	}
+
+	void TestTimestampValidationAndNonUniformSpan()
+	{
+		Require(!AnimationClipSampler::ValidateTimestamps({}),
+			"empty timestamp arrays must be rejected");
+		Require(!AnimationClipSampler::ValidateTimestamps({ -1.0f, 0.0f }),
+			"negative glTF timestamps must be rejected");
+		Require(!AnimationClipSampler::ValidateTimestamps({ 0.0f, 0.0f }),
+			"duplicate glTF timestamps must be rejected");
+		Require(!AnimationClipSampler::ValidateTimestamps({
+			0.0f,
+			(std::numeric_limits<float>::quiet_NaN)()
+		}), "non-finite glTF timestamps must be rejected");
+
+		AnimationKeyframeSpan span;
+		Require(AnimationClipSampler::ResolveKeyframeSpan(
+			{ 0.0f, 0.25f, 2.0f },
+			1.125f,
+			span), "valid non-uniform timestamps must resolve");
+		Require(span.m_first == 1 && span.m_second == 2,
+			"sampling must select keyframes by time rather than array index");
+		Require(NearlyEqual(span.m_alpha, 0.5f) && NearlyEqual(span.m_duration, 1.75f),
+			"non-uniform keyframe interpolation must use the selected time interval");
+	}
+
+	void TestLinearAndStepVectorSampling()
+	{
+		const TVector<float> timestamps{ 0.0f, 2.0f };
+		const TVector<glm::vec4> values{
+			glm::vec4(0.0f),
+			glm::vec4(10.0f, 4.0f, -2.0f, 0.0f)
+		};
+
+		glm::vec4 sampled;
+		Require(AnimationClipSampler::SampleVector(
+			timestamps,
+			values,
+			EAnimationInterpolation::Linear,
+			0.5f,
+			sampled), "LINEAR vector channels must sample");
+		Require(NearlyEqual(sampled.x, 2.5f) &&
+			NearlyEqual(sampled.y, 1.0f) &&
+			NearlyEqual(sampled.z, -0.5f),
+			"LINEAR vector channels must interpolate using glTF timestamps");
+
+		Require(AnimationClipSampler::SampleVector(
+			timestamps,
+			values,
+			EAnimationInterpolation::Step,
+			1.999f,
+			sampled), "STEP vector channels must sample");
+		Require(NearlyEqual(sampled.x, 0.0f),
+			"STEP vector channels must retain the preceding keyframe");
+
+		Require(AnimationClipSampler::SampleVector(
+			timestamps,
+			values,
+			EAnimationInterpolation::Step,
+			2.0f,
+			sampled) && NearlyEqual(sampled.x, 10.0f),
+			"STEP vector channels must reach the final keyframe at its timestamp");
+	}
+
+	void TestCubicSplineSamplingScalesTangentsByInterval()
+	{
+		const TVector<float> timestamps{ 0.0f, 2.0f };
+		const TVector<glm::vec4> values{
+			glm::vec4(0.0f),
+			glm::vec4(0.0f),
+			glm::vec4(2.0f, 0.0f, 0.0f, 0.0f),
+			glm::vec4(2.0f, 0.0f, 0.0f, 0.0f),
+			glm::vec4(4.0f, 0.0f, 0.0f, 0.0f),
+			glm::vec4(0.0f)
+		};
+
+		glm::vec4 sampled;
+		Require(AnimationClipSampler::SampleVector(
+			timestamps,
+			values,
+			EAnimationInterpolation::CubicSpline,
+			1.0f,
+			sampled), "CUBICSPLINE vector channels must sample");
+		Require(NearlyEqual(sampled.x, 2.0f),
+			"CUBICSPLINE tangents must be scaled by the keyframe interval");
+	}
+
+	void TestRotationSamplingProducesNormalizedShortestPath()
+	{
+		const float halfSqrt = std::sqrt(0.5f);
+		glm::quat sampled;
+		Require(AnimationClipSampler::SampleRotation(
+			{ 0.0f, 1.0f },
+			{
+				glm::vec4(0.0f, 0.0f, 0.0f, 1.0f),
+				glm::vec4(0.0f, 0.0f, 0.0f, -1.0f)
+			},
+			EAnimationInterpolation::Linear,
+			0.5f,
+			sampled), "LINEAR rotation channels must sample");
+		Require(NearlyEqual(std::abs(sampled.w), 1.0f),
+			"LINEAR quaternion sampling must use the shortest normalized path");
+
+		Require(AnimationClipSampler::SampleRotation(
+			{ 0.0f, 1.0f },
+			{
+				glm::vec4(0.0f),
+				glm::vec4(0.0f, 0.0f, 0.0f, 1.0f),
+				glm::vec4(0.0f),
+				glm::vec4(0.0f),
+				glm::vec4(0.0f, 0.0f, 1.0f, 0.0f),
+				glm::vec4(0.0f)
+			},
+			EAnimationInterpolation::CubicSpline,
+			0.5f,
+			sampled), "CUBICSPLINE rotation channels must sample");
+		Require(NearlyEqual(sampled.z, halfSqrt) &&
+			NearlyEqual(sampled.w, halfSqrt) &&
+			NearlyEqual(glm::length(sampled), 1.0f),
+			"CUBICSPLINE quaternion output must be normalized after Hermite interpolation");
+	}
+}
+
+int main()
+{
+	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "TimestampValidationAndNonUniformSpan", TestTimestampValidationAndNonUniformSpan },
+		{ "LinearAndStepVectorSampling", TestLinearAndStepVectorSampling },
+		{ "CubicSplineSamplingScalesTangentsByInterval", TestCubicSplineSamplingScalesTangentsByInterval },
+		{ "RotationSamplingProducesNormalizedShortestPath", TestRotationSamplingProducesNormalizedShortestPath }
+	};
+
+	for (const auto& test : tests)
+	{
+		try
+		{
+			test.second();
+			std::cout << "[PASS] " << test.first << std::endl;
+		}
+		catch (const std::exception& error)
+		{
+			std::cerr << "[FAIL] " << test.first << ": "
+				<< error.what() << std::endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/Tests/AnimationSamplingContractTests.cpp
+++ b/Tests/AnimationSamplingContractTests.cpp
@@ -409,11 +409,44 @@ namespace
 		Require(instance.SetFloat("Speed", 0.25f) && instance.SetTrigger("Jump"),
 			"hot reload must rebind typed parameters after source order changes");
 
+		for (auto& parameter : asset.GetParameters())
+		{
+			if (parameter.m_id == 1)
+			{
+				parameter.m_type = EAnimationParameterType::Bool;
+				parameter.m_defaultBool = true;
+				break;
+			}
+		}
+		asset.GetTransitions()[0].m_conditions[0].m_operation =
+			EAnimationConditionOperation::Equal;
+		asset.GetTransitions()[0].m_conditions[0].m_boolValue = true;
+		AnimationTransitionDefinition resetChangedType;
+		resetChangedType.m_id = 2000;
+		resetChangedType.m_fromStateId = 200;
+		resetChangedType.m_toStateId = 100;
+		resetChangedType.m_duration = 0.0f;
+		resetChangedType.m_conditions = {
+			AnimationTransitionCondition{
+				.m_parameterId = 1,
+				.m_operation = EAnimationConditionOperation::Equal,
+				.m_boolValue = true
+			}
+		};
+		asset.GetTransitions().Add(std::move(resetChangedType));
+		Require(controller->Initialize(asset),
+			"a compatible graph with a changed parameter type must hot reload");
+		instance.Tick(0.0f, 1.0f);
+		Require(controller->GetStates()[instance.GetActiveStateIndex()].m_id == 100 &&
+			!instance.SetFloat("Speed", 0.5f) && instance.SetBool("Speed", false),
+			"hot reload must reset a stable parameter id to its new typed default");
+
+		const uint64_t lastValidRevision = controller->GetRevision();
 		asset.GetStates()[1].m_id = asset.GetStates()[0].m_id;
 		TVector<std::string> errors;
 		Require(!controller->Initialize(asset, &errors) &&
-			controller->GetRevision() == previousRevision + 1 &&
-			controller->GetStates()[instance.GetActiveStateIndex()].m_id == 200,
+			controller->GetRevision() == lastValidRevision &&
+			controller->GetStates()[instance.GetActiveStateIndex()].m_id == 100,
 			"an invalid hot reload must retain the last valid immutable runtime graph");
 
 		instance = AnimationControllerInstance{};

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -1,6 +1,7 @@
 #include "AssetRegistry/AssetCache.h"
 #include "AssetRegistry/AssetScanSourceRevisionCache.h"
 #include "AssetRegistry/Animation/AnimationAssetInfo.h"
+#include "AssetRegistry/Animation/AnimationControllerAssetInfo.h"
 #include "AssetRegistry/AssetInfo.h"
 #include "AssetRegistry/AssetRegistry.h"
 #include "AssetRegistry/FrameGraph/FrameGraphAssetInfo.h"
@@ -394,6 +395,8 @@ namespace
 	{
 		RequireSerializedAssetInfoType<AssetInfo>("Sailor::AssetInfo");
 		RequireSerializedAssetInfoType<AnimationAssetInfo>("Sailor::AnimationAssetInfo");
+		RequireSerializedAssetInfoType<AnimationControllerAssetInfo>("Sailor::AnimationControllerAssetInfo");
+		RequireSerializedAssetInfoType<AnimationSetAssetInfo>("Sailor::AnimationSetAssetInfo");
 		RequireSerializedAssetInfoType<FrameGraphAssetInfo>("Sailor::FrameGraphAssetInfo");
 		RequireSerializedAssetInfoType<MaterialAssetInfo>("Sailor::MaterialAssetInfo");
 		RequireSerializedAssetInfoType<ModelAssetInfo>("Sailor::ModelAssetInfo");

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -71,6 +71,10 @@ add_executable(ModelImporterContractTests
     ModelImporterContractTests.cpp
 )
 
+add_executable(AnimationSamplingContractTests
+    AnimationSamplingContractTests.cpp
+)
+
 add_executable(VulkanDescriptorCacheTests
     VulkanDescriptorCacheTests.cpp
 )
@@ -213,6 +217,7 @@ target_compile_definitions(GpuCullingContractTests PRIVATE
     SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
 )
 target_compile_features(ModelImporterContractTests PRIVATE cxx_std_20)
+target_compile_features(AnimationSamplingContractTests PRIVATE cxx_std_20)
 target_compile_features(VulkanDescriptorCacheTests PRIVATE cxx_std_20)
 target_compile_definitions(VulkanDescriptorCacheTests PRIVATE
     SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
@@ -268,6 +273,7 @@ target_link_libraries(EcsLifecycleContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(BoundsContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(GpuCullingContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(ModelImporterContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(AnimationSamplingContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(VulkanDescriptorCacheTests PRIVATE Sailor::Runtime)
 target_link_libraries(EditorViewportControllerContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(SkyComponentContractTests PRIVATE Sailor::Runtime)
@@ -368,6 +374,9 @@ target_include_directories(GpuCullingContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(ModelImporterContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(AnimationSamplingContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(VulkanDescriptorCacheTests PRIVATE
@@ -507,6 +516,11 @@ add_test(
 )
 
 add_test(
+    NAME AnimationSamplingContractTests
+    COMMAND AnimationSamplingContractTests
+)
+
+add_test(
     NAME VulkanDescriptorCacheTests
     COMMAND VulkanDescriptorCacheTests
 )
@@ -617,6 +631,7 @@ set_tests_properties(
     BoundsContractTests
     GpuCullingContractTests
     ModelImporterContractTests
+    AnimationSamplingContractTests
     VulkanDescriptorCacheTests
     EditorViewportControllerContractTests
     SkyComponentContractTests

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -926,6 +926,16 @@ namespace
 		system.GetComponentData(survivingAnimator).m_gpuOffset = allocatedOffset;
 		system.GetComponentData(survivingAnimator).SetBonesCount(10);
 
+		auto allocator = Memory::ObjectAllocatorPtr::Make(
+			Memory::EAllocationPolicy::SharedMemory_MultiThreaded);
+		auto sameSkeleton = AnimationPtr::Make(allocator, FileId{});
+		sameSkeleton->m_numBones = 10;
+		system.SetAnimation(replacedAnimator, sameSkeleton);
+		Require(system.GetComponentData(replacedAnimator).m_gpuOffset == 0 &&
+			system.GetComponentData(survivingAnimator).m_gpuOffset == 10 &&
+			system.GetNextBoneOffsetForTest() == 20,
+			"switching animation data without changing the skeleton size must preserve every GPU bone range");
+
 		system.SetAnimation(replacedAnimator, TObjectPtr<Animation>());
 		Require(system.GetComponentData(replacedAnimator).m_gpuOffset == invalidOffset &&
 			system.GetComponentData(survivingAnimator).m_gpuOffset == invalidOffset,
@@ -955,6 +965,8 @@ namespace
 		Require(!AnimationECS::TryAllocateBoneRange(1, nextOffset, allocatedOffset) &&
 			nextOffset == AnimationECS::BonesMaxNum + 1 && allocatedOffset == invalidOffset,
 			"an out-of-range cursor should be rejected without unsigned-capacity underflow");
+
+		sameSkeleton.DestroyObject(allocator);
 
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string shaderSource = ReadText(sourceRoot / "Content/Shaders/Standard_glTF.shader");

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1138,6 +1138,53 @@ namespace
 			"an editor empty-world bootstrap must use the untitled scene name");
 	}
 
+	void TestEditorWorldReplacementRetiresRenderFramesContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string rendererHeader = ReadText(sourceRoot / "Runtime/RHI/Renderer.h");
+		const std::string rendererSource = ReadText(sourceRoot / "Runtime/RHI/Renderer.cpp");
+		const std::string engineLoopSource = ReadText(sourceRoot / "Runtime/Engine/EngineLoop.cpp");
+		const std::string appSource = ReadText(sourceRoot / "Runtime/Sailor.cpp");
+
+		Require(rendererHeader.find("SAILOR_API void WaitIdle()") != std::string::npos,
+			"renderer must expose a world-retirement barrier");
+		const size_t waitIdleBegin = rendererSource.find("void Renderer::WaitIdle()");
+		Require(waitIdleBegin != std::string::npos,
+			"renderer must implement its world-retirement barrier");
+		const std::string waitIdleBody = rendererSource.substr(waitIdleBegin);
+		const size_t waitRenderFrame = waitIdleBody.find("m_previousRenderFrame->Wait()");
+		const size_t waitGpu = waitIdleBody.find("m_driverInstance->WaitIdle()");
+		Require(waitRenderFrame != std::string::npos && waitGpu != std::string::npos &&
+			waitRenderFrame < waitGpu,
+			"world retirement must drain the latest chained render frame before waiting for GPU idle");
+
+		const size_t processExitsBegin = engineLoopSource.find(
+			"void EngineLoop::ProcessPendingWorldExits()");
+		const size_t processExitsEnd = engineLoopSource.find(
+			"void EngineLoop::ProcessPendingDependencyResolution", processExitsBegin);
+		Require(processExitsBegin != std::string::npos && processExitsEnd != std::string::npos,
+			"engine loop must expose pending world retirement");
+		const std::string processExitsBody = engineLoopSource.substr(
+			processExitsBegin,
+			processExitsEnd - processExitsBegin);
+		const size_t flushRenderer = processExitsBody.find("renderer->WaitIdle()");
+		const size_t clearWorld = processExitsBody.find("m_worlds[index]->Clear()");
+		Require(flushRenderer != std::string::npos && clearWorld != std::string::npos &&
+			flushRenderer < clearWorld,
+			"pending world retirement must drain renderer work before clearing ECS storage");
+
+		const size_t startBegin = appSource.find("void App::Start()");
+		const size_t startEnd = appSource.find("void App::Stop()", startBegin);
+		Require(startBegin != std::string::npos && startEnd != std::string::npos,
+			"application must expose its engine main loop");
+		const std::string startBody = appSource.substr(startBegin, startEnd - startBegin);
+		Require(startBody.find(
+			"currentFrame.GetWorld() != pEngineLoop->GetWorld().GetRawPtr()") != std::string::npos &&
+			startBody.find("bCanCreateNewFrame = true") != std::string::npos &&
+			startBody.find("bFirstFrame = true") != std::string::npos,
+			"the engine main loop must replace a stale frame immediately after an editor world switch");
+	}
+
 	void TestAnimationRelayoutMarksEveryOwnedMeshDirty()
 	{
 		AnimationMeshTestWorld world;
@@ -3556,6 +3603,7 @@ int main()
 		{ "ExpiredWorldPrefabInvalidatesLoadedCacheContract", TestExpiredWorldPrefabInvalidatesLoadedCacheContract },
 		{ "EmptyEditorWorldBootstrapContract", TestEmptyEditorWorldBootstrapContract },
 		{ "WorkspaceEditorStartupWorldContract", TestWorkspaceEditorStartupWorldContract },
+		{ "EditorWorldReplacementRetiresRenderFramesContract", TestEditorWorldReplacementRetiresRenderFramesContract },
 		{ "AnimationRelayoutMarksEveryOwnedMeshDirty", TestAnimationRelayoutMarksEveryOwnedMeshDirty },
 		{ "SparseLightSlotInvalidationAndReuse", TestSparseLightSlotInvalidationAndReuse },
 		{ "RemovingComponentCancelsPendingDependencyResolution", TestRemovingComponentCancelsPendingDependencyResolution },

--- a/Tests/EditorEngineProtocolTests.cpp
+++ b/Tests/EditorEngineProtocolTests.cpp
@@ -51,6 +51,7 @@ namespace
 	constexpr uint32_t c_uint64ResultField = 14;
 	constexpr uint32_t c_viewportEventBatchResultField = 19;
 	constexpr uint32_t c_viewportToolStateResultField = 21;
+	constexpr uint32_t c_animatorStateResultField = 22;
 	constexpr uint32_t c_emptyResultField = 10;
 	constexpr uint32_t c_initializeCommandField = 10;
 	constexpr uint32_t c_startCommandField = 11;
@@ -64,6 +65,7 @@ namespace
 	constexpr uint32_t c_isEngineRunningCommandField = 48;
 	constexpr uint32_t c_instantiatePrefabFromYamlCommandField = 42;
 	constexpr uint32_t c_createModelInstanceCommandField = 58;
+	constexpr uint32_t c_setAnimatorParameterCommandField = 59;
 
 	void Require(bool condition, const std::string& message)
 	{
@@ -267,7 +269,7 @@ namespace
 					static_cast<size_t>(length));
 			}
 			else if (fieldNumber >= 10u &&
-				fieldNumber <= c_viewportToolStateResultField)
+				fieldNumber <= c_animatorStateResultField)
 			{
 				response.m_resultField = fieldNumber;
 				response.m_resultPayload.assign(
@@ -931,6 +933,37 @@ namespace
 				response.m_resultField == 0,
 				"missing command must return a correlated protocol error");
 		}
+	}
+
+	void TestAnimatorParameterRequiresTypedValue()
+	{
+		Sailor::Protocol::TEditorEngineProtocolLifecycleGate gate;
+		std::string admissionError;
+		Require(
+			gate.TryBeginInitialization(admissionError),
+			"animator protocol fixture lifecycle must initialize");
+		gate.CompleteInitialization(true);
+
+		Sailor::Protocol::EditorEngineProtocolDependencies dependencies{};
+		dependencies.m_lifecycleGate = &gate;
+		std::string parameterRequest;
+		AppendMessageField(parameterRequest, 1u, "Animator-1");
+		AppendMessageField(parameterRequest, 2u, "Speed");
+
+		TProtocolBuffer buffer;
+		const auto response = RequireProtocolResponse(
+			MakeRequest(
+				EditorEngineProtocolVersion,
+				27,
+				c_setAnimatorParameterCommandField,
+				parameterRequest),
+			buffer,
+			dependencies);
+		Require(
+			!response.m_success &&
+				response.m_error.find("value is not set") != std::string::npos &&
+				response.m_resultField == 0,
+			"animator parameter mutations must carry exactly one typed value");
 	}
 
 	void TestStrictInstanceIdProtocolGate()
@@ -2006,6 +2039,7 @@ int main()
 		TestOversizedAndMalformedPayloads();
 		TestCommandExceptionIsContainedByTransportBoundary();
 		TestEnvelopeValidation();
+		TestAnimatorParameterRequiresTypedValue();
 		TestStrictInstanceIdProtocolGate();
 		TestModelInstanceWireContract();
 		TestEmbeddedNullIsRejected();

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -789,6 +789,117 @@ namespace
 			"render and depth passes must upload each RHIMesh baked volume scale");
 	}
 
+	void TestDepthPrepassSkinningContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string depthShader = ReadText(
+			sourceRoot / "Content/Shaders/DepthOnly.shader");
+		Require(depthShader.find("- SKINNING") != std::string::npos &&
+			depthShader.find("DefaultBoneIdsBinding") != std::string::npos &&
+			depthShader.find("DefaultBoneWeightsBinding") != std::string::npos &&
+			depthShader.find("layout(std430, set = 2, binding = 0) readonly buffer BoneMatricesSSBO") != std::string::npos &&
+			depthShader.find("data.instance[gl_InstanceIndex].skeletonOffset") != std::string::npos &&
+			depthShader.find("modelMatrix *= skinMatrix") != std::string::npos,
+			"the skinned depth permutation must apply the scene bone palette before projection");
+
+		const std::string depthPrepassSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/DepthPrepassNode.cpp");
+		const std::string getDepthMaterialBody = ExtractFunctionBody(
+			depthPrepassSource,
+			"RHI::RHIMaterialPtr DepthPrepassNode::GetOrAddDepthMaterial(");
+		Require(getDepthMaterialBody.find("m_skinnedDepthOnlyMaterials") != std::string::npos &&
+			getDepthMaterialBody.find("defines.Add(\"SKINNING\")") != std::string::npos,
+			"DepthPrepass must cache a separate material for the skinned shader permutation");
+
+		const std::string prepareBody = ExtractFunctionBody(
+			depthPrepassSource,
+			"Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(");
+		Require(prepareBody.find("proxy.m_skeletonOffset") != std::string::npos &&
+			prepareBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding)") != std::string::npos &&
+			prepareBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding)") != std::string::npos &&
+			prepareBody.find("GetOrAddDepthMaterial(mesh->m_vertexDescription, bSkinned)") != std::string::npos,
+			"DepthPrepass must select its skinned material from both the skeleton offset and the concrete mesh vertex layout");
+	}
+
+	void TestShadowPrepassSkinningContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string shadowShader = ReadText(
+			sourceRoot / "Content/Shaders/ShadowCaster.shader");
+		Require(shadowShader.find("- SKINNING") != std::string::npos &&
+			shadowShader.find("DefaultBoneIdsBinding") != std::string::npos &&
+			shadowShader.find("DefaultBoneWeightsBinding") != std::string::npos &&
+			shadowShader.find("layout(std430, set = 2, binding = 0) readonly buffer BoneMatricesSSBO") != std::string::npos &&
+			shadowShader.find("data.instance[gl_InstanceIndex].skeletonOffset") != std::string::npos &&
+			shadowShader.find("modelMatrix *= skinMatrix") != std::string::npos,
+			"the skinned shadow permutation must apply the scene bone palette before light projection");
+
+		const std::string shadowPrepassSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
+		const std::string getShadowMaterialBody = ExtractFunctionBody(
+			shadowPrepassSource,
+			"RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddShadowMaterial(");
+		Require(getShadowMaterialBody.find("m_skinnedShadowMaterials_Evsm") != std::string::npos &&
+			getShadowMaterialBody.find("m_skinnedShadowMaterials_Pcf") != std::string::npos &&
+			getShadowMaterialBody.find("defines.Add(\"SKINNING\")") != std::string::npos,
+			"PCF and EVSM shadow passes must cache separate skinned shader permutations");
+
+		const std::string processBody = ExtractFunctionBody(
+			shadowPrepassSource,
+			"void ShadowPrepassNode::Process(");
+		Require(processBody.find("proxy.m_skeletonOffset") != std::string::npos &&
+			processBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding)") != std::string::npos &&
+			processBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding)") != std::string::npos &&
+			processBody.find("GetOrAddShadowMaterial(mesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned)") != std::string::npos &&
+			processBody.find("sets.Add(sceneView.m_boneMatrices)") != std::string::npos,
+			"ShadowPrepass must select skinned batches and bind the current bone matrices");
+	}
+
+	void TestVertexDescriptionAttributeIdentityContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string vertexDescriptionSource = ReadText(
+			sourceRoot / "Runtime/RHI/VertexDescription.cpp");
+		Require(vertexDescriptionSource.find("SetAttributeFormat(m_bits, location, format)") != std::string::npos &&
+			vertexDescriptionSource.find("attribute.m_location == location") != std::string::npos,
+			"vertex descriptions must identify and query attributes by shader location, not buffer binding");
+	}
+
+	void TestGraphicsPipelineAttachmentCacheContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string materialSource = ReadText(
+			sourceRoot / "Runtime/RHI/Material.cpp");
+		const std::string getPipelineBody = ExtractFunctionBody(
+			materialSource,
+			"GraphicsDriver::Vulkan::VulkanGraphicsPipelinePtr RHIMaterial::Vulkan::GetOrAddPipeline(");
+		Require(getPipelineBody.find("ComputeAspectFlagsForFormat(depthStencilAttachment)") != std::string::npos &&
+			getPipelineBody.find("Fits(colorAttachments, depthStencilAttachment, stencilAttachmentFormat)") != std::string::npos,
+			"graphics pipeline lookup must compare a depth-only attachment with an undefined stencil format");
+		Require(getPipelineBody.find("m_pipelinesLock.Lock()") != std::string::npos &&
+			getPipelineBody.find("m_pipelinesLock.Unlock()") != std::string::npos,
+			"parallel command-list recording must serialize graphics pipeline cache misses");
+
+		const std::string pipelineStatesSource = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanPipileneStates.cpp");
+		const std::string buildPipelineBody = ExtractFunctionBody(
+			pipelineStatesSource,
+			"const TVector<VulkanPipelineStatePtr>& VulkanPipelineStateBuilder::BuildPipeline(");
+		Require(buildPipelineBody.find("vertexDescription->GetVertexStride()") != std::string::npos &&
+			buildPipelineBody.find("vertexDescription->GetAttributeDescriptions()") != std::string::npos &&
+			buildPipelineBody.find("vertexAttributeBindings.ToVector()") != std::string::npos &&
+			buildPipelineBody.find("orderedVertexAttributeBindings.Sort()") != std::string::npos,
+			"pipeline-state cache identity must include the concrete vertex layout and shader input locations");
+
+		const std::string pipelineSource = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanPipeline.cpp");
+		const std::string commandBufferSource = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp");
+		Require(pipelineSource.find("result != VK_SUCCESS || m_pipeline == VK_NULL_HANDLE") != std::string::npos &&
+			commandBufferSource.find("if (!m_bGraphicsPipelineBound)") != std::string::npos,
+			"failed graphics pipeline compilation must not record draw commands without a valid pipeline");
+	}
+
 	void TestPostProcessPingPongMipIsolationContract()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -1211,6 +1322,10 @@ int main()
 		{ "TransmissionFramebufferMipContract", TestTransmissionFramebufferMipContract },
 		{ "TransmissionFramebufferBindingUsesNodeAttachment", TestTransmissionFramebufferBindingUsesNodeAttachment },
 		{ "BakedVolumeScalePerInstanceLayoutContract", TestBakedVolumeScalePerInstanceLayoutContract },
+		{ "DepthPrepassSkinningContract", TestDepthPrepassSkinningContract },
+		{ "ShadowPrepassSkinningContract", TestShadowPrepassSkinningContract },
+		{ "VertexDescriptionAttributeIdentityContract", TestVertexDescriptionAttributeIdentityContract },
+		{ "GraphicsPipelineAttachmentCacheContract", TestGraphicsPipelineAttachmentCacheContract },
 		{ "PostProcessPingPongMipIsolationContract", TestPostProcessPingPongMipIsolationContract },
 		{ "TransparentBackToFrontOrderingContract", TestTransparentBackToFrontOrderingContract },
 		{ "ShadowCasterRenderQueueContract", TestShadowCasterRenderQueueContract },

--- a/Tests/WorkspaceModuleContractTests.cpp
+++ b/Tests/WorkspaceModuleContractTests.cpp
@@ -38,6 +38,13 @@ namespace RangeAnnotationFixture
 	};
 }
 
+namespace StableTypeNameFixture
+{
+	class ProjectAsset
+	{
+	};
+}
+
 REFL_AUTO(
 	type(RangeAnnotationFixture::NumericProperties),
 	func(GetSignedValue, property("signedValue"), Sailor::Attributes::Range(-10.0, 10.0)),
@@ -475,6 +482,11 @@ namespace
 	{
 		Require(TypeInfo::GetReflectedPropertyTypeName<uint32_t>() == "uint32",
 			"workspace metadata should use a platform-independent uint32 property name");
+		Require(
+			TypeInfo::GetReflectedPropertyTypeName<
+				TObjectPtr<StableTypeNameFixture::ProjectAsset>>() ==
+				"TObjectPtr<StableTypeNameFixture::ProjectAsset>",
+			"workspace metadata should export canonical TObjectPtr pointee types without compiler mangling");
 	}
 
 	void TestEngineRangeAnnotation()


### PR DESCRIPTION
## Summary

- fixes timestamp-aware glTF animation sampling, including `LINEAR`, `STEP`, and `CUBICSPLINE`
- adds native `.animcontroller` and `.animset` assets with validation, import, hot reload, and reflected metadata
- adds independent Animator state-machine instances with typed parameters, transitions, exit time, and cross-fades
- evaluates and blends local poses before composing the skeleton hierarchy
- adds the Editor controller graph, undo/redo, live Scene View preview, and async WebSocket runtime controls
- preserves direct-animation fallback when no controller is assigned
- renders skinned meshes consistently in the main, depth-prepass, and shadow-prepass paths
- fixes per-batch material/texture binding identity and transparent glTF material queues
- keeps Inspector selection stable while lazily resolving and revealing referenced assets
- exports canonical `TObjectPtr<Namespace::Type>` metadata so drag-and-drop type validation works for every engine or project component without compiler-specific hardcoding

## Runtime design

The controller asset owns stable state, transition, and parameter IDs. The animation-set asset maps logical clip slots to animation `FileId`s. Each `AnimatorComponent` owns its runtime clocks, transition state, and parameter values, so GameObjects sharing one controller do not share playback state.

Transitions are evaluated by priority and authored order. Conditions support float, int, bool, and trigger values; triggers are consumed by the selected transition. Cross-fades blend local poses before hierarchy composition.

Imported animations retain rest-pose hierarchy data and a skeleton signature. Missing or incompatible clips produce diagnostics and fall back safely. Hot reload preserves compatible active states and parameters while resetting stable parameters whose type changed.

## Editor and rendering integration

- Content context menus can create Animation Controller and Animation Set assets
- dropping a clip onto the graph creates a state through the existing command/undo infrastructure
- the selected Animator drives a live graph preview and runtime parameter controls through the WebSocket protocol
- Inspector asset fields are typed from canonical reflected pointer metadata, including arbitrary project-defined `TObjectPtr<T>` properties
- referenced assets are resolved lazily and selected in Content without clearing the Inspector selection first
- depth and shadow passes consume animation bone matrices and invalidate with animated scene changes
- render batching tracks texture-binding identity independently from material identity

## Validation

- Release Editor contracts: 732/732 passed
- Release `WorkspaceModuleContractTests`: 7/7 passed
- Release `EcsLifecycleContractTests`: passed
- Release `GpuCullingContractTests`: passed
- Release `AnimationSamplingContractTests`: passed
- Release `VulkanDescriptorCacheTests`: passed
- Release Engine and Editor build succeeded
- macOS Release Editor/Engine launch and viewport smoke passed
- generated Engine/Editor type caches contain canonical `TObjectPtr<Sailor::...>` names with no clang-mangled fallback
- `git diff --check` passed

## Scope

Only source and test files are included in the latest commit. No files from `Content/**` are part of this PR, and no third-party animation dependency is introduced.

Part of #142.