### PR TITLE
Fix Windows editor contract line endings

### DIFF
--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -1799,7 +1799,7 @@ public sealed class EngineLifecycleTests
     {
         var candidate = Path.Combine(relativePath.Prepend(ResolveRepositoryRoot()).ToArray());
         return File.Exists(candidate)
-            ? File.ReadAllText(candidate)
+            ? File.ReadAllText(candidate).ReplaceLineEndings("\n")
             : throw new FileNotFoundException($"Could not find repository file: {Path.Combine(relativePath)}");
     }
 

--- a/Editor.Tests/PrefabOverrideApplierTests.cs
+++ b/Editor.Tests/PrefabOverrideApplierTests.cs
@@ -68,7 +68,7 @@ public sealed class PrefabOverrideApplierTests
     [Fact]
     public void Apply_IgnoresOverridesForUnknownSourceObjects()
     {
-        var linked = LinkedYaml.Replace(
+        var linked = LinkedYaml.ReplaceLineEndings("\n").Replace(
             "source-game-object:\n    name: Applied Root",
             "unknown-game-object:\n    name: Applied Root",
             StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

- normalize repository source text to LF before source-contract assertions
- normalize the prefab YAML fixture before replacing the source object ID

## Root cause

The editor contract suite embedded LF-only fragments in its assertions. GitHub Actions checks out the files with CRLF on Windows, so two source assertions did not match and the prefab test did not construct its intended unknown-source scenario.

## Impact

The tests now validate the same behavior on Windows and macOS without changing editor or runtime production code.

## Validation

- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --configuration Release --no-restore` — 770 passed, 0 failed
- focused Runtime CTest set — 6 passed, 0 failed
- `git diff --check` — passed

Project `Content/` changes are excluded.