### PR TITLE
Add MCP integration to Sailor Editor

### DIFF
--- a/.github/workflows/editor-build.yml
+++ b/.github/workflows/editor-build.yml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Build Editor (Windows)
         run: dotnet build Editor/SailorEditor.csproj -c Release -f net10.0-windows10.0.19041.0
+
+      - name: Build MCP bridge
+        run: dotnet build Editor/McpBridge/SailorEditor.McpBridge.csproj -c Release

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="ModelContextProtocol" Version="2.1.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <PrivateAssets>all</PrivateAssets>
@@ -56,6 +57,12 @@
     <Compile Include="ModelFingerprintTests.cs" />
     <Compile Include="WorkspaceUiProjectionTests.cs" />
     <Compile Include="AIOperatorTests.cs" />
+    <Compile Include="McpEndpointDiscoveryTests.cs" />
+    <Compile Include="McpBridgeOptionsTests.cs" />
+    <Compile Include="McpBridgeIntegrationTests.cs" />
+    <Compile Include="WorkspaceBuildPlanTests.cs" />
+    <Compile Include="McpSceneSafetyContractTests.cs" />
+    <Compile Include="McpYamlUtilitiesTests.cs" />
     <Compile Include="SettingsContractsTests.cs" />
     <Compile Include="UnifiedSettingsStoreTests.cs" />
     <Compile Include="WorkflowProjectionTests.cs" />
@@ -141,6 +148,11 @@
     <Compile Include="..\Editor\AI\AIContracts.cs" Link="AI\AIContracts.cs" />
     <Compile Include="..\Editor\AI\AIOperatorService.cs" Link="AI\AIOperatorService.cs" />
     <Compile Include="..\Editor\AI\EditorAIContextProvider.cs" Link="AI\EditorAIContextProvider.cs" />
+    <Compile Include="..\Editor\Mcp\McpEndpointDiscovery.cs" Link="Mcp\McpEndpointDiscovery.cs" />
+    <Compile Include="..\Editor\Mcp\McpLoopbackAuthentication.cs" Link="Mcp\McpLoopbackAuthentication.cs" />
+    <Compile Include="..\Editor\Mcp\McpYamlUtilities.cs" Link="Mcp\McpYamlUtilities.cs" />
+    <Compile Include="..\Editor\McpBridge\McpBridgeOptions.cs" Link="McpBridge\McpBridgeOptions.cs" />
+    <Compile Include="..\Editor\McpBridge\McpBridgeRunner.cs" Link="McpBridge\McpBridgeRunner.cs" />
     <Compile Include="..\Editor\Workflow\WorkflowProjections.cs" Link="Workflow\WorkflowProjections.cs" />
     <Compile Include="..\Editor\Workflow\InspectorAutoCommitController.cs" Link="Workflow\InspectorAutoCommitController.cs" />
     <Compile Include="..\Editor\Workflow\InspectorPendingEditCoordinator.cs" Link="Workflow\InspectorPendingEditCoordinator.cs" />
@@ -155,5 +167,6 @@
     <Compile Include="..\Editor\Services\EditorTypeCacheStore.cs" Link="Services\EditorTypeCacheStore.cs" />
     <Compile Include="..\Editor\Services\AssetCacheIndexStore.cs" Link="Services\AssetCacheIndexStore.cs" />
     <Compile Include="..\Editor\Commands\EditorCommandRuntime.cs" Link="Commands\EditorCommandRuntime.cs" />
+    <Compile Include="..\Editor\Workspace\WorkspaceBuildService.cs" Link="Workspace\WorkspaceBuildService.cs" />
   </ItemGroup>
 </Project>

--- a/Editor.Tests/McpBridgeIntegrationTests.cs
+++ b/Editor.Tests/McpBridgeIntegrationTests.cs
@@ -1,0 +1,117 @@
+using System.IO.Pipelines;
+using System.Net;
+using System.Net.Sockets;
+using ModelContextProtocol.Client;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using SailorEditor.Mcp;
+using SailorEditor.McpBridge;
+
+namespace SailorEditor.Tests;
+
+public sealed class McpBridgeIntegrationTests
+{
+    [Fact]
+    public async Task Bridge_ConnectsOfficialClientToAuthenticatedEditorServer()
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+        var directory = Path.Combine(
+            Path.GetTempPath(),
+            "sailor-mcp-bridge-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var discovery = new McpEndpointDiscovery(directory);
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        var token = McpEndpointDiscovery.CreateAuthenticationToken();
+        await discovery.WriteAsync(new McpEndpointDescriptor(
+            McpEndpointDiscovery.CurrentProtocolVersion,
+            Environment.ProcessId,
+            port,
+            token,
+            "Engine",
+            directory,
+            DateTimeOffset.UtcNow), timeout.Token);
+
+        var serverTask = RunServerAsync(listener, token, timeout.Token);
+        var clientToBridge = new Pipe();
+        var bridgeToClient = new Pipe();
+        var bridge = new McpBridgeRunner(discovery);
+        var bridgeTask = bridge.RunAsync(
+            new McpBridgeOptions(Environment.ProcessId, null, directory),
+            clientToBridge.Reader.AsStream(),
+            bridgeToClient.Writer.AsStream(),
+            TextWriter.Null,
+            timeout.Token);
+
+        try
+        {
+            await using var client = await McpClient.CreateAsync(
+                new StreamClientTransport(
+                    clientToBridge.Writer.AsStream(),
+                    bridgeToClient.Reader.AsStream()),
+                cancellationToken: timeout.Token);
+            var tools = await client.ListToolsAsync(
+                cancellationToken: timeout.Token);
+
+            Assert.Contains(tools, tool => tool.Name == "sailor_test_ping");
+        }
+        finally
+        {
+            await clientToBridge.Writer.CompleteAsync();
+            await bridgeToClient.Reader.CompleteAsync();
+            listener.Stop();
+            timeout.Cancel();
+            try
+            {
+                await bridgeTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            try
+            {
+                await serverTask;
+            }
+            catch (OperationCanceledException)
+            {
+            }
+            catch (SocketException)
+            {
+            }
+            discovery.Delete(Environment.ProcessId);
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    static async Task RunServerAsync(
+        TcpListener listener,
+        string token,
+        CancellationToken cancellationToken)
+    {
+        using var connection = await listener.AcceptTcpClientAsync(cancellationToken);
+        await using var stream = connection.GetStream();
+        Assert.True(await McpLoopbackAuthentication.ValidateRequestAsync(
+            stream,
+            token,
+            cancellationToken));
+
+        await using var server = McpServer.Create(
+            new StreamServerTransport(stream, stream, "SailorEditorTest"),
+            new McpServerOptions
+            {
+                ServerInfo = new Implementation
+                {
+                    Name = "SailorEditorTest",
+                    Version = "1.0.0",
+                },
+                ToolCollection =
+                [
+                    McpServerTool.Create(
+                        () => "pong",
+                        new() { Name = "sailor_test_ping" }),
+                ],
+            });
+        await server.RunAsync(cancellationToken);
+    }
+}

--- a/Editor.Tests/McpBridgeOptionsTests.cs
+++ b/Editor.Tests/McpBridgeOptionsTests.cs
@@ -1,0 +1,40 @@
+using SailorEditor.McpBridge;
+
+namespace SailorEditor.Tests;
+
+public sealed class McpBridgeOptionsTests
+{
+    [Fact]
+    public void TryParse_ParsesExplicitEditorSelectors()
+    {
+        var parsed = McpBridgeOptions.TryParse(
+            [
+                "--pid",
+                "42",
+                "--workspace",
+                "/tmp/SailorProject",
+                "--discovery-directory",
+                "/tmp/SailorMcp",
+            ],
+            out var options,
+            out var error);
+
+        Assert.True(parsed, error);
+        Assert.Equal(42, options.ProcessId);
+        Assert.Equal("/tmp/SailorProject", options.WorkspacePath);
+        Assert.Equal("/tmp/SailorMcp", options.DiscoveryDirectory);
+    }
+
+    [Theory]
+    [InlineData("--pid")]
+    [InlineData("--pid", "zero")]
+    [InlineData("--unknown", "value")]
+    public void TryParse_RejectsInvalidArguments(params string[] arguments)
+    {
+        Assert.False(McpBridgeOptions.TryParse(
+            arguments,
+            out _,
+            out var error));
+        Assert.False(string.IsNullOrWhiteSpace(error));
+    }
+}

--- a/Editor.Tests/McpEndpointDiscoveryTests.cs
+++ b/Editor.Tests/McpEndpointDiscoveryTests.cs
@@ -1,0 +1,115 @@
+using SailorEditor.Mcp;
+
+namespace SailorEditor.Tests;
+
+public sealed class McpEndpointDiscoveryTests
+{
+    [Fact]
+    public async Task WriteAndSelect_RoundTripsCurrentEditorEndpoint()
+    {
+        var directory = CreateTemporaryDirectory();
+        try
+        {
+            var discovery = new McpEndpointDiscovery(directory);
+            var endpoint = new McpEndpointDescriptor(
+                McpEndpointDiscovery.CurrentProtocolVersion,
+                Environment.ProcessId,
+                34567,
+                McpEndpointDiscovery.CreateAuthenticationToken(),
+                "Workspace",
+                directory,
+                DateTimeOffset.UtcNow);
+
+            await discovery.WriteAsync(endpoint);
+
+            var selection = discovery.Select(
+                processId: Environment.ProcessId);
+            Assert.True(selection.Succeeded, selection.Error);
+            Assert.Equal(endpoint, selection.Endpoint);
+            Assert.DoesNotContain(
+                Directory.EnumerateFiles(directory),
+                path => path.EndsWith(".tmp", StringComparison.Ordinal));
+
+            if (!OperatingSystem.IsWindows())
+            {
+                var mode = File.GetUnixFileMode(
+                    discovery.GetDescriptorPath(Environment.ProcessId));
+                Assert.Equal(
+                    UnixFileMode.UserRead | UnixFileMode.UserWrite,
+                    mode);
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Authentication_ConsumesOnlyHandshakeLine()
+    {
+        const string token = "correct-token";
+        await using var stream = new MemoryStream();
+        await McpLoopbackAuthentication.WriteRequestAsync(stream, token);
+        await stream.WriteAsync("{\"jsonrpc\":\"2.0\"}\n"u8.ToArray());
+        stream.Position = 0;
+
+        Assert.True(await McpLoopbackAuthentication.ValidateRequestAsync(
+            stream,
+            token));
+
+        using var reader = new StreamReader(stream);
+        Assert.Equal("{\"jsonrpc\":\"2.0\"}", await reader.ReadLineAsync());
+    }
+
+    [Fact]
+    public async Task Select_RejectsDescriptorFromReusedProcessId()
+    {
+        var directory = CreateTemporaryDirectory();
+        try
+        {
+            var discovery = new McpEndpointDiscovery(directory);
+            using var currentProcess = System.Diagnostics.Process.GetCurrentProcess();
+            var endpoint = new McpEndpointDescriptor(
+                McpEndpointDiscovery.CurrentProtocolVersion,
+                Environment.ProcessId,
+                34567,
+                McpEndpointDiscovery.CreateAuthenticationToken(),
+                "Engine",
+                directory,
+                currentProcess.StartTime.ToUniversalTime().AddMinutes(-5));
+            await discovery.WriteAsync(endpoint);
+
+            var selection = discovery.Select(processId: Environment.ProcessId);
+
+            Assert.False(selection.Succeeded);
+            Assert.False(File.Exists(
+                discovery.GetDescriptorPath(Environment.ProcessId)));
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public async Task Authentication_RejectsWrongToken()
+    {
+        await using var stream = new MemoryStream();
+        await McpLoopbackAuthentication.WriteRequestAsync(stream, "wrong");
+        stream.Position = 0;
+
+        Assert.False(await McpLoopbackAuthentication.ValidateRequestAsync(
+            stream,
+            "correct"));
+    }
+
+    static string CreateTemporaryDirectory()
+    {
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            "sailor-mcp-tests-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(path);
+        return path;
+    }
+}

--- a/Editor.Tests/McpSceneSafetyContractTests.cs
+++ b/Editor.Tests/McpSceneSafetyContractTests.cs
@@ -1,0 +1,59 @@
+namespace Editor.Tests;
+
+public sealed class McpSceneSafetyContractTests
+{
+    [Fact]
+    public void AddComponent_ValidatesPropertiesBeforeNativeMutation()
+    {
+        var source = ReadRepositoryFile("Editor", "Mcp", "McpSceneBatchExecutor.cs");
+        var methodStart = source.IndexOf(
+            "async Task<CommandResult> AddComponentAsync(",
+            StringComparison.Ordinal);
+        var methodEnd = source.IndexOf(
+            "async Task<CommandResult> UpdateComponentAsync(",
+            methodStart,
+            StringComparison.Ordinal);
+
+        Assert.True(methodStart >= 0);
+        Assert.True(methodEnd > methodStart);
+
+        var method = source[methodStart..methodEnd];
+        var validate = method.IndexOf(
+            "ValidateComponentPropertiesAsync(",
+            StringComparison.Ordinal);
+        var dispatch = method.IndexOf(
+            "new AddComponentCommand(",
+            StringComparison.Ordinal);
+
+        Assert.True(validate >= 0);
+        Assert.True(dispatch > validate);
+    }
+
+    [Fact]
+    public void ObjectPointerProperties_RejectMalformedReferenceShapes()
+    {
+        var source = ReadRepositoryFile("Editor", "Mcp", "McpSceneBatchExecutor.cs");
+
+        Assert.Contains("only accepts \" +", source, StringComparison.Ordinal);
+        Assert.Contains("fileId and instanceId", source, StringComparison.Ordinal);
+        Assert.Contains(".fileId' must be a string", source, StringComparison.Ordinal);
+        Assert.Contains(".instanceId' must be a string", source, StringComparison.Ordinal);
+    }
+
+    static string ReadRepositoryFile(params string[] relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (Directory.Exists(Path.Combine(current.FullName, "Editor")) &&
+                Directory.Exists(Path.Combine(current.FullName, "Runtime")))
+            {
+                return File.ReadAllText(Path.Combine([current.FullName, .. relativePath]));
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find the Sailor repository root.");
+    }
+}

--- a/Editor.Tests/McpYamlUtilitiesTests.cs
+++ b/Editor.Tests/McpYamlUtilitiesTests.cs
@@ -1,0 +1,29 @@
+using SailorEditor.Mcp;
+using YamlDotNet.RepresentationModel;
+
+namespace Editor.Tests;
+
+public sealed class McpYamlUtilitiesTests
+{
+    [Fact]
+    public void ToPlainObject_PreservesUnsignedInstanceIdAsString()
+    {
+        var value = McpYamlUtilities.ToPlainObject(
+            new YamlScalarNode("17189606890707967961"));
+
+        Assert.Equal("17189606890707967961", value);
+    }
+
+    [Theory]
+    [InlineData("42", 42L)]
+    [InlineData("1.5", 1.5)]
+    [InlineData("true", true)]
+    public void ToPlainObject_PreservesOrdinaryScalarTypes(
+        string source,
+        object expected)
+    {
+        var value = McpYamlUtilities.ToPlainObject(new YamlScalarNode(source));
+
+        Assert.Equal(expected, value);
+    }
+}

--- a/Editor.Tests/WorkspaceBuildPlanTests.cs
+++ b/Editor.Tests/WorkspaceBuildPlanTests.cs
@@ -1,0 +1,157 @@
+using SailorEditor.Workspace;
+
+namespace SailorEditor.Tests;
+
+public sealed class WorkspaceBuildPlanTests
+{
+    [Fact]
+    public void Create_BuildsConfigureAndTargetInvocationsWithoutShellQuoting()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Sailor Workspace");
+        var session = new WorkspaceSession(
+            root,
+            Path.Combine(root, "workspace.sailor"),
+            WorkspaceManifest.CreateDefault("Game", root) with
+            {
+                LogicModuleName = "ForestGame",
+            },
+            Path.Combine(root, "Content"),
+            Path.Combine(root, "Source"),
+            Path.Combine(root, "Generated"),
+            Path.Combine(root, "Cache"))
+        {
+            BuildDirectory = Path.Combine(root, "Cache", "Build"),
+            LogicOutputDirectory = Path.Combine(root, "Binaries"),
+        };
+
+        var plan = WorkspaceBuildPlan.Create(
+            session,
+            "RelWithDebInfo",
+            configure: true);
+
+        Assert.Equal("RelWithDebInfo", plan.Configuration);
+        Assert.Equal(2, plan.Invocations.Count);
+        Assert.Equal(
+            [
+                "-S",
+                session.GeneratedProjectDirectory,
+                "-B",
+                session.BuildDirectory,
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+            ],
+            plan.Invocations[0].Arguments);
+        Assert.Equal(
+            [
+                "--build",
+                session.BuildDirectory,
+                "--config",
+                "RelWithDebInfo",
+                "--target",
+                "ForestGame",
+                "--parallel",
+                "4",
+            ],
+            plan.Invocations[1].Arguments);
+    }
+
+    [Fact]
+    public void Create_RejectsUnknownConfiguration()
+    {
+        var root = Path.GetTempPath();
+        var session = new WorkspaceSession(
+            root,
+            Path.Combine(root, "workspace.sailor"),
+            WorkspaceManifest.CreateDefault("Game", root),
+            Path.Combine(root, "Content"),
+            Path.Combine(root, "Source"),
+            Path.Combine(root, "Generated"),
+            Path.Combine(root, "Cache"))
+        {
+            BuildDirectory = Path.Combine(root, "Cache", "Build"),
+            LogicOutputDirectory = Path.Combine(root, "Binaries"),
+        };
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            WorkspaceBuildPlan.Create(
+                session,
+                "Shipping",
+                configure: false));
+    }
+
+    [Fact]
+    public void Create_UsesSourceEngineVcpkgToolchainWhenAvailable()
+    {
+        var repositoryRoot = ResolveRepositoryRoot();
+        var root = Path.Combine(Path.GetTempPath(), "Sailor Workspace");
+        var session = new WorkspaceSession(
+            root,
+            Path.Combine(root, "workspace.sailor"),
+            WorkspaceManifest.CreateDefault("Game", repositoryRoot),
+            Path.Combine(root, "Content"),
+            Path.Combine(root, "Source"),
+            Path.Combine(root, "Generated"),
+            Path.Combine(root, "Cache"))
+        {
+            BuildDirectory = Path.Combine(root, "Cache", "Build"),
+            LogicOutputDirectory = Path.Combine(root, "Binaries"),
+        };
+
+        var plan = WorkspaceBuildPlan.Create(
+            session,
+            "Release",
+            configure: true);
+
+        var toolchainPath = Path.Combine(
+            repositoryRoot,
+            "External",
+            "vcpkg",
+            "scripts",
+            "buildsystems",
+            "vcpkg.cmake");
+        Assert.Contains(
+            "-DCMAKE_TOOLCHAIN_FILE=" + toolchainPath,
+            plan.Invocations[0].Arguments);
+        var triplet = OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst()
+            ? "arm64-osx"
+            : OperatingSystem.IsWindows()
+                ? "x64-windows"
+                : OperatingSystem.IsLinux()
+                    ? "x64-linux"
+                    : null;
+        if (triplet is not null)
+        {
+            Assert.Contains(
+                "-DVCPKG_TARGET_TRIPLET=" + triplet,
+                plan.Invocations[0].Arguments);
+            var installedDirectory = Path.Combine(
+                repositoryRoot,
+                "External",
+                "vcpkg",
+                "installed",
+                triplet);
+            if (Directory.Exists(installedDirectory))
+            {
+                Assert.Contains(
+                    "-DCMAKE_PREFIX_PATH=" + installedDirectory,
+                    plan.Invocations[0].Arguments);
+            }
+        }
+    }
+
+    static string ResolveRepositoryRoot()
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (File.Exists(Path.Combine(current.FullName, "CMakeLists.txt")) &&
+                Directory.Exists(Path.Combine(current.FullName, "Editor")))
+            {
+                return current.FullName;
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find the Sailor repository root.");
+    }
+}

--- a/Editor/AI/AGENT.md
+++ b/Editor/AI/AGENT.md
@@ -137,3 +137,62 @@ If uncertain, require confirmation.
 - State the planned command before execution.
 - Mention whether approval is required.
 - After execution, summarize what changed and whether follow-up is needed.
+
+## MCP Integration
+
+The running Editor publishes an authenticated local MCP endpoint. MCP clients use the
+`SailorEditor.McpBridge` console application as a standard stdio server; the bridge
+attaches to the selected Editor process over loopback. The endpoint is not exposed on
+the LAN and does not add a direct engine API.
+
+Development bridge command:
+
+```text
+dotnet run --project Editor/McpBridge/SailorEditor.McpBridge.csproj -- --pid <editor-pid>
+```
+
+When only one Editor is running, `--pid` may be omitted. With multiple Editors, select
+one explicitly with `--pid <editor-pid>` or `--workspace <workspace-root>`. The AI panel
+shows the current PID, loopback port, connected-client count, and discovery file.
+
+Read tools do not require confirmation. Scene, asset, save, and build tools require
+`confirm: true`. A scene batch is executed through the normal command dispatcher inside
+one undo transaction. Operations can assign an alias and later refer to it as `$alias`.
+
+Example scene batch shape:
+
+```json
+{
+  "confirm": true,
+  "expectedWorkspaceEpoch": 0,
+  "description": "Create a tree",
+  "operations": [
+    {
+      "kind": "create_game_object",
+      "alias": "tree",
+      "name": "Tree",
+      "properties": {
+        "position": { "x": 0, "y": 0, "z": 0, "w": 1 },
+        "scale": { "x": 1, "y": 1, "z": 1, "w": 1 }
+      }
+    },
+    {
+      "kind": "add_component",
+      "target": "$tree",
+      "alias": "renderer",
+      "componentType": "Sailor::MeshRendererComponent",
+      "properties": {
+        "model": {
+          "fileId": "<model-file-id>",
+          "instanceId": "NullInstanceId"
+        }
+      }
+    }
+  ]
+}
+```
+
+Call `sailor_types_list_components` before assigning component properties. It is the
+canonical source for component names, editable fields, enum values, defaults, and typed
+object references. Call `sailor_assets_list` or `sailor_assets_get` to resolve stable
+FileIds instead of guessing content paths.

--- a/Editor/AI/AIOperatorService.cs
+++ b/Editor/AI/AIOperatorService.cs
@@ -129,6 +129,24 @@ public sealed class AIOperatorService
         return AddAudit(proposal, items, proposal.Summary);
     }
 
+    public AIActionAuditEntry RecordExternalExecution(
+        string title,
+        AIActionSafety safety,
+        AIProposalState state,
+        IReadOnlyList<AIActionExecutionItem> items,
+        string? summary = null,
+        string? proposalId = null)
+    {
+        var proposal = new AIProposedAction(
+            proposalId ?? "mcp-" + Guid.NewGuid().ToString("N"),
+            title,
+            Array.Empty<IEditorCommand>(),
+            safety,
+            summary,
+            state);
+        return AddAudit(proposal, items, summary);
+    }
+
     bool TryGetProposal(string proposalId, out AIProposedAction proposal) => _proposalLookup.TryGetValue(proposalId, out proposal!);
 
     bool ReplaceProposal(AIProposedAction proposal)

--- a/Editor/App.xaml.cs
+++ b/Editor/App.xaml.cs
@@ -1,6 +1,7 @@
 ﻿#if MACCATALYST
 using SailorEditor.Platforms.MacCatalyst;
 #endif
+using SailorEditor.Mcp;
 
 [assembly: XamlCompilation(XamlCompilationOptions.Compile)]
 
@@ -19,6 +20,8 @@ namespace SailorEditor
             window.MinimumWidth = 1024;
             window.MinimumHeight = 768;
             window.Title = "Engine Mode";
+            window.Destroying += async (_, _) =>
+                await MauiProgram.GetService<McpEditorHostService>().StopAsync();
 #if MACCATALYST
             MacCatalystWindowChrome.SetTitle(window.Title);
             MacCatalystWindowChrome.UseCompactTitlebar(window);

--- a/Editor/Commands/EditorAssetCommands.cs
+++ b/Editor/Commands/EditorAssetCommands.cs
@@ -17,6 +17,27 @@ public sealed class OpenAssetCommand(AssetFile assetFile) : IEditorCommand
     }
 }
 
+public sealed class ReimportAssetCommand(AssetFile assetFile) : IEditorCommand
+{
+    public string Name => nameof(ReimportAssetCommand);
+    public bool CanExecute(ActionContext context) =>
+        assetFile?.FileId is not null &&
+        !assetFile.FileId.IsEmpty();
+
+    public async Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var updated = await MauiProgram.GetService<EngineService>()
+            .UpdateAssetAsync(assetFile.FileId, cancellationToken);
+        return updated
+            ? CommandResult.Success(
+                "Asset reimport completed.",
+                assetFile.FileId)
+            : CommandResult.Failure("Asset reimport failed.");
+    }
+}
+
 public sealed class RenameAssetCommand(AssetFile assetFile, string newName) : IEditorCommand
 {
     public string Name => nameof(RenameAssetCommand);

--- a/Editor/Commands/EditorWorkspaceCommands.cs
+++ b/Editor/Commands/EditorWorkspaceCommands.cs
@@ -1,0 +1,54 @@
+#nullable enable
+
+using SailorEditor.Services;
+using SailorEditor.Workspace;
+
+namespace SailorEditor.Commands;
+
+public sealed class BuildWorkspaceCommand(
+    string configuration = "Release",
+    bool configure = true) : IEditorCommand
+{
+    public string Name => nameof(BuildWorkspaceCommand);
+    public bool CanExecute(ActionContext context) =>
+        MauiProgram.GetService<WorkspaceLifecycleService>().Current is not null;
+
+    public async Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await MauiProgram.GetService<WorkspaceBuildService>()
+            .BuildAsync(configuration, configure, cancellationToken);
+        return result.Succeeded
+            ? CommandResult.Success("Workspace build completed.", result)
+            : CommandResult.Failure(
+                result.Error ?? "Workspace build failed.",
+                result);
+    }
+}
+
+public sealed class SaveCurrentSceneCommand : IEditorCommand
+{
+    public string Name => nameof(SaveCurrentSceneCommand);
+    public bool CanExecute(ActionContext context) => true;
+
+    public async Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await MauiProgram.GetService<WorldService>()
+            .SaveCurrentWorldAsync(
+                confirmExisting: false,
+                cancellationToken);
+        return result.Outcome == SceneSaveOutcome.Saved
+            ? CommandResult.Success(
+                $"Scene saved to '{result.Path}'.",
+                result)
+            : CommandResult.Failure(
+                result.Error ??
+                    (result.Outcome == SceneSaveOutcome.Cancelled
+                        ? "Scene save was cancelled."
+                        : "Scene save failed."),
+                result);
+    }
+}

--- a/Editor/MainPage.xaml.cs
+++ b/Editor/MainPage.xaml.cs
@@ -4,6 +4,7 @@ using SailorEditor.Platforms.MacCatalyst;
 using SailorEditor.Services;
 using SailorEditor.Shell;
 using SailorEditor.Workspace;
+using SailorEditor.Mcp;
 using System.ComponentModel;
 
 namespace SailorEditor;
@@ -12,12 +13,14 @@ public partial class MainPage : ContentPage
 {
     readonly EditorShellHost _shellHost;
     readonly WorkspaceUiService _workspaceUi;
+    readonly McpEditorHostService _mcpHost;
     bool _workspaceUiInitialized;
 
     public MainPage(EditorShellHost shellHost)
     {
         _shellHost = shellHost;
         _workspaceUi = MauiProgram.GetService<WorkspaceUiService>();
+        _mcpHost = MauiProgram.GetService<McpEditorHostService>();
         InitializeComponent();
 #if MACCATALYST
         ToolbarHost.IsVisible = false;
@@ -38,6 +41,19 @@ public partial class MainPage : ContentPage
             await _workspaceUi.InitializeAsync();
         }
 
+        if (!_mcpHost.Status.IsRunning)
+        {
+            try
+            {
+                await _mcpHost.StartAsync();
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    "Unable to start Sailor Editor MCP host: " +
+                    exception.Message);
+            }
+        }
         if (_shellHost.CurrentLayout is null)
             await _shellHost.InitializeAsync();
         ShellLayoutHost.Rebuild();

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -14,6 +14,7 @@ using SailorEditor.Settings;
 using SailorEditor.AI;
 using SailorEditor.Workspace;
 using SailorEditor.Workflow;
+using SailorEditor.Mcp;
 #if MACCATALYST
 using SailorEditor.Platforms.MacCatalyst;
 #endif
@@ -78,6 +79,16 @@ namespace SailorEditor
             builder.Services.AddSingleton<IAIEditorContextProvider, EditorAIContextProvider>();
             builder.Services.AddSingleton<IAIActionPlanner, HeuristicAIActionPlanner>();
             builder.Services.AddSingleton<AIOperatorService>();
+            builder.Services.AddSingleton<McpEndpointDiscovery>();
+            builder.Services.AddSingleton<IEditorThreadDispatcher, MauiEditorThreadDispatcher>();
+            builder.Services.AddSingleton<McpEditorTools>();
+            builder.Services.AddSingleton<McpSceneSnapshotBuilder>();
+            builder.Services.AddSingleton<McpSceneBatchExecutor>();
+            builder.Services.AddSingleton<McpAssetOperations>();
+            builder.Services.AddSingleton<McpWorkspaceOperations>();
+            builder.Services.AddSingleton<IWorkspaceProcessRunner, WorkspaceProcessRunner>();
+            builder.Services.AddSingleton<WorkspaceBuildService>();
+            builder.Services.AddSingleton<McpEditorHostService>();
             builder.Services.AddTransient<MainPage>();
             builder.Services.AddTransient<ContentFolderView>();
 

--- a/Editor/Mcp/EditorThreadDispatcher.cs
+++ b/Editor/Mcp/EditorThreadDispatcher.cs
@@ -1,0 +1,52 @@
+#nullable enable
+
+namespace SailorEditor.Mcp;
+
+public interface IEditorThreadDispatcher
+{
+    Task InvokeAsync(
+        Func<Task> action,
+        CancellationToken cancellationToken = default);
+
+    Task<T> InvokeAsync<T>(
+        Func<Task<T>> action,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class MauiEditorThreadDispatcher : IEditorThreadDispatcher
+{
+    public async Task InvokeAsync(
+        Func<Task> action,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (MainThread.IsMainThread)
+        {
+            await action();
+            return;
+        }
+
+        await MainThread.InvokeOnMainThreadAsync(async () =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            await action();
+        });
+    }
+
+    public async Task<T> InvokeAsync<T>(
+        Func<Task<T>> action,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(action);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (MainThread.IsMainThread)
+            return await action();
+
+        return await MainThread.InvokeOnMainThreadAsync(async () =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            return await action();
+        });
+    }
+}

--- a/Editor/Mcp/McpAssetContracts.cs
+++ b/Editor/Mcp/McpAssetContracts.cs
@@ -1,0 +1,21 @@
+#nullable enable
+
+namespace SailorEditor.Mcp;
+
+public sealed record McpAssetSnapshot(
+    string FileId,
+    string Name,
+    string Type,
+    string AssetInfoType,
+    string SourcePath,
+    string AssetInfoPath,
+    bool IsReadOnly,
+    bool IsMetadataLoaded,
+    IReadOnlyDictionary<string, object?>? Properties,
+    string? Yaml);
+
+public sealed record McpAssetMutationResult(
+    bool Succeeded,
+    string Kind,
+    string? FileId,
+    string Message);

--- a/Editor/Mcp/McpAssetOperations.cs
+++ b/Editor/Mcp/McpAssetOperations.cs
@@ -1,0 +1,375 @@
+#nullable enable
+
+using SailorEditor.AI;
+using SailorEditor.Commands;
+using SailorEditor.Content;
+using SailorEditor.Services;
+using SailorEditor.ViewModels;
+using SailorEngine;
+
+namespace SailorEditor.Mcp;
+
+internal sealed class McpAssetOperations
+{
+    readonly AssetsService _assets;
+    readonly ICommandDispatcher _dispatcher;
+    readonly IActionContextProvider _contextProvider;
+    readonly AIOperatorService _aiOperator;
+
+    public McpAssetOperations(
+        AssetsService assets,
+        ICommandDispatcher dispatcher,
+        IActionContextProvider contextProvider,
+        AIOperatorService aiOperator)
+    {
+        _assets = assets;
+        _dispatcher = dispatcher;
+        _contextProvider = contextProvider;
+        _aiOperator = aiOperator;
+    }
+
+    public async Task<IReadOnlyList<McpAssetSnapshot>> ListAsync(
+        string? path,
+        string? type,
+        bool recursive,
+        CancellationToken cancellationToken = default)
+    {
+        var directories = ResolveListDirectoryPaths(path);
+        foreach (var directory in directories)
+        {
+            var rootFolder = await _assets.ResolveFolderAsync(
+                directory,
+                cancellationToken);
+            if (rootFolder is null)
+                continue;
+            if (recursive)
+                await EnsureFolderTreeLoadedAsync(rootFolder, cancellationToken);
+            else
+                await _assets.EnsureFolderLoadedAsync(rootFolder.Id, cancellationToken);
+        }
+
+        return _assets.Assets.Values
+            .Where(asset => directories.Any(directory =>
+                MatchesDirectory(asset, directory, recursive)))
+            .Where(asset => string.IsNullOrWhiteSpace(type) || MatchesType(asset, type))
+            .OrderBy(asset => GetSourcePath(asset), PathComparer)
+            .Select(asset => BuildSnapshot(asset, includeProperties: false))
+            .ToArray();
+    }
+
+    IReadOnlyList<string> ResolveListDirectoryPaths(string? path)
+    {
+        if (Path.IsPathRooted(path))
+            return [Path.GetFullPath(path)];
+
+        var relativePath = path?.Trim() ?? string.Empty;
+        var contentRoots = _assets.Folders
+            .Where(folder => folder.ParentFolderId == -1)
+            .Select(folder => folder.FullPath)
+            .Append(_assets.CurrentProjectRootPath)
+            .Where(root => !string.IsNullOrWhiteSpace(root))
+            .Distinct(PathComparer)
+            .ToArray();
+        return contentRoots
+            .Select(root => string.IsNullOrEmpty(relativePath)
+                ? Path.GetFullPath(root)
+                : Path.GetFullPath(relativePath, root))
+            .Distinct(PathComparer)
+            .ToArray();
+    }
+
+    public async Task<McpAssetSnapshot?> GetAsync(
+        string target,
+        CancellationToken cancellationToken = default)
+    {
+        var asset = await ResolveAssetAsync(target, cancellationToken);
+        if (asset is null)
+            return null;
+
+        await asset.EnsureMetadataLoadedAsync(cancellationToken);
+        return BuildSnapshot(asset, includeProperties: true);
+    }
+
+    public async Task<McpAssetMutationResult> ExecuteAsync(
+        bool confirm,
+        string kind,
+        string? target,
+        string? destinationFolder,
+        string? newName,
+        string? folderPath,
+        string? folderName,
+        CancellationToken cancellationToken = default)
+    {
+        if (!confirm)
+        {
+            return new McpAssetMutationResult(
+                false,
+                kind,
+                null,
+                "Asset mutations require confirm=true.");
+        }
+
+        var normalizedKind = kind.Trim().ToLowerInvariant();
+        IEditorCommand? command;
+        string? currentFileId = null;
+        switch (normalizedKind)
+        {
+            case "rename_asset":
+            case "delete_asset":
+            case "duplicate_asset":
+            case "move_asset":
+            case "reimport_asset":
+            {
+                var asset = await ResolveAssetAsync(target, cancellationToken);
+                if (asset is null)
+                    return Failure(kind, $"Asset '{target}' was not found.");
+                currentFileId = asset.FileId?.Value;
+                var destination = normalizedKind == "move_asset"
+                    ? await ResolveFolderAsync(destinationFolder, cancellationToken)
+                    : null;
+                if (normalizedKind == "move_asset" &&
+                    !string.IsNullOrWhiteSpace(destinationFolder) &&
+                    destination is null)
+                {
+                    return Failure(kind, $"Destination folder '{destinationFolder}' was not found.");
+                }
+
+                command = normalizedKind switch
+                {
+                    "rename_asset" when !string.IsNullOrWhiteSpace(newName) =>
+                        new RenameAssetCommand(asset, newName),
+                    "delete_asset" => new DeleteAssetCommand(asset),
+                    "duplicate_asset" => new DuplicateAssetCommand(asset),
+                    "move_asset" => new MoveAssetCommand(asset, destination),
+                    "reimport_asset" => new ReimportAssetCommand(asset),
+                    _ => null,
+                };
+                break;
+            }
+            case "create_folder":
+            {
+                var parent = await ResolveFolderAsync(folderPath, cancellationToken);
+                if (!string.IsNullOrWhiteSpace(folderPath) && parent is null &&
+                    !ProjectContentPathPolicy.IsSamePath(
+                        ResolveDirectoryPath(folderPath),
+                        _assets.CurrentProjectRootPath))
+                {
+                    return Failure(kind, $"Parent folder '{folderPath}' was not found.");
+                }
+                command = !string.IsNullOrWhiteSpace(folderName)
+                    ? new CreateFolderCommand(parent, folderName)
+                    : null;
+                break;
+            }
+            case "rename_folder":
+            case "delete_folder":
+            case "move_folder":
+            {
+                var folder = await ResolveFolderAsync(folderPath, cancellationToken);
+                if (folder is null)
+                    return Failure(kind, $"Folder '{folderPath}' was not found.");
+                var destination = normalizedKind == "move_folder"
+                    ? await ResolveFolderAsync(destinationFolder, cancellationToken)
+                    : null;
+                if (normalizedKind == "move_folder" &&
+                    !string.IsNullOrWhiteSpace(destinationFolder) &&
+                    destination is null)
+                {
+                    return Failure(kind, $"Destination folder '{destinationFolder}' was not found.");
+                }
+
+                command = normalizedKind switch
+                {
+                    "rename_folder" when !string.IsNullOrWhiteSpace(newName) =>
+                        new RenameFolderCommand(folder, newName),
+                    "delete_folder" => new DeleteFolderCommand(folder),
+                    "move_folder" => new MoveFolderCommand(folder, destination),
+                    _ => null,
+                };
+                break;
+            }
+            default:
+                return Failure(kind, $"Unknown asset operation '{kind}'.");
+        }
+
+        if (command is null)
+            return Failure(kind, "The asset operation arguments are incomplete.");
+
+        var context = _contextProvider.GetCurrentContext(
+            new CommandOrigin(CommandOriginKind.AI, "MCP", "External MCP Agent"),
+            new Dictionary<string, string?>
+            {
+                ["mcp"] = "true",
+                ["mcpAssetOperation"] = normalizedKind,
+            });
+        var result = await _dispatcher.DispatchAsync(
+            command,
+            context,
+            cancellationToken);
+        var resultFileId = result.Value switch
+        {
+            FileId fileId => fileId.Value,
+            string value => value,
+            _ => currentFileId,
+        };
+        _aiOperator.RecordExternalExecution(
+            $"MCP asset {normalizedKind}",
+            AIActionSafety.ConfirmRequired,
+            result.Succeeded ? AIProposalState.Executed : AIProposalState.Failed,
+            [new AIActionExecutionItem(command.Name, result.Succeeded, result.Message)],
+            result.Message);
+        return new McpAssetMutationResult(
+            result.Succeeded,
+            normalizedKind ?? kind,
+            resultFileId,
+            result.Message ?? (result.Succeeded
+                ? "Asset operation completed."
+                : "Asset operation failed."));
+    }
+
+    async Task<AssetFile?> ResolveAssetAsync(
+        string? target,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(target))
+            return null;
+
+        var normalized = target.Trim();
+        var byFileId = await _assets.ResolveAssetAsync(
+            new FileId(normalized),
+            cancellationToken);
+        if (byFileId is not null)
+            return byFileId;
+
+        foreach (var fullPath in ResolveFilePaths(normalized))
+        {
+            var directory = Path.GetDirectoryName(fullPath);
+            if (!string.IsNullOrWhiteSpace(directory))
+                await _assets.ResolveFolderAsync(directory, cancellationToken);
+            var asset = _assets.Assets.Values.FirstOrDefault(candidate =>
+                IsSamePath(candidate.AssetInfo?.FullName, fullPath) ||
+                IsSamePath(candidate.Asset?.FullName, fullPath));
+            if (asset is not null)
+                return asset;
+        }
+
+        return null;
+    }
+
+    Task<AssetFolder?> ResolveFolderAsync(
+        string? path,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return Task.FromResult<AssetFolder?>(null);
+        var fullPath = ResolveDirectoryPath(path);
+        return _assets.ResolveFolderAsync(fullPath, cancellationToken);
+    }
+
+    async Task EnsureFolderTreeLoadedAsync(
+        AssetFolder rootFolder,
+        CancellationToken cancellationToken)
+    {
+        var pending = new Queue<AssetFolder>();
+        pending.Enqueue(rootFolder);
+        while (pending.Count > 0)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var folder = pending.Dequeue();
+            await _assets.EnsureFolderLoadedAsync(folder.Id, cancellationToken);
+            foreach (var child in _assets.Folders.Where(candidate =>
+                         candidate.ParentFolderId == folder.Id))
+            {
+                pending.Enqueue(child);
+            }
+        }
+    }
+
+    McpAssetSnapshot BuildSnapshot(
+        AssetFile asset,
+        bool includeProperties)
+    {
+        IReadOnlyDictionary<string, object?>? properties = null;
+        string? yaml = null;
+        if (includeProperties && asset.AssetInfo?.Exists == true)
+        {
+            yaml = File.ReadAllText(asset.AssetInfo.FullName);
+            properties = McpYamlUtilities.ToPlainObject(
+                McpYamlUtilities.ParseMapping(yaml)) as
+                IReadOnlyDictionary<string, object?>;
+        }
+
+        return new McpAssetSnapshot(
+            asset.FileId?.Value ?? string.Empty,
+            asset.DisplayName ?? asset.Asset?.Name ?? asset.AssetInfo?.Name ?? string.Empty,
+            asset.AssetType?.Name ?? asset.GetType().Name,
+            asset.AssetInfoTypeName ?? string.Empty,
+            GetSourcePath(asset),
+            asset.AssetInfo?.FullName ?? string.Empty,
+            asset.IsReadOnly,
+            asset.IsMetadataLoaded,
+            properties,
+            yaml);
+    }
+
+    string ResolveDirectoryPath(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return Path.GetFullPath(_assets.CurrentProjectRootPath);
+        return Path.IsPathRooted(path)
+            ? Path.GetFullPath(path)
+            : Path.GetFullPath(path, _assets.CurrentProjectRootPath);
+    }
+
+    IReadOnlyList<string> ResolveFilePaths(string path)
+    {
+        if (Path.IsPathRooted(path))
+            return [Path.GetFullPath(path)];
+
+        return _assets.Folders
+            .Where(folder => folder.ParentFolderId == -1)
+            .Select(folder => folder.FullPath)
+            .Prepend(_assets.CurrentProjectRootPath)
+            .Where(root => !string.IsNullOrWhiteSpace(root))
+            .Distinct(PathComparer)
+            .Select(root => Path.GetFullPath(path, root))
+            .ToArray();
+    }
+
+    static bool MatchesDirectory(
+        AssetFile asset,
+        string directory,
+        bool recursive)
+    {
+        var assetDirectory = Path.GetDirectoryName(GetSourcePath(asset));
+        if (string.IsNullOrWhiteSpace(assetDirectory))
+            return false;
+        if (!recursive)
+            return IsSamePath(assetDirectory, directory);
+        return ProjectContentPathPolicy.IsInsideRoot(directory, assetDirectory);
+    }
+
+    static bool MatchesType(AssetFile asset, string type)
+    {
+        return string.Equals(asset.AssetType?.Name, type, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(asset.AssetInfoTypeName, type, StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(asset.GetType().Name, type, StringComparison.OrdinalIgnoreCase);
+    }
+
+    static string GetSourcePath(AssetFile asset) =>
+        asset.Asset?.FullName ?? asset.AssetInfo?.FullName ?? string.Empty;
+
+    static bool IsSamePath(string? left, string? right)
+    {
+        if (string.IsNullOrWhiteSpace(left) || string.IsNullOrWhiteSpace(right))
+            return false;
+        return ProjectContentPathPolicy.IsSamePath(left, right);
+    }
+
+    static StringComparer PathComparer => OperatingSystem.IsWindows()
+        ? StringComparer.OrdinalIgnoreCase
+        : StringComparer.Ordinal;
+
+    static McpAssetMutationResult Failure(string kind, string message) =>
+        new(false, kind, null, message);
+}

--- a/Editor/Mcp/McpEditorHostService.cs
+++ b/Editor/Mcp/McpEditorHostService.cs
@@ -1,0 +1,339 @@
+#nullable enable
+
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+using SailorEditor.Services;
+
+namespace SailorEditor.Mcp;
+
+public sealed record McpEditorHostStatus(
+    bool IsRunning,
+    int ProcessId,
+    int? Port,
+    int ConnectedClients,
+    string? DiscoveryFile,
+    string? Error);
+
+internal sealed class McpEditorHostService : IAsyncDisposable
+{
+    readonly McpEndpointDiscovery _discovery;
+    readonly McpEditorTools _tools;
+    readonly WorkspaceUiService _workspaceUi;
+    readonly ConcurrentDictionary<int, Task> _clientTasks = new();
+    readonly SemaphoreSlim _lifecycleGate = new(1, 1);
+
+    CancellationTokenSource? _lifetimeCancellation;
+    TcpListener? _listener;
+    Task? _acceptLoop;
+    McpEndpointDescriptor? _endpoint;
+    int _nextClientId;
+    int _connectedClients;
+    bool _disposed;
+
+    public McpEditorHostService(
+        McpEndpointDiscovery discovery,
+        McpEditorTools tools,
+        WorkspaceUiService workspaceUi)
+    {
+        _discovery = discovery;
+        _tools = tools;
+        _workspaceUi = workspaceUi;
+        Status = new McpEditorHostStatus(
+            false,
+            Environment.ProcessId,
+            null,
+            0,
+            null,
+            null);
+        _workspaceUi.ProjectionChanged += OnWorkspaceProjectionChanged;
+    }
+
+    public McpEditorHostStatus Status { get; private set; }
+
+    public event EventHandler? StatusChanged;
+
+    public async Task StartAsync(CancellationToken cancellationToken = default)
+    {
+        ObjectDisposedException.ThrowIf(_disposed, this);
+        await _lifecycleGate.WaitAsync(cancellationToken);
+        TcpListener? pendingListener = null;
+        try
+        {
+            if (_listener is not null)
+                return;
+
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            pendingListener = listener;
+            listener.Start();
+            var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            var endpoint = CreateEndpoint(port);
+            await _discovery.WriteAsync(endpoint, cancellationToken);
+
+            var lifetimeCancellation = new CancellationTokenSource();
+            _listener = listener;
+            _endpoint = endpoint;
+            _lifetimeCancellation = lifetimeCancellation;
+            _acceptLoop = AcceptLoopAsync(listener, lifetimeCancellation.Token);
+            pendingListener = null;
+            PublishStatus(null);
+        }
+        catch (Exception exception)
+        {
+            pendingListener?.Stop();
+            _listener?.Stop();
+            _listener = null;
+            _endpoint = null;
+            _discovery.Delete(Environment.ProcessId);
+            PublishStatus(exception.Message);
+            throw;
+        }
+        finally
+        {
+            _lifecycleGate.Release();
+        }
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken = default)
+    {
+        await _lifecycleGate.WaitAsync(cancellationToken);
+        try
+        {
+            var listener = _listener;
+            var lifetimeCancellation = _lifetimeCancellation;
+            var acceptLoop = _acceptLoop;
+            _listener = null;
+            _endpoint = null;
+            _lifetimeCancellation = null;
+            _acceptLoop = null;
+
+            if (listener is null)
+                return;
+
+            await lifetimeCancellation!.CancelAsync();
+            listener.Stop();
+            if (acceptLoop is not null)
+            {
+                try
+                {
+                    await acceptLoop.WaitAsync(cancellationToken);
+                }
+                catch (OperationCanceledException) when (lifetimeCancellation.IsCancellationRequested)
+                {
+                }
+                catch (SocketException) when (lifetimeCancellation.IsCancellationRequested)
+                {
+                }
+            }
+
+            var clients = _clientTasks.Values.ToArray();
+            if (clients.Length > 0)
+            {
+                try
+                {
+                    await Task.WhenAll(clients).WaitAsync(cancellationToken);
+                }
+                catch (OperationCanceledException) when (lifetimeCancellation.IsCancellationRequested)
+                {
+                }
+            }
+
+            lifetimeCancellation.Dispose();
+            _discovery.Delete(Environment.ProcessId);
+            PublishStatus(null);
+        }
+        finally
+        {
+            _lifecycleGate.Release();
+        }
+    }
+
+    async Task AcceptLoopAsync(
+        TcpListener listener,
+        CancellationToken cancellationToken)
+    {
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            TcpClient client;
+            try
+            {
+                client = await listener.AcceptTcpClientAsync(cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (SocketException) when (cancellationToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            var clientId = Interlocked.Increment(ref _nextClientId);
+            var task = HandleClientSafelyAsync(client, cancellationToken);
+            _clientTasks[clientId] = task;
+            _ = task.ContinueWith(
+                completedTask => _clientTasks.TryRemove(clientId, out _),
+                CancellationToken.None,
+                TaskContinuationOptions.ExecuteSynchronously,
+                TaskScheduler.Default);
+        }
+    }
+
+    async Task HandleClientSafelyAsync(
+        TcpClient client,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await HandleClientAsync(client, cancellationToken);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                "Sailor Editor MCP client connection failed: " +
+                exception.Message);
+        }
+    }
+
+    async Task HandleClientAsync(
+        TcpClient client,
+        CancellationToken cancellationToken)
+    {
+        using (client)
+        await using (var stream = client.GetStream())
+        {
+            var endpoint = _endpoint;
+            if (endpoint is null)
+            {
+                return;
+            }
+
+            using var handshakeCancellation =
+                CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            handshakeCancellation.CancelAfter(TimeSpan.FromSeconds(10));
+            try
+            {
+                if (!await McpLoopbackAuthentication.ValidateRequestAsync(
+                        stream,
+                        endpoint.AuthenticationToken,
+                        handshakeCancellation.Token))
+                {
+                    return;
+                }
+            }
+            catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+            {
+                return;
+            }
+
+            Interlocked.Increment(ref _connectedClients);
+            PublishStatus(null);
+            try
+            {
+                await using var server = McpServer.Create(
+                    new StreamServerTransport(
+                        stream,
+                        stream,
+                        $"SailorEditor-{Environment.ProcessId}"),
+                    new McpServerOptions
+                    {
+                        ServerInfo = new Implementation
+                        {
+                            Name = "SailorEditor",
+                            Version = "1.0.0",
+                        },
+                        ToolCollection = [.. _tools.CreateTools()],
+                    });
+                await server.RunAsync(cancellationToken);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _connectedClients);
+                PublishStatus(null);
+            }
+        }
+    }
+
+    McpEndpointDescriptor CreateEndpoint(int port)
+    {
+        var projection = _workspaceUi.Projection;
+        return new McpEndpointDescriptor(
+            McpEndpointDiscovery.CurrentProtocolVersion,
+            Process.GetCurrentProcess().Id,
+            port,
+            McpEndpointDiscovery.CreateAuthenticationToken(),
+            projection.Mode.ToString(),
+            projection.HasActiveWorkspace
+                ? projection.ActiveWorkspacePath
+                : projection.ActiveRootPath,
+            DateTimeOffset.UtcNow);
+    }
+
+    void OnWorkspaceProjectionChanged(object? sender, EventArgs eventArgs)
+    {
+        _ = RefreshEndpointAsync();
+    }
+
+    async Task RefreshEndpointAsync()
+    {
+        await _lifecycleGate.WaitAsync();
+        try
+        {
+            var endpoint = _endpoint;
+            if (endpoint is null)
+                return;
+
+            var projection = _workspaceUi.Projection;
+            var updated = endpoint with
+            {
+                ProjectMode = projection.Mode.ToString(),
+                WorkspacePath = projection.HasActiveWorkspace
+                    ? projection.ActiveWorkspacePath
+                    : projection.ActiveRootPath,
+            };
+            _endpoint = updated;
+            await _discovery.WriteAsync(updated);
+            PublishStatus(null);
+        }
+        catch (Exception exception)
+        {
+            PublishStatus(exception.Message);
+        }
+        finally
+        {
+            _lifecycleGate.Release();
+        }
+    }
+
+    void PublishStatus(string? error)
+    {
+        var endpoint = _endpoint;
+        Status = new McpEditorHostStatus(
+            endpoint is not null,
+            Environment.ProcessId,
+            endpoint?.Port,
+            Volatile.Read(ref _connectedClients),
+            endpoint is null
+                ? null
+                : _discovery.GetDescriptorPath(endpoint.ProcessId),
+            error);
+        StatusChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_disposed)
+            return;
+
+        _disposed = true;
+        _workspaceUi.ProjectionChanged -= OnWorkspaceProjectionChanged;
+        await StopAsync();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/Editor/Mcp/McpEditorTools.cs
+++ b/Editor/Mcp/McpEditorTools.cs
@@ -1,0 +1,405 @@
+#nullable enable
+
+using ModelContextProtocol.Server;
+using SailorEditor.AI;
+using SailorEditor.Commands;
+using SailorEditor.Services;
+using SailorEditor.Workspace;
+
+namespace SailorEditor.Mcp;
+
+public sealed record McpEditorStateSnapshot(
+    string ProjectMode,
+    string ProjectName,
+    string ProjectRoot,
+    string? WorldId,
+    string EngineState,
+    bool IsPlayMode,
+    IReadOnlyList<string> SelectionIds,
+    long WorkspaceEpoch,
+    int UndoCount,
+    int RedoCount);
+
+internal sealed class McpEditorTools
+{
+    readonly IEditorThreadDispatcher _editorThread;
+    readonly IAIEditorContextProvider _contextProvider;
+    readonly WorkspaceUiService _workspaceUi;
+    readonly EngineService _engine;
+    readonly ICommandHistoryService _history;
+    readonly AIOperatorService _aiOperator;
+    readonly McpSceneSnapshotBuilder _sceneSnapshots;
+    readonly McpSceneBatchExecutor _sceneBatch;
+    readonly McpAssetOperations _assetOperations;
+    readonly McpWorkspaceOperations _workspaceOperations;
+
+    public McpEditorTools(
+        IEditorThreadDispatcher editorThread,
+        IAIEditorContextProvider contextProvider,
+        WorkspaceUiService workspaceUi,
+        EngineService engine,
+        ICommandHistoryService history,
+        AIOperatorService aiOperator,
+        McpSceneSnapshotBuilder sceneSnapshots,
+        McpSceneBatchExecutor sceneBatch,
+        McpAssetOperations assetOperations,
+        McpWorkspaceOperations workspaceOperations)
+    {
+        _editorThread = editorThread;
+        _contextProvider = contextProvider;
+        _workspaceUi = workspaceUi;
+        _engine = engine;
+        _history = history;
+        _aiOperator = aiOperator;
+        _sceneSnapshots = sceneSnapshots;
+        _sceneBatch = sceneBatch;
+        _assetOperations = assetOperations;
+        _workspaceOperations = workspaceOperations;
+    }
+
+    public McpServerTool[] CreateTools() =>
+    [
+        McpServerTool.Create(
+            (CancellationToken cancellationToken) =>
+                GetEditorStateAsync(cancellationToken),
+            new()
+            {
+                Name = "sailor_editor_get_state",
+                Description =
+                    "Get the active Sailor Editor project, engine, world, selection and undo state.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (bool includeYaml, CancellationToken cancellationToken) =>
+                GetSceneHierarchyAsync(includeYaml, cancellationToken),
+            new()
+            {
+                Name = "sailor_scene_get_hierarchy",
+                Description =
+                    "Get the current scene hierarchy with GameObject/component instance IDs. " +
+                    "Set includeYaml=true only when the full native scene document is needed.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (string instanceId, CancellationToken cancellationToken) =>
+                GetSceneObjectAsync(instanceId, cancellationToken),
+            new()
+            {
+                Name = "sailor_scene_get_object",
+                Description = "Get one current GameObject and its components by instance ID.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (CancellationToken cancellationToken) =>
+                GetComponentTypesAsync(cancellationToken),
+            new()
+            {
+                Name = "sailor_types_list_components",
+                Description =
+                    "List canonical reflected component types, editable properties, defaults, enums and object-reference target types.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (bool confirm,
+                long? expectedWorkspaceEpoch,
+                string? description,
+                McpSceneOperation[] operations,
+                CancellationToken cancellationToken) =>
+                ApplySceneBatchAsync(
+                    confirm,
+                    expectedWorkspaceEpoch,
+                    description,
+                    operations,
+                    cancellationToken),
+            new()
+            {
+                Name = "sailor_scene_apply_batch",
+                Description =
+                    "Atomically mutate the current scene through normal Editor commands. " +
+                    "Supported kinds: create_game_object, update_game_object, destroy_game_object, " +
+                    "reparent_game_object, add_component, update_component, remove_component, " +
+                    "reset_component, select, focus. References beginning with '$' resolve an earlier operation alias. " +
+                    "Pass the workspace epoch returned by sailor_editor_get_state to reject stale plans. " +
+                    "Mutations require confirm=true and successful batches are one undo entry.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (bool confirm, CancellationToken cancellationToken) =>
+                SaveSceneAsync(confirm, cancellationToken),
+            new()
+            {
+                Name = "sailor_scene_save",
+                Description =
+                    "Save the current scene through the normal Editor save command. " +
+                    "An untitled scene opens the standard save dialog. Requires confirm=true.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (bool confirm,
+                string configuration,
+                bool configure,
+                CancellationToken cancellationToken) =>
+                BuildWorkspaceAsync(
+                    confirm,
+                    configuration,
+                    configure,
+                    cancellationToken),
+            new()
+            {
+                Name = "sailor_workspace_build",
+                Description =
+                    "Configure and build the active workspace generated CMake project. " +
+                    "Configuration may be Debug, Release, RelWithDebInfo or MinSizeRel. Requires confirm=true.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (bool confirm, CancellationToken cancellationToken) =>
+                UndoAsync(confirm, cancellationToken),
+            new()
+            {
+                Name = "sailor_scene_undo",
+                Description = "Undo the latest Editor history entry. Requires confirm=true.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (bool confirm, CancellationToken cancellationToken) =>
+                RedoAsync(confirm, cancellationToken),
+            new()
+            {
+                Name = "sailor_scene_redo",
+                Description = "Redo the latest Editor history entry. Requires confirm=true.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (string? path,
+                string? type,
+                bool recursive,
+                CancellationToken cancellationToken) =>
+                ListAssetsAsync(path, type, recursive, cancellationToken),
+            new()
+            {
+                Name = "sailor_assets_list",
+                Description =
+                    "List assets known to the Editor cache under a path. " +
+                    "Relative paths are searched in every mounted Content root; an empty path searches all roots.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (string target, CancellationToken cancellationToken) =>
+                GetAssetAsync(target, cancellationToken),
+            new()
+            {
+                Name = "sailor_assets_get",
+                Description =
+                    "Resolve an asset by fileId or source path, lazily load its typed asset info and return its properties.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (bool confirm,
+                string kind,
+                string? target,
+                string? destinationFolder,
+                string? newName,
+                string? folderPath,
+                string? folderName,
+                CancellationToken cancellationToken) =>
+                ApplyAssetOperationAsync(
+                    confirm,
+                    kind,
+                    target,
+                    destinationFolder,
+                    newName,
+                    folderPath,
+                    folderName,
+                    cancellationToken),
+            new()
+            {
+                Name = "sailor_assets_apply",
+                Description =
+                    "Run one normal Editor asset command. Supported kinds: rename_asset, delete_asset, " +
+                    "duplicate_asset, move_asset, reimport_asset, create_folder, rename_folder, " +
+                    "delete_folder, move_folder. Mutations require confirm=true.",
+                UseStructuredContent = true,
+            }),
+    ];
+
+    public Task<McpEditorStateSnapshot> GetEditorStateAsync(
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () =>
+            {
+                var projection = _workspaceUi.Projection;
+                var context = _contextProvider.GetCurrentContext();
+                return Task.FromResult(new McpEditorStateSnapshot(
+                    projection.Mode.ToString(),
+                    projection.ActiveProjectName,
+                    projection.ActiveRootPath,
+                    context.ActiveWorldId,
+                    _engine.State.ToString(),
+                    context.IsPlayMode,
+                    context.SelectionIds,
+                    _history.WorkspaceEpoch,
+                    _history.UndoCount,
+                    _history.RedoCount));
+            },
+            cancellationToken);
+
+    public Task<McpSceneHierarchySnapshot> GetSceneHierarchyAsync(
+        bool includeYaml,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () => Task.FromResult(_sceneSnapshots.Build(includeYaml)),
+            cancellationToken);
+
+    public Task<McpGameObjectSnapshot?> GetSceneObjectAsync(
+        string instanceId,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () => Task.FromResult(_sceneSnapshots.BuildObject(instanceId)),
+            cancellationToken);
+
+    public Task<IReadOnlyList<McpComponentTypeSchema>> GetComponentTypesAsync(
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () => Task.FromResult(_sceneSnapshots.BuildComponentSchemas()),
+            cancellationToken);
+
+    public Task<McpSceneBatchResult> ApplySceneBatchAsync(
+        bool confirm,
+        long? expectedWorkspaceEpoch,
+        string? description,
+        IReadOnlyList<McpSceneOperation> operations,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () => _sceneBatch.ExecuteAsync(
+                new McpSceneBatchRequest(
+                    confirm,
+                    expectedWorkspaceEpoch,
+                    description,
+                    operations ?? Array.Empty<McpSceneOperation>()),
+                cancellationToken),
+            cancellationToken);
+
+    public Task<object> UndoAsync(
+        bool confirm,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync<object>(
+            async () =>
+            {
+                if (!confirm)
+                    return new { succeeded = false, message = "Undo requires confirm=true.", undoCount = _history.UndoCount, redoCount = _history.RedoCount };
+                var succeeded = await _history.UndoAsync(
+                    new CommandOrigin(CommandOriginKind.AI, "MCP", "External MCP Agent"),
+                    cancellationToken);
+                RecordHistoryExecution("MCP undo", succeeded);
+                return new { succeeded, message = succeeded ? "Undo completed." : "Nothing was undone.", undoCount = _history.UndoCount, redoCount = _history.RedoCount };
+            },
+            cancellationToken);
+
+    public Task<object> RedoAsync(
+        bool confirm,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync<object>(
+            async () =>
+            {
+                if (!confirm)
+                    return new { succeeded = false, message = "Redo requires confirm=true.", undoCount = _history.UndoCount, redoCount = _history.RedoCount };
+                var succeeded = await _history.RedoAsync(
+                    new CommandOrigin(CommandOriginKind.AI, "MCP", "External MCP Agent"),
+                    cancellationToken);
+                RecordHistoryExecution("MCP redo", succeeded);
+                return new { succeeded, message = succeeded ? "Redo completed." : "Nothing was redone.", undoCount = _history.UndoCount, redoCount = _history.RedoCount };
+            },
+            cancellationToken);
+
+    void RecordHistoryExecution(string title, bool succeeded) =>
+        _aiOperator.RecordExternalExecution(
+            title,
+            AIActionSafety.ConfirmRequired,
+            succeeded ? AIProposalState.Executed : AIProposalState.Failed,
+            [new AIActionExecutionItem(title, succeeded, null)],
+            succeeded ? title + " completed." : title + " did not change history.");
+
+    public Task<IReadOnlyList<McpAssetSnapshot>> ListAssetsAsync(
+        string? path,
+        string? type,
+        bool recursive,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () => _assetOperations.ListAsync(
+                path,
+                type,
+                recursive,
+                cancellationToken),
+            cancellationToken);
+
+    public Task<McpAssetSnapshot?> GetAssetAsync(
+        string target,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () => _assetOperations.GetAsync(target, cancellationToken),
+            cancellationToken);
+
+    public Task<McpAssetMutationResult> ApplyAssetOperationAsync(
+        bool confirm,
+        string kind,
+        string? target,
+        string? destinationFolder,
+        string? newName,
+        string? folderPath,
+        string? folderName,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () => _assetOperations.ExecuteAsync(
+                confirm,
+                kind,
+                target,
+                destinationFolder,
+                newName,
+                folderPath,
+                folderName,
+                cancellationToken),
+            cancellationToken);
+
+    public Task<object> SaveSceneAsync(
+        bool confirm,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync<object>(
+            async () =>
+            {
+                var result = await _workspaceOperations.SaveSceneAsync(
+                    confirm,
+                    cancellationToken);
+                return new
+                {
+                    result.Succeeded,
+                    result.Message,
+                    result.Value,
+                };
+            },
+            cancellationToken);
+
+    public Task<object> BuildWorkspaceAsync(
+        bool confirm,
+        string configuration,
+        bool configure,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync<object>(
+            async () =>
+            {
+                var result = await _workspaceOperations.BuildWorkspaceAsync(
+                    confirm,
+                    configuration,
+                    configure,
+                    cancellationToken);
+                if (result.Value is WorkspaceBuildResult buildResult)
+                    return buildResult;
+
+                return new
+                {
+                    result.Succeeded,
+                    result.Message,
+                };
+            },
+            cancellationToken);
+}

--- a/Editor/Mcp/McpEndpointDiscovery.cs
+++ b/Editor/Mcp/McpEndpointDiscovery.cs
@@ -1,0 +1,300 @@
+#nullable enable
+
+using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text.Json;
+
+namespace SailorEditor.Mcp;
+
+public sealed record McpEndpointDescriptor(
+    int ProtocolVersion,
+    int ProcessId,
+    int Port,
+    string AuthenticationToken,
+    string ProjectMode,
+    string? WorkspacePath,
+    DateTimeOffset StartedAtUtc);
+
+public sealed record McpEndpointSelection(
+    McpEndpointDescriptor? Endpoint,
+    string? Error)
+{
+    public bool Succeeded => Endpoint is not null;
+}
+
+public sealed class McpEndpointDiscovery
+{
+    public const int CurrentProtocolVersion = 1;
+    const string DescriptorExtension = ".json";
+
+    static readonly JsonSerializerOptions s_jsonOptions = new(JsonSerializerDefaults.Web)
+    {
+        WriteIndented = true,
+    };
+
+    readonly string _directoryPath;
+
+    public McpEndpointDiscovery(string? directoryPath = null)
+    {
+        _directoryPath = string.IsNullOrWhiteSpace(directoryPath)
+            ? GetDefaultDirectoryPath()
+            : Path.GetFullPath(directoryPath);
+    }
+
+    public string DirectoryPath => _directoryPath;
+
+    public string GetDescriptorPath(int processId) =>
+        Path.Combine(_directoryPath, processId + DescriptorExtension);
+
+    public static string CreateAuthenticationToken() =>
+        Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+
+    public async Task WriteAsync(
+        McpEndpointDescriptor descriptor,
+        CancellationToken cancellationToken = default)
+    {
+        Validate(descriptor);
+        Directory.CreateDirectory(_directoryPath);
+        RestrictDirectoryPermissions(_directoryPath);
+
+        var destinationPath = GetDescriptorPath(descriptor.ProcessId);
+        var temporaryPath = destinationPath + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        try
+        {
+            var json = JsonSerializer.Serialize(descriptor, s_jsonOptions);
+            await File.WriteAllTextAsync(temporaryPath, json, cancellationToken);
+            RestrictFilePermissions(temporaryPath);
+            File.Move(temporaryPath, destinationPath, true);
+            RestrictFilePermissions(destinationPath);
+        }
+        finally
+        {
+            TryDelete(temporaryPath);
+        }
+    }
+
+    public void Delete(int processId) => TryDelete(GetDescriptorPath(processId));
+
+    public IReadOnlyList<McpEndpointDescriptor> ReadAvailable()
+    {
+        if (!Directory.Exists(_directoryPath))
+            return Array.Empty<McpEndpointDescriptor>();
+
+        var endpoints = new List<McpEndpointDescriptor>();
+        foreach (var path in Directory.EnumerateFiles(
+                     _directoryPath,
+                     "*" + DescriptorExtension,
+                     SearchOption.TopDirectoryOnly))
+        {
+            McpEndpointDescriptor? descriptor = null;
+            try
+            {
+                descriptor = JsonSerializer.Deserialize<McpEndpointDescriptor>(
+                    File.ReadAllText(path),
+                    s_jsonOptions);
+            }
+            catch (JsonException)
+            {
+            }
+            catch (IOException)
+            {
+            }
+            catch (UnauthorizedAccessException)
+            {
+            }
+
+            if (descriptor is null ||
+                descriptor.ProtocolVersion != CurrentProtocolVersion ||
+                descriptor.Port is < 1 or > 65535 ||
+                string.IsNullOrWhiteSpace(descriptor.AuthenticationToken) ||
+                !IsEndpointProcessAlive(descriptor))
+            {
+                TryDelete(path);
+                continue;
+            }
+
+            endpoints.Add(descriptor);
+        }
+
+        return endpoints
+            .OrderByDescending(endpoint => endpoint.StartedAtUtc)
+            .ThenByDescending(endpoint => endpoint.ProcessId)
+            .ToArray();
+    }
+
+    public McpEndpointSelection Select(
+        int? processId = null,
+        string? workspacePath = null)
+    {
+        var candidates = ReadAvailable().AsEnumerable();
+        if (processId is not null)
+            candidates = candidates.Where(endpoint => endpoint.ProcessId == processId.Value);
+
+        if (!string.IsNullOrWhiteSpace(workspacePath))
+        {
+            var normalizedWorkspace = NormalizePath(workspacePath);
+            candidates = candidates.Where(endpoint =>
+                string.Equals(
+                    NormalizePath(endpoint.WorkspacePath),
+                    normalizedWorkspace,
+                    PathComparison));
+        }
+
+        var matches = candidates.ToArray();
+        if (matches.Length == 1)
+            return new McpEndpointSelection(matches[0], null);
+
+        if (matches.Length == 0)
+        {
+            var selector = processId is not null
+                ? $" PID {processId.Value}"
+                : !string.IsNullOrWhiteSpace(workspacePath)
+                    ? $" workspace '{Path.GetFullPath(workspacePath)}'"
+                    : string.Empty;
+            return new McpEndpointSelection(
+                null,
+                "No running Sailor Editor endpoint matches" + selector + ".");
+        }
+
+        return new McpEndpointSelection(
+            null,
+            "Multiple Sailor Editor instances are running. Pass --pid or --workspace explicitly.");
+    }
+
+    static string GetDefaultDirectoryPath()
+    {
+        var configuredPath = Environment.GetEnvironmentVariable(
+            "SAILOR_EDITOR_MCP_DISCOVERY");
+        if (!string.IsNullOrWhiteSpace(configuredPath))
+        {
+            return Path.GetFullPath(configuredPath);
+        }
+
+        // MacCatalyst maps LocalApplicationData into its app container while the
+        // stdio bridge is a normal console process. Use a stable per-user path so
+        // both processes discover the same endpoint.
+        var basePath = OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst()
+            ? Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".sailor")
+            : Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                "Sailor");
+        return Path.Combine(basePath, "Editor", "Mcp");
+    }
+
+    static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+
+    static string? NormalizePath(string? path) =>
+        string.IsNullOrWhiteSpace(path)
+            ? null
+            : Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+
+    static bool IsEndpointProcessAlive(McpEndpointDescriptor descriptor)
+    {
+        if (descriptor.ProcessId <= 0)
+            return false;
+
+        try
+        {
+            using var process = Process.GetProcessById(descriptor.ProcessId);
+            if (process.HasExited)
+                return false;
+
+            // A live, unrelated process may have reused the PID of a crashed
+            // Editor. Its start time must not be newer than the descriptor.
+            return process.StartTime.ToUniversalTime() <=
+                descriptor.StartedAtUtc.UtcDateTime.AddSeconds(5);
+        }
+        catch (ArgumentException)
+        {
+            return false;
+        }
+        catch (InvalidOperationException)
+        {
+            return false;
+        }
+        catch (System.ComponentModel.Win32Exception)
+        {
+            return false;
+        }
+        catch (PlatformNotSupportedException)
+        {
+            return true;
+        }
+    }
+
+    static void Validate(McpEndpointDescriptor descriptor)
+    {
+        if (descriptor.ProtocolVersion != CurrentProtocolVersion)
+            throw new ArgumentOutOfRangeException(nameof(descriptor), "Unsupported MCP endpoint protocol version.");
+        if (descriptor.ProcessId <= 0)
+            throw new ArgumentOutOfRangeException(nameof(descriptor), "A valid process id is required.");
+        if (descriptor.Port is < 1 or > 65535)
+            throw new ArgumentOutOfRangeException(nameof(descriptor), "A valid loopback port is required.");
+        if (string.IsNullOrWhiteSpace(descriptor.AuthenticationToken))
+            throw new ArgumentException("An authentication token is required.", nameof(descriptor));
+    }
+
+    static void RestrictDirectoryPermissions(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead |
+                UnixFileMode.UserWrite |
+                UnixFileMode.UserExecute);
+        }
+        catch (PlatformNotSupportedException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    static void RestrictFilePermissions(string path)
+    {
+        if (OperatingSystem.IsWindows())
+            return;
+
+        try
+        {
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite);
+        }
+        catch (PlatformNotSupportedException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+        catch (IOException)
+        {
+        }
+    }
+
+    static void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+        }
+        catch (UnauthorizedAccessException)
+        {
+        }
+    }
+}

--- a/Editor/Mcp/McpLoopbackAuthentication.cs
+++ b/Editor/Mcp/McpLoopbackAuthentication.cs
@@ -1,0 +1,82 @@
+#nullable enable
+
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+
+namespace SailorEditor.Mcp;
+
+public static class McpLoopbackAuthentication
+{
+    const int MaximumHandshakeBytes = 4096;
+
+    sealed record AuthenticationRequest(string Token);
+
+    public static async Task WriteRequestAsync(
+        Stream stream,
+        string authenticationToken,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        if (string.IsNullOrWhiteSpace(authenticationToken))
+            throw new ArgumentException("An authentication token is required.", nameof(authenticationToken));
+
+        var payload = JsonSerializer.SerializeToUtf8Bytes(
+            new AuthenticationRequest(authenticationToken));
+        await stream.WriteAsync(payload, cancellationToken);
+        await stream.WriteAsync("\n"u8.ToArray(), cancellationToken);
+        await stream.FlushAsync(cancellationToken);
+    }
+
+    public static async Task<bool> ValidateRequestAsync(
+        Stream stream,
+        string expectedAuthenticationToken,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        if (string.IsNullOrWhiteSpace(expectedAuthenticationToken))
+            return false;
+
+        var payload = await ReadLineAsync(stream, cancellationToken);
+        if (payload is null)
+            return false;
+
+        AuthenticationRequest? request;
+        try
+        {
+            request = JsonSerializer.Deserialize<AuthenticationRequest>(payload);
+        }
+        catch (JsonException)
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(request?.Token))
+            return false;
+
+        var expected = Encoding.UTF8.GetBytes(expectedAuthenticationToken);
+        var actual = Encoding.UTF8.GetBytes(request.Token);
+        return expected.Length == actual.Length &&
+            CryptographicOperations.FixedTimeEquals(expected, actual);
+    }
+
+    static async Task<byte[]?> ReadLineAsync(
+        Stream stream,
+        CancellationToken cancellationToken)
+    {
+        using var payload = new MemoryStream();
+        var oneByte = new byte[1];
+        while (payload.Length < MaximumHandshakeBytes)
+        {
+            var read = await stream.ReadAsync(oneByte, cancellationToken);
+            if (read == 0)
+                return null;
+            if (oneByte[0] == (byte)'\n')
+                return payload.ToArray();
+            if (oneByte[0] != (byte)'\r')
+                payload.WriteByte(oneByte[0]);
+        }
+
+        return null;
+    }
+}

--- a/Editor/Mcp/McpSceneBatchExecutor.cs
+++ b/Editor/Mcp/McpSceneBatchExecutor.cs
@@ -1,0 +1,692 @@
+#nullable enable
+
+using SailorEditor.AI;
+using SailorEditor.Commands;
+using SailorEditor.Services;
+using SailorEditor.ViewModels;
+using SailorEngine;
+using ViewModelComponent = SailorEditor.ViewModels.Component;
+
+namespace SailorEditor.Mcp;
+
+internal sealed class McpSceneBatchExecutor
+{
+    readonly ICommandDispatcher _dispatcher;
+    readonly ITransactionScopeFactory _transactions;
+    readonly IActionContextProvider _contextProvider;
+    readonly ICommandHistoryService _history;
+    readonly WorldService _world;
+    readonly EngineService _engine;
+    readonly AssetsService _assets;
+    readonly AIOperatorService _aiOperator;
+
+    public McpSceneBatchExecutor(
+        ICommandDispatcher dispatcher,
+        ITransactionScopeFactory transactions,
+        IActionContextProvider contextProvider,
+        ICommandHistoryService history,
+        WorldService world,
+        EngineService engine,
+        AssetsService assets,
+        AIOperatorService aiOperator)
+    {
+        _dispatcher = dispatcher;
+        _transactions = transactions;
+        _contextProvider = contextProvider;
+        _history = history;
+        _world = world;
+        _engine = engine;
+        _assets = assets;
+        _aiOperator = aiOperator;
+    }
+
+    public async Task<McpSceneBatchResult> ExecuteAsync(
+        McpSceneBatchRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (!request.Confirm)
+        {
+            return new McpSceneBatchResult(
+                false,
+                "Scene mutations require confirm=true.",
+                _history.WorkspaceEpoch,
+                Array.Empty<McpSceneOperationResult>());
+        }
+        if (request.ExpectedWorkspaceEpoch is { } expectedEpoch &&
+            expectedEpoch != _history.WorkspaceEpoch)
+        {
+            return new McpSceneBatchResult(
+                false,
+                $"Stale workspace epoch {expectedEpoch}; current epoch is {_history.WorkspaceEpoch}. " +
+                    "Refresh editor state before retrying the batch.",
+                _history.WorkspaceEpoch,
+                Array.Empty<McpSceneOperationResult>());
+        }
+        if (request.Operations is null || request.Operations.Count == 0)
+        {
+            return new McpSceneBatchResult(
+                false,
+                "At least one scene operation is required.",
+                _history.WorkspaceEpoch,
+                Array.Empty<McpSceneOperationResult>());
+        }
+
+        var description = string.IsNullOrWhiteSpace(request.Description)
+            ? $"MCP scene batch ({request.Operations.Count} operations)"
+            : request.Description.Trim();
+        var metadata = new Dictionary<string, string?>
+        {
+            ["mcp"] = "true",
+            ["mcpOperationCount"] = request.Operations.Count.ToString(),
+            ["mcpDescription"] = description,
+        };
+        var context = _contextProvider.GetCurrentContext(
+            new CommandOrigin(CommandOriginKind.AI, "MCP", "External MCP Agent"),
+            metadata);
+        var aliases = new Dictionary<string, InstanceId>(StringComparer.Ordinal);
+        var results = new List<McpSceneOperationResult>(request.Operations.Count);
+        var auditItems = new List<AIActionExecutionItem>(request.Operations.Count);
+
+        try
+        {
+            await using var transaction = await _transactions.BeginAsync(
+                description,
+                context,
+                cancellationToken);
+            for (var index = 0; index < request.Operations.Count; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var operation = request.Operations[index];
+                var result = await ExecuteOperationAsync(
+                    operation,
+                    aliases,
+                    context,
+                    cancellationToken);
+                results.Add(new McpSceneOperationResult(
+                    index,
+                    operation.Kind,
+                    result.Succeeded,
+                    (result.Value as InstanceId)?.Value,
+                    operation.Alias,
+                    result.Message));
+                auditItems.Add(new AIActionExecutionItem(
+                    operation.Kind,
+                    result.Succeeded,
+                    result.Message));
+                if (!result.Succeeded)
+                {
+                    var message = result.Message ??
+                        $"Scene operation {index} ('{operation.Kind}') failed.";
+                    _aiOperator.RecordExternalExecution(
+                        description,
+                        AIActionSafety.ConfirmRequired,
+                        AIProposalState.Failed,
+                        auditItems,
+                        message);
+                    return new McpSceneBatchResult(
+                        false,
+                        message + " The batch was rolled back.",
+                        _history.WorkspaceEpoch,
+                        results);
+                }
+
+                if (!string.IsNullOrWhiteSpace(operation.Alias) &&
+                    result.Value is InstanceId instanceId)
+                {
+                    if (!aliases.TryAdd(operation.Alias, instanceId))
+                    {
+                        var message = $"Duplicate operation alias '{operation.Alias}'.";
+                        auditItems.Add(new AIActionExecutionItem(
+                            operation.Kind,
+                            false,
+                            message));
+                        _aiOperator.RecordExternalExecution(
+                            description,
+                            AIActionSafety.ConfirmRequired,
+                            AIProposalState.Failed,
+                            auditItems,
+                            message);
+                        return new McpSceneBatchResult(
+                            false,
+                            message + " The batch was rolled back.",
+                            _history.WorkspaceEpoch,
+                            results);
+                    }
+                }
+            }
+
+            await transaction.CompleteAsync(cancellationToken);
+            _aiOperator.RecordExternalExecution(
+                description,
+                AIActionSafety.ConfirmRequired,
+                AIProposalState.Executed,
+                auditItems,
+                description);
+            return new McpSceneBatchResult(
+                true,
+                description,
+                _history.WorkspaceEpoch,
+                results);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            throw;
+        }
+        catch (Exception exception)
+        {
+            _aiOperator.RecordExternalExecution(
+                description,
+                AIActionSafety.ConfirmRequired,
+                AIProposalState.Failed,
+                auditItems,
+                exception.Message);
+            return new McpSceneBatchResult(
+                false,
+                exception.Message + " The batch was rolled back.",
+                _history.WorkspaceEpoch,
+                results);
+        }
+    }
+
+    async Task<CommandResult> ExecuteOperationAsync(
+        McpSceneOperation operation,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        var kind = operation.Kind?.Trim().ToLowerInvariant();
+        return kind switch
+        {
+            "create_game_object" => await CreateGameObjectAsync(
+                operation,
+                aliases,
+                context,
+                cancellationToken),
+            "update_game_object" => await UpdateGameObjectAsync(
+                operation,
+                aliases,
+                context,
+                cancellationToken),
+            "destroy_game_object" => await DispatchForGameObjectAsync(
+                operation,
+                aliases,
+                context,
+                gameObject => new DestroyGameObjectCommand(gameObject),
+                cancellationToken),
+            "reparent_game_object" => await ReparentGameObjectAsync(
+                operation,
+                aliases,
+                context,
+                cancellationToken),
+            "add_component" => await AddComponentAsync(
+                operation,
+                aliases,
+                context,
+                cancellationToken),
+            "update_component" => await UpdateComponentAsync(
+                operation,
+                aliases,
+                context,
+                cancellationToken),
+            "remove_component" => await DispatchForComponentAsync(
+                operation,
+                aliases,
+                context,
+                component => new RemoveComponentCommand(component),
+                cancellationToken),
+            "reset_component" => await DispatchForComponentAsync(
+                operation,
+                aliases,
+                context,
+                component => new ResetComponentToDefaultsCommand(component),
+                cancellationToken),
+            "select" => await SelectAsync(
+                operation,
+                aliases,
+                context,
+                cancellationToken),
+            "focus" => await FocusAsync(
+                operation,
+                aliases,
+                context,
+                cancellationToken),
+            _ => CommandResult.Failure(
+                $"Unknown scene operation '{operation.Kind}'."),
+        };
+    }
+
+    async Task<CommandResult> CreateGameObjectAsync(
+        McpSceneOperation operation,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        var parentId = ResolveOptionalReference(operation.Parent, aliases);
+        if (!string.IsNullOrWhiteSpace(operation.Parent) && parentId is null)
+            return CommandResult.Failure($"Parent '{operation.Parent}' was not found.");
+
+        var created = await _dispatcher.DispatchAsync(
+            new CreateGameObjectCommand(parentId),
+            context,
+            cancellationToken);
+        if (!created.Succeeded || created.Value is not InstanceId createdId)
+            return created.Succeeded
+                ? CommandResult.Failure("CreateGameObject did not return an instance id.")
+                : created;
+
+        if (!_world.TryGetGameObject(createdId, out var gameObject))
+            return CommandResult.Failure("Created GameObject was not projected.");
+
+        var properties = new Dictionary<string, System.Text.Json.JsonElement>(
+            operation.Properties ?? new Dictionary<string, System.Text.Json.JsonElement>(),
+            StringComparer.Ordinal);
+        if (!string.IsNullOrWhiteSpace(operation.Name))
+        {
+            properties["name"] = System.Text.Json.JsonSerializer.SerializeToElement(
+                operation.Name.Trim());
+        }
+
+        if (properties.Count > 0)
+        {
+            var update = McpSceneCommandFactory.CreateGameObjectUpdate(
+                gameObject,
+                properties,
+                $"Configure {operation.Name ?? "GameObject"}");
+            var updated = await _dispatcher.DispatchAsync(
+                update,
+                context,
+                cancellationToken);
+            if (!updated.Succeeded)
+                return updated;
+        }
+
+        return CommandResult.Success(value: createdId);
+    }
+
+    async Task<CommandResult> UpdateGameObjectAsync(
+        McpSceneOperation operation,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!TryResolveGameObject(operation.Target, aliases, out var gameObject, out var error))
+            return CommandResult.Failure(error);
+
+        var properties = new Dictionary<string, System.Text.Json.JsonElement>(
+            operation.Properties ?? new Dictionary<string, System.Text.Json.JsonElement>(),
+            StringComparer.Ordinal);
+        if (!string.IsNullOrWhiteSpace(operation.Name))
+            properties["name"] = System.Text.Json.JsonSerializer.SerializeToElement(operation.Name.Trim());
+        if (properties.Count == 0)
+            return CommandResult.Failure("No GameObject properties were provided.");
+
+        var command = McpSceneCommandFactory.CreateGameObjectUpdate(
+            gameObject,
+            properties,
+            $"MCP edit {gameObject.Name}");
+        var result = await _dispatcher.DispatchAsync(command, context, cancellationToken);
+        return result.Succeeded
+            ? result with { Value = gameObject.InstanceId }
+            : result;
+    }
+
+    async Task<CommandResult> ReparentGameObjectAsync(
+        McpSceneOperation operation,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!TryResolveGameObject(operation.Target, aliases, out var child, out var error))
+            return CommandResult.Failure(error);
+
+        GameObject? parent = null;
+        if (!string.IsNullOrWhiteSpace(operation.Parent))
+        {
+            var parentId = ResolveOptionalReference(operation.Parent, aliases);
+            if (parentId is null || !_world.TryGetGameObject(parentId, out parent))
+                return CommandResult.Failure($"Parent '{operation.Parent}' was not found.");
+        }
+
+        var result = await _dispatcher.DispatchAsync(
+            new ReparentGameObjectCommand(
+                child,
+                parent,
+                operation.KeepWorldTransform),
+            context,
+            cancellationToken);
+        return result.Succeeded
+            ? result with { Value = child.InstanceId }
+            : result;
+    }
+
+    async Task<CommandResult> AddComponentAsync(
+        McpSceneOperation operation,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!TryResolveGameObject(operation.Target, aliases, out var owner, out var error))
+            return CommandResult.Failure(error);
+        if (string.IsNullOrWhiteSpace(operation.ComponentType) ||
+            !_engine.EngineTypes.IsAddableComponentType(operation.ComponentType) ||
+            !_engine.EngineTypes.TryGetComponent(operation.ComponentType, out var componentType))
+        {
+            return CommandResult.Failure(
+                $"Component type '{operation.ComponentType}' is unknown or cannot be added.");
+        }
+
+        if (operation.Properties?.Count > 0)
+        {
+            var validationError = await ValidateComponentPropertiesAsync(
+                componentType,
+                operation.Properties,
+                cancellationToken);
+            if (validationError is not null)
+                return CommandResult.Failure(validationError);
+        }
+
+        var added = await _dispatcher.DispatchAsync(
+            new AddComponentCommand(owner, operation.ComponentType),
+            context,
+            cancellationToken);
+        if (!added.Succeeded || added.Value is not InstanceId componentId)
+            return added.Succeeded
+                ? CommandResult.Failure("AddComponent did not return an instance id.")
+                : added;
+        if (!_world.TryGetComponent(componentId, out var component))
+            return CommandResult.Failure("Created component was not projected.");
+
+        if (operation.Properties?.Count > 0)
+        {
+            var update = McpSceneCommandFactory.CreateComponentUpdate(
+                component,
+                operation.Properties,
+                $"Configure {operation.ComponentType}");
+            var updated = await _dispatcher.DispatchAsync(
+                update,
+                context,
+                cancellationToken);
+            if (!updated.Succeeded)
+                return updated;
+        }
+
+        return CommandResult.Success(value: componentId);
+    }
+
+    async Task<CommandResult> UpdateComponentAsync(
+        McpSceneOperation operation,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        if (!TryResolveComponent(operation.Target, aliases, out var component, out var error))
+            return CommandResult.Failure(error);
+        if (operation.Properties is null || operation.Properties.Count == 0)
+            return CommandResult.Failure("No component properties were provided.");
+
+        var validationError = await ValidateComponentPropertiesAsync(
+            component.Typename,
+            operation.Properties,
+            cancellationToken);
+        if (validationError is not null)
+            return CommandResult.Failure(validationError);
+
+        var command = McpSceneCommandFactory.CreateComponentUpdate(
+            component,
+            operation.Properties,
+            $"MCP edit {component.Typename?.Name}");
+        var result = await _dispatcher.DispatchAsync(command, context, cancellationToken);
+        return result.Succeeded
+            ? result with { Value = component.InstanceId }
+            : result;
+    }
+
+    async Task<CommandResult> DispatchForGameObjectAsync(
+        McpSceneOperation operation,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        ActionContext context,
+        Func<GameObject, IEditorCommand> createCommand,
+        CancellationToken cancellationToken)
+    {
+        if (!TryResolveGameObject(operation.Target, aliases, out var gameObject, out var error))
+            return CommandResult.Failure(error);
+        var instanceId = gameObject.InstanceId;
+        var result = await _dispatcher.DispatchAsync(
+            createCommand(gameObject),
+            context,
+            cancellationToken);
+        return result.Succeeded
+            ? result with { Value = instanceId }
+            : result;
+    }
+
+    async Task<CommandResult> DispatchForComponentAsync(
+        McpSceneOperation operation,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        ActionContext context,
+        Func<ViewModelComponent, IEditorCommand> createCommand,
+        CancellationToken cancellationToken)
+    {
+        if (!TryResolveComponent(operation.Target, aliases, out var component, out var error))
+            return CommandResult.Failure(error);
+        var instanceId = component.InstanceId;
+        var result = await _dispatcher.DispatchAsync(
+            createCommand(component),
+            context,
+            cancellationToken);
+        return result.Succeeded
+            ? result with { Value = instanceId }
+            : result;
+    }
+
+    async Task<CommandResult> SelectAsync(
+        McpSceneOperation operation,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        var instanceId = ResolveOptionalReference(operation.Target, aliases);
+        if (!string.IsNullOrWhiteSpace(operation.Target) && instanceId is null)
+            return CommandResult.Failure($"Target '{operation.Target}' was not found.");
+        var result = await _dispatcher.DispatchAsync(
+            new SelectObjectCommand(instanceId),
+            context,
+            cancellationToken);
+        return result.Succeeded
+            ? result with { Value = instanceId }
+            : result;
+    }
+
+    async Task<CommandResult> FocusAsync(
+        McpSceneOperation operation,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        ActionContext context,
+        CancellationToken cancellationToken)
+    {
+        var instanceId = ResolveOptionalReference(operation.Target, aliases);
+        if (instanceId is null)
+            return CommandResult.Failure($"Target '{operation.Target}' was not found.");
+        var result = await _dispatcher.DispatchAsync(
+            new FocusEditorCameraCommand(instanceId),
+            context,
+            cancellationToken);
+        return result.Succeeded
+            ? result with { Value = instanceId }
+            : result;
+    }
+
+    bool TryResolveGameObject(
+        string? reference,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        out GameObject gameObject,
+        out string error)
+    {
+        var instanceId = ResolveOptionalReference(reference, aliases);
+        if (instanceId is not null && _world.TryGetGameObject(instanceId, out gameObject!))
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        gameObject = null!;
+        error = $"GameObject '{reference}' was not found.";
+        return false;
+    }
+
+    bool TryResolveComponent(
+        string? reference,
+        IReadOnlyDictionary<string, InstanceId> aliases,
+        out ViewModelComponent component,
+        out string error)
+    {
+        var instanceId = ResolveOptionalReference(reference, aliases);
+        if (instanceId is not null && _world.TryGetComponent(instanceId, out component!))
+        {
+            error = string.Empty;
+            return true;
+        }
+
+        component = null!;
+        error = $"Component '{reference}' was not found.";
+        return false;
+    }
+
+    static InstanceId? ResolveOptionalReference(
+        string? reference,
+        IReadOnlyDictionary<string, InstanceId> aliases)
+    {
+        if (string.IsNullOrWhiteSpace(reference))
+            return null;
+        var normalized = reference.Trim();
+        if (normalized.StartsWith('$'))
+            return aliases.TryGetValue(normalized[1..], out var aliasValue)
+                ? aliasValue
+                : null;
+
+        return new InstanceId(normalized);
+    }
+
+    async Task<string?> ValidateComponentPropertiesAsync(
+        ComponentType? componentType,
+        IReadOnlyDictionary<string, System.Text.Json.JsonElement> properties,
+        CancellationToken cancellationToken)
+    {
+        if (componentType is null)
+            return "The component has no reflected type.";
+
+        foreach (var property in properties)
+        {
+            if (string.Equals(property.Key, "instanceId", StringComparison.Ordinal) ||
+                string.Equals(property.Key, "fileId", StringComparison.Ordinal) ||
+                !componentType.Properties.TryGetValue(property.Key, out var descriptor))
+            {
+                return $"Unknown or immutable property '{property.Key}' for component " +
+                    $"'{componentType.Name}'.";
+            }
+            if (componentType.ReadOnlyProperties.Contains(property.Key))
+            {
+                return $"Property '{componentType.Name}.{property.Key}' is read-only.";
+            }
+            if (descriptor is not ObjectPtrProperty objectPointer)
+            {
+                continue;
+            }
+
+            if (property.Value.ValueKind != System.Text.Json.JsonValueKind.Object)
+            {
+                return $"Property '{componentType.Name}.{property.Key}' requires an object " +
+                    "with fileId and/or instanceId.";
+            }
+
+            var hasFileId = property.Value.TryGetProperty("fileId", out var fileIdNode);
+            var hasInstanceId = property.Value.TryGetProperty("instanceId", out var instanceIdNode);
+            if (!hasFileId && !hasInstanceId)
+            {
+                return $"Property '{componentType.Name}.{property.Key}' requires fileId " +
+                    "and/or instanceId.";
+            }
+            foreach (var referenceProperty in property.Value.EnumerateObject())
+            {
+                if (referenceProperty.Name is not ("fileId" or "instanceId"))
+                {
+                    return $"Property '{componentType.Name}.{property.Key}' only accepts " +
+                        "fileId and instanceId.";
+                }
+            }
+            if (hasFileId && fileIdNode.ValueKind != System.Text.Json.JsonValueKind.String)
+            {
+                return $"Property '{componentType.Name}.{property.Key}.fileId' must be a string.";
+            }
+            if (hasInstanceId &&
+                instanceIdNode.ValueKind != System.Text.Json.JsonValueKind.String)
+            {
+                return $"Property '{componentType.Name}.{property.Key}.instanceId' must be a string.";
+            }
+
+            if (hasFileId)
+            {
+                var fileIdValue = fileIdNode.GetString();
+                if (!string.IsNullOrWhiteSpace(fileIdValue) &&
+                    fileIdValue != FileId.NullFileId)
+                {
+                    var asset = await _assets.ResolveAssetAsync(
+                        new FileId(fileIdValue),
+                        cancellationToken);
+                    if (asset is null)
+                    {
+                        return $"Asset '{fileIdValue}' referenced by " +
+                            $"'{componentType.Name}.{property.Key}' was not found.";
+                    }
+                    if (objectPointer.GenericType is not null &&
+                        !objectPointer.GenericType.IsInstanceOfType(asset))
+                    {
+                        return $"Asset '{fileIdValue}' has type '{asset.GetType().Name}', but " +
+                            $"'{componentType.Name}.{property.Key}' requires " +
+                            $"'{objectPointer.GenericTypename}'.";
+                    }
+                }
+            }
+
+            if (hasInstanceId)
+            {
+                var instanceIdValue = instanceIdNode.GetString();
+                if (!string.IsNullOrWhiteSpace(instanceIdValue) &&
+                    instanceIdValue != InstanceId.NullInstanceId &&
+                    !IsCompatibleInstanceReference(
+                        new InstanceId(instanceIdValue),
+                        objectPointer.GenericTypename))
+                {
+                    return $"Instance '{instanceIdValue}' is not compatible with " +
+                        $"'{componentType.Name}.{property.Key}' " +
+                        $"({objectPointer.GenericTypename}).";
+                }
+            }
+        }
+
+        return null;
+    }
+
+    bool IsCompatibleInstanceReference(
+        InstanceId instanceId,
+        string expectedTypeName)
+    {
+        if (_world.TryGetGameObject(instanceId, out _))
+        {
+            return string.IsNullOrWhiteSpace(expectedTypeName) ||
+                expectedTypeName.EndsWith("GameObject", StringComparison.Ordinal);
+        }
+        if (!_world.TryGetComponent(instanceId, out var component))
+            return false;
+        if (string.IsNullOrWhiteSpace(expectedTypeName) ||
+            expectedTypeName.EndsWith("::Component", StringComparison.Ordinal))
+        {
+            return true;
+        }
+
+        var actualTypeName = component.Typename?.Name;
+        return string.Equals(expectedTypeName, actualTypeName, StringComparison.Ordinal) ||
+            expectedTypeName.EndsWith(
+                "::" + actualTypeName?.Split("::").LastOrDefault(),
+                StringComparison.Ordinal);
+    }
+}

--- a/Editor/Mcp/McpSceneCommandFactory.cs
+++ b/Editor/Mcp/McpSceneCommandFactory.cs
@@ -1,0 +1,90 @@
+#nullable enable
+
+using System.Text.Json;
+using SailorEditor.Commands;
+using SailorEditor.ViewModels;
+using YamlDotNet.RepresentationModel;
+using ViewModelComponent = SailorEditor.ViewModels.Component;
+
+namespace SailorEditor.Mcp;
+
+internal static class McpSceneCommandFactory
+{
+    static readonly IReadOnlyDictionary<string, string> s_gameObjectProperties =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["name"] = "name",
+            ["position"] = "position",
+            ["rotation"] = "rotation",
+            ["scale"] = "scale",
+        };
+
+    public static UpdateGameObjectCommand CreateGameObjectUpdate(
+        GameObject gameObject,
+        IReadOnlyDictionary<string, JsonElement> properties,
+        string description)
+    {
+        var beforeYaml = EditorYaml.SerializeGameObject(gameObject);
+        var mapping = McpYamlUtilities.ParseMapping(beforeYaml);
+        foreach (var property in properties)
+        {
+            if (!s_gameObjectProperties.TryGetValue(property.Key, out var canonicalName))
+            {
+                throw new InvalidDataException(
+                    $"GameObject property '{property.Key}' cannot be changed through MCP. " +
+                    "Allowed properties: name, position, rotation, scale.");
+            }
+
+            mapping.Children[new YamlScalarNode(canonicalName)] =
+                McpYamlUtilities.FromJson(property.Value);
+        }
+
+        return new UpdateGameObjectCommand(
+            gameObject,
+            beforeYaml,
+            McpYamlUtilities.Serialize(mapping),
+            description);
+    }
+
+    public static UpdateComponentCommand CreateComponentUpdate(
+        ViewModelComponent component,
+        IReadOnlyDictionary<string, JsonElement> properties,
+        string description)
+    {
+        var type = component.Typename ??
+            throw new InvalidDataException("The component has no reflected type.");
+        var beforeYaml = EditorYaml.SerializeComponent(component);
+        var mapping = McpYamlUtilities.ParseMapping(beforeYaml);
+        if (!McpYamlUtilities.TryGet(mapping, "overrideProperties", out var overridesNode) ||
+            overridesNode is not YamlMappingNode overrides)
+        {
+            overrides = new YamlMappingNode();
+            mapping.Children[new YamlScalarNode("overrideProperties")] = overrides;
+        }
+
+        foreach (var property in properties)
+        {
+            if (string.Equals(property.Key, "instanceId", StringComparison.Ordinal) ||
+                string.Equals(property.Key, "fileId", StringComparison.Ordinal) ||
+                !type.Properties.ContainsKey(property.Key))
+            {
+                throw new InvalidDataException(
+                    $"Unknown or immutable property '{property.Key}' for component '{type.Name}'.");
+            }
+            if (type.ReadOnlyProperties.Contains(property.Key))
+            {
+                throw new InvalidDataException(
+                    $"Property '{type.Name}.{property.Key}' is read-only.");
+            }
+
+            overrides.Children[new YamlScalarNode(property.Key)] =
+                McpYamlUtilities.FromJson(property.Value);
+        }
+
+        return new UpdateComponentCommand(
+            component,
+            beforeYaml,
+            McpYamlUtilities.Serialize(mapping),
+            description);
+    }
+}

--- a/Editor/Mcp/McpSceneContracts.cs
+++ b/Editor/Mcp/McpSceneContracts.cs
@@ -1,0 +1,73 @@
+#nullable enable
+
+using System.Text.Json;
+
+namespace SailorEditor.Mcp;
+
+public sealed record McpSceneOperation
+{
+    public string Kind { get; init; } = string.Empty;
+    public string? Alias { get; init; }
+    public string? Target { get; init; }
+    public string? Parent { get; init; }
+    public string? Name { get; init; }
+    public string? ComponentType { get; init; }
+    public bool KeepWorldTransform { get; init; } = true;
+    public Dictionary<string, JsonElement> Properties { get; init; } =
+        new(StringComparer.Ordinal);
+}
+
+public sealed record McpSceneBatchRequest(
+    bool Confirm,
+    long? ExpectedWorkspaceEpoch,
+    string? Description,
+    IReadOnlyList<McpSceneOperation> Operations);
+
+public sealed record McpSceneOperationResult(
+    int Index,
+    string Kind,
+    bool Succeeded,
+    string? InstanceId,
+    string? Alias,
+    string? Message);
+
+public sealed record McpSceneBatchResult(
+    bool Succeeded,
+    string Message,
+    long WorkspaceEpoch,
+    IReadOnlyList<McpSceneOperationResult> Operations);
+
+public sealed record McpComponentSnapshot(
+    string InstanceId,
+    string Type,
+    IReadOnlyDictionary<string, object?> Properties,
+    string? Yaml);
+
+public sealed record McpGameObjectSnapshot(
+    string InstanceId,
+    string Name,
+    string? ParentInstanceId,
+    string? PrefabFileId,
+    IReadOnlyDictionary<string, object?> Properties,
+    IReadOnlyList<McpComponentSnapshot> Components,
+    IReadOnlyList<McpGameObjectSnapshot> Children);
+
+public sealed record McpSceneHierarchySnapshot(
+    string Name,
+    string? WorldFileId,
+    long WorkspaceEpoch,
+    IReadOnlyList<McpGameObjectSnapshot> Roots,
+    string? Yaml);
+
+public sealed record McpComponentPropertySchema(
+    string Name,
+    string Type,
+    bool ReadOnly,
+    object? DefaultValue,
+    IReadOnlyList<string>? AllowedValues,
+    string? ObjectType);
+
+public sealed record McpComponentTypeSchema(
+    string Name,
+    string Base,
+    IReadOnlyList<McpComponentPropertySchema> Properties);

--- a/Editor/Mcp/McpSceneSnapshotBuilder.cs
+++ b/Editor/Mcp/McpSceneSnapshotBuilder.cs
@@ -1,0 +1,223 @@
+#nullable enable
+
+using SailorEditor.Commands;
+using SailorEditor.Services;
+using SailorEditor.ViewModels;
+using SailorEngine;
+using YamlDotNet.RepresentationModel;
+using ViewModelComponent = SailorEditor.ViewModels.Component;
+
+namespace SailorEditor.Mcp;
+
+internal sealed class McpSceneSnapshotBuilder
+{
+    readonly WorldService _world;
+    readonly EngineService _engine;
+
+    public McpSceneSnapshotBuilder(
+        WorldService world,
+        EngineService engine)
+    {
+        _world = world;
+        _engine = engine;
+    }
+
+    public McpSceneHierarchySnapshot Build(bool includeYaml)
+    {
+        var world = _world.Current;
+        var allObjects = world.Prefabs
+            .SelectMany(prefab => prefab.GameObjects)
+            .Where(gameObject =>
+                gameObject.InstanceId is not null &&
+                !gameObject.InstanceId.IsEmpty())
+            .GroupBy(gameObject => gameObject.InstanceId.Value, StringComparer.Ordinal)
+            .Select(group => group.First())
+            .ToArray();
+        var builders = allObjects.ToDictionary(
+            gameObject => gameObject.InstanceId.Value,
+            gameObject => new GameObjectBuilder(
+                gameObject,
+                _world.ResolveParentInstanceId(gameObject)?.Value,
+                ResolvePrefabFileId(world, gameObject),
+                BuildComponents(gameObject, includeYaml)),
+            StringComparer.Ordinal);
+
+        var roots = new List<GameObjectBuilder>();
+        foreach (var builder in builders.Values)
+        {
+            if (!string.IsNullOrWhiteSpace(builder.ParentInstanceId) &&
+                builders.TryGetValue(builder.ParentInstanceId, out var parent))
+            {
+                parent.Children.Add(builder);
+            }
+            else
+            {
+                roots.Add(builder);
+            }
+        }
+
+        return new McpSceneHierarchySnapshot(
+            world.Name,
+            _world.CurrentWorldAsset?.FileId?.Value,
+            _world.WorkspaceEpoch,
+            roots
+                .OrderBy(root => root.GameObject.Name, StringComparer.Ordinal)
+                .ThenBy(root => root.GameObject.InstanceId.Value, StringComparer.Ordinal)
+                .Select(ToSnapshot)
+                .ToArray(),
+            includeYaml ? _world.SerializeCurrentWorld() : null);
+    }
+
+    public McpGameObjectSnapshot? BuildObject(string instanceId)
+    {
+        if (!_world.TryGetGameObject(new InstanceId(instanceId), out var gameObject))
+            return null;
+
+        return ToSnapshot(new GameObjectBuilder(
+            gameObject,
+            _world.ResolveParentInstanceId(gameObject)?.Value,
+            ResolvePrefabFileId(_world.Current, gameObject),
+            BuildComponents(gameObject, includeYaml: true)));
+    }
+
+    public IReadOnlyList<McpComponentTypeSchema> BuildComponentSchemas()
+    {
+        var catalog = _engine.EngineTypes;
+        return catalog.GetAddableComponentTypeNames()
+            .Select(typeName => catalog.TryGetComponent(typeName, out var type)
+                ? new McpComponentTypeSchema(
+                    type.Name,
+                    type.Base,
+                    type.Properties
+                        .OrderBy(property => property.Key, StringComparer.Ordinal)
+                        .Select(property => BuildPropertySchema(
+                            property.Key,
+                            property.Value,
+                            type.ReadOnlyProperties.Contains(property.Key) ||
+                                property.Key is "instanceId" or "fileId",
+                            catalog.Enums))
+                        .ToArray())
+                : null)
+            .Where(schema => schema is not null)
+            .Cast<McpComponentTypeSchema>()
+            .ToArray();
+    }
+
+    IReadOnlyList<McpComponentSnapshot> BuildComponents(
+        GameObject gameObject,
+        bool includeYaml) =>
+        _world.GetComponents(gameObject)
+            .Where(component =>
+                component.InstanceId is not null &&
+                !component.InstanceId.IsEmpty())
+            .Select(component => BuildComponent(component, includeYaml))
+            .ToArray();
+
+    static McpComponentSnapshot BuildComponent(
+        ViewModelComponent component,
+        bool includeYaml)
+    {
+        var yaml = EditorYaml.SerializeComponent(component);
+        var mapping = McpYamlUtilities.ParseMapping(yaml);
+        return new McpComponentSnapshot(
+            component.InstanceId.Value,
+            component.Typename?.Name ?? string.Empty,
+            McpYamlUtilities.GetMappingValues(mapping, "overrideProperties"),
+            includeYaml ? yaml : null);
+    }
+
+    static McpGameObjectSnapshot ToSnapshot(GameObjectBuilder builder)
+    {
+        var yaml = EditorYaml.SerializeGameObject(builder.GameObject);
+        var mapping = McpYamlUtilities.ParseMapping(yaml);
+        var properties = mapping.Children
+            .Where(entry =>
+                !string.Equals(
+                    ((YamlScalarNode)entry.Key).Value,
+                    "components",
+                    StringComparison.Ordinal))
+            .ToDictionary(
+                entry => ((YamlScalarNode)entry.Key).Value ?? string.Empty,
+                entry => McpYamlUtilities.ToPlainObject(entry.Value),
+                StringComparer.Ordinal);
+
+        return new McpGameObjectSnapshot(
+            builder.GameObject.InstanceId.Value,
+            builder.GameObject.Name,
+            builder.ParentInstanceId,
+            builder.PrefabFileId,
+            properties,
+            builder.Components,
+            builder.Children
+                .OrderBy(child => child.GameObject.Name, StringComparer.Ordinal)
+                .ThenBy(child => child.GameObject.InstanceId.Value, StringComparer.Ordinal)
+                .Select(ToSnapshot)
+                .ToArray());
+    }
+
+    static McpComponentPropertySchema BuildPropertySchema(
+        string name,
+        PropertyBase property,
+        bool readOnly,
+        IReadOnlyDictionary<string, List<string>> enums)
+    {
+        object? defaultValue = property switch
+        {
+            Property<string> value => value.DefaultValue,
+            Property<bool> value => value.DefaultValue,
+            Property<int> value => value.DefaultValue,
+            Property<uint> value => value.DefaultValue,
+            Property<float> value => value.DefaultValue,
+            Property<FileId> value => value.DefaultValue?.Value,
+            Property<InstanceId> value => value.DefaultValue?.Value,
+            Property<List<FileId>> value => value.DefaultValue?
+                .Select(fileId => fileId.Value)
+                .ToArray(),
+            _ => null,
+        };
+        var allowedValues = property is EnumProperty enumProperty &&
+            enums.TryGetValue(enumProperty.Typename, out var values)
+                ? values.ToArray()
+                : null;
+        var objectType = property is ObjectPtrProperty objectPtr
+            ? objectPtr.GenericTypename
+            : null;
+
+        return new McpComponentPropertySchema(
+            name,
+            property.Typename ?? property.GetType().Name,
+            readOnly,
+            defaultValue,
+            allowedValues,
+            objectType);
+    }
+
+    static string? ResolvePrefabFileId(World world, GameObject gameObject)
+    {
+        if (gameObject.PrefabIndex < 0 || gameObject.PrefabIndex >= world.Prefabs.Count)
+            return null;
+        var fileId = world.Prefabs[gameObject.PrefabIndex].FileId;
+        return fileId is null || fileId.IsEmpty() ? null : fileId.Value;
+    }
+
+    sealed class GameObjectBuilder
+    {
+        public GameObjectBuilder(
+            GameObject gameObject,
+            string? parentInstanceId,
+            string? prefabFileId,
+            IReadOnlyList<McpComponentSnapshot> components)
+        {
+            GameObject = gameObject;
+            ParentInstanceId = parentInstanceId;
+            PrefabFileId = prefabFileId;
+            Components = components;
+        }
+
+        public GameObject GameObject { get; }
+        public string? ParentInstanceId { get; }
+        public string? PrefabFileId { get; }
+        public IReadOnlyList<McpComponentSnapshot> Components { get; }
+        public List<GameObjectBuilder> Children { get; } = [];
+    }
+}

--- a/Editor/Mcp/McpWorkspaceOperations.cs
+++ b/Editor/Mcp/McpWorkspaceOperations.cs
@@ -1,0 +1,69 @@
+#nullable enable
+
+using SailorEditor.AI;
+using SailorEditor.Commands;
+using SailorEditor.Workspace;
+
+namespace SailorEditor.Mcp;
+
+internal sealed class McpWorkspaceOperations
+{
+    readonly ICommandDispatcher _dispatcher;
+    readonly IActionContextProvider _contextProvider;
+    readonly AIOperatorService _aiOperator;
+
+    public McpWorkspaceOperations(
+        ICommandDispatcher dispatcher,
+        IActionContextProvider contextProvider,
+        AIOperatorService aiOperator)
+    {
+        _dispatcher = dispatcher;
+        _contextProvider = contextProvider;
+        _aiOperator = aiOperator;
+    }
+
+    public Task<CommandResult> SaveSceneAsync(
+        bool confirm,
+        CancellationToken cancellationToken = default) =>
+        DispatchAsync(
+            confirm,
+            new SaveCurrentSceneCommand(),
+            "MCP save scene",
+            cancellationToken);
+
+    public Task<CommandResult> BuildWorkspaceAsync(
+        bool confirm,
+        string configuration,
+        bool configure,
+        CancellationToken cancellationToken = default) =>
+        DispatchAsync(
+            confirm,
+            new BuildWorkspaceCommand(configuration, configure),
+            "MCP workspace build",
+            cancellationToken);
+
+    async Task<CommandResult> DispatchAsync(
+        bool confirm,
+        IEditorCommand command,
+        string title,
+        CancellationToken cancellationToken)
+    {
+        if (!confirm)
+            return CommandResult.Failure("This operation requires confirm=true.");
+
+        var context = _contextProvider.GetCurrentContext(
+            new CommandOrigin(CommandOriginKind.AI, "MCP", "External MCP Agent"),
+            new Dictionary<string, string?> { ["mcp"] = "true" });
+        var result = await _dispatcher.DispatchAsync(
+            command,
+            context,
+            cancellationToken);
+        _aiOperator.RecordExternalExecution(
+            title,
+            AIActionSafety.Elevated,
+            result.Succeeded ? AIProposalState.Executed : AIProposalState.Failed,
+            [new AIActionExecutionItem(command.Name, result.Succeeded, result.Message)],
+            result.Message);
+        return result;
+    }
+}

--- a/Editor/Mcp/McpYamlUtilities.cs
+++ b/Editor/Mcp/McpYamlUtilities.cs
@@ -1,0 +1,96 @@
+#nullable enable
+
+using System.Globalization;
+using System.Text.Json;
+using YamlDotNet.RepresentationModel;
+
+namespace SailorEditor.Mcp;
+
+internal static class McpYamlUtilities
+{
+    public static YamlMappingNode ParseMapping(string yaml)
+    {
+        var stream = new YamlStream();
+        using var reader = new StringReader(yaml);
+        stream.Load(reader);
+        return stream.Documents.FirstOrDefault()?.RootNode as YamlMappingNode ??
+            throw new InvalidDataException("A YAML mapping document is required.");
+    }
+
+    public static string Serialize(YamlMappingNode mapping)
+    {
+        var stream = new YamlStream(new YamlDocument(mapping));
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        stream.Save(writer, false);
+        return writer.ToString();
+    }
+
+    public static YamlNode FromJson(JsonElement value) => value.ValueKind switch
+    {
+        JsonValueKind.Object => new YamlMappingNode(value.EnumerateObject()
+            .Select(property => new KeyValuePair<YamlNode, YamlNode>(
+                new YamlScalarNode(property.Name),
+                FromJson(property.Value)))),
+        JsonValueKind.Array => new YamlSequenceNode(
+            value.EnumerateArray().Select(FromJson)),
+        JsonValueKind.String => new YamlScalarNode(value.GetString()),
+        JsonValueKind.Number => new YamlScalarNode(value.GetRawText()),
+        JsonValueKind.True => new YamlScalarNode("true"),
+        JsonValueKind.False => new YamlScalarNode("false"),
+        JsonValueKind.Null or JsonValueKind.Undefined => new YamlScalarNode((string?)null),
+        _ => throw new InvalidDataException($"Unsupported JSON value kind '{value.ValueKind}'."),
+    };
+
+    public static object? ToPlainObject(YamlNode node) => node switch
+    {
+        YamlMappingNode mapping => mapping.Children.ToDictionary(
+            entry => ((YamlScalarNode)entry.Key).Value ?? string.Empty,
+            entry => ToPlainObject(entry.Value),
+            StringComparer.Ordinal),
+        YamlSequenceNode sequence => sequence.Children
+            .Select(ToPlainObject)
+            .ToArray(),
+        YamlScalarNode scalar => ParseScalar(scalar.Value),
+        _ => node.ToString(),
+    };
+
+    public static IReadOnlyDictionary<string, object?> GetMappingValues(
+        YamlMappingNode mapping,
+        string key)
+    {
+        return TryGet(mapping, key, out var node) && node is YamlMappingNode values
+            ? (IReadOnlyDictionary<string, object?>)values.Children.ToDictionary(
+                entry => ((YamlScalarNode)entry.Key).Value ?? string.Empty,
+                entry => ToPlainObject(entry.Value),
+                StringComparer.Ordinal)
+            : new Dictionary<string, object?>(StringComparer.Ordinal);
+    }
+
+    public static bool TryGet(
+        YamlMappingNode mapping,
+        string key,
+        out YamlNode? value)
+    {
+        return mapping.Children.TryGetValue(
+            new YamlScalarNode(key),
+            out value);
+    }
+
+    static object? ParseScalar(string? value)
+    {
+        if (value is null || value == "~" ||
+            string.Equals(value, "null", StringComparison.OrdinalIgnoreCase))
+            return null;
+        if (bool.TryParse(value, out var boolean))
+            return boolean;
+        if (long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var integer))
+            return integer;
+        // InstanceId values are unsigned 64-bit integers. Keep values outside the
+        // signed range as strings so JSON clients never lose bits through a double.
+        if (ulong.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out _))
+            return value;
+        if (double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var number))
+            return number;
+        return value;
+    }
+}

--- a/Editor/McpBridge/McpBridgeOptions.cs
+++ b/Editor/McpBridge/McpBridgeOptions.cs
@@ -1,0 +1,71 @@
+namespace SailorEditor.McpBridge;
+
+public sealed record McpBridgeOptions(
+    int? ProcessId,
+    string? WorkspacePath,
+    string? DiscoveryDirectory)
+{
+    public static bool TryParse(
+        IReadOnlyList<string> arguments,
+        out McpBridgeOptions options,
+        out string? error)
+    {
+        int? processId = null;
+        string? workspacePath = null;
+        string? discoveryDirectory = null;
+
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            var argument = arguments[index];
+            if (argument is "--help" or "-h")
+            {
+                options = new McpBridgeOptions(null, null, null);
+                error = Usage;
+                return false;
+            }
+
+            if (argument is not ("--pid" or "--workspace" or "--discovery-directory"))
+            {
+                options = new McpBridgeOptions(null, null, null);
+                error = $"Unknown argument '{argument}'.\n{Usage}";
+                return false;
+            }
+
+            if (++index >= arguments.Count)
+            {
+                options = new McpBridgeOptions(null, null, null);
+                error = $"Missing value for '{argument}'.\n{Usage}";
+                return false;
+            }
+
+            var value = arguments[index];
+            switch (argument)
+            {
+                case "--pid":
+                    if (!int.TryParse(value, out var parsedProcessId) || parsedProcessId <= 0)
+                    {
+                        options = new McpBridgeOptions(null, null, null);
+                        error = "--pid must be a positive integer.";
+                        return false;
+                    }
+
+                    processId = parsedProcessId;
+                    break;
+                case "--workspace":
+                    workspacePath = value;
+                    break;
+                case "--discovery-directory":
+                    discoveryDirectory = value;
+                    break;
+            }
+        }
+
+        options = new McpBridgeOptions(processId, workspacePath, discoveryDirectory);
+        error = null;
+        return true;
+    }
+
+    public const string Usage =
+        "Usage: SailorEditor.McpBridge [--pid <editor-pid>] [--workspace <path>] " +
+        "[--discovery-directory <path>]";
+}

--- a/Editor/McpBridge/McpBridgeRunner.cs
+++ b/Editor/McpBridge/McpBridgeRunner.cs
@@ -1,0 +1,70 @@
+using System.Net;
+using System.Net.Sockets;
+using SailorEditor.Mcp;
+
+namespace SailorEditor.McpBridge;
+
+public sealed class McpBridgeRunner
+{
+    readonly McpEndpointDiscovery _discovery;
+
+    public McpBridgeRunner(McpEndpointDiscovery discovery)
+    {
+        _discovery = discovery;
+    }
+
+    public async Task<int> RunAsync(
+        McpBridgeOptions options,
+        Stream standardInput,
+        Stream standardOutput,
+        TextWriter standardError,
+        CancellationToken cancellationToken = default)
+    {
+        var selection = _discovery.Select(options.ProcessId, options.WorkspacePath);
+        if (!selection.Succeeded)
+        {
+            await standardError.WriteLineAsync(selection.Error);
+            return 2;
+        }
+
+        var endpoint = selection.Endpoint!;
+        using var client = new TcpClient(AddressFamily.InterNetwork);
+        try
+        {
+            await client.ConnectAsync(
+                IPAddress.Loopback,
+                endpoint.Port,
+                cancellationToken);
+        }
+        catch (Exception exception) when (exception is SocketException or IOException)
+        {
+            await standardError.WriteLineAsync(
+                $"Unable to connect to Sailor Editor PID {endpoint.ProcessId}: {exception.Message}");
+            return 3;
+        }
+
+        await using var stream = client.GetStream();
+        await McpLoopbackAuthentication.WriteRequestAsync(
+            stream,
+            endpoint.AuthenticationToken,
+            cancellationToken);
+
+        using var relayCancellation =
+            CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        var inputRelay = standardInput.CopyToAsync(stream, relayCancellation.Token);
+        var outputRelay = stream.CopyToAsync(standardOutput, relayCancellation.Token);
+        var completed = await Task.WhenAny(inputRelay, outputRelay);
+        await completed;
+        await relayCancellation.CancelAsync();
+
+        try
+        {
+            await Task.WhenAll(inputRelay, outputRelay);
+        }
+        catch (OperationCanceledException) when (relayCancellation.IsCancellationRequested)
+        {
+        }
+
+        return 0;
+    }
+}

--- a/Editor/McpBridge/Program.cs
+++ b/Editor/McpBridge/Program.cs
@@ -1,0 +1,16 @@
+using SailorEditor.Mcp;
+using SailorEditor.McpBridge;
+
+if (!McpBridgeOptions.TryParse(args, out var options, out var error))
+{
+    await Console.Error.WriteLineAsync(error);
+    return error == McpBridgeOptions.Usage ? 0 : 1;
+}
+
+var discovery = new McpEndpointDiscovery(options.DiscoveryDirectory);
+var runner = new McpBridgeRunner(discovery);
+return await runner.RunAsync(
+    options,
+    Console.OpenStandardInput(),
+    Console.OpenStandardOutput(),
+    Console.Error);

--- a/Editor/McpBridge/SailorEditor.McpBridge.csproj
+++ b/Editor/McpBridge/SailorEditor.McpBridge.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AssemblyName>SailorEditor.McpBridge</AssemblyName>
+    <RootNamespace>SailorEditor.McpBridge</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\Mcp\McpEndpointDiscovery.cs" Link="Mcp\McpEndpointDiscovery.cs" />
+    <Compile Include="..\Mcp\McpLoopbackAuthentication.cs" Link="Mcp\McpLoopbackAuthentication.cs" />
+  </ItemGroup>
+</Project>

--- a/Editor/SailorEditor.csproj
+++ b/Editor/SailorEditor.csproj
@@ -93,13 +93,14 @@
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
         <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
+		<PackageReference Include="ModelContextProtocol" Version="2.1.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="SkiaSharp" Version="2.88.7" />
 		<PackageReference Include="YamlDotNet" Version="15.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>
-		<Compile Remove="Protocol\Generated\**\*.cs;Protocol\obj\**\*.cs" />
+		<Compile Remove="McpBridge\**\*.cs;Protocol\Generated\**\*.cs;Protocol\obj\**\*.cs" />
 		<ProjectReference Include="Protocol\SailorEditor.Protocol.csproj" />
 	</ItemGroup>
 

--- a/Editor/SailorEditor.sln
+++ b/Editor/SailorEditor.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SailorEditor", "SailorEdito
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Editor.Contracts.Tests", "..\Editor.Tests\Editor.Contracts.Tests.csproj", "{CE60FE9A-694F-4375-B06D-B4DF2345CED8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SailorEditor.McpBridge", "McpBridge\SailorEditor.McpBridge.csproj", "{FCFC608D-C80C-4D97-8E5F-A0B401F1C4B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -23,6 +25,10 @@ Global
 		{CE60FE9A-694F-4375-B06D-B4DF2345CED8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CE60FE9A-694F-4375-B06D-B4DF2345CED8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CE60FE9A-694F-4375-B06D-B4DF2345CED8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FCFC608D-C80C-4D97-8E5F-A0B401F1C4B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FCFC608D-C80C-4D97-8E5F-A0B401F1C4B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FCFC608D-C80C-4D97-8E5F-A0B401F1C4B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FCFC608D-C80C-4D97-8E5F-A0B401F1C4B0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -941,6 +941,43 @@ namespace SailorEditor.Services
             }
         }
 
+        public async Task<AssetFolder?> ResolveFolderAsync(
+            string folderPath,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(folderPath))
+            {
+                return null;
+            }
+
+            var canonicalPath = ProjectContentPathPolicy.NormalizeRoot(folderPath);
+            var rootFolder = await MainThread.InvokeOnMainThreadAsync(() =>
+                Folders
+                    .Where(folder =>
+                        folder.ParentFolderId == -1 &&
+                        ProjectContentPathPolicy.IsInsideRoot(
+                            folder.FullPath,
+                            canonicalPath))
+                    .OrderByDescending(folder => folder.FullPath.Length)
+                    .FirstOrDefault());
+            if (rootFolder is null)
+            {
+                return null;
+            }
+
+            await EnsureAssetDirectoryLoadedAsync(
+                    canonicalPath,
+                    rootFolder.IsReadOnly,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            return await MainThread.InvokeOnMainThreadAsync(() =>
+                Folders.FirstOrDefault(folder =>
+                    folder.ProjectRootId == rootFolder.ProjectRootId &&
+                    ProjectContentPathPolicy.IsSamePath(
+                        folder.FullPath,
+                        canonicalPath)));
+        }
+
         public async Task<AssetFile?> ResolveAssetAsync(
             FileId fileId,
             CancellationToken cancellationToken = default)

--- a/Editor/Views/AIPanelView.cs
+++ b/Editor/Views/AIPanelView.cs
@@ -1,12 +1,15 @@
 using System.Collections.Specialized;
 using SailorEditor.AI;
+using SailorEditor.Mcp;
 
 namespace SailorEditor.Views;
 
 public sealed class AIPanelView : ContentView
 {
     readonly AIOperatorService _service;
+    readonly McpEditorHostService _mcpHost;
     readonly Label _contextLabel;
+    readonly Label _mcpStatusLabel;
     readonly Label _responseLabel;
     readonly Entry _promptEntry;
     readonly VerticalStackLayout _proposalStack;
@@ -15,8 +18,15 @@ public sealed class AIPanelView : ContentView
     public AIPanelView()
     {
         _service = MauiProgram.GetService<AIOperatorService>();
+        _mcpHost = MauiProgram.GetService<McpEditorHostService>();
 
         _contextLabel = new Label { FontSize = 12, Opacity = 0.8 };
+        _mcpStatusLabel = new Label
+        {
+            FontSize = 11,
+            Opacity = 0.72,
+            LineBreakMode = LineBreakMode.WordWrap,
+        };
         _responseLabel = new Label { FontSize = 12, Opacity = 0.85 };
         _promptEntry = new Entry { Placeholder = "Ask AI to operate the editor. Example: open console" };
         _proposalStack = new VerticalStackLayout { Spacing = 8 };
@@ -36,6 +46,7 @@ public sealed class AIPanelView : ContentView
                 Children =
                 {
                     _contextLabel,
+                    _mcpStatusLabel,
                     _responseLabel,
                     _promptEntry,
                     submitButton,
@@ -72,9 +83,11 @@ public sealed class AIPanelView : ContentView
 
         _service.Proposals.CollectionChanged += OnProposalsChanged;
         _service.AuditTrail.CollectionChanged += OnAuditChanged;
+        _mcpHost.StatusChanged += OnMcpStatusChanged;
         Unloaded += OnUnloaded;
 
         RefreshContext();
+        RefreshMcpStatus();
         RebuildProposals();
         RebuildAudit();
     }
@@ -93,9 +106,21 @@ public sealed class AIPanelView : ContentView
         _contextLabel.Text = $"Context • world: {context.ActiveWorldId ?? "none"} • selection: {context.SelectionCount} • panel: {context.ActivePanelId ?? "none"} • viewport: {context.FocusedViewportId ?? "none"}";
     }
 
+    void RefreshMcpStatus()
+    {
+        var status = _mcpHost.Status;
+        _mcpStatusLabel.Text = status.IsRunning
+            ? $"MCP • running • PID {status.ProcessId} • 127.0.0.1:{status.Port} • clients {status.ConnectedClients}\n" +
+                $"Discovery: {status.DiscoveryFile}"
+            : $"MCP • stopped{(string.IsNullOrWhiteSpace(status.Error) ? string.Empty : " • " + status.Error)}";
+    }
+
     void OnProposalsChanged(object? sender, NotifyCollectionChangedEventArgs e) => MainThread.BeginInvokeOnMainThread(RebuildProposals);
 
     void OnAuditChanged(object? sender, NotifyCollectionChangedEventArgs e) => MainThread.BeginInvokeOnMainThread(RebuildAudit);
+
+    void OnMcpStatusChanged(object? sender, EventArgs e) =>
+        MainThread.BeginInvokeOnMainThread(RefreshMcpStatus);
 
     void RebuildProposals()
     {
@@ -183,6 +208,7 @@ public sealed class AIPanelView : ContentView
     {
         _service.Proposals.CollectionChanged -= OnProposalsChanged;
         _service.AuditTrail.CollectionChanged -= OnAuditChanged;
+        _mcpHost.StatusChanged -= OnMcpStatusChanged;
         Unloaded -= OnUnloaded;
     }
 }

--- a/Editor/Workspace/WorkspaceBuildService.cs
+++ b/Editor/Workspace/WorkspaceBuildService.cs
@@ -1,0 +1,337 @@
+#nullable enable
+
+using System.Diagnostics;
+using System.Text;
+
+namespace SailorEditor.Workspace;
+
+public sealed record WorkspaceProcessInvocation(
+    string FileName,
+    IReadOnlyList<string> Arguments,
+    string WorkingDirectory);
+
+public sealed record WorkspaceProcessResult(
+    int ExitCode,
+    string Output,
+    TimeSpan Duration)
+{
+    public bool Succeeded => ExitCode == 0;
+}
+
+public sealed record WorkspaceBuildPlan(
+    string Configuration,
+    IReadOnlyList<WorkspaceProcessInvocation> Invocations)
+{
+    public static WorkspaceBuildPlan Create(
+        WorkspaceSession session,
+        string configuration,
+        bool configure,
+        string cmakeExecutable = "cmake")
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        var normalizedConfiguration = NormalizeConfiguration(configuration);
+        var invocations = new List<WorkspaceProcessInvocation>(configure ? 2 : 1);
+        if (configure)
+        {
+            var configureArguments = new List<string>
+            {
+                "-S",
+                session.GeneratedProjectDirectory,
+                "-B",
+                session.BuildDirectory,
+                "-DCMAKE_BUILD_TYPE=" + normalizedConfiguration,
+            };
+            AddVcpkgArguments(session, configureArguments);
+            invocations.Add(new WorkspaceProcessInvocation(
+                cmakeExecutable,
+                configureArguments,
+                session.WorkspaceRoot));
+        }
+
+        invocations.Add(new WorkspaceProcessInvocation(
+            cmakeExecutable,
+            [
+                "--build",
+                session.BuildDirectory,
+                "--config",
+                normalizedConfiguration,
+                "--target",
+                session.Manifest.LogicModuleName,
+                "--parallel",
+                "4",
+            ],
+            session.WorkspaceRoot));
+        return new WorkspaceBuildPlan(normalizedConfiguration, invocations);
+    }
+
+    static void AddVcpkgArguments(
+        WorkspaceSession session,
+        ICollection<string> arguments)
+    {
+        var configuredEnginePath = session.Manifest.EnginePath
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+        var engineDirectory = Path.IsPathRooted(configuredEnginePath)
+            ? Path.GetFullPath(configuredEnginePath)
+            : Path.GetFullPath(configuredEnginePath, session.WorkspaceRoot);
+        var toolchainPath = Path.Combine(
+            engineDirectory,
+            "External",
+            "vcpkg",
+            "scripts",
+            "buildsystems",
+            "vcpkg.cmake");
+        if (!File.Exists(toolchainPath))
+            return;
+
+        arguments.Add("-DCMAKE_TOOLCHAIN_FILE=" + toolchainPath);
+        var triplet = ResolveVcpkgTriplet();
+        if (triplet is null)
+            return;
+
+        arguments.Add("-DVCPKG_TARGET_TRIPLET=" + triplet);
+        var installedDirectory = Path.Combine(
+            engineDirectory,
+            "External",
+            "vcpkg",
+            "installed",
+            triplet);
+        if (!Directory.Exists(installedDirectory))
+            return;
+
+        // CMAKE_TOOLCHAIN_FILE is ignored by an already configured CMake cache.
+        // Prefix/module paths keep an existing workspace build cache usable too.
+        arguments.Add("-DCMAKE_PREFIX_PATH=" + installedDirectory);
+        var stbModules = Path.Combine(installedDirectory, "share", "stb");
+        if (Directory.Exists(stbModules))
+            arguments.Add("-DCMAKE_MODULE_PATH=" + stbModules);
+    }
+
+    static string? ResolveVcpkgTriplet()
+    {
+        if (OperatingSystem.IsMacOS() || OperatingSystem.IsMacCatalyst())
+            return "arm64-osx";
+        if (OperatingSystem.IsWindows())
+            return "x64-windows";
+        if (OperatingSystem.IsLinux())
+            return "x64-linux";
+        return null;
+    }
+
+    static string NormalizeConfiguration(string? configuration)
+    {
+        var value = configuration?.Trim();
+        if (string.IsNullOrWhiteSpace(value))
+            return "Release";
+        if (value is not ("Debug" or "Release" or "RelWithDebInfo" or "MinSizeRel"))
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(configuration),
+                "Configuration must be Debug, Release, RelWithDebInfo or MinSizeRel.");
+        }
+
+        return value;
+    }
+}
+
+public sealed record WorkspaceBuildResult(
+    bool Succeeded,
+    string Configuration,
+    int? ExitCode,
+    TimeSpan Duration,
+    IReadOnlyList<string> Commands,
+    string Output,
+    string? Error = null);
+
+public interface IWorkspaceProcessRunner
+{
+    Task<WorkspaceProcessResult> RunAsync(
+        WorkspaceProcessInvocation invocation,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class WorkspaceProcessRunner : IWorkspaceProcessRunner
+{
+    const int MaximumCapturedCharacters = 1_000_000;
+
+    public async Task<WorkspaceProcessResult> RunAsync(
+        WorkspaceProcessInvocation invocation,
+        CancellationToken cancellationToken = default)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = invocation.FileName,
+            WorkingDirectory = invocation.WorkingDirectory,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        foreach (var argument in invocation.Arguments)
+            startInfo.ArgumentList.Add(argument);
+
+        using var process = new Process { StartInfo = startInfo };
+        var stopwatch = Stopwatch.StartNew();
+        try
+        {
+            if (!process.Start())
+                throw new InvalidOperationException($"Unable to start '{invocation.FileName}'.");
+        }
+        catch (Exception exception) when (exception is InvalidOperationException or System.ComponentModel.Win32Exception)
+        {
+            return new WorkspaceProcessResult(
+                -1,
+                exception.Message,
+                stopwatch.Elapsed);
+        }
+
+        using var cancellationRegistration = cancellationToken.Register(() =>
+        {
+            try
+            {
+                if (!process.HasExited)
+                    process.Kill(entireProcessTree: true);
+            }
+            catch (InvalidOperationException)
+            {
+            }
+        });
+
+        var standardOutput = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var standardError = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken);
+        var output = await standardOutput;
+        var error = await standardError;
+        stopwatch.Stop();
+
+        var combined = new StringBuilder();
+        if (!string.IsNullOrWhiteSpace(output))
+            combined.AppendLine(output.TrimEnd());
+        if (!string.IsNullOrWhiteSpace(error))
+            combined.AppendLine(error.TrimEnd());
+        if (combined.Length > MaximumCapturedCharacters)
+        {
+            combined.Remove(0, combined.Length - MaximumCapturedCharacters);
+            combined.Insert(0, "[Output truncated to the final 1,000,000 characters]\n");
+        }
+
+        return new WorkspaceProcessResult(
+            process.ExitCode,
+            combined.ToString(),
+            stopwatch.Elapsed);
+    }
+}
+
+internal sealed class WorkspaceBuildService
+{
+    readonly WorkspaceLifecycleService _workspaceLifecycle;
+    readonly IWorkspaceProcessRunner _processRunner;
+    readonly SemaphoreSlim _buildGate = new(1, 1);
+
+    public WorkspaceBuildService(
+        WorkspaceLifecycleService workspaceLifecycle,
+        IWorkspaceProcessRunner processRunner)
+    {
+        _workspaceLifecycle = workspaceLifecycle;
+        _processRunner = processRunner;
+    }
+
+    public async Task<WorkspaceBuildResult> BuildAsync(
+        string configuration,
+        bool configure,
+        CancellationToken cancellationToken = default)
+    {
+        var session = _workspaceLifecycle.Current;
+        if (session is null)
+        {
+            return new WorkspaceBuildResult(
+                false,
+                configuration,
+                null,
+                TimeSpan.Zero,
+                Array.Empty<string>(),
+                string.Empty,
+                "An active workspace is required for a workspace build.");
+        }
+        if (session.GeneratedProjectState.RequiresAttention)
+        {
+            return new WorkspaceBuildResult(
+                false,
+                configuration,
+                null,
+                TimeSpan.Zero,
+                Array.Empty<string>(),
+                string.Empty,
+                session.GeneratedProjectState.Guidance);
+        }
+
+        WorkspaceBuildPlan plan;
+        try
+        {
+            plan = WorkspaceBuildPlan.Create(session, configuration, configure);
+        }
+        catch (ArgumentException exception)
+        {
+            return new WorkspaceBuildResult(
+                false,
+                configuration,
+                null,
+                TimeSpan.Zero,
+                Array.Empty<string>(),
+                string.Empty,
+                exception.Message);
+        }
+
+        await _buildGate.WaitAsync(cancellationToken);
+        try
+        {
+            Directory.CreateDirectory(session.BuildDirectory);
+            var output = new StringBuilder();
+            var commands = new List<string>(plan.Invocations.Count);
+            var duration = TimeSpan.Zero;
+            foreach (var invocation in plan.Invocations)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var displayCommand = FormatCommand(invocation);
+                commands.Add(displayCommand);
+                output.AppendLine("$ " + displayCommand);
+                var result = await _processRunner.RunAsync(
+                    invocation,
+                    cancellationToken);
+                duration += result.Duration;
+                output.Append(result.Output);
+                if (!result.Succeeded)
+                {
+                    return new WorkspaceBuildResult(
+                        false,
+                        plan.Configuration,
+                        result.ExitCode,
+                        duration,
+                        commands,
+                        output.ToString(),
+                        $"Workspace build command failed with exit code {result.ExitCode}.");
+                }
+            }
+
+            return new WorkspaceBuildResult(
+                true,
+                plan.Configuration,
+                0,
+                duration,
+                commands,
+                output.ToString());
+        }
+        finally
+        {
+            _buildGate.Release();
+        }
+    }
+
+    static string FormatCommand(WorkspaceProcessInvocation invocation) =>
+        invocation.FileName + " " + string.Join(" ", invocation.Arguments.Select(Quote));
+
+    static string Quote(string argument) =>
+        argument.Any(char.IsWhiteSpace)
+            ? "\"" + argument.Replace("\"", "\\\"") + "\""
+            : argument;
+}

--- a/build_editor.py
+++ b/build_editor.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent
 EDITOR_PROJECT = REPO_ROOT / "Editor" / "SailorEditor.csproj"
+MCP_BRIDGE_PROJECT = REPO_ROOT / "Editor" / "McpBridge" / "SailorEditor.McpBridge.csproj"
 LOCAL_DOTNET = Path.home() / ".dotnet" / ("dotnet.exe" if platform.system().lower() == "windows" else "dotnet")
 
 
@@ -68,6 +69,16 @@ def maybe_build_engine(engine: bool, config: str) -> None:
         return
     cmd = [sys.executable, str(REPO_ROOT / "build_engine.py"), "--config", config]
     run(cmd)
+
+
+def build_mcp_bridge(dotnet: str, config: str, env: dict[str, str]) -> None:
+    run([
+        dotnet,
+        "build",
+        str(MCP_BRIDGE_PROJECT),
+        "-c",
+        config,
+    ], env=env)
 
 
 def remove_generated_imgui_ini(config: str, output: Path | None) -> None:
@@ -156,6 +167,7 @@ def main() -> int:
         command += ["--self-contained", "true"]
 
     run(command, env=env)
+    build_mcp_bridge(dotnet, args.config, env)
     sync_engine_library(args.config, args.output, args.runtime)
 
     print("\nDone.")


### PR DESCRIPTION
Closes #73

## What changed

- Added an authenticated loopback MCP host inside Sailor Editor and a standalone stdio bridge for MCP clients.
- Added discovery by editor PID or workspace path, with per-process random credentials and stale-endpoint rejection.
- Exposed 12 structured tools for editor state, hierarchy, reflected component schemas, scene batch mutations, undo/redo, asset discovery and commands, scene save, and workspace builds.
- Reused the existing Editor command/history layer for scene and asset mutations; successful scene batches form one undo transaction and no new native C API was added.
- Added lazy, typed asset resolution across all mounted Content roots.
- Added safety checks for confirmation, workspace epochs, immutable/read-only fields, malformed object pointers, and incompatible asset/component references.
- Added MCP activity reporting to the existing AI panel and documented bridge setup.
- Added Editor, bridge, authentication, discovery, YAML, scene-safety, and workspace-build tests plus CI/build integration.

## Why

Issue #73 requires AI clients to inspect and modify the live Sailor scene directly. The loopback host keeps Editor ownership and command semantics intact, while the stdio bridge lets standard MCP clients attach to a specific running Editor instance without exposing the endpoint or credentials outside the local user account.

## Validation

- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --configuration Release --no-restore`: 753 passed.
- `python3 build_editor.py --config Release --runtime maccatalyst-arm64`: MAUI Release and MCP bridge succeeded.
- `cmake --build build-mac-vcpkg --config Release --target SailorLib --parallel 4`: succeeded.
- Live Release smoke in Engine mode and workspace mode:
  - all 12 tools discovered;
  - hierarchy/type/asset reads;
  - create/select/undo/redo and atomic rollback;
  - stale workspace-epoch and incompatible asset rejection;
  - relative asset list/get across workspace and Engine Content roots;
  - confirmed Release workspace configure/build.
- No `Content`, `Cache`, or `Binaries` files are included.

## Residual scope

- This PR implements local process discovery and local MCP transport only. Remote network attachment and frame transport remain out of scope.
