### PR TITLE
Integrate Jolt physics and Editor simulation

### DIFF
--- a/Content/Tests/Physics/PhysicsFallingBodies.world
+++ b/Content/Tests/Physics/PhysicsFallingBodies.world
@@ -1,0 +1,336 @@
+name: PhysicsFallingBodies
+prefabs:
+  - gameObjects:
+      - name: Camera
+        position:
+          - 0
+          - 7
+          - 18
+          - 1
+        rotation:
+          - 0.17364818
+          - 0
+          - 0
+          - 0.98480775
+        scale:
+          - 1
+          - 1
+          - 1
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14100000000000000001
+        components:
+          - 0
+    components:
+      - typename: Sailor::CameraComponent
+        overrideProperties:
+          fov: 60
+          zNear: 0.1
+          zFar: 1000
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000001_14100000000000000001
+  - gameObjects:
+      - name: Sun
+        position:
+          - 0
+          - 10
+          - 5
+          - 1
+        rotation:
+          - 0.183012709
+          - 0.683012724
+          - 0.183012709
+          - 0.683012724
+        scale:
+          - 1
+          - 1
+          - 1
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14100000000000000002
+        components:
+          - 0
+    components:
+      - typename: Sailor::LightComponent
+        overrideProperties:
+          intensity:
+            - 8
+            - 8
+            - 8
+          lightType: Directional
+          shadowType: PCF
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000002_14100000000000000002
+  - gameObjects:
+      - name: StaticGround
+        position:
+          - 0
+          - -0.5
+          - 0
+          - 1
+        rotation:
+          - 0
+          - 0
+          - 0
+          - 1
+        scale:
+          - 12
+          - 1
+          - 12
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14100000000000000003
+        components:
+          - 0
+          - 1
+          - 2
+    components:
+      - typename: Sailor::MeshRendererComponent
+        overrideProperties:
+          model:
+            fileId: "{2387902B-538E-4191-93D6-53503B5571B1}"
+            instanceId: NullInstanceId
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000003_14100000000000000003
+      - typename: Sailor::RigidBodyComponent
+        overrideProperties:
+          motionType: Static
+          friction: 0.8
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000004_14100000000000000003
+      - typename: Sailor::CollisionShapeComponent
+        overrideProperties:
+          shapeType: Box
+          size:
+            - 1
+            - 1
+            - 1
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000005_14100000000000000003
+  - gameObjects:
+      - name: DynamicBox
+        position:
+          - -2
+          - 5
+          - 0
+          - 1
+        rotation:
+          - 0
+          - 0
+          - 0
+          - 1
+        scale:
+          - 1
+          - 1
+          - 1
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14100000000000000004
+        components:
+          - 0
+          - 1
+          - 2
+    components:
+      - typename: Sailor::MeshRendererComponent
+        overrideProperties:
+          model:
+            fileId: "{2387902B-538E-4191-93D6-53503B5571B1}"
+            instanceId: NullInstanceId
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000006_14100000000000000004
+      - typename: Sailor::RigidBodyComponent
+        overrideProperties:
+          motionType: Dynamic
+          mass: 1
+          restitution: 0.15
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000007_14100000000000000004
+      - typename: Sailor::CollisionShapeComponent
+        overrideProperties:
+          shapeType: Box
+          size:
+            - 1
+            - 1
+            - 1
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000008_14100000000000000004
+  - gameObjects:
+      - name: DynamicSphere
+        position:
+          - 0
+          - 8
+          - 0
+          - 1
+        rotation:
+          - 0
+          - 0
+          - 0
+          - 1
+        scale:
+          - 1
+          - 1
+          - 1
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14100000000000000005
+        components:
+          - 0
+          - 1
+          - 2
+    components:
+      - typename: Sailor::MeshRendererComponent
+        overrideProperties:
+          model:
+            fileId: "{2387902B-538E-4191-93D6-53503B5571B1}"
+            instanceId: NullInstanceId
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000009_14100000000000000005
+      - typename: Sailor::RigidBodyComponent
+        overrideProperties:
+          motionType: Dynamic
+          mass: 1
+          restitution: 0.6
+          fileId: NullFileId
+          instanceId: 1410000000000000000000000000000A_14100000000000000005
+      - typename: Sailor::CollisionShapeComponent
+        overrideProperties:
+          shapeType: Sphere
+          radius: 0.5
+          fileId: NullFileId
+          instanceId: 1410000000000000000000000000000B_14100000000000000005
+  - gameObjects:
+      - name: DynamicCapsule
+        position:
+          - 2
+          - 11
+          - 0
+          - 1
+        rotation:
+          - 0
+          - 0
+          - 0
+          - 1
+        scale:
+          - 1
+          - 2
+          - 1
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14100000000000000006
+        components:
+          - 0
+          - 1
+          - 2
+    components:
+      - typename: Sailor::MeshRendererComponent
+        overrideProperties:
+          model:
+            fileId: "{2387902B-538E-4191-93D6-53503B5571B1}"
+            instanceId: NullInstanceId
+          fileId: NullFileId
+          instanceId: 1410000000000000000000000000000C_14100000000000000006
+      - typename: Sailor::RigidBodyComponent
+        overrideProperties:
+          motionType: Dynamic
+          mass: 1
+          fileId: NullFileId
+          instanceId: 1410000000000000000000000000000D_14100000000000000006
+      - typename: Sailor::CollisionShapeComponent
+        overrideProperties:
+          shapeType: Capsule
+          radius: 0.5
+          height: 1
+          fileId: NullFileId
+          instanceId: 1410000000000000000000000000000E_14100000000000000006
+  - gameObjects:
+      - name: SensorPlatform
+        position:
+          - 5
+          - 3
+          - 0
+          - 1
+        rotation:
+          - 0
+          - 0
+          - 0
+          - 1
+        scale:
+          - 3
+          - 0.25
+          - 3
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14100000000000000007
+        components:
+          - 0
+          - 1
+          - 2
+    components:
+      - typename: Sailor::MeshRendererComponent
+        overrideProperties:
+          model:
+            fileId: "{2387902B-538E-4191-93D6-53503B5571B1}"
+            instanceId: NullInstanceId
+          fileId: NullFileId
+          instanceId: 1410000000000000000000000000000F_14100000000000000007
+      - typename: Sailor::RigidBodyComponent
+        overrideProperties:
+          motionType: Static
+          sensor: true
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000010_14100000000000000007
+      - typename: Sailor::CollisionShapeComponent
+        overrideProperties:
+          shapeType: Box
+          size:
+            - 1
+            - 1
+            - 1
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000011_14100000000000000007
+  - gameObjects:
+      - name: SensorProbe
+        position:
+          - 5
+          - 8
+          - 0
+          - 1
+        rotation:
+          - 0
+          - 0
+          - 0
+          - 1
+        scale:
+          - 1
+          - 1
+          - 1
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14100000000000000008
+        components:
+          - 0
+          - 1
+          - 2
+    components:
+      - typename: Sailor::MeshRendererComponent
+        overrideProperties:
+          model:
+            fileId: "{2387902B-538E-4191-93D6-53503B5571B1}"
+            instanceId: NullInstanceId
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000012_14100000000000000008
+      - typename: Sailor::RigidBodyComponent
+        overrideProperties:
+          motionType: Dynamic
+          mass: 1
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000013_14100000000000000008
+      - typename: Sailor::CollisionShapeComponent
+        overrideProperties:
+          shapeType: Box
+          size:
+            - 1
+            - 1
+            - 1
+          fileId: NullFileId
+          instanceId: 14100000000000000000000000000014_14100000000000000008

--- a/Content/Tests/Physics/PhysicsFallingBodies.world.asset
+++ b/Content/Tests/Physics/PhysicsFallingBodies.world.asset
@@ -1,0 +1,3 @@
+assetInfoType: Sailor::WorldPrefabAssetInfo
+fileId: "{E69F5A5E-4856-44D9-A29E-918B9E9ED141}"
+filename: PhysicsFallingBodies.world

--- a/Content/Tests/Physics/PhysicsHierarchy.world
+++ b/Content/Tests/Physics/PhysicsHierarchy.world
@@ -1,0 +1,219 @@
+name: PhysicsHierarchy
+prefabs:
+  - gameObjects:
+      - name: Camera
+        position:
+          - 0
+          - 8
+          - 18
+          - 1
+        rotation:
+          - 0.17364818
+          - 0
+          - 0
+          - 0.98480775
+        scale:
+          - 1
+          - 1
+          - 1
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14110000000000000001
+        components:
+          - 0
+    components:
+      - typename: Sailor::CameraComponent
+        overrideProperties:
+          fov: 60
+          zNear: 0.1
+          zFar: 1000
+          fileId: NullFileId
+          instanceId: 14110000000000000000000000000001_14110000000000000001
+  - gameObjects:
+      - name: Sun
+        position:
+          - 0
+          - 10
+          - 5
+          - 1
+        rotation:
+          - 0.183012709
+          - 0.683012724
+          - 0.183012709
+          - 0.683012724
+        scale:
+          - 1
+          - 1
+          - 1
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14110000000000000002
+        components:
+          - 0
+    components:
+      - typename: Sailor::LightComponent
+        overrideProperties:
+          intensity:
+            - 8
+            - 8
+            - 8
+          lightType: Directional
+          shadowType: PCF
+          fileId: NullFileId
+          instanceId: 14110000000000000000000000000002_14110000000000000002
+  - gameObjects:
+      - name: StaticGround
+        position:
+          - 0
+          - -0.5
+          - 0
+          - 1
+        rotation:
+          - 0
+          - 0
+          - 0
+          - 1
+        scale:
+          - 12
+          - 1
+          - 12
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14110000000000000003
+        components:
+          - 0
+          - 1
+          - 2
+    components:
+      - typename: Sailor::MeshRendererComponent
+        overrideProperties:
+          model:
+            fileId: "{2387902B-538E-4191-93D6-53503B5571B1}"
+            instanceId: NullInstanceId
+          fileId: NullFileId
+          instanceId: 14110000000000000000000000000003_14110000000000000003
+      - typename: Sailor::RigidBodyComponent
+        overrideProperties:
+          motionType: Static
+          friction: 0.8
+          fileId: NullFileId
+          instanceId: 14110000000000000000000000000004_14110000000000000003
+      - typename: Sailor::CollisionShapeComponent
+        overrideProperties:
+          shapeType: Box
+          size:
+            - 1
+            - 1
+            - 1
+          fileId: NullFileId
+          instanceId: 14110000000000000000000000000005_14110000000000000003
+  - gameObjects:
+      - name: TransformedParent
+        position:
+          - 3
+          - 1
+          - 0
+          - 1
+        rotation:
+          - 0
+          - 0.258819045
+          - 0
+          - 0.965925826
+        scale:
+          - 1.5
+          - 1
+          - 0.75
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14110000000000000004
+        components: []
+      - name: DynamicChild
+        position:
+          - 0
+          - 6
+          - 0
+          - 1
+        rotation:
+          - 0
+          - 0
+          - 0
+          - 1
+        scale:
+          - 1
+          - 1
+          - 1
+          - 1
+        parentIndex: 0
+        instanceId: 14110000000000000005
+        components:
+          - 0
+          - 1
+          - 2
+    components:
+      - typename: Sailor::MeshRendererComponent
+        overrideProperties:
+          model:
+            fileId: "{2387902B-538E-4191-93D6-53503B5571B1}"
+            instanceId: NullInstanceId
+          fileId: NullFileId
+          instanceId: 14110000000000000000000000000006_14110000000000000005
+      - typename: Sailor::RigidBodyComponent
+        overrideProperties:
+          motionType: Dynamic
+          mass: 1
+          fileId: NullFileId
+          instanceId: 14110000000000000000000000000007_14110000000000000005
+      - typename: Sailor::CollisionShapeComponent
+        overrideProperties:
+          shapeType: Box
+          size:
+            - 1
+            - 1
+            - 1
+          fileId: NullFileId
+          instanceId: 14110000000000000000000000000008_14110000000000000005
+  - gameObjects:
+      - name: KinematicBody_MoveWhileSimulating
+        position:
+          - -4
+          - 2
+          - 0
+          - 1
+        rotation:
+          - 0
+          - 0
+          - 0
+          - 1
+        scale:
+          - 2
+          - 0.5
+          - 2
+          - 1
+        parentIndex: 4294967295
+        instanceId: 14110000000000000006
+        components:
+          - 0
+          - 1
+          - 2
+    components:
+      - typename: Sailor::MeshRendererComponent
+        overrideProperties:
+          model:
+            fileId: "{2387902B-538E-4191-93D6-53503B5571B1}"
+            instanceId: NullInstanceId
+          fileId: NullFileId
+          instanceId: 14110000000000000000000000000009_14110000000000000006
+      - typename: Sailor::RigidBodyComponent
+        overrideProperties:
+          motionType: Kinematic
+          fileId: NullFileId
+          instanceId: 1411000000000000000000000000000A_14110000000000000006
+      - typename: Sailor::CollisionShapeComponent
+        overrideProperties:
+          shapeType: Box
+          size:
+            - 1
+            - 1
+            - 1
+          fileId: NullFileId
+          instanceId: 1411000000000000000000000000000B_14110000000000000006

--- a/Content/Tests/Physics/PhysicsHierarchy.world.asset
+++ b/Content/Tests/Physics/PhysicsHierarchy.world.asset
@@ -1,0 +1,3 @@
+assetInfoType: Sailor::WorldPrefabAssetInfo
+fileId: "{A8E48BE7-759A-490A-B4F9-F01C741FA141}"
+filename: PhysicsHierarchy.world

--- a/Editor.Tests/EditorEngineProtocolTests.cs
+++ b/Editor.Tests/EditorEngineProtocolTests.cs
@@ -118,6 +118,8 @@ public sealed class EditorEngineProtocolTests
             ProtocolRequest.IsEngineMainThreadReadyFieldNumber);
         Assert.Equal(48, ProtocolRequest.IsEngineRunningFieldNumber);
         Assert.Equal(57, ProtocolRequest.UpdateAssetFieldNumber);
+        Assert.Equal(61, ProtocolRequest.SetEditorSimulationFieldNumber);
+        Assert.Equal(62, ProtocolRequest.GetEditorSimulationStateFieldNumber);
         Assert.Equal(10, ProtocolResponse.EmptyResultFieldNumber);
         Assert.Equal(19, ProtocolResponse.ViewportEventBatchResultFieldNumber);
     }

--- a/Editor.Tests/EngineProtocolClientTests.cs
+++ b/Editor.Tests/EngineProtocolClientTests.cs
@@ -167,6 +167,36 @@ public sealed class EngineProtocolClientTests
     }
 
     [Fact]
+    public async Task EditorSimulation_UsesTypedSetAndStateCommands()
+    {
+        var requests = new List<ProtocolRequest>();
+        var client = CreateClient(request =>
+        {
+            requests.Add(request);
+            return Success(
+                request,
+                response => response.BoolResult =
+                    new BoolResult
+                    {
+                        Value = request.CommandCase ==
+                            ProtocolRequest.CommandOneofCase.GetEditorSimulationState
+                    });
+        });
+
+        Assert.False(await client.SetEditorSimulationAsync(true));
+        Assert.True(await client.GetEditorSimulationStateAsync());
+
+        Assert.Equal(2, requests.Count);
+        Assert.Equal(
+            ProtocolRequest.CommandOneofCase.SetEditorSimulation,
+            requests[0].CommandCase);
+        Assert.True(requests[0].SetEditorSimulation.Enabled);
+        Assert.Equal(
+            ProtocolRequest.CommandOneofCase.GetEditorSimulationState,
+            requests[1].CommandCase);
+    }
+
+    [Fact]
     public async Task AnimatorParameters_UseTypedProtocolValues()
     {
         var requests = new List<ProtocolRequest>();

--- a/Editor.Tests/PhysicsEditorSimulationContractTests.cs
+++ b/Editor.Tests/PhysicsEditorSimulationContractTests.cs
@@ -1,0 +1,109 @@
+namespace SailorEditor.Tests;
+
+public sealed class PhysicsEditorSimulationContractTests
+{
+    [Fact]
+    public void NativeSimulation_SnapshotsBeforeStartAndReplacesWorldOnStop()
+    {
+        var source = ReadRepositoryFile(
+            "Runtime",
+            "Submodules",
+            "Editor.cpp");
+
+        Assert.Contains("const YAML::Node snapshot = SerializeWorld();", source, StringComparison.Ordinal);
+        Assert.Contains("External::TryDumpYaml(", source, StringComparison.Ordinal);
+        Assert.Contains("m_world->SetPhysicsSimulationEnabled(true);", source, StringComparison.Ordinal);
+        Assert.Contains("External::TryLoadYaml(", source, StringComparison.Ordinal);
+        Assert.Contains("engineLoop->InstantiateWorld(", source, StringComparison.Ordinal);
+        Assert.Contains("SetWorld(restoredWorld.GetRawPtr());", source, StringComparison.Ordinal);
+        Assert.Contains("engineLoop->ExitWorld(oldWorld);", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Toolbar_UsesNativeStateAndRefreshesAuthoritativeProjection()
+    {
+        var actions = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "EditorToolbarActions.cs");
+        var worldService = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "WorldService.cs");
+
+        Assert.Contains("GetEditorSimulationStateAsync", actions, StringComparison.Ordinal);
+        Assert.Contains("CommitInspectorChangesAsync", actions, StringComparison.Ordinal);
+        Assert.Contains("SetEditorSimulationAsync", actions, StringComparison.Ordinal);
+        Assert.Contains("RefreshCurrentWorldAuthoritativelyAsync", actions, StringComparison.Ordinal);
+        Assert.Contains("Stop simulation before saving the scene.", worldService, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Toolbar_SimulationIconTracksNativeState()
+    {
+        var toolbar = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "ToolbarView.xaml.cs");
+        var nativeToolbar = ReadRepositoryFile(
+            "Editor",
+            "Platforms",
+            "MacCatalyst",
+            "MacCatalystWindowChrome.cs");
+
+        Assert.Contains("control_stop_square.png", toolbar, StringComparison.Ordinal);
+        Assert.Contains("control.png", toolbar, StringComparison.Ordinal);
+        Assert.Contains("stop.circle.fill", nativeToolbar, StringComparison.Ordinal);
+        Assert.Contains("play.circle", nativeToolbar, StringComparison.Ordinal);
+        Assert.Contains("BeginInvokeOnMainThread", nativeToolbar, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void PhysicsStep_UsesDedicatedQueueAndJoltJobsUseWorkers()
+    {
+        var physicsEcs = ReadRepositoryFile(
+            "Runtime",
+            "ECS",
+            "PhysicsECS.cpp");
+        var jobSystem = ReadRepositoryFile(
+            "Runtime",
+            "Physics",
+            "JoltJobSystem.cpp");
+        var scheduler = ReadRepositoryFile(
+            "Runtime",
+            "Tasks",
+            "Scheduler.cpp");
+
+        Assert.Contains("EThreadType::Physics", physicsEcs, StringComparison.Ordinal);
+        Assert.Contains("physicsTask->Wait();", physicsEcs, StringComparison.Ordinal);
+        Assert.Contains("EThreadType::Worker", jobSystem, StringComparison.Ordinal);
+        Assert.Contains("JobSystemWithBarrier::WaitForJobs", jobSystem, StringComparison.Ordinal);
+        Assert.Contains("m_numQueuedTasks.wait", jobSystem, StringComparison.Ordinal);
+        Assert.Contains("\"Physics Thread\"", scheduler, StringComparison.Ordinal);
+    }
+
+    static string ReadRepositoryFile(params string[] relativePath)
+    {
+        var path = Path.Combine(
+            FindRepositoryRoot(),
+            Path.Combine(relativePath));
+        return File.ReadAllText(path);
+    }
+
+    static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "Protocol", "editor_engine.proto")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "Runtime")))
+            {
+                return directory.FullName;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find the Sailor repository root.");
+    }
+}

--- a/Editor/Platforms/MacCatalyst/MacCatalystWindowChrome.cs
+++ b/Editor/Platforms/MacCatalyst/MacCatalystWindowChrome.cs
@@ -17,6 +17,7 @@ namespace SailorEditor.Platforms.MacCatalyst
         const string RedoItem = "SailorEditorToolbarRedo";
         const string PlayItem = "SailorEditorToolbarPlay";
         const string DebugItem = "SailorEditorToolbarDebug";
+        const string SimulateItem = "SailorEditorToolbarSimulate";
         const string TraceSceneItem = "SailorEditorToolbarTraceScene";
         const string TraceSelectionItem = "SailorEditorToolbarTraceSelection";
         const string SaveLayoutItem = "SailorEditorToolbarSaveLayout";
@@ -30,6 +31,7 @@ namespace SailorEditor.Platforms.MacCatalyst
             NSToolbar.NSToolbarFlexibleSpaceItemIdentifier,
             PlayItem,
             DebugItem,
+            SimulateItem,
             NSToolbar.NSToolbarFlexibleSpaceItemIdentifier,
             TitleItem,
             TraceSceneItem,
@@ -42,7 +44,8 @@ namespace SailorEditor.Platforms.MacCatalyst
         static readonly NSSet<NSString> CenterToolbarItems = new(new NSString[]
         {
             new NSString(PlayItem),
-            new NSString(DebugItem)
+            new NSString(DebugItem),
+            new NSString(SimulateItem)
         });
 
         static readonly NativeToolbarDelegate ToolbarDelegate = new();
@@ -178,6 +181,7 @@ namespace SailorEditor.Platforms.MacCatalyst
                         "ladybug.fill",
                         () => MauiProgram.GetService<EditorToolbarActions>()
                             .RunWorldAsync(true)),
+                    SimulateItem => CreateSimulationItem(),
                     TraceSceneItem => CreateItem(TraceSceneItem, "Trace Scene", "camera.metering.matrix", () => MauiProgram.GetService<EditorToolbarActions>().ExportPathTracedImageAsync(false)),
                     TraceSelectionItem => CreateItem(TraceSelectionItem, "Trace Selection", "scope", () => MauiProgram.GetService<EditorToolbarActions>().ExportPathTracedImageAsync(true)),
                     SaveLayoutItem => CreateItem(SaveLayoutItem, "Save Layout", "rectangle.3.group", () => MauiProgram.GetService<EditorToolbarActions>().SaveLayoutAsync()),
@@ -206,6 +210,51 @@ namespace SailorEditor.Platforms.MacCatalyst
                 item.Label = currentTitle;
                 item.PaletteLabel = currentTitle;
                 item.ToolTip = currentTitle;
+                return item;
+            }
+
+            NSToolbarItem CreateSimulationItem()
+            {
+                var actions = MauiProgram.GetService<EditorToolbarActions>();
+                var target = new ToolbarActionTarget(
+                    "Simulate",
+                    () => actions.ToggleSimulationAsync());
+                actionTargets[SimulateItem] = target;
+
+                var barButton = CreateButton(
+                    "Simulate",
+                    "play.circle",
+                    target);
+                var item = NSToolbarItem.Create(SimulateItem, barButton);
+                item.Action = InvokeSelector;
+                item.Target = target;
+                item.Enabled = true;
+                item.Autovalidates = false;
+
+                void ApplyState(bool isSimulating)
+                {
+                    var label = isSimulating ? "Stop" : "Simulate";
+                    var symbol = isSimulating
+                        ? "stop.circle.fill"
+                        : "play.circle";
+                    item.Label = label;
+                    item.PaletteLabel = label;
+                    item.ToolTip = isSimulating
+                        ? "Stop physics simulation and restore the scene"
+                        : "Simulate physics in the current scene";
+                    barButton.Image = UIImage.GetSystemImage(symbol);
+                    barButton.Title = label;
+                }
+
+                void Update(bool isSimulating)
+                {
+                    Microsoft.Maui.ApplicationModel.MainThread
+                        .BeginInvokeOnMainThread(
+                            () => ApplyState(isSimulating));
+                }
+
+                actions.SimulationStateChanged += Update;
+                ApplyState(actions.IsSimulating);
                 return item;
             }
 

--- a/Editor/Protocol/EngineProtocolClient.cs
+++ b/Editor/Protocol/EngineProtocolClient.cs
@@ -417,6 +417,34 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                 .ConfigureAwait(false),
             nameof(ProtocolRequest.CreateEditorWorld));
 
+    public async Task<bool> SetEditorSimulationAsync(
+        bool enabled,
+        CancellationToken cancellationToken = default)
+        => ReadBool(
+            await SendAsync(
+                    new ProtocolRequest
+                    {
+                        SetEditorSimulation = new EditorSimulationRequest
+                        {
+                            Enabled = enabled
+                        }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.SetEditorSimulation));
+
+    public async Task<bool> GetEditorSimulationStateAsync(
+        CancellationToken cancellationToken = default)
+        => ReadBool(
+            await SendAsync(
+                    new ProtocolRequest
+                    {
+                        GetEditorSimulationState = new Empty()
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.GetEditorSimulationState));
+
     public async Task SetViewportAsync(
         uint windowPosX,
         uint windowPosY,

--- a/Editor/Protocol/Generated/EditorEngine.cs
+++ b/Editor/Protocol/Generated/EditorEngine.cs
@@ -25,7 +25,7 @@ namespace SailorEditor.Protocol.Generated {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "ChNlZGl0b3JfZW5naW5lLnByb3RvEhBzYWlsb3IuZWRpdG9yLnYxIgcKBUVt",
-            "cHR5ItwbCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
+            "cHR5IugcCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
             "IAEoDRISCgpyZXF1ZXN0X2lkGAIgASgEEjkKCmluaXRpYWxpemUYCiABKAsy",
             "Iy5zYWlsb3IuZWRpdG9yLnYxLkluaXRpYWxpemVSZXF1ZXN0SAASKAoFc3Rh",
             "cnQYCyABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASJwoEc3RvcBgM",
@@ -102,151 +102,155 @@ namespace SailorEditor.Protocol.Generated {
             "YW5pbWF0b3JfcGFyYW1ldGVyGDsgASgLMiouc2FpbG9yLmVkaXRvci52MS5B",
             "bmltYXRvclBhcmFtZXRlclJlcXVlc3RIABJBChJnZXRfYW5pbWF0b3Jfc3Rh",
             "dGUYPCABKAsyIy5zYWlsb3IuZWRpdG9yLnYxLkluc3RhbmNlSWRSZXF1ZXN0",
-            "SABCCQoHY29tbWFuZEoECAMQCkoECDIQM0oECD0QZFIYY3JlYXRlX21vZGVs",
-            "X2dhbWVfb2JqZWN0Uh5yZXNvbHZlX3ZpZXdwb3J0X2Ryb3BfcG9zaXRpb24i",
-            "3gcKEFByb3RvY29sUmVzcG9uc2USGAoQcHJvdG9jb2xfdmVyc2lvbhgBIAEo",
-            "DRISCgpyZXF1ZXN0X2lkGAIgASgEEg8KB3N1Y2Nlc3MYAyABKAgSDQoFZXJy",
-            "b3IYBCABKAkSJAocc3VwcG9ydHNfc3RyaWN0X2luc3RhbmNlX2lkcxgFIAEo",
-            "CBIvCgxlbXB0eV9yZXN1bHQYCiABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVt",
-            "cHR5SAASMwoLYm9vbF9yZXN1bHQYCyABKAsyHC5zYWlsb3IuZWRpdG9yLnYx",
-            "LkJvb2xSZXN1bHRIABI1CgxpbnQzMl9yZXN1bHQYDCABKAsyHS5zYWlsb3Iu",
-            "ZWRpdG9yLnYxLkludDMyUmVzdWx0SAASNwoNdWludDMyX3Jlc3VsdBgNIAEo",
-            "CzIeLnNhaWxvci5lZGl0b3IudjEuVUludDMyUmVzdWx0SAASNwoNdWludDY0",
-            "X3Jlc3VsdBgOIAEoCzIeLnNhaWxvci5lZGl0b3IudjEuVUludDY0UmVzdWx0",
-            "SAASNwoNc3RyaW5nX3Jlc3VsdBgPIAEoCzIeLnNhaWxvci5lZGl0b3IudjEu",
-            "U3RyaW5nUmVzdWx0SAASQAoSc3RyaW5nX2xpc3RfcmVzdWx0GBAgASgLMiIu",
-            "c2FpbG9yLmVkaXRvci52MS5TdHJpbmdMaXN0UmVzdWx0SAASTQoZYXNzZXRf",
-            "cmVsb2FkX3N0YXRlX3Jlc3VsdBgRIAEoCzIoLnNhaWxvci5lZGl0b3IudjEu",
-            "QXNzZXRSZWxvYWRTdGF0ZVJlc3VsdEgAEkAKEmluc3RhbmNlX2lkX3Jlc3Vs",
-            "dBgSIAEoCzIiLnNhaWxvci5lZGl0b3IudjEuSW5zdGFuY2VJZFJlc3VsdEgA",
-            "ElEKG3ZpZXdwb3J0X2V2ZW50X2JhdGNoX3Jlc3VsdBgTIAEoCzIqLnNhaWxv",
-            "ci5lZGl0b3IudjEuVmlld3BvcnRFdmVudEJhdGNoUmVzdWx0SAASOQoOdmVj",
-            "dG9yNF9yZXN1bHQYFCABKAsyHy5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjRS",
-            "ZXN1bHRIABJPChp2aWV3cG9ydF90b29sX3N0YXRlX3Jlc3VsdBgVIAEoCzIp",
-            "LnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUb29sU3RhdGVSZXN1bHRIABJG",
-            "ChVhbmltYXRvcl9zdGF0ZV9yZXN1bHQYFiABKAsyJS5zYWlsb3IuZWRpdG9y",
-            "LnYxLkFuaW1hdG9yU3RhdGVSZXN1bHRIAEIICgZyZXN1bHRKBAgGEApKBAgX",
-            "EGQiJgoRSW5pdGlhbGl6ZVJlcXVlc3QSEQoJYXJndW1lbnRzGAEgAygJIiEK",
-            "DENvdW50UmVxdWVzdBIRCgltYXhfY291bnQYASABKA0iIAoNRmlsZUlkUmVx",
-            "dWVzdBIPCgdmaWxlX2lkGAEgASgJIucBChpDcmVhdGVNb2RlbEluc3RhbmNl",
-            "UmVxdWVzdBIVCg1tb2RlbF9maWxlX2lkGAEgASgJEgwKBG5hbWUYAiABKAkS",
-            "GgoScGFyZW50X2luc3RhbmNlX2lkGAMgASgJEhgKEGNyZWF0ZV9oaWVyYXJj",
-            "aHkYBCABKAgSHAoUYXBwbHlfd29ybGRfcG9zaXRpb24YBSABKAgSMQoOd29y",
-            "bGRfcG9zaXRpb24YBiABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQS",
-            "HQoVcHJlZmVycmVkX2luc3RhbmNlX2lkGAcgASgJIigKEUluc3RhbmNlSWRS",
-            "ZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJIigKEVZpZXdwb3J0SWRSZXF1",
-            "ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEImAKE1ZpZXdwb3J0UmVjdFJlcXVl",
-            "c3QSFAoMd2luZG93X3Bvc194GAEgASgNEhQKDHdpbmRvd19wb3NfeRgCIAEo",
-            "DRINCgV3aWR0aBgDIAEoDRIOCgZoZWlnaHQYBCABKA0iLAoLU2l6ZVJlcXVl",
-            "c3QSDQoFd2lkdGgYASABKA0SDgoGaGVpZ2h0GAIgASgNIpkBChVSZW1vdGVW",
-            "aWV3cG9ydFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQSFAoMd2luZG93",
-            "X3Bvc194GAIgASgNEhQKDHdpbmRvd19wb3NfeRgDIAEoDRINCgV3aWR0aBgE",
-            "IAEoDRIOCgZoZWlnaHQYBSABKA0SDwoHdmlzaWJsZRgGIAEoCBIPCgdmb2N1",
-            "c2VkGAcgASgIImUKGVJlbW90ZVZpZXdwb3J0SG9zdFJlcXVlc3QSEwoLdmll",
-            "d3BvcnRfaWQYASABKAQSGAoQaG9zdF9oYW5kbGVfa2luZBgCIAEoDRIZChFo",
-            "b3N0X2hhbmRsZV92YWx1ZRgDIAEoBCL8AQoaUmVtb3RlVmlld3BvcnRJbnB1",
-            "dFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQSDAoEa2luZBgCIAEoDRIR",
-            "Cglwb2ludGVyX3gYAyABKAISEQoJcG9pbnRlcl95GAQgASgCEhUKDXdoZWVs",
-            "X2RlbHRhX3gYBSABKAISFQoNd2hlZWxfZGVsdGFfeRgGIAEoAhIQCghrZXlf",
-            "Y29kZRgHIAEoDRIOCgZidXR0b24YCCABKA0SEQoJbW9kaWZpZXJzGAkgASgN",
-            "Eg8KB3ByZXNzZWQYCiABKAgSDwoHZm9jdXNlZBgLIAEoCBIQCghjYXB0dXJl",
-            "ZBgMIAEoCCJDCh5NYW5hZ2VkTXV0YXRpb25SZXZpc2lvblJlcXVlc3QSDAoE",
-            "a2luZBgBIAEoDRITCgtpbnN0YW5jZV9pZBgCIAEoCSJAChNVcGRhdGVPYmpl",
-            "Y3RSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEhQKDHlhbWxfY2hhbmdl",
-            "cxgCIAEoCSJmChVSZXBhcmVudE9iamVjdFJlcXVlc3QSEwoLaW5zdGFuY2Vf",
-            "aWQYASABKAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAIgASgJEhwKFGtlZXBf",
-            "d29ybGRfdHJhbnNmb3JtGAMgASgIIlQKF0NyZWF0ZUdhbWVPYmplY3RSZXF1",
-            "ZXN0EhoKEnBhcmVudF9pbnN0YW5jZV9pZBgBIAEoCRIdChVwcmVmZXJyZWRf",
-            "aW5zdGFuY2VfaWQYAiABKAkiZgoTQWRkQ29tcG9uZW50UmVxdWVzdBITCgtp",
-            "bnN0YW5jZV9pZBgBIAEoCRIbChNjb21wb25lbnRfdHlwZV9uYW1lGAIgASgJ",
-            "Eh0KFXByZWZlcnJlZF9pbnN0YW5jZV9pZBgDIAEoCSLmAQoYQW5pbWF0b3JQ",
-            "YXJhbWV0ZXJSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEgwKBG5hbWUY",
-            "AiABKAkSFQoLZmxvYXRfdmFsdWUYAyABKAJIABITCglpbnRfdmFsdWUYBCAB",
-            "KBFIABIUCgpib29sX3ZhbHVlGAUgASgISAASKgoHdHJpZ2dlchgGIAEoCzIX",
-            "LnNhaWxvci5lZGl0b3IudjEuRW1wdHlIABIwCg1yZXNldF90cmlnZ2VyGAcg",
-            "ASgLMhcuc2FpbG9yLmVkaXRvci52MS5FbXB0eUgAQgcKBXZhbHVlIkcKGElu",
-            "c3RhbnRpYXRlUHJlZmFiUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJEhoKEnBh",
-            "cmVudF9pbnN0YW5jZV9pZBgCIAEoCSJwCiBJbnN0YW50aWF0ZVByZWZhYkZy",
-            "b21ZYW1sUmVxdWVzdBITCgtwcmVmYWJfeWFtbBgBIAEoCRIaChJwYXJlbnRf",
-            "aW5zdGFuY2VfaWQYAiABKAkSGwoTc3RyaWN0X2luc3RhbmNlX2lkcxgDIAEo",
-            "CCJVChJWaWV3cG9ydFJheVJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQS",
-            "FAoMbm9ybWFsaXplZF94GAIgASgCEhQKDG5vcm1hbGl6ZWRfeRgDIAEoAiKg",
-            "AQogSW5zdGFudGlhdGVQcmVmYWJJbnN0YW5jZVJlcXVlc3QSDwoHZmlsZV9p",
-            "ZBgBIAEoCRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAiABKAkSHAoUYXBwbHlf",
-            "d29ybGRfcG9zaXRpb24YAyABKAgSMQoOd29ybGRfcG9zaXRpb24YBCABKAsy",
-            "GS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQiQQoVVmlld3BvcnRPYmplY3RS",
-            "ZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhMKC2luc3RhbmNlX2lkGAIg",
-            "ASgJIjkKEVByZWZhYkxpbmtSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJ",
-            "Eg8KB2ZpbGVfaWQYAiABKAkiqQEKGFZpZXdwb3J0VG9vbFN0YXRlUmVxdWVz",
-            "dBITCgt2aWV3cG9ydF9pZBgBIAEoBBI/CglvcGVyYXRpb24YAiABKA4yLC5z",
-            "YWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtT3BlcmF0aW9uEjcK",
-            "BXNwYWNlGAMgASgOMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5z",
-            "Zm9ybVNwYWNlIigKEFNlbGVjdGlvblJlcXVlc3QSFAoMaW5zdGFuY2VfaWRz",
-            "GAEgAygJIiUKFVNob3dNYWluV2luZG93UmVxdWVzdBIMCgRzaG93GAEgASgI",
-            "IogBChxSZW5kZXJQYXRoVHJhY2VkSW1hZ2VSZXF1ZXN0EhMKC291dHB1dF9w",
-            "YXRoGAEgASgJEhMKC2luc3RhbmNlX2lkGAIgASgJEg4KBmhlaWdodBgDIAEo",
-            "DRIZChFzYW1wbGVzX3Blcl9waXhlbBgEIAEoDRITCgttYXhfYm91bmNlcxgF",
-            "IAEoDSIbCgpCb29sUmVzdWx0Eg0KBXZhbHVlGAEgASgIIhwKC0ludDMyUmVz",
-            "dWx0Eg0KBXZhbHVlGAEgASgFIh0KDFVJbnQzMlJlc3VsdBINCgV2YWx1ZRgB",
-            "IAEoDSIdCgxVSW50NjRSZXN1bHQSDQoFdmFsdWUYASABKAQiMAoMU3RyaW5n",
-            "UmVzdWx0EhEKCWhhc192YWx1ZRgBIAEoCBINCgV2YWx1ZRgCIAEoCSIiChBT",
-            "dHJpbmdMaXN0UmVzdWx0Eg4KBnZhbHVlcxgBIAMoCSKEAQoWQXNzZXRSZWxv",
-            "YWRTdGF0ZVJlc3VsdBIRCglhdmFpbGFibGUYASABKAgSGgoScmVxdWVzdF9n",
-            "ZW5lcmF0aW9uGAIgASgEEhwKFGNvbXBsZXRlZF9nZW5lcmF0aW9uGAMgASgE",
-            "Eh0KFXN1Y2Nlc3NmdWxfZ2VuZXJhdGlvbhgEIAEoBCI6ChBJbnN0YW5jZUlk",
-            "UmVzdWx0EhEKCXN1Y2NlZWRlZBgBIAEoCBITCgtpbnN0YW5jZV9pZBgCIAEo",
-            "CSI5Cg1WZWN0b3I0UmVzdWx0EigKBXZhbHVlGAEgASgLMhkuc2FpbG9yLmVk",
-            "aXRvci52MS5WZWN0b3I0IpMBChdWaWV3cG9ydFRvb2xTdGF0ZVJlc3VsdBI/",
-            "CglvcGVyYXRpb24YASABKA4yLC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0",
-            "VHJhbnNmb3JtT3BlcmF0aW9uEjcKBXNwYWNlGAIgASgOMiguc2FpbG9yLmVk",
-            "aXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybVNwYWNlIqgCChNBbmltYXRvclN0",
-            "YXRlUmVzdWx0EhYKDmhhc19jb250cm9sbGVyGAEgASgIEhsKE2NvbnRyb2xs",
-            "ZXJfcmV2aXNpb24YAiABKAQSFwoPYWN0aXZlX3N0YXRlX2lkGAMgASgEEhkK",
-            "EWFjdGl2ZV9zdGF0ZV9uYW1lGAQgASgJEhkKEWFjdGl2ZV9zdGF0ZV90aW1l",
-            "GAUgASgCEhUKDXRyYW5zaXRpb25pbmcYBiABKAgSHAoUZGVzdGluYXRpb25f",
-            "c3RhdGVfaWQYByABKAQSHgoWZGVzdGluYXRpb25fc3RhdGVfbmFtZRgIIAEo",
-            "CRIeChZkZXN0aW5hdGlvbl9zdGF0ZV90aW1lGAkgASgCEhgKEHRyYW5zaXRp",
-            "b25fYWxwaGEYCiABKAIiNQoHVmVjdG9yNBIJCgF4GAEgASgCEgkKAXkYAiAB",
-            "KAISCQoBehgDIAEoAhIJCgF3GAQgASgCIjYKFlZpZXdwb3J0U2VsZWN0aW9u",
-            "RXZlbnQSHAoUc2VsZWN0ZWRfaW5zdGFuY2VfaWQYASABKAki1gMKFlZpZXdw",
-            "b3J0VHJhbnNmb3JtRXZlbnQSEwoLaW5zdGFuY2VfaWQYASABKAkSPwoJb3Bl",
-            "cmF0aW9uGAIgASgOMiwuc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5z",
-            "Zm9ybU9wZXJhdGlvbhI3CgVzcGFjZRgDIAEoDjIoLnNhaWxvci5lZGl0b3Iu",
-            "djEuVmlld3BvcnRUcmFuc2Zvcm1TcGFjZRIyCg9iZWZvcmVfcG9zaXRpb24Y",
-            "BCABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQSMgoPYmVmb3JlX3Jv",
-            "dGF0aW9uGAUgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0Ei8KDGJl",
-            "Zm9yZV9zY2FsZRgGIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNBIx",
-            "Cg5hZnRlcl9wb3NpdGlvbhgHIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVj",
-            "dG9yNBIxCg5hZnRlcl9yb3RhdGlvbhgIIAEoCzIZLnNhaWxvci5lZGl0b3Iu",
-            "djEuVmVjdG9yNBIuCgthZnRlcl9zY2FsZRgJIAEoCzIZLnNhaWxvci5lZGl0",
-            "b3IudjEuVmVjdG9yNCJVChZWaWV3cG9ydEFzc2V0RHJvcEV2ZW50Eg8KB2Zp",
-            "bGVfaWQYASABKAkSFAoMbm9ybWFsaXplZF94GAIgASgCEhQKDG5vcm1hbGl6",
-            "ZWRfeRgDIAEoAiItChlWaWV3cG9ydFRvb2xTaG9ydGN1dEV2ZW50EhAKCGtl",
-            "eV9jb2RlGAEgASgNItkCCg1WaWV3cG9ydEV2ZW50EhAKCHJldmlzaW9uGAEg",
-            "ASgEEiEKGW1hbmFnZWRfbXV0YXRpb25fcmV2aXNpb24YAiABKAQSPQoJc2Vs",
-            "ZWN0aW9uGAogASgLMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFNlbGVj",
-            "dGlvbkV2ZW50SAASPQoJdHJhbnNmb3JtGAsgASgLMiguc2FpbG9yLmVkaXRv",
-            "ci52MS5WaWV3cG9ydFRyYW5zZm9ybUV2ZW50SAASPgoKYXNzZXRfZHJvcBgM",
-            "IAEoCzIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRBc3NldERyb3BFdmVu",
-            "dEgAEkQKDXRvb2xfc2hvcnRjdXQYDSABKAsyKy5zYWlsb3IuZWRpdG9yLnYx",
-            "LlZpZXdwb3J0VG9vbFNob3J0Y3V0RXZlbnRIAEIJCgdwYXlsb2FkSgQIAxAK",
-            "IksKGFZpZXdwb3J0RXZlbnRCYXRjaFJlc3VsdBIvCgZldmVudHMYASADKAsy",
-            "Hy5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0RXZlbnQq8AEKGlZpZXdwb3J0",
-            "VHJhbnNmb3JtT3BlcmF0aW9uEiwKKFZJRVdQT1JUX1RSQU5TRk9STV9PUEVS",
-            "QVRJT05fVU5TUEVDSUZJRUQQABInCiNWSUVXUE9SVF9UUkFOU0ZPUk1fT1BF",
-            "UkFUSU9OX1NFTEVDVBABEioKJlZJRVdQT1JUX1RSQU5TRk9STV9PUEVSQVRJ",
-            "T05fVFJBTlNMQVRFEAISJwojVklFV1BPUlRfVFJBTlNGT1JNX09QRVJBVElP",
-            "Tl9ST1RBVEUQAxImCiJWSUVXUE9SVF9UUkFOU0ZPUk1fT1BFUkFUSU9OX1ND",
-            "QUxFEAQqigEKFlZpZXdwb3J0VHJhbnNmb3JtU3BhY2USKAokVklFV1BPUlRf",
-            "VFJBTlNGT1JNX1NQQUNFX1VOU1BFQ0lGSUVEEAASIgoeVklFV1BPUlRfVFJB",
-            "TlNGT1JNX1NQQUNFX1dPUkxEEAESIgoeVklFV1BPUlRfVFJBTlNGT1JNX1NQ",
-            "QUNFX0xPQ0FMEAJCIqoCH1NhaWxvckVkaXRvci5Qcm90b2NvbC5HZW5lcmF0",
-            "ZWRiBnByb3RvMw=="));
+            "SAASSgoVc2V0X2VkaXRvcl9zaW11bGF0aW9uGD0gASgLMikuc2FpbG9yLmVk",
+            "aXRvci52MS5FZGl0b3JTaW11bGF0aW9uUmVxdWVzdEgAEj4KG2dldF9lZGl0",
+            "b3Jfc2ltdWxhdGlvbl9zdGF0ZRg+IAEoCzIXLnNhaWxvci5lZGl0b3IudjEu",
+            "RW1wdHlIAEIJCgdjb21tYW5kSgQIAxAKSgQIMhAzSgQIPxBkUhhjcmVhdGVf",
+            "bW9kZWxfZ2FtZV9vYmplY3RSHnJlc29sdmVfdmlld3BvcnRfZHJvcF9wb3Np",
+            "dGlvbiLeBwoQUHJvdG9jb2xSZXNwb25zZRIYChBwcm90b2NvbF92ZXJzaW9u",
+            "GAEgASgNEhIKCnJlcXVlc3RfaWQYAiABKAQSDwoHc3VjY2VzcxgDIAEoCBIN",
+            "CgVlcnJvchgEIAEoCRIkChxzdXBwb3J0c19zdHJpY3RfaW5zdGFuY2VfaWRz",
+            "GAUgASgIEi8KDGVtcHR5X3Jlc3VsdBgKIAEoCzIXLnNhaWxvci5lZGl0b3Iu",
+            "djEuRW1wdHlIABIzCgtib29sX3Jlc3VsdBgLIAEoCzIcLnNhaWxvci5lZGl0",
+            "b3IudjEuQm9vbFJlc3VsdEgAEjUKDGludDMyX3Jlc3VsdBgMIAEoCzIdLnNh",
+            "aWxvci5lZGl0b3IudjEuSW50MzJSZXN1bHRIABI3Cg11aW50MzJfcmVzdWx0",
+            "GA0gASgLMh4uc2FpbG9yLmVkaXRvci52MS5VSW50MzJSZXN1bHRIABI3Cg11",
+            "aW50NjRfcmVzdWx0GA4gASgLMh4uc2FpbG9yLmVkaXRvci52MS5VSW50NjRS",
+            "ZXN1bHRIABI3Cg1zdHJpbmdfcmVzdWx0GA8gASgLMh4uc2FpbG9yLmVkaXRv",
+            "ci52MS5TdHJpbmdSZXN1bHRIABJAChJzdHJpbmdfbGlzdF9yZXN1bHQYECAB",
+            "KAsyIi5zYWlsb3IuZWRpdG9yLnYxLlN0cmluZ0xpc3RSZXN1bHRIABJNChlh",
+            "c3NldF9yZWxvYWRfc3RhdGVfcmVzdWx0GBEgASgLMiguc2FpbG9yLmVkaXRv",
+            "ci52MS5Bc3NldFJlbG9hZFN0YXRlUmVzdWx0SAASQAoSaW5zdGFuY2VfaWRf",
+            "cmVzdWx0GBIgASgLMiIuc2FpbG9yLmVkaXRvci52MS5JbnN0YW5jZUlkUmVz",
+            "dWx0SAASUQobdmlld3BvcnRfZXZlbnRfYmF0Y2hfcmVzdWx0GBMgASgLMiou",
+            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHRIABI5",
+            "Cg52ZWN0b3I0X3Jlc3VsdBgUIAEoCzIfLnNhaWxvci5lZGl0b3IudjEuVmVj",
+            "dG9yNFJlc3VsdEgAEk8KGnZpZXdwb3J0X3Rvb2xfc3RhdGVfcmVzdWx0GBUg",
+            "ASgLMikuc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRvb2xTdGF0ZVJlc3Vs",
+            "dEgAEkYKFWFuaW1hdG9yX3N0YXRlX3Jlc3VsdBgWIAEoCzIlLnNhaWxvci5l",
+            "ZGl0b3IudjEuQW5pbWF0b3JTdGF0ZVJlc3VsdEgAQggKBnJlc3VsdEoECAYQ",
+            "CkoECBcQZCImChFJbml0aWFsaXplUmVxdWVzdBIRCglhcmd1bWVudHMYASAD",
+            "KAkiIQoMQ291bnRSZXF1ZXN0EhEKCW1heF9jb3VudBgBIAEoDSIgCg1GaWxl",
+            "SWRSZXF1ZXN0Eg8KB2ZpbGVfaWQYASABKAki5wEKGkNyZWF0ZU1vZGVsSW5z",
+            "dGFuY2VSZXF1ZXN0EhUKDW1vZGVsX2ZpbGVfaWQYASABKAkSDAoEbmFtZRgC",
+            "IAEoCRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAyABKAkSGAoQY3JlYXRlX2hp",
+            "ZXJhcmNoeRgEIAEoCBIcChRhcHBseV93b3JsZF9wb3NpdGlvbhgFIAEoCBIx",
+            "Cg53b3JsZF9wb3NpdGlvbhgGIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVj",
+            "dG9yNBIdChVwcmVmZXJyZWRfaW5zdGFuY2VfaWQYByABKAkiKAoRSW5zdGFu",
+            "Y2VJZFJlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkiKAoRVmlld3BvcnRJ",
+            "ZFJlcXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQiYAoTVmlld3BvcnRSZWN0",
+            "UmVxdWVzdBIUCgx3aW5kb3dfcG9zX3gYASABKA0SFAoMd2luZG93X3Bvc195",
+            "GAIgASgNEg0KBXdpZHRoGAMgASgNEg4KBmhlaWdodBgEIAEoDSIsCgtTaXpl",
+            "UmVxdWVzdBINCgV3aWR0aBgBIAEoDRIOCgZoZWlnaHQYAiABKA0iKgoXRWRp",
+            "dG9yU2ltdWxhdGlvblJlcXVlc3QSDwoHZW5hYmxlZBgBIAEoCCKZAQoVUmVt",
+            "b3RlVmlld3BvcnRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhQKDHdp",
+            "bmRvd19wb3NfeBgCIAEoDRIUCgx3aW5kb3dfcG9zX3kYAyABKA0SDQoFd2lk",
+            "dGgYBCABKA0SDgoGaGVpZ2h0GAUgASgNEg8KB3Zpc2libGUYBiABKAgSDwoH",
+            "Zm9jdXNlZBgHIAEoCCJlChlSZW1vdGVWaWV3cG9ydEhvc3RSZXF1ZXN0EhMK",
+            "C3ZpZXdwb3J0X2lkGAEgASgEEhgKEGhvc3RfaGFuZGxlX2tpbmQYAiABKA0S",
+            "GQoRaG9zdF9oYW5kbGVfdmFsdWUYAyABKAQi/AEKGlJlbW90ZVZpZXdwb3J0",
+            "SW5wdXRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEgwKBGtpbmQYAiAB",
+            "KA0SEQoJcG9pbnRlcl94GAMgASgCEhEKCXBvaW50ZXJfeRgEIAEoAhIVCg13",
+            "aGVlbF9kZWx0YV94GAUgASgCEhUKDXdoZWVsX2RlbHRhX3kYBiABKAISEAoI",
+            "a2V5X2NvZGUYByABKA0SDgoGYnV0dG9uGAggASgNEhEKCW1vZGlmaWVycxgJ",
+            "IAEoDRIPCgdwcmVzc2VkGAogASgIEg8KB2ZvY3VzZWQYCyABKAgSEAoIY2Fw",
+            "dHVyZWQYDCABKAgiQwoeTWFuYWdlZE11dGF0aW9uUmV2aXNpb25SZXF1ZXN0",
+            "EgwKBGtpbmQYASABKA0SEwoLaW5zdGFuY2VfaWQYAiABKAkiQAoTVXBkYXRl",
+            "T2JqZWN0UmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCRIUCgx5YW1sX2No",
+            "YW5nZXMYAiABKAkiZgoVUmVwYXJlbnRPYmplY3RSZXF1ZXN0EhMKC2luc3Rh",
+            "bmNlX2lkGAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIcChRr",
+            "ZWVwX3dvcmxkX3RyYW5zZm9ybRgDIAEoCCJUChdDcmVhdGVHYW1lT2JqZWN0",
+            "UmVxdWVzdBIaChJwYXJlbnRfaW5zdGFuY2VfaWQYASABKAkSHQoVcHJlZmVy",
+            "cmVkX2luc3RhbmNlX2lkGAIgASgJImYKE0FkZENvbXBvbmVudFJlcXVlc3QS",
+            "EwoLaW5zdGFuY2VfaWQYASABKAkSGwoTY29tcG9uZW50X3R5cGVfbmFtZRgC",
+            "IAEoCRIdChVwcmVmZXJyZWRfaW5zdGFuY2VfaWQYAyABKAki5gEKGEFuaW1h",
+            "dG9yUGFyYW1ldGVyUmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCRIMCgRu",
+            "YW1lGAIgASgJEhUKC2Zsb2F0X3ZhbHVlGAMgASgCSAASEwoJaW50X3ZhbHVl",
+            "GAQgASgRSAASFAoKYm9vbF92YWx1ZRgFIAEoCEgAEioKB3RyaWdnZXIYBiAB",
+            "KAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASMAoNcmVzZXRfdHJpZ2dl",
+            "chgHIAEoCzIXLnNhaWxvci5lZGl0b3IudjEuRW1wdHlIAEIHCgV2YWx1ZSJH",
+            "ChhJbnN0YW50aWF0ZVByZWZhYlJlcXVlc3QSDwoHZmlsZV9pZBgBIAEoCRIa",
+            "ChJwYXJlbnRfaW5zdGFuY2VfaWQYAiABKAkicAogSW5zdGFudGlhdGVQcmVm",
+            "YWJGcm9tWWFtbFJlcXVlc3QSEwoLcHJlZmFiX3lhbWwYASABKAkSGgoScGFy",
+            "ZW50X2luc3RhbmNlX2lkGAIgASgJEhsKE3N0cmljdF9pbnN0YW5jZV9pZHMY",
+            "AyABKAgiVQoSVmlld3BvcnRSYXlSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEg",
+            "ASgEEhQKDG5vcm1hbGl6ZWRfeBgCIAEoAhIUCgxub3JtYWxpemVkX3kYAyAB",
+            "KAIioAEKIEluc3RhbnRpYXRlUHJlZmFiSW5zdGFuY2VSZXF1ZXN0Eg8KB2Zp",
+            "bGVfaWQYASABKAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAIgASgJEhwKFGFw",
+            "cGx5X3dvcmxkX3Bvc2l0aW9uGAMgASgIEjEKDndvcmxkX3Bvc2l0aW9uGAQg",
+            "ASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0IkEKFVZpZXdwb3J0T2Jq",
+            "ZWN0UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBITCgtpbnN0YW5jZV9p",
+            "ZBgCIAEoCSI5ChFQcmVmYWJMaW5rUmVxdWVzdBITCgtpbnN0YW5jZV9pZBgB",
+            "IAEoCRIPCgdmaWxlX2lkGAIgASgJIqkBChhWaWV3cG9ydFRvb2xTdGF0ZVJl",
+            "cXVlc3QSEwoLdmlld3BvcnRfaWQYASABKAQSPwoJb3BlcmF0aW9uGAIgASgO",
+            "Miwuc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybU9wZXJhdGlv",
+            "bhI3CgVzcGFjZRgDIAEoDjIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRU",
+            "cmFuc2Zvcm1TcGFjZSIoChBTZWxlY3Rpb25SZXF1ZXN0EhQKDGluc3RhbmNl",
+            "X2lkcxgBIAMoCSIlChVTaG93TWFpbldpbmRvd1JlcXVlc3QSDAoEc2hvdxgB",
+            "IAEoCCKIAQocUmVuZGVyUGF0aFRyYWNlZEltYWdlUmVxdWVzdBITCgtvdXRw",
+            "dXRfcGF0aBgBIAEoCRITCgtpbnN0YW5jZV9pZBgCIAEoCRIOCgZoZWlnaHQY",
+            "AyABKA0SGQoRc2FtcGxlc19wZXJfcGl4ZWwYBCABKA0SEwoLbWF4X2JvdW5j",
+            "ZXMYBSABKA0iGwoKQm9vbFJlc3VsdBINCgV2YWx1ZRgBIAEoCCIcCgtJbnQz",
+            "MlJlc3VsdBINCgV2YWx1ZRgBIAEoBSIdCgxVSW50MzJSZXN1bHQSDQoFdmFs",
+            "dWUYASABKA0iHQoMVUludDY0UmVzdWx0Eg0KBXZhbHVlGAEgASgEIjAKDFN0",
+            "cmluZ1Jlc3VsdBIRCgloYXNfdmFsdWUYASABKAgSDQoFdmFsdWUYAiABKAki",
+            "IgoQU3RyaW5nTGlzdFJlc3VsdBIOCgZ2YWx1ZXMYASADKAkihAEKFkFzc2V0",
+            "UmVsb2FkU3RhdGVSZXN1bHQSEQoJYXZhaWxhYmxlGAEgASgIEhoKEnJlcXVl",
+            "c3RfZ2VuZXJhdGlvbhgCIAEoBBIcChRjb21wbGV0ZWRfZ2VuZXJhdGlvbhgD",
+            "IAEoBBIdChVzdWNjZXNzZnVsX2dlbmVyYXRpb24YBCABKAQiOgoQSW5zdGFu",
+            "Y2VJZFJlc3VsdBIRCglzdWNjZWVkZWQYASABKAgSEwoLaW5zdGFuY2VfaWQY",
+            "AiABKAkiOQoNVmVjdG9yNFJlc3VsdBIoCgV2YWx1ZRgBIAEoCzIZLnNhaWxv",
+            "ci5lZGl0b3IudjEuVmVjdG9yNCKTAQoXVmlld3BvcnRUb29sU3RhdGVSZXN1",
+            "bHQSPwoJb3BlcmF0aW9uGAEgASgOMiwuc2FpbG9yLmVkaXRvci52MS5WaWV3",
+            "cG9ydFRyYW5zZm9ybU9wZXJhdGlvbhI3CgVzcGFjZRgCIAEoDjIoLnNhaWxv",
+            "ci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1TcGFjZSKoAgoTQW5pbWF0",
+            "b3JTdGF0ZVJlc3VsdBIWCg5oYXNfY29udHJvbGxlchgBIAEoCBIbChNjb250",
+            "cm9sbGVyX3JldmlzaW9uGAIgASgEEhcKD2FjdGl2ZV9zdGF0ZV9pZBgDIAEo",
+            "BBIZChFhY3RpdmVfc3RhdGVfbmFtZRgEIAEoCRIZChFhY3RpdmVfc3RhdGVf",
+            "dGltZRgFIAEoAhIVCg10cmFuc2l0aW9uaW5nGAYgASgIEhwKFGRlc3RpbmF0",
+            "aW9uX3N0YXRlX2lkGAcgASgEEh4KFmRlc3RpbmF0aW9uX3N0YXRlX25hbWUY",
+            "CCABKAkSHgoWZGVzdGluYXRpb25fc3RhdGVfdGltZRgJIAEoAhIYChB0cmFu",
+            "c2l0aW9uX2FscGhhGAogASgCIjUKB1ZlY3RvcjQSCQoBeBgBIAEoAhIJCgF5",
+            "GAIgASgCEgkKAXoYAyABKAISCQoBdxgEIAEoAiI2ChZWaWV3cG9ydFNlbGVj",
+            "dGlvbkV2ZW50EhwKFHNlbGVjdGVkX2luc3RhbmNlX2lkGAEgASgJItYDChZW",
+            "aWV3cG9ydFRyYW5zZm9ybUV2ZW50EhMKC2luc3RhbmNlX2lkGAEgASgJEj8K",
+            "CW9wZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRU",
+            "cmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAyABKA4yKC5zYWlsb3IuZWRp",
+            "dG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2USMgoPYmVmb3JlX3Bvc2l0",
+            "aW9uGAQgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0EjIKD2JlZm9y",
+            "ZV9yb3RhdGlvbhgFIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNBIv",
+            "CgxiZWZvcmVfc2NhbGUYBiABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3Rv",
+            "cjQSMQoOYWZ0ZXJfcG9zaXRpb24YByABKAsyGS5zYWlsb3IuZWRpdG9yLnYx",
+            "LlZlY3RvcjQSMQoOYWZ0ZXJfcm90YXRpb24YCCABKAsyGS5zYWlsb3IuZWRp",
+            "dG9yLnYxLlZlY3RvcjQSLgoLYWZ0ZXJfc2NhbGUYCSABKAsyGS5zYWlsb3Iu",
+            "ZWRpdG9yLnYxLlZlY3RvcjQiVQoWVmlld3BvcnRBc3NldERyb3BFdmVudBIP",
+            "CgdmaWxlX2lkGAEgASgJEhQKDG5vcm1hbGl6ZWRfeBgCIAEoAhIUCgxub3Jt",
+            "YWxpemVkX3kYAyABKAIiLQoZVmlld3BvcnRUb29sU2hvcnRjdXRFdmVudBIQ",
+            "CghrZXlfY29kZRgBIAEoDSLZAgoNVmlld3BvcnRFdmVudBIQCghyZXZpc2lv",
+            "bhgBIAEoBBIhChltYW5hZ2VkX211dGF0aW9uX3JldmlzaW9uGAIgASgEEj0K",
+            "CXNlbGVjdGlvbhgKIAEoCzIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRT",
+            "ZWxlY3Rpb25FdmVudEgAEj0KCXRyYW5zZm9ybRgLIAEoCzIoLnNhaWxvci5l",
+            "ZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1FdmVudEgAEj4KCmFzc2V0X2Ry",
+            "b3AYDCABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0QXNzZXREcm9w",
+            "RXZlbnRIABJECg10b29sX3Nob3J0Y3V0GA0gASgLMisuc2FpbG9yLmVkaXRv",
+            "ci52MS5WaWV3cG9ydFRvb2xTaG9ydGN1dEV2ZW50SABCCQoHcGF5bG9hZEoE",
+            "CAMQCiJLChhWaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHQSLwoGZXZlbnRzGAEg",
+            "AygLMh8uc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEV2ZW50KvABChpWaWV3",
+            "cG9ydFRyYW5zZm9ybU9wZXJhdGlvbhIsCihWSUVXUE9SVF9UUkFOU0ZPUk1f",
+            "T1BFUkFUSU9OX1VOU1BFQ0lGSUVEEAASJwojVklFV1BPUlRfVFJBTlNGT1JN",
+            "X09QRVJBVElPTl9TRUxFQ1QQARIqCiZWSUVXUE9SVF9UUkFOU0ZPUk1fT1BF",
+            "UkFUSU9OX1RSQU5TTEFURRACEicKI1ZJRVdQT1JUX1RSQU5TRk9STV9PUEVS",
+            "QVRJT05fUk9UQVRFEAMSJgoiVklFV1BPUlRfVFJBTlNGT1JNX09QRVJBVElP",
+            "Tl9TQ0FMRRAEKooBChZWaWV3cG9ydFRyYW5zZm9ybVNwYWNlEigKJFZJRVdQ",
+            "T1JUX1RSQU5TRk9STV9TUEFDRV9VTlNQRUNJRklFRBAAEiIKHlZJRVdQT1JU",
+            "X1RSQU5TRk9STV9TUEFDRV9XT1JMRBABEiIKHlZJRVdQT1JUX1RSQU5TRk9S",
+            "TV9TUEFDRV9MT0NBTBACQiKqAh9TYWlsb3JFZGl0b3IuUHJvdG9jb2wuR2Vu",
+            "ZXJhdGVkYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
           new pbr::GeneratedClrTypeInfo(new[] {typeof(global::SailorEditor.Protocol.Generated.ViewportTransformOperation), typeof(global::SailorEditor.Protocol.Generated.ViewportTransformSpace), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Empty), global::SailorEditor.Protocol.Generated.Empty.Parser, null, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset", "CreateModelInstance", "SetAnimatorParameter", "GetAnimatorState" }, new[]{ "Command" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset", "CreateModelInstance", "SetAnimatorParameter", "GetAnimatorState", "SetEditorSimulation", "GetEditorSimulationState" }, new[]{ "Command" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "SupportsStrictInstanceIds", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult", "Vector4Result", "ViewportToolStateResult", "AnimatorStateResult" }, new[]{ "Result" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InitializeRequest), global::SailorEditor.Protocol.Generated.InitializeRequest.Parser, new[]{ "Arguments" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CountRequest), global::SailorEditor.Protocol.Generated.CountRequest.Parser, new[]{ "MaxCount" }, null, null, null, null),
@@ -256,6 +260,7 @@ namespace SailorEditor.Protocol.Generated {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportIdRequest), global::SailorEditor.Protocol.Generated.ViewportIdRequest.Parser, new[]{ "ViewportId" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportRectRequest), global::SailorEditor.Protocol.Generated.ViewportRectRequest.Parser, new[]{ "WindowPosX", "WindowPosY", "Width", "Height" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.SizeRequest), global::SailorEditor.Protocol.Generated.SizeRequest.Parser, new[]{ "Width", "Height" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.EditorSimulationRequest), global::SailorEditor.Protocol.Generated.EditorSimulationRequest.Parser, new[]{ "Enabled" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.RemoteViewportRequest), global::SailorEditor.Protocol.Generated.RemoteViewportRequest.Parser, new[]{ "ViewportId", "WindowPosX", "WindowPosY", "Width", "Height", "Visible", "Focused" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.RemoteViewportHostRequest), global::SailorEditor.Protocol.Generated.RemoteViewportHostRequest.Parser, new[]{ "ViewportId", "HostHandleKind", "HostHandleValue" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.RemoteViewportInputRequest), global::SailorEditor.Protocol.Generated.RemoteViewportInputRequest.Parser, new[]{ "ViewportId", "Kind", "PointerX", "PointerY", "WheelDeltaX", "WheelDeltaY", "KeyCode", "Button", "Modifiers", "Pressed", "Focused", "Captured" }, null, null, null, null),
@@ -664,6 +669,12 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case CommandOneofCase.GetAnimatorState:
           GetAnimatorState = other.GetAnimatorState.Clone();
+          break;
+        case CommandOneofCase.SetEditorSimulation:
+          SetEditorSimulation = other.SetEditorSimulation.Clone();
+          break;
+        case CommandOneofCase.GetEditorSimulationState:
+          GetEditorSimulationState = other.GetEditorSimulationState.Clone();
           break;
       }
 
@@ -1300,6 +1311,30 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "set_editor_simulation" field.</summary>
+    public const int SetEditorSimulationFieldNumber = 61;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.EditorSimulationRequest SetEditorSimulation {
+      get { return commandCase_ == CommandOneofCase.SetEditorSimulation ? (global::SailorEditor.Protocol.Generated.EditorSimulationRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.SetEditorSimulation;
+      }
+    }
+
+    /// <summary>Field number for the "get_editor_simulation_state" field.</summary>
+    public const int GetEditorSimulationStateFieldNumber = 62;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.Empty GetEditorSimulationState {
+      get { return commandCase_ == CommandOneofCase.GetEditorSimulationState ? (global::SailorEditor.Protocol.Generated.Empty) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.GetEditorSimulationState;
+      }
+    }
+
     private object command_;
     /// <summary>Enum of possible cases for the "command" oneof.</summary>
     public enum CommandOneofCase {
@@ -1354,6 +1389,8 @@ namespace SailorEditor.Protocol.Generated {
       CreateModelInstance = 58,
       SetAnimatorParameter = 59,
       GetAnimatorState = 60,
+      SetEditorSimulation = 61,
+      GetEditorSimulationState = 62,
     }
     private CommandOneofCase commandCase_ = CommandOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1436,6 +1473,8 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(CreateModelInstance, other.CreateModelInstance)) return false;
       if (!object.Equals(SetAnimatorParameter, other.SetAnimatorParameter)) return false;
       if (!object.Equals(GetAnimatorState, other.GetAnimatorState)) return false;
+      if (!object.Equals(SetEditorSimulation, other.SetEditorSimulation)) return false;
+      if (!object.Equals(GetEditorSimulationState, other.GetEditorSimulationState)) return false;
       if (CommandCase != other.CommandCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -1496,6 +1535,8 @@ namespace SailorEditor.Protocol.Generated {
       if (commandCase_ == CommandOneofCase.CreateModelInstance) hash ^= CreateModelInstance.GetHashCode();
       if (commandCase_ == CommandOneofCase.SetAnimatorParameter) hash ^= SetAnimatorParameter.GetHashCode();
       if (commandCase_ == CommandOneofCase.GetAnimatorState) hash ^= GetAnimatorState.GetHashCode();
+      if (commandCase_ == CommandOneofCase.SetEditorSimulation) hash ^= SetEditorSimulation.GetHashCode();
+      if (commandCase_ == CommandOneofCase.GetEditorSimulationState) hash ^= GetEditorSimulationState.GetHashCode();
       hash ^= (int) commandCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -1723,6 +1764,14 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(226, 3);
         output.WriteMessage(GetAnimatorState);
       }
+      if (commandCase_ == CommandOneofCase.SetEditorSimulation) {
+        output.WriteRawTag(234, 3);
+        output.WriteMessage(SetEditorSimulation);
+      }
+      if (commandCase_ == CommandOneofCase.GetEditorSimulationState) {
+        output.WriteRawTag(242, 3);
+        output.WriteMessage(GetEditorSimulationState);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -1941,6 +1990,14 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(226, 3);
         output.WriteMessage(GetAnimatorState);
       }
+      if (commandCase_ == CommandOneofCase.SetEditorSimulation) {
+        output.WriteRawTag(234, 3);
+        output.WriteMessage(SetEditorSimulation);
+      }
+      if (commandCase_ == CommandOneofCase.GetEditorSimulationState) {
+        output.WriteRawTag(242, 3);
+        output.WriteMessage(GetEditorSimulationState);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -2106,6 +2163,12 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (commandCase_ == CommandOneofCase.GetAnimatorState) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetAnimatorState);
+      }
+      if (commandCase_ == CommandOneofCase.SetEditorSimulation) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(SetEditorSimulation);
+      }
+      if (commandCase_ == CommandOneofCase.GetEditorSimulationState) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetEditorSimulationState);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -2425,6 +2488,18 @@ namespace SailorEditor.Protocol.Generated {
             GetAnimatorState = new global::SailorEditor.Protocol.Generated.InstanceIdRequest();
           }
           GetAnimatorState.MergeFrom(other.GetAnimatorState);
+          break;
+        case CommandOneofCase.SetEditorSimulation:
+          if (SetEditorSimulation == null) {
+            SetEditorSimulation = new global::SailorEditor.Protocol.Generated.EditorSimulationRequest();
+          }
+          SetEditorSimulation.MergeFrom(other.SetEditorSimulation);
+          break;
+        case CommandOneofCase.GetEditorSimulationState:
+          if (GetEditorSimulationState == null) {
+            GetEditorSimulationState = new global::SailorEditor.Protocol.Generated.Empty();
+          }
+          GetEditorSimulationState.MergeFrom(other.GetEditorSimulationState);
           break;
       }
 
@@ -2905,6 +2980,24 @@ namespace SailorEditor.Protocol.Generated {
             GetAnimatorState = subBuilder;
             break;
           }
+          case 490: {
+            global::SailorEditor.Protocol.Generated.EditorSimulationRequest subBuilder = new global::SailorEditor.Protocol.Generated.EditorSimulationRequest();
+            if (commandCase_ == CommandOneofCase.SetEditorSimulation) {
+              subBuilder.MergeFrom(SetEditorSimulation);
+            }
+            input.ReadMessage(subBuilder);
+            SetEditorSimulation = subBuilder;
+            break;
+          }
+          case 498: {
+            global::SailorEditor.Protocol.Generated.Empty subBuilder = new global::SailorEditor.Protocol.Generated.Empty();
+            if (commandCase_ == CommandOneofCase.GetEditorSimulationState) {
+              subBuilder.MergeFrom(GetEditorSimulationState);
+            }
+            input.ReadMessage(subBuilder);
+            GetEditorSimulationState = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -3380,6 +3473,24 @@ namespace SailorEditor.Protocol.Generated {
             }
             input.ReadMessage(subBuilder);
             GetAnimatorState = subBuilder;
+            break;
+          }
+          case 490: {
+            global::SailorEditor.Protocol.Generated.EditorSimulationRequest subBuilder = new global::SailorEditor.Protocol.Generated.EditorSimulationRequest();
+            if (commandCase_ == CommandOneofCase.SetEditorSimulation) {
+              subBuilder.MergeFrom(SetEditorSimulation);
+            }
+            input.ReadMessage(subBuilder);
+            SetEditorSimulation = subBuilder;
+            break;
+          }
+          case 498: {
+            global::SailorEditor.Protocol.Generated.Empty subBuilder = new global::SailorEditor.Protocol.Generated.Empty();
+            if (commandCase_ == CommandOneofCase.GetEditorSimulationState) {
+              subBuilder.MergeFrom(GetEditorSimulationState);
+            }
+            input.ReadMessage(subBuilder);
+            GetEditorSimulationState = subBuilder;
             break;
           }
         }
@@ -6404,6 +6515,204 @@ namespace SailorEditor.Protocol.Generated {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class EditorSimulationRequest : pb::IMessage<EditorSimulationRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<EditorSimulationRequest> _parser = new pb::MessageParser<EditorSimulationRequest>(() => new EditorSimulationRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<EditorSimulationRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[11]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorSimulationRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorSimulationRequest(EditorSimulationRequest other) : this() {
+      enabled_ = other.enabled_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorSimulationRequest Clone() {
+      return new EditorSimulationRequest(this);
+    }
+
+    /// <summary>Field number for the "enabled" field.</summary>
+    public const int EnabledFieldNumber = 1;
+    private bool enabled_;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Enabled {
+      get { return enabled_; }
+      set {
+        enabled_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as EditorSimulationRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(EditorSimulationRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Enabled != other.Enabled) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Enabled != false) hash ^= Enabled.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Enabled != false) {
+        output.WriteRawTag(8);
+        output.WriteBool(Enabled);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Enabled != false) {
+        output.WriteRawTag(8);
+        output.WriteBool(Enabled);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Enabled != false) {
+        size += 1 + 1;
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(EditorSimulationRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Enabled != false) {
+        Enabled = other.Enabled;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            Enabled = input.ReadBool();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            Enabled = input.ReadBool();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RemoteViewportRequest : pb::IMessage<RemoteViewportRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6418,7 +6727,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[11]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[12]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -6838,7 +7147,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[12]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[13]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7110,7 +7419,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[13]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[14]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7715,7 +8024,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[14]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[15]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7950,7 +8259,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[15]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[16]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8185,7 +8494,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[16]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[17]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8457,7 +8766,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[17]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[18]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8692,7 +9001,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[18]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[19]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8964,7 +9273,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[19]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9494,7 +9803,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9729,7 +10038,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10001,7 +10310,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10273,7 +10582,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10591,7 +10900,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10826,7 +11135,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11061,7 +11370,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11333,7 +11642,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11520,7 +11829,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11718,7 +12027,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12064,7 +12373,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12262,7 +12571,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12460,7 +12769,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12658,7 +12967,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12856,7 +13165,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13091,7 +13400,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13278,7 +13587,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13587,7 +13896,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13822,7 +14131,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14029,7 +14338,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14264,7 +14573,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14795,7 +15104,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15104,7 +15413,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15302,7 +15611,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15850,7 +16159,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -16122,7 +16431,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[46]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -16320,7 +16629,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[46]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[47]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -16794,7 +17103,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[47]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[48]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/Editor/Services/EditorToolbarActions.cs
+++ b/Editor/Services/EditorToolbarActions.cs
@@ -8,10 +8,38 @@ using ViewModelGameObject = SailorEditor.ViewModels.GameObject;
 
 namespace SailorEditor.Services
 {
-    public sealed class EditorToolbarActions
+    internal sealed class EditorToolbarActions
     {
+        readonly EngineService engineService;
+        readonly SemaphoreSlim simulationGate = new(1, 1);
+        int isSimulating;
+
+        public EditorToolbarActions(EngineService engineService)
+        {
+            this.engineService = engineService ??
+                throw new ArgumentNullException(nameof(engineService));
+            engineService.OnEditorSimulationStateChanged +=
+                SetSimulationState;
+            engineService.OnLifecycleStateChanged += state =>
+            {
+                if (state != EngineLifecycleState.Running)
+                    SetSimulationState(false);
+            };
+        }
+
+        public bool IsSimulating => Volatile.Read(ref isSimulating) != 0;
+        public event Action<bool> SimulationStateChanged = delegate { };
+
         public async Task SaveAsync()
         {
+            if (await engineService.GetEditorSimulationStateAsync())
+            {
+                await DisplayStatus(
+                    "Save Scene",
+                    "Stop simulation before saving the scene.");
+                return;
+            }
+
             var selectionService = MauiProgram.GetService<SelectionService>();
             var selected = selectionService.SelectedItem;
 
@@ -75,7 +103,14 @@ namespace SailorEditor.Services
             bool debug,
             CancellationToken cancellationToken = default)
         {
-            var engineService = MauiProgram.GetService<EngineService>();
+            if (await engineService.GetEditorSimulationStateAsync(
+                    cancellationToken))
+            {
+                await DisplayStatus(
+                    debug ? "Debug" : "Play",
+                    "Stop simulation before launching the world.");
+                return;
+            }
 
             var launchContext = engineService.GetLaunchContext();
             var world =
@@ -92,6 +127,66 @@ namespace SailorEditor.Services
                 launchContext.TempWorldRuntimePath,
                 debug,
                 launchContext);
+        }
+
+        public async Task ToggleSimulationAsync(
+            CancellationToken cancellationToken = default)
+        {
+            await simulationGate.WaitAsync(cancellationToken);
+            try
+            {
+                var nativeState = await engineService
+                    .GetEditorSimulationStateAsync(cancellationToken);
+                var enable = !nativeState;
+                if (enable)
+                {
+                    var selected = MauiProgram
+                        .GetService<SelectionService>()
+                        .SelectedItem;
+                    if (selected is IInspectorEditable editable &&
+                        editable.HasPendingInspectorChanges &&
+                        !await editable.CommitInspectorChangesAsync())
+                    {
+                        await DisplayStatus(
+                            "Simulate",
+                            "Inspector changes could not be committed.");
+                        return;
+                    }
+                }
+
+                if (!await engineService.SetEditorSimulationAsync(
+                        enable,
+                        cancellationToken))
+                {
+                    await DisplayStatus(
+                        enable ? "Simulate" : "Stop Simulation",
+                        enable
+                            ? "Unable to snapshot the current world and start physics simulation."
+                            : "Unable to restore the world snapshot.");
+                    return;
+                }
+
+                SetSimulationState(enable);
+                if (!enable &&
+                    !await engineService.RefreshCurrentWorldAuthoritativelyAsync(
+                        cancellationToken))
+                {
+                    await DisplayStatus(
+                        "Stop Simulation",
+                        "The world was restored, but the Editor projection could not be refreshed.");
+                    return;
+                }
+
+                await DisplayStatus(
+                    enable ? "Simulate" : "Stop Simulation",
+                    enable
+                        ? "Physics simulation started. Scene changes will be restored on Stop."
+                        : "Physics simulation stopped and the scene snapshot was restored.");
+            }
+            finally
+            {
+                simulationGate.Release();
+            }
         }
 
         public async Task ExportPathTracedImageAsync(bool selectedOnly)
@@ -155,6 +250,19 @@ namespace SailorEditor.Services
         {
             MauiProgram.GetService<EditorShellHost>().SetStatus(message);
             return Task.CompletedTask;
+        }
+
+        void SetSimulationState(bool value)
+        {
+            var next = value ? 1 : 0;
+            if (Interlocked.Exchange(ref isSimulating, next) == next)
+                return;
+
+            void Publish() => SimulationStateChanged(value);
+            if (MainThread.IsMainThread)
+                Publish();
+            else
+                MainThread.BeginInvokeOnMainThread(Publish);
         }
     }
 }

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -226,6 +226,7 @@ namespace SailorEditor.Services
         public event Action<EngineLifecycleState> OnLifecycleStateChanged = delegate { };
         public event Action<AssetReloadCompletion> OnAssetReloadCompleted = delegate { };
         public event Action<IReadOnlyList<EditorViewportEvent>> OnEditorViewportEvents = delegate { };
+        public event Action<bool> OnEditorSimulationStateChanged = delegate { };
 
         public string EngineContentDirectory => Path.Combine(repoRoot, "Content");
 
@@ -3004,8 +3005,15 @@ namespace SailorEditor.Services
 
             if (result)
             {
+                PublishEditorSimulationState(false);
                 await RefreshCurrentWorldAsync(
                     cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                PublishEditorSimulationState(
+                    await GetEditorSimulationStateAsync(
+                        cancellationToken).ConfigureAwait(false));
             }
 
             return result;
@@ -3028,11 +3036,47 @@ namespace SailorEditor.Services
 
             if (result)
             {
+                PublishEditorSimulationState(false);
                 await RefreshCurrentWorldAsync(
                     cancellationToken).ConfigureAwait(false);
             }
+            else
+            {
+                PublishEditorSimulationState(
+                    await GetEditorSimulationStateAsync(
+                        cancellationToken).ConfigureAwait(false));
+            }
 
             return result;
+        }
+
+        public async Task<bool> SetEditorSimulationAsync(
+            bool enabled,
+            CancellationToken cancellationToken = default)
+        {
+            var result = await InvokeRunningInteropAsync(
+                token => protocolClient.SetEditorSimulationAsync(
+                    enabled,
+                    token),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (result)
+                PublishEditorSimulationState(enabled);
+            return result;
+        }
+
+        public Task<bool> GetEditorSimulationStateAsync(
+            CancellationToken cancellationToken = default)
+            => InvokeRunningInteropAsync(
+                protocolClient.GetEditorSimulationStateAsync,
+                cancellationToken: cancellationToken);
+
+        void PublishEditorSimulationState(bool enabled)
+        {
+            void Publish() => OnEditorSimulationStateChanged(enabled);
+            if (MainThread.IsMainThread)
+                Publish();
+            else
+                MainThread.BeginInvokeOnMainThread(Publish);
         }
 
         public async Task<string> SerializeCurrentWorldAsync(

--- a/Editor/Services/WorldService.cs
+++ b/Editor/Services/WorldService.cs
@@ -327,6 +327,14 @@ namespace SailorEditor.Services
             CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
+            if (await engineService.GetEditorSimulationStateAsync(
+                    cancellationToken))
+            {
+                return new SceneSaveResult(
+                    SceneSaveOutcome.Failed,
+                    Error: "Stop simulation before saving the scene.");
+            }
+
             var page = Application.Current?.Windows.FirstOrDefault()?.Page ?? Application.Current?.MainPage;
             if (page is null)
                 return new SceneSaveResult(SceneSaveOutcome.Failed, Error: "The editor window is unavailable.");

--- a/Editor/Views/ToolbarView.xaml
+++ b/Editor/Views/ToolbarView.xaml
@@ -106,6 +106,14 @@
                         <ImageButton Source="bug__arrow.png"
                                      Style="{StaticResource ToolbarIconButtonStyle}"
                                      Clicked="OnPlayDebugButtonClicked"/>
+                        <Button x:Name="SimulationButton"
+                                Text="Simulate"
+                                ImageSource="control.png"
+                                ContentLayout="Left,4"
+                                Style="{StaticResource ToolbarGlyphButtonStyle}"
+                                WidthRequest="82"
+                                MinimumWidthRequest="82"
+                                Clicked="OnSimulationButtonClicked"/>
                     </HorizontalStackLayout>
                 </Border>
             </HorizontalStackLayout>

--- a/Editor/Views/ToolbarView.xaml.cs
+++ b/Editor/Views/ToolbarView.xaml.cs
@@ -11,6 +11,8 @@ namespace SailorEditor.Views
             InitializeComponent();
             BindingContext = this;
             actions = MauiProgram.GetService<EditorToolbarActions>();
+            actions.SimulationStateChanged += OnSimulationStateChanged;
+            UpdateSimulationButton(actions.IsSimulating);
         }
 
         private void OnSaveButtonClicked(object sender, EventArgs e)
@@ -27,6 +29,10 @@ namespace SailorEditor.Views
             => RunToolbarAction(
                 () => actions.RunWorldAsync(true),
                 "Debug play");
+        private void OnSimulationButtonClicked(object sender, EventArgs e)
+            => RunToolbarAction(
+                () => actions.ToggleSimulationAsync(),
+                actions.IsSimulating ? "Stop simulation" : "Simulate");
         private void OnPathTraceSceneButtonClicked(object sender, EventArgs e)
             => RunToolbarAction(
                 () => actions.ExportPathTracedImageAsync(false),
@@ -73,6 +79,22 @@ namespace SailorEditor.Views
                         $"Failed to publish toolbar action error status: {statusException}");
                 }
             }
+        }
+
+        void OnSimulationStateChanged(bool isSimulating)
+            => Dispatcher.Dispatch(
+                () => UpdateSimulationButton(isSimulating));
+
+        void UpdateSimulationButton(bool isSimulating)
+        {
+            SimulationButton.Text = isSimulating ? "Stop" : "Simulate";
+            SimulationButton.ImageSource = ImageSource.FromFile(
+                isSimulating
+                    ? "control_stop_square.png"
+                    : "control.png");
+            SimulationButton.TextColor = isSimulating
+                ? Color.FromArgb("#F06B6B")
+                : Color.FromArgb("#CFCFD2");
         }
     }
 }

--- a/Lib/CMakeLists.txt
+++ b/Lib/CMakeLists.txt
@@ -71,6 +71,12 @@ if(NOT ixwebsocket_FOUND)
 	sailor_create_stub_target(ixwebsocket::ixwebsocket)
 endif()
 
+find_package(Jolt CONFIG QUIET)
+if(NOT Jolt_FOUND)
+	list(APPEND SAILOR_MISSING_DEPS "Jolt")
+	sailor_create_stub_target(Jolt::Jolt)
+endif()
+
 find_package(magic_enum CONFIG QUIET)
 if(NOT magic_enum_FOUND)
 	list(APPEND SAILOR_MISSING_DEPS "magic_enum")
@@ -128,6 +134,19 @@ file(GLOB_RECURSE SAILOR_RUNTIME_SOURCES
   "${SAILOR_RUNTIME_DIR}/*.mm"
   "${SAILOR_RUNTIME_DIR}/*.hpp"
   "${SAILOR_RUNTIME_DIR}/*.natvis")
+
+# vcpkg builds Jolt without compiler RTTI. Keep the Sailor adapter that derives
+# from Jolt's JobSystemWithBarrier on the same ABI while the rest of Sailor
+# retains RTTI for reflected engine types.
+if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+	set_source_files_properties(
+		"${SAILOR_RUNTIME_DIR}/Physics/JoltJobSystem.cpp"
+		PROPERTIES COMPILE_OPTIONS "/GR-")
+else()
+	set_source_files_properties(
+		"${SAILOR_RUNTIME_DIR}/Physics/JoltJobSystem.cpp"
+		PROPERTIES COMPILE_OPTIONS "-fno-rtti")
+endif()
 
 file(GLOB_RECURSE SAILOR_LIB_SOURCES
   "*.h"
@@ -235,6 +254,7 @@ target_link_libraries(SailorLib PRIVATE
 	draco::draco
 	imguizmo::imguizmo
 	ixwebsocket::ixwebsocket
+	Jolt::Jolt
 	meshoptimizer::meshoptimizer
 	protobuf::libprotobuf
 	${CMAKE_DL_LIBS}

--- a/Lib/EditorEngineProtocol.cpp
+++ b/Lib/EditorEngineProtocol.cpp
@@ -1102,6 +1102,19 @@ namespace
 			SetBoolResult(response, Sailor::App::CreateEditorWorld());
 			break;
 
+		case ProtocolRequest::kSetEditorSimulation:
+			SetBoolResult(
+				response,
+				Sailor::App::SetEditorSimulationEnabled(
+					request.set_editor_simulation().enabled()));
+			break;
+
+		case ProtocolRequest::kGetEditorSimulationState:
+			SetBoolResult(
+				response,
+				Sailor::App::IsEditorSimulationEnabled());
+			break;
+
 		case ProtocolRequest::kSetViewport:
 		{
 			const auto& viewport = request.set_viewport();

--- a/Protocol/README.md
+++ b/Protocol/README.md
@@ -83,6 +83,17 @@ renderer using `meshIndex = -1` for the complete model. World mutation is
 marshalled from the Editor worker to the Engine main thread; any failure rolls
 back the owned root recursively before the command reports failure.
 
+`set_editor_simulation` starts or stops physics preview for the current Editor
+world. Start first serializes the authored native world into an in-memory
+snapshot and only then enables fixed-step physics. Stop instantiates that
+snapshot as a replacement Editor world, destroys the simulated world, and the
+managed Editor refreshes its hierarchy and inspector from the restored native
+state. Scene save and Play/Debug are rejected while simulation is active so
+transient physics poses cannot be persisted. `get_editor_simulation_state`
+queries the native authority; toolbar state is never inferred solely from a
+previous button click. Both commands use the regular Editor worker and marshal
+world mutations to the Engine main thread.
+
 Compatibility rules:
 
 - Ordinary commands use baseline `protocol_version = 1`. Strict InstanceId

--- a/Protocol/editor_engine.proto
+++ b/Protocol/editor_engine.proto
@@ -62,13 +62,15 @@ message ProtocolRequest {
 		CreateModelInstanceRequest create_model_instance = 58;
 		AnimatorParameterRequest set_animator_parameter = 59;
 		InstanceIdRequest get_animator_state = 60;
+		EditorSimulationRequest set_editor_simulation = 61;
+		Empty get_editor_simulation_state = 62;
 	}
 
 	reserved 3 to 9;
 	reserved 50;
 	reserved "create_model_game_object";
 	reserved "resolve_viewport_drop_position";
-	reserved 61 to 99;
+	reserved 63 to 99;
 }
 
 message ProtocolResponse {
@@ -138,6 +140,10 @@ message ViewportRectRequest {
 message SizeRequest {
 	uint32 width = 1;
 	uint32 height = 2;
+}
+
+message EditorSimulationRequest {
+	bool enabled = 1;
 }
 
 message RemoteViewportRequest {

--- a/Runtime/Components/CollisionShapeComponent.cpp
+++ b/Runtime/Components/CollisionShapeComponent.cpp
@@ -1,0 +1,145 @@
+#include "Components/CollisionShapeComponent.h"
+#include "Components/RigidBodyComponent.h"
+#include "Engine/GameObject.h"
+#include "Math/Math.h"
+#include <algorithm>
+
+using namespace Sailor;
+
+void CollisionShapeComponent::Initialize()
+{
+	NotifyRigidBody();
+}
+
+void CollisionShapeComponent::EndPlay()
+{
+	const auto owner = GetOwner();
+	if (!owner)
+	{
+		return;
+	}
+
+	for (const ComponentPtr& component : owner->GetComponents())
+	{
+		if (component.GetRawPtr() == this)
+		{
+			// RemoveAllComponents keeps every component in the owner array until
+			// teardown completes. The rigid body owns the native cleanup there,
+			// and may already have been destroyed before this shape is visited.
+			return;
+		}
+	}
+
+	NotifyRigidBody();
+}
+
+void CollisionShapeComponent::NotifyRigidBody()
+{
+	if (auto rigidBody = GetOwner()
+		? GetOwner()->GetComponent<RigidBodyComponent>()
+		: TObjectPtr<RigidBodyComponent>{})
+	{
+		rigidBody->MarkPhysicsDirty();
+	}
+}
+
+void CollisionShapeComponent::SetShapeType(
+	Physics::ECollisionShapeType value)
+{
+	if (m_shapeType != value)
+	{
+		m_shapeType = value;
+		NotifyRigidBody();
+	}
+}
+
+void CollisionShapeComponent::SetCenter(const glm::vec3& value)
+{
+	if (!Math::AllFinite(value))
+	{
+		return;
+	}
+
+	if (m_center != value)
+	{
+		m_center = value;
+		NotifyRigidBody();
+	}
+}
+
+void CollisionShapeComponent::SetRotation(const glm::quat& value)
+{
+	const glm::vec4 raw(value.x, value.y, value.z, value.w);
+	const glm::vec4 sanitized = Math::SafeNormalize(
+		raw,
+		glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+	const glm::quat normalized(
+		sanitized.w,
+		sanitized.x,
+		sanitized.y,
+		sanitized.z);
+	if (m_rotation != normalized)
+	{
+		m_rotation = normalized;
+		NotifyRigidBody();
+	}
+}
+
+void CollisionShapeComponent::SetSize(const glm::vec3& value)
+{
+	if (!Math::AllFinite(value))
+	{
+		return;
+	}
+
+	const glm::vec3 sanitized = glm::max(
+		glm::abs(value),
+		glm::vec3(0.001f));
+	if (m_size != sanitized)
+	{
+		m_size = sanitized;
+		NotifyRigidBody();
+	}
+}
+
+void CollisionShapeComponent::SetRadius(float value)
+{
+	if (!std::isfinite(value))
+	{
+		return;
+	}
+
+	value = std::max(0.001f, std::abs(value));
+	if (m_radius != value)
+	{
+		m_radius = value;
+		NotifyRigidBody();
+	}
+}
+
+void CollisionShapeComponent::SetHeight(float value)
+{
+	if (!std::isfinite(value))
+	{
+		return;
+	}
+
+	value = std::max(0.002f, std::abs(value));
+	if (m_height != value)
+	{
+		m_height = value;
+		NotifyRigidBody();
+	}
+}
+
+Physics::CollisionShapeDesc CollisionShapeComponent::BuildDesc() const
+{
+	Physics::CollisionShapeDesc result{};
+	result.m_type = m_shapeType;
+	result.m_center = m_center;
+	result.m_rotation = m_rotation;
+	result.m_size = m_size;
+	result.m_radius = m_radius;
+	result.m_height = m_height;
+	return result;
+}

--- a/Runtime/Components/CollisionShapeComponent.h
+++ b/Runtime/Components/CollisionShapeComponent.h
@@ -1,0 +1,59 @@
+#pragma once
+#include "Components/Component.h"
+#include "Physics/PhysicsTypes.h"
+
+namespace Sailor
+{
+	class CollisionShapeComponent final : public Component
+	{
+		SAILOR_REFLECTABLE(CollisionShapeComponent)
+
+	public:
+		SAILOR_API void Initialize() override;
+		SAILOR_API void EndPlay() override;
+
+		SAILOR_API Physics::ECollisionShapeType GetShapeType() const { return m_shapeType; }
+		SAILOR_API void SetShapeType(Physics::ECollisionShapeType value);
+		SAILOR_API const glm::vec3& GetCenter() const { return m_center; }
+		SAILOR_API void SetCenter(const glm::vec3& value);
+		SAILOR_API const glm::quat& GetRotation() const { return m_rotation; }
+		SAILOR_API void SetRotation(const glm::quat& value);
+		SAILOR_API const glm::vec3& GetSize() const { return m_size; }
+		SAILOR_API void SetSize(const glm::vec3& value);
+		SAILOR_API float GetRadius() const { return m_radius; }
+		SAILOR_API void SetRadius(float value);
+		SAILOR_API float GetHeight() const { return m_height; }
+		SAILOR_API void SetHeight(float value);
+
+		SAILOR_API Physics::CollisionShapeDesc BuildDesc() const;
+
+	private:
+		void NotifyRigidBody();
+
+		Physics::ECollisionShapeType m_shapeType =
+			Physics::ECollisionShapeType::Box;
+		glm::vec3 m_center{};
+		glm::quat m_rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+		glm::vec3 m_size = glm::vec3(1.0f);
+		float m_radius = 0.5f;
+		float m_height = 1.0f;
+	};
+}
+
+using namespace Sailor::Attributes;
+
+REFL_AUTO(
+	type(Sailor::CollisionShapeComponent, bases<Sailor::Component>),
+	func(GetShapeType, property("shapeType")),
+	func(SetShapeType, property("shapeType")),
+	func(GetCenter, property("center")),
+	func(SetCenter, property("center")),
+	func(GetRotation, property("rotation")),
+	func(SetRotation, property("rotation")),
+	func(GetSize, property("size")),
+	func(SetSize, property("size")),
+	func(GetRadius, property("radius")),
+	func(SetRadius, property("radius")),
+	func(GetHeight, property("height")),
+	func(SetHeight, property("height"))
+)

--- a/Runtime/Components/RigidBodyComponent.cpp
+++ b/Runtime/Components/RigidBodyComponent.cpp
@@ -1,0 +1,203 @@
+#include "Components/RigidBodyComponent.h"
+#include "ECS/PhysicsECS.h"
+#include "Engine/GameObject.h"
+#include "Math/Math.h"
+#include <algorithm>
+#include <cmath>
+
+using namespace Sailor;
+
+void RigidBodyComponent::Initialize()
+{
+	auto* ecs = GetOwner()->GetWorld()->GetECS<PhysicsECS>();
+	m_handle = ecs->RegisterComponent();
+	auto& data = ecs->GetComponentData(m_handle);
+	data.SetOwner(GetOwner());
+	data.MarkDirty();
+	data.MarkVelocityDirty();
+}
+
+void RigidBodyComponent::EndPlay()
+{
+	if (m_handle != ECS::InvalidIndex)
+	{
+		GetOwner()->GetWorld()->GetECS<PhysicsECS>()
+			->UnregisterComponent(m_handle);
+		m_handle = ECS::InvalidIndex;
+	}
+}
+
+void RigidBodyComponent::MarkPhysicsDirty()
+{
+	if (m_handle != ECS::InvalidIndex)
+	{
+		GetOwner()->GetWorld()->GetECS<PhysicsECS>()
+			->GetComponentData(m_handle)
+			.MarkDirty();
+	}
+}
+
+void RigidBodyComponent::SetMotionType(
+	Physics::ERigidBodyMotionType value)
+{
+	if (m_motionType != value)
+	{
+		m_motionType = value;
+		MarkPhysicsDirty();
+	}
+}
+
+void RigidBodyComponent::SetMass(float value)
+{
+	if (!std::isfinite(value))
+	{
+		return;
+	}
+
+	value = std::max(0.001f, value);
+	if (m_mass != value)
+	{
+		m_mass = value;
+		MarkPhysicsDirty();
+	}
+}
+
+void RigidBodyComponent::SetFriction(float value)
+{
+	if (!std::isfinite(value))
+	{
+		return;
+	}
+
+	value = std::max(0.0f, value);
+	if (m_friction != value)
+	{
+		m_friction = value;
+		MarkPhysicsDirty();
+	}
+}
+
+void RigidBodyComponent::SetRestitution(float value)
+{
+	if (!std::isfinite(value))
+	{
+		return;
+	}
+
+	value = std::clamp(value, 0.0f, 1.0f);
+	if (m_restitution != value)
+	{
+		m_restitution = value;
+		MarkPhysicsDirty();
+	}
+}
+
+void RigidBodyComponent::SetLinearDamping(float value)
+{
+	if (!std::isfinite(value))
+	{
+		return;
+	}
+
+	value = std::clamp(value, 0.0f, 1.0f);
+	if (m_linearDamping != value)
+	{
+		m_linearDamping = value;
+		MarkPhysicsDirty();
+	}
+}
+
+void RigidBodyComponent::SetAngularDamping(float value)
+{
+	if (!std::isfinite(value))
+	{
+		return;
+	}
+
+	value = std::clamp(value, 0.0f, 1.0f);
+	if (m_angularDamping != value)
+	{
+		m_angularDamping = value;
+		MarkPhysicsDirty();
+	}
+}
+
+void RigidBodyComponent::SetGravityFactor(float value)
+{
+	if (!std::isfinite(value))
+	{
+		return;
+	}
+
+	if (m_gravityFactor != value)
+	{
+		m_gravityFactor = value;
+		MarkPhysicsDirty();
+	}
+}
+
+void RigidBodyComponent::SetCollisionLayer(uint32_t value)
+{
+	const uint8_t layer = static_cast<uint8_t>(std::min(value, 15u));
+	if (m_collisionLayer != layer)
+	{
+		m_collisionLayer = layer;
+		MarkPhysicsDirty();
+	}
+}
+
+void RigidBodyComponent::SetSensor(bool value)
+{
+	if (m_bSensor != value)
+	{
+		m_bSensor = value;
+		MarkPhysicsDirty();
+	}
+}
+
+void RigidBodyComponent::SetSleepingAllowed(bool value)
+{
+	if (m_bAllowSleeping != value)
+	{
+		m_bAllowSleeping = value;
+		MarkPhysicsDirty();
+	}
+}
+
+void RigidBodyComponent::SetLinearVelocity(const glm::vec3& value)
+{
+	if (!Math::AllFinite(value))
+	{
+		return;
+	}
+
+	if (m_linearVelocity != value)
+	{
+		m_linearVelocity = value;
+		if (m_handle != ECS::InvalidIndex)
+		{
+			GetOwner()->GetWorld()->GetECS<PhysicsECS>()
+				->GetComponentData(m_handle)
+				.MarkVelocityDirty();
+		}
+	}
+}
+
+void RigidBodyComponent::SetAngularVelocity(const glm::vec3& value)
+{
+	if (!Math::AllFinite(value))
+	{
+		return;
+	}
+
+	if (m_angularVelocity != value)
+	{
+		m_angularVelocity = value;
+		if (m_handle != ECS::InvalidIndex)
+		{
+			GetOwner()->GetWorld()->GetECS<PhysicsECS>()
+				->GetComponentData(m_handle)
+				.MarkVelocityDirty();
+		}
+	}
+}

--- a/Runtime/Components/RigidBodyComponent.h
+++ b/Runtime/Components/RigidBodyComponent.h
@@ -1,0 +1,90 @@
+#pragma once
+#include "Components/Component.h"
+#include "ECS/ECS.h"
+#include "Physics/PhysicsTypes.h"
+
+namespace Sailor
+{
+	class RigidBodyComponent final : public Component
+	{
+		SAILOR_REFLECTABLE(RigidBodyComponent)
+
+	public:
+		SAILOR_API void Initialize() override;
+		SAILOR_API void EndPlay() override;
+
+		SAILOR_API Physics::ERigidBodyMotionType GetMotionType() const { return m_motionType; }
+		SAILOR_API void SetMotionType(Physics::ERigidBodyMotionType value);
+		SAILOR_API float GetMass() const { return m_mass; }
+		SAILOR_API void SetMass(float value);
+		SAILOR_API float GetFriction() const { return m_friction; }
+		SAILOR_API void SetFriction(float value);
+		SAILOR_API float GetRestitution() const { return m_restitution; }
+		SAILOR_API void SetRestitution(float value);
+		SAILOR_API float GetLinearDamping() const { return m_linearDamping; }
+		SAILOR_API void SetLinearDamping(float value);
+		SAILOR_API float GetAngularDamping() const { return m_angularDamping; }
+		SAILOR_API void SetAngularDamping(float value);
+		SAILOR_API float GetGravityFactor() const { return m_gravityFactor; }
+		SAILOR_API void SetGravityFactor(float value);
+		SAILOR_API uint32_t GetCollisionLayer() const { return m_collisionLayer; }
+		SAILOR_API void SetCollisionLayer(uint32_t value);
+		SAILOR_API bool IsSensor() const { return m_bSensor; }
+		SAILOR_API void SetSensor(bool value);
+		SAILOR_API bool IsSleepingAllowed() const { return m_bAllowSleeping; }
+		SAILOR_API void SetSleepingAllowed(bool value);
+		SAILOR_API const glm::vec3& GetLinearVelocity() const { return m_linearVelocity; }
+		SAILOR_API void SetLinearVelocity(const glm::vec3& value);
+		SAILOR_API const glm::vec3& GetAngularVelocity() const { return m_angularVelocity; }
+		SAILOR_API void SetAngularVelocity(const glm::vec3& value);
+
+		SAILOR_API void MarkPhysicsDirty();
+		SAILOR_API size_t GetComponentIndex() const { return m_handle; }
+
+	private:
+		Physics::ERigidBodyMotionType m_motionType =
+			Physics::ERigidBodyMotionType::Dynamic;
+		glm::vec3 m_linearVelocity{};
+		glm::vec3 m_angularVelocity{};
+		float m_mass = 1.0f;
+		float m_friction = 0.2f;
+		float m_restitution = 0.0f;
+		float m_linearDamping = 0.05f;
+		float m_angularDamping = 0.05f;
+		float m_gravityFactor = 1.0f;
+		size_t m_handle = ECS::InvalidIndex;
+		uint8_t m_collisionLayer = 0;
+		bool m_bSensor = false;
+		bool m_bAllowSleeping = true;
+	};
+}
+
+using namespace Sailor::Attributes;
+
+REFL_AUTO(
+	type(Sailor::RigidBodyComponent, bases<Sailor::Component>),
+	func(GetMotionType, property("motionType")),
+	func(SetMotionType, property("motionType")),
+	func(GetMass, property("mass")),
+	func(SetMass, property("mass")),
+	func(GetFriction, property("friction")),
+	func(SetFriction, property("friction")),
+	func(GetRestitution, property("restitution"), Range(0.0, 1.0)),
+	func(SetRestitution, property("restitution")),
+	func(GetLinearDamping, property("linearDamping"), Range(0.0, 1.0)),
+	func(SetLinearDamping, property("linearDamping")),
+	func(GetAngularDamping, property("angularDamping"), Range(0.0, 1.0)),
+	func(SetAngularDamping, property("angularDamping")),
+	func(GetGravityFactor, property("gravityFactor")),
+	func(SetGravityFactor, property("gravityFactor")),
+	func(GetCollisionLayer, property("collisionLayer"), Range(0.0, 15.0)),
+	func(SetCollisionLayer, property("collisionLayer")),
+	func(IsSensor, property("sensor")),
+	func(SetSensor, property("sensor")),
+	func(IsSleepingAllowed, property("allowSleeping")),
+	func(SetSleepingAllowed, property("allowSleeping")),
+	func(GetLinearVelocity, property("linearVelocity")),
+	func(SetLinearVelocity, property("linearVelocity")),
+	func(GetAngularVelocity, property("angularVelocity")),
+	func(SetAngularVelocity, property("angularVelocity"))
+)

--- a/Runtime/Core/Reflection.cpp
+++ b/Runtime/Core/Reflection.cpp
@@ -17,6 +17,7 @@
 #include "AssetRegistry/Texture/TextureAssetInfo.h"
 #include "AssetRegistry/World/WorldPrefabAssetInfo.h"
 #include "RHI/SceneView.h"
+#include "Physics/PhysicsTypes.h"
 #include <algorithm>
 #include <condition_variable>
 #include <iterator>
@@ -694,6 +695,8 @@ YAML::Node Reflection::ExportEngineTypes()
 	nodes.Add(ReflectEnumValues<EMobilityType>());
 	nodes.Add(ReflectEnumValues<ELightType>());
 	nodes.Add(ReflectEnumValues<EAnimationPlayMode>());
+	nodes.Add(ReflectEnumValues<Physics::ERigidBodyMotionType>());
+	nodes.Add(ReflectEnumValues<Physics::ECollisionShapeType>());
 	nodes.Add(ReflectEnumValues<RHI::EFormat>());
 	nodes.Add(ReflectEnumValues<RHI::ETextureFiltration>());
 	nodes.Add(ReflectEnumValues<RHI::ETextureClamping>());

--- a/Runtime/ECS/PhysicsECS.cpp
+++ b/Runtime/ECS/PhysicsECS.cpp
@@ -1,0 +1,431 @@
+#include "ECS/PhysicsECS.h"
+#include "ECS/TransformECS.h"
+#include "Physics/PhysicsWorld.h"
+#include "Physics/JoltRuntime.h"
+#include "Components/RigidBodyComponent.h"
+#include "Components/CollisionShapeComponent.h"
+#include "Engine/GameObject.h"
+#include "Engine/World.h"
+#include "Math/Transform.h"
+#include "Tasks/Tasks.h"
+#include <algorithm>
+#include <cmath>
+
+using namespace Sailor;
+
+PhysicsECS::PhysicsECS() = default;
+PhysicsECS::~PhysicsECS() = default;
+
+bool PhysicsECS::EnsurePhysicsWorld()
+{
+	if (m_physicsWorld)
+	{
+		return true;
+	}
+
+	if (!App::GetSubmodule<Physics::JoltRuntime>())
+	{
+		return false;
+	}
+
+	m_physicsWorld = TUniquePtr<Physics::PhysicsWorld>::Make();
+	return true;
+}
+
+void PhysicsECS::SetFixedDeltaTime(float value)
+{
+	m_fixedDeltaTime = std::clamp(value, 1.0f / 1000.0f, 1.0f);
+	m_accumulator = std::min(m_accumulator, m_fixedDeltaTime);
+}
+
+void PhysicsECS::SetMaxSubSteps(uint32_t value)
+{
+	m_maxSubSteps = std::clamp(value, 1u, 16u);
+}
+
+bool PhysicsECS::BuildBodyDesc(
+	size_t index,
+	Physics::RigidBodyDesc& outDesc)
+{
+	if (!IsComponentRegistered(index))
+	{
+		return false;
+	}
+
+	auto& data = GetComponentData(index);
+	auto gameObject = data.m_owner.StaticCast<GameObject>();
+	if (!gameObject)
+	{
+		return false;
+	}
+
+	auto rigidBody = gameObject->GetComponent<RigidBodyComponent>();
+	if (!rigidBody || rigidBody->GetComponentIndex() != index)
+	{
+		return false;
+	}
+
+	const Math::Transform worldTransform = Math::Transform::FromMatrix(
+		gameObject->GetTransformComponent().GetCachedWorldMatrix());
+	outDesc = {};
+	outDesc.m_instanceId = gameObject->GetInstanceId();
+	outDesc.m_motionType = rigidBody->GetMotionType();
+	outDesc.m_position = glm::vec3(worldTransform.m_position);
+	outDesc.m_rotation = worldTransform.m_rotation;
+	outDesc.m_scale = glm::vec3(worldTransform.m_scale);
+	outDesc.m_linearVelocity = rigidBody->GetLinearVelocity();
+	outDesc.m_angularVelocity = rigidBody->GetAngularVelocity();
+	outDesc.m_mass = rigidBody->GetMass();
+	outDesc.m_friction = rigidBody->GetFriction();
+	outDesc.m_restitution = rigidBody->GetRestitution();
+	outDesc.m_linearDamping = rigidBody->GetLinearDamping();
+	outDesc.m_angularDamping = rigidBody->GetAngularDamping();
+	outDesc.m_gravityFactor = rigidBody->GetGravityFactor();
+	outDesc.m_collisionLayer = static_cast<uint8_t>(
+		rigidBody->GetCollisionLayer());
+	outDesc.m_bSensor = rigidBody->IsSensor();
+	outDesc.m_bAllowSleeping = rigidBody->IsSleepingAllowed();
+
+	for (const auto& component : gameObject->GetComponents())
+	{
+		if (auto shape = component.DynamicCast<CollisionShapeComponent>())
+		{
+			outDesc.m_shapes.Add(shape->BuildDesc());
+		}
+	}
+	return !outDesc.m_shapes.IsEmpty();
+}
+
+bool PhysicsECS::RecreateBody(size_t index)
+{
+	if (!EnsurePhysicsWorld() || !IsComponentRegistered(index))
+	{
+		return false;
+	}
+
+	auto& data = GetComponentData(index);
+	Physics::RigidBodyDesc desc{};
+	if (!BuildBodyDesc(index, desc))
+	{
+		if (data.m_bodyId != RigidBodyData::InvalidBodyId)
+		{
+			m_physicsWorld->DestroyBody(data.m_bodyId);
+			data.m_bodyId = RigidBodyData::InvalidBodyId;
+		}
+		return false;
+	}
+
+	if (data.m_bodyId != RigidBodyData::InvalidBodyId)
+	{
+		Physics::PhysicsBodyPose previousPose{};
+		if (!data.m_bVelocityDirty &&
+			m_physicsWorld->GetBodyPose(data.m_bodyId, previousPose))
+		{
+			desc.m_linearVelocity = previousPose.m_linearVelocity;
+			desc.m_angularVelocity = previousPose.m_angularVelocity;
+		}
+		m_physicsWorld->DestroyBody(data.m_bodyId);
+		data.m_bodyId = RigidBodyData::InvalidBodyId;
+	}
+
+	if (!m_physicsWorld->CreateBody(desc, data.m_bodyId))
+	{
+		return false;
+	}
+
+	data.m_motionType = desc.m_motionType;
+	data.m_bodyScale = desc.m_scale;
+	data.m_bVelocityDirty = false;
+	data.ClearDirty();
+	data.m_lastAppliedTransformFrame = GetWorld()->GetCurrentFrame();
+	if (m_physicsWorld->GetBodyPose(data.m_bodyId, data.m_currentPose))
+	{
+		data.m_previousPose = data.m_currentPose;
+	}
+	return true;
+}
+
+void PhysicsECS::SyncAuthoredTransforms(float fixedDeltaTime)
+{
+	for (size_t index = 0; index < m_components.Num(); ++index)
+	{
+		if (!IsComponentRegistered(index))
+		{
+			continue;
+		}
+
+		auto& data = m_components[index];
+		if (data.IsDirty() || data.m_bodyId == RigidBodyData::InvalidBodyId)
+		{
+			if (!RecreateBody(index))
+			{
+				continue;
+			}
+		}
+
+		auto gameObject = data.m_owner.StaticCast<GameObject>();
+		if (!gameObject)
+		{
+			continue;
+		}
+
+		auto rigidBody = gameObject->GetComponent<RigidBodyComponent>();
+		if (!rigidBody)
+		{
+			continue;
+		}
+
+		const auto& transform = gameObject->GetTransformComponent();
+		const bool bAuthoredTransformChanged =
+			transform.GetFrameLastChange() > data.m_lastAppliedTransformFrame;
+		const Math::Transform worldTransform = Math::Transform::FromMatrix(
+			transform.GetCachedWorldMatrix());
+		if (bAuthoredTransformChanged &&
+			glm::any(glm::greaterThan(
+				glm::abs(glm::vec3(worldTransform.m_scale) - data.m_bodyScale),
+				glm::vec3(0.000001f))))
+		{
+			RecreateBody(index);
+			continue;
+		}
+
+		if (data.m_motionType != Physics::ERigidBodyMotionType::Dynamic ||
+			bAuthoredTransformChanged)
+		{
+			m_physicsWorld->SetBodyTransform(
+				data.m_bodyId,
+				glm::vec3(worldTransform.m_position),
+				worldTransform.m_rotation,
+				data.m_motionType == Physics::ERigidBodyMotionType::Kinematic,
+				fixedDeltaTime);
+			data.m_lastAppliedTransformFrame = GetWorld()->GetCurrentFrame();
+		}
+
+		if (data.m_bVelocityDirty)
+		{
+			m_physicsWorld->SetBodyVelocity(
+				data.m_bodyId,
+				rigidBody->GetLinearVelocity(),
+				rigidBody->GetAngularVelocity());
+			data.m_bVelocityDirty = false;
+		}
+	}
+}
+
+void PhysicsECS::ApplyDynamicTransforms(float interpolationAlpha)
+{
+	TVector<size_t> updatedComponents;
+	for (size_t index = 0; index < m_components.Num(); ++index)
+	{
+		if (!IsComponentRegistered(index))
+		{
+			continue;
+		}
+
+		auto& data = m_components[index];
+		if (data.m_motionType != Physics::ERigidBodyMotionType::Dynamic ||
+			data.m_bodyId == RigidBodyData::InvalidBodyId)
+		{
+			continue;
+		}
+
+		auto gameObject = data.m_owner.StaticCast<GameObject>();
+		if (!gameObject)
+		{
+			continue;
+		}
+
+		const glm::vec3 worldPosition = glm::mix(
+			data.m_previousPose.m_position,
+			data.m_currentPose.m_position,
+			interpolationAlpha);
+		const glm::quat worldRotation = glm::normalize(glm::slerp(
+			data.m_previousPose.m_rotation,
+			data.m_currentPose.m_rotation,
+			interpolationAlpha));
+
+		glm::vec3 localPosition = worldPosition;
+		glm::quat localRotation = worldRotation;
+		if (auto parent = gameObject->GetParent())
+		{
+			if (!Physics::TryConvertWorldPoseToLocal(
+					parent->GetTransformComponent().GetCachedWorldMatrix(),
+					worldPosition,
+					worldRotation,
+					localPosition,
+					localRotation))
+			{
+				continue;
+			}
+		}
+
+		auto& transform = gameObject->GetTransformComponent();
+		transform.SetPosition(localPosition);
+		transform.SetRotation(localRotation);
+		updatedComponents.Add(index);
+	}
+
+	if (!updatedComponents.IsEmpty())
+	{
+		GetWorld()->GetECS<TransformECS>()->Tick(0.0f);
+		for (size_t index : updatedComponents)
+		{
+			m_components[index].m_lastAppliedTransformFrame =
+				GetWorld()->GetCurrentFrame();
+		}
+	}
+}
+
+Tasks::ITaskPtr PhysicsECS::Tick(float deltaTime)
+{
+	if (!GetWorld()->IsPhysicsSimulationEnabled())
+	{
+		if (m_bWasSimulationEnabled)
+		{
+			m_accumulator = 0.0f;
+		}
+		m_bWasSimulationEnabled = false;
+		return {};
+	}
+	m_bWasSimulationEnabled = true;
+
+	if (!EnsurePhysicsWorld())
+	{
+		return {};
+	}
+
+	SyncAuthoredTransforms(m_fixedDeltaTime);
+	const float maxAccumulatedTime = m_fixedDeltaTime * m_maxSubSteps;
+	m_accumulator = std::min(
+		m_accumulator + std::max(0.0f, deltaTime),
+		maxAccumulatedTime);
+	const uint32_t numSteps = std::min(
+		static_cast<uint32_t>(m_accumulator / m_fixedDeltaTime),
+		m_maxSubSteps);
+	if (numSteps == 0)
+	{
+		ApplyDynamicTransforms(std::clamp(
+			m_accumulator / m_fixedDeltaTime,
+			0.0f,
+			1.0f));
+		return {};
+	}
+	m_accumulator -= m_fixedDeltaTime * numSteps;
+
+	bool bStepSucceeded = true;
+	auto physicsTask = Tasks::CreateTask(
+		"Physics fixed step",
+		[this, numSteps, &bStepSucceeded]()
+		{
+			for (uint32_t step = 0; step < numSteps; ++step)
+			{
+				for (auto& data : m_components)
+				{
+					if (data.m_bIsActive &&
+						data.m_motionType == Physics::ERigidBodyMotionType::Dynamic &&
+						data.m_bodyId != RigidBodyData::InvalidBodyId)
+					{
+						data.m_previousPose = data.m_currentPose;
+					}
+				}
+
+				bStepSucceeded &= m_physicsWorld->Step(m_fixedDeltaTime);
+				for (auto& data : m_components)
+				{
+					if (data.m_bIsActive &&
+						data.m_motionType == Physics::ERigidBodyMotionType::Dynamic &&
+						data.m_bodyId != RigidBodyData::InvalidBodyId)
+					{
+						m_physicsWorld->GetBodyPose(
+							data.m_bodyId,
+							data.m_currentPose);
+					}
+				}
+			}
+		},
+		EThreadType::Physics);
+	physicsTask->Run();
+	physicsTask->Wait();
+
+	if (bStepSucceeded)
+	{
+		ApplyDynamicTransforms(std::clamp(
+			m_accumulator / m_fixedDeltaTime,
+			0.0f,
+			1.0f));
+	}
+	return physicsTask;
+}
+
+bool PhysicsECS::Raycast(
+	const glm::vec3& origin,
+	const glm::vec3& direction,
+	float distance,
+	Physics::PhysicsRaycastHit& outHit,
+	uint16_t collisionMask) const
+{
+	return m_physicsWorld &&
+		m_physicsWorld->Raycast(
+			origin,
+			direction,
+			distance,
+			outHit,
+			collisionMask);
+}
+
+void PhysicsECS::SetLayerCollisionEnabled(
+	uint8_t firstLayer,
+	uint8_t secondLayer,
+	bool bEnabled)
+{
+	if (EnsurePhysicsWorld())
+	{
+		m_physicsWorld->SetLayerCollisionEnabled(
+			firstLayer,
+			secondLayer,
+			bEnabled);
+	}
+}
+
+bool PhysicsECS::IsLayerCollisionEnabled(
+	uint8_t firstLayer,
+	uint8_t secondLayer) const
+{
+	return m_physicsWorld &&
+		m_physicsWorld->IsLayerCollisionEnabled(
+			firstLayer,
+			secondLayer);
+}
+
+void PhysicsECS::DrainContactEvents(
+	TVector<Physics::PhysicsContactEvent>& outEvents)
+{
+	if (m_physicsWorld)
+	{
+		m_physicsWorld->DrainContactEvents(outEvents);
+	}
+}
+
+void PhysicsECS::OnComponentUnregistered(
+	size_t,
+	RigidBodyData& component)
+{
+	if (m_physicsWorld &&
+		component.m_bodyId != RigidBodyData::InvalidBodyId)
+	{
+		m_physicsWorld->DestroyBody(component.m_bodyId);
+	}
+	component.m_bodyId = RigidBodyData::InvalidBodyId;
+}
+
+void PhysicsECS::EndPlay()
+{
+	if (m_physicsWorld)
+	{
+		m_physicsWorld->Clear();
+		m_physicsWorld.Clear();
+	}
+	m_accumulator = 0.0f;
+	m_bWasSimulationEnabled = false;
+	ECS::TSystem<PhysicsECS, RigidBodyData>::EndPlay();
+}

--- a/Runtime/ECS/PhysicsECS.h
+++ b/Runtime/ECS/PhysicsECS.h
@@ -1,0 +1,85 @@
+#pragma once
+#include "ECS/ECS.h"
+#include "Physics/PhysicsTypes.h"
+
+namespace Sailor::Physics
+{
+	class PhysicsWorld;
+}
+
+namespace Sailor
+{
+	struct RigidBodyData final : public ECS::TComponent
+	{
+		static constexpr uint32_t InvalidBodyId = ~0u;
+
+		uint32_t m_bodyId = InvalidBodyId;
+		Physics::ERigidBodyMotionType m_motionType =
+			Physics::ERigidBodyMotionType::Dynamic;
+		glm::vec3 m_bodyScale = glm::vec3(1.0f);
+		Physics::PhysicsBodyPose m_previousPose{};
+		Physics::PhysicsBodyPose m_currentPose{};
+		size_t m_lastAppliedTransformFrame = 0;
+		bool m_bVelocityDirty = true;
+
+		void MarkVelocityDirty() { m_bVelocityDirty = true; }
+		void ClearDirty() { m_bIsDirty = false; }
+
+		friend class PhysicsECS;
+	};
+
+	class SAILOR_API PhysicsECS final :
+		public ECS::TSystem<PhysicsECS, RigidBodyData>
+	{
+	public:
+		PhysicsECS();
+		~PhysicsECS() override;
+
+		Tasks::ITaskPtr Tick(float deltaTime) override;
+		void EndPlay() override;
+		uint32_t GetOrder() const override { return 50; }
+
+		bool Raycast(
+			const glm::vec3& origin,
+			const glm::vec3& direction,
+			float distance,
+			Physics::PhysicsRaycastHit& outHit,
+			uint16_t collisionMask = 0xffffu) const;
+		void SetLayerCollisionEnabled(
+			uint8_t firstLayer,
+			uint8_t secondLayer,
+			bool bEnabled);
+		bool IsLayerCollisionEnabled(
+			uint8_t firstLayer,
+			uint8_t secondLayer) const;
+		void DrainContactEvents(
+			TVector<Physics::PhysicsContactEvent>& outEvents);
+
+		void SetFixedDeltaTime(float value);
+		float GetFixedDeltaTime() const { return m_fixedDeltaTime; }
+		void SetMaxSubSteps(uint32_t value);
+		uint32_t GetMaxSubSteps() const { return m_maxSubSteps; }
+
+	protected:
+		void OnComponentUnregistered(
+			size_t index,
+			RigidBodyData& component) override;
+
+	private:
+		bool EnsurePhysicsWorld();
+		bool RecreateBody(size_t index);
+		bool BuildBodyDesc(
+			size_t index,
+			Physics::RigidBodyDesc& outDesc);
+		void SyncAuthoredTransforms(float fixedDeltaTime);
+		void ApplyDynamicTransforms(float interpolationAlpha);
+
+		TUniquePtr<Physics::PhysicsWorld> m_physicsWorld{};
+		float m_accumulator = 0.0f;
+		float m_fixedDeltaTime = 1.0f / 60.0f;
+		uint32_t m_maxSubSteps = 4;
+		bool m_bWasSimulationEnabled = false;
+	};
+
+	template class ECS::TSystem<PhysicsECS, RigidBodyData>;
+}

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -471,6 +471,11 @@ bool App::LoadEditorWorld(const char* strFileId)
 			{
 				return false;
 			}
+			if (editor->IsSimulationEnabled() &&
+				!editor->SetSimulationEnabled(false))
+			{
+				return false;
+			}
 
 			auto oldWorld = editor->GetWorld();
 			auto newWorld = engineLoop->InstantiateWorld(worldPrefab, EngineLoop::EditorWorldMask);
@@ -500,6 +505,11 @@ bool App::CreateEditorWorld()
 			{
 				return false;
 			}
+			if (editor->IsSimulationEnabled() &&
+				!editor->SetSimulationEnabled(false))
+			{
+				return false;
+			}
 
 			auto oldWorld = editor->GetWorld();
 			auto newWorld = engineLoop->CreateEmptyWorld("New Scene", EngineLoop::EditorWorldMask);
@@ -516,6 +526,24 @@ bool App::CreateEditorWorld()
 			}
 
 			return true;
+		});
+}
+
+bool App::SetEditorSimulationEnabled(bool bEnabled)
+{
+	return ExecuteOnEngineMainThread<bool>(false, [bEnabled]()
+		{
+			auto* editor = GetSubmodule<Editor>();
+			return editor && editor->SetSimulationEnabled(bEnabled);
+		});
+}
+
+bool App::IsEditorSimulationEnabled()
+{
+	return ExecuteOnEngineMainThread<bool>(false, []()
+		{
+			const auto* editor = GetSubmodule<Editor>();
+			return editor && editor->IsSimulationEnabled();
 		});
 }
 

--- a/Runtime/Engine/World.cpp
+++ b/Runtime/Engine/World.cpp
@@ -78,7 +78,9 @@ World::World(
 	m_currentFrame(1),
 	m_name(std::move(name)),
 	m_frameInput(),
-	m_bIsBeginPlayCalled(false)
+	m_bIsBeginPlayCalled(false),
+	m_bPhysicsSimulationEnabled(
+		(mask & (uint8_t)EWorldBehaviourBit::Tickable) != 0)
 {
 	m_allocator = Memory::ObjectAllocatorPtr::Make(EAllocationPolicy::LocalMemory_SingleThread);
 

--- a/Runtime/Engine/World.h
+++ b/Runtime/Engine/World.h
@@ -79,6 +79,8 @@ namespace Sailor
 		SAILOR_API void Clear();
 		SAILOR_API size_t GetCurrentFrame() const { return m_currentFrame; }
 		SAILOR_API float GetSmoothDeltaTime() const { return m_smoothDeltaTime; }
+		SAILOR_API void SetPhysicsSimulationEnabled(bool value) { m_bPhysicsSimulationEnabled = value; }
+		SAILOR_API bool IsPhysicsSimulationEnabled() const { return m_bPhysicsSimulationEnabled; }
 
 		SAILOR_API const std::string& GetName() const { return m_name; }
 
@@ -160,6 +162,7 @@ namespace Sailor
 
 		Memory::ObjectAllocatorPtr m_allocator;
 		bool m_bIsBeginPlayCalled;
+		bool m_bPhysicsSimulationEnabled = false;
 
 		TList<GameObjectPtr, Memory::TInlineAllocator<sizeof(GameObjectPtr) * 32>> m_pendingDestroyObjects;
 

--- a/Runtime/Physics/JoltJobSystem.cpp
+++ b/Runtime/Physics/JoltJobSystem.cpp
@@ -1,0 +1,110 @@
+#include "Physics/JoltJobSystem.h"
+#include "Tasks/Scheduler.h"
+#include "Tasks/Tasks.h"
+#include <Jolt/Physics/PhysicsSettings.h>
+#include <algorithm>
+
+using namespace Sailor;
+
+Physics::JoltJobSystem::Job::Job(
+	const char* name,
+	JPH::ColorArg color,
+	JPH::JobSystem* jobSystem,
+	const JPH::JobSystem::JobFunction& jobFunction,
+	JPH::uint32 dependencyCount) :
+	JPH::JobSystem::Job(
+		name,
+		color,
+		jobSystem,
+		jobFunction,
+		dependencyCount)
+{}
+
+Physics::JoltJobSystem::JoltJobSystem(Tasks::Scheduler* scheduler) :
+	JPH::JobSystemWithBarrier(JPH::cMaxPhysicsBarriers),
+	m_scheduler(scheduler)
+{}
+
+int Physics::JoltJobSystem::GetMaxConcurrency() const
+{
+	return m_scheduler
+		? static_cast<int>(
+			std::max(1u, m_scheduler->GetNumWorkerThreads()) + 1u)
+		: 1;
+}
+
+JPH::JobHandle Physics::JoltJobSystem::CreateJob(
+	const char* name,
+	JPH::ColorArg color,
+	const JPH::JobSystem::JobFunction& jobFunction,
+	JPH::uint32 dependencyCount)
+{
+	auto* job = new Job(
+		name,
+		color,
+		this,
+		jobFunction,
+		dependencyCount);
+	JPH::JobHandle handle(job);
+	if (dependencyCount == 0)
+	{
+		QueueJob(job);
+	}
+	return handle;
+}
+
+void Physics::JoltJobSystem::QueueJob(JPH::JobSystem::Job* job)
+{
+	job->AddRef();
+	if (!m_scheduler)
+	{
+		job->Execute();
+		job->Release();
+		return;
+	}
+
+	m_numQueuedTasks.fetch_add(1, std::memory_order_relaxed);
+	auto task = Tasks::CreateTask(
+		"Jolt Physics",
+		[this, job]()
+		{
+			job->Execute();
+			job->Release();
+			m_numQueuedTasks.fetch_sub(1, std::memory_order_release);
+			m_numQueuedTasks.notify_all();
+		},
+		EThreadType::Worker);
+	m_scheduler->Run(task);
+}
+
+void Physics::JoltJobSystem::QueueJobs(
+	JPH::JobSystem::Job** jobs,
+	JPH::uint jobCount)
+{
+	for (JPH::uint index = 0; index < jobCount; ++index)
+	{
+		QueueJob(jobs[index]);
+	}
+}
+
+void Physics::JoltJobSystem::WaitForJobs(
+	JPH::JobSystem::Barrier* barrier)
+{
+	JPH::JobSystemWithBarrier::WaitForJobs(barrier);
+
+	uint32_t numQueuedTasks =
+		m_numQueuedTasks.load(std::memory_order_acquire);
+	while (numQueuedTasks != 0)
+	{
+		m_numQueuedTasks.wait(
+			numQueuedTasks,
+			std::memory_order_acquire);
+		numQueuedTasks =
+			m_numQueuedTasks.load(std::memory_order_acquire);
+	}
+}
+
+void Physics::JoltJobSystem::FreeJob(JPH::JobSystem::Job* job)
+{
+	delete static_cast<Job*>(job);
+}

--- a/Runtime/Physics/JoltJobSystem.h
+++ b/Runtime/Physics/JoltJobSystem.h
@@ -1,0 +1,45 @@
+#pragma once
+#include "Core/Defines.h"
+#include <Jolt/Jolt.h>
+#include <Jolt/Core/JobSystemWithBarrier.h>
+#include <atomic>
+
+namespace Sailor::Tasks
+{
+	class Scheduler;
+}
+
+namespace Sailor::Physics
+{
+	class JoltJobSystem final : public JPH::JobSystemWithBarrier
+	{
+		class Job final : public JPH::JobSystem::Job
+		{
+		public:
+			Job(
+				const char* name,
+				JPH::ColorArg color,
+				JPH::JobSystem* jobSystem,
+				const JPH::JobSystem::JobFunction& jobFunction,
+				JPH::uint32 dependencyCount);
+		};
+
+	public:
+		explicit JoltJobSystem(Tasks::Scheduler* scheduler);
+
+		int GetMaxConcurrency() const override;
+		JPH::JobHandle CreateJob(
+			const char* name,
+			JPH::ColorArg color,
+			const JPH::JobSystem::JobFunction& jobFunction,
+			JPH::uint32 dependencyCount = 0) override;
+		void QueueJob(JPH::JobSystem::Job* job) override;
+		void QueueJobs(JPH::JobSystem::Job** jobs, JPH::uint jobCount) override;
+		void WaitForJobs(JPH::JobSystem::Barrier* barrier) override;
+		void FreeJob(JPH::JobSystem::Job* job) override;
+
+	private:
+		Tasks::Scheduler* m_scheduler = nullptr;
+		std::atomic<uint32_t> m_numQueuedTasks = 0;
+	};
+}

--- a/Runtime/Physics/JoltRuntime.cpp
+++ b/Runtime/Physics/JoltRuntime.cpp
@@ -1,0 +1,63 @@
+#include "Physics/JoltRuntime.h"
+#include "Core/LogMacros.h"
+#include "Tasks/Tasks.h"
+#include <Jolt/Jolt.h>
+#include <Jolt/Core/Factory.h>
+#include <Jolt/RegisterTypes.h>
+#include <cstdarg>
+#include <cstdio>
+
+using namespace Sailor;
+
+namespace
+{
+	void TraceJolt(const char* format, ...)
+	{
+		char buffer[2048]{};
+		va_list arguments;
+		va_start(arguments, format);
+		vsnprintf(buffer, sizeof(buffer), format, arguments);
+		va_end(arguments);
+		SAILOR_LOG("Jolt: %s", buffer);
+	}
+
+#if defined(JPH_ENABLE_ASSERTS)
+	bool AssertJolt(
+		const char* expression,
+		const char* message,
+		const char* file,
+		JPH::uint line)
+	{
+		SAILOR_LOG_ERROR(
+			"Jolt assertion at %s:%u: %s (%s)",
+			file,
+			line,
+			expression,
+			message ? message : "");
+		return true;
+	}
+#endif
+}
+
+Physics::JoltRuntime::JoltRuntime()
+{
+	JPH::RegisterDefaultAllocator();
+	JPH::Trace = TraceJolt;
+#if defined(JPH_ENABLE_ASSERTS)
+	JPH::AssertFailed = AssertJolt;
+#endif
+	check(JPH::Factory::sInstance == nullptr);
+	JPH::Factory::sInstance = new JPH::Factory();
+	JPH::RegisterTypes();
+}
+
+Physics::JoltRuntime::~JoltRuntime()
+{
+	JPH::UnregisterTypes();
+	delete JPH::Factory::sInstance;
+	JPH::Factory::sInstance = nullptr;
+	JPH::Trace = nullptr;
+#if defined(JPH_ENABLE_ASSERTS)
+	JPH::AssertFailed = nullptr;
+#endif
+}

--- a/Runtime/Physics/JoltRuntime.h
+++ b/Runtime/Physics/JoltRuntime.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "Core/Submodule.h"
+
+namespace Sailor::Physics
+{
+	class JoltRuntime final : public TSubmodule<JoltRuntime>
+	{
+	public:
+		SAILOR_API JoltRuntime();
+		SAILOR_API ~JoltRuntime() override;
+	};
+}

--- a/Runtime/Physics/PhysicsTypes.cpp
+++ b/Runtime/Physics/PhysicsTypes.cpp
@@ -1,0 +1,110 @@
+#include "Physics/PhysicsTypes.h"
+#include "Math/Math.h"
+#include "Math/Transform.h"
+#include <cmath>
+#include <glm/gtc/matrix_inverse.hpp>
+
+using namespace Sailor;
+
+namespace
+{
+	bool IsFiniteMatrix(const glm::mat4& matrix)
+	{
+		for (glm::length_t column = 0; column < matrix.length(); ++column)
+		{
+			for (glm::length_t row = 0; row < matrix[column].length(); ++row)
+			{
+				if (!std::isfinite(matrix[column][row]))
+				{
+					return false;
+				}
+			}
+		}
+		return true;
+	}
+
+	glm::quat NormalizeRotation(const glm::quat& rotation)
+	{
+		const glm::vec4 raw(
+			rotation.x,
+			rotation.y,
+			rotation.z,
+			rotation.w);
+		const glm::vec4 normalized = Math::SafeNormalize(
+			raw,
+			glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+		return glm::quat(
+			normalized.w,
+			normalized.x,
+			normalized.y,
+			normalized.z);
+	}
+}
+
+bool Physics::TryConvertWorldPoseToLocal(
+	const glm::mat4& parentWorldMatrix,
+	const glm::vec3& worldPosition,
+	const glm::quat& worldRotation,
+	glm::vec3& outLocalPosition,
+	glm::quat& outLocalRotation)
+{
+	const glm::vec4 worldRotationVector(
+		worldRotation.x,
+		worldRotation.y,
+		worldRotation.z,
+		worldRotation.w);
+	if (!IsFiniteMatrix(parentWorldMatrix) ||
+		!Math::AllFinite(worldPosition) ||
+		!Math::AllFinite(worldRotationVector))
+	{
+		return false;
+	}
+
+	const glm::vec3 axisX(parentWorldMatrix[0]);
+	const glm::vec3 axisY(parentWorldMatrix[1]);
+	const glm::vec3 axisZ(parentWorldMatrix[2]);
+	const float axisLengthProduct =
+		glm::length(axisX) * glm::length(axisY) * glm::length(axisZ);
+	const float normalizedVolume = axisLengthProduct > 0.0f
+		? std::abs(glm::dot(glm::cross(axisX, axisY), axisZ)) /
+			axisLengthProduct
+		: 0.0f;
+	if (!std::isfinite(normalizedVolume) ||
+		normalizedVolume <= 0.000001f)
+	{
+		return false;
+	}
+
+	const glm::mat4 inverseParent = glm::inverse(parentWorldMatrix);
+	if (!IsFiniteMatrix(inverseParent))
+	{
+		return false;
+	}
+
+	const glm::vec4 localHomogeneous =
+		inverseParent * glm::vec4(worldPosition, 1.0f);
+	if (!Math::AllFinite(localHomogeneous) ||
+		std::abs(localHomogeneous.w) <= 0.000001f)
+	{
+		return false;
+	}
+
+	const Math::Transform parentTransform =
+		Math::Transform::FromMatrix(parentWorldMatrix);
+	const glm::vec4 parentRotation(
+		parentTransform.m_rotation.x,
+		parentTransform.m_rotation.y,
+		parentTransform.m_rotation.z,
+		parentTransform.m_rotation.w);
+	if (!Math::AllFinite(parentRotation))
+	{
+		return false;
+	}
+
+	outLocalPosition = glm::vec3(localHomogeneous) /
+		localHomogeneous.w;
+	outLocalRotation = NormalizeRotation(
+		glm::inverse(NormalizeRotation(parentTransform.m_rotation)) *
+		NormalizeRotation(worldRotation));
+	return Math::AllFinite(outLocalPosition);
+}

--- a/Runtime/Physics/PhysicsTypes.h
+++ b/Runtime/Physics/PhysicsTypes.h
@@ -1,0 +1,96 @@
+#pragma once
+#include "Core/Defines.h"
+#include "Engine/InstanceId.h"
+#include "Containers/Vector.h"
+#include <glm/mat4x4.hpp>
+#include <glm/vec3.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+namespace Sailor::Physics
+{
+	enum class ERigidBodyMotionType : uint8_t
+	{
+		Static = 0,
+		Kinematic,
+		Dynamic
+	};
+
+	enum class ECollisionShapeType : uint8_t
+	{
+		Box = 0,
+		Sphere,
+		Capsule
+	};
+
+	enum class EPhysicsContactType : uint8_t
+	{
+		Added = 0,
+		Persisted,
+		Removed
+	};
+
+	struct CollisionShapeDesc final
+	{
+		ECollisionShapeType m_type = ECollisionShapeType::Box;
+		glm::vec3 m_center{};
+		glm::quat m_rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+		glm::vec3 m_size = glm::vec3(1.0f);
+		float m_radius = 0.5f;
+		float m_height = 1.0f;
+	};
+
+	struct RigidBodyDesc final
+	{
+		InstanceId m_instanceId{};
+		ERigidBodyMotionType m_motionType = ERigidBodyMotionType::Dynamic;
+		glm::vec3 m_position{};
+		glm::quat m_rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+		glm::vec3 m_scale = glm::vec3(1.0f);
+		glm::vec3 m_linearVelocity{};
+		glm::vec3 m_angularVelocity{};
+		float m_mass = 1.0f;
+		float m_friction = 0.2f;
+		float m_restitution = 0.0f;
+		float m_linearDamping = 0.05f;
+		float m_angularDamping = 0.05f;
+		float m_gravityFactor = 1.0f;
+		uint8_t m_collisionLayer = 0;
+		bool m_bSensor = false;
+		bool m_bAllowSleeping = true;
+		TVector<CollisionShapeDesc> m_shapes{};
+	};
+
+	struct PhysicsBodyPose final
+	{
+		glm::vec3 m_position{};
+		glm::quat m_rotation = glm::quat(1.0f, 0.0f, 0.0f, 0.0f);
+		glm::vec3 m_linearVelocity{};
+		glm::vec3 m_angularVelocity{};
+		bool m_bActive = false;
+	};
+
+	struct PhysicsContactEvent final
+	{
+		EPhysicsContactType m_type = EPhysicsContactType::Added;
+		InstanceId m_first{};
+		InstanceId m_second{};
+		glm::vec3 m_position{};
+		glm::vec3 m_normal{};
+		bool m_bSensor = false;
+	};
+
+	struct PhysicsRaycastHit final
+	{
+		InstanceId m_instanceId{};
+		glm::vec3 m_position{};
+		glm::vec3 m_normal{};
+		float m_fraction = 0.0f;
+	};
+
+	SAILOR_API bool TryConvertWorldPoseToLocal(
+		const glm::mat4& parentWorldMatrix,
+		const glm::vec3& worldPosition,
+		const glm::quat& worldRotation,
+		glm::vec3& outLocalPosition,
+		glm::quat& outLocalRotation);
+}

--- a/Runtime/Physics/PhysicsWorld.cpp
+++ b/Runtime/Physics/PhysicsWorld.cpp
@@ -1,0 +1,840 @@
+#include "Physics/PhysicsWorld.h"
+#include "Physics/JoltJobSystem.h"
+#include "Core/LogMacros.h"
+#include "Math/Math.h"
+#include "Sailor.h"
+#include "Tasks/Scheduler.h"
+#include "Tasks/Tasks.h"
+#include <Jolt/Jolt.h>
+#include <Jolt/Core/TempAllocator.h>
+#include <Jolt/Physics/PhysicsSystem.h>
+#include <Jolt/Physics/PhysicsSettings.h>
+#include <Jolt/Physics/Body/BodyCreationSettings.h>
+#include <Jolt/Physics/Body/BodyLock.h>
+#include <Jolt/Physics/Collision/Shape/BoxShape.h>
+#include <Jolt/Physics/Collision/Shape/SphereShape.h>
+#include <Jolt/Physics/Collision/Shape/CapsuleShape.h>
+#include <Jolt/Physics/Collision/Shape/RotatedTranslatedShape.h>
+#include <Jolt/Physics/Collision/Shape/StaticCompoundShape.h>
+#include <Jolt/Physics/Collision/CastResult.h>
+#include <Jolt/Physics/Collision/RayCast.h>
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#if __has_include(<concurrent_queue.h>)
+#include <concurrent_queue.h>
+#elif __has_include(<tbb/concurrent_queue.h>)
+#include <tbb/concurrent_queue.h>
+namespace concurrency = tbb;
+#endif
+
+using namespace Sailor;
+
+namespace
+{
+	constexpr JPH::ObjectLayer c_nonMovingLayerBase = 0;
+	constexpr JPH::ObjectLayer c_movingLayerBase = 16;
+	constexpr uint8_t c_numCollisionLayers = 16;
+	constexpr float c_minShapeExtent = 0.001f;
+
+	uint8_t GetCollisionLayer(JPH::ObjectLayer layer)
+	{
+		return static_cast<uint8_t>(layer & 0x0f);
+	}
+
+	bool IsFinite(const glm::quat& value)
+	{
+		return Math::AllFinite(glm::vec4(
+			value.x,
+			value.y,
+			value.z,
+			value.w));
+	}
+
+	glm::quat SanitizeRotation(const glm::quat& value)
+	{
+		const glm::vec4 raw(value.x, value.y, value.z, value.w);
+		const glm::vec4 normalized = Math::SafeNormalize(
+			raw,
+			glm::vec4(0.0f, 0.0f, 0.0f, 1.0f));
+		return glm::quat(
+			normalized.w,
+			normalized.x,
+			normalized.y,
+			normalized.z);
+	}
+
+	JPH::Vec3 ToJolt(const glm::vec3& value)
+	{
+		return JPH::Vec3(value.x, value.y, value.z);
+	}
+
+	JPH::RVec3 ToJoltPosition(const glm::vec3& value)
+	{
+		return JPH::RVec3(value.x, value.y, value.z);
+	}
+
+	JPH::Quat ToJolt(const glm::quat& value)
+	{
+		const glm::quat normalized = SanitizeRotation(value);
+		return JPH::Quat(normalized.x, normalized.y, normalized.z, normalized.w);
+	}
+
+	template<typename TVector>
+	glm::vec3 FromJoltVector(const TVector& value)
+	{
+		return glm::vec3(
+			static_cast<float>(value.GetX()),
+			static_cast<float>(value.GetY()),
+			static_cast<float>(value.GetZ()));
+	}
+
+	glm::quat FromJoltQuat(JPH::QuatArg value)
+	{
+		return SanitizeRotation(glm::quat(
+			value.GetW(),
+			value.GetX(),
+			value.GetY(),
+			value.GetZ()));
+	}
+
+	JPH::ObjectLayer MakeObjectLayer(
+		Physics::ERigidBodyMotionType motionType,
+		uint8_t collisionLayer)
+	{
+		const JPH::ObjectLayer localLayer =
+			static_cast<JPH::ObjectLayer>(collisionLayer & 0x0f);
+		return motionType == Physics::ERigidBodyMotionType::Static
+			? c_nonMovingLayerBase + localLayer
+			: c_movingLayerBase + localLayer;
+	}
+
+	class BroadPhaseLayerInterface final : public JPH::BroadPhaseLayerInterface
+	{
+	public:
+		JPH::uint GetNumBroadPhaseLayers() const override { return 2; }
+
+		JPH::BroadPhaseLayer GetBroadPhaseLayer(
+			JPH::ObjectLayer layer) const override
+		{
+			return JPH::BroadPhaseLayer(
+				layer >= c_movingLayerBase ? 1 : 0);
+		}
+
+#if defined(JPH_EXTERNAL_PROFILE) || defined(JPH_PROFILE_ENABLED)
+		const char* GetBroadPhaseLayerName(
+			JPH::BroadPhaseLayer layer) const override
+		{
+			return static_cast<JPH::BroadPhaseLayer::Type>(layer) == 0
+				? "NonMoving"
+				: "Moving";
+		}
+#endif
+	};
+
+	class ObjectVsBroadPhaseLayerFilter final :
+		public JPH::ObjectVsBroadPhaseLayerFilter
+	{
+	public:
+		bool ShouldCollide(
+			JPH::ObjectLayer objectLayer,
+			JPH::BroadPhaseLayer broadPhaseLayer) const override
+		{
+			const bool bMoving = objectLayer >= c_movingLayerBase;
+			const bool bBroadPhaseMoving =
+				static_cast<JPH::BroadPhaseLayer::Type>(broadPhaseLayer) == 1;
+			return bMoving || bBroadPhaseMoving;
+		}
+	};
+
+	class ObjectLayerPairFilter final : public JPH::ObjectLayerPairFilter
+	{
+	public:
+		ObjectLayerPairFilter()
+		{
+			for (auto& mask : m_collisionMasks)
+			{
+				mask.store(0xffffu, std::memory_order_relaxed);
+			}
+		}
+
+		bool ShouldCollide(
+			JPH::ObjectLayer first,
+			JPH::ObjectLayer second) const override
+		{
+			if (first < c_movingLayerBase && second < c_movingLayerBase)
+			{
+				return false;
+			}
+
+			const uint8_t firstLayer = GetCollisionLayer(first);
+			const uint8_t secondLayer = GetCollisionLayer(second);
+			return (m_collisionMasks[firstLayer].load(
+				std::memory_order_relaxed) & (1u << secondLayer)) != 0;
+		}
+
+		void SetCollisionEnabled(
+			uint8_t firstLayer,
+			uint8_t secondLayer,
+			bool bEnabled)
+		{
+			firstLayer &= 0x0f;
+			secondLayer &= 0x0f;
+			const uint16_t firstBit = static_cast<uint16_t>(1u << secondLayer);
+			const uint16_t secondBit = static_cast<uint16_t>(1u << firstLayer);
+			if (bEnabled)
+			{
+				m_collisionMasks[firstLayer].fetch_or(
+					firstBit,
+					std::memory_order_relaxed);
+				m_collisionMasks[secondLayer].fetch_or(
+					secondBit,
+					std::memory_order_relaxed);
+			}
+			else
+			{
+				m_collisionMasks[firstLayer].fetch_and(
+					static_cast<uint16_t>(~firstBit),
+					std::memory_order_relaxed);
+				m_collisionMasks[secondLayer].fetch_and(
+					static_cast<uint16_t>(~secondBit),
+					std::memory_order_relaxed);
+			}
+		}
+
+		bool IsCollisionEnabled(
+			uint8_t firstLayer,
+			uint8_t secondLayer) const
+		{
+			firstLayer &= 0x0f;
+			secondLayer &= 0x0f;
+			return (m_collisionMasks[firstLayer].load(
+				std::memory_order_relaxed) & (1u << secondLayer)) != 0;
+		}
+
+	private:
+		std::atomic<uint16_t> m_collisionMasks[c_numCollisionLayers]{};
+	};
+
+	class QueryObjectLayerFilter final : public JPH::ObjectLayerFilter
+	{
+	public:
+		explicit QueryObjectLayerFilter(uint16_t collisionMask) :
+			m_collisionMask(collisionMask)
+		{}
+
+		bool ShouldCollide(JPH::ObjectLayer layer) const override
+		{
+			return (m_collisionMask &
+				(1u << GetCollisionLayer(layer))) != 0;
+		}
+
+	private:
+		uint16_t m_collisionMask = 0xffffu;
+	};
+
+	JPH::ShapeRefC BuildPrimitiveShape(
+		const Physics::CollisionShapeDesc& desc,
+		const glm::vec3& bodyScale)
+	{
+		if (!Math::AllFinite(bodyScale) ||
+			!Math::AllFinite(desc.m_center) ||
+			!IsFinite(desc.m_rotation) ||
+			!Math::AllFinite(desc.m_size) ||
+			!std::isfinite(desc.m_radius) ||
+			!std::isfinite(desc.m_height))
+		{
+			return {};
+		}
+
+		const glm::vec3 absoluteScale = glm::max(
+			glm::abs(bodyScale),
+			glm::vec3(c_minShapeExtent));
+
+		switch (desc.m_type)
+		{
+		case Physics::ECollisionShapeType::Box:
+		{
+			const glm::vec3 halfExtent = glm::max(
+				glm::abs(desc.m_size) * absoluteScale * 0.5f,
+				glm::vec3(c_minShapeExtent));
+			return new JPH::BoxShape(ToJolt(halfExtent));
+		}
+		case Physics::ECollisionShapeType::Sphere:
+		{
+			const float scale = std::max({
+				absoluteScale.x,
+				absoluteScale.y,
+				absoluteScale.z });
+			return new JPH::SphereShape(std::max(
+				c_minShapeExtent,
+				std::abs(desc.m_radius) * scale));
+		}
+		case Physics::ECollisionShapeType::Capsule:
+		{
+			const float radiusScale = std::max(
+				absoluteScale.x,
+				absoluteScale.z);
+			const float radius = std::max(
+				c_minShapeExtent,
+				std::abs(desc.m_radius) * radiusScale);
+			const float totalHeight = std::max(
+				2.0f * radius,
+				std::abs(desc.m_height) * absoluteScale.y);
+			return new JPH::CapsuleShape(
+				std::max(0.0f, totalHeight * 0.5f - radius),
+				radius);
+		}
+		default:
+			return {};
+		}
+	}
+
+	JPH::ShapeRefC BuildShape(const Physics::RigidBodyDesc& desc)
+	{
+		if (desc.m_shapes.IsEmpty())
+		{
+			return {};
+		}
+
+		if (desc.m_shapes.Num() == 1)
+		{
+			const auto& shapeDesc = desc.m_shapes[0];
+			JPH::ShapeRefC shape = BuildPrimitiveShape(shapeDesc, desc.m_scale);
+			if (!shape)
+			{
+				return {};
+			}
+
+			const glm::vec3 center = shapeDesc.m_center * desc.m_scale;
+			if (glm::dot(center, center) <= 0.0f &&
+				glm::abs(glm::dot(shapeDesc.m_rotation, shapeDesc.m_rotation) - 1.0f) <= 0.0001f &&
+				glm::abs(shapeDesc.m_rotation.w - 1.0f) <= 0.0001f)
+			{
+				return shape;
+			}
+
+			JPH::RotatedTranslatedShapeSettings transformed(
+				ToJolt(center),
+				ToJolt(shapeDesc.m_rotation),
+				shape.GetPtr());
+			auto result = transformed.Create();
+			return result.HasError() ? JPH::ShapeRefC{} : result.Get();
+		}
+
+		JPH::StaticCompoundShapeSettings compound;
+		for (const auto& shapeDesc : desc.m_shapes)
+		{
+			JPH::ShapeRefC shape = BuildPrimitiveShape(shapeDesc, desc.m_scale);
+			if (!shape)
+			{
+				return {};
+			}
+
+			compound.AddShape(
+				ToJolt(shapeDesc.m_center * desc.m_scale),
+				ToJolt(shapeDesc.m_rotation),
+				shape.GetPtr());
+		}
+
+		auto result = compound.Create();
+		return result.HasError() ? JPH::ShapeRefC{} : result.Get();
+	}
+}
+
+class Physics::PhysicsWorld::Impl final
+{
+public:
+	class ContactListener final : public JPH::ContactListener
+	{
+	public:
+		explicit ContactListener(Impl& owner) : m_owner(owner) {}
+
+		JPH::ValidateResult OnContactValidate(
+			const JPH::Body&,
+			const JPH::Body&,
+			JPH::RVec3Arg,
+			const JPH::CollideShapeResult&) override
+		{
+			return JPH::ValidateResult::AcceptAllContactsForThisBodyPair;
+		}
+
+		void OnContactAdded(
+			const JPH::Body& first,
+			const JPH::Body& second,
+			const JPH::ContactManifold& manifold,
+			JPH::ContactSettings&) override
+		{
+			Push(
+				Physics::EPhysicsContactType::Added,
+				first,
+				second,
+				manifold);
+		}
+
+		void OnContactPersisted(
+			const JPH::Body& first,
+			const JPH::Body& second,
+			const JPH::ContactManifold& manifold,
+			JPH::ContactSettings&) override
+		{
+			Push(
+				Physics::EPhysicsContactType::Persisted,
+				first,
+				second,
+				manifold);
+		}
+
+		void OnContactRemoved(
+			const JPH::SubShapeIDPair& pair) override
+		{
+			Physics::PhysicsContactEvent event{};
+			event.m_type = Physics::EPhysicsContactType::Removed;
+			if (m_owner.ResolveInstanceId(pair.GetBody1ID(), event.m_first) &&
+				m_owner.ResolveInstanceId(pair.GetBody2ID(), event.m_second))
+			{
+				Canonicalize(event);
+				m_owner.m_contactEvents.push(std::move(event));
+			}
+		}
+
+	private:
+		static void Canonicalize(
+			Physics::PhysicsContactEvent& event)
+		{
+			if (event.m_second.ToString() < event.m_first.ToString())
+			{
+				std::swap(event.m_first, event.m_second);
+				event.m_normal = -event.m_normal;
+			}
+		}
+
+		void Push(
+			Physics::EPhysicsContactType type,
+			const JPH::Body& first,
+			const JPH::Body& second,
+			const JPH::ContactManifold& manifold)
+		{
+			Physics::PhysicsContactEvent event{};
+			event.m_type = type;
+			if (!m_owner.ResolveInstanceId(first.GetID(), event.m_first) ||
+				!m_owner.ResolveInstanceId(second.GetID(), event.m_second))
+			{
+				return;
+			}
+
+			if (!manifold.mRelativeContactPointsOn1.empty())
+			{
+				event.m_position = FromJoltVector(
+					manifold.GetWorldSpaceContactPointOn1(0));
+			}
+			event.m_normal = FromJoltVector(manifold.mWorldSpaceNormal);
+			event.m_bSensor = first.IsSensor() || second.IsSensor();
+			Canonicalize(event);
+			m_owner.m_contactEvents.push(std::move(event));
+		}
+
+		Impl& m_owner;
+	};
+
+	explicit Impl(Tasks::Scheduler* scheduler) :
+		m_jobSystem(scheduler),
+		m_tempAllocator(32 * 1024 * 1024),
+		m_contactListener(*this)
+	{
+		m_physicsSystem.Init(
+			65536,
+			0,
+			65536,
+			10240,
+			m_broadPhaseLayerInterface,
+			m_objectVsBroadPhaseLayerFilter,
+			m_objectLayerPairFilter);
+		m_physicsSystem.SetGravity(JPH::Vec3(0.0f, -9.81f, 0.0f));
+		m_physicsSystem.SetContactListener(&m_contactListener);
+	}
+
+	bool ResolveInstanceId(
+		const JPH::BodyID& bodyId,
+		InstanceId& outInstanceId) const
+	{
+		const InstanceId* instanceId = nullptr;
+		if (!m_bodyInstances.Find(
+				bodyId.GetIndexAndSequenceNumber(),
+				instanceId))
+		{
+			return false;
+		}
+
+		outInstanceId = *instanceId;
+		return true;
+	}
+
+	BroadPhaseLayerInterface m_broadPhaseLayerInterface{};
+	ObjectVsBroadPhaseLayerFilter m_objectVsBroadPhaseLayerFilter{};
+	ObjectLayerPairFilter m_objectLayerPairFilter{};
+	JoltJobSystem m_jobSystem;
+	JPH::TempAllocatorImpl m_tempAllocator;
+	JPH::PhysicsSystem m_physicsSystem{};
+	ContactListener m_contactListener;
+	TMap<uint32_t, InstanceId> m_bodyInstances{};
+	concurrency::concurrent_queue<PhysicsContactEvent> m_contactEvents{};
+};
+
+Physics::PhysicsWorld::PhysicsWorld() :
+	m_pImpl(TUniquePtr<Impl>::Make(App::GetSubmodule<Tasks::Scheduler>()))
+{}
+
+Physics::PhysicsWorld::~PhysicsWorld()
+{
+	Clear();
+}
+
+bool Physics::PhysicsWorld::CreateBody(
+	const RigidBodyDesc& desc,
+	uint32_t& outBodyId)
+{
+	outBodyId = JPH::BodyID::cInvalidBodyID;
+	if (!desc.m_instanceId ||
+		!Math::AllFinite(desc.m_position) ||
+		!IsFinite(desc.m_rotation) ||
+		!Math::AllFinite(desc.m_scale) ||
+		!Math::AllFinite(desc.m_linearVelocity) ||
+		!Math::AllFinite(desc.m_angularVelocity) ||
+		!std::isfinite(desc.m_mass) ||
+		!std::isfinite(desc.m_friction) ||
+		!std::isfinite(desc.m_restitution) ||
+		!std::isfinite(desc.m_linearDamping) ||
+		!std::isfinite(desc.m_angularDamping) ||
+		!std::isfinite(desc.m_gravityFactor))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot create physics body: invalid identity or transform data.");
+		return false;
+	}
+
+	JPH::ShapeRefC shape = BuildShape(desc);
+	if (!shape)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot create physics body '%s': no valid collision shape.",
+			desc.m_instanceId.ToString().c_str());
+		return false;
+	}
+
+	JPH::EMotionType motionType = JPH::EMotionType::Dynamic;
+	switch (desc.m_motionType)
+	{
+	case ERigidBodyMotionType::Static:
+		motionType = JPH::EMotionType::Static;
+		break;
+	case ERigidBodyMotionType::Kinematic:
+		motionType = JPH::EMotionType::Kinematic;
+		break;
+	case ERigidBodyMotionType::Dynamic:
+		motionType = JPH::EMotionType::Dynamic;
+		break;
+	}
+
+	JPH::BodyCreationSettings settings(
+		shape,
+		ToJoltPosition(desc.m_position),
+		ToJolt(desc.m_rotation),
+		motionType,
+		MakeObjectLayer(desc.m_motionType, desc.m_collisionLayer));
+	settings.mFriction = std::max(0.0f, desc.m_friction);
+	settings.mRestitution = std::clamp(desc.m_restitution, 0.0f, 1.0f);
+	settings.mLinearDamping = std::clamp(desc.m_linearDamping, 0.0f, 1.0f);
+	settings.mAngularDamping = std::clamp(desc.m_angularDamping, 0.0f, 1.0f);
+	settings.mGravityFactor = desc.m_gravityFactor;
+	settings.mIsSensor = desc.m_bSensor;
+	settings.mAllowSleeping = desc.m_bAllowSleeping;
+	if (motionType == JPH::EMotionType::Dynamic)
+	{
+		settings.mOverrideMassProperties =
+			JPH::EOverrideMassProperties::CalculateInertia;
+		settings.mMassPropertiesOverride.mMass =
+			std::max(c_minShapeExtent, desc.m_mass);
+	}
+
+	auto& bodyInterface = m_pImpl->m_physicsSystem.GetBodyInterface();
+	const JPH::BodyID bodyId = bodyInterface.CreateAndAddBody(
+		settings,
+		motionType == JPH::EMotionType::Static
+			? JPH::EActivation::DontActivate
+			: JPH::EActivation::Activate);
+	if (bodyId.IsInvalid())
+	{
+		return false;
+	}
+
+	outBodyId = bodyId.GetIndexAndSequenceNumber();
+	m_pImpl->m_bodyInstances[outBodyId] = desc.m_instanceId;
+	if (motionType != JPH::EMotionType::Static)
+	{
+		bodyInterface.SetLinearAndAngularVelocity(
+			bodyId,
+			ToJolt(desc.m_linearVelocity),
+			ToJolt(desc.m_angularVelocity));
+	}
+	return true;
+}
+
+void Physics::PhysicsWorld::DestroyBody(uint32_t bodyId)
+{
+	if (bodyId == JPH::BodyID::cInvalidBodyID)
+	{
+		return;
+	}
+	if (!m_pImpl->m_bodyInstances.ContainsKey(bodyId))
+	{
+		return;
+	}
+
+	const JPH::BodyID id(bodyId);
+	auto& bodyInterface = m_pImpl->m_physicsSystem.GetBodyInterface();
+	if (bodyInterface.IsAdded(id))
+	{
+		bodyInterface.RemoveBody(id);
+	}
+	bodyInterface.DestroyBody(id);
+	m_pImpl->m_bodyInstances.Remove(bodyId);
+}
+
+bool Physics::PhysicsWorld::SetBodyTransform(
+	uint32_t bodyId,
+	const glm::vec3& position,
+	const glm::quat& rotation,
+	bool bKinematic,
+	float deltaTime)
+{
+	if (bodyId == JPH::BodyID::cInvalidBodyID)
+	{
+		return false;
+	}
+	if (!Math::AllFinite(position) || !IsFinite(rotation))
+	{
+		return false;
+	}
+
+	auto& bodyInterface = m_pImpl->m_physicsSystem.GetBodyInterface();
+	const JPH::BodyID id(bodyId);
+	if (!bodyInterface.IsAdded(id))
+	{
+		return false;
+	}
+
+	if (bKinematic && deltaTime > 0.0f)
+	{
+		bodyInterface.MoveKinematic(
+			id,
+			ToJoltPosition(position),
+			ToJolt(rotation),
+			deltaTime);
+	}
+	else
+	{
+		bodyInterface.SetPositionAndRotation(
+			id,
+			ToJoltPosition(position),
+			ToJolt(rotation),
+			JPH::EActivation::Activate);
+	}
+	return true;
+}
+
+bool Physics::PhysicsWorld::GetBodyPose(
+	uint32_t bodyId,
+	PhysicsBodyPose& outPose) const
+{
+	if (bodyId == JPH::BodyID::cInvalidBodyID)
+	{
+		return false;
+	}
+
+	const JPH::BodyID id(bodyId);
+	const auto& bodyInterface = m_pImpl->m_physicsSystem.GetBodyInterface();
+	if (!bodyInterface.IsAdded(id))
+	{
+		return false;
+	}
+
+	JPH::RVec3 position;
+	JPH::Quat rotation;
+	bodyInterface.GetPositionAndRotation(id, position, rotation);
+	outPose.m_position = FromJoltVector(position);
+	outPose.m_rotation = FromJoltQuat(rotation);
+	outPose.m_linearVelocity = FromJoltVector(bodyInterface.GetLinearVelocity(id));
+	outPose.m_angularVelocity = FromJoltVector(bodyInterface.GetAngularVelocity(id));
+	outPose.m_bActive = bodyInterface.IsActive(id);
+	return true;
+}
+
+bool Physics::PhysicsWorld::SetBodyVelocity(
+	uint32_t bodyId,
+	const glm::vec3& linearVelocity,
+	const glm::vec3& angularVelocity)
+{
+	if (bodyId == JPH::BodyID::cInvalidBodyID)
+	{
+		return false;
+	}
+	if (!Math::AllFinite(linearVelocity) ||
+		!Math::AllFinite(angularVelocity))
+	{
+		return false;
+	}
+
+	const JPH::BodyID id(bodyId);
+	auto& bodyInterface = m_pImpl->m_physicsSystem.GetBodyInterface();
+	if (!bodyInterface.IsAdded(id))
+	{
+		return false;
+	}
+	bodyInterface.SetLinearAndAngularVelocity(
+		id,
+		ToJolt(linearVelocity),
+		ToJolt(angularVelocity));
+	return true;
+}
+
+bool Physics::PhysicsWorld::Step(float deltaTime)
+{
+	if (!std::isfinite(deltaTime) || deltaTime <= 0.0f)
+	{
+		return false;
+	}
+
+	const JPH::EPhysicsUpdateError result = m_pImpl->m_physicsSystem.Update(
+		deltaTime,
+		1,
+		&m_pImpl->m_tempAllocator,
+		&m_pImpl->m_jobSystem);
+	if (result != JPH::EPhysicsUpdateError::None)
+	{
+		SAILOR_LOG_ERROR(
+			"Jolt physics update reported capacity error mask %u.",
+			static_cast<uint32_t>(result));
+		return false;
+	}
+	return true;
+}
+
+bool Physics::PhysicsWorld::Raycast(
+	const glm::vec3& origin,
+	const glm::vec3& direction,
+	float distance,
+	PhysicsRaycastHit& outHit,
+	uint16_t collisionMask) const
+{
+	if (!Math::AllFinite(origin) || !Math::AllFinite(direction) ||
+		!std::isfinite(distance) || collisionMask == 0)
+	{
+		return false;
+	}
+
+	const float directionLength = glm::length(direction);
+	if (directionLength <= 0.000001f || distance <= 0.0f)
+	{
+		return false;
+	}
+
+	const JPH::RRayCast ray(
+		ToJoltPosition(origin),
+		ToJolt(direction / directionLength * distance));
+	JPH::RayCastResult hit;
+	const QueryObjectLayerFilter objectLayerFilter(collisionMask);
+	if (!m_pImpl->m_physicsSystem.GetNarrowPhaseQuery().CastRay(
+		ray,
+		hit,
+		{},
+		objectLayerFilter))
+	{
+		return false;
+	}
+
+	if (!m_pImpl->ResolveInstanceId(hit.mBodyID, outHit.m_instanceId))
+	{
+		return false;
+	}
+
+	const JPH::RVec3 hitPosition = ray.GetPointOnRay(hit.mFraction);
+	outHit.m_position = FromJoltVector(hitPosition);
+	outHit.m_normal = glm::vec3(0.0f);
+	outHit.m_fraction = hit.mFraction;
+
+	JPH::BodyLockRead lock(
+		m_pImpl->m_physicsSystem.GetBodyLockInterface(),
+		hit.mBodyID);
+	if (lock.SucceededAndIsInBroadPhase())
+	{
+		const JPH::Body& body = lock.GetBody();
+		outHit.m_normal = FromJoltVector(
+			body.GetWorldSpaceSurfaceNormal(
+				hit.mSubShapeID2,
+				hitPosition));
+	}
+	return true;
+}
+
+void Physics::PhysicsWorld::SetLayerCollisionEnabled(
+	uint8_t firstLayer,
+	uint8_t secondLayer,
+	bool bEnabled)
+{
+	m_pImpl->m_objectLayerPairFilter.SetCollisionEnabled(
+		firstLayer,
+		secondLayer,
+		bEnabled);
+}
+
+bool Physics::PhysicsWorld::IsLayerCollisionEnabled(
+	uint8_t firstLayer,
+	uint8_t secondLayer) const
+{
+	return m_pImpl->m_objectLayerPairFilter.IsCollisionEnabled(
+		firstLayer,
+		secondLayer);
+}
+
+void Physics::PhysicsWorld::DrainContactEvents(
+	TVector<PhysicsContactEvent>& outEvents)
+{
+	PhysicsContactEvent event;
+	while (m_pImpl->m_contactEvents.try_pop(event))
+	{
+		outEvents.Add(std::move(event));
+	}
+
+	outEvents.Sort([](
+		const PhysicsContactEvent& lhs,
+		const PhysicsContactEvent& rhs)
+		{
+			if (lhs.m_first.ToString() != rhs.m_first.ToString())
+			{
+				return lhs.m_first.ToString() < rhs.m_first.ToString();
+			}
+			if (lhs.m_second.ToString() != rhs.m_second.ToString())
+			{
+				return lhs.m_second.ToString() < rhs.m_second.ToString();
+			}
+			return lhs.m_type < rhs.m_type;
+		});
+}
+
+void Physics::PhysicsWorld::Clear()
+{
+	TVector<uint32_t> bodyIds;
+	bodyIds.Reserve(m_pImpl->m_bodyInstances.Num());
+	for (const auto& body : m_pImpl->m_bodyInstances)
+	{
+		bodyIds.Add(body.m_first);
+	}
+	for (uint32_t bodyId : bodyIds)
+	{
+		DestroyBody(bodyId);
+	}
+	m_pImpl->m_bodyInstances.Clear();
+	PhysicsContactEvent event;
+	while (m_pImpl->m_contactEvents.try_pop(event)) {}
+}

--- a/Runtime/Physics/PhysicsWorld.h
+++ b/Runtime/Physics/PhysicsWorld.h
@@ -1,0 +1,56 @@
+#pragma once
+#include "Core/Defines.h"
+#include "Memory/UniquePtr.hpp"
+#include "Physics/PhysicsTypes.h"
+
+namespace Sailor::Physics
+{
+	class PhysicsWorld final
+	{
+	public:
+		SAILOR_API PhysicsWorld();
+		SAILOR_API ~PhysicsWorld();
+
+		PhysicsWorld(const PhysicsWorld&) = delete;
+		PhysicsWorld& operator=(const PhysicsWorld&) = delete;
+
+		SAILOR_API bool CreateBody(
+			const RigidBodyDesc& desc,
+			uint32_t& outBodyId);
+		SAILOR_API void DestroyBody(uint32_t bodyId);
+		SAILOR_API bool SetBodyTransform(
+			uint32_t bodyId,
+			const glm::vec3& position,
+			const glm::quat& rotation,
+			bool bKinematic,
+			float deltaTime);
+		SAILOR_API bool GetBodyPose(
+			uint32_t bodyId,
+			PhysicsBodyPose& outPose) const;
+		SAILOR_API bool SetBodyVelocity(
+			uint32_t bodyId,
+			const glm::vec3& linearVelocity,
+			const glm::vec3& angularVelocity);
+		SAILOR_API bool Step(float deltaTime);
+		SAILOR_API bool Raycast(
+			const glm::vec3& origin,
+			const glm::vec3& direction,
+			float distance,
+			PhysicsRaycastHit& outHit,
+			uint16_t collisionMask = 0xffffu) const;
+		SAILOR_API void SetLayerCollisionEnabled(
+			uint8_t firstLayer,
+			uint8_t secondLayer,
+			bool bEnabled);
+		SAILOR_API bool IsLayerCollisionEnabled(
+			uint8_t firstLayer,
+			uint8_t secondLayer) const;
+		SAILOR_API void DrainContactEvents(
+			TVector<PhysicsContactEvent>& outEvents);
+		SAILOR_API void Clear();
+
+	private:
+		class Impl;
+		TUniquePtr<Impl> m_pImpl;
+	};
+}

--- a/Runtime/Protocol/Generated/editor_engine.pb.cc
+++ b/Runtime/Protocol/Generated/editor_engine.pb.cc
@@ -934,6 +934,31 @@ struct EmptyDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 EmptyDefaultTypeInternal _Empty_default_instance_;
 
+inline constexpr EditorSimulationRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : enabled_{false},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR EditorSimulationRequest::EditorSimulationRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct EditorSimulationRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR EditorSimulationRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~EditorSimulationRequestDefaultTypeInternal() {}
+  union {
+    EditorSimulationRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 EditorSimulationRequestDefaultTypeInternal _EditorSimulationRequest_default_instance_;
+
 inline constexpr CreateGameObjectRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : parent_instance_id_(
@@ -1466,6 +1491,8 @@ const ::uint32_t
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolRequest, _impl_.command_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _internal_metadata_),
@@ -1583,6 +1610,15 @@ const ::uint32_t
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::SizeRequest, _impl_.width_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::SizeRequest, _impl_.height_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::EditorSimulationRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::EditorSimulationRequest, _impl_.enabled_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::RemoteViewportRequest, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -2019,52 +2055,53 @@ static const ::_pbi::MigrationSchema
     schemas[] ABSL_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
         {0, -1, -1, sizeof(::sailor::editor::v1::Empty)},
         {8, -1, -1, sizeof(::sailor::editor::v1::ProtocolRequest)},
-        {69, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
-        {96, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
-        {105, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
-        {114, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
-        {123, 138, -1, sizeof(::sailor::editor::v1::CreateModelInstanceRequest)},
-        {145, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
-        {154, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
-        {163, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
-        {175, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
-        {185, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
-        {200, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
-        {211, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
-        {231, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
-        {241, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
-        {251, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
-        {262, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
-        {272, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
-        {283, -1, -1, sizeof(::sailor::editor::v1::AnimatorParameterRequest)},
-        {299, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
-        {309, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
-        {320, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
-        {331, 343, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
-        {347, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
-        {357, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
-        {367, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
-        {378, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
-        {387, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
-        {396, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
-        {409, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
-        {418, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
-        {427, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
-        {436, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
-        {445, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
-        {455, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
-        {464, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
-        {476, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
-        {486, 495, -1, sizeof(::sailor::editor::v1::Vector4Result)},
-        {496, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
-        {506, -1, -1, sizeof(::sailor::editor::v1::AnimatorStateResult)},
-        {524, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
-        {536, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
-        {545, 562, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
-        {571, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
-        {582, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
-        {591, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
-        {606, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
+        {71, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
+        {98, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
+        {107, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
+        {116, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
+        {125, 140, -1, sizeof(::sailor::editor::v1::CreateModelInstanceRequest)},
+        {147, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
+        {156, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
+        {165, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
+        {177, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
+        {187, -1, -1, sizeof(::sailor::editor::v1::EditorSimulationRequest)},
+        {196, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
+        {211, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
+        {222, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
+        {242, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
+        {252, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
+        {262, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
+        {273, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
+        {283, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
+        {294, -1, -1, sizeof(::sailor::editor::v1::AnimatorParameterRequest)},
+        {310, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
+        {320, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
+        {331, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
+        {342, 354, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
+        {358, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
+        {368, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
+        {378, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
+        {389, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
+        {398, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
+        {407, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
+        {420, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
+        {429, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
+        {438, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
+        {447, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
+        {456, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
+        {466, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
+        {475, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
+        {487, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
+        {497, 506, -1, sizeof(::sailor::editor::v1::Vector4Result)},
+        {507, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
+        {517, -1, -1, sizeof(::sailor::editor::v1::AnimatorStateResult)},
+        {535, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
+        {547, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
+        {556, 573, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
+        {582, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
+        {593, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
+        {602, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
+        {617, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_Empty_default_instance_._instance,
@@ -2078,6 +2115,7 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_ViewportIdRequest_default_instance_._instance,
     &::sailor::editor::v1::_ViewportRectRequest_default_instance_._instance,
     &::sailor::editor::v1::_SizeRequest_default_instance_._instance,
+    &::sailor::editor::v1::_EditorSimulationRequest_default_instance_._instance,
     &::sailor::editor::v1::_RemoteViewportRequest_default_instance_._instance,
     &::sailor::editor::v1::_RemoteViewportHostRequest_default_instance_._instance,
     &::sailor::editor::v1::_RemoteViewportInputRequest_default_instance_._instance,
@@ -2119,7 +2157,7 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
     protodesc_cold) = {
     "\n\023editor_engine.proto\022\020sailor.editor.v1\""
-    "\007\n\005Empty\"\334\033\n\017ProtocolRequest\022\030\n\020protocol"
+    "\007\n\005Empty\"\350\034\n\017ProtocolRequest\022\030\n\020protocol"
     "_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\0229\n\nin"
     "itialize\030\n \001(\0132#.sailor.editor.v1.Initia"
     "lizeRequestH\000\022(\n\005start\030\013 \001(\0132\027.sailor.ed"
@@ -2205,176 +2243,180 @@ const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SE
     "questH\000\022L\n\026set_animator_parameter\030; \001(\0132"
     "*.sailor.editor.v1.AnimatorParameterRequ"
     "estH\000\022A\n\022get_animator_state\030< \001(\0132#.sail"
-    "or.editor.v1.InstanceIdRequestH\000B\t\n\007comm"
-    "andJ\004\010\003\020\nJ\004\0102\0203J\004\010=\020dR\030create_model_game"
-    "_objectR\036resolve_viewport_drop_position\""
-    "\336\007\n\020ProtocolResponse\022\030\n\020protocol_version"
-    "\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\022\017\n\007success\030\003 "
-    "\001(\010\022\r\n\005error\030\004 \001(\t\022$\n\034supports_strict_in"
-    "stance_ids\030\005 \001(\010\022/\n\014empty_result\030\n \001(\0132\027"
-    ".sailor.editor.v1.EmptyH\000\0223\n\013bool_result"
-    "\030\013 \001(\0132\034.sailor.editor.v1.BoolResultH\000\0225"
-    "\n\014int32_result\030\014 \001(\0132\035.sailor.editor.v1."
-    "Int32ResultH\000\0227\n\ruint32_result\030\r \001(\0132\036.s"
-    "ailor.editor.v1.UInt32ResultH\000\0227\n\ruint64"
-    "_result\030\016 \001(\0132\036.sailor.editor.v1.UInt64R"
-    "esultH\000\0227\n\rstring_result\030\017 \001(\0132\036.sailor."
-    "editor.v1.StringResultH\000\022@\n\022string_list_"
-    "result\030\020 \001(\0132\".sailor.editor.v1.StringLi"
-    "stResultH\000\022M\n\031asset_reload_state_result\030"
-    "\021 \001(\0132(.sailor.editor.v1.AssetReloadStat"
-    "eResultH\000\022@\n\022instance_id_result\030\022 \001(\0132\"."
-    "sailor.editor.v1.InstanceIdResultH\000\022Q\n\033v"
-    "iewport_event_batch_result\030\023 \001(\0132*.sailo"
-    "r.editor.v1.ViewportEventBatchResultH\000\0229"
-    "\n\016vector4_result\030\024 \001(\0132\037.sailor.editor.v"
-    "1.Vector4ResultH\000\022O\n\032viewport_tool_state"
-    "_result\030\025 \001(\0132).sailor.editor.v1.Viewpor"
-    "tToolStateResultH\000\022F\n\025animator_state_res"
-    "ult\030\026 \001(\0132%.sailor.editor.v1.AnimatorSta"
-    "teResultH\000B\010\n\006resultJ\004\010\006\020\nJ\004\010\027\020d\"&\n\021Init"
-    "ializeRequest\022\021\n\targuments\030\001 \003(\t\"!\n\014Coun"
-    "tRequest\022\021\n\tmax_count\030\001 \001(\r\" \n\rFileIdReq"
-    "uest\022\017\n\007file_id\030\001 \001(\t\"\347\001\n\032CreateModelIns"
-    "tanceRequest\022\025\n\rmodel_file_id\030\001 \001(\t\022\014\n\004n"
-    "ame\030\002 \001(\t\022\032\n\022parent_instance_id\030\003 \001(\t\022\030\n"
-    "\020create_hierarchy\030\004 \001(\010\022\034\n\024apply_world_p"
-    "osition\030\005 \001(\010\0221\n\016world_position\030\006 \001(\0132\031."
-    "sailor.editor.v1.Vector4\022\035\n\025preferred_in"
-    "stance_id\030\007 \001(\t\"(\n\021InstanceIdRequest\022\023\n\013"
-    "instance_id\030\001 \001(\t\"(\n\021ViewportIdRequest\022\023"
-    "\n\013viewport_id\030\001 \001(\004\"`\n\023ViewportRectReque"
-    "st\022\024\n\014window_pos_x\030\001 \001(\r\022\024\n\014window_pos_y"
-    "\030\002 \001(\r\022\r\n\005width\030\003 \001(\r\022\016\n\006height\030\004 \001(\r\",\n"
-    "\013SizeRequest\022\r\n\005width\030\001 \001(\r\022\016\n\006height\030\002 "
-    "\001(\r\"\231\001\n\025RemoteViewportRequest\022\023\n\013viewpor"
-    "t_id\030\001 \001(\004\022\024\n\014window_pos_x\030\002 \001(\r\022\024\n\014wind"
-    "ow_pos_y\030\003 \001(\r\022\r\n\005width\030\004 \001(\r\022\016\n\006height\030"
-    "\005 \001(\r\022\017\n\007visible\030\006 \001(\010\022\017\n\007focused\030\007 \001(\010\""
-    "e\n\031RemoteViewportHostRequest\022\023\n\013viewport"
-    "_id\030\001 \001(\004\022\030\n\020host_handle_kind\030\002 \001(\r\022\031\n\021h"
-    "ost_handle_value\030\003 \001(\004\"\374\001\n\032RemoteViewpor"
-    "tInputRequest\022\023\n\013viewport_id\030\001 \001(\004\022\014\n\004ki"
-    "nd\030\002 \001(\r\022\021\n\tpointer_x\030\003 \001(\002\022\021\n\tpointer_y"
-    "\030\004 \001(\002\022\025\n\rwheel_delta_x\030\005 \001(\002\022\025\n\rwheel_d"
-    "elta_y\030\006 \001(\002\022\020\n\010key_code\030\007 \001(\r\022\016\n\006button"
-    "\030\010 \001(\r\022\021\n\tmodifiers\030\t \001(\r\022\017\n\007pressed\030\n \001"
-    "(\010\022\017\n\007focused\030\013 \001(\010\022\020\n\010captured\030\014 \001(\010\"C\n"
-    "\036ManagedMutationRevisionRequest\022\014\n\004kind\030"
-    "\001 \001(\r\022\023\n\013instance_id\030\002 \001(\t\"@\n\023UpdateObje"
-    "ctRequest\022\023\n\013instance_id\030\001 \001(\t\022\024\n\014yaml_c"
-    "hanges\030\002 \001(\t\"f\n\025ReparentObjectRequest\022\023\n"
-    "\013instance_id\030\001 \001(\t\022\032\n\022parent_instance_id"
-    "\030\002 \001(\t\022\034\n\024keep_world_transform\030\003 \001(\010\"T\n\027"
-    "CreateGameObjectRequest\022\032\n\022parent_instan"
-    "ce_id\030\001 \001(\t\022\035\n\025preferred_instance_id\030\002 \001"
-    "(\t\"f\n\023AddComponentRequest\022\023\n\013instance_id"
-    "\030\001 \001(\t\022\033\n\023component_type_name\030\002 \001(\t\022\035\n\025p"
-    "referred_instance_id\030\003 \001(\t\"\346\001\n\030AnimatorP"
-    "arameterRequest\022\023\n\013instance_id\030\001 \001(\t\022\014\n\004"
-    "name\030\002 \001(\t\022\025\n\013float_value\030\003 \001(\002H\000\022\023\n\tint"
-    "_value\030\004 \001(\021H\000\022\024\n\nbool_value\030\005 \001(\010H\000\022*\n\007"
-    "trigger\030\006 \001(\0132\027.sailor.editor.v1.EmptyH\000"
-    "\0220\n\rreset_trigger\030\007 \001(\0132\027.sailor.editor."
-    "v1.EmptyH\000B\007\n\005value\"G\n\030InstantiatePrefab"
-    "Request\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_insta"
-    "nce_id\030\002 \001(\t\"p\n InstantiatePrefabFromYam"
-    "lRequest\022\023\n\013prefab_yaml\030\001 \001(\t\022\032\n\022parent_"
-    "instance_id\030\002 \001(\t\022\033\n\023strict_instance_ids"
-    "\030\003 \001(\010\"U\n\022ViewportRayRequest\022\023\n\013viewport"
-    "_id\030\001 \001(\004\022\024\n\014normalized_x\030\002 \001(\002\022\024\n\014norma"
-    "lized_y\030\003 \001(\002\"\240\001\n InstantiatePrefabInsta"
-    "nceRequest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_in"
-    "stance_id\030\002 \001(\t\022\034\n\024apply_world_position\030"
-    "\003 \001(\010\0221\n\016world_position\030\004 \001(\0132\031.sailor.e"
-    "ditor.v1.Vector4\"A\n\025ViewportObjectReques"
-    "t\022\023\n\013viewport_id\030\001 \001(\004\022\023\n\013instance_id\030\002 "
-    "\001(\t\"9\n\021PrefabLinkRequest\022\023\n\013instance_id\030"
-    "\001 \001(\t\022\017\n\007file_id\030\002 \001(\t\"\251\001\n\030ViewportToolS"
-    "tateRequest\022\023\n\013viewport_id\030\001 \001(\004\022\?\n\toper"
-    "ation\030\002 \001(\0162,.sailor.editor.v1.ViewportT"
-    "ransformOperation\0227\n\005space\030\003 \001(\0162(.sailo"
-    "r.editor.v1.ViewportTransformSpace\"(\n\020Se"
-    "lectionRequest\022\024\n\014instance_ids\030\001 \003(\t\"%\n\025"
-    "ShowMainWindowRequest\022\014\n\004show\030\001 \001(\010\"\210\001\n\034"
-    "RenderPathTracedImageRequest\022\023\n\013output_p"
-    "ath\030\001 \001(\t\022\023\n\013instance_id\030\002 \001(\t\022\016\n\006height"
-    "\030\003 \001(\r\022\031\n\021samples_per_pixel\030\004 \001(\r\022\023\n\013max"
-    "_bounces\030\005 \001(\r\"\033\n\nBoolResult\022\r\n\005value\030\001 "
-    "\001(\010\"\034\n\013Int32Result\022\r\n\005value\030\001 \001(\005\"\035\n\014UIn"
-    "t32Result\022\r\n\005value\030\001 \001(\r\"\035\n\014UInt64Result"
-    "\022\r\n\005value\030\001 \001(\004\"0\n\014StringResult\022\021\n\thas_v"
-    "alue\030\001 \001(\010\022\r\n\005value\030\002 \001(\t\"\"\n\020StringListR"
-    "esult\022\016\n\006values\030\001 \003(\t\"\204\001\n\026AssetReloadSta"
-    "teResult\022\021\n\tavailable\030\001 \001(\010\022\032\n\022request_g"
-    "eneration\030\002 \001(\004\022\034\n\024completed_generation\030"
-    "\003 \001(\004\022\035\n\025successful_generation\030\004 \001(\004\":\n\020"
-    "InstanceIdResult\022\021\n\tsucceeded\030\001 \001(\010\022\023\n\013i"
-    "nstance_id\030\002 \001(\t\"9\n\rVector4Result\022(\n\005val"
-    "ue\030\001 \001(\0132\031.sailor.editor.v1.Vector4\"\223\001\n\027"
-    "ViewportToolStateResult\022\?\n\toperation\030\001 \001"
-    "(\0162,.sailor.editor.v1.ViewportTransformO"
-    "peration\0227\n\005space\030\002 \001(\0162(.sailor.editor."
-    "v1.ViewportTransformSpace\"\250\002\n\023AnimatorSt"
-    "ateResult\022\026\n\016has_controller\030\001 \001(\010\022\033\n\023con"
-    "troller_revision\030\002 \001(\004\022\027\n\017active_state_i"
-    "d\030\003 \001(\004\022\031\n\021active_state_name\030\004 \001(\t\022\031\n\021ac"
-    "tive_state_time\030\005 \001(\002\022\025\n\rtransitioning\030\006"
-    " \001(\010\022\034\n\024destination_state_id\030\007 \001(\004\022\036\n\026de"
-    "stination_state_name\030\010 \001(\t\022\036\n\026destinatio"
-    "n_state_time\030\t \001(\002\022\030\n\020transition_alpha\030\n"
-    " \001(\002\"5\n\007Vector4\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n"
-    "\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n\026ViewportSelection"
-    "Event\022\034\n\024selected_instance_id\030\001 \001(\t\"\326\003\n\026"
-    "ViewportTransformEvent\022\023\n\013instance_id\030\001 "
-    "\001(\t\022\?\n\toperation\030\002 \001(\0162,.sailor.editor.v"
-    "1.ViewportTransformOperation\0227\n\005space\030\003 "
-    "\001(\0162(.sailor.editor.v1.ViewportTransform"
-    "Space\0222\n\017before_position\030\004 \001(\0132\031.sailor."
-    "editor.v1.Vector4\0222\n\017before_rotation\030\005 \001"
-    "(\0132\031.sailor.editor.v1.Vector4\022/\n\014before_"
-    "scale\030\006 \001(\0132\031.sailor.editor.v1.Vector4\0221"
-    "\n\016after_position\030\007 \001(\0132\031.sailor.editor.v"
-    "1.Vector4\0221\n\016after_rotation\030\010 \001(\0132\031.sail"
-    "or.editor.v1.Vector4\022.\n\013after_scale\030\t \001("
-    "\0132\031.sailor.editor.v1.Vector4\"U\n\026Viewport"
-    "AssetDropEvent\022\017\n\007file_id\030\001 \001(\t\022\024\n\014norma"
-    "lized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 \001(\002\"-\n\031V"
-    "iewportToolShortcutEvent\022\020\n\010key_code\030\001 \001"
-    "(\r\"\331\002\n\rViewportEvent\022\020\n\010revision\030\001 \001(\004\022!"
-    "\n\031managed_mutation_revision\030\002 \001(\004\022=\n\tsel"
-    "ection\030\n \001(\0132(.sailor.editor.v1.Viewport"
-    "SelectionEventH\000\022=\n\ttransform\030\013 \001(\0132(.sa"
-    "ilor.editor.v1.ViewportTransformEventH\000\022"
-    ">\n\nasset_drop\030\014 \001(\0132(.sailor.editor.v1.V"
-    "iewportAssetDropEventH\000\022D\n\rtool_shortcut"
-    "\030\r \001(\0132+.sailor.editor.v1.ViewportToolSh"
-    "ortcutEventH\000B\t\n\007payloadJ\004\010\003\020\n\"K\n\030Viewpo"
-    "rtEventBatchResult\022/\n\006events\030\001 \003(\0132\037.sai"
-    "lor.editor.v1.ViewportEvent*\360\001\n\032Viewport"
-    "TransformOperation\022,\n(VIEWPORT_TRANSFORM"
-    "_OPERATION_UNSPECIFIED\020\000\022\'\n#VIEWPORT_TRA"
-    "NSFORM_OPERATION_SELECT\020\001\022*\n&VIEWPORT_TR"
-    "ANSFORM_OPERATION_TRANSLATE\020\002\022\'\n#VIEWPOR"
-    "T_TRANSFORM_OPERATION_ROTATE\020\003\022&\n\"VIEWPO"
-    "RT_TRANSFORM_OPERATION_SCALE\020\004*\212\001\n\026Viewp"
-    "ortTransformSpace\022(\n$VIEWPORT_TRANSFORM_"
-    "SPACE_UNSPECIFIED\020\000\022\"\n\036VIEWPORT_TRANSFOR"
-    "M_SPACE_WORLD\020\001\022\"\n\036VIEWPORT_TRANSFORM_SP"
-    "ACE_LOCAL\020\002B\"\252\002\037SailorEditor.Protocol.Ge"
-    "neratedb\006proto3"
+    "or.editor.v1.InstanceIdRequestH\000\022J\n\025set_"
+    "editor_simulation\030= \001(\0132).sailor.editor."
+    "v1.EditorSimulationRequestH\000\022>\n\033get_edit"
+    "or_simulation_state\030> \001(\0132\027.sailor.edito"
+    "r.v1.EmptyH\000B\t\n\007commandJ\004\010\003\020\nJ\004\0102\0203J\004\010\?\020"
+    "dR\030create_model_game_objectR\036resolve_vie"
+    "wport_drop_position\"\336\007\n\020ProtocolResponse"
+    "\022\030\n\020protocol_version\030\001 \001(\r\022\022\n\nrequest_id"
+    "\030\002 \001(\004\022\017\n\007success\030\003 \001(\010\022\r\n\005error\030\004 \001(\t\022$"
+    "\n\034supports_strict_instance_ids\030\005 \001(\010\022/\n\014"
+    "empty_result\030\n \001(\0132\027.sailor.editor.v1.Em"
+    "ptyH\000\0223\n\013bool_result\030\013 \001(\0132\034.sailor.edit"
+    "or.v1.BoolResultH\000\0225\n\014int32_result\030\014 \001(\013"
+    "2\035.sailor.editor.v1.Int32ResultH\000\0227\n\ruin"
+    "t32_result\030\r \001(\0132\036.sailor.editor.v1.UInt"
+    "32ResultH\000\0227\n\ruint64_result\030\016 \001(\0132\036.sail"
+    "or.editor.v1.UInt64ResultH\000\0227\n\rstring_re"
+    "sult\030\017 \001(\0132\036.sailor.editor.v1.StringResu"
+    "ltH\000\022@\n\022string_list_result\030\020 \001(\0132\".sailo"
+    "r.editor.v1.StringListResultH\000\022M\n\031asset_"
+    "reload_state_result\030\021 \001(\0132(.sailor.edito"
+    "r.v1.AssetReloadStateResultH\000\022@\n\022instanc"
+    "e_id_result\030\022 \001(\0132\".sailor.editor.v1.Ins"
+    "tanceIdResultH\000\022Q\n\033viewport_event_batch_"
+    "result\030\023 \001(\0132*.sailor.editor.v1.Viewport"
+    "EventBatchResultH\000\0229\n\016vector4_result\030\024 \001"
+    "(\0132\037.sailor.editor.v1.Vector4ResultH\000\022O\n"
+    "\032viewport_tool_state_result\030\025 \001(\0132).sail"
+    "or.editor.v1.ViewportToolStateResultH\000\022F"
+    "\n\025animator_state_result\030\026 \001(\0132%.sailor.e"
+    "ditor.v1.AnimatorStateResultH\000B\010\n\006result"
+    "J\004\010\006\020\nJ\004\010\027\020d\"&\n\021InitializeRequest\022\021\n\targ"
+    "uments\030\001 \003(\t\"!\n\014CountRequest\022\021\n\tmax_coun"
+    "t\030\001 \001(\r\" \n\rFileIdRequest\022\017\n\007file_id\030\001 \001("
+    "\t\"\347\001\n\032CreateModelInstanceRequest\022\025\n\rmode"
+    "l_file_id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\032\n\022parent_"
+    "instance_id\030\003 \001(\t\022\030\n\020create_hierarchy\030\004 "
+    "\001(\010\022\034\n\024apply_world_position\030\005 \001(\010\0221\n\016wor"
+    "ld_position\030\006 \001(\0132\031.sailor.editor.v1.Vec"
+    "tor4\022\035\n\025preferred_instance_id\030\007 \001(\t\"(\n\021I"
+    "nstanceIdRequest\022\023\n\013instance_id\030\001 \001(\t\"(\n"
+    "\021ViewportIdRequest\022\023\n\013viewport_id\030\001 \001(\004\""
+    "`\n\023ViewportRectRequest\022\024\n\014window_pos_x\030\001"
+    " \001(\r\022\024\n\014window_pos_y\030\002 \001(\r\022\r\n\005width\030\003 \001("
+    "\r\022\016\n\006height\030\004 \001(\r\",\n\013SizeRequest\022\r\n\005widt"
+    "h\030\001 \001(\r\022\016\n\006height\030\002 \001(\r\"*\n\027EditorSimulat"
+    "ionRequest\022\017\n\007enabled\030\001 \001(\010\"\231\001\n\025RemoteVi"
+    "ewportRequest\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014wi"
+    "ndow_pos_x\030\002 \001(\r\022\024\n\014window_pos_y\030\003 \001(\r\022\r"
+    "\n\005width\030\004 \001(\r\022\016\n\006height\030\005 \001(\r\022\017\n\007visible"
+    "\030\006 \001(\010\022\017\n\007focused\030\007 \001(\010\"e\n\031RemoteViewpor"
+    "tHostRequest\022\023\n\013viewport_id\030\001 \001(\004\022\030\n\020hos"
+    "t_handle_kind\030\002 \001(\r\022\031\n\021host_handle_value"
+    "\030\003 \001(\004\"\374\001\n\032RemoteViewportInputRequest\022\023\n"
+    "\013viewport_id\030\001 \001(\004\022\014\n\004kind\030\002 \001(\r\022\021\n\tpoin"
+    "ter_x\030\003 \001(\002\022\021\n\tpointer_y\030\004 \001(\002\022\025\n\rwheel_"
+    "delta_x\030\005 \001(\002\022\025\n\rwheel_delta_y\030\006 \001(\002\022\020\n\010"
+    "key_code\030\007 \001(\r\022\016\n\006button\030\010 \001(\r\022\021\n\tmodifi"
+    "ers\030\t \001(\r\022\017\n\007pressed\030\n \001(\010\022\017\n\007focused\030\013 "
+    "\001(\010\022\020\n\010captured\030\014 \001(\010\"C\n\036ManagedMutation"
+    "RevisionRequest\022\014\n\004kind\030\001 \001(\r\022\023\n\013instanc"
+    "e_id\030\002 \001(\t\"@\n\023UpdateObjectRequest\022\023\n\013ins"
+    "tance_id\030\001 \001(\t\022\024\n\014yaml_changes\030\002 \001(\t\"f\n\025"
+    "ReparentObjectRequest\022\023\n\013instance_id\030\001 \001"
+    "(\t\022\032\n\022parent_instance_id\030\002 \001(\t\022\034\n\024keep_w"
+    "orld_transform\030\003 \001(\010\"T\n\027CreateGameObject"
+    "Request\022\032\n\022parent_instance_id\030\001 \001(\t\022\035\n\025p"
+    "referred_instance_id\030\002 \001(\t\"f\n\023AddCompone"
+    "ntRequest\022\023\n\013instance_id\030\001 \001(\t\022\033\n\023compon"
+    "ent_type_name\030\002 \001(\t\022\035\n\025preferred_instanc"
+    "e_id\030\003 \001(\t\"\346\001\n\030AnimatorParameterRequest\022"
+    "\023\n\013instance_id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\025\n\013fl"
+    "oat_value\030\003 \001(\002H\000\022\023\n\tint_value\030\004 \001(\021H\000\022\024"
+    "\n\nbool_value\030\005 \001(\010H\000\022*\n\007trigger\030\006 \001(\0132\027."
+    "sailor.editor.v1.EmptyH\000\0220\n\rreset_trigge"
+    "r\030\007 \001(\0132\027.sailor.editor.v1.EmptyH\000B\007\n\005va"
+    "lue\"G\n\030InstantiatePrefabRequest\022\017\n\007file_"
+    "id\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\"p\n "
+    "InstantiatePrefabFromYamlRequest\022\023\n\013pref"
+    "ab_yaml\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001("
+    "\t\022\033\n\023strict_instance_ids\030\003 \001(\010\"U\n\022Viewpo"
+    "rtRayRequest\022\023\n\013viewport_id\030\001 \001(\004\022\024\n\014nor"
+    "malized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 \001(\002\"\240\001"
+    "\n InstantiatePrefabInstanceRequest\022\017\n\007fi"
+    "le_id\030\001 \001(\t\022\032\n\022parent_instance_id\030\002 \001(\t\022"
+    "\034\n\024apply_world_position\030\003 \001(\010\0221\n\016world_p"
+    "osition\030\004 \001(\0132\031.sailor.editor.v1.Vector4"
+    "\"A\n\025ViewportObjectRequest\022\023\n\013viewport_id"
+    "\030\001 \001(\004\022\023\n\013instance_id\030\002 \001(\t\"9\n\021PrefabLin"
+    "kRequest\022\023\n\013instance_id\030\001 \001(\t\022\017\n\007file_id"
+    "\030\002 \001(\t\"\251\001\n\030ViewportToolStateRequest\022\023\n\013v"
+    "iewport_id\030\001 \001(\004\022\?\n\toperation\030\002 \001(\0162,.sa"
+    "ilor.editor.v1.ViewportTransformOperatio"
+    "n\0227\n\005space\030\003 \001(\0162(.sailor.editor.v1.View"
+    "portTransformSpace\"(\n\020SelectionRequest\022\024"
+    "\n\014instance_ids\030\001 \003(\t\"%\n\025ShowMainWindowRe"
+    "quest\022\014\n\004show\030\001 \001(\010\"\210\001\n\034RenderPathTraced"
+    "ImageRequest\022\023\n\013output_path\030\001 \001(\t\022\023\n\013ins"
+    "tance_id\030\002 \001(\t\022\016\n\006height\030\003 \001(\r\022\031\n\021sample"
+    "s_per_pixel\030\004 \001(\r\022\023\n\013max_bounces\030\005 \001(\r\"\033"
+    "\n\nBoolResult\022\r\n\005value\030\001 \001(\010\"\034\n\013Int32Resu"
+    "lt\022\r\n\005value\030\001 \001(\005\"\035\n\014UInt32Result\022\r\n\005val"
+    "ue\030\001 \001(\r\"\035\n\014UInt64Result\022\r\n\005value\030\001 \001(\004\""
+    "0\n\014StringResult\022\021\n\thas_value\030\001 \001(\010\022\r\n\005va"
+    "lue\030\002 \001(\t\"\"\n\020StringListResult\022\016\n\006values\030"
+    "\001 \003(\t\"\204\001\n\026AssetReloadStateResult\022\021\n\tavai"
+    "lable\030\001 \001(\010\022\032\n\022request_generation\030\002 \001(\004\022"
+    "\034\n\024completed_generation\030\003 \001(\004\022\035\n\025success"
+    "ful_generation\030\004 \001(\004\":\n\020InstanceIdResult"
+    "\022\021\n\tsucceeded\030\001 \001(\010\022\023\n\013instance_id\030\002 \001(\t"
+    "\"9\n\rVector4Result\022(\n\005value\030\001 \001(\0132\031.sailo"
+    "r.editor.v1.Vector4\"\223\001\n\027ViewportToolStat"
+    "eResult\022\?\n\toperation\030\001 \001(\0162,.sailor.edit"
+    "or.v1.ViewportTransformOperation\0227\n\005spac"
+    "e\030\002 \001(\0162(.sailor.editor.v1.ViewportTrans"
+    "formSpace\"\250\002\n\023AnimatorStateResult\022\026\n\016has"
+    "_controller\030\001 \001(\010\022\033\n\023controller_revision"
+    "\030\002 \001(\004\022\027\n\017active_state_id\030\003 \001(\004\022\031\n\021activ"
+    "e_state_name\030\004 \001(\t\022\031\n\021active_state_time\030"
+    "\005 \001(\002\022\025\n\rtransitioning\030\006 \001(\010\022\034\n\024destinat"
+    "ion_state_id\030\007 \001(\004\022\036\n\026destination_state_"
+    "name\030\010 \001(\t\022\036\n\026destination_state_time\030\t \001"
+    "(\002\022\030\n\020transition_alpha\030\n \001(\002\"5\n\007Vector4\022"
+    "\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n\001z\030\003 \001(\002\022\t\n\001w\030\004 "
+    "\001(\002\"6\n\026ViewportSelectionEvent\022\034\n\024selecte"
+    "d_instance_id\030\001 \001(\t\"\326\003\n\026ViewportTransfor"
+    "mEvent\022\023\n\013instance_id\030\001 \001(\t\022\?\n\toperation"
+    "\030\002 \001(\0162,.sailor.editor.v1.ViewportTransf"
+    "ormOperation\0227\n\005space\030\003 \001(\0162(.sailor.edi"
+    "tor.v1.ViewportTransformSpace\0222\n\017before_"
+    "position\030\004 \001(\0132\031.sailor.editor.v1.Vector"
+    "4\0222\n\017before_rotation\030\005 \001(\0132\031.sailor.edit"
+    "or.v1.Vector4\022/\n\014before_scale\030\006 \001(\0132\031.sa"
+    "ilor.editor.v1.Vector4\0221\n\016after_position"
+    "\030\007 \001(\0132\031.sailor.editor.v1.Vector4\0221\n\016aft"
+    "er_rotation\030\010 \001(\0132\031.sailor.editor.v1.Vec"
+    "tor4\022.\n\013after_scale\030\t \001(\0132\031.sailor.edito"
+    "r.v1.Vector4\"U\n\026ViewportAssetDropEvent\022\017"
+    "\n\007file_id\030\001 \001(\t\022\024\n\014normalized_x\030\002 \001(\002\022\024\n"
+    "\014normalized_y\030\003 \001(\002\"-\n\031ViewportToolShort"
+    "cutEvent\022\020\n\010key_code\030\001 \001(\r\"\331\002\n\rViewportE"
+    "vent\022\020\n\010revision\030\001 \001(\004\022!\n\031managed_mutati"
+    "on_revision\030\002 \001(\004\022=\n\tselection\030\n \001(\0132(.s"
+    "ailor.editor.v1.ViewportSelectionEventH\000"
+    "\022=\n\ttransform\030\013 \001(\0132(.sailor.editor.v1.V"
+    "iewportTransformEventH\000\022>\n\nasset_drop\030\014 "
+    "\001(\0132(.sailor.editor.v1.ViewportAssetDrop"
+    "EventH\000\022D\n\rtool_shortcut\030\r \001(\0132+.sailor."
+    "editor.v1.ViewportToolShortcutEventH\000B\t\n"
+    "\007payloadJ\004\010\003\020\n\"K\n\030ViewportEventBatchResu"
+    "lt\022/\n\006events\030\001 \003(\0132\037.sailor.editor.v1.Vi"
+    "ewportEvent*\360\001\n\032ViewportTransformOperati"
+    "on\022,\n(VIEWPORT_TRANSFORM_OPERATION_UNSPE"
+    "CIFIED\020\000\022\'\n#VIEWPORT_TRANSFORM_OPERATION"
+    "_SELECT\020\001\022*\n&VIEWPORT_TRANSFORM_OPERATIO"
+    "N_TRANSLATE\020\002\022\'\n#VIEWPORT_TRANSFORM_OPER"
+    "ATION_ROTATE\020\003\022&\n\"VIEWPORT_TRANSFORM_OPE"
+    "RATION_SCALE\020\004*\212\001\n\026ViewportTransformSpac"
+    "e\022(\n$VIEWPORT_TRANSFORM_SPACE_UNSPECIFIE"
+    "D\020\000\022\"\n\036VIEWPORT_TRANSFORM_SPACE_WORLD\020\001\022"
+    "\"\n\036VIEWPORT_TRANSFORM_SPACE_LOCAL\020\002B\"\252\002\037"
+    "SailorEditor.Protocol.Generatedb\006proto3"
 };
 static ::absl::once_flag descriptor_table_editor_5fengine_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_editor_5fengine_2eproto = {
     false,
     false,
-    9775,
+    9959,
     descriptor_table_protodef_editor_5fengine_2eproto,
     "editor_engine.proto",
     &descriptor_table_editor_5fengine_2eproto_once,
     nullptr,
     0,
-    48,
+    49,
     schemas,
     file_default_instances,
     TableStruct_editor_5fengine_2eproto::offsets,
@@ -3163,6 +3205,32 @@ void ProtocolRequest::set_allocated_get_animator_state(::sailor::editor::v1::Ins
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.get_animator_state)
 }
+void ProtocolRequest::set_allocated_set_editor_simulation(::sailor::editor::v1::EditorSimulationRequest* set_editor_simulation) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (set_editor_simulation) {
+    ::google::protobuf::Arena* submessage_arena = set_editor_simulation->GetArena();
+    if (message_arena != submessage_arena) {
+      set_editor_simulation = ::google::protobuf::internal::GetOwnedMessage(message_arena, set_editor_simulation, submessage_arena);
+    }
+    set_has_set_editor_simulation();
+    _impl_.command_.set_editor_simulation_ = set_editor_simulation;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.set_editor_simulation)
+}
+void ProtocolRequest::set_allocated_get_editor_simulation_state(::sailor::editor::v1::Empty* get_editor_simulation_state) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (get_editor_simulation_state) {
+    ::google::protobuf::Arena* submessage_arena = get_editor_simulation_state->GetArena();
+    if (message_arena != submessage_arena) {
+      get_editor_simulation_state = ::google::protobuf::internal::GetOwnedMessage(message_arena, get_editor_simulation_state, submessage_arena);
+    }
+    set_has_get_editor_simulation_state();
+    _impl_.command_.get_editor_simulation_state_ = get_editor_simulation_state;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.get_editor_simulation_state)
+}
 ProtocolRequest::ProtocolRequest(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
@@ -3351,6 +3419,12 @@ ProtocolRequest::ProtocolRequest(
         break;
       case kGetAnimatorState:
         _impl_.command_.get_animator_state_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::InstanceIdRequest>(arena, *from._impl_.command_.get_animator_state_);
+        break;
+      case kSetEditorSimulation:
+        _impl_.command_.set_editor_simulation_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::EditorSimulationRequest>(arena, *from._impl_.command_.set_editor_simulation_);
+        break;
+      case kGetEditorSimulationState:
+        _impl_.command_.get_editor_simulation_state_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Empty>(arena, *from._impl_.command_.get_editor_simulation_state_);
         break;
   }
 
@@ -3790,6 +3864,22 @@ void ProtocolRequest::clear_command() {
       }
       break;
     }
+    case kSetEditorSimulation: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.set_editor_simulation_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_editor_simulation_);
+      }
+      break;
+    }
+    case kGetEditorSimulationState: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.get_editor_simulation_state_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.get_editor_simulation_state_);
+      }
+      break;
+    }
     case COMMAND_NOT_SET: {
       break;
     }
@@ -3834,16 +3924,16 @@ const ::google::protobuf::internal::ClassData* ProtocolRequest::GetClassData() c
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 52, 50, 0, 9> ProtocolRequest::_table_ = {
+const ::_pbi::TcParseTable<1, 54, 52, 0, 9> ProtocolRequest::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    60, 8,  // max_field_number, fast_idx_mask
+    62, 8,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
     508,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    52,  // num_field_entries
-    50,  // num_aux_entries
+    54,  // num_field_entries
+    52,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -3860,7 +3950,7 @@ const ::_pbi::TcParseTable<1, 52, 50, 0, 9> ProtocolRequest::_table_ = {
      {8, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.protocol_version_)}},
   }}, {{
     33, 0, 2,
-    0, 25, 61442, 41,
+    0, 25, 49154, 41,
     65535, 65535
   }}, {{
     // uint32 protocol_version = 1;
@@ -4019,6 +4109,12 @@ const ::_pbi::TcParseTable<1, 52, 50, 0, 9> ProtocolRequest::_table_ = {
     // .sailor.editor.v1.InstanceIdRequest get_animator_state = 60;
     {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.get_animator_state_), _Internal::kOneofCaseOffset + 0, 49,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.EditorSimulationRequest set_editor_simulation = 61;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_editor_simulation_), _Internal::kOneofCaseOffset + 0, 50,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.Empty get_editor_simulation_state = 62;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.get_editor_simulation_state_), _Internal::kOneofCaseOffset + 0, 51,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InitializeRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
@@ -4070,6 +4166,8 @@ const ::_pbi::TcParseTable<1, 52, 50, 0, 9> ProtocolRequest::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::CreateModelInstanceRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::AnimatorParameterRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InstanceIdRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::EditorSimulationRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
   }}, {{
   }},
 };
@@ -4418,6 +4516,18 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
                   stream);
               break;
             }
+            case kSetEditorSimulation: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  61, *this_._impl_.command_.set_editor_simulation_, this_._impl_.command_.set_editor_simulation_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kGetEditorSimulationState: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  62, *this_._impl_.command_.get_editor_simulation_state_, this_._impl_.command_.get_editor_simulation_state_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -4756,6 +4866,18 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
             case kGetAnimatorState: {
               total_size += 2 +
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.get_animator_state_);
+              break;
+            }
+            // .sailor.editor.v1.EditorSimulationRequest set_editor_simulation = 61;
+            case kSetEditorSimulation: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.set_editor_simulation_);
+              break;
+            }
+            // .sailor.editor.v1.Empty get_editor_simulation_state = 62;
+            case kGetEditorSimulationState: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.get_editor_simulation_state_);
               break;
             }
             case COMMAND_NOT_SET: {
@@ -5239,6 +5361,24 @@ void ProtocolRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const :
               ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::InstanceIdRequest>(arena, *from._impl_.command_.get_animator_state_);
         } else {
           _this->_impl_.command_.get_animator_state_->MergeFrom(from._internal_get_animator_state());
+        }
+        break;
+      }
+      case kSetEditorSimulation: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.set_editor_simulation_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::EditorSimulationRequest>(arena, *from._impl_.command_.set_editor_simulation_);
+        } else {
+          _this->_impl_.command_.set_editor_simulation_->MergeFrom(from._internal_set_editor_simulation());
+        }
+        break;
+      }
+      case kGetEditorSimulationState: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.get_editor_simulation_state_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Empty>(arena, *from._impl_.command_.get_editor_simulation_state_);
+        } else {
+          _this->_impl_.command_.get_editor_simulation_state_->MergeFrom(from._internal_get_editor_simulation_state());
         }
         break;
       }
@@ -8374,6 +8514,212 @@ void SizeRequest::InternalSwap(SizeRequest* PROTOBUF_RESTRICT other) {
 }
 
 ::google::protobuf::Metadata SizeRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class EditorSimulationRequest::_Internal {
+ public:
+};
+
+EditorSimulationRequest::EditorSimulationRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.EditorSimulationRequest)
+}
+EditorSimulationRequest::EditorSimulationRequest(
+    ::google::protobuf::Arena* arena, const EditorSimulationRequest& from)
+    : EditorSimulationRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE EditorSimulationRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void EditorSimulationRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.enabled_ = {};
+}
+EditorSimulationRequest::~EditorSimulationRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.EditorSimulationRequest)
+  SharedDtor(*this);
+}
+inline void EditorSimulationRequest::SharedDtor(MessageLite& self) {
+  EditorSimulationRequest& this_ = static_cast<EditorSimulationRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* EditorSimulationRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) EditorSimulationRequest(arena);
+}
+constexpr auto EditorSimulationRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(EditorSimulationRequest),
+                                            alignof(EditorSimulationRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull EditorSimulationRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_EditorSimulationRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &EditorSimulationRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<EditorSimulationRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &EditorSimulationRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<EditorSimulationRequest>(), &EditorSimulationRequest::ByteSizeLong,
+            &EditorSimulationRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(EditorSimulationRequest, _impl_._cached_size_),
+        false,
+    },
+    &EditorSimulationRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* EditorSimulationRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> EditorSimulationRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::EditorSimulationRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // bool enabled = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(EditorSimulationRequest, _impl_.enabled_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(EditorSimulationRequest, _impl_.enabled_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // bool enabled = 1;
+    {PROTOBUF_FIELD_OFFSET(EditorSimulationRequest, _impl_.enabled_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void EditorSimulationRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.EditorSimulationRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.enabled_ = false;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* EditorSimulationRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const EditorSimulationRequest& this_ = static_cast<const EditorSimulationRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* EditorSimulationRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const EditorSimulationRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.EditorSimulationRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // bool enabled = 1;
+          if (this_._internal_enabled() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteBoolToArray(
+                1, this_._internal_enabled(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.EditorSimulationRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t EditorSimulationRequest::ByteSizeLong(const MessageLite& base) {
+          const EditorSimulationRequest& this_ = static_cast<const EditorSimulationRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t EditorSimulationRequest::ByteSizeLong() const {
+          const EditorSimulationRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.EditorSimulationRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // bool enabled = 1;
+            if (this_._internal_enabled() != 0) {
+              total_size += 2;
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void EditorSimulationRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<EditorSimulationRequest*>(&to_msg);
+  auto& from = static_cast<const EditorSimulationRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.EditorSimulationRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_enabled() != 0) {
+    _this->_impl_.enabled_ = from._impl_.enabled_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void EditorSimulationRequest::CopyFrom(const EditorSimulationRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.EditorSimulationRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void EditorSimulationRequest::InternalSwap(EditorSimulationRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.enabled_, other->_impl_.enabled_);
+}
+
+::google::protobuf::Metadata EditorSimulationRequest::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/Runtime/Protocol/Generated/editor_engine.pb.h
+++ b/Runtime/Protocol/Generated/editor_engine.pb.h
@@ -80,6 +80,9 @@ extern CreateGameObjectRequestDefaultTypeInternal _CreateGameObjectRequest_defau
 class CreateModelInstanceRequest;
 struct CreateModelInstanceRequestDefaultTypeInternal;
 extern CreateModelInstanceRequestDefaultTypeInternal _CreateModelInstanceRequest_default_instance_;
+class EditorSimulationRequest;
+struct EditorSimulationRequestDefaultTypeInternal;
+extern EditorSimulationRequestDefaultTypeInternal _EditorSimulationRequest_default_instance_;
 class Empty;
 struct EmptyDefaultTypeInternal;
 extern EmptyDefaultTypeInternal _Empty_default_instance_;
@@ -346,7 +349,7 @@ class ViewportToolStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateResult*>(
         &_ViewportToolStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 39;
+  static constexpr int kIndexInFileMessages = 40;
   friend void swap(ViewportToolStateResult& a, ViewportToolStateResult& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateResult* other) {
     if (other == this) return;
@@ -548,7 +551,7 @@ class ViewportToolStateRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateRequest*>(
         &_ViewportToolStateRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 26;
+  static constexpr int kIndexInFileMessages = 27;
   friend void swap(ViewportToolStateRequest& a, ViewportToolStateRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateRequest* other) {
     if (other == this) return;
@@ -762,7 +765,7 @@ class ViewportToolShortcutEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolShortcutEvent*>(
         &_ViewportToolShortcutEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 45;
+  static constexpr int kIndexInFileMessages = 46;
   friend void swap(ViewportToolShortcutEvent& a, ViewportToolShortcutEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportToolShortcutEvent* other) {
     if (other == this) return;
@@ -952,7 +955,7 @@ class ViewportSelectionEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportSelectionEvent*>(
         &_ViewportSelectionEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 42;
+  static constexpr int kIndexInFileMessages = 43;
   friend void swap(ViewportSelectionEvent& a, ViewportSelectionEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportSelectionEvent* other) {
     if (other == this) return;
@@ -1374,7 +1377,7 @@ class ViewportRayRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportRayRequest*>(
         &_ViewportRayRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 22;
+  static constexpr int kIndexInFileMessages = 23;
   friend void swap(ViewportRayRequest& a, ViewportRayRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportRayRequest* other) {
     if (other == this) return;
@@ -1588,7 +1591,7 @@ class ViewportObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportObjectRequest*>(
         &_ViewportObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 24;
+  static constexpr int kIndexInFileMessages = 25;
   friend void swap(ViewportObjectRequest& a, ViewportObjectRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportObjectRequest* other) {
     if (other == this) return;
@@ -1986,7 +1989,7 @@ class ViewportAssetDropEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportAssetDropEvent*>(
         &_ViewportAssetDropEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 44;
+  static constexpr int kIndexInFileMessages = 45;
   friend void swap(ViewportAssetDropEvent& a, ViewportAssetDropEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportAssetDropEvent* other) {
     if (other == this) return;
@@ -2206,7 +2209,7 @@ class Vector4 final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4*>(
         &_Vector4_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 41;
+  static constexpr int kIndexInFileMessages = 42;
   friend void swap(Vector4& a, Vector4& b) { a.Swap(&b); }
   inline void Swap(Vector4* other) {
     if (other == this) return;
@@ -2432,7 +2435,7 @@ class UpdateObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const UpdateObjectRequest*>(
         &_UpdateObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 15;
+  static constexpr int kIndexInFileMessages = 16;
   friend void swap(UpdateObjectRequest& a, UpdateObjectRequest& b) { a.Swap(&b); }
   inline void Swap(UpdateObjectRequest* other) {
     if (other == this) return;
@@ -2646,7 +2649,7 @@ class UInt64Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt64Result*>(
         &_UInt64Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 33;
+  static constexpr int kIndexInFileMessages = 34;
   friend void swap(UInt64Result& a, UInt64Result& b) { a.Swap(&b); }
   inline void Swap(UInt64Result* other) {
     if (other == this) return;
@@ -2836,7 +2839,7 @@ class UInt32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt32Result*>(
         &_UInt32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 32;
+  static constexpr int kIndexInFileMessages = 33;
   friend void swap(UInt32Result& a, UInt32Result& b) { a.Swap(&b); }
   inline void Swap(UInt32Result* other) {
     if (other == this) return;
@@ -3026,7 +3029,7 @@ class StringResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringResult*>(
         &_StringResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 34;
+  static constexpr int kIndexInFileMessages = 35;
   friend void swap(StringResult& a, StringResult& b) { a.Swap(&b); }
   inline void Swap(StringResult* other) {
     if (other == this) return;
@@ -3234,7 +3237,7 @@ class StringListResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringListResult*>(
         &_StringListResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 35;
+  static constexpr int kIndexInFileMessages = 36;
   friend void swap(StringListResult& a, StringListResult& b) { a.Swap(&b); }
   inline void Swap(StringListResult* other) {
     if (other == this) return;
@@ -3638,7 +3641,7 @@ class ShowMainWindowRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ShowMainWindowRequest*>(
         &_ShowMainWindowRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 28;
+  static constexpr int kIndexInFileMessages = 29;
   friend void swap(ShowMainWindowRequest& a, ShowMainWindowRequest& b) { a.Swap(&b); }
   inline void Swap(ShowMainWindowRequest* other) {
     if (other == this) return;
@@ -3828,7 +3831,7 @@ class SelectionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const SelectionRequest*>(
         &_SelectionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 27;
+  static constexpr int kIndexInFileMessages = 28;
   friend void swap(SelectionRequest& a, SelectionRequest& b) { a.Swap(&b); }
   inline void Swap(SelectionRequest* other) {
     if (other == this) return;
@@ -4030,7 +4033,7 @@ class ReparentObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ReparentObjectRequest*>(
         &_ReparentObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 16;
+  static constexpr int kIndexInFileMessages = 17;
   friend void swap(ReparentObjectRequest& a, ReparentObjectRequest& b) { a.Swap(&b); }
   inline void Swap(ReparentObjectRequest* other) {
     if (other == this) return;
@@ -4256,7 +4259,7 @@ class RenderPathTracedImageRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RenderPathTracedImageRequest*>(
         &_RenderPathTracedImageRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 29;
+  static constexpr int kIndexInFileMessages = 30;
   friend void swap(RenderPathTracedImageRequest& a, RenderPathTracedImageRequest& b) { a.Swap(&b); }
   inline void Swap(RenderPathTracedImageRequest* other) {
     if (other == this) return;
@@ -4506,7 +4509,7 @@ class RemoteViewportRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportRequest*>(
         &_RemoteViewportRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 11;
+  static constexpr int kIndexInFileMessages = 12;
   friend void swap(RemoteViewportRequest& a, RemoteViewportRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportRequest* other) {
     if (other == this) return;
@@ -4768,7 +4771,7 @@ class RemoteViewportInputRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportInputRequest*>(
         &_RemoteViewportInputRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 13;
+  static constexpr int kIndexInFileMessages = 14;
   friend void swap(RemoteViewportInputRequest& a, RemoteViewportInputRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportInputRequest* other) {
     if (other == this) return;
@@ -5090,7 +5093,7 @@ class RemoteViewportHostRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportHostRequest*>(
         &_RemoteViewportHostRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 12;
+  static constexpr int kIndexInFileMessages = 13;
   friend void swap(RemoteViewportHostRequest& a, RemoteViewportHostRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportHostRequest* other) {
     if (other == this) return;
@@ -5304,7 +5307,7 @@ class PrefabLinkRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const PrefabLinkRequest*>(
         &_PrefabLinkRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 25;
+  static constexpr int kIndexInFileMessages = 26;
   friend void swap(PrefabLinkRequest& a, PrefabLinkRequest& b) { a.Swap(&b); }
   inline void Swap(PrefabLinkRequest* other) {
     if (other == this) return;
@@ -5518,7 +5521,7 @@ class ManagedMutationRevisionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ManagedMutationRevisionRequest*>(
         &_ManagedMutationRevisionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 14;
+  static constexpr int kIndexInFileMessages = 15;
   friend void swap(ManagedMutationRevisionRequest& a, ManagedMutationRevisionRequest& b) { a.Swap(&b); }
   inline void Swap(ManagedMutationRevisionRequest* other) {
     if (other == this) return;
@@ -5726,7 +5729,7 @@ class Int32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Int32Result*>(
         &_Int32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 31;
+  static constexpr int kIndexInFileMessages = 32;
   friend void swap(Int32Result& a, Int32Result& b) { a.Swap(&b); }
   inline void Swap(Int32Result* other) {
     if (other == this) return;
@@ -5916,7 +5919,7 @@ class InstantiatePrefabRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const InstantiatePrefabRequest*>(
         &_InstantiatePrefabRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 20;
+  static constexpr int kIndexInFileMessages = 21;
   friend void swap(InstantiatePrefabRequest& a, InstantiatePrefabRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabRequest* other) {
     if (other == this) return;
@@ -6130,7 +6133,7 @@ class InstantiatePrefabFromYamlRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabFromYamlRequest*>(
         &_InstantiatePrefabFromYamlRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 21;
+  static constexpr int kIndexInFileMessages = 22;
   friend void swap(InstantiatePrefabFromYamlRequest& a, InstantiatePrefabFromYamlRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabFromYamlRequest* other) {
     if (other == this) return;
@@ -6356,7 +6359,7 @@ class InstanceIdResult final : public ::google::protobuf::Message
     return reinterpret_cast<const InstanceIdResult*>(
         &_InstanceIdResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 37;
+  static constexpr int kIndexInFileMessages = 38;
   friend void swap(InstanceIdResult& a, InstanceIdResult& b) { a.Swap(&b); }
   inline void Swap(InstanceIdResult* other) {
     if (other == this) return;
@@ -7244,6 +7247,196 @@ class Empty final : public ::google::protobuf::internal::ZeroFieldsBase
 };
 // -------------------------------------------------------------------
 
+class EditorSimulationRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.EditorSimulationRequest) */ {
+ public:
+  inline EditorSimulationRequest() : EditorSimulationRequest(nullptr) {}
+  ~EditorSimulationRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(EditorSimulationRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(EditorSimulationRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR EditorSimulationRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline EditorSimulationRequest(const EditorSimulationRequest& from) : EditorSimulationRequest(nullptr, from) {}
+  inline EditorSimulationRequest(EditorSimulationRequest&& from) noexcept
+      : EditorSimulationRequest(nullptr, std::move(from)) {}
+  inline EditorSimulationRequest& operator=(const EditorSimulationRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline EditorSimulationRequest& operator=(EditorSimulationRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const EditorSimulationRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const EditorSimulationRequest* internal_default_instance() {
+    return reinterpret_cast<const EditorSimulationRequest*>(
+        &_EditorSimulationRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 11;
+  friend void swap(EditorSimulationRequest& a, EditorSimulationRequest& b) { a.Swap(&b); }
+  inline void Swap(EditorSimulationRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(EditorSimulationRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  EditorSimulationRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<EditorSimulationRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const EditorSimulationRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const EditorSimulationRequest& from) { EditorSimulationRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(EditorSimulationRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.EditorSimulationRequest"; }
+
+ protected:
+  explicit EditorSimulationRequest(::google::protobuf::Arena* arena);
+  EditorSimulationRequest(::google::protobuf::Arena* arena, const EditorSimulationRequest& from);
+  EditorSimulationRequest(::google::protobuf::Arena* arena, EditorSimulationRequest&& from) noexcept
+      : EditorSimulationRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kEnabledFieldNumber = 1,
+  };
+  // bool enabled = 1;
+  void clear_enabled() ;
+  bool enabled() const;
+  void set_enabled(bool value);
+
+  private:
+  bool _internal_enabled() const;
+  void _internal_set_enabled(bool value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.EditorSimulationRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const EditorSimulationRequest& from_msg);
+    bool enabled_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class CreateGameObjectRequest final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.CreateGameObjectRequest) */ {
  public:
@@ -7303,7 +7496,7 @@ class CreateGameObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const CreateGameObjectRequest*>(
         &_CreateGameObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 17;
+  static constexpr int kIndexInFileMessages = 18;
   friend void swap(CreateGameObjectRequest& a, CreateGameObjectRequest& b) { a.Swap(&b); }
   inline void Swap(CreateGameObjectRequest* other) {
     if (other == this) return;
@@ -7707,7 +7900,7 @@ class BoolResult final : public ::google::protobuf::Message
     return reinterpret_cast<const BoolResult*>(
         &_BoolResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 30;
+  static constexpr int kIndexInFileMessages = 31;
   friend void swap(BoolResult& a, BoolResult& b) { a.Swap(&b); }
   inline void Swap(BoolResult* other) {
     if (other == this) return;
@@ -7897,7 +8090,7 @@ class AssetReloadStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const AssetReloadStateResult*>(
         &_AssetReloadStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 36;
+  static constexpr int kIndexInFileMessages = 37;
   friend void swap(AssetReloadStateResult& a, AssetReloadStateResult& b) { a.Swap(&b); }
   inline void Swap(AssetReloadStateResult* other) {
     if (other == this) return;
@@ -8123,7 +8316,7 @@ class AnimatorStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const AnimatorStateResult*>(
         &_AnimatorStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 40;
+  static constexpr int kIndexInFileMessages = 41;
   friend void swap(AnimatorStateResult& a, AnimatorStateResult& b) { a.Swap(&b); }
   inline void Swap(AnimatorStateResult* other) {
     if (other == this) return;
@@ -8433,7 +8626,7 @@ class AddComponentRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const AddComponentRequest*>(
         &_AddComponentRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 18;
+  static constexpr int kIndexInFileMessages = 19;
   friend void swap(AddComponentRequest& a, AddComponentRequest& b) { a.Swap(&b); }
   inline void Swap(AddComponentRequest* other) {
     if (other == this) return;
@@ -8665,7 +8858,7 @@ class ViewportTransformEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportTransformEvent*>(
         &_ViewportTransformEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 43;
+  static constexpr int kIndexInFileMessages = 44;
   friend void swap(ViewportTransformEvent& a, ViewportTransformEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportTransformEvent* other) {
     if (other == this) return;
@@ -8988,7 +9181,7 @@ class Vector4Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4Result*>(
         &_Vector4Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 38;
+  static constexpr int kIndexInFileMessages = 39;
   friend void swap(Vector4Result& a, Vector4Result& b) { a.Swap(&b); }
   inline void Swap(Vector4Result* other) {
     if (other == this) return;
@@ -9184,7 +9377,7 @@ class InstantiatePrefabInstanceRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabInstanceRequest*>(
         &_InstantiatePrefabInstanceRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 23;
+  static constexpr int kIndexInFileMessages = 24;
   friend void swap(InstantiatePrefabInstanceRequest& a, InstantiatePrefabInstanceRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabInstanceRequest* other) {
     if (other == this) return;
@@ -9728,7 +9921,7 @@ class AnimatorParameterRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const AnimatorParameterRequest*>(
         &_AnimatorParameterRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 19;
+  static constexpr int kIndexInFileMessages = 20;
   friend void swap(AnimatorParameterRequest& a, AnimatorParameterRequest& b) { a.Swap(&b); }
   inline void Swap(AnimatorParameterRequest* other) {
     if (other == this) return;
@@ -10044,7 +10237,7 @@ class ViewportEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEvent*>(
         &_ViewportEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 46;
+  static constexpr int kIndexInFileMessages = 47;
   friend void swap(ViewportEvent& a, ViewportEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportEvent* other) {
     if (other == this) return;
@@ -10390,6 +10583,8 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kCreateModelInstance = 58,
     kSetAnimatorParameter = 59,
     kGetAnimatorState = 60,
+    kSetEditorSimulation = 61,
+    kGetEditorSimulationState = 62,
     COMMAND_NOT_SET = 0,
   };
   static inline const ProtocolRequest* internal_default_instance() {
@@ -10535,6 +10730,8 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kCreateModelInstanceFieldNumber = 58,
     kSetAnimatorParameterFieldNumber = 59,
     kGetAnimatorStateFieldNumber = 60,
+    kSetEditorSimulationFieldNumber = 61,
+    kGetEditorSimulationStateFieldNumber = 62,
   };
   // uint64 request_id = 2;
   void clear_request_id() ;
@@ -11506,6 +11703,44 @@ class ProtocolRequest final : public ::google::protobuf::Message
   ::sailor::editor::v1::InstanceIdRequest* _internal_mutable_get_animator_state();
 
   public:
+  // .sailor.editor.v1.EditorSimulationRequest set_editor_simulation = 61;
+  bool has_set_editor_simulation() const;
+  private:
+  bool _internal_has_set_editor_simulation() const;
+
+  public:
+  void clear_set_editor_simulation() ;
+  const ::sailor::editor::v1::EditorSimulationRequest& set_editor_simulation() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::EditorSimulationRequest* release_set_editor_simulation();
+  ::sailor::editor::v1::EditorSimulationRequest* mutable_set_editor_simulation();
+  void set_allocated_set_editor_simulation(::sailor::editor::v1::EditorSimulationRequest* value);
+  void unsafe_arena_set_allocated_set_editor_simulation(::sailor::editor::v1::EditorSimulationRequest* value);
+  ::sailor::editor::v1::EditorSimulationRequest* unsafe_arena_release_set_editor_simulation();
+
+  private:
+  const ::sailor::editor::v1::EditorSimulationRequest& _internal_set_editor_simulation() const;
+  ::sailor::editor::v1::EditorSimulationRequest* _internal_mutable_set_editor_simulation();
+
+  public:
+  // .sailor.editor.v1.Empty get_editor_simulation_state = 62;
+  bool has_get_editor_simulation_state() const;
+  private:
+  bool _internal_has_get_editor_simulation_state() const;
+
+  public:
+  void clear_get_editor_simulation_state() ;
+  const ::sailor::editor::v1::Empty& get_editor_simulation_state() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::Empty* release_get_editor_simulation_state();
+  ::sailor::editor::v1::Empty* mutable_get_editor_simulation_state();
+  void set_allocated_get_editor_simulation_state(::sailor::editor::v1::Empty* value);
+  void unsafe_arena_set_allocated_get_editor_simulation_state(::sailor::editor::v1::Empty* value);
+  ::sailor::editor::v1::Empty* unsafe_arena_release_get_editor_simulation_state();
+
+  private:
+  const ::sailor::editor::v1::Empty& _internal_get_editor_simulation_state() const;
+  ::sailor::editor::v1::Empty* _internal_mutable_get_editor_simulation_state();
+
+  public:
   void clear_command();
   CommandCase command_case() const;
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.ProtocolRequest)
@@ -11561,11 +11796,13 @@ class ProtocolRequest final : public ::google::protobuf::Message
   void set_has_create_model_instance();
   void set_has_set_animator_parameter();
   void set_has_get_animator_state();
+  void set_has_set_editor_simulation();
+  void set_has_get_editor_simulation_state();
   inline bool has_command() const;
   inline void clear_has_command();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      1, 52, 50,
+      1, 54, 52,
       0, 9>
       _table_;
 
@@ -11638,6 +11875,8 @@ class ProtocolRequest final : public ::google::protobuf::Message
       ::sailor::editor::v1::CreateModelInstanceRequest* create_model_instance_;
       ::sailor::editor::v1::AnimatorParameterRequest* set_animator_parameter_;
       ::sailor::editor::v1::InstanceIdRequest* get_animator_state_;
+      ::sailor::editor::v1::EditorSimulationRequest* set_editor_simulation_;
+      ::sailor::editor::v1::Empty* get_editor_simulation_state_;
     } command_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -11707,7 +11946,7 @@ class ViewportEventBatchResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEventBatchResult*>(
         &_ViewportEventBatchResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 47;
+  static constexpr int kIndexInFileMessages = 48;
   friend void swap(ViewportEventBatchResult& a, ViewportEventBatchResult& b) { a.Swap(&b); }
   inline void Swap(ViewportEventBatchResult* other) {
     if (other == this) return;
@@ -16413,6 +16652,164 @@ inline ::sailor::editor::v1::InstanceIdRequest* ProtocolRequest::mutable_get_ani
   return _msg;
 }
 
+// .sailor.editor.v1.EditorSimulationRequest set_editor_simulation = 61;
+inline bool ProtocolRequest::has_set_editor_simulation() const {
+  return command_case() == kSetEditorSimulation;
+}
+inline bool ProtocolRequest::_internal_has_set_editor_simulation() const {
+  return command_case() == kSetEditorSimulation;
+}
+inline void ProtocolRequest::set_has_set_editor_simulation() {
+  _impl_._oneof_case_[0] = kSetEditorSimulation;
+}
+inline void ProtocolRequest::clear_set_editor_simulation() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kSetEditorSimulation) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.set_editor_simulation_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_editor_simulation_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::EditorSimulationRequest* ProtocolRequest::release_set_editor_simulation() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.set_editor_simulation)
+  if (command_case() == kSetEditorSimulation) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_editor_simulation_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.set_editor_simulation_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::EditorSimulationRequest& ProtocolRequest::_internal_set_editor_simulation() const {
+  return command_case() == kSetEditorSimulation ? *_impl_.command_.set_editor_simulation_ : reinterpret_cast<::sailor::editor::v1::EditorSimulationRequest&>(::sailor::editor::v1::_EditorSimulationRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::EditorSimulationRequest& ProtocolRequest::set_editor_simulation() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.set_editor_simulation)
+  return _internal_set_editor_simulation();
+}
+inline ::sailor::editor::v1::EditorSimulationRequest* ProtocolRequest::unsafe_arena_release_set_editor_simulation() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.set_editor_simulation)
+  if (command_case() == kSetEditorSimulation) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_editor_simulation_;
+    _impl_.command_.set_editor_simulation_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_set_editor_simulation(::sailor::editor::v1::EditorSimulationRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_set_editor_simulation();
+    _impl_.command_.set_editor_simulation_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.set_editor_simulation)
+}
+inline ::sailor::editor::v1::EditorSimulationRequest* ProtocolRequest::_internal_mutable_set_editor_simulation() {
+  if (command_case() != kSetEditorSimulation) {
+    clear_command();
+    set_has_set_editor_simulation();
+    _impl_.command_.set_editor_simulation_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::EditorSimulationRequest>(GetArena());
+  }
+  return _impl_.command_.set_editor_simulation_;
+}
+inline ::sailor::editor::v1::EditorSimulationRequest* ProtocolRequest::mutable_set_editor_simulation() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::EditorSimulationRequest* _msg = _internal_mutable_set_editor_simulation();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.set_editor_simulation)
+  return _msg;
+}
+
+// .sailor.editor.v1.Empty get_editor_simulation_state = 62;
+inline bool ProtocolRequest::has_get_editor_simulation_state() const {
+  return command_case() == kGetEditorSimulationState;
+}
+inline bool ProtocolRequest::_internal_has_get_editor_simulation_state() const {
+  return command_case() == kGetEditorSimulationState;
+}
+inline void ProtocolRequest::set_has_get_editor_simulation_state() {
+  _impl_._oneof_case_[0] = kGetEditorSimulationState;
+}
+inline void ProtocolRequest::clear_get_editor_simulation_state() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kGetEditorSimulationState) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.get_editor_simulation_state_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.get_editor_simulation_state_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::Empty* ProtocolRequest::release_get_editor_simulation_state() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.get_editor_simulation_state)
+  if (command_case() == kGetEditorSimulationState) {
+    clear_has_command();
+    auto* temp = _impl_.command_.get_editor_simulation_state_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.get_editor_simulation_state_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::Empty& ProtocolRequest::_internal_get_editor_simulation_state() const {
+  return command_case() == kGetEditorSimulationState ? *_impl_.command_.get_editor_simulation_state_ : reinterpret_cast<::sailor::editor::v1::Empty&>(::sailor::editor::v1::_Empty_default_instance_);
+}
+inline const ::sailor::editor::v1::Empty& ProtocolRequest::get_editor_simulation_state() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.get_editor_simulation_state)
+  return _internal_get_editor_simulation_state();
+}
+inline ::sailor::editor::v1::Empty* ProtocolRequest::unsafe_arena_release_get_editor_simulation_state() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.get_editor_simulation_state)
+  if (command_case() == kGetEditorSimulationState) {
+    clear_has_command();
+    auto* temp = _impl_.command_.get_editor_simulation_state_;
+    _impl_.command_.get_editor_simulation_state_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_get_editor_simulation_state(::sailor::editor::v1::Empty* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_get_editor_simulation_state();
+    _impl_.command_.get_editor_simulation_state_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.get_editor_simulation_state)
+}
+inline ::sailor::editor::v1::Empty* ProtocolRequest::_internal_mutable_get_editor_simulation_state() {
+  if (command_case() != kGetEditorSimulationState) {
+    clear_command();
+    set_has_get_editor_simulation_state();
+    _impl_.command_.get_editor_simulation_state_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::Empty>(GetArena());
+  }
+  return _impl_.command_.get_editor_simulation_state_;
+}
+inline ::sailor::editor::v1::Empty* ProtocolRequest::mutable_get_editor_simulation_state() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::Empty* _msg = _internal_mutable_get_editor_simulation_state();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.get_editor_simulation_state)
+  return _msg;
+}
+
 inline bool ProtocolRequest::has_command() const {
   return command_case() != COMMAND_NOT_SET;
 }
@@ -18296,6 +18693,32 @@ inline ::uint32_t SizeRequest::_internal_height() const {
 inline void SizeRequest::_internal_set_height(::uint32_t value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.height_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// EditorSimulationRequest
+
+// bool enabled = 1;
+inline void EditorSimulationRequest::clear_enabled() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.enabled_ = false;
+}
+inline bool EditorSimulationRequest::enabled() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.EditorSimulationRequest.enabled)
+  return _internal_enabled();
+}
+inline void EditorSimulationRequest::set_enabled(bool value) {
+  _internal_set_enabled(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.EditorSimulationRequest.enabled)
+}
+inline bool EditorSimulationRequest::_internal_enabled() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.enabled_;
+}
+inline void EditorSimulationRequest::_internal_set_enabled(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.enabled_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -21,6 +21,7 @@
 #include "GraphicsDriver/Vulkan/VulkanApi.h"
 #include "Tasks/Scheduler.h"
 #include "Tasks/Tasks.h"
+#include "Physics/JoltRuntime.h"
 #include "RHI/Renderer.h"
 #include "Core/Submodule.h"
 #include "Containers/Vector.h"
@@ -473,6 +474,7 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	}
 
 	s_pInstance->AddSubmodule(TSubmodule<Tasks::Scheduler>::Make())->Initialize();
+	s_pInstance->AddSubmodule(TSubmodule<Physics::JoltRuntime>::Make());
 	auto renderer = s_pInstance->AddSubmodule(TSubmodule<Renderer>::Make(s_pInstance->m_pMainWindow.GetRawPtr(), RHI::EMsaaSamples::Samples_1, bEnableRenderValidationLayers));
 	if (!renderer->IsInitialized())
 	{
@@ -1067,7 +1069,7 @@ void App::Shutdown()
 
 	if (scheduler)
 	{
-		scheduler->WaitIdle({ EThreadType::Main, EThreadType::Worker, EThreadType::RHI, EThreadType::Render, EThreadType::Editor });
+		scheduler->WaitIdle({ EThreadType::Main, EThreadType::Worker, EThreadType::RHI, EThreadType::Render, EThreadType::Editor, EThreadType::Physics });
 		s_pInstance->m_pendingAssetReloadTask.Clear();
 	}
 
@@ -1081,6 +1083,7 @@ void App::Shutdown()
 #endif
 
 	RemoveSubmodule<EngineLoop>();
+	RemoveSubmodule<Physics::JoltRuntime>();
 	RemoveSubmodule<ECS::ECSFactory>();
 	RemoveSubmodule<FrameGraphBuilder>();
 

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -91,6 +91,8 @@ namespace Sailor
 		SAILOR_API static uint32_t SerializeWorkspaceCacheIdentity(char** yamlNode);
 		SAILOR_API static bool LoadEditorWorld(const char* strFileId);
 		SAILOR_API static bool CreateEditorWorld();
+		SAILOR_API static bool SetEditorSimulationEnabled(bool bEnabled);
+		SAILOR_API static bool IsEditorSimulationEnabled();
 		SAILOR_API static bool UpdateEditorObject(const char* strInstanceId, const char* strYamlNode);
 		SAILOR_API static bool SetEditorAnimatorParameter(
 			const char* strInstanceId,

--- a/Runtime/Submodules/Editor.cpp
+++ b/Runtime/Submodules/Editor.cpp
@@ -1,6 +1,7 @@
 #include "Core/LogMacros.h"
 #include "Tasks/Scheduler.h"
 #include "Engine/Types.h"
+#include "Engine/EngineLoop.h"
 #include "Engine/World.h"
 #include "Engine/GameObject.h"
 #include "ECS/TransformECS.h"
@@ -31,6 +32,7 @@
 #include <cmath>
 #include <limits>
 #include "Platform/Win32/Window.h"
+#include "YamlExceptionBoundary.h"
 
 using namespace Sailor;
 
@@ -282,10 +284,116 @@ Editor::~Editor() = default;
 void Editor::SetWorld(World* world)
 {
 	m_world = world;
+	m_simulationSnapshot.clear();
+	m_bSimulationEnabled = false;
 	m_managedSelectionMutationRevision = 0;
 	m_managedMutationState->m_objectRevisions.Clear();
 	m_viewportController->Reset();
 	m_viewportController->SetManagedMutationRevisions(0, 0);
+}
+
+bool Editor::SetSimulationEnabled(bool bEnabled)
+{
+	if (bEnabled == m_bSimulationEnabled)
+	{
+		return true;
+	}
+
+	if (!m_world)
+	{
+		return false;
+	}
+
+	if (bEnabled)
+	{
+		const YAML::Node snapshot = SerializeWorld();
+		std::string serializedSnapshot;
+		std::string diagnostic;
+		if (!snapshot ||
+			!External::TryDumpYaml(
+				snapshot,
+				serializedSnapshot,
+				diagnostic) ||
+			serializedSnapshot.empty())
+		{
+			SAILOR_LOG_ERROR(
+				"Cannot start Editor simulation: %s.",
+				diagnostic.empty()
+					? "the current world could not be snapshotted"
+					: diagnostic.c_str());
+			return false;
+		}
+
+		CancelViewportInteraction();
+		m_simulationSnapshot = std::move(serializedSnapshot);
+		m_world->SetPhysicsSimulationEnabled(true);
+		m_bSimulationEnabled = true;
+		return true;
+	}
+
+	auto* engineLoop = App::GetSubmodule<EngineLoop>();
+	auto* worldImporter = App::GetSubmodule<WorldPrefabImporter>();
+	if (!engineLoop || !worldImporter || m_simulationSnapshot.empty())
+	{
+		return false;
+	}
+
+	YAML::Node snapshot;
+	std::string diagnostic;
+	if (!External::TryLoadYaml(
+			m_simulationSnapshot,
+			snapshot,
+			diagnostic))
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot stop Editor simulation: the world snapshot is invalid: %s.",
+			diagnostic.c_str());
+		return false;
+	}
+
+	auto worldPrefab = worldImporter->Create();
+	if (!worldPrefab ||
+		!External::GuardYamlExceptions(
+			[&worldPrefab, &snapshot]()
+			{
+				worldPrefab->Deserialize(snapshot);
+			},
+			diagnostic) ||
+		!worldPrefab->IsReady())
+	{
+		if (diagnostic.empty() && worldPrefab)
+		{
+			diagnostic = worldPrefab->GetLoadDiagnostic();
+		}
+		SAILOR_LOG_ERROR(
+			"Cannot stop Editor simulation: the world snapshot could not be restored: %s.",
+			diagnostic.empty() ? "unknown error" : diagnostic.c_str());
+		return false;
+	}
+
+	TVector<InstanceId> selection;
+	selection.Reserve(m_world->m_editorSelection.Num());
+	for (const InstanceId& instanceId : m_world->m_editorSelection)
+	{
+		selection.Add(instanceId);
+	}
+
+	World* oldWorld = m_world;
+	auto restoredWorld = engineLoop->InstantiateWorld(
+		worldPrefab,
+		EngineLoop::EditorWorldMask);
+	if (!restoredWorld)
+	{
+		SAILOR_LOG_ERROR(
+			"Cannot stop Editor simulation: the world snapshot could not be instantiated.");
+		return false;
+	}
+
+	SetWorld(restoredWorld.GetRawPtr());
+	m_world->SetEditorSelection(selection);
+	engineLoop->ExitWorld(oldWorld);
+	engineLoop->ProcessPendingWorldExits();
+	return true;
 }
 
 void Editor::TickViewportTools()

--- a/Runtime/Submodules/Editor.h
+++ b/Runtime/Submodules/Editor.h
@@ -45,6 +45,8 @@ namespace Sailor
 
 		SAILOR_SHARED_API void SetWorld(class World* world);
 		class World* GetWorld() const { return m_world; }
+		SAILOR_SHARED_API bool SetSimulationEnabled(bool bEnabled);
+		bool IsSimulationEnabled() const { return m_bSimulationEnabled; }
 		void TickViewportTools();
 		void CancelViewportInteraction();
 		bool PullViewportEvent(std::string& outEvent);
@@ -133,6 +135,8 @@ namespace Sailor
 		class Win32::Window* m_pMainWindow = nullptr;
 
 		class World* m_world = nullptr;
+		std::string m_simulationSnapshot{};
+		bool m_bSimulationEnabled = false;
 		TUniquePtr<EditorViewport::EditorViewportController> m_viewportController{};
 		uint64_t m_managedSelectionMutationRevision = 0;
 		TUniquePtr<EditorManagedMutationState> m_managedMutationState{};

--- a/Runtime/Tasks/Scheduler.cpp
+++ b/Runtime/Tasks/Scheduler.cpp
@@ -200,7 +200,7 @@ void Scheduler::Initialize()
 
 	const unsigned coresCount = std::thread::hardware_concurrency();
 	const unsigned numRHIThreads = RHIThreadsNum;
-	const unsigned numReservedThreads = 4u + numRHIThreads;
+	const unsigned numReservedThreads = 5u + numRHIThreads;
 	const unsigned numThreads = coresCount > numReservedThreads
 		? coresCount - numReservedThreads
 		: 1u;
@@ -262,6 +262,17 @@ void Scheduler::Initialize()
 	m_threadTypes[newBackgroundThread->GetThreadId()] = EThreadType::Background;
 	m_workerThreads.Emplace(newBackgroundThread);
 
+	WorkerThread* newPhysicsThread = new WorkerThread(
+		"Physics Thread",
+		EThreadType::Physics,
+		m_refreshCondVar[(uint32_t)EThreadType::Physics],
+		m_queueMutex[(uint32_t)EThreadType::Physics],
+		m_pSharedTaskQueue[(uint32_t)EThreadType::Physics]);
+
+	m_physicsThreadId = newPhysicsThread->GetThreadId();
+	m_threadTypes[m_physicsThreadId] = EThreadType::Physics;
+	m_workerThreads.Emplace(newPhysicsThread);
+
 	SAILOR_LOG("Initialize Tasks::Scheduler. Cores count: %d, Worker threads count: %zd", coresCount, m_workerThreads.Num());
 }
 
@@ -284,6 +295,7 @@ Scheduler::~Scheduler()
 	NotifyWorkerThread(EThreadType::RHI, true);
 	NotifyWorkerThread(EThreadType::Editor, true);
 	NotifyWorkerThread(EThreadType::Background, true);
+	NotifyWorkerThread(EThreadType::Physics, true);
 
 	for (auto& worker : m_workerThreads)
 	{
@@ -302,7 +314,17 @@ Scheduler::~Scheduler()
 
 uint32_t Scheduler::GetNumWorkerThreads() const
 {
-	return static_cast<uint32_t>(m_workerThreads.Num());
+	return GetNumThreads(EThreadType::Worker);
+}
+
+uint32_t Scheduler::GetNumThreads(EThreadType type) const
+{
+	uint32_t result = 0;
+	for (const WorkerThread* worker : m_workerThreads)
+	{
+		result += worker->GetThreadType() == type ? 1u : 0u;
+	}
+	return result;
 }
 
 void Scheduler::ProcessTasksOnMainThread()
@@ -609,6 +631,11 @@ bool Scheduler::IsRendererThread() const
 bool Scheduler::IsEditorThread() const
 {
 	return m_editorThreadId == GetCurrentThreadId();
+}
+
+bool Scheduler::IsPhysicsThread() const
+{
+	return m_physicsThreadId == GetCurrentThreadId();
 }
 
 bool Scheduler::HasThread(DWORD threadId) const

--- a/Runtime/Tasks/Scheduler.h
+++ b/Runtime/Tasks/Scheduler.h
@@ -41,7 +41,11 @@ namespace Sailor
 
 		// Best-effort work that must not delay explicit WaitIdle sets.
 		// A single dedicated worker processes this queue serially.
-		Background = 5
+		Background = 5,
+
+		// The outer physics step may wait for Jolt jobs running on Worker threads.
+		// Keep it on a dedicated thread so it cannot exhaust the Worker pool.
+		Physics = 6
 	};
 
 	namespace Tasks
@@ -135,6 +139,7 @@ namespace Sailor
 			SAILOR_API void WaitIdle(const TSet<EThreadType>& threads);
 
 			SAILOR_API uint32_t GetNumWorkerThreads() const;
+			SAILOR_API uint32_t GetNumThreads(EThreadType type) const;
 			SAILOR_API uint32_t GetNumTasks(EThreadType thread) const;
 			SAILOR_API uint32_t GetNumRHIThreads() const { return RHIThreadsNum; }
 
@@ -149,11 +154,13 @@ namespace Sailor
 			SAILOR_API bool IsMainThread() const;
 			SAILOR_API bool IsRendererThread() const;
 			SAILOR_API bool IsEditorThread() const;
+			SAILOR_API bool IsPhysicsThread() const;
 			SAILOR_API bool HasThread(DWORD threadId) const;
 
 			SAILOR_API DWORD GetMainThreadId() const { return m_mainThreadId.load(std::memory_order_acquire); }
 			SAILOR_API DWORD GetRendererThreadId() const { return m_renderingThreadId; }
 			SAILOR_API DWORD GetEditorThreadId() const { return m_editorThreadId; }
+			SAILOR_API DWORD GetPhysicsThreadId() const { return m_physicsThreadId; }
 			SAILOR_API EThreadType GetCurrentThreadType() const;
 
 			SAILOR_API Scheduler();
@@ -185,6 +192,7 @@ namespace Sailor
 			std::atomic<DWORD> m_mainThreadId{ static_cast<DWORD>(-1) };
 			DWORD m_renderingThreadId = -1;
 			DWORD m_editorThreadId = -1;
+			DWORD m_physicsThreadId = -1;
 
 			// Task Synchronization primitives pool
 			concurrency::concurrent_queue<uint16_t> m_freeList{};

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -87,6 +87,10 @@ add_executable(SkyComponentContractTests
     SkyComponentContractTests.cpp
 )
 
+add_executable(PhysicsRuntimeTests
+    PhysicsRuntimeTests.cpp
+)
+
 add_library(WorkspaceModuleFixture SHARED
     WorkspaceModuleFixture.cpp
 )
@@ -224,6 +228,7 @@ target_compile_definitions(VulkanDescriptorCacheTests PRIVATE
 )
 target_compile_features(EditorViewportControllerContractTests PRIVATE cxx_std_20)
 target_compile_features(SkyComponentContractTests PRIVATE cxx_std_20)
+target_compile_features(PhysicsRuntimeTests PRIVATE cxx_std_20)
 target_compile_definitions(SkyComponentContractTests PRIVATE
     SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
 )
@@ -277,6 +282,7 @@ target_link_libraries(AnimationSamplingContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(VulkanDescriptorCacheTests PRIVATE Sailor::Runtime)
 target_link_libraries(EditorViewportControllerContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(SkyComponentContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(PhysicsRuntimeTests PRIVATE Sailor::Runtime)
 target_link_libraries(AssetMountDiscoveryTests PRIVATE Sailor::Runtime)
 target_link_libraries(WorkspaceModuleContractTests PRIVATE
     Sailor::Runtime
@@ -323,6 +329,7 @@ if(WIN32)
     sailor_stage_workspace_test_runtime(VulkanDescriptorCacheTests)
     sailor_stage_workspace_test_runtime(EditorViewportControllerContractTests)
     sailor_stage_workspace_test_runtime(SkyComponentContractTests)
+    sailor_stage_workspace_test_runtime(PhysicsRuntimeTests)
     sailor_stage_workspace_test_runtime(RemoteViewportRuntimeTests)
     sailor_stage_workspace_test_runtime(EditorEngineProtocolTests)
     sailor_stage_workspace_test_runtime(EditorEngineWebSocketServerTests)
@@ -386,6 +393,9 @@ target_include_directories(EditorViewportControllerContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(SkyComponentContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(PhysicsRuntimeTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(WorkspaceModuleFixture PRIVATE
@@ -536,6 +546,11 @@ add_test(
 )
 
 add_test(
+    NAME PhysicsRuntimeTests
+    COMMAND PhysicsRuntimeTests
+)
+
+add_test(
     NAME WorkspaceModuleContractTests
     COMMAND WorkspaceModuleContractTests
 )
@@ -635,6 +650,7 @@ set_tests_properties(
     VulkanDescriptorCacheTests
     EditorViewportControllerContractTests
     SkyComponentContractTests
+    PhysicsRuntimeTests
     EditorEngineProtocolTests
     EditorEngineWebSocketServerTests
     EditorEngineWebSocketLateStopTests

--- a/Tests/EditorEngineProtocolTests.cpp
+++ b/Tests/EditorEngineProtocolTests.cpp
@@ -66,6 +66,8 @@ namespace
 	constexpr uint32_t c_instantiatePrefabFromYamlCommandField = 42;
 	constexpr uint32_t c_createModelInstanceCommandField = 58;
 	constexpr uint32_t c_setAnimatorParameterCommandField = 59;
+	constexpr uint32_t c_setEditorSimulationCommandField = 61;
+	constexpr uint32_t c_getEditorSimulationStateCommandField = 62;
 
 	void Require(bool condition, const std::string& message)
 	{
@@ -1065,6 +1067,21 @@ namespace
 				kPreferredInstanceIdFieldNumber == 7);
 	}
 
+	void TestEditorSimulationWireContract()
+	{
+		static_assert(
+			sailor::editor::v1::ProtocolRequest::
+				kSetEditorSimulationFieldNumber ==
+			c_setEditorSimulationCommandField);
+		static_assert(
+			sailor::editor::v1::ProtocolRequest::
+				kGetEditorSimulationStateFieldNumber ==
+			c_getEditorSimulationStateCommandField);
+		static_assert(
+			sailor::editor::v1::EditorSimulationRequest::
+				kEnabledFieldNumber == 1);
+	}
+
 	void TestEmbeddedNullIsRejected()
 	{
 		std::string fileIdRequest;
@@ -2042,6 +2059,7 @@ int main()
 		TestAnimatorParameterRequiresTypedValue();
 		TestStrictInstanceIdProtocolGate();
 		TestModelInstanceWireContract();
+		TestEditorSimulationWireContract();
 		TestEmbeddedNullIsRejected();
 		TestUtf8StringIsAccepted();
 		TestGetExitCodeRoundTripAndFree();

--- a/Tests/PhysicsRuntimeTests.cpp
+++ b/Tests/PhysicsRuntimeTests.cpp
@@ -1,0 +1,507 @@
+#include "Tasks/Tasks.h"
+#include "Components/CollisionShapeComponent.h"
+#include "Components/RigidBodyComponent.h"
+#include "Core/Reflection.h"
+#include "ECS/PhysicsECS.h"
+#include "ECS/TransformECS.h"
+#include "Engine/GameObject.h"
+#include "Engine/World.h"
+#include "Physics/JoltRuntime.h"
+#include "Physics/PhysicsWorld.h"
+#include "Math/Transform.h"
+
+#include <cmath>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+using namespace Sailor;
+
+namespace
+{
+	constexpr float c_fixedDeltaTime = 1.0f / 60.0f;
+
+	class PhysicsComponentTestWorld final : public World
+	{
+	public:
+		PhysicsComponentTestWorld() :
+			World("PhysicsComponentTests", 0, CreateEcs())
+		{}
+
+	private:
+		static TVector<ECS::TBaseSystemPtr> CreateEcs()
+		{
+			TVector<ECS::TBaseSystemPtr> systems;
+			systems.Add(TUniquePtr<TransformECS>::Make());
+			systems.Add(TUniquePtr<PhysicsECS>::Make());
+			return systems;
+		}
+	};
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	bool IsNear(float lhs, float rhs, float tolerance = 0.001f)
+	{
+		return std::abs(lhs - rhs) <= tolerance;
+	}
+
+	Physics::RigidBodyDesc MakeBox(
+		const InstanceId& instanceId,
+		Physics::ERigidBodyMotionType motionType,
+		const glm::vec3& position,
+		const glm::vec3& size,
+		uint8_t collisionLayer = 0)
+	{
+		Physics::RigidBodyDesc result{};
+		result.m_instanceId = instanceId;
+		result.m_motionType = motionType;
+		result.m_position = position;
+		result.m_collisionLayer = collisionLayer;
+
+		Physics::CollisionShapeDesc shape{};
+		shape.m_type = Physics::ECollisionShapeType::Box;
+		shape.m_size = size;
+		result.m_shapes.Add(shape);
+		return result;
+	}
+
+	void Step(Physics::PhysicsWorld& world, uint32_t numSteps)
+	{
+		for (uint32_t step = 0; step < numSteps; ++step)
+		{
+			Require(
+				world.Step(c_fixedDeltaTime),
+				"fixed physics step should succeed");
+		}
+	}
+
+	Physics::PhysicsBodyPose SimulateFallingBox()
+	{
+		Physics::PhysicsWorld world;
+		uint32_t groundBody = ~0u;
+		uint32_t dynamicBody = ~0u;
+		Require(
+			world.CreateBody(
+				MakeBox(
+					InstanceId::GenerateNewInstanceId(),
+					Physics::ERigidBodyMotionType::Static,
+					glm::vec3(0.0f, -0.5f, 0.0f),
+					glm::vec3(20.0f, 1.0f, 20.0f)),
+				groundBody),
+			"static ground should be created");
+		Require(
+			world.CreateBody(
+				MakeBox(
+					InstanceId::GenerateNewInstanceId(),
+					Physics::ERigidBodyMotionType::Dynamic,
+					glm::vec3(0.0f, 4.0f, 0.0f),
+					glm::vec3(1.0f)),
+				dynamicBody),
+			"dynamic box should be created");
+
+		Step(world, 240);
+		Physics::PhysicsBodyPose pose{};
+		Require(
+			world.GetBodyPose(dynamicBody, pose),
+			"dynamic box pose should remain available");
+		return pose;
+	}
+
+	void TestFixedStepGravityContactsAndRaycast()
+	{
+		Physics::PhysicsWorld world;
+		const InstanceId groundId = InstanceId::GenerateNewInstanceId();
+		const InstanceId dynamicId = InstanceId::GenerateNewInstanceId();
+		uint32_t groundBody = ~0u;
+		uint32_t dynamicBody = ~0u;
+		Require(
+			world.CreateBody(
+				MakeBox(
+					groundId,
+					Physics::ERigidBodyMotionType::Static,
+					glm::vec3(0.0f, -0.5f, 0.0f),
+					glm::vec3(20.0f, 1.0f, 20.0f)),
+				groundBody),
+			"static ground should be created");
+		Require(
+			world.CreateBody(
+				MakeBox(
+					dynamicId,
+					Physics::ERigidBodyMotionType::Dynamic,
+					glm::vec3(0.0f, 4.0f, 0.0f),
+					glm::vec3(1.0f)),
+				dynamicBody),
+			"dynamic box should be created");
+
+		Step(world, 240);
+
+		Physics::PhysicsBodyPose pose{};
+		Require(
+			world.GetBodyPose(dynamicBody, pose),
+			"dynamic box pose should be readable");
+		Require(
+			pose.m_position.y > 0.45f && pose.m_position.y < 0.56f,
+			"dynamic box should settle on top of the ground");
+
+		TVector<Physics::PhysicsContactEvent> events;
+		world.DrainContactEvents(events);
+		Require(
+			events.ContainsIf([&](const auto& event)
+				{
+					return event.m_type == Physics::EPhysicsContactType::Added &&
+						((event.m_first == groundId && event.m_second == dynamicId) ||
+							(event.m_first == dynamicId && event.m_second == groundId));
+				}),
+			"contact events should carry stable Sailor instance ids");
+
+		Physics::PhysicsRaycastHit hit{};
+		Require(
+			world.Raycast(
+				glm::vec3(0.0f, 5.0f, 0.0f),
+				glm::vec3(0.0f, -1.0f, 0.0f),
+				10.0f,
+				hit),
+			"raycast should hit the settled dynamic box");
+		Require(
+			hit.m_instanceId == dynamicId,
+			"raycast should resolve the hit to its Sailor instance id");
+		Require(
+			hit.m_normal.y > 0.99f,
+			"raycast should return a world-space surface normal");
+	}
+
+	void TestKinematicAuthority()
+	{
+		Physics::PhysicsWorld world;
+		uint32_t bodyId = ~0u;
+		Require(
+			world.CreateBody(
+				MakeBox(
+					InstanceId::GenerateNewInstanceId(),
+					Physics::ERigidBodyMotionType::Kinematic,
+					glm::vec3(0.0f),
+					glm::vec3(1.0f)),
+				bodyId),
+			"kinematic body should be created");
+		Require(
+			world.SetBodyTransform(
+				bodyId,
+				glm::vec3(3.0f, 2.0f, -1.0f),
+				glm::quat(1.0f, 0.0f, 0.0f, 0.0f),
+				true,
+				c_fixedDeltaTime),
+			"kinematic target should be accepted");
+		Step(world, 1);
+
+		Physics::PhysicsBodyPose pose{};
+		Require(world.GetBodyPose(bodyId, pose), "kinematic pose should be readable");
+		Require(
+			IsNear(pose.m_position.x, 3.0f) &&
+			IsNear(pose.m_position.y, 2.0f) &&
+			IsNear(pose.m_position.z, -1.0f),
+			"kinematic body should reach the authored target in one fixed step");
+	}
+
+	void TestCollisionLayersAndQueryMask()
+	{
+		Physics::PhysicsWorld world;
+		Require(
+			world.IsLayerCollisionEnabled(1, 2),
+			"collision layers should interact by default");
+		world.SetLayerCollisionEnabled(1, 2, false);
+		Require(
+			!world.IsLayerCollisionEnabled(1, 2) &&
+				!world.IsLayerCollisionEnabled(2, 1),
+			"collision layer matrix changes should be symmetric");
+
+		const InstanceId firstId = InstanceId::GenerateNewInstanceId();
+		const InstanceId secondId = InstanceId::GenerateNewInstanceId();
+		uint32_t firstBody = ~0u;
+		uint32_t secondBody = ~0u;
+		Require(
+			world.CreateBody(
+				MakeBox(
+					firstId,
+					Physics::ERigidBodyMotionType::Static,
+					glm::vec3(-2.0f, 0.0f, 0.0f),
+					glm::vec3(1.0f),
+					1),
+				firstBody),
+			"layer-one body should be created");
+		Require(
+			world.CreateBody(
+				MakeBox(
+					secondId,
+					Physics::ERigidBodyMotionType::Static,
+					glm::vec3(2.0f, 0.0f, 0.0f),
+					glm::vec3(1.0f),
+					2),
+				secondBody),
+			"layer-two body should be created");
+
+		Physics::PhysicsRaycastHit hit{};
+		Require(
+			world.Raycast(
+				glm::vec3(-2.0f, 3.0f, 0.0f),
+				glm::vec3(0.0f, -1.0f, 0.0f),
+				6.0f,
+				hit,
+				static_cast<uint16_t>(1u << 1)) &&
+				hit.m_instanceId == firstId,
+			"raycast mask should include its requested layer");
+		Require(
+			!world.Raycast(
+				glm::vec3(-2.0f, 3.0f, 0.0f),
+				glm::vec3(0.0f, -1.0f, 0.0f),
+				6.0f,
+				hit,
+				static_cast<uint16_t>(1u << 2)),
+			"raycast mask should exclude other layers");
+	}
+
+	void TestSensorEventsAndQueuedContactDestruction()
+	{
+		Physics::PhysicsWorld world;
+		const InstanceId groundId = InstanceId::GenerateNewInstanceId();
+		const InstanceId sensorId = InstanceId::GenerateNewInstanceId();
+		uint32_t groundBody = ~0u;
+		uint32_t sensorBody = ~0u;
+		Require(
+			world.CreateBody(
+				MakeBox(
+					groundId,
+					Physics::ERigidBodyMotionType::Static,
+					glm::vec3(0.0f, -0.5f, 0.0f),
+					glm::vec3(10.0f, 1.0f, 10.0f)),
+				groundBody),
+			"sensor fixture ground should be created");
+		auto sensor = MakeBox(
+			sensorId,
+			Physics::ERigidBodyMotionType::Dynamic,
+			glm::vec3(0.0f, 2.0f, 0.0f),
+			glm::vec3(1.0f));
+		sensor.m_bSensor = true;
+		Require(
+			world.CreateBody(sensor, sensorBody),
+			"sensor body should be created");
+
+		Step(world, 120);
+		world.DestroyBody(sensorBody);
+		world.DestroyBody(sensorBody);
+
+		TVector<Physics::PhysicsContactEvent> events;
+		world.DrainContactEvents(events);
+		Require(
+			events.ContainsIf([&](const auto& event)
+				{
+					return event.m_bSensor &&
+						event.m_type == Physics::EPhysicsContactType::Added &&
+						((event.m_first == groundId && event.m_second == sensorId) ||
+							(event.m_first == sensorId && event.m_second == groundId));
+				}),
+			"sensor overlap should be delivered as copied stable ids after the step");
+		for (size_t index = 1; index < events.Num(); ++index)
+		{
+			const auto& previous = events[index - 1];
+			const auto& current = events[index];
+			const auto previousKey = std::make_pair(
+				previous.m_first.ToString(),
+				previous.m_second.ToString());
+			const auto currentKey = std::make_pair(
+				current.m_first.ToString(),
+				current.m_second.ToString());
+			Require(
+				previousKey <= currentKey,
+				"parallel contact callbacks should drain in stable pair order");
+		}
+	}
+
+	void TestLifecycleAndInputValidation()
+	{
+		Physics::PhysicsWorld world;
+		uint32_t bodyId = ~0u;
+		Require(
+			world.CreateBody(
+				MakeBox(
+					InstanceId::GenerateNewInstanceId(),
+					Physics::ERigidBodyMotionType::Static,
+					glm::vec3(0.0f),
+					glm::vec3(1.0f)),
+				bodyId),
+			"body should be created for lifecycle validation");
+		world.DestroyBody(bodyId);
+		world.DestroyBody(bodyId);
+
+		Physics::PhysicsBodyPose pose{};
+		Require(
+			!world.GetBodyPose(bodyId, pose),
+			"destroyed body handle should no longer resolve");
+		Require(!world.Step(0.0f), "zero-length step should be rejected");
+		auto invalidBody = MakeBox(
+			InstanceId::GenerateNewInstanceId(),
+			Physics::ERigidBodyMotionType::Dynamic,
+			glm::vec3(0.0f),
+			glm::vec3(1.0f));
+		invalidBody.m_gravityFactor =
+			std::numeric_limits<float>::quiet_NaN();
+		uint32_t invalidBodyId = ~0u;
+		Require(
+			!world.CreateBody(invalidBody, invalidBodyId),
+			"non-finite body settings should be rejected");
+		Physics::PhysicsRaycastHit hit{};
+		Require(
+			!world.Raycast(
+				glm::vec3(0.0f),
+				glm::vec3(0.0f),
+				1.0f,
+				hit),
+			"zero-length ray direction should be rejected");
+		world.Clear();
+		world.Clear();
+	}
+
+	void TestSameBuildRepeatability()
+	{
+		const Physics::PhysicsBodyPose first = SimulateFallingBox();
+		const Physics::PhysicsBodyPose second = SimulateFallingBox();
+		Require(
+			IsNear(first.m_position.x, second.m_position.x, 0.000001f) &&
+			IsNear(first.m_position.y, second.m_position.y, 0.000001f) &&
+			IsNear(first.m_position.z, second.m_position.z, 0.000001f) &&
+			IsNear(first.m_linearVelocity.x, second.m_linearVelocity.x, 0.000001f) &&
+			IsNear(first.m_linearVelocity.y, second.m_linearVelocity.y, 0.000001f) &&
+			IsNear(first.m_linearVelocity.z, second.m_linearVelocity.z, 0.000001f),
+			"identical fixed-step runs should repeat within the same build");
+	}
+
+	void TestWorldPoseToLocalForTransformedParent()
+	{
+		const Math::Transform parent(
+			glm::vec4(4.0f, -2.0f, 7.0f, 1.0f),
+			glm::angleAxis(glm::radians(35.0f), glm::normalize(glm::vec3(0.0f, 1.0f, 1.0f))),
+			glm::vec4(2.0f));
+		const glm::vec3 expectedLocalPosition(-3.0f, 1.5f, 2.0f);
+		const glm::quat expectedLocalRotation = glm::angleAxis(
+			glm::radians(-24.0f),
+			glm::normalize(glm::vec3(1.0f, 0.5f, 0.25f)));
+		const glm::vec3 worldPosition = glm::vec3(
+			parent.Matrix() * glm::vec4(expectedLocalPosition, 1.0f));
+		const glm::quat worldRotation = glm::normalize(
+			parent.m_rotation * expectedLocalRotation);
+
+		glm::vec3 localPosition{};
+		glm::quat localRotation{};
+		Require(
+			Physics::TryConvertWorldPoseToLocal(
+				parent.Matrix(),
+				worldPosition,
+				worldRotation,
+				localPosition,
+				localRotation),
+			"dynamic child pose should convert through a transformed parent");
+		Require(
+			glm::length(localPosition - expectedLocalPosition) <= 0.00001f,
+			"dynamic child local position should preserve its physics world position");
+		Require(
+			std::abs(glm::dot(localRotation, expectedLocalRotation)) >= 0.99999f,
+			"dynamic child local rotation should preserve its physics world rotation");
+
+		glm::mat4 singularParent = parent.Matrix();
+		singularParent[0] = glm::vec4(0.0f);
+		Require(
+			!Physics::TryConvertWorldPoseToLocal(
+				singularParent,
+				worldPosition,
+				worldRotation,
+				localPosition,
+				localRotation),
+			"singular parent transforms should be rejected safely");
+	}
+
+	void TestReflectedPhysicsAuthoringContract()
+	{
+		const TypeInfo& rigidBodyType = TypeInfo::Get<RigidBodyComponent>();
+		Require(
+			rigidBodyType.Name() == "Sailor::RigidBodyComponent" &&
+				rigidBodyType.Base() == "Sailor::Component",
+			"rigid body should remain a reflected engine component");
+		Require(
+			rigidBodyType.Properties()["motionType"] ==
+				"enum Sailor::ERigidBodyMotionType" &&
+				rigidBodyType.Properties()["collisionLayer"] == "uint32",
+			"rigid body authoring fields should export Editor-compatible types");
+		Require(
+			rigidBodyType.PropertyRanges()["collisionLayer"].m_min == 0.0 &&
+				rigidBodyType.PropertyRanges()["collisionLayer"].m_max == 15.0,
+			"collision layer should export the supported layer range");
+
+		const TypeInfo& shapeType = TypeInfo::Get<CollisionShapeComponent>();
+		Require(
+			shapeType.Name() == "Sailor::CollisionShapeComponent" &&
+				shapeType.Properties()["shapeType"] ==
+					"enum Sailor::ECollisionShapeType" &&
+				!shapeType.Properties()["center"].empty(),
+			"collision shape should expose typed primitive authoring fields: " +
+				shapeType.Properties()["shapeType"] + ", " +
+				shapeType.Properties()["center"]);
+	}
+
+	void TestComponentTeardownOrdering()
+	{
+		PhysicsComponentTestWorld world;
+		auto owner = world.Instantiate("Physics owner");
+		owner->AddComponent<RigidBodyComponent>();
+		auto shape = owner->AddComponent<CollisionShapeComponent>();
+		Require(
+			owner->RemoveComponent(shape),
+			"an individual collision shape should be removable safely");
+
+		owner->AddComponent<CollisionShapeComponent>();
+		owner->RemoveAllComponents();
+		Require(
+			owner->GetComponents().IsEmpty(),
+			"full object teardown should not access a destroyed rigid body");
+		world.Clear();
+	}
+}
+
+int main()
+{
+	Physics::JoltRuntime runtime;
+	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "FixedStepGravityContactsAndRaycast", TestFixedStepGravityContactsAndRaycast },
+		{ "KinematicAuthority", TestKinematicAuthority },
+		{ "CollisionLayersAndQueryMask", TestCollisionLayersAndQueryMask },
+		{ "SensorEventsAndQueuedContactDestruction", TestSensorEventsAndQueuedContactDestruction },
+		{ "LifecycleAndInputValidation", TestLifecycleAndInputValidation },
+		{ "SameBuildRepeatability", TestSameBuildRepeatability },
+		{ "WorldPoseToLocalForTransformedParent", TestWorldPoseToLocalForTransformedParent },
+		{ "ReflectedPhysicsAuthoringContract", TestReflectedPhysicsAuthoringContract },
+		{ "ComponentTeardownOrdering", TestComponentTeardownOrdering },
+	};
+
+	for (const auto& test : tests)
+	{
+		try
+		{
+			test.second();
+			std::cout << "[PASS] " << test.first << std::endl;
+		}
+		catch (const std::exception& error)
+		{
+			std::cerr << "[FAIL] " << test.first << ": " << error.what() << std::endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/ThirdPartyLicenses.txt
+++ b/ThirdPartyLicenses.txt
@@ -1,0 +1,8 @@
+Jolt Physics
+Copyright 2021 Jorrit Rouwe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/update_deps.py
+++ b/update_deps.py
@@ -80,6 +80,7 @@ def main() -> int:
         'imgui[win32-binding]' if system == 'Windows' else 'imgui',
         'imguizmo',
         'ixwebsocket[core]',
+        'joltphysics',
         'magic-enum',
         'meshoptimizer',
         'nlohmann-json',


### PR DESCRIPTION
Closes #141

## What changed

- integrates Jolt Physics 5.3 through vcpkg/CMake and retains its MIT notice
- adds a Sailor-owned physics runtime with box, sphere and capsule shapes, static/kinematic/dynamic bodies, layers, sensors, contacts and raycasts
- runs fixed-step world simulation on a dedicated Sailor Physics queue while dispatching Jolt jobs to Sailor Worker tasks
- synchronizes authored static/kinematic transforms into physics and dynamic world poses back into local transforms before rendering
- adds reflected `RigidBodyComponent` and `CollisionShapeComponent` authoring
- adds Editor Simulate/Stop protocol and toolbar flow; Start snapshots the authored world in memory and Stop restores it
- changes the Simulate toolbar icon and label to Stop while simulation is active in both MAUI and native Mac toolbars
- adds `PhysicsFallingBodies` and `PhysicsHierarchy` test scenes using existing engine content

## Impact

The engine now has an engine-neutral rigid-body physics boundary backed by Jolt. Editor users can preview physics without permanently modifying the authored scene, and can verify basic bodies, sensors, kinematic authority and transformed-parent behavior with the included scenes.

## Validation

- Release CMake build: passed
- Release CTest: 36/36 passed
- Debug CMake build: passed
- focused Debug physics/protocol tests: passed
- Editor contract tests: 733/733 passed
- Release Mac Catalyst Editor build: passed with 0 errors
- live Release Editor startup: passed
- both physics test scenes loaded and ran under the Release engine without crash or assertion

## Known local environment note

Full Debug CTest on macOS is 35/36 because the existing `WorkspaceModuleRuntimeTests` fixture reports `config=checked` while the Debug engine reports `config=debug`. The same test passes in Release and this PR does not change workspace ABI selection.
