### PR TITLE
Add buoyancy and force-at-position physics API

### DIFF
--- a/Runtime/Components/BuoyancyComponent.cpp
+++ b/Runtime/Components/BuoyancyComponent.cpp
@@ -1,0 +1,75 @@
+#include "Components/BuoyancyComponent.h"
+#include "Math/Math.h"
+#include <algorithm>
+#include <cmath>
+
+using namespace Sailor;
+
+namespace
+{
+	float SanitizeNonNegative(float value, float fallback)
+	{
+		return std::isfinite(value) ? std::max(0.0f, value) : fallback;
+	}
+}
+
+void BuoyancyComponent::SetWaterHeight(float value)
+{
+	if (std::isfinite(value))
+	{
+		m_waterHeight = value;
+	}
+}
+
+void BuoyancyComponent::SetHalfExtents(const glm::vec2& value)
+{
+	if (Math::AllFinite(value))
+	{
+		m_halfExtents = glm::max(glm::abs(value), glm::vec2(0.01f));
+	}
+}
+
+void BuoyancyComponent::SetFloatationPlane(float value)
+{
+	if (std::isfinite(value))
+	{
+		m_floatationPlane = value;
+	}
+}
+
+void BuoyancyComponent::SetEquilibriumDepth(float value)
+{
+	m_equilibriumDepth = std::max(0.01f,
+		SanitizeNonNegative(value, m_equilibriumDepth));
+}
+
+void BuoyancyComponent::SetBuoyancyScale(float value)
+{
+	m_buoyancyScale = SanitizeNonNegative(value, m_buoyancyScale);
+}
+
+void BuoyancyComponent::SetVerticalDamping(float value)
+{
+	m_verticalDamping = SanitizeNonNegative(value, m_verticalDamping);
+}
+
+void BuoyancyComponent::SetWaterDrag(float value)
+{
+	m_waterDrag = SanitizeNonNegative(value, m_waterDrag);
+}
+
+void BuoyancyComponent::SetWaveAmplitude(float value)
+{
+	m_waveAmplitude = SanitizeNonNegative(value, m_waveAmplitude);
+}
+
+void BuoyancyComponent::SetWaveLength(float value)
+{
+	m_waveLength = std::max(0.01f,
+		SanitizeNonNegative(value, m_waveLength));
+}
+
+void BuoyancyComponent::SetWaveSpeed(float value)
+{
+	m_waveSpeed = SanitizeNonNegative(value, m_waveSpeed);
+}

--- a/Runtime/Components/BuoyancyComponent.h
+++ b/Runtime/Components/BuoyancyComponent.h
@@ -1,0 +1,70 @@
+#pragma once
+#include "Components/Component.h"
+
+namespace Sailor
+{
+	class BuoyancyComponent final : public Component
+	{
+		SAILOR_REFLECTABLE(BuoyancyComponent)
+
+	public:
+		SAILOR_API float GetWaterHeight() const { return m_waterHeight; }
+		SAILOR_API void SetWaterHeight(float value);
+		SAILOR_API const glm::vec2& GetHalfExtents() const { return m_halfExtents; }
+		SAILOR_API void SetHalfExtents(const glm::vec2& value);
+		SAILOR_API float GetFloatationPlane() const { return m_floatationPlane; }
+		SAILOR_API void SetFloatationPlane(float value);
+		SAILOR_API float GetEquilibriumDepth() const { return m_equilibriumDepth; }
+		SAILOR_API void SetEquilibriumDepth(float value);
+		SAILOR_API float GetBuoyancyScale() const { return m_buoyancyScale; }
+		SAILOR_API void SetBuoyancyScale(float value);
+		SAILOR_API float GetVerticalDamping() const { return m_verticalDamping; }
+		SAILOR_API void SetVerticalDamping(float value);
+		SAILOR_API float GetWaterDrag() const { return m_waterDrag; }
+		SAILOR_API void SetWaterDrag(float value);
+		SAILOR_API float GetWaveAmplitude() const { return m_waveAmplitude; }
+		SAILOR_API void SetWaveAmplitude(float value);
+		SAILOR_API float GetWaveLength() const { return m_waveLength; }
+		SAILOR_API void SetWaveLength(float value);
+		SAILOR_API float GetWaveSpeed() const { return m_waveSpeed; }
+		SAILOR_API void SetWaveSpeed(float value);
+
+	private:
+		float m_waterHeight = 0.0f;
+		glm::vec2 m_halfExtents = glm::vec2(0.65f, 1.45f);
+		float m_floatationPlane = 0.25f;
+		float m_equilibriumDepth = 0.28f;
+		float m_buoyancyScale = 1.05f;
+		float m_verticalDamping = 5.5f;
+		float m_waterDrag = 1.8f;
+		float m_waveAmplitude = 0.36f;
+		float m_waveLength = 13.0f;
+		float m_waveSpeed = 0.62f;
+	};
+}
+
+using namespace Sailor::Attributes;
+
+REFL_AUTO(
+	type(Sailor::BuoyancyComponent, bases<Sailor::Component>),
+	func(GetWaterHeight, property("waterHeight")),
+	func(SetWaterHeight, property("waterHeight")),
+	func(GetHalfExtents, property("halfExtents")),
+	func(SetHalfExtents, property("halfExtents")),
+	func(GetFloatationPlane, property("floatationPlane")),
+	func(SetFloatationPlane, property("floatationPlane")),
+	func(GetEquilibriumDepth, property("equilibriumDepth")),
+	func(SetEquilibriumDepth, property("equilibriumDepth")),
+	func(GetBuoyancyScale, property("buoyancyScale")),
+	func(SetBuoyancyScale, property("buoyancyScale")),
+	func(GetVerticalDamping, property("verticalDamping")),
+	func(SetVerticalDamping, property("verticalDamping")),
+	func(GetWaterDrag, property("waterDrag")),
+	func(SetWaterDrag, property("waterDrag")),
+	func(GetWaveAmplitude, property("waveAmplitude")),
+	func(SetWaveAmplitude, property("waveAmplitude")),
+	func(GetWaveLength, property("waveLength")),
+	func(SetWaveLength, property("waveLength")),
+	func(GetWaveSpeed, property("waveSpeed")),
+	func(SetWaveSpeed, property("waveSpeed"))
+)

--- a/Runtime/Components/RigidBodyComponent.cpp
+++ b/Runtime/Components/RigidBodyComponent.cpp
@@ -201,3 +201,17 @@ void RigidBodyComponent::SetAngularVelocity(const glm::vec3& value)
 		}
 	}
 }
+
+bool RigidBodyComponent::AddForceAtPosition(
+	const glm::vec3& force,
+	const glm::vec3& worldPosition)
+{
+	if (m_handle == ECS::InvalidIndex ||
+		!Math::AllFinite(force) || !Math::AllFinite(worldPosition))
+	{
+		return false;
+	}
+
+	return GetOwner()->GetWorld()->GetECS<PhysicsECS>()
+		->AddForceAtPosition(m_handle, force, worldPosition);
+}

--- a/Runtime/Components/RigidBodyComponent.h
+++ b/Runtime/Components/RigidBodyComponent.h
@@ -37,6 +37,9 @@ namespace Sailor
 		SAILOR_API void SetLinearVelocity(const glm::vec3& value);
 		SAILOR_API const glm::vec3& GetAngularVelocity() const { return m_angularVelocity; }
 		SAILOR_API void SetAngularVelocity(const glm::vec3& value);
+		SAILOR_API bool AddForceAtPosition(
+			const glm::vec3& force,
+			const glm::vec3& worldPosition);
 
 		SAILOR_API void MarkPhysicsDirty();
 		SAILOR_API size_t GetComponentIndex() const { return m_handle; }

--- a/Runtime/ECS/PhysicsECS.cpp
+++ b/Runtime/ECS/PhysicsECS.cpp
@@ -4,6 +4,7 @@
 #include "Physics/JoltRuntime.h"
 #include "Components/RigidBodyComponent.h"
 #include "Components/CollisionShapeComponent.h"
+#include "Components/BuoyancyComponent.h"
 #include "Engine/GameObject.h"
 #include "Engine/World.h"
 #include "Math/Transform.h"
@@ -12,6 +13,69 @@
 #include <cmath>
 
 using namespace Sailor;
+
+namespace
+{
+	constexpr float c_gravity = 9.81f;
+	constexpr float c_twoPi = 6.28318530718f;
+
+	float AddOceanWave(
+		const glm::vec2& position,
+		glm::vec2 direction,
+		float amplitude,
+		float waveLength,
+		float speed,
+		float phaseOffset,
+		float time)
+	{
+		direction = glm::normalize(direction);
+		const float frequency = c_twoPi / std::max(waveLength, 0.01f);
+		const float angularVelocity = std::sqrt(c_gravity * frequency) * speed;
+		return amplitude * std::sin(
+			frequency * glm::dot(direction, position) -
+			angularVelocity * time + phaseOffset);
+	}
+
+	float SampleOceanHeight(
+		const glm::vec2& position,
+		const BuoyancyComponent& buoyancy,
+		float time)
+	{
+		const glm::vec2 wind = glm::normalize(glm::vec2(0.94f, 0.34f));
+		const glm::vec2 acrossWind(-wind.y, wind.x);
+		glm::vec2 warpedPosition = position;
+		warpedPosition += wind * std::sin(glm::dot(position, acrossWind) *
+			0.075f + time * 0.08f) * 1.15f;
+		warpedPosition += acrossWind * std::sin(glm::dot(position, wind) *
+			0.052f - time * 0.055f) * 0.72f;
+		const float waveGroup = 0.76f + 0.24f * std::sin(glm::dot(position,
+			glm::normalize(glm::vec2(0.31f, 0.95f))) * 0.115f +
+			time * 0.12f);
+		const float amplitude = buoyancy.GetWaveAmplitude();
+		const float waveLength = buoyancy.GetWaveLength();
+		const float speed = buoyancy.GetWaveSpeed();
+
+		float height = buoyancy.GetWaterHeight();
+		height += AddOceanWave(warpedPosition, wind,
+			amplitude * 0.72f * waveGroup, waveLength * 1.37f,
+			speed * 0.84f, 0.37f, time);
+		height += AddOceanWave(warpedPosition,
+			glm::normalize(wind + acrossWind * 0.31f), amplitude * 0.38f,
+			waveLength * 0.83f, speed * 0.98f, 2.11f, time);
+		height += AddOceanWave(warpedPosition,
+			glm::normalize(wind - acrossWind * 0.43f), amplitude * 0.27f,
+			waveLength * 0.59f, speed * 1.09f, 4.73f, time);
+		height += AddOceanWave(position,
+			glm::normalize(wind + acrossWind * 0.72f), amplitude * 0.16f,
+			waveLength * 0.41f, speed * 1.22f, 1.29f, time);
+		height += AddOceanWave(position,
+			glm::normalize(wind - acrossWind * 0.81f), amplitude * 0.10f,
+			waveLength * 0.27f, speed * 1.38f, 5.62f, time);
+		height += AddOceanWave(position, acrossWind, amplitude * 0.055f,
+			waveLength * 0.18f, speed * 1.57f, 3.44f, time);
+		return height;
+	}
+}
 
 PhysicsECS::PhysicsECS() = default;
 PhysicsECS::~PhysicsECS() = default;
@@ -212,6 +276,103 @@ void PhysicsECS::SyncAuthoredTransforms(float fixedDeltaTime)
 	}
 }
 
+void PhysicsECS::ApplyBuoyancyForces(
+	float sampleTime,
+	float fixedDeltaTime)
+{
+	constexpr glm::vec2 sampleOffsets[] =
+	{
+		glm::vec2(-1.0f, -1.0f),
+		glm::vec2(1.0f, -1.0f),
+		glm::vec2(-1.0f, 1.0f),
+		glm::vec2(1.0f, 1.0f),
+		glm::vec2(0.0f, 0.0f)
+	};
+	constexpr float numSamples = static_cast<float>(
+		std::size(sampleOffsets));
+
+	for (auto& data : m_components)
+	{
+		if (!data.m_bIsActive ||
+			data.m_motionType != Physics::ERigidBodyMotionType::Dynamic ||
+			data.m_bodyId == RigidBodyData::InvalidBodyId)
+		{
+			continue;
+		}
+
+		auto gameObject = data.m_owner.StaticCast<GameObject>();
+		auto buoyancy = gameObject
+			? gameObject->GetComponent<BuoyancyComponent>()
+			: TObjectPtr<BuoyancyComponent>{};
+		auto rigidBody = gameObject
+			? gameObject->GetComponent<RigidBodyComponent>()
+			: TObjectPtr<RigidBodyComponent>{};
+		if (!buoyancy || !rigidBody)
+		{
+			continue;
+		}
+
+		Physics::PhysicsBodyPose pose{};
+		if (!m_physicsWorld->GetBodyPose(data.m_bodyId, pose))
+		{
+			continue;
+		}
+
+		const float massPerSample = rigidBody->GetMass() / numSamples;
+		const glm::vec2 halfExtents = buoyancy->GetHalfExtents();
+		for (const glm::vec2& offset : sampleOffsets)
+		{
+			const glm::vec3 localPoint(
+				offset.x * halfExtents.x,
+				buoyancy->GetFloatationPlane(),
+				offset.y * halfExtents.y);
+			const glm::vec3 worldPoint = pose.m_position +
+				pose.m_rotation * localPoint;
+			const glm::vec2 waterPosition(worldPoint.x, worldPoint.z);
+			const float waterHeight = SampleOceanHeight(
+				waterPosition,
+				*buoyancy,
+				sampleTime);
+			const float submersion = waterHeight - worldPoint.y;
+			if (submersion <= 0.0f)
+			{
+				continue;
+			}
+
+			const float previousWaterHeight = SampleOceanHeight(
+				waterPosition,
+				*buoyancy,
+				sampleTime - fixedDeltaTime);
+			const float waterVerticalVelocity =
+				(waterHeight - previousWaterHeight) / fixedDeltaTime;
+			const glm::vec3 leverArm = worldPoint - pose.m_position;
+			const glm::vec3 pointVelocity = pose.m_linearVelocity +
+				glm::cross(pose.m_angularVelocity, leverArm);
+			const float immersion = std::clamp(submersion /
+				buoyancy->GetEquilibriumDepth(), 0.0f, 2.5f);
+			float lift = massPerSample * c_gravity *
+				buoyancy->GetBuoyancyScale() * immersion;
+			lift += massPerSample * buoyancy->GetVerticalDamping() *
+				(waterVerticalVelocity - pointVelocity.y) *
+				std::min(immersion, 1.0f);
+			lift = std::clamp(lift, 0.0f,
+				massPerSample * c_gravity * 3.0f);
+
+			const glm::vec3 horizontalVelocity(
+				pointVelocity.x,
+				0.0f,
+				pointVelocity.z);
+			const glm::vec3 drag = -horizontalVelocity *
+				massPerSample * buoyancy->GetWaterDrag() *
+				std::min(immersion, 1.0f);
+			m_physicsWorld->AddForceAtPosition(
+				data.m_bodyId,
+				drag + glm::vec3(0.0f, lift, 0.0f),
+				worldPoint);
+		}
+	}
+}
+
 void PhysicsECS::ApplyDynamicTransforms(float interpolationAlpha)
 {
 	TVector<size_t> updatedComponents;
@@ -329,6 +490,9 @@ Tasks::ITaskPtr PhysicsECS::Tick(float deltaTime)
 					}
 				}
 
+				const float sampleTime = GetWorld()->GetTime() -
+					static_cast<float>(numSteps - step - 1) * m_fixedDeltaTime;
+				ApplyBuoyancyForces(sampleTime, m_fixedDeltaTime);
 				bStepSucceeded &= m_physicsWorld->Step(m_fixedDeltaTime);
 				for (auto& data : m_components)
 				{
@@ -371,6 +535,24 @@ bool PhysicsECS::Raycast(
 			distance,
 			outHit,
 			collisionMask);
+}
+
+bool PhysicsECS::AddForceAtPosition(
+	size_t componentIndex,
+	const glm::vec3& force,
+	const glm::vec3& worldPosition)
+{
+	if (!m_physicsWorld || !IsComponentRegistered(componentIndex))
+	{
+		return false;
+	}
+
+	const auto& data = GetComponentData(componentIndex);
+	return data.m_bodyId != RigidBodyData::InvalidBodyId &&
+		m_physicsWorld->AddForceAtPosition(
+			data.m_bodyId,
+			force,
+			worldPosition);
 }
 
 void PhysicsECS::SetLayerCollisionEnabled(

--- a/Runtime/ECS/PhysicsECS.h
+++ b/Runtime/ECS/PhysicsECS.h
@@ -54,6 +54,10 @@ namespace Sailor
 			uint8_t secondLayer) const;
 		void DrainContactEvents(
 			TVector<Physics::PhysicsContactEvent>& outEvents);
+		bool AddForceAtPosition(
+			size_t componentIndex,
+			const glm::vec3& force,
+			const glm::vec3& worldPosition);
 
 		void SetFixedDeltaTime(float value);
 		float GetFixedDeltaTime() const { return m_fixedDeltaTime; }
@@ -72,6 +76,7 @@ namespace Sailor
 			size_t index,
 			Physics::RigidBodyDesc& outDesc);
 		void SyncAuthoredTransforms(float fixedDeltaTime);
+		void ApplyBuoyancyForces(float sampleTime, float fixedDeltaTime);
 		void ApplyDynamicTransforms(float interpolationAlpha);
 
 		TUniquePtr<Physics::PhysicsWorld> m_physicsWorld{};

--- a/Runtime/Physics/PhysicsWorld.cpp
+++ b/Runtime/Physics/PhysicsWorld.cpp
@@ -698,6 +698,32 @@ bool Physics::PhysicsWorld::SetBodyVelocity(
 	return true;
 }
 
+bool Physics::PhysicsWorld::AddForceAtPosition(
+	uint32_t bodyId,
+	const glm::vec3& force,
+	const glm::vec3& position)
+{
+	if (bodyId == JPH::BodyID::cInvalidBodyID ||
+		!Math::AllFinite(force) || !Math::AllFinite(position))
+	{
+		return false;
+	}
+
+	const JPH::BodyID id(bodyId);
+	auto& bodyInterface = m_pImpl->m_physicsSystem.GetBodyInterface();
+	if (!bodyInterface.IsAdded(id))
+	{
+		return false;
+	}
+
+	bodyInterface.AddForce(
+		id,
+		ToJolt(force),
+		ToJoltPosition(position),
+		JPH::EActivation::Activate);
+	return true;
+}
+
 bool Physics::PhysicsWorld::Step(float deltaTime)
 {
 	if (!std::isfinite(deltaTime) || deltaTime <= 0.0f)

--- a/Runtime/Physics/PhysicsWorld.h
+++ b/Runtime/Physics/PhysicsWorld.h
@@ -31,6 +31,10 @@ namespace Sailor::Physics
 			uint32_t bodyId,
 			const glm::vec3& linearVelocity,
 			const glm::vec3& angularVelocity);
+		SAILOR_API bool AddForceAtPosition(
+			uint32_t bodyId,
+			const glm::vec3& force,
+			const glm::vec3& position);
 		SAILOR_API bool Step(float deltaTime);
 		SAILOR_API bool Raycast(
 			const glm::vec3& origin,

--- a/Tests/PhysicsRuntimeTests.cpp
+++ b/Tests/PhysicsRuntimeTests.cpp
@@ -1,5 +1,6 @@
 #include "Tasks/Tasks.h"
 #include "Components/CollisionShapeComponent.h"
+#include "Components/BuoyancyComponent.h"
 #include "Components/RigidBodyComponent.h"
 #include "Core/Reflection.h"
 #include "ECS/PhysicsECS.h"
@@ -546,6 +547,15 @@ namespace
 			"collision shape should expose typed primitive authoring fields: " +
 				shapeType.Properties()["shapeType"] + ", " +
 				shapeType.Properties()["center"]);
+
+		const TypeInfo& buoyancyType = TypeInfo::Get<BuoyancyComponent>();
+		Require(
+			buoyancyType.Name() == "Sailor::BuoyancyComponent" &&
+				!buoyancyType.Properties()["halfExtents"].empty() &&
+				buoyancyType.Properties()["waveAmplitude"] == "float",
+			"buoyancy should expose Editor-compatible hull and wave fields: " +
+				buoyancyType.Properties()["halfExtents"] + ", " +
+				buoyancyType.Properties()["waveAmplitude"]);
 	}
 
 	void TestComponentTeardownOrdering()
@@ -564,6 +574,38 @@ namespace
 			owner->GetComponents().IsEmpty(),
 			"full object teardown should not access a destroyed rigid body");
 		world.Clear();
+	}
+
+	void TestForceAtPositionAppliesLinearAndAngularImpulse()
+	{
+		Physics::PhysicsWorld world;
+		uint32_t bodyId = ~0u;
+		Physics::RigidBodyDesc body = MakeBox(
+			InstanceId::GenerateNewInstanceId(),
+			Physics::ERigidBodyMotionType::Dynamic,
+			glm::vec3(0.0f),
+			glm::vec3(1.0f));
+		body.m_mass = 1.0f;
+		Require(world.CreateBody(body, bodyId),
+			"dynamic force test body should be created");
+		for (uint32_t step = 0; step < 60; ++step)
+		{
+			Require(world.AddForceAtPosition(
+				bodyId,
+				glm::vec3(0.0f, 14.0f, 0.0f),
+				glm::vec3(0.4f, 0.0f, 0.0f)),
+				"force should be accepted for a live body");
+			Require(world.Step(c_fixedDeltaTime),
+				"force physics step should succeed");
+		}
+
+		Physics::PhysicsBodyPose pose{};
+		Require(world.GetBodyPose(bodyId, pose),
+			"force test pose should be readable");
+		Require(
+			pose.m_position.y > 0.5f &&
+				std::abs(pose.m_angularVelocity.z) > 0.01f,
+			"off-center force should create linear motion and torque");
 	}
 
 	struct PhysicsSceneStats final
@@ -878,6 +920,7 @@ int main()
 		{ "WorldPoseToLocalForTransformedParent", TestWorldPoseToLocalForTransformedParent },
 		{ "ReflectedPhysicsAuthoringContract", TestReflectedPhysicsAuthoringContract },
 		{ "ComponentTeardownOrdering", TestComponentTeardownOrdering },
+		{ "ForceAtPositionAppliesLinearAndAngularImpulse", TestForceAtPositionAppliesLinearAndAngularImpulse },
 		{ "PhysicsSceneFixtures", TestPhysicsSceneFixtures },
 	};
 


### PR DESCRIPTION
## Summary

- add a reflected `Sailor::BuoyancyComponent` with configurable hull, damping, drag, and wave parameters
- apply multi-point buoyancy and water drag during fixed physics steps
- expose `AddForceAtPosition` through `PhysicsWorld`, `PhysicsECS`, and `RigidBodyComponent`
- add physics runtime coverage for reflected buoyancy fields and off-center force behavior

## Why

Workspace modules such as `DemoMaldives` need a stable engine API for applying forces at world-space positions. Keeping that API and the reusable buoyancy component in the runtime avoids requiring project modules to patch engine internals or link against private physics implementation details.

## Impact

Dynamic rigid bodies can opt into buoyancy by adding `Sailor::BuoyancyComponent`. Project logic can also apply forces at world-space points through `RigidBodyComponent::AddForceAtPosition`, producing both linear acceleration and torque.

No `Content/**` files or demo-specific project files are included.

## Validation

- `python3 update_deps.py`
- `cmake -S . -B build-mac-vcpkg -G Xcode -DCMAKE_TOOLCHAIN_FILE=External/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=arm64-osx -DSAILOR_BUILD_TESTS=ON`
- `cmake --build build-mac-vcpkg --target PhysicsRuntimeTests --config Debug --parallel 10`
- `./Binaries/Debug/PhysicsRuntimeTests` (all tests passed)
- `git diff --cached --check`