### PR TITLE
Reduce cloud rendering resolution on Mac

### DIFF
--- a/Runtime/FrameGraph/SkyNode.cpp
+++ b/Runtime/FrameGraph/SkyNode.cpp
@@ -427,7 +427,11 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 		driver->SetDebugName(m_pSunTexture, "Sun");
 	}
 
-	const float cloudsSize = std::min(App::GetMainWindow()->GetRenderArea().x * CloudsResolutionFactor, App::GetMainWindow()->GetRenderArea().y * CloudsResolutionFactor);
+	float cloudsResolutionFactor = CloudsResolutionFactor;
+#if defined(__APPLE__)
+	cloudsResolutionFactor *= 0.5f;
+#endif
+	const float cloudsSize = std::min(App::GetMainWindow()->GetRenderArea().x * cloudsResolutionFactor, App::GetMainWindow()->GetRenderArea().y * cloudsResolutionFactor);
 	const glm::ivec2 desiredCloudsExtent(std::max(1.0f, cloudsSize), std::max(1.0f, cloudsSize));
 
 	if (m_pCloudsTexture && m_pCloudsTexture->GetExtent() != desiredCloudsExtent)


### PR DESCRIPTION
## Summary

Reduce the volumetric cloud render target resolution on macOS while preserving the existing resolution on other platforms.

## Why

Retina render areas make the cloud ray-marching target unnecessarily expensive. `SkyNode` already renders clouds at half the shorter render-area dimension on every platform; macOS now applies one additional 0.5 scale, producing a 0.25 factor there while Windows remains at 0.5.

The fixed 256x256 sky texture is unchanged.

## Impact

- macOS cloud render-target width and height are halved relative to the previous macOS behavior.
- Cloud render-target pixel count and associated storage are reduced to one quarter of the previous macOS target.
- Other platforms retain their existing cloud resolution.

## Validation

- Release `SailorLib` build on macOS.
- `SkyComponentContractTests` passed.
- Release MAUI editor build and launch completed with the updated engine library.
- `git diff --check`.
