### PR TITLE
Add project graphics quality settings

### DIFF
--- a/Content/DefaultRenderer.renderer
+++ b/Content/DefaultRenderer.renderer
@@ -21,10 +21,20 @@ float:
   
 ############################
 renderTargets:
-- name: Main
-  format: R16G16B16A16_SFLOAT
+- name: DepthBuffer
+  format: D32_SFLOAT_S8_UINT
+  width: RenderWidth
+  height: RenderHeight
+
+- name: OverlayDepthBuffer
+  format: D32_SFLOAT_S8_UINT
   width: ViewportWidth
   height: ViewportHeight
+
+- name: Main
+  format: R16G16B16A16_SFLOAT
+  width: RenderWidth
+  height: RenderHeight
   bIsSurface: true
   bIsCompatibleWithComputeShaders: true
   bGenerateMips: true
@@ -32,8 +42,8 @@ renderTargets:
 
 - name: Secondary
   format: R16G16B16A16_SFLOAT
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
   bIsSurface: false
   bGenerateMips: true
 
@@ -45,38 +55,38 @@ renderTargets:
 
 - name: Sky
   format: R16G16B16A16_SFLOAT
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
   clamping: Clamp
   bIsSurface: false
 
 - name: HalfDepth
   format: D32_SFLOAT_S8_UINT
-  width: ViewportWidth/2
-  height: ViewportHeight/2
+  width: RenderWidth/2
+  height: RenderHeight/2
   
 - name: DepthHighZ
   format: R32_SFLOAT
-  width: ViewportWidth/2
-  height: ViewportHeight/2
+  width: RenderWidth/2
+  height: RenderHeight/2
   bIsCompatibleWithComputeShaders: true
   bGenerateMips: true
   reduction: Min
 
 - name: AO
   format: R8_UNORM
-  width: ViewportWidth/2
-  height: ViewportHeight/2
+  width: RenderWidth/2
+  height: RenderHeight/2
 
 - name: TemporaryR8
   format: R8_UNORM
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
 
 - name: g_AO
   format: R8_UNORM
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
   
 - name: QuarterMain1
   format: R16G16B16A16_SFLOAT
@@ -92,8 +102,8 @@ renderTargets:
 - name: LinearDepth
   format: R32_SFLOAT
   filtration: Nearest
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
   bIsSurface: false
 
 ############################
@@ -439,7 +449,7 @@ frame:
 #############################
   renderTargets:
   - color: EditorOutput
-  - depthStencil: DepthBuffer
+  - depthStencil: OverlayDepthBuffer
 
 #############################
 - name: EditorReadback

--- a/Content/EditorRenderer.renderer
+++ b/Content/EditorRenderer.renderer
@@ -23,13 +23,18 @@ float:
 renderTargets:
 - name: DepthBuffer
   format: D32_SFLOAT_S8_UINT
+  width: RenderWidth
+  height: RenderHeight
+
+- name: OverlayDepthBuffer
+  format: D32_SFLOAT_S8_UINT
   width: ViewportWidth
   height: ViewportHeight
 
 - name: Main
   format: R16G16B16A16_SFLOAT
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
   bIsSurface: true
   bIsCompatibleWithComputeShaders: true
   bGenerateMips: true
@@ -37,8 +42,8 @@ renderTargets:
 
 - name: Secondary
   format: R16G16B16A16_SFLOAT
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
   bIsSurface: false
   bGenerateMips: true
 
@@ -50,38 +55,38 @@ renderTargets:
 
 - name: Sky
   format: R16G16B16A16_SFLOAT
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
   clamping: Clamp
   bIsSurface: false
 
 - name: HalfDepth
   format: D32_SFLOAT_S8_UINT
-  width: ViewportWidth/2
-  height: ViewportHeight/2
+  width: RenderWidth/2
+  height: RenderHeight/2
   
 - name: DepthHighZ
   format: R32_SFLOAT
-  width: ViewportWidth/2
-  height: ViewportHeight/2
+  width: RenderWidth/2
+  height: RenderHeight/2
   bIsCompatibleWithComputeShaders: true
   bGenerateMips: true
   reduction: Min
 
 - name: AO
   format: R8_UNORM
-  width: ViewportWidth/2
-  height: ViewportHeight/2
+  width: RenderWidth/2
+  height: RenderHeight/2
 
 - name: TemporaryR8
   format: R8_UNORM
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
 
 - name: g_AO
   format: R8_UNORM
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
   
 - name: QuarterMain1
   format: R16G16B16A16_SFLOAT
@@ -97,8 +102,8 @@ renderTargets:
 - name: LinearDepth
   format: R32_SFLOAT
   filtration: Nearest
-  width: ViewportWidth
-  height: ViewportHeight
+  width: RenderWidth
+  height: RenderHeight
   bIsSurface: false
 
 ############################
@@ -444,7 +449,7 @@ frame:
 #############################
   renderTargets:
   - color: EditorOutput
-  - depthStencil: DepthBuffer
+  - depthStencil: OverlayDepthBuffer
 
 #############################
 - name: EditorReadback

--- a/Content/Shaders/Debug.shader
+++ b/Content/Shaders/Debug.shader
@@ -143,10 +143,14 @@ glslFragment: |
   #elif defined(CASCADES)
     float linearDepth = texture(linearDepthSampler, fragTexcoord).r;
     float shadowFarPlane = min(frame.cameraZNearZFar.y, ShadowMaxDistance);
-    int layer = NUM_CSM_CASCADES;
-    for (int i = 0; i < NUM_CSM_CASCADES; ++i)
+    const uint activeCascadeCount = light.instance.length() > 0 ?
+      clamp(light.instance[0].activeCascadeCount, 1u, uint(NUM_CSM_CASCADES)) :
+      uint(NUM_CSM_CASCADES);
+    int layer = int(activeCascadeCount);
+    for (int i = 0; i < int(activeCascadeCount); ++i)
     {
-        if (linearDepth < shadowFarPlane * ShadowCascadeLevels[i])
+        if (linearDepth < shadowFarPlane *
+          GetActiveShadowCascadeLevel(i, activeCascadeCount))
         {
             layer = i;
             break;

--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -332,8 +332,11 @@ glslFragment: |
     vec3 surfaceNormal,
     vec3 surfaceToLightDirection)
   {
-    const int cascadeLayer = SelectCascade(frame.view, worldPosition, frame.cameraZNearZFar);
-    if(cascadeLayer >= NUM_CSM_CASCADES)
+    const uint activeCascadeCount = clamp(
+      light.activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
+    const int cascadeLayer = SelectCascade(
+      frame.view, worldPosition, frame.cameraZNearZFar, activeCascadeCount);
+    if(cascadeLayer >= int(activeCascadeCount))
     {
       return 1.0f;
     }
@@ -352,7 +355,8 @@ glslFragment: |
       frame.view,
       worldPosition,
       frame.cameraZNearZFar,
-      cascadeLayer);
+      cascadeLayer,
+      activeCascadeCount);
     if(cascadeBlend > 0.0f)
     {
       const int nextCascadeLayer = cascadeLayer + 1;
@@ -369,7 +373,8 @@ glslFragment: |
       frame.view,
       worldPosition,
       frame.cameraZNearZFar,
-      cascadeLayer);
+      cascadeLayer,
+      activeCascadeCount);
     shadow = mix(shadow, 1.0f, shadowDistanceFade);
 
     return shadow;

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -25,6 +25,7 @@ struct LightData
 {
   uint type;
   uint shadowType;
+  uint activeCascadeCount;
   vec3 worldPosition;
   vec3 direction;
   vec3 intensity;
@@ -374,16 +375,29 @@ float CalculateLocalPcfShadow(
 }
 
 
-int SelectCascade(mat4 view, vec3 worldPosition, vec2 cameraZNearZFar)
+float GetActiveShadowCascadeLevel(int cascadeLayer, uint activeCascadeCount)
+{
+  const uint safeCascadeCount = clamp(activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
+  const int levelIndex = NUM_CSM_CASCADES - int(safeCascadeCount) + cascadeLayer;
+  return ShadowCascadeLevels[clamp(levelIndex, 0, NUM_CSM_CASCADES - 1)];
+}
+
+int SelectCascade(
+  mat4 view,
+  vec3 worldPosition,
+  vec2 cameraZNearZFar,
+  uint activeCascadeCount)
 {
   vec4 fragPosViewSpace = view * vec4(worldPosition, 1.0);
   float depthValue = abs(fragPosViewSpace.z / fragPosViewSpace.w);
   float shadowFarPlane = min(cameraZNearZFar.y, ShadowMaxDistance);
+  const uint safeCascadeCount = clamp(activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
   
-  int layer = NUM_CSM_CASCADES;
-  for (int i = 0; i < NUM_CSM_CASCADES; ++i)
+  int layer = int(safeCascadeCount);
+  for (int i = 0; i < int(safeCascadeCount); ++i)
   {
-      if (depthValue < shadowFarPlane * ShadowCascadeLevels[i])
+      if (depthValue < shadowFarPlane *
+        GetActiveShadowCascadeLevel(i, safeCascadeCount))
       {
           layer = i;
           break;
@@ -397,9 +411,11 @@ float CalculateCascadeBlend(
   mat4 view,
   vec3 worldPosition,
   vec2 cameraZNearZFar,
-  int cascadeLayer)
+  int cascadeLayer,
+  uint activeCascadeCount)
 {
-  if(cascadeLayer < 0 || cascadeLayer >= NUM_CSM_CASCADES - 1)
+  const uint safeCascadeCount = clamp(activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
+  if(cascadeLayer < 0 || cascadeLayer >= int(safeCascadeCount) - 1)
   {
     return 0.0f;
   }
@@ -409,8 +425,10 @@ float CalculateCascadeBlend(
   float shadowFarPlane = min(cameraZNearZFar.y, ShadowMaxDistance);
   float cascadeNear = cascadeLayer == 0 ?
     cameraZNearZFar.x :
-    shadowFarPlane * ShadowCascadeLevels[cascadeLayer - 1];
-  float cascadeFar = shadowFarPlane * ShadowCascadeLevels[cascadeLayer];
+    shadowFarPlane * GetActiveShadowCascadeLevel(
+      cascadeLayer - 1, safeCascadeCount);
+  float cascadeFar = shadowFarPlane * GetActiveShadowCascadeLevel(
+    cascadeLayer, safeCascadeCount);
   float blendStart = cascadeFar -
     (cascadeFar - cascadeNear) * ShadowCascadeBlendFraction;
   return smoothstep(blendStart, cascadeFar, depthValue);
@@ -420,9 +438,11 @@ float CalculateShadowDistanceFade(
   mat4 view,
   vec3 worldPosition,
   vec2 cameraZNearZFar,
-  int cascadeLayer)
+  int cascadeLayer,
+  uint activeCascadeCount)
 {
-  if(cascadeLayer != NUM_CSM_CASCADES - 1)
+  const uint safeCascadeCount = clamp(activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
+  if(cascadeLayer != int(safeCascadeCount) - 1)
   {
     return 0.0f;
   }
@@ -430,8 +450,10 @@ float CalculateShadowDistanceFade(
   const vec4 fragPosViewSpace = view * vec4(worldPosition, 1.0f);
   const float depthValue = abs(fragPosViewSpace.z / fragPosViewSpace.w);
   const float shadowFarPlane = min(cameraZNearZFar.y, ShadowMaxDistance);
-  const float cascadeNear = shadowFarPlane *
-    ShadowCascadeLevels[NUM_CSM_CASCADES - 2];
+  const float cascadeNear = safeCascadeCount > 1u ?
+    shadowFarPlane * GetActiveShadowCascadeLevel(
+      int(safeCascadeCount) - 2, safeCascadeCount) :
+    cameraZNearZFar.x;
   const float fadeStart = shadowFarPlane -
     (shadowFarPlane - cascadeNear) * ShadowCascadeBlendFraction;
   return smoothstep(fadeStart, shadowFarPlane, depthValue);

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -331,8 +331,11 @@ glslFragment: |
     vec3 surfaceNormal,
     vec3 surfaceToLightDirection)
   {
-    const int cascadeLayer = SelectCascade(frame.view, worldPosition, frame.cameraZNearZFar);
-    if(cascadeLayer >= NUM_CSM_CASCADES)
+    const uint activeCascadeCount = clamp(
+      light.activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
+    const int cascadeLayer = SelectCascade(
+      frame.view, worldPosition, frame.cameraZNearZFar, activeCascadeCount);
+    if(cascadeLayer >= int(activeCascadeCount))
     {
       return 1.0f;
     }
@@ -352,7 +355,8 @@ glslFragment: |
       frame.view,
       worldPosition,
       frame.cameraZNearZFar,
-      cascadeLayer);
+      cascadeLayer,
+      activeCascadeCount);
     if(cascadeBlend > 0.0f)
     {
       const int nextCascadeLayer = cascadeLayer + 1;
@@ -369,7 +373,8 @@ glslFragment: |
       frame.view,
       worldPosition,
       frame.cameraZNearZFar,
-      cascadeLayer);
+      cascadeLayer,
+      activeCascadeCount);
     shadow = mix(shadow, 1.0f, shadowDistanceFade);
 
     return shadow;

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -439,8 +439,11 @@ glslFragment: |
     vec3 surfaceNormal,
     vec3 surfaceToLightDirection)
   {
-    const int cascadeLayer = SelectCascade(frame.view, worldPosition, frame.cameraZNearZFar);
-    if(cascadeLayer >= NUM_CSM_CASCADES)
+    const uint activeCascadeCount = clamp(
+      light.activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
+    const int cascadeLayer = SelectCascade(
+      frame.view, worldPosition, frame.cameraZNearZFar, activeCascadeCount);
+    if(cascadeLayer >= int(activeCascadeCount))
     {
       return 1.0f;
     }
@@ -460,7 +463,8 @@ glslFragment: |
       frame.view,
       worldPosition,
       frame.cameraZNearZFar,
-      cascadeLayer);
+      cascadeLayer,
+      activeCascadeCount);
     if(cascadeBlend > 0.0f)
     {
       const int nextCascadeLayer = cascadeLayer + 1;
@@ -477,7 +481,8 @@ glslFragment: |
       frame.view,
       worldPosition,
       frame.cameraZNearZFar,
-      cascadeLayer);
+      cascadeLayer,
+      activeCascadeCount);
     shadow = mix(shadow, 1.0f, shadowDistanceFade);
 
     return shadow;

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -67,6 +67,8 @@
     <Compile Include="McpYamlUtilitiesTests.cs" />
     <Compile Include="SettingsContractsTests.cs" />
     <Compile Include="UnifiedSettingsStoreTests.cs" />
+    <Compile Include="GraphicsSettingsTests.cs" />
+    <Compile Include="GraphicsSettingsUiContractTests.cs" />
     <Compile Include="WorkflowProjectionTests.cs" />
     <Compile Include="SceneViewportLifecycleTests.cs" />
     <Compile Include="SceneViewportInteractionTests.cs" />
@@ -110,6 +112,9 @@
     <Compile Include="..\Editor\History\HistoryContracts.cs" Link="History\HistoryContracts.cs" />
     <Compile Include="..\Editor\Settings\SettingsContracts.cs" Link="Settings\SettingsContracts.cs" />
     <Compile Include="..\Editor\Settings\UnifiedSettingsStore.cs" Link="Settings\UnifiedSettingsStore.cs" />
+    <Compile Include="..\Editor\Settings\GraphicsSettings.cs" Link="Settings\GraphicsSettings.cs" />
+    <Compile Include="..\Editor\Settings\GraphicsSettingsDraft.cs" Link="Settings\GraphicsSettingsDraft.cs" />
+    <Compile Include="..\Editor\Settings\GraphicsSettingsService.cs" Link="Settings\GraphicsSettingsService.cs" />
     <Compile Include="..\Editor\Content\ProjectContentAssetResolutionPolicy.cs" Link="Content\ProjectContentAssetResolutionPolicy.cs" />
     <Compile Include="..\Editor\Content\ProjectContentModels.cs" Link="Content\ProjectContentModels.cs" />
     <Compile Include="..\Editor\Content\ProjectContentFolderIds.cs" Link="Content\ProjectContentFolderIds.cs" />

--- a/Editor.Tests/EditorEngineProtocolTests.cs
+++ b/Editor.Tests/EditorEngineProtocolTests.cs
@@ -120,6 +120,7 @@ public sealed class EditorEngineProtocolTests
         Assert.Equal(57, ProtocolRequest.UpdateAssetFieldNumber);
         Assert.Equal(61, ProtocolRequest.SetEditorSimulationFieldNumber);
         Assert.Equal(62, ProtocolRequest.GetEditorSimulationStateFieldNumber);
+        Assert.Equal(64, ProtocolRequest.SetEditorStatsModeFieldNumber);
         Assert.Equal(10, ProtocolResponse.EmptyResultFieldNumber);
         Assert.Equal(19, ProtocolResponse.ViewportEventBatchResultFieldNumber);
     }

--- a/Editor.Tests/EditorViewportEventContractTests.cs
+++ b/Editor.Tests/EditorViewportEventContractTests.cs
@@ -480,6 +480,42 @@ public sealed class EditorViewportEventContractTests
     }
 
     [Fact]
+    public void MacViewportLayout_UsesCurrentPlatformBoundsInsteadOfStaleManagedSize()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Platforms",
+            "MacCatalyst",
+            "NativeSceneViewportHandler.MacCatalyst.cs");
+        var requestLayout = Slice(
+            source,
+            "public void RequestLayoutUpdate(double width, double height, double contentsScale)",
+            "void UpdatePlatformLayout(");
+        var platformLayout = Slice(
+            source,
+            "public override void LayoutSubviews()",
+            "public void FocusInput()");
+
+        AssertInOrder(
+            requestLayout,
+            "var platformBounds = PlatformView?.Bounds ?? CGRect.Empty;",
+            "ResolveLayoutBounds(platformBounds, width, height)",
+            "QueueLayoutUpdate(nextBounds, nextContentsScale);");
+        AssertInOrder(
+            platformLayout,
+            "base.LayoutSubviews();",
+            "handler.UpdatePlatformLayout(Bounds, ContentScaleFactor);");
+        Assert.Contains(
+            "var width = platformBounds.Width > 0 ? platformBounds.Width : Math.Max(fallbackWidth, 1);",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "var height = platformBounds.Height > 0 ? platformBounds.Height : Math.Max(fallbackHeight, 1);",
+            source,
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void MacMouseInput_AcquiresFocusOnlyForOwnedPressAndReleasesLifecycleObservers()
     {
         var source = ReadRepositoryFile(

--- a/Editor.Tests/EngineProtocolClientTests.cs
+++ b/Editor.Tests/EngineProtocolClientTests.cs
@@ -219,6 +219,48 @@ public sealed class EngineProtocolClientTests
             requests[1].CommandCase);
     }
 
+    [Theory]
+    [InlineData(EditorStatsMode.None)]
+    [InlineData(EditorStatsMode.RenderStats)]
+    [InlineData(EditorStatsMode.RenderStatsAndQueries)]
+    public async Task SetEditorStatsModeAsync_SendsExplicitTypedMode(
+        EditorStatsMode mode)
+    {
+        ProtocolRequest? capturedRequest = null;
+        var client = CreateClient(request =>
+        {
+            capturedRequest = request;
+            return Success(
+                request,
+                response => response.BoolResult =
+                    new BoolResult { Value = true });
+        });
+
+        Assert.True(await client.SetEditorStatsModeAsync(mode));
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(
+            ProtocolRequest.CommandOneofCase.SetEditorStatsMode,
+            capturedRequest.CommandCase);
+        Assert.Equal(mode, capturedRequest.SetEditorStatsMode.Mode);
+    }
+
+    [Theory]
+    [InlineData(EditorStatsMode.Unspecified)]
+    [InlineData((EditorStatsMode)99)]
+    public async Task SetEditorStatsModeAsync_RejectsInvalidModes(
+        EditorStatsMode mode)
+    {
+        var client = CreateClient(request =>
+            Success(
+                request,
+                response => response.BoolResult =
+                    new BoolResult { Value = true }));
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            client.SetEditorStatsModeAsync(mode));
+    }
+
     [Fact]
     public async Task AnimatorParameters_UseTypedProtocolValues()
     {

--- a/Editor.Tests/GraphicsSettingsTests.cs
+++ b/Editor.Tests/GraphicsSettingsTests.cs
@@ -1,0 +1,759 @@
+using SailorEditor.Settings;
+using YamlDotNet.RepresentationModel;
+
+namespace SailorEditor.Editor.Tests;
+
+public sealed class GraphicsSettingsTests
+{
+    [Fact]
+    public void Defaults_UseTheApprovedFivePresetContract()
+    {
+        var project = GraphicsSettingsDefaults.Project;
+
+        Assert.Equal(GraphicsQualityLevel.High, project.Graphics.DefaultQuality);
+        Assert.Equal(120, project.Graphics.Presets.Ultra.FpsCap);
+        Assert.Equal(8, project.Graphics.Presets.Ultra.MsaaSamples);
+        Assert.Equal(0.0, project.Graphics.Presets.Ultra.ShadowBias);
+        Assert.Equal([4096, 2048, 2048, 1024], project.Graphics.Presets.Ultra.ShadowCascadeResolutions);
+        Assert.Equal(0.85, project.Graphics.Presets.Medium.ResolutionFactor);
+        Assert.Equal(GraphicsShadowQuality.Medium, project.Graphics.Presets.Medium.ShadowQuality);
+        Assert.Equal(0.125, project.Graphics.Presets.VeryLow.CloudsResolutionMultiplier);
+        Assert.Equal(2, project.Graphics.Presets.VeryLow.LodBias);
+        Assert.True(GraphicsSettingsValidator.Validate(project).IsValid);
+        Assert.True(GraphicsSettingsValidator.Validate(GraphicsSettingsDefaults.Editor).IsValid);
+
+        var yaml = GraphicsSettingsYamlCodec.SerializeProject(project);
+        Assert.Contains("defaultQuality: High", yaml);
+        Assert.Contains("fpsCap: 120", yaml);
+        Assert.Contains("shadowBias: 0", yaml);
+        Assert.Contains("VeryLow:", yaml);
+        Assert.Contains("supportSoftShadows: true", yaml);
+    }
+
+    [Fact]
+    public void Validate_ReportsEveryGraphicsConstraintWithQualifiedPaths()
+    {
+        var invalidPreset = GraphicsSettingsDefaults.Presets.High with
+        {
+            ResolutionFactor = 0.1,
+            FpsCap = 0,
+            MsaaSamples = 3,
+            ShadowQuality = (GraphicsShadowQuality)99,
+            ShadowBias = 17.0,
+            ShadowCascadeCount = 3,
+            ShadowCascadeResolutions = [1024, 300],
+            CloudsResolutionMultiplier = 3.0,
+            SkyResolution = 96,
+            LodBias = 9
+        };
+        var document = GraphicsSettingsDefaults.Project with
+        {
+            Graphics = GraphicsSettingsDefaults.Project.Graphics with
+            {
+                Presets = GraphicsSettingsDefaults.Presets.With(
+                    GraphicsQualityLevel.High,
+                    invalidPreset)
+            }
+        };
+
+        var result = GraphicsSettingsValidator.Validate(document);
+
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.resolutionFactor");
+        Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.fpsCap");
+        Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.msaaSamples");
+        Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.shadowQuality");
+        Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.shadowBias");
+        Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.shadowCascadeResolutions");
+        Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.cloudsResolutionMultiplier");
+        Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.skyResolution");
+        Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.lodBias");
+    }
+
+    [Fact]
+    public async Task ApplyAsync_PreservesUnknownYamlKeysAndUsesAtomicReplacement()
+    {
+        using var workspace = TempWorkspace.Create();
+        var paths = workspace.Paths;
+        Directory.CreateDirectory(paths.CacheDirectory);
+        var root = LoadRoot(GraphicsSettingsYamlCodec.SerializeProject(GraphicsSettingsDefaults.Project));
+        root.Add("pluginSettings", new YamlMappingNode("enabled", "true"));
+        var graphics = Assert.IsType<YamlMappingNode>(root.Children[new YamlScalarNode("graphics")]);
+        graphics.Add("futureRenderer", "meshlets");
+        var presets = Assert.IsType<YamlMappingNode>(graphics.Children[new YamlScalarNode("presets")]);
+        var ultra = Assert.IsType<YamlMappingNode>(presets.Children[new YamlScalarNode("Ultra")]);
+        ultra.Add("futureUltraOption", "kept");
+        await File.WriteAllTextAsync(paths.ProjectSettingsPath, Save(root));
+
+        var restartCount = 0;
+        var service = new GraphicsSettingsService(
+            () => paths,
+            _ =>
+            {
+                restartCount++;
+                return Task.FromResult(true);
+            });
+        var loaded = await service.EnsureLoadedAsync();
+        var edited = loaded.Project with
+        {
+            Graphics = loaded.Project.Graphics with
+            {
+                Presets = loaded.Project.Graphics.Presets.With(
+                    GraphicsQualityLevel.Ultra,
+                    loaded.Project.Graphics.Presets.Ultra with
+                    {
+                        ResolutionFactor = 0.95,
+                        ShadowBias = 1.25
+                    })
+            }
+        };
+
+        var result = await service.ApplyAsync(edited, loaded.Editor, loaded);
+
+        Assert.True(result.ProjectChanged);
+        Assert.True(result.QualityChanged);
+        Assert.True(result.EngineRestarted);
+        Assert.Equal(1, restartCount);
+        Assert.False(File.Exists(paths.EditorSettingsPath));
+        Assert.Empty(Directory.EnumerateFiles(paths.WorkspaceRoot, "*.tmp", SearchOption.AllDirectories));
+
+        var saved = LoadRoot(await File.ReadAllTextAsync(paths.ProjectSettingsPath));
+        Assert.True(saved.Children.ContainsKey(new YamlScalarNode("pluginSettings")));
+        var savedGraphics = Assert.IsType<YamlMappingNode>(saved.Children[new YamlScalarNode("graphics")]);
+        Assert.Equal("meshlets", Assert.IsType<YamlScalarNode>(savedGraphics.Children[new YamlScalarNode("futureRenderer")]).Value);
+        var savedPresets = Assert.IsType<YamlMappingNode>(savedGraphics.Children[new YamlScalarNode("presets")]);
+        var savedUltra = Assert.IsType<YamlMappingNode>(savedPresets.Children[new YamlScalarNode("Ultra")]);
+        Assert.Equal("kept", Assert.IsType<YamlScalarNode>(savedUltra.Children[new YamlScalarNode("futureUltraOption")]).Value);
+        Assert.Equal("0.95", Assert.IsType<YamlScalarNode>(savedUltra.Children[new YamlScalarNode("resolutionFactor")]).Value);
+        Assert.Equal("1.25", Assert.IsType<YamlScalarNode>(savedUltra.Children[new YamlScalarNode("shadowBias")]).Value);
+    }
+
+    [Fact]
+    public async Task EditorChanges_RestartQualityAndApplyStatsLive()
+    {
+        using var workspace = TempWorkspace.Create(customCache: true);
+        await File.WriteAllTextAsync(
+            workspace.Paths.ProjectSettingsPath,
+            GraphicsSettingsYamlCodec.SerializeProject(GraphicsSettingsDefaults.Project));
+        Directory.CreateDirectory(workspace.Paths.CacheDirectory);
+        var editorRoot = LoadRoot(
+            GraphicsSettingsYamlCodec.SerializeEditor(GraphicsSettingsDefaults.Editor));
+        editorRoot.Add("pluginState", "preserved");
+        var editorGraphics = Assert.IsType<YamlMappingNode>(
+            editorRoot.Children[new YamlScalarNode("graphics")]);
+        editorGraphics.Add("futureOverlay", "preserved");
+        await File.WriteAllTextAsync(
+            workspace.Paths.EditorSettingsPath,
+            Save(editorRoot));
+        var restartCount = 0;
+        var appliedStats = new List<GraphicsStatsMode>();
+        var published = new List<GraphicsSettingsSnapshot>();
+        var service = new GraphicsSettingsService(
+            () => workspace.Paths,
+            _ =>
+            {
+                restartCount++;
+                return Task.FromResult(true);
+            },
+            (mode, _) =>
+            {
+                appliedStats.Add(mode);
+                return Task.FromResult(true);
+            });
+        service.SettingsChanged += (_, snapshot) => published.Add(snapshot);
+
+        var qualityResult = await service.SetSelectedQualityAsync(EditorQualitySelection.Ultra);
+        var statsResult = await service.SetStatsModeAsync(GraphicsStatsMode.RenderStatsAndQueries);
+
+        Assert.True(qualityResult.QualityChanged);
+        Assert.True(qualityResult.EngineRestarted);
+        Assert.True(statsResult.StatsChanged);
+        Assert.True(statsResult.StatsAppliedLive);
+        Assert.Equal(1, restartCount);
+        Assert.Equal([GraphicsStatsMode.RenderStatsAndQueries], appliedStats);
+        Assert.Contains(published, snapshot =>
+            snapshot.Editor.Graphics.SelectedQuality ==
+                EditorQualitySelection.Ultra);
+        Assert.Equal(
+            GraphicsStatsMode.RenderStatsAndQueries,
+            published[^1].Editor.Graphics.StatsMode);
+        Assert.Equal(
+            Path.Combine(workspace.CustomCacheDirectory, GraphicsSettingsPaths.EditorFileName),
+            workspace.Paths.EditorSettingsPath);
+        var editorYaml = await File.ReadAllTextAsync(workspace.Paths.EditorSettingsPath);
+        Assert.Contains("selectedQuality: Ultra", editorYaml);
+        Assert.Contains("statsMode: RenderStatsAndQueries", editorYaml);
+        var savedEditorRoot = LoadRoot(editorYaml);
+        Assert.Equal(
+            "preserved",
+            Assert.IsType<YamlScalarNode>(
+                savedEditorRoot.Children[new YamlScalarNode("pluginState")]).Value);
+        var savedEditorGraphics = Assert.IsType<YamlMappingNode>(
+            savedEditorRoot.Children[new YamlScalarNode("graphics")]);
+        Assert.Equal(
+            "preserved",
+            Assert.IsType<YamlScalarNode>(
+                savedEditorGraphics.Children[new YamlScalarNode("futureOverlay")]).Value);
+
+        var reconnected = await new GraphicsSettingsService(() => workspace.Paths)
+            .EnsureLoadedAsync();
+        Assert.Equal(
+            EditorQualitySelection.Ultra,
+            reconnected.Editor.Graphics.SelectedQuality);
+        Assert.Equal(
+            GraphicsStatsMode.RenderStatsAndQueries,
+            reconnected.Editor.Graphics.StatsMode);
+    }
+
+    [Fact]
+    public async Task EnsureLoadedAsync_FollowsWorkspaceChangesWithoutLeakingOverrides()
+    {
+        using var first = TempWorkspace.Create();
+        using var second = TempWorkspace.Create();
+        await File.WriteAllTextAsync(
+            first.Paths.ProjectSettingsPath,
+            GraphicsSettingsYamlCodec.SerializeProject(GraphicsSettingsDefaults.Project));
+        await File.WriteAllTextAsync(
+            second.Paths.ProjectSettingsPath,
+            GraphicsSettingsYamlCodec.SerializeProject(
+                GraphicsSettingsDefaults.Project with
+                {
+                    Graphics = GraphicsSettingsDefaults.Project.Graphics with
+                    {
+                        DefaultQuality = GraphicsQualityLevel.Low
+                    }
+                }));
+        Directory.CreateDirectory(first.Paths.CacheDirectory);
+        await File.WriteAllTextAsync(
+            first.Paths.EditorSettingsPath,
+            GraphicsSettingsYamlCodec.SerializeEditor(
+                GraphicsSettingsDefaults.Editor with
+                {
+                    Graphics = GraphicsSettingsDefaults.Editor.Graphics with
+                    {
+                        SelectedQuality = EditorQualitySelection.Ultra
+                    }
+                }));
+        var activePaths = first.Paths;
+        var service = new GraphicsSettingsService(() => activePaths);
+
+        var firstSnapshot = await service.EnsureLoadedAsync();
+        activePaths = second.Paths;
+        var secondSnapshot = await service.EnsureLoadedAsync();
+
+        Assert.Equal(EditorQualitySelection.Ultra, firstSnapshot.Editor.Graphics.SelectedQuality);
+        Assert.Equal(GraphicsQualityLevel.Ultra, firstSnapshot.EffectiveQuality);
+        Assert.Equal(EditorQualitySelection.ProjectDefault, secondSnapshot.Editor.Graphics.SelectedQuality);
+        Assert.Equal(GraphicsQualityLevel.Low, secondSnapshot.EffectiveQuality);
+        Assert.Equal(second.Paths, service.Current!.Paths);
+
+        var staleEdit = firstSnapshot.Project with
+        {
+            Graphics = firstSnapshot.Project.Graphics with
+            {
+                DefaultQuality = GraphicsQualityLevel.VeryLow
+            }
+        };
+        var error = await Assert.ThrowsAsync<GraphicsSettingsStaleSnapshotException>(() =>
+            service.ApplyAsync(
+                staleEdit,
+                firstSnapshot.Editor,
+                firstSnapshot));
+        Assert.Contains("active workspace changed", error.Message, StringComparison.OrdinalIgnoreCase);
+        var unchangedSecond = await new GraphicsSettingsService(() => second.Paths)
+            .EnsureLoadedAsync();
+        Assert.Equal(
+            GraphicsQualityLevel.Low,
+            unchangedSecond.Project.Graphics.DefaultQuality);
+    }
+
+    [Fact]
+    public async Task FirstEditorSpecificChange_CreatesResolvedCacheDocumentOnly()
+    {
+        using var workspace = TempWorkspace.Create(customCache: true);
+        await File.WriteAllTextAsync(
+            workspace.Paths.ProjectSettingsPath,
+            GraphicsSettingsYamlCodec.SerializeProject(GraphicsSettingsDefaults.Project));
+        var service = new GraphicsSettingsService(
+            () => workspace.Paths,
+            applyStatsModeAsync: (_, _) => Task.FromResult(true));
+
+        var loaded = await service.EnsureLoadedAsync();
+
+        Assert.False(File.Exists(loaded.Paths.EditorSettingsPath));
+        await service.SetStatsModeAsync(GraphicsStatsMode.RenderStats);
+        Assert.True(File.Exists(loaded.Paths.EditorSettingsPath));
+        Assert.False(File.Exists(Path.Combine(workspace.Root, GraphicsSettingsPaths.EditorFileName)));
+    }
+
+    [Fact]
+    public async Task InvalidYaml_ProducesDiagnosticsAndSafeDefaults()
+    {
+        using var workspace = TempWorkspace.Create();
+        await File.WriteAllTextAsync(
+            workspace.Paths.ProjectSettingsPath,
+            "settingsVersion: 1\ngraphics: [broken");
+
+        var snapshot = await new GraphicsSettingsService(() => workspace.Paths)
+            .EnsureLoadedAsync();
+
+        Assert.Equal(GraphicsQualityLevel.High, snapshot.Project.Graphics.DefaultQuality);
+        Assert.Equal(EditorQualitySelection.ProjectDefault, snapshot.Editor.Graphics.SelectedQuality);
+        Assert.Contains(snapshot.Diagnostics, x => x.Contains("failed to parse YAML", StringComparison.Ordinal));
+        Assert.Contains(snapshot.Diagnostics, x => x.Contains("was not found", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task EnsureLoadedAsync_DiscardsLoadWhenWorkspaceChangesDuringIo()
+    {
+        using var first = TempWorkspace.Create();
+        using var second = TempWorkspace.Create();
+        var activePaths = first.Paths;
+        long generation = 1;
+        var storage = new BlockingInitialLoadStorage(
+            first.Paths,
+            second.Paths);
+        var published = new List<GraphicsSettingsSnapshot>();
+        var service = new GraphicsSettingsService(
+            () => activePaths,
+            storage: storage,
+            workspaceGenerationProvider: () => Volatile.Read(ref generation));
+        service.SettingsChanged += (_, snapshot) => published.Add(snapshot);
+
+        var load = service.EnsureLoadedAsync();
+        await storage.FirstLoadStarted.Task;
+        activePaths = second.Paths;
+        Interlocked.Increment(ref generation);
+        storage.ContinueFirstLoad.TrySetResult(true);
+
+        var snapshot = await load;
+
+        Assert.Equal(second.Paths, snapshot.Paths);
+        Assert.Equal(2, snapshot.WorkspaceGeneration);
+        Assert.Equal(GraphicsQualityLevel.Low, snapshot.Project.Graphics.DefaultQuality);
+        Assert.DoesNotContain(published, value => value.Paths == first.Paths);
+        Assert.Single(published);
+        Assert.Same(snapshot, service.Current);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_DoesNotWritePublishOrRestartWhenQueuedWorkspaceMutationIsStale()
+    {
+        using var first = TempWorkspace.Create();
+        using var second = TempWorkspace.Create();
+        var activePaths = first.Paths;
+        long generation = 7;
+        var storage = new TrackingApplyStorage();
+        var serializer = new BlockingMutationSerializer();
+        var restartCount = 0;
+        var published = new List<GraphicsSettingsSnapshot>();
+        var service = new GraphicsSettingsService(
+            () => activePaths,
+            _ =>
+            {
+                restartCount++;
+                return Task.FromResult(true);
+            },
+            storage: storage,
+            workspaceGenerationProvider: () => Volatile.Read(ref generation),
+            serializeWorkspaceMutationAsync: serializer.RunAsync);
+        service.SettingsChanged += (_, snapshot) => published.Add(snapshot);
+        var loaded = await service.EnsureLoadedAsync();
+        published.Clear();
+        var edited = loaded.Project with
+        {
+            Graphics = loaded.Project.Graphics with
+            {
+                DefaultQuality = GraphicsQualityLevel.Ultra
+            }
+        };
+
+        var apply = service.ApplyAsync(edited, loaded.Editor, loaded);
+        await serializer.MutationWaiting.Task;
+        activePaths = second.Paths;
+        Interlocked.Increment(ref generation);
+        serializer.ContinueMutation.TrySetResult(true);
+
+        await Assert.ThrowsAsync<GraphicsSettingsStaleSnapshotException>(
+            () => apply);
+        Assert.Equal(0, restartCount);
+        Assert.Equal(0, storage.ProjectWriteCount);
+        Assert.Empty(published);
+        Assert.Null(service.Current);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RefusesToOverwriteExternalFileRevision()
+    {
+        using var workspace = TempWorkspace.Create();
+        var original = GraphicsSettingsYamlCodec.SerializeProject(
+            GraphicsSettingsDefaults.Project);
+        await File.WriteAllTextAsync(
+            workspace.Paths.ProjectSettingsPath,
+            original);
+        var service = new GraphicsSettingsService(() => workspace.Paths);
+        var loaded = await service.EnsureLoadedAsync();
+        var external = GraphicsSettingsYamlCodec.SerializeProject(
+            GraphicsSettingsDefaults.Project with
+            {
+                Graphics = GraphicsSettingsDefaults.Project.Graphics with
+                {
+                    DefaultQuality = GraphicsQualityLevel.Low
+                }
+            });
+        await File.WriteAllTextAsync(
+            workspace.Paths.ProjectSettingsPath,
+            external);
+        var editorDraft = loaded.Project with
+        {
+            Graphics = loaded.Project.Graphics with
+            {
+                DefaultQuality = GraphicsQualityLevel.Ultra
+            }
+        };
+
+        await Assert.ThrowsAsync<GraphicsSettingsStaleSnapshotException>(() =>
+            service.ApplyAsync(editorDraft, loaded.Editor, loaded));
+
+        Assert.Equal(
+            external,
+            await File.ReadAllTextAsync(workspace.Paths.ProjectSettingsPath));
+    }
+
+    [Fact]
+    public async Task ApplyAsync_GenerationBoundRestartRejectsWorkspaceSwitchBeforeEffect()
+    {
+        using var first = TempWorkspace.Create();
+        using var second = TempWorkspace.Create();
+        await File.WriteAllTextAsync(
+            first.Paths.ProjectSettingsPath,
+            GraphicsSettingsYamlCodec.SerializeProject(
+                GraphicsSettingsDefaults.Project));
+        var activePaths = first.Paths;
+        long generation = 21;
+        var effectWaiting = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var continueEffect = new TaskCompletionSource<bool>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+        var restartCount = 0;
+        var service = new GraphicsSettingsService(
+            () => activePaths,
+            workspaceGenerationProvider: () => Volatile.Read(ref generation),
+            restartEngineForGenerationAsync: async (expectedGeneration, cancellationToken) =>
+            {
+                effectWaiting.TrySetResult(true);
+                await continueEffect.Task.WaitAsync(cancellationToken);
+                if (expectedGeneration != Volatile.Read(ref generation))
+                    return false;
+                restartCount++;
+                return true;
+            });
+        var loaded = await service.EnsureLoadedAsync();
+        var edited = loaded.Project with
+        {
+            Graphics = loaded.Project.Graphics with
+            {
+                DefaultQuality = GraphicsQualityLevel.Ultra
+            }
+        };
+
+        var apply = service.ApplyAsync(edited, loaded.Editor, loaded);
+        await effectWaiting.Task;
+        activePaths = second.Paths;
+        Interlocked.Increment(ref generation);
+        continueEffect.TrySetResult(true);
+
+        await Assert.ThrowsAsync<GraphicsSettingsStaleSnapshotException>(
+            () => apply);
+        Assert.Equal(0, restartCount);
+        Assert.Equal(
+            GraphicsQualityLevel.Ultra,
+            (await new GraphicsSettingsService(() => first.Paths)
+                .EnsureLoadedAsync()).Project.Graphics.DefaultQuality);
+        Assert.False(File.Exists(second.Paths.ProjectSettingsPath));
+    }
+
+    [Fact]
+    public async Task ApplyAsync_RefusesMalformedYamlWithoutChangingItsBytes()
+    {
+        using var workspace = TempWorkspace.Create();
+        var malformed = "settingsVersion: 1\ngraphics: [broken\nfuture: keep-this-byte-for-byte\n";
+        await File.WriteAllTextAsync(
+            workspace.Paths.ProjectSettingsPath,
+            malformed);
+        var service = new GraphicsSettingsService(() => workspace.Paths);
+        var loaded = await service.EnsureLoadedAsync();
+        var draft = loaded.Project with
+        {
+            Graphics = loaded.Project.Graphics with
+            {
+                DefaultQuality = GraphicsQualityLevel.Ultra
+            }
+        };
+
+        var error = await Assert.ThrowsAsync<GraphicsSettingsPersistenceException>(
+            () => service.ApplyAsync(draft, loaded.Editor, loaded));
+
+        Assert.Contains("malformed", error.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal(
+            malformed,
+            await File.ReadAllTextAsync(workspace.Paths.ProjectSettingsPath));
+    }
+
+    [Fact]
+    public void DraftSession_PreservesDirtyRawValuesAcrossRefreshAndNavigation()
+    {
+        using var workspace = TempWorkspace.Create();
+        var snapshot = new GraphicsSettingsSnapshot(
+            workspace.Paths,
+            11,
+            GraphicsSettingsDefaults.Project,
+            GraphicsSettingsDefaults.Editor,
+            GraphicsSettingsFileRevision.Missing,
+            GraphicsSettingsFileRevision.Missing,
+            []);
+        var session = new GraphicsSettingsDraftSession();
+        var draft = session.GetOrCreate(snapshot);
+        draft.SetSelections(
+            GraphicsQualityLevel.Low,
+            EditorQualitySelection.VeryLow,
+            GraphicsStatsMode.RenderStats);
+        draft.SetPreset(
+            GraphicsQualityLevel.Ultra,
+            draft.GetPreset(GraphicsQualityLevel.Ultra) with
+            {
+                ResolutionFactor = "unfinished-value",
+                ShadowBias = "bias-in-progress"
+            });
+
+        var afterSearchRefresh = session.GetOrCreate(snapshot);
+        var afterCategoryNavigation = session.GetOrCreate(snapshot);
+
+        Assert.Same(draft, afterSearchRefresh);
+        Assert.Same(draft, afterCategoryNavigation);
+        Assert.True(afterCategoryNavigation.IsDirty);
+        Assert.Equal(
+            "unfinished-value",
+            afterCategoryNavigation
+                .GetPreset(GraphicsQualityLevel.Ultra)
+                .ResolutionFactor);
+        Assert.Equal(
+            "bias-in-progress",
+            afterCategoryNavigation
+                .GetPreset(GraphicsQualityLevel.Ultra)
+                .ShadowBias);
+        Assert.Equal(
+            GraphicsQualityLevel.Low,
+            afterCategoryNavigation.ProjectDefaultQuality);
+        Assert.False(afterCategoryNavigation.TryBuild(
+            out _,
+            out _,
+            out var issues));
+        Assert.Contains(
+            issues,
+            issue => issue.Path == "graphics.presets.Ultra.resolutionFactor");
+        Assert.Contains(
+            issues,
+            issue => issue.Path == "graphics.presets.Ultra.shadowBias");
+
+        var reverted = session.Replace(snapshot);
+        Assert.False(reverted.IsDirty);
+        Assert.Equal(
+            "1",
+            reverted.GetPreset(GraphicsQualityLevel.Ultra).ResolutionFactor);
+        Assert.Equal(
+            "0",
+            reverted.GetPreset(GraphicsQualityLevel.Ultra).ShadowBias);
+    }
+
+    static YamlMappingNode LoadRoot(string yaml)
+    {
+        var stream = new YamlStream();
+        using var reader = new StringReader(yaml);
+        stream.Load(reader);
+        return Assert.IsType<YamlMappingNode>(Assert.Single(stream.Documents).RootNode);
+    }
+
+    static string Save(YamlMappingNode root)
+    {
+        using var writer = new StringWriter();
+        new YamlStream(new YamlDocument(root)).Save(writer, false);
+        return writer.ToString();
+    }
+
+    static GraphicsSettingsStorageSnapshot CreateStoredSnapshot(
+        ProjectSettingsDocument project,
+        WorkspaceEditorSettingsDocument? editor = null,
+        string projectRevision = "project-1",
+        GraphicsSettingsFileRevision? editorRevision = null)
+        => new(
+            project,
+            editor ?? GraphicsSettingsDefaults.Editor,
+            GraphicsSettingsFileRevision.Readable(projectRevision),
+            editorRevision ?? GraphicsSettingsFileRevision.Missing,
+            []);
+
+    sealed class BlockingInitialLoadStorage : IGraphicsSettingsStorage
+    {
+        readonly GraphicsSettingsPaths _first;
+        readonly GraphicsSettingsPaths _second;
+        int _loadCount;
+
+        public BlockingInitialLoadStorage(
+            GraphicsSettingsPaths first,
+            GraphicsSettingsPaths second)
+        {
+            _first = first;
+            _second = second;
+        }
+
+        public TaskCompletionSource<bool> FirstLoadStarted { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<bool> ContinueFirstLoad { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task<GraphicsSettingsStorageSnapshot> LoadAsync(
+            GraphicsSettingsPaths paths,
+            CancellationToken cancellationToken)
+        {
+            var call = Interlocked.Increment(ref _loadCount);
+            if (call == 1)
+            {
+                Assert.Equal(_first, paths);
+                FirstLoadStarted.TrySetResult(true);
+                await ContinueFirstLoad.Task.WaitAsync(cancellationToken);
+            }
+            else
+            {
+                Assert.Equal(_second, paths);
+            }
+
+            var quality = paths == _first
+                ? GraphicsQualityLevel.High
+                : GraphicsQualityLevel.Low;
+            return CreateStoredSnapshot(
+                GraphicsSettingsDefaults.Project with
+                {
+                    Graphics = GraphicsSettingsDefaults.Project.Graphics with
+                    {
+                        DefaultQuality = quality
+                    }
+                },
+                projectRevision: $"project-{call}");
+        }
+
+        public Task ValidateForUpdateAsync(
+            string path,
+            GraphicsSettingsFileRevision expectedRevision,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<GraphicsSettingsFileRevision> WriteProjectAsync(
+            string path,
+            ProjectSettingsDocument document,
+            GraphicsSettingsFileRevision expectedRevision,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+
+        public Task<GraphicsSettingsFileRevision> WriteEditorAsync(
+            string path,
+            WorkspaceEditorSettingsDocument document,
+            GraphicsSettingsFileRevision expectedRevision,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    sealed class BlockingMutationSerializer
+    {
+        public TaskCompletionSource<bool> MutationWaiting { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public TaskCompletionSource<bool> ContinueMutation { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public async Task RunAsync(
+            Func<CancellationToken, Task> operation,
+            CancellationToken cancellationToken)
+        {
+            MutationWaiting.TrySetResult(true);
+            await ContinueMutation.Task.WaitAsync(cancellationToken);
+            await operation(cancellationToken);
+        }
+    }
+
+    sealed class TrackingApplyStorage : IGraphicsSettingsStorage
+    {
+        ProjectSettingsDocument _project = GraphicsSettingsDefaults.Project;
+        GraphicsSettingsFileRevision _projectRevision =
+            GraphicsSettingsFileRevision.Readable("project-1");
+        public int ProjectWriteCount { get; private set; }
+
+        public Task<GraphicsSettingsStorageSnapshot> LoadAsync(
+            GraphicsSettingsPaths paths,
+            CancellationToken cancellationToken)
+            => Task.FromResult(CreateStoredSnapshot(
+                _project,
+                projectRevision: _projectRevision.ContentHash));
+
+        public Task ValidateForUpdateAsync(
+            string path,
+            GraphicsSettingsFileRevision expectedRevision,
+            CancellationToken cancellationToken)
+        {
+            if (path.EndsWith(GraphicsSettingsPaths.ProjectFileName, StringComparison.Ordinal))
+                Assert.Equal(_projectRevision, expectedRevision);
+            else
+                Assert.Equal(GraphicsSettingsFileRevision.Missing, expectedRevision);
+            return Task.CompletedTask;
+        }
+
+        public Task<GraphicsSettingsFileRevision> WriteProjectAsync(
+            string path,
+            ProjectSettingsDocument document,
+            GraphicsSettingsFileRevision expectedRevision,
+            CancellationToken cancellationToken)
+        {
+            Assert.Equal(_projectRevision, expectedRevision);
+            ProjectWriteCount++;
+            _project = document;
+            _projectRevision = GraphicsSettingsFileRevision.Readable("project-2");
+            return Task.FromResult(_projectRevision);
+        }
+
+        public Task<GraphicsSettingsFileRevision> WriteEditorAsync(
+            string path,
+            WorkspaceEditorSettingsDocument document,
+            GraphicsSettingsFileRevision expectedRevision,
+            CancellationToken cancellationToken)
+            => throw new NotSupportedException();
+    }
+
+    sealed class TempWorkspace : IDisposable
+    {
+        TempWorkspace(string root, bool customCache)
+        {
+            Root = root;
+            CustomCacheDirectory = Path.Combine(
+                root,
+                customCache ? "Intermediate/Editor Cache" : "Cache");
+            Directory.CreateDirectory(root);
+            Paths = GraphicsSettingsPaths.Create(root, CustomCacheDirectory);
+        }
+
+        public string Root { get; }
+        public string CustomCacheDirectory { get; }
+        public GraphicsSettingsPaths Paths { get; }
+
+        public static TempWorkspace Create(bool customCache = false)
+            => new(
+                Path.Combine(
+                    Path.GetTempPath(),
+                    $"sailor-graphics-settings-{Guid.NewGuid():N}"),
+                customCache);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root))
+                Directory.Delete(Root, recursive: true);
+        }
+    }
+}

--- a/Editor.Tests/GraphicsSettingsTests.cs
+++ b/Editor.Tests/GraphicsSettingsTests.cs
@@ -732,9 +732,9 @@ public sealed class GraphicsSettingsTests
         TempWorkspace(string root, bool customCache)
         {
             Root = root;
-            CustomCacheDirectory = Path.Combine(
-                root,
-                customCache ? "Intermediate/Editor Cache" : "Cache");
+            CustomCacheDirectory = customCache
+                ? Path.Combine(root, "Intermediate", "Editor Cache")
+                : Path.Combine(root, "Cache");
             Directory.CreateDirectory(root);
             Paths = GraphicsSettingsPaths.Create(root, CustomCacheDirectory);
         }

--- a/Editor.Tests/GraphicsSettingsUiContractTests.cs
+++ b/Editor.Tests/GraphicsSettingsUiContractTests.cs
@@ -1,0 +1,99 @@
+namespace SailorEditor.Editor.Tests;
+
+public sealed class GraphicsSettingsUiContractTests
+{
+    [Fact]
+    public void SceneView_ExposesSynchronizedQualityAndStatsSelectors()
+    {
+        var xaml = ReadRepositoryFile("Editor", "Views", "SceneView.xaml");
+        var source = ReadRepositoryFile("Editor", "Views", "SceneView.xaml.cs");
+
+        Assert.Contains("x:Name=\"QualityPicker\"", xaml);
+        Assert.Contains("x:Name=\"StatsModePicker\"", xaml);
+        Assert.Contains("OnQualitySelectedIndexChanged", xaml);
+        Assert.Contains("OnStatsModeSelectedIndexChanged", xaml);
+        Assert.Contains("SetSelectedQualityAsync", source);
+        Assert.Contains("SetStatsModeAsync", source);
+        Assert.Contains("graphicsSettingsService.SettingsChanged +=", source);
+        Assert.Contains("workspaceUiService.ProjectionChanged +=", source);
+    }
+
+    [Fact]
+    public void SettingsPanel_EditsEveryFixedPresetFieldThroughSharedService()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "SettingsPanelView.cs");
+
+        Assert.Contains("Project Default Quality", source);
+        Assert.Contains("Scene View Quality", source);
+        Assert.Contains("Scene View Stats", source);
+        Assert.Contains("Resolution Factor", source);
+        Assert.Contains("FPS Cap", source);
+        Assert.Contains("MSAA", source);
+        Assert.Contains("Shadow Quality Cap", source);
+        Assert.Contains("Shadow Bias", source);
+        Assert.Contains("Shadow Cascade Count", source);
+        Assert.Contains("Cascade Resolutions", source);
+        Assert.Contains("Soft Shadows", source);
+        Assert.Contains("Clouds Resolution Multiplier", source);
+        Assert.Contains("Sky Resolution", source);
+        Assert.Contains("LOD Bias", source);
+        Assert.Contains("Enum.GetValues<GraphicsQualityLevel>()", source);
+        Assert.Contains("_graphicsSettings.ApplyAsync", source);
+        Assert.Contains("draft.TryBuild(", source);
+    }
+
+    [Fact]
+    public void SettingsPanel_UsesBoundedScrollingAndCollapsibleCompactPresets()
+    {
+        var source = ReadRepositoryFile(
+            "Editor",
+            "Views",
+            "SettingsPanelView.cs");
+
+        Assert.Contains("VerticalScrollBarVisibility = ScrollBarVisibility.Always", source);
+        Assert.Contains(
+            "new RowDefinition(GridLength.Auto),\n                " +
+            "new RowDefinition(GridLength.Auto),\n                " +
+            "new RowDefinition(GridLength.Star)\n            ]",
+            source);
+        Assert.DoesNotContain(
+            "new RowDefinition(GridLength.Auto),\n                " +
+            "new RowDefinition(GridLength.Auto),\n                " +
+            "new RowDefinition(GridLength.Auto),\n                " +
+            "new RowDefinition(GridLength.Star)",
+            source);
+        Assert.Contains("fields.IsVisible = initiallyExpanded", source);
+        Assert.Contains("quality == snapshot.EffectiveQuality", source);
+    }
+
+    [Fact]
+    public void DependencyInjection_WiresRestartAndLiveStatsEffects()
+    {
+        var source = ReadRepositoryFile("Editor", "MauiProgram.cs");
+
+        Assert.Contains("new GraphicsSettingsService", source);
+        Assert.Contains("RestartEngineForGenerationAsync", source);
+        Assert.Contains("SetEditorStatsModeAsync(mode, token)", source);
+        Assert.Contains("serializeWorkspaceMutationAsync", source);
+        Assert.Contains("activationCoordinator.State.Generation", source);
+    }
+
+    static string ReadRepositoryFile(params string[] pathParts)
+    {
+        var current = new DirectoryInfo(AppContext.BaseDirectory);
+        while (current is not null)
+        {
+            var path = Path.Combine(
+                new[] { current.FullName }.Concat(pathParts).ToArray());
+            if (File.Exists(path))
+                return File.ReadAllText(path);
+            current = current.Parent;
+        }
+
+        throw new FileNotFoundException(
+            $"Could not locate repository file '{Path.Combine(pathParts)}'.");
+    }
+}

--- a/Editor.Tests/GraphicsSettingsUiContractTests.cs
+++ b/Editor.Tests/GraphicsSettingsUiContractTests.cs
@@ -89,7 +89,7 @@ public sealed class GraphicsSettingsUiContractTests
             var path = Path.Combine(
                 new[] { current.FullName }.Concat(pathParts).ToArray());
             if (File.Exists(path))
-                return File.ReadAllText(path);
+                return File.ReadAllText(path).ReplaceLineEndings("\n");
             current = current.Parent;
         }
 

--- a/Editor.Tests/ShellStateConsistencyTests.cs
+++ b/Editor.Tests/ShellStateConsistencyTests.cs
@@ -95,6 +95,18 @@ public sealed class ShellStateConsistencyTests
         Assert.NotNull(layoutStore.Layout);
     }
 
+    [Fact]
+    public void SplitResizeDragState_PersistsLastAppliedRunningTranslation()
+    {
+        var drag = new SplitResizeDragState();
+
+        drag.Begin();
+        drag.Update(96);
+
+        Assert.Equal(96, drag.Complete());
+        Assert.Equal(0, drag.Translation);
+    }
+
     static PanelInstance CreatePanel(PanelId panelId, PanelTypeId panelTypeId, PanelRole role, string groupId)
         => new(panelId, panelTypeId, panelTypeId.Value, role, new Microsoft.Maui.Controls.Label(), true, groupId);
 

--- a/Editor.Tests/WorkspaceProjectGeneratorTests.cs
+++ b/Editor.Tests/WorkspaceProjectGeneratorTests.cs
@@ -1,4 +1,5 @@
 using SailorEditor.Workspace;
+using SailorEditor.Settings;
 
 namespace SailorEditor.Editor.Tests;
 
@@ -35,6 +36,14 @@ public sealed class WorkspaceProjectGeneratorTests
         Assert.True(File.Exists(workspace.File("Source/WorkspaceTypes.h")));
         Assert.True(File.Exists(workspace.File("Source/WorkspaceModule.cpp")));
         Assert.True(File.Exists(workspace.File(".gitignore")));
+        var projectSettingsPath = workspace.File(GraphicsSettingsPaths.ProjectFileName);
+        Assert.True(File.Exists(projectSettingsPath));
+        var projectSettings = await File.ReadAllTextAsync(projectSettingsPath);
+        Assert.Contains("defaultQuality: High", projectSettings);
+        Assert.Contains("Ultra:", projectSettings);
+        Assert.Contains("fpsCap: 120", projectSettings);
+        Assert.Contains("shadowBias: 0", projectSettings);
+        Assert.Contains("VeryLow:", projectSettings);
         var generatedState = new WorkspaceGeneratedProjectStateService().GetStatePath(workspace.Root);
         Assert.True(File.Exists(generatedState));
         Assert.Equal(generatedState, generated.CreatedFiles.Last());

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -79,6 +79,47 @@ namespace SailorEditor
             builder.Services.AddSingleton<IEditorShellLayoutStore, YamlEditorShellLayoutStore>();
             builder.Services.AddSingleton(sp => new UnifiedSettingsStore(EditorSettingsCatalog.Definitions));
             builder.Services.AddSingleton<EditorSettingsPersistenceStore>();
+            builder.Services.AddSingleton(sp =>
+            {
+                var engineService = sp.GetRequiredService<EngineService>();
+                var activationCoordinator = sp.GetRequiredService<WorkspaceActivationCoordinator>();
+                var workspaceUiService = sp.GetRequiredService<WorkspaceUiService>();
+                return new GraphicsSettingsService(
+                    () =>
+                    {
+                        var launchContext = engineService.GetLaunchContext();
+                        return GraphicsSettingsPaths.Create(
+                            launchContext.WorkspaceRoot,
+                            launchContext.CacheDirectory);
+                    },
+                    restartEngineAsync: null,
+                    applyStatsModeAsync: null,
+                    workspaceGenerationProvider: () =>
+                        activationCoordinator.State.Generation,
+                    serializeWorkspaceMutationAsync: (operation, cancellationToken) =>
+                        activationCoordinator.RunSerializedAsync(
+                            operation,
+                            cancellationToken),
+                    restartEngineForGenerationAsync: (generation, cancellationToken) =>
+                        workspaceUiService.RestartEngineForGenerationAsync(
+                            generation,
+                            cancellationToken),
+                    applyStatsModeForGenerationAsync: async (mode, generation, cancellationToken) =>
+                    {
+                        var applied = false;
+                        await activationCoordinator.RunSerializedAsync(
+                            async token =>
+                            {
+                                if (activationCoordinator.State.Generation != generation)
+                                    return;
+                                applied = await engineService
+                                    .SetEditorStatsModeAsync(mode, token)
+                                    .ConfigureAwait(false);
+                            },
+                            cancellationToken).ConfigureAwait(false);
+                        return applied;
+                    });
+            });
             builder.Services.AddSingleton<EditorShellHost>();
             builder.Services.AddSingleton<IAIAgentInstructionsProvider, MarkdownAIAgentInstructionsProvider>();
             builder.Services.AddSingleton<IAIEditorContextProvider, EditorAIContextProvider>();

--- a/Editor/Platforms/MacCatalyst/NativeSceneViewportHandler.MacCatalyst.cs
+++ b/Editor/Platforms/MacCatalyst/NativeSceneViewportHandler.MacCatalyst.cs
@@ -54,8 +54,26 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
             return;
         }
 
-        var nextBounds = new CGRect(0, 0, Math.Max(width, 1), Math.Max(height, 1));
+        var platformBounds = PlatformView?.Bounds ?? CGRect.Empty;
+        var nextBounds = ResolveLayoutBounds(platformBounds, width, height);
         var nextContentsScale = contentsScale > 0 ? (nfloat)contentsScale : UIScreen.MainScreen.Scale;
+        QueueLayoutUpdate(nextBounds, nextContentsScale);
+    }
+
+    void UpdatePlatformLayout(CGRect platformBounds, nfloat contentsScale)
+    {
+        if (!isConnected || platformBounds.Width <= 0 || platformBounds.Height <= 0)
+        {
+            return;
+        }
+
+        QueueLayoutUpdate(
+            ResolveLayoutBounds(platformBounds, platformBounds.Width, platformBounds.Height),
+            contentsScale > 0 ? contentsScale : UIScreen.MainScreen.Scale);
+    }
+
+    void QueueLayoutUpdate(CGRect nextBounds, nfloat nextContentsScale)
+    {
         if (currentBounds.Equals(nextBounds) && Math.Abs((double)(currentContentsScale - nextContentsScale)) < 0.01)
         {
             return;
@@ -72,6 +90,13 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
 
         layoutFlushQueued = true;
         DispatchQueue.MainQueue.DispatchAsync(FlushPendingLayout);
+    }
+
+    static CGRect ResolveLayoutBounds(CGRect platformBounds, double fallbackWidth, double fallbackHeight)
+    {
+        var width = platformBounds.Width > 0 ? platformBounds.Width : Math.Max(fallbackWidth, 1);
+        var height = platformBounds.Height > 0 ? platformBounds.Height : Math.Max(fallbackHeight, 1);
+        return new CGRect(0, 0, width, height);
     }
 
     public void RequestInputFocus()
@@ -296,6 +321,15 @@ public sealed class NativeSceneViewportHandler : ViewHandler<NativeSceneViewport
         }
 
         public override bool CanBecomeFirstResponder => true;
+
+        public override void LayoutSubviews()
+        {
+            base.LayoutSubviews();
+            if (owner.TryGetTarget(out var handler))
+            {
+                handler.UpdatePlatformLayout(Bounds, ContentScaleFactor);
+            }
+        }
 
         public void FocusInput()
         {

--- a/Editor/Protocol/EngineProtocolClient.cs
+++ b/Editor/Protocol/EngineProtocolClient.cs
@@ -445,6 +445,27 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                 .ConfigureAwait(false),
             nameof(ProtocolRequest.GetEditorSimulationState));
 
+    public async Task<bool> SetEditorStatsModeAsync(
+        EditorStatsMode mode,
+        CancellationToken cancellationToken = default)
+    {
+        if (mode == EditorStatsMode.Unspecified || !Enum.IsDefined(mode))
+            throw new ArgumentOutOfRangeException(nameof(mode));
+
+        return ReadBool(
+            await SendAsync(
+                    new ProtocolRequest
+                    {
+                        SetEditorStatsMode = new EditorStatsModeRequest
+                        {
+                            Mode = mode
+                        }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.SetEditorStatsMode));
+    }
+
     public async Task<bool> PreviewAudioAssetAsync(
         string fileId,
         CancellationToken cancellationToken = default)

--- a/Editor/Protocol/Generated/EditorEngine.cs
+++ b/Editor/Protocol/Generated/EditorEngine.cs
@@ -25,7 +25,7 @@ namespace SailorEditor.Protocol.Generated {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "ChNlZGl0b3JfZW5naW5lLnByb3RvEhBzYWlsb3IuZWRpdG9yLnYxIgcKBUVt",
-            "cHR5IqgdCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
+            "cHR5IvMdCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
             "IAEoDRISCgpyZXF1ZXN0X2lkGAIgASgEEjkKCmluaXRpYWxpemUYCiABKAsy",
             "Iy5zYWlsb3IuZWRpdG9yLnYxLkluaXRpYWxpemVSZXF1ZXN0SAASKAoFc3Rh",
             "cnQYCyABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASJwoEc3RvcBgM",
@@ -106,152 +106,159 @@ namespace SailorEditor.Protocol.Generated {
             "aXRvci52MS5FZGl0b3JTaW11bGF0aW9uUmVxdWVzdEgAEj4KG2dldF9lZGl0",
             "b3Jfc2ltdWxhdGlvbl9zdGF0ZRg+IAEoCzIXLnNhaWxvci5lZGl0b3IudjEu",
             "RW1wdHlIABI+ChNwcmV2aWV3X2F1ZGlvX2Fzc2V0GD8gASgLMh8uc2FpbG9y",
-            "LmVkaXRvci52MS5GaWxlSWRSZXF1ZXN0SABCCQoHY29tbWFuZEoECAMQCkoE",
-            "CDIQM0oECEAQZFIYY3JlYXRlX21vZGVsX2dhbWVfb2JqZWN0Uh5yZXNvbHZl",
-            "X3ZpZXdwb3J0X2Ryb3BfcG9zaXRpb24i3gcKEFByb3RvY29sUmVzcG9uc2US",
-            "GAoQcHJvdG9jb2xfdmVyc2lvbhgBIAEoDRISCgpyZXF1ZXN0X2lkGAIgASgE",
-            "Eg8KB3N1Y2Nlc3MYAyABKAgSDQoFZXJyb3IYBCABKAkSJAocc3VwcG9ydHNf",
-            "c3RyaWN0X2luc3RhbmNlX2lkcxgFIAEoCBIvCgxlbXB0eV9yZXN1bHQYCiAB",
-            "KAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASMwoLYm9vbF9yZXN1bHQY",
-            "CyABKAsyHC5zYWlsb3IuZWRpdG9yLnYxLkJvb2xSZXN1bHRIABI1CgxpbnQz",
-            "Ml9yZXN1bHQYDCABKAsyHS5zYWlsb3IuZWRpdG9yLnYxLkludDMyUmVzdWx0",
-            "SAASNwoNdWludDMyX3Jlc3VsdBgNIAEoCzIeLnNhaWxvci5lZGl0b3IudjEu",
-            "VUludDMyUmVzdWx0SAASNwoNdWludDY0X3Jlc3VsdBgOIAEoCzIeLnNhaWxv",
-            "ci5lZGl0b3IudjEuVUludDY0UmVzdWx0SAASNwoNc3RyaW5nX3Jlc3VsdBgP",
-            "IAEoCzIeLnNhaWxvci5lZGl0b3IudjEuU3RyaW5nUmVzdWx0SAASQAoSc3Ry",
-            "aW5nX2xpc3RfcmVzdWx0GBAgASgLMiIuc2FpbG9yLmVkaXRvci52MS5TdHJp",
-            "bmdMaXN0UmVzdWx0SAASTQoZYXNzZXRfcmVsb2FkX3N0YXRlX3Jlc3VsdBgR",
-            "IAEoCzIoLnNhaWxvci5lZGl0b3IudjEuQXNzZXRSZWxvYWRTdGF0ZVJlc3Vs",
-            "dEgAEkAKEmluc3RhbmNlX2lkX3Jlc3VsdBgSIAEoCzIiLnNhaWxvci5lZGl0",
-            "b3IudjEuSW5zdGFuY2VJZFJlc3VsdEgAElEKG3ZpZXdwb3J0X2V2ZW50X2Jh",
-            "dGNoX3Jlc3VsdBgTIAEoCzIqLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRF",
-            "dmVudEJhdGNoUmVzdWx0SAASOQoOdmVjdG9yNF9yZXN1bHQYFCABKAsyHy5z",
-            "YWlsb3IuZWRpdG9yLnYxLlZlY3RvcjRSZXN1bHRIABJPChp2aWV3cG9ydF90",
-            "b29sX3N0YXRlX3Jlc3VsdBgVIAEoCzIpLnNhaWxvci5lZGl0b3IudjEuVmll",
-            "d3BvcnRUb29sU3RhdGVSZXN1bHRIABJGChVhbmltYXRvcl9zdGF0ZV9yZXN1",
-            "bHQYFiABKAsyJS5zYWlsb3IuZWRpdG9yLnYxLkFuaW1hdG9yU3RhdGVSZXN1",
-            "bHRIAEIICgZyZXN1bHRKBAgGEApKBAgXEGQiJgoRSW5pdGlhbGl6ZVJlcXVl",
-            "c3QSEQoJYXJndW1lbnRzGAEgAygJIiEKDENvdW50UmVxdWVzdBIRCgltYXhf",
-            "Y291bnQYASABKA0iIAoNRmlsZUlkUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJ",
-            "IucBChpDcmVhdGVNb2RlbEluc3RhbmNlUmVxdWVzdBIVCg1tb2RlbF9maWxl",
-            "X2lkGAEgASgJEgwKBG5hbWUYAiABKAkSGgoScGFyZW50X2luc3RhbmNlX2lk",
-            "GAMgASgJEhgKEGNyZWF0ZV9oaWVyYXJjaHkYBCABKAgSHAoUYXBwbHlfd29y",
-            "bGRfcG9zaXRpb24YBSABKAgSMQoOd29ybGRfcG9zaXRpb24YBiABKAsyGS5z",
-            "YWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQSHQoVcHJlZmVycmVkX2luc3RhbmNl",
-            "X2lkGAcgASgJIigKEUluc3RhbmNlSWRSZXF1ZXN0EhMKC2luc3RhbmNlX2lk",
-            "GAEgASgJIigKEVZpZXdwb3J0SWRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEg",
-            "ASgEImAKE1ZpZXdwb3J0UmVjdFJlcXVlc3QSFAoMd2luZG93X3Bvc194GAEg",
-            "ASgNEhQKDHdpbmRvd19wb3NfeRgCIAEoDRINCgV3aWR0aBgDIAEoDRIOCgZo",
-            "ZWlnaHQYBCABKA0iLAoLU2l6ZVJlcXVlc3QSDQoFd2lkdGgYASABKA0SDgoG",
-            "aGVpZ2h0GAIgASgNIioKF0VkaXRvclNpbXVsYXRpb25SZXF1ZXN0Eg8KB2Vu",
-            "YWJsZWQYASABKAgimQEKFVJlbW90ZVZpZXdwb3J0UmVxdWVzdBITCgt2aWV3",
-            "cG9ydF9pZBgBIAEoBBIUCgx3aW5kb3dfcG9zX3gYAiABKA0SFAoMd2luZG93",
-            "X3Bvc195GAMgASgNEg0KBXdpZHRoGAQgASgNEg4KBmhlaWdodBgFIAEoDRIP",
-            "Cgd2aXNpYmxlGAYgASgIEg8KB2ZvY3VzZWQYByABKAgiZQoZUmVtb3RlVmll",
-            "d3BvcnRIb3N0UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIYChBob3N0",
-            "X2hhbmRsZV9raW5kGAIgASgNEhkKEWhvc3RfaGFuZGxlX3ZhbHVlGAMgASgE",
-            "IvwBChpSZW1vdGVWaWV3cG9ydElucHV0UmVxdWVzdBITCgt2aWV3cG9ydF9p",
-            "ZBgBIAEoBBIMCgRraW5kGAIgASgNEhEKCXBvaW50ZXJfeBgDIAEoAhIRCglw",
-            "b2ludGVyX3kYBCABKAISFQoNd2hlZWxfZGVsdGFfeBgFIAEoAhIVCg13aGVl",
-            "bF9kZWx0YV95GAYgASgCEhAKCGtleV9jb2RlGAcgASgNEg4KBmJ1dHRvbhgI",
-            "IAEoDRIRCgltb2RpZmllcnMYCSABKA0SDwoHcHJlc3NlZBgKIAEoCBIPCgdm",
-            "b2N1c2VkGAsgASgIEhAKCGNhcHR1cmVkGAwgASgIIkMKHk1hbmFnZWRNdXRh",
-            "dGlvblJldmlzaW9uUmVxdWVzdBIMCgRraW5kGAEgASgNEhMKC2luc3RhbmNl",
-            "X2lkGAIgASgJIkAKE1VwZGF0ZU9iamVjdFJlcXVlc3QSEwoLaW5zdGFuY2Vf",
-            "aWQYASABKAkSFAoMeWFtbF9jaGFuZ2VzGAIgASgJImYKFVJlcGFyZW50T2Jq",
-            "ZWN0UmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCRIaChJwYXJlbnRfaW5z",
-            "dGFuY2VfaWQYAiABKAkSHAoUa2VlcF93b3JsZF90cmFuc2Zvcm0YAyABKAgi",
-            "VAoXQ3JlYXRlR2FtZU9iamVjdFJlcXVlc3QSGgoScGFyZW50X2luc3RhbmNl",
-            "X2lkGAEgASgJEh0KFXByZWZlcnJlZF9pbnN0YW5jZV9pZBgCIAEoCSJmChNB",
-            "ZGRDb21wb25lbnRSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJEhsKE2Nv",
-            "bXBvbmVudF90eXBlX25hbWUYAiABKAkSHQoVcHJlZmVycmVkX2luc3RhbmNl",
-            "X2lkGAMgASgJIuYBChhBbmltYXRvclBhcmFtZXRlclJlcXVlc3QSEwoLaW5z",
-            "dGFuY2VfaWQYASABKAkSDAoEbmFtZRgCIAEoCRIVCgtmbG9hdF92YWx1ZRgD",
-            "IAEoAkgAEhMKCWludF92YWx1ZRgEIAEoEUgAEhQKCmJvb2xfdmFsdWUYBSAB",
-            "KAhIABIqCgd0cmlnZ2VyGAYgASgLMhcuc2FpbG9yLmVkaXRvci52MS5FbXB0",
-            "eUgAEjAKDXJlc2V0X3RyaWdnZXIYByABKAsyFy5zYWlsb3IuZWRpdG9yLnYx",
-            "LkVtcHR5SABCBwoFdmFsdWUiRwoYSW5zdGFudGlhdGVQcmVmYWJSZXF1ZXN0",
-            "Eg8KB2ZpbGVfaWQYASABKAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAIgASgJ",
-            "InAKIEluc3RhbnRpYXRlUHJlZmFiRnJvbVlhbWxSZXF1ZXN0EhMKC3ByZWZh",
-            "Yl95YW1sGAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIbChNz",
-            "dHJpY3RfaW5zdGFuY2VfaWRzGAMgASgIIlUKElZpZXdwb3J0UmF5UmVxdWVz",
-            "dBITCgt2aWV3cG9ydF9pZBgBIAEoBBIUCgxub3JtYWxpemVkX3gYAiABKAIS",
-            "FAoMbm9ybWFsaXplZF95GAMgASgCIqABCiBJbnN0YW50aWF0ZVByZWZhYklu",
-            "c3RhbmNlUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJEhoKEnBhcmVudF9pbnN0",
-            "YW5jZV9pZBgCIAEoCRIcChRhcHBseV93b3JsZF9wb3NpdGlvbhgDIAEoCBIx",
-            "Cg53b3JsZF9wb3NpdGlvbhgEIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVj",
-            "dG9yNCJBChVWaWV3cG9ydE9iamVjdFJlcXVlc3QSEwoLdmlld3BvcnRfaWQY",
-            "ASABKAQSEwoLaW5zdGFuY2VfaWQYAiABKAkiOQoRUHJlZmFiTGlua1JlcXVl",
-            "c3QSEwoLaW5zdGFuY2VfaWQYASABKAkSDwoHZmlsZV9pZBgCIAEoCSKpAQoY",
-            "Vmlld3BvcnRUb29sU3RhdGVSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgE",
-            "Ej8KCW9wZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmlld3Bv",
-            "cnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAyABKA4yKC5zYWlsb3Iu",
-            "ZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2UiKAoQU2VsZWN0aW9u",
-            "UmVxdWVzdBIUCgxpbnN0YW5jZV9pZHMYASADKAkiJQoVU2hvd01haW5XaW5k",
-            "b3dSZXF1ZXN0EgwKBHNob3cYASABKAgiiAEKHFJlbmRlclBhdGhUcmFjZWRJ",
-            "bWFnZVJlcXVlc3QSEwoLb3V0cHV0X3BhdGgYASABKAkSEwoLaW5zdGFuY2Vf",
-            "aWQYAiABKAkSDgoGaGVpZ2h0GAMgASgNEhkKEXNhbXBsZXNfcGVyX3BpeGVs",
-            "GAQgASgNEhMKC21heF9ib3VuY2VzGAUgASgNIhsKCkJvb2xSZXN1bHQSDQoF",
-            "dmFsdWUYASABKAgiHAoLSW50MzJSZXN1bHQSDQoFdmFsdWUYASABKAUiHQoM",
-            "VUludDMyUmVzdWx0Eg0KBXZhbHVlGAEgASgNIh0KDFVJbnQ2NFJlc3VsdBIN",
-            "CgV2YWx1ZRgBIAEoBCIwCgxTdHJpbmdSZXN1bHQSEQoJaGFzX3ZhbHVlGAEg",
-            "ASgIEg0KBXZhbHVlGAIgASgJIiIKEFN0cmluZ0xpc3RSZXN1bHQSDgoGdmFs",
-            "dWVzGAEgAygJIoQBChZBc3NldFJlbG9hZFN0YXRlUmVzdWx0EhEKCWF2YWls",
-            "YWJsZRgBIAEoCBIaChJyZXF1ZXN0X2dlbmVyYXRpb24YAiABKAQSHAoUY29t",
-            "cGxldGVkX2dlbmVyYXRpb24YAyABKAQSHQoVc3VjY2Vzc2Z1bF9nZW5lcmF0",
-            "aW9uGAQgASgEIjoKEEluc3RhbmNlSWRSZXN1bHQSEQoJc3VjY2VlZGVkGAEg",
-            "ASgIEhMKC2luc3RhbmNlX2lkGAIgASgJIjkKDVZlY3RvcjRSZXN1bHQSKAoF",
-            "dmFsdWUYASABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQikwEKF1Zp",
-            "ZXdwb3J0VG9vbFN0YXRlUmVzdWx0Ej8KCW9wZXJhdGlvbhgBIAEoDjIsLnNh",
-            "aWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoF",
-            "c3BhY2UYAiABKA4yKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNm",
-            "b3JtU3BhY2UiqAIKE0FuaW1hdG9yU3RhdGVSZXN1bHQSFgoOaGFzX2NvbnRy",
-            "b2xsZXIYASABKAgSGwoTY29udHJvbGxlcl9yZXZpc2lvbhgCIAEoBBIXCg9h",
-            "Y3RpdmVfc3RhdGVfaWQYAyABKAQSGQoRYWN0aXZlX3N0YXRlX25hbWUYBCAB",
-            "KAkSGQoRYWN0aXZlX3N0YXRlX3RpbWUYBSABKAISFQoNdHJhbnNpdGlvbmlu",
-            "ZxgGIAEoCBIcChRkZXN0aW5hdGlvbl9zdGF0ZV9pZBgHIAEoBBIeChZkZXN0",
-            "aW5hdGlvbl9zdGF0ZV9uYW1lGAggASgJEh4KFmRlc3RpbmF0aW9uX3N0YXRl",
-            "X3RpbWUYCSABKAISGAoQdHJhbnNpdGlvbl9hbHBoYRgKIAEoAiI1CgdWZWN0",
-            "b3I0EgkKAXgYASABKAISCQoBeRgCIAEoAhIJCgF6GAMgASgCEgkKAXcYBCAB",
-            "KAIiNgoWVmlld3BvcnRTZWxlY3Rpb25FdmVudBIcChRzZWxlY3RlZF9pbnN0",
-            "YW5jZV9pZBgBIAEoCSLWAwoWVmlld3BvcnRUcmFuc2Zvcm1FdmVudBITCgtp",
-            "bnN0YW5jZV9pZBgBIAEoCRI/CglvcGVyYXRpb24YAiABKA4yLC5zYWlsb3Iu",
-            "ZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtT3BlcmF0aW9uEjcKBXNwYWNl",
-            "GAMgASgOMiguc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybVNw",
-            "YWNlEjIKD2JlZm9yZV9wb3NpdGlvbhgEIAEoCzIZLnNhaWxvci5lZGl0b3Iu",
-            "djEuVmVjdG9yNBIyCg9iZWZvcmVfcm90YXRpb24YBSABKAsyGS5zYWlsb3Iu",
-            "ZWRpdG9yLnYxLlZlY3RvcjQSLwoMYmVmb3JlX3NjYWxlGAYgASgLMhkuc2Fp",
-            "bG9yLmVkaXRvci52MS5WZWN0b3I0EjEKDmFmdGVyX3Bvc2l0aW9uGAcgASgL",
-            "Mhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0EjEKDmFmdGVyX3JvdGF0aW9u",
-            "GAggASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0Ei4KC2FmdGVyX3Nj",
-            "YWxlGAkgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0IlUKFlZpZXdw",
-            "b3J0QXNzZXREcm9wRXZlbnQSDwoHZmlsZV9pZBgBIAEoCRIUCgxub3JtYWxp",
-            "emVkX3gYAiABKAISFAoMbm9ybWFsaXplZF95GAMgASgCIi0KGVZpZXdwb3J0",
-            "VG9vbFNob3J0Y3V0RXZlbnQSEAoIa2V5X2NvZGUYASABKA0i2QIKDVZpZXdw",
-            "b3J0RXZlbnQSEAoIcmV2aXNpb24YASABKAQSIQoZbWFuYWdlZF9tdXRhdGlv",
-            "bl9yZXZpc2lvbhgCIAEoBBI9CglzZWxlY3Rpb24YCiABKAsyKC5zYWlsb3Iu",
-            "ZWRpdG9yLnYxLlZpZXdwb3J0U2VsZWN0aW9uRXZlbnRIABI9Cgl0cmFuc2Zv",
-            "cm0YCyABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3Jt",
-            "RXZlbnRIABI+Cgphc3NldF9kcm9wGAwgASgLMiguc2FpbG9yLmVkaXRvci52",
-            "MS5WaWV3cG9ydEFzc2V0RHJvcEV2ZW50SAASRAoNdG9vbF9zaG9ydGN1dBgN",
-            "IAEoCzIrLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUb29sU2hvcnRjdXRF",
-            "dmVudEgAQgkKB3BheWxvYWRKBAgDEAoiSwoYVmlld3BvcnRFdmVudEJhdGNo",
-            "UmVzdWx0Ei8KBmV2ZW50cxgBIAMoCzIfLnNhaWxvci5lZGl0b3IudjEuVmll",
-            "d3BvcnRFdmVudCrwAQoaVmlld3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24SLAoo",
-            "VklFV1BPUlRfVFJBTlNGT1JNX09QRVJBVElPTl9VTlNQRUNJRklFRBAAEicK",
-            "I1ZJRVdQT1JUX1RSQU5TRk9STV9PUEVSQVRJT05fU0VMRUNUEAESKgomVklF",
-            "V1BPUlRfVFJBTlNGT1JNX09QRVJBVElPTl9UUkFOU0xBVEUQAhInCiNWSUVX",
-            "UE9SVF9UUkFOU0ZPUk1fT1BFUkFUSU9OX1JPVEFURRADEiYKIlZJRVdQT1JU",
-            "X1RSQU5TRk9STV9PUEVSQVRJT05fU0NBTEUQBCqKAQoWVmlld3BvcnRUcmFu",
-            "c2Zvcm1TcGFjZRIoCiRWSUVXUE9SVF9UUkFOU0ZPUk1fU1BBQ0VfVU5TUEVD",
-            "SUZJRUQQABIiCh5WSUVXUE9SVF9UUkFOU0ZPUk1fU1BBQ0VfV09STEQQARIi",
-            "Ch5WSUVXUE9SVF9UUkFOU0ZPUk1fU1BBQ0VfTE9DQUwQAkIiqgIfU2FpbG9y",
-            "RWRpdG9yLlByb3RvY29sLkdlbmVyYXRlZGIGcHJvdG8z"));
+            "LmVkaXRvci52MS5GaWxlSWRSZXF1ZXN0SAASSQoVc2V0X2VkaXRvcl9zdGF0",
+            "c19tb2RlGEAgASgLMiguc2FpbG9yLmVkaXRvci52MS5FZGl0b3JTdGF0c01v",
+            "ZGVSZXF1ZXN0SABCCQoHY29tbWFuZEoECAMQCkoECDIQM0oECEEQZFIYY3Jl",
+            "YXRlX21vZGVsX2dhbWVfb2JqZWN0Uh5yZXNvbHZlX3ZpZXdwb3J0X2Ryb3Bf",
+            "cG9zaXRpb24i3gcKEFByb3RvY29sUmVzcG9uc2USGAoQcHJvdG9jb2xfdmVy",
+            "c2lvbhgBIAEoDRISCgpyZXF1ZXN0X2lkGAIgASgEEg8KB3N1Y2Nlc3MYAyAB",
+            "KAgSDQoFZXJyb3IYBCABKAkSJAocc3VwcG9ydHNfc3RyaWN0X2luc3RhbmNl",
+            "X2lkcxgFIAEoCBIvCgxlbXB0eV9yZXN1bHQYCiABKAsyFy5zYWlsb3IuZWRp",
+            "dG9yLnYxLkVtcHR5SAASMwoLYm9vbF9yZXN1bHQYCyABKAsyHC5zYWlsb3Iu",
+            "ZWRpdG9yLnYxLkJvb2xSZXN1bHRIABI1CgxpbnQzMl9yZXN1bHQYDCABKAsy",
+            "HS5zYWlsb3IuZWRpdG9yLnYxLkludDMyUmVzdWx0SAASNwoNdWludDMyX3Jl",
+            "c3VsdBgNIAEoCzIeLnNhaWxvci5lZGl0b3IudjEuVUludDMyUmVzdWx0SAAS",
+            "NwoNdWludDY0X3Jlc3VsdBgOIAEoCzIeLnNhaWxvci5lZGl0b3IudjEuVUlu",
+            "dDY0UmVzdWx0SAASNwoNc3RyaW5nX3Jlc3VsdBgPIAEoCzIeLnNhaWxvci5l",
+            "ZGl0b3IudjEuU3RyaW5nUmVzdWx0SAASQAoSc3RyaW5nX2xpc3RfcmVzdWx0",
+            "GBAgASgLMiIuc2FpbG9yLmVkaXRvci52MS5TdHJpbmdMaXN0UmVzdWx0SAAS",
+            "TQoZYXNzZXRfcmVsb2FkX3N0YXRlX3Jlc3VsdBgRIAEoCzIoLnNhaWxvci5l",
+            "ZGl0b3IudjEuQXNzZXRSZWxvYWRTdGF0ZVJlc3VsdEgAEkAKEmluc3RhbmNl",
+            "X2lkX3Jlc3VsdBgSIAEoCzIiLnNhaWxvci5lZGl0b3IudjEuSW5zdGFuY2VJ",
+            "ZFJlc3VsdEgAElEKG3ZpZXdwb3J0X2V2ZW50X2JhdGNoX3Jlc3VsdBgTIAEo",
+            "CzIqLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRFdmVudEJhdGNoUmVzdWx0",
+            "SAASOQoOdmVjdG9yNF9yZXN1bHQYFCABKAsyHy5zYWlsb3IuZWRpdG9yLnYx",
+            "LlZlY3RvcjRSZXN1bHRIABJPChp2aWV3cG9ydF90b29sX3N0YXRlX3Jlc3Vs",
+            "dBgVIAEoCzIpLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUb29sU3RhdGVS",
+            "ZXN1bHRIABJGChVhbmltYXRvcl9zdGF0ZV9yZXN1bHQYFiABKAsyJS5zYWls",
+            "b3IuZWRpdG9yLnYxLkFuaW1hdG9yU3RhdGVSZXN1bHRIAEIICgZyZXN1bHRK",
+            "BAgGEApKBAgXEGQiJgoRSW5pdGlhbGl6ZVJlcXVlc3QSEQoJYXJndW1lbnRz",
+            "GAEgAygJIiEKDENvdW50UmVxdWVzdBIRCgltYXhfY291bnQYASABKA0iIAoN",
+            "RmlsZUlkUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJIucBChpDcmVhdGVNb2Rl",
+            "bEluc3RhbmNlUmVxdWVzdBIVCg1tb2RlbF9maWxlX2lkGAEgASgJEgwKBG5h",
+            "bWUYAiABKAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAMgASgJEhgKEGNyZWF0",
+            "ZV9oaWVyYXJjaHkYBCABKAgSHAoUYXBwbHlfd29ybGRfcG9zaXRpb24YBSAB",
+            "KAgSMQoOd29ybGRfcG9zaXRpb24YBiABKAsyGS5zYWlsb3IuZWRpdG9yLnYx",
+            "LlZlY3RvcjQSHQoVcHJlZmVycmVkX2luc3RhbmNlX2lkGAcgASgJIigKEUlu",
+            "c3RhbmNlSWRSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJIigKEVZpZXdw",
+            "b3J0SWRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEImAKE1ZpZXdwb3J0",
+            "UmVjdFJlcXVlc3QSFAoMd2luZG93X3Bvc194GAEgASgNEhQKDHdpbmRvd19w",
+            "b3NfeRgCIAEoDRINCgV3aWR0aBgDIAEoDRIOCgZoZWlnaHQYBCABKA0iLAoL",
+            "U2l6ZVJlcXVlc3QSDQoFd2lkdGgYASABKA0SDgoGaGVpZ2h0GAIgASgNIioK",
+            "F0VkaXRvclNpbXVsYXRpb25SZXF1ZXN0Eg8KB2VuYWJsZWQYASABKAgiSQoW",
+            "RWRpdG9yU3RhdHNNb2RlUmVxdWVzdBIvCgRtb2RlGAEgASgOMiEuc2FpbG9y",
+            "LmVkaXRvci52MS5FZGl0b3JTdGF0c01vZGUimQEKFVJlbW90ZVZpZXdwb3J0",
+            "UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIUCgx3aW5kb3dfcG9zX3gY",
+            "AiABKA0SFAoMd2luZG93X3Bvc195GAMgASgNEg0KBXdpZHRoGAQgASgNEg4K",
+            "BmhlaWdodBgFIAEoDRIPCgd2aXNpYmxlGAYgASgIEg8KB2ZvY3VzZWQYByAB",
+            "KAgiZQoZUmVtb3RlVmlld3BvcnRIb3N0UmVxdWVzdBITCgt2aWV3cG9ydF9p",
+            "ZBgBIAEoBBIYChBob3N0X2hhbmRsZV9raW5kGAIgASgNEhkKEWhvc3RfaGFu",
+            "ZGxlX3ZhbHVlGAMgASgEIvwBChpSZW1vdGVWaWV3cG9ydElucHV0UmVxdWVz",
+            "dBITCgt2aWV3cG9ydF9pZBgBIAEoBBIMCgRraW5kGAIgASgNEhEKCXBvaW50",
+            "ZXJfeBgDIAEoAhIRCglwb2ludGVyX3kYBCABKAISFQoNd2hlZWxfZGVsdGFf",
+            "eBgFIAEoAhIVCg13aGVlbF9kZWx0YV95GAYgASgCEhAKCGtleV9jb2RlGAcg",
+            "ASgNEg4KBmJ1dHRvbhgIIAEoDRIRCgltb2RpZmllcnMYCSABKA0SDwoHcHJl",
+            "c3NlZBgKIAEoCBIPCgdmb2N1c2VkGAsgASgIEhAKCGNhcHR1cmVkGAwgASgI",
+            "IkMKHk1hbmFnZWRNdXRhdGlvblJldmlzaW9uUmVxdWVzdBIMCgRraW5kGAEg",
+            "ASgNEhMKC2luc3RhbmNlX2lkGAIgASgJIkAKE1VwZGF0ZU9iamVjdFJlcXVl",
+            "c3QSEwoLaW5zdGFuY2VfaWQYASABKAkSFAoMeWFtbF9jaGFuZ2VzGAIgASgJ",
+            "ImYKFVJlcGFyZW50T2JqZWN0UmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEo",
+            "CRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAiABKAkSHAoUa2VlcF93b3JsZF90",
+            "cmFuc2Zvcm0YAyABKAgiVAoXQ3JlYXRlR2FtZU9iamVjdFJlcXVlc3QSGgoS",
+            "cGFyZW50X2luc3RhbmNlX2lkGAEgASgJEh0KFXByZWZlcnJlZF9pbnN0YW5j",
+            "ZV9pZBgCIAEoCSJmChNBZGRDb21wb25lbnRSZXF1ZXN0EhMKC2luc3RhbmNl",
+            "X2lkGAEgASgJEhsKE2NvbXBvbmVudF90eXBlX25hbWUYAiABKAkSHQoVcHJl",
+            "ZmVycmVkX2luc3RhbmNlX2lkGAMgASgJIuYBChhBbmltYXRvclBhcmFtZXRl",
+            "clJlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkSDAoEbmFtZRgCIAEoCRIV",
+            "CgtmbG9hdF92YWx1ZRgDIAEoAkgAEhMKCWludF92YWx1ZRgEIAEoEUgAEhQK",
+            "CmJvb2xfdmFsdWUYBSABKAhIABIqCgd0cmlnZ2VyGAYgASgLMhcuc2FpbG9y",
+            "LmVkaXRvci52MS5FbXB0eUgAEjAKDXJlc2V0X3RyaWdnZXIYByABKAsyFy5z",
+            "YWlsb3IuZWRpdG9yLnYxLkVtcHR5SABCBwoFdmFsdWUiRwoYSW5zdGFudGlh",
+            "dGVQcmVmYWJSZXF1ZXN0Eg8KB2ZpbGVfaWQYASABKAkSGgoScGFyZW50X2lu",
+            "c3RhbmNlX2lkGAIgASgJInAKIEluc3RhbnRpYXRlUHJlZmFiRnJvbVlhbWxS",
+            "ZXF1ZXN0EhMKC3ByZWZhYl95YW1sGAEgASgJEhoKEnBhcmVudF9pbnN0YW5j",
+            "ZV9pZBgCIAEoCRIbChNzdHJpY3RfaW5zdGFuY2VfaWRzGAMgASgIIlUKElZp",
+            "ZXdwb3J0UmF5UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIUCgxub3Jt",
+            "YWxpemVkX3gYAiABKAISFAoMbm9ybWFsaXplZF95GAMgASgCIqABCiBJbnN0",
+            "YW50aWF0ZVByZWZhYkluc3RhbmNlUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJ",
+            "EhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIcChRhcHBseV93b3JsZF9w",
+            "b3NpdGlvbhgDIAEoCBIxCg53b3JsZF9wb3NpdGlvbhgEIAEoCzIZLnNhaWxv",
+            "ci5lZGl0b3IudjEuVmVjdG9yNCJBChVWaWV3cG9ydE9iamVjdFJlcXVlc3QS",
+            "EwoLdmlld3BvcnRfaWQYASABKAQSEwoLaW5zdGFuY2VfaWQYAiABKAkiOQoR",
+            "UHJlZmFiTGlua1JlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkSDwoHZmls",
+            "ZV9pZBgCIAEoCSKpAQoYVmlld3BvcnRUb29sU3RhdGVSZXF1ZXN0EhMKC3Zp",
+            "ZXdwb3J0X2lkGAEgASgEEj8KCW9wZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5l",
+            "ZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UY",
+            "AyABKA4yKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3Bh",
+            "Y2UiKAoQU2VsZWN0aW9uUmVxdWVzdBIUCgxpbnN0YW5jZV9pZHMYASADKAki",
+            "JQoVU2hvd01haW5XaW5kb3dSZXF1ZXN0EgwKBHNob3cYASABKAgiiAEKHFJl",
+            "bmRlclBhdGhUcmFjZWRJbWFnZVJlcXVlc3QSEwoLb3V0cHV0X3BhdGgYASAB",
+            "KAkSEwoLaW5zdGFuY2VfaWQYAiABKAkSDgoGaGVpZ2h0GAMgASgNEhkKEXNh",
+            "bXBsZXNfcGVyX3BpeGVsGAQgASgNEhMKC21heF9ib3VuY2VzGAUgASgNIhsK",
+            "CkJvb2xSZXN1bHQSDQoFdmFsdWUYASABKAgiHAoLSW50MzJSZXN1bHQSDQoF",
+            "dmFsdWUYASABKAUiHQoMVUludDMyUmVzdWx0Eg0KBXZhbHVlGAEgASgNIh0K",
+            "DFVJbnQ2NFJlc3VsdBINCgV2YWx1ZRgBIAEoBCIwCgxTdHJpbmdSZXN1bHQS",
+            "EQoJaGFzX3ZhbHVlGAEgASgIEg0KBXZhbHVlGAIgASgJIiIKEFN0cmluZ0xp",
+            "c3RSZXN1bHQSDgoGdmFsdWVzGAEgAygJIoQBChZBc3NldFJlbG9hZFN0YXRl",
+            "UmVzdWx0EhEKCWF2YWlsYWJsZRgBIAEoCBIaChJyZXF1ZXN0X2dlbmVyYXRp",
+            "b24YAiABKAQSHAoUY29tcGxldGVkX2dlbmVyYXRpb24YAyABKAQSHQoVc3Vj",
+            "Y2Vzc2Z1bF9nZW5lcmF0aW9uGAQgASgEIjoKEEluc3RhbmNlSWRSZXN1bHQS",
+            "EQoJc3VjY2VlZGVkGAEgASgIEhMKC2luc3RhbmNlX2lkGAIgASgJIjkKDVZl",
+            "Y3RvcjRSZXN1bHQSKAoFdmFsdWUYASABKAsyGS5zYWlsb3IuZWRpdG9yLnYx",
+            "LlZlY3RvcjQikwEKF1ZpZXdwb3J0VG9vbFN0YXRlUmVzdWx0Ej8KCW9wZXJh",
+            "dGlvbhgBIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zv",
+            "cm1PcGVyYXRpb24SNwoFc3BhY2UYAiABKA4yKC5zYWlsb3IuZWRpdG9yLnYx",
+            "LlZpZXdwb3J0VHJhbnNmb3JtU3BhY2UiqAIKE0FuaW1hdG9yU3RhdGVSZXN1",
+            "bHQSFgoOaGFzX2NvbnRyb2xsZXIYASABKAgSGwoTY29udHJvbGxlcl9yZXZp",
+            "c2lvbhgCIAEoBBIXCg9hY3RpdmVfc3RhdGVfaWQYAyABKAQSGQoRYWN0aXZl",
+            "X3N0YXRlX25hbWUYBCABKAkSGQoRYWN0aXZlX3N0YXRlX3RpbWUYBSABKAIS",
+            "FQoNdHJhbnNpdGlvbmluZxgGIAEoCBIcChRkZXN0aW5hdGlvbl9zdGF0ZV9p",
+            "ZBgHIAEoBBIeChZkZXN0aW5hdGlvbl9zdGF0ZV9uYW1lGAggASgJEh4KFmRl",
+            "c3RpbmF0aW9uX3N0YXRlX3RpbWUYCSABKAISGAoQdHJhbnNpdGlvbl9hbHBo",
+            "YRgKIAEoAiI1CgdWZWN0b3I0EgkKAXgYASABKAISCQoBeRgCIAEoAhIJCgF6",
+            "GAMgASgCEgkKAXcYBCABKAIiNgoWVmlld3BvcnRTZWxlY3Rpb25FdmVudBIc",
+            "ChRzZWxlY3RlZF9pbnN0YW5jZV9pZBgBIAEoCSLWAwoWVmlld3BvcnRUcmFu",
+            "c2Zvcm1FdmVudBITCgtpbnN0YW5jZV9pZBgBIAEoCRI/CglvcGVyYXRpb24Y",
+            "AiABKA4yLC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtT3Bl",
+            "cmF0aW9uEjcKBXNwYWNlGAMgASgOMiguc2FpbG9yLmVkaXRvci52MS5WaWV3",
+            "cG9ydFRyYW5zZm9ybVNwYWNlEjIKD2JlZm9yZV9wb3NpdGlvbhgEIAEoCzIZ",
+            "LnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNBIyCg9iZWZvcmVfcm90YXRpb24Y",
+            "BSABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQSLwoMYmVmb3JlX3Nj",
+            "YWxlGAYgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0EjEKDmFmdGVy",
+            "X3Bvc2l0aW9uGAcgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0EjEK",
+            "DmFmdGVyX3JvdGF0aW9uGAggASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0",
+            "b3I0Ei4KC2FmdGVyX3NjYWxlGAkgASgLMhkuc2FpbG9yLmVkaXRvci52MS5W",
+            "ZWN0b3I0IlUKFlZpZXdwb3J0QXNzZXREcm9wRXZlbnQSDwoHZmlsZV9pZBgB",
+            "IAEoCRIUCgxub3JtYWxpemVkX3gYAiABKAISFAoMbm9ybWFsaXplZF95GAMg",
+            "ASgCIi0KGVZpZXdwb3J0VG9vbFNob3J0Y3V0RXZlbnQSEAoIa2V5X2NvZGUY",
+            "ASABKA0i2QIKDVZpZXdwb3J0RXZlbnQSEAoIcmV2aXNpb24YASABKAQSIQoZ",
+            "bWFuYWdlZF9tdXRhdGlvbl9yZXZpc2lvbhgCIAEoBBI9CglzZWxlY3Rpb24Y",
+            "CiABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0U2VsZWN0aW9uRXZl",
+            "bnRIABI9Cgl0cmFuc2Zvcm0YCyABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZp",
+            "ZXdwb3J0VHJhbnNmb3JtRXZlbnRIABI+Cgphc3NldF9kcm9wGAwgASgLMigu",
+            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEFzc2V0RHJvcEV2ZW50SAASRAoN",
+            "dG9vbF9zaG9ydGN1dBgNIAEoCzIrLnNhaWxvci5lZGl0b3IudjEuVmlld3Bv",
+            "cnRUb29sU2hvcnRjdXRFdmVudEgAQgkKB3BheWxvYWRKBAgDEAoiSwoYVmll",
+            "d3BvcnRFdmVudEJhdGNoUmVzdWx0Ei8KBmV2ZW50cxgBIAMoCzIfLnNhaWxv",
+            "ci5lZGl0b3IudjEuVmlld3BvcnRFdmVudCrwAQoaVmlld3BvcnRUcmFuc2Zv",
+            "cm1PcGVyYXRpb24SLAooVklFV1BPUlRfVFJBTlNGT1JNX09QRVJBVElPTl9V",
+            "TlNQRUNJRklFRBAAEicKI1ZJRVdQT1JUX1RSQU5TRk9STV9PUEVSQVRJT05f",
+            "U0VMRUNUEAESKgomVklFV1BPUlRfVFJBTlNGT1JNX09QRVJBVElPTl9UUkFO",
+            "U0xBVEUQAhInCiNWSUVXUE9SVF9UUkFOU0ZPUk1fT1BFUkFUSU9OX1JPVEFU",
+            "RRADEiYKIlZJRVdQT1JUX1RSQU5TRk9STV9PUEVSQVRJT05fU0NBTEUQBCqK",
+            "AQoWVmlld3BvcnRUcmFuc2Zvcm1TcGFjZRIoCiRWSUVXUE9SVF9UUkFOU0ZP",
+            "Uk1fU1BBQ0VfVU5TUEVDSUZJRUQQABIiCh5WSUVXUE9SVF9UUkFOU0ZPUk1f",
+            "U1BBQ0VfV09STEQQARIiCh5WSUVXUE9SVF9UUkFOU0ZPUk1fU1BBQ0VfTE9D",
+            "QUwQAiqkAQoPRWRpdG9yU3RhdHNNb2RlEiEKHUVESVRPUl9TVEFUU19NT0RF",
+            "X1VOU1BFQ0lGSUVEEAASGgoWRURJVE9SX1NUQVRTX01PREVfTk9ORRABEiIK",
+            "HkVESVRPUl9TVEFUU19NT0RFX1JFTkRFUl9TVEFUUxACEi4KKkVESVRPUl9T",
+            "VEFUU19NT0RFX1JFTkRFUl9TVEFUU19BTkRfUVVFUklFUxADQiKqAh9TYWls",
+            "b3JFZGl0b3IuUHJvdG9jb2wuR2VuZXJhdGVkYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::SailorEditor.Protocol.Generated.ViewportTransformOperation), typeof(global::SailorEditor.Protocol.Generated.ViewportTransformSpace), }, null, new pbr::GeneratedClrTypeInfo[] {
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::SailorEditor.Protocol.Generated.ViewportTransformOperation), typeof(global::SailorEditor.Protocol.Generated.ViewportTransformSpace), typeof(global::SailorEditor.Protocol.Generated.EditorStatsMode), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Empty), global::SailorEditor.Protocol.Generated.Empty.Parser, null, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset", "CreateModelInstance", "SetAnimatorParameter", "GetAnimatorState", "SetEditorSimulation", "GetEditorSimulationState", "PreviewAudioAsset" }, new[]{ "Command" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset", "CreateModelInstance", "SetAnimatorParameter", "GetAnimatorState", "SetEditorSimulation", "GetEditorSimulationState", "PreviewAudioAsset", "SetEditorStatsMode" }, new[]{ "Command" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "SupportsStrictInstanceIds", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult", "Vector4Result", "ViewportToolStateResult", "AnimatorStateResult" }, new[]{ "Result" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InitializeRequest), global::SailorEditor.Protocol.Generated.InitializeRequest.Parser, new[]{ "Arguments" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CountRequest), global::SailorEditor.Protocol.Generated.CountRequest.Parser, new[]{ "MaxCount" }, null, null, null, null),
@@ -262,6 +269,7 @@ namespace SailorEditor.Protocol.Generated {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ViewportRectRequest), global::SailorEditor.Protocol.Generated.ViewportRectRequest.Parser, new[]{ "WindowPosX", "WindowPosY", "Width", "Height" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.SizeRequest), global::SailorEditor.Protocol.Generated.SizeRequest.Parser, new[]{ "Width", "Height" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.EditorSimulationRequest), global::SailorEditor.Protocol.Generated.EditorSimulationRequest.Parser, new[]{ "Enabled" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.EditorStatsModeRequest), global::SailorEditor.Protocol.Generated.EditorStatsModeRequest.Parser, new[]{ "Mode" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.RemoteViewportRequest), global::SailorEditor.Protocol.Generated.RemoteViewportRequest.Parser, new[]{ "ViewportId", "WindowPosX", "WindowPosY", "Width", "Height", "Visible", "Focused" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.RemoteViewportHostRequest), global::SailorEditor.Protocol.Generated.RemoteViewportHostRequest.Parser, new[]{ "ViewportId", "HostHandleKind", "HostHandleValue" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.RemoteViewportInputRequest), global::SailorEditor.Protocol.Generated.RemoteViewportInputRequest.Parser, new[]{ "ViewportId", "Kind", "PointerX", "PointerY", "WheelDeltaX", "WheelDeltaY", "KeyCode", "Button", "Modifiers", "Pressed", "Focused", "Captured" }, null, null, null, null),
@@ -317,6 +325,13 @@ namespace SailorEditor.Protocol.Generated {
     [pbr::OriginalName("VIEWPORT_TRANSFORM_SPACE_UNSPECIFIED")] Unspecified = 0,
     [pbr::OriginalName("VIEWPORT_TRANSFORM_SPACE_WORLD")] World = 1,
     [pbr::OriginalName("VIEWPORT_TRANSFORM_SPACE_LOCAL")] Local = 2,
+  }
+
+  public enum EditorStatsMode {
+    [pbr::OriginalName("EDITOR_STATS_MODE_UNSPECIFIED")] Unspecified = 0,
+    [pbr::OriginalName("EDITOR_STATS_MODE_NONE")] None = 1,
+    [pbr::OriginalName("EDITOR_STATS_MODE_RENDER_STATS")] RenderStats = 2,
+    [pbr::OriginalName("EDITOR_STATS_MODE_RENDER_STATS_AND_QUERIES")] RenderStatsAndQueries = 3,
   }
 
   #endregion
@@ -679,6 +694,9 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case CommandOneofCase.PreviewAudioAsset:
           PreviewAudioAsset = other.PreviewAudioAsset.Clone();
+          break;
+        case CommandOneofCase.SetEditorStatsMode:
+          SetEditorStatsMode = other.SetEditorStatsMode.Clone();
           break;
       }
 
@@ -1351,6 +1369,18 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "set_editor_stats_mode" field.</summary>
+    public const int SetEditorStatsModeFieldNumber = 64;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.EditorStatsModeRequest SetEditorStatsMode {
+      get { return commandCase_ == CommandOneofCase.SetEditorStatsMode ? (global::SailorEditor.Protocol.Generated.EditorStatsModeRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.SetEditorStatsMode;
+      }
+    }
+
     private object command_;
     /// <summary>Enum of possible cases for the "command" oneof.</summary>
     public enum CommandOneofCase {
@@ -1408,6 +1438,7 @@ namespace SailorEditor.Protocol.Generated {
       SetEditorSimulation = 61,
       GetEditorSimulationState = 62,
       PreviewAudioAsset = 63,
+      SetEditorStatsMode = 64,
     }
     private CommandOneofCase commandCase_ = CommandOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1493,6 +1524,7 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(SetEditorSimulation, other.SetEditorSimulation)) return false;
       if (!object.Equals(GetEditorSimulationState, other.GetEditorSimulationState)) return false;
       if (!object.Equals(PreviewAudioAsset, other.PreviewAudioAsset)) return false;
+      if (!object.Equals(SetEditorStatsMode, other.SetEditorStatsMode)) return false;
       if (CommandCase != other.CommandCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -1556,6 +1588,7 @@ namespace SailorEditor.Protocol.Generated {
       if (commandCase_ == CommandOneofCase.SetEditorSimulation) hash ^= SetEditorSimulation.GetHashCode();
       if (commandCase_ == CommandOneofCase.GetEditorSimulationState) hash ^= GetEditorSimulationState.GetHashCode();
       if (commandCase_ == CommandOneofCase.PreviewAudioAsset) hash ^= PreviewAudioAsset.GetHashCode();
+      if (commandCase_ == CommandOneofCase.SetEditorStatsMode) hash ^= SetEditorStatsMode.GetHashCode();
       hash ^= (int) commandCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -1795,6 +1828,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(250, 3);
         output.WriteMessage(PreviewAudioAsset);
       }
+      if (commandCase_ == CommandOneofCase.SetEditorStatsMode) {
+        output.WriteRawTag(130, 4);
+        output.WriteMessage(SetEditorStatsMode);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -2025,6 +2062,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(250, 3);
         output.WriteMessage(PreviewAudioAsset);
       }
+      if (commandCase_ == CommandOneofCase.SetEditorStatsMode) {
+        output.WriteRawTag(130, 4);
+        output.WriteMessage(SetEditorStatsMode);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -2199,6 +2240,9 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (commandCase_ == CommandOneofCase.PreviewAudioAsset) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(PreviewAudioAsset);
+      }
+      if (commandCase_ == CommandOneofCase.SetEditorStatsMode) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(SetEditorStatsMode);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -2536,6 +2580,12 @@ namespace SailorEditor.Protocol.Generated {
             PreviewAudioAsset = new global::SailorEditor.Protocol.Generated.FileIdRequest();
           }
           PreviewAudioAsset.MergeFrom(other.PreviewAudioAsset);
+          break;
+        case CommandOneofCase.SetEditorStatsMode:
+          if (SetEditorStatsMode == null) {
+            SetEditorStatsMode = new global::SailorEditor.Protocol.Generated.EditorStatsModeRequest();
+          }
+          SetEditorStatsMode.MergeFrom(other.SetEditorStatsMode);
           break;
       }
 
@@ -3043,6 +3093,15 @@ namespace SailorEditor.Protocol.Generated {
             PreviewAudioAsset = subBuilder;
             break;
           }
+          case 514: {
+            global::SailorEditor.Protocol.Generated.EditorStatsModeRequest subBuilder = new global::SailorEditor.Protocol.Generated.EditorStatsModeRequest();
+            if (commandCase_ == CommandOneofCase.SetEditorStatsMode) {
+              subBuilder.MergeFrom(SetEditorStatsMode);
+            }
+            input.ReadMessage(subBuilder);
+            SetEditorStatsMode = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -3545,6 +3604,15 @@ namespace SailorEditor.Protocol.Generated {
             }
             input.ReadMessage(subBuilder);
             PreviewAudioAsset = subBuilder;
+            break;
+          }
+          case 514: {
+            global::SailorEditor.Protocol.Generated.EditorStatsModeRequest subBuilder = new global::SailorEditor.Protocol.Generated.EditorStatsModeRequest();
+            if (commandCase_ == CommandOneofCase.SetEditorStatsMode) {
+              subBuilder.MergeFrom(SetEditorStatsMode);
+            }
+            input.ReadMessage(subBuilder);
+            SetEditorStatsMode = subBuilder;
             break;
           }
         }
@@ -6767,6 +6835,204 @@ namespace SailorEditor.Protocol.Generated {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class EditorStatsModeRequest : pb::IMessage<EditorStatsModeRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<EditorStatsModeRequest> _parser = new pb::MessageParser<EditorStatsModeRequest>(() => new EditorStatsModeRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<EditorStatsModeRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[12]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorStatsModeRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorStatsModeRequest(EditorStatsModeRequest other) : this() {
+      mode_ = other.mode_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorStatsModeRequest Clone() {
+      return new EditorStatsModeRequest(this);
+    }
+
+    /// <summary>Field number for the "mode" field.</summary>
+    public const int ModeFieldNumber = 1;
+    private global::SailorEditor.Protocol.Generated.EditorStatsMode mode_ = global::SailorEditor.Protocol.Generated.EditorStatsMode.Unspecified;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.EditorStatsMode Mode {
+      get { return mode_; }
+      set {
+        mode_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as EditorStatsModeRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(EditorStatsModeRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Mode != other.Mode) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorStatsMode.Unspecified) hash ^= Mode.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorStatsMode.Unspecified) {
+        output.WriteRawTag(8);
+        output.WriteEnum((int) Mode);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorStatsMode.Unspecified) {
+        output.WriteRawTag(8);
+        output.WriteEnum((int) Mode);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorStatsMode.Unspecified) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Mode);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(EditorStatsModeRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Mode != global::SailorEditor.Protocol.Generated.EditorStatsMode.Unspecified) {
+        Mode = other.Mode;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            Mode = (global::SailorEditor.Protocol.Generated.EditorStatsMode) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            Mode = (global::SailorEditor.Protocol.Generated.EditorStatsMode) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RemoteViewportRequest : pb::IMessage<RemoteViewportRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -6781,7 +7047,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[12]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[13]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7201,7 +7467,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[13]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[14]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7473,7 +7739,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[14]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[15]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8078,7 +8344,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[15]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[16]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8313,7 +8579,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[16]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[17]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8548,7 +8814,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[17]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[18]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8820,7 +9086,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[18]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[19]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9055,7 +9321,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[19]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9327,7 +9593,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9857,7 +10123,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10092,7 +10358,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10364,7 +10630,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10636,7 +10902,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10954,7 +11220,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11189,7 +11455,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11424,7 +11690,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11696,7 +11962,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11883,7 +12149,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12081,7 +12347,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12427,7 +12693,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12625,7 +12891,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12823,7 +13089,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13021,7 +13287,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13219,7 +13485,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13454,7 +13720,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13641,7 +13907,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13950,7 +14216,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14185,7 +14451,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14392,7 +14658,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14627,7 +14893,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15158,7 +15424,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15467,7 +15733,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15665,7 +15931,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -16213,7 +16479,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[46]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -16485,7 +16751,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[46]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[47]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -16683,7 +16949,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[47]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[48]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -17157,7 +17423,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[48]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[49]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -5,6 +5,7 @@ using SailorEditor.Protocol.Generated;
 using SailorEditor.Utility;
 using SailorEditor.Workspace;
 using SailorEditor.Scene;
+using SailorEditor.Settings;
 using System.Threading;
 using System.Globalization;
 
@@ -2955,6 +2956,25 @@ namespace SailorEditor.Services
                     ToProtocolSpace(space),
                     token),
                 cancellationToken: cancellationToken);
+
+        public Task<bool> SetEditorStatsModeAsync(
+            GraphicsStatsMode mode,
+            CancellationToken cancellationToken = default)
+            => InvokeRunningInteropAsync(
+                token => protocolClient.SetEditorStatsModeAsync(
+                    ToProtocolStatsMode(mode),
+                    token),
+                cancellationToken: cancellationToken);
+
+        static EditorStatsMode ToProtocolStatsMode(GraphicsStatsMode mode)
+            => mode switch
+            {
+                GraphicsStatsMode.None => EditorStatsMode.None,
+                GraphicsStatsMode.RenderStats => EditorStatsMode.RenderStats,
+                GraphicsStatsMode.RenderStatsAndQueries =>
+                    EditorStatsMode.RenderStatsAndQueries,
+                _ => throw new ArgumentOutOfRangeException(nameof(mode))
+            };
 
         public async Task<SceneViewportToolState?> GetViewportToolStateAsync(
             CancellationToken cancellationToken = default)

--- a/Editor/Services/WorkspaceUiService.cs
+++ b/Editor/Services/WorkspaceUiService.cs
@@ -73,6 +73,22 @@ internal sealed class WorkspaceUiService
 
     public async Task<bool> RestartEngineAsync(
         CancellationToken cancellationToken = default)
+        => await RestartEngineForGenerationAsync(
+                expectedGeneration: null,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+    public async Task<bool> RestartEngineForGenerationAsync(
+        long expectedGeneration,
+        CancellationToken cancellationToken = default)
+        => await RestartEngineForGenerationAsync(
+                (long?)expectedGeneration,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+    async Task<bool> RestartEngineForGenerationAsync(
+        long? expectedGeneration,
+        CancellationToken cancellationToken)
     {
         await _engineRestartGate.WaitAsync(cancellationToken);
         try
@@ -81,6 +97,12 @@ internal sealed class WorkspaceUiService
             await _activationCoordinator.RunSerializedAsync(
                 async token =>
                 {
+                    if (expectedGeneration.HasValue &&
+                        _activationCoordinator.State.Generation !=
+                            expectedGeneration.Value)
+                    {
+                        return;
+                    }
                     restarted = await RestartEngineCoreAsync(token)
                         .ConfigureAwait(false);
                 },

--- a/Editor/Settings/GraphicsSettings.cs
+++ b/Editor/Settings/GraphicsSettings.cs
@@ -1,0 +1,899 @@
+using System.Globalization;
+using YamlDotNet.RepresentationModel;
+
+namespace SailorEditor.Settings;
+
+public enum GraphicsQualityLevel
+{
+    Ultra,
+    High,
+    Medium,
+    Low,
+    VeryLow,
+}
+
+public enum EditorQualitySelection
+{
+    ProjectDefault,
+    Ultra,
+    High,
+    Medium,
+    Low,
+    VeryLow,
+}
+
+public enum GraphicsShadowQuality
+{
+    High,
+    Medium,
+    Low,
+    VeryLow,
+}
+
+public enum GraphicsStatsMode
+{
+    None,
+    RenderStats,
+    RenderStatsAndQueries,
+}
+
+public sealed record GraphicsQualityPresetSettings
+{
+    public double ResolutionFactor { get; init; }
+    public int FpsCap { get; init; }
+    public int MsaaSamples { get; init; }
+    public GraphicsShadowQuality ShadowQuality { get; init; }
+    public double ShadowBias { get; init; }
+    public int ShadowCascadeCount { get; init; }
+    public IReadOnlyList<int> ShadowCascadeResolutions { get; init; } = [];
+    public bool SupportSoftShadows { get; init; }
+    public double CloudsResolutionMultiplier { get; init; }
+    public int SkyResolution { get; init; }
+    public int LodBias { get; init; }
+}
+
+public sealed record GraphicsQualityPresets
+{
+    public GraphicsQualityPresetSettings Ultra { get; init; } = new();
+    public GraphicsQualityPresetSettings High { get; init; } = new();
+    public GraphicsQualityPresetSettings Medium { get; init; } = new();
+    public GraphicsQualityPresetSettings Low { get; init; } = new();
+    public GraphicsQualityPresetSettings VeryLow { get; init; } = new();
+
+    public GraphicsQualityPresetSettings Get(GraphicsQualityLevel quality)
+        => quality switch
+        {
+            GraphicsQualityLevel.Ultra => Ultra,
+            GraphicsQualityLevel.High => High,
+            GraphicsQualityLevel.Medium => Medium,
+            GraphicsQualityLevel.Low => Low,
+            GraphicsQualityLevel.VeryLow => VeryLow,
+            _ => throw new ArgumentOutOfRangeException(nameof(quality))
+        };
+
+    public GraphicsQualityPresets With(
+        GraphicsQualityLevel quality,
+        GraphicsQualityPresetSettings settings)
+        => quality switch
+        {
+            GraphicsQualityLevel.Ultra => this with { Ultra = settings },
+            GraphicsQualityLevel.High => this with { High = settings },
+            GraphicsQualityLevel.Medium => this with { Medium = settings },
+            GraphicsQualityLevel.Low => this with { Low = settings },
+            GraphicsQualityLevel.VeryLow => this with { VeryLow = settings },
+            _ => throw new ArgumentOutOfRangeException(nameof(quality))
+        };
+}
+
+public sealed record ProjectGraphicsSettings
+{
+    public GraphicsQualityLevel DefaultQuality { get; init; } = GraphicsQualityLevel.High;
+    public GraphicsQualityPresets Presets { get; init; } = GraphicsSettingsDefaults.Presets;
+}
+
+public sealed record ProjectSettingsDocument
+{
+    public const int CurrentVersion = 1;
+
+    public int SettingsVersion { get; init; } = CurrentVersion;
+    public ProjectGraphicsSettings Graphics { get; init; } = new();
+}
+
+public sealed record EditorGraphicsSettings
+{
+    public EditorQualitySelection SelectedQuality { get; init; } = EditorQualitySelection.ProjectDefault;
+    public GraphicsStatsMode StatsMode { get; init; } = GraphicsStatsMode.None;
+}
+
+public sealed record WorkspaceEditorSettingsDocument
+{
+    public const int CurrentVersion = 1;
+
+    public int SettingsVersion { get; init; } = CurrentVersion;
+    public EditorGraphicsSettings Graphics { get; init; } = new();
+}
+
+public static class GraphicsSettingsDefaults
+{
+    public static GraphicsQualityPresets Presets { get; } = new()
+    {
+        Ultra = new GraphicsQualityPresetSettings
+        {
+            ResolutionFactor = 1.0,
+            FpsCap = 120,
+            MsaaSamples = 8,
+            ShadowQuality = GraphicsShadowQuality.High,
+            ShadowBias = 0.0,
+            ShadowCascadeCount = 4,
+            ShadowCascadeResolutions = [4096, 2048, 2048, 1024],
+            SupportSoftShadows = true,
+            CloudsResolutionMultiplier = 1.0,
+            SkyResolution = 512,
+            LodBias = -1
+        },
+        High = new GraphicsQualityPresetSettings
+        {
+            ResolutionFactor = 1.0,
+            FpsCap = 120,
+            MsaaSamples = 4,
+            ShadowQuality = GraphicsShadowQuality.High,
+            ShadowBias = 0.0,
+            ShadowCascadeCount = 4,
+            ShadowCascadeResolutions = [2048, 2048, 1024, 1024],
+            SupportSoftShadows = true,
+            CloudsResolutionMultiplier = 0.75,
+            SkyResolution = 256,
+            LodBias = 0
+        },
+        Medium = new GraphicsQualityPresetSettings
+        {
+            ResolutionFactor = 0.85,
+            FpsCap = 120,
+            MsaaSamples = 2,
+            ShadowQuality = GraphicsShadowQuality.Medium,
+            ShadowBias = 0.0,
+            ShadowCascadeCount = 3,
+            ShadowCascadeResolutions = [2048, 1024, 512],
+            SupportSoftShadows = true,
+            CloudsResolutionMultiplier = 0.5,
+            SkyResolution = 256,
+            LodBias = 0
+        },
+        Low = new GraphicsQualityPresetSettings
+        {
+            ResolutionFactor = 0.7,
+            FpsCap = 120,
+            MsaaSamples = 1,
+            ShadowQuality = GraphicsShadowQuality.Low,
+            ShadowBias = 0.0,
+            ShadowCascadeCount = 2,
+            ShadowCascadeResolutions = [1024, 512],
+            SupportSoftShadows = false,
+            CloudsResolutionMultiplier = 0.25,
+            SkyResolution = 128,
+            LodBias = 1
+        },
+        VeryLow = new GraphicsQualityPresetSettings
+        {
+            ResolutionFactor = 0.5,
+            FpsCap = 120,
+            MsaaSamples = 1,
+            ShadowQuality = GraphicsShadowQuality.VeryLow,
+            ShadowBias = 0.0,
+            ShadowCascadeCount = 1,
+            ShadowCascadeResolutions = [512],
+            SupportSoftShadows = false,
+            CloudsResolutionMultiplier = 0.125,
+            SkyResolution = 64,
+            LodBias = 2
+        }
+    };
+
+    public static ProjectSettingsDocument Project { get; } = new()
+    {
+        SettingsVersion = ProjectSettingsDocument.CurrentVersion,
+        Graphics = new ProjectGraphicsSettings
+        {
+            DefaultQuality = GraphicsQualityLevel.High,
+            Presets = Presets
+        }
+    };
+
+    public static WorkspaceEditorSettingsDocument Editor { get; } = new()
+    {
+        SettingsVersion = WorkspaceEditorSettingsDocument.CurrentVersion,
+        Graphics = new EditorGraphicsSettings
+        {
+            SelectedQuality = EditorQualitySelection.ProjectDefault,
+            StatsMode = GraphicsStatsMode.None
+        }
+    };
+}
+
+public sealed record GraphicsSettingsValidationIssue(string Path, string Message);
+
+public sealed record GraphicsSettingsValidationResult(
+    IReadOnlyList<GraphicsSettingsValidationIssue> Issues)
+{
+    public static GraphicsSettingsValidationResult Success { get; } = new([]);
+
+    public bool IsValid => Issues.Count == 0;
+}
+
+public static class GraphicsSettingsValidator
+{
+    static readonly int[] SupportedMsaaSamples = [1, 2, 4, 8];
+
+    public static GraphicsSettingsValidationResult Validate(
+        ProjectSettingsDocument? document)
+    {
+        var issues = new List<GraphicsSettingsValidationIssue>();
+        if (document is null)
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                "ProjectSettings",
+                "Project settings document is required."));
+            return new GraphicsSettingsValidationResult(issues);
+        }
+
+        if (document.SettingsVersion != ProjectSettingsDocument.CurrentVersion)
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                "settingsVersion",
+                $"Unsupported project settings version '{document.SettingsVersion}'. Supported version is '{ProjectSettingsDocument.CurrentVersion}'."));
+        }
+
+        if (!Enum.IsDefined(document.Graphics.DefaultQuality))
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                "graphics.defaultQuality",
+                "Default quality must be one of Ultra, High, Medium, Low, or VeryLow."));
+        }
+
+        foreach (var quality in Enum.GetValues<GraphicsQualityLevel>())
+        {
+            ValidatePreset(
+                document.Graphics.Presets.Get(quality),
+                $"graphics.presets.{quality}",
+                issues);
+        }
+
+        return issues.Count == 0
+            ? GraphicsSettingsValidationResult.Success
+            : new GraphicsSettingsValidationResult(issues);
+    }
+
+    public static GraphicsSettingsValidationResult Validate(
+        WorkspaceEditorSettingsDocument? document)
+    {
+        var issues = new List<GraphicsSettingsValidationIssue>();
+        if (document is null)
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                "EditorSettings",
+                "Editor settings document is required."));
+            return new GraphicsSettingsValidationResult(issues);
+        }
+
+        if (document.SettingsVersion != WorkspaceEditorSettingsDocument.CurrentVersion)
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                "settingsVersion",
+                $"Unsupported editor settings version '{document.SettingsVersion}'. Supported version is '{WorkspaceEditorSettingsDocument.CurrentVersion}'."));
+        }
+
+        if (!Enum.IsDefined(document.Graphics.SelectedQuality))
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                "graphics.selectedQuality",
+                "Selected quality must be ProjectDefault, Ultra, High, Medium, Low, or VeryLow."));
+        }
+
+        if (!Enum.IsDefined(document.Graphics.StatsMode))
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                "graphics.statsMode",
+                "Stats mode must be None, RenderStats, or RenderStatsAndQueries."));
+        }
+
+        return issues.Count == 0
+            ? GraphicsSettingsValidationResult.Success
+            : new GraphicsSettingsValidationResult(issues);
+    }
+
+    static void ValidatePreset(
+        GraphicsQualityPresetSettings? preset,
+        string path,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+    {
+        if (preset is null)
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                path,
+                "The fixed quality preset is required."));
+            return;
+        }
+
+        if (!double.IsFinite(preset.ResolutionFactor) ||
+            preset.ResolutionFactor is < 0.25 or > 2.0)
+        {
+            AddRangeIssue(issues, $"{path}.resolutionFactor", "Resolution factor", "0.25 and 2.0");
+        }
+
+        if (preset.FpsCap is < 1 or > 1000)
+        {
+            AddRangeIssue(issues, $"{path}.fpsCap", "FPS cap", "1 and 1000");
+        }
+
+        if (!SupportedMsaaSamples.Contains(preset.MsaaSamples))
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                $"{path}.msaaSamples",
+                "MSAA samples must be one of 1, 2, 4, or 8."));
+        }
+
+        if (!Enum.IsDefined(preset.ShadowQuality))
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                $"{path}.shadowQuality",
+                "Shadow quality must be High, Medium, Low, or VeryLow."));
+        }
+
+        if (!double.IsFinite(preset.ShadowBias) ||
+            preset.ShadowBias is < -16.0 or > 16.0)
+        {
+            AddRangeIssue(issues, $"{path}.shadowBias", "Shadow bias", "-16 and 16");
+        }
+
+        if (preset.ShadowCascadeCount is < 1 or > 4)
+        {
+            AddRangeIssue(issues, $"{path}.shadowCascadeCount", "Shadow cascade count", "1 and 4");
+        }
+
+        if (preset.ShadowCascadeResolutions is null ||
+            preset.ShadowCascadeResolutions.Count != preset.ShadowCascadeCount)
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                $"{path}.shadowCascadeResolutions",
+                "The number of cascade resolutions must exactly match shadowCascadeCount."));
+        }
+        else
+        {
+            for (var index = 0; index < preset.ShadowCascadeResolutions.Count; ++index)
+            {
+                if (!IsPowerOfTwoInRange(preset.ShadowCascadeResolutions[index]))
+                {
+                    issues.Add(new GraphicsSettingsValidationIssue(
+                        $"{path}.shadowCascadeResolutions[{index}]",
+                        "Cascade resolution must be a power of two between 32 and 8192."));
+                }
+            }
+        }
+
+        if (!double.IsFinite(preset.CloudsResolutionMultiplier) ||
+            preset.CloudsResolutionMultiplier is < 0.0625 or > 2.0)
+        {
+            AddRangeIssue(issues, $"{path}.cloudsResolutionMultiplier", "Clouds resolution multiplier", "0.0625 and 2.0");
+        }
+
+        if (!IsPowerOfTwoInRange(preset.SkyResolution))
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                $"{path}.skyResolution",
+                "Sky resolution must be a power of two between 32 and 8192."));
+        }
+
+        if (preset.LodBias is < -8 or > 8)
+        {
+            AddRangeIssue(issues, $"{path}.lodBias", "LOD bias", "-8 and 8");
+        }
+    }
+
+    static bool IsPowerOfTwoInRange(int value)
+        => value is >= 32 and <= 8192 && (value & (value - 1)) == 0;
+
+    static void AddRangeIssue(
+        ICollection<GraphicsSettingsValidationIssue> issues,
+        string path,
+        string displayName,
+        string range)
+        => issues.Add(new GraphicsSettingsValidationIssue(
+            path,
+            $"{displayName} must be between {range}."));
+}
+
+public sealed record GraphicsSettingsPaths(
+    string WorkspaceRoot,
+    string CacheDirectory)
+{
+    public const string ProjectFileName = "ProjectSettings.yaml";
+    public const string EditorFileName = "EditorSettings.yaml";
+
+    public string ProjectSettingsPath => Path.Combine(WorkspaceRoot, ProjectFileName);
+    public string EditorSettingsPath => Path.Combine(CacheDirectory, EditorFileName);
+
+    public static GraphicsSettingsPaths Create(
+        string workspaceRoot,
+        string cacheDirectory)
+    {
+        if (string.IsNullOrWhiteSpace(workspaceRoot))
+            throw new ArgumentException("Workspace root is required.", nameof(workspaceRoot));
+        if (string.IsNullOrWhiteSpace(cacheDirectory))
+            throw new ArgumentException("Cache directory is required.", nameof(cacheDirectory));
+
+        return new GraphicsSettingsPaths(
+            NormalizeDirectory(workspaceRoot),
+            NormalizeDirectory(cacheDirectory));
+    }
+
+    static string NormalizeDirectory(string path)
+    {
+        var fullPath = Path.GetFullPath(path);
+        var root = Path.GetPathRoot(fullPath);
+        return string.Equals(fullPath, root, PathComparison)
+            ? fullPath
+            : fullPath.TrimEnd(
+                Path.DirectorySeparatorChar,
+                Path.AltDirectorySeparatorChar);
+    }
+
+    static StringComparison PathComparison => OperatingSystem.IsWindows()
+        ? StringComparison.OrdinalIgnoreCase
+        : StringComparison.Ordinal;
+}
+
+public enum GraphicsSettingsFileRevisionKind
+{
+    Missing,
+    Readable,
+    Unreadable,
+}
+
+public readonly record struct GraphicsSettingsFileRevision(
+    GraphicsSettingsFileRevisionKind Kind,
+    string ContentHash)
+{
+    public static GraphicsSettingsFileRevision Missing { get; } = new(
+        GraphicsSettingsFileRevisionKind.Missing,
+        string.Empty);
+
+    public static GraphicsSettingsFileRevision Unreadable { get; } = new(
+        GraphicsSettingsFileRevisionKind.Unreadable,
+        string.Empty);
+
+    public static GraphicsSettingsFileRevision Readable(string contentHash)
+    {
+        if (string.IsNullOrWhiteSpace(contentHash))
+            throw new ArgumentException(
+                "A readable settings revision requires a content hash.",
+                nameof(contentHash));
+        return new GraphicsSettingsFileRevision(
+            GraphicsSettingsFileRevisionKind.Readable,
+            contentHash);
+    }
+}
+
+public sealed record GraphicsSettingsSnapshot(
+    GraphicsSettingsPaths Paths,
+    long WorkspaceGeneration,
+    ProjectSettingsDocument Project,
+    WorkspaceEditorSettingsDocument Editor,
+    GraphicsSettingsFileRevision ProjectRevision,
+    GraphicsSettingsFileRevision EditorRevision,
+    IReadOnlyList<string> Diagnostics)
+{
+    public GraphicsQualityLevel EffectiveQuality =>
+        Editor.Graphics.SelectedQuality switch
+        {
+            EditorQualitySelection.ProjectDefault => Project.Graphics.DefaultQuality,
+            EditorQualitySelection.Ultra => GraphicsQualityLevel.Ultra,
+            EditorQualitySelection.High => GraphicsQualityLevel.High,
+            EditorQualitySelection.Medium => GraphicsQualityLevel.Medium,
+            EditorQualitySelection.Low => GraphicsQualityLevel.Low,
+            EditorQualitySelection.VeryLow => GraphicsQualityLevel.VeryLow,
+            _ => Project.Graphics.DefaultQuality
+        };
+}
+
+public static class GraphicsSettingsYamlCodec
+{
+    static readonly GraphicsQualityLevel[] QualityLevels =
+        Enum.GetValues<GraphicsQualityLevel>();
+
+    public static string SerializeProject(ProjectSettingsDocument document)
+    {
+        ThrowIfInvalid(GraphicsSettingsValidator.Validate(document));
+        var root = new YamlMappingNode();
+        PatchProject(root, document);
+        return Save(root);
+    }
+
+    public static string SerializeEditor(WorkspaceEditorSettingsDocument document)
+    {
+        ThrowIfInvalid(GraphicsSettingsValidator.Validate(document));
+        var root = new YamlMappingNode();
+        PatchEditor(root, document);
+        return Save(root);
+    }
+
+    internal static ProjectSettingsDocument ParseProject(
+        string yaml,
+        ICollection<string> diagnostics,
+        string source)
+    {
+        if (!TryLoadRoot(yaml, source, diagnostics, out var root))
+            return GraphicsSettingsDefaults.Project;
+
+        var issues = new List<GraphicsSettingsValidationIssue>();
+        var version = ReadInt(root, "settingsVersion", "settingsVersion", issues);
+        var graphics = ReadMapping(root, "graphics", "graphics", issues);
+        var defaultQuality = ReadEnum<GraphicsQualityLevel>(
+            graphics,
+            "defaultQuality",
+            "graphics.defaultQuality",
+            issues);
+        var presetsNode = ReadMapping(
+            graphics,
+            "presets",
+            "graphics.presets",
+            issues);
+        var presets = GraphicsSettingsDefaults.Presets;
+        foreach (var quality in QualityLevels)
+        {
+            var preset = ReadPreset(
+                presetsNode,
+                quality.ToString(),
+                $"graphics.presets.{quality}",
+                issues);
+            presets = presets.With(quality, preset);
+        }
+
+        var parsed = new ProjectSettingsDocument
+        {
+            SettingsVersion = version,
+            Graphics = new ProjectGraphicsSettings
+            {
+                DefaultQuality = defaultQuality,
+                Presets = presets
+            }
+        };
+        issues.AddRange(GraphicsSettingsValidator.Validate(parsed).Issues);
+        if (issues.Count == 0)
+            return parsed;
+
+        AddDiagnostics(diagnostics, source, issues);
+        return GraphicsSettingsDefaults.Project;
+    }
+
+    internal static WorkspaceEditorSettingsDocument ParseEditor(
+        string yaml,
+        ICollection<string> diagnostics,
+        string source)
+    {
+        if (!TryLoadRoot(yaml, source, diagnostics, out var root))
+            return GraphicsSettingsDefaults.Editor;
+
+        var issues = new List<GraphicsSettingsValidationIssue>();
+        var version = ReadInt(root, "settingsVersion", "settingsVersion", issues);
+        var graphics = ReadMapping(root, "graphics", "graphics", issues);
+        var parsed = new WorkspaceEditorSettingsDocument
+        {
+            SettingsVersion = version,
+            Graphics = new EditorGraphicsSettings
+            {
+                SelectedQuality = ReadEnum<EditorQualitySelection>(
+                    graphics,
+                    "selectedQuality",
+                    "graphics.selectedQuality",
+                    issues),
+                StatsMode = ReadEnum<GraphicsStatsMode>(
+                    graphics,
+                    "statsMode",
+                    "graphics.statsMode",
+                    issues)
+            }
+        };
+        issues.AddRange(GraphicsSettingsValidator.Validate(parsed).Issues);
+        if (issues.Count == 0)
+            return parsed;
+
+        AddDiagnostics(diagnostics, source, issues);
+        return GraphicsSettingsDefaults.Editor;
+    }
+
+    internal static void PatchProject(
+        YamlMappingNode root,
+        ProjectSettingsDocument document)
+    {
+        SetScalar(root, "settingsVersion", document.SettingsVersion);
+        var graphics = GetOrCreateMapping(root, "graphics");
+        SetScalar(graphics, "defaultQuality", document.Graphics.DefaultQuality);
+        var presets = GetOrCreateMapping(graphics, "presets");
+        foreach (var quality in QualityLevels)
+        {
+            var preset = GetOrCreateMapping(presets, quality.ToString());
+            PatchPreset(preset, document.Graphics.Presets.Get(quality));
+        }
+    }
+
+    internal static void PatchEditor(
+        YamlMappingNode root,
+        WorkspaceEditorSettingsDocument document)
+    {
+        SetScalar(root, "settingsVersion", document.SettingsVersion);
+        var graphics = GetOrCreateMapping(root, "graphics");
+        SetScalar(graphics, "selectedQuality", document.Graphics.SelectedQuality);
+        SetScalar(graphics, "statsMode", document.Graphics.StatsMode);
+    }
+
+    internal static bool TryLoadRoot(
+        string yaml,
+        string source,
+        ICollection<string> diagnostics,
+        out YamlMappingNode root)
+    {
+        try
+        {
+            var stream = new YamlStream();
+            using var reader = new StringReader(yaml);
+            stream.Load(reader);
+            if (stream.Documents.Count != 1 ||
+                stream.Documents[0].RootNode is not YamlMappingNode mapping)
+            {
+                diagnostics.Add($"{source}: expected one YAML mapping document; using built-in defaults.");
+                root = new YamlMappingNode();
+                return false;
+            }
+
+            root = mapping;
+            return true;
+        }
+        catch (Exception exception)
+        {
+            diagnostics.Add($"{source}: failed to parse YAML ({exception.Message}); using built-in defaults.");
+            root = new YamlMappingNode();
+            return false;
+        }
+    }
+
+    internal static string Save(YamlMappingNode root)
+    {
+        using var writer = new StringWriter(CultureInfo.InvariantCulture);
+        new YamlStream(new YamlDocument(root)).Save(writer, false);
+        return writer.ToString();
+    }
+
+    static GraphicsQualityPresetSettings ReadPreset(
+        YamlMappingNode parent,
+        string key,
+        string path,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+    {
+        var preset = ReadMapping(parent, key, path, issues);
+        return new GraphicsQualityPresetSettings
+        {
+            ResolutionFactor = ReadDouble(preset, "resolutionFactor", $"{path}.resolutionFactor", issues),
+            FpsCap = ReadInt(preset, "fpsCap", $"{path}.fpsCap", issues),
+            MsaaSamples = ReadInt(preset, "msaaSamples", $"{path}.msaaSamples", issues),
+            ShadowQuality = ReadEnum<GraphicsShadowQuality>(preset, "shadowQuality", $"{path}.shadowQuality", issues),
+            ShadowBias = ReadDouble(preset, "shadowBias", $"{path}.shadowBias", issues),
+            ShadowCascadeCount = ReadInt(preset, "shadowCascadeCount", $"{path}.shadowCascadeCount", issues),
+            ShadowCascadeResolutions = ReadIntSequence(preset, "shadowCascadeResolutions", $"{path}.shadowCascadeResolutions", issues),
+            SupportSoftShadows = ReadBool(preset, "supportSoftShadows", $"{path}.supportSoftShadows", issues),
+            CloudsResolutionMultiplier = ReadDouble(preset, "cloudsResolutionMultiplier", $"{path}.cloudsResolutionMultiplier", issues),
+            SkyResolution = ReadInt(preset, "skyResolution", $"{path}.skyResolution", issues),
+            LodBias = ReadInt(preset, "lodBias", $"{path}.lodBias", issues)
+        };
+    }
+
+    static void PatchPreset(
+        YamlMappingNode preset,
+        GraphicsQualityPresetSettings settings)
+    {
+        SetScalar(preset, "resolutionFactor", settings.ResolutionFactor);
+        SetScalar(preset, "fpsCap", settings.FpsCap);
+        SetScalar(preset, "msaaSamples", settings.MsaaSamples);
+        SetScalar(preset, "shadowQuality", settings.ShadowQuality);
+        SetScalar(preset, "shadowBias", settings.ShadowBias);
+        SetScalar(preset, "shadowCascadeCount", settings.ShadowCascadeCount);
+        SetNode(
+            preset,
+            "shadowCascadeResolutions",
+            new YamlSequenceNode(settings.ShadowCascadeResolutions.Select(x =>
+                new YamlScalarNode(x.ToString(CultureInfo.InvariantCulture)))));
+        SetScalar(preset, "supportSoftShadows", settings.SupportSoftShadows);
+        SetScalar(preset, "cloudsResolutionMultiplier", settings.CloudsResolutionMultiplier);
+        SetScalar(preset, "skyResolution", settings.SkyResolution);
+        SetScalar(preset, "lodBias", settings.LodBias);
+    }
+
+    static YamlMappingNode ReadMapping(
+        YamlMappingNode? parent,
+        string key,
+        string path,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+    {
+        if (parent is not null &&
+            parent.Children.TryGetValue(new YamlScalarNode(key), out var node) &&
+            node is YamlMappingNode mapping)
+        {
+            return mapping;
+        }
+
+        issues.Add(new GraphicsSettingsValidationIssue(path, "A YAML mapping is required."));
+        return new YamlMappingNode();
+    }
+
+    static string? ReadScalar(
+        YamlMappingNode? parent,
+        string key,
+        string path,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+    {
+        if (parent is not null &&
+            parent.Children.TryGetValue(new YamlScalarNode(key), out var node) &&
+            node is YamlScalarNode scalar &&
+            scalar.Value is not null)
+        {
+            return scalar.Value;
+        }
+
+        issues.Add(new GraphicsSettingsValidationIssue(path, "A scalar value is required."));
+        return null;
+    }
+
+    static int ReadInt(
+        YamlMappingNode? parent,
+        string key,
+        string path,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+    {
+        var value = ReadScalar(parent, key, path, issues);
+        if (value is not null &&
+            int.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        if (value is not null)
+            issues.Add(new GraphicsSettingsValidationIssue(path, "An integer value is required."));
+        return 0;
+    }
+
+    static double ReadDouble(
+        YamlMappingNode? parent,
+        string key,
+        string path,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+    {
+        var value = ReadScalar(parent, key, path, issues);
+        if (value is not null &&
+            double.TryParse(value, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed))
+        {
+            return parsed;
+        }
+
+        if (value is not null)
+            issues.Add(new GraphicsSettingsValidationIssue(path, "A finite number is required."));
+        return 0;
+    }
+
+    static bool ReadBool(
+        YamlMappingNode? parent,
+        string key,
+        string path,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+    {
+        var value = ReadScalar(parent, key, path, issues);
+        if (value is not null && bool.TryParse(value, out var parsed))
+            return parsed;
+
+        if (value is not null)
+            issues.Add(new GraphicsSettingsValidationIssue(path, "A boolean value is required."));
+        return false;
+    }
+
+    static T ReadEnum<T>(
+        YamlMappingNode? parent,
+        string key,
+        string path,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+        where T : struct, Enum
+    {
+        var value = ReadScalar(parent, key, path, issues);
+        if (value is not null &&
+            Enum.TryParse<T>(value, ignoreCase: false, out var parsed) &&
+            Enum.IsDefined(parsed))
+        {
+            return parsed;
+        }
+
+        if (value is not null)
+            issues.Add(new GraphicsSettingsValidationIssue(path, $"'{value}' is not a supported value."));
+        return default;
+    }
+
+    static IReadOnlyList<int> ReadIntSequence(
+        YamlMappingNode? parent,
+        string key,
+        string path,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+    {
+        if (parent is null ||
+            !parent.Children.TryGetValue(new YamlScalarNode(key), out var node) ||
+            node is not YamlSequenceNode sequence)
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(path, "A sequence of integer values is required."));
+            return [];
+        }
+
+        var values = new List<int>();
+        for (var index = 0; index < sequence.Children.Count; ++index)
+        {
+            if (sequence.Children[index] is YamlScalarNode scalar &&
+                int.TryParse(scalar.Value, NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed))
+            {
+                values.Add(parsed);
+            }
+            else
+            {
+                issues.Add(new GraphicsSettingsValidationIssue(
+                    $"{path}[{index}]",
+                    "An integer value is required."));
+            }
+        }
+
+        return values;
+    }
+
+    static YamlMappingNode GetOrCreateMapping(
+        YamlMappingNode parent,
+        string key)
+    {
+        var yamlKey = new YamlScalarNode(key);
+        if (parent.Children.TryGetValue(yamlKey, out var existing) &&
+            existing is YamlMappingNode mapping)
+        {
+            return mapping;
+        }
+
+        var created = new YamlMappingNode();
+        parent.Children[yamlKey] = created;
+        return created;
+    }
+
+    static void SetScalar<T>(YamlMappingNode parent, string key, T value)
+    {
+        var text = value switch
+        {
+            bool boolean => boolean ? "true" : "false",
+            double number => number.ToString("0.####", CultureInfo.InvariantCulture),
+            float number => number.ToString("0.####", CultureInfo.InvariantCulture),
+            IFormattable formattable => formattable.ToString(null, CultureInfo.InvariantCulture),
+            _ => value?.ToString() ?? string.Empty
+        };
+        SetNode(parent, key, new YamlScalarNode(text));
+    }
+
+    static void SetNode(YamlMappingNode parent, string key, YamlNode value)
+        => parent.Children[new YamlScalarNode(key)] = value;
+
+    static void AddDiagnostics(
+        ICollection<string> diagnostics,
+        string source,
+        IEnumerable<GraphicsSettingsValidationIssue> issues)
+    {
+        foreach (var issue in issues.Distinct())
+            diagnostics.Add($"{source}: {issue.Path}: {issue.Message} Using built-in defaults.");
+    }
+
+    static void ThrowIfInvalid(GraphicsSettingsValidationResult validation)
+    {
+        if (validation.IsValid)
+            return;
+
+        throw new InvalidOperationException(string.Join(
+            Environment.NewLine,
+            validation.Issues.Select(issue => $"{issue.Path}: {issue.Message}")));
+    }
+}

--- a/Editor/Settings/GraphicsSettingsDraft.cs
+++ b/Editor/Settings/GraphicsSettingsDraft.cs
@@ -1,0 +1,314 @@
+using System.Globalization;
+
+namespace SailorEditor.Settings;
+
+public sealed record GraphicsQualityPresetDraft(
+    string ResolutionFactor,
+    string FpsCap,
+    int MsaaSamples,
+    GraphicsShadowQuality ShadowQuality,
+    string ShadowBias,
+    int ShadowCascadeCount,
+    string ShadowCascadeResolutions,
+    bool SupportSoftShadows,
+    string CloudsResolutionMultiplier,
+    string SkyResolution,
+    string LodBias)
+{
+    public static GraphicsQualityPresetDraft FromSettings(
+        GraphicsQualityPresetSettings settings)
+        => new(
+            FormatDouble(settings.ResolutionFactor),
+            settings.FpsCap.ToString(CultureInfo.InvariantCulture),
+            settings.MsaaSamples,
+            settings.ShadowQuality,
+            FormatDouble(settings.ShadowBias),
+            settings.ShadowCascadeCount,
+            string.Join(", ", settings.ShadowCascadeResolutions),
+            settings.SupportSoftShadows,
+            FormatDouble(settings.CloudsResolutionMultiplier),
+            settings.SkyResolution.ToString(CultureInfo.InvariantCulture),
+            settings.LodBias.ToString(CultureInfo.InvariantCulture));
+
+    internal bool TryBuild(
+        GraphicsQualityLevel quality,
+        out GraphicsQualityPresetSettings settings,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+    {
+        var path = $"graphics.presets.{quality}";
+        var valid = true;
+        valid &= TryParseDouble(
+            ResolutionFactor,
+            $"{path}.resolutionFactor",
+            "Resolution factor",
+            issues,
+            out var resolutionFactor);
+        valid &= TryParseInt(
+            FpsCap,
+            $"{path}.fpsCap",
+            "FPS cap",
+            issues,
+            out var fpsCap);
+        valid &= TryParseCascadeResolutions(
+            ShadowCascadeResolutions,
+            $"{path}.shadowCascadeResolutions",
+            issues,
+            out var cascadeResolutions);
+        valid &= TryParseDouble(
+            ShadowBias,
+            $"{path}.shadowBias",
+            "Shadow bias",
+            issues,
+            out var shadowBias);
+        valid &= TryParseDouble(
+            CloudsResolutionMultiplier,
+            $"{path}.cloudsResolutionMultiplier",
+            "Clouds resolution multiplier",
+            issues,
+            out var cloudsResolutionMultiplier);
+        valid &= TryParseInt(
+            SkyResolution,
+            $"{path}.skyResolution",
+            "Sky resolution",
+            issues,
+            out var skyResolution);
+        valid &= TryParseInt(
+            LodBias,
+            $"{path}.lodBias",
+            "LOD bias",
+            issues,
+            out var lodBias);
+
+        settings = new GraphicsQualityPresetSettings
+        {
+            ResolutionFactor = resolutionFactor,
+            FpsCap = fpsCap,
+            MsaaSamples = MsaaSamples,
+            ShadowQuality = ShadowQuality,
+            ShadowBias = shadowBias,
+            ShadowCascadeCount = ShadowCascadeCount,
+            ShadowCascadeResolutions = cascadeResolutions,
+            SupportSoftShadows = SupportSoftShadows,
+            CloudsResolutionMultiplier = cloudsResolutionMultiplier,
+            SkyResolution = skyResolution,
+            LodBias = lodBias
+        };
+        return valid;
+    }
+
+    static bool TryParseDouble(
+        string? text,
+        string path,
+        string displayName,
+        ICollection<GraphicsSettingsValidationIssue> issues,
+        out double value)
+    {
+        if (double.TryParse(
+                text,
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out value) &&
+            double.IsFinite(value))
+        {
+            return true;
+        }
+
+        issues.Add(new GraphicsSettingsValidationIssue(
+            path,
+            $"{displayName} must be a finite number using '.' as the decimal separator."));
+        value = 0;
+        return false;
+    }
+
+    static bool TryParseInt(
+        string? text,
+        string path,
+        string displayName,
+        ICollection<GraphicsSettingsValidationIssue> issues,
+        out int value)
+    {
+        if (int.TryParse(
+                text,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out value))
+        {
+            return true;
+        }
+
+        issues.Add(new GraphicsSettingsValidationIssue(
+            path,
+            $"{displayName} must be an integer."));
+        value = 0;
+        return false;
+    }
+
+    static bool TryParseCascadeResolutions(
+        string? text,
+        string path,
+        ICollection<GraphicsSettingsValidationIssue> issues,
+        out IReadOnlyList<int> values)
+    {
+        var parsed = new List<int>();
+        var parts = (text ?? string.Empty).Split(
+            ',',
+            StringSplitOptions.TrimEntries);
+        if (parts.Length == 0 || parts.Any(string.IsNullOrWhiteSpace))
+        {
+            issues.Add(new GraphicsSettingsValidationIssue(
+                path,
+                "Cascade resolutions must be a comma-separated list of integers."));
+            values = [];
+            return false;
+        }
+
+        foreach (var part in parts)
+        {
+            if (!int.TryParse(
+                    part,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out var value))
+            {
+                issues.Add(new GraphicsSettingsValidationIssue(
+                    path,
+                    $"Cascade resolution '{part}' is not an integer."));
+                values = [];
+                return false;
+            }
+            parsed.Add(value);
+        }
+
+        values = parsed;
+        return true;
+    }
+
+    static string FormatDouble(double value)
+        => value.ToString("0.####", CultureInfo.InvariantCulture);
+}
+
+public sealed class GraphicsSettingsDraft
+{
+    readonly Dictionary<GraphicsQualityLevel, GraphicsQualityPresetDraft> _presets;
+
+    internal GraphicsSettingsDraft(GraphicsSettingsSnapshot sourceSnapshot)
+    {
+        SourceSnapshot = sourceSnapshot ??
+            throw new ArgumentNullException(nameof(sourceSnapshot));
+        ProjectDefaultQuality = sourceSnapshot.Project.Graphics.DefaultQuality;
+        SelectedQuality = sourceSnapshot.Editor.Graphics.SelectedQuality;
+        StatsMode = sourceSnapshot.Editor.Graphics.StatsMode;
+        _presets = Enum.GetValues<GraphicsQualityLevel>()
+            .ToDictionary(
+                quality => quality,
+                quality => GraphicsQualityPresetDraft.FromSettings(
+                    sourceSnapshot.Project.Graphics.Presets.Get(quality)));
+    }
+
+    public GraphicsSettingsSnapshot SourceSnapshot { get; }
+    public GraphicsQualityLevel ProjectDefaultQuality { get; private set; }
+    public EditorQualitySelection SelectedQuality { get; private set; }
+    public GraphicsStatsMode StatsMode { get; private set; }
+    public bool IsDirty { get; private set; }
+
+    public GraphicsQualityPresetDraft GetPreset(GraphicsQualityLevel quality)
+        => _presets[quality];
+
+    public void SetSelections(
+        GraphicsQualityLevel projectDefaultQuality,
+        EditorQualitySelection selectedQuality,
+        GraphicsStatsMode statsMode)
+    {
+        if (ProjectDefaultQuality == projectDefaultQuality &&
+            SelectedQuality == selectedQuality &&
+            StatsMode == statsMode)
+        {
+            return;
+        }
+
+        ProjectDefaultQuality = projectDefaultQuality;
+        SelectedQuality = selectedQuality;
+        StatsMode = statsMode;
+        IsDirty = true;
+    }
+
+    public void SetPreset(
+        GraphicsQualityLevel quality,
+        GraphicsQualityPresetDraft preset)
+    {
+        ArgumentNullException.ThrowIfNull(preset);
+        if (_presets[quality] == preset)
+            return;
+
+        _presets[quality] = preset;
+        IsDirty = true;
+    }
+
+    public bool TryBuild(
+        out ProjectSettingsDocument project,
+        out WorkspaceEditorSettingsDocument editor,
+        out IReadOnlyList<GraphicsSettingsValidationIssue> issues)
+    {
+        var collected = new List<GraphicsSettingsValidationIssue>();
+        var presets = SourceSnapshot.Project.Graphics.Presets;
+        var valid = true;
+        foreach (var quality in Enum.GetValues<GraphicsQualityLevel>())
+        {
+            valid &= _presets[quality].TryBuild(
+                quality,
+                out var preset,
+                collected);
+            presets = presets.With(quality, preset);
+        }
+
+        project = SourceSnapshot.Project with
+        {
+            Graphics = SourceSnapshot.Project.Graphics with
+            {
+                DefaultQuality = ProjectDefaultQuality,
+                Presets = presets
+            }
+        };
+        editor = SourceSnapshot.Editor with
+        {
+            Graphics = SourceSnapshot.Editor.Graphics with
+            {
+                SelectedQuality = SelectedQuality,
+                StatsMode = StatsMode
+            }
+        };
+        collected.AddRange(GraphicsSettingsValidator.Validate(project).Issues);
+        collected.AddRange(GraphicsSettingsValidator.Validate(editor).Issues);
+        issues = collected.Distinct().ToArray();
+        return valid && issues.Count == 0;
+    }
+}
+
+public sealed class GraphicsSettingsDraftSession
+{
+    public GraphicsSettingsDraft? Current { get; private set; }
+
+    public GraphicsSettingsDraft GetOrCreate(GraphicsSettingsSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        if (Current is null || !BelongsToSameWorkspace(Current, snapshot))
+            Current = new GraphicsSettingsDraft(snapshot);
+        return Current;
+    }
+
+    public GraphicsSettingsDraft Replace(GraphicsSettingsSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot);
+        Current = new GraphicsSettingsDraft(snapshot);
+        return Current;
+    }
+
+    public void Clear()
+        => Current = null;
+
+    static bool BelongsToSameWorkspace(
+        GraphicsSettingsDraft draft,
+        GraphicsSettingsSnapshot snapshot)
+        => draft.SourceSnapshot.WorkspaceGeneration == snapshot.WorkspaceGeneration &&
+            draft.SourceSnapshot.Paths == snapshot.Paths;
+}

--- a/Editor/Settings/GraphicsSettingsService.cs
+++ b/Editor/Settings/GraphicsSettingsService.cs
@@ -1,0 +1,873 @@
+using System.Security.Cryptography;
+using System.Text;
+using YamlDotNet.RepresentationModel;
+
+namespace SailorEditor.Settings;
+
+public sealed record GraphicsSettingsApplyResult(
+    bool ProjectChanged,
+    bool QualityChanged,
+    bool StatsChanged,
+    bool EngineRestarted,
+    bool StatsAppliedLive);
+
+public sealed class GraphicsSettingsStaleSnapshotException : InvalidOperationException
+{
+    public GraphicsSettingsStaleSnapshotException(string message)
+        : base(message)
+    {
+    }
+}
+
+public sealed class GraphicsSettingsPersistenceException : InvalidOperationException
+{
+    public GraphicsSettingsPersistenceException(string message)
+        : base(message)
+    {
+    }
+}
+
+public sealed record GraphicsSettingsStorageSnapshot(
+    ProjectSettingsDocument Project,
+    WorkspaceEditorSettingsDocument Editor,
+    GraphicsSettingsFileRevision ProjectRevision,
+    GraphicsSettingsFileRevision EditorRevision,
+    IReadOnlyList<string> Diagnostics);
+
+public interface IGraphicsSettingsStorage
+{
+    Task<GraphicsSettingsStorageSnapshot> LoadAsync(
+        GraphicsSettingsPaths paths,
+        CancellationToken cancellationToken);
+
+    Task ValidateForUpdateAsync(
+        string path,
+        GraphicsSettingsFileRevision expectedRevision,
+        CancellationToken cancellationToken);
+
+    Task<GraphicsSettingsFileRevision> WriteProjectAsync(
+        string path,
+        ProjectSettingsDocument document,
+        GraphicsSettingsFileRevision expectedRevision,
+        CancellationToken cancellationToken);
+
+    Task<GraphicsSettingsFileRevision> WriteEditorAsync(
+        string path,
+        WorkspaceEditorSettingsDocument document,
+        GraphicsSettingsFileRevision expectedRevision,
+        CancellationToken cancellationToken);
+}
+
+public sealed class GraphicsSettingsService
+{
+    readonly Func<GraphicsSettingsPaths> _pathsProvider;
+    readonly Func<CancellationToken, Task<bool>> _restartEngineAsync;
+    readonly Func<GraphicsStatsMode, CancellationToken, Task<bool>> _applyStatsModeAsync;
+    readonly IGraphicsSettingsStorage _storage;
+    readonly Func<long> _workspaceGenerationProvider;
+    readonly Func<Func<CancellationToken, Task>, CancellationToken, Task>
+        _serializeWorkspaceMutationAsync;
+    readonly Func<long, CancellationToken, Task<bool>>
+        _restartEngineForGenerationAsync;
+    readonly Func<GraphicsStatsMode, long, CancellationToken, Task<bool>>
+        _applyStatsModeForGenerationAsync;
+    readonly SemaphoreSlim _gate = new(1, 1);
+    GraphicsSettingsSnapshot? _current;
+
+    public GraphicsSettingsService(
+        Func<GraphicsSettingsPaths> pathsProvider,
+        Func<CancellationToken, Task<bool>>? restartEngineAsync = null,
+        Func<GraphicsStatsMode, CancellationToken, Task<bool>>? applyStatsModeAsync = null,
+        IGraphicsSettingsStorage? storage = null,
+        Func<long>? workspaceGenerationProvider = null,
+        Func<Func<CancellationToken, Task>, CancellationToken, Task>?
+            serializeWorkspaceMutationAsync = null,
+        Func<long, CancellationToken, Task<bool>>?
+            restartEngineForGenerationAsync = null,
+        Func<GraphicsStatsMode, long, CancellationToken, Task<bool>>?
+            applyStatsModeForGenerationAsync = null)
+    {
+        _pathsProvider = pathsProvider ?? throw new ArgumentNullException(nameof(pathsProvider));
+        _restartEngineAsync = restartEngineAsync ?? (_ => Task.FromResult(true));
+        _applyStatsModeAsync = applyStatsModeAsync ?? ((_, _) => Task.FromResult(true));
+        _storage = storage ?? new FileGraphicsSettingsStorage();
+        _workspaceGenerationProvider = workspaceGenerationProvider ?? (() => 0L);
+        _serializeWorkspaceMutationAsync = serializeWorkspaceMutationAsync ??
+            ((operation, cancellationToken) => operation(cancellationToken));
+        _restartEngineForGenerationAsync = restartEngineForGenerationAsync ??
+            ((_, cancellationToken) => _restartEngineAsync(cancellationToken));
+        _applyStatsModeForGenerationAsync = applyStatsModeForGenerationAsync ??
+            ((mode, _, cancellationToken) =>
+                _applyStatsModeAsync(mode, cancellationToken));
+    }
+
+    public GraphicsSettingsSnapshot? Current => Volatile.Read(ref _current);
+
+    public event EventHandler<GraphicsSettingsSnapshot>? SettingsChanged;
+
+    public async Task<GraphicsSettingsSnapshot> EnsureLoadedAsync(
+        CancellationToken cancellationToken = default)
+        => await LoadForCurrentWorkspaceAsync(
+                forceReload: false,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+    public async Task<GraphicsSettingsSnapshot> ReloadAsync(
+        CancellationToken cancellationToken = default)
+        => await LoadForCurrentWorkspaceAsync(
+                forceReload: true,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+    async Task<GraphicsSettingsSnapshot> LoadForCurrentWorkspaceAsync(
+        bool forceReload,
+        CancellationToken cancellationToken)
+    {
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (!TryCaptureWorkspace(out var workspace))
+                continue;
+
+            if (!forceReload && Current is { } cached &&
+                SnapshotMatchesWorkspace(cached, workspace))
+            {
+                return cached;
+            }
+
+            GraphicsSettingsSnapshot? loaded = null;
+            var retry = false;
+            await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+            try
+            {
+                if (!IsWorkspaceCurrent(workspace))
+                {
+                    retry = true;
+                }
+                else if (!forceReload && Current is { } current &&
+                    SnapshotMatchesWorkspace(current, workspace))
+                {
+                    return current;
+                }
+                else
+                {
+                    loaded = await LoadCoreAsync(workspace, cancellationToken)
+                        .ConfigureAwait(false);
+                    if (!IsWorkspaceCurrent(workspace))
+                    {
+                        retry = true;
+                        loaded = null;
+                    }
+                    else
+                    {
+                        Volatile.Write(ref _current, loaded);
+                    }
+                }
+            }
+            finally
+            {
+                _gate.Release();
+            }
+
+            if (retry || loaded is null)
+                continue;
+
+            if (!IsWorkspaceCurrent(workspace))
+            {
+                Interlocked.CompareExchange(ref _current, null, loaded);
+                continue;
+            }
+
+            PublishChanged(loaded);
+            return loaded;
+        }
+    }
+
+    public async Task<GraphicsSettingsApplyResult> ApplyAsync(
+        ProjectSettingsDocument project,
+        WorkspaceEditorSettingsDocument editor,
+        GraphicsSettingsSnapshot? expectedSnapshot = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(project);
+        ArgumentNullException.ThrowIfNull(editor);
+        ThrowIfInvalid(GraphicsSettingsValidator.Validate(project));
+        ThrowIfInvalid(GraphicsSettingsValidator.Validate(editor));
+
+        var workspace = CaptureWorkspaceOrThrow();
+        if (expectedSnapshot is not null &&
+            !SnapshotMatchesWorkspace(expectedSnapshot, workspace))
+        {
+            throw new GraphicsSettingsStaleSnapshotException(
+                "The active workspace changed while graphics settings were being edited. Reload the Settings panel before applying.");
+        }
+
+        bool projectChanged;
+        bool qualityChanged;
+        bool statsChanged;
+        GraphicsSettingsSnapshot updated;
+        await _gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            ThrowIfWorkspaceChanged(workspace);
+            var current = Current;
+            if (current is null || !SnapshotMatchesWorkspace(current, workspace))
+            {
+                current = await LoadCoreAsync(workspace, cancellationToken)
+                    .ConfigureAwait(false);
+                ThrowIfWorkspaceChanged(workspace);
+            }
+            if (expectedSnapshot is not null &&
+                !ReferenceEquals(current, expectedSnapshot))
+            {
+                throw new GraphicsSettingsStaleSnapshotException(
+                    "Graphics settings changed while they were being edited. Reload before applying.");
+            }
+
+            projectChanged = !GraphicsSettingsEquality.ProjectEquals(
+                current.Project,
+                project);
+            var selectedQualityChanged =
+                current.Editor.Graphics.SelectedQuality !=
+                editor.Graphics.SelectedQuality;
+            statsChanged = current.Editor.Graphics.StatsMode !=
+                editor.Graphics.StatsMode;
+            var editorChanged = selectedQualityChanged || statsChanged;
+            qualityChanged = projectChanged || selectedQualityChanged;
+
+            GraphicsSettingsSnapshot? persisted = null;
+            await _serializeWorkspaceMutationAsync(
+                async mutationCancellationToken =>
+                {
+                    ThrowIfWorkspaceChanged(workspace);
+                    await _storage.ValidateForUpdateAsync(
+                            workspace.Paths.ProjectSettingsPath,
+                            current.ProjectRevision,
+                            mutationCancellationToken)
+                        .ConfigureAwait(false);
+                    ThrowIfWorkspaceChanged(workspace);
+                    await _storage.ValidateForUpdateAsync(
+                            workspace.Paths.EditorSettingsPath,
+                            current.EditorRevision,
+                            mutationCancellationToken)
+                        .ConfigureAwait(false);
+                    ThrowIfWorkspaceChanged(workspace);
+
+                    var expectedProjectRevision = current.ProjectRevision;
+                    var expectedEditorRevision = current.EditorRevision;
+                    if (projectChanged)
+                    {
+                        expectedProjectRevision = await _storage.WriteProjectAsync(
+                                workspace.Paths.ProjectSettingsPath,
+                                project,
+                                current.ProjectRevision,
+                                mutationCancellationToken)
+                            .ConfigureAwait(false);
+                        ThrowIfWorkspaceChanged(workspace);
+                    }
+
+                    if (editorChanged)
+                    {
+                        expectedEditorRevision = await _storage.WriteEditorAsync(
+                                workspace.Paths.EditorSettingsPath,
+                                editor,
+                                current.EditorRevision,
+                                mutationCancellationToken)
+                            .ConfigureAwait(false);
+                        ThrowIfWorkspaceChanged(workspace);
+                    }
+
+                    var reloaded = projectChanged || editorChanged
+                        ? await LoadCoreAsync(
+                                workspace,
+                                mutationCancellationToken)
+                            .ConfigureAwait(false)
+                        : current;
+                    ThrowIfWorkspaceChanged(workspace);
+                    if (reloaded.ProjectRevision != expectedProjectRevision ||
+                        reloaded.EditorRevision != expectedEditorRevision ||
+                        (projectChanged && !GraphicsSettingsEquality.ProjectEquals(
+                            reloaded.Project,
+                            project)) ||
+                        (editorChanged && !GraphicsSettingsEquality.EditorEquals(
+                            reloaded.Editor,
+                            editor)))
+                    {
+                        throw new GraphicsSettingsStaleSnapshotException(
+                            "A graphics settings file changed while the update was being finalized. Reload before applying again.");
+                    }
+                    persisted = reloaded;
+                },
+                cancellationToken).ConfigureAwait(false);
+            updated = persisted ?? throw new InvalidOperationException(
+                "The graphics settings persistence turn did not produce a snapshot.");
+            Volatile.Write(ref _current, updated);
+        }
+        finally
+        {
+            _gate.Release();
+        }
+
+        if (!IsWorkspaceCurrent(workspace))
+        {
+            Interlocked.CompareExchange(ref _current, null, updated);
+            throw new GraphicsSettingsStaleSnapshotException(
+                "The active workspace changed before graphics settings could be published.");
+        }
+        PublishChanged(updated);
+
+        var restarted = false;
+        var statsApplied = false;
+        if (qualityChanged)
+        {
+            ThrowIfWorkspaceChanged(workspace);
+            restarted = await _restartEngineForGenerationAsync(
+                    workspace.Generation,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            ThrowIfWorkspaceChanged(workspace);
+            if (statsChanged && !restarted)
+            {
+                ThrowIfWorkspaceChanged(workspace);
+                statsApplied = await _applyStatsModeForGenerationAsync(
+                        editor.Graphics.StatsMode,
+                        workspace.Generation,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+                ThrowIfWorkspaceChanged(workspace);
+            }
+        }
+        else if (statsChanged)
+        {
+            ThrowIfWorkspaceChanged(workspace);
+            statsApplied = await _applyStatsModeForGenerationAsync(
+                    editor.Graphics.StatsMode,
+                    workspace.Generation,
+                    cancellationToken)
+                .ConfigureAwait(false);
+            ThrowIfWorkspaceChanged(workspace);
+        }
+
+        return new GraphicsSettingsApplyResult(
+            projectChanged,
+            qualityChanged,
+            statsChanged,
+            restarted,
+            statsApplied);
+    }
+
+    public async Task<GraphicsSettingsApplyResult> SetSelectedQualityAsync(
+        EditorQualitySelection selectedQuality,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Enum.IsDefined(selectedQuality))
+            throw new ArgumentOutOfRangeException(nameof(selectedQuality));
+
+        return await ApplyLatestEditorChangeAsync(
+                editor => editor with
+                {
+                    Graphics = editor.Graphics with
+                    {
+                        SelectedQuality = selectedQuality
+                    }
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<GraphicsSettingsApplyResult> SetStatsModeAsync(
+        GraphicsStatsMode statsMode,
+        CancellationToken cancellationToken = default)
+    {
+        if (!Enum.IsDefined(statsMode))
+            throw new ArgumentOutOfRangeException(nameof(statsMode));
+
+        return await ApplyLatestEditorChangeAsync(
+                editor => editor with
+                {
+                    Graphics = editor.Graphics with
+                    {
+                        StatsMode = statsMode
+                    }
+                },
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    async Task<GraphicsSettingsApplyResult> ApplyLatestEditorChangeAsync(
+        Func<WorkspaceEditorSettingsDocument, WorkspaceEditorSettingsDocument> update,
+        CancellationToken cancellationToken)
+    {
+        for (var attempt = 0; attempt < 3; ++attempt)
+        {
+            var current = await EnsureLoadedAsync(cancellationToken)
+                .ConfigureAwait(false);
+            try
+            {
+                return await ApplyAsync(
+                        current.Project,
+                        update(current.Editor),
+                        current,
+                        cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (GraphicsSettingsStaleSnapshotException) when (attempt < 2)
+            {
+            }
+        }
+
+        throw new GraphicsSettingsStaleSnapshotException(
+            "Graphics settings kept changing while the editor update was being applied.");
+    }
+
+    GraphicsSettingsPaths ResolvePaths()
+    {
+        var paths = _pathsProvider() ??
+            throw new InvalidOperationException(
+                "The active workspace did not provide graphics settings paths.");
+        return GraphicsSettingsPaths.Create(
+            paths.WorkspaceRoot,
+            paths.CacheDirectory);
+    }
+
+    bool TryCaptureWorkspace(out WorkspaceStamp workspace)
+    {
+        var generationBefore = _workspaceGenerationProvider();
+        var paths = ResolvePaths();
+        var generationAfter = _workspaceGenerationProvider();
+        if (generationBefore != generationAfter)
+        {
+            workspace = default;
+            return false;
+        }
+
+        workspace = new WorkspaceStamp(paths, generationAfter);
+        return true;
+    }
+
+    WorkspaceStamp CaptureWorkspaceOrThrow()
+    {
+        if (TryCaptureWorkspace(out var workspace))
+            return workspace;
+
+        throw new GraphicsSettingsStaleSnapshotException(
+            "The active workspace changed while graphics settings were being resolved. Try again.");
+    }
+
+    bool IsWorkspaceCurrent(WorkspaceStamp workspace)
+        => TryCaptureWorkspace(out var current) &&
+            current.Generation == workspace.Generation &&
+            PathsEqual(current.Paths, workspace.Paths);
+
+    void ThrowIfWorkspaceChanged(WorkspaceStamp workspace)
+    {
+        if (!IsWorkspaceCurrent(workspace))
+        {
+            if (Current is { } stale &&
+                SnapshotMatchesWorkspace(stale, workspace))
+            {
+                Interlocked.CompareExchange(ref _current, null, stale);
+            }
+            throw new GraphicsSettingsStaleSnapshotException(
+                "The active workspace changed during the graphics settings operation. Reload and try again.");
+        }
+    }
+
+    static bool SnapshotMatchesWorkspace(
+        GraphicsSettingsSnapshot snapshot,
+        WorkspaceStamp workspace)
+        => snapshot.WorkspaceGeneration == workspace.Generation &&
+            PathsEqual(snapshot.Paths, workspace.Paths);
+
+    async Task<GraphicsSettingsSnapshot> LoadCoreAsync(
+        WorkspaceStamp workspace,
+        CancellationToken cancellationToken)
+    {
+        var stored = await _storage.LoadAsync(
+                workspace.Paths,
+                cancellationToken)
+            .ConfigureAwait(false);
+        return new GraphicsSettingsSnapshot(
+            workspace.Paths,
+            workspace.Generation,
+            stored.Project,
+            stored.Editor,
+            stored.ProjectRevision,
+            stored.EditorRevision,
+            stored.Diagnostics);
+    }
+
+    static void ThrowIfInvalid(GraphicsSettingsValidationResult validation)
+    {
+        if (validation.IsValid)
+            return;
+
+        throw new InvalidOperationException(string.Join(
+            Environment.NewLine,
+            validation.Issues.Select(issue =>
+                $"{issue.Path}: {issue.Message}")));
+    }
+
+    static bool PathsEqual(
+        GraphicsSettingsPaths left,
+        GraphicsSettingsPaths right)
+    {
+        var comparison = OperatingSystem.IsWindows()
+            ? StringComparison.OrdinalIgnoreCase
+            : StringComparison.Ordinal;
+        return string.Equals(
+                left.WorkspaceRoot,
+                right.WorkspaceRoot,
+                comparison) &&
+            string.Equals(
+                left.CacheDirectory,
+                right.CacheDirectory,
+                comparison);
+    }
+
+    void PublishChanged(GraphicsSettingsSnapshot snapshot)
+        => SettingsChanged?.Invoke(this, snapshot);
+
+    readonly record struct WorkspaceStamp(
+        GraphicsSettingsPaths Paths,
+        long Generation);
+}
+
+public sealed class FileGraphicsSettingsStorage : IGraphicsSettingsStorage
+{
+    public async Task<GraphicsSettingsStorageSnapshot> LoadAsync(
+        GraphicsSettingsPaths paths,
+        CancellationToken cancellationToken)
+    {
+        var diagnostics = new List<string>();
+        var projectFile = await ReadFileAsync(
+                paths.ProjectSettingsPath,
+                cancellationToken)
+            .ConfigureAwait(false);
+        var editorFile = await ReadFileAsync(
+                paths.EditorSettingsPath,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var project = projectFile.Revision.Kind switch
+        {
+            GraphicsSettingsFileRevisionKind.Readable =>
+                GraphicsSettingsYamlCodec.ParseProject(
+                    projectFile.Text!,
+                    diagnostics,
+                    paths.ProjectSettingsPath),
+            GraphicsSettingsFileRevisionKind.Missing =>
+                AddMissingProjectDiagnostic(
+                    paths.ProjectSettingsPath,
+                    diagnostics),
+            _ => AddUnreadableProjectDiagnostic(
+                paths.ProjectSettingsPath,
+                projectFile.Error,
+                diagnostics)
+        };
+        var editor = editorFile.Revision.Kind switch
+        {
+            GraphicsSettingsFileRevisionKind.Readable =>
+                GraphicsSettingsYamlCodec.ParseEditor(
+                    editorFile.Text!,
+                    diagnostics,
+                    paths.EditorSettingsPath),
+            GraphicsSettingsFileRevisionKind.Missing =>
+                AddMissingEditorDiagnostic(
+                    paths.EditorSettingsPath,
+                    diagnostics),
+            _ => AddUnreadableEditorDiagnostic(
+                paths.EditorSettingsPath,
+                editorFile.Error,
+                diagnostics)
+        };
+
+        return new GraphicsSettingsStorageSnapshot(
+            project,
+            editor,
+            projectFile.Revision,
+            editorFile.Revision,
+            diagnostics);
+    }
+
+    public async Task ValidateForUpdateAsync(
+        string path,
+        GraphicsSettingsFileRevision expectedRevision,
+        CancellationToken cancellationToken)
+        => _ = await ReadRootForUpdateAsync(
+                path,
+                expectedRevision,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+    public Task<GraphicsSettingsFileRevision> WriteProjectAsync(
+        string path,
+        ProjectSettingsDocument document,
+        GraphicsSettingsFileRevision expectedRevision,
+        CancellationToken cancellationToken)
+        => WritePatchedAsync(
+            path,
+            root => GraphicsSettingsYamlCodec.PatchProject(root, document),
+            expectedRevision,
+            cancellationToken);
+
+    public Task<GraphicsSettingsFileRevision> WriteEditorAsync(
+        string path,
+        WorkspaceEditorSettingsDocument document,
+        GraphicsSettingsFileRevision expectedRevision,
+        CancellationToken cancellationToken)
+        => WritePatchedAsync(
+            path,
+            root => GraphicsSettingsYamlCodec.PatchEditor(root, document),
+            expectedRevision,
+            cancellationToken);
+
+    static ProjectSettingsDocument AddMissingProjectDiagnostic(
+        string path,
+        ICollection<string> diagnostics)
+    {
+        diagnostics.Add(
+            $"{path}: project settings file was not found; using built-in defaults.");
+        return GraphicsSettingsDefaults.Project;
+    }
+
+    static ProjectSettingsDocument AddUnreadableProjectDiagnostic(
+        string path,
+        string? error,
+        ICollection<string> diagnostics)
+    {
+        diagnostics.Add(
+            $"{path}: failed to read project settings ({error ?? "unknown I/O error"}); using built-in defaults.");
+        return GraphicsSettingsDefaults.Project;
+    }
+
+    static WorkspaceEditorSettingsDocument AddMissingEditorDiagnostic(
+        string path,
+        ICollection<string> diagnostics)
+    {
+        diagnostics.Add(
+            $"{path}: workspace editor settings file was not found; using built-in defaults.");
+        return GraphicsSettingsDefaults.Editor;
+    }
+
+    static WorkspaceEditorSettingsDocument AddUnreadableEditorDiagnostic(
+        string path,
+        string? error,
+        ICollection<string> diagnostics)
+    {
+        diagnostics.Add(
+            $"{path}: failed to read workspace editor settings ({error ?? "unknown I/O error"}); using built-in defaults.");
+        return GraphicsSettingsDefaults.Editor;
+    }
+
+    static async Task<GraphicsSettingsFileRead> ReadFileAsync(
+        string path,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            if (!File.Exists(path))
+                return GraphicsSettingsFileRead.Missing;
+
+            var bytes = await File.ReadAllBytesAsync(path, cancellationToken)
+                .ConfigureAwait(false);
+            return GraphicsSettingsFileRead.Readable(
+                DecodeText(bytes),
+                CalculateHash(bytes));
+        }
+        catch (Exception exception) when (exception is not OperationCanceledException)
+        {
+            if (!File.Exists(path))
+                return GraphicsSettingsFileRead.Missing;
+            return GraphicsSettingsFileRead.Unreadable(exception.Message);
+        }
+    }
+
+    static string DecodeText(byte[] bytes)
+    {
+        using var stream = new MemoryStream(bytes, writable: false);
+        using var reader = new StreamReader(
+            stream,
+            Encoding.UTF8,
+            detectEncodingFromByteOrderMarks: true);
+        return reader.ReadToEnd();
+    }
+
+    static string CalculateHash(ReadOnlySpan<byte> bytes)
+        => Convert.ToHexString(SHA256.HashData(bytes));
+
+    static async Task<GraphicsSettingsFileUpdate> ReadRootForUpdateAsync(
+        string path,
+        GraphicsSettingsFileRevision expectedRevision,
+        CancellationToken cancellationToken)
+    {
+        var current = await ReadFileAsync(path, cancellationToken)
+            .ConfigureAwait(false);
+        if (current.Revision != expectedRevision)
+        {
+            throw new GraphicsSettingsStaleSnapshotException(
+                $"Settings file '{path}' changed outside the editor. Reload before applying.");
+        }
+        if (current.Revision.Kind == GraphicsSettingsFileRevisionKind.Unreadable)
+        {
+            throw new GraphicsSettingsPersistenceException(
+                $"Settings file '{path}' cannot be read and will not be overwritten: {current.Error ?? "unknown I/O error"}.");
+        }
+        if (current.Revision.Kind == GraphicsSettingsFileRevisionKind.Missing)
+        {
+            return new GraphicsSettingsFileUpdate(
+                new YamlMappingNode(),
+                current.Revision);
+        }
+
+        var diagnostics = new List<string>();
+        if (!GraphicsSettingsYamlCodec.TryLoadRoot(
+                current.Text!,
+                path,
+                diagnostics,
+                out var root))
+        {
+            throw new GraphicsSettingsPersistenceException(
+                $"Settings file '{path}' is malformed and will not be overwritten: {string.Join(" ", diagnostics)}");
+        }
+        return new GraphicsSettingsFileUpdate(root, current.Revision);
+    }
+
+    static async Task<GraphicsSettingsFileRevision> WritePatchedAsync(
+        string path,
+        Action<YamlMappingNode> patch,
+        GraphicsSettingsFileRevision expectedRevision,
+        CancellationToken cancellationToken)
+    {
+        var directory = Path.GetDirectoryName(path);
+        if (string.IsNullOrWhiteSpace(directory))
+            throw new InvalidOperationException(
+                $"Settings path does not have a parent directory: {path}");
+        Directory.CreateDirectory(directory);
+
+        var current = await ReadRootForUpdateAsync(
+                path,
+                expectedRevision,
+                cancellationToken)
+            .ConfigureAwait(false);
+        patch(current.Root);
+        var bytes = Encoding.UTF8.GetBytes(
+            GraphicsSettingsYamlCodec.Save(current.Root));
+        var writtenRevision = GraphicsSettingsFileRevision.Readable(
+            CalculateHash(bytes));
+        var temporaryPath = Path.Combine(
+            directory,
+            $".{Path.GetFileName(path)}.{Guid.NewGuid():N}.tmp");
+        try
+        {
+            await using (var stream = new FileStream(
+                temporaryPath,
+                FileMode.CreateNew,
+                FileAccess.Write,
+                FileShare.None,
+                bufferSize: 4096,
+                options: FileOptions.Asynchronous | FileOptions.WriteThrough))
+            {
+                await stream.WriteAsync(bytes, cancellationToken)
+                    .ConfigureAwait(false);
+                await stream.FlushAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+
+            var beforeReplace = await ReadFileAsync(path, cancellationToken)
+                .ConfigureAwait(false);
+            if (beforeReplace.Revision != current.Revision)
+            {
+                throw new GraphicsSettingsStaleSnapshotException(
+                    $"Settings file '{path}' changed while the replacement was being prepared. The external version was preserved.");
+            }
+
+            File.Move(temporaryPath, path, overwrite: true);
+            return writtenRevision;
+        }
+        finally
+        {
+            if (File.Exists(temporaryPath))
+                File.Delete(temporaryPath);
+        }
+    }
+
+    sealed record GraphicsSettingsFileRead(
+        GraphicsSettingsFileRevision Revision,
+        string? Text,
+        string? Error)
+    {
+        public static GraphicsSettingsFileRead Missing { get; } = new(
+            GraphicsSettingsFileRevision.Missing,
+            null,
+            null);
+
+        public static GraphicsSettingsFileRead Readable(
+            string text,
+            string hash)
+            => new(
+                GraphicsSettingsFileRevision.Readable(hash),
+                text,
+                null);
+
+        public static GraphicsSettingsFileRead Unreadable(string error)
+            => new(
+                GraphicsSettingsFileRevision.Unreadable,
+                null,
+                error);
+    }
+
+    sealed record GraphicsSettingsFileUpdate(
+        YamlMappingNode Root,
+        GraphicsSettingsFileRevision Revision);
+}
+
+static class GraphicsSettingsEquality
+{
+    public static bool ProjectEquals(
+        ProjectSettingsDocument left,
+        ProjectSettingsDocument right)
+    {
+        if (left.SettingsVersion != right.SettingsVersion ||
+            left.Graphics.DefaultQuality != right.Graphics.DefaultQuality)
+        {
+            return false;
+        }
+
+        foreach (var quality in Enum.GetValues<GraphicsQualityLevel>())
+        {
+            if (!PresetEquals(
+                    left.Graphics.Presets.Get(quality),
+                    right.Graphics.Presets.Get(quality)))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public static bool EditorEquals(
+        WorkspaceEditorSettingsDocument left,
+        WorkspaceEditorSettingsDocument right)
+        => left.SettingsVersion == right.SettingsVersion &&
+            left.Graphics.SelectedQuality == right.Graphics.SelectedQuality &&
+            left.Graphics.StatsMode == right.Graphics.StatsMode;
+
+    static bool PresetEquals(
+        GraphicsQualityPresetSettings left,
+        GraphicsQualityPresetSettings right)
+        => left.ResolutionFactor.Equals(right.ResolutionFactor) &&
+            left.FpsCap == right.FpsCap &&
+            left.MsaaSamples == right.MsaaSamples &&
+            left.ShadowQuality == right.ShadowQuality &&
+            left.ShadowBias.Equals(right.ShadowBias) &&
+            left.ShadowCascadeCount == right.ShadowCascadeCount &&
+            left.ShadowCascadeResolutions.SequenceEqual(
+                right.ShadowCascadeResolutions) &&
+            left.SupportSoftShadows == right.SupportSoftShadows &&
+            left.CloudsResolutionMultiplier.Equals(
+                right.CloudsResolutionMultiplier) &&
+            left.SkyResolution == right.SkyResolution &&
+            left.LodBias == right.LodBias;
+}

--- a/Editor/Shell/EditorShellContracts.cs
+++ b/Editor/Shell/EditorShellContracts.cs
@@ -21,3 +21,28 @@ public interface IEditorShellHost
 
     ValueTask FocusPanelAsync(PanelId panelId, CancellationToken cancellationToken = default);
 }
+
+public sealed class SplitResizeDragState
+{
+    public double Translation { get; private set; }
+
+    public void Begin()
+        => Translation = 0;
+
+    public double Update(double translation)
+    {
+        if (double.IsFinite(translation))
+            Translation = translation;
+        return Translation;
+    }
+
+    public double Complete()
+    {
+        var translation = Translation;
+        Translation = 0;
+        return translation;
+    }
+
+    public void Cancel()
+        => Translation = 0;
+}

--- a/Editor/Shell/ShellLayoutView.cs
+++ b/Editor/Shell/ShellLayoutView.cs
@@ -173,6 +173,7 @@ public sealed class ShellLayoutView : ContentView
         var startPrimary = 0d;
         var startSecondary = 0d;
         var totalAvailable = 0d;
+        var dragState = new SplitResizeDragState();
 
         pan.PanUpdated += (_, e) =>
         {
@@ -180,6 +181,7 @@ public sealed class ShellLayoutView : ContentView
             {
                 case GestureStatus.Started:
                     IsResizing = true;
+                    dragState.Begin();
                     CaptureSplitSizes(split, grid, leadingIndex, out startPrimary, out startSecondary, out totalAvailable);
                     break;
 
@@ -187,13 +189,15 @@ public sealed class ShellLayoutView : ContentView
                     if (totalAvailable <= 0)
                         return;
 
-                    var translation = isHorizontal ? e.TotalX : e.TotalY;
-                    var primary = Math.Clamp(startPrimary + translation, 40d, totalAvailable - 40d);
+                    var requestedTranslation = isHorizontal ? e.TotalX : e.TotalY;
+                    var primary = Math.Clamp(startPrimary + requestedTranslation, 40d, totalAvailable - 40d);
                     var secondary = Math.Max(totalAvailable - primary, 40d);
+                    dragState.Update(primary - startPrimary);
                     ApplySplitSizes(split, grid, leadingIndex, primary, secondary);
                     break;
 
                 case GestureStatus.Canceled:
+                    dragState.Cancel();
                     IsResizing = false;
                     Rebuild();
                     break;
@@ -201,7 +205,10 @@ public sealed class ShellLayoutView : ContentView
                 case GestureStatus.Completed:
                     if (totalAvailable > 0 && Host is not null)
                     {
-                        var translationDelta = isHorizontal ? e.TotalX : e.TotalY;
+                        // MacCatalyst reports TotalX/TotalY as zero on the Completed
+                        // event. Persist the last applied Running value so the split
+                        // does not snap back when the pointer is released.
+                        var translationDelta = dragState.Complete();
                         var ratioDelta = translationDelta / totalAvailable * (split.SizeRatios[leadingIndex] + split.SizeRatios[leadingIndex + 1]);
                         _ = MainThread.InvokeOnMainThreadAsync(async () =>
                         {
@@ -218,6 +225,7 @@ public sealed class ShellLayoutView : ContentView
                     }
                     else
                     {
+                        dragState.Cancel();
                         IsResizing = false;
                         Rebuild();
                     }

--- a/Editor/Views/SceneView.xaml
+++ b/Editor/Views/SceneView.xaml
@@ -10,7 +10,7 @@
                 Stroke="#2A2A2A"
                 StrokeThickness="1"
                 Padding="3,2">
-            <Grid ColumnDefinitions="*,Auto"
+            <Grid ColumnDefinitions="*,Auto,Auto,Auto"
                   ColumnSpacing="4">
                 <HorizontalStackLayout Spacing="3"
                                        Grid.Column="0"
@@ -57,7 +57,39 @@
                         Clicked="OnTransformSpaceClicked" />
                 </HorizontalStackLayout>
 
-                <Border Grid.Column="1"
+                <HorizontalStackLayout Grid.Column="1"
+                                       Spacing="4"
+                                       VerticalOptions="Center">
+                    <Label Text="Quality"
+                           FontSize="11"
+                           VerticalTextAlignment="Center" />
+                    <Picker x:Name="QualityPicker"
+                            WidthRequest="118"
+                            HeightRequest="26"
+                            MinimumHeightRequest="26"
+                            FontSize="11"
+                            AutomationProperties.Name="Scene View Quality"
+                            ToolTipProperties.Text="Scene View graphics quality (requires Engine restart)"
+                            SelectedIndexChanged="OnQualitySelectedIndexChanged" />
+                </HorizontalStackLayout>
+
+                <HorizontalStackLayout Grid.Column="2"
+                                       Spacing="4"
+                                       VerticalOptions="Center">
+                    <Label Text="Stats"
+                           FontSize="11"
+                           VerticalTextAlignment="Center" />
+                    <Picker x:Name="StatsModePicker"
+                            WidthRequest="154"
+                            HeightRequest="26"
+                            MinimumHeightRequest="26"
+                            FontSize="11"
+                            AutomationProperties.Name="Scene View Stats"
+                            ToolTipProperties.Text="Scene View renderer statistics overlay"
+                            SelectedIndexChanged="OnStatsModeSelectedIndexChanged" />
+                </HorizontalStackLayout>
+
+                <Border Grid.Column="3"
                         Stroke="#3B3F46"
                         StrokeThickness="1"
                         BackgroundColor="#2A2E35"

--- a/Editor/Views/SceneView.xaml.cs
+++ b/Editor/Views/SceneView.xaml.cs
@@ -51,14 +51,17 @@ namespace SailorEditor.Views
         readonly SceneViewportSelectionRouter selectionRouter = new(NullSceneViewportSelectionPicker.Instance);
         readonly EditorViewportEventRevisionGate viewportEventRevisionGate = new();
         readonly UnifiedSettingsStore settingsStore;
+        readonly GraphicsSettingsService graphicsSettingsService;
         readonly NativeViewportInputQueue nativeViewportInputQueue;
         readonly object viewportToolStateLock = new();
         readonly SemaphoreSlim viewportToolStateGate = new(1, 1);
+        readonly SemaphoreSlim graphicsSettingsGate = new(1, 1);
         SceneViewportToolState viewportToolState =
             SceneViewportToolShortcuts.Default;
         long lastViewportIntegrationTickMs = -1;
         long lastViewportStatusTickMs = -1;
         bool lifecycleSubscribed;
+        bool updatingGraphicsPickers;
 #if WINDOWS || MACCATALYST
         static readonly bool UseNativeViewportHost = true;
 #else
@@ -70,6 +73,7 @@ namespace SailorEditor.Views
             InitializeComponent();
             UpdateViewportToolVisuals();
             settingsStore = MauiProgram.GetService<UnifiedSettingsStore>();
+            graphicsSettingsService = MauiProgram.GetService<GraphicsSettingsService>();
             engineService = MauiProgram.GetService<EngineService>();
             worldService = MauiProgram.GetService<WorldService>();
             commandDispatcher = MauiProgram.GetService<ICommandDispatcher>();
@@ -85,6 +89,12 @@ namespace SailorEditor.Views
             UpdateRestartEngineButton(engineService.State);
             var shellState = MauiProgram.GetService<State.ShellState>();
             focusCoordinator = new SceneShellFocusCoordinator(shellState, $"scene:{EngineService.SceneViewportId}", () => ResolveFocusTarget(shellState));
+            QualityPicker.ItemsSource = QualityOptions
+                .Select(option => option.DisplayName)
+                .ToList();
+            StatsModePicker.ItemsSource = StatsModeOptions
+                .Select(option => option.DisplayName)
+                .ToList();
 
 #if !WINDOWS && !MACCATALYST
             var tapGesture = new TapGestureRecognizer();
@@ -155,6 +165,7 @@ namespace SailorEditor.Views
                 isRunning = true;
                 SubscribeToEngineLifecycle();
                 _ = RefreshViewportToolStateAsync();
+                _ = RefreshGraphicsSettingsAsync(reload: false);
 #if MACCATALYST
                 if (!UseNativeViewportHost)
                 {
@@ -333,6 +344,8 @@ namespace SailorEditor.Views
 
             engineService.OnLifecycleStateChanged += OnEngineLifecycleStateChanged;
             engineService.OnEditorViewportEvents += OnEditorViewportEvents;
+            graphicsSettingsService.SettingsChanged += OnGraphicsSettingsChanged;
+            workspaceUiService.ProjectionChanged += OnWorkspaceProjectionChanged;
             viewportEventRevisionGate.Reset();
             lifecycleSubscribed = true;
         }
@@ -344,6 +357,8 @@ namespace SailorEditor.Views
 
             engineService.OnLifecycleStateChanged -= OnEngineLifecycleStateChanged;
             engineService.OnEditorViewportEvents -= OnEditorViewportEvents;
+            graphicsSettingsService.SettingsChanged -= OnGraphicsSettingsChanged;
+            workspaceUiService.ProjectionChanged -= OnWorkspaceProjectionChanged;
             lifecycleSubscribed = false;
         }
 
@@ -384,6 +399,174 @@ namespace SailorEditor.Views
                 UpdateRestartEngineButton(engineService.State);
             }
         }
+
+        async void OnQualitySelectedIndexChanged(
+            object sender,
+            EventArgs e)
+        {
+            if (updatingGraphicsPickers ||
+                QualityPicker.SelectedIndex < 0 ||
+                QualityPicker.SelectedIndex >= QualityOptions.Length)
+            {
+                return;
+            }
+
+            await ApplyQualitySelectionAsync(
+                QualityOptions[QualityPicker.SelectedIndex].Value);
+        }
+
+        async void OnStatsModeSelectedIndexChanged(
+            object sender,
+            EventArgs e)
+        {
+            if (updatingGraphicsPickers ||
+                StatsModePicker.SelectedIndex < 0 ||
+                StatsModePicker.SelectedIndex >= StatsModeOptions.Length)
+            {
+                return;
+            }
+
+            await ApplyStatsModeAsync(
+                StatsModeOptions[StatsModePicker.SelectedIndex].Value);
+        }
+
+        async Task ApplyQualitySelectionAsync(
+            EditorQualitySelection selection)
+        {
+            await graphicsSettingsGate.WaitAsync();
+            SetGraphicsPickersEnabled(false);
+            try
+            {
+                var result = await graphicsSettingsService
+                    .SetSelectedQualityAsync(selection);
+                if (result.QualityChanged && !result.EngineRestarted)
+                {
+                    Console.WriteLine(
+                        "[SceneView] Quality selection was saved, but the Engine restart did not complete.");
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"[SceneView] Failed to apply graphics quality: {exception}");
+                await RefreshGraphicsSettingsAsync(reload: true);
+            }
+            finally
+            {
+                SetGraphicsPickersEnabled(true);
+                graphicsSettingsGate.Release();
+            }
+        }
+
+        async Task ApplyStatsModeAsync(GraphicsStatsMode mode)
+        {
+            await graphicsSettingsGate.WaitAsync();
+            SetGraphicsPickersEnabled(false);
+            try
+            {
+                var result = await graphicsSettingsService.SetStatsModeAsync(mode);
+                if (result.StatsChanged && !result.StatsAppliedLive)
+                {
+                    Console.WriteLine(
+                        "[SceneView] Stats mode was saved, but the live Engine command was rejected.");
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"[SceneView] Failed to apply renderer Stats mode: {exception}");
+                await RefreshGraphicsSettingsAsync(reload: true);
+            }
+            finally
+            {
+                SetGraphicsPickersEnabled(true);
+                graphicsSettingsGate.Release();
+            }
+        }
+
+        async Task RefreshGraphicsSettingsAsync(bool reload)
+        {
+            try
+            {
+                var snapshot = reload
+                    ? await graphicsSettingsService.ReloadAsync()
+                    : await graphicsSettingsService.EnsureLoadedAsync();
+                Dispatcher.Dispatch(() => UpdateGraphicsPickers(snapshot));
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"[SceneView] Failed to load graphics settings: {exception}");
+            }
+        }
+
+        void OnGraphicsSettingsChanged(
+            object? sender,
+            GraphicsSettingsSnapshot snapshot)
+            => Dispatcher.Dispatch(() => UpdateGraphicsPickers(snapshot));
+
+        void OnWorkspaceProjectionChanged(object? sender, EventArgs e)
+            => _ = RefreshGraphicsSettingsAsync(reload: false);
+
+        void UpdateGraphicsPickers(GraphicsSettingsSnapshot snapshot)
+        {
+            updatingGraphicsPickers = true;
+            try
+            {
+                QualityPicker.SelectedIndex = Array.FindIndex(
+                    QualityOptions,
+                    option => option.Value ==
+                        snapshot.Editor.Graphics.SelectedQuality);
+                StatsModePicker.SelectedIndex = Array.FindIndex(
+                    StatsModeOptions,
+                    option => option.Value ==
+                        snapshot.Editor.Graphics.StatsMode);
+                ToolTipProperties.SetText(
+                    QualityPicker,
+                    $"Scene View quality: {FormatQuality(snapshot.EffectiveQuality)}. Changing it restarts the Engine.");
+            }
+            finally
+            {
+                updatingGraphicsPickers = false;
+            }
+        }
+
+        void SetGraphicsPickersEnabled(bool enabled)
+        {
+            QualityPicker.IsEnabled = enabled;
+            StatsModePicker.IsEnabled = enabled;
+        }
+
+        static string FormatQuality(GraphicsQualityLevel quality)
+            => quality == GraphicsQualityLevel.VeryLow
+                ? "Very Low"
+                : quality.ToString();
+
+        readonly record struct GraphicsPickerOption<T>(
+            T Value,
+            string DisplayName)
+            where T : struct, Enum;
+
+        static readonly GraphicsPickerOption<EditorQualitySelection>[]
+            QualityOptions =
+            [
+                new(EditorQualitySelection.ProjectDefault, "Project Default"),
+                new(EditorQualitySelection.Ultra, "Ultra"),
+                new(EditorQualitySelection.High, "High"),
+                new(EditorQualitySelection.Medium, "Medium"),
+                new(EditorQualitySelection.Low, "Low"),
+                new(EditorQualitySelection.VeryLow, "Very Low")
+            ];
+
+        static readonly GraphicsPickerOption<GraphicsStatsMode>[]
+            StatsModeOptions =
+            [
+                new(GraphicsStatsMode.None, "None"),
+                new(GraphicsStatsMode.RenderStats, "Render stats"),
+                new(
+                    GraphicsStatsMode.RenderStatsAndQueries,
+                    "Render stats + queries")
+            ];
 
         void UpdateRestartEngineButton(EngineLifecycleState state)
         {

--- a/Editor/Views/SettingsPanelView.cs
+++ b/Editor/Views/SettingsPanelView.cs
@@ -2,59 +2,128 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
 using System.Runtime.CompilerServices;
+using Microsoft.Maui.Controls.Shapes;
+using SailorEditor.Services;
 using SailorEditor.Settings;
 
 namespace SailorEditor.Views;
 
 public sealed class SettingsPanelView : ContentView
 {
+    const string GraphicsCategory = "Graphics";
     readonly UnifiedSettingsStore _store;
     readonly EditorSettingsPersistenceStore _persistence;
+    readonly GraphicsSettingsService _graphicsSettings;
+    readonly WorkspaceUiService _workspaceUiService;
     readonly Picker _scopePicker;
-    readonly SearchBar _searchBar;
+    readonly Entry _searchBar;
     readonly Label _statusLabel;
     readonly ObservableCollection<SettingsEditorRow> _rows = [];
+    readonly List<GraphicsPresetEditor> _graphicsPresetEditors = [];
+    readonly GraphicsSettingsDraftSession _graphicsDraftSession = new();
     readonly VerticalStackLayout _entriesLayout;
+    Picker? _projectDefaultQualityPicker;
+    Picker? _editorQualityPicker;
+    Picker? _statsModePicker;
+    GraphicsSettingsSnapshot? _graphicsSnapshot;
     bool _loaded;
+    bool _graphicsDirty;
+    bool _graphicsStale;
+    bool _updatingGraphicsEditors;
+    bool _applyingGraphics;
+    bool _eventsSubscribed;
 
     public SettingsPanelView()
     {
         _store = MauiProgram.GetService<UnifiedSettingsStore>();
         _persistence = MauiProgram.GetService<EditorSettingsPersistenceStore>();
+        _graphicsSettings = MauiProgram.GetService<GraphicsSettingsService>();
+        _workspaceUiService = MauiProgram.GetService<WorkspaceUiService>();
         _scopePicker = new Picker
         {
             Title = "Category",
-            ItemsSource = Enum.GetValues<SettingsScope>().Cast<object>().ToList(),
-            SelectedItem = SettingsScope.Editor
+            ItemsSource = new[] { GraphicsCategory }
+                .Concat(Enum.GetNames<SettingsScope>())
+                .Cast<object>()
+                .ToList(),
+            SelectedItem = SettingsScope.Editor.ToString(),
+            FontSize = 11,
+            HeightRequest = 32,
+            MinimumHeightRequest = 32,
+            HorizontalOptions = LayoutOptions.Fill
         };
-        _searchBar = new SearchBar { Placeholder = "Search settings" };
-        _statusLabel = new Label { Margin = new Thickness(8, 0), FontSize = 11, Opacity = 0.8 };
-        _entriesLayout = new VerticalStackLayout { Spacing = 6, Padding = new Thickness(8, 0, 8, 8) };
+        _searchBar = new Entry
+        {
+            Placeholder = "Search settings",
+            FontSize = 11,
+            HeightRequest = 32,
+            MinimumHeightRequest = 32,
+            HorizontalOptions = LayoutOptions.Fill
+        };
+        _statusLabel = new Label
+        {
+            Margin = new Thickness(6, 1, 6, 2),
+            FontSize = 10,
+            Opacity = 0.8,
+            LineBreakMode = LineBreakMode.WordWrap
+        };
+        _entriesLayout = new VerticalStackLayout
+        {
+            Spacing = 3,
+            Padding = new Thickness(6, 1, 6, 8),
+            HorizontalOptions = LayoutOptions.Fill
+        };
 
         _scopePicker.SelectedIndexChanged += (_, _) => Refresh();
         _searchBar.TextChanged += (_, _) => Refresh();
         Loaded += OnLoaded;
+        Unloaded += OnUnloaded;
 
-        var toolbar = new HorizontalStackLayout
+        var actions = new HorizontalStackLayout
         {
-            Margin = new Thickness(8, 8, 8, 4),
-            Spacing = 8,
+            Spacing = 4,
+            HorizontalOptions = LayoutOptions.End,
             Children =
             {
-                _scopePicker,
-                _searchBar,
                 CreateToolbarButton("Apply", async () => await ApplyAllAsync()),
                 CreateToolbarButton("Revert", RevertAll),
-                CreateToolbarButton("Reset Scope", async () => await ResetScopeAsync())
+                CreateToolbarButton("Reset", async () => await ResetScopeAsync())
             }
         };
 
-        var scroll = new ScrollView { Content = _entriesLayout };
+        var toolbar = new Grid
+        {
+            Margin = new Thickness(6, 4, 6, 2),
+            RowSpacing = 2,
+            ColumnSpacing = 4,
+            RowDefinitions =
+            {
+                new RowDefinition(GridLength.Auto),
+                new RowDefinition(GridLength.Auto)
+            },
+            ColumnDefinitions =
+            {
+                new ColumnDefinition(new GridLength(2, GridUnitType.Star)),
+                new ColumnDefinition(new GridLength(3, GridUnitType.Star))
+            }
+        };
+        toolbar.Add(_scopePicker, 0, 0);
+        toolbar.Add(_searchBar, 1, 0);
+        toolbar.Add(actions, 0, 1);
+        Grid.SetColumnSpan(actions, 2);
+
+        var scroll = new ScrollView
+        {
+            Content = _entriesLayout,
+            Orientation = ScrollOrientation.Vertical,
+            VerticalOptions = LayoutOptions.Fill,
+            HorizontalOptions = LayoutOptions.Fill,
+            VerticalScrollBarVisibility = ScrollBarVisibility.Always
+        };
         var root = new Grid
         {
             RowDefinitions =
             [
-                new RowDefinition(GridLength.Auto),
                 new RowDefinition(GridLength.Auto),
                 new RowDefinition(GridLength.Auto),
                 new RowDefinition(GridLength.Star)
@@ -75,24 +144,51 @@ public sealed class SettingsPanelView : ContentView
 
     async void OnLoaded(object? sender, EventArgs e)
     {
-        if (_loaded)
-            return;
+        SubscribeToEvents();
 
-        _loaded = true;
-        await _persistence.LoadAsync(_store);
+        if (!_loaded)
+        {
+            _loaded = true;
+            await _persistence.LoadAsync(_store);
+        }
+
+        _graphicsSnapshot = await _graphicsSettings.EnsureLoadedAsync();
+        _graphicsDraftSession.GetOrCreate(_graphicsSnapshot);
         Refresh();
         UpdateStatus();
     }
 
+    void OnUnloaded(object? sender, EventArgs e)
+    {
+        CaptureGraphicsDraftFromEditors();
+        UnsubscribeFromEvents();
+    }
+
     void Refresh()
     {
+        CaptureGraphicsDraftFromEditors();
         foreach (var row in _rows)
             row.PropertyChanged -= OnRowPropertyChanged;
 
         _rows.Clear();
         _entriesLayout.Children.Clear();
 
-        var selectedScope = _scopePicker.SelectedItem is SettingsScope scope ? scope : SettingsScope.Editor;
+        if (IsGraphicsSelected())
+        {
+            RefreshGraphics();
+            return;
+        }
+
+        _graphicsPresetEditors.Clear();
+        _projectDefaultQualityPicker = null;
+        _editorQualityPicker = null;
+        _statsModePicker = null;
+
+        var selectedScope = Enum.TryParse<SettingsScope>(
+            _scopePicker.SelectedItem?.ToString(),
+            out var scope)
+            ? scope
+            : SettingsScope.Editor;
         var rows = EditorSettingsCatalog.Definitions
             .Where(definition => definition.Entry.Scope == selectedScope)
             .Where(definition => string.IsNullOrWhiteSpace(_searchBar.Text)
@@ -130,6 +226,12 @@ public sealed class SettingsPanelView : ContentView
 
     async Task ApplyAllAsync()
     {
+        if (IsGraphicsSelected())
+        {
+            await ApplyGraphicsAsync();
+            return;
+        }
+
         var dirtyRows = _rows.Where(x => x.IsDirty).ToArray();
         var invalidRows = dirtyRows.Where(x => x.HasErrors).ToArray();
         if (invalidRows.Length > 0)
@@ -147,6 +249,18 @@ public sealed class SettingsPanelView : ContentView
 
     void RevertAll()
     {
+        if (IsGraphicsSelected())
+        {
+            _graphicsSnapshot = _graphicsSettings.Current ?? _graphicsSnapshot;
+            if (_graphicsSnapshot is not null)
+                _graphicsDraftSession.Replace(_graphicsSnapshot);
+            _graphicsDirty = false;
+            _graphicsStale = false;
+            RefreshGraphics();
+            UpdateStatus("Reverted pending graphics edits.");
+            return;
+        }
+
         foreach (var row in _rows)
             row.Revert();
 
@@ -155,7 +269,41 @@ public sealed class SettingsPanelView : ContentView
 
     async Task ResetScopeAsync()
     {
-        var selectedScope = _scopePicker.SelectedItem is SettingsScope scope ? scope : SettingsScope.Editor;
+        if (IsGraphicsSelected())
+        {
+            var snapshot = _graphicsSnapshot ??
+                await _graphicsSettings.EnsureLoadedAsync();
+            try
+            {
+                _applyingGraphics = true;
+                var result = await _graphicsSettings.ApplyAsync(
+                    GraphicsSettingsDefaults.Project,
+                    GraphicsSettingsDefaults.Editor,
+                    snapshot);
+                _graphicsSnapshot = _graphicsSettings.Current;
+                if (_graphicsSnapshot is not null)
+                    _graphicsDraftSession.Replace(_graphicsSnapshot);
+                _graphicsDirty = false;
+                _graphicsStale = false;
+                RefreshGraphics();
+                UpdateStatus(DescribeGraphicsApply(result, "Reset graphics settings to defaults."));
+            }
+            catch (Exception exception)
+            {
+                UpdateStatus($"Unable to reset graphics settings: {exception.Message}");
+            }
+            finally
+            {
+                _applyingGraphics = false;
+            }
+            return;
+        }
+
+        var selectedScope = Enum.TryParse<SettingsScope>(
+            _scopePicker.SelectedItem?.ToString(),
+            out var scope)
+            ? scope
+            : SettingsScope.Editor;
         _store.ResetScope(selectedScope);
         await _persistence.SaveAsync(_store);
         Refresh();
@@ -170,6 +318,27 @@ public sealed class SettingsPanelView : ContentView
             return;
         }
 
+        if (IsGraphicsSelected())
+        {
+            if (_graphicsStale)
+            {
+                _statusLabel.Text = "Graphics settings changed outside this panel. Revert to reload before applying.";
+            }
+            else if (_graphicsDirty)
+            {
+                _statusLabel.Text = "Graphics settings have pending changes. Apply to validate, persist, and update the Engine.";
+            }
+            else if (_graphicsSnapshot?.Diagnostics.Count > 0)
+            {
+                _statusLabel.Text = string.Join(Environment.NewLine, _graphicsSnapshot.Diagnostics);
+            }
+            else
+            {
+                _statusLabel.Text = "No pending graphics changes.";
+            }
+            return;
+        }
+
         var dirtyCount = _rows.Count(x => x.IsDirty);
         var errorCount = _rows.Count(x => x.HasErrors);
         _statusLabel.Text = dirtyCount == 0
@@ -178,6 +347,368 @@ public sealed class SettingsPanelView : ContentView
                 ? $"{dirtyCount} pending change(s). Apply to persist them."
                 : $"{dirtyCount} pending change(s), {errorCount} with validation errors.";
     }
+
+    bool IsGraphicsSelected()
+        => string.Equals(
+            _scopePicker.SelectedItem?.ToString(),
+            GraphicsCategory,
+            StringComparison.Ordinal);
+
+    void RefreshGraphics()
+    {
+        _entriesLayout.Children.Clear();
+        _graphicsPresetEditors.Clear();
+        _projectDefaultQualityPicker = null;
+        _editorQualityPicker = null;
+        _statsModePicker = null;
+
+        var snapshot = _graphicsSnapshot ?? _graphicsSettings.Current;
+        if (snapshot is null)
+        {
+            _entriesLayout.Children.Add(new Label
+            {
+                Text = "Graphics settings are loading…",
+                Margin = new Thickness(8)
+            });
+            UpdateStatus();
+            return;
+        }
+
+        _graphicsSnapshot = snapshot;
+        var draft = _graphicsDraftSession.GetOrCreate(snapshot);
+        _updatingGraphicsEditors = true;
+        try
+        {
+            _entriesLayout.Children.Add(new Label
+            {
+                Text = "Project Graphics",
+                FontSize = 14,
+                FontAttributes = FontAttributes.Bold,
+                Margin = new Thickness(0, 2, 0, 0)
+            });
+            var pathsLabel = new Label
+            {
+                Text = "ProjectSettings.yaml  •  Cache/EditorSettings.yaml",
+                FontSize = 9,
+                Opacity = 0.7,
+                LineBreakMode = LineBreakMode.TailTruncation
+            };
+            ToolTipProperties.SetText(
+                pathsLabel,
+                $"Project: {snapshot.Paths.ProjectSettingsPath}\nEditor: {snapshot.Paths.EditorSettingsPath}");
+            _entriesLayout.Children.Add(pathsLabel);
+
+            _projectDefaultQualityPicker = CreateOptionPicker(
+                QualityOptions,
+                draft.ProjectDefaultQuality);
+            _editorQualityPicker = CreateOptionPicker(
+                EditorQualityOptions,
+                draft.SelectedQuality);
+            _statsModePicker = CreateOptionPicker(
+                StatsModeOptions,
+                draft.StatsMode);
+            _entriesLayout.Children.Add(CreateGraphicsField(
+                "Project Default Quality",
+                "Preset used by standalone/game startup and by Project Default in the editor.",
+                _projectDefaultQualityPicker));
+            _entriesLayout.Children.Add(CreateGraphicsField(
+                "Scene View Quality",
+                "Workspace-local editor override. Applying a change restarts the Engine.",
+                _editorQualityPicker));
+            _entriesLayout.Children.Add(CreateGraphicsField(
+                "Scene View Stats",
+                "Workspace-local overlay mode. Applying a Stats-only change is live.",
+                _statsModePicker));
+
+            foreach (var quality in Enum.GetValues<GraphicsQualityLevel>())
+            {
+                if (!GraphicsSearchMatches(quality))
+                    continue;
+
+                var editor = new GraphicsPresetEditor(
+                    quality,
+                    draft.GetPreset(quality),
+                    MarkGraphicsDirty);
+                _graphicsPresetEditors.Add(editor);
+                _entriesLayout.Children.Add(editor.CreateView(
+                    initiallyExpanded: quality == snapshot.EffectiveQuality ||
+                        !string.IsNullOrWhiteSpace(_searchBar.Text),
+                    isActive: quality == snapshot.EffectiveQuality));
+            }
+        }
+        finally
+        {
+            _updatingGraphicsEditors = false;
+        }
+
+        UpdateStatus();
+    }
+
+    async Task ApplyGraphicsAsync()
+    {
+        if (_graphicsStale)
+        {
+            UpdateStatus("Graphics settings changed outside this panel. Revert to reload before applying.");
+            return;
+        }
+
+        var snapshot = _graphicsSnapshot ??
+            await _graphicsSettings.EnsureLoadedAsync();
+        CaptureGraphicsDraftFromEditors();
+        var draft = _graphicsDraftSession.GetOrCreate(snapshot);
+        if (!draft.TryBuild(
+                out var project,
+                out var editorSettings,
+                out var issues))
+        {
+            UpdateStatus(string.Join(
+                Environment.NewLine,
+                issues.Select(issue => $"{issue.Path}: {issue.Message}")));
+            return;
+        }
+
+        try
+        {
+            _applyingGraphics = true;
+            var result = await _graphicsSettings.ApplyAsync(
+                project,
+                editorSettings,
+                draft.SourceSnapshot);
+            _graphicsSnapshot = _graphicsSettings.Current;
+            if (_graphicsSnapshot is not null)
+                _graphicsDraftSession.Replace(_graphicsSnapshot);
+            _graphicsDirty = false;
+            _graphicsStale = false;
+            RefreshGraphics();
+            UpdateStatus(DescribeGraphicsApply(result, "Graphics settings applied."));
+        }
+        catch (Exception exception)
+        {
+            if (_graphicsSettings.Current is { } current &&
+                !ReferenceEquals(current, snapshot))
+            {
+                _graphicsSnapshot = current;
+                _graphicsDraftSession.Replace(current);
+                _graphicsDirty = false;
+                _graphicsStale = false;
+                RefreshGraphics();
+                UpdateStatus($"Graphics settings were persisted, but the Engine update failed: {exception.Message}");
+            }
+            else
+            {
+                UpdateStatus($"Unable to apply graphics settings: {exception.Message}");
+            }
+        }
+        finally
+        {
+            _applyingGraphics = false;
+        }
+    }
+
+    void MarkGraphicsDirty()
+    {
+        if (_updatingGraphicsEditors)
+            return;
+
+        _graphicsDirty = true;
+        UpdateStatus();
+    }
+
+    void CaptureGraphicsDraftFromEditors()
+    {
+        var draft = _graphicsDraftSession.Current;
+        if (draft is null)
+            return;
+
+        if (_projectDefaultQualityPicker?.SelectedItem is PickerOption<GraphicsQualityLevel> projectQuality &&
+            _editorQualityPicker?.SelectedItem is PickerOption<EditorQualitySelection> editorQuality &&
+            _statsModePicker?.SelectedItem is PickerOption<GraphicsStatsMode> statsMode)
+        {
+            draft.SetSelections(
+                projectQuality.Value,
+                editorQuality.Value,
+                statsMode.Value);
+        }
+
+        foreach (var editor in _graphicsPresetEditors)
+            draft.SetPreset(editor.Quality, editor.CaptureDraft());
+        _graphicsDirty = draft.IsDirty;
+    }
+
+    bool GraphicsSearchMatches(GraphicsQualityLevel quality)
+    {
+        if (string.IsNullOrWhiteSpace(_searchBar.Text))
+            return true;
+
+        var search = _searchBar.Text.Trim();
+        return FormatQuality(quality).Contains(search, StringComparison.OrdinalIgnoreCase) ||
+            "resolution msaa shadow cascades soft clouds sky lod bias graphics quality preset"
+                .Contains(search, StringComparison.OrdinalIgnoreCase);
+    }
+
+    Picker CreateOptionPicker<T>(
+        IReadOnlyList<PickerOption<T>> options,
+        T selectedValue)
+        where T : struct, Enum
+    {
+        var picker = new Picker
+        {
+            ItemsSource = options.Cast<object>().ToList(),
+            SelectedItem = options.Single(option =>
+                EqualityComparer<T>.Default.Equals(
+                    option.Value,
+                    selectedValue)),
+            FontSize = 11,
+            HeightRequest = 30,
+            MinimumHeightRequest = 30,
+            HorizontalOptions = LayoutOptions.Fill
+        };
+        picker.SelectedIndexChanged += (_, _) => MarkGraphicsDirty();
+        return picker;
+    }
+
+    static View CreateGraphicsField(
+        string title,
+        string description,
+        View editor)
+    {
+        var titleLabel = new Label
+        {
+            Text = title,
+            FontSize = 11,
+            FontAttributes = FontAttributes.Bold,
+            LineBreakMode = LineBreakMode.TailTruncation,
+            VerticalTextAlignment = TextAlignment.Center
+        };
+        ToolTipProperties.SetText(titleLabel, description);
+        var grid = new Grid
+        {
+            ColumnDefinitions =
+            {
+                new ColumnDefinition(new GridLength(6, GridUnitType.Star)),
+                new ColumnDefinition(new GridLength(5, GridUnitType.Star))
+            },
+            ColumnSpacing = 6,
+            Padding = new Thickness(0, 1)
+        };
+        grid.Add(titleLabel, 0, 0);
+        grid.Add(editor, 1, 0);
+        return grid;
+    }
+
+    void SubscribeToEvents()
+    {
+        if (_eventsSubscribed)
+            return;
+
+        _graphicsSettings.SettingsChanged += OnGraphicsSettingsChanged;
+        _workspaceUiService.ProjectionChanged += OnWorkspaceProjectionChanged;
+        _eventsSubscribed = true;
+    }
+
+    void UnsubscribeFromEvents()
+    {
+        if (!_eventsSubscribed)
+            return;
+
+        _graphicsSettings.SettingsChanged -= OnGraphicsSettingsChanged;
+        _workspaceUiService.ProjectionChanged -= OnWorkspaceProjectionChanged;
+        _eventsSubscribed = false;
+    }
+
+    void OnGraphicsSettingsChanged(
+        object? sender,
+        GraphicsSettingsSnapshot snapshot)
+    {
+        Dispatcher.Dispatch(() =>
+        {
+            if (_applyingGraphics)
+            {
+                _graphicsSnapshot = snapshot;
+                return;
+            }
+
+            var workspaceChanged = _graphicsSnapshot is not null &&
+                (_graphicsSnapshot.Paths != snapshot.Paths ||
+                    _graphicsSnapshot.WorkspaceGeneration != snapshot.WorkspaceGeneration);
+            if (_graphicsDirty && !workspaceChanged)
+            {
+                _graphicsStale = true;
+                UpdateStatus();
+                return;
+            }
+
+            _graphicsSnapshot = snapshot;
+            _graphicsDraftSession.Replace(snapshot);
+            _graphicsDirty = false;
+            _graphicsStale = false;
+            if (IsGraphicsSelected())
+            {
+                _entriesLayout.Children.Clear();
+                RefreshGraphics();
+            }
+        });
+    }
+
+    void OnWorkspaceProjectionChanged(object? sender, EventArgs e)
+        => _ = ReloadGraphicsForWorkspaceAsync();
+
+    async Task ReloadGraphicsForWorkspaceAsync()
+    {
+        try
+        {
+            await _graphicsSettings.EnsureLoadedAsync();
+        }
+        catch (Exception exception)
+        {
+            Dispatcher.Dispatch(() =>
+                UpdateStatus($"Unable to load graphics settings for the active workspace: {exception.Message}"));
+        }
+    }
+
+    static string DescribeGraphicsApply(
+        GraphicsSettingsApplyResult result,
+        string successMessage)
+    {
+        if (result.QualityChanged && !result.EngineRestarted)
+            return "Graphics settings were saved, but the Engine restart did not complete.";
+        if (result.StatsChanged &&
+            !result.QualityChanged &&
+            !result.StatsAppliedLive)
+        {
+            return "Graphics settings were saved, but the live Stats command was rejected.";
+        }
+        return successMessage;
+    }
+
+    static string FormatQuality(GraphicsQualityLevel quality)
+        => quality == GraphicsQualityLevel.VeryLow
+            ? "Very Low"
+            : quality.ToString();
+
+    static readonly PickerOption<GraphicsQualityLevel>[] QualityOptions =
+        Enum.GetValues<GraphicsQualityLevel>()
+            .Select(value => new PickerOption<GraphicsQualityLevel>(
+                value,
+                FormatQuality(value)))
+            .ToArray();
+
+    static readonly PickerOption<EditorQualitySelection>[] EditorQualityOptions =
+    [
+        new(EditorQualitySelection.ProjectDefault, "Project Default"),
+        new(EditorQualitySelection.Ultra, "Ultra"),
+        new(EditorQualitySelection.High, "High"),
+        new(EditorQualitySelection.Medium, "Medium"),
+        new(EditorQualitySelection.Low, "Low"),
+        new(EditorQualitySelection.VeryLow, "Very Low")
+    ];
+
+    static readonly PickerOption<GraphicsStatsMode>[] StatsModeOptions =
+    [
+        new(GraphicsStatsMode.None, "None"),
+        new(GraphicsStatsMode.RenderStats, "Render stats"),
+        new(GraphicsStatsMode.RenderStatsAndQueries, "Render stats + queries")
+    ];
 
     View CreateRowView(SettingsEditorRow row)
     {
@@ -205,7 +736,7 @@ public sealed class SettingsPanelView : ContentView
 
         var actions = new HorizontalStackLayout
         {
-            Spacing = 8,
+            Spacing = 4,
             Children =
             {
                 CreateToolbarButton("Apply", async () =>
@@ -245,7 +776,7 @@ public sealed class SettingsPanelView : ContentView
 
         var editorColumn = new VerticalStackLayout
         {
-            Spacing = 6,
+            Spacing = 3,
             HorizontalOptions = LayoutOptions.Fill,
             Children = { editor, actions }
         };
@@ -257,8 +788,8 @@ public sealed class SettingsPanelView : ContentView
                 new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
                 new ColumnDefinition { Width = new GridLength(2, GridUnitType.Star) }
             },
-            ColumnSpacing = 12,
-            Padding = new Thickness(0, 4),
+            ColumnSpacing = 6,
+            Padding = new Thickness(0, 2),
             HorizontalOptions = LayoutOptions.Fill
         };
 
@@ -284,7 +815,12 @@ public sealed class SettingsPanelView : ContentView
 
     View CreateBooleanEditor(SettingsEditorRow row)
     {
-        var toggle = new Switch { BindingContext = row };
+        var toggle = new Switch
+        {
+            BindingContext = row,
+            Scale = 0.8,
+            HeightRequest = 30
+        };
         toggle.SetBinding(Switch.IsToggledProperty, nameof(SettingsEditorRow.BooleanValue), mode: BindingMode.TwoWay);
 
         return new HorizontalStackLayout
@@ -303,7 +839,10 @@ public sealed class SettingsPanelView : ContentView
         var picker = new Picker
         {
             BindingContext = row,
-            ItemsSource = row.Definition.Entry.AllowedValues?.Cast<object>().ToList() ?? []
+            ItemsSource = row.Definition.Entry.AllowedValues?.Cast<object>().ToList() ?? [],
+            FontSize = 11,
+            HeightRequest = 30,
+            MinimumHeightRequest = 30
         };
         picker.SetBinding(Picker.SelectedItemProperty, nameof(SettingsEditorRow.DraftText), mode: BindingMode.TwoWay);
         return picker;
@@ -316,7 +855,10 @@ public sealed class SettingsPanelView : ContentView
             BindingContext = row,
             Keyboard = keyboard,
             Placeholder = placeholder,
-            IsPassword = row.Definition.Entry.IsSecret
+            IsPassword = row.Definition.Entry.IsSecret,
+            FontSize = 11,
+            HeightRequest = 30,
+            MinimumHeightRequest = 30
         };
         entry.SetBinding(Entry.TextProperty, nameof(SettingsEditorRow.DraftText), mode: BindingMode.TwoWay);
         return entry;
@@ -324,16 +866,417 @@ public sealed class SettingsPanelView : ContentView
 
     static Button CreateToolbarButton(string text, Action action)
     {
-        var button = new Button { Text = text, Padding = new Thickness(12, 6) };
+        var button = new Button
+        {
+            Text = text,
+            FontSize = 11,
+            Padding = new Thickness(8, 2),
+            HeightRequest = 28,
+            MinimumHeightRequest = 28
+        };
         button.Clicked += (_, _) => action();
         return button;
     }
 
     static Button CreateToolbarButton(string text, Func<Task> action)
     {
-        var button = new Button { Text = text, Padding = new Thickness(12, 6) };
+        var button = new Button
+        {
+            Text = text,
+            FontSize = 11,
+            Padding = new Thickness(8, 2),
+            HeightRequest = 28,
+            MinimumHeightRequest = 28
+        };
         button.Clicked += async (_, _) => await action();
         return button;
+    }
+
+    sealed record PickerOption<T>(T Value, string DisplayName)
+        where T : struct, Enum
+    {
+        public override string ToString() => DisplayName;
+    }
+
+    sealed class GraphicsPresetEditor
+    {
+        static readonly PickerOption<GraphicsShadowQuality>[] ShadowQualityOptions =
+        [
+            new(GraphicsShadowQuality.High, "High"),
+            new(GraphicsShadowQuality.Medium, "Medium"),
+            new(GraphicsShadowQuality.Low, "Low"),
+            new(GraphicsShadowQuality.VeryLow, "Very Low")
+        ];
+
+        readonly Action _changed;
+        readonly Entry _resolutionFactor;
+        readonly Entry _fpsCap;
+        readonly Picker _msaaSamples;
+        readonly Picker _shadowQuality;
+        readonly Entry _shadowBias;
+        readonly Picker _shadowCascadeCount;
+        readonly Entry _shadowCascadeResolutions;
+        readonly Switch _supportSoftShadows;
+        readonly Entry _cloudsResolutionMultiplier;
+        readonly Entry _skyResolution;
+        readonly Entry _lodBias;
+
+        public GraphicsPresetEditor(
+            GraphicsQualityLevel quality,
+            GraphicsQualityPresetDraft draft,
+            Action changed)
+        {
+            Quality = quality;
+            _changed = changed;
+            _resolutionFactor = CreateEntry(draft.ResolutionFactor);
+            _fpsCap = CreateEntry(draft.FpsCap);
+            _msaaSamples = CreatePicker(
+                new object[] { 1, 2, 4, 8 },
+                draft.MsaaSamples);
+            _shadowQuality = CreatePicker(
+                ShadowQualityOptions.Cast<object>().ToArray(),
+                ShadowQualityOptions.Single(x => x.Value == draft.ShadowQuality));
+            _shadowBias = CreateEntry(draft.ShadowBias);
+            _shadowCascadeCount = CreatePicker(
+                new object[] { 1, 2, 3, 4 },
+                draft.ShadowCascadeCount);
+            _shadowCascadeResolutions = CreateEntry(
+                draft.ShadowCascadeResolutions);
+            _supportSoftShadows = new Switch
+            {
+                IsToggled = draft.SupportSoftShadows,
+                Scale = 0.8,
+                HeightRequest = 30,
+                HorizontalOptions = LayoutOptions.End
+            };
+            _supportSoftShadows.Toggled += (_, _) => _changed();
+            _cloudsResolutionMultiplier = CreateEntry(
+                draft.CloudsResolutionMultiplier);
+            _skyResolution = CreateEntry(draft.SkyResolution);
+            _lodBias = CreateEntry(draft.LodBias);
+        }
+
+        public GraphicsQualityLevel Quality { get; }
+
+        public GraphicsQualityPresetDraft CaptureDraft()
+            => new(
+                _resolutionFactor.Text ?? string.Empty,
+                _fpsCap.Text ?? string.Empty,
+                _msaaSamples.SelectedItem is int msaa ? msaa : 0,
+                _shadowQuality.SelectedItem is PickerOption<GraphicsShadowQuality> shadow
+                    ? shadow.Value
+                    : (GraphicsShadowQuality)(-1),
+                _shadowBias.Text ?? string.Empty,
+                _shadowCascadeCount.SelectedItem is int count ? count : 0,
+                _shadowCascadeResolutions.Text ?? string.Empty,
+                _supportSoftShadows.IsToggled,
+                _cloudsResolutionMultiplier.Text ?? string.Empty,
+                _skyResolution.Text ?? string.Empty,
+                _lodBias.Text ?? string.Empty);
+
+        public View CreateView(bool initiallyExpanded, bool isActive)
+        {
+            var fields = new VerticalStackLayout
+            {
+                Spacing = 1,
+                Children =
+                {
+                    CreatePresetField("Resolution Factor", "0.25–2.0", _resolutionFactor),
+                    CreatePresetField("FPS Cap", "Maximum CPU frames per second, 1–1000", _fpsCap),
+                    CreatePresetField("MSAA", "Supported sample count", _msaaSamples),
+                    CreatePresetField("Shadow Quality Cap", "Global cap over authored light quality", _shadowQuality),
+                    CreatePresetField("Shadow Bias", "Vulkan constant depth bias, -16–16", _shadowBias),
+                    CreatePresetField("Shadow Cascade Count", "Active directional cascades, 1–4", _shadowCascadeCount),
+                    CreatePresetField("Cascade Resolutions", "Comma-separated powers of two, one per active cascade", _shadowCascadeResolutions),
+                    CreatePresetField("Soft Shadows", "Enable soft shadow filtering", _supportSoftShadows),
+                    CreatePresetField("Clouds Resolution Multiplier", "0.0625–2.0", _cloudsResolutionMultiplier),
+                    CreatePresetField("Sky Resolution", "Power of two, 32–8192", _skyResolution),
+                    CreatePresetField("LOD Bias", "Signed index shift, -8 (finer) to +8 (coarser)", _lodBias)
+                }
+            };
+
+            var title = new Label
+            {
+                Text = $"{FormatQuality(Quality)} preset",
+                FontSize = 12,
+                FontAttributes = FontAttributes.Bold,
+                VerticalTextAlignment = TextAlignment.Center
+            };
+            var state = new Label
+            {
+                Text = FormatPresetState(initiallyExpanded, isActive),
+                FontSize = 10,
+                Opacity = 0.7,
+                HorizontalTextAlignment = TextAlignment.End,
+                VerticalTextAlignment = TextAlignment.Center
+            };
+            var header = new Grid
+            {
+                ColumnDefinitions =
+                {
+                    new ColumnDefinition(GridLength.Star),
+                    new ColumnDefinition(GridLength.Auto)
+                },
+                Padding = new Thickness(1, 0)
+            };
+            header.Add(title, 0, 0);
+            header.Add(state, 1, 0);
+            var tap = new TapGestureRecognizer();
+            tap.Tapped += (_, _) =>
+            {
+                fields.IsVisible = !fields.IsVisible;
+                state.Text = FormatPresetState(fields.IsVisible, isActive);
+            };
+            header.GestureRecognizers.Add(tap);
+            fields.IsVisible = initiallyExpanded;
+
+            return new Border
+            {
+                Stroke = Color.FromArgb("#3A3A3A"),
+                StrokeThickness = 1,
+                StrokeShape = new RoundRectangle { CornerRadius = 3 },
+                Padding = new Thickness(6, 4),
+                Margin = new Thickness(0, 1),
+                Content = new VerticalStackLayout
+                {
+                    Spacing = 2,
+                    Children =
+                    {
+                        header,
+                        fields
+                    }
+                }
+            };
+        }
+
+        static string FormatPresetState(bool expanded, bool isActive)
+            => $"{(expanded ? "▾" : "▸")}{(isActive ? "  Active" : string.Empty)}";
+
+        public bool TryBuild(
+            out GraphicsQualityPresetSettings settings,
+            ICollection<GraphicsSettingsValidationIssue> issues)
+        {
+            var path = $"graphics.presets.{Quality}";
+            var valid = true;
+            valid &= TryParseDouble(
+                _resolutionFactor.Text,
+                $"{path}.resolutionFactor",
+                "Resolution factor",
+                issues,
+                out var resolutionFactor);
+            valid &= TryParseInt(
+                _fpsCap.Text,
+                $"{path}.fpsCap",
+                "FPS cap",
+                issues,
+                out var fpsCap);
+            valid &= TryParseDouble(
+                _shadowBias.Text,
+                $"{path}.shadowBias",
+                "Shadow bias",
+                issues,
+                out var shadowBias);
+            valid &= TryParseCascadeResolutions(
+                _shadowCascadeResolutions.Text,
+                $"{path}.shadowCascadeResolutions",
+                issues,
+                out var cascadeResolutions);
+            valid &= TryParseDouble(
+                _cloudsResolutionMultiplier.Text,
+                $"{path}.cloudsResolutionMultiplier",
+                "Clouds resolution multiplier",
+                issues,
+                out var cloudsResolutionMultiplier);
+            valid &= TryParseInt(
+                _skyResolution.Text,
+                $"{path}.skyResolution",
+                "Sky resolution",
+                issues,
+                out var skyResolution);
+            valid &= TryParseInt(
+                _lodBias.Text,
+                $"{path}.lodBias",
+                "LOD bias",
+                issues,
+                out var lodBias);
+
+            var msaaSamples = _msaaSamples.SelectedItem is int msaa
+                ? msaa
+                : 0;
+            var shadowQuality =
+                _shadowQuality.SelectedItem is PickerOption<GraphicsShadowQuality> shadow
+                    ? shadow.Value
+                    : (GraphicsShadowQuality)(-1);
+            var cascadeCount =
+                _shadowCascadeCount.SelectedItem is int count
+                    ? count
+                    : 0;
+            settings = new GraphicsQualityPresetSettings
+            {
+                ResolutionFactor = resolutionFactor,
+                FpsCap = fpsCap,
+                MsaaSamples = msaaSamples,
+                ShadowQuality = shadowQuality,
+                ShadowBias = shadowBias,
+                ShadowCascadeCount = cascadeCount,
+                ShadowCascadeResolutions = cascadeResolutions,
+                SupportSoftShadows = _supportSoftShadows.IsToggled,
+                CloudsResolutionMultiplier = cloudsResolutionMultiplier,
+                SkyResolution = skyResolution,
+                LodBias = lodBias
+            };
+            return valid;
+        }
+
+        Entry CreateEntry(string text)
+        {
+            var entry = new Entry
+            {
+                Text = text,
+                Keyboard = Keyboard.Text,
+                FontSize = 11,
+                HeightRequest = 30,
+                MinimumHeightRequest = 30,
+                HorizontalOptions = LayoutOptions.Fill
+            };
+            entry.TextChanged += (_, _) => _changed();
+            return entry;
+        }
+
+        Picker CreatePicker(
+            IReadOnlyList<object> options,
+            object selected)
+        {
+            var picker = new Picker
+            {
+                ItemsSource = options.ToList(),
+                SelectedItem = selected,
+                FontSize = 11,
+                HeightRequest = 30,
+                MinimumHeightRequest = 30,
+                HorizontalOptions = LayoutOptions.Fill
+            };
+            picker.SelectedIndexChanged += (_, _) => _changed();
+            return picker;
+        }
+
+        static View CreatePresetField(
+            string title,
+            string description,
+            View editor)
+        {
+            var titleLabel = new Label
+            {
+                Text = title,
+                FontSize = 10,
+                LineBreakMode = LineBreakMode.TailTruncation,
+                VerticalTextAlignment = TextAlignment.Center
+            };
+            ToolTipProperties.SetText(titleLabel, description);
+            var grid = new Grid
+            {
+                ColumnDefinitions =
+                {
+                    new ColumnDefinition(new GridLength(6, GridUnitType.Star)),
+                    new ColumnDefinition(new GridLength(5, GridUnitType.Star))
+                },
+                ColumnSpacing = 6,
+                Padding = new Thickness(0, 0)
+            };
+            grid.Add(titleLabel, 0, 0);
+            grid.Add(editor, 1, 0);
+            return grid;
+        }
+
+        static bool TryParseDouble(
+            string? text,
+            string path,
+            string displayName,
+            ICollection<GraphicsSettingsValidationIssue> issues,
+            out double value)
+        {
+            if (double.TryParse(
+                    text,
+                    NumberStyles.Float,
+                    CultureInfo.InvariantCulture,
+                    out value) &&
+                double.IsFinite(value))
+            {
+                return true;
+            }
+
+            issues.Add(new GraphicsSettingsValidationIssue(
+                path,
+                $"{displayName} must be a finite number using '.' as the decimal separator."));
+            value = 0;
+            return false;
+        }
+
+        static bool TryParseInt(
+            string? text,
+            string path,
+            string displayName,
+            ICollection<GraphicsSettingsValidationIssue> issues,
+            out int value)
+        {
+            if (int.TryParse(
+                    text,
+                    NumberStyles.Integer,
+                    CultureInfo.InvariantCulture,
+                    out value))
+            {
+                return true;
+            }
+
+            issues.Add(new GraphicsSettingsValidationIssue(
+                path,
+                $"{displayName} must be an integer."));
+            value = 0;
+            return false;
+        }
+
+        static bool TryParseCascadeResolutions(
+            string? text,
+            string path,
+            ICollection<GraphicsSettingsValidationIssue> issues,
+            out IReadOnlyList<int> values)
+        {
+            var parsed = new List<int>();
+            var parts = (text ?? string.Empty).Split(
+                ',',
+                StringSplitOptions.TrimEntries);
+            if (parts.Length == 0 || parts.Any(string.IsNullOrWhiteSpace))
+            {
+                issues.Add(new GraphicsSettingsValidationIssue(
+                    path,
+                    "Cascade resolutions must be a comma-separated list of integers."));
+                values = [];
+                return false;
+            }
+
+            foreach (var part in parts)
+            {
+                if (!int.TryParse(
+                        part,
+                        NumberStyles.Integer,
+                        CultureInfo.InvariantCulture,
+                        out var value))
+                {
+                    issues.Add(new GraphicsSettingsValidationIssue(
+                        path,
+                        $"Cascade resolution '{part}' is not an integer."));
+                    values = [];
+                    return false;
+                }
+                parsed.Add(value);
+            }
+
+            values = parsed;
+            return true;
+        }
+
+        static string FormatDouble(double value)
+            => value.ToString("0.####", CultureInfo.InvariantCulture);
     }
 
     sealed class SettingsEditorRow : INotifyPropertyChanged

--- a/Editor/Workspace/WorkspaceProjectGenerator.cs
+++ b/Editor/Workspace/WorkspaceProjectGenerator.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using SailorEditor.Settings;
 
 namespace SailorEditor.Workspace;
 
@@ -34,6 +35,8 @@ public sealed class WorkspaceProjectGenerator
         var generatedFiles = new Dictionary<string, string>
         {
             [Path.Combine(session.WorkspaceRoot, ".gitignore")] = BuildGitIgnore(session.Manifest),
+            [Path.Combine(session.WorkspaceRoot, GraphicsSettingsPaths.ProjectFileName)] =
+                GraphicsSettingsYamlCodec.SerializeProject(GraphicsSettingsDefaults.Project),
             [Path.Combine(session.GeneratedProjectDirectory, "CMakeLists.txt")] = BuildCMakeProject(session),
             [Path.Combine(componentsDirectory, "SampleComponent.h")] = BuildSampleComponentHeader(session.Manifest.LogicModuleName),
             [Path.Combine(componentsDirectory, "SampleComponent.cpp")] = BuildSampleComponentSource(session.Manifest.LogicModuleName),

--- a/External/YamlExceptionBoundary.h
+++ b/External/YamlExceptionBoundary.h
@@ -76,11 +76,21 @@ namespace Sailor::External
 		TValue& outValue,
 		std::string& outDiagnostic) noexcept
 	{
-		return GuardYamlExceptions(
-			[&node, &outValue]()
+		bool bConverted = false;
+		if (!GuardYamlExceptions(
+			[&node, &outValue, &bConverted]()
 			{
-				outValue = node.as<TValue>();
+				bConverted = YAML::convert<TValue>::decode(node, outValue);
 			},
-			outDiagnostic);
+			outDiagnostic))
+		{
+			return false;
+		}
+
+		if (!bConverted)
+		{
+			outDiagnostic = "YAML value could not be converted to the requested type.";
+		}
+		return bConverted;
 	}
 }

--- a/Lib/EditorEngineProtocol.cpp
+++ b/Lib/EditorEngineProtocol.cpp
@@ -4,6 +4,7 @@
 #include "Memory/UniquePtr.hpp"
 #include "Protocol/Generated/editor_engine.pb.h"
 #include "Sailor.h"
+#include "Settings/GraphicsSettings.h"
 #include "Tasks/Scheduler.h"
 #include "Tasks/Tasks.h"
 
@@ -1121,6 +1122,35 @@ namespace
 				Sailor::App::PreviewEditorAudioAsset(
 					request.preview_audio_asset().file_id().c_str()));
 			break;
+
+		case ProtocolRequest::kSetEditorStatsMode:
+		{
+			Sailor::Settings::ERenderStatsMode statsMode{};
+			switch (request.set_editor_stats_mode().mode())
+			{
+			case sailor::editor::v1::EDITOR_STATS_MODE_NONE:
+				statsMode = Sailor::Settings::ERenderStatsMode::None;
+				break;
+			case sailor::editor::v1::EDITOR_STATS_MODE_RENDER_STATS:
+				statsMode = Sailor::Settings::ERenderStatsMode::RenderStats;
+				break;
+			case sailor::editor::v1::EDITOR_STATS_MODE_RENDER_STATS_AND_QUERIES:
+				statsMode = Sailor::Settings::ERenderStatsMode::RenderStatsAndQueries;
+				break;
+			case sailor::editor::v1::EDITOR_STATS_MODE_UNSPECIFIED:
+			default:
+				SetError(response, "The Editor stats mode is invalid.");
+				break;
+			}
+
+			if (response.error().empty())
+			{
+				SetBoolResult(
+					response,
+					Sailor::App::SetRenderStatsMode(statsMode));
+			}
+			break;
+		}
 
 		case ProtocolRequest::kSetViewport:
 		{

--- a/ProjectSettings.yaml
+++ b/ProjectSettings.yaml
@@ -1,0 +1,79 @@
+settingsVersion: 1
+graphics:
+  defaultQuality: High
+  presets:
+    Ultra:
+      resolutionFactor: 1
+      fpsCap: 120
+      msaaSamples: 8
+      shadowQuality: High
+      shadowBias: 0
+      shadowCascadeCount: 4
+      shadowCascadeResolutions:
+      - 4096
+      - 2048
+      - 2048
+      - 1024
+      supportSoftShadows: true
+      cloudsResolutionMultiplier: 1
+      skyResolution: 512
+      lodBias: -1
+    High:
+      resolutionFactor: 1
+      fpsCap: 120
+      msaaSamples: 4
+      shadowQuality: High
+      shadowBias: 0
+      shadowCascadeCount: 4
+      shadowCascadeResolutions:
+      - 2048
+      - 2048
+      - 1024
+      - 1024
+      supportSoftShadows: true
+      cloudsResolutionMultiplier: 0.75
+      skyResolution: 256
+      lodBias: 0
+    Medium:
+      resolutionFactor: 0.85
+      fpsCap: 120
+      msaaSamples: 2
+      shadowQuality: Medium
+      shadowBias: 0
+      shadowCascadeCount: 3
+      shadowCascadeResolutions:
+      - 2048
+      - 1024
+      - 512
+      supportSoftShadows: true
+      cloudsResolutionMultiplier: 0.5
+      skyResolution: 256
+      lodBias: 0
+    Low:
+      resolutionFactor: 0.7
+      fpsCap: 120
+      msaaSamples: 1
+      shadowQuality: Low
+      shadowBias: 0
+      shadowCascadeCount: 2
+      shadowCascadeResolutions:
+      - 1024
+      - 512
+      supportSoftShadows: false
+      cloudsResolutionMultiplier: 0.5
+      skyResolution: 128
+      lodBias: 1
+    VeryLow:
+      resolutionFactor: 0.5
+      fpsCap: 120
+      msaaSamples: 1
+      shadowQuality: VeryLow
+      shadowBias: 0
+      shadowCascadeCount: 1
+      shadowCascadeResolutions:
+      - 512
+      supportSoftShadows: false
+      cloudsResolutionMultiplier: 0.125
+      skyResolution: 64
+      lodBias: 2
+...

--- a/Protocol/editor_engine.proto
+++ b/Protocol/editor_engine.proto
@@ -65,13 +65,14 @@ message ProtocolRequest {
 		EditorSimulationRequest set_editor_simulation = 61;
 		Empty get_editor_simulation_state = 62;
 		FileIdRequest preview_audio_asset = 63;
+		EditorStatsModeRequest set_editor_stats_mode = 64;
 	}
 
 	reserved 3 to 9;
 	reserved 50;
 	reserved "create_model_game_object";
 	reserved "resolve_viewport_drop_position";
-	reserved 64 to 99;
+	reserved 65 to 99;
 }
 
 message ProtocolResponse {
@@ -145,6 +146,10 @@ message SizeRequest {
 
 message EditorSimulationRequest {
 	bool enabled = 1;
+}
+
+message EditorStatsModeRequest {
+	EditorStatsMode mode = 1;
 }
 
 message RemoteViewportRequest {
@@ -345,6 +350,13 @@ enum ViewportTransformSpace {
 	VIEWPORT_TRANSFORM_SPACE_UNSPECIFIED = 0;
 	VIEWPORT_TRANSFORM_SPACE_WORLD = 1;
 	VIEWPORT_TRANSFORM_SPACE_LOCAL = 2;
+}
+
+enum EditorStatsMode {
+	EDITOR_STATS_MODE_UNSPECIFIED = 0;
+	EDITOR_STATS_MODE_NONE = 1;
+	EDITOR_STATS_MODE_RENDER_STATS = 2;
+	EDITOR_STATS_MODE_RENDER_STATS_AND_QUERIES = 3;
 }
 
 message Vector4 {

--- a/Runtime/AssetRegistry/FrameGraph/FrameGraphParser.h
+++ b/Runtime/AssetRegistry/FrameGraph/FrameGraphParser.h
@@ -7,6 +7,7 @@
 #include "AssetRegistry/FileId.h"
 #include "Core/YamlSerializable.h"
 #include "Tasks/Tasks.h"
+#include "Settings/GraphicsSettings.h"
 
 namespace Sailor
 {
@@ -90,13 +91,29 @@ namespace Sailor
 					auto strings = Utils::SplitString(str, "/");
 					float multiplier = strings.Num() > 1 ? 1.0f / (float)std::atof(strings[1].c_str()) : 1.0f;
 
-					if (str.starts_with("ViewportWidth"))
+					const glm::ivec2 viewportExtent =
+						App::GetMainWindow()->GetRenderArea();
+					const Settings::GraphicsExtent renderExtent =
+						Settings::ResolveRenderDimensions(
+							static_cast<uint32_t>((std::max)(viewportExtent.x, 1)),
+							static_cast<uint32_t>((std::max)(viewportExtent.y, 1)),
+							App::GetActiveGraphicsSettings().m_resolutionFactor);
+
+					if (str.starts_with("RenderWidth"))
 					{
-						res = std::max(1u, (uint32_t)((float)App::GetMainWindow()->GetRenderArea().x * multiplier));
+						res = std::max(1u, (uint32_t)((float)renderExtent.m_width * multiplier));
+					}
+					else if (str.starts_with("RenderHeight"))
+					{
+						res = std::max(1u, (uint32_t)((float)renderExtent.m_height * multiplier));
+					}
+					else if (str.starts_with("ViewportWidth"))
+					{
+						res = std::max(1u, (uint32_t)((float)viewportExtent.x * multiplier));
 					}
 					else if (str.starts_with("ViewportHeight"))
 					{
-						res = std::max(1u, (uint32_t)((float)App::GetMainWindow()->GetRenderArea().y * multiplier));
+						res = std::max(1u, (uint32_t)((float)viewportExtent.y * multiplier));
 					}
 					else
 					{

--- a/Runtime/ECS/ECS.cpp
+++ b/Runtime/ECS/ECS.cpp
@@ -1,7 +1,10 @@
 #include <typeindex>
 #include "ECS.h"
+#include "ECSAutoRegistration.h"
 #include "Sailor.h"
 #include "Engine/GameObject.h"
+
+#include <atomic>
 
 using namespace Sailor;
 using namespace Sailor::Tasks;
@@ -10,6 +13,7 @@ using namespace Sailor::ECS;
 namespace Sailor::Internal
 {
 	TUniquePtr<TMap<size_t, std::function<TBaseSystemPtr(void)>, Memory::MallocAllocator>> g_factoryMethods;
+	std::atomic<bool> g_bSuppressEcsAutoRegistration{ false };
 }
 
 void TBaseSystem::UpdateGameObject(GameObjectPtr gameObject, size_t lastFrameChanges)
@@ -19,12 +23,33 @@ void TBaseSystem::UpdateGameObject(GameObjectPtr gameObject, size_t lastFrameCha
 
 void ECSFactory::RegisterECS(size_t typeInfo, std::function<TBaseSystemPtr(void)> factoryMethod)
 {
+	if (IsAutoRegistrationSuppressed())
+	{
+		return;
+	}
+
 	if (!Sailor::Internal::g_factoryMethods)
 	{
 		Sailor::Internal::g_factoryMethods = TUniquePtr< TMap<size_t, std::function<TBaseSystemPtr(void)>, Memory::MallocAllocator>>::Make();
 	}
 
-	(*Sailor::Internal::g_factoryMethods)[typeInfo] = factoryMethod;
+	// Static template instantiations can appear in more than one shared library.
+	// The first registration belongs to the engine image and must not be replaced
+	// with a callable whose code may disappear when a workspace module unloads.
+	Sailor::Internal::g_factoryMethods->Insert(typeInfo, std::move(factoryMethod));
+}
+
+void Sailor::ECS::SetAutoRegistrationSuppressed(bool suppressed)
+{
+	Sailor::Internal::g_bSuppressEcsAutoRegistration.store(
+		suppressed,
+		std::memory_order_release);
+}
+
+bool Sailor::ECS::IsAutoRegistrationSuppressed()
+{
+	return Sailor::Internal::g_bSuppressEcsAutoRegistration.load(
+		std::memory_order_acquire);
 }
 
 TVector<TBaseSystemPtr> ECSFactory::CreateECS() const

--- a/Runtime/ECS/ECSAutoRegistration.h
+++ b/Runtime/ECS/ECSAutoRegistration.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "Core/Defines.h"
+
+namespace Sailor::ECS
+{
+	SAILOR_API void SetAutoRegistrationSuppressed(bool suppressed);
+	SAILOR_API bool IsAutoRegistrationSuppressed();
+}

--- a/Runtime/ECS/LandscapeECS.cpp
+++ b/Runtime/ECS/LandscapeECS.cpp
@@ -1110,9 +1110,9 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			shadowCaster->m_worldAabb = proxy.m_worldAabb;
 			proxy.m_shadowCaster = shadowCaster->m_meshes.IsEmpty() ?
 				RHI::RHIShadowCasterProxyPtr{} : shadowCaster;
+			auto* textureImporter = App::GetSubmodule<TextureImporter>();
 #if defined(__APPLE__)
 			proxy.m_materialTextureSamplers.Resize(1u);
-			auto* textureImporter = App::GetSubmodule<TextureImporter>();
 			proxy.m_materialTextureSamplers[0].Insert(0u);
 			if (textureImporter)
 			{

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -7,6 +7,7 @@
 #include "RHI/DebugContext.h"
 #include "Engine/GameObject.h"
 #include "FrameGraph/ShadowPrepassNode.h"
+#include "Settings/GraphicsSettings.h"
 
 #include <array>
 
@@ -229,6 +230,7 @@ Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
 	bool bPublishedChanges = false;
 	uint32_t numLights = 0;
 	const size_t numGpuLightSlots = GetGpuLightSlotsCount(m_components.Num());
+	const auto& graphicsProfile = App::GetActiveGraphicsSettings();
 	for (size_t index = 0; index < numGpuLightSlots; ++index)
 	{
 		auto& data = m_components[index];
@@ -259,7 +261,15 @@ Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
 			if (data.m_bIsDirty || data.m_frameLastChange < ownerTransform.GetFrameLastChange())
 			{
 				shaderData.m_type = (uint32_t)data.m_type;
-				shaderData.m_shadowType = (uint32_t)data.m_shadowType;
+				const RHI::EShadowType effectiveShadowType =
+					!graphicsProfile.m_bSupportSoftShadows &&
+					data.m_shadowType == RHI::EShadowType::EVSM ?
+					RHI::EShadowType::PCF : data.m_shadowType;
+				shaderData.m_shadowType = (uint32_t)effectiveShadowType;
+				shaderData.m_activeCascadeCount = (std::clamp)(
+					graphicsProfile.m_shadowCascadeCount,
+					1u,
+					NumCascades);
 				shaderData.m_attenuation = data.m_attenuation;
 				shaderData.m_bounds = glm::vec3(data.m_radius);
 				shaderData.m_intensity = data.m_intensity;
@@ -338,6 +348,7 @@ void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
 
 	// TODO: Cache lights that cast shadows separately to decrease algo complexity
 	const size_t numGpuLightSlots = GetGpuLightSlotsCount(m_components.Num());
+	const auto& graphicsProfile = App::GetActiveGraphicsSettings();
 	for (size_t index = 0; index < numGpuLightSlots; index++)
 	{
 		auto& light = m_components[index];
@@ -358,7 +369,10 @@ void LightingECS::GetLightsInFrustum(const Math::Frustum& frustum,
 			lightProxy.m_lightTransform = ownerTransform.GetTransform();
 			lightProxy.m_distanceToCamera = 0.0f;
 			lightProxy.m_index = (uint32_t)index;
-			lightProxy.m_shadowType = light.m_shadowType;
+			lightProxy.m_shadowType =
+				!graphicsProfile.m_bSupportSoftShadows &&
+				light.m_shadowType == RHI::EShadowType::EVSM ?
+				RHI::EShadowType::PCF : light.m_shadowType;
 
 			if (light.m_type != ELightType::Directional)
 			{
@@ -407,6 +421,7 @@ void LightingECS::PrepareCSMPasses(
 	const auto casterSceneVersions = sceneView->GetRetainedSceneVersions();
 	const auto submissionToken = sceneView->GetOrCreateSubmissionCompletionToken();
 	auto& csmSnapshots = flightResources.m_csmSnapshots;
+	const auto& graphicsProfile = App::GetActiveGraphicsSettings();
 
 	for (const auto& directionalLight : directionalLights)
 	{
@@ -557,8 +572,8 @@ void LightingECS::PrepareCSMPasses(
 
 			const bool bEvsmCascade =
 				cascade.m_shadowType == RHI::EShadowType::EVSM;
-			const glm::ivec2 shadowMapExtent =
-				ShadowCascadeResolutions[k % NumCascades];
+			const glm::ivec2 shadowMapExtent(
+				graphicsProfile.GetShadowCascadeResolution(k));
 			const RHI::EFormat shadowMapFormat =
 				GetCsmShadowMapFormat(cascade.m_shadowType);
 			if (flightResources.m_csmShadowMaps.Num() <= snapshotIndex)
@@ -971,7 +986,11 @@ uint32_t LightingECS::CalculateLocalShadowResolution(
 	const CameraData& cameraData,
 	uint32_t viewportHeight) const
 {
-	const uint32_t qualityLimit = GetLocalShadowResolution(light.m_shadowQuality);
+	const ELightShadowQuality effectiveQuality =
+		Settings::ApplyShadowQualityCap(
+			light.m_shadowQuality,
+			App::GetActiveGraphicsSettings().m_shadowQuality);
+	const uint32_t qualityLimit = GetLocalShadowResolution(effectiveQuality);
 	const float safeDistance = (std::max)(distanceToCamera, 0.01f);
 	const float focalLengthPixels = static_cast<float>((std::max)(viewportHeight, 1u)) /
 		(2.0f * glm::tan(glm::radians(cameraData.GetFov()) * 0.5f));
@@ -1052,7 +1071,7 @@ bool LightingECS::EnsureLocalShadowAllocation(
 	{
 		auto findFreeSlots = [&]()
 		{
-			for (uint32_t candidate = static_cast<uint32_t>(m_csmShadowMaps.Num());
+			for (uint32_t candidate = NumCascades;
 				candidate + mapCount <= MaxShadowsInView;
 				++candidate)
 			{
@@ -1357,7 +1376,9 @@ void LightingECS::PrepareLocalShadowPasses(
 			}
 			const uint32_t firstSlot = allocation.m_slots[0];
 			shadowIndices[lightProxy.m_index] = firstSlot |
-				(light.m_shadowFilter == ELightShadowFilter::Soft ? SoftShadowMapBit : 0u);
+				(light.m_shadowFilter == ELightShadowFilter::Soft &&
+					App::GetActiveGraphicsSettings().m_bSupportSoftShadows ?
+					SoftShadowMapBit : 0u);
 
 			const float nearPlane = (std::max)(0.01f, farPlane * 0.001f);
 			std::array<glm::mat4, 6u> lightMatrices{};
@@ -1490,9 +1511,13 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 	auto& flightResources = m_shadowFlightResources[flightSlot];
 	m_writableLocalShadowAtlases.reset();
 	uint32_t snapshotIndex = 0;
-	const uint32_t viewportHeight = static_cast<uint32_t>((std::max)(
-		App::GetMainWindow()->GetRenderArea().y,
-		1));
+	const glm::ivec2 viewportExtent = App::GetMainWindow()->GetRenderArea();
+	const Settings::GraphicsExtent renderExtent =
+		Settings::ResolveRenderDimensions(
+			static_cast<uint32_t>((std::max)(viewportExtent.x, 1)),
+			static_cast<uint32_t>((std::max)(viewportExtent.y, 1)),
+			App::GetActiveGraphicsSettings().m_resolutionFactor);
+	const uint32_t viewportHeight = renderExtent.m_height;
 	const size_t numCameras = sceneView->m_cameraTransforms.Num();
 	sceneView->m_shadowMapsToUpdate.Resize(numCameras);
 	sceneView->m_shadowMapsToBlit.Resize(numCameras);

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -146,6 +146,16 @@ namespace Sailor
 		static constexpr float ShadowCascadeLevels[NumCascades] = { 0.025f, 0.075f, 0.2f, 1.0f };
 		static constexpr glm::ivec2 ShadowCascadeResolutions[NumCascades] = { {4096,4096}, {2048,2048}, {1024,1024}, {1024,1024} };
 		static constexpr glm::ivec2 ShadowCascadeBlur[NumCascades] = { glm::vec2(2, 2), glm::vec2(1, 1), glm::vec2(1, 1), glm::vec2(1, 1) };
+		static constexpr float GetShadowCascadeLevel(
+			uint32_t cascadeIndex,
+			uint32_t activeCascadeCount)
+		{
+			const uint32_t safeCount = activeCascadeCount < 1u ? 1u :
+				(activeCascadeCount > NumCascades ? NumCascades : activeCascadeCount);
+			const uint32_t safeIndex = cascadeIndex < safeCount ?
+				cascadeIndex : safeCount - 1u;
+			return ShadowCascadeLevels[NumCascades - safeCount + safeIndex];
+		}
 
 		// TODO: Tightly pack
 		using LightShaderData = RHI::RHILightShaderData;

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -7,6 +7,7 @@
 #include "RHI/Material.h"
 #include "Components/AnimatorComponent.h"
 #include "Components/MeshRendererComponent.h"
+#include "Settings/GraphicsSettings.h"
 
 #include <algorithm>
 #include <cmath>
@@ -287,7 +288,14 @@ uint32_t StaticMeshRendererData::ResolveLod(
 		selectedLod = static_cast<uint32_t>(thresholdIndex + 1u);
 	}
 
-	return (std::clamp)(selectedLod, minLod, maxLod);
+	const int32_t lodBias = App::GetInstance() ?
+		App::GetActiveGraphicsSettings().m_lodBias : 0;
+	return Settings::ApplyLodBias(
+		selectedLod,
+		numAvailableLods,
+		minLod,
+		maxLod,
+		lodBias);
 }
 
 void StaticMeshRendererData::SetLodSettings(

--- a/Runtime/Engine/EngineLoop.cpp
+++ b/Runtime/Engine/EngineLoop.cpp
@@ -18,6 +18,7 @@
 #include "RHI/CommandList.h"
 #include "RHI/Renderer.h"
 #include "RHI/Texture.h"
+#include "Settings/GraphicsSettings.h"
 
 #include <imgui.h>
 #include <cstdio>
@@ -37,7 +38,8 @@ namespace
 		float csmShadowMemoryMb,
 		float localShadowMemoryMb,
 		float shadowMemoryBudgetMb,
-		const RHI::Stats& stats)
+		const RHI::Stats& stats,
+		const char* gpuQueryText)
 	{
 		const ImGuiIO& io = ImGui::GetIO();
 		if (io.DisplaySize.x <= 0.0f || io.DisplaySize.y <= 0.0f)
@@ -46,13 +48,13 @@ namespace
 		}
 
 		constexpr float BytesToMb = 1.0f / (1024.0f * 1024.0f);
-		char text[512];
+		char text[640];
 		std::snprintf(
 			text,
 			sizeof(text),
 			"CPU %u FPS\nGPU %u FPS\nBatches %u\nInstances %u\n"
 			"Shadows %.1f / %.0f MB\n  CSM %.1f MB\n  Local %.1f MB\n"
-			"GPU memory\n  Materials %.1f MB\n  Textures %.1f MB\n  Meshes %.1f MB\n  General %.1f MB",
+			"GPU memory\n  Materials %.1f MB\n  Textures %.1f MB\n  Meshes %.1f MB\n  General %.1f MB%s%s",
 			cpuFps,
 			gpuFps,
 			numBatches,
@@ -64,7 +66,9 @@ namespace
 			stats.m_materialsMemoryUsage.load(std::memory_order_relaxed) * BytesToMb,
 			stats.m_texturesMemoryUsage.load(std::memory_order_relaxed) * BytesToMb,
 			stats.m_meshesMemoryUsage.load(std::memory_order_relaxed) * BytesToMb,
-			stats.m_generalMemoryUsage.load(std::memory_order_relaxed) * BytesToMb);
+			stats.m_generalMemoryUsage.load(std::memory_order_relaxed) * BytesToMb,
+			gpuQueryText && gpuQueryText[0] != '\0' ? "\n" : "",
+			gpuQueryText ? gpuQueryText : "");
 
 		constexpr float Margin = 10.0f;
 		const ImVec2 textSize = ImGui::CalcTextSize(text);
@@ -217,6 +221,7 @@ void EngineLoop::ProcessCpuFrame(FrameState& currentInputState)
 
 	static uint32_t totalFramesCount = 0U;
 	static Utils::Timer timer;
+	const auto cpuFrameStartedAt = std::chrono::steady_clock::now();
 
 	timer.Start();
 
@@ -229,7 +234,8 @@ void EngineLoop::ProcessCpuFrame(FrameState& currentInputState)
 	}
 
 	const auto renderer = App::GetSubmodule<RHI::Renderer>();
-	if (renderer)
+	const Settings::ERenderStatsMode statsMode = App::GetRenderStatsMode();
+	if (renderer && statsMode != Settings::ERenderStatsMode::None)
 	{
 		float shadowMemoryMb = 0.0f;
 		float csmShadowMemoryMb = 0.0f;
@@ -247,6 +253,36 @@ void EngineLoop::ProcessCpuFrame(FrameState& currentInputState)
 		}
 
 		const auto& stats = renderer->GetStats();
+		char gpuQueryText[96]{};
+		if (statsMode == Settings::ERenderStatsMode::RenderStatsAndQueries)
+		{
+			if (!renderer->GetDriver()->SupportsGpuFrameTimeQueries())
+			{
+				std::snprintf(
+					gpuQueryText,
+					sizeof(gpuQueryText),
+					"GPU queries unavailable");
+			}
+			else
+			{
+				float gpuFrameTimeMs = 0.0f;
+				if (renderer->GetDriver()->TryGetGpuFrameTimeMs(gpuFrameTimeMs))
+				{
+					std::snprintf(
+						gpuQueryText,
+						sizeof(gpuQueryText),
+						"GPU frame %.2f ms",
+						gpuFrameTimeMs);
+				}
+				else
+				{
+					std::snprintf(
+						gpuQueryText,
+						sizeof(gpuQueryText),
+						"GPU query pending");
+				}
+			}
+		}
 		DrawViewportStatsOverlay(
 			m_cpuFps,
 			stats.m_gpuFps.load(std::memory_order_relaxed),
@@ -256,7 +292,8 @@ void EngineLoop::ProcessCpuFrame(FrameState& currentInputState)
 			csmShadowMemoryMb,
 			localShadowMemoryMb,
 			shadowMemoryBudgetMb,
-			stats);
+			stats,
+			gpuQueryText);
 	}
 
 	auto& task = currentInputState.GetDrawImGuiTask();
@@ -303,6 +340,19 @@ void EngineLoop::ProcessCpuFrame(FrameState& currentInputState)
 		}, EThreadType::RHI);
 
 	task->Run();
+
+	if (m_fpsCap > 0u)
+	{
+		const auto targetCpuFrameTime =
+			std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+				std::chrono::duration<double>(1.0 / static_cast<double>(m_fpsCap)));
+		const auto cpuFrameDeadline = cpuFrameStartedAt + targetCpuFrameTime;
+		if (std::chrono::steady_clock::now() < cpuFrameDeadline)
+		{
+			SAILOR_PROFILE_SCOPE("Sleep Main Thread to cap CPU FPS");
+			std::this_thread::sleep_until(cpuFrameDeadline);
+		}
+	}
 
 	timer.Stop();
 

--- a/Runtime/Engine/EngineLoop.h
+++ b/Runtime/Engine/EngineLoop.h
@@ -23,8 +23,9 @@ namespace Sailor
 
 		SAILOR_API void ProcessCpuFrame(FrameState& currentInputState);
 		SAILOR_API uint32_t GetCpuFps() const { return m_cpuFps; }
+		SAILOR_API uint32_t GetFpsCap() const { return m_fpsCap; }
 
-		EngineLoop() = default;
+		explicit EngineLoop(uint32_t fpsCap) noexcept : m_fpsCap(fpsCap) {}
 		SAILOR_API ~EngineLoop() override;
 
 		SAILOR_API TSharedPtr<World> CreateEmptyWorld(std::string name, EWorldBehaviourMask mask);
@@ -38,6 +39,7 @@ namespace Sailor
 
 	protected:
 
+		uint32_t m_fpsCap = 0u;
 		uint32_t m_cpuFps = 0u;
 		TVector<TSharedPtr<World>> m_worlds;
 		TVector<WorldPtr> m_pendingWorldsToExit;

--- a/Runtime/FrameGraph/BlitNode.cpp
+++ b/Runtime/FrameGraph/BlitNode.cpp
@@ -78,21 +78,39 @@ void BlitNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr trans
 	glm::ivec4 srcRegion(0, 0, src->GetExtent().x, src->GetExtent().y);
 	glm::ivec4 dstRegion(0, 0, dst->GetExtent().x, dst->GetExtent().y);
 
-	commands->ImageMemoryBarrier(commandList, src, RHI::EImageLayout::TransferSrcOptimal);
-	commands->ImageMemoryBarrier(commandList, dst, RHI::EImageLayout::TransferDstOptimal);
-
-	const bool bResolvedBlitSuccessful = commands->BlitImage(
-		commandList,
-		src,
-		dst,
-		srcRegion,
-		dstRegion,
-		bIsDepthFormat ?
-			ETextureFiltration::Nearest :
-			ETextureFiltration::Linear);
+	RHISurfacePtr dstSurface = GetRHIResource("dst").DynamicCast<RHISurface>();
+	const bool bUseFullscreenColorBlit =
+		!bIsDepthFormat &&
+		!dstSurface &&
+		m_blitToMsaaTargetMaterial &&
+		src->GetExtent() != dst->GetExtent();
+	bool bResolvedBlitSuccessful = false;
+	if (bUseFullscreenColorBlit)
+	{
+		// A fullscreen pass owns the native output viewport explicitly. This keeps
+		// resolution-scaled Scene View targets correctly fitted on MoltenVK instead
+		// of relying on cross-format vkCmdBlitImage scaling.
+		commands->ImageMemoryBarrier(commandList, src, RHI::EImageLayout::ShaderReadOnlyOptimal);
+		commands->ImageMemoryBarrier(commandList, dst, RHI::EImageLayout::ColorAttachmentOptimal);
+		BlitRaw(commandList, frameGraph, sceneView, src, dst);
+		bResolvedBlitSuccessful = true;
+	}
+	else
+	{
+		commands->ImageMemoryBarrier(commandList, src, RHI::EImageLayout::TransferSrcOptimal);
+		commands->ImageMemoryBarrier(commandList, dst, RHI::EImageLayout::TransferDstOptimal);
+		bResolvedBlitSuccessful = commands->BlitImage(
+			commandList,
+			src,
+			dst,
+			srcRegion,
+			dstRegion,
+			bIsDepthFormat ?
+				ETextureFiltration::Nearest :
+				ETextureFiltration::Linear);
+	}
 
 	// Blit to MSAA targets
-	RHISurfacePtr dstSurface = GetRHIResource("dst").DynamicCast<RHISurface>();
 	if (dstSurface && dstSurface->NeedsResolve())
 	{
 		bool bMsaaBlitSuccessful = false;

--- a/Runtime/FrameGraph/LinearizeDepthNode.cpp
+++ b/Runtime/FrameGraph/LinearizeDepthNode.cpp
@@ -108,7 +108,12 @@ void LinearizeDepthNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandLis
 		false);
 
 	commands->BindMaterial(commandList, m_postEffectMaterial);
-	commands->SetDefaultViewport(commandList);
+	commands->SetViewport(commandList,
+		0, (float)target->GetExtent().y,
+		(float)target->GetExtent().x, -(float)target->GetExtent().y,
+		glm::vec2(0, 0),
+		glm::vec2(target->GetExtent().x, target->GetExtent().y),
+		0, 1.0f);
 	commands->BindVertexBuffer(commandList, mesh->m_vertexBuffer, 0);
 	commands->BindIndexBuffer(commandList, mesh->m_indexBuffer, 0);
 	commands->BindShaderBindings(commandList, m_postEffectMaterial, { sceneView.m_frameBindings,  m_linearizeDepth });

--- a/Runtime/FrameGraph/RHIFrameGraph.cpp
+++ b/Runtime/FrameGraph/RHIFrameGraph.cpp
@@ -9,6 +9,7 @@
 #include "RHI/CommandList.h"
 #include "FrameGraph/LightCullingNode.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
+#include "Settings/GraphicsSettings.h"
 #include "Tasks/Tasks.h"
 
 #include <atomic>
@@ -542,7 +543,15 @@ RHI::UboFrameData RHIFrameGraph::FillFrameData(RHI::RHICommandListPtr transferCm
 	frameData.m_currentTime = worldTime;
 	frameData.m_deltaTime = deltaTime;
 	frameData.m_view = snapshot.m_camera->GetViewMatrix();
-	frameData.m_viewportSize = glm::ivec2(App::GetMainWindow()->GetRenderArea().x, App::GetMainWindow()->GetRenderArea().y);
+	const glm::ivec2 viewportExtent = App::GetMainWindow()->GetRenderArea();
+	const Settings::GraphicsExtent renderExtent =
+		Settings::ResolveRenderDimensions(
+			static_cast<uint32_t>((std::max)(viewportExtent.x, 1)),
+			static_cast<uint32_t>((std::max)(viewportExtent.y, 1)),
+			App::GetActiveGraphicsSettings().m_resolutionFactor);
+	frameData.m_viewportSize = glm::ivec2(
+		static_cast<int32_t>(renderExtent.m_width),
+		static_cast<int32_t>(renderExtent.m_height));
 
 	RHI::Renderer::GetDriverCommands()->UpdateShaderBinding(transferCmdList, snapshot.m_frameBindings->GetOrAddShaderBinding("frameData"), &frameData, sizeof(frameData));
 	RHI::Renderer::GetDriverCommands()->UpdateShaderBinding(transferCmdList, snapshot.m_frameBindings->GetOrAddShaderBinding("previousFrameData"), &previousFrame, sizeof(previousFrame));
@@ -659,7 +668,6 @@ bool RHIFrameGraph::Process(RHI::RHISceneViewPtr rhiSceneView,
 
 		driverCommands->BeginCommandList(cmdList, true);
 		driverCommands->BeginDebugRegion(cmdList, "FrameGraph:Graphics", glm::vec4(0.75f, 1.0f, 0.75f, 0.1f));
-
 		driverCommands->BeginCommandList(transferCmdList, true);
 		driverCommands->BeginDebugRegion(transferCmdList, "FrameGraph:Transfer", glm::vec4(0.75f, 0.75f, 1.0f, 0.1f));
 

--- a/Runtime/FrameGraph/RHIFrameGraph.cpp
+++ b/Runtime/FrameGraph/RHIFrameGraph.cpp
@@ -5,6 +5,7 @@
 #include "RHI/Shader.h"
 #include "RHI/VertexDescription.h"
 #include "RHI/RenderTarget.h"
+#include "RHI/Surface.h"
 #include "RHI/Cubemap.h"
 #include "RHI/CommandList.h"
 #include "FrameGraph/LightCullingNode.h"
@@ -523,7 +524,52 @@ void RHIFrameGraph::SetSurface(const std::string& name, RHI::RHISurfacePtr surfa
 	m_surfaces[name] = surface;
 }
 
-RHI::UboFrameData RHIFrameGraph::FillFrameData(RHI::RHICommandListPtr transferCmdList, RHI::RHISceneViewSnapshot& snapshot, const RHI::UboFrameData& previousFrame, float deltaTime, float worldTime) const
+glm::ivec2 RHIFrameGraph::GetSceneRenderExtent()
+{
+	if (const auto debugDraw = GetGraphNode("DebugDraw"))
+	{
+		if (const auto colorAttachment = debugDraw->GetResolvedAttachment("color"))
+		{
+			const glm::ivec2 extent = colorAttachment->GetExtent();
+			return glm::ivec2(
+				(std::max)(extent.x, 1),
+				(std::max)(extent.y, 1));
+		}
+	}
+
+	if (const auto mainSurface = GetSurface("Main"))
+	{
+		const auto colorAttachment = mainSurface->GetResolved() ?
+			mainSurface->GetResolved() : mainSurface->GetTarget();
+		if (colorAttachment)
+		{
+			const glm::ivec2 extent = colorAttachment->GetExtent();
+			return glm::ivec2(
+				(std::max)(extent.x, 1),
+				(std::max)(extent.y, 1));
+		}
+	}
+
+	if (const auto mainTarget = GetRenderTarget("Main"))
+	{
+		const glm::ivec2 extent = mainTarget->GetExtent();
+		return glm::ivec2(
+			(std::max)(extent.x, 1),
+			(std::max)(extent.y, 1));
+	}
+
+	const glm::ivec2 viewportExtent = App::GetMainWindow()->GetRenderArea();
+	const Settings::GraphicsExtent fallbackExtent =
+		Settings::ResolveRenderDimensions(
+			static_cast<uint32_t>((std::max)(viewportExtent.x, 1)),
+			static_cast<uint32_t>((std::max)(viewportExtent.y, 1)),
+			App::GetActiveGraphicsSettings().m_resolutionFactor);
+	return glm::ivec2(
+		static_cast<int32_t>(fallbackExtent.m_width),
+		static_cast<int32_t>(fallbackExtent.m_height));
+}
+
+RHI::UboFrameData RHIFrameGraph::FillFrameData(RHI::RHICommandListPtr transferCmdList, RHI::RHISceneViewSnapshot& snapshot, const RHI::UboFrameData& previousFrame, float deltaTime, float worldTime)
 {
 	SAILOR_PROFILE_FUNCTION();
 
@@ -543,15 +589,7 @@ RHI::UboFrameData RHIFrameGraph::FillFrameData(RHI::RHICommandListPtr transferCm
 	frameData.m_currentTime = worldTime;
 	frameData.m_deltaTime = deltaTime;
 	frameData.m_view = snapshot.m_camera->GetViewMatrix();
-	const glm::ivec2 viewportExtent = App::GetMainWindow()->GetRenderArea();
-	const Settings::GraphicsExtent renderExtent =
-		Settings::ResolveRenderDimensions(
-			static_cast<uint32_t>((std::max)(viewportExtent.x, 1)),
-			static_cast<uint32_t>((std::max)(viewportExtent.y, 1)),
-			App::GetActiveGraphicsSettings().m_resolutionFactor);
-	frameData.m_viewportSize = glm::ivec2(
-		static_cast<int32_t>(renderExtent.m_width),
-		static_cast<int32_t>(renderExtent.m_height));
+	frameData.m_viewportSize = GetSceneRenderExtent();
 
 	RHI::Renderer::GetDriverCommands()->UpdateShaderBinding(transferCmdList, snapshot.m_frameBindings->GetOrAddShaderBinding("frameData"), &frameData, sizeof(frameData));
 	RHI::Renderer::GetDriverCommands()->UpdateShaderBinding(transferCmdList, snapshot.m_frameBindings->GetOrAddShaderBinding("previousFrameData"), &previousFrame, sizeof(previousFrame));

--- a/Runtime/FrameGraph/RHIFrameGraph.h
+++ b/Runtime/FrameGraph/RHIFrameGraph.h
@@ -31,6 +31,7 @@ namespace Sailor::RHI
 		SAILOR_API RHI::RHITexturePtr GetSampler(const std::string& name);
 		SAILOR_API RHI::RHIRenderTargetPtr GetRenderTarget(const std::string& name);
 		SAILOR_API RHI::RHISurfacePtr GetSurface(const std::string& name);
+		SAILOR_API glm::ivec2 GetSceneRenderExtent();
 
 		SAILOR_API RHI::RHIMeshPtr GetFullscreenNdcQuad() { return m_postEffectPlane; }
 		SAILOR_API RHI::DrawCallStats GetDrawCallStats() const { return m_drawCallStats; }
@@ -59,7 +60,7 @@ namespace Sailor::RHI
 
 	protected:
 
-		RHI::UboFrameData FillFrameData(RHI::RHICommandListPtr transferCmdList, RHI::RHISceneViewSnapshot& snapshot, const RHI::UboFrameData& previousFrame, float deltaTime, float worldTime) const;
+		RHI::UboFrameData FillFrameData(RHI::RHICommandListPtr transferCmdList, RHI::RHISceneViewSnapshot& snapshot, const RHI::UboFrameData& previousFrame, float deltaTime, float worldTime);
 
 		TMap<std::string, RHI::RHITexturePtr> m_samplers;
 		TMap<std::string, RHI::RHIRenderTargetPtr> m_renderTargets;

--- a/Runtime/FrameGraph/RenderImGuiNode.cpp
+++ b/Runtime/FrameGraph/RenderImGuiNode.cpp
@@ -36,7 +36,15 @@ void RenderImGuiNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 		}
 	}
 
-	RHI::RHITexturePtr depthAttachment = frameGraph->GetRenderTarget("DepthBuffer");
+	RHI::RHITexturePtr depthAttachment = GetResolvedAttachment("depthStencil");
+	for (const auto& r : m_unresolvedResourceParams)
+	{
+		if (r.First() == "depthStencil")
+		{
+			depthAttachment = frameGraph->GetRenderTarget(*r.Second());
+			break;
+		}
+	}
 
 	if (!colorAttachment || !depthAttachment)
 		return;

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -1274,23 +1274,56 @@ void RenderSceneNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 		std::string(GetName()) + " QueueTag:" + GetString("Tag") + " Packed",
 		DebugContext::Color_CmdGraphics);
 	commands->ImageMemoryBarrier(commandList, colorAttachment, EImageLayout::ColorAttachmentOptimal);
+	if (colorSurface && colorSurface->NeedsResolve())
+	{
+		commands->ImageMemoryBarrier(
+			commandList,
+			colorSurface->GetResolved(),
+			EImageLayout::ColorAttachmentOptimal);
+	}
 	const auto depthLayout = RHI::IsDepthStencilFormat(depthAttachment->GetFormat()) ?
 		EImageLayout::DepthStencilAttachmentOptimal : EImageLayout::DepthAttachmentOptimal;
 	commands->ImageMemoryBarrier(commandList, depthAttachment, depthLayout);
-	auto& renderPassColorAttachments =
-		resources->m_renderPassColorAttachments;
-	renderPassColorAttachments.Clear(false);
-	renderPassColorAttachments.Add(colorAttachment);
-	commands->BeginRenderPass(
-		commandList,
-		renderPassColorAttachments,
-		depthAttachment,
-		glm::vec4(0, 0, colorAttachment->GetExtent().x, colorAttachment->GetExtent().y),
-		glm::ivec2(0, 0),
-		false,
-		glm::vec4(0.0f),
-		0.0f,
-		true);
+	const glm::vec4 renderArea(
+		0,
+		0,
+		colorAttachment->GetExtent().x,
+		colorAttachment->GetExtent().y);
+	if (colorSurface)
+	{
+		auto& renderPassColorSurfaces =
+			resources->m_renderPassColorSurfaces;
+		renderPassColorSurfaces.Clear(false);
+		renderPassColorSurfaces.Add(colorSurface);
+		commands->BeginRenderPass(
+			commandList,
+			renderPassColorSurfaces,
+			depthAttachment,
+			renderArea,
+			glm::ivec2(0, 0),
+			false,
+			glm::vec4(0.0f),
+			0.0f,
+			true);
+	}
+	else
+	{
+		auto& renderPassColorAttachments =
+			resources->m_renderPassColorAttachments;
+		renderPassColorAttachments.Clear(false);
+		renderPassColorAttachments.Add(colorAttachment);
+		commands->BeginRenderPass(
+			commandList,
+			renderPassColorAttachments,
+			depthAttachment,
+			renderArea,
+			glm::ivec2(0, 0),
+			false,
+			glm::vec4(0.0f),
+			0.0f,
+			true,
+			true);
+	}
 
 	auto& cullingBindings = resources->m_cullingDispatchBindings;
 	cullingBindings.Clear(false);

--- a/Runtime/FrameGraph/RenderSceneNode.h
+++ b/Runtime/FrameGraph/RenderSceneNode.h
@@ -65,6 +65,7 @@ namespace Sailor::Framegraph
 			{
 				m_orderedDrawItems.Clear(false);
 				m_renderPassColorAttachments.Clear(false);
+				m_renderPassColorSurfaces.Clear(false);
 				m_cullingDispatchBindings.Clear(false);
 				m_arenaRangeInstances.Clear(false);
 				m_arenaRangeStableKeys.Clear(false);
@@ -91,6 +92,7 @@ namespace Sailor::Framegraph
 			RHI::RHITexturePtr m_transmissionTexture{};
 			uint64_t m_nodeLightsSourceRevision = 0ull;
 			TVector<RHI::RHITexturePtr> m_renderPassColorAttachments{};
+			TVector<RHI::RHISurfacePtr> m_renderPassColorSurfaces{};
 			TVector<RHI::RHIShaderBindingSetPtr> m_cullingDispatchBindings{};
 			TVector<PerInstanceData> m_arenaRangeInstances{};
 			TVector<uint64_t> m_arenaRangeStableKeys{};

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -4,6 +4,7 @@
 #include "RHI/Renderer.h"
 #include "RHI/Shader.h"
 #include "RHI/Texture.h"
+#include "Settings/GraphicsSettings.h"
 #include "RHI/RenderTarget.h"
 #include "RHI/Types.h"
 #include "RHI/VertexDescription.h"
@@ -56,7 +57,18 @@ RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddShadowMaterial(RHI::RHIVertexDesc
 			check(pShader->IsReady());
 
 			const ECullMode cullMode = bMasked ? ECullMode::None : ECullMode::Back;
-			RenderState renderState = RHI::RenderState(true, true, 0.0f, false, cullMode, EBlendMode::None, EFillMode::Fill, GetHash(std::string("Shadow")), false, EDepthCompare::GreaterOrEqual);
+			const float shadowBias = App::GetActiveGraphicsSettings().m_shadowBias;
+			RenderState renderState = RHI::RenderState(
+				true,
+				true,
+				shadowBias,
+				false,
+				cullMode,
+				EBlendMode::None,
+				EFillMode::Fill,
+				GetHash(std::string("Shadow")),
+				false,
+				EDepthCompare::GreaterOrEqual);
 			material = RHI::Renderer::GetDriver()->CreateMaterial(vertexDescription, RHI::EPrimitiveTopology::TriangleList, renderState, pShader);
 		}
 	}
@@ -122,9 +134,10 @@ RHI::RHIMaterialPtr ShadowPrepassNode::GetOrAddCustomShadowMaterial(
 	}
 
 	const auto& sourceState = sourceMaterial->GetRenderState();
+	const float shadowBias = App::GetActiveGraphicsSettings().m_shadowBias;
 	RenderState shadowState(true,
 		true,
-		sourceState.GetDepthBias(),
+		sourceState.GetDepthBias() + shadowBias,
 		true,
 		sourceState.GetCullMode(),
 		EBlendMode::None,
@@ -1398,18 +1411,25 @@ void ShadowPrepassNode::CalculateLightProjectionForCascades(
 {
 	SAILOR_PROFILE_FUNCTION();
 	const float shadowFarPlane = (std::min)(cameraFarPlane, LightingECS::ShadowMaxDistance);
-
+	const auto& graphicsProfile = App::GetActiveGraphicsSettings();
+	const uint32_t activeCascadeCount = (std::clamp)(
+		graphicsProfile.m_shadowCascadeCount,
+		1u,
+		LightingECS::NumCascades);
 	outMatrices.Clear(false);
-	outMatrices.Reserve(LightingECS::NumCascades);
-	for (uint32_t i = 0; i < LightingECS::NumCascades; ++i)
+	outMatrices.Reserve(activeCascadeCount);
+	for (uint32_t i = 0; i < activeCascadeCount; ++i)
 	{
-		const float cascadeFar = shadowFarPlane * LightingECS::ShadowCascadeLevels[i];
+		const float cascadeFar = shadowFarPlane *
+			LightingECS::GetShadowCascadeLevel(i, activeCascadeCount);
 		float cascadeNear = cameraNearPlane;
 		if (i > 0)
 		{
-			const float previousSplit = shadowFarPlane * LightingECS::ShadowCascadeLevels[i - 1];
+			const float previousSplit = shadowFarPlane *
+				LightingECS::GetShadowCascadeLevel(i - 1u, activeCascadeCount);
 			const float previousNear = i > 1 ?
-				shadowFarPlane * LightingECS::ShadowCascadeLevels[i - 2] : cameraNearPlane;
+				shadowFarPlane * LightingECS::GetShadowCascadeLevel(
+					i - 2u, activeCascadeCount) : cameraNearPlane;
 			const float overlap = (previousSplit - previousNear) * LightingECS::ShadowCascadeBlendFraction;
 			cascadeNear = (std::max)(cameraNearPlane, previousSplit - overlap);
 		}
@@ -1418,7 +1438,7 @@ void ShadowPrepassNode::CalculateLightProjectionForCascades(
 			cascadeNear,
 			cascadeFar,
 			10.0f,
-			LightingECS::ShadowCascadeResolutions[i],
+			glm::ivec2(graphicsProfile.GetShadowCascadeResolution(i)),
 			LightingECS::ShadowCasterDepthExtension));
 	}
 }

--- a/Runtime/FrameGraph/SkyNode.cpp
+++ b/Runtime/FrameGraph/SkyNode.cpp
@@ -1,6 +1,7 @@
 #include "SkyNode.h"
 #include "RHI/SceneView.h"
 #include "RHI/Renderer.h"
+#include "Settings/GraphicsSettings.h"
 #include "RHI/Shader.h"
 #include "RHI/Surface.h"
 #include "RHI/RenderTarget.h"
@@ -420,11 +421,29 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 		}
 	}
 
+	const auto& graphicsProfile = App::GetActiveGraphicsSettings();
+	const Settings::GraphicsExtent desiredSkyExtent =
+		Settings::ResolveSkyExtent(graphicsProfile);
+	if (m_pSkyTexture &&
+		m_pSkyTexture->GetExtent() != glm::ivec2(
+			static_cast<int32_t>(desiredSkyExtent.m_width),
+			static_cast<int32_t>(desiredSkyExtent.m_height)))
+	{
+		m_pSkyTexture.Clear();
+		m_pShaderBindings.Clear();
+		m_pSkyMaterial.Clear();
+		m_pComposeMaterial.Clear();
+		m_pCloudsMaterial.Clear();
+		m_pSunShaftsMaterial.Clear();
+	}
+
 	if (!m_pSkyTexture)
 	{
 		m_pSkyTexture = driver->CreateRenderTarget(
 			commandList,
-			glm::ivec2(SkyResolution, SkyResolution),
+			glm::ivec2(
+				static_cast<int32_t>(desiredSkyExtent.m_width),
+				static_cast<int32_t>(desiredSkyExtent.m_height)),
 			1,
 			ETextureFormat::R16G16B16A16_SFLOAT,
 			ETextureFiltration::Linear,
@@ -448,12 +467,25 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 		driver->SetDebugName(m_pSunTexture, "Sun");
 	}
 
-	float cloudsResolutionFactor = CloudsResolutionFactor;
+	float cloudsPlatformMultiplier = 1.0f;
 #if defined(__APPLE__)
-	cloudsResolutionFactor *= 0.5f;
+	cloudsPlatformMultiplier = 0.5f;
 #endif
-	const float cloudsSize = std::min(App::GetMainWindow()->GetRenderArea().x * cloudsResolutionFactor, App::GetMainWindow()->GetRenderArea().y * cloudsResolutionFactor);
-	const glm::ivec2 desiredCloudsExtent(std::max(1.0f, cloudsSize), std::max(1.0f, cloudsSize));
+	const glm::ivec2 viewportExtent = App::GetMainWindow()->GetRenderArea();
+	const Settings::GraphicsExtent renderExtent =
+		Settings::ResolveRenderDimensions(
+			static_cast<uint32_t>((std::max)(viewportExtent.x, 1)),
+			static_cast<uint32_t>((std::max)(viewportExtent.y, 1)),
+			graphicsProfile.m_resolutionFactor);
+	const Settings::GraphicsExtent cloudsExtent =
+		Settings::ResolveCloudsExtent(
+			renderExtent.m_width,
+			renderExtent.m_height,
+			graphicsProfile,
+			cloudsPlatformMultiplier);
+	const glm::ivec2 desiredCloudsExtent(
+		static_cast<int32_t>(cloudsExtent.m_width),
+		static_cast<int32_t>(cloudsExtent.m_height));
 
 	if (m_pCloudsTexture && m_pCloudsTexture->GetExtent() != desiredCloudsExtent)
 	{
@@ -802,7 +834,12 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 		commands->BindShaderBindings(commandList, m_pStarsMaterial, { sceneView.m_frameBindings, m_pShaderBindings });
 		commands->PushConstants(commandList, m_pStarsMaterial, sizeof(PushConstants), &pushConstants);
 
-		commands->SetDefaultViewport(commandList);
+		commands->SetViewport(commandList,
+			0, (float)target->GetExtent().y,
+			(float)target->GetExtent().x, -(float)target->GetExtent().y,
+			glm::vec2(0, 0),
+			glm::vec2(target->GetExtent().x, target->GetExtent().y),
+			0, 1.0f);
 
 		commands->DrawIndexed(commandList, (uint32_t)m_starsMesh->m_indexBuffer->GetSize() / sizeof(uint32_t), 1u, 0u, 0u, 0u);
 		RecordDrawCallStats(1);

--- a/Runtime/FrameGraph/SkyNode.h
+++ b/Runtime/FrameGraph/SkyNode.h
@@ -13,9 +13,7 @@ namespace Sailor::Framegraph
 	class SkyNode : public TFrameGraphNode<SkyNode>
 	{
 		const uint32_t EnvCubemapSize = 256u;
-		const uint32_t SkyResolution = 256u;
 		const uint32_t SunResolution = 32u;
-		const float CloudsResolutionFactor = 0.5f;
 		const uint32_t CloudsNoiseHighResolution = 32u;
 		const uint32_t CloudsNoiseLowResolution = 128u;
 		static constexpr float CloudsVisibilityEpsilon = 0.0001f;

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
@@ -733,6 +733,7 @@ void VulkanDevice::CreateLogicalDevice(VkPhysicalDevice physicalDevice)
 		supportedCore12.descriptorBindingStorageBufferUpdateAfterBind &&
 		supportedCore12.descriptorBindingUniformBufferUpdateAfterBind &&
 		supportedCore12.descriptorBindingStorageImageUpdateAfterBind;
+	m_bSupportsHostQueryReset = supportedCore12.hostQueryReset == VK_TRUE;
 
 
 	AddFeature<VkPhysicalDeviceVulkan12Features>(features, [&](auto& core12)
@@ -752,9 +753,11 @@ void VulkanDevice::CreateLogicalDevice(VkPhysicalDevice physicalDevice)
 			core12.descriptorBindingVariableDescriptorCount = supportedCore12.descriptorBindingVariableDescriptorCount;
 			core12.descriptorIndexing = supportedCore12.descriptorIndexing;
 			core12.descriptorBindingUpdateUnusedWhilePending = supportedCore12.descriptorBindingUpdateUnusedWhilePending;
+			core12.hostQueryReset = supportedCore12.hostQueryReset;
 		});
 
 	SAILOR_LOG("m_bSupportsDescriptorUpdateAfterBind = %d", (int32_t)m_bSupportsDescriptorUpdateAfterBind);
+	SAILOR_LOG("m_bSupportsHostQueryReset = %d", (int32_t)m_bSupportsHostQueryReset);
 	SAILOR_LOG("maxDescriptorSetUpdateAfterBindSamplers = %d", (int32_t)supportedCore12Properties.maxDescriptorSetUpdateAfterBindSamplers);
 
 	VkDeviceCreateInfo createInfo{ VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO };

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.cpp
@@ -1036,6 +1036,7 @@ bool VulkanDevice::BeginRenderSubmission(uint32_t& outFlightSlot, bool& outHasSw
 
 bool VulkanDevice::PresentFrame(const FrameState& state, const TVector<VulkanCommandBufferPtr>& primaryCommandBuffers, const TVector<VulkanSemaphorePtr>& semaphoresToWait)
 {
+	m_bLastFrameSubmitSuccessful = false;
 	//////////////////////////////////////////////////
 	if (!m_pCurrentFrameViewport ||
 		(m_pCurrentFrameViewport->GetViewport().width != m_swapchain->GetExtent().width ||
@@ -1124,6 +1125,7 @@ bool VulkanDevice::PresentFrame(const FrameState& state, const TVector<VulkanCom
 
 	//TODO: Transfer queue for transfer family command lists
 	const VkResult submitResult = m_graphicsQueue->Submit(submitInfo, m_syncFences[m_currentFrame]);
+	m_bLastFrameSubmitSuccessful = submitResult == VK_SUCCESS;
 
 	m_numSubmittedCommandBuffersAcc += (uint32_t)commandBuffers.Num();
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
@@ -67,6 +67,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API VulkanImageViewPtr GetDepthBuffer() const;
 
 		SAILOR_API bool PresentFrame(const FrameState& state, const TVector<VulkanCommandBufferPtr>& primaryCommandBuffers, const TVector<VulkanSemaphorePtr>& waitSemaphores);
+		SAILOR_API bool WasLastFrameSubmitSuccessful() const { return m_bLastFrameSubmitSuccessful; }
 		SAILOR_API bool SubmitFrameWithoutPresent(const TVector<VulkanCommandBufferPtr>& primaryCommandBuffers, const TVector<VulkanSemaphorePtr>& waitSemaphores);
 
 		SAILOR_API bool IsSwapChainOutdated() const { return m_bIsSwapChainOutdated; }
@@ -240,5 +241,6 @@ namespace Sailor::GraphicsDriver::Vulkan
 		uint32_t m_numSubmittedCommandBuffers = 0;
 
 		bool m_bIsDeviceLost = false;
+		bool m_bLastFrameSubmitSuccessful = false;
 	};
 }

--- a/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanDevice.h
@@ -84,6 +84,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 		SAILOR_API bool IsMultiDrawIndirectSupported() const { return m_bSupportsMultiDrawIndirect; };
 		SAILOR_API bool IsDescriptorUpdateAfterBindSupported() const { return m_bSupportsDescriptorUpdateAfterBind; }
+		SAILOR_API bool IsHostQueryResetSupported() const { return m_bSupportsHostQueryReset; }
 		SAILOR_API float GetMaxAllowedAnisotropy() const { return m_physicalDeviceProperties.limits.maxSamplerAnisotropy; };
 		SAILOR_API VkSampleCountFlagBits GetMaxAllowedMsaaSamples() const { return m_maxAllowedMsaaSamples; };
 		SAILOR_API VkSampleCountFlagBits GetCurrentMsaaSamples() const { return m_currentMsaaSamples; };
@@ -170,6 +171,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		VkSampleCountFlagBits m_currentMsaaSamples = VK_SAMPLE_COUNT_1_BIT;
 		bool m_bSupportsMultiDrawIndirect = false;
 		bool m_bSupportsDescriptorUpdateAfterBind = false;
+		bool m_bSupportsHostQueryReset = false;
 
 		VkMemoryRequirements m_memoryRequirements_StagingBuffer;
 

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -32,6 +32,8 @@
 #include "RHI/Renderer.h"
 #include "Sailor.h"
 
+#include <limits>
+
 using namespace Sailor;
 using namespace Sailor::GraphicsDriver::Vulkan;
 
@@ -44,6 +46,44 @@ void VulkanGraphicsDriver::Initialize(Win32::Window* pViewport, RHI::EMsaaSample
 	{
 		SAILOR_LOG_ERROR("VulkanGraphicsDriver initialization failed: Vulkan instance/device is unavailable.");
 		return;
+	}
+
+	const auto device = m_vkInstance->GetMainDevice();
+	VkPhysicalDeviceProperties physicalDeviceProperties{};
+	vkGetPhysicalDeviceProperties(device->GetPhysicalDevice(), &physicalDeviceProperties);
+	uint32_t queueFamilyCount = 0u;
+	vkGetPhysicalDeviceQueueFamilyProperties(
+		device->GetPhysicalDevice(),
+		&queueFamilyCount,
+		nullptr);
+	TVector<VkQueueFamilyProperties> queueFamilyProperties(queueFamilyCount);
+	if (queueFamilyCount > 0u)
+	{
+		vkGetPhysicalDeviceQueueFamilyProperties(
+			device->GetPhysicalDevice(),
+			&queueFamilyCount,
+			queueFamilyProperties.GetData());
+	}
+	const uint32_t graphicsQueueFamily =
+		device->GetQueueFamilies().m_graphicsFamily.value_or(queueFamilyCount);
+	if (graphicsQueueFamily < queueFamilyCount &&
+		queueFamilyProperties[graphicsQueueFamily].timestampValidBits > 0u &&
+		physicalDeviceProperties.limits.timestampPeriod > 0.0f)
+	{
+		VkQueryPoolCreateInfo queryPoolInfo{};
+		queryPoolInfo.sType = VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO;
+		queryPoolInfo.queryType = VK_QUERY_TYPE_TIMESTAMP;
+		queryPoolInfo.queryCount = NumGpuFrameTimeQuerySlots * 2u;
+		if (vkCreateQueryPool(
+			*device,
+			&queryPoolInfo,
+			nullptr,
+			&m_gpuFrameTimeQueryPool) == VK_SUCCESS)
+		{
+			m_gpuTimestampValidBits =
+				queueFamilyProperties[graphicsQueueFamily].timestampValidBits;
+			m_gpuTimestampPeriodNs = physicalDeviceProperties.limits.timestampPeriod;
+		}
 	}
 
 	m_backBuffer = RHI::RHIRenderTargetPtr::Make(RHI::ETextureFiltration::Linear, RHI::ETextureClamping::Repeat, false, RHI::EImageLayout::PresentSrc);
@@ -100,6 +140,16 @@ VulkanGraphicsDriver::~VulkanGraphicsDriver()
 		return;
 	}
 
+	if (m_gpuFrameTimeQueryPool != VK_NULL_HANDLE)
+	{
+		m_vkInstance->WaitIdle();
+		vkDestroyQueryPool(
+			*m_vkInstance->GetMainDevice(),
+			m_gpuFrameTimeQueryPool,
+			nullptr);
+		m_gpuFrameTimeQueryPool = VK_NULL_HANDLE;
+	}
+
 	m_vkInstance->GetMainDevice()->Shutdown();
 
 	// Waiting finishing releasing of rendering resources
@@ -140,8 +190,191 @@ void VulkanGraphicsDriver::BeginConditionalDestroy()
 
 	m_trackedFences.Clear();
 	m_uniformBuffers.Clear();
+	if (m_gpuFrameTimeQueryPool != VK_NULL_HANDLE)
+	{
+		vkDestroyQueryPool(
+			*m_vkInstance->GetMainDevice(),
+			m_gpuFrameTimeQueryPool,
+			nullptr);
+		m_gpuFrameTimeQueryPool = VK_NULL_HANDLE;
+		m_bHasGpuFrameTime.store(false, std::memory_order_release);
+		m_gpuFrameTimeQuerySlots = {};
+		m_activeGpuFrameTimeQuerySlot =
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot;
+		m_pendingGpuFrameTimeQuerySlot =
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot;
+	}
 
 	m_vkInstance->GetMainDevice()->BeginConditionalDestroy();
+}
+
+bool VulkanGraphicsDriver::SupportsGpuFrameTimeQueries() const
+{
+	return m_gpuFrameTimeQueryPool != VK_NULL_HANDLE &&
+		m_gpuTimestampValidBits > 0u &&
+		m_gpuTimestampPeriodNs > 0.0f;
+}
+
+void VulkanGraphicsDriver::PollGpuFrameTimeQueries()
+{
+	for (uint32_t slot = 0u; slot < NumGpuFrameTimeQuerySlots; ++slot)
+	{
+		if (m_gpuFrameTimeQuerySlots.GetState(slot) !=
+			RHI::EGpuFrameTimeQuerySlotState::Issued)
+		{
+			continue;
+		}
+
+		const uint32_t firstQuery = slot * 2u;
+		uint64_t timestamps[2]{};
+		const VkResult result = vkGetQueryPoolResults(
+			*m_vkInstance->GetMainDevice(),
+			m_gpuFrameTimeQueryPool,
+			firstQuery,
+			2u,
+			sizeof(timestamps),
+			timestamps,
+			sizeof(uint64_t),
+			VK_QUERY_RESULT_64_BIT);
+		if (result == VK_SUCCESS)
+		{
+			const uint64_t timestampMask = m_gpuTimestampValidBits >= 64u ?
+				(std::numeric_limits<uint64_t>::max)() :
+				(1ull << m_gpuTimestampValidBits) - 1ull;
+			const uint64_t elapsedTicks =
+				(timestamps[1] - timestamps[0]) & timestampMask;
+			const float milliseconds = static_cast<float>(
+				static_cast<double>(elapsedTicks) *
+				static_cast<double>(m_gpuTimestampPeriodNs) /
+				1000000.0);
+			m_gpuFrameTimeMs.store(milliseconds, std::memory_order_relaxed);
+			m_bHasGpuFrameTime.store(true, std::memory_order_release);
+			m_gpuFrameTimeQuerySlots.MarkCompleted(slot);
+		}
+		else if (result != VK_NOT_READY)
+		{
+			m_bHasGpuFrameTime.store(false, std::memory_order_release);
+			m_gpuFrameTimeQuerySlots.MarkCompleted(slot);
+		}
+	}
+}
+
+bool VulkanGraphicsDriver::BeginGpuFrameTimeQuery(
+	RHI::RHICommandListPtr commandList)
+{
+	if (!SupportsGpuFrameTimeQueries() ||
+		!commandList ||
+		commandList->GetQueue() != RHI::ECommandListQueue::Graphics ||
+		!commandList->m_vulkan.m_commandBuffer ||
+		m_activeGpuFrameTimeQuerySlot !=
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot ||
+		m_pendingGpuFrameTimeQuerySlot !=
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot)
+	{
+		return false;
+	}
+
+	PollGpuFrameTimeQueries();
+	const uint32_t slot = m_gpuFrameTimeQuerySlots.Acquire();
+	if (slot ==
+		RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot)
+	{
+		return false;
+	}
+
+	const uint32_t firstQuery = slot * 2u;
+	const VkCommandBuffer commandBuffer =
+		*commandList->m_vulkan.m_commandBuffer->GetHandle();
+	vkCmdResetQueryPool(
+		commandBuffer,
+		m_gpuFrameTimeQueryPool,
+		firstQuery,
+		2u);
+	vkCmdWriteTimestamp(
+		commandBuffer,
+		VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
+		m_gpuFrameTimeQueryPool,
+		firstQuery);
+	m_activeGpuFrameTimeQuerySlot = slot;
+	return true;
+}
+
+void VulkanGraphicsDriver::EndGpuFrameTimeQuery(
+	RHI::RHICommandListPtr commandList)
+{
+	if (m_activeGpuFrameTimeQuerySlot ==
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot ||
+		m_pendingGpuFrameTimeQuerySlot !=
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot ||
+		!SupportsGpuFrameTimeQueries() ||
+		!commandList ||
+		commandList->GetQueue() != RHI::ECommandListQueue::Graphics ||
+		!commandList->m_vulkan.m_commandBuffer)
+	{
+		if (m_activeGpuFrameTimeQuerySlot !=
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot)
+		{
+			m_gpuFrameTimeQuerySlots.CancelRecording(
+				m_activeGpuFrameTimeQuerySlot);
+			m_activeGpuFrameTimeQuerySlot =
+				RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot;
+		}
+		return;
+	}
+
+	vkCmdWriteTimestamp(
+		*commandList->m_vulkan.m_commandBuffer->GetHandle(),
+		VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
+		m_gpuFrameTimeQueryPool,
+		m_activeGpuFrameTimeQuerySlot * 2u + 1u);
+	m_pendingGpuFrameTimeQuerySlot = m_activeGpuFrameTimeQuerySlot;
+	m_activeGpuFrameTimeQuerySlot =
+		RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot;
+}
+
+void VulkanGraphicsDriver::CommitGpuFrameTimeQuery()
+{
+	if (m_pendingGpuFrameTimeQuerySlot ==
+		RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot)
+	{
+		return;
+	}
+
+	m_gpuFrameTimeQuerySlots.MarkIssued(m_pendingGpuFrameTimeQuerySlot);
+	m_pendingGpuFrameTimeQuerySlot =
+		RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot;
+}
+
+void VulkanGraphicsDriver::CancelGpuFrameTimeQuery()
+{
+	if (m_activeGpuFrameTimeQuerySlot !=
+		RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot)
+	{
+		m_gpuFrameTimeQuerySlots.CancelRecording(
+			m_activeGpuFrameTimeQuerySlot);
+		m_activeGpuFrameTimeQuerySlot =
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot;
+	}
+
+	if (m_pendingGpuFrameTimeQuerySlot !=
+		RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot)
+	{
+		m_gpuFrameTimeQuerySlots.CancelRecording(
+			m_pendingGpuFrameTimeQuerySlot);
+		m_pendingGpuFrameTimeQuerySlot =
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot;
+	}
+}
+
+bool VulkanGraphicsDriver::TryGetGpuFrameTimeMs(float& outMilliseconds) const
+{
+	if (!m_bHasGpuFrameTime.load(std::memory_order_acquire))
+	{
+		return false;
+	}
+
+	outMilliseconds = m_gpuFrameTimeMs.load(std::memory_order_relaxed);
+	return true;
 }
 
 uint32_t VulkanGraphicsDriver::GetNumSubmittedCommandBuffers() const
@@ -421,18 +654,34 @@ uint32_t VulkanGraphicsDriver::GetMaxFramesInFlight() const
 
 bool VulkanGraphicsDriver::PresentFrame(const class FrameState& state,
 	const TVector<RHI::RHICommandListPtr>& primaryCommandBuffers,
-	const TVector<RHI::RHISemaphorePtr>& waitSemaphores) const
+	const TVector<RHI::RHISemaphorePtr>& waitSemaphores)
 {
 	SAILOR_PROFILE_FUNCTION();
 	if (!m_bIsInitialized || !m_vkInstance || !m_vkInstance->GetMainDevice())
 	{
+		CancelGpuFrameTimeQuery();
 		return false;
 	}
 
 	const TVector<VulkanCommandBufferPtr> primaryBuffers = primaryCommandBuffers.Select<VulkanCommandBufferPtr>([](const auto& lhs) { return lhs->m_vulkan.m_commandBuffer; });
 	const TVector<VulkanSemaphorePtr> vkWaitSemaphores = waitSemaphores.Select<VulkanSemaphorePtr>([](const auto& lhs) { return lhs->m_vulkan.m_semaphore; });
 
-	return m_vkInstance->GetMainDevice()->PresentFrame(state, primaryBuffers, vkWaitSemaphores);
+	const bool bPresented = m_vkInstance->GetMainDevice()->PresentFrame(
+		state,
+		primaryBuffers,
+		vkWaitSemaphores);
+	if (m_gpuFrameTimeQueryPool != VK_NULL_HANDLE)
+	{
+		if (m_vkInstance->GetMainDevice()->WasLastFrameSubmitSuccessful())
+		{
+			CommitGpuFrameTimeQuery();
+		}
+		else
+		{
+			CancelGpuFrameTimeQuery();
+		}
+	}
+	return bPresented;
 }
 
 bool VulkanGraphicsDriver::SubmitFrameWithoutPresent(
@@ -442,13 +691,25 @@ bool VulkanGraphicsDriver::SubmitFrameWithoutPresent(
 	SAILOR_PROFILE_FUNCTION();
 	if (!m_bIsInitialized || !m_vkInstance || !m_vkInstance->GetMainDevice())
 	{
+		CancelGpuFrameTimeQuery();
 		return false;
 	}
 
 	const TVector<VulkanCommandBufferPtr> primaryBuffers = primaryCommandBuffers.Select<VulkanCommandBufferPtr>([](const auto& lhs) { return lhs->m_vulkan.m_commandBuffer; });
 	const TVector<VulkanSemaphorePtr> vkWaitSemaphores = waitSemaphores.Select<VulkanSemaphorePtr>([](const auto& lhs) { return lhs->m_vulkan.m_semaphore; });
 
-	return m_vkInstance->GetMainDevice()->SubmitFrameWithoutPresent(primaryBuffers, vkWaitSemaphores);
+	const bool bSubmitted = m_vkInstance->GetMainDevice()->SubmitFrameWithoutPresent(
+		primaryBuffers,
+		vkWaitSemaphores);
+	if (bSubmitted)
+	{
+		CommitGpuFrameTimeQuery();
+	}
+	else
+	{
+		CancelGpuFrameTimeQuery();
+	}
+	return bSubmitted;
 }
 
 void VulkanGraphicsDriver::WaitIdle()

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp
@@ -32,8 +32,6 @@
 #include "RHI/Renderer.h"
 #include "Sailor.h"
 
-#include <limits>
-
 using namespace Sailor;
 using namespace Sailor::GraphicsDriver::Vulkan;
 
@@ -67,6 +65,7 @@ void VulkanGraphicsDriver::Initialize(Win32::Window* pViewport, RHI::EMsaaSample
 	const uint32_t graphicsQueueFamily =
 		device->GetQueueFamilies().m_graphicsFamily.value_or(queueFamilyCount);
 	if (graphicsQueueFamily < queueFamilyCount &&
+		device->IsHostQueryResetSupported() &&
 		queueFamilyProperties[graphicsQueueFamily].timestampValidBits > 0u &&
 		physicalDeviceProperties.limits.timestampPeriod > 0.0f)
 	{
@@ -211,6 +210,9 @@ void VulkanGraphicsDriver::BeginConditionalDestroy()
 bool VulkanGraphicsDriver::SupportsGpuFrameTimeQueries() const
 {
 	return m_gpuFrameTimeQueryPool != VK_NULL_HANDLE &&
+		m_vkInstance &&
+		m_vkInstance->GetMainDevice() &&
+		m_vkInstance->GetMainDevice()->IsHostQueryResetSupported() &&
 		m_gpuTimestampValidBits > 0u &&
 		m_gpuTimestampPeriodNs > 0.0f;
 }
@@ -226,29 +228,35 @@ void VulkanGraphicsDriver::PollGpuFrameTimeQueries()
 		}
 
 		const uint32_t firstQuery = slot * 2u;
-		uint64_t timestamps[2]{};
+		uint64_t queryResults[4]{};
 		const VkResult result = vkGetQueryPoolResults(
 			*m_vkInstance->GetMainDevice(),
 			m_gpuFrameTimeQueryPool,
 			firstQuery,
 			2u,
-			sizeof(timestamps),
-			timestamps,
-			sizeof(uint64_t),
-			VK_QUERY_RESULT_64_BIT);
+			sizeof(queryResults),
+			queryResults,
+			sizeof(uint64_t) * 2u,
+			VK_QUERY_RESULT_64_BIT |
+				VK_QUERY_RESULT_WITH_AVAILABILITY_BIT);
 		if (result == VK_SUCCESS)
 		{
-			const uint64_t timestampMask = m_gpuTimestampValidBits >= 64u ?
-				(std::numeric_limits<uint64_t>::max)() :
-				(1ull << m_gpuTimestampValidBits) - 1ull;
-			const uint64_t elapsedTicks =
-				(timestamps[1] - timestamps[0]) & timestampMask;
-			const float milliseconds = static_cast<float>(
-				static_cast<double>(elapsedTicks) *
-				static_cast<double>(m_gpuTimestampPeriodNs) /
-				1000000.0);
-			m_gpuFrameTimeMs.store(milliseconds, std::memory_order_relaxed);
-			m_bHasGpuFrameTime.store(true, std::memory_order_release);
+			if (queryResults[1] == 0ull || queryResults[3] == 0ull)
+			{
+				continue;
+			}
+
+			float milliseconds = 0.0f;
+			if (RHI::TryResolveGpuFrameTimeMilliseconds(
+				queryResults[0],
+				queryResults[2],
+				m_gpuTimestampValidBits,
+				m_gpuTimestampPeriodNs,
+				milliseconds))
+			{
+				m_gpuFrameTimeMs.store(milliseconds, std::memory_order_relaxed);
+				m_bHasGpuFrameTime.store(true, std::memory_order_release);
+			}
 			m_gpuFrameTimeQuerySlots.MarkCompleted(slot);
 		}
 		else if (result != VK_NOT_READY)
@@ -285,8 +293,12 @@ bool VulkanGraphicsDriver::BeginGpuFrameTimeQuery(
 	const uint32_t firstQuery = slot * 2u;
 	const VkCommandBuffer commandBuffer =
 		*commandList->m_vulkan.m_commandBuffer->GetHandle();
-	vkCmdResetQueryPool(
-		commandBuffer,
+
+	// The slot is acquired only after its prior results have completed. Reset it
+	// synchronously on the host so stale availability from that prior generation
+	// cannot be observed before the queued reset command executes.
+	vkResetQueryPool(
+		*m_vkInstance->GetMainDevice(),
 		m_gpuFrameTimeQueryPool,
 		firstQuery,
 		2u);

--- a/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.h
@@ -4,6 +4,7 @@
 #include "Memory/MemoryPoolAllocator.hpp"
 #include "RHI/Types.h"
 #include "RHI/GraphicsDriver.h"
+#include "RHI/GpuFrameTimeQueryRing.h"
 #include "RHI/Texture.h"
 #include "RHI/Fence.h"
 #include "RHI/Mesh.h"
@@ -14,6 +15,8 @@
 #include "GraphicsDriver/Vulkan/VulkanDevice.h"
 #include "Platform/Win32/Window.h"
 #include "Containers/ConcurrentMap.h"
+#include <array>
+#include <atomic>
 #include <mutex>
 
 #ifdef SAILOR_BUILD_WITH_VULKAN
@@ -44,6 +47,12 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 		SAILOR_API virtual void StartGpuTracking() override;
 		SAILOR_API virtual RHI::GpuStats FinishGpuTracking() override;
+		SAILOR_API virtual bool SupportsGpuFrameTimeQueries() const override;
+		SAILOR_API virtual bool BeginGpuFrameTimeQuery(RHI::RHICommandListPtr commandList) override;
+		SAILOR_API virtual void EndGpuFrameTimeQuery(RHI::RHICommandListPtr commandList) override;
+		SAILOR_API virtual void CommitGpuFrameTimeQuery() override;
+		SAILOR_API virtual void CancelGpuFrameTimeQuery() override;
+		SAILOR_API virtual bool TryGetGpuFrameTimeMs(float& outMilliseconds) const override;
 
 		SAILOR_API virtual uint32_t GetNumSubmittedCommandBuffers() const override;
 
@@ -53,7 +62,7 @@ namespace Sailor::GraphicsDriver::Vulkan
 		SAILOR_API virtual bool BeginRenderSubmission(uint32_t& outFlightSlot, bool& outHasSwapchainImage) override;
 		SAILOR_API virtual uint32_t GetMaxFramesInFlight() const override;
 		SAILOR_API virtual bool AcquireNextImage() override;
-		SAILOR_API virtual bool PresentFrame(const class FrameState& state, const TVector<RHI::RHICommandListPtr>& primaryCommandBuffers, const TVector<RHI::RHISemaphorePtr>& waitSemaphores) const override;
+		SAILOR_API virtual bool PresentFrame(const class FrameState& state, const TVector<RHI::RHICommandListPtr>& primaryCommandBuffers, const TVector<RHI::RHISemaphorePtr>& waitSemaphores) override;
 		SAILOR_API virtual bool SubmitFrameWithoutPresent(const TVector<RHI::RHICommandListPtr>& primaryCommandBuffers, const TVector<RHI::RHISemaphorePtr>& waitSemaphores) override;
 
 		SAILOR_API virtual void SetDebugName(RHI::RHIResourcePtr resource, const std::string& name) override;
@@ -389,6 +398,20 @@ namespace Sailor::GraphicsDriver::Vulkan
 
 		bool m_bIsTrackingGpu = false;
 		RHI::GpuStats m_lastFrameGpuStats{};
+		void PollGpuFrameTimeQueries();
+
+		static constexpr uint32_t NumGpuFrameTimeQuerySlots = 8u;
+		VkQueryPool m_gpuFrameTimeQueryPool = VK_NULL_HANDLE;
+		RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>
+			m_gpuFrameTimeQuerySlots;
+		uint32_t m_activeGpuFrameTimeQuerySlot =
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot;
+		uint32_t m_pendingGpuFrameTimeQuerySlot =
+			RHI::TGpuFrameTimeQueryRing<NumGpuFrameTimeQuerySlots>::InvalidSlot;
+		uint32_t m_gpuTimestampValidBits = 0u;
+		float m_gpuTimestampPeriodNs = 0.0f;
+		std::atomic<float> m_gpuFrameTimeMs{ 0.0f };
+		std::atomic<bool> m_bHasGpuFrameTime{ false };
 	};
 };
 

--- a/Runtime/Protocol/Generated/editor_engine.pb.cc
+++ b/Runtime/Protocol/Generated/editor_engine.pb.cc
@@ -934,6 +934,31 @@ struct EmptyDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 EmptyDefaultTypeInternal _Empty_default_instance_;
 
+inline constexpr EditorStatsModeRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : mode_{static_cast< ::sailor::editor::v1::EditorStatsMode >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR EditorStatsModeRequest::EditorStatsModeRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct EditorStatsModeRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR EditorStatsModeRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~EditorStatsModeRequestDefaultTypeInternal() {}
+  union {
+    EditorStatsModeRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 EditorStatsModeRequestDefaultTypeInternal _EditorStatsModeRequest_default_instance_;
+
 inline constexpr EditorSimulationRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : enabled_{false},
@@ -1417,7 +1442,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
 }  // namespace v1
 }  // namespace editor
 }  // namespace sailor
-static const ::_pb::EnumDescriptor* file_level_enum_descriptors_editor_5fengine_2eproto[2];
+static const ::_pb::EnumDescriptor* file_level_enum_descriptors_editor_5fengine_2eproto[3];
 static constexpr const ::_pb::ServiceDescriptor**
     file_level_service_descriptors_editor_5fengine_2eproto = nullptr;
 const ::uint32_t
@@ -1441,6 +1466,7 @@ const ::uint32_t
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolRequest, _impl_.protocol_version_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolRequest, _impl_.request_id_),
+        ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
@@ -1620,6 +1646,15 @@ const ::uint32_t
         ~0u,  // no _split_
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::EditorSimulationRequest, _impl_.enabled_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::EditorStatsModeRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::EditorStatsModeRequest, _impl_.mode_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::RemoteViewportRequest, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -2056,53 +2091,54 @@ static const ::_pbi::MigrationSchema
     schemas[] ABSL_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
         {0, -1, -1, sizeof(::sailor::editor::v1::Empty)},
         {8, -1, -1, sizeof(::sailor::editor::v1::ProtocolRequest)},
-        {72, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
-        {99, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
-        {108, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
-        {117, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
-        {126, 141, -1, sizeof(::sailor::editor::v1::CreateModelInstanceRequest)},
-        {148, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
-        {157, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
-        {166, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
-        {178, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
-        {188, -1, -1, sizeof(::sailor::editor::v1::EditorSimulationRequest)},
-        {197, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
-        {212, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
-        {223, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
-        {243, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
-        {253, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
-        {263, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
-        {274, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
-        {284, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
-        {295, -1, -1, sizeof(::sailor::editor::v1::AnimatorParameterRequest)},
-        {311, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
-        {321, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
-        {332, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
-        {343, 355, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
-        {359, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
-        {369, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
-        {379, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
-        {390, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
-        {399, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
-        {408, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
-        {421, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
-        {430, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
-        {439, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
-        {448, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
-        {457, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
-        {467, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
-        {476, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
-        {488, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
-        {498, 507, -1, sizeof(::sailor::editor::v1::Vector4Result)},
-        {508, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
-        {518, -1, -1, sizeof(::sailor::editor::v1::AnimatorStateResult)},
-        {536, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
-        {548, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
-        {557, 574, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
-        {583, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
-        {594, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
-        {603, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
-        {618, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
+        {73, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
+        {100, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
+        {109, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
+        {118, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
+        {127, 142, -1, sizeof(::sailor::editor::v1::CreateModelInstanceRequest)},
+        {149, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
+        {158, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
+        {167, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
+        {179, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
+        {189, -1, -1, sizeof(::sailor::editor::v1::EditorSimulationRequest)},
+        {198, -1, -1, sizeof(::sailor::editor::v1::EditorStatsModeRequest)},
+        {207, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
+        {222, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
+        {233, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
+        {253, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
+        {263, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
+        {273, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
+        {284, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
+        {294, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
+        {305, -1, -1, sizeof(::sailor::editor::v1::AnimatorParameterRequest)},
+        {321, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
+        {331, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
+        {342, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
+        {353, 365, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
+        {369, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
+        {379, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
+        {389, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
+        {400, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
+        {409, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
+        {418, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
+        {431, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
+        {440, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
+        {449, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
+        {458, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
+        {467, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
+        {477, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
+        {486, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
+        {498, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
+        {508, 517, -1, sizeof(::sailor::editor::v1::Vector4Result)},
+        {518, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
+        {528, -1, -1, sizeof(::sailor::editor::v1::AnimatorStateResult)},
+        {546, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
+        {558, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
+        {567, 584, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
+        {593, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
+        {604, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
+        {613, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
+        {628, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_Empty_default_instance_._instance,
@@ -2117,6 +2153,7 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_ViewportRectRequest_default_instance_._instance,
     &::sailor::editor::v1::_SizeRequest_default_instance_._instance,
     &::sailor::editor::v1::_EditorSimulationRequest_default_instance_._instance,
+    &::sailor::editor::v1::_EditorStatsModeRequest_default_instance_._instance,
     &::sailor::editor::v1::_RemoteViewportRequest_default_instance_._instance,
     &::sailor::editor::v1::_RemoteViewportHostRequest_default_instance_._instance,
     &::sailor::editor::v1::_RemoteViewportInputRequest_default_instance_._instance,
@@ -2158,7 +2195,7 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
     protodesc_cold) = {
     "\n\023editor_engine.proto\022\020sailor.editor.v1\""
-    "\007\n\005Empty\"\250\035\n\017ProtocolRequest\022\030\n\020protocol"
+    "\007\n\005Empty\"\363\035\n\017ProtocolRequest\022\030\n\020protocol"
     "_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\0229\n\nin"
     "itialize\030\n \001(\0132#.sailor.editor.v1.Initia"
     "lizeRequestH\000\022(\n\005start\030\013 \001(\0132\027.sailor.ed"
@@ -2249,177 +2286,185 @@ const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SE
     "v1.EditorSimulationRequestH\000\022>\n\033get_edit"
     "or_simulation_state\030> \001(\0132\027.sailor.edito"
     "r.v1.EmptyH\000\022>\n\023preview_audio_asset\030\? \001("
-    "\0132\037.sailor.editor.v1.FileIdRequestH\000B\t\n\007"
-    "commandJ\004\010\003\020\nJ\004\0102\0203J\004\010@\020dR\030create_model_"
-    "game_objectR\036resolve_viewport_drop_posit"
-    "ion\"\336\007\n\020ProtocolResponse\022\030\n\020protocol_ver"
-    "sion\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\022\017\n\007succes"
-    "s\030\003 \001(\010\022\r\n\005error\030\004 \001(\t\022$\n\034supports_stric"
-    "t_instance_ids\030\005 \001(\010\022/\n\014empty_result\030\n \001"
-    "(\0132\027.sailor.editor.v1.EmptyH\000\0223\n\013bool_re"
-    "sult\030\013 \001(\0132\034.sailor.editor.v1.BoolResult"
-    "H\000\0225\n\014int32_result\030\014 \001(\0132\035.sailor.editor"
-    ".v1.Int32ResultH\000\0227\n\ruint32_result\030\r \001(\013"
-    "2\036.sailor.editor.v1.UInt32ResultH\000\0227\n\rui"
-    "nt64_result\030\016 \001(\0132\036.sailor.editor.v1.UIn"
-    "t64ResultH\000\0227\n\rstring_result\030\017 \001(\0132\036.sai"
-    "lor.editor.v1.StringResultH\000\022@\n\022string_l"
-    "ist_result\030\020 \001(\0132\".sailor.editor.v1.Stri"
-    "ngListResultH\000\022M\n\031asset_reload_state_res"
-    "ult\030\021 \001(\0132(.sailor.editor.v1.AssetReload"
-    "StateResultH\000\022@\n\022instance_id_result\030\022 \001("
-    "\0132\".sailor.editor.v1.InstanceIdResultH\000\022"
-    "Q\n\033viewport_event_batch_result\030\023 \001(\0132*.s"
-    "ailor.editor.v1.ViewportEventBatchResult"
-    "H\000\0229\n\016vector4_result\030\024 \001(\0132\037.sailor.edit"
-    "or.v1.Vector4ResultH\000\022O\n\032viewport_tool_s"
-    "tate_result\030\025 \001(\0132).sailor.editor.v1.Vie"
-    "wportToolStateResultH\000\022F\n\025animator_state"
-    "_result\030\026 \001(\0132%.sailor.editor.v1.Animato"
-    "rStateResultH\000B\010\n\006resultJ\004\010\006\020\nJ\004\010\027\020d\"&\n\021"
-    "InitializeRequest\022\021\n\targuments\030\001 \003(\t\"!\n\014"
-    "CountRequest\022\021\n\tmax_count\030\001 \001(\r\" \n\rFileI"
-    "dRequest\022\017\n\007file_id\030\001 \001(\t\"\347\001\n\032CreateMode"
-    "lInstanceRequest\022\025\n\rmodel_file_id\030\001 \001(\t\022"
-    "\014\n\004name\030\002 \001(\t\022\032\n\022parent_instance_id\030\003 \001("
-    "\t\022\030\n\020create_hierarchy\030\004 \001(\010\022\034\n\024apply_wor"
-    "ld_position\030\005 \001(\010\0221\n\016world_position\030\006 \001("
-    "\0132\031.sailor.editor.v1.Vector4\022\035\n\025preferre"
-    "d_instance_id\030\007 \001(\t\"(\n\021InstanceIdRequest"
-    "\022\023\n\013instance_id\030\001 \001(\t\"(\n\021ViewportIdReque"
-    "st\022\023\n\013viewport_id\030\001 \001(\004\"`\n\023ViewportRectR"
-    "equest\022\024\n\014window_pos_x\030\001 \001(\r\022\024\n\014window_p"
-    "os_y\030\002 \001(\r\022\r\n\005width\030\003 \001(\r\022\016\n\006height\030\004 \001("
-    "\r\",\n\013SizeRequest\022\r\n\005width\030\001 \001(\r\022\016\n\006heigh"
-    "t\030\002 \001(\r\"*\n\027EditorSimulationRequest\022\017\n\007en"
-    "abled\030\001 \001(\010\"\231\001\n\025RemoteViewportRequest\022\023\n"
-    "\013viewport_id\030\001 \001(\004\022\024\n\014window_pos_x\030\002 \001(\r"
-    "\022\024\n\014window_pos_y\030\003 \001(\r\022\r\n\005width\030\004 \001(\r\022\016\n"
-    "\006height\030\005 \001(\r\022\017\n\007visible\030\006 \001(\010\022\017\n\007focuse"
-    "d\030\007 \001(\010\"e\n\031RemoteViewportHostRequest\022\023\n\013"
-    "viewport_id\030\001 \001(\004\022\030\n\020host_handle_kind\030\002 "
-    "\001(\r\022\031\n\021host_handle_value\030\003 \001(\004\"\374\001\n\032Remot"
-    "eViewportInputRequest\022\023\n\013viewport_id\030\001 \001"
-    "(\004\022\014\n\004kind\030\002 \001(\r\022\021\n\tpointer_x\030\003 \001(\002\022\021\n\tp"
-    "ointer_y\030\004 \001(\002\022\025\n\rwheel_delta_x\030\005 \001(\002\022\025\n"
-    "\rwheel_delta_y\030\006 \001(\002\022\020\n\010key_code\030\007 \001(\r\022\016"
-    "\n\006button\030\010 \001(\r\022\021\n\tmodifiers\030\t \001(\r\022\017\n\007pre"
-    "ssed\030\n \001(\010\022\017\n\007focused\030\013 \001(\010\022\020\n\010captured\030"
-    "\014 \001(\010\"C\n\036ManagedMutationRevisionRequest\022"
-    "\014\n\004kind\030\001 \001(\r\022\023\n\013instance_id\030\002 \001(\t\"@\n\023Up"
-    "dateObjectRequest\022\023\n\013instance_id\030\001 \001(\t\022\024"
-    "\n\014yaml_changes\030\002 \001(\t\"f\n\025ReparentObjectRe"
-    "quest\022\023\n\013instance_id\030\001 \001(\t\022\032\n\022parent_ins"
-    "tance_id\030\002 \001(\t\022\034\n\024keep_world_transform\030\003"
-    " \001(\010\"T\n\027CreateGameObjectRequest\022\032\n\022paren"
-    "t_instance_id\030\001 \001(\t\022\035\n\025preferred_instanc"
-    "e_id\030\002 \001(\t\"f\n\023AddComponentRequest\022\023\n\013ins"
-    "tance_id\030\001 \001(\t\022\033\n\023component_type_name\030\002 "
-    "\001(\t\022\035\n\025preferred_instance_id\030\003 \001(\t\"\346\001\n\030A"
-    "nimatorParameterRequest\022\023\n\013instance_id\030\001"
-    " \001(\t\022\014\n\004name\030\002 \001(\t\022\025\n\013float_value\030\003 \001(\002H"
-    "\000\022\023\n\tint_value\030\004 \001(\021H\000\022\024\n\nbool_value\030\005 \001"
-    "(\010H\000\022*\n\007trigger\030\006 \001(\0132\027.sailor.editor.v1"
-    ".EmptyH\000\0220\n\rreset_trigger\030\007 \001(\0132\027.sailor"
-    ".editor.v1.EmptyH\000B\007\n\005value\"G\n\030Instantia"
-    "tePrefabRequest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022pare"
-    "nt_instance_id\030\002 \001(\t\"p\n InstantiatePrefa"
-    "bFromYamlRequest\022\023\n\013prefab_yaml\030\001 \001(\t\022\032\n"
-    "\022parent_instance_id\030\002 \001(\t\022\033\n\023strict_inst"
-    "ance_ids\030\003 \001(\010\"U\n\022ViewportRayRequest\022\023\n\013"
-    "viewport_id\030\001 \001(\004\022\024\n\014normalized_x\030\002 \001(\002\022"
-    "\024\n\014normalized_y\030\003 \001(\002\"\240\001\n InstantiatePre"
-    "fabInstanceRequest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022p"
-    "arent_instance_id\030\002 \001(\t\022\034\n\024apply_world_p"
-    "osition\030\003 \001(\010\0221\n\016world_position\030\004 \001(\0132\031."
-    "sailor.editor.v1.Vector4\"A\n\025ViewportObje"
-    "ctRequest\022\023\n\013viewport_id\030\001 \001(\004\022\023\n\013instan"
-    "ce_id\030\002 \001(\t\"9\n\021PrefabLinkRequest\022\023\n\013inst"
-    "ance_id\030\001 \001(\t\022\017\n\007file_id\030\002 \001(\t\"\251\001\n\030Viewp"
-    "ortToolStateRequest\022\023\n\013viewport_id\030\001 \001(\004"
-    "\022\?\n\toperation\030\002 \001(\0162,.sailor.editor.v1.V"
-    "iewportTransformOperation\0227\n\005space\030\003 \001(\016"
-    "2(.sailor.editor.v1.ViewportTransformSpa"
-    "ce\"(\n\020SelectionRequest\022\024\n\014instance_ids\030\001"
-    " \003(\t\"%\n\025ShowMainWindowRequest\022\014\n\004show\030\001 "
-    "\001(\010\"\210\001\n\034RenderPathTracedImageRequest\022\023\n\013"
-    "output_path\030\001 \001(\t\022\023\n\013instance_id\030\002 \001(\t\022\016"
-    "\n\006height\030\003 \001(\r\022\031\n\021samples_per_pixel\030\004 \001("
-    "\r\022\023\n\013max_bounces\030\005 \001(\r\"\033\n\nBoolResult\022\r\n\005"
-    "value\030\001 \001(\010\"\034\n\013Int32Result\022\r\n\005value\030\001 \001("
-    "\005\"\035\n\014UInt32Result\022\r\n\005value\030\001 \001(\r\"\035\n\014UInt"
-    "64Result\022\r\n\005value\030\001 \001(\004\"0\n\014StringResult\022"
-    "\021\n\thas_value\030\001 \001(\010\022\r\n\005value\030\002 \001(\t\"\"\n\020Str"
-    "ingListResult\022\016\n\006values\030\001 \003(\t\"\204\001\n\026AssetR"
-    "eloadStateResult\022\021\n\tavailable\030\001 \001(\010\022\032\n\022r"
-    "equest_generation\030\002 \001(\004\022\034\n\024completed_gen"
-    "eration\030\003 \001(\004\022\035\n\025successful_generation\030\004"
-    " \001(\004\":\n\020InstanceIdResult\022\021\n\tsucceeded\030\001 "
-    "\001(\010\022\023\n\013instance_id\030\002 \001(\t\"9\n\rVector4Resul"
-    "t\022(\n\005value\030\001 \001(\0132\031.sailor.editor.v1.Vect"
-    "or4\"\223\001\n\027ViewportToolStateResult\022\?\n\topera"
-    "tion\030\001 \001(\0162,.sailor.editor.v1.ViewportTr"
-    "ansformOperation\0227\n\005space\030\002 \001(\0162(.sailor"
-    ".editor.v1.ViewportTransformSpace\"\250\002\n\023An"
-    "imatorStateResult\022\026\n\016has_controller\030\001 \001("
-    "\010\022\033\n\023controller_revision\030\002 \001(\004\022\027\n\017active"
-    "_state_id\030\003 \001(\004\022\031\n\021active_state_name\030\004 \001"
-    "(\t\022\031\n\021active_state_time\030\005 \001(\002\022\025\n\rtransit"
-    "ioning\030\006 \001(\010\022\034\n\024destination_state_id\030\007 \001"
-    "(\004\022\036\n\026destination_state_name\030\010 \001(\t\022\036\n\026de"
-    "stination_state_time\030\t \001(\002\022\030\n\020transition"
-    "_alpha\030\n \001(\002\"5\n\007Vector4\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030"
-    "\002 \001(\002\022\t\n\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n\026ViewportS"
-    "electionEvent\022\034\n\024selected_instance_id\030\001 "
-    "\001(\t\"\326\003\n\026ViewportTransformEvent\022\023\n\013instan"
-    "ce_id\030\001 \001(\t\022\?\n\toperation\030\002 \001(\0162,.sailor."
-    "editor.v1.ViewportTransformOperation\0227\n\005"
-    "space\030\003 \001(\0162(.sailor.editor.v1.ViewportT"
-    "ransformSpace\0222\n\017before_position\030\004 \001(\0132\031"
-    ".sailor.editor.v1.Vector4\0222\n\017before_rota"
-    "tion\030\005 \001(\0132\031.sailor.editor.v1.Vector4\022/\n"
-    "\014before_scale\030\006 \001(\0132\031.sailor.editor.v1.V"
-    "ector4\0221\n\016after_position\030\007 \001(\0132\031.sailor."
-    "editor.v1.Vector4\0221\n\016after_rotation\030\010 \001("
-    "\0132\031.sailor.editor.v1.Vector4\022.\n\013after_sc"
-    "ale\030\t \001(\0132\031.sailor.editor.v1.Vector4\"U\n\026"
-    "ViewportAssetDropEvent\022\017\n\007file_id\030\001 \001(\t\022"
-    "\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 "
-    "\001(\002\"-\n\031ViewportToolShortcutEvent\022\020\n\010key_"
-    "code\030\001 \001(\r\"\331\002\n\rViewportEvent\022\020\n\010revision"
-    "\030\001 \001(\004\022!\n\031managed_mutation_revision\030\002 \001("
-    "\004\022=\n\tselection\030\n \001(\0132(.sailor.editor.v1."
-    "ViewportSelectionEventH\000\022=\n\ttransform\030\013 "
-    "\001(\0132(.sailor.editor.v1.ViewportTransform"
-    "EventH\000\022>\n\nasset_drop\030\014 \001(\0132(.sailor.edi"
-    "tor.v1.ViewportAssetDropEventH\000\022D\n\rtool_"
-    "shortcut\030\r \001(\0132+.sailor.editor.v1.Viewpo"
-    "rtToolShortcutEventH\000B\t\n\007payloadJ\004\010\003\020\n\"K"
-    "\n\030ViewportEventBatchResult\022/\n\006events\030\001 \003"
-    "(\0132\037.sailor.editor.v1.ViewportEvent*\360\001\n\032"
-    "ViewportTransformOperation\022,\n(VIEWPORT_T"
-    "RANSFORM_OPERATION_UNSPECIFIED\020\000\022\'\n#VIEW"
-    "PORT_TRANSFORM_OPERATION_SELECT\020\001\022*\n&VIE"
-    "WPORT_TRANSFORM_OPERATION_TRANSLATE\020\002\022\'\n"
-    "#VIEWPORT_TRANSFORM_OPERATION_ROTATE\020\003\022&"
-    "\n\"VIEWPORT_TRANSFORM_OPERATION_SCALE\020\004*\212"
-    "\001\n\026ViewportTransformSpace\022(\n$VIEWPORT_TR"
-    "ANSFORM_SPACE_UNSPECIFIED\020\000\022\"\n\036VIEWPORT_"
-    "TRANSFORM_SPACE_WORLD\020\001\022\"\n\036VIEWPORT_TRAN"
-    "SFORM_SPACE_LOCAL\020\002B\"\252\002\037SailorEditor.Pro"
-    "tocol.Generatedb\006proto3"
+    "\0132\037.sailor.editor.v1.FileIdRequestH\000\022I\n\025"
+    "set_editor_stats_mode\030@ \001(\0132(.sailor.edi"
+    "tor.v1.EditorStatsModeRequestH\000B\t\n\007comma"
+    "ndJ\004\010\003\020\nJ\004\0102\0203J\004\010A\020dR\030create_model_game_"
+    "objectR\036resolve_viewport_drop_position\"\336"
+    "\007\n\020ProtocolResponse\022\030\n\020protocol_version\030"
+    "\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\022\017\n\007success\030\003 \001"
+    "(\010\022\r\n\005error\030\004 \001(\t\022$\n\034supports_strict_ins"
+    "tance_ids\030\005 \001(\010\022/\n\014empty_result\030\n \001(\0132\027."
+    "sailor.editor.v1.EmptyH\000\0223\n\013bool_result\030"
+    "\013 \001(\0132\034.sailor.editor.v1.BoolResultH\000\0225\n"
+    "\014int32_result\030\014 \001(\0132\035.sailor.editor.v1.I"
+    "nt32ResultH\000\0227\n\ruint32_result\030\r \001(\0132\036.sa"
+    "ilor.editor.v1.UInt32ResultH\000\0227\n\ruint64_"
+    "result\030\016 \001(\0132\036.sailor.editor.v1.UInt64Re"
+    "sultH\000\0227\n\rstring_result\030\017 \001(\0132\036.sailor.e"
+    "ditor.v1.StringResultH\000\022@\n\022string_list_r"
+    "esult\030\020 \001(\0132\".sailor.editor.v1.StringLis"
+    "tResultH\000\022M\n\031asset_reload_state_result\030\021"
+    " \001(\0132(.sailor.editor.v1.AssetReloadState"
+    "ResultH\000\022@\n\022instance_id_result\030\022 \001(\0132\".s"
+    "ailor.editor.v1.InstanceIdResultH\000\022Q\n\033vi"
+    "ewport_event_batch_result\030\023 \001(\0132*.sailor"
+    ".editor.v1.ViewportEventBatchResultH\000\0229\n"
+    "\016vector4_result\030\024 \001(\0132\037.sailor.editor.v1"
+    ".Vector4ResultH\000\022O\n\032viewport_tool_state_"
+    "result\030\025 \001(\0132).sailor.editor.v1.Viewport"
+    "ToolStateResultH\000\022F\n\025animator_state_resu"
+    "lt\030\026 \001(\0132%.sailor.editor.v1.AnimatorStat"
+    "eResultH\000B\010\n\006resultJ\004\010\006\020\nJ\004\010\027\020d\"&\n\021Initi"
+    "alizeRequest\022\021\n\targuments\030\001 \003(\t\"!\n\014Count"
+    "Request\022\021\n\tmax_count\030\001 \001(\r\" \n\rFileIdRequ"
+    "est\022\017\n\007file_id\030\001 \001(\t\"\347\001\n\032CreateModelInst"
+    "anceRequest\022\025\n\rmodel_file_id\030\001 \001(\t\022\014\n\004na"
+    "me\030\002 \001(\t\022\032\n\022parent_instance_id\030\003 \001(\t\022\030\n\020"
+    "create_hierarchy\030\004 \001(\010\022\034\n\024apply_world_po"
+    "sition\030\005 \001(\010\0221\n\016world_position\030\006 \001(\0132\031.s"
+    "ailor.editor.v1.Vector4\022\035\n\025preferred_ins"
+    "tance_id\030\007 \001(\t\"(\n\021InstanceIdRequest\022\023\n\013i"
+    "nstance_id\030\001 \001(\t\"(\n\021ViewportIdRequest\022\023\n"
+    "\013viewport_id\030\001 \001(\004\"`\n\023ViewportRectReques"
+    "t\022\024\n\014window_pos_x\030\001 \001(\r\022\024\n\014window_pos_y\030"
+    "\002 \001(\r\022\r\n\005width\030\003 \001(\r\022\016\n\006height\030\004 \001(\r\",\n\013"
+    "SizeRequest\022\r\n\005width\030\001 \001(\r\022\016\n\006height\030\002 \001"
+    "(\r\"*\n\027EditorSimulationRequest\022\017\n\007enabled"
+    "\030\001 \001(\010\"I\n\026EditorStatsModeRequest\022/\n\004mode"
+    "\030\001 \001(\0162!.sailor.editor.v1.EditorStatsMod"
+    "e\"\231\001\n\025RemoteViewportRequest\022\023\n\013viewport_"
+    "id\030\001 \001(\004\022\024\n\014window_pos_x\030\002 \001(\r\022\024\n\014window"
+    "_pos_y\030\003 \001(\r\022\r\n\005width\030\004 \001(\r\022\016\n\006height\030\005 "
+    "\001(\r\022\017\n\007visible\030\006 \001(\010\022\017\n\007focused\030\007 \001(\010\"e\n"
+    "\031RemoteViewportHostRequest\022\023\n\013viewport_i"
+    "d\030\001 \001(\004\022\030\n\020host_handle_kind\030\002 \001(\r\022\031\n\021hos"
+    "t_handle_value\030\003 \001(\004\"\374\001\n\032RemoteViewportI"
+    "nputRequest\022\023\n\013viewport_id\030\001 \001(\004\022\014\n\004kind"
+    "\030\002 \001(\r\022\021\n\tpointer_x\030\003 \001(\002\022\021\n\tpointer_y\030\004"
+    " \001(\002\022\025\n\rwheel_delta_x\030\005 \001(\002\022\025\n\rwheel_del"
+    "ta_y\030\006 \001(\002\022\020\n\010key_code\030\007 \001(\r\022\016\n\006button\030\010"
+    " \001(\r\022\021\n\tmodifiers\030\t \001(\r\022\017\n\007pressed\030\n \001(\010"
+    "\022\017\n\007focused\030\013 \001(\010\022\020\n\010captured\030\014 \001(\010\"C\n\036M"
+    "anagedMutationRevisionRequest\022\014\n\004kind\030\001 "
+    "\001(\r\022\023\n\013instance_id\030\002 \001(\t\"@\n\023UpdateObject"
+    "Request\022\023\n\013instance_id\030\001 \001(\t\022\024\n\014yaml_cha"
+    "nges\030\002 \001(\t\"f\n\025ReparentObjectRequest\022\023\n\013i"
+    "nstance_id\030\001 \001(\t\022\032\n\022parent_instance_id\030\002"
+    " \001(\t\022\034\n\024keep_world_transform\030\003 \001(\010\"T\n\027Cr"
+    "eateGameObjectRequest\022\032\n\022parent_instance"
+    "_id\030\001 \001(\t\022\035\n\025preferred_instance_id\030\002 \001(\t"
+    "\"f\n\023AddComponentRequest\022\023\n\013instance_id\030\001"
+    " \001(\t\022\033\n\023component_type_name\030\002 \001(\t\022\035\n\025pre"
+    "ferred_instance_id\030\003 \001(\t\"\346\001\n\030AnimatorPar"
+    "ameterRequest\022\023\n\013instance_id\030\001 \001(\t\022\014\n\004na"
+    "me\030\002 \001(\t\022\025\n\013float_value\030\003 \001(\002H\000\022\023\n\tint_v"
+    "alue\030\004 \001(\021H\000\022\024\n\nbool_value\030\005 \001(\010H\000\022*\n\007tr"
+    "igger\030\006 \001(\0132\027.sailor.editor.v1.EmptyH\000\0220"
+    "\n\rreset_trigger\030\007 \001(\0132\027.sailor.editor.v1"
+    ".EmptyH\000B\007\n\005value\"G\n\030InstantiatePrefabRe"
+    "quest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_instanc"
+    "e_id\030\002 \001(\t\"p\n InstantiatePrefabFromYamlR"
+    "equest\022\023\n\013prefab_yaml\030\001 \001(\t\022\032\n\022parent_in"
+    "stance_id\030\002 \001(\t\022\033\n\023strict_instance_ids\030\003"
+    " \001(\010\"U\n\022ViewportRayRequest\022\023\n\013viewport_i"
+    "d\030\001 \001(\004\022\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normali"
+    "zed_y\030\003 \001(\002\"\240\001\n InstantiatePrefabInstanc"
+    "eRequest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_inst"
+    "ance_id\030\002 \001(\t\022\034\n\024apply_world_position\030\003 "
+    "\001(\010\0221\n\016world_position\030\004 \001(\0132\031.sailor.edi"
+    "tor.v1.Vector4\"A\n\025ViewportObjectRequest\022"
+    "\023\n\013viewport_id\030\001 \001(\004\022\023\n\013instance_id\030\002 \001("
+    "\t\"9\n\021PrefabLinkRequest\022\023\n\013instance_id\030\001 "
+    "\001(\t\022\017\n\007file_id\030\002 \001(\t\"\251\001\n\030ViewportToolSta"
+    "teRequest\022\023\n\013viewport_id\030\001 \001(\004\022\?\n\toperat"
+    "ion\030\002 \001(\0162,.sailor.editor.v1.ViewportTra"
+    "nsformOperation\0227\n\005space\030\003 \001(\0162(.sailor."
+    "editor.v1.ViewportTransformSpace\"(\n\020Sele"
+    "ctionRequest\022\024\n\014instance_ids\030\001 \003(\t\"%\n\025Sh"
+    "owMainWindowRequest\022\014\n\004show\030\001 \001(\010\"\210\001\n\034Re"
+    "nderPathTracedImageRequest\022\023\n\013output_pat"
+    "h\030\001 \001(\t\022\023\n\013instance_id\030\002 \001(\t\022\016\n\006height\030\003"
+    " \001(\r\022\031\n\021samples_per_pixel\030\004 \001(\r\022\023\n\013max_b"
+    "ounces\030\005 \001(\r\"\033\n\nBoolResult\022\r\n\005value\030\001 \001("
+    "\010\"\034\n\013Int32Result\022\r\n\005value\030\001 \001(\005\"\035\n\014UInt3"
+    "2Result\022\r\n\005value\030\001 \001(\r\"\035\n\014UInt64Result\022\r"
+    "\n\005value\030\001 \001(\004\"0\n\014StringResult\022\021\n\thas_val"
+    "ue\030\001 \001(\010\022\r\n\005value\030\002 \001(\t\"\"\n\020StringListRes"
+    "ult\022\016\n\006values\030\001 \003(\t\"\204\001\n\026AssetReloadState"
+    "Result\022\021\n\tavailable\030\001 \001(\010\022\032\n\022request_gen"
+    "eration\030\002 \001(\004\022\034\n\024completed_generation\030\003 "
+    "\001(\004\022\035\n\025successful_generation\030\004 \001(\004\":\n\020In"
+    "stanceIdResult\022\021\n\tsucceeded\030\001 \001(\010\022\023\n\013ins"
+    "tance_id\030\002 \001(\t\"9\n\rVector4Result\022(\n\005value"
+    "\030\001 \001(\0132\031.sailor.editor.v1.Vector4\"\223\001\n\027Vi"
+    "ewportToolStateResult\022\?\n\toperation\030\001 \001(\016"
+    "2,.sailor.editor.v1.ViewportTransformOpe"
+    "ration\0227\n\005space\030\002 \001(\0162(.sailor.editor.v1"
+    ".ViewportTransformSpace\"\250\002\n\023AnimatorStat"
+    "eResult\022\026\n\016has_controller\030\001 \001(\010\022\033\n\023contr"
+    "oller_revision\030\002 \001(\004\022\027\n\017active_state_id\030"
+    "\003 \001(\004\022\031\n\021active_state_name\030\004 \001(\t\022\031\n\021acti"
+    "ve_state_time\030\005 \001(\002\022\025\n\rtransitioning\030\006 \001"
+    "(\010\022\034\n\024destination_state_id\030\007 \001(\004\022\036\n\026dest"
+    "ination_state_name\030\010 \001(\t\022\036\n\026destination_"
+    "state_time\030\t \001(\002\022\030\n\020transition_alpha\030\n \001"
+    "(\002\"5\n\007Vector4\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n\001z"
+    "\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n\026ViewportSelectionEv"
+    "ent\022\034\n\024selected_instance_id\030\001 \001(\t\"\326\003\n\026Vi"
+    "ewportTransformEvent\022\023\n\013instance_id\030\001 \001("
+    "\t\022\?\n\toperation\030\002 \001(\0162,.sailor.editor.v1."
+    "ViewportTransformOperation\0227\n\005space\030\003 \001("
+    "\0162(.sailor.editor.v1.ViewportTransformSp"
+    "ace\0222\n\017before_position\030\004 \001(\0132\031.sailor.ed"
+    "itor.v1.Vector4\0222\n\017before_rotation\030\005 \001(\013"
+    "2\031.sailor.editor.v1.Vector4\022/\n\014before_sc"
+    "ale\030\006 \001(\0132\031.sailor.editor.v1.Vector4\0221\n\016"
+    "after_position\030\007 \001(\0132\031.sailor.editor.v1."
+    "Vector4\0221\n\016after_rotation\030\010 \001(\0132\031.sailor"
+    ".editor.v1.Vector4\022.\n\013after_scale\030\t \001(\0132"
+    "\031.sailor.editor.v1.Vector4\"U\n\026ViewportAs"
+    "setDropEvent\022\017\n\007file_id\030\001 \001(\t\022\024\n\014normali"
+    "zed_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 \001(\002\"-\n\031Vie"
+    "wportToolShortcutEvent\022\020\n\010key_code\030\001 \001(\r"
+    "\"\331\002\n\rViewportEvent\022\020\n\010revision\030\001 \001(\004\022!\n\031"
+    "managed_mutation_revision\030\002 \001(\004\022=\n\tselec"
+    "tion\030\n \001(\0132(.sailor.editor.v1.ViewportSe"
+    "lectionEventH\000\022=\n\ttransform\030\013 \001(\0132(.sail"
+    "or.editor.v1.ViewportTransformEventH\000\022>\n"
+    "\nasset_drop\030\014 \001(\0132(.sailor.editor.v1.Vie"
+    "wportAssetDropEventH\000\022D\n\rtool_shortcut\030\r"
+    " \001(\0132+.sailor.editor.v1.ViewportToolShor"
+    "tcutEventH\000B\t\n\007payloadJ\004\010\003\020\n\"K\n\030Viewport"
+    "EventBatchResult\022/\n\006events\030\001 \003(\0132\037.sailo"
+    "r.editor.v1.ViewportEvent*\360\001\n\032ViewportTr"
+    "ansformOperation\022,\n(VIEWPORT_TRANSFORM_O"
+    "PERATION_UNSPECIFIED\020\000\022\'\n#VIEWPORT_TRANS"
+    "FORM_OPERATION_SELECT\020\001\022*\n&VIEWPORT_TRAN"
+    "SFORM_OPERATION_TRANSLATE\020\002\022\'\n#VIEWPORT_"
+    "TRANSFORM_OPERATION_ROTATE\020\003\022&\n\"VIEWPORT"
+    "_TRANSFORM_OPERATION_SCALE\020\004*\212\001\n\026Viewpor"
+    "tTransformSpace\022(\n$VIEWPORT_TRANSFORM_SP"
+    "ACE_UNSPECIFIED\020\000\022\"\n\036VIEWPORT_TRANSFORM_"
+    "SPACE_WORLD\020\001\022\"\n\036VIEWPORT_TRANSFORM_SPAC"
+    "E_LOCAL\020\002*\244\001\n\017EditorStatsMode\022!\n\035EDITOR_"
+    "STATS_MODE_UNSPECIFIED\020\000\022\032\n\026EDITOR_STATS"
+    "_MODE_NONE\020\001\022\"\n\036EDITOR_STATS_MODE_RENDER"
+    "_STATS\020\002\022.\n*EDITOR_STATS_MODE_RENDER_STA"
+    "TS_AND_QUERIES\020\003B\"\252\002\037SailorEditor.Protoc"
+    "ol.Generatedb\006proto3"
 };
 static ::absl::once_flag descriptor_table_editor_5fengine_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_editor_5fengine_2eproto = {
     false,
     false,
-    10023,
+    10340,
     descriptor_table_protodef_editor_5fengine_2eproto,
     "editor_engine.proto",
     &descriptor_table_editor_5fengine_2eproto_once,
     nullptr,
     0,
-    49,
+    50,
     schemas,
     file_default_instances,
     TableStruct_editor_5fengine_2eproto::offsets,
@@ -2446,6 +2491,15 @@ PROTOBUF_CONSTINIT const uint32_t ViewportTransformSpace_internal_data_[] = {
     196608u, 0u, };
 bool ViewportTransformSpace_IsValid(int value) {
   return 0 <= value && value <= 2;
+}
+const ::google::protobuf::EnumDescriptor* EditorStatsMode_descriptor() {
+  ::google::protobuf::internal::AssignDescriptors(&descriptor_table_editor_5fengine_2eproto);
+  return file_level_enum_descriptors_editor_5fengine_2eproto[2];
+}
+PROTOBUF_CONSTINIT const uint32_t EditorStatsMode_internal_data_[] = {
+    262144u, 0u, };
+bool EditorStatsMode_IsValid(int value) {
+  return 0 <= value && value <= 3;
 }
 // ===================================================================
 
@@ -3247,6 +3301,19 @@ void ProtocolRequest::set_allocated_preview_audio_asset(::sailor::editor::v1::Fi
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.preview_audio_asset)
 }
+void ProtocolRequest::set_allocated_set_editor_stats_mode(::sailor::editor::v1::EditorStatsModeRequest* set_editor_stats_mode) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (set_editor_stats_mode) {
+    ::google::protobuf::Arena* submessage_arena = set_editor_stats_mode->GetArena();
+    if (message_arena != submessage_arena) {
+      set_editor_stats_mode = ::google::protobuf::internal::GetOwnedMessage(message_arena, set_editor_stats_mode, submessage_arena);
+    }
+    set_has_set_editor_stats_mode();
+    _impl_.command_.set_editor_stats_mode_ = set_editor_stats_mode;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.set_editor_stats_mode)
+}
 ProtocolRequest::ProtocolRequest(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
@@ -3444,6 +3511,9 @@ ProtocolRequest::ProtocolRequest(
         break;
       case kPreviewAudioAsset:
         _impl_.command_.preview_audio_asset_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::FileIdRequest>(arena, *from._impl_.command_.preview_audio_asset_);
+        break;
+      case kSetEditorStatsMode:
+        _impl_.command_.set_editor_stats_mode_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::EditorStatsModeRequest>(arena, *from._impl_.command_.set_editor_stats_mode_);
         break;
   }
 
@@ -3907,6 +3977,14 @@ void ProtocolRequest::clear_command() {
       }
       break;
     }
+    case kSetEditorStatsMode: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.set_editor_stats_mode_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_editor_stats_mode_);
+      }
+      break;
+    }
     case COMMAND_NOT_SET: {
       break;
     }
@@ -3951,16 +4029,16 @@ const ::google::protobuf::internal::ClassData* ProtocolRequest::GetClassData() c
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 55, 53, 0, 9> ProtocolRequest::_table_ = {
+const ::_pbi::TcParseTable<1, 56, 54, 0, 9> ProtocolRequest::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    63, 8,  // max_field_number, fast_idx_mask
+    64, 8,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
     508,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    55,  // num_field_entries
-    53,  // num_aux_entries
+    56,  // num_field_entries
+    54,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -3977,7 +4055,7 @@ const ::_pbi::TcParseTable<1, 55, 53, 0, 9> ProtocolRequest::_table_ = {
      {8, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.protocol_version_)}},
   }}, {{
     33, 0, 2,
-    0, 25, 32770, 41,
+    0, 25, 2, 41,
     65535, 65535
   }}, {{
     // uint32 protocol_version = 1;
@@ -4145,6 +4223,9 @@ const ::_pbi::TcParseTable<1, 55, 53, 0, 9> ProtocolRequest::_table_ = {
     // .sailor.editor.v1.FileIdRequest preview_audio_asset = 63;
     {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.preview_audio_asset_), _Internal::kOneofCaseOffset + 0, 52,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.EditorStatsModeRequest set_editor_stats_mode = 64;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_editor_stats_mode_), _Internal::kOneofCaseOffset + 0, 53,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InitializeRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
@@ -4199,6 +4280,7 @@ const ::_pbi::TcParseTable<1, 55, 53, 0, 9> ProtocolRequest::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::EditorSimulationRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::FileIdRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::EditorStatsModeRequest>()},
   }}, {{
   }},
 };
@@ -4565,6 +4647,12 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
                   stream);
               break;
             }
+            case kSetEditorStatsMode: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  64, *this_._impl_.command_.set_editor_stats_mode_, this_._impl_.command_.set_editor_stats_mode_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -4921,6 +5009,12 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
             case kPreviewAudioAsset: {
               total_size += 2 +
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.preview_audio_asset_);
+              break;
+            }
+            // .sailor.editor.v1.EditorStatsModeRequest set_editor_stats_mode = 64;
+            case kSetEditorStatsMode: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.set_editor_stats_mode_);
               break;
             }
             case COMMAND_NOT_SET: {
@@ -5431,6 +5525,15 @@ void ProtocolRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const :
               ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::FileIdRequest>(arena, *from._impl_.command_.preview_audio_asset_);
         } else {
           _this->_impl_.command_.preview_audio_asset_->MergeFrom(from._internal_preview_audio_asset());
+        }
+        break;
+      }
+      case kSetEditorStatsMode: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.set_editor_stats_mode_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::EditorStatsModeRequest>(arena, *from._impl_.command_.set_editor_stats_mode_);
+        } else {
+          _this->_impl_.command_.set_editor_stats_mode_->MergeFrom(from._internal_set_editor_stats_mode());
         }
         break;
       }
@@ -8772,6 +8875,213 @@ void EditorSimulationRequest::InternalSwap(EditorSimulationRequest* PROTOBUF_RES
 }
 
 ::google::protobuf::Metadata EditorSimulationRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class EditorStatsModeRequest::_Internal {
+ public:
+};
+
+EditorStatsModeRequest::EditorStatsModeRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.EditorStatsModeRequest)
+}
+EditorStatsModeRequest::EditorStatsModeRequest(
+    ::google::protobuf::Arena* arena, const EditorStatsModeRequest& from)
+    : EditorStatsModeRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE EditorStatsModeRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void EditorStatsModeRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.mode_ = {};
+}
+EditorStatsModeRequest::~EditorStatsModeRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.EditorStatsModeRequest)
+  SharedDtor(*this);
+}
+inline void EditorStatsModeRequest::SharedDtor(MessageLite& self) {
+  EditorStatsModeRequest& this_ = static_cast<EditorStatsModeRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* EditorStatsModeRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) EditorStatsModeRequest(arena);
+}
+constexpr auto EditorStatsModeRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(EditorStatsModeRequest),
+                                            alignof(EditorStatsModeRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull EditorStatsModeRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_EditorStatsModeRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &EditorStatsModeRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<EditorStatsModeRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &EditorStatsModeRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<EditorStatsModeRequest>(), &EditorStatsModeRequest::ByteSizeLong,
+            &EditorStatsModeRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(EditorStatsModeRequest, _impl_._cached_size_),
+        false,
+    },
+    &EditorStatsModeRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* EditorStatsModeRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> EditorStatsModeRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::EditorStatsModeRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .sailor.editor.v1.EditorStatsMode mode = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(EditorStatsModeRequest, _impl_.mode_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(EditorStatsModeRequest, _impl_.mode_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .sailor.editor.v1.EditorStatsMode mode = 1;
+    {PROTOBUF_FIELD_OFFSET(EditorStatsModeRequest, _impl_.mode_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void EditorStatsModeRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.EditorStatsModeRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.mode_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* EditorStatsModeRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const EditorStatsModeRequest& this_ = static_cast<const EditorStatsModeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* EditorStatsModeRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const EditorStatsModeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.EditorStatsModeRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .sailor.editor.v1.EditorStatsMode mode = 1;
+          if (this_._internal_mode() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_mode(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.EditorStatsModeRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t EditorStatsModeRequest::ByteSizeLong(const MessageLite& base) {
+          const EditorStatsModeRequest& this_ = static_cast<const EditorStatsModeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t EditorStatsModeRequest::ByteSizeLong() const {
+          const EditorStatsModeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.EditorStatsModeRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .sailor.editor.v1.EditorStatsMode mode = 1;
+            if (this_._internal_mode() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_mode());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void EditorStatsModeRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<EditorStatsModeRequest*>(&to_msg);
+  auto& from = static_cast<const EditorStatsModeRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.EditorStatsModeRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_mode() != 0) {
+    _this->_impl_.mode_ = from._impl_.mode_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void EditorStatsModeRequest::CopyFrom(const EditorStatsModeRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.EditorStatsModeRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void EditorStatsModeRequest::InternalSwap(EditorStatsModeRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.mode_, other->_impl_.mode_);
+}
+
+::google::protobuf::Metadata EditorStatsModeRequest::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/Runtime/Protocol/Generated/editor_engine.pb.h
+++ b/Runtime/Protocol/Generated/editor_engine.pb.h
@@ -83,6 +83,9 @@ extern CreateModelInstanceRequestDefaultTypeInternal _CreateModelInstanceRequest
 class EditorSimulationRequest;
 struct EditorSimulationRequestDefaultTypeInternal;
 extern EditorSimulationRequestDefaultTypeInternal _EditorSimulationRequest_default_instance_;
+class EditorStatsModeRequest;
+struct EditorStatsModeRequestDefaultTypeInternal;
+extern EditorStatsModeRequestDefaultTypeInternal _EditorStatsModeRequest_default_instance_;
 class Empty;
 struct EmptyDefaultTypeInternal;
 extern EmptyDefaultTypeInternal _Empty_default_instance_;
@@ -284,6 +287,41 @@ inline bool ViewportTransformSpace_Parse(absl::string_view name, ViewportTransfo
   return ::google::protobuf::internal::ParseNamedEnum<ViewportTransformSpace>(
       ViewportTransformSpace_descriptor(), name, value);
 }
+enum EditorStatsMode : int {
+  EDITOR_STATS_MODE_UNSPECIFIED = 0,
+  EDITOR_STATS_MODE_NONE = 1,
+  EDITOR_STATS_MODE_RENDER_STATS = 2,
+  EDITOR_STATS_MODE_RENDER_STATS_AND_QUERIES = 3,
+  EditorStatsMode_INT_MIN_SENTINEL_DO_NOT_USE_ =
+      std::numeric_limits<::int32_t>::min(),
+  EditorStatsMode_INT_MAX_SENTINEL_DO_NOT_USE_ =
+      std::numeric_limits<::int32_t>::max(),
+};
+
+bool EditorStatsMode_IsValid(int value);
+extern const uint32_t EditorStatsMode_internal_data_[];
+constexpr EditorStatsMode EditorStatsMode_MIN = static_cast<EditorStatsMode>(0);
+constexpr EditorStatsMode EditorStatsMode_MAX = static_cast<EditorStatsMode>(3);
+constexpr int EditorStatsMode_ARRAYSIZE = 3 + 1;
+const ::google::protobuf::EnumDescriptor*
+EditorStatsMode_descriptor();
+template <typename T>
+const std::string& EditorStatsMode_Name(T value) {
+  static_assert(std::is_same<T, EditorStatsMode>::value ||
+                    std::is_integral<T>::value,
+                "Incorrect type passed to EditorStatsMode_Name().");
+  return EditorStatsMode_Name(static_cast<EditorStatsMode>(value));
+}
+template <>
+inline const std::string& EditorStatsMode_Name(EditorStatsMode value) {
+  return ::google::protobuf::internal::NameOfDenseEnum<EditorStatsMode_descriptor,
+                                                 0, 3>(
+      static_cast<int>(value));
+}
+inline bool EditorStatsMode_Parse(absl::string_view name, EditorStatsMode* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<EditorStatsMode>(
+      EditorStatsMode_descriptor(), name, value);
+}
 
 // ===================================================================
 
@@ -349,7 +387,7 @@ class ViewportToolStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateResult*>(
         &_ViewportToolStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 40;
+  static constexpr int kIndexInFileMessages = 41;
   friend void swap(ViewportToolStateResult& a, ViewportToolStateResult& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateResult* other) {
     if (other == this) return;
@@ -551,7 +589,7 @@ class ViewportToolStateRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateRequest*>(
         &_ViewportToolStateRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 27;
+  static constexpr int kIndexInFileMessages = 28;
   friend void swap(ViewportToolStateRequest& a, ViewportToolStateRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateRequest* other) {
     if (other == this) return;
@@ -765,7 +803,7 @@ class ViewportToolShortcutEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolShortcutEvent*>(
         &_ViewportToolShortcutEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 46;
+  static constexpr int kIndexInFileMessages = 47;
   friend void swap(ViewportToolShortcutEvent& a, ViewportToolShortcutEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportToolShortcutEvent* other) {
     if (other == this) return;
@@ -955,7 +993,7 @@ class ViewportSelectionEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportSelectionEvent*>(
         &_ViewportSelectionEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 43;
+  static constexpr int kIndexInFileMessages = 44;
   friend void swap(ViewportSelectionEvent& a, ViewportSelectionEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportSelectionEvent* other) {
     if (other == this) return;
@@ -1377,7 +1415,7 @@ class ViewportRayRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportRayRequest*>(
         &_ViewportRayRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 23;
+  static constexpr int kIndexInFileMessages = 24;
   friend void swap(ViewportRayRequest& a, ViewportRayRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportRayRequest* other) {
     if (other == this) return;
@@ -1591,7 +1629,7 @@ class ViewportObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportObjectRequest*>(
         &_ViewportObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 25;
+  static constexpr int kIndexInFileMessages = 26;
   friend void swap(ViewportObjectRequest& a, ViewportObjectRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportObjectRequest* other) {
     if (other == this) return;
@@ -1989,7 +2027,7 @@ class ViewportAssetDropEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportAssetDropEvent*>(
         &_ViewportAssetDropEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 45;
+  static constexpr int kIndexInFileMessages = 46;
   friend void swap(ViewportAssetDropEvent& a, ViewportAssetDropEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportAssetDropEvent* other) {
     if (other == this) return;
@@ -2209,7 +2247,7 @@ class Vector4 final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4*>(
         &_Vector4_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 42;
+  static constexpr int kIndexInFileMessages = 43;
   friend void swap(Vector4& a, Vector4& b) { a.Swap(&b); }
   inline void Swap(Vector4* other) {
     if (other == this) return;
@@ -2435,7 +2473,7 @@ class UpdateObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const UpdateObjectRequest*>(
         &_UpdateObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 16;
+  static constexpr int kIndexInFileMessages = 17;
   friend void swap(UpdateObjectRequest& a, UpdateObjectRequest& b) { a.Swap(&b); }
   inline void Swap(UpdateObjectRequest* other) {
     if (other == this) return;
@@ -2649,7 +2687,7 @@ class UInt64Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt64Result*>(
         &_UInt64Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 34;
+  static constexpr int kIndexInFileMessages = 35;
   friend void swap(UInt64Result& a, UInt64Result& b) { a.Swap(&b); }
   inline void Swap(UInt64Result* other) {
     if (other == this) return;
@@ -2839,7 +2877,7 @@ class UInt32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt32Result*>(
         &_UInt32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 33;
+  static constexpr int kIndexInFileMessages = 34;
   friend void swap(UInt32Result& a, UInt32Result& b) { a.Swap(&b); }
   inline void Swap(UInt32Result* other) {
     if (other == this) return;
@@ -3029,7 +3067,7 @@ class StringResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringResult*>(
         &_StringResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 35;
+  static constexpr int kIndexInFileMessages = 36;
   friend void swap(StringResult& a, StringResult& b) { a.Swap(&b); }
   inline void Swap(StringResult* other) {
     if (other == this) return;
@@ -3237,7 +3275,7 @@ class StringListResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringListResult*>(
         &_StringListResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 36;
+  static constexpr int kIndexInFileMessages = 37;
   friend void swap(StringListResult& a, StringListResult& b) { a.Swap(&b); }
   inline void Swap(StringListResult* other) {
     if (other == this) return;
@@ -3641,7 +3679,7 @@ class ShowMainWindowRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ShowMainWindowRequest*>(
         &_ShowMainWindowRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 29;
+  static constexpr int kIndexInFileMessages = 30;
   friend void swap(ShowMainWindowRequest& a, ShowMainWindowRequest& b) { a.Swap(&b); }
   inline void Swap(ShowMainWindowRequest* other) {
     if (other == this) return;
@@ -3831,7 +3869,7 @@ class SelectionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const SelectionRequest*>(
         &_SelectionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 28;
+  static constexpr int kIndexInFileMessages = 29;
   friend void swap(SelectionRequest& a, SelectionRequest& b) { a.Swap(&b); }
   inline void Swap(SelectionRequest* other) {
     if (other == this) return;
@@ -4033,7 +4071,7 @@ class ReparentObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ReparentObjectRequest*>(
         &_ReparentObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 17;
+  static constexpr int kIndexInFileMessages = 18;
   friend void swap(ReparentObjectRequest& a, ReparentObjectRequest& b) { a.Swap(&b); }
   inline void Swap(ReparentObjectRequest* other) {
     if (other == this) return;
@@ -4259,7 +4297,7 @@ class RenderPathTracedImageRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RenderPathTracedImageRequest*>(
         &_RenderPathTracedImageRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 30;
+  static constexpr int kIndexInFileMessages = 31;
   friend void swap(RenderPathTracedImageRequest& a, RenderPathTracedImageRequest& b) { a.Swap(&b); }
   inline void Swap(RenderPathTracedImageRequest* other) {
     if (other == this) return;
@@ -4509,7 +4547,7 @@ class RemoteViewportRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportRequest*>(
         &_RemoteViewportRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 12;
+  static constexpr int kIndexInFileMessages = 13;
   friend void swap(RemoteViewportRequest& a, RemoteViewportRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportRequest* other) {
     if (other == this) return;
@@ -4771,7 +4809,7 @@ class RemoteViewportInputRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportInputRequest*>(
         &_RemoteViewportInputRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 14;
+  static constexpr int kIndexInFileMessages = 15;
   friend void swap(RemoteViewportInputRequest& a, RemoteViewportInputRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportInputRequest* other) {
     if (other == this) return;
@@ -5093,7 +5131,7 @@ class RemoteViewportHostRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportHostRequest*>(
         &_RemoteViewportHostRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 13;
+  static constexpr int kIndexInFileMessages = 14;
   friend void swap(RemoteViewportHostRequest& a, RemoteViewportHostRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportHostRequest* other) {
     if (other == this) return;
@@ -5307,7 +5345,7 @@ class PrefabLinkRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const PrefabLinkRequest*>(
         &_PrefabLinkRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 26;
+  static constexpr int kIndexInFileMessages = 27;
   friend void swap(PrefabLinkRequest& a, PrefabLinkRequest& b) { a.Swap(&b); }
   inline void Swap(PrefabLinkRequest* other) {
     if (other == this) return;
@@ -5521,7 +5559,7 @@ class ManagedMutationRevisionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ManagedMutationRevisionRequest*>(
         &_ManagedMutationRevisionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 15;
+  static constexpr int kIndexInFileMessages = 16;
   friend void swap(ManagedMutationRevisionRequest& a, ManagedMutationRevisionRequest& b) { a.Swap(&b); }
   inline void Swap(ManagedMutationRevisionRequest* other) {
     if (other == this) return;
@@ -5729,7 +5767,7 @@ class Int32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Int32Result*>(
         &_Int32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 32;
+  static constexpr int kIndexInFileMessages = 33;
   friend void swap(Int32Result& a, Int32Result& b) { a.Swap(&b); }
   inline void Swap(Int32Result* other) {
     if (other == this) return;
@@ -5919,7 +5957,7 @@ class InstantiatePrefabRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const InstantiatePrefabRequest*>(
         &_InstantiatePrefabRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 21;
+  static constexpr int kIndexInFileMessages = 22;
   friend void swap(InstantiatePrefabRequest& a, InstantiatePrefabRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabRequest* other) {
     if (other == this) return;
@@ -6133,7 +6171,7 @@ class InstantiatePrefabFromYamlRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabFromYamlRequest*>(
         &_InstantiatePrefabFromYamlRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 22;
+  static constexpr int kIndexInFileMessages = 23;
   friend void swap(InstantiatePrefabFromYamlRequest& a, InstantiatePrefabFromYamlRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabFromYamlRequest* other) {
     if (other == this) return;
@@ -6359,7 +6397,7 @@ class InstanceIdResult final : public ::google::protobuf::Message
     return reinterpret_cast<const InstanceIdResult*>(
         &_InstanceIdResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 38;
+  static constexpr int kIndexInFileMessages = 39;
   friend void swap(InstanceIdResult& a, InstanceIdResult& b) { a.Swap(&b); }
   inline void Swap(InstanceIdResult* other) {
     if (other == this) return;
@@ -7247,6 +7285,196 @@ class Empty final : public ::google::protobuf::internal::ZeroFieldsBase
 };
 // -------------------------------------------------------------------
 
+class EditorStatsModeRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.EditorStatsModeRequest) */ {
+ public:
+  inline EditorStatsModeRequest() : EditorStatsModeRequest(nullptr) {}
+  ~EditorStatsModeRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(EditorStatsModeRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(EditorStatsModeRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR EditorStatsModeRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline EditorStatsModeRequest(const EditorStatsModeRequest& from) : EditorStatsModeRequest(nullptr, from) {}
+  inline EditorStatsModeRequest(EditorStatsModeRequest&& from) noexcept
+      : EditorStatsModeRequest(nullptr, std::move(from)) {}
+  inline EditorStatsModeRequest& operator=(const EditorStatsModeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline EditorStatsModeRequest& operator=(EditorStatsModeRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const EditorStatsModeRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const EditorStatsModeRequest* internal_default_instance() {
+    return reinterpret_cast<const EditorStatsModeRequest*>(
+        &_EditorStatsModeRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 12;
+  friend void swap(EditorStatsModeRequest& a, EditorStatsModeRequest& b) { a.Swap(&b); }
+  inline void Swap(EditorStatsModeRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(EditorStatsModeRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  EditorStatsModeRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<EditorStatsModeRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const EditorStatsModeRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const EditorStatsModeRequest& from) { EditorStatsModeRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(EditorStatsModeRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.EditorStatsModeRequest"; }
+
+ protected:
+  explicit EditorStatsModeRequest(::google::protobuf::Arena* arena);
+  EditorStatsModeRequest(::google::protobuf::Arena* arena, const EditorStatsModeRequest& from);
+  EditorStatsModeRequest(::google::protobuf::Arena* arena, EditorStatsModeRequest&& from) noexcept
+      : EditorStatsModeRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kModeFieldNumber = 1,
+  };
+  // .sailor.editor.v1.EditorStatsMode mode = 1;
+  void clear_mode() ;
+  ::sailor::editor::v1::EditorStatsMode mode() const;
+  void set_mode(::sailor::editor::v1::EditorStatsMode value);
+
+  private:
+  ::sailor::editor::v1::EditorStatsMode _internal_mode() const;
+  void _internal_set_mode(::sailor::editor::v1::EditorStatsMode value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.EditorStatsModeRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const EditorStatsModeRequest& from_msg);
+    int mode_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class EditorSimulationRequest final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.EditorSimulationRequest) */ {
  public:
@@ -7496,7 +7724,7 @@ class CreateGameObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const CreateGameObjectRequest*>(
         &_CreateGameObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 18;
+  static constexpr int kIndexInFileMessages = 19;
   friend void swap(CreateGameObjectRequest& a, CreateGameObjectRequest& b) { a.Swap(&b); }
   inline void Swap(CreateGameObjectRequest* other) {
     if (other == this) return;
@@ -7900,7 +8128,7 @@ class BoolResult final : public ::google::protobuf::Message
     return reinterpret_cast<const BoolResult*>(
         &_BoolResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 31;
+  static constexpr int kIndexInFileMessages = 32;
   friend void swap(BoolResult& a, BoolResult& b) { a.Swap(&b); }
   inline void Swap(BoolResult* other) {
     if (other == this) return;
@@ -8090,7 +8318,7 @@ class AssetReloadStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const AssetReloadStateResult*>(
         &_AssetReloadStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 37;
+  static constexpr int kIndexInFileMessages = 38;
   friend void swap(AssetReloadStateResult& a, AssetReloadStateResult& b) { a.Swap(&b); }
   inline void Swap(AssetReloadStateResult* other) {
     if (other == this) return;
@@ -8316,7 +8544,7 @@ class AnimatorStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const AnimatorStateResult*>(
         &_AnimatorStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 41;
+  static constexpr int kIndexInFileMessages = 42;
   friend void swap(AnimatorStateResult& a, AnimatorStateResult& b) { a.Swap(&b); }
   inline void Swap(AnimatorStateResult* other) {
     if (other == this) return;
@@ -8626,7 +8854,7 @@ class AddComponentRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const AddComponentRequest*>(
         &_AddComponentRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 19;
+  static constexpr int kIndexInFileMessages = 20;
   friend void swap(AddComponentRequest& a, AddComponentRequest& b) { a.Swap(&b); }
   inline void Swap(AddComponentRequest* other) {
     if (other == this) return;
@@ -8858,7 +9086,7 @@ class ViewportTransformEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportTransformEvent*>(
         &_ViewportTransformEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 44;
+  static constexpr int kIndexInFileMessages = 45;
   friend void swap(ViewportTransformEvent& a, ViewportTransformEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportTransformEvent* other) {
     if (other == this) return;
@@ -9181,7 +9409,7 @@ class Vector4Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4Result*>(
         &_Vector4Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 39;
+  static constexpr int kIndexInFileMessages = 40;
   friend void swap(Vector4Result& a, Vector4Result& b) { a.Swap(&b); }
   inline void Swap(Vector4Result* other) {
     if (other == this) return;
@@ -9377,7 +9605,7 @@ class InstantiatePrefabInstanceRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabInstanceRequest*>(
         &_InstantiatePrefabInstanceRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 24;
+  static constexpr int kIndexInFileMessages = 25;
   friend void swap(InstantiatePrefabInstanceRequest& a, InstantiatePrefabInstanceRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabInstanceRequest* other) {
     if (other == this) return;
@@ -9921,7 +10149,7 @@ class AnimatorParameterRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const AnimatorParameterRequest*>(
         &_AnimatorParameterRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 20;
+  static constexpr int kIndexInFileMessages = 21;
   friend void swap(AnimatorParameterRequest& a, AnimatorParameterRequest& b) { a.Swap(&b); }
   inline void Swap(AnimatorParameterRequest* other) {
     if (other == this) return;
@@ -10237,7 +10465,7 @@ class ViewportEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEvent*>(
         &_ViewportEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 47;
+  static constexpr int kIndexInFileMessages = 48;
   friend void swap(ViewportEvent& a, ViewportEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportEvent* other) {
     if (other == this) return;
@@ -10586,6 +10814,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kSetEditorSimulation = 61,
     kGetEditorSimulationState = 62,
     kPreviewAudioAsset = 63,
+    kSetEditorStatsMode = 64,
     COMMAND_NOT_SET = 0,
   };
   static inline const ProtocolRequest* internal_default_instance() {
@@ -10734,6 +10963,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kSetEditorSimulationFieldNumber = 61,
     kGetEditorSimulationStateFieldNumber = 62,
     kPreviewAudioAssetFieldNumber = 63,
+    kSetEditorStatsModeFieldNumber = 64,
   };
   // uint64 request_id = 2;
   void clear_request_id() ;
@@ -11762,6 +11992,25 @@ class ProtocolRequest final : public ::google::protobuf::Message
   ::sailor::editor::v1::FileIdRequest* _internal_mutable_preview_audio_asset();
 
   public:
+  // .sailor.editor.v1.EditorStatsModeRequest set_editor_stats_mode = 64;
+  bool has_set_editor_stats_mode() const;
+  private:
+  bool _internal_has_set_editor_stats_mode() const;
+
+  public:
+  void clear_set_editor_stats_mode() ;
+  const ::sailor::editor::v1::EditorStatsModeRequest& set_editor_stats_mode() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::EditorStatsModeRequest* release_set_editor_stats_mode();
+  ::sailor::editor::v1::EditorStatsModeRequest* mutable_set_editor_stats_mode();
+  void set_allocated_set_editor_stats_mode(::sailor::editor::v1::EditorStatsModeRequest* value);
+  void unsafe_arena_set_allocated_set_editor_stats_mode(::sailor::editor::v1::EditorStatsModeRequest* value);
+  ::sailor::editor::v1::EditorStatsModeRequest* unsafe_arena_release_set_editor_stats_mode();
+
+  private:
+  const ::sailor::editor::v1::EditorStatsModeRequest& _internal_set_editor_stats_mode() const;
+  ::sailor::editor::v1::EditorStatsModeRequest* _internal_mutable_set_editor_stats_mode();
+
+  public:
   void clear_command();
   CommandCase command_case() const;
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.ProtocolRequest)
@@ -11820,11 +12069,12 @@ class ProtocolRequest final : public ::google::protobuf::Message
   void set_has_set_editor_simulation();
   void set_has_get_editor_simulation_state();
   void set_has_preview_audio_asset();
+  void set_has_set_editor_stats_mode();
   inline bool has_command() const;
   inline void clear_has_command();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      1, 55, 53,
+      1, 56, 54,
       0, 9>
       _table_;
 
@@ -11900,6 +12150,7 @@ class ProtocolRequest final : public ::google::protobuf::Message
       ::sailor::editor::v1::EditorSimulationRequest* set_editor_simulation_;
       ::sailor::editor::v1::Empty* get_editor_simulation_state_;
       ::sailor::editor::v1::FileIdRequest* preview_audio_asset_;
+      ::sailor::editor::v1::EditorStatsModeRequest* set_editor_stats_mode_;
     } command_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -11969,7 +12220,7 @@ class ViewportEventBatchResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEventBatchResult*>(
         &_ViewportEventBatchResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 48;
+  static constexpr int kIndexInFileMessages = 49;
   friend void swap(ViewportEventBatchResult& a, ViewportEventBatchResult& b) { a.Swap(&b); }
   inline void Swap(ViewportEventBatchResult* other) {
     if (other == this) return;
@@ -16912,6 +17163,85 @@ inline ::sailor::editor::v1::FileIdRequest* ProtocolRequest::mutable_preview_aud
   return _msg;
 }
 
+// .sailor.editor.v1.EditorStatsModeRequest set_editor_stats_mode = 64;
+inline bool ProtocolRequest::has_set_editor_stats_mode() const {
+  return command_case() == kSetEditorStatsMode;
+}
+inline bool ProtocolRequest::_internal_has_set_editor_stats_mode() const {
+  return command_case() == kSetEditorStatsMode;
+}
+inline void ProtocolRequest::set_has_set_editor_stats_mode() {
+  _impl_._oneof_case_[0] = kSetEditorStatsMode;
+}
+inline void ProtocolRequest::clear_set_editor_stats_mode() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kSetEditorStatsMode) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.set_editor_stats_mode_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_editor_stats_mode_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::EditorStatsModeRequest* ProtocolRequest::release_set_editor_stats_mode() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.set_editor_stats_mode)
+  if (command_case() == kSetEditorStatsMode) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_editor_stats_mode_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.set_editor_stats_mode_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::EditorStatsModeRequest& ProtocolRequest::_internal_set_editor_stats_mode() const {
+  return command_case() == kSetEditorStatsMode ? *_impl_.command_.set_editor_stats_mode_ : reinterpret_cast<::sailor::editor::v1::EditorStatsModeRequest&>(::sailor::editor::v1::_EditorStatsModeRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::EditorStatsModeRequest& ProtocolRequest::set_editor_stats_mode() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.set_editor_stats_mode)
+  return _internal_set_editor_stats_mode();
+}
+inline ::sailor::editor::v1::EditorStatsModeRequest* ProtocolRequest::unsafe_arena_release_set_editor_stats_mode() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.set_editor_stats_mode)
+  if (command_case() == kSetEditorStatsMode) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_editor_stats_mode_;
+    _impl_.command_.set_editor_stats_mode_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_set_editor_stats_mode(::sailor::editor::v1::EditorStatsModeRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_set_editor_stats_mode();
+    _impl_.command_.set_editor_stats_mode_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.set_editor_stats_mode)
+}
+inline ::sailor::editor::v1::EditorStatsModeRequest* ProtocolRequest::_internal_mutable_set_editor_stats_mode() {
+  if (command_case() != kSetEditorStatsMode) {
+    clear_command();
+    set_has_set_editor_stats_mode();
+    _impl_.command_.set_editor_stats_mode_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::EditorStatsModeRequest>(GetArena());
+  }
+  return _impl_.command_.set_editor_stats_mode_;
+}
+inline ::sailor::editor::v1::EditorStatsModeRequest* ProtocolRequest::mutable_set_editor_stats_mode() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::EditorStatsModeRequest* _msg = _internal_mutable_set_editor_stats_mode();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.set_editor_stats_mode)
+  return _msg;
+}
+
 inline bool ProtocolRequest::has_command() const {
   return command_case() != COMMAND_NOT_SET;
 }
@@ -18821,6 +19151,32 @@ inline bool EditorSimulationRequest::_internal_enabled() const {
 inline void EditorSimulationRequest::_internal_set_enabled(bool value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.enabled_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// EditorStatsModeRequest
+
+// .sailor.editor.v1.EditorStatsMode mode = 1;
+inline void EditorStatsModeRequest::clear_mode() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.mode_ = 0;
+}
+inline ::sailor::editor::v1::EditorStatsMode EditorStatsModeRequest::mode() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.EditorStatsModeRequest.mode)
+  return _internal_mode();
+}
+inline void EditorStatsModeRequest::set_mode(::sailor::editor::v1::EditorStatsMode value) {
+  _internal_set_mode(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.EditorStatsModeRequest.mode)
+}
+inline ::sailor::editor::v1::EditorStatsMode EditorStatsModeRequest::_internal_mode() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::sailor::editor::v1::EditorStatsMode>(_impl_.mode_);
+}
+inline void EditorStatsModeRequest::_internal_set_mode(::sailor::editor::v1::EditorStatsMode value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.mode_ = value;
 }
 
 // -------------------------------------------------------------------
@@ -23467,6 +23823,12 @@ struct is_proto_enum<::sailor::editor::v1::ViewportTransformSpace> : std::true_t
 template <>
 inline const EnumDescriptor* GetEnumDescriptor<::sailor::editor::v1::ViewportTransformSpace>() {
   return ::sailor::editor::v1::ViewportTransformSpace_descriptor();
+}
+template <>
+struct is_proto_enum<::sailor::editor::v1::EditorStatsMode> : std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor<::sailor::editor::v1::EditorStatsMode>() {
+  return ::sailor::editor::v1::EditorStatsMode_descriptor();
 }
 
 }  // namespace protobuf

--- a/Runtime/RHI/DebugContext.cpp
+++ b/Runtime/RHI/DebugContext.cpp
@@ -6,7 +6,6 @@
 #include "FrameGraph/ShadowPrepassNode.h"
 #include "ECS/LightingECS.h"
 #include "AssetRegistry/AssetRegistry.h"
-#include "Settings/GraphicsSettings.h"
 
 #ifdef SAILOR_BUILD_WITH_VULKAN
 #include "GraphicsDriver/Vulkan/VulkanPipeline.h"
@@ -388,15 +387,23 @@ DebugContext::DrawSnapshot DebugContext::GetDrawSnapshot() const
 	return snapshot;
 }
 
-void DebugContext::DrawDebugMesh(RHI::RHICommandListPtr secondaryDrawCmdList, const glm::mat4x4& viewProjection) const
+void DebugContext::DrawDebugMesh(
+	RHI::RHICommandListPtr secondaryDrawCmdList,
+	const glm::mat4x4& viewProjection,
+	const glm::ivec2& renderExtent) const
 {
-	DrawDebugMesh(secondaryDrawCmdList, viewProjection, GetDrawSnapshot());
+	DrawDebugMesh(
+		secondaryDrawCmdList,
+		viewProjection,
+		GetDrawSnapshot(),
+		renderExtent);
 }
 
 void DebugContext::DrawDebugMesh(
 	RHI::RHICommandListPtr secondaryDrawCmdList,
 	const glm::mat4x4& viewProjection,
-	const DrawSnapshot& snapshot) const
+	const DrawSnapshot& snapshot,
+	const glm::ivec2& renderExtent) const
 {
 	if (!snapshot.m_vertexBuffer ||
 		!snapshot.m_indexBuffer ||
@@ -407,14 +414,8 @@ void DebugContext::DrawDebugMesh(
 	}
 
 	auto commands = RHI::Renderer::GetDriverCommands();
-	const glm::ivec2 outputExtent = App::GetMainWindow()->GetRenderArea();
-	const Settings::GraphicsExtent renderExtent =
-		Settings::ResolveRenderDimensions(
-			static_cast<uint32_t>((std::max)(outputExtent.x, 1)),
-			static_cast<uint32_t>((std::max)(outputExtent.y, 1)),
-			App::GetActiveGraphicsSettings().m_resolutionFactor);
-	const float renderWidth = static_cast<float>(renderExtent.m_width);
-	const float renderHeight = static_cast<float>(renderExtent.m_height);
+	const float renderWidth = static_cast<float>((std::max)(renderExtent.x, 1));
+	const float renderHeight = static_cast<float>((std::max)(renderExtent.y, 1));
 
 	commands->BindMaterial(secondaryDrawCmdList, snapshot.m_material);
 	commands->SetViewport(

--- a/Runtime/RHI/DebugContext.cpp
+++ b/Runtime/RHI/DebugContext.cpp
@@ -6,6 +6,7 @@
 #include "FrameGraph/ShadowPrepassNode.h"
 #include "ECS/LightingECS.h"
 #include "AssetRegistry/AssetRegistry.h"
+#include "Settings/GraphicsSettings.h"
 
 #ifdef SAILOR_BUILD_WITH_VULKAN
 #include "GraphicsDriver/Vulkan/VulkanPipeline.h"
@@ -160,20 +161,28 @@ void DebugContext::DrawFrustum(const Math::Frustum& frustum, const glm::vec4 col
 void DebugContext::DrawLightCascades(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float duration)
 {
 	const float shadowFarPlane = (std::min)(zFar, LightingECS::ShadowMaxDistance);
+	const auto& graphicsProfile = App::GetActiveGraphicsSettings();
+	const uint32_t activeCascadeCount = (std::clamp)(
+		graphicsProfile.m_shadowCascadeCount,
+		1u,
+		LightingECS::NumCascades);
 	TVector<Math::Frustum> cascades;
-	cascades.Reserve(LightingECS::NumCascades);
-	for (uint32_t i = 0; i < LightingECS::NumCascades; i++)
+	cascades.Reserve(activeCascadeCount);
+	for (uint32_t i = 0; i < activeCascadeCount; i++)
 	{
 		Math::Frustum cameraFrustum{};
 		float cascadeNear = zNear;
 		if (i > 0)
 		{
-			const float previousSplit = shadowFarPlane * LightingECS::ShadowCascadeLevels[i - 1];
-			const float previousNear = i > 1 ? shadowFarPlane * LightingECS::ShadowCascadeLevels[i - 2] : zNear;
+			const float previousSplit = shadowFarPlane *
+				LightingECS::GetShadowCascadeLevel(i - 1u, activeCascadeCount);
+			const float previousNear = i > 1 ? shadowFarPlane *
+				LightingECS::GetShadowCascadeLevel(i - 2u, activeCascadeCount) : zNear;
 			cascadeNear = (std::max)(zNear,
 				previousSplit - (previousSplit - previousNear) * LightingECS::ShadowCascadeBlendFraction);
 		}
-		const float cascadeFar = shadowFarPlane * LightingECS::ShadowCascadeLevels[i];
+		const float cascadeFar = shadowFarPlane *
+			LightingECS::GetShadowCascadeLevel(i, activeCascadeCount);
 		cameraFrustum.ExtractFrustumPlanes(cameraWorld, aspect, fovY, cascadeNear, cascadeFar);
 		cascades.Emplace(std::move(cameraFrustum));
 	}
@@ -194,7 +203,7 @@ void DebugContext::DrawLightCascades(const glm::mat4& lightView, const glm::mat4
 		const glm::mat4 lightProjection = cascadeFrustum.CalculateOrthoMatrixByView(
 			lightView,
 			zMult,
-			LightingECS::ShadowCascadeResolutions[i],
+			glm::ivec2(graphicsProfile.GetShadowCascadeResolution(i)),
 			LightingECS::ShadowCasterDepthExtension);
 
 		// Create matrix and get all extents
@@ -398,9 +407,26 @@ void DebugContext::DrawDebugMesh(
 	}
 
 	auto commands = RHI::Renderer::GetDriverCommands();
+	const glm::ivec2 outputExtent = App::GetMainWindow()->GetRenderArea();
+	const Settings::GraphicsExtent renderExtent =
+		Settings::ResolveRenderDimensions(
+			static_cast<uint32_t>((std::max)(outputExtent.x, 1)),
+			static_cast<uint32_t>((std::max)(outputExtent.y, 1)),
+			App::GetActiveGraphicsSettings().m_resolutionFactor);
+	const float renderWidth = static_cast<float>(renderExtent.m_width);
+	const float renderHeight = static_cast<float>(renderExtent.m_height);
 
 	commands->BindMaterial(secondaryDrawCmdList, snapshot.m_material);
-	commands->SetDefaultViewport(secondaryDrawCmdList);
+	commands->SetViewport(
+		secondaryDrawCmdList,
+		0.0f,
+		renderHeight,
+		renderWidth,
+		-renderHeight,
+		glm::vec2(0.0f),
+		glm::vec2(renderWidth, renderHeight),
+		0.0f,
+		1.0f);
 	commands->BindVertexBuffer(secondaryDrawCmdList, snapshot.m_vertexBuffer, snapshot.m_vertexBuffer->GetOffset());
 	commands->BindIndexBuffer(secondaryDrawCmdList, snapshot.m_indexBuffer, snapshot.m_indexBuffer->GetOffset());
 	commands->PushConstants(secondaryDrawCmdList, snapshot.m_material, sizeof(viewProjection), &viewProjection);

--- a/Runtime/RHI/DebugContext.h
+++ b/Runtime/RHI/DebugContext.h
@@ -51,8 +51,15 @@ namespace Sailor::RHI
 		SAILOR_API void DrawPlane(const Math::Plane& plane, float size, const glm::vec4 color = { 0.0f, 1.0f, 0.3f, 0.0f }, float duration = 0.0f);
 		SAILOR_API void Tick(RHI::RHICommandListPtr transferCmd, float deltaTime);
 		SAILOR_API DrawSnapshot GetDrawSnapshot() const;
-		SAILOR_API void DrawDebugMesh(RHI::RHICommandListPtr secondaryDrawCmdList, const glm::mat4x4& viewProjection) const;
-		SAILOR_API void DrawDebugMesh(RHI::RHICommandListPtr secondaryDrawCmdList, const glm::mat4x4& viewProjection, const DrawSnapshot& snapshot) const;
+		SAILOR_API void DrawDebugMesh(
+			RHI::RHICommandListPtr secondaryDrawCmdList,
+			const glm::mat4x4& viewProjection,
+			const glm::ivec2& renderExtent) const;
+		SAILOR_API void DrawDebugMesh(
+			RHI::RHICommandListPtr secondaryDrawCmdList,
+			const glm::mat4x4& viewProjection,
+			const DrawSnapshot& snapshot,
+			const glm::ivec2& renderExtent) const;
 
 	protected:
 

--- a/Runtime/RHI/GpuFrameTimeQueryRing.h
+++ b/Runtime/RHI/GpuFrameTimeQueryRing.h
@@ -1,10 +1,45 @@
 #pragma once
 
+#include <cmath>
 #include <cstdint>
 #include <limits>
 
 namespace Sailor::RHI
 {
+	inline bool TryResolveGpuFrameTimeMilliseconds(
+		uint64_t beginTimestamp,
+		uint64_t endTimestamp,
+		uint32_t validBits,
+		float timestampPeriodNs,
+		float& outMilliseconds)
+	{
+		if (validBits == 0u || validBits > 64u ||
+			!std::isfinite(timestampPeriodNs) || timestampPeriodNs <= 0.0f)
+		{
+			return false;
+		}
+
+		const uint64_t timestampMask = validBits == 64u ?
+			(std::numeric_limits<uint64_t>::max)() :
+			(1ull << validBits) - 1ull;
+		const uint64_t elapsedTicks =
+			(endTimestamp - beginTimestamp) & timestampMask;
+		const double milliseconds = static_cast<double>(elapsedTicks) *
+			static_cast<double>(timestampPeriodNs) / 1000000.0;
+
+		// A valid GPU frame cannot reasonably span a minute. Besides filtering
+		// corrupted values, this rejects a stale end timestamp interpreted as a
+		// full-width unsigned wrap (which otherwise reaches the Stats overlay as
+		// an enormous positive duration).
+		if (!std::isfinite(milliseconds) || milliseconds > 60000.0)
+		{
+			return false;
+		}
+
+		outMilliseconds = static_cast<float>(milliseconds);
+		return true;
+	}
+
 	enum class EGpuFrameTimeQuerySlotState : uint8_t
 	{
 		Available,

--- a/Runtime/RHI/GpuFrameTimeQueryRing.h
+++ b/Runtime/RHI/GpuFrameTimeQueryRing.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+
+namespace Sailor::RHI
+{
+	enum class EGpuFrameTimeQuerySlotState : uint8_t
+	{
+		Available,
+		Recording,
+		Issued
+	};
+
+	template<uint32_t NumSlots>
+	class TGpuFrameTimeQueryRing final
+	{
+		static_assert(NumSlots > 0u);
+
+	public:
+		static constexpr uint32_t InvalidSlot =
+			(std::numeric_limits<uint32_t>::max)();
+
+		uint32_t Acquire()
+		{
+			for (uint32_t offset = 0u; offset < NumSlots; ++offset)
+			{
+				const uint32_t slot = (m_nextSlot + offset) % NumSlots;
+				if (m_states[slot] != EGpuFrameTimeQuerySlotState::Available)
+				{
+					continue;
+				}
+
+				m_states[slot] = EGpuFrameTimeQuerySlotState::Recording;
+				m_nextSlot = (slot + 1u) % NumSlots;
+				return slot;
+			}
+
+			return InvalidSlot;
+		}
+
+		bool MarkIssued(uint32_t slot)
+		{
+			if (slot >= NumSlots ||
+				m_states[slot] != EGpuFrameTimeQuerySlotState::Recording)
+			{
+				return false;
+			}
+
+			m_states[slot] = EGpuFrameTimeQuerySlotState::Issued;
+			return true;
+		}
+
+		bool MarkCompleted(uint32_t slot)
+		{
+			if (slot >= NumSlots ||
+				m_states[slot] != EGpuFrameTimeQuerySlotState::Issued)
+			{
+				return false;
+			}
+
+			m_states[slot] = EGpuFrameTimeQuerySlotState::Available;
+			return true;
+		}
+
+		bool CancelRecording(uint32_t slot)
+		{
+			if (slot >= NumSlots ||
+				m_states[slot] != EGpuFrameTimeQuerySlotState::Recording)
+			{
+				return false;
+			}
+
+			m_states[slot] = EGpuFrameTimeQuerySlotState::Available;
+			return true;
+		}
+
+		EGpuFrameTimeQuerySlotState GetState(uint32_t slot) const
+		{
+			return slot < NumSlots ?
+				m_states[slot] :
+				EGpuFrameTimeQuerySlotState::Available;
+		}
+
+	private:
+		EGpuFrameTimeQuerySlotState m_states[NumSlots]{};
+		uint32_t m_nextSlot = 0u;
+	};
+}

--- a/Runtime/RHI/GraphicsDriver.h
+++ b/Runtime/RHI/GraphicsDriver.h
@@ -67,6 +67,12 @@ namespace Sailor::RHI
 
 		SAILOR_API virtual void StartGpuTracking() = 0;
 		SAILOR_API virtual RHI::GpuStats FinishGpuTracking() = 0;
+		SAILOR_API virtual bool SupportsGpuFrameTimeQueries() const = 0;
+		SAILOR_API virtual bool BeginGpuFrameTimeQuery(RHICommandListPtr commandList) = 0;
+		SAILOR_API virtual void EndGpuFrameTimeQuery(RHICommandListPtr commandList) = 0;
+		SAILOR_API virtual void CommitGpuFrameTimeQuery() = 0;
+		SAILOR_API virtual void CancelGpuFrameTimeQuery() = 0;
+		SAILOR_API virtual bool TryGetGpuFrameTimeMs(float& outMilliseconds) const = 0;
 
 		SAILOR_API virtual uint32_t GetNumSubmittedCommandBuffers() const = 0;
 
@@ -81,7 +87,7 @@ namespace Sailor::RHI
 		SAILOR_API virtual bool AcquireNextImage() = 0;
 		SAILOR_API virtual bool PresentFrame(const Sailor::FrameState& state,
 			const TVector<RHICommandListPtr>& primaryCommandBuffers = {},
-			const TVector<RHISemaphorePtr>& waitSemaphores = {}) const = 0;
+			const TVector<RHISemaphorePtr>& waitSemaphores = {}) = 0;
 		SAILOR_API virtual bool SubmitFrameWithoutPresent(
 			const TVector<RHICommandListPtr>& primaryCommandBuffers = {},
 			const TVector<RHISemaphorePtr>& waitSemaphores = {}) = 0;

--- a/Runtime/RHI/Lighting.h
+++ b/Runtime/RHI/Lighting.h
@@ -12,6 +12,7 @@ namespace Sailor::RHI
 
 		uint32_t m_type = InvalidType;
 		uint32_t m_shadowType = 0u;
+		uint32_t m_activeCascadeCount = 1u;
 		alignas(16) glm::vec3 m_worldPosition{};
 		alignas(16) glm::vec3 m_direction{};
 		alignas(16) glm::vec3 m_intensity{};

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -157,6 +157,16 @@ Renderer::~Renderer()
 			Renderer::GetDriver()->WaitIdle();
 		}
 	}
+
+	// Submission contexts retain materials, pipelines, shader modules, and the
+	// Vulkan device that created them. Release every renderer-owned GPU resource
+	// before destroying the driver/Vulkan instance. Otherwise the last device
+	// reference can be released from a late shader-module destructor after the
+	// instance has already been destroyed (MoltenVK crashes in that ordering).
+	m_previousRenderFrame.Clear();
+	m_frameGraph.Clear();
+	m_cachedSceneViews.Clear();
+	m_submissionContexts.Clear();
 	m_driverInstance.Clear();
 }
 
@@ -247,6 +257,7 @@ void Renderer::BeginConditionalDestroy()
 		m_previousRenderFrame.Clear();
 		m_frameGraph.Clear();
 		m_cachedSceneViews.Clear();
+		m_submissionContexts.Clear();
 		return;
 	}
 
@@ -260,6 +271,7 @@ void Renderer::BeginConditionalDestroy()
 
 	m_frameGraph.Clear();
 	m_cachedSceneViews.Clear();
+	m_submissionContexts.Clear();
 	m_driverInstance->BeginConditionalDestroy();
 }
 
@@ -497,7 +509,9 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 		world->GetECS<AnimationECS>()->FillAnimationData(rhiSceneView);
 		world->GetECS<LightingECS>()->FillLightingData(rhiSceneView);
 		rhiSceneView->m_drawImGui = frame.GetDrawImGuiTask();
-		rhiSceneView->PrepareDebugDrawCommandLists(world);
+		rhiSceneView->PrepareDebugDrawCommandLists(
+			world,
+			rhiFrameGraph->GetSceneRenderExtent());
 		rhiSceneView->PrepareSnapshots();
 	}
 

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -22,6 +22,7 @@
 #include "ECS/LandscapeECS.h"
 #include "ECS/AnimationECS.h"
 #include "ECS/PathTracerECS.h"
+#include "Settings/GraphicsSettings.h"
 
 using namespace Sailor;
 using namespace Sailor::RHI;
@@ -549,7 +550,57 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 					RHISemaphorePtr chainSemaphore{};
 					const bool bCanRenderFrame = !m_bForceStop &&
 						(bHasSwapchainImage || App::HasEditor());
-					bool bFrameSubmitsSucceeded = m_bForceStop || updateFrameRHI(chainSemaphore);
+					bool bFrameSubmitsSucceeded = true;
+					bool bGpuFrameTimeQueryStarted = false;
+					if (bCanRenderFrame &&
+						App::GetRenderStatsMode() ==
+						Settings::ERenderStatsMode::RenderStatsAndQueries &&
+						m_driverInstance->SupportsGpuFrameTimeQueries())
+					{
+						auto queryBeginCommandList = m_driverInstance->CreateCommandList(
+							false,
+							RHI::ECommandListQueue::Graphics);
+						m_driverInstance->SetDebugName(
+							queryBeginCommandList,
+							"GpuFrameTime:Begin");
+						GetDriverCommands()->BeginCommandList(
+							queryBeginCommandList,
+							true);
+						bGpuFrameTimeQueryStarted =
+							m_driverInstance->BeginGpuFrameTimeQuery(
+								queryBeginCommandList);
+						GetDriverCommands()->EndCommandList(queryBeginCommandList);
+
+						if (bGpuFrameTimeQueryStarted)
+						{
+							auto signalSemaphore = GetDriver()->CreateWaitSemaphore();
+							auto fence = RHIFencePtr::Make();
+							GetDriver()->SetDebugName(
+								signalSemaphore,
+								"GpuFrameTime:Begin");
+							GetDriver()->SetDebugName(fence, "GpuFrameTime:Begin");
+							if (!GetDriver()->SubmitCommandList(
+								queryBeginCommandList,
+								fence,
+								signalSemaphore,
+								chainSemaphore))
+							{
+								GetDriver()->CancelGpuFrameTimeQuery();
+								bGpuFrameTimeQueryStarted = false;
+								bFrameSubmitsSucceeded = false;
+								SAILOR_LOG_ERROR("Renderer::PushFrame: failed to submit the GPU frame-time begin boundary.");
+							}
+							else
+							{
+								chainSemaphore = signalSemaphore;
+							}
+						}
+					}
+
+					if (bFrameSubmitsSucceeded && !m_bForceStop)
+					{
+						bFrameSubmitsSucceeded = updateFrameRHI(chainSemaphore);
+					}
 					DrawCallStats drawCallStats;
 
 					if (bFrameSubmitsSucceeded && bCanRenderFrame &&
@@ -558,7 +609,6 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 						if (!App::HasEditor())
 						{
 							rhiFrameGraph->SetRenderTarget("BackBuffer", m_driverInstance->GetBackBuffer());
-							rhiFrameGraph->SetRenderTarget("DepthBuffer", m_driverInstance->GetDepthBuffer());
 						}
 
 						RHISemaphorePtr frameGraphChainSemaphore = chainSemaphore;
@@ -601,6 +651,51 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 
 							chainSemaphore = signalSemaphore;
 							i++;
+						}
+					}
+
+					if (bGpuFrameTimeQueryStarted)
+					{
+						auto queryEndCommandList = m_driverInstance->CreateCommandList(
+							false,
+							RHI::ECommandListQueue::Graphics);
+						m_driverInstance->SetDebugName(
+							queryEndCommandList,
+							"GpuFrameTime:End");
+						GetDriverCommands()->BeginCommandList(
+							queryEndCommandList,
+							true);
+						m_driverInstance->EndGpuFrameTimeQuery(queryEndCommandList);
+						GetDriverCommands()->EndCommandList(queryEndCommandList);
+
+						if (bFrameSubmitsSucceeded)
+						{
+							primaryCommandLists.Add(queryEndCommandList);
+						}
+						else
+						{
+							auto signalSemaphore = GetDriver()->CreateWaitSemaphore();
+							auto fence = RHIFencePtr::Make();
+							GetDriver()->SetDebugName(
+								signalSemaphore,
+								"GpuFrameTime:EndAfterFailure");
+							GetDriver()->SetDebugName(
+								fence,
+								"GpuFrameTime:EndAfterFailure");
+							if (GetDriver()->SubmitCommandList(
+								queryEndCommandList,
+								fence,
+								signalSemaphore,
+								chainSemaphore))
+							{
+								GetDriver()->CommitGpuFrameTimeQuery();
+								chainSemaphore = signalSemaphore;
+							}
+							else
+							{
+								GetDriver()->CancelGpuFrameTimeQuery();
+								SAILOR_LOG_ERROR("Renderer::PushFrame: failed to submit the GPU frame-time end boundary after a frame failure.");
+							}
 						}
 					}
 

--- a/Runtime/RHI/Scene.h
+++ b/Runtime/RHI/Scene.h
@@ -162,8 +162,10 @@ namespace Sailor::RHI
 	class RHISceneVersion final : public RHIResource
 	{
 	public:
-		bool Resolve(RenderInstanceHandle handle, const RHISceneInstanceRecord*& outRecord) const;
-		bool HasShadowChangesIntersecting(
+		SAILOR_SHARED_API bool Resolve(
+			RenderInstanceHandle handle,
+			const RHISceneInstanceRecord*& outRecord) const;
+		SAILOR_SHARED_API bool HasShadowChangesIntersecting(
 			const RHISceneVersion& previousVersion,
 			const Math::Frustum& shadowFrustum) const;
 
@@ -204,14 +206,19 @@ namespace Sailor::RHI
 	class RHISceneRangeAllocator
 	{
 	public:
-		SceneRangeHandle Allocate(uint32_t count);
-		bool Resolve(SceneRangeHandle handle, PhysicalAllocation& outAllocation) const;
-		bool Retire(SceneRangeHandle handle, uint64_t retirementRevision);
-		void Collect(uint64_t minimumRetainedRevision);
+		SAILOR_SHARED_API SceneRangeHandle Allocate(uint32_t count);
+		SAILOR_SHARED_API bool Resolve(
+			SceneRangeHandle handle,
+			PhysicalAllocation& outAllocation) const;
+		SAILOR_SHARED_API bool Retire(
+			SceneRangeHandle handle,
+			uint64_t retirementRevision);
+		SAILOR_SHARED_API void Collect(uint64_t minimumRetainedRevision);
 		uint32_t GetBufferGeneration() const { return m_bufferGeneration; }
 		uint32_t GetCapacity() const { return m_capacity; }
 
-		static TVector<DirtySceneRange> CoalesceDirtyRanges(TVector<DirtySceneRange> ranges);
+		SAILOR_SHARED_API static TVector<DirtySceneRange> CoalesceDirtyRanges(
+			TVector<DirtySceneRange> ranges);
 
 	private:
 		struct RangeSlot
@@ -244,26 +251,31 @@ namespace Sailor::RHI
 	class RHIScene final : public RHIResource
 	{
 	public:
-		explicit RHIScene(uint32_t numFlightSlots = 2u);
+		SAILOR_SHARED_API explicit RHIScene(uint32_t numFlightSlots = 2u);
 
-		RenderInstanceHandle AddInstance(const RHISceneInstanceRecord& record);
-		bool UpdateInstance(
+		SAILOR_SHARED_API RenderInstanceHandle AddInstance(
+			const RHISceneInstanceRecord& record);
+		SAILOR_SHARED_API bool UpdateInstance(
 			RenderInstanceHandle handle,
 			const RHISceneInstanceRecord& record,
 			SceneChangeMask changeMask);
-		bool RemoveInstance(RenderInstanceHandle handle);
-		bool ResolveCurrent(RenderInstanceHandle handle, RHISceneInstanceRecord& outRecord) const;
+		SAILOR_SHARED_API bool RemoveInstance(RenderInstanceHandle handle);
+		SAILOR_SHARED_API bool ResolveCurrent(
+			RenderInstanceHandle handle,
+			RHISceneInstanceRecord& outRecord) const;
 
-		RHISceneVersionPtr PublishVersion(
+		SAILOR_SHARED_API RHISceneVersionPtr PublishVersion(
 			uint64_t materialRevision = 0ull,
 			uint64_t shadowRevision = 0ull,
 			uint64_t spatialRevision = 0ull);
-		RHISceneVersionPtr GetCurrentVersion() const;
-		RHISceneFlightStatePtr PrepareFlight(uint32_t flightSlot, RHISceneVersionPtr targetVersion);
-		void CollectGarbage();
+		SAILOR_SHARED_API RHISceneVersionPtr GetCurrentVersion() const;
+		SAILOR_SHARED_API RHISceneFlightStatePtr PrepareFlight(
+			uint32_t flightSlot,
+			RHISceneVersionPtr targetVersion);
+		SAILOR_SHARED_API void CollectGarbage();
 
 		uint64_t GetRevision() const { return m_revision; }
-		uint64_t GetJournalFirstRevision() const;
+		SAILOR_SHARED_API uint64_t GetJournalFirstRevision() const;
 		const RHISceneMetrics& GetMetrics() const { return m_metrics; }
 
 	private:

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -10,6 +10,7 @@
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "RHI/DebugContext.h"
 #include "RHI/CommandList.h"
+#include "Settings/GraphicsSettings.h"
 
 #include <algorithm>
 #include <array>
@@ -786,7 +787,14 @@ uint32_t RHI::RHILodPolicy::Resolve(float screenCoverage, uint32_t numAvailableL
 		}
 		selectedLod = static_cast<uint32_t>(index + 1u);
 	}
-	return (std::clamp)(selectedLod, minLod, maxLod);
+	const int32_t lodBias = App::GetInstance() ?
+		App::GetActiveGraphicsSettings().m_lodBias : 0;
+	return Settings::ApplyLodBias(
+		selectedLod,
+		numAvailableLods,
+		minLod,
+		maxLod,
+		lodBias);
 }
 
 namespace

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -817,7 +817,7 @@ namespace
 		return data.ResolveLod(screenCoverage, mesh->GetNumLods());
 	}
 
-	void ApplyCustomLodToMeshes(
+	[[maybe_unused]] void ApplyCustomLodToMeshes(
 		const RHILodPolicy& policy,
 		const Math::AABB& worldBounds,
 		const CameraData& camera,
@@ -842,7 +842,7 @@ namespace
 		}
 	}
 
-	void ApplyLodToMeshes(
+	[[maybe_unused]] void ApplyLodToMeshes(
 		const StaticMeshRendererData& data,
 		const Math::AABB& worldBounds,
 		const CameraData& camera,
@@ -865,7 +865,7 @@ namespace
 		}
 	}
 
-	RHIShadowCasterProxyPtr CreateLodShadowCaster(
+	[[maybe_unused]] RHIShadowCasterProxyPtr CreateLodShadowCaster(
 		const RHIShadowCasterProxyPtr& source,
 		WorldPtr world,
 		const CameraData& camera)

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -905,7 +905,9 @@ namespace
 	}
 }
 
-void RHISceneView::PrepareDebugDrawCommandLists(WorldPtr world)
+void RHISceneView::PrepareDebugDrawCommandLists(
+	WorldPtr world,
+	const glm::ivec2& renderExtent)
 {
 	m_debugDraw.Reserve(m_cameras.Num());
 	const DebugContext::DrawSnapshot debugDrawSnapshot = world->GetDebugContext()->GetDrawSnapshot();
@@ -921,7 +923,11 @@ void RHISceneView::PrepareDebugDrawCommandLists(WorldPtr world)
 				Sailor::RHI::Renderer::GetDriver()->SetDebugName(secondaryCmdList, "Draw Debug Mesh");
 				auto commands = App::GetSubmodule<Renderer>()->GetDriverCommands();
 				commands->BeginSecondaryCommandList(secondaryCmdList, false, true);
-				world->GetDebugContext()->DrawDebugMesh(secondaryCmdList, matrix, debugDrawSnapshot);
+				world->GetDebugContext()->DrawDebugMesh(
+					secondaryCmdList,
+					matrix,
+					debugDrawSnapshot,
+					renderExtent);
 				commands->EndCommandList(secondaryCmdList);
 
 				return secondaryCmdList;

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -416,7 +416,9 @@ namespace Sailor::RHI
 			const Math::Frustum& frustum,
 			TVector<RHIVisibleShadowCaster>& outVisibleCasters) const;
 		SAILOR_API void PrepareSnapshots();
-		SAILOR_API void PrepareDebugDrawCommandLists(WorldPtr world);
+		SAILOR_API void PrepareDebugDrawCommandLists(
+			WorldPtr world,
+			const glm::ivec2& renderExtent);
 		SAILOR_API void SetSubmissionContext(RHIRenderSubmissionContextPtr submissionContext);
 		SAILOR_API RHISubmissionCompletionTokenPtr GetOrCreateSubmissionCompletionToken();
 		SAILOR_API bool IsCurrentSubmissionCompletionToken(

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -55,6 +55,7 @@
 #include "Workspace/WorkspaceModuleManager.h"
 #include "Workspace/WorkspacePathEncoding.h"
 #include "YamlExceptionBoundary.h"
+#include <atomic>
 
 #if defined(_WIN32)
 #include <timeapi.h>
@@ -65,6 +66,12 @@ using namespace Sailor::RHI;
 
 App* App::s_pInstance = nullptr;
 std::string App::s_workspace = "../";
+
+namespace
+{
+	Settings::GraphicsSettingsState g_graphicsSettingsState{};
+	std::atomic<Settings::ERenderStatsMode> g_renderStatsMode{ Settings::ERenderStatsMode::None };
+}
 
 App::~App() = default;
 
@@ -82,6 +89,42 @@ const Workspace::WorkspaceContext& App::GetWorkspaceContext()
 {
 	check(s_pInstance);
 	return s_pInstance->m_workspaceContext;
+}
+
+const Settings::GraphicsSettings& App::GetGraphicsSettings()
+{
+	return g_graphicsSettingsState.m_projectSettings;
+}
+
+const Settings::GraphicsQualityProfile& App::GetActiveGraphicsSettings()
+{
+	return g_graphicsSettingsState.GetActiveProfile();
+}
+
+Settings::EGraphicsQualitySelection App::GetSelectedGraphicsQuality()
+{
+	return g_graphicsSettingsState.m_editorSettings.m_selectedQuality;
+}
+
+Settings::EGraphicsQuality App::GetActiveGraphicsQuality()
+{
+	return g_graphicsSettingsState.m_activeQuality;
+}
+
+Settings::ERenderStatsMode App::GetRenderStatsMode()
+{
+	return g_renderStatsMode.load(std::memory_order_acquire);
+}
+
+bool App::SetRenderStatsMode(Settings::ERenderStatsMode mode)
+{
+	if (!Settings::IsValidRenderStatsMode(mode))
+	{
+		return false;
+	}
+
+	g_renderStatsMode.store(mode, std::memory_order_release);
+	return true;
 }
 
 namespace
@@ -368,6 +411,8 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	}
 
 	EditorRuntime::ResetForAppLifecycle();
+	g_graphicsSettingsState = Settings::GraphicsSettingsState{};
+	g_renderStatsMode.store(Settings::ERenderStatsMode::None, std::memory_order_release);
 
 	{
 		const std::lock_guard<std::mutex> shutdownLock(g_engineShutdownMutex);
@@ -430,6 +475,43 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 		s_pInstance->s_workspace += "/";
 	}
 
+	g_graphicsSettingsState = Settings::LoadGraphicsSettings(
+		s_pInstance->m_workspaceContext,
+		params.m_bIsEditor);
+	g_renderStatsMode.store(
+		params.m_bIsEditor
+			? g_graphicsSettingsState.m_editorSettings.m_statsMode
+			: Settings::ERenderStatsMode::None,
+		std::memory_order_release);
+	if (g_graphicsSettingsState.m_projectLoadStatus == Settings::EGraphicsSettingsLoadStatus::Loaded ||
+		g_graphicsSettingsState.m_projectLoadStatus == Settings::EGraphicsSettingsLoadStatus::Missing)
+	{
+		SAILOR_LOG("%s", g_graphicsSettingsState.m_projectDiagnostic.c_str());
+	}
+	else
+	{
+		SAILOR_LOG_ERROR("%s", g_graphicsSettingsState.m_projectDiagnostic.c_str());
+	}
+	if (params.m_bIsEditor)
+	{
+		if (g_graphicsSettingsState.m_editorLoadStatus == Settings::EGraphicsSettingsLoadStatus::Loaded ||
+			g_graphicsSettingsState.m_editorLoadStatus == Settings::EGraphicsSettingsLoadStatus::Missing)
+		{
+			SAILOR_LOG("%s", g_graphicsSettingsState.m_editorDiagnostic.c_str());
+		}
+		else
+		{
+			SAILOR_LOG_ERROR("%s", g_graphicsSettingsState.m_editorDiagnostic.c_str());
+		}
+	}
+	SAILOR_LOG(
+		"Active graphics quality: %s (FPS cap %u, MSAA %ux, shadow bias %.3f, stats mode %s).",
+		Settings::ToString(g_graphicsSettingsState.m_activeQuality),
+		g_graphicsSettingsState.GetActiveProfile().m_fpsCap,
+		g_graphicsSettingsState.GetActiveProfile().m_msaaSamples,
+		g_graphicsSettingsState.GetActiveProfile().m_shadowBias,
+		Settings::ToString(GetRenderStatsMode()));
+
 	bool bWorkspaceModuleActivationFailed = false;
 	s_pInstance->m_pWorkspaceModuleManager = TUniquePtr<Workspace::WorkspaceModuleManager>::Make();
 	const auto& workspaceModuleResult = s_pInstance->m_pWorkspaceModuleManager->Load(
@@ -473,7 +555,16 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 		className = std::format("SailorEditor PID{}", ::GetCurrentThreadId());
 	}
 
-	s_pInstance->m_pMainWindow->Create(className.c_str(), className.c_str(), 1024, 768, false, false, params.m_editorHwnd);
+	// The editor renders continuously into an embedded viewport. Keep its hidden
+	// swapchain synchronized so an idle Scene View does not spin at uncapped FPS.
+	s_pInstance->m_pMainWindow->Create(
+		className.c_str(),
+		className.c_str(),
+		1024,
+		768,
+		false,
+		params.m_bIsEditor,
+		params.m_editorHwnd);
 
 #if defined(_WIN32)
 	if (params.m_bIsEditor)
@@ -490,7 +581,10 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	s_pInstance->AddSubmodule(TSubmodule<Tasks::Scheduler>::Make())->Initialize();
 	s_pInstance->AddSubmodule(TSubmodule<AudioSystem>::Make(params.m_bForceNullAudioDevice));
 	s_pInstance->AddSubmodule(TSubmodule<Physics::JoltRuntime>::Make());
-	auto renderer = s_pInstance->AddSubmodule(TSubmodule<Renderer>::Make(s_pInstance->m_pMainWindow.GetRawPtr(), RHI::EMsaaSamples::Samples_1, bEnableRenderValidationLayers));
+	auto renderer = s_pInstance->AddSubmodule(TSubmodule<Renderer>::Make(
+		s_pInstance->m_pMainWindow.GetRawPtr(),
+		Settings::ToMsaaSamples(GetActiveGraphicsSettings().m_msaaSamples),
+		bEnableRenderValidationLayers));
 	if (!renderer->IsInitialized())
 	{
 		SAILOR_LOG_ERROR("App initialization aborted: renderer backend failed to initialize.");
@@ -547,7 +641,8 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	}
 
 	s_pInstance->AddSubmodule(TSubmodule<ImGuiApi>::Make((void*)s_pInstance->m_pMainWindow->GetHWND()));
-	auto engineLoop = s_pInstance->AddSubmodule(TSubmodule<EngineLoop>::Make());
+	auto engineLoop = s_pInstance->AddSubmodule(TSubmodule<EngineLoop>::Make(
+		GetActiveGraphicsSettings().m_fpsCap));
 
 #ifdef SAILOR_EDITOR
 	AssetRegistry::WriteTextFile(AssetRegistry::GetCacheFolder() + "EngineTypes.yaml", Reflection::ExportEngineTypes());
@@ -1151,6 +1246,8 @@ void App::Shutdown()
 
 	delete s_pInstance;
 	s_pInstance = nullptr;
+	g_graphicsSettingsState = Settings::GraphicsSettingsState{};
+	g_renderStatsMode.store(Settings::ERenderStatsMode::None, std::memory_order_release);
 }
 
 bool App::IsRendererInitialized()

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -9,6 +9,7 @@
 #include "Platform/Win32/Window.h"
 #include "Containers/Containers.h"
 #include "Math/Math.h"
+#include "Settings/GraphicsSettings.h"
 #include "Workspace/WorkspaceContext.h"
 #include <functional>
 
@@ -52,6 +53,12 @@ namespace Sailor
 		SAILOR_API static App* GetInstance();
 		SAILOR_API static const std::string& GetWorkspace();
 		SAILOR_API static const Workspace::WorkspaceContext& GetWorkspaceContext();
+		SAILOR_API static const Settings::GraphicsSettings& GetGraphicsSettings();
+		SAILOR_API static const Settings::GraphicsQualityProfile& GetActiveGraphicsSettings();
+		SAILOR_API static Settings::EGraphicsQualitySelection GetSelectedGraphicsQuality();
+		SAILOR_API static Settings::EGraphicsQuality GetActiveGraphicsQuality();
+		SAILOR_API static Settings::ERenderStatsMode GetRenderStatsMode();
+		SAILOR_API static bool SetRenderStatsMode(Settings::ERenderStatsMode mode);
 
 		SAILOR_API static void Initialize(const char** commandLineArgs = nullptr, int32_t num = 0);
 		SAILOR_API static void Start();

--- a/Runtime/Settings/GraphicsSettings.cpp
+++ b/Runtime/Settings/GraphicsSettings.cpp
@@ -1,0 +1,1199 @@
+#include "Settings/GraphicsSettings.h"
+
+#include "RHI/Types.h"
+#include "Workspace/WorkspaceContext.h"
+#include "Workspace/WorkspacePathEncoding.h"
+#include "YamlExceptionBoundary.h"
+
+#include <algorithm>
+#include <charconv>
+#include <cmath>
+#include <fstream>
+#include <limits>
+#include <sstream>
+#include <system_error>
+#include <utility>
+#include <yaml-cpp/yaml.h>
+
+namespace
+{
+	using namespace Sailor;
+	using namespace Sailor::Settings;
+
+	constexpr std::array<EGraphicsQuality, NumGraphicsQualityPresets> GraphicsQualities
+	{
+		EGraphicsQuality::Ultra,
+		EGraphicsQuality::High,
+		EGraphicsQuality::Medium,
+		EGraphicsQuality::Low,
+		EGraphicsQuality::VeryLow
+	};
+
+	size_t QualityIndex(EGraphicsQuality quality) noexcept
+	{
+		switch (quality)
+		{
+		case EGraphicsQuality::Ultra: return 0u;
+		case EGraphicsQuality::High: return 1u;
+		case EGraphicsQuality::Medium: return 2u;
+		case EGraphicsQuality::Low: return 3u;
+		case EGraphicsQuality::VeryLow: return 4u;
+		default: return 1u;
+		}
+	}
+
+	GraphicsQualityProfile MakeProfile(
+		float resolutionFactor,
+		uint32_t fpsCap,
+		uint32_t msaaSamples,
+		ELightShadowQuality shadowQuality,
+		float shadowBias,
+		uint32_t shadowCascadeCount,
+		const std::array<uint32_t, MaxShadowCascades>& shadowCascadeResolutions,
+		bool bSupportSoftShadows,
+		float cloudsResolutionMultiplier,
+		uint32_t skyResolution,
+		int32_t lodBias)
+	{
+		GraphicsQualityProfile profile;
+		profile.m_resolutionFactor = resolutionFactor;
+		profile.m_fpsCap = fpsCap;
+		profile.m_msaaSamples = msaaSamples;
+		profile.m_shadowQuality = shadowQuality;
+		profile.m_shadowBias = shadowBias;
+		profile.m_shadowCascadeCount = shadowCascadeCount;
+		profile.m_shadowCascadeResolutions = shadowCascadeResolutions;
+		profile.m_bSupportSoftShadows = bSupportSoftShadows;
+		profile.m_cloudsResolutionMultiplier = cloudsResolutionMultiplier;
+		profile.m_skyResolution = skyResolution;
+		profile.m_lodBias = lodBias;
+		return profile;
+	}
+
+	std::string Quote(const std::string& value)
+	{
+		return "'" + value + "'";
+	}
+
+	std::string SourceLabel(const std::string& sourceName, const char* fallback)
+	{
+		return sourceName.empty() ? fallback : sourceName;
+	}
+
+	std::string InvalidField(
+		const std::string& source,
+		const std::string& fieldPath,
+		const std::string& requirement)
+	{
+		return source + " is invalid: field " + Quote(fieldPath) + " " + requirement + ".";
+	}
+
+	bool TryLoadSingleDocument(
+		const std::string& payload,
+		YAML::Node& outDocument,
+		std::string& outDiagnostic) noexcept
+	{
+		size_t documentCount = 0u;
+		if (!External::GuardYamlExceptions(
+				[&]()
+				{
+					auto documents = YAML::LoadAll(payload);
+					documentCount = documents.size();
+					if (documentCount == 1u)
+					{
+						outDocument = std::move(documents[0]);
+					}
+				},
+				outDiagnostic))
+		{
+			return false;
+		}
+		if (documentCount != 1u)
+		{
+			outDiagnostic = "expected exactly one YAML document, found " +
+				std::to_string(documentCount);
+			return false;
+		}
+		return true;
+	}
+
+	YAML::Node FindField(const YAML::Node& document, const char* fieldName)
+	{
+		if (!document.IsMap())
+		{
+			return YAML::Node(YAML::NodeType::Undefined);
+		}
+
+		for (const auto& field : document)
+		{
+			if (field.first.IsScalar() && field.first.Scalar() == fieldName)
+			{
+				return field.second;
+			}
+		}
+
+		return YAML::Node(YAML::NodeType::Undefined);
+	}
+
+	bool ValidateMap(
+		const YAML::Node& document,
+		const std::string& source,
+		const std::string& fieldPath,
+		std::string& outDiagnostic)
+	{
+		if (!document.IsMap())
+		{
+			outDiagnostic = fieldPath.empty()
+				? source + " is invalid: the document root must be a map."
+				: InvalidField(source, fieldPath, "must be a map");
+			return false;
+		}
+
+		size_t fieldIndex = 0u;
+		for (const auto& field : document)
+		{
+			if (!field.first.IsScalar() || field.first.Scalar().empty())
+			{
+				outDiagnostic = fieldPath.empty()
+					? source + " is invalid: the document contains an empty or non-scalar field name."
+					: InvalidField(source, fieldPath, "contains an empty or non-scalar field name");
+				return false;
+			}
+
+			const std::string key = field.first.Scalar();
+			size_t previousIndex = 0u;
+			for (const auto& previousField : document)
+			{
+				if (previousIndex++ >= fieldIndex)
+				{
+					break;
+				}
+				if (previousField.first.IsScalar() && previousField.first.Scalar() == key)
+				{
+					const std::string duplicatePath = fieldPath.empty() ? key : fieldPath + "." + key;
+					outDiagnostic = InvalidField(source, duplicatePath, "is duplicated");
+					return false;
+				}
+			}
+			++fieldIndex;
+		}
+
+		return true;
+	}
+
+	bool ReadMap(
+		const YAML::Node& parent,
+		const char* fieldName,
+		const std::string& source,
+		const std::string& fieldPath,
+		YAML::Node& outValue,
+		std::string& outDiagnostic)
+	{
+		outValue = FindField(parent, fieldName);
+		if (!outValue.IsDefined())
+		{
+			outDiagnostic = InvalidField(source, fieldPath, "is required and must be a map");
+			return false;
+		}
+		return ValidateMap(outValue, source, fieldPath, outDiagnostic);
+	}
+
+	bool ReadScalar(
+		const YAML::Node& parent,
+		const char* fieldName,
+		const std::string& source,
+		const std::string& fieldPath,
+		YAML::Node& outValue,
+		std::string& outDiagnostic)
+	{
+		outValue = FindField(parent, fieldName);
+		if (!outValue.IsDefined() || !outValue.IsScalar())
+		{
+			outDiagnostic = InvalidField(source, fieldPath, "is required and must be a scalar");
+			return false;
+		}
+		return true;
+	}
+
+	bool ReadUint32(
+		const YAML::Node& parent,
+		const char* fieldName,
+		const std::string& source,
+		const std::string& fieldPath,
+		uint32_t& outValue,
+		std::string& outDiagnostic)
+	{
+		YAML::Node field;
+		if (!ReadScalar(parent, fieldName, source, fieldPath, field, outDiagnostic))
+		{
+			return false;
+		}
+
+		const std::string scalar = field.Scalar();
+		const char* begin = scalar.data();
+		const char* end = begin + scalar.size();
+		const auto parsed = std::from_chars(begin, end, outValue);
+		if (scalar.empty() || parsed.ec != std::errc() || parsed.ptr != end)
+		{
+			outDiagnostic = InvalidField(source, fieldPath, "must be an unsigned 32-bit integer");
+			return false;
+		}
+		return true;
+	}
+
+	bool ReadInt32(
+		const YAML::Node& parent,
+		const char* fieldName,
+		const std::string& source,
+		const std::string& fieldPath,
+		int32_t& outValue,
+		std::string& outDiagnostic)
+	{
+		YAML::Node field;
+		if (!ReadScalar(parent, fieldName, source, fieldPath, field, outDiagnostic))
+		{
+			return false;
+		}
+
+		const std::string scalar = field.Scalar();
+		const char* begin = scalar.data();
+		const char* end = begin + scalar.size();
+		if (begin != end && *begin == '+')
+		{
+			++begin;
+		}
+		const auto parsed = std::from_chars(begin, end, outValue);
+		if (begin == end || parsed.ec != std::errc() || parsed.ptr != end)
+		{
+			outDiagnostic = InvalidField(source, fieldPath, "must be a signed 32-bit integer");
+			return false;
+		}
+		return true;
+	}
+
+	template<typename TValue>
+	bool ReadConvertedScalar(
+		const YAML::Node& parent,
+		const char* fieldName,
+		const std::string& source,
+		const std::string& fieldPath,
+		const char* expectedType,
+		TValue& outValue,
+		std::string& outDiagnostic)
+	{
+		YAML::Node field;
+		if (!ReadScalar(parent, fieldName, source, fieldPath, field, outDiagnostic))
+		{
+			return false;
+		}
+
+		std::string yamlDiagnostic;
+		if (!External::TryConvertYaml(field, outValue, yamlDiagnostic))
+		{
+			outDiagnostic = InvalidField(source, fieldPath, std::string("must be ") + expectedType);
+			if (!yamlDiagnostic.empty())
+			{
+				outDiagnostic += " YAML detail: " + yamlDiagnostic;
+			}
+			return false;
+		}
+		return true;
+	}
+
+	bool ReadString(
+		const YAML::Node& parent,
+		const char* fieldName,
+		const std::string& source,
+		const std::string& fieldPath,
+		std::string& outValue,
+		std::string& outDiagnostic)
+	{
+		YAML::Node field;
+		if (!ReadScalar(parent, fieldName, source, fieldPath, field, outDiagnostic))
+		{
+			return false;
+		}
+
+		outValue = field.Scalar();
+		if (outValue.empty())
+		{
+			outDiagnostic = InvalidField(source, fieldPath, "cannot be empty");
+			return false;
+		}
+		return true;
+	}
+
+	bool ParseQuality(const std::string& value, EGraphicsQuality& outQuality) noexcept
+	{
+		if (value == "Ultra") outQuality = EGraphicsQuality::Ultra;
+		else if (value == "High") outQuality = EGraphicsQuality::High;
+		else if (value == "Medium") outQuality = EGraphicsQuality::Medium;
+		else if (value == "Low") outQuality = EGraphicsQuality::Low;
+		else if (value == "VeryLow") outQuality = EGraphicsQuality::VeryLow;
+		else return false;
+		return true;
+	}
+
+	bool ParseQualitySelection(
+		const std::string& value,
+		EGraphicsQualitySelection& outSelection) noexcept
+	{
+		if (value == "ProjectDefault") outSelection = EGraphicsQualitySelection::ProjectDefault;
+		else if (value == "Ultra") outSelection = EGraphicsQualitySelection::Ultra;
+		else if (value == "High") outSelection = EGraphicsQualitySelection::High;
+		else if (value == "Medium") outSelection = EGraphicsQualitySelection::Medium;
+		else if (value == "Low") outSelection = EGraphicsQualitySelection::Low;
+		else if (value == "VeryLow") outSelection = EGraphicsQualitySelection::VeryLow;
+		else return false;
+		return true;
+	}
+
+	bool ParseShadowQuality(
+		const std::string& value,
+		ELightShadowQuality& outQuality) noexcept
+	{
+		if (value == "High") outQuality = ELightShadowQuality::High;
+		else if (value == "Medium") outQuality = ELightShadowQuality::Medium;
+		else if (value == "Low") outQuality = ELightShadowQuality::Low;
+		else if (value == "VeryLow") outQuality = ELightShadowQuality::VeryLow;
+		else return false;
+		return true;
+	}
+
+	bool ParseStatsMode(const std::string& value, ERenderStatsMode& outMode) noexcept
+	{
+		if (value == "None") outMode = ERenderStatsMode::None;
+		else if (value == "RenderStats") outMode = ERenderStatsMode::RenderStats;
+		else if (value == "RenderStatsAndQueries") outMode = ERenderStatsMode::RenderStatsAndQueries;
+		else return false;
+		return true;
+	}
+
+	bool IsPowerOfTwo(uint32_t value) noexcept
+	{
+		return value != 0u && (value & (value - 1u)) == 0u;
+	}
+
+	bool ReadProfile(
+		const YAML::Node& presets,
+		EGraphicsQuality quality,
+		const std::string& source,
+		GraphicsQualityProfile& outProfile,
+		std::string& outDiagnostic)
+	{
+		const char* qualityName = ToString(quality);
+		const std::string profilePath = "graphics.presets." + std::string(qualityName);
+		YAML::Node profile;
+		if (!ReadMap(presets, qualityName, source, profilePath, profile, outDiagnostic))
+		{
+			return false;
+		}
+
+		if (!ReadConvertedScalar(
+				profile,
+				"resolutionFactor",
+				source,
+				profilePath + ".resolutionFactor",
+				"a finite number",
+				outProfile.m_resolutionFactor,
+				outDiagnostic) ||
+			!std::isfinite(outProfile.m_resolutionFactor) ||
+			outProfile.m_resolutionFactor < 0.25f ||
+			outProfile.m_resolutionFactor > 2.0f)
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(
+					source,
+					profilePath + ".resolutionFactor",
+					"must be a finite number in the range [0.25, 2.0]");
+			}
+			return false;
+		}
+
+		if (!ReadUint32(
+				profile,
+				"fpsCap",
+				source,
+				profilePath + ".fpsCap",
+				outProfile.m_fpsCap,
+				outDiagnostic) ||
+			outProfile.m_fpsCap < 1u ||
+			outProfile.m_fpsCap > 1000u)
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(
+					source,
+					profilePath + ".fpsCap",
+					"must be in the range [1, 1000]");
+			}
+			return false;
+		}
+
+		if (!ReadUint32(
+				profile,
+				"msaaSamples",
+				source,
+				profilePath + ".msaaSamples",
+				outProfile.m_msaaSamples,
+				outDiagnostic) ||
+			(outProfile.m_msaaSamples != 1u &&
+				outProfile.m_msaaSamples != 2u &&
+				outProfile.m_msaaSamples != 4u &&
+				outProfile.m_msaaSamples != 8u))
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(
+					source,
+					profilePath + ".msaaSamples",
+					"must be one of 1, 2, 4, or 8");
+			}
+			return false;
+		}
+
+		std::string shadowQuality;
+		if (!ReadString(
+				profile,
+				"shadowQuality",
+				source,
+				profilePath + ".shadowQuality",
+				shadowQuality,
+				outDiagnostic) ||
+			!ParseShadowQuality(shadowQuality, outProfile.m_shadowQuality))
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(
+					source,
+					profilePath + ".shadowQuality",
+					"must be one of High, Medium, Low, or VeryLow");
+			}
+			return false;
+		}
+
+		if (!ReadConvertedScalar(
+				profile,
+				"shadowBias",
+				source,
+				profilePath + ".shadowBias",
+				"a finite number",
+				outProfile.m_shadowBias,
+				outDiagnostic) ||
+			!std::isfinite(outProfile.m_shadowBias) ||
+			outProfile.m_shadowBias < -16.0f ||
+			outProfile.m_shadowBias > 16.0f)
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(
+					source,
+					profilePath + ".shadowBias",
+					"must be a finite number in the range [-16, 16]");
+			}
+			return false;
+		}
+
+		if (!ReadUint32(
+				profile,
+				"shadowCascadeCount",
+				source,
+				profilePath + ".shadowCascadeCount",
+				outProfile.m_shadowCascadeCount,
+				outDiagnostic) ||
+			outProfile.m_shadowCascadeCount < 1u ||
+			outProfile.m_shadowCascadeCount > MaxShadowCascades)
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(
+					source,
+					profilePath + ".shadowCascadeCount",
+					"must be in the range [1, 4]");
+			}
+			return false;
+		}
+
+		const std::string cascadePath = profilePath + ".shadowCascadeResolutions";
+		const YAML::Node cascadeResolutions = FindField(profile, "shadowCascadeResolutions");
+		if (!cascadeResolutions.IsDefined() || !cascadeResolutions.IsSequence() ||
+			cascadeResolutions.size() != outProfile.m_shadowCascadeCount)
+		{
+			outDiagnostic = InvalidField(
+				source,
+				cascadePath,
+				"must be a sequence whose length matches shadowCascadeCount");
+			return false;
+		}
+
+		outProfile.m_shadowCascadeResolutions.fill(0u);
+		for (uint32_t index = 0u; index < outProfile.m_shadowCascadeCount; ++index)
+		{
+			const YAML::Node resolution = cascadeResolutions[index];
+			const std::string resolutionPath = cascadePath + "[" + std::to_string(index) + "]";
+			if (!resolution.IsScalar())
+			{
+				outDiagnostic = InvalidField(source, resolutionPath, "must be an unsigned integer");
+				return false;
+			}
+
+			const std::string scalar = resolution.Scalar();
+			uint32_t parsedResolution = 0u;
+			const char* begin = scalar.data();
+			const char* end = begin + scalar.size();
+			const auto parsed = std::from_chars(begin, end, parsedResolution);
+			if (scalar.empty() || parsed.ec != std::errc() || parsed.ptr != end ||
+				parsedResolution < 32u || parsedResolution > 8192u ||
+				!IsPowerOfTwo(parsedResolution))
+			{
+				outDiagnostic = InvalidField(
+					source,
+					resolutionPath,
+					"must be a power of two in the range [32, 8192]");
+				return false;
+			}
+			outProfile.m_shadowCascadeResolutions[index] = parsedResolution;
+		}
+
+		if (!ReadConvertedScalar(
+				profile,
+				"supportSoftShadows",
+				source,
+				profilePath + ".supportSoftShadows",
+				"a boolean",
+				outProfile.m_bSupportSoftShadows,
+				outDiagnostic))
+		{
+			return false;
+		}
+
+		if (!ReadConvertedScalar(
+				profile,
+				"cloudsResolutionMultiplier",
+				source,
+				profilePath + ".cloudsResolutionMultiplier",
+				"a finite number",
+				outProfile.m_cloudsResolutionMultiplier,
+				outDiagnostic) ||
+			!std::isfinite(outProfile.m_cloudsResolutionMultiplier) ||
+			outProfile.m_cloudsResolutionMultiplier < 0.0625f ||
+			outProfile.m_cloudsResolutionMultiplier > 2.0f)
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(
+					source,
+					profilePath + ".cloudsResolutionMultiplier",
+					"must be a finite number in the range [0.0625, 2.0]");
+			}
+			return false;
+		}
+
+		if (!ReadUint32(
+				profile,
+				"skyResolution",
+				source,
+				profilePath + ".skyResolution",
+				outProfile.m_skyResolution,
+				outDiagnostic) ||
+			outProfile.m_skyResolution < 32u ||
+			outProfile.m_skyResolution > 8192u ||
+			!IsPowerOfTwo(outProfile.m_skyResolution))
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(
+					source,
+					profilePath + ".skyResolution",
+					"must be a power of two in the range [32, 8192]");
+			}
+			return false;
+		}
+
+		if (!ReadInt32(
+				profile,
+				"lodBias",
+				source,
+				profilePath + ".lodBias",
+				outProfile.m_lodBias,
+				outDiagnostic) ||
+			outProfile.m_lodBias < -8 || outProfile.m_lodBias > 8)
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(
+					source,
+					profilePath + ".lodBias",
+					"must be in the range [-8, 8]");
+			}
+			return false;
+		}
+
+		return true;
+	}
+
+	uint32_t ScaleDimension(uint32_t dimension, float scale) noexcept
+	{
+		if (dimension == 0u || !std::isfinite(scale) || scale <= 0.0f)
+		{
+			return 1u;
+		}
+
+		const double scaled = static_cast<double>(dimension) * static_cast<double>(scale);
+		if (!std::isfinite(scaled) || scaled >= static_cast<double>((std::numeric_limits<uint32_t>::max)()))
+		{
+			return (std::numeric_limits<uint32_t>::max)();
+		}
+		return (std::max)(1u, static_cast<uint32_t>(std::floor(scaled + 0.5)));
+	}
+
+	enum class EFileReadStatus : uint8_t
+	{
+		Loaded,
+		Missing,
+		IoFailure
+	};
+
+	EFileReadStatus ReadTextFile(
+		const std::filesystem::path& path,
+		std::string& outPayload,
+		std::string& outDiagnostic)
+	{
+		outPayload.clear();
+		outDiagnostic.clear();
+		const std::string pathString = Workspace::PathToUtf8(path);
+		std::error_code fileError;
+		const bool bExists = std::filesystem::exists(path, fileError);
+		if (fileError)
+		{
+			outDiagnostic = "Cannot inspect settings file " + Quote(pathString) + ": " + fileError.message() + ".";
+			return EFileReadStatus::IoFailure;
+		}
+		if (!bExists)
+		{
+			outDiagnostic = "Settings file " + Quote(pathString) + " is missing; using built-in defaults.";
+			return EFileReadStatus::Missing;
+		}
+
+		if (!std::filesystem::is_regular_file(path, fileError) || fileError)
+		{
+			outDiagnostic = "Settings path " + Quote(pathString) + " is not a readable regular file";
+			if (fileError)
+			{
+				outDiagnostic += ": " + fileError.message();
+			}
+			outDiagnostic += ".";
+			return EFileReadStatus::IoFailure;
+		}
+
+		std::ifstream input(path, std::ios::binary);
+		if (!input.is_open())
+		{
+			outDiagnostic = "Cannot open settings file " + Quote(pathString) + ".";
+			return EFileReadStatus::IoFailure;
+		}
+
+		std::ostringstream buffer;
+		buffer << input.rdbuf();
+		if (input.bad())
+		{
+			outDiagnostic = "Cannot read settings file " + Quote(pathString) + ".";
+			return EFileReadStatus::IoFailure;
+		}
+		outPayload = buffer.str();
+		return EFileReadStatus::Loaded;
+	}
+}
+
+Sailor::Settings::GraphicsSettings::GraphicsSettings()
+{
+	m_presets[QualityIndex(EGraphicsQuality::Ultra)] = MakeProfile(
+		1.0f,
+		120u,
+		8u,
+		ELightShadowQuality::High,
+		0.0f,
+		4u,
+		{ 4096u, 2048u, 2048u, 1024u },
+		true,
+		1.0f,
+		512u,
+		-1);
+	m_presets[QualityIndex(EGraphicsQuality::High)] = MakeProfile(
+		1.0f,
+		120u,
+		4u,
+		ELightShadowQuality::High,
+		0.0f,
+		4u,
+		{ 2048u, 2048u, 1024u, 1024u },
+		true,
+		0.75f,
+		256u,
+		0);
+	m_presets[QualityIndex(EGraphicsQuality::Medium)] = MakeProfile(
+		0.85f,
+		120u,
+		2u,
+		ELightShadowQuality::Medium,
+		0.0f,
+		3u,
+		{ 2048u, 1024u, 512u, 0u },
+		true,
+		0.5f,
+		256u,
+		0);
+	m_presets[QualityIndex(EGraphicsQuality::Low)] = MakeProfile(
+		0.7f,
+		120u,
+		1u,
+		ELightShadowQuality::Low,
+		0.0f,
+		2u,
+		{ 1024u, 512u, 0u, 0u },
+		false,
+		0.25f,
+		128u,
+		1);
+	m_presets[QualityIndex(EGraphicsQuality::VeryLow)] = MakeProfile(
+		0.5f,
+		120u,
+		1u,
+		ELightShadowQuality::VeryLow,
+		0.0f,
+		1u,
+		{ 512u, 0u, 0u, 0u },
+		false,
+		0.125f,
+		64u,
+		2);
+}
+
+bool Sailor::Settings::GraphicsQualityProfile::IsShadowCascadeActive(
+	uint32_t cascadeIndex) const noexcept
+{
+	return cascadeIndex < m_shadowCascadeCount && cascadeIndex < MaxShadowCascades;
+}
+
+uint32_t Sailor::Settings::GraphicsQualityProfile::GetShadowCascadeResolution(
+	uint32_t cascadeIndex) const noexcept
+{
+	return IsShadowCascadeActive(cascadeIndex) ? m_shadowCascadeResolutions[cascadeIndex] : 0u;
+}
+
+const Sailor::Settings::GraphicsQualityProfile& Sailor::Settings::GraphicsSettings::GetProfile(
+	EGraphicsQuality quality) const noexcept
+{
+	return m_presets[QualityIndex(quality)];
+}
+
+const Sailor::Settings::GraphicsQualityProfile& Sailor::Settings::GraphicsSettingsState::GetActiveProfile() const noexcept
+{
+	return m_projectSettings.GetProfile(m_activeQuality);
+}
+
+const char* Sailor::Settings::ToString(EGraphicsQuality quality) noexcept
+{
+	switch (quality)
+	{
+	case EGraphicsQuality::Ultra: return "Ultra";
+	case EGraphicsQuality::High: return "High";
+	case EGraphicsQuality::Medium: return "Medium";
+	case EGraphicsQuality::Low: return "Low";
+	case EGraphicsQuality::VeryLow: return "VeryLow";
+	default: return "High";
+	}
+}
+
+const char* Sailor::Settings::ToString(EGraphicsQualitySelection selection) noexcept
+{
+	switch (selection)
+	{
+	case EGraphicsQualitySelection::ProjectDefault: return "ProjectDefault";
+	case EGraphicsQualitySelection::Ultra: return "Ultra";
+	case EGraphicsQualitySelection::High: return "High";
+	case EGraphicsQualitySelection::Medium: return "Medium";
+	case EGraphicsQualitySelection::Low: return "Low";
+	case EGraphicsQualitySelection::VeryLow: return "VeryLow";
+	default: return "ProjectDefault";
+	}
+}
+
+const char* Sailor::Settings::ToString(ERenderStatsMode mode) noexcept
+{
+	switch (mode)
+	{
+	case ERenderStatsMode::None: return "None";
+	case ERenderStatsMode::RenderStats: return "RenderStats";
+	case ERenderStatsMode::RenderStatsAndQueries: return "RenderStatsAndQueries";
+	default: return "None";
+	}
+}
+
+bool Sailor::Settings::IsValidRenderStatsMode(ERenderStatsMode mode) noexcept
+{
+	return mode == ERenderStatsMode::None ||
+		mode == ERenderStatsMode::RenderStats ||
+		mode == ERenderStatsMode::RenderStatsAndQueries;
+}
+
+Sailor::Settings::EGraphicsQuality Sailor::Settings::ResolveQualitySelection(
+	EGraphicsQualitySelection selection,
+	EGraphicsQuality projectDefault) noexcept
+{
+	switch (selection)
+	{
+	case EGraphicsQualitySelection::Ultra: return EGraphicsQuality::Ultra;
+	case EGraphicsQualitySelection::High: return EGraphicsQuality::High;
+	case EGraphicsQualitySelection::Medium: return EGraphicsQuality::Medium;
+	case EGraphicsQualitySelection::Low: return EGraphicsQuality::Low;
+	case EGraphicsQualitySelection::VeryLow: return EGraphicsQuality::VeryLow;
+	case EGraphicsQualitySelection::ProjectDefault:
+	default:
+		return projectDefault;
+	}
+}
+
+Sailor::RHI::EMsaaSamples Sailor::Settings::ToMsaaSamples(uint32_t samples) noexcept
+{
+	switch (samples)
+	{
+	case 2u: return RHI::EMsaaSamples::Samples_2;
+	case 4u: return RHI::EMsaaSamples::Samples_4;
+	case 8u: return RHI::EMsaaSamples::Samples_8;
+	case 1u:
+	default:
+		return RHI::EMsaaSamples::Samples_1;
+	}
+}
+
+Sailor::Settings::GraphicsExtent Sailor::Settings::ResolveRenderDimensions(
+	uint32_t outputWidth,
+	uint32_t outputHeight,
+	float resolutionFactor) noexcept
+{
+	return
+	{
+		ScaleDimension(outputWidth, resolutionFactor),
+		ScaleDimension(outputHeight, resolutionFactor)
+	};
+}
+
+Sailor::Settings::GraphicsExtent Sailor::Settings::ResolveSkyExtent(
+	const GraphicsQualityProfile& profile) noexcept
+{
+	const uint32_t resolution = (std::max)(1u, profile.m_skyResolution);
+	return { resolution, resolution };
+}
+
+Sailor::Settings::GraphicsExtent Sailor::Settings::ResolveCloudsExtent(
+	uint32_t renderWidth,
+	uint32_t renderHeight,
+	const GraphicsQualityProfile& profile,
+	float platformMultiplier) noexcept
+{
+	const uint32_t shortestDimension = (std::min)(renderWidth, renderHeight);
+	const float scale = profile.m_cloudsResolutionMultiplier * platformMultiplier;
+	const uint32_t resolution = ScaleDimension(shortestDimension, scale);
+	return { resolution, resolution };
+}
+
+Sailor::ELightShadowQuality Sailor::Settings::ApplyShadowQualityCap(
+	ELightShadowQuality authoredQuality,
+	ELightShadowQuality qualityCap) noexcept
+{
+	const uint8_t highestQuality = static_cast<uint8_t>(ELightShadowQuality::High);
+	const uint8_t authored = (std::min)(static_cast<uint8_t>(authoredQuality), highestQuality);
+	const uint8_t cap = (std::min)(static_cast<uint8_t>(qualityCap), highestQuality);
+	return static_cast<ELightShadowQuality>((std::min)(authored, cap));
+}
+
+uint32_t Sailor::Settings::ApplyLodBias(
+	uint32_t selectedLod,
+	uint32_t numAvailableLods,
+	uint32_t authoredMinLod,
+	uint32_t authoredMaxLod,
+	int32_t lodBias) noexcept
+{
+	if (numAvailableLods == 0u)
+	{
+		return 0u;
+	}
+
+	const uint32_t highestAvailableLod = numAvailableLods - 1u;
+	const uint32_t minLod = (std::min)(authoredMinLod, highestAvailableLod);
+	const uint32_t maxLod = (std::max)(minLod, (std::min)(authoredMaxLod, highestAvailableLod));
+	const int64_t selected = static_cast<int64_t>((std::clamp)(selectedLod, minLod, maxLod));
+	const int64_t biased = selected + static_cast<int64_t>(lodBias);
+	return static_cast<uint32_t>((std::clamp)(
+		biased,
+		static_cast<int64_t>(minLod),
+		static_cast<int64_t>(maxLod)));
+}
+
+Sailor::Settings::ProjectGraphicsSettingsLoadResult Sailor::Settings::ParseProjectGraphicsSettings(
+	const std::string& payload,
+	const std::string& sourceName) noexcept
+{
+	ProjectGraphicsSettingsLoadResult result;
+	const std::string source = SourceLabel(sourceName, "ProjectSettings.yaml");
+	YAML::Node document;
+	std::string yamlDiagnostic;
+	if (!TryLoadSingleDocument(payload, document, yamlDiagnostic))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		result.m_diagnostic = source + " is invalid YAML: " + yamlDiagnostic;
+		return result;
+	}
+
+	if (!ValidateMap(document, source, {}, result.m_diagnostic))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		return result;
+	}
+
+	GraphicsSettings parsedSettings;
+	if (!ReadUint32(
+			document,
+			"settingsVersion",
+			source,
+			"settingsVersion",
+			parsedSettings.m_version,
+			result.m_diagnostic))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		return result;
+	}
+	if (parsedSettings.m_version != GraphicsSettingsVersion)
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::UnsupportedVersion;
+		result.m_diagnostic = source + " has unsupported settingsVersion (expected " +
+			Quote(std::to_string(GraphicsSettingsVersion)) + ", actual " +
+			Quote(std::to_string(parsedSettings.m_version)) + "); using built-in defaults.";
+		return result;
+	}
+
+	YAML::Node graphics;
+	if (!ReadMap(document, "graphics", source, "graphics", graphics, result.m_diagnostic))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		return result;
+	}
+
+	std::string defaultQuality;
+	if (!ReadString(
+			graphics,
+			"defaultQuality",
+			source,
+			"graphics.defaultQuality",
+			defaultQuality,
+			result.m_diagnostic) ||
+		!ParseQuality(defaultQuality, parsedSettings.m_defaultQuality))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		if (result.m_diagnostic.empty())
+		{
+			result.m_diagnostic = InvalidField(
+				source,
+				"graphics.defaultQuality",
+				"must be one of Ultra, High, Medium, Low, or VeryLow");
+		}
+		return result;
+	}
+
+	YAML::Node presets;
+	if (!ReadMap(graphics, "presets", source, "graphics.presets", presets, result.m_diagnostic))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		return result;
+	}
+
+	for (EGraphicsQuality quality : GraphicsQualities)
+	{
+		if (!ReadProfile(
+				presets,
+				quality,
+				source,
+				parsedSettings.m_presets[QualityIndex(quality)],
+				result.m_diagnostic))
+		{
+			result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+			return result;
+		}
+	}
+
+	result.m_settings = std::move(parsedSettings);
+	result.m_status = EGraphicsSettingsLoadStatus::Loaded;
+	result.m_diagnostic = "Loaded " + source + ".";
+	return result;
+}
+
+Sailor::Settings::EditorGraphicsSettingsLoadResult Sailor::Settings::ParseEditorGraphicsSettings(
+	const std::string& payload,
+	const std::string& sourceName) noexcept
+{
+	EditorGraphicsSettingsLoadResult result;
+	const std::string source = SourceLabel(sourceName, "EditorSettings.yaml");
+	YAML::Node document;
+	std::string yamlDiagnostic;
+	if (!TryLoadSingleDocument(payload, document, yamlDiagnostic))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		result.m_diagnostic = source + " is invalid YAML: " + yamlDiagnostic;
+		return result;
+	}
+
+	if (!ValidateMap(document, source, {}, result.m_diagnostic))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		return result;
+	}
+
+	EditorGraphicsSettings parsedSettings;
+	if (!ReadUint32(
+			document,
+			"settingsVersion",
+			source,
+			"settingsVersion",
+			parsedSettings.m_version,
+			result.m_diagnostic))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		return result;
+	}
+	if (parsedSettings.m_version != GraphicsSettingsVersion)
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::UnsupportedVersion;
+		result.m_diagnostic = source + " has unsupported settingsVersion (expected " +
+			Quote(std::to_string(GraphicsSettingsVersion)) + ", actual " +
+			Quote(std::to_string(parsedSettings.m_version)) + "); using editor defaults.";
+		return result;
+	}
+
+	YAML::Node graphics;
+	if (!ReadMap(document, "graphics", source, "graphics", graphics, result.m_diagnostic))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		return result;
+	}
+
+	std::string selectedQuality;
+	if (!ReadString(
+			graphics,
+			"selectedQuality",
+			source,
+			"graphics.selectedQuality",
+			selectedQuality,
+			result.m_diagnostic) ||
+		!ParseQualitySelection(selectedQuality, parsedSettings.m_selectedQuality))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		if (result.m_diagnostic.empty())
+		{
+			result.m_diagnostic = InvalidField(
+				source,
+				"graphics.selectedQuality",
+				"must be one of ProjectDefault, Ultra, High, Medium, Low, or VeryLow");
+		}
+		return result;
+	}
+
+	std::string statsMode;
+	if (!ReadString(
+			graphics,
+			"statsMode",
+			source,
+			"graphics.statsMode",
+			statsMode,
+			result.m_diagnostic) ||
+		!ParseStatsMode(statsMode, parsedSettings.m_statsMode))
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
+		if (result.m_diagnostic.empty())
+		{
+			result.m_diagnostic = InvalidField(
+				source,
+				"graphics.statsMode",
+				"must be one of None, RenderStats, or RenderStatsAndQueries");
+		}
+		return result;
+	}
+
+	result.m_settings = parsedSettings;
+	result.m_status = EGraphicsSettingsLoadStatus::Loaded;
+	result.m_diagnostic = "Loaded " + source + ".";
+	return result;
+}
+
+Sailor::Settings::ProjectGraphicsSettingsLoadResult Sailor::Settings::LoadProjectGraphicsSettings(
+	const std::filesystem::path& path) noexcept
+{
+	ProjectGraphicsSettingsLoadResult result;
+	std::string payload;
+	const EFileReadStatus readStatus = ReadTextFile(path, payload, result.m_diagnostic);
+	if (readStatus == EFileReadStatus::Missing)
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Missing;
+		return result;
+	}
+	if (readStatus == EFileReadStatus::IoFailure)
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::IoFailure;
+		return result;
+	}
+	return ParseProjectGraphicsSettings(payload, "Project settings " + Quote(Workspace::PathToUtf8(path)));
+}
+
+Sailor::Settings::EditorGraphicsSettingsLoadResult Sailor::Settings::LoadEditorGraphicsSettings(
+	const std::filesystem::path& path) noexcept
+{
+	EditorGraphicsSettingsLoadResult result;
+	std::string payload;
+	const EFileReadStatus readStatus = ReadTextFile(path, payload, result.m_diagnostic);
+	if (readStatus == EFileReadStatus::Missing)
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::Missing;
+		return result;
+	}
+	if (readStatus == EFileReadStatus::IoFailure)
+	{
+		result.m_status = EGraphicsSettingsLoadStatus::IoFailure;
+		return result;
+	}
+	return ParseEditorGraphicsSettings(payload, "Editor settings " + Quote(Workspace::PathToUtf8(path)));
+}
+
+Sailor::Settings::GraphicsSettingsState Sailor::Settings::LoadGraphicsSettings(
+	const Workspace::WorkspaceContext& workspaceContext,
+	bool bEditorMode) noexcept
+{
+	GraphicsSettingsState state;
+	state.m_bEditorMode = bEditorMode;
+	const ProjectGraphicsSettingsLoadResult projectResult = LoadProjectGraphicsSettings(
+		workspaceContext.GetProjectSettingsPath());
+	state.m_projectSettings = projectResult.m_settings;
+	state.m_projectLoadStatus = projectResult.m_status;
+	state.m_projectDiagnostic = projectResult.m_diagnostic;
+
+	if (bEditorMode)
+	{
+		const EditorGraphicsSettingsLoadResult editorResult = LoadEditorGraphicsSettings(
+			workspaceContext.GetEditorSettingsPath());
+		state.m_editorSettings = editorResult.m_settings;
+		state.m_editorLoadStatus = editorResult.m_status;
+		state.m_editorDiagnostic = editorResult.m_diagnostic;
+	}
+	else
+	{
+		state.m_editorLoadStatus = EGraphicsSettingsLoadStatus::NotLoaded;
+		state.m_editorDiagnostic = "EditorSettings.yaml is ignored outside editor mode.";
+	}
+
+	state.m_activeQuality = bEditorMode
+		? ResolveQualitySelection(
+			state.m_editorSettings.m_selectedQuality,
+			state.m_projectSettings.m_defaultQuality)
+		: state.m_projectSettings.m_defaultQuality;
+	return state;
+}

--- a/Runtime/Settings/GraphicsSettings.cpp
+++ b/Runtime/Settings/GraphicsSettings.cpp
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <system_error>
 #include <utility>
+#include <yaml-cpp/eventhandler.h>
 #include <yaml-cpp/yaml.h>
 
 namespace
@@ -88,6 +89,37 @@ namespace
 		return source + " is invalid: field " + Quote(fieldPath) + " " + requirement + ".";
 	}
 
+	class YamlDocumentCounter final : public YAML::EventHandler
+	{
+	public:
+		void OnDocumentStart(const YAML::Mark&) override { ++m_numDocuments; }
+		void OnDocumentEnd() override {}
+		void OnNull(const YAML::Mark&, YAML::anchor_t) override {}
+		void OnAlias(const YAML::Mark&, YAML::anchor_t) override {}
+		void OnScalar(
+			const YAML::Mark&,
+			const std::string&,
+			YAML::anchor_t,
+			const std::string&) override {}
+		void OnSequenceStart(
+			const YAML::Mark&,
+			const std::string&,
+			YAML::anchor_t,
+			YAML::EmitterStyle::value) override {}
+		void OnSequenceEnd() override {}
+		void OnMapStart(
+			const YAML::Mark&,
+			const std::string&,
+			YAML::anchor_t,
+			YAML::EmitterStyle::value) override {}
+		void OnMapEnd() override {}
+
+		size_t GetNumDocuments() const noexcept { return m_numDocuments; }
+
+	private:
+		size_t m_numDocuments = 0u;
+	};
+
 	bool TryLoadSingleDocument(
 		const std::string& payload,
 		YAML::Node& outDocument,
@@ -97,11 +129,14 @@ namespace
 		if (!External::GuardYamlExceptions(
 				[&]()
 				{
-					auto documents = YAML::LoadAll(payload);
-					documentCount = documents.size();
+					std::istringstream input(payload);
+					YAML::Parser parser(input);
+					YamlDocumentCounter counter;
+					while (parser.HandleNextDocument(counter)) {}
+					documentCount = counter.GetNumDocuments();
 					if (documentCount == 1u)
 					{
-						outDocument = std::move(documents[0]);
+						outDocument = YAML::Load(payload);
 					}
 				},
 				outDiagnostic))

--- a/Runtime/Settings/GraphicsSettings.h
+++ b/Runtime/Settings/GraphicsSettings.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include "Core/Defines.h"
+#include "Engine/Types.h"
+
+#include <array>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+namespace Sailor::Workspace
+{
+	class WorkspaceContext;
+}
+
+namespace Sailor::RHI
+{
+	enum class EMsaaSamples : uint8_t;
+}
+
+namespace Sailor::Settings
+{
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4251)
+#endif
+
+	inline constexpr uint32_t GraphicsSettingsVersion = 1u;
+	inline constexpr uint32_t NumGraphicsQualityPresets = 5u;
+	inline constexpr uint32_t MaxShadowCascades = 4u;
+
+	enum class EGraphicsQuality : uint8_t
+	{
+		Ultra = 0,
+		High,
+		Medium,
+		Low,
+		VeryLow
+	};
+
+	enum class EGraphicsQualitySelection : uint8_t
+	{
+		ProjectDefault = 0,
+		Ultra,
+		High,
+		Medium,
+		Low,
+		VeryLow
+	};
+
+	enum class ERenderStatsMode : uint8_t
+	{
+		None = 0,
+		RenderStats,
+		RenderStatsAndQueries
+	};
+
+	enum class EGraphicsSettingsLoadStatus : uint8_t
+	{
+		NotLoaded = 0,
+		Missing,
+		Loaded,
+		Invalid,
+		UnsupportedVersion,
+		IoFailure
+	};
+
+	struct SAILOR_SHARED_API GraphicsExtent final
+	{
+		uint32_t m_width = 1u;
+		uint32_t m_height = 1u;
+	};
+
+	struct SAILOR_SHARED_API GraphicsQualityProfile final
+	{
+		float m_resolutionFactor = 1.0f;
+		uint32_t m_fpsCap = 120u;
+		uint32_t m_msaaSamples = 1u;
+		ELightShadowQuality m_shadowQuality = ELightShadowQuality::Medium;
+		float m_shadowBias = 0.0f;
+		uint32_t m_shadowCascadeCount = 1u;
+		std::array<uint32_t, MaxShadowCascades> m_shadowCascadeResolutions
+		{
+			512u,
+			0u,
+			0u,
+			0u
+		};
+		bool m_bSupportSoftShadows = false;
+		float m_cloudsResolutionMultiplier = 0.5f;
+		uint32_t m_skyResolution = 256u;
+		int32_t m_lodBias = 0;
+
+		bool IsShadowCascadeActive(uint32_t cascadeIndex) const noexcept;
+		uint32_t GetShadowCascadeResolution(uint32_t cascadeIndex) const noexcept;
+	};
+
+	struct SAILOR_SHARED_API GraphicsSettings final
+	{
+		GraphicsSettings();
+
+		uint32_t m_version = GraphicsSettingsVersion;
+		EGraphicsQuality m_defaultQuality = EGraphicsQuality::High;
+		std::array<GraphicsQualityProfile, NumGraphicsQualityPresets> m_presets{};
+
+		const GraphicsQualityProfile& GetProfile(EGraphicsQuality quality) const noexcept;
+	};
+
+	struct SAILOR_SHARED_API EditorGraphicsSettings final
+	{
+		uint32_t m_version = GraphicsSettingsVersion;
+		EGraphicsQualitySelection m_selectedQuality = EGraphicsQualitySelection::ProjectDefault;
+		ERenderStatsMode m_statsMode = ERenderStatsMode::None;
+	};
+
+	struct SAILOR_SHARED_API ProjectGraphicsSettingsLoadResult final
+	{
+		EGraphicsSettingsLoadStatus m_status = EGraphicsSettingsLoadStatus::NotLoaded;
+		std::string m_diagnostic;
+		GraphicsSettings m_settings;
+
+		bool IsLoaded() const noexcept { return m_status == EGraphicsSettingsLoadStatus::Loaded; }
+	};
+
+	struct SAILOR_SHARED_API EditorGraphicsSettingsLoadResult final
+	{
+		EGraphicsSettingsLoadStatus m_status = EGraphicsSettingsLoadStatus::NotLoaded;
+		std::string m_diagnostic;
+		EditorGraphicsSettings m_settings;
+
+		bool IsLoaded() const noexcept { return m_status == EGraphicsSettingsLoadStatus::Loaded; }
+	};
+
+	struct SAILOR_SHARED_API GraphicsSettingsState final
+	{
+		GraphicsSettings m_projectSettings;
+		EditorGraphicsSettings m_editorSettings;
+		EGraphicsQuality m_activeQuality = EGraphicsQuality::High;
+		EGraphicsSettingsLoadStatus m_projectLoadStatus = EGraphicsSettingsLoadStatus::NotLoaded;
+		EGraphicsSettingsLoadStatus m_editorLoadStatus = EGraphicsSettingsLoadStatus::NotLoaded;
+		std::string m_projectDiagnostic;
+		std::string m_editorDiagnostic;
+		bool m_bEditorMode = false;
+
+		const GraphicsQualityProfile& GetActiveProfile() const noexcept;
+	};
+
+	SAILOR_SHARED_API const char* ToString(EGraphicsQuality quality) noexcept;
+	SAILOR_SHARED_API const char* ToString(EGraphicsQualitySelection selection) noexcept;
+	SAILOR_SHARED_API const char* ToString(ERenderStatsMode mode) noexcept;
+	SAILOR_SHARED_API bool IsValidRenderStatsMode(ERenderStatsMode mode) noexcept;
+	SAILOR_SHARED_API EGraphicsQuality ResolveQualitySelection(
+		EGraphicsQualitySelection selection,
+		EGraphicsQuality projectDefault) noexcept;
+
+	SAILOR_SHARED_API RHI::EMsaaSamples ToMsaaSamples(uint32_t samples) noexcept;
+	SAILOR_SHARED_API GraphicsExtent ResolveRenderDimensions(
+		uint32_t outputWidth,
+		uint32_t outputHeight,
+		float resolutionFactor) noexcept;
+	SAILOR_SHARED_API GraphicsExtent ResolveSkyExtent(
+		const GraphicsQualityProfile& profile) noexcept;
+	SAILOR_SHARED_API GraphicsExtent ResolveCloudsExtent(
+		uint32_t renderWidth,
+		uint32_t renderHeight,
+		const GraphicsQualityProfile& profile,
+		float platformMultiplier = 1.0f) noexcept;
+	SAILOR_SHARED_API ELightShadowQuality ApplyShadowQualityCap(
+		ELightShadowQuality authoredQuality,
+		ELightShadowQuality qualityCap) noexcept;
+	SAILOR_SHARED_API uint32_t ApplyLodBias(
+		uint32_t selectedLod,
+		uint32_t numAvailableLods,
+		uint32_t authoredMinLod,
+		uint32_t authoredMaxLod,
+		int32_t lodBias) noexcept;
+
+	SAILOR_SHARED_API ProjectGraphicsSettingsLoadResult ParseProjectGraphicsSettings(
+		const std::string& payload,
+		const std::string& sourceName = "ProjectSettings.yaml") noexcept;
+	SAILOR_SHARED_API EditorGraphicsSettingsLoadResult ParseEditorGraphicsSettings(
+		const std::string& payload,
+		const std::string& sourceName = "EditorSettings.yaml") noexcept;
+	SAILOR_SHARED_API ProjectGraphicsSettingsLoadResult LoadProjectGraphicsSettings(
+		const std::filesystem::path& path) noexcept;
+	SAILOR_SHARED_API EditorGraphicsSettingsLoadResult LoadEditorGraphicsSettings(
+		const std::filesystem::path& path) noexcept;
+	SAILOR_SHARED_API GraphicsSettingsState LoadGraphicsSettings(
+		const Workspace::WorkspaceContext& workspaceContext,
+		bool bEditorMode) noexcept;
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+}

--- a/Runtime/Workspace/WorkspaceContext.h
+++ b/Runtime/Workspace/WorkspaceContext.h
@@ -44,6 +44,8 @@ namespace Sailor::Workspace
 		const std::filesystem::path& GetGenerated() const noexcept { return m_generated; }
 		const std::filesystem::path& GetBuild() const noexcept { return m_build; }
 		const std::filesystem::path& GetLogicOutput() const noexcept { return m_logicOutput; }
+		std::filesystem::path GetProjectSettingsPath() const { return m_root / "ProjectSettings.yaml"; }
+		std::filesystem::path GetEditorSettingsPath() const { return m_cache / "EditorSettings.yaml"; }
 		const std::string& GetModuleName() const noexcept { return m_moduleName; }
 		const std::string& GetWorkspaceId() const noexcept { return m_workspaceId; }
 		const std::string& GetWorkspaceName() const noexcept { return m_workspaceName; }

--- a/Runtime/Workspace/WorkspaceModuleManager.cpp
+++ b/Runtime/Workspace/WorkspaceModuleManager.cpp
@@ -4,6 +4,7 @@
 #include "Components/Component.h"
 #include "Core/Reflection.h"
 #include "Core/Utils.h"
+#include "ECS/ECSAutoRegistration.h"
 #include "Workspace/WorkspaceModuleApi.h"
 
 #include <algorithm>
@@ -1161,7 +1162,9 @@ const Sailor::Workspace::WorkspaceModuleLoadResult& Sailor::Workspace::Workspace
 	m_result.m_modulePath = loadPath;
 
 	Reflection::SetEngineAutoRegistrationSuppressed(true);
+	ECS::SetAutoRegistrationSuppressed(true);
 	const bool bLibraryOpened = m_library.Open(loadPath);
+	ECS::SetAutoRegistrationSuppressed(false);
 	Reflection::SetEngineAutoRegistrationSuppressed(false);
 	if (!bLibraryOpened)
 	{

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -99,6 +99,10 @@ add_executable(AudioContractTests
     AudioContractTests.cpp
 )
 
+add_executable(GraphicsSettingsTests
+    GraphicsSettingsTests.cpp
+)
+
 add_library(WorkspaceModuleFixture SHARED
     WorkspaceModuleFixture.cpp
 )
@@ -242,6 +246,10 @@ target_compile_definitions(PhysicsRuntimeTests PRIVATE
     SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
 )
 target_compile_features(AudioContractTests PRIVATE cxx_std_20)
+target_compile_features(GraphicsSettingsTests PRIVATE cxx_std_20)
+target_compile_definitions(GraphicsSettingsTests PRIVATE
+    SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
+)
 target_compile_definitions(SkyComponentContractTests PRIVATE
     SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
 )
@@ -304,6 +312,7 @@ target_link_libraries(EditorViewportControllerContractTests PRIVATE Sailor::Runt
 target_link_libraries(SkyComponentContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(PhysicsRuntimeTests PRIVATE Sailor::Runtime)
 target_link_libraries(AudioContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(GraphicsSettingsTests PRIVATE Sailor::Runtime)
 target_link_libraries(AssetMountDiscoveryTests PRIVATE Sailor::Runtime)
 target_link_libraries(WorkspaceModuleContractTests PRIVATE
     Sailor::Runtime
@@ -352,6 +361,7 @@ if(WIN32)
     sailor_stage_workspace_test_runtime(SkyComponentContractTests)
     sailor_stage_workspace_test_runtime(PhysicsRuntimeTests)
     sailor_stage_workspace_test_runtime(AudioContractTests)
+    sailor_stage_workspace_test_runtime(GraphicsSettingsTests)
     sailor_stage_workspace_test_runtime(RemoteViewportRuntimeTests)
     sailor_stage_workspace_test_runtime(EditorEngineProtocolTests)
     sailor_stage_workspace_test_runtime(EditorEngineWebSocketServerTests)
@@ -424,6 +434,9 @@ target_include_directories(PhysicsRuntimeTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(AudioContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(GraphicsSettingsTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(WorkspaceModuleFixture PRIVATE
@@ -589,6 +602,11 @@ add_test(
 )
 
 add_test(
+    NAME GraphicsSettingsTests
+    COMMAND GraphicsSettingsTests
+)
+
+add_test(
     NAME WorkspaceModuleContractTests
     COMMAND WorkspaceModuleContractTests
 )
@@ -691,6 +709,7 @@ set_tests_properties(
     SkyComponentContractTests
     PhysicsRuntimeTests
     AudioContractTests
+    GraphicsSettingsTests
     EditorEngineProtocolTests
     EditorEngineWebSocketServerTests
     EditorEngineWebSocketLateStopTests
@@ -707,6 +726,7 @@ if(WIN32 AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.22" AND VCPKG_INSTALLED_DIR 
         WorkspaceCacheContractTests
         AssetCacheContractTests
         ShaderCacheArtifactTests
+        GraphicsSettingsTests
         WorkspaceModuleContractTests
         WorkspaceModuleRuntimeTests
         PROPERTIES ENVIRONMENT_MODIFICATION

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -109,7 +109,11 @@ namespace
 	{
 		std::ifstream input(path, std::ios::binary);
 		Require(input.is_open(), "test source should be readable: " + path.generic_string());
-		return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+		std::string text(
+			std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>());
+		text.erase(std::remove(text.begin(), text.end(), '\r'), text.end());
+		return text;
 	}
 
 	class LifecycleData final : public ECS::TComponent

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -109,7 +109,7 @@ namespace
 	{
 		std::ifstream input(path, std::ios::binary);
 		Require(input.is_open(), "test source should be readable: " + path.generic_string());
-		std::string text(
+		std::string text = std::string(
 			std::istreambuf_iterator<char>(input),
 			std::istreambuf_iterator<char>());
 		text.erase(std::remove(text.begin(), text.end(), '\r'), text.end());

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1098,9 +1098,9 @@ namespace
 		Require(lightingSource.find("TryAllocateLocalShadowTiles(") != std::string::npos &&
 			lightingSource.find("uint32_t& outAtlasIndex") != std::string::npos &&
 			lightingSource.find("candidate + mapCount <= MaxShadowsInView") != std::string::npos &&
-			lightingSource.find("candidate = static_cast<uint32_t>(m_csmShadowMaps.Num())") != std::string::npos &&
+			lightingSource.find("candidate = NumCascades") != std::string::npos &&
 			lightingSource.find("m_shadowMapsMb + LocalShadowAtlasMemoryMb > m_shadowsMemoryBudgetMb") != std::string::npos,
-			"local shadow allocation must use bounded dynamic atlases without overlapping directional slots or the memory budget");
+			"local shadow allocation must use bounded dynamic atlases after the fixed directional ABI slots and within the memory budget");
 		Require(lightingHeader.find("GetCsmShadowsOccupiedMemoryMb") != std::string::npos &&
 			lightingHeader.find("GetLocalShadowsOccupiedMemoryMb") != std::string::npos &&
 			engineLoopSource.find("Shadows %.1f / %.0f MB") != std::string::npos &&
@@ -1109,9 +1109,10 @@ namespace
 			rhiTypesHeader.find("m_texturesMemoryUsage") != std::string::npos &&
 			blockAllocatorHeader.find("const size_t occupiedSpace = m_usedDataSpace") != std::string::npos,
 			"frame statistics must expose shadow, CSM, local atlas, and Vulkan allocator memory without racing allocator updates");
-		Require(lightingSource.find("App::GetMainWindow()->GetRenderArea().y") != std::string::npos &&
+		Require(lightingSource.find("Settings::ResolveRenderDimensions(") != std::string::npos &&
+			lightingSource.find("const uint32_t viewportHeight = renderExtent.m_height") != std::string::npos &&
 			lightingSource.find("camera,\n\t\t\t1080u,") == std::string::npos,
-			"dynamic local-shadow resolution must use the active viewport instead of a fixed reference height");
+			"dynamic local-shadow resolution must use the scaled render height instead of a fixed reference height");
 		Require(lightingSource.find("m_directionalLightsScratch.Clear(false)") != std::string::npos &&
 			lightingSource.find("m_pointLightsScratch.Clear(false)") != std::string::npos &&
 			lightingSource.find("m_spotLightsScratch.Clear(false)") != std::string::npos &&

--- a/Tests/EditorEngineProtocolTests.cpp
+++ b/Tests/EditorEngineProtocolTests.cpp
@@ -70,6 +70,7 @@ namespace
 	constexpr uint32_t c_setEditorSimulationCommandField = 61;
 	constexpr uint32_t c_getEditorSimulationStateCommandField = 62;
 	constexpr uint32_t c_previewAudioAssetCommandField = 63;
+	constexpr uint32_t c_setEditorStatsModeCommandField = 64;
 
 	void Require(bool condition, const std::string& message)
 	{
@@ -1085,6 +1086,51 @@ namespace
 				kEnabledFieldNumber == 1);
 	}
 
+	void TestEditorStatsModeWireContract()
+	{
+		static_assert(
+			sailor::editor::v1::ProtocolRequest::
+				kSetEditorStatsModeFieldNumber ==
+			c_setEditorStatsModeCommandField);
+		static_assert(
+			sailor::editor::v1::EditorStatsModeRequest::
+				kModeFieldNumber == 1);
+		static_assert(
+			sailor::editor::v1::EDITOR_STATS_MODE_NONE == 1);
+		static_assert(
+			sailor::editor::v1::EDITOR_STATS_MODE_RENDER_STATS == 2);
+		static_assert(
+			sailor::editor::v1::
+				EDITOR_STATS_MODE_RENDER_STATS_AND_QUERIES == 3);
+
+		std::string invalidModeRequest;
+		AppendVarintField(invalidModeRequest, 1u, 99u);
+		Sailor::Protocol::TEditorEngineProtocolLifecycleGate gate;
+		std::string admissionError;
+		Require(
+			gate.TryBeginInitialization(admissionError),
+			"Stats mode protocol fixture lifecycle must initialize");
+		gate.CompleteInitialization(true);
+		Sailor::Protocol::EditorEngineProtocolDependencies dependencies{};
+		dependencies.m_lifecycleGate = &gate;
+
+		TProtocolBuffer buffer;
+		const auto response = RequireProtocolResponse(
+			MakeRequest(
+				EditorEngineProtocolVersion,
+				28,
+				c_setEditorStatsModeCommandField,
+				invalidModeRequest),
+			buffer,
+			dependencies);
+		Require(
+			response.m_requestId == 28 &&
+			!response.m_success &&
+			response.m_resultField == 0 &&
+			response.m_error.find("stats mode") != std::string::npos,
+			"an invalid Editor stats mode must fail without mutating runtime state");
+	}
+
 	void TestAudioPreviewWireContract()
 	{
 		static_assert(
@@ -2074,6 +2120,7 @@ int main()
 		TestStrictInstanceIdProtocolGate();
 		TestModelInstanceWireContract();
 		TestEditorSimulationWireContract();
+		TestEditorStatsModeWireContract();
 		TestAudioPreviewWireContract();
 		TestEmbeddedNullIsRejected();
 		TestUtf8StringIsAccepted();

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -2030,6 +2030,32 @@ namespace
 			"failed graphics pipeline compilation must not record draw commands without a valid pipeline");
 	}
 
+	void TestRenderSceneSurfaceResolveContract()
+	{
+		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
+		const std::string renderSceneSource = ReadText(
+			sourceRoot / "Runtime/FrameGraph/RenderSceneNode.cpp");
+		const std::string processBody = ExtractFunctionBody(
+			renderSceneSource,
+			"void RenderSceneNode::Process(");
+
+		Require(processBody.find("if (colorSurface)") != std::string::npos &&
+			processBody.find("resources->m_renderPassColorSurfaces") !=
+				std::string::npos &&
+			processBody.find("colorSurface->NeedsResolve()") !=
+				std::string::npos &&
+			processBody.find("colorSurface->GetResolved()") !=
+				std::string::npos &&
+			processBody.find("renderPassColorSurfaces.Add(colorSurface)") !=
+				std::string::npos &&
+			processBody.find("commands->BeginRenderPass(\n\t\t\tcommandList,\n\t\t\trenderPassColorSurfaces") !=
+				std::string::npos,
+			"RenderScene must pass an RHISurface to the surface render-pass overload so an MSAA target is resolved exactly once");
+		Require(processBody.find("renderPassColorAttachments.Add(colorAttachment)") !=
+				std::string::npos,
+			"RenderScene must retain the direct texture attachment fallback for non-surface frame-graph outputs");
+	}
+
 	void TestPostProcessPingPongMipIsolationContract()
 	{
 		const std::filesystem::path sourceRoot = SAILOR_TEST_SOURCE_DIR;
@@ -2646,6 +2672,7 @@ int main()
 		{ "CustomDepthVertexAnimationReachesShadows", TestCustomDepthVertexAnimationReachesShadows },
 		{ "VertexDescriptionAttributeIdentityContract", TestVertexDescriptionAttributeIdentityContract },
 		{ "GraphicsPipelineAttachmentCacheContract", TestGraphicsPipelineAttachmentCacheContract },
+		{ "RenderSceneSurfaceResolveContract", TestRenderSceneSurfaceResolveContract },
 		{ "PostProcessPingPongMipIsolationContract", TestPostProcessPingPongMipIsolationContract },
 		{ "TransparentBackToFrontOrderingContract", TestTransparentBackToFrontOrderingContract },
 		{ "ShadowCasterRenderQueueContract", TestShadowCasterRenderQueueContract },

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -47,7 +47,7 @@ namespace
 	{
 		std::ifstream input(path, std::ios::binary);
 		Require(input.is_open(), "test source should be readable: " + path.generic_string());
-		std::string text(
+		std::string text = std::string(
 			std::istreambuf_iterator<char>(input),
 			std::istreambuf_iterator<char>());
 		text.erase(std::remove(text.begin(), text.end(), '\r'), text.end());

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -12,6 +12,7 @@
 #include "RHI/Mesh.h"
 #include "RHI/Texture.h"
 
+#include <algorithm>
 #include <cmath>
 #include <filesystem>
 #include <fstream>
@@ -46,7 +47,11 @@ namespace
 	{
 		std::ifstream input(path, std::ios::binary);
 		Require(input.is_open(), "test source should be readable: " + path.generic_string());
-		return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+		std::string text(
+			std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>());
+		text.erase(std::remove(text.begin(), text.end(), '\r'), text.end());
+		return text;
 	}
 
 	std::string ExtractFunctionBody(const std::string& source, const std::string& signature)

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -2355,7 +2355,7 @@ namespace
 			"CSM sampling and blending must interpret the near EVSM map and the wider PCF maps using their actual formats");
 		Require(lightingSource.find("float CalculateShadowDistanceFade(") !=
 				std::string::npos &&
-			lightingSource.find("cascadeLayer != NUM_CSM_CASCADES - 1") !=
+			lightingSource.find("cascadeLayer != int(safeCascadeCount) - 1") !=
 				std::string::npos &&
 			standardShader.find("shadow = mix(shadow, 1.0f, shadowDistanceFade);") !=
 				std::string::npos &&
@@ -2363,7 +2363,7 @@ namespace
 				std::string::npos &&
 			standardGltfShader.find("shadow = mix(shadow, 1.0f, shadowDistanceFade);") !=
 				std::string::npos,
-			"the final CSM cascade must fade to unshadowed lighting instead of ending at a visible hard boundary");
+			"the final active CSM cascade must fade to unshadowed lighting instead of ending at a visible hard boundary");
 		Require(lightingSource.find("SHADOW_RECEIVER_LIGHT_OFFSET") !=
 				std::string::npos &&
 			lightingSource.find("SHADOW_RECEIVER_NORMAL_OFFSET") != std::string::npos &&

--- a/Tests/GraphicsSettingsTests.cpp
+++ b/Tests/GraphicsSettingsTests.cpp
@@ -56,6 +56,14 @@ namespace
 		}
 	}
 
+	template<typename TTest>
+	void RunTest(const char* name, TTest&& test)
+	{
+		std::cout << "[ RUN      ] " << name << std::endl;
+		test();
+		std::cout << "[       OK ] " << name << std::endl;
+	}
+
 	bool IsNear(float lhs, float rhs, float tolerance = 0.0001f)
 	{
 		return std::abs(lhs - rhs) <= tolerance;
@@ -682,12 +690,12 @@ int main()
 {
 	try
 	{
-		TestBuiltInDefaultsAndPolicies();
-		TestProjectParsingAndValidation();
-		TestEditorParsingAndAppStatsMode();
-		TestWorkspaceSelectionAndEditorIsolation();
-		TestGpuFrameTimeQueryRingDoesNotReuseDelayedSlots();
-		TestGraphicsSettingsRuntimeIntegrationContracts();
+		RunTest("BuiltInDefaultsAndPolicies", TestBuiltInDefaultsAndPolicies);
+		RunTest("ProjectParsingAndValidation", TestProjectParsingAndValidation);
+		RunTest("EditorParsingAndAppStatsMode", TestEditorParsingAndAppStatsMode);
+		RunTest("WorkspaceSelectionAndEditorIsolation", TestWorkspaceSelectionAndEditorIsolation);
+		RunTest("GpuFrameTimeQueryRingDoesNotReuseDelayedSlots", TestGpuFrameTimeQueryRingDoesNotReuseDelayedSlots);
+		RunTest("GraphicsSettingsRuntimeIntegrationContracts", TestGraphicsSettingsRuntimeIntegrationContracts);
 	}
 	catch (const std::exception& exception)
 	{

--- a/Tests/GraphicsSettingsTests.cpp
+++ b/Tests/GraphicsSettingsTests.cpp
@@ -1,0 +1,659 @@
+#include "Sailor.h"
+#include "ECS/LightingECS.h"
+#include "Settings/GraphicsSettings.h"
+#include "Workspace/WorkspaceContext.h"
+#include "RHI/GpuFrameTimeQueryRing.h"
+
+#include <chrono>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <stdexcept>
+#include <string>
+
+using namespace Sailor;
+using namespace Sailor::Settings;
+
+namespace
+{
+	class TempDirectory final
+	{
+	public:
+		explicit TempDirectory(const char* label)
+		{
+			static uint64_t nextId = 0u;
+			const auto timestamp = std::chrono::steady_clock::now().time_since_epoch().count();
+			m_path = std::filesystem::temp_directory_path() /
+				("sailor-graphics-settings-" + std::string(label) + "-" +
+					std::to_string(timestamp) + "-" + std::to_string(nextId++));
+			std::filesystem::create_directories(m_path);
+		}
+
+		~TempDirectory() noexcept
+		{
+			std::error_code removeError;
+			std::filesystem::remove_all(m_path, removeError);
+		}
+
+		const std::filesystem::path& Get() const noexcept { return m_path; }
+		std::filesystem::path Path(const std::filesystem::path& relative) const
+		{
+			return m_path / relative;
+		}
+
+	private:
+		std::filesystem::path m_path;
+	};
+
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	bool IsNear(float lhs, float rhs, float tolerance = 0.0001f)
+	{
+		return std::abs(lhs - rhs) <= tolerance;
+	}
+
+	void WriteText(const std::filesystem::path& path, const std::string& text)
+	{
+		std::ofstream output(path, std::ios::binary);
+		output << text;
+		Require(output.good(), "test settings should be writable: " + path.generic_string());
+	}
+
+	std::string ReadRepositoryFile(const std::filesystem::path& relativePath)
+	{
+		std::ifstream input(
+			std::filesystem::path(SAILOR_TEST_SOURCE_DIR) / relativePath,
+			std::ios::binary);
+		Require(input.good(), "repository source should be readable: " + relativePath.generic_string());
+		return std::string(
+			std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>());
+	}
+
+	std::string ReplaceFirst(
+		std::string source,
+		const std::string& expected,
+		const std::string& replacement)
+	{
+		const size_t position = source.find(expected);
+		Require(position != std::string::npos, "test replacement source should exist: " + expected);
+		source.replace(position, expected.size(), replacement);
+		return source;
+	}
+
+	const std::string& ValidProjectSettings()
+	{
+		static const std::string settings = R"YAML(settingsVersion: 1
+unknownRoot: retained
+graphics:
+  defaultQuality: Medium
+  unknownGraphics: retained
+  presets:
+    Ultra:
+      resolutionFactor: 1.0
+      fpsCap: 120
+      msaaSamples: 8
+      shadowQuality: High
+      shadowBias: 1.25
+      shadowCascadeCount: 4
+      shadowCascadeResolutions: [4096, 2048, 2048, 1024]
+      supportSoftShadows: true
+      cloudsResolutionMultiplier: 1.0
+      skyResolution: 512
+      lodBias: -1
+      futureField: retained
+    High:
+      resolutionFactor: 1.0
+      fpsCap: 120
+      msaaSamples: 4
+      shadowQuality: High
+      shadowBias: 0
+      shadowCascadeCount: 4
+      shadowCascadeResolutions: [2048, 2048, 1024, 1024]
+      supportSoftShadows: true
+      cloudsResolutionMultiplier: 0.75
+      skyResolution: 256
+      lodBias: 0
+    Medium:
+      resolutionFactor: 0.85
+      fpsCap: 120
+      msaaSamples: 2
+      shadowQuality: Medium
+      shadowBias: 0
+      shadowCascadeCount: 3
+      shadowCascadeResolutions: [2048, 1024, 512]
+      supportSoftShadows: true
+      cloudsResolutionMultiplier: 0.5
+      skyResolution: 256
+      lodBias: 0
+    Low:
+      resolutionFactor: 0.7
+      fpsCap: 120
+      msaaSamples: 1
+      shadowQuality: Low
+      shadowBias: 0
+      shadowCascadeCount: 2
+      shadowCascadeResolutions: [1024, 512]
+      supportSoftShadows: false
+      cloudsResolutionMultiplier: 0.25
+      skyResolution: 128
+      lodBias: +1
+    VeryLow:
+      resolutionFactor: 0.5
+      fpsCap: 120
+      msaaSamples: 1
+      shadowQuality: VeryLow
+      shadowBias: 0
+      shadowCascadeCount: 1
+      shadowCascadeResolutions: [512]
+      supportSoftShadows: false
+      cloudsResolutionMultiplier: 0.125
+      skyResolution: 64
+      lodBias: +2
+)YAML";
+		return settings;
+	}
+
+	std::string EditorSettings(
+		const std::string& selectedQuality,
+		const std::string& statsMode)
+	{
+		return "settingsVersion: 1\n"
+			"unknownRoot: retained\n"
+			"graphics:\n"
+			"  selectedQuality: " + selectedQuality + "\n"
+			"  statsMode: " + statsMode + "\n"
+			"  futureField: retained\n";
+	}
+
+	void RequireInvalidProjectField(
+		const std::string& payload,
+		const std::string& fieldPath)
+	{
+		const ProjectGraphicsSettingsLoadResult result = ParseProjectGraphicsSettings(
+			payload,
+			"validation fixture");
+		Require(result.m_status == EGraphicsSettingsLoadStatus::Invalid,
+			"invalid project field should be rejected: " + result.m_diagnostic);
+		Require(result.m_diagnostic.find(fieldPath) != std::string::npos,
+			"invalid project diagnostic should identify " + fieldPath + ": " + result.m_diagnostic);
+		Require(result.m_settings.m_defaultQuality == EGraphicsQuality::High,
+			"invalid project settings should retain the safe built-in default");
+		Require(result.m_settings.GetProfile(EGraphicsQuality::Ultra).m_msaaSamples == 8u,
+			"invalid project settings should not publish partially parsed profile values");
+	}
+
+	void TestBuiltInDefaultsAndPolicies()
+	{
+		const GraphicsSettings defaults;
+		Require(defaults.m_version == GraphicsSettingsVersion,
+			"built-in settings should use the current version");
+		Require(defaults.m_defaultQuality == EGraphicsQuality::High,
+			"built-in project default should be High");
+
+		const GraphicsQualityProfile& ultra = defaults.GetProfile(EGraphicsQuality::Ultra);
+		Require(IsNear(ultra.m_resolutionFactor, 1.0f) && ultra.m_fpsCap == 120u &&
+			ultra.m_msaaSamples == 8u,
+			"Ultra should use native resolution, a 120 FPS cap, and 8x MSAA");
+		Require(ultra.m_shadowQuality == ELightShadowQuality::High &&
+			IsNear(ultra.m_shadowBias, 0.0f) &&
+			ultra.m_shadowCascadeCount == 4u &&
+			ultra.GetShadowCascadeResolution(0u) == 4096u &&
+			ultra.GetShadowCascadeResolution(3u) == 1024u,
+			"Ultra should expose all four planned shadow cascades");
+		Require(ultra.GetShadowCascadeResolution(4u) == 0u,
+			"inactive cascade access should return a safe zero extent");
+		Require(ultra.m_bSupportSoftShadows &&
+			IsNear(ultra.m_cloudsResolutionMultiplier, 1.0f) &&
+			ultra.m_skyResolution == 512u && ultra.m_lodBias == -1,
+			"Ultra should match the remaining planned defaults");
+
+		const GraphicsQualityProfile& high = defaults.GetProfile(EGraphicsQuality::High);
+		Require(IsNear(high.m_resolutionFactor, 1.0f) && high.m_fpsCap == 120u &&
+			high.m_msaaSamples == 4u &&
+			high.m_shadowQuality == ELightShadowQuality::High &&
+			IsNear(high.m_shadowBias, 0.0f) && high.m_shadowCascadeCount == 4u &&
+			high.m_shadowCascadeResolutions ==
+				std::array<uint32_t, MaxShadowCascades>{ 2048u, 2048u, 1024u, 1024u } &&
+			high.m_bSupportSoftShadows && IsNear(high.m_cloudsResolutionMultiplier, 0.75f) &&
+			high.m_skyResolution == 256u && high.m_lodBias == 0,
+			"High should match the complete planned defaults");
+
+		const GraphicsQualityProfile& medium = defaults.GetProfile(EGraphicsQuality::Medium);
+		Require(IsNear(medium.m_resolutionFactor, 0.85f) && medium.m_fpsCap == 120u &&
+			medium.m_msaaSamples == 2u &&
+			medium.m_shadowQuality == ELightShadowQuality::Medium &&
+			IsNear(medium.m_shadowBias, 0.0f) && medium.m_shadowCascadeCount == 3u &&
+			medium.m_shadowCascadeResolutions ==
+				std::array<uint32_t, MaxShadowCascades>{ 2048u, 1024u, 512u, 0u } &&
+			medium.m_bSupportSoftShadows && IsNear(medium.m_cloudsResolutionMultiplier, 0.5f) &&
+			medium.m_skyResolution == 256u && medium.m_lodBias == 0,
+			"Medium should match the complete planned defaults");
+
+		const GraphicsQualityProfile& low = defaults.GetProfile(EGraphicsQuality::Low);
+		Require(IsNear(low.m_resolutionFactor, 0.7f) && low.m_fpsCap == 120u &&
+			low.m_msaaSamples == 1u &&
+			low.m_shadowQuality == ELightShadowQuality::Low &&
+			IsNear(low.m_shadowBias, 0.0f) && low.m_shadowCascadeCount == 2u &&
+			low.m_shadowCascadeResolutions ==
+				std::array<uint32_t, MaxShadowCascades>{ 1024u, 512u, 0u, 0u } &&
+			!low.m_bSupportSoftShadows && IsNear(low.m_cloudsResolutionMultiplier, 0.25f) &&
+			low.m_skyResolution == 128u && low.m_lodBias == 1,
+			"Low should match the complete planned defaults");
+
+		const GraphicsQualityProfile& veryLow = defaults.GetProfile(EGraphicsQuality::VeryLow);
+		Require(IsNear(veryLow.m_resolutionFactor, 0.5f) &&
+			veryLow.m_fpsCap == 120u &&
+			veryLow.m_msaaSamples == 1u &&
+			veryLow.m_shadowQuality == ELightShadowQuality::VeryLow &&
+			IsNear(veryLow.m_shadowBias, 0.0f) &&
+			veryLow.m_shadowCascadeCount == 1u &&
+			!veryLow.m_bSupportSoftShadows &&
+			IsNear(veryLow.m_cloudsResolutionMultiplier, 0.125f) &&
+			veryLow.m_skyResolution == 64u && veryLow.m_lodBias == 2,
+			"VeryLow should match the planned fallback values");
+
+		const GraphicsExtent renderExtent = ResolveRenderDimensions(1919u, 1079u, 0.5f);
+		Require(renderExtent.m_width == 960u && renderExtent.m_height == 540u,
+			"render dimensions should scale and round to the nearest pixel");
+		const GraphicsExtent minimumRenderExtent = ResolveRenderDimensions(0u, 1u, 0.25f);
+		Require(minimumRenderExtent.m_width == 1u && minimumRenderExtent.m_height == 1u,
+			"render dimensions should clamp to at least one pixel");
+		const GraphicsExtent skyExtent = ResolveSkyExtent(veryLow);
+		Require(skyExtent.m_width == 64u && skyExtent.m_height == 64u,
+			"sky extent should be square and profile-controlled");
+		const GraphicsExtent cloudsExtent = ResolveCloudsExtent(1920u, 1080u, ultra, 0.5f);
+		Require(cloudsExtent.m_width == 540u && cloudsExtent.m_height == 540u,
+			"platform cloud adjustment should apply after the profile multiplier");
+
+		Require(ToMsaaSamples(8u) == RHI::EMsaaSamples::Samples_8 &&
+			ToMsaaSamples(3u) == RHI::EMsaaSamples::Samples_1,
+			"MSAA conversion should preserve supported values and safely default invalid input");
+		Require(ApplyShadowQualityCap(ELightShadowQuality::High, ELightShadowQuality::Low) ==
+			ELightShadowQuality::Low,
+			"shadow cap should lower authored quality");
+		Require(ApplyShadowQualityCap(ELightShadowQuality::Low, ELightShadowQuality::High) ==
+			ELightShadowQuality::Low,
+			"shadow cap should not raise authored quality");
+		Require(ApplyLodBias(1u, 4u, 0u, 3u, 2) == 3u &&
+			ApplyLodBias(2u, 4u, 0u, 3u, -8) == 0u &&
+			ApplyLodBias(0u, 4u, 1u, 2u, -3) == 1u,
+			"signed LOD bias should choose coarser/finer levels and honor authored bounds");
+
+		Require(IsNear(LightingECS::GetShadowCascadeLevel(0u, 1u), 1.0f),
+			"one active cascade should cover the full configured shadow distance");
+		Require(IsNear(LightingECS::GetShadowCascadeLevel(0u, 2u), 0.2f) &&
+			IsNear(LightingECS::GetShadowCascadeLevel(1u, 2u), 1.0f),
+			"two active cascades should use the two coarsest stable split levels");
+		Require(IsNear(LightingECS::GetShadowCascadeLevel(0u, 3u), 0.075f) &&
+			IsNear(LightingECS::GetShadowCascadeLevel(1u, 3u), 0.2f) &&
+			IsNear(LightingECS::GetShadowCascadeLevel(2u, 3u), 1.0f),
+			"three active cascades should end at the full-distance split");
+		Require(IsNear(LightingECS::GetShadowCascadeLevel(0u, 4u), 0.025f) &&
+			IsNear(LightingECS::GetShadowCascadeLevel(1u, 4u), 0.075f) &&
+			IsNear(LightingECS::GetShadowCascadeLevel(2u, 4u), 0.2f) &&
+			IsNear(LightingECS::GetShadowCascadeLevel(3u, 4u), 1.0f),
+			"four active cascades should retain the complete split schedule");
+	}
+
+	void TestProjectParsingAndValidation()
+	{
+		const ProjectGraphicsSettingsLoadResult parsed = ParseProjectGraphicsSettings(
+			ValidProjectSettings(),
+			"valid project fixture");
+		Require(parsed.IsLoaded(), "valid project settings should load: " + parsed.m_diagnostic);
+		Require(parsed.m_settings.m_defaultQuality == EGraphicsQuality::Medium,
+			"project default quality should deserialize");
+		Require(parsed.m_settings.GetProfile(EGraphicsQuality::Low).m_lodBias == 1,
+			"explicit positive signed LOD bias should deserialize");
+		Require(parsed.m_settings.GetProfile(EGraphicsQuality::Medium).m_fpsCap == 120u,
+			"FPS cap should deserialize with the active quality profile");
+		Require(IsNear(parsed.m_settings.GetProfile(EGraphicsQuality::Ultra).m_shadowBias, 1.25f),
+			"shadow bias should deserialize with the quality profile");
+		Require(parsed.m_settings.GetProfile(EGraphicsQuality::Medium).m_shadowCascadeResolutions[3] == 0u,
+			"inactive cascade storage should be cleared");
+
+		const ProjectGraphicsSettingsLoadResult unsupported = ParseProjectGraphicsSettings(
+			ReplaceFirst(ValidProjectSettings(), "settingsVersion: 1", "settingsVersion: 2"),
+			"future project fixture");
+		Require(unsupported.m_status == EGraphicsSettingsLoadStatus::UnsupportedVersion,
+			"future project version should be distinguished from corrupt data");
+		Require(unsupported.m_settings.m_defaultQuality == EGraphicsQuality::High,
+			"unsupported project version should use built-in defaults");
+		const ProjectGraphicsSettingsLoadResult multipleDocuments = ParseProjectGraphicsSettings(
+			ValidProjectSettings() + "---\nsettingsVersion: 1\n",
+			"multiple project documents");
+		Require(multipleDocuments.m_status == EGraphicsSettingsLoadStatus::Invalid &&
+			multipleDocuments.m_diagnostic.find("exactly one YAML document") != std::string::npos,
+			"multiple project documents should be rejected atomically");
+
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "defaultQuality: Medium", "defaultQuality: Custom"),
+			"graphics.defaultQuality");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "resolutionFactor: 1.0", "resolutionFactor: 0.1"),
+			"graphics.presets.Ultra.resolutionFactor");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "fpsCap: 120", "fpsCap: 0"),
+			"graphics.presets.Ultra.fpsCap");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "msaaSamples: 8", "msaaSamples: 3"),
+			"graphics.presets.Ultra.msaaSamples");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "shadowQuality: High", "shadowQuality: Cinematic"),
+			"graphics.presets.Ultra.shadowQuality");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "shadowBias: 1.25", "shadowBias: 17"),
+			"graphics.presets.Ultra.shadowBias");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "shadowCascadeCount: 4", "shadowCascadeCount: 5"),
+			"graphics.presets.Ultra.shadowCascadeCount");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "4096, 2048", "1000, 2048"),
+			"graphics.presets.Ultra.shadowCascadeResolutions[0]");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "supportSoftShadows: true", "supportSoftShadows: maybe"),
+			"graphics.presets.Ultra.supportSoftShadows");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "cloudsResolutionMultiplier: 1.0", "cloudsResolutionMultiplier: 0.01"),
+			"graphics.presets.Ultra.cloudsResolutionMultiplier");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "skyResolution: 512", "skyResolution: 100"),
+			"graphics.presets.Ultra.skyResolution");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "lodBias: -1", "lodBias: -9"),
+			"graphics.presets.Ultra.lodBias");
+		RequireInvalidProjectField(
+			ReplaceFirst(
+				ValidProjectSettings(),
+				"shadowCascadeResolutions: [4096, 2048, 2048, 1024]",
+				"shadowCascadeResolutions: [4096, 2048, 1024]"),
+			"graphics.presets.Ultra.shadowCascadeResolutions");
+	}
+
+	void TestEditorParsingAndAppStatsMode()
+	{
+		const EditorGraphicsSettingsLoadResult parsed = ParseEditorGraphicsSettings(
+			EditorSettings("Low", "RenderStatsAndQueries"),
+			"valid editor fixture");
+		Require(parsed.IsLoaded(), "valid editor settings should load: " + parsed.m_diagnostic);
+		Require(parsed.m_settings.m_selectedQuality == EGraphicsQualitySelection::Low &&
+			parsed.m_settings.m_statsMode == ERenderStatsMode::RenderStatsAndQueries,
+			"editor quality and stats selection should deserialize");
+		Require(ResolveQualitySelection(
+			EGraphicsQualitySelection::ProjectDefault,
+			EGraphicsQuality::Medium) == EGraphicsQuality::Medium,
+			"ProjectDefault should resolve through the project document");
+
+		const EditorGraphicsSettingsLoadResult invalid = ParseEditorGraphicsSettings(
+			EditorSettings("Low", "GpuEverything"),
+			"invalid editor fixture");
+		Require(invalid.m_status == EGraphicsSettingsLoadStatus::Invalid &&
+			invalid.m_diagnostic.find("graphics.statsMode") != std::string::npos,
+			"invalid Stats mode should produce a field-qualified diagnostic");
+		Require(invalid.m_settings.m_selectedQuality == EGraphicsQualitySelection::ProjectDefault &&
+			invalid.m_settings.m_statsMode == ERenderStatsMode::None,
+			"invalid editor settings should fall back as one atomic document");
+
+		Require(App::SetRenderStatsMode(ERenderStatsMode::RenderStats),
+			"valid live Stats mode should be accepted");
+		Require(App::GetRenderStatsMode() == ERenderStatsMode::RenderStats,
+			"live Stats mode should be observable through App");
+		Require(!App::SetRenderStatsMode(static_cast<ERenderStatsMode>(255u)),
+			"invalid live Stats mode should be rejected");
+		Require(App::GetRenderStatsMode() == ERenderStatsMode::RenderStats,
+			"rejected Stats mode should not mutate the active value");
+		Require(App::SetRenderStatsMode(ERenderStatsMode::None),
+			"test should restore the default Stats mode");
+	}
+
+	void TestWorkspaceSelectionAndEditorIsolation()
+	{
+		TempDirectory workspace("selection");
+		const Workspace::WorkspaceContextResolveResult contextResult =
+			Workspace::ResolveWorkspaceContext(workspace.Get());
+		Require(contextResult.IsSuccess(),
+			"legacy workspace should resolve for settings tests: " + contextResult.m_message);
+		const Workspace::WorkspaceContext& context = contextResult.m_context;
+		Require(context.GetProjectSettingsPath() == context.GetRoot() / "ProjectSettings.yaml",
+			"project settings path should be rooted in the active workspace");
+		Require(context.GetEditorSettingsPath() == context.GetCache() / "EditorSettings.yaml",
+			"editor settings path should use the resolved cache directory");
+
+		WriteText(context.GetProjectSettingsPath(), ValidProjectSettings());
+		WriteText(context.GetEditorSettingsPath(), EditorSettings("Ultra", "RenderStats"));
+
+		const GraphicsSettingsState editorState = LoadGraphicsSettings(context, true);
+		Require(editorState.m_projectLoadStatus == EGraphicsSettingsLoadStatus::Loaded &&
+			editorState.m_editorLoadStatus == EGraphicsSettingsLoadStatus::Loaded,
+			"editor startup should load both settings documents");
+		Require(editorState.m_activeQuality == EGraphicsQuality::Ultra &&
+			editorState.GetActiveProfile().m_msaaSamples == 8u &&
+			editorState.m_editorSettings.m_statsMode == ERenderStatsMode::RenderStats,
+			"editor startup should apply the cache-side explicit quality and Stats mode");
+
+		const GraphicsSettingsState standaloneState = LoadGraphicsSettings(context, false);
+		Require(standaloneState.m_projectLoadStatus == EGraphicsSettingsLoadStatus::Loaded &&
+			standaloneState.m_editorLoadStatus == EGraphicsSettingsLoadStatus::NotLoaded,
+			"standalone startup should not load the cache-side editor document");
+		Require(standaloneState.m_activeQuality == EGraphicsQuality::Medium &&
+			standaloneState.GetActiveProfile().m_msaaSamples == 2u &&
+			standaloneState.m_editorSettings.m_statsMode == ERenderStatsMode::None,
+			"standalone startup should use the project default and ignore editor overrides");
+
+		WriteText(context.GetEditorSettingsPath(), EditorSettings("Unknown", "RenderStats"));
+		const GraphicsSettingsState invalidEditorState = LoadGraphicsSettings(context, true);
+		Require(invalidEditorState.m_editorLoadStatus == EGraphicsSettingsLoadStatus::Invalid &&
+			invalidEditorState.m_activeQuality == EGraphicsQuality::Medium &&
+			invalidEditorState.m_editorSettings.m_statsMode == ERenderStatsMode::None,
+			"invalid editor settings should atomically fall back to ProjectDefault and None");
+
+		std::filesystem::remove(context.GetProjectSettingsPath());
+		const GraphicsSettingsState missingProjectState = LoadGraphicsSettings(context, false);
+		Require(missingProjectState.m_projectLoadStatus == EGraphicsSettingsLoadStatus::Missing &&
+			missingProjectState.m_activeQuality == EGraphicsQuality::High &&
+			missingProjectState.GetActiveProfile().m_msaaSamples == 4u,
+			"missing project settings should produce the safe built-in High profile");
+	}
+
+	void TestGpuFrameTimeQueryRingDoesNotReuseDelayedSlots()
+	{
+		RHI::TGpuFrameTimeQueryRing<2u> ring;
+		const uint32_t first = ring.Acquire();
+		Require(first == 0u && ring.MarkIssued(first),
+			"first query slot should transition from recording to issued");
+		const uint32_t second = ring.Acquire();
+		Require(second == 1u && ring.MarkIssued(second),
+			"second query slot should transition from recording to issued");
+		Require(
+			ring.Acquire() == RHI::TGpuFrameTimeQueryRing<2u>::InvalidSlot,
+			"a delayed query ring must not reset or reissue slots that are still pending");
+		Require(
+			ring.GetState(first) == RHI::EGpuFrameTimeQuerySlotState::Issued &&
+			ring.GetState(second) == RHI::EGpuFrameTimeQuerySlotState::Issued,
+			"pending slots should retain completion ownership");
+		Require(ring.MarkCompleted(second),
+			"a ready query result should release exactly its owning slot");
+		const uint32_t reused = ring.Acquire();
+		Require(reused == second,
+			"only the explicitly completed slot should become reusable");
+		Require(ring.CancelRecording(reused),
+			"a boundary command that failed before submission should be cancellable");
+		Require(
+			ring.GetState(first) == RHI::EGpuFrameTimeQuerySlotState::Issued,
+			"cancelling another recording must not release a delayed issued query");
+	}
+
+	void TestGraphicsSettingsRuntimeIntegrationContracts()
+	{
+		for (const char* rendererPath :
+			{ "Content/DefaultRenderer.renderer", "Content/EditorRenderer.renderer" })
+		{
+			const std::string renderer = ReadRepositoryFile(rendererPath);
+			Require(renderer.find(
+				"- name: DepthBuffer\n  format: D32_SFLOAT_S8_UINT\n  width: RenderWidth\n  height: RenderHeight") !=
+				std::string::npos,
+				"scene depth must be allocated at the scaled render extent");
+			Require(renderer.find(
+				"- name: OverlayDepthBuffer\n  format: D32_SFLOAT_S8_UINT\n  width: ViewportWidth\n  height: ViewportHeight") !=
+				std::string::npos,
+				"overlay depth must remain at the native viewport extent");
+			Require(renderer.find("- color: EditorOutput\n  - depthStencil: OverlayDepthBuffer") !=
+				std::string::npos,
+				"native editor overlays must bind the native depth target");
+		}
+
+		const std::string blitNode = ReadRepositoryFile("Runtime/FrameGraph/BlitNode.cpp");
+		Require(blitNode.find("bUseFullscreenColorBlit") != std::string::npos &&
+			blitNode.find("src->GetExtent() != dst->GetExtent()") != std::string::npos &&
+			blitNode.find("BlitRaw(commandList, frameGraph, sceneView, src, dst)") != std::string::npos,
+			"scaled color output must use a fullscreen pass that owns the native viewport");
+
+		const std::string lighting = ReadRepositoryFile("Runtime/ECS/LightingECS.cpp");
+		Require(lighting.find("lightCascadesMatrices.Num()") !=
+			std::string::npos &&
+			lighting.find("graphicsProfile.GetShadowCascadeResolution(k)") !=
+			std::string::npos,
+			"flight-local CSM targets should be allocated only for active matrices at profile resolutions");
+		Require(lighting.find(
+			"m_shadowMapTextures[i] = i < m_csmShadowMaps.Num() && m_csmShadowMaps[i] ?") !=
+			std::string::npos,
+			"inactive fixed CSM bindings must use the default shadow texture");
+		Require(lighting.find("for (uint32_t candidate = NumCascades;") !=
+			std::string::npos,
+			"local shadow slots must remain after the fixed CSM binding range");
+
+		const std::string shadowPrepass = ReadRepositoryFile(
+			"Runtime/FrameGraph/ShadowPrepassNode.cpp");
+		Require(shadowPrepass.find("for (uint32_t i = 0; i < activeCascadeCount; ++i)") !=
+			std::string::npos &&
+			shadowPrepass.find("GetShadowCascadeLevel(i, activeCascadeCount)") !=
+			std::string::npos,
+			"CSM matrices and splits must be generated only for active cascades");
+		Require(shadowPrepass.find("App::GetActiveGraphicsSettings().m_shadowBias") !=
+			std::string::npos &&
+			shadowPrepass.find("sourceState.GetDepthBias() + shadowBias") !=
+			std::string::npos,
+			"profile shadow bias must affect standard casters and add to custom material bias");
+
+		const std::string sky = ReadRepositoryFile("Runtime/FrameGraph/SkyNode.cpp");
+		Require(sky.find("Settings::ResolveSkyExtent(graphicsProfile)") !=
+			std::string::npos &&
+			sky.find("Settings::ResolveCloudsExtent(") != std::string::npos &&
+			sky.find("driver->CreateRenderTarget(\n\t\t\tcommandList") != std::string::npos,
+			"resolved sky and cloud extents must feed real render-target allocation paths");
+		const size_t composeBegin = sky.find(
+			"BeginDebugRegion(commandList, \"Compose\"");
+		const size_t overlaysBegin = sky.find(
+			"BeginDebugRegion(commandList, \"Stars & Clouds\"");
+		const size_t environmentBegin = sky.find(
+			"BeginDebugRegion(commandList, \"Generate Environment Map\"");
+		Require(composeBegin != std::string::npos &&
+			overlaysBegin > composeBegin &&
+			environmentBegin > overlaysBegin,
+			"sky compose and overlay passes must be independently bounded");
+		const std::string composeBody = sky.substr(
+			composeBegin,
+			overlaysBegin - composeBegin);
+		const std::string overlaysBody = sky.substr(
+			overlaysBegin,
+			environmentBegin - overlaysBegin);
+		Require(composeBody.find("-(float)target->GetExtent().y") ==
+			std::string::npos &&
+			composeBody.find(
+				"(float)target->GetExtent().x, (float)target->GetExtent().y") !=
+				std::string::npos,
+			"front-culled sky compose must retain its positive target viewport");
+		Require(overlaysBody.find("SetDefaultViewport(commandList)") ==
+			std::string::npos &&
+			overlaysBody.find("-(float)target->GetExtent().y") !=
+			std::string::npos &&
+			overlaysBody.find(
+				"glm::vec2(target->GetExtent().x, target->GetExtent().y)") !=
+				std::string::npos,
+			"back-culled sky overlays must use the scaled target viewport with Vulkan orientation");
+
+		const std::string linearDepth = ReadRepositoryFile(
+			"Runtime/FrameGraph/LinearizeDepthNode.cpp");
+		Require(linearDepth.find("SetDefaultViewport(commandList)") ==
+			std::string::npos &&
+			linearDepth.find("-(float)target->GetExtent().y") !=
+			std::string::npos &&
+			linearDepth.find(
+				"glm::vec2(target->GetExtent().x, target->GetExtent().y)") !=
+			std::string::npos,
+			"linear depth must cover the scaled target used by sky and cloud depth masking");
+
+		const std::string meshLods = ReadRepositoryFile(
+			"Runtime/ECS/StaticMeshRendererECS.cpp");
+		const std::string instanceLods = ReadRepositoryFile("Runtime/RHI/SceneView.cpp");
+		Require(meshLods.find("Settings::ApplyLodBias(") != std::string::npos &&
+			instanceLods.find("Settings::ApplyLodBias(") != std::string::npos,
+			"signed LOD bias must affect both mesh and per-instance selection paths");
+
+		const std::string renderer = ReadRepositoryFile("Runtime/RHI/Renderer.cpp");
+		const size_t beginBoundary = renderer.find("BeginGpuFrameTimeQuery(");
+		const size_t updateSubmission = renderer.find(
+			"bFrameSubmitsSucceeded = updateFrameRHI(chainSemaphore)");
+		const size_t endBoundary = renderer.find("EndGpuFrameTimeQuery(");
+		const size_t finalSubmission = renderer.find(
+			"m_driverInstance->PresentFrame(frame, primaryCommandLists");
+		Require(beginBoundary < updateSubmission &&
+			updateSubmission < endBoundary &&
+			endBoundary < finalSubmission,
+			"GPU timestamps must bracket update, compute, transfer, and final graphics submissions");
+		const std::string frameGraph = ReadRepositoryFile(
+			"Runtime/FrameGraph/RHIFrameGraph.cpp");
+		Require(frameGraph.find("GpuFrameTimeQuery") == std::string::npos,
+			"frame timing must not be narrowed to a graphics framegraph snapshot");
+		const std::string debugContext = ReadRepositoryFile(
+			"Runtime/RHI/DebugContext.cpp");
+		Require(debugContext.find("Settings::ResolveRenderDimensions(") !=
+			std::string::npos &&
+			debugContext.find("commands->SetDefaultViewport(secondaryDrawCmdList)") ==
+			std::string::npos &&
+			debugContext.find("-renderHeight") != std::string::npos &&
+			debugContext.find("glm::vec2(renderWidth, renderHeight)") !=
+			std::string::npos,
+			"debug grid secondary commands must use the scaled target viewport and scissor");
+		const std::string engineLoop = ReadRepositoryFile("Runtime/Engine/EngineLoop.cpp");
+		Require(engineLoop.find("GPU queries unavailable") != std::string::npos,
+			"unsupported timestamp devices must report an explicit Stats overlay state");
+		Require(engineLoop.find("std::this_thread::sleep_until(cpuFrameDeadline)") !=
+			std::string::npos,
+			"EngineLoop must own the CPU FPS limiter");
+		const std::string app = ReadRepositoryFile("Runtime/Sailor.cpp");
+		Require(app.find("GetActiveGraphicsSettings().m_fpsCap") != std::string::npos &&
+			app.find("EditorFrameIntervalMicro") == std::string::npos,
+			"the active profile FPS cap must be passed into EngineLoop without an editor-only duplicate limiter");
+	}
+}
+
+int main()
+{
+	try
+	{
+		TestBuiltInDefaultsAndPolicies();
+		TestProjectParsingAndValidation();
+		TestEditorParsingAndAppStatsMode();
+		TestWorkspaceSelectionAndEditorIsolation();
+		TestGpuFrameTimeQueryRingDoesNotReuseDelayedSlots();
+		TestGraphicsSettingsRuntimeIntegrationContracts();
+	}
+	catch (const std::exception& exception)
+	{
+		std::cerr << "GraphicsSettingsTests failed: " << exception.what() << std::endl;
+		return 1;
+	}
+
+	std::cout << "GraphicsSettingsTests passed." << std::endl;
+	return 0;
+}

--- a/Tests/GraphicsSettingsTests.cpp
+++ b/Tests/GraphicsSettingsTests.cpp
@@ -466,6 +466,21 @@ graphics:
 
 	void TestGpuFrameTimeQueryRingDoesNotReuseDelayedSlots()
 	{
+		float milliseconds = 0.0f;
+		Require(
+			RHI::TryResolveGpuFrameTimeMilliseconds(
+				100u, 150u, 64u, 1000000.0f, milliseconds) &&
+			milliseconds == 50.0f,
+			"ordered timestamp results should resolve to milliseconds");
+		Require(
+			!RHI::TryResolveGpuFrameTimeMilliseconds(
+				200u, 100u, 64u, 1.0f, milliseconds),
+			"a stale full-width end timestamp must not become an enormous unsigned duration");
+		Require(
+			RHI::TryResolveGpuFrameTimeMilliseconds(
+				0xfffffff0u, 0x10u, 32u, 1.0f, milliseconds),
+			"limited-width timestamp counters should still support a valid wrap");
+
 		RHI::TGpuFrameTimeQueryRing<2u> ring;
 		const uint32_t first = ring.Acquire();
 		Require(first == 0u && ring.MarkIssued(first),
@@ -600,6 +615,13 @@ graphics:
 			"signed LOD bias must affect both mesh and per-instance selection paths");
 
 		const std::string renderer = ReadRepositoryFile("Runtime/RHI/Renderer.cpp");
+		const size_t submissionContextsRelease = renderer.find(
+			"m_submissionContexts.Clear();");
+		const size_t driverRelease = renderer.find("m_driverInstance.Clear();");
+		Require(submissionContextsRelease != std::string::npos &&
+			driverRelease != std::string::npos &&
+			submissionContextsRelease < driverRelease,
+			"renderer shutdown must release flight-local GPU resources before the Vulkan driver and instance");
 		const size_t beginBoundary = renderer.find("BeginGpuFrameTimeQuery(");
 		const size_t updateSubmission = renderer.find(
 			"bFrameSubmitsSucceeded = updateFrameRHI(chainSemaphore)");
@@ -614,16 +636,32 @@ graphics:
 			"Runtime/FrameGraph/RHIFrameGraph.cpp");
 		Require(frameGraph.find("GpuFrameTimeQuery") == std::string::npos,
 			"frame timing must not be narrowed to a graphics framegraph snapshot");
+		Require(frameGraph.find("GetSceneRenderExtent()") != std::string::npos &&
+			frameGraph.find("debugDraw->GetResolvedAttachment(\"color\")") !=
+				std::string::npos &&
+			frameGraph.find("frameData.m_viewportSize = GetSceneRenderExtent();") !=
+				std::string::npos,
+			"frame shader data must use the actual resolved scene target extent");
+		const std::string vulkanDriver = ReadRepositoryFile(
+			"Runtime/GraphicsDriver/Vulkan/VulkanGraphicsDriver.cpp");
+		Require(
+			vulkanDriver.find("vkResetQueryPool(") != std::string::npos &&
+			vulkanDriver.find("vkCmdResetQueryPool(") == std::string::npos &&
+			vulkanDriver.find("VK_QUERY_RESULT_WITH_AVAILABILITY_BIT") !=
+				std::string::npos,
+			"timestamp slots must clear stale availability before reuse and poll both availability values");
 		const std::string debugContext = ReadRepositoryFile(
 			"Runtime/RHI/DebugContext.cpp");
-		Require(debugContext.find("Settings::ResolveRenderDimensions(") !=
+		Require(debugContext.find("Settings::ResolveRenderDimensions(") ==
 			std::string::npos &&
+			debugContext.find("renderExtent.x") != std::string::npos &&
+			debugContext.find("renderExtent.y") != std::string::npos &&
 			debugContext.find("commands->SetDefaultViewport(secondaryDrawCmdList)") ==
 			std::string::npos &&
 			debugContext.find("-renderHeight") != std::string::npos &&
 			debugContext.find("glm::vec2(renderWidth, renderHeight)") !=
 			std::string::npos,
-			"debug grid secondary commands must use the scaled target viewport and scissor");
+			"debug grid secondary commands must use the exact resolved target viewport and scissor");
 		const std::string engineLoop = ReadRepositoryFile("Runtime/Engine/EngineLoop.cpp");
 		Require(engineLoop.find("GPU queries unavailable") != std::string::npos,
 			"unsupported timestamp devices must report an explicit Stats overlay state");

--- a/Tests/GraphicsSettingsTests.cpp
+++ b/Tests/GraphicsSettingsTests.cpp
@@ -4,6 +4,7 @@
 #include "Workspace/WorkspaceContext.h"
 #include "RHI/GpuFrameTimeQueryRing.h"
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <filesystem>
@@ -73,9 +74,11 @@ namespace
 			std::filesystem::path(SAILOR_TEST_SOURCE_DIR) / relativePath,
 			std::ios::binary);
 		Require(input.good(), "repository source should be readable: " + relativePath.generic_string());
-		return std::string(
+		std::string text(
 			std::istreambuf_iterator<char>(input),
 			std::istreambuf_iterator<char>());
+		text.erase(std::remove(text.begin(), text.end(), '\r'), text.end());
+		return text;
 	}
 
 	std::string ReplaceFirst(

--- a/Tests/GraphicsSettingsTests.cpp
+++ b/Tests/GraphicsSettingsTests.cpp
@@ -74,7 +74,7 @@ namespace
 			std::filesystem::path(SAILOR_TEST_SOURCE_DIR) / relativePath,
 			std::ios::binary);
 		Require(input.good(), "repository source should be readable: " + relativePath.generic_string());
-		std::string text(
+		std::string text = std::string(
 			std::istreambuf_iterator<char>(input),
 			std::istreambuf_iterator<char>());
 		text.erase(std::remove(text.begin(), text.end(), '\r'), text.end());

--- a/Tests/GraphicsSettingsTests.cpp
+++ b/Tests/GraphicsSettingsTests.cpp
@@ -7,6 +7,8 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdlib>
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -19,6 +21,32 @@ using namespace Sailor::Settings;
 
 namespace
 {
+	const char* g_currentTestName = "startup";
+
+	[[noreturn]] void ReportTermination() noexcept
+	{
+		std::cerr << "GraphicsSettingsTests terminated while running: " <<
+			g_currentTestName << std::endl;
+
+		try
+		{
+			if (const std::exception_ptr exception = std::current_exception())
+			{
+				std::rethrow_exception(exception);
+			}
+		}
+		catch (const std::exception& exception)
+		{
+			std::cerr << "Termination exception: " << exception.what() << std::endl;
+		}
+		catch (...)
+		{
+			std::cerr << "Termination exception: unknown" << std::endl;
+		}
+
+		std::_Exit(2);
+	}
+
 	class TempDirectory final
 	{
 	public:
@@ -59,9 +87,12 @@ namespace
 	template<typename TTest>
 	void RunTest(const char* name, TTest&& test)
 	{
+		const char* previousTestName = g_currentTestName;
+		g_currentTestName = name;
 		std::cout << "[ RUN      ] " << name << std::endl;
 		test();
 		std::cout << "[       OK ] " << name << std::endl;
+		g_currentTestName = previousTestName;
 	}
 
 	bool IsNear(float lhs, float rhs, float tolerance = 0.0001f)
@@ -189,17 +220,21 @@ graphics:
 		const std::string& payload,
 		const std::string& fieldPath)
 	{
-		const ProjectGraphicsSettingsLoadResult result = ParseProjectGraphicsSettings(
-			payload,
-			"validation fixture");
-		Require(result.m_status == EGraphicsSettingsLoadStatus::Invalid,
-			"invalid project field should be rejected: " + result.m_diagnostic);
-		Require(result.m_diagnostic.find(fieldPath) != std::string::npos,
-			"invalid project diagnostic should identify " + fieldPath + ": " + result.m_diagnostic);
-		Require(result.m_settings.m_defaultQuality == EGraphicsQuality::High,
-			"invalid project settings should retain the safe built-in default");
-		Require(result.m_settings.GetProfile(EGraphicsQuality::Ultra).m_msaaSamples == 8u,
-			"invalid project settings should not publish partially parsed profile values");
+		const std::string testName = "ProjectParsing.Invalid." + fieldPath;
+		RunTest(testName.c_str(), [&]()
+			{
+				const ProjectGraphicsSettingsLoadResult result = ParseProjectGraphicsSettings(
+					payload,
+					"validation fixture");
+				Require(result.m_status == EGraphicsSettingsLoadStatus::Invalid,
+					"invalid project field should be rejected: " + result.m_diagnostic);
+				Require(result.m_diagnostic.find(fieldPath) != std::string::npos,
+					"invalid project diagnostic should identify " + fieldPath + ": " + result.m_diagnostic);
+				Require(result.m_settings.m_defaultQuality == EGraphicsQuality::High,
+					"invalid project settings should retain the safe built-in default");
+				Require(result.m_settings.GetProfile(EGraphicsQuality::Ultra).m_msaaSamples == 8u,
+					"invalid project settings should not publish partially parsed profile values");
+			});
 	}
 
 	void TestBuiltInDefaultsAndPolicies()
@@ -317,34 +352,44 @@ graphics:
 
 	void TestProjectParsingAndValidation()
 	{
-		const ProjectGraphicsSettingsLoadResult parsed = ParseProjectGraphicsSettings(
-			ValidProjectSettings(),
-			"valid project fixture");
-		Require(parsed.IsLoaded(), "valid project settings should load: " + parsed.m_diagnostic);
-		Require(parsed.m_settings.m_defaultQuality == EGraphicsQuality::Medium,
-			"project default quality should deserialize");
-		Require(parsed.m_settings.GetProfile(EGraphicsQuality::Low).m_lodBias == 1,
-			"explicit positive signed LOD bias should deserialize");
-		Require(parsed.m_settings.GetProfile(EGraphicsQuality::Medium).m_fpsCap == 120u,
-			"FPS cap should deserialize with the active quality profile");
-		Require(IsNear(parsed.m_settings.GetProfile(EGraphicsQuality::Ultra).m_shadowBias, 1.25f),
-			"shadow bias should deserialize with the quality profile");
-		Require(parsed.m_settings.GetProfile(EGraphicsQuality::Medium).m_shadowCascadeResolutions[3] == 0u,
-			"inactive cascade storage should be cleared");
+		RunTest("ProjectParsing.ValidDocument", []()
+			{
+				const ProjectGraphicsSettingsLoadResult parsed = ParseProjectGraphicsSettings(
+					ValidProjectSettings(),
+					"valid project fixture");
+				Require(parsed.IsLoaded(), "valid project settings should load: " + parsed.m_diagnostic);
+				Require(parsed.m_settings.m_defaultQuality == EGraphicsQuality::Medium,
+					"project default quality should deserialize");
+				Require(parsed.m_settings.GetProfile(EGraphicsQuality::Low).m_lodBias == 1,
+					"explicit positive signed LOD bias should deserialize");
+				Require(parsed.m_settings.GetProfile(EGraphicsQuality::Medium).m_fpsCap == 120u,
+					"FPS cap should deserialize with the active quality profile");
+				Require(IsNear(parsed.m_settings.GetProfile(EGraphicsQuality::Ultra).m_shadowBias, 1.25f),
+					"shadow bias should deserialize with the quality profile");
+				Require(parsed.m_settings.GetProfile(EGraphicsQuality::Medium).m_shadowCascadeResolutions[3] == 0u,
+					"inactive cascade storage should be cleared");
+			});
 
-		const ProjectGraphicsSettingsLoadResult unsupported = ParseProjectGraphicsSettings(
-			ReplaceFirst(ValidProjectSettings(), "settingsVersion: 1", "settingsVersion: 2"),
-			"future project fixture");
-		Require(unsupported.m_status == EGraphicsSettingsLoadStatus::UnsupportedVersion,
-			"future project version should be distinguished from corrupt data");
-		Require(unsupported.m_settings.m_defaultQuality == EGraphicsQuality::High,
-			"unsupported project version should use built-in defaults");
-		const ProjectGraphicsSettingsLoadResult multipleDocuments = ParseProjectGraphicsSettings(
-			ValidProjectSettings() + "---\nsettingsVersion: 1\n",
-			"multiple project documents");
-		Require(multipleDocuments.m_status == EGraphicsSettingsLoadStatus::Invalid &&
-			multipleDocuments.m_diagnostic.find("exactly one YAML document") != std::string::npos,
-			"multiple project documents should be rejected atomically");
+		RunTest("ProjectParsing.UnsupportedVersion", []()
+			{
+				const ProjectGraphicsSettingsLoadResult unsupported = ParseProjectGraphicsSettings(
+					ReplaceFirst(ValidProjectSettings(), "settingsVersion: 1", "settingsVersion: 2"),
+					"future project fixture");
+				Require(unsupported.m_status == EGraphicsSettingsLoadStatus::UnsupportedVersion,
+					"future project version should be distinguished from corrupt data");
+				Require(unsupported.m_settings.m_defaultQuality == EGraphicsQuality::High,
+					"unsupported project version should use built-in defaults");
+			});
+
+		RunTest("ProjectParsing.MultipleDocuments", []()
+			{
+				const ProjectGraphicsSettingsLoadResult multipleDocuments = ParseProjectGraphicsSettings(
+					ValidProjectSettings() + "---\nsettingsVersion: 1\n",
+					"multiple project documents");
+				Require(multipleDocuments.m_status == EGraphicsSettingsLoadStatus::Invalid &&
+					multipleDocuments.m_diagnostic.find("exactly one YAML document") != std::string::npos,
+					"multiple project documents should be rejected atomically");
+			});
 
 		RequireInvalidProjectField(
 			ReplaceFirst(ValidProjectSettings(), "defaultQuality: Medium", "defaultQuality: Custom"),
@@ -688,6 +733,8 @@ graphics:
 
 int main()
 {
+	std::set_terminate(ReportTermination);
+
 	try
 	{
 		RunTest("BuiltInDefaultsAndPolicies", TestBuiltInDefaultsAndPolicies);

--- a/Tests/WorkspaceModuleFixture.cpp
+++ b/Tests/WorkspaceModuleFixture.cpp
@@ -1,4 +1,5 @@
 #include "Components/Component.h"
+#include "ECS/TransformECS.h"
 #include "Workspace/WorkspaceTypeRegistration.h"
 
 namespace WorkspaceFixture

--- a/Tests/WorkspaceModuleRuntimeTests.cpp
+++ b/Tests/WorkspaceModuleRuntimeTests.cpp
@@ -630,7 +630,9 @@ namespace
 
 	void TestWorldInstantiationGuards()
 	{
-		EngineLoop engineLoop;
+		EngineLoop engineLoop(120u);
+		Require(engineLoop.GetFpsCap() == 120u,
+			"EngineLoop should retain the FPS cap passed by application startup");
 		Require(!engineLoop.InstantiateWorld({}, EngineLoop::DefaultWorldMask),
 			"unavailable world prefab should be rejected without creating a partial world");
 		Require(engineLoop.GetWorlds().IsEmpty(),


### PR DESCRIPTION
## Summary

Implements project and editor graphics quality settings for #169, including five editable presets, safe workspace-scoped persistence, runtime application, Scene View controls, and renderer integration.

The delivered scope also includes the requested FPS cap and shadow bias, a compact scrollable Settings UI, persistent Inspector split sizing, corrected scaled viewport handling, and stable preset-driven Engine restarts.

Closes #169

## Changes

- Stores versioned project presets in `ProjectSettings.yaml` and workspace-local editor overrides in the resolved cache.
- Supports `Ultra`, `High`, `Medium`, `Low`, and `VeryLow` presets with resolution scale, FPS cap, MSAA, shadow quality and bias, cascade configuration, soft shadows, cloud and sky resolution, and LOD bias.
- Applies quality changes through the controlled Engine restart path and Stats mode through a typed live protocol command.
- Keeps native output, readback, overlays, and debug geometry aligned while resolution-scaled internal targets are rendered and upscaled.
- Guards persistence with workspace generations and file revisions, preserves unknown YAML keys, and refuses stale, malformed, or unreadable updates.
- Uses fixed-slot CSM bindings with active cascade allocation, shared LOD bias, profile-driven sky/cloud resources, and completion-owned Vulkan frame timestamp queries.
- Makes workspace module reload safe for duplicate static ECS registrations and fixes renderer/Vulkan teardown ordering across repeated preset restarts.
- Fixes Windows vegetation sampler scope, exports the virtualized scene API needed by test executables, makes source-contract tests CRLF-independent, and avoids unsafe yaml-cpp STL-container and throwing-conversion DLL boundaries.

## Validation

- `python3 update_deps.py`: dependencies already current.
- Release `SailorLib` incremental build with one worker: passed.
- Native CTest selection: 10/10 passed (`GraphicsSettingsTests`, `WorkspaceModuleRuntimeTests`, remote viewport foundation/contract/runtime, editor protocol, GPU culling, RHI scene virtualization, sky, and viewport controller).
- Editor contracts: 806/806 passed on .NET 9.
- GitHub `build-editor`, `Build (MSVC)`, and `Build (clang-cl)`: passed on final head `843d54fc6`.
- Windows CI on both MSVC and clang-cl: 37/37 native tests, 806/806 Editor contracts, source-workspace validation, and both fresh-process two-workspace phases passed.
- Live EverythingFloats validation: all five preset transitions, scaled viewport/sky/cloud/debug-grid alignment, GPU query mode, repeated Engine restarts, and FPS-cap persistence/reload were confirmed.

## Risk and Review Notes

- Risk remains high because the change crosses Editor persistence/UI, protocol, renderer/frame graph, shadows, LOD, Vulkan queries, and workspace lifecycle.
- The full automated world-test suite was not run locally to honor the explicit Mac thermal constraint. Focused contracts and the EverythingFloats live scene cover the affected behavior; Windows compilation is delegated to CI.
- Generated shader metadata and the local FPS-cap experiment are not part of this PR.

## Agent Workflow

- [x] Implementation Summary complete.
- [x] Tech Review complete; required findings addressed.
- [x] QA Report complete with scoped thermal exception documented.
- [x] Final GitHub checks green.
- [x] Ready for human review.
