### PR TITLE
Fix CSM caster depth coverage

### DIFF
--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -319,7 +319,9 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 			cameraData.GetFov(),
 			cameraData.GetZNear(),
 			cameraData.GetZFar(),
-			10.0f) * directionalLight.m_lightMatrix;
+			10.0f,
+			glm::ivec2(0),
+			ShadowCasterDepthExtension) * directionalLight.m_lightMatrix;
 		Math::Frustum broadFrustum;
 		broadFrustum.ExtractFrustumPlanes(broadLightMatrix);
 		const auto shadowCasters = sceneView->TraceShadowCasters(broadFrustum);

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -73,6 +73,7 @@ namespace Sailor
 		// EVSM is based on https://www.cg.tuwien.ac.at/research/publications/2013/ADORJAN-2013-ASE/ADORJAN-2013-ASE-thesis.pdf
 		// Also handy paper: https://dl.acm.org/doi/pdf/10.5555/1375714.1375739
 		static constexpr uint32_t NumCascades = 4;
+		static constexpr float ShadowCasterDepthExtension = 200.0f;
 		static constexpr float ShadowCascadeLevels[NumCascades] = { 1.0f / 20.0f, 1.0f / 10.0f, 1.0f / 3.0f, 1.0f };
 		static constexpr glm::ivec2 ShadowCascadeResolutions[NumCascades] = { {4096,4096}, {4096,4096}, {4096,4096}, {4096,4096} };
 		static constexpr glm::ivec2 ShadowCascadeBlur[NumCascades] = { glm::vec2(2, 5), glm::vec2(1, 4), glm::vec2(1, 3), glm::vec2(1, 2) };

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -445,13 +445,13 @@ void ShadowPrepassNode::Clear()
 	m_skinnedShadowMaterials_Evsm.Clear();
 }
 
-glm::mat4 ShadowPrepassNode::CalculateLightProjectionMatrix(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float zMult)
+glm::mat4 ShadowPrepassNode::CalculateLightProjectionMatrix(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float zMult, glm::ivec2 shadowMapResolution, float zSourceExtension)
 {
 	SAILOR_PROFILE_FUNCTION();
 
 	Math::Frustum cameraFrustum{};
 	cameraFrustum.ExtractFrustumPlanes(cameraWorld, aspect, fovY, zNear, zFar);
-	return cameraFrustum.CalculateOrthoMatrixByView(lightView, zMult);
+	return cameraFrustum.CalculateOrthoMatrixByView(lightView, zMult, shadowMapResolution, zSourceExtension);
 }
 
 TVector<glm::mat4> ShadowPrepassNode::CalculateLightProjectionForCascades(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float cameraNearPlane, float cameraFarPlane)
@@ -461,13 +461,19 @@ TVector<glm::mat4> ShadowPrepassNode::CalculateLightProjectionForCascades(const 
 	TVector<glm::mat4> ret;
 	ret.Add(CalculateLightProjectionMatrix(lightView, cameraWorld, aspect, fovY,
 		cameraNearPlane,
-		cameraFarPlane * LightingECS::ShadowCascadeLevels[0], 10.0f));
+		cameraFarPlane * LightingECS::ShadowCascadeLevels[0],
+		10.0f,
+		LightingECS::ShadowCascadeResolutions[0],
+		LightingECS::ShadowCasterDepthExtension));
 
 	for (uint32_t i = 0; i < LightingECS::NumCascades - 1; i++)
 	{
 		ret.Add(CalculateLightProjectionMatrix(lightView, cameraWorld, aspect, fovY,
 			cameraFarPlane * LightingECS::ShadowCascadeLevels[i],
-			cameraFarPlane * LightingECS::ShadowCascadeLevels[i + 1], 10.0f));
+			cameraFarPlane * LightingECS::ShadowCascadeLevels[i + 1],
+			10.0f,
+			LightingECS::ShadowCascadeResolutions[i + 1],
+			LightingECS::ShadowCasterDepthExtension));
 	}
 
 	return ret;

--- a/Runtime/FrameGraph/ShadowPrepassNode.h
+++ b/Runtime/FrameGraph/ShadowPrepassNode.h
@@ -35,7 +35,7 @@ namespace Sailor
 		SAILOR_API virtual void Clear() override;
 
 		SAILOR_API static TVector<glm::mat4> CalculateLightProjectionForCascades(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float cameraNearPlane, float cameraFarPlane);
-		SAILOR_API static glm::mat4 CalculateLightProjectionMatrix(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float zMult);
+		SAILOR_API static glm::mat4 CalculateLightProjectionMatrix(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float zMult, glm::ivec2 shadowMapResolution = glm::ivec2(0), float zSourceExtension = 0.0f);
 
 	protected:
 

--- a/Runtime/Math/Bounds.cpp
+++ b/Runtime/Math/Bounds.cpp
@@ -72,10 +72,10 @@ glm::vec3 Frustum::CalculateCenter() const
 	{
 		center += glm::vec3(v);
 	}
-	return center;
+	return center / (float)m_corners.Num();
 }
 
-glm::mat4 Frustum::CalculateOrthoMatrixByView(const glm::mat4& view, float zMult) const
+glm::mat4 Frustum::CalculateOrthoMatrixByView(const glm::mat4& view, float zMult, glm::ivec2 shadowMapResolution, float zSourceExtension) const
 {
 	float minX = std::numeric_limits<float>::max();
 	float maxX = std::numeric_limits<float>::lowest();
@@ -95,12 +95,38 @@ glm::mat4 Frustum::CalculateOrthoMatrixByView(const glm::mat4& view, float zMult
 		maxZ = std::max(maxZ, trf.z);
 	}
 
+	if (shadowMapResolution.x > 0 && shadowMapResolution.y > 0)
+	{
+		const glm::vec3 worldCenter = CalculateCenter();
+		const glm::vec3 lightSpaceCenter = glm::vec3(view * glm::vec4(worldCenter, 1.0f));
+		float radius = 0.0f;
+		for (const glm::vec3& corner : m_corners)
+		{
+			radius = (std::max)(radius, glm::length(corner - worldCenter));
+		}
+
+		if (radius > std::numeric_limits<float>::epsilon())
+		{
+			const float diameter = 2.0f * radius;
+			const float texelSizeX = diameter / (float)shadowMapResolution.x;
+			const float texelSizeY = diameter / (float)shadowMapResolution.y;
+			const float snappedCenterX = std::round(lightSpaceCenter.x / texelSizeX) * texelSizeX;
+			const float snappedCenterY = std::round(lightSpaceCenter.y / texelSizeY) * texelSizeY;
+			minX = snappedCenterX - radius;
+			maxX = snappedCenterX + radius;
+			minY = snappedCenterY - radius;
+			maxY = snappedCenterY + radius;
+		}
+	}
+
 	// Extend the fitted depth interval relative to its own center. Scaling the
 	// absolute coordinates made the cascade depend on which side of the light's
 	// origin the camera happened to be on.
 	const float zPadding = 0.5f * (maxZ - minZ) * (zMult - 1.0f);
 	minZ -= zPadding;
-	maxZ += zPadding;
+	// Casters behind the camera can still project into the receiver slice. In
+	// light-view space larger Z is toward the directional-light source.
+	maxZ += zPadding + (std::max)(zSourceExtension, 0.0f);
 
 	const float zFar = -minZ;
 	const float zNear = -maxZ;

--- a/Runtime/Math/Bounds.h
+++ b/Runtime/Math/Bounds.h
@@ -189,7 +189,7 @@ namespace Sailor::Math
 		SAILOR_API __forceinline bool ContainsSphere(const Sphere& sphere) const;
 
 		SAILOR_API __forceinline glm::vec3 CalculateCenter() const;
-		SAILOR_API __forceinline glm::mat4 CalculateOrthoMatrixByView(const glm::mat4& view, float zMult) const;
+		SAILOR_API __forceinline glm::mat4 CalculateOrthoMatrixByView(const glm::mat4& view, float zMult, glm::ivec2 shadowMapResolution = glm::ivec2(0), float zSourceExtension = 0.0f) const;
 
 		SAILOR_API __forceinline const TVector<glm::vec3>& GetCorners() const;
 

--- a/Runtime/RHI/DebugContext.cpp
+++ b/Runtime/RHI/DebugContext.cpp
@@ -158,7 +158,7 @@ void DebugContext::DrawFrustum(const Math::Frustum& frustum, const glm::vec4 col
 }
 
 void DebugContext::DrawLightCascades(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float duration)
-{	
+{
 	TVector<Math::Frustum> cascades;
 	cascades.Reserve(LightingECS::NumCascades);
 	for (uint32_t i = 0; i < LightingECS::NumCascades; i++)
@@ -183,7 +183,11 @@ void DebugContext::DrawLightCascades(const glm::mat4& lightView, const glm::mat4
 
 		DrawFrustum(cascadeFrustum, glm::vec4(0, 1, 0, 1), duration);
 
-		const glm::mat4 lightProjection = cascadeFrustum.CalculateOrthoMatrixByView(lightView, zMult);
+		const glm::mat4 lightProjection = cascadeFrustum.CalculateOrthoMatrixByView(
+			lightView,
+			zMult,
+			LightingECS::ShadowCascadeResolutions[i],
+			LightingECS::ShadowCasterDepthExtension);
 
 		// Create matrix and get all extents
 		const glm::mat4 lightViewProjection = lightProjection * lightView;

--- a/Tests/BoundsContractTests.cpp
+++ b/Tests/BoundsContractTests.cpp
@@ -112,6 +112,46 @@ namespace
 				"reverse-Z near corners must be reconstructed from the Vulkan depth-one plane");
 		}
 	}
+
+	void TestFrustumCenterIsTheAverageOfItsCorners()
+	{
+		Math::Frustum cameraSlice;
+		const glm::vec3 cameraPosition(13.0f, 7.0f, -19.0f);
+		const glm::mat4 cameraWorld = glm::translate(glm::mat4(1.0f), cameraPosition);
+		cameraSlice.ExtractFrustumPlanes(cameraWorld, 16.0f / 9.0f, 60.0f, 0.1f, 10.0f);
+
+		glm::vec3 expectedCenter(0.0f);
+		for (const glm::vec3& corner : cameraSlice.GetCorners())
+		{
+			expectedCenter += corner;
+		}
+		expectedCenter /= (float)cameraSlice.GetCorners().Num();
+
+		Require(IsNear(cameraSlice.CalculateCenter(), expectedCenter),
+			"frustum center must be the average of its corners rather than their unnormalized sum");
+	}
+
+	void TestShadowProjectionIncludesCastersTowardLightSource()
+	{
+		Math::Frustum cameraSlice;
+		const glm::mat4 cameraWorld = glm::translate(
+			glm::mat4(1.0f),
+			glm::vec3(0.0f, 0.0f, -50.0f));
+		cameraSlice.ExtractFrustumPlanes(cameraWorld, 1.0f, 60.0f, 1.0f, 10.0f);
+
+		const glm::mat4 shadowProjection = cameraSlice.CalculateOrthoMatrixByView(
+			glm::mat4(1.0f),
+			10.0f,
+			glm::ivec2(4096),
+			200.0f);
+		const float casterDepth = ProjectDepth(
+			shadowProjection,
+			glm::vec3(0.0f, 0.0f, 100.0f));
+		Require(std::isfinite(casterDepth) &&
+			casterDepth >= -0.0001f &&
+			casterDepth <= 1.0001f,
+			"shadow projection must include casters behind the camera toward the light source");
+	}
 }
 
 int main()
@@ -122,6 +162,8 @@ int main()
 		{ "TransformPreservesAllNegativeBounds", TestTransformPreservesAllNegativeBounds },
 		{ "ReversedShadowProjectionUsesZeroToOneDepth", TestReversedShadowProjectionUsesZeroToOneDepth },
 		{ "ReverseZFrustumCornersUseZeroToOneDepth", TestReverseZFrustumCornersUseZeroToOneDepth },
+		{ "FrustumCenterIsTheAverageOfItsCorners", TestFrustumCenterIsTheAverageOfItsCorners },
+		{ "ShadowProjectionIncludesCastersTowardLightSource", TestShadowProjectionIncludesCastersTowardLightSource },
 	};
 
 	for (const auto& test : tests)


### PR DESCRIPTION
## Summary

- stabilize directional-light cascade bounds with averaged frustum centers and texel-snapped spherical XY extents
- extend each cascade 200 meters toward the light source so off-camera casters can shadow visible receivers
- keep debug cascade visualization aligned with the runtime projection
- add numerical contracts for frustum centers and off-camera caster coverage

## Root cause

The directional-light orthographic projection was fitted only to the camera receiver slice. Large casters behind the camera could therefore be clipped by the light-space near plane even when their shadows reached the visible cascade.

## Validation

- Release `SailorLib` build through the `BoundsContractTests` target
- `ctest --test-dir build-mac-vcpkg -C Release -R '^BoundsContractTests$' --output-on-failure`
- manual Release editor verification of the previously failing camera position
- `git diff --check`

No `Content` files are included.