### PR TITLE
Improve editor hierarchy and runtime scene authoring

### DIFF
--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -321,16 +321,16 @@ glslFragment: |
       return 1.0f;
     }
 
+    const vec3 shadowReceiverPosition = OffsetDirectionalShadowReceiver(
+      worldPosition,
+      surfaceNormal,
+      surfaceToLightDirection);
     const mat4 cascadeLightMatrix = lightsMatrices.instance[cascadeLayer];
     float shadow = CalculateDirectionalShadow(
-      light.shadowType,
+      GetDirectionalCascadeShadowType(light.shadowType, cascadeLayer),
       shadowMaps[cascadeLayer],
-      cascadeLightMatrix,
-      cascadeLightMatrix * vec4(worldPosition, 1.0f),
-      surfaceNormal,
-      surfaceToLightDirection,
+      cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f),
       cascadeLayer);
-
     const float cascadeBlend = CalculateCascadeBlend(
       frame.view,
       worldPosition,
@@ -341,15 +341,19 @@ glslFragment: |
       const int nextCascadeLayer = cascadeLayer + 1;
       const mat4 nextCascadeLightMatrix = lightsMatrices.instance[nextCascadeLayer];
       const float nextShadow = CalculateDirectionalShadow(
-        light.shadowType,
+        GetDirectionalCascadeShadowType(light.shadowType, nextCascadeLayer),
         shadowMaps[nextCascadeLayer],
-        nextCascadeLightMatrix,
-        nextCascadeLightMatrix * vec4(worldPosition, 1.0f),
-        surfaceNormal,
-        surfaceToLightDirection,
+        nextCascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f),
         nextCascadeLayer);
       shadow = mix(shadow, nextShadow, cascadeBlend);
     }
+
+    const float shadowDistanceFade = CalculateShadowDistanceFade(
+      frame.view,
+      worldPosition,
+      frame.cameraZNearZFar,
+      cascadeLayer);
+    shadow = mix(shadow, 1.0f, shadowDistanceFade);
 
     return shadow;
   }

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -1,13 +1,21 @@
 const float EVSM_C1 = 40.0f;
 const float EVSM_C2 = 40.0f;
-const float SHADOW_BIAS_MIN_TEXELS = 1.0f;
-const float SHADOW_BIAS_SLOPE_TEXELS = 1.5f;
-const float SHADOW_BIAS_EVSM_CASCADE_1_SCALE = 1.5f;
-const float SHADOW_BIAS_CASCADE_3_SCALE = 1.5f;
-const float SHADOW_BIAS_CASCADE_4_SCALE = 2.0f;
+// Offset the receiver before projecting it into a cascade. Applying bias after
+// projection makes the effective surface offset depend on that cascade's depth
+// range and precision, which exposes the split as a band.
+const float SHADOW_RECEIVER_LIGHT_OFFSET = 0.005f;
+const float SHADOW_RECEIVER_NORMAL_OFFSET = 0.02f;
 const uint SHADOW_TYPE_NONE = 0u;
 const uint SHADOW_TYPE_PCF = 1u;
 const uint SHADOW_TYPE_EVSM = 2u;
+
+uint GetDirectionalCascadeShadowType(uint lightShadowType, int cascadeLayer)
+{
+  // The renderer stores the near cascade using the light's requested mode,
+  // while all wider cascades use depth-only PCF maps. Sampling a PCF map as
+  // EVSM moments produces a dark band during the cross-cascade blend.
+  return cascadeLayer == 0 ? lightShadowType : SHADOW_TYPE_PCF;
+}
 
 layout(std430)
 struct LightData
@@ -207,7 +215,7 @@ float LuminanceCzm(vec3 rgb)
     return dot(rgb, w);
 }
 
-float ManualPCF(sampler2D shadowMap, vec3 projCoords, float currentDepth, float bias)
+float ManualPCF(sampler2D shadowMap, vec3 projCoords, float currentDepth)
 {
    float shadow = 0.0;
    vec2 texelSize = 1.0 / textureSize(shadowMap, 0);
@@ -228,9 +236,21 @@ float ManualPCF(sampler2D shadowMap, vec3 projCoords, float currentDepth, float 
 
    for(int i = 0; i < samples; ++i)
    {
-       vec2 offset = poissonDisk[i] * radius * texelSize;
-       float pcfDepth = texture(shadowMap, projCoords.xy + offset).r;
-       shadow += currentDepth + bias > pcfDepth ? 1.0 : 0.0;
+       const vec2 offset = poissonDisk[i] * radius * texelSize;
+       const vec2 sampleUv = projCoords.xy + offset;
+       if(any(lessThan(sampleUv, vec2(0.0f))) ||
+          any(greaterThan(sampleUv, vec2(1.0f))))
+       {
+           // A clamped depth lookup repeats the outer texel and creates a dark
+           // PCF rim at the cascade boundary. Outside the current projection
+           // there is no occluder represented by this map; the overlapping
+           // cascade supplies the valid shadow sample for this region.
+           shadow += 1.0f;
+           continue;
+       }
+
+       const float pcfDepth = texture(shadowMap, sampleUv).r;
+       shadow += currentDepth > pcfDepth ? 1.0 : 0.0;
    }
 
    shadow /= float(samples);
@@ -280,6 +300,27 @@ float CalculateCascadeBlend(
     (cascadeFar - cascadeNear) * ShadowCascadeBlendFraction;
   return smoothstep(blendStart, cascadeFar, depthValue);
 }
+
+float CalculateShadowDistanceFade(
+  mat4 view,
+  vec3 worldPosition,
+  vec2 cameraZNearZFar,
+  int cascadeLayer)
+{
+  if(cascadeLayer != NUM_CSM_CASCADES - 1)
+  {
+    return 0.0f;
+  }
+
+  const vec4 fragPosViewSpace = view * vec4(worldPosition, 1.0f);
+  const float depthValue = abs(fragPosViewSpace.z / fragPosViewSpace.w);
+  const float shadowFarPlane = min(cameraZNearZFar.y, ShadowMaxDistance);
+  const float cascadeNear = shadowFarPlane *
+    ShadowCascadeLevels[NUM_CSM_CASCADES - 2];
+  const float fadeStart = shadowFarPlane -
+    (shadowFarPlane - cascadeNear) * ShadowCascadeBlendFraction;
+  return smoothstep(fadeStart, shadowFarPlane, depthValue);
+}
   
 float Linstep(float minVal, float maxVal, float val) 
 {
@@ -305,7 +346,7 @@ float Chebyshev(vec2 moments, float currentDepth, float minVariance, float linst
     return ReduceLightBleed(variance / (variance + d * d), linstep);
 }
 
-float ShadowCalculation_Pcf(sampler2D shadowMap, vec4 fragPosLightSpace, float bias, int cascadeLayer)
+float ShadowCalculation_Pcf(sampler2D shadowMap, vec4 fragPosLightSpace, int cascadeLayer)
 {
   vec3 projCoords = fragPosLightSpace.xyz / fragPosLightSpace.w;
   projCoords.xy = projCoords.xy * 0.5 + 0.5;
@@ -320,12 +361,11 @@ float ShadowCalculation_Pcf(sampler2D shadowMap, vec4 fragPosLightSpace, float b
   
   const float currentDepth = projCoords.z;
   
-  //float shadow = currentDepth + bias > closestDepth ? 1.0 : 0.0;
-  float shadow = ManualPCF(shadowMap, projCoords, currentDepth, bias);
+  float shadow = ManualPCF(shadowMap, projCoords, currentDepth);
   return shadow;  
 }
 
-float ShadowCalculation_Evsm(sampler2D shadowMap, vec4 fragPosLightSpace, float bias, int cascadeLayer)
+float ShadowCalculation_Evsm(sampler2D shadowMap, vec4 fragPosLightSpace, int cascadeLayer)
 {
   vec3 projCoords = fragPosLightSpace.xyz / fragPosLightSpace.w;
   projCoords.xy = projCoords.xy * 0.5 + 0.5;
@@ -339,9 +379,8 @@ float ShadowCalculation_Evsm(sampler2D shadowMap, vec4 fragPosLightSpace, float 
   }
   
   vec4 shadow = texture(shadowMap, projCoords.xy);// > 0.39 ? 1.0f : 0.0f;
-  const float biasedDepth = clamp(projCoords.z + bias, 0.0f, 1.0f);
-  const float currentDepth = exp(EVSM_C1 * biasedDepth);
-  const float negCurrentDepth = -exp(-EVSM_C2 * biasedDepth);
+  const float currentDepth = exp(EVSM_C1 * projCoords.z);
+  const float negCurrentDepth = -exp(-EVSM_C2 * projCoords.z);
   
   float posValue = Chebyshev(shadow.xy, currentDepth, 0.01, 0);
   float negValue = Chebyshev(shadow.zw, negCurrentDepth, 0, 0) * (cascadeLayer > 2 ? 0 : 1);
@@ -352,10 +391,7 @@ float ShadowCalculation_Evsm(sampler2D shadowMap, vec4 fragPosLightSpace, float 
 float CalculateDirectionalShadow(
   uint shadowType,
   sampler2D shadowMap,
-  mat4 lightMatrix,
   vec4 fragPosLightSpace,
-  vec3 surfaceNormal,
-  vec3 surfaceToLightDirection,
   int cascadeLayer)
 {
   if (shadowType == SHADOW_TYPE_NONE)
@@ -363,34 +399,27 @@ float CalculateDirectionalShadow(
     return 1.0f;
   }
 
-  const float slope = 1.0f - clamp(dot(surfaceNormal, surfaceToLightDirection), 0.0f, 1.0f);
-  const ivec2 shadowMapSize = max(textureSize(shadowMap, 0), ivec2(1));
-  const vec3 projectionX = vec3(lightMatrix[0][0], lightMatrix[1][0], lightMatrix[2][0]);
-  const vec3 projectionY = vec3(lightMatrix[0][1], lightMatrix[1][1], lightMatrix[2][1]);
-  const vec3 projectionZ = vec3(lightMatrix[0][2], lightMatrix[1][2], lightMatrix[2][2]);
-  const float worldUnitsPerTexelX =
-    2.0f / max(length(projectionX) * float(shadowMapSize.x), 0.000001f);
-  const float worldUnitsPerTexelY =
-    2.0f / max(length(projectionY) * float(shadowMapSize.y), 0.000001f);
-  const float normalizedDepthPerWorldUnit = length(projectionZ);
-  const float normalizedDepthPerTexel =
-    max(worldUnitsPerTexelX, worldUnitsPerTexelY) * normalizedDepthPerWorldUnit;
-  const float cascadeBiasScale =
-    shadowType == SHADOW_TYPE_EVSM && cascadeLayer == 0
-      ? SHADOW_BIAS_EVSM_CASCADE_1_SCALE
-      : (cascadeLayer == 2
-        ? SHADOW_BIAS_CASCADE_3_SCALE
-        : (cascadeLayer >= 3 ? SHADOW_BIAS_CASCADE_4_SCALE : 1.0f));
-  const float bias = normalizedDepthPerTexel * cascadeBiasScale *
-    (SHADOW_BIAS_MIN_TEXELS + SHADOW_BIAS_SLOPE_TEXELS * slope);
   if (shadowType == SHADOW_TYPE_EVSM && cascadeLayer == 0)
   {
     return ShadowCalculation_Evsm(
       shadowMap,
       fragPosLightSpace,
-      bias,
       cascadeLayer);
   }
 
-  return ShadowCalculation_Pcf(shadowMap, fragPosLightSpace, bias, cascadeLayer);
+  return ShadowCalculation_Pcf(shadowMap, fragPosLightSpace, cascadeLayer);
+}
+
+vec3 OffsetDirectionalShadowReceiver(
+  vec3 worldPosition,
+  vec3 surfaceNormal,
+  vec3 surfaceToLightDirection)
+{
+  const vec3 normal = normalize(surfaceNormal);
+  const vec3 toLight = normalize(surfaceToLightDirection);
+  const float cosTheta = clamp(dot(normal, toLight), 0.0f, 1.0f);
+  const float sinTheta = sqrt(max(1.0f - cosTheta * cosTheta, 0.0f));
+  return worldPosition +
+    toLight * SHADOW_RECEIVER_LIGHT_OFFSET +
+    normal * (SHADOW_RECEIVER_NORMAL_OFFSET * sinTheta);
 }

--- a/Content/Shaders/Lighting.glsl.asset
+++ b/Content/Shaders/Lighting.glsl.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: "{79AA6CFB-10D1-4B52-963C-C59C67DCBF92}"
+fileId: 79AA6CFB-10D1-4B52-963C-C59C67DCBF92
 filename: Lighting.glsl

--- a/Content/Shaders/MotionBlur.shader.asset
+++ b/Content/Shaders/MotionBlur.shader.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: "{A178A9CF-EC86-438D-ABD8-D8F5A48A42E3}"
+fileId: A178A9CF-EC86-438D-ABD8-D8F5A48A42E3
 filename: MotionBlur.shader

--- a/Content/Shaders/Sky.shader
+++ b/Content/Shaders/Sky.shader
@@ -185,8 +185,9 @@ glslFragment: |
   {
     const float a = dot(direction, direction);
     const float halfB = dot(direction, origin) + earthRadius * direction.y;
-    const float c = dot(origin, origin) + 2.0f * earthRadius * origin.y -
-      altitude * (2.0f * earthRadius + altitude);
+    const float heightDelta = origin.y - altitude;
+    const float c = dot(origin.xz, origin.xz) +
+      heightDelta * (2.0f * earthRadius + origin.y + altitude);
     const float discriminant = halfB * halfB - a * c;
     if(discriminant < 0.0f)
     {
@@ -194,10 +195,18 @@ glslFragment: |
     }
 
     const float root = sqrt(discriminant);
-    const float inverseA = 1.0f / max(a, 0.000001f);
-    const float x1 = (-halfB - root) * inverseA;
-    const float x2 = (-halfB + root) * inverseA;
-    return vec2(x1, x2);
+    const float q = -halfB - (halfB >= 0.0f ? root : -root);
+    if(abs(q) <= 0.000001f)
+    {
+      const float repeatedRoot = -halfB / max(a, 0.000001f);
+      return vec2(repeatedRoot);
+    }
+
+    const float firstRoot = q / a;
+    const float secondRoot = c / q;
+    return firstRoot < secondRoot
+      ? vec2(firstRoot, secondRoot)
+      : vec2(secondRoot, firstRoot);
   }
 
   float NearestPositiveIntersection(vec2 intersections)
@@ -208,6 +217,83 @@ glslFragment: |
     }
 
     return intersections.y > 0.0f ? intersections.y : -1.0f;
+  }
+
+  float RadialMotion(vec3 position, vec3 direction)
+  {
+    return dot(direction, vec3(
+      position.x,
+      earthRadius + position.y,
+      position.z));
+  }
+
+  bool RayEntersAltitudeSphere(
+    vec3 origin,
+    vec3 direction,
+    float altitude,
+    out float distance)
+  {
+    const float heightFromBoundary = PlanetHeight(origin) - altitude;
+    const float boundaryTolerance = 0.001f;
+    distance = -1.0f;
+
+    if(heightFromBoundary < -boundaryTolerance)
+    {
+      // The ray already starts inside this sphere. Its positive root exits the
+      // sphere and therefore must not be treated as an opaque entry.
+      return false;
+    }
+
+    if(abs(heightFromBoundary) <= boundaryTolerance)
+    {
+      if(RadialMotion(origin, direction) < 0.0f)
+      {
+        distance = 0.0f;
+        return true;
+      }
+
+      return false;
+    }
+
+    distance = NearestPositiveIntersection(
+      RaySphereAtAltitude(origin, direction, altitude));
+    return distance > 0.0f;
+  }
+
+  bool ResolveAtmosphereRayOrigin(
+    vec3 origin,
+    vec3 direction,
+    out vec3 atmosphereOrigin,
+    out float distanceToAtmosphere)
+  {
+    atmosphereOrigin = origin;
+    distanceToAtmosphere = 0.0f;
+    if(PlanetHeight(origin) >= 0.0f)
+    {
+      return true;
+    }
+
+    // World-space zero is only the atmosphere datum, not a hard limit on game
+    // coordinates. From below the datum, an outward ray enters the atmosphere
+    // at the positive surface exit. An inward ray cannot see the sky.
+    if(RadialMotion(origin, direction) < 0.0f)
+    {
+      return false;
+    }
+
+    const vec2 surfaceIntersections =
+      RaySphereAtAltitude(origin, direction, 0.0f);
+    const float surfaceExit = max(
+      surfaceIntersections.x,
+      surfaceIntersections.y);
+    if(surfaceExit < 0.0f)
+    {
+      return false;
+    }
+
+    distanceToAtmosphere = surfaceExit;
+    atmosphereOrigin = origin + direction * surfaceExit;
+    return true;
   }
   
   float Density(vec3 a, vec3 b, float H0)
@@ -275,14 +361,16 @@ glslFragment: |
       const float maxCast = atmosphereRadius * 10;
       float shift = min(maxCast, outer);
       
-      vec2 tmp = RaySphereAtAltitude(origin, direction, innerHeight);
-      float inner = NearestPositiveIntersection(tmp);
-      
-      if(inner > 0.0f)
+      float inner = -1.0f;
+      if(RayEntersAltitudeSphere(
+        origin,
+        direction,
+        innerHeight,
+        inner))
       {
           // The planet is opaque. Integrate only the atmosphere between the
           // observer and the first surface intersection.
-          shift = min(shift, inner);
+          shift = min(shift, max(inner, 0.0f));
       }
       return origin + direction * shift;
   }
@@ -327,6 +415,18 @@ glslFragment: |
   
   vec3 SkyLighting(vec3 origin, vec3 direction, vec3 lightDirection)
   {
+     vec3 atmosphereOrigin;
+     float distanceToAtmosphere;
+     if(!ResolveAtmosphereRayOrigin(
+       origin,
+       direction,
+       atmosphereOrigin,
+       distanceToAtmosphere))
+     {
+       return vec3(0.0f);
+     }
+
+     origin = atmosphereOrigin;
      const vec3 destination = IntersectSphere(origin, direction, 0.0f, atmosphereRadius);
      
      if(length(destination - origin) < 0.01)
@@ -381,16 +481,16 @@ glslFragment: |
          const vec3  toLight = IntersectSphere(point, -lightDirection, 0.0f, atmosphereRadius);
          const float hLight  = max(PlanetHeight(toLight), 0.0f);
          const float stepToLight = (hLight - h) / INTEGRAL_STEPS;
-         const vec2 planetToLightIntersection =
-           RaySphereAtAltitude(point, -lightDirection, 0.0f);
-         
          float dStepLight = length(toLight - point) / INTEGRAL_STEPS;
          float densityLightR = 0.0f;
          float densityLightMie = 0.0f;
 
-         bool bReached = max(
-           planetToLightIntersection.x,
-           planetToLightIntersection.y) < 0.0f;
+         float planetEntryDistance = -1.0f;
+         bool bReached = !RayEntersAltitudeSphere(
+           point,
+           -lightDirection,
+           0.0f,
+           planetEntryDistance);
          for(int j = 0; j < INTEGRAL_STEPS; j++)
          {
             const float h1 = h + stepToLight * j;
@@ -415,8 +515,12 @@ glslFragment: |
     
     #if defined(SUN)
     // Sun disk
-        vec2 intersection = RaySphereAtAltitude(origin, direction, 0.0f);
-        if(max(intersection.x, intersection.y) < 0.0f)
+        float planetEntryDistance = -1.0f;
+        if(!RayEntersAltitudeSphere(
+          origin,
+          direction,
+          0.0f,
+          planetEntryDistance))
         {
             const float t = (1 - pow((1 - theta)/(1-zeta), 2));
             const float attenuation = mix(0.83, 1.0f, t);
@@ -511,6 +615,21 @@ glslFragment: |
   {
     vec3 traceStart;
     vec3 traceEnd;
+    vec3 atmosphereOrigin;
+    float distanceToAtmosphere;
+    if(!ResolveAtmosphereRayOrigin(
+      origin,
+      viewDir,
+      atmosphereOrigin,
+      distanceToAtmosphere))
+    {
+      return vec4(0.0f);
+    }
+
+    origin = atmosphereOrigin;
+    maxTraceDistance = max(
+      maxTraceDistance - distanceToAtmosphere,
+      0.0f);
     const float originHeight = PlanetHeight(origin);
     
     // Trace inner and outer spheres
@@ -626,10 +745,14 @@ glslFragment: |
                 float m2 = exp(-dA[j] * data.cloudsAttenuation1 * sunDensity);
                 float m3 = data.cloudsAttenuation2 * density;
                 
-                vec2 intersections = RaySphereAtAltitude(localPosition, dirToSun, 0.0f);
-        
-                // No sun rays throw the Earth
-                if(max(intersections.x, intersections.y) < 0)
+                float planetEntryDistance = -1.0f;
+
+                // No sun rays through the Earth.
+                if(!RayEntersAltitudeSphere(
+                  localPosition,
+                  dirToSun,
+                  0.0f,
+                  planetEntryDistance))
                 {
                     colorLow += dB[j] * (m11 + m12) * m2 * m3 * transmittanceLow;
                 }
@@ -673,10 +796,9 @@ glslFragment: |
   {
     vec4 dirWorldSpace = vec4(0);
     
-    // The atmosphere uses a local tangent frame in meters. Its valid domain
-    // starts at sea level; an editor camera below it observes from the surface.
-    vec3 origin = frame.cameraPosition.xyz;
-    origin.y = max(origin.y, 0.0f);
+    // Keep the actual camera position. Atmospheric functions resolve a ray
+    // crossing the datum geometrically, including cameras below world y=0.
+    const vec3 origin = frame.cameraPosition.xyz;
     const vec3 dirToSun = normalize(-data.lightDirection.xyz);
     
     #if defined(COMPOSE)

--- a/Content/Shaders/Sky.shader.asset
+++ b/Content/Shaders/Sky.shader.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: "{3B69ADBF-0AB3-4557-8AE2-ED17838EC7EA}"
+fileId: 3B69ADBF-0AB3-4557-8AE2-ED17838EC7EA
 filename: Sky.shader

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -320,14 +320,15 @@ glslFragment: |
       return 1.0f;
     }
 
+    const vec3 shadowReceiverPosition = OffsetDirectionalShadowReceiver(
+      worldPosition,
+      surfaceNormal,
+      surfaceToLightDirection);
     const mat4 cascadeLightMatrix = lightsMatrices.instance[cascadeLayer];
     float shadow = CalculateDirectionalShadow(
-      light.shadowType,
+      GetDirectionalCascadeShadowType(light.shadowType, cascadeLayer),
       shadowMaps[cascadeLayer],
-      cascadeLightMatrix,
-      cascadeLightMatrix * vec4(worldPosition, 1.0f),
-      surfaceNormal,
-      surfaceToLightDirection,
+      cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f),
       cascadeLayer);
 
     const float cascadeBlend = CalculateCascadeBlend(
@@ -340,15 +341,19 @@ glslFragment: |
       const int nextCascadeLayer = cascadeLayer + 1;
       const mat4 nextCascadeLightMatrix = lightsMatrices.instance[nextCascadeLayer];
       const float nextShadow = CalculateDirectionalShadow(
-        light.shadowType,
+        GetDirectionalCascadeShadowType(light.shadowType, nextCascadeLayer),
         shadowMaps[nextCascadeLayer],
-        nextCascadeLightMatrix,
-        nextCascadeLightMatrix * vec4(worldPosition, 1.0f),
-        surfaceNormal,
-        surfaceToLightDirection,
+        nextCascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f),
         nextCascadeLayer);
       shadow = mix(shadow, nextShadow, cascadeBlend);
     }
+
+    const float shadowDistanceFade = CalculateShadowDistanceFade(
+      frame.view,
+      worldPosition,
+      frame.cameraZNearZFar,
+      cascadeLayer);
+    shadow = mix(shadow, 1.0f, shadowDistanceFade);
 
     return shadow;
   }

--- a/Content/Shaders/Standard.shader.asset
+++ b/Content/Shaders/Standard.shader.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: "{E42B1499-8C0C-47E3-9584-E7BB6CD821FC}"
+fileId: E42B1499-8C0C-47E3-9584-E7BB6CD821FC
 filename: Standard.shader

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -428,14 +428,15 @@ glslFragment: |
       return 1.0f;
     }
 
+    const vec3 shadowReceiverPosition = OffsetDirectionalShadowReceiver(
+      worldPosition,
+      surfaceNormal,
+      surfaceToLightDirection);
     const mat4 cascadeLightMatrix = lightsMatrices.instance[cascadeLayer];
     float shadow = CalculateDirectionalShadow(
-      light.shadowType,
+      GetDirectionalCascadeShadowType(light.shadowType, cascadeLayer),
       shadowMaps[cascadeLayer],
-      cascadeLightMatrix,
-      cascadeLightMatrix * vec4(worldPosition, 1.0f),
-      surfaceNormal,
-      surfaceToLightDirection,
+      cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f),
       cascadeLayer);
 
     const float cascadeBlend = CalculateCascadeBlend(
@@ -448,15 +449,19 @@ glslFragment: |
       const int nextCascadeLayer = cascadeLayer + 1;
       const mat4 nextCascadeLightMatrix = lightsMatrices.instance[nextCascadeLayer];
       const float nextShadow = CalculateDirectionalShadow(
-        light.shadowType,
+        GetDirectionalCascadeShadowType(light.shadowType, nextCascadeLayer),
         shadowMaps[nextCascadeLayer],
-        nextCascadeLightMatrix,
-        nextCascadeLightMatrix * vec4(worldPosition, 1.0f),
-        surfaceNormal,
-        surfaceToLightDirection,
+        nextCascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f),
         nextCascadeLayer);
       shadow = mix(shadow, nextShadow, cascadeBlend);
     }
+
+    const float shadowDistanceFade = CalculateShadowDistanceFade(
+      frame.view,
+      worldPosition,
+      frame.cameraZNearZFar,
+      cascadeLayer);
+    shadow = mix(shadow, 1.0f, shadowDistanceFade);
 
     return shadow;
   }

--- a/Content/Shaders/Standard_glTF.shader.asset
+++ b/Content/Shaders/Standard_glTF.shader.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: "{1A4BA353-FDA4-4F65-941F-D9FFEE4630A0}"
+fileId: 1A4BA353-FDA4-4F65-941F-D9FFEE4630A0
 filename: Standard_glTF.shader

--- a/Content/Shaders/Stars.shader
+++ b/Content/Shaders/Stars.shader
@@ -106,8 +106,9 @@ glslFragment: |
   {
     const float a = dot(direction, direction);
     const float halfB = dot(direction, origin) + earthRadius * direction.y;
-    const float c = dot(origin, origin) + 2.0f * earthRadius * origin.y -
-      altitude * (2.0f * earthRadius + altitude);
+    const float heightDelta = origin.y - altitude;
+    const float c = dot(origin.xz, origin.xz) +
+      heightDelta * (2.0f * earthRadius + origin.y + altitude);
     const float discriminant = halfB * halfB - a * c;
     if(discriminant < 0.0f)
     {
@@ -115,16 +116,69 @@ glslFragment: |
     }
 
     const float root = sqrt(discriminant);
-    const float inverseA = 1.0f / max(a, 0.000001f);
-    return vec2(
-      (-halfB - root) * inverseA,
-      (-halfB + root) * inverseA);
+    const float q = -halfB - (halfB >= 0.0f ? root : -root);
+    if(abs(q) <= 0.000001f)
+    {
+      const float repeatedRoot = -halfB / max(a, 0.000001f);
+      return vec2(repeatedRoot);
+    }
+
+    const float firstRoot = q / a;
+    const float secondRoot = c / q;
+    return firstRoot < secondRoot
+      ? vec2(firstRoot, secondRoot)
+      : vec2(secondRoot, firstRoot);
+  }
+
+  float PlanetHeight(vec3 position)
+  {
+    const float verticalRadius = earthRadius + position.y;
+    const float horizontalDistanceSquared = dot(position.xz, position.xz);
+    const float radialDistance = sqrt(
+      verticalRadius * verticalRadius + horizontalDistanceSquared);
+    return position.y + horizontalDistanceSquared /
+      max(radialDistance + verticalRadius, 1.0f);
+  }
+
+  float RadialMotion(vec3 position, vec3 direction)
+  {
+    return dot(direction, vec3(
+      position.x,
+      earthRadius + position.y,
+      position.z));
+  }
+
+  bool RayCanReachSky(vec3 origin, vec3 direction)
+  {
+    const float height = PlanetHeight(origin);
+    const float boundaryTolerance = 0.001f;
+    if(height < -boundaryTolerance)
+    {
+      if(RadialMotion(origin, direction) < 0.0f)
+      {
+        return false;
+      }
+
+      const vec2 intersections =
+        RaySphereAtAltitude(origin, direction, 0.0f);
+      return max(intersections.x, intersections.y) >= 0.0f;
+    }
+
+    if(abs(height) <= boundaryTolerance)
+    {
+      return RadialMotion(origin, direction) >= 0.0f;
+    }
+
+    const vec2 intersections =
+      RaySphereAtAltitude(origin, direction, 0.0f);
+    const bool entersPlanet =
+      intersections.x > 0.0f || intersections.y > 0.0f;
+    return !entersPlanet;
   }
   
   void main()
   { 
-    vec3 origin = frame.cameraPosition.xyz;
-    origin.y = max(origin.y, 0.0f);
+    const vec3 origin = frame.cameraPosition.xyz;
     vec2 viewportPos = gl_FragCoord.xy / vec2(frame.viewportSize);
     viewportPos.y = 1.0f - viewportPos.y;
     
@@ -138,8 +192,7 @@ glslFragment: |
 
     float clouds = texture(cloudsSampler, viewportPos).a;
 
-    vec2 intersection = RaySphereAtAltitude(origin, dirWorldSpace.xyz, 0.0f);
-    if(max(intersection.x, intersection.y) < 0.0f)
+    if(RayCanReachSky(origin, dirWorldSpace.xyz))
     {
         const float mask = clamp(1 - 1000 * clamp(length(viewportPos.xy - fragUV.xy), 0.0, 1), 0, 1);
         const vec3 dirToSun = normalize(-data.lightDirection.xyz);

--- a/Content/Shaders/Stars.shader.asset
+++ b/Content/Shaders/Stars.shader.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: "{6A7B8AC2-A515-40B8-A201-A8AA534F9710}"
+fileId: 6A7B8AC2-A515-40B8-A201-A8AA534F9710
 filename: Stars.shader

--- a/Editor.Tests/EngineLifecycleTests.cs
+++ b/Editor.Tests/EngineLifecycleTests.cs
@@ -29,6 +29,25 @@ public sealed class EngineLifecycleTests
     }
 
     [Fact]
+    public void EditorLauncher_PrefersTheCurrentMacCatalystRuntimeBundle()
+    {
+        var runEditor = ReadRepositoryFile("run_editor.py");
+
+        Assert.Contains(
+            "runtime = \"maccatalyst-arm64\" if platform.machine() == \"arm64\" else \"maccatalyst-x64\"",
+            runEditor,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "runtime_candidates = [candidate for candidate in candidates if runtime in candidate.parts]",
+            runEditor,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "if runtime_candidates:\n                candidates = runtime_candidates",
+            runEditor,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void EditorBundle_CompilesCriticalXamlEntryPoints()
     {
         var project = ReadRepositoryFile("Editor", "SailorEditor.csproj");

--- a/Editor.Tests/EngineProtocolClientTests.cs
+++ b/Editor.Tests/EngineProtocolClientTests.cs
@@ -618,9 +618,9 @@ public sealed class EngineProtocolClientTests
 
         await client.InitializeAsync(["SailorEditor"]);
         Assert.True(
-            await client.InstantiatePrefabFromYamlStrictAsync(
+            (await client.InstantiatePrefabFromYamlStrictAsync(
                 "prefab: undo",
-                string.Empty));
+                string.Empty)).Succeeded);
 
         Assert.Single(transport.InitializeRequests);
         Assert.Equal(
@@ -736,18 +736,22 @@ public sealed class EngineProtocolClientTests
             requests.Add(request);
             return Success(
                 request,
-                response => response.BoolResult =
-                    new BoolResult { Value = true });
+                response => response.InstanceIdResult =
+                    new InstanceIdResult
+                    {
+                        Succeeded = true,
+                        InstanceId = "created-root"
+                    });
         });
 
         Assert.True(
-            await client.InstantiatePrefabFromYamlAsync(
+            (await client.InstantiatePrefabFromYamlAsync(
                 "prefab: default",
-                string.Empty));
+                string.Empty)).Succeeded);
         Assert.True(
-            await client.InstantiatePrefabFromYamlStrictAsync(
+            (await client.InstantiatePrefabFromYamlStrictAsync(
                 "prefab: undo",
-                "parent"));
+                "parent")).Succeeded);
 
         Assert.Collection(
             requests,
@@ -801,17 +805,21 @@ public sealed class EngineProtocolClientTests
                 ProtocolRequest.CommandOneofCase.InstantiatePrefabFromYaml =>
                     Success(
                         request,
-                        response => response.BoolResult =
-                            new BoolResult { Value = true }),
+                        response => response.InstanceIdResult =
+                            new InstanceIdResult
+                            {
+                                Succeeded = true,
+                                InstanceId = "created-root"
+                            }),
                 _ => throw new InvalidOperationException(
                     $"Unexpected command {request.CommandCase}.")
             };
         });
 
         Assert.True(
-            await client.InstantiatePrefabFromYamlStrictAsync(
+            (await client.InstantiatePrefabFromYamlStrictAsync(
                 "prefab: undo",
-                "parent"));
+                "parent")).Succeeded);
 
         Assert.Collection(
             requests,
@@ -855,8 +863,12 @@ public sealed class EngineProtocolClientTests
                     }
                     else
                     {
-                        response.BoolResult =
-                            new BoolResult { Value = true };
+                        response.InstanceIdResult =
+                            new InstanceIdResult
+                            {
+                                Succeeded = true,
+                                InstanceId = "created-root"
+                            };
                     }
                 },
                 supportsStrictInstanceIds: false);
@@ -864,9 +876,9 @@ public sealed class EngineProtocolClientTests
 
         await client.InitializeAsync(["SailorEditor"]);
         Assert.True(
-            await client.InstantiatePrefabFromYamlAsync(
+            (await client.InstantiatePrefabFromYamlAsync(
                 "prefab: legacy",
-                string.Empty));
+                string.Empty)).Succeeded);
 
         var exception =
             await Assert.ThrowsAsync<EngineProtocolException>(
@@ -1394,8 +1406,12 @@ public sealed class EngineProtocolClientTests
                         }
                         else
                         {
-                            response.BoolResult =
-                                new BoolResult { Value = true };
+                            response.InstanceIdResult =
+                                new InstanceIdResult
+                                {
+                                    Succeeded = true,
+                                    InstanceId = "created-root"
+                                };
                         }
                     }).ToByteArray());
         }

--- a/Editor.Tests/HierarchyMutationRecoveryPolicyTests.cs
+++ b/Editor.Tests/HierarchyMutationRecoveryPolicyTests.cs
@@ -118,7 +118,8 @@ public sealed class HierarchyMutationRecoveryPolicyTests
     [Fact]
     public void LegacyInstantiateCall_WithThirdDefaultArgument_RemainsUnambiguous()
     {
-        Func<EngineProtocolClient, Task<bool>> compileLegacyCall =
+        Func<EngineProtocolClient, Task<EngineProtocolCreationResult>>
+            compileLegacyCall =
             client => client.InstantiatePrefabFromYamlAsync(
                 "prefab: {}",
                 string.Empty,

--- a/Editor.Tests/McpLandscapeContractTests.cs
+++ b/Editor.Tests/McpLandscapeContractTests.cs
@@ -79,7 +79,10 @@ public sealed class McpLandscapeContractTests
         Assert.Contains("\"Collider radius\"", source, StringComparison.Ordinal);
         Assert.DoesNotContain("GetOrCreateLandscapeFloatList", source, StringComparison.Ordinal);
         var component = ReadRepositoryFile("Editor", "ViewModels", "Component.cs");
-        Assert.DoesNotContain("AddMissingLandscapeVegetationProperties", component, StringComparison.Ordinal);
+        Assert.Contains("AddMissingLandscapeVegetationProperties", component, StringComparison.Ordinal);
+        Assert.Contains("new Observable<FileId>(new FileId())", component, StringComparison.Ordinal);
+        Assert.Contains("new ObservableFileIdList()", component, StringComparison.Ordinal);
+        Assert.Contains("vegetationCullDistance", component, StringComparison.Ordinal);
         Assert.Contains("Import landscape heightmap", source, StringComparison.Ordinal);
         Assert.Contains("Import Material Masks", source, StringComparison.Ordinal);
         Assert.Contains("RebuildLandscapeAsync(component, advanceSeed: true)", source, StringComparison.Ordinal);
@@ -112,15 +115,10 @@ public sealed class McpLandscapeContractTests
         var source = ReadRepositoryFile("Runtime", "ECS", "LandscapeECS.cpp");
 
         Assert.Contains("models.Num()", source, StringComparison.Ordinal);
-        Assert.Contains("LoadDefaultMaterials(", source, StringComparison.Ordinal);
-        Assert.Contains("profile.m_modelFileId, profile.m_modelMaterials", source, StringComparison.Ordinal);
+        Assert.Contains("LoadDefaultMaterials(profile.m_modelFileId", source, StringComparison.Ordinal);
         Assert.Contains("ResolveMaterialIndex(", source, StringComparison.Ordinal);
         Assert.Contains("vegetationMaterials[meshIndex]", source, StringComparison.Ordinal);
         Assert.DoesNotContain("!profile.m_modelFileId || !profile.m_materialFileId", source, StringComparison.Ordinal);
-        Assert.DoesNotContain("m_buildRevision", source, StringComparison.Ordinal);
-        Assert.DoesNotContain("revision %", source, StringComparison.Ordinal);
-        var header = ReadRepositoryFile("Runtime", "ECS", "LandscapeECS.h");
-        Assert.DoesNotContain("m_buildRevision", header, StringComparison.Ordinal);
     }
 
     static string ReadRepositoryFile(params string[] relativePath)

--- a/Editor.Tests/WorkflowProjectionTests.cs
+++ b/Editor.Tests/WorkflowProjectionTests.cs
@@ -1304,7 +1304,9 @@ public sealed class WorkflowProjectionTests
             "linkedPrefab->ConfigureLinkedInstance(",
             "linkedPrefab->AppendDetachedSupplementalHierarchy(",
             "prefab = std::move(linkedPrefab);",
-            "return editor->InstantiatePrefab(");
+            "const bool bInstantiated = editor->InstantiatePrefab(",
+            "SetInteropString(",
+            "return bInstantiated;");
         AssertInOrder(
             instantiate,
             "if (prefab->m_bLinkedPrefabSnapshotRecord)",
@@ -1904,6 +1906,56 @@ public sealed class WorkflowProjectionTests
                 "public IEnumerable<GameObject> EnumerateSubHierarchy("),
             "owner.NotifyComponentsChanged();",
             "PublishCurrentWorld();");
+    }
+
+    [Fact]
+    public void HierarchyClipboard_DuplicatesSubtreesThroughUndoableNativeInstantiation()
+    {
+        var hierarchySource = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "HierarchyView.xaml.cs");
+        var clipboardSource = ReadRepositoryFile(
+            "Editor",
+            "Services",
+            "GameObjectClipboardService.cs");
+        var commandSource = ReadRepositoryFile(
+            "Editor",
+            "Commands",
+            "EditorWorldCommands.cs");
+        var worldSource = ReadRepositoryFile(
+            "Runtime",
+            "Engine",
+            "World.cpp");
+
+        Assert.Contains("Text = \"Duplicate\"", hierarchySource, StringComparison.Ordinal);
+        Assert.Contains("CreateKeyboardAccelerators(\"C\")", hierarchySource, StringComparison.Ordinal);
+        Assert.Contains("CreateKeyboardAccelerators(\"V\")", hierarchySource, StringComparison.Ordinal);
+        Assert.Contains("KeyboardAcceleratorModifiers.Ctrl", hierarchySource, StringComparison.Ordinal);
+        Assert.Contains("KeyboardAcceleratorModifiers.Cmd", hierarchySource, StringComparison.Ordinal);
+        Assert.Contains("CreatePrefabFromSubHierarchy", clipboardSource, StringComparison.Ordinal);
+        Assert.Contains("new DuplicateGameObjectCommand(", clipboardSource, StringComparison.Ordinal);
+
+        var duplicateCommand = Slice(
+            commandSource,
+            "public sealed class DuplicateGameObjectCommand",
+            "sealed class CreatedHierarchySnapshot");
+        Assert.Contains(": IUndoableEditorCommand", duplicateCommand, StringComparison.Ordinal);
+        Assert.Contains("InstantiatePrefabFromYamlAsync(", duplicateCommand, StringComparison.Ordinal);
+        Assert.Contains("_state.UndoAsync", duplicateCommand, StringComparison.Ordinal);
+
+        var forcedInstantiation = Slice(
+            worldSource,
+            "GameObjectPtr World::Instantiate(\n\tPrefabPtr prefab,\n\tbool bStrictInstanceIds,",
+            "GameObjectPtr World::Instantiate(const std::string& name)");
+        AssertInOrder(
+            forcedInstantiation,
+            "bForceNewInstanceIds ||",
+            "internalDependencies[oldInstanceId] = newComponent;",
+            "internalDependencies[prefab->m_gameObjects[j].m_instanceId] = gameObject;",
+            "TMap<InstanceId, ObjectPtr> resolveContext = m_objectsMap;",
+            "resolveContext[dependency.m_first] = *dependency.m_second;",
+            "newComp->ResolveRefs(");
     }
 
     static void AssertCommitClearsDirtyBeforeDispatch(string source)

--- a/Editor/Commands/EditorWorldCommands.cs
+++ b/Editor/Commands/EditorWorldCommands.cs
@@ -259,6 +259,64 @@ public sealed class CreateGameObjectCommand(InstanceId? parentId = null) : IUndo
     }
 }
 
+public sealed class DuplicateGameObjectCommand : IUndoableEditorCommand
+{
+    readonly string _prefabYaml;
+    readonly string _description;
+    readonly CreatedHierarchyCommandState _state;
+
+    public DuplicateGameObjectCommand(GameObject source)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var world = MauiProgram.GetService<WorldService>();
+        var prefab = world.CreatePrefabFromSubHierarchy(source, out _);
+        _prefabYaml = EditorYaml.SerializePrefab(prefab);
+        _description = $"Duplicate {source.Name}";
+        _state = new CreatedHierarchyCommandState(
+            world.ResolveParentInstanceId(source));
+    }
+
+    public DuplicateGameObjectCommand(
+        string prefabYaml,
+        InstanceId? parentId,
+        string description = "Paste GameObject")
+    {
+        if (string.IsNullOrWhiteSpace(prefabYaml))
+        {
+            throw new ArgumentException(
+                "Prefab YAML cannot be empty.",
+                nameof(prefabYaml));
+        }
+
+        _prefabYaml = prefabYaml;
+        _description = description;
+        _state = new CreatedHierarchyCommandState(parentId);
+    }
+
+    public string Name => nameof(DuplicateGameObjectCommand);
+    public string Description => _description;
+    public IHistoryMergePolicy? MergePolicy => null;
+    public bool CanExecute(ActionContext context) =>
+        !string.IsNullOrWhiteSpace(_prefabYaml);
+
+    public Task<CommandResult> ExecuteAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+        => _state.ExecuteAsync(
+            () => MauiProgram.GetService<EngineService>()
+                .InstantiatePrefabFromYamlAsync(
+                    _prefabYaml,
+                    _state.ParentId,
+                    CancellationToken.None),
+            "Duplicate GameObject failed",
+            cancellationToken);
+
+    public ValueTask<CommandResult> UndoAsync(
+        ActionContext context,
+        CancellationToken cancellationToken = default)
+        => _state.UndoAsync(cancellationToken);
+}
+
 sealed class CreatedHierarchySnapshot
 {
     readonly HashSet<string> _gameObjectIds;
@@ -672,13 +730,15 @@ static class StrictHierarchyRestore
         string? requestDiagnostic = null;
         try
         {
-            response =
+            var restoredRootId =
                 await engine.RequestInstantiatePrefabFromYamlStrictAsync(
                     snapshot.PrefabYaml,
                     parentId,
-                    CancellationToken.None)
-                ? EngineMutationResponseState.Accepted
-                : EngineMutationResponseState.Rejected;
+                    CancellationToken.None);
+            response = restoredRootId is not null &&
+                restoredRootId.Equals(snapshot.RootInstanceId)
+                    ? EngineMutationResponseState.Accepted
+                    : EngineMutationResponseState.Rejected;
         }
         catch (Exception exception)
         {
@@ -851,6 +911,8 @@ sealed class CreatedHierarchyCommandState(
         ? null
         : new FileId(prefabLinkFileId.Value);
     CreatedHierarchySnapshot? _snapshot;
+
+    public InstanceId? ParentId => _parentId;
 
     public async Task<CommandResult> ExecuteAsync(
         Func<Task<InstanceId?>> createAsync,

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -56,6 +56,7 @@ namespace SailorEditor
             builder.Services.AddSingleton<EditorToolbarActions>();
             builder.Services.AddSingleton<EditorContextMenuService>();
             builder.Services.AddSingleton<ComponentClipboardService>();
+            builder.Services.AddSingleton<GameObjectClipboardService>();
             builder.Services.AddSingleton<AssetFingerprintService>();
             builder.Services.AddSingleton<WorkspaceManifestSerializer>();
             builder.Services.AddSingleton<WorkspaceGeneratedProjectStateService>();

--- a/Editor/Mcp/McpLandscapeOperations.cs
+++ b/Editor/Mcp/McpLandscapeOperations.cs
@@ -220,6 +220,7 @@ internal sealed class McpLandscapeOperations
             ["vegetationColliderHeight"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.ColliderHeight)),
             ["vegetationColliderOffsetY"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.ColliderOffsetY)),
             ["regenerate"] = JsonSerializer.SerializeToElement(false),
+            ["flatten"] = JsonSerializer.SerializeToElement(false),
         };
 
         if (string.IsNullOrWhiteSpace(request.TargetComponentId))

--- a/Editor/Protocol/EngineProtocolClient.cs
+++ b/Editor/Protocol/EngineProtocolClient.cs
@@ -1057,7 +1057,7 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
             ValidateTransformSpace(result.Space));
     }
 
-    public Task<bool> InstantiatePrefabFromYamlAsync(
+    public Task<EngineProtocolCreationResult> InstantiatePrefabFromYamlAsync(
         string prefabYaml,
         string parentInstanceId,
         CancellationToken cancellationToken = default)
@@ -1068,7 +1068,7 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
             protocolVersion: ProtocolVersion,
             cancellationToken: cancellationToken);
 
-    public async Task<bool> InstantiatePrefabFromYamlStrictAsync(
+    public async Task<EngineProtocolCreationResult> InstantiatePrefabFromYamlStrictAsync(
         string prefabYaml,
         string parentInstanceId,
         CancellationToken cancellationToken = default)
@@ -1095,13 +1095,13 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
             .ConfigureAwait(false);
     }
 
-    async Task<bool> InstantiatePrefabFromYamlCoreAsync(
+    async Task<EngineProtocolCreationResult> InstantiatePrefabFromYamlCoreAsync(
         string prefabYaml,
         string parentInstanceId,
         bool strictInstanceIds,
         uint protocolVersion,
         CancellationToken cancellationToken)
-        => ReadBool(
+        => ReadCreation(
             await SendAsync(
                     new ProtocolRequest
                     {

--- a/Editor/Services/EditorContextMenuService.cs
+++ b/Editor/Services/EditorContextMenuService.cs
@@ -9,6 +9,7 @@ public class EditorContextMenuItem
     public object CommandParameter { get; init; }
     public bool IsEnabled { get; init; } = true;
     public bool IsDestructive { get; init; } = false;
+    public IReadOnlyList<KeyboardAccelerator> KeyboardAccelerators { get; init; } = [];
 }
 
 public class EditorContextMenuService
@@ -18,13 +19,19 @@ public class EditorContextMenuService
         var flyout = new MenuFlyout();
         foreach (var item in items.Where(item => item != null))
         {
-            flyout.Add(new MenuFlyoutItem
+            var flyoutItem = new MenuFlyoutItem
             {
                 Text = item.Text,
                 Command = item.Command,
                 CommandParameter = item.CommandParameter,
                 IsEnabled = item.IsEnabled
-            });
+            };
+            foreach (var accelerator in item.KeyboardAccelerators)
+            {
+                flyoutItem.KeyboardAccelerators.Add(accelerator);
+            }
+
+            flyout.Add(flyoutItem);
         }
 
         return flyout;

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -3029,79 +3029,62 @@ namespace SailorEditor.Services
                     $"Unsupported viewport transform space '{space}'.")
             };
 
-        public Task<bool> InstantiatePrefabFromYamlAsync(
+        public Task<InstanceId?> InstantiatePrefabFromYamlAsync(
             string prefabYaml,
             InstanceId? parentId = null,
             CancellationToken cancellationToken = default)
-            => InstantiatePrefabFromYamlCoreAsync(
-                prefabYaml,
-                parentId,
-                cancellationToken);
-
-        public async Task<bool> InstantiatePrefabFromYamlStrictAsync(
-            string prefabYaml,
-            InstanceId? parentId,
-            CancellationToken cancellationToken = default)
         {
-            var result =
-                await RequestInstantiatePrefabFromYamlStrictAsync(
-                    prefabYaml,
-                    parentId,
-                    cancellationToken).ConfigureAwait(false);
-
-            if (result)
+            if (string.IsNullOrWhiteSpace(prefabYaml))
             {
-                await RefreshCurrentWorldAsync(
-                    cancellationToken).ConfigureAwait(false);
+                return Task.FromResult<InstanceId?>(null);
             }
 
-            return result;
+            return InvokeCreationInteropAsync(
+                token => protocolClient.InstantiatePrefabFromYamlAsync(
+                    prefabYaml,
+                    parentId?.Value ?? string.Empty,
+                    token),
+                refreshWorld: true,
+                cancellationToken);
         }
 
-        internal Task<bool> RequestInstantiatePrefabFromYamlStrictAsync(
+        public Task<InstanceId?> InstantiatePrefabFromYamlStrictAsync(
             string prefabYaml,
             InstanceId? parentId,
             CancellationToken cancellationToken = default)
         {
             if (string.IsNullOrWhiteSpace(prefabYaml))
             {
-                return Task.FromResult(false);
+                return Task.FromResult<InstanceId?>(null);
+            }
+
+            return InvokeCreationInteropAsync(
+                token => protocolClient.InstantiatePrefabFromYamlStrictAsync(
+                    prefabYaml,
+                    parentId?.Value ?? string.Empty,
+                    token),
+                refreshWorld: true,
+                cancellationToken);
+        }
+
+        internal Task<InstanceId?> RequestInstantiatePrefabFromYamlStrictAsync(
+            string prefabYaml,
+            InstanceId? parentId,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(prefabYaml))
+            {
+                return Task.FromResult<InstanceId?>(null);
             }
 
             var stringParentId = parentId?.Value ?? string.Empty;
-            return InvokeRunningInteropAsync(
+            return InvokeCreationInteropAsync(
                 token => protocolClient.InstantiatePrefabFromYamlStrictAsync(
                     prefabYaml,
                     stringParentId,
                     token),
-                cancellationToken: cancellationToken);
-        }
-
-        async Task<bool> InstantiatePrefabFromYamlCoreAsync(
-            string prefabYaml,
-            InstanceId? parentId,
-            CancellationToken cancellationToken)
-        {
-            if (string.IsNullOrWhiteSpace(prefabYaml))
-            {
-                return false;
-            }
-
-            var stringParentId = parentId?.Value ?? string.Empty;
-            var result = await InvokeRunningInteropAsync(
-                token => protocolClient.InstantiatePrefabFromYamlAsync(
-                    prefabYaml,
-                    stringParentId,
-                    token),
-                cancellationToken: cancellationToken).ConfigureAwait(false);
-
-            if (result)
-            {
-                await RefreshCurrentWorldAsync(
-                    cancellationToken).ConfigureAwait(false);
-            }
-
-            return result;
+                refreshWorld: false,
+                cancellationToken);
         }
 
         public async Task<bool> LoadWorldAsync(

--- a/Editor/Services/GameObjectClipboardService.cs
+++ b/Editor/Services/GameObjectClipboardService.cs
@@ -1,0 +1,185 @@
+using SailorEditor.Commands;
+using SailorEditor.History;
+using SailorEditor.Shell;
+using SailorEditor.ViewModels;
+using SailorEngine;
+using System.Text;
+
+namespace SailorEditor.Services;
+
+internal sealed record GameObjectClipboardPayload(
+    string PrefabYaml,
+    string? ParentInstanceId);
+
+internal static class GameObjectClipboardCodec
+{
+    const string Header = "SailorEditor.GameObject/1";
+
+    public static string Encode(GameObjectClipboardPayload payload)
+    {
+        ArgumentNullException.ThrowIfNull(payload);
+        var parent = payload.ParentInstanceId ?? string.Empty;
+        var yaml = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes(payload.PrefabYaml));
+        return $"{Header}\n{parent}\n{yaml}";
+    }
+
+    public static bool TryDecode(
+        string? text,
+        out GameObjectClipboardPayload? payload)
+    {
+        payload = null;
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            return false;
+        }
+
+        var parts = text.Split('\n', 3);
+        if (parts.Length != 3 ||
+            !string.Equals(parts[0], Header, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        try
+        {
+            var prefabYaml = Encoding.UTF8.GetString(
+                Convert.FromBase64String(parts[2]));
+            if (string.IsNullOrWhiteSpace(prefabYaml))
+            {
+                return false;
+            }
+
+            payload = new GameObjectClipboardPayload(
+                prefabYaml,
+                string.IsNullOrWhiteSpace(parts[1]) ? null : parts[1]);
+            return true;
+        }
+        catch (FormatException)
+        {
+            return false;
+        }
+    }
+}
+
+internal sealed class GameObjectClipboardService
+{
+    string? copiedPayload;
+
+    public async Task CopyAsync(
+        GameObject gameObject,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(gameObject);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var world = MauiProgram.GetService<WorldService>();
+        var prefab = world.CreatePrefabFromSubHierarchy(
+            gameObject,
+            out _);
+        copiedPayload = GameObjectClipboardCodec.Encode(
+            new GameObjectClipboardPayload(
+                EditorYaml.SerializePrefab(prefab),
+                world.ResolveParentInstanceId(gameObject)?.Value));
+
+        try
+        {
+            await Clipboard.Default.SetTextAsync(copiedPayload);
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"Could not publish GameObject to the system clipboard: {exception}");
+        }
+
+        MauiProgram.GetService<EditorShellHost>()
+            .SetStatus($"Copied {gameObject.Name}");
+    }
+
+    public async Task PasteAsync(
+        CancellationToken cancellationToken = default)
+    {
+        string? systemClipboardText = null;
+        try
+        {
+            systemClipboardText = await Clipboard.Default.GetTextAsync();
+        }
+        catch (Exception exception)
+        {
+            Console.Error.WriteLine(
+                $"Could not read the system clipboard: {exception}");
+        }
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var decoded = GameObjectClipboardCodec.TryDecode(
+            systemClipboardText,
+            out var payload);
+        if (!decoded)
+        {
+            decoded = GameObjectClipboardCodec.TryDecode(
+                copiedPayload,
+                out payload);
+        }
+
+        if (!decoded || payload is null)
+        {
+            throw new InvalidDataException(
+                "The clipboard does not contain a Sailor GameObject.");
+        }
+
+        var world = MauiProgram.GetService<WorldService>();
+        InstanceId? parentId = null;
+        if (!string.IsNullOrWhiteSpace(payload.ParentInstanceId))
+        {
+            var candidate = new InstanceId(payload.ParentInstanceId);
+            if (world.TryGetGameObject(candidate, out _))
+            {
+                parentId = candidate;
+            }
+        }
+
+        var result = await MauiProgram.GetService<ICommandDispatcher>()
+            .DispatchAsync(
+                new DuplicateGameObjectCommand(
+                    payload.PrefabYaml,
+                    parentId),
+                MauiProgram.GetService<IActionContextProvider>()
+                    .GetCurrentContext(
+                        new CommandOrigin(
+                            CommandOriginKind.Menu,
+                            nameof(GameObjectClipboardService))),
+                cancellationToken);
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException(
+                result.Message ?? "Paste GameObject failed.");
+        }
+
+        MauiProgram.GetService<EditorShellHost>()
+            .SetStatus("Pasted GameObject");
+    }
+
+    public async Task DuplicateAsync(
+        GameObject gameObject,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(gameObject);
+        var result = await MauiProgram.GetService<ICommandDispatcher>()
+            .DispatchAsync(
+                new DuplicateGameObjectCommand(gameObject),
+                MauiProgram.GetService<IActionContextProvider>()
+                    .GetCurrentContext(
+                        new CommandOrigin(
+                            CommandOriginKind.Menu,
+                            nameof(GameObjectClipboardService))),
+                cancellationToken);
+        if (!result.Succeeded)
+        {
+            throw new InvalidOperationException(
+                result.Message ?? "Duplicate GameObject failed.");
+        }
+
+        MauiProgram.GetService<EditorShellHost>()
+            .SetStatus($"Duplicated {gameObject.Name}");
+    }
+}

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -276,7 +276,68 @@ public class ComponentYamlConverter : IYamlTypeConverter
             component.OverrideProperties[property.Key] = value;
         }
 
+        AddMissingLandscapeVegetationProperties(component, document.Typename);
+
         return component;
+    }
+
+    static void AddMissingLandscapeVegetationProperties(
+        Component component,
+        string componentTypeName)
+    {
+        if (!string.Equals(
+                componentTypeName,
+                "Sailor::LandscapeComponent",
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        if (component.Typename.Properties.ContainsKey("heightmapTexture") &&
+            !component.OverrideProperties.ContainsKey("heightmapTexture"))
+        {
+            component.OverrideProperties["heightmapTexture"] =
+                new Observable<FileId>(new FileId());
+        }
+
+        if (component.Typename.Properties.ContainsKey("materialMasks") &&
+            !component.OverrideProperties.ContainsKey("materialMasks"))
+        {
+            component.OverrideProperties["materialMasks"] = new ObservableFileIdList();
+        }
+
+        if (!component.OverrideProperties.TryGetValue(
+                "vegetationModels",
+                out var modelsProperty) ||
+            modelsProperty is not ObservableFileIdList models)
+        {
+            return;
+        }
+
+        (string Name, float DefaultValue)[] properties =
+        [
+            ("vegetationMeshIndex", -1.0f),
+            ("vegetationMinLod", 0.0f),
+            ("vegetationMaxLod", 2.0f),
+            ("vegetationLod1ScreenCoverage", 0.25f),
+            ("vegetationLod2ScreenCoverage", 0.05f),
+            ("vegetationCullDistance", 120.0f),
+            ("vegetationColliderRadius", 0.0f),
+            ("vegetationColliderHeight", 2.0f),
+            ("vegetationColliderOffsetY", 1.0f)
+        ];
+
+        foreach (var property in properties)
+        {
+            if (!component.Typename.Properties.ContainsKey(property.Name) ||
+                component.OverrideProperties.ContainsKey(property.Name))
+            {
+                continue;
+            }
+
+            component.OverrideProperties[property.Name] = new ObservableFloatList(
+                Enumerable.Repeat(property.DefaultValue, models.Values.Count));
+        }
     }
 
     static string ParseEnumOverride(

--- a/Editor/Views/HierarchyView.xaml.cs
+++ b/Editor/Views/HierarchyView.xaml.cs
@@ -19,6 +19,7 @@ namespace SailorEditor.Views
         readonly WorldService service;
         readonly HierarchyProjectionService projectionService;
         readonly InspectorPendingEditCoordinator inspectorPendingEditCoordinator;
+        readonly GameObjectClipboardService gameObjectClipboardService;
         readonly ObservableCollection<HierarchyListRow> visibleRows = [];
         readonly Dictionary<string, GameObject> gameObjectsById = new(StringComparer.Ordinal);
         bool suppressSelectionChanged;
@@ -32,6 +33,8 @@ namespace SailorEditor.Views
             projectionService = MauiProgram.GetService<HierarchyProjectionService>();
             inspectorPendingEditCoordinator =
                 MauiProgram.GetService<InspectorPendingEditCoordinator>();
+            gameObjectClipboardService =
+                MauiProgram.GetService<GameObjectClipboardService>();
 
             HierarchyList.ItemsSource = visibleRows;
             HierarchyList.SelectionChanged += OnHierarchySelectionChanged;
@@ -416,13 +419,30 @@ namespace SailorEditor.Views
             var contextMenu = MauiProgram.GetService<EditorContextMenuService>();
             if (gameObject == null)
             {
-                return contextMenu.CreateFlyout(new EditorContextMenuItem
-                {
-                    Text = "New GameObject",
-                    Command = CreateContextMenuCommand(
-                        () => service.CreateGameObjectAsync(),
-                        "Create GameObject")
-                });
+                return contextMenu.CreateFlyout(
+                    new EditorContextMenuItem
+                    {
+                        Text = "New GameObject",
+                        Command = CreateContextMenuCommand(
+                            () => service.CreateGameObjectAsync(),
+                            "Create GameObject")
+                    },
+                    new EditorContextMenuItem
+                    {
+                        Text = "Copy",
+                        KeyboardAccelerators = CreateKeyboardAccelerators("C"),
+                        Command = CreateContextMenuCommand(
+                            CopySelectedGameObjectAsync,
+                            "Copy GameObject")
+                    },
+                    new EditorContextMenuItem
+                    {
+                        Text = "Paste",
+                        KeyboardAccelerators = CreateKeyboardAccelerators("V"),
+                        Command = CreateContextMenuCommand(
+                            PasteGameObjectAsync,
+                            "Paste GameObject")
+                    });
             }
 
             var items = new List<EditorContextMenuItem>
@@ -440,6 +460,13 @@ namespace SailorEditor.Views
                     Command = CreateContextMenuCommand(
                         () => RenameGameObject(gameObject),
                         "Rename GameObject")
+                },
+                new EditorContextMenuItem
+                {
+                    Text = "Duplicate",
+                    Command = CreateContextMenuCommand(
+                        () => DuplicateGameObjectAsync(gameObject),
+                        "Duplicate GameObject")
                 },
                 new EditorContextMenuItem
                 {
@@ -489,6 +516,70 @@ namespace SailorEditor.Views
             }
 
             return contextMenu.CreateFlyout([.. items]);
+        }
+
+        static IReadOnlyList<KeyboardAccelerator> CreateKeyboardAccelerators(
+            string key)
+            =>
+            [
+                new KeyboardAccelerator
+                {
+                    Key = key,
+                    Modifiers = KeyboardAcceleratorModifiers.Ctrl
+                },
+                new KeyboardAccelerator
+                {
+                    Key = key,
+                    Modifiers = KeyboardAcceleratorModifiers.Cmd
+                }
+            ];
+
+        GameObject? GetSelectedGameObject()
+        {
+            if (HierarchyList.SelectedItem is not HierarchyListRow row)
+            {
+                return null;
+            }
+
+            return gameObjectsById.TryGetValue(
+                row.InstanceId,
+                out var gameObject)
+                ? gameObject
+                : null;
+        }
+
+        async Task CommitPendingInspectorChangesAsync()
+        {
+            if (!await inspectorPendingEditCoordinator
+                    .CommitPendingChangesAsync())
+            {
+                throw new InvalidOperationException(
+                    "Pending Inspector changes could not be committed.");
+            }
+        }
+
+        async Task CopySelectedGameObjectAsync()
+        {
+            var gameObject = GetSelectedGameObject();
+            if (gameObject is null)
+            {
+                return;
+            }
+
+            await CommitPendingInspectorChangesAsync();
+            await gameObjectClipboardService.CopyAsync(gameObject);
+        }
+
+        async Task PasteGameObjectAsync()
+        {
+            await CommitPendingInspectorChangesAsync();
+            await gameObjectClipboardService.PasteAsync();
+        }
+
+        async Task DuplicateGameObjectAsync(GameObject gameObject)
+        {
+            await CommitPendingInspectorChangesAsync();
+            await gameObjectClipboardService.DuplicateAsync(gameObject);
         }
 
         static Command CreateContextMenuCommand(

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -378,7 +378,7 @@ public partial class ComponentTemplate : DataTemplate
                     "vegetationLod1ScreenCoverage" or "vegetationLod2ScreenCoverage" or
                     "vegetationCullDistance" or "vegetationColliderRadius" or
                     "vegetationColliderHeight" or "vegetationColliderOffsetY" or
-                    "regenerate")
+                    "regenerate" or "flatten")
                 {
                     continue;
                 }

--- a/Lib/EditorEngineProtocol.cpp
+++ b/Lib/EditorEngineProtocol.cpp
@@ -1302,12 +1302,17 @@ namespace
 		case ProtocolRequest::kInstantiatePrefabFromYaml:
 		{
 			const auto& instantiate = request.instantiate_prefab_from_yaml();
-			SetBoolResult(
-				response,
+			TInteropString instanceId;
+			const bool bSucceeded =
 				Sailor::App::InstantiateEditorPrefabFromYaml(
 					instantiate.prefab_yaml().c_str(),
 					instantiate.parent_instance_id().c_str(),
-					instantiate.strict_instance_ids()));
+					instantiate.strict_instance_ids(),
+					instanceId.GetOutput());
+			SetInstanceIdResult(
+				response,
+				bSucceeded,
+				instanceId.GetValue());
 			break;
 		}
 

--- a/Runtime/Components/CollisionShapeComponent.cpp
+++ b/Runtime/Components/CollisionShapeComponent.cpp
@@ -1,10 +1,77 @@
 #include "Components/CollisionShapeComponent.h"
 #include "Components/RigidBodyComponent.h"
+#include "ECS/TransformECS.h"
 #include "Engine/GameObject.h"
 #include "Math/Math.h"
+#include "RHI/DebugContext.h"
 #include <algorithm>
+#include <cmath>
 
 using namespace Sailor;
+
+namespace
+{
+	struct WorldShape final
+	{
+		glm::vec3 m_center{};
+		glm::quat m_rotation = glm::identity<glm::quat>();
+		glm::vec3 m_scale = glm::vec3(1.0f);
+	};
+
+	WorldShape ResolveWorldShape(
+		const glm::mat4& ownerWorldMatrix,
+		const Physics::CollisionShapeDesc& shape)
+	{
+		const Math::Transform ownerTransform =
+			Math::Transform::FromMatrix(ownerWorldMatrix);
+		const glm::vec3 ownerScale(ownerTransform.m_scale);
+		WorldShape result{};
+		result.m_center = glm::vec3(ownerTransform.m_position) +
+			ownerTransform.m_rotation * (shape.m_center * ownerScale);
+		result.m_rotation = glm::normalize(
+			ownerTransform.m_rotation * shape.m_rotation);
+		result.m_scale = glm::max(
+			glm::abs(ownerScale),
+			glm::vec3(0.001f));
+		return result;
+	}
+
+	glm::vec3 ResolveOrientedExtent(
+		const glm::quat& rotation,
+		const glm::vec3& halfExtent)
+	{
+		return glm::abs(rotation * Math::vec3_Right) * halfExtent.x +
+			glm::abs(rotation * Math::vec3_Up) * halfExtent.y +
+			glm::abs(rotation * Math::vec3_Forward) * halfExtent.z;
+	}
+
+	void DrawOrientedBox(
+		RHI::DebugContext& debugContext,
+		const glm::vec3& center,
+		const glm::quat& rotation,
+		const glm::vec3& halfExtent,
+		const glm::vec4& color)
+	{
+		glm::vec3 corners[8];
+		for (uint32_t i = 0; i < 8; ++i)
+		{
+			const glm::vec3 local(
+				(i & 1u) != 0u ? halfExtent.x : -halfExtent.x,
+				(i & 2u) != 0u ? halfExtent.y : -halfExtent.y,
+				(i & 4u) != 0u ? halfExtent.z : -halfExtent.z);
+			corners[i] = center + rotation * local;
+		}
+
+		constexpr uint32_t edges[][2] = {
+			{ 0, 1 }, { 0, 2 }, { 0, 4 }, { 1, 3 }, { 1, 5 }, { 2, 3 },
+			{ 2, 6 }, { 3, 7 }, { 4, 5 }, { 4, 6 }, { 5, 7 }, { 6, 7 }
+		};
+		for (const auto& edge : edges)
+		{
+			debugContext.DrawLine(corners[edge[0]], corners[edge[1]], color);
+		}
+	}
+}
 
 void CollisionShapeComponent::Initialize()
 {
@@ -142,4 +209,120 @@ Physics::CollisionShapeDesc CollisionShapeComponent::BuildDesc() const
 	result.m_radius = m_radius;
 	result.m_height = m_height;
 	return result;
+}
+
+bool CollisionShapeComponent::TryGetWorldBounds(
+	const glm::mat4& ownerWorldMatrix,
+	Math::AABB& outBounds) const
+{
+	outBounds = {};
+	const Physics::CollisionShapeDesc shape = BuildDesc();
+	const WorldShape worldShape = ResolveWorldShape(ownerWorldMatrix, shape);
+
+	switch (shape.m_type)
+	{
+	case Physics::ECollisionShapeType::Box:
+	{
+		const glm::vec3 halfExtent =
+			glm::abs(shape.m_size) * worldShape.m_scale * 0.5f;
+		const glm::vec3 worldExtent = ResolveOrientedExtent(
+			worldShape.m_rotation,
+			halfExtent);
+		outBounds = Math::AABB(worldShape.m_center, worldExtent);
+		break;
+	}
+	case Physics::ECollisionShapeType::Sphere:
+	{
+		const float radius = std::abs(shape.m_radius) * std::max({
+			worldShape.m_scale.x,
+			worldShape.m_scale.y,
+			worldShape.m_scale.z });
+		outBounds = Math::AABB(
+			worldShape.m_center,
+			glm::vec3(radius));
+		break;
+	}
+	case Physics::ECollisionShapeType::Capsule:
+	{
+		const float radius = std::abs(shape.m_radius) * std::max(
+			worldShape.m_scale.x,
+			worldShape.m_scale.z);
+		const float totalHeight = std::max(
+			2.0f * radius,
+			std::abs(shape.m_height) * worldShape.m_scale.y);
+		const glm::vec3 axis = worldShape.m_rotation * Math::vec3_Up;
+		const glm::vec3 segmentExtent =
+			glm::abs(axis) * (totalHeight * 0.5f - radius);
+		const glm::vec3 worldExtent = segmentExtent + glm::vec3(radius);
+		outBounds = Math::AABB(worldShape.m_center, worldExtent);
+		break;
+	}
+	case Physics::ECollisionShapeType::TriangleMesh:
+	default:
+		return false;
+	}
+
+	return outBounds.IsValid();
+}
+
+void CollisionShapeComponent::OnGizmo()
+{
+	auto owner = GetOwner();
+	if (!owner || !owner->GetWorld())
+	{
+		return;
+	}
+
+	const glm::mat4& ownerWorldMatrix =
+		owner->GetTransformComponent().GetCachedWorldMatrix();
+	auto& debugContext = *owner->GetWorld()->GetDebugContext();
+	const glm::vec4 color(0.2f, 1.0f, 0.35f, 1.0f);
+	const Physics::CollisionShapeDesc shape = BuildDesc();
+	const WorldShape worldShape = ResolveWorldShape(ownerWorldMatrix, shape);
+
+	switch (shape.m_type)
+	{
+	case Physics::ECollisionShapeType::Box:
+		DrawOrientedBox(
+			debugContext,
+			worldShape.m_center,
+			worldShape.m_rotation,
+			glm::abs(shape.m_size) * worldShape.m_scale * 0.5f,
+			color);
+		break;
+	case Physics::ECollisionShapeType::Sphere:
+		debugContext.DrawSphere(
+			worldShape.m_center,
+			std::abs(shape.m_radius) * std::max({
+				worldShape.m_scale.x,
+				worldShape.m_scale.y,
+				worldShape.m_scale.z }),
+			color);
+		break;
+	case Physics::ECollisionShapeType::Capsule:
+	{
+		const float radius = std::abs(shape.m_radius) * std::max(
+			worldShape.m_scale.x,
+			worldShape.m_scale.z);
+		const float totalHeight = std::max(
+			2.0f * radius,
+			std::abs(shape.m_height) * worldShape.m_scale.y);
+		const float halfSegment = totalHeight * 0.5f - radius;
+		const glm::vec3 axis = worldShape.m_rotation * Math::vec3_Up;
+		const glm::vec3 firstCenter = worldShape.m_center - axis * halfSegment;
+		const glm::vec3 secondCenter = worldShape.m_center + axis * halfSegment;
+		debugContext.DrawSphere(firstCenter, radius, color);
+		debugContext.DrawSphere(secondCenter, radius, color);
+		const glm::vec3 right = worldShape.m_rotation * Math::vec3_Right * radius;
+		const glm::vec3 forward = worldShape.m_rotation * Math::vec3_Forward * radius;
+		debugContext.DrawLine(firstCenter + right, secondCenter + right, color);
+		debugContext.DrawLine(firstCenter - right, secondCenter - right, color);
+		debugContext.DrawLine(firstCenter + forward, secondCenter + forward, color);
+		debugContext.DrawLine(firstCenter - forward, secondCenter - forward, color);
+		break;
+	}
+	case Physics::ECollisionShapeType::TriangleMesh:
+	default:
+		break;
+	}
 }

--- a/Runtime/Components/CollisionShapeComponent.h
+++ b/Runtime/Components/CollisionShapeComponent.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Components/Component.h"
+#include "Math/Bounds.h"
 #include "Physics/PhysicsTypes.h"
 
 namespace Sailor
@@ -11,6 +12,7 @@ namespace Sailor
 	public:
 		SAILOR_API void Initialize() override;
 		SAILOR_API void EndPlay() override;
+		SAILOR_API void OnGizmo() override;
 
 		SAILOR_API Physics::ECollisionShapeType GetShapeType() const { return m_shapeType; }
 		SAILOR_API void SetShapeType(Physics::ECollisionShapeType value);
@@ -26,6 +28,9 @@ namespace Sailor
 		SAILOR_API void SetHeight(float value);
 
 		SAILOR_API Physics::CollisionShapeDesc BuildDesc() const;
+		SAILOR_API bool TryGetWorldBounds(
+			const glm::mat4& ownerWorldMatrix,
+			Math::AABB& outBounds) const;
 
 	private:
 		void NotifyRigidBody();

--- a/Runtime/Components/LandscapeComponent.cpp
+++ b/Runtime/Components/LandscapeComponent.cpp
@@ -1,5 +1,4 @@
 #include "Components/LandscapeComponent.h"
-#include "ECS/LandscapeECS.h"
 #include "Engine/GameObject.h"
 
 #include <algorithm>
@@ -12,11 +11,6 @@ void LandscapeComponent::Initialize()
 	m_handle = ecs->RegisterComponent();
 	auto& data = ecs->GetComponentData(m_handle);
 	data.SetOwner(GetOwner());
-	SyncToECS(data);
-}
-
-void LandscapeComponent::SyncToECS(LandscapeData& data) const
-{
 	data.SetSettings(m_chunksX, m_chunksZ, m_chunkSize, m_chunkResolution,
 		m_heightScale, m_noiseScale, m_seed, m_textureTiling);
 	data.SetMaterial(m_material);
@@ -56,7 +50,20 @@ void LandscapeComponent::MarkDirty()
 {
 	if (auto* data = TryGetData())
 	{
-		SyncToECS(*data);
+		data->SetSettings(m_chunksX, m_chunksZ, m_chunkSize, m_chunkResolution,
+			m_heightScale, m_noiseScale, m_seed, m_textureTiling);
+		data->SetMaterial(m_material);
+		data->SetLayerTextures(m_layerTextures);
+		data->SetImportMaps(m_heightmapTexture, m_materialMasks);
+		data->SetAuthoredStamps(m_sculptStamps, m_paintStamps);
+		data->SetVegetationProfiles(m_vegetationModels, m_vegetationMaterials,
+			m_vegetationMeshIndex, m_vegetationInstancesPerChunk, m_vegetationMinScale,
+			m_vegetationMaxScale, m_vegetationGroundOffset,
+			m_vegetationShadowMode, m_vegetationShadowDistance,
+			m_vegetationMinLod, m_vegetationMaxLod,
+			m_vegetationLod1ScreenCoverage, m_vegetationLod2ScreenCoverage,
+			m_vegetationCullDistance, m_vegetationColliderRadius,
+			m_vegetationColliderHeight, m_vegetationColliderOffsetY);
 	}
 }
 
@@ -91,4 +98,5 @@ void LandscapeComponent::SetVegetationCullDistance(const TVector<float>& value) 
 void LandscapeComponent::SetVegetationColliderRadius(const TVector<float>& value) { m_vegetationColliderRadius = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationColliderHeight(const TVector<float>& value) { m_vegetationColliderHeight = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationColliderOffsetY(const TVector<float>& value) { m_vegetationColliderOffsetY = value; MarkDirty(); }
-void LandscapeComponent::SetRegenerate(bool value) { if (value) MarkDirty(); }
+void LandscapeComponent::SetRegenerate(bool value) { m_bRegenerate = false; if (value) MarkDirty(); }
+void LandscapeComponent::SetFlatten(bool value) { m_bFlatten = false; if (value) { m_heightScale = 0.0f; MarkDirty(); } }

--- a/Runtime/Components/LandscapeComponent.h
+++ b/Runtime/Components/LandscapeComponent.h
@@ -1,13 +1,12 @@
 #pragma once
 
 #include "Components/Component.h"
+#include "ECS/LandscapeECS.h"
 #include "AssetRegistry/Material/MaterialImporter.h"
-#include "ECS/ECS.h"
+#include "AssetRegistry/Model/ModelImporter.h"
 
 namespace Sailor
 {
-	class LandscapeData;
-
 	class LandscapeComponent final : public Component
 	{
 		SAILOR_REFLECTABLE(LandscapeComponent)
@@ -78,14 +77,15 @@ namespace Sailor
 		SAILOR_API void SetVegetationColliderHeight(const TVector<float>& value);
 		SAILOR_API const TVector<float>& GetVegetationColliderOffsetY() const { return m_vegetationColliderOffsetY; }
 		SAILOR_API void SetVegetationColliderOffsetY(const TVector<float>& value);
-		SAILOR_API bool GetRegenerate() const { return false; }
+		SAILOR_API bool GetRegenerate() const { return m_bRegenerate; }
 		SAILOR_API void SetRegenerate(bool value);
+		SAILOR_API bool GetFlatten() const { return m_bFlatten; }
+		SAILOR_API void SetFlatten(bool value);
 
 		SAILOR_API size_t GetComponentIndex() const { return m_handle; }
 
 	private:
 		void MarkDirty();
-		void SyncToECS(LandscapeData& data) const;
 		LandscapeData* TryGetData();
 
 		size_t m_handle = ECS::InvalidIndex;
@@ -120,6 +120,8 @@ namespace Sailor
 		TVector<float> m_vegetationColliderRadius{};
 		TVector<float> m_vegetationColliderHeight{};
 		TVector<float> m_vegetationColliderOffsetY{};
+		bool m_bRegenerate = false;
+		bool m_bFlatten = false;
 	};
 }
 
@@ -190,5 +192,7 @@ REFL_AUTO(
 	func(GetVegetationColliderOffsetY, property("vegetationColliderOffsetY")),
 	func(SetVegetationColliderOffsetY, property("vegetationColliderOffsetY")),
 	func(GetRegenerate, property("regenerate")),
-	func(SetRegenerate, property("regenerate"))
+	func(SetRegenerate, property("regenerate")),
+	func(GetFlatten, property("flatten")),
+	func(SetFlatten, property("flatten"))
 )

--- a/Runtime/ECS/LandscapeECS.cpp
+++ b/Runtime/ECS/LandscapeECS.cpp
@@ -530,6 +530,10 @@ void LandscapeData::SetVegetationProfiles(
 	MarkDirty();
 }
 
+void LandscapeECS::BeginPlay()
+{
+}
+
 void LandscapeECS::OnComponentUnregistered(size_t, LandscapeData& component)
 {
 	DestroyPhysicsBodies(component);
@@ -592,37 +596,21 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 
 		auto* modelImporter = App::GetSubmodule<ModelImporter>();
 		auto* materialImporter = App::GetSubmodule<MaterialImporter>();
-		bool bVegetationResourcesReady = true;
 		for (auto& profile : data.m_vegetationProfiles)
 		{
 			if (!profile.m_model && modelImporter && profile.m_modelFileId)
 			{
 				modelImporter->LoadModel_Immediate(profile.m_modelFileId, profile.m_model);
 			}
-			if (profile.m_model && !profile.m_model->IsReady())
-			{
-				bVegetationResourcesReady = false;
-				continue;
-			}
 			if (profile.m_materialFileId && !profile.m_material && materialImporter)
 			{
 				materialImporter->LoadMaterial_Immediate(profile.m_materialFileId, profile.m_material);
 			}
-			else if (!profile.m_materialFileId && profile.m_model &&
-				!profile.m_modelMaterialsTask && modelImporter)
+			else if (!profile.m_materialFileId && !profile.m_bModelMaterialsRequested && modelImporter)
 			{
-				profile.m_modelMaterialsTask = modelImporter->LoadDefaultMaterials(
-					profile.m_modelFileId, profile.m_modelMaterials);
+				modelImporter->LoadDefaultMaterials(profile.m_modelFileId, profile.m_modelMaterials);
+				profile.m_bModelMaterialsRequested = true;
 			}
-			if ((profile.m_material && !profile.m_material->IsReady()) ||
-				(profile.m_modelMaterialsTask && !profile.m_modelMaterialsTask->IsFinished()))
-			{
-				bVegetationResourcesReady = false;
-			}
-		}
-		if (!bVegetationResourcesReady)
-		{
-			continue;
 		}
 
 		LandscapeCpuTexture heightmap;
@@ -666,6 +654,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		size_t vegetationRenderProxies = 0u;
 		size_t vegetationProfilesNotReady = 0u;
 		size_t vegetationProfilesWithoutRenderData = 0u;
+		bool bVegetationResourcesPending = false;
 		const glm::mat4 ownerMatrix = owner->GetTransformComponent().GetCachedWorldMatrix();
 		const Math::Transform ownerTransform = Math::Transform::FromMatrix(ownerMatrix);
 		auto* physics = GetWorld()->GetECS<PhysicsECS>();
@@ -763,6 +752,8 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 					(bUseMaterialOverride && (!profile.m_material || !profile.m_material->IsReady())))
 				{
 					++vegetationProfilesNotReady;
+					bVegetationResourcesPending = bVegetationResourcesPending ||
+						(profile.m_model && (!bUseMaterialOverride || profile.m_material));
 					continue;
 				}
 
@@ -798,6 +789,8 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 				if (!bVegetationMaterialsReady)
 				{
 					++vegetationProfilesNotReady;
+					bVegetationResourcesPending = bVegetationResourcesPending ||
+						(!bUseMaterialOverride && !profile.m_modelMaterials.IsEmpty());
 					continue;
 				}
 				LandscapeVegetationRenderProxy vegetationRenderProxy;
@@ -892,20 +885,25 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			}
 			data.m_chunks.Add(std::move(chunk));
 		}
-		data.m_bIsDirty = false;
+		// Model and material import tasks complete before their GPU upload fences do.
+		// Keep the component dirty while valid vegetation resources are pending so
+		// the next frame can populate the vegetation proxies after those fences signal.
+		data.m_bIsDirty = bVegetationResourcesPending;
 		data.SetLastChange(owner->GetTransformComponent().GetFrameLastChange());
+		++data.m_buildRevision;
 		++m_shadowCastersRevision;
 		size_t vegetationPerChunk = 0u;
 		for (const auto& profile : data.m_vegetationProfiles)
 		{
 			vegetationPerChunk += profile.m_instancesPerChunk;
 		}
-		SAILOR_LOG("LandscapeECS: built %zu chunks with %zu collision bodies (%ux%u, %.1fm, resolution %u), %zu vegetation profiles, %zu instances per chunk and %zu render proxies (%zu profile loads not ready, %zu without render data), %zu sculpt and %zu paint stamps.",
+		SAILOR_LOG("LandscapeECS: built %zu chunks with %zu collision bodies (%ux%u, %.1fm, resolution %u), %zu vegetation profiles, %zu instances per chunk and %zu render proxies (%zu profile loads not ready, %zu without render data), %zu sculpt and %zu paint stamps, revision %llu.",
 			data.m_chunks.Num(), data.m_physicsBodies.Num(), data.m_chunksX, data.m_chunksZ, data.m_chunkSize,
 			data.m_chunkResolution, data.m_vegetationProfiles.Num(), vegetationPerChunk,
 			vegetationRenderProxies, vegetationProfilesNotReady,
 			vegetationProfilesWithoutRenderData,
-			data.m_sculptStamps.Num() / 5u, data.m_paintStamps.Num() / 5u);
+			data.m_sculptStamps.Num() / 5u, data.m_paintStamps.Num() / 5u,
+			static_cast<unsigned long long>(data.m_buildRevision));
 	}
 	return nullptr;
 }
@@ -935,17 +933,9 @@ void LandscapeECS::AppendSceneView(RHI::RHISceneViewPtr& sceneView) const
 		}
 		for (const auto& profile : m_components[componentIndex].m_vegetationProfiles)
 		{
-			if (profile.m_shadowMode == ELandscapeVegetationShadowMode::None)
-			{
-				continue;
-			}
 			sceneView->m_bHasCustomDepthShadowCasters |= profile.m_material &&
+				profile.m_shadowMode != ELandscapeVegetationShadowMode::None &&
 				profile.m_material->GetRenderState().IsRequiredCustomDepthShader();
-			for (const auto& material : profile.m_modelMaterials)
-			{
-				sceneView->m_bHasCustomDepthShadowCasters |= material &&
-					material->GetRenderState().IsRequiredCustomDepthShader();
-			}
 		}
 	}
 	sceneView->m_shadowCastersRevision =

--- a/Runtime/ECS/LandscapeECS.h
+++ b/Runtime/ECS/LandscapeECS.h
@@ -19,7 +19,7 @@ namespace Sailor
 		ModelPtr m_model{};
 		MaterialPtr m_material{};
 		TVector<MaterialPtr> m_modelMaterials{};
-		Tasks::TaskPtr<bool> m_modelMaterialsTask{};
+		bool m_bModelMaterialsRequested = false;
 		int32_t m_meshIndex = -1;
 		uint32_t m_instancesPerChunk = 0u;
 		float m_minScale = 0.75f;
@@ -83,6 +83,9 @@ namespace Sailor
 			const TVector<float>& colliderOffsetY);
 
 	public:
+		// Immutable while worker tasks build a dirty landscape revision.
+		// LandscapeECS owns mutation and publishes the finished chunks atomically
+		// on the game thread.
 		uint32_t m_chunksX = 4u;
 		uint32_t m_chunksZ = 4u;
 		float m_chunkSize = 24.0f;
@@ -101,6 +104,7 @@ namespace Sailor
 		TVector<LandscapeVegetationProfile> m_vegetationProfiles{};
 		TVector<LandscapeChunk> m_chunks{};
 		TVector<uint32_t> m_physicsBodies{};
+		uint64_t m_buildRevision = 0u;
 
 		friend class LandscapeECS;
 	};
@@ -108,6 +112,7 @@ namespace Sailor
 	class LandscapeECS final : public ECS::TSystem<LandscapeECS, LandscapeData>
 	{
 	public:
+		SAILOR_API virtual void BeginPlay() override;
 		SAILOR_API virtual Tasks::ITaskPtr Tick(float deltaTime) override;
 		SAILOR_API virtual void EndPlay() override;
 		SAILOR_API void AppendSceneView(RHI::RHISceneViewPtr& sceneView) const;

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -330,13 +330,8 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 		broadFrustum.ExtractFrustumPlanes(broadLightMatrix);
 		const auto shadowCasters = sceneView->TraceShadowCasters(broadFrustum);
 
-		RHI::EShadowType bCascadeAdded[NumCascades];
-		const uint32_t alreadyPlacedPasses = (uint32_t)updateShadowMaps.Num();
-
 		for (uint32_t k = 0; k < lightCascadesMatrices.Num(); ++k)
 		{
-			bCascadeAdded[k] = RHI::EShadowType::None;
-
 			RHI::RHIUpdateShadowMapCommand cascade;
 			cascade.m_shadowMap = m_csmShadowMaps[k];
 			cascade.m_lightMatrix = lightMatrices[k];
@@ -377,33 +372,6 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 				continue;
 			}
 
-			if (k > 0)
-			{
-				int32_t shift = -1;
-				for (uint32_t z = 0; z < k; ++z)
-				{
-					if (bCascadeAdded[z] != RHI::EShadowType::None)
-					{
-						++shift;
-					}
-
-					if (bCascadeAdded[z] != cascade.m_shadowType)
-					{
-						continue;
-					}
-
-					const uint32_t removed = (uint32_t)cascade.m_meshList.RemoveAll([z, &frustums](const auto& m)
-						{
-							return m && frustums[z].OverlapsAABB(m->m_worldAabb);
-						});
-
-					if (removed > 0)
-					{
-						cascade.m_internalCommandsList.Add(alreadyPlacedPasses + shift);
-					}
-				}
-			}
-
 			if (snapshotIndex < m_csmSnapshots.Num())
 			{
 				m_csmSnapshots[snapshotIndex] = std::move(snapshot);
@@ -413,7 +381,6 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 				m_csmSnapshots.Emplace(std::move(snapshot));
 			}
 
-			bCascadeAdded[k] = cascade.m_shadowType;
 			updateShadowMaps.Emplace(std::move(cascade));
 			++snapshotIndex;
 		}

--- a/Runtime/Editor/EditorInterop.cpp
+++ b/Runtime/Editor/EditorInterop.cpp
@@ -1100,6 +1100,19 @@ bool App::InstantiateEditorPrefabFromYaml(
 	const char* strParentInstanceId,
 	bool bStrictInstanceIds)
 {
+	return InstantiateEditorPrefabFromYaml(
+		strPrefabYaml,
+		strParentInstanceId,
+		bStrictInstanceIds,
+		nullptr);
+}
+
+bool App::InstantiateEditorPrefabFromYaml(
+	const char* strPrefabYaml,
+	const char* strParentInstanceId,
+	bool bStrictInstanceIds,
+	char** outInstanceId)
+{
 	if (!strPrefabYaml || strPrefabYaml[0] == '\0')
 	{
 		return false;
@@ -1109,7 +1122,7 @@ bool App::InstantiateEditorPrefabFromYaml(
 	const std::string parentInstanceIdValue = strParentInstanceId ? strParentInstanceId : "";
 	return ExecuteOnEngineMainThread<bool>(
 		false,
-		[prefabYaml, parentInstanceIdValue, bStrictInstanceIds]()
+		[prefabYaml, parentInstanceIdValue, bStrictInstanceIds, outInstanceId]()
 		{
 			auto editor = GetSubmodule<Editor>();
 			auto prefabImporter = GetSubmodule<PrefabImporter>();
@@ -1188,10 +1201,22 @@ bool App::InstantiateEditorPrefabFromYaml(
 				prefab = std::move(linkedPrefab);
 			}
 
-			return editor->InstantiatePrefab(
+			InstanceId createdInstanceId;
+			const bool bInstantiated = editor->InstantiatePrefab(
 				prefab,
 				parentInstanceId,
-				bStrictInstanceIds);
+				nullptr,
+				createdInstanceId,
+				bStrictInstanceIds,
+				!bStrictInstanceIds);
+			if (bInstantiated && outInstanceId)
+			{
+				SetInteropString(
+					createdInstanceId.ToString(),
+					outInstanceId);
+			}
+
+			return bInstantiated;
 		});
 }
 

--- a/Runtime/Editor/EditorViewportController.cpp
+++ b/Runtime/Editor/EditorViewportController.cpp
@@ -3,6 +3,7 @@
 #include "AssetRegistry/Model/ModelImporter.h"
 #include "Components/CameraComponent.h"
 #include "Components/EditorComponent.h"
+#include "Components/CollisionShapeComponent.h"
 #include "Components/MeshRendererComponent.h"
 #include "Core/YamlSerializable.h"
 #include "ECS/CameraECS.h"
@@ -433,10 +434,10 @@ bool EditorViewport::TryConvertWorldToLocalTransform(
 bool EditorViewport::ResolveGameObjectBounds(
 	const TObjectPtr<GameObject>& gameObject,
 	Math::AABB& outWorldBounds,
-	bool& outUsesMeshBounds)
+	bool& outUsesSelectableGeometry)
 {
 	outWorldBounds = {};
-	outUsesMeshBounds = false;
+	outUsesSelectableGeometry = false;
 	if (!gameObject || gameObject->GetComponent<EditorComponent>())
 	{
 		return false;
@@ -445,33 +446,40 @@ bool EditorViewport::ResolveGameObjectBounds(
 	const glm::mat4 worldMatrix = CalculateCurrentWorldMatrix(gameObject);
 	for (const auto& component : gameObject->GetComponents())
 	{
-		auto meshRenderer = component.DynamicCast<MeshRendererComponent>();
-		const ModelPtr model = meshRenderer ? meshRenderer->GetModel() : ModelPtr{};
-		if (!model || !model->IsReady())
+		Math::AABB componentBounds{};
+		if (auto meshRenderer = component.DynamicCast<MeshRendererComponent>())
+		{
+			const ModelPtr model = meshRenderer->GetModel();
+			if (model && model->IsReady())
+			{
+				componentBounds = model->GetBoundsAABB(
+					meshRenderer->GetMeshIndex());
+				componentBounds.Apply(worldMatrix);
+			}
+		}
+		else if (auto collisionShape =
+			component.DynamicCast<CollisionShapeComponent>())
+		{
+			collisionShape->TryGetWorldBounds(worldMatrix, componentBounds);
+		}
+
+		if (!componentBounds.IsValid())
 		{
 			continue;
 		}
 
-		Math::AABB meshBounds =
-			model->GetBoundsAABB(meshRenderer->GetMeshIndex());
-		meshBounds.Apply(worldMatrix);
-		if (!meshBounds.IsValid())
+		if (outUsesSelectableGeometry)
 		{
-			continue;
-		}
-
-		if (outUsesMeshBounds)
-		{
-			outWorldBounds.Extend(meshBounds);
+			outWorldBounds.Extend(componentBounds);
 		}
 		else
 		{
-			outWorldBounds = meshBounds;
-			outUsesMeshBounds = true;
+			outWorldBounds = componentBounds;
+			outUsesSelectableGeometry = true;
 		}
 	}
 
-	if (outUsesMeshBounds)
+	if (outUsesSelectableGeometry)
 	{
 		return true;
 	}
@@ -638,9 +646,12 @@ bool EditorViewportController::TraceViewportRay(
 	for (const auto& gameObject : world.GetGameObjects())
 	{
 		Math::AABB bounds{};
-		bool bUsesMeshBounds = false;
-		if (ResolveGameObjectBounds(gameObject, bounds, bUsesMeshBounds) &&
-			bUsesMeshBounds)
+		bool bUsesSelectableGeometry = false;
+		if (ResolveGameObjectBounds(
+				gameObject,
+				bounds,
+				bUsesSelectableGeometry) &&
+			bUsesSelectableGeometry)
 		{
 			candidates.Add(PickCandidate{ gameObject->GetInstanceId(), bounds });
 		}
@@ -664,17 +675,17 @@ bool EditorViewportController::FocusCameraOnObject(
 	const auto targetObject =
 		world.GetObjectByInstanceId(instanceId).DynamicCast<GameObject>();
 	Math::AABB targetBounds{};
-	bool bUsesMeshBounds = false;
+	bool bUsesSelectableGeometry = false;
 	if (!targetObject ||
 		!ResolveGameObjectBounds(
 			targetObject,
 			targetBounds,
-			bUsesMeshBounds))
+			bUsesSelectableGeometry))
 	{
 		return false;
 	}
 
-	if (!bUsesMeshBounds)
+	if (!bUsesSelectableGeometry)
 	{
 		targetBounds = Math::AABB(
 			targetBounds.GetCenter(),
@@ -1003,9 +1014,12 @@ void EditorViewportController::TickSelection(World& world)
 	for (const auto& gameObject : world.GetGameObjects())
 	{
 		Math::AABB bounds{};
-		bool bUsesMeshBounds = false;
-		if (ResolveGameObjectBounds(gameObject, bounds, bUsesMeshBounds) &&
-			bUsesMeshBounds)
+		bool bUsesSelectableGeometry = false;
+		if (ResolveGameObjectBounds(
+				gameObject,
+				bounds,
+				bUsesSelectableGeometry) &&
+			bUsesSelectableGeometry)
 		{
 			candidates.Add(PickCandidate{ gameObject->GetInstanceId(), bounds });
 		}

--- a/Runtime/Editor/EditorViewportController.h
+++ b/Runtime/Editor/EditorViewportController.h
@@ -71,7 +71,7 @@ namespace Sailor
 		SAILOR_API bool ResolveGameObjectBounds(
 			const TObjectPtr<GameObject>& gameObject,
 			Math::AABB& outWorldBounds,
-			bool& outUsesMeshBounds);
+			bool& outUsesSelectableGeometry);
 
 		SAILOR_API bool CanBeginSelectionGesture(
 			bool bHasModifiers,

--- a/Runtime/Engine/EngineLoop.cpp
+++ b/Runtime/Engine/EngineLoop.cpp
@@ -260,15 +260,6 @@ void EngineLoop::ProcessCpuFrame(FrameState& currentInputState)
 
 	totalFramesCount++;
 
-	const float TargetCpuTime = (1000.0f / 130);
-
-	if (timer.ResultMs() < TargetCpuTime)
-	{
-		SAILOR_PROFILE_SCOPE("Sleep Main Thread to cap FPS (~120fps)");
-
-		std::this_thread::sleep_for(std::chrono::milliseconds(std::max(1ull, (uint64_t)(TargetCpuTime - timer.ResultMs()))));
-	}
-
 	if (timer.ResultAccumulatedMs() > 1000)
 	{
 		m_cpuFps = totalFramesCount;

--- a/Runtime/Engine/EngineLoop.h
+++ b/Runtime/Engine/EngineLoop.h
@@ -20,7 +20,6 @@ namespace Sailor
 		static constexpr EWorldBehaviourMask EditorWorldMask = (uint8_t)EWorldBehaviourBit::EcsTickable |
 			(uint8_t)EWorldBehaviourBit::EditorTick;
 
-		const float MaxCpuFrames = 120.0f;
 
 		SAILOR_API void ProcessCpuFrame(FrameState& currentInputState);
 		SAILOR_API uint32_t GetCpuFps() const { return m_cpuFps; }

--- a/Runtime/Engine/GameObject.cpp
+++ b/Runtime/Engine/GameObject.cpp
@@ -148,6 +148,8 @@ void GameObject::EditorTick(float deltaTime)
 		auto& el = m_components[i];
 		el->EditorTick(deltaTime);
 	}
+
+	m_componentsToAdd = 0;
 }
 
 void GameObject::DrawEditorSelectedGizmo()
@@ -159,23 +161,22 @@ void GameObject::DrawEditorSelectedGizmo()
 		std::max(std::abs(localScale.x), std::max(std::abs(localScale.y), std::abs(localScale.z))) * 100.0f);
 
 	Math::AABB selectionBounds{};
-	bool bUsesMeshBounds = false;
-	if (EditorViewport::ResolveGameObjectBounds(m_self, selectionBounds, bUsesMeshBounds))
+	bool bUsesSelectableGeometry = false;
+	if (EditorViewport::ResolveGameObjectBounds(
+			m_self,
+			selectionBounds,
+			bUsesSelectableGeometry))
 	{
 		const glm::vec4 selectionColor(1.0f, 0.62f, 0.05f, 1.0f);
-		if (bUsesMeshBounds)
+		if (bUsesSelectableGeometry)
 		{
 			GetWorld()->GetDebugContext()->DrawAABB(selectionBounds, selectionColor);
-		}
-		else
-		{
-			GetWorld()->GetDebugContext()->DrawSphere(selectionBounds.GetCenter(), 10.0f, selectionColor);
 		}
 	}
 
 	GetWorld()->GetDebugContext()->DrawOrigin(worldPosition, transform.GetCachedWorldMatrix(), axisSize);
 
-	for (uint32_t i = 0; i < m_components.Num() - m_componentsToAdd; i++)
+	for (uint32_t i = 0; i < m_components.Num(); i++)
 	{
 		m_components[i]->OnGizmo();
 	}

--- a/Runtime/Engine/World.cpp
+++ b/Runtime/Engine/World.cpp
@@ -867,6 +867,14 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab)
 
 GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 {
+	return Instantiate(prefab, bStrictInstanceIds, false);
+}
+
+GameObjectPtr World::Instantiate(
+	PrefabPtr prefab,
+	bool bStrictInstanceIds,
+	bool bForceNewInstanceIds)
+{
 	if (!prefab || prefab->m_gameObjects.IsEmpty())
 	{
 		SAILOR_LOG_ERROR("Cannot instantiate an invalid or empty prefab.");
@@ -1159,7 +1167,8 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 				? strictSourceToInstanceIds[sourceInstanceId]
 				: sourceInstanceId;
 			if (!bStrictInstanceIds &&
-				(!gameObjectId ||
+				(bForceNewInstanceIds ||
+					!gameObjectId ||
 					m_objectsMap.ContainsKey(gameObjectId) ||
 					reservedInstanceIds.Contains(gameObjectId)))
 			{
@@ -1251,6 +1260,15 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 			gameObject;
 	}
 
+	TMap<InstanceId, ObjectPtr> resolveContext = m_objectsMap;
+	for (const auto& dependency : internalDependencies)
+	{
+		// Source ids inside the instantiated prefab must shadow live
+		// world objects with the same ids. Other entries remain available
+		// for references outside the copied hierarchy.
+		resolveContext[dependency.m_first] = *dependency.m_second;
+	}
+
 	for (uint32_t goIndex = 0; goIndex < gameObjects.Num(); goIndex++)
 	{
 		auto& go = gameObjects[goIndex];
@@ -1267,15 +1285,14 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 
 			const ReflectedData& reflection = prefab->m_components[componentIndex];
 
-			// Resolve internal dependencies first
 			bool bResolved = false;
 			std::string resolveDiagnostic;
 			if (!External::TryInvokeYaml(
-					[newComp, &reflection, &internalDependencies]() mutable
+					[newComp, &reflection, &resolveContext]() mutable
 					{
 						return newComp->ResolveRefs(
 							reflection,
-							internalDependencies,
+							resolveContext,
 							true);
 					},
 					bResolved,
@@ -1288,27 +1305,6 @@ GameObjectPtr World::Instantiate(PrefabPtr prefab, bool bStrictInstanceIds)
 					resolveDiagnostic.c_str());
 				return {};
 			}
-
-			// Resolve external dependencies
-			if (!bResolved)
-			{
-				if (!External::TryInvokeYaml(
-						[newComp, &reflection, this]() mutable
-						{
-							return newComp->ResolveRefs(reflection, m_objectsMap, true);
-						},
-						bResolved,
-						resolveDiagnostic))
-				{
-					SAILOR_LOG_ERROR(
-						"Cannot resolve external references for component %u from prefab '%s': %s.",
-						componentIndex,
-						prefab->GetFileId().ToString().c_str(),
-						resolveDiagnostic.c_str());
-					return {};
-				}
-			}
-
 			if (!bResolved)
 			{
 				ComponentsToResolveDependencies.Add(TPair(newComp, reflection));

--- a/Runtime/Engine/World.h
+++ b/Runtime/Engine/World.h
@@ -50,6 +50,10 @@ namespace Sailor
 		SAILOR_API GameObjectPtr Instantiate(
 			PrefabPtr prefab,
 			bool bStrictInstanceIds);
+		SAILOR_API GameObjectPtr Instantiate(
+			PrefabPtr prefab,
+			bool bStrictInstanceIds,
+			bool bForceNewInstanceIds);
 		SAILOR_API GameObjectPtr Instantiate(const std::string& name = "Untitled");
 		SAILOR_API GameObjectPtr Instantiate(const std::string& name, const InstanceId& preferredInstanceId);
 		SAILOR_API void Destroy(GameObjectPtr object);

--- a/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanApi.cpp
@@ -618,8 +618,15 @@ VkPresentModeKHR VulkanApi::ChooseSwapPresentMode(const TVector<VkPresentModeKHR
 
 	for (const auto& availablePresentMode : availablePresentModes)
 	{
-		if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR ||
-			availablePresentMode == VK_PRESENT_MODE_IMMEDIATE_KHR)
+		if (availablePresentMode == VK_PRESENT_MODE_IMMEDIATE_KHR)
+		{
+			return availablePresentMode;
+		}
+	}
+
+	for (const auto& availablePresentMode : availablePresentModes)
+	{
+		if (availablePresentMode == VK_PRESENT_MODE_MAILBOX_KHR)
 		{
 			return availablePresentMode;
 		}

--- a/Runtime/GraphicsDriver/Vulkan/VulkanSwapchain.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanSwapchain.cpp
@@ -46,6 +46,7 @@ VulkanSwapchain::VulkanSwapchain(VulkanDevicePtr device, uint32_t width, uint32_
 
 	m_surfaceFormat = VulkanApi::ChooseSwapSurfaceFormat(m_swapChainSupport.m_formats);
 	m_presentMode = VulkanApi::ChooseSwapPresentMode(m_swapChainSupport.m_presentModes, bIsVSync);
+	SAILOR_LOG("Vulkan swapchain present mode: %d (vsync requested: %d)", (int32_t)m_presentMode, (int32_t)bIsVSync);
 	m_swapchainExtent = VulkanApi::ChooseSwapExtent(m_swapChainSupport.m_capabilities, width, height);
 
 	uint32_t imageCount = m_swapChainSupport.m_capabilities.minImageCount + 1;

--- a/Runtime/Math/Bounds.cpp
+++ b/Runtime/Math/Bounds.cpp
@@ -110,15 +110,28 @@ glm::mat4 Frustum::CalculateOrthoMatrixByView(const glm::mat4& view, float zMult
 		// not make an otherwise static shadow crawl between shadow-map texels.
 		if (radius > std::numeric_limits<float>::epsilon())
 		{
-			const float diameter = 2.0f * radius;
+			// Snapping can move the projection by half a texel. Keep the original
+			// receiver sphere plus a complete two-texel PCF footprint inside the
+			// map on both axes, otherwise every cascade exposes a border strip.
+			constexpr float shadowGuardTexels = 3.0f;
+			const float safeResolutionX = (std::max)(
+				(float)shadowMapResolution.x - 2.0f * shadowGuardTexels,
+				1.0f);
+			const float safeResolutionY = (std::max)(
+				(float)shadowMapResolution.y - 2.0f * shadowGuardTexels,
+				1.0f);
+			const float guardedRadius = radius * (std::max)(
+				(float)shadowMapResolution.x / safeResolutionX,
+				(float)shadowMapResolution.y / safeResolutionY);
+			const float diameter = 2.0f * guardedRadius;
 			const float texelSizeX = diameter / (float)shadowMapResolution.x;
 			const float texelSizeY = diameter / (float)shadowMapResolution.y;
 			const float snappedCenterX = std::round(lightSpaceCenter.x / texelSizeX) * texelSizeX;
 			const float snappedCenterY = std::round(lightSpaceCenter.y / texelSizeY) * texelSizeY;
-			minX = snappedCenterX - radius;
-			maxX = snappedCenterX + radius;
-			minY = snappedCenterY - radius;
-			maxY = snappedCenterY + radius;
+			minX = snappedCenterX - guardedRadius;
+			maxX = snappedCenterX + guardedRadius;
+			minY = snappedCenterY - guardedRadius;
+			maxY = snappedCenterY + guardedRadius;
 		}
 	}
 

--- a/Runtime/Platform/Mac/Window.mm
+++ b/Runtime/Platform/Mac/Window.mm
@@ -71,7 +71,17 @@ static uint32_t SailorMapMacKeyCode(unsigned short keyCode)
 	}
 }
 
-static void SailorApplyMacWindowSizeOnMainThread(NSWindow* window, int32_t width, int32_t height, bool bIsFullScreen, bool bRunsInsideEditor)
+static void SailorConfigureMetalLayer(CAMetalLayer* metalLayer, bool bIsVsyncRequested)
+{
+	if (!metalLayer)
+	{
+		return;
+	}
+
+	metalLayer.displaySyncEnabled = bIsVsyncRequested ? YES : NO;
+}
+
+static void SailorApplyMacWindowSizeOnMainThread(NSWindow* window, int32_t width, int32_t height, bool bIsFullScreen, bool bRunsInsideEditor, bool bIsVsyncRequested)
 {
 	if (bRunsInsideEditor)
 	{
@@ -92,6 +102,7 @@ static void SailorApplyMacWindowSizeOnMainThread(NSWindow* window, int32_t width
 				contentView.layer = metalLayer;
 			}
 
+			SailorConfigureMetalLayer(metalLayer, bIsVsyncRequested);
 			metalLayer.contentsScale = backingScale;
 			metalLayer.frame = contentView.bounds;
 			metalLayer.drawableSize = CGSizeMake((CGFloat)width, (CGFloat)height);
@@ -404,8 +415,10 @@ bool Window::Create(LPCSTR title, LPCSTR className, int32_t inWidth, int32_t inH
 		SailorContentView* contentView = [[SailorContentView alloc] initWithFrame:frame];
 		contentView.sailorWindow = this;
 		contentView.wantsLayer = YES;
-		contentView.layer = [CAMetalLayer layer];
-		contentView.layer.contentsScale = [window backingScaleFactor];
+		CAMetalLayer* metalLayer = [CAMetalLayer layer];
+		SailorConfigureMetalLayer(metalLayer, bIsVsyncRequested);
+		contentView.layer = metalLayer;
+		metalLayer.contentsScale = [window backingScaleFactor];
 
 		window.contentView = contentView;
 		window.acceptsMouseMovedEvents = YES;
@@ -463,12 +476,12 @@ void Window::ChangeWindowSize(int32_t width, int32_t height, bool bInIsFullScree
 	{
 		dispatch_async(dispatch_get_main_queue(), ^
 		{
-			SailorApplyMacWindowSizeOnMainThread(window, contentWidth, contentHeight, bInIsFullScreen, bRunsInsideEditor);
+			SailorApplyMacWindowSizeOnMainThread(window, contentWidth, contentHeight, bInIsFullScreen, bRunsInsideEditor, m_bIsVsyncRequested);
 		});
 		return;
 	}
 
-	SailorApplyMacWindowSizeOnMainThread(window, contentWidth, contentHeight, bInIsFullScreen, bRunsInsideEditor);
+	SailorApplyMacWindowSizeOnMainThread(window, contentWidth, contentHeight, bInIsFullScreen, bRunsInsideEditor, m_bIsVsyncRequested);
 }
 
 void Sailor::Win32::Window::ProcessMacMsgs()
@@ -656,13 +669,16 @@ void* Window::GetMetalLayer() const
 		return nullptr;
 	}
 
-	if (!window.contentView.wantsLayer)
+	CAMetalLayer* metalLayer = [window.contentView.layer isKindOfClass:[CAMetalLayer class]] ? (CAMetalLayer*)window.contentView.layer : nil;
+	if (!metalLayer)
 	{
 		window.contentView.wantsLayer = YES;
-		window.contentView.layer = [CAMetalLayer layer];
+		metalLayer = [CAMetalLayer layer];
+		window.contentView.layer = metalLayer;
 	}
 
-	return (__bridge void*)window.contentView.layer;
+	SailorConfigureMetalLayer(metalLayer, m_bIsVsyncRequested);
+	return (__bridge void*)metalLayer;
 }
 
 void* Window::GetNativeView() const

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -149,6 +149,11 @@ namespace Sailor
 			const char* strPrefabYaml,
 			const char* strParentInstanceId,
 			bool bStrictInstanceIds);
+		SAILOR_API static bool InstantiateEditorPrefabFromYaml(
+			const char* strPrefabYaml,
+			const char* strParentInstanceId,
+			bool bStrictInstanceIds,
+			char** outInstanceId);
 		SAILOR_API static bool FocusEditorCamera(const char* strInstanceId);
 		SAILOR_API static bool SetEditorPrefabLink(
 			const char* strInstanceId,

--- a/Runtime/Submodules/Editor.cpp
+++ b/Runtime/Submodules/Editor.cpp
@@ -1159,7 +1159,8 @@ bool Editor::InstantiatePrefab(
 	const InstanceId& parentInstanceId,
 	const glm::vec3* worldPosition,
 	InstanceId& outInstanceId,
-	bool bStrictInstanceIds)
+	bool bStrictInstanceIds,
+	bool bForceNewInstanceIds)
 {
 	SAILOR_PROFILE_FUNCTION();
 	outInstanceId = InstanceId::Invalid;
@@ -1207,7 +1208,10 @@ bool Editor::InstantiatePrefab(
 		}
 	}
 
-	auto root = m_world->Instantiate(prefab, bStrictInstanceIds);
+	auto root = m_world->Instantiate(
+		prefab,
+		bStrictInstanceIds,
+		bForceNewInstanceIds);
 	if (!root)
 	{
 		return false;

--- a/Runtime/Submodules/Editor.h
+++ b/Runtime/Submodules/Editor.h
@@ -107,7 +107,8 @@ namespace Sailor
 			const class InstanceId& parentInstanceId,
 			const glm::vec3* worldPosition,
 			class InstanceId& outInstanceId,
-			bool bStrictInstanceIds = false);
+			bool bStrictInstanceIds = false,
+			bool bForceNewInstanceIds = false);
 		bool TraceViewportRay(
 			uint64_t viewportId,
 			float normalizedX,

--- a/Tests/BoundsContractTests.cpp
+++ b/Tests/BoundsContractTests.cpp
@@ -175,6 +175,33 @@ namespace
 		policy.m_minLod = 1;
 		Require(policy.Resolve(1.0f, 3) == 1, "the configured minimum LOD must be respected");
 	}
+
+	void TestStabilizedShadowProjectionKeepsReceiverGuardBand()
+	{
+		Math::Frustum cameraSlice;
+		cameraSlice.ExtractFrustumPlanes(
+			glm::translate(glm::mat4(1.0f), glm::vec3(0.013f, 0.017f, 0.0f)),
+			16.0f / 9.0f,
+			60.0f,
+			0.1f,
+			40.0f);
+
+		const glm::ivec2 resolution(1024);
+		const glm::mat4 shadowProjection = cameraSlice.CalculateOrthoMatrixByView(
+			glm::mat4(1.0f),
+			10.0f,
+			resolution,
+			200.0f);
+		const glm::vec2 guardUv(2.0f / (float)resolution.x);
+		for (const glm::vec3& corner : cameraSlice.GetCorners())
+		{
+			const glm::vec4 clip = shadowProjection * glm::vec4(corner, 1.0f);
+			const glm::vec2 uv = glm::vec2(clip) * 0.5f + 0.5f;
+			Require(uv.x >= guardUv.x && uv.x <= 1.0f - guardUv.x &&
+				uv.y >= guardUv.y && uv.y <= 1.0f - guardUv.y,
+				"stabilized CSM projection must retain every receiver corner plus the PCF footprint");
+		}
+	}
 }
 
 int main()
@@ -185,9 +212,10 @@ int main()
 		{ "TransformPreservesAllNegativeBounds", TestTransformPreservesAllNegativeBounds },
 		{ "ReversedShadowProjectionUsesZeroToOneDepth", TestReversedShadowProjectionUsesZeroToOneDepth },
 		{ "FrustumCenterIsTheAverageOfItsCorners", TestFrustumCenterIsTheAverageOfItsCorners },
-			{ "ReverseZFrustumCornersUseZeroToOneDepth", TestReverseZFrustumCornersUseZeroToOneDepth },
-			{ "ShadowProjectionIncludesCastersTowardLightSource", TestShadowProjectionIncludesCastersTowardLightSource },
-			{ "LodPolicyResolvesCoverageAndAvailableMeshes", TestLodPolicyResolvesCoverageAndAvailableMeshes },
+		{ "ReverseZFrustumCornersUseZeroToOneDepth", TestReverseZFrustumCornersUseZeroToOneDepth },
+		{ "ShadowProjectionIncludesCastersTowardLightSource", TestShadowProjectionIncludesCastersTowardLightSource },
+		{ "LodPolicyResolvesCoverageAndAvailableMeshes", TestLodPolicyResolvesCoverageAndAvailableMeshes },
+		{ "StabilizedShadowProjectionKeepsReceiverGuardBand", TestStabilizedShadowProjectionKeepsReceiverGuardBand },
 	};
 
 	for (const auto& test : tests)

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -3252,6 +3252,94 @@ namespace
 		world.Clear();
 	}
 
+	void TestForcedPrefabIdsRemapInternalAndPreserveExternalReferences()
+	{
+		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
+		constexpr const char* rootId =
+			"10010010010010010000";
+		constexpr const char* childId =
+			"20020020020020020000";
+		constexpr const char* externalOwnerId =
+			"30030030030030030000";
+		constexpr const char* sourceComponentId =
+			"1111111111111111_10010010010010010000";
+		constexpr const char* internalTargetId =
+			"2222222222222222_20020020020020020000";
+		constexpr const char* externalTargetId =
+			"3333333333333333_30030030030030030000";
+
+		PrefabTestWorld world;
+		GameObjectPtr externalOwner = world.Instantiate(
+			"ExternalTarget",
+			DeserializeInstanceId(externalOwnerId));
+		ComponentPtr externalTarget =
+			TObjectPtr<PrefabRollbackTestComponent>::Make(
+				world.GetAllocator());
+		externalTarget = externalOwner->AddComponentRaw(
+			externalTarget,
+			DeserializeInstanceId(externalTargetId));
+		Require(static_cast<bool>(externalTarget),
+			"the external dependency fixture should be created");
+
+		YAML::Node sourceProperties;
+		sourceProperties["m_sourceDependency"]["fileId"] =
+			"NullFileId";
+		sourceProperties["m_sourceDependency"]["instanceId"] =
+			internalTargetId;
+		sourceProperties["m_liveDependency"]["fileId"] =
+			"NullFileId";
+		sourceProperties["m_liveDependency"]["instanceId"] =
+			externalTargetId;
+
+		YAML::Node components(YAML::NodeType::Sequence);
+		components.push_back(MakeReflectedComponent(
+			sourceComponentId,
+			sourceProperties,
+			true,
+			PrefabMixedDependencyTestComponent::
+				GetStaticTypeInfo().Name()));
+		components.push_back(MakeReflectedComponent(
+			internalTargetId,
+			{}));
+
+		YAML::Node prefabNode = MakePrefabNode({ noParent, 0 });
+		prefabNode["gameObjects"][0]["instanceId"] = rootId;
+		prefabNode["gameObjects"][0]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		prefabNode["gameObjects"][0]["components"].push_back(0);
+		prefabNode["gameObjects"][1]["instanceId"] = childId;
+		prefabNode["gameObjects"][1]["components"] =
+			YAML::Node(YAML::NodeType::Sequence);
+		prefabNode["gameObjects"][1]["components"].push_back(1);
+		prefabNode["components"] = components;
+
+		GameObjectPtr copiedRoot = world.Instantiate(
+			DeserializePrefab(world, prefabNode),
+			false,
+			true);
+		Require(copiedRoot &&
+			copiedRoot->GetInstanceId() !=
+				DeserializeInstanceId(rootId) &&
+			copiedRoot->GetChildren().Num() == 1 &&
+			copiedRoot->GetChildren()[0]->GetInstanceId() !=
+				DeserializeInstanceId(childId),
+			"forced prefab instantiation should assign new ids to every copied game object");
+
+		auto copiedSource = copiedRoot->GetComponent<
+			PrefabMixedDependencyTestComponent>();
+		auto copiedInternalTarget = copiedRoot->GetChildren()[0]->
+			GetComponent<PrefabRollbackTestComponent>();
+		Require(copiedSource && copiedInternalTarget &&
+			copiedSource->m_sourceDependency ==
+				copiedInternalTarget &&
+			copiedSource->m_liveDependency == externalTarget,
+			"forced prefab instantiation should remap internal references and preserve external references");
+		Require(world.GetPendingDependencyCount() == 0,
+			"all copied references should resolve without pending work");
+
+		world.Clear();
+	}
+
 	void TestStrictPrefabInstantiationPreservesIdsAndRejectsAtomically()
 	{
 		constexpr uint32_t noParent = static_cast<uint32_t>(-1);
@@ -3759,6 +3847,7 @@ int main()
 		{ "EditorUpdatePreservesNewUnresolvedDependency", TestEditorUpdatePreservesNewUnresolvedDependency },
 		{ "LegacyPrefabApiSymbolsRemainAddressable", TestLegacyPrefabApiSymbolsRemainAddressable },
 		{ "PrefabComponentReferencesFollowRemappedOwners", TestPrefabComponentReferencesFollowRemappedOwners },
+		{ "ForcedPrefabIdsRemapInternalAndPreserveExternalReferences", TestForcedPrefabIdsRemapInternalAndPreserveExternalReferences },
 		{ "LinkedPrefabPersistenceAndWorldContract", TestLinkedPrefabPersistenceAndWorldContract },
 		{ "LinkedPrefabBaselineAndSaveFailureContract", TestLinkedPrefabBaselineAndSaveFailureContract },
 		{ "LinkedPrefabSourceStructureEvolutionContract", TestLinkedPrefabSourceStructureEvolutionContract },

--- a/Tests/EditorEngineProtocolTests.cpp
+++ b/Tests/EditorEngineProtocolTests.cpp
@@ -49,6 +49,7 @@ namespace
 	constexpr uint32_t c_boolResultField = 11;
 	constexpr uint32_t c_int32ResultField = 12;
 	constexpr uint32_t c_uint64ResultField = 14;
+	constexpr uint32_t c_instanceIdResultField = 18;
 	constexpr uint32_t c_viewportEventBatchResultField = 19;
 	constexpr uint32_t c_viewportToolStateResultField = 21;
 	constexpr uint32_t c_animatorStateResultField = 22;
@@ -278,7 +279,8 @@ namespace
 				response.m_resultPayload.assign(
 					reinterpret_cast<const char*>(value),
 					static_cast<size_t>(length));
-				if (fieldNumber == c_boolResultField)
+				if (fieldNumber == c_boolResultField ||
+					fieldNumber == c_instanceIdResultField)
 				{
 					Require(
 						TryDecodeBoolResult(
@@ -1041,7 +1043,7 @@ namespace
 					EditorEngineProtocolStrictInstanceIdsVersion &&
 				response.m_requestId == 26 &&
 				response.m_success &&
-				response.m_resultField == c_boolResultField &&
+				response.m_resultField == c_instanceIdResultField &&
 				!response.m_boolResult &&
 				response.m_supportsStrictInstanceIds,
 				"a capability-compatible host must dispatch a version-gated strict restore request");

--- a/Tests/EditorViewportControllerContractTests.cpp
+++ b/Tests/EditorViewportControllerContractTests.cpp
@@ -1,5 +1,6 @@
 #include "Editor/EditorViewportController.h"
 #include "AssetRegistry/Model/ModelImporter.h"
+#include "Components/CollisionShapeComponent.h"
 #include "Components/EditorComponent.h"
 #include "Components/MeshRendererComponent.h"
 #include "ECS/StaticMeshRendererECS.h"
@@ -583,7 +584,7 @@ namespace
 			"a gizmo submitted and dragged this frame must own the pointer");
 	}
 
-	void TestResolveGameObjectBoundsDistinguishesMeshPickingFromSelectionFallback()
+	void TestResolveGameObjectBoundsAggregatesSelectableGeometry()
 	{
 		BoundsTestWorld world;
 		auto parent = world.Instantiate("Parent");
@@ -620,14 +621,45 @@ namespace
 		expectedFirst.Extend(expectedSecond);
 
 		Math::AABB actualBounds;
-		bool bUsesMeshBounds = false;
-		Require(EditorViewport::ResolveGameObjectBounds(meshObject, actualBounds, bUsesMeshBounds),
+		bool bUsesSelectableGeometry = false;
+		Require(EditorViewport::ResolveGameObjectBounds(meshObject, actualBounds, bUsesSelectableGeometry),
 			"a hierarchy object with ready mesh renderers must expose selectable world bounds");
-		Require(bUsesMeshBounds,
+		Require(bUsesSelectableGeometry,
 			"ready mesh renderers must be distinguished from the origin fallback");
 		Require(AreVectorsNear(actualBounds.m_min, expectedFirst.m_min) &&
 			AreVectorsNear(actualBounds.m_max, expectedFirst.m_max),
 			"mesh bounds must aggregate every renderer after hierarchy, rotation, and negative-scale transforms");
+
+		auto collisionObject = world.Instantiate("CollisionObject");
+		collisionObject->GetTransformComponent().SetPosition(
+			glm::vec4(4.0f, 5.0f, 6.0f, 1.0f));
+		collisionObject->GetTransformComponent().SetScale(
+			glm::vec4(-2.0f, 3.0f, 4.0f, 1.0f));
+		auto boxShape = collisionObject->AddComponent<CollisionShapeComponent>();
+		boxShape->SetShapeType(Physics::ECollisionShapeType::Box);
+		boxShape->SetCenter(glm::vec3(1.0f, -1.0f, 0.5f));
+		boxShape->SetSize(glm::vec3(2.0f));
+		auto sphereShape = collisionObject->AddComponent<CollisionShapeComponent>();
+		sphereShape->SetShapeType(Physics::ECollisionShapeType::Sphere);
+		sphereShape->SetCenter(glm::vec3(-2.0f, 0.0f, 0.0f));
+		sphereShape->SetRadius(0.5f);
+		auto capsuleShape = collisionObject->AddComponent<CollisionShapeComponent>();
+		capsuleShape->SetShapeType(Physics::ECollisionShapeType::Capsule);
+		capsuleShape->SetCenter(glm::vec3(0.0f, 0.0f, -2.0f));
+		capsuleShape->SetRadius(0.25f);
+		capsuleShape->SetHeight(2.0f);
+
+		bUsesSelectableGeometry = false;
+		Require(EditorViewport::ResolveGameObjectBounds(
+				collisionObject,
+				actualBounds,
+				bUsesSelectableGeometry),
+			"an object with collision primitives but no mesh must expose selectable bounds");
+		Require(bUsesSelectableGeometry,
+			"collision primitives must participate in viewport picking");
+		Require(AreVectorsNear(actualBounds.m_min, glm::vec3(0.0f, -1.0f, -3.0f)) &&
+			AreVectorsNear(actualBounds.m_max, glm::vec3(10.0f, 8.0f, 12.0f)),
+			"selection bounds must aggregate every collision primitive with signed owner scale and local offsets");
 
 		auto fallbackObject = world.Instantiate("FallbackObject");
 		fallbackObject->SetParent(parent);
@@ -636,20 +668,20 @@ namespace
 			parent->GetTransformComponent().GetTransform().Matrix() *
 			fallbackObject->GetTransformComponent().GetTransform().Matrix();
 		const glm::vec3 fallbackPosition(fallbackWorldMatrix[3]);
-		bUsesMeshBounds = true;
-		Require(EditorViewport::ResolveGameObjectBounds(fallbackObject, actualBounds, bUsesMeshBounds),
+		bUsesSelectableGeometry = true;
+		Require(EditorViewport::ResolveGameObjectBounds(fallbackObject, actualBounds, bUsesSelectableGeometry),
 			"an object without a ready mesh must expose its center for the selected-object marker");
-		Require(!bUsesMeshBounds,
+		Require(!bUsesSelectableGeometry,
 			"selection fallback bounds must be excluded from viewport mesh picking");
 		Require(AreVectorsNear(actualBounds.GetCenter(), fallbackPosition),
 			"selection fallback must use the fully composed world position");
 
 		auto editorOnlyObject = world.Instantiate("EditorOnlyObject");
 		editorOnlyObject->AddComponent<EditorComponent>();
-		bUsesMeshBounds = true;
-		Require(!EditorViewport::ResolveGameObjectBounds(editorOnlyObject, actualBounds, bUsesMeshBounds),
+		bUsesSelectableGeometry = true;
+		Require(!EditorViewport::ResolveGameObjectBounds(editorOnlyObject, actualBounds, bUsesSelectableGeometry),
 			"editor-only infrastructure must never enter scene picking candidates");
-		Require(!bUsesMeshBounds,
+		Require(!bUsesSelectableGeometry,
 			"rejected editor-only objects must clear the mesh-bound result flag");
 
 		world.Clear();
@@ -679,7 +711,7 @@ int main()
 		{ "PickNearestBreaksTiesDeterministically", TestPickNearestBreaksTiesDeterministically },
 		{ "SelectionGesturePolicyRejectsNavigationModifiersAndUiOwnership", TestSelectionGesturePolicyRejectsNavigationModifiersAndUiOwnership },
 		{ "OnlySubmittedGizmoOwnsPointerForCurrentFrame", TestOnlySubmittedGizmoOwnsPointerForCurrentFrame },
-		{ "ResolveGameObjectBoundsDistinguishesMeshPickingFromSelectionFallback", TestResolveGameObjectBoundsDistinguishesMeshPickingFromSelectionFallback },
+		{ "ResolveGameObjectBoundsAggregatesSelectableGeometry", TestResolveGameObjectBoundsAggregatesSelectableGeometry },
 	};
 
 	for (const auto& test : tests)

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -1225,6 +1225,12 @@ namespace
 			sourceRoot / "Content/Shaders/Lighting.glsl");
 		const std::string lightingHeader = ReadText(
 			sourceRoot / "Runtime/ECS/LightingECS.h");
+		const std::string standardShader = ReadText(
+			sourceRoot / "Content/Shaders/Standard.shader");
+		const std::string landscapeShader = ReadText(
+			sourceRoot / "Content/Shaders/Landscape.shader");
+		const std::string standardGltfShader = ReadText(
+			sourceRoot / "Content/Shaders/Standard_glTF.shader");
 
 		Require(lightingHeader.find("ShadowMapFormat = RHI::EFormat::R16_UNORM") !=
 				std::string::npos &&
@@ -1238,31 +1244,70 @@ namespace
 		Require(lightingSource.find("projCoords = projCoords * 0.5 + 0.5;") ==
 				std::string::npos,
 			"Vulkan zero-to-one shadow depth must not be remapped as OpenGL depth");
-		Require(lightingSource.find("float pcfDepth = texture(shadowMap, projCoords.xy + offset).r;") !=
+		Require(lightingSource.find("const float pcfDepth = texture(shadowMap, sampleUv).r;") !=
 				std::string::npos &&
 			lightingSource.find("texture(shadowMap, projCoords.xy + offset).r * 0.5 + 0.5") ==
 				std::string::npos,
 			"PCF must compare raw reverse-Z Vulkan depth values");
+		Require(lightingSource.find("any(lessThan(sampleUv, vec2(0.0f)))") !=
+				std::string::npos &&
+			lightingSource.find("shadow += 1.0f;") != std::string::npos,
+			"PCF taps outside a cascade projection must remain lit instead of repeating clamped border depth");
 		Require(lightingSource.find("projCoords.z < 0.0f || projCoords.z > 1.0f") !=
 				std::string::npos,
 			"shadow sampling must reject coordinates outside Vulkan's zero-to-one depth range");
 		Require(lightingSource.find("shadowType == SHADOW_TYPE_NONE") !=
 				std::string::npos &&
-			lightingSource.find("dot(surfaceNormal, surfaceToLightDirection)") !=
+			lightingSource.find("dot(normal, toLight)") !=
 				std::string::npos,
-			"directional shadow sampling must skip disabled shadows and derive slope bias from the direction toward the light");
-		Require(lightingSource.find("SHADOW_BIAS_MIN_TEXELS") !=
+			"directional shadow sampling must skip disabled shadows and derive receiver offset from the direction toward the light");
+		Require(lightingSource.find(
+				"return cascadeLayer == 0 ? lightShadowType : SHADOW_TYPE_PCF;") !=
 				std::string::npos &&
-			lightingSource.find("normalizedDepthPerTexel") != std::string::npos &&
-			lightingSource.find("SHADOW_BIAS_CASCADE_3_SCALE") != std::string::npos &&
-			lightingSource.find("SHADOW_BIAS_CASCADE_4_SCALE") != std::string::npos &&
-			lightingSource.find("const float biasedDepth =") !=
+			standardShader.find(
+				"GetDirectionalCascadeShadowType(light.shadowType, cascadeLayer)") !=
 				std::string::npos &&
-			lightingSource.find("exp(EVSM_C1 * biasedDepth)") !=
+			standardShader.find(
+				"GetDirectionalCascadeShadowType(light.shadowType, nextCascadeLayer)") !=
 				std::string::npos &&
-			lightingSource.find("-exp(-EVSM_C2 * biasedDepth)") !=
+			landscapeShader.find(
+				"GetDirectionalCascadeShadowType(light.shadowType, cascadeLayer)") !=
+				std::string::npos &&
+			landscapeShader.find(
+				"GetDirectionalCascadeShadowType(light.shadowType, nextCascadeLayer)") !=
+				std::string::npos &&
+			standardGltfShader.find(
+				"GetDirectionalCascadeShadowType(light.shadowType, cascadeLayer)") !=
+				std::string::npos &&
+			standardGltfShader.find(
+				"GetDirectionalCascadeShadowType(light.shadowType, nextCascadeLayer)") !=
 				std::string::npos,
-			"both EVSM warps must use the same non-zero receiver depth bias to avoid self-shadowing bands");
+			"CSM sampling and blending must interpret the near EVSM map and the wider PCF maps using their actual formats");
+		Require(lightingSource.find("float CalculateShadowDistanceFade(") !=
+				std::string::npos &&
+			lightingSource.find("cascadeLayer != NUM_CSM_CASCADES - 1") !=
+				std::string::npos &&
+			standardShader.find("shadow = mix(shadow, 1.0f, shadowDistanceFade);") !=
+				std::string::npos &&
+			landscapeShader.find("shadow = mix(shadow, 1.0f, shadowDistanceFade);") !=
+				std::string::npos &&
+			standardGltfShader.find("shadow = mix(shadow, 1.0f, shadowDistanceFade);") !=
+				std::string::npos,
+			"the final CSM cascade must fade to unshadowed lighting instead of ending at a visible hard boundary");
+		Require(lightingSource.find("SHADOW_RECEIVER_LIGHT_OFFSET") !=
+				std::string::npos &&
+			lightingSource.find("SHADOW_RECEIVER_NORMAL_OFFSET") != std::string::npos &&
+			lightingSource.find("vec3 OffsetDirectionalShadowReceiver(") != std::string::npos &&
+			lightingSource.find("normal * (SHADOW_RECEIVER_NORMAL_OFFSET * sinTheta)") != std::string::npos &&
+			lightingSource.find("currentDepth + bias") == std::string::npos &&
+			lightingSource.find("exp(EVSM_C1 * projCoords.z)") !=
+				std::string::npos &&
+			lightingSource.find("-exp(-EVSM_C2 * projCoords.z)") !=
+				std::string::npos &&
+			standardShader.find("cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f)") != std::string::npos &&
+			landscapeShader.find("cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f)") != std::string::npos &&
+			standardGltfShader.find("cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f)") != std::string::npos,
+			"all cascades and material shaders must project the same world-space-offset receiver to avoid split bands");
 
 		const std::string boundsSource = ReadText(
 			sourceRoot / "Runtime/Math/Bounds.cpp");
@@ -1342,8 +1387,10 @@ namespace
 			sourceRoot / "Content/Shaders/Sky.shader");
 		Require(skySource.find("float PlanetHeight(vec3 position)") != std::string::npos &&
 			skySource.find("vec2 RaySphereAtAltitude") != std::string::npos &&
+			skySource.find("ResolveAtmosphereRayOrigin") != std::string::npos &&
+			skySource.find("origin.y = max(origin.y, 0.0f)") == std::string::npos &&
 			skySource.find("length(position) - earthRadius") == std::string::npos,
-			"near-surface atmosphere math must avoid subtracting planet-sized floats to recover meter heights");
+			"near-surface atmosphere math must remain stable for arbitrary camera height without clamping world coordinates");
 	}
 
 	void TestPathTracerThicknessSamplerContract()

--- a/Tests/PhysicsRuntimeTests.cpp
+++ b/Tests/PhysicsRuntimeTests.cpp
@@ -97,6 +97,29 @@ namespace
 		return result;
 	}
 
+	Physics::RigidBodyDesc MakeTriangleMesh(
+		const InstanceId& instanceId,
+		const glm::vec3& position,
+		const glm::vec3& scale = glm::vec3(1.0f))
+	{
+		Physics::RigidBodyDesc result{};
+		result.m_instanceId = instanceId;
+		result.m_motionType = Physics::ERigidBodyMotionType::Static;
+		result.m_position = position;
+		result.m_scale = scale;
+
+		Physics::CollisionShapeDesc shape{};
+		shape.m_type = Physics::ECollisionShapeType::TriangleMesh;
+		shape.m_vertices.AddRange({
+			glm::vec3(-5.0f, 0.0f, -5.0f),
+			glm::vec3(5.0f, 0.0f, -5.0f),
+			glm::vec3(-5.0f, 0.0f, 5.0f),
+			glm::vec3(5.0f, 0.0f, 5.0f) });
+		shape.m_indices.AddRange({ 0u, 2u, 1u, 1u, 2u, 3u });
+		result.m_shapes.Add(std::move(shape));
+		return result;
+	}
+
 	void Step(Physics::PhysicsWorld& world, uint32_t numSteps)
 	{
 		for (uint32_t step = 0; step < numSteps; ++step)
@@ -200,6 +223,53 @@ namespace
 		Require(
 			hit.m_normal.y > 0.99f,
 			"raycast should return a world-space surface normal");
+	}
+
+	void TestStaticTriangleMeshCollisionAndRaycast()
+	{
+		Physics::PhysicsWorld world;
+		const InstanceId landscapeId = InstanceId::GenerateNewInstanceId();
+		uint32_t landscapeBody = ~0u;
+		uint32_t dynamicBody = ~0u;
+		Require(
+			world.CreateBody(
+				MakeTriangleMesh(
+					landscapeId,
+					glm::vec3(0.0f, 1.25f, 0.0f),
+					glm::vec3(2.0f, 1.0f, 2.0f)),
+				landscapeBody),
+			"static landscape triangle mesh should be created");
+		Require(
+			world.CreateBody(
+				MakeSphere(
+					InstanceId::GenerateNewInstanceId(),
+					Physics::ERigidBodyMotionType::Dynamic,
+					glm::vec3(0.0f, 4.0f, 0.0f),
+					0.5f),
+				dynamicBody),
+			"dynamic sphere above landscape should be created");
+
+		Step(world, 240u);
+		Physics::PhysicsBodyPose pose{};
+		Require(
+			world.GetBodyPose(dynamicBody, pose),
+			"dynamic sphere pose above triangle mesh should be readable");
+		Require(
+			pose.m_position.y > 1.70f && pose.m_position.y < 1.80f,
+			"dynamic sphere should settle on the scaled landscape mesh");
+
+		world.DestroyBody(dynamicBody);
+		Physics::PhysicsRaycastHit hit{};
+		Require(
+			world.Raycast(
+				glm::vec3(0.0f, 5.0f, 0.0f),
+				glm::vec3(0.0f, -1.0f, 0.0f),
+				10.0f,
+				hit),
+			"raycast should hit the landscape triangle mesh");
+		Require(
+			hit.m_instanceId == landscapeId && hit.m_normal.y > 0.99f,
+			"landscape raycast should resolve its owner and upward normal");
 	}
 
 	void TestKinematicAuthority()
@@ -951,6 +1021,7 @@ int main()
 	Physics::JoltRuntime runtime;
 	const std::pair<const char*, std::function<void()>> tests[] = {
 		{ "FixedStepGravityContactsAndRaycast", TestFixedStepGravityContactsAndRaycast },
+		{ "StaticTriangleMeshCollisionAndRaycast", TestStaticTriangleMeshCollisionAndRaycast },
 		{ "KinematicAuthority", TestKinematicAuthority },
 		{ "ScaledSphereVolume", TestScaledSphereVolume },
 		{ "CollisionLayersAndQueryMask", TestCollisionLayersAndQueryMask },

--- a/Tests/RemoteViewportRuntimeTests.cpp
+++ b/Tests/RemoteViewportRuntimeTests.cpp
@@ -614,6 +614,8 @@ namespace
 		const std::string editorSource = ReadText(sourceRoot / "Runtime/Submodules/Editor.cpp");
 		const std::string viewportControllerSource = ReadText(sourceRoot / "Runtime/Editor/EditorViewportController.cpp");
 		const std::string gameObjectSource = ReadText(sourceRoot / "Runtime/Engine/GameObject.cpp");
+		const std::string collisionShapeSource = ReadText(
+			sourceRoot / "Runtime/Components/CollisionShapeComponent.cpp");
 		const std::string imGuiSource = ReadText(sourceRoot / "Runtime/Submodules/ImGuiApi.cpp");
 		const std::string macInputSource = ReadText(sourceRoot / "Editor/Platforms/MacCatalyst/NativeSceneViewportHandler.MacCatalyst.cs");
 		const std::string windowsExports = ReadText(sourceRoot / "Lib/DllMain.cpp");
@@ -1000,21 +1002,34 @@ namespace
 		Require(resolveBoundsBegin != std::string::npos && viewportTickBegin > resolveBoundsBegin,
 			"viewport object bounds resolution must be bounded");
 		const std::string resolveBoundsBody = viewportControllerSource.substr(resolveBoundsBegin, viewportTickBegin - resolveBoundsBegin);
-		Require(resolveBoundsBody.find("model->GetBoundsAABB(meshRenderer->GetMeshIndex())") != std::string::npos &&
+		Require(resolveBoundsBody.find("model->GetBoundsAABB(") != std::string::npos &&
+			resolveBoundsBody.find("meshRenderer->GetMeshIndex())") != std::string::npos &&
 			resolveBoundsBody.find("model->GetBoundsAABB();") == std::string::npos,
 			"viewport selection and picking must use the selected glTF source mesh bounds instead of full-model bounds");
-		Require(selectionTickBody.find("ResolveGameObjectBounds(gameObject, bounds, bUsesMeshBounds) &&") != std::string::npos &&
-			selectionTickBody.find("bUsesMeshBounds)") != std::string::npos,
-			"viewport picking must exclude empty-object selection fallback bounds");
+		Require(selectionTickBody.find("bUsesSelectableGeometry) &&") != std::string::npos &&
+			resolveBoundsBody.find("DynamicCast<CollisionShapeComponent>()") != std::string::npos,
+			"viewport picking must include collision geometry and exclude empty-object selection fallback bounds");
 		const size_t selectedGizmoBegin = gameObjectSource.find("void GameObject::DrawEditorSelectedGizmo()");
 		const size_t selectedGizmoEnd = gameObjectSource.find("void GameObject::Tick(", selectedGizmoBegin);
 		Require(selectedGizmoBegin != std::string::npos && selectedGizmoEnd > selectedGizmoBegin,
 			"selected GameObject gizmo drawing must be bounded");
 		const std::string selectedGizmoBody = gameObjectSource.substr(selectedGizmoBegin, selectedGizmoEnd - selectedGizmoBegin);
-		Require(selectedGizmoBody.find("if (bUsesMeshBounds)") != std::string::npos &&
+		const size_t editorTickBegin = gameObjectSource.find("void GameObject::EditorTick(float deltaTime)");
+		const size_t selectedGizmoFunctionBegin = gameObjectSource.find("void GameObject::DrawEditorSelectedGizmo()", editorTickBegin);
+		Require(editorTickBegin != std::string::npos && selectedGizmoFunctionBegin > editorTickBegin &&
+			gameObjectSource.substr(editorTickBegin, selectedGizmoFunctionBegin - editorTickBegin).find("m_componentsToAdd = 0;") != std::string::npos,
+			"editor tick must release deferred components so components added to a running editor world can draw gizmos");
+		Require(selectedGizmoBody.find("if (bUsesSelectableGeometry)") != std::string::npos &&
 			selectedGizmoBody.find("DrawAABB(selectionBounds, selectionColor)") != std::string::npos &&
-			selectedGizmoBody.find("DrawSphere(selectionBounds.GetCenter(), 10.0f, selectionColor)") != std::string::npos,
-			"selected empty GameObjects must draw a radius-10 center sphere without changing mesh selection bounds");
+			collisionShapeSource.find("void CollisionShapeComponent::OnGizmo()") != std::string::npos &&
+			collisionShapeSource.find("case Physics::ECollisionShapeType::Box:") != std::string::npos &&
+			collisionShapeSource.find("case Physics::ECollisionShapeType::Sphere:") != std::string::npos &&
+			collisionShapeSource.find("case Physics::ECollisionShapeType::Capsule:") != std::string::npos &&
+			selectedGizmoBody.find("DrawSphere(selectionBounds.GetCenter(), 10.0f, selectionColor)") == std::string::npos,
+			"selected GameObjects must draw collision primitives without the empty-object debug sphere");
+		Require(collisionShapeSource.find("GetDebugContext()") != std::string::npos &&
+			selectedGizmoBody.find("i < m_components.Num()") != std::string::npos,
+			"collision gizmos must use the same selected-object debug path as mesh renderer bounds, including newly added components");
 		const size_t viewportResetBegin = viewportControllerSource.find("void EditorViewportController::Reset()", viewportTickBegin);
 		Require(viewportTickBegin != std::string::npos && viewportResetBegin > viewportTickBegin &&
 			viewportControllerSource.substr(viewportTickBegin, viewportResetBegin - viewportTickBegin).find("ResetImGuizmoInteractionState();") != std::string::npos,

--- a/Tests/SkyComponentContractTests.cpp
+++ b/Tests/SkyComponentContractTests.cpp
@@ -1099,13 +1099,21 @@ namespace
 				std::string::npos &&
 			skyShader.find("vec2 RaySphereAtAltitude") !=
 				std::string::npos &&
-			skyShader.find("planetToLightIntersection") !=
+			skyShader.find("ResolveAtmosphereRayOrigin") !=
+				std::string::npos &&
+			skyShader.find("origin.y = max(origin.y, 0.0f)") ==
+				std::string::npos &&
+			skyShader.find("const float q = -halfB") !=
+				std::string::npos &&
+			skyShader.find("heightDelta * (2.0f * earthRadius") !=
+				std::string::npos &&
+			skyShader.find("planetToLightIntersection") ==
 				std::string::npos &&
 			skyShader.find("if((-lightDirection).y < 0.0f)") ==
 				std::string::npos &&
 			skyShader.find("pow(angle / border, 3)") ==
 				std::string::npos,
-			"the atmosphere must preserve twilight, occlude sunlight with the planet, and avoid undefined negative pow inputs");
+			"the atmosphere must preserve twilight, handle below-datum cameras geometrically, occlude sunlight with the planet, and avoid undefined negative pow inputs");
 		Require(
 			sunShaftsShader.find("SunDiskVisibility") != std::string::npos &&
 			sunShaftsShader.find("sunVisibility <= 0.0f") != std::string::npos,

--- a/run_editor.py
+++ b/run_editor.py
@@ -77,6 +77,10 @@ def find_editor_artifact(host_os: str, framework: str, config: str, published: b
     if host_os == "mac":
         candidates = sorted(config_dir.rglob("SailorEditor.app"))
         if candidates:
+            runtime = "maccatalyst-arm64" if platform.machine() == "arm64" else "maccatalyst-x64"
+            runtime_candidates = [candidate for candidate in candidates if runtime in candidate.parts]
+            if runtime_candidates:
+                candidates = runtime_candidates
             if published:
                 pub = [c for c in candidates if "publish" in c.parts]
                 return pub[0] if pub else candidates[0]


### PR DESCRIPTION
## Summary

- add Hierarchy Copy/Paste and Duplicate with Cmd/Ctrl shortcuts, undo/redo integration, fresh GameObject identities, internal-reference remapping, and unchanged external references
- improve collision-shape authoring, selection visualization, physics behavior, viewport interaction, and runtime lifecycle handling
- refine landscape vegetation generation, resource readiness, LOD/culling/collider settings, and inspector defaults on top of the current landscape architecture
- fix cascade/shadow, sky, motion-vector, Vulkan presentation, and related rendering behavior
- make the macOS editor launcher select the current architecture-specific Mac Catalyst bundle instead of a stale universal app
- include only required engine shaders and shader metadata from Content; no worlds, models, audio, Bistro assets, or project content are included

## Root causes

The Hierarchy workflow had no subtree clipboard command, and prefab-style duplication needed an explicit forced-new-ID path plus one combined dependency context so internal and external references could coexist. On Apple Silicon, the launcher sorted all app bundles and opened the first result, which could be an older universal bundle rather than the newly built arm64 editor.

The remaining runtime/editor fixes reconcile local follow-up work with the landscape architecture already present on main, retaining the shared RHILodPolicy and split landscape inspector partial.

## Validation

- Editor contract tests: 777 passed
- Release MAUI arm64 build: succeeded with no errors
- Release native build: SailorExec and all selected contract targets succeeded
- BoundsContractTests: passed
- EcsLifecycleContractTests: passed
- EditorViewportControllerContractTests: passed
- GpuCullingContractTests: passed
- PhysicsRuntimeTests: passed
- RemoteViewportRuntimeTests: passed
- SkyComponentContractTests: passed
- git diff --check: clean

## Notes

This PR is intentionally a draft for human review and is not merged.