### PR TITLE
Add generated model LOD support

### DIFF
--- a/Editor.Tests/ModelFingerprintTests.cs
+++ b/Editor.Tests/ModelFingerprintTests.cs
@@ -51,8 +51,40 @@ public sealed class ModelFingerprintTests
             "BindableLayout.ItemsSource=\"{Binding Animations}\"",
             template);
         Assert.DoesNotContain(
-            "<CollectionView Grid.Row=\"13\"",
+            "<CollectionView Grid.Row=\"16\"",
             template);
+    }
+
+    [Fact]
+    public void Inspector_RoundTripsModelLodGenerationSettings()
+    {
+        var viewModel = ReadRepositoryFile(
+            "Editor",
+            "ViewModels",
+            "ModelFile.cs");
+        var template = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "InspectorView",
+            "ModelFileTemplate.xaml");
+
+        foreach (var property in new[]
+        {
+            "ShouldGenerateLods",
+            "NumGeneratedLods",
+            "LodReductionFactor"
+        })
+        {
+            Assert.Contains(property, viewModel, StringComparison.Ordinal);
+            Assert.Contains($"Binding {property}", template, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("case \"bGenerateLods\"", viewModel, StringComparison.Ordinal);
+        Assert.Contains("case \"numGeneratedLods\"", viewModel, StringComparison.Ordinal);
+        Assert.Contains("case \"lodReductionFactor\"", viewModel, StringComparison.Ordinal);
+        Assert.Contains("new Scalar(null, \"bGenerateLods\")", viewModel, StringComparison.Ordinal);
+        Assert.Contains("new Scalar(null, \"numGeneratedLods\")", viewModel, StringComparison.Ordinal);
+        Assert.Contains("new Scalar(null, \"lodReductionFactor\")", viewModel, StringComparison.Ordinal);
     }
 
     static string ReadRepositoryFile(

--- a/Editor/Services/WorldService.cs
+++ b/Editor/Services/WorldService.cs
@@ -1173,6 +1173,12 @@ namespace SailorEditor.Services
                     fileId => (FileId)fileId.Value.Clone()));
             }
 
+            if (property is ObservableFloatList floatValues)
+            {
+                return new ObservableFloatList(
+                    floatValues.Values.Select(value => value.Value));
+            }
+
             if (property is ObjectPtr objectPtr)
             {
                 return new ObjectPtr

--- a/Editor/Utility/EngineTypes.cs
+++ b/Editor/Utility/EngineTypes.cs
@@ -329,6 +329,7 @@ namespace SailorEngine
                         var value when value.Contains("InstanceId") => new InstanceIdProperty(),
                         "FileId" => new FileIdProperty(),
                         "List<FileId>" => new Property<List<FileId>>(),
+                        "List<float>" => new Property<List<float>>(),
                         var value when value.StartsWith("enum") => new EnumProperty() { Typename = value },
                         var value when res.Enums.ContainsKey(value) => new EnumProperty() { Typename = value },
                         _ => throw new InvalidDataException(
@@ -461,6 +462,7 @@ namespace SailorEngine
             {
                 "FileId" => new FileIdProperty(),
                 "List<FileId>" => new Property<List<FileId>>(),
+                "List<float>" => new Property<List<float>>(),
                 var value when value.StartsWith("enum") => new EnumProperty() { Typename = value },
                 _ => throw new InvalidDataException($"Unsupported asset property type: {propertyType}")
             };

--- a/Editor/Utility/Templates.cs
+++ b/Editor/Utility/Templates.cs
@@ -430,6 +430,66 @@ static class Templates
         };
     }
 
+    public static View FloatListEditor(ObservableFloatList values)
+    {
+        var listEditor = new VerticalStackLayout
+        {
+            HorizontalOptions = LayoutOptions.Fill,
+            Spacing = InspectorFieldSpacing
+        };
+        BindableLayout.SetItemsSource(listEditor, values.Values);
+        BindableLayout.SetItemTemplate(
+            listEditor,
+            new DataTemplate(() =>
+            {
+                var row = new Grid
+                {
+                    ColumnDefinitions =
+                    {
+                        new ColumnDefinition { Width = GridLength.Auto },
+                        new ColumnDefinition { Width = GridLength.Star }
+                    },
+                    ColumnSpacing = InspectorFieldSpacing,
+                    HorizontalOptions = LayoutOptions.Fill
+                };
+
+                row.BindingContextChanged += (sender, args) =>
+                {
+                    row.Children.Clear();
+                    if (row.BindingContext is not Observable<float> value)
+                        return;
+
+                    var removeButton = new Button { Text = "-" };
+                    removeButton.Clicked += (buttonSender, clickArgs) =>
+                        values.Values.Remove(value);
+                    var editor = FloatEditor<Observable<float>>(
+                        static vm => vm.Value,
+                        static (vm, newValue) => vm.Value = newValue);
+                    editor.BindingContext = value;
+                    row.Add(removeButton, 0, 0);
+                    row.Add(editor, 1, 0);
+                };
+
+                return row;
+            }));
+
+        var addButton = new Button { Text = "+" };
+        addButton.Clicked += (sender, args) =>
+            values.Values.Add(new Observable<float>(0.0f));
+        var clearButton = new Button { Text = "Clear" };
+        clearButton.Clicked += (sender, args) => values.Values.Clear();
+
+        return new VerticalStackLayout
+        {
+            HorizontalOptions = LayoutOptions.Fill,
+            Children =
+            {
+                new HorizontalStackLayout { Children = { addButton, clearButton } },
+                listEditor
+            }
+        };
+    }
+
     public static View InstanceIdEditor<TBindingContext>(object bindingContext, string bindingPath, Expression<Func<TBindingContext, InstanceId>> getter, Action<TBindingContext, InstanceId> setter, string expectedTypename = "")
         where TBindingContext : class
     {

--- a/Editor/ViewModels/AssetFile.cs
+++ b/Editor/ViewModels/AssetFile.cs
@@ -699,6 +699,35 @@ public partial class ObservableFileIdList : ObservableObject
     }
 }
 
+public partial class ObservableFloatList : ObservableObject
+{
+    public ObservableFloatList()
+    {
+        Values.CollectionChanged += ValuesCollectionChanged;
+        Values.ItemChanged += ValuesItemChanged;
+    }
+
+    public ObservableFloatList(IEnumerable<float> values) : this()
+    {
+        foreach (var value in values)
+        {
+            Values.Add(new Observable<float>(value));
+        }
+    }
+
+    public ObservableList<Observable<float>> Values { get; } = [];
+
+    void ValuesCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(Values));
+    }
+
+    void ValuesItemChanged(object sender, ItemChangedEventArgs<Observable<float>> e)
+    {
+        OnPropertyChanged(nameof(Values));
+    }
+}
+
 public class AssetFileYamlConverter : IYamlTypeConverter
 {
     public bool Accepts(Type type) => type == typeof(AssetFile);

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -222,6 +222,10 @@ public class ComponentYamlConverter : IYamlTypeConverter
                     property.Value,
                     bufferedSerializer,
                     bufferedDeserializer),
+                Property<List<float>> => DeserializeFloatList(
+                    property.Value,
+                    bufferedSerializer,
+                    bufferedDeserializer),
                 InstanceIdProperty => new Observable<InstanceId>(scalar),
                 FloatProperty => new Observable<float>((float)EditorComponentScalarCodec.Parse(
                     EditorComponentScalarKind.Float,
@@ -306,6 +310,21 @@ public class ComponentYamlConverter : IYamlTypeConverter
                 deserializer) ?? []);
     }
 
+    static ObservableFloatList DeserializeFloatList(
+        object? value,
+        ISerializer serializer,
+        IDeserializer deserializer)
+    {
+        if (value is null)
+            return new ObservableFloatList();
+
+        return new ObservableFloatList(
+            DeserializeBuffered<List<float>>(
+                value,
+                serializer,
+                deserializer) ?? []);
+    }
+
     public void WriteYaml(IEmitter emitter, object value, Type type)
     {
         var component = (Component)value;
@@ -360,6 +379,16 @@ public class ComponentYamlConverter : IYamlTypeConverter
                             emitter,
                             assetId.Value ?? new FileId(),
                             typeof(FileId));
+                    }
+                    emitter.Emit(new SequenceEnd());
+                    break;
+                case ObservableFloatList floatValues:
+                    emitter.Emit(new SequenceStart(null, null, false, SequenceStyle.Block));
+                    foreach (var floatValue in floatValues.Values)
+                    {
+                        emitter.Emit(new Scalar(null, EditorComponentScalarCodec.Format(
+                            EditorComponentScalarKind.Float,
+                            floatValue.Value)));
                     }
                     emitter.Emit(new SequenceEnd());
                     break;

--- a/Editor/ViewModels/ModelFile.cs
+++ b/Editor/ViewModels/ModelFile.cs
@@ -29,6 +29,15 @@ public partial class ModelFile : AssetFile
     bool shouldGenerateBLAS = true;
 
     [ObservableProperty]
+    bool shouldGenerateLods = true;
+
+    [ObservableProperty]
+    uint numGeneratedLods = 2;
+
+    [ObservableProperty]
+    float lodReductionFactor = 0.5f;
+
+    [ObservableProperty]
     float unitScale;
 
     [ObservableProperty]
@@ -152,6 +161,9 @@ public partial class ModelFile : AssetFile
                 ShouldBatchByMaterial = intermediateObject.ShouldBatchByMaterial;
                 ShouldKeepCpuBuffers = intermediateObject.ShouldKeepCpuBuffers;
                 ShouldGenerateBLAS = intermediateObject.ShouldGenerateBLAS;
+                ShouldGenerateLods = intermediateObject.ShouldGenerateLods;
+                NumGeneratedLods = intermediateObject.NumGeneratedLods;
+                LodReductionFactor = intermediateObject.LodReductionFactor;
                 UnitScale = intermediateObject.UnitScale;
                 Materials = intermediateObject.Materials ?? [];
                 Animations = intermediateObject.Animations ?? [];
@@ -221,6 +233,15 @@ public class ModelFileYamlConverter : IYamlTypeConverter
                     case "bGenerateBLAS":
                         assetFile.ShouldGenerateBLAS = deserializer.Deserialize<bool>(parser);
                         break;
+                    case "bGenerateLods":
+                        assetFile.ShouldGenerateLods = deserializer.Deserialize<bool>(parser);
+                        break;
+                    case "numGeneratedLods":
+                        assetFile.NumGeneratedLods = deserializer.Deserialize<uint>(parser);
+                        break;
+                    case "lodReductionFactor":
+                        assetFile.LodReductionFactor = deserializer.Deserialize<float>(parser);
+                        break;
                     case "unitScale":
                         assetFile.UnitScale = deserializer.Deserialize<float>(parser);
                         break;
@@ -274,6 +295,15 @@ public class ModelFileYamlConverter : IYamlTypeConverter
 
         emitter.Emit(new Scalar(null, "bGenerateBLAS"));
         emitter.Emit(new Scalar(null, assetFile.ShouldGenerateBLAS.ToString().ToLower()));
+
+        emitter.Emit(new Scalar(null, "bGenerateLods"));
+        emitter.Emit(new Scalar(null, assetFile.ShouldGenerateLods.ToString().ToLower()));
+
+        emitter.Emit(new Scalar(null, "numGeneratedLods"));
+        emitter.Emit(new Scalar(null, assetFile.NumGeneratedLods.ToString(CultureInfo.InvariantCulture)));
+
+        emitter.Emit(new Scalar(null, "lodReductionFactor"));
+        emitter.Emit(new Scalar(null, assetFile.LodReductionFactor.ToString(CultureInfo.InvariantCulture)));
 
         emitter.Emit(new Scalar(null, "unitScale"));
         emitter.Emit(new Scalar(null, assetFile.UnitScale.ToString(CultureInfo.InvariantCulture)));

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -226,6 +226,7 @@ public class ComponentTemplate : DataTemplate
                                     ResolveFileIdListSupportedType(
                                         component,
                                         property.Key)),
+                                ObservableFloatList floatValues => Templates.FloatListEditor(floatValues),
                                 Observable<InstanceId> observableInstanceId => Templates.InstanceIdEditor(component.OverrideProperties[property.Key], nameof(Observable<InstanceId>.Value), (Observable<InstanceId> vm) => vm.Value, (vm, value) => vm.Value = value),
                                 _ => new Label { Text = "Unsupported property type" }
                             };

--- a/Editor/Views/InspectorView/ModelFileTemplate.xaml
+++ b/Editor/Views/InspectorView/ModelFileTemplate.xaml
@@ -34,6 +34,9 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <views:ControlPanelView Grid.Row="0" Grid.ColumnSpan="2" />
@@ -94,17 +97,26 @@
         <Label Text="Generate BLAS" VerticalOptions="Center" Grid.Row="6" Grid.Column="0"/>
         <CheckBox IsChecked="{Binding ShouldGenerateBLAS}" Grid.Row="6" Grid.Column="1"/>
 
-        <Label Text="Unit Scale" VerticalOptions="Center" Grid.Row="7" Grid.Column="0"/>
-        <Entry Text="{Binding UnitScale, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" Grid.Row="7" Grid.Column="1" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric"/>
+        <Label Text="Generate LODs" VerticalOptions="Center" Grid.Row="7" Grid.Column="0"/>
+        <CheckBox IsChecked="{Binding ShouldGenerateLods}" Grid.Row="7" Grid.Column="1"/>
 
-        <Label Text="Default Materials" FontAttributes="Bold" Grid.Row="8" Grid.ColumnSpan="2" />
+        <Label Text="Generated LOD Count" VerticalOptions="Center" Grid.Row="8" Grid.Column="0"/>
+        <Entry Text="{Binding NumGeneratedLods}" VerticalOptions="Center" Grid.Row="8" Grid.Column="1" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric"/>
 
-        <HorizontalStackLayout Grid.Row="9" Grid.ColumnSpan="2">
+        <Label Text="LOD Reduction Factor" VerticalOptions="Center" Grid.Row="9" Grid.Column="0"/>
+        <Entry Text="{Binding LodReductionFactor, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" Grid.Row="9" Grid.Column="1" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric"/>
+
+        <Label Text="Unit Scale" VerticalOptions="Center" Grid.Row="10" Grid.Column="0"/>
+        <Entry Text="{Binding UnitScale, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" Grid.Row="10" Grid.Column="1" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric"/>
+
+        <Label Text="Default Materials" FontAttributes="Bold" Grid.Row="11" Grid.ColumnSpan="2" />
+
+        <HorizontalStackLayout Grid.Row="12" Grid.ColumnSpan="2">
             <Button Text="+" Command="{Binding AddMaterialCommand, Source={RelativeSource AncestorType={x:Type vm:ModelFile}}}"  />
             <Button Text="Clear" Width ="40" Command="{Binding ClearMaterialsCommand, Source={RelativeSource AncestorType={x:Type vm:ModelFile}}}"/>
         </HorizontalStackLayout>
 
-        <CollectionView Grid.Row="10" Grid.ColumnSpan="2" ItemsSource="{Binding Materials}">
+        <CollectionView Grid.Row="13" Grid.ColumnSpan="2" ItemsSource="{Binding Materials}">
             <CollectionView.ItemTemplate>
                 <DataTemplate>
                     <HorizontalStackLayout>
@@ -121,14 +133,14 @@
             </CollectionView.ItemTemplate>
         </CollectionView>
 
-        <Label Text="Animations" FontAttributes="Bold" Grid.Row="11" Grid.ColumnSpan="2" />
+        <Label Text="Animations" FontAttributes="Bold" Grid.Row="14" Grid.ColumnSpan="2" />
 
-        <HorizontalStackLayout Grid.Row="12" Grid.ColumnSpan="2">
+        <HorizontalStackLayout Grid.Row="15" Grid.ColumnSpan="2">
             <Button Text="+" Command="{Binding AddAnimationCommand, Source={RelativeSource AncestorType={x:Type vm:ModelFile}}}"  />
             <Button Text="Clear" Width ="40" Command="{Binding ClearAnimationsCommand, Source={RelativeSource AncestorType={x:Type vm:ModelFile}}}"/>
         </HorizontalStackLayout>
 
-        <VerticalStackLayout Grid.Row="13"
+        <VerticalStackLayout Grid.Row="16"
                              Grid.ColumnSpan="2"
                              BindableLayout.ItemsSource="{Binding Animations}">
             <BindableLayout.ItemTemplate>

--- a/Runtime/AssetRegistry/Model/ModelAssetInfo.h
+++ b/Runtime/AssetRegistry/Model/ModelAssetInfo.h
@@ -23,6 +23,9 @@ namespace Sailor
 		SAILOR_API bool ShouldBatchByMaterial() const { return m_bShouldBatchByMaterial; }
 		SAILOR_API bool ShouldKeepCpuBuffers() const { return m_bShouldKeepCpuBuffers; }
 		SAILOR_API bool ShouldGenerateBLAS() const { return m_bGenerateBLAS; }
+		SAILOR_API bool ShouldGenerateLods() const { return m_bGenerateLods; }
+		SAILOR_API uint32_t GetNumGeneratedLods() const { return m_numGeneratedLods; }
+		SAILOR_API float GetLodReductionFactor() const { return m_lodReductionFactor; }
 
 		SAILOR_API const TVector<FileId>& GetDefaultMaterials() const { return m_materials; }
 		SAILOR_API TVector<FileId>& GetDefaultMaterials() { return m_materials; }
@@ -42,6 +45,9 @@ namespace Sailor
 		bool m_bShouldBatchByMaterial = true;
 		bool m_bShouldKeepCpuBuffers = false;
 		bool m_bGenerateBLAS = true;
+		bool m_bGenerateLods = true;
+		uint32_t m_numGeneratedLods = 2u;
+		float m_lodReductionFactor = 0.5f;
 	};
 
 	using ModelAssetInfoPtr = ModelAssetInfo*;
@@ -70,6 +76,9 @@ REFL_AUTO(
 	field(m_bShouldBatchByMaterial),
 	field(m_bShouldKeepCpuBuffers),
 	field(m_bGenerateBLAS),
+	field(m_bGenerateLods),
+	field(m_numGeneratedLods),
+	field(m_lodReductionFactor),
 	field(m_unitScale),
 	field(m_materials),
 	field(m_animations)

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -61,7 +61,7 @@ namespace
 		4ull * 1024ull * 1024ull;
 	constexpr int32_t MaxFingerprintTextureDimension = 256;
 	constexpr int32_t FingerprintImageDimension = 256;
-	constexpr uint32_t ModelLodCacheVersion = 1u;
+	constexpr uint32_t ModelLodCacheVersion = 2u;
 	constexpr uint32_t MaxGeneratedModelLods = 8u;
 	constexpr uint64_t MaxModelLodCacheBytes = 1024ull * 1024ull * 1024ull;
 	constexpr std::array<char, 8> ModelLodCacheMagic = {
@@ -351,6 +351,132 @@ namespace
 		}
 	}
 
+	bool TryNormalizeLodDirection(
+		const glm::vec3& value,
+		glm::vec3& outDirection)
+	{
+		outDirection = glm::vec3(0.0f);
+		if (!Math::AllFinite(value))
+		{
+			return false;
+		}
+
+		const float lengthSquared = glm::dot(value, value);
+		if (!std::isfinite(lengthSquared) || lengthSquared <= 1e-12f)
+		{
+			return false;
+		}
+
+		outDirection = value / std::sqrt(lengthSquared);
+		return Math::AllFinite(outDirection);
+	}
+
+	void RecalculateLodShadingBasis(
+		ModelImporter::MeshContext::LodGeometry& geometry)
+	{
+		const size_t vertexCount = geometry.m_vertices.Num();
+		if (vertexCount == 0u || geometry.m_indices.Num() < 3u)
+		{
+			return;
+		}
+
+		TVector<glm::vec3> normals(vertexCount, glm::vec3(0.0f));
+		TVector<glm::vec3> tangents(vertexCount, glm::vec3(0.0f));
+		TVector<glm::vec3> bitangents(vertexCount, glm::vec3(0.0f));
+		for (size_t index = 0u;
+			index + 2u < geometry.m_indices.Num();
+			index += 3u)
+		{
+			const uint32_t i0 = geometry.m_indices[index];
+			const uint32_t i1 = geometry.m_indices[index + 1u];
+			const uint32_t i2 = geometry.m_indices[index + 2u];
+			if (i0 >= vertexCount || i1 >= vertexCount || i2 >= vertexCount)
+			{
+				continue;
+			}
+
+			const auto& v0 = geometry.m_vertices[i0];
+			const auto& v1 = geometry.m_vertices[i1];
+			const auto& v2 = geometry.m_vertices[i2];
+			const glm::vec3 edge1 = v1.m_position - v0.m_position;
+			const glm::vec3 edge2 = v2.m_position - v0.m_position;
+			const glm::vec3 faceNormal = glm::cross(edge1, edge2);
+			if (Math::AllFinite(faceNormal))
+			{
+				normals[i0] += faceNormal;
+				normals[i1] += faceNormal;
+				normals[i2] += faceNormal;
+			}
+
+			const glm::vec2 uv1 = v1.m_texcoord - v0.m_texcoord;
+			const glm::vec2 uv2 = v2.m_texcoord - v0.m_texcoord;
+			const float determinant = uv1.x * uv2.y - uv1.y * uv2.x;
+			if (!std::isfinite(determinant) || std::abs(determinant) <= 1e-8f)
+			{
+				continue;
+			}
+
+			const float reciprocal = 1.0f / determinant;
+			const glm::vec3 tangent =
+				(edge1 * uv2.y - edge2 * uv1.y) * reciprocal;
+			const glm::vec3 bitangent =
+				(edge2 * uv1.x - edge1 * uv2.x) * reciprocal;
+			if (Math::AllFinite(tangent) && Math::AllFinite(bitangent))
+			{
+				tangents[i0] += tangent;
+				tangents[i1] += tangent;
+				tangents[i2] += tangent;
+				bitangents[i0] += bitangent;
+				bitangents[i1] += bitangent;
+				bitangents[i2] += bitangent;
+			}
+		}
+
+		for (size_t vertexIndex = 0u;
+			vertexIndex < vertexCount;
+			++vertexIndex)
+		{
+			auto& vertex = geometry.m_vertices[vertexIndex];
+			glm::vec3 normal;
+			if (!TryNormalizeLodDirection(normals[vertexIndex], normal) &&
+				!TryNormalizeLodDirection(vertex.m_normal, normal))
+			{
+				normal = glm::vec3(0.0f, 1.0f, 0.0f);
+			}
+
+			glm::vec3 tangentInput = tangents[vertexIndex];
+			glm::vec3 tangent;
+			if (!TryNormalizeLodDirection(
+					tangentInput - normal * glm::dot(tangentInput, normal),
+					tangent))
+			{
+				tangentInput = vertex.m_tangent;
+			}
+			if (!TryNormalizeLodDirection(
+					tangentInput - normal * glm::dot(tangentInput, normal),
+					tangent))
+			{
+				const glm::vec3 axis = std::abs(normal.y) < 0.999f ?
+					glm::vec3(0.0f, 1.0f, 0.0f) :
+					glm::vec3(1.0f, 0.0f, 0.0f);
+				TryNormalizeLodDirection(glm::cross(axis, normal), tangent);
+			}
+
+			glm::vec3 bitangent;
+			TryNormalizeLodDirection(glm::cross(normal, tangent), bitangent);
+			const glm::vec3 bitangentReference =
+				glm::dot(bitangents[vertexIndex], bitangents[vertexIndex]) > 1e-12f ?
+					bitangents[vertexIndex] : vertex.m_bitangent;
+			const float handedness =
+				Math::AllFinite(bitangentReference) &&
+				glm::dot(bitangent, bitangentReference) < 0.0f ? -1.0f : 1.0f;
+
+			vertex.m_normal = normal;
+			vertex.m_tangent = tangent;
+			vertex.m_bitangent = bitangent * handedness;
+		}
+	}
+
 	ModelImporter::MeshContext::LodGeometry GenerateModelLod(
 		const ModelImporter::MeshContext& mesh,
 		float targetRatio)
@@ -398,6 +524,7 @@ namespace
 				mesh.outVertices.Num(),
 				sizeof(RHI::VertexP3N3T3B3UV2C4I4W4));
 			result.m_vertices.Resize(compactedVertexCount);
+			RecalculateLodShadingBasis(result);
 		}
 #endif
 

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -10,6 +10,7 @@
 #include <mutex>
 #include <sstream>
 #include <string>
+#include <type_traits>
 
 #include <nlohmann/json.hpp>
 
@@ -60,6 +61,406 @@ namespace
 		4ull * 1024ull * 1024ull;
 	constexpr int32_t MaxFingerprintTextureDimension = 256;
 	constexpr int32_t FingerprintImageDimension = 256;
+	constexpr uint32_t ModelLodCacheVersion = 1u;
+	constexpr uint32_t MaxGeneratedModelLods = 8u;
+	constexpr uint64_t MaxModelLodCacheBytes = 1024ull * 1024ull * 1024ull;
+	constexpr std::array<char, 8> ModelLodCacheMagic = {
+		'S', 'A', 'I', 'L', 'L', 'O', 'D', '\0'
+	};
+
+	struct ModelLodCacheHeader
+	{
+		std::array<char, 8> m_magic{};
+		uint32_t m_version = ModelLodCacheVersion;
+		uint32_t m_vertexStride = 0u;
+		uint32_t m_meshCount = 0u;
+		uint32_t m_lodLevel = 0u;
+		int64_t m_sourceModificationTime = 0;
+		uint64_t m_sourceSize = 0u;
+		uint64_t m_sourceContentHash = 0u;
+		float m_unitScale = 1.0f;
+		float m_reductionFactor = 0.5f;
+		uint32_t m_bBatchByMaterial = 0u;
+	};
+
+	struct ModelLodCacheMeshHeader
+	{
+		uint64_t m_vertexCount = 0u;
+		uint64_t m_indexCount = 0u;
+	};
+
+	std::filesystem::path GetModelLodCachePath(
+		const FileId& fileId,
+		uint32_t lodLevel)
+	{
+		const std::filesystem::path filename =
+			ModelImporter::GetLodCacheFilename(fileId, lodLevel);
+		if (filename.empty())
+		{
+			return {};
+		}
+
+		return std::filesystem::path(AssetRegistry::GetCacheFolder()) /
+			"Lods" /
+			filename;
+	}
+
+	template<typename T>
+	void AppendModelLodCacheBytes(std::string& output, const T& value)
+	{
+		static_assert(std::is_trivially_copyable_v<T>);
+		output.append(
+			reinterpret_cast<const char*>(&value),
+			sizeof(T));
+	}
+
+	void AppendModelLodCacheRange(
+		std::string& output,
+		const void* data,
+		size_t size)
+	{
+		if (data != nullptr && size > 0u)
+		{
+			output.append(static_cast<const char*>(data), size);
+		}
+	}
+
+	template<typename T>
+	bool ReadModelLodCacheValue(
+		const std::string& input,
+		size_t& offset,
+		T& value)
+	{
+		static_assert(std::is_trivially_copyable_v<T>);
+		if (offset > input.size() || sizeof(T) > input.size() - offset)
+		{
+			return false;
+		}
+
+		std::memcpy(&value, input.data() + offset, sizeof(T));
+		offset += sizeof(T);
+		return true;
+	}
+
+	bool ReadModelLodCacheRange(
+		const std::string& input,
+		size_t& offset,
+		void* data,
+		size_t size)
+	{
+		if (offset > input.size() || size > input.size() - offset ||
+			(data == nullptr && size > 0u))
+		{
+			return false;
+		}
+
+		if (size > 0u)
+		{
+			std::memcpy(data, input.data() + offset, size);
+		}
+		offset += size;
+		return true;
+	}
+
+	bool IsModelLodCacheHeaderCurrent(
+		const ModelLodCacheHeader& header,
+		const ModelAssetInfo& assetInfo,
+		const FileRevision& sourceRevision,
+		uint32_t lodLevel,
+		size_t meshCount)
+	{
+		return header.m_magic == ModelLodCacheMagic &&
+			header.m_version == ModelLodCacheVersion &&
+			header.m_vertexStride == sizeof(RHI::VertexP3N3T3B3UV2C4I4W4) &&
+			header.m_meshCount == meshCount &&
+			header.m_lodLevel == lodLevel &&
+			header.m_sourceModificationTime == sourceRevision.m_modificationTimeNanoseconds &&
+			header.m_sourceSize == sourceRevision.m_fileSize &&
+			header.m_sourceContentHash == sourceRevision.m_contentHash &&
+			header.m_unitScale == assetInfo.GetUnitScale() &&
+			header.m_reductionFactor == assetInfo.GetLodReductionFactor() &&
+			header.m_bBatchByMaterial == static_cast<uint32_t>(assetInfo.ShouldBatchByMaterial());
+	}
+
+	bool LoadModelLodCache(
+		const ModelAssetInfo& assetInfo,
+		const FileRevision& sourceRevision,
+		uint32_t lodLevel,
+		TVector<ModelImporter::MeshContext>& meshes)
+	{
+		const std::filesystem::path path = GetModelLodCachePath(
+			assetInfo.GetFileId(),
+			lodLevel);
+		std::error_code error;
+		const uint64_t fileSize = path.empty() ? 0u :
+			std::filesystem::file_size(path, error);
+		if (error || fileSize < sizeof(ModelLodCacheHeader) ||
+			fileSize > MaxModelLodCacheBytes)
+		{
+			return false;
+		}
+
+		std::ifstream input(path, std::ios::binary);
+		std::string bytes{
+			std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>() };
+		if (input.bad() || bytes.size() != fileSize)
+		{
+			return false;
+		}
+
+		size_t offset = 0u;
+		ModelLodCacheHeader header{};
+		if (!ReadModelLodCacheValue(bytes, offset, header) ||
+			!IsModelLodCacheHeaderCurrent(
+				header,
+				assetInfo,
+				sourceRevision,
+				lodLevel,
+				meshes.Num()))
+		{
+			return false;
+		}
+
+		TVector<ModelImporter::MeshContext::LodGeometry> loaded;
+		loaded.Resize(meshes.Num());
+		for (size_t meshIndex = 0; meshIndex < meshes.Num(); ++meshIndex)
+		{
+			ModelLodCacheMeshHeader meshHeader{};
+			if (!ReadModelLodCacheValue(bytes, offset, meshHeader) ||
+				meshHeader.m_vertexCount > std::numeric_limits<uint32_t>::max() ||
+				meshHeader.m_indexCount > std::numeric_limits<uint32_t>::max())
+			{
+				return false;
+			}
+
+			const uint64_t vertexBytes = meshHeader.m_vertexCount *
+				sizeof(RHI::VertexP3N3T3B3UV2C4I4W4);
+			const uint64_t indexBytes = meshHeader.m_indexCount * sizeof(uint32_t);
+			if (vertexBytes > MaxModelLodCacheBytes ||
+				indexBytes > MaxModelLodCacheBytes ||
+				vertexBytes + indexBytes > MaxModelLodCacheBytes)
+			{
+				return false;
+			}
+
+			auto& lod = loaded[meshIndex];
+			lod.m_vertices.Resize(static_cast<size_t>(meshHeader.m_vertexCount));
+			lod.m_indices.Resize(static_cast<size_t>(meshHeader.m_indexCount));
+			if (!ReadModelLodCacheRange(
+					bytes,
+					offset,
+					lod.m_vertices.GetData(),
+					static_cast<size_t>(vertexBytes)) ||
+				!ReadModelLodCacheRange(
+					bytes,
+					offset,
+					lod.m_indices.GetData(),
+					static_cast<size_t>(indexBytes)))
+			{
+				return false;
+			}
+
+			for (uint32_t index : lod.m_indices)
+			{
+				if (index >= lod.m_vertices.Num())
+				{
+					return false;
+				}
+			}
+		}
+
+		if (offset != bytes.size())
+		{
+			return false;
+		}
+
+		const size_t lodIndex = static_cast<size_t>(lodLevel - 1u);
+		for (size_t meshIndex = 0; meshIndex < meshes.Num(); ++meshIndex)
+		{
+			meshes[meshIndex].lods.Resize((std::max)(
+				meshes[meshIndex].lods.Num(),
+				lodIndex + 1u));
+			meshes[meshIndex].lods[lodIndex] = std::move(loaded[meshIndex]);
+		}
+		return true;
+	}
+
+	void SaveModelLodCache(
+		const ModelAssetInfo& assetInfo,
+		const FileRevision& sourceRevision,
+		uint32_t lodLevel,
+		const TVector<ModelImporter::MeshContext>& meshes)
+	{
+		ModelLodCacheHeader header{};
+		header.m_magic = ModelLodCacheMagic;
+		header.m_vertexStride = sizeof(RHI::VertexP3N3T3B3UV2C4I4W4);
+		header.m_meshCount = static_cast<uint32_t>(meshes.Num());
+		header.m_lodLevel = lodLevel;
+		header.m_sourceModificationTime = sourceRevision.m_modificationTimeNanoseconds;
+		header.m_sourceSize = sourceRevision.m_fileSize;
+		header.m_sourceContentHash = sourceRevision.m_contentHash;
+		header.m_unitScale = assetInfo.GetUnitScale();
+		header.m_reductionFactor = assetInfo.GetLodReductionFactor();
+		header.m_bBatchByMaterial = static_cast<uint32_t>(assetInfo.ShouldBatchByMaterial());
+
+		std::string bytes;
+		AppendModelLodCacheBytes(bytes, header);
+		const size_t lodIndex = static_cast<size_t>(lodLevel - 1u);
+		for (const auto& mesh : meshes)
+		{
+			const auto* lod = lodIndex < mesh.lods.Num() ?
+				&mesh.lods[lodIndex] : nullptr;
+			ModelLodCacheMeshHeader meshHeader{};
+			meshHeader.m_vertexCount = lod ? lod->m_vertices.Num() : 0u;
+			meshHeader.m_indexCount = lod ? lod->m_indices.Num() : 0u;
+			AppendModelLodCacheBytes(bytes, meshHeader);
+			if (lod)
+			{
+				AppendModelLodCacheRange(
+					bytes,
+					lod->m_vertices.GetData(),
+					lod->m_vertices.Num() * sizeof(RHI::VertexP3N3T3B3UV2C4I4W4));
+				AppendModelLodCacheRange(
+					bytes,
+					lod->m_indices.GetData(),
+					lod->m_indices.Num() * sizeof(uint32_t));
+			}
+		}
+
+		if (bytes.size() > MaxModelLodCacheBytes)
+		{
+			return;
+		}
+
+		std::string diagnostic;
+		const std::filesystem::path path = GetModelLodCachePath(
+			assetInfo.GetFileId(),
+			lodLevel);
+		if (!path.empty() &&
+			!Workspace::AtomicReplaceWorkspaceCacheBinary(
+				path,
+				bytes.data(),
+				bytes.size(),
+				diagnostic))
+		{
+			SAILOR_LOG(
+				"Cannot save model LOD cache %s: %s",
+				path.string().c_str(),
+				diagnostic.c_str());
+		}
+	}
+
+	ModelImporter::MeshContext::LodGeometry GenerateModelLod(
+		const ModelImporter::MeshContext& mesh,
+		float targetRatio)
+	{
+		ModelImporter::MeshContext::LodGeometry result{};
+		if (!mesh.HasGeometry())
+		{
+			return result;
+		}
+
+		const size_t triangleIndexCount = mesh.outIndices.Num() -
+			(mesh.outIndices.Num() % 3u);
+		const size_t targetIndexCount = (std::max)(
+			size_t{ 3u },
+			(static_cast<size_t>(triangleIndexCount * targetRatio) / 3u) * 3u);
+
+#if defined(SAILOR_HAS_MESHOPT)
+		result.m_indices.Resize(triangleIndexCount);
+		float simplificationError = 0.0f;
+		const size_t simplifiedIndexCount = meshopt_simplify(
+			result.m_indices.GetData(),
+			mesh.outIndices.GetData(),
+			triangleIndexCount,
+			&mesh.outVertices[0].m_position.x,
+			mesh.outVertices.Num(),
+			sizeof(RHI::VertexP3N3T3B3UV2C4I4W4),
+			(std::min)(targetIndexCount, triangleIndexCount),
+			0.01f,
+			meshopt_SimplifyLockBorder,
+			&simplificationError);
+		result.m_indices.Resize(simplifiedIndexCount);
+		if (simplifiedIndexCount >= 3u)
+		{
+			meshopt_optimizeVertexCache(
+				result.m_indices.GetData(),
+				result.m_indices.GetData(),
+				result.m_indices.Num(),
+				mesh.outVertices.Num());
+			result.m_vertices.Resize(mesh.outVertices.Num());
+			const size_t compactedVertexCount = meshopt_optimizeVertexFetch(
+				result.m_vertices.GetData(),
+				result.m_indices.GetData(),
+				result.m_indices.Num(),
+				mesh.outVertices.GetData(),
+				mesh.outVertices.Num(),
+				sizeof(RHI::VertexP3N3T3B3UV2C4I4W4));
+			result.m_vertices.Resize(compactedVertexCount);
+		}
+#endif
+
+		if (result.m_vertices.IsEmpty() || result.m_indices.Num() < 3u)
+		{
+			result.m_vertices = mesh.outVertices;
+			result.m_indices = mesh.outIndices;
+		}
+		return result;
+	}
+
+	void PrepareModelLods(
+		const ModelAssetInfo& assetInfo,
+		TVector<ModelImporter::MeshContext>& meshes)
+	{
+		if (!assetInfo.ShouldGenerateLods() || meshes.IsEmpty())
+		{
+			return;
+		}
+
+		const uint32_t numLods = (std::min)(
+			assetInfo.GetNumGeneratedLods(),
+			MaxGeneratedModelLods);
+		const float reductionFactor = (std::clamp)(
+			assetInfo.GetLodReductionFactor(),
+			0.05f,
+			0.95f);
+		FileRevision sourceRevision{};
+		if (numLods == 0u ||
+			!Utils::TryGetFileRevision(
+				assetInfo.GetAssetFilepath(),
+				sourceRevision))
+		{
+			return;
+		}
+
+		for (uint32_t lodLevel = 1u; lodLevel <= numLods; ++lodLevel)
+		{
+			if (LoadModelLodCache(
+					assetInfo,
+					sourceRevision,
+					lodLevel,
+					meshes))
+			{
+				continue;
+			}
+
+			const size_t lodIndex = static_cast<size_t>(lodLevel - 1u);
+			const float targetRatio = std::pow(
+				reductionFactor,
+				static_cast<float>(lodLevel));
+			for (auto& mesh : meshes)
+			{
+				mesh.lods.Resize((std::max)(mesh.lods.Num(), lodIndex + 1u));
+				mesh.lods[lodIndex] = GenerateModelLod(mesh, targetRatio);
+			}
+			SaveModelLodCache(
+				assetInfo,
+				sourceRevision,
+				lodLevel,
+				meshes);
+		}
+	}
 
 	bool IsFiniteGltfMatrix(const glm::mat4& matrix)
 	{
@@ -3103,6 +3504,48 @@ ModelImporter::~ModelImporter()
 	}
 }
 
+std::string ModelImporter::GetLodCacheFilename(
+	const FileId& fileId,
+	uint32_t lodLevel)
+{
+	if (!fileId || lodLevel == 0u)
+	{
+		return {};
+	}
+
+	const std::filesystem::path filename = fileId.ToString() +
+		"_lod" + std::to_string(lodLevel) + ".bin";
+	return filename == filename.filename() ? filename.string() : std::string{};
+}
+
+void ModelImporter::GenerateLods(
+	TVector<MeshContext>& meshes,
+	uint32_t numLods,
+	float reductionFactor)
+{
+	const uint32_t clampedNumLods = (std::min)(
+		numLods,
+		MaxGeneratedModelLods);
+	const float clampedReductionFactor = (std::clamp)(
+		reductionFactor,
+		0.05f,
+		0.95f);
+	for (auto& mesh : meshes)
+	{
+		mesh.lods.Clear();
+		mesh.lods.Reserve(clampedNumLods);
+		for (uint32_t lodLevel = 1u;
+			lodLevel <= clampedNumLods;
+			++lodLevel)
+		{
+			const float targetRatio = std::pow(
+				clampedReductionFactor,
+				static_cast<float>(lodLevel));
+			mesh.lods.Add(GenerateModelLod(mesh, targetRatio));
+		}
+	}
+}
+
 void ModelImporter::OnUpdateAssetInfo(AssetInfoPtr assetInfo, bool bWasExpired)
 {
 	SAILOR_PROFILE_FUNCTION();
@@ -5098,6 +5541,10 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 					&pData->m_gltfModel);
 				if (pData->m_bIsImported)
 				{
+					PrepareModelLods(*pAssetInfo, pData->m_parsedMeshes);
+				}
+				if (pData->m_bIsImported)
+				{
 					pData->m_bIsImported =
 						GltfImporterUtils::CollectSceneNodes(
 							pData->m_gltfModel,
@@ -5182,9 +5629,46 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 									mesh.materialSlot :
 									static_cast<uint32_t>(meshIndex);
 							pMesh->m_bakedVolumeScale = mesh.bakedVolumeScale;
+							TVector<RHI::VertexP3N3T3B3UV2C4I4W4> uploadVertices = mesh.outVertices;
+							TVector<uint32_t> uploadIndices = mesh.outIndices;
+							TVector<uint32_t> lodVertexOffsets;
+							TVector<uint32_t> lodFirstIndices;
+							lodVertexOffsets.Reserve(mesh.lods.Num());
+							lodFirstIndices.Reserve(mesh.lods.Num());
+							for (const auto& lod : mesh.lods)
+							{
+								lodVertexOffsets.Add(static_cast<uint32_t>(uploadVertices.Num()));
+								lodFirstIndices.Add(static_cast<uint32_t>(uploadIndices.Num()));
+								uploadVertices.AddRange(lod.m_vertices);
+								uploadIndices.AddRange(lod.m_indices);
+							}
+							pMesh->m_indexCount = static_cast<uint32_t>(mesh.outIndices.Num());
+							pMesh->m_firstIndex = 0u;
+							pMesh->m_vertexOffset = 0u;
 							RHI::Renderer::GetDriver()->UpdateMesh(pMesh,
-								mesh.outVertices.GetData(), sizeof(RHI::VertexP3N3T3B3UV2C4I4W4) * mesh.outVertices.Num(),
-								mesh.outIndices.GetData(), sizeof(uint32_t) * mesh.outIndices.Num());
+								uploadVertices.GetData(), sizeof(RHI::VertexP3N3T3B3UV2C4I4W4) * uploadVertices.Num(),
+								uploadIndices.GetData(), sizeof(uint32_t) * uploadIndices.Num());
+							pMesh->m_lods.Reserve(mesh.lods.Num());
+							for (size_t lodIndex = 0; lodIndex < mesh.lods.Num(); ++lodIndex)
+							{
+								const auto& lodGeometry = mesh.lods[lodIndex];
+								if (lodGeometry.m_vertices.IsEmpty() || lodGeometry.m_indices.IsEmpty())
+								{
+									continue;
+								}
+
+								RHI::RHIMeshPtr lodMesh = RHI::Renderer::GetDriver()->CreateMesh();
+								lodMesh->m_vertexDescription = pMesh->m_vertexDescription;
+								lodMesh->m_vertexBuffer = pMesh->m_vertexBuffer;
+								lodMesh->m_indexBuffer = pMesh->m_indexBuffer;
+								lodMesh->m_bounds = pMesh->m_bounds;
+								lodMesh->m_materialIndex = pMesh->m_materialIndex;
+								lodMesh->m_bakedVolumeScale = pMesh->m_bakedVolumeScale;
+								lodMesh->m_indexCount = static_cast<uint32_t>(lodGeometry.m_indices.Num());
+								lodMesh->m_firstIndex = lodFirstIndices[lodIndex];
+								lodMesh->m_vertexOffset = lodVertexOffsets[lodIndex];
+								pMesh->m_lods.Add(std::move(lodMesh));
+							}
 
 							const uint32_t renderMeshIndex =
 								static_cast<uint32_t>(pModel->m_meshes.Num());

--- a/Runtime/AssetRegistry/Model/ModelImporter.h
+++ b/Runtime/AssetRegistry/Model/ModelImporter.h
@@ -173,9 +173,16 @@ namespace Sailor
 
 		struct MeshContext
 		{
+			struct LodGeometry
+			{
+				TVector<RHI::VertexP3N3T3B3UV2C4I4W4> m_vertices;
+				TVector<uint32_t> m_indices;
+			};
+
 			TMap<RHI::VertexP3N3T3B3UV2C4I4W4, uint32_t> uniqueVertices;
 			TVector<RHI::VertexP3N3T3B3UV2C4I4W4> outVertices;
 			TVector<uint32_t> outIndices;
+			TVector<LodGeometry> lods;
 			Math::AABB bounds{};
 			int32_t materialIndex = -1;
 			uint32_t materialSlot = (std::numeric_limits<uint32_t>::max)();
@@ -197,6 +204,13 @@ namespace Sailor
 		SAILOR_API bool LoadAsset(FileId uid, TObjectPtr<Object>& out, bool bImmediate = true) override;
 		SAILOR_API Tasks::TaskPtr<ModelPtr> LoadModel(FileId uid, ModelPtr& outModel);
 		SAILOR_API bool LoadModel_Immediate(FileId uid, ModelPtr& outModel);
+		SAILOR_API static void GenerateLods(
+			TVector<MeshContext>& meshes,
+			uint32_t numLods,
+			float reductionFactor);
+		SAILOR_API static std::string GetLodCacheFilename(
+			const FileId& fileId,
+			uint32_t lodLevel);
 
 		SAILOR_API Tasks::TaskPtr<bool> LoadDefaultMaterials(FileId uid, TVector<MaterialPtr>& outMaterials);
 

--- a/Runtime/Components/MeshRendererComponent.cpp
+++ b/Runtime/Components/MeshRendererComponent.cpp
@@ -3,6 +3,8 @@
 #include "ECS/StaticMeshRendererECS.h"
 #include "AssetRegistry/Material/MaterialImporter.h"
 
+#include <algorithm>
+
 using namespace Sailor;
 using namespace Sailor::Tasks;
 
@@ -13,6 +15,7 @@ void MeshRendererComponent::Initialize()
 
 	GetData().SetOwner(GetOwner());
 	GetData().SetMeshIndex(m_meshIndex);
+	GetData().SetLodSettings(m_minLod, m_maxLod, m_lodDistances);
 }
 
 void MeshRendererComponent::BeginPlay()
@@ -57,6 +60,35 @@ void MeshRendererComponent::SetOverrideMaterials(const TVector<FileId>& override
 {
 	m_overrideMaterials = overrideMaterials;
 	RebuildMaterials();
+}
+
+void MeshRendererComponent::SetMinLod(uint32_t minLod)
+{
+	m_minLod = minLod;
+	m_maxLod = (std::max)(m_maxLod, m_minLod);
+	if (m_handle != ECS::InvalidIndex)
+	{
+		GetData().SetLodSettings(m_minLod, m_maxLod, m_lodDistances);
+	}
+}
+
+void MeshRendererComponent::SetMaxLod(uint32_t maxLod)
+{
+	m_maxLod = (std::max)(maxLod, m_minLod);
+	if (m_handle != ECS::InvalidIndex)
+	{
+		GetData().SetLodSettings(m_minLod, m_maxLod, m_lodDistances);
+	}
+}
+
+void MeshRendererComponent::SetLodDistances(const TVector<float>& lodDistances)
+{
+	m_lodDistances = lodDistances;
+	std::sort(m_lodDistances.begin(), m_lodDistances.end());
+	if (m_handle != ECS::InvalidIndex)
+	{
+		GetData().SetLodSettings(m_minLod, m_maxLod, m_lodDistances);
+	}
 }
 
 void MeshRendererComponent::RebuildMaterials()

--- a/Runtime/Components/MeshRendererComponent.cpp
+++ b/Runtime/Components/MeshRendererComponent.cpp
@@ -4,6 +4,8 @@
 #include "AssetRegistry/Material/MaterialImporter.h"
 
 #include <algorithm>
+#include <cmath>
+#include <functional>
 
 using namespace Sailor;
 using namespace Sailor::Tasks;
@@ -15,7 +17,10 @@ void MeshRendererComponent::Initialize()
 
 	GetData().SetOwner(GetOwner());
 	GetData().SetMeshIndex(m_meshIndex);
-	GetData().SetLodSettings(m_minLod, m_maxLod, m_lodDistances);
+	GetData().SetLodSettings(
+		m_minLod,
+		m_maxLod,
+		m_screenCoverageThresholds);
 }
 
 void MeshRendererComponent::BeginPlay()
@@ -68,7 +73,10 @@ void MeshRendererComponent::SetMinLod(uint32_t minLod)
 	m_maxLod = (std::max)(m_maxLod, m_minLod);
 	if (m_handle != ECS::InvalidIndex)
 	{
-		GetData().SetLodSettings(m_minLod, m_maxLod, m_lodDistances);
+		GetData().SetLodSettings(
+			m_minLod,
+			m_maxLod,
+			m_screenCoverageThresholds);
 	}
 }
 
@@ -77,17 +85,32 @@ void MeshRendererComponent::SetMaxLod(uint32_t maxLod)
 	m_maxLod = (std::max)(maxLod, m_minLod);
 	if (m_handle != ECS::InvalidIndex)
 	{
-		GetData().SetLodSettings(m_minLod, m_maxLod, m_lodDistances);
+		GetData().SetLodSettings(
+			m_minLod,
+			m_maxLod,
+			m_screenCoverageThresholds);
 	}
 }
 
-void MeshRendererComponent::SetLodDistances(const TVector<float>& lodDistances)
+void MeshRendererComponent::SetScreenCoverageThresholds(
+	const TVector<float>& screenCoverageThresholds)
 {
-	m_lodDistances = lodDistances;
-	std::sort(m_lodDistances.begin(), m_lodDistances.end());
+	m_screenCoverageThresholds = screenCoverageThresholds;
+	for (float& threshold : m_screenCoverageThresholds)
+	{
+		threshold = std::isfinite(threshold) ?
+			(std::clamp)(threshold, 0.0f, 100.0f) : 0.0f;
+	}
+	std::sort(
+		m_screenCoverageThresholds.begin(),
+		m_screenCoverageThresholds.end(),
+		std::greater<float>());
 	if (m_handle != ECS::InvalidIndex)
 	{
-		GetData().SetLodSettings(m_minLod, m_maxLod, m_lodDistances);
+		GetData().SetLodSettings(
+			m_minLod,
+			m_maxLod,
+			m_screenCoverageThresholds);
 	}
 }
 

--- a/Runtime/Components/MeshRendererComponent.h
+++ b/Runtime/Components/MeshRendererComponent.h
@@ -28,6 +28,12 @@ namespace Sailor
 		SAILOR_API void SetMeshIndex(int32_t meshIndex);
 		SAILOR_API const TVector<FileId>& GetOverrideMaterials() const { return m_overrideMaterials; }
 		SAILOR_API void SetOverrideMaterials(const TVector<FileId>& overrideMaterials);
+		SAILOR_API uint32_t GetMinLod() const { return m_minLod; }
+		SAILOR_API void SetMinLod(uint32_t minLod);
+		SAILOR_API uint32_t GetMaxLod() const { return m_maxLod; }
+		SAILOR_API void SetMaxLod(uint32_t maxLod);
+		SAILOR_API const TVector<float>& GetLodDistances() const { return m_lodDistances; }
+		SAILOR_API void SetLodDistances(const TVector<float>& lodDistances);
 
 		SAILOR_API __forceinline TVector<MaterialPtr>& GetMaterials() { return GetData().GetMaterials(); }
 		SAILOR_API __forceinline StaticMeshRendererData& GetData();
@@ -41,6 +47,9 @@ namespace Sailor
 		size_t m_handle = (size_t)(-1);
 		int32_t m_meshIndex = Model::AllMeshes;
 		TVector<FileId> m_overrideMaterials;
+		uint32_t m_minLod = 0u;
+		uint32_t m_maxLod = 2u;
+		TVector<float> m_lodDistances{ 25.0f, 75.0f };
 	};
 }
 
@@ -55,5 +64,11 @@ REFL_AUTO(
 	func(SetMeshIndex, property("meshIndex")),
 
 	func(GetOverrideMaterials, property("overrideMaterials")),
-	func(SetOverrideMaterials, property("overrideMaterials"))
+	func(SetOverrideMaterials, property("overrideMaterials")),
+	func(GetMinLod, property("minLod"), Range(0.0, 16.0)),
+	func(SetMinLod, property("minLod")),
+	func(GetMaxLod, property("maxLod"), Range(0.0, 16.0)),
+	func(SetMaxLod, property("maxLod")),
+	func(GetLodDistances, property("lodDistances")),
+	func(SetLodDistances, property("lodDistances"))
 )

--- a/Runtime/Components/MeshRendererComponent.h
+++ b/Runtime/Components/MeshRendererComponent.h
@@ -32,8 +32,8 @@ namespace Sailor
 		SAILOR_API void SetMinLod(uint32_t minLod);
 		SAILOR_API uint32_t GetMaxLod() const { return m_maxLod; }
 		SAILOR_API void SetMaxLod(uint32_t maxLod);
-		SAILOR_API const TVector<float>& GetLodDistances() const { return m_lodDistances; }
-		SAILOR_API void SetLodDistances(const TVector<float>& lodDistances);
+		SAILOR_API const TVector<float>& GetScreenCoverageThresholds() const { return m_screenCoverageThresholds; }
+		SAILOR_API void SetScreenCoverageThresholds(const TVector<float>& screenCoverageThresholds);
 
 		SAILOR_API __forceinline TVector<MaterialPtr>& GetMaterials() { return GetData().GetMaterials(); }
 		SAILOR_API __forceinline StaticMeshRendererData& GetData();
@@ -49,7 +49,7 @@ namespace Sailor
 		TVector<FileId> m_overrideMaterials;
 		uint32_t m_minLod = 0u;
 		uint32_t m_maxLod = 2u;
-		TVector<float> m_lodDistances{ 25.0f, 75.0f };
+		TVector<float> m_screenCoverageThresholds{ 25.0f, 5.0f };
 	};
 }
 
@@ -69,6 +69,6 @@ REFL_AUTO(
 	func(SetMinLod, property("minLod")),
 	func(GetMaxLod, property("maxLod"), Range(0.0, 16.0)),
 	func(SetMaxLod, property("maxLod")),
-	func(GetLodDistances, property("lodDistances")),
-	func(SetLodDistances, property("lodDistances"))
+	func(GetScreenCoverageThresholds, property("screenCoverageThresholds")),
+	func(SetScreenCoverageThresholds, property("screenCoverageThresholds"))
 )

--- a/Runtime/Core/Reflection.h
+++ b/Runtime/Core/Reflection.h
@@ -248,6 +248,10 @@ namespace Sailor
 			{
 				return "List<FileId>";
 			}
+			else if constexpr (std::is_same_v<PropertyType, TVector<float>>)
+			{
+				return "List<float>";
+			}
 			else if constexpr (std::is_enum_v<PropertyType>)
 			{
 				return GetReflectedEnumTypeName<PropertyType>();

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -8,6 +8,9 @@
 #include "Components/AnimatorComponent.h"
 #include "Components/MeshRendererComponent.h"
 
+#include <algorithm>
+#include <cmath>
+
 using namespace Sailor;
 using namespace Sailor::Tasks;
 
@@ -197,6 +200,48 @@ namespace
 		RHI::RHIShadowCasterProxyPtr m_shadowCaster{};
 		Math::AABB m_worldBounds{};
 	};
+}
+
+uint32_t StaticMeshRendererData::ResolveLod(
+	float distanceToCamera,
+	uint32_t numAvailableLods) const
+{
+	if (numAvailableLods == 0u)
+	{
+		return 0u;
+	}
+
+	const uint32_t highestAvailableLod = numAvailableLods - 1u;
+	const uint32_t minLod = (std::min)(m_minLod, highestAvailableLod);
+	const uint32_t maxLod = (std::max)(
+		minLod,
+		(std::min)(m_maxLod, highestAvailableLod));
+	uint32_t selectedLod = 0u;
+	for (size_t thresholdIndex = 0;
+		thresholdIndex < m_lodDistances.Num();
+		++thresholdIndex)
+	{
+		const float threshold = m_lodDistances[thresholdIndex];
+		if (!std::isfinite(threshold) || distanceToCamera < threshold)
+		{
+			break;
+		}
+
+		selectedLod = static_cast<uint32_t>(thresholdIndex + 1u);
+	}
+
+	return (std::clamp)(selectedLod, minLod, maxLod);
+}
+
+void StaticMeshRendererData::SetLodSettings(
+	uint32_t minLod,
+	uint32_t maxLod,
+	const TVector<float>& lodDistances)
+{
+	m_minLod = minLod;
+	m_maxLod = (std::max)(minLod, maxLod);
+	m_lodDistances = lodDistances;
+	std::sort(m_lodDistances.begin(), m_lodDistances.end());
 }
 
 void StaticMeshRendererECS::BeginPlay()

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <functional>
 
 using namespace Sailor;
 using namespace Sailor::Tasks;
@@ -203,7 +204,7 @@ namespace
 }
 
 uint32_t StaticMeshRendererData::ResolveLod(
-	float distanceToCamera,
+	float screenCoveragePercent,
 	uint32_t numAvailableLods) const
 {
 	if (numAvailableLods == 0u)
@@ -217,12 +218,16 @@ uint32_t StaticMeshRendererData::ResolveLod(
 		minLod,
 		(std::min)(m_maxLod, highestAvailableLod));
 	uint32_t selectedLod = 0u;
+	const float coverage = (std::clamp)(
+		screenCoveragePercent,
+		0.0f,
+		100.0f);
 	for (size_t thresholdIndex = 0;
-		thresholdIndex < m_lodDistances.Num();
+		thresholdIndex < m_screenCoverageThresholds.Num();
 		++thresholdIndex)
 	{
-		const float threshold = m_lodDistances[thresholdIndex];
-		if (!std::isfinite(threshold) || distanceToCamera < threshold)
+		const float threshold = m_screenCoverageThresholds[thresholdIndex];
+		if (!std::isfinite(threshold) || coverage >= threshold)
 		{
 			break;
 		}
@@ -236,12 +241,20 @@ uint32_t StaticMeshRendererData::ResolveLod(
 void StaticMeshRendererData::SetLodSettings(
 	uint32_t minLod,
 	uint32_t maxLod,
-	const TVector<float>& lodDistances)
+	const TVector<float>& screenCoverageThresholds)
 {
 	m_minLod = minLod;
 	m_maxLod = (std::max)(minLod, maxLod);
-	m_lodDistances = lodDistances;
-	std::sort(m_lodDistances.begin(), m_lodDistances.end());
+	m_screenCoverageThresholds = screenCoverageThresholds;
+	for (float& threshold : m_screenCoverageThresholds)
+	{
+		threshold = std::isfinite(threshold) ?
+			(std::clamp)(threshold, 0.0f, 100.0f) : 0.0f;
+	}
+	std::sort(
+		m_screenCoverageThresholds.begin(),
+		m_screenCoverageThresholds.end(),
+		std::greater<float>());
 }
 
 void StaticMeshRendererECS::BeginPlay()

--- a/Runtime/ECS/StaticMeshRendererECS.h
+++ b/Runtime/ECS/StaticMeshRendererECS.h
@@ -43,6 +43,8 @@ namespace Sailor
 
 		SAILOR_API __forceinline bool ShouldCastShadow() const { return true; }
 		SAILOR_API __forceinline uint32_t GetSkeletonOffset() const { return m_skeletonOffset; }
+		SAILOR_API uint32_t ResolveLod(float distanceToCamera, uint32_t numAvailableLods) const;
+		SAILOR_API void SetLodSettings(uint32_t minLod, uint32_t maxLod, const TVector<float>& lodDistances);
 	protected:
 
 		ModelPtr m_model;
@@ -51,6 +53,9 @@ namespace Sailor
 		RHI::RHIShadowCasterProxyPtr m_shadowCaster;
 		uint32_t m_skeletonOffset = InvalidSkeletonOffset;
 		int32_t m_meshIndex = -1;
+		uint32_t m_minLod = 0u;
+		uint32_t m_maxLod = 2u;
+		TVector<float> m_lodDistances{ 25.0f, 75.0f };
 		bool m_bInvalidMeshIndexReported = false;
 
 		friend class StaticMeshRendererECS;

--- a/Runtime/ECS/StaticMeshRendererECS.h
+++ b/Runtime/ECS/StaticMeshRendererECS.h
@@ -43,8 +43,11 @@ namespace Sailor
 
 		SAILOR_API __forceinline bool ShouldCastShadow() const { return true; }
 		SAILOR_API __forceinline uint32_t GetSkeletonOffset() const { return m_skeletonOffset; }
-		SAILOR_API uint32_t ResolveLod(float distanceToCamera, uint32_t numAvailableLods) const;
-		SAILOR_API void SetLodSettings(uint32_t minLod, uint32_t maxLod, const TVector<float>& lodDistances);
+		SAILOR_API uint32_t ResolveLod(float screenCoveragePercent, uint32_t numAvailableLods) const;
+		SAILOR_API void SetLodSettings(
+			uint32_t minLod,
+			uint32_t maxLod,
+			const TVector<float>& screenCoverageThresholds);
 	protected:
 
 		ModelPtr m_model;
@@ -55,7 +58,7 @@ namespace Sailor
 		int32_t m_meshIndex = -1;
 		uint32_t m_minLod = 0u;
 		uint32_t m_maxLod = 2u;
-		TVector<float> m_lodDistances{ 25.0f, 75.0f };
+		TVector<float> m_screenCoverageThresholds{ 25.0f, 5.0f };
 		bool m_bInvalidMeshIndexReported = false;
 
 		friend class StaticMeshRendererECS;

--- a/Runtime/RHI/Batch.hpp
+++ b/Runtime/RHI/Batch.hpp
@@ -207,10 +207,10 @@ namespace Sailor::RHI
 				auto& matrices = *instancedDrawCall.Second();
 
 				RHI::DrawIndexedIndirectData data{};
-				data.m_indexCount = (uint32_t)mesh->m_indexBuffer->GetSize() / sizeof(uint32_t);
+				data.m_indexCount = mesh->GetIndexCount();
 				data.m_instanceCount = (uint32_t)matrices.Num();
-				data.m_firstIndex = (uint32_t)mesh->m_indexBuffer->GetOffset() / sizeof(uint32_t);
-				data.m_vertexOffset = mesh->m_vertexBuffer->GetOffset() / (uint32_t)mesh->m_vertexDescription->GetVertexStride();
+				data.m_firstIndex = mesh->GetFirstIndex();
+				data.m_vertexOffset = mesh->GetVertexOffset();
 				data.m_firstInstance = storageIndex[j] + ssboOffset;
 				drawIndirect.Emplace(std::move(data));
 				meshesInCurrentBatch++;
@@ -389,10 +389,10 @@ namespace Sailor::RHI
 				auto& matrices = *instancedDrawCall.Second();
 
 				RHI::DrawIndexedIndirectData data{};
-				data.m_indexCount = (uint32_t)mesh->m_indexBuffer->GetSize() / sizeof(uint32_t);
+				data.m_indexCount = mesh->GetIndexCount();
 				data.m_instanceCount = (uint32_t)matrices.Num();
-				data.m_firstIndex = (uint32_t)mesh->m_indexBuffer->GetOffset() / sizeof(uint32_t);
-				data.m_vertexOffset = mesh->m_vertexBuffer->GetOffset() / (uint32_t)mesh->m_vertexDescription->GetVertexStride();
+				data.m_firstIndex = mesh->GetFirstIndex();
+				data.m_vertexOffset = mesh->GetVertexOffset();
 				data.m_firstInstance = storageIndex[j] + ssboOffset;
 
 				drawIndirect.Emplace(std::move(data));

--- a/Runtime/RHI/Mesh.cpp
+++ b/Runtime/RHI/Mesh.cpp
@@ -18,17 +18,41 @@ bool RHIMesh::IsReady() const
 
 uint32_t RHIMesh::GetIndexCount() const
 {
-	return (uint32_t)m_indexBuffer->GetSize() / sizeof(uint32_t);
+	return m_indexCount != (std::numeric_limits<uint32_t>::max)() ?
+		m_indexCount :
+		(uint32_t)m_indexBuffer->GetSize() / sizeof(uint32_t);
 }
 
 uint32_t RHIMesh::GetFirstIndex() const
 {
-	return (uint32_t)m_indexBuffer->GetOffset() / sizeof(uint32_t);
+	return m_firstIndex != (std::numeric_limits<uint32_t>::max)() ?
+		(uint32_t)m_indexBuffer->GetOffset() / sizeof(uint32_t) + m_firstIndex :
+		(uint32_t)m_indexBuffer->GetOffset() / sizeof(uint32_t);
 }
 
 uint32_t RHIMesh::GetVertexOffset() const
 {
-	return m_vertexBuffer->GetOffset() / (uint32_t)m_vertexDescription->GetVertexStride();
+	return m_vertexOffset != (std::numeric_limits<uint32_t>::max)() ?
+		m_vertexBuffer->GetOffset() / (uint32_t)m_vertexDescription->GetVertexStride() + m_vertexOffset :
+		m_vertexBuffer->GetOffset() / (uint32_t)m_vertexDescription->GetVertexStride();
+}
+
+uint32_t RHIMesh::GetNumLods() const
+{
+	return 1u + static_cast<uint32_t>(m_lods.Num());
+}
+
+RHIMeshPtr RHIMesh::GetLod(uint32_t lod) const
+{
+	if (lod == 0 || m_lods.IsEmpty())
+	{
+		return {};
+	}
+
+	const size_t lodIndex = (std::min)(
+		static_cast<size_t>(lod - 1u),
+		m_lods.Num() - 1u);
+	return m_lods[lodIndex];
 }
 
 size_t RHIMesh::ResolveMaterialIndex(

--- a/Runtime/RHI/Mesh.h
+++ b/Runtime/RHI/Mesh.h
@@ -15,6 +15,8 @@ namespace Sailor::RHI
 		SAILOR_API uint32_t GetIndexCount() const;
 		SAILOR_API uint32_t GetFirstIndex() const;
 		SAILOR_API uint32_t GetVertexOffset() const;
+		SAILOR_API uint32_t GetNumLods() const;
+		SAILOR_API RHIMeshPtr GetLod(uint32_t lod) const;
 		SAILOR_API size_t ResolveMaterialIndex(
 			size_t meshIndex,
 			size_t numMaterials) const;
@@ -25,6 +27,10 @@ namespace Sailor::RHI
 		Math::AABB m_bounds{};
 		uint32_t m_materialIndex = (std::numeric_limits<uint32_t>::max)();
 		glm::vec3 m_bakedVolumeScale{ 1.0f };
+		uint32_t m_indexCount = (std::numeric_limits<uint32_t>::max)();
+		uint32_t m_firstIndex = (std::numeric_limits<uint32_t>::max)();
+		uint32_t m_vertexOffset = (std::numeric_limits<uint32_t>::max)();
+		TVector<RHIMeshPtr> m_lods{};
 
 		SAILOR_API virtual bool IsReady() const override;
 

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -11,15 +11,95 @@
 #include "RHI/DebugContext.h"
 #include "RHI/CommandList.h"
 
+#include <algorithm>
+#include <array>
+#include <limits>
+
 using namespace Sailor;
 using namespace Sailor::RHI;
+
+float Sailor::RHI::CalculateScreenCoveragePercent(
+	const Math::AABB& worldBounds,
+	const glm::mat4& viewMatrix,
+	const glm::mat4& projectionMatrix)
+{
+	const auto isMatrixFinite = [](const glm::mat4& matrix)
+		{
+			return Math::AllFinite(matrix[0]) &&
+				Math::AllFinite(matrix[1]) &&
+				Math::AllFinite(matrix[2]) &&
+				Math::AllFinite(matrix[3]);
+		};
+	if (!worldBounds.IsValid() ||
+		!isMatrixFinite(viewMatrix) ||
+		!isMatrixFinite(projectionMatrix))
+	{
+		return 0.0f;
+	}
+
+	const glm::vec3 min = worldBounds.m_min;
+	const glm::vec3 max = worldBounds.m_max;
+	const std::array<glm::vec3, 8u> corners = {
+		glm::vec3(min.x, min.y, min.z),
+		glm::vec3(max.x, min.y, min.z),
+		glm::vec3(min.x, max.y, min.z),
+		glm::vec3(max.x, max.y, min.z),
+		glm::vec3(min.x, min.y, max.z),
+		glm::vec3(max.x, min.y, max.z),
+		glm::vec3(min.x, max.y, max.z),
+		glm::vec3(max.x, max.y, max.z)
+	};
+
+	const glm::mat4 viewProjection = projectionMatrix * viewMatrix;
+	std::array<glm::vec4, 8u> clipCorners{};
+	uint32_t numCornersInFront = 0u;
+	for (size_t cornerIndex = 0u;
+		cornerIndex < corners.size();
+		++cornerIndex)
+	{
+		glm::vec4& clip = clipCorners[cornerIndex];
+		clip = viewProjection * glm::vec4(corners[cornerIndex], 1.0f);
+		if (!Math::AllFinite(clip))
+		{
+			return 0.0f;
+		}
+		numCornersInFront += clip.w > 1e-5f ? 1u : 0u;
+	}
+	if (numCornersInFront == 0u)
+	{
+		return 0.0f;
+	}
+	if (numCornersInFront < corners.size())
+	{
+		return 100.0f;
+	}
+
+	glm::vec2 minNdc((std::numeric_limits<float>::max)());
+	glm::vec2 maxNdc((std::numeric_limits<float>::lowest)());
+	for (const glm::vec4& clip : clipCorners)
+	{
+		const glm::vec2 ndc = glm::vec2(clip) / clip.w;
+		minNdc = glm::min(minNdc, ndc);
+		maxNdc = glm::max(maxNdc, ndc);
+	}
+
+	minNdc = glm::max(minNdc, glm::vec2(-1.0f));
+	maxNdc = glm::min(maxNdc, glm::vec2(1.0f));
+	const glm::vec2 coveredNdc = glm::max(
+		maxNdc - minNdc,
+		glm::vec2(0.0f));
+	return (std::clamp)(
+		coveredNdc.x * coveredNdc.y * 25.0f,
+		0.0f,
+		100.0f);
+}
 
 namespace
 {
 	uint32_t ResolveProxyLod(
 		const StaticMeshRendererData& data,
 		const Math::AABB& worldBounds,
-		const Math::Transform& cameraTransform,
+		const CameraData& camera,
 		const RHIMeshPtr& mesh)
 	{
 		if (!mesh)
@@ -27,16 +107,17 @@ namespace
 			return 0u;
 		}
 
-		const float distanceToCamera = glm::distance(
-			glm::vec3(cameraTransform.m_position),
-			worldBounds.GetCenter());
-		return data.ResolveLod(distanceToCamera, mesh->GetNumLods());
+		const float screenCoveragePercent = CalculateScreenCoveragePercent(
+			worldBounds,
+			camera.GetViewMatrix(),
+			camera.GetProjectionMatrix());
+		return data.ResolveLod(screenCoveragePercent, mesh->GetNumLods());
 	}
 
 	void ApplyLodToMeshes(
 		const StaticMeshRendererData& data,
 		const Math::AABB& worldBounds,
-		const Math::Transform& cameraTransform,
+		const CameraData& camera,
 		TVector<RHIMeshPtr>& meshes)
 	{
 		for (auto& mesh : meshes)
@@ -44,7 +125,7 @@ namespace
 			const uint32_t lod = ResolveProxyLod(
 				data,
 				worldBounds,
-				cameraTransform,
+				camera,
 				mesh);
 			if (lod > 0u)
 			{
@@ -59,7 +140,7 @@ namespace
 	RHIShadowCasterProxyPtr CreateLodShadowCaster(
 		const RHIShadowCasterProxyPtr& source,
 		WorldPtr world,
-		const Math::Transform& cameraTransform)
+		const CameraData& camera)
 	{
 		if (!source || !world)
 		{
@@ -79,7 +160,7 @@ namespace
 			const uint32_t lod = ResolveProxyLod(
 				data,
 				source->m_worldAabb,
-				cameraTransform,
+				camera,
 				shadowMesh.m_mesh);
 			if (lod > 0u)
 			{
@@ -333,12 +414,12 @@ void RHISceneView::PrepareSnapshots()
 				ApplyLodToMeshes(
 					data,
 					proxy.m_worldAabb,
-					res.m_cameraTransform,
+					camera,
 					proxy.m_meshes);
 				proxy.m_shadowCaster = CreateLodShadowCaster(
 					proxy.m_shadowCaster,
 					m_world,
-					res.m_cameraTransform);
+					camera);
 			}
 		}
 		for (auto& shadowMap : res.m_shadowMapsToUpdate)
@@ -348,7 +429,7 @@ void RHISceneView::PrepareSnapshots()
 				shadowCaster = CreateLodShadowCaster(
 					shadowCaster,
 					m_world,
-					res.m_cameraTransform);
+					camera);
 			}
 		}
 

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -14,6 +14,85 @@
 using namespace Sailor;
 using namespace Sailor::RHI;
 
+namespace
+{
+	uint32_t ResolveProxyLod(
+		const StaticMeshRendererData& data,
+		const Math::AABB& worldBounds,
+		const Math::Transform& cameraTransform,
+		const RHIMeshPtr& mesh)
+	{
+		if (!mesh)
+		{
+			return 0u;
+		}
+
+		const float distanceToCamera = glm::distance(
+			glm::vec3(cameraTransform.m_position),
+			worldBounds.GetCenter());
+		return data.ResolveLod(distanceToCamera, mesh->GetNumLods());
+	}
+
+	void ApplyLodToMeshes(
+		const StaticMeshRendererData& data,
+		const Math::AABB& worldBounds,
+		const Math::Transform& cameraTransform,
+		TVector<RHIMeshPtr>& meshes)
+	{
+		for (auto& mesh : meshes)
+		{
+			const uint32_t lod = ResolveProxyLod(
+				data,
+				worldBounds,
+				cameraTransform,
+				mesh);
+			if (lod > 0u)
+			{
+				if (RHIMeshPtr lodMesh = mesh->GetLod(lod))
+				{
+					mesh = std::move(lodMesh);
+				}
+			}
+		}
+	}
+
+	RHIShadowCasterProxyPtr CreateLodShadowCaster(
+		const RHIShadowCasterProxyPtr& source,
+		WorldPtr world,
+		const Math::Transform& cameraTransform)
+	{
+		if (!source || !world)
+		{
+			return source;
+		}
+
+		auto* meshEcs = world->GetECS<StaticMeshRendererECS>();
+		if (!meshEcs || !meshEcs->IsComponentRegistered(source->m_staticMeshEcs))
+		{
+			return source;
+		}
+
+		const auto& data = meshEcs->GetComponentData(source->m_staticMeshEcs);
+		RHIShadowCasterProxyPtr result = RHIShadowCasterProxyPtr::Make(*source);
+		for (auto& shadowMesh : result->m_meshes)
+		{
+			const uint32_t lod = ResolveProxyLod(
+				data,
+				source->m_worldAabb,
+				cameraTransform,
+				shadowMesh.m_mesh);
+			if (lod > 0u)
+			{
+				if (RHIMeshPtr lodMesh = shadowMesh.m_mesh->GetLod(lod))
+				{
+					shadowMesh.m_mesh = std::move(lodMesh);
+				}
+			}
+		}
+		return result;
+	}
+}
+
 void RHISceneView::PrepareDebugDrawCommandLists(WorldPtr world)
 {
 	m_debugDraw.Reserve(m_cameras.Num());
@@ -241,6 +320,37 @@ void RHISceneView::PrepareSnapshots()
 		res.m_drawImGui = m_drawImGui;
 		res.m_shadowMapsToUpdate = std::move(m_shadowMapsToUpdate[i]);
 		res.m_proxies = TraceScene(frustum, false);
+		auto* meshEcs = m_world ? m_world->GetECS<StaticMeshRendererECS>() : nullptr;
+		if (meshEcs)
+		{
+			for (auto& proxy : res.m_proxies)
+			{
+				if (!meshEcs->IsComponentRegistered(proxy.m_staticMeshEcs))
+				{
+					continue;
+				}
+				const auto& data = meshEcs->GetComponentData(proxy.m_staticMeshEcs);
+				ApplyLodToMeshes(
+					data,
+					proxy.m_worldAabb,
+					res.m_cameraTransform,
+					proxy.m_meshes);
+				proxy.m_shadowCaster = CreateLodShadowCaster(
+					proxy.m_shadowCaster,
+					m_world,
+					res.m_cameraTransform);
+			}
+		}
+		for (auto& shadowMap : res.m_shadowMapsToUpdate)
+		{
+			for (auto& shadowCaster : shadowMap.m_meshList)
+			{
+				shadowCaster = CreateLodShadowCaster(
+					shadowCaster,
+					m_world,
+					res.m_cameraTransform);
+			}
+		}
 
 		if (i < m_debugDraw.Num())
 		{

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -14,6 +14,11 @@
 
 namespace Sailor::RHI
 {
+	SAILOR_API float CalculateScreenCoveragePercent(
+		const Math::AABB& worldBounds,
+		const glm::mat4& viewMatrix,
+		const glm::mat4& projectionMatrix);
+
 	enum class EShadowType : uint32_t
 	{
 		None = 0,

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -23,6 +23,7 @@
 #include "ECS/TransformECS.h"
 #include "Engine/GameObject.h"
 #include "Engine/World.h"
+#include "RHI/SceneView.h"
 #include "Submodules/Editor.h"
 
 using namespace Sailor;
@@ -806,21 +807,56 @@ namespace
 		Require(data.GetMaterials().IsEmpty(), "clearing a model should clear its stale material overrides");
 	}
 
-	void TestStaticMeshLodSelectionClampsAndUsesDistances()
+	void TestStaticMeshLodSelectionUsesScreenCoverage()
 	{
 		StaticMeshRendererData data;
-		data.SetLodSettings(0u, 2u, TVector<float>{ 20.0f, 60.0f });
-		Require(data.ResolveLod(0.0f, 3u) == 0u &&
-			data.ResolveLod(20.0f, 3u) == 1u &&
-			data.ResolveLod(59.0f, 3u) == 1u &&
-			data.ResolveLod(60.0f, 3u) == 2u,
-			"mesh renderer LOD selection must follow ascending camera-distance thresholds");
+		data.SetLodSettings(0u, 2u, TVector<float>{ 5.0f, 25.0f });
+		Require(data.ResolveLod(100.0f, 3u) == 0u &&
+			data.ResolveLod(25.0f, 3u) == 0u &&
+			data.ResolveLod(24.9f, 3u) == 1u &&
+			data.ResolveLod(4.9f, 3u) == 2u,
+			"mesh renderer LOD selection must follow descending screen-coverage thresholds");
 
-		data.SetLodSettings(1u, 5u, TVector<float>{ 60.0f, 20.0f });
-		Require(data.ResolveLod(0.0f, 3u) == 1u,
-			"mesh renderer minimum LOD must clamp near-camera selection");
-		Require(data.ResolveLod(1000.0f, 2u) == 1u,
+		data.SetLodSettings(1u, 5u, TVector<float>{ 25.0f, 5.0f });
+		Require(data.ResolveLod(100.0f, 3u) == 1u,
+			"mesh renderer minimum LOD must clamp high-coverage selection");
+		Require(data.ResolveLod(0.0f, 2u) == 1u,
 			"mesh renderer maximum LOD must clamp to available model geometry");
+
+		const glm::mat4 projection = glm::perspective(
+			glm::radians(60.0f),
+			1.0f,
+			0.1f,
+			1000.0f);
+		const glm::mat4 view(1.0f);
+		const float nearCoverage = RHI::CalculateScreenCoveragePercent(
+			Math::AABB(glm::vec3(0.0f, 0.0f, -5.0f), glm::vec3(1.0f)),
+			view,
+			projection);
+		const float farCoverage = RHI::CalculateScreenCoveragePercent(
+			Math::AABB(glm::vec3(0.0f, 0.0f, -20.0f), glm::vec3(1.0f)),
+			view,
+			projection);
+		const float offscreenCoverage = RHI::CalculateScreenCoveragePercent(
+			Math::AABB(glm::vec3(100.0f, 0.0f, -5.0f), glm::vec3(1.0f)),
+			view,
+			projection);
+		const float behindCameraCoverage = RHI::CalculateScreenCoveragePercent(
+			Math::AABB(glm::vec3(0.0f, 0.0f, 5.0f), glm::vec3(1.0f)),
+			view,
+			projection);
+		const float cameraIntersectionCoverage = RHI::CalculateScreenCoveragePercent(
+			Math::AABB(glm::vec3(0.0f), glm::vec3(1.0f)),
+			view,
+			projection);
+		Require(nearCoverage > farCoverage && farCoverage > 0.0f,
+			"projected AABB coverage must decrease as the same object recedes from the camera");
+		Require(offscreenCoverage == 0.0f,
+			"projected AABB coverage must exclude bounds outside the viewport");
+		Require(behindCameraCoverage == 0.0f,
+			"projected AABB coverage must exclude bounds behind the camera");
+		Require(cameraIntersectionCoverage == 100.0f,
+			"projected AABB coverage must conservatively select the highest LOD when bounds cross the camera plane");
 
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string sceneViewSource = ReadText(
@@ -1414,9 +1450,9 @@ namespace
 			"mesh renderer material overrides must be exported as an editable FileId list");
 		Require(properties.ContainsKey("minLod") &&
 			properties.ContainsKey("maxLod") &&
-			properties.ContainsKey("lodDistances") &&
-			properties["lodDistances"] == "List<float>",
-			"mesh renderer LOD limits and distance thresholds must be editable reflected properties");
+			properties.ContainsKey("screenCoverageThresholds") &&
+			properties["screenCoverageThresholds"] == "List<float>",
+			"mesh renderer LOD limits and screen-coverage thresholds must be editable reflected properties");
 
 		PrefabTestWorld world;
 		auto root = world.Instantiate("MaterialOverrides");
@@ -1459,7 +1495,8 @@ namespace
 		meshRenderer->SetOverrideMaterials(overrides);
 		meshRenderer->SetMinLod(1u);
 		meshRenderer->SetMaxLod(2u);
-		meshRenderer->SetLodDistances(TVector<float>{ 80.0f, 30.0f });
+		meshRenderer->SetScreenCoverageThresholds(
+			TVector<float>{ 5.0f, 25.0f });
 		Require(meshRenderer->GetOverrideMaterials() == overrides,
 			"assigning material overrides must preserve their slot order and inherited gaps");
 		Require(meshRenderer->GetData().IsDirty(),
@@ -1490,10 +1527,11 @@ namespace
 		Require(restoredRenderer && areOverridesEquivalent(
 			restoredRenderer->GetOverrideMaterials(), overrides),
 			"prefab instantiation must restore component-owned material overrides");
-		const TVector<float> expectedLodDistances{ 30.0f, 80.0f };
+		const TVector<float> expectedCoverageThresholds{ 25.0f, 5.0f };
 		Require(restoredRenderer->GetMinLod() == 1u &&
 			restoredRenderer->GetMaxLod() == 2u &&
-			restoredRenderer->GetLodDistances() == expectedLodDistances,
+			restoredRenderer->GetScreenCoverageThresholds() ==
+				expectedCoverageThresholds,
 			"prefab instantiation must restore sorted mesh renderer LOD settings");
 
 		restoredRenderer->SetModel(ModelPtr());
@@ -3672,7 +3710,7 @@ int main()
 		{ "EditorKeepWorldReparentRejectsShearedCandidateWithoutMutation", TestEditorKeepWorldReparentRejectsShearedCandidateWithoutMutation },
 		{ "OctreeRelocationPreservesElementCount", TestOctreeRelocationPreservesElementCount },
 		{ "ClearingMeshModelAlsoClearsMaterials", TestClearingMeshModelAlsoClearsMaterials },
-		{ "StaticMeshLodSelectionClampsAndUsesDistances", TestStaticMeshLodSelectionClampsAndUsesDistances },
+		{ "StaticMeshLodSelectionUsesScreenCoverage", TestStaticMeshLodSelectionUsesScreenCoverage },
 		{ "StaticMeshProxyPublishesTransformRevisionForShadowInvalidation", TestStaticMeshProxyPublishesTransformRevisionForShadowInvalidation },
 		{ "StaticMeshProxyTracksMaterialContentRevisions", TestStaticMeshProxyTracksMaterialContentRevisions },
 		{ "CsmSnapshotTracksCastersBeforeDependencyFiltering", TestCsmSnapshotTracksCastersBeforeDependencyFiltering },

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -810,6 +810,9 @@ namespace
 	void TestStaticMeshLodSelectionUsesScreenCoverage()
 	{
 		StaticMeshRendererData data;
+		Require(data.ResolveLod(0.0f, 1u) == 0u &&
+			data.ResolveLod(100.0f, 1u) == 0u,
+			"mesh renderer must keep LOD0 when no generated LOD is available");
 		data.SetLodSettings(0u, 2u, TVector<float>{ 5.0f, 25.0f });
 		Require(data.ResolveLod(100.0f, 3u) == 0u &&
 			data.ResolveLod(25.0f, 3u) == 0u &&

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -806,6 +806,39 @@ namespace
 		Require(data.GetMaterials().IsEmpty(), "clearing a model should clear its stale material overrides");
 	}
 
+	void TestStaticMeshLodSelectionClampsAndUsesDistances()
+	{
+		StaticMeshRendererData data;
+		data.SetLodSettings(0u, 2u, TVector<float>{ 20.0f, 60.0f });
+		Require(data.ResolveLod(0.0f, 3u) == 0u &&
+			data.ResolveLod(20.0f, 3u) == 1u &&
+			data.ResolveLod(59.0f, 3u) == 1u &&
+			data.ResolveLod(60.0f, 3u) == 2u,
+			"mesh renderer LOD selection must follow ascending camera-distance thresholds");
+
+		data.SetLodSettings(1u, 5u, TVector<float>{ 60.0f, 20.0f });
+		Require(data.ResolveLod(0.0f, 3u) == 1u,
+			"mesh renderer minimum LOD must clamp near-camera selection");
+		Require(data.ResolveLod(1000.0f, 2u) == 1u,
+			"mesh renderer maximum LOD must clamp to available model geometry");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string sceneViewSource = ReadText(
+			sourceRoot / "Runtime/RHI/SceneView.cpp");
+		const size_t visibleSelection = sceneViewSource.find(
+			"ApplyLodToMeshes(");
+		const size_t visibleShadowSelection = sceneViewSource.find(
+			"proxy.m_shadowCaster = CreateLodShadowCaster(",
+			visibleSelection);
+		const size_t shadowPassSelection = sceneViewSource.find(
+			"shadowCaster = CreateLodShadowCaster(",
+			visibleShadowSelection);
+		Require(visibleSelection != std::string::npos &&
+			visibleShadowSelection > visibleSelection &&
+			shadowPassSelection > visibleShadowSelection,
+			"snapshot preparation must apply the camera-selected LOD to main, depth, and shadow proxies");
+	}
+
 	void TestStaticMeshProxyPublishesTransformRevisionForShadowInvalidation()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -1379,6 +1412,11 @@ namespace
 		Require(properties.ContainsKey("overrideMaterials") &&
 			properties["overrideMaterials"] == "List<FileId>",
 			"mesh renderer material overrides must be exported as an editable FileId list");
+		Require(properties.ContainsKey("minLod") &&
+			properties.ContainsKey("maxLod") &&
+			properties.ContainsKey("lodDistances") &&
+			properties["lodDistances"] == "List<float>",
+			"mesh renderer LOD limits and distance thresholds must be editable reflected properties");
 
 		PrefabTestWorld world;
 		auto root = world.Instantiate("MaterialOverrides");
@@ -1419,6 +1457,9 @@ namespace
 		TVector<FileId> overrides{ firstMaterial, FileId::Invalid, secondMaterial };
 
 		meshRenderer->SetOverrideMaterials(overrides);
+		meshRenderer->SetMinLod(1u);
+		meshRenderer->SetMaxLod(2u);
+		meshRenderer->SetLodDistances(TVector<float>{ 80.0f, 30.0f });
 		Require(meshRenderer->GetOverrideMaterials() == overrides,
 			"assigning material overrides must preserve their slot order and inherited gaps");
 		Require(meshRenderer->GetData().IsDirty(),
@@ -1449,6 +1490,11 @@ namespace
 		Require(restoredRenderer && areOverridesEquivalent(
 			restoredRenderer->GetOverrideMaterials(), overrides),
 			"prefab instantiation must restore component-owned material overrides");
+		const TVector<float> expectedLodDistances{ 30.0f, 80.0f };
+		Require(restoredRenderer->GetMinLod() == 1u &&
+			restoredRenderer->GetMaxLod() == 2u &&
+			restoredRenderer->GetLodDistances() == expectedLodDistances,
+			"prefab instantiation must restore sorted mesh renderer LOD settings");
 
 		restoredRenderer->SetModel(ModelPtr());
 		Require(areOverridesEquivalent(
@@ -3626,6 +3672,7 @@ int main()
 		{ "EditorKeepWorldReparentRejectsShearedCandidateWithoutMutation", TestEditorKeepWorldReparentRejectsShearedCandidateWithoutMutation },
 		{ "OctreeRelocationPreservesElementCount", TestOctreeRelocationPreservesElementCount },
 		{ "ClearingMeshModelAlsoClearsMaterials", TestClearingMeshModelAlsoClearsMaterials },
+		{ "StaticMeshLodSelectionClampsAndUsesDistances", TestStaticMeshLodSelectionClampsAndUsesDistances },
 		{ "StaticMeshProxyPublishesTransformRevisionForShadowInvalidation", TestStaticMeshProxyPublishesTransformRevisionForShadowInvalidation },
 		{ "StaticMeshProxyTracksMaterialContentRevisions", TestStaticMeshProxyTracksMaterialContentRevisions },
 		{ "CsmSnapshotTracksCastersBeforeDependencyFiltering", TestCsmSnapshotTracksCastersBeforeDependencyFiltering },

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -5,6 +5,7 @@
 #include "Raytracing/MaterialUtils.h"
 #include "Raytracing/PathTracer.h"
 #include "Components/MeshRendererComponent.h"
+#include "RHI/Buffer.h"
 
 #include <cmath>
 #include <filesystem>
@@ -286,6 +287,138 @@ namespace
 		emptyMesh.outIndices = { 0, 0, 0 };
 		Require(emptyMesh.HasGeometry(),
 			"a mesh context with vertices and indices must remain uploadable");
+	}
+
+	void TestModelLodMetadataDefaultsAndRoundTrip()
+	{
+		ModelAssetInfo defaults;
+		Require(defaults.ShouldGenerateLods(),
+			"model assets must generate LODs by default");
+		Require(defaults.GetNumGeneratedLods() == 2u,
+			"model assets must generate medium and low LODs by default");
+		Require(NearlyEqual(defaults.GetLodReductionFactor(), 0.5f),
+			"default model LOD reduction factor");
+
+		YAML::Node metadata = defaults.Serialize();
+		Require(metadata["bGenerateLods"].as<bool>(),
+			"model metadata must serialize the LOD generation switch");
+		Require(metadata["numGeneratedLods"].as<uint32_t>() == 2u,
+			"model metadata must serialize the generated LOD count");
+		Require(NearlyEqual(metadata["lodReductionFactor"].as<float>(), 0.5f),
+			"serialized model LOD reduction factor");
+
+		metadata["bGenerateLods"] = false;
+		metadata["numGeneratedLods"] = 4u;
+		metadata["lodReductionFactor"] = 0.4f;
+		ModelAssetInfo restored;
+		restored.Deserialize(metadata);
+		Require(!restored.ShouldGenerateLods() &&
+			restored.GetNumGeneratedLods() == 4u,
+			"model LOD metadata must round-trip generation settings");
+		Require(NearlyEqual(restored.GetLodReductionFactor(), 0.4f),
+			"round-tripped model LOD reduction factor");
+
+		YAML::Node legacy = defaults.Serialize();
+		legacy.remove("bGenerateLods");
+		legacy.remove("numGeneratedLods");
+		legacy.remove("lodReductionFactor");
+		ModelAssetInfo migrated;
+		migrated.Deserialize(legacy);
+		Require(migrated.ShouldGenerateLods() &&
+			migrated.GetNumGeneratedLods() == 2u,
+			"legacy model metadata must retain the new LOD defaults");
+	}
+
+	void TestModelLodGenerationAndCacheNaming()
+	{
+		ModelImporter::MeshContext mesh;
+		constexpr uint32_t GridSize = 8u;
+		for (uint32_t y = 0u; y <= GridSize; ++y)
+		{
+			for (uint32_t x = 0u; x <= GridSize; ++x)
+			{
+				mesh.outVertices.Add(MakeVertex(glm::vec3(
+					static_cast<float>(x),
+					static_cast<float>(y),
+					0.0f)));
+			}
+		}
+		for (uint32_t y = 0u; y < GridSize; ++y)
+		{
+			for (uint32_t x = 0u; x < GridSize; ++x)
+			{
+				const uint32_t topLeft = y * (GridSize + 1u) + x;
+				const uint32_t topRight = topLeft + 1u;
+				const uint32_t bottomLeft = topLeft + GridSize + 1u;
+				const uint32_t bottomRight = bottomLeft + 1u;
+				mesh.outIndices.AddRange({
+					topLeft, bottomLeft, topRight,
+					topRight, bottomLeft, bottomRight
+				});
+			}
+		}
+
+		const size_t sourceIndexCount = mesh.outIndices.Num();
+		TVector<ModelImporter::MeshContext> meshes{ std::move(mesh) };
+		ModelImporter::GenerateLods(meshes, 2u, 0.5f);
+		Require(meshes[0].lods.Num() == 2u,
+			"model import must generate the requested LOD count");
+		Require(!meshes[0].lods[0].m_vertices.IsEmpty() &&
+			!meshes[0].lods[0].m_indices.IsEmpty() &&
+			!meshes[0].lods[1].m_vertices.IsEmpty() &&
+			!meshes[0].lods[1].m_indices.IsEmpty(),
+			"generated model LODs must retain renderable geometry");
+		Require(meshes[0].lods[0].m_indices.Num() < sourceIndexCount &&
+			meshes[0].lods[1].m_indices.Num() <= meshes[0].lods[0].m_indices.Num(),
+			"successive model LODs must reduce or retain triangle count monotonically");
+		for (const auto& lod : meshes[0].lods)
+		{
+			for (uint32_t index : lod.m_indices)
+			{
+				Require(index < lod.m_vertices.Num(),
+					"generated model LOD indices must reference compacted vertices");
+			}
+		}
+
+		FileId fileId;
+		fileId.Deserialize(YAML::Node("01234567-89ab-cdef-0123-456789abcdef"));
+		Require(
+			ModelImporter::GetLodCacheFilename(fileId, 2u) ==
+				"01234567-89ab-cdef-0123-456789abcdef_lod2.bin",
+			"model LOD cache filenames must follow the fileId_lodN.bin contract");
+		Require(ModelImporter::GetLodCacheFilename(fileId, 0u).empty(),
+			"LOD0 must remain source geometry instead of a generated cache file");
+	}
+
+	void TestRhiMeshLodsShareBuffersAndDrawRanges()
+	{
+		auto vertexBuffer = RHI::RHIBufferPtr::Make(
+			RHI::EBufferUsageBit::VertexBuffer_Bit,
+			RHI::EMemoryPropertyBit::DeviceLocal);
+		auto indexBuffer = RHI::RHIBufferPtr::Make(
+			RHI::EBufferUsageBit::IndexBuffer_Bit,
+			RHI::EMemoryPropertyBit::DeviceLocal);
+		auto baseMesh = RHI::RHIMeshPtr::Make();
+		baseMesh->m_vertexBuffer = vertexBuffer;
+		baseMesh->m_indexBuffer = indexBuffer;
+		baseMesh->m_indexCount = 120u;
+		auto mediumMesh = RHI::RHIMeshPtr::Make();
+		mediumMesh->m_vertexBuffer = vertexBuffer;
+		mediumMesh->m_indexBuffer = indexBuffer;
+		mediumMesh->m_indexCount = 60u;
+		mediumMesh->m_firstIndex = 120u;
+		mediumMesh->m_vertexOffset = 80u;
+		baseMesh->m_lods.Add(mediumMesh);
+
+		Require(baseMesh->GetNumLods() == 2u &&
+			baseMesh->GetIndexCount() == 120u &&
+			baseMesh->GetLod(1u)->GetIndexCount() == 60u,
+			"RHI mesh LOD views must retain independent draw ranges");
+		Require(baseMesh->GetLod(1u)->m_vertexBuffer == baseMesh->m_vertexBuffer &&
+			baseMesh->GetLod(1u)->m_indexBuffer == baseMesh->m_indexBuffer,
+			"RHI mesh LOD views must share the base mesh GPU buffers");
+		Require(baseMesh->GetLod(8u) == mediumMesh,
+			"LOD selection must clamp to the highest available mesh view");
 	}
 
 	void TestGltfAlphaModesResolveRenderState()
@@ -1469,6 +1602,9 @@ int main()
 	const std::pair<const char*, std::function<void()>> tests[] = {
 		{ "ModelReadinessTracksMeshUploads", TestModelReadinessTracksMeshUploads },
 		{ "MeshContextRejectsEmptyGpuUploads", TestMeshContextRejectsEmptyGpuUploads },
+		{ "ModelLodMetadataDefaultsAndRoundTrip", TestModelLodMetadataDefaultsAndRoundTrip },
+		{ "ModelLodGenerationAndCacheNaming", TestModelLodGenerationAndCacheNaming },
+		{ "RhiMeshLodsShareBuffersAndDrawRanges", TestRhiMeshLodsShareBuffersAndDrawRanges },
 		{ "GltfAlphaModesResolveRenderState", TestGltfAlphaModesResolveRenderState },
 		{ "MaterialAssetRetainsRenderQueue", TestMaterialAssetRetainsRenderQueue },
 		{ "GltfTransmissionExtensionResolvesMaterialFields", TestGltfTransmissionExtensionResolvesMaterialFields },

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -411,6 +411,8 @@ namespace
 		baseMesh->m_vertexBuffer = vertexBuffer;
 		baseMesh->m_indexBuffer = indexBuffer;
 		baseMesh->m_indexCount = 120u;
+		Require(baseMesh->GetNumLods() == 1u && !baseMesh->GetLod(1u),
+			"a model without generated LODs must expose only source LOD0");
 		auto mediumMesh = RHI::RHIMeshPtr::Make();
 		mediumMesh->m_vertexBuffer = vertexBuffer;
 		mediumMesh->m_indexBuffer = indexBuffer;

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -318,15 +318,6 @@ namespace
 		Require(NearlyEqual(restored.GetLodReductionFactor(), 0.4f),
 			"round-tripped model LOD reduction factor");
 
-		YAML::Node legacy = defaults.Serialize();
-		legacy.remove("bGenerateLods");
-		legacy.remove("numGeneratedLods");
-		legacy.remove("lodReductionFactor");
-		ModelAssetInfo migrated;
-		migrated.Deserialize(legacy);
-		Require(migrated.ShouldGenerateLods() &&
-			migrated.GetNumGeneratedLods() == 2u,
-			"legacy model metadata must retain the new LOD defaults");
 	}
 
 	void TestModelLodGenerationAndCacheNaming()
@@ -337,10 +328,12 @@ namespace
 		{
 			for (uint32_t x = 0u; x <= GridSize; ++x)
 			{
-				mesh.outVertices.Add(MakeVertex(glm::vec3(
+				auto vertex = MakeVertex(glm::vec3(
 					static_cast<float>(x),
 					static_cast<float>(y),
-					0.0f)));
+					0.0f));
+				vertex.m_normal = glm::vec3(1.0f, 0.0f, 0.0f);
+				mesh.outVertices.Add(std::move(vertex));
 			}
 		}
 		for (uint32_t y = 0u; y < GridSize; ++y)
@@ -377,6 +370,22 @@ namespace
 			{
 				Require(index < lod.m_vertices.Num(),
 					"generated model LOD indices must reference compacted vertices");
+			}
+			for (const auto& vertex : lod.m_vertices)
+			{
+				Require(NearlyEqual(glm::length(vertex.m_normal), 1.0f) &&
+					NearlyEqual(glm::length(vertex.m_tangent), 1.0f) &&
+					NearlyEqual(glm::length(vertex.m_bitangent), 1.0f),
+					"generated model LOD shading directions must be normalized");
+				Require(std::abs(vertex.m_normal.z) > 0.99f,
+					"generated model LOD normals must be rebuilt from simplified geometry");
+				Require(std::abs(glm::dot(
+						vertex.m_normal,
+						vertex.m_tangent)) < 1e-3f &&
+					std::abs(glm::dot(
+						vertex.m_normal,
+						vertex.m_bitangent)) < 1e-3f,
+					"generated model LOD tangent space must be orthogonal");
 			}
 		}
 


### PR DESCRIPTION
## Summary

Add generated model LODs from asset import through renderer snapshot selection.

- Generate two additional model LODs by default with configurable count and reduction factor.
- Persist versioned binary geometry caches under `Cache/Lods/<fileId>_lodN.bin` and invalidate them when the source revision or import settings change.
- Upload base and generated geometry into shared vertex/index buffers and expose each LOD as a draw-range view.
- Rebuild generated LOD normals and tangent basis from the simplified topology.
- Select LODs from projected world-AABB screen coverage and reuse the same selection for main, depth, and shadow rendering.
- Expose model generation options plus Mesh Renderer min/max LOD and screen-coverage thresholds in the editor.

## Linked Issue

Closes #152

## Implementation Notes

- LOD generation uses meshoptimizer and retains source geometry as a safe fallback when simplification cannot produce a renderable mesh.
- Generated LOD shading data is recalculated after vertex compaction; the cache version is bumped so stale generated geometry is rebuilt.
- Cache publication uses the existing atomic workspace-cache replacement contract.
- LOD views share the base mesh buffers, material index, bounds, and baked volume scale; only index count, first index, and vertex offset differ.
- Reflected `TVector<float>` properties are exported as `List<float>` and have an editor list control/YAML round trip.
- Path-tracer BLAS generation intentionally remains based on source geometry.
- Models without generated LODs always resolve to source LOD0; failed simplification falls back to source geometry for that generated level.
- The branch is rebased onto `origin/main` at merge commit `4608c5b9`, which contains the rendering fixes from PR #156 and the Windows editor viewport integration fix from PR #157.

## Agent Workflow

- [x] Implementation Summary is prepared.
- [x] Tech Review: approved locally; no blocking architecture findings.
- [x] QA Report: approved for the implemented scope.
- [ ] Ready for human review after the local branch is pushed and the PR is opened.

## Tests

- [x] Release C++ build.
- [x] `ctest --test-dir build-make-release-main-deps --output-on-failure` — 37/37 passed.
- [x] Relevant Debug contracts: `ModelImporterContractTests` and `EcsLifecycleContractTests`.
- [x] Editor contracts via `dotnet test` — 758/758 passed.
- [x] Debug and Release MAUI Mac Catalyst editor builds.
- [x] Focused Release world smoke: `SingleModelRendering.world` — passed after the final rebase (4.20 s).
- [x] Cold smoke created two non-empty LOD artifacts; warm smoke reused them without changing timestamps.
- [x] `git diff --check`.
- [ ] Full Debug CTest: 36/37 passed; the unrelated `WorkspaceModuleRuntimeTests` owner-claim contract fails in Debug while the same Release suite passes.

## QA Report

Status: Approved

- Model metadata defaults, simplification monotonicity, valid compacted indices, rebuilt shading basis, cache naming, shared GPU buffers, draw ranges, coverage selection, LOD clamping, reflected component persistence, and main/depth/shadow snapshot routing have contract coverage.
- Release runtime smoke verified actual `Cache/Lods` artifact generation and cache reuse.
- No tracked content changes from runtime validation remain.

## Tech Review

Status: Approved

- Runtime/editor responsibilities remain separated through reflection metadata and YAML contracts.
- LOD storage extends the existing RHI mesh abstraction without duplicating GPU allocations.
- Cache files are bounded, versioned, validated against source/settings, and published atomically.
- Snapshot selection is camera-local and does not mutate shared ECS proxies.

Residual risk:

- Projected AABB coverage is intentionally conservative and can keep a higher LOD for sparse or strongly rotated bounds.
- The cache format is a rebuildable native binary artifact rather than a portable interchange format.
- No GPU performance benchmark was added; the smoke test proves behavior and cache reuse, not frame-time improvement.

## Risk

- Risk level: high
- Risk notes: touches model import/cache, RHI draw ranges, renderer snapshots, reflected component serialization, and editor inspectors. Automated contracts and a real Release rendering smoke cover the primary failure modes.
