### PR TITLE
Fix Windows editor viewport integration

### DIFF
--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -538,7 +538,7 @@ public sealed class EngineLifecycleTests
         Assert.True(removeAfterFailure > nativeBind);
 
         var sync = lifecycleSource.IndexOf("public bool Sync", StringComparison.Ordinal);
-        var announceHost = lifecycleSource.IndexOf("backend.BindMacHost(viewportId, frame.NativeHostHandle);", sync, StringComparison.Ordinal);
+        var announceHost = lifecycleSource.IndexOf("backend.BindMacHost(viewportId, frame.NativeHostHandle, frame.NativeHostScale);", sync, StringComparison.Ordinal);
         var updateViewport = lifecycleSource.IndexOf("backend.TryUpdateViewport", announceHost, StringComparison.Ordinal);
         Assert.True(sync >= 0);
         Assert.True(announceHost > sync);
@@ -721,6 +721,107 @@ public sealed class EngineLifecycleTests
             source,
             StringComparison.Ordinal);
         Assert.DoesNotContain("TryRefreshSceneRemoteViewport(Viewport)", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void WindowsNativeViewport_UsesDrawableRenderAreaAndRoutesCapturedKeyboardInput()
+    {
+        var graphicsSource = ReadRepositoryFile(
+            "Runtime",
+            "GraphicsDriver",
+            "Vulkan",
+            "VulkanGraphicsDriver.cpp");
+        var handlerSource = ReadRepositoryFile(
+            "Editor",
+            "Platforms",
+            "Windows",
+            "NativeSceneViewportHandler.Windows.cs").ReplaceLineEndings("\n");
+        var bridgeSource = ReadRepositoryFile(
+            "Runtime",
+            "Editor",
+            "EditorRuntimeBridge.cpp");
+        var imGuiSource = ReadRepositoryFile(
+            "Runtime",
+            "Submodules",
+            "ImGuiApi.cpp");
+        var editorCameraSource = ReadRepositoryFile(
+            "Runtime",
+            "Components",
+            "EditorComponent.cpp");
+
+        Assert.Equal(
+            1,
+            graphicsSource.Split(
+                "#if defined(__APPLE__) || defined(_WIN32)",
+                StringSplitOptions.None).Length - 1);
+        Assert.Contains(
+            "#if defined(_WIN32)",
+            graphicsSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "GetMainWindow()->GetRenderArea()",
+            graphicsSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "keyboardRoot?.AddHandler(\n            UIElement.KeyDownEvent",
+            handlerSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "(!viewportFocused && !HasRightMouseCapture())",
+            handlerSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ReleaseForwardedKeys();",
+            handlerSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "AllowFocusOnInteraction = true",
+            handlerSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "SetViewportFocused(true);",
+            handlerSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "ResolveDrawablePosition(panel, point.Position.X, point.Position.Y)",
+            handlerSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "return ((float)(x * scale), (float)(y * scale));",
+            handlerSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "if (!hadActivePointerButtons)",
+            handlerSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "HandleWindowsEditorInput(event);",
+            bridgeSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "io.DisplaySize = ImVec2((float)renderArea.x, (float)renderArea.y);",
+            imGuiSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "constexpr float preciseMoveMultiplier = 0.1f;",
+            editorCameraSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "GetWorld()->GetInput().IsKeyDown(VK_CONTROL) ? preciseMoveMultiplier : 1.0f",
+            editorCameraSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "GetWorld()->GetInput().IsButtonClick(VK_RBUTTON)",
+            editorCameraSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "GetWorld()->GetInput().GetButtonPressCursorPos(VK_RBUTTON)",
+            editorCameraSource,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "platformView.KeyDown +=",
+            handlerSource,
+            StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1405,6 +1506,10 @@ public sealed class EngineLifecycleTests
             "EntryPoint = \"SailorProtocolStopLocalHost\"",
             nativeInteropSource,
             StringComparison.Ordinal);
+        Assert.Contains(
+            "EntryPoint = \"SailorProtocolSetWindowsViewportHost\"",
+            nativeInteropSource,
+            StringComparison.Ordinal);
         Assert.DoesNotContain(
             "SailorProtocolInvoke",
             nativeInteropSource,
@@ -1413,8 +1518,12 @@ public sealed class EngineLifecycleTests
             "SailorProtocolFreeBuffer",
             nativeInteropSource,
             StringComparison.Ordinal);
+        Assert.Contains(
+            "if (params.m_bRunConsole && !params.m_bIsEditor)",
+            nativeSource,
+            StringComparison.Ordinal);
         Assert.Equal(
-            3,
+            4,
             nativeInteropSource.Split("[DllImport(", StringSplitOptions.None).Length - 1);
         Assert.Contains(
             "const int numArguments = request.arguments_size();",

--- a/Editor.Tests/SceneViewportLifecycleTests.cs
+++ b/Editor.Tests/SceneViewportLifecycleTests.cs
@@ -19,12 +19,14 @@ public sealed class SceneViewportLifecycleTests
             new SceneViewportRenderTarget(1600, 1200),
             true,
             true,
-            (nint)0xCAFE));
+            (nint)0xCAFE,
+            1.5));
 
         Assert.True(updated);
         Assert.Equal([(ulong)7], backend.UpdatedViewportIds);
         Assert.Equal((ulong)7, backend.BoundViewportId);
         Assert.Equal((nint)0xCAFE, backend.BoundHostHandle);
+        Assert.Equal(1.5, backend.BoundHostScale);
         Assert.Equal(new SceneViewportRect(0, 0, 800, 600), backend.LastEditorViewport);
         Assert.Equal(new SceneViewportRenderTarget(1600, 1200), backend.LastRenderTarget);
     }
@@ -232,6 +234,7 @@ public sealed class SceneViewportLifecycleTests
     {
         public ulong BoundViewportId { get; private set; }
         public nint BoundHostHandle { get; private set; }
+        public double BoundHostScale { get; private set; }
         public int BindCount { get; private set; }
         public List<nint> BoundHostHandles { get; } = [];
         public SceneViewportRect LastEditorViewport { get; private set; }
@@ -241,10 +244,11 @@ public sealed class SceneViewportLifecycleTests
         public List<ulong> UpdatedViewportIds { get; } = [];
         public List<string> Operations { get; } = [];
 
-        public void BindMacHost(ulong viewportId, nint hostHandle)
+        public void BindMacHost(ulong viewportId, nint hostHandle, double compositionScale)
         {
             BoundViewportId = viewportId;
             BoundHostHandle = hostHandle;
+            BoundHostScale = compositionScale;
             BindCount++;
             BoundHostHandles.Add(hostHandle);
             Operations.Add($"bind:{hostHandle}");

--- a/Editor/MainPage.xaml.cs
+++ b/Editor/MainPage.xaml.cs
@@ -56,7 +56,6 @@ public partial class MainPage : ContentPage
         }
         if (_shellHost.CurrentLayout is null)
             await _shellHost.InitializeAsync();
-        ShellLayoutHost.Rebuild();
         UpdateStatusText();
     }
 
@@ -64,8 +63,6 @@ public partial class MainPage : ContentPage
     {
         if (e.PropertyName == nameof(EditorShellHost.StatusText))
             MainThread.BeginInvokeOnMainThread(UpdateStatusText);
-        if (e.PropertyName == nameof(EditorShellHost.CurrentLayout))
-            MainThread.BeginInvokeOnMainThread(() => ShellLayoutHost.Rebuild());
     }
 
     void OnWorkspaceProjectionChanged(object? sender, EventArgs e)

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -17,6 +17,8 @@ using SailorEditor.Workflow;
 using SailorEditor.Mcp;
 #if MACCATALYST
 using SailorEditor.Platforms.MacCatalyst;
+#elif WINDOWS
+using SailorEditor.Platforms.Windows;
 #endif
 
 namespace SailorEditor
@@ -31,7 +33,7 @@ namespace SailorEditor
             builder
                 .UseMauiApp<App>()
                 .UseMauiCommunityToolkit()
-#if MACCATALYST
+#if MACCATALYST || WINDOWS
                 .ConfigureMauiHandlers(handlers =>
                 {
                     handlers.AddHandler<NativeSceneViewport, NativeSceneViewportHandler>();

--- a/Editor/Platforms/Windows/NativeSceneViewportHandler.Windows.cs
+++ b/Editor/Platforms/Windows/NativeSceneViewportHandler.Windows.cs
@@ -1,0 +1,553 @@
+#nullable enable
+using Microsoft.Maui.Handlers;
+using Microsoft.UI.Input;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Input;
+using Microsoft.UI.Xaml.Media;
+using SailorEditor.Controls;
+using System.Runtime.InteropServices;
+using Windows.System;
+
+namespace SailorEditor.Platforms.Windows;
+
+public sealed class NativeSceneViewportHandler :
+    ViewHandler<NativeSceneViewport, SwapChainPanel>,
+    INativeSceneViewportLayoutHost
+{
+    public static readonly IPropertyMapper<NativeSceneViewport, NativeSceneViewportHandler> Mapper =
+        new PropertyMapper<NativeSceneViewport, NativeSceneViewportHandler>(ViewMapper)
+        {
+            [nameof(Microsoft.Maui.IView.Background)] = static (_, _) => { }
+        };
+
+    nint hostHandle;
+    NativeSceneViewportInputModifier activePointerButtons;
+    readonly HashSet<VirtualKey> forwardedKeys = [];
+    readonly KeyEventHandler rootKeyDownHandler;
+    readonly KeyEventHandler rootKeyUpHandler;
+    readonly PointerEventHandler rootPointerPressedHandler;
+    UIElement? keyboardRoot;
+    bool viewportFocused;
+    double lastPublishedWidth = -1;
+    double lastPublishedHeight = -1;
+    double lastPublishedScale = -1;
+    uint lastPublishedDrawableWidth;
+    uint lastPublishedDrawableHeight;
+
+    public NativeSceneViewportHandler() : base(Mapper)
+    {
+        rootKeyDownHandler = OnRootKeyDown;
+        rootKeyUpHandler = OnRootKeyUp;
+        rootPointerPressedHandler = OnRootPointerPressed;
+    }
+
+    protected override SwapChainPanel CreatePlatformView() => new()
+    {
+        AllowFocusOnInteraction = true
+    };
+
+    protected override void ConnectHandler(SwapChainPanel platformView)
+    {
+        base.ConnectHandler(platformView);
+
+        platformView.Loaded += OnLoaded;
+        platformView.Unloaded += OnUnloaded;
+        platformView.SizeChanged += OnSizeChanged;
+        platformView.CompositionScaleChanged += OnCompositionScaleChanged;
+        platformView.PointerEntered += OnPointerEntered;
+        platformView.PointerMoved += OnPointerMoved;
+        platformView.PointerPressed += OnPointerPressed;
+        platformView.PointerReleased += OnPointerReleased;
+        platformView.PointerWheelChanged += OnPointerWheelChanged;
+        platformView.PointerCaptureLost += OnPointerCaptureLost;
+        platformView.GotFocus += OnGotFocus;
+        platformView.LostFocus += OnLostFocus;
+
+        if (platformView.IsLoaded)
+        {
+            AttachKeyboardRoot(platformView);
+            PublishHostHandle(platformView);
+            PublishLayout(platformView);
+        }
+    }
+
+    protected override void DisconnectHandler(SwapChainPanel platformView)
+    {
+        platformView.Loaded -= OnLoaded;
+        platformView.Unloaded -= OnUnloaded;
+        platformView.SizeChanged -= OnSizeChanged;
+        platformView.CompositionScaleChanged -= OnCompositionScaleChanged;
+        platformView.PointerEntered -= OnPointerEntered;
+        platformView.PointerMoved -= OnPointerMoved;
+        platformView.PointerPressed -= OnPointerPressed;
+        platformView.PointerReleased -= OnPointerReleased;
+        platformView.PointerWheelChanged -= OnPointerWheelChanged;
+        platformView.PointerCaptureLost -= OnPointerCaptureLost;
+        platformView.GotFocus -= OnGotFocus;
+        platformView.LostFocus -= OnLostFocus;
+
+        ReleaseViewportFocus();
+        DetachKeyboardRoot();
+        ReleaseHostHandle();
+        base.DisconnectHandler(platformView);
+    }
+
+    public void RequestLayoutUpdate(double width, double height, double contentsScale)
+    {
+        if (PlatformView is not { } platformView)
+        {
+            return;
+        }
+
+        PublishLayout(
+            platformView,
+            platformView.ActualWidth > 1 ? platformView.ActualWidth : width,
+            platformView.ActualHeight > 1 ? platformView.ActualHeight : height,
+            ResolveScale(platformView, contentsScale));
+    }
+
+    public void RequestInputFocus()
+    {
+        if (PlatformView is not { } panel)
+        {
+            return;
+        }
+
+        AttachKeyboardRoot(panel);
+        SetViewportFocused(true);
+        panel.Focus(FocusState.Programmatic);
+    }
+
+    void OnLoaded(object sender, RoutedEventArgs args)
+    {
+        if (sender is not SwapChainPanel panel)
+        {
+            return;
+        }
+
+        AttachKeyboardRoot(panel);
+        PublishHostHandle(panel);
+        PublishLayout(panel);
+    }
+
+    void OnUnloaded(object sender, RoutedEventArgs args)
+    {
+        ReleaseViewportFocus();
+        DetachKeyboardRoot();
+        ReleaseHostHandle();
+    }
+
+    void AttachKeyboardRoot(SwapChainPanel panel)
+    {
+        var root = panel.XamlRoot?.Content as UIElement;
+        if (ReferenceEquals(keyboardRoot, root))
+        {
+            return;
+        }
+
+        DetachKeyboardRoot();
+        keyboardRoot = root;
+        keyboardRoot?.AddHandler(
+            UIElement.KeyDownEvent,
+            rootKeyDownHandler,
+            handledEventsToo: true);
+        keyboardRoot?.AddHandler(
+            UIElement.KeyUpEvent,
+            rootKeyUpHandler,
+            handledEventsToo: true);
+        keyboardRoot?.AddHandler(
+            UIElement.PointerPressedEvent,
+            rootPointerPressedHandler,
+            handledEventsToo: true);
+    }
+
+    void DetachKeyboardRoot()
+    {
+        keyboardRoot?.RemoveHandler(
+            UIElement.KeyDownEvent,
+            rootKeyDownHandler);
+        keyboardRoot?.RemoveHandler(
+            UIElement.KeyUpEvent,
+            rootKeyUpHandler);
+        keyboardRoot?.RemoveHandler(
+            UIElement.PointerPressedEvent,
+            rootPointerPressedHandler);
+        keyboardRoot = null;
+    }
+
+    void OnSizeChanged(object sender, SizeChangedEventArgs args)
+    {
+        if (sender is SwapChainPanel panel)
+        {
+            PublishLayout(panel, args.NewSize.Width, args.NewSize.Height, ResolveScale(panel));
+        }
+    }
+
+    void OnCompositionScaleChanged(SwapChainPanel sender, object args)
+    {
+        PublishLayout(sender);
+    }
+
+    void PublishHostHandle(SwapChainPanel panel)
+    {
+        if (hostHandle != nint.Zero)
+        {
+            return;
+        }
+
+        hostHandle = Marshal.GetIUnknownForObject(panel);
+        VirtualView?.UpdateHostHandle(hostHandle);
+    }
+
+    void ReleaseHostHandle()
+    {
+        if (hostHandle == nint.Zero)
+        {
+            return;
+        }
+
+        VirtualView?.UpdateHostHandle(nint.Zero);
+        Marshal.Release(hostHandle);
+        hostHandle = nint.Zero;
+    }
+
+    void PublishLayout(SwapChainPanel panel)
+    {
+        PublishLayout(panel, panel.ActualWidth, panel.ActualHeight, ResolveScale(panel));
+    }
+
+    void PublishLayout(SwapChainPanel panel, double width, double height, double scale)
+    {
+        width = Math.Max(0, width);
+        height = Math.Max(0, height);
+        scale = scale > 0 ? scale : 1;
+        var drawableWidth = (uint)Math.Max(1, Math.Round(width * scale));
+        var drawableHeight = (uint)Math.Max(1, Math.Round(height * scale));
+        if (Math.Abs(lastPublishedWidth - width) < 0.5 &&
+            Math.Abs(lastPublishedHeight - height) < 0.5 &&
+            Math.Abs(lastPublishedScale - scale) < 0.01 &&
+            lastPublishedDrawableWidth == drawableWidth &&
+            lastPublishedDrawableHeight == drawableHeight)
+        {
+            return;
+        }
+
+        lastPublishedWidth = width;
+        lastPublishedHeight = height;
+        lastPublishedScale = scale;
+        lastPublishedDrawableWidth = drawableWidth;
+        lastPublishedDrawableHeight = drawableHeight;
+        VirtualView?.UpdateHostLayout(
+            width,
+            height,
+            scale,
+            drawableWidth,
+            drawableHeight);
+    }
+
+    static double ResolveScale(SwapChainPanel panel, double fallback = 1)
+    {
+        if (panel.CompositionScaleX > 0 &&
+            panel.CompositionScaleY > 0 &&
+            Math.Abs(panel.CompositionScaleX - panel.CompositionScaleY) < 0.01)
+        {
+            return panel.CompositionScaleX;
+        }
+
+        return panel.XamlRoot?.RasterizationScale is > 0 and var scale
+            ? scale
+            : Math.Max(1, fallback);
+    }
+
+    void OnPointerEntered(object sender, PointerRoutedEventArgs args)
+    {
+        if (sender is SwapChainPanel panel)
+        {
+            PublishPointer(panel, args, NativeSceneViewportInputKind.PointerMove);
+        }
+    }
+
+    void OnPointerMoved(object sender, PointerRoutedEventArgs args)
+    {
+        if (sender is SwapChainPanel panel)
+        {
+            PublishPointer(panel, args, NativeSceneViewportInputKind.PointerMove);
+        }
+    }
+
+    void OnPointerPressed(object sender, PointerRoutedEventArgs args)
+    {
+        if (sender is not SwapChainPanel panel)
+        {
+            return;
+        }
+
+        AttachKeyboardRoot(panel);
+        var point = args.GetCurrentPoint(panel);
+        var (button, modifier) = ResolveChangedButton(point.Properties.PointerUpdateKind);
+        activePointerButtons |= modifier;
+        SetViewportFocused(true);
+        panel.Focus(FocusState.Pointer);
+        panel.CapturePointer(args.Pointer);
+        PublishPointer(
+            panel,
+            args,
+            NativeSceneViewportInputKind.PointerButton,
+            button,
+            pressed: true);
+        args.Handled = true;
+    }
+
+    void OnPointerReleased(object sender, PointerRoutedEventArgs args)
+    {
+        if (sender is not SwapChainPanel panel)
+        {
+            return;
+        }
+
+        var point = args.GetCurrentPoint(panel);
+        var (button, modifier) = ResolveChangedButton(point.Properties.PointerUpdateKind);
+        activePointerButtons &= ~modifier;
+        PublishPointer(
+            panel,
+            args,
+            NativeSceneViewportInputKind.PointerButton,
+            button,
+            pressed: false);
+        if (modifier == NativeSceneViewportInputModifier.MouseRight)
+        {
+            ReleaseForwardedKeys();
+        }
+        if (activePointerButtons == NativeSceneViewportInputModifier.None)
+        {
+            panel.ReleasePointerCapture(args.Pointer);
+        }
+        args.Handled = true;
+    }
+
+    void OnPointerWheelChanged(object sender, PointerRoutedEventArgs args)
+    {
+        if (sender is not SwapChainPanel panel)
+        {
+            return;
+        }
+
+        var point = args.GetCurrentPoint(panel);
+        var position = ResolveDrawablePosition(panel, point.Position.X, point.Position.Y);
+        VirtualView?.PublishInput(new NativeSceneViewportInputEvent(
+            NativeSceneViewportInputKind.PointerWheel,
+            position.X,
+            position.Y,
+            WheelDeltaY: point.Properties.MouseWheelDelta,
+            Modifiers: ResolveModifiers(args.KeyModifiers) | activePointerButtons));
+        args.Handled = true;
+    }
+
+    void OnPointerCaptureLost(object sender, PointerRoutedEventArgs args)
+    {
+        var hadActivePointerButtons =
+            activePointerButtons != NativeSceneViewportInputModifier.None;
+        activePointerButtons = NativeSceneViewportInputModifier.None;
+        ReleaseForwardedKeys();
+        if (!hadActivePointerButtons)
+        {
+            return;
+        }
+
+        VirtualView?.PublishInput(new NativeSceneViewportInputEvent(
+            NativeSceneViewportInputKind.Capture,
+            Captured: false));
+    }
+
+    void PublishPointer(
+        SwapChainPanel panel,
+        PointerRoutedEventArgs args,
+        NativeSceneViewportInputKind kind,
+        uint button = 0,
+        bool pressed = false)
+    {
+        var point = args.GetCurrentPoint(panel);
+        var position = ResolveDrawablePosition(panel, point.Position.X, point.Position.Y);
+        VirtualView?.PublishInput(new NativeSceneViewportInputEvent(
+            kind,
+            position.X,
+            position.Y,
+            Button: button,
+            Modifiers: ResolveModifiers(args.KeyModifiers) | activePointerButtons,
+            Pressed: pressed,
+            Captured: activePointerButtons != NativeSceneViewportInputModifier.None));
+    }
+
+    void OnGotFocus(object sender, RoutedEventArgs args)
+    {
+        SetViewportFocused(true);
+    }
+
+    void OnLostFocus(object sender, RoutedEventArgs args)
+    {
+        if (activePointerButtons != NativeSceneViewportInputModifier.None)
+        {
+            return;
+        }
+
+        ReleaseViewportFocus();
+    }
+
+    void OnRootPointerPressed(object sender, PointerRoutedEventArgs args)
+    {
+        if (PlatformView is { } panel &&
+            args.OriginalSource is DependencyObject source &&
+            IsDescendantOf(source, panel))
+        {
+            return;
+        }
+
+        ReleaseViewportFocus();
+    }
+
+    void SetViewportFocused(bool focused)
+    {
+        if (viewportFocused == focused)
+        {
+            return;
+        }
+
+        viewportFocused = focused;
+        PublishFocus(focused);
+    }
+
+    void ReleaseViewportFocus()
+    {
+        var hadInputOwnership = viewportFocused ||
+            activePointerButtons != NativeSceneViewportInputModifier.None ||
+            forwardedKeys.Count > 0;
+        viewportFocused = false;
+        activePointerButtons = NativeSceneViewportInputModifier.None;
+        ReleaseForwardedKeys();
+        if (hadInputOwnership)
+        {
+            PublishFocus(false);
+        }
+    }
+
+    void PublishFocus(bool focused)
+    {
+        VirtualView?.PublishInput(new NativeSceneViewportInputEvent(
+            NativeSceneViewportInputKind.Focus,
+            Focused: focused));
+    }
+
+    void OnRootKeyDown(object sender, KeyRoutedEventArgs args)
+    {
+        if (!ShouldForwardKey(args.Key) ||
+            (!viewportFocused && !HasRightMouseCapture()))
+        {
+            return;
+        }
+
+        if (forwardedKeys.Add(args.Key))
+        {
+            PublishKey(args.Key, pressed: true);
+        }
+        args.Handled = true;
+    }
+
+    void OnRootKeyUp(object sender, KeyRoutedEventArgs args)
+    {
+        if (!ShouldForwardKey(args.Key) ||
+            (!forwardedKeys.Remove(args.Key) &&
+             !viewportFocused &&
+             !HasRightMouseCapture()))
+        {
+            return;
+        }
+
+        PublishKey(args.Key, pressed: false);
+        args.Handled = true;
+    }
+
+    void ReleaseForwardedKeys()
+    {
+        foreach (var key in forwardedKeys)
+        {
+            PublishKey(key, pressed: false);
+        }
+        forwardedKeys.Clear();
+    }
+
+    bool HasRightMouseCapture() =>
+        (activePointerButtons & NativeSceneViewportInputModifier.MouseRight) != 0;
+
+    static (float X, float Y) ResolveDrawablePosition(
+        SwapChainPanel panel,
+        double x,
+        double y)
+    {
+        var scale = ResolveScale(panel);
+        return ((float)(x * scale), (float)(y * scale));
+    }
+
+    static bool IsDescendantOf(
+        DependencyObject source,
+        DependencyObject ancestor)
+    {
+        for (DependencyObject? current = source;
+             current is not null;
+             current = VisualTreeHelper.GetParent(current))
+        {
+            if (ReferenceEquals(current, ancestor))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static bool ShouldForwardKey(VirtualKey key) =>
+        key != VirtualKey.None && (uint)key < 256;
+
+    void PublishKey(VirtualKey key, bool pressed)
+    {
+        VirtualView?.PublishInput(new NativeSceneViewportInputEvent(
+            NativeSceneViewportInputKind.Key,
+            KeyCode: (uint)key,
+            Modifiers: activePointerButtons,
+            Pressed: pressed));
+    }
+
+    static (uint Button, NativeSceneViewportInputModifier Modifier) ResolveChangedButton(
+        PointerUpdateKind updateKind) => updateKind switch
+    {
+        PointerUpdateKind.LeftButtonPressed or PointerUpdateKind.LeftButtonReleased =>
+            (0, NativeSceneViewportInputModifier.MouseLeft),
+        PointerUpdateKind.RightButtonPressed or PointerUpdateKind.RightButtonReleased =>
+            (1, NativeSceneViewportInputModifier.MouseRight),
+        PointerUpdateKind.MiddleButtonPressed or PointerUpdateKind.MiddleButtonReleased =>
+            (2, NativeSceneViewportInputModifier.MouseMiddle),
+        _ => (0, NativeSceneViewportInputModifier.None)
+    };
+
+    static NativeSceneViewportInputModifier ResolveModifiers(VirtualKeyModifiers modifiers)
+    {
+        var result = NativeSceneViewportInputModifier.None;
+        if ((modifiers & VirtualKeyModifiers.Shift) != 0)
+        {
+            result |= NativeSceneViewportInputModifier.Shift;
+        }
+        if ((modifiers & VirtualKeyModifiers.Control) != 0)
+        {
+            result |= NativeSceneViewportInputModifier.Control;
+        }
+        if ((modifiers & VirtualKeyModifiers.Menu) != 0)
+        {
+            result |= NativeSceneViewportInputModifier.Alt;
+        }
+        if ((modifiers & VirtualKeyModifiers.Windows) != 0)
+        {
+            result |= NativeSceneViewportInputModifier.Meta;
+        }
+        return result;
+    }
+}

--- a/Editor/Protocol/EngineProtocolNative.cs
+++ b/Editor/Protocol/EngineProtocolNative.cs
@@ -68,4 +68,16 @@ internal static class EngineProtocolNative
         CallingConvention = CallingConvention.Cdecl)]
     internal static extern void SailorProtocolStopLocalHost(
         [MarshalAs(UnmanagedType.I1)] bool shutdownEngine);
+
+#if WINDOWS
+    [DllImport(
+        EngineLibrary,
+        EntryPoint = "SailorProtocolSetWindowsViewportHost",
+        ExactSpelling = true,
+        CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int SailorProtocolSetWindowsViewportHost(
+        ulong viewportId,
+        nint swapChainPanelInspectable,
+        float compositionScale);
+#endif
 }

--- a/Editor/Scene/EngineSceneViewportBackend.cs
+++ b/Editor/Scene/EngineSceneViewportBackend.cs
@@ -4,7 +4,8 @@ namespace SailorEditor.Scene;
 
 internal sealed class EngineSceneViewportBackend(EngineService engineService) : ISceneViewportBackend
 {
-    public void BindMacHost(ulong viewportId, nint hostHandle) => engineService.BindMacRemoteViewportHost(viewportId, hostHandle);
+    public void BindMacHost(ulong viewportId, nint hostHandle, double compositionScale)
+        => engineService.BindMacRemoteViewportHost(viewportId, hostHandle, compositionScale);
 
     public bool TryUpdateViewport(ulong viewportId, SceneViewportRect rect, bool visible, bool focused)
         => engineService.TryUpdateRemoteViewport(viewportId, new Rect(rect.X, rect.Y, rect.Width, rect.Height), visible, focused);

--- a/Editor/Scene/SceneViewportLifecycle.cs
+++ b/Editor/Scene/SceneViewportLifecycle.cs
@@ -20,14 +20,15 @@ public readonly record struct SceneViewportFrame(
     SceneViewportRenderTarget RenderTarget,
     bool IsVisible,
     bool IsFocused,
-    nint NativeHostHandle = 0)
+    nint NativeHostHandle = 0,
+    double NativeHostScale = 1)
 {
     public bool HasNativeHost => NativeHostHandle != 0;
 }
 
 public interface ISceneViewportBackend
 {
-    void BindMacHost(ulong viewportId, nint hostHandle);
+    void BindMacHost(ulong viewportId, nint hostHandle, double compositionScale);
     bool TryUpdateViewport(ulong viewportId, SceneViewportRect rect, bool visible, bool focused);
     void SetEditorViewport(SceneViewportRect rect);
     void SetRenderTargetSize(uint width, uint height);
@@ -62,12 +63,12 @@ public sealed class SceneViewportLifecycleAdapter(ISceneViewportBackend backend,
 
         if (frame.HasNativeHost)
         {
-            backend.BindMacHost(viewportId, frame.NativeHostHandle);
+            backend.BindMacHost(viewportId, frame.NativeHostHandle, frame.NativeHostScale);
             _observedHostHandle = frame.NativeHostHandle;
         }
         else if (_observedHostHandle != 0)
         {
-            backend.BindMacHost(viewportId, 0);
+            backend.BindMacHost(viewportId, 0, 1);
             _observedHostHandle = 0;
         }
 
@@ -102,7 +103,7 @@ public sealed class SceneViewportLifecycleAdapter(ISceneViewportBackend backend,
 
         if (_observedHostHandle != 0)
         {
-            backend.BindMacHost(viewportId, 0);
+            backend.BindMacHost(viewportId, 0, 1);
             _observedHostHandle = 0;
         }
 

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -146,6 +146,9 @@ namespace SailorEditor.Services
         readonly object macRemoteViewportHostLock = new();
         readonly Dictionary<ulong, (long Generation, nint Handle)> appliedMacRemoteViewportHosts = [];
 #endif
+#if WINDOWS
+        int windowsViewportInteropFailureLogged;
+#endif
         EngineSession? activeSession;
         EngineLaunchContext? activeLaunchContext;
         int lastExitCode;
@@ -643,9 +646,38 @@ namespace SailorEditor.Services
             return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", ".."));
         }
 
-        public void BindMacRemoteViewportHost(ulong viewportId, nint hostHandle)
+        public void BindMacRemoteViewportHost(
+            ulong viewportId,
+            nint hostHandle,
+            double compositionScale = 1)
         {
-#if MACCATALYST
+#if WINDOWS
+            if (!IsRunning)
+            {
+                return;
+            }
+
+            try
+            {
+                if (EngineProtocolNative.SailorProtocolSetWindowsViewportHost(
+                        viewportId,
+                        hostHandle,
+                        double.IsFinite(compositionScale) && compositionScale > 0
+                            ? (float)compositionScale
+                            : 1.0f) != 0)
+                {
+                    Interlocked.Exchange(ref windowsViewportInteropFailureLogged, 0);
+                }
+            }
+            catch (Exception exception)
+            {
+                if (Interlocked.Exchange(ref windowsViewportInteropFailureLogged, 1) == 0)
+                {
+                    Console.WriteLine(
+                        $"[EngineService] Windows viewport host binding failed: {exception}");
+                }
+            }
+#elif MACCATALYST
             var generation = Volatile.Read(ref engineGeneration);
             if (!IsGenerationActive(generation))
             {

--- a/Editor/Shell/ShellLayoutView.cs
+++ b/Editor/Shell/ShellLayoutView.cs
@@ -27,6 +27,8 @@ public sealed class ShellLayoutView : ContentView
     static readonly Color SplitterColor = Color.FromArgb("#2A2C31");
     static readonly Color SplitterHoverColor = Color.FromArgb("#4D8DFF");
 
+    readonly List<ContentView> _panelContentHosts = [];
+
     public static readonly BindableProperty HostProperty = BindableProperty.Create(
         nameof(Host), typeof(EditorShellHost), typeof(ShellLayoutView), propertyChanged: OnHostChanged);
 
@@ -50,7 +52,7 @@ public sealed class ShellLayoutView : ContentView
 
     void OnHostPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
     {
-        if (e.PropertyName is nameof(EditorShellHost.State) or nameof(EditorShellHost.CurrentLayout))
+        if (e.PropertyName == nameof(EditorShellHost.CurrentLayout))
             Rebuild();
     }
 
@@ -58,6 +60,11 @@ public sealed class ShellLayoutView : ContentView
     {
         if (IsResizing)
             return;
+
+        foreach (var contentHost in _panelContentHosts)
+            contentHost.Content = null;
+        _panelContentHosts.Clear();
+        Content = null;
 
         Content = Host?.CurrentLayout is { } layout
             ? BuildNode(layout.Root.Content, [])
@@ -205,6 +212,7 @@ public sealed class ShellLayoutView : ContentView
                             finally
                             {
                                 IsResizing = false;
+                                Rebuild();
                             }
                         });
                     }
@@ -280,6 +288,7 @@ public sealed class ShellLayoutView : ContentView
             VerticalOptions = LayoutOptions.Fill,
             BackgroundColor = Colors.Transparent
         };
+        _panelContentHosts.Add(contentHost);
 
         var tabBar = new HorizontalStackLayout
         {

--- a/Editor/Shell/YamlEditorShellLayoutStore.cs
+++ b/Editor/Shell/YamlEditorShellLayoutStore.cs
@@ -8,7 +8,19 @@ public sealed class YamlEditorShellLayoutStore : IEditorShellLayoutStore
 
     public YamlEditorShellLayoutStore(string? layoutPath = null)
     {
-        _layoutPath = layoutPath ?? Path.Combine(FileSystem.Current.AppDataDirectory, "Layouts", "editor-shell-layout.yaml");
+#if MACCATALYST
+        var defaultLayoutPath = Path.Combine(
+            Microsoft.Maui.Storage.FileSystem.Current.AppDataDirectory,
+            "Layouts",
+            "editor-shell-layout.yaml");
+#else
+        var defaultLayoutPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "SailorEditor",
+            "Layouts",
+            "editor-shell-layout.yaml");
+#endif
+        _layoutPath = layoutPath ?? defaultLayoutPath;
     }
 
     public async ValueTask<EditorLayout?> LoadAsync(CancellationToken cancellationToken = default)

--- a/Editor/Views/SceneView.xaml.cs
+++ b/Editor/Views/SceneView.xaml.cs
@@ -59,7 +59,7 @@ namespace SailorEditor.Views
         long lastViewportIntegrationTickMs = -1;
         long lastViewportStatusTickMs = -1;
         bool lifecycleSubscribed;
-#if MACCATALYST
+#if WINDOWS || MACCATALYST
         static readonly bool UseNativeViewportHost = true;
 #else
         static readonly bool UseNativeViewportHost = false;
@@ -86,7 +86,7 @@ namespace SailorEditor.Views
             var shellState = MauiProgram.GetService<State.ShellState>();
             focusCoordinator = new SceneShellFocusCoordinator(shellState, $"scene:{EngineService.SceneViewportId}", () => ResolveFocusTarget(shellState));
 
-#if !MACCATALYST
+#if !WINDOWS && !MACCATALYST
             var tapGesture = new TapGestureRecognizer();
             tapGesture.Tapped += (sender, args) =>
             {
@@ -110,7 +110,7 @@ namespace SailorEditor.Views
                 SetSceneFocus(false, sendRemoteFocus: true);
             };
 
-#if MACCATALYST
+#if WINDOWS || MACCATALYST
             if (UseNativeViewportHost)
             {
                 nativeViewportHost = new NativeSceneViewport
@@ -1007,13 +1007,13 @@ namespace SailorEditor.Views
             var remoteRect = Viewport.GetAbsolutePositionWin();
             var editorRect = new SceneViewportRect(remoteRect.X, remoteRect.Y, remoteRect.Width, remoteRect.Height);
             var renderTarget = default(SceneViewportRenderTarget);
-#if MACCATALYST
+#if WINDOWS || MACCATALYST
             if (UseNativeViewportHost)
             {
                 if (nativeHostHandle == nint.Zero)
                 {
                     if (ViewportStatusOverlay.IsVisible)
-                        SetLabelText(ViewportStatusText, "Waiting for native CAMetalLayer host…");
+                        SetLabelText(ViewportStatusText, "Waiting for native viewport host...");
                     return;
                 }
 
@@ -1062,10 +1062,18 @@ namespace SailorEditor.Views
                 renderTarget,
                 IsVisible,
                 isFocused,
-                nativeHostHandle));
+                nativeHostHandle,
+                nativeViewportScale));
 
             if (!updated)
-                viewportAdapter.Sync(new SceneViewportFrame(editorRect, editorRect, renderTarget, IsVisible, isFocused, nativeHostHandle));
+                viewportAdapter.Sync(new SceneViewportFrame(
+                    editorRect,
+                    editorRect,
+                    renderTarget,
+                    IsVisible,
+                    isFocused,
+                    nativeHostHandle,
+                    nativeViewportScale));
         }
 
         double ResolveViewportMouseSensitivity()
@@ -1124,7 +1132,7 @@ namespace SailorEditor.Views
 
         void RequestNativeViewportLayout()
         {
-#if MACCATALYST
+#if WINDOWS || MACCATALYST
             if (!UseNativeViewportHost || nativeViewportHost is null)
             {
                 return;
@@ -1154,7 +1162,7 @@ namespace SailorEditor.Views
 
         void QueueViewportRetry(TimeSpan? keepAlive = null)
         {
-#if MACCATALYST
+#if WINDOWS || MACCATALYST
             if (!UseNativeViewportHost || !isRunning)
             {
                 return;

--- a/Lib/CMakeLists.txt
+++ b/Lib/CMakeLists.txt
@@ -155,6 +155,12 @@ else()
 		PROPERTIES COMPILE_OPTIONS "-fno-rtti")
 endif()
 
+if(MSVC)
+	set_source_files_properties(
+		"${SAILOR_RUNTIME_DIR}/AssetRegistry/Model/ModelImporter.cpp"
+		PROPERTIES COMPILE_OPTIONS "/bigobj")
+endif()
+
 file(GLOB_RECURSE SAILOR_LIB_SOURCES
   "*.h"
   "*.cpp")
@@ -341,7 +347,7 @@ endif()
 
 if(WIN32)
   target_compile_definitions(SailorLib PUBLIC NOMINMAX WIN32_LEAN_AND_MEAN)
-  target_link_libraries(SailorLib PRIVATE Winmm.lib)
+  target_link_libraries(SailorLib PRIVATE Winmm.lib d3d11.lib dxgi.lib)
 endif()
 
 if(APPLE)

--- a/Lib/EditorProtocolExports.cpp
+++ b/Lib/EditorProtocolExports.cpp
@@ -165,6 +165,24 @@ extern "C"
 		}
 	}
 
+	SAILOR_API int32_t SailorProtocolSetWindowsViewportHost(
+		uint64_t viewportId,
+		void* swapChainPanelInspectable,
+		float compositionScale) noexcept
+	{
+		try
+		{
+			return Sailor::App::SetEditorRemoteViewportWindowsHost(
+				viewportId,
+				swapChainPanelInspectable,
+				compositionScale) ? 1 : 0;
+		}
+		catch (...)
+		{
+			return 0;
+		}
+	}
+
 	SAILOR_API int32_t SailorProtocolInvoke(
 		const uint8_t* requestData,
 		uint32_t requestSize,

--- a/Runtime/Components/EditorComponent.cpp
+++ b/Runtime/Components/EditorComponent.cpp
@@ -73,6 +73,7 @@ void EditorComponent::EditorTick(float deltaTime)
 	constexpr float preciseMoveMultiplier = 0.1f;
 
 	const bool bNavigatingViewport = GetWorld()->GetInput().IsKeyDown(VK_RBUTTON);
+	const bool bStartedNavigatingViewport = GetWorld()->GetInput().IsButtonClick(VK_RBUTTON);
 	const glm::ivec2 cursorPos = GetWorld()->GetInput().GetCursorPos();
 	if (!bNavigatingViewport)
 	{
@@ -113,7 +114,10 @@ void EditorComponent::EditorTick(float deltaTime)
 			transform.SetPosition(transform.GetPosition() + shift);
 		}
 
-		const vec2 deltaCursorPos = cursorPos - m_lastCursorPos;
+		const glm::ivec2 cursorOrigin = bStartedNavigatingViewport
+			? GetWorld()->GetInput().GetButtonPressCursorPos(VK_RBUTTON)
+			: m_lastCursorPos;
+		const vec2 deltaCursorPos = cursorPos - cursorOrigin;
 		if (deltaCursorPos != vec2(0.0f))
 		{
 			constexpr float rotationDegreesPerPixel = 0.2f;

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -1391,6 +1391,10 @@ void App::ShowMainWindow(bool bShow)
 {
 	if (auto editor = GetSubmodule<Editor>())
 	{
+#if defined(_WIN32)
+		editor->ShowMainWindow(false);
+#else
 		editor->ShowMainWindow(bShow);
+#endif
 	}
 }

--- a/Runtime/Editor/EditorRuntimeBridge.cpp
+++ b/Runtime/Editor/EditorRuntimeBridge.cpp
@@ -18,11 +18,16 @@
 #include "RHI/Surface.h"
 #include "Submodules/Editor.h"
 #include "Submodules/EditorRemote/RemoteViewportMacTransport.h"
+#if defined(_WIN32)
+#include "Submodules/EditorRemote/RemoteViewportWindowsNative.h"
+#endif
 #include "Submodules/ImGuiApi.h"
 #include "Tasks/Scheduler.h"
+#include "Tasks/Tasks.h"
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <chrono>
 #include <cmath>
 #include <cstring>
@@ -409,16 +414,25 @@ namespace
 	struct RemoteViewportBinding
 	{
 		ViewportDescriptor m_descriptor{};
+#if defined(_WIN32)
+		SailorWindowsSharedSurfaceProvider m_surfaceProvider{};
+		SailorWindowsViewportPresenter m_presenter{};
+		WindowsViewportLoopbackBinding m_binding{ m_descriptor, m_surfaceProvider, m_presenter };
+#else
 		SailorRendererFrameSourceProvider m_rendererFrameSourceProvider{};
 		MacLoopbackIOSurfaceProvider m_surfaceProvider{ &m_rendererFrameSourceProvider };
 		MacLoopbackViewportPresenter m_presenter{};
 		MacViewportLoopbackBinding m_binding{ m_descriptor, m_surfaceProvider, m_presenter };
+#endif
 		RECT m_lastRect{};
 		bool m_created = false;
 		bool m_visible = true;
 		bool m_focused = false;
 		uint64_t m_nowMs = 0;
 		Failure m_lastPumpFailure = Failure::Ok();
+#if defined(_WIN32)
+		std::atomic_bool m_pumpScheduled = false;
+#endif
 		std::mutex m_mutex{};
 
 		explicit RemoteViewportBinding(ViewportDescriptor descriptor) :
@@ -471,8 +485,11 @@ namespace
 	};
 
 	TMap<ViewportId, TSharedPtr<RemoteViewportBinding>> g_remoteViewportBindings;
+#if defined(__APPLE__)
 	TMap<ViewportId, Sailor::EditorRemote::MacNativeHostHandle> g_pendingRemoteViewportHostHandles;
+#endif
 	TMap<ViewportId, std::array<bool, 3>> g_remoteViewportMouseButtons;
+	TMap<ViewportId, std::array<bool, 4>> g_remoteViewportKeyboardModifiers;
 	TVector<InputPacket> g_pendingEditorInput;
 	TSet<ViewportId> g_pendingEditorInputResets;
 	std::mutex g_remoteViewportBindingsMutex;
@@ -502,6 +519,7 @@ namespace
 		return it != g_remoteViewportBindings.end() && it.Value() == binding;
 	}
 
+#if defined(__APPLE__)
 	bool TryGetCurrentRemoteViewportHostHandle(
 		ViewportId viewportId,
 		const TSharedPtr<RemoteViewportBinding>& binding,
@@ -525,6 +543,7 @@ namespace
 		}
 		return true;
 	}
+#endif
 
 	ViewportDescriptor MakeRemoteViewportDescriptor(ViewportId viewportId, uint32_t width, uint32_t height)
 	{
@@ -562,6 +581,7 @@ namespace
 
 		std::lock_guard bindingsLock(g_remoteViewportBindingsMutex);
 		g_remoteViewportMouseButtons.Clear();
+		g_remoteViewportKeyboardModifiers.Clear();
 	}
 
 	bool IsEditorInputCurrent(const InputPacket& input)
@@ -607,13 +627,76 @@ namespace
 			state[i] = desired[i];
 			GlobalInput::SetMouseButtonState(i, desired[i] ? KeyState::Pressed : KeyState::Up);
 
-#if defined(__APPLE__)
+#if defined(_WIN32)
+			if (imGui)
+			{
+				ImGuiApi::WindowsEditorInputEvent event{};
+				event.EventType = ImGuiApi::WindowsEditorInputEvent::Type::MouseButton;
+				event.Button = static_cast<int32_t>(i);
+				event.bPressed = desired[i];
+				imGui->HandleWindowsEditorInput(event);
+			}
+#elif defined(__APPLE__)
 			if (imGui)
 			{
 				ImGuiApi::MacEvent event{};
 				event.EventType = ImGuiApi::MacEvent::Type::MouseButton;
 				event.Button = static_cast<int32_t>(i);
 				event.bPressed = desired[i];
+				imGui->HandleMac(event);
+			}
+#else
+			(void)imGui;
+#endif
+		}
+	}
+
+	void SyncEditorKeyboardModifiers(const InputPacket& input, ImGuiApi* imGui)
+	{
+		using Sailor::Win32::GlobalInput;
+		using Sailor::Win32::KeyState;
+
+		constexpr std::array<InputModifier, 4> modifiers = {
+			InputModifier::Shift,
+			InputModifier::Control,
+			InputModifier::Alt,
+			InputModifier::Meta
+		};
+		constexpr std::array<uint32_t, 4> keyCodes = {
+			VK_SHIFT,
+			VK_CONTROL,
+			VK_MENU,
+			VK_LWIN
+		};
+		auto& modifierState = g_remoteViewportKeyboardModifiers[input.m_viewportId];
+
+		for (uint32_t i = 0; i < modifiers.size(); i++)
+		{
+			const bool desired = (input.m_modifiers & modifiers[i]) == modifiers[i];
+			if (modifierState[i] == desired)
+			{
+				continue;
+			}
+
+			modifierState[i] = desired;
+			GlobalInput::SetKeyState(keyCodes[i], desired ? KeyState::Pressed : KeyState::Up);
+
+#if defined(_WIN32)
+			if (imGui)
+			{
+				ImGuiApi::WindowsEditorInputEvent event{};
+				event.EventType = ImGuiApi::WindowsEditorInputEvent::Type::Key;
+				event.Key = keyCodes[i];
+				event.bPressed = desired;
+				imGui->HandleWindowsEditorInput(event);
+			}
+#elif defined(__APPLE__)
+			if (imGui)
+			{
+				ImGuiApi::MacEvent event{};
+				event.EventType = ImGuiApi::MacEvent::Type::Key;
+				event.Key = keyCodes[i];
+				event.bPressed = desired;
 				imGui->HandleMac(event);
 			}
 #else
@@ -629,11 +712,34 @@ namespace
 
 		const KeyState state = input.m_pressed ? KeyState::Pressed : KeyState::Up;
 
-#if defined(__APPLE__)
+#if defined(_WIN32) || defined(__APPLE__)
 		auto* imGui = App::GetSubmodule<ImGuiApi>();
 #else
 		ImGuiApi* imGui = nullptr;
 #endif
+
+#if defined(_WIN32)
+		if (imGui &&
+			(input.m_kind == InputKind::PointerMove ||
+				input.m_kind == InputKind::PointerButton ||
+				input.m_kind == InputKind::PointerWheel))
+		{
+			ImGuiApi::WindowsEditorInputEvent event{};
+			event.EventType = ImGuiApi::WindowsEditorInputEvent::Type::MousePos;
+			event.X = input.m_pointerX;
+			event.Y = input.m_pointerY;
+			imGui->HandleWindowsEditorInput(event);
+		}
+#endif
+
+		if (input.m_kind == InputKind::PointerMove ||
+			input.m_kind == InputKind::PointerButton ||
+			input.m_kind == InputKind::PointerWheel)
+		{
+			GlobalInput::SetCursorPosition(
+				static_cast<int32_t>(input.m_pointerX),
+				static_cast<int32_t>(input.m_pointerY));
+		}
 
 		switch (input.m_kind)
 		{
@@ -642,6 +748,7 @@ namespace
 		case InputKind::PointerWheel:
 		case InputKind::Focus:
 		case InputKind::Capture:
+			SyncEditorKeyboardModifiers(input, imGui);
 			SyncEditorMouseButtons(input, imGui);
 			break;
 		default:
@@ -656,15 +763,6 @@ namespace
 
 		switch (input.m_kind)
 		{
-		case InputKind::PointerMove:
-			GlobalInput::SetCursorPosition(static_cast<int32_t>(input.m_pointerX), static_cast<int32_t>(input.m_pointerY));
-			break;
-		case InputKind::PointerButton:
-			GlobalInput::SetCursorPosition(static_cast<int32_t>(input.m_pointerX), static_cast<int32_t>(input.m_pointerY));
-			break;
-		case InputKind::PointerWheel:
-			GlobalInput::SetCursorPosition(static_cast<int32_t>(input.m_pointerX), static_cast<int32_t>(input.m_pointerY));
-			break;
 		case InputKind::Key:
 			if (input.m_keyCode < 256)
 			{
@@ -674,7 +772,6 @@ namespace
 		default:
 			break;
 		}
-
 #if defined(__APPLE__)
 		if (imGui)
 		{
@@ -705,6 +802,32 @@ namespace
 			}
 
 			imGui->HandleMac(event);
+		}
+#elif defined(_WIN32)
+		if (imGui)
+		{
+			ImGuiApi::WindowsEditorInputEvent event{};
+			switch (input.m_kind)
+			{
+			case InputKind::PointerWheel:
+				event.EventType = ImGuiApi::WindowsEditorInputEvent::Type::MouseWheel;
+				event.X = input.m_wheelDeltaX / (float)WHEEL_DELTA;
+				event.Y = input.m_wheelDeltaY / (float)WHEEL_DELTA;
+				break;
+			case InputKind::Key:
+				event.EventType = ImGuiApi::WindowsEditorInputEvent::Type::Key;
+				event.Key = input.m_keyCode;
+				event.bPressed = input.m_pressed;
+				break;
+			case InputKind::Focus:
+				event.EventType = ImGuiApi::WindowsEditorInputEvent::Type::Focus;
+				event.bPressed = input.m_focused;
+				break;
+			default:
+				return;
+			}
+
+			imGui->HandleWindowsEditorInput(event);
 		}
 #endif
 	}
@@ -769,7 +892,11 @@ bool Sailor::EditorRuntime::ApplyPendingEditorViewportOnEngineThread()
 		{
 			renderer->GetDriver()->WaitIdle();
 		}
+#if defined(_WIN32)
+		mainWindow->Show(false);
+#else
 		mainWindow->ChangeWindowSize(requestedWindowArea.x, requestedWindowArea.y, false);
+#endif
 		mainWindow->SetRenderArea(requestedWindowArea);
 		{
 			std::lock_guard lock(g_editorViewportMutex);
@@ -780,7 +907,11 @@ bool Sailor::EditorRuntime::ApplyPendingEditorViewportOnEngineThread()
 	}
 	else
 	{
+#if defined(_WIN32)
+		mainWindow->Show(false);
+#else
 		mainWindow->ChangeWindowSize(requestedWindowArea.x, requestedWindowArea.y, false);
+#endif
 		mainWindow->SetRenderArea(requestedWindowArea);
 		std::lock_guard lock(g_editorViewportMutex);
 		g_editorRemoteViewportRenderArea = requestedWindowArea;
@@ -837,8 +968,11 @@ void Sailor::EditorRuntime::ResetForAppLifecycle()
 		}
 
 		g_remoteViewportBindings.Clear();
+#if defined(__APPLE__)
 		g_pendingRemoteViewportHostHandles.Clear();
+#endif
 		g_remoteViewportMouseButtons.Clear();
+		g_remoteViewportKeyboardModifiers.Clear();
 	}
 
 	for (auto& binding : bindings)
@@ -897,6 +1031,27 @@ void Sailor::EditorRuntime::PumpEditorRemoteViewportsOnEngineThread()
 
 	for (auto& binding : bindings)
 	{
+#if defined(_WIN32)
+		if (!binding || binding->m_pumpScheduled.exchange(true))
+		{
+			continue;
+		}
+
+		scheduler->Run(Tasks::CreateTask(
+			"Pump Windows editor remote viewport",
+			[binding]()
+			{
+				{
+					std::lock_guard bindingLock(binding->m_mutex);
+					if (binding->m_created && binding->m_visible)
+					{
+						binding->Pump();
+					}
+				}
+				binding->m_pumpScheduled.store(false);
+			},
+			EThreadType::Render));
+#else
 		std::lock_guard bindingLock(binding->m_mutex);
 		if (binding && binding->m_created && binding->m_visible)
 		{
@@ -911,6 +1066,7 @@ void Sailor::EditorRuntime::PumpEditorRemoteViewportsOnEngineThread()
 #endif
 			binding->Pump();
 		}
+#endif
 	}
 }
 
@@ -956,7 +1112,10 @@ void App::SetEditorRenderTargetSize(uint32_t width, uint32_t height)
 
 bool App::UpsertEditorRemoteViewport(uint64_t viewportId, uint32_t windowPosX, uint32_t windowPosY, uint32_t width, uint32_t height, bool bVisible, bool bFocused)
 {
-#if !defined(__APPLE__)
+#if defined(_WIN32)
+	SetEditorRenderTargetSize(width, height);
+	SetEditorViewport(0, 0, width, height);
+#elif !defined(__APPLE__)
 	SetEditorViewport(windowPosX, windowPosY, width, height);
 #else
 	SetEditorRenderTargetSize(width, height);
@@ -1014,6 +1173,7 @@ bool App::UpsertEditorRemoteViewport(uint64_t viewportId, uint32_t windowPosX, u
 		return true;
 	}
 
+#if defined(__APPLE__)
 	std::optional<MacNativeHostHandle> hostHandle{};
 	if (!TryGetCurrentRemoteViewportHostHandle(viewportId, binding, hostHandle))
 	{
@@ -1023,6 +1183,7 @@ bool App::UpsertEditorRemoteViewport(uint64_t viewportId, uint32_t windowPosX, u
 	{
 		binding->m_binding.GetHost().BindNativeHostHandle(viewportId, *hostHandle);
 	}
+#endif
 	if (!binding->m_created)
 	{
 		binding->m_binding.Create();
@@ -1140,7 +1301,21 @@ uint32_t App::GetEditorRemoteViewportDiagnostics(uint64_t viewportId, char** dia
 	}
 
 	auto info = binding->m_binding.GetRuntimeSession().GetDiagnostics();
-#if defined(__APPLE__)
+#if defined(_WIN32)
+	info.m_nativePresenterSummary = binding->m_presenter.BuildSummary(viewportId);
+	const std::string surfaceSummary = binding->m_surfaceProvider.BuildSummary(
+		viewportId,
+		info.m_connectionEpoch,
+		info.m_generation);
+	if (!surfaceSummary.empty())
+	{
+		if (!info.m_nativePresenterSummary.empty())
+		{
+			info.m_nativePresenterSummary += " ";
+		}
+		info.m_nativePresenterSummary += surfaceSummary;
+	}
+#elif defined(__APPLE__)
 	info.m_nativePresenterSummary = binding->m_presenter.BuildViewportSummary(viewportId);
 	if (const auto* allocation = binding->m_surfaceProvider.FindAllocation({ viewportId, info.m_connectionEpoch, info.m_generation }))
 	{
@@ -1285,6 +1460,41 @@ bool App::SetEditorRemoteViewportMacHostHandle(uint64_t viewportId, uint32_t hos
 	(void)viewportId;
 	(void)hostHandleKind;
 	(void)hostHandleValue;
+	return false;
+#endif
+}
+
+bool App::SetEditorRemoteViewportWindowsHost(
+	uint64_t viewportId,
+	void* swapChainPanelInspectable,
+	float compositionScale)
+{
+#if defined(_WIN32)
+	if (!GetInstance() || !HasEditor())
+	{
+		return false;
+	}
+
+	viewportId = viewportId == 0 ? kPrimaryEditorViewportId : viewportId;
+	auto binding = FindRemoteViewportBinding(viewportId);
+	if (!binding)
+	{
+		return swapChainPanelInspectable == nullptr;
+	}
+
+	std::unique_lock bindingLock(binding->m_mutex, std::try_to_lock);
+	if (!bindingLock.owns_lock() || !IsCurrentRemoteViewportBinding(viewportId, binding))
+	{
+		return false;
+	}
+
+	return binding->m_presenter
+		.BindNativeHost(swapChainPanelInspectable, compositionScale)
+		.IsOk();
+#else
+	(void)viewportId;
+	(void)swapChainPanelInspectable;
+	(void)compositionScale;
 	return false;
 #endif
 }

--- a/Runtime/FrameGraph/LightCullingNode.cpp
+++ b/Runtime/FrameGraph/LightCullingNode.cpp
@@ -41,6 +41,20 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 	{
 		depthAttachment = frameGraph->GetRenderTarget("DepthBuffer").DynamicCast<RHI::RHITexture>();
 	}
+	if (!depthAttachment)
+	{
+		commands->EndDebugRegion(commandList);
+		return;
+	}
+
+	RHI::RHITexturePtr sampledDepthAttachment = depthAttachment;
+	if (auto depthRenderTarget = depthAttachment.DynamicCast<RHI::RHIRenderTarget>())
+	{
+		if (auto depthAspect = depthRenderTarget->GetDepthAspect())
+		{
+			sampledDepthAttachment = depthAspect;
+		}
+	}
 
 #ifdef _DEBUG
 	if (RHIShaderPtr computeShader = m_pComputeShader->GetDebugComputeShaderRHI())
@@ -67,7 +81,7 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 			m_culledLights = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
 			RHI::RHIShaderBindingPtr culledLightsSSBO = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_culledLights, "culledLights", sizeof(uint32_t) * numTiles * LightsPerTile, 1, 0, true);
 			RHI::RHIShaderBindingPtr lightsGridSSBO = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_culledLights, "lightsGrid", sizeof(uint32_t) * numTiles * 2, 1, 1, true);
-			RHI::RHIShaderBindingPtr depthSampler = Sailor::RHI::Renderer::GetDriver()->AddSamplerToShaderBindings(m_culledLights, "sceneDepth", depthAttachment, 2);
+			Sailor::RHI::Renderer::GetDriver()->AddSamplerToShaderBindings(m_culledLights, "sceneDepth", sampledDepthAttachment, 2);
 
 			auto shaderBindingSet = sceneView.m_rhiLightsData;
 			Sailor::RHI::Renderer::GetDriver()->AddShaderBinding(shaderBindingSet, culledLightsSSBO, "culledLights", 1);

--- a/Runtime/FrameGraph/LinearizeDepthNode.cpp
+++ b/Runtime/FrameGraph/LinearizeDepthNode.cpp
@@ -46,15 +46,30 @@ void LinearizeDepthNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandLis
 
 	auto target = GetResolvedAttachment("target");
 
-	if (!m_pLinearizeDepthShader || !target || !m_pLinearizeDepthShader->IsReady())
+	if (!m_pLinearizeDepthShader || !depthAttachment || !target || !m_pLinearizeDepthShader->IsReady())
 	{
 		return;
 	}
 
-	if (!m_linearizeDepth)
+	RHI::RHITexturePtr sampledDepthAttachment = depthAttachment;
+	if (auto depthRenderTarget = depthAttachment.DynamicCast<RHI::RHIRenderTarget>())
 	{
-		m_linearizeDepth = driver->CreateShaderBindings();
-		driver->AddSamplerToShaderBindings(m_linearizeDepth, "depthSampler", depthAttachment, 0);
+		if (auto depthAspect = depthRenderTarget->GetDepthAspect())
+		{
+			sampledDepthAttachment = depthAspect;
+		}
+	}
+
+	if (!m_linearizeDepth || m_boundDepthAttachment != sampledDepthAttachment)
+	{
+		if (!m_linearizeDepth)
+		{
+			m_linearizeDepth = driver->CreateShaderBindings();
+		}
+
+		driver->AddSamplerToShaderBindings(m_linearizeDepth, "depthSampler", sampledDepthAttachment, 0);
+		m_linearizeDepth->RecalculateCompatibility();
+		m_boundDepthAttachment = sampledDepthAttachment;
 	}
 
 	if (!m_postEffectMaterial)
@@ -113,6 +128,7 @@ void LinearizeDepthNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandLis
 void LinearizeDepthNode::Clear()
 {
 	m_linearizeDepth.Clear();
+	m_boundDepthAttachment.Clear();
 	m_postEffectMaterial.Clear();
 	m_pLinearizeDepthShader.Clear();
 }

--- a/Runtime/FrameGraph/LinearizeDepthNode.h
+++ b/Runtime/FrameGraph/LinearizeDepthNode.h
@@ -23,6 +23,7 @@ namespace Sailor::Framegraph
 		ShaderSetPtr m_pLinearizeDepthShader{};
 		RHI::RHIMaterialPtr m_postEffectMaterial{};
 		RHI::RHIShaderBindingSetPtr m_linearizeDepth{};
+		RHI::RHITexturePtr m_boundDepthAttachment{};
 	};
 
 	template class TFrameGraphNode<LinearizeDepthNode>;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
@@ -1239,6 +1239,96 @@ VulkanImagePtr VulkanApi::CreateImage(
 	return outImage;
 }
 
+#if defined(_WIN32)
+VulkanImagePtr VulkanApi::CreateExportableImage(
+	VulkanDevicePtr device,
+	VkExtent3D extent,
+	VkFormat format,
+	VkImageUsageFlags usage,
+	VkImageLayout defaultLayout,
+	VkExternalMemoryHandleTypeFlagBits handleType)
+{
+	VkPhysicalDeviceExternalImageFormatInfo externalFormatInfo{};
+	externalFormatInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
+	externalFormatInfo.handleType = handleType;
+
+	VkPhysicalDeviceImageFormatInfo2 formatInfo{};
+	formatInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
+	formatInfo.pNext = &externalFormatInfo;
+	formatInfo.format = format;
+	formatInfo.type = VK_IMAGE_TYPE_2D;
+	formatInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+	formatInfo.usage = usage;
+	formatInfo.flags = 0;
+
+	VkExternalImageFormatProperties externalProperties{};
+	externalProperties.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
+
+	VkImageFormatProperties2 imageProperties{};
+	imageProperties.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
+	imageProperties.pNext = &externalProperties;
+
+	const VkResult propertiesResult = vkGetPhysicalDeviceImageFormatProperties2(
+		device->GetPhysicalDevice(),
+		&formatInfo,
+		&imageProperties);
+	const VkExternalMemoryFeatureFlags requiredFeatures =
+		VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT |
+		VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT;
+	if (propertiesResult != VK_SUCCESS ||
+		(externalProperties.externalMemoryProperties.externalMemoryFeatures & requiredFeatures) != requiredFeatures)
+	{
+		SAILOR_LOG_ERROR(
+			"Vulkan external image is unsupported: result=%d format=%d handleType=0x%x features=0x%x",
+			static_cast<int32_t>(propertiesResult),
+			static_cast<int32_t>(format),
+			static_cast<uint32_t>(handleType),
+			static_cast<uint32_t>(externalProperties.externalMemoryProperties.externalMemoryFeatures));
+		return nullptr;
+	}
+
+	VulkanImagePtr outImage = new VulkanImage(device);
+	outImage->EnableExternalMemory(handleType);
+	outImage->m_extent = extent;
+	outImage->m_imageType = VK_IMAGE_TYPE_2D;
+	outImage->m_format = format;
+	outImage->m_tiling = VK_IMAGE_TILING_OPTIMAL;
+	outImage->m_usage = usage;
+	outImage->m_mipLevels = 1;
+	outImage->m_samples = VK_SAMPLE_COUNT_1_BIT;
+	outImage->m_arrayLayers = 1;
+	outImage->m_sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	outImage->m_defaultLayout = defaultLayout;
+	outImage->m_initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	outImage->m_flags = 0;
+	outImage->Compile();
+
+	const VkMemoryRequirements requirements = outImage->GetMemoryRequirements();
+
+	VkMemoryDedicatedAllocateInfo dedicatedInfo{};
+	dedicatedInfo.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+	dedicatedInfo.image = *outImage;
+
+	VkExportMemoryAllocateInfo exportInfo{};
+	exportInfo.sType = VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO;
+	exportInfo.pNext = &dedicatedInfo;
+	exportInfo.handleTypes = handleType;
+
+	auto memory = VulkanDeviceMemoryPtr::Make(
+		device,
+		requirements,
+		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+		&exportInfo);
+	if (!memory || outImage->Bind(memory, 0) != VK_SUCCESS)
+	{
+		SAILOR_LOG_ERROR("Failed to allocate or bind Vulkan external image memory.");
+		return nullptr;
+	}
+
+	return outImage;
+}
+#endif
+
 VulkanImagePtr VulkanApi::CreateImage_Immediate(
         VulkanDevicePtr device,
         const void* pData,
@@ -1271,24 +1361,36 @@ VulkanImagePtr VulkanApi::CreateImage_Immediate(
 #ifdef _WIN32
 void* VulkanApi::ExportImage(VulkanDevicePtr device, VulkanImagePtr image, VkExternalMemoryHandleTypeFlagBits handleType)
 {
-        auto vkGetMemoryWin32HandleKHR = (PFN_vkGetMemoryWin32HandleKHR)vkGetDeviceProcAddr(*device, "vkGetMemoryWin32HandleKHR");
-        if (!vkGetMemoryWin32HandleKHR)
-        {
-                return nullptr;
-        }
+	if (!device || !image || !image->IsExternalMemoryEnabled() || !image->GetMemoryDevice())
+	{
+		return nullptr;
+	}
 
-        VkMemoryGetWin32HandleInfoKHR handleInfo{};
-        handleInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR;
-        handleInfo.handleType = handleType;
-        handleInfo.memory = *image->GetMemoryDevice();
+	auto vkGetMemoryWin32HandleKHR = reinterpret_cast<PFN_vkGetMemoryWin32HandleKHR>(
+		vkGetDeviceProcAddr(*device, "vkGetMemoryWin32HandleKHR"));
+	if (!vkGetMemoryWin32HandleKHR)
+	{
+		SAILOR_LOG_ERROR("vkGetMemoryWin32HandleKHR is unavailable.");
+		return nullptr;
+	}
 
-        HANDLE handle = nullptr;
-        //if (vkGetMemoryWin32HandleKHR(*device, &handleInfo, &handle) != VK_SUCCESS)
-        //{
-        //        return nullptr;
-        //}
+	VkMemoryGetWin32HandleInfoKHR handleInfo{};
+	handleInfo.sType = VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR;
+	handleInfo.handleType = handleType;
+	handleInfo.memory = *image->GetMemoryDevice();
 
-        return handle;
+	HANDLE handle = nullptr;
+	const VkResult result = vkGetMemoryWin32HandleKHR(*device, &handleInfo, &handle);
+	if (result != VK_SUCCESS)
+	{
+		SAILOR_LOG_ERROR(
+			"vkGetMemoryWin32HandleKHR failed: result=%d handleType=0x%x",
+			static_cast<int32_t>(result),
+			static_cast<uint32_t>(handleType));
+		return nullptr;
+	}
+
+	return handle;
 }
 #else
 void* VulkanApi::ExportImage(VulkanDevicePtr /*device*/, VulkanImagePtr /*image*/, VkExternalMemoryHandleTypeFlagBits /*handleType*/)
@@ -1299,50 +1401,109 @@ void* VulkanApi::ExportImage(VulkanDevicePtr /*device*/, VulkanImagePtr /*image*
 
 #ifdef _WIN32
 VulkanImagePtr VulkanApi::ImportImage(VulkanDevicePtr device,
-        void* handle,
-        VkExtent3D extent,
-        VkFormat format,
-        VkImageUsageFlags usage,
-        VkImageLayout defaultLayout,
-        VkImageCreateFlags flags,
-        uint32_t arrayLayers,
-        VkSampleCountFlagBits sampleCount)
+	void* handle,
+	VkExtent3D extent,
+	VkFormat format,
+	VkImageUsageFlags usage,
+	VkImageLayout defaultLayout,
+	VkImageCreateFlags flags,
+	uint32_t arrayLayers,
+	VkSampleCountFlagBits sampleCount,
+	VkExternalMemoryHandleTypeFlagBits handleType)
 {
-        VulkanImagePtr outImage = new VulkanImage(device);
-        outImage->EnableExternalMemory(VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
-        outImage->m_extent = extent;
-        outImage->m_imageType = VK_IMAGE_TYPE_2D;
-        outImage->m_format = format;
-        outImage->m_tiling = VK_IMAGE_TILING_OPTIMAL;
-        outImage->m_usage = usage;
-        outImage->m_mipLevels = 1;
-        outImage->m_samples = sampleCount;
-        outImage->m_arrayLayers = arrayLayers;
-        outImage->m_sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-        outImage->m_defaultLayout = defaultLayout;
-        outImage->m_initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        outImage->m_flags = flags;
+	if (!device || !handle)
+	{
+		return nullptr;
+	}
+	if (handleType == static_cast<VkExternalMemoryHandleTypeFlagBits>(0))
+	{
+		handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
+	}
 
-        outImage->Compile();
+	VkPhysicalDeviceExternalImageFormatInfo externalFormatInfo{};
+	externalFormatInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO;
+	externalFormatInfo.handleType = handleType;
 
-        VkMemoryRequirements requirements = outImage->GetMemoryRequirements();
+	VkPhysicalDeviceImageFormatInfo2 formatInfo{};
+	formatInfo.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2;
+	formatInfo.pNext = &externalFormatInfo;
+	formatInfo.format = format;
+	formatInfo.type = VK_IMAGE_TYPE_2D;
+	formatInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
+	formatInfo.usage = usage;
+	formatInfo.flags = flags;
 
-		VkImportMemoryWin32HandleInfoKHR importInfo{};
-        importInfo.sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
-        importInfo.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-        importInfo.handle = (HANDLE)handle;
+	VkExternalImageFormatProperties externalProperties{};
+	externalProperties.sType = VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES;
+	VkImageFormatProperties2 imageProperties{};
+	imageProperties.sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2;
+	imageProperties.pNext = &externalProperties;
 
-        auto memory = VulkanDeviceMemoryPtr::Make(device, requirements,
-                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &importInfo);
+	const VkResult propertiesResult = vkGetPhysicalDeviceImageFormatProperties2(
+		device->GetPhysicalDevice(),
+		&formatInfo,
+		&imageProperties);
+	const VkExternalMemoryFeatureFlags externalFeatures =
+		externalProperties.externalMemoryProperties.externalMemoryFeatures;
+	if (propertiesResult != VK_SUCCESS ||
+		(externalFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT) == 0)
+	{
+		SAILOR_LOG_ERROR(
+			"Vulkan external image cannot be imported: result=%d format=%d handleType=0x%x features=0x%x",
+			static_cast<int32_t>(propertiesResult),
+			static_cast<int32_t>(format),
+			static_cast<uint32_t>(handleType),
+			static_cast<uint32_t>(externalFeatures));
+		return nullptr;
+	}
 
-        outImage->Bind(memory, 0);
+	VulkanImagePtr outImage = new VulkanImage(device);
+	outImage->EnableExternalMemory(handleType);
+	outImage->m_extent = extent;
+	outImage->m_imageType = VK_IMAGE_TYPE_2D;
+	outImage->m_format = format;
+	outImage->m_tiling = VK_IMAGE_TILING_OPTIMAL;
+	outImage->m_usage = usage;
+	outImage->m_mipLevels = 1;
+	outImage->m_samples = sampleCount;
+	outImage->m_arrayLayers = arrayLayers;
+	outImage->m_sharingMode = VK_SHARING_MODE_EXCLUSIVE;
+	outImage->m_defaultLayout = defaultLayout;
+	outImage->m_initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	outImage->m_flags = flags;
+	outImage->Compile();
 
-        return outImage;
+	const VkMemoryRequirements requirements = outImage->GetMemoryRequirements();
+	VkMemoryDedicatedAllocateInfo dedicatedInfo{};
+	dedicatedInfo.sType = VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO;
+	dedicatedInfo.image = *outImage;
+
+	VkImportMemoryWin32HandleInfoKHR importInfo{};
+	importInfo.sType = VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR;
+	importInfo.pNext =
+		(externalFeatures & VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT) != 0
+			? &dedicatedInfo
+			: nullptr;
+	importInfo.handleType = handleType;
+	importInfo.handle = static_cast<HANDLE>(handle);
+
+	auto memory = VulkanDeviceMemoryPtr::Make(
+		device,
+		requirements,
+		VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+		&importInfo);
+	if (!memory || outImage->Bind(memory, 0) != VK_SUCCESS)
+	{
+		SAILOR_LOG_ERROR("Failed to allocate or bind imported Vulkan image memory.");
+		return nullptr;
+	}
+
+	return outImage;
 }
 #else
-VulkanImagePtr VulkanApi::ImportImage(VulkanDevicePtr /*device*/, void* /*handle*/, VkExtent3D /*extent*/, VkFormat /*format*/, VkImageUsageFlags /*usage*/, VkImageLayout /*defaultLayout*/, VkImageCreateFlags /*flags*/, uint32_t /*arrayLayers*/, VkSampleCountFlagBits /*sampleCount*/)
+VulkanImagePtr VulkanApi::ImportImage(VulkanDevicePtr /*device*/, void* /*handle*/, VkExtent3D /*extent*/, VkFormat /*format*/, VkImageUsageFlags /*usage*/, VkImageLayout /*defaultLayout*/, VkImageCreateFlags /*flags*/, uint32_t /*arrayLayers*/, VkSampleCountFlagBits /*sampleCount*/, VkExternalMemoryHandleTypeFlagBits /*handleType*/)
 {
-        return nullptr;
+	return nullptr;
 }
 #endif
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.h
@@ -158,6 +158,12 @@ namespace Sailor::GraphicsDriver::Vulkan
 			requiredDeviceExtensions.Add(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
 #endif
 
+#if defined(_WIN32)
+			requiredDeviceExtensions.Add(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
+			requiredDeviceExtensions.Add(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
+			requiredDeviceExtensions.Add(VK_KHR_WIN32_KEYED_MUTEX_EXTENSION_NAME);
+#endif
+
 #if defined(__APPLE__)
 			requiredDeviceExtensions.Add(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
 #endif
@@ -222,6 +228,16 @@ namespace Sailor::GraphicsDriver::Vulkan
 			VkImageCreateFlags flags = 0,
 			uint32_t arrayLayers = 1);
 
+#if defined(_WIN32)
+		SAILOR_API static VulkanImagePtr CreateExportableImage(
+			VulkanDevicePtr device,
+			VkExtent3D extent,
+			VkFormat format,
+			VkImageUsageFlags usage,
+			VkImageLayout defaultLayout,
+			VkExternalMemoryHandleTypeFlagBits handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT);
+#endif
+
 		SAILOR_API static VulkanCommandBufferPtr UpdateBuffer(VulkanDevicePtr device, const VulkanBufferMemoryPtr& dst, const void* pData, VkDeviceSize size);
 
 		//Immediate context
@@ -244,8 +260,8 @@ namespace Sailor::GraphicsDriver::Vulkan
                         uint32_t arrayLayer = 1);
 
 #ifdef _WIN32
-                SAILOR_API static void* ExportImage(VulkanDevicePtr device, VulkanImagePtr image,
-                        VkExternalMemoryHandleTypeFlagBits handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT);
+		SAILOR_API static void* ExportImage(VulkanDevicePtr device, VulkanImagePtr image,
+			VkExternalMemoryHandleTypeFlagBits handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT);
 #else
                 SAILOR_API static void* ExportImage(VulkanDevicePtr device, VulkanImagePtr image,
                         VkExternalMemoryHandleTypeFlagBits handleType = (VkExternalMemoryHandleTypeFlagBits)0);
@@ -259,7 +275,9 @@ namespace Sailor::GraphicsDriver::Vulkan
                         VkImageLayout defaultLayout,
                         VkImageCreateFlags flags = 0,
                         uint32_t arrayLayers = 1,
-                        VkSampleCountFlagBits sampleCount = VK_SAMPLE_COUNT_1_BIT);
+                        VkSampleCountFlagBits sampleCount = VK_SAMPLE_COUNT_1_BIT,
+			VkExternalMemoryHandleTypeFlagBits handleType =
+				static_cast<VkExternalMemoryHandleTypeFlagBits>(0));
 
 		//Immediate context
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
@@ -1075,14 +1075,16 @@ void VulkanCommandBuffer::ImageMemoryBarrier(VulkanImageViewPtr image,
 	VkAccessFlags srcAccess,
 	VkAccessFlags dstAccess,
 	VkPipelineStageFlags srcStage,
-	VkPipelineStageFlags dstStage)
+	VkPipelineStageFlags dstStage,
+	uint32_t srcQueueFamilyIndex,
+	uint32_t dstQueueFamilyIndex)
 {
 	VkImageMemoryBarrier barrier{};
 	barrier.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
 	barrier.oldLayout = oldLayout;
 	barrier.newLayout = newLayout;
-	barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
-	barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+	barrier.srcQueueFamilyIndex = srcQueueFamilyIndex;
+	barrier.dstQueueFamilyIndex = dstQueueFamilyIndex;
 	barrier.image = *image->GetImage();
 
 	barrier.subresourceRange = image->m_subresourceRange;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.h
@@ -98,7 +98,9 @@ namespace Sailor::GraphicsDriver::Vulkan
 			VkAccessFlags srcAccess,
 			VkAccessFlags dstAccess,
 			VkPipelineStageFlags srcStage,
-			VkPipelineStageFlags dstStage);
+			VkPipelineStageFlags dstStage,
+			uint32_t srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
+			uint32_t dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED);
 
 		SAILOR_API void ImageMemoryBarrier(VulkanImageViewPtr image, VkFormat format, VkImageLayout oldLayout, VkImageLayout newLayout);
 		SAILOR_API void ImageMemoryBarrier(VulkanImagePtr image, VkFormat format, VkImageLayout oldLayout, VkImageLayout newLayout);

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
@@ -394,12 +394,14 @@ VulkanCommandBufferPtr VulkanDevice::CreateCommandBuffer(RHI::ECommandListQueue 
 bool VulkanDevice::SubmitCommandBuffer(VulkanCommandBufferPtr commandBuffer,
 	VulkanFencePtr fence,
 	TVector<VulkanSemaphorePtr> signalSemaphores,
-	TVector<VulkanSemaphorePtr> waitSemaphores)
+	TVector<VulkanSemaphorePtr> waitSemaphores,
+	const void* submitNext)
 {
 	SAILOR_PROFILE_FUNCTION();
 
 	VkSubmitInfo submitInfo{};
 	submitInfo.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
+	submitInfo.pNext = submitNext;
 	submitInfo.commandBufferCount = 1;
 	submitInfo.pCommandBuffers = { commandBuffer->GetHandle() };
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
@@ -73,7 +73,8 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API bool SubmitCommandBuffer(VulkanCommandBufferPtr commandBuffer,
 			VulkanFencePtr fence = nullptr,
 			TVector<VulkanSemaphorePtr> signalSemaphores = {},
-			TVector<VulkanSemaphorePtr> waitSemaphores = {});
+			TVector<VulkanSemaphorePtr> waitSemaphores = {},
+			const void* submitNext = nullptr);
 
 		SAILOR_API bool ShouldFixLostDevice(const Platform::Window* pViewport);
 		SAILOR_API void FixLostDevice(Platform::Window* pViewport);

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -777,6 +777,93 @@ RHI::RHITexturePtr VulkanGraphicsDriver::CreateImage_Immediate(
 	return res;
 }
 
+#if defined(_WIN32)
+RHI::RHIRenderTargetPtr VulkanGraphicsDriver::CreateExportableRenderTarget(
+	glm::ivec2 extent,
+	RHI::ETextureFormat format,
+	RHI::ETextureUsageFlags usage)
+{
+	if (extent.x <= 0 || extent.y <= 0)
+	{
+		return nullptr;
+	}
+
+	auto device = m_vkInstance->GetMainDevice();
+	RHI::RHIRenderTargetPtr result = RHI::RHIRenderTargetPtr::Make(
+		RHI::ETextureFiltration::Linear,
+		RHI::ETextureClamping::Clamp,
+		false,
+		RHI::EImageLayout::General);
+
+	const VkExtent3D vkExtent{
+		static_cast<uint32_t>(extent.x),
+		static_cast<uint32_t>(extent.y),
+		1u
+	};
+	result->m_vulkan.m_image = VulkanApi::CreateExportableImage(
+		device,
+		vkExtent,
+		static_cast<VkFormat>(format),
+		static_cast<VkImageUsageFlags>(usage),
+		VK_IMAGE_LAYOUT_GENERAL);
+	if (!result->m_vulkan.m_image)
+	{
+		return nullptr;
+	}
+
+	result->m_vulkan.m_imageView = VulkanImageViewPtr::Make(
+		device,
+		result->m_vulkan.m_image);
+	result->m_vulkan.m_imageView->Compile();
+	return result;
+}
+
+RHI::RHITexturePtr VulkanGraphicsDriver::ImportD3D11Texture(
+	void* handle,
+	glm::ivec2 extent,
+	RHI::ETextureFormat format,
+	RHI::ETextureUsageFlags usage,
+	RHI::EImageLayout layout)
+{
+	if (!handle || extent.x <= 0 || extent.y <= 0)
+	{
+		return nullptr;
+	}
+
+	auto device = m_vkInstance->GetMainDevice();
+	const VkExtent3D vkExtent{
+		static_cast<uint32_t>(extent.x),
+		static_cast<uint32_t>(extent.y),
+		1u
+	};
+	auto vkImage = VulkanApi::ImportImage(
+		device,
+		handle,
+		vkExtent,
+		static_cast<VkFormat>(format),
+		static_cast<VkImageUsageFlags>(usage),
+		static_cast<VkImageLayout>(layout),
+		0,
+		1,
+		VK_SAMPLE_COUNT_1_BIT,
+		VK_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_TEXTURE_BIT);
+	if (!vkImage)
+	{
+		return nullptr;
+	}
+
+	RHI::RHIRenderTargetPtr result = RHI::RHIRenderTargetPtr::Make(
+		RHI::ETextureFiltration::Linear,
+		RHI::ETextureClamping::Clamp,
+		false,
+		layout);
+	result->m_vulkan.m_image = vkImage;
+	result->m_vulkan.m_imageView = VulkanImageViewPtr::Make(device, vkImage);
+	result->m_vulkan.m_imageView->Compile();
+	return result;
+}
+#endif
+
 void* VulkanGraphicsDriver::ExportImage(RHI::RHITexturePtr image)
 {
 	if (!image || !image->m_vulkan.m_image)
@@ -2913,7 +3000,7 @@ void VulkanGraphicsDriver::SetDefaultViewport(RHI::RHICommandListPtr cmd)
 	auto device = m_vkInstance->GetMainDevice();
 	auto pStateViewport = device->GetCurrentFrameViewport();
 
-#if defined(__APPLE__)
+#if defined(__APPLE__) || defined(_WIN32)
 	if (Sailor::App::HasEditor())
 	{
 		const glm::ivec2 renderArea = Sailor::App::GetMainWindow()->GetRenderArea();
@@ -3267,6 +3354,20 @@ bool VulkanGraphicsDriver::FitsDefaultViewport(RHI::RHICommandListPtr cmd)
 {
 	auto device = m_vkInstance->GetMainDevice();
 	auto pStateViewport = device->GetCurrentFrameViewport();
+
+#if defined(_WIN32)
+	if (Sailor::App::HasEditor())
+	{
+		const glm::ivec2 renderArea = Sailor::App::GetMainWindow()->GetRenderArea();
+		const float width = (float)std::max(renderArea.x, 1);
+		const float height = (float)std::max(renderArea.y, 1);
+		pStateViewport = new VulkanStateViewport(0.0f, height,
+			width, -height,
+			{ 0, 0 },
+			{ (uint32_t)width, (uint32_t)height },
+			0.0f, 1.0f);
+	}
+#endif
 
 	return cmd->m_vulkan.m_commandBuffer->FitsViewport(pStateViewport->GetViewport());
 }

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -153,6 +153,20 @@ namespace Sailor::GraphicsDriver::Vulkan
 			RHI::ETextureClamping clamping = RHI::ETextureClamping::Clamp,
 			RHI::ETextureUsageFlags usage = RHI::ETextureUsageBit::TextureTransferSrc_Bit | RHI::ETextureUsageBit::TextureTransferDst_Bit | RHI::ETextureUsageBit::Sampled_Bit) override;
 
+#if defined(_WIN32)
+		SAILOR_API virtual RHI::RHIRenderTargetPtr CreateExportableRenderTarget(
+			glm::ivec2 extent,
+			RHI::ETextureFormat format = RHI::ETextureFormat::B8G8R8A8_UNORM,
+			RHI::ETextureUsageFlags usage = RHI::ETextureUsageBit::TextureTransferSrc_Bit |
+				RHI::ETextureUsageBit::TextureTransferDst_Bit |
+				RHI::ETextureUsageBit::Sampled_Bit) override;
+		SAILOR_API virtual RHI::RHITexturePtr ImportD3D11Texture(
+			void* handle,
+			glm::ivec2 extent,
+			RHI::ETextureFormat format,
+			RHI::ETextureUsageFlags usage,
+			RHI::EImageLayout layout = RHI::EImageLayout::General) override;
+#endif
 		SAILOR_API virtual void* ExportImage(RHI::RHITexturePtr image) override;
 		SAILOR_API virtual RHI::RHITexturePtr ImportImage(void* handle,
 			glm::ivec3 extent,

--- a/Runtime/Platform/Win32/Input.cpp
+++ b/Runtime/Platform/Win32/Input.cpp
@@ -63,6 +63,17 @@ glm::ivec2 InputState::GetCursorPos() const
 	return glm::ivec2(m_cursorPosition[0], m_cursorPosition[1]);
 }
 
+glm::ivec2 InputState::GetButtonPressCursorPos(uint32_t button) const
+{
+	uint32_t index = 0;
+	if (!TryGetMouseButtonIndex(button, index))
+	{
+		return {};
+	}
+
+	return glm::ivec2(m_mousePressPosition[index][0], m_mousePressPosition[index][1]);
+}
+
 void InputState::TrackForChanges(const InputState& previousState)
 {
 	for (uint32_t i = 0; i < 256; i++)
@@ -124,6 +135,12 @@ void GlobalInput::SetMouseButtonState(uint32_t button, KeyState state)
 {
 	if (button < 3)
 	{
+		if (state == KeyState::Pressed && m_rawState.m_mouse[button] == KeyState::Up)
+		{
+			m_rawState.m_mousePressPosition[button][0] = m_rawState.m_cursorPosition[0];
+			m_rawState.m_mousePressPosition[button][1] = m_rawState.m_cursorPosition[1];
+		}
+
 		m_rawState.m_mouse[button] = state;
 		const uint32_t key = button == 0 ? VK_LBUTTON : button == 1 ? VK_RBUTTON : VK_MBUTTON;
 		m_rawState.m_keyboard[key] = state;

--- a/Runtime/Platform/Win32/Input.h
+++ b/Runtime/Platform/Win32/Input.h
@@ -22,6 +22,7 @@ namespace Sailor::Win32
 		SAILOR_API bool IsButtonClick(uint32_t button) const;
 
 		SAILOR_API glm::ivec2 GetCursorPos() const;
+		SAILOR_API glm::ivec2 GetButtonPressCursorPos(uint32_t button) const;
 		SAILOR_API void TrackForChanges(const InputState& previousState);
 
 	protected:
@@ -29,6 +30,7 @@ namespace Sailor::Win32
 		KeyState m_keyboard[256]{};
 		KeyState m_mouse[3]{};
 		int32_t m_cursorPosition[2]{};
+		int32_t m_mousePressPosition[3][2]{};
 
 #if defined(_WIN32)
 		friend LRESULT Sailor::Win32::WindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);

--- a/Runtime/RHI/GraphicsDriver.h
+++ b/Runtime/RHI/GraphicsDriver.h
@@ -207,6 +207,20 @@ namespace Sailor::RHI
                         ETextureUsageFlags usage = ETextureUsageBit::TextureTransferSrc_Bit | ETextureUsageBit::TextureTransferDst_Bit | ETextureUsageBit::Sampled_Bit) = 0;
 
                 // External memory support
+#if defined(_WIN32)
+		SAILOR_API virtual RHIRenderTargetPtr CreateExportableRenderTarget(
+			glm::ivec2 extent,
+			ETextureFormat format = ETextureFormat::B8G8R8A8_UNORM,
+			ETextureUsageFlags usage = ETextureUsageBit::TextureTransferSrc_Bit |
+				ETextureUsageBit::TextureTransferDst_Bit |
+				ETextureUsageBit::Sampled_Bit) = 0;
+		SAILOR_API virtual RHITexturePtr ImportD3D11Texture(
+			void* handle,
+			glm::ivec2 extent,
+			ETextureFormat format,
+			ETextureUsageFlags usage,
+			EImageLayout layout = EImageLayout::General) = 0;
+#endif
                 SAILOR_API virtual void* ExportImage(RHITexturePtr image) = 0;
                 SAILOR_API virtual RHITexturePtr ImportImage(void* handle,
                         glm::ivec3 extent,

--- a/Runtime/RHI/Types.h
+++ b/Runtime/RHI/Types.h
@@ -7,6 +7,11 @@
 #include "Containers/Containers.h"
 #include "Containers/Hash.h"
 
+#if defined(_MSC_VER)
+# pragma warning(push)
+# pragma warning(disable: 4251)
+#endif
+
 namespace Sailor::RHI
 {
 	using ShaderByteCode = Sailor::TVector<uint32_t>;
@@ -952,6 +957,10 @@ namespace Sailor::RHI
 		virtual ~IStateModifier() = default;
 	};
 };
+
+#if defined(_MSC_VER)
+# pragma warning(pop)
+#endif
 
 namespace std
 {

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -404,7 +404,7 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 #if defined(_WIN32)
 	Win32::ConsoleWindow::Initialize(false);
 
-	if (params.m_bRunConsole)
+	if (params.m_bRunConsole && !params.m_bIsEditor)
 	{
 		Win32::ConsoleWindow::GetInstance()->OpenWindow(L"Sailor Console");
 	}
@@ -474,6 +474,13 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	}
 
 	s_pInstance->m_pMainWindow->Create(className.c_str(), className.c_str(), 1024, 768, false, false, params.m_editorHwnd);
+
+#if defined(_WIN32)
+	if (params.m_bIsEditor)
+	{
+		s_pInstance->m_pMainWindow->Show(false);
+	}
+#endif
 
 	if (params.m_bIsEditor)
 	{

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -75,6 +75,7 @@ namespace Sailor
 		SAILOR_API static uint32_t GetEditorRemoteViewportDiagnostics(uint64_t viewportId, char** diagnostics);
 		SAILOR_API static bool RetryEditorRemoteViewport(uint64_t viewportId);
 		SAILOR_API static bool SetEditorRemoteViewportMacHostHandle(uint64_t viewportId, uint32_t hostHandleKind, uint64_t hostHandleValue);
+		SAILOR_API static bool SetEditorRemoteViewportWindowsHost(uint64_t viewportId, void* swapChainPanelInspectable, float compositionScale);
 		SAILOR_API static bool SendEditorRemoteViewportInput(uint64_t viewportId, uint32_t kind, float pointerX, float pointerY, float wheelDeltaX, float wheelDeltaY, uint32_t keyCode, uint32_t button, uint32_t modifiers, bool bPressed, bool bFocused, bool bCaptured);
 		SAILOR_API static uint32_t PullEditorMessages(char** messages, uint32_t num);
 		SAILOR_API static uint32_t PullEditorViewportEvents(char** events, uint32_t num);

--- a/Runtime/Submodules/EditorRemote/RemoteViewportFoundation.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportFoundation.h
@@ -293,7 +293,8 @@ namespace Sailor::EditorRemote
 	{
 		None = 0,
 		CpuDeviceIdle,
-		MetalSharedEvent
+		MetalSharedEvent,
+		Win32KeyedMutex
 	};
 
 	struct FrameSyncMetadata

--- a/Runtime/Submodules/EditorRemote/RemoteViewportWindowsNative.cpp
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportWindowsNative.cpp
@@ -1,0 +1,1046 @@
+#if defined(_WIN32)
+
+#include <d3d11_4.h>
+#include <dxgi1_6.h>
+#include <wrl/client.h>
+
+#include "RemoteViewportWindowsNative.h"
+
+#include "AssetRegistry/FrameGraph/FrameGraphImporter.h"
+#include "Core/LogMacros.h"
+#include "FrameGraph/EditorReadbackNode.h"
+#include "FrameGraph/RHIFrameGraph.h"
+#include "GraphicsDriver/Vulkan/VulkanApi.h"
+#include "GraphicsDriver/Vulkan/VulkanCommandBuffer.h"
+#include "GraphicsDriver/Vulkan/VulkanDevice.h"
+#include "GraphicsDriver/Vulkan/VulkanDeviceMemory.h"
+#include "GraphicsDriver/Vulkan/VulkanFence.h"
+#include "GraphicsDriver/Vulkan/VulkanImage.h"
+#include "GraphicsDriver/Vulkan/VulkanImageView.h"
+#include "RHI/CommandList.h"
+#include "RHI/Fence.h"
+#include "RHI/Renderer.h"
+#include "RHI/RenderTarget.h"
+#include "RHI/Surface.h"
+#include "Sailor.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstring>
+#include <sstream>
+#include <thread>
+
+using Microsoft::WRL::ComPtr;
+
+// WinUI 3 uses a different native SwapChainPanel interface than UWP XAML.
+// Keep the declaration local so the engine does not depend on a NuGet include path.
+struct __declspec(uuid("63aad0b8-7c24-40ff-85a8-640d944cc325")) IWinUI3SwapChainPanelNative : IUnknown
+{
+	virtual HRESULT STDMETHODCALLTYPE SetSwapChain(IDXGISwapChain* swapChain) = 0;
+};
+
+namespace Sailor::EditorRemote
+{
+	namespace
+	{
+		struct WindowsRendererFrameSource
+		{
+			RHI::RHITexturePtr m_texture{};
+			std::string m_debugName{};
+
+			bool IsValid() const
+			{
+				return m_texture &&
+					m_texture->m_vulkan.m_image &&
+					m_texture->m_vulkan.m_imageView;
+			}
+		};
+
+		WindowsRendererFrameSource TryAcquireRendererFrameSource()
+		{
+			auto* renderer = App::GetSubmodule<RHI::Renderer>();
+			FrameGraphPtr frameGraph{};
+			if (renderer)
+			{
+				frameGraph = renderer->GetFrameGraph();
+			}
+			auto rhiFrameGraph = frameGraph ? frameGraph->GetRHI() : RHI::RHIFrameGraphPtr{};
+			if (!rhiFrameGraph)
+			{
+				return {};
+			}
+
+			const auto readbackNode = rhiFrameGraph
+				->GetGraphNode("EditorReadback")
+				.DynamicCast<Framegraph::EditorReadbackNode>();
+			if (readbackNode)
+			{
+				auto texture = readbackNode->GetTexture();
+				if (texture && texture->m_vulkan.m_image && texture->m_vulkan.m_imageView)
+				{
+					WindowsRendererFrameSource source{};
+					source.m_texture = texture;
+					source.m_debugName = "EditorReadback";
+					return source;
+				}
+			}
+
+			constexpr const char* surfaceNames[] = {
+				"EditorOutput",
+				"Main",
+				"BackBuffer",
+				"Secondary"
+			};
+			for (const char* surfaceName : surfaceNames)
+			{
+				if (auto surface = rhiFrameGraph->GetSurface(surfaceName))
+				{
+					auto texture = surface->GetResolved();
+					if (!texture)
+					{
+						texture = surface->GetTarget();
+					}
+					if (texture && texture->m_vulkan.m_image && texture->m_vulkan.m_imageView)
+					{
+						WindowsRendererFrameSource source{};
+						source.m_texture = texture;
+						source.m_debugName = std::string("Surface.") + surfaceName;
+						return source;
+					}
+				}
+
+				if (auto texture = rhiFrameGraph->GetRenderTarget(surfaceName))
+				{
+					if (texture->m_vulkan.m_image && texture->m_vulkan.m_imageView)
+					{
+						WindowsRendererFrameSource source{};
+						source.m_texture = texture;
+						source.m_debugName = std::string("RenderTarget.") + surfaceName;
+						return source;
+					}
+				}
+			}
+
+			return {};
+		}
+
+		Failure MakeWindowsFailure(HRESULT result, const char* operation)
+		{
+			std::ostringstream message;
+			message << operation << " failed with HRESULT=0x"
+				<< std::hex << static_cast<uint32_t>(result);
+			return Failure::FromDomain(
+				ErrorDomain::Transport,
+				static_cast<int32_t>(result),
+				message.str());
+		}
+
+		Failure CreateD3D11DeviceForVulkanAdapter(
+			ComPtr<ID3D11Device1>& outDevice,
+			ComPtr<ID3D11DeviceContext1>& outContext,
+			ComPtr<IDXGIFactory2>& outFactory)
+		{
+			auto* vulkanApi = Sailor::GraphicsDriver::Vulkan::VulkanApi::GetInstance();
+			auto vulkanDevice = vulkanApi ? vulkanApi->GetMainDevice() : nullptr;
+			if (!vulkanDevice)
+			{
+				return Failure::FromDomain(
+					ErrorDomain::Session,
+					1,
+					"The Vulkan device is unavailable while creating the D3D11 device");
+			}
+
+			VkPhysicalDeviceIDProperties idProperties{};
+			idProperties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES;
+			VkPhysicalDeviceProperties2 properties{};
+			properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+			properties.pNext = &idProperties;
+			vkGetPhysicalDeviceProperties2(vulkanDevice->GetPhysicalDevice(), &properties);
+			if (!idProperties.deviceLUIDValid)
+			{
+				return Failure::FromDomain(
+					ErrorDomain::Capability,
+					1,
+					"The Vulkan adapter does not expose a Windows LUID");
+			}
+
+			ComPtr<IDXGIFactory6> factory6;
+			HRESULT result = CreateDXGIFactory1(IID_PPV_ARGS(&factory6));
+			if (FAILED(result))
+			{
+				return MakeWindowsFailure(result, "CreateDXGIFactory1");
+			}
+
+			ComPtr<IDXGIAdapter1> matchingAdapter;
+			for (UINT adapterIndex = 0; ; ++adapterIndex)
+			{
+				ComPtr<IDXGIAdapter1> adapter;
+				result = factory6->EnumAdapters1(adapterIndex, &adapter);
+				if (result == DXGI_ERROR_NOT_FOUND)
+				{
+					break;
+				}
+				if (FAILED(result))
+				{
+					return MakeWindowsFailure(result, "IDXGIFactory::EnumAdapters1");
+				}
+
+				DXGI_ADAPTER_DESC1 description{};
+				if (SUCCEEDED(adapter->GetDesc1(&description)) &&
+					std::memcmp(&description.AdapterLuid, idProperties.deviceLUID, sizeof(LUID)) == 0)
+				{
+					matchingAdapter = adapter;
+					break;
+				}
+			}
+			if (!matchingAdapter)
+			{
+				return Failure::FromDomain(
+					ErrorDomain::Capability,
+					1,
+					"No D3D11 adapter matches the Vulkan physical-device LUID");
+			}
+
+			constexpr D3D_FEATURE_LEVEL featureLevels[] = {
+				D3D_FEATURE_LEVEL_11_1,
+				D3D_FEATURE_LEVEL_11_0
+			};
+			ComPtr<ID3D11Device> baseDevice;
+			ComPtr<ID3D11DeviceContext> baseContext;
+			D3D_FEATURE_LEVEL selectedFeatureLevel{};
+			result = D3D11CreateDevice(
+				matchingAdapter.Get(),
+				D3D_DRIVER_TYPE_UNKNOWN,
+				nullptr,
+				D3D11_CREATE_DEVICE_BGRA_SUPPORT,
+				featureLevels,
+				static_cast<UINT>(std::size(featureLevels)),
+				D3D11_SDK_VERSION,
+				&baseDevice,
+				&selectedFeatureLevel,
+				&baseContext);
+			if (FAILED(result))
+			{
+				return MakeWindowsFailure(result, "D3D11CreateDevice");
+			}
+
+			result = baseDevice.As(&outDevice);
+			if (SUCCEEDED(result))
+			{
+				result = baseContext.As(&outContext);
+			}
+			if (FAILED(result))
+			{
+				return MakeWindowsFailure(result, "D3D11 interface upgrade");
+			}
+
+			result = matchingAdapter->GetParent(IID_PPV_ARGS(&outFactory));
+			return FAILED(result)
+				? MakeWindowsFailure(result, "IDXGIAdapter::GetParent")
+				: Failure::Ok();
+		}
+	}
+
+	struct SailorWindowsSharedSurfaceProvider::Impl
+	{
+		struct Allocation
+		{
+			WindowsViewportSurfaceKey m_key{};
+			RHI::RHITexturePtr m_texture{};
+			ComPtr<ID3D11Texture2D> m_ownerTexture{};
+			HANDLE m_sharedHandle = nullptr;
+			uint64_t m_allocationId = 0;
+			FrameIndex m_frameIndex = 0;
+			bool m_ownedByExternal = false;
+			std::string m_lastSourceName{};
+
+			~Allocation()
+			{
+				if (m_sharedHandle)
+				{
+					CloseHandle(m_sharedHandle);
+				}
+			}
+		};
+
+		TMap<WindowsViewportSurfaceKey, TUniquePtr<Allocation>> m_allocations{};
+		ComPtr<ID3D11Device1> m_device{};
+		ComPtr<ID3D11DeviceContext1> m_context{};
+		ComPtr<IDXGIFactory2> m_factory{};
+		Failure m_lastFailure = Failure::Ok();
+		uint64_t m_nextAllocationId = 1;
+
+		Failure EnsureDevice()
+		{
+			return m_device && m_context && m_factory
+				? Failure::Ok()
+				: CreateD3D11DeviceForVulkanAdapter(m_device, m_context, m_factory);
+		}
+
+		Failure CreateSharedTexture(
+			uint32_t width,
+			uint32_t height,
+			ComPtr<ID3D11Texture2D>& outTexture,
+			HANDLE& outHandle)
+		{
+			auto result = EnsureDevice();
+			if (!result.IsOk())
+			{
+				return result;
+			}
+
+			D3D11_TEXTURE2D_DESC description{};
+			description.Width = width;
+			description.Height = height;
+			description.MipLevels = 1;
+			description.ArraySize = 1;
+			description.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+			description.SampleDesc = { 1, 0 };
+			description.Usage = D3D11_USAGE_DEFAULT;
+			description.BindFlags =
+				D3D11_BIND_RENDER_TARGET |
+				D3D11_BIND_SHADER_RESOURCE;
+			description.MiscFlags =
+				D3D11_RESOURCE_MISC_SHARED_NTHANDLE |
+				D3D11_RESOURCE_MISC_SHARED_KEYEDMUTEX;
+
+			HRESULT nativeResult = m_device->CreateTexture2D(
+				&description,
+				nullptr,
+				&outTexture);
+			if (FAILED(nativeResult))
+			{
+				return MakeWindowsFailure(nativeResult, "ID3D11Device::CreateTexture2D");
+			}
+
+			ComPtr<IDXGIResource1> resource;
+			nativeResult = outTexture.As(&resource);
+			if (FAILED(nativeResult))
+			{
+				return MakeWindowsFailure(nativeResult, "D3D11 texture IDXGIResource1 query");
+			}
+
+			nativeResult = resource->CreateSharedHandle(
+				nullptr,
+				DXGI_SHARED_RESOURCE_READ | DXGI_SHARED_RESOURCE_WRITE,
+				nullptr,
+				&outHandle);
+			return FAILED(nativeResult)
+				? MakeWindowsFailure(nativeResult, "IDXGIResource1::CreateSharedHandle")
+				: Failure::Ok();
+		}
+
+		Allocation* Find(const WindowsViewportSurfaceKey& key)
+		{
+			auto it = m_allocations.Find(key);
+			return it != m_allocations.end() ? it.Value().GetRawPtr() : nullptr;
+		}
+
+		const Allocation* Find(const WindowsViewportSurfaceKey& key) const
+		{
+			auto it = m_allocations.Find(key);
+			return it != m_allocations.end() ? it.Value().GetRawPtr() : nullptr;
+		}
+	};
+
+	SailorWindowsSharedSurfaceProvider::SailorWindowsSharedSurfaceProvider() :
+		m_impl(TUniquePtr<Impl>::Make())
+	{
+	}
+
+	SailorWindowsSharedSurfaceProvider::~SailorWindowsSharedSurfaceProvider() = default;
+
+	Failure SailorWindowsSharedSurfaceProvider::CreateOrResizeSurface(
+		const ViewportDescriptor& viewport,
+		ConnectionEpoch epoch,
+		SurfaceGeneration generation,
+		WindowsViewportSurfaceState& inOutState)
+	{
+		auto& driver = RHI::Renderer::GetDriver();
+		if (!driver)
+		{
+			m_impl->m_lastFailure = Failure::FromDomain(
+				ErrorDomain::Session,
+				1,
+				"Renderer is unavailable while creating the Windows shared surface");
+			return m_impl->m_lastFailure;
+		}
+
+		const RHI::ETextureUsageFlags usage =
+			RHI::ETextureUsageBit::TextureTransferSrc_Bit |
+			RHI::ETextureUsageBit::TextureTransferDst_Bit |
+			RHI::ETextureUsageBit::Sampled_Bit;
+		HANDLE sharedHandle = nullptr;
+		ComPtr<ID3D11Texture2D> ownerTexture;
+		auto createResult = m_impl->CreateSharedTexture(
+			viewport.m_width,
+			viewport.m_height,
+			ownerTexture,
+			sharedHandle);
+		if (!createResult.IsOk())
+		{
+			SAILOR_LOG_ERROR("Windows shared texture creation failed: native=%d message=%s",
+				createResult.m_nativeCode,
+				createResult.m_message.c_str());
+			m_impl->m_lastFailure = createResult;
+			return createResult;
+		}
+
+		auto texture = driver->ImportD3D11Texture(
+			sharedHandle,
+			{ static_cast<int32_t>(viewport.m_width), static_cast<int32_t>(viewport.m_height) },
+			RHI::ETextureFormat::B8G8R8A8_UNORM,
+			usage,
+			RHI::EImageLayout::General);
+		if (!texture)
+		{
+			CloseHandle(sharedHandle);
+			m_impl->m_lastFailure = Failure::FromDomain(
+				ErrorDomain::Capability,
+				1,
+				"Vulkan could not import the D3D11 shared texture");
+			SAILOR_LOG_ERROR("%s", m_impl->m_lastFailure.m_message.c_str());
+			return m_impl->m_lastFailure;
+		}
+
+		auto allocation = TUniquePtr<Impl::Allocation>::Make();
+		allocation->m_key = { viewport.m_viewportId, epoch, generation };
+		allocation->m_texture = texture;
+		allocation->m_ownerTexture = std::move(ownerTexture);
+		allocation->m_sharedHandle = sharedHandle;
+		allocation->m_allocationId = m_impl->m_nextAllocationId++;
+		allocation->m_ownedByExternal = true;
+
+		WindowsSharedSurfaceHandle nativeHandle{};
+		nativeHandle.m_sharedTextureHandle = reinterpret_cast<uint64_t>(sharedHandle);
+		nativeHandle.m_allocationId = allocation->m_allocationId;
+		nativeHandle.m_rowPitch = viewport.m_width * 4u;
+
+		inOutState.m_transport.m_syncMode = SyncMode::ExplicitFence;
+		inOutState.m_transport.m_nativeHandles = { nativeHandle };
+		const WindowsViewportSurfaceKey allocationKey = allocation->m_key;
+		m_impl->m_allocations[allocationKey] = std::move(allocation);
+		m_impl->m_lastFailure = Failure::Ok();
+		return Failure::Ok();
+	}
+
+	Failure SailorWindowsSharedSurfaceProvider::BeginFrame(
+		WindowsViewportSurfaceState& state)
+	{
+		auto* allocation = m_impl->Find(state.m_key);
+		if (!allocation || !allocation->m_texture)
+		{
+			m_impl->m_lastFailure = Failure::FromDomain(
+				ErrorDomain::Session,
+				2,
+				"Windows shared surface allocation is missing");
+			return m_impl->m_lastFailure;
+		}
+
+		auto& driver = RHI::Renderer::GetDriver();
+		auto* commands = RHI::Renderer::GetDriverCommands();
+		if (!driver || !commands)
+		{
+			m_impl->m_lastFailure = Failure::FromDomain(
+				ErrorDomain::Session,
+				1,
+				"Renderer commands are unavailable for the Windows shared surface");
+			return m_impl->m_lastFailure;
+		}
+
+		const WindowsRendererFrameSource source = TryAcquireRendererFrameSource();
+
+		auto commandList = driver->CreateCommandList(false, RHI::ECommandListQueue::Graphics);
+		commands->BeginCommandList(commandList, true);
+
+		auto device = Sailor::GraphicsDriver::Vulkan::VulkanApi::GetInstance()->GetMainDevice();
+		const uint32_t graphicsFamily = device->GetQueueFamilies().m_graphicsFamily.value();
+		auto sharedImageView = allocation->m_texture->m_vulkan.m_imageView;
+		if (allocation->m_ownedByExternal)
+		{
+			commandList->m_vulkan.m_commandBuffer->ImageMemoryBarrier(
+				sharedImageView,
+				sharedImageView->m_format,
+				VK_IMAGE_LAYOUT_GENERAL,
+				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+				0,
+				VK_ACCESS_TRANSFER_WRITE_BIT,
+				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+				VK_PIPELINE_STAGE_TRANSFER_BIT,
+				VK_QUEUE_FAMILY_EXTERNAL,
+				graphicsFamily);
+		}
+		else
+		{
+			commandList->m_vulkan.m_commandBuffer->ImageMemoryBarrier(
+				sharedImageView,
+				sharedImageView->m_format,
+				VK_IMAGE_LAYOUT_UNDEFINED,
+				VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+				0,
+				VK_ACCESS_TRANSFER_WRITE_BIT,
+				VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+				VK_PIPELINE_STAGE_TRANSFER_BIT);
+		}
+
+		if (source.IsValid())
+		{
+			commands->ImageMemoryBarrier(
+				commandList,
+				source.m_texture,
+				source.m_texture->GetFormat(),
+				source.m_texture->GetDefaultLayout(),
+				RHI::EImageLayout::TransferSrcOptimal);
+
+			const auto sourceExtent = source.m_texture->GetExtent();
+			const auto destinationExtent = allocation->m_texture->GetExtent();
+			const bool copied = commands->BlitImage(
+				commandList,
+				source.m_texture,
+				allocation->m_texture,
+				{ 0, 0, sourceExtent.x, sourceExtent.y },
+				{ 0, 0, destinationExtent.x, destinationExtent.y });
+
+			commands->ImageMemoryBarrier(
+				commandList,
+				source.m_texture,
+				source.m_texture->GetFormat(),
+				RHI::EImageLayout::TransferSrcOptimal,
+				source.m_texture->GetDefaultLayout());
+			if (!copied)
+			{
+				commands->EndCommandList(commandList);
+				m_impl->m_lastFailure = Failure::FromDomain(
+					ErrorDomain::Capability,
+					1,
+					"Vulkan cannot blit the renderer output into the Windows shared texture");
+				return m_impl->m_lastFailure;
+			}
+			allocation->m_lastSourceName = source.m_debugName;
+		}
+		else
+		{
+			commands->ClearImage(commandList, allocation->m_texture, glm::vec4(0.0f));
+			allocation->m_lastSourceName = "unavailable";
+		}
+
+		commandList->m_vulkan.m_commandBuffer->ImageMemoryBarrier(
+			sharedImageView,
+			sharedImageView->m_format,
+			VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
+			VK_IMAGE_LAYOUT_GENERAL,
+			VK_ACCESS_TRANSFER_WRITE_BIT,
+			0,
+			VK_PIPELINE_STAGE_TRANSFER_BIT,
+			VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+			graphicsFamily,
+			VK_QUEUE_FAMILY_EXTERNAL);
+
+		commands->EndCommandList(commandList);
+		const FrameIndex nextFrameIndex = allocation->m_frameIndex + 1;
+		const uint64_t acquireKey = (nextFrameIndex - 1) * 2;
+		const uint64_t releaseKey = acquireKey + 1;
+		const uint32_t acquireTimeoutMs = 2000;
+		VkDeviceMemory sharedMemory = *allocation->m_texture
+			->m_vulkan.m_image
+			->GetMemoryDevice();
+
+		VkWin32KeyedMutexAcquireReleaseInfoKHR keyedMutexInfo{};
+		keyedMutexInfo.sType = VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR;
+		keyedMutexInfo.acquireCount = 1;
+		keyedMutexInfo.pAcquireSyncs = &sharedMemory;
+		keyedMutexInfo.pAcquireKeys = &acquireKey;
+		keyedMutexInfo.pAcquireTimeouts = &acquireTimeoutMs;
+		keyedMutexInfo.releaseCount = 1;
+		keyedMutexInfo.pReleaseSyncs = &sharedMemory;
+		keyedMutexInfo.pReleaseKeys = &releaseKey;
+
+		auto fence = Sailor::GraphicsDriver::Vulkan::VulkanFencePtr::Make(device);
+		if (!device->SubmitCommandBuffer(
+				commandList->m_vulkan.m_commandBuffer,
+				fence,
+				{},
+				{},
+				&keyedMutexInfo))
+		{
+			m_impl->m_lastFailure = Failure::FromDomain(
+				ErrorDomain::Transport,
+				1,
+				"Submitting the Windows shared-texture copy failed");
+			return m_impl->m_lastFailure;
+		}
+		fence->Wait();
+		allocation->m_ownedByExternal = true;
+		m_impl->m_lastFailure = Failure::Ok();
+		return Failure::Ok();
+	}
+
+	Failure SailorWindowsSharedSurfaceProvider::ExportFrame(
+		WindowsViewportSurfaceState& state,
+		FramePacket& outFrame)
+	{
+		auto* allocation = m_impl->Find(state.m_key);
+		if (!allocation || !allocation->m_ownedByExternal)
+		{
+			m_impl->m_lastFailure = Failure::FromDomain(
+				ErrorDomain::Session,
+				2,
+				"Windows shared surface is not ready for export");
+			return m_impl->m_lastFailure;
+		}
+
+		outFrame = {};
+		outFrame.m_viewportId = state.m_key.m_viewportId;
+		outFrame.m_connectionEpoch = state.m_key.m_epoch;
+		outFrame.m_generation = state.m_key.m_generation;
+		outFrame.m_frameIndex = ++allocation->m_frameIndex;
+		outFrame.m_width = state.m_viewport.m_width;
+		outFrame.m_height = state.m_viewport.m_height;
+		outFrame.m_timestampNs = static_cast<uint64_t>(
+			std::chrono::duration_cast<std::chrono::nanoseconds>(
+				std::chrono::steady_clock::now().time_since_epoch()).count());
+		outFrame.m_sync.m_acquireValue = outFrame.m_frameIndex * 2 - 1;
+		outFrame.m_sync.m_releaseValue = outFrame.m_frameIndex * 2;
+		outFrame.m_sync.m_crossApiAcquireValue = outFrame.m_sync.m_acquireValue;
+		outFrame.m_sync.m_crossApiSyncKind = CrossApiSyncKind::Win32KeyedMutex;
+		outFrame.m_sync.m_requiresExplicitRelease = true;
+		outFrame.m_sync.m_crossApiCpuWaited = true;
+		m_impl->m_lastFailure = Failure::Ok();
+		return Failure::Ok();
+	}
+
+	Failure SailorWindowsSharedSurfaceProvider::ReleaseSurface(
+		const WindowsViewportSurfaceState& state)
+	{
+		auto it = m_impl->m_allocations.Find(state.m_key);
+		if (it == m_impl->m_allocations.end())
+		{
+			m_impl->m_lastFailure = Failure::Ok();
+			return Failure::Ok();
+		}
+
+		auto& allocation = *it.Value();
+		if (allocation.m_sharedHandle)
+		{
+			CloseHandle(allocation.m_sharedHandle);
+			allocation.m_sharedHandle = nullptr;
+		}
+		m_impl->m_allocations.Remove(state.m_key);
+		m_impl->m_lastFailure = Failure::Ok();
+		return Failure::Ok();
+	}
+
+	Failure SailorWindowsSharedSurfaceProvider::GetLastFailure() const
+	{
+		return m_impl->m_lastFailure;
+	}
+
+	std::string SailorWindowsSharedSurfaceProvider::BuildSummary(
+		ViewportId viewportId,
+		ConnectionEpoch epoch,
+		SurfaceGeneration generation) const
+	{
+		const auto* allocation = m_impl->Find({ viewportId, epoch, generation });
+		if (!allocation)
+		{
+			return "windowsSurface=missing";
+		}
+
+		std::ostringstream summary;
+		summary << "windowsSurface=1 allocation=" << allocation->m_allocationId
+			<< " frame=" << allocation->m_frameIndex
+			<< " source='" << allocation->m_lastSourceName << "'"
+			<< " externalOwned=" << (allocation->m_ownedByExternal ? 1 : 0);
+		return summary.str();
+	}
+
+	struct SailorWindowsViewportPresenter::Impl
+	{
+		ComPtr<ID3D11Device1> m_device{};
+		ComPtr<ID3D11DeviceContext1> m_context{};
+		ComPtr<IDXGIFactory2> m_factory{};
+		ComPtr<ID3D11Texture2D> m_sharedTexture{};
+		ComPtr<IDXGIKeyedMutex> m_keyedMutex{};
+		ComPtr<IDXGISwapChain1> m_swapChain{};
+		ComPtr<ID3D11Query> m_copyCompleteQuery{};
+		ComPtr<IWinUI3SwapChainPanelNative> m_panel{};
+		ComPtr<IDXGISwapChain1> m_attachedSwapChain{};
+		ViewportId m_viewportId = 0;
+		ConnectionEpoch m_epoch = 0;
+		SurfaceGeneration m_generation = 0;
+		FrameIndex m_presentedFrameIndex = 0;
+		uint32_t m_width = 0;
+		uint32_t m_height = 0;
+		float m_compositionScale = 1.0f;
+		Failure m_lastFailure = Failure::Ok();
+
+		Failure EnsureDevice()
+		{
+			if (m_device && m_context && m_factory)
+			{
+				return Failure::Ok();
+			}
+
+			auto createResult = CreateD3D11DeviceForVulkanAdapter(
+				m_device,
+				m_context,
+				m_factory);
+			if (!createResult.IsOk())
+			{
+				return createResult;
+			}
+
+			D3D11_QUERY_DESC queryDescription{};
+			queryDescription.Query = D3D11_QUERY_EVENT;
+			const HRESULT result = m_device->CreateQuery(
+				&queryDescription,
+				&m_copyCompleteQuery);
+			if (FAILED(result))
+			{
+				return MakeWindowsFailure(result, "ID3D11Device::CreateQuery");
+			}
+
+			return Failure::Ok();
+		}
+
+		Failure AttachSwapChainOnCurrentThread()
+		{
+			if (!m_panel)
+			{
+				return Failure::FromDomain(
+					ErrorDomain::Session,
+					1,
+					"The Windows viewport has no SwapChainPanel host");
+			}
+			if (!m_swapChain)
+			{
+				return Failure::Ok();
+			}
+			if (m_attachedSwapChain.Get() == m_swapChain.Get())
+			{
+				return Failure::Ok();
+			}
+
+			const HRESULT result = m_panel->SetSwapChain(m_swapChain.Get());
+			if (FAILED(result))
+			{
+				return MakeWindowsFailure(result, "ISwapChainPanelNative::SetSwapChain");
+			}
+			m_attachedSwapChain = m_swapChain;
+			return Failure::Ok();
+		}
+
+		Failure ApplyCompositionScale()
+		{
+			if (!m_swapChain)
+			{
+				return Failure::Ok();
+			}
+
+			ComPtr<IDXGISwapChain2> swapChain;
+			const HRESULT queryResult = m_swapChain.As(&swapChain);
+			if (FAILED(queryResult))
+			{
+				return MakeWindowsFailure(queryResult, "IDXGISwapChain2 query");
+			}
+
+			const float inverseScale = 1.0f / m_compositionScale;
+			const DXGI_MATRIX_3X2_F transform{
+				inverseScale, 0.0f,
+				0.0f, inverseScale,
+				0.0f, 0.0f
+			};
+			const HRESULT result = swapChain->SetMatrixTransform(&transform);
+			return FAILED(result)
+				? MakeWindowsFailure(result, "IDXGISwapChain2::SetMatrixTransform")
+				: Failure::Ok();
+		}
+	};
+
+	SailorWindowsViewportPresenter::SailorWindowsViewportPresenter() :
+		m_impl(TUniquePtr<Impl>::Make())
+	{
+	}
+
+	SailorWindowsViewportPresenter::~SailorWindowsViewportPresenter() = default;
+
+	Failure SailorWindowsViewportPresenter::ImportSurface(
+		const ViewportDescriptor& viewport,
+		const TransportDescriptor& transport,
+		ConnectionEpoch epoch,
+		SurfaceGeneration generation)
+	{
+		if (transport.m_nativeHandles.empty() ||
+			!transport.m_nativeHandles.front().IsValid())
+		{
+			m_impl->m_lastFailure = Failure::FromDomain(
+				ErrorDomain::Protocol,
+				1,
+				"The Windows transport has no shared texture handle");
+			return m_impl->m_lastFailure;
+		}
+
+		auto result = m_impl->EnsureDevice();
+		if (!result.IsOk())
+		{
+			m_impl->m_lastFailure = result;
+			return result;
+		}
+
+		m_impl->m_sharedTexture.Reset();
+		m_impl->m_keyedMutex.Reset();
+		const HANDLE sharedHandle = reinterpret_cast<HANDLE>(
+			transport.m_nativeHandles.front().m_sharedTextureHandle);
+		HRESULT nativeResult = m_impl->m_device->OpenSharedResource1(
+			sharedHandle,
+			IID_PPV_ARGS(&m_impl->m_sharedTexture));
+		if (FAILED(nativeResult))
+		{
+			m_impl->m_lastFailure = MakeWindowsFailure(
+				nativeResult,
+				"ID3D11Device1::OpenSharedResource1");
+			return m_impl->m_lastFailure;
+		}
+
+		nativeResult = m_impl->m_sharedTexture.As(&m_impl->m_keyedMutex);
+		if (FAILED(nativeResult))
+		{
+			m_impl->m_lastFailure = MakeWindowsFailure(
+				nativeResult,
+				"D3D11 shared texture IDXGIKeyedMutex query");
+			return m_impl->m_lastFailure;
+		}
+
+		D3D11_TEXTURE2D_DESC textureDescription{};
+		m_impl->m_sharedTexture->GetDesc(&textureDescription);
+		if (textureDescription.Width != viewport.m_width ||
+			textureDescription.Height != viewport.m_height ||
+			textureDescription.Format != DXGI_FORMAT_B8G8R8A8_UNORM)
+		{
+			m_impl->m_lastFailure = Failure::FromDomain(
+				ErrorDomain::Protocol,
+				1,
+				"The imported D3D11 texture does not match the viewport descriptor");
+			return m_impl->m_lastFailure;
+		}
+
+		DXGI_SWAP_CHAIN_DESC1 swapChainDescription{};
+		swapChainDescription.Width = viewport.m_width;
+		swapChainDescription.Height = viewport.m_height;
+		swapChainDescription.Format = DXGI_FORMAT_B8G8R8A8_UNORM;
+		swapChainDescription.Stereo = FALSE;
+		swapChainDescription.SampleDesc = { 1, 0 };
+		swapChainDescription.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
+		swapChainDescription.BufferCount = 2;
+		swapChainDescription.Scaling = DXGI_SCALING_STRETCH;
+		swapChainDescription.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
+		swapChainDescription.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
+
+		m_impl->m_swapChain.Reset();
+		nativeResult = m_impl->m_factory->CreateSwapChainForComposition(
+			m_impl->m_device.Get(),
+			&swapChainDescription,
+			nullptr,
+			&m_impl->m_swapChain);
+		if (FAILED(nativeResult))
+		{
+			m_impl->m_lastFailure = MakeWindowsFailure(
+				nativeResult,
+				"IDXGIFactory2::CreateSwapChainForComposition");
+			return m_impl->m_lastFailure;
+		}
+
+		result = m_impl->ApplyCompositionScale();
+		if (!result.IsOk())
+		{
+			m_impl->m_lastFailure = result;
+			m_impl->m_swapChain.Reset();
+			return result;
+		}
+
+		m_impl->m_attachedSwapChain.Reset();
+		m_impl->m_viewportId = viewport.m_viewportId;
+		m_impl->m_epoch = epoch;
+		m_impl->m_generation = generation;
+		m_impl->m_width = viewport.m_width;
+		m_impl->m_height = viewport.m_height;
+		m_impl->m_presentedFrameIndex = 0;
+		m_impl->m_lastFailure = Failure::Ok();
+		return Failure::Ok();
+	}
+
+	Failure SailorWindowsViewportPresenter::PresentFrame(
+		ViewportId viewportId,
+		const FramePacket& frame)
+	{
+		if (viewportId != m_impl->m_viewportId ||
+			frame.m_connectionEpoch != m_impl->m_epoch ||
+			frame.m_generation != m_impl->m_generation ||
+			!m_impl->m_sharedTexture ||
+			!m_impl->m_keyedMutex ||
+			!m_impl->m_swapChain)
+		{
+			m_impl->m_lastFailure = Failure::FromDomain(
+				ErrorDomain::Session,
+				2,
+				"The Windows presenter surface generation is stale");
+			return m_impl->m_lastFailure;
+		}
+
+		const uint64_t acquireKey = frame.m_sync.m_acquireValue;
+		const uint64_t releaseKey = frame.m_sync.m_releaseValue;
+		HRESULT result = m_impl->m_keyedMutex->AcquireSync(acquireKey, 2000);
+		if (FAILED(result))
+		{
+			m_impl->m_lastFailure = MakeWindowsFailure(result, "IDXGIKeyedMutex::AcquireSync");
+			return m_impl->m_lastFailure;
+		}
+
+		if (m_impl->m_attachedSwapChain.Get() == m_impl->m_swapChain.Get())
+		{
+			ComPtr<ID3D11Texture2D> backBuffer;
+			result = m_impl->m_swapChain->GetBuffer(0, IID_PPV_ARGS(&backBuffer));
+			if (FAILED(result))
+			{
+				m_impl->m_keyedMutex->ReleaseSync(releaseKey);
+				m_impl->m_lastFailure = MakeWindowsFailure(result, "IDXGISwapChain::GetBuffer");
+				return m_impl->m_lastFailure;
+			}
+
+			m_impl->m_context->CopyResource(backBuffer.Get(), m_impl->m_sharedTexture.Get());
+			m_impl->m_context->End(m_impl->m_copyCompleteQuery.Get());
+			m_impl->m_context->Flush();
+
+			const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+			while (m_impl->m_context->GetData(
+				m_impl->m_copyCompleteQuery.Get(),
+				nullptr,
+				0,
+				0) == S_FALSE)
+			{
+				if (std::chrono::steady_clock::now() >= deadline)
+				{
+					m_impl->m_keyedMutex->ReleaseSync(releaseKey);
+					m_impl->m_lastFailure = Failure::FromDomain(
+						ErrorDomain::Session,
+						1,
+						"Timed out waiting for the D3D11 shared-texture copy");
+					return m_impl->m_lastFailure;
+				}
+				std::this_thread::yield();
+			}
+
+			result = m_impl->m_swapChain->Present(1, 0);
+			if (FAILED(result) && result != DXGI_STATUS_OCCLUDED)
+			{
+				m_impl->m_keyedMutex->ReleaseSync(releaseKey);
+				m_impl->m_lastFailure = MakeWindowsFailure(result, "IDXGISwapChain::Present");
+				return m_impl->m_lastFailure;
+			}
+		}
+
+		result = m_impl->m_keyedMutex->ReleaseSync(releaseKey);
+		if (FAILED(result))
+		{
+			m_impl->m_lastFailure = MakeWindowsFailure(result, "IDXGIKeyedMutex::ReleaseSync");
+			return m_impl->m_lastFailure;
+		}
+
+		m_impl->m_presentedFrameIndex = frame.m_frameIndex;
+		m_impl->m_lastFailure = Failure::Ok();
+		return Failure::Ok();
+	}
+
+	void SailorWindowsViewportPresenter::ResetViewport(ViewportId viewportId)
+	{
+		if (viewportId != m_impl->m_viewportId)
+		{
+			return;
+		}
+
+		m_impl->m_attachedSwapChain.Reset();
+		m_impl->m_swapChain.Reset();
+		m_impl->m_keyedMutex.Reset();
+		m_impl->m_sharedTexture.Reset();
+		m_impl->m_viewportId = 0;
+		m_impl->m_epoch = 0;
+		m_impl->m_generation = 0;
+		m_impl->m_presentedFrameIndex = 0;
+		m_impl->m_width = 0;
+		m_impl->m_height = 0;
+		m_impl->m_lastFailure = Failure::Ok();
+	}
+
+	Failure SailorWindowsViewportPresenter::GetLastFailure() const
+	{
+		return m_impl->m_lastFailure;
+	}
+
+	Failure SailorWindowsViewportPresenter::BindNativeHost(
+		void* swapChainPanelInspectable,
+		float compositionScale)
+	{
+		if (!swapChainPanelInspectable)
+		{
+			if (m_impl->m_panel)
+			{
+				const HRESULT result = m_impl->m_panel->SetSwapChain(nullptr);
+				if (FAILED(result))
+				{
+					m_impl->m_lastFailure = MakeWindowsFailure(
+						result,
+						"ISwapChainPanelNative::SetSwapChain(null)");
+					return m_impl->m_lastFailure;
+				}
+			}
+			m_impl->m_attachedSwapChain.Reset();
+			m_impl->m_panel.Reset();
+			m_impl->m_lastFailure = Failure::Ok();
+			return Failure::Ok();
+		}
+
+		ComPtr<IWinUI3SwapChainPanelNative> panel;
+		const HRESULT result = static_cast<IUnknown*>(swapChainPanelInspectable)
+			->QueryInterface(IID_PPV_ARGS(&panel));
+		if (FAILED(result))
+		{
+			m_impl->m_lastFailure = MakeWindowsFailure(
+				result,
+				"SwapChainPanel QueryInterface");
+			return m_impl->m_lastFailure;
+		}
+
+		if (m_impl->m_panel.Get() != panel.Get())
+		{
+			m_impl->m_attachedSwapChain.Reset();
+			m_impl->m_panel = std::move(panel);
+		}
+
+		m_impl->m_compositionScale =
+			std::isfinite(compositionScale) && compositionScale > 0.0f
+				? compositionScale
+				: 1.0f;
+		m_impl->m_lastFailure = m_impl->ApplyCompositionScale();
+		if (!m_impl->m_lastFailure.IsOk())
+		{
+			return m_impl->m_lastFailure;
+		}
+
+		m_impl->m_lastFailure = m_impl->AttachSwapChainOnCurrentThread();
+		return m_impl->m_lastFailure;
+	}
+
+	std::string SailorWindowsViewportPresenter::BuildSummary(ViewportId viewportId) const
+	{
+		std::ostringstream summary;
+		summary << "windowsPresenter=" << (viewportId == m_impl->m_viewportId ? 1 : 0)
+			<< " panel=" << (m_impl->m_panel ? 1 : 0)
+			<< " attached=" << (m_impl->m_attachedSwapChain ? 1 : 0)
+			<< " size=" << m_impl->m_width << "x" << m_impl->m_height
+			<< " compositionScale=" << m_impl->m_compositionScale
+			<< " presentedFrame=" << m_impl->m_presentedFrameIndex;
+		return summary.str();
+	}
+}
+
+#endif

--- a/Runtime/Submodules/EditorRemote/RemoteViewportWindowsNative.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportWindowsNative.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#if defined(_WIN32)
+
+#include "RemoteViewportWindowsTransport.h"
+
+#include <string>
+
+namespace Sailor::EditorRemote
+{
+	class SailorWindowsSharedSurfaceProvider final : public IWindowsSharedSurfaceProvider
+	{
+	public:
+		SailorWindowsSharedSurfaceProvider();
+		~SailorWindowsSharedSurfaceProvider() override;
+
+		Failure CreateOrResizeSurface(
+			const ViewportDescriptor& viewport,
+			ConnectionEpoch epoch,
+			SurfaceGeneration generation,
+			WindowsViewportSurfaceState& inOutState) override;
+		Failure BeginFrame(WindowsViewportSurfaceState& state) override;
+		Failure ExportFrame(
+			WindowsViewportSurfaceState& state,
+			FramePacket& outFrame) override;
+		Failure ReleaseSurface(const WindowsViewportSurfaceState& state) override;
+		Failure GetLastFailure() const override;
+
+		std::string BuildSummary(
+			ViewportId viewportId,
+			ConnectionEpoch epoch,
+			SurfaceGeneration generation) const;
+
+	private:
+		struct Impl;
+		TUniquePtr<Impl> m_impl;
+	};
+
+	class SailorWindowsViewportPresenter final : public IWindowsViewportPresenter
+	{
+	public:
+		SailorWindowsViewportPresenter();
+		~SailorWindowsViewportPresenter() override;
+
+		Failure ImportSurface(
+			const ViewportDescriptor& viewport,
+			const TransportDescriptor& transport,
+			ConnectionEpoch epoch,
+			SurfaceGeneration generation) override;
+		Failure PresentFrame(ViewportId viewportId, const FramePacket& frame) override;
+		void ResetViewport(ViewportId viewportId) override;
+		Failure GetLastFailure() const override;
+
+		Failure BindNativeHost(void* swapChainPanelInspectable, float compositionScale);
+		std::string BuildSummary(ViewportId viewportId) const;
+
+	private:
+		struct Impl;
+		TUniquePtr<Impl> m_impl;
+	};
+}
+
+#endif

--- a/Runtime/Submodules/EditorRemote/RemoteViewportWindowsTransport.h
+++ b/Runtime/Submodules/EditorRemote/RemoteViewportWindowsTransport.h
@@ -2,6 +2,7 @@
 #include "Containers/Containers.h"
 #include "Memory/UniquePtr.hpp"
 
+#include <algorithm>
 #include <optional>
 #include <utility>
 
@@ -304,5 +305,188 @@ namespace Sailor::EditorRemote
 		SurfaceGeneration m_importedGeneration = 0;
 		std::optional<FramePacket> m_lastAcceptedFrame{};
 		Failure m_lastFailure = Failure::Ok();
+	};
+
+	class WindowsViewportLoopbackBinding
+	{
+	public:
+		WindowsViewportLoopbackBinding(
+			ViewportDescriptor descriptor,
+			IWindowsSharedSurfaceProvider& provider,
+			IWindowsViewportPresenter& presenter,
+			ConnectionEpoch epoch = 1) :
+			m_transportBackend(provider),
+			m_host(presenter),
+			m_runtimeSession(std::move(descriptor), epoch)
+		{
+		}
+
+		RemoteViewportSession& GetRuntimeSession() { return m_runtimeSession; }
+		const RemoteViewportSession& GetRuntimeSession() const { return m_runtimeSession; }
+		WindowsViewportTransportBackend& GetTransportBackend() { return m_transportBackend; }
+		const WindowsViewportTransportBackend& GetTransportBackend() const { return m_transportBackend; }
+		WindowsViewportNativeHost& GetHost() { return m_host; }
+		const WindowsViewportNativeHost& GetHost() const { return m_host; }
+
+		Failure Create()
+		{
+			auto result = m_runtimeSession.BeginNegotiation();
+			if (!result.IsOk())
+			{
+				return result;
+			}
+
+			m_visible = true;
+			m_focused = false;
+			m_created = true;
+			return EnsureTransportImported();
+		}
+
+		Failure Resize(uint32_t width, uint32_t height)
+		{
+			const auto previousEpoch = m_runtimeSession.GetConnectionEpoch();
+			const auto previousGeneration = m_runtimeSession.GetGeneration();
+			auto descriptor = m_runtimeSession.GetDescriptor();
+			descriptor.m_width = std::max(width, 1u);
+			descriptor.m_height = std::max(height, 1u);
+			auto result = m_runtimeSession.HandleResize(descriptor);
+			if (!result.IsOk())
+			{
+				return result;
+			}
+
+			result = EnsureTransportImported();
+			if (!result.IsOk())
+			{
+				return result;
+			}
+
+			return m_transportBackend.ReleaseSurface(
+				m_runtimeSession.GetViewportId(),
+				previousEpoch,
+				previousGeneration);
+		}
+
+		Failure SetVisible(bool visible)
+		{
+			m_visible = visible;
+			return m_runtimeSession.SetVisible(visible);
+		}
+
+		Failure SetFocused(bool focused)
+		{
+			m_focused = focused;
+			InputPacket input{};
+			input.m_viewportId = m_runtimeSession.GetViewportId();
+			input.m_connectionEpoch = m_runtimeSession.GetConnectionEpoch();
+			input.m_generation = m_runtimeSession.GetGeneration();
+			input.m_kind = InputKind::Focus;
+			input.m_focused = focused;
+			input.m_timestampNs = ++m_inputTimestampNs;
+			return m_runtimeSession.HandleInput(input);
+		}
+
+		Failure PumpFrame()
+		{
+			if (!m_created)
+			{
+				return Failure::FromDomain(
+					ErrorDomain::Session,
+					1,
+					"Windows loopback binding must be created before pumping frames");
+			}
+			if (m_runtimeSession.GetState() != SessionState::Active)
+			{
+				return Failure::Ok();
+			}
+
+			auto result = m_runtimeSession.PublishFrameFromBackend(m_transportBackend);
+			if (!result.IsOk())
+			{
+				return result;
+			}
+
+			result = m_host.AcceptFrame(m_runtimeSession.GetLastFrame());
+			if (!result.IsOk())
+			{
+				return result;
+			}
+
+			return m_host.PresentLatestFrame(
+				m_runtimeSession.GetDescriptor().m_viewportId);
+		}
+
+		Failure Destroy()
+		{
+			if (!m_created)
+			{
+				return Failure::Ok();
+			}
+
+			auto release = m_runtimeSession.ReleaseBackendTransport(m_transportBackend);
+			m_host.ResetViewport(m_runtimeSession.GetDescriptor().m_viewportId);
+			auto destroy = m_runtimeSession.Destroy();
+			m_created = false;
+			return !release.IsOk() ? release : destroy;
+		}
+
+	private:
+		Failure EnsureTransportImported()
+		{
+			auto result = m_runtimeSession.EnsureBackendTransport(m_transportBackend);
+			if (!result.IsOk())
+			{
+				return result;
+			}
+
+			const auto* surface = std::as_const(m_transportBackend).FindSurface(
+				m_runtimeSession.GetViewportId(),
+				m_runtimeSession.GetConnectionEpoch(),
+				m_runtimeSession.GetGeneration());
+			if (!surface)
+			{
+				return Failure::FromDomain(
+					ErrorDomain::Transport,
+					1,
+					"Windows loopback binding could not resolve imported surface");
+			}
+
+			result = m_host.ImportTransport(
+				m_runtimeSession.GetDescriptor(),
+				surface->m_transport,
+				m_runtimeSession.GetConnectionEpoch(),
+				m_runtimeSession.GetGeneration());
+			if (!result.IsOk())
+			{
+				return result;
+			}
+
+			if (!m_visible)
+			{
+				result = m_runtimeSession.SetVisible(false);
+				if (!result.IsOk())
+				{
+					return result;
+				}
+			}
+			if (m_focused)
+			{
+				result = SetFocused(true);
+				if (!result.IsOk())
+				{
+					return result;
+				}
+			}
+
+			return Failure::Ok();
+		}
+
+		WindowsViewportTransportBackend m_transportBackend;
+		WindowsViewportNativeHost m_host;
+		RemoteViewportSession m_runtimeSession;
+		uint64_t m_inputTimestampNs = 0;
+		bool m_created = false;
+		bool m_visible = true;
+		bool m_focused = false;
 	};
 }

--- a/Runtime/Submodules/ImGuiApi.cpp
+++ b/Runtime/Submodules/ImGuiApi.cpp
@@ -31,6 +31,101 @@ void ImGuiApi::HandleWin32(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 	SAILOR_PROFILE_FUNCTION();
 	ImGui_ImplWin32_WndProcHandler(hWnd, msg, wParam, lParam);
 }
+
+static ImGuiKey SailorMapWindowsVirtualKey(uint32_t key)
+{
+	if (key >= '0' && key <= '9')
+	{
+		return static_cast<ImGuiKey>(ImGuiKey_0 + key - '0');
+	}
+
+	if (key >= 'A' && key <= 'Z')
+	{
+		return static_cast<ImGuiKey>(ImGuiKey_A + key - 'A');
+	}
+
+	if (key >= VK_F1 && key <= VK_F12)
+	{
+		return static_cast<ImGuiKey>(ImGuiKey_F1 + key - VK_F1);
+	}
+
+	switch (key)
+	{
+	case VK_TAB: return ImGuiKey_Tab;
+	case VK_LEFT: return ImGuiKey_LeftArrow;
+	case VK_RIGHT: return ImGuiKey_RightArrow;
+	case VK_UP: return ImGuiKey_UpArrow;
+	case VK_DOWN: return ImGuiKey_DownArrow;
+	case VK_PRIOR: return ImGuiKey_PageUp;
+	case VK_NEXT: return ImGuiKey_PageDown;
+	case VK_HOME: return ImGuiKey_Home;
+	case VK_END: return ImGuiKey_End;
+	case VK_INSERT: return ImGuiKey_Insert;
+	case VK_DELETE: return ImGuiKey_Delete;
+	case VK_BACK: return ImGuiKey_Backspace;
+	case VK_SPACE: return ImGuiKey_Space;
+	case VK_RETURN: return ImGuiKey_Enter;
+	case VK_ESCAPE: return ImGuiKey_Escape;
+	case VK_SHIFT:
+	case VK_LSHIFT:
+	case VK_RSHIFT:
+		return ImGuiKey_ModShift;
+	case VK_CONTROL:
+	case VK_LCONTROL:
+	case VK_RCONTROL:
+		return ImGuiKey_ModCtrl;
+	case VK_MENU:
+	case VK_LMENU:
+	case VK_RMENU:
+		return ImGuiKey_ModAlt;
+	case VK_LWIN:
+	case VK_RWIN:
+		return ImGuiKey_ModSuper;
+	default:
+		return ImGuiKey_None;
+	}
+}
+
+void ImGuiApi::HandleWindowsEditorInput(const WindowsEditorInputEvent& event)
+{
+	SAILOR_PROFILE_FUNCTION();
+
+	if (!ImGui::GetCurrentContext())
+	{
+		return;
+	}
+
+	ImGuiIO& io = ImGui::GetIO();
+	switch (event.EventType)
+	{
+	case WindowsEditorInputEvent::Type::MousePos:
+		io.AddMousePosEvent(event.X, event.Y);
+		break;
+	case WindowsEditorInputEvent::Type::MouseButton:
+		if (event.Button >= 0 && event.Button < ImGuiMouseButton_COUNT)
+		{
+			io.AddMouseButtonEvent(event.Button, event.bPressed);
+		}
+		break;
+	case WindowsEditorInputEvent::Type::MouseWheel:
+		io.AddMouseWheelEvent(event.X, event.Y);
+		break;
+	case WindowsEditorInputEvent::Type::Key:
+	{
+		const ImGuiKey imguiKey = SailorMapWindowsVirtualKey(event.Key);
+		if (imguiKey != ImGuiKey_None)
+		{
+			io.AddKeyEvent(imguiKey, event.bPressed);
+		}
+		break;
+	}
+	case WindowsEditorInputEvent::Type::Focus:
+		io.AddFocusEvent(event.bPressed);
+		break;
+	default:
+		break;
+	}
+}
 #elif defined(__APPLE__)
 static ImGuiKey SailorMapMacVirtualKey(uint32_t key)
 {
@@ -145,6 +240,20 @@ void ImGuiApi::NewFrame()
 
 #if defined(_WIN32)
 	ImGui_ImplWin32_NewFrame();
+	if (App::HasEditor())
+	{
+		auto& window = App::GetMainWindow();
+		if (window)
+		{
+			const glm::ivec2 renderArea = window->GetRenderArea();
+			if (renderArea.x > 0 && renderArea.y > 0)
+			{
+				ImGuiIO& io = ImGui::GetIO();
+				io.DisplaySize = ImVec2((float)renderArea.x, (float)renderArea.y);
+				io.DisplayFramebufferScale = ImVec2(1.0f, 1.0f);
+			}
+		}
+	}
 #elif defined(__APPLE__)
 	static auto s_prevFrameTime = std::chrono::steady_clock::now();
 	const auto now = std::chrono::steady_clock::now();

--- a/Runtime/Submodules/ImGuiApi.h
+++ b/Runtime/Submodules/ImGuiApi.h
@@ -19,6 +19,27 @@ namespace Sailor
 		void RenderFrame(RHI::RHICommandListPtr drawCmdList);
 #if defined(_WIN32)
 		void HandleWin32(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+		struct WindowsEditorInputEvent
+		{
+			enum class Type : uint8_t
+			{
+				MousePos,
+				MouseButton,
+				MouseWheel,
+				Key,
+				Focus
+			};
+
+			Type EventType = Type::MousePos;
+			float X = 0.0f;
+			float Y = 0.0f;
+			uint32_t Key = 0;
+			int32_t Button = -1;
+			bool bPressed = false;
+		};
+
+		void HandleWindowsEditorInput(const WindowsEditorInputEvent& event);
 #elif defined(__APPLE__)
 		struct MacEvent
 		{

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -381,6 +381,17 @@ namespace
 			highZShader.find("sourceEnd") != std::string::npos &&
 			highZShader.find("texelFetch") != std::string::npos,
 			"odd-sized Hi-Z mips must explicitly reduce their complete source footprint");
+
+		const std::string linearizeDepthSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/LinearizeDepthNode.cpp");
+		const size_t linearizeDepthAspect = linearizeDepthSource.find(
+			"sampledDepthAttachment = depthAspect");
+		const size_t linearizeDepthBinding = linearizeDepthSource.find(
+			"AddSamplerToShaderBindings(m_linearizeDepth, \"depthSampler\", sampledDepthAttachment",
+			linearizeDepthAspect);
+		Require(linearizeDepthAspect != std::string::npos &&
+			linearizeDepthBinding > linearizeDepthAspect,
+			"linear depth sampling must exclude the stencil aspect from combined depth-stencil targets");
 	}
 
 	void TestForwardPlusTileSynchronizationContract()
@@ -408,6 +419,14 @@ namespace
 		const std::string processBody = ExtractFunctionBody(
 			lightCullingSource,
 			"void LightCullingNode::Process(");
+		const size_t depthAspectOffset = processBody.find(
+			"sampledDepthAttachment = depthAspect");
+		const size_t depthBindingOffset = processBody.find(
+			"AddSamplerToShaderBindings(m_culledLights, \"sceneDepth\", sampledDepthAttachment",
+			depthAspectOffset);
+		Require(depthAspectOffset != std::string::npos &&
+			depthBindingOffset > depthAspectOffset,
+			"Forward+ depth sampling must exclude the stencil aspect from combined depth-stencil targets");
 		const size_t dispatchOffset = processBody.find("commands->Dispatch(");
 		const size_t barrierOffset = processBody.find(
 			"commands->MemoryBarrier(",

--- a/Tests/RemoteViewportRuntimeTests.cpp
+++ b/Tests/RemoteViewportRuntimeTests.cpp
@@ -585,16 +585,24 @@ namespace
 		using Sailor::Win32::GlobalInput;
 		using Sailor::Win32::KeyState;
 
-		GlobalInput::SetKeyState('W', KeyState::Pressed);
-		GlobalInput::SetMouseButtonState(0, KeyState::Pressed);
 		GlobalInput::SetCursorPosition(320, 240);
+		GlobalInput::SetKeyState('W', KeyState::Pressed);
+		GlobalInput::SetMouseButtonState(1, KeyState::Pressed);
+		GlobalInput::SetCursorPosition(350, 275);
+		const glm::ivec2 pressCursor = GlobalInput::GetInputState().GetButtonPressCursorPos(VK_RBUTTON);
+		Require(pressCursor == glm::ivec2(320, 240),
+			"a mouse press must retain its cursor origin while later motion accumulates");
+		Require(GlobalInput::GetInputState().GetCursorPos() - pressCursor == glm::ivec2(30, 35),
+			"the first navigation frame must preserve motion after the press without using a stale cursor origin");
 
 		GlobalInput::Reset();
 		const auto& state = GlobalInput::GetInputState();
 		Require(!state.IsKeyDown('W'), "lifecycle reset should release keyboard input");
-		Require(!state.IsButtonDown(0), "lifecycle reset should release mouse input");
+		Require(!state.IsButtonDown(VK_RBUTTON), "lifecycle reset should release mouse input");
 		const glm::ivec2 cursor = state.GetCursorPos();
 		Require(cursor.x == 0 && cursor.y == 0, "lifecycle reset should clear the stale cursor position");
+		Require(state.GetButtonPressCursorPos(VK_RBUTTON) == glm::ivec2(0),
+			"lifecycle reset should clear mouse press origins");
 	}
 
 	void TestEditorRemoteInputAndViewportEventInteropContract()
@@ -637,15 +645,36 @@ namespace
 		const size_t mainThreadGuard = enginePumpBody.find(
 			"if (!scheduler || !scheduler->IsMainThread())",
 			schedulerLookup);
-		const size_t pumpBinding = enginePumpBody.find(
-			"binding->Pump();",
+		const size_t windowsBranch = enginePumpBody.find(
+			"#if defined(_WIN32)",
 			mainThreadGuard);
+		const size_t platformElse = enginePumpBody.find(
+			"#else",
+			windowsBranch);
+		const size_t windowsReleaseGuard = enginePumpBody.find(
+			"binding->m_pumpScheduled.exchange(true)",
+			windowsBranch);
+		const size_t windowsPump = enginePumpBody.find(
+			"binding->Pump();",
+			windowsReleaseGuard);
+		const size_t windowsRenderThread = enginePumpBody.find(
+			"EThreadType::Render",
+			windowsPump);
+		const size_t nonWindowsPump = enginePumpBody.find(
+			"binding->Pump();",
+			platformElse);
 		Require(
 			schedulerLookup != std::string::npos &&
 				mainThreadGuard > schedulerLookup &&
-				pumpBinding > mainThreadGuard &&
-				CountOccurrences(enginePumpBody, "binding->Pump();") == 1,
-			"remote viewport frame acquisition must be release-guarded and pumped exactly once from the engine main thread");
+				windowsBranch > mainThreadGuard &&
+				windowsReleaseGuard > windowsBranch &&
+				windowsPump > windowsReleaseGuard &&
+				windowsPump < platformElse &&
+				windowsRenderThread > windowsPump &&
+				windowsRenderThread < platformElse &&
+				nonWindowsPump > platformElse &&
+				CountOccurrences(enginePumpBody, "binding->Pump();") == 2,
+			"remote viewport frame acquisition must be release-guarded on the Windows render thread and pumped inline on the main thread elsewhere");
 
 		const size_t upsertViewportBegin = bridgeSource.find(
 			"bool App::UpsertEditorRemoteViewport(",
@@ -663,7 +692,7 @@ namespace
 		Require(
 			upsertViewportBody.find("binding->Pump();") ==
 				std::string::npos,
-			"protocol-thread viewport upsert must defer frame acquisition to the engine main-thread pump");
+			"protocol-thread viewport upsert must defer frame acquisition to the engine-owned pump");
 
 		const size_t retryViewportBegin = bridgeSource.find(
 			"bool App::RetryEditorRemoteViewport(",
@@ -681,8 +710,8 @@ namespace
 		Require(
 			retryViewportBody.find("binding->Pump();") ==
 				std::string::npos &&
-				CountOccurrences(bridgeSource, "binding->Pump();") == 1,
-			"protocol-thread viewport retry must defer frame acquisition and the engine main-thread boundary must remain the sole binding pump owner");
+				CountOccurrences(bridgeSource, "binding->Pump();") == 2,
+			"protocol-thread viewport retry must defer frame acquisition and each platform branch must retain a single binding pump owner");
 
 		const size_t bindNativeLayerBegin = macNativeBridgeSource.find(
 			"Failure BindMacNativeLayer(");
@@ -803,12 +832,25 @@ namespace
 			inputResetBody.find("io.ClearInputMouse()") != std::string::npos &&
 			inputResetBody.find("#if defined(__APPLE__)") == std::string::npos,
 			"focus, capture, resize, and lifecycle reset must release native and ImGui input on every platform");
-		Require(bridgeSource.find("case InputKind::Capture:\n\t\t\tSyncEditorMouseButtons") != std::string::npos &&
+		const size_t captureInputCase = bridgeSource.find("case InputKind::Capture:");
+		const size_t captureModifierSync = bridgeSource.find(
+			"SyncEditorKeyboardModifiers(input, imGui)",
+			captureInputCase);
+		const size_t captureMouseSync = bridgeSource.find(
+			"SyncEditorMouseButtons(input, imGui)",
+			captureModifierSync);
+		Require(captureInputCase != std::string::npos &&
+			captureModifierSync > captureInputCase &&
+			captureMouseSync > captureModifierSync &&
 			bridgeSource.find("input.m_kind == InputKind::Capture && !input.m_captured") != std::string::npos,
 			"capture loss must release native and ImGui mouse buttons");
 		Require(bridgeSource.find("ResolveRemoteMouseButtonState(state, input)") != std::string::npos &&
 			bridgeSource.find("HasInputModifier(input.m_modifiers, InputModifier::MouseLeft)") == std::string::npos,
 			"mouse buttons must change only through explicit button input so resize cannot restart a held drag");
+		Require(bridgeSource.find("SyncEditorKeyboardModifiers(input, imGui)") != std::string::npos &&
+			bridgeSource.find("GlobalInput::SetCursorPosition(") <
+				bridgeSource.find("SyncEditorMouseButtons(input, imGui)"),
+			"pointer packets must synchronize modifier keys and the press origin before changing button state");
 
 		const size_t sendBegin = bridgeSource.find("bool App::SendEditorRemoteViewportInput(");
 		Require(sendBegin != std::string::npos, "editor runtime bridge must expose remote input interop");
@@ -867,7 +909,7 @@ namespace
 			!std::filesystem::exists(sourceRoot / "Lib/InteropExports.cpp"),
 			"the duplicated portable editor export surface must be removed");
 		Require(
-			CountOccurrences(protocolExports, "SAILOR_API ") == 5 &&
+			CountOccurrences(protocolExports, "SAILOR_API ") == 6 &&
 			protocolExports.find(
 				"SAILOR_API int32_t SailorProtocolStartLocalHost(") !=
 				std::string::npos &&
@@ -877,9 +919,12 @@ namespace
 			protocolExports.find(
 				"SAILOR_API void SailorProtocolStopLocalHost(") !=
 				std::string::npos &&
+			protocolExports.find(
+				"SAILOR_API int32_t SailorProtocolSetWindowsViewportHost(") !=
+				std::string::npos &&
 			protocolExports.find("SAILOR_API int32_t SailorProtocolInvoke(") != std::string::npos &&
 			protocolExports.find("SAILOR_API void SailorProtocolFreeBuffer(uint8_t* buffer)") != std::string::npos,
-			"the native boundary must expose local host lifecycle bootstrap plus the two compatibility protocol exports");
+			"the native boundary must expose local host lifecycle bootstrap, the Windows viewport host, and the two compatibility protocol exports");
 		Require(
 			protocolExports.find(
 				"StartEditorEngineWebSocketServer(") != std::string::npos &&
@@ -984,6 +1029,10 @@ namespace
 		Require(imGuiSource.find("case VK_MENU: return ImGuiKey_ModAlt") != std::string::npos &&
 			imGuiSource.find("case VK_LWIN: return ImGuiKey_ModSuper") != std::string::npos,
 			"Mac modifier keys must reach ImGui selection suppression");
+		Require(bridgeSource.find("ImGuiApi::WindowsEditorInputEvent") != std::string::npos &&
+			bridgeSource.find("HandleWindowsEditorInput(event)") != std::string::npos &&
+			imGuiSource.find("io.DisplaySize = ImVec2((float)renderArea.x, (float)renderArea.y)") != std::string::npos,
+			"Windows remote pointer and keyboard input must use the editor render area's ImGui coordinate space");
 		Require(macInputSource.find("SceneViewportPointerRouting.ShouldPublishHoverMove(activeMouseModifiers)") != std::string::npos &&
 			macInputSource.find("SceneViewportPointerRouting.ShouldPublishCapturedMove(") != std::string::npos &&
 			macInputSource.find("TryUsePointerMotionSource(PointerMotionSource.UIKit)") != std::string::npos &&


### PR DESCRIPTION
# Fix Windows editor viewport rendering and input integration

## Summary

Fix the Windows MAUI editor viewport so it presents the engine's Vulkan output directly, uses the correct physical viewport dimensions, and forwards mouse and keyboard input reliably. The implementation is Windows-only; the existing macOS path is unchanged.

## Linked Issue

No linked issue. This PR was prepared from the local Windows editor debugging session.

## Implementation Notes

- Add Vulkan external-memory export and a D3D11 keyed-mutex presenter hosted by a WinUI `SwapChainPanel`.
- Pump engine rendering from the editor process and suppress the legacy engine window and console while embedded.
- Use MAUI composition scale for swap-chain sizing, pointer coordinates, ImGui display size, viewport aspect, and ImGuizmo transforms.
- Route viewport focus, capture, keyboard modifiers, clicks, selection, and right-mouse camera controls into the engine input state.
- Preserve the cursor position captured at right-button press so the first camera update uses only real post-press motion.
- Make Ctrl slow the editor camera while Shift remains the speed boost.
- Use depth-only image views when sampling depth/stencil resources to satisfy Vulkan validation.
- Add Windows transport, runtime integration, input, viewport lifecycle, and GPU-culling contract coverage.

## Agent Workflow

- [x] Implementation Summary is included below.
- [ ] Tech Review is approved or requested.
- [x] QA validation was run locally.
- [ ] Ready for human review only after Tech Review approval.

## Implementation Summary

### Changes

- Implemented the Windows external device-memory bridge between Vulkan and the MAUI editor.
- Corrected viewport sizing, presentation, focus, selection, gizmos, and camera input.
- Kept all platform-specific presentation code behind Windows guards.

### Files and Modules

- `Runtime/GraphicsDriver/Vulkan`, `Runtime/RHI`: external image export and synchronization.
- `Runtime/Editor`, `Runtime/Submodules/EditorRemote`, `Runtime/Submodules/ImGuiApi.cpp`: embedded render loop, transport, and remote input.
- `Editor/Platforms/Windows`, `Editor/Scene`, `Editor/Services`: WinUI presenter hosting and lifecycle.
- `Tests`, `Editor.Tests`: focused transport, runtime, viewport, and lifecycle contracts.

### Deviations from Plan

- None. The work remained limited to the Windows editor integration plus the Vulkan depth-view validation fix required by that path.

### Known Limitations

- Full-suite failures outside this patch remain in locally modified asset sidecars and the existing concurrent-container benchmark. Those local asset changes are excluded from this PR.

## Tests

- [x] Native build completed successfully with the x64 Dev configuration.
- [x] `ctest --test-dir out/build/x64-Dev -R "RemoteViewport|EditorViewportController|GpuCulling|RuntimeNoStdContainers" --output-on-failure` (7/7 passed).
- [x] `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj -c Debug --no-restore --filter "FullyQualifiedName~EngineLifecycleTests|FullyQualifiedName~SceneViewportLifecycleTests"` (54/54 passed after rebasing onto the latest `main`).
- [x] Published and launched the Windows editor without arguments.
- [x] Manually verified viewport image, physical aspect, gizmos, selection, WASD/right-mouse camera control, Ctrl slowdown, and first-click behavior.
- [x] Verified the embedded session has no separate engine process or engine console and no Vulkan validation errors in the final log.

## Risk

- Risk level: high
- Risk notes: The change crosses Vulkan/D3D11 synchronization, native/managed interop, render-thread lifetime, DPI scaling, and input routing. Focused automated coverage and a live Windows editor run reduce the immediate risk; macOS behavior is intentionally untouched.
