### PR TITLE
Fix clang-cl shadow prepass symbol linkage

### DIFF
--- a/Runtime/FrameGraph/ShadowPrepassNode.h
+++ b/Runtime/FrameGraph/ShadowPrepassNode.h
@@ -88,7 +88,7 @@ namespace Sailor
 		RHI::RHIShaderBindingPtr m_lightMatrices{};
 		Framegraph::TextureBindingCache m_textureBindingCache{};
 
-		static const char* m_name;
+		SAILOR_SHARED_API static const char* m_name;
 	};
 
 	namespace Framegraph


### PR DESCRIPTION
## Summary

- export `ShadowPrepassNode::m_name` from the Sailor shared library
- restore clang-cl linkage for consumers that instantiate `TFrameGraphNode<ShadowPrepassNode>`

## Root cause

`ShadowPrepassNode.cpp` defines `m_name` only when building the Sailor library, but the declaration was not marked with `SAILOR_SHARED_API`. Windows clang-cl therefore emitted a reference from `GpuCullingContractTests` without importing the symbol from the DLL and failed with:

```
lld-link: error: undefined symbol: Sailor::ShadowPrepassNode::m_name
```

The declaration now matches other exported frame-graph node names such as `DepthPrepassNode`, `RenderSceneNode`, and `SkyNode`.

## Validation

- `python3 update_deps.py`
- `python3 build_engine.py --config Release --target GpuCullingContractTests --generator 'Unix Makefiles' --build-dir build-mac-make-ci --parallel 10`
- `./Binaries/GpuCullingContractTests` — 25/25 passed
- `git diff --check`

## Scope

One engine header only. No Content, workspace assets, generated cache, or unrelated local changes are included.