### PR TITLE
Improve runtime rendering, input, and editor tooling

### DIFF
--- a/Content/DefaultRenderer.renderer
+++ b/Content/DefaultRenderer.renderer
@@ -326,7 +326,39 @@ frame:
   - depthHighZ: DepthHighZ
   - transmissionFramebuffer: Secondary
 
-  
+############################
+- name: PostProcess
+############################
+  string:
+  - shader: Shaders/MotionBlur.shader
+  - defines: ~
+  float:
+  - data.intensity: 1
+  - data.samples: 10
+  - data.maxSpeed: 50
+  renderTargets:
+  - color: Secondary
+  - depthSampler: DepthBuffer
+  - colorSampler: Main
+
+############################
+- name: Blit
+############################
+  renderTargets:
+  - src: Secondary
+  - dst: Main
+
+############################
+- name: RenderScene
+############################
+  string:
+  - Tag: Viewmodel
+  - GPUCulling: false
+  renderTargets:
+  - color: Main
+  - depthStencil: DepthBuffer
+  - depthHighZ: DepthHighZ
+
 ##############################
 - name: Bloom
 ##############################
@@ -353,20 +385,12 @@ frame:
   - colorSampler: Main
   - depthStencil: DepthBuffer
 
-  ############################
-- name: PostProcess
 ############################
-  string:
-  - shader: Shaders/MotionBlur.shader
-  - defines: ~
-  float:
-  - data.intensity: 1
-  - data.samples: 10
-  - data.maxSpeed: 50
+- name: Blit
+############################
   renderTargets:
-  - color: Main
-  - depthSampler: DepthBuffer
-  - colorSampler: Secondary
+  - src: Secondary
+  - dst: Main
 
 #############################
 #- name: Blit

--- a/Content/EditorRenderer.renderer
+++ b/Content/EditorRenderer.renderer
@@ -331,6 +331,39 @@ frame:
   - depthHighZ: DepthHighZ
   - transmissionFramebuffer: Secondary
 
+############################
+- name: PostProcess
+############################
+  string:
+  - shader: Shaders/MotionBlur.shader
+  - defines: ~
+  float:
+  - data.intensity: 1
+  - data.samples: 10
+  - data.maxSpeed: 50
+  renderTargets:
+  - color: Secondary
+  - depthSampler: DepthBuffer
+  - colorSampler: Main
+
+############################
+- name: Blit
+############################
+  renderTargets:
+  - src: Secondary
+  - dst: Main
+
+############################
+- name: RenderScene
+############################
+  string:
+  - Tag: Viewmodel
+  - GPUCulling: false
+  renderTargets:
+  - color: Main
+  - depthStencil: DepthBuffer
+  - depthHighZ: DepthHighZ
+
 ##############################
 - name: Bloom
 ##############################
@@ -357,21 +390,13 @@ frame:
   - colorSampler: Main
   - depthStencil: DepthBuffer
 
-  ############################
-- name: PostProcess
 ############################
-  string:
-  - shader: Shaders/MotionBlur.shader
-  - defines: ~
-  float:
-  - data.intensity: 1
-  - data.samples: 10
-  - data.maxSpeed: 50
+- name: Blit
+############################
   renderTargets:
-  - color: Main
-  - depthSampler: DepthBuffer
-  - colorSampler: Secondary
-  
+  - src: Secondary
+  - dst: Main
+
 #############################
 #- name: Blit
 #############################

--- a/Content/Shaders/MotionBlur.shader
+++ b/Content/Shaders/MotionBlur.shader
@@ -68,21 +68,21 @@ glslFragment: |
       
       vec4 viewPos = inverse(frame.projection) * clipPos;
       viewPos /= viewPos.w;
+
+      vec3 color = textureLod(colorSampler, fragTexcoord, 0.0).xyz;
   
       vec4 worldPos = inverse(frame.view) * viewPos;
 
       vec4 previousClipPos = previousFrame.projection * previousFrame.view * worldPos;
       previousClipPos /= previousClipPos.w;
       
-      vec2 velocity = (clipPos.xy - previousClipPos.xy) / 2.0;
-  
-      velocity /= data.maxSpeed;
-      
-      velocity.x = min(1, velocity.x) * data.intensity;
-      velocity.y = min(1, velocity.y) * data.intensity;
-      
-      vec3 color = textureLod(colorSampler, fragTexcoord, 0.0).xyz;
-      vec2 texCoord = fragTexcoord;
+      vec2 velocity = (clipPos.xy - previousClipPos.xy) * 0.5 * data.intensity;
+      vec2 velocityPixels = velocity * vec2(frame.viewportSize);
+      float speedPixels = length(velocityPixels);
+      if (speedPixels > data.maxSpeed && speedPixels > 0.0)
+      {
+          velocity *= data.maxSpeed / speedPixels;
+      }
       
       if(length(velocity) <= 0.0001)
       {
@@ -90,13 +90,15 @@ glslFragment: |
           return;
       }
       
-      for(int i = 1; i < int(data.samples); ++i) 
+      int sampleCount = max(1, int(data.samples));
+      for(int i = 1; i < sampleCount; ++i)
       {
-          texCoord = clamp(texCoord + velocity, 0.0, 1.0);
+          float t = float(i) / float(max(1, sampleCount - 1));
+          vec2 texCoord = clamp(fragTexcoord - velocity * t, 0.0, 1.0);
           vec3 currentColor = textureLod(colorSampler, texCoord, 0.0).xyz;
           color += currentColor;
       }
       
-      color /= float(data.samples);
+      color /= float(sampleCount);
       outColor = vec4(color, 1.0);
   }

--- a/Content/Shaders/Sky.shader
+++ b/Content/Shaders/Sky.shader
@@ -712,6 +712,14 @@ glslFragment: |
        }
 
     #elif defined(CLOUDS)
+      const float cloudsVisibilityEpsilon = 0.0001f;
+      if(data.cloudsDensity <= cloudsVisibilityEpsilon ||
+         data.cloudsCoverage <= cloudsVisibilityEpsilon)
+      {
+          outColor = vec4(0.0f);
+          return;
+      }
+
       #if defined(DITHER)
        vec2 ditherUv = vec2(mod(gl_FragCoord.x, 4), mod(gl_FragCoord.y, 4)) / 4.0f;
        

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -899,7 +899,10 @@ glslFragment: |
       material.roughnessFactor = material.roughnessFactor * orm.g;
     }
 
-    float occlusion = texture(g_aoSampler, viewportUv).r;
+    float occlusion = 1.0;
+  #ifndef DISABLE_SCREEN_SPACE_AO
+    occlusion = texture(g_aoSampler, viewportUv).r;
+  #endif
     if(material.occlusionSampler != 0)
     {
       float occlusionTex = texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.occlusionSampler))], vin.texcoord).r;

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -90,6 +90,7 @@ namespace SailorEditor
             builder.Services.AddSingleton<McpSceneBatchExecutor>();
             builder.Services.AddSingleton<McpAssetOperations>();
             builder.Services.AddSingleton<McpWorkspaceOperations>();
+            builder.Services.AddSingleton<McpCSharpEvaluator>();
             builder.Services.AddSingleton<IWorkspaceProcessRunner, WorkspaceProcessRunner>();
             builder.Services.AddSingleton<WorkspaceBuildService>();
             builder.Services.AddSingleton<McpEditorHostService>();

--- a/Editor/Mcp/McpCSharpEvaluator.cs
+++ b/Editor/Mcp/McpCSharpEvaluator.cs
@@ -1,0 +1,211 @@
+#nullable enable
+
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Security;
+using System.Text;
+
+namespace SailorEditor.Mcp;
+
+public sealed record McpCSharpEvalResult(
+    bool Succeeded,
+    string? Result,
+    string? ResultType,
+    string Output,
+    string? Error);
+
+internal sealed class McpCSharpEvaluator
+{
+    const int MaxCodeLength = 64 * 1024;
+    readonly IServiceProvider _services;
+    readonly IEditorThreadDispatcher _editorThread;
+
+    public McpCSharpEvaluator(
+        IServiceProvider services,
+        IEditorThreadDispatcher editorThread)
+    {
+        _services = services;
+        _editorThread = editorThread;
+    }
+
+    public async Task<McpCSharpEvalResult> EvaluateAsync(
+        string code,
+        int timeoutMs,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+            return new(false, null, null, string.Empty, "C# code must not be empty.");
+        if (code.Length > MaxCodeLength)
+            return new(false, null, null, string.Empty, $"C# code is limited to {MaxCodeLength} characters.");
+
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        timeout.CancelAfter(Math.Clamp(timeoutMs, 100, 30_000));
+        var temporaryRoot = Path.Combine(
+            Path.GetTempPath(),
+            "SailorEditorMcpEval",
+            Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(temporaryRoot);
+        try
+        {
+            await File.WriteAllTextAsync(
+                Path.Combine(temporaryRoot, "Eval.csproj"),
+                CreateProjectSource(),
+                timeout.Token);
+            await File.WriteAllTextAsync(
+                Path.Combine(temporaryRoot, "Script.cs"),
+                CreateScriptSource(code),
+                timeout.Token);
+
+            var build = await BuildAsync(temporaryRoot, timeout.Token);
+            if (!build.Succeeded)
+                return new(false, null, null, build.Output, build.Error);
+
+            return await ExecuteAsync(
+                Path.Combine(temporaryRoot, "bin", "Release", "net10.0", "SailorMcpEval.dll"),
+                timeout.Token);
+        }
+        catch (OperationCanceledException) when (!cancellationToken.IsCancellationRequested)
+        {
+            return new(false, null, null, string.Empty, "C# evaluation timed out.");
+        }
+        catch (Exception exception)
+        {
+            return new(false, null, null, string.Empty, exception.ToString());
+        }
+        finally
+        {
+            try { Directory.Delete(temporaryRoot, true); }
+            catch (IOException) { }
+            catch (UnauthorizedAccessException) { }
+        }
+    }
+
+    async Task<McpCSharpEvalResult> ExecuteAsync(
+        string assemblyPath,
+        CancellationToken cancellationToken)
+    {
+        var output = new StringBuilder();
+        var loadContext = new AssemblyLoadContext(
+            "SailorMcpEval_" + Guid.NewGuid().ToString("N"),
+            isCollectible: true);
+        loadContext.Resolving += ResolveEditorAssembly;
+        try
+        {
+            var assembly = loadContext.LoadFromAssemblyPath(assemblyPath);
+            var method = assembly.GetType("SailorMcpEval.ScriptEntry")?
+                .GetMethod("EvaluateAsync", BindingFlags.Public | BindingFlags.Static);
+            if (method is null)
+                return new(false, null, null, string.Empty, "Compiled C# script has no entry point.");
+
+            var result = await _editorThread.InvokeAsync<object?>(
+                async () =>
+                {
+                    var task = method.Invoke(
+                        null,
+                        [_services, _editorThread, cancellationToken, (Action<object?>)(value => output.AppendLine(value?.ToString() ?? "null"))]) as Task<object?>;
+                    if (task is null)
+                        throw new InvalidOperationException("Compiled C# script returned an invalid task.");
+                    return await task;
+                },
+                cancellationToken);
+            return new(true, result?.ToString(), result?.GetType().FullName, output.ToString().TrimEnd(), null);
+        }
+        catch (TargetInvocationException exception)
+        {
+            return new(false, null, null, output.ToString().TrimEnd(), (exception.InnerException ?? exception).ToString());
+        }
+        catch (Exception exception)
+        {
+            return new(false, null, null, output.ToString().TrimEnd(), exception.ToString());
+        }
+        finally
+        {
+            loadContext.Resolving -= ResolveEditorAssembly;
+            loadContext.Unload();
+        }
+    }
+
+    static Assembly? ResolveEditorAssembly(AssemblyLoadContext _, AssemblyName name) =>
+        AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(assembly =>
+            AssemblyName.ReferenceMatchesDefinition(assembly.GetName(), name));
+
+    static async Task<(bool Succeeded, string Output, string? Error)> BuildAsync(
+        string workingDirectory,
+        CancellationToken cancellationToken)
+    {
+        using var process = Process.Start(new ProcessStartInfo
+        {
+            FileName = "dotnet",
+            Arguments = "build Eval.csproj --configuration Release --nologo --verbosity quiet",
+            WorkingDirectory = workingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        });
+        if (process is null)
+            return (false, string.Empty, "Failed to start the dotnet C# compiler.");
+
+        var output = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var error = process.StandardError.ReadToEndAsync(cancellationToken);
+        try
+        {
+            await process.WaitForExitAsync(cancellationToken);
+        }
+        catch (OperationCanceledException)
+        {
+            TryKill(process);
+            throw;
+        }
+
+        var standardOutput = await output;
+        var standardError = await error;
+        return process.ExitCode == 0
+            ? (true, standardOutput.Trim(), null)
+            : (false, standardOutput.Trim(), string.IsNullOrWhiteSpace(standardError) ? standardOutput.Trim() : standardError.Trim());
+    }
+
+    static string CreateProjectSource()
+    {
+        var editorAssembly = SecurityElement.Escape(typeof(McpCSharpEvaluator).Assembly.Location);
+        return $$"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <Nullable>enable</Nullable>
+                <AssemblyName>SailorMcpEval</AssemblyName>
+              </PropertyGroup>
+              <ItemGroup>
+                <Reference Include="SailorEditor"><HintPath>{{editorAssembly}}</HintPath><Private>false</Private></Reference>
+              </ItemGroup>
+            </Project>
+            """;
+    }
+
+    static string CreateScriptSource(string code) => $$"""
+        namespace SailorMcpEval;
+
+        public static class ScriptEntry
+        {
+            public static async Task<object?> EvaluateAsync(
+                IServiceProvider Services,
+                SailorEditor.Mcp.IEditorThreadDispatcher EditorThread,
+                CancellationToken CancellationToken,
+                Action<object?> Print)
+            {
+        #line 1 "MCP C# eval"
+        {{code}}
+        #line default
+            }
+        }
+        """;
+
+    static void TryKill(Process process)
+    {
+        try { process.Kill(true); }
+        catch (InvalidOperationException) { }
+        catch (System.ComponentModel.Win32Exception) { }
+    }
+}

--- a/Editor/Mcp/McpEditorTools.cs
+++ b/Editor/Mcp/McpEditorTools.cs
@@ -32,6 +32,7 @@ internal sealed class McpEditorTools
     readonly McpSceneBatchExecutor _sceneBatch;
     readonly McpAssetOperations _assetOperations;
     readonly McpWorkspaceOperations _workspaceOperations;
+    readonly McpCSharpEvaluator _csharpEvaluator;
 
     public McpEditorTools(
         IEditorThreadDispatcher editorThread,
@@ -43,7 +44,8 @@ internal sealed class McpEditorTools
         McpSceneSnapshotBuilder sceneSnapshots,
         McpSceneBatchExecutor sceneBatch,
         McpAssetOperations assetOperations,
-        McpWorkspaceOperations workspaceOperations)
+        McpWorkspaceOperations workspaceOperations,
+        McpCSharpEvaluator csharpEvaluator)
     {
         _editorThread = editorThread;
         _contextProvider = contextProvider;
@@ -55,6 +57,7 @@ internal sealed class McpEditorTools
         _sceneBatch = sceneBatch;
         _assetOperations = assetOperations;
         _workspaceOperations = workspaceOperations;
+        _csharpEvaluator = csharpEvaluator;
     }
 
     public McpServerTool[] CreateTools() =>
@@ -121,6 +124,21 @@ internal sealed class McpEditorTools
                     "reset_component, select, focus. References beginning with '$' resolve an earlier operation alias. " +
                     "Pass the workspace epoch returned by sailor_editor_get_state to reject stale plans. " +
                     "Mutations require confirm=true and successful batches are one undo entry.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (bool confirm,
+                string code,
+                int timeoutMs,
+                CancellationToken cancellationToken) =>
+                EvalCSharpAsync(confirm, code, timeoutMs, cancellationToken),
+            new()
+            {
+                Name = "sailor_editor_eval_csharp",
+                Description =
+                    "Compile trusted C# code out of process, then evaluate it inside Sailor Editor with Services, EditorThread, " +
+                    "CancellationToken and Print available. The code is the body of an async method; use return to provide a result. " +
+                    "This is an unrestricted local operation and requires confirm=true. timeoutMs is clamped to 100..30000.",
                 UseStructuredContent = true,
             }),
         McpServerTool.Create(
@@ -295,6 +313,33 @@ internal sealed class McpEditorTools
                 return new { succeeded, message = succeeded ? "Undo completed." : "Nothing was undone.", undoCount = _history.UndoCount, redoCount = _history.RedoCount };
             },
             cancellationToken);
+
+    public async Task<McpCSharpEvalResult> EvalCSharpAsync(
+        bool confirm,
+        string code,
+        int timeoutMs,
+        CancellationToken cancellationToken = default)
+    {
+        if (!confirm)
+            return new McpCSharpEvalResult(false, null, null, string.Empty, "C# evaluation requires confirm=true.");
+
+        var result = await Task.Run(
+            () => _csharpEvaluator.EvaluateAsync(code, timeoutMs, cancellationToken),
+            cancellationToken);
+        await _editorThread.InvokeAsync(
+            () =>
+            {
+                _aiOperator.RecordExternalExecution(
+                    "MCP C# eval",
+                    AIActionSafety.ConfirmRequired,
+                    result.Succeeded ? AIProposalState.Executed : AIProposalState.Failed,
+                    [new AIActionExecutionItem("Evaluate C#", result.Succeeded, result.Error)],
+                    result.Succeeded ? "C# evaluation completed." : "C# evaluation failed.");
+                return Task.CompletedTask;
+            },
+            cancellationToken);
+        return result;
+    }
 
     public Task<object> RedoAsync(
         bool confirm,

--- a/Editor/Services/WorldService.cs
+++ b/Editor/Services/WorldService.cs
@@ -335,17 +335,16 @@ namespace SailorEditor.Services
                     Error: "Stop simulation before saving the scene.");
             }
 
-            var page = Application.Current?.Windows.FirstOrDefault()?.Page ?? Application.Current?.MainPage;
-            if (page is null)
-                return new SceneSaveResult(SceneSaveOutcome.Failed, Error: "The editor window is unavailable.");
-
             var assetsService = MauiProgram.GetService<AssetsService>();
             var worldAsset = CurrentWorldAsset ?? (IsCurrentWorldUntitled ? null : ResolveCurrentWorldAsset());
             if (worldAsset is not null && assetsService.CanModifyAsset(worldAsset))
             {
                 if (confirmExisting)
                 {
-                    var confirmed = await page.DisplayAlert(
+                    var confirmationPage = Application.Current?.Windows.FirstOrDefault()?.Page ?? Application.Current?.MainPage;
+                    if (confirmationPage is null)
+                        return new SceneSaveResult(SceneSaveOutcome.Failed, Error: "The editor window is unavailable.");
+                    var confirmed = await confirmationPage.DisplayAlert(
                         "Save scene",
                         $"Save the current scene to {worldAsset.Asset.FullName}?",
                         "Save",
@@ -359,6 +358,10 @@ namespace SailorEditor.Services
                     assetsService,
                     cancellationToken);
             }
+
+            var page = Application.Current?.Windows.FirstOrDefault()?.Page ?? Application.Current?.MainPage;
+            if (page is null)
+                return new SceneSaveResult(SceneSaveOutcome.Failed, Error: "The editor window is unavailable.");
 
             return await SaveCurrentWorldAsAsync(page, assetsService, cancellationToken);
         }

--- a/Runtime/AssetRegistry/Animation/AnimationImporter.cpp
+++ b/Runtime/AssetRegistry/Animation/AnimationImporter.cpp
@@ -648,46 +648,15 @@ bool AnimationImporter::ImportAnimation(FileId uid, AnimationPtr& outAnimation)
 			for (size_t i = 0; i < numNodes; ++i)
 			{
 				const auto& n = gltfModel.nodes[i];
-				if (n.translation.size() == 3)
+				glm::mat4 nodeMatrix(1.0f);
+				if (!GltfImporterUtils::TryComposeNodeMatrix(n, nodeMatrix))
 				{
-					const glm::vec4 translation(
-						static_cast<float>(n.translation[0]),
-						static_cast<float>(n.translation[1]),
-						static_cast<float>(n.translation[2]),
-						1.0f);
-					if (Math::AllFinite(translation))
-					{
-						base[i].m_position = translation;
-					}
+					SAILOR_LOG_ERROR(
+						"Cannot import invalid glTF animation node transform: %s",
+						info->GetAssetFilepath().c_str());
+					return false;
 				}
-
-				if (n.rotation.size() == 4)
-				{
-					glm::quat rotation(
-						static_cast<float>(n.rotation[3]),
-						static_cast<float>(n.rotation[0]),
-						static_cast<float>(n.rotation[1]),
-						static_cast<float>(n.rotation[2]));
-					const float lengthSquared = glm::dot(rotation, rotation);
-					if (std::isfinite(lengthSquared) &&
-						lengthSquared > std::numeric_limits<float>::epsilon())
-					{
-						base[i].m_rotation = glm::normalize(rotation);
-					}
-				}
-
-				if (n.scale.size() == 3)
-				{
-					const glm::vec4 scale(
-						static_cast<float>(n.scale[0]),
-						static_cast<float>(n.scale[1]),
-						static_cast<float>(n.scale[2]),
-						1.0f);
-					if (Math::AllFinite(scale))
-					{
-						base[i].m_scale = scale;
-					}
-				}
+				base[i] = Math::Transform::FromMatrix(nodeMatrix);
 			}
 
 			auto composeGlobalTransforms = [numNodes, &parents](

--- a/Runtime/AssetRegistry/Model/GltfImporterUtils.h
+++ b/Runtime/AssetRegistry/Model/GltfImporterUtils.h
@@ -104,6 +104,10 @@ namespace Sailor::GltfImporterUtils
 		const tinygltf::Node& node,
 		glm::mat4& outMatrix);
 
+	SAILOR_SHARED_API bool IsMaterialUsedBySkinnedMesh(
+		const tinygltf::Model& model,
+		size_t materialIndex);
+
 	SAILOR_SHARED_API bool CollectMeshInstances(
 		const tinygltf::Model& model,
 		TVector<MeshInstance>& outInstances);

--- a/Runtime/AssetRegistry/Model/ModelImporter.cpp
+++ b/Runtime/AssetRegistry/Model/ModelImporter.cpp
@@ -2668,7 +2668,8 @@ bool GltfImporterUtils::MergeGeneratedMaterialProperties(
 
 	auto isManagedDefine = [](const std::string& define)
 		{
-			return define == "TRANSMISSION" || define == "ALPHA_CUTOUT";
+			return define == "TRANSMISSION" || define == "ALPHA_CUTOUT" ||
+				define == "SKINNING";
 		};
 
 	YAML::Node mergedDefines(YAML::NodeType::Sequence);
@@ -2705,6 +2706,7 @@ bool GltfImporterUtils::MergeGeneratedMaterialProperties(
 
 		bool bHasTransmission = false;
 		bool bHasAlphaCutout = false;
+		bool bHasSkinning = false;
 		for (const YAML::Node& defineNode : generatedDefines)
 		{
 			if (!defineNode.IsScalar())
@@ -2722,6 +2724,11 @@ bool GltfImporterUtils::MergeGeneratedMaterialProperties(
 			{
 				mergedDefines.push_back(define);
 				bHasAlphaCutout = true;
+			}
+			else if (define == "SKINNING" && !bHasSkinning)
+			{
+				mergedDefines.push_back(define);
+				bHasSkinning = true;
 			}
 		}
 	}
@@ -2879,6 +2886,34 @@ bool GltfImporterUtils::TryComposeNodeMatrix(
 		glm::mat4_cast(rotation) *
 		glm::scale(glm::mat4(1.0f), scale);
 	return IsFiniteGltfMatrix(outMatrix);
+}
+
+bool GltfImporterUtils::IsMaterialUsedBySkinnedMesh(
+	const tinygltf::Model& model,
+	size_t materialIndex)
+{
+	for (const tinygltf::Node& node : model.nodes)
+	{
+		if (node.skin < 0 || node.mesh < 0 ||
+			static_cast<size_t>(node.mesh) >= model.meshes.size())
+		{
+			continue;
+		}
+
+		for (const tinygltf::Primitive& primitive :
+			model.meshes[static_cast<size_t>(node.mesh)].primitives)
+		{
+			if (primitive.material >= 0 &&
+				static_cast<size_t>(primitive.material) == materialIndex &&
+				primitive.attributes.find("JOINTS_0") != primitive.attributes.end() &&
+				primitive.attributes.find("WEIGHTS_0") != primitive.attributes.end())
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
 }
 
 bool GltfImporterUtils::CollectSceneNodes(
@@ -4705,6 +4740,10 @@ bool ModelImporter::GenerateMaterialAssets(ModelAssetInfoPtr assetInfo)
 
 		MaterialAsset::Data& data = materials[i];
 		data.m_name = !material.name.empty() ? material.name : ("material" + std::to_string(i));
+		if (GltfImporterUtils::IsMaterialUsedBySkinnedMesh(gltfModel, i))
+		{
+			data.m_shaderDefines.Add("SKINNING");
+		}
 
 		std::filesystem::path materialNamePath;
 		if (!App::GetSubmodule<AssetRegistry>()->ResolveWorkspaceContentPathForWrite(
@@ -5385,6 +5424,12 @@ bool ModelImporter::UpdateGeneratedMaterialProperties(
 			alphaMode.m_blendMode);
 
 		YAML::Node generatedDefines(YAML::NodeType::Sequence);
+		if (GltfImporterUtils::IsMaterialUsedBySkinnedMesh(
+				gltfModel,
+				materialIndex))
+		{
+			generatedDefines.push_back("SKINNING");
+		}
 		if (transmission.IsEnabled())
 		{
 			generatedDefines.push_back("TRANSMISSION");

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -75,6 +75,20 @@ namespace
 		return true;
 	}
 
+	void GetConservativeOctreeBounds(
+		const Math::AABB& bounds,
+		glm::ivec3& outCenter,
+		glm::ivec3& outExtents)
+	{
+		const glm::ivec3 minimum = glm::ivec3(glm::floor(bounds.m_min));
+		const glm::ivec3 maximum = glm::ivec3(glm::ceil(bounds.m_max));
+		outCenter = minimum + (maximum - minimum) / 2;
+		outExtents = glm::max(
+			maximum - outCenter,
+			outCenter - minimum);
+		outExtents = glm::max(outExtents, glm::ivec3(1));
+	}
+
 	bool AreShadowCastersEqual(
 		const RHI::RHIShadowCasterProxy& lhs,
 		const RHI::RHIShadowCasterProxy& rhs)
@@ -634,18 +648,24 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 		{
 			m_sceneViewProxiesCache->m_staticOctree.Remove(staticKey);
 			update.m_stationaryProxy.m_shadowCaster = data.m_shadowCaster;
+			glm::ivec3 octreeCenter{};
+			glm::ivec3 octreeExtents{};
+			GetConservativeOctreeBounds(update.m_worldBounds, octreeCenter, octreeExtents);
 			m_sceneViewProxiesCache->m_stationaryOctree.Update(
-				glm::ivec3(update.m_worldBounds.GetCenter()),
-				glm::ivec3(update.m_worldBounds.GetExtents()),
+				octreeCenter,
+				octreeExtents,
 				update.m_stationaryProxy);
 		}
 		else
 		{
 			m_sceneViewProxiesCache->m_stationaryOctree.Remove(stationaryKey);
 			update.m_staticProxy.m_shadowCaster = data.m_shadowCaster;
+			glm::ivec3 octreeCenter{};
+			glm::ivec3 octreeExtents{};
+			GetConservativeOctreeBounds(update.m_worldBounds, octreeCenter, octreeExtents);
 			m_sceneViewProxiesCache->m_staticOctree.Update(
-				glm::ivec3(update.m_worldBounds.GetCenter()),
-				glm::ivec3(update.m_worldBounds.GetExtents()),
+				octreeCenter,
+				octreeExtents,
 				update.m_staticProxy);
 		}
 

--- a/Runtime/FrameGraph/SkyNode.cpp
+++ b/Runtime/FrameGraph/SkyNode.cpp
@@ -645,7 +645,8 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 	}
 	commands->EndDebugRegion(commandList);
 
-	if (m_skyParams.m_cloudsDensity > 0.0f)
+	if (m_skyParams.m_cloudsDensity > CloudsVisibilityEpsilon &&
+		m_skyParams.m_cloudsCoverage > CloudsVisibilityEpsilon)
 	{
 		commands->BeginDebugRegion(commandList, "Clouds", DebugContext::Color_CmdPostProcess);
 		{

--- a/Runtime/FrameGraph/SkyNode.h
+++ b/Runtime/FrameGraph/SkyNode.h
@@ -18,6 +18,7 @@ namespace Sailor::Framegraph
 		const float CloudsResolutionFactor = 0.5f;
 		const uint32_t CloudsNoiseHighResolution = 32u;
 		const uint32_t CloudsNoiseLowResolution = 128u;
+		static constexpr float CloudsVisibilityEpsilon = 0.0001f;
 
 		struct BrighStarCatalogue_Header
 		{

--- a/Runtime/Platform/Mac/Window.mm
+++ b/Runtime/Platform/Mac/Window.mm
@@ -50,8 +50,14 @@ static uint32_t SailorMapMacKeyCode(unsigned short keyCode)
 	case 0x0F: return 'R';
 	case 0x10: return 'Y';
 	case 0x11: return 'T';
+	case 0x23: return 'P';
 	case 0x20: return 'U';
-	case 0x53: return VK_ESCAPE;
+	case 0x12: return '1';
+	case 0x13: return '2';
+	case 0x14: return '3';
+	case 0x30: return 0x09;
+	case 0x31: return 0x20;
+	case 0x35: return VK_ESCAPE;
 	case 0x60: return VK_F5;
 	case 0x61: return VK_F6;
 	case 0x38:
@@ -247,6 +253,7 @@ static void SailorApplyMacWindowSizeOnMainThread(NSWindow* window, int32_t width
 - (void)scrollWheel:(NSEvent*)event
 {
 	[self updateCursorFromEvent:event];
+	GlobalInput::AddMouseWheelDelta((float)event.scrollingDeltaY);
 	SailorDispatchImGuiMacEvent({ ImGuiApi::MacEvent::Type::MouseWheel, (float)event.scrollingDeltaX, (float)event.scrollingDeltaY, 0, -1, false, nullptr });
 }
 

--- a/Runtime/Platform/Win32/Input.cpp
+++ b/Runtime/Platform/Win32/Input.cpp
@@ -74,8 +74,14 @@ glm::ivec2 InputState::GetButtonPressCursorPos(uint32_t button) const
 	return glm::ivec2(m_mousePressPosition[index][0], m_mousePressPosition[index][1]);
 }
 
+float InputState::GetMouseWheelDelta() const
+{
+	return m_mouseWheelDelta;
+}
+
 void InputState::TrackForChanges(const InputState& previousState)
 {
+	m_mouseWheelDelta = m_mouseWheelPosition - previousState.m_mouseWheelPosition;
 	for (uint32_t i = 0; i < 256; i++)
 	{
 		auto prevState = previousState.m_keyboard[i];
@@ -151,6 +157,11 @@ void GlobalInput::SetCursorPosition(int32_t x, int32_t y)
 {
 	m_rawState.m_cursorPosition[0] = x;
 	m_rawState.m_cursorPosition[1] = y;
+}
+
+void GlobalInput::AddMouseWheelDelta(float delta)
+{
+	m_rawState.m_mouseWheelPosition += delta;
 }
 
 void GlobalInput::Reset()

--- a/Runtime/Platform/Win32/Input.h
+++ b/Runtime/Platform/Win32/Input.h
@@ -23,6 +23,7 @@ namespace Sailor::Win32
 
 		SAILOR_API glm::ivec2 GetCursorPos() const;
 		SAILOR_API glm::ivec2 GetButtonPressCursorPos(uint32_t button) const;
+		SAILOR_API float GetMouseWheelDelta() const;
 		SAILOR_API void TrackForChanges(const InputState& previousState);
 
 	protected:
@@ -31,6 +32,8 @@ namespace Sailor::Win32
 		KeyState m_mouse[3]{};
 		int32_t m_cursorPosition[2]{};
 		int32_t m_mousePressPosition[3][2]{};
+		float m_mouseWheelPosition = 0.0f;
+		float m_mouseWheelDelta = 0.0f;
 
 #if defined(_WIN32)
 		friend LRESULT Sailor::Win32::WindowProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
@@ -50,6 +53,7 @@ namespace Sailor::Win32
 		SAILOR_API static void SetKeyState(uint32_t key, KeyState state);
 		SAILOR_API static void SetMouseButtonState(uint32_t button, KeyState state);
 		SAILOR_API static void SetCursorPosition(int32_t x, int32_t y);
+		SAILOR_API static void AddMouseWheelDelta(float delta);
 		SAILOR_API static void Reset();
 
 	protected:

--- a/Runtime/Platform/Win32/Window.cpp
+++ b/Runtime/Platform/Win32/Window.cpp
@@ -954,6 +954,11 @@ LRESULT CALLBACK Sailor::Win32::WindowProc(HWND hWnd, UINT msg, WPARAM wParam, L
 		GlobalInput::SetCursorPosition((int32_t)LOWORD(lParam), (int32_t)HIWORD(lParam));
 		return FALSE;
 	}
+	case WM_MOUSEWHEEL:
+	{
+		GlobalInput::AddMouseWheelDelta(static_cast<float>(GET_WHEEL_DELTA_WPARAM(wParam)) / static_cast<float>(WHEEL_DELTA));
+		return FALSE;
+	}
 
 	case WM_KEYDOWN:
 	case WM_SYSKEYDOWN:

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -734,7 +734,9 @@ void App::Start()
 			bFirstFrame = true;
 		}
 
-		if (systemInputState.IsKeyPressed(VK_ESCAPE) || !pMainWindow->IsParentWindowValid())
+		// Escape is application input. Gameplay UI must get the opportunity to
+		// close its topmost window instead of the engine terminating the process.
+		if (!pMainWindow->IsParentWindowValid())
 		{
 			Stop();
 			break;

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -993,6 +993,16 @@ namespace
 			secondBaseMipSample != std::string::npos &&
 			motionBlur.find("texture(colorSampler") == std::string::npos,
 			"motion blur must sample only the tone-mapped base mip after Secondary was used as an HDR transmission snapshot");
+		Require(motionBlur.find("cameraRelativeDepth") == std::string::npos &&
+			motionBlur.find("speedPixels > data.maxSpeed") != std::string::npos &&
+			motionBlur.find("min(1, velocity") == std::string::npos,
+			"depth-reprojection motion blur must clamp signed velocity symmetrically without distance-based geometry exclusions");
+
+		const std::string standardGltf = ReadText(
+			sourceRoot / "Content/Shaders/Standard_glTF.shader");
+		Require(standardGltf.find("#ifndef DISABLE_SCREEN_SPACE_AO") != std::string::npos &&
+			standardGltf.find("float occlusion = 1.0") != std::string::npos,
+			"late-rendered viewmodels must be able to skip screen-space AO while retaining material occlusion");
 
 		const std::string eyeAdaptationSource = ReadText(
 			sourceRoot / "Runtime/FrameGraph/EyeAdaptationNode.cpp");
@@ -1013,9 +1023,15 @@ namespace
 			const std::string renderer = ReadText(rendererPath);
 			const size_t motionBlurOffset = renderer.find(
 				"- shader: Shaders/MotionBlur.shader");
+			const size_t viewmodelOffset = renderer.find(
+				"- Tag: Viewmodel",
+				motionBlurOffset);
+			const size_t eyeAdaptationOffset = renderer.find(
+				"- name: EyeAdaptation",
+				viewmodelOffset);
 			const size_t debugDrawOffset = renderer.find(
 				"- name: DebugDraw",
-				motionBlurOffset);
+				eyeAdaptationOffset);
 			const size_t outputBlitOffset = renderer.find(
 				"- name: Blit",
 				debugDrawOffset);
@@ -1023,10 +1039,18 @@ namespace
 				"- name: RenderImGui",
 				outputBlitOffset);
 			Require(motionBlurOffset != std::string::npos &&
+				viewmodelOffset != std::string::npos &&
+				eyeAdaptationOffset != std::string::npos &&
 				debugDrawOffset != std::string::npos &&
 				outputBlitOffset != std::string::npos &&
 				renderImGuiOffset != std::string::npos,
 				"the post-process, debug overlay, and final output sequence must be explicit");
+			const std::string toneMappingTail = renderer.substr(
+				eyeAdaptationOffset,
+				debugDrawOffset - eyeAdaptationOffset);
+			Require(toneMappingTail.find("- src: Secondary") != std::string::npos &&
+				toneMappingTail.find("- dst: Main") != std::string::npos,
+				"the tone-mapped Secondary target must be copied back to Main before final output");
 
 			const std::string debugDraw = renderer.substr(
 				debugDrawOffset,

--- a/Tests/ModelImporterContractTests.cpp
+++ b/Tests/ModelImporterContractTests.cpp
@@ -725,6 +725,28 @@ uniformsFloat:
 			"malformed authored YAML must be rejected without partial mutation");
 	}
 
+	void TestSkinnedGltfMaterialsRequireSkinningShaderVariant()
+	{
+		tinygltf::Model model;
+		model.materials.resize(2);
+		model.meshes.resize(2);
+		model.meshes[0].primitives.resize(1);
+		model.meshes[0].primitives[0].material = 0;
+		model.meshes[0].primitives[0].attributes["JOINTS_0"] = 0;
+		model.meshes[0].primitives[0].attributes["WEIGHTS_0"] = 1;
+		model.meshes[1].primitives.resize(1);
+		model.meshes[1].primitives[0].material = 1;
+		model.nodes.resize(2);
+		model.nodes[0].mesh = 0;
+		model.nodes[0].skin = 0;
+		model.nodes[1].mesh = 1;
+
+		Require(GltfImporterUtils::IsMaterialUsedBySkinnedMesh(model, 0),
+			"a material on a skinned primitive must compile the SKINNING variant");
+		Require(!GltfImporterUtils::IsMaterialUsedBySkinnedMesh(model, 1),
+			"an unskinned material must not pay for the SKINNING variant");
+	}
+
 	void TestGeneratedMaterialMigrationRecognizesLegacyOwnership()
 	{
 		const std::filesystem::path sourceRoot =
@@ -1637,6 +1659,7 @@ int main()
 		{ "MaterialAssetRetainsRenderQueue", TestMaterialAssetRetainsRenderQueue },
 		{ "GltfTransmissionExtensionResolvesMaterialFields", TestGltfTransmissionExtensionResolvesMaterialFields },
 		{ "GeneratedMaterialMigrationPreservesAuthoredProperties", TestGeneratedMaterialMigrationPreservesAuthoredProperties },
+		{ "SkinnedGltfMaterialsRequireSkinningShaderVariant", TestSkinnedGltfMaterialsRequireSkinningShaderVariant },
 		{ "GeneratedMaterialMigrationRecognizesLegacyOwnership", TestGeneratedMaterialMigrationRecognizesLegacyOwnership },
 		{ "GltfMaterialTextureColorSpaces", TestGltfMaterialTextureColorSpaces },
 		{ "CompactedMeshesRetainMaterialSlots", TestCompactedMeshesRetainMaterialSlots },


### PR DESCRIPTION
## Summary

- add a dedicated late `Viewmodel` renderer queue and correct motion-blur velocity clamping so camera-attached weapons remain sharp
- make static-mesh octree bounds conservative and allow viewmodel materials to bypass screen-space AO
- skip volumetric cloud ray marching when density or coverage is below epsilon
- preserve complete glTF node transforms for animation bases and automatically compile skinned materials with `SKINNING`
- expose mouse-wheel input consistently on macOS and Windows, improve macOS key mapping, and leave Escape to gameplay/UI handling
- add confirmed, timeout-bounded C# evaluation to the editor MCP surface and fix scene-save UI lookup

## Why

These fixes come from runtime validation in EverythingFloats: first-person geometry was affected by world-space post effects, large imported meshes could disappear near frustum edges, imported animated models lost transform/material information, platform input was incomplete, and zero-coverage clouds still consumed most of the GPU frame. The editor also needed a direct C# automation entry point for controlled scene work.

## Scope

Content changes are limited to the two engine renderer configurations required for the `Viewmodel` queue and the three affected engine shaders. Project scenes, models, imported assets, and asset metadata are intentionally excluded. The experimental Canvas UI renderer was dropped; runtime UI remains ImGui-based.

## Validation

- `cmake --build build-mac-vcpkg --config Release -j8`
- `ctest --test-dir build-mac-vcpkg -C Release --output-on-failure -R 'GpuCullingContractTests|ModelImporterContractTests|AnimationSamplingContractTests|BoundsContractTests|SkyComponentContractTests|MacWindowThreadingTests'` — 6/6 passed
- `dotnet msbuild Editor/SailorEditor.csproj -t:Compile -p:Configuration=Release -p:TargetFramework=net10.0-maccatalyst -p:RuntimeIdentifier=maccatalyst-arm64 -v:minimal`

Full macOS app packaging reaches codesign but the existing bundle contains an unsealed `imgui.ini` at its root; compilation itself succeeds.
