### PR TITLE
Add point and spot light shadows

### DIFF
--- a/Content/DefaultRenderer.renderer
+++ b/Content/DefaultRenderer.renderer
@@ -134,7 +134,7 @@ frame:
 - name: LightCulling
 ############################
   renderTargets:
-  - depthStencil: LinearDepth
+  - linearDepth: LinearDepth
 
 ############################
 - name: Clear

--- a/Content/DefaultRenderer.renderer
+++ b/Content/DefaultRenderer.renderer
@@ -134,7 +134,7 @@ frame:
 - name: LightCulling
 ############################
   renderTargets:
-  - depthStencil: DepthBuffer
+  - linearDepth: LinearDepth
 
 ############################
 - name: Clear

--- a/Content/DefaultRenderer.renderer
+++ b/Content/DefaultRenderer.renderer
@@ -134,7 +134,7 @@ frame:
 - name: LightCulling
 ############################
   renderTargets:
-  - linearDepth: LinearDepth
+  - depthStencil: DepthBuffer
 
 ############################
 - name: Clear

--- a/Content/EditorRenderer.renderer
+++ b/Content/EditorRenderer.renderer
@@ -139,7 +139,7 @@ frame:
 - name: LightCulling
 ############################
   renderTargets:
-  - depthStencil: LinearDepth
+  - linearDepth: LinearDepth
 
 ############################
 - name: Clear

--- a/Content/EditorRenderer.renderer
+++ b/Content/EditorRenderer.renderer
@@ -139,7 +139,7 @@ frame:
 - name: LightCulling
 ############################
   renderTargets:
-  - linearDepth: LinearDepth
+  - depthStencil: DepthBuffer
 
 ############################
 - name: Clear

--- a/Content/EditorRenderer.renderer
+++ b/Content/EditorRenderer.renderer
@@ -139,7 +139,7 @@ frame:
 - name: LightCulling
 ############################
   renderTargets:
-  - depthStencil: DepthBuffer
+  - linearDepth: LinearDepth
 
 ############################
 - name: Clear

--- a/Content/Experimental/MeshParticles/Particle.shader
+++ b/Content/Experimental/MeshParticles/Particle.shader
@@ -98,7 +98,7 @@ glslVertex: |
       uint instance[];
   } shadowIndices;
   
-  layout(set=1, binding=8) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  layout(set=1, binding=8) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
   layout(set=1, binding=9) uniform sampler2D g_aoSampler;
 
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
@@ -217,7 +217,7 @@ glslFragment: |
       uint instance[];
   } shadowIndices;
   
-  layout(set=1, binding=8) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  layout(set=1, binding=8) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
   layout(set=1, binding=9) uniform sampler2D g_aoSampler;
   
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO

--- a/Content/ExperimentalRenderer.renderer
+++ b/Content/ExperimentalRenderer.renderer
@@ -114,7 +114,7 @@ frame:
 
 - name: LightCulling
   renderTargets:
-  - depthStencil: DepthBuffer
+  - linearDepth: LinearDepth
 
 - name: ShadowPrepass
 

--- a/Content/ExperimentalRenderer.renderer
+++ b/Content/ExperimentalRenderer.renderer
@@ -114,7 +114,7 @@ frame:
 
 - name: LightCulling
   renderTargets:
-  - depthStencil: LinearDepth
+  - linearDepth: LinearDepth
 
 - name: ShadowPrepass
 

--- a/Content/ExperimentalRenderer.renderer
+++ b/Content/ExperimentalRenderer.renderer
@@ -114,7 +114,7 @@ frame:
 
 - name: LightCulling
   renderTargets:
-  - linearDepth: LinearDepth
+  - depthStencil: DepthBuffer
 
 - name: ShadowPrepass
 

--- a/Content/Models/Box/materials/Default.mat
+++ b/Content/Models/Box/materials/Default.mat
@@ -4,7 +4,8 @@ bSupportMultisampling: true
 bCustomDepthShader: false
 depthBias: 0
 renderQueue: Opaque
-defines: ~
+defines:
+- SUPPORT_LIGHTS_OVERFLOW
 cullMode: Back
 blendMode: None
 fillMode: Fill

--- a/Content/Shaders/ComputeLightCulling.shader
+++ b/Content/Shaders/ComputeLightCulling.shader
@@ -116,10 +116,11 @@ glslCompute: |
     {
         vec2 uv = vec2(gl_GlobalInvocationID.xy + vec2(0.5, 0.5)) / PushConstants.viewportSize;
         uv.y = 1 - uv.y;
-        float linearDepth = texture(sceneDepth, uv).x;
+        const float viewDepth = texture(sceneDepth, uv).x;
 
-        // Convert depth to uint so we can do atomic min and max comparisons between the threads
-        uint depthInt = floatBitsToUint(linearDepth);
+        // LinearDepth stores positive view-space distance. Positive IEEE floats
+        // preserve ordering when reduced through their uint representation.
+        uint depthInt = floatBitsToUint(viewDepth);
         atomicMax(maxDepthInt, depthInt);
         atomicMin(minDepthInt, depthInt);
     }
@@ -172,13 +173,8 @@ glslCompute: |
           // Reverse Z
           lightPosViewSpace.z *= -1;
 
-          float zFar = uintBitsToFloat(maxDepthInt);
-          float zNear = uintBitsToFloat(minDepthInt);
-
-          // Add extra bounds
-          const float diff = zFar - zNear;
-          zFar -= diff;
-          zNear += diff;
+          const float zFar = uintBitsToFloat(maxDepthInt);
+          const float zNear = uintBitsToFloat(minDepthInt);
 
           // If greater than zero, then it is a visible light
           if (SphereFrustumOverlaps(lightPosViewSpace.xyz, radius, frustum, zNear, zFar))

--- a/Content/Shaders/ComputeLightCulling.shader
+++ b/Content/Shaders/ComputeLightCulling.shader
@@ -113,12 +113,15 @@ glslCompute: |
 
       barrier();
 
-      // LinearDepth is produced from the same opaque/masked depth prepass and
-      // stores positive view-space distance in framebuffer coordinates.
+      // Read the depth-prepass pixel that belongs to this framebuffer tile and
+      // reconstruct positive view-space distance without another viewport pass.
       const bool isInsideViewport = all(lessThan(location, PushConstants.viewportSize));
       if (isInsideViewport)
       {
-          const float viewDepth = texelFetch(sceneDepth, location, 0).x;
+          const float deviceDepth = texelFetch(sceneDepth, location, 0).x;
+          const float viewDepth = LinearizeDepth(
+              deviceDepth,
+              frame.cameraZNearZFar.yx);
 
           // Positive IEEE floats preserve ordering when reduced through uint atomics.
           const uint depthInt = floatBitsToUint(viewDepth);
@@ -161,7 +164,7 @@ glslCompute: |
               continue;
           }
 
-          float radius = light.instance[lightIndex].bounds.x;
+          const float radius = light.instance[lightIndex].bounds.x;
           vec4 lightPosViewSpace = frame.view * vec4(light.instance[lightIndex].worldPosition, 1);
           lightPosViewSpace /= lightPosViewSpace.w;
 

--- a/Content/Shaders/ComputeLightCulling.shader
+++ b/Content/Shaders/ComputeLightCulling.shader
@@ -32,7 +32,7 @@ glslCompute: |
       LightsGrid instance[];
   } lightsGrid;
 
-  layout(set = 1, binding = 2) uniform sampler2D sceneDepth;
+  layout(set = 1, binding = 2) uniform sampler2D linearDepth;
 
   layout(set = 2, binding = 0) uniform FrameData
   {
@@ -46,55 +46,69 @@ glslCompute: |
       float deltaTime;
   } frame;
 
+  shared ViewFrustum tileFrustum;
   shared int lightCountForTile;
   shared uint minDepthInt;
   shared uint maxDepthInt;
 
-  bool SphereTileOverlaps(vec3 lightPosition, float radius, ivec2 tileId,
-      float zNear, float zFar)
+  ViewFrustum CreateTileFrustum(ivec2 tileId)
+  {
+      const vec2 tileMin = vec2(tileId * LIGHTS_CULLING_TILE_SIZE);
+      const vec2 tileMax = min(
+          vec2((tileId + ivec2(1)) * LIGHTS_CULLING_TILE_SIZE),
+          vec2(PushConstants.viewportSize));
+      const vec2 tileCenter = (tileMin + tileMax) * 0.5f;
+      const vec3 eyePosition = vec3(0.0f);
+      vec3 corners[4];
+
+      corners[0] = ScreenSpaceToViewSpace(
+          vec4(tileMin, NdcNearPlane, 1.0f),
+          PushConstants.viewportSize,
+          frame.invProjection).xyz;
+      corners[1] = ScreenSpaceToViewSpace(
+          vec4(tileMax.x, tileMin.y, NdcNearPlane, 1.0f),
+          PushConstants.viewportSize,
+          frame.invProjection).xyz;
+      corners[2] = ScreenSpaceToViewSpace(
+          vec4(tileMin.x, tileMax.y, NdcNearPlane, 1.0f),
+          PushConstants.viewportSize,
+          frame.invProjection).xyz;
+      corners[3] = ScreenSpaceToViewSpace(
+          vec4(tileMax, NdcNearPlane, 1.0f),
+          PushConstants.viewportSize,
+          frame.invProjection).xyz;
+
+      ViewFrustum result;
+      result.planes[0] = ComputePlane(eyePosition, corners[2], corners[0]);
+      result.planes[1] = ComputePlane(eyePosition, corners[1], corners[3]);
+      result.planes[2] = ComputePlane(eyePosition, corners[0], corners[1]);
+      result.planes[3] = ComputePlane(eyePosition, corners[3], corners[2]);
+      result.center = ScreenSpaceToViewSpace(
+          vec4(tileCenter, NdcNearPlane, 1.0f),
+          PushConstants.viewportSize,
+          frame.invProjection).xy;
+
+      return result;
+  }
+
+  bool SphereTileOverlaps(vec3 lightPosition, float radius,
+      ViewFrustum frustum, float zNear, float zFar)
   {
       if(lightPosition.z - radius > zFar || lightPosition.z + radius < zNear)
       {
           return false;
       }
 
-      // A sphere intersecting the camera plane can cover any screen tile.
-      if(lightPosition.z <= radius)
+      for(int i = 0; i < 4; ++i)
       {
-          return true;
+          if(dot(frustum.planes[i].xyz, lightPosition) -
+              frustum.planes[i].w < -radius)
+          {
+              return false;
+          }
       }
 
-      // Project the sphere's view-space AABB. It is slightly wider than the
-      // exact projected sphere, but cannot reject a pixel influenced by it.
-      // Evaluate both depths because the ratio's extremum depends on the sign
-      // of the view-space coordinate.
-      const float nearestDepth = lightPosition.z - radius;
-      const float farthestDepth = lightPosition.z + radius;
-      const vec2 boundsMin = lightPosition.xy - vec2(radius);
-      const vec2 boundsMax = lightPosition.xy + vec2(radius);
-      vec2 projectedMin = min(
-          min(boundsMin / nearestDepth, boundsMin / farthestDepth),
-          min(boundsMax / nearestDepth, boundsMax / farthestDepth));
-      vec2 projectedMax = max(
-          max(boundsMin / nearestDepth, boundsMin / farthestDepth),
-          max(boundsMax / nearestDepth, boundsMax / farthestDepth));
-
-      // Sailor renders with a negative-height Vulkan viewport, so framebuffer
-      // rows (and gl_FragCoord) run opposite to mathematical view-space Y.
-      const vec2 projectionScale = vec2(
-          frame.projection[0][0],
-          -frame.projection[1][1]);
-      projectedMin *= projectionScale;
-      projectedMax *= projectionScale;
-      const vec2 ndcMin = min(projectedMin, projectedMax);
-      const vec2 ndcMax = max(projectedMin, projectedMax);
-      const vec2 screenMin = (ndcMin * 0.5f + 0.5f) * PushConstants.viewportSize;
-      const vec2 screenMax = (ndcMax * 0.5f + 0.5f) * PushConstants.viewportSize;
-      const vec2 tileMin = vec2(tileId * LIGHTS_CULLING_TILE_SIZE);
-      const vec2 tileMax = vec2((tileId + ivec2(1)) * LIGHTS_CULLING_TILE_SIZE);
-
-      return all(greaterThanEqual(screenMax, tileMin)) &&
-          all(lessThanEqual(screenMin, tileMax));
+      return true;
   }
 
   void main()
@@ -118,15 +132,19 @@ glslCompute: |
       const bool isInsideViewport = all(lessThan(location, PushConstants.viewportSize));
       if (isInsideViewport)
       {
-          const float deviceDepth = texelFetch(sceneDepth, location, 0).x;
-          const float viewDepth = LinearizeDepth(
-              deviceDepth,
-              frame.cameraZNearZFar.yx);
+          const float viewDepth = texelFetch(linearDepth, location, 0).x;
 
           // Positive IEEE floats preserve ordering when reduced through uint atomics.
           const uint depthInt = floatBitsToUint(viewDepth);
           atomicMax(maxDepthInt, depthInt);
           atomicMin(minDepthInt, depthInt);
+      }
+
+      barrier();
+
+      if(gl_LocalInvocationIndex == 0)
+      {
+          tileFrustum = CreateTileFrustum(tileId);
       }
 
       barrier();
@@ -174,9 +192,10 @@ glslCompute: |
           const float zNear = uintBitsToFloat(minDepthInt);
           const float zFar = uintBitsToFloat(maxDepthInt);
 
-          // Cull against the conservative projected sphere bounds and the
-          // exact depth interval occupied by this tile.
-          if (SphereTileOverlaps(lightPosViewSpace.xyz, radius, tileId, zNear, zFar))
+          // Cull against the tile's view frustum and the exact depth interval
+          // occupied by this tile.
+          if (SphereTileOverlaps(
+              lightPosViewSpace.xyz, radius, tileFrustum, zNear, zFar))
           {
               // Add index to the shared array of visible indices
               uint offset = atomicAdd(lightCountForTile, 1);

--- a/Content/Shaders/ComputeLightCulling.shader
+++ b/Content/Shaders/ComputeLightCulling.shader
@@ -46,58 +46,60 @@ glslCompute: |
       float deltaTime;
   } frame;
 
-  shared ViewFrustum frustum;
   shared int lightCountForTile;
   shared uint minDepthInt;
   shared uint maxDepthInt;
-  shared uint candidateIndices[LIGHTS_CANDIDATES_PER_TILE];
-  shared float candidateImpact[LIGHTS_CANDIDATES_PER_TILE];
 
-  // Construct view frustum
-  ViewFrustum CreateFrustum(ivec2 tileId)
+  bool SphereTileOverlaps(vec3 lightPosition, float radius, ivec2 tileId,
+      float zNear, float zFar)
   {
-      vec3 eyePos = vec3(0,0,0);
-      vec4 screenSpace[5];
-
-      // Top left point
-      screenSpace[0] = vec4(tileId.xy * LIGHTS_CULLING_TILE_SIZE, -1.0f, 1.0f );
-      // Top right point
-      screenSpace[1] = vec4(vec2(tileId.x + 1, tileId.y) * LIGHTS_CULLING_TILE_SIZE, -1.0f, 1.0f );
-      // Bottom left point
-      screenSpace[2] = vec4(vec2(tileId.x, tileId.y + 1) * LIGHTS_CULLING_TILE_SIZE, -1.0f, 1.0f );
-      // Bottom right point
-      screenSpace[3] = vec4(vec2(tileId.x + 1, tileId.y + 1) * LIGHTS_CULLING_TILE_SIZE, -1.0f, 1.0f );
-
-        // Center point
-      screenSpace[4] = (screenSpace[0] + screenSpace[3]) * 0.5f;
-
-      vec3 viewSpace[5];
-      // Now convert the screen space points to view space
-      for ( int i = 0; i < 5; i++ )
+      if(lightPosition.z - radius > zFar || lightPosition.z + radius < zNear)
       {
-          viewSpace[i] = ScreenSpaceToViewSpace(screenSpace[i], frame.viewportSize, frame.invProjection).xyz;
+          return false;
       }
 
-    ViewFrustum frustum;
+      // A sphere intersecting the camera plane can cover any screen tile.
+      if(lightPosition.z <= radius)
+      {
+          return true;
+      }
 
-    // Left plane
-    frustum.planes[0] = ComputePlane(eyePos, viewSpace[2], viewSpace[0]);
-    // Right plane
-    frustum.planes[1] = ComputePlane(eyePos, viewSpace[1], viewSpace[3]);
-    // Top plane
-    frustum.planes[2] = ComputePlane(eyePos, viewSpace[0], viewSpace[1]);
-    // Bottom plane
-    frustum.planes[3] = ComputePlane(eyePos, viewSpace[3], viewSpace[2]);
+      // Project the sphere's view-space AABB. It is slightly wider than the
+      // exact projected sphere, but cannot reject a pixel influenced by it.
+      // Evaluate both depths because the ratio's extremum depends on the sign
+      // of the view-space coordinate.
+      const float nearestDepth = lightPosition.z - radius;
+      const float farthestDepth = lightPosition.z + radius;
+      const vec2 boundsMin = lightPosition.xy - vec2(radius);
+      const vec2 boundsMax = lightPosition.xy + vec2(radius);
+      vec2 projectedMin = min(
+          min(boundsMin / nearestDepth, boundsMin / farthestDepth),
+          min(boundsMax / nearestDepth, boundsMax / farthestDepth));
+      vec2 projectedMax = max(
+          max(boundsMin / nearestDepth, boundsMin / farthestDepth),
+          max(boundsMax / nearestDepth, boundsMax / farthestDepth));
 
-      frustum.center = viewSpace[4].xy;
+      // Sailor renders with a negative-height Vulkan viewport, so framebuffer
+      // rows (and gl_FragCoord) run opposite to mathematical view-space Y.
+      const vec2 projectionScale = vec2(
+          frame.projection[0][0],
+          -frame.projection[1][1]);
+      projectedMin *= projectionScale;
+      projectedMax *= projectionScale;
+      const vec2 ndcMin = min(projectedMin, projectedMax);
+      const vec2 ndcMax = max(projectedMin, projectedMax);
+      const vec2 screenMin = (ndcMin * 0.5f + 0.5f) * PushConstants.viewportSize;
+      const vec2 screenMax = (ndcMax * 0.5f + 0.5f) * PushConstants.viewportSize;
+      const vec2 tileMin = vec2(tileId * LIGHTS_CULLING_TILE_SIZE);
+      const vec2 tileMax = vec2((tileId + ivec2(1)) * LIGHTS_CULLING_TILE_SIZE);
 
-      return frustum;
+      return all(greaterThanEqual(screenMax, tileMin)) &&
+          all(lessThanEqual(screenMin, tileMax));
   }
 
   void main()
   {
       ivec2 location = ivec2(gl_GlobalInvocationID.xy);
-      ivec2 itemID = ivec2(gl_LocalInvocationID.xy);
       ivec2 tileId = ivec2(gl_WorkGroupID.xy);
       ivec2 tileNumber = ivec2(gl_NumWorkGroups.xy);
       uint tileIndex = tileId.y * tileNumber.x + tileId.x;
@@ -111,25 +113,17 @@ glslCompute: |
 
       barrier();
 
-    const bool isInsideViewport = all(lessThan(location, PushConstants.viewportSize));
-    if (isInsideViewport)
-    {
-        vec2 uv = vec2(gl_GlobalInvocationID.xy + vec2(0.5, 0.5)) / PushConstants.viewportSize;
-        uv.y = 1 - uv.y;
-        const float viewDepth = texture(sceneDepth, uv).x;
-
-        // LinearDepth stores positive view-space distance. Positive IEEE floats
-        // preserve ordering when reduced through their uint representation.
-        uint depthInt = floatBitsToUint(viewDepth);
-        atomicMax(maxDepthInt, depthInt);
-        atomicMin(minDepthInt, depthInt);
-    }
-
-      barrier();
-
-      if (gl_LocalInvocationIndex == 0)
+      // LinearDepth is produced from the same opaque/masked depth prepass and
+      // stores positive view-space distance in framebuffer coordinates.
+      const bool isInsideViewport = all(lessThan(location, PushConstants.viewportSize));
+      if (isInsideViewport)
       {
-          frustum = CreateFrustum(tileId);
+          const float viewDepth = texelFetch(sceneDepth, location, 0).x;
+
+          // Positive IEEE floats preserve ordering when reduced through uint atomics.
+          const uint depthInt = floatBitsToUint(viewDepth);
+          atomicMax(maxDepthInt, depthInt);
+          atomicMin(minDepthInt, depthInt);
       }
 
       barrier();
@@ -144,7 +138,7 @@ glslCompute: |
       {
           // Get the lightIndex to test for this thread / pass. If the index is >= light count, then this thread can stop testing lights
           uint lightIndex = i * threadCount + gl_LocalInvocationIndex;
-          if (lightIndex >= PushConstants.lightsNum || lightCountForTile >= LIGHTS_CANDIDATES_PER_TILE)
+          if (lightIndex >= PushConstants.lightsNum)
           {
               break;
           }
@@ -158,12 +152,13 @@ glslCompute: |
           if(light.instance[lightIndex].type == 0)
           {
               uint offset = atomicAdd(lightCountForTile, 1);
-              if(offset < LIGHTS_CANDIDATES_PER_TILE)
+              if(offset < LIGHTS_PER_TILE)
               {
-                  candidateIndices[offset] = int(lightIndex);
-                  candidateImpact[offset] = 0.0f;
-                  continue;
+                  culledLights.indices[
+                      tileIndex * LIGHTS_PER_TILE + offset] =
+                      lightIndex;
               }
+              continue;
           }
 
           float radius = light.instance[lightIndex].bounds.x;
@@ -173,18 +168,20 @@ glslCompute: |
           // Reverse Z
           lightPosViewSpace.z *= -1;
 
-          const float zFar = uintBitsToFloat(maxDepthInt);
           const float zNear = uintBitsToFloat(minDepthInt);
+          const float zFar = uintBitsToFloat(maxDepthInt);
 
-          // If greater than zero, then it is a visible light
-          if (SphereFrustumOverlaps(lightPosViewSpace.xyz, radius, frustum, zNear, zFar))
+          // Cull against the conservative projected sphere bounds and the
+          // exact depth interval occupied by this tile.
+          if (SphereTileOverlaps(lightPosViewSpace.xyz, radius, tileId, zNear, zFar))
           {
               // Add index to the shared array of visible indices
               uint offset = atomicAdd(lightCountForTile, 1);
-              if(offset < LIGHTS_CANDIDATES_PER_TILE)
+              if(offset < LIGHTS_PER_TILE)
               {
-                  candidateIndices[offset] = int(lightIndex);
-                  candidateImpact[offset] = length(lightPosViewSpace.xyz - vec3(frustum.center.xy, (zFar + zNear) * 0.5));
+                  culledLights.indices[
+                      tileIndex * LIGHTS_PER_TILE + offset] =
+                      lightIndex;
               }
           }
       }
@@ -192,49 +189,15 @@ glslCompute: |
 
       if(gl_LocalInvocationIndex == 0)
       {
-          uint numCandidates = min(lightCountForTile, LIGHTS_CANDIDATES_PER_TILE);
-
-          // Sort by distance
-          if(numCandidates > LIGHTS_PER_TILE)
-          {
-              uint numSorted = LIGHTS_PER_TILE;
-
-              for(uint i = 0; i < numCandidates-1; i++)
-              {
-                  for(uint j = 0; j < numCandidates - i - 1; j++)
-                  {
-                      if(candidateImpact[j] < candidateImpact[j+1])
-                      {
-                          float value = candidateImpact[j];
-                          candidateImpact[j] = candidateImpact[j+1];
-                          candidateImpact[j+1] = value;
-
-                          uint index = candidateIndices[j];
-                          candidateIndices[j] = candidateIndices[j+1];
-                          candidateIndices[j+1] = index;
-                      }
-                  }
-
-                  --numSorted;
-
-                  if(numSorted == 0)
-                  {
-                      break;
-                  }
-              }
-          }
-
           // Fill lightsGrid
-        const uint numLights = min(numCandidates, LIGHTS_PER_TILE);
-        const uint offset = tileIndex * LIGHTS_PER_TILE;
+          const uint uncappedNumLights = uint(lightCountForTile);
+          const uint numLights = min(uncappedNumLights, uint(LIGHTS_PER_TILE));
+          const uint offset = tileIndex * LIGHTS_PER_TILE;
 
-          lightsGrid.instance[tileIndex].num = numLights;
+          const bool lightsOverflow = uncappedNumLights > LIGHTS_PER_TILE;
+          lightsGrid.instance[tileIndex].num = lightsOverflow ?
+              (uint(PushConstants.lightsNum) | LIGHT_TILE_OVERFLOW_BIT) :
+              numLights;
           lightsGrid.instance[tileIndex].offset = offset;
-
-          // Copy calculated data
-          for(uint i = 0; i < numLights; i++)
-          {
-              culledLights.indices[offset + i] = candidateIndices[numCandidates - i - 1];
-          }
       }
   }

--- a/Content/Shaders/ComputeMeshCulling.shader
+++ b/Content/Shaders/ComputeMeshCulling.shader
@@ -150,7 +150,7 @@ glslCompute: |
 
     float radius = sphereBounds.w * ConservativeSphereScale(data.instance[instanceIndex].model);
 
-    bool bIsCulled = !SphereFrustumOverlaps(center.xyz, radius, frustum, frame.cameraZNearZFar.y, frame.cameraZNearZFar.x);
+    bool bIsCulled = !SphereFrustumOverlaps(center.xyz, radius, frustum, frame.cameraZNearZFar.x, frame.cameraZNearZFar.y);
   
     return bIsCulled;
   }

--- a/Content/Shaders/Constants.glsl
+++ b/Content/Shaders/Constants.glsl
@@ -20,7 +20,8 @@
 #define GPU_CULLING_GROUP_SIZE 256
 
 // Shadows
-#define MAX_SHADOWS_IN_VIEW 128
+#define MAX_SHADOWS_IN_VIEW 2048
+#define MAX_SHADOW_MAP_SAMPLERS 128
 #define MAX_TEXTURES_IN_SCENE 8192
 #define NUM_CSM_CASCADES 4
 const float ShadowMaxDistance = 200;

--- a/Content/Shaders/Debug.shader
+++ b/Content/Shaders/Debug.shader
@@ -127,9 +127,9 @@ glslFragment: |
     const uint offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0;
     const uint listLength = uint(culledLights.indices.length());
     const uint availableLights = offset < listLength ? listLength - offset : 0;
-    const uint numLights = hasLightTile ? min(
-        min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE)),
-        availableLights) : 0;
+    const uint numLights = !hasLightTile ? 0u : min(
+        min(lightsGrid.instance[tileIndex].num & LIGHT_TILE_COUNT_MASK, uint(LIGHTS_PER_TILE)),
+        availableLights);
     
     for(int i = 0; i < numLights; i++)
     {

--- a/Content/Shaders/DepthOnly.shader
+++ b/Content/Shaders/DepthOnly.shader
@@ -1,6 +1,7 @@
 ---
 defines:
 - SKINNING
+- MASKED
 
 includes:
 - Shaders/Constants.glsl
@@ -8,6 +9,7 @@ includes:
 glslCommon: |
   #version 460
   #extension GL_ARB_separate_shader_objects : enable
+  #extension GL_EXT_nonuniform_qualifier : require
    
 glslVertex: |
   layout(location=DefaultPositionBinding) in vec3 inPosition;
@@ -65,15 +67,34 @@ glslVertex: |
   const uint INVALID_SKELETON_OFFSET = 0xFFFFFFFFu;
 
   #ifdef SKINNING
+  #ifdef MASKED
+  layout(std430, set = 3, binding = 0) readonly buffer BoneMatricesSSBO
+  #else
   layout(std430, set = 2, binding = 0) readonly buffer BoneMatricesSSBO
+  #endif
   {
       BoneData instance[];
   } bones;
+  #endif
+
+  #ifdef MASKED
+  layout(location=DefaultTexcoordBinding) in vec2 inTexcoord;
+  layout(location=DefaultColorBinding) in vec4 inColor;
+  layout(location=0) out vec2 outTexcoord;
+  layout(location=1) flat out uint outBaseColorSampler;
+  layout(location=2) flat out float outAlphaCutoff;
+  layout(location=3) out float outVertexAlpha;
   #endif
   
   void main() 
   {
       mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
+  #ifdef MASKED
+      outTexcoord = inTexcoord;
+      outBaseColorSampler = data.instance[gl_InstanceIndex].materialInstance;
+      outAlphaCutoff = uintBitsToFloat(data.instance[gl_InstanceIndex].padding);
+      outVertexAlpha = inColor.a;
+  #endif
   #ifdef SKINNING
       uint offset = data.instance[gl_InstanceIndex].skeletonOffset;
       if (offset != INVALID_SKELETON_OFFSET)
@@ -90,6 +111,47 @@ glslVertex: |
   }
   
 glslFragment: |
+  #ifdef MASKED
+  layout(location=0) in vec2 inTexcoord;
+  layout(location=1) flat in uint inBaseColorSampler;
+  layout(location=2) flat in float inAlphaCutoff;
+  layout(location=3) in float inVertexAlpha;
+
+  #if defined(SAILOR_TEXTURE_REMAP)
+  layout(std430, set=2, binding=0) readonly buffer TextureSamplerRemapSSBO
+  {
+      uint indices[MAX_TEXTURES_IN_SCENE];
+  } textureSamplerRemap;
+  layout(set=2, binding=1) uniform sampler2D textureSamplers[];
+  #else
+  layout(set=2, binding=0) uniform sampler2D textureSamplers[];
+  #endif
+
+  uint ResolveTextureSamplerIndex(uint globalTextureIndex)
+  {
+  #if defined(SAILOR_TEXTURE_REMAP)
+      if(globalTextureIndex >= MAX_TEXTURES_IN_SCENE)
+      {
+        return 0;
+      }
+      return textureSamplerRemap.indices[globalTextureIndex];
+  #else
+      return globalTextureIndex;
+  #endif
+  }
+  #endif
+
   void main() 
   {
+  #ifdef MASKED
+      float alpha = inVertexAlpha;
+      if(inBaseColorSampler != 0u)
+      {
+        alpha *= texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(inBaseColorSampler))], inTexcoord).a;
+      }
+      if(alpha < inAlphaCutoff)
+      {
+        discard;
+      }
+  #endif
   }

--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -4,7 +4,8 @@ includes:
 - Shaders/Math.glsl
 - Shaders/Lighting.glsl
 
-defines: []
+defines:
+- SUPPORT_LIGHTS_OVERFLOW
 
 glslCommon: |
   #version 460
@@ -113,7 +114,7 @@ glslVertex: |
   } shadowIndices;
 
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
 
      layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
      {
@@ -273,7 +274,7 @@ glslFragment: |
   } shadowIndices;
 
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
 
      layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
      {
@@ -392,10 +393,17 @@ glslFragment: |
       return 1.0f;
     }
 
+    const uint packedAtlasTile = shadowAtlasTiles.instance[shadowMapIndex];
+    const uint shadowSamplerIndex = NUM_CSM_CASCADES + DecodeShadowAtlasIndex(packedAtlasTile);
+    if(shadowSamplerIndex >= MAX_SHADOW_MAP_SAMPLERS)
+    {
+      return 1.0f;
+    }
+
     return CalculateLocalPcfShadow(
-      shadowMaps[NUM_CSM_CASCADES],
+      shadowMaps[nonuniformEXT(shadowSamplerIndex)],
       lightsMatrices.instance[shadowMapIndex],
-      DecodeShadowAtlasRect(shadowAtlasTiles.instance[shadowMapIndex]),
+      DecodeShadowAtlasRect(packedAtlasTile),
       worldPosition,
       surfaceNormal,
       surfaceToLightDirection,
@@ -559,15 +567,25 @@ glslFragment: |
     const uint offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0;
     const uint listLength = uint(culledLights.indices.length());
     const uint availableLights = offset < listLength ? listLength - offset : 0;
-    const uint numLights = hasLightTile ? min(
-        min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE)),
-        availableLights) : 0;
+    const uint packedNumLights = hasLightTile ? lightsGrid.instance[tileIndex].num : 0u;
+    const bool lightsOverflow = (packedNumLights & LIGHT_TILE_OVERFLOW_BIT) != 0u;
+    const uint numLights = !hasLightTile ? 0u :
+    #ifdef SUPPORT_LIGHTS_OVERFLOW
+        (lightsOverflow ? min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(light.instance.length())) :
+            min(packedNumLights & LIGHT_TILE_COUNT_MASK, availableLights));
+    #else
+        min(min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(LIGHTS_PER_TILE)), availableLights);
+    #endif
 
     outColor.xyz = AmbientLighting(material, F0, Lr, normal, cosLo);
 
     for(int i = 0; i < numLights; i++)
     {
+    #ifdef SUPPORT_LIGHTS_OVERFLOW
+        uint index = lightsOverflow ? uint(i) : culledLights.indices[offset + i];
+    #else
         uint index = culledLights.indices[offset + i];
+    #endif
         if(index == uint(-1) ||
             index >= uint(light.instance.length()) ||
             light.instance[index].type == INVALID_LIGHT_TYPE)

--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -115,6 +115,11 @@ glslVertex: |
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
   layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
 
+     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
+     {
+         uint instance[];
+     } shadowAtlasTiles;
+
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {
       PerInstanceData instance[];
@@ -270,6 +275,11 @@ glslFragment: |
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
   layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
 
+     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
+     {
+         uint instance[];
+     } shadowAtlasTiles;
+
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {
       PerInstanceData instance[];
@@ -383,11 +393,13 @@ glslFragment: |
     }
 
     return CalculateLocalPcfShadow(
-      shadowMaps[shadowMapIndex],
+      shadowMaps[NUM_CSM_CASCADES],
       lightsMatrices.instance[shadowMapIndex],
+      DecodeShadowAtlasRect(shadowAtlasTiles.instance[shadowMapIndex]),
       worldPosition,
       surfaceNormal,
       surfaceToLightDirection,
+      length(light.worldPosition - worldPosition),
       (packedShadowIndex & SOFT_SHADOW_MAP_BIT) != 0u);
   }
 

--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -435,8 +435,7 @@ glslFragment: |
     {
       // Attenuation
       const float distance    = length(light.worldPosition - worldPos);
-      const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
-      falloff         = attenuation * (1 - pow(clamp(distance / light.bounds.x, 0,1), 2));
+      falloff = CalculateLocalLightRangeAttenuation(light, distance);
       Li = normalize(light.worldPosition - worldPos);
       shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
     }
@@ -449,8 +448,8 @@ glslFragment: |
       float epsilon   = light.cutOff.x - light.cutOff.y;
       float theta = dot(lightDir, normalize(-light.direction));
       const float distance    = length(light.worldPosition - worldPos);
-      const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
-      falloff         = attenuation * clamp((theta - light.cutOff.y) / epsilon, 0.0, 1.0);
+      falloff = CalculateLocalLightRangeAttenuation(light, distance) *
+        clamp((theta - light.cutOff.y) / epsilon, 0.0, 1.0);
 
       if(theta < light.cutOff.y)
       {

--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -354,12 +354,46 @@ glslFragment: |
     return shadow;
   }
 
+  float CalculateLocalLightShadow(
+    LightData light,
+    uint lightIndex,
+    vec3 worldPosition,
+    vec3 surfaceNormal,
+    vec3 surfaceToLightDirection)
+  {
+    const uint packedShadowIndex = shadowIndices.instance[lightIndex];
+    if(light.shadowType == SHADOW_TYPE_NONE ||
+       packedShadowIndex == INVALID_SHADOW_MAP_INDEX)
+    {
+      return 1.0f;
+    }
+
+    uint shadowMapIndex = packedShadowIndex & SHADOW_MAP_INDEX_MASK;
+    if(light.type == 1u)
+    {
+      shadowMapIndex += SelectPointShadowFace(worldPosition - light.worldPosition);
+    }
+    if(shadowMapIndex >= MAX_SHADOWS_IN_VIEW)
+    {
+      return 1.0f;
+    }
+
+    return CalculateLocalPcfShadow(
+      shadowMaps[shadowMapIndex],
+      lightsMatrices.instance[shadowMapIndex],
+      worldPosition,
+      surfaceNormal,
+      surfaceToLightDirection,
+      (packedShadowIndex & SOFT_SHADOW_MAP_BIT) != 0u);
+  }
+
   const float Epsilon = 0.00001;
-  vec3 CalculateLighting(LightData light, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
+  vec3 CalculateLighting(LightData light, uint lightIndex, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
   {
     float falloff = 1.0f;
     float attenuation = 1.0;
     float shadow = 1.0f;
+    vec3 Li = -light.direction;
 
     // Directional light
     if(light.type == 0)
@@ -379,12 +413,15 @@ glslFragment: |
       const float distance    = length(light.worldPosition - worldPos);
       const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
       falloff         = attenuation * (1 - pow(clamp(distance / light.bounds.x, 0,1), 2));
+      Li = normalize(light.worldPosition - worldPos);
+      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
     }
     // Spot light
     else if(light.type == 2)
     {
       // Attenuation
       vec3 lightDir = normalize(light.worldPosition - worldPos);
+      Li = lightDir;
       float epsilon   = light.cutOff.x - light.cutOff.y;
       float theta = dot(lightDir, normalize(-light.direction));
       const float distance    = length(light.worldPosition - worldPos);
@@ -395,9 +432,9 @@ glslFragment: |
       {
         falloff = 0.0f;
       }
-    }
 
-    vec3 Li = -light.direction;
+      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
+    }
     vec3 Lradiance = light.intensity;
 
     // Half-vector between Li and Lo.
@@ -522,7 +559,7 @@ glslFragment: |
             continue;
         }
 
-        outColor.xyz += CalculateLighting(light.instance[index], material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
+        outColor.xyz += CalculateLighting(light.instance[index], index, material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
     }
 
     outColor.a = material.albedo.a;

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -57,6 +57,24 @@ uint GetLightTileIndex(vec2 fragmentPosition, ivec2 viewportSize)
   return uint(tileId.y * numTiles.x + tileId.x);
 }
 
+float CalculateLocalLightRangeAttenuation(LightData light, float distanceToLight)
+{
+  const float safeRadius = max(light.bounds.x, 0.00001f);
+  const float normalizedDistance = clamp(distanceToLight / safeRadius, 0.0f, 1.0f);
+  const float squaredDistance = distanceToLight * distanceToLight;
+  const float attenuation = 1.0f / max(
+    light.attenuation.x +
+      light.attenuation.y * distanceToLight +
+      light.attenuation.z * squaredDistance,
+    0.00001f);
+
+  // Radius is the actual light range in world metres. Preserve the configured
+  // attenuation throughout that range and only soften the final edge so tile
+  // rejection reaches zero without visibly shrinking the light volume.
+  const float rangeWindow = 1.0f - smoothstep(0.9f, 1.0f, normalizedDistance);
+  return attenuation * rangeWindow;
+}
+
 // Importance sample GGX normal distribution function for a fixed roughness value.
 // This returns normalized half-vector between Li & Lo.
 // For derivation see: http://blog.tobias-franke.eu/2014/03/30/notes_on_importance_sampling.html

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -8,6 +8,9 @@ const float SHADOW_BIAS_CASCADE_4_SCALE = 2.0f;
 const uint SHADOW_TYPE_NONE = 0u;
 const uint SHADOW_TYPE_PCF = 1u;
 const uint SHADOW_TYPE_EVSM = 2u;
+const uint INVALID_SHADOW_MAP_INDEX = 0xFFFFFFFFu;
+const uint SOFT_SHADOW_MAP_BIT = 0x80000000u;
+const uint SHADOW_MAP_INDEX_MASK = 0x7FFFFFFFu;
 
 layout(std430)
 struct LightData
@@ -236,6 +239,53 @@ float ManualPCF(sampler2D shadowMap, vec3 projCoords, float currentDepth, float 
    shadow /= float(samples);
    
    return shadow;
+}
+
+uint SelectPointShadowFace(vec3 lightToReceiver)
+{
+  const vec3 axis = abs(lightToReceiver);
+  if(axis.x >= axis.y && axis.x >= axis.z)
+  {
+    return lightToReceiver.x >= 0.0f ? 0u : 1u;
+  }
+  if(axis.y >= axis.z)
+  {
+    return lightToReceiver.y >= 0.0f ? 2u : 3u;
+  }
+  return lightToReceiver.z >= 0.0f ? 4u : 5u;
+}
+
+float CalculateLocalPcfShadow(
+  sampler2D shadowMap,
+  mat4 lightMatrix,
+  vec3 worldPosition,
+  vec3 surfaceNormal,
+  vec3 surfaceToLightDirection,
+  bool softShadow)
+{
+  const vec3 normal = normalize(surfaceNormal);
+  const vec3 toLight = normalize(surfaceToLightDirection);
+  const float slope = 1.0f - clamp(dot(normal, toLight), 0.0f, 1.0f);
+  const vec3 receiverPosition = worldPosition + normal * (0.001f + 0.003f * slope);
+
+  const vec4 fragPosLightSpace = lightMatrix * vec4(receiverPosition, 1.0f);
+  vec3 projCoords = fragPosLightSpace.xyz / fragPosLightSpace.w;
+  projCoords.xy = projCoords.xy * 0.5f + 0.5f;
+  projCoords.y = 1.0f - projCoords.y;
+  if(any(lessThan(projCoords, vec3(0.0f))) ||
+     any(greaterThan(projCoords, vec3(1.0f))))
+  {
+    return 1.0f;
+  }
+
+  const float bias = 0.0005f + 0.0015f * slope;
+  if(softShadow)
+  {
+    return ManualPCF(shadowMap, projCoords, projCoords.z, bias);
+  }
+
+  const float shadowDepth = texture(shadowMap, projCoords.xy).r;
+  return projCoords.z + bias > shadowDepth ? 1.0f : 0.0f;
 }
 
 

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -275,18 +275,36 @@ uint SelectPointShadowFace(vec3 lightToReceiver)
   return lightToReceiver.z >= 0.0f ? 4u : 5u;
 }
 
+vec4 DecodeShadowAtlasRect(uint packedTile)
+{
+  const uint tileX = packedTile & 31u;
+  const uint tileY = (packedTile >> 5u) & 31u;
+  const uint tileCells = 1u << ((packedTile >> 10u) & 7u);
+  return vec4(tileX, tileY, tileCells, tileCells) / 32.0f;
+}
+
 float CalculateLocalPcfShadow(
   sampler2D shadowMap,
   mat4 lightMatrix,
+  vec4 atlasRect,
   vec3 worldPosition,
   vec3 surfaceNormal,
   vec3 surfaceToLightDirection,
+  float surfaceToLightDistance,
   bool softShadow)
 {
   const vec3 normal = normalize(surfaceNormal);
   const vec3 toLight = normalize(surfaceToLightDirection);
   const float slope = 1.0f - clamp(dot(normal, toLight), 0.0f, 1.0f);
-  const vec3 receiverPosition = worldPosition + normal * (0.001f + 0.003f * slope);
+  const float tileResolution = max(
+    float(textureSize(shadowMap, 0).x) * atlasRect.z,
+    1.0f);
+  const float receiverTexelWorldSize = max(
+    2.0f * surfaceToLightDistance / tileResolution,
+    0.001f);
+  const vec3 receiverPosition = worldPosition +
+    normal * receiverTexelWorldSize * (1.0f + slope) +
+    toLight * receiverTexelWorldSize * 0.25f;
 
   const vec4 fragPosLightSpace = lightMatrix * vec4(receiverPosition, 1.0f);
   vec3 projCoords = fragPosLightSpace.xyz / fragPosLightSpace.w;
@@ -298,14 +316,37 @@ float CalculateLocalPcfShadow(
     return 1.0f;
   }
 
-  const float bias = 0.0005f + 0.0015f * slope;
   if(softShadow)
   {
-    return ManualPCF(shadowMap, projCoords, projCoords.z, bias);
+    const vec2 atlasTexelSize = 1.0f / textureSize(shadowMap, 0);
+    const vec2 tileMin = atlasRect.xy + atlasTexelSize * 0.5f;
+    const vec2 tileMax = atlasRect.xy + atlasRect.zw - atlasTexelSize * 0.5f;
+    const vec2 atlasUv = atlasRect.xy + projCoords.xy * atlasRect.zw;
+    const vec2 poissonDisk[16] = vec2[](
+      vec2(-0.94201624, -0.39906216), vec2(0.94558609, -0.76890725),
+      vec2(-0.094184101, -0.92938870), vec2(0.34495938, 0.29387760),
+      vec2(-0.91588581, 0.45771432), vec2(-0.81544232, -0.87912464),
+      vec2(-0.38277543, 0.27676845), vec2(0.97484398, 0.75648379),
+      vec2(0.44323325, -0.97511554), vec2(0.53742981, -0.47373420),
+      vec2(-0.26496911, -0.41893023), vec2(0.79197514, 0.19090188),
+      vec2(-0.24188840, 0.99706507), vec2(-0.81409955, 0.91437590),
+      vec2(0.19984126, 0.78641367), vec2(0.14383161, -0.14100790));
+    float lit = 0.0f;
+    for(int sampleIndex = 0; sampleIndex < 16; ++sampleIndex)
+    {
+      const vec2 sampleUv = clamp(
+        atlasUv + poissonDisk[sampleIndex] * 2.0f * atlasTexelSize,
+        tileMin,
+        tileMax);
+      const float shadowDepth = texture(shadowMap, sampleUv).r;
+      lit += projCoords.z > shadowDepth ? 1.0f : 0.0f;
+    }
+    return lit / 16.0f;
   }
 
-  const float shadowDepth = texture(shadowMap, projCoords.xy).r;
-  return projCoords.z + bias > shadowDepth ? 1.0f : 0.0f;
+  const vec2 atlasUv = atlasRect.xy + projCoords.xy * atlasRect.zw;
+  const float shadowDepth = texture(shadowMap, atlasUv).r;
+  return projCoords.z > shadowDepth ? 1.0f : 0.0f;
 }
 
 

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -34,6 +34,8 @@ struct LightData
 };
 
 const uint INVALID_LIGHT_TYPE = 0xFFFFFFFFu;
+const uint LIGHT_TILE_OVERFLOW_BIT = 0x80000000u;
+const uint LIGHT_TILE_COUNT_MASK = 0x7FFFFFFFu;
 
 layout(std430)
 struct LightsGrid
@@ -48,11 +50,8 @@ uint GetLightTileIndex(vec2 fragmentPosition, ivec2 viewportSize)
   const ivec2 numTiles =
     (safeViewportSize + ivec2(LIGHTS_CULLING_TILE_SIZE - 1)) /
     LIGHTS_CULLING_TILE_SIZE;
-  const vec2 screenPosition = vec2(
-    fragmentPosition.x,
-    float(safeViewportSize.y) - fragmentPosition.y);
   const ivec2 tileId = clamp(
-    ivec2(screenPosition) / LIGHTS_CULLING_TILE_SIZE,
+    ivec2(fragmentPosition) / LIGHTS_CULLING_TILE_SIZE,
     ivec2(0),
     numTiles - ivec2(1));
   return uint(tileId.y * numTiles.x + tileId.x);
@@ -277,10 +276,15 @@ uint SelectPointShadowFace(vec3 lightToReceiver)
 
 vec4 DecodeShadowAtlasRect(uint packedTile)
 {
-  const uint tileX = packedTile & 31u;
-  const uint tileY = (packedTile >> 5u) & 31u;
-  const uint tileCells = 1u << ((packedTile >> 10u) & 7u);
-  return vec4(tileX, tileY, tileCells, tileCells) / 32.0f;
+  const uint tileX = packedTile & 63u;
+  const uint tileY = (packedTile >> 6u) & 63u;
+  const uint tileCells = 1u << ((packedTile >> 12u) & 7u);
+  return vec4(tileX, tileY, tileCells, tileCells) / 64.0f;
+}
+
+uint DecodeShadowAtlasIndex(uint packedTile)
+{
+  return packedTile >> 15u;
 }
 
 float CalculateLocalPcfShadow(

--- a/Content/Shaders/LinearizeDepth.shader
+++ b/Content/Shaders/LinearizeDepth.shader
@@ -3,9 +3,6 @@ includes:
 - Shaders/Constants.glsl
 - Shaders/Math.glsl
 
-defines: 
-- REVERSE_Z_INF_FAR_PLANE
-
 colorAttachments :
 - R32_SFLOAT
 
@@ -39,36 +36,30 @@ glslCommon: |
  
 glslVertex: |
  layout(location=DefaultPositionBinding) in vec3 inPosition;
- layout(location=DefaultTexcoordBinding) in vec2 inTexcoord;
- 
- layout(location=0) out vec2 fragTexcoord;
  
  void main() 
  {
- 	gl_Position = vec4(inPosition, 1);
- 	fragTexcoord = inTexcoord;
- 
- 	// Flip Y
- 	fragTexcoord.y = 1.0f - fragTexcoord.y;
+     gl_Position = vec4(inPosition, 1);
  }
 
 glslFragment: |
- layout(location=0) in vec2 fragTexcoord;
- 
  layout(set=1, binding=0) uniform sampler2D depthSampler;
  layout(location=0) out vec4 outColor;
  
  void main() 
  {
- 	float depth = texture(depthSampler, fragTexcoord).x;
- 	vec4 vss = vec4(0, 0, depth, 1);
- 	vec4 invVss = frame.invProjection * vss;
- 	float zvs = invVss.z / invVss.w;
- 	
- #ifdef REVERSE_Z_INF_FAR_PLANE
- 	float linearDepth = -frame.cameraZNearZFar.x / depth;
- #else
- 	float linearDepth = -LinearizeDepth(depth, frame.cameraZNearZFar.yx);
- #endif
- 	outColor = vec4(-linearDepth);
+    // Preserve framebuffer coordinates exactly. This avoids coupling depth
+    // reconstruction to viewport orientation or platform vertex-Y conversion.
+    ivec2 depthSize = textureSize(depthSampler, 0);
+    ivec2 pixel = clamp(ivec2(gl_FragCoord.xy), ivec2(0), depthSize - ivec2(1));
+    float depth = texelFetch(depthSampler, pixel, 0).x;
+     vec4 vss = vec4(0, 0, depth, 1);
+     vec4 invVss = frame.invProjection * vss;
+     float zvs = invVss.z / invVss.w;
+
+    // The camera uses a finite reverse-Z projection. Passing far/near restores
+    // the positive view-space distance from that projection, including the
+    // clear-depth value at the finite far plane.
+    float linearDepth = -LinearizeDepth(depth, frame.cameraZNearZFar.yx);
+    outColor = vec4(-linearDepth);
  }

--- a/Content/Shaders/LinearizeDepth.shader
+++ b/Content/Shaders/LinearizeDepth.shader
@@ -57,9 +57,12 @@ glslFragment: |
      vec4 invVss = frame.invProjection * vss;
      float zvs = invVss.z / invVss.w;
 
-    // The camera uses a finite reverse-Z projection. Passing far/near restores
-    // the positive view-space distance from that projection, including the
-    // clear-depth value at the finite far plane.
+ #ifdef REVERSE_Z_INF_FAR_PLANE
+    float linearDepth = -frame.cameraZNearZFar.x / depth;
+ #else
+    // The default camera uses a finite reverse-Z projection. Passing far/near
+    // restores the positive view-space distance, including clear depth at far.
     float linearDepth = -LinearizeDepth(depth, frame.cameraZNearZFar.yx);
+ #endif
     outColor = vec4(-linearDepth);
  }

--- a/Content/Shaders/Math.glsl
+++ b/Content/Shaders/Math.glsl
@@ -223,7 +223,7 @@ ViewFrustum CreateViewFrustum(ivec2 viewportSize, mat4 invProjection)
 
 bool SphereFrustumOverlaps(vec3 lightPos, float radius, ViewFrustum frustum, float zNear, float zFar)
 {
-  if (lightPos.z - radius > zNear || lightPos.z + radius < zFar) 
+  if (lightPos.z - radius > zFar || lightPos.z + radius < zNear)
   {
     return false;
   }

--- a/Content/Shaders/Math.glsl
+++ b/Content/Shaders/Math.glsl
@@ -108,10 +108,10 @@ vec4 slerp(vec4 start, vec4 end, float t)
      return ((start*cos(theta)) + (RelativeVec*sin(theta)));
 }
 
-// Vulkan NDC, Reverse Z: minDepth = 1.0, maxDepth = 0.0
+// Vulkan NDC with reverse Z: the camera near plane maps to 1 and far to 0.
 const vec2 NdcUpperLeft = vec2(-1.0, -1.0);
-const float NdcNearPlane = 0.0;
-const float NdcFarPlane = 1.0;
+const float NdcNearPlane = 1.0;
+const float NdcFarPlane = 0.0;
 
 struct ViewFrustum
 {
@@ -188,13 +188,13 @@ ViewFrustum CreateViewFrustum(ivec2 viewportSize, mat4 invProjection)
   vec4 screenSpace[5];
 
   // Top left point
-  screenSpace[0] = vec4(0.0f, 0.0f, -1.0f, 1.0f );
+  screenSpace[0] = vec4(0.0f, 0.0f, NdcNearPlane, 1.0f );
   // Top right point
-  screenSpace[1] = vec4(viewportSize.x, 0.0f, -1.0f, 1.0f );
+  screenSpace[1] = vec4(viewportSize.x, 0.0f, NdcNearPlane, 1.0f );
   // Bottom left point
-  screenSpace[2] = vec4(0.0f, viewportSize.y, -1.0f, 1.0f );
+  screenSpace[2] = vec4(0.0f, viewportSize.y, NdcNearPlane, 1.0f );
   // Bottom right point
-  screenSpace[3] = vec4(viewportSize.xy, -1.0f, 1.0f );
+  screenSpace[3] = vec4(viewportSize.xy, NdcNearPlane, 1.0f );
   // Center point
   screenSpace[4] = (screenSpace[0] + screenSpace[3]) * 0.5f;
   

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -111,9 +111,14 @@ glslVertex: |
   {
       uint instance[];
   } shadowIndices;
-  
+
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
   layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+
+     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
+     {
+         uint instance[];
+     } shadowAtlasTiles;
 
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {
@@ -265,9 +270,14 @@ glslFragment: |
   {
       uint instance[];
   } shadowIndices;
-  
+
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
   layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+
+     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
+     {
+         uint instance[];
+     } shadowAtlasTiles;
   
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {
@@ -383,11 +393,13 @@ glslFragment: |
     }
 
     return CalculateLocalPcfShadow(
-      shadowMaps[shadowMapIndex],
+      shadowMaps[NUM_CSM_CASCADES],
       lightsMatrices.instance[shadowMapIndex],
+      DecodeShadowAtlasRect(shadowAtlasTiles.instance[shadowMapIndex]),
       worldPosition,
       surfaceNormal,
       surfaceToLightDirection,
+      length(light.worldPosition - worldPosition),
       (packedShadowIndex & SOFT_SHADOW_MAP_BIT) != 0u);
   }
   
@@ -564,7 +576,7 @@ glslFragment: |
         {
             continue;
         }
-    
+
         outColor.xyz += CalculateLighting(light.instance[index], index, material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
     }
 

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -6,6 +6,7 @@ includes:
 
 defines:
 - ALPHA_CUTOUT
+- SUPPORT_LIGHTS_OVERFLOW
 
 glslCommon: |
   #version 460
@@ -113,7 +114,7 @@ glslVertex: |
   } shadowIndices;
 
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
 
      layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
      {
@@ -272,7 +273,7 @@ glslFragment: |
   } shadowIndices;
 
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
 
      layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
      {
@@ -392,10 +393,17 @@ glslFragment: |
       return 1.0f;
     }
 
+    const uint packedAtlasTile = shadowAtlasTiles.instance[shadowMapIndex];
+    const uint shadowSamplerIndex = NUM_CSM_CASCADES + DecodeShadowAtlasIndex(packedAtlasTile);
+    if(shadowSamplerIndex >= MAX_SHADOW_MAP_SAMPLERS)
+    {
+      return 1.0f;
+    }
+
     return CalculateLocalPcfShadow(
-      shadowMaps[NUM_CSM_CASCADES],
+      shadowMaps[nonuniformEXT(shadowSamplerIndex)],
       lightsMatrices.instance[shadowMapIndex],
-      DecodeShadowAtlasRect(shadowAtlasTiles.instance[shadowMapIndex]),
+      DecodeShadowAtlasRect(packedAtlasTile),
       worldPosition,
       surfaceNormal,
       surfaceToLightDirection,
@@ -561,15 +569,25 @@ glslFragment: |
     const uint offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0;
     const uint listLength = uint(culledLights.indices.length());
     const uint availableLights = offset < listLength ? listLength - offset : 0;
-    const uint numLights = hasLightTile ? min(
-        min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE)),
-        availableLights) : 0;
+    const uint packedNumLights = hasLightTile ? lightsGrid.instance[tileIndex].num : 0u;
+    const bool lightsOverflow = (packedNumLights & LIGHT_TILE_OVERFLOW_BIT) != 0u;
+    const uint numLights = !hasLightTile ? 0u :
+    #ifdef SUPPORT_LIGHTS_OVERFLOW
+        (lightsOverflow ? min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(light.instance.length())) :
+            min(packedNumLights & LIGHT_TILE_COUNT_MASK, availableLights));
+    #else
+        min(min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(LIGHTS_PER_TILE)), availableLights);
+    #endif
     
     outColor.xyz = AmbientLighting(material, F0, Lr, normal, cosLo);
     
     for(int i = 0; i < numLights; i++)
     {
+    #ifdef SUPPORT_LIGHTS_OVERFLOW
+        uint index = lightsOverflow ? uint(i) : culledLights.indices[offset + i];
+    #else
         uint index = culledLights.indices[offset + i];
+    #endif
         if(index == uint(-1) ||
             index >= uint(light.instance.length()) ||
             light.instance[index].type == INVALID_LIGHT_TYPE)

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -352,13 +352,47 @@ glslFragment: |
 
     return shadow;
   }
+
+  float CalculateLocalLightShadow(
+    LightData light,
+    uint lightIndex,
+    vec3 worldPosition,
+    vec3 surfaceNormal,
+    vec3 surfaceToLightDirection)
+  {
+    const uint packedShadowIndex = shadowIndices.instance[lightIndex];
+    if(light.shadowType == SHADOW_TYPE_NONE ||
+       packedShadowIndex == INVALID_SHADOW_MAP_INDEX)
+    {
+      return 1.0f;
+    }
+
+    uint shadowMapIndex = packedShadowIndex & SHADOW_MAP_INDEX_MASK;
+    if(light.type == 1u)
+    {
+      shadowMapIndex += SelectPointShadowFace(worldPosition - light.worldPosition);
+    }
+    if(shadowMapIndex >= MAX_SHADOWS_IN_VIEW)
+    {
+      return 1.0f;
+    }
+
+    return CalculateLocalPcfShadow(
+      shadowMaps[shadowMapIndex],
+      lightsMatrices.instance[shadowMapIndex],
+      worldPosition,
+      surfaceNormal,
+      surfaceToLightDirection,
+      (packedShadowIndex & SOFT_SHADOW_MAP_BIT) != 0u);
+  }
   
   const float Epsilon = 0.00001;
-  vec3 CalculateLighting(LightData light, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
+  vec3 CalculateLighting(LightData light, uint lightIndex, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
   {
     float falloff = 1.0f;
     float attenuation = 1.0;
     float shadow = 1.0f;
+    vec3 Li = -light.direction;
     
     // Directional light
     if(light.type == 0)
@@ -378,12 +412,15 @@ glslFragment: |
       const float distance    = length(light.worldPosition - worldPos);
       const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
       falloff         = attenuation * (1 - pow(clamp(distance / light.bounds.x, 0,1), 2));
+      Li = normalize(light.worldPosition - worldPos);
+      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
     }
     // Spot light
     else if(light.type == 2)
     {
       // Attenuation
       vec3 lightDir = normalize(light.worldPosition - worldPos);
+      Li = lightDir;
       float epsilon   = light.cutOff.x - light.cutOff.y;
       float theta = dot(lightDir, normalize(-light.direction));
       const float distance    = length(light.worldPosition - worldPos);
@@ -394,9 +431,9 @@ glslFragment: |
       {
         falloff = 0.0f;
       }
+
+      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
     }
-    
-    vec3 Li = -light.direction;
     vec3 Lradiance = light.intensity;
 
     // Half-vector between Li and Lo.
@@ -523,7 +560,7 @@ glslFragment: |
             continue;
         }
     
-        outColor.xyz += CalculateLighting(light.instance[index], material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
+        outColor.xyz += CalculateLighting(light.instance[index], index, material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
     }
 
     outColor.a = material.albedo.a;

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -435,8 +435,7 @@ glslFragment: |
     {
       // Attenuation
       const float distance    = length(light.worldPosition - worldPos);
-      const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
-      falloff         = attenuation * (1 - pow(clamp(distance / light.bounds.x, 0,1), 2));
+      falloff = CalculateLocalLightRangeAttenuation(light, distance);
       Li = normalize(light.worldPosition - worldPos);
       shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
     }
@@ -449,8 +448,8 @@ glslFragment: |
       float epsilon   = light.cutOff.x - light.cutOff.y;
       float theta = dot(lightDir, normalize(-light.direction));
       const float distance    = length(light.worldPosition - worldPos);
-      const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
-      falloff         = attenuation * clamp((theta - light.cutOff.y) / epsilon, 0.0, 1.0);      
+      falloff = CalculateLocalLightRangeAttenuation(light, distance) *
+        clamp((theta - light.cutOff.y) / epsilon, 0.0, 1.0);
       
       if(theta < light.cutOff.y)
       {

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -154,9 +154,14 @@ glslVertex: |
   {
       uint instance[];
   } shadowIndices;
-  
+
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
   layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+
+     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
+     {
+         uint instance[];
+     } shadowAtlasTiles;
 
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {
@@ -366,12 +371,17 @@ glslFragment: |
   {
       uint instance[];
   } shadowIndices;
-  
+
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
   layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
   #ifdef TRANSMISSION
   layout(set=1, binding=10) uniform sampler2D g_transmissionFramebufferSampler;
   #endif
+
+     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
+     {
+         uint instance[];
+     } shadowAtlasTiles;
   
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {
@@ -490,12 +500,15 @@ glslFragment: |
       return 1.0f;
     }
 
+    const vec4 atlasRect = DecodeShadowAtlasRect(shadowAtlasTiles.instance[shadowMapIndex]);
     return CalculateLocalPcfShadow(
-      shadowMaps[shadowMapIndex],
+      shadowMaps[NUM_CSM_CASCADES],
       lightsMatrices.instance[shadowMapIndex],
+      atlasRect,
       worldPosition,
       surfaceNormal,
       surfaceToLightDirection,
+      length(light.worldPosition - worldPosition),
       (packedShadowIndex & SOFT_SHADOW_MAP_BIT) != 0u);
   }
   
@@ -1071,7 +1084,7 @@ glslFragment: |
         {
             continue;
         }
-    
+
         outColor.xyz += CalculateLighting(light.instance[index], index, material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
   #ifdef CLEAR_COAT
         outColor.xyz += material.clearcoatFactor * ClearCoatLighting(light.instance[index], material.clearcoatRoughnessFactor, Fdielectric, -viewDirection, cosLoCC, clearcoatNormal, vin.worldPosition);

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -10,6 +10,7 @@ defines:
  - CLEAR_COAT
  - SHEEN
  - TRANSMISSION
+ - SUPPORT_LIGHTS_OVERFLOW
 
 glslCommon: |
   #version 460
@@ -156,7 +157,7 @@ glslVertex: |
   } shadowIndices;
 
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
 
      layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
      {
@@ -373,7 +374,7 @@ glslFragment: |
   } shadowIndices;
 
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
   #ifdef TRANSMISSION
   layout(set=1, binding=10) uniform sampler2D g_transmissionFramebufferSampler;
   #endif
@@ -500,9 +501,16 @@ glslFragment: |
       return 1.0f;
     }
 
-    const vec4 atlasRect = DecodeShadowAtlasRect(shadowAtlasTiles.instance[shadowMapIndex]);
+    const uint packedAtlasTile = shadowAtlasTiles.instance[shadowMapIndex];
+    const uint shadowSamplerIndex = NUM_CSM_CASCADES + DecodeShadowAtlasIndex(packedAtlasTile);
+    if(shadowSamplerIndex >= MAX_SHADOW_MAP_SAMPLERS)
+    {
+      return 1.0f;
+    }
+
+    const vec4 atlasRect = DecodeShadowAtlasRect(packedAtlasTile);
     return CalculateLocalPcfShadow(
-      shadowMaps[NUM_CSM_CASCADES],
+      shadowMaps[nonuniformEXT(shadowSamplerIndex)],
       lightsMatrices.instance[shadowMapIndex],
       atlasRect,
       worldPosition,
@@ -1063,9 +1071,15 @@ glslFragment: |
     const uint offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0;
     const uint listLength = uint(culledLights.indices.length());
     const uint availableLights = offset < listLength ? listLength - offset : 0;
-    const uint numLights = hasLightTile ? min(
-        min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE)),
-        availableLights) : 0;
+    const uint packedNumLights = hasLightTile ? lightsGrid.instance[tileIndex].num : 0u;
+    const bool lightsOverflow = (packedNumLights & LIGHT_TILE_OVERFLOW_BIT) != 0u;
+    const uint numLights = !hasLightTile ? 0u :
+    #ifdef SUPPORT_LIGHTS_OVERFLOW
+        (lightsOverflow ? min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(light.instance.length())) :
+            min(packedNumLights & LIGHT_TILE_COUNT_MASK, availableLights));
+    #else
+        min(min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(LIGHTS_PER_TILE)), availableLights);
+    #endif
     
     outColor.xyz += AmbientLighting(material, F0, Lr, normal, cosLo);
   #ifdef CLEAR_COAT
@@ -1077,7 +1091,11 @@ glslFragment: |
     
     for(int i = 0; i < numLights; i++)
     {
+    #ifdef SUPPORT_LIGHTS_OVERFLOW
+        uint index = lightsOverflow ? uint(i) : culledLights.indices[offset + i];
+    #else
         uint index = culledLights.indices[offset + i];
+    #endif
         if(index == uint(-1) ||
             index >= uint(light.instance.length()) ||
             light.instance[index].type == INVALID_LIGHT_TYPE)

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -614,8 +614,7 @@ glslFragment: |
     {
       // Attenuation
       const float distance    = length(pointToLight);
-      const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
-      falloff         = attenuation * (1 - pow(clamp(distance / light.bounds.x, 0,1), 2));
+      falloff = CalculateLocalLightRangeAttenuation(light, distance);
       shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
     }
     // Spot light
@@ -626,8 +625,8 @@ glslFragment: |
       float epsilon   = light.cutOff.x - light.cutOff.y;
       float theta = dot(lightDir, normalize(-light.direction));
       const float distance    = length(pointToLight);
-      const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
-      falloff         = attenuation * clamp((theta - light.cutOff.y) / max(epsilon, Epsilon), 0.0, 1.0);
+      falloff = CalculateLocalLightRangeAttenuation(light, distance) *
+        clamp((theta - light.cutOff.y) / max(epsilon, Epsilon), 0.0, 1.0);
       
       if(theta < light.cutOff.y)
       {
@@ -750,29 +749,19 @@ glslFragment: |
             float transmissionFalloff = falloff;
             if(light.type == 1)
             {
-              float attenuation = 1.0 /
-                (light.attenuation.x +
-                  light.attenuation.y * exitPointToLightLength +
-                  light.attenuation.z *
-                    exitPointToLightLength * exitPointToLightLength);
-              transmissionFalloff = attenuation *
-                (1.0 - pow(clamp(
-                  exitPointToLightLength / light.bounds.x,
-                  0.0,
-                  1.0), 2.0));
+              transmissionFalloff = CalculateLocalLightRangeAttenuation(
+                light,
+                exitPointToLightLength);
             }
             else if(light.type == 2)
             {
-              float attenuation = 1.0 /
-                (light.attenuation.x +
-                  light.attenuation.y * exitPointToLightLength +
-                  light.attenuation.z *
-                    exitPointToLightLength * exitPointToLightLength);
               float coneRange = light.cutOff.x - light.cutOff.y;
               float coneCos = dot(
                 transmissionLi,
                 normalize(-light.direction));
-              transmissionFalloff = attenuation * clamp(
+              transmissionFalloff = CalculateLocalLightRangeAttenuation(
+                light,
+                exitPointToLightLength) * clamp(
                 (coneCos - light.cutOff.y) / max(coneRange, Epsilon),
                 0.0,
                 1.0);
@@ -847,8 +836,7 @@ glslFragment: |
     else if(light.type == 1 || light.type == 2)
     {
         const float distance = length(light.worldPosition - worldPos);
-        float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
-        falloff = attenuation;
+        falloff = CalculateLocalLightRangeAttenuation(light, distance);
     }
 
     vec3 pointToLight = light.type == 0 ?
@@ -901,8 +889,7 @@ glslFragment: |
     else if(light.type == 1 || light.type == 2)
     {
         const float distance = length(light.worldPosition - worldPos);
-        float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
-        falloff = attenuation;
+        falloff = CalculateLocalLightRangeAttenuation(light, distance);
     }
 
     vec3 pointToLight = light.type == 0 ?

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -460,6 +460,39 @@ glslFragment: |
 
     return shadow;
   }
+
+  float CalculateLocalLightShadow(
+    LightData light,
+    uint lightIndex,
+    vec3 worldPosition,
+    vec3 surfaceNormal,
+    vec3 surfaceToLightDirection)
+  {
+    const uint packedShadowIndex = shadowIndices.instance[lightIndex];
+    if(light.shadowType == SHADOW_TYPE_NONE ||
+       packedShadowIndex == INVALID_SHADOW_MAP_INDEX)
+    {
+      return 1.0f;
+    }
+
+    uint shadowMapIndex = packedShadowIndex & SHADOW_MAP_INDEX_MASK;
+    if(light.type == 1u)
+    {
+      shadowMapIndex += SelectPointShadowFace(worldPosition - light.worldPosition);
+    }
+    if(shadowMapIndex >= MAX_SHADOWS_IN_VIEW)
+    {
+      return 1.0f;
+    }
+
+    return CalculateLocalPcfShadow(
+      shadowMaps[shadowMapIndex],
+      lightsMatrices.instance[shadowMapIndex],
+      worldPosition,
+      surfaceNormal,
+      surfaceToLightDirection,
+      (packedShadowIndex & SOFT_SHADOW_MAP_BIT) != 0u);
+  }
   
   const float Epsilon = 0.00001;
 
@@ -529,7 +562,7 @@ glslFragment: |
   }
   #endif
 
-  vec3 CalculateLighting(LightData light, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
+  vec3 CalculateLighting(LightData light, uint lightIndex, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
   {
     float falloff = 1.0f;
     float shadow = 1.0f;
@@ -557,6 +590,7 @@ glslFragment: |
       const float distance    = length(pointToLight);
       const float attenuation = 1.0 / (light.attenuation.x + light.attenuation.y * distance + light.attenuation.z * (distance * distance));
       falloff         = attenuation * (1 - pow(clamp(distance / light.bounds.x, 0,1), 2));
+      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
     }
     // Spot light
     else if(light.type == 2)
@@ -573,6 +607,8 @@ glslFragment: |
       {
         falloff = 0.0f;
       }
+
+      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
     }
     
     vec3 Lradiance = light.intensity;
@@ -1031,7 +1067,7 @@ glslFragment: |
             continue;
         }
     
-        outColor.xyz += CalculateLighting(light.instance[index], material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
+        outColor.xyz += CalculateLighting(light.instance[index], index, material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
   #ifdef CLEAR_COAT
         outColor.xyz += material.clearcoatFactor * ClearCoatLighting(light.instance[index], material.clearcoatRoughnessFactor, Fdielectric, -viewDirection, cosLoCC, clearcoatNormal, vin.worldPosition);
   #endif

--- a/Content/Shaders/Unlit.shader
+++ b/Content/Shaders/Unlit.shader
@@ -112,7 +112,7 @@ glslVertex: |
   } shadowIndices;
   
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
 
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {
@@ -254,7 +254,7 @@ glslFragment: |
   } shadowIndices;
   
   layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOWS_IN_VIEW];
+  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
   
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {

--- a/Content/Tests/Visual/CombinedShadows.world
+++ b/Content/Tests/Visual/CombinedShadows.world
@@ -1,0 +1,27 @@
+name: CombinedShadows
+prefabs:
+  - gameObjects:
+      - name: CombinedShadows
+        position: [0, 0, 0, 1]
+        rotation: [0, 0, 0, 1]
+        scale: [1, 1, 1, 1]
+        parentIndex: 4294967295
+        instanceId: A4000000000000000001
+        components: [0, 1]
+    components:
+      - typename: Sailor::VisualTestCaseComponent
+        overrideProperties:
+          testName: CombinedShadows
+          screenshotName: CombinedShadows
+          captureAfterFrames: 180
+          minRunTimeSeconds: 2
+          quitAfterFinish: true
+          fileId: NullFileId
+          instanceId: A4000000000000000000000000000002_A4000000000000000001
+      - typename: Sailor::ShadowVisualTestSetupComponent
+        overrideProperties:
+          directional: true
+          point: true
+          spot: true
+          fileId: NullFileId
+          instanceId: A4000000000000000000000000000003_A4000000000000000001

--- a/Content/Tests/Visual/CombinedShadows.world.asset
+++ b/Content/Tests/Visual/CombinedShadows.world.asset
@@ -1,0 +1,3 @@
+assetInfoType: Sailor::WorldPrefabAssetInfo
+fileId: "{A4000000-0000-4000-8000-000000000004}"
+filename: CombinedShadows.world

--- a/Content/Tests/Visual/DirectionalShadow.world
+++ b/Content/Tests/Visual/DirectionalShadow.world
@@ -1,0 +1,27 @@
+name: DirectionalShadow
+prefabs:
+  - gameObjects:
+      - name: DirectionalShadow
+        position: [0, 0, 0, 1]
+        rotation: [0, 0, 0, 1]
+        scale: [1, 1, 1, 1]
+        parentIndex: 4294967295
+        instanceId: A1000000000000000001
+        components: [0, 1]
+    components:
+      - typename: Sailor::VisualTestCaseComponent
+        overrideProperties:
+          testName: DirectionalShadow
+          screenshotName: DirectionalShadow
+          captureAfterFrames: 180
+          minRunTimeSeconds: 2
+          quitAfterFinish: true
+          fileId: NullFileId
+          instanceId: A1000000000000000000000000000002_A1000000000000000001
+      - typename: Sailor::ShadowVisualTestSetupComponent
+        overrideProperties:
+          directional: true
+          point: false
+          spot: false
+          fileId: NullFileId
+          instanceId: A1000000000000000000000000000003_A1000000000000000001

--- a/Content/Tests/Visual/DirectionalShadow.world.asset
+++ b/Content/Tests/Visual/DirectionalShadow.world.asset
@@ -1,0 +1,3 @@
+assetInfoType: Sailor::WorldPrefabAssetInfo
+fileId: "{A1000000-0000-4000-8000-000000000001}"
+filename: DirectionalShadow.world

--- a/Content/Tests/Visual/LocalShadowAtlasStress.world
+++ b/Content/Tests/Visual/LocalShadowAtlasStress.world
@@ -1,0 +1,24 @@
+name: LocalShadowAtlasStress
+prefabs:
+  - gameObjects:
+      - name: LocalShadowAtlasStress
+        position: [0, 0, 0, 1]
+        rotation: [0, 0, 0, 1]
+        scale: [1, 1, 1, 1]
+        parentIndex: 4294967295
+        instanceId: A5000000000000000001
+        components: [0, 1]
+    components:
+      - typename: Sailor::VisualTestCaseComponent
+        overrideProperties:
+          testName: LocalShadowAtlasStress
+          screenshotName: LocalShadowAtlasStress
+          captureAfterFrames: 1
+          minRunTimeSeconds: 30
+          quitAfterFinish: true
+          fileId: NullFileId
+          instanceId: A5000000000000000000000000000002_A5000000000000000001
+      - typename: Sailor::LocalShadowAtlasStressTestSetupComponent
+        overrideProperties:
+          fileId: NullFileId
+          instanceId: A5000000000000000000000000000003_A5000000000000000001

--- a/Content/Tests/Visual/LocalShadowAtlasStress.world.asset
+++ b/Content/Tests/Visual/LocalShadowAtlasStress.world.asset
@@ -1,0 +1,3 @@
+assetInfoType: Sailor::WorldPrefabAssetInfo
+fileId: "{7BE1A148-03D9-4AF6-AD6E-84C8EFDA1DAE}"
+filename: LocalShadowAtlasStress.world

--- a/Content/Tests/Visual/PointShadow.world
+++ b/Content/Tests/Visual/PointShadow.world
@@ -1,0 +1,27 @@
+name: PointShadow
+prefabs:
+  - gameObjects:
+      - name: PointShadow
+        position: [0, 0, 0, 1]
+        rotation: [0, 0, 0, 1]
+        scale: [1, 1, 1, 1]
+        parentIndex: 4294967295
+        instanceId: A2000000000000000001
+        components: [0, 1]
+    components:
+      - typename: Sailor::VisualTestCaseComponent
+        overrideProperties:
+          testName: PointShadow
+          screenshotName: PointShadow
+          captureAfterFrames: 180
+          minRunTimeSeconds: 2
+          quitAfterFinish: true
+          fileId: NullFileId
+          instanceId: A2000000000000000000000000000002_A2000000000000000001
+      - typename: Sailor::ShadowVisualTestSetupComponent
+        overrideProperties:
+          directional: false
+          point: true
+          spot: false
+          fileId: NullFileId
+          instanceId: A2000000000000000000000000000003_A2000000000000000001

--- a/Content/Tests/Visual/PointShadow.world.asset
+++ b/Content/Tests/Visual/PointShadow.world.asset
@@ -1,0 +1,3 @@
+assetInfoType: Sailor::WorldPrefabAssetInfo
+fileId: "{A2000000-0000-4000-8000-000000000002}"
+filename: PointShadow.world

--- a/Content/Tests/Visual/SpotShadow.world
+++ b/Content/Tests/Visual/SpotShadow.world
@@ -1,0 +1,27 @@
+name: SpotShadow
+prefabs:
+  - gameObjects:
+      - name: SpotShadow
+        position: [0, 0, 0, 1]
+        rotation: [0, 0, 0, 1]
+        scale: [1, 1, 1, 1]
+        parentIndex: 4294967295
+        instanceId: A3000000000000000001
+        components: [0, 1]
+    components:
+      - typename: Sailor::VisualTestCaseComponent
+        overrideProperties:
+          testName: SpotShadow
+          screenshotName: SpotShadow
+          captureAfterFrames: 180
+          minRunTimeSeconds: 2
+          quitAfterFinish: true
+          fileId: NullFileId
+          instanceId: A3000000000000000000000000000002_A3000000000000000001
+      - typename: Sailor::ShadowVisualTestSetupComponent
+        overrideProperties:
+          directional: false
+          point: false
+          spot: true
+          fileId: NullFileId
+          instanceId: A3000000000000000000000000000003_A3000000000000000001

--- a/Content/Tests/Visual/SpotShadow.world.asset
+++ b/Content/Tests/Visual/SpotShadow.world.asset
@@ -1,0 +1,3 @@
+assetInfoType: Sailor::WorldPrefabAssetInfo
+fileId: "{A3000000-0000-4000-8000-000000000003}"
+filename: SpotShadow.world

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -187,6 +187,7 @@ std::string GenerateConstantsLibrary(uint32_t version)
 
 	stream << "\n" << "// Shadows" << "\n";
 	stream << "#define MAX_SHADOWS_IN_VIEW " << LightingECS::MaxShadowsInView << "\n";
+	stream << "#define MAX_SHADOW_MAP_SAMPLERS " << LightingECS::MaxShadowMapSamplers << "\n";
 	stream << "#define MAX_TEXTURES_IN_SCENE " << TextureImporter::MaxTexturesInScene << "\n";
 	stream << "#define NUM_CSM_CASCADES " << LightingECS::NumCascades << "\n";
 	stream << "const float ShadowMaxDistance = " << LightingECS::ShadowMaxDistance << ";\n";

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -1719,6 +1719,21 @@ bool ShaderCompilerTestAccess::ReadShaderSourceBinary(
 	return ShaderCompiler::ReadShaderSourceBinary(filepath, outSource, outDiagnostic);
 }
 
+bool ShaderCompilerTestAccess::CompileGlslToSpirv(
+	const std::string& filename,
+	const std::string& source,
+	RHI::EShaderStage shaderStage,
+	RHI::ShaderByteCode& outByteCode,
+	bool bIsDebug)
+{
+	return ShaderCompiler::CompileGlslToSpirv(
+		filename,
+		source,
+		shaderStage,
+		outByteCode,
+		bIsDebug);
+}
+
 bool ShaderCompilerTestAccess::ExerciseFailedLoadEvictionAndRetry()
 {
 	constexpr uint32_t permutation = 7;

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.h
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.h
@@ -308,6 +308,12 @@ namespace Sailor
 			const std::string& filepath,
 			std::string& outSource,
 			std::string& outDiagnostic);
+		SAILOR_API static bool CompileGlslToSpirv(
+			const std::string& filename,
+			const std::string& source,
+			RHI::EShaderStage shaderStage,
+			RHI::ShaderByteCode& outByteCode,
+			bool bIsDebug);
 		SAILOR_API static bool ExerciseFailedLoadEvictionAndRetry();
 		SAILOR_API static bool ExercisePromiseGarbageCollection();
 	};

--- a/Runtime/Components/LightComponent.cpp
+++ b/Runtime/Components/LightComponent.cpp
@@ -45,8 +45,7 @@ void LightComponent::OnGizmo()
 	const glm::vec4 worldPosition = GetOwner()->GetTransformComponent().GetWorldPosition();
 	const glm::vec3 forward = GetOwner()->GetTransformComponent().GetForwardVector();
 
-	const glm::vec3 bounds = glm::abs(GetData().m_bounds);
-	const float originSize = glm::clamp(std::max(bounds.x, std::max(bounds.y, bounds.z)), 25.0f, 250.0f);
+	const float originSize = glm::clamp(glm::abs(GetData().m_radius), 25.0f, 250.0f);
 
 	GetOwner()->GetWorld()->GetDebugContext()->DrawOrigin(worldPosition, GetOwner()->GetTransformComponent().GetCachedWorldMatrix(), originSize);
 	GetOwner()->GetWorld()->GetDebugContext()->DrawArrow(worldPosition, glm::vec3(worldPosition) + forward * originSize, vec4(1, 1, 1, 1));
@@ -85,13 +84,14 @@ void LightComponent::SetAttenuation(const glm::vec3& value)
 	}
 }
 
-void LightComponent::SetBounds(const glm::vec3& value)
+void LightComponent::SetRadius(float value)
 {
 	LightData& lightData = GetData();
+	value = (std::max)(value, 0.01f);
 
-	if (value != lightData.m_bounds)
+	if (value != lightData.m_radius)
 	{
-		lightData.m_bounds = value;
+		lightData.m_radius = value;
 		lightData.MarkDirty();
 	}
 }

--- a/Runtime/Components/LightComponent.cpp
+++ b/Runtime/Components/LightComponent.cpp
@@ -117,3 +117,25 @@ void LightComponent::SetShadowType(RHI::EShadowType value)
 		lightData.MarkDirty();
 	}
 }
+
+void LightComponent::SetShadowQuality(ELightShadowQuality value)
+{
+	LightData& lightData = GetData();
+
+	if (value != lightData.m_shadowQuality)
+	{
+		lightData.m_shadowQuality = value;
+		lightData.MarkDirty();
+	}
+}
+
+void LightComponent::SetShadowFilter(ELightShadowFilter value)
+{
+	LightData& lightData = GetData();
+
+	if (value != lightData.m_shadowFilter)
+	{
+		lightData.m_shadowFilter = value;
+		lightData.MarkDirty();
+	}
+}

--- a/Runtime/Components/LightComponent.h
+++ b/Runtime/Components/LightComponent.h
@@ -29,6 +29,8 @@ namespace Sailor
 		SAILOR_API __forceinline const glm::vec2& GetCutOff() const { return GetData().m_cutOff; }
 		SAILOR_API __forceinline ELightType GetLightType() const { return (ELightType)GetData().m_type; }
 		SAILOR_API __forceinline RHI::EShadowType GetShadowType() const { return GetData().m_shadowType; }
+		SAILOR_API __forceinline ELightShadowQuality GetShadowQuality() const { return GetData().m_shadowQuality; }
+		SAILOR_API __forceinline ELightShadowFilter GetShadowFilter() const { return GetData().m_shadowFilter; }
 
 		SAILOR_API void SetCutOff(const glm::vec2& innerOuterDegrees);
 		SAILOR_API void SetIntensity(const glm::vec3& value);
@@ -36,6 +38,8 @@ namespace Sailor
 		SAILOR_API void SetBounds(const glm::vec3& value);
 		SAILOR_API void SetLightType(ELightType value);
 		SAILOR_API void SetShadowType(RHI::EShadowType value);
+		SAILOR_API void SetShadowQuality(ELightShadowQuality value);
+		SAILOR_API void SetShadowFilter(ELightShadowFilter value);
 
 	protected:
 
@@ -66,5 +70,11 @@ REFL_AUTO(
 	func(SetLightType, property("lightType"), SkipCDO()),
 
 	func(GetShadowType, property("shadowType"), SkipCDO()),
-	func(SetShadowType, property("shadowType"), SkipCDO())
+	func(SetShadowType, property("shadowType"), SkipCDO()),
+
+	func(GetShadowQuality, property("shadowQuality"), SkipCDO()),
+	func(SetShadowQuality, property("shadowQuality"), SkipCDO()),
+
+	func(GetShadowFilter, property("shadowFilter"), SkipCDO()),
+	func(SetShadowFilter, property("shadowFilter"), SkipCDO())
 )

--- a/Runtime/Components/LightComponent.h
+++ b/Runtime/Components/LightComponent.h
@@ -60,7 +60,7 @@ REFL_AUTO(
 	func(GetAttenuation, property("attenuation"), SkipCDO()),
 	func(SetAttenuation, property("attenuation"), SkipCDO()),
 
-	func(GetRadius, property("radius"), SkipCDO(), Range(0.01, 100000.0)),
+	func(GetRadius, property("radius"), SkipCDO()),
 	func(SetRadius, property("radius"), SkipCDO()),
 
 	func(GetCutOff, property("cutOff"), SkipCDO()),

--- a/Runtime/Components/LightComponent.h
+++ b/Runtime/Components/LightComponent.h
@@ -25,7 +25,7 @@ namespace Sailor
 
 		SAILOR_API __forceinline const glm::vec3& GetIntensity() const { return GetData().m_intensity; }
 		SAILOR_API __forceinline const glm::vec3& GetAttenuation() const { return GetData().m_attenuation; }
-		SAILOR_API __forceinline const glm::vec3& GetBounds() const { return GetData().m_bounds; }
+		SAILOR_API __forceinline float GetRadius() const { return GetData().m_radius; }
 		SAILOR_API __forceinline const glm::vec2& GetCutOff() const { return GetData().m_cutOff; }
 		SAILOR_API __forceinline ELightType GetLightType() const { return (ELightType)GetData().m_type; }
 		SAILOR_API __forceinline RHI::EShadowType GetShadowType() const { return GetData().m_shadowType; }
@@ -35,7 +35,7 @@ namespace Sailor
 		SAILOR_API void SetCutOff(const glm::vec2& innerOuterDegrees);
 		SAILOR_API void SetIntensity(const glm::vec3& value);
 		SAILOR_API void SetAttenuation(const glm::vec3& value);
-		SAILOR_API void SetBounds(const glm::vec3& value);
+		SAILOR_API void SetRadius(float value);
 		SAILOR_API void SetLightType(ELightType value);
 		SAILOR_API void SetShadowType(RHI::EShadowType value);
 		SAILOR_API void SetShadowQuality(ELightShadowQuality value);
@@ -60,8 +60,8 @@ REFL_AUTO(
 	func(GetAttenuation, property("attenuation"), SkipCDO()),
 	func(SetAttenuation, property("attenuation"), SkipCDO()),
 
-	func(GetBounds, property("bounds"), SkipCDO()),
-	func(SetBounds, property("bounds"), SkipCDO()),
+	func(GetRadius, property("radius"), SkipCDO(), Range(0.01, 100000.0)),
+	func(SetRadius, property("radius"), SkipCDO()),
 
 	func(GetCutOff, property("cutOff"), SkipCDO()),
 	func(SetCutOff, property("cutOff"), SkipCDO()),

--- a/Runtime/Components/TestComponent.cpp
+++ b/Runtime/Components/TestComponent.cpp
@@ -102,7 +102,7 @@ void TestComponent::BeginPlay()
 	//spotLight->GetTransformComponent().SetPosition(vec3(200.0f, 40.0f, 0.0f));
 	//spotLight->GetTransformComponent().SetRotation(quat(vec3(-45, 0.0f, 0.0f)));
 
-	//lightComponent->SetBounds(vec3(300.0f, 300.0f, 300.0f));
+	//lightComponent->SetRadius(300.0f);
 	//lightComponent->SetIntensity(vec3(260.0f, 260.0f, 200.0f));
 	//lightComponent->SetLightType(ELightType::Spot);
 
@@ -119,7 +119,7 @@ void TestComponent::BeginPlay()
 
 				//lightGameObject->SetMobilityType(EMobilityType::Static);
 				lightGameObject->GetTransformComponent().SetPosition(vec3(i, j, k));
-				lightComponent->SetBounds(vec3(size, size, size));
+				lightComponent->SetRadius(size);
 				lightComponent->SetIntensity(vec3(rand() % 256, rand() % 256, rand() % 256));
 
 				m_lights.Emplace(std::move(lightGameObject));

--- a/Runtime/Components/Tests/LocalShadowAtlasStressTestSetupComponent.cpp
+++ b/Runtime/Components/Tests/LocalShadowAtlasStressTestSetupComponent.cpp
@@ -1,0 +1,190 @@
+#include "Components/Tests/LocalShadowAtlasStressTestSetupComponent.h"
+#include "AssetRegistry/AssetRegistry.h"
+#include "Components/CameraComponent.h"
+#include "Components/LightComponent.h"
+#include "Components/MeshRendererComponent.h"
+#include "Components/SkyComponent.h"
+#include "ECS/TransformECS.h"
+#include "Engine/GameObject.h"
+#include "Engine/World.h"
+#include "Math/Math.h"
+
+#include <cmath>
+#include <cstdio>
+#include <glm/gtc/constants.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+using namespace Sailor;
+
+namespace
+{
+	constexpr uint32_t NumBoxesPerField = 25u;
+	constexpr uint32_t NumPointLightsPerField = 300u;
+	constexpr float FieldSpacing = 165.0f;
+	constexpr float CameraHeight = 62.0f;
+	constexpr float CameraDepth = 80.0f;
+	constexpr float CameraTravel = 190.0f;
+	constexpr float CameraPeriodSeconds = 8.0f;
+	const glm::vec3 CameraTarget(0.0f, 2.0f, -330.0f);
+
+	const glm::vec3 LightPalette[] =
+	{
+		glm::vec3(1.0f, 0.18f, 0.12f),
+		glm::vec3(1.0f, 0.48f, 0.12f),
+		glm::vec3(1.0f, 0.90f, 0.18f),
+		glm::vec3(0.25f, 1.0f, 0.32f),
+		glm::vec3(0.12f, 0.82f, 1.0f),
+		glm::vec3(0.22f, 0.38f, 1.0f),
+		glm::vec3(0.72f, 0.24f, 1.0f),
+		glm::vec3(1.0f, 0.20f, 0.68f)
+	};
+}
+
+void LocalShadowAtlasStressTestSetupComponent::BeginPlay()
+{
+	Component::BeginPlay();
+	SpawnGeometry();
+	SpawnLights();
+	EnsureSky();
+	EnsureCamera();
+}
+
+void LocalShadowAtlasStressTestSetupComponent::Tick(float deltaTime)
+{
+	if (!m_camera)
+	{
+		return;
+	}
+
+	m_elapsedTime += deltaTime;
+	const float phase = m_elapsedTime * glm::two_pi<float>() / CameraPeriodSeconds;
+	const glm::vec3 position(
+		std::sin(phase) * CameraTravel,
+		CameraHeight,
+		CameraDepth);
+	auto& transform = m_camera->GetTransformComponent();
+	transform.SetPosition(glm::vec4(position, 1.0f));
+	const glm::vec3 target = CameraTarget + glm::vec3(position.x, 0.0f, 0.0f);
+	transform.SetRotation(glm::quatLookAt(
+		Math::SafeNormalize(target - position, glm::vec3(0.0f, 0.0f, -1.0f)),
+		glm::vec3(0.0f, 1.0f, 0.0f)));
+}
+
+void LocalShadowAtlasStressTestSetupComponent::SpawnBox(
+	const char* name,
+	const glm::vec3& position,
+	const glm::vec3& scale)
+{
+	auto gameObject = GetWorld()->Instantiate(name);
+	gameObject->SetMobilityType(EMobilityType::Stationary);
+	auto& transform = gameObject->GetTransformComponent();
+	transform.SetPosition(glm::vec4(position, 1.0f));
+	transform.SetScale(glm::vec4(scale, 1.0f));
+
+	auto mesh = gameObject->AddComponent<MeshRendererComponent>();
+	mesh->LoadModel("Models/Box/Box.gltf");
+	if (auto materialInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(
+		"Models/Box/materials/Default.mat"))
+	{
+		mesh->SetOverrideMaterials({ materialInfo->GetFileId() });
+	}
+}
+
+void LocalShadowAtlasStressTestSetupComponent::SpawnGeometry()
+{
+	SpawnBox("ShadowStressFloor", glm::vec3(0.0f, -2.0f, -380.0f), glm::vec3(275.0f, 2.0f, 470.0f));
+
+	SpawnGeometryField("Left", -FieldSpacing, 0u);
+	SpawnGeometryField("Center", 0.0f, 1u);
+	SpawnGeometryField("Right", FieldSpacing, 2u);
+}
+
+void LocalShadowAtlasStressTestSetupComponent::SpawnGeometryField(
+	const char* namePrefix,
+	float xOffset,
+	uint32_t fieldIndex)
+{
+	for (uint32_t i = 0; i < NumBoxesPerField; ++i)
+	{
+		const uint32_t variedIndex = i + fieldIndex * 7u;
+		const uint32_t lane = (variedIndex * 3u) % 5u;
+		const float height = 10.0f + static_cast<float>((variedIndex * 7u) % 5u) * 3.0f;
+		const float width = 8.0f + static_cast<float>((variedIndex * 11u) % 4u) * 1.5f;
+		char name[64];
+		sprintf_s(name, sizeof(name), "ShadowStressBox_%s_%02u", namePrefix, i);
+		SpawnBox(
+			name,
+			glm::vec3(
+				xOffset + (static_cast<float>(lane) - 2.0f) * 27.5f,
+				height * 0.5f,
+				-45.0f - static_cast<float>(i) * 29.0f),
+			glm::vec3(width, height, width));
+	}
+}
+
+void LocalShadowAtlasStressTestSetupComponent::SpawnLights()
+{
+	SpawnLightField("Left", -FieldSpacing, 0u);
+	SpawnLightField("Center", 0.0f, 1u);
+	SpawnLightField("Right", FieldSpacing, 2u);
+}
+
+void LocalShadowAtlasStressTestSetupComponent::SpawnLightField(
+	const char* namePrefix,
+	float xOffset,
+	uint32_t fieldIndex)
+{
+	constexpr uint32_t LightsAcross = 5u;
+	constexpr uint32_t LightsHigh = 3u;
+	constexpr uint32_t LightsDeep = 20u;
+	static_assert(LightsAcross * LightsHigh * LightsDeep == NumPointLightsPerField);
+
+	for (uint32_t depth = 0; depth < LightsDeep; ++depth)
+	{
+		for (uint32_t height = 0; height < LightsHigh; ++height)
+		{
+			for (uint32_t across = 0; across < LightsAcross; ++across)
+			{
+				const uint32_t index =
+					depth * LightsHigh * LightsAcross + height * LightsAcross + across;
+				char name[64];
+				sprintf_s(name, sizeof(name), "ShadowStressPointLight_%s_%03u", namePrefix, index);
+
+				auto gameObject = GetWorld()->Instantiate(name);
+				gameObject->SetMobilityType(EMobilityType::Stationary);
+				gameObject->GetTransformComponent().SetPosition(glm::vec4(
+					xOffset - 55.0f + static_cast<float>(across) * 27.5f,
+					10.0f + static_cast<float>(height) * 14.0f,
+					-20.0f - static_cast<float>(depth) * 40.0f,
+					1.0f));
+
+				auto light = gameObject->AddComponent<LightComponent>();
+				light->SetLightType(ELightType::Point);
+				light->SetIntensity(LightPalette[
+					(index + fieldIndex * 3u) % (sizeof(LightPalette) / sizeof(LightPalette[0]))] * 20.0f);
+				light->SetAttenuation(glm::vec3(1.0f, 0.045f, 0.0075f));
+				light->SetRadius(65.0f);
+				light->SetShadowType(RHI::EShadowType::PCF);
+				light->SetShadowQuality(ELightShadowQuality::VeryLow);
+			}
+		}
+	}
+}
+
+void LocalShadowAtlasStressTestSetupComponent::EnsureSky()
+{
+	auto gameObject = GetWorld()->Instantiate("ShadowStressSky");
+	auto sky = gameObject->AddComponent<SkyComponent>();
+	sky->SetAmbient(0.02f);
+	sky->SetSunIntensity(0.0f);
+	sky->SetCloudsCoverage(0.0f);
+}
+
+void LocalShadowAtlasStressTestSetupComponent::EnsureCamera()
+{
+	m_camera = GetWorld()->Instantiate("ShadowStressCamera");
+	auto camera = m_camera->AddComponent<CameraComponent>();
+	camera->SetZNear(0.1f);
+	camera->SetZFar(750.0f);
+	Tick(0.0f);
+}

--- a/Runtime/Components/Tests/LocalShadowAtlasStressTestSetupComponent.h
+++ b/Runtime/Components/Tests/LocalShadowAtlasStressTestSetupComponent.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "Sailor.h"
+#include "Components/Component.h"
+
+namespace Sailor
+{
+	class LocalShadowAtlasStressTestSetupComponent : public Component
+	{
+		SAILOR_REFLECTABLE(LocalShadowAtlasStressTestSetupComponent)
+
+	public:
+		SAILOR_API virtual void BeginPlay() override;
+		SAILOR_API virtual void Tick(float deltaTime) override;
+
+	private:
+		void SpawnBox(const char* name, const glm::vec3& position, const glm::vec3& scale);
+		void SpawnGeometryField(const char* namePrefix, float xOffset, uint32_t fieldIndex);
+		void SpawnLightField(const char* namePrefix, float xOffset, uint32_t fieldIndex);
+		void SpawnGeometry();
+		void SpawnLights();
+		void EnsureSky();
+		void EnsureCamera();
+
+		GameObjectPtr m_camera;
+		float m_elapsedTime = 0.0f;
+	};
+}
+
+using namespace Sailor::Attributes;
+
+REFL_AUTO(
+	type(Sailor::LocalShadowAtlasStressTestSetupComponent, bases<Sailor::Component>)
+)

--- a/Runtime/Components/Tests/PerformanceTestSetupComponent.cpp
+++ b/Runtime/Components/Tests/PerformanceTestSetupComponent.cpp
@@ -269,7 +269,7 @@ void PerformanceTestSetupComponent::SpawnLights()
 					auto light = lightGo->AddComponent<LightComponent>();
 					light->SetLightType(ELightType::Point);
 					light->SetIntensity(palette[(x + y * lightGrid + z * lightGrid * lightGrid) % (sizeof(palette) / sizeof(palette[0]))] * 45.0f);
-					light->SetBounds(glm::vec3(450.0f));
+					light->SetRadius(450.0f);
 					light->SetAttenuation(glm::vec3(1.0f, 0.030f, 0.0015f));
 					light->SetShadowType(RHI::EShadowType::None);
 				}

--- a/Runtime/Components/Tests/ShadowVisualTestSetupComponent.cpp
+++ b/Runtime/Components/Tests/ShadowVisualTestSetupComponent.cpp
@@ -1,0 +1,118 @@
+#include "Components/Tests/ShadowVisualTestSetupComponent.h"
+#include "Components/CameraComponent.h"
+#include "Components/LightComponent.h"
+#include "Components/MeshRendererComponent.h"
+#include "Components/SkyComponent.h"
+#include "ECS/TransformECS.h"
+#include "Engine/GameObject.h"
+#include "Engine/World.h"
+#include "Math/Math.h"
+
+#include <glm/gtc/quaternion.hpp>
+
+using namespace Sailor;
+
+void ShadowVisualTestSetupComponent::BeginPlay()
+{
+	Component::BeginPlay();
+
+	SpawnBox("ShadowFloor", glm::vec3(0.0f, -4.0f, 0.0f), glm::vec3(70.0f, 2.0f, 70.0f));
+	SpawnBox("ShadowReceiverWall", glm::vec3(0.0f, 23.0f, -48.0f), glm::vec3(64.0f, 28.0f, 2.0f));
+	SpawnBox("ShadowCasterLeft", glm::vec3(-18.0f, 5.0f, 4.0f), glm::vec3(7.0f, 9.0f, 7.0f));
+	SpawnBox("ShadowCasterCenter", glm::vec3(0.0f, 9.0f, -4.0f), glm::vec3(8.0f, 13.0f, 8.0f));
+	SpawnBox("ShadowCasterRight", glm::vec3(19.0f, 3.0f, 10.0f), glm::vec3(7.0f, 7.0f, 7.0f));
+
+	SpawnLights();
+	EnsureSky();
+	EnsureCamera();
+}
+
+void ShadowVisualTestSetupComponent::SpawnBox(
+	const char* name,
+	const glm::vec3& position,
+	const glm::vec3& scale)
+{
+	auto gameObject = GetWorld()->Instantiate(name);
+	gameObject->SetMobilityType(EMobilityType::Stationary);
+	auto& transform = gameObject->GetTransformComponent();
+	transform.SetPosition(glm::vec4(position, 1.0f));
+	transform.SetScale(glm::vec4(scale, 1.0f));
+
+	auto mesh = gameObject->AddComponent<MeshRendererComponent>();
+	mesh->LoadModel("Models/Box/Box.gltf");
+	if (auto materialInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(
+		"Models/Box/materials/Default.mat"))
+	{
+		mesh->SetOverrideMaterials({ materialInfo->GetFileId() });
+	}
+}
+
+void ShadowVisualTestSetupComponent::SpawnLights()
+{
+	if (m_bDirectional)
+	{
+		auto gameObject = GetWorld()->Instantiate("ShadowDirectionalLight");
+		gameObject->GetTransformComponent().SetRotation(glm::quatLookAt(
+			Math::SafeNormalize(glm::vec3(0.65f, -1.0f, 0.35f), glm::vec3(0.0f, -1.0f, 0.0f)),
+			glm::vec3(0.0f, 1.0f, 0.0f)));
+		auto light = gameObject->AddComponent<LightComponent>();
+		light->SetLightType(ELightType::Directional);
+		light->SetIntensity(glm::vec3(4.0f));
+		light->SetShadowType(RHI::EShadowType::PCF);
+	}
+
+	if (m_bPoint)
+	{
+		auto gameObject = GetWorld()->Instantiate("ShadowPointLight");
+		gameObject->GetTransformComponent().SetPosition(glm::vec4(-38.0f, 30.0f, 34.0f, 1.0f));
+		auto light = gameObject->AddComponent<LightComponent>();
+		light->SetLightType(ELightType::Point);
+		light->SetIntensity(glm::vec3(8.0f, 4.8f, 2.8f));
+		light->SetAttenuation(glm::vec3(1.0f, 0.0f, 0.0f));
+		light->SetRadius(220.0f);
+		light->SetShadowType(RHI::EShadowType::PCF);
+		light->SetShadowQuality(ELightShadowQuality::Medium);
+	}
+
+	if (m_bSpot)
+	{
+		auto gameObject = GetWorld()->Instantiate("ShadowSpotLight");
+		auto& transform = gameObject->GetTransformComponent();
+		const glm::vec3 position(42.0f, 42.0f, 42.0f);
+		transform.SetPosition(glm::vec4(position, 1.0f));
+		transform.SetRotation(glm::quatLookAt(
+			Math::SafeNormalize(-position, glm::vec3(0.0f, -1.0f, 0.0f)),
+			glm::vec3(0.0f, 1.0f, 0.0f)));
+		auto light = gameObject->AddComponent<LightComponent>();
+		light->SetLightType(ELightType::Spot);
+		light->SetIntensity(glm::vec3(4.0f, 6.0f, 10.0f));
+		light->SetAttenuation(glm::vec3(1.0f, 0.0f, 0.0f));
+		light->SetRadius(220.0f);
+		light->SetCutOff(glm::vec2(32.0f, 52.0f));
+		light->SetShadowType(RHI::EShadowType::PCF);
+		light->SetShadowQuality(ELightShadowQuality::Medium);
+	}
+}
+
+void ShadowVisualTestSetupComponent::EnsureSky()
+{
+	auto skyObject = GetWorld()->Instantiate("ShadowTestSky");
+	auto sky = skyObject->AddComponent<SkyComponent>();
+	sky->SetAmbient(0.0f);
+	sky->SetSunIntensity(0.0f);
+	sky->SetCloudsCoverage(0.0f);
+}
+
+void ShadowVisualTestSetupComponent::EnsureCamera()
+{
+	auto cameraObject = GetWorld()->Instantiate("ShadowTestCamera");
+	const glm::vec3 position(0.0f, 34.0f, 105.0f);
+	auto& transform = cameraObject->GetTransformComponent();
+	transform.SetPosition(glm::vec4(position, 1.0f));
+	transform.SetRotation(glm::quatLookAt(
+		Math::SafeNormalize(glm::vec3(0.0f, 4.0f, 0.0f) - position, glm::vec3(0.0f, 0.0f, -1.0f)),
+		glm::vec3(0.0f, 1.0f, 0.0f)));
+	auto camera = cameraObject->AddComponent<CameraComponent>();
+	camera->SetZNear(0.1f);
+	camera->SetZFar(500.0f);
+}

--- a/Runtime/Components/Tests/ShadowVisualTestSetupComponent.h
+++ b/Runtime/Components/Tests/ShadowVisualTestSetupComponent.h
@@ -1,0 +1,44 @@
+#pragma once
+#include "Sailor.h"
+#include "Components/Component.h"
+
+namespace Sailor
+{
+	class ShadowVisualTestSetupComponent : public Component
+	{
+		SAILOR_REFLECTABLE(ShadowVisualTestSetupComponent)
+
+	public:
+		SAILOR_API virtual void BeginPlay() override;
+
+		SAILOR_API bool GetDirectional() const { return m_bDirectional; }
+		SAILOR_API void SetDirectional(bool value) { m_bDirectional = value; }
+		SAILOR_API bool GetPoint() const { return m_bPoint; }
+		SAILOR_API void SetPoint(bool value) { m_bPoint = value; }
+		SAILOR_API bool GetSpot() const { return m_bSpot; }
+		SAILOR_API void SetSpot(bool value) { m_bSpot = value; }
+
+	private:
+		void SpawnBox(const char* name, const glm::vec3& position, const glm::vec3& scale);
+		void SpawnLights();
+		void EnsureSky();
+		void EnsureCamera();
+
+		bool m_bDirectional = false;
+		bool m_bPoint = false;
+		bool m_bSpot = false;
+	};
+}
+
+using namespace Sailor::Attributes;
+
+REFL_AUTO(
+	type(Sailor::ShadowVisualTestSetupComponent, bases<Sailor::Component>),
+
+	func(GetDirectional, property("directional"), SkipCDO()),
+	func(SetDirectional, property("directional"), SkipCDO()),
+	func(GetPoint, property("point"), SkipCDO()),
+	func(SetPoint, property("point"), SkipCDO()),
+	func(GetSpot, property("spot"), SkipCDO()),
+	func(SetSpot, property("spot"), SkipCDO())
+)

--- a/Runtime/Core/Reflection.cpp
+++ b/Runtime/Core/Reflection.cpp
@@ -696,6 +696,8 @@ YAML::Node Reflection::ExportEngineTypes()
 	nodes.Clear();
 	nodes.Add(ReflectEnumValues<EMobilityType>());
 	nodes.Add(ReflectEnumValues<ELightType>());
+	nodes.Add(ReflectEnumValues<ELightShadowQuality>());
+	nodes.Add(ReflectEnumValues<ELightShadowFilter>());
 	nodes.Add(ReflectEnumValues<EAnimationPlayMode>());
 	nodes.Add(ReflectEnumValues<Physics::ERigidBodyMotionType>());
 	nodes.Add(ReflectEnumValues<Physics::ECollisionShapeType>());

--- a/Runtime/ECS/LandscapeECS.cpp
+++ b/Runtime/ECS/LandscapeECS.cpp
@@ -400,6 +400,51 @@ namespace
 		shadowCaster.m_meshes.Add(std::move(shadowMesh));
 	}
 
+	void AppendDepthMaterialMetadata(RHI::RHISceneViewProxy& proxy, const MaterialPtr& material)
+	{
+		glm::vec4 baseColorFactor{ 1.0f };
+		float alphaCutoff = 0.5f;
+		uint32_t baseColorSampler = 0u;
+		if (material->GetRenderState().GetTag() != GetHash(std::string("Masked")))
+		{
+			proxy.m_baseColorFactors.Add(baseColorFactor);
+			proxy.m_alphaCutoffs.Add(alphaCutoff);
+			proxy.m_baseColorSamplers.Add(baseColorSampler);
+			return;
+		}
+
+		const glm::vec4* materialBaseColorFactor = nullptr;
+		if (!material->GetUniformsVec4().Find("material.baseColorFactor", materialBaseColorFactor))
+		{
+			material->GetUniformsVec4().Find("material.albedo", materialBaseColorFactor);
+		}
+		if (materialBaseColorFactor)
+		{
+			baseColorFactor = *materialBaseColorFactor;
+		}
+		proxy.m_baseColorFactors.Add(baseColorFactor);
+
+		const float* materialAlphaCutoff = nullptr;
+		if (material->GetUniformsFloat().Find("material.alphaCutoff", materialAlphaCutoff) && materialAlphaCutoff)
+		{
+			alphaCutoff = *materialAlphaCutoff;
+		}
+		proxy.m_alphaCutoffs.Add(alphaCutoff);
+
+		const TexturePtr* baseColorTexture = nullptr;
+		if (!material->GetSamplers().Find("baseColorSampler", baseColorTexture))
+		{
+			material->GetSamplers().Find("albedoSampler", baseColorTexture);
+		}
+		auto* textureImporter = App::GetSubmodule<TextureImporter>();
+		if (textureImporter && baseColorTexture && *baseColorTexture)
+		{
+			baseColorSampler = static_cast<uint32_t>(
+				textureImporter->GetTextureIndex((*baseColorTexture)->GetFileId()));
+		}
+		proxy.m_baseColorSamplers.Add(baseColorSampler);
+	}
+
 	void GetOctreeBounds(const Math::AABB& bounds, glm::ivec3& center, glm::ivec3& extents)
 	{
 		const glm::ivec3 minimum = glm::ivec3(glm::floor(bounds.m_min));
@@ -719,6 +764,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			proxy.m_meshModelMatrices.Add(ownerMatrix);
 			proxy.m_overrideMaterials.Add(data.m_runtimeMaterial->GetOrAddRHI(mesh->m_vertexDescription));
 			proxy.m_renderQueueTags.Add(data.m_runtimeMaterial->GetRenderState().GetTag());
+			AppendDepthMaterialMetadata(proxy, data.m_runtimeMaterial);
 			auto shadowCaster = RHI::RHIShadowCasterProxyPtr::Make();
 			shadowCaster->m_staticMeshEcs = proxy.m_staticMeshEcs;
 			shadowCaster->m_skeletonOffset = (std::numeric_limits<uint32_t>::max)();
@@ -844,6 +890,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 						vegetationProxy.m_overrideMaterials.Add(material->GetOrAddRHI(
 							vegetationMeshes[meshIndex]->m_vertexDescription));
 						vegetationProxy.m_renderQueueTags.Add(material->GetRenderState().GetTag());
+						AppendDepthMaterialMetadata(vegetationProxy, material);
 						if (profile.m_shadowMode != ELandscapeVegetationShadowMode::None)
 						{
 							AppendShadowMesh(*vegetationShadowCaster, vegetationMeshes[meshIndex], meshMatrix,

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -75,6 +75,22 @@ void LightingECS::BeginPlay()
 		RHI::ETextureUsageBit::Sampled_Bit;
 
 	m_defaultShadowMap = driver->CreateRenderTarget(glm::ivec2(1, 1), 1, ShadowMapFormat, RHI::ETextureFiltration::Linear, RHI::ETextureClamping::Clamp, usage);
+	m_localShadowAtlas = driver->CreateRenderTarget(
+		glm::ivec2(LocalShadowAtlasResolution),
+		1,
+		ShadowMapFormat,
+		RHI::ETextureFiltration::Nearest,
+		RHI::ETextureClamping::Clamp,
+		usage);
+	driver->SetDebugName(m_localShadowAtlas, "Shadow Map, Local Light Atlas");
+	m_shadowMapsMb += static_cast<float>(LocalShadowAtlasResolution * LocalShadowAtlasResolution * 2u) /
+		(1024.0f * 1024.0f);
+	const uint32_t atlasCellsPerAxis = LocalShadowAtlasResolution / LocalShadowMinResolution;
+	m_localShadowAtlasOccupancy.Resize(atlasCellsPerAxis * atlasCellsPerAxis);
+	for (auto& occupied : m_localShadowAtlasOccupancy)
+	{
+		occupied = 0;
+	}
 
 	for (uint32_t i = 0; i < NumCascades; i++)
 	{
@@ -101,15 +117,36 @@ void LightingECS::BeginPlay()
 	for (uint32_t i = 0; i < MaxShadowsInView; i++)
 	{
 		m_shadowMapOwners[i] = InvalidShadowMapIndex;
-		m_shadowMapSlots[i] = (i < m_csmShadowMaps.Num()) ? m_csmShadowMaps[i] : m_defaultShadowMap;
-		shadowMaps[i] = m_shadowMapSlots[i];
+		m_shadowMapSlots[i] = (i < m_csmShadowMaps.Num()) ? m_csmShadowMaps[i] : m_localShadowAtlas;
+		shadowMaps[i] = i < m_csmShadowMaps.Num() ?
+			m_csmShadowMaps[i] :
+			(i == NumCascades ? m_localShadowAtlas : m_defaultShadowMap);
 	}
 
 	m_shadowMaps = Sailor::RHI::Renderer::GetDriver()->AddSamplerToShaderBindings(m_lightsData, "shadowMaps", shadowMaps, 9);
 
 	auto shaderBindingSet = m_lightsData;
-	m_lightMatrices = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(shaderBindingSet, "lightsMatrices", sizeof(glm::mat4), LightingECS::MaxShadowsInView, 6);
-	m_shadowIndices = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(shaderBindingSet, "shadowIndices", sizeof(uint32_t), LightingECS::LightsMaxNum, 7);
+	m_lightMatrices = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(
+		shaderBindingSet,
+		"lightsMatrices",
+		sizeof(glm::mat4),
+		LightingECS::MaxShadowsInView,
+		6,
+		true);
+	m_shadowIndices = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(
+		shaderBindingSet,
+		"shadowIndices",
+		sizeof(uint32_t),
+		LightingECS::LightsMaxNum,
+		7,
+		true);
+	m_shadowAtlasTiles = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(
+		shaderBindingSet,
+		"shadowAtlasTiles",
+		sizeof(uint32_t),
+		LightingECS::MaxShadowsInView,
+		11,
+		true);
 }
 
 Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
@@ -138,7 +175,7 @@ Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
 		driverCommands->UpdateShaderBinding(cmdList, binding,
 			shaderDataBatch.GetData(),
 			sizeof(LightingECS::LightShaderData) * shaderDataBatch.Num(),
-			binding->GetBufferOffset() + sizeof(LightingECS::LightShaderData) * startIndex);
+			sizeof(LightingECS::LightShaderData) * startIndex);
 		shaderDataBatch.Clear(false);
 	};
 
@@ -161,7 +198,7 @@ Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
 				shaderData.m_type = (uint32_t)data.m_type;
 				shaderData.m_shadowType = (uint32_t)data.m_shadowType;
 				shaderData.m_attenuation = data.m_attenuation;
-				shaderData.m_bounds = data.m_bounds;
+				shaderData.m_bounds = glm::vec3(data.m_radius);
 				shaderData.m_intensity = data.m_intensity;
 				shaderData.m_direction = glm::normalize(ownerTransform.GetForwardVector());
 				shaderData.m_worldPosition = ownerTransform.GetWorldPosition();
@@ -215,10 +252,13 @@ void LightingECS::EndPlay()
 	m_shadowMapSlots.Clear();
 	m_shadowMapOwners.Clear();
 	m_localShadowAllocations.Clear();
+	m_localShadowAtlasOccupancy.Clear();
 	m_defaultShadowMap.Clear();
+	m_localShadowAtlas.Clear();
 	m_shadowMaps.Clear();
 	m_lightMatrices.Clear();
 	m_shadowIndices.Clear();
+	m_shadowAtlasTiles.Clear();
 	m_numLights = 0;
 	m_shadowMapsMb = 0.0f;
 }
@@ -257,11 +297,10 @@ void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
 
 			if (light.m_type != ELightType::Directional)
 			{
-				const float sphereRadius = (std::max)(glm::abs(light.m_bounds.x),
-					(std::max)(glm::abs(light.m_bounds.y), glm::abs(light.m_bounds.z)));
+				const float sphereRadius = (std::max)(light.m_radius, 0.01f);
 				const glm::vec3 worldPosition = ownerTransform.GetWorldPosition();
 
-				if (frustum.ContainsSphere(Math::Sphere(worldPosition, sphereRadius)))
+				if (frustum.OverlapsSphere(Math::Sphere(worldPosition, sphereRadius)))
 				{
 					// TODO: Sort by screen size, not by distance to camera
 					lightProxy.m_distanceToCamera = glm::length(worldPosition - glm::vec3(cameraTransform.m_position));
@@ -311,6 +350,7 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 		TVector<glm::mat4> lightMatrices(lightCascadesMatrices.Num());
 		const bool bForceCustomDepthShadowUpdate = sceneView->m_bHasCustomDepthShadowCasters;
 		bool bCanReuseAllCascades = !bForceCustomDepthShadowUpdate;
+		bool bHasCachedShadowCasters = false;
 		for (uint32_t cascadeIndex = 0; cascadeIndex < lightCascadesMatrices.Num(); ++cascadeIndex)
 		{
 			lightMatrices[cascadeIndex] = lightCascadesMatrices[cascadeIndex] * directionalLight.m_lightMatrix;
@@ -324,9 +364,11 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 					shadowType,
 					lightMatrices[cascadeIndex],
 					sceneView->m_shadowCastersRevision);
+			bHasCachedShadowCasters |= currentSnapshotIndex < m_csmSnapshots.Num() &&
+				!m_csmSnapshots[currentSnapshotIndex].m_snapshot.IsEmpty();
 		}
 
-		if (bCanReuseAllCascades)
+		if (bCanReuseAllCascades && bHasCachedShadowCasters)
 		{
 			snapshotIndex += (uint32_t)lightCascadesMatrices.Num();
 			continue;
@@ -345,24 +387,40 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 		Math::Frustum broadFrustum;
 		broadFrustum.ExtractFrustumPlanes(broadLightMatrix);
 		const auto shadowCasters = sceneView->TraceShadowCasters(broadFrustum);
+		TVector<Tasks::TaskPtr<TVector<RHI::RHIShadowCasterProxyPtr>>> cascadeCasterTasks;
+		cascadeCasterTasks.Reserve(lightCascadesMatrices.Num());
+		for (uint32_t cascadeIndex = 0; cascadeIndex < lightCascadesMatrices.Num(); ++cascadeIndex)
+		{
+			auto task = Tasks::CreateTask<TVector<RHI::RHIShadowCasterProxyPtr>>(
+				"LightingECS:Build CSM Cascade",
+				[&shadowCasters, &frustums, cascadeIndex]()
+				{
+					TVector<RHI::RHIShadowCasterProxyPtr> casters;
+					casters.Reserve(shadowCasters.Num());
+					for (const auto& caster : shadowCasters)
+					{
+						if (caster && frustums[cascadeIndex].OverlapsAABB(caster->m_worldAabb))
+						{
+							casters.Add(caster);
+						}
+					}
+					return casters;
+				},
+				EThreadType::Worker);
+			task->Run();
+			cascadeCasterTasks.Add(task);
+		}
 
 		for (uint32_t k = 0; k < lightCascadesMatrices.Num(); ++k)
 		{
+			cascadeCasterTasks[k]->Wait();
 			RHI::RHIUpdateShadowMapCommand cascade;
 			cascade.m_shadowMap = m_csmShadowMaps[k];
 			cascade.m_lightMatrix = lightMatrices[k];
 			cascade.m_lighMatrixIndex = k;
 			cascade.m_blurRadius = ShadowCascadeBlur[k];
 			cascade.m_shadowType = k > 0 ? RHI::EShadowType::PCF : directionalLight.m_shadowType;
-			cascade.m_meshList.Reserve(shadowCasters.Num());
-			for (const auto& caster : shadowCasters)
-			{
-				if (caster && frustums[k].OverlapsAABB(caster->m_worldAabb))
-				{
-					cascade.m_meshList.Add(caster);
-				}
-			}
-
+			cascade.m_meshList = std::move(cascadeCasterTasks[k]->m_result);
 			CSMLightState snapshot{};
 			snapshot.m_componentIndex = directionalLight.m_index;
 			snapshot.m_shadowType = cascade.m_shadowType;
@@ -418,7 +476,7 @@ void LightingECS::ReleaseLocalShadowAllocation(uint32_t componentIndex)
 		return;
 	}
 
-	auto& driver = Sailor::RHI::Renderer::GetDriver();
+	ReleaseLocalShadowTiles(allocation.m_tiles);
 	for (uint32_t slot : allocation.m_slots)
 	{
 		if (slot >= m_shadowMapSlots.Num())
@@ -427,18 +485,131 @@ void LightingECS::ReleaseLocalShadowAllocation(uint32_t componentIndex)
 		}
 
 		m_shadowMapOwners[slot] = InvalidShadowMapIndex;
-		m_shadowMapSlots[slot] = m_defaultShadowMap;
-		driver->UpdateShaderBinding(m_lightsData, "shadowMaps", m_defaultShadowMap, slot);
+		m_shadowMapSlots[slot] = m_localShadowAtlas;
 	}
 
-	m_shadowMapsMb = (std::max)(0.0f, m_shadowMapsMb - allocation.m_memoryMb);
 	allocation = {};
+}
+
+void LightingECS::ReleaseLocalShadowTiles(const TVector<glm::ivec4>& tiles)
+{
+	const uint32_t cellsPerAxis = LocalShadowAtlasResolution / LocalShadowMinResolution;
+	for (const auto& tile : tiles)
+	{
+		const uint32_t firstX = static_cast<uint32_t>(tile.x) / LocalShadowMinResolution;
+		const uint32_t firstY = static_cast<uint32_t>(tile.y) / LocalShadowMinResolution;
+		const uint32_t cellCount = static_cast<uint32_t>(tile.z) / LocalShadowMinResolution;
+		for (uint32_t y = firstY; y < firstY + cellCount; ++y)
+		{
+			for (uint32_t x = firstX; x < firstX + cellCount; ++x)
+			{
+				m_localShadowAtlasOccupancy[y * cellsPerAxis + x] = 0;
+			}
+		}
+	}
+}
+
+bool LightingECS::TryAllocateLocalShadowTiles(
+	uint32_t count,
+	uint32_t desiredResolution,
+	TVector<glm::ivec4>& outTiles)
+{
+	outTiles.Clear();
+	const uint32_t cellsPerAxis = LocalShadowAtlasResolution / LocalShadowMinResolution;
+	uint32_t resolution = glm::clamp(
+		desiredResolution,
+		LocalShadowMinResolution,
+		LocalShadowAtlasResolution);
+
+	while (resolution >= LocalShadowMinResolution)
+	{
+		const uint32_t cellsPerTile = resolution / LocalShadowMinResolution;
+		for (uint32_t tileIndex = 0; tileIndex < count; ++tileIndex)
+		{
+			bool bAllocated = false;
+			for (uint32_t y = 0; y + cellsPerTile <= cellsPerAxis && !bAllocated; y += cellsPerTile)
+			{
+				for (uint32_t x = 0; x + cellsPerTile <= cellsPerAxis; x += cellsPerTile)
+				{
+					bool bFree = true;
+					for (uint32_t cellY = y; cellY < y + cellsPerTile && bFree; ++cellY)
+					{
+						for (uint32_t cellX = x; cellX < x + cellsPerTile; ++cellX)
+						{
+							if (m_localShadowAtlasOccupancy[cellY * cellsPerAxis + cellX] != 0)
+							{
+								bFree = false;
+								break;
+							}
+						}
+					}
+
+					if (!bFree)
+					{
+						continue;
+					}
+
+					for (uint32_t cellY = y; cellY < y + cellsPerTile; ++cellY)
+					{
+						for (uint32_t cellX = x; cellX < x + cellsPerTile; ++cellX)
+						{
+							m_localShadowAtlasOccupancy[cellY * cellsPerAxis + cellX] = 1;
+						}
+					}
+					outTiles.Add(glm::ivec4(
+						static_cast<int32_t>(x * LocalShadowMinResolution),
+						static_cast<int32_t>(y * LocalShadowMinResolution),
+						static_cast<int32_t>(resolution),
+						static_cast<int32_t>(resolution)));
+					bAllocated = true;
+					break;
+				}
+			}
+
+			if (!bAllocated)
+			{
+				ReleaseLocalShadowTiles(outTiles);
+				outTiles.Clear();
+				break;
+			}
+		}
+
+		if (outTiles.Num() == count)
+		{
+			return true;
+		}
+
+		resolution /= 2;
+	}
+
+	return false;
+}
+
+uint32_t LightingECS::CalculateLocalShadowResolution(
+	const LightData& light,
+	float distanceToCamera,
+	const CameraData& cameraData,
+	uint32_t viewportHeight) const
+{
+	const uint32_t qualityLimit = GetLocalShadowResolution(light.m_shadowQuality);
+	const float safeDistance = (std::max)(distanceToCamera, 0.01f);
+	const float focalLengthPixels = static_cast<float>((std::max)(viewportHeight, 1u)) /
+		(2.0f * glm::tan(glm::radians(cameraData.GetFov()) * 0.5f));
+	const float projectedDiameter = 2.0f * light.m_radius * focalLengthPixels / safeDistance;
+	const uint32_t requestedPixels = static_cast<uint32_t>((std::max)(projectedDiameter, 1.0f));
+
+	uint32_t resolution = LocalShadowMinResolution;
+	while (resolution < requestedPixels && resolution < qualityLimit)
+	{
+		resolution *= 2;
+	}
+	return (std::min)(resolution, qualityLimit);
 }
 
 bool LightingECS::EnsureLocalShadowAllocation(
 	uint32_t componentIndex,
 	ELightType lightType,
-	ELightShadowQuality quality,
+	uint32_t desiredResolution,
 	uint64_t frame)
 {
 	if (m_localShadowAllocations.Num() <= componentIndex)
@@ -449,7 +620,8 @@ bool LightingECS::EnsureLocalShadowAllocation(
 	auto& current = m_localShadowAllocations[componentIndex];
 	if (current.m_componentIndex == componentIndex &&
 		current.m_lightType == lightType &&
-		current.m_quality == quality &&
+		current.m_requestedResolution >= desiredResolution &&
+		desiredResolution * 2u >= current.m_requestedResolution &&
 		!current.m_slots.IsEmpty())
 	{
 		current.m_lastUsedFrame = frame;
@@ -465,7 +637,7 @@ bool LightingECS::EnsureLocalShadowAllocation(
 	}
 
 	uint32_t firstSlot = InvalidShadowMapIndex;
-	for (uint32_t candidate = NumCascades;
+	for (uint32_t candidate = static_cast<uint32_t>(m_csmShadowMaps.Num());
 		candidate + mapCount <= MaxShadowsInView;
 		++candidate)
 	{
@@ -491,53 +663,30 @@ bool LightingECS::EnsureLocalShadowAllocation(
 		return false;
 	}
 
-	const uint32_t resolution = GetLocalShadowResolution(quality);
-	const float allocationMb = static_cast<float>(resolution) *
-		static_cast<float>(resolution) * 2.0f * static_cast<float>(mapCount) /
-		(1024.0f * 1024.0f);
-	if (m_shadowMapsMb + allocationMb > ShadowsMemoryBudgetMb)
+	TVector<glm::ivec4> tiles;
+	if (!TryAllocateLocalShadowTiles(mapCount, desiredResolution, tiles))
 	{
 		return false;
 	}
 
-	const auto usage = RHI::ETextureUsageBit::ColorAttachment_Bit |
-		RHI::ETextureUsageBit::TextureTransferSrc_Bit |
-		RHI::ETextureUsageBit::TextureTransferDst_Bit |
-		RHI::ETextureUsageBit::Sampled_Bit;
-	auto& driver = Sailor::RHI::Renderer::GetDriver();
-
 	LocalLightShadowAllocation allocation{};
 	allocation.m_componentIndex = componentIndex;
 	allocation.m_lightType = lightType;
-	allocation.m_quality = quality;
+	allocation.m_resolution = static_cast<uint32_t>(tiles[0].z);
+	allocation.m_requestedResolution = desiredResolution;
 	allocation.m_lastUsedFrame = frame;
-	allocation.m_memoryMb = allocationMb;
 	allocation.m_slots.Reserve(mapCount);
+	allocation.m_tiles = std::move(tiles);
 	allocation.m_snapshots.Resize(mapCount);
 
 	for (uint32_t face = 0; face < mapCount; ++face)
 	{
 		const uint32_t slot = firstSlot + face;
-		auto shadowMap = driver->CreateRenderTarget(
-			glm::ivec2(resolution),
-			1,
-			ShadowMapFormat,
-			RHI::ETextureFiltration::Nearest,
-			RHI::ETextureClamping::Clamp,
-			usage);
-
-		char debugName[96];
-		sprintf_s(debugName, sizeof(debugName),
-			"Shadow Map, Local Light: %u, Face: %u", componentIndex, face);
-		driver->SetDebugName(shadowMap, debugName);
-
 		m_shadowMapOwners[slot] = componentIndex;
-		m_shadowMapSlots[slot] = shadowMap;
-		driver->UpdateShaderBinding(m_lightsData, "shadowMaps", shadowMap, slot);
+		m_shadowMapSlots[slot] = m_localShadowAtlas;
 		allocation.m_slots.Add(slot);
 	}
 
-	m_shadowMapsMb += allocationMb;
 	m_localShadowAllocations[componentIndex] = std::move(allocation);
 	return true;
 }
@@ -561,7 +710,10 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 	const RHI::RHISceneViewPtr& sceneView,
 	const TVector<RHI::RHILightProxy>& spotLights,
 	const TVector<RHI::RHILightProxy>& pointLights,
-	TVector<uint32_t>& shadowIndices)
+	const CameraData& cameraData,
+	uint32_t viewportHeight,
+	TVector<uint32_t>& shadowIndices,
+	TVector<uint32_t>& shadowAtlasTiles)
 {
 	TVector<RHI::RHIUpdateShadowMapCommand> updateShadowMaps{};
 	const uint64_t frame = GetWorld()->GetCurrentFrame();
@@ -577,12 +729,17 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 			}
 
 			const auto& light = m_components[lightProxy.m_index];
+			const uint32_t desiredResolution = CalculateLocalShadowResolution(
+				light,
+				lightProxy.m_distanceToCamera,
+				cameraData,
+				viewportHeight);
 			if (light.m_shadowType == RHI::EShadowType::None ||
 				(light.m_type != ELightType::Point && light.m_type != ELightType::Spot) ||
 				!EnsureLocalShadowAllocation(
 					lightProxy.m_index,
 					light.m_type,
-					light.m_shadowQuality,
+					desiredResolution,
 					frame))
 			{
 				continue;
@@ -602,9 +759,7 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 
 			const auto& transform = owner->GetTransformComponent();
 			const glm::vec3 position = transform.GetWorldPosition();
-			const float farPlane = (std::max)(
-				glm::abs(light.m_bounds.x),
-				(std::max)(glm::abs(light.m_bounds.y), glm::abs(light.m_bounds.z)));
+			const float farPlane = (std::max)(light.m_radius, 0.01f);
 			if (farPlane <= 0.05f)
 			{
 				shadowIndices[lightProxy.m_index] = InvalidShadowMapIndex;
@@ -650,24 +805,41 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 				}
 			}
 
+			bool bHasCachedLocalShadowCasters = false;
+			for (const auto& cachedFace : allocation.m_snapshots)
+			{
+				bHasCachedLocalShadowCasters |= !cachedFace.m_snapshot.IsEmpty();
+			}
+
 			for (uint32_t face = 0; face < lightMatrices.Num(); ++face)
 			{
+				const uint32_t shadowSlot = allocation.m_slots[face];
+				const glm::ivec4 tile = allocation.m_tiles[face];
+				const uint32_t tileX = static_cast<uint32_t>(tile.x) / LocalShadowMinResolution;
+				const uint32_t tileY = static_cast<uint32_t>(tile.y) / LocalShadowMinResolution;
+				const uint32_t tileCells = static_cast<uint32_t>(tile.z) / LocalShadowMinResolution;
+				const uint32_t tileLevel = static_cast<uint32_t>(glm::log2(static_cast<float>(tileCells)));
+				shadowAtlasTiles[shadowSlot] = tileX | (tileY << 5u) | (tileLevel << 10u);
 				auto& cachedState = allocation.m_snapshots[face];
-				if (!sceneView->m_bHasCustomDepthShadowCasters &&
+				// Mesh proxies can be published asynchronously after the light has
+				// already rendered its first frame. Do not turn that bootstrap
+				// miss into a permanent empty cache entry.
+				if (bHasCachedLocalShadowCasters &&
 					cachedState.CanReuse(
-					lightProxy.m_index,
-					RHI::EShadowType::PCF,
-					lightMatrices[face],
-					sceneView->m_shadowCastersRevision))
+						lightProxy.m_index,
+						RHI::EShadowType::PCF,
+						lightMatrices[face],
+						sceneView->m_shadowCastersRevision))
 				{
 					continue;
 				}
 
 				Math::Frustum shadowFrustum(lightMatrices[face]);
 				RHI::RHIUpdateShadowMapCommand shadowPass{};
-				shadowPass.m_shadowMap = m_shadowMapSlots[allocation.m_slots[face]];
+				shadowPass.m_shadowMap = m_localShadowAtlas;
+				shadowPass.m_renderArea = tile;
 				shadowPass.m_lightMatrix = lightMatrices[face];
-				shadowPass.m_lighMatrixIndex = allocation.m_slots[face];
+				shadowPass.m_lighMatrixIndex = shadowSlot;
 				shadowPass.m_shadowType = RHI::EShadowType::PCF;
 				shadowPass.m_meshList = sceneView->TraceShadowCasters(shadowFrustum);
 
@@ -703,14 +875,23 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
 	uint32_t snapshotIndex = 0;
-	TVector<uint32_t> shadowIndices(GetGpuLightSlotsCount(m_components.Num()));
-	for (auto& shadowIndex : shadowIndices)
-	{
-		shadowIndex = InvalidShadowMapIndex;
-	}
+	const uint32_t viewportHeight = static_cast<uint32_t>((std::max)(
+		App::GetMainWindow()->GetRenderArea().y,
+		1));
 
 	for (uint32_t i = 0; i < sceneView->m_cameraTransforms.Num(); i++)
 	{
+		TVector<uint32_t> shadowIndices(GetGpuLightSlotsCount(m_components.Num()));
+		TVector<uint32_t> shadowAtlasTiles(MaxShadowsInView);
+		for (auto& shadowIndex : shadowIndices)
+		{
+			shadowIndex = InvalidShadowMapIndex;
+		}
+		for (auto& atlasTile : shadowAtlasTiles)
+		{
+			atlasTile = 0u;
+		}
+
 		const auto& camera = sceneView->m_cameras[i];
 
 		Math::Frustum frustum;
@@ -733,12 +914,17 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 			sceneView,
 			sortedSpotLights,
 			sortedPointLights,
-			shadowIndices);
+			camera,
+			viewportHeight,
+			shadowIndices,
+			shadowAtlasTiles);
 		for (auto& localShadowMap : localShadowMaps)
 		{
 			updateShadowMaps.Emplace(std::move(localShadowMap));
 		}
 		sceneView->m_shadowMapsToUpdate.Add(std::move(updateShadowMaps));
+		sceneView->m_shadowIndices.Add(std::move(shadowIndices));
+		sceneView->m_shadowAtlasTiles.Add(std::move(shadowAtlasTiles));
 	}
 
 	if (m_csmSnapshots.Num() > snapshotIndex)
@@ -746,16 +932,6 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 		m_csmSnapshots.Resize(snapshotIndex);
 	}
 
-	if (!shadowIndices.IsEmpty())
-	{
-		auto commands = Sailor::RHI::Renderer::GetDriverCommands();
-		commands->UpdateShaderBinding(
-			GetWorld()->GetCommandList(),
-			m_shadowIndices,
-			shadowIndices.GetData(),
-			shadowIndices.Num() * sizeof(uint32_t),
-			0);
-	}
 	ReleaseUnusedLocalShadowAllocations(GetWorld()->GetCurrentFrame());
 
 	sceneView->m_totalNumLights = m_numLights;
@@ -791,7 +967,7 @@ void LightingECS::GetLightProxies(TVector<Raytracing::LightProxy>& outLights) co
 		lightProxy.m_direction = glm::normalize(transform.GetForwardVector());
 		lightProxy.m_intensity = light.m_intensity;
 		lightProxy.m_attenuation = light.m_attenuation;
-		lightProxy.m_bounds = light.m_bounds;
+		lightProxy.m_bounds = glm::vec3(light.m_radius);
 		lightProxy.m_cutOff = vec2(glm::cos(glm::radians(light.m_cutOff.x)), glm::cos(glm::radians(light.m_cutOff.y)));
 
 		outLights.Add(lightProxy);

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -89,19 +89,27 @@ void LightingECS::BeginPlay()
 			usage));
 
 		driver->SetDebugName(m_csmShadowMaps[m_csmShadowMaps.Num() - 1], csmDebugName);
+		const float bytesPerPixel = bEvsmCascade ? 16.0f : 2.0f;
+		m_shadowMapsMb += static_cast<float>(
+			ShadowCascadeResolutions[i].x * ShadowCascadeResolutions[i].y) *
+			bytesPerPixel / (1024.0f * 1024.0f);
 	}
 
+	m_shadowMapSlots.Resize(MaxShadowsInView);
+	m_shadowMapOwners.Resize(MaxShadowsInView);
 	TVector<RHI::RHITexturePtr> shadowMaps(MaxShadowsInView);
 	for (uint32_t i = 0; i < MaxShadowsInView; i++)
 	{
-		shadowMaps[i] = (i < m_csmShadowMaps.Num()) ? m_csmShadowMaps[i] : m_defaultShadowMap;
+		m_shadowMapOwners[i] = InvalidShadowMapIndex;
+		m_shadowMapSlots[i] = (i < m_csmShadowMaps.Num()) ? m_csmShadowMaps[i] : m_defaultShadowMap;
+		shadowMaps[i] = m_shadowMapSlots[i];
 	}
 
 	m_shadowMaps = Sailor::RHI::Renderer::GetDriver()->AddSamplerToShaderBindings(m_lightsData, "shadowMaps", shadowMaps, 9);
 
 	auto shaderBindingSet = m_lightsData;
 	m_lightMatrices = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(shaderBindingSet, "lightsMatrices", sizeof(glm::mat4), LightingECS::MaxShadowsInView, 6);
-	m_shadowIndices = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(shaderBindingSet, "shadowIndices", sizeof(uint32_t), LightingECS::MaxShadowsInView, 7);
+	m_shadowIndices = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(shaderBindingSet, "shadowIndices", sizeof(uint32_t), LightingECS::LightsMaxNum, 7);
 }
 
 Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
@@ -203,11 +211,16 @@ void LightingECS::EndPlay()
 {
 	m_lightsData.Clear();
 	m_csmShadowMaps.Clear();
+	m_csmSnapshots.Clear();
+	m_shadowMapSlots.Clear();
+	m_shadowMapOwners.Clear();
+	m_localShadowAllocations.Clear();
 	m_defaultShadowMap.Clear();
 	m_shadowMaps.Clear();
 	m_lightMatrices.Clear();
 	m_shadowIndices.Clear();
 	m_numLights = 0;
+	m_shadowMapsMb = 0.0f;
 }
 
 void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
@@ -225,7 +238,8 @@ void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
 		auto& light = m_components[index];
 		if (light.m_shadowType != RHI::EShadowType::None && light.m_bIsActive)
 		{
-			GameObjectPtr owner = light.m_owner.StaticCast<GameObject>();
+			ObjectPtr ownerObject = light.m_owner;
+			GameObjectPtr owner = ownerObject.StaticCast<GameObject>();
 			if (!owner)
 			{
 				continue;
@@ -243,12 +257,14 @@ void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
 
 			if (light.m_type != ELightType::Directional)
 			{
-				const float sphereRadius = std::max(std::max(light.m_bounds.x, light.m_bounds.y), light.m_bounds.z);
+				const float sphereRadius = (std::max)(glm::abs(light.m_bounds.x),
+					(std::max)(glm::abs(light.m_bounds.y), glm::abs(light.m_bounds.z)));
+				const glm::vec3 worldPosition = ownerTransform.GetWorldPosition();
 
-				if (frustum.ContainsSphere(Math::Sphere(ownerTransform.GetPosition(), sphereRadius)))
+				if (frustum.ContainsSphere(Math::Sphere(worldPosition, sphereRadius)))
 				{
 					// TODO: Sort by screen size, not by distance to camera
-					lightProxy.m_distanceToCamera = glm::length(ownerTransform.GetPosition() - cameraTransform.m_position);
+					lightProxy.m_distanceToCamera = glm::length(worldPosition - glm::vec3(cameraTransform.m_position));
 
 					if (ELightType::Spot == light.m_type)
 					{
@@ -422,10 +438,309 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 	return updateShadowMaps;
 }
 
+void LightingECS::ReleaseLocalShadowAllocation(uint32_t componentIndex)
+{
+	if (componentIndex >= m_localShadowAllocations.Num())
+	{
+		return;
+	}
+
+	auto& allocation = m_localShadowAllocations[componentIndex];
+	if (allocation.m_componentIndex != componentIndex)
+	{
+		return;
+	}
+
+	auto& driver = Sailor::RHI::Renderer::GetDriver();
+	for (uint32_t slot : allocation.m_slots)
+	{
+		if (slot >= m_shadowMapSlots.Num())
+		{
+			continue;
+		}
+
+		m_shadowMapOwners[slot] = InvalidShadowMapIndex;
+		m_shadowMapSlots[slot] = m_defaultShadowMap;
+		driver->UpdateShaderBinding(m_lightsData, "shadowMaps", m_defaultShadowMap, slot);
+	}
+
+	m_shadowMapsMb = (std::max)(0.0f, m_shadowMapsMb - allocation.m_memoryMb);
+	allocation = {};
+}
+
+bool LightingECS::EnsureLocalShadowAllocation(
+	uint32_t componentIndex,
+	ELightType lightType,
+	ELightShadowQuality quality,
+	uint64_t frame)
+{
+	if (m_localShadowAllocations.Num() <= componentIndex)
+	{
+		m_localShadowAllocations.Resize(static_cast<size_t>(componentIndex) + 1);
+	}
+
+	auto& current = m_localShadowAllocations[componentIndex];
+	if (current.m_componentIndex == componentIndex &&
+		current.m_lightType == lightType &&
+		current.m_quality == quality &&
+		!current.m_slots.IsEmpty())
+	{
+		current.m_lastUsedFrame = frame;
+		return true;
+	}
+
+	ReleaseLocalShadowAllocation(componentIndex);
+
+	const uint32_t mapCount = GetLocalShadowMapCount(lightType);
+	if (mapCount == 0)
+	{
+		return false;
+	}
+
+	uint32_t firstSlot = InvalidShadowMapIndex;
+	for (uint32_t candidate = NumCascades;
+		candidate + mapCount <= MaxShadowsInView;
+		++candidate)
+	{
+		bool bRangeAvailable = true;
+		for (uint32_t offset = 0; offset < mapCount; ++offset)
+		{
+			if (m_shadowMapOwners[candidate + offset] != InvalidShadowMapIndex)
+			{
+				bRangeAvailable = false;
+				break;
+			}
+		}
+
+		if (bRangeAvailable)
+		{
+			firstSlot = candidate;
+			break;
+		}
+	}
+
+	if (firstSlot == InvalidShadowMapIndex)
+	{
+		return false;
+	}
+
+	const uint32_t resolution = GetLocalShadowResolution(quality);
+	const float allocationMb = static_cast<float>(resolution) *
+		static_cast<float>(resolution) * 2.0f * static_cast<float>(mapCount) /
+		(1024.0f * 1024.0f);
+	if (m_shadowMapsMb + allocationMb > ShadowsMemoryBudgetMb)
+	{
+		return false;
+	}
+
+	const auto usage = RHI::ETextureUsageBit::ColorAttachment_Bit |
+		RHI::ETextureUsageBit::TextureTransferSrc_Bit |
+		RHI::ETextureUsageBit::TextureTransferDst_Bit |
+		RHI::ETextureUsageBit::Sampled_Bit;
+	auto& driver = Sailor::RHI::Renderer::GetDriver();
+
+	LocalLightShadowAllocation allocation{};
+	allocation.m_componentIndex = componentIndex;
+	allocation.m_lightType = lightType;
+	allocation.m_quality = quality;
+	allocation.m_lastUsedFrame = frame;
+	allocation.m_memoryMb = allocationMb;
+	allocation.m_slots.Reserve(mapCount);
+	allocation.m_snapshots.Resize(mapCount);
+
+	for (uint32_t face = 0; face < mapCount; ++face)
+	{
+		const uint32_t slot = firstSlot + face;
+		auto shadowMap = driver->CreateRenderTarget(
+			glm::ivec2(resolution),
+			1,
+			ShadowMapFormat,
+			RHI::ETextureFiltration::Nearest,
+			RHI::ETextureClamping::Clamp,
+			usage);
+
+		char debugName[96];
+		sprintf_s(debugName, sizeof(debugName),
+			"Shadow Map, Local Light: %u, Face: %u", componentIndex, face);
+		driver->SetDebugName(shadowMap, debugName);
+
+		m_shadowMapOwners[slot] = componentIndex;
+		m_shadowMapSlots[slot] = shadowMap;
+		driver->UpdateShaderBinding(m_lightsData, "shadowMaps", shadowMap, slot);
+		allocation.m_slots.Add(slot);
+	}
+
+	m_shadowMapsMb += allocationMb;
+	m_localShadowAllocations[componentIndex] = std::move(allocation);
+	return true;
+}
+
+void LightingECS::ReleaseUnusedLocalShadowAllocations(uint64_t frame)
+{
+	for (uint32_t componentIndex = 0;
+		componentIndex < m_localShadowAllocations.Num();
+		++componentIndex)
+	{
+		const auto& allocation = m_localShadowAllocations[componentIndex];
+		if (allocation.m_componentIndex == componentIndex &&
+			allocation.m_lastUsedFrame != frame)
+		{
+			ReleaseLocalShadowAllocation(componentIndex);
+		}
+	}
+}
+
+TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
+	const RHI::RHISceneViewPtr& sceneView,
+	const TVector<RHI::RHILightProxy>& spotLights,
+	const TVector<RHI::RHILightProxy>& pointLights,
+	TVector<uint32_t>& shadowIndices)
+{
+	TVector<RHI::RHIUpdateShadowMapCommand> updateShadowMaps{};
+	const uint64_t frame = GetWorld()->GetCurrentFrame();
+
+	auto prepareLights = [&](const TVector<RHI::RHILightProxy>& lights)
+	{
+		for (const auto& lightProxy : lights)
+		{
+			if (lightProxy.m_index >= m_components.Num() ||
+				lightProxy.m_index >= shadowIndices.Num())
+			{
+				continue;
+			}
+
+			const auto& light = m_components[lightProxy.m_index];
+			if (light.m_shadowType == RHI::EShadowType::None ||
+				(light.m_type != ELightType::Point && light.m_type != ELightType::Spot) ||
+				!EnsureLocalShadowAllocation(
+					lightProxy.m_index,
+					light.m_type,
+					light.m_shadowQuality,
+					frame))
+			{
+				continue;
+			}
+
+			auto& allocation = m_localShadowAllocations[lightProxy.m_index];
+			const uint32_t firstSlot = allocation.m_slots[0];
+			shadowIndices[lightProxy.m_index] = firstSlot |
+				(light.m_shadowFilter == ELightShadowFilter::Soft ? SoftShadowMapBit : 0u);
+
+			ObjectPtr ownerObject = light.m_owner;
+			GameObjectPtr owner = ownerObject.StaticCast<GameObject>();
+			if (!owner)
+			{
+				continue;
+			}
+
+			const auto& transform = owner->GetTransformComponent();
+			const glm::vec3 position = transform.GetWorldPosition();
+			const float farPlane = (std::max)(
+				glm::abs(light.m_bounds.x),
+				(std::max)(glm::abs(light.m_bounds.y), glm::abs(light.m_bounds.z)));
+			if (farPlane <= 0.05f)
+			{
+				shadowIndices[lightProxy.m_index] = InvalidShadowMapIndex;
+				continue;
+			}
+
+			const float nearPlane = (std::max)(0.01f, farPlane * 0.001f);
+			TVector<glm::mat4> lightMatrices{};
+			if (light.m_type == ELightType::Spot)
+			{
+				const float fieldOfView = glm::clamp(
+					glm::abs(light.m_cutOff.y) * 2.0f,
+					1.0f,
+					179.0f);
+				const glm::mat4 view = glm::lookAtRH(
+					position,
+					position + glm::normalize(transform.GetForwardVector()),
+					glm::normalize(glm::vec3(
+						transform.GetCachedWorldMatrix() * Math::vec4_Up)));
+				lightMatrices.Add(Math::PerspectiveRH(
+					glm::radians(fieldOfView), 1.0f, nearPlane, farPlane) * view);
+			}
+			else
+			{
+				static constexpr glm::vec3 directions[6] = {
+					{ 1.0f, 0.0f, 0.0f }, { -1.0f, 0.0f, 0.0f },
+					{ 0.0f, 1.0f, 0.0f }, { 0.0f, -1.0f, 0.0f },
+					{ 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, -1.0f }
+				};
+				static constexpr glm::vec3 upVectors[6] = {
+					{ 0.0f, -1.0f, 0.0f }, { 0.0f, -1.0f, 0.0f },
+					{ 0.0f, 0.0f, 1.0f }, { 0.0f, 0.0f, -1.0f },
+					{ 0.0f, -1.0f, 0.0f }, { 0.0f, -1.0f, 0.0f }
+				};
+				const glm::mat4 projection = Math::PerspectiveRH(
+					glm::radians(90.0f), 1.0f, nearPlane, farPlane);
+				for (uint32_t face = 0; face < 6; ++face)
+				{
+					lightMatrices.Add(projection * glm::lookAtRH(
+						position,
+						position + directions[face],
+						upVectors[face]));
+				}
+			}
+
+			for (uint32_t face = 0; face < lightMatrices.Num(); ++face)
+			{
+				auto& cachedState = allocation.m_snapshots[face];
+				if (!sceneView->m_bHasCustomDepthShadowCasters &&
+					cachedState.CanReuse(
+					lightProxy.m_index,
+					RHI::EShadowType::PCF,
+					lightMatrices[face],
+					sceneView->m_shadowCastersRevision))
+				{
+					continue;
+				}
+
+				Math::Frustum shadowFrustum(lightMatrices[face]);
+				RHI::RHIUpdateShadowMapCommand shadowPass{};
+				shadowPass.m_shadowMap = m_shadowMapSlots[allocation.m_slots[face]];
+				shadowPass.m_lightMatrix = lightMatrices[face];
+				shadowPass.m_lighMatrixIndex = allocation.m_slots[face];
+				shadowPass.m_shadowType = RHI::EShadowType::PCF;
+				shadowPass.m_meshList = sceneView->TraceShadowCasters(shadowFrustum);
+
+				CSMLightState snapshot{};
+				snapshot.m_componentIndex = lightProxy.m_index;
+				snapshot.m_shadowType = RHI::EShadowType::PCF;
+				snapshot.m_lightMatrix = lightMatrices[face];
+				snapshot.m_sceneRevision = sceneView->m_shadowCastersRevision;
+				snapshot.m_snapshot.Reserve(shadowPass.m_meshList.Num());
+				for (const auto& caster : shadowPass.m_meshList)
+				{
+					if (caster)
+					{
+						snapshot.m_snapshot.Add({ caster->m_staticMeshEcs, caster->m_frame });
+					}
+				}
+				snapshot.m_snapshot.Sort([](const auto& lhs, const auto& rhs)
+					{
+						return lhs.m_first < rhs.m_first;
+					});
+				cachedState = std::move(snapshot);
+				updateShadowMaps.Emplace(std::move(shadowPass));
+			}
+		}
+	};
+
+	prepareLights(spotLights);
+	prepareLights(pointLights);
+	return updateShadowMaps;
+}
+
 void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
 	uint32_t snapshotIndex = 0;
+	TVector<uint32_t> shadowIndices(GetGpuLightSlotsCount(m_components.Num()));
+	for (auto& shadowIndex : shadowIndices)
+	{
+		shadowIndex = InvalidShadowMapIndex;
+	}
 
 	for (uint32_t i = 0; i < sceneView->m_cameraTransforms.Num(); i++)
 	{
@@ -439,7 +754,7 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 		TVector<RHI::RHILightProxy> sortedSpotLights;
 		TVector<RHI::RHILightProxy> sortedPointLights;
 
-		GetLightsInFrustum(frustum, sceneView->m_cameraTransforms[i], directionalLights, sortedSpotLights, sortedPointLights);
+		GetLightsInFrustum(frustum, sceneView->m_cameraTransforms[i], directionalLights, sortedPointLights, sortedSpotLights);
 
 		auto updateShadowMaps = PrepareCSMPasses(
 			sceneView,
@@ -447,6 +762,15 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 			camera,
 			directionalLights,
 			snapshotIndex);
+		auto localShadowMaps = PrepareLocalShadowPasses(
+			sceneView,
+			sortedSpotLights,
+			sortedPointLights,
+			shadowIndices);
+		for (auto& localShadowMap : localShadowMaps)
+		{
+			updateShadowMaps.Emplace(std::move(localShadowMap));
+		}
 		sceneView->m_shadowMapsToUpdate.Add(std::move(updateShadowMaps));
 	}
 
@@ -454,6 +778,18 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 	{
 		m_csmSnapshots.Resize(snapshotIndex);
 	}
+
+	if (!shadowIndices.IsEmpty())
+	{
+		auto commands = Sailor::RHI::Renderer::GetDriverCommands();
+		commands->UpdateShaderBinding(
+			GetWorld()->GetCommandList(),
+			m_shadowIndices,
+			shadowIndices.GetData(),
+			shadowIndices.Num() * sizeof(uint32_t),
+			0);
+	}
+	ReleaseUnusedLocalShadowAllocations(GetWorld()->GetCurrentFrame());
 
 	sceneView->m_totalNumLights = m_numLights;
 	sceneView->m_rhiLightsData = m_lightsData;

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -22,7 +22,7 @@ namespace
 				if (lhs[column][row] != rhs[column][row])
 				{
 					return false;
-				}
+		}
 			}
 		}
 
@@ -65,6 +65,8 @@ bool CSMLightState::CanReuse(
 
 void LightingECS::BeginPlay()
 {
+	m_shadowMapsMb = 0.0f;
+	m_csmShadowMapsMb = 0.0f;
 	auto& driver = Sailor::RHI::Renderer::GetDriver();
 	m_lightsData = driver->CreateShaderBindings();
 	driver->AddSsboToShaderBindings(m_lightsData, "light", sizeof(LightingECS::LightShaderData), LightsMaxNum, 0, true);
@@ -75,23 +77,6 @@ void LightingECS::BeginPlay()
 		RHI::ETextureUsageBit::Sampled_Bit;
 
 	m_defaultShadowMap = driver->CreateRenderTarget(glm::ivec2(1, 1), 1, ShadowMapFormat, RHI::ETextureFiltration::Linear, RHI::ETextureClamping::Clamp, usage);
-	m_localShadowAtlas = driver->CreateRenderTarget(
-		glm::ivec2(LocalShadowAtlasResolution),
-		1,
-		ShadowMapFormat,
-		RHI::ETextureFiltration::Nearest,
-		RHI::ETextureClamping::Clamp,
-		usage);
-	driver->SetDebugName(m_localShadowAtlas, "Shadow Map, Local Light Atlas");
-	m_shadowMapsMb += static_cast<float>(LocalShadowAtlasResolution * LocalShadowAtlasResolution * 2u) /
-		(1024.0f * 1024.0f);
-	const uint32_t atlasCellsPerAxis = LocalShadowAtlasResolution / LocalShadowMinResolution;
-	m_localShadowAtlasOccupancy.Resize(atlasCellsPerAxis * atlasCellsPerAxis);
-	for (auto& occupied : m_localShadowAtlasOccupancy)
-	{
-		occupied = 0;
-	}
-
 	for (uint32_t i = 0; i < NumCascades; i++)
 	{
 		char csmDebugName[64];
@@ -106,21 +91,22 @@ void LightingECS::BeginPlay()
 
 		driver->SetDebugName(m_csmShadowMaps[m_csmShadowMaps.Num() - 1], csmDebugName);
 		const float bytesPerPixel = bEvsmCascade ? 16.0f : 2.0f;
-		m_shadowMapsMb += static_cast<float>(
+		const float shadowMapMemoryMb = static_cast<float>(
 			ShadowCascadeResolutions[i].x * ShadowCascadeResolutions[i].y) *
 			bytesPerPixel / (1024.0f * 1024.0f);
+		m_csmShadowMapsMb += shadowMapMemoryMb;
+		m_shadowMapsMb += shadowMapMemoryMb;
 	}
 
-	m_shadowMapSlots.Resize(MaxShadowsInView);
 	m_shadowMapOwners.Resize(MaxShadowsInView);
-	TVector<RHI::RHITexturePtr> shadowMaps(MaxShadowsInView);
+	TVector<RHI::RHITexturePtr> shadowMaps(MaxShadowMapSamplers);
 	for (uint32_t i = 0; i < MaxShadowsInView; i++)
 	{
 		m_shadowMapOwners[i] = InvalidShadowMapIndex;
-		m_shadowMapSlots[i] = (i < m_csmShadowMaps.Num()) ? m_csmShadowMaps[i] : m_localShadowAtlas;
-		shadowMaps[i] = i < m_csmShadowMaps.Num() ?
-			m_csmShadowMaps[i] :
-			(i == NumCascades ? m_localShadowAtlas : m_defaultShadowMap);
+	}
+	for (uint32_t i = 0; i < MaxShadowMapSamplers; i++)
+	{
+		shadowMaps[i] = i < m_csmShadowMaps.Num() ? m_csmShadowMaps[i] : m_defaultShadowMap;
 	}
 
 	m_shadowMaps = Sailor::RHI::Renderer::GetDriver()->AddSamplerToShaderBindings(m_lightsData, "shadowMaps", shadowMaps, 9);
@@ -249,18 +235,17 @@ void LightingECS::EndPlay()
 	m_lightsData.Clear();
 	m_csmShadowMaps.Clear();
 	m_csmSnapshots.Clear();
-	m_shadowMapSlots.Clear();
 	m_shadowMapOwners.Clear();
 	m_localShadowAllocations.Clear();
-	m_localShadowAtlasOccupancy.Clear();
+	m_localShadowAtlases.Clear();
 	m_defaultShadowMap.Clear();
-	m_localShadowAtlas.Clear();
 	m_shadowMaps.Clear();
 	m_lightMatrices.Clear();
 	m_shadowIndices.Clear();
 	m_shadowAtlasTiles.Clear();
 	m_numLights = 0;
 	m_shadowMapsMb = 0.0f;
+	m_csmShadowMapsMb = 0.0f;
 }
 
 void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
@@ -476,24 +461,31 @@ void LightingECS::ReleaseLocalShadowAllocation(uint32_t componentIndex)
 		return;
 	}
 
-	ReleaseLocalShadowTiles(allocation.m_tiles);
+	ReleaseLocalShadowTiles(allocation.m_atlasIndex, allocation.m_tiles);
 	for (uint32_t slot : allocation.m_slots)
 	{
-		if (slot >= m_shadowMapSlots.Num())
+		if (slot >= m_shadowMapOwners.Num())
 		{
 			continue;
 		}
 
 		m_shadowMapOwners[slot] = InvalidShadowMapIndex;
-		m_shadowMapSlots[slot] = m_localShadowAtlas;
 	}
 
 	allocation = {};
 }
 
-void LightingECS::ReleaseLocalShadowTiles(const TVector<glm::ivec4>& tiles)
+void LightingECS::ReleaseLocalShadowTiles(
+	uint32_t atlasIndex,
+	const TVector<glm::ivec4>& tiles)
 {
-	const uint32_t cellsPerAxis = LocalShadowAtlasResolution / LocalShadowMinResolution;
+	if (atlasIndex >= m_localShadowAtlases.Num() ||
+		!m_localShadowAtlases[atlasIndex].m_texture)
+	{
+		return;
+	}
+
+	auto& occupancy = m_localShadowAtlases[atlasIndex].m_occupancy;
 	for (const auto& tile : tiles)
 	{
 		const uint32_t firstX = static_cast<uint32_t>(tile.x) / LocalShadowMinResolution;
@@ -503,82 +495,187 @@ void LightingECS::ReleaseLocalShadowTiles(const TVector<glm::ivec4>& tiles)
 		{
 			for (uint32_t x = firstX; x < firstX + cellCount; ++x)
 			{
-				m_localShadowAtlasOccupancy[y * cellsPerAxis + x] = 0;
+				occupancy[y * LocalShadowAtlasCellsPerAxis + x] = 0;
 			}
 		}
 	}
 }
 
-bool LightingECS::TryAllocateLocalShadowTiles(
+bool LightingECS::TryCreateLocalShadowAtlas(uint32_t& outAtlasIndex)
+{
+	if (m_shadowMapsMb + LocalShadowAtlasMemoryMb > m_shadowsMemoryBudgetMb + 0.001f)
+	{
+		return false;
+	}
+
+	uint32_t atlasIndex = static_cast<uint32_t>(m_localShadowAtlases.Num());
+	for (uint32_t i = 0; i < m_localShadowAtlases.Num(); ++i)
+	{
+		if (!m_localShadowAtlases[i].m_texture)
+		{
+			atlasIndex = i;
+			break;
+		}
+	}
+	if (NumCascades + atlasIndex >= MaxShadowMapSamplers)
+	{
+		return false;
+	}
+
+	const auto usage = RHI::ETextureUsageBit::ColorAttachment_Bit |
+		RHI::ETextureUsageBit::TextureTransferSrc_Bit |
+		RHI::ETextureUsageBit::TextureTransferDst_Bit |
+		RHI::ETextureUsageBit::Sampled_Bit;
+	auto texture = RHI::Renderer::GetDriver()->CreateRenderTarget(
+		glm::ivec2(LocalShadowAtlasResolution),
+		1,
+		ShadowMapFormat,
+		RHI::ETextureFiltration::Nearest,
+		RHI::ETextureClamping::Clamp,
+		usage);
+	if (!texture)
+	{
+		return false;
+	}
+
+	char debugName[64];
+	sprintf_s(debugName, sizeof(debugName), "Shadow Map, Local Light Atlas %u", atlasIndex);
+	RHI::Renderer::GetDriver()->SetDebugName(texture, debugName);
+
+	LocalShadowAtlas atlas{};
+	atlas.m_texture = texture;
+	atlas.m_occupancy.Resize(
+		static_cast<size_t>(LocalShadowAtlasCellsPerAxis) * LocalShadowAtlasCellsPerAxis);
+	for (auto& occupied : atlas.m_occupancy)
+	{
+		occupied = 0;
+	}
+	if (atlasIndex == m_localShadowAtlases.Num())
+	{
+		m_localShadowAtlases.Add(std::move(atlas));
+	}
+	else
+	{
+		m_localShadowAtlases[atlasIndex] = std::move(atlas);
+	}
+
+	RHI::Renderer::GetDriver()->UpdateShaderBinding(
+		m_lightsData,
+		"shadowMaps",
+		texture,
+		NumCascades + atlasIndex);
+	m_shadowMapsMb += LocalShadowAtlasMemoryMb;
+	outAtlasIndex = atlasIndex;
+	return true;
+}
+
+bool LightingECS::TryAllocateLocalShadowTilesInAtlas(
+	uint32_t atlasIndex,
 	uint32_t count,
-	uint32_t desiredResolution,
+	uint32_t resolution,
 	TVector<glm::ivec4>& outTiles)
 {
 	outTiles.Clear();
-	const uint32_t cellsPerAxis = LocalShadowAtlasResolution / LocalShadowMinResolution;
-	uint32_t resolution = glm::clamp(
-		desiredResolution,
-		LocalShadowMinResolution,
-		LocalShadowAtlasResolution);
-
-	while (resolution >= LocalShadowMinResolution)
+	if (atlasIndex >= m_localShadowAtlases.Num() ||
+		!m_localShadowAtlases[atlasIndex].m_texture)
 	{
-		const uint32_t cellsPerTile = resolution / LocalShadowMinResolution;
-		for (uint32_t tileIndex = 0; tileIndex < count; ++tileIndex)
+		return false;
+	}
+
+	auto& occupancy = m_localShadowAtlases[atlasIndex].m_occupancy;
+	const uint32_t cellsPerTile = resolution / LocalShadowMinResolution;
+	for (uint32_t tileIndex = 0; tileIndex < count; ++tileIndex)
+	{
+		bool bAllocated = false;
+		for (uint32_t y = 0;
+			y + cellsPerTile <= LocalShadowAtlasCellsPerAxis && !bAllocated;
+			y += cellsPerTile)
 		{
-			bool bAllocated = false;
-			for (uint32_t y = 0; y + cellsPerTile <= cellsPerAxis && !bAllocated; y += cellsPerTile)
+			for (uint32_t x = 0;
+				x + cellsPerTile <= LocalShadowAtlasCellsPerAxis;
+				x += cellsPerTile)
 			{
-				for (uint32_t x = 0; x + cellsPerTile <= cellsPerAxis; x += cellsPerTile)
+				bool bFree = true;
+				for (uint32_t cellY = y; cellY < y + cellsPerTile && bFree; ++cellY)
 				{
-					bool bFree = true;
-					for (uint32_t cellY = y; cellY < y + cellsPerTile && bFree; ++cellY)
+					for (uint32_t cellX = x; cellX < x + cellsPerTile; ++cellX)
 					{
-						for (uint32_t cellX = x; cellX < x + cellsPerTile; ++cellX)
+						if (occupancy[cellY * LocalShadowAtlasCellsPerAxis + cellX] != 0)
 						{
-							if (m_localShadowAtlasOccupancy[cellY * cellsPerAxis + cellX] != 0)
-							{
-								bFree = false;
-								break;
-							}
+							bFree = false;
+							break;
 						}
 					}
-
-					if (!bFree)
-					{
-						continue;
-					}
-
-					for (uint32_t cellY = y; cellY < y + cellsPerTile; ++cellY)
-					{
-						for (uint32_t cellX = x; cellX < x + cellsPerTile; ++cellX)
-						{
-							m_localShadowAtlasOccupancy[cellY * cellsPerAxis + cellX] = 1;
-						}
-					}
-					outTiles.Add(glm::ivec4(
-						static_cast<int32_t>(x * LocalShadowMinResolution),
-						static_cast<int32_t>(y * LocalShadowMinResolution),
-						static_cast<int32_t>(resolution),
-						static_cast<int32_t>(resolution)));
-					bAllocated = true;
-					break;
 				}
-			}
 
-			if (!bAllocated)
-			{
-				ReleaseLocalShadowTiles(outTiles);
-				outTiles.Clear();
+				if (!bFree)
+				{
+					continue;
+				}
+
+				for (uint32_t cellY = y; cellY < y + cellsPerTile; ++cellY)
+				{
+					for (uint32_t cellX = x; cellX < x + cellsPerTile; ++cellX)
+					{
+						occupancy[cellY * LocalShadowAtlasCellsPerAxis + cellX] = 1;
+					}
+				}
+				outTiles.Add(glm::ivec4(
+					static_cast<int32_t>(x * LocalShadowMinResolution),
+					static_cast<int32_t>(y * LocalShadowMinResolution),
+					static_cast<int32_t>(resolution),
+					static_cast<int32_t>(resolution)));
+				bAllocated = true;
 				break;
 			}
 		}
 
-		if (outTiles.Num() == count)
+		if (!bAllocated)
 		{
-			return true;
+			ReleaseLocalShadowTiles(atlasIndex, outTiles);
+			outTiles.Clear();
+			return false;
+		}
+	}
+	return true;
+}
+
+bool LightingECS::TryAllocateLocalShadowTiles(
+	uint32_t count,
+	uint32_t desiredResolution,
+	uint32_t& outAtlasIndex,
+	TVector<glm::ivec4>& outTiles)
+{
+	uint32_t resolution = glm::clamp(
+		desiredResolution,
+		LocalShadowMinResolution,
+		LocalShadowAtlasResolution);
+	while (resolution >= LocalShadowMinResolution)
+	{
+		for (uint32_t atlasIndex = 0; atlasIndex < m_localShadowAtlases.Num(); ++atlasIndex)
+		{
+			if (TryAllocateLocalShadowTilesInAtlas(
+				atlasIndex,
+				count,
+				resolution,
+				outTiles))
+			{
+				outAtlasIndex = atlasIndex;
+				return true;
+			}
 		}
 
+		uint32_t atlasIndex = InvalidShadowMapIndex;
+		if (TryCreateLocalShadowAtlas(atlasIndex) &&
+			TryAllocateLocalShadowTilesInAtlas(
+				atlasIndex,
+				count,
+				resolution,
+				outTiles))
+		{
+			outAtlasIndex = atlasIndex;
+			return true;
+		}
 		resolution /= 2;
 	}
 
@@ -610,7 +707,8 @@ bool LightingECS::EnsureLocalShadowAllocation(
 	uint32_t componentIndex,
 	ELightType lightType,
 	uint32_t desiredResolution,
-	uint64_t frame)
+	uint64_t frame,
+	TVector<RHI::RHIBlitShadowMapCommand>& shadowMapsToBlit)
 {
 	if (m_localShadowAllocations.Num() <= componentIndex)
 	{
@@ -620,15 +718,47 @@ bool LightingECS::EnsureLocalShadowAllocation(
 	auto& current = m_localShadowAllocations[componentIndex];
 	if (current.m_componentIndex == componentIndex &&
 		current.m_lightType == lightType &&
-		current.m_requestedResolution >= desiredResolution &&
-		desiredResolution * 2u >= current.m_requestedResolution &&
 		!current.m_slots.IsEmpty())
 	{
-		current.m_lastUsedFrame = frame;
-		return true;
-	}
+		if (desiredResolution < current.m_resolution)
+		{
+			uint32_t destinationAtlasIndex = InvalidShadowMapIndex;
+			TVector<glm::ivec4> destinationTiles;
+			if (TryAllocateLocalShadowTiles(
+				static_cast<uint32_t>(current.m_tiles.Num()),
+				desiredResolution,
+				destinationAtlasIndex,
+				destinationTiles))
+			{
+				const auto sourceAtlas = m_localShadowAtlases[current.m_atlasIndex].m_texture;
+				const auto destinationAtlas = m_localShadowAtlases[destinationAtlasIndex].m_texture;
+				for (uint32_t face = 0; face < destinationTiles.Num(); ++face)
+				{
+					RHI::RHIBlitShadowMapCommand blit{};
+					blit.m_source = sourceAtlas;
+					blit.m_destination = destinationAtlas;
+					blit.m_sourceArea = current.m_tiles[face];
+					blit.m_destinationArea = destinationTiles[face];
+					shadowMapsToBlit.Add(std::move(blit));
+				}
 
-	ReleaseLocalShadowAllocation(componentIndex);
+				ReleaseLocalShadowTiles(current.m_atlasIndex, current.m_tiles);
+				current.m_atlasIndex = destinationAtlasIndex;
+				current.m_tiles = std::move(destinationTiles);
+				current.m_resolution = static_cast<uint32_t>(current.m_tiles[0].z);
+			}
+		}
+
+		if (desiredResolution <= current.m_resolution)
+		{
+			current.m_requestedResolution = desiredResolution;
+			current.m_lastUsedFrame = frame;
+			return true;
+		}
+
+		// Increasing resolution requires a new shadow render. Keep the old
+		// allocation alive until a replacement has been found below.
+	}
 
 	const uint32_t mapCount = GetLocalShadowMapCount(lightType);
 	if (mapCount == 0)
@@ -637,36 +767,89 @@ bool LightingECS::EnsureLocalShadowAllocation(
 	}
 
 	uint32_t firstSlot = InvalidShadowMapIndex;
-	for (uint32_t candidate = static_cast<uint32_t>(m_csmShadowMaps.Num());
-		candidate + mapCount <= MaxShadowsInView;
-		++candidate)
+	if (current.m_componentIndex == componentIndex &&
+		current.m_lightType == lightType &&
+		current.m_slots.Num() == mapCount)
 	{
-		bool bRangeAvailable = true;
-		for (uint32_t offset = 0; offset < mapCount; ++offset)
+		firstSlot = current.m_slots[0];
+	}
+	else
+	{
+		auto findFreeSlots = [&]()
 		{
-			if (m_shadowMapOwners[candidate + offset] != InvalidShadowMapIndex)
+			for (uint32_t candidate = static_cast<uint32_t>(m_csmShadowMaps.Num());
+				candidate + mapCount <= MaxShadowsInView;
+				++candidate)
 			{
-				bRangeAvailable = false;
-				break;
-			}
-		}
+				bool bRangeAvailable = true;
+				for (uint32_t offset = 0; offset < mapCount; ++offset)
+				{
+					if (m_shadowMapOwners[candidate + offset] != InvalidShadowMapIndex)
+					{
+						bRangeAvailable = false;
+						break;
+					}
+				}
 
-		if (bRangeAvailable)
+				if (bRangeAvailable)
+				{
+					return candidate;
+				}
+			}
+			return InvalidShadowMapIndex;
+		};
+
+		firstSlot = findFreeSlots();
+		while (firstSlot == InvalidShadowMapIndex &&
+			EvictLeastRecentlyUsedLocalShadowAllocation(componentIndex, frame))
 		{
-			firstSlot = candidate;
-			break;
+			firstSlot = findFreeSlots();
 		}
 	}
 
 	if (firstSlot == InvalidShadowMapIndex)
 	{
+		if (current.m_componentIndex == componentIndex)
+		{
+			current.m_lastUsedFrame = frame;
+			return true;
+		}
 		return false;
 	}
 
+	uint32_t atlasIndex = InvalidShadowMapIndex;
 	TVector<glm::ivec4> tiles;
-	if (!TryAllocateLocalShadowTiles(mapCount, desiredResolution, tiles))
+	bool bAllocatedTiles = TryAllocateLocalShadowTiles(
+		mapCount,
+		desiredResolution,
+		atlasIndex,
+		tiles);
+	while (!bAllocatedTiles &&
+		EvictLeastRecentlyUsedLocalShadowAllocation(componentIndex, frame))
 	{
+		bAllocatedTiles = TryAllocateLocalShadowTiles(
+			mapCount,
+			desiredResolution,
+			atlasIndex,
+			tiles);
+	}
+	if (!bAllocatedTiles)
+	{
+		if (current.m_componentIndex == componentIndex)
+		{
+			current.m_lastUsedFrame = frame;
+			return true;
+		}
 		return false;
+	}
+	if (current.m_componentIndex == componentIndex &&
+		current.m_lightType == lightType &&
+		static_cast<uint32_t>(tiles[0].z) <= current.m_resolution)
+	{
+		ReleaseLocalShadowTiles(atlasIndex, tiles);
+		current.m_requestedResolution = desiredResolution;
+		current.m_lastUsedFrame = frame;
+		return true;
 	}
 
 	LocalLightShadowAllocation allocation{};
@@ -674,20 +857,63 @@ bool LightingECS::EnsureLocalShadowAllocation(
 	allocation.m_lightType = lightType;
 	allocation.m_resolution = static_cast<uint32_t>(tiles[0].z);
 	allocation.m_requestedResolution = desiredResolution;
+	allocation.m_atlasIndex = atlasIndex;
 	allocation.m_lastUsedFrame = frame;
 	allocation.m_slots.Reserve(mapCount);
 	allocation.m_tiles = std::move(tiles);
 	allocation.m_snapshots.Resize(mapCount);
 
-	for (uint32_t face = 0; face < mapCount; ++face)
+	if (current.m_componentIndex == componentIndex &&
+		current.m_lightType == lightType &&
+		current.m_slots.Num() == mapCount)
 	{
-		const uint32_t slot = firstSlot + face;
-		m_shadowMapOwners[slot] = componentIndex;
-		m_shadowMapSlots[slot] = m_localShadowAtlas;
-		allocation.m_slots.Add(slot);
+		allocation.m_slots = current.m_slots;
+		ReleaseLocalShadowTiles(current.m_atlasIndex, current.m_tiles);
+	}
+	else
+	{
+		ReleaseLocalShadowAllocation(componentIndex);
+		for (uint32_t face = 0; face < mapCount; ++face)
+		{
+			const uint32_t slot = firstSlot + face;
+			m_shadowMapOwners[slot] = componentIndex;
+			allocation.m_slots.Add(slot);
+		}
 	}
 
 	m_localShadowAllocations[componentIndex] = std::move(allocation);
+	return true;
+}
+
+bool LightingECS::EvictLeastRecentlyUsedLocalShadowAllocation(
+	uint32_t protectedComponentIndex,
+	uint64_t frame)
+{
+	uint32_t oldestComponentIndex = InvalidShadowMapIndex;
+	uint64_t oldestFrame = frame;
+	for (uint32_t componentIndex = 0;
+		componentIndex < m_localShadowAllocations.Num();
+		++componentIndex)
+	{
+		const auto& allocation = m_localShadowAllocations[componentIndex];
+		if (componentIndex == protectedComponentIndex ||
+			allocation.m_componentIndex != componentIndex ||
+			allocation.m_lastUsedFrame >= frame ||
+			allocation.m_lastUsedFrame > oldestFrame)
+		{
+			continue;
+		}
+
+		oldestFrame = allocation.m_lastUsedFrame;
+		oldestComponentIndex = componentIndex;
+	}
+
+	if (oldestComponentIndex == InvalidShadowMapIndex)
+	{
+		return false;
+	}
+
+	ReleaseLocalShadowAllocation(oldestComponentIndex);
 	return true;
 }
 
@@ -698,11 +924,51 @@ void LightingECS::ReleaseUnusedLocalShadowAllocations(uint64_t frame)
 		++componentIndex)
 	{
 		const auto& allocation = m_localShadowAllocations[componentIndex];
+		const bool bComponentCannotCastShadows =
+			componentIndex >= m_components.Num() ||
+			!m_components[componentIndex].m_bIsActive ||
+			m_components[componentIndex].m_shadowType == RHI::EShadowType::None;
+		const bool bExpired = frame > allocation.m_lastUsedFrame &&
+			frame - allocation.m_lastUsedFrame > LocalShadowCacheRetentionFrames;
 		if (allocation.m_componentIndex == componentIndex &&
-			allocation.m_lastUsedFrame != frame)
+			(bComponentCannotCastShadows || bExpired))
 		{
 			ReleaseLocalShadowAllocation(componentIndex);
 		}
+	}
+}
+
+void LightingECS::ReleaseUnusedLocalShadowAtlases()
+{
+	for (uint32_t atlasIndex = 0; atlasIndex < m_localShadowAtlases.Num(); ++atlasIndex)
+	{
+		auto& atlas = m_localShadowAtlases[atlasIndex];
+		if (!atlas.m_texture)
+		{
+			continue;
+		}
+
+		bool bUsed = false;
+		for (const auto occupied : atlas.m_occupancy)
+		{
+			if (occupied != 0)
+			{
+				bUsed = true;
+				break;
+			}
+		}
+		if (bUsed)
+		{
+			continue;
+		}
+
+		RHI::Renderer::GetDriver()->UpdateShaderBinding(
+			m_lightsData,
+			"shadowMaps",
+			m_defaultShadowMap,
+			NumCascades + atlasIndex);
+		atlas = {};
+		m_shadowMapsMb = (std::max)(0.0f, m_shadowMapsMb - LocalShadowAtlasMemoryMb);
 	}
 }
 
@@ -713,7 +979,8 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 	const CameraData& cameraData,
 	uint32_t viewportHeight,
 	TVector<uint32_t>& shadowIndices,
-	TVector<uint32_t>& shadowAtlasTiles)
+	TVector<uint32_t>& shadowAtlasTiles,
+	TVector<RHI::RHIBlitShadowMapCommand>& shadowMapsToBlit)
 {
 	TVector<RHI::RHIUpdateShadowMapCommand> updateShadowMaps{};
 	const uint64_t frame = GetWorld()->GetCurrentFrame();
@@ -740,7 +1007,8 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 					lightProxy.m_index,
 					light.m_type,
 					desiredResolution,
-					frame))
+					frame,
+					shadowMapsToBlit))
 			{
 				continue;
 			}
@@ -819,7 +1087,10 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 				const uint32_t tileY = static_cast<uint32_t>(tile.y) / LocalShadowMinResolution;
 				const uint32_t tileCells = static_cast<uint32_t>(tile.z) / LocalShadowMinResolution;
 				const uint32_t tileLevel = static_cast<uint32_t>(glm::log2(static_cast<float>(tileCells)));
-				shadowAtlasTiles[shadowSlot] = tileX | (tileY << 5u) | (tileLevel << 10u);
+				shadowAtlasTiles[shadowSlot] = tileX |
+					(tileY << 6u) |
+					(tileLevel << 12u) |
+					(allocation.m_atlasIndex << 15u);
 				auto& cachedState = allocation.m_snapshots[face];
 				// Mesh proxies can be published asynchronously after the light has
 				// already rendered its first frame. Do not turn that bootstrap
@@ -836,7 +1107,7 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 
 				Math::Frustum shadowFrustum(lightMatrices[face]);
 				RHI::RHIUpdateShadowMapCommand shadowPass{};
-				shadowPass.m_shadowMap = m_localShadowAtlas;
+				shadowPass.m_shadowMap = m_localShadowAtlases[allocation.m_atlasIndex].m_texture;
 				shadowPass.m_renderArea = tile;
 				shadowPass.m_lightMatrix = lightMatrices[face];
 				shadowPass.m_lighMatrixIndex = shadowSlot;
@@ -860,6 +1131,11 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 					{
 						return lhs.m_first < rhs.m_first;
 					});
+				if (snapshot.Equals(cachedState))
+				{
+					cachedState.m_sceneRevision = sceneView->m_shadowCastersRevision;
+					continue;
+				}
 				cachedState = std::move(snapshot);
 				updateShadowMaps.Emplace(std::move(shadowPass));
 			}
@@ -883,6 +1159,7 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 	{
 		TVector<uint32_t> shadowIndices(GetGpuLightSlotsCount(m_components.Num()));
 		TVector<uint32_t> shadowAtlasTiles(MaxShadowsInView);
+		TVector<RHI::RHIBlitShadowMapCommand> shadowMapsToBlit;
 		for (auto& shadowIndex : shadowIndices)
 		{
 			shadowIndex = InvalidShadowMapIndex;
@@ -917,12 +1194,14 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 			camera,
 			viewportHeight,
 			shadowIndices,
-			shadowAtlasTiles);
+			shadowAtlasTiles,
+			shadowMapsToBlit);
 		for (auto& localShadowMap : localShadowMaps)
 		{
 			updateShadowMaps.Emplace(std::move(localShadowMap));
 		}
 		sceneView->m_shadowMapsToUpdate.Add(std::move(updateShadowMaps));
+		sceneView->m_shadowMapsToBlit.Add(std::move(shadowMapsToBlit));
 		sceneView->m_shadowIndices.Add(std::move(shadowIndices));
 		sceneView->m_shadowAtlasTiles.Add(std::move(shadowAtlasTiles));
 	}
@@ -933,6 +1212,7 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 	}
 
 	ReleaseUnusedLocalShadowAllocations(GetWorld()->GetCurrentFrame());
+	ReleaseUnusedLocalShadowAtlases();
 
 	sceneView->m_totalNumLights = m_numLights;
 	sceneView->m_rhiLightsData = m_lightsData;

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -25,7 +25,7 @@ namespace Sailor
 
 		glm::vec3 m_intensity{ 100.0f, 100.0f, 100.0f };
 		glm::vec3 m_attenuation{ 1.0f, 0.022f, 0.0019f };
-		glm::vec3 m_bounds{ 100.0f, 100.0f, 100.0f };
+		float m_radius = 100.0f;
 		glm::vec2 m_cutOff{ 30.0f, 45.0f };
 		ELightType m_type = ELightType::Point;
 		RHI::EShadowType m_shadowType = RHI::EShadowType::PCF;
@@ -59,10 +59,11 @@ namespace Sailor
 	{
 		uint32_t m_componentIndex = (std::numeric_limits<uint32_t>::max)();
 		ELightType m_lightType = ELightType::Point;
-		ELightShadowQuality m_quality = ELightShadowQuality::Medium;
+		uint32_t m_resolution = 0;
+		uint32_t m_requestedResolution = 0;
 		uint64_t m_lastUsedFrame = 0;
-		float m_memoryMb = 0.0f;
 		TVector<uint32_t> m_slots{};
+		TVector<glm::ivec4> m_tiles{};
 		TVector<CSMLightState> m_snapshots{};
 	};
 
@@ -80,6 +81,8 @@ namespace Sailor
 			return numComponentSlots < LightsMaxNum ? numComponentSlots : LightsMaxNum;
 		}
 		static constexpr float ShadowsMemoryBudgetMb = 350.0f;
+		static constexpr uint32_t LocalShadowAtlasResolution = 4096;
+		static constexpr uint32_t LocalShadowMinResolution = 128;
 		static constexpr uint32_t GetLocalShadowMapCount(ELightType lightType)
 		{
 			return lightType == ELightType::Point ? 6u :
@@ -146,12 +149,22 @@ namespace Sailor
 			const RHI::RHISceneViewPtr& sceneView,
 			const TVector<RHI::RHILightProxy>& spotLights,
 			const TVector<RHI::RHILightProxy>& pointLights,
-			TVector<uint32_t>& shadowIndices);
+			const CameraData& cameraData,
+			uint32_t viewportHeight,
+			TVector<uint32_t>& shadowIndices,
+			TVector<uint32_t>& shadowAtlasTiles);
 		SAILOR_API bool EnsureLocalShadowAllocation(
 			uint32_t componentIndex,
 			ELightType lightType,
-			ELightShadowQuality quality,
+			uint32_t desiredResolution,
 			uint64_t frame);
+		SAILOR_API uint32_t CalculateLocalShadowResolution(
+			const LightData& light,
+			float distanceToCamera,
+			const CameraData& cameraData,
+			uint32_t viewportHeight) const;
+		SAILOR_API bool TryAllocateLocalShadowTiles(uint32_t count, uint32_t desiredResolution, TVector<glm::ivec4>& outTiles);
+		SAILOR_API void ReleaseLocalShadowTiles(const TVector<glm::ivec4>& tiles);
 		SAILOR_API void ReleaseLocalShadowAllocation(uint32_t componentIndex);
 		SAILOR_API void ReleaseUnusedLocalShadowAllocations(uint64_t frame);
 
@@ -170,14 +183,17 @@ namespace Sailor
 		RHI::RHIShaderBindingPtr m_shadowMaps;
 		RHI::RHIShaderBindingPtr m_lightMatrices;
 		RHI::RHIShaderBindingPtr m_shadowIndices;
+		RHI::RHIShaderBindingPtr m_shadowAtlasTiles;
 
 		TVector<RHI::RHIRenderTargetPtr> m_csmShadowMaps;
 		TVector<CSMLightState> m_csmSnapshots;
 		TVector<RHI::RHIRenderTargetPtr> m_shadowMapSlots;
 		TVector<uint32_t> m_shadowMapOwners;
 		TVector<LocalLightShadowAllocation> m_localShadowAllocations;
+		TVector<uint8_t> m_localShadowAtlasOccupancy;
 
 		RHI::RHIRenderTargetPtr m_defaultShadowMap;
+		RHI::RHIRenderTargetPtr m_localShadowAtlas;
 
 		float m_shadowMapsMb = 0;
 	};

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -11,6 +11,8 @@
 #include "RHI/SceneView.h"
 #include "Raytracing/LightingModel.h"
 
+#include <limits>
+
 namespace Sailor
 {
 	using WorldPtr = class World*;
@@ -27,6 +29,8 @@ namespace Sailor
 		glm::vec2 m_cutOff{ 30.0f, 45.0f };
 		ELightType m_type = ELightType::Point;
 		RHI::EShadowType m_shadowType = RHI::EShadowType::PCF;
+		ELightShadowQuality m_shadowQuality = ELightShadowQuality::Medium;
+		ELightShadowFilter m_shadowFilter = ELightShadowFilter::Soft;
 
 	protected:
 
@@ -51,6 +55,17 @@ namespace Sailor
 			uint64_t sceneRevision) const;
 	};
 
+	struct LocalLightShadowAllocation
+	{
+		uint32_t m_componentIndex = (std::numeric_limits<uint32_t>::max)();
+		ELightType m_lightType = ELightType::Point;
+		ELightShadowQuality m_quality = ELightShadowQuality::Medium;
+		uint64_t m_lastUsedFrame = 0;
+		float m_memoryMb = 0.0f;
+		TVector<uint32_t> m_slots{};
+		TVector<CSMLightState> m_snapshots{};
+	};
+
 	class LightingECS final : public ECS::TSystem<LightingECS, LightData>
 	{
 	public:
@@ -58,11 +73,24 @@ namespace Sailor
 		// Global constants
 		static constexpr uint32_t MaxShadowsInView = 128;
 		static constexpr uint32_t LightsMaxNum = 65535;
+		static constexpr uint32_t InvalidShadowMapIndex = (std::numeric_limits<uint32_t>::max)();
+		static constexpr uint32_t SoftShadowMapBit = 0x80000000u;
 		static constexpr size_t GetGpuLightSlotsCount(size_t numComponentSlots)
 		{
 			return numComponentSlots < LightsMaxNum ? numComponentSlots : LightsMaxNum;
 		}
 		static constexpr float ShadowsMemoryBudgetMb = 350.0f;
+		static constexpr uint32_t GetLocalShadowMapCount(ELightType lightType)
+		{
+			return lightType == ELightType::Point ? 6u :
+				lightType == ELightType::Spot ? 1u : 0u;
+		}
+		static constexpr uint32_t GetLocalShadowResolution(ELightShadowQuality quality)
+		{
+			return quality == ELightShadowQuality::VeryLow ? 256u :
+				quality == ELightShadowQuality::Low ? 512u :
+				quality == ELightShadowQuality::High ? 2048u : 1024u;
+		}
 
 		const RHI::EFormat ShadowMapFormat = RHI::EFormat::R16_UNORM;
 		const RHI::EFormat ShadowMapFormat_Evsm = RHI::EFormat::R32G32B32A32_SFLOAT;
@@ -114,6 +142,19 @@ namespace Sailor
 			const TVector<RHI::RHILightProxy>& directionalLights,
 			uint32_t& snapshotIndex);
 
+		SAILOR_API TVector<RHI::RHIUpdateShadowMapCommand> PrepareLocalShadowPasses(
+			const RHI::RHISceneViewPtr& sceneView,
+			const TVector<RHI::RHILightProxy>& spotLights,
+			const TVector<RHI::RHILightProxy>& pointLights,
+			TVector<uint32_t>& shadowIndices);
+		SAILOR_API bool EnsureLocalShadowAllocation(
+			uint32_t componentIndex,
+			ELightType lightType,
+			ELightShadowQuality quality,
+			uint64_t frame);
+		SAILOR_API void ReleaseLocalShadowAllocation(uint32_t componentIndex);
+		SAILOR_API void ReleaseUnusedLocalShadowAllocations(uint64_t frame);
+
 		SAILOR_API void GetLightsInFrustum(const Math::Frustum& frustum,
 			const Math::Transform& cameraTransform,
 			TVector<RHI::RHILightProxy>& outDirectionalLights,
@@ -132,6 +173,9 @@ namespace Sailor
 
 		TVector<RHI::RHIRenderTargetPtr> m_csmShadowMaps;
 		TVector<CSMLightState> m_csmSnapshots;
+		TVector<RHI::RHIRenderTargetPtr> m_shadowMapSlots;
+		TVector<uint32_t> m_shadowMapOwners;
+		TVector<LocalLightShadowAllocation> m_localShadowAllocations;
 
 		RHI::RHIRenderTargetPtr m_defaultShadowMap;
 

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -61,10 +61,17 @@ namespace Sailor
 		ELightType m_lightType = ELightType::Point;
 		uint32_t m_resolution = 0;
 		uint32_t m_requestedResolution = 0;
+		uint32_t m_atlasIndex = (std::numeric_limits<uint32_t>::max)();
 		uint64_t m_lastUsedFrame = 0;
 		TVector<uint32_t> m_slots{};
 		TVector<glm::ivec4> m_tiles{};
 		TVector<CSMLightState> m_snapshots{};
+	};
+
+	struct LocalShadowAtlas
+	{
+		RHI::RHIRenderTargetPtr m_texture{};
+		TVector<uint8_t> m_occupancy{};
 	};
 
 	class LightingECS final : public ECS::TSystem<LightingECS, LightData>
@@ -72,7 +79,8 @@ namespace Sailor
 	public:
 
 		// Global constants
-		static constexpr uint32_t MaxShadowsInView = 128;
+		static constexpr uint32_t MaxShadowMapSamplers = 128;
+		static constexpr uint32_t MaxShadowsInView = 2048;
 		static constexpr uint32_t LightsMaxNum = 65535;
 		static constexpr uint32_t InvalidShadowMapIndex = (std::numeric_limits<uint32_t>::max)();
 		static constexpr uint32_t SoftShadowMapBit = 0x80000000u;
@@ -80,9 +88,15 @@ namespace Sailor
 		{
 			return numComponentSlots < LightsMaxNum ? numComponentSlots : LightsMaxNum;
 		}
-		static constexpr float ShadowsMemoryBudgetMb = 350.0f;
+		static constexpr float DefaultShadowsMemoryBudgetMb = 768.0f;
 		static constexpr uint32_t LocalShadowAtlasResolution = 4096;
-		static constexpr uint32_t LocalShadowMinResolution = 128;
+		static constexpr uint32_t LocalShadowMinResolution = 64;
+		static constexpr uint32_t LocalShadowAtlasCellsPerAxis =
+			LocalShadowAtlasResolution / LocalShadowMinResolution;
+		static constexpr float LocalShadowAtlasMemoryMb =
+			static_cast<float>(LocalShadowAtlasResolution * LocalShadowAtlasResolution * 2u) /
+			(1024.0f * 1024.0f);
+		static constexpr uint64_t LocalShadowCacheRetentionFrames = 300u;
 		static constexpr uint32_t GetLocalShadowMapCount(ELightType lightType)
 		{
 			return lightType == ELightType::Point ? 6u :
@@ -135,6 +149,16 @@ namespace Sailor
 		void FillLightingData(RHI::RHISceneViewPtr& sceneView);
 
 		float GetShadowsOccupiedMemoryMb() const { return m_shadowMapsMb; }
+		float GetCsmShadowsOccupiedMemoryMb() const { return m_csmShadowMapsMb; }
+		float GetLocalShadowsOccupiedMemoryMb() const
+		{
+			return (std::max)(0.0f, m_shadowMapsMb - m_csmShadowMapsMb);
+		}
+		float GetShadowsMemoryBudgetMb() const { return m_shadowsMemoryBudgetMb; }
+		void SetShadowsMemoryBudgetMb(float budgetMb)
+		{
+			m_shadowsMemoryBudgetMb = (std::max)(budgetMb, 0.0f);
+		}
 
 	protected:
 
@@ -152,20 +176,36 @@ namespace Sailor
 			const CameraData& cameraData,
 			uint32_t viewportHeight,
 			TVector<uint32_t>& shadowIndices,
-			TVector<uint32_t>& shadowAtlasTiles);
+			TVector<uint32_t>& shadowAtlasTiles,
+			TVector<RHI::RHIBlitShadowMapCommand>& shadowMapsToBlit);
 		SAILOR_API bool EnsureLocalShadowAllocation(
 			uint32_t componentIndex,
 			ELightType lightType,
 			uint32_t desiredResolution,
-			uint64_t frame);
+			uint64_t frame,
+			TVector<RHI::RHIBlitShadowMapCommand>& shadowMapsToBlit);
 		SAILOR_API uint32_t CalculateLocalShadowResolution(
 			const LightData& light,
 			float distanceToCamera,
 			const CameraData& cameraData,
 			uint32_t viewportHeight) const;
-		SAILOR_API bool TryAllocateLocalShadowTiles(uint32_t count, uint32_t desiredResolution, TVector<glm::ivec4>& outTiles);
-		SAILOR_API void ReleaseLocalShadowTiles(const TVector<glm::ivec4>& tiles);
+		SAILOR_API bool TryAllocateLocalShadowTiles(
+			uint32_t count,
+			uint32_t desiredResolution,
+			uint32_t& outAtlasIndex,
+			TVector<glm::ivec4>& outTiles);
+		SAILOR_API bool TryAllocateLocalShadowTilesInAtlas(
+			uint32_t atlasIndex,
+			uint32_t count,
+			uint32_t resolution,
+			TVector<glm::ivec4>& outTiles);
+		SAILOR_API bool TryCreateLocalShadowAtlas(uint32_t& outAtlasIndex);
+		SAILOR_API void ReleaseLocalShadowTiles(uint32_t atlasIndex, const TVector<glm::ivec4>& tiles);
+		SAILOR_API void ReleaseUnusedLocalShadowAtlases();
 		SAILOR_API void ReleaseLocalShadowAllocation(uint32_t componentIndex);
+		SAILOR_API bool EvictLeastRecentlyUsedLocalShadowAllocation(
+			uint32_t protectedComponentIndex,
+			uint64_t frame);
 		SAILOR_API void ReleaseUnusedLocalShadowAllocations(uint64_t frame);
 
 		SAILOR_API void GetLightsInFrustum(const Math::Frustum& frustum,
@@ -187,15 +227,14 @@ namespace Sailor
 
 		TVector<RHI::RHIRenderTargetPtr> m_csmShadowMaps;
 		TVector<CSMLightState> m_csmSnapshots;
-		TVector<RHI::RHIRenderTargetPtr> m_shadowMapSlots;
 		TVector<uint32_t> m_shadowMapOwners;
 		TVector<LocalLightShadowAllocation> m_localShadowAllocations;
-		TVector<uint8_t> m_localShadowAtlasOccupancy;
+		TVector<LocalShadowAtlas> m_localShadowAtlases;
 
 		RHI::RHIRenderTargetPtr m_defaultShadowMap;
-		RHI::RHIRenderTargetPtr m_localShadowAtlas;
-
 		float m_shadowMapsMb = 0;
+		float m_csmShadowMapsMb = 0;
+		float m_shadowsMemoryBudgetMb = DefaultShadowsMemoryBudgetMb;
 	};
 
 	template class ECS::TSystem<LightingECS, LightData>;

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -520,8 +520,13 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			proxy.m_bCastShadows = data.ShouldCastShadow();
 			proxy.m_overrideMaterials.Reserve(proxy.m_meshes.Num());
 			proxy.m_renderQueueTags.Reserve(proxy.m_meshes.Num());
+			proxy.m_baseColorFactors.Reserve(proxy.m_meshes.Num());
+			proxy.m_baseColorSamplers.Reserve(proxy.m_meshes.Num());
+			proxy.m_alphaCutoffs.Reserve(proxy.m_meshes.Num());
 #if defined(__APPLE__)
 			proxy.m_materialTextureSamplers.Reserve(proxy.m_meshes.Num());
+			auto textureImporter = App::GetSubmodule<TextureImporter>();
+#else
 			auto textureImporter = App::GetSubmodule<TextureImporter>();
 #endif
 			for (size_t meshIndex = 0; meshIndex < proxy.m_meshes.Num(); ++meshIndex)
@@ -532,6 +537,39 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 				auto material = data.GetMaterials()[materialIndex];
 				proxy.m_renderQueueTags.Add(material->GetRenderState().GetTag());
 				proxy.m_overrideMaterials.Add(material->GetOrAddRHI(proxy.m_meshes[meshIndex]->m_vertexDescription));
+
+				glm::vec4 baseColorFactor{ 1.0f };
+				const glm::vec4* materialBaseColorFactor = nullptr;
+				if (!material->GetUniformsVec4().Find("material.baseColorFactor", materialBaseColorFactor))
+				{
+					material->GetUniformsVec4().Find("material.albedo", materialBaseColorFactor);
+				}
+				if (materialBaseColorFactor)
+				{
+					baseColorFactor = *materialBaseColorFactor;
+				}
+				proxy.m_baseColorFactors.Add(baseColorFactor);
+
+				float alphaCutoff = 0.5f;
+				const float* materialAlphaCutoff = nullptr;
+				if (material->GetUniformsFloat().Find("material.alphaCutoff", materialAlphaCutoff) && materialAlphaCutoff)
+				{
+					alphaCutoff = *materialAlphaCutoff;
+				}
+				proxy.m_alphaCutoffs.Add(alphaCutoff);
+
+				uint32_t baseColorSampler = 0u;
+				const TexturePtr* baseColorTexture = nullptr;
+				if (!material->GetSamplers().Find("baseColorSampler", baseColorTexture))
+				{
+					material->GetSamplers().Find("albedoSampler", baseColorTexture);
+				}
+				if (textureImporter && baseColorTexture && *baseColorTexture)
+				{
+					baseColorSampler = static_cast<uint32_t>(
+						textureImporter->GetTextureIndex((*baseColorTexture)->GetFileId()));
+				}
+				proxy.m_baseColorSamplers.Add(baseColorSampler);
 #if defined(__APPLE__)
 				TSet<uint32_t> requestedTextures;
 				requestedTextures.Insert(0u);

--- a/Runtime/Engine/EngineLoop.cpp
+++ b/Runtime/Engine/EngineLoop.cpp
@@ -11,6 +11,7 @@
 #include "Components/MeshRendererComponent.h"
 #include "Components/CameraComponent.h"
 #include "Components/EditorComponent.h"
+#include "ECS/LightingECS.h"
 #include "ECS/TransformECS.h"
 #include "Submodules/ImGuiApi.h"
 #include "RHI/Types.h"
@@ -27,7 +28,16 @@ using namespace Sailor;
 
 namespace
 {
-	void DrawViewportStatsOverlay(uint32_t cpuFps, uint32_t gpuFps, uint32_t numBatches, uint32_t numInstances)
+	void DrawViewportStatsOverlay(
+		uint32_t cpuFps,
+		uint32_t gpuFps,
+		uint32_t numBatches,
+		uint32_t numInstances,
+		float shadowMemoryMb,
+		float csmShadowMemoryMb,
+		float localShadowMemoryMb,
+		float shadowMemoryBudgetMb,
+		const RHI::Stats& stats)
 	{
 		const ImGuiIO& io = ImGui::GetIO();
 		if (io.DisplaySize.x <= 0.0f || io.DisplaySize.y <= 0.0f)
@@ -35,8 +45,26 @@ namespace
 			return;
 		}
 
-		char text[128];
-		std::snprintf(text, sizeof(text), "CPU %u FPS\nGPU %u FPS\nBatches %u\nInstances %u", cpuFps, gpuFps, numBatches, numInstances);
+		constexpr float BytesToMb = 1.0f / (1024.0f * 1024.0f);
+		char text[512];
+		std::snprintf(
+			text,
+			sizeof(text),
+			"CPU %u FPS\nGPU %u FPS\nBatches %u\nInstances %u\n"
+			"Shadows %.1f / %.0f MB\n  CSM %.1f MB\n  Local %.1f MB\n"
+			"GPU memory\n  Materials %.1f MB\n  Textures %.1f MB\n  Meshes %.1f MB\n  General %.1f MB",
+			cpuFps,
+			gpuFps,
+			numBatches,
+			numInstances,
+			shadowMemoryMb,
+			shadowMemoryBudgetMb,
+			csmShadowMemoryMb,
+			localShadowMemoryMb,
+			stats.m_materialsMemoryUsage.load(std::memory_order_relaxed) * BytesToMb,
+			stats.m_texturesMemoryUsage.load(std::memory_order_relaxed) * BytesToMb,
+			stats.m_meshesMemoryUsage.load(std::memory_order_relaxed) * BytesToMb,
+			stats.m_generalMemoryUsage.load(std::memory_order_relaxed) * BytesToMb);
 
 		constexpr float Margin = 10.0f;
 		const ImVec2 textSize = ImGui::CalcTextSize(text);
@@ -203,12 +231,32 @@ void EngineLoop::ProcessCpuFrame(FrameState& currentInputState)
 	const auto renderer = App::GetSubmodule<RHI::Renderer>();
 	if (renderer)
 	{
+		float shadowMemoryMb = 0.0f;
+		float csmShadowMemoryMb = 0.0f;
+		float localShadowMemoryMb = 0.0f;
+		float shadowMemoryBudgetMb = 0.0f;
+		for (const auto& world : m_worlds)
+		{
+			if (auto lighting = world->GetECS<LightingECS>())
+			{
+				shadowMemoryMb += lighting->GetShadowsOccupiedMemoryMb();
+				csmShadowMemoryMb += lighting->GetCsmShadowsOccupiedMemoryMb();
+				localShadowMemoryMb += lighting->GetLocalShadowsOccupiedMemoryMb();
+				shadowMemoryBudgetMb += lighting->GetShadowsMemoryBudgetMb();
+			}
+		}
+
 		const auto& stats = renderer->GetStats();
 		DrawViewportStatsOverlay(
 			m_cpuFps,
 			stats.m_gpuFps.load(std::memory_order_relaxed),
 			stats.m_numBatches.load(std::memory_order_relaxed),
-			stats.m_numInstances.load(std::memory_order_relaxed));
+			stats.m_numInstances.load(std::memory_order_relaxed),
+			shadowMemoryMb,
+			csmShadowMemoryMb,
+			localShadowMemoryMb,
+			shadowMemoryBudgetMb,
+			stats);
 	}
 
 	auto& task = currentInputState.GetDrawImGuiTask();

--- a/Runtime/Engine/Types.h
+++ b/Runtime/Engine/Types.h
@@ -38,6 +38,20 @@ namespace Sailor
 		Area
 	};
 
+	enum class ELightShadowQuality : uint8_t
+	{
+		VeryLow = 0,
+		Low,
+		Medium,
+		High
+	};
+
+	enum class ELightShadowFilter : uint8_t
+	{
+		Hard = 0,
+		Soft
+	};
+
 	enum class EAnimationPlayMode : uint8_t
 	{
 		Repeat = 0,

--- a/Runtime/FrameGraph/DepthPrepassNode.cpp
+++ b/Runtime/FrameGraph/DepthPrepassNode.cpp
@@ -18,9 +18,14 @@ using namespace Sailor::RHI;
 const char* DepthPrepassNode::m_name = "DepthPrepass";
 #endif
 
-RHI::RHIMaterialPtr DepthPrepassNode::GetOrAddDepthMaterial(RHI::RHIVertexDescriptionPtr vertexDescription, bool bSkinned)
+RHI::RHIMaterialPtr DepthPrepassNode::GetOrAddDepthMaterial(
+	RHI::RHIVertexDescriptionPtr vertexDescription,
+	bool bSkinned,
+	bool bMasked)
 {
-	auto& materials = bSkinned ? m_skinnedDepthOnlyMaterials : m_depthOnlyMaterials;
+	auto& materials = bMasked ?
+		(bSkinned ? m_skinnedMaskedDepthOnlyMaterials : m_maskedDepthOnlyMaterials) :
+		(bSkinned ? m_skinnedDepthOnlyMaterials : m_depthOnlyMaterials);
 	auto& material = materials[vertexDescription->GetVertexAttributeBits()];
 
 	if (!material)
@@ -32,10 +37,15 @@ RHI::RHIMaterialPtr DepthPrepassNode::GetOrAddDepthMaterial(RHI::RHIVertexDescri
 		{
 			defines.Add("SKINNING");
 		}
+		if (bMasked)
+		{
+			defines.Add("MASKED");
+		}
 
 		if (App::GetSubmodule<ShaderCompiler>()->LoadShader_Immediate(shaderFileId->GetFileId(), pShader, defines) && pShader->IsReady())
 		{
-			RenderState renderState = RHI::RenderState(true, true, 0.0f, false, ECullMode::Back, EBlendMode::None, EFillMode::Fill, GetHash(std::string("DepthOnly")), true);
+			const ECullMode cullMode = bMasked ? ECullMode::None : ECullMode::Back;
+			RenderState renderState = RHI::RenderState(true, true, 0.0f, false, cullMode, EBlendMode::None, EFillMode::Fill, GetHash(std::string("DepthOnly")), true);
 			material = RHI::Renderer::GetDriver()->CreateMaterial(vertexDescription, RHI::EPrimitiveTopology::TriangleList, renderState, pShader);
 		}
 	}
@@ -61,6 +71,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 
 	const std::string QueueTag = GetString("Tag");
 	const size_t QueueTagHash = GetHash(QueueTag);
+	const bool bMaskedQueue = QueueTagHash == GetHash(std::string("Masked"));
 
 	auto res = Tasks::CreateTask("Prepare DepthPrepassNode " + std::to_string(sceneView.m_frame),
 		[=, this, holdRhiResources = frameGraph, &syncSharedResources = m_syncSharedResources, &sceneViewSnapshot = sceneView]() mutable {
@@ -98,9 +109,13 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						proxy.m_skeletonOffset != (std::numeric_limits<uint32_t>::max)() &&
 						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
 						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
-					auto depthMaterial = GetOrAddDepthMaterial(mesh->m_vertexDescription, bSkinned);
+					auto depthMaterial = GetOrAddDepthMaterial(
+						mesh->m_vertexDescription,
+						bSkinned,
+						bMaskedQueue);
 
-					const bool bRequiredCustomDepth = proxy.GetMaterials()[i]->GetRenderState().IsRequiredCustomDepthShader();
+					const bool bRequiredCustomDepth = !bMaskedQueue &&
+						proxy.GetMaterials()[i]->GetRenderState().IsRequiredCustomDepthShader();
 					if (bRequiredCustomDepth)
 					{
 						depthMaterial = proxy.GetMaterials()[i];
@@ -136,13 +151,25 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						}
 						data.materialInstance = shaderBinding.IsValid() ? shaderBinding->GetStorageInstanceIndex() : 0;
 					}
+					else if (bMaskedQueue)
+					{
+						data.materialInstance = proxy.m_baseColorSamplers.Num() > i ?
+							proxy.m_baseColorSamplers[i] : 0u;
+						const float baseColorAlpha = proxy.m_baseColorFactors.Num() > i ?
+							proxy.m_baseColorFactors[i].a : 1.0f;
+						const float alphaCutoff = proxy.m_alphaCutoffs.Num() > i ?
+							proxy.m_alphaCutoffs[i] : 0.5f;
+						const float effectiveAlphaCutoff = baseColorAlpha > 0.000001f ?
+							alphaCutoff / baseColorAlpha : 2.0f;
+						data.padding = glm::floatBitsToUint(effectiveAlphaCutoff);
+					}
 					else
 					{
 						data.materialInstance = 0;
 					}
 
 					RHIBatch batch(depthMaterial, mesh);
-					if (bRequiredCustomDepth)
+					if (bRequiredCustomDepth || bMaskedQueue)
 					{
 						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
 #if defined(__APPLE__)
@@ -215,7 +242,12 @@ void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 		{
 			if (auto shaderInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr("Shaders/ComputeMeshCulling.shader"))
 			{
-				App::GetSubmodule<ShaderCompiler>()->LoadShader(shaderInfo->GetFileId(), m_pComputeMeshCullingShader, { "OCCLUSION_CULLING" });
+				// The depth prepass produces the current frame's occlusion source.
+				// Culling its contributors against the previous frame can create holes
+				// in depth after camera or LOD changes. Keep GPU frustum culling here;
+				// the main scene pass can occlusion-cull against the completed Hi-Z.
+				App::GetSubmodule<ShaderCompiler>()->LoadShader(
+					shaderInfo->GetFileId(), m_pComputeMeshCullingShader);
 			}
 		}
 
@@ -301,6 +333,10 @@ void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 			if (material->GetRenderState().IsRequiredCustomDepthShader())
 			{
 				sets = TVector<RHIShaderBindingSetPtr>({ sceneView.m_frameBindings, sceneView.m_rhiLightsData, m_perInstanceData, material->GetBindings(), batch.m_textureBindings });
+			}
+			else if (batch.m_textureBindings)
+			{
+				sets.Add(batch.m_textureBindings);
 			}
 
 			const bool bSkinned =

--- a/Runtime/FrameGraph/DepthPrepassNode.h
+++ b/Runtime/FrameGraph/DepthPrepassNode.h
@@ -50,10 +50,15 @@ namespace Sailor
 
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_depthOnlyMaterials;
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedDepthOnlyMaterials;
+		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_maskedDepthOnlyMaterials;
+		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedMaskedDepthOnlyMaterials;
 		RHI::RHIShaderBindingSetPtr m_perInstanceData;
 		size_t m_sizePerInstanceData = 0;
 
-		RHI::RHIMaterialPtr GetOrAddDepthMaterial(RHI::RHIVertexDescriptionPtr vertex, bool bSkinned);
+		RHI::RHIMaterialPtr GetOrAddDepthMaterial(
+			RHI::RHIVertexDescriptionPtr vertex,
+			bool bSkinned,
+			bool bMasked);
 		TVector<RHI::RHIBufferPtr> m_indirectBuffers;
 
 		// Culling

--- a/Runtime/FrameGraph/LightCullingNode.cpp
+++ b/Runtime/FrameGraph/LightCullingNode.cpp
@@ -35,24 +35,15 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
 	commands->BeginDebugRegion(commandList, GetName(), DebugContext::Color_CmdCompute);
 
-	auto depthAttachment = GetRHIResource("depthStencil").DynamicCast<RHI::RHITexture>();
-	if (!depthAttachment)
+	auto linearDepthAttachment = GetRHIResource("linearDepth").DynamicCast<RHI::RHITexture>();
+	if (!linearDepthAttachment)
 	{
-		depthAttachment = frameGraph->GetRenderTarget("DepthBuffer").DynamicCast<RHI::RHITexture>();
+		linearDepthAttachment = frameGraph->GetRenderTarget("LinearDepth").DynamicCast<RHI::RHITexture>();
 	}
-	if (!depthAttachment)
+	if (!linearDepthAttachment)
 	{
 		commands->EndDebugRegion(commandList);
 		return;
-	}
-
-	RHI::RHITexturePtr sampledDepthAttachment = depthAttachment;
-	if (auto depthRenderTarget = depthAttachment.DynamicCast<RHI::RHIRenderTarget>())
-	{
-		if (auto depthAspect = depthRenderTarget->GetDepthAspect())
-		{
-			sampledDepthAttachment = depthAspect;
-		}
 	}
 
 #ifdef _DEBUG
@@ -65,12 +56,12 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 
 		pushConstants.m_invViewProjection = sceneView.m_camera->GetInvViewProjection();
 		pushConstants.m_lightsNum = sceneView.m_totalNumLights;
-		pushConstants.m_viewportSize = depthAttachment->GetExtent();
-		pushConstants.m_numTiles.x = (depthAttachment->GetExtent().x - 1) / (int32_t)TileSize + 1;
-		pushConstants.m_numTiles.y = (depthAttachment->GetExtent().y - 1) / (int32_t)TileSize + 1;
+		pushConstants.m_viewportSize = linearDepthAttachment->GetExtent();
+		pushConstants.m_numTiles.x = (linearDepthAttachment->GetExtent().x - 1) / (int32_t)TileSize + 1;
+		pushConstants.m_numTiles.y = (linearDepthAttachment->GetExtent().y - 1) / (int32_t)TileSize + 1;
 		const bool bBindingsOutdated = !m_culledLights ||
 			m_boundLightsData != sceneView.m_rhiLightsData ||
-			m_boundDepthAttachment != sampledDepthAttachment ||
+			m_boundDepthAttachment != linearDepthAttachment ||
 			m_bindingsViewportSize != pushConstants.m_viewportSize;
 		if (bBindingsOutdated)
 		{
@@ -79,18 +70,18 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 			m_culledLights = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
 			RHI::RHIShaderBindingPtr culledLightsSSBO = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_culledLights, "culledLights", sizeof(uint32_t) * numTiles * LightsPerTile, 1, 0, true);
 			RHI::RHIShaderBindingPtr lightsGridSSBO = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_culledLights, "lightsGrid", sizeof(uint32_t) * numTiles * 2, 1, 1, true);
-			Sailor::RHI::Renderer::GetDriver()->AddSamplerToShaderBindings(m_culledLights, "sceneDepth", sampledDepthAttachment, 2);
+			Sailor::RHI::Renderer::GetDriver()->AddSamplerToShaderBindings(m_culledLights, "linearDepth", linearDepthAttachment, 2);
 
 			auto shaderBindingSet = sceneView.m_rhiLightsData;
 			Sailor::RHI::Renderer::GetDriver()->AddShaderBinding(shaderBindingSet, culledLightsSSBO, "culledLights", 1);
 			Sailor::RHI::Renderer::GetDriver()->AddShaderBinding(shaderBindingSet, lightsGridSSBO, "lightsGrid", 2);
 
 			m_boundLightsData = sceneView.m_rhiLightsData;
-			m_boundDepthAttachment = sampledDepthAttachment;
+			m_boundDepthAttachment = linearDepthAttachment;
 			m_bindingsViewportSize = pushConstants.m_viewportSize;
 		}
 
-		commands->ImageMemoryBarrier(commandList, depthAttachment, RHI::EImageLayout::ShaderReadOnlyOptimal);
+		commands->ImageMemoryBarrier(commandList, linearDepthAttachment, RHI::EImageLayout::ShaderReadOnlyOptimal);
 		commands->Dispatch(commandList, computeShader,
 			pushConstants.m_numTiles.x, pushConstants.m_numTiles.y, 1,
 			{ sceneView.m_rhiLightsData, m_culledLights, sceneView.m_frameBindings },

--- a/Runtime/FrameGraph/LightCullingNode.cpp
+++ b/Runtime/FrameGraph/LightCullingNode.cpp
@@ -35,10 +35,10 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
 	commands->BeginDebugRegion(commandList, GetName(), DebugContext::Color_CmdCompute);
 
-	auto depthAttachment = GetRHIResource("linearDepth").DynamicCast<RHI::RHITexture>();
+	auto depthAttachment = GetRHIResource("depthStencil").DynamicCast<RHI::RHITexture>();
 	if (!depthAttachment)
 	{
-		depthAttachment = frameGraph->GetRenderTarget("LinearDepth").DynamicCast<RHI::RHITexture>();
+		depthAttachment = frameGraph->GetRenderTarget("DepthBuffer").DynamicCast<RHI::RHITexture>();
 	}
 	if (!depthAttachment)
 	{
@@ -47,6 +47,13 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 	}
 
 	RHI::RHITexturePtr sampledDepthAttachment = depthAttachment;
+	if (auto depthRenderTarget = depthAttachment.DynamicCast<RHI::RHIRenderTarget>())
+	{
+		if (auto depthAspect = depthRenderTarget->GetDepthAspect())
+		{
+			sampledDepthAttachment = depthAspect;
+		}
+	}
 
 #ifdef _DEBUG
 	if (RHIShaderPtr computeShader = m_pComputeShader->GetDebugComputeShaderRHI())
@@ -63,7 +70,7 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 		pushConstants.m_numTiles.y = (depthAttachment->GetExtent().y - 1) / (int32_t)TileSize + 1;
 		const bool bBindingsOutdated = !m_culledLights ||
 			m_boundLightsData != sceneView.m_rhiLightsData ||
-			m_boundDepthAttachment != depthAttachment ||
+			m_boundDepthAttachment != sampledDepthAttachment ||
 			m_bindingsViewportSize != pushConstants.m_viewportSize;
 		if (bBindingsOutdated)
 		{
@@ -79,7 +86,7 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 			Sailor::RHI::Renderer::GetDriver()->AddShaderBinding(shaderBindingSet, lightsGridSSBO, "lightsGrid", 2);
 
 			m_boundLightsData = sceneView.m_rhiLightsData;
-			m_boundDepthAttachment = depthAttachment;
+			m_boundDepthAttachment = sampledDepthAttachment;
 			m_bindingsViewportSize = pushConstants.m_viewportSize;
 		}
 

--- a/Runtime/FrameGraph/LightCullingNode.cpp
+++ b/Runtime/FrameGraph/LightCullingNode.cpp
@@ -32,14 +32,13 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 		auto computeShaderInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr("Shaders/ComputeLightCulling.shader");
 		App::GetSubmodule<ShaderCompiler>()->LoadShader_Immediate(computeShaderInfo->GetFileId(), m_pComputeShader);
 	}
-
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
 	commands->BeginDebugRegion(commandList, GetName(), DebugContext::Color_CmdCompute);
 
-	auto depthAttachment = GetRHIResource("depthStencil").DynamicCast<RHI::RHITexture>();
+	auto depthAttachment = GetRHIResource("linearDepth").DynamicCast<RHI::RHITexture>();
 	if (!depthAttachment)
 	{
-		depthAttachment = frameGraph->GetRenderTarget("DepthBuffer").DynamicCast<RHI::RHITexture>();
+		depthAttachment = frameGraph->GetRenderTarget("LinearDepth").DynamicCast<RHI::RHITexture>();
 	}
 	if (!depthAttachment)
 	{
@@ -48,13 +47,6 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 	}
 
 	RHI::RHITexturePtr sampledDepthAttachment = depthAttachment;
-	if (auto depthRenderTarget = depthAttachment.DynamicCast<RHI::RHIRenderTarget>())
-	{
-		if (auto depthAspect = depthRenderTarget->GetDepthAspect())
-		{
-			sampledDepthAttachment = depthAspect;
-		}
-	}
 
 #ifdef _DEBUG
 	if (RHIShaderPtr computeShader = m_pComputeShader->GetDebugComputeShaderRHI())
@@ -69,7 +61,6 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 		pushConstants.m_viewportSize = depthAttachment->GetExtent();
 		pushConstants.m_numTiles.x = (depthAttachment->GetExtent().x - 1) / (int32_t)TileSize + 1;
 		pushConstants.m_numTiles.y = (depthAttachment->GetExtent().y - 1) / (int32_t)TileSize + 1;
-
 		const bool bBindingsOutdated = !m_culledLights ||
 			m_boundLightsData != sceneView.m_rhiLightsData ||
 			m_boundDepthAttachment != depthAttachment ||
@@ -97,6 +88,7 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 			pushConstants.m_numTiles.x, pushConstants.m_numTiles.y, 1,
 			{ sceneView.m_rhiLightsData, m_culledLights, sceneView.m_frameBindings },
 			&pushConstants, sizeof(PushConstants));
+
 		commands->MemoryBarrier(commandList,
 			static_cast<EAccessFlags>(EAccessBit::ShaderWrite_Bit),
 			static_cast<EAccessFlags>(EAccessBit::ShaderRead_Bit));

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -204,6 +204,77 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 				0);
 		}
 	}
+
+	if (!sceneView.m_shadowMapsToBlit.IsEmpty())
+	{
+		commands->BeginDebugRegion(
+			commandList,
+			"Downsample Local Shadow Tiles",
+			DebugContext::Color_CmdTransfer);
+		for (const auto& blit : sceneView.m_shadowMapsToBlit)
+		{
+			if (!blit.m_source || !blit.m_destination ||
+				blit.m_sourceArea.z <= 0 || blit.m_sourceArea.w <= 0 ||
+				blit.m_destinationArea.z <= 0 || blit.m_destinationArea.w <= 0)
+			{
+				continue;
+			}
+
+			if (blit.m_source == blit.m_destination)
+			{
+				auto scratch = driver->GetOrAddTemporaryRenderTarget(
+					blit.m_source->GetFormat(),
+					glm::ivec2(blit.m_destinationArea.z, blit.m_destinationArea.w),
+					1);
+				commands->ImageMemoryBarrier(
+					commandList, blit.m_source, EImageLayout::TransferSrcOptimal);
+				commands->ImageMemoryBarrier(
+					commandList, scratch, EImageLayout::TransferDstOptimal);
+				commands->BlitImage(
+					commandList,
+					blit.m_source,
+					scratch,
+					blit.m_sourceArea,
+					glm::ivec4(0, 0, scratch->GetExtent().x, scratch->GetExtent().y),
+					ETextureFiltration::Nearest);
+
+				commands->ImageMemoryBarrier(
+					commandList, scratch, EImageLayout::TransferSrcOptimal);
+				commands->ImageMemoryBarrier(
+					commandList, blit.m_destination, EImageLayout::TransferDstOptimal);
+				commands->BlitImage(
+					commandList,
+					scratch,
+					blit.m_destination,
+					glm::ivec4(0, 0, scratch->GetExtent().x, scratch->GetExtent().y),
+					blit.m_destinationArea,
+					ETextureFiltration::Nearest);
+				commands->ImageMemoryBarrier(
+					commandList, scratch, EImageLayout::ShaderReadOnlyOptimal);
+				driver->ReleaseTemporaryRenderTarget(scratch);
+			}
+			else
+			{
+				commands->ImageMemoryBarrier(
+					commandList, blit.m_source, EImageLayout::TransferSrcOptimal);
+				commands->ImageMemoryBarrier(
+					commandList, blit.m_destination, EImageLayout::TransferDstOptimal);
+				commands->BlitImage(
+					commandList,
+					blit.m_source,
+					blit.m_destination,
+					blit.m_sourceArea,
+					blit.m_destinationArea,
+					ETextureFiltration::Nearest);
+			}
+
+			commands->ImageMemoryBarrier(
+				commandList, blit.m_source, EImageLayout::ShaderReadOnlyOptimal);
+			commands->ImageMemoryBarrier(
+				commandList, blit.m_destination, EImageLayout::ShaderReadOnlyOptimal);
+		}
+		commands->EndDebugRegion(commandList);
+	}
 	if (sceneView.m_shadowMapsToUpdate.Num() == 0)
 	{
 		return;

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -173,13 +173,42 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 	}
 
 	RHIShaderBindingPtr blurDataBinding = m_pBlurShaderBindings->GetOrAddShaderBinding("data");
-
+	auto shaderBindingSet = sceneView.m_rhiLightsData;
+	if (shaderBindingSet &&
+		shaderBindingSet->HasBinding("shadowIndices") &&
+		!sceneView.m_shadowIndices.IsEmpty())
+	{
+		auto shadowIndices = shaderBindingSet->GetOrAddShaderBinding("shadowIndices");
+		if (shadowIndices && shadowIndices->IsBind())
+		{
+			commands->UpdateShaderBinding(
+				transferCommandList,
+				shadowIndices,
+				sceneView.m_shadowIndices.GetData(),
+				sceneView.m_shadowIndices.Num() * sizeof(uint32_t),
+				0);
+		}
+	}
+	if (shaderBindingSet &&
+		shaderBindingSet->HasBinding("shadowAtlasTiles") &&
+		!sceneView.m_shadowAtlasTiles.IsEmpty())
+	{
+		auto shadowAtlasTiles = shaderBindingSet->GetOrAddShaderBinding("shadowAtlasTiles");
+		if (shadowAtlasTiles && shadowAtlasTiles->IsBind())
+		{
+			commands->UpdateShaderBinding(
+				transferCommandList,
+				shadowAtlasTiles,
+				sceneView.m_shadowAtlasTiles.GetData(),
+				sceneView.m_shadowAtlasTiles.Num() * sizeof(uint32_t),
+				0);
+		}
+	}
 	if (sceneView.m_shadowMapsToUpdate.Num() == 0)
 	{
 		return;
 	}
 
-	auto shaderBindingSet = sceneView.m_rhiLightsData;
 	if (!shaderBindingSet || !shaderBindingSet->HasBinding("lightsMatrices"))
 	{
 		return;
@@ -420,8 +449,16 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 			SAILOR_PROFILE_SCOPE("Record Shadow Map Pass");
 
 			const auto& shadowPass = sceneView.m_shadowMapsToUpdate[index];
+			const glm::ivec2 shadowExtent = shadowPass.m_shadowMap->GetExtent();
+			const bool bUsesAtlasTile = shadowPass.m_renderArea.z > 0 && shadowPass.m_renderArea.w > 0;
+			const glm::ivec4 renderArea = bUsesAtlasTile ?
+				shadowPass.m_renderArea :
+				glm::ivec4(0, 0, shadowExtent.x, shadowExtent.y);
 
-			RHI::RHIRenderTargetPtr depthAttachment = driver->GetOrAddTemporaryRenderTarget(driver->GetDepthBuffer()->GetFormat(), shadowPass.m_shadowMap->GetExtent(), 1);
+			RHI::RHIRenderTargetPtr depthAttachment = driver->GetOrAddTemporaryRenderTarget(
+				driver->GetDepthBuffer()->GetFormat(),
+				shadowExtent,
+				1);
 
 			commands->BeginDebugRegion(commandList, debugMarker, DebugContext::Color_CmdGraphics);
 			{
@@ -440,13 +477,17 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 				commands->BeginRenderPass(commandList,
 					TVector<RHI::RHITexturePtr>{ shadowPass.m_shadowMap },
 					depthAttachment,
-					glm::vec4(0, 0, shadowPass.m_shadowMap->GetExtent().x, shadowPass.m_shadowMap->GetExtent().y),
+					glm::vec4(renderArea),
 					glm::ivec2(0, 0),
-					true,
+					!bUsesAtlasTile,
 					shadowClearValue,
 					0.0f,
 					false,
 					true);
+				if (bUsesAtlasTile)
+				{
+					commands->ClearAttachments(commandList, renderArea, shadowClearValue, 0.0f);
+				}
 
 				RHI::RHIMaterialPtr pushConstantsMaterial;
 				if (passes[index].Num() > 0)
@@ -473,8 +514,8 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 				if (pushConstantsMaterial && passes[index].Num() > 0)
 				{
 					m_drawCallStats += RHIRecordDrawCall(0, (uint32_t)passes[index].Num(), passes[index], commandList, transferCommandList, shaderBindingsByMaterial, drawCalls[index], passIndices[index], m_indirectBuffers[index],
-						glm::ivec4(0, shadowPass.m_shadowMap->GetExtent().y, shadowPass.m_shadowMap->GetExtent().x, -shadowPass.m_shadowMap->GetExtent().y),
-						glm::uvec4(0, 0, shadowPass.m_shadowMap->GetExtent().x, shadowPass.m_shadowMap->GetExtent().y),
+						glm::ivec4(renderArea.x, renderArea.y + renderArea.w, renderArea.z, -renderArea.w),
+						glm::uvec4(renderArea),
 						glm::vec2(0.0f, 1.0f));
 				}
 
@@ -486,8 +527,8 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 					{
 						m_drawCallStats += RHIDrawCall(0, numBatches, passes[dependencyPass], commandList, shaderBindingsByMaterial,
 							drawCalls[dependencyPass], m_indirectBuffers[dependencyPass],
-							glm::ivec4(0, shadowPass.m_shadowMap->GetExtent().y, shadowPass.m_shadowMap->GetExtent().x, -shadowPass.m_shadowMap->GetExtent().y),
-							glm::uvec4(0, 0, shadowPass.m_shadowMap->GetExtent().x, shadowPass.m_shadowMap->GetExtent().y),
+							glm::ivec4(renderArea.x, renderArea.y + renderArea.w, renderArea.z, -renderArea.w),
+							glm::uvec4(renderArea),
 							glm::vec2(0.0f, 1.0f));
 					}
 				}

--- a/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
@@ -541,7 +541,12 @@ bool VulkanCommandBuffer::BlitImage(VulkanImageViewPtr src, VulkanImageViewPtr d
 	m_rhiDependecies.Insert(dst);
 	m_rhiDependecies.Insert(src);
 
-	if (src->m_format == dst->m_format && std::memcmp(&src->GetImage()->m_extent, &dst->GetImage()->m_extent, sizeof(VkExtent3D)) == 0)
+	const bool bRegionsHaveSameExtent =
+		srcRegion.extent.width == dstRegion.extent.width &&
+		srcRegion.extent.height == dstRegion.extent.height;
+	if (src->m_format == dst->m_format &&
+		std::memcmp(&src->GetImage()->m_extent, &dst->GetImage()->m_extent, sizeof(VkExtent3D)) == 0 &&
+		bRegionsHaveSameExtent)
 	{
 		// Resolve Multisampling 
 		if (src->GetImage()->m_samples != VK_SAMPLE_COUNT_1_BIT && (dst->GetImage()->m_samples & VK_SAMPLE_COUNT_1_BIT))
@@ -563,7 +568,10 @@ bool VulkanCommandBuffer::BlitImage(VulkanImageViewPtr src, VulkanImageViewPtr d
 			resolve.srcSubresource.baseArrayLayer = src->m_subresourceRange.baseArrayLayer;
 			resolve.srcSubresource.aspectMask = VulkanApi::ComputeAspectFlagsForFormat(src->m_format);
 
-			resolve.extent = src->GetImage()->m_extent;
+			resolve.extent = {
+				srcRegion.extent.width,
+				srcRegion.extent.height,
+				1u };
 
 			vkCmdResolveImage(
 				m_commandBuffer,
@@ -597,7 +605,10 @@ bool VulkanCommandBuffer::BlitImage(VulkanImageViewPtr src, VulkanImageViewPtr d
 			copy.srcSubresource.baseArrayLayer = src->m_subresourceRange.baseArrayLayer;
 			copy.srcSubresource.aspectMask = VulkanApi::ComputeAspectFlagsForFormat(src->m_format);
 
-			copy.extent = src->GetImage()->m_extent;
+			copy.extent = {
+				srcRegion.extent.width,
+				srcRegion.extent.height,
+				1u };
 
 			vkCmdCopyImage(
 				m_commandBuffer,

--- a/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp
@@ -682,6 +682,24 @@ void VulkanCommandBuffer::ClearImage(VulkanImageViewPtr dst, const glm::vec4& cl
 	m_gpuCost += 5;
 }
 
+void VulkanCommandBuffer::ClearAttachments(VkRect2D renderArea, const glm::vec4& clearColor, float clearDepth)
+{
+	VkClearAttachment attachments[2]{};
+	attachments[0].aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+	attachments[0].colorAttachment = 0;
+	attachments[0].clearValue.color = { { clearColor.x, clearColor.y, clearColor.z, clearColor.w } };
+	attachments[1].aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+	attachments[1].clearValue.depthStencil = { clearDepth, 0u };
+
+	VkClearRect rect{};
+	rect.rect = renderArea;
+	rect.baseArrayLayer = 0u;
+	rect.layerCount = 1u;
+	vkCmdClearAttachments(m_commandBuffer, 2u, attachments, 1u, &rect);
+	m_numRecordedCommands++;
+	m_gpuCost += 2;
+}
+
 void VulkanCommandBuffer::PushConstants(VulkanPipelineLayoutPtr pipelineLayout, size_t offset, size_t size, const void* ptr)
 {
 	vkCmdPushConstants(m_commandBuffer, *pipelineLayout, VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_VERTEX_BIT, (uint32_t)offset, (uint32_t)size, ptr);

--- a/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.h
@@ -110,6 +110,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 		SAILOR_API void ClearImage(VulkanImageViewPtr dst, const glm::vec4& clearColor);
 		SAILOR_API void ClearDepthStencil(VulkanImageViewPtr dst, float depth, uint32_t stencil);
+		SAILOR_API void ClearAttachments(VkRect2D renderArea, const glm::vec4& clearColor, float clearDepth);
 
 		SAILOR_API void GenerateMipMaps(VulkanImagePtr image);
 		SAILOR_API void ClearDependencies();

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -2405,6 +2405,14 @@ void VulkanGraphicsDriver::ClearImage(RHI::RHICommandListPtr cmd, RHI::RHITextur
 	cmd->m_vulkan.m_commandBuffer->ClearImage(dst->m_vulkan.m_imageView, clearColor);
 }
 
+void VulkanGraphicsDriver::ClearAttachments(RHI::RHICommandListPtr cmd, glm::ivec4 renderArea, const glm::vec4& clearColor, float clearDepth)
+{
+	VkRect2D rect{};
+	rect.offset = { renderArea.x, renderArea.y };
+	rect.extent = { static_cast<uint32_t>(renderArea.z), static_cast<uint32_t>(renderArea.w) };
+	cmd->m_vulkan.m_commandBuffer->ClearAttachments(rect, clearColor, clearDepth);
+}
+
 void VulkanGraphicsDriver::ExecuteSecondaryCommandList(RHI::RHICommandListPtr cmd, RHI::RHICommandListPtr cmdSecondary)
 {
 	//TODO: Check secondary

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -288,6 +288,9 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API TSharedPtr<VulkanBufferAllocator>& GetMaterialSsboAllocator();
 		SAILOR_API TSharedPtr<VulkanBufferAllocator>& GetGeneralSsboAllocator();
 		SAILOR_API TSharedPtr<VulkanBufferAllocator>& GetMeshSsboAllocator();
+		SAILOR_API const TSharedPtr<VulkanBufferAllocator>& GetMaterialSsboAllocatorIfInitialized() const { return m_materialSsboAllocator; }
+		SAILOR_API const TSharedPtr<VulkanBufferAllocator>& GetGeneralSsboAllocatorIfInitialized() const { return m_generalSsboAllocator; }
+		SAILOR_API const TSharedPtr<VulkanBufferAllocator>& GetMeshSsboAllocatorIfInitialized() const { return m_meshSsboAllocator; }
 		SAILOR_API const TConcurrentMap<std::string, TSharedPtr<VulkanBufferAllocator>>& GetUniformBufferAllocators() const { return m_uniformBuffers; }
 
 	protected:

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -239,6 +239,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API virtual bool BlitImage(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr src, RHI::RHITexturePtr dst, glm::ivec4 srcRegionRect, glm::ivec4 dstRegionRect, RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear) override;
 		SAILOR_API virtual void ClearImage(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr dst, const glm::vec4& clearColor) override;
 		SAILOR_API virtual void ClearDepthStencil(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr dst, float depth, uint32_t stencil) override;
+		SAILOR_API virtual void ClearAttachments(RHI::RHICommandListPtr cmd, glm::ivec4 renderArea, const glm::vec4& clearColor, float clearDepth) override;
 		SAILOR_API virtual void UpdateShaderBindingVariable(RHI::RHICommandListPtr cmd, RHI::RHIShaderBindingPtr binding, const std::string& variable, const void* value, size_t size) override;
 		SAILOR_API virtual void UpdateShaderBinding(RHI::RHICommandListPtr cmd, RHI::RHIShaderBindingPtr binding, const void* data, size_t size, size_t offset = 0) override;
 		SAILOR_API virtual void UpdateBuffer(RHI::RHICommandListPtr cmd, RHI::RHIBufferPtr buffer, const void* data, size_t size, size_t offset = 0) override;

--- a/Runtime/Memory/MemoryBlockAllocator.hpp
+++ b/Runtime/Memory/MemoryBlockAllocator.hpp
@@ -283,13 +283,19 @@ namespace Sailor::Memory
 		}
 
 		MemoryBlock& GetMemoryBlock(uint32_t index) const { return m_blocks[index]; }
-		size_t GetOccupiedSpace() const { return m_usedDataSpace; }
+		size_t GetOccupiedSpace() const
+		{
+			m_lock.Lock();
+			const size_t occupiedSpace = m_usedDataSpace;
+			m_lock.Unlock();
+			return occupiedSpace;
+		}
 
 		TGlobalAllocator& GetGlobalAllocator() { return m_dataAllocator; }
 
 	private:
 
-		SpinLock m_lock;
+		mutable SpinLock m_lock;
 		static constexpr uint32_t InvalidIndexUINT32 = (uint32_t)-1;
 
 		bool HeuristicToSkipBlocks(float occupation) const

--- a/Runtime/RHI/GraphicsDriver.h
+++ b/Runtime/RHI/GraphicsDriver.h
@@ -318,6 +318,7 @@ namespace Sailor::RHI
 		SAILOR_API virtual bool BlitImage(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr src, RHI::RHITexturePtr dst, glm::ivec4 srcRegionRect, glm::ivec4 dstRegionRect, RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear) = 0;
 		SAILOR_API virtual void ClearImage(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr dst, const glm::vec4& clearColor) = 0;
 		SAILOR_API virtual void ClearDepthStencil(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr dst, float depth = 0.0f, uint32_t stencil = 0) = 0;
+		SAILOR_API virtual void ClearAttachments(RHI::RHICommandListPtr cmd, glm::ivec4 renderArea, const glm::vec4& clearColor, float clearDepth = 0.0f) = 0;
 
 		SAILOR_API virtual void BeginSecondaryCommandList(RHICommandListPtr cmd, bool bOneTimeSubmit = false, bool bSupportMultisampling = true, RHI::EFormat colorAttachment = RHI::EFormat::R16G16B16A16_SFLOAT) = 0;
 		SAILOR_API virtual void BeginCommandList(RHICommandListPtr cmd, bool bOneTimeSubmit) = 0;

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -133,31 +133,53 @@ Renderer::~Renderer()
 void Renderer::MemoryStats()
 {
 #if defined(SAILOR_BUILD_WITH_VULKAN)
-	auto driverInstance = App::GetSubmodule<Renderer>()->GetDriver().DynamicCast<Sailor::GraphicsDriver::Vulkan::VulkanGraphicsDriver>();
-
-	const auto& internalMemoryAllocators = VulkanApi::GetInstance()->GetMainDevice()->GetMemoryAllocators();
-
-	float texturesOccupiedSpace = 0.0f;
-	for (const auto& allocator : internalMemoryAllocators)
+	auto renderer = App::GetSubmodule<Renderer>();
+	if (!renderer)
 	{
-		texturesOccupiedSpace += allocator.m_second->GetOccupiedSpace() / (1024.0f * 1024.0f);
+		return;
 	}
-
-	const auto& uniformBuffersMemoryAllocators = driverInstance->GetUniformBufferAllocators();
-
-	float uniformBuffersOccupiedSpace = 0.0f;
-	for (const auto& allocator : uniformBuffersMemoryAllocators)
-	{
-		uniformBuffersOccupiedSpace += allocator.m_second->GetOccupiedSpace() / (1024.0f * 1024.0f);
-	}
+	renderer->UpdateMemoryStats();
+	const auto& stats = renderer->GetStats();
+	constexpr float BytesToMb = 1.0f / (1024.0f * 1024.0f);
 
 	SAILOR_LOG("Memory consumption (GPU):");
-	SAILOR_LOG("Materials: % 2.fmb", driverInstance->GetMaterialSsboAllocator()->GetOccupiedSpace() / (1024.0f * 1024.0f));
-	SAILOR_LOG("General: % 2.fmb", driverInstance->GetGeneralSsboAllocator()->GetOccupiedSpace() / (1024.0f * 1024.0f));
-	SAILOR_LOG("Meshes: % 2.fmb", driverInstance->GetMeshSsboAllocator()->GetOccupiedSpace() / (1024.0f * 1024.0f));
-	SAILOR_LOG("Textures: % 2.fmb", texturesOccupiedSpace);
-	SAILOR_LOG("UniformBuffers: % 2.fmb", uniformBuffersOccupiedSpace);
+	SAILOR_LOG("Materials: %.2fmb", stats.m_materialsMemoryUsage.load(std::memory_order_relaxed) * BytesToMb);
+	SAILOR_LOG("General: %.2fmb", stats.m_generalMemoryUsage.load(std::memory_order_relaxed) * BytesToMb);
+	SAILOR_LOG("Meshes: %.2fmb", stats.m_meshesMemoryUsage.load(std::memory_order_relaxed) * BytesToMb);
+	SAILOR_LOG("Textures: %.2fmb", stats.m_texturesMemoryUsage.load(std::memory_order_relaxed) * BytesToMb);
 
+#endif
+}
+
+void Renderer::UpdateMemoryStats()
+{
+#if defined(SAILOR_BUILD_WITH_VULKAN)
+	auto driverInstance = GetDriver().DynamicCast<Sailor::GraphicsDriver::Vulkan::VulkanGraphicsDriver>();
+	if (!driverInstance)
+	{
+		return;
+	}
+
+	size_t texturesOccupiedSpace = 0u;
+	const auto& internalMemoryAllocators = VulkanApi::GetInstance()->GetMainDevice()->GetMemoryAllocators();
+	for (const auto& allocator : internalMemoryAllocators)
+	{
+		texturesOccupiedSpace += allocator.m_second->GetOccupiedSpace();
+	}
+
+	const auto& materialAllocator = driverInstance->GetMaterialSsboAllocatorIfInitialized();
+	const auto& generalAllocator = driverInstance->GetGeneralSsboAllocatorIfInitialized();
+	const auto& meshAllocator = driverInstance->GetMeshSsboAllocatorIfInitialized();
+	m_stats.m_materialsMemoryUsage.store(
+		materialAllocator ? materialAllocator->GetOccupiedSpace() : 0u,
+		std::memory_order_relaxed);
+	m_stats.m_generalMemoryUsage.store(
+		generalAllocator ? generalAllocator->GetOccupiedSpace() : 0u,
+		std::memory_order_relaxed);
+	m_stats.m_meshesMemoryUsage.store(
+		meshAllocator ? meshAllocator->GetOccupiedSpace() : 0u,
+		std::memory_order_relaxed);
+	m_stats.m_texturesMemoryUsage.store(texturesOccupiedSpace, std::memory_order_relaxed);
 #endif
 }
 
@@ -504,6 +526,7 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 							m_stats.m_gpuHeapUsage = heapUsage;
 							m_stats.m_gpuHeapBudget = heapBudget;
 							m_stats.m_numSubmittedCommandBuffers = m_driverInstance->GetNumSubmittedCommandBuffers();
+							UpdateMemoryStats();
 #endif // SAILOR_BUILD_WITH_VULKAN
 						}
 					}

--- a/Runtime/RHI/Renderer.h
+++ b/Runtime/RHI/Renderer.h
@@ -62,6 +62,7 @@ namespace Sailor::RHI
 		SAILOR_API static void MemoryStats();
 
 	protected:
+		void UpdateMemoryStats();
 
 		RHI::EMsaaSamples m_msaaSamples;
 

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -263,6 +263,7 @@ void RHISceneView::Clear()
 	m_cameras.Clear();
 	m_cameraTransforms.Clear();
 	m_shadowMapsToUpdate.Clear();
+	m_shadowMapsToBlit.Clear();
 	m_shadowIndices.Clear();
 	m_shadowAtlasTiles.Clear();
 
@@ -455,6 +456,7 @@ void RHISceneView::PrepareSnapshots()
 		res.m_boneMatrices = m_boneMatrices;
 		res.m_drawImGui = m_drawImGui;
 		res.m_shadowMapsToUpdate = std::move(m_shadowMapsToUpdate[i]);
+		res.m_shadowMapsToBlit = std::move(m_shadowMapsToBlit[i]);
 		res.m_shadowIndices = std::move(m_shadowIndices[i]);
 		res.m_shadowAtlasTiles = std::move(m_shadowAtlasTiles[i]);
 		res.m_proxies = TraceScene(frustum, false);

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -263,6 +263,8 @@ void RHISceneView::Clear()
 	m_cameras.Clear();
 	m_cameraTransforms.Clear();
 	m_shadowMapsToUpdate.Clear();
+	m_shadowIndices.Clear();
+	m_shadowAtlasTiles.Clear();
 
 	m_drawImGui.Clear();
 	m_debugDraw.Clear();
@@ -453,6 +455,8 @@ void RHISceneView::PrepareSnapshots()
 		res.m_boneMatrices = m_boneMatrices;
 		res.m_drawImGui = m_drawImGui;
 		res.m_shadowMapsToUpdate = std::move(m_shadowMapsToUpdate[i]);
+		res.m_shadowIndices = std::move(m_shadowIndices[i]);
+		res.m_shadowAtlasTiles = std::move(m_shadowAtlasTiles[i]);
 		res.m_proxies = TraceScene(frustum, false);
 		auto* meshEcs = m_world ? m_world->GetECS<StaticMeshRendererECS>() : nullptr;
 		const glm::vec3 cameraPosition = glm::vec3(m_cameraTransforms[i].m_position);

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -124,6 +124,7 @@ namespace Sailor::RHI
 		uint32_t m_lighMatrixIndex{};
 		EShadowType m_shadowType = EShadowType::None;
 		glm::vec2 m_blurRadius{}; // [Umbra, Penumbra]
+		glm::ivec4 m_renderArea{}; // [x, y, width, height], zero means the full target
 		RHI::RHIRenderTargetPtr m_shadowMap{};
 		glm::mat4 m_lightMatrix{};
 		TVector<uint32_t> m_internalCommandsList{};
@@ -145,6 +146,8 @@ namespace Sailor::RHI
 
 		uint32_t m_totalNumLights = 0;
 		TVector<RHIUpdateShadowMapCommand> m_shadowMapsToUpdate{};
+		TVector<uint32_t> m_shadowIndices{};
+		TVector<uint32_t> m_shadowAtlasTiles{};
 
 		RHIShaderBindingSetPtr m_frameBindings{};
 		RHIShaderBindingSetPtr m_rhiLightsData{};
@@ -170,6 +173,8 @@ namespace Sailor::RHI
 
 		// For each camera
 		TVector<TVector<RHIUpdateShadowMapCommand>> m_shadowMapsToUpdate;
+		TVector<TVector<uint32_t>> m_shadowIndices;
+		TVector<TVector<uint32_t>> m_shadowAtlasTiles;
 
 		TVector<CameraData> m_cameras;
 		TVector<Math::Transform> m_cameraTransforms;

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -98,6 +98,9 @@ namespace Sailor::RHI
 		TVector<glm::mat4> m_meshModelMatrices;
 		TVector<RHIMaterialPtr> m_overrideMaterials;
 		TVector<size_t> m_renderQueueTags;
+		TVector<glm::vec4> m_baseColorFactors;
+		TVector<uint32_t> m_baseColorSamplers;
+		TVector<float> m_alphaCutoffs;
 #if defined(__APPLE__)
 		TVector<TSet<uint32_t>> m_materialTextureSamplers;
 #endif

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -131,6 +131,14 @@ namespace Sailor::RHI
 		TVector<RHIShadowCasterProxyPtr> m_meshList{};
 	};
 
+	struct RHIBlitShadowMapCommand
+	{
+		RHI::RHIRenderTargetPtr m_source{};
+		RHI::RHIRenderTargetPtr m_destination{};
+		glm::ivec4 m_sourceArea{};
+		glm::ivec4 m_destinationArea{};
+	};
+
 	struct RHISceneViewSnapshot
 	{
 		float m_deltaTime = 0.0f;
@@ -146,6 +154,7 @@ namespace Sailor::RHI
 
 		uint32_t m_totalNumLights = 0;
 		TVector<RHIUpdateShadowMapCommand> m_shadowMapsToUpdate{};
+		TVector<RHIBlitShadowMapCommand> m_shadowMapsToBlit{};
 		TVector<uint32_t> m_shadowIndices{};
 		TVector<uint32_t> m_shadowAtlasTiles{};
 
@@ -173,6 +182,7 @@ namespace Sailor::RHI
 
 		// For each camera
 		TVector<TVector<RHIUpdateShadowMapCommand>> m_shadowMapsToUpdate;
+		TVector<TVector<RHIBlitShadowMapCommand>> m_shadowMapsToBlit;
 		TVector<TVector<uint32_t>> m_shadowIndices;
 		TVector<TVector<uint32_t>> m_shadowAtlasTiles;
 

--- a/Runtime/RHI/Types.h
+++ b/Runtime/RHI/Types.h
@@ -825,9 +825,13 @@ namespace Sailor::RHI
 		std::atomic<uint32_t> m_gpuFps = 0u;
 		std::atomic<uint32_t> m_numBatches = 0u;
 		std::atomic<uint32_t> m_numInstances = 0u;
-		size_t m_gpuHeapBudget;
-		size_t m_gpuHeapUsage;
-		uint32_t m_numSubmittedCommandBuffers;
+		std::atomic<size_t> m_materialsMemoryUsage = 0u;
+		std::atomic<size_t> m_texturesMemoryUsage = 0u;
+		std::atomic<size_t> m_meshesMemoryUsage = 0u;
+		std::atomic<size_t> m_generalMemoryUsage = 0u;
+		size_t m_gpuHeapBudget = 0u;
+		size_t m_gpuHeapUsage = 0u;
+		uint32_t m_numSubmittedCommandBuffers = 0u;
 	};
 
 	class RHIResource : public TRefBase

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -255,6 +255,9 @@ target_compile_features(WorkspaceContextTests PRIVATE cxx_std_20)
 target_compile_features(WorkspaceCacheContractTests PRIVATE cxx_std_20)
 target_compile_features(AssetCacheContractTests PRIVATE cxx_std_20)
 target_compile_features(ShaderCacheArtifactTests PRIVATE cxx_std_20)
+target_compile_definitions(ShaderCacheArtifactTests PRIVATE
+    SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
+)
 target_compile_features(AssetMountDiscoveryTests PRIVATE cxx_std_20)
 target_compile_definitions(WorkspaceModuleFixture PRIVATE
     SAILOR_WORKSPACE_MODULE

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -933,7 +933,7 @@ namespace
 		const size_t prepareCsmBegin = lightingEcsSource.find(
 			"LightingECS::PrepareCSMPasses");
 		const size_t fillLightingBegin = lightingEcsSource.find(
-			"void LightingECS::FillLightingData", prepareCsmBegin);
+			"void LightingECS::ReleaseLocalShadowAllocation", prepareCsmBegin);
 		Require(prepareCsmBegin != std::string::npos &&
 			fillLightingBegin > prepareCsmBegin,
 			"lighting ECS must expose a bounded CSM preparation path");
@@ -958,6 +958,43 @@ namespace
 				"TraceShadowCasters(",
 				traceShadowCasters + std::string("TraceShadowCasters(").size()) == std::string::npos,
 			"CSM preparation must not build full scene proxies or repeat the broad caster query per cascade");
+	}
+
+	void TestLocalLightShadowContract()
+	{
+		Require(LightingECS::GetLocalShadowMapCount(ELightType::Point) == 6u,
+			"a point light must render all six shadow faces");
+		Require(LightingECS::GetLocalShadowMapCount(ELightType::Spot) == 1u,
+			"a spot light must render one perspective shadow map");
+		Require(LightingECS::GetLocalShadowMapCount(ELightType::Directional) == 0u,
+			"local shadow allocation must not replace directional CSM");
+		Require(LightingECS::GetLocalShadowResolution(ELightShadowQuality::VeryLow) == 256u &&
+			LightingECS::GetLocalShadowResolution(ELightShadowQuality::Low) == 512u &&
+			LightingECS::GetLocalShadowResolution(ELightShadowQuality::Medium) == 1024u &&
+			LightingECS::GetLocalShadowResolution(ELightShadowQuality::High) == 2048u,
+			"local shadow quality must map to the documented power-of-two resolutions");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string lightComponentHeader = ReadText(
+			sourceRoot / "Runtime/Components/LightComponent.h");
+		const std::string lightingSource = ReadText(
+			sourceRoot / "Runtime/ECS/LightingECS.cpp");
+		const std::string lightingShader = ReadText(
+			sourceRoot / "Content/Shaders/Lighting.glsl");
+		Require(lightComponentHeader.find("property(\"shadowQuality\")") != std::string::npos &&
+			lightComponentHeader.find("property(\"shadowFilter\")") != std::string::npos,
+			"light shadow quality and hard/soft filtering must be editor-visible reflected properties");
+		Require(lightingSource.find("glm::radians(90.0f)") != std::string::npos &&
+			lightingSource.find("light.m_type == ELightType::Spot") != std::string::npos &&
+			lightingSource.find("shadowPass.m_shadowType = RHI::EShadowType::PCF") != std::string::npos,
+			"point and spot shadow passes must use their respective projections and PCF-only rendering");
+		Require(lightingSource.find("m_shadowMapsMb + allocationMb > ShadowsMemoryBudgetMb") != std::string::npos &&
+			lightingSource.find("candidate + mapCount <= MaxShadowsInView") != std::string::npos,
+			"local shadow allocation must respect both memory and descriptor limits");
+		Require(lightingShader.find("SelectPointShadowFace") != std::string::npos &&
+			lightingShader.find("CalculateLocalPcfShadow") != std::string::npos &&
+			lightingShader.find("SOFT_SHADOW_MAP_BIT") != std::string::npos,
+			"lighting shaders must select point faces and support hard/soft PCF sampling");
 	}
 
 	void TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves()
@@ -3743,6 +3780,7 @@ int main()
 		{ "StaticMeshProxyPublishesTransformRevisionForShadowInvalidation", TestStaticMeshProxyPublishesTransformRevisionForShadowInvalidation },
 		{ "StaticMeshProxyTracksMaterialContentRevisions", TestStaticMeshProxyTracksMaterialContentRevisions },
 		{ "CsmSnapshotTracksCastersBeforeDependencyFiltering", TestCsmSnapshotTracksCastersBeforeDependencyFiltering },
+		{ "LocalLightShadowContract", TestLocalLightShadowContract },
 		{ "CsmSnapshotInvalidatesWhenCascadeProjectionMoves", TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves },
 		{ "CustomDepthShadowCastersInvalidateCsmEveryFrame", TestCustomDepthShadowCastersInvalidateCsmEveryFrame },
 		{ "MeshRendererMaterialOverridesAreReflectedAndPersisted", TestMeshRendererMaterialOverridesAreReflectedAndPersisted },

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1021,9 +1021,9 @@ namespace
 		Require(lightComponentHeader.find("property(\"shadowQuality\")") != std::string::npos &&
 			lightComponentHeader.find("property(\"shadowFilter\")") != std::string::npos,
 			"light shadow quality and hard/soft filtering must be editor-visible reflected properties");
-		Require(lightComponentHeader.find("property(\"radius\")") != std::string::npos &&
-			lightComponentHeader.find("Range(0.01, 100000.0)") != std::string::npos,
-			"local lights must expose an explicit positive radius in the editor");
+		Require(lightComponentHeader.find("func(GetRadius, property(\"radius\"), SkipCDO())") != std::string::npos &&
+			lightComponentHeader.find("func(GetRadius, property(\"radius\"), SkipCDO(), Range(") == std::string::npos,
+			"local light radius must be an unrestricted float field in the editor");
 		Require(lightingSource.find("glm::radians(90.0f)") != std::string::npos &&
 			lightingSource.find("light.m_type == ELightType::Spot") != std::string::npos &&
 			lightingSource.find("shadowPass.m_shadowType = RHI::EShadowType::PCF") != std::string::npos,
@@ -1091,13 +1091,13 @@ namespace
 			linearizeDepthShader.find("LinearizeDepth(depth, frame.cameraZNearZFar.yx)") != std::string::npos &&
 			linearizeDepthShader.find("texelFetch(depthSampler, pixel, 0)") != std::string::npos &&
 			linearizeDepthShader.find("fragTexcoord.y") == std::string::npos,
-			"Forward+ depth bounds must linearize the camera's finite reverse-Z projection in matching framebuffer coordinates");
+			"linear-depth consumers must preserve the camera's finite reverse-Z projection and framebuffer coordinates");
 		const size_t lightCullingNode = defaultRenderer.find("- name: LightCulling");
 		Require(lightCullingNode != std::string::npos &&
-			defaultRenderer.find("- linearDepth: LinearDepth", lightCullingNode) != std::string::npos &&
-			defaultRenderer.find("- linearDepth: LinearDepth", lightCullingNode) <
+			defaultRenderer.find("- depthStencil: DepthBuffer", lightCullingNode) != std::string::npos &&
+			defaultRenderer.find("- depthStencil: DepthBuffer", lightCullingNode) <
 				defaultRenderer.find("- name:", lightCullingNode + 1),
-			"Forward+ culling must consume the frame graph's linear depth target");
+			"Forward+ culling must reconstruct view depth directly from the depth prepass target");
 	}
 
 	void TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves()

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -958,6 +958,16 @@ namespace
 				"TraceShadowCasters(",
 				traceShadowCasters + std::string("TraceShadowCasters(").size()) == std::string::npos,
 			"CSM preparation must not build full scene proxies or repeat the broad caster query per cascade");
+		Require(prepareCsmBody.find("bHasCachedShadowCasters") != std::string::npos &&
+			prepareCsmBody.find("bCanReuseAllCascades && bHasCachedShadowCasters") != std::string::npos,
+			"CSM must not reuse an empty bootstrap snapshot before asynchronous mesh proxies become available");
+		Require(lightingEcsSource.find("bHasCachedLocalShadowCasters") != std::string::npos &&
+			lightingEcsSource.find("if (bHasCachedLocalShadowCasters &&") != std::string::npos,
+			"local shadows must not reuse an empty bootstrap snapshot before asynchronous mesh proxies become available");
+		Require(prepareCsmBody.find("LightingECS:Build CSM Cascade") != std::string::npos &&
+			prepareCsmBody.find("EThreadType::Worker") != std::string::npos &&
+			prepareCsmBody.find("cascadeCasterTasks[k]->Wait()") != std::string::npos,
+			"CSM caster filtering must run per cascade on worker tasks and join before command assembly");
 	}
 
 	void TestLocalLightShadowContract()
@@ -979,22 +989,54 @@ namespace
 			sourceRoot / "Runtime/Components/LightComponent.h");
 		const std::string lightingSource = ReadText(
 			sourceRoot / "Runtime/ECS/LightingECS.cpp");
+		const std::string shadowPrepassSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
+		const std::string sceneViewSource = ReadText(
+			sourceRoot / "Runtime/RHI/SceneView.cpp");
 		const std::string lightingShader = ReadText(
 			sourceRoot / "Content/Shaders/Lighting.glsl");
+		const std::string lightCullingShader = ReadText(
+			sourceRoot / "Content/Shaders/ComputeLightCulling.shader");
 		Require(lightComponentHeader.find("property(\"shadowQuality\")") != std::string::npos &&
 			lightComponentHeader.find("property(\"shadowFilter\")") != std::string::npos,
 			"light shadow quality and hard/soft filtering must be editor-visible reflected properties");
+		Require(lightComponentHeader.find("property(\"radius\")") != std::string::npos &&
+			lightComponentHeader.find("Range(0.01, 100000.0)") != std::string::npos,
+			"local lights must expose an explicit positive radius in the editor");
 		Require(lightingSource.find("glm::radians(90.0f)") != std::string::npos &&
 			lightingSource.find("light.m_type == ELightType::Spot") != std::string::npos &&
 			lightingSource.find("shadowPass.m_shadowType = RHI::EShadowType::PCF") != std::string::npos,
 			"point and spot shadow passes must use their respective projections and PCF-only rendering");
-		Require(lightingSource.find("m_shadowMapsMb + allocationMb > ShadowsMemoryBudgetMb") != std::string::npos &&
-			lightingSource.find("candidate + mapCount <= MaxShadowsInView") != std::string::npos,
-			"local shadow allocation must respect both memory and descriptor limits");
+		Require(lightingSource.find("TryAllocateLocalShadowTiles(mapCount, desiredResolution, tiles)") != std::string::npos &&
+			lightingSource.find("candidate + mapCount <= MaxShadowsInView") != std::string::npos &&
+			lightingSource.find("candidate = static_cast<uint32_t>(m_csmShadowMaps.Num())") != std::string::npos &&
+			lightingSource.find("m_localShadowAtlas") != std::string::npos,
+			"local shadow allocation must use the bounded shared atlas without overlapping directional slots");
+		Require(lightingSource.find("App::GetMainWindow()->GetRenderArea().y") != std::string::npos &&
+			lightingSource.find("camera,\n\t\t\t1080u,") == std::string::npos,
+			"dynamic local-shadow resolution must use the active viewport instead of a fixed reference height");
+		Require(lightingSource.find(
+			"GetLightsInFrustum(frustum, sceneView->m_cameraTransforms[i], directionalLights, sortedPointLights, sortedSpotLights)") != std::string::npos,
+			"point and spot lights must remain in their matching sorted collections");
+		Require(lightingSource.find("frustum.OverlapsSphere(Math::Sphere(worldPosition, sphereRadius))") != std::string::npos &&
+			lightingSource.find("frustum.ContainsSphere(Math::Sphere(worldPosition, sphereRadius))") == std::string::npos,
+			"local shadow lights must remain visible when their influence sphere intersects the camera frustum");
+		Require(lightingSource.find("sceneView->m_shadowIndices.Add(std::move(shadowIndices))") != std::string::npos &&
+			lightingSource.find("sceneView->m_shadowAtlasTiles.Add(std::move(shadowAtlasTiles))") != std::string::npos &&
+			sceneViewSource.find("res.m_shadowIndices = std::move(m_shadowIndices[i])") != std::string::npos &&
+			sceneViewSource.find("res.m_shadowAtlasTiles = std::move(m_shadowAtlasTiles[i])") != std::string::npos &&
+			shadowPrepassSource.find("transferCommandList,\n\t\t\t\tshadowIndices") != std::string::npos,
+			"local shadow indices and atlas transforms must cross the scene snapshot and upload through the frame transfer command list");
+		Require(lightingSource.find("GetWorld()->GetCommandList(),\n\t\t\tm_shadowIndices") == std::string::npos,
+			"scene preparation must not record shadow-index uploads into the world command list");
 		Require(lightingShader.find("SelectPointShadowFace") != std::string::npos &&
 			lightingShader.find("CalculateLocalPcfShadow") != std::string::npos &&
+			lightingShader.find("atlasRect.xy + projCoords.xy * atlasRect.zw") != std::string::npos &&
 			lightingShader.find("SOFT_SHADOW_MAP_BIT") != std::string::npos,
-			"lighting shaders must select point faces and support hard/soft PCF sampling");
+			"lighting shaders must select point faces and support atlas-aware hard/soft PCF sampling");
+		Require(lightCullingShader.find("const float viewDepth = texture(sceneDepth, uv).x;") != std::string::npos &&
+			lightCullingShader.find("ScreenSpaceToViewSpace(uv, deviceDepth") == std::string::npos,
+			"tiled local-light culling must consume the renderer's linear view-depth target directly");
 	}
 
 	void TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves()
@@ -1039,21 +1081,27 @@ namespace
 			"a changed cascade projection must invalidate the cached shadow map even for camera motion below the old threshold");
 	}
 
-	void TestCustomDepthShadowCastersInvalidateCsmEveryFrame()
+	void TestShadowCachePolicy()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
-		const std::string sceneViewHeader = ReadText(sourceRoot / "Runtime/RHI/SceneView.h");
 		const std::string meshRendererSource = ReadText(sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
 		const std::string lightingSource = ReadText(sourceRoot / "Runtime/ECS/LightingECS.cpp");
+		const size_t localShadowBegin = lightingSource.find("LightingECS::PrepareLocalShadowPasses");
+		const size_t fillLightingBegin = lightingSource.find("void LightingECS::FillLightingData", localShadowBegin);
+		Require(localShadowBegin != std::string::npos && fillLightingBegin > localShadowBegin,
+			"lighting ECS must expose a bounded local-shadow preparation path");
+		const std::string localShadowBody = lightingSource.substr(
+			localShadowBegin, fillLightingBegin - localShadowBegin);
 
-		Require(sceneViewHeader.find("bool m_bHasCustomDepthShadowCasters = false") != std::string::npos &&
-			meshRendererSource.find("IsRequiredCustomDepthShader()") != std::string::npos &&
-			meshRendererSource.find("m_bHasCustomDepthShadowCasters = bHasCustomDepthShadowCasters") != std::string::npos,
-			"scene snapshots must identify custom-depth shadow casters");
+		Require(meshRendererSource.find("++m_sceneViewProxiesCache->m_shadowCastersRevision;") != std::string::npos &&
+			lightingSource.find("sceneView->m_shadowCastersRevision") != std::string::npos,
+			"shadow caches must invalidate when the shadow-caster scene revision changes");
 		Require(lightingSource.find("bForceCustomDepthShadowUpdate") != std::string::npos &&
-			lightingSource.find("bool bCanReuseAllCascades = !bForceCustomDepthShadowUpdate") != std::string::npos &&
-			lightingSource.find("if (!bForceCustomDepthShadowUpdate &&") != std::string::npos,
-			"custom-depth shadow casters must bypass both CSM snapshot reuse paths every frame");
+			lightingSource.find("bool bCanReuseAllCascades = !bForceCustomDepthShadowUpdate") != std::string::npos,
+			"directional CSM must retain the conservative custom-depth update policy");
+		Require(localShadowBody.find("m_bHasCustomDepthShadowCasters") == std::string::npos &&
+			localShadowBody.find("cachedState.CanReuse(") != std::string::npos,
+			"static local-light shadow maps must reuse revision-validated snapshots even with custom-depth vegetation");
 	}
 
 	void TestAnimationGpuBoneLayoutContract()
@@ -3870,7 +3918,7 @@ int main()
 		{ "CsmSnapshotTracksCastersBeforeDependencyFiltering", TestCsmSnapshotTracksCastersBeforeDependencyFiltering },
 		{ "LocalLightShadowContract", TestLocalLightShadowContract },
 		{ "CsmSnapshotInvalidatesWhenCascadeProjectionMoves", TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves },
-		{ "CustomDepthShadowCastersInvalidateCsmEveryFrame", TestCustomDepthShadowCastersInvalidateCsmEveryFrame },
+		{ "ShadowCachePolicy", TestShadowCachePolicy },
 		{ "MeshRendererMaterialOverridesAreReflectedAndPersisted", TestMeshRendererMaterialOverridesAreReflectedAndPersisted },
 		{ "AnimationGpuBoneLayoutContract", TestAnimationGpuBoneLayoutContract },
 		{ "ExpiredWorldPrefabInvalidatesLoadedCacheContract", TestExpiredWorldPrefabInvalidatesLoadedCacheContract },

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1087,11 +1087,13 @@ namespace
 			lightCullingShader.find("uv.y = 1 - uv.y") == std::string::npos &&
 			lightingShader.find("float(safeViewportSize.y) - fragmentPosition.y") == std::string::npos,
 			"tiled local-light culling must use per-tile depth bounds and address compute and fragment tiles in the same framebuffer coordinates");
-		Require(linearizeDepthShader.find("REVERSE_Z_INF_FAR_PLANE") == std::string::npos &&
+		Require(linearizeDepthShader.find("#ifdef REVERSE_Z_INF_FAR_PLANE") != std::string::npos &&
+			linearizeDepthShader.find("- REVERSE_Z_INF_FAR_PLANE") == std::string::npos &&
+			linearizeDepthShader.find("frame.cameraZNearZFar.x / depth") != std::string::npos &&
 			linearizeDepthShader.find("LinearizeDepth(depth, frame.cameraZNearZFar.yx)") != std::string::npos &&
 			linearizeDepthShader.find("texelFetch(depthSampler, pixel, 0)") != std::string::npos &&
 			linearizeDepthShader.find("fragTexcoord.y") == std::string::npos,
-			"linear-depth consumers must preserve the camera's finite reverse-Z projection and framebuffer coordinates");
+			"linear depth must retain disabled infinite-far support while defaulting to finite reverse-Z in framebuffer coordinates");
 		const size_t lightCullingNode = defaultRenderer.find("- name: LightCulling");
 		Require(lightCullingNode != std::string::npos &&
 			defaultRenderer.find("- linearDepth: LinearDepth", lightCullingNode) != std::string::npos &&

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1082,7 +1082,7 @@ namespace
 			"distance-driven local shadow downgrades must migrate cached tiles through a GPU blit");
 		Require(lightCullingShader.find("uintBitsToFloat(minDepthInt)") != std::string::npos &&
 			lightCullingShader.find("uintBitsToFloat(maxDepthInt)") != std::string::npos &&
-			lightCullingShader.find("texelFetch(sceneDepth, location, 0)") != std::string::npos &&
+			lightCullingShader.find("texelFetch(linearDepth, location, 0)") != std::string::npos &&
 			lightCullingShader.find("SphereTileOverlaps(") != std::string::npos &&
 			lightCullingShader.find("uv.y = 1 - uv.y") == std::string::npos &&
 			lightingShader.find("float(safeViewportSize.y) - fragmentPosition.y") == std::string::npos,
@@ -1094,10 +1094,10 @@ namespace
 			"linear-depth consumers must preserve the camera's finite reverse-Z projection and framebuffer coordinates");
 		const size_t lightCullingNode = defaultRenderer.find("- name: LightCulling");
 		Require(lightCullingNode != std::string::npos &&
-			defaultRenderer.find("- depthStencil: DepthBuffer", lightCullingNode) != std::string::npos &&
-			defaultRenderer.find("- depthStencil: DepthBuffer", lightCullingNode) <
+			defaultRenderer.find("- linearDepth: LinearDepth", lightCullingNode) != std::string::npos &&
+			defaultRenderer.find("- linearDepth: LinearDepth", lightCullingNode) <
 				defaultRenderer.find("- name:", lightCullingNode + 1),
-			"Forward+ culling must reconstruct view depth directly from the depth prepass target");
+			"Forward+ culling must consume the pre-linearized depth target");
 	}
 
 	void TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves()

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1025,7 +1025,10 @@ namespace
 			lightingSource.find("sceneView->m_shadowAtlasTiles.Add(std::move(shadowAtlasTiles))") != std::string::npos &&
 			sceneViewSource.find("res.m_shadowIndices = std::move(m_shadowIndices[i])") != std::string::npos &&
 			sceneViewSource.find("res.m_shadowAtlasTiles = std::move(m_shadowAtlasTiles[i])") != std::string::npos &&
-			shadowPrepassSource.find("transferCommandList,\n\t\t\t\tshadowIndices") != std::string::npos,
+			shadowPrepassSource.find("sceneView.m_shadowIndices.GetData()") != std::string::npos &&
+			shadowPrepassSource.find("sceneView.m_shadowAtlasTiles.GetData()") != std::string::npos &&
+			shadowPrepassSource.find("commands->UpdateShaderBinding(") != std::string::npos &&
+			shadowPrepassSource.find("transferCommandList") != std::string::npos,
 			"local shadow indices and atlas transforms must cross the scene snapshot and upload through the frame transfer command list");
 		Require(lightingSource.find("GetWorld()->GetCommandList(),\n\t\t\tm_shadowIndices") == std::string::npos,
 			"scene preparation must not record shadow-index uploads into the world command list");

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -983,12 +983,29 @@ namespace
 			LightingECS::GetLocalShadowResolution(ELightShadowQuality::Medium) == 1024u &&
 			LightingECS::GetLocalShadowResolution(ELightShadowQuality::High) == 2048u,
 			"local shadow quality must map to the documented power-of-two resolutions");
+		Require(LightingECS::LocalShadowMinResolution == 64u,
+			"distant local lights must be allowed to fall back to 64x64 shadow tiles");
+		Require(LightingECS::MaxShadowsInView >= 1804u &&
+			LightingECS::MaxShadowMapSamplers < LightingECS::MaxShadowsInView,
+			"shadow matrix capacity must cover 300 point lights without allocating one sampler per face");
+		Require(LightingECS::DefaultShadowsMemoryBudgetMb == 768.0f,
+			"the runtime shadow cache must expose the planned 768 MB default budget");
 
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string lightComponentHeader = ReadText(
 			sourceRoot / "Runtime/Components/LightComponent.h");
 		const std::string lightingSource = ReadText(
 			sourceRoot / "Runtime/ECS/LightingECS.cpp");
+		const std::string lightingHeader = ReadText(
+			sourceRoot / "Runtime/ECS/LightingECS.h");
+		const std::string engineLoopSource = ReadText(
+			sourceRoot / "Runtime/Engine/EngineLoop.cpp");
+		const std::string rendererSource = ReadText(
+			sourceRoot / "Runtime/RHI/Renderer.cpp");
+		const std::string rhiTypesHeader = ReadText(
+			sourceRoot / "Runtime/RHI/Types.h");
+		const std::string blockAllocatorHeader = ReadText(
+			sourceRoot / "Runtime/Memory/MemoryBlockAllocator.hpp");
 		const std::string shadowPrepassSource = ReadText(
 			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
 		const std::string sceneViewSource = ReadText(
@@ -997,6 +1014,10 @@ namespace
 			sourceRoot / "Content/Shaders/Lighting.glsl");
 		const std::string lightCullingShader = ReadText(
 			sourceRoot / "Content/Shaders/ComputeLightCulling.shader");
+		const std::string linearizeDepthShader = ReadText(
+			sourceRoot / "Content/Shaders/LinearizeDepth.shader");
+		const std::string defaultRenderer = ReadText(
+			sourceRoot / "Content/DefaultRenderer.renderer");
 		Require(lightComponentHeader.find("property(\"shadowQuality\")") != std::string::npos &&
 			lightComponentHeader.find("property(\"shadowFilter\")") != std::string::npos,
 			"light shadow quality and hard/soft filtering must be editor-visible reflected properties");
@@ -1007,11 +1028,24 @@ namespace
 			lightingSource.find("light.m_type == ELightType::Spot") != std::string::npos &&
 			lightingSource.find("shadowPass.m_shadowType = RHI::EShadowType::PCF") != std::string::npos,
 			"point and spot shadow passes must use their respective projections and PCF-only rendering");
-		Require(lightingSource.find("TryAllocateLocalShadowTiles(mapCount, desiredResolution, tiles)") != std::string::npos &&
+		Require(lightingSource.find("TryCreateLocalShadowAtlas") != std::string::npos &&
+			lightingSource.find("UpdateShaderBinding(\n\t\tm_lightsData,\n\t\t\"shadowMaps\"") != std::string::npos &&
+			lightingSource.find("NumCascades + atlasIndex") != std::string::npos,
+			"local shadow atlases must be created and published into the sampler array on demand");
+		Require(lightingSource.find("TryAllocateLocalShadowTiles(") != std::string::npos &&
+			lightingSource.find("uint32_t& outAtlasIndex") != std::string::npos &&
 			lightingSource.find("candidate + mapCount <= MaxShadowsInView") != std::string::npos &&
 			lightingSource.find("candidate = static_cast<uint32_t>(m_csmShadowMaps.Num())") != std::string::npos &&
-			lightingSource.find("m_localShadowAtlas") != std::string::npos,
-			"local shadow allocation must use the bounded shared atlas without overlapping directional slots");
+			lightingSource.find("m_shadowMapsMb + LocalShadowAtlasMemoryMb > m_shadowsMemoryBudgetMb") != std::string::npos,
+			"local shadow allocation must use bounded dynamic atlases without overlapping directional slots or the memory budget");
+		Require(lightingHeader.find("GetCsmShadowsOccupiedMemoryMb") != std::string::npos &&
+			lightingHeader.find("GetLocalShadowsOccupiedMemoryMb") != std::string::npos &&
+			engineLoopSource.find("Shadows %.1f / %.0f MB") != std::string::npos &&
+			engineLoopSource.find("Materials %.1f MB") != std::string::npos &&
+			rendererSource.find("void Renderer::UpdateMemoryStats()") != std::string::npos &&
+			rhiTypesHeader.find("m_texturesMemoryUsage") != std::string::npos &&
+			blockAllocatorHeader.find("const size_t occupiedSpace = m_usedDataSpace") != std::string::npos,
+			"frame statistics must expose shadow, CSM, local atlas, and Vulkan allocator memory without racing allocator updates");
 		Require(lightingSource.find("App::GetMainWindow()->GetRenderArea().y") != std::string::npos &&
 			lightingSource.find("camera,\n\t\t\t1080u,") == std::string::npos,
 			"dynamic local-shadow resolution must use the active viewport instead of a fixed reference height");
@@ -1022,7 +1056,9 @@ namespace
 			lightingSource.find("frustum.ContainsSphere(Math::Sphere(worldPosition, sphereRadius))") == std::string::npos,
 			"local shadow lights must remain visible when their influence sphere intersects the camera frustum");
 		Require(lightingSource.find("sceneView->m_shadowIndices.Add(std::move(shadowIndices))") != std::string::npos &&
+			lightingSource.find("sceneView->m_shadowMapsToBlit.Add(std::move(shadowMapsToBlit))") != std::string::npos &&
 			lightingSource.find("sceneView->m_shadowAtlasTiles.Add(std::move(shadowAtlasTiles))") != std::string::npos &&
+			sceneViewSource.find("res.m_shadowMapsToBlit = std::move(m_shadowMapsToBlit[i])") != std::string::npos &&
 			sceneViewSource.find("res.m_shadowIndices = std::move(m_shadowIndices[i])") != std::string::npos &&
 			sceneViewSource.find("res.m_shadowAtlasTiles = std::move(m_shadowAtlasTiles[i])") != std::string::npos &&
 			shadowPrepassSource.find("sceneView.m_shadowIndices.GetData()") != std::string::npos &&
@@ -1034,12 +1070,34 @@ namespace
 			"scene preparation must not record shadow-index uploads into the world command list");
 		Require(lightingShader.find("SelectPointShadowFace") != std::string::npos &&
 			lightingShader.find("CalculateLocalPcfShadow") != std::string::npos &&
+			lightingShader.find("DecodeShadowAtlasIndex") != std::string::npos &&
 			lightingShader.find("atlasRect.xy + projCoords.xy * atlasRect.zw") != std::string::npos &&
 			lightingShader.find("SOFT_SHADOW_MAP_BIT") != std::string::npos,
 			"lighting shaders must select point faces and support atlas-aware hard/soft PCF sampling");
-		Require(lightCullingShader.find("const float viewDepth = texture(sceneDepth, uv).x;") != std::string::npos &&
-			lightCullingShader.find("ScreenSpaceToViewSpace(uv, deviceDepth") == std::string::npos,
-			"tiled local-light culling must consume the renderer's linear view-depth target directly");
+		Require(lightingSource.find("snapshot.Equals(cachedState)") != std::string::npos,
+			"a global caster revision must not redraw a local static shadow whose actual caster snapshot is unchanged");
+		Require(shadowPrepassSource.find("Downsample Local Shadow Tiles") != std::string::npos &&
+			shadowPrepassSource.find("sceneView.m_shadowMapsToBlit") != std::string::npos &&
+			shadowPrepassSource.find("commands->BlitImage(") != std::string::npos,
+			"distance-driven local shadow downgrades must migrate cached tiles through a GPU blit");
+		Require(lightCullingShader.find("uintBitsToFloat(minDepthInt)") != std::string::npos &&
+			lightCullingShader.find("uintBitsToFloat(maxDepthInt)") != std::string::npos &&
+			lightCullingShader.find("texelFetch(sceneDepth, location, 0)") != std::string::npos &&
+			lightCullingShader.find("SphereTileOverlaps(") != std::string::npos &&
+			lightCullingShader.find("uv.y = 1 - uv.y") == std::string::npos &&
+			lightingShader.find("float(safeViewportSize.y) - fragmentPosition.y") == std::string::npos,
+			"tiled local-light culling must use per-tile depth bounds and address compute and fragment tiles in the same framebuffer coordinates");
+		Require(linearizeDepthShader.find("REVERSE_Z_INF_FAR_PLANE") == std::string::npos &&
+			linearizeDepthShader.find("LinearizeDepth(depth, frame.cameraZNearZFar.yx)") != std::string::npos &&
+			linearizeDepthShader.find("texelFetch(depthSampler, pixel, 0)") != std::string::npos &&
+			linearizeDepthShader.find("fragTexcoord.y") == std::string::npos,
+			"Forward+ depth bounds must linearize the camera's finite reverse-Z projection in matching framebuffer coordinates");
+		const size_t lightCullingNode = defaultRenderer.find("- name: LightCulling");
+		Require(lightCullingNode != std::string::npos &&
+			defaultRenderer.find("- linearDepth: LinearDepth", lightCullingNode) != std::string::npos &&
+			defaultRenderer.find("- linearDepth: LinearDepth", lightCullingNode) <
+				defaultRenderer.find("- name:", lightCullingNode + 1),
+			"Forward+ culling must consume the frame graph's linear depth target");
 	}
 
 	void TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves()

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -412,25 +412,37 @@ namespace
 			cullingShader.find("atomicAdd(culledLights") ==
 				std::string::npos,
 			"Forward+ light-list allocation must not race across workgroups");
+		Require(cullingShader.find("candidateImpact") == std::string::npos &&
+			cullingShader.find("BitonicSortCandidates") == std::string::npos &&
+			cullingShader.find("uncappedNumLights > LIGHTS_PER_TILE") !=
+				std::string::npos,
+			"Forward+ must mark tiles whose compact 128-light list overflows");
 		Require(cullingShader.find("const bool isInsideViewport") !=
 				std::string::npos &&
 			cullingShader.find("if (isInsideViewport)") !=
 				std::string::npos,
 			"partial Forward+ tiles must not sample outside the viewport");
+		Require(cullingShader.find("bool SphereTileOverlaps(") !=
+				std::string::npos &&
+			cullingShader.find("-frame.projection[1][1]") !=
+				std::string::npos &&
+			cullingShader.find("greaterThanEqual(screenMax, tileMin)") !=
+				std::string::npos,
+			"Forward+ sphere bounds must use the negative-height Vulkan viewport orientation");
 
 		const std::string lightCullingSource = ReadText(
 			sourceRoot / "Runtime/FrameGraph/LightCullingNode.cpp");
 		const std::string processBody = ExtractFunctionBody(
 			lightCullingSource,
 			"void LightCullingNode::Process(");
-		const size_t depthAspectOffset = processBody.find(
-			"sampledDepthAttachment = depthAspect");
+		const size_t linearDepthLookup = processBody.find(
+			"GetRHIResource(\"linearDepth\")");
 		const size_t depthBindingOffset = processBody.find(
 			"AddSamplerToShaderBindings(m_culledLights, \"sceneDepth\", sampledDepthAttachment",
-			depthAspectOffset);
-		Require(depthAspectOffset != std::string::npos &&
-			depthBindingOffset > depthAspectOffset,
-			"Forward+ depth sampling must exclude the stencil aspect from combined depth-stencil targets");
+			linearDepthLookup);
+		Require(linearDepthLookup != std::string::npos &&
+			depthBindingOffset > linearDepthLookup,
+			"Forward+ must reduce the frame graph's linear view-space depth target");
 		const size_t dispatchOffset = processBody.find("commands->Dispatch(");
 		const size_t barrierOffset = processBody.find(
 			"commands->MemoryBarrier(",
@@ -449,12 +461,13 @@ namespace
 			processBody.find("m_bindingsViewportSize != pushConstants.m_viewportSize") !=
 				std::string::npos,
 			"Forward+ buffers must be recreated when their resource identity or extent changes");
-
 		const std::string lightingLibrary = ReadText(
 			sourceRoot / "Content/Shaders/Lighting.glsl");
 		Require(lightingLibrary.find("uint GetLightTileIndex(") !=
 				std::string::npos &&
 			lightingLibrary.find("const ivec2 tileId = clamp(") !=
+				std::string::npos &&
+			lightingLibrary.find("LIGHT_TILE_OVERFLOW_BIT") !=
 				std::string::npos,
 			"Forward+ consumers must clamp screen coordinates to the tile grid");
 		Require(lightingLibrary.find(
@@ -474,8 +487,11 @@ namespace
 			Require(shader.find(
 					"GetLightTileIndex(gl_FragCoord.xy, frame.viewportSize)") !=
 					std::string::npos &&
+				shader.find("lightsGrid.instance[tileIndex].num") !=
+					std::string::npos &&
+				shader.find("usesOverflowList") == std::string::npos &&
 				shader.find(
-					"min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE))") !=
+					"min(lightsGrid.instance[tileIndex].num, uint(LIGHTS_PER_TILE))") ==
 					std::string::npos &&
 				shader.find("lightsGrid.instance.length()") !=
 					std::string::npos &&
@@ -490,13 +506,34 @@ namespace
 			sourceRoot / "Content/Shaders/Standard_glTF.shader" })
 		{
 			const std::string shader = ReadText(shaderPath);
-			Require(shader.find("light.instance.length()") !=
+			Require(shader.find("SUPPORT_LIGHTS_OVERFLOW") !=
+					std::string::npos &&
+				shader.find("lightsOverflow ? uint(i)") !=
+					std::string::npos &&
+				shader.find("light.instance.length()") !=
 					std::string::npos &&
 				shader.find("light.instance[index].type == INVALID_LIGHT_TYPE") !=
 					std::string::npos,
 				"Forward+ lighting must reject invalid light indices: " +
 					shaderPath.generic_string());
 		}
+	}
+
+	void TestRegionBlitDoesNotPromoteToFullImageCopy()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string source = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanCommandBuffer.cpp");
+		const std::string body = ExtractFunctionBody(
+			source,
+			"bool VulkanCommandBuffer::BlitImage(");
+		Require(body.find("bRegionsHaveSameExtent") != std::string::npos &&
+			body.find("srcRegion.extent.width") != std::string::npos &&
+			body.find("srcRegion.extent.height") != std::string::npos,
+			"equal-format image operations must use copy only when source and destination regions have equal dimensions");
+		Require(body.find("copy.extent = {\n\t\t\t\tsrcRegion.extent.width") != std::string::npos &&
+			body.find("copy.extent = src->GetImage()->m_extent") == std::string::npos,
+			"a regional copy must never silently expand to the complete source image");
 	}
 
 	void TestVulkanMemoryBarrierRecordsPipelineBarrier()
@@ -1543,6 +1580,7 @@ int main()
 		{ "ModelHierarchyRenderPropagationContract", TestModelHierarchyRenderPropagationContract },
 		{ "GpuCullingShaderSafetyContract", TestGpuCullingShaderSafetyContract },
 		{ "ForwardPlusTileSynchronizationContract", TestForwardPlusTileSynchronizationContract },
+		{ "RegionBlitDoesNotPromoteToFullImageCopy", TestRegionBlitDoesNotPromoteToFullImageCopy },
 		{ "VulkanMemoryBarrierRecordsPipelineBarrier", TestVulkanMemoryBarrierRecordsPipelineBarrier },
 		{ "ShaderReadOnlyBarrierSynchronizesShaderSampling", TestShaderReadOnlyBarrierSynchronizesShaderSampling },
 		{ "CommandListImageTrackingPreservesPublishedContents", TestCommandListImageTrackingPreservesPublishedContents },

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -367,6 +367,9 @@ namespace
 			cullingShader.find("column1") != std::string::npos &&
 			cullingShader.find("column2") != std::string::npos,
 			"sphere scaling must account for every transformed basis vector");
+		Require(cullingShader.find(
+			"SphereFrustumOverlaps(center.xyz, radius, frustum, frame.cameraZNearZFar.x, frame.cameraZNearZFar.y)") != std::string::npos,
+			"mesh culling must pass near and far planes in the shared frustum helper's canonical order");
 		Require(cullingShader.find("textureQueryLevels(depthHighZ)") != std::string::npos &&
 			cullingShader.find("ceil(log2") != std::string::npos,
 			"occlusion LOD selection must cover the projected bounds and clamp to the pyramid");

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -421,20 +421,23 @@ namespace
 				std::string::npos &&
 			cullingShader.find("if (isInsideViewport)") !=
 				std::string::npos &&
-			cullingShader.find("const float deviceDepth = texelFetch(sceneDepth, location, 0).x") !=
-				std::string::npos &&
-			cullingShader.find("LinearizeDepth(") !=
-				std::string::npos &&
-			cullingShader.find("frame.cameraZNearZFar.yx") !=
+			cullingShader.find("texelFetch(linearDepth, location, 0).x") !=
 				std::string::npos,
-			"Forward+ must reconstruct view depth from the matching in-bounds depth-prepass pixel");
+			"Forward+ must reduce the matching texels from the pre-linearized depth target");
 		Require(cullingShader.find("bool SphereTileOverlaps(") !=
 				std::string::npos &&
-			cullingShader.find("-frame.projection[1][1]") !=
+			cullingShader.find("ViewFrustum CreateTileFrustum(") !=
 				std::string::npos &&
-			cullingShader.find("greaterThanEqual(screenMax, tileMin)") !=
+			cullingShader.find("ScreenSpaceToViewSpace(") !=
+				std::string::npos &&
+			cullingShader.find("frame.invProjection") !=
+				std::string::npos &&
+			cullingShader.find("dot(frustum.planes[i].xyz, lightPosition)") !=
 				std::string::npos,
-			"Forward+ sphere bounds must use the negative-height Vulkan viewport orientation");
+			"Forward+ sphere bounds must use the inverse-projected tile frustum");
+		Require(cullingShader.find("if(lightPosition.z <= radius)") ==
+				std::string::npos,
+			"Forward+ screen culling must not bypass tile bounds based on light radius");
 		Require(cullingShader.find("const float zNear = uintBitsToFloat(minDepthInt)") !=
 				std::string::npos &&
 			cullingShader.find("const float zFar = uintBitsToFloat(maxDepthInt)") !=
@@ -467,14 +470,14 @@ namespace
 			lightCullingSource,
 			"void LightCullingNode::Process(");
 		const size_t depthLookup = processBody.find(
-			"GetRHIResource(\"depthStencil\")");
+			"GetRHIResource(\"linearDepth\")");
 		const size_t depthBindingOffset = processBody.find(
-			"AddSamplerToShaderBindings(m_culledLights, \"sceneDepth\", sampledDepthAttachment",
+			"AddSamplerToShaderBindings(m_culledLights, \"linearDepth\", linearDepthAttachment",
 			depthLookup);
 		Require(depthLookup != std::string::npos &&
 			depthBindingOffset > depthLookup &&
-			processBody.find("ImageMemoryBarrier(commandList, depthAttachment", depthBindingOffset) != std::string::npos,
-			"Forward+ must sample the depth aspect while transitioning the owning depth target");
+			processBody.find("ImageMemoryBarrier(commandList, linearDepthAttachment", depthBindingOffset) != std::string::npos,
+			"Forward+ must sample the pre-linearized R32F depth target");
 		const size_t dispatchOffset = processBody.find("commands->Dispatch(");
 		const size_t barrierOffset = processBody.find(
 			"commands->MemoryBarrier(",
@@ -488,7 +491,7 @@ namespace
 			"fragment lighting must wait for Forward+ compute shader writes");
 		Require(processBody.find("m_boundLightsData != sceneView.m_rhiLightsData") !=
 				std::string::npos &&
-			processBody.find("m_boundDepthAttachment != sampledDepthAttachment") !=
+			processBody.find("m_boundDepthAttachment != linearDepthAttachment") !=
 				std::string::npos &&
 			processBody.find("m_bindingsViewportSize != pushConstants.m_viewportSize") !=
 				std::string::npos,

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -420,8 +420,14 @@ namespace
 		Require(cullingShader.find("const bool isInsideViewport") !=
 				std::string::npos &&
 			cullingShader.find("if (isInsideViewport)") !=
+				std::string::npos &&
+			cullingShader.find("const float deviceDepth = texelFetch(sceneDepth, location, 0).x") !=
+				std::string::npos &&
+			cullingShader.find("LinearizeDepth(") !=
+				std::string::npos &&
+			cullingShader.find("frame.cameraZNearZFar.yx") !=
 				std::string::npos,
-			"partial Forward+ tiles must not sample outside the viewport");
+			"Forward+ must reconstruct view depth from the matching in-bounds depth-prepass pixel");
 		Require(cullingShader.find("bool SphereTileOverlaps(") !=
 				std::string::npos &&
 			cullingShader.find("-frame.projection[1][1]") !=
@@ -429,20 +435,46 @@ namespace
 			cullingShader.find("greaterThanEqual(screenMax, tileMin)") !=
 				std::string::npos,
 			"Forward+ sphere bounds must use the negative-height Vulkan viewport orientation");
+		Require(cullingShader.find("const float zNear = uintBitsToFloat(minDepthInt)") !=
+				std::string::npos &&
+			cullingShader.find("const float zFar = uintBitsToFloat(maxDepthInt)") !=
+				std::string::npos,
+			"Forward+ light culling must use the exact reduced near-far tile interval");
+
+		const std::string lightingShader = ReadText(
+			sourceRoot / "Content/Shaders/Lighting.glsl");
+		const std::string standardShader = ReadText(
+			sourceRoot / "Content/Shaders/Standard.shader");
+		const std::string gltfShader = ReadText(
+			sourceRoot / "Content/Shaders/Standard_glTF.shader");
+		const std::string landscapeShader = ReadText(
+			sourceRoot / "Content/Shaders/Landscape.shader");
+		Require(lightingShader.find("CalculateLocalLightRangeAttenuation") !=
+				std::string::npos &&
+			lightingShader.find("smoothstep(0.9f, 1.0f, normalizedDistance)") != std::string::npos &&
+			lightingShader.find("return attenuation * rangeWindow") != std::string::npos &&
+			standardShader.find("CalculateLocalLightRangeAttenuation(light, distance)") !=
+				std::string::npos &&
+			gltfShader.find("CalculateLocalLightRangeAttenuation(light, distance)") !=
+				std::string::npos &&
+			landscapeShader.find("CalculateLocalLightRangeAttenuation(light, distance)") !=
+				std::string::npos,
+			"all Forward+ surface shaders must preserve attenuation and only fade the final edge of the culling radius");
 
 		const std::string lightCullingSource = ReadText(
 			sourceRoot / "Runtime/FrameGraph/LightCullingNode.cpp");
 		const std::string processBody = ExtractFunctionBody(
 			lightCullingSource,
 			"void LightCullingNode::Process(");
-		const size_t linearDepthLookup = processBody.find(
-			"GetRHIResource(\"linearDepth\")");
+		const size_t depthLookup = processBody.find(
+			"GetRHIResource(\"depthStencil\")");
 		const size_t depthBindingOffset = processBody.find(
 			"AddSamplerToShaderBindings(m_culledLights, \"sceneDepth\", sampledDepthAttachment",
-			linearDepthLookup);
-		Require(linearDepthLookup != std::string::npos &&
-			depthBindingOffset > linearDepthLookup,
-			"Forward+ must reduce the frame graph's linear view-space depth target");
+			depthLookup);
+		Require(depthLookup != std::string::npos &&
+			depthBindingOffset > depthLookup &&
+			processBody.find("ImageMemoryBarrier(commandList, depthAttachment", depthBindingOffset) != std::string::npos,
+			"Forward+ must sample the depth aspect while transitioning the owning depth target");
 		const size_t dispatchOffset = processBody.find("commands->Dispatch(");
 		const size_t barrierOffset = processBody.find(
 			"commands->MemoryBarrier(",
@@ -456,7 +488,7 @@ namespace
 			"fragment lighting must wait for Forward+ compute shader writes");
 		Require(processBody.find("m_boundLightsData != sceneView.m_rhiLightsData") !=
 				std::string::npos &&
-			processBody.find("m_boundDepthAttachment != depthAttachment") !=
+			processBody.find("m_boundDepthAttachment != sampledDepthAttachment") !=
 				std::string::npos &&
 			processBody.find("m_bindingsViewportSize != pushConstants.m_viewportSize") !=
 				std::string::npos,
@@ -888,8 +920,27 @@ namespace
 		Require(prepareBody.find("proxy.m_skeletonOffset") != std::string::npos &&
 			prepareBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding)") != std::string::npos &&
 			prepareBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding)") != std::string::npos &&
-			prepareBody.find("GetOrAddDepthMaterial(mesh->m_vertexDescription, bSkinned)") != std::string::npos,
+			prepareBody.find("GetOrAddDepthMaterial(") != std::string::npos &&
+			prepareBody.find("bSkinned,") != std::string::npos &&
+			prepareBody.find("bMaskedQueue);") != std::string::npos,
 			"DepthPrepass must select its skinned material from both the skeleton offset and the concrete mesh vertex layout");
+
+		Require(depthShader.find("- MASKED") != std::string::npos &&
+			depthShader.find("ResolveTextureSamplerIndex") != std::string::npos &&
+			depthShader.find("alpha < inAlphaCutoff") != std::string::npos &&
+			depthShader.find("float alpha = inVertexAlpha") != std::string::npos &&
+			prepareBody.find("proxy.m_baseColorSamplers") != std::string::npos &&
+			prepareBody.find("effectiveAlphaCutoff") != std::string::npos &&
+			prepareBody.find("const bool bRequiredCustomDepth = !bMaskedQueue") != std::string::npos,
+			"masked depth prepass must apply the same alpha silhouette as the forward material");
+
+		const std::string processBody = ExtractFunctionBody(
+			depthPrepassSource,
+			"void DepthPrepassNode::Process(");
+		Require(processBody.find("shaderInfo->GetFileId(), m_pComputeMeshCullingShader);") !=
+				std::string::npos &&
+			processBody.find("OCCLUSION_CULLING") == std::string::npos,
+			"the depth prepass must keep GPU frustum culling but cannot occlusion-cull the geometry that produces current-frame Hi-Z");
 	}
 
 	void TestShadowPrepassSkinningContract()

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -976,6 +976,101 @@ namespace
 			"native nested GLSL include text should remain opaque to the YAML include resolver");
 	}
 
+	void TestRuntimeLightingShadersCompile()
+	{
+		const std::filesystem::path contentRoot =
+			std::filesystem::path(SAILOR_TEST_SOURCE_DIR) / "Content";
+		const std::array<const char*, 3> shaderPaths =
+		{
+			"Shaders/Standard.shader",
+			"Shaders/Standard_glTF.shader",
+			"Shaders/Landscape.shader"
+		};
+
+		for (const char* shaderPath : shaderPaths)
+		{
+			const std::filesystem::path sourcePath = contentRoot / shaderPath;
+			ShaderAsset shader;
+			shader.Deserialize(YAML::Load(ReadText(sourcePath)));
+
+			std::string source = shader.GetGlslCommonCode() + "\n#define FRAGMENT\n";
+#if defined(__APPLE__)
+			source += "#define SAILOR_TEXTURE_REMAP\n";
+#endif
+			std::string diagnostic;
+			Require(
+				ShaderYamlIncludeResolver::Append(
+					shader.GetIncludes(),
+					[&](const std::string& include, std::string& contents)
+					{
+						const std::filesystem::path includePath = contentRoot / include;
+						std::ifstream input(includePath, std::ios::binary);
+						if (!input.is_open())
+						{
+							return false;
+						}
+						contents.assign(
+							std::istreambuf_iterator<char>(input),
+							std::istreambuf_iterator<char>());
+						return true;
+					},
+					source,
+					diagnostic),
+				std::string("runtime shader includes should resolve for ") + shaderPath +
+					": " + diagnostic);
+
+			source += "\n#ifdef FRAGMENT\n" + shader.GetGlslFragmentCode() +
+				"\n#endif\n";
+			RHI::ShaderByteCode byteCode;
+			Require(
+				ShaderCompilerTestAccess::CompileGlslToSpirv(
+					shaderPath,
+					source,
+					RHI::EShaderStage::Fragment,
+					byteCode,
+					false),
+				std::string("runtime fragment shader should compile: ") + shaderPath);
+			Require(!byteCode.IsEmpty(),
+				std::string("runtime fragment shader should produce SPIR-V: ") + shaderPath);
+		}
+
+		const char* computeShaderPath = "Shaders/ComputeLightCulling.shader";
+		ShaderAsset computeShader;
+		computeShader.Deserialize(YAML::Load(ReadText(contentRoot / computeShaderPath)));
+		std::string computeSource = computeShader.GetGlslCommonCode() + "\n#define COMPUTE\n";
+		std::string computeDiagnostic;
+		Require(
+			ShaderYamlIncludeResolver::Append(
+				computeShader.GetIncludes(),
+				[&](const std::string& include, std::string& contents)
+				{
+					std::ifstream input(contentRoot / include, std::ios::binary);
+					if (!input.is_open())
+					{
+						return false;
+					}
+					contents.assign(
+						std::istreambuf_iterator<char>(input),
+						std::istreambuf_iterator<char>());
+					return true;
+				},
+				computeSource,
+				computeDiagnostic),
+			std::string("light-culling shader includes should resolve: ") + computeDiagnostic);
+		computeSource += "\n#ifdef COMPUTE\n" + computeShader.GetGlslComputeCode() + "\n#endif\n";
+		RHI::ShaderByteCode computeByteCode;
+		Require(
+			ShaderCompilerTestAccess::CompileGlslToSpirv(
+				computeShaderPath,
+				computeSource,
+				RHI::EShaderStage::Compute,
+				computeByteCode,
+				false),
+			"runtime light-culling compute shader should compile");
+		Require(!computeByteCode.IsEmpty(),
+			"runtime light-culling compute shader should produce SPIR-V");
+	}
+
 	void TestShaderSourceNormalization()
 	{
 		std::string diagnostic;
@@ -1120,6 +1215,7 @@ int main()
 		TestShaderCompilerFailureLifecycle();
 		TestShaderDependencyFingerprintTracksTimestampAndWinner();
 		TestMissingYamlIncludeFailsWithoutPartialSource();
+		TestRuntimeLightingShadersCompile();
 		TestShaderSourceNormalization();
 		TestShaderSourceRewritePreservesFileIdentity();
 		std::cout << "Shader cache artifact tests passed.\n";


### PR DESCRIPTION
Closes #170

## Summary

- render six PCF faces for point lights and one perspective PCF map for spot lights
- pack local-light shadows into a bounded 4096x4096 atlas with aligned tiles, quality caps, hysteresis, and stable reuse
- expose scalar light radius, shadow quality, and hard or soft filtering
- retain 128 Forward+ lights per tile with a material-controlled overflow path
- preserve exact per-tile near and far rejection using the existing pre-linearized R32F depth target
- use inverse-projected tile frusta for conservative local-light screen bounds
- sample local shadows in Standard, Standard glTF, and Landscape materials
- add shader compilation coverage and auto-exit visual shadow stress scenes

## Root cause

Local lights had no complete render and sampling path. The first shadow frame could also cache an empty caster set before asynchronous mesh proxies appeared, permanently suppressing local shadows. A shared partial-clear path additionally regressed directional CSM.

The Forward+ regression came from sampling the depth and stencil aspect directly in the compute pass. The reduced tile minimum could remain at clear depth, making a local light visible only when its radius approached the camera far plane. Light culling now consumes the existing LinearDepth R32F target produced immediately before it, reduces matching texels to exact view-space near and far bounds, and compares those bounds against view-space light spheres.

## Scope

No project worlds, models, textures, generated asset metadata, or unrelated content are included. Content changes are limited to required engine shaders, renderer configurations, and dedicated visual test fixtures.

## Validation

- Release SailorExec build
- EcsLifecycleContractTests
- GpuCullingContractTests
- ShaderCacheArtifactTests
- ShaderConstantsModeContract
- RuntimeNoExceptions
- RuntimeNoStdContainersOrSmartPointers
- visual runs for directional, point, spot, combined, and stress scenes
- manual EverythingFloats validation with local-light radius below camera far plane
- git diff --check

All selected checks pass locally. The final Forward+ path retains exact tile depth bounds and has no radius or far-plane bypass.