### PR TITLE
Fix editor workflows, LOD coverage, and sky rendering

### DIFF
--- a/Content/Shaders/Sky.shader
+++ b/Content/Shaders/Sky.shader
@@ -452,12 +452,16 @@ glslFragment: |
     vec3 shift1 = vec3(-0.0021, 0.0017, -0.02f) * frame.currentTime * -0.5;
     vec3 shift2 = vec3(0.021, 0.017, 0.0f) * frame.currentTime * -0.2;
     
-    const float cloudsLow = pow(texture(cloudsNoiseLowSampler, shift1 + position.xyz / 9000.0f).r, 1);
-    const float cloudsHigh = pow(texture(cloudsNoiseHighSampler, shift2 + position.xyz / 1300.0f).r, 1);
+    // Implicit derivatives are undefined in this divergent ray-march path and
+    // produced different mip selection on native Vulkan and Metal/MoltenVK.
+    const float cloudsLow = textureLod(cloudsNoiseLowSampler,
+      shift1 + position.xyz / 9000.0f, 0.0f).r;
+    const float cloudsHigh = textureLod(cloudsNoiseHighSampler,
+      shift2 + position.xyz / 1300.0f, 0.0f).r;
 
     vec2 uv = position.xz / 409600.0f + vec2(0.2, 0.1);
 
-    vec4 weather = texture(cloudsMapSampler, uv);
+    vec4 weather = textureLod(cloudsMapSampler, uv, 0.0f);
 
     float height = CloudsGetHeight(position);
     

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -3,26 +3,29 @@ namespace Editor.Tests;
 public sealed class EngineLifecycleTests
 {
     [Fact]
-    public void ManagedPlayLaunch_UsesCMakeRuntimeOutputDirectoryOnNonWindowsHosts()
+    public void ManagedPlayLaunch_UsesConfigurationSpecificCMakeOutputOnMacCatalyst()
     {
         var source = ReadRepositoryFile("Editor", "Services", "EngineService.cs");
 
         Assert.Contains(
-            "Path.Combine(EngineWorkingDirectory, \"Binaries\", \"SailorEngine-Debug\")",
+            "\"Debug\",\n                    \"SailorEngine-Debug\")",
             source,
             StringComparison.Ordinal);
         Assert.Contains(
-            "Path.Combine(EngineWorkingDirectory, \"Binaries\", \"SailorEngine-Release\")",
+            "\"Release\",\n                    \"SailorEngine-Release\")",
             source,
             StringComparison.Ordinal);
-        Assert.DoesNotContain(
-            "Path.Combine(EngineWorkingDirectory, \"Binaries\", \"Debug\", \"SailorEngine-Debug\")",
-            source,
-            StringComparison.Ordinal);
-        Assert.DoesNotContain(
-            "Path.Combine(EngineWorkingDirectory, \"Binaries\", \"Release\", \"SailorEngine-Release\")",
-            source,
-            StringComparison.Ordinal);
+        Assert.Contains("#elif MACCATALYST", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EditorBuildEntryPoints_BuildStandaloneExecutableForPlay()
+    {
+        var runEditor = ReadRepositoryFile("run_editor.py");
+        var buildEditor = ReadRepositoryFile("build_editor.py");
+
+        Assert.Contains("\"--target\",\n        \"SailorExec\"", runEditor, StringComparison.Ordinal);
+        Assert.Contains("\"--target\",\n        \"SailorExec\"", buildEditor, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -1391,7 +1394,28 @@ public sealed class EngineLifecycleTests
         Assert.Contains("await EnsureAssetDirectoryLoadedAsync(", assetsSource, StringComparison.Ordinal);
         Assert.Contains("await service.ResolveAssetAsync(file.FileId)", contentViewSource, StringComparison.Ordinal);
         Assert.Contains("QueueAssetCacheIndexLoad(launchContext, contentGeneration)", assetsSource, StringComparison.Ordinal);
-        Assert.Contains("MergeAssetCacheIndex(result.Entries!)", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("? PrepareAssetCacheIndex(", assetsSource, StringComparison.Ordinal);
+        Assert.Contains("MergeAssetCacheIndex(backgroundResult.PreparedEntries)", assetsSource, StringComparison.Ordinal);
+        var backgroundLoad = assetsSource.IndexOf(
+            "var backgroundResult = await Task.Run(",
+            StringComparison.Ordinal);
+        var backgroundPreparation = assetsSource.IndexOf(
+            "? PrepareAssetCacheIndex(",
+            backgroundLoad,
+            StringComparison.Ordinal);
+        var uiPublication = assetsSource.IndexOf(
+            "await MainThread.InvokeOnMainThreadAsync(",
+            backgroundPreparation,
+            StringComparison.Ordinal);
+        var uiMerge = assetsSource.IndexOf(
+            "MergeAssetCacheIndex(backgroundResult.PreparedEntries)",
+            uiPublication,
+            StringComparison.Ordinal);
+        Assert.True(
+            backgroundLoad >= 0 &&
+            backgroundPreparation > backgroundLoad &&
+            uiPublication > backgroundPreparation &&
+            uiMerge > uiPublication);
         Assert.Contains("Files.Add(file)", assetsSource, StringComparison.Ordinal);
         Assert.Contains("Assets[file.FileId] = file", assetsSource, StringComparison.Ordinal);
         Assert.Contains("producerIdentity", cacheIndexSource, StringComparison.Ordinal);

--- a/Editor.Tests/ModelFingerprintTests.cs
+++ b/Editor.Tests/ModelFingerprintTests.cs
@@ -39,6 +39,60 @@ public sealed class ModelFingerprintTests
     }
 
     [Fact]
+    public void AssetReferences_UseSharedAsyncFingerprintPreviews()
+    {
+        var service = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "AssetFingerprintService.cs");
+        var preview = ReadRepositoryFile(
+            "Editor",
+            "Controls",
+            "AssetPreviewImage.cs");
+        var templates = ReadRepositoryFile(
+            "Editor",
+            "Utility",
+            "Templates.cs");
+        var texture = ReadRepositoryFile(
+            "Editor",
+            "ViewModels",
+            "TextureFile.cs");
+        var converter = ReadRepositoryFile(
+            "Editor",
+            "Controls",
+            "FileIdToPreviewTextureConverter.cs");
+        var fileIdEditor = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "Elements",
+            "FileIdEditor.xaml");
+        var materialTemplate = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "InspectorView",
+            "MaterialFileTemplate.xaml");
+
+        Assert.Contains("\"Fingerprints\"", service, StringComparison.Ordinal);
+        Assert.Contains("GlbExtractor.ExtractTextureFromGLB(", service, StringComparison.Ordinal);
+        Assert.Contains("GenerateGlbFingerprint(", service, StringComparison.Ordinal);
+        Assert.Contains("await Task.Run(", service, StringComparison.Ordinal);
+        Assert.Contains("File.Move(temporaryPath, fingerprintPath, true)", service, StringComparison.Ordinal);
+        Assert.Contains("File.GetLastWriteTimeUtc(fingerprintPath)", service, StringComparison.Ordinal);
+        Assert.Contains("LoadTexturePreviewAsync(this, cancellationToken)", texture, StringComparison.Ordinal);
+        Assert.Contains("class AssetPreviewImage", preview, StringComparison.Ordinal);
+        Assert.Contains("new FileId()", preview, StringComparison.Ordinal);
+        Assert.Contains("ResolveAssetAsync(", preview, StringComparison.Ordinal);
+        Assert.Contains("LoadPreviewAsync(asset, cancellation.Token)", preview, StringComparison.Ordinal);
+        Assert.True(
+            CountOccurrences(templates, "new AssetPreviewImage") >= 2,
+            "Both texture fields and general FileId fields must use the shared preview control.");
+        Assert.Contains("AssetPreviewImage.FileIdProperty", templates, StringComparison.Ordinal);
+        Assert.Contains("<controls:AssetPreviewImage", fileIdEditor, StringComparison.Ordinal);
+        Assert.Contains("<controls:AssetPreviewImage", materialTemplate, StringComparison.Ordinal);
+        Assert.Contains("TryGetCachedPreview(outAsset)", converter, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Inspector_UsesParentScrollerForAnimations()
     {
         var template = ReadRepositoryFile(
@@ -109,5 +163,18 @@ public sealed class ModelFingerprintTests
         throw new FileNotFoundException(
             $"Could not find repository file: " +
             $"{Path.Combine(relativePath)}");
+    }
+
+    static int CountOccurrences(string source, string value)
+    {
+        var count = 0;
+        var index = 0;
+        while ((index = source.IndexOf(value, index, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            index += value.Length;
+        }
+
+        return count;
     }
 }

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -876,6 +876,38 @@ public sealed class WorkflowProjectionTests
     }
 
     [Fact]
+    public void FloatEditors_ApplyTextOnlyAfterEditingFinishes()
+    {
+        var templatesSource = ReadRepositoryFile(
+            "Editor",
+            "Utility",
+            "Templates.cs");
+        var floatEditor = Slice(
+            templatesSource,
+            "static Entry CreateFloatEditor<TBindingContext>(",
+            "public static View RangedFloatEditor<TBindingContext>(");
+        var deferredInteraction = Slice(
+            templatesSource,
+            "static void ConfigureDeferredFloatEntry<TBindingContext>(",
+            "public static View RangedFloatEditor<TBindingContext>(");
+
+        Assert.Contains(
+            "ConfigureDeferredFloatEntry(",
+            floatEditor,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "mode: BindingMode.OneWay",
+            floatEditor,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            deferredInteraction,
+            "entry.Unfocused +=",
+            "float.TryParse(",
+            "setter(bindingContext, parsedValue);",
+            "ScheduleInspectorCommit(current);");
+    }
+
+    [Fact]
     public void WorldProjectionRefresh_DropsStaleSelectionBeforePublishing()
     {
         var worldSource = ReadRepositoryFile("Editor", "Services", "WorldService.cs");
@@ -1736,6 +1768,111 @@ public sealed class WorkflowProjectionTests
             "NumberOfTapsRequired = 2",
             "SelectHierarchyRowAsync(",
             "FocusGameObjectAsync(row)");
+    }
+
+    [Fact]
+    public void InspectorReferences_UseSharedNavigationAndComponentsSelectTheirOwner()
+    {
+        var selectionSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "SelectionService.cs");
+        var navigation = Slice(
+            selectionSource,
+            "public async Task<bool> NavigateToReferenceAsync(",
+            "public async Task SelectObjectAsync(");
+        var targetResolution = Slice(
+            selectionSource,
+            "static GameObject? ResolveSceneReferenceTarget(",
+            "static string? TryGetSelectionId");
+        var fileBehavior = ReadRepositoryFile(
+            "Editor",
+            "Controls",
+            "FileIdSelectBehavior.cs");
+        var instanceBehavior = ReadRepositoryFile(
+            "Editor",
+            "Controls",
+            "InstanceIdSelectBehavior.cs");
+
+        Assert.Contains("Observable<FileId>", navigation, StringComparison.Ordinal);
+        Assert.Contains("Observable<InstanceId>", navigation, StringComparison.Ordinal);
+        Assert.Contains("ObjectPtr objectPtr", navigation, StringComparison.Ordinal);
+        Assert.Contains("AssetFile assetFile", navigation, StringComparison.Ordinal);
+        Assert.Contains("Component component => worldService.FindOwner(component)", navigation, StringComparison.Ordinal);
+        AssertInOrder(
+            targetResolution,
+            "TryGetGameObject(instanceId",
+            "TryGetComponent(instanceId",
+            "worldService.FindOwner(component)");
+        Assert.Contains(
+            ".NavigateToReferenceAsync(BoundProperty)",
+            fileBehavior,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            ".NavigateToReferenceAsync(BoundProperty)",
+            instanceBehavior,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("SelectInstance(id)", instanceBehavior, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ComponentContextMenu_CopyPasteValuesPreservesIdentityAndUsesHistory()
+    {
+        var templateSource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "InspectorView",
+            "ComponentTemplate.cs");
+        var clipboardSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "ComponentClipboardService.cs");
+        var worldServiceSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "WorldService.cs");
+        var menu = Slice(
+            templateSource,
+            "var contextItems = new[]",
+            "var flyout = contextMenuService.CreateFlyout(");
+        var merge = Slice(
+            clipboardSource,
+            "internal static string MergeValues(",
+            "return EditorYaml.SerializeComponent(destination);");
+
+        AssertInOrder(
+            menu,
+            "Text = \"Copy Values\"",
+            "clipboardService.CopyValuesAsync(component)",
+            "Text = \"Paste Values\"",
+            "clipboardService.PasteValuesAsync(component)",
+            "Text = \"Reset to Defaults\"",
+            "Text = \"Remove Component\"");
+        Assert.Equal(
+            4,
+            CountOccurrences(
+                templateSource,
+                "contextMenuService.CreateFlyout(contextItems)"));
+        Assert.Contains("EditorYaml.SerializeComponent(component)", clipboardSource, StringComparison.Ordinal);
+        Assert.Contains("copiedValuesYaml = EditorYaml.SerializeComponent(component)", clipboardSource, StringComparison.Ordinal);
+        Assert.Contains("var clipboardText = copiedValuesYaml", clipboardSource, StringComparison.Ordinal);
+        Assert.Contains("new UpdateComponentCommand(", clipboardSource, StringComparison.Ordinal);
+        Assert.Contains("dispatcher.DispatchAsync(", clipboardSource, StringComparison.Ordinal);
+        Assert.Contains("IdentityProperties.Contains(property.Key)", merge, StringComparison.Ordinal);
+        Assert.Contains("EditorComponentPropertyAccess.Writable", merge, StringComparison.Ordinal);
+        Assert.Contains("new ComponentYamlConverter()", merge, StringComparison.Ordinal);
+        Assert.Contains("Deserialize<Component>(clipboardYaml)", merge, StringComparison.Ordinal);
+        Assert.Contains("EditorYaml.SerializeComponent(destination)", clipboardSource, StringComparison.Ordinal);
+        Assert.Contains("source.Typename", merge, StringComparison.Ordinal);
+        Assert.Contains("target.Typename.Name", merge, StringComparison.Ordinal);
+        Assert.Contains("SetStatus($\"Pasted", clipboardSource, StringComparison.Ordinal);
+        AssertInOrder(
+            Slice(
+                worldServiceSource,
+                "public bool ApplyComponentYamlLocal(",
+                "public IEnumerable<GameObject> EnumerateSubHierarchy("),
+            "owner.NotifyComponentsChanged();",
+            "PublishCurrentWorld();");
     }
 
     static void AssertCommitClearsDirtyBeforeDispatch(string source)

--- a/Editor/Controls/AssetPreviewImage.cs
+++ b/Editor/Controls/AssetPreviewImage.cs
@@ -1,0 +1,100 @@
+using SailorEditor.Services;
+using SailorEngine;
+
+namespace SailorEditor.Controls;
+
+public sealed class AssetPreviewImage : Image
+{
+    CancellationTokenSource? previewCancellation;
+
+    public static readonly BindableProperty FileIdProperty =
+        BindableProperty.Create(
+            nameof(FileId),
+            typeof(FileId),
+            typeof(AssetPreviewImage),
+            new FileId(),
+            propertyChanged: OnFileIdChanged);
+
+    public FileId FileId
+    {
+        get => (FileId)GetValue(FileIdProperty);
+        set => SetValue(FileIdProperty, value);
+    }
+
+    public AssetPreviewImage()
+    {
+        Aspect = Aspect.AspectFit;
+        IsVisible = false;
+        Unloaded += (_, _) => CancelPendingPreview();
+    }
+
+    static void OnFileIdChanged(
+        BindableObject bindable,
+        object oldValue,
+        object newValue)
+        => ((AssetPreviewImage)bindable).QueuePreviewRefresh();
+
+    void QueuePreviewRefresh()
+    {
+        CancelPendingPreview();
+        Source = null;
+        IsVisible = false;
+        if (FileId is null || FileId.IsEmpty())
+            return;
+
+        var cancellation = new CancellationTokenSource();
+        previewCancellation = cancellation;
+        _ = RefreshPreviewAsync(FileId.Value, cancellation);
+    }
+
+    async Task RefreshPreviewAsync(
+        string requestedFileId,
+        CancellationTokenSource cancellation)
+    {
+        try
+        {
+            var asset = await MauiProgram.GetService<AssetsService>()
+                .ResolveAssetAsync(
+                    new FileId(requestedFileId),
+                    cancellation.Token);
+            var preview = asset is null
+                ? null
+                : await MauiProgram.GetService<AssetFingerprintService>()
+                    .LoadPreviewAsync(asset, cancellation.Token);
+            if (cancellation.IsCancellationRequested ||
+                !string.Equals(FileId?.Value, requestedFileId, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            Dispatcher.Dispatch(() =>
+            {
+                if (cancellation.IsCancellationRequested ||
+                    !string.Equals(FileId?.Value, requestedFileId, StringComparison.Ordinal))
+                {
+                    return;
+                }
+
+                Source = preview;
+                IsVisible = preview is not null && !preview.IsEmpty;
+            });
+        }
+        catch (OperationCanceledException) when (cancellation.IsCancellationRequested)
+        {
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"Asset preview failed for {requestedFileId}: {exception.Message}");
+        }
+        finally
+        {
+            if (ReferenceEquals(previewCancellation, cancellation))
+                previewCancellation = null;
+            cancellation.Dispose();
+        }
+    }
+
+    void CancelPendingPreview()
+        => Interlocked.Exchange(ref previewCancellation, null)?.Cancel();
+}

--- a/Editor/Controls/FileIdSelectBehavior.cs
+++ b/Editor/Controls/FileIdSelectBehavior.cs
@@ -65,27 +65,15 @@ public class FileIdSelectBehavior : Behavior<Label>
 
     private async void OnLabelTapped(object sender, EventArgs e)
     {
-        var fileId = BoundProperty as FileId ??
-            (BoundProperty as Observable<FileId>)?.Value;
-        if (fileId is null || fileId.IsEmpty())
-        {
-            return;
-        }
-
         try
         {
-            var asset = await MauiProgram.GetService<AssetsService>()
-                .ResolveAssetAsync(fileId);
-            if (asset is not null)
-            {
-                await MauiProgram.GetService<SelectionService>()
-                    .SelectObjectAsync(asset);
-            }
+            await MauiProgram.GetService<SelectionService>()
+                .NavigateToReferenceAsync(BoundProperty);
         }
         catch (Exception exception)
         {
             Console.WriteLine(
-                $"[FileIdSelectBehavior] Failed to select asset '{fileId}': {exception.Message}");
+                $"[FileIdSelectBehavior] Failed to navigate to reference: {exception.Message}");
         }
     }
 

--- a/Editor/Controls/FileIdToPreviewTextureConverter.cs
+++ b/Editor/Controls/FileIdToPreviewTextureConverter.cs
@@ -24,12 +24,8 @@ public class FileIdToPreviewTextureConverter : IValueConverter
             return FileId.NullFileId;
         }
 
-        if (outAsset is TextureFile texture)
-        {
-            return texture.Texture;
-        }
-
-        return FileId.NullFileId;
+        return MauiProgram.GetService<AssetFingerprintService>()
+            .TryGetCachedPreview(outAsset) ?? FileId.NullFileId;
     }
 
     public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/Editor/Controls/InstanceIdSelectBehavior.cs
+++ b/Editor/Controls/InstanceIdSelectBehavior.cs
@@ -7,9 +7,10 @@ using SailorEditor.Controls;
 public class InstanceIdSelectBehavior : Behavior<Label>
 {
     private Label _associatedLabel;
+    private TapGestureRecognizer _tapGestureRecognizer;
 
     public static readonly BindableProperty BoundPropertyProperty =
-        BindableProperty.Create(nameof(BoundProperty), typeof(object), typeof(FileIdDragAndDropBehaviour), null, BindingMode.TwoWay);
+        BindableProperty.Create(nameof(BoundProperty), typeof(object), typeof(InstanceIdSelectBehavior), null, BindingMode.TwoWay);
 
     public object BoundProperty
     {
@@ -26,15 +27,21 @@ public class InstanceIdSelectBehavior : Behavior<Label>
 
         BindingContext = _associatedLabel.BindingContext;
 
-        var tapGestureRecognizer = new TapGestureRecognizer();
-        tapGestureRecognizer.Tapped += OnLabelTapped;
-        bindable.GestureRecognizers.Add(tapGestureRecognizer);
+        _tapGestureRecognizer = new TapGestureRecognizer();
+        _tapGestureRecognizer.Tapped += OnLabelTapped;
+        bindable.GestureRecognizers.Add(_tapGestureRecognizer);
     }
 
     protected override void OnDetachingFrom(Label bindable)
     {
         base.OnDetachingFrom(bindable);
 
+        if (_tapGestureRecognizer is not null)
+        {
+            _tapGestureRecognizer.Tapped -= OnLabelTapped;
+            bindable.GestureRecognizers.Remove(_tapGestureRecognizer);
+            _tapGestureRecognizer = null;
+        }
         _associatedLabel.BindingContextChanged -= OnBindingContextChanged;
         _associatedLabel = null;
     }
@@ -44,14 +51,17 @@ public class InstanceIdSelectBehavior : Behavior<Label>
         BindingContext = _associatedLabel.BindingContext;
     }
 
-    private void OnLabelTapped(object sender, EventArgs e)
+    private async void OnLabelTapped(object sender, EventArgs e)
     {
-        if (BoundProperty != null)
+        try
         {
-            if (BoundProperty is InstanceId id)
-            {
-                MauiProgram.GetService<SelectionService>().SelectInstance(id);
-            }
+            await MauiProgram.GetService<SelectionService>()
+                .NavigateToReferenceAsync(BoundProperty);
+        }
+        catch (Exception exception)
+        {
+            Console.WriteLine(
+                $"[InstanceIdSelectBehavior] Failed to navigate to reference: {exception.Message}");
         }
     }
 }

--- a/Editor/MainPage.xaml.cs
+++ b/Editor/MainPage.xaml.cs
@@ -39,19 +39,23 @@ public partial class MainPage : ContentPage
         if (!_workspaceUiInitialized)
         {
             _workspaceUiInitialized = true;
-            await _workspaceUi.InitializeAsync();
+            var manifestPath = ResolveCommandLineWorkspaceManifest(
+                Environment.GetCommandLineArgs());
+            if (!string.IsNullOrWhiteSpace(manifestPath))
+            {
+                _commandLineWorkspaceHandled = true;
+                await _workspaceUi.OpenWorkspaceAsync(manifestPath);
+                await LoadCommandLineWorldAsync(Environment.GetCommandLineArgs());
+            }
+            else
+            {
+                await _workspaceUi.InitializeAsync();
+            }
         }
 
         if (!_commandLineWorkspaceHandled)
         {
             _commandLineWorkspaceHandled = true;
-            var manifestPath = ResolveCommandLineWorkspaceManifest(
-                Environment.GetCommandLineArgs());
-            if (!string.IsNullOrWhiteSpace(manifestPath))
-            {
-                await _workspaceUi.OpenWorkspaceAsync(manifestPath);
-                await LoadCommandLineWorldAsync(Environment.GetCommandLineArgs());
-            }
         }
 
         if (!_mcpHost.Status.IsRunning)

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -55,6 +55,8 @@ namespace SailorEditor
             builder.Services.AddSingleton<EngineService>();
             builder.Services.AddSingleton<EditorToolbarActions>();
             builder.Services.AddSingleton<EditorContextMenuService>();
+            builder.Services.AddSingleton<ComponentClipboardService>();
+            builder.Services.AddSingleton<AssetFingerprintService>();
             builder.Services.AddSingleton<WorkspaceManifestSerializer>();
             builder.Services.AddSingleton<WorkspaceGeneratedProjectStateService>();
             builder.Services.AddSingleton<WorkspaceProjectGenerator>();

--- a/Editor/Services/AssetFingerprintService.cs
+++ b/Editor/Services/AssetFingerprintService.cs
@@ -1,0 +1,243 @@
+using SailorEditor.Utility;
+using SailorEditor.ViewModels;
+using SailorEngine;
+using SkiaSharp;
+
+namespace SailorEditor.Services;
+
+sealed class AssetFingerprintService(EngineService engineService)
+{
+    const int FingerprintSize = 256;
+    readonly SemaphoreSlim fingerprintWriteLock = new(1, 1);
+
+    public string? GetFingerprintPath(FileId? fileId)
+    {
+        var value = fileId?.Value;
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+
+        var filename = value + ".png";
+        if (!string.Equals(
+                Path.GetFileName(filename),
+                filename,
+                StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        return Path.Combine(
+            engineService.GetLaunchContext().CacheDirectory,
+            "Fingerprints",
+            filename);
+    }
+
+    public ImageSource? TryGetCachedPreview(AssetFile asset)
+    {
+        if (asset is ModelFile { Fingerprint: not null } model)
+            return model.Fingerprint;
+        if (asset is TextureFile { Texture: not null } texture &&
+            !texture.Texture.IsEmpty)
+        {
+            return texture.Texture;
+        }
+
+        var fingerprintPath = GetFingerprintPath(asset.FileId);
+        return fingerprintPath is not null && File.Exists(fingerprintPath)
+            ? ImageSource.FromFile(fingerprintPath)
+            : null;
+    }
+
+    public async Task<ImageSource?> LoadPreviewAsync(
+        AssetFile asset,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(asset);
+        await asset.EnsureMetadataLoadedAsync(cancellationToken);
+
+        if (asset is TextureFile texture)
+        {
+            await texture.LoadDependentResources(cancellationToken);
+            return texture.Texture;
+        }
+
+        if (asset is ModelFile model)
+        {
+            await model.LoadDependentResources();
+            return model.Fingerprint;
+        }
+
+        return TryGetCachedPreview(asset);
+    }
+
+    public async Task<ImageSource?> LoadTexturePreviewAsync(
+        TextureFile texture,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(texture);
+        var fingerprintPath = GetFingerprintPath(texture.FileId);
+
+        if (texture.GlbTextureIndex >= 0)
+        {
+            var generatedPath = await EnsureGlbFingerprintAsync(
+                texture,
+                fingerprintPath,
+                cancellationToken);
+            if (generatedPath is not null)
+                return ImageSource.FromFile(generatedPath);
+        }
+        else if (texture.Asset?.Exists == true &&
+                 await CanDecodeImageAsync(
+                     texture.Asset.FullName,
+                     cancellationToken))
+        {
+            return ImageSource.FromFile(texture.Asset.FullName);
+        }
+
+        return fingerprintPath is not null && File.Exists(fingerprintPath)
+            ? ImageSource.FromFile(fingerprintPath)
+            : null;
+    }
+
+    async Task<string?> EnsureGlbFingerprintAsync(
+        TextureFile texture,
+        string? fingerprintPath,
+        CancellationToken cancellationToken)
+    {
+        if (fingerprintPath is null ||
+            texture.Asset?.Exists != true ||
+            texture.GlbTextureIndex < 0)
+        {
+            return null;
+        }
+
+        if (IsFingerprintCurrent(fingerprintPath, texture.Asset.FullName))
+            return fingerprintPath;
+
+        await fingerprintWriteLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (IsFingerprintCurrent(fingerprintPath, texture.Asset.FullName))
+                return fingerprintPath;
+
+            var generated = false;
+            try
+            {
+                generated = await Task.Run(
+                    () => GenerateGlbFingerprint(
+                        texture.Asset.FullName,
+                        texture.GlbTextureIndex,
+                        fingerprintPath,
+                        cancellationToken),
+                    cancellationToken);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"Could not generate GLB texture fingerprint for " +
+                    $"{texture.FileId}: {exception.Message}");
+            }
+
+            return generated || File.Exists(fingerprintPath)
+                ? fingerprintPath
+                : null;
+        }
+        finally
+        {
+            fingerprintWriteLock.Release();
+        }
+    }
+
+    static bool IsFingerprintCurrent(
+        string fingerprintPath,
+        string sourcePath)
+    {
+        try
+        {
+            return File.Exists(fingerprintPath) &&
+                File.GetLastWriteTimeUtc(fingerprintPath) >=
+                File.GetLastWriteTimeUtc(sourcePath);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    static Task<bool> CanDecodeImageAsync(
+        string imagePath,
+        CancellationToken cancellationToken)
+        => Task.Run(() =>
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var codec = SKCodec.Create(imagePath);
+            return codec is not null;
+        }, cancellationToken);
+
+    static bool GenerateGlbFingerprint(
+        string glbPath,
+        int textureIndex,
+        string fingerprintPath,
+        CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (!GlbExtractor.ExtractTextureFromGLB(
+                glbPath,
+                textureIndex,
+                out var textureStream) ||
+            textureStream is null)
+        {
+            return false;
+        }
+
+        using (textureStream)
+        using (var original = SKBitmap.Decode(textureStream))
+        {
+            if (original is null || original.Width <= 0 || original.Height <= 0)
+                return false;
+
+            var scale = Math.Min(
+                1f,
+                FingerprintSize / (float)Math.Max(original.Width, original.Height));
+            var width = Math.Max(1, (int)Math.Round(original.Width * scale));
+            var height = Math.Max(1, (int)Math.Round(original.Height * scale));
+            using var resized = original.Resize(
+                new SKImageInfo(width, height),
+                SKFilterQuality.High);
+            if (resized is null)
+                return false;
+
+            using var image = SKImage.FromBitmap(resized);
+            using var encoded = image.Encode(SKEncodedImageFormat.Png, 90);
+            if (encoded is null || encoded.Size == 0)
+                return false;
+
+            Directory.CreateDirectory(Path.GetDirectoryName(fingerprintPath)!);
+            var temporaryPath = fingerprintPath + "." +
+                Guid.NewGuid().ToString("N") + ".tmp";
+            try
+            {
+                using (var stream = new FileStream(
+                    temporaryPath,
+                    FileMode.CreateNew,
+                    FileAccess.Write,
+                    FileShare.None))
+                {
+                    encoded.SaveTo(stream);
+                    stream.Flush(true);
+                }
+
+                File.Move(temporaryPath, fingerprintPath, true);
+                return true;
+            }
+            finally
+            {
+                if (File.Exists(temporaryPath))
+                    File.Delete(temporaryPath);
+            }
+        }
+    }
+}

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -1246,12 +1246,28 @@ namespace SailorEditor.Services
         {
             try
             {
-                var result = await Task.Run(
-                    () => _assetCacheIndexStore.Load(
-                        launchContext.AssetCacheFilePath,
-                        launchContext.WorkspaceIdentity,
-                        cancellation.Token),
+                var engineTypes = _engineService.EngineTypes;
+                var backgroundResult = await Task.Run(
+                    () =>
+                    {
+                        var result = _assetCacheIndexStore.Load(
+                            launchContext.AssetCacheFilePath,
+                            launchContext.WorkspaceIdentity,
+                            cancellation.Token);
+                        var preparedEntries = result.Succeeded
+                            ? PrepareAssetCacheIndex(
+                                result.Entries!,
+                                launchContext,
+                                _engineContentDirectory,
+                                engineTypes,
+                                cancellation.Token)
+                            : [];
+                        return new AssetCacheIndexBackgroundResult(
+                            result,
+                            preparedEntries);
+                    },
                     cancellation.Token).ConfigureAwait(false);
+                var result = backgroundResult.LoadResult;
                 if (!result.Succeeded)
                 {
                     if (result.Status is not AssetCacheIndexStatus.Missing)
@@ -1270,7 +1286,7 @@ namespace SailorEditor.Services
                         return;
                     }
 
-                    MergeAssetCacheIndex(result.Entries!);
+                    MergeAssetCacheIndex(backgroundResult.PreparedEntries);
                     Changed?.Invoke();
                 });
             }
@@ -1420,17 +1436,69 @@ namespace SailorEditor.Services
             IReadOnlyList<AssetFolder> Folders,
             IReadOnlyList<AssetFile> Files);
 
+        private sealed record PreparedAssetCacheEntry(
+            FileId FileId,
+            AssetFile Asset);
+
+        private sealed record AssetCacheIndexBackgroundResult(
+            AssetCacheIndexLoadResult LoadResult,
+            IReadOnlyList<PreparedAssetCacheEntry> PreparedEntries);
+
         private void MergeAssetCacheIndex(
-            IReadOnlyList<AssetCacheIndexEntry> entries)
+            IReadOnlyList<PreparedAssetCacheEntry> entries)
         {
+            using var perfScope = EditorPerf.Scope("AssetsService.MergeAssetCacheIndex");
             foreach (var entry in entries)
             {
-                if (!TryResolveAssetIndexLocation(
-                        entry,
-                        out var projectRootId,
-                        out var isReadOnly))
+                var indexedAsset = entry.Asset;
+                if (Assets.TryGetValue(entry.FileId, out var existing))
                 {
-                    continue;
+                    if ((existing.AssetInfo is not null &&
+                         ProjectContentPathPolicy.IsSamePath(
+                             existing.AssetInfo.FullName,
+                             indexedAsset.AssetInfo.FullName)) ||
+                        !ProjectContentAssetResolutionPolicy.ShouldReplace(
+                            existing.IsReadOnly,
+                            indexedAsset.IsReadOnly))
+                    {
+                        continue;
+                    }
+                }
+
+                indexedAsset.Id = _nextAssetId++;
+                Assets[entry.FileId] = indexedAsset;
+            }
+        }
+
+        private static IReadOnlyList<PreparedAssetCacheEntry>
+            PrepareAssetCacheIndex(
+                IReadOnlyList<AssetCacheIndexEntry> entries,
+                EngineLaunchContext launchContext,
+                string engineContentDirectory,
+                EngineTypes engineTypes,
+                CancellationToken cancellationToken)
+        {
+            using var perfScope = EditorPerf.Scope("AssetsService.PrepareAssetCacheIndex");
+            var prepared = new List<PreparedAssetCacheEntry>(entries.Count);
+            foreach (var entry in entries)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var projectRootId = ActiveProjectRootId;
+                var isReadOnly = false;
+                if (!ProjectContentPathPolicy.IsInsideRoot(
+                        launchContext.ContentDirectory,
+                        entry.SourcePath))
+                {
+                    if (launchContext.Mode != EditorProjectMode.Workspace ||
+                        !ProjectContentPathPolicy.IsInsideRoot(
+                            engineContentDirectory,
+                            entry.SourcePath))
+                    {
+                        continue;
+                    }
+
+                    projectRootId = EngineProjectRootId;
+                    isReadOnly = true;
                 }
 
                 var fileId = new FileId(entry.FileId);
@@ -1439,24 +1507,10 @@ namespace SailorEditor.Services
                     entry.MetadataFilename);
                 var metadataFile = new FileInfo(
                     Path.Combine(sourceFile.DirectoryName!, entry.MetadataFilename));
-                if (Assets.TryGetValue(fileId, out var existing))
-                {
-                    if ((existing.AssetInfo is not null &&
-                         ProjectContentPathPolicy.IsSamePath(
-                             existing.AssetInfo.FullName,
-                             metadataFile.FullName)) ||
-                        !ProjectContentAssetResolutionPolicy.ShouldReplace(
-                            existing.IsReadOnly,
-                            isReadOnly))
-                    {
-                        continue;
-                    }
-                }
-
                 var indexedAsset = CreateAssetFile(
                     entry.AssetInfoType,
-                    Path.GetExtension(indexedFilename));
-                indexedAsset.Id = _nextAssetId++;
+                    Path.GetExtension(indexedFilename),
+                    engineTypes);
                 indexedAsset.DisplayName = indexedFilename;
                 indexedAsset.FolderId = -1;
                 indexedAsset.ProjectRootId = projectRootId;
@@ -1471,35 +1525,10 @@ namespace SailorEditor.Services
                 indexedAsset.IsDirty = false;
                 indexedAsset.IsReadOnly = isReadOnly;
                 indexedAsset.IsMetadataLoaded = false;
-                Assets[fileId] = indexedAsset;
-            }
-        }
-
-        private bool TryResolveAssetIndexLocation(
-            AssetCacheIndexEntry entry,
-            out int projectRootId,
-            out bool isReadOnly)
-        {
-            projectRootId = ActiveProjectRootId;
-            isReadOnly = false;
-            if (ProjectContentPathPolicy.IsInsideRoot(
-                    CurrentProjectRootPath,
-                    entry.SourcePath))
-            {
-                return true;
+                prepared.Add(new PreparedAssetCacheEntry(fileId, indexedAsset));
             }
 
-            if (CurrentProjectMode == EditorProjectMode.Workspace &&
-                ProjectContentPathPolicy.IsInsideRoot(
-                    _engineContentDirectory,
-                    entry.SourcePath))
-            {
-                projectRootId = EngineProjectRootId;
-                isReadOnly = true;
-                return true;
-            }
-
-            return false;
+            return prepared;
         }
 
         private FolderLoadSnapshot ReadDirectoryLevel(AssetFolder parentFolder)
@@ -1810,9 +1839,10 @@ namespace SailorEditor.Services
 
         private static AssetFile CreateAssetFile(
             string assetInfoType,
-            string extension)
+            string extension,
+            EngineTypes engineTypes = null)
         {
-            var engineTypes = MauiProgram.GetService<EngineService>()?.EngineTypes;
+            engineTypes ??= MauiProgram.GetService<EngineService>()?.EngineTypes;
             AssetType assetType = null;
             if (!string.IsNullOrEmpty(assetInfoType))
             {

--- a/Editor/Services/ComponentClipboardService.cs
+++ b/Editor/Services/ComponentClipboardService.cs
@@ -1,0 +1,130 @@
+using SailorEditor.Commands;
+using SailorEditor.Shell;
+using SailorEditor.Utility;
+using SailorEditor.ViewModels;
+using SailorEditor.Workflow;
+using SailorEngine;
+using YamlDotNet.Serialization;
+
+namespace SailorEditor.Services;
+
+internal sealed class ComponentClipboardService
+{
+    static readonly HashSet<string> IdentityProperties = new(
+        ["instanceId", "fileId"],
+        StringComparer.Ordinal);
+
+    string? copiedValuesYaml;
+
+    public async Task CopyValuesAsync(
+        Component component,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(component);
+        cancellationToken.ThrowIfCancellationRequested();
+        copiedValuesYaml = EditorYaml.SerializeComponent(component);
+
+        try
+        {
+            await Clipboard.Default.SetTextAsync(copiedValuesYaml);
+        }
+        catch (Exception ex)
+        {
+            // Copy/Paste Values is an editor operation first. Keep it working
+            // even if the platform clipboard is temporarily unavailable.
+            Console.Error.WriteLine($"Could not publish component values to the system clipboard: {ex}");
+        }
+
+        Console.WriteLine($"Copied values for {component.Typename?.Name}.");
+        MauiProgram.GetService<EditorShellHost>()
+            .SetStatus($"Copied {component.Typename?.Name} values");
+    }
+
+    public async Task PasteValuesAsync(
+        Component component,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(component);
+        var clipboardText = copiedValuesYaml;
+        if (string.IsNullOrWhiteSpace(clipboardText))
+            clipboardText = await Clipboard.Default.GetTextAsync();
+        cancellationToken.ThrowIfCancellationRequested();
+        if (string.IsNullOrWhiteSpace(clipboardText))
+            throw new InvalidDataException("The clipboard does not contain component values.");
+
+        var beforeYaml = EditorYaml.SerializeComponent(component);
+        var afterYaml = MergeValues(component, beforeYaml, clipboardText);
+        if (string.Equals(beforeYaml, afterYaml, StringComparison.Ordinal))
+        {
+            MauiProgram.GetService<EditorShellHost>()
+                .SetStatus($"{component.Typename?.Name} values already match");
+            return;
+        }
+
+        var dispatcher = MauiProgram.GetService<ICommandDispatcher>();
+        var contextProvider = MauiProgram.GetService<IActionContextProvider>();
+        var result = await dispatcher.DispatchAsync(
+            new UpdateComponentCommand(
+                component,
+                beforeYaml,
+                afterYaml,
+                $"Paste {component.Typename?.Name} values"),
+            contextProvider.GetCurrentContext(
+                new CommandOrigin(
+                    CommandOriginKind.Menu,
+                    nameof(ComponentClipboardService))),
+            cancellationToken);
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException(
+                result.Message ?? "Component values could not be applied.");
+        }
+
+        Console.WriteLine($"Pasted values into {component.Typename?.Name}.");
+        MauiProgram.GetService<EditorShellHost>()
+            .SetStatus($"Pasted {component.Typename?.Name} values");
+    }
+
+    internal static string MergeValues(
+        Component target,
+        string targetYaml,
+        string clipboardYaml)
+    {
+        if (target.Typename is null || string.IsNullOrWhiteSpace(target.Typename.Name))
+            throw new InvalidDataException("The target component type is unavailable.");
+
+        var deserializer = SerializationUtils.CreateDeserializerBuilder()
+            .WithTypeConverter(new ComponentYamlConverter())
+            .Build();
+        var source = deserializer.Deserialize<Component>(clipboardYaml) ??
+            throw new InvalidDataException("The clipboard does not contain component values.");
+        var destination = deserializer.Deserialize<Component>(targetYaml) ??
+            throw new InvalidDataException("The target component values are unavailable.");
+
+        if (!string.Equals(
+                source.Typename?.Name,
+                target.Typename.Name,
+                StringComparison.Ordinal))
+        {
+            throw new InvalidDataException(
+                $"Cannot paste values from '{source.Typename?.Name}' into '{target.Typename.Name}'.");
+        }
+
+        foreach (var property in source.OverrideProperties)
+        {
+            if (IdentityProperties.Contains(property.Key) ||
+                EditorComponentPropertyContract.Classify(
+                    property.Key,
+                    target.Typename.Properties,
+                    target.Typename.ReadOnlyProperties) !=
+                    EditorComponentPropertyAccess.Writable)
+            {
+                continue;
+            }
+
+            destination.OverrideProperties[property.Key] = property.Value;
+        }
+
+        return EditorYaml.SerializeComponent(destination);
+    }
+}

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -269,6 +269,12 @@ namespace SailorEditor.Services
             {
 #if WINDOWS
                 return Path.Combine(EngineWorkingDirectory, "SailorEngine-Debug.exe");
+#elif MACCATALYST
+                return Path.Combine(
+                    EngineWorkingDirectory,
+                    "Binaries",
+                    "Debug",
+                    "SailorEngine-Debug");
 #else
                 return Path.Combine(EngineWorkingDirectory, "Binaries", "SailorEngine-Debug");
 #endif
@@ -281,6 +287,12 @@ namespace SailorEditor.Services
             {
 #if WINDOWS
                 return Path.Combine(EngineWorkingDirectory, "SailorEngine-Release.exe");
+#elif MACCATALYST
+                return Path.Combine(
+                    EngineWorkingDirectory,
+                    "Binaries",
+                    "Release",
+                    "SailorEngine-Release");
 #else
                 return Path.Combine(EngineWorkingDirectory, "Binaries", "SailorEngine-Release");
 #endif

--- a/Editor/Services/SelectionService.cs
+++ b/Editor/Services/SelectionService.cs
@@ -77,6 +77,43 @@ namespace SailorEditor.Services
         public async void SelectObject(ObservableObject obj, bool force = false)
             => await SelectObjectAsync(obj, force);
 
+        public async Task<bool> NavigateToReferenceAsync(
+            object? reference,
+            CancellationToken cancellationToken = default)
+        {
+            if (IsWorkspaceChangeInProgress || reference is null)
+                return false;
+
+            reference = reference switch
+            {
+                Observable<FileId> observableFileId => observableFileId.Value,
+                Observable<InstanceId> observableInstanceId => observableInstanceId.Value,
+                ObjectPtr objectPtr when !objectPtr.FileId.IsEmpty() => objectPtr.FileId,
+                ObjectPtr objectPtr => objectPtr.InstanceId,
+                _ => reference,
+            };
+
+            var worldService = MauiProgram.GetService<WorldService>();
+            ObservableObject? target = reference switch
+            {
+                FileId fileId when !fileId.IsEmpty() =>
+                    await MauiProgram.GetService<AssetsService>()
+                        .ResolveAssetAsync(fileId, cancellationToken),
+                InstanceId instanceId when !instanceId.IsEmpty() =>
+                    ResolveSceneReferenceTarget(worldService, instanceId),
+                Component component => worldService.FindOwner(component),
+                GameObject gameObject => gameObject,
+                AssetFile assetFile => assetFile,
+                _ => null,
+            };
+
+            if (target is null)
+                return false;
+
+            await SelectObjectAsync(target);
+            return true;
+        }
+
         public async Task SelectObjectAsync(
             ObservableObject obj,
             bool force = false)
@@ -271,6 +308,18 @@ namespace SailorEditor.Services
                 Console.WriteLine(
                     $"[SelectionService] Failed to synchronize runtime selection: {exception.Message}");
             }
+        }
+
+        static GameObject? ResolveSceneReferenceTarget(
+            WorldService worldService,
+            InstanceId instanceId)
+        {
+            if (worldService.TryGetGameObject(instanceId, out var gameObject))
+                return gameObject;
+
+            return worldService.TryGetComponent(instanceId, out var component)
+                ? worldService.FindOwner(component)
+                : null;
         }
 
         static string? TryGetSelectionId(ObservableObject obj) => obj switch

--- a/Editor/Services/WorldService.cs
+++ b/Editor/Services/WorldService.cs
@@ -747,6 +747,7 @@ namespace SailorEditor.Services
             componentOwnersDict.Remove(current.InstanceId);
             componentOwnersDict[updated.InstanceId] = owner;
 
+            owner.NotifyComponentsChanged();
             PublishCurrentWorld();
             return true;
         }

--- a/Editor/Utility/Templates.cs
+++ b/Editor/Utility/Templates.cs
@@ -273,7 +273,7 @@ static class Templates
             }
         };
 
-        var image = new Image
+        var image = new AssetPreviewImage
         {
             WidthRequest = 64,
             HeightRequest = 64,
@@ -282,10 +282,9 @@ static class Templates
             VerticalOptions = LayoutOptions.Start
         };
 
-        image.Bind<Image, Uniform<FileId>, FileId, Image>(Image.SourceProperty,
-            mode: BindingMode.Default,
-            converter: new FileIdToPreviewTextureConverter(),
-            getter: static (Uniform<FileId> vm) => vm.Value);
+        image.SetBinding(
+            AssetPreviewImage.FileIdProperty,
+            nameof(Uniform<FileId>.Value));
 
         var valueEntry = CreateInspectorValueLabel();
 
@@ -344,10 +343,23 @@ static class Templates
         valueEntry.Behaviors.Add(dragAndDropBehaviour);
         valueEntry.Behaviors.Add(selectBehavior);
 
+        var preview = new AssetPreviewImage
+        {
+            BindingContext = bindingContext,
+            WidthRequest = 36,
+            HeightRequest = 36,
+            HorizontalOptions = LayoutOptions.Start,
+            VerticalOptions = LayoutOptions.Center
+        };
+        preview.SetBinding(
+            AssetPreviewImage.FileIdProperty,
+            new Binding(bindingPath));
+
         var grid = new Grid
         {
             ColumnDefinitions =
             {
+                new ColumnDefinition { Width = GridLength.Auto },
                 new ColumnDefinition { Width = GridLength.Auto },
                 new ColumnDefinition { Width = GridLength.Star }
             },
@@ -355,7 +367,8 @@ static class Templates
         };
 
         grid.Add(clearButton, 0, 0);
-        grid.Add(valueEntry, 1, 0);
+        grid.Add(preview, 1, 0);
+        grid.Add(valueEntry, 2, 0);
 
         return grid;
     }
@@ -579,8 +592,11 @@ static class Templates
         value.ReturnType = ReturnType.Done;
         value.IsTextPredictionEnabled = false;
         var getValue = getter.Compile();
-        ConfigureCommittingEntry(
+        var converter = new FloatValueConverter();
+        ConfigureDeferredFloatEntry(
             value,
+            getValue,
+            setter,
             normalizeOnUnfocus
                 ? entry =>
                 {
@@ -592,10 +608,43 @@ static class Templates
         value.Bind<Entry, TBindingContext, float, string>(Entry.TextProperty,
             getter: getter,
             setter: setter,
-            mode: BindingMode.TwoWay,
-            converter: new FloatValueConverter());
+            mode: BindingMode.OneWay,
+            converter: converter);
 
         return value;
+    }
+
+    static void ConfigureDeferredFloatEntry<TBindingContext>(
+        Entry entry,
+        Func<TBindingContext, float> getter,
+        Action<TBindingContext, float> setter,
+        Action<Entry> normalizeOnUnfocus)
+        where TBindingContext : class
+    {
+        entry.Completed += (sender, args) => ((Entry)sender).Unfocus();
+        entry.Unfocused += (sender, args) =>
+        {
+            var current = (Entry)sender;
+            if (current.BindingContext is not TBindingContext bindingContext)
+                return;
+
+            if (float.TryParse(
+                    current.Text,
+                    System.Globalization.NumberStyles.Float,
+                    System.Globalization.CultureInfo.InvariantCulture,
+                    out var parsedValue) &&
+                float.IsFinite(parsedValue))
+            {
+                setter(bindingContext, parsedValue);
+            }
+
+            if (normalizeOnUnfocus is not null)
+                normalizeOnUnfocus(current);
+            else
+                current.Text = NumericRangeEntryInteraction.Format(getter(bindingContext));
+
+            ScheduleInspectorCommit(current);
+        };
     }
 
     public static View RangedFloatEditor<TBindingContext>(

--- a/Editor/ViewModels/GameObject.cs
+++ b/Editor/ViewModels/GameObject.cs
@@ -166,6 +166,9 @@ public partial class GameObject : ObservableObject, ICloneable, IInspectorEditab
     [YamlIgnore]
     public List<Component> Components { get { return MauiProgram.GetService<WorldService>().GetComponents(this); } }
 
+    public void NotifyComponentsChanged()
+        => OnPropertyChanged(nameof(Components));
+
     public object Clone() => new GameObject()
     {
         Name = Name + "(Clone)",

--- a/Editor/ViewModels/TextureFile.cs
+++ b/Editor/ViewModels/TextureFile.cs
@@ -76,27 +76,25 @@ public partial class TextureFile : AssetFile
 
     public override Task Save() => Save(new TextureFileYamlConverter());
 
-    public override async Task<bool> LoadDependentResources()
+    public override Task<bool> LoadDependentResources()
+        => LoadDependentResources(CancellationToken.None);
+
+    public async Task<bool> LoadDependentResources(
+        CancellationToken cancellationToken)
     {
         if (!IsLoaded)
         {
             try
             {
                 await PrepareInspectorResources();
-
-                LoadRuntimeDataWithoutDirtyTracking(() =>
-                {
-                    if (GlbTextureIndex != -1)
-                    {
-                        MemoryStream textureStream = null;
-                        GlbExtractor.ExtractTextureFromGLB(Asset.FullName, GlbTextureIndex, out textureStream);
-                        Texture = ImageSource.FromStream(() => textureStream);
-                    }
-                    else
-                    {
-                        Texture = ImageSource.FromFile(Asset.FullName);
-                    }
-                });
+                var preview = await MauiProgram
+                    .GetService<AssetFingerprintService>()
+                    .LoadTexturePreviewAsync(this, cancellationToken);
+                LoadRuntimeDataWithoutDirtyTracking(() => Texture = preview);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw;
             }
             catch (Exception ex)
             {

--- a/Editor/Views/Elements/FileIdEditor.xaml
+++ b/Editor/Views/Elements/FileIdEditor.xaml
@@ -10,7 +10,6 @@
     <ContentView.Resources>
         <ResourceDictionary>
             <controls:FileIdToFilenameConverter x:Key="FileIdToFilenameConverter"/>
-            <controls:FileIdToPreviewTextureConverter x:Key="FileIdToPreviewTextureConverter"/>
         </ResourceDictionary>
     </ContentView.Resources>
     
@@ -19,7 +18,7 @@
         <Button Text="Select" Command="{Binding SelectFileCommand}" WidthRequest="80" HeightRequest="40" Grid.Column="0"/>
         <Button Text="Clear" Command="{Binding ClearFileCommand}" WidthRequest="80" HeightRequest="40" Grid.Column="1"/>
 
-        <Image Source="{Binding Source={x:Reference FileIdEditorControl}, Path=FileId, Converter={StaticResource FileIdToPreviewTextureConverter}}"
+        <controls:AssetPreviewImage FileId="{Binding Source={x:Reference FileIdEditorControl}, Path=FileId}"
         WidthRequest="40"
         HeightRequest="40"
         Aspect="AspectFit"

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -88,6 +88,7 @@ public class ComponentTemplate : DataTemplate
                 nameLabel.GestureRecognizers.Add(dragGesture);
 
                 var worldService = MauiProgram.GetService<WorldService>();
+                var clipboardService = MauiProgram.GetService<ComponentClipboardService>();
                 var contextMenuService = MauiProgram.GetService<EditorContextMenuService>();
                 var componentKey = component.InstanceId?.ToString() ?? component.GetHashCode().ToString();
                 var isCompact = CompactComponents.Contains(componentKey);
@@ -115,6 +116,20 @@ public class ComponentTemplate : DataTemplate
                 {
                     new EditorContextMenuItem
                     {
+                        Text = "Copy Values",
+                        Command = CreateContextMenuCommand(
+                            () => clipboardService.CopyValuesAsync(component),
+                            "Copy component values")
+                    },
+                    new EditorContextMenuItem
+                    {
+                        Text = "Paste Values",
+                        Command = CreateContextMenuCommand(
+                            () => clipboardService.PasteValuesAsync(component),
+                            "Paste component values")
+                    },
+                    new EditorContextMenuItem
+                    {
                         Text = "Reset to Defaults",
                         Command = CreateContextMenuCommand(
                             () => worldService.ResetComponentToDefaultsAsync(component),
@@ -131,9 +146,15 @@ public class ComponentTemplate : DataTemplate
 
                 var flyout = contextMenuService.CreateFlyout(contextItems);
                 FlyoutBase.SetContextFlyout(props, flyout);
-                FlyoutBase.SetContextFlyout(header, flyout);
-                FlyoutBase.SetContextFlyout(nameLabel, flyout);
-                FlyoutBase.SetContextFlyout(compactButton, flyout);
+                FlyoutBase.SetContextFlyout(
+                    header,
+                    contextMenuService.CreateFlyout(contextItems));
+                FlyoutBase.SetContextFlyout(
+                    nameLabel,
+                    contextMenuService.CreateFlyout(contextItems));
+                FlyoutBase.SetContextFlyout(
+                    compactButton,
+                    contextMenuService.CreateFlyout(contextItems));
 
                 header.Add(compactButton, 0, 0);
                 header.Add(nameLabel, 1, 0);

--- a/Editor/Views/InspectorView/MaterialFileTemplate.xaml
+++ b/Editor/Views/InspectorView/MaterialFileTemplate.xaml
@@ -11,7 +11,6 @@
         <Grid.Resources>
             <ResourceDictionary>
                 <controls:FileIdToFilenameConverter x:Key="FileIdToFilenameConverter"/>
-                <controls:FileIdToPreviewTextureConverter x:Key="FileIdToPreviewTextureConverter"/>
                 <controls:FloatValueConverter x:Key="FloatValueConverter"/>
             </ResourceDictionary>
         </Grid.Resources>
@@ -112,15 +111,15 @@
                         <Button Text="-" Command="{Binding Path=BindingContext.RemoveSamplerCommand, Source={RelativeSource AncestorType={x:Type Grid}}}" CommandParameter="{Binding .}" />
                         <Editor Text="{Binding Key}" WidthRequest="160" VerticalOptions="Center" AutoSize="TextChanges"/>
                         <Button Text="Clear" Command="{Binding Path=BindingContext.ClearSamplerCommand, Source={RelativeSource AncestorType={x:Type Grid}}}" CommandParameter="{Binding Key}" />
-                        <Image Source="{Binding Value, Converter={StaticResource FileIdToPreviewTextureConverter}}"
+                        <controls:AssetPreviewImage FileId="{Binding Value}"
                                 WidthRequest="40"
                                 HeightRequest="40"
                                 Aspect="AspectFit"
                                 VerticalOptions="Center">
-                            <Image.GestureRecognizers>
+                            <controls:AssetPreviewImage.GestureRecognizers>
                                 <TapGestureRecognizer Command="{Binding Path=BindingContext.SelectSamplerCommand, Source={RelativeSource AncestorType={x:Type Grid}}}" CommandParameter="{Binding Key}" />
-                            </Image.GestureRecognizers>
-                        </Image>
+                            </controls:AssetPreviewImage.GestureRecognizers>
+                        </controls:AssetPreviewImage>
                         <Label Text="{Binding Value, Converter={StaticResource FileIdToFilenameConverter}}" VerticalOptions="Center">
                             <Label.Behaviors>
                                 <controls:FileIdDragAndDropBehaviour BoundProperty="{Binding Value}" SupportedType="{x:Type vm:TextureFile}"/>

--- a/Runtime/Components/MeshRendererComponent.cpp
+++ b/Runtime/Components/MeshRendererComponent.cpp
@@ -99,7 +99,7 @@ void MeshRendererComponent::SetScreenCoverageThresholds(
 	for (float& threshold : m_screenCoverageThresholds)
 	{
 		threshold = std::isfinite(threshold) ?
-			(std::clamp)(threshold, 0.0f, 100.0f) : 0.0f;
+			(std::clamp)(threshold, 0.0f, 1.0f) : 0.0f;
 	}
 	std::sort(
 		m_screenCoverageThresholds.begin(),

--- a/Runtime/Components/MeshRendererComponent.h
+++ b/Runtime/Components/MeshRendererComponent.h
@@ -49,7 +49,7 @@ namespace Sailor
 		TVector<FileId> m_overrideMaterials;
 		uint32_t m_minLod = 0u;
 		uint32_t m_maxLod = 2u;
-		TVector<float> m_screenCoverageThresholds{ 25.0f, 5.0f };
+		TVector<float> m_screenCoverageThresholds{ 0.25f, 0.05f };
 	};
 }
 

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -77,7 +77,7 @@ namespace Sailor
 		static constexpr float ShadowCasterDepthExtension = 200.0f;
 		static constexpr float ShadowCascadeBlendFraction = 0.1f;
 		static constexpr float ShadowCascadeLevels[NumCascades] = { 0.025f, 0.075f, 0.2f, 1.0f };
-		static constexpr glm::ivec2 ShadowCascadeResolutions[NumCascades] = { {4096,4096}, {4096,4096}, {4096,4096}, {4096,4096} };
+		static constexpr glm::ivec2 ShadowCascadeResolutions[NumCascades] = { {4096,4096}, {2048,2048}, {1024,1024}, {1024,1024} };
 		static constexpr glm::ivec2 ShadowCascadeBlur[NumCascades] = { glm::vec2(2, 2), glm::vec2(1, 1), glm::vec2(1, 1), glm::vec2(1, 1) };
 
 		// TODO: Tightly pack

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -227,7 +227,7 @@ namespace
 }
 
 uint32_t StaticMeshRendererData::ResolveLod(
-	float screenCoveragePercent,
+	float screenCoverage,
 	uint32_t numAvailableLods) const
 {
 	if (numAvailableLods == 0u)
@@ -242,9 +242,9 @@ uint32_t StaticMeshRendererData::ResolveLod(
 		(std::min)(m_maxLod, highestAvailableLod));
 	uint32_t selectedLod = 0u;
 	const float coverage = (std::clamp)(
-		screenCoveragePercent,
+		screenCoverage,
 		0.0f,
-		100.0f);
+		1.0f);
 	for (size_t thresholdIndex = 0;
 		thresholdIndex < m_screenCoverageThresholds.Num();
 		++thresholdIndex)
@@ -272,7 +272,7 @@ void StaticMeshRendererData::SetLodSettings(
 	for (float& threshold : m_screenCoverageThresholds)
 	{
 		threshold = std::isfinite(threshold) ?
-			(std::clamp)(threshold, 0.0f, 100.0f) : 0.0f;
+			(std::clamp)(threshold, 0.0f, 1.0f) : 0.0f;
 	}
 	std::sort(
 		m_screenCoverageThresholds.begin(),

--- a/Runtime/ECS/StaticMeshRendererECS.h
+++ b/Runtime/ECS/StaticMeshRendererECS.h
@@ -43,7 +43,7 @@ namespace Sailor
 
 		SAILOR_API __forceinline bool ShouldCastShadow() const { return true; }
 		SAILOR_API __forceinline uint32_t GetSkeletonOffset() const { return m_skeletonOffset; }
-		SAILOR_API uint32_t ResolveLod(float screenCoveragePercent, uint32_t numAvailableLods) const;
+		SAILOR_API uint32_t ResolveLod(float screenCoverage, uint32_t numAvailableLods) const;
 		SAILOR_API void SetLodSettings(
 			uint32_t minLod,
 			uint32_t maxLod,
@@ -58,7 +58,7 @@ namespace Sailor
 		int32_t m_meshIndex = -1;
 		uint32_t m_minLod = 0u;
 		uint32_t m_maxLod = 2u;
-		TVector<float> m_screenCoverageThresholds{ 25.0f, 5.0f };
+		TVector<float> m_screenCoverageThresholds{ 0.25f, 0.05f };
 		bool m_bInvalidMeshIndexReported = false;
 
 		friend class StaticMeshRendererECS;

--- a/Runtime/FrameGraph/SkyNode.cpp
+++ b/Runtime/FrameGraph/SkyNode.cpp
@@ -259,6 +259,27 @@ void SkyNode::SetLocation(float latitudeDegrees, float longitudeDegrees)
 	m_starsModelView = glm::toMat4(precession);
 }
 
+glm::mat4 SkyNode::CreateEnvironmentProjectionMatrix()
+{
+	glm::mat4 projection = Math::PerspectiveRH(glm::radians(90.0f), 1.0f, 0.1f, 1000.0f);
+	// Vulkan cubemap faces run from -Z to +Z along their horizontal axis,
+	// opposite to the fullscreen camera ray reconstructed by Sky.shader.
+	projection[0][0] *= -1.0f;
+	return projection;
+}
+
+TVector<glm::mat4x4> SkyNode::CreateEnvironmentViewMatrices()
+{
+	return {
+		glm::rotate(glm::mat4(1), glm::radians(90.0f), Math::vec3_Up),
+		glm::rotate(glm::mat4(1), glm::radians(-90.0f), Math::vec3_Up),
+		glm::rotate(glm::rotate(glm::mat4(1), glm::radians(-90.0f), Math::vec3_Right), glm::radians(180.0f), Math::vec3_Up),
+		glm::rotate(glm::rotate(glm::mat4(1), glm::radians(90.0f), Math::vec3_Right), glm::radians(180.0f), Math::vec3_Up),
+		glm::rotate(glm::mat4(1), glm::radians(180.0f), Math::vec3_Up),
+		glm::rotate(glm::mat4(1), glm::radians(0.0f), Math::vec3_Up),
+	};
+}
+
 void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	ResetDrawCallStats();
@@ -552,15 +573,8 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 
 	if (!m_pEnvCubemapBindings[0])
 	{
-		const glm::mat prjMatrix = Math::PerspectiveRH(glm::radians(90.0f), 1.0f, 0.1f, 1000.0f);
-		const TVector<glm::mat4x4> viewMatrices{
-			glm::rotate(glm::mat4(1), glm::radians(-90.0f), Math::vec3_Up),
-			glm::rotate(glm::mat4(1), glm::radians(90.0f), Math::vec3_Up),
-			glm::rotate(glm::rotate(glm::mat4(1), glm::radians(-90.0f), Math::vec3_Right), glm::radians(180.0f), Math::vec3_Up),
-			glm::rotate(glm::rotate(glm::mat4(1), glm::radians(90.0f), Math::vec3_Right), glm::radians(180.0f), Math::vec3_Up),
-			glm::rotate(glm::mat4(1), glm::radians(180.0f), Math::vec3_Up),
-			glm::rotate(glm::mat4(1), glm::radians(0.0f), Math::vec3_Up),
-		};
+		const glm::mat4 prjMatrix = CreateEnvironmentProjectionMatrix();
+		const TVector<glm::mat4x4> viewMatrices = CreateEnvironmentViewMatrices();
 
 		for (uint32_t face = 0; face < 6; face++)
 		{

--- a/Runtime/FrameGraph/SkyNode.h
+++ b/Runtime/FrameGraph/SkyNode.h
@@ -73,6 +73,8 @@ namespace Sailor::Framegraph
 		};
 
 		SAILOR_API void ConsumePendingSkyParams();
+		SAILOR_API static glm::mat4 CreateEnvironmentProjectionMatrix();
+		SAILOR_API static TVector<glm::mat4x4> CreateEnvironmentViewMatrices();
 
 		mutable SpinLock m_skyParamsLock;
 		SkyParameters m_skyParams{};

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -18,7 +18,7 @@
 using namespace Sailor;
 using namespace Sailor::RHI;
 
-float Sailor::RHI::CalculateScreenCoveragePercent(
+float Sailor::RHI::CalculateScreenCoverage(
 	const Math::AABB& worldBounds,
 	const glm::mat4& viewMatrix,
 	const glm::mat4& projectionMatrix)
@@ -71,7 +71,7 @@ float Sailor::RHI::CalculateScreenCoveragePercent(
 	}
 	if (numCornersInFront < corners.size())
 	{
-		return 100.0f;
+		return 1.0f;
 	}
 
 	glm::vec2 minNdc((std::numeric_limits<float>::max)());
@@ -89,9 +89,9 @@ float Sailor::RHI::CalculateScreenCoveragePercent(
 		maxNdc - minNdc,
 		glm::vec2(0.0f));
 	return (std::clamp)(
-		coveredNdc.x * coveredNdc.y * 25.0f,
+		coveredNdc.x * coveredNdc.y * 0.25f,
 		0.0f,
-		100.0f);
+		1.0f);
 }
 
 namespace
@@ -107,11 +107,11 @@ namespace
 			return 0u;
 		}
 
-		const float screenCoveragePercent = CalculateScreenCoveragePercent(
+		const float screenCoverage = CalculateScreenCoverage(
 			worldBounds,
 			camera.GetViewMatrix(),
 			camera.GetProjectionMatrix());
-		return data.ResolveLod(screenCoveragePercent, mesh->GetNumLods());
+		return data.ResolveLod(screenCoverage, mesh->GetNumLods());
 	}
 
 	void ApplyLodToMeshes(

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -14,7 +14,7 @@
 
 namespace Sailor::RHI
 {
-	SAILOR_API float CalculateScreenCoveragePercent(
+	SAILOR_API float CalculateScreenCoverage(
 		const Math::AABB& worldBounds,
 		const glm::mat4& viewMatrix,
 		const glm::mat4& projectionMatrix);

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -811,17 +811,17 @@ namespace
 	{
 		StaticMeshRendererData data;
 		Require(data.ResolveLod(0.0f, 1u) == 0u &&
-			data.ResolveLod(100.0f, 1u) == 0u,
+			data.ResolveLod(1.0f, 1u) == 0u,
 			"mesh renderer must keep LOD0 when no generated LOD is available");
-		data.SetLodSettings(0u, 2u, TVector<float>{ 5.0f, 25.0f });
-		Require(data.ResolveLod(100.0f, 3u) == 0u &&
-			data.ResolveLod(25.0f, 3u) == 0u &&
-			data.ResolveLod(24.9f, 3u) == 1u &&
-			data.ResolveLod(4.9f, 3u) == 2u,
+		data.SetLodSettings(0u, 2u, TVector<float>{ 0.05f, 0.25f });
+		Require(data.ResolveLod(1.0f, 3u) == 0u &&
+			data.ResolveLod(0.25f, 3u) == 0u &&
+			data.ResolveLod(0.249f, 3u) == 1u &&
+			data.ResolveLod(0.049f, 3u) == 2u,
 			"mesh renderer LOD selection must follow descending screen-coverage thresholds");
 
-		data.SetLodSettings(1u, 5u, TVector<float>{ 25.0f, 5.0f });
-		Require(data.ResolveLod(100.0f, 3u) == 1u,
+		data.SetLodSettings(1u, 5u, TVector<float>{ 0.25f, 0.05f });
+		Require(data.ResolveLod(1.0f, 3u) == 1u,
 			"mesh renderer minimum LOD must clamp high-coverage selection");
 		Require(data.ResolveLod(0.0f, 2u) == 1u,
 			"mesh renderer maximum LOD must clamp to available model geometry");
@@ -832,33 +832,34 @@ namespace
 			0.1f,
 			1000.0f);
 		const glm::mat4 view(1.0f);
-		const float nearCoverage = RHI::CalculateScreenCoveragePercent(
+		const float nearCoverage = RHI::CalculateScreenCoverage(
 			Math::AABB(glm::vec3(0.0f, 0.0f, -5.0f), glm::vec3(1.0f)),
 			view,
 			projection);
-		const float farCoverage = RHI::CalculateScreenCoveragePercent(
+		const float farCoverage = RHI::CalculateScreenCoverage(
 			Math::AABB(glm::vec3(0.0f, 0.0f, -20.0f), glm::vec3(1.0f)),
 			view,
 			projection);
-		const float offscreenCoverage = RHI::CalculateScreenCoveragePercent(
+		const float offscreenCoverage = RHI::CalculateScreenCoverage(
 			Math::AABB(glm::vec3(100.0f, 0.0f, -5.0f), glm::vec3(1.0f)),
 			view,
 			projection);
-		const float behindCameraCoverage = RHI::CalculateScreenCoveragePercent(
+		const float behindCameraCoverage = RHI::CalculateScreenCoverage(
 			Math::AABB(glm::vec3(0.0f, 0.0f, 5.0f), glm::vec3(1.0f)),
 			view,
 			projection);
-		const float cameraIntersectionCoverage = RHI::CalculateScreenCoveragePercent(
+		const float cameraIntersectionCoverage = RHI::CalculateScreenCoverage(
 			Math::AABB(glm::vec3(0.0f), glm::vec3(1.0f)),
 			view,
 			projection);
-		Require(nearCoverage > farCoverage && farCoverage > 0.0f,
+		Require(nearCoverage <= 1.0f &&
+			nearCoverage > farCoverage && farCoverage > 0.0f,
 			"projected AABB coverage must decrease as the same object recedes from the camera");
 		Require(offscreenCoverage == 0.0f,
 			"projected AABB coverage must exclude bounds outside the viewport");
 		Require(behindCameraCoverage == 0.0f,
 			"projected AABB coverage must exclude bounds behind the camera");
-		Require(cameraIntersectionCoverage == 100.0f,
+		Require(cameraIntersectionCoverage == 1.0f,
 			"projected AABB coverage must conservatively select the highest LOD when bounds cross the camera plane");
 
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -1516,7 +1517,15 @@ namespace
 		meshRenderer->SetMinLod(1u);
 		meshRenderer->SetMaxLod(2u);
 		meshRenderer->SetScreenCoverageThresholds(
-			TVector<float>{ 5.0f, 25.0f });
+			TVector<float>{ -1.0f, 0.25f, 2.0f });
+		const TVector<float> clampedCoverageThresholds{
+			1.0f, 0.25f, 0.0f };
+		Require(
+			meshRenderer->GetScreenCoverageThresholds() ==
+				clampedCoverageThresholds,
+			"mesh renderer screen coverage must stay normalized to [0, 1]");
+		meshRenderer->SetScreenCoverageThresholds(
+			TVector<float>{ 0.05f, 0.25f });
 		Require(meshRenderer->GetOverrideMaterials() == overrides,
 			"assigning material overrides must preserve their slot order and inherited gaps");
 		Require(meshRenderer->GetData().IsDirty(),
@@ -1547,7 +1556,7 @@ namespace
 		Require(restoredRenderer && areOverridesEquivalent(
 			restoredRenderer->GetOverrideMaterials(), overrides),
 			"prefab instantiation must restore component-owned material overrides");
-		const TVector<float> expectedCoverageThresholds{ 25.0f, 5.0f };
+		const TVector<float> expectedCoverageThresholds{ 0.25f, 0.05f };
 		Require(restoredRenderer->GetMinLod() == 1u &&
 			restoredRenderer->GetMaxLod() == 2u &&
 			restoredRenderer->GetScreenCoverageThresholds() ==

--- a/Tests/SkyComponentContractTests.cpp
+++ b/Tests/SkyComponentContractTests.cpp
@@ -151,7 +151,69 @@ namespace
 	public:
 
 		using Framegraph::SkyNode::ConsumePendingSkyParams;
+		using Framegraph::SkyNode::CreateEnvironmentProjectionMatrix;
+		using Framegraph::SkyNode::CreateEnvironmentViewMatrices;
 	};
+
+	glm::vec3 ReconstructEnvironmentDirection(
+		const glm::mat4& projection,
+		const glm::mat4& view,
+		const glm::vec2& uv)
+	{
+		glm::vec4 viewDirection = glm::inverse(projection) *
+			glm::vec4(uv * 2.0f - 1.0f, 1.0f, 1.0f);
+		viewDirection /= viewDirection.w;
+		return glm::normalize(glm::vec3(
+			glm::inverse(view) * glm::vec4(
+				glm::vec3(viewDirection), 0.0f)));
+	}
+
+	void TestEnvironmentCubemapOrientation()
+	{
+		const glm::mat4 projection =
+			SkyNodeMailboxProbe::CreateEnvironmentProjectionMatrix();
+		const auto views =
+			SkyNodeMailboxProbe::CreateEnvironmentViewMatrices();
+		Require(views.Num() == 6,
+			"the procedural environment should define all six cubemap faces");
+
+		const glm::vec3 centerDirections[] = {
+			Math::vec3_Right, Math::vec3_Left,
+			Math::vec3_Up, Math::vec3_Down,
+			Math::vec3_Backward, Math::vec3_Forward
+		};
+		const glm::vec3 rightDirections[] = {
+			glm::normalize(Math::vec3_Right + Math::vec3_Forward),
+			glm::normalize(Math::vec3_Left + Math::vec3_Backward),
+			glm::normalize(Math::vec3_Up + Math::vec3_Right),
+			glm::normalize(Math::vec3_Down + Math::vec3_Right),
+			glm::normalize(Math::vec3_Backward + Math::vec3_Right),
+			glm::normalize(Math::vec3_Forward + Math::vec3_Left)
+		};
+		const glm::vec3 topDirections[] = {
+			glm::normalize(Math::vec3_Right + Math::vec3_Up),
+			glm::normalize(Math::vec3_Left + Math::vec3_Up),
+			glm::normalize(Math::vec3_Up + Math::vec3_Forward),
+			glm::normalize(Math::vec3_Down + Math::vec3_Backward),
+			glm::normalize(Math::vec3_Backward + Math::vec3_Up),
+			glm::normalize(Math::vec3_Forward + Math::vec3_Up)
+		};
+
+		for (uint32_t face = 0; face < views.Num(); face++)
+		{
+			Require(
+				IsNear(ReconstructEnvironmentDirection(
+					projection, views[face], glm::vec2(0.5f)),
+					centerDirections[face]) &&
+				IsNear(ReconstructEnvironmentDirection(
+					projection, views[face], glm::vec2(1.0f, 0.5f)),
+					rightDirections[face]) &&
+				IsNear(ReconstructEnvironmentDirection(
+					projection, views[face], glm::vec2(0.5f, 1.0f)),
+					topDirections[face]),
+				"procedural environment face orientation should match Vulkan cubemap sampling");
+		}
+	}
 
 	void RequireRange(
 		const TypeInfo& type,
@@ -1072,6 +1134,7 @@ int main()
 		{ "SettersClampAndUpdateDirection", TestSettersClampAndUpdateDirection },
 		{ "EnvironmentKeyHashEquality", TestEnvironmentKeyHashEquality },
 		{ "SkyNodeMailboxHandoff", TestSkyNodeMailboxHandoff },
+		{ "EnvironmentCubemapOrientation", TestEnvironmentCubemapOrientation },
 		{ "ExplicitDirectionalLightSynchronization", TestExplicitDirectionalLightSynchronization },
 		{ "DestroyedLightReferencesSerializeAsNull", TestDestroyedLightReferencesSerializeAsNull },
 		{ "PrefabRoundTripRemapsExplicitLight", TestPrefabRoundTripRemapsExplicitLight },

--- a/build_editor.py
+++ b/build_editor.py
@@ -67,7 +67,14 @@ def prepare_env(dotnet_path: str) -> dict[str, str]:
 def maybe_build_engine(engine: bool, config: str) -> None:
     if not engine:
         return
-    cmd = [sys.executable, str(REPO_ROOT / "build_engine.py"), "--config", config]
+    cmd = [
+        sys.executable,
+        str(REPO_ROOT / "build_engine.py"),
+        "--config",
+        config,
+        "--target",
+        "SailorExec",
+    ]
     run(cmd)
 
 

--- a/run_editor.py
+++ b/run_editor.py
@@ -55,7 +55,14 @@ def prepare_env() -> dict[str, str]:
 
 
 def build_engine(config: str) -> None:
-    run([sys.executable, str(REPO_ROOT / "build_engine.py"), "--config", config])
+    run([
+        sys.executable,
+        str(REPO_ROOT / "build_engine.py"),
+        "--config",
+        config,
+        "--target",
+        "SailorExec",
+    ])
 
 
 def build_editor(framework: str, config: str, publish: bool) -> None:


### PR DESCRIPTION
## Summary

This PR collects the editor and renderer fixes validated during the DemoMaldives workflow.

### Inspector and selection

- navigate asset, GameObject, component, FileId, InstanceId, and ObjectPtr references through one shared selection path
- select the owning GameObject when an inspector component reference is clicked
- add Copy Values / Paste Values to component context menus
- preserve component identity and read-only properties during paste and route changes through editor history
- defer float field commits until editing completes so intermediate text does not reset focus

### Assets and previews

- move asset-cache index preparation off the UI thread and publish prepared entries on the main thread
- add a shared asynchronous asset preview control
- generate and persist GLB texture fingerprints under the cache Fingerprints directory
- fall back to fingerprints when the original texture cannot be decoded
- show thumbnails for general model/asset pointer properties and material texture fields

### Editor launch and play

- open command-line workspaces before normal recent-workspace initialization
- build the standalone SailorExec target from editor entry points
- resolve configuration-specific macOS play executables correctly

### Runtime rendering

- normalize mesh LOD screen coverage and thresholds to the engine-wide [0, 1] range
- align procedural sky cubemap face centers and orientation with Vulkan cubemap sampling
- use explicit LOD 0 for cloud volume noise and weather-map samples inside divergent ray marching
- retain 4096² shadows for the nearest cascade while reducing distant cascades to 2048², 1024², and 1024²

## Root causes

- reference controls had separate type-specific navigation paths and component IDs were selected directly instead of resolving their owners
- component paste previously lacked a history-backed, identity-preserving merge path
- two-way float bindings committed every transient edit and refreshed the inspector
- asset-cache objects and previews performed too much work on the UI thread, while embedded GLB textures had no persistent fallback thumbnail
- macOS Play searched a non-configuration-specific binary path and editor build scripts did not explicitly build SailorExec
- LOD code mixed percentage values with normalized coverage
- procedural sky cubemap transforms did not match Vulkan face orientation
- cloud density used implicit texture derivatives inside dynamic ray-march control flow, allowing Vulkan and Metal/MoltenVK to choose different mip levels
- all directional-light shadow cascades used the maximum resolution even where distant coverage does not need it

## Validation

- `$HOME/.dotnet/dotnet test Editor.Tests/Editor.Contracts.Tests.csproj -c Release --no-restore` — 764/764 passed
- `cmake --build build-mac-vcpkg --config Release --target EcsLifecycleContractTests -j 8`
- `./Binaries/Release/EcsLifecycleContractTests` — passed
- `cmake --build build-mac-vcpkg --config Release --target SkyComponentContractTests -j 8`
- `./Binaries/Release/SkyComponentContractTests` — 10/10 passed
- `git diff --check origin/main...HEAD`
- Release editor launched with `DemoMaldives/Content/Maldives.world`; engine state confirmed `Running`
- manual validation confirmed reference navigation, component value paste, float editing, asynchronous loading, fingerprints, Play, water reflections, and macOS clouds

## Scope

The PR contains editor/runtime code, focused tests, build entry points, the engine sky shader, and the directional-light shadow cascade resolution adjustment. DemoMaldives assets, imported models, worlds, generated cache data, and unrelated local worktree changes are excluded.