### PR TITLE
Fix custom depth shadows and workspace editor flow

### DIFF
--- a/Content/Shaders/ShadowCaster.shader
+++ b/Content/Shaders/ShadowCaster.shader
@@ -42,11 +42,17 @@ glslVertex: |
   struct PerInstanceData
   {
       mat4 model;
-      vec4 baseColorFactor;
+      vec4 sphereBounds;
+      uint materialInstance;
       uint skeletonOffset;
+      uint isCulled;
+      uint padding;
+      vec4 bakedVolumeScale;
+      vec4 baseColorFactor;
       uint baseColorSampler;
       float alphaCutoff;
-      uint padding;
+      uint maskedPadding;
+      uint stridePadding;
   };
 
   struct BoneData

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -525,6 +525,43 @@ public sealed class WorkflowProjectionTests
             StringComparison.Ordinal);
     }
 
+    [Fact]
+    public void ContentContextMenu_ExposesFolderRefreshAndTargetedAssetReimport()
+    {
+        var viewSource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "ContentFolderView.xaml.cs");
+        var serviceSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "AssetsService.cs");
+        var contextMenu = Slice(
+            viewSource,
+            "void ShowContextMenu(object model)",
+            "async Task ReimportAsset(");
+
+        Assert.Contains("model is AssetFile assetFile", contextMenu, StringComparison.Ordinal);
+        Assert.Contains("Text = \"Reimport\"", contextMenu, StringComparison.Ordinal);
+        Assert.Contains("service.CanReimportAsset(assetFile)", contextMenu, StringComparison.Ordinal);
+        Assert.Contains("() => ReimportAsset(assetFile)", contextMenu, StringComparison.Ordinal);
+        Assert.Contains("model is AssetFolder folder", contextMenu, StringComparison.Ordinal);
+        Assert.Contains("Text = \"Refresh\"", contextMenu, StringComparison.Ordinal);
+        Assert.Contains("service.CanRefreshFolder(folder)", contextMenu, StringComparison.Ordinal);
+        Assert.Contains("() => RefreshFolder(folder)", contextMenu, StringComparison.Ordinal);
+        Assert.Contains("ProjectContentFolderItem { IsRoot: true } rootFolder", contextMenu, StringComparison.Ordinal);
+        Assert.Contains("service.CanRefreshFolder(rootFolder)", contextMenu, StringComparison.Ordinal);
+        Assert.Contains("() => RefreshFolder(rootFolder)", contextMenu, StringComparison.Ordinal);
+
+        Assert.Contains("public Task<bool> ReimportAssetAsync(", serviceSource, StringComparison.Ordinal);
+        Assert.Contains("return _engineService.UpdateAssetAsync(", serviceSource, StringComparison.Ordinal);
+        Assert.Contains("public async Task<bool> RefreshFolderAsync(", serviceSource, StringComparison.Ordinal);
+        Assert.Contains("_engineService.RequestAssetReloadAsync(", serviceSource, StringComparison.Ordinal);
+        Assert.Contains("public bool CanReimportAsset(", serviceSource, StringComparison.Ordinal);
+        Assert.Contains("public bool CanRefreshFolder(", serviceSource, StringComparison.Ordinal);
+        Assert.Contains("CanRefreshFolderPath(folder.FullPath)", serviceSource, StringComparison.Ordinal);
+    }
+
     sealed record ContentProjectionTestRow(
         string Id,
         string Label);

--- a/Editor/MainPage.xaml.cs
+++ b/Editor/MainPage.xaml.cs
@@ -15,6 +15,7 @@ public partial class MainPage : ContentPage
     readonly WorkspaceUiService _workspaceUi;
     readonly McpEditorHostService _mcpHost;
     bool _workspaceUiInitialized;
+    bool _commandLineWorkspaceHandled;
 
     public MainPage(EditorShellHost shellHost)
     {
@@ -39,6 +40,18 @@ public partial class MainPage : ContentPage
         {
             _workspaceUiInitialized = true;
             await _workspaceUi.InitializeAsync();
+        }
+
+        if (!_commandLineWorkspaceHandled)
+        {
+            _commandLineWorkspaceHandled = true;
+            var manifestPath = ResolveCommandLineWorkspaceManifest(
+                Environment.GetCommandLineArgs());
+            if (!string.IsNullOrWhiteSpace(manifestPath))
+            {
+                await _workspaceUi.OpenWorkspaceAsync(manifestPath);
+                await LoadCommandLineWorldAsync(Environment.GetCommandLineArgs());
+            }
         }
 
         if (!_mcpHost.Status.IsRunning)
@@ -106,4 +119,101 @@ public partial class MainPage : ContentPage
 
     static string BuildWindowTitle(WorkspaceUiProjection projection)
         => projection.WindowTitle;
+
+    async Task LoadCommandLineWorldAsync(IReadOnlyList<string> arguments)
+    {
+        var world = ResolveCommandLineValue(arguments, "--world");
+        var contentRoot = _workspaceUi.Projection.ActiveContentPath;
+        if (string.IsNullOrWhiteSpace(world) ||
+            string.IsNullOrWhiteSpace(contentRoot))
+        {
+            return;
+        }
+
+        var worldPath = Path.GetFullPath(
+            Path.IsPathRooted(world)
+                ? world
+                : Path.Combine(contentRoot, world));
+        var assets = MauiProgram.GetService<AssetsService>();
+        var contentFolder = assets.Folders.FirstOrDefault(folder =>
+            string.Equals(
+                Path.GetFullPath(folder.FullPath),
+                Path.GetFullPath(contentRoot),
+                StringComparison.OrdinalIgnoreCase));
+        if (contentFolder is not null)
+            await assets.EnsureFolderLoadedAsync(contentFolder.Id);
+
+        var worldFile = assets.Assets.Values
+            .OfType<SailorEditor.ViewModels.WorldFile>()
+            .FirstOrDefault(asset => asset.Asset is not null &&
+                string.Equals(
+                    Path.GetFullPath(asset.Asset.FullName),
+                    worldPath,
+                    StringComparison.OrdinalIgnoreCase));
+        if (worldFile is null ||
+            !await MauiProgram.GetService<WorldService>().LoadWorldAsync(worldFile))
+        {
+            Console.Error.WriteLine(
+                $"Unable to load command-line workspace world: {worldPath}");
+        }
+    }
+
+    static string? ResolveCommandLineWorkspaceManifest(
+        IReadOnlyList<string> arguments)
+    {
+        string? workspacePath = null;
+        string? manifestPath = null;
+        for (var index = 0; index < arguments.Count; ++index)
+        {
+            var argument = arguments[index];
+            if (argument == "--workspace" && index + 1 < arguments.Count)
+            {
+                workspacePath = arguments[++index];
+            }
+            else if (argument == "--workspace-manifest" &&
+                index + 1 < arguments.Count)
+            {
+                manifestPath = arguments[++index];
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(manifestPath))
+            return Path.GetFullPath(manifestPath);
+        if (string.IsNullOrWhiteSpace(workspacePath))
+            return null;
+
+        var fullWorkspacePath = Path.GetFullPath(workspacePath);
+        if (File.Exists(fullWorkspacePath))
+            return fullWorkspacePath;
+        if (!Directory.Exists(fullWorkspacePath))
+            return null;
+
+        foreach (var filename in new[]
+        {
+            "SailorWorkspace.sailor",
+            WorkspaceTemplateService.ManifestFileName
+        })
+        {
+            var candidate = Path.Combine(fullWorkspacePath, filename);
+            if (File.Exists(candidate))
+                return candidate;
+        }
+
+        return Directory.EnumerateFiles(fullWorkspacePath, "*.sailor")
+            .OrderBy(path => path, StringComparer.OrdinalIgnoreCase)
+            .FirstOrDefault();
+    }
+
+    static string? ResolveCommandLineValue(
+        IReadOnlyList<string> arguments,
+        string option)
+    {
+        for (var index = 0; index + 1 < arguments.Count; ++index)
+        {
+            if (arguments[index] == option)
+                return arguments[index + 1];
+        }
+
+        return null;
+    }
 }

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -167,6 +167,59 @@ namespace SailorEditor.Services
             }
         }
 
+        public Task<bool> ReimportAssetAsync(
+            AssetFile assetFile,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(assetFile);
+            if (!CanReimportAsset(assetFile))
+            {
+                return Task.FromResult(false);
+            }
+
+            return _engineService.UpdateAssetAsync(
+                assetFile.FileId,
+                cancellationToken);
+        }
+
+        public async Task<bool> RefreshFolderAsync(
+            AssetFolder? folder,
+            CancellationToken cancellationToken = default)
+        {
+            var directoryPath = folder?.FullPath ?? CurrentProjectRootPath;
+            return await RefreshFolderPathAsync(directoryPath, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        public async Task<bool> RefreshFolderAsync(
+            ProjectContentFolderItem folder,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(folder);
+            return await RefreshFolderPathAsync(folder.FullPath, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        async Task<bool> RefreshFolderPathAsync(
+            string directoryPath,
+            CancellationToken cancellationToken)
+        {
+            if (!CanRefreshFolderPath(directoryPath))
+            {
+                return false;
+            }
+
+            if (_engineService.IsRunning)
+            {
+                return await _engineService.RequestAssetReloadAsync(
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            await RefreshAsync(cancellationToken).ConfigureAwait(false);
+            return true;
+        }
+
         public string GetFolderPath(AssetFolder? folder)
         {
             if (folder == null)
@@ -1592,6 +1645,13 @@ namespace SailorEditor.Services
                 || ProjectContentPathPolicy.IsInsideRoot(CurrentProjectRootPath, assetFile.Asset.FullName);
         }
 
+        public bool CanReimportAsset(AssetFile? assetFile)
+            => _engineService.IsRunning &&
+               assetFile?.FileId is not null &&
+               !assetFile.FileId.IsEmpty() &&
+               assetFile.AssetInfo?.Exists == true &&
+               assetFile.Asset?.Exists == true;
+
         public bool CanRenameAsset(AssetFile? assetFile)
             => assetFile?.OwnsSourceFile == true && CanModifyAsset(assetFile);
 
@@ -1613,6 +1673,22 @@ namespace SailorEditor.Services
 
         public bool CanCreateFolder(AssetFolder? parentFolder)
             => TryGetWritableDestinationDirectory(parentFolder, out _);
+
+        public bool CanRefreshFolder(AssetFolder? folder)
+        {
+            var directoryPath = folder?.FullPath ?? CurrentProjectRootPath;
+            return CanRefreshFolderPath(directoryPath);
+        }
+
+        public bool CanRefreshFolder(ProjectContentFolderItem? folder)
+            => folder is not null && CanRefreshFolderPath(folder.FullPath);
+
+        bool CanRefreshFolderPath(string directoryPath)
+            => !string.IsNullOrWhiteSpace(directoryPath) &&
+               Directory.Exists(directoryPath) &&
+               (ProjectContentPathPolicy.IsInsideRoot(CurrentProjectRootPath, directoryPath) ||
+                (CurrentProjectMode == EditorProjectMode.Workspace &&
+                 ProjectContentPathPolicy.IsInsideRoot(_engineContentDirectory, directoryPath)));
 
         public bool CanMoveAsset(AssetFile? assetFile, AssetFolder? destinationFolder)
         {

--- a/Editor/Views/ContentFolderView.xaml.cs
+++ b/Editor/Views/ContentFolderView.xaml.cs
@@ -850,10 +850,22 @@ namespace SailorEditor.Views
         void ShowContextMenu(object model)
         {
             var contextMenu = MauiProgram.GetService<EditorContextMenuService>();
-            if (model is AssetFile assetFile && service.CanModifyAsset(assetFile))
+            if (model is AssetFile assetFile)
             {
                 var items = new List<EditorContextMenuItem>();
-                if (service.CanDuplicateAsset(assetFile))
+                if (service.CanReimportAsset(assetFile))
+                {
+                    items.Add(new EditorContextMenuItem
+                    {
+                        Text = "Reimport",
+                        Command = CreateContentContextMenuCommand(
+                            () => ReimportAsset(assetFile),
+                            "Reimport asset")
+                    });
+                }
+
+                if (service.CanModifyAsset(assetFile) &&
+                    service.CanDuplicateAsset(assetFile))
                 {
                     items.Add(new EditorContextMenuItem
                     {
@@ -864,7 +876,8 @@ namespace SailorEditor.Views
                     });
                 }
 
-                if (service.CanRenameAsset(assetFile))
+                if (service.CanModifyAsset(assetFile) &&
+                    service.CanRenameAsset(assetFile))
                 {
                     items.Add(new EditorContextMenuItem
                     {
@@ -875,43 +888,62 @@ namespace SailorEditor.Views
                     });
                 }
 
-                var deleteItem = new EditorContextMenuItem
+                if (service.CanModifyAsset(assetFile))
                 {
-                    Text = "Delete",
-                    IsDestructive = true,
-                    Command = CreateContentContextMenuCommand(
-                        () => DeleteAsset(assetFile),
-                        "Delete asset")
-                };
-                items.Add(deleteItem);
-                contextMenu.Show(items.ToArray());
+                    items.Add(new EditorContextMenuItem
+                    {
+                        Text = "Delete",
+                        IsDestructive = true,
+                        Command = CreateContentContextMenuCommand(
+                            () => DeleteAsset(assetFile),
+                            "Delete asset")
+                    });
+                }
+
+                if (items.Count > 0)
+                {
+                    contextMenu.Show(items.ToArray());
+                }
             }
-            else if (model is AssetFolder folder && service.CanCreateFolder(folder))
+            else if (model is AssetFolder folder)
             {
-                var items = new List<EditorContextMenuItem>
+                var items = new List<EditorContextMenuItem>();
+                if (service.CanRefreshFolder(folder))
                 {
-                    new EditorContextMenuItem
+                    items.Add(new EditorContextMenuItem
+                    {
+                        Text = "Refresh",
+                        Command = CreateContentContextMenuCommand(
+                            () => RefreshFolder(folder),
+                            "Refresh folder")
+                    });
+                }
+
+                if (service.CanCreateFolder(folder))
+                {
+                    items.Add(new EditorContextMenuItem
                     {
                         Text = "Create Folder",
                         Command = CreateContentContextMenuCommand(
                             () => CreateFolder(folder),
                             "Create folder")
-                    },
-                    new EditorContextMenuItem
+                    });
+                    items.Add(new EditorContextMenuItem
                     {
                         Text = "Create Animation Controller",
                         Command = CreateContentContextMenuCommand(
                             () => CreateAnimationAsset(folder, false),
                             "Create animation controller")
-                    },
-                    new EditorContextMenuItem
+                    });
+                    items.Add(new EditorContextMenuItem
                     {
                         Text = "Create Animation Set",
                         Command = CreateContentContextMenuCommand(
                             () => CreateAnimationAsset(folder, true),
                             "Create animation set")
-                    }
-                };
+                    });
+                }
+
                 if (service.CanModifyFolder(folder))
                 {
                     items.Add(new EditorContextMenuItem
@@ -930,33 +962,88 @@ namespace SailorEditor.Views
                             "Delete folder")
                     });
                 }
-                contextMenu.Show(items.ToArray());
+
+                if (items.Count > 0)
+                {
+                    contextMenu.Show(items.ToArray());
+                }
             }
-            else if (model is ProjectContentFolderItem { IsRoot: true, IsReadOnly: false } &&
-                service.CanCreateFolder(null))
+            else if (model is ProjectContentFolderItem { IsRoot: true } rootFolder)
             {
-                contextMenu.Show(
-                    new EditorContextMenuItem
+                var items = new List<EditorContextMenuItem>();
+                if (service.CanRefreshFolder(rootFolder))
+                {
+                    items.Add(new EditorContextMenuItem
+                    {
+                        Text = "Refresh",
+                        Command = CreateContentContextMenuCommand(
+                            () => RefreshFolder(rootFolder),
+                            "Refresh folder")
+                    });
+                }
+
+                if (service.CanCreateFolder(null))
+                {
+                    items.Add(new EditorContextMenuItem
                     {
                         Text = "Create Folder",
                         Command = CreateContentContextMenuCommand(
                             () => CreateFolder(null),
                             "Create folder")
-                    },
-                    new EditorContextMenuItem
+                    });
+                    items.Add(new EditorContextMenuItem
                     {
                         Text = "Create Animation Controller",
                         Command = CreateContentContextMenuCommand(
                             () => CreateAnimationAsset(null, false),
                             "Create animation controller")
-                    },
-                    new EditorContextMenuItem
+                    });
+                    items.Add(new EditorContextMenuItem
                     {
                         Text = "Create Animation Set",
                         Command = CreateContentContextMenuCommand(
                             () => CreateAnimationAsset(null, true),
                             "Create animation set")
                     });
+                }
+
+                if (items.Count > 0)
+                {
+                    contextMenu.Show(items.ToArray());
+                }
+            }
+        }
+
+        async Task ReimportAsset(AssetFile assetFile)
+        {
+            if (!await service.ReimportAssetAsync(assetFile))
+            {
+                await Application.Current.MainPage.DisplayAlert(
+                    "Reimport failed",
+                    $"Unable to reimport {assetFile.DisplayName}.",
+                    "OK");
+            }
+        }
+
+        async Task RefreshFolder(AssetFolder? folder)
+        {
+            if (!await service.RefreshFolderAsync(folder))
+            {
+                await Application.Current.MainPage.DisplayAlert(
+                    "Refresh failed",
+                    "Unable to refresh the Content folder.",
+                    "OK");
+            }
+        }
+
+        async Task RefreshFolder(ProjectContentFolderItem folder)
+        {
+            if (!await service.RefreshFolderAsync(folder))
+            {
+                await Application.Current.MainPage.DisplayAlert(
+                    "Refresh failed",
+                    "Unable to refresh the Content folder.",
+                    "OK");
             }
         }
 

--- a/Runtime/AssetRegistry/Material/MaterialImporter.h
+++ b/Runtime/AssetRegistry/Material/MaterialImporter.h
@@ -40,6 +40,7 @@ namespace Sailor
 
 		SAILOR_API ShaderSetPtr GetShader() { return m_shader; }
 		SAILOR_API RHI::RHIShaderBindingSetPtr GetShaderBindings() { return m_commonShaderBindings; }
+		SAILOR_API RHI::RHIShaderBindingSetPtr GetShaderBindings() const { return m_commonShaderBindings; }
 
 		SAILOR_API const TConcurrentMap<std::string, TexturePtr>& GetSamplers() const { return m_samplers; }
 		SAILOR_API const TConcurrentMap<std::string, glm::vec4>& GetUniformsVec4() const { return m_uniformsVec4; }

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -2634,7 +2634,6 @@ bool GltfImporterUtils::MergeGeneratedMaterialProperties(
 	for (const char* property : {
 		"renderQueue",
 		"bEnableZWrite",
-		"bCustomDepthShader",
 		"blendMode" })
 	{
 		if (!generatedProperties[property] ||
@@ -2644,6 +2643,25 @@ bool GltfImporterUtils::MergeGeneratedMaterialProperties(
 		}
 		merged[property] = YAML::Clone(generatedProperties[property]);
 	}
+
+	const YAML::Node generatedCustomDepth =
+		generatedProperties["bCustomDepthShader"];
+	if (!generatedCustomDepth || !generatedCustomDepth.IsScalar())
+	{
+		return false;
+	}
+
+	bool bCustomDepthShader = generatedCustomDepth.as<bool>();
+	const YAML::Node authoredCustomDepth = merged["bCustomDepthShader"];
+	if (authoredCustomDepth)
+	{
+		if (!authoredCustomDepth.IsScalar())
+		{
+			return false;
+		}
+		bCustomDepthShader |= authoredCustomDepth.as<bool>();
+	}
+	merged["bCustomDepthShader"] = bCustomDepthShader;
 
 	auto isManagedDefine = [](const std::string& define)
 		{

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -293,7 +293,8 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 
 		TVector<Math::Frustum> frustums(lightCascadesMatrices.Num());
 		TVector<glm::mat4> lightMatrices(lightCascadesMatrices.Num());
-		bool bCanReuseAllCascades = true;
+		const bool bForceCustomDepthShadowUpdate = sceneView->m_bHasCustomDepthShadowCasters;
+		bool bCanReuseAllCascades = !bForceCustomDepthShadowUpdate;
 		for (uint32_t cascadeIndex = 0; cascadeIndex < lightCascadesMatrices.Num(); ++cascadeIndex)
 		{
 			lightMatrices[cascadeIndex] = lightCascadesMatrices[cascadeIndex] * directionalLight.m_lightMatrix;
@@ -367,7 +368,9 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 					return lhs.m_first < rhs.m_first;
 				});
 
-			if (snapshotIndex < m_csmSnapshots.Num() && snapshot.Equals(m_csmSnapshots[snapshotIndex]))
+			if (!bForceCustomDepthShadowUpdate &&
+				snapshotIndex < m_csmSnapshots.Num() &&
+				snapshot.Equals(m_csmSnapshots[snapshotIndex]))
 			{
 				m_csmSnapshots[snapshotIndex].m_sceneRevision = sceneView->m_shadowCastersRevision;
 				++snapshotIndex;

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -96,6 +96,7 @@ namespace
 				lhsMesh.m_baseColorFactor != rhsMesh.m_baseColorFactor ||
 				lhsMesh.m_alphaCutoff != rhsMesh.m_alphaCutoff ||
 				lhsMesh.m_baseColorSampler != rhsMesh.m_baseColorSampler ||
+				lhsMesh.m_customDepthMaterial != rhsMesh.m_customDepthMaterial ||
 #if defined(__APPLE__)
 				lhsMesh.m_materialTextureSamplers != rhsMesh.m_materialTextureSamplers ||
 #endif
@@ -145,6 +146,10 @@ namespace
 			shadowMesh.m_mesh = meshes[meshIndex];
 			shadowMesh.m_worldMatrix = matrices.Num() > meshIndex ? matrices[meshIndex] : ownerWorldMatrix;
 			shadowMesh.m_renderQueueTag = renderQueueTag;
+			if (material->GetRenderState().IsRequiredCustomDepthShader())
+			{
+				shadowMesh.m_customDepthMaterial = material;
+			}
 			if (renderQueueTag == maskedQueueTag)
 			{
 				const glm::vec4* baseColorFactor = nullptr;
@@ -173,10 +178,28 @@ namespace
 					shadowMesh.m_baseColorSampler = (uint32_t)textureImporter->GetTextureIndex((*baseColorTexture)->GetFileId());
 				}
 #if defined(__APPLE__)
-				shadowMesh.m_materialTextureSamplers.Insert(0u);
-				shadowMesh.m_materialTextureSamplers.Insert(shadowMesh.m_baseColorSampler);
+				if (!shadowMesh.m_customDepthMaterial)
+				{
+					shadowMesh.m_materialTextureSamplers.Insert(0u);
+					shadowMesh.m_materialTextureSamplers.Insert(shadowMesh.m_baseColorSampler);
+				}
 #endif
 			}
+#if defined(__APPLE__)
+			if (shadowMesh.m_customDepthMaterial)
+			{
+				shadowMesh.m_materialTextureSamplers.Insert(0u);
+				if (textureImporter)
+				{
+					for (const auto& sampler : material->GetSamplers())
+					{
+						const uint32_t textureIndex = sampler.m_second ?
+							(uint32_t)textureImporter->GetTextureIndex(sampler.m_second->GetFileId()) : 0u;
+						shadowMesh.m_materialTextureSamplers.Insert(textureIndex);
+					}
+				}
+			}
+#endif
 			shadowCaster->m_meshes.Add(std::move(shadowMesh));
 		}
 
@@ -318,6 +341,7 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 
 	const uint64_t materialContentRevision = Material::GetGlobalContentRevision();
 	const bool bCheckMaterialRevisions = materialContentRevision != m_lastMaterialContentRevision;
+	bool bHasCustomDepthShadowCasters = false;
 	TVector<size_t> dirtyComponents;
 	dirtyComponents.Reserve(m_components.Num());
 	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
@@ -325,6 +349,19 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 		if (!IsComponentRegistered(componentIndex))
 		{
 			continue;
+		}
+
+		auto& registeredData = m_components[componentIndex];
+		if (registeredData.ShouldCastShadow())
+		{
+			for (const auto& material : registeredData.GetMaterials())
+			{
+				if (material && material->GetRenderState().IsRequiredCustomDepthShader())
+				{
+					bHasCustomDepthShadowCasters = true;
+					break;
+				}
+			}
 		}
 
 		auto& data = m_components[componentIndex];
@@ -643,6 +680,7 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 	{
 		++m_sceneViewProxiesCache->m_shadowCastersRevision;
 	}
+	m_sceneViewProxiesCache->m_bHasCustomDepthShadowCasters = bHasCustomDepthShadowCasters;
 
 	return nullptr;
 }
@@ -654,6 +692,7 @@ void StaticMeshRendererECS::CopySceneView(RHI::RHISceneViewPtr& outProxies)
 	outProxies->m_stationaryOctree = m_sceneViewProxiesCache->m_stationaryOctree;
 	outProxies->m_staticOctree = m_sceneViewProxiesCache->m_staticOctree;
 	outProxies->m_shadowCastersRevision = m_sceneViewProxiesCache->m_shadowCastersRevision;
+	outProxies->m_bHasCustomDepthShadowCasters = m_sceneViewProxiesCache->m_bHasCustomDepthShadowCasters;
 }
 
 void StaticMeshRendererECS::EndPlay()

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -8,6 +8,7 @@
 #include "RHI/Types.h"
 #include "RHI/VertexDescription.h"
 #include "AssetRegistry/AssetRegistry.h"
+#include "AssetRegistry/Material/MaterialImporter.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "ECS/LightingECS.h"
 
@@ -60,6 +61,81 @@ RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddShadowMaterial(RHI::RHIVertexDesc
 		}
 	}
 
+	return material;
+}
+
+RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddCustomShadowMaterial(
+	const MaterialPtr& sourceMaterial,
+	RHI::RHIVertexDescriptionPtr vertexDescription,
+	RHI::EShadowType shadowType,
+	bool bMasked)
+{
+	if (!sourceMaterial || !sourceMaterial->GetShader())
+	{
+		return nullptr;
+	}
+
+	auto shaderCompiler = App::GetSubmodule<ShaderCompiler>();
+	auto shaderAsset = shaderCompiler->LoadShaderAsset(
+		sourceMaterial->GetShader()->GetFileId()).Lock();
+	if (!shaderAsset || !shaderAsset->GetSupportedDefines().Contains("SHADOW_CASTER"))
+	{
+		return nullptr;
+	}
+
+	size_t cacheKey = reinterpret_cast<size_t>(sourceMaterial.GetRawPtr());
+	HashCombine(cacheKey,
+		vertexDescription->GetVertexAttributeBits(),
+		static_cast<uint32_t>(shadowType),
+		bMasked,
+		sourceMaterial->GetContentRevision());
+	auto& material = m_customShadowMaterials[cacheKey];
+	if (material)
+	{
+		return material;
+	}
+
+	TVector<std::string> defines = sourceMaterial->GetShader()->GetDefines();
+	if (!defines.Contains("SHADOW_CASTER"))
+	{
+		defines.Add("SHADOW_CASTER");
+	}
+	if (bMasked && shaderAsset->GetSupportedDefines().Contains("ALPHA_CUTOUT") &&
+		!defines.Contains("ALPHA_CUTOUT"))
+	{
+		defines.Add("ALPHA_CUTOUT");
+	}
+	if (shadowType == EShadowType::EVSM && !defines.Contains("EVSM"))
+	{
+		defines.Add("EVSM");
+	}
+
+	ShaderSetPtr shadowShader;
+	if (!shaderCompiler->LoadShader_Immediate(
+		sourceMaterial->GetShader()->GetFileId(),
+		shadowShader,
+		defines) || !shadowShader->IsReady())
+	{
+		return nullptr;
+	}
+
+	const auto& sourceState = sourceMaterial->GetRenderState();
+	RenderState shadowState(true,
+		true,
+		sourceState.GetDepthBias(),
+		true,
+		sourceState.GetCullMode(),
+		EBlendMode::None,
+		sourceState.GetFillMode(),
+		GetHash(std::string("Shadow")),
+		false,
+		EDepthCompare::GreaterOrEqual);
+	material = RHI::Renderer::GetDriver()->CreateMaterial(
+		vertexDescription,
+		RHI::EPrimitiveTopology::TriangleList,
+		shadowState,
+		shadowShader,
+		sourceMaterial->GetShaderBindings());
 	return material;
 }
 
@@ -156,6 +232,18 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
 					const bool bMasked = renderQueueTag == maskedQueueTag;
 					auto depthMaterial = GetOrAddShadowMaterial(mesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
+					if (shadowMesh.m_customDepthMaterial)
+					{
+						auto customShadowMaterial = GetOrAddCustomShadowMaterial(
+							shadowMesh.m_customDepthMaterial,
+							mesh->m_vertexDescription,
+							shadowPass.m_shadowType,
+							bMasked);
+						if (customShadowMaterial)
+						{
+							depthMaterial = customShadowMaterial;
+						}
+					}
 
 					const bool bIsDepthMaterialReady = depthMaterial &&
 						depthMaterial->GetVertexShader() &&
@@ -168,13 +256,18 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 
 					ShadowPrepassNode::PerInstanceData data;
 					data.model = shadowMesh.m_worldMatrix;
+					data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+					data.materialInstance = shadowMesh.m_customDepthMaterial &&
+						shadowMesh.m_customDepthMaterial->GetShaderBindings() ?
+						shadowMesh.m_customDepthMaterial->GetShaderBindings()->GetStorageInstanceIndex("material") :
+						0u;
 					data.skeletonOffset = bSkinned ? proxy->m_skeletonOffset : (std::numeric_limits<uint32_t>::max)();
 					data.baseColorFactor = shadowMesh.m_baseColorFactor;
 					data.baseColorSampler = shadowMesh.m_baseColorSampler;
 					data.alphaCutoff = shadowMesh.m_alphaCutoff;
 
 					RHIBatch batch(depthMaterial, mesh);
-					if (bMasked)
+					if (bMasked || depthMaterial->GetRenderState().IsRequiredCustomDepthShader())
 					{
 						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
 #if defined(__APPLE__)
@@ -267,10 +360,26 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 
 		auto shaderBindingsByMaterial = [&](const RHIBatch& batch)
 			{
-				TVector<RHIShaderBindingSetPtr> sets({ sceneView.m_frameBindings, m_perInstanceData });
+				TVector<RHIShaderBindingSetPtr> sets;
+				if (batch.m_material->GetRenderState().IsRequiredCustomDepthShader())
+				{
+					sets = TVector<RHIShaderBindingSetPtr>({
+						sceneView.m_frameBindings,
+						sceneView.m_rhiLightsData,
+						m_perInstanceData,
+						batch.m_material->GetBindings(),
+						batch.m_textureBindings });
+				}
+				else
+				{
+					sets = TVector<RHIShaderBindingSetPtr>({ sceneView.m_frameBindings, m_perInstanceData });
+				}
 				if (batch.m_textureBindings)
 				{
-					sets.Add(batch.m_textureBindings);
+					if (!batch.m_material->GetRenderState().IsRequiredCustomDepthShader())
+					{
+						sets.Add(batch.m_textureBindings);
+					}
 				}
 				const bool bSkinned =
 					batch.m_mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
@@ -484,6 +593,7 @@ void ShadowPrepassNode::Clear()
 	m_maskedShadowMaterials_Evsm.Clear();
 	m_skinnedMaskedShadowMaterials_Pcf.Clear();
 	m_skinnedMaskedShadowMaterials_Evsm.Clear();
+	m_customShadowMaterials.Clear();
 	m_textureBindingCache.Clear();
 }
 

--- a/Runtime/FrameGraph/ShadowPrepassNode.h
+++ b/Runtime/FrameGraph/ShadowPrepassNode.h
@@ -16,15 +16,22 @@ namespace Sailor
 		struct PerInstanceData
 		{
 			glm::mat4 model;
-			glm::vec4 baseColorFactor{ 1.0f };
+			glm::vec4 sphereBounds{};
+			uint32_t materialInstance = 0;
 			uint32_t skeletonOffset = 0;
+			uint32_t bIsCulled = 0;
+			uint32_t padding = 0;
+			glm::vec4 bakedVolumeScale{ 1.0f };
+			glm::vec4 baseColorFactor{ 1.0f };
 			uint32_t baseColorSampler = 0;
 			float alphaCutoff = 0.5f;
-			uint32_t padding = 0;
+			uint32_t maskedPadding = 0;
+			uint32_t stridePadding = 0;
 
 			bool operator==(const PerInstanceData& rhs) const
 			{
 				return model == rhs.model &&
+					materialInstance == rhs.materialInstance &&
 					baseColorFactor == rhs.baseColorFactor &&
 					skeletonOffset == rhs.skeletonOffset &&
 					baseColorSampler == rhs.baseColorSampler &&
@@ -63,8 +70,14 @@ namespace Sailor
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_maskedShadowMaterials_Pcf{};
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedMaskedShadowMaterials_Evsm{};
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedMaskedShadowMaterials_Pcf{};
+		TMap<size_t, RHI::RHIMaterialPtr> m_customShadowMaterials{};
 
 		RHI::RHIMaterialPtr GetOrAddShadowMaterial(RHI::RHIVertexDescriptionPtr vertex, RHI::EShadowType shadowType, bool bSkinned, bool bMasked);
+		RHI::RHIMaterialPtr GetOrAddCustomShadowMaterial(
+			const MaterialPtr& sourceMaterial,
+			RHI::RHIVertexDescriptionPtr vertex,
+			RHI::EShadowType shadowType,
+			bool bMasked);
 
 		// Record drawcalls
 		size_t m_sizePerInstanceData = 0;

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -34,6 +34,7 @@ namespace Sailor::RHI
 		glm::vec4 m_baseColorFactor{ 1.0f };
 		float m_alphaCutoff = 0.5f;
 		uint32_t m_baseColorSampler = 0;
+		MaterialPtr m_customDepthMaterial{};
 #if defined(__APPLE__)
 		TSet<uint32_t> m_materialTextureSamplers{};
 #endif
@@ -167,6 +168,7 @@ namespace Sailor::RHI
 		TVector<Tasks::TaskPtr<RHI::RHICommandListPtr>> m_debugDraw;
 		TVector<RHISceneViewSnapshot> m_snapshots;
 		uint64_t m_shadowCastersRevision = 0;
+		bool m_bHasCustomDepthShadowCasters = false;
 
 		WorldPtr m_world{};
 		float m_deltaTime{};

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1001,6 +1001,23 @@ namespace
 			"a changed cascade projection must invalidate the cached shadow map even for camera motion below the old threshold");
 	}
 
+	void TestCustomDepthShadowCastersInvalidateCsmEveryFrame()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string sceneViewHeader = ReadText(sourceRoot / "Runtime/RHI/SceneView.h");
+		const std::string meshRendererSource = ReadText(sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
+		const std::string lightingSource = ReadText(sourceRoot / "Runtime/ECS/LightingECS.cpp");
+
+		Require(sceneViewHeader.find("bool m_bHasCustomDepthShadowCasters = false") != std::string::npos &&
+			meshRendererSource.find("IsRequiredCustomDepthShader()") != std::string::npos &&
+			meshRendererSource.find("m_bHasCustomDepthShadowCasters = bHasCustomDepthShadowCasters") != std::string::npos,
+			"scene snapshots must identify custom-depth shadow casters");
+		Require(lightingSource.find("bForceCustomDepthShadowUpdate") != std::string::npos &&
+			lightingSource.find("bool bCanReuseAllCascades = !bForceCustomDepthShadowUpdate") != std::string::npos &&
+			lightingSource.find("if (!bForceCustomDepthShadowUpdate &&") != std::string::npos,
+			"custom-depth shadow casters must bypass both CSM snapshot reuse paths every frame");
+	}
+
 	void TestAnimationGpuBoneLayoutContract()
 	{
 		const uint32_t invalidOffset = AnimatorComponentData::InvalidGpuOffset;
@@ -3718,6 +3735,7 @@ int main()
 		{ "StaticMeshProxyTracksMaterialContentRevisions", TestStaticMeshProxyTracksMaterialContentRevisions },
 		{ "CsmSnapshotTracksCastersBeforeDependencyFiltering", TestCsmSnapshotTracksCastersBeforeDependencyFiltering },
 		{ "CsmSnapshotInvalidatesWhenCascadeProjectionMoves", TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves },
+		{ "CustomDepthShadowCastersInvalidateCsmEveryFrame", TestCustomDepthShadowCastersInvalidateCsmEveryFrame },
 		{ "MeshRendererMaterialOverridesAreReflectedAndPersisted", TestMeshRendererMaterialOverridesAreReflectedAndPersisted },
 		{ "AnimationGpuBoneLayoutContract", TestAnimationGpuBoneLayoutContract },
 		{ "ExpiredWorldPrefabInvalidatesLoadedCacheContract", TestExpiredWorldPrefabInvalidatesLoadedCacheContract },

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -5,6 +5,7 @@
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "FrameGraph/DepthPrepassNode.h"
 #include "FrameGraph/RenderSceneNode.h"
+#include "FrameGraph/ShadowPrepassNode.h"
 #include "Raytracing/MaterialUtils.h"
 #include "RHI/Buffer.h"
 #include "RHI/Material.h"
@@ -886,6 +887,53 @@ namespace
 			"ShadowPrepass must select skinned batches and bind the current bone matrices");
 	}
 
+	void TestCustomDepthVertexAnimationReachesShadows()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string sceneViewHeader = ReadText(
+			sourceRoot / "Runtime/RHI/SceneView.h");
+		const std::string meshRendererSource = ReadText(
+			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
+		const std::string shadowPrepassSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
+		const std::string shadowCasterShader = ReadText(
+			sourceRoot / "Content/Shaders/ShadowCaster.shader");
+
+		Require(sceneViewHeader.find("MaterialPtr m_customDepthMaterial") != std::string::npos &&
+			meshRendererSource.find("IsRequiredCustomDepthShader()") != std::string::npos &&
+			meshRendererSource.find("shadowMesh.m_customDepthMaterial = material") != std::string::npos,
+			"shadow proxies must retain the source custom-depth material");
+		Require(shadowPrepassSource.find("GetOrAddCustomShadowMaterial(") != std::string::npos &&
+			shadowPrepassSource.find("GetSupportedDefines().Contains(\"SHADOW_CASTER\")") != std::string::npos &&
+			shadowPrepassSource.find("defines.Add(\"SHADOW_CASTER\")") != std::string::npos &&
+			shadowPrepassSource.find("defines.Add(\"ALPHA_CUTOUT\")") != std::string::npos &&
+			shadowPrepassSource.find("sceneView.m_rhiLightsData") != std::string::npos &&
+			shadowPrepassSource.find("batch.m_material->GetBindings()") != std::string::npos,
+			"supported custom shadow permutations must bind the same frame, light and material data as the forward vertex shader");
+		Require(shadowPrepassSource.find("auto depthMaterial = GetOrAddShadowMaterial(") != std::string::npos &&
+			shadowPrepassSource.find("if (customShadowMaterial)") != std::string::npos &&
+			shadowPrepassSource.find("depthMaterial = customShadowMaterial") != std::string::npos,
+			"unsupported or failed custom shadow permutations must fall back to the working main shadow caster");
+		Require(shadowPrepassSource.find("RHI::RHIMaterialPtr pushConstantsMaterial") != std::string::npos &&
+			shadowPrepassSource.find("PushConstants(commandList, pushConstantsMaterial, 64") != std::string::npos,
+			"custom shadow permutations must preserve the main CSM cascade-matrix recording path");
+		Require(meshRendererSource.find("if (shadowMesh.m_customDepthMaterial)") != std::string::npos &&
+			meshRendererSource.find("for (const auto& sampler : material->GetSamplers())") != std::string::npos &&
+			meshRendererSource.find("shadowMesh.m_materialTextureSamplers.Insert(textureIndex)") != std::string::npos,
+			"custom shadow vertex animation must receive the material texture remap even for opaque casters");
+		Require(shadowCasterShader.find("vec4 sphereBounds;") != std::string::npos &&
+			shadowCasterShader.find("uint materialInstance;") != std::string::npos &&
+			shadowCasterShader.find("vec4 bakedVolumeScale;") != std::string::npos &&
+			shadowCasterShader.find("uint maskedPadding;") != std::string::npos &&
+			shadowCasterShader.find("uint stridePadding;") != std::string::npos,
+			"the default and custom shadow permutations must share the 144-byte shadow instance layout");
+		Require(sizeof(ShadowPrepassNode::PerInstanceData) == 144u &&
+			sizeof(Framegraph::RenderSceneNode::PerInstanceData) == 112u,
+			"CPU instance layouts must match the conditional std430 strides used by the foliage shadow and forward permutations; shadow=" +
+			std::to_string(sizeof(ShadowPrepassNode::PerInstanceData)) +
+			", forward=" + std::to_string(sizeof(Framegraph::RenderSceneNode::PerInstanceData)));
+	}
+
 	void TestVertexDescriptionAttributeIdentityContract()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -1429,6 +1477,7 @@ int main()
 		{ "BakedVolumeScalePerInstanceLayoutContract", TestBakedVolumeScalePerInstanceLayoutContract },
 		{ "DepthPrepassSkinningContract", TestDepthPrepassSkinningContract },
 		{ "ShadowPrepassSkinningContract", TestShadowPrepassSkinningContract },
+		{ "CustomDepthVertexAnimationReachesShadows", TestCustomDepthVertexAnimationReachesShadows },
 		{ "VertexDescriptionAttributeIdentityContract", TestVertexDescriptionAttributeIdentityContract },
 		{ "GraphicsPipelineAttachmentCacheContract", TestGraphicsPipelineAttachmentCacheContract },
 		{ "PostProcessPingPongMipIsolationContract", TestPostProcessPingPongMipIsolationContract },

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -644,9 +644,9 @@ samplers:
 			"valid generated material properties must be mergeable");
 		Require(material["renderQueue"].as<std::string>() == "Transparent" &&
 			!material["bEnableZWrite"].as<bool>() &&
-			!material["bCustomDepthShader"].as<bool>() &&
+			material["bCustomDepthShader"].as<bool>() &&
 			material["blendMode"].as<std::string>() == "None",
-			"alpha and transmission render state must follow the glTF source");
+			"generated render state must preserve authored custom depth shaders");
 		Require(material["cullMode"].as<std::string>() == "Front" &&
 			material["shaderUid"].as<std::string>() == "custom-shader",
 			"unrelated authored render and shader properties must be preserved");
@@ -693,11 +693,21 @@ uniformsFloat:
 			material,
 			opaqueGenerated),
 			"transmission removal must be mergeable");
-		Require(!material["uniformsFloat"]["material.transmissionFactor"] &&
+		Require(material["bCustomDepthShader"].as<bool>() &&
+			!material["uniformsFloat"]["material.transmissionFactor"] &&
 			!material["uniformsFloat"]["material.thicknessFactor"] &&
 			!material["uniformsVec4"]["material.attenuationColor"] &&
 			!material["samplers"]["transmissionSampler"],
-			"removing the glTF extension must remove stale managed properties");
+			"removing glTF extensions must preserve authored custom depth state");
+
+		material["bCustomDepthShader"] = false;
+		YAML::Node cutoutGenerated = YAML::Clone(opaqueGenerated);
+		cutoutGenerated["bCustomDepthShader"] = true;
+		Require(GltfImporterUtils::MergeGeneratedMaterialProperties(
+			material,
+			cutoutGenerated) &&
+			material["bCustomDepthShader"].as<bool>(),
+			"alpha cutout imports must still force custom depth shaders");
 
 		YAML::Node malformed = YAML::Load("defines: INVALID");
 		const YAML::Node malformedBefore = YAML::Clone(malformed);


### PR DESCRIPTION
## What changed

- route custom-depth materials through the shadow prepass so vertex animation and material bindings are shared with shadow rendering
- invalidate cached CSM cascades every frame while custom-depth shadow casters are active
- preserve authored `bCustomDepthShader` when generated glTF material properties are merged
- keep the default shadow instance layout aligned with the custom shadow permutation
- honor `--workspace`, `--workspace-manifest`, and `--world` when the Editor starts
- add Content Browser actions for targeted asset reimport and folder refresh, including workspace and read-only engine roots

## Why

Custom-depth meshes could animate in the forward/depth path while their shadows remained static or disappeared because the shadow prepass replaced their material and reused cached cascades. Reimporting generated materials could also clear an authored custom-depth opt-in.

The Editor additionally ignored workspace launch arguments and did not expose direct refresh/reimport actions, which made standalone workspace iteration unreliable.

## Impact

- animated custom-depth meshes now produce matching, continuously updated CSM shadows
- ordinary and masked shadow casters keep the existing fallback path
- workspaces can be opened directly with an initial world from the command line
- individual assets and Content roots can be refreshed without restarting the Editor

No Maldives scene, demo model, material, water, vegetation, audio, or gameplay content is included. `Content/Shaders/ShadowCaster.shader` is the engine-owned runtime shader required by the C++ layout change.

## Validation

- Debug `SailorLib` build with AppleClang and vcpkg: passed
- Debug Mac Catalyst Editor and MCP bridge build: passed
- `EcsLifecycleContractTests`, `GpuCullingContractTests`, and `ModelImporterContractTests`: 3/3 passed
- `Editor.Contracts.Tests`: 759/759 passed
- full CTest run: 36/37 passed; `WorkspaceModuleRuntimeTests` reports `a module must not claim an owner that is already registered` in the local single-config Unix Makefiles build
- `git diff --check`: passed
