### PR TITLE
Add prefab authoring and cross-platform runtime asset fixes

### DIFF
--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -36,6 +36,7 @@
     <Compile Include="ProjectContentPathPolicyTests.cs" />
     <Compile Include="AssetSourcePathContractTests.cs" />
     <Compile Include="ProjectContentFileOperationsTests.cs" />
+    <Compile Include="PrefabOverrideApplierTests.cs" />
     <Compile Include="ProjectContentFolderRebindPolicyTests.cs" />
     <Compile Include="ProjectContentMutationReloadPolicyTests.cs" />
     <Compile Include="RepositoryAssetSidecarContractTests.cs" />
@@ -113,6 +114,7 @@
     <Compile Include="..\Editor\Content\ProjectContentPathPolicy.cs" Link="Content\ProjectContentPathPolicy.cs" />
     <Compile Include="..\Editor\Content\AssetSourcePathContract.cs" Link="Content\AssetSourcePathContract.cs" />
     <Compile Include="..\Editor\Content\ProjectContentFileOperations.cs" Link="Content\ProjectContentFileOperations.cs" />
+    <Compile Include="..\Editor\Content\PrefabOverrideApplier.cs" Link="Content\PrefabOverrideApplier.cs" />
     <Compile Include="..\Editor\Content\ProjectContentFolderRebindPolicy.cs" Link="Content\ProjectContentFolderRebindPolicy.cs" />
     <Compile Include="..\Editor\Content\ProjectContentMutationReloadPolicy.cs" Link="Content\ProjectContentMutationReloadPolicy.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceManifest.cs" Link="Workspace\WorkspaceManifest.cs" />

--- a/Editor.Tests/EditorDragDropRoutingTests.cs
+++ b/Editor.Tests/EditorDragDropRoutingTests.cs
@@ -40,6 +40,28 @@ public sealed class EditorDragDropRoutingTests
         Assert.Equal(fileId, result);
     }
 
+    [Fact]
+    public void TryResolveAssetFileId_AcceptsOnlyAudioForAudioClipPointers()
+    {
+        var audioId = new FileId("{AUDIO}");
+        var modelId = new FileId("{MODEL}");
+        var audio = new AudioFile { FileId = audioId };
+        var model = new ModelFile { FileId = modelId };
+
+        Assert.True(EditorDragDrop.TryResolveAssetFileId(
+            audio,
+            typeof(AudioFile),
+            id => id == audioId ? audio : null,
+            out var resolved));
+        Assert.Equal(audioId, resolved);
+
+        Assert.False(EditorDragDrop.TryResolveAssetFileId(
+            model,
+            typeof(AudioFile),
+            id => id == modelId ? model : null,
+            out _));
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/Editor.Tests/EditorDragDropTestStubs.cs
+++ b/Editor.Tests/EditorDragDropTestStubs.cs
@@ -37,6 +37,10 @@ namespace SailorEditor.ViewModels
         public bool IsReadOnly { get; set; }
     }
 
+    public sealed class AudioFile : AssetFile
+    {
+    }
+
     public sealed class MaterialFile : AssetFile;
     public sealed class TextureFile : AssetFile;
     public sealed class ModelFile : AssetFile;

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -909,6 +909,40 @@ public sealed class EngineLifecycleTests
     }
 
     [Fact]
+    public void AudioClipPointers_AreMappedToTypedEditorAssets()
+    {
+        var engineTypes = ReadRepositoryFile(
+            "Editor",
+            "Utility",
+            "EngineTypes.cs");
+        var assetsService = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "AssetsService.cs");
+        var assetFile = ReadRepositoryFile(
+            "Editor",
+            "ViewModels",
+            "AssetFile.cs");
+
+        Assert.Contains(
+            "\"Sailor::AudioClip\" => typeof(AudioFile)",
+            engineTypes,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "\"Sailor::AudioAssetInfo\" => new AudioFile()",
+            assetsService,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "\".wav\" or \".flac\" or \".mp3\" => new AudioFile()",
+            assetsService,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "AudioFile => \"Sailor::AudioAssetInfo\"",
+            assetFile,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void CreateEditorWorld_IsRoutedThroughTheSharedProtocolAbi()
     {
         var managedSource = ReadRepositoryFile("Editor", "Services", "EngineService.cs");

--- a/Editor.Tests/PrefabOverrideApplierTests.cs
+++ b/Editor.Tests/PrefabOverrideApplierTests.cs
@@ -1,0 +1,171 @@
+using SailorEditor.Content;
+using YamlDotNet.RepresentationModel;
+
+namespace Editor.Tests;
+
+public sealed class PrefabOverrideApplierTests
+{
+    const string SourceYaml = """
+        gameObjects:
+          - name: Original Root
+            position: [0, 1, 2, 1]
+            rotation: [0, 0, 0, 1]
+            scale: [1, 1, 1, 1]
+            parentIndex: 4294967295
+            instanceId: source-game-object
+            components: [0]
+        components:
+          - typename: Sailor::TestComponent
+            overrideProperties:
+              value: 10
+              untouched: original
+              fileId: source-file
+              instanceId: source-component
+        """;
+
+    const string LinkedYaml = """
+        fileId: source-prefab
+        instanceIds:
+          source-game-object: live-game-object
+          source-component: live-component
+        gameObjectOverrides:
+          source-game-object:
+            name: Applied Root
+            position: [7, 8, 9, 1]
+        componentOverrides:
+          source-component:
+            typename: Sailor::TestComponent
+            overrideProperties:
+              value: 42
+              added: applied
+              fileId: live-file
+              instanceId: live-component
+        """;
+
+    [Fact]
+    public void Apply_MergesOverridesAndPreservesStableSourceIdentity()
+    {
+        var result = PrefabOverrideApplier.Apply(SourceYaml, LinkedYaml);
+        var root = ParseRoot(result);
+        var gameObject = Sequence(root, "gameObjects").Children
+            .OfType<YamlMappingNode>()
+            .Single();
+        var component = Sequence(root, "components").Children
+            .OfType<YamlMappingNode>()
+            .Single();
+        var properties = Mapping(component, "overrideProperties");
+
+        Assert.Equal("Applied Root", Scalar(gameObject, "name"));
+        Assert.Equal("[0, 1, 2, 1]", InlineSequence(gameObject, "position"));
+        Assert.Equal("source-game-object", Scalar(gameObject, "instanceId"));
+        Assert.Equal("42", Scalar(properties, "value"));
+        Assert.Equal("applied", Scalar(properties, "added"));
+        Assert.Equal("original", Scalar(properties, "untouched"));
+        Assert.Equal("source-file", Scalar(properties, "fileId"));
+        Assert.Equal("source-component", Scalar(properties, "instanceId"));
+    }
+
+    [Fact]
+    public void Apply_IgnoresOverridesForUnknownSourceObjects()
+    {
+        var linked = LinkedYaml.Replace(
+            "source-game-object:\n    name: Applied Root",
+            "unknown-game-object:\n    name: Applied Root",
+            StringComparison.Ordinal);
+
+        var result = PrefabOverrideApplier.Apply(SourceYaml, linked);
+        var gameObject = Sequence(ParseRoot(result), "gameObjects").Children
+            .OfType<YamlMappingNode>()
+            .Single();
+
+        Assert.Equal("Original Root", Scalar(gameObject, "name"));
+        Assert.Equal("source-game-object", Scalar(gameObject, "instanceId"));
+    }
+
+    [Fact]
+    public void Apply_CopiesCompleteExpandedComponentValuesIncludingReferences()
+    {
+        const string source = """
+            gameObjects:
+              - name: Saxophone
+                position: [0, 0, 0, 1]
+                rotation: [0, 0, 0, 1]
+                scale: [1, 1, 1, 1]
+                parentIndex: 4294967295
+                instanceId: source-object
+                components: [0]
+            components:
+              - typename: Sailor::AudioSourceComponent
+                overrideProperties:
+                  clip: ~
+                  volume: 0.5
+                  fileId: source-file
+                  instanceId: audio_source-object
+            """;
+        const string linked = """
+            fileId: source-prefab
+            instanceIds:
+              source-object: live-object
+            gameObjects:
+              - name: Edited Saxophone
+                position: [4, 5, 6, 1]
+                rotation: [0, 0, 0, 1]
+                scale: [2, 2, 2, 1]
+                parentIndex: 4294967295
+                instanceId: live-object
+                components: [0]
+            components:
+              - typename: Sailor::AudioSourceComponent
+                overrideProperties:
+                  clip:
+                    fileId: AUDIO-FILE
+                    instanceId: ''
+                  volume: 0.8
+                  fileId: live-file
+                  instanceId: audio_live-object
+            """;
+
+        var result = PrefabOverrideApplier.Apply(source, linked);
+        var root = ParseRoot(result);
+        var gameObject = Sequence(root, "gameObjects").Children
+            .OfType<YamlMappingNode>()
+            .Single();
+        var component = Sequence(root, "components").Children
+            .OfType<YamlMappingNode>()
+            .Single();
+        var properties = Mapping(component, "overrideProperties");
+        var clip = Mapping(properties, "clip");
+
+        Assert.Equal("Edited Saxophone", Scalar(gameObject, "name"));
+        Assert.Equal("[0, 0, 0, 1]", InlineSequence(gameObject, "position"));
+        Assert.Equal("[2, 2, 2, 1]", InlineSequence(gameObject, "scale"));
+        Assert.Equal("source-object", Scalar(gameObject, "instanceId"));
+        Assert.Equal("0.8", Scalar(properties, "volume"));
+        Assert.Equal("AUDIO-FILE", Scalar(clip, "fileId"));
+        Assert.Equal("source-file", Scalar(properties, "fileId"));
+        Assert.Equal("audio_source-object", Scalar(properties, "instanceId"));
+    }
+
+    static YamlMappingNode ParseRoot(string yaml)
+    {
+        var stream = new YamlStream();
+        stream.Load(new StringReader(yaml));
+        return Assert.IsType<YamlMappingNode>(
+            Assert.Single(stream.Documents).RootNode);
+    }
+
+    static YamlMappingNode Mapping(YamlMappingNode parent, string key) =>
+        Assert.IsType<YamlMappingNode>(parent.Children[new YamlScalarNode(key)]);
+
+    static YamlSequenceNode Sequence(YamlMappingNode parent, string key) =>
+        Assert.IsType<YamlSequenceNode>(parent.Children[new YamlScalarNode(key)]);
+
+    static string Scalar(YamlMappingNode parent, string key) =>
+        Assert.IsType<YamlScalarNode>(
+            parent.Children[new YamlScalarNode(key)]).Value!;
+
+    static string InlineSequence(YamlMappingNode parent, string key) =>
+        $"[{string.Join(", ", Sequence(parent, key).Children
+            .Cast<YamlScalarNode>()
+            .Select(node => node.Value))}]";
+}

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -1816,6 +1816,37 @@ public sealed class WorkflowProjectionTests
     }
 
     [Fact]
+    public void ApplyPrefab_WaitsForPendingComponentReferenceEdits()
+    {
+        var gameObjectSource = ReadRepositoryFile(
+            "Editor",
+            "ViewModels",
+            "GameObject.cs");
+        var templateSource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "InspectorView",
+            "GameObjectTemplate.xaml.cs");
+
+        Assert.Contains(
+            "GetComponentsSafely().Any(component =>",
+            gameObjectSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "component.HasPendingInspectorChanges",
+            gameObjectSource,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "await component.CommitInspectorChangesAsync(",
+            gameObjectSource,
+            StringComparison.Ordinal);
+        AssertInOrder(
+            templateSource,
+            ".CommitPendingChangesAsync()",
+            "new ApplyPrefabInstanceCommand(gameObject)");
+    }
+
+    [Fact]
     public void ComponentContextMenu_CopyPasteValuesPreservesIdentityAndUsesHistory()
     {
         var templateSource = ReadRepositoryFile(

--- a/Editor/Commands/EditorAssetCommands.cs
+++ b/Editor/Commands/EditorAssetCommands.cs
@@ -438,6 +438,149 @@ public sealed class CreatePrefabAssetCommand(GameObject gameObject, AssetFolder?
     }
 }
 
+public sealed class ApplyPrefabInstanceCommand(GameObject gameObject) : IEditorCommand
+{
+    readonly InstanceId _instanceId = gameObject.InstanceId is null
+        ? InstanceId.NullInstanceId
+        : new InstanceId(gameObject.InstanceId.Value);
+
+    public string Name => nameof(ApplyPrefabInstanceCommand);
+
+    public bool CanExecute(ActionContext context) =>
+        _instanceId is not null &&
+        !_instanceId.IsEmpty();
+
+    public async Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var engine = MauiProgram.GetService<EngineService>();
+        var world = MauiProgram.GetService<WorldService>();
+        await engine.RefreshCurrentWorldAsync(cancellationToken);
+        if (!world.TryGetGameObject(_instanceId, out var liveObject) ||
+            liveObject.PrefabIndex < 0 ||
+            liveObject.PrefabIndex >= world.Current.Prefabs.Count)
+        {
+            return CommandResult.Failure(
+                "The selected GameObject is no longer available.");
+        }
+
+        var linkedPrefab = world.Current.Prefabs[liveObject.PrefabIndex];
+        if (linkedPrefab.FileId is null || linkedPrefab.FileId.IsEmpty())
+        {
+            return CommandResult.Failure(
+                "The selected GameObject is not linked to a prefab.");
+        }
+
+        var assets = MauiProgram.GetService<AssetsService>();
+        if (!assets.Assets.TryGetValue(
+                linkedPrefab.FileId,
+                out var sourceAsset) ||
+            sourceAsset is not PrefabFile sourcePrefab)
+        {
+            return CommandResult.Failure(
+                $"Prefab asset '{linkedPrefab.FileId.Value}' is not available.");
+        }
+        if (sourcePrefab.IsReadOnly)
+        {
+            return CommandResult.Failure(
+                "The source prefab is read-only.");
+        }
+
+        var write = assets.BeginApplyPrefabOverrides(
+            sourcePrefab,
+            EditorYaml.SerializePrefab(linkedPrefab));
+        if (write is null)
+        {
+            return CommandResult.Failure(
+                "Apply prefab could not prepare an atomic asset write.");
+        }
+
+        var atomicCancellationToken = CancellationToken.None;
+        try
+        {
+            if (!await engine.RequestAssetReloadAsync(
+                    atomicCancellationToken))
+            {
+                return await RollbackAsync(
+                    assets,
+                    write.Transaction,
+                    engine,
+                    "The native registry rejected the updated prefab.");
+            }
+
+            var commit = assets.CompletePrefabAssetWrite(
+                write.Transaction,
+                commit: true);
+            if (!commit.Succeeded)
+            {
+                return await RollbackAsync(
+                    assets,
+                    write.Transaction,
+                    engine,
+                    AssetCommandMessages.Error(
+                        commit,
+                        "The prefab write transaction could not be committed"));
+            }
+
+            await engine.RefreshCurrentWorldAsync(
+                atomicCancellationToken);
+            return CommandResult.Success(
+                "Prefab changes applied.",
+                linkedPrefab.FileId);
+        }
+        catch (Exception exception)
+        {
+            return await RollbackAsync(
+                assets,
+                write.Transaction,
+                engine,
+                $"Apply prefab failed: {exception.Message}");
+        }
+    }
+
+    static async Task<CommandResult> RollbackAsync(
+        AssetsService assets,
+        ProjectContentAssetWriteTransaction transaction,
+        EngineService engine,
+        string reason)
+    {
+        var diagnostics = new List<string> { reason };
+        if (transaction.IsActive)
+        {
+            var rollback = assets.CompletePrefabAssetWrite(
+                transaction,
+                commit: false);
+            if (!rollback.Succeeded)
+            {
+                diagnostics.Add(AssetCommandMessages.Error(
+                    rollback,
+                    "Prefab rollback failed"));
+            }
+        }
+
+        try
+        {
+            if (!await engine.RequestAssetReloadAsync(
+                    CancellationToken.None))
+            {
+                diagnostics.Add(
+                    "The native registry rejected the rollback reload.");
+            }
+            await engine.RefreshCurrentWorldAsync(
+                CancellationToken.None);
+        }
+        catch (Exception exception)
+        {
+            diagnostics.Add(
+                $"Prefab rollback reconciliation failed: {exception.Message}");
+        }
+
+        return CommandResult.Failure(string.Join(" ", diagnostics));
+    }
+}
+
 static class AssetCommandMessages
 {
     public static async Task<CommandResult> CompleteMutationAsync(

--- a/Editor/Content/PrefabOverrideApplier.cs
+++ b/Editor/Content/PrefabOverrideApplier.cs
@@ -1,0 +1,331 @@
+using System.Globalization;
+using YamlDotNet.RepresentationModel;
+
+namespace SailorEditor.Content;
+
+public static class PrefabOverrideApplier
+{
+    public static string Apply(string sourceYaml, string linkedPrefabYaml)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceYaml);
+        ArgumentException.ThrowIfNullOrWhiteSpace(linkedPrefabYaml);
+
+        var sourceStream = new YamlStream();
+        sourceStream.Load(new StringReader(sourceYaml));
+        var linkedStream = new YamlStream();
+        linkedStream.Load(new StringReader(linkedPrefabYaml));
+        if (sourceStream.Documents.Count != 1 ||
+            linkedStream.Documents.Count != 1 ||
+            sourceStream.Documents[0].RootNode is not YamlMappingNode source ||
+            linkedStream.Documents[0].RootNode is not YamlMappingNode linked)
+        {
+            throw new InvalidDataException("Prefab YAML root is invalid.");
+        }
+
+        ApplyExpandedGameObjectValues(source, linked);
+        ApplyExpandedComponentValues(source, linked);
+        ApplyGameObjectOverrides(source, linked);
+        ApplyComponentOverrides(source, linked);
+
+        var yaml = new YamlStream(new YamlDocument(source));
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        yaml.Save(writer, false);
+        return writer.ToString();
+    }
+
+    static void ApplyExpandedGameObjectValues(
+        YamlMappingNode source,
+        YamlMappingNode linked)
+    {
+        if (!TryGetSequence(source, "gameObjects", out var sourceObjects) ||
+            !TryGetSequence(linked, "gameObjects", out var linkedObjects))
+        {
+            return;
+        }
+
+        var instanceIds = ReadInstanceIdMap(linked);
+        var linkedByInstanceId = IndexByInstanceId(linkedObjects);
+        foreach (var sourceObject in sourceObjects.Children
+                     .OfType<YamlMappingNode>())
+        {
+            if (!TryGetScalar(sourceObject, "instanceId", out var sourceId) ||
+                !linkedByInstanceId.TryGetValue(
+                    ResolveLiveInstanceId(sourceId, instanceIds),
+                    out var linkedObject))
+            {
+                continue;
+            }
+
+            foreach (var propertyName in new[]
+                     {
+                         "name",
+                         "scale"
+                     })
+            {
+                var key = new YamlScalarNode(propertyName);
+                if (linkedObject.Children.TryGetValue(key, out var value))
+                    sourceObject.Children[key] = value;
+            }
+        }
+    }
+
+    static void ApplyExpandedComponentValues(
+        YamlMappingNode source,
+        YamlMappingNode linked)
+    {
+        if (!TryGetSequence(source, "components", out var sourceComponents) ||
+            !TryGetSequence(linked, "components", out var linkedComponents))
+        {
+            return;
+        }
+
+        var instanceIds = ReadInstanceIdMap(linked);
+        var linkedByInstanceId = linkedComponents.Children
+            .OfType<YamlMappingNode>()
+            .Where(component =>
+                TryGetMapping(component, "overrideProperties", out var properties) &&
+                TryGetScalar(properties, "instanceId", out _))
+            .ToDictionary(
+                component => GetScalar(
+                    (YamlMappingNode)component.Children[
+                        new YamlScalarNode("overrideProperties")],
+                    "instanceId"),
+                StringComparer.Ordinal);
+
+        foreach (var sourceComponent in sourceComponents.Children
+                     .OfType<YamlMappingNode>())
+        {
+            if (!TryGetMapping(
+                    sourceComponent,
+                    "overrideProperties",
+                    out var sourceProperties) ||
+                !TryGetScalar(sourceProperties, "instanceId", out var sourceId) ||
+                !linkedByInstanceId.TryGetValue(
+                    ResolveLiveInstanceId(sourceId, instanceIds),
+                    out var linkedComponent) ||
+                !TryGetMapping(
+                    linkedComponent,
+                    "overrideProperties",
+                    out var linkedProperties))
+            {
+                continue;
+            }
+
+            if (TryGetScalar(sourceComponent, "typename", out var sourceType) &&
+                TryGetScalar(linkedComponent, "typename", out var linkedType) &&
+                !string.Equals(sourceType, linkedType, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            CopyComponentProperties(linkedProperties, sourceProperties);
+        }
+    }
+
+    static void ApplyGameObjectOverrides(
+        YamlMappingNode source,
+        YamlMappingNode linked)
+    {
+        if (!TryGetMapping(linked, "gameObjectOverrides", out var overrides) ||
+            !TryGetSequence(source, "gameObjects", out var gameObjects))
+        {
+            return;
+        }
+
+        var byInstanceId = gameObjects.Children
+            .OfType<YamlMappingNode>()
+            .Where(gameObject => TryGetScalar(
+                gameObject,
+                "instanceId",
+                out _))
+            .ToDictionary(
+                gameObject => GetScalar(gameObject, "instanceId"),
+                StringComparer.Ordinal);
+        foreach (var entry in overrides.Children)
+        {
+            var sourceId = (entry.Key as YamlScalarNode)?.Value;
+            if (sourceId is null ||
+                entry.Value is not YamlMappingNode values ||
+                !byInstanceId.TryGetValue(sourceId, out var target))
+            {
+                continue;
+            }
+
+            foreach (var value in values.Children)
+            {
+                if (IsPrefabRoot(target) &&
+                    (value.Key as YamlScalarNode)?.Value is
+                        "position" or "rotation")
+                {
+                    continue;
+                }
+                target.Children[value.Key] = value.Value;
+            }
+        }
+    }
+
+    static bool IsPrefabRoot(YamlMappingNode gameObject) =>
+        TryGetScalar(gameObject, "parentIndex", out var parentIndex) &&
+        parentIndex == uint.MaxValue.ToString(CultureInfo.InvariantCulture);
+
+    static void ApplyComponentOverrides(
+        YamlMappingNode source,
+        YamlMappingNode linked)
+    {
+        if (!TryGetMapping(linked, "componentOverrides", out var overrides) ||
+            !TryGetSequence(source, "components", out var components))
+        {
+            return;
+        }
+
+        var byInstanceId = components.Children
+            .OfType<YamlMappingNode>()
+            .Where(component =>
+                TryGetMapping(component, "overrideProperties", out var properties) &&
+                TryGetScalar(properties, "instanceId", out _))
+            .ToDictionary(
+                component => GetScalar(
+                    (YamlMappingNode)component.Children[
+                        new YamlScalarNode("overrideProperties")],
+                    "instanceId"),
+                StringComparer.Ordinal);
+        foreach (var entry in overrides.Children)
+        {
+            var sourceId = (entry.Key as YamlScalarNode)?.Value;
+            if (sourceId is null ||
+                entry.Value is not YamlMappingNode reflectedOverride ||
+                !byInstanceId.TryGetValue(sourceId, out var target) ||
+                !TryGetMapping(
+                    reflectedOverride,
+                    "overrideProperties",
+                    out var changedProperties) ||
+                !TryGetMapping(
+                    target,
+                    "overrideProperties",
+                    out var targetProperties))
+            {
+                continue;
+            }
+
+            if (TryGetScalar(reflectedOverride, "typename", out var typename))
+            {
+                target.Children[new YamlScalarNode("typename")] =
+                    new YamlScalarNode(typename);
+            }
+            CopyComponentProperties(changedProperties, targetProperties);
+        }
+    }
+
+    static void CopyComponentProperties(
+        YamlMappingNode source,
+        YamlMappingNode target)
+    {
+        foreach (var property in source.Children)
+        {
+            if ((property.Key as YamlScalarNode)?.Value is
+                "fileId" or "instanceId")
+            {
+                continue;
+            }
+            target.Children[property.Key] = property.Value;
+        }
+    }
+
+    static Dictionary<string, string> ReadInstanceIdMap(
+        YamlMappingNode linked)
+    {
+        if (!TryGetMapping(linked, "instanceIds", out var mapping))
+            return new Dictionary<string, string>(StringComparer.Ordinal);
+
+        return mapping.Children
+            .Where(entry =>
+                entry.Key is YamlScalarNode { Value: not null } &&
+                entry.Value is YamlScalarNode { Value: not null })
+            .ToDictionary(
+                entry => ((YamlScalarNode)entry.Key).Value!,
+                entry => ((YamlScalarNode)entry.Value).Value!,
+                StringComparer.Ordinal);
+    }
+
+    static Dictionary<string, YamlMappingNode> IndexByInstanceId(
+        YamlSequenceNode nodes) => nodes.Children
+        .OfType<YamlMappingNode>()
+        .Where(node => TryGetScalar(node, "instanceId", out _))
+        .ToDictionary(
+            node => GetScalar(node, "instanceId"),
+            StringComparer.Ordinal);
+
+    static string ResolveLiveInstanceId(
+        string sourceId,
+        IReadOnlyDictionary<string, string> instanceIds)
+    {
+        if (instanceIds.TryGetValue(sourceId, out var liveId))
+            return liveId;
+
+        var separator = sourceId.LastIndexOf('_');
+        if (separator >= 0 &&
+            instanceIds.TryGetValue(
+                sourceId[(separator + 1)..],
+                out var liveOwnerId))
+        {
+            return sourceId[..(separator + 1)] + liveOwnerId;
+        }
+
+        return sourceId;
+    }
+
+    static bool TryGetMapping(
+        YamlMappingNode parent,
+        string key,
+        out YamlMappingNode mapping)
+    {
+        if (parent.Children.TryGetValue(
+                new YamlScalarNode(key),
+                out var value) &&
+            value is YamlMappingNode resolved)
+        {
+            mapping = resolved;
+            return true;
+        }
+
+        mapping = null!;
+        return false;
+    }
+
+    static bool TryGetSequence(
+        YamlMappingNode parent,
+        string key,
+        out YamlSequenceNode sequence)
+    {
+        if (parent.Children.TryGetValue(
+                new YamlScalarNode(key),
+                out var value) &&
+            value is YamlSequenceNode resolved)
+        {
+            sequence = resolved;
+            return true;
+        }
+
+        sequence = null!;
+        return false;
+    }
+
+    static bool TryGetScalar(
+        YamlMappingNode parent,
+        string key,
+        out string value)
+    {
+        value = string.Empty;
+        return parent.Children.TryGetValue(
+                new YamlScalarNode(key),
+                out var node) &&
+            node is YamlScalarNode { Value: not null } scalar &&
+            !string.IsNullOrWhiteSpace(value = scalar.Value);
+    }
+
+    static string GetScalar(YamlMappingNode parent, string key) =>
+        TryGetScalar(parent, key, out var value)
+            ? value
+            : throw new InvalidDataException(
+                $"Prefab field '{key}' is missing.");
+}

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -619,6 +619,96 @@ namespace SailorEditor.Services
             return new PrefabAssetWriteResult(created, transaction);
         }
 
+        public PrefabAssetWriteResult? BeginApplyPrefabOverrides(
+            PrefabFile existingPrefab,
+            string linkedPrefabYaml)
+        {
+            ArgumentNullException.ThrowIfNull(existingPrefab);
+            if (existingPrefab.IsReadOnly ||
+                existingPrefab.FileId is null ||
+                existingPrefab.FileId.IsEmpty() ||
+                !ProjectContentPathPolicy.IsInsideRoot(
+                    CurrentProjectRootPath,
+                    existingPrefab.Asset.FullName))
+            {
+                return null;
+            }
+
+            string sourceContents;
+            string metadataContents;
+            try
+            {
+                sourceContents = File.ReadAllText(existingPrefab.Asset.FullName);
+                metadataContents = File.ReadAllText(existingPrefab.AssetInfo.FullName);
+                sourceContents = PrefabOverrideApplier.Apply(
+                    sourceContents,
+                    linkedPrefabYaml);
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"Apply prefab preparation failed: {exception}");
+                return null;
+            }
+
+            ProjectContentAssetWriteTransaction transaction;
+            lock (_watcherLock)
+            {
+                var watcherStates = _contentWatchers
+                    .Select(watcher => watcher.EnableRaisingEvents)
+                    .ToArray();
+                try
+                {
+                    foreach (var watcher in _contentWatchers)
+                        watcher.EnableRaisingEvents = false;
+                    transaction = _fileOperations.BeginWriteAssetPair(
+                        CurrentProjectRootPath,
+                        existingPrefab.Asset.FullName,
+                        sourceContents,
+                        metadataContents,
+                        existingPrefab.FileId.Value,
+                        overwrite: true);
+                }
+                finally
+                {
+                    for (var index = 0;
+                        index < _contentWatchers.Count;
+                        index++)
+                    {
+                        _contentWatchers[index].EnableRaisingEvents =
+                            watcherStates[index];
+                    }
+                }
+            }
+
+            if (!transaction.Result.Succeeded)
+                return null;
+
+            try
+            {
+                Refresh();
+            }
+            catch
+            {
+                CompletePrefabAssetWrite(transaction, commit: false);
+                return null;
+            }
+
+            var refreshed = Assets.TryGetValue(
+                    existingPrefab.FileId,
+                    out var asset) &&
+                asset is PrefabFile prefabFile
+                    ? prefabFile
+                    : null;
+            if (refreshed is null)
+            {
+                CompletePrefabAssetWrite(transaction, commit: false);
+                return null;
+            }
+
+            return new PrefabAssetWriteResult(refreshed, transaction);
+        }
+
         public ProjectContentFileOperationResult CompletePrefabAssetWrite(
             ProjectContentAssetWriteTransaction transaction,
             bool commit)
@@ -1866,6 +1956,7 @@ namespace SailorEditor.Services
                 "Sailor::AnimationAssetInfo" => new AnimationFile(),
                 "Sailor::AnimationControllerAssetInfo" => new AnimationControllerFile(),
                 "Sailor::AnimationSetAssetInfo" => new AnimationSetFile(),
+                "Sailor::AudioAssetInfo" => new AudioFile(),
                 "Sailor::PrefabAssetInfo" => new PrefabFile(),
                 "Sailor::WorldPrefabAssetInfo" => new WorldFile(),
                 "Sailor::ShaderAssetInfo" when string.Equals(
@@ -1924,6 +2015,7 @@ namespace SailorEditor.Services
             ".anim" => new AnimationFile(),
             ".animcontroller" => new AnimationControllerFile(),
             ".animset" => new AnimationSetFile(),
+            ".wav" or ".flac" or ".mp3" => new AudioFile(),
             ".prefab" => new PrefabFile(),
             ".world" => new WorldFile(),
             ".shader" => new ShaderFile(),

--- a/Editor/Utility/EngineTypes.cs
+++ b/Editor/Utility/EngineTypes.cs
@@ -196,6 +196,8 @@ namespace SailorEngine
                 "class Sailor::AnimationController" => typeof(AnimationControllerFile),
                 "Sailor::AnimationSet" => typeof(AnimationSetFile),
                 "class Sailor::AnimationSet" => typeof(AnimationSetFile),
+                "Sailor::AudioClip" => typeof(AudioFile),
+                "class Sailor::AudioClip" => typeof(AudioFile),
                 _ => null
             };
 

--- a/Editor/ViewModels/AssetFile.cs
+++ b/Editor/ViewModels/AssetFile.cs
@@ -391,6 +391,7 @@ public partial class AssetFile : ObservableObject, ICloneable
             AnimationFile => "Sailor::AnimationAssetInfo",
             AnimationControllerFile => "Sailor::AnimationControllerAssetInfo",
             AnimationSetFile => "Sailor::AnimationSetAssetInfo",
+            AudioFile => "Sailor::AudioAssetInfo",
             FrameGraphFile => "Sailor::FrameGraphAssetInfo",
             MaterialFile => "Sailor::MaterialAssetInfo",
             ModelFile => "Sailor::ModelAssetInfo",

--- a/Editor/ViewModels/AudioFile.cs
+++ b/Editor/ViewModels/AudioFile.cs
@@ -1,0 +1,5 @@
+namespace SailorEditor.ViewModels;
+
+public sealed class AudioFile : AssetFile
+{
+}

--- a/Editor/ViewModels/GameObject.cs
+++ b/Editor/ViewModels/GameObject.cs
@@ -57,8 +57,27 @@ public partial class GameObject : ObservableObject, ICloneable, IInspectorEditab
         {
             await _commitGate.WaitAsync(cancellationToken);
             acquired = true;
-            return await CommitInspectorChangesCoreAsync(
-                cancellationToken);
+            if (!await CommitInspectorChangesCoreAsync(cancellationToken) &&
+                HasPendingGameObjectChanges)
+            {
+                return false;
+            }
+
+            foreach (var component in GetComponentsSafely().ToArray())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (!component.HasPendingInspectorChanges)
+                    continue;
+
+                if (!await component.CommitInspectorChangesAsync(
+                        cancellationToken) &&
+                    component.HasPendingInspectorChanges)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
         finally
         {
@@ -132,7 +151,25 @@ public partial class GameObject : ObservableObject, ICloneable, IInspectorEditab
 
     [YamlIgnore]
     public bool HasPendingInspectorChanges =>
+        HasPendingGameObjectChanges ||
+        GetComponentsSafely().Any(component =>
+            component.HasPendingInspectorChanges);
+
+    [YamlIgnore]
+    bool HasPendingGameObjectChanges =>
         IsDirty || Volatile.Read(ref pendingInspectorCommits) != 0;
+
+    IEnumerable<Component> GetComponentsSafely()
+    {
+        try
+        {
+            return Components;
+        }
+        catch
+        {
+            return [];
+        }
+    }
 
     public void Initialize()
     {
@@ -160,6 +197,37 @@ public partial class GameObject : ObservableObject, ICloneable, IInspectorEditab
 
     [YamlIgnore]
     public int PrefabIndex = -1;
+
+    [YamlIgnore]
+    public bool IsPrefabLinked => TryGetLinkedPrefab(out _);
+
+    [YamlIgnore]
+    public string? PrefabFileId =>
+        TryGetLinkedPrefab(out var prefab)
+            ? prefab.FileId?.Value
+            : null;
+
+    bool TryGetLinkedPrefab(out Prefab prefab)
+    {
+        prefab = null!;
+        try
+        {
+            var world = MauiProgram.GetService<WorldService>();
+            if (PrefabIndex < 0 ||
+                PrefabIndex >= world.Current.Prefabs.Count)
+            {
+                return false;
+            }
+
+            prefab = world.Current.Prefabs[PrefabIndex];
+            return prefab.FileId is not null &&
+                !prefab.FileId.IsEmpty();
+        }
+        catch
+        {
+            return false;
+        }
+    }
 
     public void MarkDirty([CallerMemberName] string propertyName = null) { IsDirty = true; OnPropertyChanged(propertyName); }
 

--- a/Editor/Views/InspectorView/GameObjectTemplate.xaml
+++ b/Editor/Views/InspectorView/GameObjectTemplate.xaml
@@ -34,39 +34,49 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <!-- Properties Label -->
-        <Label Text="Transform" FontAttributes="Bold" Grid.Row="0" Grid.ColumnSpan="2" />
+        <HorizontalStackLayout Grid.Row="0"
+                               Grid.ColumnSpan="2"
+                               Spacing="8"
+                               IsVisible="{Binding IsPrefabLinked}">
+            <Button Text="Apply prefab"
+                    Clicked="OnApplyPrefabClicked" />
+            <Button Text="Select Prefab"
+                    Clicked="OnSelectPrefabClicked" />
+        </HorizontalStackLayout>
 
-        <Label Text="Position" VerticalOptions="Center" Grid.Row="1" Grid.Column="0"/>
-        <Grid Grid.Row="1" Grid.Column="1" ColumnSpacing="6" ColumnDefinitions="*,*,*" HorizontalOptions="Fill">
+        <!-- Properties Label -->
+        <Label Text="Transform" FontAttributes="Bold" Grid.Row="1" Grid.ColumnSpan="2" />
+
+        <Label Text="Position" VerticalOptions="Center" Grid.Row="2" Grid.Column="0"/>
+        <Grid Grid.Row="2" Grid.Column="1" ColumnSpacing="6" ColumnDefinitions="*,*,*" HorizontalOptions="Fill">
             <Entry Grid.Column="0" Text="{Binding Position.X, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" HorizontalOptions="Fill" ReturnType="Done" Completed="OnEntryCompleted" Unfocused="OnEntryUnfocused" Keyboard="Numeric"/>
             <Entry Grid.Column="1" Text="{Binding Position.Y, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" HorizontalOptions="Fill" ReturnType="Done" Completed="OnEntryCompleted" Unfocused="OnEntryUnfocused" Keyboard="Numeric"/>
             <Entry Grid.Column="2" Text="{Binding Position.Z, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" HorizontalOptions="Fill" ReturnType="Done" Completed="OnEntryCompleted" Unfocused="OnEntryUnfocused" Keyboard="Numeric"/>
         </Grid>
 
-        <Label Text="Rotation" VerticalOptions="Center" Grid.Row="2" Grid.Column="0"/>
-        <Grid Grid.Row="2" Grid.Column="1" ColumnSpacing="6" ColumnDefinitions="*,*,*" HorizontalOptions="Fill">
+        <Label Text="Rotation" VerticalOptions="Center" Grid.Row="3" Grid.Column="0"/>
+        <Grid Grid.Row="3" Grid.Column="1" ColumnSpacing="6" ColumnDefinitions="*,*,*" HorizontalOptions="Fill">
             <Entry Grid.Column="0" Text="{Binding Rotation.Yaw, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" HorizontalOptions="Fill" ReturnType="Done" Completed="OnEntryCompleted" Unfocused="OnEntryUnfocused" Keyboard="Numeric"/>
             <Entry Grid.Column="1" Text="{Binding Rotation.Pitch, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" HorizontalOptions="Fill" ReturnType="Done" Completed="OnEntryCompleted" Unfocused="OnEntryUnfocused" Keyboard="Numeric"/>
             <Entry Grid.Column="2" Text="{Binding Rotation.Roll, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" HorizontalOptions="Fill" ReturnType="Done" Completed="OnEntryCompleted" Unfocused="OnEntryUnfocused" Keyboard="Numeric"/>
         </Grid>
 
-        <Label Text="Scale" VerticalOptions="Center" Grid.Row="3" Grid.Column="0"/>
-        <Grid Grid.Row="3" Grid.Column="1" ColumnSpacing="6" ColumnDefinitions="*,*,*" HorizontalOptions="Fill">
+        <Label Text="Scale" VerticalOptions="Center" Grid.Row="4" Grid.Column="0"/>
+        <Grid Grid.Row="4" Grid.Column="1" ColumnSpacing="6" ColumnDefinitions="*,*,*" HorizontalOptions="Fill">
             <Entry Grid.Column="0" Text="{Binding Scale.X, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" HorizontalOptions="Fill" ReturnType="Done" Completed="OnEntryCompleted" Unfocused="OnEntryUnfocused" Keyboard="Numeric"/>
             <Entry Grid.Column="1" Text="{Binding Scale.Y, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" HorizontalOptions="Fill" ReturnType="Done" Completed="OnEntryCompleted" Unfocused="OnEntryUnfocused" Keyboard="Numeric"/>
             <Entry Grid.Column="2" Text="{Binding Scale.Z, Converter={StaticResource FloatValueConverter}}" VerticalOptions="Center" HorizontalOptions="Fill" ReturnType="Done" Completed="OnEntryCompleted" Unfocused="OnEntryUnfocused" Keyboard="Numeric"/>
         </Grid>
 
 
-        <Label Text="Components" FontAttributes="Bold" Grid.Row="4" Grid.ColumnSpan="2" />
+        <Label Text="Components" FontAttributes="Bold" Grid.Row="5" Grid.ColumnSpan="2" />
 
-        <HorizontalStackLayout Grid.Row="5" Grid.ColumnSpan="2">
+        <HorizontalStackLayout Grid.Row="6" Grid.ColumnSpan="2">
             <Button Text="Add Component"
                     Clicked="OnAddComponentClicked" />
         </HorizontalStackLayout>
 
-        <CollectionView Grid.Row="6" Grid.ColumnSpan="2" ItemsSource="{Binding Components}" ItemTemplate="{StaticResource ComponentTemplateSelector}" />
+        <CollectionView Grid.Row="7" Grid.ColumnSpan="2" ItemsSource="{Binding Components}" ItemTemplate="{StaticResource ComponentTemplateSelector}" />
 
     </Grid>
 </DataTemplate>

--- a/Editor/Views/InspectorView/GameObjectTemplate.xaml.cs
+++ b/Editor/Views/InspectorView/GameObjectTemplate.xaml.cs
@@ -1,5 +1,10 @@
 using SailorEditor.ViewModels;
 using SailorEditor.Services;
+using SailorEditor.Commands;
+using SailorEditor.Panels;
+using SailorEditor.Shell;
+using SailorEditor.Workflow;
+using SailorEngine;
 
 namespace SailorEditor;
 
@@ -41,6 +46,93 @@ public partial class GameObjectTemplate : DataTemplate
     {
         if (ResolveGameObject(sender) is GameObject gameObject)
             await gameObject.AddComponentFromInspectorAsync();
+    }
+
+    async void OnApplyPrefabClicked(object sender, EventArgs e)
+    {
+        if (ResolveGameObject(sender) is not GameObject gameObject)
+            return;
+
+        var host = MauiProgram.GetService<EditorShellHost>();
+        try
+        {
+            if (!await MauiProgram
+                    .GetService<InspectorPendingEditCoordinator>()
+                    .CommitPendingChangesAsync())
+            {
+                throw new InvalidOperationException(
+                    "Pending Inspector changes could not be committed.");
+            }
+
+            var context = MauiProgram
+                .GetService<IActionContextProvider>()
+                .GetCurrentContext(new CommandOrigin(
+                    CommandOriginKind.UI,
+                    nameof(GameObjectTemplate)));
+            var result = await MauiProgram
+                .GetService<ICommandDispatcher>()
+                .DispatchAsync(
+                    new ApplyPrefabInstanceCommand(gameObject),
+                    context);
+            if (!result.Succeeded)
+            {
+                throw new InvalidOperationException(
+                    result.Message ?? "Apply prefab failed.");
+            }
+            host.SetStatus("Prefab changes applied.");
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"Apply prefab failed: {exception}");
+            host.SetStatus($"Apply prefab failed: {exception.Message}");
+        }
+    }
+
+    async void OnSelectPrefabClicked(object sender, EventArgs e)
+    {
+        if (ResolveGameObject(sender) is not GameObject
+            {
+                PrefabFileId: not null
+            } gameObject ||
+            string.IsNullOrWhiteSpace(gameObject.PrefabFileId))
+        {
+            return;
+        }
+
+        var host = MauiProgram.GetService<EditorShellHost>();
+        try
+        {
+            var fileId = new FileId(gameObject.PrefabFileId);
+            if (!MauiProgram.GetService<AssetsService>()
+                    .Assets.TryGetValue(fileId, out var asset) ||
+                asset is not PrefabFile prefab)
+            {
+                throw new InvalidOperationException(
+                    $"Prefab asset '{fileId.Value}' is not available.");
+            }
+
+            await host.OpenPanelAsync(KnownPanelTypes.Content);
+            var context = MauiProgram
+                .GetService<IActionContextProvider>()
+                .GetCurrentContext(new CommandOrigin(
+                    CommandOriginKind.UI,
+                    nameof(GameObjectTemplate)));
+            var result = await MauiProgram
+                .GetService<ICommandDispatcher>()
+                .DispatchAsync(new OpenAssetCommand(prefab), context);
+            if (!result.Succeeded)
+            {
+                throw new InvalidOperationException(
+                    result.Message ?? "Select prefab failed.");
+            }
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"Select prefab failed: {exception}");
+            host.SetStatus($"Select prefab failed: {exception.Message}");
+        }
     }
 
     static GameObject ResolveGameObject(object sender)

--- a/Runtime/AssetRegistry/FileId.cpp
+++ b/Runtime/AssetRegistry/FileId.cpp
@@ -8,10 +8,46 @@
 #include <cstdio>
 #endif
 
+#include <cctype>
+
 using namespace Sailor;
 using namespace nlohmann;
 
 const FileId FileId::Invalid = FileId();
+
+namespace
+{
+	std::string CanonicalizeFileId(std::string value)
+	{
+		const bool bHasBraces = value.size() == 38 &&
+			value.front() == '{' && value.back() == '}';
+		if (!bHasBraces && value.size() != 36)
+			return value;
+
+		const size_t offset = bHasBraces ? 1 : 0;
+		std::string canonical;
+		canonical.reserve(36);
+		for (size_t index = 0; index < 36; index++)
+		{
+			const char character = value[index + offset];
+			if (index == 8 || index == 13 || index == 18 || index == 23)
+			{
+				if (character != '-')
+					return value;
+				canonical.push_back(character);
+				continue;
+			}
+
+			if (!std::isxdigit(static_cast<unsigned char>(character)))
+				return value;
+
+			canonical.push_back(static_cast<char>(
+				std::toupper(static_cast<unsigned char>(character))));
+		}
+
+		return canonical;
+	}
+}
 
 YAML::Node FileId::Serialize() const
 {
@@ -22,7 +58,7 @@ YAML::Node FileId::Serialize() const
 
 void FileId::Deserialize(const YAML::Node& inData)
 {
-	m_fileId = StringHash::Runtime(inData.as<std::string>());
+	m_fileId = StringHash::Runtime(CanonicalizeFileId(inData.as<std::string>()));
 }
 
 const std::string& FileId::ToString() const
@@ -53,6 +89,6 @@ FileId FileId::CreateNewFileId()
 	uuid_unparse_upper(id, buffer);
 #endif
 
-	newuid.m_fileId = StringHash::Runtime(std::string(buffer));
+	newuid.m_fileId = StringHash::Runtime(CanonicalizeFileId(buffer));
 	return newuid;
 }

--- a/Runtime/AssetRegistry/Model/ModelAssetInfo.h
+++ b/Runtime/AssetRegistry/Model/ModelAssetInfo.h
@@ -24,6 +24,7 @@ namespace Sailor
 		SAILOR_API bool ShouldKeepCpuBuffers() const { return m_bShouldKeepCpuBuffers; }
 		SAILOR_API bool ShouldGenerateBLAS() const { return m_bGenerateBLAS; }
 		SAILOR_API bool ShouldGenerateLods() const { return m_bGenerateLods; }
+		SAILOR_API bool ShouldFlipTexcoordY() const { return m_bFlipTexcoordY; }
 		SAILOR_API uint32_t GetNumGeneratedLods() const { return m_numGeneratedLods; }
 		SAILOR_API float GetLodReductionFactor() const { return m_lodReductionFactor; }
 
@@ -46,6 +47,7 @@ namespace Sailor
 		bool m_bShouldKeepCpuBuffers = false;
 		bool m_bGenerateBLAS = true;
 		bool m_bGenerateLods = true;
+		bool m_bFlipTexcoordY = false;
 		uint32_t m_numGeneratedLods = 2u;
 		float m_lodReductionFactor = 0.5f;
 	};
@@ -77,6 +79,7 @@ REFL_AUTO(
 	field(m_bShouldKeepCpuBuffers),
 	field(m_bGenerateBLAS),
 	field(m_bGenerateLods),
+	field(m_bFlipTexcoordY),
 	field(m_numGeneratedLods),
 	field(m_lodReductionFactor),
 	field(m_unitScale),

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -61,7 +61,7 @@ namespace
 		4ull * 1024ull * 1024ull;
 	constexpr int32_t MaxFingerprintTextureDimension = 256;
 	constexpr int32_t FingerprintImageDimension = 256;
-	constexpr uint32_t ModelLodCacheVersion = 2u;
+	constexpr uint32_t ModelLodCacheVersion = 3u;
 	constexpr uint32_t MaxGeneratedModelLods = 8u;
 	constexpr uint64_t MaxModelLodCacheBytes = 1024ull * 1024ull * 1024ull;
 	constexpr std::array<char, 8> ModelLodCacheMagic = {
@@ -81,6 +81,7 @@ namespace
 		float m_unitScale = 1.0f;
 		float m_reductionFactor = 0.5f;
 		uint32_t m_bBatchByMaterial = 0u;
+		uint32_t m_bFlipTexcoordY = 0u;
 	};
 
 	struct ModelLodCacheMeshHeader
@@ -179,7 +180,8 @@ namespace
 			header.m_sourceContentHash == sourceRevision.m_contentHash &&
 			header.m_unitScale == assetInfo.GetUnitScale() &&
 			header.m_reductionFactor == assetInfo.GetLodReductionFactor() &&
-			header.m_bBatchByMaterial == static_cast<uint32_t>(assetInfo.ShouldBatchByMaterial());
+			header.m_bBatchByMaterial == static_cast<uint32_t>(assetInfo.ShouldBatchByMaterial()) &&
+			header.m_bFlipTexcoordY == static_cast<uint32_t>(assetInfo.ShouldFlipTexcoordY());
 	}
 
 	bool LoadModelLodCache(
@@ -303,6 +305,7 @@ namespace
 		header.m_unitScale = assetInfo.GetUnitScale();
 		header.m_reductionFactor = assetInfo.GetLodReductionFactor();
 		header.m_bBatchByMaterial = static_cast<uint32_t>(assetInfo.ShouldBatchByMaterial());
+		header.m_bFlipTexcoordY = static_cast<uint32_t>(assetInfo.ShouldFlipTexcoordY());
 
 		std::string bytes;
 		AppendModelLodCacheBytes(bytes, header);
@@ -3816,6 +3819,7 @@ void ModelImporter::GenerateFingerprintAsync(ModelAssetInfoPtr modelAssetInfo)
 	const std::string assetFilepath = modelAssetInfo->GetAssetFilepath();
 	const float unitScale = modelAssetInfo->GetUnitScale();
 	const bool bShouldBatchByMaterial = modelAssetInfo->ShouldBatchByMaterial();
+	const bool bFlipTexcoordY = modelAssetInfo->ShouldFlipTexcoordY();
 	FileRevision sourceRevision;
 	if (!Utils::TryGetFileRevision(assetFilepath, sourceRevision))
 	{
@@ -3861,6 +3865,7 @@ void ModelImporter::GenerateFingerprintAsync(ModelAssetInfoPtr modelAssetInfo)
 			assetFilepath,
 			unitScale,
 			bShouldBatchByMaterial,
+			bFlipTexcoordY,
 			outputPath,
 			generation,
 			sourceRevision
@@ -3879,6 +3884,7 @@ void ModelImporter::GenerateFingerprintAsync(ModelAssetInfoPtr modelAssetInfo)
 					assetFilepath,
 					unitScale,
 					bShouldBatchByMaterial,
+					bFlipTexcoordY,
 					outputPath.string());
 			}
 
@@ -3905,6 +3911,7 @@ bool ModelImporter::GenerateFingerprint(
 	const std::string& assetFilepath,
 	float unitScale,
 	bool bShouldBatchByMaterial,
+	bool bFlipTexcoordY,
 	const std::string& outputPath)
 {
 	TVector<MeshContext> parsedMeshes;
@@ -3914,9 +3921,10 @@ bool ModelImporter::GenerateFingerprint(
 	tinygltf::Model gltfModel;
 	if (!ImportModel(
 			assetFilepath,
-			unitScale,
-			bShouldBatchByMaterial,
-			parsedMeshes,
+		unitScale,
+		bShouldBatchByMaterial,
+		bFlipTexcoordY,
+		parsedMeshes,
 			boundsAabb,
 			boundsSphere,
 			inverseBind,
@@ -5679,6 +5687,7 @@ Tasks::TaskPtr<ModelPtr> ModelImporter::LoadModel(FileId uid, ModelPtr& outModel
 					pAssetInfo->GetAssetFilepath(),
 					pAssetInfo->GetUnitScale(),
 					pAssetInfo->ShouldBatchByMaterial(),
+					pAssetInfo->ShouldFlipTexcoordY(),
 					pData->m_parsedMeshes,
 					boundsAabb,
 					boundsSphere,
@@ -6005,6 +6014,7 @@ bool ModelImporter::ImportModel(ModelAssetInfoPtr assetInfo, TVector<MeshContext
 			assetInfo->GetAssetFilepath(),
 			assetInfo->GetUnitScale(),
 			assetInfo->ShouldBatchByMaterial(),
+			assetInfo->ShouldFlipTexcoordY(),
 			outParsedMeshes,
 			outBoundsAabb,
 			outBoundsSphere,
@@ -6015,6 +6025,7 @@ bool ModelImporter::ImportModel(
 	const std::string& assetFilepath,
 	float unitScale,
 	bool bShouldBatchByMaterial,
+	bool bFlipTexcoordY,
 	TVector<MeshContext>& outParsedMeshes,
 	Math::AABB& outBoundsAabb,
 	Math::Sphere& outBoundsSphere,
@@ -6453,6 +6464,10 @@ bool ModelImporter::ImportModel(
 						ReadAccessorFloat(texcoordView, i, 0),
 						ReadAccessorFloat(texcoordView, i, 1)) :
 					glm::vec2(0.0f);
+				if (bHasTexcoords && bFlipTexcoordY)
+				{
+					vertex.m_texcoord.y = 1.0f - vertex.m_texcoord.y;
+				}
 				const glm::vec3 sourceTangent = bHasTangents ?
 					glm::vec3(
 						ReadAccessorFloat(tangentView, i, 0),

--- a/Runtime/AssetRegistry/Model/ModelImporter.h
+++ b/Runtime/AssetRegistry/Model/ModelImporter.h
@@ -242,6 +242,7 @@ namespace Sailor
 			const std::string& assetFilepath,
 			float unitScale,
 			bool bShouldBatchByMaterial,
+			bool bFlipTexcoordY,
 			TVector<MeshContext>& outParsedMeshes,
 			Math::AABB& outBoundsAabb,
 			Math::Sphere& outBoundsSphere,
@@ -255,6 +256,7 @@ namespace Sailor
 			const std::string& assetFilepath,
 			float unitScale,
 			bool bShouldBatchByMaterial,
+			bool bFlipTexcoordY,
 			const std::string& outputPath);
 		static void GenerateFingerprintAsync(ModelAssetInfoPtr modelAssetInfo);
 

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -485,16 +485,11 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 				result.m_skeletonOffset,
 				currentFrame);
 
-			if (owner->GetMobilityType() == EMobilityType::Stationary)
+			if (owner->GetMobilityType() != EMobilityType::Static)
 			{
 				result.m_state = EPreparedProxyState::Stationary;
 				result.m_stationaryProxy.m_staticMeshEcs = componentIndex;
 				result.m_stationaryProxy.m_worldMatrix = ownerWorldMatrix;
-				return result;
-			}
-
-			if (owner->GetMobilityType() != EMobilityType::Static)
-			{
 				return result;
 			}
 

--- a/Runtime/Engine/World.cpp
+++ b/Runtime/Engine/World.cpp
@@ -1276,7 +1276,7 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 						return newComp->ResolveRefs(
 							reflection,
 							internalDependencies,
-							false);
+							true);
 					},
 					bResolved,
 					resolveDiagnostic))
@@ -1295,7 +1295,7 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 				if (!External::TryInvokeYaml(
 						[newComp, &reflection, this]() mutable
 						{
-							return newComp->ResolveRefs(reflection, m_objectsMap, false);
+							return newComp->ResolveRefs(reflection, m_objectsMap, true);
 						},
 						bResolved,
 						resolveDiagnostic))

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -366,6 +366,29 @@ namespace
 		return result;
 	}
 
+	void TestNewFileIdsUseCrossPlatformGuidFormatting()
+	{
+		const FileId braced = MakeFileId("{7810180E-F1BB-4C88-9C9B-28ED9B086974}");
+		const FileId plain = MakeFileId("7810180E-F1BB-4C88-9C9B-28ED9B086974");
+		const FileId lowercase = MakeFileId("7810180e-f1bb-4c88-9c9b-28ed9b086974");
+		Require(braced == plain && plain == lowercase,
+			"Windows and macOS GUID spellings must resolve to the same FileId");
+		Require(braced.ToString() == "7810180E-F1BB-4C88-9C9B-28ED9B086974",
+			"deserialized GUID FileIds must use uppercase unbraced canonical form");
+		Require(braced.Serialize().as<std::string>() == plain.ToString(),
+			"serialized GUID FileIds must remain portable across platforms");
+		Require(MakeFileId("{ASSET-CACHE-SYMBOLIC}").ToString() ==
+			"{ASSET-CACHE-SYMBOLIC}",
+			"non-GUID symbolic FileIds must remain unchanged");
+		Require(MakeFileId("7810180E-F1BB-4C88-9C9B-INVALID-GUID").ToString() ==
+			"7810180E-F1BB-4C88-9C9B-INVALID-GUID",
+			"malformed GUID-like FileIds must remain unchanged");
+
+		const std::string generated = FileId::CreateNewFileId().ToString();
+		Require(generated.size() == 36 && generated.front() != '{' && generated.back() != '}',
+			"new FileIds must use the same unbraced GUID representation on every platform");
+	}
+
 	FileRevision MakeRevision(
 		int64_t modificationTimeNanoseconds = 123456789,
 		uint64_t fileSize = 64,
@@ -2098,6 +2121,7 @@ int main()
 {
 	try
 	{
+		TestNewFileIdsUseCrossPlatformGuidFormatting();
 		TestPayloadRoundTrip();
 		TestEmptyPayloadRoundTrip();
 		TestPreV1PayloadIsRejected();

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -294,6 +294,8 @@ namespace
 		ModelAssetInfo defaults;
 		Require(defaults.ShouldGenerateLods(),
 			"model assets must generate LODs by default");
+		Require(!defaults.ShouldFlipTexcoordY(),
+			"model assets must preserve glTF texcoords by default");
 		Require(defaults.GetNumGeneratedLods() == 2u,
 			"model assets must generate medium and low LODs by default");
 		Require(NearlyEqual(defaults.GetLodReductionFactor(), 0.5f),
@@ -302,12 +304,15 @@ namespace
 		YAML::Node metadata = defaults.Serialize();
 		Require(metadata["bGenerateLods"].as<bool>(),
 			"model metadata must serialize the LOD generation switch");
+		Require(!metadata["bFlipTexcoordY"].as<bool>(),
+			"model metadata must serialize the texcoord flip switch");
 		Require(metadata["numGeneratedLods"].as<uint32_t>() == 2u,
 			"model metadata must serialize the generated LOD count");
 		Require(NearlyEqual(metadata["lodReductionFactor"].as<float>(), 0.5f),
 			"serialized model LOD reduction factor");
 
 		metadata["bGenerateLods"] = false;
+		metadata["bFlipTexcoordY"] = true;
 		metadata["numGeneratedLods"] = 4u;
 		metadata["lodReductionFactor"] = 0.4f;
 		ModelAssetInfo restored;
@@ -315,6 +320,8 @@ namespace
 		Require(!restored.ShouldGenerateLods() &&
 			restored.GetNumGeneratedLods() == 4u,
 			"model LOD metadata must round-trip generation settings");
+		Require(restored.ShouldFlipTexcoordY(),
+			"model texcoord flip metadata must round-trip");
 		Require(NearlyEqual(restored.GetLodReductionFactor(), 0.4f),
 			"round-tripped model LOD reduction factor");
 
@@ -391,10 +398,10 @@ namespace
 
 		FileId fileId;
 		fileId.Deserialize(YAML::Node("01234567-89ab-cdef-0123-456789abcdef"));
-		Require(
-			ModelImporter::GetLodCacheFilename(fileId, 2u) ==
-				"01234567-89ab-cdef-0123-456789abcdef_lod2.bin",
-			"model LOD cache filenames must follow the fileId_lodN.bin contract");
+			Require(
+				ModelImporter::GetLodCacheFilename(fileId, 2u) ==
+					"01234567-89AB-CDEF-0123-456789ABCDEF_lod2.bin",
+				"model LOD cache filenames must follow the fileId_lodN.bin contract");
 		Require(ModelImporter::GetLodCacheFilename(fileId, 0u).empty(),
 			"LOD0 must remain source geometry instead of a generated cache file");
 	}


### PR DESCRIPTION
## Summary

- add typed editor support for audio assets and `AudioClip` inspector pointers
- add `Apply prefab` and `Select Prefab` actions for linked GameObjects
- merge live prefab overrides back into the source asset while preserving stable source identities and root placement
- commit pending GameObject and component inspector edits before applying a prefab
- use an atomic asset-pair write with native reload validation and rollback
- resolve instantiated prefab references immediately so authored model and audio pointers survive runtime spawning
- keep movable static-mesh instances in the render proxy update path
- add opt-in model texcoord-Y flipping and include it in LOD/fingerprint cache identity
- canonicalize valid UUID FileIds across Windows and macOS
- add focused editor and runtime contract coverage

## Why

Prefab-authored model and audio references could be edited in the Inspector but were not reliably carried back to the source prefab or resolved after runtime instantiation. Audio clips also lacked a typed editor asset, and generated FileIds used different UUID spellings between Windows and macOS.

## Cross-platform FileId contract

Valid UUIDs now use one portable representation: uppercase, unbraced, 36-character GUID text. Windows-style `{GUID}`, macOS-style `GUID`, and lowercase serialized variants all deserialize to the same `FileId` and serialize back identically. Non-GUID symbolic IDs and malformed GUID-like strings remain unchanged.

This lets the same project assets, prefab references, registries, and generated cache names resolve on Windows and macOS without platform-specific metadata rewrites.

## Impact

Project authors can assign WAV, FLAC, or MP3 assets to `AudioClip` properties, apply instance changes safely to a linked prefab, jump to its source asset, and instantiate movable prefab units with their model/audio references intact. Models that require legacy UV orientation can opt in without changing the glTF default.

Engine Content and game-project content are intentionally excluded.

## Validation

- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --no-restore` — 770 passed, 0 failed
- `python3 run_editor.py --config Release --skip-engine --no-launch` — succeeded, 0 errors
- macOS Debug build of `AssetCacheContractTests` and `ModelImporterContractTests` — succeeded
- focused CTest set — 6 passed, 0 failed:
  - `InstanceIdContractTests`
  - `EcsLifecycleContractTests`
  - `ModelImporterContractTests`
  - `WorkspaceModuleContractTests`
  - `WorkspaceCacheContractTests`
  - `AssetCacheContractTests`
- `git diff --check` — passed

GitHub CI provides the Windows MSVC and clang-cl validation for the same cross-platform contracts.

## Known limitations

The existing Mac Catalyst editor build still reports its baseline nullable/platform/XamlC warnings; this change adds no build errors.