### PR TITLE
Remove incidental shader metadata normalization

### DIFF
--- a/Content/Shaders/Lighting.glsl.asset
+++ b/Content/Shaders/Lighting.glsl.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: 79AA6CFB-10D1-4B52-963C-C59C67DCBF92
+fileId: "{79AA6CFB-10D1-4B52-963C-C59C67DCBF92}"
 filename: Lighting.glsl

--- a/Content/Shaders/MotionBlur.shader.asset
+++ b/Content/Shaders/MotionBlur.shader.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: A178A9CF-EC86-438D-ABD8-D8F5A48A42E3
+fileId: "{A178A9CF-EC86-438D-ABD8-D8F5A48A42E3}"
 filename: MotionBlur.shader

--- a/Content/Shaders/Sky.shader.asset
+++ b/Content/Shaders/Sky.shader.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: 3B69ADBF-0AB3-4557-8AE2-ED17838EC7EA
+fileId: "{3B69ADBF-0AB3-4557-8AE2-ED17838EC7EA}"
 filename: Sky.shader

--- a/Content/Shaders/Standard.shader.asset
+++ b/Content/Shaders/Standard.shader.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: E42B1499-8C0C-47E3-9584-E7BB6CD821FC
+fileId: "{E42B1499-8C0C-47E3-9584-E7BB6CD821FC}"
 filename: Standard.shader

--- a/Content/Shaders/Standard_glTF.shader.asset
+++ b/Content/Shaders/Standard_glTF.shader.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: 1A4BA353-FDA4-4F65-941F-D9FFEE4630A0
+fileId: "{1A4BA353-FDA4-4F65-941F-D9FFEE4630A0}"
 filename: Standard_glTF.shader

--- a/Content/Shaders/Stars.shader.asset
+++ b/Content/Shaders/Stars.shader.asset
@@ -1,3 +1,3 @@
 assetInfoType: Sailor::ShaderAssetInfo
-fileId: 6A7B8AC2-A515-40B8-A201-A8AA534F9710
+fileId: "{6A7B8AC2-A515-40B8-A201-A8AA534F9710}"
 filename: Stars.shader


### PR DESCRIPTION
Follow-up scope cleanup for #171, which was merged while its final audit was still running.

## Summary

Restore the six shader metadata UUID lines to their pre-#171 representation. The previous PR only changed these files mechanically by removing YAML braces; that normalization was unrelated to the editor/runtime/shader fixes and should not have been part of the content scope.

## Scope

Only these existing metadata files are touched:

- `Content/Shaders/Lighting.glsl.asset`
- `Content/Shaders/MotionBlur.shader.asset`
- `Content/Shaders/Sky.shader.asset`
- `Content/Shaders/Standard.shader.asset`
- `Content/Shaders/Standard_glTF.shader.asset`
- `Content/Shaders/Stars.shader.asset`

No source shader or runtime behavior changes.

## Validation

- exact diff audited: six one-line UUID representation restorations
- `git diff --check`
- dependencies synchronized with `python3 update_deps.py`

This PR is intentionally draft and must not be merged automatically.