### PR TITLE
Virtualize per-instance render resources

### DIFF
--- a/Content/DefaultRenderer.renderer
+++ b/Content/DefaultRenderer.renderer
@@ -112,6 +112,7 @@ frame:
   - Tag: Opaque
   - ClearDepth: true
   - GPUCulling: true
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - depthStencil: DepthBuffer
   - depthHighZ: DepthHighZ
@@ -120,6 +121,7 @@ frame:
   string:
   - Tag: Masked
   - GPUCulling: true
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - depthStencil: DepthBuffer
   - depthHighZ: DepthHighZ
@@ -147,6 +149,8 @@ frame:
 ############################
 - name: ShadowPrepass
 ############################
+  string:
+  - VirtualizeInstancePayloads: true
 
 ############################
 - name: Sky
@@ -276,6 +280,7 @@ frame:
   string:
   - Tag: Opaque
   - GPUCulling: true
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - color: Main
   - depthStencil: DepthBuffer
@@ -299,6 +304,7 @@ frame:
   string:
   - Tag: Masked
   - GPUCulling: true
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - color: Main
   - depthStencil: DepthBuffer
@@ -320,6 +326,7 @@ frame:
   - Tag: Transparent
   - Sorting: BackToFront
   - GPUCulling: false
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - color: Main
   - depthStencil: DepthBuffer
@@ -354,6 +361,7 @@ frame:
   string:
   - Tag: Viewmodel
   - GPUCulling: false
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - color: Main
   - depthStencil: DepthBuffer

--- a/Content/EditorRenderer.renderer
+++ b/Content/EditorRenderer.renderer
@@ -117,6 +117,7 @@ frame:
   - Tag: Opaque
   - ClearDepth: true
   - GPUCulling: true
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - depthStencil: DepthBuffer
   - depthHighZ: DepthHighZ
@@ -125,6 +126,7 @@ frame:
   string:
   - Tag: Masked
   - GPUCulling: true
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - depthStencil: DepthBuffer
   - depthHighZ: DepthHighZ
@@ -152,6 +154,8 @@ frame:
 ############################
 - name: ShadowPrepass
 ############################
+  string:
+  - VirtualizeInstancePayloads: true
 
 ############################
 - name: Sky
@@ -281,6 +285,7 @@ frame:
   string:
   - Tag: Opaque
   - GPUCulling: true
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - color: Main
   - depthStencil: DepthBuffer
@@ -304,6 +309,7 @@ frame:
   string:
   - Tag: Masked
   - GPUCulling: true
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - color: Main
   - depthStencil: DepthBuffer
@@ -325,6 +331,7 @@ frame:
   - Tag: Transparent
   - Sorting: BackToFront
   - GPUCulling: false
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - color: Main
   - depthStencil: DepthBuffer
@@ -359,6 +366,7 @@ frame:
   string:
   - Tag: Viewmodel
   - GPUCulling: false
+  - VirtualizeInstancePayloads: true
   renderTargets:
   - color: Main
   - depthStencil: DepthBuffer

--- a/Content/Experimental/MeshParticles/Particle.shader
+++ b/Content/Experimental/MeshParticles/Particle.shader
@@ -6,6 +6,8 @@ includes:
 
 defines:
 - SHADOW_CASTER
+- PACKED_SHADOW_CASTER
+- EVSM
 
 glslCommon: |
   #version 460
@@ -31,6 +33,22 @@ glslVertex: |
     mat3 tangentBasis;
   } vout;
   
+  #ifdef PACKED_SHADOW_CASTER
+  struct PerInstanceData
+  {
+      mat4 model;
+      vec4 sphereBounds;
+      uint materialInstance;
+      uint skeletonOffset;
+      uint isCulled;
+      uint padding;
+      vec4 bakedVolumeScale;
+      float baseColorAlpha;
+      uint baseColorSampler;
+      float alphaCutoff;
+      uint maskedPadding;
+  };
+  #else
   struct PerInstanceData
   {
       mat4 model;
@@ -39,6 +57,7 @@ glslVertex: |
       uint materialInstance;
       uint isCulled;
   };
+  #endif
   
   struct MaterialData
   {
@@ -105,6 +124,18 @@ glslVertex: |
   {
       PerInstanceData instance[];
   } data;
+
+  #ifdef PACKED_SHADOW_CASTER
+  layout(std430, set = 2, binding = 1) readonly buffer InstanceIndicesSSBO
+  {
+      uint instance[];
+  } instanceIndices;
+
+  layout(std430, push_constant) uniform Constants
+  {
+      mat4 lightMatrix;
+  } PushConstants;
+  #endif
   
   layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
   {
@@ -116,13 +147,16 @@ glslVertex: |
     
   void main() 
   {
+  #ifdef PACKED_SHADOW_CASTER
+    uint instanceIndex = instanceIndices.instance[gl_InstanceIndex];
+    gl_Position = PushConstants.lightMatrix * data.instance[instanceIndex].model * vec4(inPosition, 1.0);
+  #else
     vec4 vertexPosition = data.instance[gl_InstanceIndex].model * vec4(inPosition, 1.0);
     vout.worldPosition = vertexPosition.xyz / vertexPosition.w;
 
     gl_Position = frame.projection * (frame.view * (data.instance[gl_InstanceIndex].model * vec4(inPosition, 1.0)));
-    
     #if defined(SHADOW_CASTER)
-        gl_Position = lightsMatrices.instance[0] * data.instance[gl_InstanceIndex].model * vec4(inPosition, 1.0);
+      gl_Position = lightsMatrices.instance[0] * data.instance[gl_InstanceIndex].model * vec4(inPosition, 1.0);
     #endif
     
     vec4 worldNormal = data.instance[gl_InstanceIndex].model * vec4(inNormal, 0.0);
@@ -133,6 +167,7 @@ glslVertex: |
     vout.texcoord = inTexcoord;
     materialInstance = data.instance[gl_InstanceIndex].materialInstance;
     vout.tangentBasis = mat3(data.instance[gl_InstanceIndex].model) * mat3(inTangent, inBitangent, inNormal);
+  #endif
   }
 
 glslFragment: |
@@ -148,16 +183,15 @@ glslFragment: |
     mat3 tangentBasis;
   } vin;
   
-  layout(location=0) out vec4 outColor;
-  
-  struct PerInstanceData
-  {
-      mat4 model;
-      vec4 color;
-      vec4 colorOld;
-      uint materialInstance;
-      uint isCulled;
-  };
+  #if defined(SHADOW_CASTER) || defined(PACKED_SHADOW_CASTER)
+    #if defined(EVSM)
+      layout(location=0) out vec4 outDepth;
+    #else
+      layout(location=0) out float outDepth;
+    #endif
+  #else
+    layout(location=0) out vec4 outColor;
+  #endif
   
   struct MaterialData
   {
@@ -219,11 +253,6 @@ glslFragment: |
   
   layout(set=1, binding=8) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
   layout(set=1, binding=9) uniform sampler2D g_aoSampler;
-  
-  layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
-  {
-      PerInstanceData instance[];
-  } data;
   
   layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
   {
@@ -240,8 +269,15 @@ glslFragment: |
   
   void main() 
   {
-    #if defined(SHADOW_CASTER)
-        outColor.x = gl_FragCoord.z;
+    #if defined(SHADOW_CASTER) || defined(PACKED_SHADOW_CASTER)
+      #if defined(EVSM)
+        outDepth.x = exp(EVSM_C1 * gl_FragCoord.z);
+        outDepth.y = outDepth.x * outDepth.x;
+        outDepth.z = -exp(-EVSM_C2 * gl_FragCoord.z);
+        outDepth.w = outDepth.z * outDepth.z;
+      #else
+        outDepth = gl_FragCoord.z;
+      #endif
     #else   
         MaterialData material = GetMaterialData();
         outColor = vin.color;        

--- a/Content/ExperimentalRenderer.renderer
+++ b/Content/ExperimentalRenderer.renderer
@@ -117,6 +117,8 @@ frame:
   - linearDepth: LinearDepth
 
 - name: ShadowPrepass
+  string:
+  - VirtualizeInstancePayloads: true
 
 - name: Sky
   renderTargets:

--- a/Content/Shaders/ComputeLightCulling.shader
+++ b/Content/Shaders/ComputeLightCulling.shader
@@ -53,28 +53,39 @@ glslCompute: |
 
   ViewFrustum CreateTileFrustum(ivec2 tileId)
   {
-      const vec2 tileMin = vec2(tileId * LIGHTS_CULLING_TILE_SIZE);
-      const vec2 tileMax = min(
+      const vec2 viewportSize = vec2(PushConstants.viewportSize);
+      const vec2 framebufferTileMin = vec2(tileId * LIGHTS_CULLING_TILE_SIZE);
+      const vec2 framebufferTileMax = min(
           vec2((tileId + ivec2(1)) * LIGHTS_CULLING_TILE_SIZE),
-          vec2(PushConstants.viewportSize));
-      const vec2 tileCenter = (tileMin + tileMax) * 0.5f;
+          viewportSize);
+
+      // The graphics viewport has a negative height, so framebuffer Y grows
+      // opposite to the projection-space Y expected by inverse projection.
+      const vec2 projectionTileMin = vec2(
+          framebufferTileMin.x,
+          viewportSize.y - framebufferTileMax.y);
+      const vec2 projectionTileMax = vec2(
+          framebufferTileMax.x,
+          viewportSize.y - framebufferTileMin.y);
+      const vec2 projectionTileCenter =
+          (projectionTileMin + projectionTileMax) * 0.5f;
       const vec3 eyePosition = vec3(0.0f);
       vec3 corners[4];
 
       corners[0] = ScreenSpaceToViewSpace(
-          vec4(tileMin, NdcNearPlane, 1.0f),
+          vec4(projectionTileMin, NdcNearPlane, 1.0f),
           PushConstants.viewportSize,
           frame.invProjection).xyz;
       corners[1] = ScreenSpaceToViewSpace(
-          vec4(tileMax.x, tileMin.y, NdcNearPlane, 1.0f),
+          vec4(projectionTileMax.x, projectionTileMin.y, NdcNearPlane, 1.0f),
           PushConstants.viewportSize,
           frame.invProjection).xyz;
       corners[2] = ScreenSpaceToViewSpace(
-          vec4(tileMin.x, tileMax.y, NdcNearPlane, 1.0f),
+          vec4(projectionTileMin.x, projectionTileMax.y, NdcNearPlane, 1.0f),
           PushConstants.viewportSize,
           frame.invProjection).xyz;
       corners[3] = ScreenSpaceToViewSpace(
-          vec4(tileMax, NdcNearPlane, 1.0f),
+          vec4(projectionTileMax, NdcNearPlane, 1.0f),
           PushConstants.viewportSize,
           frame.invProjection).xyz;
 
@@ -84,7 +95,7 @@ glslCompute: |
       result.planes[2] = ComputePlane(eyePosition, corners[0], corners[1]);
       result.planes[3] = ComputePlane(eyePosition, corners[3], corners[2]);
       result.center = ScreenSpaceToViewSpace(
-          vec4(tileCenter, NdcNearPlane, 1.0f),
+          vec4(projectionTileCenter, NdcNearPlane, 1.0f),
           PushConstants.viewportSize,
           frame.invProjection).xy;
 
@@ -94,6 +105,15 @@ glslCompute: |
   bool SphereTileOverlaps(vec3 lightPosition, float radius,
       ViewFrustum frustum, float zNear, float zFar)
   {
+      // Every tile frustum starts at the camera. If the camera is inside the
+      // light volume, rejecting a tile from its reduced depth interval can
+      // expose 16x16 discontinuities at foreground vegetation. Keep the light
+      // for every tile and let the fragment shader apply the exact 3D range.
+      if(dot(lightPosition, lightPosition) <= radius * radius)
+      {
+          return true;
+      }
+
       if(lightPosition.z - radius > zFar || lightPosition.z + radius < zNear)
       {
           return false;

--- a/Content/Shaders/ComputeMeshCulling.shader
+++ b/Content/Shaders/ComputeMeshCulling.shader
@@ -15,6 +15,8 @@ glslCompute: |
     uint numBatches;
     uint numInstances;
     uint firstInstanceIndex;
+    uint firstStorageInstance;
+    uint firstCandidateInstance;
     uint phase;
     uint enableOcclusion;
   } PushConstants;
@@ -25,9 +27,14 @@ glslCompute: |
       vec4 sphereBounds;
       uint materialInstance;
       uint skeletonOffset;
+  #ifdef DEPTH_INSTANCE_LAYOUT
+      uint padding;
+      uint reserved;
+  #else
       uint isCulled;
       uint padding;
       vec4 bakedVolumeScale;
+  #endif
   };
   
   struct DrawIndexedIndirectData
@@ -44,6 +51,11 @@ glslCompute: |
   {
       PerInstanceData instance[];
   } data;
+
+  layout(std430, set = 1, binding = 1) buffer InstanceIndicesSSBO
+  {
+      uint instance[];
+  } instanceIndices;
   
   layout(std430, set = 2, binding = 0) buffer DrawIndexedIndirectBuffer
   {
@@ -174,7 +186,11 @@ glslCompute: |
       // GLSL workgroup barrier cannot synchronize multiple workgroups.
       if (globalIndex < PushConstants.numInstances)
       {
-        uint instanceId = PushConstants.firstInstanceIndex + globalIndex;
+        uint compactIndex = PushConstants.firstInstanceIndex + globalIndex;
+        uint candidateIndex = PushConstants.firstCandidateInstance + globalIndex;
+        // Candidate indices are immutable for the logical view. Phase 0 copies
+        // them into a separate output range before phase 1 compacts that range.
+        uint instanceId = instanceIndices.instance[candidateIndex];
 
         bool bIsCulled = FrustumCulling(instanceId);
         #ifdef OCCLUSION_CULLING
@@ -184,7 +200,7 @@ glslCompute: |
           }
         #endif
         
-        data.instance[instanceId].isCulled = bIsCulled ? 1u : 0u;
+        instanceIndices.instance[compactIndex] = bIsCulled ? 0xFFFFFFFFu : instanceId;
       }
     }
     else if (globalIndex < PushConstants.numBatches)
@@ -197,12 +213,13 @@ glslCompute: |
         
         for (uint i = 0; i < drawIndexedIndirect.batches[batchId].instanceCount; i++)
         {
-            if (data.instance[readIndex].isCulled == 0)
+            uint instanceId = instanceIndices.instance[readIndex];
+            if (instanceId != 0xFFFFFFFFu)
             {
-                if (readIndex != writeIndex)
-                {
-                    data.instance[writeIndex] = data.instance[readIndex];
-                }
+              if (readIndex != writeIndex)
+              {
+                    instanceIndices.instance[writeIndex] = instanceId;
+              }
                 writeIndex++;
             }
             readIndex++;

--- a/Content/Shaders/DepthOnly.shader
+++ b/Content/Shaders/DepthOnly.shader
@@ -49,15 +49,19 @@ glslVertex: |
       vec4 sphereBounds;
       uint materialInstance;
       uint skeletonOffset;
-      uint isCulled;
       uint padding;
-      vec4 bakedVolumeScale;
+      uint reserved;
   };
   
   layout(std430, set = 1, binding = 0) readonly buffer PerInstanceDataSSBO
   {
       PerInstanceData instance[];
   } data;
+
+  layout(std430, set = 1, binding = 1) readonly buffer InstanceIndicesSSBO
+  {
+      uint instance[];
+  } instanceIndices;
 
   struct BoneData
   {
@@ -88,15 +92,16 @@ glslVertex: |
   
   void main() 
   {
-      mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
+      uint instanceIndex = instanceIndices.instance[gl_InstanceIndex];
+      mat4 modelMatrix = data.instance[instanceIndex].model;
   #ifdef MASKED
       outTexcoord = inTexcoord;
-      outBaseColorSampler = data.instance[gl_InstanceIndex].materialInstance;
-      outAlphaCutoff = uintBitsToFloat(data.instance[gl_InstanceIndex].padding);
+      outBaseColorSampler = data.instance[instanceIndex].materialInstance;
+      outAlphaCutoff = uintBitsToFloat(data.instance[instanceIndex].padding);
       outVertexAlpha = inColor.a;
   #endif
   #ifdef SKINNING
-      uint offset = data.instance[gl_InstanceIndex].skeletonOffset;
+      uint offset = data.instance[instanceIndex].skeletonOffset;
       if (offset != INVALID_SKELETON_OFFSET)
       {
           mat4 skinMatrix = bones.instance[offset + inBoneIds.x].matrix * inBoneWeights.x +

--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -126,6 +126,11 @@ glslVertex: |
       PerInstanceData instance[];
   } data;
 
+  layout(std430, set = 2, binding = 1) readonly buffer InstanceIndicesSSBO
+  {
+      uint instance[];
+  } instanceIndices;
+
   layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
   {
       MaterialData instance[];
@@ -143,7 +148,8 @@ glslVertex: |
 
   void main()
   {
-    mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
+    uint instanceIndex = instanceIndices.instance[gl_InstanceIndex];
+    mat4 modelMatrix = data.instance[instanceIndex].model;
     vec4 vertexPosition = modelMatrix * vec4(inPosition, 1.0);
     vout.worldPosition = vertexPosition.xyz / vertexPosition.w;
 
@@ -173,7 +179,7 @@ glslVertex: |
     vout.color = inColor;
     vout.normal = normal;
     vout.texcoord = inTexcoord;
-    materialInstance = data.instance[gl_InstanceIndex].materialInstance;
+    materialInstance = data.instance[instanceIndex].materialInstance;
     vout.tangentBasis = mat3(tangent, bitangent, normal);
   }
 

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -338,12 +338,15 @@ float CalculateLocalPcfShadow(
     return 1.0f;
   }
 
+  const vec2 atlasTexelSize = 1.0f / textureSize(shadowMap, 0);
+  const vec2 tileMin = atlasRect.xy + atlasTexelSize * 0.5f;
+  const vec2 tileMax = atlasRect.xy + atlasRect.zw - atlasTexelSize * 0.5f;
+  const vec2 atlasUv = clamp(
+    atlasRect.xy + projCoords.xy * atlasRect.zw,
+    tileMin,
+    tileMax);
   if(softShadow)
   {
-    const vec2 atlasTexelSize = 1.0f / textureSize(shadowMap, 0);
-    const vec2 tileMin = atlasRect.xy + atlasTexelSize * 0.5f;
-    const vec2 tileMax = atlasRect.xy + atlasRect.zw - atlasTexelSize * 0.5f;
-    const vec2 atlasUv = atlasRect.xy + projCoords.xy * atlasRect.zw;
     const vec2 poissonDisk[16] = vec2[](
       vec2(-0.94201624, -0.39906216), vec2(0.94558609, -0.76890725),
       vec2(-0.094184101, -0.92938870), vec2(0.34495938, 0.29387760),
@@ -366,7 +369,6 @@ float CalculateLocalPcfShadow(
     return lit / 16.0f;
   }
 
-  const vec2 atlasUv = atlasRect.xy + projCoords.xy * atlasRect.zw;
   const float shadowDepth = texture(shadowMap, atlasUv).r;
   return projCoords.z > shadowDepth ? 1.0f : 0.0f;
 }

--- a/Content/Shaders/ShadowCaster.shader
+++ b/Content/Shaders/ShadowCaster.shader
@@ -48,11 +48,10 @@ glslVertex: |
       uint isCulled;
       uint padding;
       vec4 bakedVolumeScale;
-      vec4 baseColorFactor;
+      float baseColorAlpha;
       uint baseColorSampler;
       float alphaCutoff;
       uint maskedPadding;
-      uint stridePadding;
   };
 
   struct BoneData
@@ -71,6 +70,11 @@ glslVertex: |
   {
       PerInstanceData instance[];
   } data;
+
+  layout(std430, set = 1, binding = 1) readonly buffer InstanceIndicesSSBO
+  {
+      uint instance[];
+  } instanceIndices;
 
   #ifdef SKINNING
   #ifdef MASKED
@@ -100,15 +104,16 @@ glslVertex: |
   
   void main() 
   {
-      mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
+      uint instanceIndex = instanceIndices.instance[gl_InstanceIndex];
+      mat4 modelMatrix = data.instance[instanceIndex].model;
   #ifdef MASKED
       outTexcoord = inTexcoord;
-      outBaseColorFactor = data.instance[gl_InstanceIndex].baseColorFactor;
-      outBaseColorSampler = data.instance[gl_InstanceIndex].baseColorSampler;
-      outAlphaCutoff = data.instance[gl_InstanceIndex].alphaCutoff;
+      outBaseColorFactor = vec4(1.0, 1.0, 1.0, data.instance[instanceIndex].baseColorAlpha);
+      outBaseColorSampler = data.instance[instanceIndex].baseColorSampler;
+      outAlphaCutoff = data.instance[instanceIndex].alphaCutoff;
   #endif
   #ifdef SKINNING
-      uint offset = data.instance[gl_InstanceIndex].skeletonOffset;
+      uint offset = data.instance[instanceIndex].skeletonOffset;
       if (offset != INVALID_SKELETON_OFFSET)
       {
           mat4 skinMatrix = bones.instance[offset + inBoneIds.x].matrix * inBoneWeights.x +

--- a/Content/Shaders/Simple.shader
+++ b/Content/Shaders/Simple.shader
@@ -13,19 +13,19 @@ glslCommon: |
 glslVertex: |
   struct LightData
   {
-  	vec3 worldPosition;
-  	vec3 direction;
-  	vec3 intensity;
-  	vec3 attenuation;
-  	vec4 bounds;
-  	int type;
+      vec3 worldPosition;
+      vec3 direction;
+      vec3 intensity;
+      vec3 attenuation;
+      vec4 bounds;
+      int type;
   };
   
   struct PerInstanceData
   {
-  	mat4 model;
+      mat4 model;
     vec4 sphereBounds;
-  	uint materialInstance;
+      uint materialInstance;
     uint skeletonOffset;
     uint isCulled;
     uint padding;
@@ -34,7 +34,7 @@ glslVertex: |
   
   struct MaterialData
   {
-  	vec4 color;
+      vec4 color;
   };
   
   layout(set = 0, binding = 0) uniform FrameData
@@ -62,24 +62,29 @@ glslVertex: |
   } previousFrame;
   
   layout(std140, set = 1, binding = 0) readonly buffer LightDataSSBO
-  {	
-  	LightData instance[];
+  {
+      LightData instance[];
   } light;
   
   layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
   {
-  	PerInstanceData instance[];
+      PerInstanceData instance[];
   } data;
+
+  layout(std430, set = 2, binding = 1) readonly buffer InstanceIndicesSSBO
+  {
+      uint instance[];
+  } instanceIndices;
   
   #ifdef CUSTOM_DATA
   layout(std140, set = 3, binding = 0) readonly buffer MaterialDataSSBO
   {
-  	MaterialData instance[];
+      MaterialData instance[];
   } material;
   
   MaterialData GetMaterialData()
   {
-  	return material.instance[data.instance[gl_InstanceIndex].materialInstance];
+    return material.instance[data.instance[instanceIndices.instance[gl_InstanceIndex]].materialInstance];
   }
   #endif
   
@@ -94,17 +99,18 @@ glslVertex: |
   
   void main() 
   {
-  	gl_Position = frame.projection * frame.view * data.instance[gl_InstanceIndex].model * vec4(inPosition, 1.0);
-  	vec4 worldNormal = data.instance[gl_InstanceIndex].model * vec4(inNormal, 0.0);
+      uint instanceIndex = instanceIndices.instance[gl_InstanceIndex];
+      gl_Position = frame.projection * frame.view * data.instance[instanceIndex].model * vec4(inPosition, 1.0);
+      vec4 worldNormal = data.instance[instanceIndex].model * vec4(inNormal, 0.0);
   
-  	fragColor = 1 - inColor * gl_Position.z / 3000;
+      fragColor = 1 - inColor * gl_Position.z / 3000;
   
   #ifdef CUSTOM_DATA
-  	fragColor *= GetMaterialData().color;
+      fragColor *= GetMaterialData().color;
   #endif
   
-  	fragNormal = worldNormal.xyz;
-  	fragTexcoord = inTexcoord;
+      fragNormal = worldNormal.xyz;
+      fragTexcoord = inTexcoord;
   }
 
 glslFragment: |  
@@ -121,9 +127,9 @@ glslFragment: |
   void main() 
   {
   #ifndef NO_DIFFUSE
-  	outColor = fragColor * texture(diffuseSampler, fragTexcoord);
+      outColor = fragColor * texture(diffuseSampler, fragTexcoord);
   #endif
   
-  	outColor.xyz *= max(0.2, dot(normalize(-vec3(-0.3, -0.5, 0.1)), fragNormal.xyz));
-  	outColor.xyz += 0.007;    
+      outColor.xyz *= max(0.2, dot(normalize(-vec3(-0.3, -0.5, 0.1)), fragNormal.xyz));
+      outColor.xyz += 0.007;
   }

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -125,6 +125,11 @@ glslVertex: |
   {
       PerInstanceData instance[];
   } data;
+
+  layout(std430, set = 2, binding = 1) readonly buffer InstanceIndicesSSBO
+  {
+      uint instance[];
+  } instanceIndices;
   
   layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
   {
@@ -143,7 +148,8 @@ glslVertex: |
   
   void main() 
   {
-    mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
+    uint instanceIndex = instanceIndices.instance[gl_InstanceIndex];
+    mat4 modelMatrix = data.instance[instanceIndex].model;
     vec4 vertexPosition = modelMatrix * vec4(inPosition, 1.0);
     vout.worldPosition = vertexPosition.xyz / vertexPosition.w;
 
@@ -173,7 +179,7 @@ glslVertex: |
     vout.color = inColor;
     vout.normal = normal;
     vout.texcoord = inTexcoord;
-    materialInstance = data.instance[gl_InstanceIndex].materialInstance;
+    materialInstance = data.instance[instanceIndex].materialInstance;
     vout.tangentBasis = mat3(tangent, bitangent, normal);
   }
 

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -168,6 +168,11 @@ glslVertex: |
   {
       PerInstanceData instance[];
   } data;
+
+  layout(std430, set = 2, binding = 1) readonly buffer InstanceIndicesSSBO
+  {
+      uint instance[];
+  } instanceIndices;
   
   layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
   {
@@ -193,17 +198,18 @@ glslVertex: |
   
   void main()
   {
-    mat4 modelMatrix = data.instance[gl_InstanceIndex].model;
+    uint instanceIndex = instanceIndices.instance[gl_InstanceIndex];
+    mat4 modelMatrix = data.instance[instanceIndex].model;
   #ifdef TRANSMISSION
     mat3 instanceLinearMatrix = mat3(modelMatrix);
     vout.modelScale = vec3(
       length(instanceLinearMatrix[0]),
       length(instanceLinearMatrix[1]),
       length(instanceLinearMatrix[2])) *
-      data.instance[gl_InstanceIndex].bakedVolumeScale.xyz;
+      data.instance[instanceIndex].bakedVolumeScale.xyz;
   #endif
   #ifdef SKINNING
-    uint offset = data.instance[gl_InstanceIndex].skeletonOffset;
+    uint offset = data.instance[instanceIndex].skeletonOffset;
 
     if (offset != INVALID_SKELETON_OFFSET)
     {
@@ -247,7 +253,7 @@ glslVertex: |
 
     vout.color = inColor;
     vout.texcoord = inTexcoord;
-    materialInstance = data.instance[gl_InstanceIndex].materialInstance;
+    materialInstance = data.instance[instanceIndex].materialInstance;
   }
 
 glslFragment: |

--- a/Content/Shaders/Unlit.shader
+++ b/Content/Shaders/Unlit.shader
@@ -118,6 +118,11 @@ glslVertex: |
   {
       PerInstanceData instance[];
   } data;
+
+  layout(std430, set = 2, binding = 1) readonly buffer InstanceIndicesSSBO
+  {
+      uint instance[];
+  } instanceIndices;
   
   layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
   {
@@ -136,22 +141,23 @@ glslVertex: |
   
   void main() 
   {
-    vec4 vertexPosition = data.instance[gl_InstanceIndex].model * vec4(inPosition, 1.0);
+    uint instanceIndex = instanceIndices.instance[gl_InstanceIndex];
+    vec4 vertexPosition = data.instance[instanceIndex].model * vec4(inPosition, 1.0);
     vout.worldPosition = vertexPosition.xyz / vertexPosition.w;
 
-    gl_Position = frame.projection * (frame.view * (data.instance[gl_InstanceIndex].model * vec4(inPosition, 1.0)));
+    gl_Position = frame.projection * (frame.view * (data.instance[instanceIndex].model * vec4(inPosition, 1.0)));
     
     #if defined(SHADOW)
-        gl_Position = lightsMatrices.instance[0] * data.instance[gl_InstanceIndex].model * vec4(inPosition, 1.0);
+        gl_Position = lightsMatrices.instance[0] * data.instance[instanceIndex].model * vec4(inPosition, 1.0);
     #endif
 
-    vec4 worldNormal = data.instance[gl_InstanceIndex].model * vec4(inNormal, 0.0);
+    vec4 worldNormal = data.instance[instanceIndex].model * vec4(inNormal, 0.0);
 
     vout.color = inColor;
     vout.normal = normalize(worldNormal.xyz);
     vout.texcoord = inTexcoord;
-    materialInstance = data.instance[gl_InstanceIndex].materialInstance;
-    vout.tangentBasis = mat3(data.instance[gl_InstanceIndex].model) * mat3(inTangent, inBitangent, inNormal);
+    materialInstance = data.instance[instanceIndex].materialInstance;
+    vout.tangentBasis = mat3(data.instance[instanceIndex].model) * mat3(inTangent, inBitangent, inNormal);
   }
 
 glslFragment: |

--- a/Runtime/AssetRegistry/Material/MaterialImporter.cpp
+++ b/Runtime/AssetRegistry/Material/MaterialImporter.cpp
@@ -30,6 +30,12 @@ using namespace Sailor;
 namespace
 {
 	std::atomic<uint64_t> g_materialContentRevision{};
+
+	bool IsBaseColorMetadataUniform(const std::string& name)
+	{
+		return name == "material.baseColorFactor" ||
+			name == "material.albedo";
+	}
 }
 
 uint64_t Material::GetGlobalContentRevision()
@@ -43,21 +49,41 @@ void Material::AdvanceContentRevision()
 	g_materialContentRevision.fetch_add(1, std::memory_order_release);
 }
 
+void Material::AdvanceRenderMetadataRevision()
+{
+	m_renderMetadataRevision.fetch_add(1, std::memory_order_release);
+}
+
 void Material::SetShader(ShaderSetPtr shader)
 {
 	m_shader = shader;
 	AdvanceContentRevision();
+	AdvanceRenderMetadataRevision();
 }
 
 void Material::SetRenderState(const RHI::RenderState& renderState)
 {
 	m_renderState = renderState;
 	AdvanceContentRevision();
+	AdvanceRenderMetadataRevision();
 }
 
 bool Material::IsReady() const
 {
-	return m_shader && m_shader->IsReady() && m_commonShaderBindings.IsValid() && m_commonShaderBindings->IsReady();
+	const bool bReady = m_shader && m_shader->IsReady() &&
+		m_commonShaderBindings.IsValid() && m_commonShaderBindings->IsReady();
+	if (bReady)
+	{
+		for (const auto& entry : m_rhiMaterials)
+		{
+			auto material = entry.m_second;
+			if (material)
+			{
+				material->TryPublishPendingBindings();
+			}
+		}
+	}
+	return bReady;
 }
 
 MaterialPtr Material::CreateInstance(WorldPtr world, const MaterialPtr& material)
@@ -88,6 +114,7 @@ Tasks::ITaskPtr Material::OnHotReload()
 			// Dependency hot reload tasks are joined before this task executes, so
 			// publish the revision only after their material-visible data is ready.
 			AdvanceContentRevision();
+			AdvanceRenderMetadataRevision();
 			UpdateRHIResource();
 			ForcelyUpdateUniforms();
 		}, EThreadType::Render);
@@ -100,6 +127,7 @@ void Material::ClearSamplers()
 	SAILOR_PROFILE_FUNCTION();
 	m_samplers.Clear();
 	AdvanceContentRevision();
+	AdvanceRenderMetadataRevision();
 }
 
 void Material::ClearUniforms()
@@ -107,6 +135,7 @@ void Material::ClearUniforms()
 	m_uniformsVec4.Clear();
 	m_uniformsFloat.Clear();
 	AdvanceContentRevision();
+	AdvanceRenderMetadataRevision();
 }
 
 void Material::SetSampler(const std::string& name, TexturePtr value)
@@ -120,6 +149,7 @@ void Material::SetSampler(const std::string& name, TexturePtr value)
 
 		m_bIsDirty = true;
 		AdvanceContentRevision();
+		AdvanceRenderMetadataRevision();
 	}
 }
 
@@ -127,22 +157,69 @@ void Material::SetUniform(const std::string& name, float value)
 {
 	SAILOR_PROFILE_FUNCTION();
 
+	float* currentValue = nullptr;
+	if (m_uniformsFloat.Find(name, currentValue) && currentValue && *currentValue == value)
+	{
+		return;
+	}
+
+	bool bRenderMetadataChanged = false;
+	if (name == "material.alphaCutoff")
+	{
+		constexpr float defaultAlphaCutoff = 0.5f;
+		const float currentAlphaCutoff = currentValue ? *currentValue : defaultAlphaCutoff;
+		bRenderMetadataChanged = currentAlphaCutoff != value;
+	}
+
 	m_uniformsFloat.At_Lock(name) = value;
 	m_uniformsFloat.Unlock(name);
 
 	m_bIsDirty = true;
 	AdvanceContentRevision();
+	if (bRenderMetadataChanged)
+	{
+		AdvanceRenderMetadataRevision();
+	}
 }
 
 void Material::SetUniform(const std::string& name, glm::vec4 value)
 {
 	SAILOR_PROFILE_FUNCTION();
 
+	glm::vec4* currentValue = nullptr;
+	if (m_uniformsVec4.Find(name, currentValue) && currentValue && *currentValue == value)
+	{
+		return;
+	}
+
+	auto resolveBaseColorAlpha = [this]()
+	{
+		glm::vec4* baseColor = nullptr;
+		if (m_uniformsVec4.Find("material.baseColorFactor", baseColor) && baseColor)
+		{
+			return baseColor->a;
+		}
+
+		if (m_uniformsVec4.Find("material.albedo", baseColor) && baseColor)
+		{
+			return baseColor->a;
+		}
+
+		return 1.0f;
+	};
+
+	const bool bBaseColorMetadataUniform = IsBaseColorMetadataUniform(name);
+	const float currentBaseColorAlpha = bBaseColorMetadataUniform ? resolveBaseColorAlpha() : 1.0f;
+
 	m_uniformsVec4.At_Lock(name) = value;
 	m_uniformsVec4.Unlock(name);
 
 	m_bIsDirty = true;
 	AdvanceContentRevision();
+	if (bBaseColorMetadataUniform && currentBaseColorAlpha != resolveBaseColorAlpha())
+	{
+		AdvanceRenderMetadataRevision();
+	}
 }
 
 RHI::RHIMaterialPtr Material::GetOrAddRHI(RHI::RHIVertexDescriptionPtr vertexDescription)
@@ -265,6 +342,15 @@ void Material::UpdateRHIResourceAndUniforms()
 	ForcelyUpdateUniforms();
 }
 
+void Material::SynchronizeUniformValues(const Material& source)
+{
+	m_uniformsVec4 = source.m_uniformsVec4;
+	m_uniformsFloat = source.m_uniformsFloat;
+	m_bIsDirty = true;
+	AdvanceContentRevision();
+	ForcelyUpdateUniforms();
+}
+
 void Material::UpdateUniforms(RHI::RHICommandListPtr cmdList)
 {
 	if (!m_commonShaderBindings)
@@ -370,6 +456,14 @@ void Material::ForcelyUpdateUniforms()
 	{
 		return;
 	}
+	auto nextBindings = RHI::Renderer::GetDriver()->CloneMaterialShaderBindings(
+		m_commonShaderBindings);
+	if (!nextBindings)
+	{
+		m_bIsDirty = true;
+		return;
+	}
+	m_commonShaderBindings = std::move(nextBindings);
 
 	RHI::RHICommandListPtr cmdList;
 	{
@@ -387,6 +481,14 @@ void Material::ForcelyUpdateUniforms()
 	RHI::Renderer::GetDriver()->SetDebugName(fence, std::format("Forcely update uniforms"));
 
 	RHI::Renderer::GetDriver()->TrackDelayedInitialization(m_commonShaderBindings.GetRawPtr(), fence);
+	for (const auto& entry : m_rhiMaterials)
+	{
+		auto material = entry.m_second;
+		if (material)
+		{
+			material->StageBindings(m_commonShaderBindings);
+		}
+	}
 
 	// Submit cmd lists
 	SAILOR_ENQUEUE_TASK_RENDER_THREAD("Update shader bindings set rhi",

--- a/Runtime/AssetRegistry/Material/MaterialImporter.h
+++ b/Runtime/AssetRegistry/Material/MaterialImporter.h
@@ -34,6 +34,7 @@ namespace Sailor
 		SAILOR_API virtual bool IsReady() const override;
 		SAILOR_API bool IsDirty() const { return m_bIsDirty.load(); }
 		SAILOR_API uint64_t GetContentRevision() const { return m_contentRevision.load(std::memory_order_acquire); }
+		SAILOR_API uint64_t GetRenderMetadataRevision() const { return m_renderMetadataRevision.load(std::memory_order_acquire); }
 		SAILOR_API static uint64_t GetGlobalContentRevision();
 
 		SAILOR_API virtual Tasks::ITaskPtr OnHotReload() override;
@@ -53,6 +54,7 @@ namespace Sailor
 
 		SAILOR_API void UpdateRHIResource();
 		SAILOR_API void UpdateRHIResourceAndUniforms();
+		SAILOR_API void SynchronizeUniformValues(const Material& source);
 
 		// TODO: Incapsulate & isolate
 		SAILOR_API RHI::RHIMaterialPtr GetOrAddRHI(RHI::RHIVertexDescriptionPtr vertexDescription);
@@ -70,11 +72,13 @@ namespace Sailor
 	protected:
 
 		void AdvanceContentRevision();
+		void AdvanceRenderMetadataRevision();
 		void ForcelyUpdateUniforms();
 		void UpdateUniforms(RHI::RHICommandListPtr cmdList);
 
 		std::atomic<bool> m_bIsDirty{};
 		std::atomic<uint64_t> m_contentRevision{};
+		std::atomic<uint64_t> m_renderMetadataRevision{};
 
 		ShaderSetPtr m_shader{};
 		RHI::RHIShaderBindingSetPtr m_commonShaderBindings{};

--- a/Runtime/AssetRegistry/Texture/TextureImporter.cpp
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.cpp
@@ -380,6 +380,32 @@ TextureImporter::TextureSamplersSnapshot TextureImporter::GetTextureSamplersSnap
 	return snapshot;
 }
 
+uint64_t TextureImporter::CalculateTextureSamplersRevision(
+	const TVector<uint32_t>& requestedIndices) const
+{
+	size_t result = 1469598103934665603ull;
+	m_textureSamplersLock.Lock();
+	if (!m_textureSamplersBindings)
+	{
+		m_textureSamplersLock.Unlock();
+		return 0ull;
+	}
+
+	for (const uint32_t requestedIndex : requestedIndices)
+	{
+		if (requestedIndex >= MaxTexturesInScene)
+		{
+			continue;
+		}
+		const uint64_t contentRevision =
+			requestedIndex < m_textureSamplerSlotRevisions.Num() ?
+			m_textureSamplerSlotRevisions[requestedIndex] : 0ull;
+		HashCombine(result, requestedIndex, contentRevision);
+	}
+	m_textureSamplersLock.Unlock();
+	return static_cast<uint64_t>(result);
+}
+
 bool TextureImporter::RegisterTextureSamplerBinding(RHI::RHITexturePtr texture, size_t& outIndex)
 {
 	outIndex = 0;

--- a/Runtime/AssetRegistry/Texture/TextureImporter.h
+++ b/Runtime/AssetRegistry/Texture/TextureImporter.h
@@ -100,6 +100,8 @@ namespace Sailor
 
 		SAILOR_API RHI::RHIShaderBindingSetPtr GetTextureSamplersBindingSet() { return m_textureSamplersBindings; }
 		SAILOR_API TextureSamplersSnapshot GetTextureSamplersSnapshot(const TVector<uint32_t>& requestedIndices) const;
+		SAILOR_API uint64_t CalculateTextureSamplersRevision(
+			const TVector<uint32_t>& requestedIndices) const;
 		SAILOR_API size_t GetTextureIndex(FileId uid);
 		SAILOR_API size_t GetTextureSamplersCount() const { return m_textureSamplersCurrentIndex.load(); }
 

--- a/Runtime/Components/LandscapeComponent.cpp
+++ b/Runtime/Components/LandscapeComponent.cpp
@@ -98,5 +98,15 @@ void LandscapeComponent::SetVegetationCullDistance(const TVector<float>& value) 
 void LandscapeComponent::SetVegetationColliderRadius(const TVector<float>& value) { m_vegetationColliderRadius = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationColliderHeight(const TVector<float>& value) { m_vegetationColliderHeight = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationColliderOffsetY(const TVector<float>& value) { m_vegetationColliderOffsetY = value; MarkDirty(); }
-void LandscapeComponent::SetRegenerate(bool value) { m_bRegenerate = false; if (value) MarkDirty(); }
+void LandscapeComponent::SetRegenerate(bool value)
+{
+	m_bRegenerate = false;
+	if (value)
+	{
+		if (auto* data = TryGetData())
+		{
+			data->RequestFullRebuild();
+		}
+	}
+}
 void LandscapeComponent::SetFlatten(bool value) { m_bFlatten = false; if (value) { m_heightScale = 0.0f; MarkDirty(); } }

--- a/Runtime/Components/Tests/ShadowVisualTestSetupComponent.cpp
+++ b/Runtime/Components/Tests/ShadowVisualTestSetupComponent.cpp
@@ -8,6 +8,7 @@
 #include "Engine/World.h"
 #include "Math/Math.h"
 
+#include <cmath>
 #include <glm/gtc/quaternion.hpp>
 
 using namespace Sailor;
@@ -16,24 +17,79 @@ void ShadowVisualTestSetupComponent::BeginPlay()
 {
 	Component::BeginPlay();
 
-	SpawnBox("ShadowFloor", glm::vec3(0.0f, -4.0f, 0.0f), glm::vec3(70.0f, 2.0f, 70.0f));
-	SpawnBox("ShadowReceiverWall", glm::vec3(0.0f, 23.0f, -48.0f), glm::vec3(64.0f, 28.0f, 2.0f));
-	SpawnBox("ShadowCasterLeft", glm::vec3(-18.0f, 5.0f, 4.0f), glm::vec3(7.0f, 9.0f, 7.0f));
-	SpawnBox("ShadowCasterCenter", glm::vec3(0.0f, 9.0f, -4.0f), glm::vec3(8.0f, 13.0f, 8.0f));
-	SpawnBox("ShadowCasterRight", glm::vec3(19.0f, 3.0f, 10.0f), glm::vec3(7.0f, 7.0f, 7.0f));
+	SpawnBox(
+		"ShadowFloor",
+		glm::vec3(0.0f, -4.0f, 0.0f),
+		glm::vec3(70.0f, 2.0f, 70.0f),
+		EMobilityType::Static);
+	SpawnBox(
+		"ShadowReceiverWall",
+		glm::vec3(0.0f, 23.0f, -48.0f),
+		glm::vec3(64.0f, 28.0f, 2.0f),
+		EMobilityType::Static);
+	SpawnBox(
+		"ShadowCasterStatic",
+		glm::vec3(-18.0f, 5.0f, 4.0f),
+		glm::vec3(7.0f, 9.0f, 7.0f),
+		EMobilityType::Static);
+	m_stationaryCaster = SpawnBox(
+		"ShadowCasterStationary",
+		glm::vec3(0.0f, 9.0f, -4.0f),
+		glm::vec3(8.0f, 13.0f, 8.0f),
+		EMobilityType::Stationary);
+	m_dynamicCaster = SpawnBox(
+		"ShadowCasterDynamic",
+		glm::vec3(19.0f, 3.0f, 10.0f),
+		glm::vec3(7.0f, 7.0f, 7.0f),
+		EMobilityType::Dynamic);
 
 	SpawnLights();
 	EnsureSky();
 	EnsureCamera();
 }
 
-void ShadowVisualTestSetupComponent::SpawnBox(
+void ShadowVisualTestSetupComponent::Tick(float deltaTime)
+{
+	++m_numFrames;
+	m_elapsedTime += deltaTime;
+
+	if (m_dynamicCaster)
+	{
+		m_dynamicCaster->GetTransformComponent().SetPosition(glm::vec4(
+			19.0f + std::sin(m_elapsedTime * 2.0f) * 9.0f,
+			3.0f,
+			10.0f,
+			1.0f));
+	}
+
+	if (m_numFrames == 60u && m_stationaryCaster)
+	{
+		m_stationaryCaster->GetTransformComponent().SetPosition(
+			glm::vec4(0.0f, 9.0f, -18.0f, 1.0f));
+	}
+
+	if (m_numFrames == 45u || m_numFrames == 90u)
+	{
+		const auto shadowType = m_numFrames == 45u ?
+			RHI::EShadowType::None : RHI::EShadowType::PCF;
+		for (auto& light : m_localShadowLights)
+		{
+			if (light)
+			{
+				light->SetShadowType(shadowType);
+			}
+		}
+	}
+}
+
+GameObjectPtr ShadowVisualTestSetupComponent::SpawnBox(
 	const char* name,
 	const glm::vec3& position,
-	const glm::vec3& scale)
+	const glm::vec3& scale,
+	EMobilityType mobility)
 {
 	auto gameObject = GetWorld()->Instantiate(name);
-	gameObject->SetMobilityType(EMobilityType::Stationary);
+	gameObject->SetMobilityType(mobility);
 	auto& transform = gameObject->GetTransformComponent();
 	transform.SetPosition(glm::vec4(position, 1.0f));
 	transform.SetScale(glm::vec4(scale, 1.0f));
@@ -45,6 +101,8 @@ void ShadowVisualTestSetupComponent::SpawnBox(
 	{
 		mesh->SetOverrideMaterials({ materialInfo->GetFileId() });
 	}
+
+	return gameObject;
 }
 
 void ShadowVisualTestSetupComponent::SpawnLights()
@@ -72,6 +130,7 @@ void ShadowVisualTestSetupComponent::SpawnLights()
 		light->SetRadius(220.0f);
 		light->SetShadowType(RHI::EShadowType::PCF);
 		light->SetShadowQuality(ELightShadowQuality::Medium);
+		m_localShadowLights.Add(light);
 	}
 
 	if (m_bSpot)
@@ -91,6 +150,7 @@ void ShadowVisualTestSetupComponent::SpawnLights()
 		light->SetCutOff(glm::vec2(32.0f, 52.0f));
 		light->SetShadowType(RHI::EShadowType::PCF);
 		light->SetShadowQuality(ELightShadowQuality::Medium);
+		m_localShadowLights.Add(light);
 	}
 }
 

--- a/Runtime/Components/Tests/ShadowVisualTestSetupComponent.h
+++ b/Runtime/Components/Tests/ShadowVisualTestSetupComponent.h
@@ -10,6 +10,7 @@ namespace Sailor
 
 	public:
 		SAILOR_API virtual void BeginPlay() override;
+		SAILOR_API virtual void Tick(float deltaTime) override;
 
 		SAILOR_API bool GetDirectional() const { return m_bDirectional; }
 		SAILOR_API void SetDirectional(bool value) { m_bDirectional = value; }
@@ -19,11 +20,20 @@ namespace Sailor
 		SAILOR_API void SetSpot(bool value) { m_bSpot = value; }
 
 	private:
-		void SpawnBox(const char* name, const glm::vec3& position, const glm::vec3& scale);
+		GameObjectPtr SpawnBox(
+			const char* name,
+			const glm::vec3& position,
+			const glm::vec3& scale,
+			EMobilityType mobility);
 		void SpawnLights();
 		void EnsureSky();
 		void EnsureCamera();
 
+		GameObjectPtr m_stationaryCaster{};
+		GameObjectPtr m_dynamicCaster{};
+		TVector<TObjectPtr<class LightComponent>> m_localShadowLights{};
+		uint32_t m_numFrames = 0u;
+		float m_elapsedTime = 0.0f;
 		bool m_bDirectional = false;
 		bool m_bPoint = false;
 		bool m_bSpot = false;

--- a/Runtime/Containers/ConcurrentMap.h
+++ b/Runtime/Containers/ConcurrentMap.h
@@ -174,8 +174,12 @@ namespace Sailor
 		SAILOR_API bool Find(const TKeyType& key, TValueType const*& out) const
 		{
 			auto it = Find(key);
-			out = &it->m_second;
-			return it != Super::end();
+			if (it != Super::end())
+			{
+				out = &it->m_second;
+				return true;
+			}
+			return false;
 		}
 
 		SAILOR_API Super::TIterator Find(const TKeyType& key)

--- a/Runtime/ECS/AnimationECS.cpp
+++ b/Runtime/ECS/AnimationECS.cpp
@@ -15,6 +15,25 @@ using namespace Sailor::Tasks;
 
 namespace
 {
+	TSharedPtr<TVector<glm::mat4>> AcquireBoneSnapshot(
+		TVector<TSharedPtr<TVector<glm::mat4>>>& pool,
+		const TVector<glm::mat4>& source)
+	{
+		for (auto& candidate : pool)
+		{
+			if (candidate && !candidate.IsShared())
+			{
+				*candidate = source;
+				return candidate;
+			}
+		}
+
+		auto snapshot = TSharedPtr<TVector<glm::mat4>>::Make();
+		*snapshot = source;
+		pool.Add(snapshot);
+		return snapshot;
+	}
+
 	void MarkMeshSkeletonDirty(GameObjectPtr owner)
 	{
 		if (!owner)
@@ -36,13 +55,17 @@ void AnimationECS::BeginPlay()
 {
 	auto& driver = RHI::Renderer::GetDriver();
 	m_bonesBinding = driver->CreateShaderBindings();
-	m_bonesBuffer = driver->AddSsboToShaderBindings(m_bonesBinding, "bones", sizeof(glm::mat4), BonesMaxNum, 0);
+	m_bonesBuffer.Clear();
 }
 
 void AnimationECS::EndPlay()
 {
 	m_bonesBinding.Clear();
 	m_bonesBuffer.Clear();
+	m_cpuBoneMatrices.Clear();
+	m_publishedBoneMatrices.Clear();
+	m_boneSnapshotPool.Clear();
+	m_animationRevision = 0ull;
 	m_nextBoneOffset = 0;
 }
 
@@ -269,10 +292,7 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 		}
 	}
 
-	auto renderer = App::GetSubmodule<RHI::Renderer>();
-	auto commands = renderer->GetDriverCommands();
-	auto cmdList = GetWorld()->GetCommandList();
-	commands->BeginDebugRegion(cmdList, "AnimationECS:Update", RHI::DebugContext::Color_CmdTransfer);
+	bool bBoneDataChanged = false;
 
 	for (const auto& data : m_components)
 	{
@@ -500,17 +520,39 @@ Tasks::ITaskPtr AnimationECS::Tick(float deltaTime)
 			data.m_currentMatrices[i] = data.m_globalMatrices[i] * bind;
 		}
 
-		commands->UpdateShaderBinding(cmdList, m_bonesBuffer,
-			data.m_currentMatrices.GetData(),
-			sizeof(glm::mat4) * data.m_currentMatrices.Num(),
-			m_bonesBuffer->GetBufferOffset() + sizeof(glm::mat4) * data.m_gpuOffset);
+		const size_t requiredMatrices = static_cast<size_t>(data.m_gpuOffset) + data.m_currentMatrices.Num();
+		if (m_cpuBoneMatrices.Num() < requiredMatrices)
+		{
+			m_cpuBoneMatrices.Resize(requiredMatrices);
+		}
+		for (size_t matrixIndex = 0u; matrixIndex < data.m_currentMatrices.Num(); ++matrixIndex)
+		{
+			m_cpuBoneMatrices[data.m_gpuOffset + matrixIndex] = data.m_currentMatrices[matrixIndex];
+		}
+		bBoneDataChanged = true;
 	}
 
-	commands->EndDebugRegion(cmdList);
+	if (m_cpuBoneMatrices.Num() != m_nextBoneOffset)
+	{
+		m_cpuBoneMatrices.Resize(m_nextBoneOffset);
+		bBoneDataChanged = true;
+	}
+	if (bBoneDataChanged || !m_publishedBoneMatrices)
+	{
+		m_publishedBoneMatrices = AcquireBoneSnapshot(
+			m_boneSnapshotPool,
+			m_cpuBoneMatrices);
+		++m_animationRevision;
+	}
+
 	return nullptr;
 }
 
 void AnimationECS::FillAnimationData(RHI::RHISceneViewPtr& sceneView)
 {
+	// The empty set is an immutable identity token for this AnimationECS. The
+	// frame graph replaces it with a flight-local binding before recording draws.
 	sceneView->m_boneMatrices = m_bonesBinding;
+	sceneView->m_cpuBoneMatrices = m_publishedBoneMatrices;
+	sceneView->m_animationRevision = m_animationRevision;
 }

--- a/Runtime/ECS/AnimationECS.h
+++ b/Runtime/ECS/AnimationECS.h
@@ -91,6 +91,10 @@ namespace Sailor
 
 		RHI::RHIShaderBindingSetPtr m_bonesBinding{};
 		RHI::RHIShaderBindingPtr m_bonesBuffer{};
+		TVector<glm::mat4> m_cpuBoneMatrices{};
+		TSharedPtr<TVector<glm::mat4>> m_publishedBoneMatrices{};
+		TVector<TSharedPtr<TVector<glm::mat4>>> m_boneSnapshotPool{};
+		uint64_t m_animationRevision = 0ull;
 		uint32_t m_nextBoneOffset = 0;
 	};
 

--- a/Runtime/ECS/LandscapeECS.cpp
+++ b/Runtime/ECS/LandscapeECS.cpp
@@ -353,7 +353,10 @@ namespace
 		shadowMesh.m_maxCameraDistance = maxCameraDistance;
 		if (material->GetRenderState().IsRequiredCustomDepthShader())
 		{
-			shadowMesh.m_customDepthMaterial = material;
+			auto rhiMaterialSource = material;
+			shadowMesh.m_customDepthMaterial = rhiMaterialSource->GetOrAddRHI(
+				mesh->m_vertexDescription);
+			shadowMesh.m_customDepthShader = material->GetShader();
 		}
 
 		auto* textureImporter = App::GetSubmodule<TextureImporter>();
@@ -468,52 +471,225 @@ namespace
 			((componentIndex & 0xfffffu) << 36u) |
 			((chunkIndex & 0xfffffu) << 16u) | (instanceIndex & 0xffffu);
 	}
+
+	bool AreVegetationProfileSettingsEqual(
+		const LandscapeVegetationProfile& lhs,
+		const LandscapeVegetationProfile& rhs)
+	{
+		return lhs.m_modelFileId == rhs.m_modelFileId &&
+			lhs.m_materialFileId == rhs.m_materialFileId &&
+			lhs.m_meshIndex == rhs.m_meshIndex &&
+			lhs.m_instancesPerChunk == rhs.m_instancesPerChunk &&
+			lhs.m_minScale == rhs.m_minScale &&
+			lhs.m_maxScale == rhs.m_maxScale &&
+			lhs.m_groundOffset == rhs.m_groundOffset &&
+			lhs.m_shadowMode == rhs.m_shadowMode &&
+			lhs.m_shadowDistance == rhs.m_shadowDistance &&
+			lhs.m_minLod == rhs.m_minLod &&
+			lhs.m_maxLod == rhs.m_maxLod &&
+			lhs.m_screenCoverageThresholds == rhs.m_screenCoverageThresholds &&
+			lhs.m_cullDistance == rhs.m_cullDistance &&
+			lhs.m_colliderRadius == rhs.m_colliderRadius &&
+			lhs.m_colliderHeight == rhs.m_colliderHeight &&
+			lhs.m_colliderOffsetY == rhs.m_colliderOffsetY;
+	}
+
+	uint64_t CalculateVegetationMaterialRenderMetadataRevision(
+		const LandscapeVegetationProfile& profile)
+	{
+		size_t result = 1469598103934665603ull;
+		if (profile.m_materialFileId)
+		{
+			HashCombine(
+				result,
+				profile.m_material,
+				profile.m_material ? profile.m_material->GetRenderMetadataRevision() : 0ull);
+		}
+		else
+		{
+			HashCombine(result, profile.m_modelMaterials.Num());
+			for (const auto& material : profile.m_modelMaterials)
+			{
+				HashCombine(
+					result,
+					material,
+					material ? material->GetRenderMetadataRevision() : 0ull);
+			}
+		}
+		return static_cast<uint64_t>(result);
+	}
+
+	void MarkChunksIntersectingStamp(
+		LandscapeData& data,
+		const TVector<float>& stamps,
+		size_t offset,
+		float margin)
+	{
+		if (offset + 4u >= stamps.Num())
+		{
+			return;
+		}
+
+		const float radius = (std::max)(stamps[offset + 2u], 0.001f) + margin;
+		const glm::vec2 center(stamps[offset], stamps[offset + 1u]);
+		const float landscapeWidth = data.m_chunksX * data.m_chunkSize;
+		const float landscapeDepth = data.m_chunksZ * data.m_chunkSize;
+		for (uint32_t z = 0u; z < data.m_chunksZ; ++z)
+		{
+			for (uint32_t x = 0u; x < data.m_chunksX; ++x)
+			{
+				const glm::vec2 minimum(
+					x * data.m_chunkSize - landscapeWidth * 0.5f,
+					z * data.m_chunkSize - landscapeDepth * 0.5f);
+				const glm::vec2 maximum = minimum + glm::vec2(data.m_chunkSize);
+				const glm::vec2 closest = glm::clamp(center, minimum, maximum);
+				if (glm::distance(center, closest) <= radius)
+				{
+					data.m_dirtyChunks.Insert(z * data.m_chunksX + x);
+				}
+			}
+		}
+	}
+
+	void MarkChunksAffectedByStampChanges(
+		LandscapeData& data,
+		const TVector<float>& previous,
+		const TVector<float>& current,
+		float margin)
+	{
+		const size_t numStamps = (std::max)(previous.Num(), current.Num()) / 5u;
+		for (size_t stampIndex = 0u; stampIndex < numStamps; ++stampIndex)
+		{
+			const size_t offset = stampIndex * 5u;
+			bool bSame = offset + 4u < previous.Num() && offset + 4u < current.Num();
+			for (size_t valueIndex = 0u; bSame && valueIndex < 5u; ++valueIndex)
+			{
+				bSame = previous[offset + valueIndex] == current[offset + valueIndex];
+			}
+			if (bSame)
+			{
+				continue;
+			}
+
+			MarkChunksIntersectingStamp(data, previous, offset, margin);
+			MarkChunksIntersectingStamp(data, current, offset, margin);
+		}
+	}
 }
 
 void LandscapeData::SetSettings(uint32_t chunksX, uint32_t chunksZ,
 	float chunkSize, uint32_t chunkResolution, float heightScale,
 	float noiseScale, uint32_t seed, float textureTiling)
 {
-	m_chunksX = (std::clamp)(chunksX, 1u, 64u);
-	m_chunksZ = (std::clamp)(chunksZ, 1u, 64u);
-	m_chunkSize = (std::max)(chunkSize, 1.0f);
-	m_chunkResolution = (std::clamp)(chunkResolution, 2u, 128u);
-	m_heightScale = (std::max)(heightScale, 0.0f);
-	m_noiseScale = (std::max)(noiseScale, 0.0001f);
+	const uint32_t normalizedChunksX = (std::clamp)(chunksX, 1u, 64u);
+	const uint32_t normalizedChunksZ = (std::clamp)(chunksZ, 1u, 64u);
+	const float normalizedChunkSize = (std::max)(chunkSize, 1.0f);
+	const uint32_t normalizedChunkResolution = (std::clamp)(chunkResolution, 2u, 128u);
+	const float normalizedHeightScale = (std::max)(heightScale, 0.0f);
+	const float normalizedNoiseScale = (std::max)(noiseScale, 0.0001f);
+	const float normalizedTextureTiling = (std::max)(textureTiling, 0.001f);
+	if (m_chunksX == normalizedChunksX &&
+		m_chunksZ == normalizedChunksZ &&
+		m_chunkSize == normalizedChunkSize &&
+		m_chunkResolution == normalizedChunkResolution &&
+		m_heightScale == normalizedHeightScale &&
+		m_noiseScale == normalizedNoiseScale &&
+		m_seed == seed &&
+		m_textureTiling == normalizedTextureTiling)
+	{
+		return;
+	}
+
+	m_chunksX = normalizedChunksX;
+	m_chunksZ = normalizedChunksZ;
+	m_chunkSize = normalizedChunkSize;
+	m_chunkResolution = normalizedChunkResolution;
+	m_heightScale = normalizedHeightScale;
+	m_noiseScale = normalizedNoiseScale;
 	m_seed = seed;
-	m_textureTiling = (std::max)(textureTiling, 0.001f);
-	MarkDirty();
+	m_textureTiling = normalizedTextureTiling;
+	RequestFullRebuild();
 }
 
 void LandscapeData::SetMaterial(const MaterialPtr& material)
 {
+	if (m_material == material)
+	{
+		return;
+	}
 	m_material = material;
 	m_runtimeMaterial.Clear();
-	MarkDirty();
+	m_cachedSourceMaterialContentRevision = 0ull;
+	m_cachedSourceMaterialRenderMetadataRevision = 0ull;
+	RequestFullRebuild();
 }
 
 void LandscapeData::SetLayerTextures(const TVector<FileId>& textures)
 {
-	m_layerTextures = textures;
-	if (m_layerTextures.Num() > 4u) m_layerTextures.Resize(4u);
+	TVector<FileId> normalized = textures;
+	if (normalized.Num() > 4u) normalized.Resize(4u);
+	if (m_layerTextures == normalized)
+	{
+		return;
+	}
+	m_layerTextures = std::move(normalized);
 	m_runtimeMaterial.Clear();
-	MarkDirty();
+	m_cachedSourceMaterialContentRevision = 0ull;
+	m_cachedSourceMaterialRenderMetadataRevision = 0ull;
+	RequestFullRebuild();
 }
 
 void LandscapeData::SetImportMaps(const FileId& heightmapTexture,
 	const TVector<FileId>& materialMasks)
 {
+	TVector<FileId> normalizedMasks = materialMasks;
+	if (normalizedMasks.Num() > 4u) normalizedMasks.Resize(4u);
+	if (m_heightmapTexture == heightmapTexture && m_materialMasks == normalizedMasks)
+	{
+		return;
+	}
 	m_heightmapTexture = heightmapTexture;
-	m_materialMasks = materialMasks;
-	if (m_materialMasks.Num() > 4u) m_materialMasks.Resize(4u);
-	MarkDirty();
+	m_materialMasks = std::move(normalizedMasks);
+	RequestFullRebuild();
 }
 
 void LandscapeData::SetAuthoredStamps(const TVector<float>& sculptStamps,
 	const TVector<float>& paintStamps)
 {
+	if (m_sculptStamps == sculptStamps && m_paintStamps == paintStamps)
+	{
+		return;
+	}
+
+	if (!m_bRebuildAllChunks &&
+		m_chunks.Num() == static_cast<size_t>(m_chunksX) * m_chunksZ)
+	{
+		const float normalSampleMargin = m_chunkSize /
+			static_cast<float>((std::max)(m_chunkResolution, 1u));
+		MarkChunksAffectedByStampChanges(
+			*this,
+			m_sculptStamps,
+			sculptStamps,
+			normalSampleMargin);
+		MarkChunksAffectedByStampChanges(
+			*this,
+			m_paintStamps,
+			paintStamps,
+			0.0f);
+	}
+	else
+	{
+		m_bRebuildAllChunks = true;
+	}
 	m_sculptStamps = sculptStamps;
 	m_paintStamps = paintStamps;
+	MarkDirty();
+}
+
+void LandscapeData::RequestFullRebuild()
+{
+	m_bRebuildAllChunks = true;
+	m_dirtyChunks.Clear();
 	MarkDirty();
 }
 
@@ -536,9 +712,9 @@ void LandscapeData::SetVegetationProfiles(
 	const TVector<float>& colliderHeight,
 	const TVector<float>& colliderOffsetY)
 {
-	m_vegetationProfiles.Clear();
+	TVector<LandscapeVegetationProfile> profiles;
 	const size_t numProfiles = models.Num();
-	m_vegetationProfiles.Reserve(numProfiles);
+	profiles.Reserve(numProfiles);
 	for (size_t index = 0u; index < numProfiles; ++index)
 	{
 		LandscapeVegetationProfile profile;
@@ -570,13 +746,46 @@ void LandscapeData::SetVegetationProfiles(
 		profile.m_colliderHeight = (std::max)(GetProfileValue(colliderHeight, index, 2.0f),
 			profile.m_colliderRadius * 2.0f);
 		profile.m_colliderOffsetY = GetProfileValue(colliderOffsetY, index, 1.0f);
-		m_vegetationProfiles.Add(std::move(profile));
+		profiles.Add(std::move(profile));
 	}
-	MarkDirty();
+
+	bool bSettingsChanged = profiles.Num() != m_vegetationProfiles.Num();
+	for (size_t index = 0u; !bSettingsChanged && index < profiles.Num(); ++index)
+	{
+		bSettingsChanged = !AreVegetationProfileSettingsEqual(
+			profiles[index],
+			m_vegetationProfiles[index]);
+	}
+	if (!bSettingsChanged)
+	{
+		return;
+	}
+
+	for (size_t index = 0u; index < profiles.Num() && index < m_vegetationProfiles.Num(); ++index)
+	{
+		auto& profile = profiles[index];
+		const auto& previous = m_vegetationProfiles[index];
+		if (profile.m_modelFileId == previous.m_modelFileId)
+		{
+			profile.m_model = previous.m_model;
+			profile.m_modelMaterials = previous.m_modelMaterials;
+			profile.m_bModelMaterialsRequested = previous.m_bModelMaterialsRequested;
+		}
+		if (profile.m_materialFileId == previous.m_materialFileId)
+		{
+			profile.m_material = previous.m_material;
+			profile.m_cachedMaterialRenderMetadataRevision =
+				previous.m_cachedMaterialRenderMetadataRevision;
+		}
+	}
+	m_vegetationProfiles = std::move(profiles);
+	RequestFullRebuild();
 }
 
 void LandscapeECS::BeginPlay()
 {
+	m_rhiScene = RHI::RHIScenePtr::Make();
+	PublishSceneVersion();
 }
 
 void LandscapeECS::OnComponentUnregistered(size_t, LandscapeData& component)
@@ -585,6 +794,7 @@ void LandscapeECS::OnComponentUnregistered(size_t, LandscapeData& component)
 	component.m_chunks.Clear();
 	component.m_runtimeMaterial.Clear();
 	++m_shadowCastersRevision;
+	PublishSceneVersion();
 }
 
 void LandscapeECS::DestroyPhysicsBodies(LandscapeData& component)
@@ -598,11 +808,32 @@ void LandscapeECS::DestroyPhysicsBodies(LandscapeData& component)
 		}
 	}
 	component.m_physicsBodies.Clear();
+	for (auto& chunk : component.m_chunks)
+	{
+		chunk.m_physicsBodies.Clear();
+	}
+}
+
+void LandscapeECS::DestroyChunkPhysicsBodies(
+	LandscapeData& component,
+	LandscapeChunk& chunk)
+{
+	auto* physics = GetWorld() ? GetWorld()->GetECS<PhysicsECS>() : nullptr;
+	for (uint32_t bodyId : chunk.m_physicsBodies)
+	{
+		if (physics)
+		{
+			physics->DestroyExternalBody(bodyId);
+		}
+		component.m_physicsBodies.Remove(bodyId);
+	}
+	chunk.m_physicsBodies.Clear();
 }
 
 Tasks::ITaskPtr LandscapeECS::Tick(float)
 {
 	SAILOR_PROFILE_FUNCTION();
+	bool bSceneChanged = false;
 	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
 	{
 		if (!IsComponentRegistered(componentIndex))
@@ -613,11 +844,69 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		auto& data = m_components[componentIndex];
 		GameObjectPtr owner = const_cast<ObjectPtr&>(data.GetOwner()).StaticCast<GameObject>();
 		const bool transformChanged = owner && owner->GetTransformComponent().GetFrameLastChange() > data.GetFrameLastChange();
+		const bool bTerrainMaterialReady = data.m_material && data.m_material->IsReady();
+		if (data.m_runtimeMaterial)
+		{
+			// Publishing is fence-gated. Calling IsReady every tick advances the
+			// runtime material only after its cloned bindings are upload-complete.
+			data.m_runtimeMaterial->IsReady();
+		}
+		const bool bTerrainMaterialContentRevisionChanged =
+			data.m_runtimeMaterial && data.m_material &&
+			data.m_cachedSourceMaterialContentRevision !=
+				data.m_material->GetContentRevision();
+		const bool bTerrainMaterialRenderMetadataRevisionChanged =
+			data.m_runtimeMaterial && data.m_material &&
+			data.m_cachedSourceMaterialRenderMetadataRevision !=
+				data.m_material->GetRenderMetadataRevision();
+		bool bVegetationMaterialRenderMetadataRevisionChanged = false;
+		for (const auto& profile : data.m_vegetationProfiles)
+		{
+			if (profile.m_material)
+			{
+				profile.m_material->IsReady();
+			}
+			for (const auto& material : profile.m_modelMaterials)
+			{
+				if (material)
+				{
+					material->IsReady();
+				}
+			}
+			bVegetationMaterialRenderMetadataRevisionChanged |=
+				profile.m_cachedMaterialRenderMetadataRevision !=
+				CalculateVegetationMaterialRenderMetadataRevision(profile);
+		}
+		if (bTerrainMaterialRenderMetadataRevisionChanged)
+		{
+			data.m_runtimeMaterial.Clear();
+		}
+		if (bTerrainMaterialRenderMetadataRevisionChanged ||
+			bVegetationMaterialRenderMetadataRevisionChanged)
+		{
+			data.RequestFullRebuild();
+		}
+		else if (bTerrainMaterialContentRevisionChanged)
+		{
+			if (bTerrainMaterialReady)
+			{
+				// Landscape keeps its layer samplers on a private material instance.
+				// Copy only source uniform values and version its bindings in place;
+				// chunk meshes, physics, vegetation and scene records remain shared.
+				data.m_runtimeMaterial->SynchronizeUniformValues(*data.m_material);
+				data.m_cachedSourceMaterialContentRevision =
+					data.m_material->GetContentRevision();
+			}
+			else
+			{
+				data.MarkDirty();
+			}
+		}
 		if (!data.IsDirty() && !transformChanged)
 		{
 			continue;
 		}
-		if (!owner || !data.m_material || !data.m_material->IsReady())
+		if (!owner || !bTerrainMaterialReady)
 		{
 			data.MarkDirty();
 			continue;
@@ -637,6 +926,10 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 				}
 			}
 			data.m_runtimeMaterial->UpdateRHIResourceAndUniforms();
+			data.m_cachedSourceMaterialContentRevision =
+				data.m_material->GetContentRevision();
+			data.m_cachedSourceMaterialRenderMetadataRevision =
+				data.m_material->GetRenderMetadataRevision();
 		}
 
 		auto* modelImporter = App::GetSubmodule<ModelImporter>();
@@ -656,6 +949,39 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 				modelImporter->LoadDefaultMaterials(profile.m_modelFileId, profile.m_modelMaterials);
 				profile.m_bModelMaterialsRequested = true;
 			}
+		}
+
+		const size_t numLandscapeChunks = static_cast<size_t>(data.m_chunksX) * data.m_chunksZ;
+		const bool bRebuildAllChunks = data.m_bRebuildAllChunks ||
+			transformChanged || data.m_chunks.Num() != numLandscapeChunks;
+		TVector<uint32_t> chunksToBuild;
+		if (bRebuildAllChunks)
+		{
+			chunksToBuild.Resize(numLandscapeChunks);
+			for (uint32_t chunkIndex = 0u; chunkIndex < chunksToBuild.Num(); ++chunkIndex)
+			{
+				chunksToBuild[chunkIndex] = chunkIndex;
+			}
+		}
+		else
+		{
+			chunksToBuild = data.m_dirtyChunks.ToVector();
+			size_t validChunkWriteIndex = 0u;
+			for (const uint32_t chunkIndex : chunksToBuild)
+			{
+				if (chunkIndex < numLandscapeChunks)
+				{
+					chunksToBuild[validChunkWriteIndex++] = chunkIndex;
+				}
+			}
+			chunksToBuild.Resize(validChunkWriteIndex);
+			chunksToBuild.Sort();
+		}
+		if (chunksToBuild.IsEmpty())
+		{
+			data.m_bIsDirty = false;
+			data.SetLastChange(owner->GetTransformComponent().GetFrameLastChange());
+			continue;
 		}
 
 		LandscapeCpuTexture heightmap;
@@ -678,24 +1004,26 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		}
 
 		TVector<Tasks::TaskPtr<LandscapeChunkCpuData>> tasks;
-		tasks.Reserve(static_cast<size_t>(data.m_chunksX) * data.m_chunksZ);
-		for (uint32_t z = 0; z < data.m_chunksZ; ++z)
+		tasks.Reserve(chunksToBuild.Num());
+		for (uint32_t chunkIndex : chunksToBuild)
 		{
-			for (uint32_t x = 0; x < data.m_chunksX; ++x)
-			{
-				auto task = Tasks::CreateTask<LandscapeChunkCpuData>(
-					"LandscapeECS:Build Chunk", [&data, &heightmap, &materialMasks, x, z]()
-					{
-						return BuildChunk(data, heightmap, materialMasks, x, z);
-					}, EThreadType::Worker);
-				task->Run();
-				tasks.Add(task);
-			}
+			const uint32_t x = chunkIndex % data.m_chunksX;
+			const uint32_t z = chunkIndex / data.m_chunksX;
+			auto task = Tasks::CreateTask<LandscapeChunkCpuData>(
+				"LandscapeECS:Build Chunk", [&data, &heightmap, &materialMasks, x, z]()
+				{
+					return BuildChunk(data, heightmap, materialMasks, x, z);
+				}, EThreadType::Worker);
+			task->Run();
+			tasks.Add(task);
 		}
 
-		data.m_chunks.Clear();
-		DestroyPhysicsBodies(data);
-		data.m_chunks.Reserve(tasks.Num());
+		if (bRebuildAllChunks)
+		{
+			DestroyPhysicsBodies(data);
+			data.m_chunks.Clear();
+			data.m_chunks.Resize(numLandscapeChunks);
+		}
 		size_t vegetationRenderProxies = 0u;
 		size_t vegetationProfilesNotReady = 0u;
 		size_t vegetationProfilesWithoutRenderData = 0u;
@@ -703,10 +1031,16 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		const glm::mat4 ownerMatrix = owner->GetTransformComponent().GetCachedWorldMatrix();
 		const Math::Transform ownerTransform = Math::Transform::FromMatrix(ownerMatrix);
 		auto* physics = GetWorld()->GetECS<PhysicsECS>();
-		for (size_t chunkIndex = 0; chunkIndex < tasks.Num(); ++chunkIndex)
+		for (size_t taskIndex = 0u; taskIndex < tasks.Num(); ++taskIndex)
 		{
-			tasks[chunkIndex]->Wait();
-			auto& cpu = tasks[chunkIndex]->m_result;
+			const uint32_t chunkIndex = chunksToBuild[taskIndex];
+			tasks[taskIndex]->Wait();
+			auto& cpu = tasks[taskIndex]->m_result;
+			if (!bRebuildAllChunks)
+			{
+				DestroyChunkPhysicsBodies(data, data.m_chunks[chunkIndex]);
+			}
+			LandscapeChunk chunk;
 			TVector<glm::vec3> collisionVertices;
 			collisionVertices.Resize(cpu.m_vertices.Num());
 			for (size_t vertexIndex = 0u; vertexIndex < cpu.m_vertices.Num(); ++vertexIndex)
@@ -719,6 +1053,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 				ownerTransform.m_rotation, glm::vec3(ownerTransform.m_scale), physicsBodyId))
 			{
 				data.m_physicsBodies.Add(physicsBodyId);
+				chunk.m_physicsBodies.Add(physicsBodyId);
 			}
 			TVector<Physics::CollisionShapeDesc> vegetationCollisionShapes;
 			for (const auto& placement : cpu.m_vegetation)
@@ -743,6 +1078,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 					glm::vec3(ownerTransform.m_scale), physicsBodyId))
 			{
 				data.m_physicsBodies.Add(physicsBodyId);
+				chunk.m_physicsBodies.Add(physicsBodyId);
 			}
 			auto mesh = RHI::Renderer::GetDriver()->CreateMesh();
 			mesh->m_vertexDescription = RHI::Renderer::GetDriver()->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4>();
@@ -752,8 +1088,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 				cpu.m_vertices.GetData(), cpu.m_vertices.Num() * sizeof(RHI::VertexP3N3T3B3UV2C4),
 				cpu.m_indices.GetData(), cpu.m_indices.Num() * sizeof(uint32_t));
 
-			LandscapeChunk chunk;
-			auto& proxy = chunk.m_proxy;
+			RHI::RHISceneViewProxy proxy;
 			proxy.m_staticMeshEcs = LandscapeProxyId(componentIndex, chunkIndex);
 			proxy.m_worldMatrix = ownerMatrix;
 			proxy.m_worldAabb = cpu.m_localBounds;
@@ -840,7 +1175,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 					continue;
 				}
 				LandscapeVegetationRenderProxy vegetationRenderProxy;
-				auto& vegetationProxy = vegetationRenderProxy.m_proxy;
+				RHI::RHISceneViewProxy vegetationProxy;
 				vegetationProxy.m_staticMeshEcs = LandscapeVegetationProxyId(
 					componentIndex, chunkIndex, profileIndex);
 				vegetationProxy.m_worldMatrix = ownerMatrix;
@@ -853,6 +1188,79 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 				vegetationProxy.m_lodPolicy.m_screenCoverageThresholds =
 					profile.m_screenCoverageThresholds;
 				vegetationProxy.m_lodPolicy.m_maxCameraDistance = profile.m_cullDistance;
+				RHI::RHIInstancedMeshGroup instanceGroup;
+				instanceGroup.m_bCastShadows = vegetationProxy.m_bCastShadows;
+				instanceGroup.m_maxShadowDistance = (std::min)(profile.m_cullDistance,
+					profile.m_shadowMode == ELandscapeVegetationShadowMode::NearOnly ?
+					profile.m_shadowDistance : (std::numeric_limits<float>::max)());
+				instanceGroup.m_materials.Reserve(vegetationMeshes.Num());
+				instanceGroup.m_sourceMaterialShaders.Reserve(vegetationMeshes.Num());
+				instanceGroup.m_renderQueueTags.Reserve(vegetationMeshes.Num());
+				instanceGroup.m_baseColorFactors.Reserve(vegetationMeshes.Num());
+				instanceGroup.m_baseColorSamplers.Reserve(vegetationMeshes.Num());
+				instanceGroup.m_alphaCutoffs.Reserve(vegetationMeshes.Num());
+#if defined(__APPLE__)
+				instanceGroup.m_materialTextureSamplers.Resize(vegetationMeshes.Num());
+#endif
+				for (size_t meshIndex = 0u; meshIndex < vegetationMeshes.Num(); ++meshIndex)
+				{
+					MaterialPtr& material = vegetationMaterials[meshIndex];
+					instanceGroup.m_sourceMaterialShaders.Add(material->GetShader());
+					instanceGroup.m_materials.Add(material->GetOrAddRHI(
+						vegetationMeshes[meshIndex]->m_vertexDescription));
+					instanceGroup.m_renderQueueTags.Add(material->GetRenderState().GetTag());
+
+					glm::vec4 baseColorFactor{ 1.0f };
+					const glm::vec4* materialBaseColorFactor = nullptr;
+					if (!material->GetUniformsVec4().Find(
+						"material.baseColorFactor",
+						materialBaseColorFactor))
+					{
+						material->GetUniformsVec4().Find("material.albedo", materialBaseColorFactor);
+					}
+					if (materialBaseColorFactor)
+					{
+						baseColorFactor = *materialBaseColorFactor;
+					}
+					instanceGroup.m_baseColorFactors.Add(baseColorFactor);
+
+					float alphaCutoff = 0.5f;
+					const float* materialAlphaCutoff = nullptr;
+					if (material->GetUniformsFloat().Find(
+						"material.alphaCutoff",
+						materialAlphaCutoff) && materialAlphaCutoff)
+					{
+						alphaCutoff = *materialAlphaCutoff;
+					}
+					instanceGroup.m_alphaCutoffs.Add(alphaCutoff);
+
+					uint32_t baseColorSampler = 0u;
+					const TexturePtr* baseColorTexture = nullptr;
+					if (!material->GetSamplers().Find("baseColorSampler", baseColorTexture))
+					{
+						material->GetSamplers().Find("albedoSampler", baseColorTexture);
+					}
+					if (textureImporter && baseColorTexture && *baseColorTexture)
+					{
+						baseColorSampler = static_cast<uint32_t>(
+							textureImporter->GetTextureIndex((*baseColorTexture)->GetFileId()));
+					}
+					instanceGroup.m_baseColorSamplers.Add(baseColorSampler);
+#if defined(__APPLE__)
+					auto& requested = instanceGroup.m_materialTextureSamplers[meshIndex];
+					requested.Insert(0u);
+					if (textureImporter)
+					{
+						for (const auto& sampler : material->GetSamplers())
+						{
+							requested.Insert(sampler.m_second ? static_cast<uint32_t>(
+								textureImporter->GetTextureIndex(sampler.m_second->GetFileId())) : 0u);
+						}
+					}
+#endif
+				}
+				instanceGroup.m_meshes = std::move(vegetationMeshes);
+				instanceGroup.m_meshTransforms = std::move(vegetationModelMatrices);
 				auto vegetationShadowCaster = RHI::RHIShadowCasterProxyPtr::Make();
 				vegetationShadowCaster->m_staticMeshEcs = vegetationProxy.m_staticMeshEcs;
 				vegetationShadowCaster->m_skeletonOffset =
@@ -864,9 +1272,6 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 				vegetationShadowCaster->m_lodPolicy.m_screenCoverageThresholds =
 					profile.m_screenCoverageThresholds;
 				Math::AABB batchedVegetationBounds;
-				const float shadowDistance = (std::min)(profile.m_cullDistance,
-					profile.m_shadowMode == ELandscapeVegetationShadowMode::NearOnly ?
-					profile.m_shadowDistance : (std::numeric_limits<float>::max)());
 				for (const auto& placement : cpu.m_vegetation)
 				{
 					if (placement.m_profileIndex != profileIndex)
@@ -874,85 +1279,266 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 						continue;
 					}
 
-					const glm::mat4 instanceMatrix = ownerMatrix *
+					const glm::mat4 localInstanceMatrix =
 						glm::translate(glm::mat4(1.0f), placement.m_position) *
 						glm::rotate(glm::mat4(1.0f), placement.m_angle, glm::vec3(0.0f, 1.0f, 0.0f)) *
 						glm::scale(glm::mat4(1.0f), glm::vec3(placement.m_scale));
+					instanceGroup.m_instanceTransforms.Add(localInstanceMatrix);
+					const glm::mat4 instanceMatrix = ownerMatrix * localInstanceMatrix;
 					Math::AABB instanceBounds = vegetationBounds;
 					instanceBounds.Apply(instanceMatrix);
 					batchedVegetationBounds.Extend(instanceBounds);
-					for (size_t meshIndex = 0; meshIndex < vegetationMeshes.Num(); ++meshIndex)
-					{
-						MaterialPtr& material = vegetationMaterials[meshIndex];
-						const glm::mat4 meshMatrix = instanceMatrix * vegetationModelMatrices[meshIndex];
-						vegetationProxy.m_meshes.Add(vegetationMeshes[meshIndex]);
-						vegetationProxy.m_meshModelMatrices.Add(meshMatrix);
-						vegetationProxy.m_overrideMaterials.Add(material->GetOrAddRHI(
-							vegetationMeshes[meshIndex]->m_vertexDescription));
-						vegetationProxy.m_renderQueueTags.Add(material->GetRenderState().GetTag());
-						AppendDepthMaterialMetadata(vegetationProxy, material);
-						if (profile.m_shadowMode != ELandscapeVegetationShadowMode::None)
-						{
-							AppendShadowMesh(*vegetationShadowCaster, vegetationMeshes[meshIndex], meshMatrix,
-								material, shadowDistance);
-						}
-					}
 				}
-				if (vegetationProxy.m_meshes.IsEmpty() || !batchedVegetationBounds.IsValid())
+				if (instanceGroup.m_instanceTransforms.IsEmpty() ||
+					instanceGroup.m_meshes.IsEmpty() ||
+					!batchedVegetationBounds.IsValid())
 				{
 					continue;
 				}
 				vegetationProxy.m_worldAabb = batchedVegetationBounds;
 				vegetationShadowCaster->m_worldAabb = vegetationProxy.m_worldAabb;
-				vegetationProxy.m_shadowCaster = vegetationShadowCaster->m_meshes.IsEmpty() ?
-					RHI::RHIShadowCasterProxyPtr{} : vegetationShadowCaster;
-#if defined(__APPLE__)
-				vegetationProxy.m_materialTextureSamplers.Resize(vegetationProxy.m_meshes.Num());
-				for (size_t proxyMeshIndex = 0u;
-					proxyMeshIndex < vegetationProxy.m_materialTextureSamplers.Num(); ++proxyMeshIndex)
-				{
-					auto& requested = vegetationProxy.m_materialTextureSamplers[proxyMeshIndex];
-					requested.Insert(0u);
-					if (textureImporter)
-					{
-						const MaterialPtr& material = vegetationMaterials[
-							proxyMeshIndex % vegetationMaterials.Num()];
-						for (const auto& sampler : material->GetSamplers())
-						{
-							requested.Insert(sampler.m_second ? static_cast<uint32_t>(
-								textureImporter->GetTextureIndex(sampler.m_second->GetFileId())) : 0u);
-						}
-					}
-				}
-#endif
+				vegetationProxy.m_shadowCaster = vegetationProxy.m_bCastShadows ?
+					vegetationShadowCaster : RHI::RHIShadowCasterProxyPtr{};
+				vegetationProxy.m_instancedGroups.Add(std::move(instanceGroup));
 				GetOctreeBounds(vegetationProxy.m_worldAabb,
 					vegetationRenderProxy.m_octreeCenter, vegetationRenderProxy.m_octreeExtents);
+				vegetationRenderProxy.m_resource =
+					RHI::RHISceneProxyResourcePtr::Make(std::move(vegetationProxy));
 				chunk.m_vegetationProxies.Add(std::move(vegetationRenderProxy));
 				++vegetationRenderProxies;
 			}
-			data.m_chunks.Add(std::move(chunk));
+			chunk.m_resource = RHI::RHISceneProxyResourcePtr::Make(std::move(proxy));
+			chunk.m_buildRevision = ++data.m_buildRevision;
+			data.m_chunks[chunkIndex] = std::move(chunk);
 		}
 		// Model and material import tasks complete before their GPU upload fences do.
 		// Keep the component dirty while valid vegetation resources are pending so
 		// the next frame can populate the vegetation proxies after those fences signal.
+		data.m_dirtyChunks.Clear();
+		data.m_bRebuildAllChunks = bVegetationResourcesPending;
 		data.m_bIsDirty = bVegetationResourcesPending;
+		for (auto& profile : data.m_vegetationProfiles)
+		{
+			profile.m_cachedMaterialRenderMetadataRevision =
+				CalculateVegetationMaterialRenderMetadataRevision(profile);
+		}
 		data.SetLastChange(owner->GetTransformComponent().GetFrameLastChange());
-		++data.m_buildRevision;
 		++m_shadowCastersRevision;
+		bSceneChanged = true;
 		size_t vegetationPerChunk = 0u;
 		for (const auto& profile : data.m_vegetationProfiles)
 		{
 			vegetationPerChunk += profile.m_instancesPerChunk;
 		}
-		SAILOR_LOG("LandscapeECS: built %zu chunks with %zu collision bodies (%ux%u, %.1fm, resolution %u), %zu vegetation profiles, %zu instances per chunk and %zu render proxies (%zu profile loads not ready, %zu without render data), %zu sculpt and %zu paint stamps, revision %llu.",
-			data.m_chunks.Num(), data.m_physicsBodies.Num(), data.m_chunksX, data.m_chunksZ, data.m_chunkSize,
+		SAILOR_LOG("LandscapeECS: rebuilt %zu of %zu chunks with %zu collision bodies (%ux%u, %.1fm, resolution %u), %zu vegetation profiles, %zu instances per chunk and %zu render proxies (%zu profile loads not ready, %zu without render data), %zu sculpt and %zu paint stamps, revision %llu.",
+			chunksToBuild.Num(), data.m_chunks.Num(), data.m_physicsBodies.Num(), data.m_chunksX, data.m_chunksZ, data.m_chunkSize,
 			data.m_chunkResolution, data.m_vegetationProfiles.Num(), vegetationPerChunk,
 			vegetationRenderProxies, vegetationProfilesNotReady,
 			vegetationProfilesWithoutRenderData,
 			data.m_sculptStamps.Num() / 5u, data.m_paintStamps.Num() / 5u,
 			static_cast<unsigned long long>(data.m_buildRevision));
 	}
+	if (bSceneChanged)
+	{
+		PublishSceneVersion();
+	}
 	return nullptr;
+}
+
+void LandscapeECS::PublishSceneVersion()
+{
+	auto version = RHI::RHISpatialSceneVersionPtr::Make();
+	version->m_revision = ++m_sceneVersionRevision;
+	version->m_shadowCastersRevision = m_shadowCastersRevision;
+	version->m_scene = m_rhiScene;
+	TSet<size_t> activeProducerKeys;
+	size_t spatialHash = 1469598103934665603ull;
+	auto hashSpatialEntry = [&spatialHash](
+		const RHI::RenderInstanceHandle& handle,
+		const glm::ivec3& center,
+		const glm::ivec3& extents)
+		{
+			HashCombine(
+				spatialHash,
+				handle.m_slot,
+				handle.m_generation,
+				center.x,
+				center.y,
+				center.z,
+				extents.x,
+				extents.y,
+				extents.z);
+		};
+
+	auto publishProxy = [this, &activeProducerKeys](
+		const RHI::RHISceneProxyResourcePtr& resource,
+		uint64_t buildRevision) -> RHI::RenderInstanceHandle
+		{
+			if (!m_rhiScene || !resource)
+			{
+				return {};
+			}
+
+			const auto& proxy = resource->m_proxy;
+			const size_t producerKey = proxy.m_staticMeshEcs;
+			activeProducerKeys.Insert(producerKey);
+			RHI::RenderInstanceHandle* handle = nullptr;
+			uint64_t* publishedRevision = nullptr;
+			if (m_renderInstanceHandles.Find(producerKey, handle) && handle &&
+				m_publishedBuildRevisions.Find(producerKey, publishedRevision) &&
+				publishedRevision && *publishedRevision == buildRevision)
+			{
+				return *handle;
+			}
+
+			RHI::RHISceneInstanceRecord record;
+			record.m_producerKey = producerKey;
+			record.m_mobility = EMobilityType::Static;
+			record.m_worldMatrix = proxy.m_worldMatrix;
+			record.m_worldBounds = proxy.m_worldAabb;
+			record.m_topology = resource;
+			record.m_topologyRevision = buildRevision;
+			record.m_materialRevision = Material::GetGlobalContentRevision();
+			record.m_shadowRevision = resource->m_shadowRevision;
+			record.m_skeletonOffset = proxy.m_skeletonOffset;
+			record.m_renderFlags = proxy.m_bCastShadows ? 1u : 0u;
+
+			if (m_renderInstanceHandles.Find(producerKey, handle) && handle)
+			{
+				m_rhiScene->UpdateInstance(
+					*handle,
+					record,
+					RHI::ToMask(RHI::ESceneChangeBit::ReplaceChunkRange) |
+					RHI::ToMask(RHI::ESceneChangeBit::MeshOrLodTopology) |
+					RHI::ToMask(RHI::ESceneChangeBit::Material) |
+					RHI::ToMask(RHI::ESceneChangeBit::ShadowState));
+			}
+			else
+			{
+				m_renderInstanceHandles[producerKey] = m_rhiScene->AddInstance(record);
+				handle = &m_renderInstanceHandles[producerKey];
+			}
+			m_publishedBuildRevisions[producerKey] = buildRevision;
+			return handle ? *handle : RHI::RenderInstanceHandle{};
+		};
+
+	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
+	{
+		if (!IsComponentRegistered(componentIndex))
+		{
+			continue;
+		}
+
+		const auto& data = m_components[componentIndex];
+		for (const auto& chunk : data.m_chunks)
+		{
+			const auto chunkHandle = publishProxy(chunk.m_resource, chunk.m_buildRevision);
+			if (chunkHandle.IsValid())
+			{
+				hashSpatialEntry(chunkHandle, chunk.m_octreeCenter, chunk.m_octreeExtents);
+			}
+			for (const auto& vegetation : chunk.m_vegetationProxies)
+			{
+				const auto vegetationHandle = publishProxy(
+					vegetation.m_resource,
+					chunk.m_buildRevision);
+				if (vegetationHandle.IsValid())
+				{
+					hashSpatialEntry(
+						vegetationHandle,
+						vegetation.m_octreeCenter,
+						vegetation.m_octreeExtents);
+				}
+			}
+		}
+
+		for (const auto& profile : data.m_vegetationProfiles)
+		{
+			version->m_bHasCustomDepthShadowCasters |= profile.m_material &&
+				profile.m_shadowMode != ELandscapeVegetationShadowMode::None &&
+				profile.m_material->GetRenderState().IsRequiredCustomDepthShader();
+		}
+	}
+	if (m_rhiScene)
+	{
+		for (size_t producerKey : m_renderInstanceHandles.GetKeys())
+		{
+			if (activeProducerKeys.Contains(producerKey))
+			{
+				continue;
+			}
+			RHI::RenderInstanceHandle* handle = nullptr;
+			if (m_renderInstanceHandles.Find(producerKey, handle) && handle)
+			{
+				m_rhiScene->RemoveInstance(*handle);
+			}
+			m_renderInstanceHandles.Remove(producerKey);
+			m_publishedBuildRevisions.Remove(producerKey);
+		}
+
+		const bool bSpatialChanged = !m_publishedSceneVersion ||
+			m_spatialHash != spatialHash;
+		if (bSpatialChanged)
+		{
+			++m_spatialRevision;
+			if (!activeProducerKeys.IsEmpty())
+			{
+				version->m_staticOctree =
+					TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
+						glm::ivec3(0, 0, 0), 16536 * 16, 4);
+				auto appendSpatialEntry = [this, &version](
+					const RHI::RHISceneProxyResourcePtr& resource,
+					const glm::ivec3& center,
+					const glm::ivec3& extents)
+					{
+						if (!resource)
+						{
+							return;
+						}
+						RHI::RenderInstanceHandle* handle = nullptr;
+						if (m_renderInstanceHandles.Find(
+							resource->m_proxy.m_staticMeshEcs,
+							handle) && handle)
+						{
+							version->m_staticOctree->Update(center, extents, *handle);
+						}
+					};
+				for (size_t componentIndex = 0u;
+					componentIndex < m_components.Num(); ++componentIndex)
+				{
+					if (!IsComponentRegistered(componentIndex))
+					{
+						continue;
+					}
+					for (const auto& chunk : m_components[componentIndex].m_chunks)
+					{
+						appendSpatialEntry(
+							chunk.m_resource,
+							chunk.m_octreeCenter,
+							chunk.m_octreeExtents);
+						for (const auto& vegetation : chunk.m_vegetationProxies)
+						{
+							appendSpatialEntry(
+								vegetation.m_resource,
+								vegetation.m_octreeCenter,
+								vegetation.m_octreeExtents);
+						}
+					}
+				}
+			}
+		}
+		else
+		{
+			version->m_staticOctree = m_publishedSceneVersion->m_staticOctree;
+		}
+		m_spatialHash = spatialHash;
+		version->m_sceneVersion = m_rhiScene->PublishVersion(
+			Material::GetGlobalContentRevision(),
+			m_shadowCastersRevision,
+			m_spatialRevision);
+	}
+
+	m_publishedSceneVersion = std::move(version);
 }
 
 void LandscapeECS::AppendSceneView(RHI::RHISceneViewPtr& sceneView) const
@@ -961,32 +1547,7 @@ void LandscapeECS::AppendSceneView(RHI::RHISceneViewPtr& sceneView) const
 	{
 		return;
 	}
-	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
-	{
-		if (!IsComponentRegistered(componentIndex))
-		{
-			continue;
-		}
-		for (const auto& chunk : m_components[componentIndex].m_chunks)
-		{
-			sceneView->m_staticOctree.Update(chunk.m_octreeCenter, chunk.m_octreeExtents, chunk.m_proxy);
-			for (const auto& vegetation : chunk.m_vegetationProxies)
-			{
-				sceneView->m_staticOctree.Update(
-					vegetation.m_octreeCenter,
-					vegetation.m_octreeExtents,
-					vegetation.m_proxy);
-			}
-		}
-		for (const auto& profile : m_components[componentIndex].m_vegetationProfiles)
-		{
-			sceneView->m_bHasCustomDepthShadowCasters |= profile.m_material &&
-				profile.m_shadowMode != ELandscapeVegetationShadowMode::None &&
-				profile.m_material->GetRenderState().IsRequiredCustomDepthShader();
-		}
-	}
-	sceneView->m_shadowCastersRevision =
-		sceneView->m_shadowCastersRevision * 1099511628211ull ^ m_shadowCastersRevision;
+	sceneView->AddSceneVersion(m_publishedSceneVersion);
 }
 
 void LandscapeECS::EndPlay()
@@ -997,4 +1558,11 @@ void LandscapeECS::EndPlay()
 	}
 	ECS::TSystem<LandscapeECS, LandscapeData>::EndPlay();
 	m_shadowCastersRevision = 0u;
+	m_sceneVersionRevision = 0u;
+	m_spatialRevision = 0u;
+	m_spatialHash = 0u;
+	m_publishedSceneVersion.Clear();
+	m_rhiScene.Clear();
+	m_renderInstanceHandles.Clear();
+	m_publishedBuildRevisions.Clear();
 }

--- a/Runtime/ECS/LandscapeECS.h
+++ b/Runtime/ECS/LandscapeECS.h
@@ -20,6 +20,7 @@ namespace Sailor
 		MaterialPtr m_material{};
 		TVector<MaterialPtr> m_modelMaterials{};
 		bool m_bModelMaterialsRequested = false;
+		uint64_t m_cachedMaterialRenderMetadataRevision = 0ull;
 		int32_t m_meshIndex = -1;
 		uint32_t m_instancesPerChunk = 0u;
 		float m_minScale = 0.75f;
@@ -38,17 +39,19 @@ namespace Sailor
 
 	struct LandscapeVegetationRenderProxy final
 	{
-		RHI::RHISceneViewProxy m_proxy{};
+		RHI::RHISceneProxyResourcePtr m_resource{};
 		glm::ivec3 m_octreeCenter{};
 		glm::ivec3 m_octreeExtents{ 1 };
 	};
 
 	struct LandscapeChunk final
 	{
-		RHI::RHISceneViewProxy m_proxy{};
+		RHI::RHISceneProxyResourcePtr m_resource{};
 		glm::ivec3 m_octreeCenter{};
 		glm::ivec3 m_octreeExtents{ 1 };
 		TVector<LandscapeVegetationRenderProxy> m_vegetationProxies{};
+		TVector<uint32_t> m_physicsBodies{};
+		uint64_t m_buildRevision = 0u;
 	};
 
 	class LandscapeData final : public ECS::TComponent
@@ -63,6 +66,7 @@ namespace Sailor
 			const TVector<FileId>& materialMasks);
 		SAILOR_API void SetAuthoredStamps(const TVector<float>& sculptStamps,
 			const TVector<float>& paintStamps);
+		SAILOR_API void RequestFullRebuild();
 		SAILOR_API void SetVegetationProfiles(
 			const TVector<FileId>& models,
 			const TVector<FileId>& materials,
@@ -96,6 +100,8 @@ namespace Sailor
 		float m_textureTiling = 0.15f;
 		MaterialPtr m_material{};
 		MaterialPtr m_runtimeMaterial{};
+		uint64_t m_cachedSourceMaterialContentRevision = 0ull;
+		uint64_t m_cachedSourceMaterialRenderMetadataRevision = 0ull;
 		TVector<FileId> m_layerTextures{};
 		FileId m_heightmapTexture{};
 		TVector<FileId> m_materialMasks{};
@@ -104,6 +110,8 @@ namespace Sailor
 		TVector<LandscapeVegetationProfile> m_vegetationProfiles{};
 		TVector<LandscapeChunk> m_chunks{};
 		TVector<uint32_t> m_physicsBodies{};
+		TSet<uint32_t> m_dirtyChunks{};
+		bool m_bRebuildAllChunks = true;
 		uint64_t m_buildRevision = 0u;
 
 		friend class LandscapeECS;
@@ -123,7 +131,16 @@ namespace Sailor
 
 	private:
 		void DestroyPhysicsBodies(LandscapeData& component);
+		void DestroyChunkPhysicsBodies(LandscapeData& component, LandscapeChunk& chunk);
+		void PublishSceneVersion();
 		uint64_t m_shadowCastersRevision = 0u;
+		uint64_t m_sceneVersionRevision = 0u;
+		uint64_t m_spatialRevision = 0u;
+		size_t m_spatialHash = 0u;
+		RHI::RHISpatialSceneVersionPtr m_publishedSceneVersion{};
+		RHI::RHIScenePtr m_rhiScene{};
+		TMap<size_t, RHI::RenderInstanceHandle> m_renderInstanceHandles{};
+		TMap<size_t, uint64_t> m_publishedBuildRevisions{};
 	};
 
 	template class ECS::TSystem<LandscapeECS, LandscapeData>;

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -8,11 +8,32 @@
 #include "Engine/GameObject.h"
 #include "FrameGraph/ShadowPrepassNode.h"
 
+#include <array>
+
 using namespace Sailor;
 using namespace Sailor::Tasks;
 
 namespace
 {
+	TSharedPtr<TVector<LightingECS::LightShaderData>> AcquireLightsSnapshot(
+		TVector<TSharedPtr<TVector<LightingECS::LightShaderData>>>& pool,
+		const TVector<LightingECS::LightShaderData>& source)
+	{
+		for (auto& candidate : pool)
+		{
+			if (candidate && !candidate.IsShared())
+			{
+				*candidate = source;
+				return candidate;
+			}
+		}
+
+		auto snapshot = TSharedPtr<TVector<LightingECS::LightShaderData>>::Make();
+		*snapshot = source;
+		pool.Add(snapshot);
+		return snapshot;
+	}
+
 	bool AreMatricesExactlyEqual(const glm::mat4& lhs, const glm::mat4& rhs)
 	{
 		for (glm::length_t column = 0; column < lhs.length(); ++column)
@@ -28,21 +49,102 @@ namespace
 
 		return true;
 	}
+
+	void ResolveShadowCasterUpdatePolicy(
+		const TVector<RHI::RHIVisibleShadowCaster>& casters,
+		bool& outContainsDynamicCasters,
+		bool& outContainsAnimatedCasters)
+	{
+		outContainsDynamicCasters = false;
+		outContainsAnimatedCasters = false;
+		for (const auto& caster : casters)
+		{
+			outContainsDynamicCasters |=
+				caster.GetMobility() == EMobilityType::Dynamic;
+			outContainsAnimatedCasters |=
+				caster.GetSkeletonOffset() !=
+				(std::numeric_limits<uint32_t>::max)();
+			if (outContainsDynamicCasters && outContainsAnimatedCasters)
+			{
+				return;
+			}
+		}
+	}
+
+	RHI::RHISubmissionCompletionTokenPtr AcquireShadowPayloadToken(
+		const RHI::RHISubmissionCompletionTokenPtr& cachedToken)
+	{
+		auto token = cachedToken;
+		if (token)
+		{
+			token->Reset();
+		}
+		else
+		{
+			token = RHI::RHISubmissionCompletionTokenPtr::Make();
+		}
+		return token;
+	}
 }
 
-bool CSMLightState::Equals(const CSMLightState& rhs) const
+bool CSMLightState::CanReuse(
+	uint32_t componentIndex,
+	RHI::EShadowType shadowType,
+	const glm::mat4& lightMatrix,
+	uint64_t sceneRevision,
+	const TSharedPtr<TVector<RHI::RHISceneVersionPtr>>& sceneVersions,
+	const Math::Frustum& shadowFrustum,
+	const RHI::RHISubmissionCompletionTokenPtr& currentSubmissionToken,
+	uint64_t animationRevision) const
 {
-	if (m_componentIndex != rhs.m_componentIndex ||
-		m_shadowType != rhs.m_shadowType ||
-		m_snapshot.Num() != rhs.m_snapshot.Num() ||
-		!AreMatricesExactlyEqual(m_lightMatrix, rhs.m_lightMatrix))
+	if (m_componentIndex != componentIndex ||
+		m_shadowType != shadowType ||
+		!AreMatricesExactlyEqual(m_lightMatrix, lightMatrix) ||
+		!m_submissionToken ||
+		(!m_submissionToken->IsSuccessful() &&
+			(!m_submissionToken->IsPending() ||
+				m_submissionToken != currentSubmissionToken)) ||
+		!m_payloadCompletionToken ||
+		(!m_payloadCompletionToken->IsSuccessful() &&
+			(!m_payloadCompletionToken->IsPending() ||
+				m_submissionToken != currentSubmissionToken)))
 	{
 		return false;
 	}
-
-	for (uint32_t i = 0; i < m_snapshot.Num(); i++)
+	if (m_bContainsDynamicCasters &&
+		m_submissionToken != currentSubmissionToken)
 	{
-		if (m_snapshot[i] != rhs.m_snapshot[i])
+		return false;
+	}
+	if (m_bContainsAnimatedCasters &&
+		m_animationRevision != animationRevision)
+	{
+		return false;
+	}
+	if (m_sceneRevision == sceneRevision)
+	{
+		return true;
+	}
+	if (!m_casterSceneVersions || !sceneVersions ||
+		m_casterSceneVersions->Num() != sceneVersions->Num())
+	{
+		return false;
+	}
+	if (m_casterSceneVersions == sceneVersions)
+	{
+		return true;
+	}
+
+	for (size_t index = 0u; index < sceneVersions->Num(); ++index)
+	{
+		const auto& previous = (*m_casterSceneVersions)[index];
+		const auto& current = (*sceneVersions)[index];
+		if (previous == current)
+		{
+			continue;
+		}
+		if (!previous || !current ||
+			current->HasShadowChangesIntersecting(*previous, shadowFrustum))
 		{
 			return false;
 		}
@@ -51,25 +153,13 @@ bool CSMLightState::Equals(const CSMLightState& rhs) const
 	return true;
 }
 
-bool CSMLightState::CanReuse(
-	uint32_t componentIndex,
-	RHI::EShadowType shadowType,
-	const glm::mat4& lightMatrix,
-	uint64_t sceneRevision) const
-{
-	return m_componentIndex == componentIndex &&
-		m_shadowType == shadowType &&
-		m_sceneRevision == sceneRevision &&
-		AreMatricesExactlyEqual(m_lightMatrix, lightMatrix);
-}
-
 void LightingECS::BeginPlay()
 {
 	m_shadowMapsMb = 0.0f;
 	m_csmShadowMapsMb = 0.0f;
+	m_localShadowAllocationRevision = 0ull;
 	auto& driver = Sailor::RHI::Renderer::GetDriver();
 	m_lightsData = driver->CreateShaderBindings();
-	driver->AddSsboToShaderBindings(m_lightsData, "light", sizeof(LightingECS::LightShaderData), LightsMaxNum, 0, true);
 
 	const auto usage = RHI::ETextureUsageBit::ColorAttachment_Bit |
 		RHI::ETextureUsageBit::TextureTransferSrc_Bit |
@@ -77,106 +167,77 @@ void LightingECS::BeginPlay()
 		RHI::ETextureUsageBit::Sampled_Bit;
 
 	m_defaultShadowMap = driver->CreateRenderTarget(glm::ivec2(1, 1), 1, ShadowMapFormat, RHI::ETextureFiltration::Linear, RHI::ETextureClamping::Clamp, usage);
-	for (uint32_t i = 0; i < NumCascades; i++)
-	{
-		char csmDebugName[64];
-		sprintf_s(csmDebugName, sizeof(csmDebugName), "Shadow Map, CSM: %d, Cascade: %d", i / NumCascades, i % NumCascades);
-
-		const bool bEvsmCascade = i % NumCascades == 0;
-		m_csmShadowMaps.Add(driver->CreateRenderTarget(ShadowCascadeResolutions[i % NumCascades], 1,
-			bEvsmCascade ? ShadowMapFormat_Evsm : ShadowMapFormat,
-			bEvsmCascade ? RHI::ETextureFiltration::Linear : RHI::ETextureFiltration::Nearest,
-			RHI::ETextureClamping::Clamp,
-			usage));
-
-		driver->SetDebugName(m_csmShadowMaps[m_csmShadowMaps.Num() - 1], csmDebugName);
-		const float bytesPerPixel = bEvsmCascade ? 16.0f : 2.0f;
-		const float shadowMapMemoryMb = static_cast<float>(
-			ShadowCascadeResolutions[i].x * ShadowCascadeResolutions[i].y) *
-			bytesPerPixel / (1024.0f * 1024.0f);
-		m_csmShadowMapsMb += shadowMapMemoryMb;
-		m_shadowMapsMb += shadowMapMemoryMb;
-	}
+	m_csmShadowMaps.Resize(NumCascades);
+	m_shadowFlightResources.Resize((std::max)(
+		1u,
+		RHI::Renderer::GetDriver()->GetMaxFramesInFlight()));
 
 	m_shadowMapOwners.Resize(MaxShadowsInView);
-	TVector<RHI::RHITexturePtr> shadowMaps(MaxShadowMapSamplers);
+	m_shadowMapTextures.Resize(MaxShadowMapSamplers);
 	for (uint32_t i = 0; i < MaxShadowsInView; i++)
 	{
 		m_shadowMapOwners[i] = InvalidShadowMapIndex;
 	}
 	for (uint32_t i = 0; i < MaxShadowMapSamplers; i++)
 	{
-		shadowMaps[i] = i < m_csmShadowMaps.Num() ? m_csmShadowMaps[i] : m_defaultShadowMap;
+		m_shadowMapTextures[i] = i < m_csmShadowMaps.Num() && m_csmShadowMaps[i] ?
+			m_csmShadowMaps[i] : m_defaultShadowMap;
 	}
 
-	m_shadowMaps = Sailor::RHI::Renderer::GetDriver()->AddSamplerToShaderBindings(m_lightsData, "shadowMaps", shadowMaps, 9);
+	PublishShadowMapBindings();
+}
 
-	auto shaderBindingSet = m_lightsData;
-	m_lightMatrices = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(
-		shaderBindingSet,
-		"lightsMatrices",
-		sizeof(glm::mat4),
-		LightingECS::MaxShadowsInView,
-		6,
-		true);
-	m_shadowIndices = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(
-		shaderBindingSet,
-		"shadowIndices",
-		sizeof(uint32_t),
-		LightingECS::LightsMaxNum,
-		7,
-		true);
-	m_shadowAtlasTiles = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(
-		shaderBindingSet,
-		"shadowAtlasTiles",
-		sizeof(uint32_t),
-		LightingECS::MaxShadowsInView,
-		11,
-		true);
+void LightingECS::PublishShadowMapBindings()
+{
+	if (m_shadowMapTextures.IsEmpty())
+	{
+		return;
+	}
+
+	auto& driver = Sailor::RHI::Renderer::GetDriver();
+	auto immutableTemplate = driver->CreateShaderBindings();
+	m_shadowMaps = driver->AddSamplerToShaderBindings(
+		immutableTemplate,
+		"shadowMaps",
+		m_shadowMapTextures,
+		9u);
+	immutableTemplate->RecalculateCompatibility();
+	m_lightsData = std::move(immutableTemplate);
+	m_bShadowMapBindingsDirty = false;
 }
 
 Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
 {
 	SAILOR_PROFILE_FUNCTION();
-
-	auto renderer = App::GetSubmodule<RHI::Renderer>();
-	auto driverCommands = renderer->GetDriverCommands();
-	auto cmdList = GetWorld()->GetCommandList();
-	auto& binding = m_lightsData->GetOrAddShaderBinding("light");
-
-	driverCommands->BeginDebugRegion(cmdList, "LightingECS:Update Lights", RHI::DebugContext::Color_CmdTransfer);
-
-	TVector<LightShaderData> shaderDataBatch;
-	shaderDataBatch.Reserve(64);
-	size_t startIndex = 0;
+	(void)deltaTime;
+	bool bPublishedChanges = false;
 	uint32_t numLights = 0;
-
-	auto flushBatch = [&]()
-	{
-		if (shaderDataBatch.IsEmpty())
-		{
-			return;
-		}
-
-		driverCommands->UpdateShaderBinding(cmdList, binding,
-			shaderDataBatch.GetData(),
-			sizeof(LightingECS::LightShaderData) * shaderDataBatch.Num(),
-			sizeof(LightingECS::LightShaderData) * startIndex);
-		shaderDataBatch.Clear(false);
-	};
-
 	const size_t numGpuLightSlots = GetGpuLightSlotsCount(m_components.Num());
-	for (size_t index = 0; index < numGpuLightSlots; index++)
+	for (size_t index = 0; index < numGpuLightSlots; ++index)
 	{
 		auto& data = m_components[index];
-		GameObjectPtr owner = data.m_owner.StaticCast<GameObject>();
+		if (data.m_bIsActive && data.m_owner)
+		{
+			numLights = static_cast<uint32_t>(index) + 1u;
+		}
+	}
+	if (m_cpuLightsData.Num() != numLights)
+	{
+		m_cpuLightsData.Resize(numLights);
+		bPublishedChanges = true;
+	}
+
+	for (size_t index = 0; index < numLights; index++)
+	{
+		auto& data = m_components[index];
+		GameObject* owner = data.m_owner ?
+			static_cast<GameObject*>(data.m_owner.GetRawPtr()) : nullptr;
 		const bool bIsUsable = data.m_bIsActive && owner;
 		bool bShouldWrite = false;
 		LightShaderData shaderData{};
 
 		if (bIsUsable)
 		{
-			numLights = (uint32_t)index + 1;
 			const auto& ownerTransform = owner->GetTransformComponent();
 
 			if (data.m_bIsDirty || data.m_frameLastChange < ownerTransform.GetFrameLastChange())
@@ -205,27 +266,20 @@ Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
 
 		if (!bShouldWrite)
 		{
-			flushBatch();
 			continue;
 		}
-
-		if (!shaderDataBatch.IsEmpty() && startIndex + shaderDataBatch.Num() != index)
-		{
-			flushBatch();
-		}
-
-		if (shaderDataBatch.IsEmpty())
-		{
-			startIndex = index;
-		}
-
-		shaderDataBatch.Emplace(std::move(shaderData));
+		m_cpuLightsData[index] = std::move(shaderData);
+		bPublishedChanges = true;
 	}
 
-	flushBatch();
 	m_numLights = numLights;
-
-	driverCommands->EndDebugRegion(cmdList);
+	if (bPublishedChanges || !m_publishedLightsData)
+	{
+		m_publishedLightsData = AcquireLightsSnapshot(
+			m_lightsSnapshotPool,
+			m_cpuLightsData);
+		++m_lightingRevision;
+	}
 
 	return nullptr;
 }
@@ -233,19 +287,29 @@ Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
 void LightingECS::EndPlay()
 {
 	m_lightsData.Clear();
+	m_cpuLightsData.Clear();
+	m_publishedLightsData.Clear();
+	m_lightsSnapshotPool.Clear();
+	m_lightingRevision = 0ull;
 	m_csmShadowMaps.Clear();
-	m_csmSnapshots.Clear();
+	m_shadowFlightResources.Clear();
 	m_shadowMapOwners.Clear();
 	m_localShadowAllocations.Clear();
 	m_localShadowAtlases.Clear();
+	m_directionalLightsScratch.Clear();
+	m_pointLightsScratch.Clear();
+	m_spotLightsScratch.Clear();
+	m_cascadeProjectionScratch.Clear();
+	m_csmBroadCastersScratch.Clear();
 	m_defaultShadowMap.Clear();
 	m_shadowMaps.Clear();
-	m_lightMatrices.Clear();
-	m_shadowIndices.Clear();
-	m_shadowAtlasTiles.Clear();
+	m_shadowMapTextures.Clear();
+	m_writableLocalShadowAtlases.reset();
+	m_bShadowMapBindingsDirty = false;
 	m_numLights = 0;
 	m_shadowMapsMb = 0.0f;
 	m_csmShadowMapsMb = 0.0f;
+	m_localShadowAllocationRevision = 0ull;
 }
 
 void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
@@ -263,8 +327,8 @@ void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
 		auto& light = m_components[index];
 		if (light.m_shadowType != RHI::EShadowType::None && light.m_bIsActive)
 		{
-			ObjectPtr ownerObject = light.m_owner;
-			GameObjectPtr owner = ownerObject.StaticCast<GameObject>();
+			GameObject* owner = light.m_owner ?
+				static_cast<GameObject*>(light.m_owner.GetRawPtr()) : nullptr;
 			if (!owner)
 			{
 				continue;
@@ -310,52 +374,88 @@ void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
 	}
 }
 
-TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
+void LightingECS::PrepareCSMPasses(
 	const RHI::RHISceneViewPtr& sceneView,
 	const Math::Transform& cameraTransform,
 	const CameraData& cameraData,
 	const TVector<RHI::RHILightProxy>& directionalLights,
-	uint32_t& snapshotIndex)
+	uint32_t flightSlot,
+	LightingShadowFlightResources& flightResources,
+	uint32_t& snapshotIndex,
+	TVector<RHI::RHIUpdateShadowMapCommand>& outUpdateShadowMaps)
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	TVector<RHI::RHIUpdateShadowMapCommand> updateShadowMaps{};
-	updateShadowMaps.Reserve(directionalLights.Num() * NumCascades);
+	outUpdateShadowMaps.Reserve(
+		outUpdateShadowMaps.Num() + directionalLights.Num() * NumCascades);
+	const auto casterSceneVersions = sceneView->GetRetainedSceneVersions();
+	const auto submissionToken = sceneView->GetOrCreateSubmissionCompletionToken();
+	auto& csmSnapshots = flightResources.m_csmSnapshots;
 
 	for (const auto& directionalLight : directionalLights)
 	{
-		const auto lightCascadesMatrices = ShadowPrepassNode::CalculateLightProjectionForCascades(directionalLight.m_lightMatrix,
+		ShadowPrepassNode::CalculateLightProjectionForCascades(
+			directionalLight.m_lightMatrix,
 			cameraTransform.Matrix(),
 			cameraData.GetAspect(),
 			cameraData.GetFov(),
 			cameraData.GetZNear(),
-			cameraData.GetZFar());
+			cameraData.GetZFar(),
+			m_cascadeProjectionScratch);
+		const auto& lightCascadesMatrices = m_cascadeProjectionScratch;
+		const uint32_t numCascades = static_cast<uint32_t>((std::min)(
+			lightCascadesMatrices.Num(),
+			static_cast<size_t>(NumCascades)));
 
-		TVector<Math::Frustum> frustums(lightCascadesMatrices.Num());
-		TVector<glm::mat4> lightMatrices(lightCascadesMatrices.Num());
+		std::array<Math::Frustum, NumCascades> frustums{};
+		std::array<glm::mat4, NumCascades> lightMatrices{};
+		std::array<uint8_t, NumCascades> cascadeNeedsUpdate{};
 		const bool bForceCustomDepthShadowUpdate = sceneView->m_bHasCustomDepthShadowCasters;
-		bool bCanReuseAllCascades = !bForceCustomDepthShadowUpdate;
-		bool bHasCachedShadowCasters = false;
-		for (uint32_t cascadeIndex = 0; cascadeIndex < lightCascadesMatrices.Num(); ++cascadeIndex)
+		bool bCanReuseAllCascades = true;
+		for (uint32_t cascadeIndex = 0; cascadeIndex < numCascades; ++cascadeIndex)
 		{
 			lightMatrices[cascadeIndex] = lightCascadesMatrices[cascadeIndex] * directionalLight.m_lightMatrix;
 			frustums[cascadeIndex].ExtractFrustumPlanes(lightMatrices[cascadeIndex]);
 			const RHI::EShadowType shadowType = cascadeIndex > 0 ?
 				RHI::EShadowType::PCF : directionalLight.m_shadowType;
 			const uint32_t currentSnapshotIndex = snapshotIndex + cascadeIndex;
-			bCanReuseAllCascades &= currentSnapshotIndex < m_csmSnapshots.Num() &&
-				m_csmSnapshots[currentSnapshotIndex].CanReuse(
+			const bool bCanReuseCascade = !bForceCustomDepthShadowUpdate &&
+				currentSnapshotIndex < csmSnapshots.Num() &&
+				currentSnapshotIndex < flightResources.m_csmShadowMaps.Num() &&
+				flightResources.m_csmShadowMaps[currentSnapshotIndex] &&
+				csmSnapshots[currentSnapshotIndex].m_shadowMap ==
+					flightResources.m_csmShadowMaps[currentSnapshotIndex] &&
+				csmSnapshots[currentSnapshotIndex].CanReuse(
 					directionalLight.m_index,
 					shadowType,
 					lightMatrices[cascadeIndex],
-					sceneView->m_shadowCastersRevision);
-			bHasCachedShadowCasters |= currentSnapshotIndex < m_csmSnapshots.Num() &&
-				!m_csmSnapshots[currentSnapshotIndex].m_snapshot.IsEmpty();
+					sceneView->m_shadowCastersRevision,
+					casterSceneVersions,
+					frustums[cascadeIndex],
+					submissionToken,
+					sceneView->m_animationRevision);
+			cascadeNeedsUpdate[cascadeIndex] = bCanReuseCascade ? 0u : 1u;
+			bCanReuseAllCascades &= bCanReuseCascade;
 		}
 
-		if (bCanReuseAllCascades && bHasCachedShadowCasters)
+		if (bCanReuseAllCascades)
 		{
-			snapshotIndex += (uint32_t)lightCascadesMatrices.Num();
+			for (uint32_t cascadeIndex = 0u;
+				cascadeIndex < numCascades;
+				++cascadeIndex)
+			{
+				auto& cached = csmSnapshots[snapshotIndex + cascadeIndex];
+				cached.m_sceneRevision = sceneView->m_shadowCastersRevision;
+				cached.m_animationRevision = sceneView->m_animationRevision;
+				cached.m_casterSceneVersions = casterSceneVersions;
+				if (cached.m_shadowMap && m_csmShadowMaps[cascadeIndex] != cached.m_shadowMap)
+				{
+					m_csmShadowMaps[cascadeIndex] = cached.m_shadowMap;
+					m_shadowMapTextures[cascadeIndex] = cached.m_shadowMap;
+					m_bShadowMapBindingsDirty = true;
+				}
+			}
+			snapshotIndex += numCascades;
 			continue;
 		}
 
@@ -371,20 +471,26 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 			ShadowCasterDepthExtension) * directionalLight.m_lightMatrix;
 		Math::Frustum broadFrustum;
 		broadFrustum.ExtractFrustumPlanes(broadLightMatrix);
-		const auto shadowCasters = sceneView->TraceShadowCasters(broadFrustum);
-		TVector<Tasks::TaskPtr<TVector<RHI::RHIShadowCasterProxyPtr>>> cascadeCasterTasks;
-		cascadeCasterTasks.Reserve(lightCascadesMatrices.Num());
-		for (uint32_t cascadeIndex = 0; cascadeIndex < lightCascadesMatrices.Num(); ++cascadeIndex)
+		sceneView->TraceShadowCasters(broadFrustum, m_csmBroadCastersScratch);
+		const auto& shadowCasters = m_csmBroadCastersScratch;
+		std::array<Tasks::TaskPtr<TVector<RHI::RHIVisibleShadowCaster>>, NumCascades>
+			cascadeCasterTasks{};
+		for (uint32_t cascadeIndex = 0; cascadeIndex < numCascades; ++cascadeIndex)
 		{
-			auto task = Tasks::CreateTask<TVector<RHI::RHIShadowCasterProxyPtr>>(
+			if (cascadeNeedsUpdate[cascadeIndex] == 0u)
+			{
+				continue;
+			}
+			auto task = Tasks::CreateTask<TVector<RHI::RHIVisibleShadowCaster>>(
 				"LightingECS:Build CSM Cascade",
 				[&shadowCasters, &frustums, cascadeIndex]()
 				{
-					TVector<RHI::RHIShadowCasterProxyPtr> casters;
+					TVector<RHI::RHIVisibleShadowCaster> casters;
 					casters.Reserve(shadowCasters.Num());
 					for (const auto& caster : shadowCasters)
 					{
-						if (caster && frustums[cascadeIndex].OverlapsAABB(caster->m_worldAabb))
+						if (caster.GetSource() &&
+							frustums[cascadeIndex].OverlapsAABB(caster.GetWorldBounds()))
 						{
 							casters.Add(caster);
 						}
@@ -393,14 +499,29 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 				},
 				EThreadType::Worker);
 			task->Run();
-			cascadeCasterTasks.Add(task);
+			cascadeCasterTasks[cascadeIndex] = std::move(task);
 		}
 
-		for (uint32_t k = 0; k < lightCascadesMatrices.Num(); ++k)
+		for (uint32_t k = 0; k < numCascades; ++k)
 		{
+			if (cascadeNeedsUpdate[k] == 0u)
+			{
+				auto& cached = csmSnapshots[snapshotIndex];
+				cached.m_sceneRevision = sceneView->m_shadowCastersRevision;
+				cached.m_animationRevision = sceneView->m_animationRevision;
+				cached.m_casterSceneVersions = casterSceneVersions;
+				if (cached.m_shadowMap && m_csmShadowMaps[k] != cached.m_shadowMap)
+				{
+					m_csmShadowMaps[k] = cached.m_shadowMap;
+					m_shadowMapTextures[k] = cached.m_shadowMap;
+					m_bShadowMapBindingsDirty = true;
+				}
+				++snapshotIndex;
+				continue;
+			}
+
 			cascadeCasterTasks[k]->Wait();
 			RHI::RHIUpdateShadowMapCommand cascade;
-			cascade.m_shadowMap = m_csmShadowMaps[k];
 			cascade.m_lightMatrix = lightMatrices[k];
 			cascade.m_lighMatrixIndex = k;
 			cascade.m_blurRadius = ShadowCascadeBlur[k];
@@ -411,41 +532,85 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareCSMPasses(
 			snapshot.m_shadowType = cascade.m_shadowType;
 			snapshot.m_lightMatrix = lightMatrices[k];
 			snapshot.m_sceneRevision = sceneView->m_shadowCastersRevision;
-			snapshot.m_snapshot.Reserve(cascade.m_meshList.Num());
+			snapshot.m_animationRevision = sceneView->m_animationRevision;
+			snapshot.m_casterSceneVersions = casterSceneVersions;
+			ResolveShadowCasterUpdatePolicy(
+				cascade.m_meshList,
+				snapshot.m_bContainsDynamicCasters,
+				snapshot.m_bContainsAnimatedCasters);
 
-			for (const auto& caster : cascade.m_meshList)
+			const bool bEvsmCascade =
+				cascade.m_shadowType == RHI::EShadowType::EVSM;
+			if (flightResources.m_csmShadowMaps.Num() <= snapshotIndex)
 			{
-				snapshot.m_snapshot.Add({ caster->m_staticMeshEcs, caster->m_frame });
+				flightResources.m_csmShadowMaps.Resize(
+					static_cast<size_t>(snapshotIndex) + 1u);
 			}
-			snapshot.m_snapshot.Sort([](const auto& lhs, const auto& rhs)
-				{
-					return lhs.m_first < rhs.m_first;
-				});
-
-			if (!bForceCustomDepthShadowUpdate &&
-				snapshotIndex < m_csmSnapshots.Num() &&
-				snapshot.Equals(m_csmSnapshots[snapshotIndex]))
+			auto& writableShadowMap =
+				flightResources.m_csmShadowMaps[snapshotIndex];
+			if (!writableShadowMap)
 			{
-				m_csmSnapshots[snapshotIndex].m_sceneRevision = sceneView->m_shadowCastersRevision;
+				const auto usage = RHI::ETextureUsageBit::ColorAttachment_Bit |
+					RHI::ETextureUsageBit::TextureTransferSrc_Bit |
+					RHI::ETextureUsageBit::TextureTransferDst_Bit |
+					RHI::ETextureUsageBit::Sampled_Bit;
+				writableShadowMap = RHI::Renderer::GetDriver()->CreateRenderTarget(
+					ShadowCascadeResolutions[k % NumCascades],
+					1,
+					bEvsmCascade ? ShadowMapFormat_Evsm : ShadowMapFormat,
+					bEvsmCascade ? RHI::ETextureFiltration::Linear : RHI::ETextureFiltration::Nearest,
+					RHI::ETextureClamping::Clamp,
+					usage);
+				if (writableShadowMap)
+				{
+					const float bytesPerPixel = bEvsmCascade ? 16.0f : 2.0f;
+					const float shadowMapMemoryMb = static_cast<float>(
+						ShadowCascadeResolutions[k].x * ShadowCascadeResolutions[k].y) *
+						bytesPerPixel / (1024.0f * 1024.0f);
+					m_csmShadowMapsMb += shadowMapMemoryMb;
+					m_shadowMapsMb += shadowMapMemoryMb;
+				}
+			}
+			if (!writableShadowMap)
+			{
 				++snapshotIndex;
 				continue;
 			}
+			char csmDebugName[96];
+			sprintf_s(
+				csmDebugName,
+				sizeof(csmDebugName),
+				"Shadow Map, CSM Flight %u, View %u, Cascade %u",
+				flightSlot,
+				snapshotIndex / NumCascades,
+				k);
+			RHI::Renderer::GetDriver()->SetDebugName(writableShadowMap, csmDebugName);
+			m_csmShadowMaps[k] = writableShadowMap;
+			m_shadowMapTextures[k] = writableShadowMap;
+			m_bShadowMapBindingsDirty = true;
+			cascade.m_shadowMap = writableShadowMap;
+			snapshot.m_shadowMap = cascade.m_shadowMap;
+			snapshot.m_submissionToken = submissionToken;
+			snapshot.m_payloadCompletionToken = AcquireShadowPayloadToken(
+				snapshotIndex < csmSnapshots.Num() ?
+					csmSnapshots[snapshotIndex].m_payloadCompletionToken :
+					RHI::RHISubmissionCompletionTokenPtr{});
+			cascade.m_payloadCompletionToken =
+				snapshot.m_payloadCompletionToken;
 
-			if (snapshotIndex < m_csmSnapshots.Num())
+			if (snapshotIndex < csmSnapshots.Num())
 			{
-				m_csmSnapshots[snapshotIndex] = std::move(snapshot);
+				csmSnapshots[snapshotIndex] = std::move(snapshot);
 			}
 			else
 			{
-				m_csmSnapshots.Emplace(std::move(snapshot));
+				csmSnapshots.Emplace(std::move(snapshot));
 			}
 
-			updateShadowMaps.Emplace(std::move(cascade));
+			outUpdateShadowMaps.Emplace(std::move(cascade));
 			++snapshotIndex;
 		}
 	}
-
-	return updateShadowMaps;
 }
 
 void LightingECS::ReleaseLocalShadowAllocation(uint32_t componentIndex)
@@ -470,6 +635,13 @@ void LightingECS::ReleaseLocalShadowAllocation(uint32_t componentIndex)
 		}
 
 		m_shadowMapOwners[slot] = InvalidShadowMapIndex;
+	}
+	for (auto& flightResources : m_shadowFlightResources)
+	{
+		if (flightResources.m_localShadowSnapshots.Num() > componentIndex)
+		{
+			flightResources.m_localShadowSnapshots[componentIndex].Clear();
+		}
 	}
 
 	allocation = {};
@@ -559,13 +731,81 @@ bool LightingECS::TryCreateLocalShadowAtlas(uint32_t& outAtlasIndex)
 		m_localShadowAtlases[atlasIndex] = std::move(atlas);
 	}
 
-	RHI::Renderer::GetDriver()->UpdateShaderBinding(
-		m_lightsData,
-		"shadowMaps",
-		texture,
-		NumCascades + atlasIndex);
+	m_shadowMapTextures[NumCascades + atlasIndex] = texture;
+	m_writableLocalShadowAtlases.set(atlasIndex);
+	m_bShadowMapBindingsDirty = true;
 	m_shadowMapsMb += LocalShadowAtlasMemoryMb;
 	outAtlasIndex = atlasIndex;
+	return true;
+}
+
+bool LightingECS::EnsureWritableLocalShadowAtlas(
+	uint32_t atlasIndex,
+	uint32_t flightSlot,
+	LightingShadowFlightResources& flightResources)
+{
+	if (atlasIndex >= m_localShadowAtlases.Num() ||
+		atlasIndex >= m_writableLocalShadowAtlases.size() ||
+		!m_localShadowAtlases[atlasIndex].m_texture)
+	{
+		return false;
+	}
+	if (flightResources.m_localShadowAtlasTextures.Num() <= atlasIndex)
+	{
+		flightResources.m_localShadowAtlasTextures.Resize(
+			static_cast<size_t>(atlasIndex) + 1u);
+	}
+	auto& writableTexture =
+		flightResources.m_localShadowAtlasTextures[atlasIndex];
+	if (m_writableLocalShadowAtlases.test(atlasIndex))
+	{
+		if (!writableTexture)
+		{
+			writableTexture = m_localShadowAtlases[atlasIndex].m_texture;
+		}
+		return writableTexture.IsValid();
+	}
+
+	if (!writableTexture)
+	{
+		if (m_shadowMapsMb + LocalShadowAtlasMemoryMb >
+			m_shadowsMemoryBudgetMb + 0.001f)
+		{
+			return false;
+		}
+		const auto usage = RHI::ETextureUsageBit::ColorAttachment_Bit |
+			RHI::ETextureUsageBit::TextureTransferSrc_Bit |
+			RHI::ETextureUsageBit::TextureTransferDst_Bit |
+			RHI::ETextureUsageBit::Sampled_Bit;
+		writableTexture = RHI::Renderer::GetDriver()->CreateRenderTarget(
+			glm::ivec2(LocalShadowAtlasResolution),
+			1,
+			ShadowMapFormat,
+			RHI::ETextureFiltration::Nearest,
+			RHI::ETextureClamping::Clamp,
+			usage);
+		if (writableTexture)
+		{
+			m_shadowMapsMb += LocalShadowAtlasMemoryMb;
+		}
+	}
+	if (!writableTexture)
+	{
+		return false;
+	}
+
+	char debugName[64];
+	sprintf_s(
+		debugName,
+		sizeof(debugName),
+		"Shadow Map, Local Atlas %u, Flight %u",
+		atlasIndex,
+		flightSlot);
+	RHI::Renderer::GetDriver()->SetDebugName(writableTexture, debugName);
+	m_localShadowAtlases[atlasIndex].m_texture = writableTexture;
+	m_shadowMapTextures[NumCascades + atlasIndex] = writableTexture;
+	m_writableLocalShadowAtlases.set(atlasIndex);
+	m_bShadowMapBindingsDirty = true;
 	return true;
 }
 
@@ -575,7 +815,7 @@ bool LightingECS::TryAllocateLocalShadowTilesInAtlas(
 	uint32_t resolution,
 	TVector<glm::ivec4>& outTiles)
 {
-	outTiles.Clear();
+	outTiles.Clear(false);
 	if (atlasIndex >= m_localShadowAtlases.Num() ||
 		!m_localShadowAtlases[atlasIndex].m_texture)
 	{
@@ -633,7 +873,7 @@ bool LightingECS::TryAllocateLocalShadowTilesInAtlas(
 		if (!bAllocated)
 		{
 			ReleaseLocalShadowTiles(atlasIndex, outTiles);
-			outTiles.Clear();
+		outTiles.Clear(false);
 			return false;
 		}
 	}
@@ -707,8 +947,7 @@ bool LightingECS::EnsureLocalShadowAllocation(
 	uint32_t componentIndex,
 	ELightType lightType,
 	uint32_t desiredResolution,
-	uint64_t frame,
-	TVector<RHI::RHIBlitShadowMapCommand>& shadowMapsToBlit)
+	uint64_t frame)
 {
 	if (m_localShadowAllocations.Num() <= componentIndex)
 	{
@@ -730,22 +969,15 @@ bool LightingECS::EnsureLocalShadowAllocation(
 				destinationAtlasIndex,
 				destinationTiles))
 			{
-				const auto sourceAtlas = m_localShadowAtlases[current.m_atlasIndex].m_texture;
-				const auto destinationAtlas = m_localShadowAtlases[destinationAtlasIndex].m_texture;
-				for (uint32_t face = 0; face < destinationTiles.Num(); ++face)
-				{
-					RHI::RHIBlitShadowMapCommand blit{};
-					blit.m_source = sourceAtlas;
-					blit.m_destination = destinationAtlas;
-					blit.m_sourceArea = current.m_tiles[face];
-					blit.m_destinationArea = destinationTiles[face];
-					shadowMapsToBlit.Add(std::move(blit));
-				}
-
 				ReleaseLocalShadowTiles(current.m_atlasIndex, current.m_tiles);
 				current.m_atlasIndex = destinationAtlasIndex;
 				current.m_tiles = std::move(destinationTiles);
 				current.m_resolution = static_cast<uint32_t>(current.m_tiles[0].z);
+				current.m_revision = ++m_localShadowAllocationRevision;
+				if (current.m_revision == 0ull)
+				{
+					current.m_revision = ++m_localShadowAllocationRevision;
+				}
 			}
 		}
 
@@ -859,9 +1091,13 @@ bool LightingECS::EnsureLocalShadowAllocation(
 	allocation.m_requestedResolution = desiredResolution;
 	allocation.m_atlasIndex = atlasIndex;
 	allocation.m_lastUsedFrame = frame;
+	allocation.m_revision = ++m_localShadowAllocationRevision;
+	if (allocation.m_revision == 0ull)
+	{
+		allocation.m_revision = ++m_localShadowAllocationRevision;
+	}
 	allocation.m_slots.Reserve(mapCount);
 	allocation.m_tiles = std::move(tiles);
-	allocation.m_snapshots.Resize(mapCount);
 
 	if (current.m_componentIndex == componentIndex &&
 		current.m_lightType == lightType &&
@@ -962,28 +1198,57 @@ void LightingECS::ReleaseUnusedLocalShadowAtlases()
 			continue;
 		}
 
-		RHI::Renderer::GetDriver()->UpdateShaderBinding(
-			m_lightsData,
-			"shadowMaps",
-			m_defaultShadowMap,
-			NumCascades + atlasIndex);
+		m_shadowMapTextures[NumCascades + atlasIndex] = m_defaultShadowMap;
+		m_bShadowMapBindingsDirty = true;
+		const auto latestTexture = atlas.m_texture;
+		bool bLatestOwnedByFlight = false;
+		size_t numPhysicalTextures = 0u;
+		for (auto& flightResources : m_shadowFlightResources)
+		{
+			if (flightResources.m_localShadowAtlasTextures.Num() <= atlasIndex)
+			{
+				continue;
+			}
+			auto& flightTexture =
+				flightResources.m_localShadowAtlasTextures[atlasIndex];
+			if (!flightTexture)
+			{
+				continue;
+			}
+			bLatestOwnedByFlight |= flightTexture == latestTexture;
+			++numPhysicalTextures;
+			flightTexture.Clear();
+		}
+		if (latestTexture && !bLatestOwnedByFlight)
+		{
+			++numPhysicalTextures;
+		}
 		atlas = {};
-		m_shadowMapsMb = (std::max)(0.0f, m_shadowMapsMb - LocalShadowAtlasMemoryMb);
+		m_shadowMapsMb = (std::max)(
+			0.0f,
+			m_shadowMapsMb -
+				LocalShadowAtlasMemoryMb * static_cast<float>(numPhysicalTextures));
 	}
 }
 
-TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
+void LightingECS::PrepareLocalShadowPasses(
 	const RHI::RHISceneViewPtr& sceneView,
 	const TVector<RHI::RHILightProxy>& spotLights,
 	const TVector<RHI::RHILightProxy>& pointLights,
 	const CameraData& cameraData,
 	uint32_t viewportHeight,
+	uint32_t flightSlot,
+	LightingShadowFlightResources& flightResources,
 	TVector<uint32_t>& shadowIndices,
 	TVector<uint32_t>& shadowAtlasTiles,
-	TVector<RHI::RHIBlitShadowMapCommand>& shadowMapsToBlit)
+	TVector<RHI::RHIUpdateShadowMapCommand>& outUpdateShadowMaps)
 {
-	TVector<RHI::RHIUpdateShadowMapCommand> updateShadowMaps{};
 	const uint64_t frame = GetWorld()->GetCurrentFrame();
+	const auto casterSceneVersions = sceneView->GetRetainedSceneVersions();
+	const auto submissionToken = sceneView->GetOrCreateSubmissionCompletionToken();
+	outUpdateShadowMaps.Reserve(
+		outUpdateShadowMaps.Num() +
+		spotLights.Num() + pointLights.Num() * 6u);
 
 	auto prepareLights = [&](const TVector<RHI::RHILightProxy>& lights)
 	{
@@ -1007,19 +1272,14 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 					lightProxy.m_index,
 					light.m_type,
 					desiredResolution,
-					frame,
-					shadowMapsToBlit))
+					frame))
 			{
 				continue;
 			}
 
 			auto& allocation = m_localShadowAllocations[lightProxy.m_index];
-			const uint32_t firstSlot = allocation.m_slots[0];
-			shadowIndices[lightProxy.m_index] = firstSlot |
-				(light.m_shadowFilter == ELightShadowFilter::Soft ? SoftShadowMapBit : 0u);
-
-			ObjectPtr ownerObject = light.m_owner;
-			GameObjectPtr owner = ownerObject.StaticCast<GameObject>();
+			GameObject* owner = light.m_owner ?
+				static_cast<GameObject*>(light.m_owner.GetRawPtr()) : nullptr;
 			if (!owner)
 			{
 				continue;
@@ -1033,9 +1293,32 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 				shadowIndices[lightProxy.m_index] = InvalidShadowMapIndex;
 				continue;
 			}
+			if (!EnsureWritableLocalShadowAtlas(
+					allocation.m_atlasIndex,
+					flightSlot,
+					flightResources))
+			{
+				continue;
+			}
+			if (flightResources.m_localShadowSnapshots.Num() <= lightProxy.m_index)
+			{
+				flightResources.m_localShadowSnapshots.Resize(
+					static_cast<size_t>(lightProxy.m_index) + 1u);
+			}
+			auto& flightSnapshots =
+				flightResources.m_localShadowSnapshots[lightProxy.m_index];
+			const uint32_t mapCount = GetLocalShadowMapCount(light.m_type);
+			if (flightSnapshots.Num() != mapCount)
+			{
+				flightSnapshots.Resize(mapCount);
+			}
+			const uint32_t firstSlot = allocation.m_slots[0];
+			shadowIndices[lightProxy.m_index] = firstSlot |
+				(light.m_shadowFilter == ELightShadowFilter::Soft ? SoftShadowMapBit : 0u);
 
 			const float nearPlane = (std::max)(0.01f, farPlane * 0.001f);
-			TVector<glm::mat4> lightMatrices{};
+			std::array<glm::mat4, 6u> lightMatrices{};
+			uint32_t numLightMatrices = 0u;
 			if (light.m_type == ELightType::Spot)
 			{
 				const float fieldOfView = glm::clamp(
@@ -1047,8 +1330,9 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 					position + glm::normalize(transform.GetForwardVector()),
 					glm::normalize(glm::vec3(
 						transform.GetCachedWorldMatrix() * Math::vec4_Up)));
-				lightMatrices.Add(Math::PerspectiveRH(
-					glm::radians(fieldOfView), 1.0f, nearPlane, farPlane) * view);
+				lightMatrices[0] = Math::PerspectiveRH(
+					glm::radians(fieldOfView), 1.0f, nearPlane, farPlane) * view;
+				numLightMatrices = 1u;
 			}
 			else
 			{
@@ -1066,22 +1350,21 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 					glm::radians(90.0f), 1.0f, nearPlane, farPlane);
 				for (uint32_t face = 0; face < 6; ++face)
 				{
-					lightMatrices.Add(projection * glm::lookAtRH(
+					lightMatrices[face] = projection * glm::lookAtRH(
 						position,
 						position + directions[face],
-						upVectors[face]));
+						upVectors[face]);
 				}
+				numLightMatrices = 6u;
 			}
 
-			bool bHasCachedLocalShadowCasters = false;
-			for (const auto& cachedFace : allocation.m_snapshots)
-			{
-				bHasCachedLocalShadowCasters |= !cachedFace.m_snapshot.IsEmpty();
-			}
-
-			for (uint32_t face = 0; face < lightMatrices.Num(); ++face)
+			for (uint32_t face = 0; face < numLightMatrices; ++face)
 			{
 				const uint32_t shadowSlot = allocation.m_slots[face];
+				if (shadowAtlasTiles.Num() <= shadowSlot)
+				{
+					shadowAtlasTiles.Resize(static_cast<size_t>(shadowSlot) + 1u);
+				}
 				const glm::ivec4 tile = allocation.m_tiles[face];
 				const uint32_t tileX = static_cast<uint32_t>(tile.x) / LocalShadowMinResolution;
 				const uint32_t tileY = static_cast<uint32_t>(tile.y) / LocalShadowMinResolution;
@@ -1091,23 +1374,26 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 					(tileY << 6u) |
 					(tileLevel << 12u) |
 					(allocation.m_atlasIndex << 15u);
-				auto& cachedState = allocation.m_snapshots[face];
-				// Mesh proxies can be published asynchronously after the light has
-				// already rendered its first frame. Do not turn that bootstrap
-				// miss into a permanent empty cache entry.
-				if (bHasCachedLocalShadowCasters &&
+				auto& cachedState = flightSnapshots[face];
+				Math::Frustum shadowFrustum(lightMatrices[face]);
+				if (cachedState.m_resourceRevision == allocation.m_revision &&
 					cachedState.CanReuse(
 						lightProxy.m_index,
 						RHI::EShadowType::PCF,
 						lightMatrices[face],
-						sceneView->m_shadowCastersRevision))
+						sceneView->m_shadowCastersRevision,
+						casterSceneVersions,
+						shadowFrustum,
+						submissionToken,
+						sceneView->m_animationRevision))
 				{
+					cachedState.m_sceneRevision = sceneView->m_shadowCastersRevision;
+					cachedState.m_animationRevision = sceneView->m_animationRevision;
+					cachedState.m_casterSceneVersions = casterSceneVersions;
 					continue;
 				}
 
-				Math::Frustum shadowFrustum(lightMatrices[face]);
 				RHI::RHIUpdateShadowMapCommand shadowPass{};
-				shadowPass.m_shadowMap = m_localShadowAtlases[allocation.m_atlasIndex].m_texture;
 				shadowPass.m_renderArea = tile;
 				shadowPass.m_lightMatrix = lightMatrices[face];
 				shadowPass.m_lighMatrixIndex = shadowSlot;
@@ -1119,47 +1405,79 @@ TVector<RHI::RHIUpdateShadowMapCommand> LightingECS::PrepareLocalShadowPasses(
 				snapshot.m_shadowType = RHI::EShadowType::PCF;
 				snapshot.m_lightMatrix = lightMatrices[face];
 				snapshot.m_sceneRevision = sceneView->m_shadowCastersRevision;
-				snapshot.m_snapshot.Reserve(shadowPass.m_meshList.Num());
-				for (const auto& caster : shadowPass.m_meshList)
-				{
-					if (caster)
-					{
-						snapshot.m_snapshot.Add({ caster->m_staticMeshEcs, caster->m_frame });
-					}
-				}
-				snapshot.m_snapshot.Sort([](const auto& lhs, const auto& rhs)
-					{
-						return lhs.m_first < rhs.m_first;
-					});
-				if (snapshot.Equals(cachedState))
-				{
-					cachedState.m_sceneRevision = sceneView->m_shadowCastersRevision;
-					continue;
-				}
+				snapshot.m_animationRevision = sceneView->m_animationRevision;
+				snapshot.m_resourceRevision = allocation.m_revision;
+				snapshot.m_casterSceneVersions = casterSceneVersions;
+				ResolveShadowCasterUpdatePolicy(
+					shadowPass.m_meshList,
+					snapshot.m_bContainsDynamicCasters,
+					snapshot.m_bContainsAnimatedCasters);
+				shadowPass.m_shadowMap =
+					m_localShadowAtlases[allocation.m_atlasIndex].m_texture;
+				snapshot.m_submissionToken = submissionToken;
+				snapshot.m_payloadCompletionToken = AcquireShadowPayloadToken(
+					cachedState.m_payloadCompletionToken);
+				shadowPass.m_payloadCompletionToken =
+					snapshot.m_payloadCompletionToken;
 				cachedState = std::move(snapshot);
-				updateShadowMaps.Emplace(std::move(shadowPass));
+				outUpdateShadowMaps.Emplace(std::move(shadowPass));
 			}
 		}
 	};
 
 	prepareLights(spotLights);
 	prepareLights(pointLights);
-	return updateShadowMaps;
 }
 
 void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
+	if (!sceneView || !sceneView->m_submissionContext)
+	{
+		SAILOR_LOG_ERROR(
+			"LightingECS::FillLightingData requires an acquired render submission flight.");
+		return;
+	}
+	const uint32_t flightSlot =
+		sceneView->m_submissionContext->GetFlightSlot();
+	if (m_shadowFlightResources.Num() <= flightSlot)
+	{
+		m_shadowFlightResources.Resize(static_cast<size_t>(flightSlot) + 1u);
+	}
+	auto& flightResources = m_shadowFlightResources[flightSlot];
+	m_writableLocalShadowAtlases.reset();
 	uint32_t snapshotIndex = 0;
 	const uint32_t viewportHeight = static_cast<uint32_t>((std::max)(
 		App::GetMainWindow()->GetRenderArea().y,
 		1));
+	const size_t numCameras = sceneView->m_cameraTransforms.Num();
+	sceneView->m_shadowMapsToUpdate.Resize(numCameras);
+	sceneView->m_shadowMapsToBlit.Resize(numCameras);
+	sceneView->m_shadowIndices.Resize(numCameras);
+	sceneView->m_shadowAtlasTiles.Resize(numCameras);
+	sceneView->m_shadowMatrices.Resize(numCameras);
 
-	for (uint32_t i = 0; i < sceneView->m_cameraTransforms.Num(); i++)
+	for (uint32_t i = 0; i < numCameras; i++)
 	{
-		TVector<uint32_t> shadowIndices(GetGpuLightSlotsCount(m_components.Num()));
-		TVector<uint32_t> shadowAtlasTiles(MaxShadowsInView);
-		TVector<RHI::RHIBlitShadowMapCommand> shadowMapsToBlit;
+		auto& updateShadowMaps = sceneView->m_shadowMapsToUpdate[i];
+		auto& shadowMapsToBlit = sceneView->m_shadowMapsToBlit[i];
+		auto& shadowIndices = sceneView->m_shadowIndices[i];
+		auto& shadowAtlasTiles = sceneView->m_shadowAtlasTiles[i];
+		auto& shadowMatrices = sceneView->m_shadowMatrices[i];
+		if (i < sceneView->m_snapshots.Num())
+		{
+			auto& previous = sceneView->m_snapshots[i];
+			updateShadowMaps = std::move(previous.m_shadowMapsToUpdate);
+			shadowMapsToBlit = std::move(previous.m_shadowMapsToBlit);
+			shadowIndices = std::move(previous.m_shadowIndices);
+			shadowAtlasTiles = std::move(previous.m_shadowAtlasTiles);
+			shadowMatrices = std::move(previous.m_shadowMatrices);
+		}
+		updateShadowMaps.Clear(false);
+		shadowMapsToBlit.Clear(false);
+		shadowIndices.Resize(m_numLights);
+		shadowAtlasTiles.Resize(NumCascades);
+		shadowMatrices.Resize(NumCascades);
 		for (auto& shadowIndex : shadowIndices)
 		{
 			shadowIndex = InvalidShadowMapIndex;
@@ -1168,6 +1486,10 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 		{
 			atlasTile = 0u;
 		}
+		for (auto& matrix : shadowMatrices)
+		{
+			matrix = glm::mat4(1.0f);
+		}
 
 		const auto& camera = sceneView->m_cameras[i];
 
@@ -1175,47 +1497,106 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 		frustum.ExtractFrustumPlanes(sceneView->m_cameraTransforms[i].Matrix(), camera.GetAspect(), camera.GetFov(), camera.GetZNear(), camera.GetZFar());
 
 		// Sort all the lights per camera
-		TVector<RHI::RHILightProxy> directionalLights;
-		TVector<RHI::RHILightProxy> sortedSpotLights;
-		TVector<RHI::RHILightProxy> sortedPointLights;
+		m_directionalLightsScratch.Clear(false);
+		m_pointLightsScratch.Clear(false);
+		m_spotLightsScratch.Clear(false);
 
-		GetLightsInFrustum(frustum, sceneView->m_cameraTransforms[i], directionalLights, sortedPointLights, sortedSpotLights);
+		GetLightsInFrustum(
+			frustum,
+			sceneView->m_cameraTransforms[i],
+			m_directionalLightsScratch,
+			m_pointLightsScratch,
+			m_spotLightsScratch);
 
-		auto updateShadowMaps = PrepareCSMPasses(
+		const uint32_t cameraCsmSnapshotStart = snapshotIndex;
+		PrepareCSMPasses(
 			sceneView,
 			sceneView->m_cameraTransforms[i],
 			camera,
-			directionalLights,
-			snapshotIndex);
-		auto localShadowMaps = PrepareLocalShadowPasses(
+			m_directionalLightsScratch,
+			flightSlot,
+			flightResources,
+			snapshotIndex,
+			updateShadowMaps);
+		PrepareLocalShadowPasses(
 			sceneView,
-			sortedSpotLights,
-			sortedPointLights,
+			m_spotLightsScratch,
+			m_pointLightsScratch,
 			camera,
 			viewportHeight,
+			flightSlot,
+			flightResources,
 			shadowIndices,
 			shadowAtlasTiles,
-			shadowMapsToBlit);
-		for (auto& localShadowMap : localShadowMaps)
+			updateShadowMaps);
+		for (uint32_t cascadeIndex = 0u;
+			cascadeIndex < NumCascades &&
+			cameraCsmSnapshotStart + cascadeIndex <
+				flightResources.m_csmSnapshots.Num();
+			++cascadeIndex)
 		{
-			updateShadowMaps.Emplace(std::move(localShadowMap));
+			shadowMatrices[cascadeIndex] =
+				flightResources.m_csmSnapshots[
+					cameraCsmSnapshotStart + cascadeIndex].m_lightMatrix;
 		}
-		sceneView->m_shadowMapsToUpdate.Add(std::move(updateShadowMaps));
-		sceneView->m_shadowMapsToBlit.Add(std::move(shadowMapsToBlit));
-		sceneView->m_shadowIndices.Add(std::move(shadowIndices));
-		sceneView->m_shadowAtlasTiles.Add(std::move(shadowAtlasTiles));
+		for (const auto& allocation : m_localShadowAllocations)
+		{
+			if (allocation.m_componentIndex == InvalidShadowMapIndex ||
+				allocation.m_componentIndex >= shadowIndices.Num() ||
+				shadowIndices[allocation.m_componentIndex] == InvalidShadowMapIndex)
+			{
+				continue;
+			}
+			if (flightResources.m_localShadowSnapshots.Num() <=
+				allocation.m_componentIndex)
+			{
+				continue;
+			}
+			const auto& flightSnapshots =
+				flightResources.m_localShadowSnapshots[
+					allocation.m_componentIndex];
+			const uint32_t numFaces = static_cast<uint32_t>((std::min)(
+				allocation.m_slots.Num(),
+				flightSnapshots.Num()));
+			for (uint32_t face = 0u; face < numFaces; ++face)
+			{
+				const uint32_t slot = allocation.m_slots[face];
+				if (shadowMatrices.Num() <= slot)
+				{
+					const size_t previousSize = shadowMatrices.Num();
+					shadowMatrices.Resize(static_cast<size_t>(slot) + 1u);
+					for (size_t matrixIndex = previousSize;
+						matrixIndex < shadowMatrices.Num(); ++matrixIndex)
+					{
+						shadowMatrices[matrixIndex] = glm::mat4(1.0f);
+					}
+				}
+				shadowMatrices[slot] = flightSnapshots[face].m_lightMatrix;
+			}
+		}
+		if (m_bShadowMapBindingsDirty)
+		{
+			PublishShadowMapBindings();
+		}
+		sceneView->m_rhiLightsDataPerCamera.Add(m_lightsData);
 	}
 
-	if (m_csmSnapshots.Num() > snapshotIndex)
+	if (flightResources.m_csmSnapshots.Num() > snapshotIndex)
 	{
-		m_csmSnapshots.Resize(snapshotIndex);
+		flightResources.m_csmSnapshots.Resize(snapshotIndex);
 	}
 
 	ReleaseUnusedLocalShadowAllocations(GetWorld()->GetCurrentFrame());
 	ReleaseUnusedLocalShadowAtlases();
+	if (m_bShadowMapBindingsDirty)
+	{
+		PublishShadowMapBindings();
+	}
 
 	sceneView->m_totalNumLights = m_numLights;
 	sceneView->m_rhiLightsData = m_lightsData;
+	sceneView->m_cpuLightsData = m_publishedLightsData;
+	sceneView->m_lightingRevision = m_lightingRevision;
 }
 
 void LightingECS::GetLightProxies(TVector<Raytracing::LightProxy>& outLights) const
@@ -1232,8 +1613,8 @@ void LightingECS::GetLightProxies(TVector<Raytracing::LightProxy>& outLights) co
 			continue;
 		}
 
-		ObjectPtr owner = light.m_owner;
-		auto pOwner = owner.StaticCast<GameObject>();
+		GameObject* pOwner = light.m_owner ?
+			static_cast<GameObject*>(light.m_owner.GetRawPtr()) : nullptr;
 		if (!pOwner)
 		{
 			continue;

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -85,6 +85,22 @@ namespace
 		}
 		return token;
 	}
+
+	float CalculateCsmShadowMapMemoryMb(
+		const RHI::RHIRenderTargetPtr& shadowMap)
+	{
+		if (!shadowMap)
+		{
+			return 0.0f;
+		}
+
+		const float bytesPerPixel =
+			shadowMap->GetFormat() == LightingECS::ShadowMapFormat_Evsm ?
+				16.0f : 2.0f;
+		const glm::ivec2 extent = shadowMap->GetExtent();
+		return static_cast<float>(extent.x * extent.y) * bytesPerPixel /
+			(1024.0f * 1024.0f);
+	}
 }
 
 bool CSMLightState::CanReuse(
@@ -541,6 +557,10 @@ void LightingECS::PrepareCSMPasses(
 
 			const bool bEvsmCascade =
 				cascade.m_shadowType == RHI::EShadowType::EVSM;
+			const glm::ivec2 shadowMapExtent =
+				ShadowCascadeResolutions[k % NumCascades];
+			const RHI::EFormat shadowMapFormat =
+				GetCsmShadowMapFormat(cascade.m_shadowType);
 			if (flightResources.m_csmShadowMaps.Num() <= snapshotIndex)
 			{
 				flightResources.m_csmShadowMaps.Resize(
@@ -548,6 +568,31 @@ void LightingECS::PrepareCSMPasses(
 			}
 			auto& writableShadowMap =
 				flightResources.m_csmShadowMaps[snapshotIndex];
+			if (writableShadowMap &&
+				(writableShadowMap->GetFormat() != shadowMapFormat ||
+					writableShadowMap->GetExtent().x != shadowMapExtent.x ||
+					writableShadowMap->GetExtent().y != shadowMapExtent.y))
+			{
+				const auto staleShadowMap = writableShadowMap;
+				const float staleMemoryMb =
+					CalculateCsmShadowMapMemoryMb(staleShadowMap);
+				m_csmShadowMapsMb = (std::max)(
+					0.0f,
+					m_csmShadowMapsMb - staleMemoryMb);
+				m_shadowMapsMb = (std::max)(
+					0.0f,
+					m_shadowMapsMb - staleMemoryMb);
+				if (m_csmShadowMaps[k] == staleShadowMap)
+				{
+					m_csmShadowMaps[k].Clear();
+				}
+				if (m_shadowMapTextures[k] == staleShadowMap)
+				{
+					m_shadowMapTextures[k] = m_defaultShadowMap;
+					m_bShadowMapBindingsDirty = true;
+				}
+				writableShadowMap.Clear();
+			}
 			if (!writableShadowMap)
 			{
 				const auto usage = RHI::ETextureUsageBit::ColorAttachment_Bit |
@@ -555,18 +600,16 @@ void LightingECS::PrepareCSMPasses(
 					RHI::ETextureUsageBit::TextureTransferDst_Bit |
 					RHI::ETextureUsageBit::Sampled_Bit;
 				writableShadowMap = RHI::Renderer::GetDriver()->CreateRenderTarget(
-					ShadowCascadeResolutions[k % NumCascades],
+					shadowMapExtent,
 					1,
-					bEvsmCascade ? ShadowMapFormat_Evsm : ShadowMapFormat,
+					shadowMapFormat,
 					bEvsmCascade ? RHI::ETextureFiltration::Linear : RHI::ETextureFiltration::Nearest,
 					RHI::ETextureClamping::Clamp,
 					usage);
 				if (writableShadowMap)
 				{
-					const float bytesPerPixel = bEvsmCascade ? 16.0f : 2.0f;
-					const float shadowMapMemoryMb = static_cast<float>(
-						ShadowCascadeResolutions[k].x * ShadowCascadeResolutions[k].y) *
-						bytesPerPixel / (1024.0f * 1024.0f);
+					const float shadowMapMemoryMb =
+						CalculateCsmShadowMapMemoryMb(writableShadowMap);
 					m_csmShadowMapsMb += shadowMapMemoryMb;
 					m_shadowMapsMb += shadowMapMemoryMb;
 				}

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -126,8 +126,13 @@ namespace Sailor
 				quality == ELightShadowQuality::High ? 2048u : 1024u;
 		}
 
-		const RHI::EFormat ShadowMapFormat = RHI::EFormat::R16_UNORM;
-		const RHI::EFormat ShadowMapFormat_Evsm = RHI::EFormat::R32G32B32A32_SFLOAT;
+		static constexpr RHI::EFormat ShadowMapFormat = RHI::EFormat::R16_UNORM;
+		static constexpr RHI::EFormat ShadowMapFormat_Evsm = RHI::EFormat::R32G32B32A32_SFLOAT;
+		static constexpr RHI::EFormat GetCsmShadowMapFormat(RHI::EShadowType shadowType)
+		{
+			return shadowType == RHI::EShadowType::EVSM ?
+				ShadowMapFormat_Evsm : ShadowMapFormat;
+		}
 
 		// CSM is based on https://learnopengl.com/Guest-Articles/2021/CSM
 		// and https://learn.microsoft.com/en-us/windows/win32/dxtecharts/cascaded-shadow-maps

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -5,12 +5,13 @@
 #include "ECS/ECS.h"
 #include "Engine/Types.h"
 #include "RHI/Types.h"
-#include "Containers/Pair.h"
 #include "Components/Component.h"
 #include "Memory/Memory.h"
 #include "RHI/SceneView.h"
+#include "RHI/Lighting.h"
 #include "Raytracing/LightingModel.h"
 
+#include <bitset>
 #include <limits>
 
 namespace Sailor
@@ -43,16 +44,24 @@ namespace Sailor
 		RHI::EShadowType m_shadowType = RHI::EShadowType::None;
 		glm::mat4 m_lightMatrix{};
 		uint64_t m_sceneRevision = 0;
+		uint64_t m_animationRevision = 0;
+		uint64_t m_resourceRevision = 0;
+		bool m_bContainsDynamicCasters = false;
+		bool m_bContainsAnimatedCasters = false;
+		TSharedPtr<TVector<RHI::RHISceneVersionPtr>> m_casterSceneVersions{};
+		RHI::RHIRenderTargetPtr m_shadowMap{};
+		RHI::RHISubmissionCompletionTokenPtr m_submissionToken{};
+		RHI::RHISubmissionCompletionTokenPtr m_payloadCompletionToken{};
 
-		// <Mesh ECS Index, LastFrameChanged>
-		TVector<TPair<size_t, size_t>> m_snapshot{};
-
-		SAILOR_API bool Equals(const CSMLightState& rhs) const;
 		SAILOR_API bool CanReuse(
 			uint32_t componentIndex,
 			RHI::EShadowType shadowType,
 			const glm::mat4& lightMatrix,
-			uint64_t sceneRevision) const;
+			uint64_t sceneRevision,
+			const TSharedPtr<TVector<RHI::RHISceneVersionPtr>>& sceneVersions,
+			const Math::Frustum& shadowFrustum,
+			const RHI::RHISubmissionCompletionTokenPtr& currentSubmissionToken = {},
+			uint64_t animationRevision = 0ull) const;
 	};
 
 	struct LocalLightShadowAllocation
@@ -63,15 +72,23 @@ namespace Sailor
 		uint32_t m_requestedResolution = 0;
 		uint32_t m_atlasIndex = (std::numeric_limits<uint32_t>::max)();
 		uint64_t m_lastUsedFrame = 0;
+		uint64_t m_revision = 0;
 		TVector<uint32_t> m_slots{};
 		TVector<glm::ivec4> m_tiles{};
-		TVector<CSMLightState> m_snapshots{};
 	};
 
 	struct LocalShadowAtlas
 	{
 		RHI::RHIRenderTargetPtr m_texture{};
 		TVector<uint8_t> m_occupancy{};
+	};
+
+	struct LightingShadowFlightResources
+	{
+		TVector<RHI::RHIRenderTargetPtr> m_csmShadowMaps{};
+		TVector<CSMLightState> m_csmSnapshots{};
+		TVector<RHI::RHIRenderTargetPtr> m_localShadowAtlasTextures{};
+		TVector<TVector<CSMLightState>> m_localShadowSnapshots{};
 	};
 
 	class LightingECS final : public ECS::TSystem<LightingECS, LightData>
@@ -126,19 +143,7 @@ namespace Sailor
 		static constexpr glm::ivec2 ShadowCascadeBlur[NumCascades] = { glm::vec2(2, 2), glm::vec2(1, 1), glm::vec2(1, 1), glm::vec2(1, 1) };
 
 		// TODO: Tightly pack
-		struct LightShaderData
-		{
-			static constexpr uint32_t InvalidType = static_cast<uint32_t>(-1);
-
-			uint32_t m_type = InvalidType;
-			uint32_t m_shadowType;
-			alignas(16) glm::vec3 m_worldPosition;
-			alignas(16) glm::vec3 m_direction;
-			alignas(16) glm::vec3 m_intensity;
-			alignas(16) glm::vec3 m_attenuation;
-			alignas(16) glm::vec2 m_cutOff;
-			alignas(16) glm::vec3 m_bounds;
-		};
+		using LightShaderData = RHI::RHILightShaderData;
 
 		SAILOR_API virtual void BeginPlay() override;
 		SAILOR_API virtual Tasks::ITaskPtr Tick(float deltaTime) override;
@@ -162,28 +167,32 @@ namespace Sailor
 
 	protected:
 
-		SAILOR_API TVector<RHI::RHIUpdateShadowMapCommand> PrepareCSMPasses(
+		SAILOR_API void PrepareCSMPasses(
 			const RHI::RHISceneViewPtr& sceneView,
 			const Math::Transform& cameraTransform,
 			const CameraData& cameraData,
 			const TVector<RHI::RHILightProxy>& directionalLights,
-			uint32_t& snapshotIndex);
+			uint32_t flightSlot,
+			LightingShadowFlightResources& flightResources,
+			uint32_t& snapshotIndex,
+			TVector<RHI::RHIUpdateShadowMapCommand>& outUpdateShadowMaps);
 
-		SAILOR_API TVector<RHI::RHIUpdateShadowMapCommand> PrepareLocalShadowPasses(
+		SAILOR_API void PrepareLocalShadowPasses(
 			const RHI::RHISceneViewPtr& sceneView,
 			const TVector<RHI::RHILightProxy>& spotLights,
 			const TVector<RHI::RHILightProxy>& pointLights,
 			const CameraData& cameraData,
 			uint32_t viewportHeight,
+			uint32_t flightSlot,
+			LightingShadowFlightResources& flightResources,
 			TVector<uint32_t>& shadowIndices,
 			TVector<uint32_t>& shadowAtlasTiles,
-			TVector<RHI::RHIBlitShadowMapCommand>& shadowMapsToBlit);
+			TVector<RHI::RHIUpdateShadowMapCommand>& outUpdateShadowMaps);
 		SAILOR_API bool EnsureLocalShadowAllocation(
 			uint32_t componentIndex,
 			ELightType lightType,
 			uint32_t desiredResolution,
-			uint64_t frame,
-			TVector<RHI::RHIBlitShadowMapCommand>& shadowMapsToBlit);
+			uint64_t frame);
 		SAILOR_API uint32_t CalculateLocalShadowResolution(
 			const LightData& light,
 			float distanceToCamera,
@@ -200,6 +209,11 @@ namespace Sailor
 			uint32_t resolution,
 			TVector<glm::ivec4>& outTiles);
 		SAILOR_API bool TryCreateLocalShadowAtlas(uint32_t& outAtlasIndex);
+		SAILOR_API bool EnsureWritableLocalShadowAtlas(
+			uint32_t atlasIndex,
+			uint32_t flightSlot,
+			LightingShadowFlightResources& flightResources);
+		SAILOR_API void PublishShadowMapBindings();
 		SAILOR_API void ReleaseLocalShadowTiles(uint32_t atlasIndex, const TVector<glm::ivec4>& tiles);
 		SAILOR_API void ReleaseUnusedLocalShadowAtlases();
 		SAILOR_API void ReleaseLocalShadowAllocation(uint32_t componentIndex);
@@ -217,24 +231,34 @@ namespace Sailor
 		// Lights
 		uint32_t m_numLights = 0;
 		RHI::RHIShaderBindingSetPtr m_lightsData;
+		TVector<LightShaderData> m_cpuLightsData{};
+		TSharedPtr<TVector<LightShaderData>> m_publishedLightsData{};
+		TVector<TSharedPtr<TVector<LightShaderData>>> m_lightsSnapshotPool{};
+		uint64_t m_lightingRevision = 0ull;
 
 		// Shadows
-		// Light matrices and shadowMaps
+		// Texture template shared by immutable per-flight lighting descriptors.
 		RHI::RHIShaderBindingPtr m_shadowMaps;
-		RHI::RHIShaderBindingPtr m_lightMatrices;
-		RHI::RHIShaderBindingPtr m_shadowIndices;
-		RHI::RHIShaderBindingPtr m_shadowAtlasTiles;
+		TVector<RHI::RHITexturePtr> m_shadowMapTextures{};
+		std::bitset<MaxShadowMapSamplers - NumCascades> m_writableLocalShadowAtlases{};
+		bool m_bShadowMapBindingsDirty = false;
 
 		TVector<RHI::RHIRenderTargetPtr> m_csmShadowMaps;
-		TVector<CSMLightState> m_csmSnapshots;
+		TVector<LightingShadowFlightResources> m_shadowFlightResources;
 		TVector<uint32_t> m_shadowMapOwners;
 		TVector<LocalLightShadowAllocation> m_localShadowAllocations;
 		TVector<LocalShadowAtlas> m_localShadowAtlases;
+		TVector<RHI::RHILightProxy> m_directionalLightsScratch{};
+		TVector<RHI::RHILightProxy> m_pointLightsScratch{};
+		TVector<RHI::RHILightProxy> m_spotLightsScratch{};
+		TVector<glm::mat4> m_cascadeProjectionScratch{};
+		TVector<RHI::RHIVisibleShadowCaster> m_csmBroadCastersScratch{};
 
 		RHI::RHIRenderTargetPtr m_defaultShadowMap;
 		float m_shadowMapsMb = 0;
 		float m_csmShadowMapsMb = 0;
 		float m_shadowsMemoryBudgetMb = DefaultShadowsMemoryBudgetMb;
+		uint64_t m_localShadowAllocationRevision = 0ull;
 	};
 
 	template class ECS::TSystem<LightingECS, LightData>;

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -17,6 +17,38 @@ using namespace Sailor::Tasks;
 
 namespace
 {
+	constexpr uint8_t StaticSpatialChange = 1u << 0u;
+	constexpr uint8_t StationarySpatialChange = 1u << 1u;
+	constexpr uint8_t DynamicSpatialChange = 1u << 2u;
+
+	uint8_t GetSpatialChangeMask(EMobilityType mobility)
+	{
+		switch (mobility)
+		{
+		case EMobilityType::Static:
+			return StaticSpatialChange;
+		case EMobilityType::Stationary:
+			return StationarySpatialChange;
+		case EMobilityType::Dynamic:
+			return DynamicSpatialChange;
+		}
+		return DynamicSpatialChange;
+	}
+
+	uint64_t CalculateMaterialRenderMetadataSignature(
+		const TVector<MaterialPtr>& materials)
+	{
+		size_t result = 1469598103934665603ull;
+		HashCombine(result, materials.Num());
+		for (const auto& material : materials)
+		{
+			HashCombine(result,
+				material,
+				material ? material->GetRenderMetadataRevision() : 0ull);
+		}
+		return static_cast<uint64_t>(result);
+	}
+
 	bool HasRenderableSelection(const StaticMeshRendererData& data)
 	{
 		const ModelPtr& model = data.GetModel();
@@ -36,22 +68,19 @@ namespace
 			return false;
 		}
 
-		TVector<glm::mat4> modelMatrices;
 		Math::AABB modelBounds;
 		if (!data.GetModel()->CollectRenderData(
 				data.GetMeshIndex(),
 				outMeshes,
-				modelMatrices,
+				outWorldMatrices,
 				modelBounds))
 		{
 			return false;
 		}
 
-		outWorldMatrices.Clear();
-		outWorldMatrices.Reserve(modelMatrices.Num());
-		for (const glm::mat4& modelMatrix : modelMatrices)
+		for (glm::mat4& modelMatrix : outWorldMatrices)
 		{
-			outWorldMatrices.Add(ownerWorldMatrix * modelMatrix);
+			modelMatrix = ownerWorldMatrix * modelMatrix;
 		}
 
 		outWorldBounds = modelBounds;
@@ -112,6 +141,7 @@ namespace
 				lhsMesh.m_baseColorSampler != rhsMesh.m_baseColorSampler ||
 				lhsMesh.m_maxCameraDistance != rhsMesh.m_maxCameraDistance ||
 				lhsMesh.m_customDepthMaterial != rhsMesh.m_customDepthMaterial ||
+				lhsMesh.m_customDepthShader != rhsMesh.m_customDepthShader ||
 #if defined(__APPLE__)
 				lhsMesh.m_materialTextureSamplers != rhsMesh.m_materialTextureSamplers ||
 #endif
@@ -150,7 +180,7 @@ namespace
 			const size_t materialIndex = meshes[meshIndex]->ResolveMaterialIndex(
 				meshIndex,
 				data.GetMaterials().Num());
-			const auto& material = data.GetMaterials()[materialIndex];
+			auto material = data.GetMaterials()[materialIndex];
 			const size_t renderQueueTag = material ? material->GetRenderState().GetTag() : 0u;
 			if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
 			{
@@ -163,7 +193,9 @@ namespace
 			shadowMesh.m_renderQueueTag = renderQueueTag;
 			if (material->GetRenderState().IsRequiredCustomDepthShader())
 			{
-				shadowMesh.m_customDepthMaterial = material;
+				shadowMesh.m_customDepthMaterial = material->GetOrAddRHI(
+					meshes[meshIndex]->m_vertexDescription);
+				shadowMesh.m_customDepthShader = material->GetShader();
 			}
 			if (renderQueueTag == maskedQueueTag)
 			{
@@ -221,24 +253,6 @@ namespace
 		return shadowCaster->m_meshes.IsEmpty() ? RHI::RHIShadowCasterProxyPtr{} : shadowCaster;
 	}
 
-	enum class EPreparedProxyState : uint8_t
-	{
-		Remove,
-		Retry,
-		Stationary,
-		Static
-	};
-
-	struct PreparedProxyUpdate
-	{
-		size_t m_componentIndex = ECS::InvalidIndex;
-		EPreparedProxyState m_state = EPreparedProxyState::Remove;
-		uint32_t m_skeletonOffset = StaticMeshRendererData::InvalidSkeletonOffset;
-		RHI::RHIMeshProxy m_stationaryProxy{};
-		RHI::RHISceneViewProxy m_staticProxy{};
-		RHI::RHIShadowCasterProxyPtr m_shadowCaster{};
-		Math::AABB m_worldBounds{};
-	};
 }
 
 uint32_t StaticMeshRendererData::ResolveLod(
@@ -297,8 +311,102 @@ void StaticMeshRendererData::SetLodSettings(
 
 void StaticMeshRendererECS::BeginPlay()
 {
-	m_sceneViewProxiesCache = RHI::RHISceneViewPtr::Make();
+	m_rhiScene = RHI::RHIScenePtr::Make();
 	m_lastMaterialContentRevision = Material::GetGlobalContentRevision();
+	PublishSceneVersion();
+}
+
+void StaticMeshRendererECS::PublishSceneVersion(uint8_t spatialChangeMask)
+{
+	auto version = RHI::RHISpatialSceneVersionPtr::Make();
+	version->m_revision = ++m_sceneVersionRevision;
+	if (spatialChangeMask != 0u || !m_publishedSceneVersion)
+	{
+		++m_spatialRevision;
+	}
+	version->m_shadowCastersRevision = m_shadowCastersRevision;
+	version->m_bHasCustomDepthShadowCasters = m_bHasCustomDepthShadowCasters;
+	version->m_scene = m_rhiScene;
+	if (m_rhiScene)
+	{
+		version->m_sceneVersion = m_rhiScene->PublishVersion(
+			m_lastMaterialContentRevision,
+			m_shadowCastersRevision,
+			m_spatialRevision);
+
+		const bool bRebuildStatic = !m_publishedSceneVersion ||
+			(spatialChangeMask & StaticSpatialChange) != 0u;
+		const bool bRebuildStationary = !m_publishedSceneVersion ||
+			(spatialChangeMask & StationarySpatialChange) != 0u;
+		const bool bRebuildDynamic = !m_publishedSceneVersion ||
+			(spatialChangeMask & DynamicSpatialChange) != 0u;
+		if (bRebuildStatic)
+		{
+			version->m_staticOctree = TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
+				glm::ivec3(0, 0, 0), 16536 * 16, 4);
+		}
+		if (!bRebuildStatic)
+		{
+			version->m_staticOctree = m_publishedSceneVersion->m_staticOctree;
+		}
+		if (bRebuildStationary)
+		{
+			version->m_stationaryOctree = TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
+				glm::ivec3(0, 0, 0), 16536 * 16, 4);
+		}
+		if (!bRebuildStationary)
+		{
+			version->m_stationaryOctree = m_publishedSceneVersion->m_stationaryOctree;
+		}
+		if (bRebuildDynamic)
+		{
+			version->m_dynamicOctree = TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
+				glm::ivec3(0, 0, 0), 16536 * 16, 4);
+		}
+		if (!bRebuildDynamic)
+		{
+			version->m_dynamicOctree = m_publishedSceneVersion->m_dynamicOctree;
+		}
+
+		auto rebuildSpatialRoot = [&](const TSharedPtr<TVector<RHI::RenderInstanceHandle>>& handles,
+			const TSharedPtr<TOctree<RHI::RenderInstanceHandle>>& octree)
+			{
+				if (!handles || !octree)
+				{
+					return;
+				}
+				for (const auto& handle : *handles)
+				{
+					const RHI::RHISceneInstanceRecord* record = nullptr;
+					if (!version->m_sceneVersion->Resolve(handle, record) || !record)
+					{
+						continue;
+					}
+					glm::ivec3 octreeCenter{};
+					glm::ivec3 octreeExtents{};
+					GetConservativeOctreeBounds(
+						record->m_worldBounds,
+						octreeCenter,
+						octreeExtents);
+					octree->Update(octreeCenter, octreeExtents, handle);
+				}
+			};
+		if (bRebuildStatic)
+		{
+			rebuildSpatialRoot(version->m_sceneVersion->m_staticHandles, version->m_staticOctree);
+		}
+		if (bRebuildStationary)
+		{
+			rebuildSpatialRoot(
+				version->m_sceneVersion->m_stationaryHandles,
+				version->m_stationaryOctree);
+		}
+		if (bRebuildDynamic)
+		{
+			rebuildSpatialRoot(version->m_sceneVersion->m_dynamicHandles, version->m_dynamicOctree);
+		}
+	}
+	m_publishedSceneVersion = std::move(version);
 }
 
 void StaticMeshRendererECS::MarkDirty(GameObjectPtr owner)
@@ -323,24 +431,25 @@ void StaticMeshRendererECS::MarkDirty(GameObjectPtr owner)
 
 void StaticMeshRendererECS::OnComponentUnregistered(size_t index, StaticMeshRendererData& component)
 {
-	if (!m_sceneViewProxiesCache)
+	uint8_t spatialChangeMask = 0u;
+	RHI::RenderInstanceHandle* renderHandle = nullptr;
+	if (m_rhiScene && m_renderInstanceHandles.Find(index, renderHandle) && renderHandle)
 	{
-		return;
+		RHI::RHISceneInstanceRecord previousRecord;
+		if (m_rhiScene->ResolveCurrent(*renderHandle, previousRecord))
+		{
+			spatialChangeMask |= GetSpatialChangeMask(previousRecord.m_mobility);
+		}
+		m_rhiScene->RemoveInstance(*renderHandle);
+		m_renderInstanceHandles.Remove(index);
 	}
-
-	RHI::RHIMeshProxy stationaryProxy{};
-	stationaryProxy.m_staticMeshEcs = index;
-	m_sceneViewProxiesCache->m_stationaryOctree.Remove(stationaryProxy);
-
-	RHI::RHISceneViewProxy staticProxy{};
-	staticProxy.m_staticMeshEcs = index;
-	m_sceneViewProxiesCache->m_staticOctree.Remove(staticProxy);
 
 	if (component.m_shadowCaster)
 	{
 		component.m_shadowCaster.Clear();
-		++m_sceneViewProxiesCache->m_shadowCastersRevision;
+		++m_shadowCastersRevision;
 	}
+	PublishSceneVersion(spatialChangeMask);
 }
 
 Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
@@ -349,15 +458,11 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 
 	SAILOR_PROFILE_FUNCTION();
 
-	if (!m_sceneViewProxiesCache)
-	{
-		return nullptr;
-	}
-
 	const uint64_t materialContentRevision = Material::GetGlobalContentRevision();
 	const bool bCheckMaterialRevisions = materialContentRevision != m_lastMaterialContentRevision;
 	bool bHasCustomDepthShadowCasters = false;
-	TVector<size_t> dirtyComponents;
+	auto& dirtyComponents = m_componentScanScratch;
+	dirtyComponents.Clear(false);
 	dirtyComponents.Reserve(m_components.Num());
 	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
 	{
@@ -380,7 +485,8 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 		}
 
 		auto& data = m_components[componentIndex];
-		bool bNeedsUpdate = data.m_bIsDirty || (data.GetModel() && data.m_frameLastChange == 0);
+		bool bNeedsUpdate = data.m_bIsDirty ||
+			(data.GetModel() && data.m_frameLastChange == 0);
 		if (GameObjectPtr owner = data.m_owner.StaticCast<GameObject>())
 		{
 			bNeedsUpdate |= owner->GetTransformComponent().GetFrameLastChange() > data.m_frameLastChange;
@@ -388,7 +494,8 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 
 		if (!bNeedsUpdate && bCheckMaterialRevisions)
 		{
-			bool bMaterialsChanged = data.m_materialContentRevisions.Num() != data.GetMaterials().Num();
+			bool bMaterialsChanged =
+				data.m_materialContentRevisions.Num() != data.GetMaterials().Num() + 1u;
 			for (size_t materialIndex = 0; !bMaterialsChanged && materialIndex < data.GetMaterials().Num(); ++materialIndex)
 			{
 				const auto& material = data.GetMaterials()[materialIndex];
@@ -404,10 +511,9 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			dirtyComponents.Add(componentIndex);
 		}
 	}
-	m_lastMaterialContentRevision = materialContentRevision;
-
 	if (dirtyComponents.IsEmpty())
 	{
+		m_lastMaterialContentRevision = materialContentRevision;
 		return nullptr;
 	}
 
@@ -429,10 +535,36 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 				return result;
 			}
 
+			const bool bTopologyDirty = data.m_bIsDirty ||
+				(data.GetModel() && data.m_frameLastChange == 0);
+			const bool bTransformDirty = owner->GetTransformComponent().GetFrameLastChange() > data.m_frameLastChange;
+			const bool bMaterialsDirty =
+				data.m_materialContentRevisions.Num() != data.GetMaterials().Num() + 1u ||
+				data.m_materialContentRevisions[data.GetMaterials().Num()] !=
+					CalculateMaterialRenderMetadataSignature(data.GetMaterials());
+			if (bTransformDirty)
+			{
+				result.m_changeMask |= RHI::ToMask(RHI::ESceneChangeBit::Transform) |
+					RHI::ToMask(RHI::ESceneChangeBit::Bounds);
+			}
+			if (bTopologyDirty)
+			{
+				result.m_changeMask |= RHI::ToMask(RHI::ESceneChangeBit::MeshOrLodTopology) |
+					RHI::ToMask(RHI::ESceneChangeBit::Material) |
+					RHI::ToMask(RHI::ESceneChangeBit::RenderState) |
+					RHI::ToMask(RHI::ESceneChangeBit::ShadowState) |
+					RHI::ToMask(RHI::ESceneChangeBit::Bounds);
+			}
+			else if (bMaterialsDirty)
+			{
+				result.m_changeMask |= RHI::ToMask(RHI::ESceneChangeBit::Material) |
+					RHI::ToMask(RHI::ESceneChangeBit::RenderState) |
+					RHI::ToMask(RHI::ESceneChangeBit::ShadowState);
+			}
 			const ModelPtr& model = data.GetModel();
 			if (!model->IsReady())
 			{
-				result.m_state = EPreparedProxyState::Retry;
+				result.m_state = EPreparedProxyState::Pending;
 				return result;
 			}
 
@@ -454,25 +586,74 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 
 			if (data.GetMaterials().IsEmpty())
 			{
-				result.m_state = EPreparedProxyState::Retry;
 				return result;
 			}
 			for (const auto& material : data.GetMaterials())
 			{
 				if (!material)
 				{
-					result.m_state = EPreparedProxyState::Retry;
+					result.m_state = EPreparedProxyState::Pending;
 					return result;
 				}
 				if (!material->IsReady())
 				{
-					result.m_state = EPreparedProxyState::Retry;
+					result.m_state = !bTopologyDirty && !bTransformDirty && !bMaterialsDirty ?
+						EPreparedProxyState::PendingMaterialVersion : EPreparedProxyState::Pending;
 					return result;
 				}
+			}
+			if (!bTopologyDirty && !bTransformDirty && !bMaterialsDirty)
+			{
+				// Uniform-only changes publish a new immutable RHI material version.
+				// Scene topology and instance records remain valid and are selected by
+				// the submission's material cutoff during packet construction.
+				result.m_state = EPreparedProxyState::MaterialVersionOnly;
+				return result;
 			}
 
 			const auto& ownerTransform = owner->GetTransformComponent();
 			const glm::mat4& ownerWorldMatrix = ownerTransform.GetCachedWorldMatrix();
+			if (auto animator = owner->GetComponent<AnimatorComponent>())
+			{
+				result.m_skeletonOffset = animator->GetSkeletonOffset();
+			}
+
+			// A transform-only update must not rebuild and then discard the full
+			// mesh/material/shadow topology. Once the published resource stores
+			// local mesh transforms, the scene record can carry the new mutable
+			// state while every active version retains the immutable topology.
+			if (!bTopologyDirty && !bMaterialsDirty && m_rhiScene)
+			{
+				RHI::RenderInstanceHandle* renderHandle = nullptr;
+				RHI::RHISceneInstanceRecord previousRecord;
+				if (m_renderInstanceHandles.Find(componentIndex, renderHandle) &&
+					renderHandle &&
+					m_rhiScene->ResolveCurrent(*renderHandle, previousRecord))
+				{
+					const auto previousResource =
+						previousRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>();
+					Math::AABB worldBounds = model->GetBoundsAABB(data.GetMeshIndex());
+					worldBounds.Apply(ownerWorldMatrix);
+					if (previousResource && previousResource->m_bMeshTransformsAreLocal &&
+						worldBounds.IsValid())
+					{
+						result.m_worldBounds = worldBounds;
+						result.m_shadowCaster = data.m_shadowCaster;
+						result.m_state = owner->GetMobilityType() == EMobilityType::Static ?
+							EPreparedProxyState::Static : EPreparedProxyState::Stationary;
+						result.m_staticProxy.m_staticMeshEcs = componentIndex;
+						result.m_staticProxy.m_mobility = owner->GetMobilityType();
+						result.m_staticProxy.m_worldMatrix = ownerWorldMatrix;
+						result.m_staticProxy.m_worldAabb = worldBounds;
+						result.m_staticProxy.m_frame = currentFrame;
+						result.m_staticProxy.m_skeletonOffset = result.m_skeletonOffset;
+						result.m_staticProxy.m_bCastShadows = data.ShouldCastShadow();
+						result.m_bStateOnly = true;
+						return result;
+					}
+				}
+			}
+
 			TVector<RHI::RHIMeshPtr> selectedMeshes;
 			TVector<glm::mat4> selectedMatrices;
 			if (!CollectComponentRenderData(
@@ -485,11 +666,6 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 				return result;
 			}
 
-			if (auto animator = owner->GetComponent<AnimatorComponent>())
-			{
-				result.m_skeletonOffset = animator->GetSkeletonOffset();
-			}
-
 			result.m_shadowCaster = CreateShadowCasterProxy(
 				data,
 				componentIndex,
@@ -500,17 +676,11 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 				result.m_skeletonOffset,
 				currentFrame);
 
-			if (owner->GetMobilityType() != EMobilityType::Static)
-			{
-				result.m_state = EPreparedProxyState::Stationary;
-				result.m_stationaryProxy.m_staticMeshEcs = componentIndex;
-				result.m_stationaryProxy.m_worldMatrix = ownerWorldMatrix;
-				return result;
-			}
-
-			result.m_state = EPreparedProxyState::Static;
+			result.m_state = owner->GetMobilityType() == EMobilityType::Static ?
+				EPreparedProxyState::Static : EPreparedProxyState::Stationary;
 			auto& proxy = result.m_staticProxy;
 			proxy.m_staticMeshEcs = componentIndex;
+			proxy.m_mobility = owner->GetMobilityType();
 			proxy.m_worldMatrix = ownerWorldMatrix;
 			proxy.m_frame = currentFrame;
 			proxy.m_skeletonOffset = result.m_skeletonOffset;
@@ -518,6 +688,10 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			proxy.m_meshModelMatrices = std::move(selectedMatrices);
 			proxy.m_worldAabb = result.m_worldBounds;
 			proxy.m_bCastShadows = data.ShouldCastShadow();
+			proxy.m_lodPolicy.m_bEnabled = true;
+			proxy.m_lodPolicy.m_minLod = data.m_minLod;
+			proxy.m_lodPolicy.m_maxLod = data.m_maxLod;
+			proxy.m_lodPolicy.m_screenCoverageThresholds = data.m_screenCoverageThresholds;
 			proxy.m_overrideMaterials.Reserve(proxy.m_meshes.Num());
 			proxy.m_renderQueueTags.Reserve(proxy.m_meshes.Num());
 			proxy.m_baseColorFactors.Reserve(proxy.m_meshes.Num());
@@ -589,35 +763,34 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			return result;
 		};
 
-	TVector<PreparedProxyUpdate> preparedUpdates;
-	preparedUpdates.Reserve(dirtyComponents.Num());
+	auto& preparedUpdates = m_preparedUpdatesScratch;
+	preparedUpdates.Clear(false);
+	preparedUpdates.Resize(dirtyComponents.Num());
 	if (dirtyComponents.Num() <= NumDirtyComponentsPerTask)
 	{
-		for (size_t componentIndex : dirtyComponents)
+		for (size_t index = 0; index < dirtyComponents.Num(); ++index)
 		{
-			preparedUpdates.Add(prepareProxyUpdate(componentIndex));
+			preparedUpdates[index] = prepareProxyUpdate(dirtyComponents[index]);
 		}
 	}
 	else
 	{
-		TVector<Tasks::TaskPtr<TVector<PreparedProxyUpdate>>> tasks;
+		auto& tasks = m_prepareTasksScratch;
+		tasks.Clear(false);
 		const size_t numTasks = (dirtyComponents.Num() + NumDirtyComponentsPerTask - 1) / NumDirtyComponentsPerTask;
 		tasks.Reserve(numTasks);
 		for (size_t taskIndex = 0; taskIndex < numTasks; ++taskIndex)
 		{
 			const size_t beginIndex = taskIndex * NumDirtyComponentsPerTask;
 			const size_t endIndex = (std::min)(beginIndex + NumDirtyComponentsPerTask, dirtyComponents.Num());
-			auto task = Tasks::CreateTask<TVector<PreparedProxyUpdate>>(
+			auto task = Tasks::CreateTask(
 				"StaticMeshRendererECS:Prepare Dirty Proxies",
-				[beginIndex, endIndex, &dirtyComponents, prepareProxyUpdate]()
+				[beginIndex, endIndex, &dirtyComponents, &preparedUpdates, prepareProxyUpdate]()
 				{
-					TVector<PreparedProxyUpdate> result;
-					result.Reserve(endIndex - beginIndex);
 					for (size_t index = beginIndex; index < endIndex; ++index)
 					{
-						result.Add(prepareProxyUpdate(dirtyComponents[index]));
+						preparedUpdates[index] = prepareProxyUpdate(dirtyComponents[index]);
 					}
-					return result;
 				},
 				EThreadType::Worker);
 			task->Run();
@@ -627,11 +800,15 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 		for (auto& task : tasks)
 		{
 			task->Wait();
-			preparedUpdates.AddRange(std::move(task->m_result));
 		}
 	}
 
 	bool bShadowCastersChanged = false;
+	bool bSceneRecordsChanged = false;
+	bool bMaterialVersionsPending = false;
+	const bool bPreviousHasCustomDepthShadowCasters =
+		m_bHasCustomDepthShadowCasters;
+	uint8_t spatialChangeMask = 0u;
 	for (auto& update : preparedUpdates)
 	{
 		if (!IsComponentRegistered(update.m_componentIndex))
@@ -640,28 +817,37 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 		}
 
 		auto& data = m_components[update.m_componentIndex];
-		RHI::RHIMeshProxy stationaryKey{};
-		stationaryKey.m_staticMeshEcs = update.m_componentIndex;
-		RHI::RHISceneViewProxy staticKey{};
-		staticKey.m_staticMeshEcs = update.m_componentIndex;
-
-		if (update.m_state == EPreparedProxyState::Retry)
-		{
-			m_sceneViewProxiesCache->m_stationaryOctree.Remove(stationaryKey);
-			m_sceneViewProxiesCache->m_staticOctree.Remove(staticKey);
-			if (data.m_shadowCaster)
+		auto cacheMaterialRevisions = [&data]()
 			{
-				data.m_shadowCaster.Clear();
-				bShadowCastersChanged = true;
-			}
+				data.m_materialContentRevisions.Resize(data.GetMaterials().Num() + 1u);
+				for (size_t materialIndex = 0u;
+					materialIndex < data.GetMaterials().Num(); ++materialIndex)
+				{
+					const auto& material = data.GetMaterials()[materialIndex];
+					data.m_materialContentRevisions[materialIndex] = material ?
+						material->GetContentRevision() : 0ull;
+				}
+				data.m_materialContentRevisions[data.GetMaterials().Num()] =
+					CalculateMaterialRenderMetadataSignature(data.GetMaterials());
+			};
+		if (update.m_state == EPreparedProxyState::Pending)
+		{
 			data.m_bIsDirty = true;
+			continue;
+		}
+		if (update.m_state == EPreparedProxyState::PendingMaterialVersion)
+		{
+			bMaterialVersionsPending = true;
+			continue;
+		}
+		if (update.m_state == EPreparedProxyState::MaterialVersionOnly)
+		{
+			cacheMaterialRevisions();
 			continue;
 		}
 
 		if (update.m_state == EPreparedProxyState::Remove)
 		{
-			m_sceneViewProxiesCache->m_stationaryOctree.Remove(stationaryKey);
-			m_sceneViewProxiesCache->m_staticOctree.Remove(staticKey);
 			if (data.m_shadowCaster)
 			{
 				data.m_shadowCaster.Clear();
@@ -669,6 +855,17 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			}
 			data.m_materialContentRevisions.Clear();
 			data.m_bIsDirty = false;
+			RHI::RenderInstanceHandle* renderHandle = nullptr;
+			if (m_rhiScene && m_renderInstanceHandles.Find(update.m_componentIndex, renderHandle) && renderHandle)
+			{
+				RHI::RHISceneInstanceRecord previousRecord;
+				if (m_rhiScene->ResolveCurrent(*renderHandle, previousRecord))
+				{
+					spatialChangeMask |= GetSpatialChangeMask(previousRecord.m_mobility);
+				}
+				bSceneRecordsChanged |= m_rhiScene->RemoveInstance(*renderHandle);
+				m_renderInstanceHandles.Remove(update.m_componentIndex);
+			}
 			continue;
 		}
 
@@ -682,39 +879,112 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			data.m_shadowCaster = update.m_shadowCaster;
 			bShadowCastersChanged = true;
 		}
-
-		if (update.m_state == EPreparedProxyState::Stationary)
+		if (update.m_bStateOnly &&
+			(update.m_changeMask & RHI::ToMask(RHI::ESceneChangeBit::Transform)) != 0u &&
+			update.m_staticProxy.m_bCastShadows)
 		{
-			m_sceneViewProxiesCache->m_staticOctree.Remove(staticKey);
-			update.m_stationaryProxy.m_shadowCaster = data.m_shadowCaster;
-			glm::ivec3 octreeCenter{};
-			glm::ivec3 octreeExtents{};
-			GetConservativeOctreeBounds(update.m_worldBounds, octreeCenter, octreeExtents);
-			m_sceneViewProxiesCache->m_stationaryOctree.Update(
-				octreeCenter,
-				octreeExtents,
-				update.m_stationaryProxy);
+			bShadowCastersChanged = true;
 		}
-		else
+
+		update.m_staticProxy.m_shadowCaster = data.m_shadowCaster;
+		if (update.m_staticProxy.m_shadowCaster)
 		{
-			m_sceneViewProxiesCache->m_stationaryOctree.Remove(stationaryKey);
-			update.m_staticProxy.m_shadowCaster = data.m_shadowCaster;
-			glm::ivec3 octreeCenter{};
-			glm::ivec3 octreeExtents{};
-			GetConservativeOctreeBounds(update.m_worldBounds, octreeCenter, octreeExtents);
-			m_sceneViewProxiesCache->m_staticOctree.Update(
-				octreeCenter,
-				octreeExtents,
-				update.m_staticProxy);
+			update.m_staticProxy.m_shadowCaster->m_mobility = update.m_staticProxy.m_mobility;
+		}
+		if (m_rhiScene)
+		{
+			RHI::RHISceneInstanceRecord sceneRecord;
+			sceneRecord.m_producerKey = update.m_componentIndex;
+			sceneRecord.m_mobility = update.m_staticProxy.m_mobility;
+			sceneRecord.m_worldMatrix = update.m_staticProxy.m_worldMatrix;
+			sceneRecord.m_worldBounds = update.m_staticProxy.m_worldAabb;
+			sceneRecord.m_topologyRevision = currentFrame;
+			sceneRecord.m_materialRevision = Material::GetGlobalContentRevision();
+			sceneRecord.m_skeletonOffset = update.m_staticProxy.m_skeletonOffset;
+			sceneRecord.m_renderFlags = update.m_staticProxy.m_bCastShadows ? 1u : 0u;
+
+			RHI::RenderInstanceHandle* renderHandle = nullptr;
+			if (m_renderInstanceHandles.Find(update.m_componentIndex, renderHandle) && renderHandle)
+			{
+				RHI::RHISceneInstanceRecord previousRecord;
+				const bool bResolvedPrevious =
+					m_rhiScene->ResolveCurrent(*renderHandle, previousRecord);
+				if (bResolvedPrevious)
+				{
+					const RHI::SceneChangeMask topologyChanges =
+						RHI::ToMask(RHI::ESceneChangeBit::MeshOrLodTopology) |
+						RHI::ToMask(RHI::ESceneChangeBit::Material) |
+						RHI::ToMask(RHI::ESceneChangeBit::RenderState) |
+						RHI::ToMask(RHI::ESceneChangeBit::ShadowState);
+					bool bCanReuseTopology = (update.m_changeMask & topologyChanges) == 0u;
+					if (bCanReuseTopology &&
+						(update.m_changeMask & RHI::ToMask(RHI::ESceneChangeBit::Transform)) != 0u)
+					{
+						const auto previousResource =
+							previousRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>();
+						bCanReuseTopology = previousResource &&
+							previousResource->m_bMeshTransformsAreLocal;
+					}
+					if (bCanReuseTopology)
+					{
+						sceneRecord.m_topology = previousRecord.m_topology;
+						sceneRecord.m_topologyRevision = previousRecord.m_topologyRevision;
+						if ((update.m_changeMask &
+							RHI::ToMask(RHI::ESceneChangeBit::Material)) == 0u)
+						{
+							sceneRecord.m_materialRevision = previousRecord.m_materialRevision;
+						}
+					}
+					else
+					{
+						update.m_changeMask |=
+							RHI::ToMask(RHI::ESceneChangeBit::MeshOrLodTopology);
+						sceneRecord.m_topology =
+							RHI::RHISceneProxyResourcePtr::Make(std::move(update.m_staticProxy));
+					}
+					if (previousRecord.m_mobility != sceneRecord.m_mobility)
+					{
+						update.m_changeMask |= RHI::ToMask(RHI::ESceneChangeBit::Mobility);
+					}
+					if (const auto resource = sceneRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>())
+					{
+						sceneRecord.m_shadowRevision = resource->m_shadowRevision;
+					}
+				}
+				const RHI::SceneChangeMask spatialChanges =
+					RHI::ToMask(RHI::ESceneChangeBit::Transform) |
+					RHI::ToMask(RHI::ESceneChangeBit::Bounds) |
+					RHI::ToMask(RHI::ESceneChangeBit::Mobility);
+				const bool bUpdated = m_rhiScene->UpdateInstance(
+					*renderHandle,
+					sceneRecord,
+					update.m_changeMask);
+				bSceneRecordsChanged |= bUpdated;
+				if (bUpdated && (update.m_changeMask & spatialChanges) != 0u)
+				{
+					if (bResolvedPrevious)
+					{
+						spatialChangeMask |= GetSpatialChangeMask(previousRecord.m_mobility);
+					}
+					spatialChangeMask |= GetSpatialChangeMask(sceneRecord.m_mobility);
+				}
+			}
+			else
+			{
+				sceneRecord.m_topology =
+					RHI::RHISceneProxyResourcePtr::Make(std::move(update.m_staticProxy));
+				if (const auto resource = sceneRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>())
+				{
+					sceneRecord.m_shadowRevision = resource->m_shadowRevision;
+				}
+				m_renderInstanceHandles[update.m_componentIndex] = m_rhiScene->AddInstance(sceneRecord);
+				bSceneRecordsChanged = true;
+				spatialChangeMask |= GetSpatialChangeMask(sceneRecord.m_mobility);
+			}
 		}
 
 		data.m_skeletonOffset = update.m_skeletonOffset;
-		data.m_materialContentRevisions.Resize(data.GetMaterials().Num());
-		for (size_t materialIndex = 0; materialIndex < data.GetMaterials().Num(); ++materialIndex)
-		{
-			const auto& material = data.GetMaterials()[materialIndex];
-			data.m_materialContentRevisions[materialIndex] = material ? material->GetContentRevision() : 0ull;
-		}
+		cacheMaterialRevisions();
 
 		ObjectPtr ownerObject = data.GetOwner();
 		GameObjectPtr owner = ownerObject.StaticCast<GameObject>();
@@ -729,12 +999,21 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 		}
 		data.m_bIsDirty = false;
 	}
+	if (!bMaterialVersionsPending)
+	{
+		m_lastMaterialContentRevision = materialContentRevision;
+	}
 
 	if (bShadowCastersChanged)
 	{
-		++m_sceneViewProxiesCache->m_shadowCastersRevision;
+		++m_shadowCastersRevision;
 	}
-	m_sceneViewProxiesCache->m_bHasCustomDepthShadowCasters = bHasCustomDepthShadowCasters;
+	m_bHasCustomDepthShadowCasters = bHasCustomDepthShadowCasters;
+	if (bSceneRecordsChanged || bShadowCastersChanged ||
+		bPreviousHasCustomDepthShadowCasters != m_bHasCustomDepthShadowCasters)
+	{
+		PublishSceneVersion(spatialChangeMask);
+	}
 
 	return nullptr;
 }
@@ -743,14 +1022,20 @@ void StaticMeshRendererECS::CopySceneView(RHI::RHISceneViewPtr& outProxies)
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	outProxies->m_stationaryOctree = m_sceneViewProxiesCache->m_stationaryOctree;
-	outProxies->m_staticOctree = m_sceneViewProxiesCache->m_staticOctree;
-	outProxies->m_shadowCastersRevision = m_sceneViewProxiesCache->m_shadowCastersRevision;
-	outProxies->m_bHasCustomDepthShadowCasters = m_sceneViewProxiesCache->m_bHasCustomDepthShadowCasters;
+	outProxies->AddSceneVersion(m_publishedSceneVersion);
 }
 
 void StaticMeshRendererECS::EndPlay()
 {
 	ECS::TSystem<StaticMeshRendererECS, StaticMeshRendererData>::EndPlay();
-	m_sceneViewProxiesCache.Clear();
+	m_publishedSceneVersion.Clear();
+	m_rhiScene.Clear();
+	m_renderInstanceHandles.Clear();
+	m_sceneVersionRevision = 0ull;
+	m_spatialRevision = 0ull;
+	m_shadowCastersRevision = 0ull;
+	m_componentScanScratch.Clear();
+	m_preparedUpdatesScratch.Clear();
+	m_prepareTasksScratch.Clear();
+	m_bHasCustomDepthShadowCasters = false;
 }

--- a/Runtime/ECS/StaticMeshRendererECS.h
+++ b/Runtime/ECS/StaticMeshRendererECS.h
@@ -73,15 +73,47 @@ namespace Sailor
 		SAILOR_API virtual Tasks::ITaskPtr Tick(float deltaTime) override;
 		void CopySceneView(RHI::RHISceneViewPtr& outProxies);
 		void MarkDirty(GameObjectPtr owner);
+		const RHI::RHIScenePtr& GetRHIScene() const { return m_rhiScene; }
 
 		virtual uint32_t GetOrder() const override { return 1000; }
 
 	protected:
+		enum class EPreparedProxyState : uint8_t
+		{
+			Remove,
+			Pending,
+			PendingMaterialVersion,
+			MaterialVersionOnly,
+			Stationary,
+			Static
+		};
+
+		struct PreparedProxyUpdate
+		{
+			size_t m_componentIndex = ECS::InvalidIndex;
+			EPreparedProxyState m_state = EPreparedProxyState::Remove;
+			uint32_t m_skeletonOffset = StaticMeshRendererData::InvalidSkeletonOffset;
+			RHI::RHISceneViewProxy m_staticProxy{};
+			RHI::RHIShadowCasterProxyPtr m_shadowCaster{};
+			Math::AABB m_worldBounds{};
+			RHI::SceneChangeMask m_changeMask = RHI::ToMask(RHI::ESceneChangeBit::None);
+			bool m_bStateOnly = false;
+		};
 
 		SAILOR_API virtual void OnComponentUnregistered(size_t index, StaticMeshRendererData& component) override;
+		void PublishSceneVersion(uint8_t spatialChangeMask = 0x7u);
 
-		RHI::RHISceneViewPtr m_sceneViewProxiesCache;
+		RHI::RHISpatialSceneVersionPtr m_publishedSceneVersion{};
+		RHI::RHIScenePtr m_rhiScene{};
+		TMap<size_t, RHI::RenderInstanceHandle> m_renderInstanceHandles{};
+		uint64_t m_sceneVersionRevision = 0ull;
+		uint64_t m_spatialRevision = 0ull;
+		uint64_t m_shadowCastersRevision = 0ull;
 		uint64_t m_lastMaterialContentRevision = 0;
+		TVector<size_t> m_componentScanScratch{};
+		TVector<PreparedProxyUpdate> m_preparedUpdatesScratch{};
+		TVector<Tasks::ITaskPtr> m_prepareTasksScratch{};
+		bool m_bHasCustomDepthShadowCasters = false;
 	};
 
 	template class ECS::TSystem<StaticMeshRendererECS, StaticMeshRendererData>;

--- a/Runtime/FrameGraph/DepthPrepassNode.cpp
+++ b/Runtime/FrameGraph/DepthPrepassNode.cpp
@@ -73,41 +73,613 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 	const std::string QueueTag = GetString("Tag");
 	const size_t QueueTagHash = GetHash(QueueTag);
 	const bool bMaskedQueue = QueueTagHash == GetHash(std::string("Masked"));
+	std::string virtualizeInstancePayloadsSetting;
+	const bool bVirtualizeInstancePayloads =
+		!TryGetString("VirtualizeInstancePayloads", virtualizeInstancePayloadsSetting) ||
+		virtualizeInstancePayloadsSetting != "false";
 
 	auto res = Tasks::CreateTask("Prepare DepthPrepassNode " + std::to_string(sceneView.m_frame),
 		[=, this, holdRhiResources = frameGraph, &syncSharedResources = m_syncSharedResources, &sceneViewSnapshot = sceneView]() mutable {
+			if (!sceneViewSnapshot.m_submissionContext)
+			{
+				return;
+			}
+			const uint64_t materialSubmissionId =
+				sceneViewSnapshot.m_submissionContext->GetSubmissionId();
+
+			auto submissionResources = sceneViewSnapshot.m_submissionContext->GetOrAddFrameGraphResources<SubmissionResources>(
+				this,
+				sceneViewSnapshot.m_cameraIndex,
+				0u);
+			auto& m_packet = submissionResources->m_packet;
+			auto& m_customPacket = submissionResources->m_customPacket;
+
 			syncSharedResources.Lock();
+			auto& requestedPacketTextures =
+				submissionResources->m_requestedPacketTextures;
+			for (auto& requestedTextures : requestedPacketTextures)
+			{
+				requestedTextures.Reset();
+			}
 
 			SAILOR_PROFILE_SCOPE("Filter sceneView by tag");
 
-			m_numMeshes = 0;
-			m_drawCalls.Clear();
-			m_batches.Clear();
-			Framegraph::Details::EvictTextureBindingCache(m_textureBindingCache, sceneViewSnapshot.m_frame);
-			for (auto& proxy : sceneViewSnapshot.m_proxies)
+			constexpr size_t PayloadRevisionSeed = 1469598103934665603ull;
+			std::array<size_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				payloadRevisions{};
+			std::array<uint32_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				numRelevantProxies{};
+			std::array<bool, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				bUsesPacketTextures{};
+			for (size_t index = 0u; index < payloadRevisions.size(); ++index)
 			{
-				for (size_t i = 0; i < proxy.m_meshes.Num(); i++)
+				payloadRevisions[index] = PayloadRevisionSeed;
+				HashCombine(payloadRevisions[index], index);
+				bUsesPacketTextures[index] = bMaskedQueue;
+			}
+			const size_t staticPayloadIndex =
+				RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
+					EMobilityType::Static);
+			const size_t stationaryPayloadIndex =
+				RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
+					EMobilityType::Stationary);
+			const bool bUsesPagedArenas = bVirtualizeInstancePayloads;
+			auto usesPagedArena = [&](size_t payloadIndex)
 				{
-					const bool bHasMaterial = proxy.GetMaterials().Num() > i;
+					return bUsesPagedArenas &&
+						(payloadIndex == staticPayloadIndex ||
+							payloadIndex == stationaryPayloadIndex);
+				};
+			if (bUsesPagedArenas)
+			{
+				for (const EMobilityType mobility :
+					{ EMobilityType::Static, EMobilityType::Stationary })
+				{
+					const size_t payloadIndex =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					payloadRevisions[payloadIndex] = PayloadRevisionSeed;
+					HashCombine(
+						payloadRevisions[payloadIndex],
+						payloadIndex,
+						QueueTagHash,
+						bMaskedQueue,
+						sceneViewSnapshot.m_submissionContext->GetMaterialRevision(),
+						sceneViewSnapshot.GetMobilityRevision(mobility));
+				}
+			}
+			for (const auto& proxy : sceneViewSnapshot.m_proxies)
+			{
+				const auto* source = proxy.GetSource();
+				if (!source || !proxy.m_resource)
+				{
+					continue;
+				}
+				const EMobilityType payloadMobility = proxy.GetMobility();
+				const size_t payloadIndex =
+					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(payloadMobility);
+				bool bContributesToQueue = false;
+				for (size_t materialIndex = 0u;
+					materialIndex < source->GetMaterials().Num(); ++materialIndex)
+				{
+					const auto& material = source->GetMaterials()[materialIndex];
+					const bool bRelevant = material &&
+						material->GetRenderState().GetTag() == QueueTagHash;
+					bContributesToQueue |= bRelevant;
+					const bool bCustom = bRelevant &&
+						material->GetRenderState().IsRequiredCustomDepthShader();
+					bUsesPacketTextures[payloadIndex] =
+						bUsesPacketTextures[payloadIndex] || bCustom;
+#if defined(__APPLE__)
+					if ((bMaskedQueue || bCustom) &&
+						materialIndex < source->m_materialTextureSamplers.Num())
+					{
+						for (uint32_t texture : source->m_materialTextureSamplers[materialIndex])
+						{
+							requestedPacketTextures[payloadIndex].Insert(texture);
+						}
+					}
+#endif
+				}
+				for (const auto& group : source->m_instancedGroups)
+				{
+					for (size_t materialIndex = 0u;
+						materialIndex < group.m_materials.Num(); ++materialIndex)
+					{
+						const auto& material = group.m_materials[materialIndex];
+						const bool bRelevant = material &&
+							material->GetRenderState().GetTag() == QueueTagHash;
+						bContributesToQueue |= bRelevant;
+						const bool bCustom = bRelevant &&
+							material->GetRenderState().IsRequiredCustomDepthShader();
+						bUsesPacketTextures[payloadIndex] =
+							bUsesPacketTextures[payloadIndex] || bCustom;
+#if defined(__APPLE__)
+						if ((bMaskedQueue || bCustom) &&
+							materialIndex < group.m_materialTextureSamplers.Num())
+						{
+							for (uint32_t texture : group.m_materialTextureSamplers[materialIndex])
+							{
+								requestedPacketTextures[payloadIndex].Insert(texture);
+							}
+						}
+#endif
+					}
+				}
+				if (bContributesToQueue)
+				{
+					++numRelevantProxies[payloadIndex];
+					if (!usesPagedArena(payloadIndex))
+					{
+						HashCombine(
+							payloadRevisions[payloadIndex],
+							proxy.m_handle.m_slot,
+							proxy.m_handle.m_generation,
+							proxy.m_resource->m_depthRevision,
+							source->m_staticMeshEcs,
+							std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
+							proxy.GetSkeletonOffset());
+						for (size_t meshIndex = 0u; meshIndex < source->m_meshes.Num(); ++meshIndex)
+						{
+							if (meshIndex < source->GetMaterials().Num() &&
+								source->GetMaterials()[meshIndex] &&
+								source->GetMaterials()[meshIndex]->GetRenderState().GetTag() == QueueTagHash)
+							{
+								HashCombine(payloadRevisions[payloadIndex], proxy.ResolveMesh(meshIndex));
+							}
+						}
+						for (const auto& group : source->m_instancedGroups)
+						{
+							for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+							{
+								if (meshIndex < group.m_materials.Num() &&
+									group.m_materials[meshIndex] &&
+									group.m_materials[meshIndex]->GetRenderState().GetTag() == QueueTagHash)
+								{
+									HashCombine(payloadRevisions[payloadIndex], proxy.ResolveMesh(group.m_meshes[meshIndex]));
+							}
+						}
+						}
+					}
+				}
+			}
+			for (size_t index = 0u; index < payloadRevisions.size(); ++index)
+			{
+				const uint64_t textureDescriptorRevision = bUsesPacketTextures[index] ?
+					Framegraph::Details::CalculateTextureDependencyRevision(
+						requestedPacketTextures[index].GetIndices()) : 0ull;
+				if (!usesPagedArena(index))
+				{
+					HashCombine(
+						payloadRevisions[index],
+						numRelevantProxies[index],
+						QueueTagHash,
+						bMaskedQueue,
+						textureDescriptorRevision);
+				}
+			}
+			m_packet.Reset();
+			m_customPacket.Reset();
+			std::array<bool, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				bBuildPacketPayload{ true, true, true };
+			std::array<bool, RHI::TPackedDrawPacket<CustomPerInstanceData>::NumMobilitySegments>
+				bBuildCustomPayload{ true, true, true };
+			std::array<bool, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				bPacketPayloadComplete{ true, true, true };
+			std::array<bool, RHI::TPackedDrawPacket<CustomPerInstanceData>::NumMobilitySegments>
+				bCustomPayloadComplete{ true, true, true };
+			auto buildPayloadCacheSlot = [&](EMobilityType mobility)
+				{
+					size_t cacheSlot = PayloadRevisionSeed;
+					const size_t index =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					const uint32_t cameraIndex = usesPagedArena(index) ?
+						0u : sceneViewSnapshot.m_cameraIndex;
+					HashCombine(cacheSlot, cameraIndex, index);
+					return cacheSlot;
+				};
+			if (bVirtualizeInstancePayloads)
+			{
+				for (const EMobilityType mobility :
+					{ EMobilityType::Static, EMobilityType::Stationary })
+				{
+					const size_t index =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					const size_t cacheSlot = buildPayloadCacheSlot(mobility);
+					auto packetPayload = usesPagedArena(index) ?
+						m_pagedArenaCache.Find(
+							cacheSlot,
+							payloadRevisions[index],
+							sceneViewSnapshot.m_frame) :
+						m_packetPayloadCache.Find(
+							cacheSlot,
+							payloadRevisions[index],
+							sceneViewSnapshot.m_frame);
+					if (packetPayload)
+					{
+						if (usesPagedArena(index))
+						{
+							m_packet.UseSharedArenaPayload(mobility, std::move(packetPayload));
+						}
+						else
+						{
+							m_packet.UseSharedPayload(mobility, std::move(packetPayload));
+						}
+						bBuildPacketPayload[index] = false;
+					}
+					auto customPayload = usesPagedArena(index) ?
+						m_customPagedArenaCache.Find(
+							cacheSlot,
+							payloadRevisions[index],
+							sceneViewSnapshot.m_frame) :
+						m_customPacketPayloadCache.Find(
+							cacheSlot,
+							payloadRevisions[index],
+							sceneViewSnapshot.m_frame);
+					if (customPayload)
+					{
+						if (usesPagedArena(index))
+						{
+							m_customPacket.UseSharedArenaPayload(mobility, std::move(customPayload));
+						}
+						else
+						{
+							m_customPacket.UseSharedPayload(mobility, std::move(customPayload));
+						}
+						bBuildCustomPayload[index] = false;
+					}
+				}
+			}
+
+			if (bUsesPagedArenas)
+			{
+				for (const EMobilityType mobility : {EMobilityType::Static, EMobilityType::Stationary})
+				{
+					const size_t arenaPayloadIndex = RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					if (!bBuildPacketPayload[arenaPayloadIndex] && !bBuildCustomPayload[arenaPayloadIndex])
+					{
+						continue;
+					}
+					const size_t arenaCacheSlot = buildPayloadCacheSlot(mobility);
+					if (bBuildPacketPayload[arenaPayloadIndex])
+					{
+						m_pagedArenaCache.BeginUpdate(
+							arenaCacheSlot, payloadRevisions[arenaPayloadIndex], sceneViewSnapshot.m_frame);
+					}
+					if (bBuildCustomPayload[arenaPayloadIndex])
+					{
+						m_customPagedArenaCache.BeginUpdate(
+							arenaCacheSlot, payloadRevisions[arenaPayloadIndex], sceneViewSnapshot.m_frame);
+					}
+					auto& rangeInstances = submissionResources->m_arenaRangeInstances;
+					auto& rangeStableKeys = submissionResources->m_arenaRangeStableKeys;
+					auto& rangeMaterialVersionRuns = submissionResources->m_arenaRangeMaterialVersionRuns;
+					auto& customRangeInstances = submissionResources->m_customArenaRangeInstances;
+					auto& customRangeStableKeys = submissionResources->m_customArenaRangeStableKeys;
+					auto& customRangeMaterialVersionRuns = submissionResources->m_customArenaRangeMaterialVersionRuns;
+					bool bBuildPacketRange = false;
+					bool bBuildCustomRange = false;
+					auto addArenaDepthInstance = [&](const RHIVisibleSceneProxy& proxy,
+													 const RHIMeshPtr& mesh,
+													 const RHIMaterialPtr& sourceMaterial,
+													 const glm::mat4& model,
+													 uint32_t baseColorSampler,
+													 const glm::vec4& baseColorFactor,
+													 float alphaCutoff,
+													 uint64_t stableKey)
+					{
+						if (!sourceMaterial || sourceMaterial->GetRenderState().GetTag() != QueueTagHash)
+						{
+							return;
+						}
+						const bool bRequiredCustomDepth =
+							!bMaskedQueue && sourceMaterial->GetRenderState().IsRequiredCustomDepthShader();
+						if ((bRequiredCustomDepth && !bBuildCustomRange) ||
+							(!bRequiredCustomDepth && !bBuildPacketRange))
+						{
+							return;
+						}
+						if (!mesh)
+						{
+							if (bRequiredCustomDepth)
+							{
+								bCustomPayloadComplete[arenaPayloadIndex] = false;
+							}
+							else
+							{
+								bPacketPayloadComplete[arenaPayloadIndex] = false;
+							}
+							return;
+						}
+
+						const bool bSkinned = proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
+							mesh->m_vertexDescription->HasAttribute(RHIVertexDescription::DefaultBoneIdsBinding) &&
+							mesh->m_vertexDescription->HasAttribute(RHIVertexDescription::DefaultBoneWeightsBinding);
+						auto depthMaterial = GetOrAddDepthMaterial(mesh->m_vertexDescription,
+							bSkinned,
+							bMaskedQueue,
+							sourceMaterial->GetRenderState().GetCullMode());
+						if (bRequiredCustomDepth)
+						{
+							depthMaterial = sourceMaterial;
+						}
+						const bool bReady = depthMaterial && depthMaterial->GetVertexShader() &&
+							depthMaterial->GetFragmentShader() && depthMaterial->GetRenderState().IsEnabledZWrite();
+						if (!bReady)
+						{
+							if (bRequiredCustomDepth)
+							{
+								bCustomPayloadComplete[arenaPayloadIndex] = false;
+							}
+							else
+							{
+								bPacketPayloadComplete[arenaPayloadIndex] = false;
+							}
+							return;
+						}
+
+						RHIBatch batch(depthMaterial, mesh, materialSubmissionId);
+						PerInstanceData data;
+						data.model = model;
+						data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+						data.skeletonOffset =
+							bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
+						if (bRequiredCustomDepth)
+						{
+							const auto bindings = batch.GetMaterialBindings();
+							if (bindings && bindings->GetShaderBindings().ContainsKey("material"))
+							{
+								const auto binding = bindings->GetShaderBindings()["material"];
+								data.materialInstance = binding ? binding->GetStorageInstanceIndex() : 0u;
+							}
+						}
+						else if (bMaskedQueue)
+						{
+							data.materialInstance = baseColorSampler;
+							const float effectiveAlphaCutoff =
+								baseColorFactor.a > 0.000001f ? alphaCutoff / baseColorFactor.a : 2.0f;
+							data.padding = glm::floatBitsToUint(effectiveAlphaCutoff);
+						}
+
+						if (bRequiredCustomDepth)
+						{
+							CustomPerInstanceData customData;
+							customData.model = data.model;
+							customData.sphereBounds = data.sphereBounds;
+							customData.materialInstance = data.materialInstance;
+							customData.skeletonOffset = data.skeletonOffset;
+							customData.padding = data.padding;
+							customData.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+							customRangeInstances.Add(std::move(customData));
+							customRangeStableKeys.Add(stableKey);
+							RHI::AppendPackedDrawArenaMaterialVersion(
+								customRangeMaterialVersionRuns, batch.m_materialVersion);
+						}
+						else
+						{
+							rangeInstances.Add(std::move(data));
+							rangeStableKeys.Add(stableKey);
+							RHI::AppendPackedDrawArenaMaterialVersion(
+								rangeMaterialVersionRuns, batch.m_materialVersion);
+						}
+					};
+
+					sceneViewSnapshot.ForEachSceneProxy(mobility,
+						[&](const RHIVisibleSceneProxy& proxy)
+						{
+							const auto* source = proxy.GetSource();
+							if (!source)
+							{
+								return;
+							}
+							const uint64_t rangeKey =
+								BuildPackedDrawRangeKey(proxy.m_handle, source->m_staticMeshEcs, proxy.m_resource);
+							size_t rangeRevision =
+								proxy.m_resource ? proxy.m_resource->m_depthRevision : proxy.GetContentRevision();
+							HashCombine(rangeRevision,
+								QueueTagHash,
+								bMaskedQueue,
+								proxy.GetContentRevision(),
+								std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
+								proxy.GetSkeletonOffset());
+							if (proxy.m_record)
+							{
+								HashCombine(
+									rangeRevision, proxy.m_record->m_materialRevision, proxy.m_record->m_renderFlags);
+							}
+							auto hashCustomDepthMaterialVersion =
+								[&](const RHI::RHIMaterialPtr& material)
+								{
+									if (bMaskedQueue || !material ||
+										material->GetRenderState().GetTag() != QueueTagHash ||
+										!material->GetRenderState().IsRequiredCustomDepthShader())
+									{
+										return;
+									}
+
+									const auto version =
+										material->GetVersionForSubmission(materialSubmissionId);
+									HashCombine(
+										rangeRevision,
+										version ? version->GetVersionId() : 0ull);
+								};
+							for (const auto& material : source->GetMaterials())
+							{
+								hashCustomDepthMaterialVersion(material);
+							}
+							for (const auto& group : source->m_instancedGroups)
+							{
+								for (const auto& material : group.m_materials)
+								{
+									hashCustomDepthMaterialVersion(material);
+								}
+							}
+							bBuildPacketRange = bBuildPacketPayload[arenaPayloadIndex] &&
+								!m_pagedArenaCache.TryReuseRange(rangeKey, rangeRevision);
+							bBuildCustomRange = bBuildCustomPayload[arenaPayloadIndex] &&
+								!m_customPagedArenaCache.TryReuseRange(rangeKey, rangeRevision);
+							if (!bBuildPacketRange && !bBuildCustomRange)
+							{
+								return;
+							}
+							rangeInstances.Clear(false);
+							rangeStableKeys.Clear(false);
+							rangeMaterialVersionRuns.Clear(false);
+							customRangeInstances.Clear(false);
+							customRangeStableKeys.Clear(false);
+							customRangeMaterialVersionRuns.Clear(false);
+							for (size_t meshIndex = 0u; meshIndex < source->m_meshes.Num(); ++meshIndex)
+							{
+								if (meshIndex >= source->GetMaterials().Num())
+								{
+									break;
+								}
+								addArenaDepthInstance(proxy,
+									source->m_meshes[meshIndex],
+									source->GetMaterials()[meshIndex],
+									proxy.ResolveMeshWorldMatrix(meshIndex),
+									meshIndex < source->m_baseColorSamplers.Num() ?
+										source->m_baseColorSamplers[meshIndex] :
+										0u,
+									meshIndex < source->m_baseColorFactors.Num() ?
+										source->m_baseColorFactors[meshIndex] :
+										glm::vec4(1.0f),
+									meshIndex < source->m_alphaCutoffs.Num() ? source->m_alphaCutoffs[meshIndex] : 0.5f,
+									BuildPackedDrawStableKey(proxy.m_handle,
+										source->m_staticMeshEcs,
+										0u,
+										static_cast<uint32_t>(meshIndex),
+										0u));
+							}
+							for (size_t groupIndex = 0u; groupIndex < source->m_instancedGroups.Num(); ++groupIndex)
+							{
+								const auto& group = source->m_instancedGroups[groupIndex];
+								for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+								{
+									if (meshIndex >= group.m_materials.Num())
+									{
+										break;
+									}
+									for (size_t instanceIndex = 0u; instanceIndex < group.m_instanceTransforms.Num();
+										++instanceIndex)
+									{
+										addArenaDepthInstance(proxy,
+											group.m_meshes[meshIndex],
+											group.m_materials[meshIndex],
+											proxy.ResolveInstancedMeshWorldMatrix(group, instanceIndex, meshIndex),
+											meshIndex < group.m_baseColorSamplers.Num() ?
+												group.m_baseColorSamplers[meshIndex] :
+												0u,
+											meshIndex < group.m_baseColorFactors.Num() ?
+												group.m_baseColorFactors[meshIndex] :
+												glm::vec4(1.0f),
+											meshIndex < group.m_alphaCutoffs.Num() ? group.m_alphaCutoffs[meshIndex] :
+																					 0.5f,
+											BuildPackedDrawStableKey(proxy.m_handle,
+												source->m_staticMeshEcs,
+												static_cast<uint32_t>(groupIndex + 1u),
+												static_cast<uint32_t>(meshIndex),
+												static_cast<uint32_t>(instanceIndex)));
+									}
+								}
+							}
+							if (bBuildPacketRange &&
+								!m_pagedArenaCache.ReplaceRange(rangeKey,
+									rangeRevision,
+									rangeInstances,
+									rangeStableKeys,
+									&rangeMaterialVersionRuns))
+							{
+								bPacketPayloadComplete[arenaPayloadIndex] = false;
+							}
+							if (bBuildCustomRange &&
+								!m_customPagedArenaCache.ReplaceRange(rangeKey,
+									rangeRevision,
+									customRangeInstances,
+									customRangeStableKeys,
+									&customRangeMaterialVersionRuns))
+							{
+								bCustomPayloadComplete[arenaPayloadIndex] = false;
+							}
+						});
+
+					if (bBuildPacketPayload[arenaPayloadIndex])
+					{
+						auto packetPayload = m_pagedArenaCache.EndUpdate(bPacketPayloadComplete[arenaPayloadIndex]);
+						m_packet.UseSharedArenaPayload(mobility, std::move(packetPayload));
+					}
+					if (bBuildCustomPayload[arenaPayloadIndex])
+					{
+						auto customPayload =
+							m_customPagedArenaCache.EndUpdate(bCustomPayloadComplete[arenaPayloadIndex]);
+						m_customPacket.UseSharedArenaPayload(mobility, std::move(customPayload));
+					}
+					rangeInstances.Clear(false);
+					rangeStableKeys.Clear(false);
+					rangeMaterialVersionRuns.Clear(false);
+					customRangeInstances.Clear(false);
+					customRangeStableKeys.Clear(false);
+					customRangeMaterialVersionRuns.Clear(false);
+					bBuildPacketPayload[arenaPayloadIndex] = false;
+					bBuildCustomPayload[arenaPayloadIndex] = false;
+				}
+			}
+			Framegraph::Details::EvictTextureBindingCache(m_textureBindingCache, sceneViewSnapshot.m_frame);
+			m_packetPayloadCache.Evict(sceneViewSnapshot.m_frame);
+			m_customPacketPayloadCache.Evict(sceneViewSnapshot.m_frame);
+			m_pagedArenaCache.Evict(sceneViewSnapshot.m_frame);
+			m_customPagedArenaCache.Evict(sceneViewSnapshot.m_frame);
+			for (const auto& proxy : sceneViewSnapshot.m_proxies)
+			{
+				const auto* source = proxy.GetSource();
+				if (!source)
+				{
+					continue;
+				}
+				const EMobilityType payloadMobility = proxy.GetMobility();
+				const size_t payloadIndex =
+					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(payloadMobility);
+				const bool bArenaView = usesPagedArena(payloadIndex);
+				if (!bBuildPacketPayload[payloadIndex] &&
+					!bBuildCustomPayload[payloadIndex] && !bArenaView)
+				{
+					continue;
+				}
+				for (size_t i = 0; i < source->m_meshes.Num(); i++)
+				{
+					const bool bHasMaterial = source->GetMaterials().Num() > i;
 					if (!bHasMaterial)
 					{
 						break;
 					}
-					if (proxy.GetMaterials()[i] == nullptr)
+					if (source->GetMaterials()[i] == nullptr)
 					{
 						continue;
 					}
 
-					const auto& sourceMaterial = proxy.GetMaterials()[i];
+					const auto& sourceMaterial = source->GetMaterials()[i];
 					if (sourceMaterial->GetRenderState().GetTag() != QueueTagHash)
 					{
 						continue;
 					}
 
-					const auto& mesh = proxy.m_meshes[i];
+					const auto mesh = proxy.ResolveMesh(i);
+					if (!mesh)
+					{
+						const bool bExpectedCustomDepth = !bMaskedQueue &&
+							sourceMaterial->GetRenderState().IsRequiredCustomDepthShader();
+						if (bExpectedCustomDepth)
+						{
+							bCustomPayloadComplete[payloadIndex] = false;
+						}
+						else
+						{
+							bPacketPayloadComplete[payloadIndex] = false;
+						}
+						continue;
+					}
 
 					const bool bSkinned =
-						proxy.m_skeletonOffset != (std::numeric_limits<uint32_t>::max)() &&
+						proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
 						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
 						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
 					auto depthMaterial = GetOrAddDepthMaterial(
@@ -118,6 +690,12 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 
 					const bool bRequiredCustomDepth = !bMaskedQueue &&
 						sourceMaterial->GetRenderState().IsRequiredCustomDepthShader();
+					if (!bArenaView &&
+						((bRequiredCustomDepth && !bBuildCustomPayload[payloadIndex]) ||
+						(!bRequiredCustomDepth && !bBuildPacketPayload[payloadIndex])))
+					{
+						continue;
+					}
 					if (bRequiredCustomDepth)
 					{
 						depthMaterial = sourceMaterial;
@@ -130,37 +708,42 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 
 					if (!bIsDepthMaterialReady)
 					{
+						if (bRequiredCustomDepth)
+						{
+							bCustomPayloadComplete[payloadIndex] = false;
+						}
+						else
+						{
+							bPacketPayloadComplete[payloadIndex] = false;
+						}
 						continue;
 					}
+					RHIBatch batch(depthMaterial, mesh, materialSubmissionId);
 
-					const glm::mat4& meshWorldMatrix =
-						proxy.m_meshModelMatrices.Num() > i ?
-							proxy.m_meshModelMatrices[i] :
-							proxy.m_worldMatrix;
+					const glm::mat4 meshWorldMatrix = proxy.ResolveMeshWorldMatrix(i);
 					DepthPrepassNode::PerInstanceData data;
 					data.model = meshWorldMatrix;
-					data.skeletonOffset = bSkinned ? proxy.m_skeletonOffset : (std::numeric_limits<uint32_t>::max)();
-					data.bIsCulled = 0;
+					data.skeletonOffset = bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
 					data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
-					data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
 
 					if (bRequiredCustomDepth)
 					{
 						RHIShaderBindingPtr shaderBinding;
-						if (depthMaterial->GetBindings()->GetShaderBindings().ContainsKey("material"))
+						const auto materialBindings = batch.GetMaterialBindings();
+						if (materialBindings && materialBindings->GetShaderBindings().ContainsKey("material"))
 						{
-							shaderBinding = depthMaterial->GetBindings()->GetShaderBindings()["material"];
+							shaderBinding = materialBindings->GetShaderBindings()["material"];
 						}
 						data.materialInstance = shaderBinding.IsValid() ? shaderBinding->GetStorageInstanceIndex() : 0;
 					}
 					else if (bMaskedQueue)
 					{
-						data.materialInstance = proxy.m_baseColorSamplers.Num() > i ?
-							proxy.m_baseColorSamplers[i] : 0u;
-						const float baseColorAlpha = proxy.m_baseColorFactors.Num() > i ?
-							proxy.m_baseColorFactors[i].a : 1.0f;
-						const float alphaCutoff = proxy.m_alphaCutoffs.Num() > i ?
-							proxy.m_alphaCutoffs[i] : 0.5f;
+						data.materialInstance = source->m_baseColorSamplers.Num() > i ?
+							source->m_baseColorSamplers[i] : 0u;
+						const float baseColorAlpha = source->m_baseColorFactors.Num() > i ?
+							source->m_baseColorFactors[i].a : 1.0f;
+						const float alphaCutoff = source->m_alphaCutoffs.Num() > i ?
+							source->m_alphaCutoffs[i] : 0.5f;
 						const float effectiveAlphaCutoff = baseColorAlpha > 0.000001f ?
 							alphaCutoff / baseColorAlpha : 2.0f;
 						data.padding = glm::floatBitsToUint(effectiveAlphaCutoff);
@@ -170,20 +753,14 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						data.materialInstance = 0;
 					}
 
-					RHIBatch batch(depthMaterial, mesh);
 					if (bRequiredCustomDepth || bMaskedQueue)
 					{
 						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
 #if defined(__APPLE__)
-						TSet<uint32_t> requestedTextures;
-						if (proxy.m_materialTextureSamplers.Num() > i)
-						{
-							requestedTextures = proxy.m_materialTextureSamplers[i];
-						}
-						else
-						{
-							requestedTextures.Insert(0u);
-						}
+						const auto& requestedTextures =
+							source->m_materialTextureSamplers.Num() > i ?
+							source->m_materialTextureSamplers[i] :
+							Framegraph::Details::GetDefaultRequestedTextures();
 						batch.m_textureBindings = Framegraph::Details::GetTextureBindingSet(
 							m_textureBindingCache,
 							requestedTextures,
@@ -195,17 +772,366 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						batch.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
 						if (!batch.m_textureBindings)
 						{
+							if (bRequiredCustomDepth)
+							{
+								bCustomPayloadComplete[payloadIndex] = false;
+							}
+							else
+							{
+								bPacketPayloadComplete[payloadIndex] = false;
+							}
 							continue;
 						}
 					}
+					const uint64_t stableKey = BuildPackedDrawStableKey(
+						proxy.m_handle,
+						source->m_staticMeshEcs,
+						0u,
+						static_cast<uint32_t>(i),
+						0u);
+					if (bArenaView)
+					{
+						const bool bAdded = bRequiredCustomDepth ?
+							m_customPacket.AddArenaView(
+								std::move(batch),
+								mesh,
+								BuildPackedDrawRangeKey(
+									proxy.m_handle,
+									source->m_staticMeshEcs,
+									proxy.m_resource),
+								stableKey,
+								payloadMobility) :
+							m_packet.AddArenaView(
+								std::move(batch),
+								mesh,
+								BuildPackedDrawRangeKey(
+									proxy.m_handle,
+									source->m_staticMeshEcs,
+									proxy.m_resource),
+								stableKey,
+								payloadMobility);
+						if (!bAdded)
+						{
+							if (bRequiredCustomDepth)
+							{
+								bCustomPayloadComplete[payloadIndex] = false;
+							}
+							else
+							{
+								bPacketPayloadComplete[payloadIndex] = false;
+							}
+						}
+						continue;
+					}
 
-					m_drawCalls[batch][mesh].Add(data);
-					m_batches.Insert(batch);
+					if (bRequiredCustomDepth)
+					{
+						DepthPrepassNode::CustomPerInstanceData customData;
+						customData.model = data.model;
+						customData.sphereBounds = data.sphereBounds;
+						customData.materialInstance = data.materialInstance;
+						customData.skeletonOffset = data.skeletonOffset;
+						customData.padding = data.padding;
+						customData.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+						m_customPacket.Add(
+							std::move(batch),
+							mesh,
+							customData,
+							stableKey,
+							payloadMobility);
+					}
+					else
+					{
+						m_packet.Add(
+							std::move(batch),
+							mesh,
+							data,
+							stableKey,
+							payloadMobility);
+					}
+				}
 
-					m_numMeshes++;
+				for (size_t groupIndex = 0u;
+					groupIndex < source->m_instancedGroups.Num(); ++groupIndex)
+				{
+					const auto& group = source->m_instancedGroups[groupIndex];
+					for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+					{
+						if (meshIndex >= group.m_materials.Num())
+						{
+							break;
+						}
+
+						const auto& sourceMaterial = group.m_materials[meshIndex];
+						if (!sourceMaterial ||
+							sourceMaterial->GetRenderState().GetTag() != QueueTagHash)
+						{
+							continue;
+						}
+
+						const auto& sourceMesh = group.m_meshes[meshIndex];
+						if (!sourceMesh)
+						{
+							const bool bExpectedCustomDepth = !bMaskedQueue &&
+								sourceMaterial->GetRenderState().IsRequiredCustomDepthShader();
+							if (bExpectedCustomDepth)
+							{
+								bCustomPayloadComplete[payloadIndex] = false;
+							}
+							else
+							{
+								bPacketPayloadComplete[payloadIndex] = false;
+							}
+							continue;
+						}
+
+						const bool bSkinned =
+							proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
+							sourceMesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
+							sourceMesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
+						auto depthMaterial = GetOrAddDepthMaterial(
+							sourceMesh->m_vertexDescription,
+							bSkinned,
+							bMaskedQueue,
+							sourceMaterial->GetRenderState().GetCullMode());
+						const bool bRequiredCustomDepth = !bMaskedQueue &&
+							sourceMaterial->GetRenderState().IsRequiredCustomDepthShader();
+						if (!bArenaView &&
+							((bRequiredCustomDepth && !bBuildCustomPayload[payloadIndex]) ||
+							(!bRequiredCustomDepth && !bBuildPacketPayload[payloadIndex])))
+						{
+							continue;
+						}
+						if (bRequiredCustomDepth)
+						{
+							depthMaterial = sourceMaterial;
+						}
+
+						const bool bIsDepthMaterialReady = depthMaterial &&
+							depthMaterial->GetVertexShader() &&
+							depthMaterial->GetFragmentShader() &&
+							depthMaterial->GetRenderState().IsEnabledZWrite();
+						if (!bIsDepthMaterialReady)
+						{
+							if (bRequiredCustomDepth)
+							{
+								bCustomPayloadComplete[payloadIndex] = false;
+							}
+							else
+							{
+								bPacketPayloadComplete[payloadIndex] = false;
+							}
+							continue;
+						}
+
+						RHIBatch batchTemplate(
+							depthMaterial,
+							sourceMesh,
+							materialSubmissionId);
+						uint32_t materialInstance = 0u;
+						if (bRequiredCustomDepth)
+						{
+							const auto materialBindings = batchTemplate.GetMaterialBindings();
+							if (materialBindings && materialBindings->GetShaderBindings().ContainsKey("material"))
+							{
+								const auto shaderBinding = materialBindings->GetShaderBindings()["material"];
+								materialInstance = shaderBinding.IsValid() ?
+									shaderBinding->GetStorageInstanceIndex() : 0u;
+							}
+						}
+						else if (bMaskedQueue && meshIndex < group.m_baseColorSamplers.Num())
+						{
+							materialInstance = group.m_baseColorSamplers[meshIndex];
+						}
+
+						float effectiveAlphaCutoff = 0.0f;
+						if (bMaskedQueue)
+						{
+							const float baseColorAlpha = meshIndex < group.m_baseColorFactors.Num() ?
+								group.m_baseColorFactors[meshIndex].a : 1.0f;
+							const float alphaCutoff = meshIndex < group.m_alphaCutoffs.Num() ?
+								group.m_alphaCutoffs[meshIndex] : 0.5f;
+							effectiveAlphaCutoff = baseColorAlpha > 0.000001f ?
+								alphaCutoff / baseColorAlpha : 2.0f;
+						}
+
+						if (bRequiredCustomDepth || bMaskedQueue)
+						{
+							uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
+#if defined(__APPLE__)
+							const auto& requestedTextures =
+								meshIndex < group.m_materialTextureSamplers.Num() ?
+								group.m_materialTextureSamplers[meshIndex] :
+								Framegraph::Details::GetDefaultRequestedTextures();
+							batchTemplate.m_textureBindings = Framegraph::Details::GetTextureBindingSet(
+								m_textureBindingCache,
+								requestedTextures,
+								sceneViewSnapshot.m_frame,
+								supportedMeshesPerBatch);
+#else
+							batchTemplate.m_textureBindings = App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
+#endif
+							batchTemplate.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
+							if (!batchTemplate.m_textureBindings)
+							{
+								if (bRequiredCustomDepth)
+								{
+									bCustomPayloadComplete[payloadIndex] = false;
+								}
+								else
+								{
+									bPacketPayloadComplete[payloadIndex] = false;
+								}
+								continue;
+							}
+						}
+
+						for (size_t instanceIndex = 0u;
+							instanceIndex < group.m_instanceTransforms.Num(); ++instanceIndex)
+						{
+							if (!proxy.IsInstancedMeshWithinDistance(
+								group,
+								instanceIndex,
+								meshIndex,
+								glm::vec3(sceneViewSnapshot.m_cameraTransform.m_position),
+								source->m_lodPolicy.m_maxCameraDistance))
+							{
+								continue;
+							}
+							const auto mesh = proxy.ResolveInstancedMesh(
+								group,
+								instanceIndex,
+								meshIndex,
+								sceneViewSnapshot.m_camera->GetViewMatrix(),
+								sceneViewSnapshot.m_camera->GetProjectionMatrix());
+							if (!mesh)
+							{
+								if (bRequiredCustomDepth)
+								{
+									bCustomPayloadComplete[payloadIndex] = false;
+								}
+								else
+								{
+									bPacketPayloadComplete[payloadIndex] = false;
+								}
+								continue;
+							}
+							const uint64_t stableKey = BuildPackedDrawStableKey(
+								proxy.m_handle,
+								source->m_staticMeshEcs,
+								static_cast<uint32_t>(groupIndex + 1u),
+								static_cast<uint32_t>(meshIndex),
+								static_cast<uint32_t>(instanceIndex));
+							RHIBatch batch = batchTemplate;
+							batch.m_mesh = mesh;
+							if (bArenaView)
+							{
+								const bool bAdded = bRequiredCustomDepth ?
+								m_customPacket.AddArenaView(
+									std::move(batch),
+									mesh,
+									BuildPackedDrawRangeKey(
+										proxy.m_handle,
+										source->m_staticMeshEcs,
+										proxy.m_resource),
+									stableKey,
+									payloadMobility) :
+								m_packet.AddArenaView(
+									std::move(batch),
+									mesh,
+									BuildPackedDrawRangeKey(
+										proxy.m_handle,
+										source->m_staticMeshEcs,
+										proxy.m_resource),
+									stableKey,
+										payloadMobility);
+								if (!bAdded)
+								{
+									if (bRequiredCustomDepth)
+									{
+										bCustomPayloadComplete[payloadIndex] = false;
+									}
+									else
+									{
+										bPacketPayloadComplete[payloadIndex] = false;
+									}
+								}
+								continue;
+							}
+
+							DepthPrepassNode::PerInstanceData data;
+							data.model = proxy.ResolveInstancedMeshWorldMatrix(
+								group,
+								instanceIndex,
+								meshIndex);
+							data.skeletonOffset = bSkinned ? proxy.GetSkeletonOffset() :
+								(std::numeric_limits<uint32_t>::max)();
+							data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+							data.materialInstance = materialInstance;
+							if (bMaskedQueue)
+							{
+								data.padding = glm::floatBitsToUint(effectiveAlphaCutoff);
+							}
+
+							if (bRequiredCustomDepth)
+							{
+								DepthPrepassNode::CustomPerInstanceData customData;
+								customData.model = data.model;
+								customData.sphereBounds = data.sphereBounds;
+								customData.materialInstance = data.materialInstance;
+								customData.skeletonOffset = data.skeletonOffset;
+								customData.padding = data.padding;
+								customData.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+								m_customPacket.Add(
+									std::move(batch),
+									mesh,
+									customData,
+									stableKey,
+									payloadMobility);
+							}
+							else
+							{
+								m_packet.Add(
+									std::move(batch),
+									mesh,
+									data,
+									stableKey,
+									payloadMobility);
+							}
+						}
+					}
 				}
 			}
-
+			m_packet.Finalize(false);
+			m_customPacket.Finalize(false);
+			for (const EMobilityType mobility :
+				{ EMobilityType::Static, EMobilityType::Stationary })
+			{
+				const size_t index =
+					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+				if (usesPagedArena(index))
+				{
+					continue;
+				}
+				if (bVirtualizeInstancePayloads &&
+					bBuildPacketPayload[index] && bPacketPayloadComplete[index])
+				{
+					m_packetPayloadCache.Publish(
+						buildPayloadCacheSlot(mobility),
+						payloadRevisions[index],
+						m_packet.SharePayload(mobility),
+						sceneViewSnapshot.m_frame);
+				}
+				if (bVirtualizeInstancePayloads &&
+					bBuildCustomPayload[index] && bCustomPayloadComplete[index])
+				{
+					m_customPacketPayloadCache.Publish(
+						buildPayloadCacheSlot(mobility),
+						payloadRevisions[index],
+						m_customPacket.SharePayload(mobility),
+						sceneViewSnapshot.m_frame);
+				}
+			}
 			syncSharedResources.Unlock();
 		}, EThreadType::RHI);
 
@@ -216,193 +1142,233 @@ void DepthPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 {
 	SAILOR_PROFILE_FUNCTION();
 	m_drawCallStats = {};
+	if (!sceneView.m_submissionContext)
+	{
+		return;
+	}
+
+	auto resources = sceneView.m_submissionContext->GetOrAddFrameGraphResources<SubmissionResources>(
+		this,
+		sceneView.m_cameraIndex,
+		0u);
 	m_syncSharedResources.Lock();
-
-	const std::string QueueTag = GetString("Tag");
-
-	std::string temp;
-	TryGetString("ClearDepth", temp);
-	const bool bShouldClearDepth = temp == "true";
-
-	temp.clear();
-	TryGetString("GPUCulling", temp);
-	const bool bGpuCullingEnabled = temp == "true";
-
-	auto scheduler = App::GetSubmodule<Tasks::Scheduler>();
-	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
-	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
-
-	auto depthAttachment = GetRHIResource("depthStencil").StaticCast<RHI::RHITexture>();
-	if (!depthAttachment)
-	{
-		depthAttachment = frameGraph->GetRenderTarget("DepthBuffer");
-	}
-
-	if (bGpuCullingEnabled)
-	{
-		if (!m_pComputeMeshCullingShader)
-		{
-			if (auto shaderInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr("Shaders/ComputeMeshCulling.shader"))
-			{
-				// The depth prepass produces the current frame's occlusion source.
-				// Culling its contributors against the previous frame can create holes
-				// in depth after camera or LOD changes. Keep GPU frustum culling here;
-				// the main scene pass can occlusion-cull against the completed Hi-Z.
-				App::GetSubmodule<ShaderCompiler>()->LoadShader(
-					shaderInfo->GetFileId(), m_pComputeMeshCullingShader);
-			}
-		}
-
-		if (!m_computeMeshCullingBindings.IsValid())
-		{
-			auto depthHighZ = GetResolvedAttachment("depthHighZ").StaticCast<RHI::RHITexture>();
-			m_computeMeshCullingBindings = driver->CreateShaderBindings();
-			driver->AddSamplerToShaderBindings(m_computeMeshCullingBindings, "depthHighZ", depthHighZ, 0);
-		}
-	}
-
-	if (m_numMeshes == 0 || (bGpuCullingEnabled && !m_pComputeMeshCullingShader->IsReady()))
+	if (resources->m_packet.GetNumInstances() == 0u && resources->m_customPacket.GetNumInstances() == 0u)
 	{
 		m_syncSharedResources.Unlock();
 		return;
 	}
 
-	if (!m_perInstanceData || m_sizePerInstanceData < sizeof(DepthPrepassNode::PerInstanceData) * m_numMeshes)
+	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
+	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
+	auto depthAttachment = GetRHIResource("depthStencil").StaticCast<RHI::RHITexture>();
+	if (!depthAttachment)
 	{
-		SAILOR_PROFILE_SCOPE("Create storage for matrices");
-
-		m_perInstanceData = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
-		Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_perInstanceData, "data", sizeof(DepthPrepassNode::PerInstanceData), m_numMeshes, 0);
-		m_sizePerInstanceData = sizeof(DepthPrepassNode::PerInstanceData) * m_numMeshes;
+		depthAttachment = frameGraph->GetRenderTarget("DepthBuffer");
+	}
+	if (!depthAttachment)
+	{
+		m_syncSharedResources.Unlock();
+		return;
 	}
 
-	RHI::RHIShaderBindingPtr storageBinding = m_perInstanceData->GetOrAddShaderBinding("data");
-
-	TVector<DepthPrepassNode::PerInstanceData> gpuMatricesData;
-	gpuMatricesData.AddDefault(m_numMeshes);
-	auto vecBatches = m_batches.ToVector();
-	TVector<uint32_t> storageIndex(vecBatches.Num());
-
+	std::string gpuCullingSetting;
+	TryGetString("GPUCulling", gpuCullingSetting);
+	const uint32_t compactCount = resources->m_packet.GetNumStorageInstances();
+	const uint32_t compactIndexCount = resources->m_packet.GetNumDrawInstances();
+	const bool bGpuCullingRequested =
+		compactCount > 0u && gpuCullingSetting == "true";
+	const size_t compactIndexCapacity =
+		static_cast<size_t>(compactIndexCount) * (bGpuCullingRequested ? 2u : 1u);
+	if (compactCount > 0u && compactIndexCount > 0u &&
+		(!resources->m_perInstanceData ||
+			resources->m_sizePerInstanceData < sizeof(PerInstanceData) * compactCount ||
+			resources->m_sizeInstanceIndices < sizeof(uint32_t) * compactIndexCapacity))
 	{
-		SAILOR_PROFILE_SCOPE("Calculate SSBO offsets");
-		size_t ssboIndex = 0;
-		for (uint32_t j = 0; j < vecBatches.Num(); j++)
+		resources->m_perInstanceData = driver->CreateShaderBindings();
+		driver->AddSsboToShaderBindings(resources->m_perInstanceData, "data", sizeof(PerInstanceData), compactCount, 0u);
+		driver->AddSsboToShaderBindings(resources->m_perInstanceData, "indices", sizeof(uint32_t), compactIndexCapacity, 1u);
+		resources->m_sizePerInstanceData = sizeof(PerInstanceData) * compactCount;
+		resources->m_sizeInstanceIndices = sizeof(uint32_t) * compactIndexCapacity;
+	}
+
+	const uint32_t customCount = resources->m_customPacket.GetNumStorageInstances();
+	const uint32_t customIndexCount = resources->m_customPacket.GetNumDrawInstances();
+	if (customCount > 0u && customIndexCount > 0u &&
+		(!resources->m_customPerInstanceData ||
+			resources->m_sizeCustomPerInstanceData < sizeof(CustomPerInstanceData) * customCount ||
+			resources->m_sizeCustomInstanceIndices < sizeof(uint32_t) * customIndexCount))
+	{
+		resources->m_customPerInstanceData = driver->CreateShaderBindings();
+		driver->AddSsboToShaderBindings(resources->m_customPerInstanceData, "data", sizeof(CustomPerInstanceData), customCount, 0u);
+		driver->AddSsboToShaderBindings(resources->m_customPerInstanceData, "indices", sizeof(uint32_t), customIndexCount, 1u);
+		resources->m_sizeCustomPerInstanceData = sizeof(CustomPerInstanceData) * customCount;
+		resources->m_sizeCustomInstanceIndices = sizeof(uint32_t) * customIndexCount;
+	}
+
+	if (resources->m_indirectBuffers.IsEmpty())
+	{
+		resources->m_indirectBuffers.Resize(1u);
+	}
+	if (resources->m_cullingIndirectBufferBinding.IsEmpty())
+	{
+		resources->m_cullingIndirectBufferBinding.Resize(1u);
+		resources->m_cullingIndirectBufferBinding[0] = driver->CreateShaderBindings();
+	}
+
+	bool bGpuCullingEnabled = bGpuCullingRequested;
+	if (bGpuCullingEnabled && !m_pComputeMeshCullingShader)
+	{
+		if (auto shaderInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr("Shaders/ComputeMeshCulling.shader"))
 		{
-			bool bIsInited = false;
-			for (const auto& instancedDrawCall : m_drawCalls[vecBatches[j]])
-			{
-				auto& matrices = *instancedDrawCall.Second();
-
-				memcpy(&gpuMatricesData[ssboIndex], matrices.GetData(), sizeof(DepthPrepassNode::PerInstanceData) * matrices.Num());
-
-				if (!bIsInited)
-				{
-					storageIndex[j] = storageBinding->GetStorageInstanceIndex() + (uint32_t)ssboIndex;
-					bIsInited = true;
-				}
-				ssboIndex += matrices.Num();
-			}
+			App::GetSubmodule<ShaderCompiler>()->LoadShader(
+				shaderInfo->GetFileId(),
+				m_pComputeMeshCullingShader,
+				{ "DEPTH_INSTANCE_LAYOUT" });
 		}
 	}
 
-	if (gpuMatricesData.Num() > 0)
+	RHIShaderPtr cullingShader;
+	if (bGpuCullingEnabled && m_pComputeMeshCullingShader && m_pComputeMeshCullingShader->IsReady())
 	{
-		SAILOR_PROFILE_SCOPE("Fill transfer command list with matrices data");
-		commands->UpdateShaderBinding(transferCommandList, storageBinding,
-			gpuMatricesData.GetData(),
-			sizeof(DepthPrepassNode::PerInstanceData) * gpuMatricesData.Num(),
-			0);
-	}
-
-	const size_t numThreads = scheduler->GetNumRHIThreads() + 1;
-
-	if (m_indirectBuffers.Num() < numThreads)
-	{
-		m_indirectBuffers.Resize(numThreads);
-		m_cullingIndirectBufferBinding.Resize(numThreads);
-
-		for (uint32_t i = 0; i < numThreads; i++)
+		auto depthHighZ = GetResolvedAttachment("depthHighZ").StaticCast<RHI::RHITexture>();
+		if (depthHighZ &&
+			(!resources->m_computeMeshCullingBindings ||
+				resources->m_cullingDepthHighZ != depthHighZ))
 		{
-			m_cullingIndirectBufferBinding[i] = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
+			resources->m_computeMeshCullingBindings = driver->CreateShaderBindings();
+			driver->AddSamplerToShaderBindings(
+				resources->m_computeMeshCullingBindings,
+				"depthHighZ",
+				depthHighZ,
+				0u);
+			resources->m_cullingDepthHighZ = depthHighZ;
 		}
+		if (!depthHighZ)
+		{
+			bGpuCullingEnabled = false;
+		}
+#ifdef _DEBUG
+		cullingShader = bGpuCullingEnabled ?
+			m_pComputeMeshCullingShader->GetDebugComputeShaderRHI() : RHIShaderPtr{};
+#else
+		cullingShader = bGpuCullingEnabled ?
+			m_pComputeMeshCullingShader->GetComputeShaderRHI() : RHIShaderPtr{};
+#endif
 	}
 
-	auto shaderBindingsByMaterial = [&](const RHIBatch& batch)
+	const auto viewport = glm::ivec4(
+		0,
+		depthAttachment->GetExtent().y,
+		depthAttachment->GetExtent().x,
+		-depthAttachment->GetExtent().y);
+	const auto scissors = glm::uvec4(0, 0, depthAttachment->GetExtent().x, depthAttachment->GetExtent().y);
+	const auto collectCompactBindings = [&](
+		const RHIBatch& batch,
+		TVector<RHIShaderBindingSetPtr>& sets)
 		{
-			auto material = batch.m_material;
-			TVector<RHIShaderBindingSetPtr> sets({ sceneView.m_frameBindings, m_perInstanceData });
-
-			if (material->GetRenderState().IsRequiredCustomDepthShader())
-			{
-				sets = TVector<RHIShaderBindingSetPtr>({ sceneView.m_frameBindings, sceneView.m_rhiLightsData, m_perInstanceData, material->GetBindings(), batch.m_textureBindings });
-			}
-			else if (batch.m_textureBindings)
+			sets.Add(sceneView.m_frameBindings);
+			sets.Add(resources->m_perInstanceData);
+			if (batch.m_textureBindings)
 			{
 				sets.Add(batch.m_textureBindings);
 			}
-
 			const bool bSkinned =
-				batch.m_mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
-				batch.m_mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
+				batch.m_mesh->m_vertexDescription->HasAttribute(RHIVertexDescription::DefaultBoneIdsBinding) &&
+				batch.m_mesh->m_vertexDescription->HasAttribute(RHIVertexDescription::DefaultBoneWeightsBinding);
 			if (bSkinned && sceneView.m_boneMatrices)
 			{
 				sets.Add(sceneView.m_boneMatrices);
 			}
-			return sets;
+		};
+	const auto collectCustomBindings = [&](
+		const RHIBatch& batch,
+		TVector<RHIShaderBindingSetPtr>& sets)
+		{
+			sets.Add(sceneView.m_frameBindings);
+			sets.Add(sceneView.m_rhiLightsData);
+			sets.Add(resources->m_customPerInstanceData);
+			sets.Add(batch.GetMaterialBindings());
+			sets.Add(batch.m_textureBindings);
+			const bool bSkinned =
+				batch.m_mesh->m_vertexDescription->HasAttribute(RHIVertexDescription::DefaultBoneIdsBinding) &&
+				batch.m_mesh->m_vertexDescription->HasAttribute(RHIVertexDescription::DefaultBoneWeightsBinding);
+			if (bSkinned && sceneView.m_boneMatrices)
+			{
+				sets.Add(sceneView.m_boneMatrices);
+			}
 		};
 
-	commands->BeginDebugRegion(commandList, std::string(GetName()) + " QueueTag:" + QueueTag, DebugContext::Color_CmdGraphics);
-
-	const auto depthAttachmentLayout = RHI::IsDepthStencilFormat(depthAttachment->GetFormat()) ? EImageLayout::DepthStencilAttachmentOptimal : EImageLayout::DepthAttachmentOptimal;
-	commands->ImageMemoryBarrier(commandList, depthAttachment, depthAttachmentLayout);
-
-	commands->BeginRenderPass(commandList,
-		TVector<RHI::RHITexturePtr>{},
+	std::string clearDepth;
+	TryGetString("ClearDepth", clearDepth);
+	commands->BeginDebugRegion(
+		commandList,
+		std::string(GetName()) + " QueueTag:" + GetString("Tag") + " Packed",
+		DebugContext::Color_CmdGraphics);
+	const auto depthLayout = RHI::IsDepthStencilFormat(depthAttachment->GetFormat()) ?
+		EImageLayout::DepthStencilAttachmentOptimal : EImageLayout::DepthAttachmentOptimal;
+	commands->ImageMemoryBarrier(commandList, depthAttachment, depthLayout);
+	static const TVector<RHI::RHITexturePtr> NoColorAttachments;
+	commands->BeginRenderPass(
+		commandList,
+		NoColorAttachments,
 		depthAttachment,
 		glm::vec4(0, 0, depthAttachment->GetExtent().x, depthAttachment->GetExtent().y),
 		glm::ivec2(0, 0),
-		bShouldClearDepth,
+		clearDepth == "true",
 		glm::vec4(0.0f),
 		0.0f,
 		true,
 		true);
 
-	if (bGpuCullingEnabled)
+	if (compactCount > 0u)
 	{
-		auto cullingComputeShader = m_pComputeMeshCullingShader->GetComputeShaderRHI();
-
-#ifdef _DEBUG
-		cullingComputeShader = m_pComputeMeshCullingShader->GetDebugComputeShaderRHI();
-#endif
-		m_drawCallStats = RHIRecordDrawCallGPUCulling(0,
-			(uint32_t)vecBatches.Num(), vecBatches,
-			commandList, transferCommandList,
-			shaderBindingsByMaterial,
-			m_drawCalls,
-			storageIndex,
-			m_indirectBuffers[0],
-			glm::ivec4(0, depthAttachment->GetExtent().y, depthAttachment->GetExtent().x, -depthAttachment->GetExtent().y),
-			glm::uvec4(0, 0, depthAttachment->GetExtent().x, depthAttachment->GetExtent().y),
-			glm::vec2(0.0f, 1.0f), cullingComputeShader, m_cullingIndirectBufferBinding[0],
-			{ m_computeMeshCullingBindings , m_perInstanceData, m_cullingIndirectBufferBinding[0], sceneView.m_frameBindings });
-	}
-	else
-	{
-		m_drawCallStats = RHIRecordDrawCall(0, (uint32_t)vecBatches.Num(), vecBatches, commandList, transferCommandList, shaderBindingsByMaterial, m_drawCalls, storageIndex, m_indirectBuffers[0],
-			glm::ivec4(0, depthAttachment->GetExtent().y, depthAttachment->GetExtent().x, -depthAttachment->GetExtent().y),
-			glm::uvec4(0, 0, depthAttachment->GetExtent().x, depthAttachment->GetExtent().y),
+		auto& cullingBindings = resources->m_cullingDispatchBindings;
+		cullingBindings.Clear(false);
+		if (cullingShader)
+		{
+			cullingBindings = {
+				resources->m_computeMeshCullingBindings,
+				resources->m_perInstanceData,
+				resources->m_cullingIndirectBufferBinding[0],
+				sceneView.m_frameBindings };
+		}
+		m_drawCallStats += RHIRecordPackedDrawPacket(
+			resources->m_packet,
+			commandList,
+			transferCommandList,
+			collectCompactBindings,
+			resources->m_perInstanceData,
+			resources->m_indirectBuffers[0],
+			viewport,
+			scissors,
 			glm::vec2(0.0f, 1.0f),
-			&m_cullingIndirectBufferBinding[0]);
+			cullingShader,
+			&resources->m_cullingIndirectBufferBinding[0],
+			cullingBindings);
 	}
+	if (customCount > 0u)
+	{
+		m_drawCallStats += RHIRecordPackedDrawPacket(
+			resources->m_customPacket,
+			commandList,
+			transferCommandList,
+			collectCustomBindings,
+			resources->m_customPerInstanceData,
+			resources->m_customIndirectBuffer,
+			viewport,
+			scissors);
+	}
+
 	commands->EndRenderPass(commandList);
-
 	commands->EndDebugRegion(commandList);
-
 	m_syncSharedResources.Unlock();
 }
 
 void DepthPrepassNode::Clear()
 {
-	m_perInstanceData.Clear();
 	m_textureBindingCache.Clear();
+	m_packetPayloadCache.Clear();
+	m_customPacketPayloadCache.Clear();
+	m_pagedArenaCache.Clear();
+	m_customPagedArenaCache.Clear();
 }

--- a/Runtime/FrameGraph/DepthPrepassNode.h
+++ b/Runtime/FrameGraph/DepthPrepassNode.h
@@ -3,6 +3,7 @@
 #include "Memory/RefPtr.hpp"
 #include "Engine/Object.h"
 #include "RHI/Types.h"
+#include "RHI/RenderSubmission.h"
 #include "RHI/Batch.hpp"
 #include "FrameGraph/BaseFrameGraphNode.h"
 #include "FrameGraph/FrameGraphNode.h"
@@ -21,17 +22,44 @@ namespace Sailor
 			vec4 sphereBounds;
 			uint32_t materialInstance = 0;
 			uint32_t skeletonOffset = 0;
-			uint32_t bIsCulled = 0;
 			uint32_t padding = 0;
+			uint32_t reserved = 0;
+
+			bool operator==(const PerInstanceData& rhs) const
+			{
+				return model == rhs.model &&
+					sphereBounds == rhs.sphereBounds &&
+					materialInstance == rhs.materialInstance &&
+					skeletonOffset == rhs.skeletonOffset &&
+					padding == rhs.padding &&
+					reserved == rhs.reserved;
+			}
+
+		};
+
+		// Custom depth shaders reuse the main-pass material layout. Keep this rare
+		// stream separate so ordinary opaque/masked depth records stay compact.
+		struct CustomPerInstanceData
+		{
+			glm::mat4 model;
+			vec4 sphereBounds;
+			uint32_t materialInstance = 0u;
+			uint32_t skeletonOffset = 0u;
+			uint32_t bIsCulled = 0u;
+			uint32_t padding = 0u;
 			vec4 bakedVolumeScale = vec4(1.0f);
 
-			bool operator==(const PerInstanceData& rhs) const { return this->materialInstance == rhs.materialInstance && this->model == rhs.model; }
-
-			size_t GetHash() const
+			bool operator==(const CustomPerInstanceData& rhs) const
 			{
-				hash<glm::mat4> p;
-				return p(model);
+				return model == rhs.model &&
+					sphereBounds == rhs.sphereBounds &&
+					materialInstance == rhs.materialInstance &&
+					skeletonOffset == rhs.skeletonOffset &&
+					bIsCulled == rhs.bIsCulled &&
+					padding == rhs.padding &&
+					bakedVolumeScale == rhs.bakedVolumeScale;
 			}
+
 		};
 
 		SAILOR_API static const char* GetName() { return m_name; }
@@ -42,6 +70,52 @@ namespace Sailor
 		SAILOR_API RHI::ESortingOrder GetSortingOrder() const;
 
 	protected:
+		class SubmissionResources final : public RHI::RHIFrameGraphSubmissionResource
+		{
+		public:
+			void ResetForSubmission() override
+			{
+				m_cullingDispatchBindings.Clear(false);
+				m_arenaRangeInstances.Clear(false);
+				m_arenaRangeStableKeys.Clear(false);
+				m_arenaRangeMaterialVersionRuns.Clear(false);
+				m_customArenaRangeInstances.Clear(false);
+				m_customArenaRangeStableKeys.Clear(false);
+				m_customArenaRangeMaterialVersionRuns.Clear(false);
+			}
+
+			void InvalidateSubmission() override
+			{
+				ResetForSubmission();
+				m_packet.InvalidateUploadedState();
+				m_customPacket.InvalidateUploadedState();
+			}
+
+			RHI::TPackedDrawPacket<PerInstanceData> m_packet;
+			RHI::RHIShaderBindingSetPtr m_perInstanceData{};
+			size_t m_sizePerInstanceData = 0u;
+			size_t m_sizeInstanceIndices = 0u;
+			TVector<RHI::RHIBufferPtr> m_indirectBuffers;
+			TVector<RHI::RHIShaderBindingSetPtr> m_cullingIndirectBufferBinding;
+			RHI::RHIShaderBindingSetPtr m_computeMeshCullingBindings{};
+			RHI::RHITexturePtr m_cullingDepthHighZ{};
+			RHI::TPackedDrawPacket<CustomPerInstanceData> m_customPacket;
+			RHI::RHIShaderBindingSetPtr m_customPerInstanceData{};
+			size_t m_sizeCustomPerInstanceData = 0u;
+			size_t m_sizeCustomInstanceIndices = 0u;
+			RHI::RHIBufferPtr m_customIndirectBuffer{};
+			TVector<RHI::RHIShaderBindingSetPtr> m_cullingDispatchBindings{};
+			TVector<PerInstanceData> m_arenaRangeInstances{};
+			TVector<uint64_t> m_arenaRangeStableKeys{};
+			TVector<RHI::PackedDrawArenaMaterialRun> m_arenaRangeMaterialVersionRuns{};
+			TVector<CustomPerInstanceData> m_customArenaRangeInstances{};
+			TVector<uint64_t> m_customArenaRangeStableKeys{};
+			TVector<RHI::PackedDrawArenaMaterialRun> m_customArenaRangeMaterialVersionRuns{};
+			std::array<Framegraph::TextureDependencyCollector,
+				RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				m_requestedPacketTextures{};
+		};
+
 		struct DepthMaterialKey
 		{
 			RHI::VertexAttributeBits m_vertexAttributes = 0u;
@@ -61,30 +135,24 @@ namespace Sailor
 			}
 		};
 
-		uint32_t m_numMeshes = 0;
 		SpinLock m_syncSharedResources;
-		RHI::TDrawCalls<PerInstanceData> m_drawCalls;
-		TSet<RHI::RHIBatch> m_batches;
 
 		TMap<DepthMaterialKey, RHI::RHIMaterialPtr> m_depthOnlyMaterials;
 		TMap<DepthMaterialKey, RHI::RHIMaterialPtr> m_skinnedDepthOnlyMaterials;
 		TMap<DepthMaterialKey, RHI::RHIMaterialPtr> m_maskedDepthOnlyMaterials;
 		TMap<DepthMaterialKey, RHI::RHIMaterialPtr> m_skinnedMaskedDepthOnlyMaterials;
-		RHI::RHIShaderBindingSetPtr m_perInstanceData;
-		size_t m_sizePerInstanceData = 0;
-
 		RHI::RHIMaterialPtr GetOrAddDepthMaterial(
 			RHI::RHIVertexDescriptionPtr vertex,
 			bool bSkinned,
 			bool bMasked,
 			RHI::ECullMode cullMode);
-		TVector<RHI::RHIBufferPtr> m_indirectBuffers;
-
 		// Culling
-		TVector<RHI::RHIShaderBindingSetPtr> m_cullingIndirectBufferBinding;
 		ShaderSetPtr m_pComputeMeshCullingShader{};
-		RHI::RHIShaderBindingSetPtr m_computeMeshCullingBindings{};
 		Framegraph::TextureBindingCache m_textureBindingCache;
+		RHI::TPackedDrawPacketPayloadCache<PerInstanceData> m_packetPayloadCache;
+		RHI::TPackedDrawPacketPayloadCache<CustomPerInstanceData> m_customPacketPayloadCache;
+		RHI::TPackedDrawPagedArenaCache<PerInstanceData> m_pagedArenaCache;
+		RHI::TPackedDrawPagedArenaCache<CustomPerInstanceData> m_customPagedArenaCache;
 
 		SAILOR_SHARED_API static const char* m_name;
 	};

--- a/Runtime/FrameGraph/LightCullingNode.cpp
+++ b/Runtime/FrameGraph/LightCullingNode.cpp
@@ -21,7 +21,7 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	if (!sceneView.m_rhiLightsData)
+	if (!sceneView.m_rhiLightsData || !sceneView.m_rhiLightCullingData)
 	{
 		// No point to cull lights if we have no lights in the scene
 		return;
@@ -59,35 +59,10 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 		pushConstants.m_viewportSize = linearDepthAttachment->GetExtent();
 		pushConstants.m_numTiles.x = (linearDepthAttachment->GetExtent().x - 1) / (int32_t)TileSize + 1;
 		pushConstants.m_numTiles.y = (linearDepthAttachment->GetExtent().y - 1) / (int32_t)TileSize + 1;
-		const bool bBindingsOutdated = !m_culledLights ||
-			m_boundLightsData != sceneView.m_rhiLightsData ||
-			m_boundDepthAttachment != linearDepthAttachment ||
-			m_bindingsViewportSize != pushConstants.m_viewportSize;
-		if (bBindingsOutdated)
-		{
-			const size_t numTiles = pushConstants.m_numTiles.x * pushConstants.m_numTiles.y;
-
-			m_culledLights = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
-			RHI::RHIShaderBindingPtr culledLightsSSBO = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_culledLights, "culledLights", sizeof(uint32_t) * numTiles * LightsPerTile, 1, 0, true);
-			RHI::RHIShaderBindingPtr lightsGridSSBO = Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_culledLights, "lightsGrid", sizeof(uint32_t) * numTiles * 2, 1, 1, true);
-			Sailor::RHI::Renderer::GetDriver()->AddSamplerToShaderBindings(m_culledLights, "linearDepth", linearDepthAttachment, 2);
-
-			auto shaderBindingSet = sceneView.m_rhiLightsData;
-			Sailor::RHI::Renderer::GetDriver()->AddShaderBinding(shaderBindingSet, culledLightsSSBO, "culledLights", 1);
-			Sailor::RHI::Renderer::GetDriver()->AddShaderBinding(shaderBindingSet, lightsGridSSBO, "lightsGrid", 2);
-
-			m_boundLightsData = sceneView.m_rhiLightsData;
-			m_boundDepthAttachment = linearDepthAttachment;
-			m_bindingsViewportSize = pushConstants.m_viewportSize;
-		}
-
-		commands->ImageMemoryBarrier(commandList, linearDepthAttachment, RHI::EImageLayout::ShaderReadOnlyOptimal);
-		commands->MemoryBarrier(commandList,
-			static_cast<EAccessFlags>(EAccessBit::ColorAttachmentWrite_Bit),
-			static_cast<EAccessFlags>(EAccessBit::ShaderRead_Bit));
+		commands->ImageMemoryBarrierForComputeSampling(commandList, linearDepthAttachment);
 		commands->Dispatch(commandList, computeShader,
 			pushConstants.m_numTiles.x, pushConstants.m_numTiles.y, 1,
-			{ sceneView.m_rhiLightsData, m_culledLights, sceneView.m_frameBindings },
+			{ sceneView.m_rhiLightsData, sceneView.m_rhiLightCullingData, sceneView.m_frameBindings },
 			&pushConstants, sizeof(PushConstants));
 
 		commands->MemoryBarrier(commandList,
@@ -101,8 +76,4 @@ void LightCullingNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListP
 void LightCullingNode::Clear()
 {
 	m_pComputeShader.Clear();
-	m_culledLights.Clear();
-	m_boundLightsData.Clear();
-	m_boundDepthAttachment.Clear();
-	m_bindingsViewportSize = {};
 }

--- a/Runtime/FrameGraph/LightCullingNode.h
+++ b/Runtime/FrameGraph/LightCullingNode.h
@@ -33,10 +33,6 @@ namespace Sailor::Framegraph
 		static const char* m_name;
 
 		ShaderSetPtr m_pComputeShader{};
-		RHI::RHIShaderBindingSetPtr m_culledLights;
-		RHI::RHIShaderBindingSetPtr m_boundLightsData;
-		RHI::RHITexturePtr m_boundDepthAttachment;
-		glm::ivec2 m_bindingsViewportSize{};
 	};
 
 	template class TFrameGraphNode<LightCullingNode>;

--- a/Runtime/FrameGraph/RHIFrameGraph.cpp
+++ b/Runtime/FrameGraph/RHIFrameGraph.cpp
@@ -2,17 +2,490 @@
 #include "RHI/SceneView.h"
 #include "RHI/Renderer.h"
 #include "RHI/GraphicsDriver.h"
+#include "RHI/Shader.h"
 #include "RHI/VertexDescription.h"
 #include "RHI/RenderTarget.h"
 #include "RHI/Cubemap.h"
 #include "RHI/CommandList.h"
+#include "FrameGraph/LightCullingNode.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "Tasks/Tasks.h"
 
 #include <atomic>
+#include <limits>
 
 using namespace Sailor;
 using namespace Sailor::RHI;
+
+namespace
+{
+	constexpr uint64_t InvalidContentHash = (std::numeric_limits<uint64_t>::max)();
+
+	class RHISubmissionProgress final
+	{
+	public:
+		void SetLastSuccessfulSemaphore(RHISemaphorePtr semaphore)
+		{
+			m_lock.Lock();
+			m_lastSuccessfulSemaphore = std::move(semaphore);
+			m_lock.Unlock();
+		}
+
+		RHISemaphorePtr GetLastSuccessfulSemaphore() const
+		{
+			m_lock.Lock();
+			auto result = m_lastSuccessfulSemaphore;
+			m_lock.Unlock();
+			return result;
+		}
+
+	private:
+		mutable SpinLock m_lock;
+		RHISemaphorePtr m_lastSuccessfulSemaphore{};
+	};
+
+	class RHIViewSubmissionResources final : public RHIFrameGraphSubmissionResource
+	{
+	public:
+		void ResetForSubmission() override {}
+		void InvalidateSubmission() override
+		{
+			m_shadowMatricesHash = InvalidContentHash;
+			m_shadowIndicesHash = InvalidContentHash;
+			m_shadowAtlasTilesHash = InvalidContentHash;
+		}
+
+		RHIShaderBindingSetPtr m_lightsBindings{};
+		RHIShaderBindingSetPtr m_lightsTemplate{};
+		RHIShaderBindingSetPtr m_sharedLightsStorage{};
+		RHIShaderBindingSetPtr m_frameBindings{};
+		RHIShaderBindingSetPtr m_lightCullingBindings{};
+		RHITexturePtr m_lightCullingDepth{};
+		glm::ivec2 m_lightCullingViewportSize{};
+		size_t m_shadowMatrixCapacity = 0u;
+		size_t m_shadowIndexCapacity = 0u;
+		size_t m_shadowAtlasTileCapacity = 0u;
+		uint64_t m_lightsTemplateRevision = 0ull;
+		size_t m_frameGraphSamplerHash = 0u;
+		uint64_t m_shadowMatricesHash = InvalidContentHash;
+		uint64_t m_shadowIndicesHash = InvalidContentHash;
+		uint64_t m_shadowAtlasTilesHash = InvalidContentHash;
+	};
+
+	class RHISharedViewSubmissionResources final : public RHIFrameGraphSubmissionResource
+	{
+	public:
+		void ResetForSubmission() override {}
+		void InvalidateSubmission() override
+		{
+			m_uploadedLightingRevision = InvalidContentHash;
+			m_uploadedAnimationRevision = InvalidContentHash;
+			m_lightsSource.Clear();
+			m_bonesSource.Clear();
+		}
+
+		RHIShaderBindingSetPtr m_lightsStorage{};
+		RHIShaderBindingSetPtr m_boneBindings{};
+		TSharedPtr<TVector<RHILightShaderData>> m_lightsSource{};
+		TSharedPtr<TVector<glm::mat4>> m_bonesSource{};
+		size_t m_lightCapacity = 0u;
+		size_t m_boneCapacity = 0u;
+		uint64_t m_uploadedLightingRevision = InvalidContentHash;
+		uint64_t m_uploadedAnimationRevision = InvalidContentHash;
+	};
+
+	size_t GrowSubmissionCapacity(size_t currentCapacity, size_t requiredCapacity)
+	{
+		size_t result = (std::max)(size_t{ 1u }, currentCapacity);
+		while (result < requiredCapacity)
+		{
+			const size_t next = result * 2u;
+			if (next <= result)
+			{
+				return requiredCapacity;
+			}
+			result = next;
+		}
+		return result;
+	}
+
+	template<typename T>
+	uint64_t HashSubmissionValues(const TVector<T>& values)
+	{
+		uint64_t result = 1469598103934665603ull;
+		const auto* bytes = reinterpret_cast<const uint8_t*>(values.GetData());
+		const size_t numBytes = values.Num() * sizeof(T);
+		for (size_t index = 0u; index < numBytes; ++index)
+		{
+			result ^= bytes[index];
+			result *= 1099511628211ull;
+		}
+		result ^= values.Num();
+		result *= 1099511628211ull;
+		return result;
+	}
+
+	void CloneTextureBindings(
+		const RHIShaderBindingSetPtr& source,
+		RHIShaderBindingSetPtr& destination)
+	{
+		if (!source || !destination)
+		{
+			return;
+		}
+
+		auto& driver = Renderer::GetDriver();
+		for (const auto& entry : source->GetShaderBindings())
+		{
+			const auto& binding = entry.m_second;
+			if (!binding || binding->GetTextureBindings().IsEmpty())
+			{
+				continue;
+			}
+
+			const auto& layout = binding->GetLayout();
+			if (layout.m_type != EShaderBindingType::CombinedImageSampler)
+			{
+				continue;
+			}
+
+			driver->AddSamplerToShaderBindings(
+				destination,
+				entry.m_first,
+				binding->GetTextureBindings(),
+				layout.m_binding,
+				layout.m_bVariableDescriptorCount,
+				layout.m_arrayCount);
+		}
+	}
+
+	void PrepareViewSubmissionResources(
+		RHIFrameGraph* owner,
+		RHICommandListPtr transferCommandList,
+		RHISceneViewSnapshot& snapshot,
+		bool bUploadSharedPayload)
+	{
+		if (!snapshot.m_submissionContext)
+		{
+			return;
+		}
+
+		auto resources = snapshot.m_submissionContext->GetOrAddFrameGraphResources<RHIViewSubmissionResources>(
+			owner,
+			snapshot.m_cameraIndex,
+			0u);
+		auto sharedResources = snapshot.m_submissionContext->GetOrAddFrameGraphResources<RHISharedViewSubmissionResources>(
+			owner,
+			(std::numeric_limits<uint32_t>::max)(),
+			1u);
+		auto& driver = Renderer::GetDriver();
+		auto commands = App::GetSubmodule<Renderer>()->GetDriverCommands();
+		if (!resources->m_frameBindings)
+		{
+			resources->m_frameBindings = driver->CreateShaderBindings();
+			driver->AddBufferToShaderBindings(
+				resources->m_frameBindings,
+				"frameData",
+				sizeof(UboFrameData),
+				0u,
+				EShaderBindingType::UniformBuffer);
+			driver->AddBufferToShaderBindings(
+				resources->m_frameBindings,
+				"previousFrameData",
+				sizeof(UboFrameData),
+				1u,
+				EShaderBindingType::UniformBuffer);
+		}
+		snapshot.m_frameBindings = resources->m_frameBindings;
+
+		auto linearDepthAttachment = owner->GetRenderTarget("LinearDepth");
+		const glm::ivec2 lightCullingViewportSize = linearDepthAttachment ?
+			linearDepthAttachment->GetExtent() : glm::ivec2{};
+		const bool bRecreateLightCulling = linearDepthAttachment &&
+			(!resources->m_lightCullingBindings ||
+				resources->m_lightCullingDepth != linearDepthAttachment ||
+				resources->m_lightCullingViewportSize != lightCullingViewportSize);
+		if (bRecreateLightCulling)
+		{
+			const uint32_t numTilesX =
+				(lightCullingViewportSize.x - 1) / LightCullingNode::TileSize + 1;
+			const uint32_t numTilesY =
+				(lightCullingViewportSize.y - 1) / LightCullingNode::TileSize + 1;
+			const size_t numTiles = static_cast<size_t>(numTilesX) * numTilesY;
+			resources->m_lightCullingBindings = driver->CreateShaderBindings();
+			driver->AddSsboToShaderBindings(
+				resources->m_lightCullingBindings,
+				"culledLights",
+				sizeof(uint32_t) * numTiles * LightCullingNode::LightsPerTile,
+				1u,
+				0u,
+				true);
+			driver->AddSsboToShaderBindings(
+				resources->m_lightCullingBindings,
+				"lightsGrid",
+				sizeof(uint32_t) * numTiles * 2u,
+				1u,
+				1u,
+				true);
+			driver->AddSamplerToShaderBindings(
+				resources->m_lightCullingBindings,
+				"linearDepth",
+				linearDepthAttachment,
+				2u);
+			resources->m_lightCullingBindings->RecalculateCompatibility();
+			resources->m_lightCullingDepth = linearDepthAttachment;
+			resources->m_lightCullingViewportSize = lightCullingViewportSize;
+		}
+		snapshot.m_rhiLightCullingData = resources->m_lightCullingBindings;
+
+		auto lightsTemplate = snapshot.m_rhiLightsData;
+		if (lightsTemplate == resources->m_lightsBindings && resources->m_lightsTemplate)
+		{
+			lightsTemplate = resources->m_lightsTemplate;
+		}
+		const uint64_t lightsTemplateRevision = lightsTemplate ?
+			lightsTemplate->GetDescriptorRevision() : 0ull;
+		const size_t numLights = snapshot.m_cpuLightsData ? snapshot.m_cpuLightsData->Num() : 0u;
+		const size_t numShadowMatrices = snapshot.m_shadowMatrices.Num();
+		const size_t numShadowIndices = snapshot.m_shadowIndices.Num();
+		const size_t numShadowAtlasTiles = snapshot.m_shadowAtlasTiles.Num();
+		const bool bRecreateLightStorage = !sharedResources->m_lightsStorage ||
+			sharedResources->m_lightCapacity < numLights;
+		if (bRecreateLightStorage)
+		{
+			sharedResources->m_lightCapacity = GrowSubmissionCapacity(
+				sharedResources->m_lightCapacity,
+				numLights);
+			sharedResources->m_lightsStorage = driver->CreateShaderBindings();
+			driver->AddSsboToShaderBindings(
+				sharedResources->m_lightsStorage,
+				"light",
+				sizeof(RHILightShaderData),
+				sharedResources->m_lightCapacity,
+				0u,
+				true);
+			sharedResources->m_lightsStorage->RecalculateCompatibility();
+			sharedResources->m_uploadedLightingRevision = InvalidContentHash;
+			sharedResources->m_lightsSource.Clear();
+		}
+		if (bUploadSharedPayload && snapshot.m_cpuLightsData &&
+			(sharedResources->m_lightsSource != snapshot.m_cpuLightsData ||
+				sharedResources->m_uploadedLightingRevision != snapshot.m_lightingRevision))
+		{
+			if (!snapshot.m_cpuLightsData->IsEmpty())
+			{
+				commands->UpdateShaderBinding(
+					transferCommandList,
+					sharedResources->m_lightsStorage->GetOrAddShaderBinding("light"),
+					snapshot.m_cpuLightsData->GetData(),
+					snapshot.m_cpuLightsData->Num() * sizeof(RHILightShaderData),
+					0u);
+			}
+			sharedResources->m_lightsSource = snapshot.m_cpuLightsData;
+			sharedResources->m_uploadedLightingRevision = snapshot.m_lightingRevision;
+		}
+
+		size_t frameGraphSamplerHash = 0u;
+		HashCombine(frameGraphSamplerHash, Sailor::GetHash(owner->GetSampler("g_irradianceCubemap")));
+		HashCombine(frameGraphSamplerHash, Sailor::GetHash(owner->GetSampler("g_brdfSampler")));
+		HashCombine(frameGraphSamplerHash, Sailor::GetHash(owner->GetSampler("g_envCubemap")));
+		HashCombine(frameGraphSamplerHash, Sailor::GetHash(owner->GetRenderTarget("g_AO")));
+		const bool bRecreateLights = !resources->m_lightsBindings ||
+			bRecreateLightCulling ||
+			resources->m_lightsTemplate != lightsTemplate ||
+			resources->m_sharedLightsStorage != sharedResources->m_lightsStorage ||
+			resources->m_lightsTemplateRevision != lightsTemplateRevision ||
+			resources->m_frameGraphSamplerHash != frameGraphSamplerHash ||
+			resources->m_shadowMatrixCapacity < numShadowMatrices ||
+			resources->m_shadowIndexCapacity < numShadowIndices ||
+			resources->m_shadowAtlasTileCapacity < numShadowAtlasTiles;
+
+		if (bRecreateLights)
+		{
+			resources->m_shadowMatrixCapacity = GrowSubmissionCapacity(resources->m_shadowMatrixCapacity, numShadowMatrices);
+			resources->m_shadowIndexCapacity = GrowSubmissionCapacity(resources->m_shadowIndexCapacity, numShadowIndices);
+			resources->m_shadowAtlasTileCapacity = GrowSubmissionCapacity(resources->m_shadowAtlasTileCapacity, numShadowAtlasTiles);
+			resources->m_lightsBindings = driver->CreateShaderBindings();
+			driver->AddShaderBinding(
+				resources->m_lightsBindings,
+				sharedResources->m_lightsStorage->GetOrAddShaderBinding("light"),
+				"light",
+				0u);
+			if (resources->m_lightCullingBindings)
+			{
+				driver->AddShaderBinding(
+					resources->m_lightsBindings,
+					resources->m_lightCullingBindings->GetOrAddShaderBinding("culledLights"),
+					"culledLights",
+					1u);
+				driver->AddShaderBinding(
+					resources->m_lightsBindings,
+					resources->m_lightCullingBindings->GetOrAddShaderBinding("lightsGrid"),
+					"lightsGrid",
+					2u);
+			}
+			driver->AddSsboToShaderBindings(
+				resources->m_lightsBindings,
+				"lightsMatrices",
+				sizeof(glm::mat4),
+				resources->m_shadowMatrixCapacity,
+				6u,
+				true);
+			driver->AddSsboToShaderBindings(
+				resources->m_lightsBindings,
+				"shadowIndices",
+				sizeof(uint32_t),
+				resources->m_shadowIndexCapacity,
+				7u,
+				true);
+			driver->AddSsboToShaderBindings(
+				resources->m_lightsBindings,
+				"shadowAtlasTiles",
+				sizeof(uint32_t),
+				resources->m_shadowAtlasTileCapacity,
+				11u,
+				true);
+			CloneTextureBindings(lightsTemplate, resources->m_lightsBindings);
+			if (auto texture = owner->GetSampler("g_irradianceCubemap"))
+			{
+				driver->AddSamplerToShaderBindings(
+					resources->m_lightsBindings,
+					"g_irradianceCubemap",
+					texture,
+					3u);
+			}
+			if (auto texture = owner->GetSampler("g_brdfSampler"))
+			{
+				driver->AddSamplerToShaderBindings(
+					resources->m_lightsBindings,
+					"g_brdfSampler",
+					texture,
+					4u);
+			}
+			if (auto texture = owner->GetSampler("g_envCubemap"))
+			{
+				driver->AddSamplerToShaderBindings(
+					resources->m_lightsBindings,
+					"g_envCubemap",
+					texture,
+					5u);
+			}
+			if (auto texture = owner->GetRenderTarget("g_AO"))
+			{
+				driver->AddSamplerToShaderBindings(
+					resources->m_lightsBindings,
+					"g_aoSampler",
+					texture,
+					8u);
+			}
+			if (auto texture = driver->GetDefaultTexture())
+			{
+				driver->AddSamplerToShaderBindings(
+					resources->m_lightsBindings,
+					"g_transmissionFramebufferSampler",
+					texture,
+					10u);
+			}
+			resources->m_lightsBindings->RecalculateCompatibility();
+			resources->m_lightsTemplate = lightsTemplate;
+			resources->m_sharedLightsStorage = sharedResources->m_lightsStorage;
+			resources->m_lightsTemplateRevision = lightsTemplateRevision;
+			resources->m_frameGraphSamplerHash = frameGraphSamplerHash;
+			resources->m_shadowMatricesHash = InvalidContentHash;
+			resources->m_shadowIndicesHash = InvalidContentHash;
+			resources->m_shadowAtlasTilesHash = InvalidContentHash;
+		}
+
+		const uint64_t shadowMatricesHash = HashSubmissionValues(snapshot.m_shadowMatrices);
+		if (resources->m_shadowMatricesHash != shadowMatricesHash)
+		{
+			if (!snapshot.m_shadowMatrices.IsEmpty())
+			{
+				commands->UpdateShaderBinding(
+					transferCommandList,
+					resources->m_lightsBindings->GetOrAddShaderBinding("lightsMatrices"),
+					snapshot.m_shadowMatrices.GetData(),
+					snapshot.m_shadowMatrices.Num() * sizeof(glm::mat4),
+					0u);
+			}
+			resources->m_shadowMatricesHash = shadowMatricesHash;
+		}
+
+		const uint64_t shadowIndicesHash = HashSubmissionValues(snapshot.m_shadowIndices);
+		if (resources->m_shadowIndicesHash != shadowIndicesHash)
+		{
+			if (!snapshot.m_shadowIndices.IsEmpty())
+			{
+				commands->UpdateShaderBinding(
+					transferCommandList,
+					resources->m_lightsBindings->GetOrAddShaderBinding("shadowIndices"),
+					snapshot.m_shadowIndices.GetData(),
+					snapshot.m_shadowIndices.Num() * sizeof(uint32_t),
+					0u);
+			}
+			resources->m_shadowIndicesHash = shadowIndicesHash;
+		}
+
+		const uint64_t shadowAtlasTilesHash = HashSubmissionValues(snapshot.m_shadowAtlasTiles);
+		if (resources->m_shadowAtlasTilesHash != shadowAtlasTilesHash)
+		{
+			if (!snapshot.m_shadowAtlasTiles.IsEmpty())
+			{
+				commands->UpdateShaderBinding(
+					transferCommandList,
+					resources->m_lightsBindings->GetOrAddShaderBinding("shadowAtlasTiles"),
+					snapshot.m_shadowAtlasTiles.GetData(),
+					snapshot.m_shadowAtlasTiles.Num() * sizeof(uint32_t),
+					0u);
+			}
+			resources->m_shadowAtlasTilesHash = shadowAtlasTilesHash;
+		}
+
+		snapshot.m_rhiLightsData = resources->m_lightsBindings;
+
+		const size_t numBoneMatrices = snapshot.m_cpuBoneMatrices ? snapshot.m_cpuBoneMatrices->Num() : 0u;
+		if (numBoneMatrices == 0u)
+		{
+			snapshot.m_boneMatrices.Clear();
+			return;
+		}
+
+		const bool bRecreateBones = !sharedResources->m_boneBindings ||
+			sharedResources->m_boneCapacity < numBoneMatrices;
+		if (bRecreateBones)
+		{
+			sharedResources->m_boneCapacity = GrowSubmissionCapacity(
+				sharedResources->m_boneCapacity,
+				numBoneMatrices);
+			sharedResources->m_boneBindings = driver->CreateShaderBindings();
+			driver->AddSsboToShaderBindings(
+				sharedResources->m_boneBindings,
+				"bones",
+				sizeof(glm::mat4),
+				sharedResources->m_boneCapacity,
+				0u,
+				true);
+			sharedResources->m_boneBindings->RecalculateCompatibility();
+			sharedResources->m_uploadedAnimationRevision = InvalidContentHash;
+			sharedResources->m_bonesSource.Clear();
+		}
+
+		if (bUploadSharedPayload &&
+			(sharedResources->m_bonesSource != snapshot.m_cpuBoneMatrices ||
+				sharedResources->m_uploadedAnimationRevision != snapshot.m_animationRevision))
+		{
+			commands->UpdateShaderBinding(
+				transferCommandList,
+				sharedResources->m_boneBindings->GetOrAddShaderBinding("bones"),
+				snapshot.m_cpuBoneMatrices->GetData(),
+				numBoneMatrices * sizeof(glm::mat4),
+				0u);
+			sharedResources->m_bonesSource = snapshot.m_cpuBoneMatrices;
+			sharedResources->m_uploadedAnimationRevision = snapshot.m_animationRevision;
+		}
+		snapshot.m_boneMatrices = sharedResources->m_boneBindings;
+	}
+}
 
 void RHIFrameGraph::Clear()
 {
@@ -55,9 +528,12 @@ RHI::UboFrameData RHIFrameGraph::FillFrameData(RHI::RHICommandListPtr transferCm
 
 	RHI::UboFrameData frameData;
 
-	snapshot.m_frameBindings = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
-	Sailor::RHI::Renderer::GetDriver()->AddBufferToShaderBindings(snapshot.m_frameBindings, "frameData", sizeof(RHI::UboFrameData), 0, RHI::EShaderBindingType::UniformBuffer);
-	Sailor::RHI::Renderer::GetDriver()->AddBufferToShaderBindings(snapshot.m_frameBindings, "previousFrameData", sizeof(RHI::UboFrameData), 1, RHI::EShaderBindingType::UniformBuffer);
+	if (!snapshot.m_frameBindings)
+	{
+		snapshot.m_frameBindings = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
+		Sailor::RHI::Renderer::GetDriver()->AddBufferToShaderBindings(snapshot.m_frameBindings, "frameData", sizeof(RHI::UboFrameData), 0, RHI::EShaderBindingType::UniformBuffer);
+		Sailor::RHI::Renderer::GetDriver()->AddBufferToShaderBindings(snapshot.m_frameBindings, "previousFrameData", sizeof(RHI::UboFrameData), 1, RHI::EShaderBindingType::UniformBuffer);
+	}
 
 	frameData.m_cameraPosition = snapshot.m_cameraTransform.m_position;
 	frameData.m_projection = snapshot.m_camera->GetProjectionMatrix();
@@ -107,6 +583,47 @@ bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 	auto& driver = RHI::Renderer::GetDriver();
 	auto driverCommands = renderer->GetDriverCommands();
 	RHISemaphorePtr frameGraphChainSemaphore = inSignalSemaphore;
+	auto submissionProgress = TSharedPtr<RHISubmissionProgress>::Make();
+	submissionProgress->SetLastSuccessfulSemaphore(inSignalSemaphore);
+	outWaitSemaphore = inSignalSemaphore;
+
+	if (!rhiSceneView->m_snapshots.IsEmpty() &&
+		rhiSceneView->m_snapshots[0].m_submissionContext)
+	{
+		auto resourceUploadCommandList = renderer->GetDriver()->CreateCommandList(
+			false,
+			RHI::ECommandListQueue::Compute);
+		driver->SetDebugName(resourceUploadCommandList, "FrameGraph:SharedResourceUpload");
+		driverCommands->BeginCommandList(resourceUploadCommandList, true);
+		PrepareViewSubmissionResources(
+			this,
+			resourceUploadCommandList,
+			rhiSceneView->m_snapshots[0],
+			true);
+		const bool bHasSharedResourceUploads =
+			resourceUploadCommandList->GetNumRecordedCommands() > 0u;
+		driverCommands->EndCommandList(resourceUploadCommandList);
+
+		if (bHasSharedResourceUploads)
+		{
+			auto resourceReadySemaphore = driver->CreateWaitSemaphore();
+			auto resourceUploadFence = RHIFencePtr::Make();
+			driver->SetDebugName(resourceReadySemaphore, "FrameGraph:SharedResourceReady");
+			driver->SetDebugName(resourceUploadFence, "FrameGraph:SharedResourceUpload");
+			if (!driver->SubmitCommandList(
+					resourceUploadCommandList,
+					resourceUploadFence,
+					resourceReadySemaphore,
+					frameGraphChainSemaphore))
+			{
+				SAILOR_LOG_ERROR("RHIFrameGraph::Process: failed to submit shared resource upload command buffer.");
+				return false;
+			}
+
+			frameGraphChainSemaphore = resourceReadySemaphore;
+			submissionProgress->SetLastSuccessfulSemaphore(resourceReadySemaphore);
+		}
+	}
 
 	if (!m_postEffectPlane)
 	{
@@ -130,81 +647,6 @@ bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 		RHI::Renderer::GetDriver()->UpdateMesh(m_postEffectPlane, &ndcQuad[0], ndcQuad.Num() * sizeof(VertexP3N3UV2C4), &indices[0], sizeof(uint32_t) * indices.Num());
 	}
 
-	bool bShouldRecalculateCompatibility = false;
-	if (auto g_irradianceCubemap = GetSampler("g_irradianceCubemap"))
-	{
-		if (g_irradianceCubemap != rhiSceneView->m_rhiLightsData->GetOrAddShaderBinding("g_irradianceCubemap")->GetTextureBinding())
-		{
-			renderer->GetDriver()->AddSamplerToShaderBindings(rhiSceneView->m_rhiLightsData, "g_irradianceCubemap", g_irradianceCubemap, 3);
-			bShouldRecalculateCompatibility = true;
-		}
-	}
-
-	if (auto g_brdfSampler = GetSampler("g_brdfSampler"))
-	{
-		if (g_brdfSampler != rhiSceneView->m_rhiLightsData->GetOrAddShaderBinding("g_brdfSampler")->GetTextureBinding())
-		{
-			renderer->GetDriver()->AddSamplerToShaderBindings(rhiSceneView->m_rhiLightsData, "g_brdfSampler", g_brdfSampler, 4);
-			bShouldRecalculateCompatibility = true;
-		}
-	}
-
-	if (auto g_envCubemap = GetSampler("g_envCubemap"))
-	{
-		if (g_envCubemap != rhiSceneView->m_rhiLightsData->GetOrAddShaderBinding("g_envCubemap")->GetTextureBinding())
-		{
-			renderer->GetDriver()->AddSamplerToShaderBindings(rhiSceneView->m_rhiLightsData, "g_envCubemap", g_envCubemap, 5);
-			bShouldRecalculateCompatibility = true;
-		}
-	}
-
-	// TODO: Move to another place
-	if (auto g_aoSampler = GetRenderTarget("g_AO"))
-	{
-		if (g_aoSampler != rhiSceneView->m_rhiLightsData->GetOrAddShaderBinding("g_aoSampler")->GetTextureBinding())
-		{
-			renderer->GetDriver()->AddSamplerToShaderBindings(rhiSceneView->m_rhiLightsData, "g_aoSampler", g_aoSampler, 8);
-			bShouldRecalculateCompatibility = true;
-		}
-	}
-
-	bool bHasTransmissionFramebuffer = false;
-	for (const auto& node : m_graph)
-	{
-		if (node && node->GetResolvedAttachment("transmissionFramebuffer"))
-		{
-			bHasTransmissionFramebuffer = true;
-			break;
-		}
-	}
-
-	constexpr const char* transmissionSamplerName =
-		"g_transmissionFramebufferSampler";
-	if (!bHasTransmissionFramebuffer &&
-		rhiSceneView->m_rhiLightsData->HasBinding(transmissionSamplerName))
-	{
-		RHI::RHITexturePtr defaultTexture =
-			renderer->GetDriver()->GetDefaultTexture();
-		RHI::RHIShaderBindingPtr& transmissionBinding =
-			rhiSceneView->m_rhiLightsData->GetOrAddShaderBinding(
-				transmissionSamplerName);
-		if (defaultTexture &&
-			transmissionBinding->GetTextureBinding() != defaultTexture)
-		{
-			renderer->GetDriver()->AddSamplerToShaderBindings(
-				rhiSceneView->m_rhiLightsData,
-				transmissionSamplerName,
-				defaultTexture,
-				10);
-			bShouldRecalculateCompatibility = true;
-		}
-	}
-
-	if (bShouldRecalculateCompatibility)
-	{
-		rhiSceneView->m_rhiLightsData->RecalculateCompatibility();
-	}
-
 	for (auto& snapshot : rhiSceneView->m_snapshots)
 	{
 		SAILOR_PROFILE_SCOPE("Process snapshot");
@@ -220,6 +662,8 @@ bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 
 		driverCommands->BeginCommandList(transferCmdList, true);
 		driverCommands->BeginDebugRegion(transferCmdList, "FrameGraph:Transfer", glm::vec4(0.75f, 0.75f, 1.0f, 0.1f));
+
+		PrepareViewSubmissionResources(this, transferCmdList, snapshot, false);
 
 		driverCommands->BeginDebugRegion(transferCmdList, "Fill Frame Data", DebugContext::Color_CmdTransfer);
 		{
@@ -325,6 +769,10 @@ bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 								SAILOR_LOG_ERROR("RHIFrameGraph::Process: failed to submit a chained transfer command buffer.");
 								submitsSucceeded->store(false, std::memory_order_release);
 							}
+							else
+							{
+								submissionProgress->SetLastSuccessfulSemaphore(newChainSemaphore);
+							}
 						}, EThreadType::RHI);
 
 					if (tasks.Num() > 0)
@@ -351,6 +799,10 @@ bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 							{
 								SAILOR_LOG_ERROR("RHIFrameGraph::Process: failed to submit a chained graphics command buffer.");
 								submitsSucceeded->store(false, std::memory_order_release);
+							}
+							else
+							{
+								submissionProgress->SetLastSuccessfulSemaphore(chainSemaphore);
 							}
 						}, EThreadType::RHI);
 
@@ -397,7 +849,7 @@ bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 		if (!submitsSucceeded->load(std::memory_order_acquire))
 		{
 			m_lastFrameGpuStats = driver->FinishGpuTracking();
-			outWaitSemaphore.Clear();
+			outWaitSemaphore = submissionProgress->GetLastSuccessfulSemaphore();
 			return false;
 		}
 

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -20,9 +20,71 @@ using namespace Sailor;
 using namespace Sailor::RHI;
 using namespace Sailor::Framegraph;
 
+static_assert(TextureDependencyCollector::MaxTrackedTextures ==
+	TextureImporter::MaxTexturesInScene);
+
 #ifndef _SAILOR_IMPORT_
 const char* RenderSceneNode::m_name = "RenderScene";
 #endif
+
+namespace
+{
+	RHIShaderBindingSetPtr CloneBindingsWithSampler(
+		const RHIShaderBindingSetPtr& source,
+		const std::string& samplerName,
+		const RHITexturePtr& sampler,
+		uint32_t samplerBinding)
+	{
+		if (!source || !sampler)
+		{
+			return source;
+		}
+
+		auto& driver = Renderer::GetDriver();
+		auto result = driver->CreateShaderBindings();
+		for (const auto& entry : source->GetShaderBindings())
+		{
+			const auto& name = entry.m_first;
+			const auto& binding = entry.m_second;
+			if (!binding || name == samplerName)
+			{
+				continue;
+			}
+
+			const auto& layout = binding->GetLayout();
+			if (layout.m_type == EShaderBindingType::CombinedImageSampler)
+			{
+				driver->AddSamplerToShaderBindings(
+					result,
+					name,
+					binding->GetTextureBindings(),
+					layout.m_binding,
+					layout.m_bVariableDescriptorCount,
+					layout.m_arrayCount);
+			}
+			else if (layout.m_type == EShaderBindingType::StorageImage)
+			{
+				driver->AddStorageImageToShaderBindings(
+					result,
+					name,
+					binding->GetTextureBindings(),
+					layout.m_binding);
+			}
+			else
+			{
+				driver->AddShaderBinding(result, binding, name, layout.m_binding);
+			}
+		}
+
+		driver->AddSamplerToShaderBindings(
+			result,
+			samplerName,
+			sampler,
+			samplerBinding);
+		result->RecalculateCompatibility();
+		return result;
+	}
+}
 
 bool Details::CanReuseRenderSceneTextureBindings(
 	uint64_t cachedSourceRevision,
@@ -44,6 +106,23 @@ bool Details::CanReuseRenderSceneTextureBindings(
 	return cachedSlotRevisions &&
 		currentSlotRevisions &&
 		*cachedSlotRevisions == *currentSlotRevisions;
+}
+
+uint64_t Details::CalculateTextureDependencyRevision(
+	const TVector<uint32_t>& requestedTextures)
+{
+	auto* textureImporter = App::GetSubmodule<TextureImporter>();
+	if (!textureImporter)
+	{
+		return 0ull;
+	}
+
+#if defined(__APPLE__)
+	return textureImporter->CalculateTextureSamplersRevision(requestedTextures);
+#else
+	const auto bindings = textureImporter->GetTextureSamplersBindingSet();
+	return bindings ? bindings->GetDescriptorRevision() : 0ull;
+#endif
 }
 
 TVector<uint32_t> Details::BuildDenseTextureRemap(
@@ -102,24 +181,7 @@ RHIShaderBindingSetPtr Details::GetTextureBindingSet(
 	auto globalTextureSet = textureImporter->GetTextureSamplersBindingSet();
 
 #if defined(__APPLE__)
-	TextureBindingCacheKey key;
-	key.m_requestedTextures = requestedTextures.ToVector();
-	key.m_requestedTextures.RemoveAll([](uint32_t textureIndex)
-		{
-			return textureIndex >= TextureImporter::MaxTexturesInScene;
-		});
-
-	if (key.m_requestedTextures.IsEmpty())
-	{
-		key.m_requestedTextures.Add(0u);
-	}
-
-	if (!key.m_requestedTextures.Contains(0u))
-	{
-		key.m_requestedTextures.Add(0u);
-	}
-
-	key.m_requestedTextures.Sort();
+	TextureBindingCacheKey key(requestedTextures);
 	const uint64_t currentSourceDescriptorRevision = globalTextureSet ? globalTextureSet->GetDescriptorRevision() : 0;
 	TextureBindingCacheEntry* cachedEntry = nullptr;
 	textureBindingCache.Find(key, cachedEntry);
@@ -144,6 +206,7 @@ RHIShaderBindingSetPtr Details::GetTextureBindingSet(
 		return cachedEntry->m_textureBindings;
 	}
 
+	key.Materialize();
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	const auto sourceSnapshot = textureImporter->GetTextureSamplersSnapshot(key.m_requestedTextures);
 	TVector<uint64_t> currentSlotRevisions;
@@ -281,76 +344,490 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 	const std::string QueueTag = GetString("Tag");
 	const size_t QueueTagHash = GetHash(QueueTag);
 	const bool bBackToFront = GetSortingOrder() == RHI::ESortingOrder::BackToFront;
+	std::string virtualizeInstancePayloadsSetting;
+	const bool bVirtualizeInstancePayloads =
+		!TryGetString("VirtualizeInstancePayloads", virtualizeInstancePayloadsSetting) ||
+		virtualizeInstancePayloadsSetting != "false";
 
 	auto res = Tasks::CreateTask("Prepare RenderSceneNode  " + std::to_string(sceneView.m_frame),
 		[=, this, holdRhiResources = frameGraph, &syncSharedResources = m_syncSharedResources, &sceneViewSnapshot = sceneView]() mutable {
+			if (!sceneViewSnapshot.m_submissionContext)
+			{
+				return;
+			}
+			const uint64_t materialSubmissionId =
+				sceneViewSnapshot.m_submissionContext->GetSubmissionId();
+
+			auto submissionResources = sceneViewSnapshot.m_submissionContext->GetOrAddFrameGraphResources<SubmissionResources>(
+				this,
+				sceneViewSnapshot.m_cameraIndex,
+				0u);
+			auto& m_packet = submissionResources->m_packet;
+			auto& m_orderedDrawItems = submissionResources->m_orderedDrawItems;
 
 			syncSharedResources.Lock();
+			auto& requestedPacketTextures =
+				submissionResources->m_requestedPacketTextures;
+			for (auto& requestedTextures : requestedPacketTextures)
+			{
+				requestedTextures.Reset();
+			}
 
-			m_numMeshes = 0;
-			m_drawCalls.Clear();
-			m_batches.Clear();
-			m_orderedDrawItems.Clear();
+			constexpr size_t PayloadRevisionSeed = 1469598103934665603ull;
+			std::array<size_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				payloadRevisions{};
+			std::array<uint32_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				numRelevantProxies{};
+			for (size_t index = 0u; index < payloadRevisions.size(); ++index)
+			{
+				payloadRevisions[index] = PayloadRevisionSeed;
+				HashCombine(payloadRevisions[index], index);
+			}
+			const size_t staticPayloadIndex =
+				RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
+					EMobilityType::Static);
+			const size_t stationaryPayloadIndex =
+				RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
+					EMobilityType::Stationary);
+			const bool bUsesPagedArenas = bVirtualizeInstancePayloads && !bBackToFront;
+			auto usesPagedArena = [&](size_t payloadIndex)
+				{
+					return bUsesPagedArenas &&
+						(payloadIndex == staticPayloadIndex ||
+							payloadIndex == stationaryPayloadIndex);
+				};
+			if (bUsesPagedArenas)
+			{
+				for (const EMobilityType mobility :
+					{ EMobilityType::Static, EMobilityType::Stationary })
+				{
+					const size_t payloadIndex =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					payloadRevisions[payloadIndex] = PayloadRevisionSeed;
+					HashCombine(
+						payloadRevisions[payloadIndex],
+						payloadIndex,
+						QueueTagHash,
+						sceneViewSnapshot.m_submissionContext->GetMaterialRevision(),
+						sceneViewSnapshot.GetMobilityRevision(mobility));
+				}
+			}
+			for (const auto& proxy : sceneViewSnapshot.m_proxies)
+			{
+				const auto* source = proxy.GetSource();
+				if (!source || !proxy.m_resource)
+				{
+					continue;
+				}
+				bool bContributesToQueue = false;
+				for (size_t renderQueueTag : source->m_renderQueueTags)
+				{
+					bContributesToQueue |= renderQueueTag == QueueTagHash;
+				}
+				for (const auto& group : source->m_instancedGroups)
+				{
+					for (size_t renderQueueTag : group.m_renderQueueTags)
+					{
+						bContributesToQueue |= renderQueueTag == QueueTagHash;
+					}
+				}
+				const EMobilityType payloadMobility = bBackToFront ?
+					EMobilityType::Dynamic : proxy.GetMobility();
+				const size_t payloadIndex =
+					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(payloadMobility);
+#if defined(__APPLE__)
+				for (size_t materialIndex = 0u;
+					materialIndex < source->m_materialTextureSamplers.Num(); ++materialIndex)
+				{
+					if (materialIndex < source->m_renderQueueTags.Num() &&
+						source->m_renderQueueTags[materialIndex] == QueueTagHash)
+					{
+						for (uint32_t texture : source->m_materialTextureSamplers[materialIndex])
+						{
+							requestedPacketTextures[payloadIndex].Insert(texture);
+						}
+					}
+				}
+				for (const auto& group : source->m_instancedGroups)
+				{
+					for (size_t materialIndex = 0u;
+						materialIndex < group.m_materialTextureSamplers.Num(); ++materialIndex)
+					{
+						if (materialIndex < group.m_renderQueueTags.Num() &&
+							group.m_renderQueueTags[materialIndex] == QueueTagHash)
+						{
+							for (uint32_t texture : group.m_materialTextureSamplers[materialIndex])
+							{
+								requestedPacketTextures[payloadIndex].Insert(texture);
+							}
+						}
+					}
+				}
+#endif
+				if (bContributesToQueue)
+				{
+					++numRelevantProxies[payloadIndex];
+					if (!usesPagedArena(payloadIndex))
+					{
+						HashCombine(
+							payloadRevisions[payloadIndex],
+							proxy.m_handle.m_slot,
+							proxy.m_handle.m_generation,
+							proxy.m_resource->m_mainRevision,
+							source->m_staticMeshEcs,
+							std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
+							proxy.GetSkeletonOffset(),
+							proxy.GetRenderFlags());
+						for (size_t meshIndex = 0u; meshIndex < source->m_meshes.Num(); ++meshIndex)
+						{
+							if (meshIndex < source->m_renderQueueTags.Num() &&
+								source->m_renderQueueTags[meshIndex] == QueueTagHash)
+							{
+								HashCombine(payloadRevisions[payloadIndex], proxy.ResolveMesh(meshIndex));
+							}
+						}
+						for (const auto& group : source->m_instancedGroups)
+						{
+							for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+							{
+								if (meshIndex < group.m_renderQueueTags.Num() &&
+									group.m_renderQueueTags[meshIndex] == QueueTagHash)
+								{
+									HashCombine(payloadRevisions[payloadIndex], proxy.ResolveMesh(group.m_meshes[meshIndex]));
+								}
+							}
+						}
+					}
+				}
+			}
+			for (size_t index = 0u; index < payloadRevisions.size(); ++index)
+			{
+				const uint64_t textureDescriptorRevision =
+					Details::CalculateTextureDependencyRevision(
+						requestedPacketTextures[index].GetIndices());
+				if (!usesPagedArena(index))
+				{
+					HashCombine(
+						payloadRevisions[index],
+						numRelevantProxies[index],
+						QueueTagHash,
+						bBackToFront,
+						textureDescriptorRevision);
+				}
+			}
+			if (bBackToFront)
+			{
+				HashCombine(
+					payloadRevisions[RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
+						EMobilityType::Dynamic)],
+					std::hash<glm::mat4>{}(sceneViewSnapshot.m_camera->GetViewMatrix()));
+			}
+			m_packet.Reset();
+			m_orderedDrawItems.Clear(false);
+			std::array<bool, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				bBuildPayload{ true, true, true };
+			std::array<bool, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				bPayloadComplete{ true, true, true };
+			auto buildPayloadCacheSlot = [&](EMobilityType mobility)
+				{
+					size_t cacheSlot = PayloadRevisionSeed;
+					const size_t index =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					const uint32_t cameraIndex = usesPagedArena(index) ?
+						0u : sceneViewSnapshot.m_cameraIndex;
+					HashCombine(cacheSlot, cameraIndex, index);
+					return cacheSlot;
+				};
+			if (bVirtualizeInstancePayloads && !bBackToFront)
+			{
+				for (const EMobilityType mobility :
+					{ EMobilityType::Static, EMobilityType::Stationary })
+				{
+					const size_t index =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					const size_t cacheSlot = buildPayloadCacheSlot(mobility);
+					auto payload = usesPagedArena(index) ?
+						m_pagedArenaCache.Find(
+							cacheSlot,
+							payloadRevisions[index],
+							sceneViewSnapshot.m_frame) :
+						m_packetPayloadCache.Find(
+							cacheSlot,
+							payloadRevisions[index],
+							sceneViewSnapshot.m_frame);
+					if (payload)
+					{
+						if (usesPagedArena(index))
+						{
+							m_packet.UseSharedArenaPayload(mobility, std::move(payload));
+						}
+						else
+						{
+							m_packet.UseSharedPayload(mobility, std::move(payload));
+						}
+						bBuildPayload[index] = false;
+					}
+				}
+			}
+
+			if (bUsesPagedArenas)
+			{
+				for (const EMobilityType mobility : {EMobilityType::Static, EMobilityType::Stationary})
+				{
+					const size_t arenaPayloadIndex = RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					if (!bBuildPayload[arenaPayloadIndex])
+					{
+						continue;
+					}
+					const size_t arenaCacheSlot = buildPayloadCacheSlot(mobility);
+					m_pagedArenaCache.BeginUpdate(
+						arenaCacheSlot, payloadRevisions[arenaPayloadIndex], sceneViewSnapshot.m_frame);
+					auto& rangeInstances = submissionResources->m_arenaRangeInstances;
+					auto& rangeStableKeys = submissionResources->m_arenaRangeStableKeys;
+					auto& rangeMaterialVersionRuns = submissionResources->m_arenaRangeMaterialVersionRuns;
+					sceneViewSnapshot.ForEachSceneProxy(mobility,
+						[&](const RHIVisibleSceneProxy& proxy)
+						{
+							const auto* source = proxy.GetSource();
+							if (!source)
+							{
+								return;
+							}
+							const uint64_t rangeKey =
+								BuildPackedDrawRangeKey(proxy.m_handle, source->m_staticMeshEcs, proxy.m_resource);
+							size_t rangeRevision =
+								proxy.m_resource ? proxy.m_resource->m_mainRevision : proxy.GetContentRevision();
+							HashCombine(rangeRevision,
+								QueueTagHash,
+								proxy.GetContentRevision(),
+								std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
+								proxy.GetSkeletonOffset());
+							if (proxy.m_record)
+							{
+								HashCombine(
+									rangeRevision, proxy.m_record->m_materialRevision, proxy.m_record->m_renderFlags);
+							}
+							for (const auto& material : source->GetMaterials())
+							{
+								const auto version = material ?
+									material->GetVersionForSubmission(materialSubmissionId) :
+									RHIMaterialVersionPtr{};
+								HashCombine(rangeRevision, version ? version->GetVersionId() : 0ull);
+							}
+							for (const auto& group : source->m_instancedGroups)
+							{
+								for (const auto& material : group.m_materials)
+								{
+									const auto version = material ?
+										material->GetVersionForSubmission(materialSubmissionId) :
+										RHIMaterialVersionPtr{};
+									HashCombine(rangeRevision, version ? version->GetVersionId() : 0ull);
+								}
+							}
+							if (m_pagedArenaCache.TryReuseRange(rangeKey, rangeRevision))
+							{
+								return;
+							}
+
+							rangeInstances.Clear(false);
+							rangeStableKeys.Clear(false);
+							rangeMaterialVersionRuns.Clear(false);
+							bool bRangeComplete = true;
+
+							for (size_t meshIndex = 0u; meshIndex < source->m_meshes.Num(); ++meshIndex)
+							{
+								if (meshIndex >= source->GetMaterials().Num())
+								{
+									break;
+								}
+								const auto& material = source->GetMaterials()[meshIndex];
+								const auto& mesh = source->m_meshes[meshIndex];
+								const bool bRelevantMaterial =
+									material && material->GetRenderState().GetTag() == QueueTagHash;
+								if (!bRelevantMaterial)
+								{
+									continue;
+								}
+								if (!mesh || !material->GetVertexShader() || !material->GetFragmentShader())
+								{
+									bRangeComplete = false;
+									continue;
+								}
+
+								RHIBatch batch(material, mesh, materialSubmissionId);
+								const auto materialBindings = batch.GetMaterialBindings();
+								if (!materialBindings || materialBindings->GetShaderBindings().Num() == 0u)
+								{
+									bRangeComplete = false;
+									continue;
+								}
+
+								RHIShaderBindingPtr materialBinding;
+								if (materialBindings->GetShaderBindings().ContainsKey("material"))
+								{
+									materialBinding = materialBindings->GetShaderBindings()["material"];
+								}
+								PerInstanceData data;
+								data.model = proxy.ResolveMeshWorldMatrix(meshIndex);
+								data.skeletonOffset = proxy.GetSkeletonOffset();
+								data.materialInstance =
+									materialBinding ? materialBinding->GetStorageInstanceIndex() : 0u;
+								data.bIsCulled = 0u;
+								data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+								data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+								rangeInstances.Add(std::move(data));
+								rangeStableKeys.Add(BuildPackedDrawStableKey(
+									proxy.m_handle, source->m_staticMeshEcs, 0u, static_cast<uint32_t>(meshIndex), 0u));
+								AppendPackedDrawArenaMaterialVersion(rangeMaterialVersionRuns, batch.m_materialVersion);
+							}
+
+							for (size_t groupIndex = 0u; groupIndex < source->m_instancedGroups.Num(); ++groupIndex)
+							{
+								const auto& group = source->m_instancedGroups[groupIndex];
+								for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+								{
+									if (meshIndex >= group.m_materials.Num())
+									{
+										break;
+									}
+									const auto& material = group.m_materials[meshIndex];
+									const auto& mesh = group.m_meshes[meshIndex];
+									const bool bRelevantMaterial =
+										material && material->GetRenderState().GetTag() == QueueTagHash;
+									if (!bRelevantMaterial)
+									{
+										continue;
+									}
+									if (!mesh || !material->GetVertexShader() || !material->GetFragmentShader())
+									{
+										bRangeComplete = false;
+										continue;
+									}
+
+									RHIBatch batch(material, mesh, materialSubmissionId);
+									const auto materialBindings = batch.GetMaterialBindings();
+									if (!materialBindings || materialBindings->GetShaderBindings().Num() == 0u)
+									{
+										bRangeComplete = false;
+										continue;
+									}
+
+									RHIShaderBindingPtr materialBinding;
+									if (materialBindings->GetShaderBindings().ContainsKey("material"))
+									{
+										materialBinding = materialBindings->GetShaderBindings()["material"];
+									}
+									for (size_t instanceIndex = 0u; instanceIndex < group.m_instanceTransforms.Num();
+										++instanceIndex)
+									{
+										PerInstanceData data;
+										data.model =
+											proxy.ResolveInstancedMeshWorldMatrix(group, instanceIndex, meshIndex);
+										data.skeletonOffset = proxy.GetSkeletonOffset();
+										data.materialInstance =
+											materialBinding ? materialBinding->GetStorageInstanceIndex() : 0u;
+										data.bIsCulled = 0u;
+										data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+										data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+										rangeInstances.Add(std::move(data));
+										rangeStableKeys.Add(BuildPackedDrawStableKey(proxy.m_handle,
+											source->m_staticMeshEcs,
+											static_cast<uint32_t>(groupIndex + 1u),
+											static_cast<uint32_t>(meshIndex),
+											static_cast<uint32_t>(instanceIndex)));
+										AppendPackedDrawArenaMaterialVersion(
+											rangeMaterialVersionRuns, batch.m_materialVersion);
+									}
+								}
+							}
+
+							if (!m_pagedArenaCache.ReplaceRange(rangeKey,
+									rangeRevision,
+									rangeInstances,
+									rangeStableKeys,
+									&rangeMaterialVersionRuns))
+							{
+								bRangeComplete = false;
+							}
+							bPayloadComplete[arenaPayloadIndex] &= bRangeComplete;
+						});
+
+					auto arenaPayload = m_pagedArenaCache.EndUpdate(bPayloadComplete[arenaPayloadIndex]);
+					m_packet.UseSharedArenaPayload(mobility, std::move(arenaPayload));
+					rangeInstances.Clear(false);
+					rangeStableKeys.Clear(false);
+					rangeMaterialVersionRuns.Clear(false);
+					bBuildPayload[arenaPayloadIndex] = false;
+				}
+			}
 			Details::EvictTextureBindingCache(m_textureBindingCache, sceneViewSnapshot.m_frame);
+			m_packetPayloadCache.Evict(sceneViewSnapshot.m_frame);
+			m_pagedArenaCache.Evict(sceneViewSnapshot.m_frame);
 
 			SAILOR_PROFILE_SCOPE("Filter sceneView by tag");
 
-			for (auto& proxy : sceneViewSnapshot.m_proxies)
+			for (const auto& proxy : sceneViewSnapshot.m_proxies)
 			{
-				for (size_t i = 0; i < proxy.m_meshes.Num(); i++)
+				const auto* source = proxy.GetSource();
+				if (!source)
 				{
-					const bool bHasMaterial = proxy.GetMaterials().Num() > i;
+					continue;
+				}
+				const EMobilityType payloadMobility = bBackToFront ?
+					EMobilityType::Dynamic : proxy.GetMobility();
+				const size_t payloadIndex =
+					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(payloadMobility);
+				if (!bBuildPayload[payloadIndex] && !usesPagedArena(payloadIndex))
+				{
+					continue;
+				}
+				for (size_t i = 0; i < source->m_meshes.Num(); i++)
+				{
+					const bool bHasMaterial = source->GetMaterials().Num() > i;
 					if (!bHasMaterial)
 					{
 						break;
 					}
 
-					const auto& mesh = proxy.m_meshes[i];
-					const auto& material = proxy.GetMaterials()[i];
+					const auto mesh = proxy.ResolveMesh(i);
+					const auto& material = source->GetMaterials()[i];
 
-					const bool bIsMaterialReady = material &&
+					const bool bRelevantMaterial = material &&
+						material->GetRenderState().GetTag() == QueueTagHash;
+					const bool bHasMaterialShaders = mesh && bRelevantMaterial &&
 						material->GetVertexShader() &&
-						material->GetFragmentShader() &&
-						material->GetBindings() &&
-						material->GetBindings()->GetShaderBindings().Num() > 0;
+						material->GetFragmentShader();
 
-					if (!bIsMaterialReady)
+					if (!bHasMaterialShaders)
 					{
+						if (bRelevantMaterial)
+						{
+							bPayloadComplete[payloadIndex] = false;
+						}
+						continue;
+					}
+					RHI::RHIBatch batch(material, mesh, materialSubmissionId);
+					const auto materialBindings = batch.GetMaterialBindings();
+					if (!materialBindings || materialBindings->GetShaderBindings().Num() == 0u)
+					{
+						bPayloadComplete[payloadIndex] = false;
 						continue;
 					}
 
-					if (material->GetRenderState().GetTag() == QueueTagHash)
+					if (bRelevantMaterial)
 					{
 						RHIShaderBindingPtr shaderBinding;
-						if (material->GetBindings()->GetShaderBindings().ContainsKey("material"))
+						if (materialBindings->GetShaderBindings().ContainsKey("material"))
 						{
-							shaderBinding = material->GetBindings()->GetShaderBindings()["material"];
+							shaderBinding = materialBindings->GetShaderBindings()["material"];
 						}
 
-						const glm::mat4& meshWorldMatrix =
-							proxy.m_meshModelMatrices.Num() > i ?
-								proxy.m_meshModelMatrices[i] :
-								proxy.m_worldMatrix;
-						RenderSceneNode::PerInstanceData data;
-						data.model = meshWorldMatrix;
-						data.skeletonOffset = proxy.m_skeletonOffset;
-						data.materialInstance = shaderBinding.IsValid() ? shaderBinding->GetStorageInstanceIndex() : 0;
-						data.bIsCulled = 0;
-						data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
-						data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
-
-						RHI::RHIBatch batch(material, mesh);
 						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
 #if defined(__APPLE__)
-						TSet<uint32_t> requestedTextures;
-						if (proxy.m_materialTextureSamplers.Num() > i)
-						{
-							requestedTextures = proxy.m_materialTextureSamplers[i];
-						}
-						else
-						{
-							requestedTextures.Insert(0u);
-						}
+						const auto& requestedTextures =
+							source->m_materialTextureSamplers.Num() > i ?
+							source->m_materialTextureSamplers[i] :
+							Details::GetDefaultRequestedTextures();
 						batch.m_textureBindings = Details::GetTextureBindingSet(
 							m_textureBindingCache,
 							requestedTextures,
@@ -360,6 +837,38 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 						batch.m_textureBindings = App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
 #endif
 						batch.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
+						const uint64_t stableKey = BuildPackedDrawStableKey(
+							proxy.m_handle,
+							source->m_staticMeshEcs,
+							0u,
+							static_cast<uint32_t>(i),
+							0u);
+						if (usesPagedArena(payloadIndex))
+						{
+							if (!m_packet.AddArenaView(
+								std::move(batch),
+								mesh,
+								BuildPackedDrawRangeKey(
+									proxy.m_handle,
+									source->m_staticMeshEcs,
+									proxy.m_resource),
+								stableKey,
+								payloadMobility))
+							{
+								bPayloadComplete[payloadIndex] = false;
+							}
+							continue;
+						}
+
+						const glm::mat4 meshWorldMatrix = proxy.ResolveMeshWorldMatrix(i);
+						RenderSceneNode::PerInstanceData data;
+						data.model = meshWorldMatrix;
+						data.skeletonOffset = proxy.GetSkeletonOffset();
+						data.materialInstance = shaderBinding.IsValid() ?
+							shaderBinding->GetStorageInstanceIndex() : 0u;
+						data.bIsCulled = 0u;
+						data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+						data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
 
 						if (bBackToFront)
 						{
@@ -375,17 +884,173 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 							item.m_cameraDepth = std::isfinite(viewCenter.z) ?
 								-viewCenter.z :
 								-(std::numeric_limits<float>::max)();
-							item.m_staticMeshEcs = proxy.m_staticMeshEcs;
+							item.m_staticMeshEcs = source->m_staticMeshEcs;
 							item.m_meshIndex = i;
 							m_orderedDrawItems.Emplace(std::move(item));
 						}
 						else
 						{
-							m_drawCalls[batch][mesh].Add(data);
-							m_batches.Insert(batch);
+							m_packet.Add(
+								std::move(batch),
+								mesh,
+								data,
+								stableKey,
+								payloadMobility);
 						}
 
-						m_numMeshes++;
+					}
+				}
+
+				for (size_t groupIndex = 0u;
+					groupIndex < source->m_instancedGroups.Num(); ++groupIndex)
+				{
+					const auto& group = source->m_instancedGroups[groupIndex];
+					for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+					{
+						if (meshIndex >= group.m_materials.Num())
+						{
+							break;
+						}
+
+						const auto& sourceMesh = group.m_meshes[meshIndex];
+						const auto& material = group.m_materials[meshIndex];
+						const bool bRelevantMaterial = material &&
+							material->GetRenderState().GetTag() == QueueTagHash;
+						const bool bHasMaterialShaders = sourceMesh && bRelevantMaterial &&
+							material->GetVertexShader() &&
+							material->GetFragmentShader();
+						if (!bHasMaterialShaders)
+						{
+							if (bRelevantMaterial)
+							{
+								bPayloadComplete[payloadIndex] = false;
+							}
+							continue;
+						}
+
+						RHI::RHIBatch batchTemplate(
+							material,
+							sourceMesh,
+							materialSubmissionId);
+						const auto materialBindings = batchTemplate.GetMaterialBindings();
+						if (!materialBindings || materialBindings->GetShaderBindings().Num() == 0u)
+						{
+							bPayloadComplete[payloadIndex] = false;
+							continue;
+						}
+
+						RHIShaderBindingPtr shaderBinding;
+						if (materialBindings->GetShaderBindings().ContainsKey("material"))
+						{
+							shaderBinding = materialBindings->GetShaderBindings()["material"];
+						}
+
+						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
+#if defined(__APPLE__)
+						const auto& requestedTextures =
+							meshIndex < group.m_materialTextureSamplers.Num() ?
+							group.m_materialTextureSamplers[meshIndex] :
+							Details::GetDefaultRequestedTextures();
+						batchTemplate.m_textureBindings = Details::GetTextureBindingSet(
+							m_textureBindingCache,
+							requestedTextures,
+							sceneViewSnapshot.m_frame,
+							supportedMeshesPerBatch);
+#else
+						batchTemplate.m_textureBindings = App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
+#endif
+						batchTemplate.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
+
+						for (size_t instanceIndex = 0u;
+							instanceIndex < group.m_instanceTransforms.Num(); ++instanceIndex)
+						{
+							if (!proxy.IsInstancedMeshWithinDistance(
+								group,
+								instanceIndex,
+								meshIndex,
+								glm::vec3(sceneViewSnapshot.m_cameraTransform.m_position),
+								source->m_lodPolicy.m_maxCameraDistance))
+							{
+								continue;
+							}
+							const auto mesh = proxy.ResolveInstancedMesh(
+								group,
+								instanceIndex,
+								meshIndex,
+								sceneViewSnapshot.m_camera->GetViewMatrix(),
+								sceneViewSnapshot.m_camera->GetProjectionMatrix());
+							if (!mesh)
+							{
+								bPayloadComplete[payloadIndex] = false;
+								continue;
+							}
+							const uint64_t stableKey = BuildPackedDrawStableKey(
+								proxy.m_handle,
+								source->m_staticMeshEcs,
+								static_cast<uint32_t>(groupIndex + 1u),
+								static_cast<uint32_t>(meshIndex),
+								static_cast<uint32_t>(instanceIndex));
+							RHI::RHIBatch batch = batchTemplate;
+							batch.m_mesh = mesh;
+							if (usesPagedArena(payloadIndex))
+							{
+								if (!m_packet.AddArenaView(
+									std::move(batch),
+									mesh,
+									BuildPackedDrawRangeKey(
+										proxy.m_handle,
+										source->m_staticMeshEcs,
+										proxy.m_resource),
+									stableKey,
+									payloadMobility))
+								{
+									bPayloadComplete[payloadIndex] = false;
+								}
+								continue;
+							}
+
+							const glm::mat4 meshWorldMatrix = proxy.ResolveInstancedMeshWorldMatrix(
+								group,
+								instanceIndex,
+								meshIndex);
+							RenderSceneNode::PerInstanceData data;
+							data.model = meshWorldMatrix;
+							data.skeletonOffset = proxy.GetSkeletonOffset();
+							data.materialInstance = shaderBinding.IsValid() ?
+								shaderBinding->GetStorageInstanceIndex() : 0u;
+							data.bIsCulled = 0u;
+							data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+							data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+
+							if (bBackToFront)
+							{
+								const glm::vec4 worldCenter = meshWorldMatrix *
+									glm::vec4(mesh->m_bounds.GetCenter(), 1.0f);
+								const glm::vec4 viewCenter = sceneViewSnapshot.m_camera->GetViewMatrix() *
+									worldCenter;
+
+								OrderedDrawItem item;
+								item.m_batch = std::move(batch);
+								item.m_mesh = mesh;
+								item.m_instanceData = data;
+								item.m_cameraDepth = std::isfinite(viewCenter.z) ?
+									-viewCenter.z :
+									-(std::numeric_limits<float>::max)();
+								item.m_staticMeshEcs = source->m_staticMeshEcs;
+								item.m_meshIndex = source->m_meshes.Num() + instanceIndex;
+								HashCombine(item.m_meshIndex, groupIndex, meshIndex);
+								m_orderedDrawItems.Emplace(std::move(item));
+							}
+							else
+							{
+								m_packet.Add(
+									std::move(batch),
+									mesh,
+									data,
+									stableKey,
+									payloadMobility);
+							}
+						}
 					}
 				}
 			}
@@ -406,600 +1071,261 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 
 						return lhs.m_meshIndex < rhs.m_meshIndex;
 					});
+				for (auto& item : m_orderedDrawItems)
+				{
+					m_packet.Add(std::move(item.m_batch), item.m_mesh, item.m_instanceData);
+				}
+				m_packet.Finalize(true);
 			}
-
+			else
+			{
+				m_packet.Finalize(false);
+				for (const EMobilityType mobility :
+					{ EMobilityType::Static, EMobilityType::Stationary })
+				{
+					const size_t index =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					if (usesPagedArena(index))
+					{
+						continue;
+					}
+					if (bVirtualizeInstancePayloads &&
+						bBuildPayload[index] && bPayloadComplete[index])
+					{
+						m_packetPayloadCache.Publish(
+							buildPayloadCacheSlot(mobility),
+							payloadRevisions[index],
+							m_packet.SharePayload(mobility),
+							sceneViewSnapshot.m_frame);
+					}
+				}
+			}
+			m_orderedDrawItems.Clear(false);
 			syncSharedResources.Unlock();
 		}, EThreadType::RHI);
 
 	return res;
 }
 
-void RenderSceneNode::ProcessBackToFront(RHIFrameGraphPtr frameGraph,
-	RHI::RHICommandListPtr transferCommandList,
-	RHI::RHICommandListPtr commandList,
-	const RHI::RHISceneViewSnapshot& sceneView,
-	const RHI::RHIShaderBindingPtr& storageBinding,
-	const std::string& queueTag)
+void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
-	if (m_orderedDrawItems.IsEmpty())
+	SAILOR_PROFILE_FUNCTION();
+	m_drawCallStats = {};
+	if (!sceneView.m_submissionContext)
 	{
+		return;
+	}
+
+	auto resources = sceneView.m_submissionContext->GetOrAddFrameGraphResources<SubmissionResources>(
+		this,
+		sceneView.m_cameraIndex,
+		0u);
+	m_syncSharedResources.Lock();
+	if (resources->m_packet.GetNumInstances() == 0u)
+	{
+		m_syncSharedResources.Unlock();
 		return;
 	}
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
-
-	RHI::RHISurfacePtr colorAttachment = GetRHIResource("color").DynamicCast<RHI::RHISurface>();
-	RHI::RHITexturePtr depthAttachment = GetRHIResource("depthStencil").DynamicCast<RHI::RHITexture>();
+	auto colorAttachment = GetRHIResource("color").DynamicCast<RHI::RHIRenderTarget>();
+	auto colorSurface = GetRHIResource("color").DynamicCast<RHI::RHISurface>();
+	if (colorSurface)
+	{
+		colorAttachment = colorSurface->GetTarget();
+	}
+	auto depthAttachment = GetRHIResource("depthStencil").DynamicCast<RHI::RHITexture>();
 	if (!depthAttachment)
 	{
 		depthAttachment = frameGraph->GetRenderTarget("DepthBuffer");
 	}
-
 	if (!colorAttachment || !depthAttachment)
 	{
+		m_syncSharedResources.Unlock();
 		return;
 	}
 
-	TVector<PerInstanceData> gpuMatricesData;
-	gpuMatricesData.Reserve(m_orderedDrawItems.Num());
-
-	TVector<RHI::DrawIndexedIndirectData> indirectCommands;
-	indirectCommands.Reserve(m_orderedDrawItems.Num());
-
-	const uint32_t firstStorageInstance = storageBinding->GetStorageInstanceIndex();
-	for (uint32_t i = 0; i < m_orderedDrawItems.Num(); i++)
+	RHIShaderBindingSetPtr nodeLightsData = sceneView.m_rhiLightsData;
+	RHI::RHITexturePtr transmissionFramebuffer = GetResolvedAttachment("transmissionFramebuffer");
+	if (transmissionFramebuffer)
 	{
-		const OrderedDrawItem& item = m_orderedDrawItems[i];
-		gpuMatricesData.Add(item.m_instanceData);
-
-		RHI::DrawIndexedIndirectData command{};
-		command.m_indexCount = item.m_mesh->GetIndexCount();
-		command.m_instanceCount = 1u;
-		command.m_firstIndex = item.m_mesh->GetFirstIndex();
-		command.m_vertexOffset = item.m_mesh->GetVertexOffset();
-		command.m_firstInstance = firstStorageInstance + i;
-		indirectCommands.Emplace(std::move(command));
+		constexpr const char* transmissionSamplerName = "g_transmissionFramebufferSampler";
+		const uint64_t sourceRevision = sceneView.m_rhiLightsData ?
+			sceneView.m_rhiLightsData->GetDescriptorRevision() : 0ull;
+		const bool bCloneOutdated = !resources->m_nodeLightsBindings ||
+			resources->m_nodeLightsSource != sceneView.m_rhiLightsData ||
+			resources->m_nodeLightsSourceRevision != sourceRevision ||
+			resources->m_transmissionTexture != transmissionFramebuffer;
+		if (bCloneOutdated)
+		{
+			resources->m_nodeLightsBindings = CloneBindingsWithSampler(
+				sceneView.m_rhiLightsData,
+				transmissionSamplerName,
+				transmissionFramebuffer,
+				10u);
+			resources->m_nodeLightsSource = sceneView.m_rhiLightsData;
+			resources->m_nodeLightsSourceRevision = sourceRevision;
+			resources->m_transmissionTexture = transmissionFramebuffer;
+		}
+		nodeLightsData = resources->m_nodeLightsBindings;
+		commands->ImageMemoryBarrier(commandList, transmissionFramebuffer, RHI::EImageLayout::ShaderReadOnlyOptimal);
 	}
 
-	commands->UpdateShaderBinding(transferCommandList,
-		storageBinding,
-		gpuMatricesData.GetData(),
-		sizeof(PerInstanceData) * gpuMatricesData.Num(),
-		0);
-
-	if (m_indirectBuffers.IsEmpty())
+	std::string gpuCullingSetting;
+	TryGetString("GPUCulling", gpuCullingSetting);
+	const bool bGpuCullingRequested = gpuCullingSetting == "true";
+	const uint32_t numInstances = resources->m_packet.GetNumStorageInstances();
+	const uint32_t numInstanceIndices = resources->m_packet.GetNumDrawInstances();
+	const size_t numAllocatedInstanceIndices =
+		static_cast<size_t>(numInstanceIndices) * (bGpuCullingRequested ? 2u : 1u);
+	if (!resources->m_perInstanceData ||
+		resources->m_sizePerInstanceData < sizeof(PerInstanceData) * numInstances ||
+		resources->m_sizeInstanceIndices < sizeof(uint32_t) * numAllocatedInstanceIndices)
 	{
-		m_indirectBuffers.Resize(1);
+		resources->m_perInstanceData = driver->CreateShaderBindings();
+		driver->AddSsboToShaderBindings(
+			resources->m_perInstanceData,
+			"data",
+			sizeof(PerInstanceData),
+			numInstances,
+			0u);
+		driver->AddSsboToShaderBindings(
+			resources->m_perInstanceData,
+			"indices",
+			sizeof(uint32_t),
+			numAllocatedInstanceIndices,
+			1u);
+		resources->m_sizePerInstanceData = sizeof(PerInstanceData) * numInstances;
+		resources->m_sizeInstanceIndices =
+			sizeof(uint32_t) * numAllocatedInstanceIndices;
 	}
 
-	const size_t indirectBufferSize =
-		sizeof(RHI::DrawIndexedIndirectData) * indirectCommands.Num();
-	if (!m_indirectBuffers[0].IsValid() ||
-		m_indirectBuffers[0]->GetSize() < indirectBufferSize)
+	if (resources->m_indirectBuffers.IsEmpty())
 	{
-		constexpr size_t IndirectBufferSlack = 256;
-		m_indirectBuffers[0] = driver->CreateIndirectBuffer(
-			indirectBufferSize + IndirectBufferSlack);
+		resources->m_indirectBuffers.Resize(1u);
+	}
+	if (resources->m_cullingIndirectBufferBinding.IsEmpty())
+	{
+		resources->m_cullingIndirectBufferBinding.Resize(1u);
+		resources->m_cullingIndirectBufferBinding[0] = driver->CreateShaderBindings();
 	}
 
-	commands->UpdateBuffer(transferCommandList,
-		m_indirectBuffers[0],
-		indirectCommands.GetData(),
-		indirectBufferSize,
-		0);
+	bool bGpuCullingEnabled = bGpuCullingRequested;
+	if (bGpuCullingEnabled && !m_pComputeMeshCullingShader)
+	{
+		if (auto shaderInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr("Shaders/ComputeMeshCulling.shader"))
+		{
+			App::GetSubmodule<ShaderCompiler>()->LoadShader(
+				shaderInfo->GetFileId(),
+				m_pComputeMeshCullingShader,
+				{ "OCCLUSION_CULLING" });
+		}
+	}
 
-	const auto viewport = glm::ivec4(0,
-		colorAttachment->GetTarget()->GetExtent().y,
-		colorAttachment->GetTarget()->GetExtent().x,
-		-colorAttachment->GetTarget()->GetExtent().y);
-	const auto scissor = glm::uvec4(0,
+	RHIShaderPtr cullingShader;
+	if (bGpuCullingEnabled && m_pComputeMeshCullingShader && m_pComputeMeshCullingShader->IsReady())
+	{
+		auto depthHighZ = GetResolvedAttachment("depthHighZ").StaticCast<RHI::RHITexture>();
+		if (depthHighZ)
+		{
+			if (!resources->m_computeMeshCullingBindings ||
+				resources->m_cullingDepthHighZ != depthHighZ)
+			{
+				resources->m_computeMeshCullingBindings = driver->CreateShaderBindings();
+				driver->AddSamplerToShaderBindings(
+					resources->m_computeMeshCullingBindings,
+					"depthHighZ",
+					depthHighZ,
+					0u);
+				resources->m_cullingDepthHighZ = depthHighZ;
+			}
+#ifdef _DEBUG
+			cullingShader = m_pComputeMeshCullingShader->GetDebugComputeShaderRHI();
+#else
+			cullingShader = m_pComputeMeshCullingShader->GetComputeShaderRHI();
+#endif
+		}
+	}
+
+	const auto viewport = glm::ivec4(
 		0,
-		colorAttachment->GetTarget()->GetExtent().x,
-		colorAttachment->GetTarget()->GetExtent().y);
+		colorAttachment->GetExtent().y,
+		colorAttachment->GetExtent().x,
+		-colorAttachment->GetExtent().y);
+	const auto scissors = glm::uvec4(0, 0, colorAttachment->GetExtent().x, colorAttachment->GetExtent().y);
+	const auto collectShaderBindings = [&](
+		const RHIBatch& batch,
+		TVector<RHIShaderBindingSetPtr>& sets)
+		{
+			sets.Add(sceneView.m_frameBindings);
+			sets.Add(nodeLightsData);
+			sets.Add(resources->m_perInstanceData);
+			sets.Add(batch.GetMaterialBindings());
+			sets.Add(batch.m_textureBindings);
+			if (sceneView.m_boneMatrices)
+			{
+				sets.Add(sceneView.m_boneMatrices);
+			}
+		};
 
-	commands->BeginDebugRegion(commandList,
-		std::string(GetName()) + " QueueTag:" + queueTag + " BackToFront",
+	commands->BeginDebugRegion(
+		commandList,
+		std::string(GetName()) + " QueueTag:" + GetString("Tag") + " Packed",
 		DebugContext::Color_CmdGraphics);
-	commands->ImageMemoryBarrier(commandList,
-		colorAttachment->GetTarget(),
-		EImageLayout::ColorAttachmentOptimal);
-
-	const auto depthAttachmentLayout = RHI::IsDepthStencilFormat(depthAttachment->GetFormat()) ?
-		EImageLayout::DepthStencilAttachmentOptimal :
-		EImageLayout::DepthAttachmentOptimal;
-	commands->ImageMemoryBarrier(commandList,
+	commands->ImageMemoryBarrier(commandList, colorAttachment, EImageLayout::ColorAttachmentOptimal);
+	const auto depthLayout = RHI::IsDepthStencilFormat(depthAttachment->GetFormat()) ?
+		EImageLayout::DepthStencilAttachmentOptimal : EImageLayout::DepthAttachmentOptimal;
+	commands->ImageMemoryBarrier(commandList, depthAttachment, depthLayout);
+	auto& renderPassColorAttachments =
+		resources->m_renderPassColorAttachments;
+	renderPassColorAttachments.Clear(false);
+	renderPassColorAttachments.Add(colorAttachment);
+	commands->BeginRenderPass(
+		commandList,
+		renderPassColorAttachments,
 		depthAttachment,
-		depthAttachmentLayout);
-
-	commands->BeginRenderPass(commandList,
-		TVector<RHI::RHISurfacePtr>{ colorAttachment },
-		depthAttachment,
-		glm::vec4(0,
-			0,
-			colorAttachment->GetTarget()->GetExtent().x,
-			colorAttachment->GetTarget()->GetExtent().y),
+		glm::vec4(0, 0, colorAttachment->GetExtent().x, colorAttachment->GetExtent().y),
 		glm::ivec2(0, 0),
 		false,
 		glm::vec4(0.0f),
 		0.0f,
 		true);
 
-#if defined(_WIN32)
-	constexpr uint32_t MaxMeshesPerIndirectBatch = 16384u;
-#else
-	constexpr uint32_t MaxMeshesPerIndirectBatch = 128u;
-#endif
-
-	uint32_t runBegin = 0;
-	while (runBegin < m_orderedDrawItems.Num())
+	auto& cullingBindings = resources->m_cullingDispatchBindings;
+	cullingBindings.Clear(false);
+	if (cullingShader)
 	{
-		const OrderedDrawItem& firstItem = m_orderedDrawItems[runBegin];
-		uint32_t runLimit = (std::max)(1u,
-			(std::min)(MaxMeshesPerIndirectBatch,
-				firstItem.m_batch.m_supportedMeshesPerBatch));
-		uint32_t runEnd = runBegin + 1u;
-		while (runEnd < m_orderedDrawItems.Num())
-		{
-			const OrderedDrawItem& nextItem = m_orderedDrawItems[runEnd];
-			if (!(firstItem.m_batch == nextItem.m_batch))
-			{
-				break;
-			}
-
-			const uint32_t nextLimit = (std::max)(1u,
-				(std::min)(MaxMeshesPerIndirectBatch,
-					nextItem.m_batch.m_supportedMeshesPerBatch));
-			runLimit = (std::min)(runLimit, nextLimit);
-			if (runEnd - runBegin >= runLimit)
-			{
-				break;
-			}
-
-			runEnd++;
-		}
-
-		const RHIBatch& batch = firstItem.m_batch;
-		TVector<RHIShaderBindingSetPtr> shaderBindings({
-			sceneView.m_frameBindings,
-			sceneView.m_rhiLightsData,
-			m_perInstanceData,
-			batch.m_material->GetBindings(),
-			batch.m_textureBindings });
-		if (sceneView.m_boneMatrices)
-		{
-			shaderBindings.Add(sceneView.m_boneMatrices);
-		}
-
-		commands->BindMaterial(commandList, batch.m_material);
-		commands->SetViewport(commandList,
-			(float)viewport.x,
-			(float)viewport.y,
-			(float)viewport.z,
-			(float)viewport.w,
-			glm::vec2(scissor.x, scissor.y),
-			glm::vec2(scissor.z, scissor.w),
-			0.0f,
-			1.0f);
-		commands->BindShaderBindings(commandList,
-			batch.m_material,
-			shaderBindings);
-		commands->BindVertexBuffer(commandList,
-			batch.m_mesh->m_vertexBuffer,
-			0);
-		commands->BindIndexBuffer(commandList,
-			batch.m_mesh->m_indexBuffer,
-			0);
-
-		const uint32_t runSize = runEnd - runBegin;
-		commands->DrawIndexedIndirect(commandList,
-			m_indirectBuffers[0],
-			sizeof(RHI::DrawIndexedIndirectData) * runBegin,
-			runSize,
-			sizeof(RHI::DrawIndexedIndirectData));
-		m_drawCallStats.m_numBatches++;
-		m_drawCallStats.m_numInstances += runSize;
-
-		runBegin = runEnd;
+		cullingBindings = {
+			resources->m_computeMeshCullingBindings,
+			resources->m_perInstanceData,
+			resources->m_cullingIndirectBufferBinding[0],
+			sceneView.m_frameBindings };
 	}
+	m_drawCallStats = RHIRecordPackedDrawPacket(
+		resources->m_packet,
+		commandList,
+		transferCommandList,
+		collectShaderBindings,
+		resources->m_perInstanceData,
+		resources->m_indirectBuffers[0],
+		viewport,
+		scissors,
+		glm::vec2(0.0f, 1.0f),
+		cullingShader,
+		&resources->m_cullingIndirectBufferBinding[0],
+		cullingBindings);
 
 	commands->EndRenderPass(commandList);
 	commands->EndDebugRegion(commandList);
-}
-
-/*
-https://developer.nvidia.com/vulkan-shader-resource-binding
-*/
-void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
-{
-	SAILOR_PROFILE_FUNCTION();
-	m_drawCallStats = {};
-	m_syncSharedResources.Lock();
-
-	std::string temp;
-	TryGetString("GPUCulling", temp);
-	const bool bGpuCullingRequested = temp == "true";
-	bool bGpuCullingEnabled = bGpuCullingRequested;
-
-	const std::string QueueTag = GetString("Tag");
-
-	auto scheduler = App::GetSubmodule<Tasks::Scheduler>();
-	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
-	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
-
-	if (bGpuCullingEnabled)
-	{
-		if (!m_pComputeMeshCullingShader)
-		{
-			if (auto shaderInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr("Shaders/ComputeMeshCulling.shader"))
-			{
-				App::GetSubmodule<ShaderCompiler>()->LoadShader(shaderInfo->GetFileId(), m_pComputeMeshCullingShader, { "OCCLUSION_CULLING" });
-			}
-		}
-
-		bGpuCullingEnabled = m_pComputeMeshCullingShader && m_pComputeMeshCullingShader->IsReady();
-
-		RHI::RHITexturePtr depthHighZ;
-		if (bGpuCullingEnabled)
-		{
-			depthHighZ = GetResolvedAttachment("depthHighZ").StaticCast<RHI::RHITexture>();
-			bGpuCullingEnabled = depthHighZ.IsValid();
-		}
-
-		if (bGpuCullingEnabled && !m_computeMeshCullingBindings.IsValid())
-		{
-			m_computeMeshCullingBindings = driver->CreateShaderBindings();
-			driver->AddSamplerToShaderBindings(m_computeMeshCullingBindings, "depthHighZ", depthHighZ, 0);
-		}
-	}
-
-	RHI::RHITexturePtr transmissionFramebuffer =
-		GetResolvedAttachment("transmissionFramebuffer");
-	if (transmissionFramebuffer)
-	{
-		auto rhiLightsData = sceneView.m_rhiLightsData;
-		constexpr const char* transmissionSamplerName =
-			"g_transmissionFramebufferSampler";
-		RHI::RHIShaderBindingPtr& transmissionBinding =
-			rhiLightsData->GetOrAddShaderBinding(
-				transmissionSamplerName);
-		if (transmissionBinding->GetTextureBinding() !=
-			transmissionFramebuffer)
-		{
-			driver->AddSamplerToShaderBindings(
-				rhiLightsData,
-				transmissionSamplerName,
-				transmissionFramebuffer,
-				10);
-			rhiLightsData->RecalculateCompatibility();
-		}
-	}
-
-	if (m_numMeshes == 0)
-	{
-		m_syncSharedResources.Unlock();
-		return;
-	}
-
-	if (transmissionFramebuffer)
-	{
-		commands->ImageMemoryBarrier(
-			commandList,
-			transmissionFramebuffer,
-			RHI::EImageLayout::ShaderReadOnlyOptimal);
-	}
-
-	if (!m_perInstanceData || m_sizePerInstanceData < sizeof(RenderSceneNode::PerInstanceData) * m_numMeshes)
-	{
-		SAILOR_PROFILE_SCOPE("Create storage for matrices");
-
-		m_perInstanceData = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
-		Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_perInstanceData, "data", sizeof(RenderSceneNode::PerInstanceData), m_numMeshes, 0);
-		m_sizePerInstanceData = sizeof(RenderSceneNode::PerInstanceData) * m_numMeshes;
-	}
-
-	RHI::RHIShaderBindingPtr storageBinding = m_perInstanceData->GetOrAddShaderBinding("data");
-	if (GetSortingOrder() == RHI::ESortingOrder::BackToFront)
-	{
-		ProcessBackToFront(frameGraph,
-			transferCommandList,
-			commandList,
-			sceneView,
-			storageBinding,
-			QueueTag);
-		m_syncSharedResources.Unlock();
-		return;
-	}
-
-	{
-		SAILOR_PROFILE_SCOPE("Prepare command list");
-		TVector<PerInstanceData> gpuMatricesData;
-		gpuMatricesData.AddDefault(m_numMeshes);
-
-		RHI::RHISurfacePtr colorAttachment = GetRHIResource("color").DynamicCast<RHI::RHISurface>();
-		RHI::RHITexturePtr depthAttachment = GetRHIResource("depthStencil").DynamicCast<RHI::RHITexture>();
-		if (!depthAttachment)
-		{
-			depthAttachment = frameGraph->GetRenderTarget("DepthBuffer");
-		}
-
-		if (!colorAttachment)
-		{
-			m_syncSharedResources.Unlock();
-			return;
-		}
-
-		const auto viewport = glm::ivec4(0, colorAttachment->GetTarget()->GetExtent().y, colorAttachment->GetTarget()->GetExtent().x, -colorAttachment->GetTarget()->GetExtent().y);
-		const auto scissor = glm::uvec4(0, 0, colorAttachment->GetTarget()->GetExtent().x, colorAttachment->GetTarget()->GetExtent().y);
-
-		RHI::RHIShaderPtr cullingComputeShader;
-		if (bGpuCullingEnabled)
-		{
-#ifdef _DEBUG
-			cullingComputeShader = m_pComputeMeshCullingShader->GetDebugComputeShaderRHI();
-#else
-			cullingComputeShader = m_pComputeMeshCullingShader->GetComputeShaderRHI();
-#endif
-			bGpuCullingEnabled = cullingComputeShader.IsValid();
-		}
-
-		const size_t numThreads = scheduler->GetNumRHIThreads() + 1;
-		const size_t materialsPerThread = (m_batches.Num()) / numThreads;
-
-		if (m_indirectBuffers.Num() < numThreads)
-		{
-			m_indirectBuffers.Resize(numThreads);
-			m_cullingIndirectBufferBinding.Resize(numThreads);
-
-			for (uint32_t i = 0; i < numThreads; i++)
-			{
-				m_cullingIndirectBufferBinding[i] = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
-			}
-		}
-		if (bGpuCullingEnabled)
-		{
-			bGpuCullingEnabled =
-				m_computeMeshCullingBindings.IsValid() && m_computeMeshCullingBindings->IsReady() &&
-				m_perInstanceData.IsValid() && m_perInstanceData->IsReady() &&
-				!m_cullingIndirectBufferBinding.IsEmpty() && m_cullingIndirectBufferBinding[0].IsValid() && m_cullingIndirectBufferBinding[0]->IsReady() &&
-				sceneView.m_frameBindings.IsValid() && sceneView.m_frameBindings->IsReady();
-		}
-
-		TVector<RHICommandListPtr> secondaryCommandLists(m_batches.Num() > numThreads ? (numThreads - 1) : 0);
-		TVector<RHI::DrawCallStats> secondaryDrawCallStats(secondaryCommandLists.Num());
-		TVector<Tasks::ITaskPtr> tasks;
-
-		auto vecBatches = m_batches.ToVector();
-		TVector<uint32_t> storageIndex(vecBatches.Num());
-		TMap<RHIBatch, TVector<RHIShaderBindingSetPtr>> shaderBindingsCache;
-
-		{
-			SAILOR_PROFILE_SCOPE("Calculate SSBO offsets");
-
-			size_t ssboIndex = 0;
-			for (uint32_t j = 0; j < vecBatches.Num(); j++)
-			{
-				bool bIsInited = false;
-				for (const auto& instancedDrawCall : m_drawCalls[vecBatches[j]])
-				{
-					auto& matrices = *instancedDrawCall.Second();
-
-					memcpy(&gpuMatricesData[ssboIndex], matrices.GetData(), sizeof(PerInstanceData) * matrices.Num());
-
-					if (!bIsInited)
-					{
-						storageIndex[j] = storageBinding->GetStorageInstanceIndex() + (uint32_t)ssboIndex;
-						bIsInited = true;
-					}
-					ssboIndex += matrices.Num();
-				}
-			}
-		}
-
-		{
-			SAILOR_PROFILE_SCOPE("Build shader bindings cache");
-
-			for (const auto& batch : vecBatches)
-			{
-				TVector<RHIShaderBindingSetPtr> sets({ sceneView.m_frameBindings, sceneView.m_rhiLightsData, m_perInstanceData, batch.m_material->GetBindings(), batch.m_textureBindings });
-				if (sceneView.m_boneMatrices)
-				{
-					sets.Add(sceneView.m_boneMatrices);
-				}
-
-				shaderBindingsCache.Insert(batch, std::move(sets));
-			}
-		}
-
-		auto shaderBindingsByMaterial = [&](const RHIBatch& batch)
-			{
-				if (shaderBindingsCache.ContainsKey(batch))
-				{
-					return shaderBindingsCache[batch];
-				}
-
-				TVector<RHIShaderBindingSetPtr> sets({ sceneView.m_frameBindings, sceneView.m_rhiLightsData, m_perInstanceData, batch.m_material->GetBindings(), batch.m_textureBindings });
-				if (sceneView.m_boneMatrices)
-				{
-					sets.Add(sceneView.m_boneMatrices);
-				}
-				return sets;
-			};
-
-		if (gpuMatricesData.Num() > 0)
-		{
-			SAILOR_PROFILE_SCOPE("Fill transfer command list with matrices data");
-			commands->UpdateShaderBinding(transferCommandList, storageBinding,
-				gpuMatricesData.GetData(),
-				sizeof(PerInstanceData) * gpuMatricesData.Num(),
-				0);
-		}
-
-		commands->BeginDebugRegion(commandList, std::string(GetName()) + " QueueTag:" + QueueTag, DebugContext::Color_CmdGraphics);
-		SpinLock transferCommandListLock;
-
-		for (uint32_t i = 0; i < secondaryCommandLists.Num(); i++)
-		{
-			SAILOR_PROFILE_SCOPE("Create secondary command list");
-
-			const uint32_t start = (uint32_t)materialsPerThread * i;
-			const uint32_t end = (uint32_t)materialsPerThread * (i + 1);
-
-			auto task = Tasks::CreateTask("Record draw calls in secondary command list",
-				[&, i = i, start = start, end = end, transferCommandList = transferCommandList]()
-				{
-					RHICommandListPtr cmdList = driver->CreateCommandList(true, RHI::ECommandListQueue::Graphics);
-					RHI::Renderer::GetDriver()->SetDebugName(cmdList, "Record draw calls in secondary command list");
-					commands->BeginSecondaryCommandList(cmdList, true, true);
-
-					const bool bCanDispatchCulling = bGpuCullingEnabled && cullingComputeShader.IsValid() &&
-				m_computeMeshCullingBindings.IsValid() && m_computeMeshCullingBindings->IsReady() &&
-				m_perInstanceData.IsValid() && m_perInstanceData->IsReady() &&
-				m_cullingIndirectBufferBinding[i + 1].IsValid() && m_cullingIndirectBufferBinding[i + 1]->IsReady() &&
-				sceneView.m_frameBindings.IsValid() && sceneView.m_frameBindings->IsReady();
-
-					if (bCanDispatchCulling)
-					{
-						secondaryDrawCallStats[i] = RHIRecordDrawCallGPUCulling(start,
-							end,
-							vecBatches,
-							cmdList, transferCommandList,
-							shaderBindingsByMaterial,
-							m_drawCalls,
-							storageIndex,
-							m_indirectBuffers[i + 1],
-							viewport,
-							scissor,
-							glm::vec2(0.0f, 1.0f),
-							cullingComputeShader, m_cullingIndirectBufferBinding[i + 1],
-							{ m_computeMeshCullingBindings , m_perInstanceData, m_cullingIndirectBufferBinding[i + 1], sceneView.m_frameBindings },
-							&transferCommandListLock);
-					}
-					else
-					{
-						secondaryDrawCallStats[i] = RHIRecordDrawCall(start,
-							end,
-							vecBatches,
-							cmdList, transferCommandList,
-							shaderBindingsByMaterial,
-							m_drawCalls,
-							storageIndex,
-							m_indirectBuffers[i + 1],
-							viewport,
-							scissor,
-							glm::vec2(0.0f, 1.0f),
-							&m_cullingIndirectBufferBinding[i + 1],
-							&transferCommandListLock);
-					}
-
-					commands->EndCommandList(cmdList);
-					secondaryCommandLists[i] = std::move(cmdList);
-				}, EThreadType::RHI);
-
-			task->Run();
-			tasks.Add(task);
-		}
-
-		commands->ImageMemoryBarrier(commandList, colorAttachment->GetTarget(), EImageLayout::ColorAttachmentOptimal);
-
-		const auto depthAttachmentLayout = RHI::IsDepthStencilFormat(depthAttachment->GetFormat()) ? EImageLayout::DepthStencilAttachmentOptimal : EImageLayout::DepthAttachmentOptimal;
-		commands->ImageMemoryBarrier(commandList, depthAttachment, depthAttachmentLayout);
-
-		if (m_batches.Num() > 0)
-		{
-			SAILOR_PROFILE_SCOPE("Record draw calls in primary command list");
-			commands->BeginRenderPass(commandList,
-				TVector<RHI::RHISurfacePtr>{ colorAttachment },
-				depthAttachment,
-				glm::vec4(0, 0, colorAttachment->GetTarget()->GetExtent().x, colorAttachment->GetTarget()->GetExtent().y),
-				glm::ivec2(0, 0),
-				false,
-				glm::vec4(0.0f),
-				0.0f,
-				true);
-
-			const bool bCanDispatchCulling = bGpuCullingEnabled && cullingComputeShader.IsValid() &&
-			m_computeMeshCullingBindings.IsValid() && m_computeMeshCullingBindings->IsReady() &&
-			m_perInstanceData.IsValid() && m_perInstanceData->IsReady() &&
-			m_cullingIndirectBufferBinding[0].IsValid() && m_cullingIndirectBufferBinding[0]->IsReady() &&
-			sceneView.m_frameBindings.IsValid() && sceneView.m_frameBindings->IsReady();
-
-			if (bCanDispatchCulling)
-			{
-				m_drawCallStats += RHIRecordDrawCallGPUCulling((uint32_t)secondaryCommandLists.Num() * (uint32_t)materialsPerThread,
-					(uint32_t)vecBatches.Num(),
-					vecBatches,
-					commandList, transferCommandList,
-					shaderBindingsByMaterial,
-					m_drawCalls,
-					storageIndex,
-					m_indirectBuffers[0],
-					viewport,
-					scissor,
-					glm::vec2(0.0f, 1.0f),
-					cullingComputeShader, m_cullingIndirectBufferBinding[0],
-					{ m_computeMeshCullingBindings , m_perInstanceData, m_cullingIndirectBufferBinding[0], sceneView.m_frameBindings },
-					&transferCommandListLock);
-			}
-			else
-			{
-				m_drawCallStats += RHIRecordDrawCall((uint32_t)secondaryCommandLists.Num() * (uint32_t)materialsPerThread,
-					(uint32_t)vecBatches.Num(),
-					vecBatches,
-					commandList, transferCommandList,
-					shaderBindingsByMaterial,
-					m_drawCalls,
-					storageIndex,
-					m_indirectBuffers[0],
-					viewport,
-					scissor,
-					glm::vec2(0.0f, 1.0f),
-					&m_cullingIndirectBufferBinding[0],
-					&transferCommandListLock);
-			}
-
-			commands->EndRenderPass(commandList);
-		}
-
-		{
-			SAILOR_PROFILE_SCOPE("Wait for secondary command lists");
-			for (auto& task : tasks)
-			{
-				task->Wait();
-			}
-
-			for (const RHI::DrawCallStats& drawCallStats : secondaryDrawCallStats)
-			{
-				m_drawCallStats += drawCallStats;
-			}
-		}
-
-		if (secondaryCommandLists.Num() > 0)
-		{
-			commands->RenderSecondaryCommandBuffers(commandList,
-				secondaryCommandLists,
-				TVector<RHI::RHISurfacePtr>{ colorAttachment },
-				depthAttachment,
-				glm::vec4(0, 0, colorAttachment->GetTarget()->GetExtent().x, colorAttachment->GetTarget()->GetExtent().y),
-				glm::ivec2(0, 0),
-				false,
-				glm::vec4(0.0f),
-				0.0f,
-				true);
-		}
-
-	}
-	commands->EndDebugRegion(commandList);
-
 	m_syncSharedResources.Unlock();
 }
 
 void RenderSceneNode::Clear()
 {
-	m_orderedDrawItems.Clear();
-	m_indirectBuffers.Clear();
-	m_perInstanceData.Clear();
 #if defined(__APPLE__)
 	m_textureBindingCache.Clear();
 #endif
+	m_packetPayloadCache.Clear();
+	m_pagedArenaCache.Clear();
 }

--- a/Runtime/FrameGraph/RenderSceneNode.h
+++ b/Runtime/FrameGraph/RenderSceneNode.h
@@ -3,6 +3,7 @@
 #include "Memory/RefPtr.hpp"
 #include "Engine/Object.h"
 #include "RHI/Types.h"
+#include "RHI/RenderSubmission.h"
 #include "FrameGraph/BaseFrameGraphNode.h"
 #include "FrameGraph/FrameGraphNode.h"
 #include "FrameGraph/RenderSceneTextureCache.h"
@@ -26,13 +27,17 @@ namespace Sailor::Framegraph
 			uint32_t padding = 0;
 			vec4 bakedVolumeScale = vec4(1.0f);
 
-			bool operator==(const PerInstanceData& rhs) const { return this->materialInstance == rhs.materialInstance && this->model == rhs.model; }
-
-			size_t GetHash() const
+			bool operator==(const PerInstanceData& rhs) const
 			{
-				hash<glm::mat4> p;
-				return p(model);
+				return model == rhs.model &&
+					sphereBounds == rhs.sphereBounds &&
+					materialInstance == rhs.materialInstance &&
+					skeletonOffset == rhs.skeletonOffset &&
+					bIsCulled == rhs.bIsCulled &&
+					padding == rhs.padding &&
+					bakedVolumeScale == rhs.bakedVolumeScale;
 			}
+
 		};
 
 		SAILOR_API static const char* GetName() { return m_name; }
@@ -53,32 +58,59 @@ namespace Sailor::Framegraph
 			size_t m_meshIndex = 0;
 		};
 
-		void ProcessBackToFront(RHI::RHIFrameGraphPtr frameGraph,
-			RHI::RHICommandListPtr transferCommandList,
-			RHI::RHICommandListPtr commandList,
-			const RHI::RHISceneViewSnapshot& sceneView,
-			const RHI::RHIShaderBindingPtr& storageBinding,
-			const std::string& queueTag);
+		class SubmissionResources final : public RHI::RHIFrameGraphSubmissionResource
+		{
+		public:
+			void ResetForSubmission() override
+			{
+				m_orderedDrawItems.Clear(false);
+				m_renderPassColorAttachments.Clear(false);
+				m_cullingDispatchBindings.Clear(false);
+				m_arenaRangeInstances.Clear(false);
+				m_arenaRangeStableKeys.Clear(false);
+				m_arenaRangeMaterialVersionRuns.Clear(false);
+			}
+
+			void InvalidateSubmission() override
+			{
+				ResetForSubmission();
+				m_packet.InvalidateUploadedState();
+			}
+
+			RHI::TPackedDrawPacket<PerInstanceData> m_packet;
+			TVector<OrderedDrawItem> m_orderedDrawItems;
+			TVector<RHI::RHIBufferPtr> m_indirectBuffers;
+			RHI::RHIShaderBindingSetPtr m_perInstanceData{};
+			size_t m_sizePerInstanceData = 0u;
+			size_t m_sizeInstanceIndices = 0u;
+			TVector<RHI::RHIShaderBindingSetPtr> m_cullingIndirectBufferBinding;
+			RHI::RHIShaderBindingSetPtr m_computeMeshCullingBindings{};
+			RHI::RHITexturePtr m_cullingDepthHighZ{};
+			RHI::RHIShaderBindingSetPtr m_nodeLightsBindings{};
+			RHI::RHIShaderBindingSetPtr m_nodeLightsSource{};
+			RHI::RHITexturePtr m_transmissionTexture{};
+			uint64_t m_nodeLightsSourceRevision = 0ull;
+			TVector<RHI::RHITexturePtr> m_renderPassColorAttachments{};
+			TVector<RHI::RHIShaderBindingSetPtr> m_cullingDispatchBindings{};
+			TVector<PerInstanceData> m_arenaRangeInstances{};
+			TVector<uint64_t> m_arenaRangeStableKeys{};
+			TVector<RHI::PackedDrawArenaMaterialRun> m_arenaRangeMaterialVersionRuns{};
+			std::array<TextureDependencyCollector,
+				RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				m_requestedPacketTextures{};
+		};
 
 		SAILOR_SHARED_API static const char* m_name;
 
-		uint32_t m_numMeshes = 0;
 		SpinLock m_syncSharedResources;
-		RHI::TDrawCalls<PerInstanceData> m_drawCalls;
-		TSet<RHI::RHIBatch> m_batches;
-		TVector<OrderedDrawItem> m_orderedDrawItems;
-		TVector<RHI::RHIBufferPtr> m_indirectBuffers;
-
-		RHI::RHIShaderBindingSetPtr m_perInstanceData;
-		size_t m_sizePerInstanceData = 0;
 
 		// Culling
-		TVector<RHI::RHIShaderBindingSetPtr> m_cullingIndirectBufferBinding;
 		ShaderSetPtr m_pComputeMeshCullingShader{};
-		RHI::RHIShaderBindingSetPtr m_computeMeshCullingBindings{};
 
 		// Shared cache across platforms; macOS relies on it most because of descriptor pressure.
 		TextureBindingCache m_textureBindingCache;
+		RHI::TPackedDrawPacketPayloadCache<PerInstanceData> m_packetPayloadCache;
+		RHI::TPackedDrawPagedArenaCache<PerInstanceData> m_pagedArenaCache;
 	};
 
 	template class TFrameGraphNode<RenderSceneNode>;

--- a/Runtime/FrameGraph/RenderSceneTextureCache.h
+++ b/Runtime/FrameGraph/RenderSceneTextureCache.h
@@ -5,23 +5,188 @@
 #include "Containers/Vector.h"
 #include "RHI/Types.h"
 
+#include <bitset>
+
 namespace Sailor::Framegraph
 {
+	class TextureDependencyCollector
+	{
+	public:
+		static constexpr size_t MaxTrackedTextures = 8192u;
+
+		void Reset()
+		{
+			m_seen.reset();
+			m_indices.Clear(false);
+			Insert(0u);
+			m_bSorted = true;
+		}
+
+		void Insert(uint32_t textureIndex)
+		{
+			if (textureIndex >= MaxTrackedTextures || m_seen.test(textureIndex))
+			{
+				return;
+			}
+			m_seen.set(textureIndex);
+			m_indices.Add(textureIndex);
+			m_bSorted = false;
+		}
+
+		const TVector<uint32_t>& GetIndices()
+		{
+			if (!m_bSorted)
+			{
+				m_indices.Sort();
+				m_bSorted = true;
+			}
+			return m_indices;
+		}
+
+	private:
+		std::bitset<MaxTrackedTextures> m_seen{};
+		TVector<uint32_t> m_indices{};
+		bool m_bSorted = true;
+	};
+
 	struct TextureBindingCacheKey
 	{
-		TVector<uint32_t> m_requestedTextures;
+		TextureBindingCacheKey() = default;
+		explicit TextureBindingCacheKey(const TSet<uint32_t>& lookupTextures) :
+			m_lookupTextures(&lookupTextures)
+		{
+		}
 
-		bool operator==(const TextureBindingCacheKey& rhs) const { return m_requestedTextures == rhs.m_requestedTextures; }
+		void Materialize()
+		{
+			if (!m_lookupTextures)
+			{
+				return;
+			}
+
+			m_requestedTextures.Clear(false);
+			m_requestedTextures.Reserve(GetNumRequestedTextures());
+			ForEachRequestedTexture([&](uint32_t textureIndex)
+				{
+					m_requestedTextures.Add(textureIndex);
+				});
+			m_requestedTextures.Sort();
+			m_lookupTextures = nullptr;
+		}
+
+		bool operator==(const TextureBindingCacheKey& rhs) const
+		{
+			if (GetNumRequestedTextures() != rhs.GetNumRequestedTextures())
+			{
+				return false;
+			}
+
+			bool bEqual = true;
+			ForEachRequestedTexture([&](uint32_t textureIndex)
+				{
+					bEqual = bEqual && rhs.ContainsRequestedTexture(textureIndex);
+				});
+			rhs.ForEachRequestedTexture([&](uint32_t textureIndex)
+				{
+					bEqual = bEqual && ContainsRequestedTexture(textureIndex);
+				});
+			return bEqual;
+		}
 
 		size_t GetHash() const
 		{
-			size_t hash = 0;
-			for (const uint32_t textureIndex : m_requestedTextures)
-			{
-				HashCombine(hash, textureIndex);
-			}
-			return hash;
+			uint64_t xorHash = 0ull;
+			uint64_t sumHash = 0ull;
+			ForEachRequestedTexture([&](uint32_t textureIndex)
+				{
+					uint64_t elementHash =
+						static_cast<uint64_t>(textureIndex) + 0x9e3779b97f4a7c15ull;
+					elementHash =
+						(elementHash ^ (elementHash >> 30u)) *
+						0xbf58476d1ce4e5b9ull;
+					elementHash =
+						(elementHash ^ (elementHash >> 27u)) *
+						0x94d049bb133111ebull;
+					elementHash ^= elementHash >> 31u;
+					xorHash ^= elementHash;
+					sumHash += elementHash;
+				});
+			size_t result = 1469598103934665603ull;
+			HashCombine(
+				result,
+				GetNumRequestedTextures(),
+				xorHash,
+				sumHash);
+			return result;
 		}
+
+		TVector<uint32_t> m_requestedTextures{};
+
+	private:
+		template<typename TCallback>
+		void ForEachRequestedTexture(TCallback&& callback) const
+		{
+			callback(0u);
+			if (m_lookupTextures)
+			{
+				for (uint32_t textureIndex : *m_lookupTextures)
+				{
+					if (textureIndex > 0u &&
+						textureIndex < TextureDependencyCollector::MaxTrackedTextures)
+					{
+						callback(textureIndex);
+					}
+				}
+				return;
+			}
+
+			for (uint32_t textureIndex : m_requestedTextures)
+			{
+				if (textureIndex > 0u &&
+					textureIndex < TextureDependencyCollector::MaxTrackedTextures)
+				{
+					callback(textureIndex);
+				}
+			}
+		}
+
+		size_t GetNumRequestedTextures() const
+		{
+			size_t result = 1u;
+			if (m_lookupTextures)
+			{
+				for (uint32_t textureIndex : *m_lookupTextures)
+				{
+					result += textureIndex > 0u &&
+						textureIndex < TextureDependencyCollector::MaxTrackedTextures;
+				}
+				return result;
+			}
+
+			for (uint32_t textureIndex : m_requestedTextures)
+			{
+				result += textureIndex > 0u &&
+					textureIndex < TextureDependencyCollector::MaxTrackedTextures;
+			}
+			return result;
+		}
+
+		bool ContainsRequestedTexture(uint32_t textureIndex) const
+		{
+			if (textureIndex == 0u)
+			{
+				return true;
+			}
+			if (textureIndex >= TextureDependencyCollector::MaxTrackedTextures)
+			{
+				return false;
+			}
+			return m_lookupTextures ?
+				m_lookupTextures->Contains(textureIndex) :
+				m_requestedTextures.Contains(textureIndex);
+		}
+
+		const TSet<uint32_t>* m_lookupTextures = nullptr;
 	};
 
 	struct TextureBindingCacheEntry
@@ -42,6 +207,12 @@ namespace Sailor::Framegraph::Details
 	static constexpr uint32_t MaxTextureSlotsPerBatch = 1024u;
 	static constexpr uint64_t MaxTextureBindingCacheUnusedFrames = 5u;
 
+	inline const TSet<uint32_t>& GetDefaultRequestedTextures()
+	{
+		static const TSet<uint32_t> DefaultRequestedTextures{ 0u };
+		return DefaultRequestedTextures;
+	}
+
 	SAILOR_API RHI::RHIShaderBindingSetPtr GetTextureBindingSet(
 		TextureBindingCache& cache,
 		const TSet<uint32_t>& requestedTextures,
@@ -61,4 +232,7 @@ namespace Sailor::Framegraph::Details
 		bool bHasCachedBindings,
 		const TVector<uint64_t>* cachedSlotRevisions = nullptr,
 		const TVector<uint64_t>* currentSlotRevisions = nullptr);
+
+	SAILOR_API uint64_t CalculateTextureDependencyRevision(
+		const TVector<uint32_t>& requestedTextures);
 }

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -65,20 +65,23 @@ RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddShadowMaterial(RHI::RHIVertexDesc
 }
 
 RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddCustomShadowMaterial(
-	const MaterialPtr& sourceMaterial,
+	const ShaderSetPtr& sourceShader,
+	const RHI::RHIMaterialPtr& sourceMaterial,
+	const RHI::RHIMaterialVersionPtr& sourceMaterialVersion,
 	RHI::RHIVertexDescriptionPtr vertexDescription,
 	RHI::EShadowType shadowType,
 	bool bMasked)
 {
-	if (!sourceMaterial || !sourceMaterial->GetShader())
+	if (!sourceShader || !sourceMaterial ||
+		!sourceMaterialVersion || !sourceMaterialVersion->GetBindings())
 	{
 		return nullptr;
 	}
 
 	auto shaderCompiler = App::GetSubmodule<ShaderCompiler>();
 	auto shaderAsset = shaderCompiler->LoadShaderAsset(
-		sourceMaterial->GetShader()->GetFileId()).Lock();
-	if (!shaderAsset || !shaderAsset->GetSupportedDefines().Contains("SHADOW_CASTER"))
+		sourceShader->GetFileId()).Lock();
+	if (!shaderAsset || !shaderAsset->GetSupportedDefines().Contains("PACKED_SHADOW_CASTER"))
 	{
 		return nullptr;
 	}
@@ -87,18 +90,17 @@ RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddCustomShadowMaterial(
 	HashCombine(cacheKey,
 		vertexDescription->GetVertexAttributeBits(),
 		static_cast<uint32_t>(shadowType),
-		bMasked,
-		sourceMaterial->GetContentRevision());
-	auto& material = m_customShadowMaterials[cacheKey];
-	if (material)
+		bMasked);
+	auto& entry = m_customShadowMaterials[cacheKey];
+	if (entry.m_sourceVersion == sourceMaterialVersion && entry.m_material)
 	{
-		return material;
+		return entry.m_material;
 	}
 
-	TVector<std::string> defines = sourceMaterial->GetShader()->GetDefines();
-	if (!defines.Contains("SHADOW_CASTER"))
+	TVector<std::string> defines = sourceShader->GetDefines();
+	if (!defines.Contains("PACKED_SHADOW_CASTER"))
 	{
-		defines.Add("SHADOW_CASTER");
+		defines.Add("PACKED_SHADOW_CASTER");
 	}
 	if (bMasked && shaderAsset->GetSupportedDefines().Contains("ALPHA_CUTOUT") &&
 		!defines.Contains("ALPHA_CUTOUT"))
@@ -112,7 +114,7 @@ RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddCustomShadowMaterial(
 
 	ShaderSetPtr shadowShader;
 	if (!shaderCompiler->LoadShader_Immediate(
-		sourceMaterial->GetShader()->GetFileId(),
+		sourceShader->GetFileId(),
 		shadowShader,
 		defines) || !shadowShader->IsReady())
 	{
@@ -130,12 +132,17 @@ RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddCustomShadowMaterial(
 		GetHash(std::string("Shadow")),
 		false,
 		EDepthCompare::GreaterOrEqual);
-	material = RHI::Renderer::GetDriver()->CreateMaterial(
+	auto material = RHI::Renderer::GetDriver()->CreateMaterial(
 		vertexDescription,
 		RHI::EPrimitiveTopology::TriangleList,
 		shadowState,
 		shadowShader,
-		sourceMaterial->GetShaderBindings());
+		sourceMaterialVersion->GetBindings());
+	if (material)
+	{
+		entry.m_sourceVersion = sourceMaterialVersion;
+		entry.m_material = material;
+	}
 	return material;
 }
 
@@ -143,9 +150,28 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 {
 	SAILOR_PROFILE_FUNCTION();
 	m_drawCallStats = {};
+	if (!sceneView.m_submissionContext)
+	{
+		return;
+	}
+	const uint64_t materialSubmissionId =
+		sceneView.m_submissionContext->GetSubmissionId();
+
+	auto submissionResources = sceneView.m_submissionContext->GetOrAddFrameGraphResources<SubmissionResources>(
+		this,
+		sceneView.m_cameraIndex,
+		0u);
+	auto& blurShaderBindings = submissionResources->m_blurShaderBindings;
+	auto& renderPassColorAttachments =
+		submissionResources->m_renderPassColorAttachments;
+	auto& blurDrawBindingSets = submissionResources->m_blurDrawBindingSets;
 
 	auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 	auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
+	std::string virtualizeInstancePayloadsSetting;
+	const bool bVirtualizeInstancePayloads =
+		!TryGetString("VirtualizeInstancePayloads", virtualizeInstancePayloadsSetting) ||
+		virtualizeInstancePayloadsSetting != "false";
 
 	if (!m_pBlurVerticalShader)
 	{
@@ -153,57 +179,34 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 		RenderState renderState{ false, false, 0.0f, false, ECullMode::Front, EBlendMode::None, EFillMode::Fill, 0, false };
 
 		auto shaderFileId = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr("Shaders/Blur.shader");
-		if (App::GetSubmodule<ShaderCompiler>()->LoadShader_Immediate(shaderFileId->GetFileId(), m_pBlurVerticalShader, { "VERTICAL", "EVSM" }))
-		{
-			m_pBlurVerticalMaterial = driver->CreateMaterial(vertexDescription, EPrimitiveTopology::TriangleList, renderState, m_pBlurVerticalShader, m_pBlurShaderBindings);
-		}
-
-		if (App::GetSubmodule<ShaderCompiler>()->LoadShader_Immediate(shaderFileId->GetFileId(), m_pBlurHorizontalShader, { "HORIZONTAL", "EVSM" }))
-		{
-			m_pBlurHorizontalMaterial = driver->CreateMaterial(vertexDescription, EPrimitiveTopology::TriangleList, renderState, m_pBlurHorizontalShader, m_pBlurShaderBindings);
-		}
+		const bool bVerticalReady = App::GetSubmodule<ShaderCompiler>()->LoadShader_Immediate(shaderFileId->GetFileId(), m_pBlurVerticalShader, { "VERTICAL", "EVSM" });
+		const bool bHorizontalReady = App::GetSubmodule<ShaderCompiler>()->LoadShader_Immediate(shaderFileId->GetFileId(), m_pBlurHorizontalShader, { "HORIZONTAL", "EVSM" });
 
 		m_pBlurShaderBindings = driver->CreateShaderBindings();
 		driver->FillShadersLayout(m_pBlurShaderBindings, { m_pBlurVerticalShader->GetDebugVertexShaderRHI(), m_pBlurVerticalShader->GetDebugFragmentShaderRHI() }, 1);
+		driver->AddBufferToShaderBindings(m_pBlurShaderBindings, "data", sizeof(glm::vec4) * 3, 0, RHI::EShaderBindingType::UniformBuffer);
 
-		RHIShaderBindingPtr blurDataBinding = driver->AddBufferToShaderBindings(m_pBlurShaderBindings, "data", sizeof(glm::vec4) * 3, 0, RHI::EShaderBindingType::UniformBuffer);
+		if (bVerticalReady)
+		{
+			m_pBlurVerticalMaterial = driver->CreateMaterial(vertexDescription, EPrimitiveTopology::TriangleList, renderState, m_pBlurVerticalShader, m_pBlurShaderBindings);
+		}
+		if (bHorizontalReady)
+		{
+			m_pBlurHorizontalMaterial = driver->CreateMaterial(vertexDescription, EPrimitiveTopology::TriangleList, renderState, m_pBlurHorizontalShader, m_pBlurShaderBindings);
+		}
+	}
+
+	if (!blurShaderBindings)
+	{
+		blurShaderBindings = driver->CreateShaderBindings();
+		driver->FillShadersLayout(blurShaderBindings, { m_pBlurVerticalShader->GetDebugVertexShaderRHI(), m_pBlurVerticalShader->GetDebugFragmentShaderRHI() }, 1);
+		RHIShaderBindingPtr initialBlurDataBinding = driver->AddBufferToShaderBindings(blurShaderBindings, "data", sizeof(glm::vec4) * 3, 0, RHI::EShaderBindingType::UniformBuffer);
 		const float defaultBlurRadius = 3.0f;
 		glm::vec4 blurData[] = { {defaultBlurRadius, 0, 0, 0}, {0,0,0,0}, {0,0,0,0} };
-		RHI::Renderer::GetDriverCommands()->UpdateShaderBinding(transferCommandList, blurDataBinding, &blurData, sizeof(glm::vec4) * 3);
+		RHI::Renderer::GetDriverCommands()->UpdateShaderBinding(transferCommandList, initialBlurDataBinding, &blurData, sizeof(glm::vec4) * 3);
 	}
 
-	RHIShaderBindingPtr blurDataBinding = m_pBlurShaderBindings->GetOrAddShaderBinding("data");
-	auto shaderBindingSet = sceneView.m_rhiLightsData;
-	if (shaderBindingSet &&
-		shaderBindingSet->HasBinding("shadowIndices") &&
-		!sceneView.m_shadowIndices.IsEmpty())
-	{
-		auto shadowIndices = shaderBindingSet->GetOrAddShaderBinding("shadowIndices");
-		if (shadowIndices && shadowIndices->IsBind())
-		{
-			commands->UpdateShaderBinding(
-				transferCommandList,
-				shadowIndices,
-				sceneView.m_shadowIndices.GetData(),
-				sceneView.m_shadowIndices.Num() * sizeof(uint32_t),
-				0);
-		}
-	}
-	if (shaderBindingSet &&
-		shaderBindingSet->HasBinding("shadowAtlasTiles") &&
-		!sceneView.m_shadowAtlasTiles.IsEmpty())
-	{
-		auto shadowAtlasTiles = shaderBindingSet->GetOrAddShaderBinding("shadowAtlasTiles");
-		if (shadowAtlasTiles && shadowAtlasTiles->IsBind())
-		{
-			commands->UpdateShaderBinding(
-				transferCommandList,
-				shadowAtlasTiles,
-				sceneView.m_shadowAtlasTiles.GetData(),
-				sceneView.m_shadowAtlasTiles.Num() * sizeof(uint32_t),
-				0);
-		}
-	}
+	RHIShaderBindingPtr blurDataBinding = blurShaderBindings->GetOrAddShaderBinding("data");
 
 	if (!sceneView.m_shadowMapsToBlit.IsEmpty())
 	{
@@ -280,57 +283,514 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 		return;
 	}
 
-	if (!shaderBindingSet || !shaderBindingSet->HasBinding("lightsMatrices"))
-	{
-		return;
-	}
-
-	// A scene/world switch replaces the lighting binding set. Always resolve the
-	// target from the current snapshot instead of retaining the previous world.
-	m_lightMatrices = shaderBindingSet->GetOrAddShaderBinding("lightsMatrices");
-	if (!m_lightMatrices || !m_lightMatrices->IsBind())
-	{
-		return;
-	}
-
 	commands->BeginDebugRegion(commandList, std::string(GetName()), DebugContext::Color_CmdGraphics);
 	{
 		const uint32_t NumShadowPasses = (uint32_t)sceneView.m_shadowMapsToUpdate.Num();
-
-		TVector<TDrawCalls<ShadowPrepassNode::PerInstanceData>> drawCalls(NumShadowPasses);
-		TVector<TSet<RHIBatch>> batches(NumShadowPasses);
-
-		uint32_t numMeshes = 0;
 		const size_t opaqueQueueTag = GetHash(std::string("Opaque"));
 		const size_t maskedQueueTag = GetHash(std::string("Masked"));
+		const size_t staticPayloadIndex =
+			RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
+				EMobilityType::Static);
+		const size_t stationaryPayloadIndex =
+			RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
+				EMobilityType::Stationary);
+		const bool bUsesPagedArenas = bVirtualizeInstancePayloads;
+		auto usesPagedArena = [&](size_t payloadIndex)
+			{
+				return bUsesPagedArenas &&
+					(payloadIndex == staticPayloadIndex ||
+						payloadIndex == stationaryPayloadIndex);
+			};
+		auto buildPayloadCacheSlot = [&](
+			uint64_t viewKey,
+			EShadowType shadowType,
+			EMobilityType mobility)
+			{
+				const size_t index =
+					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+				size_t cacheSlot = usesPagedArena(index) ?
+					1469598103934665603ull : viewKey;
+				if (usesPagedArena(index))
+				{
+					HashCombine(cacheSlot, static_cast<uint32_t>(shadowType), index);
+				}
+				else
+				{
+					HashCombine(cacheSlot, sceneView.m_cameraIndex, index);
+				}
+				return cacheSlot;
+			};
+		submissionResources->m_activeShadowViews.Clear(false);
+		submissionResources->m_activeShadowViews.Reserve(NumShadowPasses);
+		submissionResources->m_numActiveShadowViews = NumShadowPasses;
+		auto& shadowPayloadRevisions = submissionResources->m_shadowPayloadRevisions;
+		auto& bBuildShadowPayloads = submissionResources->m_buildShadowPayloads;
+		auto& bShadowPayloadComplete = submissionResources->m_shadowPayloadComplete;
+		auto& requestedPacketTextures =
+			submissionResources->m_requestedPacketTextures;
+		shadowPayloadRevisions.Clear(false);
+		bBuildShadowPayloads.Clear(false);
+		bShadowPayloadComplete.Clear(false);
+		shadowPayloadRevisions.Resize(NumShadowPasses);
+		bBuildShadowPayloads.Resize(NumShadowPasses);
+		bShadowPayloadComplete.Resize(NumShadowPasses);
+		for (uint32_t passIndex = 0u; passIndex < NumShadowPasses; ++passIndex)
+		{
+			for (auto& requestedTextures : requestedPacketTextures)
+			{
+				requestedTextures.Reset();
+			}
+			const auto& shadowPass = sceneView.m_shadowMapsToUpdate[passIndex];
+			size_t viewKey = 1469598103934665603ull;
+			HashCombine(
+				viewKey,
+				shadowPass.m_lighMatrixIndex,
+				static_cast<uint32_t>(shadowPass.m_shadowType));
+			auto& viewResources = submissionResources->m_shadowViewCache[viewKey];
+			if (!viewResources)
+			{
+				viewResources = TSharedPtr<SubmissionResources::ShadowViewResources>::Make();
+			}
+			viewResources->Begin(viewKey);
+			submissionResources->m_activeShadowViews.Add(viewResources);
+
+			std::array<uint32_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				numRelevantCasters{};
+			for (size_t index = 0u; index < shadowPayloadRevisions[passIndex].size(); ++index)
+			{
+				auto& revision = shadowPayloadRevisions[passIndex][index];
+				revision = 1469598103934665603ull;
+				HashCombine(
+					revision,
+					index,
+					shadowPass.m_lighMatrixIndex,
+					static_cast<uint32_t>(shadowPass.m_shadowType),
+					std::hash<glm::mat4>{}(shadowPass.m_lightMatrix),
+					std::hash<glm::vec3>{}(glm::vec3(sceneView.m_cameraTransform.m_position)));
+				bBuildShadowPayloads[passIndex][index] = true;
+				bShadowPayloadComplete[passIndex][index] = true;
+			}
+			if (bUsesPagedArenas)
+			{
+				for (const EMobilityType mobility :
+					{ EMobilityType::Static, EMobilityType::Stationary })
+				{
+					const size_t payloadIndex =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					auto& arenaRevision =
+						shadowPayloadRevisions[passIndex][payloadIndex];
+					arenaRevision = 1469598103934665603ull;
+					HashCombine(
+						arenaRevision,
+						payloadIndex,
+						static_cast<uint32_t>(shadowPass.m_shadowType),
+						sceneView.m_submissionContext->GetMaterialRevision(),
+						sceneView.GetMobilityRevision(mobility));
+				}
+			}
+
+			for (const auto& proxy : shadowPass.m_meshList)
+			{
+				const auto* source = proxy.GetSource();
+				if (!source || !proxy.m_resource)
+				{
+					continue;
+				}
+				const EMobilityType mobility = proxy.GetMobility();
+				const size_t payloadIndex =
+					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+				auto& revision = shadowPayloadRevisions[passIndex][payloadIndex];
+				++numRelevantCasters[payloadIndex];
+				if (!usesPagedArena(payloadIndex))
+				{
+					HashCombine(
+						revision,
+						proxy.m_handle.m_slot,
+						proxy.m_handle.m_generation,
+						proxy.m_resource->m_shadowRevision,
+						proxy.GetProducerKey(),
+						std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
+						proxy.GetSkeletonOffset());
+				}
+
+				for (const auto& shadowMesh : source->m_meshes)
+				{
+					if (shadowMesh.m_renderQueueTag != opaqueQueueTag &&
+						shadowMesh.m_renderQueueTag != maskedQueueTag)
+					{
+						continue;
+					}
+					if (!usesPagedArena(payloadIndex))
+					{
+						HashCombine(revision, proxy.ResolveMesh(shadowMesh, shadowPass.m_lightMatrix));
+					}
+#if defined(__APPLE__)
+					if (shadowMesh.m_renderQueueTag == maskedQueueTag ||
+						shadowMesh.m_customDepthMaterial)
+					{
+						for (uint32_t texture : shadowMesh.m_materialTextureSamplers)
+						{
+							requestedPacketTextures[payloadIndex].Insert(texture);
+						}
+					}
+#endif
+				}
+				const auto* topology = &proxy.m_resource->m_proxy;
+				for (const auto& group : topology->m_instancedGroups)
+				{
+					if (!group.m_bCastShadows)
+					{
+						continue;
+					}
+					for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+					{
+						const size_t renderQueueTag = meshIndex < group.m_renderQueueTags.Num() ?
+							group.m_renderQueueTags[meshIndex] : 0u;
+						if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
+						{
+							continue;
+						}
+						if (!usesPagedArena(payloadIndex))
+						{
+							HashCombine(
+								revision,
+								proxy.ResolveMesh(group.m_meshes[meshIndex], shadowPass.m_lightMatrix));
+						}
+#if defined(__APPLE__)
+						const bool bCustomDepth = meshIndex < group.m_materials.Num() &&
+							group.m_materials[meshIndex] &&
+							group.m_materials[meshIndex]->GetRenderState().IsRequiredCustomDepthShader();
+						if ((renderQueueTag == maskedQueueTag || bCustomDepth) &&
+							meshIndex < group.m_materialTextureSamplers.Num())
+						{
+							for (uint32_t texture : group.m_materialTextureSamplers[meshIndex])
+							{
+								requestedPacketTextures[payloadIndex].Insert(texture);
+							}
+						}
+#endif
+					}
+				}
+			}
+
+			for (size_t index = 0u; index < shadowPayloadRevisions[passIndex].size(); ++index)
+			{
+				if (!usesPagedArena(index))
+				{
+					HashCombine(
+						shadowPayloadRevisions[passIndex][index],
+						numRelevantCasters[index],
+						Framegraph::Details::CalculateTextureDependencyRevision(
+							requestedPacketTextures[index].GetIndices()));
+				}
+			}
+			if (bVirtualizeInstancePayloads)
+			{
+				for (const EMobilityType mobility :
+					{ EMobilityType::Static, EMobilityType::Stationary })
+				{
+					const size_t index =
+						RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					const size_t cacheSlot = buildPayloadCacheSlot(
+						viewKey,
+						shadowPass.m_shadowType,
+						mobility);
+					auto payload = usesPagedArena(index) ?
+						m_pagedArenaCache.Find(
+							cacheSlot,
+							shadowPayloadRevisions[passIndex][index],
+							sceneView.m_frame) :
+						m_packetPayloadCache.Find(
+							cacheSlot,
+							shadowPayloadRevisions[passIndex][index],
+							sceneView.m_frame);
+					if (payload)
+					{
+						if (usesPagedArena(index))
+						{
+							viewResources->m_packet.UseSharedArenaPayload(
+								mobility,
+								std::move(payload));
+						}
+						else
+						{
+							viewResources->m_packet.UseSharedPayload(
+								mobility,
+								std::move(payload));
+						}
+						bBuildShadowPayloads[passIndex][index] = false;
+					}
+				}
+			}
+		}
+
 		Framegraph::Details::EvictTextureBindingCache(m_textureBindingCache, sceneView.m_frame);
+		m_packetPayloadCache.Evict(sceneView.m_frame);
 
 		SAILOR_PROFILE_SCOPE("Filter sceneView by tag");
 
 		for (uint32_t passIndex = 0; passIndex < sceneView.m_shadowMapsToUpdate.Num(); passIndex++)
 		{
 			const auto& shadowPass = sceneView.m_shadowMapsToUpdate[passIndex];
+			auto& viewResources =
+				*submissionResources->m_activeShadowViews[passIndex];
+			if (bUsesPagedArenas)
+			{
+				for (const EMobilityType mobility : {EMobilityType::Static, EMobilityType::Stationary})
+				{
+					const size_t arenaPayloadIndex = RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+					if (!bBuildShadowPayloads[passIndex][arenaPayloadIndex])
+					{
+						continue;
+					}
+					const size_t arenaCacheSlot =
+						buildPayloadCacheSlot(viewResources.m_viewKey, shadowPass.m_shadowType, mobility);
+					if (auto payload = m_pagedArenaCache.Find(
+							arenaCacheSlot, shadowPayloadRevisions[passIndex][arenaPayloadIndex], sceneView.m_frame))
+					{
+						viewResources.m_packet.UseSharedArenaPayload(mobility, std::move(payload));
+						bBuildShadowPayloads[passIndex][arenaPayloadIndex] = false;
+					}
+					else
+					{
+						m_pagedArenaCache.BeginUpdate(
+							arenaCacheSlot, shadowPayloadRevisions[passIndex][arenaPayloadIndex], sceneView.m_frame);
+						auto& rangeInstances = submissionResources->m_arenaRangeInstances;
+						auto& rangeStableKeys = submissionResources->m_arenaRangeStableKeys;
+						auto& rangeMaterialVersionRuns = submissionResources->m_arenaRangeMaterialVersionRuns;
+						sceneView.ForEachShadowCaster(mobility,
+							[&](const RHIVisibleShadowCaster& proxy)
+							{
+								const auto* source = proxy.GetSource();
+								if (!source || !proxy.m_resource)
+								{
+									return;
+								}
+								const uint64_t rangeKey =
+									BuildPackedDrawRangeKey(proxy.m_handle, proxy.GetProducerKey(), proxy.m_resource);
+								size_t rangeRevision = proxy.m_resource->m_shadowRevision;
+								HashCombine(rangeRevision, static_cast<uint32_t>(shadowPass.m_shadowType),
+									proxy.GetContentRevision(), std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
+									proxy.GetSkeletonOffset());
+								if (proxy.m_record)
+								{
+									HashCombine(rangeRevision, proxy.m_record->m_materialRevision,
+										proxy.m_record->m_shadowRevision, proxy.m_record->m_renderFlags);
+								}
+								for (const auto& shadowMesh : source->m_meshes)
+								{
+									if (shadowMesh.m_customDepthMaterial)
+									{
+										const auto materialVersion =
+											shadowMesh.m_customDepthMaterial->GetVersionForSubmission(
+												materialSubmissionId);
+										HashCombine(
+											rangeRevision, materialVersion ? materialVersion->GetVersionId() : 0ull);
+									}
+								}
+								for (const auto& group : proxy.m_resource->m_proxy.m_instancedGroups)
+								{
+									for (const auto& material : group.m_materials)
+									{
+										if (material && material->GetRenderState().IsRequiredCustomDepthShader())
+										{
+											const auto materialVersion =
+												material->GetVersionForSubmission(materialSubmissionId);
+											HashCombine(rangeRevision,
+												materialVersion ? materialVersion->GetVersionId() : 0ull);
+										}
+									}
+								}
+								if (m_pagedArenaCache.TryReuseRange(rangeKey, rangeRevision))
+								{
+									return;
+								}
+								rangeInstances.Clear(false);
+								rangeStableKeys.Clear(false);
+								rangeMaterialVersionRuns.Clear(false);
+
+								auto addArenaShadowInstance =
+									[&](const RHIMeshPtr& mesh, const glm::mat4& model, size_t renderQueueTag,
+										float baseColorAlpha, uint32_t baseColorSampler, float alphaCutoff,
+										const ShaderSetPtr& customDepthShader,
+										const RHIMaterialPtr& customDepthMaterial,
+										const RHIMaterialVersionPtr& customDepthMaterialVersion, uint64_t stableKey)
+								{
+									if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
+									{
+										return;
+									}
+									if (!mesh)
+									{
+										bShadowPayloadComplete[passIndex][arenaPayloadIndex] = false;
+										return;
+									}
+
+									const bool bSkinned =
+										proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
+										mesh->m_vertexDescription->HasAttribute(
+											RHIVertexDescription::DefaultBoneIdsBinding) &&
+										mesh->m_vertexDescription->HasAttribute(
+											RHIVertexDescription::DefaultBoneWeightsBinding);
+									const bool bMasked = renderQueueTag == maskedQueueTag;
+									auto depthMaterial = GetOrAddShadowMaterial(
+										mesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
+									if (customDepthMaterial)
+									{
+										if (auto customShadowMaterial = GetOrAddCustomShadowMaterial(customDepthShader,
+												customDepthMaterial, customDepthMaterialVersion,
+												mesh->m_vertexDescription, shadowPass.m_shadowType, bMasked))
+										{
+											depthMaterial = customShadowMaterial;
+										}
+									}
+									if (!depthMaterial || !depthMaterial->GetVertexShader() ||
+										!depthMaterial->GetFragmentShader())
+									{
+										bShadowPayloadComplete[passIndex][arenaPayloadIndex] = false;
+										return;
+									}
+
+									// Shadow materials are immutable derivatives of the exact source
+									// version resolved for this submission.
+									RHIBatch batch(depthMaterial, mesh);
+									const auto materialBindings = batch.GetMaterialBindings();
+									PerInstanceData data;
+									data.model = model;
+									data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+									data.materialInstance =
+										materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
+									data.skeletonOffset =
+										bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
+									data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+									data.baseColorAlpha = baseColorAlpha;
+									data.baseColorSampler = baseColorSampler;
+									data.alphaCutoff = alphaCutoff;
+									rangeInstances.Add(std::move(data));
+									rangeStableKeys.Add(stableKey);
+									AppendPackedDrawArenaMaterialVersion(
+										rangeMaterialVersionRuns, batch.m_materialVersion);
+								};
+
+								for (size_t shadowMeshIndex = 0u; shadowMeshIndex < source->m_meshes.Num();
+									++shadowMeshIndex)
+								{
+									const auto& shadowMesh = source->m_meshes[shadowMeshIndex];
+									addArenaShadowInstance(shadowMesh.m_mesh, proxy.ResolveMeshWorldMatrix(shadowMesh),
+										shadowMesh.m_renderQueueTag, shadowMesh.m_baseColorFactor.a,
+										shadowMesh.m_baseColorSampler, shadowMesh.m_alphaCutoff,
+										shadowMesh.m_customDepthShader, shadowMesh.m_customDepthMaterial,
+										shadowMesh.m_customDepthMaterial
+											? shadowMesh.m_customDepthMaterial->GetVersionForSubmission(
+												  materialSubmissionId)
+											: RHIMaterialVersionPtr{},
+										BuildPackedDrawStableKey(proxy.m_handle, proxy.GetProducerKey(), 0u,
+											static_cast<uint32_t>(shadowMeshIndex), 0u));
+								}
+
+								const auto& topology = proxy.m_resource->m_proxy;
+								for (size_t groupIndex = 0u; groupIndex < topology.m_instancedGroups.Num();
+									++groupIndex)
+								{
+									const auto& group = topology.m_instancedGroups[groupIndex];
+									if (!group.m_bCastShadows)
+									{
+										continue;
+									}
+									for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+									{
+										const size_t renderQueueTag = meshIndex < group.m_renderQueueTags.Num()
+											? group.m_renderQueueTags[meshIndex]
+											: 0u;
+										ShaderSetPtr customDepthShader;
+										RHIMaterialPtr customDepthMaterial;
+										if (meshIndex < group.m_sourceMaterialShaders.Num() &&
+											group.m_sourceMaterialShaders[meshIndex] &&
+											meshIndex < group.m_materials.Num() && group.m_materials[meshIndex] &&
+											group.m_materials[meshIndex]
+												->GetRenderState()
+												.IsRequiredCustomDepthShader())
+										{
+											customDepthShader = group.m_sourceMaterialShaders[meshIndex];
+											customDepthMaterial = group.m_materials[meshIndex];
+										}
+										for (size_t instanceIndex = 0u;
+											instanceIndex < group.m_instanceTransforms.Num(); ++instanceIndex)
+										{
+											addArenaShadowInstance(group.m_meshes[meshIndex],
+												proxy.ResolveInstancedMeshWorldMatrix(group, instanceIndex, meshIndex),
+												renderQueueTag,
+												meshIndex < group.m_baseColorFactors.Num()
+													? group.m_baseColorFactors[meshIndex].a
+													: 1.0f,
+												meshIndex < group.m_baseColorSamplers.Num()
+													? group.m_baseColorSamplers[meshIndex]
+													: 0u,
+												meshIndex < group.m_alphaCutoffs.Num() ? group.m_alphaCutoffs[meshIndex]
+																					   : 0.5f,
+												customDepthShader, customDepthMaterial,
+												customDepthMaterial
+													? customDepthMaterial->GetVersionForSubmission(materialSubmissionId)
+													: RHIMaterialVersionPtr{},
+												BuildPackedDrawStableKey(proxy.m_handle, proxy.GetProducerKey(),
+													static_cast<uint32_t>(groupIndex + 1u),
+													static_cast<uint32_t>(meshIndex),
+													static_cast<uint32_t>(instanceIndex)));
+										}
+									}
+								}
+								if (!m_pagedArenaCache.ReplaceRange(rangeKey, rangeRevision, rangeInstances,
+										rangeStableKeys, &rangeMaterialVersionRuns))
+								{
+									bShadowPayloadComplete[passIndex][arenaPayloadIndex] = false;
+								}
+							});
+
+						auto arenaPayload =
+							m_pagedArenaCache.EndUpdate(bShadowPayloadComplete[passIndex][arenaPayloadIndex]);
+						viewResources.m_packet.UseSharedArenaPayload(mobility, std::move(arenaPayload));
+						rangeInstances.Clear(false);
+						rangeStableKeys.Clear(false);
+						rangeMaterialVersionRuns.Clear(false);
+						bBuildShadowPayloads[passIndex][arenaPayloadIndex] = false;
+					}
+				}
+			}
 			for (const auto& proxy : shadowPass.m_meshList)
 			{
-				if (!proxy)
+				const auto* source = proxy.GetSource();
+				if (!source)
+				{
+					continue;
+				}
+				const EMobilityType payloadMobility = proxy.GetMobility();
+				const size_t payloadIndex = RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(payloadMobility);
+				if (!bBuildShadowPayloads[passIndex][payloadIndex] && !usesPagedArena(payloadIndex))
 				{
 					continue;
 				}
 
-				for (const auto& shadowMesh : proxy->m_meshes)
+				for (size_t shadowMeshIndex = 0u; shadowMeshIndex < source->m_meshes.Num(); ++shadowMeshIndex)
 				{
-					if (!shadowMesh.m_mesh)
+					const auto& shadowMesh = source->m_meshes[shadowMeshIndex];
+					const auto mesh = proxy.ResolveMesh(shadowMesh, shadowPass.m_lightMatrix);
+					if (!mesh)
 					{
+						if (shadowMesh.m_renderQueueTag == opaqueQueueTag ||
+							shadowMesh.m_renderQueueTag == maskedQueueTag)
+						{
+							bShadowPayloadComplete[passIndex][payloadIndex] = false;
+						}
 						continue;
 					}
+					const glm::mat4 meshWorldMatrix = proxy.ResolveMeshWorldMatrix(shadowMesh);
 
 					if (shadowMesh.m_maxCameraDistance < (std::numeric_limits<float>::max)())
 					{
-						Math::AABB worldBounds = shadowMesh.m_mesh->m_bounds;
-						worldBounds.Apply(shadowMesh.m_worldMatrix);
+						Math::AABB worldBounds = mesh->m_bounds;
+						worldBounds.Apply(meshWorldMatrix);
 						const glm::vec3 cameraPosition(sceneView.m_cameraTransform.m_position);
-						const glm::vec3 closestPoint = glm::clamp(
-							cameraPosition, worldBounds.m_min, worldBounds.m_max);
+						const glm::vec3 closestPoint = glm::clamp(cameraPosition, worldBounds.m_min, worldBounds.m_max);
 						if (glm::distance(cameraPosition, closestPoint) > shadowMesh.m_maxCameraDistance)
 						{
 							continue;
@@ -342,171 +802,296 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 						continue;
 					}
 
-					const auto& mesh = shadowMesh.m_mesh;
-					const bool bSkinned =
-						proxy->m_skeletonOffset != (std::numeric_limits<uint32_t>::max)() &&
+					const bool bSkinned = proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
 						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
 						mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
 					const bool bMasked = renderQueueTag == maskedQueueTag;
-					auto depthMaterial = GetOrAddShadowMaterial(mesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
+					auto depthMaterial =
+						GetOrAddShadowMaterial(mesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
 					if (shadowMesh.m_customDepthMaterial)
 					{
-						auto customShadowMaterial = GetOrAddCustomShadowMaterial(
+						auto customShadowMaterial = GetOrAddCustomShadowMaterial(shadowMesh.m_customDepthShader,
 							shadowMesh.m_customDepthMaterial,
-							mesh->m_vertexDescription,
-							shadowPass.m_shadowType,
-							bMasked);
+							shadowMesh.m_customDepthMaterial->GetVersionForSubmission(materialSubmissionId),
+							mesh->m_vertexDescription, shadowPass.m_shadowType, bMasked);
 						if (customShadowMaterial)
 						{
 							depthMaterial = customShadowMaterial;
 						}
 					}
 
-					const bool bIsDepthMaterialReady = depthMaterial &&
-						depthMaterial->GetVertexShader() &&
-						depthMaterial->GetFragmentShader();
+					const bool bIsDepthMaterialReady =
+						depthMaterial && depthMaterial->GetVertexShader() && depthMaterial->GetFragmentShader();
 
 					if (!bIsDepthMaterialReady)
 					{
+						bShadowPayloadComplete[passIndex][payloadIndex] = false;
 						continue;
 					}
+					RHIBatch batch(depthMaterial, mesh);
 
 					ShadowPrepassNode::PerInstanceData data;
-					data.model = shadowMesh.m_worldMatrix;
+					data.model = meshWorldMatrix;
 					data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
-					data.materialInstance = shadowMesh.m_customDepthMaterial &&
-						shadowMesh.m_customDepthMaterial->GetShaderBindings() ?
-						shadowMesh.m_customDepthMaterial->GetShaderBindings()->GetStorageInstanceIndex("material") :
-						0u;
-					data.skeletonOffset = bSkinned ? proxy->m_skeletonOffset : (std::numeric_limits<uint32_t>::max)();
-					data.baseColorFactor = shadowMesh.m_baseColorFactor;
+					const auto materialBindings = batch.GetMaterialBindings();
+					data.materialInstance =
+						materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
+					data.skeletonOffset = bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
+					data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+					data.baseColorAlpha = shadowMesh.m_baseColorFactor.a;
 					data.baseColorSampler = shadowMesh.m_baseColorSampler;
 					data.alphaCutoff = shadowMesh.m_alphaCutoff;
 
-					RHIBatch batch(depthMaterial, mesh);
 					if (bMasked || depthMaterial->GetRenderState().IsRequiredCustomDepthShader())
 					{
 						uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
 #if defined(__APPLE__)
-						batch.m_textureBindings = Framegraph::Details::GetTextureBindingSet(
-							m_textureBindingCache,
-							shadowMesh.m_materialTextureSamplers,
-							sceneView.m_frame,
-							supportedMeshesPerBatch);
+						batch.m_textureBindings = Framegraph::Details::GetTextureBindingSet(m_textureBindingCache,
+							shadowMesh.m_materialTextureSamplers, sceneView.m_frame, supportedMeshesPerBatch);
 #else
 						batch.m_textureBindings = App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
 #endif
 						batch.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
 						if (!batch.m_textureBindings)
 						{
+							bShadowPayloadComplete[passIndex][payloadIndex] = false;
 							continue;
 						}
 					}
+					const uint64_t stableKey = BuildPackedDrawStableKey(
+						proxy.m_handle, proxy.GetProducerKey(), 0u, static_cast<uint32_t>(shadowMeshIndex), 0u);
+					if (usesPagedArena(payloadIndex))
+					{
+						if (!viewResources.m_packet.AddArenaView(std::move(batch), mesh,
+								BuildPackedDrawRangeKey(proxy.m_handle, proxy.GetProducerKey(), proxy.m_resource),
+								stableKey, payloadMobility))
+						{
+							bShadowPayloadComplete[passIndex][payloadIndex] = false;
+						}
+						continue;
+					}
 
-					drawCalls[passIndex][batch][mesh].Add(data);
-					batches[passIndex].Insert(batch);
-
-					numMeshes++;
+					viewResources.m_packet.Add(std::move(batch), mesh, data, stableKey, payloadMobility);
 				}
-			}
-		}
 
-		TVector<ShadowPrepassNode::PerInstanceData> gpuMatricesData(numMeshes);
-		TVector<TVector<RHIBatch>> passes(NumShadowPasses);
-		TVector<TVector<uint32_t>> passIndices(NumShadowPasses);
-		RHI::RHIShaderBindingPtr storageBinding;
-
-		if (numMeshes > 0)
-		{
-			if (!m_perInstanceData || m_sizePerInstanceData < sizeof(ShadowPrepassNode::PerInstanceData) * numMeshes)
-			{
-				SAILOR_PROFILE_SCOPE("Create storage for matrices");
-				m_perInstanceData = Sailor::RHI::Renderer::GetDriver()->CreateShaderBindings();
-				Sailor::RHI::Renderer::GetDriver()->AddSsboToShaderBindings(m_perInstanceData, "data", sizeof(ShadowPrepassNode::PerInstanceData), numMeshes, 0);
-				m_sizePerInstanceData = sizeof(ShadowPrepassNode::PerInstanceData) * numMeshes;
-			}
-
-			storageBinding = m_perInstanceData->GetOrAddShaderBinding("data");
-
-			{
-				SAILOR_PROFILE_SCOPE("Calculate SSBO offsets");
-				size_t ssboIndex = 0;
-				for (uint32_t i = 0; i < NumShadowPasses; i++)
+				const auto* topology = proxy.m_resource ? &proxy.m_resource->m_proxy : nullptr;
+				if (!topology)
 				{
-					auto vecBatches = batches[i].ToVector();
-					if (vecBatches.Num() == 0)
+					continue;
+				}
+
+				for (size_t groupIndex = 0u; groupIndex < topology->m_instancedGroups.Num(); ++groupIndex)
+				{
+					const auto& group = topology->m_instancedGroups[groupIndex];
+					if (!group.m_bCastShadows)
 					{
 						continue;
 					}
 
-					TVector<uint32_t> storageIndex(vecBatches.Num());
-					for (uint32_t j = 0; j < vecBatches.Num(); j++)
+					for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
 					{
-						bool bIsInited = false;
-						for (const auto& instancedDrawCall : drawCalls[i][vecBatches[j]])
+						const size_t renderQueueTag =
+							meshIndex < group.m_renderQueueTags.Num() ? group.m_renderQueueTags[meshIndex] : 0u;
+						if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
 						{
-							auto& matrices = *instancedDrawCall.Second();
+							continue;
+						}
 
-							memcpy(&gpuMatricesData[ssboIndex], matrices.GetData(), sizeof(ShadowPrepassNode::PerInstanceData) * matrices.Num());
+						const auto& sourceMesh = group.m_meshes[meshIndex];
+						if (!sourceMesh)
+						{
+							bShadowPayloadComplete[passIndex][payloadIndex] = false;
+							continue;
+						}
 
-							if (!bIsInited)
+						const bool bSkinned = proxy.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)() &&
+							sourceMesh->m_vertexDescription->HasAttribute(
+								RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
+							sourceMesh->m_vertexDescription->HasAttribute(
+								RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
+						const bool bMasked = renderQueueTag == maskedQueueTag;
+						auto depthMaterial = GetOrAddShadowMaterial(
+							sourceMesh->m_vertexDescription, shadowPass.m_shadowType, bSkinned, bMasked);
+
+						ShaderSetPtr customDepthShader;
+						RHIMaterialPtr customDepthMaterial;
+						if (meshIndex < group.m_sourceMaterialShaders.Num() &&
+							group.m_sourceMaterialShaders[meshIndex] && meshIndex < group.m_materials.Num() &&
+							group.m_materials[meshIndex] &&
+							group.m_materials[meshIndex]->GetRenderState().IsRequiredCustomDepthShader())
+						{
+							customDepthShader = group.m_sourceMaterialShaders[meshIndex];
+							customDepthMaterial = group.m_materials[meshIndex];
+							auto customShadowMaterial = GetOrAddCustomShadowMaterial(customDepthShader,
+								customDepthMaterial,
+								customDepthMaterial ? customDepthMaterial->GetVersionForSubmission(materialSubmissionId)
+													: RHIMaterialVersionPtr{},
+								sourceMesh->m_vertexDescription, shadowPass.m_shadowType, bMasked);
+							if (customShadowMaterial)
 							{
-								storageIndex[j] = storageBinding->GetStorageInstanceIndex() + (uint32_t)ssboIndex;
-								bIsInited = true;
+								depthMaterial = customShadowMaterial;
 							}
-							ssboIndex += matrices.Num();
+						}
+
+						const bool bIsDepthMaterialReady =
+							depthMaterial && depthMaterial->GetVertexShader() && depthMaterial->GetFragmentShader();
+						if (!bIsDepthMaterialReady)
+						{
+							bShadowPayloadComplete[passIndex][payloadIndex] = false;
+							continue;
+						}
+
+						RHIBatch batchTemplate(depthMaterial, sourceMesh);
+						const auto materialBindings = batchTemplate.GetMaterialBindings();
+						const uint32_t materialInstance =
+							materialBindings ? materialBindings->GetStorageInstanceIndex("material") : 0u;
+						if (bMasked || depthMaterial->GetRenderState().IsRequiredCustomDepthShader())
+						{
+							uint32_t supportedMeshesPerBatch = (std::numeric_limits<uint32_t>::max)();
+#if defined(__APPLE__)
+							const auto& requestedTextures = meshIndex < group.m_materialTextureSamplers.Num()
+								? group.m_materialTextureSamplers[meshIndex]
+								: Framegraph::Details::GetDefaultRequestedTextures();
+							batchTemplate.m_textureBindings = Framegraph::Details::GetTextureBindingSet(
+								m_textureBindingCache, requestedTextures, sceneView.m_frame, supportedMeshesPerBatch);
+#else
+							batchTemplate.m_textureBindings =
+								App::GetSubmodule<TextureImporter>()->GetTextureSamplersBindingSet();
+#endif
+							batchTemplate.m_supportedMeshesPerBatch = supportedMeshesPerBatch;
+							if (!batchTemplate.m_textureBindings)
+							{
+								bShadowPayloadComplete[passIndex][payloadIndex] = false;
+								continue;
+							}
+						}
+
+						const float baseColorAlpha = meshIndex < group.m_baseColorFactors.Num()
+							? group.m_baseColorFactors[meshIndex].a
+							: 1.0f;
+						const uint32_t baseColorSampler =
+							meshIndex < group.m_baseColorSamplers.Num() ? group.m_baseColorSamplers[meshIndex] : 0u;
+						const float alphaCutoff =
+							meshIndex < group.m_alphaCutoffs.Num() ? group.m_alphaCutoffs[meshIndex] : 0.5f;
+
+						for (size_t instanceIndex = 0u; instanceIndex < group.m_instanceTransforms.Num();
+							++instanceIndex)
+						{
+							if (!proxy.IsInstancedMeshWithinDistance(group, instanceIndex, meshIndex,
+									glm::vec3(sceneView.m_cameraTransform.m_position), group.m_maxShadowDistance))
+							{
+								continue;
+							}
+							const auto mesh =
+								proxy.ResolveInstancedMesh(group, instanceIndex, meshIndex, shadowPass.m_lightMatrix);
+							if (!mesh)
+							{
+								bShadowPayloadComplete[passIndex][payloadIndex] = false;
+								continue;
+							}
+							const uint64_t stableKey = BuildPackedDrawStableKey(proxy.m_handle, proxy.GetProducerKey(),
+								static_cast<uint32_t>(groupIndex + 1u), static_cast<uint32_t>(meshIndex),
+								static_cast<uint32_t>(instanceIndex));
+							const glm::mat4 meshWorldMatrix =
+								proxy.ResolveInstancedMeshWorldMatrix(group, instanceIndex, meshIndex);
+							RHIBatch batch = batchTemplate;
+							batch.m_mesh = mesh;
+							if (usesPagedArena(payloadIndex))
+							{
+								if (!viewResources.m_packet.AddArenaView(std::move(batch), mesh,
+										BuildPackedDrawRangeKey(
+											proxy.m_handle, proxy.GetProducerKey(), proxy.m_resource),
+										stableKey, payloadMobility))
+								{
+									bShadowPayloadComplete[passIndex][payloadIndex] = false;
+								}
+								continue;
+							}
+
+							ShadowPrepassNode::PerInstanceData data;
+							data.model = meshWorldMatrix;
+							data.sphereBounds = mesh->m_bounds.ToSphere().GetVec4();
+							data.materialInstance = materialInstance;
+							data.skeletonOffset =
+								bSkinned ? proxy.GetSkeletonOffset() : (std::numeric_limits<uint32_t>::max)();
+							data.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f);
+							data.baseColorAlpha = baseColorAlpha;
+							data.baseColorSampler = baseColorSampler;
+							data.alphaCutoff = alphaCutoff;
+
+							viewResources.m_packet.Add(std::move(batch), mesh, data, stableKey, payloadMobility);
 						}
 					}
-
-					passIndices[i] = std::move(storageIndex);
-					passes[i] = std::move(vecBatches);
 				}
 			}
-
-			SAILOR_PROFILE_SCOPE("Fill transfer command list with matrices data");
-			commands->UpdateShaderBinding(transferCommandList, storageBinding,
-				gpuMatricesData.GetData(),
-				sizeof(ShadowPrepassNode::PerInstanceData) * gpuMatricesData.Num(),
-				0);
-		}
-
-		if (m_indirectBuffers.Num() < NumShadowPasses)
-		{
-			m_indirectBuffers.Resize(NumShadowPasses);
-		}
-
-		auto shaderBindingsByMaterial = [&](const RHIBatch& batch)
+			auto& packet = submissionResources->m_activeShadowViews[passIndex]->m_packet;
+			packet.Finalize(false);
+			bool bPassPayloadComplete = true;
+			for (bool bPayloadComplete : bShadowPayloadComplete[passIndex])
 			{
-				TVector<RHIShaderBindingSetPtr> sets;
-				if (batch.m_material->GetRenderState().IsRequiredCustomDepthShader())
+				bPassPayloadComplete &= bPayloadComplete;
+			}
+			if (shadowPass.m_payloadCompletionToken)
+			{
+				shadowPass.m_payloadCompletionToken->Complete(
+					bPassPayloadComplete);
+			}
+			for (const EMobilityType mobility :
+				{ EMobilityType::Static, EMobilityType::Stationary })
+			{
+				const size_t index =
+					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
+				if (usesPagedArena(index))
 				{
-					sets = TVector<RHIShaderBindingSetPtr>({
-						sceneView.m_frameBindings,
-						sceneView.m_rhiLightsData,
-						m_perInstanceData,
-						batch.m_material->GetBindings(),
-						batch.m_textureBindings });
+					continue;
 				}
-				else
+				if (bVirtualizeInstancePayloads &&
+					bBuildShadowPayloads[passIndex][index] &&
+					bShadowPayloadComplete[passIndex][index])
 				{
-					sets = TVector<RHIShaderBindingSetPtr>({ sceneView.m_frameBindings, m_perInstanceData });
+					m_packetPayloadCache.Publish(
+						buildPayloadCacheSlot(
+							viewResources.m_viewKey,
+							shadowPass.m_shadowType,
+							mobility),
+						shadowPayloadRevisions[passIndex][index],
+						packet.SharePayload(mobility),
+						sceneView.m_frame);
 				}
-				if (batch.m_textureBindings)
-				{
-					if (!batch.m_material->GetRenderState().IsRequiredCustomDepthShader())
-					{
-						sets.Add(batch.m_textureBindings);
-					}
-				}
-				const bool bSkinned =
-					batch.m_mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding) &&
-					batch.m_mesh->m_vertexDescription->HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding);
-				if (bSkinned && sceneView.m_boneMatrices)
-				{
-					sets.Add(sceneView.m_boneMatrices);
-				}
-				return sets;
-			};
+			}
+		}
+		m_pagedArenaCache.Evict(sceneView.m_frame);
+
+		for (uint32_t passIndex = 0u; passIndex < NumShadowPasses; ++passIndex)
+		{
+			auto& viewResources = *submissionResources->m_activeShadowViews[passIndex];
+			const uint32_t numInstances = viewResources.m_packet.GetNumStorageInstances();
+			const uint32_t numInstanceIndices = viewResources.m_packet.GetNumDrawInstances();
+			if (numInstances == 0u || numInstanceIndices == 0u)
+			{
+				continue;
+			}
+			if (!viewResources.m_perInstanceData ||
+				viewResources.m_sizePerInstanceData < sizeof(PerInstanceData) * numInstances ||
+				viewResources.m_sizeInstanceIndices < sizeof(uint32_t) * numInstanceIndices)
+			{
+				viewResources.m_perInstanceData = driver->CreateShaderBindings();
+				driver->AddSsboToShaderBindings(
+					viewResources.m_perInstanceData,
+					"data",
+					sizeof(PerInstanceData),
+					numInstances,
+					0u);
+				driver->AddSsboToShaderBindings(
+					viewResources.m_perInstanceData,
+					"indices",
+					sizeof(uint32_t),
+					numInstanceIndices,
+					1u);
+				viewResources.m_sizePerInstanceData = sizeof(PerInstanceData) * numInstances;
+				viewResources.m_sizeInstanceIndices = sizeof(uint32_t) * numInstanceIndices;
+			}
+		}
 
 		auto fullscreenMesh = frameGraph->GetFullscreenNdcQuad();
 
@@ -545,8 +1130,10 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 					glm::vec4(1.0f, 1.0f, -1.0f, 1.0f) :
 					glm::vec4(0.0f);
 
+				renderPassColorAttachments.Clear(false);
+				renderPassColorAttachments.Add(shadowPass.m_shadowMap);
 				commands->BeginRenderPass(commandList,
-					TVector<RHI::RHITexturePtr>{ shadowPass.m_shadowMap },
+					renderPassColorAttachments,
 					depthAttachment,
 					glm::vec4(renderArea),
 					glm::ivec2(0, 0),
@@ -561,17 +1148,20 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 				}
 
 				RHI::RHIMaterialPtr pushConstantsMaterial;
-				if (passes[index].Num() > 0)
+				auto& currentViewResources = *submissionResources->m_activeShadowViews[index];
+				if (!currentViewResources.m_packet.GetGroups().IsEmpty())
 				{
-					pushConstantsMaterial = passes[index][0].m_material;
+					pushConstantsMaterial = currentViewResources.m_packet.GetGroups()[0].m_batch.m_material;
 				}
 				else
 				{
 					for (uint32_t dependencyPass : shadowPass.m_internalCommandsList)
 					{
-						if (passes[dependencyPass].Num() > 0)
+						if (dependencyPass < submissionResources->m_activeShadowViews.Num() &&
+							!submissionResources->m_activeShadowViews[dependencyPass]->m_packet.GetGroups().IsEmpty())
 						{
-							pushConstantsMaterial = passes[dependencyPass][0].m_material;
+							pushConstantsMaterial = submissionResources->m_activeShadowViews[dependencyPass]
+								->m_packet.GetGroups()[0].m_batch.m_material;
 							break;
 						}
 					}
@@ -582,32 +1172,71 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 					commands->PushConstants(commandList, pushConstantsMaterial, 64, &shadowPass.m_lightMatrix);
 				}
 
-				if (pushConstantsMaterial && passes[index].Num() > 0)
+				auto recordShadowPacket = [&](uint32_t packetIndex)
 				{
-					m_drawCallStats += RHIRecordDrawCall(0, (uint32_t)passes[index].Num(), passes[index], commandList, transferCommandList, shaderBindingsByMaterial, drawCalls[index], passIndices[index], m_indirectBuffers[index],
+					if (packetIndex >= submissionResources->m_activeShadowViews.Num())
+					{
+						return;
+					}
+					auto& viewResources = *submissionResources->m_activeShadowViews[packetIndex];
+					if (viewResources.m_packet.GetGroups().IsEmpty() || !viewResources.m_perInstanceData)
+					{
+						return;
+					}
+					const auto collectShaderBindingsByMaterial = [&](
+						const RHIBatch& batch,
+						TVector<RHIShaderBindingSetPtr>& sets)
+					{
+						if (batch.m_material->GetRenderState().IsRequiredCustomDepthShader())
+						{
+							sets.Add(sceneView.m_frameBindings);
+							sets.Add(sceneView.m_rhiLightsData);
+							sets.Add(viewResources.m_perInstanceData);
+							sets.Add(batch.GetMaterialBindings());
+							sets.Add(batch.m_textureBindings);
+						}
+						else
+						{
+							sets.Add(sceneView.m_frameBindings);
+							sets.Add(viewResources.m_perInstanceData);
+							if (batch.m_textureBindings)
+							{
+								sets.Add(batch.m_textureBindings);
+							}
+						}
+						const bool bSkinned =
+							batch.m_mesh->m_vertexDescription->HasAttribute(RHIVertexDescription::DefaultBoneIdsBinding) &&
+							batch.m_mesh->m_vertexDescription->HasAttribute(RHIVertexDescription::DefaultBoneWeightsBinding);
+						if (bSkinned && sceneView.m_boneMatrices)
+						{
+							sets.Add(sceneView.m_boneMatrices);
+						}
+					};
+
+					m_drawCallStats += RHIRecordPackedDrawPacket(
+						viewResources.m_packet,
+						commandList,
+						transferCommandList,
+						collectShaderBindingsByMaterial,
+						viewResources.m_perInstanceData,
+						viewResources.m_indirectBuffer,
 						glm::ivec4(renderArea.x, renderArea.y + renderArea.w, renderArea.z, -renderArea.w),
 						glm::uvec4(renderArea),
 						glm::vec2(0.0f, 1.0f));
-				}
+					viewResources.m_bUploadedThisSubmission = true;
+				};
 
+				if (pushConstantsMaterial)
+				{
+					recordShadowPacket(index);
+				}
 				for (uint32_t dependencyPass : shadowPass.m_internalCommandsList)
 				{
-					const uint32_t numBatches = (uint32_t)passes[dependencyPass].Num();
-
-					if (pushConstantsMaterial && numBatches > 0)
+					if (pushConstantsMaterial)
 					{
-						m_drawCallStats += RHIDrawCall(0, numBatches, passes[dependencyPass], commandList, shaderBindingsByMaterial,
-							drawCalls[dependencyPass], m_indirectBuffers[dependencyPass],
-							glm::ivec4(renderArea.x, renderArea.y + renderArea.w, renderArea.z, -renderArea.w),
-							glm::uvec4(renderArea),
-							glm::vec2(0.0f, 1.0f));
+						recordShadowPacket(dependencyPass);
 					}
 				}
-
-				commands->UpdateShaderBinding(transferCommandList, m_lightMatrices,
-					&shadowPass.m_lightMatrix,
-					sizeof(glm::mat4),
-					sizeof(glm::mat4) * shadowPass.m_lighMatrixIndex);
 
 				commands->EndRenderPass(commandList);
 
@@ -622,15 +1251,20 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 					// Blur Horizontal
 					commands->BeginDebugRegion(commandList, "Blur Horizontal", DebugContext::Color_CmdPostProcess);
 					{
-						RHITexturePtr sm = shadowPass.m_shadowMap;
-						RHIShaderBindingPtr blurSampler = driver->AddSamplerToShaderBindings(m_pBlurShaderBindings, "colorSampler", { sm }, 1);
-						m_pBlurShaderBindings->RecalculateCompatibility();
+						driver->AddSamplerToShaderBindings(
+							blurShaderBindings,
+							"colorSampler",
+							shadowPass.m_shadowMap,
+							1);
+						blurShaderBindings->RecalculateCompatibility();
 
 						commands->ImageMemoryBarrier(commandList, shadowPass.m_shadowMap, EImageLayout::ShaderReadOnlyOptimal);
 						commands->ImageMemoryBarrier(commandList, blurAttachment, EImageLayout::ColorAttachmentOptimal);
 
+						renderPassColorAttachments.Clear(false);
+						renderPassColorAttachments.Add(blurAttachment);
 						commands->BeginRenderPass(commandList,
-							TVector<RHI::RHITexturePtr>{blurAttachment},
+							renderPassColorAttachments,
 							nullptr,
 							glm::vec4(0, 0, shadowPass.m_shadowMap->GetExtent().x, shadowPass.m_shadowMap->GetExtent().y),
 							glm::ivec2(0, 0),
@@ -640,7 +1274,13 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 							false);
 
 						commands->BindMaterial(commandList, m_pBlurHorizontalMaterial);
-						commands->BindShaderBindings(commandList, m_pBlurHorizontalMaterial, { sceneView.m_frameBindings, m_pBlurShaderBindings });
+						blurDrawBindingSets.Clear(false);
+						blurDrawBindingSets.Add(sceneView.m_frameBindings);
+						blurDrawBindingSets.Add(blurShaderBindings);
+						commands->BindShaderBindings(
+							commandList,
+							m_pBlurHorizontalMaterial,
+							blurDrawBindingSets);
 
 						commands->SetViewport(commandList,
 							0, 0,
@@ -662,11 +1302,17 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 					// Blur Vertical
 					commands->BeginDebugRegion(commandList, "Blur Vertical", DebugContext::Color_CmdPostProcess);
 					{
-						RHIShaderBindingPtr blurSampler = driver->AddSamplerToShaderBindings(m_pBlurShaderBindings, "colorSampler", TVector<RHITexturePtr>{ blurAttachment }, 1);
-						m_pBlurShaderBindings->RecalculateCompatibility();
+						driver->AddSamplerToShaderBindings(
+							blurShaderBindings,
+							"colorSampler",
+							blurAttachment,
+							1);
+						blurShaderBindings->RecalculateCompatibility();
 
+						renderPassColorAttachments.Clear(false);
+						renderPassColorAttachments.Add(shadowPass.m_shadowMap);
 						commands->BeginRenderPass(commandList,
-							TVector<RHI::RHITexturePtr>{shadowPass.m_shadowMap},
+							renderPassColorAttachments,
 							nullptr,
 							glm::vec4(0, 0, shadowPass.m_shadowMap->GetExtent().x, shadowPass.m_shadowMap->GetExtent().y),
 							glm::ivec2(0, 0),
@@ -676,7 +1322,13 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 							false);
 
 						commands->BindMaterial(commandList, m_pBlurVerticalMaterial);
-						commands->BindShaderBindings(commandList, m_pBlurVerticalMaterial, { sceneView.m_frameBindings, m_pBlurShaderBindings });
+						blurDrawBindingSets.Clear(false);
+						blurDrawBindingSets.Add(sceneView.m_frameBindings);
+						blurDrawBindingSets.Add(blurShaderBindings);
+						commands->BindShaderBindings(
+							commandList,
+							m_pBlurVerticalMaterial,
+							blurDrawBindingSets);
 
 						commands->SetViewport(commandList,
 							0, 0,
@@ -712,8 +1364,6 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 
 void ShadowPrepassNode::Clear()
 {
-	m_lightMatrices.Clear();
-	m_perInstanceData.Clear();
 	m_shadowMaterials_Pcf.Clear();
 	m_shadowMaterials_Evsm.Clear();
 	m_skinnedShadowMaterials_Pcf.Clear();
@@ -724,6 +1374,8 @@ void ShadowPrepassNode::Clear()
 	m_skinnedMaskedShadowMaterials_Evsm.Clear();
 	m_customShadowMaterials.Clear();
 	m_textureBindingCache.Clear();
+	m_packetPayloadCache.Clear();
+	m_pagedArenaCache.Clear();
 }
 
 glm::mat4 ShadowPrepassNode::CalculateLightProjectionMatrix(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float zMult, glm::ivec2 shadowMapResolution, float zSourceExtension)
@@ -735,12 +1387,20 @@ glm::mat4 ShadowPrepassNode::CalculateLightProjectionMatrix(const glm::mat4& lig
 	return cameraFrustum.CalculateOrthoMatrixByView(lightView, zMult, shadowMapResolution, zSourceExtension);
 }
 
-TVector<glm::mat4> ShadowPrepassNode::CalculateLightProjectionForCascades(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float cameraNearPlane, float cameraFarPlane)
+void ShadowPrepassNode::CalculateLightProjectionForCascades(
+	const glm::mat4& lightView,
+	const glm::mat4& cameraWorld,
+	float aspect,
+	float fovY,
+	float cameraNearPlane,
+	float cameraFarPlane,
+	TVector<glm::mat4>& outMatrices)
 {
 	SAILOR_PROFILE_FUNCTION();
 	const float shadowFarPlane = (std::min)(cameraFarPlane, LightingECS::ShadowMaxDistance);
 
-	TVector<glm::mat4> ret;
+	outMatrices.Clear(false);
+	outMatrices.Reserve(LightingECS::NumCascades);
 	for (uint32_t i = 0; i < LightingECS::NumCascades; ++i)
 	{
 		const float cascadeFar = shadowFarPlane * LightingECS::ShadowCascadeLevels[i];
@@ -754,13 +1414,11 @@ TVector<glm::mat4> ShadowPrepassNode::CalculateLightProjectionForCascades(const 
 			cascadeNear = (std::max)(cameraNearPlane, previousSplit - overlap);
 		}
 
-		ret.Add(CalculateLightProjectionMatrix(lightView, cameraWorld, aspect, fovY,
+		outMatrices.Add(CalculateLightProjectionMatrix(lightView, cameraWorld, aspect, fovY,
 			cascadeNear,
 			cascadeFar,
 			10.0f,
 			LightingECS::ShadowCascadeResolutions[i],
 			LightingECS::ShadowCasterDepthExtension));
 	}
-
-	return ret;
 }

--- a/Runtime/FrameGraph/ShadowPrepassNode.h
+++ b/Runtime/FrameGraph/ShadowPrepassNode.h
@@ -3,6 +3,8 @@
 #include "Memory/RefPtr.hpp"
 #include "Engine/Object.h"
 #include "RHI/Types.h"
+#include "RHI/RenderSubmission.h"
+#include "RHI/Batch.hpp"
 #include "FrameGraph/BaseFrameGraphNode.h"
 #include "FrameGraph/FrameGraphNode.h"
 #include "FrameGraph/RenderSceneTextureCache.h"
@@ -22,27 +24,26 @@ namespace Sailor
 			uint32_t bIsCulled = 0;
 			uint32_t padding = 0;
 			glm::vec4 bakedVolumeScale{ 1.0f };
-			glm::vec4 baseColorFactor{ 1.0f };
+			float baseColorAlpha = 1.0f;
 			uint32_t baseColorSampler = 0;
 			float alphaCutoff = 0.5f;
 			uint32_t maskedPadding = 0;
-			uint32_t stridePadding = 0;
 
 			bool operator==(const PerInstanceData& rhs) const
 			{
 				return model == rhs.model &&
+					sphereBounds == rhs.sphereBounds &&
 					materialInstance == rhs.materialInstance &&
-					baseColorFactor == rhs.baseColorFactor &&
 					skeletonOffset == rhs.skeletonOffset &&
+					bIsCulled == rhs.bIsCulled &&
+					padding == rhs.padding &&
+					bakedVolumeScale == rhs.bakedVolumeScale &&
+					baseColorAlpha == rhs.baseColorAlpha &&
 					baseColorSampler == rhs.baseColorSampler &&
-					alphaCutoff == rhs.alphaCutoff;
+					alphaCutoff == rhs.alphaCutoff &&
+					maskedPadding == rhs.maskedPadding;
 			}
 
-			size_t GetHash() const
-			{
-				hash<glm::mat4> p;
-				return p(model);
-			}
 		};
 
 		SAILOR_API static const char* GetName() { return m_name; }
@@ -50,10 +51,89 @@ namespace Sailor
 		SAILOR_API virtual void Process(RHI::RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandLists, const RHI::RHISceneViewSnapshot& sceneView) override;
 		SAILOR_API virtual void Clear() override;
 
-		SAILOR_API static TVector<glm::mat4> CalculateLightProjectionForCascades(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float cameraNearPlane, float cameraFarPlane);
+		SAILOR_API static void CalculateLightProjectionForCascades(
+			const glm::mat4& lightView,
+			const glm::mat4& cameraWorld,
+			float aspect,
+			float fovY,
+			float cameraNearPlane,
+			float cameraFarPlane,
+			TVector<glm::mat4>& outMatrices);
 		SAILOR_API static glm::mat4 CalculateLightProjectionMatrix(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float zMult, glm::ivec2 shadowMapResolution = glm::ivec2(0), float zSourceExtension = 0.0f);
 
 	protected:
+		class SubmissionResources final : public RHI::RHIFrameGraphSubmissionResource
+		{
+		public:
+			struct ShadowViewResources
+			{
+				uint64_t m_viewKey = 0ull;
+				RHI::TPackedDrawPacket<PerInstanceData> m_packet{};
+				size_t m_sizePerInstanceData = 0u;
+				size_t m_sizeInstanceIndices = 0u;
+				RHI::RHIShaderBindingSetPtr m_perInstanceData{};
+				RHI::RHIBufferPtr m_indirectBuffer{};
+				bool m_bUploadedThisSubmission = false;
+
+				void Begin(uint64_t viewKey)
+				{
+					if (m_viewKey != viewKey)
+					{
+						*this = {};
+						m_viewKey = viewKey;
+					}
+					m_packet.Reset();
+					m_bUploadedThisSubmission = false;
+				}
+			};
+
+			void ResetForSubmission() override
+			{
+				m_numActiveShadowViews = 0u;
+				m_activeShadowViews.Clear(false);
+				m_shadowPayloadRevisions.Clear(false);
+				m_buildShadowPayloads.Clear(false);
+				m_shadowPayloadComplete.Clear(false);
+				m_renderPassColorAttachments.Clear(false);
+				m_blurDrawBindingSets.Clear(false);
+				m_arenaRangeInstances.Clear(false);
+				m_arenaRangeStableKeys.Clear(false);
+				m_arenaRangeMaterialVersionRuns.Clear(false);
+			}
+
+			void InvalidateSubmission() override
+			{
+				ResetForSubmission();
+				for (const auto& entry : m_shadowViewCache)
+				{
+					if (entry.Second() && *entry.Second())
+					{
+						(*entry.Second())->m_packet.InvalidateUploadedState();
+						(*entry.Second())->m_bUploadedThisSubmission = false;
+					}
+				}
+			}
+
+			TMap<uint64_t, TSharedPtr<ShadowViewResources>> m_shadowViewCache{};
+			TVector<TSharedPtr<ShadowViewResources>> m_activeShadowViews{};
+			TVector<std::array<size_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>>
+				m_shadowPayloadRevisions{};
+			TVector<std::array<bool, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>>
+				m_buildShadowPayloads{};
+			TVector<std::array<bool, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>>
+				m_shadowPayloadComplete{};
+			uint32_t m_numActiveShadowViews = 0u;
+			std::array<Framegraph::TextureDependencyCollector,
+				RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
+				m_requestedPacketTextures{};
+			TVector<RHI::RHITexturePtr> m_renderPassColorAttachments{};
+			TVector<RHI::RHIShaderBindingSetPtr> m_blurDrawBindingSets{};
+			TVector<PerInstanceData> m_arenaRangeInstances{};
+			TVector<uint64_t> m_arenaRangeStableKeys{};
+			TVector<RHI::PackedDrawArenaMaterialRun> m_arenaRangeMaterialVersionRuns{};
+
+			RHI::RHIShaderBindingSetPtr m_blurShaderBindings{};
+		};
 
 		ShaderSetPtr m_pBlurVerticalShader{};
 		ShaderSetPtr m_pBlurHorizontalShader{};
@@ -70,23 +150,25 @@ namespace Sailor
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_maskedShadowMaterials_Pcf{};
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedMaskedShadowMaterials_Evsm{};
 		TMap<RHI::VertexAttributeBits, RHI::RHIMaterialPtr> m_skinnedMaskedShadowMaterials_Pcf{};
-		TMap<size_t, RHI::RHIMaterialPtr> m_customShadowMaterials{};
+		struct CustomShadowMaterialCacheEntry
+		{
+			RHI::RHIMaterialVersionPtr m_sourceVersion{};
+			RHI::RHIMaterialPtr m_material{};
+		};
+		TMap<size_t, CustomShadowMaterialCacheEntry> m_customShadowMaterials{};
 
 		RHI::RHIMaterialPtr GetOrAddShadowMaterial(RHI::RHIVertexDescriptionPtr vertex, RHI::EShadowType shadowType, bool bSkinned, bool bMasked);
 		RHI::RHIMaterialPtr GetOrAddCustomShadowMaterial(
-			const MaterialPtr& sourceMaterial,
+			const ShaderSetPtr& sourceShader,
+			const RHI::RHIMaterialPtr& sourceMaterial,
+			const RHI::RHIMaterialVersionPtr& sourceMaterialVersion,
 			RHI::RHIVertexDescriptionPtr vertex,
 			RHI::EShadowType shadowType,
 			bool bMasked);
 
-		// Record drawcalls
-		size_t m_sizePerInstanceData = 0;
-		RHI::RHIShaderBindingSetPtr m_perInstanceData{};
-		TVector<RHI::RHIBufferPtr> m_indirectBuffers{};
-
-		// Light matrices
-		RHI::RHIShaderBindingPtr m_lightMatrices{};
 		Framegraph::TextureBindingCache m_textureBindingCache{};
+		RHI::TPackedDrawPacketPayloadCache<PerInstanceData> m_packetPayloadCache{};
+		RHI::TPackedDrawPagedArenaCache<PerInstanceData> m_pagedArenaCache{};
 
 		SAILOR_SHARED_API static const char* m_name;
 	};

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
@@ -968,21 +968,52 @@ VulkanImageViewPtr VulkanDevice::GetDepthBuffer() const
 
 bool VulkanDevice::AcquireNextImage()
 {
-	// Wait while we recreate swapchain from main thread to sync with Win32Api
-	if (m_bIsSwapChainOutdated)
+	uint32_t flightSlot = 0u;
+	bool bHasSwapchainImage = false;
+	return BeginRenderSubmission(flightSlot, bHasSwapchainImage) && bHasSwapchainImage;
+}
+
+uint32_t VulkanDevice::GetMaxFramesInFlight() const
+{
+	return VulkanApi::MaxFramesInFlight;
+}
+
+bool VulkanDevice::BeginRenderSubmission(uint32_t& outFlightSlot, bool& outHasSwapchainImage)
+{
+	outFlightSlot = static_cast<uint32_t>(m_currentFrame);
+	outHasSwapchainImage = false;
+
+	if (m_currentFrame >= m_syncFences.Num() || !m_syncFences[m_currentFrame])
 	{
 		return false;
 	}
 
-	// Wait while GPU is finishing frame
-	m_syncFences[m_currentFrame]->Wait();
+	// The slot fence is the ownership boundary for every mutable resource retained
+	// by this flight. Always wait it, including the editor/no-present path and an
+	// outdated swapchain, before FrameGraph preparation can reuse the slot.
+	const VkResult previousFrameResult = m_syncFences[m_currentFrame]->Wait();
+	if (previousFrameResult != VK_SUCCESS)
+	{
+		if (previousFrameResult == VK_ERROR_DEVICE_LOST)
+		{
+			m_bIsDeviceLost = true;
+		}
+		return false;
+	}
+
+	// Wait while we recreate swapchain from main thread to sync with Win32Api.
+	// The flight slot is still safely acquired even though there is no image.
+	if (m_bIsSwapChainOutdated)
+	{
+		return true;
+	}
 
 	VkResult result = m_swapchain->AcquireNextImage(UINT64_MAX, m_imageAvailableSemaphores[m_currentFrame], VulkanFencePtr(), m_currentSwapchainImageIndex);
 
 	if (result == VK_ERROR_OUT_OF_DATE_KHR)
 	{
 		m_bIsSwapChainOutdated = true;
-		return false;
+		return true;
 	}
 	else if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR)
 	{
@@ -999,6 +1030,7 @@ bool VulkanDevice::AcquireNextImage()
 	// Mark the image as now being in use by this frame
 	m_syncImages[m_currentSwapchainImageIndex] = m_syncFences[m_currentFrame];
 
+	outHasSwapchainImage = true;
 	return true;
 }
 
@@ -1013,7 +1045,7 @@ bool VulkanDevice::PresentFrame(const FrameState& state, const TVector<VulkanCom
 	}
 
 	// Clear previous frame deps
-	m_frameDeps[m_currentFrame].Clear();
+	m_frameDeps[m_currentFrame].Clear(false);
 
 	TVector<VkCommandBuffer> commandBuffers;
 
@@ -1153,7 +1185,7 @@ bool VulkanDevice::SubmitFrameWithoutPresent(const TVector<VulkanCommandBufferPt
 		return false;
 	}
 
-	m_frameDeps[m_currentFrame].Clear();
+	m_frameDeps[m_currentFrame].Clear(false);
 
 	TVector<VkCommandBuffer> commandBuffers;
 	if (primaryCommandBuffers.Num() > 0)
@@ -1201,11 +1233,6 @@ bool VulkanDevice::SubmitFrameWithoutPresent(const TVector<VulkanCommandBufferPt
 	if (waitStages)
 	{
 		_freea(waitStages);
-	}
-
-	if (submitResult == VK_SUCCESS)
-	{
-		m_syncFences[m_currentFrame]->Wait();
 	}
 
 	m_currentFrame = (m_currentFrame + 1) % VulkanApi::MaxFramesInFlight;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
@@ -59,7 +59,9 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API void WaitIdle();
 		SAILOR_API void WaitIdlePresentQueue();
 
+		SAILOR_API bool BeginRenderSubmission(uint32_t& outFlightSlot, bool& outHasSwapchainImage);
 		SAILOR_API bool AcquireNextImage();
+		SAILOR_API uint32_t GetMaxFramesInFlight() const;
 
 		SAILOR_API VulkanImageViewPtr GetBackBuffer() const;
 		SAILOR_API VulkanImageViewPtr GetDepthBuffer() const;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -392,6 +392,33 @@ bool VulkanGraphicsDriver::AcquireNextImage()
 	return bRes;
 }
 
+bool VulkanGraphicsDriver::BeginRenderSubmission(uint32_t& outFlightSlot, bool& outHasSwapchainImage)
+{
+	SAILOR_PROFILE_FUNCTION();
+	outFlightSlot = 0u;
+	outHasSwapchainImage = false;
+	if (!m_bIsInitialized || !m_vkInstance || !m_vkInstance->GetMainDevice())
+	{
+		return false;
+	}
+
+	const bool bResult = m_vkInstance->GetMainDevice()->BeginRenderSubmission(
+		outFlightSlot,
+		outHasSwapchainImage);
+	RefreshSwapchainTargets();
+	return bResult;
+}
+
+uint32_t VulkanGraphicsDriver::GetMaxFramesInFlight() const
+{
+	if (!m_bIsInitialized || !m_vkInstance || !m_vkInstance->GetMainDevice())
+	{
+		return 0u;
+	}
+
+	return m_vkInstance->GetMainDevice()->GetMaxFramesInFlight();
+}
+
 bool VulkanGraphicsDriver::PresentFrame(const class FrameState& state,
 	const TVector<RHI::RHICommandListPtr>& primaryCommandBuffers,
 	const TVector<RHI::RHISemaphorePtr>& waitSemaphores) const
@@ -1698,6 +1725,72 @@ RHI::RHIShaderBindingSetPtr VulkanGraphicsDriver::CreateShaderBindings()
 	return res;
 }
 
+RHI::RHIShaderBindingSetPtr VulkanGraphicsDriver::CloneMaterialShaderBindings(
+	const RHI::RHIShaderBindingSetPtr& source)
+{
+	SAILOR_PROFILE_FUNCTION();
+	if (!source)
+	{
+		return {};
+	}
+
+	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
+	auto device = m_vkInstance->GetMainDevice();
+	auto result = CreateShaderBindings();
+	result->SetLayoutShaderBindings(source->GetLayoutBindings());
+
+	for (const auto& entry : source->GetShaderBindings())
+	{
+		const auto& sourceBinding = entry.m_second;
+		if (!sourceBinding)
+		{
+			continue;
+		}
+
+		auto& targetBinding = result->GetOrAddShaderBinding(entry.m_first);
+		const auto& layout = sourceBinding->GetLayout();
+		targetBinding->SetLayout(layout);
+		targetBinding->m_vulkan.m_descriptorSetLayout =
+			sourceBinding->m_vulkan.m_descriptorSetLayout;
+		targetBinding->m_vulkan.m_bBindSsboWithOffset =
+			sourceBinding->m_vulkan.m_bBindSsboWithOffset;
+		targetBinding->SetTextureBindings(sourceBinding->GetTextureBindings());
+
+		if (layout.m_type == RHI::EShaderBindingType::UniformBuffer ||
+			layout.m_type == RHI::EShaderBindingType::UniformBufferDynamic)
+		{
+			auto& allocator = GetUniformBufferAllocator(layout.m_name);
+			const size_t size = (std::max)(size_t{ 1u }, static_cast<size_t>(layout.m_size));
+			targetBinding->m_vulkan.m_valueBinding =
+				TManagedMemoryPtr<VulkanBufferMemoryPtr, VulkanBufferAllocator>::Make(
+					allocator->Allocate(size, device->GetMinUboOffsetAlignment()),
+					allocator);
+			targetBinding->m_vulkan.m_storageInstanceIndex = 0u;
+		}
+		else if (layout.m_type == RHI::EShaderBindingType::StorageBuffer ||
+			layout.m_type == RHI::EShaderBindingType::StorageBufferDynamic)
+		{
+			auto& allocator = GetMaterialSsboAllocator();
+			const uint32_t paddedSize = (std::max)(1u, layout.m_paddedSize);
+			targetBinding->m_vulkan.m_valueBinding =
+				TManagedMemoryPtr<VulkanBufferMemoryPtr, VulkanBufferAllocator>::Make(
+					allocator->Allocate(paddedSize, paddedSize),
+					allocator);
+			const auto& allocation = targetBinding->m_vulkan.m_valueBinding->Get();
+			check((allocation.m_offset % paddedSize) == 0u);
+			targetBinding->m_vulkan.m_storageInstanceIndex =
+				static_cast<uint32_t>(allocation.m_offset / paddedSize);
+		}
+	}
+
+	result->RecalculateCompatibility();
+	if (!UpdateDescriptorSet(result))
+	{
+		return {};
+	}
+	return result;
+}
+
 RHI::RHIShaderBindingPtr VulkanGraphicsDriver::AddShaderBinding(RHI::RHIShaderBindingSetPtr& pShaderBindings, const RHI::RHIShaderBindingPtr& binding, const std::string& name, uint32_t shaderBinding)
 {
 	std::lock_guard<std::recursive_mutex> descriptorLock(m_descriptorUpdateMutex);
@@ -2334,6 +2427,45 @@ void VulkanGraphicsDriver::ImageMemoryBarrier(RHI::RHICommandListPtr cmd, RHI::R
 	}
 
 	ImageMemoryBarrier(cmd, image, image->GetFormat(), oldLayout, newLayout);
+
+	imageBarriers[vkHandle] = TPair(image, newLayout);
+}
+
+void VulkanGraphicsDriver::ImageMemoryBarrierForComputeSampling(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr image)
+{
+	constexpr RHI::EImageLayout newLayout = RHI::EImageLayout::ShaderReadOnlyOptimal;
+	if (m_bIsTrackingGpu)
+	{
+		m_lastFrameGpuStats.m_barriers[image][newLayout]++;
+	}
+
+	auto& imageBarriers = cmd->m_vulkan.m_commandBuffer->GetImageBarriers();
+	const VkImage vkHandle = *image->m_vulkan.m_image;
+	if (!imageBarriers.ContainsKey(vkHandle))
+	{
+		imageBarriers[vkHandle] = TPair(image, image->GetDefaultLayout());
+	}
+
+	const RHI::EImageLayout oldLayout = imageBarriers[vkHandle].Second();
+	const bool bComputeOld = oldLayout == RHI::EImageLayout::ComputeRead ||
+		oldLayout == RHI::EImageLayout::ComputeWrite;
+	const VkImageLayout oldVkLayout = bComputeOld ?
+		VK_IMAGE_LAYOUT_GENERAL : static_cast<VkImageLayout>(oldLayout);
+	const VkAccessFlags oldAccess = bComputeOld ?
+		(oldLayout == RHI::EImageLayout::ComputeWrite ? VK_ACCESS_SHADER_WRITE_BIT : VK_ACCESS_SHADER_READ_BIT) :
+		VulkanCommandBuffer::GetAccessFlags(oldVkLayout);
+	const VkPipelineStageFlags oldStage = bComputeOld ?
+		VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT : VulkanCommandBuffer::GetPipelineStage(oldVkLayout);
+
+	cmd->m_vulkan.m_commandBuffer->ImageMemoryBarrier(
+		image->m_vulkan.m_imageView,
+		static_cast<VkFormat>(image->GetFormat()),
+		oldVkLayout,
+		VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL,
+		oldAccess,
+		VK_ACCESS_SHADER_READ_BIT,
+		oldStage,
+		VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT);
 
 	imageBarriers[vkHandle] = TPair(image, newLayout);
 }

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -50,6 +50,8 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API virtual bool ShouldFixLostDevice(const Win32::Window* pViewport) override;
 		SAILOR_API virtual bool FixLostDevice(Win32::Window* pViewport) override;
 
+		SAILOR_API virtual bool BeginRenderSubmission(uint32_t& outFlightSlot, bool& outHasSwapchainImage) override;
+		SAILOR_API virtual uint32_t GetMaxFramesInFlight() const override;
 		SAILOR_API virtual bool AcquireNextImage() override;
 		SAILOR_API virtual bool PresentFrame(const class FrameState& state, const TVector<RHI::RHICommandListPtr>& primaryCommandBuffers, const TVector<RHI::RHISemaphorePtr>& waitSemaphores) const override;
 		SAILOR_API virtual bool SubmitFrameWithoutPresent(const TVector<RHI::RHICommandListPtr>& primaryCommandBuffers, const TVector<RHI::RHISemaphorePtr>& waitSemaphores) override;
@@ -123,6 +125,8 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 		// Shader binding set
 		SAILOR_API virtual RHI::RHIShaderBindingSetPtr CreateShaderBindings() override;
+		SAILOR_API virtual RHI::RHIShaderBindingSetPtr CloneMaterialShaderBindings(
+			const RHI::RHIShaderBindingSetPtr& source) override;
 
 		SAILOR_API virtual RHI::RHIShaderBindingPtr AddBufferToShaderBindings(RHI::RHIShaderBindingSetPtr& pShaderBindings, RHI::RHIBufferPtr buffer, const std::string& name, uint32_t shaderBinding) override;
 		SAILOR_API virtual RHI::RHIShaderBindingPtr AddSsboToShaderBindings(RHI::RHIShaderBindingSetPtr& pShaderBindings, const std::string& name, size_t elementSize, size_t numElements, uint32_t shaderBinding, bool bBindSsboWithOffset) override;
@@ -227,6 +231,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API virtual void EndRenderPass(RHI::RHICommandListPtr cmd) override;
 		SAILOR_API virtual void MemoryBarrier(RHI::RHICommandListPtr cmd, RHI::EAccessFlags srcBit, RHI::EAccessFlags dstBit) override;
 		SAILOR_API virtual void ImageMemoryBarrier(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr image, RHI::EImageLayout newLayout) override;
+		SAILOR_API virtual void ImageMemoryBarrierForComputeSampling(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr image) override;
 		SAILOR_API virtual void ImageMemoryBarrier(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr image, RHI::EFormat format, RHI::EImageLayout layout, bool bAllowToWriteFromComputeShader) override;
 		SAILOR_API virtual void ImageMemoryBarrier(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr image, RHI::EFormat format, RHI::EImageLayout oldLayout, RHI::EImageLayout newLayout) override;
 		SAILOR_API virtual bool FitsViewport(RHI::RHICommandListPtr cmd, float x, float y, float width, float height, glm::vec2 scissorOffset, glm::vec2 scissorExtent, float minDepth, float maxDepth) override;

--- a/Runtime/RHI/Batch.hpp
+++ b/Runtime/RHI/Batch.hpp
@@ -8,6 +8,9 @@
 #include "RHI/Shader.h"
 #include "RHI/Texture.h"
 #include "RHI/RenderTarget.h"
+#include <algorithm>
+#include <array>
+#include <cstring>
 #include <limits>
 
 using namespace GraphicsDriver::Vulkan;
@@ -19,6 +22,7 @@ namespace Sailor::RHI
 	public:
 
 		RHIMaterialPtr m_material;
+		RHIMaterialVersionPtr m_materialVersion;
 
 		// Here we store the vertex and index bindings that could be shared during rendering (not meshes)
 		RHIMeshPtr m_mesh;
@@ -26,12 +30,44 @@ namespace Sailor::RHI
 		uint32_t m_supportedMeshesPerBatch = std::numeric_limits<uint32_t>::max();
 
 		RHIBatch() = default;
-		RHIBatch(const RHIMaterialPtr& material, const RHIMeshPtr& mesh) : m_material(material), m_mesh(mesh) {}
+		RHIBatch(const RHIMaterialPtr& material, const RHIMeshPtr& mesh) :
+			m_material(material),
+			m_materialVersion(material ? material->GetVersion() : RHIMaterialVersionPtr{}),
+			m_mesh(mesh)
+		{}
+		RHIBatch(
+			const RHIMaterialPtr& material,
+			const RHIMeshPtr& mesh,
+			uint64_t submissionId) :
+			m_material(material),
+			m_materialVersion(material ?
+				material->GetVersionForSubmission(submissionId) : RHIMaterialVersionPtr{}),
+			m_mesh(mesh)
+		{}
+
+		RHIShaderBindingSetPtr GetMaterialBindings() const
+		{
+			return m_materialVersion ? m_materialVersion->GetBindings() : RHIShaderBindingSetPtr{};
+		}
 
 		bool operator==(const RHIBatch& rhs) const
 		{
+			const auto bindings = GetMaterialBindings();
+			const auto rhsBindings = rhs.GetMaterialBindings();
+			if (!m_material || !rhs.m_material || !m_mesh || !rhs.m_mesh ||
+				!m_mesh->m_vertexBuffer || !rhs.m_mesh->m_vertexBuffer ||
+				!m_mesh->m_indexBuffer || !rhs.m_mesh->m_indexBuffer ||
+				!bindings || !rhsBindings)
+			{
+				return m_material == rhs.m_material &&
+					m_materialVersion == rhs.m_materialVersion &&
+					m_mesh == rhs.m_mesh &&
+					m_textureBindings == rhs.m_textureBindings;
+			}
+
 			const bool bSameBatch =
-				m_material->GetBindings()->GetCompatibilityHashCode() == rhs.m_material->GetBindings()->GetCompatibilityHashCode() &&
+				m_materialVersion == rhs.m_materialVersion &&
+				bindings->GetCompatibilityHashCode() == rhsBindings->GetCompatibilityHashCode() &&
 				m_material->GetVertexShader() == rhs.m_material->GetVertexShader() &&
 				m_material->GetFragmentShader() == rhs.m_material->GetFragmentShader() &&
 				m_material->GetRenderState() == rhs.m_material->GetRenderState() &&
@@ -44,456 +80,1683 @@ namespace Sailor::RHI
 
 		size_t GetHash() const
 		{
-			const size_t renderStateHash = Sailor::GetHash(m_material->GetRenderState());
+			const auto bindings = GetMaterialBindings();
+			size_t hash = bindings ? bindings->GetCompatibilityHashCode() : 0u;
 
-			size_t hash = m_material->GetBindings()->GetCompatibilityHashCode();
-
-			HashCombine(hash, m_mesh->m_vertexBuffer->GetCompatibilityHashCode(), m_mesh->m_indexBuffer->GetCompatibilityHashCode(), renderStateHash);
+			HashCombine(hash, m_materialVersion);
+			if (m_material)
+			{
+				HashCombine(hash, Sailor::GetHash(m_material->GetRenderState()));
+			}
+			if (m_mesh && m_mesh->m_vertexBuffer && m_mesh->m_indexBuffer)
+			{
+				HashCombine(
+					hash,
+					m_mesh->m_vertexBuffer->GetCompatibilityHashCode(),
+					m_mesh->m_indexBuffer->GetCompatibilityHashCode());
+			}
+			else
+			{
+				HashCombine(hash, m_mesh);
+			}
 			HashCombine(hash, m_textureBindings);
 			return hash;
 		}
 	};
 
-	template<typename TPerInstanceData>
-	using TDrawCalls = TMap<RHIBatch, TMap<RHI::RHIMeshPtr, TVector<TPerInstanceData>>>;
+	inline uint64_t BuildPackedDrawStableKey(
+		RenderInstanceHandle handle,
+		uint64_t producerKey,
+		uint32_t groupIndex,
+		uint32_t meshIndex,
+		uint32_t instanceIndex)
+	{
+		size_t result = handle.IsValid() ? std::hash<uint32_t>{}(handle.m_slot) :
+			std::hash<uint64_t>{}(producerKey);
+		HashCombine(
+			result,
+			producerKey,
+			handle.m_generation,
+			groupIndex,
+			meshIndex,
+			instanceIndex);
+		return static_cast<uint64_t>(result);
+	}
+
+	inline uint64_t BuildPackedDrawRangeKey(
+		RenderInstanceHandle handle,
+		uint64_t producerKey,
+		const void* topologyIdentity = nullptr)
+	{
+		size_t result = handle.IsValid() ? std::hash<uint32_t>{}(handle.m_slot) :
+			std::hash<uint64_t>{}(producerKey);
+		HashCombine(result, producerKey, handle.m_generation, topologyIdentity);
+		return static_cast<uint64_t>(result);
+	}
 
 	template<typename TPerInstanceData>
-	DrawCallStats RHIRecordDrawCallGPUCulling(uint32_t start,
-		uint32_t end,
-		const TVector<RHIBatch>& vecBatches,
-		RHI::RHICommandListPtr graphicsCmdList,
-		RHI::RHICommandListPtr transferCmdList,
-		std::function<TVector<RHIShaderBindingSetPtr>(const RHIBatch&)> shaderBindings,
-		const TDrawCalls<TPerInstanceData>& drawCalls,
-		const TVector<uint32_t>& storageIndex,
+	struct TPackedDrawItem
+	{
+		RHIBatch m_batch{};
+		RHIMeshPtr m_mesh{};
+		uint32_t m_instanceIndex = 0u;
+		uint64_t m_stableSortKey = 0ull;
+	};
+
+	struct PackedDrawGroup
+	{
+		RHIBatch m_batch{};
+		RHIMeshPtr m_mesh{};
+		uint32_t m_firstInstance = 0u;
+		uint32_t m_numInstances = 0u;
+	};
+
+	struct PackedDrawPacketMetrics
+	{
+		uint64_t m_instanceUploadBytes = 0ull;
+		uint64_t m_indexUploadBytes = 0ull;
+		uint64_t m_indirectUploadBytes = 0ull;
+		uint32_t m_dirtyInstanceRanges = 0u;
+		bool m_bReusedInstancePayload = false;
+		bool m_bSharedImmutablePayload = false;
+	};
+
+	template<typename TPerInstanceData>
+	struct TPackedDrawArenaPage
+	{
+		static constexpr uint32_t NumInstances = 64u;
+		std::array<TPerInstanceData, NumInstances> m_instances{};
+	};
+
+	template<typename TPerInstanceData>
+	using TPackedDrawArenaPagePtr = TSharedPtr<TPackedDrawArenaPage<TPerInstanceData>>;
+
+	struct PackedDrawArenaMaterialRun
+	{
+		uint32_t m_first = 0u;
+		uint32_t m_count = 0u;
+		RHIMaterialVersionPtr m_version{};
+	};
+
+	inline void AppendPackedDrawArenaMaterialVersion(
+		TVector<PackedDrawArenaMaterialRun>& runs,
+		RHIMaterialVersionPtr version)
+	{
+		if (!runs.IsEmpty() && runs.Last()->m_version == version)
+		{
+			++runs.Last()->m_count;
+			return;
+		}
+		const uint32_t first = runs.IsEmpty() ? 0u :
+			runs.Last()->m_first + runs.Last()->m_count;
+		runs.Add({ first, 1u, std::move(version) });
+	}
+
+	struct PackedDrawArenaItemOffset
+	{
+		uint64_t m_stableKey = 0ull;
+		uint32_t m_relativeIndex = 0u;
+	};
+
+	struct PackedDrawArenaRange
+	{
+		uint64_t m_contentRevision = 0ull;
+		uint32_t m_offset = 0u;
+		uint32_t m_count = 0u;
+		uint32_t m_capacity = 0u;
+		uint64_t m_lastVisitSerial = 0ull;
+		TSharedPtr<TVector<PackedDrawArenaItemOffset>> m_itemOffsets{};
+		TSharedPtr<TVector<PackedDrawArenaMaterialRun>> m_materialVersionRuns{};
+	};
+
+	template<typename TPerInstanceData>
+	struct TPackedDrawPacketPayload
+	{
+		TVector<TPerInstanceData> m_instances{};
+		TVector<PackedDrawGroup> m_groups{};
+		TVector<uint64_t> m_stableKeys{};
+		TMap<uint64_t, uint32_t> m_instanceLookup{};
+		TVector<TPackedDrawArenaPagePtr<TPerInstanceData>> m_arenaPages{};
+		TMap<uint64_t, PackedDrawArenaRange> m_arenaRanges{};
+		uint32_t m_arenaCapacity = 0u;
+
+		bool IsPagedArena() const
+		{
+			return m_arenaCapacity > 0u || !m_arenaRanges.IsEmpty();
+		}
+
+		uint32_t GetNumStorageInstances() const
+		{
+			return IsPagedArena() ? m_arenaCapacity :
+				static_cast<uint32_t>(m_instances.Num());
+		}
+
+		void RebuildInstanceLookup()
+		{
+			m_instanceLookup.Clear();
+			for (uint32_t index = 0u; index < m_stableKeys.Num(); ++index)
+			{
+				m_instanceLookup[m_stableKeys[index]] = index;
+			}
+		}
+
+		bool FindInstance(uint64_t stableKey, uint32_t& outInstanceIndex) const
+		{
+			const uint32_t* instanceIndex = nullptr;
+			if (!m_instanceLookup.Find(stableKey, instanceIndex) || !instanceIndex)
+			{
+				return false;
+			}
+			outInstanceIndex = *instanceIndex;
+			return true;
+		}
+
+		bool FindInstance(
+			uint64_t rangeKey,
+			uint64_t stableKey,
+			uint32_t& outInstanceIndex,
+			RHIMaterialVersionPtr* outMaterialVersion = nullptr) const
+		{
+			if (!IsPagedArena())
+			{
+				if (outMaterialVersion)
+				{
+					outMaterialVersion->Clear();
+				}
+				return FindInstance(stableKey, outInstanceIndex);
+			}
+
+			const PackedDrawArenaRange* range = nullptr;
+			if (!m_arenaRanges.Find(rangeKey, range) || !range ||
+				!range->m_itemOffsets)
+			{
+				return false;
+			}
+			uint32_t relativeIndex = 0u;
+			size_t first = 0u;
+			size_t last = range->m_itemOffsets->Num();
+			while (first < last)
+			{
+				const size_t middle = first + (last - first) / 2u;
+				const auto& candidate = (*range->m_itemOffsets)[middle];
+				if (candidate.m_stableKey < stableKey)
+				{
+					first = middle + 1u;
+				}
+				else
+				{
+					last = middle;
+				}
+			}
+			if (first >= range->m_itemOffsets->Num() ||
+				(*range->m_itemOffsets)[first].m_stableKey != stableKey)
+			{
+				return false;
+			}
+			relativeIndex = (*range->m_itemOffsets)[first].m_relativeIndex;
+			if (relativeIndex >= range->m_count)
+			{
+				return false;
+			}
+			outInstanceIndex = range->m_offset + relativeIndex;
+			if (outMaterialVersion)
+			{
+				outMaterialVersion->Clear();
+				if (range->m_materialVersionRuns)
+				{
+					for (const auto& run : *range->m_materialVersionRuns)
+					{
+						if (relativeIndex >= run.m_first &&
+							relativeIndex - run.m_first < run.m_count)
+						{
+							*outMaterialVersion = run.m_version;
+							break;
+						}
+					}
+				}
+			}
+			return true;
+		}
+	};
+
+	template<typename TPerInstanceData>
+	using TPackedDrawPacketPayloadPtr = TSharedPtr<TPackedDrawPacketPayload<TPerInstanceData>>;
+
+	template<typename TPerInstanceData>
+	struct TPackedDrawInstanceUpload
+	{
+		const TPerInstanceData* m_data = nullptr;
+		uint32_t m_offset = 0u;
+		uint32_t m_count = 0u;
+	};
+
+	template<typename TPerInstanceData>
+	class TPackedDrawPacketPayloadCache
+	{
+	public:
+		TPackedDrawPacketPayloadPtr<TPerInstanceData> Find(
+			size_t slotKey,
+			size_t revision,
+			uint64_t frame)
+		{
+			Entry* entry = nullptr;
+			if (m_entries.Find(slotKey, entry) && entry && entry->m_payload &&
+				entry->m_revision == revision)
+			{
+				entry->m_lastUsedFrame = frame;
+				return entry->m_payload;
+			}
+			return {};
+		}
+
+		void Publish(
+			size_t slotKey,
+			size_t revision,
+			TPackedDrawPacketPayloadPtr<TPerInstanceData> payload,
+			uint64_t frame)
+		{
+			// Replacing a logical slot releases the cache reference to the old
+			// revision immediately. Active submissions retain their own shared
+			// reference until the corresponding completion fence is signalled.
+			m_entries[slotKey] = { revision, std::move(payload), frame };
+		}
+
+		void Evict(uint64_t frame, uint64_t retentionFrames = 3ull)
+		{
+			m_expiredKeys.Clear(false);
+			for (const auto& entry : m_entries)
+			{
+				if (entry.Second() && frame > entry.Second()->m_lastUsedFrame &&
+					frame - entry.Second()->m_lastUsedFrame > retentionFrames)
+				{
+					m_expiredKeys.Add(entry.First());
+				}
+			}
+			for (size_t key : m_expiredKeys)
+			{
+				m_entries.Remove(key);
+			}
+			m_expiredKeys.Clear(false);
+		}
+
+		void Clear()
+		{
+			m_entries.Clear();
+			m_expiredKeys.Clear();
+		}
+
+		size_t Num() const { return m_entries.Num(); }
+
+	private:
+		struct Entry
+		{
+			size_t m_revision = 0u;
+			TPackedDrawPacketPayloadPtr<TPerInstanceData> m_payload{};
+			uint64_t m_lastUsedFrame = 0ull;
+		};
+
+		TMap<size_t, Entry> m_entries{};
+		TVector<size_t> m_expiredKeys{};
+	};
+
+	/**
+	 * Builds immutable, view-independent instance arenas as copy-on-write pages.
+	 * A logical producer owns one stable range. Unchanged ranges retain both their
+	 * page pointers and stable-key lookup; changing one producer clones only the
+	 * pages overlapped by that range. Published payloads remain alive through the
+	 * packets owned by submissions that are still in flight.
+	 */
+	template<typename TPerInstanceData>
+	class TPackedDrawPagedArenaCache
+	{
+	public:
+		using Payload = TPackedDrawPacketPayload<TPerInstanceData>;
+		using PayloadPtr = TPackedDrawPacketPayloadPtr<TPerInstanceData>;
+		static constexpr uint32_t PageSize =
+			TPackedDrawArenaPage<TPerInstanceData>::NumInstances;
+
+		PayloadPtr Find(size_t slotKey, size_t revision, uint64_t frame)
+		{
+			Entry* entry = nullptr;
+			if (m_entries.Find(slotKey, entry) && entry && entry->m_payload &&
+				entry->m_revision == revision)
+			{
+				entry->m_lastUsedFrame = frame;
+				return entry->m_payload;
+			}
+			return {};
+		}
+
+		void BeginUpdate(size_t slotKey, size_t revision, uint64_t frame)
+		{
+			m_buildingSlotKey = slotKey;
+			m_buildingRevision = revision;
+			m_buildingFrame = frame;
+			if (++m_updateSerial == 0ull)
+			{
+				m_updateSerial = 1ull;
+			}
+			m_dirtyPages.Clear(false);
+			m_freeRanges.Clear(false);
+			m_removedRangeKeys.Clear(false);
+
+			m_buildingPayload = PayloadPtr::Make();
+			Entry* entry = nullptr;
+			if (m_entries.Find(slotKey, entry) && entry && entry->m_payload &&
+				entry->m_payload->IsPagedArena())
+			{
+				m_buildingPayload->m_arenaPages = entry->m_payload->m_arenaPages;
+				m_buildingPayload->m_arenaRanges = entry->m_payload->m_arenaRanges;
+				m_buildingPayload->m_arenaCapacity = entry->m_payload->m_arenaCapacity;
+			}
+			m_dirtyPages.Resize(m_buildingPayload->m_arenaPages.Num());
+			if (!m_dirtyPages.IsEmpty())
+			{
+				std::memset(m_dirtyPages.GetData(), 0, m_dirtyPages.Num());
+			}
+
+			BuildFreeRanges();
+		}
+
+		bool TryReuseRange(uint64_t rangeKey, uint64_t contentRevision)
+		{
+			if (!m_buildingPayload)
+			{
+				return false;
+			}
+
+			PackedDrawArenaRange* range = nullptr;
+			if (!m_buildingPayload->m_arenaRanges.Find(rangeKey, range) || !range ||
+				range->m_contentRevision != contentRevision)
+			{
+				return false;
+			}
+
+			range->m_lastVisitSerial = m_updateSerial;
+			return true;
+		}
+
+		bool ReplaceRange(
+			uint64_t rangeKey,
+			uint64_t contentRevision,
+			const TVector<TPerInstanceData>& instances,
+			const TVector<uint64_t>& stableKeys,
+			const TVector<PackedDrawArenaMaterialRun>* materialVersionRuns = nullptr)
+		{
+			if (!m_buildingPayload || instances.Num() != stableKeys.Num())
+			{
+				return false;
+			}
+			if (materialVersionRuns)
+			{
+				uint32_t coveredInstances = 0u;
+				for (const auto& run : *materialVersionRuns)
+				{
+					if (run.m_count == 0u || run.m_first != coveredInstances ||
+						run.m_count > instances.Num() - coveredInstances)
+					{
+						return false;
+					}
+					coveredInstances += run.m_count;
+				}
+				if (coveredInstances != instances.Num())
+				{
+					return false;
+				}
+			}
+			auto itemOffsets = TSharedPtr<TVector<PackedDrawArenaItemOffset>>::Make();
+			itemOffsets->Reserve(stableKeys.Num());
+			for (uint32_t index = 0u; index < stableKeys.Num(); ++index)
+			{
+				itemOffsets->Add({ stableKeys[index], index });
+			}
+			itemOffsets->Sort([](const auto& lhs, const auto& rhs)
+			{
+				return lhs.m_stableKey < rhs.m_stableKey;
+			});
+			for (uint32_t index = 1u; index < itemOffsets->Num(); ++index)
+			{
+				if ((*itemOffsets)[index - 1u].m_stableKey ==
+					(*itemOffsets)[index].m_stableKey)
+				{
+					return false;
+				}
+			}
+
+			PackedDrawArenaRange* existingRange = nullptr;
+			m_buildingPayload->m_arenaRanges.Find(rangeKey, existingRange);
+			const uint32_t count = static_cast<uint32_t>(instances.Num());
+			const uint32_t requiredCapacity = AllocateCapacity(count);
+			PackedDrawArenaRange range = existingRange ? *existingRange :
+				PackedDrawArenaRange{};
+			if (!existingRange || range.m_capacity < requiredCapacity)
+			{
+				if (existingRange && range.m_capacity > 0u)
+				{
+					m_freeRanges.Add({ range.m_offset, range.m_capacity });
+					MergeFreeRanges();
+				}
+				range.m_offset = AllocateRange(requiredCapacity);
+				range.m_capacity = requiredCapacity;
+			}
+
+			range.m_contentRevision = contentRevision;
+			range.m_count = count;
+			range.m_lastVisitSerial = m_updateSerial;
+			range.m_itemOffsets = std::move(itemOffsets);
+			if (materialVersionRuns && !materialVersionRuns->IsEmpty())
+			{
+				auto runs = TSharedPtr<TVector<PackedDrawArenaMaterialRun>>::Make();
+				*runs = *materialVersionRuns;
+				range.m_materialVersionRuns = std::move(runs);
+			}
+			else
+			{
+				range.m_materialVersionRuns.Clear();
+			}
+			for (uint32_t index = 0u; index < count; ++index)
+			{
+				WriteInstance(range.m_offset + index, instances[index]);
+			}
+
+			m_buildingPayload->m_arenaRanges[rangeKey] = std::move(range);
+			return true;
+		}
+
+		PayloadPtr EndUpdate(bool bPublish = true)
+		{
+			if (!m_buildingPayload)
+			{
+				return {};
+			}
+
+			m_removedRangeKeys.Clear(false);
+			for (const auto& entry : m_buildingPayload->m_arenaRanges)
+			{
+				if (!entry.Second() ||
+					entry.Second()->m_lastVisitSerial != m_updateSerial)
+				{
+					m_removedRangeKeys.Add(entry.First());
+				}
+			}
+			for (uint64_t key : m_removedRangeKeys)
+			{
+				m_buildingPayload->m_arenaRanges.Remove(key);
+			}
+
+			auto result = m_buildingPayload;
+			if (bPublish)
+			{
+				m_entries[m_buildingSlotKey] = {
+					m_buildingRevision,
+					result,
+					m_buildingFrame };
+			}
+			m_buildingPayload.Clear();
+			m_dirtyPages.Clear(false);
+			m_freeRanges.Clear(false);
+			m_removedRangeKeys.Clear(false);
+			return result;
+		}
+
+		void Evict(uint64_t frame, uint64_t retentionFrames = 3ull)
+		{
+			m_expiredKeys.Clear(false);
+			for (const auto& entry : m_entries)
+			{
+				if (entry.Second() && frame > entry.Second()->m_lastUsedFrame &&
+					frame - entry.Second()->m_lastUsedFrame > retentionFrames)
+				{
+					m_expiredKeys.Add(entry.First());
+				}
+			}
+			for (size_t key : m_expiredKeys)
+			{
+				m_entries.Remove(key);
+			}
+			m_expiredKeys.Clear(false);
+		}
+
+		void Clear()
+		{
+			m_entries.Clear();
+			m_buildingPayload.Clear();
+			m_dirtyPages.Clear(false);
+			m_freeRanges.Clear();
+			m_occupiedRangesScratch.Clear();
+			m_removedRangeKeys.Clear();
+			m_expiredKeys.Clear();
+		}
+
+		size_t Num() const { return m_entries.Num(); }
+
+	private:
+		struct Entry
+		{
+			size_t m_revision = 0u;
+			PayloadPtr m_payload{};
+			uint64_t m_lastUsedFrame = 0ull;
+		};
+
+		struct FreeRange
+		{
+			uint32_t m_offset = 0u;
+			uint32_t m_capacity = 0u;
+		};
+
+		static uint32_t AllocateCapacity(uint32_t count)
+		{
+			if (count == 0u)
+			{
+				return 0u;
+			}
+			uint32_t result = 1u;
+			while (result < count && result <= (std::numeric_limits<uint32_t>::max)() / 2u)
+			{
+				result *= 2u;
+			}
+			return (std::max)(result, count);
+		}
+
+		void BuildFreeRanges()
+		{
+			if (!m_buildingPayload || m_buildingPayload->m_arenaCapacity == 0u)
+			{
+				return;
+			}
+
+			auto& occupied = m_occupiedRangesScratch;
+			occupied.Clear(false);
+			occupied.Reserve(m_buildingPayload->m_arenaRanges.Num());
+			for (const auto& entry : m_buildingPayload->m_arenaRanges)
+			{
+				if (entry.Second() && entry.Second()->m_capacity > 0u)
+				{
+					occupied.Add({ entry.Second()->m_offset, entry.Second()->m_capacity });
+				}
+			}
+			occupied.Sort([](const FreeRange& lhs, const FreeRange& rhs)
+			{
+				return lhs.m_offset < rhs.m_offset;
+			});
+
+			uint32_t cursor = 0u;
+			for (const auto& range : occupied)
+			{
+				if (range.m_offset > cursor)
+				{
+					m_freeRanges.Add({ cursor, range.m_offset - cursor });
+				}
+				cursor = (std::max)(cursor, range.m_offset + range.m_capacity);
+			}
+			if (cursor < m_buildingPayload->m_arenaCapacity)
+			{
+				m_freeRanges.Add({
+					cursor,
+					m_buildingPayload->m_arenaCapacity - cursor });
+			}
+			occupied.Clear(false);
+		}
+
+		void MergeFreeRanges()
+		{
+			if (m_freeRanges.Num() < 2u)
+			{
+				return;
+			}
+			m_freeRanges.Sort([](const FreeRange& lhs, const FreeRange& rhs)
+			{
+				return lhs.m_offset < rhs.m_offset;
+			});
+			uint32_t writeIndex = 0u;
+			for (uint32_t readIndex = 1u; readIndex < m_freeRanges.Num(); ++readIndex)
+			{
+				auto& current = m_freeRanges[writeIndex];
+				const auto& next = m_freeRanges[readIndex];
+				const uint32_t currentEnd = current.m_offset + current.m_capacity;
+				if (next.m_offset <= currentEnd)
+				{
+					current.m_capacity = (std::max)(currentEnd,
+						next.m_offset + next.m_capacity) - current.m_offset;
+				}
+				else
+				{
+					++writeIndex;
+					m_freeRanges[writeIndex] = next;
+				}
+			}
+			m_freeRanges.Resize(writeIndex + 1u);
+		}
+
+		uint32_t AllocateRange(uint32_t capacity)
+		{
+			if (capacity == 0u)
+			{
+				return 0u;
+			}
+			for (uint32_t index = 0u; index < m_freeRanges.Num(); ++index)
+			{
+				auto& freeRange = m_freeRanges[index];
+				if (freeRange.m_capacity < capacity)
+				{
+					continue;
+				}
+				const uint32_t result = freeRange.m_offset;
+				freeRange.m_offset += capacity;
+				freeRange.m_capacity -= capacity;
+				if (freeRange.m_capacity == 0u)
+				{
+					m_freeRanges.RemoveAt(index);
+				}
+				return result;
+			}
+
+			const uint32_t result = m_buildingPayload->m_arenaCapacity;
+			m_buildingPayload->m_arenaCapacity += capacity;
+			const uint32_t requiredPages =
+				(m_buildingPayload->m_arenaCapacity + PageSize - 1u) / PageSize;
+			const uint32_t previousPages =
+				static_cast<uint32_t>(m_buildingPayload->m_arenaPages.Num());
+			m_buildingPayload->m_arenaPages.Resize(requiredPages);
+			m_dirtyPages.Resize(requiredPages);
+			for (uint32_t pageIndex = previousPages; pageIndex < requiredPages; ++pageIndex)
+			{
+				m_buildingPayload->m_arenaPages[pageIndex] = GetZeroPage();
+			}
+			return result;
+		}
+
+		TPackedDrawArenaPagePtr<TPerInstanceData> GetZeroPage()
+		{
+			if (!m_zeroPage)
+			{
+				m_zeroPage = TPackedDrawArenaPagePtr<TPerInstanceData>::Make();
+			}
+			return m_zeroPage;
+		}
+
+		TPackedDrawArenaPage<TPerInstanceData>* MakePageWritable(uint32_t pageIndex)
+		{
+			if (pageIndex >= m_buildingPayload->m_arenaPages.Num())
+			{
+				return nullptr;
+			}
+			if (!m_dirtyPages[pageIndex])
+			{
+				const auto& source = m_buildingPayload->m_arenaPages[pageIndex];
+				m_buildingPayload->m_arenaPages[pageIndex] = source ?
+					TPackedDrawArenaPagePtr<TPerInstanceData>::Make(*source) :
+					TPackedDrawArenaPagePtr<TPerInstanceData>::Make();
+				m_dirtyPages[pageIndex] = 1u;
+			}
+			return m_buildingPayload->m_arenaPages[pageIndex].GetRawPtr();
+		}
+
+		void WriteInstance(uint32_t instanceIndex, const TPerInstanceData& instance)
+		{
+			const uint32_t pageIndex = instanceIndex / PageSize;
+			const uint32_t pageOffset = instanceIndex % PageSize;
+			if (auto* page = MakePageWritable(pageIndex))
+			{
+				page->m_instances[pageOffset] = instance;
+			}
+		}
+
+		TMap<size_t, Entry> m_entries{};
+		PayloadPtr m_buildingPayload{};
+		TVector<uint8_t> m_dirtyPages{};
+		TVector<FreeRange> m_freeRanges{};
+		TVector<FreeRange> m_occupiedRangesScratch{};
+		TVector<uint64_t> m_removedRangeKeys{};
+		TVector<size_t> m_expiredKeys{};
+		TPackedDrawArenaPagePtr<TPerInstanceData> m_zeroPage{};
+		size_t m_buildingSlotKey = 0u;
+		size_t m_buildingRevision = 0u;
+		uint64_t m_buildingFrame = 0ull;
+		uint64_t m_updateSerial = 0ull;
+	};
+
+	template<typename TPerInstanceData>
+	class TPackedDrawPacket
+	{
+	public:
+		static constexpr size_t NumMobilitySegments = 3u;
+
+		void Reset()
+		{
+			for (auto& segment : m_segments)
+			{
+				segment.m_items.Clear(false);
+				segment.m_reorderVisited.Clear(false);
+				segment.m_viewInstanceIndices.Clear(false);
+				segment.m_groups.Clear(false);
+				segment.m_sharedPayload.Clear();
+				segment.m_localPayload.m_instances.Clear(false);
+				segment.m_localPayload.m_groups.Clear(false);
+				segment.m_localPayload.m_stableKeys.Clear(false);
+				if (!segment.m_localPayload.m_instanceLookup.IsEmpty())
+				{
+					segment.m_localPayload.m_instanceLookup.Clear();
+				}
+				segment.m_localPayload.m_arenaPages.Clear(false);
+				if (!segment.m_localPayload.m_arenaRanges.IsEmpty())
+				{
+					segment.m_localPayload.m_arenaRanges.Clear();
+				}
+				segment.m_localPayload.m_arenaCapacity = 0u;
+				segment.m_bUsesArenaPayload = false;
+			}
+			m_groups.Clear(false);
+			m_instanceIndices.Clear(false);
+			m_metrics = {};
+		}
+
+		void InvalidateUploadedState()
+		{
+			m_uploadedStorageBinding.Clear();
+			m_uploadedIndexBinding.Clear();
+			m_uploadedIndirectBuffer.Clear();
+			m_uploadedStationaryInstances.Clear(false);
+			m_uploadedInstanceIndices.Clear(false);
+			m_resolvedInstanceIndices.Clear(false);
+			m_instanceUploads.Clear(false);
+			m_uploadedFirstStorageInstance = 0u;
+			m_uploadedFirstIndexInstance = 0u;
+			for (size_t index = 0u; index < NumMobilitySegments; ++index)
+			{
+				m_uploadedSharedPayloads[index].Clear();
+				m_uploadedSegmentOffsets[index] = 0u;
+				m_uploadedSegmentCounts[index] = 0u;
+			}
+			m_metrics = {};
+		}
+
+		uint32_t GetNumStorageInstances() const
+		{
+			uint32_t result = 0u;
+			for (size_t index = 0u; index < NumMobilitySegments; ++index)
+			{
+				result += GetPayload(index).GetNumStorageInstances();
+			}
+			return result;
+		}
+
+		uint32_t GetNumDrawInstances() const
+		{
+			return static_cast<uint32_t>(m_instanceIndices.Num());
+		}
+
+		uint32_t GetNumInstances() const
+		{
+			return GetNumDrawInstances();
+		}
+
+		const TVector<PackedDrawGroup>& GetGroups() const
+		{
+			return m_groups;
+		}
+
+		const TVector<uint32_t>& GetInstanceIndices() const
+		{
+			return m_instanceIndices;
+		}
+
+		const TPackedDrawPacketPayload<TPerInstanceData>& GetPayload(
+			EMobilityType mobility) const
+		{
+			return GetPayload(ToSegmentIndex(mobility));
+		}
+
+		TPackedDrawPacketPayloadPtr<TPerInstanceData> SharePayload(
+			EMobilityType mobility)
+		{
+			auto& segment = m_segments[ToSegmentIndex(mobility)];
+			if (!segment.m_sharedPayload)
+			{
+				segment.m_sharedPayload = TPackedDrawPacketPayloadPtr<TPerInstanceData>::Make();
+				segment.m_sharedPayload->m_instances = std::move(segment.m_localPayload.m_instances);
+				segment.m_sharedPayload->m_groups = std::move(segment.m_localPayload.m_groups);
+			}
+			m_metrics.m_bSharedImmutablePayload = HasSharedImmutablePayload();
+			return segment.m_sharedPayload;
+		}
+
+		TPackedDrawPacketPayloadPtr<TPerInstanceData> ShareArenaPayload(
+			EMobilityType mobility)
+		{
+			auto& segment = m_segments[ToSegmentIndex(mobility)];
+			if (!segment.m_sharedPayload)
+			{
+				segment.m_sharedPayload = TPackedDrawPacketPayloadPtr<TPerInstanceData>::Make();
+				segment.m_sharedPayload->m_instances =
+					std::move(segment.m_localPayload.m_instances);
+				segment.m_sharedPayload->m_stableKeys =
+					std::move(segment.m_localPayload.m_stableKeys);
+				segment.m_sharedPayload->RebuildInstanceLookup();
+			}
+			segment.m_bUsesArenaPayload = true;
+			m_metrics.m_bSharedImmutablePayload = HasSharedImmutablePayload();
+			return segment.m_sharedPayload;
+		}
+
+		void UseSharedPayload(
+			EMobilityType mobility,
+			TPackedDrawPacketPayloadPtr<TPerInstanceData> payload)
+		{
+			auto& segment = m_segments[ToSegmentIndex(mobility)];
+			segment.m_items.Clear(false);
+			segment.m_localPayload.m_instances.Clear(false);
+			segment.m_localPayload.m_groups.Clear(false);
+			segment.m_sharedPayload = std::move(payload);
+			segment.m_bUsesArenaPayload = false;
+			m_metrics.m_bSharedImmutablePayload = HasSharedImmutablePayload();
+		}
+
+		void UseSharedArenaPayload(
+			EMobilityType mobility,
+			TPackedDrawPacketPayloadPtr<TPerInstanceData> payload)
+		{
+			auto& segment = m_segments[ToSegmentIndex(mobility)];
+			segment.m_items.Clear(false);
+			segment.m_localPayload.m_instances.Clear(false);
+			segment.m_localPayload.m_groups.Clear(false);
+			segment.m_localPayload.m_stableKeys.Clear(false);
+			if (!segment.m_localPayload.m_instanceLookup.IsEmpty())
+			{
+				segment.m_localPayload.m_instanceLookup.Clear();
+			}
+			segment.m_localPayload.m_arenaPages.Clear(false);
+			if (!segment.m_localPayload.m_arenaRanges.IsEmpty())
+			{
+				segment.m_localPayload.m_arenaRanges.Clear();
+			}
+			segment.m_localPayload.m_arenaCapacity = 0u;
+			segment.m_sharedPayload = std::move(payload);
+			segment.m_bUsesArenaPayload = true;
+			m_metrics.m_bSharedImmutablePayload = HasSharedImmutablePayload();
+		}
+
+		const TPackedDrawPacketPayloadPtr<TPerInstanceData>& GetSharedPayload(
+			EMobilityType mobility) const
+		{
+			return m_segments[ToSegmentIndex(mobility)].m_sharedPayload;
+		}
+
+		bool HasSharedImmutablePayload() const
+		{
+			return m_segments[ToSegmentIndex(EMobilityType::Static)].m_sharedPayload.IsValid() ||
+				m_segments[ToSegmentIndex(EMobilityType::Stationary)].m_sharedPayload.IsValid();
+		}
+
+		void Add(
+			RHIBatch batch,
+			RHIMeshPtr mesh,
+			TPerInstanceData instanceData,
+			uint64_t stableSortKey = 0ull,
+			EMobilityType mobility = EMobilityType::Dynamic)
+		{
+			auto& segment = m_segments[ToSegmentIndex(mobility)];
+			const uint32_t instanceIndex =
+				static_cast<uint32_t>(segment.m_localPayload.m_instances.Num());
+			segment.m_localPayload.m_instances.Emplace(std::move(instanceData));
+			segment.m_items.Emplace(
+				TPackedDrawItem<TPerInstanceData>{
+				std::move(batch),
+				std::move(mesh),
+				instanceIndex,
+				stableSortKey });
+		}
+
+		bool AddArenaInstance(
+			TPerInstanceData instanceData,
+			uint64_t stableKey,
+			EMobilityType mobility = EMobilityType::Static)
+		{
+			auto& segment = m_segments[ToSegmentIndex(mobility)];
+			if (segment.m_sharedPayload)
+			{
+				return false;
+			}
+			uint32_t existingIndex = 0u;
+			if (segment.m_localPayload.FindInstance(stableKey, existingIndex))
+			{
+				return false;
+			}
+
+			const uint32_t instanceIndex =
+				static_cast<uint32_t>(segment.m_localPayload.m_instances.Num());
+			segment.m_localPayload.m_instances.Emplace(std::move(instanceData));
+			segment.m_localPayload.m_stableKeys.Add(stableKey);
+			segment.m_localPayload.m_instanceLookup[stableKey] = instanceIndex;
+			segment.m_bUsesArenaPayload = true;
+			return true;
+		}
+
+		bool AddArenaView(
+			RHIBatch batch,
+			RHIMeshPtr mesh,
+			uint64_t stableKey,
+			EMobilityType mobility = EMobilityType::Static)
+		{
+			auto& segment = m_segments[ToSegmentIndex(mobility)];
+			const auto& payload = GetPayload(mobility);
+			uint32_t instanceIndex = 0u;
+			if (!payload.FindInstance(stableKey, instanceIndex))
+			{
+				return false;
+			}
+
+			segment.m_items.Emplace(
+				TPackedDrawItem<TPerInstanceData>{
+				std::move(batch),
+				std::move(mesh),
+				instanceIndex,
+				stableKey });
+			segment.m_bUsesArenaPayload = true;
+			return true;
+		}
+
+		bool AddArenaView(
+			RHIBatch batch,
+			RHIMeshPtr mesh,
+			uint64_t rangeKey,
+			uint64_t stableKey,
+			EMobilityType mobility = EMobilityType::Static)
+		{
+			auto& segment = m_segments[ToSegmentIndex(mobility)];
+			const auto& payload = GetPayload(mobility);
+			uint32_t instanceIndex = 0u;
+			RHIMaterialVersionPtr materialVersion;
+			if (!payload.FindInstance(
+				rangeKey,
+				stableKey,
+				instanceIndex,
+				&materialVersion))
+			{
+				return false;
+			}
+			if (materialVersion)
+			{
+				batch.m_materialVersion = std::move(materialVersion);
+			}
+
+			segment.m_items.Emplace(
+				TPackedDrawItem<TPerInstanceData>{
+				std::move(batch),
+				std::move(mesh),
+				instanceIndex,
+				stableKey });
+			segment.m_bUsesArenaPayload = true;
+			return true;
+		}
+
+		void Finalize(bool bPreserveInstanceOrder = false)
+		{
+			for (auto& segment : m_segments)
+			{
+				segment.m_viewInstanceIndices.Clear(false);
+				segment.m_groups.Clear(false);
+				if (segment.m_sharedPayload && !segment.m_bUsesArenaPayload)
+				{
+					segment.m_items.Clear(false);
+					continue;
+				}
+
+				auto& instances = segment.m_localPayload.m_instances;
+				auto& groups = segment.m_bUsesArenaPayload ?
+					segment.m_groups : segment.m_localPayload.m_groups;
+				groups.Clear(false);
+
+				if (!bPreserveInstanceOrder)
+				{
+					segment.m_items.Sort([](const auto& lhs, const auto& rhs)
+					{
+						const size_t lhsBatchHash = lhs.m_batch.GetHash();
+						const size_t rhsBatchHash = rhs.m_batch.GetHash();
+						if (lhsBatchHash != rhsBatchHash)
+						{
+							return lhsBatchHash < rhsBatchHash;
+						}
+						const auto lhsMaterialVersion = reinterpret_cast<uintptr_t>(
+							lhs.m_batch.m_materialVersion.GetRawPtr());
+						const auto rhsMaterialVersion = reinterpret_cast<uintptr_t>(
+							rhs.m_batch.m_materialVersion.GetRawPtr());
+						if (lhsMaterialVersion != rhsMaterialVersion)
+						{
+							return lhsMaterialVersion < rhsMaterialVersion;
+						}
+						const auto lhsMesh = reinterpret_cast<uintptr_t>(lhs.m_mesh.GetRawPtr());
+						const auto rhsMesh = reinterpret_cast<uintptr_t>(rhs.m_mesh.GetRawPtr());
+						if (lhsMesh != rhsMesh)
+						{
+							return lhsMesh < rhsMesh;
+						}
+						const auto lhsTextures = reinterpret_cast<uintptr_t>(
+							lhs.m_batch.m_textureBindings.GetRawPtr());
+						const auto rhsTextures = reinterpret_cast<uintptr_t>(
+							rhs.m_batch.m_textureBindings.GetRawPtr());
+						if (lhsTextures != rhsTextures)
+						{
+							return lhsTextures < rhsTextures;
+						}
+						return lhs.m_stableSortKey < rhs.m_stableSortKey;
+					});
+
+					if (!segment.m_bUsesArenaPayload)
+					{
+						segment.m_reorderVisited.Resize(instances.Num());
+						std::memset(
+							segment.m_reorderVisited.GetData(),
+							0,
+							segment.m_reorderVisited.Num());
+						for (uint32_t start = 0u; start < instances.Num(); ++start)
+						{
+							if (segment.m_reorderVisited[start])
+							{
+								continue;
+							}
+
+							uint32_t destination = start;
+							TPerInstanceData displaced = std::move(instances[destination]);
+							while (segment.m_items[destination].m_instanceIndex != start)
+							{
+								const uint32_t source =
+									segment.m_items[destination].m_instanceIndex;
+								instances[destination] = std::move(instances[source]);
+								segment.m_reorderVisited[destination] = 1u;
+								destination = source;
+							}
+							instances[destination] = std::move(displaced);
+							segment.m_reorderVisited[destination] = 1u;
+						}
+					}
+				}
+
+				groups.Reserve(segment.m_items.Num());
+				for (uint32_t itemIndex = 0u; itemIndex < segment.m_items.Num(); ++itemIndex)
+				{
+					const auto& item = segment.m_items[itemIndex];
+					const bool bAppendToGroup = !bPreserveInstanceOrder &&
+						!groups.IsEmpty() &&
+						groups.Last()->m_mesh == item.m_mesh &&
+						groups.Last()->m_batch == item.m_batch;
+					if (!bAppendToGroup)
+					{
+						PackedDrawGroup group;
+						group.m_batch = item.m_batch;
+						group.m_mesh = item.m_mesh;
+						group.m_firstInstance = itemIndex;
+						groups.Emplace(std::move(group));
+					}
+
+					++groups.Last()->m_numInstances;
+					if (segment.m_bUsesArenaPayload)
+					{
+						segment.m_viewInstanceIndices.Add(item.m_instanceIndex);
+					}
+				}
+
+				// The packed arrays replace the duplicate per-item payload. Retain the
+				// builder capacity for the next use of this flight slot.
+				segment.m_items.Clear(false);
+			}
+
+			RebuildCombinedGroups();
+			m_metrics.m_bSharedImmutablePayload = HasSharedImmutablePayload();
+		}
+
+		const TPackedDrawPacketPayload<TPerInstanceData>& GetPayload(size_t index) const
+		{
+			const auto& segment = m_segments[index];
+			return segment.m_sharedPayload ? *segment.m_sharedPayload : segment.m_localPayload;
+		}
+
+		static size_t ToSegmentIndex(EMobilityType mobility)
+		{
+			const size_t result = static_cast<size_t>(mobility);
+			return result < NumMobilitySegments ? result :
+				static_cast<size_t>(EMobilityType::Dynamic);
+		}
+
+		void RebuildCombinedGroups()
+		{
+			m_groups.Clear(false);
+			m_instanceIndices.Clear(false);
+			uint32_t firstStorageInstance = 0u;
+			uint32_t firstViewInstance = 0u;
+			for (size_t index = 0u; index < NumMobilitySegments; ++index)
+			{
+				auto& segment = m_segments[index];
+				const auto& payload = GetPayload(index);
+				const auto& sourceGroups = segment.m_bUsesArenaPayload ?
+					segment.m_groups : payload.m_groups;
+				m_groups.Reserve(m_groups.Num() + sourceGroups.Num());
+				for (const auto& sourceGroup : sourceGroups)
+				{
+					auto group = sourceGroup;
+					group.m_firstInstance += firstViewInstance;
+					m_groups.Emplace(std::move(group));
+				}
+
+				if (segment.m_bUsesArenaPayload)
+				{
+					m_instanceIndices.Reserve(
+						m_instanceIndices.Num() + segment.m_viewInstanceIndices.Num());
+					for (uint32_t instanceIndex : segment.m_viewInstanceIndices)
+					{
+						m_instanceIndices.Add(firstStorageInstance + instanceIndex);
+					}
+					firstViewInstance +=
+						static_cast<uint32_t>(segment.m_viewInstanceIndices.Num());
+				}
+				else
+				{
+					const uint32_t numInstances = payload.GetNumStorageInstances();
+					m_instanceIndices.Reserve(m_instanceIndices.Num() + numInstances);
+					for (uint32_t instanceIndex = 0u; instanceIndex < numInstances; ++instanceIndex)
+					{
+						m_instanceIndices.Add(firstStorageInstance + instanceIndex);
+					}
+					firstViewInstance += numInstances;
+				}
+				firstStorageInstance += payload.GetNumStorageInstances();
+			}
+		}
+
+		struct Segment
+		{
+			TVector<TPackedDrawItem<TPerInstanceData>> m_items{};
+			TVector<uint8_t> m_reorderVisited{};
+			TVector<uint32_t> m_viewInstanceIndices{};
+			TVector<PackedDrawGroup> m_groups{};
+			TPackedDrawPacketPayload<TPerInstanceData> m_localPayload{};
+			TPackedDrawPacketPayloadPtr<TPerInstanceData> m_sharedPayload{};
+			bool m_bUsesArenaPayload = false;
+		};
+
+		std::array<Segment, NumMobilitySegments> m_segments{};
+		TVector<PackedDrawGroup> m_groups{};
+		TVector<uint32_t> m_instanceIndices{};
+		TVector<uint32_t> m_resolvedInstanceIndices{};
+		TVector<uint32_t> m_uploadedInstanceIndices{};
+		TVector<DrawIndexedIndirectData> m_indirectCommands{};
+		TVector<TPackedDrawInstanceUpload<TPerInstanceData>> m_instanceUploads{};
+		TVector<RHIShaderBindingSetPtr> m_drawBindingSets{};
+		TVector<TPerInstanceData> m_uploadedStationaryInstances{};
+		TVector<DrawIndexedIndirectData> m_uploadedIndirectCommands{};
+		RHIShaderBindingPtr m_uploadedStorageBinding{};
+		RHIShaderBindingPtr m_uploadedIndexBinding{};
+		RHIBufferPtr m_uploadedIndirectBuffer{};
+		uint32_t m_uploadedFirstStorageInstance = 0u;
+		uint32_t m_uploadedFirstIndexInstance = 0u;
+		std::array<TPackedDrawPacketPayloadPtr<TPerInstanceData>, NumMobilitySegments>
+			m_uploadedSharedPayloads{};
+		std::array<uint32_t, NumMobilitySegments> m_uploadedSegmentOffsets{};
+		std::array<uint32_t, NumMobilitySegments> m_uploadedSegmentCounts{};
+		PackedDrawPacketMetrics m_metrics{};
+	};
+
+	template<typename TPerInstanceData, typename TShaderBindingsCallback>
+	DrawCallStats RHIRecordPackedDrawPacket(
+		TPackedDrawPacket<TPerInstanceData>& packet,
+		RHICommandListPtr graphicsCmdList,
+		RHICommandListPtr transferCmdList,
+		TShaderBindingsCallback&& collectShaderBindings,
+		RHIShaderBindingSetPtr instanceBindings,
 		RHIBufferPtr& indirectCommandBuffer,
 		glm::ivec4 viewport,
 		glm::uvec4 scissors,
-		glm::vec2 depthRange,
-		RHIShaderPtr computeCullingShader,
-		RHIShaderBindingSetPtr& indirectCommandBufferBinding,
-		const TVector<RHIShaderBindingSetPtr>& cullingDistpatchBindings,
-		SpinLock* transferCommandListLock = nullptr)
+		glm::vec2 depthRange = glm::vec2(0.0f, 1.0f),
+		RHIShaderPtr computeCullingShader = {},
+		RHIShaderBindingSetPtr* indirectCommandBufferBinding = nullptr,
+		const TVector<RHIShaderBindingSetPtr>& cullingDispatchBindings = {})
 	{
 		SAILOR_PROFILE_FUNCTION();
 		DrawCallStats stats;
-		if (start >= end || end > vecBatches.Num() || end > storageIndex.Num())
+		const uint32_t numInstances = packet.GetNumDrawInstances();
+		const uint32_t numStorageInstances = packet.GetNumStorageInstances();
+		const auto& groups = packet.GetGroups();
+		if (numInstances == 0u || numStorageInstances == 0u ||
+			groups.IsEmpty() || !instanceBindings)
 		{
 			return stats;
 		}
 
 		auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
 		auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
+		auto storageBinding = instanceBindings->GetOrAddShaderBinding("data");
+		auto indexBinding = instanceBindings->GetOrAddShaderBinding("indices");
+		const uint32_t firstStorageInstance = storageBinding->GetStorageInstanceIndex();
+		const uint32_t firstCandidateInstance = indexBinding->GetStorageInstanceIndex();
+		// GPU culling compacts into the second half of the same flight-local SSBO.
+		// The first half remains immutable until the logical view changes, so the
+		// shader can restore the compacted stream without another CPU upload.
+		const uint32_t firstIndexInstance = computeCullingShader ?
+			firstCandidateInstance + numInstances : firstCandidateInstance;
 
-		size_t indirectBufferSize = 0;
-		for (uint32_t j = start; j < end; j++)
+		const bool bStorageAllocationChanged =
+			packet.m_uploadedStorageBinding != storageBinding ||
+			packet.m_uploadedFirstStorageInstance != firstStorageInstance;
+		auto& instanceUploads = packet.m_instanceUploads;
+		instanceUploads.Clear(false);
+		uint32_t segmentOffset = 0u;
+		for (size_t index = 0u;
+			index < TPackedDrawPacket<TPerInstanceData>::NumMobilitySegments;
+			++index)
 		{
-			indirectBufferSize += drawCalls[vecBatches[j]].Num() * sizeof(RHI::DrawIndexedIndirectData);
-		}
-
-		if (!indirectCommandBuffer.IsValid() || indirectCommandBuffer->GetSize() < indirectBufferSize)
-		{
-			const size_t slack = 256;
-
-			indirectCommandBuffer.Clear();
-			indirectCommandBuffer = driver->CreateIndirectBuffer(indirectBufferSize + slack);
-
-			Sailor::RHI::Renderer::GetDriver()->AddBufferToShaderBindings(indirectCommandBufferBinding,
-				indirectCommandBuffer,
-				"drawIndexedIndirect",
-				0);
-		}
-		else if (!indirectCommandBufferBinding->HasBinding("drawIndexedIndirect"))
-		{
-			// The buffer can have been allocated by the non-culling path. In that case
-			// its storage-buffer descriptor still has to be created before dispatch.
-			Sailor::RHI::Renderer::GetDriver()->AddBufferToShaderBindings(indirectCommandBufferBinding,
-				indirectCommandBuffer,
-				"drawIndexedIndirect",
-				0);
-		}
-
-		RHIMaterialPtr prevMaterial = nullptr;
-		RHIShaderBindingSetPtr prevTextureBindings = nullptr;
-		RHIBufferPtr prevVertexBuffer = nullptr;
-		RHIBufferPtr prevIndexBuffer = nullptr;
-
-		uint32_t firstInstanceIndex = storageIndex[start];
-		uint32_t totalNumInstances = 0;
-		uint32_t totalNumBatches = 0;
-
-#if defined(_WIN32)
-		constexpr uint32_t MaxMeshesPerIndirectBatch = 16384;
-#else
-		constexpr uint32_t MaxMeshesPerIndirectBatch = 128;
-#endif
-
-		size_t indirectBufferOffset = 0;
-		for (uint32_t j = start; j < end; j++)
-		{
-			auto& material = vecBatches[j].m_material;
-			auto& mesh = vecBatches[j].m_mesh;
-			auto& drawCall = drawCalls[vecBatches[j]];
-
-			const bool bMaterialChanged = prevMaterial != material;
-			const bool bTextureBindingsChanged = prevTextureBindings != vecBatches[j].m_textureBindings;
-			if (bMaterialChanged)
+			const auto mobility = static_cast<EMobilityType>(index);
+			const auto& payload = packet.GetPayload(mobility);
+			const auto& sharedPayload = packet.GetSharedPayload(mobility);
+			const uint32_t segmentCount = payload.GetNumStorageInstances();
+			const bool bSegmentLayoutChanged =
+				packet.m_uploadedSegmentOffsets[index] != segmentOffset ||
+				packet.m_uploadedSegmentCounts[index] != segmentCount;
+			const bool bSharedPayloadChanged =
+				packet.m_uploadedSharedPayloads[index] != sharedPayload;
+			if (payload.IsPagedArena())
 			{
-				commands->BindMaterial(graphicsCmdList, material);
-				commands->SetViewport(graphicsCmdList, (float)viewport.x, (float)viewport.y,
-					(float)viewport.z,
-					(float)viewport.w,
-					glm::vec2(scissors.x, scissors.y),
-					glm::vec2(scissors.z, scissors.w),
-					depthRange.x,
-					depthRange.y);
-				prevMaterial = material;
-			}
-			if (bMaterialChanged || bTextureBindingsChanged)
-			{
-				TVector<RHIShaderBindingSetPtr> sets = shaderBindings(vecBatches[j]);
-				commands->BindShaderBindings(graphicsCmdList, material, sets);
-				prevTextureBindings = vecBatches[j].m_textureBindings;
-			}
-
-			if (prevVertexBuffer != mesh->m_vertexBuffer)
-			{
-				commands->BindVertexBuffer(graphicsCmdList, mesh->m_vertexBuffer, 0);
-				prevVertexBuffer = mesh->m_vertexBuffer;
-			}
-
-			if (prevIndexBuffer != mesh->m_indexBuffer)
-			{
-				commands->BindIndexBuffer(graphicsCmdList, mesh->m_indexBuffer, 0);
-				prevIndexBuffer = mesh->m_indexBuffer;
-			}
-
-			firstInstanceIndex = std::min(firstInstanceIndex, storageIndex[j]);
-
-			uint32_t ssboOffset = 0;
-			const uint32_t meshesPerBatchLimit = (std::min)(MaxMeshesPerIndirectBatch, vecBatches[j].m_supportedMeshesPerBatch);
-			uint32_t meshesInCurrentBatch = 0;
-			TVector<RHI::DrawIndexedIndirectData> drawIndirect;
-			drawIndirect.Reserve((std::min)((uint32_t)drawCall.Num(), meshesPerBatchLimit));
-
-			auto flushIndirectBatch = [&]()
-			{
-				if (drawIndirect.IsEmpty())
+				if (mobility == EMobilityType::Stationary)
 				{
-					return;
+					// The contiguous fallback owns this comparison mirror. Invalidate it
+					// while a paged version is active so a later mode switch cannot compare
+					// against data older than the GPU's current arena pages.
+					packet.m_uploadedStationaryInstances.Clear(false);
 				}
+				using ArenaPage = TPackedDrawArenaPage<TPerInstanceData>;
+				const auto& previousPayload = packet.m_uploadedSharedPayloads[index];
+				const bool bCanDiffPages = !bStorageAllocationChanged &&
+					!bSegmentLayoutChanged && sharedPayload && previousPayload &&
+					previousPayload->IsPagedArena() &&
+					previousPayload->m_arenaCapacity == payload.m_arenaCapacity &&
+					previousPayload->m_arenaPages.Num() == payload.m_arenaPages.Num();
+				static const ArenaPage ZeroPage{};
+				auto appendPage = [&](uint32_t pageIndex)
+					{
+						const uint32_t pageOffset = pageIndex * ArenaPage::NumInstances;
+						if (pageOffset >= segmentCount)
+						{
+							return;
+						}
+						const uint32_t pageCount = (std::min)(
+							ArenaPage::NumInstances,
+							segmentCount - pageOffset);
+						const auto& page = payload.m_arenaPages[pageIndex];
+						instanceUploads.Add({
+							page ? page->m_instances.data() : ZeroPage.m_instances.data(),
+							segmentOffset + pageOffset,
+							pageCount });
+					};
 
-				const size_t bufferSize = sizeof(RHI::DrawIndexedIndirectData) * drawIndirect.Num();
-				if (transferCommandListLock)
+				if (!bCanDiffPages)
 				{
-					transferCommandListLock->Lock();
-					commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
-					transferCommandListLock->Unlock();
+					if (segmentCount > 0u &&
+						(bStorageAllocationChanged || bSegmentLayoutChanged ||
+							!sharedPayload || bSharedPayloadChanged))
+					{
+						for (uint32_t pageIndex = 0u;
+							pageIndex < payload.m_arenaPages.Num(); ++pageIndex)
+						{
+							appendPage(pageIndex);
+						}
+					}
 				}
-				else
+				else if (bSharedPayloadChanged)
 				{
-					commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
-				}
-				commands->DrawIndexedIndirect(graphicsCmdList, indirectCommandBuffer, indirectBufferOffset, (uint32_t)drawIndirect.Num(), sizeof(RHI::DrawIndexedIndirectData));
-				stats.m_numBatches++;
-				indirectBufferOffset += bufferSize;
-				drawIndirect.Clear();
-				meshesInCurrentBatch = 0;
-			};
-
-			for (const auto& instancedDrawCall : drawCall)
-			{
-				auto& mesh = instancedDrawCall.First();
-				auto& matrices = *instancedDrawCall.Second();
-
-				RHI::DrawIndexedIndirectData data{};
-				data.m_indexCount = mesh->GetIndexCount();
-				data.m_instanceCount = (uint32_t)matrices.Num();
-				data.m_firstIndex = mesh->GetFirstIndex();
-				data.m_vertexOffset = mesh->GetVertexOffset();
-				data.m_firstInstance = storageIndex[j] + ssboOffset;
-				drawIndirect.Emplace(std::move(data));
-				meshesInCurrentBatch++;
-
-				ssboOffset += (uint32_t)matrices.Num();
-
-				totalNumBatches++;
-				totalNumInstances += (uint32_t)matrices.Num();
-
-				if (meshesInCurrentBatch >= meshesPerBatchLimit)
-				{
-					flushIndirectBatch();
+					for (uint32_t pageIndex = 0u;
+						pageIndex < payload.m_arenaPages.Num(); ++pageIndex)
+					{
+						if (previousPayload->m_arenaPages[pageIndex] !=
+							payload.m_arenaPages[pageIndex])
+						{
+							appendPage(pageIndex);
+						}
+					}
 				}
 			}
-
-			flushIndirectBatch();
-		}
-
-		struct PushConstants
-		{
-			uint32_t m_numBatches = 0;
-			uint32_t m_numInstances = 0;
-			uint32_t m_firstInstanceIndex = 0;
-			uint32_t m_phase = 0;
-			uint32_t m_bEnableOcclusion = 0;
-		};
-
-		PushConstants constants{};
-		constants.m_numBatches = totalNumBatches;
-		constants.m_numInstances = totalNumInstances;
-		constants.m_firstInstanceIndex = firstInstanceIndex;
-		// The Hi-Z texture belongs to the previous frame, while the frame and
-		// instance transforms are current. Occlusion is not conservative until
-		// matching camera/object history is supplied; frustum culling remains on.
-		constants.m_bEnableOcclusion = 0;
-		stats.m_numInstances = totalNumInstances;
-
-		auto recordCullingDispatch = [&]()
+			else if (mobility == EMobilityType::Static)
 			{
-				commands->BeginDebugRegion(transferCmdList, "GPU Culling", DebugContext::Color_CmdCompute);
+				// Static payload pointer identity is the immutable version. A freed
+				// flight can patch a same-layout successor directly from the two
+				// retained versions, without keeping another per-flight CPU mirror.
+				const auto& previousPayload = packet.m_uploadedSharedPayloads[index];
+				const bool bCanDiffVersions = !bStorageAllocationChanged &&
+					!bSegmentLayoutChanged && sharedPayload && previousPayload &&
+					previousPayload->m_instances.Num() == payload.m_instances.Num();
+				if (!bCanDiffVersions)
+				{
+					if (segmentCount > 0u &&
+						(bStorageAllocationChanged || bSegmentLayoutChanged ||
+							!sharedPayload || bSharedPayloadChanged))
+					{
+						instanceUploads.Add({
+							payload.m_instances.GetData(),
+							segmentOffset,
+							segmentCount });
+					}
+				}
+				else if (bSharedPayloadChanged)
+				{
+					uint32_t dirtyBegin = (std::numeric_limits<uint32_t>::max)();
+					auto appendDirtyRange = [&](uint32_t begin, uint32_t end)
+						{
+							instanceUploads.Add({
+								&payload.m_instances[begin],
+								segmentOffset + begin,
+								end - begin });
+						};
+					for (uint32_t instanceIndex = 0u;
+						instanceIndex < segmentCount; ++instanceIndex)
+					{
+						const bool bChanged = !(previousPayload->m_instances[instanceIndex] ==
+							payload.m_instances[instanceIndex]);
+						if (bChanged && dirtyBegin == (std::numeric_limits<uint32_t>::max)())
+						{
+							dirtyBegin = instanceIndex;
+						}
+						else if (!bChanged &&
+							dirtyBegin != (std::numeric_limits<uint32_t>::max)())
+						{
+							appendDirtyRange(dirtyBegin, instanceIndex);
+							dirtyBegin = (std::numeric_limits<uint32_t>::max)();
+						}
+					}
+					if (dirtyBegin != (std::numeric_limits<uint32_t>::max)())
+					{
+						appendDirtyRange(dirtyBegin, segmentCount);
+					}
+				}
+			}
+			else if (mobility == EMobilityType::Stationary)
+			{
+				auto& uploaded = packet.m_uploadedStationaryInstances;
+				const bool bStationaryCountChanged = uploaded.Num() != segmentCount;
+				if (bStorageAllocationChanged || bSegmentLayoutChanged || bStationaryCountChanged)
+				{
+					if (segmentCount > 0u)
+					{
+						instanceUploads.Add({
+							payload.m_instances.GetData(),
+							segmentOffset,
+							segmentCount });
+						uploaded = payload.m_instances;
+					}
+					else
+					{
+						uploaded.Clear(false);
+					}
+				}
+				else if (bSharedPayloadChanged || !sharedPayload)
+				{
+					uint32_t dirtyBegin = (std::numeric_limits<uint32_t>::max)();
+					auto appendDirtyRange = [&](uint32_t begin, uint32_t end)
+						{
+							const uint32_t count = end - begin;
+							instanceUploads.Add({
+								&payload.m_instances[begin],
+								segmentOffset + begin,
+								count });
+							std::memcpy(
+								&uploaded[begin],
+								&payload.m_instances[begin],
+								sizeof(TPerInstanceData) * count);
+						};
+					for (uint32_t instanceIndex = 0u; instanceIndex < segmentCount; ++instanceIndex)
+					{
+						const bool bChanged =
+							!(uploaded[instanceIndex] == payload.m_instances[instanceIndex]);
+						if (bChanged && dirtyBegin == (std::numeric_limits<uint32_t>::max)())
+						{
+							dirtyBegin = instanceIndex;
+						}
+						else if (!bChanged && dirtyBegin != (std::numeric_limits<uint32_t>::max)())
+						{
+							appendDirtyRange(dirtyBegin, instanceIndex);
+							dirtyBegin = (std::numeric_limits<uint32_t>::max)();
+						}
+					}
+					if (dirtyBegin != (std::numeric_limits<uint32_t>::max)())
+					{
+						appendDirtyRange(dirtyBegin, segmentCount);
+					}
+				}
+			}
+			else if (segmentCount > 0u)
+			{
+				// Dynamic records deliberately remain flight-local and are rewritten
+				// on every submission, independently of pointer or hash stability.
+				instanceUploads.Add({
+					payload.m_instances.GetData(),
+					segmentOffset,
+					segmentCount });
+			}
 
-				const EAccessFlags uploadWrites = static_cast<EAccessFlags>(EAccessBit::TransferWrite_Bit) |
-					static_cast<EAccessFlags>(EAccessBit::HostWrite_Bit);
-				const EAccessFlags shaderReadWrite = static_cast<EAccessFlags>(EAccessBit::ShaderRead_Bit) |
-					static_cast<EAccessFlags>(EAccessBit::ShaderWrite_Bit);
-				commands->MemoryBarrier(transferCmdList, uploadWrites, shaderReadWrite);
-
-				constants.m_phase = 0;
-				const uint32_t cullingGroupsX = (std::max)(1u, (constants.m_numInstances + RHI::Renderer::GPUCullingGroupSize - 1u) / RHI::Renderer::GPUCullingGroupSize);
-				commands->Dispatch(transferCmdList, computeCullingShader, cullingGroupsX, 1, 1, cullingDistpatchBindings, &constants, sizeof(constants));
-
-				commands->MemoryBarrier(transferCmdList,
-					static_cast<EAccessFlags>(EAccessBit::ShaderWrite_Bit),
-					shaderReadWrite);
-
-				constants.m_phase = 1;
-				const uint32_t compactionGroupsX = (std::max)(1u, (constants.m_numBatches + RHI::Renderer::GPUCullingGroupSize - 1u) / RHI::Renderer::GPUCullingGroupSize);
-				commands->Dispatch(transferCmdList, computeCullingShader, compactionGroupsX, 1, 1, cullingDistpatchBindings, &constants, sizeof(constants));
-				commands->EndDebugRegion(transferCmdList);
-			};
-
-		if (transferCommandListLock)
-		{
-			transferCommandListLock->Lock();
-			recordCullingDispatch();
-			transferCommandListLock->Unlock();
+			packet.m_uploadedSharedPayloads[index] = sharedPayload;
+			packet.m_uploadedSegmentOffsets[index] = segmentOffset;
+			packet.m_uploadedSegmentCounts[index] = segmentCount;
+			segmentOffset += segmentCount;
 		}
-		else
+		packet.m_uploadedStorageBinding = storageBinding;
+		packet.m_uploadedFirstStorageInstance = firstStorageInstance;
+		packet.m_metrics.m_dirtyInstanceRanges = static_cast<uint32_t>(instanceUploads.Num());
+		packet.m_metrics.m_bReusedInstancePayload = instanceUploads.IsEmpty();
+		packet.m_metrics.m_bSharedImmutablePayload = packet.HasSharedImmutablePayload();
+
+		const size_t instanceIndexBytes =
+			sizeof(uint32_t) * packet.m_instanceIndices.Num();
+		const bool bIndexContentsChanged =
+			packet.m_uploadedInstanceIndices.Num() !=
+				packet.m_instanceIndices.Num() ||
+			(packet.m_instanceIndices.Num() > 0u && std::memcmp(
+				packet.m_uploadedInstanceIndices.GetData(),
+				packet.m_instanceIndices.GetData(),
+				instanceIndexBytes) != 0);
+		const bool bResetIndices = bStorageAllocationChanged ||
+			packet.m_uploadedIndexBinding != indexBinding ||
+			packet.m_uploadedFirstIndexInstance != firstCandidateInstance ||
+			bIndexContentsChanged;
+		packet.m_uploadedIndexBinding = indexBinding;
+		packet.m_uploadedFirstIndexInstance = firstCandidateInstance;
+
+		packet.m_indirectCommands.Resize(groups.Num());
+		for (uint32_t groupIndex = 0u; groupIndex < groups.Num(); ++groupIndex)
 		{
-			recordCullingDispatch();
+			const auto& group = groups[groupIndex];
+			auto& command = packet.m_indirectCommands[groupIndex];
+			command.m_indexCount = group.m_mesh->GetIndexCount();
+			command.m_instanceCount = group.m_numInstances;
+			command.m_firstIndex = group.m_mesh->GetFirstIndex();
+			command.m_vertexOffset = group.m_mesh->GetVertexOffset();
+			command.m_firstInstance = firstIndexInstance + group.m_firstInstance;
+			stats.m_numInstances += group.m_numInstances;
 		}
 
-		return stats;
-	}
-
-	template<typename TPerInstanceData>
-	DrawCallStats RHIRecordDrawCall(uint32_t start,
-		uint32_t end,
-		const TVector<RHIBatch>& vecBatches,
-		RHI::RHICommandListPtr cmdList,
-		RHI::RHICommandListPtr transferCmdList,
-		std::function<TVector<RHIShaderBindingSetPtr>(const RHIBatch&)> shaderBindings,
-		const TDrawCalls<TPerInstanceData>& drawCalls,
-		const TVector<uint32_t>& storageIndex,
-		RHIBufferPtr& indirectCommandBuffer,
-		glm::ivec4 viewport,
-		glm::uvec4 scissors,
-		glm::vec2 depthRange = glm::vec2(0.0f, 1.0f),
-		RHIShaderBindingSetPtr* indirectCommandBufferBinding = nullptr,
-		SpinLock* transferCommandListLock = nullptr)
-	{
-		SAILOR_PROFILE_FUNCTION();
-		DrawCallStats stats;
-
-		auto& driver = App::GetSubmodule<RHI::Renderer>()->GetDriver();
-		auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
-
-		size_t indirectBufferSize = 0;
-		for (uint32_t j = start; j < end; j++)
+		for (const auto& upload : instanceUploads)
 		{
-			indirectBufferSize += drawCalls[vecBatches[j]].Num() * sizeof(RHI::DrawIndexedIndirectData);
+			const size_t rangeSize = sizeof(TPerInstanceData) * upload.m_count;
+			commands->UpdateShaderBinding(
+				transferCmdList,
+				storageBinding,
+				upload.m_data,
+				rangeSize,
+				sizeof(TPerInstanceData) * upload.m_offset);
+			packet.m_metrics.m_instanceUploadBytes += rangeSize;
+		}
+		if (bResetIndices)
+		{
+			packet.m_resolvedInstanceIndices.Resize(packet.m_instanceIndices.Num());
+			for (uint32_t index = 0u; index < packet.m_instanceIndices.Num(); ++index)
+			{
+				packet.m_resolvedInstanceIndices[index] =
+					firstStorageInstance + packet.m_instanceIndices[index];
+			}
+			commands->UpdateShaderBinding(
+				transferCmdList,
+				indexBinding,
+				packet.m_resolvedInstanceIndices.GetData(),
+				instanceIndexBytes,
+				0u);
+			packet.m_uploadedInstanceIndices = packet.m_instanceIndices;
+			packet.m_metrics.m_indexUploadBytes += instanceIndexBytes;
 		}
 
-		if (!indirectCommandBuffer.IsValid() || indirectCommandBuffer->GetSize() < indirectBufferSize)
+		const size_t indirectBufferSize = sizeof(DrawIndexedIndirectData) * packet.m_indirectCommands.Num();
+		bool bIndirectBufferChanged = false;
+		if (!indirectCommandBuffer || indirectCommandBuffer->GetSize() < indirectBufferSize)
 		{
-			const size_t slack = 256;
-
-			indirectCommandBuffer.Clear();
-			indirectCommandBuffer = driver->CreateIndirectBuffer(indirectBufferSize + slack);
-
-			// The same indirect buffer is used by the optional GPU-culling path.
-			// Keep its storage descriptor synchronized when streaming adds enough
-			// draw calls to grow the buffer while culling is temporarily unavailable.
+			constexpr size_t IndirectBufferSlack = 256u;
+			indirectCommandBuffer = driver->CreateIndirectBuffer(indirectBufferSize + IndirectBufferSlack);
+			bIndirectBufferChanged = true;
 			if (indirectCommandBufferBinding && *indirectCommandBufferBinding)
 			{
 				driver->AddBufferToShaderBindings(
 					*indirectCommandBufferBinding,
 					indirectCommandBuffer,
 					"drawIndexedIndirect",
-					0);
+					0u);
 			}
 		}
-
-		RHIMaterialPtr prevMaterial = nullptr;
-		RHIShaderBindingSetPtr prevTextureBindings = nullptr;
-		RHIBufferPtr prevVertexBuffer = nullptr;
-		RHIBufferPtr prevIndexBuffer = nullptr;
-
-		size_t indirectBufferOffset = 0;
-		for (uint32_t j = start; j < end; j++)
+		else if (computeCullingShader && indirectCommandBufferBinding &&
+			*indirectCommandBufferBinding &&
+			!(*indirectCommandBufferBinding)->HasBinding("drawIndexedIndirect"))
 		{
-			auto& material = vecBatches[j].m_material;
-			auto& mesh = vecBatches[j].m_mesh;
-			auto& drawCall = drawCalls[vecBatches[j]];
-
-			const bool bMaterialChanged = prevMaterial != material;
-			const bool bTextureBindingsChanged = prevTextureBindings != vecBatches[j].m_textureBindings;
-			if (bMaterialChanged)
-			{
-				commands->BindMaterial(cmdList, material);
-				commands->SetViewport(cmdList, (float)viewport.x, (float)viewport.y,
-					(float)viewport.z,
-					(float)viewport.w,
-					glm::vec2(scissors.x, scissors.y),
-					glm::vec2(scissors.z, scissors.w),
-					depthRange.x,
-					depthRange.y);
-				prevMaterial = material;
-			}
-			if (bMaterialChanged || bTextureBindingsChanged)
-			{
-				TVector<RHIShaderBindingSetPtr> sets = shaderBindings(vecBatches[j]);
-				commands->BindShaderBindings(cmdList, material, sets);
-				prevTextureBindings = vecBatches[j].m_textureBindings;
-			}
-
-			if (prevVertexBuffer != mesh->m_vertexBuffer)
-			{
-				commands->BindVertexBuffer(cmdList, mesh->m_vertexBuffer, 0);
-				prevVertexBuffer = mesh->m_vertexBuffer;
-			}
-
-			if (prevIndexBuffer != mesh->m_indexBuffer)
-			{
-				commands->BindIndexBuffer(cmdList, mesh->m_indexBuffer, 0);
-				prevIndexBuffer = mesh->m_indexBuffer;
-			}
-
-			TVector<RHI::DrawIndexedIndirectData> drawIndirect;
-			drawIndirect.Reserve(drawCall.Num());
-
-			uint32_t ssboOffset = 0;
-			for (const auto& instancedDrawCall : drawCall)
-			{
-				auto& mesh = instancedDrawCall.First();
-				auto& matrices = *instancedDrawCall.Second();
-
-				RHI::DrawIndexedIndirectData data{};
-				data.m_indexCount = mesh->GetIndexCount();
-				data.m_instanceCount = (uint32_t)matrices.Num();
-				data.m_firstIndex = mesh->GetFirstIndex();
-				data.m_vertexOffset = mesh->GetVertexOffset();
-				data.m_firstInstance = storageIndex[j] + ssboOffset;
-
-				drawIndirect.Emplace(std::move(data));
-
-				ssboOffset += (uint32_t)matrices.Num();
-				stats.m_numInstances += (uint32_t)matrices.Num();
-			}
-
-			const size_t bufferSize = sizeof(RHI::DrawIndexedIndirectData) * drawIndirect.Num();
-			if (transferCommandListLock)
-			{
-				transferCommandListLock->Lock();
-				commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
-				transferCommandListLock->Unlock();
-			}
-			else
-			{
-				commands->UpdateBuffer(transferCmdList, indirectCommandBuffer, drawIndirect.GetData(), bufferSize, indirectBufferOffset);
-			}
-			commands->DrawIndexedIndirect(cmdList, indirectCommandBuffer, indirectBufferOffset, (uint32_t)drawIndirect.Num(), sizeof(RHI::DrawIndexedIndirectData));
-			stats.m_numBatches++;
-
-			indirectBufferOffset += bufferSize;
+			driver->AddBufferToShaderBindings(
+				*indirectCommandBufferBinding,
+				indirectCommandBuffer,
+				"drawIndexedIndirect",
+				0u);
 		}
+
+		const bool bResetIndirectCommands = computeCullingShader ||
+			bIndirectBufferChanged ||
+			packet.m_uploadedIndirectBuffer != indirectCommandBuffer ||
+			packet.m_uploadedIndirectCommands.Num() != packet.m_indirectCommands.Num() ||
+			(packet.m_indirectCommands.Num() > 0u && std::memcmp(
+				packet.m_uploadedIndirectCommands.GetData(),
+				packet.m_indirectCommands.GetData(),
+				indirectBufferSize) != 0);
+		if (bResetIndirectCommands)
+		{
+			commands->UpdateBuffer(
+				transferCmdList,
+				indirectCommandBuffer,
+				packet.m_indirectCommands.GetData(),
+				indirectBufferSize,
+				0u);
+			packet.m_uploadedIndirectCommands = packet.m_indirectCommands;
+			packet.m_uploadedIndirectBuffer = indirectCommandBuffer;
+			packet.m_metrics.m_indirectUploadBytes += indirectBufferSize;
+		}
+
+		if (computeCullingShader)
+		{
+			struct PushConstants
+			{
+				uint32_t m_numBatches = 0u;
+				uint32_t m_numInstances = 0u;
+				uint32_t m_firstInstanceIndex = 0u;
+				uint32_t m_firstStorageInstance = 0u;
+				uint32_t m_firstCandidateInstance = 0u;
+				uint32_t m_phase = 0u;
+				uint32_t m_bEnableOcclusion = 0u;
+			};
+
+			PushConstants constants;
+			constants.m_numBatches = static_cast<uint32_t>(groups.Num());
+			constants.m_numInstances = numInstances;
+			constants.m_firstInstanceIndex = firstIndexInstance;
+			constants.m_firstStorageInstance = firstStorageInstance;
+			constants.m_firstCandidateInstance = firstCandidateInstance;
+			commands->BeginDebugRegion(transferCmdList, "GPU Culling", DebugContext::Color_CmdCompute);
+			const EAccessFlags uploadWrites = static_cast<EAccessFlags>(EAccessBit::TransferWrite_Bit) |
+				static_cast<EAccessFlags>(EAccessBit::HostWrite_Bit);
+			const EAccessFlags shaderReadWrite = static_cast<EAccessFlags>(EAccessBit::ShaderRead_Bit) |
+				static_cast<EAccessFlags>(EAccessBit::ShaderWrite_Bit);
+			commands->MemoryBarrier(transferCmdList, uploadWrites, shaderReadWrite);
+
+			const uint32_t cullingGroups = (std::max)(1u,
+				(constants.m_numInstances + Renderer::GPUCullingGroupSize - 1u) / Renderer::GPUCullingGroupSize);
+			commands->Dispatch(
+				transferCmdList,
+				computeCullingShader,
+				cullingGroups,
+				1u,
+				1u,
+				cullingDispatchBindings,
+				&constants,
+				sizeof(constants));
+			commands->MemoryBarrier(
+				transferCmdList,
+				static_cast<EAccessFlags>(EAccessBit::ShaderWrite_Bit),
+				shaderReadWrite);
+
+			constants.m_phase = 1u;
+			const uint32_t compactionGroups = (std::max)(1u,
+				(constants.m_numBatches + Renderer::GPUCullingGroupSize - 1u) / Renderer::GPUCullingGroupSize);
+			commands->Dispatch(
+				transferCmdList,
+				computeCullingShader,
+				compactionGroups,
+				1u,
+				1u,
+				cullingDispatchBindings,
+				&constants,
+				sizeof(constants));
+			commands->EndDebugRegion(transferCmdList);
+		}
+
+#if defined(_WIN32)
+		constexpr uint32_t MaxMeshesPerIndirectBatch = 16384u;
+#else
+		constexpr uint32_t MaxMeshesPerIndirectBatch = 128u;
+#endif
+
+		uint32_t runBegin = 0u;
+		auto& drawBindingSets = packet.m_drawBindingSets;
+		while (runBegin < groups.Num())
+		{
+			const auto& firstGroup = groups[runBegin];
+			const uint32_t runLimit = (std::max)(1u,
+				(std::min)(MaxMeshesPerIndirectBatch, firstGroup.m_batch.m_supportedMeshesPerBatch));
+			uint32_t runEnd = runBegin + 1u;
+			while (runEnd < groups.Num() &&
+				runEnd - runBegin < runLimit &&
+				firstGroup.m_batch == groups[runEnd].m_batch)
+			{
+				++runEnd;
+			}
+
+			const auto& batch = firstGroup.m_batch;
+			commands->BindMaterial(graphicsCmdList, batch.m_material);
+			commands->SetViewport(
+				graphicsCmdList,
+				static_cast<float>(viewport.x),
+				static_cast<float>(viewport.y),
+				static_cast<float>(viewport.z),
+				static_cast<float>(viewport.w),
+				glm::vec2(scissors.x, scissors.y),
+				glm::vec2(scissors.z, scissors.w),
+				depthRange.x,
+				depthRange.y);
+			drawBindingSets.Clear(false);
+			collectShaderBindings(batch, drawBindingSets);
+			commands->BindShaderBindings(
+				graphicsCmdList,
+				batch.m_material,
+				drawBindingSets);
+			commands->BindVertexBuffer(graphicsCmdList, batch.m_mesh->m_vertexBuffer, 0u);
+			commands->BindIndexBuffer(graphicsCmdList, batch.m_mesh->m_indexBuffer, 0u);
+			commands->DrawIndexedIndirect(
+				graphicsCmdList,
+				indirectCommandBuffer,
+				sizeof(DrawIndexedIndirectData) * runBegin,
+				runEnd - runBegin,
+				sizeof(DrawIndexedIndirectData));
+			++stats.m_numBatches;
+			runBegin = runEnd;
+		}
+		drawBindingSets.Clear(false);
 
 		return stats;
 	}
 
-	template<typename TPerInstanceData>
-	DrawCallStats RHIDrawCall(uint32_t start,
-		uint32_t end,
-		const TVector<RHIBatch>& vecBatches,
-		RHI::RHICommandListPtr cmdList,
-		std::function<TVector<RHIShaderBindingSetPtr>(const RHIBatch&)> shaderBindings,
-		const TDrawCalls<TPerInstanceData>& drawCalls,
-		RHIBufferPtr& indirectCommandBuffer,
-		glm::ivec4 viewport,
-		glm::uvec4 scissors,
-		glm::vec2 depthRange = glm::vec2(0.0f, 1.0f))
-	{
-		SAILOR_PROFILE_FUNCTION();
-		DrawCallStats stats;
-
-		auto commands = App::GetSubmodule<RHI::Renderer>()->GetDriverCommands();
-
-		RHIMaterialPtr prevMaterial = nullptr;
-		RHIShaderBindingSetPtr prevTextureBindings = nullptr;
-		RHIBufferPtr prevVertexBuffer = nullptr;
-		RHIBufferPtr prevIndexBuffer = nullptr;
-
-		size_t indirectBufferOffset = 0;
-		for (uint32_t j = start; j < end; j++)
-		{
-			auto& material = vecBatches[j].m_material;
-			auto& mesh = vecBatches[j].m_mesh;
-			auto& drawCall = drawCalls[vecBatches[j]];
-			for (const auto& instancedDrawCall : drawCall)
-			{
-				stats.m_numInstances += (uint32_t)instancedDrawCall.Second()->Num();
-			}
-
-			const bool bMaterialChanged = prevMaterial != material;
-			const bool bTextureBindingsChanged = prevTextureBindings != vecBatches[j].m_textureBindings;
-			if (bMaterialChanged)
-			{
-				commands->BindMaterial(cmdList, material);
-				commands->SetViewport(cmdList, (float)viewport.x, (float)viewport.y,
-					(float)viewport.z,
-					(float)viewport.w,
-					glm::vec2(scissors.x, scissors.y),
-					glm::vec2(scissors.z, scissors.w),
-					depthRange.x,
-					depthRange.y);
-				prevMaterial = material;
-			}
-			if (bMaterialChanged || bTextureBindingsChanged)
-			{
-				TVector<RHIShaderBindingSetPtr> sets = shaderBindings(vecBatches[j]);
-				commands->BindShaderBindings(cmdList, material, sets);
-				prevTextureBindings = vecBatches[j].m_textureBindings;
-			}
-
-			if (prevVertexBuffer != mesh->m_vertexBuffer)
-			{
-				commands->BindVertexBuffer(cmdList, mesh->m_vertexBuffer, 0);
-				prevVertexBuffer = mesh->m_vertexBuffer;
-			}
-
-			if (prevIndexBuffer != mesh->m_indexBuffer)
-			{
-				commands->BindIndexBuffer(cmdList, mesh->m_indexBuffer, 0);
-				prevIndexBuffer = mesh->m_indexBuffer;
-			}
-
-			const size_t bufferSize = sizeof(RHI::DrawIndexedIndirectData) * drawCall.Num();
-			commands->DrawIndexedIndirect(cmdList, indirectCommandBuffer, indirectBufferOffset, (uint32_t)drawCall.Num(), sizeof(RHI::DrawIndexedIndirectData));
-			stats.m_numBatches++;
-
-			indirectBufferOffset += bufferSize;
-		}
-
-		return stats;
-	}
 };

--- a/Runtime/RHI/GraphicsDriver.h
+++ b/Runtime/RHI/GraphicsDriver.h
@@ -73,6 +73,11 @@ namespace Sailor::RHI
 		SAILOR_API virtual bool ShouldFixLostDevice(const Win32::Window* pViewport) = 0;
 		SAILOR_API virtual bool FixLostDevice(Win32::Window* pViewport) = 0;
 
+		// Waits only the flight slot that is about to be reused. This must happen
+		// before FrameGraph preparation mutates any submission-owned resources.
+		SAILOR_API virtual bool BeginRenderSubmission(uint32_t& outFlightSlot, bool& outHasSwapchainImage) = 0;
+		SAILOR_API virtual uint32_t GetMaxFramesInFlight() const = 0;
+
 		SAILOR_API virtual bool AcquireNextImage() = 0;
 		SAILOR_API virtual bool PresentFrame(const Sailor::FrameState& state,
 			const TVector<RHICommandListPtr>& primaryCommandBuffers = {},
@@ -153,6 +158,8 @@ namespace Sailor::RHI
 
 		// Shader binding set
 		SAILOR_API virtual RHIShaderBindingSetPtr CreateShaderBindings() = 0;
+		SAILOR_API virtual RHIShaderBindingSetPtr CloneMaterialShaderBindings(
+			const RHIShaderBindingSetPtr& source) = 0;
 		SAILOR_API virtual RHI::RHIShaderBindingPtr AddBufferToShaderBindings(RHIShaderBindingSetPtr& pShaderBindings, RHIBufferPtr buffer, const std::string& name, uint32_t shaderBinding) = 0;
 		SAILOR_API virtual RHI::RHIShaderBindingPtr AddSsboToShaderBindings(RHIShaderBindingSetPtr& pShaderBindings, const std::string& name, size_t elementSize, size_t numElements, uint32_t shaderBinding, bool bBindSsboWithOffset = false) = 0;
 		SAILOR_API virtual RHI::RHIShaderBindingPtr AddBufferToShaderBindings(RHIShaderBindingSetPtr& pShaderBindings, const std::string& name, size_t size, uint32_t shaderBinding, RHI::EShaderBindingType bufferType) = 0;
@@ -313,6 +320,7 @@ namespace Sailor::RHI
 
 		SAILOR_API virtual void MemoryBarrier(RHI::RHICommandListPtr cmd, RHI::EAccessFlags srcBit, RHI::EAccessFlags dstBit) = 0;
 		SAILOR_API virtual void ImageMemoryBarrier(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr image, RHI::EImageLayout newLayout) = 0;
+		SAILOR_API virtual void ImageMemoryBarrierForComputeSampling(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr image) = 0;
 		SAILOR_API virtual void ImageMemoryBarrier(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr image, RHI::EFormat format, RHI::EImageLayout layout, bool bAllowToWriteFromComputeShader) = 0;
 		SAILOR_API virtual void ImageMemoryBarrier(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr image, RHI::EFormat format, RHI::EImageLayout oldLayout, RHI::EImageLayout newLayout) = 0;
 		SAILOR_API virtual bool BlitImage(RHI::RHICommandListPtr cmd, RHI::RHITexturePtr src, RHI::RHITexturePtr dst, glm::ivec4 srcRegionRect, glm::ivec4 dstRegionRect, RHI::ETextureFiltration filtration = RHI::ETextureFiltration::Linear) = 0;

--- a/Runtime/RHI/Lighting.h
+++ b/Runtime/RHI/Lighting.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Math/Math.h"
+
+#include <cstdint>
+
+namespace Sailor::RHI
+{
+	struct RHILightShaderData
+	{
+		static constexpr uint32_t InvalidType = static_cast<uint32_t>(-1);
+
+		uint32_t m_type = InvalidType;
+		uint32_t m_shadowType = 0u;
+		alignas(16) glm::vec3 m_worldPosition{};
+		alignas(16) glm::vec3 m_direction{};
+		alignas(16) glm::vec3 m_intensity{};
+		alignas(16) glm::vec3 m_attenuation{};
+		alignas(16) glm::vec2 m_cutOff{};
+		alignas(16) glm::vec3 m_bounds{};
+	};
+}

--- a/Runtime/RHI/Material.cpp
+++ b/Runtime/RHI/Material.cpp
@@ -5,9 +5,56 @@
 #include "GraphicsDriver/Vulkan/VulkanApi.h"
 #include "GraphicsDriver/Vulkan/VulkanPipeline.h"
 
+#include <limits>
+
 using namespace Sailor;
 using namespace Sailor::RHI;
 using namespace Sailor::GraphicsDriver::Vulkan;
+
+namespace
+{
+	std::atomic<uint64_t> g_rhiMaterialVersion{ 1ull };
+	std::atomic<uint64_t> g_publishedRhiMaterialRevision{ 1ull };
+	SpinLock g_rhiMaterialPublicationLock;
+	struct ActiveMaterialSubmissionCapture
+	{
+		uint64_t m_submissionId = 0ull;
+		uint64_t m_revision = 0ull;
+	};
+	// CPU packet construction is serialized today, while the renderer supports
+	// up to three flights. Keep one spare slot without allocating per frame.
+	std::array<ActiveMaterialSubmissionCapture, 4u>
+		g_activeMaterialSubmissionCaptures{};
+	TVector<RHIMaterialPtr> g_materialsWithRetainedPublicationHistory;
+
+	uint64_t GetOldestActiveMaterialRevisionLocked()
+	{
+		uint64_t result = (std::numeric_limits<uint64_t>::max)();
+		for (const auto& capture : g_activeMaterialSubmissionCaptures)
+		{
+			if (capture.m_submissionId != 0ull)
+			{
+				result = (std::min)(result, capture.m_revision);
+			}
+		}
+		return result;
+	}
+
+	bool FindActiveMaterialRevisionLocked(
+		uint64_t submissionId,
+		uint64_t& outRevision)
+	{
+		for (const auto& capture : g_activeMaterialSubmissionCaptures)
+		{
+			if (capture.m_submissionId == submissionId)
+			{
+				outRevision = capture.m_revision;
+				return true;
+			}
+		}
+		return false;
+	}
+}
 
 GraphicsDriver::Vulkan::VulkanGraphicsPipelinePtr RHIMaterial::Vulkan::GetOrAddPipeline(const TVector<VkFormat>& colorAttachments, VkFormat depthStencilAttachment)
 {
@@ -175,5 +222,271 @@ bool RHIShaderBindingSet::HasParameter(const std::string& parameter) const
 
 SAILOR_API bool RHIMaterial::IsReady() const
 {
-	return m_vertexShader.IsValid() && m_fragmentShader.IsValid() && m_bindings.IsValid() && m_bindings->IsReady();
+	auto bindings = GetBindings();
+	return m_vertexShader.IsValid() && m_fragmentShader.IsValid() && bindings.IsValid() && bindings->IsReady();
+}
+
+RHIShaderBindingSetPtr RHIMaterial::GetBindings() const
+{
+	m_versionLock.Lock();
+	auto result = m_version ? m_version->GetBindings() : RHIShaderBindingSetPtr{};
+	m_versionLock.Unlock();
+	return result;
+}
+
+RHIMaterialVersionPtr RHIMaterial::GetVersion() const
+{
+	m_versionLock.Lock();
+	auto result = m_version;
+	m_versionLock.Unlock();
+	return result;
+}
+
+RHIMaterialVersionPtr RHIMaterial::GetVersionForSubmission(uint64_t submissionId) const
+{
+	if (submissionId == 0ull)
+	{
+		return GetVersion();
+	}
+
+	const size_t captureIndex =
+		static_cast<size_t>(submissionId % NumSubmissionVersionCaptures);
+	m_versionLock.Lock();
+	if (m_submissionVersionCaptures[captureIndex].m_submissionId == submissionId)
+	{
+		const auto& capture = m_submissionVersionCaptures[captureIndex];
+		auto result = capture.m_uncutVersion ? capture.m_uncutVersion :
+			ResolveVersionLocked(capture.m_publicationRevision);
+		m_versionLock.Unlock();
+		return result;
+	}
+	m_versionLock.Unlock();
+
+	uint64_t publicationRevision = 0ull;
+	g_rhiMaterialPublicationLock.Lock();
+	const bool bHasActiveCapture =
+		FindActiveMaterialRevisionLocked(submissionId, publicationRevision);
+	g_rhiMaterialPublicationLock.Unlock();
+
+	m_versionLock.Lock();
+	auto& capture = m_submissionVersionCaptures[captureIndex];
+	if (capture.m_submissionId != submissionId)
+	{
+		capture.m_submissionId = submissionId;
+		capture.m_publicationRevision = bHasActiveCapture ?
+			publicationRevision : 0ull;
+		capture.m_uncutVersion = bHasActiveCapture ?
+			RHIMaterialVersionPtr{} : m_version;
+	}
+	auto result = capture.m_uncutVersion ? capture.m_uncutVersion :
+		ResolveVersionLocked(capture.m_publicationRevision);
+	m_versionLock.Unlock();
+	return result;
+}
+
+void RHIMaterial::PublishVersionLocked(
+	RHIMaterialVersionPtr version,
+	uint64_t oldestActiveRevision)
+{
+	m_version = std::move(version);
+	m_publishedVersions.Add(m_version);
+	PrunePublishedVersionsLocked(oldestActiveRevision);
+	if (m_publishedVersions.Num() > 1u)
+	{
+		auto self = ToRefPtr<RHIMaterial>();
+		if (!g_materialsWithRetainedPublicationHistory.Contains(self))
+		{
+			g_materialsWithRetainedPublicationHistory.Add(std::move(self));
+		}
+	}
+}
+
+RHIMaterialVersionPtr RHIMaterial::ResolveVersionLocked(
+	uint64_t publicationRevision) const
+{
+	for (size_t index = m_publishedVersions.Num(); index > 0u; --index)
+	{
+		const auto& candidate = m_publishedVersions[index - 1u];
+		if (candidate && candidate->GetPublicationRevision() <= publicationRevision)
+		{
+			return candidate;
+		}
+	}
+	return {};
+}
+
+void RHIMaterial::PrunePublishedVersionsLocked(uint64_t oldestActiveRevision)
+{
+	if (m_publishedVersions.Num() <= 1u)
+	{
+		return;
+	}
+
+	if (oldestActiveRevision == (std::numeric_limits<uint64_t>::max)())
+	{
+		m_publishedVersions.RemoveAt(0u, m_publishedVersions.Num() - 1u);
+		return;
+	}
+
+	size_t firstRequired = 0u;
+	while (firstRequired < m_publishedVersions.Num() &&
+		m_publishedVersions[firstRequired]->GetPublicationRevision() <
+			oldestActiveRevision)
+	{
+		++firstRequired;
+	}
+	if (firstRequired > 0u)
+	{
+		// The newest version before the oldest active cutoff is still needed if
+		// a submission first encounters this material after a later publication.
+		--firstRequired;
+		if (firstRequired > 0u)
+		{
+			m_publishedVersions.RemoveAt(0u, firstRequired);
+		}
+	}
+}
+
+void RHIMaterial::SetBindings(RHIShaderBindingSetPtr bindings)
+{
+	const uint64_t versionId = g_rhiMaterialVersion.fetch_add(1ull, std::memory_order_relaxed);
+	g_rhiMaterialPublicationLock.Lock();
+	const uint64_t publicationRevision =
+		g_publishedRhiMaterialRevision.load(std::memory_order_relaxed) + 1ull;
+	m_versionLock.Lock();
+	PublishVersionLocked(
+		RHIMaterialVersionPtr::Make(
+			versionId,
+			std::move(bindings),
+			publicationRevision),
+		GetOldestActiveMaterialRevisionLocked());
+	m_pendingVersion.Clear();
+	m_versionLock.Unlock();
+	g_publishedRhiMaterialRevision.store(publicationRevision, std::memory_order_release);
+	g_rhiMaterialPublicationLock.Unlock();
+}
+
+void RHIMaterial::StageBindings(RHIShaderBindingSetPtr bindings)
+{
+	const uint64_t versionId = g_rhiMaterialVersion.fetch_add(1ull, std::memory_order_relaxed);
+	m_versionLock.Lock();
+	m_pendingVersion = RHIMaterialVersionPtr::Make(versionId, std::move(bindings));
+	m_versionLock.Unlock();
+}
+
+bool RHIMaterial::TryPublishPendingBindings()
+{
+	m_versionLock.Lock();
+	auto pending = m_pendingVersion;
+	m_versionLock.Unlock();
+	if (!pending || !pending->GetBindings() || !pending->GetBindings()->IsReady())
+	{
+		return false;
+	}
+
+	g_rhiMaterialPublicationLock.Lock();
+	m_versionLock.Lock();
+	if (m_pendingVersion != pending)
+	{
+		m_versionLock.Unlock();
+		g_rhiMaterialPublicationLock.Unlock();
+		return false;
+	}
+	const uint64_t publicationRevision =
+		g_publishedRhiMaterialRevision.load(std::memory_order_relaxed) + 1ull;
+	PublishVersionLocked(
+		RHIMaterialVersionPtr::Make(
+			pending->GetVersionId(),
+			pending->GetBindings(),
+			publicationRevision),
+		GetOldestActiveMaterialRevisionLocked());
+	m_pendingVersion.Clear();
+	m_versionLock.Unlock();
+	g_publishedRhiMaterialRevision.store(publicationRevision, std::memory_order_release);
+	g_rhiMaterialPublicationLock.Unlock();
+	return true;
+}
+
+uint64_t RHIMaterial::GetGlobalPublishedVersionRevision()
+{
+	return g_publishedRhiMaterialRevision.load(std::memory_order_acquire);
+}
+
+uint64_t RHIMaterial::BeginSubmissionVersionCapture(uint64_t submissionId)
+{
+	if (submissionId == 0ull)
+	{
+		return GetGlobalPublishedVersionRevision();
+	}
+
+	g_rhiMaterialPublicationLock.Lock();
+	const uint64_t revision =
+		g_publishedRhiMaterialRevision.load(std::memory_order_relaxed);
+	ActiveMaterialSubmissionCapture* freeCapture = nullptr;
+	for (auto& capture : g_activeMaterialSubmissionCaptures)
+	{
+		if (capture.m_submissionId == submissionId)
+		{
+			freeCapture = &capture;
+			break;
+		}
+		if (!freeCapture && capture.m_submissionId == 0ull)
+		{
+			freeCapture = &capture;
+		}
+	}
+	check(freeCapture);
+	if (freeCapture)
+	{
+		*freeCapture = { submissionId, revision };
+	}
+	g_rhiMaterialPublicationLock.Unlock();
+	return revision;
+}
+
+void RHIMaterial::EndSubmissionVersionCapture(uint64_t submissionId)
+{
+	if (submissionId == 0ull)
+	{
+		return;
+	}
+
+	g_rhiMaterialPublicationLock.Lock();
+	for (auto& capture : g_activeMaterialSubmissionCaptures)
+	{
+		if (capture.m_submissionId == submissionId)
+		{
+			capture = {};
+			break;
+		}
+	}
+
+	const uint64_t oldestActiveRevision =
+		GetOldestActiveMaterialRevisionLocked();
+	size_t writeIndex = 0u;
+	for (size_t readIndex = 0u;
+		readIndex < g_materialsWithRetainedPublicationHistory.Num();
+		++readIndex)
+	{
+		auto& material = g_materialsWithRetainedPublicationHistory[readIndex];
+		if (!material)
+		{
+			continue;
+		}
+		material->m_versionLock.Lock();
+		material->PrunePublishedVersionsLocked(oldestActiveRevision);
+		const bool bKeepRetained = material->m_publishedVersions.Num() > 1u;
+		material->m_versionLock.Unlock();
+		if (bKeepRetained)
+		{
+			if (writeIndex != readIndex)
+			{
+				g_materialsWithRetainedPublicationHistory[writeIndex] =
+					std::move(material);
+			}
+			++writeIndex;
+		}
+	}
+	g_materialsWithRetainedPublicationHistory.Resize(writeIndex);
+	g_rhiMaterialPublicationLock.Unlock();
 }

--- a/Runtime/RHI/Material.h
+++ b/Runtime/RHI/Material.h
@@ -4,6 +4,7 @@
 #include "Containers/Map.h"
 #include "GraphicsDriver/Vulkan/VulkanApi.h"
 #include "GraphicsDriver/Vulkan/VulkanPipeline.h"
+#include <array>
 #include <atomic>
 
 namespace Sailor::RHI
@@ -54,6 +55,35 @@ namespace Sailor::RHI
 		std::atomic<uint32_t> m_variableDescriptorCount{ 0 };
 	};
 
+	/**
+	 * Immutable descriptor/storage generation captured by draw packets. Keeping the
+	 * version alive also keeps its material SSBO allocation and descriptor set alive
+	 * until the owning render submission flight completes.
+	 */
+	class RHIMaterialVersion final : public RHIResource
+	{
+	public:
+		RHIMaterialVersion(
+			uint64_t versionId,
+			RHIShaderBindingSetPtr bindings,
+			uint64_t publicationRevision = 0ull) :
+			m_versionId(versionId),
+			m_bindings(std::move(bindings)),
+			m_publicationRevision(publicationRevision)
+		{}
+
+		uint64_t GetVersionId() const { return m_versionId; }
+		uint64_t GetPublicationRevision() const { return m_publicationRevision; }
+		RHIShaderBindingSetPtr GetBindings() const { return m_bindings; }
+
+	private:
+		uint64_t m_versionId = 0ull;
+		RHIShaderBindingSetPtr m_bindings{};
+		uint64_t m_publicationRevision = 0ull;
+	};
+
+	using RHIMaterialVersionPtr = TRefPtr<RHIMaterialVersion>;
+
 	class RHIMaterial : public RHIResource
 	{
 	public:
@@ -79,17 +109,45 @@ namespace Sailor::RHI
 		SAILOR_API RHIShaderPtr GetVertexShader() const { return m_vertexShader; }
 		SAILOR_API RHIShaderPtr GetFragmentShader() const { return m_fragmentShader; }
 
-		SAILOR_API RHIShaderBindingSetPtr GetBindings() const { return m_bindings; }
-		SAILOR_API void SetBindings(RHIShaderBindingSetPtr bindings) { m_bindings = bindings; }
+		SAILOR_API RHIShaderBindingSetPtr GetBindings() const;
+		SAILOR_API RHIMaterialVersionPtr GetVersion() const;
+		SAILOR_API RHIMaterialVersionPtr GetVersionForSubmission(uint64_t submissionId) const;
+		SAILOR_API void SetBindings(RHIShaderBindingSetPtr bindings);
+		SAILOR_API void StageBindings(RHIShaderBindingSetPtr bindings);
+		SAILOR_API bool TryPublishPendingBindings();
+		SAILOR_API static uint64_t GetGlobalPublishedVersionRevision();
+		SAILOR_API static uint64_t BeginSubmissionVersionCapture(uint64_t submissionId);
+		SAILOR_API static void EndSubmissionVersionCapture(uint64_t submissionId);
 
 	protected:
+		void PublishVersionLocked(
+			RHIMaterialVersionPtr version,
+			uint64_t oldestActiveRevision);
+		RHIMaterialVersionPtr ResolveVersionLocked(uint64_t publicationRevision) const;
+		void PrunePublishedVersionsLocked(uint64_t oldestActiveRevision);
 
 		RHI::RenderState m_renderState;
 
 		RHIShaderPtr m_vertexShader;
 		RHIShaderPtr m_fragmentShader;
 
-		RHIShaderBindingSetPtr m_bindings;
+		mutable SpinLock m_versionLock;
+		RHIMaterialVersionPtr m_version{};
+		RHIMaterialVersionPtr m_pendingVersion{};
+		TVector<RHIMaterialVersionPtr> m_publishedVersions{};
+		struct SubmissionVersionCapture
+		{
+			uint64_t m_submissionId = 0ull;
+			uint64_t m_publicationRevision = 0ull;
+			// Compatibility fallback for callers that did not register a global
+			// submission cutoff. Renderer submissions use only the revision.
+			RHIMaterialVersionPtr m_uncutVersion{};
+		};
+		// One extra entry beyond the required three flights avoids an immediate
+		// modulo collision while the next CPU submission begins.
+		static constexpr size_t NumSubmissionVersionCaptures = 4u;
+		mutable std::array<SubmissionVersionCapture, NumSubmissionVersionCaptures>
+			m_submissionVersionCaptures{};
 
 		friend class IGraphicsDriver;
 	};

--- a/Runtime/RHI/RenderSubmission.h
+++ b/Runtime/RHI/RenderSubmission.h
@@ -1,0 +1,209 @@
+#pragma once
+
+#include "Containers/Map.h"
+#include "Containers/Vector.h"
+#include "Core/SpinLock.h"
+#include "RHI/Types.h"
+
+#include <atomic>
+#include <cstdint>
+#include <utility>
+
+namespace Sailor::RHI
+{
+	class RHISubmissionCompletionToken final : public RHIResource
+	{
+	public:
+		void Reset() const
+		{
+			m_state.store(0u, std::memory_order_release);
+		}
+
+		void Complete(bool bSucceeded) const
+		{
+			m_state.store(bSucceeded ? 2u : 1u, std::memory_order_release);
+		}
+
+		bool IsPending() const
+		{
+			return m_state.load(std::memory_order_acquire) == 0u;
+		}
+
+		bool IsSuccessful() const
+		{
+			return m_state.load(std::memory_order_acquire) == 2u;
+		}
+
+	private:
+		mutable std::atomic<uint8_t> m_state{ 0u };
+	};
+
+	using RHISubmissionCompletionTokenPtr = TRefPtr<RHISubmissionCompletionToken>;
+
+	struct RHIFrameGraphResourceKey
+	{
+		const void* m_owner = nullptr;
+		uint32_t m_cameraIndex = 0u;
+		uint32_t m_variant = 0u;
+		uint64_t m_generation = 0ull;
+
+		bool operator==(const RHIFrameGraphResourceKey& rhs) const
+		{
+			return m_owner == rhs.m_owner &&
+				m_cameraIndex == rhs.m_cameraIndex &&
+				m_variant == rhs.m_variant &&
+				m_generation == rhs.m_generation;
+		}
+
+		size_t GetHash() const
+		{
+			size_t result = std::hash<const void*>{}(m_owner);
+			HashCombine(result, m_cameraIndex);
+			HashCombine(result, m_variant);
+			HashCombine(result, m_generation);
+			return result;
+		}
+	};
+
+	class RHIFrameGraphSubmissionResource : public RHIResource
+	{
+	public:
+		virtual void ResetForSubmission() = 0;
+		virtual void InvalidateSubmission() { ResetForSubmission(); }
+	};
+
+	using RHIFrameGraphSubmissionResourcePtr = TRefPtr<RHIFrameGraphSubmissionResource>;
+
+	/**
+	 * Resources retained by one driver flight slot. The renderer calls BeginSubmission
+	 * only after the slot completion fence has signalled, so derived resources can keep
+	 * capacity and safely overwrite their mutable GPU ranges on the next use.
+	 */
+	class RHIRenderSubmissionContext final : public RHIResource
+	{
+	public:
+		void BeginSubmission(
+			uint64_t submissionId,
+			uint32_t flightSlot,
+			uint64_t sceneRevision = 0ull,
+			uint64_t materialRevision = 0ull,
+			uint64_t resourceGeneration = 0ull)
+		{
+			m_lock.Lock();
+			m_submissionId = submissionId;
+			m_flightSlot = flightSlot;
+			m_sceneRevision = sceneRevision;
+			m_materialRevision = materialRevision;
+			m_resourceGeneration = resourceGeneration;
+			m_resourceReadySemaphore.Clear();
+			m_retainedResources.Clear(false);
+			m_expiredFrameGraphResourcesScratch.Clear(false);
+			m_expiredFrameGraphResourcesScratch.Reserve(m_frameGraphResources.Num());
+			for (const auto& entry : m_frameGraphResources)
+			{
+				if (entry.First().m_generation != resourceGeneration)
+				{
+					m_expiredFrameGraphResourcesScratch.Add(entry.First());
+				}
+			}
+			for (const auto& key : m_expiredFrameGraphResourcesScratch)
+			{
+				m_frameGraphResources.Remove(key);
+			}
+
+			for (const auto& entry : m_frameGraphResources)
+			{
+				if (entry.Second() && *entry.Second())
+				{
+					(*entry.Second())->ResetForSubmission();
+				}
+			}
+			m_lock.Unlock();
+		}
+
+		template<typename TResource, typename... TArgs>
+		TRefPtr<TResource> GetOrAddFrameGraphResources(
+			const void* owner,
+			uint32_t cameraIndex,
+			uint32_t variant,
+			TArgs&&... args) const
+			requires IsBaseOf<RHIFrameGraphSubmissionResource, TResource>
+		{
+			const RHIFrameGraphResourceKey key{
+				owner,
+				cameraIndex,
+				variant,
+				m_resourceGeneration };
+			TRefPtr<TResource> result;
+
+			m_lock.Lock();
+			RHIFrameGraphSubmissionResourcePtr* existing = nullptr;
+			if (m_frameGraphResources.Find(key, existing) && existing && *existing)
+			{
+				result = existing->template DynamicCast<TResource>();
+			}
+
+			if (!result)
+			{
+				result = TRefPtr<TResource>::Make(std::forward<TArgs>(args)...);
+				m_frameGraphResources[key] = result;
+			}
+			m_lock.Unlock();
+
+			return result;
+		}
+
+		void RetainResource(RHIResourcePtr resource)
+		{
+			if (!resource)
+			{
+				return;
+			}
+
+			m_lock.Lock();
+			m_retainedResources.Emplace(std::move(resource));
+			m_lock.Unlock();
+		}
+
+		void SetResourceReadySemaphore(RHISemaphorePtr semaphore)
+		{
+			m_lock.Lock();
+			m_resourceReadySemaphore = std::move(semaphore);
+			m_lock.Unlock();
+		}
+
+		void InvalidateSubmissionResources()
+		{
+			m_lock.Lock();
+			m_resourceReadySemaphore.Clear();
+			for (const auto& entry : m_frameGraphResources)
+			{
+				if (entry.Second() && *entry.Second())
+				{
+					(*entry.Second())->InvalidateSubmission();
+				}
+			}
+			m_lock.Unlock();
+		}
+
+		uint64_t GetSubmissionId() const { return m_submissionId; }
+		uint32_t GetFlightSlot() const { return m_flightSlot; }
+		uint64_t GetSceneRevision() const { return m_sceneRevision; }
+		uint64_t GetMaterialRevision() const { return m_materialRevision; }
+		const RHISemaphorePtr& GetResourceReadySemaphore() const { return m_resourceReadySemaphore; }
+
+	private:
+		mutable SpinLock m_lock;
+		uint64_t m_submissionId = 0ull;
+		uint32_t m_flightSlot = 0u;
+		uint64_t m_sceneRevision = 0ull;
+		uint64_t m_materialRevision = 0ull;
+		uint64_t m_resourceGeneration = 0ull;
+		mutable TMap<RHIFrameGraphResourceKey, RHIFrameGraphSubmissionResourcePtr> m_frameGraphResources;
+		TVector<RHIFrameGraphResourceKey> m_expiredFrameGraphResourcesScratch;
+		TVector<RHIResourcePtr> m_retainedResources;
+		RHISemaphorePtr m_resourceReadySemaphore{};
+	};
+
+	using RHIRenderSubmissionContextPtr = TRefPtr<RHIRenderSubmissionContext>;
+}

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -26,6 +26,28 @@
 using namespace Sailor;
 using namespace Sailor::RHI;
 
+namespace
+{
+	struct RenderSubmissionBeginState
+	{
+		~RenderSubmissionBeginState()
+		{
+			if (m_bMaterialCaptureActive)
+			{
+				RHIMaterial::EndSubmissionVersionCapture(m_submissionId);
+			}
+		}
+
+		bool m_bLifecycleReady = false;
+		bool m_bHasSwapchainImage = false;
+		bool m_bMaterialCaptureActive = false;
+		uint64_t m_submissionId = 0ull;
+		uint64_t m_materialRevision = 0ull;
+		uint32_t m_flightSlot = 0u;
+		RHIRenderSubmissionContextPtr m_context{};
+	};
+}
+
 void IDelayedInitialization::TraceVisit(class TRefPtr<RHIResource> visitor, bool& bShouldRemoveFromList)
 {
 	bShouldRemoveFromList = false;
@@ -77,6 +99,13 @@ Renderer::Renderer(Win32::Window* pViewport, RHI::EMsaaSamples msaaSamples, bool
 	}
 #endif
 	m_bIsInitialized = true;
+
+	const uint32_t numFlightSlots = (std::max)(1u, m_driverInstance->GetMaxFramesInFlight());
+	m_submissionContexts.Resize(numFlightSlots);
+	for (auto& context : m_submissionContexts)
+	{
+		context = RHIRenderSubmissionContextPtr::Make();
+	}
 
 	// Create default Vertices descriptions cache 
 	auto& vertexP3N3UV2C4 = m_driverInstance->GetOrAddVertexDescription<RHI::VertexP3N3UV2C4>();
@@ -317,6 +346,10 @@ bool Renderer::EnsureFrameGraph()
 	}
 
 	m_bFrameGraphOutdated = false;
+	if (m_frameGraph)
+	{
+		++m_frameGraphResourceGeneration;
+	}
 	return m_frameGraph.IsValid();
 }
 
@@ -347,6 +380,15 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 
 	WorldPtr world = frame.GetWorld();
 	RHISceneViewPtr rhiSceneView;
+	const uint64_t currentFrame = world->GetCurrentFrame();
+	const uint64_t submissionId = m_nextSubmissionId.fetch_add(1ull, std::memory_order_relaxed);
+	auto rhiFrameGraph = m_frameGraph->GetRHI();
+	const uint64_t frameGraphResourceGeneration = m_frameGraphResourceGeneration;
+	auto submissionBeginState = TSharedPtr<RenderSubmissionBeginState>::Make();
+	submissionBeginState->m_submissionId = submissionId;
+	submissionBeginState->m_materialRevision =
+		RHIMaterial::BeginSubmissionVersionCapture(submissionId);
+	submissionBeginState->m_bMaterialCaptureActive = true;
 
 	{
 		SAILOR_PROFILE_SCOPE("Copy scene view to render thread");
@@ -361,36 +403,111 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 			pathTracerEcs->CopySceneView(rhiSceneView);
 		}
 		world->GetECS<CameraECS>()->CopyCameraData(rhiSceneView);
-		world->GetECS<LightingECS>()->FillLightingData(rhiSceneView);
-		world->GetECS<AnimationECS>()->FillAnimationData(rhiSceneView);
 
 		rhiSceneView->m_deltaTime = frame.GetDeltaTime();
 		rhiSceneView->m_currentTime = frame.GetWorld()->GetTime();
+	}
 
+	const uint64_t sceneRevision = rhiSceneView->m_sceneRevision;
+	auto acquireRenderSubmission = Tasks::CreateTask(
+		"Acquire render submission flight " + std::to_string(currentFrame),
+		[this, rhiSceneView, submissionId, sceneRevision,
+			frameGraphResourceGeneration, submissionBeginState]()
+		{
+			uint32_t flightSlot = 0u;
+			bool bHasSwapchainImage = false;
+			submissionBeginState->m_bLifecycleReady =
+				m_driverInstance->BeginRenderSubmission(
+					flightSlot,
+					bHasSwapchainImage);
+			submissionBeginState->m_flightSlot = flightSlot;
+			submissionBeginState->m_bHasSwapchainImage = bHasSwapchainImage;
+
+			if (submissionBeginState->m_bLifecycleReady &&
+				flightSlot < m_submissionContexts.Num())
+			{
+				auto context = m_submissionContexts[flightSlot];
+				context->BeginSubmission(
+					submissionId,
+					flightSlot,
+					sceneRevision,
+					submissionBeginState->m_materialRevision,
+					frameGraphResourceGeneration);
+				for (const auto& spatialVersion : rhiSceneView->m_sceneVersions)
+				{
+					if (!spatialVersion || !spatialVersion->m_scene ||
+						!spatialVersion->m_sceneVersion)
+					{
+						continue;
+					}
+
+					auto flightState = spatialVersion->m_scene->PrepareFlight(
+						flightSlot,
+						spatialVersion->m_sceneVersion);
+					context->RetainResource(spatialVersion->m_scene);
+					context->RetainResource(spatialVersion->m_sceneVersion);
+					context->RetainResource(flightState);
+					spatialVersion->m_scene->CollectGarbage();
+				}
+				rhiSceneView->SetSubmissionContext(context);
+				submissionBeginState->m_context = std::move(context);
+			}
+			else
+			{
+				submissionBeginState->m_bLifecycleReady = false;
+				SAILOR_LOG_ERROR(
+					"Renderer::PushFrame: failed to acquire render submission flight slot.");
+			}
+
+			this->GetDriver()->TrackResources_ThreadSafe();
+		},
+		Sailor::EThreadType::Render);
+	if (m_previousRenderFrame.IsValid())
+	{
+		acquireRenderSubmission->Join(m_previousRenderFrame);
+	}
+	acquireRenderSubmission->Run();
+	acquireRenderSubmission->Wait();
+
+	if (!submissionBeginState->m_bLifecycleReady ||
+		!submissionBeginState->m_context)
+	{
+		if (submissionBeginState->m_bMaterialCaptureActive)
+		{
+			RHIMaterial::EndSubmissionVersionCapture(submissionId);
+			submissionBeginState->m_bMaterialCaptureActive = false;
+		}
+		rhiSceneView->Clear();
+		auto& list = m_cachedSceneViews.At_Lock(world);
+		auto it = list.FindIf([&](const auto& el)
+			{
+				return el.m_first == rhiSceneView;
+			});
+		if (it != list.end())
+		{
+			(*it).m_second = true;
+		}
+		m_cachedSceneViews.Unlock(world);
+		return false;
+	}
+
+	{
+		SAILOR_PROFILE_SCOPE("Prepare flight-local scene view");
+		world->GetECS<AnimationECS>()->FillAnimationData(rhiSceneView);
+		world->GetECS<LightingECS>()->FillLightingData(rhiSceneView);
 		rhiSceneView->m_drawImGui = frame.GetDrawImGuiTask();
 		rhiSceneView->PrepareDebugDrawCommandLists(world);
 		rhiSceneView->PrepareSnapshots();
-
 	}
 
 	{
 		SAILOR_PROFILE_SCOPE("Push frame");
 
-		uint64_t currentFrame = world->GetCurrentFrame();
-		auto rhiFrameGraph = m_frameGraph->GetRHI();
-
-		auto renderFrame = Tasks::CreateTask("Trace command lists & Track RHI resources " + std::to_string(currentFrame),
-			[this]() { this->GetDriver()->TrackResources_ThreadSafe(); }, Sailor::EThreadType::Render);
-
 		auto renderFrame1 = Tasks::CreateTask("Render Frame " + std::to_string(currentFrame),
-			[this, rhiFrameGraph = rhiFrameGraph, frame, rhiSceneView]() mutable
+			[this, rhiFrameGraph = rhiFrameGraph, frame, rhiSceneView, submissionId, submissionBeginState]() mutable
 			{
 				SAILOR_PROFILE_SCOPE("Render Frame");
-				if (m_bForceStop)
-				{
-					return;
-				}
-
+				bool bSubmissionResourcesSucceeded = false;
 				auto frameInstance = frame;
 				static Utils::Timer timer;
 				timer.Start();
@@ -425,14 +542,18 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 						return true;
 					};
 
-				const bool bHasSwapchainImage = m_driverInstance->AcquireNextImage();
-				if (bHasSwapchainImage || App::HasEditor())
+				const bool bHasSwapchainImage = submissionBeginState->m_bHasSwapchainImage;
+				if (submissionBeginState->m_bLifecycleReady)
 				{
+					bool bFrameGraphProcessed = false;
 					RHISemaphorePtr chainSemaphore{};
-					bool bFrameSubmitsSucceeded = updateFrameRHI(chainSemaphore);
+					const bool bCanRenderFrame = !m_bForceStop &&
+						(bHasSwapchainImage || App::HasEditor());
+					bool bFrameSubmitsSucceeded = m_bForceStop || updateFrameRHI(chainSemaphore);
 					DrawCallStats drawCallStats;
 
-					if (bFrameSubmitsSucceeded && !m_bFrameGraphOutdated && !m_pViewport->IsIconic())
+					if (bFrameSubmitsSucceeded && bCanRenderFrame &&
+						!m_bFrameGraphOutdated && !m_pViewport->IsIconic())
 					{
 						if (!App::HasEditor())
 						{
@@ -441,19 +562,21 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 						}
 
 						RHISemaphorePtr frameGraphChainSemaphore = chainSemaphore;
-						if (!rhiFrameGraph->Process(
+						const bool bFrameGraphSucceeded = rhiFrameGraph->Process(
 							rhiSceneView,
 							transferCommandLists,
 							primaryCommandLists,
 							chainSemaphore,
-							frameGraphChainSemaphore))
+							frameGraphChainSemaphore);
+						chainSemaphore = frameGraphChainSemaphore;
+						if (!bFrameGraphSucceeded)
 						{
 							SAILOR_LOG_ERROR("Renderer::PushFrame: FrameGraph command buffer submission failed.");
 							bFrameSubmitsSucceeded = false;
 						}
 						else
 						{
-							chainSemaphore = frameGraphChainSemaphore;
+							bFrameGraphProcessed = true;
 							drawCallStats = rhiFrameGraph->GetDrawCallStats();
 						}
 					}
@@ -482,18 +605,26 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 					}
 
 					TVector<RHISemaphorePtr> waitFrameUpdate;
-					if (bFrameSubmitsSucceeded && chainSemaphore)
+					if (chainSemaphore)
 					{
 						waitFrameUpdate.Add(chainSemaphore);
+						if (bFrameSubmitsSucceeded && submissionBeginState->m_context)
+						{
+							submissionBeginState->m_context->SetResourceReadySemaphore(chainSemaphore);
+						}
 					}
 
-					if (!bFrameSubmitsSucceeded && bHasSwapchainImage)
+					if (!bFrameSubmitsSucceeded)
 					{
 						TVector<RHICommandListPtr> noCommandLists;
-						TVector<RHISemaphorePtr> noWaitSemaphores;
-						if (!m_driverInstance->PresentFrame(frame, noCommandLists, noWaitSemaphores))
+						const bool bFlightReleased = bHasSwapchainImage ?
+							m_driverInstance->PresentFrame(frame, noCommandLists, waitFrameUpdate) :
+							m_driverInstance->SubmitFrameWithoutPresent(
+								noCommandLists,
+								waitFrameUpdate);
+						if (!bFlightReleased)
 						{
-							SAILOR_LOG_ERROR("Renderer::PushFrame: failed to release an acquired swapchain image after a submit failure.");
+							SAILOR_LOG_ERROR("Renderer::PushFrame: failed to fence an acquired flight slot after a submit failure.");
 						}
 					}
 
@@ -502,11 +633,12 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 					{
 						bFrameCompleted = bHasSwapchainImage
 							? m_driverInstance->PresentFrame(frame, primaryCommandLists, waitFrameUpdate)
-							: App::HasEditor() && m_driverInstance->SubmitFrameWithoutPresent(primaryCommandLists, waitFrameUpdate);
+							: m_driverInstance->SubmitFrameWithoutPresent(primaryCommandLists, waitFrameUpdate);
 					}
 
 					if (bFrameCompleted)
 					{
+						bSubmissionResourcesSucceeded = bFrameGraphProcessed;
 						m_stats.m_numBatches.store(drawCallStats.m_numBatches, std::memory_order_relaxed);
 						m_stats.m_numInstances.store(drawCallStats.m_numInstances, std::memory_order_relaxed);
 						totalFramesCount++;
@@ -532,16 +664,23 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 					}
 					else
 					{
+						if (submissionBeginState->m_context)
+						{
+							submissionBeginState->m_context->InvalidateSubmissionResources();
+						}
 						m_stats.m_gpuFps.store(0u, std::memory_order_relaxed);
 						m_stats.m_numBatches.store(0u, std::memory_order_relaxed);
 						m_stats.m_numInstances.store(0u, std::memory_order_relaxed);
 					}
 				}
-				else
+				if (submissionBeginState->m_bMaterialCaptureActive)
 				{
-					RHISemaphorePtr chainSemaphore;
-					updateFrameRHI(chainSemaphore);
+					RHIMaterial::EndSubmissionVersionCapture(submissionId);
+					submissionBeginState->m_bMaterialCaptureActive = false;
 				}
+
+				rhiSceneView->CompleteSubmissionResources(
+					bSubmissionResourcesSucceeded);
 
 				{
 					SAILOR_PROFILE_SCOPE("Clear after Present");
@@ -565,20 +704,10 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 
 		for (auto& t : prepareRenderFrame)
 		{
-			t->Join(renderFrame);
-
-			if (m_previousRenderFrame.IsValid())
-			{
-				renderFrame->Join(m_previousRenderFrame);
-			}
-
 			renderFrame1->Join(t);
-
 		}
-		renderFrame1->Join(renderFrame);
 
 		renderFrame1->Run();
-		renderFrame->Run();
 		for (auto& t : prepareRenderFrame)
 		{
 			t->Run();

--- a/Runtime/RHI/Renderer.h
+++ b/Runtime/RHI/Renderer.h
@@ -77,6 +77,9 @@ namespace Sailor::RHI
 		TConcurrentMap<WorldPtr, TList<TPair<RHISceneViewPtr,bool>>, 4, ERehashPolicy::Never> m_cachedSceneViews{};
 			TUniquePtr<IGraphicsDriver> m_driverInstance{};
 			Tasks::ITaskPtr m_previousRenderFrame{};
+			TVector<RHIRenderSubmissionContextPtr> m_submissionContexts{};
+			std::atomic<uint64_t> m_nextSubmissionId = 1ull;
+			uint64_t m_frameGraphResourceGeneration = 0ull;
 			bool m_bIsInitialized = false;
 		};
 	};

--- a/Runtime/RHI/Scene.cpp
+++ b/Runtime/RHI/Scene.cpp
@@ -1,0 +1,880 @@
+#include "RHI/Scene.h"
+
+#include <algorithm>
+#include <cstring>
+
+using namespace Sailor;
+using namespace Sailor::RHI;
+
+bool RHISceneVersion::Resolve(
+	RenderInstanceHandle handle,
+	const RHISceneInstanceRecord*& outRecord) const
+{
+	outRecord = nullptr;
+	if (!handle.IsValid() || !m_recordsRoot)
+	{
+		return false;
+	}
+
+	const uint32_t pageIndex = handle.m_slot / RHISceneRecordPage::NumRecords;
+	const uint32_t slotIndex = handle.m_slot % RHISceneRecordPage::NumRecords;
+	if (pageIndex >= m_recordsRoot->m_pages.Num() || !m_recordsRoot->m_pages[pageIndex])
+	{
+		return false;
+	}
+
+	const auto& slot = m_recordsRoot->m_pages[pageIndex]->m_slots[slotIndex];
+	if (!slot.m_bActive || slot.m_generation != handle.m_generation)
+	{
+		return false;
+	}
+
+	outRecord = &slot.m_record;
+	return true;
+}
+
+bool RHISceneVersion::HasShadowChangesIntersecting(
+	const RHISceneVersion& previousVersion,
+	const Math::Frustum& shadowFrustum) const
+{
+	if (m_recordsRoot == previousVersion.m_recordsRoot)
+	{
+		return false;
+	}
+	if (!m_recordsRoot || !previousVersion.m_recordsRoot)
+	{
+		return true;
+	}
+
+	const size_t numPages = (std::max)(
+		m_recordsRoot->m_pages.Num(),
+		previousVersion.m_recordsRoot->m_pages.Num());
+	for (size_t pageIndex = 0u; pageIndex < numPages; ++pageIndex)
+	{
+		const RHISceneRecordPage* currentPage =
+			pageIndex < m_recordsRoot->m_pages.Num() ?
+			m_recordsRoot->m_pages[pageIndex].GetRawPtr() : nullptr;
+		const RHISceneRecordPage* previousPage =
+			pageIndex < previousVersion.m_recordsRoot->m_pages.Num() ?
+			previousVersion.m_recordsRoot->m_pages[pageIndex].GetRawPtr() : nullptr;
+		if (currentPage == previousPage)
+		{
+			continue;
+		}
+
+		for (uint32_t slotIndex = 0u; slotIndex < RHISceneRecordPage::NumRecords; ++slotIndex)
+		{
+			const RHISceneRecordSlot* current = currentPage ?
+				&currentPage->m_slots[slotIndex] : nullptr;
+			const RHISceneRecordSlot* previous = previousPage ?
+				&previousPage->m_slots[slotIndex] : nullptr;
+			const bool bCurrentCaster = current && current->m_bActive &&
+				(current->m_record.m_renderFlags & 1u) != 0u;
+			const bool bPreviousCaster = previous && previous->m_bActive &&
+				(previous->m_record.m_renderFlags & 1u) != 0u;
+			if (!bCurrentCaster && !bPreviousCaster)
+			{
+				continue;
+			}
+
+			const bool bSameRecord = current && previous &&
+				current->m_bActive == previous->m_bActive &&
+				current->m_generation == previous->m_generation &&
+				current->m_record.m_shadowRevision == previous->m_record.m_shadowRevision &&
+				current->m_record.m_skeletonOffset == previous->m_record.m_skeletonOffset &&
+				current->m_record.m_renderFlags == previous->m_record.m_renderFlags &&
+				current->m_record.m_worldBounds == previous->m_record.m_worldBounds &&
+				std::memcmp(
+					&current->m_record.m_worldMatrix,
+					&previous->m_record.m_worldMatrix,
+					sizeof(glm::mat4)) == 0;
+			if (bSameRecord)
+			{
+				continue;
+			}
+
+			auto intersects = [&shadowFrustum](
+				const RHISceneRecordSlot* slot,
+				bool bCaster)
+				{
+					if (!slot || !bCaster)
+					{
+						return false;
+					}
+					return !slot->m_record.m_worldBounds.IsValid() ||
+						shadowFrustum.OverlapsAABB(slot->m_record.m_worldBounds);
+				};
+			if (intersects(current, bCurrentCaster) ||
+				intersects(previous, bPreviousCaster))
+			{
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+uint32_t RHISceneRangeAllocator::AllocateCapacity(uint32_t count) const
+{
+	uint32_t result = 1u;
+	while (result < count && result <= (std::numeric_limits<uint32_t>::max)() / 2u)
+	{
+		result *= 2u;
+	}
+	return (std::max)(result, count);
+}
+
+SceneRangeHandle RHISceneRangeAllocator::Allocate(uint32_t count)
+{
+	if (count == 0u)
+	{
+		return {};
+	}
+
+	const uint32_t requestedCapacity = AllocateCapacity(count);
+	uint32_t slotIndex = 0u;
+	if (!m_reusableSlots.IsEmpty())
+	{
+		slotIndex = *m_reusableSlots.Last();
+		m_reusableSlots.RemoveLast();
+	}
+	else
+	{
+		slotIndex = static_cast<uint32_t>(m_slots.Num());
+		m_slots.AddDefault(1u);
+	}
+
+	auto& slot = m_slots[slotIndex];
+	slot.m_bActive = true;
+	slot.m_retirementRevision = 0ull;
+	slot.m_allocation = {};
+	for (size_t index = 0u; index < m_freeRanges.Num(); ++index)
+	{
+		auto& freeRange = m_freeRanges[index];
+		if (freeRange.m_bufferGeneration != m_bufferGeneration ||
+			freeRange.m_capacity < requestedCapacity)
+		{
+			continue;
+		}
+
+		slot.m_allocation = {
+			m_bufferGeneration,
+			freeRange.m_offset,
+			count,
+			requestedCapacity };
+		freeRange.m_offset += requestedCapacity;
+		freeRange.m_capacity -= requestedCapacity;
+		if (freeRange.m_capacity == 0u)
+		{
+			m_freeRanges.RemoveAt(index);
+		}
+		break;
+	}
+
+	if (!slot.m_allocation.IsValid())
+	{
+		const uint64_t required = static_cast<uint64_t>(m_nextOffset) + requestedCapacity;
+		if (required > m_capacity)
+		{
+			uint32_t newCapacity = (std::max)(1u, m_capacity);
+			while (newCapacity < required && newCapacity <= (std::numeric_limits<uint32_t>::max)() / 2u)
+			{
+				newCapacity *= 2u;
+			}
+			m_capacity = (std::max)(newCapacity, static_cast<uint32_t>(required));
+			++m_bufferGeneration;
+			if (m_bufferGeneration == 0u)
+			{
+				m_bufferGeneration = 1u;
+			}
+		}
+
+		slot.m_allocation = {
+			m_bufferGeneration,
+			m_nextOffset,
+			count,
+			requestedCapacity };
+		m_nextOffset += requestedCapacity;
+	}
+
+	return { slotIndex, slot.m_generation };
+}
+
+bool RHISceneRangeAllocator::Resolve(
+	SceneRangeHandle handle,
+	PhysicalAllocation& outAllocation) const
+{
+	outAllocation = {};
+	if (!handle.IsValid() || handle.m_slot >= m_slots.Num())
+	{
+		return false;
+	}
+
+	const auto& slot = m_slots[handle.m_slot];
+	if (!slot.m_bActive || slot.m_generation != handle.m_generation)
+	{
+		return false;
+	}
+
+	outAllocation = slot.m_allocation;
+	return true;
+}
+
+bool RHISceneRangeAllocator::Retire(
+	SceneRangeHandle handle,
+	uint64_t retirementRevision)
+{
+	if (!handle.IsValid() || handle.m_slot >= m_slots.Num())
+	{
+		return false;
+	}
+
+	auto& slot = m_slots[handle.m_slot];
+	if (!slot.m_bActive || slot.m_generation != handle.m_generation)
+	{
+		return false;
+	}
+
+	slot.m_bActive = false;
+	slot.m_retirementRevision = retirementRevision;
+	m_retiredSlots.Add(handle.m_slot);
+	return true;
+}
+
+void RHISceneRangeAllocator::MergeFreeRanges()
+{
+	if (m_freeRanges.Num() < 2u)
+	{
+		return;
+	}
+
+	m_freeRanges.Sort([](const FreeRange& lhs, const FreeRange& rhs)
+		{
+			if (lhs.m_bufferGeneration != rhs.m_bufferGeneration)
+			{
+				return lhs.m_bufferGeneration < rhs.m_bufferGeneration;
+			}
+			return lhs.m_offset < rhs.m_offset;
+		});
+
+	size_t writeIndex = 0u;
+	for (size_t readIndex = 1u; readIndex < m_freeRanges.Num(); ++readIndex)
+	{
+		auto& previous = m_freeRanges[writeIndex];
+		const auto& range = m_freeRanges[readIndex];
+		if (previous.m_bufferGeneration == range.m_bufferGeneration &&
+			previous.m_offset + previous.m_capacity == range.m_offset)
+		{
+			previous.m_capacity += range.m_capacity;
+			continue;
+		}
+		++writeIndex;
+		m_freeRanges[writeIndex] = range;
+	}
+	m_freeRanges.Resize(writeIndex + 1u);
+}
+
+void RHISceneRangeAllocator::Collect(uint64_t minimumRetainedRevision)
+{
+	size_t writeIndex = 0u;
+	for (size_t readIndex = 0u; readIndex < m_retiredSlots.Num(); ++readIndex)
+	{
+		const uint32_t slotIndex = m_retiredSlots[readIndex];
+		auto& slot = m_slots[slotIndex];
+		if (minimumRetainedRevision < slot.m_retirementRevision)
+		{
+			m_retiredSlots[writeIndex++] = slotIndex;
+			continue;
+		}
+
+		m_freeRanges.Add({
+			slot.m_allocation.m_bufferGeneration,
+			slot.m_allocation.m_offset,
+			slot.m_allocation.m_capacity });
+		slot.m_allocation = {};
+		slot.m_retirementRevision = 0ull;
+		++slot.m_generation;
+		if (slot.m_generation == 0u)
+		{
+			slot.m_generation = 1u;
+		}
+		m_reusableSlots.Add(slotIndex);
+	}
+	m_retiredSlots.Resize(writeIndex);
+	MergeFreeRanges();
+}
+
+TVector<DirtySceneRange> RHISceneRangeAllocator::CoalesceDirtyRanges(
+	TVector<DirtySceneRange> ranges)
+{
+	size_t validRangeWriteIndex = 0u;
+	for (const auto& range : ranges)
+	{
+		if (range.m_count > 0u)
+		{
+			ranges[validRangeWriteIndex++] = range;
+		}
+	}
+	ranges.Resize(validRangeWriteIndex);
+	ranges.Sort([](const DirtySceneRange& lhs, const DirtySceneRange& rhs)
+		{
+			return lhs.m_offset < rhs.m_offset;
+		});
+
+	if (ranges.Num() < 2u)
+	{
+		return ranges;
+	}
+
+	size_t writeIndex = 0u;
+	for (size_t readIndex = 1u; readIndex < ranges.Num(); ++readIndex)
+	{
+		auto& previous = ranges[writeIndex];
+		const auto& range = ranges[readIndex];
+		const uint64_t previousEnd = static_cast<uint64_t>(previous.m_offset) + previous.m_count;
+		const uint64_t rangeEnd = static_cast<uint64_t>(range.m_offset) + range.m_count;
+		if (range.m_offset <= previousEnd)
+		{
+			previous.m_count = static_cast<uint32_t>(
+				(std::max)(previousEnd, rangeEnd) - previous.m_offset);
+			continue;
+		}
+		++writeIndex;
+		ranges[writeIndex] = range;
+	}
+	ranges.Resize(writeIndex + 1u);
+	return ranges;
+}
+
+RHIScene::RHIScene(uint32_t numFlightSlots)
+{
+	m_currentRoot = RHISceneRecordRootPtr::Make();
+	m_flights.Resize((std::max)(1u, numFlightSlots));
+	for (uint32_t index = 0u; index < m_flights.Num(); ++index)
+	{
+		m_flights[index] = RHISceneFlightStatePtr::Make();
+		m_flights[index]->m_flightSlot = index;
+	}
+}
+
+bool RHIScene::ResolveSlot(RenderInstanceHandle handle, LogicalSlot*& outSlot)
+{
+	outSlot = nullptr;
+	if (!handle.IsValid() || handle.m_slot >= m_slots.Num())
+	{
+		return false;
+	}
+	auto& slot = m_slots[handle.m_slot];
+	if (!slot.m_bActive || slot.m_generation != handle.m_generation)
+	{
+		return false;
+	}
+	outSlot = &slot;
+	return true;
+}
+
+bool RHIScene::ResolveSlot(RenderInstanceHandle handle, const LogicalSlot*& outSlot) const
+{
+	outSlot = nullptr;
+	if (!handle.IsValid() || handle.m_slot >= m_slots.Num())
+	{
+		return false;
+	}
+	const auto& slot = m_slots[handle.m_slot];
+	if (!slot.m_bActive || slot.m_generation != handle.m_generation)
+	{
+		return false;
+	}
+	outSlot = &slot;
+	return true;
+}
+
+void RHIScene::AppendChange(
+	RenderInstanceHandle handle,
+	SceneChangeMask mask)
+{
+	++m_revision;
+	m_journal.Add({ m_revision, handle, mask });
+	if (m_dirtySlotFlags.Num() <= handle.m_slot)
+	{
+		m_dirtySlotFlags.Resize(static_cast<size_t>(handle.m_slot) + 1u);
+	}
+	if (m_dirtySlotFlags[handle.m_slot] == 0u)
+	{
+		m_dirtySlotFlags[handle.m_slot] = 1u;
+		m_dirtySlots.Add(handle.m_slot);
+	}
+	++m_metrics.m_numDirtyChanges;
+}
+
+void RHIScene::BumpMobilityRevision(EMobilityType mobility)
+{
+	switch (mobility)
+	{
+	case EMobilityType::Static:
+		++m_staticRevision;
+		break;
+	case EMobilityType::Stationary:
+		++m_stationaryRevision;
+		break;
+	case EMobilityType::Dynamic:
+		++m_dynamicRevision;
+		break;
+	}
+}
+
+RenderInstanceHandle RHIScene::AddInstance(const RHISceneInstanceRecord& record)
+{
+	m_lock.Lock();
+	uint32_t slotIndex = 0u;
+	if (!m_reusableSlots.IsEmpty())
+	{
+		slotIndex = *m_reusableSlots.Last();
+		m_reusableSlots.RemoveLast();
+	}
+	else
+	{
+		slotIndex = static_cast<uint32_t>(m_slots.Num());
+		m_slots.AddDefault(1u);
+	}
+
+	auto& slot = m_slots[slotIndex];
+	slot.m_bActive = true;
+	slot.m_retirementRevision = 0ull;
+	slot.m_record = record;
+	const RenderInstanceHandle handle{ slotIndex, slot.m_generation };
+	AppendChange(handle, ToMask(ESceneChangeBit::Add));
+	BumpMobilityRevision(record.m_mobility);
+	m_bHandleListsDirty = true;
+	m_lock.Unlock();
+	return handle;
+}
+
+bool RHIScene::UpdateInstance(
+	RenderInstanceHandle handle,
+	const RHISceneInstanceRecord& record,
+	SceneChangeMask changeMask)
+{
+	if (changeMask == ToMask(ESceneChangeBit::None))
+	{
+		return true;
+	}
+
+	m_lock.Lock();
+	LogicalSlot* slot = nullptr;
+	if (!ResolveSlot(handle, slot))
+	{
+		m_lock.Unlock();
+		return false;
+	}
+
+	const EMobilityType oldMobility = slot->m_record.m_mobility;
+	slot->m_record = record;
+	AppendChange(handle, changeMask);
+	BumpMobilityRevision(oldMobility);
+	if (oldMobility != record.m_mobility)
+	{
+		BumpMobilityRevision(record.m_mobility);
+	}
+	if (oldMobility != record.m_mobility ||
+		(changeMask & ToMask(ESceneChangeBit::Mobility)) != 0u)
+	{
+		m_bHandleListsDirty = true;
+	}
+	m_lock.Unlock();
+	return true;
+}
+
+bool RHIScene::RemoveInstance(RenderInstanceHandle handle)
+{
+	m_lock.Lock();
+	LogicalSlot* slot = nullptr;
+	if (!ResolveSlot(handle, slot))
+	{
+		m_lock.Unlock();
+		return false;
+	}
+
+	const EMobilityType oldMobility = slot->m_record.m_mobility;
+	slot->m_bActive = false;
+	AppendChange(handle, ToMask(ESceneChangeBit::Remove));
+	BumpMobilityRevision(oldMobility);
+	slot->m_retirementRevision = m_revision;
+	m_retiredSlots.Add(handle.m_slot);
+	m_bHandleListsDirty = true;
+	m_lock.Unlock();
+	return true;
+}
+
+bool RHIScene::ResolveCurrent(
+	RenderInstanceHandle handle,
+	RHISceneInstanceRecord& outRecord) const
+{
+	m_lock.Lock();
+	const LogicalSlot* slot = nullptr;
+	const bool bResult = ResolveSlot(handle, slot);
+	outRecord = bResult ? slot->m_record : RHISceneInstanceRecord{};
+	m_lock.Unlock();
+	return bResult;
+}
+
+RHISceneRecordRootPtr RHIScene::BuildRecordRoot()
+{
+	if (m_dirtySlots.IsEmpty() && m_currentRoot)
+	{
+		return m_currentRoot;
+	}
+
+	auto root = RHISceneRecordRootPtr::Make();
+	if (m_currentRoot)
+	{
+		root->m_pages = m_currentRoot->m_pages;
+		root->m_generation = m_currentRoot->m_generation;
+	}
+
+	m_cowPageScratch.Clear(false);
+	m_cowPageScratch.Resize(
+		(m_slots.Num() + RHISceneRecordPage::NumRecords - 1u) /
+		RHISceneRecordPage::NumRecords);
+	if (!m_cowPageScratch.IsEmpty())
+	{
+		std::memset(m_cowPageScratch.GetData(), 0, m_cowPageScratch.Num());
+	}
+	for (uint32_t logicalSlotIndex : m_dirtySlots)
+	{
+		const uint32_t pageIndex = logicalSlotIndex / RHISceneRecordPage::NumRecords;
+		const uint32_t pageSlot = logicalSlotIndex % RHISceneRecordPage::NumRecords;
+		if (root->m_pages.Num() <= pageIndex)
+		{
+			root->m_pages.Resize(pageIndex + 1u);
+		}
+
+		if (m_cowPageScratch[pageIndex] == 0u)
+		{
+			root->m_pages[pageIndex] = root->m_pages[pageIndex] ?
+				RHISceneRecordPagePtr::Make(*root->m_pages[pageIndex]) :
+				RHISceneRecordPagePtr::Make();
+			m_cowPageScratch[pageIndex] = 1u;
+			++m_metrics.m_numCowPages;
+			m_metrics.m_copiedCpuBytes += sizeof(RHISceneRecordPage);
+		}
+
+		auto& target = root->m_pages[pageIndex]->m_slots[pageSlot];
+		const auto& source = m_slots[logicalSlotIndex];
+		target.m_generation = source.m_generation;
+		target.m_bActive = source.m_bActive;
+		if (source.m_bActive)
+		{
+			target.m_record = source.m_record;
+		}
+		else
+		{
+			target.m_record = {};
+		}
+	}
+
+	if (!m_dirtySlots.IsEmpty())
+	{
+		++root->m_generation;
+		if (root->m_generation == 0u)
+		{
+			root->m_generation = 1u;
+		}
+	}
+	return root;
+}
+
+void RHIScene::RebuildHandleLists(RHISceneVersion& version)
+{
+	version.m_staticHandles = TSharedPtr<TVector<RenderInstanceHandle>>::Make();
+	version.m_stationaryHandles = TSharedPtr<TVector<RenderInstanceHandle>>::Make();
+	version.m_dynamicHandles = TSharedPtr<TVector<RenderInstanceHandle>>::Make();
+	m_metrics.m_numStaticInstances = 0u;
+	m_metrics.m_numStationaryInstances = 0u;
+	m_metrics.m_numDynamicInstances = 0u;
+
+	for (uint32_t slotIndex = 0u; slotIndex < m_slots.Num(); ++slotIndex)
+	{
+		const auto& slot = m_slots[slotIndex];
+		if (!slot.m_bActive)
+		{
+			continue;
+		}
+		const RenderInstanceHandle handle{ slotIndex, slot.m_generation };
+		switch (slot.m_record.m_mobility)
+		{
+		case EMobilityType::Static:
+			version.m_staticHandles->Add(handle);
+			++m_metrics.m_numStaticInstances;
+			break;
+		case EMobilityType::Stationary:
+			version.m_stationaryHandles->Add(handle);
+			++m_metrics.m_numStationaryInstances;
+			break;
+		case EMobilityType::Dynamic:
+			version.m_dynamicHandles->Add(handle);
+			++m_metrics.m_numDynamicInstances;
+			break;
+		}
+	}
+}
+
+RHISceneVersionPtr RHIScene::PublishVersion(
+	uint64_t materialRevision,
+	uint64_t shadowRevision,
+	uint64_t spatialRevision)
+{
+	m_lock.Lock();
+	if (m_currentVersion &&
+		m_lastPublishedRevision == m_revision &&
+		m_currentVersion->m_materialRevision == materialRevision &&
+		m_currentVersion->m_shadowRevision == shadowRevision &&
+		m_currentVersion->m_spatialRevision == spatialRevision)
+	{
+		auto result = m_currentVersion;
+		m_lock.Unlock();
+		return result;
+	}
+
+	auto version = RHISceneVersionPtr::Make();
+	version->m_sceneRevision = m_revision;
+	version->m_sceneIdentity = reinterpret_cast<uint64_t>(this);
+	version->m_staticRevision = m_staticRevision;
+	version->m_stationaryRevision = m_stationaryRevision;
+	version->m_dynamicRevision = m_dynamicRevision;
+	version->m_materialRevision = materialRevision;
+	version->m_shadowRevision = shadowRevision;
+	version->m_spatialRevision = spatialRevision;
+	version->m_recordsRoot = BuildRecordRoot();
+	version->m_staticRoot = version->m_recordsRoot;
+
+	if (m_bHandleListsDirty || !m_currentVersion)
+	{
+		RebuildHandleLists(*version);
+	}
+	else
+	{
+		version->m_staticHandles = m_currentVersion->m_staticHandles;
+		version->m_stationaryHandles = m_currentVersion->m_stationaryHandles;
+		version->m_dynamicHandles = m_currentVersion->m_dynamicHandles;
+	}
+
+	if (m_currentVersion)
+	{
+		m_retainedVersions.Add(m_currentVersion);
+	}
+	m_currentVersion = version;
+	m_currentRoot = version->m_recordsRoot;
+	m_lastPublishedRevision = m_revision;
+	m_bHandleListsDirty = false;
+	for (uint32_t slotIndex : m_dirtySlots)
+	{
+		m_dirtySlotFlags[slotIndex] = 0u;
+	}
+	m_dirtySlots.Clear(false);
+	m_lock.Unlock();
+	return version;
+}
+
+RHISceneVersionPtr RHIScene::GetCurrentVersion() const
+{
+	m_lock.Lock();
+	auto result = m_currentVersion;
+	m_lock.Unlock();
+	return result;
+}
+
+void RHIScene::RebuildFlight(
+	RHISceneFlightState& flight,
+	const RHISceneVersion& version)
+{
+	flight.m_stationaryHandles = version.m_stationaryHandles;
+	flight.m_stationaryDirtyHandles.Clear(false);
+	flight.m_bStationaryFullRebuild = true;
+	++flight.m_metrics.m_numFullRebuilds;
+}
+
+RHISceneFlightStatePtr RHIScene::PrepareFlight(
+	uint32_t flightSlot,
+	RHISceneVersionPtr targetVersion)
+{
+	m_lock.Lock();
+	if (!targetVersion)
+	{
+		targetVersion = m_currentVersion;
+	}
+	if (!targetVersion)
+	{
+		m_lock.Unlock();
+		return {};
+	}
+
+	if (m_flights.Num() <= flightSlot)
+	{
+		const size_t previousNum = m_flights.Num();
+		m_flights.Resize(flightSlot + 1u);
+		for (size_t index = previousNum; index < m_flights.Num(); ++index)
+		{
+			m_flights[index] = RHISceneFlightStatePtr::Make();
+			m_flights[index]->m_flightSlot = static_cast<uint32_t>(index);
+		}
+	}
+
+	auto flight = m_flights[flightSlot];
+	flight->m_metrics = {};
+	flight->m_bStationaryFullRebuild = false;
+	flight->m_stationaryDirtyHandles.Clear(false);
+	const uint64_t firstJournalRevision = m_journal.IsEmpty() ?
+		m_revision + 1ull : m_journal[0].m_revision;
+	const bool bNeedsFullRebuild = flight->m_appliedRevision == 0ull ||
+		flight->m_appliedRevision > targetVersion->m_sceneRevision ||
+		flight->m_appliedRevision + 1ull < firstJournalRevision;
+
+	if (bNeedsFullRebuild)
+	{
+		RebuildFlight(*flight, *targetVersion);
+	}
+	else if (flight->m_appliedRevision < targetVersion->m_sceneRevision)
+	{
+		auto& coalesced = flight->m_coalescedHandlesScratch;
+		coalesced.Clear(false);
+		if (flight->m_coalescedSlotFlags.Num() < m_slots.Num())
+		{
+			flight->m_coalescedSlotFlags.Resize(m_slots.Num());
+		}
+		uint32_t numJournalChanges = 0u;
+		for (const auto& change : m_journal)
+		{
+			if (change.m_revision > flight->m_appliedRevision &&
+				change.m_revision <= targetVersion->m_sceneRevision)
+			{
+				++numJournalChanges;
+				if (flight->m_coalescedSlotFlags[change.m_handle.m_slot] == 0u)
+				{
+					flight->m_coalescedSlotFlags[change.m_handle.m_slot] = 1u;
+					coalesced.Add(change.m_handle);
+				}
+			}
+		}
+		flight->m_metrics.m_numDirtyChanges = numJournalChanges;
+		flight->m_metrics.m_numCoalescedChanges = static_cast<uint32_t>(coalesced.Num());
+		flight->m_stationaryDirtyHandles.Reserve(coalesced.Num());
+		for (const auto& handle : coalesced)
+		{
+			const RHISceneInstanceRecord* targetRecord = nullptr;
+			const RHISceneInstanceRecord* previousRecord = nullptr;
+			const bool bTouchesStationary =
+				(targetVersion->Resolve(handle, targetRecord) && targetRecord &&
+					targetRecord->m_mobility == EMobilityType::Stationary) ||
+				(flight->m_appliedVersion &&
+					flight->m_appliedVersion->Resolve(handle, previousRecord) &&
+					previousRecord &&
+					previousRecord->m_mobility == EMobilityType::Stationary);
+			if (bTouchesStationary)
+			{
+				flight->m_stationaryDirtyHandles.Add(handle);
+			}
+			flight->m_coalescedSlotFlags[handle.m_slot] = 0u;
+		}
+		flight->m_metrics.m_copiedCpuBytes +=
+			flight->m_stationaryDirtyHandles.Num() * sizeof(RenderInstanceHandle);
+	}
+
+	flight->m_stationaryHandles = targetVersion->m_stationaryHandles;
+	flight->m_dynamicHandles = targetVersion->m_dynamicHandles;
+	flight->m_appliedVersion = targetVersion;
+	flight->m_appliedRevision = targetVersion->m_sceneRevision;
+	m_metrics.m_numCoalescedChanges += flight->m_metrics.m_numCoalescedChanges;
+	m_metrics.m_numFullRebuilds += flight->m_metrics.m_numFullRebuilds;
+	m_metrics.m_copiedCpuBytes += flight->m_metrics.m_copiedCpuBytes;
+	m_metrics.m_dynamicRewriteBytes += flight->m_metrics.m_dynamicRewriteBytes;
+	m_lock.Unlock();
+	return flight;
+}
+
+uint64_t RHIScene::MinimumRetainedRevision() const
+{
+	uint64_t result = m_currentVersion ? m_currentVersion->m_sceneRevision : m_revision;
+	for (const auto& flight : m_flights)
+	{
+		if (flight && flight->m_appliedRevision > 0ull)
+		{
+			result = (std::min)(result, flight->m_appliedRevision);
+		}
+	}
+	for (const auto& version : m_retainedVersions)
+	{
+		if (version && version.NumRefs() > 1u)
+		{
+			result = (std::min)(result, version->m_sceneRevision);
+		}
+	}
+	return result;
+}
+
+void RHIScene::CollectGarbage()
+{
+	m_lock.Lock();
+	const uint64_t minimumRetainedRevision = MinimumRetainedRevision();
+	size_t firstRetainedJournalEntry = 0u;
+	while (firstRetainedJournalEntry < m_journal.Num() &&
+		m_journal[firstRetainedJournalEntry].m_revision <= minimumRetainedRevision)
+	{
+		++firstRetainedJournalEntry;
+	}
+	if (firstRetainedJournalEntry > 0u)
+	{
+		m_journal.RemoveAt(0u, firstRetainedJournalEntry);
+	}
+
+	size_t retiredWriteIndex = 0u;
+	for (size_t retiredReadIndex = 0u;
+		retiredReadIndex < m_retiredSlots.Num();
+		++retiredReadIndex)
+	{
+		const uint32_t slotIndex = m_retiredSlots[retiredReadIndex];
+		auto& slot = m_slots[slotIndex];
+		if (minimumRetainedRevision < slot.m_retirementRevision)
+		{
+			m_retiredSlots[retiredWriteIndex++] = slotIndex;
+			continue;
+		}
+		++slot.m_generation;
+		if (slot.m_generation == 0u)
+		{
+			slot.m_generation = 1u;
+		}
+		slot.m_retirementRevision = 0ull;
+		slot.m_record = {};
+		m_reusableSlots.Add(slotIndex);
+	}
+	m_retiredSlots.Resize(retiredWriteIndex);
+
+	size_t versionWriteIndex = 0u;
+	for (size_t versionReadIndex = 0u;
+		versionReadIndex < m_retainedVersions.Num();
+		++versionReadIndex)
+	{
+		auto& version = m_retainedVersions[versionReadIndex];
+		if (!version || version.NumRefs() == 1u)
+		{
+			continue;
+		}
+		if (versionWriteIndex != versionReadIndex)
+		{
+			m_retainedVersions[versionWriteIndex] = std::move(version);
+		}
+		++versionWriteIndex;
+	}
+	m_retainedVersions.Resize(versionWriteIndex);
+	m_lock.Unlock();
+}
+
+uint64_t RHIScene::GetJournalFirstRevision() const
+{
+	m_lock.Lock();
+	const uint64_t result = m_journal.IsEmpty() ? m_revision + 1ull : m_journal[0].m_revision;
+	m_lock.Unlock();
+	return result;
+}

--- a/Runtime/RHI/Scene.h
+++ b/Runtime/RHI/Scene.h
@@ -1,0 +1,309 @@
+#pragma once
+
+#include "Containers/Map.h"
+#include "Containers/Set.h"
+#include "Containers/Vector.h"
+#include "Core/SpinLock.h"
+#include "Engine/Types.h"
+#include "Math/Math.h"
+#include "Math/Bounds.h"
+#include "Memory/SharedPtr.hpp"
+#include "RHI/Types.h"
+
+#include <limits>
+
+namespace Sailor::RHI
+{
+	template<typename TTag>
+	struct TGenerationalRenderHandle
+	{
+		uint32_t m_slot = (std::numeric_limits<uint32_t>::max)();
+		uint32_t m_generation = 0u;
+
+		bool IsValid() const
+		{
+			return m_slot != (std::numeric_limits<uint32_t>::max)() && m_generation != 0u;
+		}
+
+		bool operator==(const TGenerationalRenderHandle& rhs) const
+		{
+			return m_slot == rhs.m_slot && m_generation == rhs.m_generation;
+		}
+
+		size_t GetHash() const
+		{
+			size_t result = std::hash<uint32_t>{}(m_slot);
+			HashCombine(result, m_generation);
+			return result;
+		}
+	};
+
+	struct RenderInstanceHandleTag;
+	struct RenderItemHandleTag;
+	struct SceneRangeHandleTag;
+	struct MaterialVersionHandleTag;
+	struct ShadowTileHandleTag;
+
+	using RenderInstanceHandle = TGenerationalRenderHandle<RenderInstanceHandleTag>;
+	using RenderItemHandle = TGenerationalRenderHandle<RenderItemHandleTag>;
+	using SceneRangeHandle = TGenerationalRenderHandle<SceneRangeHandleTag>;
+	using MaterialVersionHandle = TGenerationalRenderHandle<MaterialVersionHandleTag>;
+	using ShadowTileHandle = TGenerationalRenderHandle<ShadowTileHandleTag>;
+
+	enum class ESceneChangeBit : uint32_t
+	{
+		None = 0u,
+		Add = 1u << 0u,
+		Remove = 1u << 1u,
+		Transform = 1u << 2u,
+		Bounds = 1u << 3u,
+		MeshOrLodTopology = 1u << 4u,
+		Material = 1u << 5u,
+		RenderState = 1u << 6u,
+		ShadowState = 1u << 7u,
+		SkeletonOffset = 1u << 8u,
+		Mobility = 1u << 9u,
+		ReplaceChunkRange = 1u << 10u,
+		ReplaceBulkRange = 1u << 11u
+	};
+
+	using SceneChangeMask = uint32_t;
+
+	constexpr SceneChangeMask ToMask(ESceneChangeBit bit)
+	{
+		return static_cast<SceneChangeMask>(bit);
+	}
+
+	constexpr SceneChangeMask operator|(ESceneChangeBit lhs, ESceneChangeBit rhs)
+	{
+		return ToMask(lhs) | ToMask(rhs);
+	}
+
+	struct PhysicalAllocation
+	{
+		uint32_t m_bufferGeneration = 0u;
+		uint32_t m_offset = 0u;
+		uint32_t m_count = 0u;
+		uint32_t m_capacity = 0u;
+
+		bool IsValid() const { return m_bufferGeneration != 0u && m_capacity != 0u; }
+	};
+
+	struct DirtySceneRange
+	{
+		uint32_t m_offset = 0u;
+		uint32_t m_count = 0u;
+	};
+
+	struct RHISceneInstanceRecord
+	{
+		uint64_t m_producerKey = 0ull;
+		EMobilityType m_mobility = EMobilityType::Static;
+		glm::mat4 m_worldMatrix{ 1.0f };
+		Math::AABB m_worldBounds{};
+		RHIResourcePtr m_topology{};
+		uint64_t m_topologyRevision = 0ull;
+		uint64_t m_materialRevision = 0ull;
+		uint64_t m_shadowRevision = 0ull;
+		uint32_t m_skeletonOffset = (std::numeric_limits<uint32_t>::max)();
+		uint32_t m_renderFlags = 0u;
+	};
+
+	static_assert(sizeof(RHISceneInstanceRecord) <= 160u,
+		"Persistent scene records must not accumulate pass-local allocation metadata.");
+
+	struct RHISceneChangeEntry
+	{
+		uint64_t m_revision = 0ull;
+		RenderInstanceHandle m_handle{};
+		SceneChangeMask m_changeMask = ToMask(ESceneChangeBit::None);
+	};
+
+	static_assert(sizeof(RHISceneChangeEntry) <= 24u,
+		"The change journal must not duplicate complete scene records.");
+
+	struct RHISceneMetrics
+	{
+		uint32_t m_numStaticInstances = 0u;
+		uint32_t m_numStationaryInstances = 0u;
+		uint32_t m_numDynamicInstances = 0u;
+		uint32_t m_numDirtyChanges = 0u;
+		uint32_t m_numCoalescedChanges = 0u;
+		uint32_t m_numCowPages = 0u;
+		uint32_t m_numFullRebuilds = 0u;
+		uint64_t m_copiedCpuBytes = 0ull;
+		uint64_t m_dynamicRewriteBytes = 0ull;
+	};
+
+	struct RHISceneRecordSlot
+	{
+		uint32_t m_generation = 0u;
+		bool m_bActive = false;
+		RHISceneInstanceRecord m_record{};
+	};
+
+	struct RHISceneRecordPage
+	{
+		static constexpr uint32_t NumRecords = 64u;
+		RHISceneRecordSlot m_slots[NumRecords]{};
+	};
+
+	using RHISceneRecordPagePtr = TSharedPtr<RHISceneRecordPage>;
+
+	class RHISceneRecordRoot final : public RHIResource
+	{
+	public:
+		TVector<RHISceneRecordPagePtr> m_pages{};
+		uint32_t m_generation = 1u;
+	};
+
+	using RHISceneRecordRootPtr = TRefPtr<RHISceneRecordRoot>;
+
+	class RHISceneVersion final : public RHIResource
+	{
+	public:
+		bool Resolve(RenderInstanceHandle handle, const RHISceneInstanceRecord*& outRecord) const;
+		bool HasShadowChangesIntersecting(
+			const RHISceneVersion& previousVersion,
+			const Math::Frustum& shadowFrustum) const;
+
+		uint64_t m_sceneRevision = 0ull;
+		uint64_t m_sceneIdentity = 0ull;
+		uint64_t m_staticRevision = 0ull;
+		uint64_t m_stationaryRevision = 0ull;
+		uint64_t m_dynamicRevision = 0ull;
+		uint64_t m_materialRevision = 0ull;
+		uint64_t m_shadowRevision = 0ull;
+		uint64_t m_spatialRevision = 0ull;
+		RHISceneRecordRootPtr m_staticRoot{};
+		RHISceneRecordRootPtr m_recordsRoot{};
+		TSharedPtr<TVector<RenderInstanceHandle>> m_staticHandles{};
+		TSharedPtr<TVector<RenderInstanceHandle>> m_stationaryHandles{};
+		TSharedPtr<TVector<RenderInstanceHandle>> m_dynamicHandles{};
+	};
+
+	using RHISceneVersionPtr = TRefPtr<RHISceneVersion>;
+
+	class RHISceneFlightState final : public RHIResource
+	{
+	public:
+		uint32_t m_flightSlot = 0u;
+		uint64_t m_appliedRevision = 0ull;
+		RHISceneVersionPtr m_appliedVersion{};
+		TSharedPtr<TVector<RenderInstanceHandle>> m_stationaryHandles{};
+		TSharedPtr<TVector<RenderInstanceHandle>> m_dynamicHandles{};
+		TVector<RenderInstanceHandle> m_stationaryDirtyHandles{};
+		TVector<RenderInstanceHandle> m_coalescedHandlesScratch{};
+		TVector<uint8_t> m_coalescedSlotFlags{};
+		bool m_bStationaryFullRebuild = false;
+		RHISceneMetrics m_metrics{};
+	};
+
+	using RHISceneFlightStatePtr = TRefPtr<RHISceneFlightState>;
+
+	class RHISceneRangeAllocator
+	{
+	public:
+		SceneRangeHandle Allocate(uint32_t count);
+		bool Resolve(SceneRangeHandle handle, PhysicalAllocation& outAllocation) const;
+		bool Retire(SceneRangeHandle handle, uint64_t retirementRevision);
+		void Collect(uint64_t minimumRetainedRevision);
+		uint32_t GetBufferGeneration() const { return m_bufferGeneration; }
+		uint32_t GetCapacity() const { return m_capacity; }
+
+		static TVector<DirtySceneRange> CoalesceDirtyRanges(TVector<DirtySceneRange> ranges);
+
+	private:
+		struct RangeSlot
+		{
+			uint32_t m_generation = 1u;
+			bool m_bActive = false;
+			uint64_t m_retirementRevision = 0ull;
+			PhysicalAllocation m_allocation{};
+		};
+
+		struct FreeRange
+		{
+			uint32_t m_bufferGeneration = 0u;
+			uint32_t m_offset = 0u;
+			uint32_t m_capacity = 0u;
+		};
+
+		uint32_t AllocateCapacity(uint32_t count) const;
+		void MergeFreeRanges();
+
+		TVector<RangeSlot> m_slots{};
+		TVector<uint32_t> m_reusableSlots{};
+		TVector<uint32_t> m_retiredSlots{};
+		TVector<FreeRange> m_freeRanges{};
+		uint32_t m_bufferGeneration = 1u;
+		uint32_t m_capacity = 0u;
+		uint32_t m_nextOffset = 0u;
+	};
+
+	class RHIScene final : public RHIResource
+	{
+	public:
+		explicit RHIScene(uint32_t numFlightSlots = 2u);
+
+		RenderInstanceHandle AddInstance(const RHISceneInstanceRecord& record);
+		bool UpdateInstance(
+			RenderInstanceHandle handle,
+			const RHISceneInstanceRecord& record,
+			SceneChangeMask changeMask);
+		bool RemoveInstance(RenderInstanceHandle handle);
+		bool ResolveCurrent(RenderInstanceHandle handle, RHISceneInstanceRecord& outRecord) const;
+
+		RHISceneVersionPtr PublishVersion(
+			uint64_t materialRevision = 0ull,
+			uint64_t shadowRevision = 0ull,
+			uint64_t spatialRevision = 0ull);
+		RHISceneVersionPtr GetCurrentVersion() const;
+		RHISceneFlightStatePtr PrepareFlight(uint32_t flightSlot, RHISceneVersionPtr targetVersion);
+		void CollectGarbage();
+
+		uint64_t GetRevision() const { return m_revision; }
+		uint64_t GetJournalFirstRevision() const;
+		const RHISceneMetrics& GetMetrics() const { return m_metrics; }
+
+	private:
+		struct LogicalSlot
+		{
+			uint32_t m_generation = 1u;
+			bool m_bActive = false;
+			uint64_t m_retirementRevision = 0ull;
+			RHISceneInstanceRecord m_record{};
+		};
+
+		bool ResolveSlot(RenderInstanceHandle handle, LogicalSlot*& outSlot);
+		bool ResolveSlot(RenderInstanceHandle handle, const LogicalSlot*& outSlot) const;
+		void AppendChange(RenderInstanceHandle handle, SceneChangeMask mask);
+		void BumpMobilityRevision(EMobilityType mobility);
+		void RebuildHandleLists(RHISceneVersion& version);
+		RHISceneRecordRootPtr BuildRecordRoot();
+		void RebuildFlight(RHISceneFlightState& flight, const RHISceneVersion& version);
+		uint64_t MinimumRetainedRevision() const;
+
+		mutable SpinLock m_lock;
+		uint64_t m_revision = 0ull;
+		uint64_t m_staticRevision = 0ull;
+		uint64_t m_stationaryRevision = 0ull;
+		uint64_t m_dynamicRevision = 0ull;
+		uint64_t m_lastPublishedRevision = (std::numeric_limits<uint64_t>::max)();
+		bool m_bHandleListsDirty = true;
+		TVector<LogicalSlot> m_slots{};
+		TVector<uint32_t> m_reusableSlots{};
+		TVector<uint32_t> m_retiredSlots{};
+		TVector<uint32_t> m_dirtySlots{};
+		TVector<uint8_t> m_dirtySlotFlags{};
+		TVector<uint8_t> m_cowPageScratch{};
+		TVector<RHISceneChangeEntry> m_journal{};
+		RHISceneRecordRootPtr m_currentRoot{};
+		RHISceneVersionPtr m_currentVersion{};
+		TVector<RHISceneVersionPtr> m_retainedVersions{};
+		TVector<RHISceneFlightStatePtr> m_flights{};
+		RHISceneMetrics m_metrics{};
+	};
+
+	using RHIScenePtr = TRefPtr<RHIScene>;
+}

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -19,6 +19,676 @@
 using namespace Sailor;
 using namespace Sailor::RHI;
 
+namespace
+{
+	bool TryNormalizeProxyTransforms(RHISceneProxyResource& resource)
+	{
+		const glm::mat4& referenceWorld = resource.m_proxy.m_worldMatrix;
+		const float determinant = glm::determinant(referenceWorld);
+		if (!std::isfinite(determinant) || std::abs(determinant) <= 1e-8f)
+		{
+			return false;
+		}
+
+		const glm::mat4 inverseWorld = glm::inverse(referenceWorld);
+		if (!Math::AllFinite(inverseWorld[0]) ||
+			!Math::AllFinite(inverseWorld[1]) ||
+			!Math::AllFinite(inverseWorld[2]) ||
+			!Math::AllFinite(inverseWorld[3]))
+		{
+			return false;
+		}
+
+		for (auto& meshMatrix : resource.m_proxy.m_meshModelMatrices)
+		{
+			meshMatrix = inverseWorld * meshMatrix;
+		}
+		if (resource.m_proxy.m_shadowCaster)
+		{
+			resource.m_proxy.m_shadowCaster = RHIShadowCasterProxyPtr::Make(
+				*resource.m_proxy.m_shadowCaster);
+			for (auto& shadowMesh : resource.m_proxy.m_shadowCaster->m_meshes)
+			{
+				shadowMesh.m_worldMatrix = inverseWorld * shadowMesh.m_worldMatrix;
+			}
+		}
+		resource.m_bMeshTransformsAreLocal = true;
+		return true;
+	}
+
+	void HashMatrix(size_t& result, const glm::mat4& matrix)
+	{
+		HashCombine(result, std::hash<glm::mat4>{}(matrix));
+	}
+
+	void HashMaterialVersion(size_t& result, const RHIMaterialPtr& material)
+	{
+		if (!material)
+		{
+			HashCombine(result, 0u);
+			return;
+		}
+
+		const auto version = material->GetVersion();
+		HashCombine(
+			result,
+			material,
+			version ? version->GetVersionId() : 0ull,
+			Sailor::GetHash(material->GetRenderState()));
+	}
+
+#if defined(__APPLE__)
+	void HashTextureSet(size_t& result, const TSet<uint32_t>& textures)
+	{
+		auto sortedTextures = textures.ToVector();
+		sortedTextures.Sort();
+		HashCombine(result, sortedTextures.Num());
+		for (uint32_t texture : sortedTextures)
+		{
+			HashCombine(result, texture);
+		}
+	}
+#endif
+
+	void CalculateProxyResourceRevisions(RHISceneProxyResource& resource)
+	{
+		const auto& proxy = resource.m_proxy;
+		size_t geometryRevision = 1469598103934665603ull;
+		HashCombine(
+			geometryRevision,
+			proxy.m_meshes.Num(),
+			proxy.m_meshModelMatrices.Num(),
+			proxy.m_instancedGroups.Num(),
+			proxy.m_lodPolicy.m_bEnabled,
+			proxy.m_lodPolicy.m_minLod,
+			proxy.m_lodPolicy.m_maxLod,
+			std::hash<float>{}(proxy.m_lodPolicy.m_maxCameraDistance));
+		for (float threshold : proxy.m_lodPolicy.m_screenCoverageThresholds)
+		{
+			HashCombine(geometryRevision, std::hash<float>{}(threshold));
+		}
+		for (const auto& mesh : proxy.m_meshes)
+		{
+			HashCombine(geometryRevision, mesh);
+		}
+		for (const auto& matrix : proxy.m_meshModelMatrices)
+		{
+			HashMatrix(geometryRevision, matrix);
+		}
+		for (const auto& group : proxy.m_instancedGroups)
+		{
+			HashCombine(
+				geometryRevision,
+				group.m_instanceTransforms.Num(),
+				group.m_meshes.Num(),
+				group.m_bCastShadows,
+				std::hash<float>{}(group.m_maxShadowDistance));
+			for (const auto& mesh : group.m_meshes)
+			{
+				HashCombine(geometryRevision, mesh);
+			}
+			for (const auto& matrix : group.m_meshTransforms)
+			{
+				HashMatrix(geometryRevision, matrix);
+			}
+			for (const auto& matrix : group.m_instanceTransforms)
+			{
+				HashMatrix(geometryRevision, matrix);
+			}
+		}
+		resource.m_geometryRevision = geometryRevision;
+
+		size_t mainRevision = geometryRevision;
+		for (const auto& material : proxy.m_overrideMaterials)
+		{
+			HashMaterialVersion(mainRevision, material);
+		}
+#if defined(__APPLE__)
+		for (const auto& textures : proxy.m_materialTextureSamplers)
+		{
+			HashTextureSet(mainRevision, textures);
+		}
+#endif
+		for (const auto& group : proxy.m_instancedGroups)
+		{
+			for (const auto& material : group.m_materials)
+			{
+				HashMaterialVersion(mainRevision, material);
+			}
+#if defined(__APPLE__)
+			for (const auto& textures : group.m_materialTextureSamplers)
+			{
+				HashTextureSet(mainRevision, textures);
+			}
+#endif
+		}
+		resource.m_mainRevision = mainRevision;
+
+		const size_t maskedQueue = GetHash(std::string("Masked"));
+		size_t depthRevision = geometryRevision;
+		auto hashDepthMaterial = [&](const RHIMaterialPtr& material,
+			size_t renderQueue,
+			const glm::vec4& baseColor,
+			uint32_t baseColorSampler,
+			float alphaCutoff)
+			{
+				if (!material)
+				{
+					HashCombine(depthRevision, 0u);
+					return;
+				}
+
+				const auto& state = material->GetRenderState();
+				HashCombine(
+					depthRevision,
+					renderQueue,
+					static_cast<uint32_t>(state.GetCullMode()),
+					state.IsRequiredCustomDepthShader());
+				if (state.IsRequiredCustomDepthShader())
+				{
+					HashMaterialVersion(depthRevision, material);
+				}
+				if (renderQueue == maskedQueue)
+				{
+					HashCombine(
+						depthRevision,
+						std::hash<glm::vec4>{}(baseColor),
+						baseColorSampler,
+						std::hash<float>{}(alphaCutoff));
+				}
+			};
+		for (size_t index = 0u; index < proxy.m_overrideMaterials.Num(); ++index)
+		{
+			hashDepthMaterial(
+				proxy.m_overrideMaterials[index],
+				index < proxy.m_renderQueueTags.Num() ? proxy.m_renderQueueTags[index] : 0u,
+				index < proxy.m_baseColorFactors.Num() ? proxy.m_baseColorFactors[index] : glm::vec4(1.0f),
+				index < proxy.m_baseColorSamplers.Num() ? proxy.m_baseColorSamplers[index] : 0u,
+				index < proxy.m_alphaCutoffs.Num() ? proxy.m_alphaCutoffs[index] : 0.5f);
+		}
+		for (const auto& group : proxy.m_instancedGroups)
+		{
+			for (size_t index = 0u; index < group.m_materials.Num(); ++index)
+			{
+				hashDepthMaterial(
+					group.m_materials[index],
+					index < group.m_renderQueueTags.Num() ? group.m_renderQueueTags[index] : 0u,
+					index < group.m_baseColorFactors.Num() ? group.m_baseColorFactors[index] : glm::vec4(1.0f),
+					index < group.m_baseColorSamplers.Num() ? group.m_baseColorSamplers[index] : 0u,
+					index < group.m_alphaCutoffs.Num() ? group.m_alphaCutoffs[index] : 0.5f);
+			}
+		}
+		resource.m_depthRevision = depthRevision;
+
+		size_t shadowRevision = geometryRevision;
+		if (proxy.m_shadowCaster)
+		{
+			for (const auto& shadowMesh : proxy.m_shadowCaster->m_meshes)
+			{
+				HashCombine(
+					shadowRevision,
+					shadowMesh.m_mesh,
+					shadowMesh.m_renderQueueTag,
+					std::hash<glm::vec4>{}(shadowMesh.m_baseColorFactor),
+					shadowMesh.m_baseColorSampler,
+					std::hash<float>{}(shadowMesh.m_alphaCutoff),
+					std::hash<float>{}(shadowMesh.m_maxCameraDistance));
+				if (shadowMesh.m_customDepthMaterial)
+				{
+					HashMaterialVersion(
+						shadowRevision,
+						shadowMesh.m_customDepthMaterial);
+					HashCombine(shadowRevision, shadowMesh.m_customDepthShader);
+				}
+#if defined(__APPLE__)
+				HashTextureSet(shadowRevision, shadowMesh.m_materialTextureSamplers);
+#endif
+			}
+		}
+		for (const auto& group : proxy.m_instancedGroups)
+		{
+			HashCombine(
+				shadowRevision,
+				group.m_bCastShadows,
+				std::hash<float>{}(group.m_maxShadowDistance));
+			for (size_t index = 0u; index < group.m_materials.Num(); ++index)
+			{
+				HashCombine(
+					shadowRevision,
+					index < group.m_renderQueueTags.Num() ? group.m_renderQueueTags[index] : 0u,
+					index < group.m_baseColorFactors.Num() ?
+						std::hash<glm::vec4>{}(group.m_baseColorFactors[index]) : 0u,
+					index < group.m_baseColorSamplers.Num() ? group.m_baseColorSamplers[index] : 0u,
+					index < group.m_alphaCutoffs.Num() ?
+						std::hash<float>{}(group.m_alphaCutoffs[index]) : 0u);
+				if (index < group.m_sourceMaterialShaders.Num() &&
+					group.m_sourceMaterialShaders[index] &&
+					index < group.m_materials.Num() &&
+					group.m_materials[index] &&
+					group.m_materials[index]->GetRenderState().IsRequiredCustomDepthShader())
+				{
+					const auto materialVersion = group.m_materials[index]->GetVersion();
+					HashCombine(
+						shadowRevision,
+						group.m_sourceMaterialShaders[index],
+						group.m_materials[index],
+						materialVersion ? materialVersion->GetVersionId() : 0ull);
+				}
+			}
+		}
+		resource.m_shadowRevision = shadowRevision;
+	}
+}
+
+RHISceneProxyResource::RHISceneProxyResource(const RHISceneViewProxy& proxy) :
+	m_proxy(proxy)
+{
+	TryNormalizeProxyTransforms(*this);
+	CalculateProxyResourceRevisions(*this);
+}
+
+RHISceneProxyResource::RHISceneProxyResource(RHISceneViewProxy&& proxy) :
+	m_proxy(std::move(proxy))
+{
+	TryNormalizeProxyTransforms(*this);
+	CalculateProxyResourceRevisions(*this);
+}
+
+const RHISceneViewProxy* RHIVisibleSceneProxy::GetSource() const
+{
+	return m_resource ? &m_resource->m_proxy : nullptr;
+}
+
+const glm::mat4& RHIVisibleSceneProxy::GetWorldMatrix() const
+{
+	if (m_record)
+	{
+		return m_record->m_worldMatrix;
+	}
+	if (const auto* source = GetSource())
+	{
+		return source->m_worldMatrix;
+	}
+
+	static const glm::mat4 identity{ 1.0f };
+	return identity;
+}
+
+const Math::AABB& RHIVisibleSceneProxy::GetWorldBounds() const
+{
+	if (m_record)
+	{
+		return m_record->m_worldBounds;
+	}
+	if (const auto* source = GetSource())
+	{
+		return source->m_worldAabb;
+	}
+
+	static const Math::AABB empty{};
+	return empty;
+}
+
+EMobilityType RHIVisibleSceneProxy::GetMobility() const
+{
+	if (m_record)
+	{
+		return m_record->m_mobility;
+	}
+	if (const auto* source = GetSource())
+	{
+		return source->m_mobility;
+	}
+	return EMobilityType::Static;
+}
+
+uint32_t RHIVisibleSceneProxy::GetSkeletonOffset() const
+{
+	if (m_record)
+	{
+		return m_record->m_skeletonOffset;
+	}
+	if (const auto* source = GetSource())
+	{
+		return source->m_skeletonOffset;
+	}
+	return (std::numeric_limits<uint32_t>::max)();
+}
+
+uint32_t RHIVisibleSceneProxy::GetRenderFlags() const
+{
+	if (m_record)
+	{
+		return m_record->m_renderFlags;
+	}
+	if (const auto* source = GetSource())
+	{
+		return source->m_bCastShadows ? 1u : 0u;
+	}
+	return 0u;
+}
+
+uint64_t RHIVisibleSceneProxy::GetContentRevision() const
+{
+	return m_record ? m_record->m_topologyRevision : 0ull;
+}
+
+RHIMeshPtr RHIVisibleSceneProxy::ResolveMesh(size_t meshIndex) const
+{
+	const auto* source = GetSource();
+	if (!source || meshIndex >= source->m_meshes.Num())
+	{
+		return {};
+	}
+
+	auto mesh = source->m_meshes[meshIndex];
+	return ResolveMesh(mesh);
+}
+
+RHIMeshPtr RHIVisibleSceneProxy::ResolveMesh(const RHIMeshPtr& sourceMesh) const
+{
+	auto mesh = sourceMesh;
+	const auto* source = GetSource();
+	if (mesh && source && source->m_lodPolicy.m_bEnabled)
+	{
+		const uint32_t lod = source->m_lodPolicy.Resolve(
+			m_screenCoverage,
+			mesh->GetNumLods());
+		if (lod > 0u)
+		{
+			if (auto lodMesh = mesh->GetLod(lod))
+			{
+				mesh = std::move(lodMesh);
+			}
+		}
+	}
+	return mesh;
+}
+
+glm::mat4 RHIVisibleSceneProxy::ResolveMeshWorldMatrix(size_t meshIndex) const
+{
+	const auto* source = GetSource();
+	if (!source || meshIndex >= source->m_meshModelMatrices.Num())
+	{
+		return GetWorldMatrix();
+	}
+	return m_resource->m_bMeshTransformsAreLocal ?
+		GetWorldMatrix() * source->m_meshModelMatrices[meshIndex] :
+		source->m_meshModelMatrices[meshIndex];
+}
+
+glm::mat4 RHIVisibleSceneProxy::ResolveInstancedMeshWorldMatrix(
+	const RHIInstancedMeshGroup& group,
+	size_t instanceIndex,
+	size_t meshIndex) const
+{
+	if (instanceIndex >= group.m_instanceTransforms.Num())
+	{
+		return GetWorldMatrix();
+	}
+	const glm::mat4 meshTransform = meshIndex < group.m_meshTransforms.Num() ?
+		group.m_meshTransforms[meshIndex] : glm::mat4(1.0f);
+	return GetWorldMatrix() * group.m_instanceTransforms[instanceIndex] * meshTransform;
+}
+
+RHIMeshPtr RHIVisibleSceneProxy::ResolveInstancedMesh(
+	const RHIInstancedMeshGroup& group,
+	size_t instanceIndex,
+	size_t meshIndex,
+	const glm::mat4& viewMatrix,
+	const glm::mat4& projectionMatrix) const
+{
+	if (meshIndex >= group.m_meshes.Num())
+	{
+		return {};
+	}
+	auto mesh = group.m_meshes[meshIndex];
+	const auto* source = GetSource();
+	if (!mesh || !source || !source->m_lodPolicy.m_bEnabled)
+	{
+		return mesh;
+	}
+
+	Math::AABB worldBounds = mesh->m_bounds;
+	worldBounds.Apply(ResolveInstancedMeshWorldMatrix(
+		group,
+		instanceIndex,
+		meshIndex));
+	const uint32_t lod = source->m_lodPolicy.Resolve(
+		CalculateScreenCoverage(worldBounds, viewMatrix, projectionMatrix),
+		mesh->GetNumLods());
+	if (lod > 0u)
+	{
+		if (auto lodMesh = mesh->GetLod(lod))
+		{
+			mesh = std::move(lodMesh);
+		}
+	}
+	return mesh;
+}
+
+bool RHIVisibleSceneProxy::IsInstancedMeshWithinDistance(
+	const RHIInstancedMeshGroup& group,
+	size_t instanceIndex,
+	size_t meshIndex,
+	const glm::vec3& cameraPosition,
+	float maxDistance) const
+{
+	if (!std::isfinite(maxDistance) || meshIndex >= group.m_meshes.Num() ||
+		!group.m_meshes[meshIndex])
+	{
+		return true;
+	}
+	Math::AABB worldBounds = group.m_meshes[meshIndex]->m_bounds;
+	worldBounds.Apply(ResolveInstancedMeshWorldMatrix(
+		group,
+		instanceIndex,
+		meshIndex));
+	if (!worldBounds.IsValid())
+	{
+		return true;
+	}
+	const glm::vec3 closestPoint = glm::clamp(
+		cameraPosition,
+		worldBounds.m_min,
+		worldBounds.m_max);
+	return glm::distance(cameraPosition, closestPoint) <= maxDistance;
+}
+
+const RHIShadowCasterProxy* RHIVisibleShadowCaster::GetSource() const
+{
+	const auto* proxy = m_resource ? &m_resource->m_proxy : nullptr;
+	return proxy && proxy->m_shadowCaster ? proxy->m_shadowCaster.GetRawPtr() : nullptr;
+}
+
+const glm::mat4& RHIVisibleShadowCaster::GetWorldMatrix() const
+{
+	if (m_record)
+	{
+		return m_record->m_worldMatrix;
+	}
+	if (m_resource)
+	{
+		return m_resource->m_proxy.m_worldMatrix;
+	}
+
+	static const glm::mat4 identity{ 1.0f };
+	return identity;
+}
+
+const Math::AABB& RHIVisibleShadowCaster::GetWorldBounds() const
+{
+	if (m_record)
+	{
+		return m_record->m_worldBounds;
+	}
+	if (const auto* source = GetSource())
+	{
+		return source->m_worldAabb;
+	}
+
+	static const Math::AABB empty{};
+	return empty;
+}
+
+EMobilityType RHIVisibleShadowCaster::GetMobility() const
+{
+	if (m_record)
+	{
+		return m_record->m_mobility;
+	}
+	if (m_resource)
+	{
+		return m_resource->m_proxy.m_mobility;
+	}
+	return EMobilityType::Static;
+}
+
+uint32_t RHIVisibleShadowCaster::GetSkeletonOffset() const
+{
+	if (m_record)
+	{
+		return m_record->m_skeletonOffset;
+	}
+	if (const auto* source = GetSource())
+	{
+		return source->m_skeletonOffset;
+	}
+	return (std::numeric_limits<uint32_t>::max)();
+}
+
+uint64_t RHIVisibleShadowCaster::GetProducerKey() const
+{
+	if (m_record)
+	{
+		return m_record->m_producerKey;
+	}
+	return m_resource ? m_resource->m_proxy.m_staticMeshEcs : 0ull;
+}
+
+uint64_t RHIVisibleShadowCaster::GetContentRevision() const
+{
+	return m_resource ? m_resource->m_shadowRevision : 0ull;
+}
+
+RHIMeshPtr RHIVisibleShadowCaster::ResolveMesh(
+	const RHIShadowMeshProxy& shadowMesh,
+	const glm::mat4& shadowViewProjection) const
+{
+	return ResolveMesh(shadowMesh.m_mesh, shadowViewProjection);
+}
+
+RHIMeshPtr RHIVisibleShadowCaster::ResolveMesh(
+	const RHIMeshPtr& sourceMesh,
+	const glm::mat4& shadowViewProjection) const
+{
+	auto mesh = sourceMesh;
+	const auto* topology = m_resource ? &m_resource->m_proxy : nullptr;
+	if (!mesh || !topology || !topology->m_lodPolicy.m_bEnabled)
+	{
+		return mesh;
+	}
+
+	const float coverage = CalculateScreenCoverage(
+		GetWorldBounds(),
+		glm::mat4(1.0f),
+		shadowViewProjection);
+	const uint32_t lod = topology->m_lodPolicy.Resolve(coverage, mesh->GetNumLods());
+	if (lod > 0u)
+	{
+		if (auto lodMesh = mesh->GetLod(lod))
+		{
+			mesh = std::move(lodMesh);
+		}
+	}
+	return mesh;
+}
+
+glm::mat4 RHIVisibleShadowCaster::ResolveMeshWorldMatrix(
+	const RHIShadowMeshProxy& shadowMesh) const
+{
+	return m_resource && m_resource->m_bMeshTransformsAreLocal ?
+		GetWorldMatrix() * shadowMesh.m_worldMatrix :
+		shadowMesh.m_worldMatrix;
+}
+
+glm::mat4 RHIVisibleShadowCaster::ResolveInstancedMeshWorldMatrix(
+	const RHIInstancedMeshGroup& group,
+	size_t instanceIndex,
+	size_t meshIndex) const
+{
+	if (instanceIndex >= group.m_instanceTransforms.Num())
+	{
+		return GetWorldMatrix();
+	}
+	const glm::mat4 meshTransform = meshIndex < group.m_meshTransforms.Num() ?
+		group.m_meshTransforms[meshIndex] : glm::mat4(1.0f);
+	return GetWorldMatrix() * group.m_instanceTransforms[instanceIndex] * meshTransform;
+}
+
+RHIMeshPtr RHIVisibleShadowCaster::ResolveInstancedMesh(
+	const RHIInstancedMeshGroup& group,
+	size_t instanceIndex,
+	size_t meshIndex,
+	const glm::mat4& shadowViewProjection) const
+{
+	if (meshIndex >= group.m_meshes.Num())
+	{
+		return {};
+	}
+	auto mesh = group.m_meshes[meshIndex];
+	const auto* topology = m_resource ? &m_resource->m_proxy : nullptr;
+	if (!mesh || !topology || !topology->m_lodPolicy.m_bEnabled)
+	{
+		return mesh;
+	}
+
+	Math::AABB worldBounds = mesh->m_bounds;
+	worldBounds.Apply(ResolveInstancedMeshWorldMatrix(
+		group,
+		instanceIndex,
+		meshIndex));
+	const uint32_t lod = topology->m_lodPolicy.Resolve(
+		CalculateScreenCoverage(worldBounds, glm::mat4(1.0f), shadowViewProjection),
+		mesh->GetNumLods());
+	if (lod > 0u)
+	{
+		if (auto lodMesh = mesh->GetLod(lod))
+		{
+			mesh = std::move(lodMesh);
+		}
+	}
+	return mesh;
+}
+
+bool RHIVisibleShadowCaster::IsInstancedMeshWithinDistance(
+	const RHIInstancedMeshGroup& group,
+	size_t instanceIndex,
+	size_t meshIndex,
+	const glm::vec3& cameraPosition,
+	float maxDistance) const
+{
+	if (!std::isfinite(maxDistance) || meshIndex >= group.m_meshes.Num() ||
+		!group.m_meshes[meshIndex])
+	{
+		return true;
+	}
+	Math::AABB worldBounds = group.m_meshes[meshIndex]->m_bounds;
+	worldBounds.Apply(ResolveInstancedMeshWorldMatrix(
+		group,
+		instanceIndex,
+		meshIndex));
+	if (!worldBounds.IsValid())
+	{
+		return true;
+	}
+	const glm::vec3 closestPoint = glm::clamp(
+		cameraPosition,
+		worldBounds.m_min,
+		worldBounds.m_max);
+	return glm::distance(cameraPosition, closestPoint) <= maxDistance;
+}
+
 float Sailor::RHI::CalculateScreenCoverage(
 	const Math::AABB& worldBounds,
 	const glm::mat4& viewMatrix,
@@ -258,183 +928,339 @@ void RHISceneView::PrepareDebugDrawCommandLists(WorldPtr world)
 void RHISceneView::Clear()
 {
 	m_rhiLightsData.Clear();
+	m_rhiLightsDataPerCamera.Clear(false);
 	m_boneMatrices.Clear();
 
-	m_cameras.Clear();
-	m_cameraTransforms.Clear();
-	m_shadowMapsToUpdate.Clear();
-	m_shadowMapsToBlit.Clear();
-	m_shadowIndices.Clear();
-	m_shadowAtlasTiles.Clear();
+	m_cameras.Clear(false);
+	m_cameraTransforms.Clear(false);
+	m_shadowMapsToUpdate.Clear(false);
+	m_shadowMapsToBlit.Clear(false);
+	m_shadowIndices.Clear(false);
+	m_shadowAtlasTiles.Clear(false);
+	m_shadowMatrices.Clear(false);
+	m_cpuLightsData.Clear();
+	m_lightingRevision = 0ull;
+	m_cpuBoneMatrices.Clear();
+	m_animationRevision = 0ull;
 
 	m_drawImGui.Clear();
-	m_debugDraw.Clear();
-	m_snapshots.Clear();
-	m_pathTracerProxies.Clear();
-	m_pathTracerLights.Clear();
+	m_debugDraw.Clear(false);
+	for (auto& snapshot : m_snapshots)
+	{
+		snapshot.ResetForReuse();
+	}
+	m_submissionContext.Clear();
+	m_submissionCompletionToken.Clear();
+	m_sceneVersions.Clear(false);
+	m_virtualSceneVersions.Clear(false);
+	m_retainedSceneVersions.Clear();
+	m_sceneRevision = 0ull;
+	m_shadowCastersRevision = 0ull;
+	m_bHasCustomDepthShadowCasters = false;
+	m_pathTracerProxies.Clear(false);
+	m_pathTracerTLASInstances.Clear(false);
+	m_pathTracerMaterials.Clear(false);
+	m_pathTracerLights.Clear(false);
 }
 
-TVector<RHISceneViewProxy> RHISceneView::TraceScene(const Math::Frustum& frustum, bool bSkipMaterials) const
+void RHISceneViewSnapshot::ResetForReuse()
 {
-	const uint32_t NumProxiesPerTask = 1024;
+	m_submissionContext.Clear();
+	m_sceneVersions.Clear();
+	m_sceneRevision = 0ull;
+	m_deltaTime = 0.0f;
+	m_frame = 0ull;
+	m_cameraIndex = 0u;
+	m_cameraTransform = {};
+	m_proxies.Clear(false);
+	m_pathTracerProxies.Clear(false);
+	m_pathTracerTLASInstances.Clear(false);
+	m_pathTracerMaterials.Clear(false);
+	m_pathTracerLights.Clear(false);
+	m_totalNumLights = 0u;
+	m_shadowMapsToUpdate.Clear(false);
+	m_shadowMapsToBlit.Clear(false);
+	m_shadowIndices.Clear(false);
+	m_shadowAtlasTiles.Clear(false);
+	m_frameBindings.Clear();
+	m_rhiLightsData.Clear();
+	m_rhiLightCullingData.Clear();
+	m_cpuLightsData.Clear();
+	m_shadowMatrices.Clear(false);
+	m_lightingRevision = 0ull;
+	m_boneMatrices.Clear();
+	m_cpuBoneMatrices.Clear();
+	m_animationRevision = 0ull;
+	m_debugDrawSecondaryCmdList.Clear();
+	m_drawImGui.Clear();
+}
 
-	SAILOR_PROFILE_FUNCTION();
-
-	TVector<RHISceneViewProxy> res;
-
-	// Stationary
-	TVector<RHIMeshProxy> meshProxies;
-	m_stationaryOctree.Trace(frustum, meshProxies);
-	TVector<Tasks::TaskPtr<TVector<RHISceneViewProxy>>> tasks;
-	for (uint32_t i = 0; i < meshProxies.Num() / NumProxiesPerTask + 1; i++)
+uint64_t RHISceneViewSnapshot::GetMobilityRevision(EMobilityType mobility) const
+{
+	size_t result = 1469598103934665603ull;
+	HashCombine(result, static_cast<uint32_t>(mobility));
+	if (!m_sceneVersions)
 	{
-		Tasks::TaskPtr<TVector<RHISceneViewProxy>> task = Tasks::CreateTaskWithResult<TVector<RHISceneViewProxy>>("Create list of scene view proxies",
-			[i, &meshProxies, &m_world = m_world, bSkipMaterials]()
-			{
-				TVector<RHISceneViewProxy> temp;
-				temp.Reserve(NumProxiesPerTask);
-				for (uint32_t j = 0; j < NumProxiesPerTask; j++)
-				{
-					if (i * NumProxiesPerTask + j >= meshProxies.Num())
-					{
-						break;
-					}
+		return static_cast<uint64_t>(result);
+	}
 
-					auto& meshProxy = meshProxies[i * NumProxiesPerTask + j];
-					auto& ecsData = m_world->GetECS<StaticMeshRendererECS>()->GetComponentData(meshProxy.m_staticMeshEcs);
-
-					if (ecsData.GetMaterials().Num() == 0)
-					{
-						continue;
-					}
-
-					RHISceneViewProxy viewProxy;
-					viewProxy.m_staticMeshEcs = meshProxy.m_staticMeshEcs;
-					viewProxy.m_worldMatrix = meshProxy.m_worldMatrix;
-					TVector<glm::mat4> modelMatrices;
-					Math::AABB modelBounds;
-					if (!ecsData.GetModel()->CollectRenderData(
-							ecsData.GetMeshIndex(),
-							viewProxy.m_meshes,
-							modelMatrices,
-							modelBounds))
-					{
-						continue;
-					}
-					viewProxy.m_meshModelMatrices.Reserve(
-						modelMatrices.Num());
-					for (const glm::mat4& modelMatrix : modelMatrices)
-					{
-						viewProxy.m_meshModelMatrices.Add(
-							meshProxy.m_worldMatrix * modelMatrix);
-					}
-					viewProxy.m_skeletonOffset = ecsData.GetSkeletonOffset();
-					viewProxy.m_frame = ecsData.GetFrameLastChange();
-					viewProxy.m_bCastShadows = ecsData.ShouldCastShadow();
-					viewProxy.m_worldAabb = modelBounds;
-					viewProxy.m_worldAabb.Apply(viewProxy.m_worldMatrix);
-
-					if (!bSkipMaterials)
-					{
-						viewProxy.m_overrideMaterials.Resize(viewProxy.m_meshes.Num());
-						viewProxy.m_renderQueueTags.Reserve(viewProxy.m_meshes.Num());
-#if defined(__APPLE__)
-						viewProxy.m_materialTextureSamplers.Resize(viewProxy.m_meshes.Num());
-						auto textureImporter = App::GetSubmodule<TextureImporter>();
-#endif
-						// TODO: Should we check AABB for each mesh in model?
-
-						for (size_t i = 0; i < viewProxy.m_meshes.Num(); i++)
-						{
-							const size_t materialIndex =
-								viewProxy.m_meshes[i]->ResolveMaterialIndex(
-									i, ecsData.GetMaterials().Num());
-
-							auto& material = ecsData.GetMaterials()[materialIndex];
-							viewProxy.m_renderQueueTags.Add(material ? material->GetRenderState().GetTag() : 0u);
-#if defined(__APPLE__)
-							auto& requestedTextures = viewProxy.m_materialTextureSamplers[i];
-							requestedTextures.Insert(0u);
-#endif
-							if (material && material->IsReady())
-							{
-								viewProxy.m_overrideMaterials[i] = material->GetOrAddRHI(viewProxy.m_meshes[i]->m_vertexDescription);
-#if defined(__APPLE__)
-								if (textureImporter)
-								{
-									for (const auto& sampler : material->GetSamplers())
-									{
-										const uint32_t textureIndex = sampler.m_second ? (uint32_t)textureImporter->GetTextureIndex(sampler.m_second->GetFileId()) : 0u;
-										requestedTextures.Insert(textureIndex);
-									}
-								}
-#endif
-							}
-						}
-					}
-
-					temp.Emplace(std::move(viewProxy));
-				}
-
-				return temp;
-			});
-
-		if (meshProxies.Num() < NumProxiesPerTask)
+	HashCombine(result, m_sceneVersions->Num());
+	for (const auto& sceneVersion : *m_sceneVersions)
+	{
+		if (!sceneVersion)
 		{
-			task->Execute();
-			res.AddRange(std::move(task->m_result));
-
-			break;
+			HashCombine(result, 0ull);
+			continue;
 		}
 
-		task->Run();
-		tasks.Add(task);
+		uint64_t revision = sceneVersion->m_dynamicRevision;
+		size_t numHandles = sceneVersion->m_dynamicHandles ?
+			sceneVersion->m_dynamicHandles->Num() : 0u;
+		switch (mobility)
+		{
+		case EMobilityType::Static:
+			revision = sceneVersion->m_staticRevision;
+			numHandles = sceneVersion->m_staticHandles ?
+				sceneVersion->m_staticHandles->Num() : 0u;
+			break;
+		case EMobilityType::Stationary:
+			revision = sceneVersion->m_stationaryRevision;
+			numHandles = sceneVersion->m_stationaryHandles ?
+				sceneVersion->m_stationaryHandles->Num() : 0u;
+			break;
+		case EMobilityType::Dynamic:
+			break;
+		}
+		HashCombine(
+			result,
+			sceneVersion->m_sceneIdentity,
+			revision,
+			numHandles);
 	}
-
-	for (auto& t : tasks)
-	{
-		t->Wait();
-		res.AddRange(std::move(t->m_result));
-	}
-
-	// Static
-	TVector<RHISceneViewProxy> proxies;
-	m_staticOctree.Trace(frustum, proxies);
-
-	res.AddRange(std::move(proxies));
-
-	return res;
+	return static_cast<uint64_t>(result);
 }
 
-TVector<RHIShadowCasterProxyPtr> RHISceneView::TraceShadowCasters(const Math::Frustum& frustum) const
+void RHISceneView::AddSceneVersion(RHISpatialSceneVersionPtr sceneVersion)
+{
+	if (!sceneVersion)
+	{
+		return;
+	}
+
+	m_sceneRevision = m_sceneRevision * 1099511628211ull ^ sceneVersion->m_revision;
+	m_shadowCastersRevision = m_shadowCastersRevision * 1099511628211ull ^ sceneVersion->m_shadowCastersRevision;
+	m_bHasCustomDepthShadowCasters |= sceneVersion->m_bHasCustomDepthShadowCasters;
+	if (sceneVersion->m_sceneVersion)
+	{
+		m_virtualSceneVersions.Add(sceneVersion->m_sceneVersion);
+		m_retainedSceneVersions.Clear();
+	}
+	m_sceneVersions.Emplace(std::move(sceneVersion));
+}
+
+TSharedPtr<TVector<RHISceneVersionPtr>> RHISceneView::GetRetainedSceneVersions()
+{
+	if (!m_retainedSceneVersions)
+	{
+		m_retainedSceneVersions = TSharedPtr<TVector<RHISceneVersionPtr>>::Make();
+		*m_retainedSceneVersions = m_virtualSceneVersions;
+	}
+	return m_retainedSceneVersions;
+}
+
+void RHISceneView::SetSubmissionContext(RHIRenderSubmissionContextPtr submissionContext)
+{
+	m_submissionContext = std::move(submissionContext);
+	for (auto& snapshot : m_snapshots)
+	{
+		snapshot.m_submissionContext = m_submissionContext;
+	}
+}
+
+RHISubmissionCompletionTokenPtr RHISceneView::GetOrCreateSubmissionCompletionToken()
+{
+	if (!m_submissionCompletionToken)
+	{
+		m_submissionCompletionToken = RHISubmissionCompletionTokenPtr::Make();
+	}
+	return m_submissionCompletionToken;
+}
+
+bool RHISceneView::IsCurrentSubmissionCompletionToken(
+	const RHISubmissionCompletionTokenPtr& token) const
+{
+	return token && token == m_submissionCompletionToken;
+}
+
+void RHISceneView::CompleteSubmissionResources(bool bSucceeded)
+{
+	if (m_submissionCompletionToken)
+	{
+		m_submissionCompletionToken->Complete(bSucceeded);
+	}
+}
+
+TVector<RHIVisibleSceneProxy> RHISceneView::TraceScene(const Math::Frustum& frustum, bool bSkipMaterials) const
+{
+	TVector<RHIVisibleSceneProxy> result;
+	TraceScene(frustum, result, bSkipMaterials);
+	return result;
+}
+
+void RHISceneView::TraceScene(
+	const Math::Frustum& frustum,
+	TVector<RHIVisibleSceneProxy>& result,
+	bool bSkipMaterials) const
+{
+	SAILOR_PROFILE_FUNCTION();
+	(void)bSkipMaterials;
+
+	result.Clear(false);
+	size_t numCandidates = 0u;
+	for (const auto& spatialVersion : m_sceneVersions)
+	{
+		if (spatialVersion)
+		{
+			numCandidates += spatialVersion->m_dynamicOctree ?
+				spatialVersion->m_dynamicOctree->Num() : 0u;
+			numCandidates += spatialVersion->m_stationaryOctree ?
+				spatialVersion->m_stationaryOctree->Num() : 0u;
+			numCandidates += spatialVersion->m_staticOctree ?
+				spatialVersion->m_staticOctree->Num() : 0u;
+		}
+	}
+	result.Reserve(numCandidates);
+
+	for (const auto& spatialVersion : m_sceneVersions)
+	{
+		if (!spatialVersion || !spatialVersion->m_sceneVersion)
+		{
+			continue;
+		}
+
+		auto appendHandle = [&result, &sceneVersion = spatialVersion->m_sceneVersion](
+			const RenderInstanceHandle& handle)
+			{
+				const RHISceneInstanceRecord* record = nullptr;
+				if (!sceneVersion->Resolve(handle, record) || !record)
+				{
+					return;
+				}
+				const auto* resource = dynamic_cast<const RHISceneProxyResource*>(
+					record->m_topology.GetRawPtr());
+				if (!resource)
+				{
+					return;
+				}
+
+				RHIVisibleSceneProxy visible;
+				visible.m_handle = handle;
+				visible.m_record = record;
+				visible.m_resource = resource;
+				result.Add(std::move(visible));
+		};
+		if (spatialVersion->m_dynamicOctree)
+		{
+			spatialVersion->m_dynamicOctree->Trace(frustum, appendHandle);
+		}
+		if (spatialVersion->m_stationaryOctree)
+		{
+			spatialVersion->m_stationaryOctree->Trace(frustum, appendHandle);
+		}
+		if (spatialVersion->m_staticOctree)
+		{
+			spatialVersion->m_staticOctree->Trace(frustum, appendHandle);
+		}
+	}
+
+}
+
+TVector<RHIVisibleShadowCaster> RHISceneView::TraceShadowCasters(const Math::Frustum& frustum) const
+{
+	TVector<RHIVisibleShadowCaster> result;
+	TraceShadowCasters(frustum, result);
+	return result;
+}
+
+void RHISceneView::TraceShadowCasters(
+	const Math::Frustum& frustum,
+	TVector<RHIVisibleShadowCaster>& result) const
 {
 	SAILOR_PROFILE_FUNCTION();
 
-	TVector<RHIShadowCasterProxyPtr> result;
-	result.Reserve(m_stationaryOctree.Num() + m_staticOctree.Num());
-
-	auto appendShadowCaster = [&result](const auto& proxy)
+	result.Clear(false);
+	size_t numShadowCandidates = 0u;
+	for (const auto& sceneVersion : m_sceneVersions)
+	{
+		if (sceneVersion)
 		{
-			if (proxy.m_shadowCaster)
+			numShadowCandidates += sceneVersion->m_dynamicOctree ?
+				sceneVersion->m_dynamicOctree->Num() : 0u;
+			numShadowCandidates += sceneVersion->m_stationaryOctree ?
+				sceneVersion->m_stationaryOctree->Num() : 0u;
+			numShadowCandidates += sceneVersion->m_staticOctree ?
+				sceneVersion->m_staticOctree->Num() : 0u;
+		}
+	}
+	result.Reserve(numShadowCandidates);
+	for (const auto& spatialVersion : m_sceneVersions)
+	{
+		if (!spatialVersion || !spatialVersion->m_sceneVersion)
+		{
+			continue;
+		}
+
+		auto appendHandle = [&result, &sceneVersion = spatialVersion->m_sceneVersion](
+			const RenderInstanceHandle& handle)
 			{
-				result.Add(proxy.m_shadowCaster);
-			}
+				const RHISceneInstanceRecord* record = nullptr;
+				if (!sceneVersion->Resolve(handle, record) || !record ||
+					(record->m_renderFlags & 1u) == 0u)
+				{
+					return;
+				}
+				const auto* resource = dynamic_cast<const RHISceneProxyResource*>(
+					record->m_topology.GetRawPtr());
+				if (!resource || !resource->m_proxy.m_shadowCaster)
+				{
+					return;
+				}
+
+				RHIVisibleShadowCaster visible;
+				visible.m_handle = handle;
+				visible.m_record = record;
+				visible.m_resource = resource;
+				result.Add(std::move(visible));
 		};
+		if (spatialVersion->m_dynamicOctree)
+		{
+			spatialVersion->m_dynamicOctree->Trace(frustum, appendHandle);
+		}
+		if (spatialVersion->m_stationaryOctree)
+		{
+			spatialVersion->m_stationaryOctree->Trace(frustum, appendHandle);
+		}
+		if (spatialVersion->m_staticOctree)
+		{
+			spatialVersion->m_staticOctree->Trace(frustum, appendHandle);
+		}
+	}
 
-	m_stationaryOctree.Trace(frustum, appendShadowCaster);
-	m_staticOctree.Trace(frustum, appendShadowCaster);
-
-	return result;
 }
 
 void RHISceneView::PrepareSnapshots()
 {
 	SAILOR_PROFILE_FUNCTION();
+	m_snapshots.Resize(m_cameras.Num());
 
 	for (uint32_t i = 0; i < m_cameras.Num(); i++)
 	{
 		auto& camera = m_cameras[i];
-		RHISceneViewSnapshot res;
+		auto& res = m_snapshots[i];
+		res.ResetForReuse();
+		res.m_submissionContext = m_submissionContext;
+		res.m_sceneVersions = GetRetainedSceneVersions();
+		res.m_sceneRevision = m_sceneRevision;
 
 		Math::Frustum frustum;
 
@@ -444,7 +1270,10 @@ void RHISceneView::PrepareSnapshots()
 		res.m_frame = m_world->GetCurrentFrame();
 		res.m_cameraIndex = i;
 		res.m_cameraTransform = m_cameraTransforms[i];
-		res.m_camera = TUniquePtr<CameraData>::Make();
+		if (!res.m_camera)
+		{
+			res.m_camera = TUniquePtr<CameraData>::Make();
+		}
 		*res.m_camera = camera;
 		res.m_pathTracerProxies = m_pathTracerProxies;
 		res.m_pathTracerTLASInstances = m_pathTracerTLASInstances;
@@ -452,61 +1281,88 @@ void RHISceneView::PrepareSnapshots()
 		res.m_pathTracerLights = m_pathTracerLights;
 
 		res.m_totalNumLights = m_totalNumLights;
-		res.m_rhiLightsData = m_rhiLightsData;
+		res.m_rhiLightsData = i < m_rhiLightsDataPerCamera.Num() ?
+			m_rhiLightsDataPerCamera[i] : m_rhiLightsData;
 		res.m_boneMatrices = m_boneMatrices;
 		res.m_drawImGui = m_drawImGui;
 		res.m_shadowMapsToUpdate = std::move(m_shadowMapsToUpdate[i]);
 		res.m_shadowMapsToBlit = std::move(m_shadowMapsToBlit[i]);
 		res.m_shadowIndices = std::move(m_shadowIndices[i]);
 		res.m_shadowAtlasTiles = std::move(m_shadowAtlasTiles[i]);
-		res.m_proxies = TraceScene(frustum, false);
-		auto* meshEcs = m_world ? m_world->GetECS<StaticMeshRendererECS>() : nullptr;
+		res.m_shadowMatrices = std::move(m_shadowMatrices[i]);
+		res.m_cpuLightsData = m_cpuLightsData;
+		res.m_lightingRevision = m_lightingRevision;
+		res.m_cpuBoneMatrices = m_cpuBoneMatrices;
+		res.m_animationRevision = m_animationRevision;
+		TraceScene(frustum, res.m_proxies, false);
 		const glm::vec3 cameraPosition = glm::vec3(m_cameraTransforms[i].m_position);
-		res.m_proxies.RemoveAll([&](const RHISceneViewProxy& proxy)
+		size_t visibleProxyWriteIndex = 0u;
+		for (size_t visibleProxyReadIndex = 0u;
+			visibleProxyReadIndex < res.m_proxies.Num();
+			++visibleProxyReadIndex)
+		{
+			auto& proxy = res.m_proxies[visibleProxyReadIndex];
+			const auto* source = proxy.GetSource();
+			bool bKeepProxy = source != nullptr;
+			if (source && std::isfinite(source->m_lodPolicy.m_maxCameraDistance))
 			{
-				if (!std::isfinite(proxy.m_lodPolicy.m_maxCameraDistance))
-				{
-					return false;
-				}
 				const glm::vec3 closest = glm::clamp(
-					cameraPosition, proxy.m_worldAabb.m_min, proxy.m_worldAabb.m_max);
-				return glm::distance(cameraPosition, closest) > proxy.m_lodPolicy.m_maxCameraDistance;
+					cameraPosition,
+					proxy.GetWorldBounds().m_min,
+					proxy.GetWorldBounds().m_max);
+				bKeepProxy = glm::distance(cameraPosition, closest) <=
+					source->m_lodPolicy.m_maxCameraDistance;
+			}
+			if (!bKeepProxy)
+			{
+				continue;
+			}
+			if (visibleProxyWriteIndex != visibleProxyReadIndex)
+			{
+				res.m_proxies[visibleProxyWriteIndex] = std::move(proxy);
+			}
+			++visibleProxyWriteIndex;
+		}
+		res.m_proxies.Resize(visibleProxyWriteIndex);
+		res.m_proxies.Sort([](const RHIVisibleSceneProxy& lhs, const RHIVisibleSceneProxy& rhs)
+			{
+				if (lhs.m_handle.IsValid() != rhs.m_handle.IsValid())
+				{
+					return lhs.m_handle.IsValid();
+				}
+				if (lhs.m_handle.IsValid())
+				{
+					if (lhs.m_handle.m_slot != rhs.m_handle.m_slot)
+					{
+						return lhs.m_handle.m_slot < rhs.m_handle.m_slot;
+					}
+					if (lhs.m_handle.m_generation != rhs.m_handle.m_generation)
+					{
+						return lhs.m_handle.m_generation < rhs.m_handle.m_generation;
+					}
+				}
+				const auto* lhsSource = lhs.GetSource();
+				const auto* rhsSource = rhs.GetSource();
+				const size_t lhsProducer = lhsSource ? lhsSource->m_staticMeshEcs : 0u;
+				const size_t rhsProducer = rhsSource ? rhsSource->m_staticMeshEcs : 0u;
+				if (lhsProducer != rhsProducer)
+				{
+					return lhsProducer < rhsProducer;
+				}
+				return reinterpret_cast<uintptr_t>(lhs.m_resource) <
+					reinterpret_cast<uintptr_t>(rhs.m_resource);
 			});
 		for (auto& proxy : res.m_proxies)
 		{
-			if (proxy.m_lodPolicy.m_bEnabled)
-			{
-				ApplyCustomLodToMeshes(proxy.m_lodPolicy, proxy.m_worldAabb,
-					camera, proxy.m_meshes);
-			}
-			else if (meshEcs && meshEcs->IsComponentRegistered(proxy.m_staticMeshEcs))
-			{
-				const auto& data = meshEcs->GetComponentData(proxy.m_staticMeshEcs);
-				ApplyLodToMeshes(
-					data,
-					proxy.m_worldAabb,
-					camera,
-					proxy.m_meshes);
-			}
-			proxy.m_shadowCaster = CreateLodShadowCaster(
-				proxy.m_shadowCaster, m_world, camera);
+			proxy.m_screenCoverage = CalculateScreenCoverage(
+				proxy.GetWorldBounds(),
+				camera.GetViewMatrix(),
+				camera.GetProjectionMatrix());
 		}
-		for (auto& shadowMap : res.m_shadowMapsToUpdate)
-		{
-			for (auto& shadowCaster : shadowMap.m_meshList)
-			{
-				shadowCaster = CreateLodShadowCaster(
-					shadowCaster,
-					m_world,
-					camera);
-			}
-		}
-
 		if (i < m_debugDraw.Num())
 		{
 			res.m_debugDrawSecondaryCmdList = m_debugDraw[i];
 		}
-		m_snapshots.Emplace(std::move(res));
 	}
 }
 

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -5,6 +5,9 @@
 #include "Engine/Types.h"
 #include "RHI/Mesh.h"
 #include "RHI/Material.h"
+#include "RHI/RenderSubmission.h"
+#include "RHI/Scene.h"
+#include "RHI/Lighting.h"
 #include "ECS/CameraECS.h"
 #include "Math/Math.h"
 #include "Raytracing/LightingModel.h"
@@ -35,7 +38,8 @@ namespace Sailor::RHI
 		float m_alphaCutoff = 0.5f;
 		uint32_t m_baseColorSampler = 0;
 		float m_maxCameraDistance = (std::numeric_limits<float>::max)();
-		MaterialPtr m_customDepthMaterial{};
+		RHIMaterialPtr m_customDepthMaterial{};
+		ShaderSetPtr m_customDepthShader{};
 #if defined(__APPLE__)
 		TSet<uint32_t> m_materialTextureSamplers{};
 #endif
@@ -55,6 +59,7 @@ namespace Sailor::RHI
 	struct RHIShadowCasterProxy
 	{
 		size_t m_staticMeshEcs{};
+		EMobilityType m_mobility = EMobilityType::Static;
 		Math::AABB m_worldAabb{};
 		uint32_t m_skeletonOffset = (std::numeric_limits<uint32_t>::max)();
 		size_t m_frame{};
@@ -63,6 +68,29 @@ namespace Sailor::RHI
 	};
 
 	using RHIShadowCasterProxyPtr = TSharedPtr<RHIShadowCasterProxy>;
+
+	/**
+	 * Immutable topology shared by every instance of one landscape vegetation
+	 * profile. Instance transforms are stored once; mesh/material metadata stays
+	 * per profile mesh instead of being repeated instance x mesh.
+	 */
+	struct RHIInstancedMeshGroup
+	{
+		TVector<glm::mat4> m_instanceTransforms{};
+		TVector<RHIMeshPtr> m_meshes{};
+		TVector<glm::mat4> m_meshTransforms{};
+		TVector<RHIMaterialPtr> m_materials{};
+		TVector<ShaderSetPtr> m_sourceMaterialShaders{};
+		TVector<size_t> m_renderQueueTags{};
+		TVector<glm::vec4> m_baseColorFactors{};
+		TVector<uint32_t> m_baseColorSamplers{};
+		TVector<float> m_alphaCutoffs{};
+#if defined(__APPLE__)
+		TVector<TSet<uint32_t>> m_materialTextureSamplers{};
+#endif
+		bool m_bCastShadows = false;
+		float m_maxShadowDistance = (std::numeric_limits<float>::max)();
+	};
 
 	struct RHIMeshProxy
 	{
@@ -87,6 +115,7 @@ namespace Sailor::RHI
 	struct RHISceneViewProxy
 	{
 		size_t m_staticMeshEcs{};
+		EMobilityType m_mobility = EMobilityType::Static;
 		glm::mat4 m_worldMatrix;
 		Math::AABB m_worldAabb{};
 
@@ -101,6 +130,7 @@ namespace Sailor::RHI
 		TVector<glm::vec4> m_baseColorFactors;
 		TVector<uint32_t> m_baseColorSamplers;
 		TVector<float> m_alphaCutoffs;
+		TVector<RHIInstancedMeshGroup> m_instancedGroups{};
 #if defined(__APPLE__)
 		TVector<TSet<uint32_t>> m_materialTextureSamplers;
 #endif
@@ -111,6 +141,121 @@ namespace Sailor::RHI
 		SAILOR_API const TVector<RHIMaterialPtr>& GetMaterials() const;
 
 	};
+
+	class RHISceneProxyResource final : public RHIResource
+	{
+	public:
+		RHISceneProxyResource() = default;
+		SAILOR_API explicit RHISceneProxyResource(const RHISceneViewProxy& proxy);
+		SAILOR_API explicit RHISceneProxyResource(RHISceneViewProxy&& proxy);
+
+		RHISceneViewProxy m_proxy{};
+		bool m_bMeshTransformsAreLocal = false;
+		size_t m_geometryRevision = 0u;
+		size_t m_mainRevision = 0u;
+		size_t m_depthRevision = 0u;
+		size_t m_shadowRevision = 0u;
+	};
+
+	using RHISceneProxyResourcePtr = TRefPtr<RHISceneProxyResource>;
+
+	struct RHIVisibleSceneProxy
+	{
+		RenderInstanceHandle m_handle{};
+		// Non-owning pointers into the immutable record root retained by
+		// RHISceneViewSnapshot::m_sceneVersions for the whole submission.
+		const RHISceneInstanceRecord* m_record = nullptr;
+		const RHISceneProxyResource* m_resource = nullptr;
+		float m_screenCoverage = 1.0f;
+
+		SAILOR_API const RHISceneViewProxy* GetSource() const;
+		SAILOR_API const glm::mat4& GetWorldMatrix() const;
+		SAILOR_API const Math::AABB& GetWorldBounds() const;
+		SAILOR_API EMobilityType GetMobility() const;
+		SAILOR_API uint32_t GetSkeletonOffset() const;
+		SAILOR_API uint32_t GetRenderFlags() const;
+		SAILOR_API uint64_t GetContentRevision() const;
+		SAILOR_API RHIMeshPtr ResolveMesh(size_t meshIndex) const;
+		SAILOR_API RHIMeshPtr ResolveMesh(const RHIMeshPtr& mesh) const;
+		SAILOR_API glm::mat4 ResolveMeshWorldMatrix(size_t meshIndex) const;
+		SAILOR_API glm::mat4 ResolveInstancedMeshWorldMatrix(
+			const RHIInstancedMeshGroup& group,
+			size_t instanceIndex,
+			size_t meshIndex) const;
+		SAILOR_API RHIMeshPtr ResolveInstancedMesh(
+			const RHIInstancedMeshGroup& group,
+			size_t instanceIndex,
+			size_t meshIndex,
+			const glm::mat4& viewMatrix,
+			const glm::mat4& projectionMatrix) const;
+		SAILOR_API bool IsInstancedMeshWithinDistance(
+			const RHIInstancedMeshGroup& group,
+			size_t instanceIndex,
+			size_t meshIndex,
+			const glm::vec3& cameraPosition,
+			float maxDistance) const;
+	};
+
+	struct RHIVisibleShadowCaster
+	{
+		RenderInstanceHandle m_handle{};
+		// The owning RHISceneVersion is retained by the submission snapshot.
+		const RHISceneInstanceRecord* m_record = nullptr;
+		const RHISceneProxyResource* m_resource = nullptr;
+
+		SAILOR_API const RHIShadowCasterProxy* GetSource() const;
+		SAILOR_API const glm::mat4& GetWorldMatrix() const;
+		SAILOR_API const Math::AABB& GetWorldBounds() const;
+		SAILOR_API EMobilityType GetMobility() const;
+		SAILOR_API uint32_t GetSkeletonOffset() const;
+		SAILOR_API uint64_t GetProducerKey() const;
+		SAILOR_API uint64_t GetContentRevision() const;
+		SAILOR_API RHIMeshPtr ResolveMesh(
+			const RHIShadowMeshProxy& shadowMesh,
+			const glm::mat4& shadowViewProjection) const;
+		SAILOR_API RHIMeshPtr ResolveMesh(
+			const RHIMeshPtr& mesh,
+			const glm::mat4& shadowViewProjection) const;
+		SAILOR_API glm::mat4 ResolveMeshWorldMatrix(const RHIShadowMeshProxy& shadowMesh) const;
+		SAILOR_API glm::mat4 ResolveInstancedMeshWorldMatrix(
+			const RHIInstancedMeshGroup& group,
+			size_t instanceIndex,
+			size_t meshIndex) const;
+		SAILOR_API RHIMeshPtr ResolveInstancedMesh(
+			const RHIInstancedMeshGroup& group,
+			size_t instanceIndex,
+			size_t meshIndex,
+			const glm::mat4& shadowViewProjection) const;
+		SAILOR_API bool IsInstancedMeshWithinDistance(
+			const RHIInstancedMeshGroup& group,
+			size_t instanceIndex,
+			size_t meshIndex,
+			const glm::vec3& cameraPosition,
+			float maxDistance) const;
+	};
+
+	static_assert(sizeof(RHIVisibleSceneProxy) <= sizeof(void*) * 4u,
+		"Visible scene records must remain lightweight immutable references.");
+	static_assert(sizeof(RHIVisibleShadowCaster) <= sizeof(void*) * 3u,
+		"Visible shadow records must remain lightweight immutable references.");
+
+	/**
+	 * Immutable after publication. ECS producers rebuild this adapter only when
+	 * their scene data changes; render views retain and share it across submissions.
+	 */
+	struct RHISpatialSceneVersion
+	{
+		TSharedPtr<TOctree<RenderInstanceHandle>> m_dynamicOctree{};
+		TSharedPtr<TOctree<RenderInstanceHandle>> m_stationaryOctree{};
+		TSharedPtr<TOctree<RenderInstanceHandle>> m_staticOctree{};
+		uint64_t m_revision = 0ull;
+		uint64_t m_shadowCastersRevision = 0ull;
+		bool m_bHasCustomDepthShadowCasters = false;
+		RHIScenePtr m_scene{};
+		RHISceneVersionPtr m_sceneVersion{};
+	};
+
+	using RHISpatialSceneVersionPtr = TSharedPtr<RHISpatialSceneVersion>;
 
 	struct RHIPathTracerProxy
 	{
@@ -129,9 +274,10 @@ namespace Sailor::RHI
 		glm::vec2 m_blurRadius{}; // [Umbra, Penumbra]
 		glm::ivec4 m_renderArea{}; // [x, y, width, height], zero means the full target
 		RHI::RHIRenderTargetPtr m_shadowMap{};
+		RHISubmissionCompletionTokenPtr m_payloadCompletionToken{};
 		glm::mat4 m_lightMatrix{};
 		TVector<uint32_t> m_internalCommandsList{};
-		TVector<RHIShadowCasterProxyPtr> m_meshList{};
+		TVector<RHIVisibleShadowCaster> m_meshList{};
 	};
 
 	struct RHIBlitShadowMapCommand
@@ -144,12 +290,95 @@ namespace Sailor::RHI
 
 	struct RHISceneViewSnapshot
 	{
+		SAILOR_API void ResetForReuse();
+		SAILOR_API uint64_t GetMobilityRevision(EMobilityType mobility) const;
+
+		template<typename TCallback>
+		void ForEachSceneProxy(EMobilityType mobility, TCallback&& callback) const
+		{
+			if (!m_sceneVersions)
+			{
+				return;
+			}
+
+			for (const auto& sceneVersion : *m_sceneVersions)
+			{
+				if (!sceneVersion)
+				{
+					continue;
+				}
+
+				const TSharedPtr<TVector<RenderInstanceHandle>>* handles = nullptr;
+				switch (mobility)
+				{
+				case EMobilityType::Static:
+					handles = &sceneVersion->m_staticHandles;
+					break;
+				case EMobilityType::Stationary:
+					handles = &sceneVersion->m_stationaryHandles;
+					break;
+				case EMobilityType::Dynamic:
+					handles = &sceneVersion->m_dynamicHandles;
+					break;
+				}
+				if (!handles || !*handles)
+				{
+					continue;
+				}
+
+				for (const auto& handle : **handles)
+				{
+					const RHISceneInstanceRecord* record = nullptr;
+					if (!sceneVersion->Resolve(handle, record) || !record)
+					{
+						continue;
+					}
+					const auto* resource = dynamic_cast<const RHISceneProxyResource*>(
+						record->m_topology.GetRawPtr());
+					if (!resource)
+					{
+						continue;
+					}
+
+					RHIVisibleSceneProxy proxy;
+					proxy.m_handle = handle;
+					proxy.m_record = record;
+					proxy.m_resource = resource;
+					callback(proxy);
+				}
+			}
+		}
+
+		template<typename TCallback>
+		void ForEachShadowCaster(EMobilityType mobility, TCallback&& callback) const
+		{
+			ForEachSceneProxy(mobility, [&](const RHIVisibleSceneProxy& sceneProxy)
+			{
+				if (!sceneProxy.m_record ||
+					(sceneProxy.m_record->m_renderFlags & 1u) == 0u ||
+					!sceneProxy.m_resource ||
+					!sceneProxy.m_resource->m_proxy.m_shadowCaster)
+				{
+					return;
+				}
+
+				RHIVisibleShadowCaster caster;
+				caster.m_handle = sceneProxy.m_handle;
+				caster.m_record = sceneProxy.m_record;
+				caster.m_resource = sceneProxy.m_resource;
+				callback(caster);
+			});
+		}
+
+		RHIRenderSubmissionContextPtr m_submissionContext{};
+		TSharedPtr<TVector<RHISceneVersionPtr>> m_sceneVersions{};
+		uint64_t m_sceneRevision = 0ull;
 		float m_deltaTime = 0.0f;
 		uint64_t m_frame = 0ull;
 		uint32_t m_cameraIndex = 0u;
 		Math::Transform m_cameraTransform{};
 		TUniquePtr<CameraData> m_camera{};
-		TVector<RHISceneViewProxy> m_proxies{};
+		TVector<RHIVisibleSceneProxy> m_proxies{};
 		TVector<RHIPathTracerProxy> m_pathTracerProxies{};
 		TVector<Sailor::Raytracing::PathTracer::TLASInstance> m_pathTracerTLASInstances{};
 		TVector<MaterialPtr> m_pathTracerMaterials{};
@@ -163,7 +392,13 @@ namespace Sailor::RHI
 
 		RHIShaderBindingSetPtr m_frameBindings{};
 		RHIShaderBindingSetPtr m_rhiLightsData{};
+		RHIShaderBindingSetPtr m_rhiLightCullingData{};
+		TSharedPtr<TVector<RHILightShaderData>> m_cpuLightsData{};
+		TVector<glm::mat4> m_shadowMatrices{};
+		uint64_t m_lightingRevision = 0ull;
 		RHIShaderBindingSetPtr m_boneMatrices{};
+		TSharedPtr<TVector<glm::mat4>> m_cpuBoneMatrices{};
+		uint64_t m_animationRevision = 0ull;
 
 		Tasks::TaskPtr<RHICommandListPtr> m_debugDrawSecondaryCmdList{};
 		Tasks::TaskPtr<RHICommandListPtr, void> m_drawImGui{};
@@ -171,23 +406,45 @@ namespace Sailor::RHI
 
 	struct RHISceneView
 	{
-		SAILOR_API TVector<RHISceneViewProxy> TraceScene(const Math::Frustum& frustum, bool bSkipMaterials) const;
-		SAILOR_API TVector<RHIShadowCasterProxyPtr> TraceShadowCasters(const Math::Frustum& frustum) const;
+		SAILOR_API TVector<RHIVisibleSceneProxy> TraceScene(const Math::Frustum& frustum, bool bSkipMaterials) const;
+		SAILOR_API void TraceScene(
+			const Math::Frustum& frustum,
+			TVector<RHIVisibleSceneProxy>& outVisibleProxies,
+			bool bSkipMaterials) const;
+		SAILOR_API TVector<RHIVisibleShadowCaster> TraceShadowCasters(const Math::Frustum& frustum) const;
+		SAILOR_API void TraceShadowCasters(
+			const Math::Frustum& frustum,
+			TVector<RHIVisibleShadowCaster>& outVisibleCasters) const;
 		SAILOR_API void PrepareSnapshots();
 		SAILOR_API void PrepareDebugDrawCommandLists(WorldPtr world);
+		SAILOR_API void SetSubmissionContext(RHIRenderSubmissionContextPtr submissionContext);
+		SAILOR_API RHISubmissionCompletionTokenPtr GetOrCreateSubmissionCompletionToken();
+		SAILOR_API bool IsCurrentSubmissionCompletionToken(
+			const RHISubmissionCompletionTokenPtr& token) const;
+		SAILOR_API void CompleteSubmissionResources(bool bSucceeded);
+		SAILOR_API void AddSceneVersion(RHISpatialSceneVersionPtr sceneVersion);
+		SAILOR_API TSharedPtr<TVector<RHISceneVersionPtr>> GetRetainedSceneVersions();
 
-		TOctree<RHIMeshProxy> m_stationaryOctree{ glm::ivec3(0,0,0), 16536 * 16, 4 };
-		TOctree<RHISceneViewProxy> m_staticOctree{ glm::ivec3(0,0,0), 16536 * 16, 4 };
+		TVector<RHISpatialSceneVersionPtr> m_sceneVersions{};
+		TVector<RHISceneVersionPtr> m_virtualSceneVersions{};
+		TSharedPtr<TVector<RHISceneVersionPtr>> m_retainedSceneVersions{};
+		uint64_t m_sceneRevision = 0ull;
 
 		uint32_t m_totalNumLights = 0;
 		RHI::RHIShaderBindingSetPtr m_rhiLightsData{};
+		TVector<RHI::RHIShaderBindingSetPtr> m_rhiLightsDataPerCamera{};
+		TSharedPtr<TVector<RHILightShaderData>> m_cpuLightsData{};
+		uint64_t m_lightingRevision = 0ull;
 		RHI::RHIShaderBindingSetPtr m_boneMatrices{};
+		TSharedPtr<TVector<glm::mat4>> m_cpuBoneMatrices{};
+		uint64_t m_animationRevision = 0ull;
 
 		// For each camera
 		TVector<TVector<RHIUpdateShadowMapCommand>> m_shadowMapsToUpdate;
 		TVector<TVector<RHIBlitShadowMapCommand>> m_shadowMapsToBlit;
 		TVector<TVector<uint32_t>> m_shadowIndices;
 		TVector<TVector<uint32_t>> m_shadowAtlasTiles;
+		TVector<TVector<glm::mat4>> m_shadowMatrices;
 
 		TVector<CameraData> m_cameras;
 		TVector<Math::Transform> m_cameraTransforms;
@@ -199,6 +456,8 @@ namespace Sailor::RHI
 		Tasks::TaskPtr<RHI::RHICommandListPtr, void> m_drawImGui;
 		TVector<Tasks::TaskPtr<RHI::RHICommandListPtr>> m_debugDraw;
 		TVector<RHISceneViewSnapshot> m_snapshots;
+		RHIRenderSubmissionContextPtr m_submissionContext{};
+		RHISubmissionCompletionTokenPtr m_submissionCompletionToken{};
 		uint64_t m_shadowCastersRevision = 0;
 		bool m_bHasCustomDepthShadowCasters = false;
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -67,6 +67,10 @@ add_executable(GpuCullingContractTests
     GpuCullingContractTests.cpp
 )
 
+add_executable(RHISceneVirtualizationTests
+    RHISceneVirtualizationTests.cpp
+)
+
 add_executable(ModelImporterContractTests
     ModelImporterContractTests.cpp
 )
@@ -221,6 +225,7 @@ target_compile_features(InstanceIdContractTests PRIVATE cxx_std_20)
 target_compile_features(EcsLifecycleContractTests PRIVATE cxx_std_20)
 target_compile_features(BoundsContractTests PRIVATE cxx_std_20)
 target_compile_features(GpuCullingContractTests PRIVATE cxx_std_20)
+target_compile_features(RHISceneVirtualizationTests PRIVATE cxx_std_20)
 target_compile_definitions(GpuCullingContractTests PRIVATE
     SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
 )
@@ -291,6 +296,7 @@ target_link_libraries(InstanceIdContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(EcsLifecycleContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(BoundsContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(GpuCullingContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(RHISceneVirtualizationTests PRIVATE Sailor::Runtime)
 target_link_libraries(ModelImporterContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(AnimationSamplingContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(VulkanDescriptorCacheTests PRIVATE Sailor::Runtime)
@@ -394,6 +400,9 @@ target_include_directories(BoundsContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(GpuCullingContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(RHISceneVirtualizationTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(ModelImporterContractTests PRIVATE
@@ -540,6 +549,11 @@ add_test(
 )
 
 add_test(
+    NAME RHISceneVirtualizationTests
+    COMMAND RHISceneVirtualizationTests
+)
+
+add_test(
     NAME ModelImporterContractTests
     COMMAND ModelImporterContractTests
 )
@@ -669,6 +683,7 @@ set_tests_properties(
     EcsLifecycleContractTests
     BoundsContractTests
     GpuCullingContractTests
+    RHISceneVirtualizationTests
     ModelImporterContractTests
     AnimationSamplingContractTests
     VulkanDescriptorCacheTests

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1323,6 +1323,33 @@ namespace
 			"a new bone-matrix generation must invalidate animated shadows even when RHIScene is unchanged");
 	}
 
+	void TestCsmShadowTargetFormatTracksShadowMode()
+	{
+		Require(
+			LightingECS::GetCsmShadowMapFormat(RHI::EShadowType::PCF) ==
+				LightingECS::ShadowMapFormat,
+			"a PCF near cascade must use the compact single-channel shadow target");
+		Require(
+			LightingECS::GetCsmShadowMapFormat(RHI::EShadowType::EVSM) ==
+				LightingECS::ShadowMapFormat_Evsm,
+			"an EVSM near cascade must use the four-channel floating-point moments target");
+		Require(
+			LightingECS::GetCsmShadowMapFormat(RHI::EShadowType::PCF) !=
+				LightingECS::GetCsmShadowMapFormat(RHI::EShadowType::EVSM),
+			"switching the near cascade between PCF and EVSM must invalidate an incompatible flight target");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string lightingSource = ReadText(
+			sourceRoot / "Runtime/ECS/LightingECS.cpp");
+		Require(
+			lightingSource.find("writableShadowMap->GetFormat() != shadowMapFormat") !=
+				std::string::npos &&
+			lightingSource.find("writableShadowMap->GetExtent().x != shadowMapExtent.x") !=
+				std::string::npos &&
+			lightingSource.find("writableShadowMap.Clear();") != std::string::npos,
+			"flight-local CSM targets must be recreated when their mode or resolution changes");
+	}
+
 	void TestShadowCachePolicy()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -4166,6 +4193,7 @@ int main()
 		{ "CsmSnapshotTracksCastersBeforeDependencyFiltering", TestCsmSnapshotTracksCastersBeforeDependencyFiltering },
 		{ "LocalLightShadowContract", TestLocalLightShadowContract },
 		{ "CsmSnapshotInvalidatesWhenCascadeProjectionMoves", TestCsmSnapshotInvalidatesWhenCascadeProjectionMoves },
+		{ "CsmShadowTargetFormatTracksShadowMode", TestCsmShadowTargetFormatTracksShadowMode },
 		{ "ShadowCachePolicy", TestShadowCachePolicy },
 		{ "MeshRendererMaterialOverridesAreReflectedAndPersisted", TestMeshRendererMaterialOverridesAreReflectedAndPersisted },
 		{ "AnimationGpuBoneLayoutContract", TestAnimationGpuBoneLayoutContract },

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -865,18 +865,18 @@ namespace
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string sceneViewSource = ReadText(
 			sourceRoot / "Runtime/RHI/SceneView.cpp");
-		const size_t visibleSelection = sceneViewSource.find(
-			"ApplyLodToMeshes(");
-		const size_t visibleShadowSelection = sceneViewSource.find(
-			"proxy.m_shadowCaster = CreateLodShadowCaster(",
-			visibleSelection);
-		const size_t shadowPassSelection = sceneViewSource.find(
-			"shadowCaster = CreateLodShadowCaster(",
-			visibleShadowSelection);
-		Require(visibleSelection != std::string::npos &&
-			visibleShadowSelection > visibleSelection &&
-			shadowPassSelection > visibleShadowSelection,
-			"snapshot preparation must apply the camera-selected LOD to main, depth, and shadow proxies");
+		const std::string renderSceneSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RenderSceneNode.cpp");
+		const std::string depthSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/DepthPrepassNode.cpp");
+		const std::string shadowSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
+		Require(sceneViewSource.find("source->m_lodPolicy.Resolve(") != std::string::npos &&
+			sceneViewSource.find("topology->m_lodPolicy.Resolve(") != std::string::npos &&
+			renderSceneSource.find("proxy.ResolveMesh(") != std::string::npos &&
+			depthSource.find("proxy.ResolveMesh(") != std::string::npos &&
+			shadowSource.find("proxy.ResolveMesh(") != std::string::npos,
+			"main, depth, and shadow packets must resolve view-local LODs from lightweight visible references");
 	}
 
 	void TestStaticMeshProxyPublishesTransformRevisionForShadowInvalidation()
@@ -884,13 +884,23 @@ namespace
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string rendererEcsSource = ReadText(
 			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
+		const size_t stateOnlyPath = rendererEcsSource.find(
+			"if (!bTopologyDirty && !bMaterialsDirty && m_rhiScene)");
+		const size_t topologyCollection = rendererEcsSource.find(
+			"CollectComponentRenderData(", stateOnlyPath);
 		Require(rendererEcsSource.find(
 			"shadowCaster->m_frame = currentFrame;") != std::string::npos &&
 			rendererEcsSource.find(
-			"++m_sceneViewProxiesCache->m_shadowCastersRevision;") != std::string::npos &&
+			"++m_shadowCastersRevision;") != std::string::npos &&
 			rendererEcsSource.find(
-			"outProxies->m_shadowCastersRevision = m_sceneViewProxiesCache->m_shadowCastersRevision;") != std::string::npos,
-			"dirty mesh updates must publish a monotonic shadow-caster revision with their lightweight proxy");
+			"version->m_shadowCastersRevision = m_shadowCastersRevision;") != std::string::npos &&
+			stateOnlyPath != std::string::npos &&
+			topologyCollection != std::string::npos &&
+			rendererEcsSource.find(
+				"previousResource->m_bMeshTransformsAreLocal", stateOnlyPath) < topologyCollection &&
+			rendererEcsSource.find(
+				"result.m_bStateOnly = true;", stateOnlyPath) < topologyCollection,
+			"transform-only mesh updates must publish shadow invalidation while reusing immutable topology before full render-data collection");
 	}
 
 	void TestStaticMeshProxyTracksMaterialContentRevisions()
@@ -899,8 +909,10 @@ namespace
 		const std::string rendererEcsHeader = ReadText(
 			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.h");
 		Require(rendererEcsHeader.find("TVector<uint64_t> m_materialContentRevisions;") !=
-			std::string::npos,
-			"static mesh renderer data must retain the material revisions represented by its cached proxy");
+				std::string::npos &&
+			rendererEcsHeader.find("m_materialRenderMetadataRevisions") == std::string::npos &&
+			rendererEcsHeader.find("m_bMaterialVersionPending") == std::string::npos,
+			"static mesh material state must reuse one compact revision vector without new per-component allocations");
 
 		const std::string rendererEcsSource = ReadText(
 			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
@@ -912,17 +924,46 @@ namespace
 		const size_t collectDirtyComponent = rendererEcsSource.find(
 			"dirtyComponents.Add(componentIndex);",
 			compareCachedRevisions);
-		const size_t cacheRebuiltRevisions = rendererEcsSource.find(
-			"data.m_materialContentRevisions[materialIndex] = material ? material->GetContentRevision() : 0ull;",
+		const size_t compareRenderMetadataRevisions = rendererEcsSource.find(
+			"CalculateMaterialRenderMetadataSignature(data.GetMaterials())",
 			collectDirtyComponent);
+		const size_t cacheRebuiltRevisions = rendererEcsSource.find(
+			"data.m_materialContentRevisions[materialIndex] = material ?",
+			collectDirtyComponent);
+		const size_t materialVersionOnlyBegin = rendererEcsSource.find(
+			"if (update.m_state == EPreparedProxyState::MaterialVersionOnly)");
+		const size_t materialVersionOnlyCache = rendererEcsSource.find(
+			"cacheMaterialRevisions();",
+			materialVersionOnlyBegin);
+		const size_t materialVersionOnlyContinue = rendererEcsSource.find(
+			"continue;",
+			materialVersionOnlyCache);
+		const size_t nextSceneUpdate = rendererEcsSource.find(
+			"UpdateInstance",
+			materialVersionOnlyBegin);
 		Require(globalRevisionGate != std::string::npos &&
 			compareCachedRevisions > globalRevisionGate &&
 			collectDirtyComponent > compareCachedRevisions &&
-			cacheRebuiltRevisions > collectDirtyComponent,
-			"material revisions should scan components only after a global change and rebuild only affected proxies");
+			compareRenderMetadataRevisions > collectDirtyComponent &&
+			cacheRebuiltRevisions > compareRenderMetadataRevisions &&
+			rendererEcsSource.find("data.GetMaterials().Num() + 1u") != std::string::npos &&
+			rendererEcsSource.find("bool bMaterialVersionsPending = false;") != std::string::npos &&
+			materialVersionOnlyBegin != std::string::npos &&
+			materialVersionOnlyCache > materialVersionOnlyBegin &&
+			materialVersionOnlyContinue > materialVersionOnlyCache &&
+			nextSceneUpdate > materialVersionOnlyContinue,
+			"material changes should publish pending bindings while rebuilding proxy topology only for render metadata");
 		Require(rendererEcsSource.find("for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)") != std::string::npos &&
 			rendererEcsSource.find("m_dirtyComponents") == std::string::npos,
 			"static mesh updates should use the conservative component scan without a separate dirty queue");
+		Require(rendererEcsHeader.find("TVector<PreparedProxyUpdate> m_preparedUpdatesScratch{};") != std::string::npos &&
+			rendererEcsHeader.find("TVector<Tasks::ITaskPtr> m_prepareTasksScratch{};") != std::string::npos &&
+			rendererEcsSource.find("preparedUpdates.Resize(dirtyComponents.Num());") != std::string::npos &&
+			rendererEcsSource.find("TVector<glm::mat4> modelMatrices;") == std::string::npos &&
+			rendererEcsSource.find("modelMatrix = ownerWorldMatrix * modelMatrix;") != std::string::npos &&
+			rendererEcsSource.find("TVector<Tasks::TaskPtr<TVector<PreparedProxyUpdate>>>") == std::string::npos &&
+			rendererEcsSource.find("preparedUpdates.AddRange") == std::string::npos,
+			"dirty mesh proxy preparation should reuse one pre-sized result array without per-task result vectors");
 	}
 
 	void TestCsmSnapshotTracksCastersBeforeDependencyFiltering()
@@ -930,6 +971,8 @@ namespace
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string lightingEcsSource = ReadText(
 			sourceRoot / "Runtime/ECS/LightingECS.cpp");
+		const std::string lightingEcsHeader = ReadText(
+			sourceRoot / "Runtime/ECS/LightingECS.h");
 		const size_t prepareCsmBegin = lightingEcsSource.find(
 			"LightingECS::PrepareCSMPasses");
 		const size_t fillLightingBegin = lightingEcsSource.find(
@@ -940,34 +983,50 @@ namespace
 
 		const std::string prepareCsmBody = lightingEcsSource.substr(
 			prepareCsmBegin, fillLightingBegin - prepareCsmBegin);
+		const size_t reuseDecision = prepareCsmBody.find(
+			"csmSnapshots[currentSnapshotIndex].CanReuse(");
 		const size_t traceShadowCasters = prepareCsmBody.find(
-			"sceneView->TraceShadowCasters(broadFrustum)");
-		const size_t cascadeLoop = prepareCsmBody.find(
-			"for (uint32_t k = 0; k < lightCascadesMatrices.Num(); ++k)");
-		const size_t captureCaster = prepareCsmBody.find(
-			"snapshot.m_snapshot.Add({ caster->m_staticMeshEcs, caster->m_frame });");
-		const size_t filterDependency = prepareCsmBody.find(
-			"cascade.m_meshList.RemoveAll");
-		Require(traceShadowCasters != std::string::npos &&
-			cascadeLoop > traceShadowCasters &&
-			captureCaster > cascadeLoop &&
-			filterDependency > captureCaster,
-			"CSM must query lightweight casters once before distributing and snapshotting them across cascades");
+			"sceneView->TraceShadowCasters(broadFrustum, m_csmBroadCastersScratch)");
+		Require(reuseDecision != std::string::npos &&
+			traceShadowCasters > reuseDecision,
+			"CSM must consult retained scene versions before tracing any shadow casters");
 		Require(prepareCsmBody.find("TraceScene(") == std::string::npos &&
 			prepareCsmBody.find(
 				"TraceShadowCasters(",
 				traceShadowCasters + std::string("TraceShadowCasters(").size()) == std::string::npos,
 			"CSM preparation must not build full scene proxies or repeat the broad caster query per cascade");
-		Require(prepareCsmBody.find("bHasCachedShadowCasters") != std::string::npos &&
-			prepareCsmBody.find("bCanReuseAllCascades && bHasCachedShadowCasters") != std::string::npos,
-			"CSM must not reuse an empty bootstrap snapshot before asynchronous mesh proxies become available");
-		Require(lightingEcsSource.find("bHasCachedLocalShadowCasters") != std::string::npos &&
-			lightingEcsSource.find("if (bHasCachedLocalShadowCasters &&") != std::string::npos,
-			"local shadows must not reuse an empty bootstrap snapshot before asynchronous mesh proxies become available");
+		Require(prepareCsmBody.find("cascadeNeedsUpdate[cascadeIndex]") != std::string::npos &&
+			prepareCsmBody.find("if (cascadeNeedsUpdate[k] == 0u)") != std::string::npos,
+			"a localized scene change must filter and rebuild only invalidated CSM cascades");
 		Require(prepareCsmBody.find("LightingECS:Build CSM Cascade") != std::string::npos &&
 			prepareCsmBody.find("EThreadType::Worker") != std::string::npos &&
 			prepareCsmBody.find("cascadeCasterTasks[k]->Wait()") != std::string::npos,
 			"CSM caster filtering must run per cascade on worker tasks and join before command assembly");
+		Require(prepareCsmBody.find("const auto& shadowCasters = m_csmBroadCastersScratch;") != std::string::npos &&
+			lightingEcsHeader.find("TVector<RHI::RHIVisibleShadowCaster> m_csmBroadCastersScratch{};") != std::string::npos,
+			"CSM invalidation must reuse broad-caster scratch instead of reallocating the broad query result");
+		const size_t selectFlightCsm = prepareCsmBody.find(
+			"flightResources.m_csmShadowMaps[snapshotIndex]");
+		const size_t allocateFlightCsm = prepareCsmBody.find(
+			"if (!writableShadowMap)", selectFlightCsm);
+		const size_t createFlightCsm = prepareCsmBody.find(
+			"CreateRenderTarget(", allocateFlightCsm);
+		Require(lightingEcsHeader.find("struct LightingShadowFlightResources") != std::string::npos &&
+			lightingEcsHeader.find("TVector<RHI::RHIRenderTargetPtr> m_csmShadowMaps{};") != std::string::npos &&
+			lightingEcsHeader.find("TVector<CSMLightState> m_csmSnapshots{};") != std::string::npos &&
+			prepareCsmBody.find("auto& csmSnapshots = flightResources.m_csmSnapshots;") != std::string::npos &&
+			selectFlightCsm != std::string::npos &&
+			allocateFlightCsm > selectFlightCsm &&
+			createFlightCsm > allocateFlightCsm &&
+			prepareCsmBody.find("cascade.m_shadowMap = writableShadowMap;") != std::string::npos &&
+			prepareCsmBody.find("std::move(writableShadowMap)") == std::string::npos,
+			"changed CSM cascades must overwrite the freed flight-slot texture and allocate only while warming an empty slot");
+		Require(prepareCsmBody.find(
+			"cascade.m_shadowType == RHI::EShadowType::EVSM") != std::string::npos,
+			"PCF cascades must use the compact depth format instead of allocating EVSM moments per flight");
+		Require(lightingEcsSource.find("snapshot.Equals(") == std::string::npos &&
+			lightingEcsSource.find("m_snapshot.Add(") == std::string::npos,
+			"a transform invalidation must not be overridden by a duplicate caster-id snapshot");
 	}
 
 	void TestLocalLightShadowContract()
@@ -1008,6 +1067,8 @@ namespace
 			sourceRoot / "Runtime/Memory/MemoryBlockAllocator.hpp");
 		const std::string shadowPrepassSource = ReadText(
 			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
+		const std::string frameGraphSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RHIFrameGraph.cpp");
 		const std::string sceneViewSource = ReadText(
 			sourceRoot / "Runtime/RHI/SceneView.cpp");
 		const std::string lightingShader = ReadText(
@@ -1029,9 +1090,11 @@ namespace
 			lightingSource.find("shadowPass.m_shadowType = RHI::EShadowType::PCF") != std::string::npos,
 			"point and spot shadow passes must use their respective projections and PCF-only rendering");
 		Require(lightingSource.find("TryCreateLocalShadowAtlas") != std::string::npos &&
-			lightingSource.find("UpdateShaderBinding(\n\t\tm_lightsData,\n\t\t\"shadowMaps\"") != std::string::npos &&
-			lightingSource.find("NumCascades + atlasIndex") != std::string::npos,
-			"local shadow atlases must be created and published into the sampler array on demand");
+			lightingSource.find("m_shadowMapTextures[NumCascades + atlasIndex] = texture") != std::string::npos &&
+			lightingSource.find("m_bShadowMapBindingsDirty = true") != std::string::npos &&
+			lightingSource.find("PublishShadowMapBindings()") != std::string::npos &&
+			lightingSource.find("AddSamplerToShaderBindings(") != std::string::npos,
+			"local shadow atlases must publish a new immutable sampler generation on demand");
 		Require(lightingSource.find("TryAllocateLocalShadowTiles(") != std::string::npos &&
 			lightingSource.find("uint32_t& outAtlasIndex") != std::string::npos &&
 			lightingSource.find("candidate + mapCount <= MaxShadowsInView") != std::string::npos &&
@@ -1049,22 +1112,41 @@ namespace
 		Require(lightingSource.find("App::GetMainWindow()->GetRenderArea().y") != std::string::npos &&
 			lightingSource.find("camera,\n\t\t\t1080u,") == std::string::npos,
 			"dynamic local-shadow resolution must use the active viewport instead of a fixed reference height");
-		Require(lightingSource.find(
-			"GetLightsInFrustum(frustum, sceneView->m_cameraTransforms[i], directionalLights, sortedPointLights, sortedSpotLights)") != std::string::npos,
+		Require(lightingSource.find("m_directionalLightsScratch.Clear(false)") != std::string::npos &&
+			lightingSource.find("m_pointLightsScratch.Clear(false)") != std::string::npos &&
+			lightingSource.find("m_spotLightsScratch.Clear(false)") != std::string::npos &&
+			lightingSource.find("m_directionalLightsScratch,\n\t\t\tm_pointLightsScratch,\n\t\t\tm_spotLightsScratch") != std::string::npos,
 			"point and spot lights must remain in their matching sorted collections");
+		Require(lightingHeader.find(
+			"std::bitset<MaxShadowMapSamplers - NumCascades> m_writableLocalShadowAtlases") != std::string::npos &&
+			lightingHeader.find("TVector<RHI::RHIRenderTargetPtr> m_localShadowAtlasTextures{};") != std::string::npos &&
+			lightingHeader.find("TVector<TVector<CSMLightState>> m_localShadowSnapshots{};") != std::string::npos &&
+			lightingSource.find("m_writableLocalShadowAtlases.reset()") != std::string::npos &&
+			lightingSource.find("flightResources.m_localShadowAtlasTextures[atlasIndex]") != std::string::npos &&
+			lightingSource.find("shadowMapsToBlit.Add(") == std::string::npos &&
+			lightingSource.find("std::array<Math::Frustum, NumCascades> frustums") != std::string::npos &&
+			lightingSource.find("std::array<glm::mat4, 6u> lightMatrices") != std::string::npos &&
+			shadowPrepassSource.find("outMatrices.Clear(false)") != std::string::npos,
+			"per-camera shadow preparation must reuse bounded CPU scratch and freed flight-slot shadow textures without transient allocations");
 		Require(lightingSource.find("frustum.OverlapsSphere(Math::Sphere(worldPosition, sphereRadius))") != std::string::npos &&
 			lightingSource.find("frustum.ContainsSphere(Math::Sphere(worldPosition, sphereRadius))") == std::string::npos,
 			"local shadow lights must remain visible when their influence sphere intersects the camera frustum");
-		Require(lightingSource.find("sceneView->m_shadowIndices.Add(std::move(shadowIndices))") != std::string::npos &&
-			lightingSource.find("sceneView->m_shadowMapsToBlit.Add(std::move(shadowMapsToBlit))") != std::string::npos &&
-			lightingSource.find("sceneView->m_shadowAtlasTiles.Add(std::move(shadowAtlasTiles))") != std::string::npos &&
+		Require(lightingSource.find("sceneView->m_shadowIndices.Resize(numCameras)") != std::string::npos &&
+			lightingSource.find("shadowIndices = std::move(previous.m_shadowIndices)") != std::string::npos &&
+			lightingSource.find("shadowMapsToBlit = std::move(previous.m_shadowMapsToBlit)") != std::string::npos &&
+			lightingSource.find("shadowAtlasTiles = std::move(previous.m_shadowAtlasTiles)") != std::string::npos &&
+			lightingSource.find("shadowIndices.Resize(m_numLights)") != std::string::npos &&
+			lightingSource.find("shadowAtlasTiles.Resize(NumCascades)") != std::string::npos &&
+			lightingSource.find("shadowAtlasTiles.Resize(static_cast<size_t>(shadowSlot) + 1u)") != std::string::npos &&
+			lightingSource.find("TVector<uint32_t> shadowAtlasTiles(MaxShadowsInView)") == std::string::npos &&
 			sceneViewSource.find("res.m_shadowMapsToBlit = std::move(m_shadowMapsToBlit[i])") != std::string::npos &&
 			sceneViewSource.find("res.m_shadowIndices = std::move(m_shadowIndices[i])") != std::string::npos &&
 			sceneViewSource.find("res.m_shadowAtlasTiles = std::move(m_shadowAtlasTiles[i])") != std::string::npos &&
-			shadowPrepassSource.find("sceneView.m_shadowIndices.GetData()") != std::string::npos &&
-			shadowPrepassSource.find("sceneView.m_shadowAtlasTiles.GetData()") != std::string::npos &&
-			shadowPrepassSource.find("commands->UpdateShaderBinding(") != std::string::npos &&
-			shadowPrepassSource.find("transferCommandList") != std::string::npos,
+			frameGraphSource.find("snapshot.m_shadowIndices.GetData()") != std::string::npos &&
+			frameGraphSource.find("snapshot.m_shadowAtlasTiles.GetData()") != std::string::npos &&
+			frameGraphSource.find("PrepareViewSubmissionResources(") != std::string::npos &&
+			frameGraphSource.find("commands->UpdateShaderBinding(") != std::string::npos &&
+			frameGraphSource.find("transferCmdList") != std::string::npos,
 			"local shadow indices and atlas transforms must cross the scene snapshot and upload through the frame transfer command list");
 		Require(lightingSource.find("GetWorld()->GetCommandList(),\n\t\t\tm_shadowIndices") == std::string::npos,
 			"scene preparation must not record shadow-index uploads into the world command list");
@@ -1072,14 +1154,16 @@ namespace
 			lightingShader.find("CalculateLocalPcfShadow") != std::string::npos &&
 			lightingShader.find("DecodeShadowAtlasIndex") != std::string::npos &&
 			lightingShader.find("atlasRect.xy + projCoords.xy * atlasRect.zw") != std::string::npos &&
+			lightingShader.find("tileMin,\n    tileMax") != std::string::npos &&
 			lightingShader.find("SOFT_SHADOW_MAP_BIT") != std::string::npos,
 			"lighting shaders must select point faces and support atlas-aware hard/soft PCF sampling");
-		Require(lightingSource.find("snapshot.Equals(cachedState)") != std::string::npos,
-			"a global caster revision must not redraw a local static shadow whose actual caster snapshot is unchanged");
-		Require(shadowPrepassSource.find("Downsample Local Shadow Tiles") != std::string::npos &&
-			shadowPrepassSource.find("sceneView.m_shadowMapsToBlit") != std::string::npos &&
-			shadowPrepassSource.find("commands->BlitImage(") != std::string::npos,
-			"distance-driven local shadow downgrades must migrate cached tiles through a GPU blit");
+		Require(lightingSource.find("snapshot.Equals(cachedState)") == std::string::npos &&
+			lightingSource.find("m_submissionToken != currentSubmissionToken") != std::string::npos,
+			"local shadow reuse must use COW scene diffs and submission identity without hiding transform invalidation behind caster ids");
+		Require(lightingSource.find("current.m_revision = ++m_localShadowAllocationRevision") != std::string::npos &&
+			lightingSource.find("cachedState.m_resourceRevision == allocation.m_revision") != std::string::npos &&
+			shadowPrepassSource.find("sceneView.m_shadowMapsToBlit") != std::string::npos,
+			"distance-driven tile moves must invalidate only that flight-local shadow while retaining the generic blit command path");
 		Require(lightCullingShader.find("uintBitsToFloat(minDepthInt)") != std::string::npos &&
 			lightCullingShader.find("uintBitsToFloat(maxDepthInt)") != std::string::npos &&
 			lightCullingShader.find("texelFetch(linearDepth, location, 0)") != std::string::npos &&
@@ -1121,28 +1205,122 @@ namespace
 		cachedState.m_shadowType = RHI::EShadowType::PCF;
 		cachedState.m_lightMatrix = cachedLightMatrix;
 		cachedState.m_sceneRevision = 23u;
-		cachedState.m_snapshot.Add({ 11u, 19u });
+		cachedState.m_casterSceneVersions =
+			TSharedPtr<TVector<RHI::RHISceneVersionPtr>>::Make();
+		cachedState.m_submissionToken = RHI::RHISubmissionCompletionTokenPtr::Make();
+		cachedState.m_submissionToken->Complete(true);
+		cachedState.m_payloadCompletionToken =
+			RHI::RHISubmissionCompletionTokenPtr::Make();
+		cachedState.m_payloadCompletionToken->Complete(true);
+		Math::Frustum shadowFrustum;
 		Require(cachedState.CanReuse(
 			cachedState.m_componentIndex,
 			cachedState.m_shadowType,
 			cachedState.m_lightMatrix,
-			cachedState.m_sceneRevision),
+			cachedState.m_sceneRevision,
+			cachedState.m_casterSceneVersions,
+			shadowFrustum),
 			"an unchanged light and shadow-caster scene should reuse its CSM snapshot before tracing");
 		Require(!cachedState.CanReuse(
 			cachedState.m_componentIndex,
 			cachedState.m_shadowType,
-			cachedState.m_lightMatrix,
-			cachedState.m_sceneRevision + 1),
-			"a changed shadow-caster scene revision should require a lightweight CSM query");
-
-		CSMLightState movedState{};
-		movedState.m_componentIndex = cachedState.m_componentIndex;
-		movedState.m_shadowType = cachedState.m_shadowType;
-		movedState.m_lightMatrix = movedLightMatrix;
-		movedState.m_snapshot.Add({ 11u, 19u });
-
-		Require(!movedState.Equals(cachedState),
+			movedLightMatrix,
+			cachedState.m_sceneRevision,
+			cachedState.m_casterSceneVersions,
+			shadowFrustum),
 			"a changed cascade projection must invalidate the cached shadow map even for camera motion below the old threshold");
+
+		CSMLightState pendingState = cachedState;
+		pendingState.m_submissionToken = RHI::RHISubmissionCompletionTokenPtr::Make();
+		Require(!pendingState.CanReuse(
+			pendingState.m_componentIndex,
+			pendingState.m_shadowType,
+			pendingState.m_lightMatrix,
+			pendingState.m_sceneRevision,
+			pendingState.m_casterSceneVersions,
+			shadowFrustum),
+			"a pending shadow resource must not leak into another submission");
+		Require(pendingState.CanReuse(
+			pendingState.m_componentIndex,
+			pendingState.m_shadowType,
+			pendingState.m_lightMatrix,
+			pendingState.m_sceneRevision,
+			pendingState.m_casterSceneVersions,
+			shadowFrustum,
+			pendingState.m_submissionToken),
+			"multiple cameras in one submission may reuse the same scheduled shadow update");
+
+		CSMLightState incompletePayloadState = cachedState;
+		incompletePayloadState.m_payloadCompletionToken =
+			RHI::RHISubmissionCompletionTokenPtr::Make();
+		incompletePayloadState.m_payloadCompletionToken->Complete(false);
+		Require(!incompletePayloadState.CanReuse(
+			incompletePayloadState.m_componentIndex,
+			incompletePayloadState.m_shadowType,
+			incompletePayloadState.m_lightMatrix,
+			incompletePayloadState.m_sceneRevision,
+			incompletePayloadState.m_casterSceneVersions,
+			shadowFrustum),
+			"a shadow pass with incomplete mesh or material dependencies must be rebuilt");
+
+		CSMLightState pendingPayloadState = pendingState;
+		pendingPayloadState.m_payloadCompletionToken =
+			RHI::RHISubmissionCompletionTokenPtr::Make();
+		Require(pendingPayloadState.CanReuse(
+			pendingPayloadState.m_componentIndex,
+			pendingPayloadState.m_shadowType,
+			pendingPayloadState.m_lightMatrix,
+			pendingPayloadState.m_sceneRevision,
+			pendingPayloadState.m_casterSceneVersions,
+			shadowFrustum,
+			pendingPayloadState.m_submissionToken),
+			"multiple cameras in one submission may share one pending shadow payload build");
+
+		auto nextSubmissionToken = RHI::RHISubmissionCompletionTokenPtr::Make();
+		CSMLightState dynamicState = cachedState;
+		dynamicState.m_bContainsDynamicCasters = true;
+		Require(!dynamicState.CanReuse(
+			dynamicState.m_componentIndex,
+			dynamicState.m_shadowType,
+			dynamicState.m_lightMatrix,
+			dynamicState.m_sceneRevision,
+			dynamicState.m_casterSceneVersions,
+			shadowFrustum,
+			nextSubmissionToken),
+			"a shadow map containing dynamic casters must be rebuilt for every submission");
+		Require(dynamicState.CanReuse(
+			dynamicState.m_componentIndex,
+			dynamicState.m_shadowType,
+			dynamicState.m_lightMatrix,
+			dynamicState.m_sceneRevision,
+			dynamicState.m_casterSceneVersions,
+			shadowFrustum,
+			dynamicState.m_submissionToken),
+			"multiple cameras in one submission may share a scheduled dynamic shadow update");
+
+		CSMLightState animatedState = cachedState;
+		animatedState.m_animationRevision = 41ull;
+		animatedState.m_bContainsAnimatedCasters = true;
+		Require(animatedState.CanReuse(
+			animatedState.m_componentIndex,
+			animatedState.m_shadowType,
+			animatedState.m_lightMatrix,
+			animatedState.m_sceneRevision,
+			animatedState.m_casterSceneVersions,
+			shadowFrustum,
+			nextSubmissionToken,
+			41ull),
+			"an unchanged bone-matrix generation may reuse its shadow map");
+		Require(!animatedState.CanReuse(
+			animatedState.m_componentIndex,
+			animatedState.m_shadowType,
+			animatedState.m_lightMatrix,
+			animatedState.m_sceneRevision,
+			animatedState.m_casterSceneVersions,
+			shadowFrustum,
+			nextSubmissionToken,
+			42ull),
+			"a new bone-matrix generation must invalidate animated shadows even when RHIScene is unchanged");
 	}
 
 	void TestShadowCachePolicy()
@@ -1150,6 +1328,8 @@ namespace
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string meshRendererSource = ReadText(sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
 		const std::string lightingSource = ReadText(sourceRoot / "Runtime/ECS/LightingECS.cpp");
+		const std::string shadowPrepassSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
 		const size_t localShadowBegin = lightingSource.find("LightingECS::PrepareLocalShadowPasses");
 		const size_t fillLightingBegin = lightingSource.find("void LightingECS::FillLightingData", localShadowBegin);
 		Require(localShadowBegin != std::string::npos && fillLightingBegin > localShadowBegin,
@@ -1157,15 +1337,19 @@ namespace
 		const std::string localShadowBody = lightingSource.substr(
 			localShadowBegin, fillLightingBegin - localShadowBegin);
 
-		Require(meshRendererSource.find("++m_sceneViewProxiesCache->m_shadowCastersRevision;") != std::string::npos &&
+		Require(meshRendererSource.find("++m_shadowCastersRevision;") != std::string::npos &&
 			lightingSource.find("sceneView->m_shadowCastersRevision") != std::string::npos,
 			"shadow caches must invalidate when the shadow-caster scene revision changes");
 		Require(lightingSource.find("bForceCustomDepthShadowUpdate") != std::string::npos &&
-			lightingSource.find("bool bCanReuseAllCascades = !bForceCustomDepthShadowUpdate") != std::string::npos,
+			lightingSource.find("const bool bCanReuseCascade = !bForceCustomDepthShadowUpdate") != std::string::npos,
 			"directional CSM must retain the conservative custom-depth update policy");
 		Require(localShadowBody.find("m_bHasCustomDepthShadowCasters") == std::string::npos &&
 			localShadowBody.find("cachedState.CanReuse(") != std::string::npos,
 			"static local-light shadow maps must reuse revision-validated snapshots even with custom-depth vegetation");
+		Require(lightingSource.find("m_payloadCompletionToken->IsSuccessful()") != std::string::npos &&
+			shadowPrepassSource.find("bPassPayloadComplete") != std::string::npos &&
+			shadowPrepassSource.find("m_payloadCompletionToken->Complete(") != std::string::npos,
+			"incomplete shadow packets must remain invalid and retry instead of caching a cleared map");
 	}
 
 	void TestAnimationGpuBoneLayoutContract()

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -105,18 +105,470 @@ namespace
 			"a one-pixel dimension must never become zero");
 	}
 
+	void TestPackedDrawMobilityPayloadVirtualization()
+	{
+		struct TestInstance
+		{
+			uint32_t m_value = 0u;
+		};
+
+		RHI::TPackedDrawPacket<TestInstance> source;
+		source.Add({}, {}, { 10u }, 10ull, EMobilityType::Static);
+		source.Add({}, {}, { 20u }, 20ull, EMobilityType::Stationary);
+		source.Add({}, {}, { 30u }, 30ull, EMobilityType::Dynamic);
+		source.Finalize(false);
+		Require(source.GetNumInstances() == 3u && source.GetGroups().Num() == 3u,
+			"mobility segments must materialize as one logical packed packet");
+		Require(source.GetGroups()[0].m_firstInstance == 0u &&
+			source.GetGroups()[1].m_firstInstance == 1u &&
+			source.GetGroups()[2].m_firstInstance == 2u,
+			"combined packet groups must reference contiguous static, stationary, and dynamic ranges");
+
+		auto staticPayload = source.SharePayload(EMobilityType::Static);
+		auto stationaryPayload = source.SharePayload(EMobilityType::Stationary);
+		Require(staticPayload && stationaryPayload && source.HasSharedImmutablePayload(),
+			"static and stationary payloads must be publishable as immutable shared storage");
+
+		RHI::TPackedDrawPacket<TestInstance> nextFlight;
+		nextFlight.UseSharedPayload(EMobilityType::Static, staticPayload);
+		nextFlight.UseSharedPayload(EMobilityType::Stationary, stationaryPayload);
+		nextFlight.Add({}, {}, { 31u }, 31ull, EMobilityType::Dynamic);
+		nextFlight.Finalize(false);
+		Require(nextFlight.GetSharedPayload(EMobilityType::Static) == staticPayload &&
+			nextFlight.GetSharedPayload(EMobilityType::Stationary) == stationaryPayload,
+			"independent flight packets must retain the same immutable payload identities");
+		Require(nextFlight.GetPayload(EMobilityType::Dynamic).m_instances[0].m_value == 31u &&
+			!nextFlight.GetSharedPayload(EMobilityType::Dynamic),
+			"dynamic records must remain flight-local and be rebuilt for the new submission");
+
+		RHI::TPackedDrawPacket<TestInstance> arenaSource;
+		Require(arenaSource.AddArenaInstance({ 10u }, 101ull, EMobilityType::Static) &&
+			arenaSource.AddArenaInstance({ 20u }, 102ull, EMobilityType::Static) &&
+			arenaSource.AddArenaInstance({ 30u }, 103ull, EMobilityType::Static),
+			"a static arena must register immutable records independently of a view");
+		auto arenaPayload = arenaSource.ShareArenaPayload(EMobilityType::Static);
+		RHI::TPackedDrawPacket<TestInstance> arenaView;
+		arenaView.UseSharedArenaPayload(EMobilityType::Static, arenaPayload);
+		Require(arenaView.AddArenaView({}, {}, 103ull, EMobilityType::Static) &&
+			arenaView.AddArenaView({}, {}, 101ull, EMobilityType::Static),
+			"a view packet must resolve visible items through stable arena keys");
+		arenaView.Finalize(false);
+		Require(arenaView.GetNumStorageInstances() == 3u &&
+			arenaView.GetNumDrawInstances() == 2u &&
+			arenaView.GetInstanceIndices().Num() == 2u &&
+			arenaView.GetInstanceIndices()[0] == 0u &&
+			arenaView.GetInstanceIndices()[1] == 2u,
+			"view sorting must rebuild compact indices without copying the three static records");
+
+		auto baseLodMesh = RHI::RHIMeshPtr::Make();
+		auto selectedLodMesh = RHI::RHIMeshPtr::Make();
+		RHI::TPackedDrawPacket<TestInstance> nearView;
+		nearView.UseSharedArenaPayload(EMobilityType::Static, arenaPayload);
+		Require(nearView.AddArenaView(
+			{}, baseLodMesh, 101ull, EMobilityType::Static),
+			"the near view must resolve the shared static record");
+		nearView.Finalize(false);
+		RHI::TPackedDrawPacket<TestInstance> farView;
+		farView.UseSharedArenaPayload(EMobilityType::Static, arenaPayload);
+		Require(farView.AddArenaView(
+			{}, selectedLodMesh, 101ull, EMobilityType::Static),
+			"the far view must resolve the same shared static record");
+		farView.Finalize(false);
+		Require(nearView.GetSharedPayload(EMobilityType::Static) ==
+				farView.GetSharedPayload(EMobilityType::Static) &&
+			nearView.GetGroups().Num() == 1u && farView.GetGroups().Num() == 1u &&
+			nearView.GetGroups()[0].m_mesh == baseLodMesh &&
+			farView.GetGroups()[0].m_mesh == selectedLodMesh &&
+			nearView.GetInstanceIndices() == farView.GetInstanceIndices(),
+			"CPU LOD selection must change only flight/view-local draw groups while retaining the immutable per-instance arena");
+
+		RHI::TPackedDrawPacket<TestInstance> disjointCameraView;
+		disjointCameraView.UseSharedArenaPayload(
+			EMobilityType::Static,
+			arenaPayload);
+		Require(disjointCameraView.AddArenaView(
+			{}, baseLodMesh, 102ull, EMobilityType::Static),
+			"a disjoint camera must resolve records absent from another camera's visible set");
+		disjointCameraView.Finalize(false);
+		Require(disjointCameraView.GetSharedPayload(EMobilityType::Static) ==
+				arenaView.GetSharedPayload(EMobilityType::Static) &&
+			disjointCameraView.GetNumStorageInstances() == 3u &&
+			disjointCameraView.GetNumDrawInstances() == 1u &&
+			disjointCameraView.GetInstanceIndices()[0] == 1u,
+			"camera-independent arenas must retain the complete immutable scene while each view owns only compact indices");
+
+		Require(RHI::BuildPackedDrawStableKey({ 7u, 1u }, 11ull, 0u, 0u, 0u) !=
+			RHI::BuildPackedDrawStableKey({ 7u, 1u }, 12ull, 0u, 0u, 0u),
+			"identical handle slots from independent scene producers must not alias");
+
+		RHI::TPackedDrawPacket<TestInstance> reordered;
+		reordered.Add({}, {}, { 30u }, 30ull, EMobilityType::Static);
+		reordered.Add({}, {}, { 10u }, 10ull, EMobilityType::Static);
+		reordered.Add({}, {}, { 20u }, 20ull, EMobilityType::Static);
+		reordered.Finalize(false);
+		const auto& reorderedInstances =
+			reordered.GetPayload(EMobilityType::Static).m_instances;
+		Require(reorderedInstances[0].m_value == 10u &&
+			reorderedInstances[1].m_value == 20u &&
+			reorderedInstances[2].m_value == 30u,
+			"metadata sorting must reorder the single instance array in place without a duplicate payload");
+
+		RHI::TPackedDrawPacketPayloadCache<TestInstance> cache;
+		cache.Publish(7u, 101u, staticPayload, 1ull);
+		Require(cache.Find(7u, 101u, 2ull) == staticPayload,
+			"payload cache must preserve immutable identity across flight slots");
+		auto replacementPayload = RHI::TPackedDrawPacketPayloadPtr<TestInstance>::Make();
+		replacementPayload->m_instances.Add({ 91u });
+		cache.Publish(7u, 102u, replacementPayload, 3ull);
+		Require(!cache.Find(7u, 101u, 3ull) &&
+			cache.Find(7u, 102u, 3ull) == replacementPayload &&
+			cache.Num() == 1u,
+			"a logical cache slot must retain only its current immutable revision");
+		cache.Evict(12ull, 8ull);
+		Require(!cache.Find(7u, 102u, 12ull),
+			"unreferenced payload cache entries must expire after the retention window");
+
+		RHI::TPackedDrawPagedArenaCache<TestInstance> pagedCache;
+		TVector<TestInstance> rangeA;
+		TVector<TestInstance> rangeB;
+		TVector<uint64_t> keysA;
+		TVector<uint64_t> keysB;
+		for (uint32_t index = 0u; index < 64u; ++index)
+		{
+			rangeA.Add({ 100u + index });
+			rangeB.Add({ 200u + index });
+			keysA.Add(1000ull + index);
+			keysB.Add(2000ull + index);
+		}
+		const uint64_t rangeKeyA = RHI::BuildPackedDrawRangeKey({ 1u, 1u }, 10ull);
+		const uint64_t rangeKeyB = RHI::BuildPackedDrawRangeKey({ 2u, 1u }, 20ull);
+		int topologyA = 0;
+		int topologyB = 0;
+		Require(RHI::BuildPackedDrawRangeKey({ 1u, 1u }, 10ull, &topologyA) !=
+			RHI::BuildPackedDrawRangeKey({ 1u, 1u }, 10ull, &topologyB),
+			"static arena ranges from different scene topology roots must not alias");
+		pagedCache.BeginUpdate(3u, 1u, 1ull);
+		Require(pagedCache.ReplaceRange(rangeKeyA, 1ull, rangeA, keysA) &&
+			pagedCache.ReplaceRange(rangeKeyB, 1ull, rangeB, keysB),
+			"paged static arena must allocate independent stable producer ranges");
+		auto pagedV1 = pagedCache.EndUpdate();
+		Require(pagedV1 && pagedV1->GetNumStorageInstances() == 128u &&
+			pagedV1->m_arenaPages.Num() == 2u,
+			"two full producer ranges must occupy two arena pages");
+
+		pagedCache.BeginUpdate(3u, 2u, 2ull);
+		Require(pagedCache.TryReuseRange(rangeKeyA, 1ull) &&
+			pagedCache.TryReuseRange(rangeKeyB, 1ull),
+			"unchanged producer ranges must be reusable without visiting their instances");
+		auto pagedV2 = pagedCache.EndUpdate();
+		Require(pagedV2->m_arenaPages[0] == pagedV1->m_arenaPages[0] &&
+			pagedV2->m_arenaPages[1] == pagedV1->m_arenaPages[1],
+			"an unchanged arena version must share every immutable page");
+
+		rangeB[5].m_value = 999u;
+		pagedCache.BeginUpdate(3u, 3u, 3ull);
+		Require(pagedCache.TryReuseRange(rangeKeyA, 1ull) &&
+			pagedCache.ReplaceRange(rangeKeyB, 2ull, rangeB, keysB),
+			"a changed producer must replace only its logical range");
+		auto pagedV3 = pagedCache.EndUpdate();
+		uint32_t changedIndex = 0u;
+		Require(pagedV3->m_arenaPages[0] == pagedV2->m_arenaPages[0] &&
+			pagedV3->m_arenaPages[1] != pagedV2->m_arenaPages[1] &&
+			pagedV3->FindInstance(rangeKeyB, keysB[5], changedIndex) &&
+			changedIndex == 69u &&
+			pagedV3->m_arenaPages[1]->m_instances[5].m_value == 999u &&
+			pagedV2->m_arenaPages[1]->m_instances[5].m_value == 205u,
+			"range mutation must clone one page while older in-flight versions stay immutable");
+
+		RHI::TPackedDrawPacket<TestInstance> stationaryArenaView;
+		stationaryArenaView.UseSharedArenaPayload(
+			EMobilityType::Stationary,
+			pagedV3);
+		Require(stationaryArenaView.AddArenaView(
+			{},
+			{},
+			rangeKeyB,
+			keysB[5],
+			EMobilityType::Stationary),
+			"stationary records must resolve through the same immutable paged arena path");
+		stationaryArenaView.Finalize(false);
+		Require(stationaryArenaView.GetPayload(EMobilityType::Stationary).IsPagedArena() &&
+			stationaryArenaView.GetNumStorageInstances() == 128u &&
+			stationaryArenaView.GetNumDrawInstances() == 1u &&
+			stationaryArenaView.GetInstanceIndices()[0] == 69u,
+			"a stationary view must share arena pages and rebuild only its compact view indices");
+
+		rangeA[7].m_value = 777u;
+		pagedCache.BeginUpdate(3u, 4u, 4ull);
+		Require(pagedCache.ReplaceRange(rangeKeyA, 2ull, rangeA, keysA) &&
+			pagedCache.TryReuseRange(rangeKeyB, 2ull),
+			"a later arena version must retain earlier mutations while applying a new delta");
+		auto pagedV4 = pagedCache.EndUpdate();
+		Require(pagedV4->m_arenaPages[0] != pagedV1->m_arenaPages[0] &&
+			pagedV4->m_arenaPages[1] != pagedV1->m_arenaPages[1],
+			"a flight that skips versions must observe every page changed since its upload");
+
+		auto versionedMaterial = RHI::RHIMaterialPtr::Make(
+			RHI::RenderState{},
+			RHI::RHIShaderPtr{},
+			RHI::RHIShaderPtr{});
+		auto bindingsV1 = RHI::RHIShaderBindingSetPtr::Make();
+		versionedMaterial->SetBindings(bindingsV1);
+		const auto materialV1 = versionedMaterial->GetVersion();
+		TVector<RHI::PackedDrawArenaMaterialRun> rangeMaterialVersionRuns({
+			{ 0u, static_cast<uint32_t>(rangeA.Num()), materialV1 } });
+		pagedCache.BeginUpdate(4u, 1u, 5ull);
+		Require(pagedCache.ReplaceRange(
+			rangeKeyA,
+			3ull,
+			rangeA,
+			keysA,
+			&rangeMaterialVersionRuns),
+			"paged arena ranges must retain the material generation used to encode each record");
+		auto materialPayload = pagedCache.EndUpdate();
+		const RHI::PackedDrawArenaRange* materialRange = nullptr;
+		Require(materialPayload->m_arenaRanges.Find(rangeKeyA, materialRange) &&
+			materialRange && materialRange->m_itemOffsets &&
+			materialRange->m_itemOffsets->Num() == rangeA.Num() &&
+			materialRange->m_materialVersionRuns &&
+			materialRange->m_materialVersionRuns->Num() == 1u &&
+			(*materialRange->m_materialVersionRuns)[0].m_count == rangeA.Num(),
+			"arena lookup must stay dense and repeated material versions must collapse into one compact run");
+
+		auto bindingsV2 = RHI::RHIShaderBindingSetPtr::Make();
+		versionedMaterial->SetBindings(bindingsV2);
+		RHI::RHIBatch currentBatch(versionedMaterial, {});
+		Require(currentBatch.m_materialVersion != materialV1,
+			"the fixture must publish a newer material generation");
+		RHI::TPackedDrawPacket<TestInstance> materialView;
+		materialView.UseSharedArenaPayload(EMobilityType::Static, materialPayload);
+		Require(materialView.AddArenaView(
+			currentBatch,
+			{},
+			rangeKeyA,
+			keysA[0],
+			EMobilityType::Static),
+			"a view must resolve a record from the versioned producer range");
+		materialView.Finalize(false);
+		Require(materialView.GetGroups().Num() == 1u &&
+			materialView.GetGroups()[0].m_batch.m_materialVersion == materialV1 &&
+			materialView.GetGroups()[0].m_batch.GetMaterialBindings() == bindingsV1,
+			"a reused static record must bind the exact material version that produced its material index");
+	}
+
+	void TestMaterialVersionPublicationContract()
+	{
+		class TestDependency final : public RHI::RHIResource
+		{
+		public:
+			TestDependency() = default;
+		};
+
+		auto material = RHI::RHIMaterialPtr::Make(
+			RHI::RenderState{},
+			RHI::RHIShaderPtr{},
+			RHI::RHIShaderPtr{});
+		auto oldBindings = RHI::RHIShaderBindingSetPtr::Make();
+		material->SetBindings(oldBindings);
+		const auto oldVersion = material->GetVersion();
+		const auto submissionVersion = material->GetVersionForSubmission(100ull);
+
+		auto pendingBindings = RHI::RHIShaderBindingSetPtr::Make();
+		pendingBindings->AddDependency(TRefPtr<TestDependency>::Make());
+		material->StageBindings(pendingBindings);
+		Require(material->GetVersion() == oldVersion &&
+			!material->TryPublishPendingBindings(),
+			"a pending material upload must not replace the generation visible to submitted frames");
+		Require(material->GetVersion() == oldVersion &&
+			material->GetBindings() == oldBindings,
+			"failed publication must leave the previous material bindings untouched");
+
+		pendingBindings->ClearDependencies();
+		Require(material->TryPublishPendingBindings() &&
+			material->GetVersion() != oldVersion &&
+			material->GetBindings() == pendingBindings,
+			"a completed upload must publish a new immutable material generation atomically");
+		Require(oldVersion->GetBindings() == oldBindings,
+			"publishing the next generation must not mutate the bindings retained by an older flight");
+		Require(submissionVersion == oldVersion &&
+			material->GetVersionForSubmission(100ull) == oldVersion &&
+			material->GetVersionForSubmission(101ull) == material->GetVersion(),
+			"one submission must keep its first captured material generation while the next submission observes the publication");
+		RHI::RHIBatch oldBatch(material, {}, 100ull);
+		RHI::RHIBatch nextBatch(material, {}, 101ull);
+		Require(oldBatch.GetMaterialBindings() == oldBindings &&
+			nextBatch.GetMaterialBindings() == pendingBindings,
+			"main, depth, and shadow batch construction must use the submission-scoped material capture");
+
+		const auto cutoffVersion = material->GetVersion();
+		const uint64_t cutoffRevision =
+			RHI::RHIMaterial::BeginSubmissionVersionCapture(200ull);
+		for (uint32_t updateIndex = 0u; updateIndex < 6u; ++updateIndex)
+		{
+			material->SetBindings(RHI::RHIShaderBindingSetPtr::Make());
+		}
+		const auto latestVersion = material->GetVersion();
+		const auto delayedCapture = material->GetVersionForSubmission(200ull);
+		RHI::RHIMaterial::EndSubmissionVersionCapture(200ull);
+		Require(delayedCapture == cutoffVersion &&
+			cutoffVersion->GetPublicationRevision() <= cutoffRevision &&
+			latestVersion != cutoffVersion &&
+			material->GetVersionForSubmission(201ull) == latestVersion,
+			"a submission must resolve the material generation at its begin revision even when several publications happen before the first batch is built");
+
+		auto retentionMaterial = RHI::RHIMaterialPtr::Make(
+			RHI::RenderState{},
+			RHI::RHIShaderPtr{},
+			RHI::RHIShaderPtr{});
+		retentionMaterial->SetBindings(RHI::RHIShaderBindingSetPtr::Make());
+		auto retiredVersion = retentionMaterial->GetVersion();
+		RHI::RHIMaterial::BeginSubmissionVersionCapture(300ull);
+		retentionMaterial->SetBindings(RHI::RHIShaderBindingSetPtr::Make());
+		auto retainedBySubmission =
+			retentionMaterial->GetVersionForSubmission(300ull);
+		Require(retainedBySubmission == retiredVersion,
+			"the active cutoff must retain its exact material generation until packet capture");
+		RHI::RHIMaterial::EndSubmissionVersionCapture(300ull);
+		retainedBySubmission.Clear();
+		Require(retiredVersion.NumRefs() == 1u,
+			"ending an active submission must release material history that is no longer retained by a packet");
+	}
+
+	void TestDynamicSpatialRootIsolation()
+	{
+		RHI::RHISceneViewProxy proxy;
+		proxy.m_staticMeshEcs = 41u;
+		proxy.m_mobility = EMobilityType::Dynamic;
+		proxy.m_worldMatrix = glm::mat4(1.0f);
+		proxy.m_worldAabb = Math::AABB(
+			glm::vec3(0.0f, 0.0f, -5.0f),
+			glm::vec3(1.0f));
+		auto resource = RHI::RHISceneProxyResourcePtr::Make(std::move(proxy));
+		auto scene = RHI::RHIScenePtr::Make(3u);
+		RHI::RHISceneInstanceRecord record;
+		record.m_producerKey = 41u;
+		record.m_mobility = EMobilityType::Dynamic;
+		record.m_worldMatrix = glm::mat4(1.0f);
+		record.m_worldBounds = resource->m_proxy.m_worldAabb;
+		record.m_topology = resource;
+		const auto handle = scene->AddInstance(record);
+
+		auto spatial = RHI::RHISpatialSceneVersionPtr::Make();
+		spatial->m_scene = scene;
+		spatial->m_sceneVersion = scene->PublishVersion();
+		spatial->m_dynamicOctree =
+			TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
+				glm::ivec3(0), 128, 4);
+		Require(spatial->m_dynamicOctree->Update(
+			glm::ivec3(0, 0, -5),
+			glm::ivec3(1),
+			handle),
+			"the dynamic spatial fixture must publish its handle");
+
+		RHI::RHISceneView view;
+		view.AddSceneVersion(spatial);
+		Math::Frustum frustum;
+		frustum.ExtractFrustumPlanes(
+			glm::mat4(1.0f),
+			1.0f,
+			60.0f,
+			0.1f,
+			10.0f);
+		const auto visible = view.TraceScene(frustum, false);
+		Require(visible.Num() == 1u && visible[0].m_handle == handle &&
+			visible[0].GetMobility() == EMobilityType::Dynamic &&
+			!spatial->m_staticOctree && !spatial->m_stationaryOctree,
+			"dynamic instances must remain visible through an independent spatial root without allocating static roots");
+	}
+
+	void TestInstancedViewLodAndDistanceContract()
+	{
+		auto baseMesh = RHI::RHIMeshPtr::Make();
+		auto lodMesh = RHI::RHIMeshPtr::Make();
+		baseMesh->m_bounds = Math::AABB(glm::vec3(0.0f), glm::vec3(0.5f));
+		lodMesh->m_bounds = baseMesh->m_bounds;
+		baseMesh->m_lods.Add(lodMesh);
+
+		RHI::RHIInstancedMeshGroup group;
+		group.m_meshes.Add(baseMesh);
+		glm::mat4 nearTransform(1.0f);
+		nearTransform[3].z = -2.0f;
+		glm::mat4 farTransform(1.0f);
+		farTransform[3].z = -20.0f;
+		group.m_instanceTransforms = { nearTransform, farTransform };
+
+		const glm::mat4 view(1.0f);
+		const glm::mat4 projection = glm::perspective(
+			glm::radians(60.0f),
+			1.0f,
+			0.1f,
+			100.0f);
+		Math::AABB nearBounds = baseMesh->m_bounds;
+		nearBounds.Apply(nearTransform);
+		Math::AABB farBounds = baseMesh->m_bounds;
+		farBounds.Apply(farTransform);
+		const float nearCoverage = RHI::CalculateScreenCoverage(
+			nearBounds,
+			view,
+			projection);
+		const float farCoverage = RHI::CalculateScreenCoverage(
+			farBounds,
+			view,
+			projection);
+		Require(nearCoverage > farCoverage,
+			"the LOD fixture must distinguish near and far instance coverage");
+
+		RHI::RHISceneViewProxy proxy;
+		proxy.m_worldMatrix = glm::mat4(1.0f);
+		proxy.m_worldAabb = Math::AABB(glm::vec3(0.0f, 0.0f, -11.0f),
+			glm::vec3(1.0f, 1.0f, 10.0f));
+		proxy.m_lodPolicy.m_bEnabled = true;
+		proxy.m_lodPolicy.m_minLod = 0u;
+		proxy.m_lodPolicy.m_maxLod = 1u;
+		proxy.m_lodPolicy.m_screenCoverageThresholds = {
+			(nearCoverage + farCoverage) * 0.5f };
+		proxy.m_instancedGroups.Add(group);
+		auto resource = RHI::RHISceneProxyResourcePtr::Make(std::move(proxy));
+
+		RHI::RHIVisibleSceneProxy cameraView;
+		cameraView.m_resource = resource.GetRawPtr();
+		Require(cameraView.ResolveInstancedMesh(group, 0u, 0u, view, projection) == baseMesh &&
+			cameraView.ResolveInstancedMesh(group, 1u, 0u, view, projection) == lodMesh,
+			"main and depth view classification must select LOD per vegetation instance instead of per chunk");
+		Require(cameraView.IsInstancedMeshWithinDistance(
+				group, 0u, 0u, glm::vec3(0.0f), 10.0f) &&
+			!cameraView.IsInstancedMeshWithinDistance(
+				group, 1u, 0u, glm::vec3(0.0f), 10.0f),
+			"vegetation distance culling must use per-instance bounds");
+
+		RHI::RHIVisibleShadowCaster shadowView;
+		shadowView.m_resource = resource.GetRawPtr();
+		const glm::mat4 shadowViewProjection = projection * view;
+		Require(shadowView.ResolveInstancedMesh(
+				group, 0u, 0u, shadowViewProjection) == baseMesh &&
+			shadowView.ResolveInstancedMesh(
+				group, 1u, 0u, shadowViewProjection) == lodMesh,
+			"shadow views must retain independent per-instance LOD classification");
+	}
+
 	void TestGpuCullingRangeAndSynchronizationContract()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string batchHeader = ReadText(sourceRoot / "Runtime/RHI/Batch.hpp");
-		const std::string cullingBody = ExtractFunctionBody(batchHeader, "DrawCallStats RHIRecordDrawCallGPUCulling(");
+		const std::string cullingBody = ExtractFunctionBody(
+			batchHeader,
+			"const TVector<RHIShaderBindingSetPtr>& cullingDispatchBindings = {})");
 
-		Require(cullingBody.find("storageIndex[start]") != std::string::npos,
-			"a partitioned culling dispatch must start from its requested batch range");
-		Require(cullingBody.find("storageIndex[0]") == std::string::npos,
-			"a secondary partition must not cull the first partition's instances");
-		Require(cullingBody.find("constants.m_phase = 0") != std::string::npos &&
-			cullingBody.find("constants.m_phase = 1") != std::string::npos,
+		Require(cullingBody.find("constants.m_firstInstanceIndex = firstIndexInstance") != std::string::npos,
+			"packed culling must address the flight-local compact index stream");
+		Require(cullingBody.find("constants.m_firstStorageInstance = firstStorageInstance") != std::string::npos &&
+			cullingBody.find("constants.m_firstCandidateInstance = firstCandidateInstance") != std::string::npos &&
+			cullingBody.find("firstCandidateInstance + numInstances") != std::string::npos &&
+			cullingBody.find("const bool bResetIndices = computeCullingShader") == std::string::npos &&
+			cullingBody.find("packet.m_resolvedInstanceIndices") != std::string::npos,
+			"GPU culling must retain immutable candidates and restore its compacted output without a per-frame CPU upload");
+		Require(cullingBody.find("constants.m_phase = 1u") != std::string::npos &&
+			cullingBody.find("uint32_t m_phase = 0u") != std::string::npos,
 			"culling and indirect compaction must be recorded as separate dispatch phases");
 		Require(cullingBody.find("EAccessBit::ShaderWrite_Bit") != std::string::npos &&
 			cullingBody.find("commands->MemoryBarrier") != std::string::npos,
@@ -124,14 +576,11 @@ namespace
 		Require(cullingBody.find("m_bEnableOcclusion = 0") != std::string::npos,
 			"previous-frame Hi-Z must not cull current-frame transforms");
 
-		const std::string fallbackBody = ExtractFunctionBody(
-			batchHeader,
-			"DrawCallStats RHIRecordDrawCall(");
-		Require(fallbackBody.find(
+		Require(cullingBody.find(
 			"driver->AddBufferToShaderBindings(") != std::string::npos &&
-			fallbackBody.find(
-				"*indirectCommandBufferBinding") != std::string::npos,
-			"the fallback draw path must update the GPU-culling descriptor when its shared indirect buffer grows");
+			cullingBody.find(
+			"*indirectCommandBufferBinding") != std::string::npos,
+			"the packed path must update the GPU-culling descriptor when its shared indirect buffer grows");
 	}
 
 	void TestBatchTextureBindingIdentityContract()
@@ -150,6 +599,22 @@ namespace
 			"a different equal-sized texture binding cache key must not collapse into the first");
 		Require(textureBindingCache.Num() == 2,
 			"texture sets with the same count and layout capacity must retain distinct cache identities");
+		TSet<uint32_t> lookupTextures{ 8u, 4u };
+		TextureBindingCacheKey lookupKey(lookupTextures);
+		Require(lookupKey.m_requestedTextures.IsEmpty() &&
+			lookupKey == firstTextureSet &&
+			lookupKey.GetHash() == firstTextureSet.GetHash(),
+			"a cache-hit lookup key must compare and hash a non-owning texture set without materializing a vector");
+		uint32_t* lookupValue = nullptr;
+		Require(textureBindingCache.Find(lookupKey, lookupValue) &&
+			lookupValue && *lookupValue == 1u,
+			"a non-owning texture key must resolve the canonical cached entry");
+		lookupKey.Materialize();
+		Require(lookupKey.m_requestedTextures.Num() == 3u &&
+			lookupKey.m_requestedTextures[0] == 0u &&
+			lookupKey.m_requestedTextures[1] == 4u &&
+			lookupKey.m_requestedTextures[2] == 8u,
+			"a cache miss must materialize one sorted canonical key including the default texture slot");
 
 		const auto materialBindings = RHI::RHIShaderBindingSetPtr::Make();
 		auto material = RHI::RHIMaterialPtr::Make(
@@ -186,30 +651,19 @@ namespace
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string batchHeader = ReadText(sourceRoot / "Runtime/RHI/Batch.hpp");
 		Require(batchHeader.find("m_textureBindings == rhs.m_textureBindings") != std::string::npos &&
-			batchHeader.find("HashCombine(hash, m_textureBindings)") != std::string::npos,
-			"render batches must include the texture binding set in equality and hashing");
+			batchHeader.find("HashCombine(hash, m_textureBindings)") != std::string::npos &&
+			batchHeader.find("m_materialVersion == rhs.m_materialVersion") != std::string::npos &&
+			batchHeader.find("HashCombine(hash, m_materialVersion)") != std::string::npos,
+			"render batches must include immutable material and texture binding versions in equality and hashing");
 
-		const char* drawFunctions[] = {
-			"DrawCallStats RHIRecordDrawCallGPUCulling(",
-			"DrawCallStats RHIRecordDrawCall(",
-			"DrawCallStats RHIDrawCall("
-		};
-
-		for (const char* drawFunction : drawFunctions)
-		{
-			const std::string drawBody = ExtractFunctionBody(batchHeader, drawFunction);
-			Require(drawBody.find("prevTextureBindings != vecBatches[j].m_textureBindings") != std::string::npos,
-				std::string(drawFunction) +
-				" must detect a texture descriptor set change independently of the material pointer");
-
-			const std::string rebindBody = ExtractFunctionBody(
-				drawBody,
-				"if (bMaterialChanged || bTextureBindingsChanged)");
-			Require(rebindBody.find("commands->BindShaderBindings") != std::string::npos &&
-				rebindBody.find("prevTextureBindings = vecBatches[j].m_textureBindings") != std::string::npos,
-				std::string(drawFunction) +
-				" must rebind and remember a different texture descriptor set");
-		}
+		const std::string drawBody = ExtractFunctionBody(
+			batchHeader,
+			"const TVector<RHIShaderBindingSetPtr>& cullingDispatchBindings = {})");
+		Require(drawBody.find("firstGroup.m_batch == groups[runEnd].m_batch") != std::string::npos &&
+			drawBody.find("collectShaderBindings(batch, drawBindingSets)") != std::string::npos &&
+			drawBody.find("commands->BindShaderBindings(") != std::string::npos &&
+			drawBody.find("drawBindingSets);") != std::string::npos,
+			"packed MDI runs must split on immutable material-version and texture-binding identity");
 	}
 
 	void TestSceneViewProxyMaterialAlignmentContract()
@@ -218,33 +672,27 @@ namespace
 		const std::string sceneViewSource = ReadText(sourceRoot / "Runtime/RHI/SceneView.cpp");
 		const std::string traceBody = ExtractFunctionBody(
 			sceneViewSource,
-			"TVector<RHISceneViewProxy> RHISceneView::TraceScene(");
+			"void RHISceneView::TraceScene(");
 
-		const size_t materialSlotsOffset = traceBody.find(
-			"viewProxy.m_overrideMaterials.Resize(viewProxy.m_meshes.Num())");
-		const size_t textureSlotsOffset = traceBody.find(
-			"viewProxy.m_materialTextureSamplers.Resize(viewProxy.m_meshes.Num())");
-		const size_t readyMaterialOffset = traceBody.find(
-			"if (material && material->IsReady())");
-		const size_t skipMaterialsGuard = traceBody.find(
-			"if (!bSkipMaterials)");
-		Require(materialSlotsOffset != std::string::npos &&
-			textureSlotsOffset != std::string::npos &&
-			readyMaterialOffset != std::string::npos &&
-			skipMaterialsGuard < materialSlotsOffset &&
-			materialSlotsOffset < readyMaterialOffset &&
-			textureSlotsOffset < readyMaterialOffset,
-			"stationary scene proxies must allocate one material and texture slot per mesh before testing asynchronous readiness");
-
-		const std::string readyMaterialBody = ExtractFunctionBody(
-			traceBody,
-			"if (material && material->IsReady())");
-		Require(readyMaterialBody.find(
-			"viewProxy.m_overrideMaterials[i] = material->GetOrAddRHI") != std::string::npos,
-			"a ready stationary material must fill its original mesh slot");
-		Require(traceBody.find(
-			"auto& requestedTextures = viewProxy.m_materialTextureSamplers[i]") != std::string::npos,
-			"stationary texture indices must be written into the original mesh slot");
+		Require(traceBody.find("sceneVersion->Resolve(handle, record)") != std::string::npos &&
+			traceBody.find("record->m_topology.GetRawPtr()") != std::string::npos &&
+			traceBody.find("auto topology = record->m_topology") == std::string::npos &&
+			traceBody.find("RHIVisibleSceneProxy visible") != std::string::npos &&
+			traceBody.find("visible.m_record = record") != std::string::npos &&
+			traceBody.find("visible.m_worldMatrix =") == std::string::npos &&
+			traceBody.find("visible.m_worldAabb =") == std::string::npos,
+			"scene tracing must resolve compact handles into immutable shared proxy resources");
+		Require(traceBody.find("CollectRenderData(") == std::string::npos &&
+			traceBody.find("viewProxy.m_overrideMaterials") == std::string::npos,
+			"scene tracing must not rebuild or copy mesh and material topology per camera");
+		Require(sceneViewSource.find("TraceScene(frustum, res.m_proxies, false)") != std::string::npos &&
+			sceneViewSource.find("proxy.m_screenCoverage = CalculateScreenCoverage(") != std::string::npos,
+			"camera snapshots must retain lightweight visible references and view-local LOD coverage");
+		Require(sceneViewSource.find("m_snapshots.Resize(m_cameras.Num())") != std::string::npos &&
+			sceneViewSource.find("res.ResetForReuse()") != std::string::npos &&
+			sceneViewSource.find("m_proxies.Clear(false)") != std::string::npos &&
+			sceneViewSource.find("m_snapshots.Emplace(std::move(res))") == std::string::npos,
+			"pooled scene views must retain per-camera visible-list capacity instead of allocating snapshots every frame");
 
 		const std::string depthSource = ReadText(
 			sourceRoot / "Runtime/FrameGraph/DepthPrepassNode.cpp");
@@ -253,7 +701,7 @@ namespace
 			"Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(");
 		const std::string pendingMaterialBody = ExtractFunctionBody(
 			depthPrepareBody,
-			"if (proxy.GetMaterials()[i] == nullptr)");
+			"if (source->GetMaterials()[i] == nullptr)");
 		Require(pendingMaterialBody.find("continue;") != std::string::npos &&
 			pendingMaterialBody.find("break;") == std::string::npos,
 			"a pending material slot must not discard later ready meshes from the depth pass");
@@ -264,15 +712,13 @@ namespace
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string sceneViewSource = ReadText(
 			sourceRoot / "Runtime/RHI/SceneView.cpp");
-		const std::string traceBody = ExtractFunctionBody(
+		const std::string normalizeBody = ExtractFunctionBody(
 			sceneViewSource,
-			"TVector<RHISceneViewProxy> RHISceneView::TraceScene(");
-		Require(traceBody.find("CollectRenderData(") != std::string::npos &&
-			traceBody.find("meshProxy.m_worldMatrix * modelMatrix") !=
-				std::string::npos &&
-			traceBody.find("viewProxy.m_meshModelMatrices.Add(") !=
-				std::string::npos,
-			"stationary proxies must expand model hierarchy instances into aligned world matrices");
+			"bool TryNormalizeProxyTransforms(");
+		Require(normalizeBody.find("inverseWorld * meshMatrix") != std::string::npos &&
+			normalizeBody.find("inverseWorld * shadowMesh.m_worldMatrix") != std::string::npos &&
+			normalizeBody.find("m_bMeshTransformsAreLocal = true") != std::string::npos,
+			"immutable topology must normalize model hierarchy transforms once for reuse across transform-only scene versions");
 
 		const std::string staticMeshSource = ReadText(
 			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
@@ -287,6 +733,9 @@ namespace
 			"proxy.m_meshModelMatrices = std::move(selectedMatrices)") !=
 				std::string::npos,
 			"cached static proxies must retain one world matrix per selected render part");
+		Require(staticMeshSource.find("previousResource->m_bMeshTransformsAreLocal") != std::string::npos &&
+			staticMeshSource.find("bCanReuseTopology = previousResource") != std::string::npos,
+			"transform-only updates must rebuild topology when a singular transform prevented local-space normalization");
 
 		const struct
 		{
@@ -299,22 +748,22 @@ namespace
 			{
 				"Runtime/FrameGraph/RenderSceneNode.cpp",
 				"Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(",
-				"proxy.m_meshModelMatrices[i]",
+				"proxy.ResolveMeshWorldMatrix(i)",
 				"data.model = meshWorldMatrix",
 				"raster"
 			},
 			{
 				"Runtime/FrameGraph/DepthPrepassNode.cpp",
 				"Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(",
-				"proxy.m_meshModelMatrices[i]",
+				"proxy.ResolveMeshWorldMatrix(i)",
 				"data.model = meshWorldMatrix",
 				"depth"
 			},
 			{
 				"Runtime/FrameGraph/ShadowPrepassNode.cpp",
 				"void ShadowPrepassNode::Process(",
-				"shadowMesh.m_worldMatrix",
-				"data.model = shadowMesh.m_worldMatrix",
+				"proxy.ResolveMeshWorldMatrix(shadowMesh)",
+				"data.model = meshWorldMatrix",
 				"shadow"
 			}
 		};
@@ -355,6 +804,399 @@ namespace
 			"path tracing must intersect and shade the same selected source-mesh geometry");
 	}
 
+	void TestRenderResourceVirtualizationContract()
+	{
+		Framegraph::TextureDependencyCollector textureDependencies;
+		textureDependencies.Reset();
+		textureDependencies.Insert(42u);
+		textureDependencies.Insert(7u);
+		textureDependencies.Insert(42u);
+		textureDependencies.Insert(
+			static_cast<uint32_t>(Framegraph::TextureDependencyCollector::MaxTrackedTextures));
+		const auto& textureIndices = textureDependencies.GetIndices();
+		Require(textureIndices.Num() == 3u &&
+			textureIndices[0] == 0u &&
+			textureIndices[1] == 7u &&
+			textureIndices[2] == 42u,
+			"the reusable texture dependency collector must deduplicate, bound, and sort indices without transient sets");
+
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string rendererSource = ReadText(
+			sourceRoot / "Runtime/RHI/Renderer.cpp");
+		const std::string pushFrameBody = ExtractFunctionBody(
+			rendererSource,
+			"bool Renderer::PushFrame(");
+		const size_t materialCutoffCapture = pushFrameBody.find(
+			"RHIMaterial::BeginSubmissionVersionCapture(submissionId)");
+		const size_t acquireTaskCreation = pushFrameBody.find(
+			"auto acquireRenderSubmission = Tasks::CreateTask(");
+		const size_t acquireFlight = pushFrameBody.find("BeginRenderSubmission(");
+		const size_t waitForFlight = pushFrameBody.find(
+			"acquireRenderSubmission->Wait()");
+		const size_t prepareLighting = pushFrameBody.find(
+			"FillLightingData(rhiSceneView)");
+		const size_t prepareAnimation = pushFrameBody.find(
+			"FillAnimationData(rhiSceneView)");
+		const size_t prepareFrameGraph = pushFrameBody.find(
+			"rhiFrameGraph->Prepare(rhiSceneView)");
+		Require(pushFrameBody.find("BeginRenderSubmission(") != std::string::npos &&
+			pushFrameBody.find("BeginSubmissionVersionCapture(") != std::string::npos &&
+			pushFrameBody.find("EndSubmissionVersionCapture(") != std::string::npos &&
+			pushFrameBody.find("acquireRenderSubmission->Join(m_previousRenderFrame)") != std::string::npos &&
+			pushFrameBody.find("renderFrame1->Join(t)") != std::string::npos,
+			"the selected flight fence must complete before any FrameGraph prepare task can reuse mutable resources");
+		Require(materialCutoffCapture != std::string::npos &&
+			acquireTaskCreation > materialCutoffCapture &&
+			acquireFlight > materialCutoffCapture &&
+			waitForFlight > acquireFlight &&
+			prepareAnimation > waitForFlight &&
+			prepareLighting > waitForFlight &&
+			prepareLighting > prepareAnimation &&
+			prepareFrameGraph > prepareLighting &&
+			pushFrameBody.find("submissionBeginState->m_materialRevision") != std::string::npos,
+			"a frame must freeze material publication, acquire a freed flight, and only then prepare flight-local lighting and FrameGraph resources");
+		Require(pushFrameBody.find("chainSemaphore = frameGraphChainSemaphore") != std::string::npos &&
+			pushFrameBody.find("InvalidateSubmissionResources()") != std::string::npos &&
+			pushFrameBody.find("CompleteSubmissionResources(") != std::string::npos &&
+			pushFrameBody.find("App::HasEditor() && m_driverInstance->SubmitFrameWithoutPresent") == std::string::npos,
+			"partial failures and no-image frames must fence the acquired slot and reject unsubmitted resource versions");
+
+		const std::string submissionHeader = ReadText(
+			sourceRoot / "Runtime/RHI/RenderSubmission.h");
+		const std::string batchHeader = ReadText(
+			sourceRoot / "Runtime/RHI/Batch.hpp");
+		const std::string materialImporterSource = ReadText(
+			sourceRoot / "Runtime/AssetRegistry/Material/MaterialImporter.cpp");
+		const std::string forceMaterialUpdateBody = ExtractFunctionBody(
+			materialImporterSource,
+			"void Material::ForcelyUpdateUniforms()");
+		const size_t cloneBindings = forceMaterialUpdateBody.find(
+			"CloneMaterialShaderBindings(");
+		const size_t updateUniforms = forceMaterialUpdateBody.find(
+			"UpdateUniforms(cmdList)");
+		const size_t trackUpload = forceMaterialUpdateBody.find(
+			"TrackDelayedInitialization(m_commonShaderBindings.GetRawPtr(), fence)");
+		const size_t stageBindings = forceMaterialUpdateBody.find(
+			"material->StageBindings(m_commonShaderBindings)");
+		Require(cloneBindings != std::string::npos &&
+			updateUniforms != std::string::npos &&
+			trackUpload != std::string::npos &&
+			stageBindings != std::string::npos &&
+			cloneBindings < updateUniforms &&
+			updateUniforms < trackUpload &&
+			trackUpload < stageBindings,
+			"material updates must write a fresh binding generation and stage it only after attaching the upload fence");
+		const std::string materialReadyBody = ExtractFunctionBody(
+			materialImporterSource,
+			"bool Material::IsReady() const");
+		Require(materialReadyBody.find("TryPublishPendingBindings()") !=
+			std::string::npos,
+			"ready material uploads must publish their pending immutable RHI generations");
+
+		const std::string rhiMaterialSource = ReadText(
+			sourceRoot / "Runtime/RHI/Material.cpp");
+		const std::string publishMaterialBody = ExtractFunctionBody(
+			rhiMaterialSource,
+			"bool RHIMaterial::TryPublishPendingBindings()");
+		Require(publishMaterialBody.find("pending->GetBindings()->IsReady()") !=
+			std::string::npos &&
+			publishMaterialBody.find("PublishVersionLocked(") !=
+				std::string::npos &&
+			publishMaterialBody.find("m_pendingVersion.Clear()") !=
+				std::string::npos &&
+			publishMaterialBody.find("g_publishedRhiMaterialRevision.store") !=
+				std::string::npos,
+			"an RHI material generation must become globally visible only after its upload is ready");
+
+		const std::string vulkanDriverSource = ReadText(
+			sourceRoot /
+			"Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp");
+		const std::string cloneMaterialBody = ExtractFunctionBody(
+			vulkanDriverSource,
+			"RHI::RHIShaderBindingSetPtr VulkanGraphicsDriver::CloneMaterialShaderBindings(");
+		Require(cloneMaterialBody.find("GetUniformBufferAllocator(") !=
+				std::string::npos &&
+			cloneMaterialBody.find("GetMaterialSsboAllocator()") !=
+				std::string::npos &&
+			cloneMaterialBody.find("UpdateDescriptorSet(result)") !=
+				std::string::npos,
+			"copy-on-write material bindings must allocate fresh UBO/SSBO ranges and a fresh descriptor set");
+		Require(submissionHeader.find("virtual void InvalidateSubmission()") != std::string::npos &&
+			submissionHeader.find("void InvalidateSubmissionResources()") != std::string::npos &&
+			batchHeader.find("void InvalidateUploadedState()") != std::string::npos,
+			"failed submissions must force a later full upload without discarding retained flight capacity");
+
+		const std::string frameGraphSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RHIFrameGraph.cpp");
+		const std::string processBody = ExtractFunctionBody(
+			frameGraphSource,
+			"bool RHIFrameGraph::Process(");
+		Require(processBody.find("FrameGraph:SharedResourceUpload") != std::string::npos &&
+			processBody.find("rhiSceneView->m_snapshots[0]") != std::string::npos &&
+			processBody.find("PrepareViewSubmissionResources(this, transferCmdList, snapshot, false)") != std::string::npos,
+			"light and bone payloads must be uploaded once in an explicit submission dependency before per-camera processing");
+		Require(processBody.find("submissionProgress->SetLastSuccessfulSemaphore") != std::string::npos &&
+			processBody.find("outWaitSemaphore = submissionProgress->GetLastSuccessfulSemaphore()") != std::string::npos,
+			"a partial FrameGraph submit failure must expose the last successful semaphore for slot fencing");
+
+		const std::string renderSceneSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RenderSceneNode.cpp");
+		const std::string renderSceneHeader = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RenderSceneNode.h");
+		const std::string textureCacheHeader = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RenderSceneTextureCache.h");
+		const std::string textureImporterSource = ReadText(
+			sourceRoot / "Runtime/AssetRegistry/Texture/TextureImporter.cpp");
+		const std::string renderPrepareBody = ExtractFunctionBody(
+			renderSceneSource,
+			"Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(");
+		const std::string depthSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/DepthPrepassNode.cpp");
+		const std::string depthHeader = ReadText(
+			sourceRoot / "Runtime/FrameGraph/DepthPrepassNode.h");
+		const std::string depthPrepareBody = ExtractFunctionBody(
+			depthSource,
+			"Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(");
+		Require(renderPrepareBody.find("sceneViewSnapshot.m_visibilityRevision") == std::string::npos &&
+			renderPrepareBody.find("bContributesToQueue") != std::string::npos &&
+			renderPrepareBody.find("m_mainRevision") != std::string::npos,
+			"main packet reuse must depend only on objects relevant to its render queue");
+		Require(depthPrepareBody.find("sceneViewSnapshot.m_visibilityRevision") == std::string::npos &&
+			depthPrepareBody.find("bContributesToQueue") != std::string::npos &&
+			depthPrepareBody.find("m_depthRevision") != std::string::npos,
+			"depth packet reuse must ignore unrelated main-pass and render-queue changes");
+		const size_t pagedUploadBranch = batchHeader.find("if (payload.IsPagedArena())");
+		const size_t stationaryUploadBranch =
+			batchHeader.find("else if (mobility == EMobilityType::Stationary)");
+		Require(batchHeader.find("NumMobilitySegments = 3u") != std::string::npos &&
+			batchHeader.find("m_uploadedStationaryInstances") != std::string::npos &&
+			pagedUploadBranch != std::string::npos &&
+			stationaryUploadBranch != std::string::npos &&
+			pagedUploadBranch < stationaryUploadBranch &&
+			batchHeader.find("Dynamic records deliberately remain flight-local") != std::string::npos,
+			"packed payload storage must diff paged static/stationary arenas before the contiguous stationary fallback and keep dynamic records flight-local");
+		Require(renderPrepareBody.find("m_packetPayloadCache.Find") != std::string::npos &&
+			renderPrepareBody.find("m_packet.SharePayload(mobility)") != std::string::npos &&
+			depthPrepareBody.find("m_customPacketPayloadCache.Find") != std::string::npos &&
+			depthPrepareBody.find("m_customPacket.SharePayload(mobility)") != std::string::npos,
+			"main and ordinary/custom depth streams must share immutable payload versions independently");
+		Require(renderPrepareBody.find("GetMaterialRevision()") != std::string::npos &&
+			depthPrepareBody.find("GetMaterialRevision()") != std::string::npos &&
+			depthPrepareBody.find("hashCustomDepthMaterialVersion") != std::string::npos &&
+			depthPrepareBody.find("IsRequiredCustomDepthShader()") != std::string::npos,
+			"main arenas must version all material bindings while depth ranges version only custom-depth dependencies");
+		const std::string shadowPayloadSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
+		const std::string shadowPayloadHeader = ReadText(
+			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.h");
+		const std::string shadowPayloadProcessBody = ExtractFunctionBody(
+			shadowPayloadSource,
+			"void ShadowPrepassNode::Process(");
+		const std::string textureDependencyRevisionBody = ExtractFunctionBody(
+			renderSceneSource,
+			"uint64_t Details::CalculateTextureDependencyRevision(");
+		const std::string textureSamplerRevisionBody = ExtractFunctionBody(
+			textureImporterSource,
+			"uint64_t TextureImporter::CalculateTextureSamplersRevision(");
+		Require(shadowPayloadProcessBody.find("m_packetPayloadCache.Find") != std::string::npos &&
+			shadowPayloadProcessBody.find("bBuildShadowPayloads") != std::string::npos &&
+			shadowPayloadProcessBody.find("packet.SharePayload(mobility)") != std::string::npos &&
+			shadowPayloadProcessBody.find("GetMaterialRevision()") != std::string::npos &&
+			shadowPayloadProcessBody.find("m_customDepthMaterial->GetVersionForSubmission(") !=
+				std::string::npos &&
+			shadowPayloadProcessBody.find("material->GetRenderState().IsRequiredCustomDepthShader()") !=
+				std::string::npos,
+			"shadow views must reuse ordinary caster pages and version only exact custom-depth material dependencies");
+		Require(renderPrepareBody.find("stationaryPayloadIndex") != std::string::npos &&
+			renderPrepareBody.find("m_packet.UseSharedArenaPayload(mobility") != std::string::npos &&
+			depthPrepareBody.find("stationaryPayloadIndex") != std::string::npos &&
+			depthPrepareBody.find("m_customPacket.UseSharedArenaPayload(") != std::string::npos &&
+			shadowPayloadProcessBody.find("stationaryPayloadIndex") != std::string::npos &&
+			shadowPayloadProcessBody.find("viewResources.m_packet.UseSharedArenaPayload(") != std::string::npos,
+			"main, ordinary/custom depth, and shadow passes must virtualize stationary records through camera-independent paged arenas");
+		Require(renderPrepareBody.find(
+				"sceneViewSnapshot.ForEachSceneProxy(mobility") != std::string::npos &&
+			depthPrepareBody.find(
+				"sceneViewSnapshot.ForEachSceneProxy(mobility") != std::string::npos &&
+			shadowPayloadProcessBody.find(
+				"sceneView.ForEachShadowCaster(mobility") != std::string::npos &&
+			renderPrepareBody.find(
+				"0u : sceneViewSnapshot.m_cameraIndex") != std::string::npos &&
+			depthPrepareBody.find(
+				"0u : sceneViewSnapshot.m_cameraIndex") != std::string::npos &&
+			shadowPayloadProcessBody.find(
+				"1469598103934665603ull : viewKey") != std::string::npos,
+			"paged main, depth, and shadow arenas must be built from complete scene-version handle lists and shared across disjoint camera views");
+		Require(textureCacheHeader.find("class TextureDependencyCollector") != std::string::npos &&
+			textureCacheHeader.find("std::bitset<MaxTrackedTextures> m_seen") != std::string::npos &&
+			renderPrepareBody.find("m_requestedPacketTextures") != std::string::npos &&
+			depthPrepareBody.find("m_requestedPacketTextures") != std::string::npos &&
+			shadowPayloadProcessBody.find("m_requestedPacketTextures") != std::string::npos &&
+			renderPrepareBody.find("std::array<TSet<uint32_t>") == std::string::npos &&
+			depthPrepareBody.find("std::array<TSet<uint32_t>") == std::string::npos &&
+			shadowPayloadProcessBody.find("std::array<TSet<uint32_t>") == std::string::npos &&
+			renderSceneSource.find("TSet<uint32_t> requestedTextures;") == std::string::npos &&
+			depthSource.find("TSet<uint32_t> requestedTextures;") == std::string::npos &&
+			shadowPayloadSource.find("TSet<uint32_t> requestedTextures;") == std::string::npos &&
+			textureDependencyRevisionBody.find("CalculateTextureSamplersRevision(requestedTextures)") != std::string::npos &&
+			textureSamplerRevisionBody.find("m_textureSamplerSlotRevisions") != std::string::npos &&
+			textureSamplerRevisionBody.find("GetTextureSamplersSnapshot") == std::string::npos,
+			"main, depth, and shadow dependency hashing must reuse bounded collectors and inspect slot revisions without transient snapshots or set copies");
+		Require(batchHeader.find("TVector<RHIShaderBindingSetPtr> m_drawBindingSets") != std::string::npos &&
+			batchHeader.find("typename TShaderBindingsCallback") != std::string::npos &&
+			batchHeader.find("collectShaderBindings(batch, drawBindingSets)") != std::string::npos &&
+			batchHeader.find("std::function<TVector<RHIShaderBindingSetPtr>") == std::string::npos &&
+			renderSceneSource.find("TVector<RHIShaderBindingSetPtr> sets") == std::string::npos &&
+			depthSource.find("TVector<RHIShaderBindingSetPtr> sets") == std::string::npos &&
+			shadowPayloadSource.find("TVector<RHIShaderBindingSetPtr> sets") == std::string::npos &&
+			renderSceneSource.find("TVector<RHIShaderBindingSetPtr> cullingBindings") == std::string::npos &&
+			depthSource.find("TVector<RHIShaderBindingSetPtr> cullingBindings") == std::string::npos &&
+			renderSceneSource.find("TVector<RHI::RHITexturePtr>{") == std::string::npos &&
+			depthSource.find("TVector<RHI::RHITexturePtr>{") == std::string::npos &&
+			shadowPayloadSource.find("TVector<RHI::RHITexturePtr>{") == std::string::npos &&
+			shadowPayloadSource.find("TVector<RHITexturePtr>{") == std::string::npos &&
+			renderSceneSource.find("m_cullingDispatchBindings") != std::string::npos &&
+			depthSource.find("m_cullingDispatchBindings") != std::string::npos &&
+			shadowPayloadSource.find("m_blurDrawBindingSets") != std::string::npos,
+			"packed draw and render-pass recording must reuse flight-local binding and attachment scratch without per-batch or per-pass vectors");
+		Require(renderSceneHeader.find("m_arenaRangeInstances") != std::string::npos &&
+			depthHeader.find("m_customArenaRangeInstances") != std::string::npos &&
+			shadowPayloadHeader.find("m_arenaRangeInstances") != std::string::npos &&
+			renderPrepareBody.find("TVector<PerInstanceData> rangeInstances") == std::string::npos &&
+			depthPrepareBody.find("TVector<CustomPerInstanceData> customRangeInstances") == std::string::npos &&
+			shadowPayloadProcessBody.find("TVector<PerInstanceData> rangeInstances") == std::string::npos,
+			"changed static ranges must reuse flight-local builders across main, ordinary/custom depth, and shadow passes");
+		Require(batchHeader.find("TVector<FreeRange> m_occupiedRangesScratch") != std::string::npos &&
+			batchHeader.find("TVector<FreeRange> occupied;") == std::string::npos,
+			"paged static arena free-range discovery must retain its metadata scratch capacity across updates");
+		Require(batchHeader.find("TDrawCalls") == std::string::npos &&
+			renderSceneSource.find("ProcessLegacy") == std::string::npos &&
+			depthSource.find("ProcessLegacy") == std::string::npos,
+			"the migrated renderer must not retain duplicate legacy per-instance containers");
+		Require(renderPrepareBody.find("TryGetString(\"VirtualizeInstancePayloads\"") != std::string::npos &&
+			depthPrepareBody.find("TryGetString(\"VirtualizeInstancePayloads\"") != std::string::npos &&
+			shadowPayloadProcessBody.find("TryGetString(\"VirtualizeInstancePayloads\"") != std::string::npos,
+			"immutable payload sharing must remain independently disableable without changing packet ABI");
+		for (const auto& rendererPath : {
+			sourceRoot / "Content/DefaultRenderer.renderer",
+			sourceRoot / "Content/EditorRenderer.renderer",
+			sourceRoot / "Content/ExperimentalRenderer.renderer" })
+		{
+			Require(ReadText(rendererPath).find("VirtualizeInstancePayloads: true") != std::string::npos,
+				"shipped renderer graphs must opt into instance payload virtualization");
+		}
+
+		const std::string sceneViewHeader = ReadText(
+			sourceRoot / "Runtime/RHI/SceneView.h");
+		const std::string sceneViewImplementation = ReadText(
+			sourceRoot / "Runtime/RHI/SceneView.cpp");
+		const std::string sceneImplementation = ReadText(
+			sourceRoot / "Runtime/RHI/Scene.cpp");
+		const std::string staticMeshSource = ReadText(
+			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
+		Require(sceneViewHeader.find("TSharedPtr<TOctree<RenderInstanceHandle>> m_dynamicOctree") != std::string::npos &&
+			sceneViewHeader.find("TSharedPtr<TOctree<RenderInstanceHandle>> m_stationaryOctree") != std::string::npos &&
+			sceneViewHeader.find("TSharedPtr<TOctree<RenderInstanceHandle>> m_staticOctree") != std::string::npos &&
+			sceneViewHeader.find("record->m_topology.GetRawPtr()") != std::string::npos &&
+			sceneViewHeader.find("auto topology = record->m_topology") == std::string::npos &&
+			staticMeshSource.find("version->m_staticOctree = m_publishedSceneVersion->m_staticOctree") != std::string::npos &&
+			staticMeshSource.find("version->m_stationaryOctree = m_publishedSceneVersion->m_stationaryOctree") != std::string::npos &&
+			staticMeshSource.find("version->m_dynamicOctree = m_publishedSceneVersion->m_dynamicOctree") != std::string::npos &&
+			staticMeshSource.find("PublishSceneVersion(spatialChangeMask)") != std::string::npos &&
+			staticMeshSource.find("else if (bMaterialsDirty)") != std::string::npos &&
+			staticMeshSource.find("else if (!bTransformDirty)") == std::string::npos,
+			"scene traversal must avoid topology refcount copies and retain unaffected immutable spatial roots");
+		const std::string collectGarbageBody = ExtractFunctionBody(
+			sceneImplementation,
+			"void RHIScene::CollectGarbage()");
+		const std::string prepareSnapshotsBody = ExtractFunctionBody(
+			sceneViewImplementation,
+			"void RHISceneView::PrepareSnapshots()");
+		Require(collectGarbageBody.find("m_journal.RemoveAll") == std::string::npos &&
+			collectGarbageBody.find("m_retainedVersions.RemoveAll") == std::string::npos &&
+			prepareSnapshotsBody.find("m_proxies.RemoveAll") == std::string::npos,
+			"flight collection and camera filtering must compact retained storage in place");
+		const size_t textureCacheLookup =
+			renderSceneSource.find("textureBindingCache.Find(key, cachedEntry)");
+		const size_t textureKeyMaterialization =
+			renderSceneSource.find("key.Materialize()");
+		Require(renderSceneSource.find("TextureBindingCacheKey key(requestedTextures)") !=
+				std::string::npos &&
+			textureCacheLookup != std::string::npos &&
+			textureKeyMaterialization != std::string::npos &&
+			textureCacheLookup < textureKeyMaterialization &&
+			renderSceneSource.find("requestedTextures.ToVector()") == std::string::npos,
+			"macOS texture cache hits must use a non-owning key and allocate canonical storage only after a miss");
+		const std::string pendingProxyBody = ExtractFunctionBody(
+			staticMeshSource,
+			"if (update.m_state == EPreparedProxyState::Pending)");
+		Require(pendingProxyBody.find("data.m_bIsDirty = true") != std::string::npos &&
+			pendingProxyBody.find("RemoveInstance") == std::string::npos,
+			"a static proxy must retain its last ready topology until a pending material upload completes");
+
+		const std::string landscapeSource = ReadText(
+			sourceRoot / "Runtime/ECS/LandscapeECS.cpp");
+		const std::string landscapeTickBody = ExtractFunctionBody(
+			landscapeSource,
+			"Tasks::ITaskPtr LandscapeECS::Tick(");
+		Require(landscapeTickBody.find("chunksToBuild = data.m_dirtyChunks.ToVector()") != std::string::npos &&
+			landscapeTickBody.find("validChunkWriteIndex") != std::string::npos &&
+			landscapeTickBody.find("chunk.m_buildRevision = ++data.m_buildRevision") != std::string::npos &&
+			landscapeTickBody.find("bVegetationMaterialRenderMetadataRevisionChanged") != std::string::npos &&
+			landscapeTickBody.find("data.m_runtimeMaterial->SynchronizeUniformValues(*data.m_material)") !=
+				std::string::npos &&
+			landscapeSource.find("CalculateVegetationMaterialRenderMetadataRevision") != std::string::npos &&
+			landscapeSource.find("material->GetRenderMetadataRevision()") != std::string::npos &&
+			landscapeTickBody.find("instanceGroup.m_meshes = std::move(vegetationMeshes)") != std::string::npos &&
+			landscapeTickBody.find("instanceGroup.m_meshTransforms = std::move(vegetationModelMatrices)") != std::string::npos,
+			"landscape edits and render metadata changes must publish immutable chunks while uniform-only changes version bindings in place");
+		Require(landscapeSource.find("m_spatialHash != spatialHash") != std::string::npos &&
+			landscapeSource.find("version->m_staticOctree = m_publishedSceneVersion->m_staticOctree") != std::string::npos,
+			"landscape chunk payload changes must reuse the immutable spatial root while coarse bounds stay unchanged");
+
+		const std::string lightingSource = ReadText(
+			sourceRoot / "Runtime/ECS/LightingECS.cpp");
+		const std::string shadowReuseBody = ExtractFunctionBody(
+			lightingSource,
+			"bool CSMLightState::CanReuse(");
+		Require(shadowReuseBody.find("HasShadowChangesIntersecting") != std::string::npos &&
+			shadowReuseBody.find("m_casterSceneVersions == sceneVersions") != std::string::npos &&
+			shadowReuseBody.find("m_submissionToken->IsSuccessful()") != std::string::npos &&
+			shadowReuseBody.find("m_submissionToken != currentSubmissionToken") != std::string::npos &&
+			shadowReuseBody.find("m_payloadCompletionToken->IsSuccessful()") != std::string::npos &&
+			shadowReuseBody.find("m_bContainsDynamicCasters") != std::string::npos &&
+			shadowReuseBody.find("m_bContainsAnimatedCasters") != std::string::npos &&
+			shadowReuseBody.find("m_animationRevision != animationRevision") != std::string::npos &&
+			lightingSource.find("snapshot.Equals(") == std::string::npos &&
+			lightingSource.find("cascadeNeedsUpdate[cascadeIndex]") != std::string::npos,
+			"shadow cache invalidation must diff retained COW scene versions and only reuse successfully submitted resources");
+		const std::string shadowSceneDiffBody = ExtractFunctionBody(
+			sceneImplementation,
+			"bool RHISceneVersion::HasShadowChangesIntersecting(");
+		Require(shadowSceneDiffBody.find("const RHISceneRecordPage* currentPage") != std::string::npos &&
+			shadowSceneDiffBody.find("const RHISceneRecordPagePtr currentPage") == std::string::npos,
+			"shadow scene diffs must traverse pages through retained non-owning pointers without per-page shared-ref churn");
+
+		const std::string shadowPrepassSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
+		const std::string customShadowMaterialBody = ExtractFunctionBody(
+			shadowPrepassSource,
+			"RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddCustomShadowMaterial(");
+		Require(customShadowMaterialBody.find(
+				"sourceMaterialVersion->GetBindings()") != std::string::npos &&
+			customShadowMaterialBody.find(
+				"entry.m_sourceVersion == sourceMaterialVersion") != std::string::npos &&
+			customShadowMaterialBody.find(
+				"sourceMaterial->GetShaderBindings()") == std::string::npos,
+			"custom shadow packets must bind the published generation through a bounded logical material cache");
+		const std::string shadowProcessBody = ExtractFunctionBody(
+			shadowPrepassSource,
+			"void ShadowPrepassNode::Process(");
+		Require(shadowProcessBody.find("m_shadowViewCache[viewKey]") != std::string::npos &&
+			shadowProcessBody.find("GetHash(shadowPass.m_shadowMap)") == std::string::npos,
+			"shadow packet buffers must be cached by logical view slot instead of transient COW texture identity");
+	}
+
 	void TestGpuCullingShaderSafetyContract()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -364,6 +1206,13 @@ namespace
 		Require(cullingShader.find("PushConstants.phase == 0") != std::string::npos &&
 			cullingShader.find("globalIndex < PushConstants.numBatches") != std::string::npos,
 			"the shader must keep culling and compaction in distinct dispatch phases");
+		Require(cullingShader.find("InstanceIndicesSSBO") != std::string::npos &&
+			cullingShader.find("uint candidateIndex = PushConstants.firstCandidateInstance + globalIndex") != std::string::npos &&
+			cullingShader.find("uint instanceId = instanceIndices.instance[candidateIndex]") != std::string::npos &&
+			cullingShader.find("instanceIndices.instance[compactIndex] = bIsCulled") != std::string::npos &&
+			cullingShader.find("instanceIndices.instance[writeIndex] = instanceId") != std::string::npos &&
+			cullingShader.find("data.instance[writeIndex] = data.instance[readIndex]") == std::string::npos,
+			"GPU culling must compact uint indices without copying or mutating full per-instance records");
 		Require(cullingShader.find("column0") != std::string::npos &&
 			cullingShader.find("column1") != std::string::npos &&
 			cullingShader.find("column2") != std::string::npos,
@@ -436,9 +1285,25 @@ namespace
 			cullingShader.find("dot(frustum.planes[i].xyz, lightPosition)") !=
 				std::string::npos,
 			"Forward+ sphere bounds must use the inverse-projected tile frustum");
-		Require(cullingShader.find("if(lightPosition.z <= radius)") ==
+		Require(cullingShader.find("const vec2 framebufferTileMin") !=
+				std::string::npos &&
+			cullingShader.find("const vec2 framebufferTileMax") !=
+				std::string::npos &&
+			cullingShader.find("viewportSize.y - framebufferTileMax.y") !=
+				std::string::npos &&
+			cullingShader.find("viewportSize.y - framebufferTileMin.y") !=
+				std::string::npos &&
+			cullingShader.find("vec4(projectionTileMin, NdcNearPlane") !=
+				std::string::npos &&
+			cullingShader.find("vec4(projectionTileMax, NdcNearPlane") !=
 				std::string::npos,
-			"Forward+ screen culling must not bypass tile bounds based on light radius");
+			"Forward+ tile frusta must convert negative-viewport framebuffer Y before inverse projection");
+		Require(cullingShader.find(
+				"dot(lightPosition, lightPosition) <= radius * radius") !=
+				std::string::npos &&
+			cullingShader.find("if(lightPosition.z <= radius)") ==
+				std::string::npos,
+			"Forward+ may bypass tile rejection only when the camera is inside the complete light sphere");
 		Require(cullingShader.find("const float zNear = uintBitsToFloat(minDepthInt)") !=
 				std::string::npos &&
 			cullingShader.find("const float zFar = uintBitsToFloat(maxDepthInt)") !=
@@ -472,22 +1337,52 @@ namespace
 			"void LightCullingNode::Process(");
 		const size_t depthLookup = processBody.find(
 			"GetRHIResource(\"linearDepth\")");
-		const size_t depthBindingOffset = processBody.find(
-			"AddSamplerToShaderBindings(m_culledLights, \"linearDepth\", linearDepthAttachment",
-			depthLookup);
-		Require(depthLookup != std::string::npos &&
-			depthBindingOffset > depthLookup &&
-			processBody.find("ImageMemoryBarrier(commandList, linearDepthAttachment", depthBindingOffset) != std::string::npos,
-			"Forward+ must sample the pre-linearized R32F depth target");
-		const size_t dispatchOffset = processBody.find("commands->Dispatch(");
 		const size_t depthBarrierOffset = processBody.find(
-			"commands->MemoryBarrier(",
-			depthBindingOffset);
-		Require(depthBarrierOffset != std::string::npos &&
+			"ImageMemoryBarrierForComputeSampling(commandList, linearDepthAttachment)",
+			depthLookup);
+		const size_t dispatchOffset = processBody.find("commands->Dispatch(");
+		Require(depthLookup != std::string::npos &&
+			depthBarrierOffset != std::string::npos &&
 			depthBarrierOffset < dispatchOffset &&
-			processBody.find("EAccessBit::ColorAttachmentWrite_Bit", depthBarrierOffset) < dispatchOffset &&
-			processBody.find("EAccessBit::ShaderRead_Bit", depthBarrierOffset) < dispatchOffset,
-			"Forward+ compute sampling must wait for the linear-depth color attachment write");
+			dispatchOffset != std::string::npos &&
+			processBody.find("sceneView.m_rhiLightCullingData", dispatchOffset) !=
+				std::string::npos,
+			"Forward+ must transition pre-linearized R32F depth for compute sampling before dispatch");
+
+		const std::string frameGraphSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RHIFrameGraph.cpp");
+		const std::string prepareViewBody = ExtractFunctionBody(
+			frameGraphSource,
+			"void PrepareViewSubmissionResources(");
+		const size_t createCullingBindings = prepareViewBody.find(
+			"resources->m_lightCullingBindings = driver->CreateShaderBindings()");
+		const size_t bindCullingOutputs = prepareViewBody.find(
+			"resources->m_lightCullingBindings->GetOrAddShaderBinding(\"culledLights\")");
+		const size_t publishCullingBindings = prepareViewBody.find(
+			"snapshot.m_rhiLightCullingData = resources->m_lightCullingBindings");
+		Require(createCullingBindings != std::string::npos &&
+			bindCullingOutputs > createCullingBindings &&
+			publishCullingBindings > createCullingBindings &&
+			prepareViewBody.find("bRecreateLightCulling") != std::string::npos &&
+			processBody.find("AddShaderBinding(") == std::string::npos,
+			"Forward+ buffers must be flight-local and fully bound before graph nodes record commands");
+
+		const std::string driverSource = ReadText(
+			sourceRoot / "Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp");
+		const std::string computeSamplingBarrierBody = ExtractFunctionBody(
+			driverSource,
+			"void VulkanGraphicsDriver::ImageMemoryBarrierForComputeSampling(");
+		Require(computeSamplingBarrierBody.find("VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL") !=
+				std::string::npos &&
+			computeSamplingBarrierBody.find("VulkanCommandBuffer::GetAccessFlags(oldVkLayout)") !=
+				std::string::npos &&
+			computeSamplingBarrierBody.find("VulkanCommandBuffer::GetPipelineStage(oldVkLayout)") !=
+				std::string::npos &&
+			computeSamplingBarrierBody.find("VK_ACCESS_SHADER_READ_BIT") !=
+				std::string::npos &&
+			computeSamplingBarrierBody.find("VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT") !=
+				std::string::npos,
+			"Forward+ linear depth transition must synchronize its producer with the compute sampler without changing descriptor layout");
 		const size_t barrierOffset = processBody.find(
 			"commands->MemoryBarrier(",
 			dispatchOffset);
@@ -498,11 +1393,11 @@ namespace
 			processBody.find("EAccessBit::ShaderRead_Bit", barrierOffset) !=
 				std::string::npos,
 			"fragment lighting must wait for Forward+ compute shader writes");
-		Require(processBody.find("m_boundLightsData != sceneView.m_rhiLightsData") !=
+		Require(prepareViewBody.find(
+				"resources->m_lightCullingDepth != linearDepthAttachment") !=
 				std::string::npos &&
-			processBody.find("m_boundDepthAttachment != linearDepthAttachment") !=
-				std::string::npos &&
-			processBody.find("m_bindingsViewportSize != pushConstants.m_viewportSize") !=
+			prepareViewBody.find(
+				"resources->m_lightCullingViewportSize != lightCullingViewportSize") !=
 				std::string::npos,
 			"Forward+ buffers must be recreated when their resource identity or extent changes");
 		const std::string lightingLibrary = ReadText(
@@ -784,12 +1679,12 @@ namespace
 			sourceRoot / "Runtime/FrameGraph/RHIFrameGraph.cpp");
 		const std::string frameGraphBody = ExtractFunctionBody(
 			frameGraphSource,
-			"bool RHIFrameGraph::Process(");
+			"void PrepareViewSubmissionResources(");
 		Require(frameGraphBody.find("GetRenderTarget(\"Secondary\")") ==
 			std::string::npos,
 			"transmission bindings must not depend on a hardcoded render-target name");
 		Require(frameGraphBody.find(
-				"node->GetResolvedAttachment(\"transmissionFramebuffer\")") !=
+				"\"g_transmissionFramebufferSampler\"") !=
 				std::string::npos &&
 			frameGraphBody.find("GetDefaultTexture()") !=
 				std::string::npos,
@@ -814,38 +1709,53 @@ namespace
 	{
 		Framegraph::RenderSceneNode::PerInstanceData renderInstance{};
 		DepthPrepassNode::PerInstanceData depthInstance{};
+		DepthPrepassNode::CustomPerInstanceData customDepthInstance{};
+		ShadowPrepassNode::PerInstanceData shadowInstance{};
 		const size_t renderScaleOffset = static_cast<size_t>(
 			reinterpret_cast<const uint8_t*>(&renderInstance.bakedVolumeScale) -
 			reinterpret_cast<const uint8_t*>(&renderInstance));
-		const size_t depthScaleOffset = static_cast<size_t>(
-			reinterpret_cast<const uint8_t*>(&depthInstance.bakedVolumeScale) -
-			reinterpret_cast<const uint8_t*>(&depthInstance));
+		const size_t customDepthScaleOffset = static_cast<size_t>(
+			reinterpret_cast<const uint8_t*>(&customDepthInstance.bakedVolumeScale) -
+			reinterpret_cast<const uint8_t*>(&customDepthInstance));
+		const size_t shadowScaleOffset = static_cast<size_t>(
+			reinterpret_cast<const uint8_t*>(&shadowInstance.bakedVolumeScale) -
+			reinterpret_cast<const uint8_t*>(&shadowInstance));
+		const size_t shadowAlphaOffset = static_cast<size_t>(
+			reinterpret_cast<const uint8_t*>(&shadowInstance.baseColorAlpha) -
+			reinterpret_cast<const uint8_t*>(&shadowInstance));
 
-		Require(sizeof(renderInstance) == sizeof(depthInstance) &&
-			renderScaleOffset == depthScaleOffset &&
+		Require(sizeof(renderInstance) == 112u &&
+			sizeof(depthInstance) == 96u &&
+			sizeof(customDepthInstance) == 112u &&
+			sizeof(shadowInstance) == 128u &&
 			renderScaleOffset == 96u &&
-			sizeof(renderInstance) == 112u &&
+			customDepthScaleOffset == 96u &&
+			shadowScaleOffset == 96u &&
+			shadowAlphaOffset == 112u &&
 			renderScaleOffset + sizeof(vec4) == sizeof(renderInstance),
-			"render, depth, and compute passes must share the 112-byte std430 per-instance stride");
+			"main, ordinary depth, custom depth, and shadow passes must keep their independent std430 instance layouts");
 
 		RHI::RHIMesh mesh;
 		Require(mesh.m_bakedVolumeScale == glm::vec3(1.0f) &&
 			renderInstance.bakedVolumeScale == glm::vec4(1.0f) &&
-			depthInstance.bakedVolumeScale == glm::vec4(1.0f),
+			customDepthInstance.bakedVolumeScale == glm::vec4(1.0f) &&
+			shadowInstance.bakedVolumeScale == glm::vec4(1.0f),
 			"procedural and legacy meshes must default to an identity baked volume scale");
 
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
-		const std::pair<std::filesystem::path, size_t> sharedShaders[] = {
-			{ sourceRoot / "Content/Shaders/ComputeMeshCulling.shader", 1u },
-			{ sourceRoot / "Content/Shaders/DepthOnly.shader", 1u },
+		const std::pair<std::filesystem::path, size_t> mainShaders[] = {
 			{ sourceRoot / "Content/Shaders/Simple.shader", 1u },
 			{ sourceRoot / "Content/Shaders/Standard.shader", 2u },
 			{ sourceRoot / "Content/Shaders/Standard_glTF.shader", 2u },
 			{ sourceRoot / "Content/Shaders/Unlit.shader", 2u }
 		};
-		for (const auto& [shaderPath, expectedLayoutCount] : sharedShaders)
+		for (const auto& [shaderPath, expectedLayoutCount] : mainShaders)
 		{
 			const std::string shader = ReadText(shaderPath);
+			Require(shader.find("InstanceIndicesSSBO") != std::string::npos &&
+				shader.find("instanceIndices.instance[gl_InstanceIndex]") != std::string::npos,
+				"main shaders must dereference the compact instance-index stream: " +
+					shaderPath.generic_string());
 			size_t layoutCount = 0;
 			size_t searchOffset = 0;
 			while ((searchOffset = shader.find(
@@ -871,7 +1781,7 @@ namespace
 				{
 					memberOffset = layout.find(member, memberOffset);
 					Require(memberOffset != std::string::npos,
-						"shared per-instance shader layouts must preserve the 112-byte std430 member order: " +
+						"main per-instance shader layouts must preserve the 112-byte std430 member order: " +
 							shaderPath.generic_string());
 					memberOffset += std::char_traits<char>::length(member);
 				}
@@ -880,14 +1790,29 @@ namespace
 				searchOffset = layoutEnd + 2u;
 			}
 			Require(layoutCount == expectedLayoutCount,
-				"every shared per-instance shader stage must use the common std430 layout: " +
+				"every main per-instance shader stage must use the main-pass std430 layout: " +
 					shaderPath.generic_string());
 		}
+
+		const std::string depthShader = ReadText(
+			sourceRoot / "Content/Shaders/DepthOnly.shader");
+		Require(depthShader.find("uint reserved;") != std::string::npos &&
+			depthShader.find("vec4 bakedVolumeScale;") == std::string::npos &&
+			depthShader.find("InstanceIndicesSSBO") != std::string::npos &&
+			depthShader.find("instanceIndices.instance[gl_InstanceIndex]") != std::string::npos,
+			"ordinary depth must use its compact 96-byte layout and the shared index indirection");
+
+		const std::string cullingShader = ReadText(
+			sourceRoot / "Content/Shaders/ComputeMeshCulling.shader");
+		Require(cullingShader.find("#ifdef DEPTH_INSTANCE_LAYOUT") != std::string::npos &&
+			cullingShader.find("InstanceIndicesSSBO") != std::string::npos &&
+			cullingShader.find("data.instance[writeIndex] = data.instance[readIndex]") == std::string::npos,
+			"GPU culling must select the pass layout and compact uint indices instead of full instance records");
 
 		const std::string gltfShader = ReadText(
 			sourceRoot / "Content/Shaders/Standard_glTF.shader");
 		Require(gltfShader.find(
-				"data.instance[gl_InstanceIndex].bakedVolumeScale.xyz") !=
+				"data.instance[instanceIndex].bakedVolumeScale.xyz") !=
 				std::string::npos,
 			"glTF transmission must combine runtime and baked node scale");
 
@@ -899,9 +1824,9 @@ namespace
 				"vec4(mesh->m_bakedVolumeScale, 1.0f)") !=
 				std::string::npos &&
 			depthPrepassSource.find(
-				"vec4(mesh->m_bakedVolumeScale, 1.0f)") !=
+				"customData.bakedVolumeScale = vec4(mesh->m_bakedVolumeScale, 1.0f)") !=
 				std::string::npos,
-			"render and depth passes must upload each RHIMesh baked volume scale");
+			"main and custom-depth streams must upload each RHIMesh baked volume scale");
 	}
 
 	void TestDepthPrepassSkinningContract()
@@ -918,7 +1843,7 @@ namespace
 			depthShader.find("DefaultBoneIdsBinding") != std::string::npos &&
 			depthShader.find("DefaultBoneWeightsBinding") != std::string::npos &&
 			depthShader.find("layout(std430, set = 2, binding = 0) readonly buffer BoneMatricesSSBO") != std::string::npos &&
-			depthShader.find("data.instance[gl_InstanceIndex].skeletonOffset") != std::string::npos &&
+			depthShader.find("data.instance[instanceIndex].skeletonOffset") != std::string::npos &&
 			depthShader.find("modelMatrix *= skinMatrix") != std::string::npos,
 			"the skinned depth permutation must apply the scene bone palette before projection");
 
@@ -934,7 +1859,7 @@ namespace
 		const std::string prepareBody = ExtractFunctionBody(
 			depthPrepassSource,
 			"Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(");
-		Require(prepareBody.find("proxy.m_skeletonOffset") != std::string::npos &&
+		Require(prepareBody.find("proxy.GetSkeletonOffset()") != std::string::npos &&
 			prepareBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding)") != std::string::npos &&
 			prepareBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding)") != std::string::npos &&
 			prepareBody.find("GetOrAddDepthMaterial(") != std::string::npos &&
@@ -950,7 +1875,7 @@ namespace
 			depthShader.find("ResolveTextureSamplerIndex") != std::string::npos &&
 			depthShader.find("alpha < inAlphaCutoff") != std::string::npos &&
 			depthShader.find("float alpha = inVertexAlpha") != std::string::npos &&
-			prepareBody.find("proxy.m_baseColorSamplers") != std::string::npos &&
+			prepareBody.find("m_baseColorSamplers") != std::string::npos &&
 			prepareBody.find("effectiveAlphaCutoff") != std::string::npos &&
 			prepareBody.find("const bool bRequiredCustomDepth = !bMaskedQueue") != std::string::npos,
 			"masked depth prepass must apply the same alpha silhouette as the forward material");
@@ -958,7 +1883,7 @@ namespace
 		const std::string processBody = ExtractFunctionBody(
 			depthPrepassSource,
 			"void DepthPrepassNode::Process(");
-		Require(processBody.find("shaderInfo->GetFileId(), m_pComputeMeshCullingShader);") !=
+		Require(processBody.find("{ \"DEPTH_INSTANCE_LAYOUT\" }") !=
 				std::string::npos &&
 			processBody.find("OCCLUSION_CULLING") == std::string::npos,
 			"the depth prepass must keep GPU frustum culling but cannot occlusion-cull the geometry that produces current-frame Hi-Z");
@@ -973,7 +1898,7 @@ namespace
 			shadowShader.find("DefaultBoneIdsBinding") != std::string::npos &&
 			shadowShader.find("DefaultBoneWeightsBinding") != std::string::npos &&
 			shadowShader.find("layout(std430, set = 2, binding = 0) readonly buffer BoneMatricesSSBO") != std::string::npos &&
-			shadowShader.find("data.instance[gl_InstanceIndex].skeletonOffset") != std::string::npos &&
+			shadowShader.find("data.instance[instanceIndex].skeletonOffset") != std::string::npos &&
 			shadowShader.find("modelMatrix *= skinMatrix") != std::string::npos,
 			"the skinned shadow permutation must apply the scene bone palette before light projection");
 
@@ -990,7 +1915,7 @@ namespace
 		const std::string processBody = ExtractFunctionBody(
 			shadowPrepassSource,
 			"void ShadowPrepassNode::Process(");
-		Require((processBody.find("proxy.m_skeletonOffset") != std::string::npos ||
+		Require((processBody.find("proxy.GetSkeletonOffset()") != std::string::npos ||
 			processBody.find("proxy->m_skeletonOffset") != std::string::npos) &&
 			processBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneIdsBinding)") != std::string::npos &&
 			processBody.find("HasAttribute(RHI::RHIVertexDescription::DefaultBoneWeightsBinding)") != std::string::npos &&
@@ -1010,17 +1935,21 @@ namespace
 			sourceRoot / "Runtime/FrameGraph/ShadowPrepassNode.cpp");
 		const std::string shadowCasterShader = ReadText(
 			sourceRoot / "Content/Shaders/ShadowCaster.shader");
+		const std::string customShadowCasterShader = ReadText(
+			sourceRoot / "Content/Experimental/MeshParticles/Particle.shader");
 
-		Require(sceneViewHeader.find("MaterialPtr m_customDepthMaterial") != std::string::npos &&
+		Require(sceneViewHeader.find("RHIMaterialPtr m_customDepthMaterial") != std::string::npos &&
+			sceneViewHeader.find("ShaderSetPtr m_customDepthShader") != std::string::npos &&
 			meshRendererSource.find("IsRequiredCustomDepthShader()") != std::string::npos &&
-			meshRendererSource.find("shadowMesh.m_customDepthMaterial = material") != std::string::npos,
-			"shadow proxies must retain the source custom-depth material");
+			meshRendererSource.find("shadowMesh.m_customDepthMaterial = material->GetOrAddRHI(") != std::string::npos,
+			"shadow proxies must retain immutable custom-depth RHI material and shader identities");
 		Require(shadowPrepassSource.find("GetOrAddCustomShadowMaterial(") != std::string::npos &&
-			shadowPrepassSource.find("GetSupportedDefines().Contains(\"SHADOW_CASTER\")") != std::string::npos &&
-			shadowPrepassSource.find("defines.Add(\"SHADOW_CASTER\")") != std::string::npos &&
+			shadowPrepassSource.find("m_customDepthMaterial->GetVersionForSubmission(") != std::string::npos &&
+			shadowPrepassSource.find("GetSupportedDefines().Contains(\"PACKED_SHADOW_CASTER\")") != std::string::npos &&
+			shadowPrepassSource.find("defines.Add(\"PACKED_SHADOW_CASTER\")") != std::string::npos &&
 			shadowPrepassSource.find("defines.Add(\"ALPHA_CUTOUT\")") != std::string::npos &&
 			shadowPrepassSource.find("sceneView.m_rhiLightsData") != std::string::npos &&
-			shadowPrepassSource.find("batch.m_material->GetBindings()") != std::string::npos,
+			shadowPrepassSource.find("batch.GetMaterialBindings()") != std::string::npos,
 			"supported custom shadow permutations must bind the same frame, light and material data as the forward vertex shader");
 		Require(shadowPrepassSource.find("auto depthMaterial = GetOrAddShadowMaterial(") != std::string::npos &&
 			shadowPrepassSource.find("if (customShadowMaterial)") != std::string::npos &&
@@ -1036,12 +1965,22 @@ namespace
 		Require(shadowCasterShader.find("vec4 sphereBounds;") != std::string::npos &&
 			shadowCasterShader.find("uint materialInstance;") != std::string::npos &&
 			shadowCasterShader.find("vec4 bakedVolumeScale;") != std::string::npos &&
+			shadowCasterShader.find("float baseColorAlpha;") != std::string::npos &&
 			shadowCasterShader.find("uint maskedPadding;") != std::string::npos &&
-			shadowCasterShader.find("uint stridePadding;") != std::string::npos,
-			"the default and custom shadow permutations must share the 144-byte shadow instance layout");
-		Require(sizeof(ShadowPrepassNode::PerInstanceData) == 144u &&
+			shadowCasterShader.find("vec4 baseColorFactor;") == std::string::npos,
+			"the default shadow caster must keep only alpha metadata in its compact instance layout");
+		Require(customShadowCasterShader.find("- SHADOW_CASTER") != std::string::npos &&
+			customShadowCasterShader.find("- PACKED_SHADOW_CASTER") != std::string::npos &&
+			customShadowCasterShader.find("- EVSM") != std::string::npos &&
+			customShadowCasterShader.find("vec4 sphereBounds;") != std::string::npos &&
+			customShadowCasterShader.find("float baseColorAlpha;") != std::string::npos &&
+			customShadowCasterShader.find("InstanceIndicesSSBO") != std::string::npos &&
+			customShadowCasterShader.find("instanceIndices.instance[gl_InstanceIndex]") != std::string::npos &&
+			customShadowCasterShader.find("PushConstants.lightMatrix") != std::string::npos,
+			"custom shadow permutations must use the compact shadow ABI, draw-index indirection, and pass-local light matrix");
+		Require(sizeof(ShadowPrepassNode::PerInstanceData) == 128u &&
 			sizeof(Framegraph::RenderSceneNode::PerInstanceData) == 112u,
-			"CPU instance layouts must match the conditional std430 strides used by the foliage shadow and forward permutations; shadow=" +
+			"CPU instance layouts must match the 128-byte shadow and 112-byte forward std430 strides; shadow=" +
 			std::to_string(sizeof(ShadowPrepassNode::PerInstanceData)) +
 			", forward=" + std::to_string(sizeof(Framegraph::RenderSceneNode::PerInstanceData)));
 	}
@@ -1252,36 +2191,28 @@ namespace
 				std::string::npos,
 			"transparent instances must use deterministic far-to-near ordering");
 
-		const std::string orderedBody = ExtractFunctionBody(
-			renderSceneSource,
-			"void RenderSceneNode::ProcessBackToFront(");
-		Require(orderedBody.find("gpuMatricesData.Add(item.m_instanceData)") !=
+		Require(prepareBody.find("m_packet.Add(std::move(item.m_batch)") !=
 				std::string::npos &&
-			orderedBody.find("command.m_instanceCount = 1u") !=
-				std::string::npos &&
-			orderedBody.find("firstStorageInstance + i") !=
+			prepareBody.find("m_packet.Finalize(true)") !=
 				std::string::npos,
-			"the instance SSBO and indirect commands must share sorted indices");
-		Require(orderedBody.find("firstItem.m_batch == nextItem.m_batch") !=
+			"the sorted transparent stream must be finalized without batch reordering");
+
+		const std::string batchHeader = ReadText(
+			sourceRoot / "Runtime/RHI/Batch.hpp");
+		Require(batchHeader.find("firstGroup.m_batch == groups[runEnd].m_batch") !=
 				std::string::npos &&
-			orderedBody.find("commands->DrawIndexedIndirect") !=
+			batchHeader.find("commands->DrawIndexedIndirect") !=
 				std::string::npos,
-			"only adjacent compatible transparent items may be combined into an MDI run");
-		Require(orderedBody.find("BeginSecondaryCommandList") ==
-				std::string::npos &&
-			orderedBody.find("RHIRecordDrawCallGPUCulling") ==
-				std::string::npos,
-			"back-to-front rendering must remain sequential on the primary command list");
+			"only adjacent compatible transparent packet groups may share an MDI run");
 
 		const std::string processBody = ExtractFunctionBody(
 			renderSceneSource,
 			"void RenderSceneNode::Process(");
-		Require(processBody.find(
-				"GetSortingOrder() == RHI::ESortingOrder::BackToFront") !=
+		Require(processBody.find("RHIRecordPackedDrawPacket(") !=
 				std::string::npos &&
-			processBody.find("ProcessBackToFront(") !=
+			processBody.find("ProcessBackToFront(") ==
 				std::string::npos,
-			"the configured sorting order must select the ordered rendering path");
+			"transparent and opaque rendering must use the same flight-local packed packet path");
 	}
 
 	void TestShadowCasterRenderQueueContract()
@@ -1313,8 +2244,9 @@ namespace
 			shadowMeshProxy.find("size_t m_renderQueueTag") != std::string::npos &&
 			shadowMeshProxy.find("uint32_t m_baseColorSampler") != std::string::npos &&
 			shadowMeshProxy.find("float m_alphaCutoff") != std::string::npos &&
-			shadowMeshProxy.find("RHIMaterialPtr") == std::string::npos,
-			"shadow casters must retain lightweight mesh and alpha-mask metadata without full material bindings");
+			shadowMeshProxy.find("RHIMaterialPtr m_customDepthMaterial") != std::string::npos &&
+			shadowMeshProxy.find("RHIShaderBindingSetPtr") == std::string::npos,
+			"ordinary shadow casters must retain lightweight alpha-mask metadata while custom depth retains only its immutable RHI identity");
 
 		const std::string staticMeshSource = ReadText(
 			sourceRoot / "Runtime/ECS/StaticMeshRendererECS.cpp");
@@ -1592,21 +2524,64 @@ namespace
 
 		uint64_t revision = material->GetContentRevision();
 		const uint64_t globalRevision = Material::GetGlobalContentRevision();
+		uint64_t renderMetadataRevision = material->GetRenderMetadataRevision();
 		material->SetUniform("material.transmissionFactor", 1.0f);
 		Require(material->GetContentRevision() > revision,
 			"changing a scalar uniform must advance the material content revision");
 		Require(Material::GetGlobalContentRevision() > globalRevision,
 			"a material mutation must publish the global revision gate used by dirty mesh updates");
+		Require(material->GetRenderMetadataRevision() == renderMetadataRevision,
+			"main-pass-only uniforms must not invalidate cached depth, shadow, or scene topology");
 
 		revision = material->GetContentRevision();
 		material->SetUniform("material.attenuationColor", glm::vec4(0.9f, 0.6f, 0.1f, 1.0f));
 		Require(material->GetContentRevision() > revision,
 			"changing a vector uniform must advance the material content revision");
+		Require(material->GetRenderMetadataRevision() == renderMetadataRevision,
+			"ordinary vector uniforms must remain material-version-only changes");
+
+		revision = material->GetContentRevision();
+		material->SetUniform("material.baseColorFactor", glm::vec4(0.5f));
+		Require(material->GetContentRevision() > revision &&
+			material->GetRenderMetadataRevision() > renderMetadataRevision,
+			"masked depth alpha metadata must invalidate cached proxy metadata");
+		renderMetadataRevision = material->GetRenderMetadataRevision();
+
+		revision = material->GetContentRevision();
+		material->SetUniform(
+			"material.baseColorFactor",
+			glm::vec4(0.8f, 0.7f, 0.6f, 0.5f));
+		Require(material->GetContentRevision() > revision,
+			"changing base color RGB must advance the material binding version");
+		Require(material->GetRenderMetadataRevision() == renderMetadataRevision,
+			"base color RGB must not invalidate alpha-only depth and shadow metadata");
+
+		revision = material->GetContentRevision();
+		material->SetUniform(
+			"material.baseColorFactor",
+			glm::vec4(0.8f, 0.7f, 0.6f, 0.5f));
+		Require(material->GetContentRevision() == revision,
+			"assigning the same material uniform must not publish a redundant revision");
+
+		revision = material->GetContentRevision();
+		material->SetUniform("material.alphaCutoff", 0.5f);
+		Require(material->GetContentRevision() > revision,
+			"adding an explicit alpha cutoff must advance the material binding version");
+		Require(material->GetRenderMetadataRevision() == renderMetadataRevision,
+			"the default alpha cutoff must not invalidate equivalent proxy metadata");
+
+		material->SetUniform("material.alphaCutoff", 0.35f);
+		Require(material->GetRenderMetadataRevision() > renderMetadataRevision,
+			"changing the effective alpha cutoff must invalidate depth and shadow metadata");
+		renderMetadataRevision = material->GetRenderMetadataRevision();
 
 		revision = material->GetContentRevision();
 		material->SetSampler("thicknessSampler", texture);
 		Require(material->GetContentRevision() > revision,
 			"changing a sampler must advance the material content revision");
+		Require(material->GetRenderMetadataRevision() > renderMetadataRevision,
+			"sampler changes must invalidate immutable texture dependency metadata");
+		renderMetadataRevision = material->GetRenderMetadataRevision();
 
 		revision = material->GetContentRevision();
 		material->SetRenderState(RHI::RenderState(
@@ -1620,6 +2595,8 @@ namespace
 			GetHash(std::string("Transparent"))));
 		Require(material->GetContentRevision() > revision,
 			"changing render state must advance the material content revision");
+		Require(material->GetRenderMetadataRevision() > renderMetadataRevision,
+			"changing render state must advance the proxy metadata revision");
 
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
 		const std::string pathTracerSource = ReadText(
@@ -1646,10 +2623,15 @@ int main()
 {
 	const std::pair<const char*, std::function<void()>> tests[] = {
 		{ "MipExtentUsesVulkanFloorAndClamp", TestMipExtentUsesVulkanFloorAndClamp },
+		{ "PackedDrawMobilityPayloadVirtualization", TestPackedDrawMobilityPayloadVirtualization },
+		{ "MaterialVersionPublicationContract", TestMaterialVersionPublicationContract },
+		{ "DynamicSpatialRootIsolation", TestDynamicSpatialRootIsolation },
+		{ "InstancedViewLodAndDistanceContract", TestInstancedViewLodAndDistanceContract },
 		{ "GpuCullingRangeAndSynchronizationContract", TestGpuCullingRangeAndSynchronizationContract },
 		{ "BatchTextureBindingIdentityContract", TestBatchTextureBindingIdentityContract },
 		{ "SceneViewProxyMaterialAlignmentContract", TestSceneViewProxyMaterialAlignmentContract },
 		{ "ModelHierarchyRenderPropagationContract", TestModelHierarchyRenderPropagationContract },
+		{ "RenderResourceVirtualizationContract", TestRenderResourceVirtualizationContract },
 		{ "GpuCullingShaderSafetyContract", TestGpuCullingShaderSafetyContract },
 		{ "ForwardPlusTileSynchronizationContract", TestForwardPlusTileSynchronizationContract },
 		{ "RegionBlitDoesNotPromoteToFullImageCopy", TestRegionBlitDoesNotPromoteToFullImageCopy },

--- a/Tests/RHISceneVirtualizationTests.cpp
+++ b/Tests/RHISceneVirtualizationTests.cpp
@@ -1,0 +1,333 @@
+#include "Engine/World.h"
+#include "RHI/Material.h"
+#include "RHI/RenderSubmission.h"
+#include "RHI/Scene.h"
+#include "RHI/SceneView.h"
+
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+using namespace Sailor;
+using namespace Sailor::RHI;
+
+namespace
+{
+	class TestWorld final : public World
+	{
+	public:
+		TestWorld() : World("RHISceneVirtualizationTests", 0u, {}) {}
+	};
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	RHISceneInstanceRecord MakeRecord(
+		uint64_t producerKey,
+		EMobilityType mobility,
+		float translation = 0.0f)
+	{
+		RHISceneInstanceRecord record;
+		record.m_producerKey = producerKey;
+		record.m_mobility = mobility;
+		record.m_worldMatrix = glm::translate(glm::mat4(1.0f), glm::vec3(translation, 0.0f, 0.0f));
+		record.m_worldBounds = Math::AABB(glm::vec3(translation), glm::vec3(1.0f));
+		return record;
+	}
+
+	void TestGenerationalHandlesAndImmutableVersions()
+	{
+		auto scene = RHIScenePtr::Make(3u);
+		const auto oldHandle = scene->AddInstance(MakeRecord(10ull, EMobilityType::Static));
+		auto oldVersion = scene->PublishVersion();
+
+		RHISceneInstanceRecord current;
+		Require(scene->ResolveCurrent(oldHandle, current), "a live handle must resolve in the mutable scene");
+		Require(current.m_producerKey == 10ull, "the resolved live record must preserve its payload");
+
+		Require(scene->RemoveInstance(oldHandle), "a live handle must be removable");
+		auto removedVersion = scene->PublishVersion();
+		Require(!scene->ResolveCurrent(oldHandle, current), "a removed handle must be rejected by the mutable scene");
+
+		const RHISceneInstanceRecord* retainedRecord = nullptr;
+		Require(oldVersion->Resolve(oldHandle, retainedRecord) && retainedRecord,
+			"an older retained version must still resolve a removed record");
+		Require(!removedVersion->Resolve(oldHandle, retainedRecord),
+			"the removal version must not resolve the removed record");
+
+		for (uint32_t flight = 0u; flight < 3u; ++flight)
+		{
+			scene->PrepareFlight(flight, removedVersion);
+		}
+		oldVersion.Clear();
+		scene->CollectGarbage();
+
+		const auto reusedHandle = scene->AddInstance(MakeRecord(11ull, EMobilityType::Static));
+		Require(reusedHandle.m_slot == oldHandle.m_slot,
+			"a retired slot should be recycled once every referencing version and flight reaches its removal revision");
+		Require(reusedHandle.m_generation != oldHandle.m_generation,
+			"a recycled slot must advance its generation");
+		Require(!scene->ResolveCurrent(oldHandle, current),
+			"a stale generation must never resolve the recycled slot");
+
+		auto advancedVersion = scene->PublishVersion();
+		for (uint32_t flight = 0u; flight < 3u; ++flight)
+		{
+			scene->PrepareFlight(flight, advancedVersion);
+		}
+		removedVersion.Clear();
+		scene->CollectGarbage();
+
+		Require(scene->ResolveCurrent(reusedHandle, current),
+			"collecting older versions must not invalidate a recycled live handle");
+	}
+
+	void TestCopyOnWritePageSharing()
+	{
+		auto scene = RHIScenePtr::Make();
+		TVector<RenderInstanceHandle> handles;
+		for (uint32_t index = 0u; index <= RHISceneRecordPage::NumRecords; ++index)
+		{
+			handles.Add(scene->AddInstance(MakeRecord(index, EMobilityType::Static)));
+		}
+
+		auto first = scene->PublishVersion();
+		Require(first->m_recordsRoot->m_pages.Num() == 2u,
+			"records spanning the page boundary must create two COW pages");
+
+		auto changed = MakeRecord(RHISceneRecordPage::NumRecords, EMobilityType::Static, 5.0f);
+		Require(scene->UpdateInstance(
+			handles[RHISceneRecordPage::NumRecords],
+			changed,
+			ToMask(ESceneChangeBit::Transform) | ToMask(ESceneChangeBit::Bounds)),
+			"the record on the second page must update");
+		auto second = scene->PublishVersion();
+
+		Require(first->m_recordsRoot->m_pages[0] == second->m_recordsRoot->m_pages[0],
+			"an untouched record page must be physically shared between versions");
+		Require(first->m_recordsRoot->m_pages[1] != second->m_recordsRoot->m_pages[1],
+			"a dirty record page must use copy-on-write");
+
+		const RHISceneInstanceRecord* oldRecord = nullptr;
+		const RHISceneInstanceRecord* newRecord = nullptr;
+		const auto changedHandle = handles[RHISceneRecordPage::NumRecords];
+		Require(first->Resolve(changedHandle, oldRecord) && oldRecord,
+			"the old COW root must retain the original record");
+		Require(second->Resolve(changedHandle, newRecord) && newRecord,
+			"the new COW root must resolve the changed record");
+		Require(oldRecord->m_worldMatrix[3].x == 0.0f && newRecord->m_worldMatrix[3].x == 5.0f,
+			"copy-on-write must isolate record payloads between versions");
+
+		auto materialOnlyVersion = scene->PublishVersion(1ull);
+		Require(materialOnlyVersion->m_recordsRoot == second->m_recordsRoot,
+			"publishing a version without record deltas must retain the immutable COW root");
+	}
+
+	void TestTwoAndThreeFlightRevisionReplay()
+	{
+		auto scene = RHIScenePtr::Make(3u);
+		const auto stationary = scene->AddInstance(MakeRecord(1ull, EMobilityType::Stationary, 1.0f));
+		const auto dynamic = scene->AddInstance(MakeRecord(2ull, EMobilityType::Dynamic, 2.0f));
+		auto first = scene->PublishVersion();
+
+		auto flight0 = scene->PrepareFlight(0u, first);
+		auto flight1 = scene->PrepareFlight(1u, first);
+		auto flight2 = scene->PrepareFlight(2u, first);
+		const RHISceneInstanceRecord* flight0Stationary = nullptr;
+		Require(flight0->m_appliedVersion->Resolve(stationary, flight0Stationary) &&
+			flight0Stationary->m_worldMatrix[3].x == 1.0f &&
+			flight0->m_bStationaryFullRebuild,
+			"the first free flight must retain the immutable stationary version without copying complete records");
+		Require(flight0->m_dynamicHandles->Num() == 1u &&
+			flight1->m_dynamicHandles->Num() == 1u &&
+			flight2->m_dynamicHandles->Num() == 1u,
+			"every flight must reference its version's dynamic handle list");
+
+		Require(scene->UpdateInstance(
+			stationary,
+			MakeRecord(1ull, EMobilityType::Stationary, 10.0f),
+			ToMask(ESceneChangeBit::Transform) | ToMask(ESceneChangeBit::Bounds)),
+			"the stationary record must update");
+		Require(scene->UpdateInstance(
+			dynamic,
+			MakeRecord(2ull, EMobilityType::Dynamic, 20.0f),
+			ToMask(ESceneChangeBit::Transform) | ToMask(ESceneChangeBit::Bounds)),
+			"the dynamic record must update");
+		auto second = scene->PublishVersion();
+
+		scene->PrepareFlight(0u, second);
+		const RHISceneInstanceRecord* updatedStationary = nullptr;
+		const RHISceneInstanceRecord* retainedStationary1 = nullptr;
+		const RHISceneInstanceRecord* retainedStationary2 = nullptr;
+		const RHISceneInstanceRecord* updatedDynamic = nullptr;
+		Require(flight0->m_appliedVersion->Resolve(stationary, updatedStationary) &&
+			updatedStationary->m_worldMatrix[3].x == 10.0f &&
+			flight0->m_stationaryDirtyHandles.Contains(stationary),
+			"a freed flight must advance to the latest stationary delta by handle");
+		Require(flight1->m_appliedVersion->Resolve(stationary, retainedStationary1) &&
+			flight2->m_appliedVersion->Resolve(stationary, retainedStationary2) &&
+			retainedStationary1->m_worldMatrix[3].x == 1.0f &&
+			retainedStationary2->m_worldMatrix[3].x == 1.0f,
+			"active flights must retain their previous immutable stationary version");
+		Require(flight0->m_appliedVersion->Resolve(dynamic, updatedDynamic) &&
+			updatedDynamic->m_worldMatrix[3].x == 20.0f,
+			"the reused flight must resolve dynamic state without a duplicate record array");
+
+		scene->PrepareFlight(1u, second);
+		scene->PrepareFlight(2u, second);
+		Require(flight1->m_appliedVersion == second &&
+			flight2->m_appliedVersion == second,
+			"two and three-flight replay must converge only when each slot is reused");
+	}
+
+	void TestRangeRetirementAndDirtyCoalescing()
+	{
+		RHISceneRangeAllocator allocator;
+		const SceneRangeHandle first = allocator.Allocate(3u);
+		PhysicalAllocation firstAllocation;
+		Require(allocator.Resolve(first, firstAllocation) && firstAllocation.m_capacity == 4u,
+			"range allocation should grow geometrically");
+		Require(allocator.Retire(first, 4ull), "a live range must enter deferred retirement");
+
+		const SceneRangeHandle second = allocator.Allocate(3u);
+		Require(second.m_slot != first.m_slot,
+			"a range must not be recycled before its retirement revision completes");
+		allocator.Collect(4ull);
+		const SceneRangeHandle recycled = allocator.Allocate(3u);
+		Require(recycled.m_slot == first.m_slot && recycled.m_generation != first.m_generation,
+			"a completed range retirement must recycle the slot with a new generation");
+
+		const auto ranges = RHISceneRangeAllocator::CoalesceDirtyRanges({
+			{ 8u, 2u }, { 0u, 4u }, { 3u, 5u }, { 20u, 0u }, { 12u, 2u } });
+		Require(ranges.Num() == 2u && ranges[0].m_offset == 0u && ranges[0].m_count == 10u &&
+			ranges[1].m_offset == 12u && ranges[1].m_count == 2u,
+			"overlapping and adjacent dirty ranges must be coalesced before upload");
+	}
+
+	void TestImmutableMaterialBindingVersions()
+	{
+		auto material = RHIMaterialPtr::Make(RenderState{}, RHIShaderPtr{}, RHIShaderPtr{});
+		auto firstBindings = RHIShaderBindingSetPtr::Make();
+		auto secondBindings = RHIShaderBindingSetPtr::Make();
+		material->SetBindings(firstBindings);
+		auto firstVersion = material->GetVersion();
+		material->SetBindings(secondBindings);
+		auto secondVersion = material->GetVersion();
+
+		Require(firstVersion && secondVersion && firstVersion != secondVersion,
+			"publishing material bindings must create a new immutable version");
+		Require(firstVersion->GetBindings() == firstBindings && secondVersion->GetBindings() == secondBindings,
+			"an older material version must retain its original binding allocation");
+		Require(firstVersion->GetVersionId() < secondVersion->GetVersionId(),
+			"material version identifiers must increase monotonically");
+	}
+
+	void TestLocalizedShadowVersionDiff()
+	{
+		auto scene = RHIScenePtr::Make();
+		auto casterRecord = MakeRecord(20ull, EMobilityType::Static);
+		casterRecord.m_renderFlags = 1u;
+		const auto caster = scene->AddInstance(casterRecord);
+		const auto nonCaster = scene->AddInstance(
+			MakeRecord(21ull, EMobilityType::Static));
+		auto first = scene->PublishVersion();
+
+		Require(scene->UpdateInstance(
+			nonCaster,
+			MakeRecord(21ull, EMobilityType::Static, 4.0f),
+			ToMask(ESceneChangeBit::Transform) | ToMask(ESceneChangeBit::Bounds)),
+			"a non-caster update must publish successfully");
+		auto nonShadowChange = scene->PublishVersion();
+		const Math::Frustum shadowFrustum(glm::mat4(1.0f));
+		Require(!nonShadowChange->HasShadowChangesIntersecting(*first, shadowFrustum),
+			"a changed COW page must not invalidate a shadow view when only non-casters changed");
+
+		auto movedCaster = MakeRecord(20ull, EMobilityType::Static, 0.25f);
+		movedCaster.m_renderFlags = 1u;
+		Require(scene->UpdateInstance(
+			caster,
+			movedCaster,
+			ToMask(ESceneChangeBit::Transform) |
+				ToMask(ESceneChangeBit::Bounds) |
+				ToMask(ESceneChangeBit::ShadowState)),
+			"a caster update must publish successfully");
+		auto shadowChange = scene->PublishVersion();
+		Require(shadowChange->HasShadowChangesIntersecting(
+			*nonShadowChange,
+			shadowFrustum),
+			"a caster change intersecting the light frustum must invalidate that shadow view");
+	}
+
+	void TestSubmissionCompletionToken()
+	{
+		auto successful = RHISubmissionCompletionTokenPtr::Make();
+		Require(successful->IsPending() && !successful->IsSuccessful(),
+			"a newly prepared resource version must not be reusable before submission");
+		successful->Complete(true);
+		Require(!successful->IsPending() && successful->IsSuccessful(),
+			"a successfully submitted resource version must become reusable");
+		successful->Reset();
+		Require(successful->IsPending() && !successful->IsSuccessful(),
+			"a freed flight slot must reset and reuse its completion token");
+
+		auto failed = RHISubmissionCompletionTokenPtr::Make();
+		failed->Complete(false);
+		Require(!failed->IsPending() && !failed->IsSuccessful(),
+			"a failed submission must never publish its prepared resource version");
+	}
+
+	void TestSubmissionContextSurvivesSnapshotPreparation()
+	{
+		TestWorld world;
+		RHISceneView view;
+		view.m_world = &world;
+
+		CameraData camera;
+		camera.SetAspect(1.0f);
+		camera.SetFov(60.0f);
+		view.m_cameras.Add(camera);
+		view.m_cameraTransforms.Add(Math::Transform{});
+		view.m_shadowMapsToUpdate.Resize(1u);
+		view.m_shadowMapsToBlit.Resize(1u);
+		view.m_shadowIndices.Resize(1u);
+		view.m_shadowAtlasTiles.Resize(1u);
+		view.m_shadowMatrices.Resize(1u);
+
+		auto context = RHIRenderSubmissionContextPtr::Make();
+		context->BeginSubmission(11ull, 1u);
+		view.SetSubmissionContext(context);
+		view.PrepareSnapshots();
+
+		Require(view.m_snapshots.Num() == 1u &&
+			view.m_snapshots[0].m_submissionContext == context,
+			"preparing a camera snapshot must retain the acquired flight submission context");
+	}
+}
+
+int main()
+{
+	try
+	{
+		TestGenerationalHandlesAndImmutableVersions();
+		TestCopyOnWritePageSharing();
+		TestTwoAndThreeFlightRevisionReplay();
+		TestRangeRetirementAndDirtyCoalescing();
+		TestImmutableMaterialBindingVersions();
+		TestLocalizedShadowVersionDiff();
+		TestSubmissionCompletionToken();
+		TestSubmissionContextSurvivesSnapshotPreparation();
+	}
+	catch (const std::exception& exception)
+	{
+		std::cerr << "RHIScene virtualization tests failed: " << exception.what() << '\n';
+		return 1;
+	}
+
+	std::cout << "RHIScene virtualization tests passed\n";
+	return 0;
+}

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
+#include <initializer_list>
 #include <iostream>
 #include <iterator>
 #include <stdexcept>
@@ -1071,6 +1072,77 @@ namespace
 			"runtime light-culling compute shader should produce SPIR-V");
 	}
 
+	void TestShadowCasterPermutationsCompile()
+	{
+		const std::filesystem::path contentRoot =
+			std::filesystem::path(SAILOR_TEST_SOURCE_DIR) / "Content";
+		auto compilePermutation = [&](
+			const char* shaderPath,
+			std::initializer_list<const char*> permutationDefines)
+			{
+				ShaderAsset shader;
+				shader.Deserialize(YAML::Load(ReadText(contentRoot / shaderPath)));
+				auto compileStage = [&](
+					const char* stageDefine,
+					const std::string& stageSource,
+					RHI::EShaderStage stage)
+					{
+						std::string source = shader.GetGlslCommonCode() + "\n#define " +
+							stageDefine + "\n";
+						for (const char* define : permutationDefines)
+						{
+							source += std::string("#define ") + define + "\n";
+						}
+#if defined(__APPLE__)
+						source += "#define SAILOR_TEXTURE_REMAP\n";
+#endif
+						std::string diagnostic;
+						Require(
+							ShaderYamlIncludeResolver::Append(
+								shader.GetIncludes(),
+								[&](const std::string& include, std::string& contents)
+								{
+									std::ifstream input(contentRoot / include, std::ios::binary);
+									if (!input.is_open())
+									{
+										return false;
+									}
+									contents.assign(
+										std::istreambuf_iterator<char>(input),
+										std::istreambuf_iterator<char>());
+									return true;
+								},
+								source,
+								diagnostic),
+							std::string("shadow shader includes should resolve for ") +
+								shaderPath + ": " + diagnostic);
+						source += std::string("\n#ifdef ") + stageDefine + "\n" +
+							stageSource + "\n#endif\n";
+						RHI::ShaderByteCode byteCode;
+						Require(
+							ShaderCompilerTestAccess::CompileGlslToSpirv(
+								shaderPath,
+								source,
+								stage,
+								byteCode,
+								false),
+							std::string("shadow shader stage should compile: ") + shaderPath);
+						Require(!byteCode.IsEmpty(),
+							std::string("shadow shader stage should produce SPIR-V: ") + shaderPath);
+					};
+
+				compileStage("VERTEX", shader.GetGlslVertexCode(), RHI::EShaderStage::Vertex);
+				compileStage("FRAGMENT", shader.GetGlslFragmentCode(), RHI::EShaderStage::Fragment);
+			};
+
+		compilePermutation("Shaders/ShadowCaster.shader", { "MASKED" });
+		compilePermutation("Shaders/ShadowCaster.shader", { "EVSM", "SKINNING", "MASKED" });
+		compilePermutation("Experimental/MeshParticles/Particle.shader", { "SHADOW_CASTER" });
+		compilePermutation("Experimental/MeshParticles/Particle.shader", { "PACKED_SHADOW_CASTER" });
+		compilePermutation(
+			"Experimental/MeshParticles/Particle.shader", { "PACKED_SHADOW_CASTER", "EVSM" });
+	}
+
 	void TestShaderSourceNormalization()
 	{
 		std::string diagnostic;
@@ -1216,6 +1288,7 @@ int main()
 		TestShaderDependencyFingerprintTracksTimestampAndWinner();
 		TestMissingYamlIncludeFailsWithoutPartialSource();
 		TestRuntimeLightingShadersCompile();
+		TestShadowCasterPermutationsCompile();
 		TestShaderSourceNormalization();
 		TestShaderSourceRewritePreservesFileIdentity();
 		std::cout << "Shader cache artifact tests passed.\n";

--- a/Tests/VulkanDescriptorCacheTests.cpp
+++ b/Tests/VulkanDescriptorCacheTests.cpp
@@ -198,6 +198,22 @@ namespace
 			"removing the expired descriptor cache key must release its map entry");
 	}
 
+	void TestConcurrentMapConstFindDoesNotExposeEndIterator()
+	{
+		TConcurrentMap<std::string, uint32_t> values;
+		values.At_Lock("present") = 7u;
+		values.Unlock("present");
+
+		const auto& constValues = values;
+		const uint32_t* present = nullptr;
+		Require(constValues.Find("present", present) && present && *present == 7u,
+			"const Find must return the stored value for an existing key");
+
+		const uint32_t* missing = nullptr;
+		Require(!constValues.Find("missing", missing) && missing == nullptr,
+			"const Find must not expose or dereference the end iterator for a missing key");
+	}
+
 	void TestDescriptorCacheKeyTracksDescriptorRevision()
 	{
 		using DescriptorCacheKey =
@@ -408,10 +424,10 @@ namespace
 			"batch.m_textureBindings = Framegraph::Details::GetTextureBindingSet(") !=
 			std::string::npos &&
 			depthPrepassSource.find(
-				"material->GetBindings(), batch.m_textureBindings") !=
+				"sets.Add(batch.GetMaterialBindings());") !=
 				std::string::npos &&
 			depthPrepassSource.find(
-				"material->GetBindings(), textureSamplers") ==
+				"batch.m_material->GetBindings(),") ==
 				std::string::npos,
 			"custom depth batches must use their dense texture bindings instead of the legacy global set");
 		Require(gltfShader.find(
@@ -768,6 +784,8 @@ int main()
 			TestSsboElementAlignmentPreservesStd430Stride },
 		{ "DescriptorCacheKeyKeepsItsCompatibilitySnapshot",
 			TestDescriptorCacheKeyKeepsItsCompatibilitySnapshot },
+		{ "ConcurrentMapConstFindDoesNotExposeEndIterator",
+			TestConcurrentMapConstFindDoesNotExposeEndIterator },
 		{ "DescriptorCacheKeyTracksDescriptorRevision",
 			TestDescriptorCacheKeyTracksDescriptorRevision },
 		{ "TextureSamplerUpdatesUseSynchronizedSnapshot",


### PR DESCRIPTION
## Summary

- add versioned `RHIScene` snapshots and per-flight submission resources so two or three in-flight frames retain independent render data until their fences complete
- split instance lifetime by `Static`, `Stationary`, and `Dynamic`: reuse unchanged static/stationary copy-on-write pages and rebuild dynamic payloads every submission
- use pass-specific packed payloads and instance-index streams for main, depth prepass, and shadow passes; GPU culling compacts indices instead of copying full per-instance records while LOD selection remains on CPU
- virtualize landscape and vegetation data per chunk, including localized chunk invalidation, stable packed ranges, and shadow-caster updates
- capture immutable material versions per submission and keep light-culling buffers/bindings flight-local to prevent cross-frame descriptor reuse
- virtualize CSM and local-shadow packets, revisions, cache invalidation, and cleanup for static/stationary/dynamic casters
- enable instance-payload virtualization in the default, editor, and experimental renderer configurations

## Validation

- `cmake --build build-mac --config Release --target RHISceneVirtualizationTests GpuCullingContractTests EcsLifecycleContractTests VulkanDescriptorCacheTests ShaderCacheArtifactTests --parallel 2`
- `RHISceneVirtualizationTests` — passed
- `GpuCullingContractTests` — 31/31 passed
- `EcsLifecycleContractTests` — passed, including scene-version, material-revision, CSM, local-shadow, and shadow-cache contracts
- `VulkanDescriptorCacheTests` — 17/17 passed
- `ShaderCacheArtifactTests` — passed
- Release Editor smoke-tested with `EverythingFloats` / `Everything Floats - Highland Trail`: terrain and vegetation chunks remained stable; Duck rendering, forward+ light culling, CSM, and local shadows were checked after the per-flight light-culling fix

## Notes

- CPU-side LOD selection is intentionally retained; the optimization targets payload reuse, allocation/copy reduction, and compact render submission.
- Generated `.shader.asset` serialization churn and the local Duck material test edit are intentionally excluded from this PR.
- Validation was performed on macOS arm64. A Windows MSVC/clang build was not run locally.
- No formal performance numbers are claimed in this PR; the architectural and behavioral contracts plus the live scene smoke test are included.
