### PR TITLE
Fix Forward+ depth synchronization

### DIFF
--- a/Content/Shaders/ComputeLightCulling.shader
+++ b/Content/Shaders/ComputeLightCulling.shader
@@ -127,8 +127,8 @@ glslCompute: |
 
       barrier();
 
-      // Read the depth-prepass pixel that belongs to this framebuffer tile and
-      // reconstruct positive view-space distance without another viewport pass.
+      // Read the depth-prepass pixel that belongs to this framebuffer tile from
+      // the R32F target produced by the graphics linearization pass.
       const bool isInsideViewport = all(lessThan(location, PushConstants.viewportSize));
       if (isInsideViewport)
       {

--- a/Content/Shaders/LinearizeDepth.shader
+++ b/Content/Shaders/LinearizeDepth.shader
@@ -53,16 +53,14 @@ glslFragment: |
     ivec2 depthSize = textureSize(depthSampler, 0);
     ivec2 pixel = clamp(ivec2(gl_FragCoord.xy), ivec2(0), depthSize - ivec2(1));
     float depth = texelFetch(depthSampler, pixel, 0).x;
-     vec4 vss = vec4(0, 0, depth, 1);
-     vec4 invVss = frame.invProjection * vss;
-     float zvs = invVss.z / invVss.w;
-
  #ifdef REVERSE_Z_INF_FAR_PLANE
-    float linearDepth = -frame.cameraZNearZFar.x / depth;
+    float linearDepth = frame.cameraZNearZFar.x / depth;
  #else
-    // The default camera uses a finite reverse-Z projection. Passing far/near
-    // restores the positive view-space distance, including clear depth at far.
-    float linearDepth = -LinearizeDepth(depth, frame.cameraZNearZFar.yx);
+    // Reconstruct from the same projection matrix that produced the depth.
+    // This remains exact when the camera projection parameters or conventions
+    // change and keeps the result in positive view-space distance.
+    vec4 viewPosition = frame.invProjection * vec4(0.0, 0.0, depth, 1.0);
+    float linearDepth = abs(viewPosition.z / viewPosition.w);
  #endif
-    outColor = vec4(-linearDepth);
+    outColor = vec4(linearDepth);
  }

--- a/Runtime/AssetRegistry/Texture/TextureImporter.cpp
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.cpp
@@ -627,6 +627,12 @@ bool TextureImporter::DecodeTextureCpu(FileId uid, ByteCode& decodedData,
 bool TextureImporter::LoadTexture_Immediate(FileId uid, TexturePtr& outTexture)
 {
 	auto task = LoadTexture(uid, outTexture);
+	if (!task)
+	{
+		outTexture = nullptr;
+		return false;
+	}
+
 	task->Wait();
 	return task->GetResult().IsValid();
 }

--- a/Runtime/FrameGraph/DepthPrepassNode.cpp
+++ b/Runtime/FrameGraph/DepthPrepassNode.cpp
@@ -21,12 +21,14 @@ const char* DepthPrepassNode::m_name = "DepthPrepass";
 RHI::RHIMaterialPtr DepthPrepassNode::GetOrAddDepthMaterial(
 	RHI::RHIVertexDescriptionPtr vertexDescription,
 	bool bSkinned,
-	bool bMasked)
+	bool bMasked,
+	RHI::ECullMode cullMode)
 {
 	auto& materials = bMasked ?
 		(bSkinned ? m_skinnedMaskedDepthOnlyMaterials : m_maskedDepthOnlyMaterials) :
 		(bSkinned ? m_skinnedDepthOnlyMaterials : m_depthOnlyMaterials);
-	auto& material = materials[vertexDescription->GetVertexAttributeBits()];
+	const DepthMaterialKey key{ vertexDescription->GetVertexAttributeBits(), cullMode };
+	auto& material = materials[key];
 
 	if (!material)
 	{
@@ -44,7 +46,6 @@ RHI::RHIMaterialPtr DepthPrepassNode::GetOrAddDepthMaterial(
 
 		if (App::GetSubmodule<ShaderCompiler>()->LoadShader_Immediate(shaderFileId->GetFileId(), pShader, defines) && pShader->IsReady())
 		{
-			const ECullMode cullMode = bMasked ? ECullMode::None : ECullMode::Back;
 			RenderState renderState = RHI::RenderState(true, true, 0.0f, false, cullMode, EBlendMode::None, EFillMode::Fill, GetHash(std::string("DepthOnly")), true);
 			material = RHI::Renderer::GetDriver()->CreateMaterial(vertexDescription, RHI::EPrimitiveTopology::TriangleList, renderState, pShader);
 		}
@@ -83,7 +84,6 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 			m_drawCalls.Clear();
 			m_batches.Clear();
 			Framegraph::Details::EvictTextureBindingCache(m_textureBindingCache, sceneViewSnapshot.m_frame);
-
 			for (auto& proxy : sceneViewSnapshot.m_proxies)
 			{
 				for (size_t i = 0; i < proxy.m_meshes.Num(); i++)
@@ -98,7 +98,8 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						continue;
 					}
 
-					if (proxy.GetMaterials()[i]->GetRenderState().GetTag() != QueueTagHash)
+					const auto& sourceMaterial = proxy.GetMaterials()[i];
+					if (sourceMaterial->GetRenderState().GetTag() != QueueTagHash)
 					{
 						continue;
 					}
@@ -112,13 +113,14 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 					auto depthMaterial = GetOrAddDepthMaterial(
 						mesh->m_vertexDescription,
 						bSkinned,
-						bMaskedQueue);
+						bMaskedQueue,
+						sourceMaterial->GetRenderState().GetCullMode());
 
 					const bool bRequiredCustomDepth = !bMaskedQueue &&
-						proxy.GetMaterials()[i]->GetRenderState().IsRequiredCustomDepthShader();
+						sourceMaterial->GetRenderState().IsRequiredCustomDepthShader();
 					if (bRequiredCustomDepth)
 					{
-						depthMaterial = proxy.GetMaterials()[i];
+						depthMaterial = sourceMaterial;
 					}
 
 					const bool bIsDepthMaterialReady = depthMaterial &&

--- a/Runtime/FrameGraph/DepthPrepassNode.h
+++ b/Runtime/FrameGraph/DepthPrepassNode.h
@@ -42,23 +42,42 @@ namespace Sailor
 		SAILOR_API RHI::ESortingOrder GetSortingOrder() const;
 
 	protected:
+		struct DepthMaterialKey
+		{
+			RHI::VertexAttributeBits m_vertexAttributes = 0u;
+			RHI::ECullMode m_cullMode = RHI::ECullMode::Back;
+
+			bool operator==(const DepthMaterialKey& rhs) const
+			{
+				return m_vertexAttributes == rhs.m_vertexAttributes &&
+					m_cullMode == rhs.m_cullMode;
+			}
+
+			size_t GetHash() const
+			{
+				size_t result = std::hash<RHI::VertexAttributeBits>{}(m_vertexAttributes);
+				HashCombine(result, static_cast<uint32_t>(m_cullMode));
+				return result;
+			}
+		};
 
 		uint32_t m_numMeshes = 0;
 		SpinLock m_syncSharedResources;
 		RHI::TDrawCalls<PerInstanceData> m_drawCalls;
 		TSet<RHI::RHIBatch> m_batches;
 
-		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_depthOnlyMaterials;
-		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedDepthOnlyMaterials;
-		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_maskedDepthOnlyMaterials;
-		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedMaskedDepthOnlyMaterials;
+		TMap<DepthMaterialKey, RHI::RHIMaterialPtr> m_depthOnlyMaterials;
+		TMap<DepthMaterialKey, RHI::RHIMaterialPtr> m_skinnedDepthOnlyMaterials;
+		TMap<DepthMaterialKey, RHI::RHIMaterialPtr> m_maskedDepthOnlyMaterials;
+		TMap<DepthMaterialKey, RHI::RHIMaterialPtr> m_skinnedMaskedDepthOnlyMaterials;
 		RHI::RHIShaderBindingSetPtr m_perInstanceData;
 		size_t m_sizePerInstanceData = 0;
 
 		RHI::RHIMaterialPtr GetOrAddDepthMaterial(
 			RHI::RHIVertexDescriptionPtr vertex,
 			bool bSkinned,
-			bool bMasked);
+			bool bMasked,
+			RHI::ECullMode cullMode);
 		TVector<RHI::RHIBufferPtr> m_indirectBuffers;
 
 		// Culling

--- a/Runtime/FrameGraph/LightCullingNode.cpp
+++ b/Runtime/FrameGraph/LightCullingNode.cpp
@@ -82,6 +82,9 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 		}
 
 		commands->ImageMemoryBarrier(commandList, linearDepthAttachment, RHI::EImageLayout::ShaderReadOnlyOptimal);
+		commands->MemoryBarrier(commandList,
+			static_cast<EAccessFlags>(EAccessBit::ColorAttachmentWrite_Bit),
+			static_cast<EAccessFlags>(EAccessBit::ShaderRead_Bit));
 		commands->Dispatch(commandList, computeShader,
 			pushConstants.m_numTiles.x, pushConstants.m_numTiles.y, 1,
 			{ sceneView.m_rhiLightsData, m_culledLights, sceneView.m_frameBindings },

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -91,7 +91,7 @@ namespace Sailor::RHI
 		Math::AABB m_worldAabb{};
 
 		bool m_bCastShadows{};
-		uint32_t m_skeletonOffset = 0;
+		uint32_t m_skeletonOffset = (std::numeric_limits<uint32_t>::max)();
 		size_t m_frame{};
 
 		TVector<RHIMeshPtr> m_meshes;

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1090,7 +1090,8 @@ namespace
 		Require(linearizeDepthShader.find("#ifdef REVERSE_Z_INF_FAR_PLANE") != std::string::npos &&
 			linearizeDepthShader.find("- REVERSE_Z_INF_FAR_PLANE") == std::string::npos &&
 			linearizeDepthShader.find("frame.cameraZNearZFar.x / depth") != std::string::npos &&
-			linearizeDepthShader.find("LinearizeDepth(depth, frame.cameraZNearZFar.yx)") != std::string::npos &&
+			linearizeDepthShader.find("frame.invProjection * vec4(0.0, 0.0, depth, 1.0)") != std::string::npos &&
+			linearizeDepthShader.find("abs(viewPosition.z / viewPosition.w)") != std::string::npos &&
 			linearizeDepthShader.find("texelFetch(depthSampler, pixel, 0)") != std::string::npos &&
 			linearizeDepthShader.find("fragTexcoord.y") == std::string::npos,
 			"linear depth must retain disabled infinite-far support while defaulting to finite reverse-Z in framebuffer coordinates");

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -18,6 +18,7 @@
 #include <functional>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <stdexcept>
 #include <string>
 #include <utility>
@@ -479,6 +480,14 @@ namespace
 			processBody.find("ImageMemoryBarrier(commandList, linearDepthAttachment", depthBindingOffset) != std::string::npos,
 			"Forward+ must sample the pre-linearized R32F depth target");
 		const size_t dispatchOffset = processBody.find("commands->Dispatch(");
+		const size_t depthBarrierOffset = processBody.find(
+			"commands->MemoryBarrier(",
+			depthBindingOffset);
+		Require(depthBarrierOffset != std::string::npos &&
+			depthBarrierOffset < dispatchOffset &&
+			processBody.find("EAccessBit::ColorAttachmentWrite_Bit", depthBarrierOffset) < dispatchOffset &&
+			processBody.find("EAccessBit::ShaderRead_Bit", depthBarrierOffset) < dispatchOffset,
+			"Forward+ compute sampling must wait for the linear-depth color attachment write");
 		const size_t barrierOffset = processBody.find(
 			"commands->MemoryBarrier(",
 			dispatchOffset);
@@ -897,6 +906,11 @@ namespace
 
 	void TestDepthPrepassSkinningContract()
 	{
+		const RHI::RHISceneViewProxy unskinnedProxy{};
+		Require(unskinnedProxy.m_skeletonOffset ==
+			(std::numeric_limits<uint32_t>::max)(),
+			"scene proxies without an animator must use the invalid skeleton offset so meshes with unused bone attributes stay rigid in the depth pass");
+
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string depthShader = ReadText(
 			sourceRoot / "Content/Shaders/DepthOnly.shader");
@@ -925,8 +939,12 @@ namespace
 			prepareBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding)") != std::string::npos &&
 			prepareBody.find("GetOrAddDepthMaterial(") != std::string::npos &&
 			prepareBody.find("bSkinned,") != std::string::npos &&
-			prepareBody.find("bMaskedQueue);") != std::string::npos,
+			prepareBody.find("bMaskedQueue,") != std::string::npos,
 			"DepthPrepass must select its skinned material from both the skeleton offset and the concrete mesh vertex layout");
+		Require(getDepthMaterialBody.find("DepthMaterialKey key") != std::string::npos &&
+			getDepthMaterialBody.find("cullMode") != std::string::npos &&
+			prepareBody.find("sourceMaterial->GetRenderState().GetCullMode()") != std::string::npos,
+			"DepthPrepass must preserve the source material cull mode so its depth contributors match the visible geometry");
 
 		Require(depthShader.find("- MASKED") != std::string::npos &&
 			depthShader.find("ResolveTextureSamplerIndex") != std::string::npos &&

--- a/build_editor.py
+++ b/build_editor.py
@@ -109,12 +109,39 @@ def remove_generated_imgui_ini(config: str, output: Path | None) -> None:
             print(f"Removed generated file before build: {imgui_ini}")
 
 
-def sync_engine_library(config: str, output: Path | None, runtime: str | None) -> None:
+def find_engine_library(config: str) -> Path | None:
     library_name = "Sailor-Debug.dylib" if config == "Debug" else "Sailor-Release.dylib"
-    source = REPO_ROOT / "build-mac-vcpkg" / "Lib" / config / library_name
-    if not source.exists():
-        print(f"Engine library was not found, skipping app sync: {source}")
+    library_root = REPO_ROOT / "build-mac-vcpkg" / "Lib"
+    candidates = [
+        library_root / library_name,
+        library_root / config / library_name,
+    ]
+    existing_candidates = [candidate for candidate in candidates if candidate.exists()]
+    if not existing_candidates:
+        print(f"Engine library was not found, skipping app sync: {candidates}")
+        return None
+    return max(existing_candidates, key=lambda candidate: candidate.stat().st_mtime_ns)
+
+
+def stage_engine_library(config: str) -> None:
+    source = find_engine_library(config)
+    if source is None:
         return
+
+    destination = REPO_ROOT / "build-mac-vcpkg" / "Lib" / config / source.name
+    if source.resolve() == destination.resolve():
+        return
+
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(source, destination)
+    print(f"Staged engine library for editor build: {destination}")
+
+
+def sync_engine_library(config: str, output: Path | None, runtime: str | None) -> None:
+    source = find_engine_library(config)
+    if source is None:
+        return
+    library_name = source.name
 
     search_roots = [
         REPO_ROOT / "Binaries" / "Editor" / config,
@@ -161,6 +188,7 @@ def main() -> int:
 
     maybe_build_engine(args.build_engine, args.config)
     remove_generated_imgui_ini(args.config, args.output)
+    stage_engine_library(args.config)
 
     dotnet = detect_dotnet()
     env = prepare_env(dotnet)


### PR DESCRIPTION
# Fix Forward+ depth synchronization

## Summary

- reconstruct linear depth from the active inverse projection in framebuffer coordinates
- preserve source material culling and rigid/skinned classification in the depth prepass
- synchronize the linear-depth color attachment write before Forward+ compute sampling
- add renderer contract coverage for depth reconstruction, depth material selection, and the targeted compute-read barrier
- fail safely when immediate texture loading cannot create an asynchronous load task
- locate and stage macOS engine libraries from both CMake output layouts before building the editor

## Root cause

Forward+ light culling sampled the current frame's linear-depth target from a compute shader, but the transition to the sampled layout only synchronized graphics shader stages. Under camera motion, a 16x16 light-culling workgroup could observe an unfinished depth tile and derive an incorrect tile depth range.

Depth-prepass mismatches could also be introduced when a generated depth material did not preserve the source material's cull mode or when a rigid proxy used a valid-looking default skeleton offset.

The editor build expected the engine dylib only under `Lib/<Config>/`, while the active CMake generator emitted it directly under `Lib/`. Immediate texture loading also dereferenced a missing load task on failed imports.

## Impact

Forward+ lighting no longer produces transient 16x16 blocks on thin geometry during rapid camera rotation. The synchronization is scoped to the linear-depth consumer instead of expanding every shader-read image transition.

## Validation

- `./Binaries/GpuCullingContractTests`
- Release C++ build of `GpuCullingContractTests` and `SailorLib`
- Release editor build and runtime visual reproduction: rapid camera rotation no longer produced 16x16 lighting artifacts
- Debug and Release editor builds with engine library staging

## Follow-up

- Performance comparison of the targeted barrier remains to be repeated after unrelated concurrent workload is stopped.
- Material-defined depth-prepass shader defines are intentionally out of scope.
