### PR TITLE
[Feature] Renderer asset Inspector view

### DIFF
--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -87,6 +87,7 @@
     <Compile Include="SceneDocumentContractTests.cs" />
     <Compile Include="WorldAssetRebindPolicyTests.cs" />
     <Compile Include="EngineLifecycleTests.cs" />
+    <Compile Include="FrameGraphDiagramLayoutTests.cs" />
     <Compile Include="WorldSnapshotPublicationGateTests.cs" />
     <Compile Include="LatestSceneViewportStateTests.cs" />
     <Compile Include="LatestQueuedCommandTests.cs" />
@@ -159,6 +160,7 @@
     <Compile Include="..\Editor\Workflow\WorkflowProjections.cs" Link="Workflow\WorkflowProjections.cs" />
     <Compile Include="..\Editor\Workflow\InspectorAutoCommitController.cs" Link="Workflow\InspectorAutoCommitController.cs" />
     <Compile Include="..\Editor\Workflow\InspectorPendingEditCoordinator.cs" Link="Workflow\InspectorPendingEditCoordinator.cs" />
+    <Compile Include="..\Editor\Workflow\FrameGraphDiagramLayout.cs" Link="Workflow\FrameGraphDiagramLayout.cs" />
     <Compile Include="..\Editor\Utility\EditorDragDrop.cs" Link="Utility\EditorDragDrop.cs" />
     <Compile Include="..\Editor\Utility\EditorPerf.cs" Link="Utility\EditorPerf.cs" />
     <Compile Include="..\Editor\Services\EngineLaunchContract.cs" Link="Services\EngineLaunchContract.cs" />

--- a/Editor.Tests/FrameGraphDiagramLayoutTests.cs
+++ b/Editor.Tests/FrameGraphDiagramLayoutTests.cs
@@ -1,0 +1,124 @@
+using SailorEditor.Workflow;
+
+namespace SailorEditor.Tests;
+
+public sealed class FrameGraphDiagramLayoutTests
+{
+    [Fact]
+    public void Arrange_PreservesFrameOrderAndConnectsAdjacentNodes()
+    {
+        var layout = FrameGraphDiagramLayout.Arrange(3);
+
+        Assert.Equal(3, layout.Nodes.Count);
+        Assert.Equal(2, layout.Connectors.Count);
+        Assert.Equal(new[] { 0, 1, 2 }, layout.Nodes.Select(node => node.Index));
+        Assert.True(layout.Nodes[0].Bounds.Right < layout.Nodes[1].Bounds.X);
+        Assert.True(layout.Nodes[1].Bounds.Right < layout.Nodes[2].Bounds.X);
+        Assert.Equal(0, layout.Connectors[0].FromIndex);
+        Assert.Equal(1, layout.Connectors[0].ToIndex);
+        Assert.Equal(layout.Nodes[0].Bounds.Right, layout.Connectors[0].Start.X);
+        Assert.Equal(layout.Nodes[1].Bounds.X, layout.Connectors[0].End.X);
+        Assert.True(layout.ContentWidth > FrameGraphDiagramLayout.MinimumWidth);
+    }
+
+    [Fact]
+    public void HitTest_ReturnsCardIndexAndRejectsConnectorSpace()
+    {
+        var layout = FrameGraphDiagramLayout.Arrange(2);
+        var first = layout.Nodes[0].Bounds;
+        var second = layout.Nodes[1].Bounds;
+
+        Assert.Equal(
+            0,
+            layout.HitTest(
+                first.X + first.Width * 0.5,
+                first.Y + first.Height * 0.5));
+        Assert.Equal(
+            1,
+            layout.HitTest(
+                second.X + second.Width * 0.5,
+                second.Y + second.Height * 0.5));
+        Assert.Equal(-1, layout.HitTest(first.Right + 1.0, first.Y));
+    }
+
+    [Fact]
+    public void Arrange_UsesStableEmptyStateAndRejectsNegativeCounts()
+    {
+        var layout = FrameGraphDiagramLayout.Arrange(0);
+
+        Assert.Empty(layout.Nodes);
+        Assert.Empty(layout.Connectors);
+        Assert.Equal(FrameGraphDiagramLayout.MinimumWidth, layout.ContentWidth);
+        Assert.Equal(-1, layout.HitTest(20.0, 20.0));
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            FrameGraphDiagramLayout.Arrange(-1));
+    }
+
+    [Fact]
+    public void Move_ReordersByReferenceAndClampsAtPipelineEnds()
+    {
+        var first = new object();
+        var second = new object();
+        var third = new object();
+        IList<object> nodes = new List<object> { first, second, third };
+
+        Assert.True(FrameGraphDiagramOrder.Move(nodes, second, 1));
+        Assert.Equal(new[] { first, third, second }, nodes);
+        Assert.False(FrameGraphDiagramOrder.Move(nodes, second, 1));
+        Assert.True(FrameGraphDiagramOrder.Move(nodes, second, -2));
+        Assert.Equal(new[] { second, first, third }, nodes);
+        Assert.False(FrameGraphDiagramOrder.Move(nodes, new object(), 1));
+    }
+
+    [Fact]
+    public void RendererInspector_UsesDiagramSelectionWithoutChangingYamlSchema()
+    {
+        var repositoryRoot = FindRepositoryRoot();
+        var inspector = File.ReadAllText(Path.Combine(
+            repositoryRoot,
+            "Editor",
+            "Views",
+            "InspectorView",
+            "FrameGraphFileTemplate.xaml"));
+        var viewModel = File.ReadAllText(Path.Combine(
+            repositoryRoot,
+            "Editor",
+            "ViewModels",
+            "FrameGraphFile.cs"));
+        var diagram = File.ReadAllText(Path.Combine(
+            repositoryRoot,
+            "Editor",
+            "Controls",
+            "FrameGraphDiagramView.cs"));
+
+        Assert.Contains("FrameGraphDiagramView", inspector, StringComparison.Ordinal);
+        Assert.Contains("SelectedNode", inspector, StringComparison.Ordinal);
+        Assert.Contains("MoveNodeEarlierCommand", inspector, StringComparison.Ordinal);
+        Assert.Contains("MoveNodeLaterCommand", inspector, StringComparison.Ordinal);
+        Assert.Contains("Global Vec4", inspector, StringComparison.Ordinal);
+        Assert.Contains("frameGraph.SelectedNode", diagram, StringComparison.Ordinal);
+        Assert.Contains("{ \"vec4\", WriteNamedVec4List(Vec4) }", viewModel, StringComparison.Ordinal);
+        Assert.Contains("Tag = ReadString(node, \"tag\")", viewModel, StringComparison.Ordinal);
+        Assert.Contains("node.Add(\"tag\", Tag)", viewModel, StringComparison.Ordinal);
+        Assert.Contains("Value.PropertyChanged += OnComponentChanged", viewModel, StringComparison.Ordinal);
+        Assert.DoesNotContain("editorX", viewModel, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("editorY", viewModel, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("editor", viewModel[viewModel.IndexOf("void SaveRendererAsset()", StringComparison.Ordinal)..viewModel.IndexOf("void TrackList", StringComparison.Ordinal)], StringComparison.OrdinalIgnoreCase);
+    }
+
+    static string FindRepositoryRoot()
+    {
+        var directory = new DirectoryInfo(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            if (File.Exists(Path.Combine(directory.FullName, "CMakeLists.txt")) &&
+                Directory.Exists(Path.Combine(directory.FullName, "Editor")))
+            {
+                return directory.FullName;
+            }
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException("Could not locate the Sailor repository root.");
+    }
+}

--- a/Editor/Controls/FrameGraphDiagramView.cs
+++ b/Editor/Controls/FrameGraphDiagramView.cs
@@ -1,0 +1,314 @@
+using SailorEditor.Utility;
+using SailorEditor.ViewModels;
+using SailorEditor.Workflow;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+namespace SailorEditor.Controls;
+
+public sealed class FrameGraphDiagramView : GraphicsView, IDrawable
+{
+    const float CardPadding = 10.0f;
+    const int VisibleBindingCount = 6;
+
+    FrameGraphFile? frameGraph;
+    ObservableList<FrameGraphNode>? subscribedNodes;
+    FrameGraphDiagramLayoutResult layout = FrameGraphDiagramLayout.Arrange(0);
+
+    public FrameGraphDiagramView()
+    {
+        Drawable = this;
+        BackgroundColor = Color.FromArgb("#171A1F");
+        StartInteraction += OnStartInteraction;
+        BindingContextChanged += (_, _) => BindFrameGraph(BindingContext as FrameGraphFile);
+        Loaded += (_, _) => BindFrameGraph(BindingContext as FrameGraphFile);
+        Unloaded += (_, _) => Detach();
+        UpdateLayout();
+    }
+
+    public void Draw(ICanvas canvas, RectF dirtyRect)
+    {
+        canvas.FillColor = Color.FromArgb("#171A1F");
+        canvas.FillRectangle(dirtyRect);
+        DrawGrid(canvas, dirtyRect);
+
+        if (frameGraph is null || frameGraph.Nodes.Count == 0)
+        {
+            canvas.FontColor = Color.FromArgb("#929AA5");
+            canvas.FontSize = 13.0f;
+            canvas.DrawString(
+                "No frame nodes. Add a node to start the pipeline.",
+                18.0f,
+                18.0f,
+                440.0f,
+                30.0f,
+                HorizontalAlignment.Left,
+                VerticalAlignment.Center);
+            return;
+        }
+
+        foreach (var connector in layout.Connectors)
+        {
+            DrawConnector(canvas, connector);
+        }
+
+        foreach (var nodeLayout in layout.Nodes)
+        {
+            DrawNode(canvas, nodeLayout, frameGraph.Nodes[nodeLayout.Index]);
+        }
+    }
+
+    void BindFrameGraph(FrameGraphFile? value)
+    {
+        if (ReferenceEquals(frameGraph, value) && subscribedNodes is not null)
+        {
+            return;
+        }
+
+        Unsubscribe();
+        frameGraph = value;
+        if (frameGraph is not null)
+        {
+            frameGraph.PropertyChanged += OnFrameGraphChanged;
+            SubscribeNodes(frameGraph.Nodes);
+        }
+        UpdateLayout();
+        Invalidate();
+    }
+
+    void Detach()
+    {
+        Unsubscribe();
+        frameGraph = null;
+    }
+
+    void SubscribeNodes(ObservableList<FrameGraphNode> nodes)
+    {
+        subscribedNodes = nodes;
+        subscribedNodes.CollectionChanged += OnNodesCollectionChanged;
+        subscribedNodes.ItemChanged += OnNodeChanged;
+    }
+
+    void Unsubscribe()
+    {
+        if (frameGraph is not null)
+        {
+            frameGraph.PropertyChanged -= OnFrameGraphChanged;
+        }
+        if (subscribedNodes is not null)
+        {
+            subscribedNodes.CollectionChanged -= OnNodesCollectionChanged;
+            subscribedNodes.ItemChanged -= OnNodeChanged;
+            subscribedNodes = null;
+        }
+    }
+
+    void OnFrameGraphChanged(object? sender, PropertyChangedEventArgs args)
+    {
+        if (frameGraph is not null &&
+            args.PropertyName == nameof(FrameGraphFile.Nodes) &&
+            !ReferenceEquals(subscribedNodes, frameGraph.Nodes))
+        {
+            if (subscribedNodes is not null)
+            {
+                subscribedNodes.CollectionChanged -= OnNodesCollectionChanged;
+                subscribedNodes.ItemChanged -= OnNodeChanged;
+            }
+            SubscribeNodes(frameGraph.Nodes);
+            UpdateLayout();
+        }
+
+        Invalidate();
+    }
+
+    void OnNodesCollectionChanged(object? sender, NotifyCollectionChangedEventArgs args)
+    {
+        UpdateLayout();
+        Invalidate();
+    }
+
+    void OnNodeChanged(object? sender, ItemChangedEventArgs<FrameGraphNode> args) =>
+        Invalidate();
+
+    void UpdateLayout()
+    {
+        layout = FrameGraphDiagramLayout.Arrange(frameGraph?.Nodes.Count ?? 0);
+        WidthRequest = layout.ContentWidth;
+        MinimumWidthRequest = layout.ContentWidth;
+        HeightRequest = layout.ContentHeight;
+    }
+
+    void OnStartInteraction(object? sender, TouchEventArgs args)
+    {
+        if (frameGraph is null || args.Touches.Length == 0)
+        {
+            return;
+        }
+
+        var point = args.Touches[0];
+        var nodeIndex = layout.HitTest(point.X, point.Y);
+        frameGraph.SelectedNode = nodeIndex >= 0 && nodeIndex < frameGraph.Nodes.Count
+            ? frameGraph.Nodes[nodeIndex]
+            : null;
+        Invalidate();
+    }
+
+    static void DrawGrid(ICanvas canvas, RectF bounds)
+    {
+        canvas.StrokeColor = Color.FromArgb("#252A32");
+        canvas.StrokeSize = 1.0f;
+        const float grid = 24.0f;
+        for (var x = 0.0f; x < bounds.Right; x += grid)
+        {
+            canvas.DrawLine(x, bounds.Top, x, bounds.Bottom);
+        }
+        for (var y = 0.0f; y < bounds.Bottom; y += grid)
+        {
+            canvas.DrawLine(bounds.Left, y, bounds.Right, y);
+        }
+    }
+
+    static void DrawConnector(
+        ICanvas canvas,
+        FrameGraphDiagramConnector connector)
+    {
+        var start = new PointF((float)connector.Start.X, (float)connector.Start.Y);
+        var end = new PointF((float)connector.End.X, (float)connector.End.Y);
+        canvas.StrokeColor = Color.FromArgb("#7E8B9D");
+        canvas.StrokeSize = 2.0f;
+        canvas.DrawLine(start, end);
+
+        const float arrow = 8.0f;
+        canvas.DrawLine(end, new PointF(end.X - arrow, end.Y - arrow * 0.55f));
+        canvas.DrawLine(end, new PointF(end.X - arrow, end.Y + arrow * 0.55f));
+    }
+
+    void DrawNode(
+        ICanvas canvas,
+        FrameGraphDiagramNodeLayout nodeLayout,
+        FrameGraphNode node)
+    {
+        var bounds = nodeLayout.Bounds;
+        var rect = new RectF(
+            (float)bounds.X,
+            (float)bounds.Y,
+            (float)bounds.Width,
+            (float)bounds.Height);
+        var isSelected = ReferenceEquals(frameGraph?.SelectedNode, node);
+
+        canvas.FillColor = isSelected
+            ? Color.FromArgb("#263C57")
+            : Color.FromArgb("#20252C");
+        canvas.FillRoundedRectangle(rect, 7.0f);
+        canvas.StrokeColor = isSelected
+            ? Color.FromArgb("#74A5E8")
+            : Color.FromArgb("#56606E");
+        canvas.StrokeSize = isSelected ? 2.0f : 1.0f;
+        canvas.DrawRoundedRectangle(rect, 7.0f);
+
+        canvas.FontColor = Color.FromArgb("#8FA2B8");
+        canvas.FontSize = 11.0f;
+        canvas.DrawString(
+            $"FRAME {nodeLayout.Index + 1}",
+            rect.X + CardPadding,
+            rect.Y + 7.0f,
+            rect.Width - CardPadding * 2,
+            18.0f,
+            HorizontalAlignment.Left,
+            VerticalAlignment.Center);
+
+        canvas.FontColor = Colors.White;
+        canvas.FontSize = 14.0f;
+        canvas.DrawString(
+            string.IsNullOrWhiteSpace(node.Name) ? "Unnamed Node" : node.Name,
+            rect.X + CardPadding,
+            rect.Y + 27.0f,
+            rect.Width - CardPadding * 2,
+            24.0f,
+            HorizontalAlignment.Left,
+            VerticalAlignment.Center);
+
+        canvas.FontColor = Color.FromArgb("#929AA5");
+        canvas.FontSize = 10.0f;
+        canvas.DrawString(
+            string.IsNullOrWhiteSpace(node.Tag)
+                ? "tag: node name"
+                : $"tag: {node.Tag}",
+            rect.X + CardPadding,
+            rect.Y + 48.0f,
+            rect.Width - CardPadding * 2,
+            17.0f,
+            HorizontalAlignment.Left,
+            VerticalAlignment.Center);
+
+        canvas.StrokeColor = Color.FromArgb("#3B424D");
+        canvas.StrokeSize = 1.0f;
+        canvas.DrawLine(
+            rect.X + CardPadding,
+            rect.Y + 70.0f,
+            rect.Right - CardPadding,
+            rect.Y + 70.0f);
+
+        canvas.FontSize = 11.0f;
+        var bindingY = rect.Y + 78.0f;
+        var visibleBindings = node.RenderTargets.Take(VisibleBindingCount).ToArray();
+        foreach (var binding in visibleBindings)
+        {
+            canvas.FontColor = Color.FromArgb("#9BB9DC");
+            canvas.DrawString(
+                binding.Key ?? string.Empty,
+                rect.X + CardPadding,
+                bindingY,
+                78.0f,
+                20.0f,
+                HorizontalAlignment.Left,
+                VerticalAlignment.Center);
+            canvas.FontColor = Color.FromArgb("#D8DEE8");
+            canvas.DrawString(
+                $"→ {binding.Value}",
+                rect.X + 88.0f,
+                bindingY,
+                rect.Width - 98.0f,
+                20.0f,
+                HorizontalAlignment.Left,
+                VerticalAlignment.Center);
+            bindingY += 22.0f;
+        }
+
+        if (node.RenderTargets.Count > visibleBindings.Length)
+        {
+            canvas.FontColor = Color.FromArgb("#929AA5");
+            canvas.DrawString(
+                $"+{node.RenderTargets.Count - visibleBindings.Length} bindings",
+                rect.X + CardPadding,
+                bindingY,
+                rect.Width - CardPadding * 2,
+                20.0f,
+                HorizontalAlignment.Left,
+                VerticalAlignment.Center);
+        }
+        else if (node.RenderTargets.Count == 0)
+        {
+            canvas.FontColor = Color.FromArgb("#747D89");
+            canvas.DrawString(
+                "No resource bindings",
+                rect.X + CardPadding,
+                bindingY,
+                rect.Width - CardPadding * 2,
+                20.0f,
+                HorizontalAlignment.Left,
+                VerticalAlignment.Center);
+        }
+
+        canvas.FontColor = Color.FromArgb("#929AA5");
+        canvas.FontSize = 10.5f;
+        canvas.DrawString(
+            $"{node.Strings.Count} strings  ·  {node.Floats.Count} floats  ·  {node.Vec4.Count} vec4",
+            rect.X + CardPadding,
+            rect.Bottom - 31.0f,
+            rect.Width - CardPadding * 2,
+            20.0f,
+            HorizontalAlignment.Left,
+            VerticalAlignment.Center);
+    }
+}

--- a/Editor/ViewModels/FrameGraphFile.cs
+++ b/Editor/ViewModels/FrameGraphFile.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using SailorEditor.Utility;
+using SailorEditor.Workflow;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Globalization;
@@ -17,10 +18,18 @@ public partial class FrameGraphFile : AssetFile
     ObservableList<FrameGraphScalar> floats = [];
 
     [ObservableProperty]
+    ObservableList<FrameGraphVec4Value> vec4 = [];
+
+    [ObservableProperty]
     ObservableList<FrameGraphRenderTarget> renderTargets = [];
 
     [ObservableProperty]
     ObservableList<FrameGraphNode> nodes = [];
+
+    [ObservableProperty]
+    FrameGraphNode? selectedNode;
+
+    public bool HasSelectedNode => SelectedNode is not null;
 
     public FrameGraphFile()
     {
@@ -32,13 +41,28 @@ public partial class FrameGraphFile : AssetFile
         RemoveFloatCommand = new Command<FrameGraphScalar>(value => Floats.Remove(value));
         ClearFloatsCommand = new Command(() => Floats.Clear());
 
+        AddVec4Command = new Command(() => Vec4.Add(new FrameGraphVec4Value()));
+        RemoveVec4Command = new Command<FrameGraphVec4Value>(value => Vec4.Remove(value));
+        ClearVec4Command = new Command(() => Vec4.Clear());
+
         AddRenderTargetCommand = new Command(() => RenderTargets.Add(new FrameGraphRenderTarget()));
         RemoveRenderTargetCommand = new Command<FrameGraphRenderTarget>(target => RenderTargets.Remove(target));
         ClearRenderTargetsCommand = new Command(() => RenderTargets.Clear());
 
-        AddNodeCommand = new Command(() => Nodes.Add(new FrameGraphNode()));
-        RemoveNodeCommand = new Command<FrameGraphNode>(node => Nodes.Remove(node));
-        ClearNodesCommand = new Command(() => Nodes.Clear());
+        AddNodeCommand = new Command(() =>
+        {
+            var node = new FrameGraphNode();
+            Nodes.Add(node);
+            SelectedNode = node;
+        });
+        RemoveNodeCommand = new Command<FrameGraphNode>(RemoveNode);
+        ClearNodesCommand = new Command(() =>
+        {
+            Nodes.Clear();
+            SelectedNode = null;
+        });
+        MoveNodeEarlierCommand = new Command<FrameGraphNode>(node => MoveNode(node, -1));
+        MoveNodeLaterCommand = new Command<FrameGraphNode>(node => MoveNode(node, 1));
     }
 
     public ICommand AddSamplerCommand { get; }
@@ -47,12 +71,55 @@ public partial class FrameGraphFile : AssetFile
     public ICommand AddFloatCommand { get; }
     public ICommand RemoveFloatCommand { get; }
     public ICommand ClearFloatsCommand { get; }
+    public ICommand AddVec4Command { get; }
+    public ICommand RemoveVec4Command { get; }
+    public ICommand ClearVec4Command { get; }
     public ICommand AddRenderTargetCommand { get; }
     public ICommand RemoveRenderTargetCommand { get; }
     public ICommand ClearRenderTargetsCommand { get; }
     public ICommand AddNodeCommand { get; }
     public ICommand RemoveNodeCommand { get; }
     public ICommand ClearNodesCommand { get; }
+    public ICommand MoveNodeEarlierCommand { get; }
+    public ICommand MoveNodeLaterCommand { get; }
+
+    partial void OnSelectedNodeChanged(FrameGraphNode? value) =>
+        OnPropertyChanged(nameof(HasSelectedNode));
+
+    partial void OnNodesChanged(ObservableList<FrameGraphNode> value)
+    {
+        if (SelectedNode is not null && !value.Contains(SelectedNode))
+        {
+            SelectedNode = null;
+        }
+    }
+
+    void RemoveNode(FrameGraphNode? node)
+    {
+        if (node is null)
+        {
+            return;
+        }
+
+        var index = Nodes.IndexOf(node);
+        if (index < 0)
+        {
+            return;
+        }
+
+        Nodes.RemoveAt(index);
+        SelectedNode = Nodes.Count == 0
+            ? null
+            : Nodes[Math.Min(index, Nodes.Count - 1)];
+    }
+
+    void MoveNode(FrameGraphNode? node, int offset)
+    {
+        if (FrameGraphDiagramOrder.Move(Nodes, node, offset))
+        {
+            SelectedNode = node;
+        }
+    }
 
     public override Task Save()
     {
@@ -93,11 +160,13 @@ public partial class FrameGraphFile : AssetFile
         var root = stream.Documents.Count > 0 ? stream.Documents[0].RootNode as YamlMappingNode : null;
         Samplers = ReadList(root, "samplers", FrameGraphSampler.FromYaml);
         Floats = ReadNamedScalarList(root, "float");
+        Vec4 = ReadNamedVec4List(root, "vec4");
         RenderTargets = ReadList(root, "renderTargets", FrameGraphRenderTarget.FromYaml);
         Nodes = ReadList(root, "frame", FrameGraphNode.FromYaml);
 
         TrackList(Samplers, nameof(Samplers));
         TrackList(Floats, nameof(Floats));
+        TrackList(Vec4, nameof(Vec4));
         TrackList(RenderTargets, nameof(RenderTargets));
         TrackList(Nodes, nameof(Nodes));
     }
@@ -108,6 +177,7 @@ public partial class FrameGraphFile : AssetFile
         {
             { "samplers", WriteList(Samplers, sampler => sampler.ToYaml()) },
             { "float", WriteNamedScalarList(Floats) },
+            { "vec4", WriteNamedVec4List(Vec4) },
             { "renderTargets", WriteList(RenderTargets, target => target.ToYaml()) },
             { "frame", WriteList(Nodes, node => node.ToYaml()) }
         };
@@ -166,6 +236,30 @@ public partial class FrameGraphFile : AssetFile
         return result;
     }
 
+    static ObservableList<FrameGraphVec4Value> ReadNamedVec4List(YamlMappingNode root, string name)
+    {
+        var result = new ObservableList<FrameGraphVec4Value>();
+        if (root?.Children.TryGetValue(new YamlScalarNode(name), out var node) != true ||
+            node is not YamlSequenceNode sequence)
+        {
+            return result;
+        }
+
+        foreach (var item in sequence.Children.OfType<YamlMappingNode>())
+        {
+            foreach (var entry in item.Children)
+            {
+                result.Add(new FrameGraphVec4Value
+                {
+                    Key = ScalarToString(entry.Key),
+                    Value = FrameGraphVec4.FromYaml(entry.Value)
+                });
+            }
+        }
+
+        return result;
+    }
+
     static YamlSequenceNode WriteList<T>(IEnumerable<T> values, Func<T, YamlMappingNode> serialize)
     {
         var sequence = new YamlSequenceNode();
@@ -182,6 +276,19 @@ public partial class FrameGraphFile : AssetFile
         foreach (var value in values)
         {
             sequence.Add(new YamlMappingNode { { value.Key ?? string.Empty, Scalar(value.Value) } });
+        }
+        return sequence;
+    }
+
+    static YamlSequenceNode WriteNamedVec4List(IEnumerable<FrameGraphVec4Value> values)
+    {
+        var sequence = new YamlSequenceNode();
+        foreach (var value in values)
+        {
+            sequence.Add(new YamlMappingNode
+            {
+                { value.Key ?? string.Empty, value.Value?.ToYaml() ?? new FrameGraphVec4().ToYaml() }
+            });
         }
         return sequence;
     }
@@ -365,11 +472,25 @@ public partial class FrameGraphVec4 : ObservableObject
 
 public partial class FrameGraphVec4Value : ObservableObject
 {
+    public FrameGraphVec4Value()
+    {
+        Value.PropertyChanged += OnComponentChanged;
+    }
+
     [ObservableProperty]
     string key = string.Empty;
 
     [ObservableProperty]
     FrameGraphVec4 value = new();
+
+    partial void OnValueChanging(FrameGraphVec4 value) =>
+        Value.PropertyChanged -= OnComponentChanged;
+
+    partial void OnValueChanged(FrameGraphVec4 value) =>
+        value.PropertyChanged += OnComponentChanged;
+
+    void OnComponentChanged(object? sender, PropertyChangedEventArgs args) =>
+        OnPropertyChanged(nameof(Value));
 }
 
 public partial class FrameGraphTargetBinding : ObservableObject
@@ -385,6 +506,9 @@ public partial class FrameGraphNode : ObservableObject
 {
     [ObservableProperty]
     string name = string.Empty;
+
+    [ObservableProperty]
+    string tag = string.Empty;
 
     public FrameGraphNode()
     {
@@ -430,7 +554,11 @@ public partial class FrameGraphNode : ObservableObject
 
     public static FrameGraphNode FromYaml(YamlMappingNode node)
     {
-        var result = new FrameGraphNode { Name = ReadString(node, "name") };
+        var result = new FrameGraphNode
+        {
+            Name = ReadString(node, "name"),
+            Tag = ReadString(node, "tag")
+        };
         ReadNamedScalarList(node, "string", result.Strings);
         ReadNamedScalarList(node, "float", result.Floats);
         ReadVec4List(node, result.Vec4);
@@ -441,6 +569,10 @@ public partial class FrameGraphNode : ObservableObject
     public YamlMappingNode ToYaml()
     {
         var node = new YamlMappingNode { { "name", Name ?? string.Empty } };
+        if (!string.IsNullOrWhiteSpace(Tag))
+        {
+            node.Add("tag", Tag);
+        }
         AddNamedScalarList(node, "string", Strings);
         AddNamedScalarList(node, "float", Floats);
         AddVec4List(node, Vec4);

--- a/Editor/Views/InspectorView/FrameGraphFileTemplate.xaml
+++ b/Editor/Views/InspectorView/FrameGraphFileTemplate.xaml
@@ -9,185 +9,401 @@
 
     <VerticalStackLayout x:Name="Root" Spacing="10">
         <VerticalStackLayout.Resources>
-            <controls:FloatValueConverter x:Key="FloatValueConverter"/>
+            <controls:FloatValueConverter x:Key="FloatValueConverter" />
         </VerticalStackLayout.Resources>
 
         <views:ControlPanelView />
 
-        <Label Text="Samplers" FontAttributes="Bold" />
-        <HorizontalStackLayout>
-            <Button Text="+" Command="{Binding AddSamplerCommand}" />
-            <Button Text="Clear" Command="{Binding ClearSamplersCommand}" />
+        <Label Text="Frame Pipeline" FontAttributes="Bold" FontSize="16" />
+        <HorizontalStackLayout Spacing="6">
+            <Button Text="Add Node" Command="{Binding AddNodeCommand}" />
+            <Button Text="Earlier"
+                    Command="{Binding MoveNodeEarlierCommand}"
+                    CommandParameter="{Binding SelectedNode}"
+                    IsEnabled="{Binding HasSelectedNode}" />
+            <Button Text="Later"
+                    Command="{Binding MoveNodeLaterCommand}"
+                    CommandParameter="{Binding SelectedNode}"
+                    IsEnabled="{Binding HasSelectedNode}" />
+            <Button Text="Delete"
+                    Command="{Binding RemoveNodeCommand}"
+                    CommandParameter="{Binding SelectedNode}"
+                    IsEnabled="{Binding HasSelectedNode}" />
         </HorizontalStackLayout>
-        <CollectionView ItemsSource="{Binding Samplers}">
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="vm:FrameGraphSampler">
-                    <Grid ColumnSpacing="6" Padding="0,2">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="130" />
-                            <ColumnDefinition Width="170" />
-                            <ColumnDefinition Width="260" />
-                        </Grid.ColumnDefinitions>
-                        <Button Grid.Column="0" Text="-" Command="{Binding BindingContext.RemoveSamplerCommand, Source={x:Reference Root}}" CommandParameter="{Binding .}" />
-                        <Entry Grid.Column="1" Text="{Binding Name}" Placeholder="name" ReturnType="Done" Completed="OnEntryCompleted" />
-                        <Entry Grid.Column="2" Text="{Binding FileId}" Placeholder="fileId" ReturnType="Done" Completed="OnEntryCompleted" />
-                        <Entry Grid.Column="3" Text="{Binding Path}" Placeholder="path" ReturnType="Done" Completed="OnEntryCompleted" />
-                    </Grid>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
 
-        <Label Text="Global Floats" FontAttributes="Bold" />
-        <HorizontalStackLayout>
-            <Button Text="+" Command="{Binding AddFloatCommand}" />
-            <Button Text="Clear" Command="{Binding ClearFloatsCommand}" />
-        </HorizontalStackLayout>
-        <CollectionView ItemsSource="{Binding Floats}">
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="vm:FrameGraphScalar">
-                    <HorizontalStackLayout Spacing="6">
-                        <Button Text="-" Command="{Binding BindingContext.RemoveFloatCommand, Source={x:Reference Root}}" CommandParameter="{Binding .}" />
-                        <Entry Text="{Binding Key}" WidthRequest="180" Placeholder="name" ReturnType="Done" Completed="OnEntryCompleted" />
-                        <Entry Text="{Binding Value}" WidthRequest="180" Placeholder="value" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric" />
+        <ScrollView Orientation="Horizontal"
+                    HorizontalScrollBarVisibility="Always">
+            <controls:FrameGraphDiagramView BindingContext="{Binding .}"
+                                            HorizontalOptions="Start" />
+        </ScrollView>
+        <Label Text="Cards follow serialized frame order. Select a card to edit its bindings and parameters."
+               FontSize="11"
+               TextColor="#929AA5" />
+
+        <Border Stroke="#3B424D"
+                BackgroundColor="#1D2229"
+                Padding="10"
+                IsVisible="{Binding HasSelectedNode}">
+            <VerticalStackLayout x:Name="SelectedNodeEditor"
+                                 x:DataType="vm:FrameGraphNode"
+                                 BindingContext="{Binding BindingContext.SelectedNode, Source={x:Reference Root}}"
+                                 Spacing="8">
+                <Label Text="Selected Node" FontAttributes="Bold" FontSize="14" />
+                <Entry Text="{Binding Name}"
+                       Placeholder="node name"
+                       FontAttributes="Bold"
+                       ReturnType="Done"
+                       Completed="OnEntryCompleted" />
+                <Entry Text="{Binding Tag}"
+                       Placeholder="optional runtime tag (defaults to node name)"
+                       ReturnType="Done"
+                       Completed="OnEntryCompleted" />
+
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                    <Label Text="Render Target Bindings"
+                           FontAttributes="Bold"
+                           FontSize="12"
+                           VerticalTextAlignment="Center" />
+                    <HorizontalStackLayout Grid.Column="1" Spacing="4">
+                        <Button Text="+" Command="{Binding AddRenderTargetCommand}" />
+                        <Button Text="Clear" Command="{Binding ClearRenderTargetsCommand}" />
                     </HorizontalStackLayout>
+                </Grid>
+                <VerticalStackLayout BindableLayout.ItemsSource="{Binding RenderTargets}" Spacing="4">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="vm:FrameGraphTargetBinding">
+                            <Grid ColumnDefinitions="Auto,*,*" ColumnSpacing="6">
+                                <Button Text="-"
+                                        Command="{Binding BindingContext.SelectedNode.RemoveRenderTargetCommand, Source={x:Reference Root}}"
+                                        CommandParameter="{Binding .}" />
+                                <Entry Grid.Column="1"
+                                       Text="{Binding Key}"
+                                       Placeholder="slot"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                                <Entry Grid.Column="2"
+                                       Text="{Binding Value}"
+                                       Placeholder="resource"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                            </Grid>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                    <Label Text="Strings"
+                           FontAttributes="Bold"
+                           FontSize="12"
+                           VerticalTextAlignment="Center" />
+                    <HorizontalStackLayout Grid.Column="1" Spacing="4">
+                        <Button Text="+" Command="{Binding AddStringCommand}" />
+                        <Button Text="Clear" Command="{Binding ClearStringsCommand}" />
+                    </HorizontalStackLayout>
+                </Grid>
+                <VerticalStackLayout BindableLayout.ItemsSource="{Binding Strings}" Spacing="4">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="vm:FrameGraphScalar">
+                            <Grid ColumnDefinitions="Auto,*,*" ColumnSpacing="6">
+                                <Button Text="-"
+                                        Command="{Binding BindingContext.SelectedNode.RemoveStringCommand, Source={x:Reference Root}}"
+                                        CommandParameter="{Binding .}" />
+                                <Entry Grid.Column="1"
+                                       Text="{Binding Key}"
+                                       Placeholder="name"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                                <Entry Grid.Column="2"
+                                       Text="{Binding Value}"
+                                       Placeholder="value"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                            </Grid>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                    <Label Text="Floats"
+                           FontAttributes="Bold"
+                           FontSize="12"
+                           VerticalTextAlignment="Center" />
+                    <HorizontalStackLayout Grid.Column="1" Spacing="4">
+                        <Button Text="+" Command="{Binding AddFloatCommand}" />
+                        <Button Text="Clear" Command="{Binding ClearFloatsCommand}" />
+                    </HorizontalStackLayout>
+                </Grid>
+                <VerticalStackLayout BindableLayout.ItemsSource="{Binding Floats}" Spacing="4">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="vm:FrameGraphScalar">
+                            <Grid ColumnDefinitions="Auto,*,*" ColumnSpacing="6">
+                                <Button Text="-"
+                                        Command="{Binding BindingContext.SelectedNode.RemoveFloatCommand, Source={x:Reference Root}}"
+                                        CommandParameter="{Binding .}" />
+                                <Entry Grid.Column="1"
+                                       Text="{Binding Key}"
+                                       Placeholder="name"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                                <Entry Grid.Column="2"
+                                       Text="{Binding Value}"
+                                       Placeholder="value"
+                                       Keyboard="Numeric"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                            </Grid>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+                    <Label Text="Vec4"
+                           FontAttributes="Bold"
+                           FontSize="12"
+                           VerticalTextAlignment="Center" />
+                    <HorizontalStackLayout Grid.Column="1" Spacing="4">
+                        <Button Text="+" Command="{Binding AddVec4Command}" />
+                        <Button Text="Clear" Command="{Binding ClearVec4Command}" />
+                    </HorizontalStackLayout>
+                </Grid>
+                <VerticalStackLayout BindableLayout.ItemsSource="{Binding Vec4}" Spacing="4">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="vm:FrameGraphVec4Value">
+                            <VerticalStackLayout Spacing="4">
+                                <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6">
+                                    <Button Text="-"
+                                            Command="{Binding BindingContext.SelectedNode.RemoveVec4Command, Source={x:Reference Root}}"
+                                            CommandParameter="{Binding .}" />
+                                    <Entry Grid.Column="1"
+                                           Text="{Binding Key}"
+                                           Placeholder="name"
+                                           ReturnType="Done"
+                                           Completed="OnEntryCompleted" />
+                                </Grid>
+                                <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="4" Margin="38,0,0,0">
+                                    <Entry Text="{Binding Value.X, Converter={StaticResource FloatValueConverter}}"
+                                           Placeholder="X"
+                                           Keyboard="Numeric"
+                                           ReturnType="Done"
+                                           Completed="OnEntryCompleted" />
+                                    <Entry Grid.Column="1"
+                                           Text="{Binding Value.Y, Converter={StaticResource FloatValueConverter}}"
+                                           Placeholder="Y"
+                                           Keyboard="Numeric"
+                                           ReturnType="Done"
+                                           Completed="OnEntryCompleted" />
+                                    <Entry Grid.Column="2"
+                                           Text="{Binding Value.Z, Converter={StaticResource FloatValueConverter}}"
+                                           Placeholder="Z"
+                                           Keyboard="Numeric"
+                                           ReturnType="Done"
+                                           Completed="OnEntryCompleted" />
+                                    <Entry Grid.Column="3"
+                                           Text="{Binding Value.W, Converter={StaticResource FloatValueConverter}}"
+                                           Placeholder="W"
+                                           Keyboard="Numeric"
+                                           ReturnType="Done"
+                                           Completed="OnEntryCompleted" />
+                                </Grid>
+                            </VerticalStackLayout>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+            </VerticalStackLayout>
+        </Border>
+
+        <Label Text="Renderer Resources" FontAttributes="Bold" FontSize="16" Margin="0,6,0,0" />
+
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+            <Label Text="Samplers" FontAttributes="Bold" VerticalTextAlignment="Center" />
+            <HorizontalStackLayout Grid.Column="1" Spacing="4">
+                <Button Text="+" Command="{Binding AddSamplerCommand}" />
+                <Button Text="Clear" Command="{Binding ClearSamplersCommand}" />
+            </HorizontalStackLayout>
+        </Grid>
+        <VerticalStackLayout BindableLayout.ItemsSource="{Binding Samplers}" Spacing="6">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate x:DataType="vm:FrameGraphSampler">
+                    <Border Stroke="#3B424D" Padding="8">
+                        <VerticalStackLayout Spacing="4">
+                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6">
+                                <Button Text="-"
+                                        Command="{Binding BindingContext.RemoveSamplerCommand, Source={x:Reference Root}}"
+                                        CommandParameter="{Binding .}" />
+                                <Entry Grid.Column="1"
+                                       Text="{Binding Name}"
+                                       Placeholder="sampler name"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                            </Grid>
+                            <Entry Text="{Binding FileId}"
+                                   Placeholder="fileId"
+                                   ReturnType="Done"
+                                   Completed="OnEntryCompleted" />
+                            <Entry Text="{Binding Path}"
+                                   Placeholder="asset path"
+                                   ReturnType="Done"
+                                   Completed="OnEntryCompleted" />
+                        </VerticalStackLayout>
+                    </Border>
                 </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
+            </BindableLayout.ItemTemplate>
+        </VerticalStackLayout>
 
-        <Label Text="Render Targets" FontAttributes="Bold" />
-        <HorizontalStackLayout>
-            <Button Text="+" Command="{Binding AddRenderTargetCommand}" />
-            <Button Text="Clear" Command="{Binding ClearRenderTargetsCommand}" />
-        </HorizontalStackLayout>
-        <CollectionView ItemsSource="{Binding RenderTargets}">
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="vm:FrameGraphRenderTarget">
-                    <Grid ColumnSpacing="6" RowSpacing="4" Padding="0,4">
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="130" />
-                            <ColumnDefinition Width="160" />
-                            <ColumnDefinition Width="140" />
-                            <ColumnDefinition Width="140" />
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-
-                        <Button Grid.RowSpan="3" Grid.Column="0" Text="-" Command="{Binding BindingContext.RemoveRenderTargetCommand, Source={x:Reference Root}}" CommandParameter="{Binding .}" />
-                        <Entry Grid.Column="1" Text="{Binding Name}" Placeholder="name" ReturnType="Done" Completed="OnEntryCompleted" />
-                        <Entry Grid.Column="2" Text="{Binding Format}" Placeholder="format" ReturnType="Done" Completed="OnEntryCompleted" />
-                        <Entry Grid.Column="3" Text="{Binding Width}" Placeholder="width" ReturnType="Done" Completed="OnEntryCompleted" />
-                        <Entry Grid.Column="4" Text="{Binding Height}" Placeholder="height" ReturnType="Done" Completed="OnEntryCompleted" />
-
-                        <Entry Grid.Row="1" Grid.Column="1" Text="{Binding Clamping}" Placeholder="clamping" ReturnType="Done" Completed="OnEntryCompleted" />
-                        <Entry Grid.Row="1" Grid.Column="2" Text="{Binding Filtration}" Placeholder="filtration" ReturnType="Done" Completed="OnEntryCompleted" />
-                        <Entry Grid.Row="1" Grid.Column="3" Text="{Binding Reduction}" Placeholder="reduction" ReturnType="Done" Completed="OnEntryCompleted" />
-                        <Entry Grid.Row="1" Grid.Column="4" Text="{Binding MaxMipLevel}" Placeholder="max mip" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric" />
-
-                        <HorizontalStackLayout Grid.Row="2" Grid.Column="1" Grid.ColumnSpan="4" Spacing="10">
-                            <Label Text="Surface" VerticalOptions="Center" />
-                            <CheckBox IsChecked="{Binding IsSurface}" />
-                            <Label Text="Compute" VerticalOptions="Center" />
-                            <CheckBox IsChecked="{Binding IsCompatibleWithComputeShaders}" />
-                            <Label Text="Mips" VerticalOptions="Center" />
-                            <CheckBox IsChecked="{Binding GenerateMips}" />
-                        </HorizontalStackLayout>
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+            <Label Text="Global Floats" FontAttributes="Bold" VerticalTextAlignment="Center" />
+            <HorizontalStackLayout Grid.Column="1" Spacing="4">
+                <Button Text="+" Command="{Binding AddFloatCommand}" />
+                <Button Text="Clear" Command="{Binding ClearFloatsCommand}" />
+            </HorizontalStackLayout>
+        </Grid>
+        <VerticalStackLayout BindableLayout.ItemsSource="{Binding Floats}" Spacing="4">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate x:DataType="vm:FrameGraphScalar">
+                    <Grid ColumnDefinitions="Auto,*,*" ColumnSpacing="6">
+                        <Button Text="-"
+                                Command="{Binding BindingContext.RemoveFloatCommand, Source={x:Reference Root}}"
+                                CommandParameter="{Binding .}" />
+                        <Entry Grid.Column="1"
+                               Text="{Binding Key}"
+                               Placeholder="name"
+                               ReturnType="Done"
+                               Completed="OnEntryCompleted" />
+                        <Entry Grid.Column="2"
+                               Text="{Binding Value}"
+                               Placeholder="value"
+                               Keyboard="Numeric"
+                               ReturnType="Done"
+                               Completed="OnEntryCompleted" />
                     </Grid>
                 </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
+            </BindableLayout.ItemTemplate>
+        </VerticalStackLayout>
 
-        <Label Text="Frame Nodes" FontAttributes="Bold" />
-        <HorizontalStackLayout>
-            <Button Text="+" Command="{Binding AddNodeCommand}" />
-            <Button Text="Clear" Command="{Binding ClearNodesCommand}" />
-        </HorizontalStackLayout>
-        <CollectionView ItemsSource="{Binding Nodes}">
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="vm:FrameGraphNode">
-                    <VerticalStackLayout Spacing="6" Padding="0,8">
-                        <HorizontalStackLayout Spacing="6">
-                            <Button Text="-" Command="{Binding BindingContext.RemoveNodeCommand, Source={x:Reference Root}}" CommandParameter="{Binding .}" />
-                            <Entry Text="{Binding Name}" WidthRequest="220" Placeholder="node name" FontAttributes="Bold" ReturnType="Done" Completed="OnEntryCompleted" />
-                        </HorizontalStackLayout>
-
-                        <Label Text="Render Targets" FontAttributes="Bold" FontSize="12" />
-                        <HorizontalStackLayout>
-                            <Button Text="+" Command="{Binding AddRenderTargetCommand}" />
-                            <Button Text="Clear" Command="{Binding ClearRenderTargetsCommand}" />
-                        </HorizontalStackLayout>
-                        <CollectionView ItemsSource="{Binding RenderTargets}">
-                            <CollectionView.ItemTemplate>
-                                <DataTemplate x:DataType="vm:FrameGraphTargetBinding">
-                                    <HorizontalStackLayout Spacing="6">
-                                        <Button Text="-" Command="{Binding Path=BindingContext.RemoveRenderTargetCommand, Source={RelativeSource AncestorType={x:Type VerticalStackLayout}}}" CommandParameter="{Binding .}" />
-                                        <Entry Text="{Binding Key}" WidthRequest="160" Placeholder="slot" ReturnType="Done" Completed="OnEntryCompleted" />
-                                        <Entry Text="{Binding Value}" WidthRequest="220" Placeholder="target" ReturnType="Done" Completed="OnEntryCompleted" />
-                                    </HorizontalStackLayout>
-                                </DataTemplate>
-                            </CollectionView.ItemTemplate>
-                        </CollectionView>
-
-                        <Label Text="Strings" FontAttributes="Bold" FontSize="12" />
-                        <HorizontalStackLayout>
-                            <Button Text="+" Command="{Binding AddStringCommand}" />
-                            <Button Text="Clear" Command="{Binding ClearStringsCommand}" />
-                        </HorizontalStackLayout>
-                        <CollectionView ItemsSource="{Binding Strings}">
-                            <CollectionView.ItemTemplate>
-                                <DataTemplate x:DataType="vm:FrameGraphScalar">
-                                    <HorizontalStackLayout Spacing="6">
-                                        <Button Text="-" Command="{Binding Path=BindingContext.RemoveStringCommand, Source={RelativeSource AncestorType={x:Type VerticalStackLayout}}}" CommandParameter="{Binding .}" />
-                                        <Entry Text="{Binding Key}" WidthRequest="180" Placeholder="name" ReturnType="Done" Completed="OnEntryCompleted" />
-                                        <Entry Text="{Binding Value}" WidthRequest="260" Placeholder="value" ReturnType="Done" Completed="OnEntryCompleted" />
-                                    </HorizontalStackLayout>
-                                </DataTemplate>
-                            </CollectionView.ItemTemplate>
-                        </CollectionView>
-
-                        <Label Text="Floats" FontAttributes="Bold" FontSize="12" />
-                        <HorizontalStackLayout>
-                            <Button Text="+" Command="{Binding AddFloatCommand}" />
-                            <Button Text="Clear" Command="{Binding ClearFloatsCommand}" />
-                        </HorizontalStackLayout>
-                        <CollectionView ItemsSource="{Binding Floats}">
-                            <CollectionView.ItemTemplate>
-                                <DataTemplate x:DataType="vm:FrameGraphScalar">
-                                    <HorizontalStackLayout Spacing="6">
-                                        <Button Text="-" Command="{Binding Path=BindingContext.RemoveFloatCommand, Source={RelativeSource AncestorType={x:Type VerticalStackLayout}}}" CommandParameter="{Binding .}" />
-                                        <Entry Text="{Binding Key}" WidthRequest="180" Placeholder="name" ReturnType="Done" Completed="OnEntryCompleted" />
-                                        <Entry Text="{Binding Value}" WidthRequest="180" Placeholder="value" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric" />
-                                    </HorizontalStackLayout>
-                                </DataTemplate>
-                            </CollectionView.ItemTemplate>
-                        </CollectionView>
-
-                        <Label Text="Vec4" FontAttributes="Bold" FontSize="12" />
-                        <HorizontalStackLayout>
-                            <Button Text="+" Command="{Binding AddVec4Command}" />
-                            <Button Text="Clear" Command="{Binding ClearVec4Command}" />
-                        </HorizontalStackLayout>
-                        <CollectionView ItemsSource="{Binding Vec4}">
-                            <CollectionView.ItemTemplate>
-                                <DataTemplate x:DataType="vm:FrameGraphVec4Value">
-                                    <HorizontalStackLayout Spacing="6">
-                                        <Button Text="-" Command="{Binding Path=BindingContext.RemoveVec4Command, Source={RelativeSource AncestorType={x:Type VerticalStackLayout}}}" CommandParameter="{Binding .}" />
-                                        <Entry Text="{Binding Key}" WidthRequest="180" Placeholder="name" ReturnType="Done" Completed="OnEntryCompleted" />
-                                        <Entry Text="{Binding Value.X, Converter={StaticResource FloatValueConverter}}" WidthRequest="60" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric" />
-                                        <Entry Text="{Binding Value.Y, Converter={StaticResource FloatValueConverter}}" WidthRequest="60" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric" />
-                                        <Entry Text="{Binding Value.Z, Converter={StaticResource FloatValueConverter}}" WidthRequest="60" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric" />
-                                        <Entry Text="{Binding Value.W, Converter={StaticResource FloatValueConverter}}" WidthRequest="60" ReturnType="Done" Completed="OnEntryCompleted" Keyboard="Numeric" />
-                                    </HorizontalStackLayout>
-                                </DataTemplate>
-                            </CollectionView.ItemTemplate>
-                        </CollectionView>
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+            <Label Text="Global Vec4" FontAttributes="Bold" VerticalTextAlignment="Center" />
+            <HorizontalStackLayout Grid.Column="1" Spacing="4">
+                <Button Text="+" Command="{Binding AddVec4Command}" />
+                <Button Text="Clear" Command="{Binding ClearVec4Command}" />
+            </HorizontalStackLayout>
+        </Grid>
+        <VerticalStackLayout BindableLayout.ItemsSource="{Binding Vec4}" Spacing="4">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate x:DataType="vm:FrameGraphVec4Value">
+                    <VerticalStackLayout Spacing="4">
+                        <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6">
+                            <Button Text="-"
+                                    Command="{Binding BindingContext.RemoveVec4Command, Source={x:Reference Root}}"
+                                    CommandParameter="{Binding .}" />
+                            <Entry Grid.Column="1"
+                                   Text="{Binding Key}"
+                                   Placeholder="name"
+                                   ReturnType="Done"
+                                   Completed="OnEntryCompleted" />
+                        </Grid>
+                        <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="4" Margin="38,0,0,0">
+                            <Entry Text="{Binding Value.X, Converter={StaticResource FloatValueConverter}}"
+                                   Placeholder="X"
+                                   Keyboard="Numeric"
+                                   ReturnType="Done"
+                                   Completed="OnEntryCompleted" />
+                            <Entry Grid.Column="1"
+                                   Text="{Binding Value.Y, Converter={StaticResource FloatValueConverter}}"
+                                   Placeholder="Y"
+                                   Keyboard="Numeric"
+                                   ReturnType="Done"
+                                   Completed="OnEntryCompleted" />
+                            <Entry Grid.Column="2"
+                                   Text="{Binding Value.Z, Converter={StaticResource FloatValueConverter}}"
+                                   Placeholder="Z"
+                                   Keyboard="Numeric"
+                                   ReturnType="Done"
+                                   Completed="OnEntryCompleted" />
+                            <Entry Grid.Column="3"
+                                   Text="{Binding Value.W, Converter={StaticResource FloatValueConverter}}"
+                                   Placeholder="W"
+                                   Keyboard="Numeric"
+                                   ReturnType="Done"
+                                   Completed="OnEntryCompleted" />
+                        </Grid>
                     </VerticalStackLayout>
                 </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
+            </BindableLayout.ItemTemplate>
+        </VerticalStackLayout>
+
+        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="6">
+            <Label Text="Render Targets" FontAttributes="Bold" VerticalTextAlignment="Center" />
+            <HorizontalStackLayout Grid.Column="1" Spacing="4">
+                <Button Text="+" Command="{Binding AddRenderTargetCommand}" />
+                <Button Text="Clear" Command="{Binding ClearRenderTargetsCommand}" />
+            </HorizontalStackLayout>
+        </Grid>
+        <VerticalStackLayout BindableLayout.ItemsSource="{Binding RenderTargets}" Spacing="6">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate x:DataType="vm:FrameGraphRenderTarget">
+                    <Border Stroke="#3B424D" Padding="8">
+                        <VerticalStackLayout Spacing="4">
+                            <Grid ColumnDefinitions="Auto,*" ColumnSpacing="6">
+                                <Button Text="-"
+                                        Command="{Binding BindingContext.RemoveRenderTargetCommand, Source={x:Reference Root}}"
+                                        CommandParameter="{Binding .}" />
+                                <Entry Grid.Column="1"
+                                       Text="{Binding Name}"
+                                       Placeholder="target name"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                            </Grid>
+                            <Grid ColumnDefinitions="*,*" ColumnSpacing="6">
+                                <Entry Text="{Binding Format}"
+                                       Placeholder="format"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                                <Entry Grid.Column="1"
+                                       Text="{Binding MaxMipLevel}"
+                                       Placeholder="max mip level"
+                                       Keyboard="Numeric"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                            </Grid>
+                            <Grid ColumnDefinitions="*,*" ColumnSpacing="6">
+                                <Entry Text="{Binding Width}"
+                                       Placeholder="width"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                                <Entry Grid.Column="1"
+                                       Text="{Binding Height}"
+                                       Placeholder="height"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                            </Grid>
+                            <Grid ColumnDefinitions="*,*,*" ColumnSpacing="6">
+                                <Entry Text="{Binding Clamping}"
+                                       Placeholder="clamping"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                                <Entry Grid.Column="1"
+                                       Text="{Binding Filtration}"
+                                       Placeholder="filtration"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                                <Entry Grid.Column="2"
+                                       Text="{Binding Reduction}"
+                                       Placeholder="reduction"
+                                       ReturnType="Done"
+                                       Completed="OnEntryCompleted" />
+                            </Grid>
+                            <HorizontalStackLayout Spacing="10">
+                                <Label Text="Surface" VerticalOptions="Center" />
+                                <CheckBox IsChecked="{Binding IsSurface}" />
+                                <Label Text="Compute" VerticalOptions="Center" />
+                                <CheckBox IsChecked="{Binding IsCompatibleWithComputeShaders}" />
+                                <Label Text="Mips" VerticalOptions="Center" />
+                                <CheckBox IsChecked="{Binding GenerateMips}" />
+                            </HorizontalStackLayout>
+                        </VerticalStackLayout>
+                    </Border>
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
+        </VerticalStackLayout>
     </VerticalStackLayout>
 </DataTemplate>

--- a/Editor/Workflow/FrameGraphDiagramLayout.cs
+++ b/Editor/Workflow/FrameGraphDiagramLayout.cs
@@ -1,0 +1,125 @@
+namespace SailorEditor.Workflow;
+
+public readonly record struct FrameGraphDiagramPoint(double X, double Y);
+
+public readonly record struct FrameGraphDiagramRect(
+    double X,
+    double Y,
+    double Width,
+    double Height)
+{
+    public double Right => X + Width;
+    public double Bottom => Y + Height;
+
+    public bool Contains(double x, double y) =>
+        x >= X && x <= Right && y >= Y && y <= Bottom;
+}
+
+public readonly record struct FrameGraphDiagramNodeLayout(
+    int Index,
+    FrameGraphDiagramRect Bounds);
+
+public readonly record struct FrameGraphDiagramConnector(
+    int FromIndex,
+    int ToIndex,
+    FrameGraphDiagramPoint Start,
+    FrameGraphDiagramPoint End);
+
+public sealed record FrameGraphDiagramLayoutResult(
+    IReadOnlyList<FrameGraphDiagramNodeLayout> Nodes,
+    IReadOnlyList<FrameGraphDiagramConnector> Connectors,
+    double ContentWidth,
+    double ContentHeight)
+{
+    public int HitTest(double x, double y)
+    {
+        for (var index = Nodes.Count - 1; index >= 0; --index)
+        {
+            if (Nodes[index].Bounds.Contains(x, y))
+            {
+                return Nodes[index].Index;
+            }
+        }
+
+        return -1;
+    }
+}
+
+public static class FrameGraphDiagramLayout
+{
+    public const double NodeWidth = 220.0;
+    public const double NodeHeight = 270.0;
+    public const double NodeGap = 58.0;
+    public const double Padding = 18.0;
+    public const double MinimumWidth = 480.0;
+
+    public static FrameGraphDiagramLayoutResult Arrange(int nodeCount)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(nodeCount);
+
+        var nodes = new List<FrameGraphDiagramNodeLayout>(nodeCount);
+        var connectors = new List<FrameGraphDiagramConnector>(Math.Max(0, nodeCount - 1));
+        for (var index = 0; index < nodeCount; ++index)
+        {
+            var x = Padding + index * (NodeWidth + NodeGap);
+            var bounds = new FrameGraphDiagramRect(
+                x,
+                Padding,
+                NodeWidth,
+                NodeHeight);
+            nodes.Add(new FrameGraphDiagramNodeLayout(index, bounds));
+
+            if (index == 0)
+            {
+                continue;
+            }
+
+            var previous = nodes[index - 1].Bounds;
+            connectors.Add(new FrameGraphDiagramConnector(
+                index - 1,
+                index,
+                new FrameGraphDiagramPoint(previous.Right, previous.Y + previous.Height * 0.5),
+                new FrameGraphDiagramPoint(bounds.X, bounds.Y + bounds.Height * 0.5)));
+        }
+
+        var contentWidth = nodeCount == 0
+            ? MinimumWidth
+            : Math.Max(
+                MinimumWidth,
+                Padding * 2 + nodeCount * NodeWidth + (nodeCount - 1) * NodeGap);
+        return new FrameGraphDiagramLayoutResult(
+            nodes,
+            connectors,
+            contentWidth,
+            Padding * 2 + NodeHeight);
+    }
+}
+
+public static class FrameGraphDiagramOrder
+{
+    public static bool Move<T>(IList<T> items, T? item, int offset)
+        where T : class
+    {
+        ArgumentNullException.ThrowIfNull(items);
+        if (item is null || offset == 0)
+        {
+            return false;
+        }
+
+        var index = items.IndexOf(item);
+        if (index < 0)
+        {
+            return false;
+        }
+
+        var destination = Math.Clamp(index + offset, 0, items.Count - 1);
+        if (destination == index)
+        {
+            return false;
+        }
+
+        items.RemoveAt(index);
+        items.Insert(destination, item);
+        return true;
+    }
+}


### PR DESCRIPTION
## Summary
- replace the long `.renderer` frame list with an ordered, horizontally scrollable pipeline diagram
- select, add, remove, rename, configure, and reorder frame nodes from a focused Inspector editor
- expose existing renderer resources plus Runtime-supported node tags and global vec4 values
- preserve YAML frame order without persisting diagram-only metadata
- add deterministic layout, hit-test, reorder, and Inspector integration contracts

## Validation
- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --no-restore`: 782/782 passed
- focused frame graph diagram tests: 5/5 passed
- `xmllint --noout Editor/Views/InspectorView/FrameGraphFileTemplate.xaml`: passed
- `git diff --check`: passed
- `python3 update_deps.py`: passed
- Release engine build with Unix Makefiles: passed
- Release macOS MAUI Editor build: passed with 0 errors
- live Release Editor smoke test: MCP reported `engineState: Running`, `worldId: WorldEditor`, and the exact issue worktree root

## Scope
- Editor and Editor contract tests only
- no Runtime, RHI, importer, or renderer implementation changes
- no new editor-only YAML fields

Closes #153