### PR TITLE
Fix canonical asset metadata UUID scan

### DIFF
--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -216,6 +216,9 @@ namespace
 					}
 
 					outFileId = fileId.as<std::string>();
+					FileId canonicalFileId;
+					canonicalFileId.Deserialize(YAML::Node(outFileId));
+					outFileId = canonicalFileId.ToString();
 					outFilename = filename.as<std::string>();
 					YAML::Node assetInfoType(YAML::NodeType::Undefined);
 					for (const auto& field : metadata)

--- a/Tests/AssetCacheContractTests.cpp
+++ b/Tests/AssetCacheContractTests.cpp
@@ -746,6 +746,35 @@ namespace
 			"the new secondary AssetInfo should be immediately resolvable");
 	}
 
+	void TestScanCanonicalizesUuidMetadataIdentity()
+	{
+		TempDirectory directory("canonical-uuid-scan");
+		const Workspace::WorkspaceContext workspaceContext =
+			CreateWorkspaceContext(directory);
+		WriteFile(
+			workspaceContext.GetContent() / "Portable.raw",
+			"portable-source");
+		WriteFile(
+			workspaceContext.GetContent() / "Portable.raw.asset",
+			"fileId: '{7810180E-F1BB-4C88-9C9B-28ED9B086974}'\n"
+			"filename: Portable.raw\n"
+			"testValue: 9\n");
+
+		TargetedUpdateAssetInfoHandler handler;
+		AssetRegistry registry(workspaceContext);
+		RegisterTargetedUpdateHandler(registry, handler);
+		Require(registry.ScanContentFolder() &&
+			registry.CompleteScanProcessing(),
+			"a Windows-style braced UUID must survive staged metadata loading");
+
+		const FileId portableId =
+			MakeFileId("7810180E-F1BB-4C88-9C9B-28ED9B086974");
+		AssetInfoPtr assetInfo = registry.GetAssetInfoPtr(portableId);
+		Require(assetInfo != nullptr &&
+			assetInfo->GetFileId().ToString() == portableId.ToString(),
+			"the staged registry must publish the canonical cross-platform UUID");
+	}
+
 	void TestPayloadRoundTrip()
 	{
 		const FileId fileId = MakeFileId("{ASSET-CACHE-ROUNDTRIP}");
@@ -2128,6 +2157,7 @@ int main()
 		TestV2EnvelopeIsResetInsteadOfMigrated();
 		TestLazyScanDefersUnchangedMetadataMaterialization();
 		TestLazyScanLoadsOnlyNewSecondaryMetadata();
+		TestScanCanonicalizesUuidMetadataIdentity();
 		TestCorruptPayloadDoesNotPartiallyPublish();
 		TestMismatchedEntryIdentityIsCorrupt();
 		TestDirectDeserializeDoesNotThrowOnCorruptData();


### PR DESCRIPTION
## Summary

- canonicalize asset metadata FileIds during fast discovery before staged registry resolution
- preserve compatibility with legacy Windows-style braced UUID metadata on Windows and macOS
- add a contract test covering staged publication and lookup by the canonical UUID

## Root cause

The metadata discovery pass kept the raw `{UUID}` spelling, while full deserialization normalized the same ID to canonical unbraced uppercase form. The staged loader treated those equivalent values as an ID change, rejected the registry generation, and later rendering could crash because required shader/material assets were unavailable.

## Validation

- `cmake --build build-mac-vcpkg --target AssetCacheContractTests -j8`
- `ctest --test-dir build-mac-vcpkg -C Debug --output-on-failure -R "^AssetCacheContractTests$"` — 1/1 passed
- Release `SailorExec` build passed
- Release Brassline module build passed
- Brassline launched successfully: world loaded, 14 units created, phrase bank 64/64
- `git diff --check` passed

## Scope

Only Runtime asset-registry code and its contract test are included. No `Content/` files are part of this PR.