### PR TITLE
Add landscape authoring and runtime

### DIFF
--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -1,0 +1,529 @@
+---
+includes:
+- Shaders/Constants.glsl
+- Shaders/Math.glsl
+- Shaders/Lighting.glsl
+
+defines: []
+
+glslCommon: |
+  #version 460
+  #extension GL_ARB_separate_shader_objects : enable
+  #extension GL_EXT_nonuniform_qualifier : require
+
+glslVertex: |
+  layout(location=DefaultPositionBinding) in vec3 inPosition;
+  layout(location=DefaultNormalBinding) in vec3 inNormal;
+  layout(location=DefaultTexcoordBinding) in vec2 inTexcoord;
+  layout(location=DefaultColorBinding) in vec4 inColor;
+  layout(location=DefaultTangentBinding) in vec3 inTangent;
+  layout(location=DefaultBitangentBinding) in vec3 inBitangent;
+
+  layout(location=0)
+  flat out uint materialInstance;
+
+  layout(location=1) out Vertex
+  {
+    vec2 texcoord;
+    vec3 worldPosition;
+    vec3 normal;
+    vec4 color;
+    mat3 tangentBasis;
+  } vout;
+
+  struct PerInstanceData
+  {
+      mat4 model;
+      vec4 sphereBounds;
+      uint materialInstance;
+      uint skeletonOffset;
+      uint isCulled;
+      uint padding;
+      vec4 bakedVolumeScale;
+  };
+
+  struct MaterialData
+  {
+    vec4 albedo;
+    vec4 ambient;
+    vec4 emission;
+    vec4 layerUvScale;
+
+    float metallic;
+    float roughness;
+    float ao;
+
+    uint layer0Sampler;
+    uint layer1Sampler;
+    uint layer2Sampler;
+    uint layer3Sampler;
+  };
+
+  layout(set = 0, binding = 0) uniform FrameData
+  {
+      mat4 view;
+      mat4 projection;
+      mat4 invProjection;
+      vec4 cameraPosition;
+      ivec2 viewportSize;
+      vec2 cameraZNearZFar;
+      float currentTime;
+      float deltaTime;
+  } frame;
+
+  layout(set = 0, binding = 1) uniform PreviousFrameData
+  {
+      mat4 view;
+      mat4 projection;
+      mat4 invProjection;
+      vec4 cameraPosition;
+      ivec2 viewportSize;
+      vec2 cameraZNearZFar;
+      float currentTime;
+      float deltaTime;
+  } previousFrame;
+
+  layout(std430, set = 1, binding = 0) readonly buffer LightDataSSBO
+  {
+    LightData instance[];
+  } light;
+
+  layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
+  {
+      uint indices[MAX_TEXTURES_IN_SCENE];
+  } culledLights;
+
+  layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
+  {
+      LightsGrid instance[];
+  } lightsGrid;
+
+  layout(set=1, binding=3) uniform samplerCube g_irradianceCubemap;
+  layout(set=1, binding=4) uniform sampler2D   g_brdfSampler;
+  layout(set=1, binding=5) uniform samplerCube g_envCubemap;
+
+  layout(std430, set = 1, binding = 6) readonly buffer LightsMatricesSSBO
+  {
+      mat4 instance[];
+  } lightsMatrices;
+
+  layout(std430, set = 1, binding = 7) readonly buffer ShadowIndicesSSBO
+  {
+      uint instance[];
+  } shadowIndices;
+
+  layout(set=1, binding=8) uniform sampler2D g_aoSampler;
+  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+
+  layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
+  {
+      PerInstanceData instance[];
+  } data;
+
+  layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
+  {
+      MaterialData instance[];
+  } material;
+
+  #if defined(SAILOR_TEXTURE_REMAP)
+  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
+  {
+      uint indices[MAX_TEXTURES_IN_SCENE];
+  } textureSamplerRemap;
+  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
+  #else
+  layout(set=4, binding=0) uniform sampler2D textureSamplers[];
+  #endif
+
+  void main()
+  {
+    mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
+    vec4 vertexPosition = modelMatrix * vec4(inPosition, 1.0);
+    vout.worldPosition = vertexPosition.xyz / vertexPosition.w;
+
+    gl_Position = frame.projection * (frame.view * vertexPosition);
+
+    mat3 linearMatrix = mat3(modelMatrix);
+    mat3 normalMatrix = transpose(inverse(linearMatrix));
+    vec3 normal = normalize(normalMatrix * inNormal);
+
+    vec3 tangent = linearMatrix * inTangent;
+    tangent -= normal * dot(normal, tangent);
+    float tangentLengthSquared = dot(tangent, tangent);
+    if(tangentLengthSquared > 1e-8)
+    {
+      tangent *= inversesqrt(tangentLengthSquared);
+    }
+    else
+    {
+      vec3 fallbackAxis = abs(normal.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
+      tangent = normalize(cross(fallbackAxis, normal));
+    }
+
+    vec3 transformedBitangent = linearMatrix * inBitangent;
+    float handedness = dot(cross(normal, tangent), transformedBitangent) < 0.0 ? -1.0 : 1.0;
+    vec3 bitangent = normalize(cross(normal, tangent)) * handedness;
+
+    vout.color = inColor;
+    vout.normal = normal;
+    vout.texcoord = inTexcoord;
+    materialInstance = data.instance[gl_InstanceIndex].materialInstance;
+    vout.tangentBasis = mat3(tangent, bitangent, normal);
+  }
+
+glslFragment: |
+  layout(location=0)
+  flat in uint materialInstance;
+
+  layout(location=1) in Vertex
+  {
+    vec2 texcoord;
+    vec3 worldPosition;
+    vec3 normal;
+    vec4 color;
+    mat3 tangentBasis;
+  } vin;
+
+  layout(location=0) out vec4 outColor;
+
+  struct PerInstanceData
+  {
+      mat4 model;
+      vec4 sphereBounds;
+      uint materialInstance;
+      uint skeletonOffset;
+      uint isCulled;
+      uint padding;
+      vec4 bakedVolumeScale;
+  };
+
+  struct MaterialData
+  {
+    vec4 albedo;
+    vec4 ambient;
+    vec4 emission;
+    vec4 layerUvScale;
+
+    float metallic;
+    float roughness;
+    float ao;
+
+    uint layer0Sampler;
+    uint layer1Sampler;
+    uint layer2Sampler;
+    uint layer3Sampler;
+  };
+
+  layout(set = 0, binding = 0) uniform FrameData
+  {
+      mat4 view;
+      mat4 projection;
+      mat4 invProjection;
+      vec4 cameraPosition;
+      ivec2 viewportSize;
+      vec2 cameraZNearZFar;
+      float currentTime;
+      float deltaTime;
+  } frame;
+
+  layout(set = 0, binding = 1) uniform PreviousFrameData
+  {
+      mat4 view;
+      mat4 projection;
+      mat4 invProjection;
+      vec4 cameraPosition;
+      ivec2 viewportSize;
+      vec2 cameraZNearZFar;
+      float currentTime;
+      float deltaTime;
+  } previousFrame;
+
+  layout(std430, set = 1, binding = 0) readonly buffer LightDataSSBO
+  {
+    LightData instance[];
+  } light;
+
+  layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
+  {
+      uint indices[];
+  } culledLights;
+
+  layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
+  {
+      LightsGrid instance[];
+  } lightsGrid;
+
+  layout(set=1, binding=3) uniform samplerCube g_irradianceCubemap;
+  layout(set=1, binding=4) uniform sampler2D   g_brdfSampler;
+  layout(set=1, binding=5) uniform samplerCube g_envCubemap;
+
+  layout(std430, set = 1, binding = 6) readonly buffer LightsMatricesSSBO
+  {
+      mat4 instance[];
+  } lightsMatrices;
+
+  layout(std430, set = 1, binding = 7) readonly buffer ShadowIndicesSSBO
+  {
+      uint instance[];
+  } shadowIndices;
+
+  layout(set=1, binding=8) uniform sampler2D g_aoSampler;
+  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+
+  layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
+  {
+      PerInstanceData instance[];
+  } data;
+
+  layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
+  {
+      MaterialData instance[];
+  } material;
+
+  //layout(set=3, binding=1) uniform sampler2D layer0Sampler;
+  //layout(set=3, binding=2) uniform sampler2D layer1Sampler;
+  //layout(set=3, binding=3) uniform sampler2D layer2Sampler;
+  //layout(set=3, binding=4) uniform sampler2D layer3Sampler;
+
+  #if defined(SAILOR_TEXTURE_REMAP)
+  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
+  {
+      uint indices[];
+  } textureSamplerRemap;
+  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
+  #else
+  layout(set=4, binding=0) uniform sampler2D textureSamplers[];
+  #endif
+
+  uint ResolveTextureSamplerIndex(uint globalTextureIndex)
+  {
+  #if defined(SAILOR_TEXTURE_REMAP)
+      return textureSamplerRemap.indices[globalTextureIndex];
+  #else
+      return globalTextureIndex;
+  #endif
+  }
+
+  MaterialData GetMaterialData()
+  {
+      return material.instance[materialInstance];
+  }
+
+  float CalculateCascadedDirectionalShadow(
+    LightData light,
+    vec3 worldPosition,
+    vec3 surfaceNormal,
+    vec3 surfaceToLightDirection)
+  {
+    const int cascadeLayer = SelectCascade(frame.view, worldPosition, frame.cameraZNearZFar);
+    if(cascadeLayer >= NUM_CSM_CASCADES)
+    {
+      return 1.0f;
+    }
+
+    const mat4 cascadeLightMatrix = lightsMatrices.instance[cascadeLayer];
+    float shadow = CalculateDirectionalShadow(
+      light.shadowType,
+      shadowMaps[cascadeLayer],
+      cascadeLightMatrix,
+      cascadeLightMatrix * vec4(worldPosition, 1.0f),
+      surfaceNormal,
+      surfaceToLightDirection,
+      cascadeLayer);
+
+    const float cascadeBlend = CalculateCascadeBlend(
+      frame.view,
+      worldPosition,
+      frame.cameraZNearZFar,
+      cascadeLayer);
+    if(cascadeBlend > 0.0f)
+    {
+      const int nextCascadeLayer = cascadeLayer + 1;
+      const mat4 nextCascadeLightMatrix = lightsMatrices.instance[nextCascadeLayer];
+      const float nextShadow = CalculateDirectionalShadow(
+        light.shadowType,
+        shadowMaps[nextCascadeLayer],
+        nextCascadeLightMatrix,
+        nextCascadeLightMatrix * vec4(worldPosition, 1.0f),
+        surfaceNormal,
+        surfaceToLightDirection,
+        nextCascadeLayer);
+      shadow = mix(shadow, nextShadow, cascadeBlend);
+    }
+
+    return shadow;
+  }
+
+  const float Epsilon = 0.00001;
+  vec3 CalculateLighting(LightData light, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
+  {
+    float falloff = 1.0f;
+    float attenuation = 1.0;
+    float shadow = 1.0f;
+
+    // Directional light
+    if(light.type == 0)
+    {
+        attenuation = 1.0;
+
+        shadow = CalculateCascadedDirectionalShadow(
+          light,
+          worldPos,
+          normal,
+          -light.direction);
+    }
+    // Point light
+    else if(light.type == 1)
+    {
+      // Attenuation
+      const float distance    = length(light.worldPosition - worldPos);
+      const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
+      falloff         = attenuation * (1 - pow(clamp(distance / light.bounds.x, 0,1), 2));
+    }
+    // Spot light
+    else if(light.type == 2)
+    {
+      // Attenuation
+      vec3 lightDir = normalize(light.worldPosition - worldPos);
+      float epsilon   = light.cutOff.x - light.cutOff.y;
+      float theta = dot(lightDir, normalize(-light.direction));
+      const float distance    = length(light.worldPosition - worldPos);
+      const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
+      falloff         = attenuation * clamp((theta - light.cutOff.y) / epsilon, 0.0, 1.0);
+
+      if(theta < light.cutOff.y)
+      {
+        falloff = 0.0f;
+      }
+    }
+
+    vec3 Li = -light.direction;
+    vec3 Lradiance = light.intensity;
+
+    // Half-vector between Li and Lo.
+    vec3 Lh = normalize(Li + Lo);
+
+    // Calculate angles between surface normal and various light vectors.
+    float cosLi = max(0.0, dot(normal, Li));
+    float cosLh = max(0.0, dot(normal, Lh));
+
+    // Calculate Fresnel term for direct lighting.
+    vec3 F  = FresnelSchlick(F0, max(0.0, dot(Lh, Lo)));
+    // Calculate normal distribution for specular BRDF.
+    float D = NdfGGX(cosLh, material.roughness);
+    // Calculate geometric attenuation for specular BRDF.
+    float G = GeometrySchlickGGX(cosLi, cosLo, material.roughness);
+
+    // Diffuse scattering happens due to light being refracted multiple times by a dielectric medium.
+    // Metals on the other hand either reflect or absorb energy, so diffuse contribution is always zero.
+    // To be energy conserving we must scale diffuse BRDF contribution based on Fresnel factor & metalness.
+    vec3 kd = mix(vec3(1.0) - F, vec3(0.0), material.metallic);
+
+    // Lambert diffuse BRDF.
+    // We don't scale by 1/PI for lighting & material units to be more convenient.
+    // See: https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/
+    vec3 diffuseBRDF = kd * material.albedo.xyz;
+
+    // Cook-Torrance specular microfacet BRDF.
+    vec3 specularBRDF = (F * D * G) / max(Epsilon, 4.0 * cosLi * cosLo);
+
+    // Total contribution for this light.
+    return shadow * ((diffuseBRDF + specularBRDF) * Lradiance * cosLi) * falloff;
+  }
+
+  vec3 AmbientLighting(MaterialData material, vec3 F0, vec3 Lr, vec3 normal, float cosLo)
+  {
+    // Sample diffuse irradiance at normal direction.
+    vec3 irradiance = texture(g_irradianceCubemap, normal).rgb;
+
+    // Calculate Fresnel term for ambient lighting.
+    // Since we use pre-filtered cubemap(s) and irradiance is coming from many directions
+    // use cosLo instead of angle with light's half-vector (cosLh above).
+    // See: https://seblagarde.wordpress.com/2011/08/17/hello-world/
+    vec3 F = FresnelSchlick(F0, cosLo);
+
+    // Get diffuse contribution factor (as with direct lighting).
+    vec3 kd = mix(vec3(1.0) - F, vec3(0.0), material.metallic);
+
+    // Irradiance map contains exitant radiance assuming Lambertian BRDF, no need to scale by 1/PI here either.
+    vec3 diffuseIBL = kd * material.albedo.xyz * irradiance;
+
+    // Sample pre-filtered specular reflection environment at correct mipmap level.
+    int specularTextureLevels = textureQueryLevels(g_envCubemap);
+    vec3 specularIrradiance = textureLod(g_envCubemap, Lr, material.roughness * specularTextureLevels).rgb;
+
+    // Split-sum approximation factors for Cook-Torrance specular BRDF.
+    vec2 specularBRDF = texture(g_brdfSampler, vec2(cosLo, material.roughness)).rg;
+
+    // Total specular IBL contribution.
+    vec3 specularIBL = (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance;
+
+    // Total ambient lighting contribution. Screen-space AO only affects the
+    // diffuse portion similar to the glTF occlusion workflow.
+    return diffuseIBL * material.ao + specularIBL;
+  }
+
+  // Constant normal incidence Fresnel factor for all dielectrics.
+  const vec3 Fdielectric = vec3(0.04);
+
+  void main()
+  {
+    const vec3 viewDirection = normalize(vin.worldPosition - frame.cameraPosition.xyz);
+    const vec2 viewportUv = gl_FragCoord.xy * rcp(frame.viewportSize);
+
+    MaterialData material = GetMaterialData();
+    vec4 layerWeights = max(vin.color, vec4(0.0));
+    layerWeights /= max(dot(layerWeights, vec4(1.0)), Epsilon);
+    vec4 landscapeAlbedo =
+      texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.layer0Sampler))], vin.texcoord * material.layerUvScale.x) * layerWeights.x +
+      texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.layer1Sampler))], vin.texcoord * material.layerUvScale.y) * layerWeights.y +
+      texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.layer2Sampler))], vin.texcoord * material.layerUvScale.z) * layerWeights.z +
+      texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.layer3Sampler))], vin.texcoord * material.layerUvScale.w) * layerWeights.w;
+    material.albedo *= landscapeAlbedo;
+    material.metallic = 0.0;
+    material.ao = texture(g_aoSampler, viewportUv).r;
+
+    vec3 normal = normalize(vin.normal);
+
+    //outColor.xyz = AmbientLighting(material, vin.normal, vin.worldPosition, viewDirection);
+    outColor.xyz = vec3(0);
+
+    // Angle between surface normal and outgoing light direction.
+    float cosLo = max(0.0, dot(normal, -viewDirection));
+
+    // Specular reflection vector.
+    vec3 Lr = 2.0 * cosLo * normal + viewDirection;
+
+    // Fresnel reflectance at normal incidence (for metals use albedo color).
+    vec3 F0 = mix(Fdielectric, material.albedo.xyz, material.metallic);
+
+    //outColor.xyz += vec3(texture(g_envCubemap, R).xyz);
+    //outColor.xyz *= max(0.1, dot(normalize(-vec3(-0.3, -0.5, 0.1)), vin.normal.xyz)) * 0.5;
+
+    const uint tileIndex = GetLightTileIndex(gl_FragCoord.xy, frame.viewportSize);
+    const uint gridLength = uint(lightsGrid.instance.length());
+    const bool hasLightTile = tileIndex < gridLength;
+    const uint offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0;
+    const uint listLength = uint(culledLights.indices.length());
+    const uint availableLights = offset < listLength ? listLength - offset : 0;
+    const uint numLights = hasLightTile ? min(
+        min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE)),
+        availableLights) : 0;
+
+    outColor.xyz = AmbientLighting(material, F0, Lr, normal, cosLo);
+
+    for(int i = 0; i < numLights; i++)
+    {
+        uint index = culledLights.indices[offset + i];
+        if(index == uint(-1) ||
+            index >= uint(light.instance.length()) ||
+            light.instance[index].type == INVALID_LIGHT_TYPE)
+        {
+            continue;
+        }
+
+        outColor.xyz += CalculateLighting(light.instance[index], material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
+    }
+
+    outColor.a = material.albedo.a;
+  }

--- a/Content/Shaders/Landscape.shader.asset
+++ b/Content/Shaders/Landscape.shader.asset
@@ -1,0 +1,3 @@
+assetInfoType: Sailor::ShaderAssetInfo
+fileId: 545C0F94-89A0-4D44-9894-852C7AD24BDB
+filename: Landscape.shader

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -63,6 +63,7 @@
     <Compile Include="McpBridgeIntegrationTests.cs" />
     <Compile Include="WorkspaceBuildPlanTests.cs" />
     <Compile Include="McpSceneSafetyContractTests.cs" />
+    <Compile Include="McpLandscapeContractTests.cs" />
     <Compile Include="McpYamlUtilitiesTests.cs" />
     <Compile Include="SettingsContractsTests.cs" />
     <Compile Include="UnifiedSettingsStoreTests.cs" />

--- a/Editor.Tests/McpLandscapeContractTests.cs
+++ b/Editor.Tests/McpLandscapeContractTests.cs
@@ -1,0 +1,142 @@
+namespace Editor.Tests;
+
+public sealed class McpLandscapeContractTests
+{
+    [Fact]
+    public void Mcp_ExposesTypedLandscapeAuthoringAndRegenerationTools()
+    {
+        var tools = ReadRepositoryFile("Editor", "Mcp", "McpEditorTools.cs");
+        var contracts = ReadRepositoryFile("Editor", "Mcp", "McpLandscapeContracts.cs");
+
+        Assert.Contains("sailor_landscape_apply", tools, StringComparison.Ordinal);
+        Assert.Contains("sailor_landscape_regenerate", tools, StringComparison.Ordinal);
+        Assert.Contains("McpLandscapeVegetationProfile", contracts, StringComparison.Ordinal);
+        Assert.Contains("McpLandscapeSculptStamp", contracts, StringComparison.Ordinal);
+        Assert.Contains("McpLandscapePaintStamp", contracts, StringComparison.Ordinal);
+        Assert.Contains("HeightmapTextureFileId", contracts, StringComparison.Ordinal);
+        Assert.Contains("MaterialMaskFileIds", contracts, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Mapping_PacksAllVegetationControlsAndAuthoringStamps()
+    {
+        var source = ReadRepositoryFile("Editor", "Mcp", "McpLandscapeOperations.cs");
+
+        Assert.Contains("vegetationModels", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationMaterials", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationMeshIndex", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationInstancesPerChunk", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationMinScale", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationMaxScale", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationGroundOffset", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationShadowMode", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationShadowDistance", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationMinLod", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationMaxLod", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationLod1ScreenCoverage", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationLod2ScreenCoverage", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationCullDistance", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationColliderRadius", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationColliderHeight", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationColliderOffsetY", source, StringComparison.Ordinal);
+        Assert.Contains("heightmapTexture", source, StringComparison.Ordinal);
+        Assert.Contains("materialMasks", source, StringComparison.Ordinal);
+        Assert.Contains("sculptStamps", source, StringComparison.Ordinal);
+        Assert.Contains("paintStamps", source, StringComparison.Ordinal);
+        Assert.Contains("None, NearOnly, or All", source, StringComparison.Ordinal);
+        Assert.Contains("an empty materialFileId uses the GLB materials", source, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "string.IsNullOrWhiteSpace(profile.MaterialFileId)",
+            source,
+            StringComparison.Ordinal);
+        var tools = ReadRepositoryFile("Editor", "Mcp", "McpEditorTools.cs");
+        Assert.Contains(
+            "leave it empty to use the GLB materials",
+            tools,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Inspector_HidesBrushDataButKeepsGenerationActions()
+    {
+        var source = ReadRepositoryFile(
+            "Editor", "Views", "InspectorView", "ComponentTemplate.Landscape.cs");
+        var template = ReadRepositoryFile(
+            "Editor", "Views", "InspectorView", "ComponentTemplate.cs");
+
+        Assert.Contains("Text = \"Generate\"", source, StringComparison.Ordinal);
+        Assert.Contains("Text = \"Regenerate\"", source, StringComparison.Ordinal);
+        Assert.Contains("Text = \"Flatten\"", source, StringComparison.Ordinal);
+        Assert.Contains("Text = \"Vegetation\"", source, StringComparison.Ordinal);
+        Assert.Contains("Text = \"+ Add\"", source, StringComparison.Ordinal);
+        Assert.Contains("typeof(ModelFile)", source, StringComparison.Ordinal);
+        Assert.Contains("Material override", source, StringComparison.Ordinal);
+        Assert.Contains("typeof(MaterialFile)", source, StringComparison.Ordinal);
+        Assert.Contains("EnsureLandscapeProfileLength(materials, models.Values.Count)", source, StringComparison.Ordinal);
+        Assert.Contains("\"None\", \"Near only\", \"All\"", source, StringComparison.Ordinal);
+        Assert.Contains("\"Mesh index\"", source, StringComparison.Ordinal);
+        Assert.Contains("\"Cull distance\"", source, StringComparison.Ordinal);
+        Assert.Contains("\"Collider radius\"", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("GetOrCreateLandscapeFloatList", source, StringComparison.Ordinal);
+        var component = ReadRepositoryFile("Editor", "ViewModels", "Component.cs");
+        Assert.DoesNotContain("AddMissingLandscapeVegetationProperties", component, StringComparison.Ordinal);
+        Assert.Contains("Import landscape heightmap", source, StringComparison.Ordinal);
+        Assert.Contains("Import Material Masks", source, StringComparison.Ordinal);
+        Assert.Contains("RebuildLandscapeAsync(component, advanceSeed: true)", source, StringComparison.Ordinal);
+        Assert.Contains("await component.CommitInspectorChangesAsync()", source, StringComparison.Ordinal);
+        Assert.Contains("await component.ApplyInspectorBatchAsync", source, StringComparison.Ordinal);
+        Assert.True(
+            template.IndexOf("foreach (var property in EnumerateInspectorProperties", StringComparison.Ordinal) <
+            template.IndexOf("AddLandscapeVegetationEditor(props, component);", StringComparison.Ordinal),
+            "Vegetation settings must be rendered after the regular landscape properties.");
+        Assert.Contains("ApplyInspectorBatchAsync", component, StringComparison.Ordinal);
+        Assert.DoesNotContain("Task.Delay(125)", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Text = \"Raise\"", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Text = \"Lower\"", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Text = \"Smooth\"", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("Text = \"Paint Layer\"", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void FileIdSerialization_AllowsMissingLandscapeImportAssets()
+    {
+        var source = ReadRepositoryFile("Editor", "Utility", "EngineTypes.cs");
+
+        Assert.Contains("parser.Consume<Scalar>().Value ?? string.Empty", source, StringComparison.Ordinal);
+        Assert.Contains("(value as FileId)?.Value ?? string.Empty", source, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Runtime_UsesGlbMaterialsWhenVegetationOverrideIsEmpty()
+    {
+        var source = ReadRepositoryFile("Runtime", "ECS", "LandscapeECS.cpp");
+
+        Assert.Contains("models.Num()", source, StringComparison.Ordinal);
+        Assert.Contains("LoadDefaultMaterials(", source, StringComparison.Ordinal);
+        Assert.Contains("profile.m_modelFileId, profile.m_modelMaterials", source, StringComparison.Ordinal);
+        Assert.Contains("ResolveMaterialIndex(", source, StringComparison.Ordinal);
+        Assert.Contains("vegetationMaterials[meshIndex]", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("!profile.m_modelFileId || !profile.m_materialFileId", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("m_buildRevision", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("revision %", source, StringComparison.Ordinal);
+        var header = ReadRepositoryFile("Runtime", "ECS", "LandscapeECS.h");
+        Assert.DoesNotContain("m_buildRevision", header, StringComparison.Ordinal);
+    }
+
+    static string ReadRepositoryFile(params string[] relativePath)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            if (Directory.Exists(Path.Combine(current.FullName, "Editor")) &&
+                Directory.Exists(Path.Combine(current.FullName, "Runtime")))
+            {
+                return File.ReadAllText(Path.Combine([current.FullName, .. relativePath]));
+            }
+
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not find the Sailor repository root.");
+    }
+}

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -88,6 +88,7 @@ namespace SailorEditor
             builder.Services.AddSingleton<McpEditorTools>();
             builder.Services.AddSingleton<McpSceneSnapshotBuilder>();
             builder.Services.AddSingleton<McpSceneBatchExecutor>();
+            builder.Services.AddSingleton<McpLandscapeOperations>();
             builder.Services.AddSingleton<McpAssetOperations>();
             builder.Services.AddSingleton<McpWorkspaceOperations>();
             builder.Services.AddSingleton<IWorkspaceProcessRunner, WorkspaceProcessRunner>();

--- a/Editor/Mcp/McpEditorTools.cs
+++ b/Editor/Mcp/McpEditorTools.cs
@@ -30,6 +30,7 @@ internal sealed class McpEditorTools
     readonly AIOperatorService _aiOperator;
     readonly McpSceneSnapshotBuilder _sceneSnapshots;
     readonly McpSceneBatchExecutor _sceneBatch;
+    readonly McpLandscapeOperations _landscapeOperations;
     readonly McpAssetOperations _assetOperations;
     readonly McpWorkspaceOperations _workspaceOperations;
 
@@ -42,6 +43,7 @@ internal sealed class McpEditorTools
         AIOperatorService aiOperator,
         McpSceneSnapshotBuilder sceneSnapshots,
         McpSceneBatchExecutor sceneBatch,
+        McpLandscapeOperations landscapeOperations,
         McpAssetOperations assetOperations,
         McpWorkspaceOperations workspaceOperations)
     {
@@ -53,6 +55,7 @@ internal sealed class McpEditorTools
         _aiOperator = aiOperator;
         _sceneSnapshots = sceneSnapshots;
         _sceneBatch = sceneBatch;
+        _landscapeOperations = landscapeOperations;
         _assetOperations = assetOperations;
         _workspaceOperations = workspaceOperations;
     }
@@ -121,6 +124,39 @@ internal sealed class McpEditorTools
                     "reset_component, select, focus. References beginning with '$' resolve an earlier operation alias. " +
                     "Pass the workspace epoch returned by sailor_editor_get_state to reject stale plans. " +
                     "Mutations require confirm=true and successful batches are one undo entry.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (McpLandscapeApplyRequest request, CancellationToken cancellationToken) =>
+                ApplyLandscapeAsync(request, cancellationToken),
+            new()
+            {
+                Name = "sailor_landscape_apply",
+                Description =
+                    "Create or fully author a LandscapeComponent from a level description. " +
+                    "Resolve material, texture and model fileIds with sailor_assets_list/get first. " +
+                    "The request replaces terrain stamps and all vegetation profiles atomically. " +
+                    "A vegetation materialFileId is optional; leave it empty to use the GLB materials. " +
+                    "Vegetation shadows accept None, NearOnly, or All. Leave targetComponentId empty to create a new Landscape GameObject. " +
+                    "Pass the current workspace epoch and confirm=true; the complete edit is one undo entry.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (bool confirm,
+                long? expectedWorkspaceEpoch,
+                string targetComponentId,
+                CancellationToken cancellationToken) =>
+                RegenerateLandscapeAsync(
+                    confirm,
+                    expectedWorkspaceEpoch,
+                    targetComponentId,
+                    cancellationToken),
+            new()
+            {
+                Name = "sailor_landscape_regenerate",
+                Description =
+                    "Regenerate terrain, vegetation, render proxies and collision for an existing LandscapeComponent. " +
+                    "Requires its component instance ID, the current workspace epoch and confirm=true.",
                 UseStructuredContent = true,
             }),
         McpServerTool.Create(
@@ -277,6 +313,26 @@ internal sealed class McpEditorTools
                     expectedWorkspaceEpoch,
                     description,
                     operations ?? Array.Empty<McpSceneOperation>()),
+                cancellationToken),
+            cancellationToken);
+
+    public Task<McpSceneBatchResult> ApplyLandscapeAsync(
+        McpLandscapeApplyRequest request,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () => _landscapeOperations.ApplyAsync(request, cancellationToken),
+            cancellationToken);
+
+    public Task<McpSceneBatchResult> RegenerateLandscapeAsync(
+        bool confirm,
+        long? expectedWorkspaceEpoch,
+        string targetComponentId,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () => _landscapeOperations.RegenerateAsync(
+                confirm,
+                expectedWorkspaceEpoch,
+                targetComponentId,
                 cancellationToken),
             cancellationToken);
 

--- a/Editor/Mcp/McpLandscapeContracts.cs
+++ b/Editor/Mcp/McpLandscapeContracts.cs
@@ -1,0 +1,68 @@
+#nullable enable
+
+namespace SailorEditor.Mcp;
+
+public sealed record McpLandscapeVegetationProfile
+{
+    public string ModelFileId { get; init; } = string.Empty;
+    public string MaterialFileId { get; init; } = string.Empty;
+    public int MeshIndex { get; init; } = -1;
+    public uint InstancesPerChunk { get; init; } = 4;
+    public float MinScale { get; init; } = 0.75f;
+    public float MaxScale { get; init; } = 1.25f;
+    public float GroundOffset { get; init; }
+    public string Shadows { get; init; } = "NearOnly";
+    public float ShadowDistance { get; init; } = 35.0f;
+    public uint MinLod { get; init; }
+    public uint MaxLod { get; init; } = 2;
+    public float Lod1ScreenCoverage { get; init; } = 0.25f;
+    public float Lod2ScreenCoverage { get; init; } = 0.05f;
+    public float CullDistance { get; init; } = 120.0f;
+    public float ColliderRadius { get; init; }
+    public float ColliderHeight { get; init; } = 2.0f;
+    public float ColliderOffsetY { get; init; } = 1.0f;
+}
+
+public sealed record McpLandscapeSculptStamp
+{
+    public float X { get; init; }
+    public float Z { get; init; }
+    public float Radius { get; init; } = 6.0f;
+    public float Strength { get; init; } = 0.5f;
+    public string Operation { get; init; } = "Raise";
+}
+
+public sealed record McpLandscapePaintStamp
+{
+    public float X { get; init; }
+    public float Z { get; init; }
+    public float Radius { get; init; } = 6.0f;
+    public float Strength { get; init; } = 0.5f;
+    public uint Layer { get; init; }
+}
+
+public sealed record McpLandscapeApplyRequest
+{
+    public bool Confirm { get; init; }
+    public long? ExpectedWorkspaceEpoch { get; init; }
+    public string? TargetComponentId { get; init; }
+    public string Name { get; init; } = "Landscape";
+    public float PositionX { get; init; }
+    public float PositionY { get; init; }
+    public float PositionZ { get; init; }
+    public uint ChunksX { get; init; } = 4;
+    public uint ChunksZ { get; init; } = 4;
+    public float ChunkSize { get; init; } = 24.0f;
+    public uint ChunkResolution { get; init; } = 24;
+    public float HeightScale { get; init; } = 5.0f;
+    public float NoiseScale { get; init; } = 0.035f;
+    public uint Seed { get; init; } = 1337;
+    public string MaterialFileId { get; init; } = string.Empty;
+    public string[] LayerTextureFileIds { get; init; } = [];
+    public string HeightmapTextureFileId { get; init; } = string.Empty;
+    public string[] MaterialMaskFileIds { get; init; } = [];
+    public float TextureTiling { get; init; } = 0.15f;
+    public McpLandscapeVegetationProfile[] Vegetation { get; init; } = [];
+    public McpLandscapeSculptStamp[] Sculpt { get; init; } = [];
+    public McpLandscapePaintStamp[] Paint { get; init; } = [];
+}

--- a/Editor/Mcp/McpLandscapeOperations.cs
+++ b/Editor/Mcp/McpLandscapeOperations.cs
@@ -1,0 +1,311 @@
+#nullable enable
+
+using System.Text.Json;
+using SailorEditor.Commands;
+
+namespace SailorEditor.Mcp;
+
+internal sealed class McpLandscapeOperations
+{
+    const string LandscapeComponentType = "Sailor::LandscapeComponent";
+
+    readonly McpSceneBatchExecutor _sceneBatch;
+    readonly ICommandHistoryService _history;
+
+    public McpLandscapeOperations(
+        McpSceneBatchExecutor sceneBatch,
+        ICommandHistoryService history)
+    {
+        _sceneBatch = sceneBatch;
+        _history = history;
+    }
+
+    public Task<McpSceneBatchResult> ApplyAsync(
+        McpLandscapeApplyRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        if (!TryBuildOperations(request, out var operations, out var error))
+        {
+            return Task.FromResult(new McpSceneBatchResult(
+                false,
+                error,
+                _history.WorkspaceEpoch,
+                Array.Empty<McpSceneOperationResult>()));
+        }
+
+        return _sceneBatch.ExecuteAsync(
+            new McpSceneBatchRequest(
+                request.Confirm,
+                request.ExpectedWorkspaceEpoch,
+                string.IsNullOrWhiteSpace(request.TargetComponentId)
+                    ? $"Create landscape '{request.Name}' through MCP"
+                    : $"Author landscape '{request.Name}' through MCP",
+                operations),
+            cancellationToken);
+    }
+
+    public Task<McpSceneBatchResult> RegenerateAsync(
+        bool confirm,
+        long? expectedWorkspaceEpoch,
+        string targetComponentId,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(targetComponentId))
+        {
+            return Task.FromResult(new McpSceneBatchResult(
+                false,
+                "A LandscapeComponent instance ID is required.",
+                _history.WorkspaceEpoch,
+                Array.Empty<McpSceneOperationResult>()));
+        }
+
+        return _sceneBatch.ExecuteAsync(
+            new McpSceneBatchRequest(
+                confirm,
+                expectedWorkspaceEpoch,
+                "Regenerate landscape through MCP",
+                [
+                    new McpSceneOperation
+                    {
+                        Kind = "update_component",
+                        Target = targetComponentId,
+                        Properties = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+                        {
+                            ["regenerate"] = JsonSerializer.SerializeToElement(true),
+                        },
+                    },
+                    new McpSceneOperation
+                    {
+                        Kind = "update_component",
+                        Target = targetComponentId,
+                        Properties = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+                        {
+                            ["regenerate"] = JsonSerializer.SerializeToElement(false),
+                        },
+                    },
+                ]),
+            cancellationToken);
+    }
+
+    internal static bool TryBuildOperations(
+        McpLandscapeApplyRequest request,
+        out IReadOnlyList<McpSceneOperation> operations,
+        out string error)
+    {
+        operations = Array.Empty<McpSceneOperation>();
+        error = string.Empty;
+
+        if (request.ChunksX is < 1 or > 64 || request.ChunksZ is < 1 or > 64)
+            return Fail("chunksX and chunksZ must be between 1 and 64.", out error);
+        if (!IsFinitePositive(request.ChunkSize))
+            return Fail("chunkSize must be a finite positive number.", out error);
+        if (request.ChunkResolution is < 2 or > 128)
+            return Fail("chunkResolution must be between 2 and 128.", out error);
+        if (!float.IsFinite(request.HeightScale) || request.HeightScale < 0.0f)
+            return Fail("heightScale must be a finite non-negative number.", out error);
+        if (!IsFinitePositive(request.NoiseScale))
+            return Fail("noiseScale must be a finite positive number.", out error);
+        if (!IsFinitePositive(request.TextureTiling))
+            return Fail("textureTiling must be a finite positive number.", out error);
+        if (string.IsNullOrWhiteSpace(request.MaterialFileId))
+            return Fail("materialFileId is required.", out error);
+        if (request.LayerTextureFileIds is null || request.LayerTextureFileIds.Length != 4 ||
+            request.LayerTextureFileIds.Any(string.IsNullOrWhiteSpace))
+        {
+            return Fail("Exactly four non-empty layerTextureFileIds are required.", out error);
+        }
+        if (request.MaterialMaskFileIds is null || request.MaterialMaskFileIds.Length > 4 ||
+            request.MaterialMaskFileIds.Any(string.IsNullOrWhiteSpace))
+        {
+            return Fail("materialMaskFileIds must contain zero to four non-empty texture IDs.", out error);
+        }
+
+        var vegetation = request.Vegetation ?? [];
+        var shadowModes = new List<float>(vegetation.Length);
+        foreach (var profile in vegetation)
+        {
+            if (string.IsNullOrWhiteSpace(profile.ModelFileId))
+            {
+                return Fail("Every vegetation profile requires modelFileId; an empty materialFileId uses the GLB materials.", out error);
+            }
+            if (profile.InstancesPerChunk > 2048)
+                return Fail("vegetation instancesPerChunk cannot exceed 2048.", out error);
+            if (profile.MeshIndex < -1)
+                return Fail("vegetation meshIndex must be -1 (all meshes) or a non-negative mesh index.", out error);
+            if (!IsFinitePositive(profile.MinScale) ||
+                !IsFinitePositive(profile.MaxScale) ||
+                profile.MaxScale < profile.MinScale)
+            {
+                return Fail("Every vegetation profile requires 0 < minScale <= maxScale.", out error);
+            }
+            if (!float.IsFinite(profile.GroundOffset))
+                return Fail("vegetation groundOffset must be finite.", out error);
+            if (!TryParseShadowMode(profile.Shadows, out var shadowMode))
+                return Fail("vegetation shadows must be None, NearOnly, or All.", out error);
+            if (shadowMode == 1.0f && !IsFinitePositive(profile.ShadowDistance))
+                return Fail("NearOnly vegetation requires a positive shadowDistance.", out error);
+            if (profile.MinLod > 15 || profile.MaxLod > 15 || profile.MaxLod < profile.MinLod)
+                return Fail("vegetation LOD range must satisfy 0 <= minLod <= maxLod <= 15.", out error);
+            if (!IsCoverage(profile.Lod1ScreenCoverage) || !IsCoverage(profile.Lod2ScreenCoverage) ||
+                profile.Lod1ScreenCoverage < profile.Lod2ScreenCoverage)
+            {
+                return Fail("vegetation LOD screen coverage must be in 0..1 and descend from LOD1 to LOD2.", out error);
+            }
+            if (!IsFinitePositive(profile.CullDistance))
+                return Fail("vegetation cullDistance must be a finite positive number.", out error);
+            if (!float.IsFinite(profile.ColliderRadius) || profile.ColliderRadius < 0.0f ||
+                !float.IsFinite(profile.ColliderHeight) || profile.ColliderHeight < profile.ColliderRadius * 2.0f ||
+                !float.IsFinite(profile.ColliderOffsetY))
+            {
+                return Fail("vegetation collider requires radius >= 0, height >= 2 * radius, and a finite Y offset.", out error);
+            }
+            shadowModes.Add(shadowMode);
+        }
+
+        var sculptValues = new List<float>((request.Sculpt?.Length ?? 0) * 5);
+        foreach (var stamp in request.Sculpt ?? [])
+        {
+            if (!AllFinite(stamp.X, stamp.Z, stamp.Radius, stamp.Strength) ||
+                stamp.Radius <= 0.0f || stamp.Strength < 0.0f)
+            {
+                return Fail("Every sculpt stamp requires finite coordinates, radius > 0 and strength >= 0.", out error);
+            }
+            if (!TryParseSculptOperation(stamp.Operation, out var operation))
+                return Fail("sculpt operation must be Raise, Lower, or Smooth.", out error);
+            sculptValues.AddRange([stamp.X, stamp.Z, stamp.Radius, stamp.Strength, operation]);
+        }
+
+        var paintValues = new List<float>((request.Paint?.Length ?? 0) * 5);
+        foreach (var stamp in request.Paint ?? [])
+        {
+            if (!AllFinite(stamp.X, stamp.Z, stamp.Radius, stamp.Strength) ||
+                stamp.Radius <= 0.0f || stamp.Strength < 0.0f || stamp.Layer > 3)
+            {
+                return Fail("Every paint stamp requires finite coordinates, radius > 0, strength >= 0 and layer 0..3.", out error);
+            }
+            paintValues.AddRange([stamp.X, stamp.Z, stamp.Radius, stamp.Strength, stamp.Layer]);
+        }
+
+        var properties = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+        {
+            ["chunksX"] = JsonSerializer.SerializeToElement(request.ChunksX),
+            ["chunksZ"] = JsonSerializer.SerializeToElement(request.ChunksZ),
+            ["chunkSize"] = JsonSerializer.SerializeToElement(request.ChunkSize),
+            ["chunkResolution"] = JsonSerializer.SerializeToElement(request.ChunkResolution),
+            ["heightScale"] = JsonSerializer.SerializeToElement(request.HeightScale),
+            ["noiseScale"] = JsonSerializer.SerializeToElement(request.NoiseScale),
+            ["seed"] = JsonSerializer.SerializeToElement(request.Seed),
+            ["material"] = JsonSerializer.SerializeToElement(new { fileId = request.MaterialFileId, instanceId = string.Empty }),
+            ["layerTextures"] = JsonSerializer.SerializeToElement(request.LayerTextureFileIds),
+            ["heightmapTexture"] = JsonSerializer.SerializeToElement(request.HeightmapTextureFileId ?? string.Empty),
+            ["materialMasks"] = JsonSerializer.SerializeToElement(request.MaterialMaskFileIds),
+            ["textureTiling"] = JsonSerializer.SerializeToElement(request.TextureTiling),
+            ["sculptStamps"] = JsonSerializer.SerializeToElement(sculptValues),
+            ["paintStamps"] = JsonSerializer.SerializeToElement(paintValues),
+            ["vegetationModels"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.ModelFileId)),
+            ["vegetationMaterials"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.MaterialFileId)),
+            ["vegetationMeshIndex"] = JsonSerializer.SerializeToElement(vegetation.Select(value => (float)value.MeshIndex)),
+            ["vegetationInstancesPerChunk"] = JsonSerializer.SerializeToElement(vegetation.Select(value => (float)value.InstancesPerChunk)),
+            ["vegetationMinScale"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.MinScale)),
+            ["vegetationMaxScale"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.MaxScale)),
+            ["vegetationGroundOffset"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.GroundOffset)),
+            ["vegetationShadowMode"] = JsonSerializer.SerializeToElement(shadowModes),
+            ["vegetationShadowDistance"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.ShadowDistance)),
+            ["vegetationMinLod"] = JsonSerializer.SerializeToElement(vegetation.Select(value => (float)value.MinLod)),
+            ["vegetationMaxLod"] = JsonSerializer.SerializeToElement(vegetation.Select(value => (float)value.MaxLod)),
+            ["vegetationLod1ScreenCoverage"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.Lod1ScreenCoverage)),
+            ["vegetationLod2ScreenCoverage"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.Lod2ScreenCoverage)),
+            ["vegetationCullDistance"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.CullDistance)),
+            ["vegetationColliderRadius"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.ColliderRadius)),
+            ["vegetationColliderHeight"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.ColliderHeight)),
+            ["vegetationColliderOffsetY"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.ColliderOffsetY)),
+            ["regenerate"] = JsonSerializer.SerializeToElement(false),
+        };
+
+        if (string.IsNullOrWhiteSpace(request.TargetComponentId))
+        {
+            operations =
+            [
+                new McpSceneOperation
+                {
+                    Kind = "create_game_object",
+                    Alias = "landscape",
+                    Name = string.IsNullOrWhiteSpace(request.Name) ? "Landscape" : request.Name.Trim(),
+                    Properties = new Dictionary<string, JsonElement>(StringComparer.Ordinal)
+                    {
+                        ["position"] = JsonSerializer.SerializeToElement(new[]
+                        {
+                            request.PositionX, request.PositionY, request.PositionZ, 1.0f,
+                        }),
+                    },
+                },
+                new McpSceneOperation
+                {
+                    Kind = "add_component",
+                    Alias = "landscapeComponent",
+                    Target = "$landscape",
+                    ComponentType = LandscapeComponentType,
+                    Properties = properties,
+                },
+                new McpSceneOperation
+                {
+                    Kind = "select",
+                    Target = "$landscape",
+                },
+                new McpSceneOperation
+                {
+                    Kind = "focus",
+                    Target = "$landscape",
+                },
+            ];
+        }
+        else
+        {
+            operations =
+            [
+                new McpSceneOperation
+                {
+                    Kind = "update_component",
+                    Target = request.TargetComponentId.Trim(),
+                    Properties = properties,
+                },
+            ];
+        }
+
+        return true;
+    }
+
+    static bool TryParseShadowMode(string value, out float mode)
+    {
+        mode = value?.Trim().ToLowerInvariant() switch
+        {
+            "none" => 0.0f,
+            "nearonly" or "near_only" or "near only" => 1.0f,
+            "all" => 2.0f,
+            _ => -1.0f,
+        };
+        return mode >= 0.0f;
+    }
+
+    static bool TryParseSculptOperation(string value, out float operation)
+    {
+        operation = value?.Trim().ToLowerInvariant() switch
+        {
+            "raise" => 0.0f,
+            "lower" => 1.0f,
+            "smooth" => 2.0f,
+            _ => -1.0f,
+        };
+        return operation >= 0.0f;
+    }
+
+    static bool IsFinitePositive(float value) => float.IsFinite(value) && value > 0.0f;
+    static bool IsCoverage(float value) => float.IsFinite(value) && value is >= 0.0f and <= 1.0f;
+    static bool AllFinite(params float[] values) => values.All(float.IsFinite);
+
+    static bool Fail(string message, out string error)
+    {
+        error = message;
+        return false;
+    }
+}

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -200,6 +200,71 @@ namespace SailorEditor.Services
                 .ConfigureAwait(false);
         }
 
+        public async Task<FileId?> ImportTextureAsync(
+            string sourcePath,
+            string category,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(sourcePath) || !File.Exists(sourcePath) ||
+                string.IsNullOrWhiteSpace(CurrentProjectRootPath))
+            {
+                return null;
+            }
+
+            var extension = Path.GetExtension(sourcePath).ToLowerInvariant();
+            if (extension is not (".png" or ".jpg" or ".bmp" or
+                ".tga" or ".dds" or ".hdr"))
+            {
+                return null;
+            }
+
+            var safeCategory = string.Join("_", (category ?? "Textures")
+                .Split(Path.GetInvalidFileNameChars(), StringSplitOptions.RemoveEmptyEntries));
+            if (string.IsNullOrWhiteSpace(safeCategory))
+            {
+                safeCategory = "Textures";
+            }
+            var destinationDirectory = Path.Combine(
+                CurrentProjectRootPath, "Landscape", safeCategory);
+            Directory.CreateDirectory(destinationDirectory);
+            var destinationName = GetUniqueAssetName(
+                destinationDirectory,
+                Path.GetFileNameWithoutExtension(sourcePath),
+                extension);
+            var destinationPath = Path.Combine(destinationDirectory, destinationName);
+
+            await using (var source = new FileStream(sourcePath, FileMode.Open,
+                FileAccess.Read, FileShare.Read, 81920, FileOptions.Asynchronous))
+            await using (var destination = new FileStream(destinationPath,
+                FileMode.CreateNew, FileAccess.Write, FileShare.None, 81920,
+                FileOptions.Asynchronous))
+            {
+                await source.CopyToAsync(destination, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            if (!_engineService.IsRunning ||
+                !await _engineService.RequestAssetReloadAsync(cancellationToken)
+                    .ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            var metadataPath = destinationPath + ".asset";
+            for (var attempt = 0; attempt < 50 && !File.Exists(metadataPath); ++attempt)
+            {
+                await Task.Delay(100, cancellationToken).ConfigureAwait(false);
+            }
+            if (!File.Exists(metadataPath))
+            {
+                return null;
+            }
+
+            await RefreshAsync(cancellationToken).ConfigureAwait(false);
+            return new FileId(ReadAssetMetadataIdentity(
+                new FileInfo(metadataPath)).FileId);
+        }
+
         async Task<bool> RefreshFolderPathAsync(
             string directoryPath,
             CancellationToken cancellationToken)

--- a/Editor/Utility/EngineTypes.cs
+++ b/Editor/Utility/EngineTypes.cs
@@ -926,8 +926,10 @@ namespace SailorEditor
     public class FileIdYamlConverter : IYamlTypeConverter
     {
         public bool Accepts(Type type) => type == typeof(FileId);
-        public object ReadYaml(IParser parser, Type type) => new FileId(parser.Consume<Scalar>().Value);
-        public void WriteYaml(IEmitter emitter, object value, Type type) => emitter.Emit(new Scalar(((FileId)value).Value));
+        public object ReadYaml(IParser parser, Type type) =>
+            new FileId(parser.Consume<Scalar>().Value ?? string.Empty);
+        public void WriteYaml(IEmitter emitter, object value, Type type) =>
+            emitter.Emit(new Scalar((value as FileId)?.Value ?? string.Empty));
     }
 
     public class InstanceIdYamlConverter : IYamlTypeConverter

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -23,6 +23,7 @@ public partial class Component : ObservableObject, ICloneable, IInspectorEditabl
         propertyName => propertyName == nameof(OverrideProperties));
     readonly SemaphoreSlim _commitGate = new(1, 1);
     int pendingInspectorCommits;
+    int inspectorBatchDepth;
 
     public Component()
     {
@@ -33,9 +34,27 @@ public partial class Component : ObservableObject, ICloneable, IInspectorEditabl
                 return;
 
             IsDirty = true;
-            if (decision.CommitNow)
+            if (decision.CommitNow && Volatile.Read(ref inspectorBatchDepth) == 0)
                 _ = CommitInspectorChangesSafelyAsync();
         };
+    }
+
+    public async Task<bool> ApplyInspectorBatchAsync(
+        Action mutation,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(mutation);
+        Interlocked.Increment(ref inspectorBatchDepth);
+        try
+        {
+            mutation();
+        }
+        finally
+        {
+            Interlocked.Decrement(ref inspectorBatchDepth);
+        }
+
+        return await CommitInspectorChangesAsync(cancellationToken);
     }
 
     public async Task<bool> CommitInspectorChangesAsync(

--- a/Editor/Views/InspectorView/ComponentTemplate.Landscape.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.Landscape.cs
@@ -1,0 +1,666 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using SailorEditor;
+using SailorEditor.Helpers;
+using SailorEditor.Services;
+using SailorEditor.Shell;
+using SailorEditor.Utility;
+using SailorEditor.ViewModels;
+using SailorEditor.Views;
+using SailorEngine;
+
+namespace SailorEditor;
+
+public partial class ComponentTemplate
+{
+    static void AddLandscapeTools(Grid props, Component component)
+    {
+        var heading = new Label
+        {
+            Text = "Landscape Tools",
+            FontAttributes = FontAttributes.Bold,
+            Margin = new Thickness(0, 8, 0, 0)
+        };
+        Templates.AddGridRow(props, heading, GridLength.Auto);
+        Grid.SetColumnSpan(heading, props.ColumnDefinitions.Count);
+
+        var generate = new Button
+        {
+            Text = "Generate"
+        };
+        ToolTipProperties.SetText(generate, "Generate terrain from the next seed");
+        generate.Clicked += async (_, _) =>
+        {
+            generate.IsEnabled = false;
+            var previousText = generate.Text;
+            generate.Text = "Generating…";
+            try
+            {
+                await RebuildLandscapeAsync(component, advanceSeed: true);
+            }
+            finally
+            {
+                generate.Text = previousText;
+                generate.IsEnabled = true;
+            }
+        };
+
+        var regenerate = new Button
+        {
+            Text = "Regenerate"
+        };
+        ToolTipProperties.SetText(regenerate, "Rebuild terrain and vegetation from the current authored settings");
+        regenerate.Clicked += async (_, _) =>
+        {
+            regenerate.IsEnabled = false;
+            var previousText = regenerate.Text;
+            regenerate.Text = "Rebuilding…";
+            try
+            {
+                await RebuildLandscapeAsync(component, advanceSeed: false);
+            }
+            finally
+            {
+                regenerate.Text = previousText;
+                regenerate.IsEnabled = true;
+            }
+        };
+
+        var flatten = new Button
+        {
+            Text = "Flatten"
+        };
+        ToolTipProperties.SetText(flatten, "Set the generated terrain height to zero");
+        flatten.Clicked += async (_, _) =>
+        {
+            if (component.OverrideProperties.TryGetValue("heightScale", out var value) &&
+                value is Observable<float> heightScale)
+            {
+                heightScale.Value = 0.0f;
+                await RebuildLandscapeAsync(component, advanceSeed: false);
+            }
+        };
+
+        var toolbar = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition(GridLength.Star),
+                new ColumnDefinition(GridLength.Star),
+                new ColumnDefinition(GridLength.Star)
+            },
+            ColumnSpacing = 6
+        };
+        toolbar.Add(generate, 0, 0);
+        toolbar.Add(regenerate, 1, 0);
+        toolbar.Add(flatten, 2, 0);
+        Templates.AddGridRow(props, toolbar, GridLength.Auto);
+        Grid.SetColumnSpan(toolbar, props.ColumnDefinitions.Count);
+
+        var hint = new Label
+        {
+            Text = "Author terrain shape, layer painting and vegetation profiles through the Sailor landscape MCP tools.",
+            TextColor = Color.FromArgb("#929AA5"),
+            FontSize = 11
+        };
+        Templates.AddGridRow(props, hint, GridLength.Auto);
+        Grid.SetColumnSpan(hint, props.ColumnDefinitions.Count);
+    }
+
+    static async Task RebuildLandscapeAsync(Component component, bool advanceSeed)
+    {
+        if (advanceSeed &&
+            component.OverrideProperties.TryGetValue("seed", out var seedProperty) &&
+            seedProperty is Observable<uint> seed)
+        {
+            seed.Value = (uint)Random.Shared.NextInt64(0, (long)uint.MaxValue + 1L);
+            await component.CommitInspectorChangesAsync();
+            return;
+        }
+
+        if (!component.OverrideProperties.TryGetValue("regenerate", out var regenerateProperty) ||
+            regenerateProperty is not Observable<bool> regenerate)
+        {
+            await component.CommitInspectorChangesAsync();
+            return;
+        }
+
+        regenerate.Value = true;
+        await component.CommitInspectorChangesAsync();
+        regenerate.Value = false;
+        await component.CommitInspectorChangesAsync();
+    }
+
+    static void AddLandscapeVegetationEditor(Grid props, Component component)
+    {
+        if (!TryGetLandscapeVegetationLists(component,
+                out var models,
+                out var materials,
+                out var meshIndex,
+                out var instancesPerChunk,
+                out var minScale,
+                out var maxScale,
+                out var groundOffset,
+                out var shadowMode,
+                out var shadowDistance,
+                out var minLod,
+                out var maxLod,
+                out var lod1ScreenCoverage,
+                out var lod2ScreenCoverage,
+                out var cullDistance,
+                out var colliderRadius,
+                out var colliderHeight,
+                out var colliderOffsetY))
+        {
+            return;
+        }
+
+        var headingRow = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition(GridLength.Star),
+                new ColumnDefinition(GridLength.Auto)
+            },
+            ColumnSpacing = 6,
+            Margin = new Thickness(0, 8, 0, 0)
+        };
+        headingRow.Add(new Label
+        {
+            Text = "Vegetation",
+            FontAttributes = FontAttributes.Bold,
+            VerticalOptions = LayoutOptions.Center
+        }, 0, 0);
+        var addProfile = new Button { Text = "+ Add" };
+        headingRow.Add(addProfile, 1, 0);
+        Templates.AddGridRow(props, headingRow, GridLength.Auto);
+        Grid.SetColumnSpan(headingRow, props.ColumnDefinitions.Count);
+
+        var profiles = new VerticalStackLayout
+        {
+            Spacing = 8,
+            HorizontalOptions = LayoutOptions.Fill
+        };
+        Templates.AddGridRow(props, profiles, GridLength.Auto);
+        Grid.SetColumnSpan(profiles, props.ColumnDefinitions.Count);
+
+        void RebuildProfiles()
+        {
+            profiles.Children.Clear();
+            var count = new[]
+            {
+                models.Values.Count,
+                materials.Values.Count,
+                meshIndex.Values.Count,
+                instancesPerChunk.Values.Count,
+                minScale.Values.Count,
+                maxScale.Values.Count,
+                groundOffset.Values.Count,
+                shadowMode.Values.Count,
+                shadowDistance.Values.Count,
+                minLod.Values.Count,
+                maxLod.Values.Count,
+                lod1ScreenCoverage.Values.Count,
+                lod2ScreenCoverage.Values.Count,
+                cullDistance.Values.Count,
+                colliderRadius.Values.Count,
+                colliderHeight.Values.Count,
+                colliderOffsetY.Values.Count,
+            }.Min();
+
+            if (count == 0)
+            {
+                profiles.Children.Add(new Label
+                {
+                    Text = "No vegetation profiles. Add one or author the list through MCP.",
+                    TextColor = Color.FromArgb("#929AA5"),
+                    FontSize = 11
+                });
+                return;
+            }
+
+            for (var profileIndex = 0; profileIndex < count; ++profileIndex)
+            {
+                var index = profileIndex;
+                var card = new Grid
+                {
+                    ColumnDefinitions =
+                    {
+                        new ColumnDefinition(new GridLength(110)),
+                        new ColumnDefinition(GridLength.Star)
+                    },
+                    RowDefinitions =
+                    {
+                        new RowDefinition(GridLength.Auto)
+                    },
+                    RowSpacing = 5,
+                    ColumnSpacing = 8,
+                    Padding = new Thickness(8),
+                    BackgroundColor = Color.FromArgb("#141A22")
+                };
+
+                var title = new Label
+                {
+                    Text = $"Profile {index + 1}",
+                    FontAttributes = FontAttributes.Bold,
+                    VerticalOptions = LayoutOptions.Center
+                };
+                card.Add(title, 0, 0);
+                var remove = new Button
+                {
+                    Text = "Remove",
+                    HorizontalOptions = LayoutOptions.End
+                };
+                remove.Clicked += async (_, _) =>
+                {
+                    remove.IsEnabled = false;
+                    await component.ApplyInspectorBatchAsync(() =>
+                    {
+                        RemoveLandscapeVegetationProfile(index, models, materials,
+                            meshIndex, instancesPerChunk, minScale, maxScale, groundOffset,
+                            shadowMode, shadowDistance, minLod, maxLod,
+                            lod1ScreenCoverage, lod2ScreenCoverage, cullDistance,
+                            colliderRadius, colliderHeight, colliderOffsetY);
+                        RebuildProfiles();
+                    });
+                };
+                card.Add(remove, 1, 0);
+
+                AddVegetationField(card, "Model", Templates.FileIdEditor(
+                    models.Values[index],
+                    nameof(Observable<FileId>.Value),
+                    static (Observable<FileId> value) => value.Value,
+                    static (value, fileId) => value.Value = fileId,
+                    typeof(ModelFile)));
+                AddVegetationField(card, "Material override", Templates.FileIdEditor(
+                    materials.Values[index],
+                    nameof(Observable<FileId>.Value),
+                    static (Observable<FileId> value) => value.Value,
+                    static (value, fileId) => value.Value = fileId,
+                    typeof(MaterialFile)));
+                AddVegetationField(card, "Mesh index", CreateLandscapeFloatEditor(
+                    component, meshIndex.Values[index], value => MathF.Max(-1.0f, MathF.Round(value))));
+                AddVegetationField(card, "Per chunk", CreateLandscapeFloatEditor(
+                    component, instancesPerChunk.Values[index], value => MathF.Max(0.0f, MathF.Round(value))));
+                AddVegetationField(card, "Min scale", CreateLandscapeFloatEditor(
+                    component, minScale.Values[index], value => MathF.Max(0.01f, value)));
+                AddVegetationField(card, "Max scale", CreateLandscapeFloatEditor(
+                    component, maxScale.Values[index], value => MathF.Max(minScale.Values[index].Value, value)));
+                AddVegetationField(card, "Ground offset", CreateLandscapeFloatEditor(
+                    component, groundOffset.Values[index], value => value));
+
+                var shadows = new Picker
+                {
+                    ItemsSource = new[] { "None", "Near only", "All" },
+                    SelectedIndex = Math.Clamp((int)shadowMode.Values[index].Value, 0, 2),
+                    FontSize = 12,
+                    BindingContext = component
+                };
+                shadows.SelectedIndexChanged += (_, _) =>
+                {
+                    if (shadows.SelectedIndex < 0)
+                        return;
+                    shadowMode.Values[index].Value = shadows.SelectedIndex;
+                    _ = component.CommitInspectorChangesAsync();
+                };
+                AddVegetationField(card, "Shadows", shadows);
+                AddVegetationField(card, "Near distance", CreateLandscapeFloatEditor(
+                    component, shadowDistance.Values[index], value => MathF.Max(0.1f, value)));
+                AddVegetationField(card, "Min LOD", CreateLandscapeFloatEditor(
+                    component, minLod.Values[index], value => Math.Clamp(MathF.Round(value), 0.0f, 15.0f)));
+                AddVegetationField(card, "Max LOD", CreateLandscapeFloatEditor(
+                    component, maxLod.Values[index], value => Math.Clamp(MathF.Round(value), minLod.Values[index].Value, 15.0f)));
+                AddVegetationField(card, "LOD 1 coverage", CreateLandscapeFloatEditor(
+                    component, lod1ScreenCoverage.Values[index], value => Math.Clamp(value, lod2ScreenCoverage.Values[index].Value, 1.0f)));
+                AddVegetationField(card, "LOD 2 coverage", CreateLandscapeFloatEditor(
+                    component, lod2ScreenCoverage.Values[index], value => Math.Clamp(value, 0.0f, lod1ScreenCoverage.Values[index].Value)));
+                AddVegetationField(card, "Cull distance", CreateLandscapeFloatEditor(
+                    component, cullDistance.Values[index], value => MathF.Max(0.1f, value)));
+                AddVegetationField(card, "Collider radius", CreateLandscapeFloatEditor(
+                    component, colliderRadius.Values[index], value => MathF.Max(0.0f, value)));
+                AddVegetationField(card, "Collider height", CreateLandscapeFloatEditor(
+                    component, colliderHeight.Values[index], value => MathF.Max(colliderRadius.Values[index].Value * 2.0f, value)));
+                AddVegetationField(card, "Collider Y offset", CreateLandscapeFloatEditor(
+                    component, colliderOffsetY.Values[index], value => value));
+
+                profiles.Children.Add(card);
+            }
+        }
+
+        addProfile.Clicked += async (_, _) =>
+        {
+            addProfile.IsEnabled = false;
+            try
+            {
+                await component.ApplyInspectorBatchAsync(() =>
+                {
+                    models.Values.Add(new Observable<FileId>(new FileId()));
+                    materials.Values.Add(new Observable<FileId>(new FileId()));
+                    meshIndex.Values.Add(new Observable<float>(-1.0f));
+                    instancesPerChunk.Values.Add(new Observable<float>(4.0f));
+                    minScale.Values.Add(new Observable<float>(0.75f));
+                    maxScale.Values.Add(new Observable<float>(1.25f));
+                    groundOffset.Values.Add(new Observable<float>(0.0f));
+                    shadowMode.Values.Add(new Observable<float>(1.0f));
+                    shadowDistance.Values.Add(new Observable<float>(35.0f));
+                    minLod.Values.Add(new Observable<float>(0.0f));
+                    maxLod.Values.Add(new Observable<float>(2.0f));
+                    lod1ScreenCoverage.Values.Add(new Observable<float>(0.25f));
+                    lod2ScreenCoverage.Values.Add(new Observable<float>(0.05f));
+                    cullDistance.Values.Add(new Observable<float>(120.0f));
+                    colliderRadius.Values.Add(new Observable<float>(0.0f));
+                    colliderHeight.Values.Add(new Observable<float>(2.0f));
+                    colliderOffsetY.Values.Add(new Observable<float>(1.0f));
+                    RebuildProfiles();
+                });
+            }
+            finally
+            {
+                addProfile.IsEnabled = true;
+            }
+        };
+        RebuildProfiles();
+    }
+
+    static void AddLandscapeImportEditor(Grid props, Component component)
+    {
+        if (!component.OverrideProperties.TryGetValue("heightmapTexture", out var heightmapProperty) ||
+            heightmapProperty is not Observable<FileId> heightmap ||
+            !component.OverrideProperties.TryGetValue("layerTextures", out var layersProperty) ||
+            layersProperty is not ObservableFileIdList layers ||
+            !component.OverrideProperties.TryGetValue("materialMasks", out var masksProperty) ||
+            masksProperty is not ObservableFileIdList masks)
+        {
+            return;
+        }
+
+        var heading = new Label
+        {
+            Text = "Imported Maps",
+            FontAttributes = FontAttributes.Bold,
+            Margin = new Thickness(0, 8, 0, 0)
+        };
+        Templates.AddGridRow(props, heading, GridLength.Auto);
+        Grid.SetColumnSpan(heading, props.ColumnDefinitions.Count);
+
+        var status = new Label
+        {
+            FontSize = 11,
+            TextColor = Color.FromArgb("#929AA5")
+        };
+
+        var heightmapRow = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition(GridLength.Star),
+                new ColumnDefinition(GridLength.Auto)
+            },
+            ColumnSpacing = 6
+        };
+        var heightmapEditor = Templates.FileIdEditor(
+            heightmap,
+            nameof(Observable<FileId>.Value),
+            static (Observable<FileId> value) => value.Value,
+            static (value, fileId) => value.Value = fileId,
+            typeof(TextureFile));
+        heightmapRow.Add(heightmapEditor, 0, 0);
+        var importHeightmap = new Button { Text = "Import…" };
+        ToolTipProperties.SetText(importHeightmap,
+            "Copy an image into Content/Landscape/Heightmaps and use it as terrain height");
+        importHeightmap.Clicked += async (_, _) =>
+        {
+            var picked = await FilePicker.Default.PickAsync(new PickOptions
+            {
+                PickerTitle = "Import landscape heightmap"
+            });
+            if (picked is null)
+                return;
+
+            status.Text = "Importing heightmap…";
+            var fileId = await MauiProgram.GetService<AssetsService>()
+                .ImportTextureAsync(picked.FullPath, "Heightmaps");
+            if (fileId is null || fileId.IsEmpty())
+            {
+                status.Text = "Heightmap import failed. Use PNG, JPG, BMP, TGA, DDS or HDR.";
+                return;
+            }
+            heightmap.Value = fileId;
+            await component.CommitInspectorChangesAsync();
+            status.Text = "Heightmap imported. Regenerate to rebuild the terrain.";
+        };
+        heightmapRow.Add(importHeightmap, 1, 0);
+        Templates.AddGridRowWithLabel(props, "Heightmap", heightmapRow, GridLength.Auto);
+
+        var layersEditor = new VerticalStackLayout { Spacing = 4 };
+        layersEditor.Children.Add(Templates.FileIdListEditor(layers, typeof(TextureFile)));
+        layersEditor.Children.Add(new Label
+        {
+            Text = "Up to four albedo layers. Material masks use the same order.",
+            FontSize = 11,
+            TextColor = Color.FromArgb("#929AA5")
+        });
+        Templates.AddGridRowWithLabel(props, "Material layers", layersEditor, GridLength.Auto);
+
+        var masksRow = new VerticalStackLayout { Spacing = 6 };
+        masksRow.Children.Add(Templates.FileIdListEditor(masks, typeof(TextureFile)));
+        var importMasks = new Button
+        {
+            Text = "Import Material Masks…",
+            HorizontalOptions = LayoutOptions.Start
+        };
+        ToolTipProperties.SetText(importMasks,
+            "Import one RGBA splat-map or up to four grayscale masks, ordered by landscape layer");
+        importMasks.Clicked += async (_, _) =>
+        {
+            var pickedFiles = await FilePicker.Default.PickMultipleAsync(new PickOptions
+            {
+                PickerTitle = "Import landscape material masks"
+            });
+            var selected = pickedFiles?.Take(4).ToArray() ?? [];
+            if (selected.Length == 0)
+                return;
+
+            status.Text = "Importing material masks…";
+            var imported = new List<FileId>(selected.Length);
+            foreach (var picked in selected)
+            {
+                var fileId = await MauiProgram.GetService<AssetsService>()
+                    .ImportTextureAsync(picked.FullPath, "Masks");
+                if (fileId is not null && !fileId.IsEmpty())
+                {
+                    imported.Add(fileId);
+                }
+            }
+            if (imported.Count != selected.Length)
+            {
+                status.Text = "One or more material masks could not be imported.";
+                return;
+            }
+
+            masks.Values.Clear();
+            foreach (var fileId in imported)
+            {
+                masks.Values.Add(new Observable<FileId>(fileId));
+            }
+            await component.CommitInspectorChangesAsync();
+            status.Text = imported.Count == 1
+                ? "RGBA material mask imported. Regenerate to apply it."
+                : $"{imported.Count} material masks imported. Regenerate to apply them.";
+        };
+        masksRow.Children.Add(importMasks);
+        Templates.AddGridRowWithLabel(props, "Material masks", masksRow, GridLength.Auto);
+        Templates.AddGridRow(props, status, GridLength.Auto);
+        Grid.SetColumnSpan(status, props.ColumnDefinitions.Count);
+    }
+
+    static View CreateLandscapeFloatEditor(
+        Component component,
+        Observable<float> observable,
+        Func<float, float> sanitize)
+    {
+        var editor = Templates.FloatEditor(
+            (Component _) => observable.Value,
+            (Component _, float value) => observable.Value = sanitize(value));
+        editor.BindingContext = component;
+        return editor;
+    }
+
+    static void AddVegetationField(Grid card, string label, View editor)
+    {
+        var row = card.RowDefinitions.Count;
+        card.RowDefinitions.Add(new RowDefinition(GridLength.Auto));
+        card.Add(new Label
+        {
+            Text = label,
+            FontSize = 11,
+            TextColor = Color.FromArgb("#929AA5"),
+            VerticalOptions = LayoutOptions.Center
+        }, 0, row);
+        editor.HorizontalOptions = LayoutOptions.Fill;
+        editor.MinimumWidthRequest = 0;
+        card.Add(editor, 1, row);
+    }
+
+    static void RemoveLandscapeVegetationProfile(
+        int index,
+        ObservableFileIdList models,
+        ObservableFileIdList materials,
+        ObservableFloatList meshIndex,
+        ObservableFloatList instancesPerChunk,
+        ObservableFloatList minScale,
+        ObservableFloatList maxScale,
+        ObservableFloatList groundOffset,
+        ObservableFloatList shadowMode,
+        ObservableFloatList shadowDistance,
+        ObservableFloatList minLod,
+        ObservableFloatList maxLod,
+        ObservableFloatList lod1ScreenCoverage,
+        ObservableFloatList lod2ScreenCoverage,
+        ObservableFloatList cullDistance,
+        ObservableFloatList colliderRadius,
+        ObservableFloatList colliderHeight,
+        ObservableFloatList colliderOffsetY)
+    {
+        models.Values.RemoveAt(index);
+        materials.Values.RemoveAt(index);
+        meshIndex.Values.RemoveAt(index);
+        instancesPerChunk.Values.RemoveAt(index);
+        minScale.Values.RemoveAt(index);
+        maxScale.Values.RemoveAt(index);
+        groundOffset.Values.RemoveAt(index);
+        shadowMode.Values.RemoveAt(index);
+        shadowDistance.Values.RemoveAt(index);
+        minLod.Values.RemoveAt(index);
+        maxLod.Values.RemoveAt(index);
+        lod1ScreenCoverage.Values.RemoveAt(index);
+        lod2ScreenCoverage.Values.RemoveAt(index);
+        cullDistance.Values.RemoveAt(index);
+        colliderRadius.Values.RemoveAt(index);
+        colliderHeight.Values.RemoveAt(index);
+        colliderOffsetY.Values.RemoveAt(index);
+    }
+
+    static bool TryGetLandscapeVegetationLists(
+        Component component,
+        out ObservableFileIdList models,
+        out ObservableFileIdList materials,
+        out ObservableFloatList meshIndex,
+        out ObservableFloatList instancesPerChunk,
+        out ObservableFloatList minScale,
+        out ObservableFloatList maxScale,
+        out ObservableFloatList groundOffset,
+        out ObservableFloatList shadowMode,
+        out ObservableFloatList shadowDistance,
+        out ObservableFloatList minLod,
+        out ObservableFloatList maxLod,
+        out ObservableFloatList lod1ScreenCoverage,
+        out ObservableFloatList lod2ScreenCoverage,
+        out ObservableFloatList cullDistance,
+        out ObservableFloatList colliderRadius,
+        out ObservableFloatList colliderHeight,
+        out ObservableFloatList colliderOffsetY)
+    {
+        component.OverrideProperties.TryGetValue("vegetationModels", out var modelsProperty);
+        component.OverrideProperties.TryGetValue("vegetationMaterials", out var materialsProperty);
+        component.OverrideProperties.TryGetValue("vegetationMeshIndex", out var meshIndexProperty);
+        component.OverrideProperties.TryGetValue("vegetationInstancesPerChunk", out var instancesPerChunkProperty);
+        component.OverrideProperties.TryGetValue("vegetationMinScale", out var minScaleProperty);
+        component.OverrideProperties.TryGetValue("vegetationMaxScale", out var maxScaleProperty);
+        component.OverrideProperties.TryGetValue("vegetationGroundOffset", out var groundOffsetProperty);
+        component.OverrideProperties.TryGetValue("vegetationShadowMode", out var shadowModeProperty);
+        component.OverrideProperties.TryGetValue("vegetationShadowDistance", out var shadowDistanceProperty);
+        component.OverrideProperties.TryGetValue("vegetationMinLod", out var minLodProperty);
+        component.OverrideProperties.TryGetValue("vegetationMaxLod", out var maxLodProperty);
+        component.OverrideProperties.TryGetValue("vegetationLod1ScreenCoverage", out var lod1ScreenCoverageProperty);
+        component.OverrideProperties.TryGetValue("vegetationLod2ScreenCoverage", out var lod2ScreenCoverageProperty);
+        component.OverrideProperties.TryGetValue("vegetationCullDistance", out var cullDistanceProperty);
+        component.OverrideProperties.TryGetValue("vegetationColliderRadius", out var colliderRadiusProperty);
+        component.OverrideProperties.TryGetValue("vegetationColliderHeight", out var colliderHeightProperty);
+        component.OverrideProperties.TryGetValue("vegetationColliderOffsetY", out var colliderOffsetYProperty);
+
+        models = modelsProperty as ObservableFileIdList;
+        materials = materialsProperty as ObservableFileIdList;
+        meshIndex = meshIndexProperty as ObservableFloatList;
+        instancesPerChunk = instancesPerChunkProperty as ObservableFloatList;
+        minScale = minScaleProperty as ObservableFloatList;
+        maxScale = maxScaleProperty as ObservableFloatList;
+        groundOffset = groundOffsetProperty as ObservableFloatList;
+        shadowMode = shadowModeProperty as ObservableFloatList;
+        shadowDistance = shadowDistanceProperty as ObservableFloatList;
+        minLod = minLodProperty as ObservableFloatList;
+        maxLod = maxLodProperty as ObservableFloatList;
+        lod1ScreenCoverage = lod1ScreenCoverageProperty as ObservableFloatList;
+        lod2ScreenCoverage = lod2ScreenCoverageProperty as ObservableFloatList;
+        cullDistance = cullDistanceProperty as ObservableFloatList;
+        colliderRadius = colliderRadiusProperty as ObservableFloatList;
+        colliderHeight = colliderHeightProperty as ObservableFloatList;
+        colliderOffsetY = colliderOffsetYProperty as ObservableFloatList;
+        if (models is not null)
+        {
+            EnsureLandscapeProfileLength(materials, models.Values.Count);
+            EnsureLandscapeProfileLength(meshIndex, models.Values.Count, -1.0f);
+            EnsureLandscapeProfileLength(minLod, models.Values.Count, 0.0f);
+            EnsureLandscapeProfileLength(maxLod, models.Values.Count, 2.0f);
+            EnsureLandscapeProfileLength(lod1ScreenCoverage, models.Values.Count, 0.25f);
+            EnsureLandscapeProfileLength(lod2ScreenCoverage, models.Values.Count, 0.05f);
+            EnsureLandscapeProfileLength(cullDistance, models.Values.Count, 120.0f);
+            EnsureLandscapeProfileLength(colliderRadius, models.Values.Count, 0.0f);
+            EnsureLandscapeProfileLength(colliderHeight, models.Values.Count, 2.0f);
+            EnsureLandscapeProfileLength(colliderOffsetY, models.Values.Count, 1.0f);
+        }
+        return models is not null && materials is not null && meshIndex is not null &&
+            instancesPerChunk is not null && minScale is not null &&
+            maxScale is not null && groundOffset is not null &&
+            shadowMode is not null && shadowDistance is not null &&
+            minLod is not null && maxLod is not null &&
+            lod1ScreenCoverage is not null && lod2ScreenCoverage is not null &&
+            cullDistance is not null && colliderRadius is not null &&
+            colliderHeight is not null && colliderOffsetY is not null;
+    }
+
+    static void EnsureLandscapeProfileLength(
+        ObservableFileIdList? values,
+        int count)
+    {
+        if (values is null)
+            return;
+        while (values.Values.Count < count)
+        {
+            values.Values.Add(new Observable<FileId>(new FileId()));
+        }
+    }
+
+    static void EnsureLandscapeProfileLength(
+        ObservableFloatList? values,
+        int count,
+        float defaultValue)
+    {
+        if (values is null)
+            return;
+        while (values.Values.Count < count)
+        {
+            values.Values.Add(new Observable<float>(defaultValue));
+        }
+    }
+
+}

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -9,7 +9,7 @@ using SailorEditor.Views;
 using SailorEngine;
 
 namespace SailorEditor;
-public class ComponentTemplate : DataTemplate
+public partial class ComponentTemplate : DataTemplate
 {
     static readonly HashSet<string> CompactComponents = [];
 
@@ -166,6 +166,12 @@ public class ComponentTemplate : DataTemplate
                     return;
                 }
 
+                if (component.Typename.Name == "Sailor::LandscapeComponent")
+                {
+                    AddLandscapeTools(props, component);
+                    AddLandscapeImportEditor(props, component);
+                }
+
                 var engineTypes = MauiProgram.GetService<EngineService>().EngineTypes;
 
                 foreach (var property in EnumerateInspectorProperties(component))
@@ -254,6 +260,11 @@ public class ComponentTemplate : DataTemplate
                     }
 
                     Templates.AddGridRowWithLabel(props, property.Key, propertyEditor, GridLength.Auto);
+                }
+
+                if (component.Typename.Name == "Sailor::LandscapeComponent")
+                {
+                    AddLandscapeVegetationEditor(props, component);
                 }
 
                 if (component.Typename.Name == "Sailor::AnimatorComponent")
@@ -352,6 +363,30 @@ public class ComponentTemplate : DataTemplate
     static IEnumerable<KeyValuePair<string, ObservableObject>> EnumerateInspectorProperties(
         Component component)
     {
+        if (component.Typename.Name == "Sailor::LandscapeComponent")
+        {
+            foreach (var property in component.OverrideProperties)
+            {
+                if (property.Key is "sculptStamps" or "paintStamps" or
+                    "layerTextures" or "heightmapTexture" or "materialMasks" or
+                    "vegetationModels" or "vegetationMaterials" or
+                    "vegetationMeshIndex" or
+                    "vegetationInstancesPerChunk" or "vegetationMinScale" or
+                    "vegetationMaxScale" or "vegetationGroundOffset" or
+                    "vegetationShadowMode" or "vegetationShadowDistance" or
+                    "vegetationMinLod" or "vegetationMaxLod" or
+                    "vegetationLod1ScreenCoverage" or "vegetationLod2ScreenCoverage" or
+                    "vegetationCullDistance" or "vegetationColliderRadius" or
+                    "vegetationColliderHeight" or "vegetationColliderOffsetY" or
+                    "regenerate")
+                {
+                    continue;
+                }
+                yield return property;
+            }
+            yield break;
+        }
+
         if (component.Typename.Name != "Sailor::MeshRendererComponent")
         {
             foreach (var property in component.OverrideProperties)
@@ -390,7 +425,10 @@ public class ComponentTemplate : DataTemplate
         return component.Typename.Name == "Sailor::MeshRendererComponent" &&
             propertyName == "overrideMaterials"
             ? typeof(MaterialFile)
-            : null;
+            : component.Typename.Name == "Sailor::LandscapeComponent" &&
+                propertyName == "layerTextures"
+                ? typeof(TextureFile)
+                : null;
     }
 
     static Command CreateContextMenuCommand(

--- a/Runtime/AssetRegistry/Material/MaterialImporter.cpp
+++ b/Runtime/AssetRegistry/Material/MaterialImporter.cpp
@@ -259,6 +259,12 @@ void Material::UpdateRHIResource()
 	m_bIsDirty = false;
 }
 
+void Material::UpdateRHIResourceAndUniforms()
+{
+	UpdateRHIResource();
+	ForcelyUpdateUniforms();
+}
+
 void Material::UpdateUniforms(RHI::RHICommandListPtr cmdList)
 {
 	if (!m_commonShaderBindings)

--- a/Runtime/AssetRegistry/Material/MaterialImporter.h
+++ b/Runtime/AssetRegistry/Material/MaterialImporter.h
@@ -52,6 +52,7 @@ namespace Sailor
 		SAILOR_API const RHI::RenderState& GetRenderState() const { return m_renderState; }
 
 		SAILOR_API void UpdateRHIResource();
+		SAILOR_API void UpdateRHIResourceAndUniforms();
 
 		// TODO: Incapsulate & isolate
 		SAILOR_API RHI::RHIMaterialPtr GetOrAddRHI(RHI::RHIVertexDescriptionPtr vertexDescription);

--- a/Runtime/AssetRegistry/Texture/TextureImporter.cpp
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.cpp
@@ -618,6 +618,12 @@ bool TextureImporter::ImportTexture(FileId uid, ByteCode& decodedData, int32_t& 
 	return false;
 }
 
+bool TextureImporter::DecodeTextureCpu(FileId uid, ByteCode& decodedData,
+	int32_t& width, int32_t& height, uint32_t& mipLevels)
+{
+	return ImportTexture(uid, decodedData, width, height, mipLevels);
+}
+
 bool TextureImporter::LoadTexture_Immediate(FileId uid, TexturePtr& outTexture)
 {
 	auto task = LoadTexture(uid, outTexture);

--- a/Runtime/AssetRegistry/Texture/TextureImporter.h
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.h
@@ -92,6 +92,8 @@ namespace Sailor
 		SAILOR_API bool LoadAsset(FileId uid, TObjectPtr<Object>& out, bool bImmediate = true) override;
 		SAILOR_API bool LoadTexture_Immediate(FileId uid, TexturePtr& outTexture);
 		SAILOR_API Tasks::TaskPtr<TexturePtr> LoadTexture(FileId uid, TexturePtr& outTexture);
+		SAILOR_API static bool DecodeTextureCpu(FileId uid, ByteCode& decodedData,
+			int32_t& width, int32_t& height, uint32_t& mipLevels);
 		SAILOR_API TexturePtr GetLoadedTexture(FileId uid);
 		SAILOR_API Tasks::TaskPtr<TexturePtr> GetLoadPromise(FileId uid);
 		SAILOR_API virtual void CollectGarbage() override;

--- a/Runtime/Components/LandscapeComponent.cpp
+++ b/Runtime/Components/LandscapeComponent.cpp
@@ -1,0 +1,94 @@
+#include "Components/LandscapeComponent.h"
+#include "ECS/LandscapeECS.h"
+#include "Engine/GameObject.h"
+
+#include <algorithm>
+
+using namespace Sailor;
+
+void LandscapeComponent::Initialize()
+{
+	auto* ecs = GetOwner()->GetWorld()->GetECS<LandscapeECS>();
+	m_handle = ecs->RegisterComponent();
+	auto& data = ecs->GetComponentData(m_handle);
+	data.SetOwner(GetOwner());
+	SyncToECS(data);
+}
+
+void LandscapeComponent::SyncToECS(LandscapeData& data) const
+{
+	data.SetSettings(m_chunksX, m_chunksZ, m_chunkSize, m_chunkResolution,
+		m_heightScale, m_noiseScale, m_seed, m_textureTiling);
+	data.SetMaterial(m_material);
+	data.SetLayerTextures(m_layerTextures);
+	data.SetImportMaps(m_heightmapTexture, m_materialMasks);
+	data.SetAuthoredStamps(m_sculptStamps, m_paintStamps);
+	data.SetVegetationProfiles(m_vegetationModels, m_vegetationMaterials,
+		m_vegetationMeshIndex, m_vegetationInstancesPerChunk, m_vegetationMinScale,
+		m_vegetationMaxScale, m_vegetationGroundOffset,
+		m_vegetationShadowMode, m_vegetationShadowDistance,
+		m_vegetationMinLod, m_vegetationMaxLod,
+		m_vegetationLod1ScreenCoverage, m_vegetationLod2ScreenCoverage,
+		m_vegetationCullDistance, m_vegetationColliderRadius,
+		m_vegetationColliderHeight, m_vegetationColliderOffsetY);
+}
+
+void LandscapeComponent::EndPlay()
+{
+	if (m_handle != ECS::InvalidIndex)
+	{
+		GetOwner()->GetWorld()->GetECS<LandscapeECS>()->UnregisterComponent(m_handle);
+		m_handle = ECS::InvalidIndex;
+	}
+}
+
+LandscapeData* LandscapeComponent::TryGetData()
+{
+	if (m_handle == ECS::InvalidIndex || !GetOwner() || !GetOwner()->GetWorld())
+	{
+		return nullptr;
+	}
+	auto* ecs = GetOwner()->GetWorld()->GetECS<LandscapeECS>();
+	return ecs && ecs->IsComponentRegistered(m_handle) ? &ecs->GetComponentData(m_handle) : nullptr;
+}
+
+void LandscapeComponent::MarkDirty()
+{
+	if (auto* data = TryGetData())
+	{
+		SyncToECS(*data);
+	}
+}
+
+void LandscapeComponent::SetChunksX(uint32_t value) { m_chunksX = (std::clamp)(value, 1u, 64u); MarkDirty(); }
+void LandscapeComponent::SetChunksZ(uint32_t value) { m_chunksZ = (std::clamp)(value, 1u, 64u); MarkDirty(); }
+void LandscapeComponent::SetChunkSize(float value) { m_chunkSize = (std::max)(value, 1.0f); MarkDirty(); }
+void LandscapeComponent::SetChunkResolution(uint32_t value) { m_chunkResolution = (std::clamp)(value, 2u, 128u); MarkDirty(); }
+void LandscapeComponent::SetHeightScale(float value) { m_heightScale = (std::max)(value, 0.0f); MarkDirty(); }
+void LandscapeComponent::SetNoiseScale(float value) { m_noiseScale = (std::max)(value, 0.0001f); MarkDirty(); }
+void LandscapeComponent::SetSeed(uint32_t value) { m_seed = value; MarkDirty(); }
+void LandscapeComponent::SetMaterial(const MaterialPtr& value) { m_material = value; MarkDirty(); }
+void LandscapeComponent::SetLayerTextures(const TVector<FileId>& value) { m_layerTextures = value; if (m_layerTextures.Num() > 4u) m_layerTextures.Resize(4u); MarkDirty(); }
+void LandscapeComponent::SetHeightmapTexture(const FileId& value) { m_heightmapTexture = value; MarkDirty(); }
+void LandscapeComponent::SetMaterialMasks(const TVector<FileId>& value) { m_materialMasks = value; if (m_materialMasks.Num() > 4u) m_materialMasks.Resize(4u); MarkDirty(); }
+void LandscapeComponent::SetTextureTiling(float value) { m_textureTiling = (std::max)(value, 0.001f); MarkDirty(); }
+void LandscapeComponent::SetSculptStamps(const TVector<float>& value) { m_sculptStamps = value; m_sculptStamps.Resize(m_sculptStamps.Num() / 5u * 5u); MarkDirty(); }
+void LandscapeComponent::SetPaintStamps(const TVector<float>& value) { m_paintStamps = value; m_paintStamps.Resize(m_paintStamps.Num() / 5u * 5u); MarkDirty(); }
+void LandscapeComponent::SetVegetationModels(const TVector<FileId>& value) { m_vegetationModels = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationMaterials(const TVector<FileId>& value) { m_vegetationMaterials = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationMeshIndex(const TVector<float>& value) { m_vegetationMeshIndex = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationInstancesPerChunk(const TVector<float>& value) { m_vegetationInstancesPerChunk = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationMinScale(const TVector<float>& value) { m_vegetationMinScale = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationMaxScale(const TVector<float>& value) { m_vegetationMaxScale = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationGroundOffset(const TVector<float>& value) { m_vegetationGroundOffset = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationShadowMode(const TVector<float>& value) { m_vegetationShadowMode = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationShadowDistance(const TVector<float>& value) { m_vegetationShadowDistance = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationMinLod(const TVector<float>& value) { m_vegetationMinLod = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationMaxLod(const TVector<float>& value) { m_vegetationMaxLod = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationLod1ScreenCoverage(const TVector<float>& value) { m_vegetationLod1ScreenCoverage = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationLod2ScreenCoverage(const TVector<float>& value) { m_vegetationLod2ScreenCoverage = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationCullDistance(const TVector<float>& value) { m_vegetationCullDistance = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationColliderRadius(const TVector<float>& value) { m_vegetationColliderRadius = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationColliderHeight(const TVector<float>& value) { m_vegetationColliderHeight = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationColliderOffsetY(const TVector<float>& value) { m_vegetationColliderOffsetY = value; MarkDirty(); }
+void LandscapeComponent::SetRegenerate(bool value) { if (value) MarkDirty(); }

--- a/Runtime/Components/LandscapeComponent.h
+++ b/Runtime/Components/LandscapeComponent.h
@@ -1,0 +1,194 @@
+#pragma once
+
+#include "Components/Component.h"
+#include "AssetRegistry/Material/MaterialImporter.h"
+#include "ECS/ECS.h"
+
+namespace Sailor
+{
+	class LandscapeData;
+
+	class LandscapeComponent final : public Component
+	{
+		SAILOR_REFLECTABLE(LandscapeComponent)
+
+	public:
+		SAILOR_API virtual void Initialize() override;
+		SAILOR_API virtual void EndPlay() override;
+
+		SAILOR_API uint32_t GetChunksX() const { return m_chunksX; }
+		SAILOR_API void SetChunksX(uint32_t value);
+		SAILOR_API uint32_t GetChunksZ() const { return m_chunksZ; }
+		SAILOR_API void SetChunksZ(uint32_t value);
+		SAILOR_API float GetChunkSize() const { return m_chunkSize; }
+		SAILOR_API void SetChunkSize(float value);
+		SAILOR_API uint32_t GetChunkResolution() const { return m_chunkResolution; }
+		SAILOR_API void SetChunkResolution(uint32_t value);
+		SAILOR_API float GetHeightScale() const { return m_heightScale; }
+		SAILOR_API void SetHeightScale(float value);
+		SAILOR_API float GetNoiseScale() const { return m_noiseScale; }
+		SAILOR_API void SetNoiseScale(float value);
+		SAILOR_API uint32_t GetSeed() const { return m_seed; }
+		SAILOR_API void SetSeed(uint32_t value);
+		SAILOR_API const MaterialPtr& GetMaterial() const { return m_material; }
+		SAILOR_API void SetMaterial(const MaterialPtr& value);
+		SAILOR_API const TVector<FileId>& GetLayerTextures() const { return m_layerTextures; }
+		SAILOR_API void SetLayerTextures(const TVector<FileId>& value);
+		SAILOR_API const FileId& GetHeightmapTexture() const { return m_heightmapTexture; }
+		SAILOR_API void SetHeightmapTexture(const FileId& value);
+		SAILOR_API const TVector<FileId>& GetMaterialMasks() const { return m_materialMasks; }
+		SAILOR_API void SetMaterialMasks(const TVector<FileId>& value);
+		SAILOR_API float GetTextureTiling() const { return m_textureTiling; }
+		SAILOR_API void SetTextureTiling(float value);
+		SAILOR_API const TVector<float>& GetSculptStamps() const { return m_sculptStamps; }
+		SAILOR_API void SetSculptStamps(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetPaintStamps() const { return m_paintStamps; }
+		SAILOR_API void SetPaintStamps(const TVector<float>& value);
+		SAILOR_API const TVector<FileId>& GetVegetationModels() const { return m_vegetationModels; }
+		SAILOR_API void SetVegetationModels(const TVector<FileId>& value);
+		SAILOR_API const TVector<FileId>& GetVegetationMaterials() const { return m_vegetationMaterials; }
+		SAILOR_API void SetVegetationMaterials(const TVector<FileId>& value);
+		SAILOR_API const TVector<float>& GetVegetationMeshIndex() const { return m_vegetationMeshIndex; }
+		SAILOR_API void SetVegetationMeshIndex(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationInstancesPerChunk() const { return m_vegetationInstancesPerChunk; }
+		SAILOR_API void SetVegetationInstancesPerChunk(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationMinScale() const { return m_vegetationMinScale; }
+		SAILOR_API void SetVegetationMinScale(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationMaxScale() const { return m_vegetationMaxScale; }
+		SAILOR_API void SetVegetationMaxScale(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationGroundOffset() const { return m_vegetationGroundOffset; }
+		SAILOR_API void SetVegetationGroundOffset(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationShadowMode() const { return m_vegetationShadowMode; }
+		SAILOR_API void SetVegetationShadowMode(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationShadowDistance() const { return m_vegetationShadowDistance; }
+		SAILOR_API void SetVegetationShadowDistance(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationMinLod() const { return m_vegetationMinLod; }
+		SAILOR_API void SetVegetationMinLod(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationMaxLod() const { return m_vegetationMaxLod; }
+		SAILOR_API void SetVegetationMaxLod(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationLod1ScreenCoverage() const { return m_vegetationLod1ScreenCoverage; }
+		SAILOR_API void SetVegetationLod1ScreenCoverage(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationLod2ScreenCoverage() const { return m_vegetationLod2ScreenCoverage; }
+		SAILOR_API void SetVegetationLod2ScreenCoverage(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationCullDistance() const { return m_vegetationCullDistance; }
+		SAILOR_API void SetVegetationCullDistance(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationColliderRadius() const { return m_vegetationColliderRadius; }
+		SAILOR_API void SetVegetationColliderRadius(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationColliderHeight() const { return m_vegetationColliderHeight; }
+		SAILOR_API void SetVegetationColliderHeight(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationColliderOffsetY() const { return m_vegetationColliderOffsetY; }
+		SAILOR_API void SetVegetationColliderOffsetY(const TVector<float>& value);
+		SAILOR_API bool GetRegenerate() const { return false; }
+		SAILOR_API void SetRegenerate(bool value);
+
+		SAILOR_API size_t GetComponentIndex() const { return m_handle; }
+
+	private:
+		void MarkDirty();
+		void SyncToECS(LandscapeData& data) const;
+		LandscapeData* TryGetData();
+
+		size_t m_handle = ECS::InvalidIndex;
+		uint32_t m_chunksX = 4u;
+		uint32_t m_chunksZ = 4u;
+		float m_chunkSize = 24.0f;
+		uint32_t m_chunkResolution = 24u;
+		float m_heightScale = 5.0f;
+		float m_noiseScale = 0.035f;
+		uint32_t m_seed = 1337u;
+		MaterialPtr m_material{};
+		TVector<FileId> m_layerTextures{};
+		FileId m_heightmapTexture{};
+		TVector<FileId> m_materialMasks{};
+		float m_textureTiling = 0.15f;
+		TVector<float> m_sculptStamps{};
+		TVector<float> m_paintStamps{};
+		TVector<FileId> m_vegetationModels{};
+		TVector<FileId> m_vegetationMaterials{};
+		TVector<float> m_vegetationMeshIndex{};
+		TVector<float> m_vegetationInstancesPerChunk{};
+		TVector<float> m_vegetationMinScale{};
+		TVector<float> m_vegetationMaxScale{};
+		TVector<float> m_vegetationGroundOffset{};
+		TVector<float> m_vegetationShadowMode{};
+		TVector<float> m_vegetationShadowDistance{};
+		TVector<float> m_vegetationMinLod{};
+		TVector<float> m_vegetationMaxLod{};
+		TVector<float> m_vegetationLod1ScreenCoverage{};
+		TVector<float> m_vegetationLod2ScreenCoverage{};
+		TVector<float> m_vegetationCullDistance{};
+		TVector<float> m_vegetationColliderRadius{};
+		TVector<float> m_vegetationColliderHeight{};
+		TVector<float> m_vegetationColliderOffsetY{};
+	};
+}
+
+using namespace Sailor::Attributes;
+
+REFL_AUTO(
+	type(Sailor::LandscapeComponent, bases<Sailor::Component>),
+	func(GetChunksX, property("chunksX"), Range(1.0, 64.0)),
+	func(SetChunksX, property("chunksX")),
+	func(GetChunksZ, property("chunksZ"), Range(1.0, 64.0)),
+	func(SetChunksZ, property("chunksZ")),
+	func(GetChunkSize, property("chunkSize"), Range(1.0, 512.0)),
+	func(SetChunkSize, property("chunkSize")),
+	func(GetChunkResolution, property("chunkResolution"), Range(2.0, 128.0)),
+	func(SetChunkResolution, property("chunkResolution")),
+	func(GetHeightScale, property("heightScale"), Range(0.0, 128.0)),
+	func(SetHeightScale, property("heightScale")),
+	func(GetNoiseScale, property("noiseScale"), Range(0.0001, 2.0)),
+	func(SetNoiseScale, property("noiseScale")),
+	func(GetSeed, property("seed")),
+	func(SetSeed, property("seed")),
+	func(GetMaterial, property("material"), SkipCDO()),
+	func(SetMaterial, property("material"), SkipCDO()),
+	func(GetLayerTextures, property("layerTextures")),
+	func(SetLayerTextures, property("layerTextures")),
+	func(GetHeightmapTexture, property("heightmapTexture")),
+	func(SetHeightmapTexture, property("heightmapTexture")),
+	func(GetMaterialMasks, property("materialMasks")),
+	func(SetMaterialMasks, property("materialMasks")),
+	func(GetTextureTiling, property("textureTiling"), Range(0.001, 8.0)),
+	func(SetTextureTiling, property("textureTiling")),
+	func(GetSculptStamps, property("sculptStamps")),
+	func(SetSculptStamps, property("sculptStamps")),
+	func(GetPaintStamps, property("paintStamps")),
+	func(SetPaintStamps, property("paintStamps")),
+	func(GetVegetationModels, property("vegetationModels")),
+	func(SetVegetationModels, property("vegetationModels")),
+	func(GetVegetationMaterials, property("vegetationMaterials")),
+	func(SetVegetationMaterials, property("vegetationMaterials")),
+	func(GetVegetationMeshIndex, property("vegetationMeshIndex")),
+	func(SetVegetationMeshIndex, property("vegetationMeshIndex")),
+	func(GetVegetationInstancesPerChunk, property("vegetationInstancesPerChunk")),
+	func(SetVegetationInstancesPerChunk, property("vegetationInstancesPerChunk")),
+	func(GetVegetationMinScale, property("vegetationMinScale")),
+	func(SetVegetationMinScale, property("vegetationMinScale")),
+	func(GetVegetationMaxScale, property("vegetationMaxScale")),
+	func(SetVegetationMaxScale, property("vegetationMaxScale")),
+	func(GetVegetationGroundOffset, property("vegetationGroundOffset")),
+	func(SetVegetationGroundOffset, property("vegetationGroundOffset")),
+	func(GetVegetationShadowMode, property("vegetationShadowMode")),
+	func(SetVegetationShadowMode, property("vegetationShadowMode")),
+	func(GetVegetationShadowDistance, property("vegetationShadowDistance")),
+	func(SetVegetationShadowDistance, property("vegetationShadowDistance")),
+	func(GetVegetationMinLod, property("vegetationMinLod")),
+	func(SetVegetationMinLod, property("vegetationMinLod")),
+	func(GetVegetationMaxLod, property("vegetationMaxLod")),
+	func(SetVegetationMaxLod, property("vegetationMaxLod")),
+	func(GetVegetationLod1ScreenCoverage, property("vegetationLod1ScreenCoverage")),
+	func(SetVegetationLod1ScreenCoverage, property("vegetationLod1ScreenCoverage")),
+	func(GetVegetationLod2ScreenCoverage, property("vegetationLod2ScreenCoverage")),
+	func(SetVegetationLod2ScreenCoverage, property("vegetationLod2ScreenCoverage")),
+	func(GetVegetationCullDistance, property("vegetationCullDistance")),
+	func(SetVegetationCullDistance, property("vegetationCullDistance")),
+	func(GetVegetationColliderRadius, property("vegetationColliderRadius")),
+	func(SetVegetationColliderRadius, property("vegetationColliderRadius")),
+	func(GetVegetationColliderHeight, property("vegetationColliderHeight")),
+	func(SetVegetationColliderHeight, property("vegetationColliderHeight")),
+	func(GetVegetationColliderOffsetY, property("vegetationColliderOffsetY")),
+	func(SetVegetationColliderOffsetY, property("vegetationColliderOffsetY")),
+	func(GetRegenerate, property("regenerate")),
+	func(SetRegenerate, property("regenerate"))
+)

--- a/Runtime/Containers/Vector.h
+++ b/Runtime/Containers/Vector.h
@@ -610,8 +610,6 @@ namespace Sailor
 				return;
 			}
 
-			const size_t slack = newCapacity - m_capacity;
-
 			m_capacity = newCapacity;
 
 			if (m_pRawPtr && m_allocator.Reallocate(m_pRawPtr, newCapacity * sizeof(TElementType)))
@@ -626,11 +624,11 @@ namespace Sailor
 			{
 				if constexpr (IsMoveConstructible<TElementType>)
 				{
-					ConstructMoveElements(0, pRawPtr[0], newCapacity - slack);
+					ConstructMoveElements(0, pRawPtr[0], m_arrayNum);
 				}
 				else if constexpr (IsCopyConstructible<TElementType>)
 				{
-					ConstructElements(0, pRawPtr[0], newCapacity - slack);
+					ConstructElements(0, pRawPtr[0], m_arrayNum);
 				}
 				else
 				{
@@ -639,7 +637,7 @@ namespace Sailor
 				}
 
 				// Destruct old elements
-				for (size_t i = 0; i < newCapacity - slack; i++)
+				for (size_t i = 0; i < m_arrayNum; i++)
 				{
 					pRawPtr[i].~TElementType();
 				}

--- a/Runtime/ECS/LandscapeECS.cpp
+++ b/Runtime/ECS/LandscapeECS.cpp
@@ -1,0 +1,963 @@
+#include "ECS/LandscapeECS.h"
+
+#include "AssetRegistry/Material/MaterialImporter.h"
+#include "AssetRegistry/Model/ModelImporter.h"
+#include "AssetRegistry/Texture/TextureImporter.h"
+#include "Components/LandscapeComponent.h"
+#include "ECS/TransformECS.h"
+#include "ECS/PhysicsECS.h"
+#include "Engine/GameObject.h"
+#include "Math/Transform.h"
+#include "RHI/GraphicsDriver.h"
+#include "RHI/Renderer.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <limits>
+
+using namespace Sailor;
+using namespace Sailor::Tasks;
+
+namespace
+{
+	struct LandscapeCpuTexture
+	{
+		TVector<uint8_t> m_pixels{};
+		int32_t m_width = 0;
+		int32_t m_height = 0;
+		bool m_bFloat = false;
+
+		bool IsValid() const
+		{
+			return m_width > 0 && m_height > 0 &&
+				m_pixels.Num() >= static_cast<size_t>(m_width) * m_height * (m_bFloat ? 16u : 4u);
+		}
+	};
+
+	struct LandscapeChunkCpuData
+	{
+		struct VegetationInstance
+		{
+			size_t m_profileIndex = 0u;
+			glm::vec3 m_position{};
+			float m_angle = 0.0f;
+			float m_scale = 1.0f;
+		};
+
+		uint32_t m_chunkX = 0u;
+		uint32_t m_chunkZ = 0u;
+		TVector<RHI::VertexP3N3T3B3UV2C4> m_vertices{};
+		TVector<uint32_t> m_indices{};
+		TVector<VegetationInstance> m_vegetation{};
+		Math::AABB m_localBounds{};
+	};
+
+	uint32_t Hash(uint32_t value)
+	{
+		value ^= value >> 16u;
+		value *= 0x7feb352du;
+		value ^= value >> 15u;
+		value *= 0x846ca68bu;
+		return value ^ (value >> 16u);
+	}
+
+	float Random01(uint32_t value)
+	{
+		return static_cast<float>(Hash(value) & 0x00ffffffu) / 16777215.0f;
+	}
+
+	float SmoothNoise(int32_t x, int32_t z, uint32_t seed)
+	{
+		const uint32_t key = static_cast<uint32_t>(x) * 0x9e3779b9u ^
+			static_cast<uint32_t>(z) * 0x85ebca6bu ^ seed;
+		return Random01(key) * 2.0f - 1.0f;
+	}
+
+	float Fade(float value)
+	{
+		return value * value * (3.0f - 2.0f * value);
+	}
+
+	float ValueNoise(float x, float z, uint32_t seed)
+	{
+		const int32_t x0 = static_cast<int32_t>(std::floor(x));
+		const int32_t z0 = static_cast<int32_t>(std::floor(z));
+		const float tx = Fade(x - static_cast<float>(x0));
+		const float tz = Fade(z - static_cast<float>(z0));
+		const float a = glm::mix(SmoothNoise(x0, z0, seed), SmoothNoise(x0 + 1, z0, seed), tx);
+		const float b = glm::mix(SmoothNoise(x0, z0 + 1, seed), SmoothNoise(x0 + 1, z0 + 1, seed), tx);
+		return glm::mix(a, b, tz);
+	}
+
+	bool DecodeCpuTexture(const FileId& fileId, LandscapeCpuTexture& result)
+	{
+		if (!fileId)
+		{
+			return false;
+		}
+		uint32_t mipLevels = 1u;
+		if (!TextureImporter::DecodeTextureCpu(fileId, result.m_pixels,
+			result.m_width, result.m_height, mipLevels))
+		{
+			return false;
+		}
+		const size_t pixelCount = static_cast<size_t>(result.m_width) * result.m_height;
+		result.m_bFloat = pixelCount > 0u && result.m_pixels.Num() == pixelCount * sizeof(float) * 4u;
+		return result.IsValid();
+	}
+
+	float ReadTextureChannel(const LandscapeCpuTexture& texture, int32_t x, int32_t y, uint32_t channel)
+	{
+		x = (std::clamp)(x, 0, texture.m_width - 1);
+		y = (std::clamp)(y, 0, texture.m_height - 1);
+		channel = (std::min)(channel, 3u);
+		const size_t pixel = static_cast<size_t>(y) * texture.m_width + x;
+		if (!texture.m_bFloat)
+		{
+			return static_cast<float>(texture.m_pixels[pixel * 4u + channel]) / 255.0f;
+		}
+
+		float value = 0.0f;
+		memcpy(&value, texture.m_pixels.GetData() +
+			(pixel * 4u + channel) * sizeof(float), sizeof(float));
+		return (std::clamp)(value, 0.0f, 1.0f);
+	}
+
+	float SampleTextureChannel(const LandscapeCpuTexture& texture, float u, float v, uint32_t channel)
+	{
+		if (!texture.IsValid())
+		{
+			return 0.0f;
+		}
+		const float x = (std::clamp)(u, 0.0f, 1.0f) * static_cast<float>(texture.m_width - 1);
+		const float y = (std::clamp)(v, 0.0f, 1.0f) * static_cast<float>(texture.m_height - 1);
+		const int32_t x0 = static_cast<int32_t>(std::floor(x));
+		const int32_t y0 = static_cast<int32_t>(std::floor(y));
+		const float tx = x - x0;
+		const float ty = y - y0;
+		const float a = glm::mix(ReadTextureChannel(texture, x0, y0, channel),
+			ReadTextureChannel(texture, x0 + 1, y0, channel), tx);
+		const float b = glm::mix(ReadTextureChannel(texture, x0, y0 + 1, channel),
+			ReadTextureChannel(texture, x0 + 1, y0 + 1, channel), tx);
+		return glm::mix(a, b, ty);
+	}
+
+	float BrushFalloff(float x, float z, const TVector<float>& stamps, size_t offset)
+	{
+		const float radius = (std::max)(stamps[offset + 2u], 0.001f);
+		const float distance = glm::distance(glm::vec2(x, z), glm::vec2(stamps[offset], stamps[offset + 1u]));
+		const float linear = (std::clamp)(1.0f - distance / radius, 0.0f, 1.0f);
+		return linear * linear * (3.0f - 2.0f * linear);
+	}
+
+	float SampleHeight(float x, float z, float landscapeWidth, float landscapeDepth,
+		float noiseScale, float heightScale, uint32_t seed,
+		const TVector<float>& sculptStamps, const LandscapeCpuTexture& heightmap)
+	{
+		float height = 0.0f;
+		if (heightmap.IsValid())
+		{
+			const float u = x / landscapeWidth + 0.5f;
+			const float v = z / landscapeDepth + 0.5f;
+			height = (SampleTextureChannel(heightmap, u, v, 0u) * 2.0f - 1.0f) * heightScale;
+		}
+		else
+		{
+			float amplitude = 1.0f;
+			float frequency = noiseScale;
+			float sum = 0.0f;
+			float normalization = 0.0f;
+			for (uint32_t octave = 0; octave < 4u; ++octave)
+			{
+				sum += ValueNoise(x * frequency, z * frequency, seed + octave * 1013u) * amplitude;
+				normalization += amplitude;
+				amplitude *= 0.5f;
+				frequency *= 2.0f;
+			}
+			height = heightScale > 0.0f ? sum / normalization * heightScale : 0.0f;
+		}
+		for (size_t stamp = 0u; stamp + 4u < sculptStamps.Num(); stamp += 5u)
+		{
+			const float falloff = BrushFalloff(x, z, sculptStamps, stamp);
+			const float strength = sculptStamps[stamp + 3u] * falloff;
+			const uint32_t operation = static_cast<uint32_t>(sculptStamps[stamp + 4u]);
+			if (operation == 0u) height += strength;
+			else if (operation == 1u) height -= strength;
+			else height = glm::mix(height, 0.0f, (std::clamp)(strength, 0.0f, 1.0f));
+		}
+		return height;
+	}
+
+	LandscapeChunkCpuData BuildChunk(const LandscapeData& data,
+		const LandscapeCpuTexture& heightmap,
+		const TVector<LandscapeCpuTexture>& materialMasks,
+		uint32_t chunkX, uint32_t chunkZ)
+	{
+		LandscapeChunkCpuData result;
+		result.m_chunkX = chunkX;
+		result.m_chunkZ = chunkZ;
+		const uint32_t resolution = data.m_chunkResolution;
+		const uint32_t row = resolution + 1u;
+		const float step = data.m_chunkSize / static_cast<float>(resolution);
+		const float landscapeWidth = data.m_chunksX * data.m_chunkSize;
+		const float landscapeDepth = data.m_chunksZ * data.m_chunkSize;
+		const float originX = chunkX * data.m_chunkSize - landscapeWidth * 0.5f;
+		const float originZ = chunkZ * data.m_chunkSize - landscapeDepth * 0.5f;
+
+		result.m_vertices.Resize(static_cast<size_t>(row) * row);
+		for (uint32_t z = 0u; z <= resolution; ++z)
+		{
+			for (uint32_t x = 0u; x <= resolution; ++x)
+			{
+				const float localX = originX + x * step;
+				const float localZ = originZ + z * step;
+				const auto sampleHeight = [&](float sampleX, float sampleZ)
+				{
+					return SampleHeight(sampleX, sampleZ, landscapeWidth, landscapeDepth,
+						data.m_noiseScale, data.m_heightScale, data.m_seed,
+						data.m_sculptStamps, heightmap);
+				};
+				const float height = sampleHeight(localX, localZ);
+				const float left = sampleHeight(localX - step, localZ);
+				const float right = sampleHeight(localX + step, localZ);
+				const float down = sampleHeight(localX, localZ - step);
+				const float up = sampleHeight(localX, localZ + step);
+				const glm::vec3 normal = glm::normalize(glm::vec3(left - right, 2.0f * step, down - up));
+				const glm::vec3 tangent = glm::normalize(glm::vec3(2.0f * step, right - left, 0.0f));
+				const glm::vec3 bitangent = glm::normalize(glm::cross(normal, tangent));
+				const float slope = 1.0f - (std::clamp)(normal.y, 0.0f, 1.0f);
+				const float normalizedHeight = data.m_heightScale > 0.0f ?
+					(std::clamp)(height / (data.m_heightScale * 2.0f) + 0.5f, 0.0f, 1.0f) : 0.5f;
+				glm::vec4 weights;
+				weights.x = (1.0f - slope) * (1.0f - normalizedHeight);
+				weights.y = slope;
+				weights.z = (1.0f - slope) * normalizedHeight;
+				weights.w = (std::max)(0.0f, normalizedHeight - 0.72f) * 3.57f;
+				weights /= (std::max)(glm::dot(weights, glm::vec4(1.0f)), 0.0001f);
+				if (!materialMasks.IsEmpty())
+				{
+					const float u = localX / landscapeWidth + 0.5f;
+					const float v = localZ / landscapeDepth + 0.5f;
+					glm::vec4 importedWeights(0.0f);
+					if (materialMasks.Num() == 1u)
+					{
+						for (uint32_t channel = 0u; channel < 4u; ++channel)
+						{
+							importedWeights[channel] = SampleTextureChannel(materialMasks[0], u, v, channel);
+						}
+					}
+					else
+					{
+						for (size_t mask = 0u; mask < materialMasks.Num() && mask < 4u; ++mask)
+						{
+							importedWeights[static_cast<glm::length_t>(mask)] =
+								SampleTextureChannel(materialMasks[mask], u, v, 0u);
+						}
+					}
+					const float importedWeightSum = glm::dot(importedWeights, glm::vec4(1.0f));
+					if (importedWeightSum > 0.0001f)
+					{
+						weights = importedWeights / importedWeightSum;
+					}
+				}
+				for (size_t stamp = 0u; stamp + 4u < data.m_paintStamps.Num(); stamp += 5u)
+				{
+					const float alpha = (std::clamp)(data.m_paintStamps[stamp + 3u] *
+						BrushFalloff(localX, localZ, data.m_paintStamps, stamp), 0.0f, 1.0f);
+					glm::vec4 target(0.0f);
+					target[(std::min)(static_cast<uint32_t>(data.m_paintStamps[stamp + 4u]), 3u)] = 1.0f;
+					weights = glm::mix(weights, target, alpha);
+				}
+
+				auto& vertex = result.m_vertices[static_cast<size_t>(z) * row + x];
+				vertex.m_position = glm::vec3(localX, height, localZ);
+				vertex.m_normal = normal;
+				vertex.m_tangent = tangent;
+				vertex.m_bitangent = bitangent;
+				vertex.m_texcoord = glm::vec2(localX, localZ) * data.m_textureTiling;
+				vertex.m_color = weights;
+				result.m_localBounds.Extend(Math::AABB(vertex.m_position, glm::vec3(0.01f)));
+			}
+		}
+
+		result.m_indices.Reserve(static_cast<size_t>(resolution) * resolution * 6u);
+		for (uint32_t z = 0u; z < resolution; ++z)
+		{
+			for (uint32_t x = 0u; x < resolution; ++x)
+			{
+				const uint32_t i0 = z * row + x;
+				const uint32_t i1 = i0 + 1u;
+				const uint32_t i2 = i0 + row;
+				const uint32_t i3 = i2 + 1u;
+				result.m_indices.AddRange({ i0, i2, i1, i1, i2, i3 });
+			}
+		}
+
+		for (size_t profileIndex = 0u; profileIndex < data.m_vegetationProfiles.Num(); ++profileIndex)
+		{
+			const auto& profile = data.m_vegetationProfiles[profileIndex];
+			if (!profile.m_modelFileId)
+			{
+				continue;
+			}
+			result.m_vegetation.Reserve(result.m_vegetation.Num() + profile.m_instancesPerChunk);
+			for (uint32_t instance = 0u; instance < profile.m_instancesPerChunk; ++instance)
+			{
+				const uint32_t randomSeed = data.m_seed ^
+					static_cast<uint32_t>(chunkX * 92821u + chunkZ * 68917u +
+						profileIndex * 4099u + instance * 131u);
+				LandscapeChunkCpuData::VegetationInstance placement;
+				placement.m_profileIndex = profileIndex;
+				placement.m_position.x = originX + Random01(randomSeed) * data.m_chunkSize;
+				placement.m_position.z = originZ + Random01(randomSeed + 1u) * data.m_chunkSize;
+				placement.m_position.y = SampleHeight(placement.m_position.x, placement.m_position.z,
+					landscapeWidth, landscapeDepth, data.m_noiseScale, data.m_heightScale,
+					data.m_seed, data.m_sculptStamps, heightmap) +
+					profile.m_groundOffset;
+				placement.m_angle = Random01(randomSeed + 2u) * glm::two_pi<float>();
+				placement.m_scale = glm::mix(profile.m_minScale, profile.m_maxScale,
+					Random01(randomSeed + 3u));
+				result.m_vegetation.Add(std::move(placement));
+			}
+		}
+		return result;
+	}
+
+	float GetProfileValue(const TVector<float>& values, size_t index, float fallback)
+	{
+		return index < values.Num() && std::isfinite(values[index]) ? values[index] : fallback;
+	}
+
+	void AppendShadowMesh(RHI::RHIShadowCasterProxy& shadowCaster,
+		const RHI::RHIMeshPtr& mesh, const glm::mat4& worldMatrix,
+		const MaterialPtr& material, float maxCameraDistance)
+	{
+		if (!mesh || !material)
+		{
+			return;
+		}
+
+		const size_t opaqueQueueTag = GetHash(std::string("Opaque"));
+		const size_t maskedQueueTag = GetHash(std::string("Masked"));
+		const size_t renderQueueTag = material->GetRenderState().GetTag();
+		if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
+		{
+			return;
+		}
+
+		RHI::RHIShadowMeshProxy shadowMesh;
+		shadowMesh.m_mesh = mesh;
+		shadowMesh.m_worldMatrix = worldMatrix;
+		shadowMesh.m_renderQueueTag = renderQueueTag;
+		shadowMesh.m_maxCameraDistance = maxCameraDistance;
+		if (material->GetRenderState().IsRequiredCustomDepthShader())
+		{
+			shadowMesh.m_customDepthMaterial = material;
+		}
+
+		auto* textureImporter = App::GetSubmodule<TextureImporter>();
+		if (renderQueueTag == maskedQueueTag)
+		{
+			const glm::vec4* baseColorFactor = nullptr;
+			if (!material->GetUniformsVec4().Find("material.baseColorFactor", baseColorFactor))
+			{
+				material->GetUniformsVec4().Find("material.albedo", baseColorFactor);
+			}
+			if (baseColorFactor)
+			{
+				shadowMesh.m_baseColorFactor = *baseColorFactor;
+			}
+
+			const float* alphaCutoff = nullptr;
+			if (material->GetUniformsFloat().Find("material.alphaCutoff", alphaCutoff) && alphaCutoff)
+			{
+				shadowMesh.m_alphaCutoff = *alphaCutoff;
+			}
+
+			const TexturePtr* baseColorTexture = nullptr;
+			if (!material->GetSamplers().Find("baseColorSampler", baseColorTexture))
+			{
+				material->GetSamplers().Find("albedoSampler", baseColorTexture);
+			}
+			if (textureImporter && baseColorTexture && *baseColorTexture)
+			{
+				shadowMesh.m_baseColorSampler = static_cast<uint32_t>(
+					textureImporter->GetTextureIndex((*baseColorTexture)->GetFileId()));
+			}
+		}
+#if defined(__APPLE__)
+		shadowMesh.m_materialTextureSamplers.Insert(0u);
+		if (textureImporter)
+		{
+			for (const auto& sampler : material->GetSamplers())
+			{
+				shadowMesh.m_materialTextureSamplers.Insert(sampler.m_second ?
+					static_cast<uint32_t>(textureImporter->GetTextureIndex(sampler.m_second->GetFileId())) : 0u);
+			}
+		}
+#endif
+		shadowCaster.m_meshes.Add(std::move(shadowMesh));
+	}
+
+	void GetOctreeBounds(const Math::AABB& bounds, glm::ivec3& center, glm::ivec3& extents)
+	{
+		const glm::ivec3 minimum = glm::ivec3(glm::floor(bounds.m_min));
+		const glm::ivec3 maximum = glm::ivec3(glm::ceil(bounds.m_max));
+		center = minimum + (maximum - minimum) / 2;
+		extents = glm::max(glm::max(maximum - center, center - minimum), glm::ivec3(1));
+	}
+
+	size_t LandscapeProxyId(size_t componentIndex, size_t chunkIndex)
+	{
+		return (size_t(1) << (sizeof(size_t) * 8u - 1u)) |
+			((componentIndex & 0x7fffffffu) << 24u) | (chunkIndex & 0xffffffu);
+	}
+
+	size_t LandscapeVegetationProxyId(
+		size_t componentIndex,
+		size_t chunkIndex,
+		size_t instanceIndex)
+	{
+		return (size_t(3) << (sizeof(size_t) * 8u - 2u)) |
+			((componentIndex & 0xfffffu) << 36u) |
+			((chunkIndex & 0xfffffu) << 16u) | (instanceIndex & 0xffffu);
+	}
+}
+
+void LandscapeData::SetSettings(uint32_t chunksX, uint32_t chunksZ,
+	float chunkSize, uint32_t chunkResolution, float heightScale,
+	float noiseScale, uint32_t seed, float textureTiling)
+{
+	m_chunksX = (std::clamp)(chunksX, 1u, 64u);
+	m_chunksZ = (std::clamp)(chunksZ, 1u, 64u);
+	m_chunkSize = (std::max)(chunkSize, 1.0f);
+	m_chunkResolution = (std::clamp)(chunkResolution, 2u, 128u);
+	m_heightScale = (std::max)(heightScale, 0.0f);
+	m_noiseScale = (std::max)(noiseScale, 0.0001f);
+	m_seed = seed;
+	m_textureTiling = (std::max)(textureTiling, 0.001f);
+	MarkDirty();
+}
+
+void LandscapeData::SetMaterial(const MaterialPtr& material)
+{
+	m_material = material;
+	m_runtimeMaterial.Clear();
+	MarkDirty();
+}
+
+void LandscapeData::SetLayerTextures(const TVector<FileId>& textures)
+{
+	m_layerTextures = textures;
+	if (m_layerTextures.Num() > 4u) m_layerTextures.Resize(4u);
+	m_runtimeMaterial.Clear();
+	MarkDirty();
+}
+
+void LandscapeData::SetImportMaps(const FileId& heightmapTexture,
+	const TVector<FileId>& materialMasks)
+{
+	m_heightmapTexture = heightmapTexture;
+	m_materialMasks = materialMasks;
+	if (m_materialMasks.Num() > 4u) m_materialMasks.Resize(4u);
+	MarkDirty();
+}
+
+void LandscapeData::SetAuthoredStamps(const TVector<float>& sculptStamps,
+	const TVector<float>& paintStamps)
+{
+	m_sculptStamps = sculptStamps;
+	m_paintStamps = paintStamps;
+	MarkDirty();
+}
+
+void LandscapeData::SetVegetationProfiles(
+	const TVector<FileId>& models,
+	const TVector<FileId>& materials,
+	const TVector<float>& meshIndex,
+	const TVector<float>& instancesPerChunk,
+	const TVector<float>& minScale,
+	const TVector<float>& maxScale,
+	const TVector<float>& groundOffset,
+	const TVector<float>& shadowMode,
+	const TVector<float>& shadowDistance,
+	const TVector<float>& minLod,
+	const TVector<float>& maxLod,
+	const TVector<float>& lod1ScreenCoverage,
+	const TVector<float>& lod2ScreenCoverage,
+	const TVector<float>& cullDistance,
+	const TVector<float>& colliderRadius,
+	const TVector<float>& colliderHeight,
+	const TVector<float>& colliderOffsetY)
+{
+	m_vegetationProfiles.Clear();
+	const size_t numProfiles = models.Num();
+	m_vegetationProfiles.Reserve(numProfiles);
+	for (size_t index = 0u; index < numProfiles; ++index)
+	{
+		LandscapeVegetationProfile profile;
+		profile.m_modelFileId = models[index];
+		profile.m_materialFileId = index < materials.Num() ? materials[index] : FileId{};
+		profile.m_meshIndex = static_cast<int32_t>((std::clamp)(
+			GetProfileValue(meshIndex, index, -1.0f), -1.0f, 65535.0f));
+		profile.m_instancesPerChunk = static_cast<uint32_t>((std::clamp)(
+			GetProfileValue(instancesPerChunk, index, 0.0f), 0.0f, 2048.0f));
+		profile.m_minScale = (std::max)(GetProfileValue(minScale, index, 0.75f), 0.01f);
+		profile.m_maxScale = (std::max)(GetProfileValue(maxScale, index, 1.25f), profile.m_minScale);
+		profile.m_groundOffset = GetProfileValue(groundOffset, index, 0.0f);
+		profile.m_shadowMode = static_cast<ELandscapeVegetationShadowMode>(
+			static_cast<uint32_t>((std::clamp)(GetProfileValue(shadowMode, index, 1.0f), 0.0f, 2.0f)));
+		profile.m_shadowDistance = (std::max)(GetProfileValue(shadowDistance, index, 35.0f), 0.1f);
+		profile.m_minLod = static_cast<uint32_t>((std::clamp)(
+			GetProfileValue(minLod, index, 0.0f), 0.0f, 15.0f));
+		profile.m_maxLod = static_cast<uint32_t>((std::clamp)(
+			GetProfileValue(maxLod, index, 2.0f),
+			static_cast<float>(profile.m_minLod), 15.0f));
+		profile.m_screenCoverageThresholds = {
+			(std::clamp)(GetProfileValue(lod1ScreenCoverage, index, 0.25f), 0.0f, 1.0f),
+			(std::clamp)(GetProfileValue(lod2ScreenCoverage, index, 0.05f), 0.0f, 1.0f)
+		};
+		std::sort(profile.m_screenCoverageThresholds.begin(),
+			profile.m_screenCoverageThresholds.end(), std::greater<float>());
+		profile.m_cullDistance = (std::max)(GetProfileValue(cullDistance, index, 120.0f), 0.1f);
+		profile.m_colliderRadius = (std::max)(GetProfileValue(colliderRadius, index, 0.0f), 0.0f);
+		profile.m_colliderHeight = (std::max)(GetProfileValue(colliderHeight, index, 2.0f),
+			profile.m_colliderRadius * 2.0f);
+		profile.m_colliderOffsetY = GetProfileValue(colliderOffsetY, index, 1.0f);
+		m_vegetationProfiles.Add(std::move(profile));
+	}
+	MarkDirty();
+}
+
+void LandscapeECS::OnComponentUnregistered(size_t, LandscapeData& component)
+{
+	DestroyPhysicsBodies(component);
+	component.m_chunks.Clear();
+	component.m_runtimeMaterial.Clear();
+	++m_shadowCastersRevision;
+}
+
+void LandscapeECS::DestroyPhysicsBodies(LandscapeData& component)
+{
+	auto* physics = GetWorld() ? GetWorld()->GetECS<PhysicsECS>() : nullptr;
+	if (physics)
+	{
+		for (uint32_t bodyId : component.m_physicsBodies)
+		{
+			physics->DestroyExternalBody(bodyId);
+		}
+	}
+	component.m_physicsBodies.Clear();
+}
+
+Tasks::ITaskPtr LandscapeECS::Tick(float)
+{
+	SAILOR_PROFILE_FUNCTION();
+	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
+	{
+		if (!IsComponentRegistered(componentIndex))
+		{
+			continue;
+		}
+
+		auto& data = m_components[componentIndex];
+		GameObjectPtr owner = const_cast<ObjectPtr&>(data.GetOwner()).StaticCast<GameObject>();
+		const bool transformChanged = owner && owner->GetTransformComponent().GetFrameLastChange() > data.GetFrameLastChange();
+		if (!data.IsDirty() && !transformChanged)
+		{
+			continue;
+		}
+		if (!owner || !data.m_material || !data.m_material->IsReady())
+		{
+			data.MarkDirty();
+			continue;
+		}
+
+		if (!data.m_runtimeMaterial)
+		{
+			data.m_runtimeMaterial = Material::CreateInstance(GetWorld(), data.m_material);
+			static const char* LayerNames[] = { "layer0Sampler", "layer1Sampler", "layer2Sampler", "layer3Sampler" };
+			auto* textureImporter = App::GetSubmodule<TextureImporter>();
+			for (size_t layer = 0; textureImporter && layer < data.m_layerTextures.Num() && layer < 4u; ++layer)
+			{
+				TexturePtr texture;
+				if (data.m_layerTextures[layer] && textureImporter->LoadTexture_Immediate(data.m_layerTextures[layer], texture) && texture)
+				{
+					data.m_runtimeMaterial->SetSampler(LayerNames[layer], texture);
+				}
+			}
+			data.m_runtimeMaterial->UpdateRHIResourceAndUniforms();
+		}
+
+		auto* modelImporter = App::GetSubmodule<ModelImporter>();
+		auto* materialImporter = App::GetSubmodule<MaterialImporter>();
+		bool bVegetationResourcesReady = true;
+		for (auto& profile : data.m_vegetationProfiles)
+		{
+			if (!profile.m_model && modelImporter && profile.m_modelFileId)
+			{
+				modelImporter->LoadModel_Immediate(profile.m_modelFileId, profile.m_model);
+			}
+			if (profile.m_model && !profile.m_model->IsReady())
+			{
+				bVegetationResourcesReady = false;
+				continue;
+			}
+			if (profile.m_materialFileId && !profile.m_material && materialImporter)
+			{
+				materialImporter->LoadMaterial_Immediate(profile.m_materialFileId, profile.m_material);
+			}
+			else if (!profile.m_materialFileId && profile.m_model &&
+				!profile.m_modelMaterialsTask && modelImporter)
+			{
+				profile.m_modelMaterialsTask = modelImporter->LoadDefaultMaterials(
+					profile.m_modelFileId, profile.m_modelMaterials);
+			}
+			if ((profile.m_material && !profile.m_material->IsReady()) ||
+				(profile.m_modelMaterialsTask && !profile.m_modelMaterialsTask->IsFinished()))
+			{
+				bVegetationResourcesReady = false;
+			}
+		}
+		if (!bVegetationResourcesReady)
+		{
+			continue;
+		}
+
+		LandscapeCpuTexture heightmap;
+		if (data.m_heightmapTexture && !DecodeCpuTexture(data.m_heightmapTexture, heightmap))
+		{
+			SAILOR_LOG_ERROR("LandscapeECS: failed to decode heightmap %s; procedural height will be used.",
+				data.m_heightmapTexture.ToString().c_str());
+		}
+		TVector<LandscapeCpuTexture> materialMasks;
+		materialMasks.Reserve(data.m_materialMasks.Num());
+		for (const FileId& maskFileId : data.m_materialMasks)
+		{
+			LandscapeCpuTexture mask;
+			if (!DecodeCpuTexture(maskFileId, mask) && maskFileId)
+			{
+				SAILOR_LOG_ERROR("LandscapeECS: failed to decode material mask %s.",
+					maskFileId.ToString().c_str());
+			}
+			materialMasks.Add(std::move(mask));
+		}
+
+		TVector<Tasks::TaskPtr<LandscapeChunkCpuData>> tasks;
+		tasks.Reserve(static_cast<size_t>(data.m_chunksX) * data.m_chunksZ);
+		for (uint32_t z = 0; z < data.m_chunksZ; ++z)
+		{
+			for (uint32_t x = 0; x < data.m_chunksX; ++x)
+			{
+				auto task = Tasks::CreateTask<LandscapeChunkCpuData>(
+					"LandscapeECS:Build Chunk", [&data, &heightmap, &materialMasks, x, z]()
+					{
+						return BuildChunk(data, heightmap, materialMasks, x, z);
+					}, EThreadType::Worker);
+				task->Run();
+				tasks.Add(task);
+			}
+		}
+
+		data.m_chunks.Clear();
+		DestroyPhysicsBodies(data);
+		data.m_chunks.Reserve(tasks.Num());
+		size_t vegetationRenderProxies = 0u;
+		size_t vegetationProfilesNotReady = 0u;
+		size_t vegetationProfilesWithoutRenderData = 0u;
+		const glm::mat4 ownerMatrix = owner->GetTransformComponent().GetCachedWorldMatrix();
+		const Math::Transform ownerTransform = Math::Transform::FromMatrix(ownerMatrix);
+		auto* physics = GetWorld()->GetECS<PhysicsECS>();
+		for (size_t chunkIndex = 0; chunkIndex < tasks.Num(); ++chunkIndex)
+		{
+			tasks[chunkIndex]->Wait();
+			auto& cpu = tasks[chunkIndex]->m_result;
+			TVector<glm::vec3> collisionVertices;
+			collisionVertices.Resize(cpu.m_vertices.Num());
+			for (size_t vertexIndex = 0u; vertexIndex < cpu.m_vertices.Num(); ++vertexIndex)
+			{
+				collisionVertices[vertexIndex] = cpu.m_vertices[vertexIndex].m_position;
+			}
+			uint32_t physicsBodyId = RigidBodyData::InvalidBodyId;
+			if (physics && physics->CreateStaticTriangleMesh(owner->GetInstanceId(),
+				collisionVertices, cpu.m_indices, glm::vec3(ownerTransform.m_position),
+				ownerTransform.m_rotation, glm::vec3(ownerTransform.m_scale), physicsBodyId))
+			{
+				data.m_physicsBodies.Add(physicsBodyId);
+			}
+			TVector<Physics::CollisionShapeDesc> vegetationCollisionShapes;
+			for (const auto& placement : cpu.m_vegetation)
+			{
+				const auto& profile = data.m_vegetationProfiles[placement.m_profileIndex];
+				if (profile.m_colliderRadius <= 0.0f)
+				{
+					continue;
+				}
+				Physics::CollisionShapeDesc shape;
+				shape.m_type = Physics::ECollisionShapeType::Capsule;
+				shape.m_center = placement.m_position + glm::vec3(
+					0.0f, profile.m_colliderOffsetY * placement.m_scale, 0.0f);
+				shape.m_rotation = glm::angleAxis(placement.m_angle, glm::vec3(0.0f, 1.0f, 0.0f));
+				shape.m_radius = profile.m_colliderRadius * placement.m_scale;
+				shape.m_height = profile.m_colliderHeight * placement.m_scale;
+				vegetationCollisionShapes.Add(std::move(shape));
+			}
+			if (physics && !vegetationCollisionShapes.IsEmpty() &&
+				physics->CreateStaticCompound(owner->GetInstanceId(), vegetationCollisionShapes,
+					glm::vec3(ownerTransform.m_position), ownerTransform.m_rotation,
+					glm::vec3(ownerTransform.m_scale), physicsBodyId))
+			{
+				data.m_physicsBodies.Add(physicsBodyId);
+			}
+			auto mesh = RHI::Renderer::GetDriver()->CreateMesh();
+			mesh->m_vertexDescription = RHI::Renderer::GetDriver()->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4>();
+			mesh->m_bounds = cpu.m_localBounds;
+			mesh->m_materialIndex = 0u;
+			RHI::Renderer::GetDriver()->UpdateMesh(mesh,
+				cpu.m_vertices.GetData(), cpu.m_vertices.Num() * sizeof(RHI::VertexP3N3T3B3UV2C4),
+				cpu.m_indices.GetData(), cpu.m_indices.Num() * sizeof(uint32_t));
+
+			LandscapeChunk chunk;
+			auto& proxy = chunk.m_proxy;
+			proxy.m_staticMeshEcs = LandscapeProxyId(componentIndex, chunkIndex);
+			proxy.m_worldMatrix = ownerMatrix;
+			proxy.m_worldAabb = cpu.m_localBounds;
+			proxy.m_worldAabb.Apply(ownerMatrix);
+			proxy.m_frame = GetWorld()->GetCurrentFrame();
+			proxy.m_bCastShadows = true;
+			proxy.m_meshes.Add(mesh);
+			proxy.m_meshModelMatrices.Add(ownerMatrix);
+			proxy.m_overrideMaterials.Add(data.m_runtimeMaterial->GetOrAddRHI(mesh->m_vertexDescription));
+			proxy.m_renderQueueTags.Add(data.m_runtimeMaterial->GetRenderState().GetTag());
+			auto shadowCaster = RHI::RHIShadowCasterProxyPtr::Make();
+			shadowCaster->m_staticMeshEcs = proxy.m_staticMeshEcs;
+			shadowCaster->m_skeletonOffset = (std::numeric_limits<uint32_t>::max)();
+			shadowCaster->m_frame = proxy.m_frame;
+			AppendShadowMesh(*shadowCaster, mesh, ownerMatrix, data.m_runtimeMaterial,
+				(std::numeric_limits<float>::max)());
+
+			shadowCaster->m_worldAabb = proxy.m_worldAabb;
+			proxy.m_shadowCaster = shadowCaster->m_meshes.IsEmpty() ?
+				RHI::RHIShadowCasterProxyPtr{} : shadowCaster;
+#if defined(__APPLE__)
+			proxy.m_materialTextureSamplers.Resize(1u);
+			auto* textureImporter = App::GetSubmodule<TextureImporter>();
+			proxy.m_materialTextureSamplers[0].Insert(0u);
+			if (textureImporter)
+			{
+				for (const auto& sampler : data.m_runtimeMaterial->GetSamplers())
+				{
+					proxy.m_materialTextureSamplers[0].Insert(sampler.m_second ?
+						static_cast<uint32_t>(textureImporter->GetTextureIndex(sampler.m_second->GetFileId())) : 0u);
+				}
+			}
+#endif
+			GetOctreeBounds(proxy.m_worldAabb, chunk.m_octreeCenter, chunk.m_octreeExtents);
+
+			for (size_t profileIndex = 0u; profileIndex < data.m_vegetationProfiles.Num(); ++profileIndex)
+			{
+				auto& profile = data.m_vegetationProfiles[profileIndex];
+				const bool bUseMaterialOverride = static_cast<bool>(profile.m_materialFileId);
+				if (!profile.m_model || !profile.m_model->IsReady() ||
+					(bUseMaterialOverride && (!profile.m_material || !profile.m_material->IsReady())))
+				{
+					++vegetationProfilesNotReady;
+					continue;
+				}
+
+				TVector<RHI::RHIMeshPtr> vegetationMeshes;
+				TVector<glm::mat4> vegetationModelMatrices;
+				Math::AABB vegetationBounds;
+				if (!profile.m_model->CollectRenderData(profile.m_meshIndex,
+					vegetationMeshes, vegetationModelMatrices, vegetationBounds))
+				{
+					++vegetationProfilesWithoutRenderData;
+					continue;
+				}
+				TVector<MaterialPtr> vegetationMaterials;
+				vegetationMaterials.Reserve(vegetationMeshes.Num());
+				bool bVegetationMaterialsReady = true;
+				for (size_t meshIndex = 0u; meshIndex < vegetationMeshes.Num(); ++meshIndex)
+				{
+					MaterialPtr material = profile.m_material;
+					if (!bUseMaterialOverride)
+					{
+						const size_t materialIndex = vegetationMeshes[meshIndex]->ResolveMaterialIndex(
+							meshIndex, profile.m_modelMaterials.Num());
+						material = materialIndex < profile.m_modelMaterials.Num() ?
+							profile.m_modelMaterials[materialIndex] : MaterialPtr{};
+					}
+					if (!material || !material->IsReady())
+					{
+						bVegetationMaterialsReady = false;
+						break;
+					}
+					vegetationMaterials.Add(std::move(material));
+				}
+				if (!bVegetationMaterialsReady)
+				{
+					++vegetationProfilesNotReady;
+					continue;
+				}
+				LandscapeVegetationRenderProxy vegetationRenderProxy;
+				auto& vegetationProxy = vegetationRenderProxy.m_proxy;
+				vegetationProxy.m_staticMeshEcs = LandscapeVegetationProxyId(
+					componentIndex, chunkIndex, profileIndex);
+				vegetationProxy.m_worldMatrix = ownerMatrix;
+				vegetationProxy.m_frame = proxy.m_frame;
+				vegetationProxy.m_bCastShadows =
+					profile.m_shadowMode != ELandscapeVegetationShadowMode::None;
+				vegetationProxy.m_lodPolicy.m_bEnabled = true;
+				vegetationProxy.m_lodPolicy.m_minLod = profile.m_minLod;
+				vegetationProxy.m_lodPolicy.m_maxLod = profile.m_maxLod;
+				vegetationProxy.m_lodPolicy.m_screenCoverageThresholds =
+					profile.m_screenCoverageThresholds;
+				vegetationProxy.m_lodPolicy.m_maxCameraDistance = profile.m_cullDistance;
+				auto vegetationShadowCaster = RHI::RHIShadowCasterProxyPtr::Make();
+				vegetationShadowCaster->m_staticMeshEcs = vegetationProxy.m_staticMeshEcs;
+				vegetationShadowCaster->m_skeletonOffset =
+					(std::numeric_limits<uint32_t>::max)();
+				vegetationShadowCaster->m_frame = vegetationProxy.m_frame;
+				vegetationShadowCaster->m_lodPolicy.m_bEnabled = true;
+				vegetationShadowCaster->m_lodPolicy.m_minLod = profile.m_minLod;
+				vegetationShadowCaster->m_lodPolicy.m_maxLod = profile.m_maxLod;
+				vegetationShadowCaster->m_lodPolicy.m_screenCoverageThresholds =
+					profile.m_screenCoverageThresholds;
+				Math::AABB batchedVegetationBounds;
+				const float shadowDistance = (std::min)(profile.m_cullDistance,
+					profile.m_shadowMode == ELandscapeVegetationShadowMode::NearOnly ?
+					profile.m_shadowDistance : (std::numeric_limits<float>::max)());
+				for (const auto& placement : cpu.m_vegetation)
+				{
+					if (placement.m_profileIndex != profileIndex)
+					{
+						continue;
+					}
+
+					const glm::mat4 instanceMatrix = ownerMatrix *
+						glm::translate(glm::mat4(1.0f), placement.m_position) *
+						glm::rotate(glm::mat4(1.0f), placement.m_angle, glm::vec3(0.0f, 1.0f, 0.0f)) *
+						glm::scale(glm::mat4(1.0f), glm::vec3(placement.m_scale));
+					Math::AABB instanceBounds = vegetationBounds;
+					instanceBounds.Apply(instanceMatrix);
+					batchedVegetationBounds.Extend(instanceBounds);
+					for (size_t meshIndex = 0; meshIndex < vegetationMeshes.Num(); ++meshIndex)
+					{
+						MaterialPtr& material = vegetationMaterials[meshIndex];
+						const glm::mat4 meshMatrix = instanceMatrix * vegetationModelMatrices[meshIndex];
+						vegetationProxy.m_meshes.Add(vegetationMeshes[meshIndex]);
+						vegetationProxy.m_meshModelMatrices.Add(meshMatrix);
+						vegetationProxy.m_overrideMaterials.Add(material->GetOrAddRHI(
+							vegetationMeshes[meshIndex]->m_vertexDescription));
+						vegetationProxy.m_renderQueueTags.Add(material->GetRenderState().GetTag());
+						if (profile.m_shadowMode != ELandscapeVegetationShadowMode::None)
+						{
+							AppendShadowMesh(*vegetationShadowCaster, vegetationMeshes[meshIndex], meshMatrix,
+								material, shadowDistance);
+						}
+					}
+				}
+				if (vegetationProxy.m_meshes.IsEmpty() || !batchedVegetationBounds.IsValid())
+				{
+					continue;
+				}
+				vegetationProxy.m_worldAabb = batchedVegetationBounds;
+				vegetationShadowCaster->m_worldAabb = vegetationProxy.m_worldAabb;
+				vegetationProxy.m_shadowCaster = vegetationShadowCaster->m_meshes.IsEmpty() ?
+					RHI::RHIShadowCasterProxyPtr{} : vegetationShadowCaster;
+#if defined(__APPLE__)
+				vegetationProxy.m_materialTextureSamplers.Resize(vegetationProxy.m_meshes.Num());
+				for (size_t proxyMeshIndex = 0u;
+					proxyMeshIndex < vegetationProxy.m_materialTextureSamplers.Num(); ++proxyMeshIndex)
+				{
+					auto& requested = vegetationProxy.m_materialTextureSamplers[proxyMeshIndex];
+					requested.Insert(0u);
+					if (textureImporter)
+					{
+						const MaterialPtr& material = vegetationMaterials[
+							proxyMeshIndex % vegetationMaterials.Num()];
+						for (const auto& sampler : material->GetSamplers())
+						{
+							requested.Insert(sampler.m_second ? static_cast<uint32_t>(
+								textureImporter->GetTextureIndex(sampler.m_second->GetFileId())) : 0u);
+						}
+					}
+				}
+#endif
+				GetOctreeBounds(vegetationProxy.m_worldAabb,
+					vegetationRenderProxy.m_octreeCenter, vegetationRenderProxy.m_octreeExtents);
+				chunk.m_vegetationProxies.Add(std::move(vegetationRenderProxy));
+				++vegetationRenderProxies;
+			}
+			data.m_chunks.Add(std::move(chunk));
+		}
+		data.m_bIsDirty = false;
+		data.SetLastChange(owner->GetTransformComponent().GetFrameLastChange());
+		++m_shadowCastersRevision;
+		size_t vegetationPerChunk = 0u;
+		for (const auto& profile : data.m_vegetationProfiles)
+		{
+			vegetationPerChunk += profile.m_instancesPerChunk;
+		}
+		SAILOR_LOG("LandscapeECS: built %zu chunks with %zu collision bodies (%ux%u, %.1fm, resolution %u), %zu vegetation profiles, %zu instances per chunk and %zu render proxies (%zu profile loads not ready, %zu without render data), %zu sculpt and %zu paint stamps.",
+			data.m_chunks.Num(), data.m_physicsBodies.Num(), data.m_chunksX, data.m_chunksZ, data.m_chunkSize,
+			data.m_chunkResolution, data.m_vegetationProfiles.Num(), vegetationPerChunk,
+			vegetationRenderProxies, vegetationProfilesNotReady,
+			vegetationProfilesWithoutRenderData,
+			data.m_sculptStamps.Num() / 5u, data.m_paintStamps.Num() / 5u);
+	}
+	return nullptr;
+}
+
+void LandscapeECS::AppendSceneView(RHI::RHISceneViewPtr& sceneView) const
+{
+	if (!sceneView)
+	{
+		return;
+	}
+	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
+	{
+		if (!IsComponentRegistered(componentIndex))
+		{
+			continue;
+		}
+		for (const auto& chunk : m_components[componentIndex].m_chunks)
+		{
+			sceneView->m_staticOctree.Update(chunk.m_octreeCenter, chunk.m_octreeExtents, chunk.m_proxy);
+			for (const auto& vegetation : chunk.m_vegetationProxies)
+			{
+				sceneView->m_staticOctree.Update(
+					vegetation.m_octreeCenter,
+					vegetation.m_octreeExtents,
+					vegetation.m_proxy);
+			}
+		}
+		for (const auto& profile : m_components[componentIndex].m_vegetationProfiles)
+		{
+			if (profile.m_shadowMode == ELandscapeVegetationShadowMode::None)
+			{
+				continue;
+			}
+			sceneView->m_bHasCustomDepthShadowCasters |= profile.m_material &&
+				profile.m_material->GetRenderState().IsRequiredCustomDepthShader();
+			for (const auto& material : profile.m_modelMaterials)
+			{
+				sceneView->m_bHasCustomDepthShadowCasters |= material &&
+					material->GetRenderState().IsRequiredCustomDepthShader();
+			}
+		}
+	}
+	sceneView->m_shadowCastersRevision =
+		sceneView->m_shadowCastersRevision * 1099511628211ull ^ m_shadowCastersRevision;
+}
+
+void LandscapeECS::EndPlay()
+{
+	for (auto& component : m_components)
+	{
+		DestroyPhysicsBodies(component);
+	}
+	ECS::TSystem<LandscapeECS, LandscapeData>::EndPlay();
+	m_shadowCastersRevision = 0u;
+}

--- a/Runtime/ECS/LandscapeECS.h
+++ b/Runtime/ECS/LandscapeECS.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "ECS/ECS.h"
+#include "RHI/SceneView.h"
+
+namespace Sailor
+{
+	enum class ELandscapeVegetationShadowMode : uint8_t
+	{
+		None = 0u,
+		NearOnly,
+		All
+	};
+
+	struct LandscapeVegetationProfile final
+	{
+		FileId m_modelFileId{};
+		FileId m_materialFileId{};
+		ModelPtr m_model{};
+		MaterialPtr m_material{};
+		TVector<MaterialPtr> m_modelMaterials{};
+		Tasks::TaskPtr<bool> m_modelMaterialsTask{};
+		int32_t m_meshIndex = -1;
+		uint32_t m_instancesPerChunk = 0u;
+		float m_minScale = 0.75f;
+		float m_maxScale = 1.25f;
+		float m_groundOffset = 0.0f;
+		ELandscapeVegetationShadowMode m_shadowMode = ELandscapeVegetationShadowMode::NearOnly;
+		float m_shadowDistance = 35.0f;
+		uint32_t m_minLod = 0u;
+		uint32_t m_maxLod = 2u;
+		TVector<float> m_screenCoverageThresholds{ 0.25f, 0.05f };
+		float m_cullDistance = 120.0f;
+		float m_colliderRadius = 0.0f;
+		float m_colliderHeight = 2.0f;
+		float m_colliderOffsetY = 1.0f;
+	};
+
+	struct LandscapeVegetationRenderProxy final
+	{
+		RHI::RHISceneViewProxy m_proxy{};
+		glm::ivec3 m_octreeCenter{};
+		glm::ivec3 m_octreeExtents{ 1 };
+	};
+
+	struct LandscapeChunk final
+	{
+		RHI::RHISceneViewProxy m_proxy{};
+		glm::ivec3 m_octreeCenter{};
+		glm::ivec3 m_octreeExtents{ 1 };
+		TVector<LandscapeVegetationRenderProxy> m_vegetationProxies{};
+	};
+
+	class LandscapeData final : public ECS::TComponent
+	{
+	public:
+		SAILOR_API void SetSettings(uint32_t chunksX, uint32_t chunksZ,
+			float chunkSize, uint32_t chunkResolution, float heightScale,
+			float noiseScale, uint32_t seed, float textureTiling);
+		SAILOR_API void SetMaterial(const MaterialPtr& material);
+		SAILOR_API void SetLayerTextures(const TVector<FileId>& textures);
+		SAILOR_API void SetImportMaps(const FileId& heightmapTexture,
+			const TVector<FileId>& materialMasks);
+		SAILOR_API void SetAuthoredStamps(const TVector<float>& sculptStamps,
+			const TVector<float>& paintStamps);
+		SAILOR_API void SetVegetationProfiles(
+			const TVector<FileId>& models,
+			const TVector<FileId>& materials,
+			const TVector<float>& meshIndex,
+			const TVector<float>& instancesPerChunk,
+			const TVector<float>& minScale,
+			const TVector<float>& maxScale,
+			const TVector<float>& groundOffset,
+			const TVector<float>& shadowMode,
+			const TVector<float>& shadowDistance,
+			const TVector<float>& minLod,
+			const TVector<float>& maxLod,
+			const TVector<float>& lod1ScreenCoverage,
+			const TVector<float>& lod2ScreenCoverage,
+			const TVector<float>& cullDistance,
+			const TVector<float>& colliderRadius,
+			const TVector<float>& colliderHeight,
+			const TVector<float>& colliderOffsetY);
+
+	public:
+		uint32_t m_chunksX = 4u;
+		uint32_t m_chunksZ = 4u;
+		float m_chunkSize = 24.0f;
+		uint32_t m_chunkResolution = 24u;
+		float m_heightScale = 5.0f;
+		float m_noiseScale = 0.035f;
+		uint32_t m_seed = 1337u;
+		float m_textureTiling = 0.15f;
+		MaterialPtr m_material{};
+		MaterialPtr m_runtimeMaterial{};
+		TVector<FileId> m_layerTextures{};
+		FileId m_heightmapTexture{};
+		TVector<FileId> m_materialMasks{};
+		TVector<float> m_sculptStamps{};
+		TVector<float> m_paintStamps{};
+		TVector<LandscapeVegetationProfile> m_vegetationProfiles{};
+		TVector<LandscapeChunk> m_chunks{};
+		TVector<uint32_t> m_physicsBodies{};
+
+		friend class LandscapeECS;
+	};
+
+	class LandscapeECS final : public ECS::TSystem<LandscapeECS, LandscapeData>
+	{
+	public:
+		SAILOR_API virtual Tasks::ITaskPtr Tick(float deltaTime) override;
+		SAILOR_API virtual void EndPlay() override;
+		SAILOR_API void AppendSceneView(RHI::RHISceneViewPtr& sceneView) const;
+		virtual uint32_t GetOrder() const override { return 990u; }
+
+	protected:
+		SAILOR_API virtual void OnComponentUnregistered(size_t index, LandscapeData& component) override;
+
+	private:
+		void DestroyPhysicsBodies(LandscapeData& component);
+		uint64_t m_shadowCastersRevision = 0u;
+	};
+
+	template class ECS::TSystem<LandscapeECS, LandscapeData>;
+}

--- a/Runtime/ECS/PhysicsECS.cpp
+++ b/Runtime/ECS/PhysicsECS.cpp
@@ -555,6 +555,71 @@ bool PhysicsECS::AddForceAtPosition(
 			worldPosition);
 }
 
+bool PhysicsECS::CreateStaticTriangleMesh(
+	const InstanceId& instanceId,
+	const TVector<glm::vec3>& vertices,
+	const TVector<uint32_t>& indices,
+	const glm::vec3& position,
+	const glm::quat& rotation,
+	const glm::vec3& scale,
+	uint32_t& outBodyId)
+{
+	outBodyId = RigidBodyData::InvalidBodyId;
+	if (!EnsurePhysicsWorld() || !instanceId || vertices.IsEmpty() || indices.Num() < 3u)
+	{
+		return false;
+	}
+
+	Physics::RigidBodyDesc desc{};
+	desc.m_instanceId = instanceId;
+	desc.m_motionType = Physics::ERigidBodyMotionType::Static;
+	desc.m_position = position;
+	desc.m_rotation = rotation;
+	desc.m_scale = scale;
+	desc.m_friction = 0.8f;
+	desc.m_bAllowSleeping = true;
+	Physics::CollisionShapeDesc shape{};
+	shape.m_type = Physics::ECollisionShapeType::TriangleMesh;
+	shape.m_vertices = vertices;
+	shape.m_indices = indices;
+	desc.m_shapes.Add(std::move(shape));
+	return m_physicsWorld->CreateBody(desc, outBodyId);
+}
+
+bool PhysicsECS::CreateStaticCompound(
+	const InstanceId& instanceId,
+	const TVector<Physics::CollisionShapeDesc>& shapes,
+	const glm::vec3& position,
+	const glm::quat& rotation,
+	const glm::vec3& scale,
+	uint32_t& outBodyId)
+{
+	outBodyId = RigidBodyData::InvalidBodyId;
+	if (!EnsurePhysicsWorld() || !instanceId || shapes.IsEmpty())
+	{
+		return false;
+	}
+
+	Physics::RigidBodyDesc desc{};
+	desc.m_instanceId = instanceId;
+	desc.m_motionType = Physics::ERigidBodyMotionType::Static;
+	desc.m_position = position;
+	desc.m_rotation = rotation;
+	desc.m_scale = scale;
+	desc.m_friction = 0.8f;
+	desc.m_bAllowSleeping = true;
+	desc.m_shapes = shapes;
+	return m_physicsWorld->CreateBody(desc, outBodyId);
+}
+
+void PhysicsECS::DestroyExternalBody(uint32_t bodyId)
+{
+	if (m_physicsWorld && bodyId != RigidBodyData::InvalidBodyId)
+	{
+		m_physicsWorld->DestroyBody(bodyId);
+	}
+}
+
 void PhysicsECS::SetLayerCollisionEnabled(
 	uint8_t firstLayer,
 	uint8_t secondLayer,

--- a/Runtime/ECS/PhysicsECS.h
+++ b/Runtime/ECS/PhysicsECS.h
@@ -58,6 +58,22 @@ namespace Sailor
 			size_t componentIndex,
 			const glm::vec3& force,
 			const glm::vec3& worldPosition);
+		bool CreateStaticTriangleMesh(
+			const InstanceId& instanceId,
+			const TVector<glm::vec3>& vertices,
+			const TVector<uint32_t>& indices,
+			const glm::vec3& position,
+			const glm::quat& rotation,
+			const glm::vec3& scale,
+			uint32_t& outBodyId);
+		bool CreateStaticCompound(
+			const InstanceId& instanceId,
+			const TVector<Physics::CollisionShapeDesc>& shapes,
+			const glm::vec3& position,
+			const glm::quat& rotation,
+			const glm::vec3& scale,
+			uint32_t& outBodyId);
+		void DestroyExternalBody(uint32_t bodyId);
 
 		void SetFixedDeltaTime(float value);
 		float GetFixedDeltaTime() const { return m_fixedDeltaTime; }

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -96,6 +96,7 @@ namespace
 				lhsMesh.m_baseColorFactor != rhsMesh.m_baseColorFactor ||
 				lhsMesh.m_alphaCutoff != rhsMesh.m_alphaCutoff ||
 				lhsMesh.m_baseColorSampler != rhsMesh.m_baseColorSampler ||
+				lhsMesh.m_maxCameraDistance != rhsMesh.m_maxCameraDistance ||
 				lhsMesh.m_customDepthMaterial != rhsMesh.m_customDepthMaterial ||
 #if defined(__APPLE__)
 				lhsMesh.m_materialTextureSamplers != rhsMesh.m_materialTextureSamplers ||

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -219,6 +219,23 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 
 				for (const auto& shadowMesh : proxy->m_meshes)
 				{
+					if (!shadowMesh.m_mesh)
+					{
+						continue;
+					}
+
+					if (shadowMesh.m_maxCameraDistance < (std::numeric_limits<float>::max)())
+					{
+						Math::AABB worldBounds = shadowMesh.m_mesh->m_bounds;
+						worldBounds.Apply(shadowMesh.m_worldMatrix);
+						const glm::vec3 cameraPosition(sceneView.m_cameraTransform.m_position);
+						const glm::vec3 closestPoint = glm::clamp(
+							cameraPosition, worldBounds.m_min, worldBounds.m_max);
+						if (glm::distance(cameraPosition, closestPoint) > shadowMesh.m_maxCameraDistance)
+						{
+							continue;
+						}
+					}
 					const size_t renderQueueTag = shadowMesh.m_renderQueueTag;
 					if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
 					{

--- a/Runtime/Physics/PhysicsTypes.h
+++ b/Runtime/Physics/PhysicsTypes.h
@@ -19,7 +19,8 @@ namespace Sailor::Physics
 	{
 		Box = 0,
 		Sphere,
-		Capsule
+		Capsule,
+		TriangleMesh
 	};
 
 	enum class EPhysicsContactType : uint8_t
@@ -37,6 +38,8 @@ namespace Sailor::Physics
 		glm::vec3 m_size = glm::vec3(1.0f);
 		float m_radius = 0.5f;
 		float m_height = 1.0f;
+		TVector<glm::vec3> m_vertices{};
+		TVector<uint32_t> m_indices{};
 	};
 
 	struct RigidBodyDesc final

--- a/Runtime/Physics/PhysicsWorld.cpp
+++ b/Runtime/Physics/PhysicsWorld.cpp
@@ -14,6 +14,7 @@
 #include <Jolt/Physics/Collision/Shape/BoxShape.h>
 #include <Jolt/Physics/Collision/Shape/SphereShape.h>
 #include <Jolt/Physics/Collision/Shape/CapsuleShape.h>
+#include <Jolt/Physics/Collision/Shape/MeshShape.h>
 #include <Jolt/Physics/Collision/Shape/RotatedTranslatedShape.h>
 #include <Jolt/Physics/Collision/Shape/StaticCompoundShape.h>
 #include <Jolt/Physics/Collision/CastResult.h>
@@ -284,6 +285,43 @@ namespace
 			return new JPH::CapsuleShape(
 				std::max(0.0f, totalHeight * 0.5f - radius),
 				radius);
+		}
+		case Physics::ECollisionShapeType::TriangleMesh:
+		{
+			if (desc.m_vertices.IsEmpty() || desc.m_indices.Num() < 3u)
+			{
+				return {};
+			}
+
+			JPH::VertexList vertices;
+			vertices.reserve(desc.m_vertices.Num());
+			for (const glm::vec3& vertex : desc.m_vertices)
+			{
+				const glm::vec3 scaled = vertex * absoluteScale;
+				vertices.emplace_back(scaled.x, scaled.y, scaled.z);
+			}
+
+			JPH::IndexedTriangleList triangles;
+			triangles.reserve(desc.m_indices.Num() / 3u);
+			for (size_t index = 0u; index + 2u < desc.m_indices.Num(); index += 3u)
+			{
+				const uint32_t i0 = desc.m_indices[index];
+				const uint32_t i1 = desc.m_indices[index + 1u];
+				const uint32_t i2 = desc.m_indices[index + 2u];
+				if (i0 < desc.m_vertices.Num() && i1 < desc.m_vertices.Num() && i2 < desc.m_vertices.Num())
+				{
+					triangles.emplace_back(i0, i1, i2, 0u);
+				}
+			}
+			if (triangles.empty())
+			{
+				return {};
+			}
+
+			JPH::MeshShapeSettings settings(std::move(vertices), std::move(triangles));
+			settings.mBuildQuality = JPH::MeshShapeSettings::EBuildQuality::FavorRuntimePerformance;
+			auto result = settings.Create();
+			return result.HasError() ? JPH::ShapeRefC{} : result.Get();
 		}
 		default:
 			return {};

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -19,6 +19,7 @@
 #include "AssetRegistry/Material/MaterialImporter.h"
 #include "ECS/CameraECS.h"
 #include "ECS/LightingECS.h"
+#include "ECS/LandscapeECS.h"
 #include "ECS/AnimationECS.h"
 #include "ECS/PathTracerECS.h"
 
@@ -332,6 +333,7 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 
 		rhiSceneView->m_world = world;
 		world->GetECS<StaticMeshRendererECS>()->CopySceneView(rhiSceneView);
+		world->GetECS<LandscapeECS>()->AppendSceneView(rhiSceneView);
 		if (auto* pathTracerEcs = world->GetECS<PathTracerECS>())
 		{
 			pathTracerEcs->CopySceneView(rhiSceneView);

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <limits>
 
 using namespace Sailor;
@@ -94,6 +95,30 @@ float Sailor::RHI::CalculateScreenCoverage(
 		1.0f);
 }
 
+uint32_t RHI::RHILodPolicy::Resolve(float screenCoverage, uint32_t numAvailableLods) const
+{
+	if (numAvailableLods == 0u)
+	{
+		return 0u;
+	}
+
+	const uint32_t highestAvailableLod = numAvailableLods - 1u;
+	const uint32_t minLod = (std::min)(m_minLod, highestAvailableLod);
+	const uint32_t maxLod = (std::max)(minLod, (std::min)(m_maxLod, highestAvailableLod));
+	uint32_t selectedLod = 0u;
+	const float coverage = (std::clamp)(screenCoverage, 0.0f, 1.0f);
+	for (size_t index = 0u; index < m_screenCoverageThresholds.Num(); ++index)
+	{
+		if (!std::isfinite(m_screenCoverageThresholds[index]) ||
+			coverage >= m_screenCoverageThresholds[index])
+		{
+			break;
+		}
+		selectedLod = static_cast<uint32_t>(index + 1u);
+	}
+	return (std::clamp)(selectedLod, minLod, maxLod);
+}
+
 namespace
 {
 	uint32_t ResolveProxyLod(
@@ -112,6 +137,31 @@ namespace
 			camera.GetViewMatrix(),
 			camera.GetProjectionMatrix());
 		return data.ResolveLod(screenCoverage, mesh->GetNumLods());
+	}
+
+	void ApplyCustomLodToMeshes(
+		const RHILodPolicy& policy,
+		const Math::AABB& worldBounds,
+		const CameraData& camera,
+		TVector<RHIMeshPtr>& meshes)
+	{
+		const float coverage = CalculateScreenCoverage(
+			worldBounds, camera.GetViewMatrix(), camera.GetProjectionMatrix());
+		for (auto& mesh : meshes)
+		{
+			if (!mesh)
+			{
+				continue;
+			}
+			const uint32_t lod = policy.Resolve(coverage, mesh->GetNumLods());
+			if (lod > 0u)
+			{
+				if (RHIMeshPtr lodMesh = mesh->GetLod(lod))
+				{
+					mesh = std::move(lodMesh);
+				}
+			}
+		}
 	}
 
 	void ApplyLodToMeshes(
@@ -148,20 +198,23 @@ namespace
 		}
 
 		auto* meshEcs = world->GetECS<StaticMeshRendererECS>();
-		if (!meshEcs || !meshEcs->IsComponentRegistered(source->m_staticMeshEcs))
+		const bool bUseStaticMeshSettings = meshEcs &&
+			meshEcs->IsComponentRegistered(source->m_staticMeshEcs);
+		if (!source->m_lodPolicy.m_bEnabled && !bUseStaticMeshSettings)
 		{
 			return source;
 		}
 
-		const auto& data = meshEcs->GetComponentData(source->m_staticMeshEcs);
 		RHIShadowCasterProxyPtr result = RHIShadowCasterProxyPtr::Make(*source);
+		const float coverage = CalculateScreenCoverage(
+			source->m_worldAabb, camera.GetViewMatrix(), camera.GetProjectionMatrix());
 		for (auto& shadowMesh : result->m_meshes)
 		{
-			const uint32_t lod = ResolveProxyLod(
-				data,
-				source->m_worldAabb,
-				camera,
-				shadowMesh.m_mesh);
+			const uint32_t lod = source->m_lodPolicy.m_bEnabled ?
+				source->m_lodPolicy.Resolve(coverage,
+					shadowMesh.m_mesh ? shadowMesh.m_mesh->GetNumLods() : 0u) :
+				ResolveProxyLod(meshEcs->GetComponentData(source->m_staticMeshEcs),
+					source->m_worldAabb, camera, shadowMesh.m_mesh);
 			if (lod > 0u)
 			{
 				if (RHIMeshPtr lodMesh = shadowMesh.m_mesh->GetLod(lod))
@@ -402,25 +455,35 @@ void RHISceneView::PrepareSnapshots()
 		res.m_shadowMapsToUpdate = std::move(m_shadowMapsToUpdate[i]);
 		res.m_proxies = TraceScene(frustum, false);
 		auto* meshEcs = m_world ? m_world->GetECS<StaticMeshRendererECS>() : nullptr;
-		if (meshEcs)
-		{
-			for (auto& proxy : res.m_proxies)
+		const glm::vec3 cameraPosition = glm::vec3(m_cameraTransforms[i].m_position);
+		res.m_proxies.RemoveAll([&](const RHISceneViewProxy& proxy)
 			{
-				if (!meshEcs->IsComponentRegistered(proxy.m_staticMeshEcs))
+				if (!std::isfinite(proxy.m_lodPolicy.m_maxCameraDistance))
 				{
-					continue;
+					return false;
 				}
+				const glm::vec3 closest = glm::clamp(
+					cameraPosition, proxy.m_worldAabb.m_min, proxy.m_worldAabb.m_max);
+				return glm::distance(cameraPosition, closest) > proxy.m_lodPolicy.m_maxCameraDistance;
+			});
+		for (auto& proxy : res.m_proxies)
+		{
+			if (proxy.m_lodPolicy.m_bEnabled)
+			{
+				ApplyCustomLodToMeshes(proxy.m_lodPolicy, proxy.m_worldAabb,
+					camera, proxy.m_meshes);
+			}
+			else if (meshEcs && meshEcs->IsComponentRegistered(proxy.m_staticMeshEcs))
+			{
 				const auto& data = meshEcs->GetComponentData(proxy.m_staticMeshEcs);
 				ApplyLodToMeshes(
 					data,
 					proxy.m_worldAabb,
 					camera,
 					proxy.m_meshes);
-				proxy.m_shadowCaster = CreateLodShadowCaster(
-					proxy.m_shadowCaster,
-					m_world,
-					camera);
 			}
+			proxy.m_shadowCaster = CreateLodShadowCaster(
+				proxy.m_shadowCaster, m_world, camera);
 		}
 		for (auto& shadowMap : res.m_shadowMapsToUpdate)
 		{

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -34,10 +34,22 @@ namespace Sailor::RHI
 		glm::vec4 m_baseColorFactor{ 1.0f };
 		float m_alphaCutoff = 0.5f;
 		uint32_t m_baseColorSampler = 0;
+		float m_maxCameraDistance = (std::numeric_limits<float>::max)();
 		MaterialPtr m_customDepthMaterial{};
 #if defined(__APPLE__)
 		TSet<uint32_t> m_materialTextureSamplers{};
 #endif
+	};
+
+	struct RHILodPolicy
+	{
+		bool m_bEnabled = false;
+		uint32_t m_minLod = 0u;
+		uint32_t m_maxLod = 2u;
+		TVector<float> m_screenCoverageThresholds{ 0.25f, 0.05f };
+		float m_maxCameraDistance = (std::numeric_limits<float>::infinity)();
+
+		SAILOR_API uint32_t Resolve(float screenCoverage, uint32_t numAvailableLods) const;
 	};
 
 	struct RHIShadowCasterProxy
@@ -47,6 +59,7 @@ namespace Sailor::RHI
 		uint32_t m_skeletonOffset = (std::numeric_limits<uint32_t>::max)();
 		size_t m_frame{};
 		TVector<RHIShadowMeshProxy> m_meshes{};
+		RHILodPolicy m_lodPolicy{};
 	};
 
 	using RHIShadowCasterProxyPtr = TSharedPtr<RHIShadowCasterProxy>;
@@ -89,6 +102,7 @@ namespace Sailor::RHI
 		TVector<TSet<uint32_t>> m_materialTextureSamplers;
 #endif
 		RHIShadowCasterProxyPtr m_shadowCaster{};
+		RHILodPolicy m_lodPolicy{};
 
 		SAILOR_API bool operator==(const RHISceneViewProxy& rhs) const { return m_staticMeshEcs == rhs.m_staticMeshEcs; }
 		SAILOR_API const TVector<RHIMaterialPtr>& GetMaterials() const;

--- a/Tests/BoundsContractTests.cpp
+++ b/Tests/BoundsContractTests.cpp
@@ -1,4 +1,5 @@
 #include "Math/Bounds.h"
+#include "RHI/SceneView.h"
 
 #include <cmath>
 #include <functional>
@@ -157,6 +158,23 @@ namespace
 			casterDepth <= 1.0001f,
 			"shadow projection must include casters behind the camera toward the light source");
 	}
+
+	void TestLodPolicyResolvesCoverageAndAvailableMeshes()
+	{
+		RHI::RHILodPolicy policy;
+		policy.m_bEnabled = true;
+		policy.m_minLod = 0;
+		policy.m_maxLod = 2;
+		policy.m_screenCoverageThresholds = { 0.25f, 0.05f };
+
+		Require(policy.Resolve(0.5f, 3) == 0, "high coverage must select the highest-detail LOD");
+		Require(policy.Resolve(0.1f, 3) == 1, "medium coverage must select the middle LOD");
+		Require(policy.Resolve(0.01f, 3) == 2, "low coverage must select the lowest-detail LOD");
+		Require(policy.Resolve(0.01f, 2) == 1, "LOD selection must clamp to the available mesh count");
+
+		policy.m_minLod = 1;
+		Require(policy.Resolve(1.0f, 3) == 1, "the configured minimum LOD must be respected");
+	}
 }
 
 int main()
@@ -169,6 +187,7 @@ int main()
 		{ "FrustumCenterIsTheAverageOfItsCorners", TestFrustumCenterIsTheAverageOfItsCorners },
 			{ "ReverseZFrustumCornersUseZeroToOneDepth", TestReverseZFrustumCornersUseZeroToOneDepth },
 			{ "ShadowProjectionIncludesCastersTowardLightSource", TestShadowProjectionIncludesCastersTowardLightSource },
+			{ "LodPolicyResolvesCoverageAndAvailableMeshes", TestLodPolicyResolvesCoverageAndAvailableMeshes },
 	};
 
 	for (const auto& test : tests)

--- a/Tests/PhysicsRuntimeTests.cpp
+++ b/Tests/PhysicsRuntimeTests.cpp
@@ -608,6 +608,46 @@ namespace
 			"off-center force should create linear motion and torque");
 	}
 
+	void TestStaticTriangleMeshSupportsDynamicBodies()
+	{
+		Physics::PhysicsWorld world;
+		Physics::RigidBodyDesc terrain{};
+		terrain.m_instanceId = InstanceId::GenerateNewInstanceId();
+		terrain.m_motionType = Physics::ERigidBodyMotionType::Static;
+
+		Physics::CollisionShapeDesc mesh{};
+		mesh.m_type = Physics::ECollisionShapeType::TriangleMesh;
+		mesh.m_vertices = {
+			glm::vec3(-10.0f, 0.0f, -10.0f),
+			glm::vec3(-10.0f, 0.0f, 10.0f),
+			glm::vec3(10.0f, 0.0f, -10.0f),
+			glm::vec3(10.0f, 0.0f, 10.0f)
+		};
+		mesh.m_indices = { 0, 1, 2, 2, 1, 3 };
+		terrain.m_shapes.Add(std::move(mesh));
+
+		uint32_t terrainBody = ~0u;
+		Require(world.CreateBody(terrain, terrainBody),
+			"static triangle-mesh terrain should be created");
+
+		uint32_t dynamicBody = ~0u;
+		Require(world.CreateBody(
+			MakeBox(
+				InstanceId::GenerateNewInstanceId(),
+				Physics::ERigidBodyMotionType::Dynamic,
+				glm::vec3(0.0f, 4.0f, 0.0f),
+				glm::vec3(1.0f)),
+			dynamicBody),
+			"dynamic body above triangle-mesh terrain should be created");
+
+		Step(world, 240);
+		Physics::PhysicsBodyPose pose{};
+		Require(world.GetBodyPose(dynamicBody, pose),
+			"dynamic body on triangle-mesh terrain should remain readable");
+		Require(pose.m_position.y > 0.45f && pose.m_position.y < 0.56f,
+			"dynamic body should settle on triangle-mesh terrain");
+	}
+
 	struct PhysicsSceneStats final
 	{
 		size_t m_dynamicBodies = 0;
@@ -921,6 +961,7 @@ int main()
 		{ "ReflectedPhysicsAuthoringContract", TestReflectedPhysicsAuthoringContract },
 		{ "ComponentTeardownOrdering", TestComponentTeardownOrdering },
 		{ "ForceAtPositionAppliesLinearAndAngularImpulse", TestForceAtPositionAppliesLinearAndAngularImpulse },
+		{ "StaticTriangleMeshSupportsDynamicBodies", TestStaticTriangleMeshSupportsDynamicBodies },
 		{ "PhysicsSceneFixtures", TestPhysicsSceneFixtures },
 	};
 

--- a/Tests/SmartPointerTests.cpp
+++ b/Tests/SmartPointerTests.cpp
@@ -8,6 +8,7 @@
 
 #include "Memory/SharedPtr.hpp"
 #include "Memory/UniquePtr.hpp"
+#include "Containers/Vector.h"
 
 using namespace Sailor;
 
@@ -48,6 +49,40 @@ namespace
 		static inline int s_liveCount = 0;
 		static inline int s_destroyedCount = 0;
 		int m_value = 0;
+	};
+
+	struct VectorLifetimeProbe
+	{
+		VectorLifetimeProbe()
+		{
+			++s_liveCount;
+		}
+
+		VectorLifetimeProbe(const VectorLifetimeProbe&) = delete;
+		VectorLifetimeProbe& operator=(const VectorLifetimeProbe&) = delete;
+
+		VectorLifetimeProbe(VectorLifetimeProbe&&) noexcept
+		{
+			++s_liveCount;
+			++s_moveCount;
+		}
+
+		~VectorLifetimeProbe()
+		{
+			--s_liveCount;
+			++s_destroyedCount;
+		}
+
+		static void Reset()
+		{
+			s_liveCount = 0;
+			s_moveCount = 0;
+			s_destroyedCount = 0;
+		}
+
+		static inline int s_liveCount = 0;
+		static inline int s_moveCount = 0;
+		static inline int s_destroyedCount = 0;
 	};
 
 	void TestSharedPtrConstObserversAndComparison()
@@ -126,6 +161,29 @@ namespace
 			Require(values[i] == 0, "array Make should value-initialize fundamental elements");
 		}
 	}
+
+	void TestVectorReserveMovesOnlyLiveElements()
+	{
+		VectorLifetimeProbe::Reset();
+		{
+			TVector<VectorLifetimeProbe> values;
+			values.Reserve(8);
+			values.Emplace();
+			values.Reserve(16);
+
+			Require(VectorLifetimeProbe::s_liveCount == 1,
+				"vector reserve should preserve exactly one live element");
+			Require(VectorLifetimeProbe::s_moveCount == 1,
+				"vector reserve should move Num elements rather than Capacity elements");
+			Require(VectorLifetimeProbe::s_destroyedCount == 1,
+				"vector reserve should destroy only the initialized source elements");
+		}
+
+		Require(VectorLifetimeProbe::s_liveCount == 0,
+			"vector destruction should release the remaining live element");
+		Require(VectorLifetimeProbe::s_destroyedCount == 2,
+			"vector growth and destruction should destroy each constructed element once");
+	}
 }
 
 int main()
@@ -135,6 +193,7 @@ int main()
 		{ "UniquePtrScalarRelease", TestUniquePtrScalarRelease },
 		{ "UniquePtrArrayLifetimeMoveAndRelease", TestUniquePtrArrayLifetimeMoveAndRelease },
 		{ "UniquePtrArrayValueInitialization", TestUniquePtrArrayValueInitialization },
+		{ "VectorReserveMovesOnlyLiveElements", TestVectorReserveMovesOnlyLiveElements },
 	};
 
 	for (const auto& test : tests)


### PR DESCRIPTION
## Summary

- add `LandscapeComponent` and `LandscapeECS` with task-parallel chunk generation, heightmaps, material masks, authored stamps, terrain collision, and procedural fallback
- add per-vegetation model/mesh/material settings, GLB material fallback, scale/offset, shadow policy, LOD coverage, cull distance, and optional colliders
- integrate landscape proxies with the renderer through a reusable RHI LOD policy and distance-aware shadow submission
- add landscape inspector controls, texture import, and typed MCP apply/regenerate tools
- add the layered landscape shader required by the runtime

## Architecture

- the current landscape schema is canonical; there is no revision field, migration path, or legacy compatibility code
- landscape-specific inspector code is isolated from the generic component template
- component-to-ECS synchronization is centralized, and chunk CPU work runs on worker tasks
- vegetation render resources are resolved before chunk construction to avoid duplicate rebuilds

## Scope

- no project worlds, models, textures, materials, or other game content are included
- the only `Content/` files are `Landscape.shader` and its engine asset metadata

## Validation

- `python3 update_deps.py`
- Release `SailorLib` build
- Release `SailorExec` and all C++ test targets build
- Release macOS editor and MCP bridge build
- C++ tests: 37/37 passed
- editor contract tests: 775/775 passed

This PR is intentionally left as a draft for human review and must not be merged automatically.
