### PR TITLE
Add Scene View render modes and correct AO lighting

### DIFF
--- a/Content/DefaultRenderer.renderer
+++ b/Content/DefaultRenderer.renderer
@@ -121,7 +121,7 @@ frame:
   string:
   - Tag: Opaque
   - ClearDepth: true
-  - GPUCulling: true
+  - GPUCulling: false
   - VirtualizeInstancePayloads: true
   renderTargets:
   - depthStencil: DepthBuffer
@@ -130,7 +130,7 @@ frame:
 - name: DepthPrepass
   string:
   - Tag: Masked
-  - GPUCulling: true
+  - GPUCulling: false
   - VirtualizeInstancePayloads: true
   renderTargets:
   - depthStencil: DepthBuffer

--- a/Content/EditorRenderer.renderer
+++ b/Content/EditorRenderer.renderer
@@ -121,7 +121,7 @@ frame:
   string:
   - Tag: Opaque
   - ClearDepth: true
-  - GPUCulling: true
+  - GPUCulling: false
   - VirtualizeInstancePayloads: true
   renderTargets:
   - depthStencil: DepthBuffer
@@ -130,7 +130,7 @@ frame:
 - name: DepthPrepass
   string:
   - Tag: Masked
-  - GPUCulling: true
+  - GPUCulling: false
   - VirtualizeInstancePayloads: true
   renderTargets:
   - depthStencil: DepthBuffer

--- a/Content/EditorRenderer.renderer
+++ b/Content/EditorRenderer.renderer
@@ -438,11 +438,14 @@ frame:
   - depthStencil: DepthBuffer
 
 ############################
-- name: Blit
+- name: DebugView
 ############################
+  string:
+  - shader: Shaders/Debug.shader
   renderTargets:
   - src: Main
   - dst: EditorOutput
+  - linearDepth: LinearDepth
 
 #############################
 - name: RenderImGui

--- a/Content/Shaders/Debug.shader
+++ b/Content/Shaders/Debug.shader
@@ -56,7 +56,7 @@ glslVertex: |
       LightsGrid instance[];
   } lightsGrid;
 
-  layout(set=2, binding=9) uniform sampler2D g_aoSampler;
+  layout(set=2, binding=8) uniform sampler2D g_aoSampler;
   
   layout(location=DefaultPositionBinding) in vec3 inPosition;
   layout(location=DefaultTexcoordBinding) in vec2 inTexcoord;
@@ -110,14 +110,15 @@ glslFragment: |
       LightsGrid instance[];
   } lightsGrid;
   
-  layout(set=2, binding=9) uniform sampler2D g_aoSampler;
+  layout(set=2, binding=8) uniform sampler2D g_aoSampler;
   
   void main() 
   {
     outColor = texture(ldrSceneSampler, fragTexcoord);
     
   #if defined(AO)
-    outColor = texture(g_aoSampler, fragTexcoord);
+    const float ao = texture(g_aoSampler, fragTexcoord).r;
+    outColor = vec4(vec3(ao), 1.0);
   #elif defined(LIGHT_TILES)
     outColor = vec4(texture(linearDepthSampler, fragTexcoord).r / 50000);
   

--- a/Content/Shaders/HBAO.shader
+++ b/Content/Shaders/HBAO.shader
@@ -126,9 +126,18 @@ glslFragment: |
     return normalize(cross(right.xyz, framebufferDown.xyz));
   }
   
-  vec2 SnapTexel(vec2 uv, vec2 depthTextureSize)
+  vec2 SnapTexelOffset(vec2 uvOffset, vec2 depthTextureSize)
   {
-     return round(uv * depthTextureSize) * rcp(depthTextureSize);
+    return round(uvOffset * depthTextureSize) * rcp(depthTextureSize);
+  }
+
+  vec2 SnapTexelCenter(vec2 uv, vec2 depthTextureSize)
+  {
+    vec2 pixel = clamp(
+      floor(uv * depthTextureSize),
+      vec2(0.0f),
+      depthTextureSize - vec2(1.0f));
+    return (pixel + vec2(0.5f)) * rcp(depthTextureSize);
   }
   
   float SampleAO(inout float sinH, vec3 viewSpaceSamplePos, vec3 viewSpaceOriginPos, vec3 viewSpaceOriginNormal)
@@ -172,9 +181,9 @@ glslFragment: |
     direction *= sampleRadius;
 
     // jitter the starting position for ray marching between the nearest neighbour and the sample step size
-    vec2 stepUV = SnapTexel(direction * rcp(NumSamples + 1.0f), depthTextureSize);
+    vec2 stepUV = SnapTexelOffset(direction * rcp(NumSamples + 1.0f), depthTextureSize);
     vec2 jitteredOffset = mix(singleTexelStep, stepUV, jitter);
-    vec2 rayStart = SnapTexel(rayOrigin + jitteredOffset, depthTextureSize);
+    vec2 rayStart = SnapTexelCenter(rayOrigin + jitteredOffset, depthTextureSize);
     vec2 rayEnd = rayStart + direction;
 
     // top occlusion keeps track of the occlusion contribution of the last found occluder.
@@ -186,7 +195,9 @@ glslFragment: |
     [[unroll]]
     for (uint step = 0; step < NumSamples; ++step)
     {
-        vec2 uv = SnapTexel(mix(rayStart, rayEnd, step / float(NumSamples)), depthTextureSize);
+        vec2 uv = SnapTexelCenter(
+          mix(rayStart, rayEnd, step / float(NumSamples)),
+          depthTextureSize);
         vec3 viewSpaceSamplePos = GetViewSpacePos(uv);
 
         occlusion += SampleAO(sinH, viewSpaceSamplePos, viewSpaceOriginPos, viewSpaceOriginNormal);
@@ -244,6 +255,10 @@ glslFragment: |
             depthTextureSize);
     }
 
-    outColor = vec4(1 - saturate((data.occlusionPower / NumDirections) * occlusionFactor));
+    float averageOcclusion = saturate(occlusionFactor / float(NumDirections));
+    float visibility = saturate(1.0f - averageOcclusion);
+    // Treat power as the final visibility exponent so it changes contrast
+    // without changing the directional normalization of the estimator.
+    outColor = vec4(pow(visibility, max(data.occlusionPower, 0.0001f)));
     //outColor.xyz = viewSpaceNormal;
   }

--- a/Content/Shaders/HBAO.shader
+++ b/Content/Shaders/HBAO.shader
@@ -88,7 +88,8 @@ glslFragment: |
   vec3 GetViewSpacePos(vec2 uv)
   {
     float depth = texture(depthSampler, uv).r;
-    return ScreenSpaceToViewSpace(uv, depth, frame.invProjection).xyz;
+    vec2 projectionUv = FramebufferUvToSceneProjectionUv(uv);
+    return ScreenSpaceToViewSpace(projectionUv, depth, frame.invProjection).xyz;
   }
   
   vec3 GetViewSpaceNormal(vec2 uv, vec2 depthTextureSize)
@@ -109,11 +110,20 @@ glslFragment: |
     float depthDdx = TakeSmallerAbsDelta(depthLeft, depth, depthRight);
     float depthDdy = TakeSmallerAbsDelta(depthDown, depth, depthUp);
 
-    vec4 mid    = ScreenSpaceToViewSpace(uv, depth, frame.invProjection);
-    vec4 right  = ScreenSpaceToViewSpace(uvRight, depth + depthDdx, frame.invProjection) - mid;
-    vec4 up     = ScreenSpaceToViewSpace(uvUp, depth + depthDdy, frame.invProjection) - mid;
+    vec4 mid = ScreenSpaceToViewSpace(
+      FramebufferUvToSceneProjectionUv(uv),
+      depth,
+      frame.invProjection);
+    vec4 right = ScreenSpaceToViewSpace(
+      FramebufferUvToSceneProjectionUv(uvRight),
+      depth + depthDdx,
+      frame.invProjection) - mid;
+    vec4 framebufferDown = ScreenSpaceToViewSpace(
+      FramebufferUvToSceneProjectionUv(uvUp),
+      depth + depthDdy,
+      frame.invProjection) - mid;
 
-    return normalize(cross(up.xyz, right.xyz));
+    return normalize(cross(right.xyz, framebufferDown.xyz));
   }
   
   vec2 SnapTexel(vec2 uv, vec2 depthTextureSize)

--- a/Content/Shaders/HBAO_Blur.shader
+++ b/Content/Shaders/HBAO_Blur.shader
@@ -67,7 +67,8 @@ glslFragment: |
   float GetViewDepth(vec2 uv)
   {
     float depth = texture(depthSampler, uv).r;
-    return ScreenSpaceToViewSpace(uv, depth, frame.invProjection).z;
+    vec2 projectionUv = FramebufferUvToSceneProjectionUv(uv);
+    return ScreenSpaceToViewSpace(projectionUv, depth, frame.invProjection).z;
   }
 
   vec4 CalcBilateral(vec2 UV, float R, float CenterViewDepth, inout float TotalW)

--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -529,9 +529,15 @@ glslFragment: |
     // Total specular IBL contribution.
     vec3 specularIBL = (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance;
 
-    // Total ambient lighting contribution. Screen-space AO only affects the
-    // diffuse portion similar to the glTF occlusion workflow.
-    return diffuseIBL * material.ao + specularIBL;
+    // Ambient occlusion applies to all indirect lighting. Use a view- and
+    // roughness-dependent approximation for specular IBL so smooth surfaces
+    // retain plausible reflections without leaking them into occluded areas.
+    float ambientOcclusion = clamp(material.ao, 0.0, 1.0);
+    float specularOcclusion = CalculateSpecularOcclusion(
+      ambientOcclusion,
+      cosLo,
+      material.roughness);
+    return diffuseIBL * ambientOcclusion + specularIBL * specularOcclusion;
   }
 
   // Constant normal incidence Fresnel factor for all dielectrics.

--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -546,7 +546,8 @@ glslFragment: |
   void main()
   {
     const vec3 viewDirection = normalize(vin.worldPosition - frame.cameraPosition.xyz);
-    const vec2 viewportUv = gl_FragCoord.xy * rcp(frame.viewportSize);
+    const vec2 viewportUv = gl_FragCoord.xy *
+      rcp(vec2(textureSize(g_aoSampler, 0)));
 
     MaterialData material = GetMaterialData();
     vec4 layerWeights = max(vin.color, vec4(0.0));
@@ -593,7 +594,8 @@ glslFragment: |
         min(min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(LIGHTS_PER_TILE)), availableLights);
     #endif
 
-    outColor.xyz = AmbientLighting(material, F0, Lr, normal, cosLo);
+    const vec3 indirectLighting = AmbientLighting(material, F0, Lr, normal, cosLo);
+    outColor.xyz = indirectLighting;
 
     for(int i = 0; i < numLights; i++)
     {
@@ -611,6 +613,10 @@ glslFragment: |
 
         outColor.xyz += CalculateLighting(light.instance[index], index, material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
     }
+
+    outColor.xyz = indirectLighting +
+      (outColor.xyz - indirectLighting) *
+      CalculateDirectLightingOcclusion(material.ao);
 
     outColor.a = material.albedo.a;
   }

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -37,6 +37,7 @@ struct LightData
 const uint INVALID_LIGHT_TYPE = 0xFFFFFFFFu;
 const uint LIGHT_TILE_OVERFLOW_BIT = 0x80000000u;
 const uint LIGHT_TILE_COUNT_MASK = 0x7FFFFFFFu;
+const float SCREEN_SPACE_AO_DIRECT_LIGHTING_STRENGTH = 0.5f;
 
 layout(std430)
 struct LightsGrid
@@ -161,6 +162,18 @@ float CalculateSpecularOcclusion(float ambientOcclusion, float cosLo, float roug
   const float clampedRoughness = clamp(roughness, 0.0, 1.0);
   const float exponent = exp2(-16.0 * clampedRoughness - 1.0);
   return clamp(pow(nDotV + ao, exponent) - 1.0 + ao, 0.0, 1.0);
+}
+
+// A bounded direct-lighting contribution turns screen-space AO into a useful
+// contact shadow even in scenes where analytic lights dominate the IBL.
+// Keep the strength bounded so emissive lighting and authored light shadows
+// remain the primary sources of contrast.
+float CalculateDirectLightingOcclusion(float ambientOcclusion)
+{
+  return mix(
+    1.0,
+    clamp(ambientOcclusion, 0.0, 1.0),
+    SCREEN_SPACE_AO_DIRECT_LIGHTING_STRENGTH);
 }
 
 vec4 GaussianBlur_Evsm(sampler2D textureSampler, vec2 uv, vec2 texelSize, ivec2 radius)

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -151,6 +151,18 @@ vec3 FresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness)
     return F0 + (max(vec3(1.0 - roughness), F0) - F0) * pow(clamp(1.0 - cosTheta, 0.0, 1.0), 5.0);
 } 
 
+// Screen-space ambient occlusion describes the visibility of indirect light.
+// Diffuse IBL can use the visibility directly, while glossy reflections need
+// a view- and roughness-dependent approximation to avoid over-darkening.
+float CalculateSpecularOcclusion(float ambientOcclusion, float cosLo, float roughness)
+{
+  const float ao = clamp(ambientOcclusion, 0.0, 1.0);
+  const float nDotV = clamp(cosLo, 0.0, 1.0);
+  const float clampedRoughness = clamp(roughness, 0.0, 1.0);
+  const float exponent = exp2(-16.0 * clampedRoughness - 1.0);
+  return clamp(pow(nDotV + ao, exponent) - 1.0 + ao, 0.0, 1.0);
+}
+
 vec4 GaussianBlur_Evsm(sampler2D textureSampler, vec2 uv, vec2 texelSize, ivec2 radius)
 {
   const int stepCount = 12;

--- a/Content/Shaders/Math.glsl
+++ b/Content/Shaders/Math.glsl
@@ -181,6 +181,14 @@ vec4 ScreenSpaceToViewSpace(vec2 texCoord, float z, mat4 invProjection)
     return ClipSpaceToViewSpace(clip, invProjection);
 }
 
+// Scene geometry is rendered with a negative Vulkan viewport height, while
+// fullscreen post-process passes use a positive viewport. Convert a sampled
+// framebuffer UV before reconstructing the scene's projection-space position.
+vec2 FramebufferUvToSceneProjectionUv(vec2 framebufferUv)
+{
+  return vec2(framebufferUv.x, 1.0 - framebufferUv.y);
+}
+
 // Construct view frustum
 ViewFrustum CreateViewFrustum(ivec2 viewportSize, mat4 invProjection)
 {

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -528,10 +528,16 @@ glslFragment: |
     
     // Total specular IBL contribution.
     vec3 specularIBL = (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance;
-    
-    // Total ambient lighting contribution. Screen-space AO only affects the
-    // diffuse portion similar to the glTF occlusion workflow.
-    return diffuseIBL * material.ao + specularIBL;
+
+    // Ambient occlusion applies to all indirect lighting. Use a view- and
+    // roughness-dependent approximation for specular IBL so smooth surfaces
+    // retain plausible reflections without leaking them into occluded areas.
+    float ambientOcclusion = clamp(material.ao, 0.0, 1.0);
+    float specularOcclusion = CalculateSpecularOcclusion(
+      ambientOcclusion,
+      cosLo,
+      material.roughness);
+    return diffuseIBL * ambientOcclusion + specularIBL * specularOcclusion;
   }
   
   // Constant normal incidence Fresnel factor for all dielectrics.

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -546,7 +546,8 @@ glslFragment: |
   void main() 
   {
     const vec3 viewDirection = normalize(vin.worldPosition - frame.cameraPosition.xyz);
-    const vec2 viewportUv = gl_FragCoord.xy * rcp(frame.viewportSize);
+    const vec2 viewportUv = gl_FragCoord.xy *
+      rcp(vec2(textureSize(g_aoSampler, 0)));
     
     MaterialData material = GetMaterialData();
     material.albedo = material.albedo * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.albedoSampler))], vin.texcoord) * vin.color;
@@ -595,7 +596,8 @@ glslFragment: |
         min(min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(LIGHTS_PER_TILE)), availableLights);
     #endif
     
-    outColor.xyz = AmbientLighting(material, F0, Lr, normal, cosLo);
+    const vec3 indirectLighting = AmbientLighting(material, F0, Lr, normal, cosLo);
+    outColor.xyz = indirectLighting;
     
     for(int i = 0; i < numLights; i++)
     {
@@ -613,6 +615,10 @@ glslFragment: |
 
         outColor.xyz += CalculateLighting(light.instance[index], index, material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
     }
+
+    outColor.xyz = indirectLighting +
+      (outColor.xyz - indirectLighting) *
+      CalculateDirectLightingOcclusion(material.ao);
 
     outColor.a = material.albedo.a;
   }

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -825,10 +825,16 @@ glslFragment: |
     
     // Total specular IBL contribution.
     vec3 specularIBL = (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance;
-    
-    // Total ambient lighting contribution. Occlusion affects only the diffuse
-    // portion as per glTF 2.0 specification.
-    return diffuseIBL * material.occlusionStrength + specularIBL;
+
+    // Occlusion affects indirect lighting, not analytic lights. Apply the
+    // visibility directly to diffuse IBL and use a view- and roughness-aware
+    // approximation for specular IBL.
+    float ambientOcclusion = clamp(material.occlusionStrength, 0.0, 1.0);
+    float specularOcclusion = CalculateSpecularOcclusion(
+      ambientOcclusion,
+      cosLo,
+      material.roughnessFactor);
+    return diffuseIBL * ambientOcclusion + specularIBL * specularOcclusion;
   }
 
   #ifdef CLEAR_COAT
@@ -875,12 +881,16 @@ glslFragment: |
     return shadow * (specularBRDF * Lradiance * cosLi) * falloff;
   }
 
-  vec3 ClearCoatAmbientLighting(float roughness, vec3 F0, vec3 Lr, vec3 normal, float cosLo)
+  vec3 ClearCoatAmbientLighting(float roughness, vec3 F0, vec3 Lr, vec3 normal, float cosLo, float ambientOcclusion)
   {
     int specularTextureLevels = textureQueryLevels(g_envCubemap);
     vec3 specularIrradiance = textureLod(g_envCubemap, Lr, roughness * specularTextureLevels).rgb;
     vec2 specularBRDF = texture(g_brdfSampler, vec2(cosLo, roughness)).rg;
-    return (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance;
+    float specularOcclusion = CalculateSpecularOcclusion(
+      ambientOcclusion,
+      cosLo,
+      roughness);
+    return (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance * specularOcclusion;
   }
   #endif
 
@@ -928,12 +938,16 @@ glslFragment: |
     return shadow * (specularBRDF * Lradiance * cosLi) * falloff;
   }
 
-  vec3 SheenAmbientLighting(float roughness, vec3 color, vec3 Lr, vec3 normal, float cosLo)
+  vec3 SheenAmbientLighting(float roughness, vec3 color, vec3 Lr, vec3 normal, float cosLo, float ambientOcclusion)
   {
     int specularTextureLevels = textureQueryLevels(g_envCubemap);
     vec3 specularIrradiance = textureLod(g_envCubemap, Lr, roughness * specularTextureLevels).rgb;
     vec2 specularBRDF = texture(g_brdfSampler, vec2(cosLo, roughness)).rg;
-    return (color * specularBRDF.x + specularBRDF.y) * specularIrradiance;
+    float specularOcclusion = CalculateSpecularOcclusion(
+      ambientOcclusion,
+      cosLo,
+      roughness);
+    return (color * specularBRDF.x + specularBRDF.y) * specularIrradiance * specularOcclusion;
   }
   #endif
   
@@ -1081,10 +1095,10 @@ glslFragment: |
     
     outColor.xyz += AmbientLighting(material, F0, Lr, normal, cosLo);
   #ifdef CLEAR_COAT
-    outColor.xyz += material.clearcoatFactor * ClearCoatAmbientLighting(material.clearcoatRoughnessFactor, Fdielectric, LrCC, clearcoatNormal, cosLoCC);
+    outColor.xyz += material.clearcoatFactor * ClearCoatAmbientLighting(material.clearcoatRoughnessFactor, Fdielectric, LrCC, clearcoatNormal, cosLoCC, material.occlusionStrength);
   #endif
   #ifdef SHEEN
-    outColor.xyz += SheenAmbientLighting(material.sheenRoughnessFactor, material.sheenColorFactor.rgb, Lr, normal, cosLo);
+    outColor.xyz += SheenAmbientLighting(material.sheenRoughnessFactor, material.sheenColorFactor.rgb, Lr, normal, cosLo, material.occlusionStrength);
   #endif
     
     for(int i = 0; i < numLights; i++)

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -826,9 +826,9 @@ glslFragment: |
     // Total specular IBL contribution.
     vec3 specularIBL = (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance;
 
-    // Occlusion affects indirect lighting, not analytic lights. Apply the
-    // visibility directly to diffuse IBL and use a view- and roughness-aware
-    // approximation for specular IBL.
+    // Apply visibility directly to diffuse IBL and use a view- and
+    // roughness-aware approximation for specular IBL. The bounded analytic
+    // contact term is composed separately after direct-light accumulation.
     float ambientOcclusion = clamp(material.occlusionStrength, 0.0, 1.0);
     float specularOcclusion = CalculateSpecularOcclusion(
       ambientOcclusion,
@@ -957,7 +957,8 @@ glslFragment: |
   void main() 
   {
     const vec3 viewDirection = normalize(vin.worldPosition - frame.cameraPosition.xyz);
-    const vec2 viewportUv = gl_FragCoord.xy * rcp(frame.viewportSize);
+    const vec2 viewportUv = gl_FragCoord.xy *
+      rcp(vec2(textureSize(g_aoSampler, 0)));
     
     MaterialData material = GetMaterialData();
     if(material.baseColorSampler != 0)
@@ -973,10 +974,11 @@ glslFragment: |
       material.roughnessFactor = material.roughnessFactor * orm.g;
     }
 
-    float occlusion = 1.0;
+    float screenSpaceOcclusion = 1.0;
   #ifndef DISABLE_SCREEN_SPACE_AO
-    occlusion = texture(g_aoSampler, viewportUv).r;
+    screenSpaceOcclusion = texture(g_aoSampler, viewportUv).r;
   #endif
+    float occlusion = screenSpaceOcclusion;
     if(material.occlusionSampler != 0)
     {
       float occlusionTex = texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.occlusionSampler))], vin.texcoord).r;
@@ -1100,6 +1102,8 @@ glslFragment: |
   #ifdef SHEEN
     outColor.xyz += SheenAmbientLighting(material.sheenRoughnessFactor, material.sheenColorFactor.rgb, Lr, normal, cosLo, material.occlusionStrength);
   #endif
+
+    const vec3 nonAnalyticLighting = outColor.xyz;
     
     for(int i = 0; i < numLights; i++)
     {
@@ -1123,6 +1127,10 @@ glslFragment: |
         outColor.xyz += SheenLighting(light.instance[index], material.sheenRoughnessFactor, material.sheenColorFactor.rgb, -viewDirection, cosLo, normal, vin.worldPosition);
   #endif
     }
+
+    outColor.xyz = nonAnalyticLighting +
+      (outColor.xyz - nonAnalyticLighting) *
+      CalculateDirectLightingOcclusion(screenSpaceOcclusion);
 
   #ifdef TRANSMISSION
     float dielectricFresnel =

--- a/Editor.Tests/EditorEngineProtocolTests.cs
+++ b/Editor.Tests/EditorEngineProtocolTests.cs
@@ -121,8 +121,13 @@ public sealed class EditorEngineProtocolTests
         Assert.Equal(61, ProtocolRequest.SetEditorSimulationFieldNumber);
         Assert.Equal(62, ProtocolRequest.GetEditorSimulationStateFieldNumber);
         Assert.Equal(64, ProtocolRequest.SetEditorStatsModeFieldNumber);
+        Assert.Equal(65, ProtocolRequest.SetEditorRenderModeFieldNumber);
+        Assert.Equal(66, ProtocolRequest.GetEditorRenderModeFieldNumber);
         Assert.Equal(10, ProtocolResponse.EmptyResultFieldNumber);
         Assert.Equal(19, ProtocolResponse.ViewportEventBatchResultFieldNumber);
+        Assert.Equal(
+            23,
+            ProtocolResponse.EditorRenderModeResultFieldNumber);
     }
 
 }

--- a/Editor.Tests/EngineProtocolClientTests.cs
+++ b/Editor.Tests/EngineProtocolClientTests.cs
@@ -261,6 +261,74 @@ public sealed class EngineProtocolClientTests
             client.SetEditorStatsModeAsync(mode));
     }
 
+    [Theory]
+    [InlineData(EditorRenderMode.Lit)]
+    [InlineData(EditorRenderMode.AmbientOcclusion)]
+    [InlineData(EditorRenderMode.Cascades)]
+    [InlineData(EditorRenderMode.LightTiles)]
+    public async Task SetEditorRenderModeAsync_SendsExplicitTypedMode(
+        EditorRenderMode mode)
+    {
+        ProtocolRequest? capturedRequest = null;
+        var client = CreateClient(request =>
+        {
+            capturedRequest = request;
+            return Success(
+                request,
+                response => response.BoolResult =
+                    new BoolResult { Value = true });
+        });
+
+        Assert.True(await client.SetEditorRenderModeAsync(mode));
+
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(
+            ProtocolRequest.CommandOneofCase.SetEditorRenderMode,
+            capturedRequest.CommandCase);
+        Assert.Equal(mode, capturedRequest.SetEditorRenderMode.Mode);
+    }
+
+    [Theory]
+    [InlineData(EditorRenderMode.Unspecified)]
+    [InlineData((EditorRenderMode)99)]
+    public async Task SetEditorRenderModeAsync_RejectsInvalidModes(
+        EditorRenderMode mode)
+    {
+        var client = CreateClient(request =>
+            Success(
+                request,
+                response => response.BoolResult =
+                    new BoolResult { Value = true }));
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(() =>
+            client.SetEditorRenderModeAsync(mode));
+    }
+
+    [Fact]
+    public async Task GetEditorRenderModeAsync_ReadsTypedEngineState()
+    {
+        ProtocolRequest? capturedRequest = null;
+        var client = CreateClient(request =>
+        {
+            capturedRequest = request;
+            return Success(
+                request,
+                response => response.EditorRenderModeResult =
+                    new EditorRenderModeResult
+                    {
+                        Mode = EditorRenderMode.Cascades
+                    });
+        });
+
+        Assert.Equal(
+            EditorRenderMode.Cascades,
+            await client.GetEditorRenderModeAsync());
+        Assert.NotNull(capturedRequest);
+        Assert.Equal(
+            ProtocolRequest.CommandOneofCase.GetEditorRenderMode,
+            capturedRequest.CommandCase);
+    }
+
     [Fact]
     public async Task AnimatorParameters_UseTypedProtocolValues()
     {

--- a/Editor.Tests/SceneViewportInteractionTests.cs
+++ b/Editor.Tests/SceneViewportInteractionTests.cs
@@ -5,6 +5,33 @@ namespace Editor.Tests;
 public sealed class SceneViewportInteractionTests
 {
     [Theory]
+    [InlineData("lit", SceneViewRenderMode.Lit)]
+    [InlineData("ambient_occlusion", SceneViewRenderMode.AmbientOcclusion)]
+    [InlineData("Ambient Occlusion", SceneViewRenderMode.AmbientOcclusion)]
+    [InlineData("AO", SceneViewRenderMode.AmbientOcclusion)]
+    [InlineData("csm", SceneViewRenderMode.Cascades)]
+    [InlineData("light-tiles", SceneViewRenderMode.LightTiles)]
+    public void RenderModeName_ParsesMcpValues(
+        string value,
+        SceneViewRenderMode expected)
+    {
+        Assert.True(SceneViewRenderModeNames.TryParse(value, out var mode));
+        Assert.Equal(expected, mode);
+        Assert.Contains(
+            SceneViewRenderModeNames.ToExternalName(mode),
+            SceneViewRenderModeNames.Supported);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("depth")]
+    [InlineData("ambient")]
+    public void RenderModeName_RejectsUnsupportedValues(string value)
+    {
+        Assert.False(SceneViewRenderModeNames.TryParse(value, out _));
+    }
+
+    [Theory]
     [InlineData('Q', EditorViewportTransformOperation.Select)]
     [InlineData('W', EditorViewportTransformOperation.Translate)]
     [InlineData('E', EditorViewportTransformOperation.Rotate)]

--- a/Editor/Mcp/McpEditorTools.cs
+++ b/Editor/Mcp/McpEditorTools.cs
@@ -3,6 +3,7 @@
 using ModelContextProtocol.Server;
 using SailorEditor.AI;
 using SailorEditor.Commands;
+using SailorEditor.Scene;
 using SailorEditor.Services;
 using SailorEditor.Workspace;
 
@@ -19,6 +20,11 @@ public sealed record McpEditorStateSnapshot(
     long WorkspaceEpoch,
     int UndoCount,
     int RedoCount);
+
+public sealed record McpEditorRenderModeSnapshot(
+    bool Succeeded,
+    string Mode,
+    string Message);
 
 internal sealed class McpEditorTools
 {
@@ -73,6 +79,27 @@ internal sealed class McpEditorTools
                 Name = "sailor_editor_get_state",
                 Description =
                     "Get the active Sailor Editor project, engine, world, selection and undo state.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (CancellationToken cancellationToken) =>
+                GetRenderModeAsync(cancellationToken),
+            new()
+            {
+                Name = "sailor_editor_get_render_mode",
+                Description =
+                    "Get the active Scene View rendering mode. Canonical modes are lit, ambient_occlusion, cascades and light_tiles.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
+            (string mode, CancellationToken cancellationToken) =>
+                SetRenderModeAsync(mode, cancellationToken),
+            new()
+            {
+                Name = "sailor_editor_set_render_mode",
+                Description =
+                    "Set the transient Scene View rendering mode without changing the scene or project settings. " +
+                    "Accepted canonical modes are lit, ambient_occlusion, cascades and light_tiles.",
                 UseStructuredContent = true,
             }),
         McpServerTool.Create(
@@ -303,6 +330,54 @@ internal sealed class McpEditorTools
         CancellationToken cancellationToken = default) =>
         _editorThread.InvokeAsync(
             () => Task.FromResult(_sceneSnapshots.Build(includeYaml)),
+            cancellationToken);
+
+    public Task<McpEditorRenderModeSnapshot> GetRenderModeAsync(
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            async () =>
+            {
+                var mode = await _engine.GetEditorRenderModeAsync(
+                    cancellationToken);
+                return mode is not null
+                    ? new McpEditorRenderModeSnapshot(
+                        true,
+                        SceneViewRenderModeNames.ToExternalName(mode.Value),
+                        "Scene View render mode read successfully.")
+                    : new McpEditorRenderModeSnapshot(
+                        false,
+                        string.Empty,
+                        "The Engine is not running or rejected the render mode query.");
+            },
+            cancellationToken);
+
+    public Task<McpEditorRenderModeSnapshot> SetRenderModeAsync(
+        string mode,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            async () =>
+            {
+                if (!SceneViewRenderModeNames.TryParse(mode, out var parsed))
+                {
+                    return new McpEditorRenderModeSnapshot(
+                        false,
+                        string.Empty,
+                        "Unsupported render mode. Use one of: " +
+                        string.Join(", ", SceneViewRenderModeNames.Supported) + ".");
+                }
+
+                var succeeded = await _engine.SetEditorRenderModeAsync(
+                    parsed,
+                    cancellationToken);
+                return new McpEditorRenderModeSnapshot(
+                    succeeded,
+                    succeeded
+                        ? SceneViewRenderModeNames.ToExternalName(parsed)
+                        : string.Empty,
+                    succeeded
+                        ? "Scene View render mode updated."
+                        : "The Engine is not running or rejected the render mode command.");
+            },
             cancellationToken);
 
     public Task<McpGameObjectSnapshot?> GetSceneObjectAsync(

--- a/Editor/Protocol/EngineProtocolClient.cs
+++ b/Editor/Protocol/EngineProtocolClient.cs
@@ -466,6 +466,41 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
             nameof(ProtocolRequest.SetEditorStatsMode));
     }
 
+    public async Task<bool> SetEditorRenderModeAsync(
+        EditorRenderMode mode,
+        CancellationToken cancellationToken = default)
+    {
+        ValidateEditorRenderMode(mode);
+
+        return ReadBool(
+            await SendAsync(
+                    new ProtocolRequest
+                    {
+                        SetEditorRenderMode = new EditorRenderModeRequest
+                        {
+                            Mode = mode
+                        }
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false),
+            nameof(ProtocolRequest.SetEditorRenderMode));
+    }
+
+    public async Task<EditorRenderMode> GetEditorRenderModeAsync(
+        CancellationToken cancellationToken = default)
+    {
+        var result = RequireResult<EditorRenderModeResult>(
+            (await SendAsync(
+                    new ProtocolRequest
+                    {
+                        GetEditorRenderMode = new Empty()
+                    },
+                    cancellationToken)
+                .ConfigureAwait(false)).EditorRenderModeResult,
+            nameof(ProtocolRequest.GetEditorRenderMode));
+        return ValidateEditorRenderMode(result.Mode);
+    }
+
     public async Task<bool> PreviewAudioAssetAsync(
         string fileId,
         CancellationToken cancellationToken = default)
@@ -1456,6 +1491,19 @@ internal sealed class EngineProtocolClient : IDisposable, IAsyncDisposable
                 nameof(space),
                 space,
                 "The viewport transform space is unsupported.");
+
+    static EditorRenderMode ValidateEditorRenderMode(
+        EditorRenderMode mode)
+        => mode is
+            EditorRenderMode.Lit or
+            EditorRenderMode.AmbientOcclusion or
+            EditorRenderMode.Cascades or
+            EditorRenderMode.LightTiles
+            ? mode
+            : throw new ArgumentOutOfRangeException(
+                nameof(mode),
+                mode,
+                "The Editor render mode is unsupported.");
 
     static void RequireEmpty(ProtocolResponse response, string commandName)
         => RequireResult<Empty>(response.EmptyResult, commandName);

--- a/Editor/Protocol/Generated/EditorEngine.cs
+++ b/Editor/Protocol/Generated/EditorEngine.cs
@@ -25,7 +25,7 @@ namespace SailorEditor.Protocol.Generated {
       byte[] descriptorData = global::System.Convert.FromBase64String(
           string.Concat(
             "ChNlZGl0b3JfZW5naW5lLnByb3RvEhBzYWlsb3IuZWRpdG9yLnYxIgcKBUVt",
-            "cHR5IvMdCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
+            "cHR5IvseCg9Qcm90b2NvbFJlcXVlc3QSGAoQcHJvdG9jb2xfdmVyc2lvbhgB",
             "IAEoDRISCgpyZXF1ZXN0X2lkGAIgASgEEjkKCmluaXRpYWxpemUYCiABKAsy",
             "Iy5zYWlsb3IuZWRpdG9yLnYxLkluaXRpYWxpemVSZXF1ZXN0SAASKAoFc3Rh",
             "cnQYCyABKAsyFy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASJwoEc3RvcBgM",
@@ -108,158 +108,171 @@ namespace SailorEditor.Protocol.Generated {
             "RW1wdHlIABI+ChNwcmV2aWV3X2F1ZGlvX2Fzc2V0GD8gASgLMh8uc2FpbG9y",
             "LmVkaXRvci52MS5GaWxlSWRSZXF1ZXN0SAASSQoVc2V0X2VkaXRvcl9zdGF0",
             "c19tb2RlGEAgASgLMiguc2FpbG9yLmVkaXRvci52MS5FZGl0b3JTdGF0c01v",
-            "ZGVSZXF1ZXN0SABCCQoHY29tbWFuZEoECAMQCkoECDIQM0oECEEQZFIYY3Jl",
-            "YXRlX21vZGVsX2dhbWVfb2JqZWN0Uh5yZXNvbHZlX3ZpZXdwb3J0X2Ryb3Bf",
-            "cG9zaXRpb24i3gcKEFByb3RvY29sUmVzcG9uc2USGAoQcHJvdG9jb2xfdmVy",
-            "c2lvbhgBIAEoDRISCgpyZXF1ZXN0X2lkGAIgASgEEg8KB3N1Y2Nlc3MYAyAB",
-            "KAgSDQoFZXJyb3IYBCABKAkSJAocc3VwcG9ydHNfc3RyaWN0X2luc3RhbmNl",
-            "X2lkcxgFIAEoCBIvCgxlbXB0eV9yZXN1bHQYCiABKAsyFy5zYWlsb3IuZWRp",
-            "dG9yLnYxLkVtcHR5SAASMwoLYm9vbF9yZXN1bHQYCyABKAsyHC5zYWlsb3Iu",
-            "ZWRpdG9yLnYxLkJvb2xSZXN1bHRIABI1CgxpbnQzMl9yZXN1bHQYDCABKAsy",
-            "HS5zYWlsb3IuZWRpdG9yLnYxLkludDMyUmVzdWx0SAASNwoNdWludDMyX3Jl",
-            "c3VsdBgNIAEoCzIeLnNhaWxvci5lZGl0b3IudjEuVUludDMyUmVzdWx0SAAS",
-            "NwoNdWludDY0X3Jlc3VsdBgOIAEoCzIeLnNhaWxvci5lZGl0b3IudjEuVUlu",
-            "dDY0UmVzdWx0SAASNwoNc3RyaW5nX3Jlc3VsdBgPIAEoCzIeLnNhaWxvci5l",
-            "ZGl0b3IudjEuU3RyaW5nUmVzdWx0SAASQAoSc3RyaW5nX2xpc3RfcmVzdWx0",
-            "GBAgASgLMiIuc2FpbG9yLmVkaXRvci52MS5TdHJpbmdMaXN0UmVzdWx0SAAS",
-            "TQoZYXNzZXRfcmVsb2FkX3N0YXRlX3Jlc3VsdBgRIAEoCzIoLnNhaWxvci5l",
-            "ZGl0b3IudjEuQXNzZXRSZWxvYWRTdGF0ZVJlc3VsdEgAEkAKEmluc3RhbmNl",
-            "X2lkX3Jlc3VsdBgSIAEoCzIiLnNhaWxvci5lZGl0b3IudjEuSW5zdGFuY2VJ",
-            "ZFJlc3VsdEgAElEKG3ZpZXdwb3J0X2V2ZW50X2JhdGNoX3Jlc3VsdBgTIAEo",
-            "CzIqLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRFdmVudEJhdGNoUmVzdWx0",
-            "SAASOQoOdmVjdG9yNF9yZXN1bHQYFCABKAsyHy5zYWlsb3IuZWRpdG9yLnYx",
-            "LlZlY3RvcjRSZXN1bHRIABJPChp2aWV3cG9ydF90b29sX3N0YXRlX3Jlc3Vs",
-            "dBgVIAEoCzIpLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUb29sU3RhdGVS",
-            "ZXN1bHRIABJGChVhbmltYXRvcl9zdGF0ZV9yZXN1bHQYFiABKAsyJS5zYWls",
-            "b3IuZWRpdG9yLnYxLkFuaW1hdG9yU3RhdGVSZXN1bHRIAEIICgZyZXN1bHRK",
-            "BAgGEApKBAgXEGQiJgoRSW5pdGlhbGl6ZVJlcXVlc3QSEQoJYXJndW1lbnRz",
-            "GAEgAygJIiEKDENvdW50UmVxdWVzdBIRCgltYXhfY291bnQYASABKA0iIAoN",
-            "RmlsZUlkUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJIucBChpDcmVhdGVNb2Rl",
-            "bEluc3RhbmNlUmVxdWVzdBIVCg1tb2RlbF9maWxlX2lkGAEgASgJEgwKBG5h",
-            "bWUYAiABKAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAMgASgJEhgKEGNyZWF0",
-            "ZV9oaWVyYXJjaHkYBCABKAgSHAoUYXBwbHlfd29ybGRfcG9zaXRpb24YBSAB",
-            "KAgSMQoOd29ybGRfcG9zaXRpb24YBiABKAsyGS5zYWlsb3IuZWRpdG9yLnYx",
-            "LlZlY3RvcjQSHQoVcHJlZmVycmVkX2luc3RhbmNlX2lkGAcgASgJIigKEUlu",
-            "c3RhbmNlSWRSZXF1ZXN0EhMKC2luc3RhbmNlX2lkGAEgASgJIigKEVZpZXdw",
-            "b3J0SWRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEImAKE1ZpZXdwb3J0",
-            "UmVjdFJlcXVlc3QSFAoMd2luZG93X3Bvc194GAEgASgNEhQKDHdpbmRvd19w",
-            "b3NfeRgCIAEoDRINCgV3aWR0aBgDIAEoDRIOCgZoZWlnaHQYBCABKA0iLAoL",
-            "U2l6ZVJlcXVlc3QSDQoFd2lkdGgYASABKA0SDgoGaGVpZ2h0GAIgASgNIioK",
-            "F0VkaXRvclNpbXVsYXRpb25SZXF1ZXN0Eg8KB2VuYWJsZWQYASABKAgiSQoW",
-            "RWRpdG9yU3RhdHNNb2RlUmVxdWVzdBIvCgRtb2RlGAEgASgOMiEuc2FpbG9y",
-            "LmVkaXRvci52MS5FZGl0b3JTdGF0c01vZGUimQEKFVJlbW90ZVZpZXdwb3J0",
-            "UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIUCgx3aW5kb3dfcG9zX3gY",
-            "AiABKA0SFAoMd2luZG93X3Bvc195GAMgASgNEg0KBXdpZHRoGAQgASgNEg4K",
-            "BmhlaWdodBgFIAEoDRIPCgd2aXNpYmxlGAYgASgIEg8KB2ZvY3VzZWQYByAB",
-            "KAgiZQoZUmVtb3RlVmlld3BvcnRIb3N0UmVxdWVzdBITCgt2aWV3cG9ydF9p",
-            "ZBgBIAEoBBIYChBob3N0X2hhbmRsZV9raW5kGAIgASgNEhkKEWhvc3RfaGFu",
-            "ZGxlX3ZhbHVlGAMgASgEIvwBChpSZW1vdGVWaWV3cG9ydElucHV0UmVxdWVz",
-            "dBITCgt2aWV3cG9ydF9pZBgBIAEoBBIMCgRraW5kGAIgASgNEhEKCXBvaW50",
-            "ZXJfeBgDIAEoAhIRCglwb2ludGVyX3kYBCABKAISFQoNd2hlZWxfZGVsdGFf",
-            "eBgFIAEoAhIVCg13aGVlbF9kZWx0YV95GAYgASgCEhAKCGtleV9jb2RlGAcg",
-            "ASgNEg4KBmJ1dHRvbhgIIAEoDRIRCgltb2RpZmllcnMYCSABKA0SDwoHcHJl",
-            "c3NlZBgKIAEoCBIPCgdmb2N1c2VkGAsgASgIEhAKCGNhcHR1cmVkGAwgASgI",
-            "IkMKHk1hbmFnZWRNdXRhdGlvblJldmlzaW9uUmVxdWVzdBIMCgRraW5kGAEg",
-            "ASgNEhMKC2luc3RhbmNlX2lkGAIgASgJIkAKE1VwZGF0ZU9iamVjdFJlcXVl",
-            "c3QSEwoLaW5zdGFuY2VfaWQYASABKAkSFAoMeWFtbF9jaGFuZ2VzGAIgASgJ",
-            "ImYKFVJlcGFyZW50T2JqZWN0UmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEo",
-            "CRIaChJwYXJlbnRfaW5zdGFuY2VfaWQYAiABKAkSHAoUa2VlcF93b3JsZF90",
-            "cmFuc2Zvcm0YAyABKAgiVAoXQ3JlYXRlR2FtZU9iamVjdFJlcXVlc3QSGgoS",
-            "cGFyZW50X2luc3RhbmNlX2lkGAEgASgJEh0KFXByZWZlcnJlZF9pbnN0YW5j",
-            "ZV9pZBgCIAEoCSJmChNBZGRDb21wb25lbnRSZXF1ZXN0EhMKC2luc3RhbmNl",
-            "X2lkGAEgASgJEhsKE2NvbXBvbmVudF90eXBlX25hbWUYAiABKAkSHQoVcHJl",
-            "ZmVycmVkX2luc3RhbmNlX2lkGAMgASgJIuYBChhBbmltYXRvclBhcmFtZXRl",
-            "clJlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkSDAoEbmFtZRgCIAEoCRIV",
-            "CgtmbG9hdF92YWx1ZRgDIAEoAkgAEhMKCWludF92YWx1ZRgEIAEoEUgAEhQK",
-            "CmJvb2xfdmFsdWUYBSABKAhIABIqCgd0cmlnZ2VyGAYgASgLMhcuc2FpbG9y",
-            "LmVkaXRvci52MS5FbXB0eUgAEjAKDXJlc2V0X3RyaWdnZXIYByABKAsyFy5z",
-            "YWlsb3IuZWRpdG9yLnYxLkVtcHR5SABCBwoFdmFsdWUiRwoYSW5zdGFudGlh",
-            "dGVQcmVmYWJSZXF1ZXN0Eg8KB2ZpbGVfaWQYASABKAkSGgoScGFyZW50X2lu",
-            "c3RhbmNlX2lkGAIgASgJInAKIEluc3RhbnRpYXRlUHJlZmFiRnJvbVlhbWxS",
-            "ZXF1ZXN0EhMKC3ByZWZhYl95YW1sGAEgASgJEhoKEnBhcmVudF9pbnN0YW5j",
-            "ZV9pZBgCIAEoCRIbChNzdHJpY3RfaW5zdGFuY2VfaWRzGAMgASgIIlUKElZp",
-            "ZXdwb3J0UmF5UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBIUCgxub3Jt",
-            "YWxpemVkX3gYAiABKAISFAoMbm9ybWFsaXplZF95GAMgASgCIqABCiBJbnN0",
-            "YW50aWF0ZVByZWZhYkluc3RhbmNlUmVxdWVzdBIPCgdmaWxlX2lkGAEgASgJ",
-            "EhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIcChRhcHBseV93b3JsZF9w",
-            "b3NpdGlvbhgDIAEoCBIxCg53b3JsZF9wb3NpdGlvbhgEIAEoCzIZLnNhaWxv",
-            "ci5lZGl0b3IudjEuVmVjdG9yNCJBChVWaWV3cG9ydE9iamVjdFJlcXVlc3QS",
-            "EwoLdmlld3BvcnRfaWQYASABKAQSEwoLaW5zdGFuY2VfaWQYAiABKAkiOQoR",
-            "UHJlZmFiTGlua1JlcXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkSDwoHZmls",
-            "ZV9pZBgCIAEoCSKpAQoYVmlld3BvcnRUb29sU3RhdGVSZXF1ZXN0EhMKC3Zp",
-            "ZXdwb3J0X2lkGAEgASgEEj8KCW9wZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5l",
-            "ZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UY",
-            "AyABKA4yKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtU3Bh",
-            "Y2UiKAoQU2VsZWN0aW9uUmVxdWVzdBIUCgxpbnN0YW5jZV9pZHMYASADKAki",
-            "JQoVU2hvd01haW5XaW5kb3dSZXF1ZXN0EgwKBHNob3cYASABKAgiiAEKHFJl",
-            "bmRlclBhdGhUcmFjZWRJbWFnZVJlcXVlc3QSEwoLb3V0cHV0X3BhdGgYASAB",
-            "KAkSEwoLaW5zdGFuY2VfaWQYAiABKAkSDgoGaGVpZ2h0GAMgASgNEhkKEXNh",
-            "bXBsZXNfcGVyX3BpeGVsGAQgASgNEhMKC21heF9ib3VuY2VzGAUgASgNIhsK",
-            "CkJvb2xSZXN1bHQSDQoFdmFsdWUYASABKAgiHAoLSW50MzJSZXN1bHQSDQoF",
-            "dmFsdWUYASABKAUiHQoMVUludDMyUmVzdWx0Eg0KBXZhbHVlGAEgASgNIh0K",
-            "DFVJbnQ2NFJlc3VsdBINCgV2YWx1ZRgBIAEoBCIwCgxTdHJpbmdSZXN1bHQS",
-            "EQoJaGFzX3ZhbHVlGAEgASgIEg0KBXZhbHVlGAIgASgJIiIKEFN0cmluZ0xp",
-            "c3RSZXN1bHQSDgoGdmFsdWVzGAEgAygJIoQBChZBc3NldFJlbG9hZFN0YXRl",
-            "UmVzdWx0EhEKCWF2YWlsYWJsZRgBIAEoCBIaChJyZXF1ZXN0X2dlbmVyYXRp",
-            "b24YAiABKAQSHAoUY29tcGxldGVkX2dlbmVyYXRpb24YAyABKAQSHQoVc3Vj",
-            "Y2Vzc2Z1bF9nZW5lcmF0aW9uGAQgASgEIjoKEEluc3RhbmNlSWRSZXN1bHQS",
-            "EQoJc3VjY2VlZGVkGAEgASgIEhMKC2luc3RhbmNlX2lkGAIgASgJIjkKDVZl",
-            "Y3RvcjRSZXN1bHQSKAoFdmFsdWUYASABKAsyGS5zYWlsb3IuZWRpdG9yLnYx",
-            "LlZlY3RvcjQikwEKF1ZpZXdwb3J0VG9vbFN0YXRlUmVzdWx0Ej8KCW9wZXJh",
-            "dGlvbhgBIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zv",
-            "cm1PcGVyYXRpb24SNwoFc3BhY2UYAiABKA4yKC5zYWlsb3IuZWRpdG9yLnYx",
-            "LlZpZXdwb3J0VHJhbnNmb3JtU3BhY2UiqAIKE0FuaW1hdG9yU3RhdGVSZXN1",
-            "bHQSFgoOaGFzX2NvbnRyb2xsZXIYASABKAgSGwoTY29udHJvbGxlcl9yZXZp",
-            "c2lvbhgCIAEoBBIXCg9hY3RpdmVfc3RhdGVfaWQYAyABKAQSGQoRYWN0aXZl",
-            "X3N0YXRlX25hbWUYBCABKAkSGQoRYWN0aXZlX3N0YXRlX3RpbWUYBSABKAIS",
-            "FQoNdHJhbnNpdGlvbmluZxgGIAEoCBIcChRkZXN0aW5hdGlvbl9zdGF0ZV9p",
-            "ZBgHIAEoBBIeChZkZXN0aW5hdGlvbl9zdGF0ZV9uYW1lGAggASgJEh4KFmRl",
-            "c3RpbmF0aW9uX3N0YXRlX3RpbWUYCSABKAISGAoQdHJhbnNpdGlvbl9hbHBo",
-            "YRgKIAEoAiI1CgdWZWN0b3I0EgkKAXgYASABKAISCQoBeRgCIAEoAhIJCgF6",
-            "GAMgASgCEgkKAXcYBCABKAIiNgoWVmlld3BvcnRTZWxlY3Rpb25FdmVudBIc",
-            "ChRzZWxlY3RlZF9pbnN0YW5jZV9pZBgBIAEoCSLWAwoWVmlld3BvcnRUcmFu",
-            "c2Zvcm1FdmVudBITCgtpbnN0YW5jZV9pZBgBIAEoCRI/CglvcGVyYXRpb24Y",
-            "AiABKA4yLC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VHJhbnNmb3JtT3Bl",
-            "cmF0aW9uEjcKBXNwYWNlGAMgASgOMiguc2FpbG9yLmVkaXRvci52MS5WaWV3",
-            "cG9ydFRyYW5zZm9ybVNwYWNlEjIKD2JlZm9yZV9wb3NpdGlvbhgEIAEoCzIZ",
-            "LnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNBIyCg9iZWZvcmVfcm90YXRpb24Y",
-            "BSABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQSLwoMYmVmb3JlX3Nj",
-            "YWxlGAYgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0EjEKDmFmdGVy",
-            "X3Bvc2l0aW9uGAcgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0EjEK",
-            "DmFmdGVyX3JvdGF0aW9uGAggASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0",
-            "b3I0Ei4KC2FmdGVyX3NjYWxlGAkgASgLMhkuc2FpbG9yLmVkaXRvci52MS5W",
-            "ZWN0b3I0IlUKFlZpZXdwb3J0QXNzZXREcm9wRXZlbnQSDwoHZmlsZV9pZBgB",
-            "IAEoCRIUCgxub3JtYWxpemVkX3gYAiABKAISFAoMbm9ybWFsaXplZF95GAMg",
-            "ASgCIi0KGVZpZXdwb3J0VG9vbFNob3J0Y3V0RXZlbnQSEAoIa2V5X2NvZGUY",
-            "ASABKA0i2QIKDVZpZXdwb3J0RXZlbnQSEAoIcmV2aXNpb24YASABKAQSIQoZ",
-            "bWFuYWdlZF9tdXRhdGlvbl9yZXZpc2lvbhgCIAEoBBI9CglzZWxlY3Rpb24Y",
-            "CiABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0U2VsZWN0aW9uRXZl",
-            "bnRIABI9Cgl0cmFuc2Zvcm0YCyABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZp",
-            "ZXdwb3J0VHJhbnNmb3JtRXZlbnRIABI+Cgphc3NldF9kcm9wGAwgASgLMigu",
-            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEFzc2V0RHJvcEV2ZW50SAASRAoN",
-            "dG9vbF9zaG9ydGN1dBgNIAEoCzIrLnNhaWxvci5lZGl0b3IudjEuVmlld3Bv",
-            "cnRUb29sU2hvcnRjdXRFdmVudEgAQgkKB3BheWxvYWRKBAgDEAoiSwoYVmll",
-            "d3BvcnRFdmVudEJhdGNoUmVzdWx0Ei8KBmV2ZW50cxgBIAMoCzIfLnNhaWxv",
-            "ci5lZGl0b3IudjEuVmlld3BvcnRFdmVudCrwAQoaVmlld3BvcnRUcmFuc2Zv",
-            "cm1PcGVyYXRpb24SLAooVklFV1BPUlRfVFJBTlNGT1JNX09QRVJBVElPTl9V",
-            "TlNQRUNJRklFRBAAEicKI1ZJRVdQT1JUX1RSQU5TRk9STV9PUEVSQVRJT05f",
-            "U0VMRUNUEAESKgomVklFV1BPUlRfVFJBTlNGT1JNX09QRVJBVElPTl9UUkFO",
-            "U0xBVEUQAhInCiNWSUVXUE9SVF9UUkFOU0ZPUk1fT1BFUkFUSU9OX1JPVEFU",
-            "RRADEiYKIlZJRVdQT1JUX1RSQU5TRk9STV9PUEVSQVRJT05fU0NBTEUQBCqK",
-            "AQoWVmlld3BvcnRUcmFuc2Zvcm1TcGFjZRIoCiRWSUVXUE9SVF9UUkFOU0ZP",
-            "Uk1fU1BBQ0VfVU5TUEVDSUZJRUQQABIiCh5WSUVXUE9SVF9UUkFOU0ZPUk1f",
-            "U1BBQ0VfV09STEQQARIiCh5WSUVXUE9SVF9UUkFOU0ZPUk1fU1BBQ0VfTE9D",
-            "QUwQAiqkAQoPRWRpdG9yU3RhdHNNb2RlEiEKHUVESVRPUl9TVEFUU19NT0RF",
-            "X1VOU1BFQ0lGSUVEEAASGgoWRURJVE9SX1NUQVRTX01PREVfTk9ORRABEiIK",
-            "HkVESVRPUl9TVEFUU19NT0RFX1JFTkRFUl9TVEFUUxACEi4KKkVESVRPUl9T",
-            "VEFUU19NT0RFX1JFTkRFUl9TVEFUU19BTkRfUVVFUklFUxADQiKqAh9TYWls",
-            "b3JFZGl0b3IuUHJvdG9jb2wuR2VuZXJhdGVkYgZwcm90bzM="));
+            "ZGVSZXF1ZXN0SAASSwoWc2V0X2VkaXRvcl9yZW5kZXJfbW9kZRhBIAEoCzIp",
+            "LnNhaWxvci5lZGl0b3IudjEuRWRpdG9yUmVuZGVyTW9kZVJlcXVlc3RIABI5",
+            "ChZnZXRfZWRpdG9yX3JlbmRlcl9tb2RlGEIgASgLMhcuc2FpbG9yLmVkaXRv",
+            "ci52MS5FbXB0eUgAQgkKB2NvbW1hbmRKBAgDEApKBAgyEDNKBAhDEGRSGGNy",
+            "ZWF0ZV9tb2RlbF9nYW1lX29iamVjdFIecmVzb2x2ZV92aWV3cG9ydF9kcm9w",
+            "X3Bvc2l0aW9uIq0IChBQcm90b2NvbFJlc3BvbnNlEhgKEHByb3RvY29sX3Zl",
+            "cnNpb24YASABKA0SEgoKcmVxdWVzdF9pZBgCIAEoBBIPCgdzdWNjZXNzGAMg",
+            "ASgIEg0KBWVycm9yGAQgASgJEiQKHHN1cHBvcnRzX3N0cmljdF9pbnN0YW5j",
+            "ZV9pZHMYBSABKAgSLwoMZW1wdHlfcmVzdWx0GAogASgLMhcuc2FpbG9yLmVk",
+            "aXRvci52MS5FbXB0eUgAEjMKC2Jvb2xfcmVzdWx0GAsgASgLMhwuc2FpbG9y",
+            "LmVkaXRvci52MS5Cb29sUmVzdWx0SAASNQoMaW50MzJfcmVzdWx0GAwgASgL",
+            "Mh0uc2FpbG9yLmVkaXRvci52MS5JbnQzMlJlc3VsdEgAEjcKDXVpbnQzMl9y",
+            "ZXN1bHQYDSABKAsyHi5zYWlsb3IuZWRpdG9yLnYxLlVJbnQzMlJlc3VsdEgA",
+            "EjcKDXVpbnQ2NF9yZXN1bHQYDiABKAsyHi5zYWlsb3IuZWRpdG9yLnYxLlVJ",
+            "bnQ2NFJlc3VsdEgAEjcKDXN0cmluZ19yZXN1bHQYDyABKAsyHi5zYWlsb3Iu",
+            "ZWRpdG9yLnYxLlN0cmluZ1Jlc3VsdEgAEkAKEnN0cmluZ19saXN0X3Jlc3Vs",
+            "dBgQIAEoCzIiLnNhaWxvci5lZGl0b3IudjEuU3RyaW5nTGlzdFJlc3VsdEgA",
+            "Ek0KGWFzc2V0X3JlbG9hZF9zdGF0ZV9yZXN1bHQYESABKAsyKC5zYWlsb3Iu",
+            "ZWRpdG9yLnYxLkFzc2V0UmVsb2FkU3RhdGVSZXN1bHRIABJAChJpbnN0YW5j",
+            "ZV9pZF9yZXN1bHQYEiABKAsyIi5zYWlsb3IuZWRpdG9yLnYxLkluc3RhbmNl",
+            "SWRSZXN1bHRIABJRCht2aWV3cG9ydF9ldmVudF9iYXRjaF9yZXN1bHQYEyAB",
+            "KAsyKi5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0RXZlbnRCYXRjaFJlc3Vs",
+            "dEgAEjkKDnZlY3RvcjRfcmVzdWx0GBQgASgLMh8uc2FpbG9yLmVkaXRvci52",
+            "MS5WZWN0b3I0UmVzdWx0SAASTwoadmlld3BvcnRfdG9vbF9zdGF0ZV9yZXN1",
+            "bHQYFSABKAsyKS5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0VG9vbFN0YXRl",
+            "UmVzdWx0SAASRgoVYW5pbWF0b3Jfc3RhdGVfcmVzdWx0GBYgASgLMiUuc2Fp",
+            "bG9yLmVkaXRvci52MS5BbmltYXRvclN0YXRlUmVzdWx0SAASTQoZZWRpdG9y",
+            "X3JlbmRlcl9tb2RlX3Jlc3VsdBgXIAEoCzIoLnNhaWxvci5lZGl0b3IudjEu",
+            "RWRpdG9yUmVuZGVyTW9kZVJlc3VsdEgAQggKBnJlc3VsdEoECAYQCkoECBgQ",
+            "ZCImChFJbml0aWFsaXplUmVxdWVzdBIRCglhcmd1bWVudHMYASADKAkiIQoM",
+            "Q291bnRSZXF1ZXN0EhEKCW1heF9jb3VudBgBIAEoDSIgCg1GaWxlSWRSZXF1",
+            "ZXN0Eg8KB2ZpbGVfaWQYASABKAki5wEKGkNyZWF0ZU1vZGVsSW5zdGFuY2VS",
+            "ZXF1ZXN0EhUKDW1vZGVsX2ZpbGVfaWQYASABKAkSDAoEbmFtZRgCIAEoCRIa",
+            "ChJwYXJlbnRfaW5zdGFuY2VfaWQYAyABKAkSGAoQY3JlYXRlX2hpZXJhcmNo",
+            "eRgEIAEoCBIcChRhcHBseV93b3JsZF9wb3NpdGlvbhgFIAEoCBIxCg53b3Js",
+            "ZF9wb3NpdGlvbhgGIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNBId",
+            "ChVwcmVmZXJyZWRfaW5zdGFuY2VfaWQYByABKAkiKAoRSW5zdGFuY2VJZFJl",
+            "cXVlc3QSEwoLaW5zdGFuY2VfaWQYASABKAkiKAoRVmlld3BvcnRJZFJlcXVl",
+            "c3QSEwoLdmlld3BvcnRfaWQYASABKAQiYAoTVmlld3BvcnRSZWN0UmVxdWVz",
+            "dBIUCgx3aW5kb3dfcG9zX3gYASABKA0SFAoMd2luZG93X3Bvc195GAIgASgN",
+            "Eg0KBXdpZHRoGAMgASgNEg4KBmhlaWdodBgEIAEoDSIsCgtTaXplUmVxdWVz",
+            "dBINCgV3aWR0aBgBIAEoDRIOCgZoZWlnaHQYAiABKA0iKgoXRWRpdG9yU2lt",
+            "dWxhdGlvblJlcXVlc3QSDwoHZW5hYmxlZBgBIAEoCCJJChZFZGl0b3JTdGF0",
+            "c01vZGVSZXF1ZXN0Ei8KBG1vZGUYASABKA4yIS5zYWlsb3IuZWRpdG9yLnYx",
+            "LkVkaXRvclN0YXRzTW9kZSJLChdFZGl0b3JSZW5kZXJNb2RlUmVxdWVzdBIw",
+            "CgRtb2RlGAEgASgOMiIuc2FpbG9yLmVkaXRvci52MS5FZGl0b3JSZW5kZXJN",
+            "b2RlIkoKFkVkaXRvclJlbmRlck1vZGVSZXN1bHQSMAoEbW9kZRgBIAEoDjIi",
+            "LnNhaWxvci5lZGl0b3IudjEuRWRpdG9yUmVuZGVyTW9kZSKZAQoVUmVtb3Rl",
+            "Vmlld3BvcnRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEhQKDHdpbmRv",
+            "d19wb3NfeBgCIAEoDRIUCgx3aW5kb3dfcG9zX3kYAyABKA0SDQoFd2lkdGgY",
+            "BCABKA0SDgoGaGVpZ2h0GAUgASgNEg8KB3Zpc2libGUYBiABKAgSDwoHZm9j",
+            "dXNlZBgHIAEoCCJlChlSZW1vdGVWaWV3cG9ydEhvc3RSZXF1ZXN0EhMKC3Zp",
+            "ZXdwb3J0X2lkGAEgASgEEhgKEGhvc3RfaGFuZGxlX2tpbmQYAiABKA0SGQoR",
+            "aG9zdF9oYW5kbGVfdmFsdWUYAyABKAQi/AEKGlJlbW90ZVZpZXdwb3J0SW5w",
+            "dXRSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgEEgwKBGtpbmQYAiABKA0S",
+            "EQoJcG9pbnRlcl94GAMgASgCEhEKCXBvaW50ZXJfeRgEIAEoAhIVCg13aGVl",
+            "bF9kZWx0YV94GAUgASgCEhUKDXdoZWVsX2RlbHRhX3kYBiABKAISEAoIa2V5",
+            "X2NvZGUYByABKA0SDgoGYnV0dG9uGAggASgNEhEKCW1vZGlmaWVycxgJIAEo",
+            "DRIPCgdwcmVzc2VkGAogASgIEg8KB2ZvY3VzZWQYCyABKAgSEAoIY2FwdHVy",
+            "ZWQYDCABKAgiQwoeTWFuYWdlZE11dGF0aW9uUmV2aXNpb25SZXF1ZXN0EgwK",
+            "BGtpbmQYASABKA0SEwoLaW5zdGFuY2VfaWQYAiABKAkiQAoTVXBkYXRlT2Jq",
+            "ZWN0UmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCRIUCgx5YW1sX2NoYW5n",
+            "ZXMYAiABKAkiZgoVUmVwYXJlbnRPYmplY3RSZXF1ZXN0EhMKC2luc3RhbmNl",
+            "X2lkGAEgASgJEhoKEnBhcmVudF9pbnN0YW5jZV9pZBgCIAEoCRIcChRrZWVw",
+            "X3dvcmxkX3RyYW5zZm9ybRgDIAEoCCJUChdDcmVhdGVHYW1lT2JqZWN0UmVx",
+            "dWVzdBIaChJwYXJlbnRfaW5zdGFuY2VfaWQYASABKAkSHQoVcHJlZmVycmVk",
+            "X2luc3RhbmNlX2lkGAIgASgJImYKE0FkZENvbXBvbmVudFJlcXVlc3QSEwoL",
+            "aW5zdGFuY2VfaWQYASABKAkSGwoTY29tcG9uZW50X3R5cGVfbmFtZRgCIAEo",
+            "CRIdChVwcmVmZXJyZWRfaW5zdGFuY2VfaWQYAyABKAki5gEKGEFuaW1hdG9y",
+            "UGFyYW1ldGVyUmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEoCRIMCgRuYW1l",
+            "GAIgASgJEhUKC2Zsb2F0X3ZhbHVlGAMgASgCSAASEwoJaW50X3ZhbHVlGAQg",
+            "ASgRSAASFAoKYm9vbF92YWx1ZRgFIAEoCEgAEioKB3RyaWdnZXIYBiABKAsy",
+            "Fy5zYWlsb3IuZWRpdG9yLnYxLkVtcHR5SAASMAoNcmVzZXRfdHJpZ2dlchgH",
+            "IAEoCzIXLnNhaWxvci5lZGl0b3IudjEuRW1wdHlIAEIHCgV2YWx1ZSJHChhJ",
+            "bnN0YW50aWF0ZVByZWZhYlJlcXVlc3QSDwoHZmlsZV9pZBgBIAEoCRIaChJw",
+            "YXJlbnRfaW5zdGFuY2VfaWQYAiABKAkicAogSW5zdGFudGlhdGVQcmVmYWJG",
+            "cm9tWWFtbFJlcXVlc3QSEwoLcHJlZmFiX3lhbWwYASABKAkSGgoScGFyZW50",
+            "X2luc3RhbmNlX2lkGAIgASgJEhsKE3N0cmljdF9pbnN0YW5jZV9pZHMYAyAB",
+            "KAgiVQoSVmlld3BvcnRSYXlSZXF1ZXN0EhMKC3ZpZXdwb3J0X2lkGAEgASgE",
+            "EhQKDG5vcm1hbGl6ZWRfeBgCIAEoAhIUCgxub3JtYWxpemVkX3kYAyABKAIi",
+            "oAEKIEluc3RhbnRpYXRlUHJlZmFiSW5zdGFuY2VSZXF1ZXN0Eg8KB2ZpbGVf",
+            "aWQYASABKAkSGgoScGFyZW50X2luc3RhbmNlX2lkGAIgASgJEhwKFGFwcGx5",
+            "X3dvcmxkX3Bvc2l0aW9uGAMgASgIEjEKDndvcmxkX3Bvc2l0aW9uGAQgASgL",
+            "Mhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0IkEKFVZpZXdwb3J0T2JqZWN0",
+            "UmVxdWVzdBITCgt2aWV3cG9ydF9pZBgBIAEoBBITCgtpbnN0YW5jZV9pZBgC",
+            "IAEoCSI5ChFQcmVmYWJMaW5rUmVxdWVzdBITCgtpbnN0YW5jZV9pZBgBIAEo",
+            "CRIPCgdmaWxlX2lkGAIgASgJIqkBChhWaWV3cG9ydFRvb2xTdGF0ZVJlcXVl",
+            "c3QSEwoLdmlld3BvcnRfaWQYASABKAQSPwoJb3BlcmF0aW9uGAIgASgOMiwu",
+            "c2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydFRyYW5zZm9ybU9wZXJhdGlvbhI3",
+            "CgVzcGFjZRgDIAEoDjIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFu",
+            "c2Zvcm1TcGFjZSIoChBTZWxlY3Rpb25SZXF1ZXN0EhQKDGluc3RhbmNlX2lk",
+            "cxgBIAMoCSIlChVTaG93TWFpbldpbmRvd1JlcXVlc3QSDAoEc2hvdxgBIAEo",
+            "CCKIAQocUmVuZGVyUGF0aFRyYWNlZEltYWdlUmVxdWVzdBITCgtvdXRwdXRf",
+            "cGF0aBgBIAEoCRITCgtpbnN0YW5jZV9pZBgCIAEoCRIOCgZoZWlnaHQYAyAB",
+            "KA0SGQoRc2FtcGxlc19wZXJfcGl4ZWwYBCABKA0SEwoLbWF4X2JvdW5jZXMY",
+            "BSABKA0iGwoKQm9vbFJlc3VsdBINCgV2YWx1ZRgBIAEoCCIcCgtJbnQzMlJl",
+            "c3VsdBINCgV2YWx1ZRgBIAEoBSIdCgxVSW50MzJSZXN1bHQSDQoFdmFsdWUY",
+            "ASABKA0iHQoMVUludDY0UmVzdWx0Eg0KBXZhbHVlGAEgASgEIjAKDFN0cmlu",
+            "Z1Jlc3VsdBIRCgloYXNfdmFsdWUYASABKAgSDQoFdmFsdWUYAiABKAkiIgoQ",
+            "U3RyaW5nTGlzdFJlc3VsdBIOCgZ2YWx1ZXMYASADKAkihAEKFkFzc2V0UmVs",
+            "b2FkU3RhdGVSZXN1bHQSEQoJYXZhaWxhYmxlGAEgASgIEhoKEnJlcXVlc3Rf",
+            "Z2VuZXJhdGlvbhgCIAEoBBIcChRjb21wbGV0ZWRfZ2VuZXJhdGlvbhgDIAEo",
+            "BBIdChVzdWNjZXNzZnVsX2dlbmVyYXRpb24YBCABKAQiOgoQSW5zdGFuY2VJ",
+            "ZFJlc3VsdBIRCglzdWNjZWVkZWQYASABKAgSEwoLaW5zdGFuY2VfaWQYAiAB",
+            "KAkiOQoNVmVjdG9yNFJlc3VsdBIoCgV2YWx1ZRgBIAEoCzIZLnNhaWxvci5l",
+            "ZGl0b3IudjEuVmVjdG9yNCKTAQoXVmlld3BvcnRUb29sU3RhdGVSZXN1bHQS",
+            "PwoJb3BlcmF0aW9uGAEgASgOMiwuc2FpbG9yLmVkaXRvci52MS5WaWV3cG9y",
+            "dFRyYW5zZm9ybU9wZXJhdGlvbhI3CgVzcGFjZRgCIAEoDjIoLnNhaWxvci5l",
+            "ZGl0b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1TcGFjZSKoAgoTQW5pbWF0b3JT",
+            "dGF0ZVJlc3VsdBIWCg5oYXNfY29udHJvbGxlchgBIAEoCBIbChNjb250cm9s",
+            "bGVyX3JldmlzaW9uGAIgASgEEhcKD2FjdGl2ZV9zdGF0ZV9pZBgDIAEoBBIZ",
+            "ChFhY3RpdmVfc3RhdGVfbmFtZRgEIAEoCRIZChFhY3RpdmVfc3RhdGVfdGlt",
+            "ZRgFIAEoAhIVCg10cmFuc2l0aW9uaW5nGAYgASgIEhwKFGRlc3RpbmF0aW9u",
+            "X3N0YXRlX2lkGAcgASgEEh4KFmRlc3RpbmF0aW9uX3N0YXRlX25hbWUYCCAB",
+            "KAkSHgoWZGVzdGluYXRpb25fc3RhdGVfdGltZRgJIAEoAhIYChB0cmFuc2l0",
+            "aW9uX2FscGhhGAogASgCIjUKB1ZlY3RvcjQSCQoBeBgBIAEoAhIJCgF5GAIg",
+            "ASgCEgkKAXoYAyABKAISCQoBdxgEIAEoAiI2ChZWaWV3cG9ydFNlbGVjdGlv",
+            "bkV2ZW50EhwKFHNlbGVjdGVkX2luc3RhbmNlX2lkGAEgASgJItYDChZWaWV3",
+            "cG9ydFRyYW5zZm9ybUV2ZW50EhMKC2luc3RhbmNlX2lkGAEgASgJEj8KCW9w",
+            "ZXJhdGlvbhgCIAEoDjIsLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRUcmFu",
+            "c2Zvcm1PcGVyYXRpb24SNwoFc3BhY2UYAyABKA4yKC5zYWlsb3IuZWRpdG9y",
+            "LnYxLlZpZXdwb3J0VHJhbnNmb3JtU3BhY2USMgoPYmVmb3JlX3Bvc2l0aW9u",
+            "GAQgASgLMhkuc2FpbG9yLmVkaXRvci52MS5WZWN0b3I0EjIKD2JlZm9yZV9y",
+            "b3RhdGlvbhgFIAEoCzIZLnNhaWxvci5lZGl0b3IudjEuVmVjdG9yNBIvCgxi",
+            "ZWZvcmVfc2NhbGUYBiABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZlY3RvcjQS",
+            "MQoOYWZ0ZXJfcG9zaXRpb24YByABKAsyGS5zYWlsb3IuZWRpdG9yLnYxLlZl",
+            "Y3RvcjQSMQoOYWZ0ZXJfcm90YXRpb24YCCABKAsyGS5zYWlsb3IuZWRpdG9y",
+            "LnYxLlZlY3RvcjQSLgoLYWZ0ZXJfc2NhbGUYCSABKAsyGS5zYWlsb3IuZWRp",
+            "dG9yLnYxLlZlY3RvcjQiVQoWVmlld3BvcnRBc3NldERyb3BFdmVudBIPCgdm",
+            "aWxlX2lkGAEgASgJEhQKDG5vcm1hbGl6ZWRfeBgCIAEoAhIUCgxub3JtYWxp",
+            "emVkX3kYAyABKAIiLQoZVmlld3BvcnRUb29sU2hvcnRjdXRFdmVudBIQCghr",
+            "ZXlfY29kZRgBIAEoDSLZAgoNVmlld3BvcnRFdmVudBIQCghyZXZpc2lvbhgB",
+            "IAEoBBIhChltYW5hZ2VkX211dGF0aW9uX3JldmlzaW9uGAIgASgEEj0KCXNl",
+            "bGVjdGlvbhgKIAEoCzIoLnNhaWxvci5lZGl0b3IudjEuVmlld3BvcnRTZWxl",
+            "Y3Rpb25FdmVudEgAEj0KCXRyYW5zZm9ybRgLIAEoCzIoLnNhaWxvci5lZGl0",
+            "b3IudjEuVmlld3BvcnRUcmFuc2Zvcm1FdmVudEgAEj4KCmFzc2V0X2Ryb3AY",
+            "DCABKAsyKC5zYWlsb3IuZWRpdG9yLnYxLlZpZXdwb3J0QXNzZXREcm9wRXZl",
+            "bnRIABJECg10b29sX3Nob3J0Y3V0GA0gASgLMisuc2FpbG9yLmVkaXRvci52",
+            "MS5WaWV3cG9ydFRvb2xTaG9ydGN1dEV2ZW50SABCCQoHcGF5bG9hZEoECAMQ",
+            "CiJLChhWaWV3cG9ydEV2ZW50QmF0Y2hSZXN1bHQSLwoGZXZlbnRzGAEgAygL",
+            "Mh8uc2FpbG9yLmVkaXRvci52MS5WaWV3cG9ydEV2ZW50KvABChpWaWV3cG9y",
+            "dFRyYW5zZm9ybU9wZXJhdGlvbhIsCihWSUVXUE9SVF9UUkFOU0ZPUk1fT1BF",
+            "UkFUSU9OX1VOU1BFQ0lGSUVEEAASJwojVklFV1BPUlRfVFJBTlNGT1JNX09Q",
+            "RVJBVElPTl9TRUxFQ1QQARIqCiZWSUVXUE9SVF9UUkFOU0ZPUk1fT1BFUkFU",
+            "SU9OX1RSQU5TTEFURRACEicKI1ZJRVdQT1JUX1RSQU5TRk9STV9PUEVSQVRJ",
+            "T05fUk9UQVRFEAMSJgoiVklFV1BPUlRfVFJBTlNGT1JNX09QRVJBVElPTl9T",
+            "Q0FMRRAEKooBChZWaWV3cG9ydFRyYW5zZm9ybVNwYWNlEigKJFZJRVdQT1JU",
+            "X1RSQU5TRk9STV9TUEFDRV9VTlNQRUNJRklFRBAAEiIKHlZJRVdQT1JUX1RS",
+            "QU5TRk9STV9TUEFDRV9XT1JMRBABEiIKHlZJRVdQT1JUX1RSQU5TRk9STV9T",
+            "UEFDRV9MT0NBTBACKqQBCg9FZGl0b3JTdGF0c01vZGUSIQodRURJVE9SX1NU",
+            "QVRTX01PREVfVU5TUEVDSUZJRUQQABIaChZFRElUT1JfU1RBVFNfTU9ERV9O",
+            "T05FEAESIgoeRURJVE9SX1NUQVRTX01PREVfUkVOREVSX1NUQVRTEAISLgoq",
+            "RURJVE9SX1NUQVRTX01PREVfUkVOREVSX1NUQVRTX0FORF9RVUVSSUVTEAMq",
+            "wQEKEEVkaXRvclJlbmRlck1vZGUSIgoeRURJVE9SX1JFTkRFUl9NT0RFX1VO",
+            "U1BFQ0lGSUVEEAASGgoWRURJVE9SX1JFTkRFUl9NT0RFX0xJVBABEigKJEVE",
+            "SVRPUl9SRU5ERVJfTU9ERV9BTUJJRU5UX09DQ0xVU0lPThACEh8KG0VESVRP",
+            "Ul9SRU5ERVJfTU9ERV9DQVNDQURFUxADEiIKHkVESVRPUl9SRU5ERVJfTU9E",
+            "RV9MSUdIVF9USUxFUxAEQiKqAh9TYWlsb3JFZGl0b3IuUHJvdG9jb2wuR2Vu",
+            "ZXJhdGVkYgZwcm90bzM="));
       descriptor = pbr::FileDescriptor.FromGeneratedCode(descriptorData,
           new pbr::FileDescriptor[] { },
-          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::SailorEditor.Protocol.Generated.ViewportTransformOperation), typeof(global::SailorEditor.Protocol.Generated.ViewportTransformSpace), typeof(global::SailorEditor.Protocol.Generated.EditorStatsMode), }, null, new pbr::GeneratedClrTypeInfo[] {
+          new pbr::GeneratedClrTypeInfo(new[] {typeof(global::SailorEditor.Protocol.Generated.ViewportTransformOperation), typeof(global::SailorEditor.Protocol.Generated.ViewportTransformSpace), typeof(global::SailorEditor.Protocol.Generated.EditorStatsMode), typeof(global::SailorEditor.Protocol.Generated.EditorRenderMode), }, null, new pbr::GeneratedClrTypeInfo[] {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.Empty), global::SailorEditor.Protocol.Generated.Empty.Parser, null, null, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset", "CreateModelInstance", "SetAnimatorParameter", "GetAnimatorState", "SetEditorSimulation", "GetEditorSimulationState", "PreviewAudioAsset", "SetEditorStatsMode" }, new[]{ "Command" }, null, null, null),
-            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "SupportsStrictInstanceIds", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult", "Vector4Result", "ViewportToolStateResult", "AnimatorStateResult" }, new[]{ "Result" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolRequest), global::SailorEditor.Protocol.Generated.ProtocolRequest.Parser, new[]{ "ProtocolVersion", "RequestId", "Initialize", "Start", "Stop", "Shutdown", "RequestAssetReload", "GetAssetReloadState", "GetExitCode", "GetMessages", "SerializeCurrentWorld", "SerializeEditorTypes", "SerializeWorkspaceCacheIdentity", "LoadEditorWorld", "CreateEditorWorld", "SetViewport", "SetEditorRenderTargetSize", "UpsertRemoteViewport", "DestroyRemoteViewport", "GetRemoteViewportState", "GetRemoteViewportDiagnostics", "RetryRemoteViewport", "SetRemoteViewportMacHostHandle", "SendRemoteViewportInput", "PullEditorViewportEvents", "GetEditorManagedMutationRevision", "UpdateObject", "ReparentObject", "CreateGameObject", "DestroyObject", "ResetComponentToDefaults", "AddComponent", "RemoveComponent", "InstantiatePrefab", "InstantiatePrefabFromYaml", "SetEditorSelection", "ShowMainWindow", "RenderPathTracedImage", "SerializeEngineTypes", "IsEngineMainThreadReady", "IsEngineRunning", "TraceViewportRay", "InstantiatePrefabInstance", "FocusEditorCamera", "SetPrefabLink", "BreakPrefabLink", "SetViewportToolState", "GetViewportToolState", "UpdateAsset", "CreateModelInstance", "SetAnimatorParameter", "GetAnimatorState", "SetEditorSimulation", "GetEditorSimulationState", "PreviewAudioAsset", "SetEditorStatsMode", "SetEditorRenderMode", "GetEditorRenderMode" }, new[]{ "Command" }, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.ProtocolResponse), global::SailorEditor.Protocol.Generated.ProtocolResponse.Parser, new[]{ "ProtocolVersion", "RequestId", "Success", "Error", "SupportsStrictInstanceIds", "EmptyResult", "BoolResult", "Int32Result", "Uint32Result", "Uint64Result", "StringResult", "StringListResult", "AssetReloadStateResult", "InstanceIdResult", "ViewportEventBatchResult", "Vector4Result", "ViewportToolStateResult", "AnimatorStateResult", "EditorRenderModeResult" }, new[]{ "Result" }, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.InitializeRequest), global::SailorEditor.Protocol.Generated.InitializeRequest.Parser, new[]{ "Arguments" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.CountRequest), global::SailorEditor.Protocol.Generated.CountRequest.Parser, new[]{ "MaxCount" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.FileIdRequest), global::SailorEditor.Protocol.Generated.FileIdRequest.Parser, new[]{ "FileId" }, null, null, null, null),
@@ -270,6 +283,8 @@ namespace SailorEditor.Protocol.Generated {
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.SizeRequest), global::SailorEditor.Protocol.Generated.SizeRequest.Parser, new[]{ "Width", "Height" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.EditorSimulationRequest), global::SailorEditor.Protocol.Generated.EditorSimulationRequest.Parser, new[]{ "Enabled" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.EditorStatsModeRequest), global::SailorEditor.Protocol.Generated.EditorStatsModeRequest.Parser, new[]{ "Mode" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.EditorRenderModeRequest), global::SailorEditor.Protocol.Generated.EditorRenderModeRequest.Parser, new[]{ "Mode" }, null, null, null, null),
+            new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.EditorRenderModeResult), global::SailorEditor.Protocol.Generated.EditorRenderModeResult.Parser, new[]{ "Mode" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.RemoteViewportRequest), global::SailorEditor.Protocol.Generated.RemoteViewportRequest.Parser, new[]{ "ViewportId", "WindowPosX", "WindowPosY", "Width", "Height", "Visible", "Focused" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.RemoteViewportHostRequest), global::SailorEditor.Protocol.Generated.RemoteViewportHostRequest.Parser, new[]{ "ViewportId", "HostHandleKind", "HostHandleValue" }, null, null, null, null),
             new pbr::GeneratedClrTypeInfo(typeof(global::SailorEditor.Protocol.Generated.RemoteViewportInputRequest), global::SailorEditor.Protocol.Generated.RemoteViewportInputRequest.Parser, new[]{ "ViewportId", "Kind", "PointerX", "PointerY", "WheelDeltaX", "WheelDeltaY", "KeyCode", "Button", "Modifiers", "Pressed", "Focused", "Captured" }, null, null, null, null),
@@ -332,6 +347,14 @@ namespace SailorEditor.Protocol.Generated {
     [pbr::OriginalName("EDITOR_STATS_MODE_NONE")] None = 1,
     [pbr::OriginalName("EDITOR_STATS_MODE_RENDER_STATS")] RenderStats = 2,
     [pbr::OriginalName("EDITOR_STATS_MODE_RENDER_STATS_AND_QUERIES")] RenderStatsAndQueries = 3,
+  }
+
+  public enum EditorRenderMode {
+    [pbr::OriginalName("EDITOR_RENDER_MODE_UNSPECIFIED")] Unspecified = 0,
+    [pbr::OriginalName("EDITOR_RENDER_MODE_LIT")] Lit = 1,
+    [pbr::OriginalName("EDITOR_RENDER_MODE_AMBIENT_OCCLUSION")] AmbientOcclusion = 2,
+    [pbr::OriginalName("EDITOR_RENDER_MODE_CASCADES")] Cascades = 3,
+    [pbr::OriginalName("EDITOR_RENDER_MODE_LIGHT_TILES")] LightTiles = 4,
   }
 
   #endregion
@@ -697,6 +720,12 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case CommandOneofCase.SetEditorStatsMode:
           SetEditorStatsMode = other.SetEditorStatsMode.Clone();
+          break;
+        case CommandOneofCase.SetEditorRenderMode:
+          SetEditorRenderMode = other.SetEditorRenderMode.Clone();
+          break;
+        case CommandOneofCase.GetEditorRenderMode:
+          GetEditorRenderMode = other.GetEditorRenderMode.Clone();
           break;
       }
 
@@ -1381,6 +1410,30 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "set_editor_render_mode" field.</summary>
+    public const int SetEditorRenderModeFieldNumber = 65;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.EditorRenderModeRequest SetEditorRenderMode {
+      get { return commandCase_ == CommandOneofCase.SetEditorRenderMode ? (global::SailorEditor.Protocol.Generated.EditorRenderModeRequest) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.SetEditorRenderMode;
+      }
+    }
+
+    /// <summary>Field number for the "get_editor_render_mode" field.</summary>
+    public const int GetEditorRenderModeFieldNumber = 66;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.Empty GetEditorRenderMode {
+      get { return commandCase_ == CommandOneofCase.GetEditorRenderMode ? (global::SailorEditor.Protocol.Generated.Empty) command_ : null; }
+      set {
+        command_ = value;
+        commandCase_ = value == null ? CommandOneofCase.None : CommandOneofCase.GetEditorRenderMode;
+      }
+    }
+
     private object command_;
     /// <summary>Enum of possible cases for the "command" oneof.</summary>
     public enum CommandOneofCase {
@@ -1439,6 +1492,8 @@ namespace SailorEditor.Protocol.Generated {
       GetEditorSimulationState = 62,
       PreviewAudioAsset = 63,
       SetEditorStatsMode = 64,
+      SetEditorRenderMode = 65,
+      GetEditorRenderMode = 66,
     }
     private CommandOneofCase commandCase_ = CommandOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -1525,6 +1580,8 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(GetEditorSimulationState, other.GetEditorSimulationState)) return false;
       if (!object.Equals(PreviewAudioAsset, other.PreviewAudioAsset)) return false;
       if (!object.Equals(SetEditorStatsMode, other.SetEditorStatsMode)) return false;
+      if (!object.Equals(SetEditorRenderMode, other.SetEditorRenderMode)) return false;
+      if (!object.Equals(GetEditorRenderMode, other.GetEditorRenderMode)) return false;
       if (CommandCase != other.CommandCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -1589,6 +1646,8 @@ namespace SailorEditor.Protocol.Generated {
       if (commandCase_ == CommandOneofCase.GetEditorSimulationState) hash ^= GetEditorSimulationState.GetHashCode();
       if (commandCase_ == CommandOneofCase.PreviewAudioAsset) hash ^= PreviewAudioAsset.GetHashCode();
       if (commandCase_ == CommandOneofCase.SetEditorStatsMode) hash ^= SetEditorStatsMode.GetHashCode();
+      if (commandCase_ == CommandOneofCase.SetEditorRenderMode) hash ^= SetEditorRenderMode.GetHashCode();
+      if (commandCase_ == CommandOneofCase.GetEditorRenderMode) hash ^= GetEditorRenderMode.GetHashCode();
       hash ^= (int) commandCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -1832,6 +1891,14 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(130, 4);
         output.WriteMessage(SetEditorStatsMode);
       }
+      if (commandCase_ == CommandOneofCase.SetEditorRenderMode) {
+        output.WriteRawTag(138, 4);
+        output.WriteMessage(SetEditorRenderMode);
+      }
+      if (commandCase_ == CommandOneofCase.GetEditorRenderMode) {
+        output.WriteRawTag(146, 4);
+        output.WriteMessage(GetEditorRenderMode);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -2066,6 +2133,14 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(130, 4);
         output.WriteMessage(SetEditorStatsMode);
       }
+      if (commandCase_ == CommandOneofCase.SetEditorRenderMode) {
+        output.WriteRawTag(138, 4);
+        output.WriteMessage(SetEditorRenderMode);
+      }
+      if (commandCase_ == CommandOneofCase.GetEditorRenderMode) {
+        output.WriteRawTag(146, 4);
+        output.WriteMessage(GetEditorRenderMode);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -2243,6 +2318,12 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (commandCase_ == CommandOneofCase.SetEditorStatsMode) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(SetEditorStatsMode);
+      }
+      if (commandCase_ == CommandOneofCase.SetEditorRenderMode) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(SetEditorRenderMode);
+      }
+      if (commandCase_ == CommandOneofCase.GetEditorRenderMode) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(GetEditorRenderMode);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -2587,6 +2668,18 @@ namespace SailorEditor.Protocol.Generated {
           }
           SetEditorStatsMode.MergeFrom(other.SetEditorStatsMode);
           break;
+        case CommandOneofCase.SetEditorRenderMode:
+          if (SetEditorRenderMode == null) {
+            SetEditorRenderMode = new global::SailorEditor.Protocol.Generated.EditorRenderModeRequest();
+          }
+          SetEditorRenderMode.MergeFrom(other.SetEditorRenderMode);
+          break;
+        case CommandOneofCase.GetEditorRenderMode:
+          if (GetEditorRenderMode == null) {
+            GetEditorRenderMode = new global::SailorEditor.Protocol.Generated.Empty();
+          }
+          GetEditorRenderMode.MergeFrom(other.GetEditorRenderMode);
+          break;
       }
 
       _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
@@ -3102,6 +3195,24 @@ namespace SailorEditor.Protocol.Generated {
             SetEditorStatsMode = subBuilder;
             break;
           }
+          case 522: {
+            global::SailorEditor.Protocol.Generated.EditorRenderModeRequest subBuilder = new global::SailorEditor.Protocol.Generated.EditorRenderModeRequest();
+            if (commandCase_ == CommandOneofCase.SetEditorRenderMode) {
+              subBuilder.MergeFrom(SetEditorRenderMode);
+            }
+            input.ReadMessage(subBuilder);
+            SetEditorRenderMode = subBuilder;
+            break;
+          }
+          case 530: {
+            global::SailorEditor.Protocol.Generated.Empty subBuilder = new global::SailorEditor.Protocol.Generated.Empty();
+            if (commandCase_ == CommandOneofCase.GetEditorRenderMode) {
+              subBuilder.MergeFrom(GetEditorRenderMode);
+            }
+            input.ReadMessage(subBuilder);
+            GetEditorRenderMode = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -3615,6 +3726,24 @@ namespace SailorEditor.Protocol.Generated {
             SetEditorStatsMode = subBuilder;
             break;
           }
+          case 522: {
+            global::SailorEditor.Protocol.Generated.EditorRenderModeRequest subBuilder = new global::SailorEditor.Protocol.Generated.EditorRenderModeRequest();
+            if (commandCase_ == CommandOneofCase.SetEditorRenderMode) {
+              subBuilder.MergeFrom(SetEditorRenderMode);
+            }
+            input.ReadMessage(subBuilder);
+            SetEditorRenderMode = subBuilder;
+            break;
+          }
+          case 530: {
+            global::SailorEditor.Protocol.Generated.Empty subBuilder = new global::SailorEditor.Protocol.Generated.Empty();
+            if (commandCase_ == CommandOneofCase.GetEditorRenderMode) {
+              subBuilder.MergeFrom(GetEditorRenderMode);
+            }
+            input.ReadMessage(subBuilder);
+            GetEditorRenderMode = subBuilder;
+            break;
+          }
         }
       }
     }
@@ -3701,6 +3830,9 @@ namespace SailorEditor.Protocol.Generated {
           break;
         case ResultOneofCase.AnimatorStateResult:
           AnimatorStateResult = other.AnimatorStateResult.Clone();
+          break;
+        case ResultOneofCase.EditorRenderModeResult:
+          EditorRenderModeResult = other.EditorRenderModeResult.Clone();
           break;
       }
 
@@ -3929,6 +4061,18 @@ namespace SailorEditor.Protocol.Generated {
       }
     }
 
+    /// <summary>Field number for the "editor_render_mode_result" field.</summary>
+    public const int EditorRenderModeResultFieldNumber = 23;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.EditorRenderModeResult EditorRenderModeResult {
+      get { return resultCase_ == ResultOneofCase.EditorRenderModeResult ? (global::SailorEditor.Protocol.Generated.EditorRenderModeResult) result_ : null; }
+      set {
+        result_ = value;
+        resultCase_ = value == null ? ResultOneofCase.None : ResultOneofCase.EditorRenderModeResult;
+      }
+    }
+
     private object result_;
     /// <summary>Enum of possible cases for the "result" oneof.</summary>
     public enum ResultOneofCase {
@@ -3946,6 +4090,7 @@ namespace SailorEditor.Protocol.Generated {
       Vector4Result = 20,
       ViewportToolStateResult = 21,
       AnimatorStateResult = 22,
+      EditorRenderModeResult = 23,
     }
     private ResultOneofCase resultCase_ = ResultOneofCase.None;
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -3994,6 +4139,7 @@ namespace SailorEditor.Protocol.Generated {
       if (!object.Equals(Vector4Result, other.Vector4Result)) return false;
       if (!object.Equals(ViewportToolStateResult, other.ViewportToolStateResult)) return false;
       if (!object.Equals(AnimatorStateResult, other.AnimatorStateResult)) return false;
+      if (!object.Equals(EditorRenderModeResult, other.EditorRenderModeResult)) return false;
       if (ResultCase != other.ResultCase) return false;
       return Equals(_unknownFields, other._unknownFields);
     }
@@ -4020,6 +4166,7 @@ namespace SailorEditor.Protocol.Generated {
       if (resultCase_ == ResultOneofCase.Vector4Result) hash ^= Vector4Result.GetHashCode();
       if (resultCase_ == ResultOneofCase.ViewportToolStateResult) hash ^= ViewportToolStateResult.GetHashCode();
       if (resultCase_ == ResultOneofCase.AnimatorStateResult) hash ^= AnimatorStateResult.GetHashCode();
+      if (resultCase_ == ResultOneofCase.EditorRenderModeResult) hash ^= EditorRenderModeResult.GetHashCode();
       hash ^= (int) resultCase_;
       if (_unknownFields != null) {
         hash ^= _unknownFields.GetHashCode();
@@ -4111,6 +4258,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(178, 1);
         output.WriteMessage(AnimatorStateResult);
       }
+      if (resultCase_ == ResultOneofCase.EditorRenderModeResult) {
+        output.WriteRawTag(186, 1);
+        output.WriteMessage(EditorRenderModeResult);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(output);
       }
@@ -4193,6 +4344,10 @@ namespace SailorEditor.Protocol.Generated {
         output.WriteRawTag(178, 1);
         output.WriteMessage(AnimatorStateResult);
       }
+      if (resultCase_ == ResultOneofCase.EditorRenderModeResult) {
+        output.WriteRawTag(186, 1);
+        output.WriteMessage(EditorRenderModeResult);
+      }
       if (_unknownFields != null) {
         _unknownFields.WriteTo(ref output);
       }
@@ -4256,6 +4411,9 @@ namespace SailorEditor.Protocol.Generated {
       }
       if (resultCase_ == ResultOneofCase.AnimatorStateResult) {
         size += 2 + pb::CodedOutputStream.ComputeMessageSize(AnimatorStateResult);
+      }
+      if (resultCase_ == ResultOneofCase.EditorRenderModeResult) {
+        size += 2 + pb::CodedOutputStream.ComputeMessageSize(EditorRenderModeResult);
       }
       if (_unknownFields != null) {
         size += _unknownFields.CalculateSize();
@@ -4362,6 +4520,12 @@ namespace SailorEditor.Protocol.Generated {
             AnimatorStateResult = new global::SailorEditor.Protocol.Generated.AnimatorStateResult();
           }
           AnimatorStateResult.MergeFrom(other.AnimatorStateResult);
+          break;
+        case ResultOneofCase.EditorRenderModeResult:
+          if (EditorRenderModeResult == null) {
+            EditorRenderModeResult = new global::SailorEditor.Protocol.Generated.EditorRenderModeResult();
+          }
+          EditorRenderModeResult.MergeFrom(other.EditorRenderModeResult);
           break;
       }
 
@@ -4521,6 +4685,15 @@ namespace SailorEditor.Protocol.Generated {
             AnimatorStateResult = subBuilder;
             break;
           }
+          case 186: {
+            global::SailorEditor.Protocol.Generated.EditorRenderModeResult subBuilder = new global::SailorEditor.Protocol.Generated.EditorRenderModeResult();
+            if (resultCase_ == ResultOneofCase.EditorRenderModeResult) {
+              subBuilder.MergeFrom(EditorRenderModeResult);
+            }
+            input.ReadMessage(subBuilder);
+            EditorRenderModeResult = subBuilder;
+            break;
+          }
         }
       }
     #endif
@@ -4675,6 +4848,15 @@ namespace SailorEditor.Protocol.Generated {
             }
             input.ReadMessage(subBuilder);
             AnimatorStateResult = subBuilder;
+            break;
+          }
+          case 186: {
+            global::SailorEditor.Protocol.Generated.EditorRenderModeResult subBuilder = new global::SailorEditor.Protocol.Generated.EditorRenderModeResult();
+            if (resultCase_ == ResultOneofCase.EditorRenderModeResult) {
+              subBuilder.MergeFrom(EditorRenderModeResult);
+            }
+            input.ReadMessage(subBuilder);
+            EditorRenderModeResult = subBuilder;
             break;
           }
         }
@@ -7033,6 +7215,402 @@ namespace SailorEditor.Protocol.Generated {
   }
 
   [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class EditorRenderModeRequest : pb::IMessage<EditorRenderModeRequest>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<EditorRenderModeRequest> _parser = new pb::MessageParser<EditorRenderModeRequest>(() => new EditorRenderModeRequest());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<EditorRenderModeRequest> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[13]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorRenderModeRequest() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorRenderModeRequest(EditorRenderModeRequest other) : this() {
+      mode_ = other.mode_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorRenderModeRequest Clone() {
+      return new EditorRenderModeRequest(this);
+    }
+
+    /// <summary>Field number for the "mode" field.</summary>
+    public const int ModeFieldNumber = 1;
+    private global::SailorEditor.Protocol.Generated.EditorRenderMode mode_ = global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.EditorRenderMode Mode {
+      get { return mode_; }
+      set {
+        mode_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as EditorRenderModeRequest);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(EditorRenderModeRequest other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Mode != other.Mode) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified) hash ^= Mode.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified) {
+        output.WriteRawTag(8);
+        output.WriteEnum((int) Mode);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified) {
+        output.WriteRawTag(8);
+        output.WriteEnum((int) Mode);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Mode);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(EditorRenderModeRequest other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Mode != global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified) {
+        Mode = other.Mode;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            Mode = (global::SailorEditor.Protocol.Generated.EditorRenderMode) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            Mode = (global::SailorEditor.Protocol.Generated.EditorRenderMode) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
+  public sealed partial class EditorRenderModeResult : pb::IMessage<EditorRenderModeResult>
+  #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      , pb::IBufferMessage
+  #endif
+  {
+    private static readonly pb::MessageParser<EditorRenderModeResult> _parser = new pb::MessageParser<EditorRenderModeResult>(() => new EditorRenderModeResult());
+    private pb::UnknownFieldSet _unknownFields;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pb::MessageParser<EditorRenderModeResult> Parser { get { return _parser; } }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public static pbr::MessageDescriptor Descriptor {
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[14]; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    pbr::MessageDescriptor pb::IMessage.Descriptor {
+      get { return Descriptor; }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorRenderModeResult() {
+      OnConstruction();
+    }
+
+    partial void OnConstruction();
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorRenderModeResult(EditorRenderModeResult other) : this() {
+      mode_ = other.mode_;
+      _unknownFields = pb::UnknownFieldSet.Clone(other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public EditorRenderModeResult Clone() {
+      return new EditorRenderModeResult(this);
+    }
+
+    /// <summary>Field number for the "mode" field.</summary>
+    public const int ModeFieldNumber = 1;
+    private global::SailorEditor.Protocol.Generated.EditorRenderMode mode_ = global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified;
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public global::SailorEditor.Protocol.Generated.EditorRenderMode Mode {
+      get { return mode_; }
+      set {
+        mode_ = value;
+      }
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override bool Equals(object other) {
+      return Equals(other as EditorRenderModeResult);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public bool Equals(EditorRenderModeResult other) {
+      if (ReferenceEquals(other, null)) {
+        return false;
+      }
+      if (ReferenceEquals(other, this)) {
+        return true;
+      }
+      if (Mode != other.Mode) return false;
+      return Equals(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override int GetHashCode() {
+      int hash = 1;
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified) hash ^= Mode.GetHashCode();
+      if (_unknownFields != null) {
+        hash ^= _unknownFields.GetHashCode();
+      }
+      return hash;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public override string ToString() {
+      return pb::JsonFormatter.ToDiagnosticString(this);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void WriteTo(pb::CodedOutputStream output) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      output.WriteRawMessage(this);
+    #else
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified) {
+        output.WriteRawTag(8);
+        output.WriteEnum((int) Mode);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(output);
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalWriteTo(ref pb::WriteContext output) {
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified) {
+        output.WriteRawTag(8);
+        output.WriteEnum((int) Mode);
+      }
+      if (_unknownFields != null) {
+        _unknownFields.WriteTo(ref output);
+      }
+    }
+    #endif
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public int CalculateSize() {
+      int size = 0;
+      if (Mode != global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified) {
+        size += 1 + pb::CodedOutputStream.ComputeEnumSize((int) Mode);
+      }
+      if (_unknownFields != null) {
+        size += _unknownFields.CalculateSize();
+      }
+      return size;
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(EditorRenderModeResult other) {
+      if (other == null) {
+        return;
+      }
+      if (other.Mode != global::SailorEditor.Protocol.Generated.EditorRenderMode.Unspecified) {
+        Mode = other.Mode;
+      }
+      _unknownFields = pb::UnknownFieldSet.MergeFrom(_unknownFields, other._unknownFields);
+    }
+
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    public void MergeFrom(pb::CodedInputStream input) {
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+      input.ReadRawMessage(this);
+    #else
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, input);
+            break;
+          case 8: {
+            Mode = (global::SailorEditor.Protocol.Generated.EditorRenderMode) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    #endif
+    }
+
+    #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
+    [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
+    [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
+    void pb::IBufferMessage.InternalMergeFrom(ref pb::ParseContext input) {
+      uint tag;
+      while ((tag = input.ReadTag()) != 0) {
+      if ((tag & 7) == 4) {
+        // Abort on any end group tag.
+        return;
+      }
+      switch(tag) {
+          default:
+            _unknownFields = pb::UnknownFieldSet.MergeFieldFrom(_unknownFields, ref input);
+            break;
+          case 8: {
+            Mode = (global::SailorEditor.Protocol.Generated.EditorRenderMode) input.ReadEnum();
+            break;
+          }
+        }
+      }
+    }
+    #endif
+
+  }
+
+  [global::System.Diagnostics.DebuggerDisplayAttribute("{ToString(),nq}")]
   public sealed partial class RemoteViewportRequest : pb::IMessage<RemoteViewportRequest>
   #if !GOOGLE_PROTOBUF_REFSTRUCT_COMPATIBILITY_MODE
       , pb::IBufferMessage
@@ -7047,7 +7625,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[13]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[15]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7467,7 +8045,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[14]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[16]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -7739,7 +8317,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[15]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[17]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8344,7 +8922,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[16]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[18]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8579,7 +9157,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[17]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[19]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -8814,7 +9392,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[18]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9086,7 +9664,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[19]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9321,7 +9899,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[20]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -9593,7 +10171,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[21]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10123,7 +10701,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[22]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10358,7 +10936,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[23]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10630,7 +11208,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[24]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -10902,7 +11480,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[25]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11220,7 +11798,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[26]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11455,7 +12033,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[27]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11690,7 +12268,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[28]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -11962,7 +12540,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[29]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12149,7 +12727,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[30]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12347,7 +12925,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[31]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12693,7 +13271,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[32]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -12891,7 +13469,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[33]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13089,7 +13667,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[34]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13287,7 +13865,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[35]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13485,7 +14063,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[36]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13720,7 +14298,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[37]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -13907,7 +14485,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[38]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14216,7 +14794,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[39]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14451,7 +15029,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[40]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14658,7 +15236,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[41]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -14893,7 +15471,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[42]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15424,7 +16002,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[43]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15733,7 +16311,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[44]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[46]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -15931,7 +16509,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[45]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[47]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -16479,7 +17057,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[46]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[48]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -16751,7 +17329,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[47]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[49]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -16949,7 +17527,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[48]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[50]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
@@ -17423,7 +18001,7 @@ namespace SailorEditor.Protocol.Generated {
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]
     [global::System.CodeDom.Compiler.GeneratedCode("protoc", null)]
     public static pbr::MessageDescriptor Descriptor {
-      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[49]; }
+      get { return global::SailorEditor.Protocol.Generated.EditorEngineReflection.Descriptor.MessageTypes[51]; }
     }
 
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute]

--- a/Editor/Scene/SceneViewportToolState.cs
+++ b/Editor/Scene/SceneViewportToolState.cs
@@ -1,5 +1,56 @@
 namespace SailorEditor.Scene;
 
+public enum SceneViewRenderMode
+{
+    Lit = 0,
+    AmbientOcclusion,
+    Cascades,
+    LightTiles
+}
+
+public static class SceneViewRenderModeNames
+{
+    public static IReadOnlyList<string> Supported { get; } =
+    [
+        "lit",
+        "ambient_occlusion",
+        "cascades",
+        "light_tiles"
+    ];
+
+    public static string ToExternalName(SceneViewRenderMode mode) => mode switch
+    {
+        SceneViewRenderMode.Lit => "lit",
+        SceneViewRenderMode.AmbientOcclusion => "ambient_occlusion",
+        SceneViewRenderMode.Cascades => "cascades",
+        SceneViewRenderMode.LightTiles => "light_tiles",
+        _ => throw new ArgumentOutOfRangeException(nameof(mode))
+    };
+
+    public static bool TryParse(
+        string? value,
+        out SceneViewRenderMode mode)
+    {
+        var normalized = value?
+            .Trim()
+            .Replace("-", string.Empty, StringComparison.Ordinal)
+            .Replace("_", string.Empty, StringComparison.Ordinal)
+            .Replace(" ", string.Empty, StringComparison.Ordinal)
+            .ToLowerInvariant();
+        mode = normalized switch
+        {
+            "lit" => SceneViewRenderMode.Lit,
+            "ambientocclusion" or "ao" =>
+                SceneViewRenderMode.AmbientOcclusion,
+            "cascades" or "csm" => SceneViewRenderMode.Cascades,
+            "lighttiles" => SceneViewRenderMode.LightTiles,
+            _ => default
+        };
+        return normalized is "lit" or "ambientocclusion" or "ao" or
+            "cascades" or "csm" or "lighttiles";
+    }
+}
+
 public readonly record struct SceneViewportToolState(
     EditorViewportTransformOperation Operation,
     EditorViewportTransformSpace Space);

--- a/Editor/Services/EngineService.cs
+++ b/Editor/Services/EngineService.cs
@@ -232,6 +232,7 @@ namespace SailorEditor.Services
         public event Action<AssetReloadCompletion> OnAssetReloadCompleted = delegate { };
         public event Action<IReadOnlyList<EditorViewportEvent>> OnEditorViewportEvents = delegate { };
         public event Action<bool> OnEditorSimulationStateChanged = delegate { };
+        public event Action<SceneViewRenderMode> OnEditorRenderModeChanged = delegate { };
 
         public string EngineContentDirectory => Path.Combine(repoRoot, "Content");
 
@@ -2965,6 +2966,60 @@ namespace SailorEditor.Services
                     ToProtocolStatsMode(mode),
                     token),
                 cancellationToken: cancellationToken);
+
+        public async Task<bool> SetEditorRenderModeAsync(
+            SceneViewRenderMode mode,
+            CancellationToken cancellationToken = default)
+        {
+            var succeeded = await InvokeRunningInteropAsync(
+                token => protocolClient.SetEditorRenderModeAsync(
+                    ToProtocolRenderMode(mode),
+                    token),
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            if (succeeded)
+            {
+                OnEditorRenderModeChanged?.Invoke(mode);
+            }
+            return succeeded;
+        }
+
+        public async Task<SceneViewRenderMode?> GetEditorRenderModeAsync(
+            CancellationToken cancellationToken = default)
+        {
+            var mode = EditorRenderMode.Unspecified;
+            var succeeded = await InvokeRunningInteropAsync(
+                async token =>
+                {
+                    mode = await protocolClient
+                        .GetEditorRenderModeAsync(token)
+                        .ConfigureAwait(false);
+                    return true;
+                },
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+            return succeeded ? FromProtocolRenderMode(mode) : null;
+        }
+
+        static EditorRenderMode ToProtocolRenderMode(SceneViewRenderMode mode)
+            => mode switch
+            {
+                SceneViewRenderMode.Lit => EditorRenderMode.Lit,
+                SceneViewRenderMode.AmbientOcclusion =>
+                    EditorRenderMode.AmbientOcclusion,
+                SceneViewRenderMode.Cascades => EditorRenderMode.Cascades,
+                SceneViewRenderMode.LightTiles => EditorRenderMode.LightTiles,
+                _ => throw new ArgumentOutOfRangeException(nameof(mode))
+            };
+
+        static SceneViewRenderMode FromProtocolRenderMode(EditorRenderMode mode)
+            => mode switch
+            {
+                EditorRenderMode.Lit => SceneViewRenderMode.Lit,
+                EditorRenderMode.AmbientOcclusion =>
+                    SceneViewRenderMode.AmbientOcclusion,
+                EditorRenderMode.Cascades => SceneViewRenderMode.Cascades,
+                EditorRenderMode.LightTiles => SceneViewRenderMode.LightTiles,
+                _ => throw new ArgumentOutOfRangeException(nameof(mode))
+            };
 
         static EditorStatsMode ToProtocolStatsMode(GraphicsStatsMode mode)
             => mode switch

--- a/Editor/Views/SceneView.xaml
+++ b/Editor/Views/SceneView.xaml
@@ -10,7 +10,7 @@
                 Stroke="#2A2A2A"
                 StrokeThickness="1"
                 Padding="3,2">
-            <Grid ColumnDefinitions="*,Auto,Auto,Auto"
+            <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto"
                   ColumnSpacing="4">
                 <HorizontalStackLayout Spacing="3"
                                        Grid.Column="0"
@@ -60,6 +60,22 @@
                 <HorizontalStackLayout Grid.Column="1"
                                        Spacing="4"
                                        VerticalOptions="Center">
+                    <Label Text="Mode"
+                           FontSize="11"
+                           VerticalTextAlignment="Center" />
+                    <Picker x:Name="RenderModePicker"
+                            WidthRequest="138"
+                            HeightRequest="26"
+                            MinimumHeightRequest="26"
+                            FontSize="11"
+                            AutomationProperties.Name="Scene View Rendering Mode"
+                            ToolTipProperties.Text="Scene View rendering visualization"
+                            SelectedIndexChanged="OnRenderModeSelectedIndexChanged" />
+                </HorizontalStackLayout>
+
+                <HorizontalStackLayout Grid.Column="2"
+                                       Spacing="4"
+                                       VerticalOptions="Center">
                     <Label Text="Quality"
                            FontSize="11"
                            VerticalTextAlignment="Center" />
@@ -73,7 +89,7 @@
                             SelectedIndexChanged="OnQualitySelectedIndexChanged" />
                 </HorizontalStackLayout>
 
-                <HorizontalStackLayout Grid.Column="2"
+                <HorizontalStackLayout Grid.Column="3"
                                        Spacing="4"
                                        VerticalOptions="Center">
                     <Label Text="Stats"
@@ -89,7 +105,7 @@
                             SelectedIndexChanged="OnStatsModeSelectedIndexChanged" />
                 </HorizontalStackLayout>
 
-                <Border Grid.Column="3"
+                <Border Grid.Column="4"
                         Stroke="#3B3F46"
                         StrokeThickness="1"
                         BackgroundColor="#2A2E35"

--- a/Editor/Views/SceneView.xaml.cs
+++ b/Editor/Views/SceneView.xaml.cs
@@ -56,12 +56,15 @@ namespace SailorEditor.Views
         readonly object viewportToolStateLock = new();
         readonly SemaphoreSlim viewportToolStateGate = new(1, 1);
         readonly SemaphoreSlim graphicsSettingsGate = new(1, 1);
+        readonly SemaphoreSlim renderModeGate = new(1, 1);
         SceneViewportToolState viewportToolState =
             SceneViewportToolShortcuts.Default;
+        SceneViewRenderMode renderMode = SceneViewRenderMode.Lit;
         long lastViewportIntegrationTickMs = -1;
         long lastViewportStatusTickMs = -1;
         bool lifecycleSubscribed;
         bool updatingGraphicsPickers;
+        bool updatingRenderModePicker;
 #if WINDOWS || MACCATALYST
         static readonly bool UseNativeViewportHost = true;
 #else
@@ -93,6 +96,9 @@ namespace SailorEditor.Views
                 .Select(option => option.DisplayName)
                 .ToList();
             StatsModePicker.ItemsSource = StatsModeOptions
+                .Select(option => option.DisplayName)
+                .ToList();
+            RenderModePicker.ItemsSource = RenderModeOptions
                 .Select(option => option.DisplayName)
                 .ToList();
 
@@ -166,6 +172,7 @@ namespace SailorEditor.Views
                 SubscribeToEngineLifecycle();
                 _ = RefreshViewportToolStateAsync();
                 _ = RefreshGraphicsSettingsAsync(reload: false);
+                _ = RefreshRenderModeAsync();
 #if MACCATALYST
                 if (!UseNativeViewportHost)
                 {
@@ -344,6 +351,7 @@ namespace SailorEditor.Views
 
             engineService.OnLifecycleStateChanged += OnEngineLifecycleStateChanged;
             engineService.OnEditorViewportEvents += OnEditorViewportEvents;
+            engineService.OnEditorRenderModeChanged += OnEditorRenderModeChanged;
             graphicsSettingsService.SettingsChanged += OnGraphicsSettingsChanged;
             workspaceUiService.ProjectionChanged += OnWorkspaceProjectionChanged;
             viewportEventRevisionGate.Reset();
@@ -357,6 +365,7 @@ namespace SailorEditor.Views
 
             engineService.OnLifecycleStateChanged -= OnEngineLifecycleStateChanged;
             engineService.OnEditorViewportEvents -= OnEditorViewportEvents;
+            engineService.OnEditorRenderModeChanged -= OnEditorRenderModeChanged;
             graphicsSettingsService.SettingsChanged -= OnGraphicsSettingsChanged;
             workspaceUiService.ProjectionChanged -= OnWorkspaceProjectionChanged;
             lifecycleSubscribed = false;
@@ -374,7 +383,11 @@ namespace SailorEditor.Views
             QueueViewportRetry(TimeSpan.FromSeconds(1));
             UpdateViewportIntegration();
             _ = RefreshViewportToolStateAsync();
+            _ = ReapplyRenderModeAsync();
         }
+
+        void OnEditorRenderModeChanged(SceneViewRenderMode mode) =>
+            Dispatcher.Dispatch(() => UpdateRenderModePicker(mode));
 
         async void OnRestartEngineClicked(object sender, EventArgs e)
         {
@@ -430,6 +443,21 @@ namespace SailorEditor.Views
                 StatsModeOptions[StatsModePicker.SelectedIndex].Value);
         }
 
+        async void OnRenderModeSelectedIndexChanged(
+            object sender,
+            EventArgs e)
+        {
+            if (updatingRenderModePicker ||
+                RenderModePicker.SelectedIndex < 0 ||
+                RenderModePicker.SelectedIndex >= RenderModeOptions.Length)
+            {
+                return;
+            }
+
+            await ApplyRenderModeAsync(
+                RenderModeOptions[RenderModePicker.SelectedIndex].Value);
+        }
+
         async Task ApplyQualitySelectionAsync(
             EditorQualitySelection selection)
         {
@@ -481,6 +509,90 @@ namespace SailorEditor.Views
             {
                 SetGraphicsPickersEnabled(true);
                 graphicsSettingsGate.Release();
+            }
+        }
+
+        async Task ApplyRenderModeAsync(SceneViewRenderMode mode)
+        {
+            await renderModeGate.WaitAsync();
+            RenderModePicker.IsEnabled = false;
+            try
+            {
+                if (await engineService.SetEditorRenderModeAsync(mode))
+                {
+                    renderMode = mode;
+                }
+                else
+                {
+                    Console.WriteLine(
+                        "[SceneView] Rendering mode command was rejected by the Engine.");
+                    await RefreshRenderModeAsync();
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"[SceneView] Failed to apply rendering mode: {exception}");
+                await RefreshRenderModeAsync();
+            }
+            finally
+            {
+                RenderModePicker.IsEnabled = true;
+                renderModeGate.Release();
+            }
+        }
+
+        async Task RefreshRenderModeAsync()
+        {
+            try
+            {
+                var current = await engineService.GetEditorRenderModeAsync();
+                if (current is not null)
+                {
+                    Dispatcher.Dispatch(() => UpdateRenderModePicker(current.Value));
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"[SceneView] Failed to read rendering mode: {exception}");
+            }
+        }
+
+        async Task ReapplyRenderModeAsync()
+        {
+            await renderModeGate.WaitAsync();
+            try
+            {
+                if (!await engineService.SetEditorRenderModeAsync(renderMode))
+                {
+                    await RefreshRenderModeAsync();
+                }
+            }
+            catch (Exception exception)
+            {
+                Console.Error.WriteLine(
+                    $"[SceneView] Failed to restore rendering mode: {exception}");
+            }
+            finally
+            {
+                renderModeGate.Release();
+            }
+        }
+
+        void UpdateRenderModePicker(SceneViewRenderMode mode)
+        {
+            renderMode = mode;
+            updatingRenderModePicker = true;
+            try
+            {
+                RenderModePicker.SelectedIndex = Array.FindIndex(
+                    RenderModeOptions,
+                    option => option.Value == mode);
+            }
+            finally
+            {
+                updatingRenderModePicker = false;
             }
         }
 
@@ -566,6 +678,17 @@ namespace SailorEditor.Views
                 new(
                     GraphicsStatsMode.RenderStatsAndQueries,
                     "Render stats + queries")
+            ];
+
+        static readonly GraphicsPickerOption<SceneViewRenderMode>[]
+            RenderModeOptions =
+            [
+                new(SceneViewRenderMode.Lit, "Lit"),
+                new(
+                    SceneViewRenderMode.AmbientOcclusion,
+                    "Ambient Occlusion"),
+                new(SceneViewRenderMode.Cascades, "Cascades"),
+                new(SceneViewRenderMode.LightTiles, "Light Tiles")
             ];
 
         void UpdateRestartEngineButton(EngineLifecycleState state)

--- a/Lib/EditorEngineProtocol.cpp
+++ b/Lib/EditorEngineProtocol.cpp
@@ -64,6 +64,7 @@ namespace
 	using Sailor::Protocol::EditorEngineProtocolLatestVersion;
 	using Sailor::Protocol::EditorEngineProtocolStrictInstanceIdsVersion;
 	using Sailor::Protocol::EditorEngineProtocolVersion;
+	using sailor::editor::v1::EditorRenderMode;
 	using sailor::editor::v1::ProtocolRequest;
 	using sailor::editor::v1::ProtocolResponse;
 	using sailor::editor::v1::Vector4;
@@ -199,6 +200,47 @@ namespace
 	{
 		SetSuccess(response);
 		response.mutable_bool_result()->set_value(value);
+	}
+
+	bool TryGetSceneViewRenderMode(
+		EditorRenderMode protocolMode,
+		Sailor::RHI::ESceneViewRenderMode& outMode)
+	{
+		switch (protocolMode)
+		{
+		case sailor::editor::v1::EDITOR_RENDER_MODE_LIT:
+			outMode = Sailor::RHI::ESceneViewRenderMode::Lit;
+			return true;
+		case sailor::editor::v1::EDITOR_RENDER_MODE_AMBIENT_OCCLUSION:
+			outMode = Sailor::RHI::ESceneViewRenderMode::AmbientOcclusion;
+			return true;
+		case sailor::editor::v1::EDITOR_RENDER_MODE_CASCADES:
+			outMode = Sailor::RHI::ESceneViewRenderMode::Cascades;
+			return true;
+		case sailor::editor::v1::EDITOR_RENDER_MODE_LIGHT_TILES:
+			outMode = Sailor::RHI::ESceneViewRenderMode::LightTiles;
+			return true;
+		case sailor::editor::v1::EDITOR_RENDER_MODE_UNSPECIFIED:
+		default:
+			return false;
+		}
+	}
+
+	EditorRenderMode ToProtocolRenderMode(
+		Sailor::RHI::ESceneViewRenderMode mode)
+	{
+		switch (mode)
+		{
+		case Sailor::RHI::ESceneViewRenderMode::AmbientOcclusion:
+			return sailor::editor::v1::EDITOR_RENDER_MODE_AMBIENT_OCCLUSION;
+		case Sailor::RHI::ESceneViewRenderMode::Cascades:
+			return sailor::editor::v1::EDITOR_RENDER_MODE_CASCADES;
+		case Sailor::RHI::ESceneViewRenderMode::LightTiles:
+			return sailor::editor::v1::EDITOR_RENDER_MODE_LIGHT_TILES;
+		case Sailor::RHI::ESceneViewRenderMode::Lit:
+		default:
+			return sailor::editor::v1::EDITOR_RENDER_MODE_LIT;
+		}
 	}
 
 	void SetUInt32Result(ProtocolResponse& response, uint32_t value)
@@ -1151,6 +1193,29 @@ namespace
 			}
 			break;
 		}
+
+		case ProtocolRequest::kSetEditorRenderMode:
+		{
+			Sailor::RHI::ESceneViewRenderMode renderMode{};
+			if (!TryGetSceneViewRenderMode(
+					request.set_editor_render_mode().mode(),
+					renderMode))
+			{
+				SetError(response, "The Editor render mode is invalid.");
+				break;
+			}
+
+			SetBoolResult(
+				response,
+				Sailor::App::SetEditorRenderMode(renderMode));
+			break;
+		}
+
+		case ProtocolRequest::kGetEditorRenderMode:
+			SetSuccess(response);
+			response.mutable_editor_render_mode_result()->set_mode(
+				ToProtocolRenderMode(Sailor::App::GetEditorRenderMode()));
+			break;
 
 		case ProtocolRequest::kSetViewport:
 		{

--- a/Protocol/editor_engine.proto
+++ b/Protocol/editor_engine.proto
@@ -66,13 +66,15 @@ message ProtocolRequest {
 		Empty get_editor_simulation_state = 62;
 		FileIdRequest preview_audio_asset = 63;
 		EditorStatsModeRequest set_editor_stats_mode = 64;
+		EditorRenderModeRequest set_editor_render_mode = 65;
+		Empty get_editor_render_mode = 66;
 	}
 
 	reserved 3 to 9;
 	reserved 50;
 	reserved "create_model_game_object";
 	reserved "resolve_viewport_drop_position";
-	reserved 65 to 99;
+	reserved 67 to 99;
 }
 
 message ProtocolResponse {
@@ -96,10 +98,11 @@ message ProtocolResponse {
 		Vector4Result vector4_result = 20;
 		ViewportToolStateResult viewport_tool_state_result = 21;
 		AnimatorStateResult animator_state_result = 22;
+		EditorRenderModeResult editor_render_mode_result = 23;
 	}
 
 	reserved 6 to 9;
-	reserved 23 to 99;
+	reserved 24 to 99;
 }
 
 message InitializeRequest {
@@ -150,6 +153,14 @@ message EditorSimulationRequest {
 
 message EditorStatsModeRequest {
 	EditorStatsMode mode = 1;
+}
+
+message EditorRenderModeRequest {
+	EditorRenderMode mode = 1;
+}
+
+message EditorRenderModeResult {
+	EditorRenderMode mode = 1;
 }
 
 message RemoteViewportRequest {
@@ -357,6 +368,14 @@ enum EditorStatsMode {
 	EDITOR_STATS_MODE_NONE = 1;
 	EDITOR_STATS_MODE_RENDER_STATS = 2;
 	EDITOR_STATS_MODE_RENDER_STATS_AND_QUERIES = 3;
+}
+
+enum EditorRenderMode {
+	EDITOR_RENDER_MODE_UNSPECIFIED = 0;
+	EDITOR_RENDER_MODE_LIT = 1;
+	EDITOR_RENDER_MODE_AMBIENT_OCCLUSION = 2;
+	EDITOR_RENDER_MODE_CASCADES = 3;
+	EDITOR_RENDER_MODE_LIGHT_TILES = 4;
 }
 
 message Vector4 {

--- a/Runtime/FrameGraph/DebugViewNode.cpp
+++ b/Runtime/FrameGraph/DebugViewNode.cpp
@@ -1,0 +1,139 @@
+#include "DebugViewNode.h"
+
+#include "RHI/RenderDebugView.h"
+#include "RHI/SceneView.h"
+
+using namespace Sailor;
+using namespace Sailor::Framegraph;
+using namespace Sailor::RHI;
+
+#ifndef _SAILOR_IMPORT_
+const char* DebugViewNode::m_name = "DebugView";
+#endif
+
+Tasks::TaskPtr<void, void> DebugViewNode::Prepare(
+	RHIFrameGraphPtr,
+	const RHISceneViewSnapshot&)
+{
+	EnsurePasses();
+	for (auto& pass : m_debugPasses)
+	{
+		pass->PreloadShader();
+	}
+	return {};
+}
+
+void DebugViewNode::Process(
+	RHIFrameGraphPtr frameGraph,
+	RHICommandListPtr transferCommandList,
+	RHICommandListPtr commandList,
+	const RHISceneViewSnapshot& sceneView)
+{
+	SAILOR_PROFILE_FUNCTION();
+	ResetDrawCallStats();
+	EnsurePasses();
+
+	const ESceneViewRenderMode mode = IsValidSceneViewRenderMode(sceneView.m_renderMode)
+		? sceneView.m_renderMode
+		: ESceneViewRenderMode::Lit;
+	PostProcessNode* debugPass = GetDebugPass(mode);
+	if (debugPass && debugPass->IsShaderReady())
+	{
+		debugPass->Process(
+			frameGraph,
+			transferCommandList,
+			commandList,
+			sceneView);
+		m_drawCallStats = debugPass->GetDrawCallStats();
+		return;
+	}
+
+	m_litPass->Process(
+		frameGraph,
+		transferCommandList,
+		commandList,
+		sceneView);
+	m_drawCallStats = m_litPass->GetDrawCallStats();
+}
+
+void DebugViewNode::Clear()
+{
+	if (m_litPass)
+	{
+		m_litPass->Clear();
+	}
+	m_litPass.Clear();
+	for (auto& pass : m_debugPasses)
+	{
+		if (pass)
+		{
+			pass->Clear();
+		}
+		pass.Clear();
+	}
+}
+
+void DebugViewNode::EnsurePasses()
+{
+	if (m_litPass)
+	{
+		return;
+	}
+
+	m_litPass = TRefPtr<BlitNode>::Make();
+	CopyResource(*m_litPass, "src", "src");
+	CopyResource(*m_litPass, "dst", "dst");
+
+	constexpr std::array modes{
+		ESceneViewRenderMode::AmbientOcclusion,
+		ESceneViewRenderMode::Cascades,
+		ESceneViewRenderMode::LightTiles
+	};
+	for (size_t index = 0u; index < modes.size(); ++index)
+	{
+		auto& pass = m_debugPasses[index];
+		pass = TRefPtr<PostProcessNode>::Make();
+		pass->SetString("shader", GetString("shader"));
+		pass->SetString(
+			"defines",
+			GetSceneViewRenderModeShaderDefine(modes[index]));
+		CopyResource(*pass, "color", "dst");
+		CopyResource(*pass, "ldrSceneSampler", "src");
+		CopyResource(*pass, "linearDepthSampler", "linearDepth");
+	}
+}
+
+void DebugViewNode::CopyResource(
+	BaseFrameGraphNode& destination,
+	const std::string& destinationName,
+	const std::string& sourceName)
+{
+	if (m_resourceParams.ContainsKey(sourceName))
+	{
+		destination.SetRHIResource(
+			destinationName,
+			GetRHIResource(sourceName));
+	}
+	else if (m_unresolvedResourceParams.ContainsKey(sourceName))
+	{
+		destination.SetRHIResource_Unresolved(
+			destinationName,
+			m_unresolvedResourceParams[sourceName]);
+	}
+}
+
+PostProcessNode* DebugViewNode::GetDebugPass(ESceneViewRenderMode mode)
+{
+	switch (mode)
+	{
+	case ESceneViewRenderMode::AmbientOcclusion:
+		return m_debugPasses[0].GetRawPtr();
+	case ESceneViewRenderMode::Cascades:
+		return m_debugPasses[1].GetRawPtr();
+	case ESceneViewRenderMode::LightTiles:
+		return m_debugPasses[2].GetRawPtr();
+	case ESceneViewRenderMode::Lit:
+	default:
+		return nullptr;
+	}
+}

--- a/Runtime/FrameGraph/DebugViewNode.h
+++ b/Runtime/FrameGraph/DebugViewNode.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "Core/Defines.h"
+#include "FrameGraph/BlitNode.h"
+#include "FrameGraph/FrameGraphNode.h"
+#include "FrameGraph/PostProcessNode.h"
+#include "Memory/RefPtr.hpp"
+#include "RHI/RenderDebugView.h"
+
+#include <array>
+
+namespace Sailor::Framegraph
+{
+	class DebugViewNode final : public TFrameGraphNode<DebugViewNode>
+	{
+	public:
+		SAILOR_API static const char* GetName() { return m_name; }
+
+		SAILOR_API virtual Sailor::Tasks::TaskPtr<void, void> Prepare(
+			RHI::RHIFrameGraphPtr frameGraph,
+			const RHI::RHISceneViewSnapshot& sceneView) override;
+		SAILOR_API virtual void Process(
+			RHI::RHIFrameGraphPtr frameGraph,
+			RHI::RHICommandListPtr transferCommandList,
+			RHI::RHICommandListPtr commandList,
+			const RHI::RHISceneViewSnapshot& sceneView) override;
+		SAILOR_API virtual void Clear() override;
+
+	private:
+		void EnsurePasses();
+		void CopyResource(
+			BaseFrameGraphNode& destination,
+			const std::string& destinationName,
+			const std::string& sourceName);
+		PostProcessNode* GetDebugPass(RHI::ESceneViewRenderMode mode);
+
+		static const char* m_name;
+		TRefPtr<BlitNode> m_litPass{};
+		std::array<TRefPtr<PostProcessNode>, 3> m_debugPasses{};
+	};
+
+	template class TFrameGraphNode<DebugViewNode>;
+}

--- a/Runtime/FrameGraph/PostProcessNode.cpp
+++ b/Runtime/FrameGraph/PostProcessNode.cpp
@@ -19,6 +19,30 @@ using namespace Sailor::Framegraph;
 const char* PostProcessNode::m_name = "PostProcess";
 #endif
 
+void PostProcessNode::PreloadShader()
+{
+	if (m_pShader)
+	{
+		return;
+	}
+
+	auto shaderPath = GetString("shader");
+	check(!shaderPath.empty());
+
+	auto definesStr = GetString("defines");
+	TVector<std::string> defines = Sailor::Utils::SplitString(definesStr, " ");
+
+	if (auto shaderInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(shaderPath))
+	{
+		App::GetSubmodule<ShaderCompiler>()->LoadShader(shaderInfo->GetFileId(), m_pShader, defines);
+	}
+}
+
+bool PostProcessNode::IsShaderReady() const
+{
+	return m_pShader && m_pShader->IsReady();
+}
+
 void PostProcessNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
 {
 	SAILOR_PROFILE_FUNCTION();
@@ -45,19 +69,7 @@ void PostProcessNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 		}
 	}
 
-	if (!m_pShader)
-	{
-		auto shaderPath = GetString("shader");
-		check(!shaderPath.empty());
-
-		auto definesStr = GetString("defines");
-		TVector<std::string> defines = Sailor::Utils::SplitString(definesStr, " ");
-
-		if (auto shaderInfo = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr(shaderPath))
-		{
-			App::GetSubmodule<ShaderCompiler>()->LoadShader(shaderInfo->GetFileId(), m_pShader, defines);
-		}
-	}
+	PreloadShader();
 
 	if (!m_pShader || !m_pShader->IsReady() || !target)
 	{

--- a/Runtime/FrameGraph/PostProcessNode.h
+++ b/Runtime/FrameGraph/PostProcessNode.h
@@ -13,6 +13,8 @@ namespace Sailor::Framegraph
 	public:
 		SAILOR_API static const char* GetName() { return m_name; }
 
+		SAILOR_API void PreloadShader();
+		SAILOR_API bool IsShaderReady() const;
 		SAILOR_API virtual void Process(RHI::RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView) override;
 		SAILOR_API virtual void Clear() override;
 

--- a/Runtime/Protocol/Generated/editor_engine.pb.cc
+++ b/Runtime/Protocol/Generated/editor_engine.pb.cc
@@ -984,6 +984,56 @@ struct EditorSimulationRequestDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 EditorSimulationRequestDefaultTypeInternal _EditorSimulationRequest_default_instance_;
 
+inline constexpr EditorRenderModeResult::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : mode_{static_cast< ::sailor::editor::v1::EditorRenderMode >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR EditorRenderModeResult::EditorRenderModeResult(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct EditorRenderModeResultDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR EditorRenderModeResultDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~EditorRenderModeResultDefaultTypeInternal() {}
+  union {
+    EditorRenderModeResult _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 EditorRenderModeResultDefaultTypeInternal _EditorRenderModeResult_default_instance_;
+
+inline constexpr EditorRenderModeRequest::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : mode_{static_cast< ::sailor::editor::v1::EditorRenderMode >(0)},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR EditorRenderModeRequest::EditorRenderModeRequest(::_pbi::ConstantInitialized)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(_class_data_.base()),
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(),
+#endif  // PROTOBUF_CUSTOM_VTABLE
+      _impl_(::_pbi::ConstantInitialized()) {
+}
+struct EditorRenderModeRequestDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR EditorRenderModeRequestDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~EditorRenderModeRequestDefaultTypeInternal() {}
+  union {
+    EditorRenderModeRequest _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 EditorRenderModeRequestDefaultTypeInternal _EditorRenderModeRequest_default_instance_;
+
 inline constexpr CreateGameObjectRequest::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : parent_instance_id_(
@@ -1442,7 +1492,7 @@ PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
 }  // namespace v1
 }  // namespace editor
 }  // namespace sailor
-static const ::_pb::EnumDescriptor* file_level_enum_descriptors_editor_5fengine_2eproto[3];
+static const ::_pb::EnumDescriptor* file_level_enum_descriptors_editor_5fengine_2eproto[4];
 static constexpr const ::_pb::ServiceDescriptor**
     file_level_service_descriptors_editor_5fengine_2eproto = nullptr;
 const ::uint32_t
@@ -1520,6 +1570,8 @@ const ::uint32_t
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
+        ::_pbi::kInvalidFieldOffsetTag,
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolRequest, _impl_.command_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _internal_metadata_),
@@ -1534,6 +1586,7 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _impl_.success_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _impl_.error_),
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::ProtocolResponse, _impl_.supports_strict_instance_ids_),
+        ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
         ::_pbi::kInvalidFieldOffsetTag,
@@ -1655,6 +1708,24 @@ const ::uint32_t
         ~0u,  // no _split_
         ~0u,  // no sizeof(Split)
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::EditorStatsModeRequest, _impl_.mode_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::EditorRenderModeRequest, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::EditorRenderModeRequest, _impl_.mode_),
+        ~0u,  // no _has_bits_
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::EditorRenderModeResult, _internal_metadata_),
+        ~0u,  // no _extensions_
+        ~0u,  // no _oneof_case_
+        ~0u,  // no _weak_field_map_
+        ~0u,  // no _inlined_string_donated_
+        ~0u,  // no _split_
+        ~0u,  // no sizeof(Split)
+        PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::EditorRenderModeResult, _impl_.mode_),
         ~0u,  // no _has_bits_
         PROTOBUF_FIELD_OFFSET(::sailor::editor::v1::RemoteViewportRequest, _internal_metadata_),
         ~0u,  // no _extensions_
@@ -2091,54 +2162,56 @@ static const ::_pbi::MigrationSchema
     schemas[] ABSL_ATTRIBUTE_SECTION_VARIABLE(protodesc_cold) = {
         {0, -1, -1, sizeof(::sailor::editor::v1::Empty)},
         {8, -1, -1, sizeof(::sailor::editor::v1::ProtocolRequest)},
-        {73, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
-        {100, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
-        {109, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
-        {118, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
-        {127, 142, -1, sizeof(::sailor::editor::v1::CreateModelInstanceRequest)},
-        {149, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
-        {158, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
-        {167, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
-        {179, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
-        {189, -1, -1, sizeof(::sailor::editor::v1::EditorSimulationRequest)},
-        {198, -1, -1, sizeof(::sailor::editor::v1::EditorStatsModeRequest)},
-        {207, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
-        {222, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
-        {233, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
-        {253, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
-        {263, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
-        {273, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
-        {284, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
-        {294, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
-        {305, -1, -1, sizeof(::sailor::editor::v1::AnimatorParameterRequest)},
-        {321, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
-        {331, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
-        {342, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
-        {353, 365, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
-        {369, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
-        {379, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
-        {389, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
-        {400, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
-        {409, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
-        {418, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
-        {431, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
-        {440, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
-        {449, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
-        {458, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
-        {467, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
-        {477, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
-        {486, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
-        {498, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
-        {508, 517, -1, sizeof(::sailor::editor::v1::Vector4Result)},
-        {518, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
-        {528, -1, -1, sizeof(::sailor::editor::v1::AnimatorStateResult)},
-        {546, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
-        {558, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
-        {567, 584, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
-        {593, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
-        {604, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
-        {613, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
-        {628, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
+        {75, -1, -1, sizeof(::sailor::editor::v1::ProtocolResponse)},
+        {103, -1, -1, sizeof(::sailor::editor::v1::InitializeRequest)},
+        {112, -1, -1, sizeof(::sailor::editor::v1::CountRequest)},
+        {121, -1, -1, sizeof(::sailor::editor::v1::FileIdRequest)},
+        {130, 145, -1, sizeof(::sailor::editor::v1::CreateModelInstanceRequest)},
+        {152, -1, -1, sizeof(::sailor::editor::v1::InstanceIdRequest)},
+        {161, -1, -1, sizeof(::sailor::editor::v1::ViewportIdRequest)},
+        {170, -1, -1, sizeof(::sailor::editor::v1::ViewportRectRequest)},
+        {182, -1, -1, sizeof(::sailor::editor::v1::SizeRequest)},
+        {192, -1, -1, sizeof(::sailor::editor::v1::EditorSimulationRequest)},
+        {201, -1, -1, sizeof(::sailor::editor::v1::EditorStatsModeRequest)},
+        {210, -1, -1, sizeof(::sailor::editor::v1::EditorRenderModeRequest)},
+        {219, -1, -1, sizeof(::sailor::editor::v1::EditorRenderModeResult)},
+        {228, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportRequest)},
+        {243, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportHostRequest)},
+        {254, -1, -1, sizeof(::sailor::editor::v1::RemoteViewportInputRequest)},
+        {274, -1, -1, sizeof(::sailor::editor::v1::ManagedMutationRevisionRequest)},
+        {284, -1, -1, sizeof(::sailor::editor::v1::UpdateObjectRequest)},
+        {294, -1, -1, sizeof(::sailor::editor::v1::ReparentObjectRequest)},
+        {305, -1, -1, sizeof(::sailor::editor::v1::CreateGameObjectRequest)},
+        {315, -1, -1, sizeof(::sailor::editor::v1::AddComponentRequest)},
+        {326, -1, -1, sizeof(::sailor::editor::v1::AnimatorParameterRequest)},
+        {342, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabRequest)},
+        {352, -1, -1, sizeof(::sailor::editor::v1::InstantiatePrefabFromYamlRequest)},
+        {363, -1, -1, sizeof(::sailor::editor::v1::ViewportRayRequest)},
+        {374, 386, -1, sizeof(::sailor::editor::v1::InstantiatePrefabInstanceRequest)},
+        {390, -1, -1, sizeof(::sailor::editor::v1::ViewportObjectRequest)},
+        {400, -1, -1, sizeof(::sailor::editor::v1::PrefabLinkRequest)},
+        {410, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateRequest)},
+        {421, -1, -1, sizeof(::sailor::editor::v1::SelectionRequest)},
+        {430, -1, -1, sizeof(::sailor::editor::v1::ShowMainWindowRequest)},
+        {439, -1, -1, sizeof(::sailor::editor::v1::RenderPathTracedImageRequest)},
+        {452, -1, -1, sizeof(::sailor::editor::v1::BoolResult)},
+        {461, -1, -1, sizeof(::sailor::editor::v1::Int32Result)},
+        {470, -1, -1, sizeof(::sailor::editor::v1::UInt32Result)},
+        {479, -1, -1, sizeof(::sailor::editor::v1::UInt64Result)},
+        {488, -1, -1, sizeof(::sailor::editor::v1::StringResult)},
+        {498, -1, -1, sizeof(::sailor::editor::v1::StringListResult)},
+        {507, -1, -1, sizeof(::sailor::editor::v1::AssetReloadStateResult)},
+        {519, -1, -1, sizeof(::sailor::editor::v1::InstanceIdResult)},
+        {529, 538, -1, sizeof(::sailor::editor::v1::Vector4Result)},
+        {539, -1, -1, sizeof(::sailor::editor::v1::ViewportToolStateResult)},
+        {549, -1, -1, sizeof(::sailor::editor::v1::AnimatorStateResult)},
+        {567, -1, -1, sizeof(::sailor::editor::v1::Vector4)},
+        {579, -1, -1, sizeof(::sailor::editor::v1::ViewportSelectionEvent)},
+        {588, 605, -1, sizeof(::sailor::editor::v1::ViewportTransformEvent)},
+        {614, -1, -1, sizeof(::sailor::editor::v1::ViewportAssetDropEvent)},
+        {625, -1, -1, sizeof(::sailor::editor::v1::ViewportToolShortcutEvent)},
+        {634, -1, -1, sizeof(::sailor::editor::v1::ViewportEvent)},
+        {649, -1, -1, sizeof(::sailor::editor::v1::ViewportEventBatchResult)},
 };
 static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_Empty_default_instance_._instance,
@@ -2154,6 +2227,8 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::sailor::editor::v1::_SizeRequest_default_instance_._instance,
     &::sailor::editor::v1::_EditorSimulationRequest_default_instance_._instance,
     &::sailor::editor::v1::_EditorStatsModeRequest_default_instance_._instance,
+    &::sailor::editor::v1::_EditorRenderModeRequest_default_instance_._instance,
+    &::sailor::editor::v1::_EditorRenderModeResult_default_instance_._instance,
     &::sailor::editor::v1::_RemoteViewportRequest_default_instance_._instance,
     &::sailor::editor::v1::_RemoteViewportHostRequest_default_instance_._instance,
     &::sailor::editor::v1::_RemoteViewportInputRequest_default_instance_._instance,
@@ -2195,7 +2270,7 @@ static const ::_pb::Message* const file_default_instances[] = {
 const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SECTION_VARIABLE(
     protodesc_cold) = {
     "\n\023editor_engine.proto\022\020sailor.editor.v1\""
-    "\007\n\005Empty\"\363\035\n\017ProtocolRequest\022\030\n\020protocol"
+    "\007\n\005Empty\"\373\036\n\017ProtocolRequest\022\030\n\020protocol"
     "_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\0229\n\nin"
     "itialize\030\n \001(\0132#.sailor.editor.v1.Initia"
     "lizeRequestH\000\022(\n\005start\030\013 \001(\0132\027.sailor.ed"
@@ -2288,183 +2363,197 @@ const char descriptor_table_protodef_editor_5fengine_2eproto[] ABSL_ATTRIBUTE_SE
     "r.v1.EmptyH\000\022>\n\023preview_audio_asset\030\? \001("
     "\0132\037.sailor.editor.v1.FileIdRequestH\000\022I\n\025"
     "set_editor_stats_mode\030@ \001(\0132(.sailor.edi"
-    "tor.v1.EditorStatsModeRequestH\000B\t\n\007comma"
-    "ndJ\004\010\003\020\nJ\004\0102\0203J\004\010A\020dR\030create_model_game_"
-    "objectR\036resolve_viewport_drop_position\"\336"
-    "\007\n\020ProtocolResponse\022\030\n\020protocol_version\030"
-    "\001 \001(\r\022\022\n\nrequest_id\030\002 \001(\004\022\017\n\007success\030\003 \001"
-    "(\010\022\r\n\005error\030\004 \001(\t\022$\n\034supports_strict_ins"
-    "tance_ids\030\005 \001(\010\022/\n\014empty_result\030\n \001(\0132\027."
-    "sailor.editor.v1.EmptyH\000\0223\n\013bool_result\030"
-    "\013 \001(\0132\034.sailor.editor.v1.BoolResultH\000\0225\n"
-    "\014int32_result\030\014 \001(\0132\035.sailor.editor.v1.I"
-    "nt32ResultH\000\0227\n\ruint32_result\030\r \001(\0132\036.sa"
-    "ilor.editor.v1.UInt32ResultH\000\0227\n\ruint64_"
-    "result\030\016 \001(\0132\036.sailor.editor.v1.UInt64Re"
-    "sultH\000\0227\n\rstring_result\030\017 \001(\0132\036.sailor.e"
-    "ditor.v1.StringResultH\000\022@\n\022string_list_r"
-    "esult\030\020 \001(\0132\".sailor.editor.v1.StringLis"
-    "tResultH\000\022M\n\031asset_reload_state_result\030\021"
-    " \001(\0132(.sailor.editor.v1.AssetReloadState"
-    "ResultH\000\022@\n\022instance_id_result\030\022 \001(\0132\".s"
-    "ailor.editor.v1.InstanceIdResultH\000\022Q\n\033vi"
-    "ewport_event_batch_result\030\023 \001(\0132*.sailor"
-    ".editor.v1.ViewportEventBatchResultH\000\0229\n"
-    "\016vector4_result\030\024 \001(\0132\037.sailor.editor.v1"
-    ".Vector4ResultH\000\022O\n\032viewport_tool_state_"
-    "result\030\025 \001(\0132).sailor.editor.v1.Viewport"
-    "ToolStateResultH\000\022F\n\025animator_state_resu"
-    "lt\030\026 \001(\0132%.sailor.editor.v1.AnimatorStat"
-    "eResultH\000B\010\n\006resultJ\004\010\006\020\nJ\004\010\027\020d\"&\n\021Initi"
-    "alizeRequest\022\021\n\targuments\030\001 \003(\t\"!\n\014Count"
-    "Request\022\021\n\tmax_count\030\001 \001(\r\" \n\rFileIdRequ"
-    "est\022\017\n\007file_id\030\001 \001(\t\"\347\001\n\032CreateModelInst"
-    "anceRequest\022\025\n\rmodel_file_id\030\001 \001(\t\022\014\n\004na"
-    "me\030\002 \001(\t\022\032\n\022parent_instance_id\030\003 \001(\t\022\030\n\020"
-    "create_hierarchy\030\004 \001(\010\022\034\n\024apply_world_po"
-    "sition\030\005 \001(\010\0221\n\016world_position\030\006 \001(\0132\031.s"
-    "ailor.editor.v1.Vector4\022\035\n\025preferred_ins"
-    "tance_id\030\007 \001(\t\"(\n\021InstanceIdRequest\022\023\n\013i"
-    "nstance_id\030\001 \001(\t\"(\n\021ViewportIdRequest\022\023\n"
-    "\013viewport_id\030\001 \001(\004\"`\n\023ViewportRectReques"
-    "t\022\024\n\014window_pos_x\030\001 \001(\r\022\024\n\014window_pos_y\030"
-    "\002 \001(\r\022\r\n\005width\030\003 \001(\r\022\016\n\006height\030\004 \001(\r\",\n\013"
-    "SizeRequest\022\r\n\005width\030\001 \001(\r\022\016\n\006height\030\002 \001"
-    "(\r\"*\n\027EditorSimulationRequest\022\017\n\007enabled"
-    "\030\001 \001(\010\"I\n\026EditorStatsModeRequest\022/\n\004mode"
-    "\030\001 \001(\0162!.sailor.editor.v1.EditorStatsMod"
-    "e\"\231\001\n\025RemoteViewportRequest\022\023\n\013viewport_"
-    "id\030\001 \001(\004\022\024\n\014window_pos_x\030\002 \001(\r\022\024\n\014window"
-    "_pos_y\030\003 \001(\r\022\r\n\005width\030\004 \001(\r\022\016\n\006height\030\005 "
-    "\001(\r\022\017\n\007visible\030\006 \001(\010\022\017\n\007focused\030\007 \001(\010\"e\n"
-    "\031RemoteViewportHostRequest\022\023\n\013viewport_i"
-    "d\030\001 \001(\004\022\030\n\020host_handle_kind\030\002 \001(\r\022\031\n\021hos"
-    "t_handle_value\030\003 \001(\004\"\374\001\n\032RemoteViewportI"
-    "nputRequest\022\023\n\013viewport_id\030\001 \001(\004\022\014\n\004kind"
-    "\030\002 \001(\r\022\021\n\tpointer_x\030\003 \001(\002\022\021\n\tpointer_y\030\004"
-    " \001(\002\022\025\n\rwheel_delta_x\030\005 \001(\002\022\025\n\rwheel_del"
-    "ta_y\030\006 \001(\002\022\020\n\010key_code\030\007 \001(\r\022\016\n\006button\030\010"
-    " \001(\r\022\021\n\tmodifiers\030\t \001(\r\022\017\n\007pressed\030\n \001(\010"
-    "\022\017\n\007focused\030\013 \001(\010\022\020\n\010captured\030\014 \001(\010\"C\n\036M"
-    "anagedMutationRevisionRequest\022\014\n\004kind\030\001 "
-    "\001(\r\022\023\n\013instance_id\030\002 \001(\t\"@\n\023UpdateObject"
-    "Request\022\023\n\013instance_id\030\001 \001(\t\022\024\n\014yaml_cha"
-    "nges\030\002 \001(\t\"f\n\025ReparentObjectRequest\022\023\n\013i"
-    "nstance_id\030\001 \001(\t\022\032\n\022parent_instance_id\030\002"
-    " \001(\t\022\034\n\024keep_world_transform\030\003 \001(\010\"T\n\027Cr"
-    "eateGameObjectRequest\022\032\n\022parent_instance"
-    "_id\030\001 \001(\t\022\035\n\025preferred_instance_id\030\002 \001(\t"
-    "\"f\n\023AddComponentRequest\022\023\n\013instance_id\030\001"
-    " \001(\t\022\033\n\023component_type_name\030\002 \001(\t\022\035\n\025pre"
-    "ferred_instance_id\030\003 \001(\t\"\346\001\n\030AnimatorPar"
-    "ameterRequest\022\023\n\013instance_id\030\001 \001(\t\022\014\n\004na"
-    "me\030\002 \001(\t\022\025\n\013float_value\030\003 \001(\002H\000\022\023\n\tint_v"
-    "alue\030\004 \001(\021H\000\022\024\n\nbool_value\030\005 \001(\010H\000\022*\n\007tr"
-    "igger\030\006 \001(\0132\027.sailor.editor.v1.EmptyH\000\0220"
-    "\n\rreset_trigger\030\007 \001(\0132\027.sailor.editor.v1"
-    ".EmptyH\000B\007\n\005value\"G\n\030InstantiatePrefabRe"
-    "quest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_instanc"
-    "e_id\030\002 \001(\t\"p\n InstantiatePrefabFromYamlR"
-    "equest\022\023\n\013prefab_yaml\030\001 \001(\t\022\032\n\022parent_in"
-    "stance_id\030\002 \001(\t\022\033\n\023strict_instance_ids\030\003"
-    " \001(\010\"U\n\022ViewportRayRequest\022\023\n\013viewport_i"
-    "d\030\001 \001(\004\022\024\n\014normalized_x\030\002 \001(\002\022\024\n\014normali"
-    "zed_y\030\003 \001(\002\"\240\001\n InstantiatePrefabInstanc"
-    "eRequest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent_inst"
-    "ance_id\030\002 \001(\t\022\034\n\024apply_world_position\030\003 "
-    "\001(\010\0221\n\016world_position\030\004 \001(\0132\031.sailor.edi"
-    "tor.v1.Vector4\"A\n\025ViewportObjectRequest\022"
-    "\023\n\013viewport_id\030\001 \001(\004\022\023\n\013instance_id\030\002 \001("
-    "\t\"9\n\021PrefabLinkRequest\022\023\n\013instance_id\030\001 "
-    "\001(\t\022\017\n\007file_id\030\002 \001(\t\"\251\001\n\030ViewportToolSta"
-    "teRequest\022\023\n\013viewport_id\030\001 \001(\004\022\?\n\toperat"
-    "ion\030\002 \001(\0162,.sailor.editor.v1.ViewportTra"
-    "nsformOperation\0227\n\005space\030\003 \001(\0162(.sailor."
-    "editor.v1.ViewportTransformSpace\"(\n\020Sele"
-    "ctionRequest\022\024\n\014instance_ids\030\001 \003(\t\"%\n\025Sh"
-    "owMainWindowRequest\022\014\n\004show\030\001 \001(\010\"\210\001\n\034Re"
-    "nderPathTracedImageRequest\022\023\n\013output_pat"
-    "h\030\001 \001(\t\022\023\n\013instance_id\030\002 \001(\t\022\016\n\006height\030\003"
-    " \001(\r\022\031\n\021samples_per_pixel\030\004 \001(\r\022\023\n\013max_b"
-    "ounces\030\005 \001(\r\"\033\n\nBoolResult\022\r\n\005value\030\001 \001("
-    "\010\"\034\n\013Int32Result\022\r\n\005value\030\001 \001(\005\"\035\n\014UInt3"
-    "2Result\022\r\n\005value\030\001 \001(\r\"\035\n\014UInt64Result\022\r"
-    "\n\005value\030\001 \001(\004\"0\n\014StringResult\022\021\n\thas_val"
-    "ue\030\001 \001(\010\022\r\n\005value\030\002 \001(\t\"\"\n\020StringListRes"
-    "ult\022\016\n\006values\030\001 \003(\t\"\204\001\n\026AssetReloadState"
-    "Result\022\021\n\tavailable\030\001 \001(\010\022\032\n\022request_gen"
-    "eration\030\002 \001(\004\022\034\n\024completed_generation\030\003 "
-    "\001(\004\022\035\n\025successful_generation\030\004 \001(\004\":\n\020In"
-    "stanceIdResult\022\021\n\tsucceeded\030\001 \001(\010\022\023\n\013ins"
-    "tance_id\030\002 \001(\t\"9\n\rVector4Result\022(\n\005value"
-    "\030\001 \001(\0132\031.sailor.editor.v1.Vector4\"\223\001\n\027Vi"
-    "ewportToolStateResult\022\?\n\toperation\030\001 \001(\016"
-    "2,.sailor.editor.v1.ViewportTransformOpe"
-    "ration\0227\n\005space\030\002 \001(\0162(.sailor.editor.v1"
-    ".ViewportTransformSpace\"\250\002\n\023AnimatorStat"
-    "eResult\022\026\n\016has_controller\030\001 \001(\010\022\033\n\023contr"
-    "oller_revision\030\002 \001(\004\022\027\n\017active_state_id\030"
-    "\003 \001(\004\022\031\n\021active_state_name\030\004 \001(\t\022\031\n\021acti"
-    "ve_state_time\030\005 \001(\002\022\025\n\rtransitioning\030\006 \001"
-    "(\010\022\034\n\024destination_state_id\030\007 \001(\004\022\036\n\026dest"
-    "ination_state_name\030\010 \001(\t\022\036\n\026destination_"
-    "state_time\030\t \001(\002\022\030\n\020transition_alpha\030\n \001"
-    "(\002\"5\n\007Vector4\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 \001(\002\022\t\n\001z"
-    "\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n\026ViewportSelectionEv"
-    "ent\022\034\n\024selected_instance_id\030\001 \001(\t\"\326\003\n\026Vi"
-    "ewportTransformEvent\022\023\n\013instance_id\030\001 \001("
-    "\t\022\?\n\toperation\030\002 \001(\0162,.sailor.editor.v1."
-    "ViewportTransformOperation\0227\n\005space\030\003 \001("
-    "\0162(.sailor.editor.v1.ViewportTransformSp"
-    "ace\0222\n\017before_position\030\004 \001(\0132\031.sailor.ed"
-    "itor.v1.Vector4\0222\n\017before_rotation\030\005 \001(\013"
-    "2\031.sailor.editor.v1.Vector4\022/\n\014before_sc"
-    "ale\030\006 \001(\0132\031.sailor.editor.v1.Vector4\0221\n\016"
-    "after_position\030\007 \001(\0132\031.sailor.editor.v1."
-    "Vector4\0221\n\016after_rotation\030\010 \001(\0132\031.sailor"
-    ".editor.v1.Vector4\022.\n\013after_scale\030\t \001(\0132"
-    "\031.sailor.editor.v1.Vector4\"U\n\026ViewportAs"
-    "setDropEvent\022\017\n\007file_id\030\001 \001(\t\022\024\n\014normali"
-    "zed_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 \001(\002\"-\n\031Vie"
-    "wportToolShortcutEvent\022\020\n\010key_code\030\001 \001(\r"
-    "\"\331\002\n\rViewportEvent\022\020\n\010revision\030\001 \001(\004\022!\n\031"
-    "managed_mutation_revision\030\002 \001(\004\022=\n\tselec"
-    "tion\030\n \001(\0132(.sailor.editor.v1.ViewportSe"
-    "lectionEventH\000\022=\n\ttransform\030\013 \001(\0132(.sail"
-    "or.editor.v1.ViewportTransformEventH\000\022>\n"
-    "\nasset_drop\030\014 \001(\0132(.sailor.editor.v1.Vie"
-    "wportAssetDropEventH\000\022D\n\rtool_shortcut\030\r"
-    " \001(\0132+.sailor.editor.v1.ViewportToolShor"
-    "tcutEventH\000B\t\n\007payloadJ\004\010\003\020\n\"K\n\030Viewport"
-    "EventBatchResult\022/\n\006events\030\001 \003(\0132\037.sailo"
-    "r.editor.v1.ViewportEvent*\360\001\n\032ViewportTr"
-    "ansformOperation\022,\n(VIEWPORT_TRANSFORM_O"
-    "PERATION_UNSPECIFIED\020\000\022\'\n#VIEWPORT_TRANS"
-    "FORM_OPERATION_SELECT\020\001\022*\n&VIEWPORT_TRAN"
-    "SFORM_OPERATION_TRANSLATE\020\002\022\'\n#VIEWPORT_"
-    "TRANSFORM_OPERATION_ROTATE\020\003\022&\n\"VIEWPORT"
-    "_TRANSFORM_OPERATION_SCALE\020\004*\212\001\n\026Viewpor"
-    "tTransformSpace\022(\n$VIEWPORT_TRANSFORM_SP"
-    "ACE_UNSPECIFIED\020\000\022\"\n\036VIEWPORT_TRANSFORM_"
-    "SPACE_WORLD\020\001\022\"\n\036VIEWPORT_TRANSFORM_SPAC"
-    "E_LOCAL\020\002*\244\001\n\017EditorStatsMode\022!\n\035EDITOR_"
-    "STATS_MODE_UNSPECIFIED\020\000\022\032\n\026EDITOR_STATS"
-    "_MODE_NONE\020\001\022\"\n\036EDITOR_STATS_MODE_RENDER"
-    "_STATS\020\002\022.\n*EDITOR_STATS_MODE_RENDER_STA"
-    "TS_AND_QUERIES\020\003B\"\252\002\037SailorEditor.Protoc"
-    "ol.Generatedb\006proto3"
+    "tor.v1.EditorStatsModeRequestH\000\022K\n\026set_e"
+    "ditor_render_mode\030A \001(\0132).sailor.editor."
+    "v1.EditorRenderModeRequestH\000\0229\n\026get_edit"
+    "or_render_mode\030B \001(\0132\027.sailor.editor.v1."
+    "EmptyH\000B\t\n\007commandJ\004\010\003\020\nJ\004\0102\0203J\004\010C\020dR\030cr"
+    "eate_model_game_objectR\036resolve_viewport"
+    "_drop_position\"\255\010\n\020ProtocolResponse\022\030\n\020p"
+    "rotocol_version\030\001 \001(\r\022\022\n\nrequest_id\030\002 \001("
+    "\004\022\017\n\007success\030\003 \001(\010\022\r\n\005error\030\004 \001(\t\022$\n\034sup"
+    "ports_strict_instance_ids\030\005 \001(\010\022/\n\014empty"
+    "_result\030\n \001(\0132\027.sailor.editor.v1.EmptyH\000"
+    "\0223\n\013bool_result\030\013 \001(\0132\034.sailor.editor.v1"
+    ".BoolResultH\000\0225\n\014int32_result\030\014 \001(\0132\035.sa"
+    "ilor.editor.v1.Int32ResultH\000\0227\n\ruint32_r"
+    "esult\030\r \001(\0132\036.sailor.editor.v1.UInt32Res"
+    "ultH\000\0227\n\ruint64_result\030\016 \001(\0132\036.sailor.ed"
+    "itor.v1.UInt64ResultH\000\0227\n\rstring_result\030"
+    "\017 \001(\0132\036.sailor.editor.v1.StringResultH\000\022"
+    "@\n\022string_list_result\030\020 \001(\0132\".sailor.edi"
+    "tor.v1.StringListResultH\000\022M\n\031asset_reloa"
+    "d_state_result\030\021 \001(\0132(.sailor.editor.v1."
+    "AssetReloadStateResultH\000\022@\n\022instance_id_"
+    "result\030\022 \001(\0132\".sailor.editor.v1.Instance"
+    "IdResultH\000\022Q\n\033viewport_event_batch_resul"
+    "t\030\023 \001(\0132*.sailor.editor.v1.ViewportEvent"
+    "BatchResultH\000\0229\n\016vector4_result\030\024 \001(\0132\037."
+    "sailor.editor.v1.Vector4ResultH\000\022O\n\032view"
+    "port_tool_state_result\030\025 \001(\0132).sailor.ed"
+    "itor.v1.ViewportToolStateResultH\000\022F\n\025ani"
+    "mator_state_result\030\026 \001(\0132%.sailor.editor"
+    ".v1.AnimatorStateResultH\000\022M\n\031editor_rend"
+    "er_mode_result\030\027 \001(\0132(.sailor.editor.v1."
+    "EditorRenderModeResultH\000B\010\n\006resultJ\004\010\006\020\n"
+    "J\004\010\030\020d\"&\n\021InitializeRequest\022\021\n\targuments"
+    "\030\001 \003(\t\"!\n\014CountRequest\022\021\n\tmax_count\030\001 \001("
+    "\r\" \n\rFileIdRequest\022\017\n\007file_id\030\001 \001(\t\"\347\001\n\032"
+    "CreateModelInstanceRequest\022\025\n\rmodel_file"
+    "_id\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\032\n\022parent_instan"
+    "ce_id\030\003 \001(\t\022\030\n\020create_hierarchy\030\004 \001(\010\022\034\n"
+    "\024apply_world_position\030\005 \001(\010\0221\n\016world_pos"
+    "ition\030\006 \001(\0132\031.sailor.editor.v1.Vector4\022\035"
+    "\n\025preferred_instance_id\030\007 \001(\t\"(\n\021Instanc"
+    "eIdRequest\022\023\n\013instance_id\030\001 \001(\t\"(\n\021Viewp"
+    "ortIdRequest\022\023\n\013viewport_id\030\001 \001(\004\"`\n\023Vie"
+    "wportRectRequest\022\024\n\014window_pos_x\030\001 \001(\r\022\024"
+    "\n\014window_pos_y\030\002 \001(\r\022\r\n\005width\030\003 \001(\r\022\016\n\006h"
+    "eight\030\004 \001(\r\",\n\013SizeRequest\022\r\n\005width\030\001 \001("
+    "\r\022\016\n\006height\030\002 \001(\r\"*\n\027EditorSimulationReq"
+    "uest\022\017\n\007enabled\030\001 \001(\010\"I\n\026EditorStatsMode"
+    "Request\022/\n\004mode\030\001 \001(\0162!.sailor.editor.v1"
+    ".EditorStatsMode\"K\n\027EditorRenderModeRequ"
+    "est\0220\n\004mode\030\001 \001(\0162\".sailor.editor.v1.Edi"
+    "torRenderMode\"J\n\026EditorRenderModeResult\022"
+    "0\n\004mode\030\001 \001(\0162\".sailor.editor.v1.EditorR"
+    "enderMode\"\231\001\n\025RemoteViewportRequest\022\023\n\013v"
+    "iewport_id\030\001 \001(\004\022\024\n\014window_pos_x\030\002 \001(\r\022\024"
+    "\n\014window_pos_y\030\003 \001(\r\022\r\n\005width\030\004 \001(\r\022\016\n\006h"
+    "eight\030\005 \001(\r\022\017\n\007visible\030\006 \001(\010\022\017\n\007focused\030"
+    "\007 \001(\010\"e\n\031RemoteViewportHostRequest\022\023\n\013vi"
+    "ewport_id\030\001 \001(\004\022\030\n\020host_handle_kind\030\002 \001("
+    "\r\022\031\n\021host_handle_value\030\003 \001(\004\"\374\001\n\032RemoteV"
+    "iewportInputRequest\022\023\n\013viewport_id\030\001 \001(\004"
+    "\022\014\n\004kind\030\002 \001(\r\022\021\n\tpointer_x\030\003 \001(\002\022\021\n\tpoi"
+    "nter_y\030\004 \001(\002\022\025\n\rwheel_delta_x\030\005 \001(\002\022\025\n\rw"
+    "heel_delta_y\030\006 \001(\002\022\020\n\010key_code\030\007 \001(\r\022\016\n\006"
+    "button\030\010 \001(\r\022\021\n\tmodifiers\030\t \001(\r\022\017\n\007press"
+    "ed\030\n \001(\010\022\017\n\007focused\030\013 \001(\010\022\020\n\010captured\030\014 "
+    "\001(\010\"C\n\036ManagedMutationRevisionRequest\022\014\n"
+    "\004kind\030\001 \001(\r\022\023\n\013instance_id\030\002 \001(\t\"@\n\023Upda"
+    "teObjectRequest\022\023\n\013instance_id\030\001 \001(\t\022\024\n\014"
+    "yaml_changes\030\002 \001(\t\"f\n\025ReparentObjectRequ"
+    "est\022\023\n\013instance_id\030\001 \001(\t\022\032\n\022parent_insta"
+    "nce_id\030\002 \001(\t\022\034\n\024keep_world_transform\030\003 \001"
+    "(\010\"T\n\027CreateGameObjectRequest\022\032\n\022parent_"
+    "instance_id\030\001 \001(\t\022\035\n\025preferred_instance_"
+    "id\030\002 \001(\t\"f\n\023AddComponentRequest\022\023\n\013insta"
+    "nce_id\030\001 \001(\t\022\033\n\023component_type_name\030\002 \001("
+    "\t\022\035\n\025preferred_instance_id\030\003 \001(\t\"\346\001\n\030Ani"
+    "matorParameterRequest\022\023\n\013instance_id\030\001 \001"
+    "(\t\022\014\n\004name\030\002 \001(\t\022\025\n\013float_value\030\003 \001(\002H\000\022"
+    "\023\n\tint_value\030\004 \001(\021H\000\022\024\n\nbool_value\030\005 \001(\010"
+    "H\000\022*\n\007trigger\030\006 \001(\0132\027.sailor.editor.v1.E"
+    "mptyH\000\0220\n\rreset_trigger\030\007 \001(\0132\027.sailor.e"
+    "ditor.v1.EmptyH\000B\007\n\005value\"G\n\030Instantiate"
+    "PrefabRequest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022parent"
+    "_instance_id\030\002 \001(\t\"p\n InstantiatePrefabF"
+    "romYamlRequest\022\023\n\013prefab_yaml\030\001 \001(\t\022\032\n\022p"
+    "arent_instance_id\030\002 \001(\t\022\033\n\023strict_instan"
+    "ce_ids\030\003 \001(\010\"U\n\022ViewportRayRequest\022\023\n\013vi"
+    "ewport_id\030\001 \001(\004\022\024\n\014normalized_x\030\002 \001(\002\022\024\n"
+    "\014normalized_y\030\003 \001(\002\"\240\001\n InstantiatePrefa"
+    "bInstanceRequest\022\017\n\007file_id\030\001 \001(\t\022\032\n\022par"
+    "ent_instance_id\030\002 \001(\t\022\034\n\024apply_world_pos"
+    "ition\030\003 \001(\010\0221\n\016world_position\030\004 \001(\0132\031.sa"
+    "ilor.editor.v1.Vector4\"A\n\025ViewportObject"
+    "Request\022\023\n\013viewport_id\030\001 \001(\004\022\023\n\013instance"
+    "_id\030\002 \001(\t\"9\n\021PrefabLinkRequest\022\023\n\013instan"
+    "ce_id\030\001 \001(\t\022\017\n\007file_id\030\002 \001(\t\"\251\001\n\030Viewpor"
+    "tToolStateRequest\022\023\n\013viewport_id\030\001 \001(\004\022\?"
+    "\n\toperation\030\002 \001(\0162,.sailor.editor.v1.Vie"
+    "wportTransformOperation\0227\n\005space\030\003 \001(\0162("
+    ".sailor.editor.v1.ViewportTransformSpace"
+    "\"(\n\020SelectionRequest\022\024\n\014instance_ids\030\001 \003"
+    "(\t\"%\n\025ShowMainWindowRequest\022\014\n\004show\030\001 \001("
+    "\010\"\210\001\n\034RenderPathTracedImageRequest\022\023\n\013ou"
+    "tput_path\030\001 \001(\t\022\023\n\013instance_id\030\002 \001(\t\022\016\n\006"
+    "height\030\003 \001(\r\022\031\n\021samples_per_pixel\030\004 \001(\r\022"
+    "\023\n\013max_bounces\030\005 \001(\r\"\033\n\nBoolResult\022\r\n\005va"
+    "lue\030\001 \001(\010\"\034\n\013Int32Result\022\r\n\005value\030\001 \001(\005\""
+    "\035\n\014UInt32Result\022\r\n\005value\030\001 \001(\r\"\035\n\014UInt64"
+    "Result\022\r\n\005value\030\001 \001(\004\"0\n\014StringResult\022\021\n"
+    "\thas_value\030\001 \001(\010\022\r\n\005value\030\002 \001(\t\"\"\n\020Strin"
+    "gListResult\022\016\n\006values\030\001 \003(\t\"\204\001\n\026AssetRel"
+    "oadStateResult\022\021\n\tavailable\030\001 \001(\010\022\032\n\022req"
+    "uest_generation\030\002 \001(\004\022\034\n\024completed_gener"
+    "ation\030\003 \001(\004\022\035\n\025successful_generation\030\004 \001"
+    "(\004\":\n\020InstanceIdResult\022\021\n\tsucceeded\030\001 \001("
+    "\010\022\023\n\013instance_id\030\002 \001(\t\"9\n\rVector4Result\022"
+    "(\n\005value\030\001 \001(\0132\031.sailor.editor.v1.Vector"
+    "4\"\223\001\n\027ViewportToolStateResult\022\?\n\toperati"
+    "on\030\001 \001(\0162,.sailor.editor.v1.ViewportTran"
+    "sformOperation\0227\n\005space\030\002 \001(\0162(.sailor.e"
+    "ditor.v1.ViewportTransformSpace\"\250\002\n\023Anim"
+    "atorStateResult\022\026\n\016has_controller\030\001 \001(\010\022"
+    "\033\n\023controller_revision\030\002 \001(\004\022\027\n\017active_s"
+    "tate_id\030\003 \001(\004\022\031\n\021active_state_name\030\004 \001(\t"
+    "\022\031\n\021active_state_time\030\005 \001(\002\022\025\n\rtransitio"
+    "ning\030\006 \001(\010\022\034\n\024destination_state_id\030\007 \001(\004"
+    "\022\036\n\026destination_state_name\030\010 \001(\t\022\036\n\026dest"
+    "ination_state_time\030\t \001(\002\022\030\n\020transition_a"
+    "lpha\030\n \001(\002\"5\n\007Vector4\022\t\n\001x\030\001 \001(\002\022\t\n\001y\030\002 "
+    "\001(\002\022\t\n\001z\030\003 \001(\002\022\t\n\001w\030\004 \001(\002\"6\n\026ViewportSel"
+    "ectionEvent\022\034\n\024selected_instance_id\030\001 \001("
+    "\t\"\326\003\n\026ViewportTransformEvent\022\023\n\013instance"
+    "_id\030\001 \001(\t\022\?\n\toperation\030\002 \001(\0162,.sailor.ed"
+    "itor.v1.ViewportTransformOperation\0227\n\005sp"
+    "ace\030\003 \001(\0162(.sailor.editor.v1.ViewportTra"
+    "nsformSpace\0222\n\017before_position\030\004 \001(\0132\031.s"
+    "ailor.editor.v1.Vector4\0222\n\017before_rotati"
+    "on\030\005 \001(\0132\031.sailor.editor.v1.Vector4\022/\n\014b"
+    "efore_scale\030\006 \001(\0132\031.sailor.editor.v1.Vec"
+    "tor4\0221\n\016after_position\030\007 \001(\0132\031.sailor.ed"
+    "itor.v1.Vector4\0221\n\016after_rotation\030\010 \001(\0132"
+    "\031.sailor.editor.v1.Vector4\022.\n\013after_scal"
+    "e\030\t \001(\0132\031.sailor.editor.v1.Vector4\"U\n\026Vi"
+    "ewportAssetDropEvent\022\017\n\007file_id\030\001 \001(\t\022\024\n"
+    "\014normalized_x\030\002 \001(\002\022\024\n\014normalized_y\030\003 \001("
+    "\002\"-\n\031ViewportToolShortcutEvent\022\020\n\010key_co"
+    "de\030\001 \001(\r\"\331\002\n\rViewportEvent\022\020\n\010revision\030\001"
+    " \001(\004\022!\n\031managed_mutation_revision\030\002 \001(\004\022"
+    "=\n\tselection\030\n \001(\0132(.sailor.editor.v1.Vi"
+    "ewportSelectionEventH\000\022=\n\ttransform\030\013 \001("
+    "\0132(.sailor.editor.v1.ViewportTransformEv"
+    "entH\000\022>\n\nasset_drop\030\014 \001(\0132(.sailor.edito"
+    "r.v1.ViewportAssetDropEventH\000\022D\n\rtool_sh"
+    "ortcut\030\r \001(\0132+.sailor.editor.v1.Viewport"
+    "ToolShortcutEventH\000B\t\n\007payloadJ\004\010\003\020\n\"K\n\030"
+    "ViewportEventBatchResult\022/\n\006events\030\001 \003(\013"
+    "2\037.sailor.editor.v1.ViewportEvent*\360\001\n\032Vi"
+    "ewportTransformOperation\022,\n(VIEWPORT_TRA"
+    "NSFORM_OPERATION_UNSPECIFIED\020\000\022\'\n#VIEWPO"
+    "RT_TRANSFORM_OPERATION_SELECT\020\001\022*\n&VIEWP"
+    "ORT_TRANSFORM_OPERATION_TRANSLATE\020\002\022\'\n#V"
+    "IEWPORT_TRANSFORM_OPERATION_ROTATE\020\003\022&\n\""
+    "VIEWPORT_TRANSFORM_OPERATION_SCALE\020\004*\212\001\n"
+    "\026ViewportTransformSpace\022(\n$VIEWPORT_TRAN"
+    "SFORM_SPACE_UNSPECIFIED\020\000\022\"\n\036VIEWPORT_TR"
+    "ANSFORM_SPACE_WORLD\020\001\022\"\n\036VIEWPORT_TRANSF"
+    "ORM_SPACE_LOCAL\020\002*\244\001\n\017EditorStatsMode\022!\n"
+    "\035EDITOR_STATS_MODE_UNSPECIFIED\020\000\022\032\n\026EDIT"
+    "OR_STATS_MODE_NONE\020\001\022\"\n\036EDITOR_STATS_MOD"
+    "E_RENDER_STATS\020\002\022.\n*EDITOR_STATS_MODE_RE"
+    "NDER_STATS_AND_QUERIES\020\003*\301\001\n\020EditorRende"
+    "rMode\022\"\n\036EDITOR_RENDER_MODE_UNSPECIFIED\020"
+    "\000\022\032\n\026EDITOR_RENDER_MODE_LIT\020\001\022(\n$EDITOR_"
+    "RENDER_MODE_AMBIENT_OCCLUSION\020\002\022\037\n\033EDITO"
+    "R_RENDER_MODE_CASCADES\020\003\022\"\n\036EDITOR_RENDE"
+    "R_MODE_LIGHT_TILES\020\004B\"\252\002\037SailorEditor.Pr"
+    "otocol.Generatedb\006proto3"
 };
 static ::absl::once_flag descriptor_table_editor_5fengine_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_editor_5fengine_2eproto = {
     false,
     false,
-    10340,
+    10904,
     descriptor_table_protodef_editor_5fengine_2eproto,
     "editor_engine.proto",
     &descriptor_table_editor_5fengine_2eproto_once,
     nullptr,
     0,
-    50,
+    52,
     schemas,
     file_default_instances,
     TableStruct_editor_5fengine_2eproto::offsets,
@@ -2500,6 +2589,15 @@ PROTOBUF_CONSTINIT const uint32_t EditorStatsMode_internal_data_[] = {
     262144u, 0u, };
 bool EditorStatsMode_IsValid(int value) {
   return 0 <= value && value <= 3;
+}
+const ::google::protobuf::EnumDescriptor* EditorRenderMode_descriptor() {
+  ::google::protobuf::internal::AssignDescriptors(&descriptor_table_editor_5fengine_2eproto);
+  return file_level_enum_descriptors_editor_5fengine_2eproto[3];
+}
+PROTOBUF_CONSTINIT const uint32_t EditorRenderMode_internal_data_[] = {
+    327680u, 0u, };
+bool EditorRenderMode_IsValid(int value) {
+  return 0 <= value && value <= 4;
 }
 // ===================================================================
 
@@ -3314,6 +3412,32 @@ void ProtocolRequest::set_allocated_set_editor_stats_mode(::sailor::editor::v1::
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.set_editor_stats_mode)
 }
+void ProtocolRequest::set_allocated_set_editor_render_mode(::sailor::editor::v1::EditorRenderModeRequest* set_editor_render_mode) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (set_editor_render_mode) {
+    ::google::protobuf::Arena* submessage_arena = set_editor_render_mode->GetArena();
+    if (message_arena != submessage_arena) {
+      set_editor_render_mode = ::google::protobuf::internal::GetOwnedMessage(message_arena, set_editor_render_mode, submessage_arena);
+    }
+    set_has_set_editor_render_mode();
+    _impl_.command_.set_editor_render_mode_ = set_editor_render_mode;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.set_editor_render_mode)
+}
+void ProtocolRequest::set_allocated_get_editor_render_mode(::sailor::editor::v1::Empty* get_editor_render_mode) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_command();
+  if (get_editor_render_mode) {
+    ::google::protobuf::Arena* submessage_arena = get_editor_render_mode->GetArena();
+    if (message_arena != submessage_arena) {
+      get_editor_render_mode = ::google::protobuf::internal::GetOwnedMessage(message_arena, get_editor_render_mode, submessage_arena);
+    }
+    set_has_get_editor_render_mode();
+    _impl_.command_.get_editor_render_mode_ = get_editor_render_mode;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolRequest.get_editor_render_mode)
+}
 ProtocolRequest::ProtocolRequest(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
@@ -3514,6 +3638,12 @@ ProtocolRequest::ProtocolRequest(
         break;
       case kSetEditorStatsMode:
         _impl_.command_.set_editor_stats_mode_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::EditorStatsModeRequest>(arena, *from._impl_.command_.set_editor_stats_mode_);
+        break;
+      case kSetEditorRenderMode:
+        _impl_.command_.set_editor_render_mode_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::EditorRenderModeRequest>(arena, *from._impl_.command_.set_editor_render_mode_);
+        break;
+      case kGetEditorRenderMode:
+        _impl_.command_.get_editor_render_mode_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Empty>(arena, *from._impl_.command_.get_editor_render_mode_);
         break;
   }
 
@@ -3985,6 +4115,22 @@ void ProtocolRequest::clear_command() {
       }
       break;
     }
+    case kSetEditorRenderMode: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.set_editor_render_mode_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_editor_render_mode_);
+      }
+      break;
+    }
+    case kGetEditorRenderMode: {
+      if (GetArena() == nullptr) {
+        delete _impl_.command_.get_editor_render_mode_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.get_editor_render_mode_);
+      }
+      break;
+    }
     case COMMAND_NOT_SET: {
       break;
     }
@@ -4029,16 +4175,16 @@ const ::google::protobuf::internal::ClassData* ProtocolRequest::GetClassData() c
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<1, 56, 54, 0, 9> ProtocolRequest::_table_ = {
+const ::_pbi::TcParseTable<1, 58, 56, 0, 11> ProtocolRequest::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    64, 8,  // max_field_number, fast_idx_mask
+    66, 8,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
     508,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    56,  // num_field_entries
-    54,  // num_aux_entries
+    58,  // num_field_entries
+    56,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -4054,8 +4200,8 @@ const ::_pbi::TcParseTable<1, 56, 54, 0, 9> ProtocolRequest::_table_ = {
     {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(ProtocolRequest, _impl_.protocol_version_), 63>(),
      {8, 63, 0, PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.protocol_version_)}},
   }}, {{
-    33, 0, 2,
-    0, 25, 2, 41,
+    33, 0, 3,
+    0, 25, 2, 41, 65532, 56,
     65535, 65535
   }}, {{
     // uint32 protocol_version = 1;
@@ -4226,6 +4372,12 @@ const ::_pbi::TcParseTable<1, 56, 54, 0, 9> ProtocolRequest::_table_ = {
     // .sailor.editor.v1.EditorStatsModeRequest set_editor_stats_mode = 64;
     {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_editor_stats_mode_), _Internal::kOneofCaseOffset + 0, 53,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.EditorRenderModeRequest set_editor_render_mode = 65;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.set_editor_render_mode_), _Internal::kOneofCaseOffset + 0, 54,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.Empty get_editor_render_mode = 66;
+    {PROTOBUF_FIELD_OFFSET(ProtocolRequest, _impl_.command_.get_editor_render_mode_), _Internal::kOneofCaseOffset + 0, 55,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::InitializeRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
@@ -4281,6 +4433,8 @@ const ::_pbi::TcParseTable<1, 56, 54, 0, 9> ProtocolRequest::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::FileIdRequest>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::EditorStatsModeRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::EditorRenderModeRequest>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
   }}, {{
   }},
 };
@@ -4653,6 +4807,18 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
                   stream);
               break;
             }
+            case kSetEditorRenderMode: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  65, *this_._impl_.command_.set_editor_render_mode_, this_._impl_.command_.set_editor_render_mode_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
+            case kGetEditorRenderMode: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  66, *this_._impl_.command_.get_editor_render_mode_, this_._impl_.command_.get_editor_render_mode_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -5015,6 +5181,18 @@ PROTOBUF_NOINLINE void ProtocolRequest::Clear() {
             case kSetEditorStatsMode: {
               total_size += 2 +
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.set_editor_stats_mode_);
+              break;
+            }
+            // .sailor.editor.v1.EditorRenderModeRequest set_editor_render_mode = 65;
+            case kSetEditorRenderMode: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.set_editor_render_mode_);
+              break;
+            }
+            // .sailor.editor.v1.Empty get_editor_render_mode = 66;
+            case kGetEditorRenderMode: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.command_.get_editor_render_mode_);
               break;
             }
             case COMMAND_NOT_SET: {
@@ -5537,6 +5715,24 @@ void ProtocolRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const :
         }
         break;
       }
+      case kSetEditorRenderMode: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.set_editor_render_mode_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::EditorRenderModeRequest>(arena, *from._impl_.command_.set_editor_render_mode_);
+        } else {
+          _this->_impl_.command_.set_editor_render_mode_->MergeFrom(from._internal_set_editor_render_mode());
+        }
+        break;
+      }
+      case kGetEditorRenderMode: {
+        if (oneof_needs_init) {
+          _this->_impl_.command_.get_editor_render_mode_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::Empty>(arena, *from._impl_.command_.get_editor_render_mode_);
+        } else {
+          _this->_impl_.command_.get_editor_render_mode_->MergeFrom(from._internal_get_editor_render_mode());
+        }
+        break;
+      }
       case COMMAND_NOT_SET:
         break;
     }
@@ -5745,6 +5941,19 @@ void ProtocolResponse::set_allocated_animator_state_result(::sailor::editor::v1:
   }
   // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolResponse.animator_state_result)
 }
+void ProtocolResponse::set_allocated_editor_render_mode_result(::sailor::editor::v1::EditorRenderModeResult* editor_render_mode_result) {
+  ::google::protobuf::Arena* message_arena = GetArena();
+  clear_result();
+  if (editor_render_mode_result) {
+    ::google::protobuf::Arena* submessage_arena = editor_render_mode_result->GetArena();
+    if (message_arena != submessage_arena) {
+      editor_render_mode_result = ::google::protobuf::internal::GetOwnedMessage(message_arena, editor_render_mode_result, submessage_arena);
+    }
+    set_has_editor_render_mode_result();
+    _impl_.result_.editor_render_mode_result_ = editor_render_mode_result;
+  }
+  // @@protoc_insertion_point(field_set_allocated:sailor.editor.v1.ProtocolResponse.editor_render_mode_result)
+}
 ProtocolResponse::ProtocolResponse(::google::protobuf::Arena* arena)
 #if defined(PROTOBUF_CUSTOM_VTABLE)
     : ::google::protobuf::Message(arena, _class_data_.base()) {
@@ -5823,6 +6032,9 @@ ProtocolResponse::ProtocolResponse(
         break;
       case kAnimatorStateResult:
         _impl_.result_.animator_state_result_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::AnimatorStateResult>(arena, *from._impl_.result_.animator_state_result_);
+        break;
+      case kEditorRenderModeResult:
+        _impl_.result_.editor_render_mode_result_ = ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::EditorRenderModeResult>(arena, *from._impl_.result_.editor_render_mode_result_);
         break;
   }
 
@@ -5968,6 +6180,14 @@ void ProtocolResponse::clear_result() {
       }
       break;
     }
+    case kEditorRenderModeResult: {
+      if (GetArena() == nullptr) {
+        delete _impl_.result_.editor_render_mode_result_;
+      } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+        ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.result_.editor_render_mode_result_);
+      }
+      break;
+    }
     case RESULT_NOT_SET: {
       break;
     }
@@ -6012,16 +6232,16 @@ const ::google::protobuf::internal::ClassData* ProtocolResponse::GetClassData() 
   return _class_data_.base();
 }
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<3, 18, 13, 63, 2> ProtocolResponse::_table_ = {
+const ::_pbi::TcParseTable<3, 19, 14, 63, 2> ProtocolResponse::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
-    22, 56,  // max_field_number, fast_idx_mask
+    23, 56,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4290773472,  // skipmap
+    4286579168,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    18,  // num_field_entries
-    13,  // num_aux_entries
+    19,  // num_field_entries
+    14,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     _class_data_.base(),
     nullptr,  // post_loop_handler
@@ -6105,6 +6325,9 @@ const ::_pbi::TcParseTable<3, 18, 13, 63, 2> ProtocolResponse::_table_ = {
     // .sailor.editor.v1.AnimatorStateResult animator_state_result = 22;
     {PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.result_.animator_state_result_), _Internal::kOneofCaseOffset + 0, 12,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
+    // .sailor.editor.v1.EditorRenderModeResult editor_render_mode_result = 23;
+    {PROTOBUF_FIELD_OFFSET(ProtocolResponse, _impl_.result_.editor_render_mode_result_), _Internal::kOneofCaseOffset + 0, 13,
+    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Empty>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::BoolResult>()},
@@ -6119,6 +6342,7 @@ const ::_pbi::TcParseTable<3, 18, 13, 63, 2> ProtocolResponse::_table_ = {
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::Vector4Result>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::ViewportToolStateResult>()},
     {::_pbi::TcParser::GetTable<::sailor::editor::v1::AnimatorStateResult>()},
+    {::_pbi::TcParser::GetTable<::sailor::editor::v1::EditorRenderModeResult>()},
   }}, {{
     "\41\0\0\0\5\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0"
     "sailor.editor.v1.ProtocolResponse"
@@ -6271,6 +6495,12 @@ PROTOBUF_NOINLINE void ProtocolResponse::Clear() {
                   stream);
               break;
             }
+            case kEditorRenderModeResult: {
+              target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
+                  23, *this_._impl_.result_.editor_render_mode_result_, this_._impl_.result_.editor_render_mode_result_->GetCachedSize(), target,
+                  stream);
+              break;
+            }
             default:
               break;
           }
@@ -6400,6 +6630,12 @@ PROTOBUF_NOINLINE void ProtocolResponse::Clear() {
             case kAnimatorStateResult: {
               total_size += 2 +
                             ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.result_.animator_state_result_);
+              break;
+            }
+            // .sailor.editor.v1.EditorRenderModeResult editor_render_mode_result = 23;
+            case kEditorRenderModeResult: {
+              total_size += 2 +
+                            ::google::protobuf::internal::WireFormatLite::MessageSize(*this_._impl_.result_.editor_render_mode_result_);
               break;
             }
             case RESULT_NOT_SET: {
@@ -6559,6 +6795,15 @@ void ProtocolResponse::MergeImpl(::google::protobuf::MessageLite& to_msg, const 
               ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::AnimatorStateResult>(arena, *from._impl_.result_.animator_state_result_);
         } else {
           _this->_impl_.result_.animator_state_result_->MergeFrom(from._internal_animator_state_result());
+        }
+        break;
+      }
+      case kEditorRenderModeResult: {
+        if (oneof_needs_init) {
+          _this->_impl_.result_.editor_render_mode_result_ =
+              ::google::protobuf::Message::CopyConstruct<::sailor::editor::v1::EditorRenderModeResult>(arena, *from._impl_.result_.editor_render_mode_result_);
+        } else {
+          _this->_impl_.result_.editor_render_mode_result_->MergeFrom(from._internal_editor_render_mode_result());
         }
         break;
       }
@@ -9082,6 +9327,420 @@ void EditorStatsModeRequest::InternalSwap(EditorStatsModeRequest* PROTOBUF_RESTR
 }
 
 ::google::protobuf::Metadata EditorStatsModeRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class EditorRenderModeRequest::_Internal {
+ public:
+};
+
+EditorRenderModeRequest::EditorRenderModeRequest(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.EditorRenderModeRequest)
+}
+EditorRenderModeRequest::EditorRenderModeRequest(
+    ::google::protobuf::Arena* arena, const EditorRenderModeRequest& from)
+    : EditorRenderModeRequest(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE EditorRenderModeRequest::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void EditorRenderModeRequest::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.mode_ = {};
+}
+EditorRenderModeRequest::~EditorRenderModeRequest() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.EditorRenderModeRequest)
+  SharedDtor(*this);
+}
+inline void EditorRenderModeRequest::SharedDtor(MessageLite& self) {
+  EditorRenderModeRequest& this_ = static_cast<EditorRenderModeRequest&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* EditorRenderModeRequest::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) EditorRenderModeRequest(arena);
+}
+constexpr auto EditorRenderModeRequest::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(EditorRenderModeRequest),
+                                            alignof(EditorRenderModeRequest));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull EditorRenderModeRequest::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_EditorRenderModeRequest_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &EditorRenderModeRequest::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<EditorRenderModeRequest>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &EditorRenderModeRequest::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<EditorRenderModeRequest>(), &EditorRenderModeRequest::ByteSizeLong,
+            &EditorRenderModeRequest::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(EditorRenderModeRequest, _impl_._cached_size_),
+        false,
+    },
+    &EditorRenderModeRequest::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* EditorRenderModeRequest::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> EditorRenderModeRequest::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::EditorRenderModeRequest>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .sailor.editor.v1.EditorRenderMode mode = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(EditorRenderModeRequest, _impl_.mode_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(EditorRenderModeRequest, _impl_.mode_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .sailor.editor.v1.EditorRenderMode mode = 1;
+    {PROTOBUF_FIELD_OFFSET(EditorRenderModeRequest, _impl_.mode_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void EditorRenderModeRequest::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.EditorRenderModeRequest)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.mode_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* EditorRenderModeRequest::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const EditorRenderModeRequest& this_ = static_cast<const EditorRenderModeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* EditorRenderModeRequest::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const EditorRenderModeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.EditorRenderModeRequest)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .sailor.editor.v1.EditorRenderMode mode = 1;
+          if (this_._internal_mode() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_mode(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.EditorRenderModeRequest)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t EditorRenderModeRequest::ByteSizeLong(const MessageLite& base) {
+          const EditorRenderModeRequest& this_ = static_cast<const EditorRenderModeRequest&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t EditorRenderModeRequest::ByteSizeLong() const {
+          const EditorRenderModeRequest& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.EditorRenderModeRequest)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .sailor.editor.v1.EditorRenderMode mode = 1;
+            if (this_._internal_mode() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_mode());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void EditorRenderModeRequest::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<EditorRenderModeRequest*>(&to_msg);
+  auto& from = static_cast<const EditorRenderModeRequest&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.EditorRenderModeRequest)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_mode() != 0) {
+    _this->_impl_.mode_ = from._impl_.mode_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void EditorRenderModeRequest::CopyFrom(const EditorRenderModeRequest& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.EditorRenderModeRequest)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void EditorRenderModeRequest::InternalSwap(EditorRenderModeRequest* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.mode_, other->_impl_.mode_);
+}
+
+::google::protobuf::Metadata EditorRenderModeRequest::GetMetadata() const {
+  return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
+}
+// ===================================================================
+
+class EditorRenderModeResult::_Internal {
+ public:
+};
+
+EditorRenderModeResult::EditorRenderModeResult(::google::protobuf::Arena* arena)
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+    : ::google::protobuf::Message(arena, _class_data_.base()) {
+#else   // PROTOBUF_CUSTOM_VTABLE
+    : ::google::protobuf::Message(arena) {
+#endif  // PROTOBUF_CUSTOM_VTABLE
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:sailor.editor.v1.EditorRenderModeResult)
+}
+EditorRenderModeResult::EditorRenderModeResult(
+    ::google::protobuf::Arena* arena, const EditorRenderModeResult& from)
+    : EditorRenderModeResult(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE EditorRenderModeResult::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void EditorRenderModeResult::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.mode_ = {};
+}
+EditorRenderModeResult::~EditorRenderModeResult() {
+  // @@protoc_insertion_point(destructor:sailor.editor.v1.EditorRenderModeResult)
+  SharedDtor(*this);
+}
+inline void EditorRenderModeResult::SharedDtor(MessageLite& self) {
+  EditorRenderModeResult& this_ = static_cast<EditorRenderModeResult&>(self);
+  this_._internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  ABSL_DCHECK(this_.GetArena() == nullptr);
+  this_._impl_.~Impl_();
+}
+
+inline void* EditorRenderModeResult::PlacementNew_(const void*, void* mem,
+                                        ::google::protobuf::Arena* arena) {
+  return ::new (mem) EditorRenderModeResult(arena);
+}
+constexpr auto EditorRenderModeResult::InternalNewImpl_() {
+  return ::google::protobuf::internal::MessageCreator::ZeroInit(sizeof(EditorRenderModeResult),
+                                            alignof(EditorRenderModeResult));
+}
+PROTOBUF_CONSTINIT
+PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::google::protobuf::internal::ClassDataFull EditorRenderModeResult::_class_data_ = {
+    ::google::protobuf::internal::ClassData{
+        &_EditorRenderModeResult_default_instance_._instance,
+        &_table_.header,
+        nullptr,  // OnDemandRegisterArenaDtor
+        nullptr,  // IsInitialized
+        &EditorRenderModeResult::MergeImpl,
+        ::google::protobuf::Message::GetNewImpl<EditorRenderModeResult>(),
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        &EditorRenderModeResult::SharedDtor,
+        ::google::protobuf::Message::GetClearImpl<EditorRenderModeResult>(), &EditorRenderModeResult::ByteSizeLong,
+            &EditorRenderModeResult::_InternalSerialize,
+#endif  // PROTOBUF_CUSTOM_VTABLE
+        PROTOBUF_FIELD_OFFSET(EditorRenderModeResult, _impl_._cached_size_),
+        false,
+    },
+    &EditorRenderModeResult::kDescriptorMethods,
+    &descriptor_table_editor_5fengine_2eproto,
+    nullptr,  // tracker
+};
+const ::google::protobuf::internal::ClassData* EditorRenderModeResult::GetClassData() const {
+  ::google::protobuf::internal::PrefetchToLocalCache(&_class_data_);
+  ::google::protobuf::internal::PrefetchToLocalCache(_class_data_.tc_table);
+  return _class_data_.base();
+}
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> EditorRenderModeResult::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    _class_data_.base(),
+    nullptr,  // post_loop_handler
+    ::_pbi::TcParser::GenericFallback,  // fallback
+    #ifdef PROTOBUF_PREFETCH_PARSE_TABLE
+    ::_pbi::TcParser::GetTable<::sailor::editor::v1::EditorRenderModeResult>(),  // to_prefetch
+    #endif  // PROTOBUF_PREFETCH_PARSE_TABLE
+  }, {{
+    // .sailor.editor.v1.EditorRenderMode mode = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<::uint32_t, offsetof(EditorRenderModeResult, _impl_.mode_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(EditorRenderModeResult, _impl_.mode_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // .sailor.editor.v1.EditorRenderMode mode = 1;
+    {PROTOBUF_FIELD_OFFSET(EditorRenderModeResult, _impl_.mode_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kOpenEnum)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+PROTOBUF_NOINLINE void EditorRenderModeResult::Clear() {
+// @@protoc_insertion_point(message_clear_start:sailor.editor.v1.EditorRenderModeResult)
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.mode_ = 0;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::uint8_t* EditorRenderModeResult::_InternalSerialize(
+            const MessageLite& base, ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) {
+          const EditorRenderModeResult& this_ = static_cast<const EditorRenderModeResult&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::uint8_t* EditorRenderModeResult::_InternalSerialize(
+            ::uint8_t* target,
+            ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+          const EditorRenderModeResult& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(serialize_to_array_start:sailor.editor.v1.EditorRenderModeResult)
+          ::uint32_t cached_has_bits = 0;
+          (void)cached_has_bits;
+
+          // .sailor.editor.v1.EditorRenderMode mode = 1;
+          if (this_._internal_mode() != 0) {
+            target = stream->EnsureSpace(target);
+            target = ::_pbi::WireFormatLite::WriteEnumToArray(
+                1, this_._internal_mode(), target);
+          }
+
+          if (PROTOBUF_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
+            target =
+                ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+                    this_._internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+          }
+          // @@protoc_insertion_point(serialize_to_array_end:sailor.editor.v1.EditorRenderModeResult)
+          return target;
+        }
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+        ::size_t EditorRenderModeResult::ByteSizeLong(const MessageLite& base) {
+          const EditorRenderModeResult& this_ = static_cast<const EditorRenderModeResult&>(base);
+#else   // PROTOBUF_CUSTOM_VTABLE
+        ::size_t EditorRenderModeResult::ByteSizeLong() const {
+          const EditorRenderModeResult& this_ = *this;
+#endif  // PROTOBUF_CUSTOM_VTABLE
+          // @@protoc_insertion_point(message_byte_size_start:sailor.editor.v1.EditorRenderModeResult)
+          ::size_t total_size = 0;
+
+          ::uint32_t cached_has_bits = 0;
+          // Prevent compiler warnings about cached_has_bits being unused
+          (void)cached_has_bits;
+
+           {
+            // .sailor.editor.v1.EditorRenderMode mode = 1;
+            if (this_._internal_mode() != 0) {
+              total_size += 1 +
+                            ::_pbi::WireFormatLite::EnumSize(this_._internal_mode());
+            }
+          }
+          return this_.MaybeComputeUnknownFieldsSize(total_size,
+                                                     &this_._impl_._cached_size_);
+        }
+
+void EditorRenderModeResult::MergeImpl(::google::protobuf::MessageLite& to_msg, const ::google::protobuf::MessageLite& from_msg) {
+  auto* const _this = static_cast<EditorRenderModeResult*>(&to_msg);
+  auto& from = static_cast<const EditorRenderModeResult&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:sailor.editor.v1.EditorRenderModeResult)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_mode() != 0) {
+    _this->_impl_.mode_ = from._impl_.mode_;
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void EditorRenderModeResult::CopyFrom(const EditorRenderModeResult& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:sailor.editor.v1.EditorRenderModeResult)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+
+void EditorRenderModeResult::InternalSwap(EditorRenderModeResult* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+  swap(_impl_.mode_, other->_impl_.mode_);
+}
+
+::google::protobuf::Metadata EditorRenderModeResult::GetMetadata() const {
   return ::google::protobuf::Message::GetMetadataImpl(GetClassData()->full());
 }
 // ===================================================================

--- a/Runtime/Protocol/Generated/editor_engine.pb.h
+++ b/Runtime/Protocol/Generated/editor_engine.pb.h
@@ -80,6 +80,12 @@ extern CreateGameObjectRequestDefaultTypeInternal _CreateGameObjectRequest_defau
 class CreateModelInstanceRequest;
 struct CreateModelInstanceRequestDefaultTypeInternal;
 extern CreateModelInstanceRequestDefaultTypeInternal _CreateModelInstanceRequest_default_instance_;
+class EditorRenderModeRequest;
+struct EditorRenderModeRequestDefaultTypeInternal;
+extern EditorRenderModeRequestDefaultTypeInternal _EditorRenderModeRequest_default_instance_;
+class EditorRenderModeResult;
+struct EditorRenderModeResultDefaultTypeInternal;
+extern EditorRenderModeResultDefaultTypeInternal _EditorRenderModeResult_default_instance_;
 class EditorSimulationRequest;
 struct EditorSimulationRequestDefaultTypeInternal;
 extern EditorSimulationRequestDefaultTypeInternal _EditorSimulationRequest_default_instance_;
@@ -322,6 +328,42 @@ inline bool EditorStatsMode_Parse(absl::string_view name, EditorStatsMode* value
   return ::google::protobuf::internal::ParseNamedEnum<EditorStatsMode>(
       EditorStatsMode_descriptor(), name, value);
 }
+enum EditorRenderMode : int {
+  EDITOR_RENDER_MODE_UNSPECIFIED = 0,
+  EDITOR_RENDER_MODE_LIT = 1,
+  EDITOR_RENDER_MODE_AMBIENT_OCCLUSION = 2,
+  EDITOR_RENDER_MODE_CASCADES = 3,
+  EDITOR_RENDER_MODE_LIGHT_TILES = 4,
+  EditorRenderMode_INT_MIN_SENTINEL_DO_NOT_USE_ =
+      std::numeric_limits<::int32_t>::min(),
+  EditorRenderMode_INT_MAX_SENTINEL_DO_NOT_USE_ =
+      std::numeric_limits<::int32_t>::max(),
+};
+
+bool EditorRenderMode_IsValid(int value);
+extern const uint32_t EditorRenderMode_internal_data_[];
+constexpr EditorRenderMode EditorRenderMode_MIN = static_cast<EditorRenderMode>(0);
+constexpr EditorRenderMode EditorRenderMode_MAX = static_cast<EditorRenderMode>(4);
+constexpr int EditorRenderMode_ARRAYSIZE = 4 + 1;
+const ::google::protobuf::EnumDescriptor*
+EditorRenderMode_descriptor();
+template <typename T>
+const std::string& EditorRenderMode_Name(T value) {
+  static_assert(std::is_same<T, EditorRenderMode>::value ||
+                    std::is_integral<T>::value,
+                "Incorrect type passed to EditorRenderMode_Name().");
+  return EditorRenderMode_Name(static_cast<EditorRenderMode>(value));
+}
+template <>
+inline const std::string& EditorRenderMode_Name(EditorRenderMode value) {
+  return ::google::protobuf::internal::NameOfDenseEnum<EditorRenderMode_descriptor,
+                                                 0, 4>(
+      static_cast<int>(value));
+}
+inline bool EditorRenderMode_Parse(absl::string_view name, EditorRenderMode* value) {
+  return ::google::protobuf::internal::ParseNamedEnum<EditorRenderMode>(
+      EditorRenderMode_descriptor(), name, value);
+}
 
 // ===================================================================
 
@@ -387,7 +429,7 @@ class ViewportToolStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateResult*>(
         &_ViewportToolStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 41;
+  static constexpr int kIndexInFileMessages = 43;
   friend void swap(ViewportToolStateResult& a, ViewportToolStateResult& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateResult* other) {
     if (other == this) return;
@@ -589,7 +631,7 @@ class ViewportToolStateRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolStateRequest*>(
         &_ViewportToolStateRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 28;
+  static constexpr int kIndexInFileMessages = 30;
   friend void swap(ViewportToolStateRequest& a, ViewportToolStateRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportToolStateRequest* other) {
     if (other == this) return;
@@ -803,7 +845,7 @@ class ViewportToolShortcutEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportToolShortcutEvent*>(
         &_ViewportToolShortcutEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 47;
+  static constexpr int kIndexInFileMessages = 49;
   friend void swap(ViewportToolShortcutEvent& a, ViewportToolShortcutEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportToolShortcutEvent* other) {
     if (other == this) return;
@@ -993,7 +1035,7 @@ class ViewportSelectionEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportSelectionEvent*>(
         &_ViewportSelectionEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 44;
+  static constexpr int kIndexInFileMessages = 46;
   friend void swap(ViewportSelectionEvent& a, ViewportSelectionEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportSelectionEvent* other) {
     if (other == this) return;
@@ -1415,7 +1457,7 @@ class ViewportRayRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportRayRequest*>(
         &_ViewportRayRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 24;
+  static constexpr int kIndexInFileMessages = 26;
   friend void swap(ViewportRayRequest& a, ViewportRayRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportRayRequest* other) {
     if (other == this) return;
@@ -1629,7 +1671,7 @@ class ViewportObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportObjectRequest*>(
         &_ViewportObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 26;
+  static constexpr int kIndexInFileMessages = 28;
   friend void swap(ViewportObjectRequest& a, ViewportObjectRequest& b) { a.Swap(&b); }
   inline void Swap(ViewportObjectRequest* other) {
     if (other == this) return;
@@ -2027,7 +2069,7 @@ class ViewportAssetDropEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportAssetDropEvent*>(
         &_ViewportAssetDropEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 46;
+  static constexpr int kIndexInFileMessages = 48;
   friend void swap(ViewportAssetDropEvent& a, ViewportAssetDropEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportAssetDropEvent* other) {
     if (other == this) return;
@@ -2247,7 +2289,7 @@ class Vector4 final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4*>(
         &_Vector4_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 43;
+  static constexpr int kIndexInFileMessages = 45;
   friend void swap(Vector4& a, Vector4& b) { a.Swap(&b); }
   inline void Swap(Vector4* other) {
     if (other == this) return;
@@ -2473,7 +2515,7 @@ class UpdateObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const UpdateObjectRequest*>(
         &_UpdateObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 17;
+  static constexpr int kIndexInFileMessages = 19;
   friend void swap(UpdateObjectRequest& a, UpdateObjectRequest& b) { a.Swap(&b); }
   inline void Swap(UpdateObjectRequest* other) {
     if (other == this) return;
@@ -2687,7 +2729,7 @@ class UInt64Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt64Result*>(
         &_UInt64Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 35;
+  static constexpr int kIndexInFileMessages = 37;
   friend void swap(UInt64Result& a, UInt64Result& b) { a.Swap(&b); }
   inline void Swap(UInt64Result* other) {
     if (other == this) return;
@@ -2877,7 +2919,7 @@ class UInt32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const UInt32Result*>(
         &_UInt32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 34;
+  static constexpr int kIndexInFileMessages = 36;
   friend void swap(UInt32Result& a, UInt32Result& b) { a.Swap(&b); }
   inline void Swap(UInt32Result* other) {
     if (other == this) return;
@@ -3067,7 +3109,7 @@ class StringResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringResult*>(
         &_StringResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 36;
+  static constexpr int kIndexInFileMessages = 38;
   friend void swap(StringResult& a, StringResult& b) { a.Swap(&b); }
   inline void Swap(StringResult* other) {
     if (other == this) return;
@@ -3275,7 +3317,7 @@ class StringListResult final : public ::google::protobuf::Message
     return reinterpret_cast<const StringListResult*>(
         &_StringListResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 37;
+  static constexpr int kIndexInFileMessages = 39;
   friend void swap(StringListResult& a, StringListResult& b) { a.Swap(&b); }
   inline void Swap(StringListResult* other) {
     if (other == this) return;
@@ -3679,7 +3721,7 @@ class ShowMainWindowRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ShowMainWindowRequest*>(
         &_ShowMainWindowRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 30;
+  static constexpr int kIndexInFileMessages = 32;
   friend void swap(ShowMainWindowRequest& a, ShowMainWindowRequest& b) { a.Swap(&b); }
   inline void Swap(ShowMainWindowRequest* other) {
     if (other == this) return;
@@ -3869,7 +3911,7 @@ class SelectionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const SelectionRequest*>(
         &_SelectionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 29;
+  static constexpr int kIndexInFileMessages = 31;
   friend void swap(SelectionRequest& a, SelectionRequest& b) { a.Swap(&b); }
   inline void Swap(SelectionRequest* other) {
     if (other == this) return;
@@ -4071,7 +4113,7 @@ class ReparentObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ReparentObjectRequest*>(
         &_ReparentObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 18;
+  static constexpr int kIndexInFileMessages = 20;
   friend void swap(ReparentObjectRequest& a, ReparentObjectRequest& b) { a.Swap(&b); }
   inline void Swap(ReparentObjectRequest* other) {
     if (other == this) return;
@@ -4297,7 +4339,7 @@ class RenderPathTracedImageRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RenderPathTracedImageRequest*>(
         &_RenderPathTracedImageRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 31;
+  static constexpr int kIndexInFileMessages = 33;
   friend void swap(RenderPathTracedImageRequest& a, RenderPathTracedImageRequest& b) { a.Swap(&b); }
   inline void Swap(RenderPathTracedImageRequest* other) {
     if (other == this) return;
@@ -4547,7 +4589,7 @@ class RemoteViewportRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportRequest*>(
         &_RemoteViewportRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 13;
+  static constexpr int kIndexInFileMessages = 15;
   friend void swap(RemoteViewportRequest& a, RemoteViewportRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportRequest* other) {
     if (other == this) return;
@@ -4809,7 +4851,7 @@ class RemoteViewportInputRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportInputRequest*>(
         &_RemoteViewportInputRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 15;
+  static constexpr int kIndexInFileMessages = 17;
   friend void swap(RemoteViewportInputRequest& a, RemoteViewportInputRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportInputRequest* other) {
     if (other == this) return;
@@ -5131,7 +5173,7 @@ class RemoteViewportHostRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const RemoteViewportHostRequest*>(
         &_RemoteViewportHostRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 14;
+  static constexpr int kIndexInFileMessages = 16;
   friend void swap(RemoteViewportHostRequest& a, RemoteViewportHostRequest& b) { a.Swap(&b); }
   inline void Swap(RemoteViewportHostRequest* other) {
     if (other == this) return;
@@ -5345,7 +5387,7 @@ class PrefabLinkRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const PrefabLinkRequest*>(
         &_PrefabLinkRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 27;
+  static constexpr int kIndexInFileMessages = 29;
   friend void swap(PrefabLinkRequest& a, PrefabLinkRequest& b) { a.Swap(&b); }
   inline void Swap(PrefabLinkRequest* other) {
     if (other == this) return;
@@ -5559,7 +5601,7 @@ class ManagedMutationRevisionRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const ManagedMutationRevisionRequest*>(
         &_ManagedMutationRevisionRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 16;
+  static constexpr int kIndexInFileMessages = 18;
   friend void swap(ManagedMutationRevisionRequest& a, ManagedMutationRevisionRequest& b) { a.Swap(&b); }
   inline void Swap(ManagedMutationRevisionRequest* other) {
     if (other == this) return;
@@ -5767,7 +5809,7 @@ class Int32Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Int32Result*>(
         &_Int32Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 33;
+  static constexpr int kIndexInFileMessages = 35;
   friend void swap(Int32Result& a, Int32Result& b) { a.Swap(&b); }
   inline void Swap(Int32Result* other) {
     if (other == this) return;
@@ -5957,7 +5999,7 @@ class InstantiatePrefabRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const InstantiatePrefabRequest*>(
         &_InstantiatePrefabRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 22;
+  static constexpr int kIndexInFileMessages = 24;
   friend void swap(InstantiatePrefabRequest& a, InstantiatePrefabRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabRequest* other) {
     if (other == this) return;
@@ -6171,7 +6213,7 @@ class InstantiatePrefabFromYamlRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabFromYamlRequest*>(
         &_InstantiatePrefabFromYamlRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 23;
+  static constexpr int kIndexInFileMessages = 25;
   friend void swap(InstantiatePrefabFromYamlRequest& a, InstantiatePrefabFromYamlRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabFromYamlRequest* other) {
     if (other == this) return;
@@ -6397,7 +6439,7 @@ class InstanceIdResult final : public ::google::protobuf::Message
     return reinterpret_cast<const InstanceIdResult*>(
         &_InstanceIdResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 39;
+  static constexpr int kIndexInFileMessages = 41;
   friend void swap(InstanceIdResult& a, InstanceIdResult& b) { a.Swap(&b); }
   inline void Swap(InstanceIdResult* other) {
     if (other == this) return;
@@ -7665,6 +7707,386 @@ class EditorSimulationRequest final : public ::google::protobuf::Message
 };
 // -------------------------------------------------------------------
 
+class EditorRenderModeResult final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.EditorRenderModeResult) */ {
+ public:
+  inline EditorRenderModeResult() : EditorRenderModeResult(nullptr) {}
+  ~EditorRenderModeResult() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(EditorRenderModeResult* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(EditorRenderModeResult));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR EditorRenderModeResult(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline EditorRenderModeResult(const EditorRenderModeResult& from) : EditorRenderModeResult(nullptr, from) {}
+  inline EditorRenderModeResult(EditorRenderModeResult&& from) noexcept
+      : EditorRenderModeResult(nullptr, std::move(from)) {}
+  inline EditorRenderModeResult& operator=(const EditorRenderModeResult& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline EditorRenderModeResult& operator=(EditorRenderModeResult&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const EditorRenderModeResult& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const EditorRenderModeResult* internal_default_instance() {
+    return reinterpret_cast<const EditorRenderModeResult*>(
+        &_EditorRenderModeResult_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 14;
+  friend void swap(EditorRenderModeResult& a, EditorRenderModeResult& b) { a.Swap(&b); }
+  inline void Swap(EditorRenderModeResult* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(EditorRenderModeResult* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  EditorRenderModeResult* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<EditorRenderModeResult>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const EditorRenderModeResult& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const EditorRenderModeResult& from) { EditorRenderModeResult::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(EditorRenderModeResult* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.EditorRenderModeResult"; }
+
+ protected:
+  explicit EditorRenderModeResult(::google::protobuf::Arena* arena);
+  EditorRenderModeResult(::google::protobuf::Arena* arena, const EditorRenderModeResult& from);
+  EditorRenderModeResult(::google::protobuf::Arena* arena, EditorRenderModeResult&& from) noexcept
+      : EditorRenderModeResult(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kModeFieldNumber = 1,
+  };
+  // .sailor.editor.v1.EditorRenderMode mode = 1;
+  void clear_mode() ;
+  ::sailor::editor::v1::EditorRenderMode mode() const;
+  void set_mode(::sailor::editor::v1::EditorRenderMode value);
+
+  private:
+  ::sailor::editor::v1::EditorRenderMode _internal_mode() const;
+  void _internal_set_mode(::sailor::editor::v1::EditorRenderMode value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.EditorRenderModeResult)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const EditorRenderModeResult& from_msg);
+    int mode_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
+class EditorRenderModeRequest final : public ::google::protobuf::Message
+/* @@protoc_insertion_point(class_definition:sailor.editor.v1.EditorRenderModeRequest) */ {
+ public:
+  inline EditorRenderModeRequest() : EditorRenderModeRequest(nullptr) {}
+  ~EditorRenderModeRequest() PROTOBUF_FINAL;
+
+#if defined(PROTOBUF_CUSTOM_VTABLE)
+  void operator delete(EditorRenderModeRequest* msg, std::destroying_delete_t) {
+    SharedDtor(*msg);
+    ::google::protobuf::internal::SizedDelete(msg, sizeof(EditorRenderModeRequest));
+  }
+#endif
+
+  template <typename = void>
+  explicit PROTOBUF_CONSTEXPR EditorRenderModeRequest(
+      ::google::protobuf::internal::ConstantInitialized);
+
+  inline EditorRenderModeRequest(const EditorRenderModeRequest& from) : EditorRenderModeRequest(nullptr, from) {}
+  inline EditorRenderModeRequest(EditorRenderModeRequest&& from) noexcept
+      : EditorRenderModeRequest(nullptr, std::move(from)) {}
+  inline EditorRenderModeRequest& operator=(const EditorRenderModeRequest& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline EditorRenderModeRequest& operator=(EditorRenderModeRequest&& from) noexcept {
+    if (this == &from) return *this;
+    if (::google::protobuf::internal::CanMoveWithInternalSwap(GetArena(), from.GetArena())) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const EditorRenderModeRequest& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const EditorRenderModeRequest* internal_default_instance() {
+    return reinterpret_cast<const EditorRenderModeRequest*>(
+        &_EditorRenderModeRequest_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages = 13;
+  friend void swap(EditorRenderModeRequest& a, EditorRenderModeRequest& b) { a.Swap(&b); }
+  inline void Swap(EditorRenderModeRequest* other) {
+    if (other == this) return;
+    if (::google::protobuf::internal::CanUseInternalSwap(GetArena(), other->GetArena())) {
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(EditorRenderModeRequest* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  EditorRenderModeRequest* New(::google::protobuf::Arena* arena = nullptr) const {
+    return ::google::protobuf::Message::DefaultConstruct<EditorRenderModeRequest>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const EditorRenderModeRequest& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom(const EditorRenderModeRequest& from) { EditorRenderModeRequest::MergeImpl(*this, from); }
+
+  private:
+  static void MergeImpl(
+      ::google::protobuf::MessageLite& to_msg,
+      const ::google::protobuf::MessageLite& from_msg);
+
+  public:
+  bool IsInitialized() const {
+    return true;
+  }
+  ABSL_ATTRIBUTE_REINITIALIZES void Clear() PROTOBUF_FINAL;
+  #if defined(PROTOBUF_CUSTOM_VTABLE)
+  private:
+  static ::size_t ByteSizeLong(const ::google::protobuf::MessageLite& msg);
+  static ::uint8_t* _InternalSerialize(
+      const MessageLite& msg, ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream);
+
+  public:
+  ::size_t ByteSizeLong() const { return ByteSizeLong(*this); }
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+    return _InternalSerialize(*this, target, stream);
+  }
+  #else   // PROTOBUF_CUSTOM_VTABLE
+  ::size_t ByteSizeLong() const final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target,
+      ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  #endif  // PROTOBUF_CUSTOM_VTABLE
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  void SharedCtor(::google::protobuf::Arena* arena);
+  static void SharedDtor(MessageLite& self);
+  void InternalSwap(EditorRenderModeRequest* other);
+ private:
+  template <typename T>
+  friend ::absl::string_view(
+      ::google::protobuf::internal::GetAnyMessageName)();
+  static ::absl::string_view FullMessageName() { return "sailor.editor.v1.EditorRenderModeRequest"; }
+
+ protected:
+  explicit EditorRenderModeRequest(::google::protobuf::Arena* arena);
+  EditorRenderModeRequest(::google::protobuf::Arena* arena, const EditorRenderModeRequest& from);
+  EditorRenderModeRequest(::google::protobuf::Arena* arena, EditorRenderModeRequest&& from) noexcept
+      : EditorRenderModeRequest(arena) {
+    *this = ::std::move(from);
+  }
+  const ::google::protobuf::internal::ClassData* GetClassData() const PROTOBUF_FINAL;
+  static void* PlacementNew_(const void*, void* mem,
+                             ::google::protobuf::Arena* arena);
+  static constexpr auto InternalNewImpl_();
+  static const ::google::protobuf::internal::ClassDataFull _class_data_;
+
+ public:
+  ::google::protobuf::Metadata GetMetadata() const;
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+  enum : int {
+    kModeFieldNumber = 1,
+  };
+  // .sailor.editor.v1.EditorRenderMode mode = 1;
+  void clear_mode() ;
+  ::sailor::editor::v1::EditorRenderMode mode() const;
+  void set_mode(::sailor::editor::v1::EditorRenderMode value);
+
+  private:
+  ::sailor::editor::v1::EditorRenderMode _internal_mode() const;
+  void _internal_set_mode(::sailor::editor::v1::EditorRenderMode value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:sailor.editor.v1.EditorRenderModeRequest)
+ private:
+  class _Internal;
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+    inline explicit constexpr Impl_(
+        ::google::protobuf::internal::ConstantInitialized) noexcept;
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena);
+    inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                          ::google::protobuf::Arena* arena, const Impl_& from,
+                          const EditorRenderModeRequest& from_msg);
+    int mode_;
+    ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_editor_5fengine_2eproto;
+};
+// -------------------------------------------------------------------
+
 class CreateGameObjectRequest final : public ::google::protobuf::Message
 /* @@protoc_insertion_point(class_definition:sailor.editor.v1.CreateGameObjectRequest) */ {
  public:
@@ -7724,7 +8146,7 @@ class CreateGameObjectRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const CreateGameObjectRequest*>(
         &_CreateGameObjectRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 19;
+  static constexpr int kIndexInFileMessages = 21;
   friend void swap(CreateGameObjectRequest& a, CreateGameObjectRequest& b) { a.Swap(&b); }
   inline void Swap(CreateGameObjectRequest* other) {
     if (other == this) return;
@@ -8128,7 +8550,7 @@ class BoolResult final : public ::google::protobuf::Message
     return reinterpret_cast<const BoolResult*>(
         &_BoolResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 32;
+  static constexpr int kIndexInFileMessages = 34;
   friend void swap(BoolResult& a, BoolResult& b) { a.Swap(&b); }
   inline void Swap(BoolResult* other) {
     if (other == this) return;
@@ -8318,7 +8740,7 @@ class AssetReloadStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const AssetReloadStateResult*>(
         &_AssetReloadStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 38;
+  static constexpr int kIndexInFileMessages = 40;
   friend void swap(AssetReloadStateResult& a, AssetReloadStateResult& b) { a.Swap(&b); }
   inline void Swap(AssetReloadStateResult* other) {
     if (other == this) return;
@@ -8544,7 +8966,7 @@ class AnimatorStateResult final : public ::google::protobuf::Message
     return reinterpret_cast<const AnimatorStateResult*>(
         &_AnimatorStateResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 42;
+  static constexpr int kIndexInFileMessages = 44;
   friend void swap(AnimatorStateResult& a, AnimatorStateResult& b) { a.Swap(&b); }
   inline void Swap(AnimatorStateResult* other) {
     if (other == this) return;
@@ -8854,7 +9276,7 @@ class AddComponentRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const AddComponentRequest*>(
         &_AddComponentRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 20;
+  static constexpr int kIndexInFileMessages = 22;
   friend void swap(AddComponentRequest& a, AddComponentRequest& b) { a.Swap(&b); }
   inline void Swap(AddComponentRequest* other) {
     if (other == this) return;
@@ -9086,7 +9508,7 @@ class ViewportTransformEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportTransformEvent*>(
         &_ViewportTransformEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 45;
+  static constexpr int kIndexInFileMessages = 47;
   friend void swap(ViewportTransformEvent& a, ViewportTransformEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportTransformEvent* other) {
     if (other == this) return;
@@ -9409,7 +9831,7 @@ class Vector4Result final : public ::google::protobuf::Message
     return reinterpret_cast<const Vector4Result*>(
         &_Vector4Result_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 40;
+  static constexpr int kIndexInFileMessages = 42;
   friend void swap(Vector4Result& a, Vector4Result& b) { a.Swap(&b); }
   inline void Swap(Vector4Result* other) {
     if (other == this) return;
@@ -9605,7 +10027,7 @@ class InstantiatePrefabInstanceRequest final : public ::google::protobuf::Messag
     return reinterpret_cast<const InstantiatePrefabInstanceRequest*>(
         &_InstantiatePrefabInstanceRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 25;
+  static constexpr int kIndexInFileMessages = 27;
   friend void swap(InstantiatePrefabInstanceRequest& a, InstantiatePrefabInstanceRequest& b) { a.Swap(&b); }
   inline void Swap(InstantiatePrefabInstanceRequest* other) {
     if (other == this) return;
@@ -10149,7 +10571,7 @@ class AnimatorParameterRequest final : public ::google::protobuf::Message
     return reinterpret_cast<const AnimatorParameterRequest*>(
         &_AnimatorParameterRequest_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 21;
+  static constexpr int kIndexInFileMessages = 23;
   friend void swap(AnimatorParameterRequest& a, AnimatorParameterRequest& b) { a.Swap(&b); }
   inline void Swap(AnimatorParameterRequest* other) {
     if (other == this) return;
@@ -10465,7 +10887,7 @@ class ViewportEvent final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEvent*>(
         &_ViewportEvent_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 48;
+  static constexpr int kIndexInFileMessages = 50;
   friend void swap(ViewportEvent& a, ViewportEvent& b) { a.Swap(&b); }
   inline void Swap(ViewportEvent* other) {
     if (other == this) return;
@@ -10815,6 +11237,8 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kGetEditorSimulationState = 62,
     kPreviewAudioAsset = 63,
     kSetEditorStatsMode = 64,
+    kSetEditorRenderMode = 65,
+    kGetEditorRenderMode = 66,
     COMMAND_NOT_SET = 0,
   };
   static inline const ProtocolRequest* internal_default_instance() {
@@ -10964,6 +11388,8 @@ class ProtocolRequest final : public ::google::protobuf::Message
     kGetEditorSimulationStateFieldNumber = 62,
     kPreviewAudioAssetFieldNumber = 63,
     kSetEditorStatsModeFieldNumber = 64,
+    kSetEditorRenderModeFieldNumber = 65,
+    kGetEditorRenderModeFieldNumber = 66,
   };
   // uint64 request_id = 2;
   void clear_request_id() ;
@@ -12011,6 +12437,44 @@ class ProtocolRequest final : public ::google::protobuf::Message
   ::sailor::editor::v1::EditorStatsModeRequest* _internal_mutable_set_editor_stats_mode();
 
   public:
+  // .sailor.editor.v1.EditorRenderModeRequest set_editor_render_mode = 65;
+  bool has_set_editor_render_mode() const;
+  private:
+  bool _internal_has_set_editor_render_mode() const;
+
+  public:
+  void clear_set_editor_render_mode() ;
+  const ::sailor::editor::v1::EditorRenderModeRequest& set_editor_render_mode() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::EditorRenderModeRequest* release_set_editor_render_mode();
+  ::sailor::editor::v1::EditorRenderModeRequest* mutable_set_editor_render_mode();
+  void set_allocated_set_editor_render_mode(::sailor::editor::v1::EditorRenderModeRequest* value);
+  void unsafe_arena_set_allocated_set_editor_render_mode(::sailor::editor::v1::EditorRenderModeRequest* value);
+  ::sailor::editor::v1::EditorRenderModeRequest* unsafe_arena_release_set_editor_render_mode();
+
+  private:
+  const ::sailor::editor::v1::EditorRenderModeRequest& _internal_set_editor_render_mode() const;
+  ::sailor::editor::v1::EditorRenderModeRequest* _internal_mutable_set_editor_render_mode();
+
+  public:
+  // .sailor.editor.v1.Empty get_editor_render_mode = 66;
+  bool has_get_editor_render_mode() const;
+  private:
+  bool _internal_has_get_editor_render_mode() const;
+
+  public:
+  void clear_get_editor_render_mode() ;
+  const ::sailor::editor::v1::Empty& get_editor_render_mode() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::Empty* release_get_editor_render_mode();
+  ::sailor::editor::v1::Empty* mutable_get_editor_render_mode();
+  void set_allocated_get_editor_render_mode(::sailor::editor::v1::Empty* value);
+  void unsafe_arena_set_allocated_get_editor_render_mode(::sailor::editor::v1::Empty* value);
+  ::sailor::editor::v1::Empty* unsafe_arena_release_get_editor_render_mode();
+
+  private:
+  const ::sailor::editor::v1::Empty& _internal_get_editor_render_mode() const;
+  ::sailor::editor::v1::Empty* _internal_mutable_get_editor_render_mode();
+
+  public:
   void clear_command();
   CommandCase command_case() const;
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.ProtocolRequest)
@@ -12070,12 +12534,14 @@ class ProtocolRequest final : public ::google::protobuf::Message
   void set_has_get_editor_simulation_state();
   void set_has_preview_audio_asset();
   void set_has_set_editor_stats_mode();
+  void set_has_set_editor_render_mode();
+  void set_has_get_editor_render_mode();
   inline bool has_command() const;
   inline void clear_has_command();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      1, 56, 54,
-      0, 9>
+      1, 58, 56,
+      0, 11>
       _table_;
 
   friend class ::google::protobuf::MessageLite;
@@ -12151,6 +12617,8 @@ class ProtocolRequest final : public ::google::protobuf::Message
       ::sailor::editor::v1::Empty* get_editor_simulation_state_;
       ::sailor::editor::v1::FileIdRequest* preview_audio_asset_;
       ::sailor::editor::v1::EditorStatsModeRequest* set_editor_stats_mode_;
+      ::sailor::editor::v1::EditorRenderModeRequest* set_editor_render_mode_;
+      ::sailor::editor::v1::Empty* get_editor_render_mode_;
     } command_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -12220,7 +12688,7 @@ class ViewportEventBatchResult final : public ::google::protobuf::Message
     return reinterpret_cast<const ViewportEventBatchResult*>(
         &_ViewportEventBatchResult_default_instance_);
   }
-  static constexpr int kIndexInFileMessages = 49;
+  static constexpr int kIndexInFileMessages = 51;
   friend void swap(ViewportEventBatchResult& a, ViewportEventBatchResult& b) { a.Swap(&b); }
   inline void Swap(ViewportEventBatchResult* other) {
     if (other == this) return;
@@ -12427,6 +12895,7 @@ class ProtocolResponse final : public ::google::protobuf::Message
     kVector4Result = 20,
     kViewportToolStateResult = 21,
     kAnimatorStateResult = 22,
+    kEditorRenderModeResult = 23,
     RESULT_NOT_SET = 0,
   };
   static inline const ProtocolResponse* internal_default_instance() {
@@ -12538,6 +13007,7 @@ class ProtocolResponse final : public ::google::protobuf::Message
     kVector4ResultFieldNumber = 20,
     kViewportToolStateResultFieldNumber = 21,
     kAnimatorStateResultFieldNumber = 22,
+    kEditorRenderModeResultFieldNumber = 23,
   };
   // string error = 4;
   void clear_error() ;
@@ -12842,6 +13312,25 @@ class ProtocolResponse final : public ::google::protobuf::Message
   ::sailor::editor::v1::AnimatorStateResult* _internal_mutable_animator_state_result();
 
   public:
+  // .sailor.editor.v1.EditorRenderModeResult editor_render_mode_result = 23;
+  bool has_editor_render_mode_result() const;
+  private:
+  bool _internal_has_editor_render_mode_result() const;
+
+  public:
+  void clear_editor_render_mode_result() ;
+  const ::sailor::editor::v1::EditorRenderModeResult& editor_render_mode_result() const;
+  PROTOBUF_NODISCARD ::sailor::editor::v1::EditorRenderModeResult* release_editor_render_mode_result();
+  ::sailor::editor::v1::EditorRenderModeResult* mutable_editor_render_mode_result();
+  void set_allocated_editor_render_mode_result(::sailor::editor::v1::EditorRenderModeResult* value);
+  void unsafe_arena_set_allocated_editor_render_mode_result(::sailor::editor::v1::EditorRenderModeResult* value);
+  ::sailor::editor::v1::EditorRenderModeResult* unsafe_arena_release_editor_render_mode_result();
+
+  private:
+  const ::sailor::editor::v1::EditorRenderModeResult& _internal_editor_render_mode_result() const;
+  ::sailor::editor::v1::EditorRenderModeResult* _internal_mutable_editor_render_mode_result();
+
+  public:
   void clear_result();
   ResultCase result_case() const;
   // @@protoc_insertion_point(class_scope:sailor.editor.v1.ProtocolResponse)
@@ -12860,11 +13349,12 @@ class ProtocolResponse final : public ::google::protobuf::Message
   void set_has_vector4_result();
   void set_has_viewport_tool_state_result();
   void set_has_animator_state_result();
+  void set_has_editor_render_mode_result();
   inline bool has_result() const;
   inline void clear_has_result();
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      3, 18, 13,
+      3, 19, 14,
       63, 2>
       _table_;
 
@@ -12903,6 +13393,7 @@ class ProtocolResponse final : public ::google::protobuf::Message
       ::sailor::editor::v1::Vector4Result* vector4_result_;
       ::sailor::editor::v1::ViewportToolStateResult* viewport_tool_state_result_;
       ::sailor::editor::v1::AnimatorStateResult* animator_state_result_;
+      ::sailor::editor::v1::EditorRenderModeResult* editor_render_mode_result_;
     } result_;
     ::google::protobuf::internal::CachedSize _cached_size_;
     ::uint32_t _oneof_case_[1];
@@ -17242,6 +17733,164 @@ inline ::sailor::editor::v1::EditorStatsModeRequest* ProtocolRequest::mutable_se
   return _msg;
 }
 
+// .sailor.editor.v1.EditorRenderModeRequest set_editor_render_mode = 65;
+inline bool ProtocolRequest::has_set_editor_render_mode() const {
+  return command_case() == kSetEditorRenderMode;
+}
+inline bool ProtocolRequest::_internal_has_set_editor_render_mode() const {
+  return command_case() == kSetEditorRenderMode;
+}
+inline void ProtocolRequest::set_has_set_editor_render_mode() {
+  _impl_._oneof_case_[0] = kSetEditorRenderMode;
+}
+inline void ProtocolRequest::clear_set_editor_render_mode() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kSetEditorRenderMode) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.set_editor_render_mode_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.set_editor_render_mode_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::EditorRenderModeRequest* ProtocolRequest::release_set_editor_render_mode() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.set_editor_render_mode)
+  if (command_case() == kSetEditorRenderMode) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_editor_render_mode_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.set_editor_render_mode_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::EditorRenderModeRequest& ProtocolRequest::_internal_set_editor_render_mode() const {
+  return command_case() == kSetEditorRenderMode ? *_impl_.command_.set_editor_render_mode_ : reinterpret_cast<::sailor::editor::v1::EditorRenderModeRequest&>(::sailor::editor::v1::_EditorRenderModeRequest_default_instance_);
+}
+inline const ::sailor::editor::v1::EditorRenderModeRequest& ProtocolRequest::set_editor_render_mode() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.set_editor_render_mode)
+  return _internal_set_editor_render_mode();
+}
+inline ::sailor::editor::v1::EditorRenderModeRequest* ProtocolRequest::unsafe_arena_release_set_editor_render_mode() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.set_editor_render_mode)
+  if (command_case() == kSetEditorRenderMode) {
+    clear_has_command();
+    auto* temp = _impl_.command_.set_editor_render_mode_;
+    _impl_.command_.set_editor_render_mode_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_set_editor_render_mode(::sailor::editor::v1::EditorRenderModeRequest* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_set_editor_render_mode();
+    _impl_.command_.set_editor_render_mode_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.set_editor_render_mode)
+}
+inline ::sailor::editor::v1::EditorRenderModeRequest* ProtocolRequest::_internal_mutable_set_editor_render_mode() {
+  if (command_case() != kSetEditorRenderMode) {
+    clear_command();
+    set_has_set_editor_render_mode();
+    _impl_.command_.set_editor_render_mode_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::EditorRenderModeRequest>(GetArena());
+  }
+  return _impl_.command_.set_editor_render_mode_;
+}
+inline ::sailor::editor::v1::EditorRenderModeRequest* ProtocolRequest::mutable_set_editor_render_mode() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::EditorRenderModeRequest* _msg = _internal_mutable_set_editor_render_mode();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.set_editor_render_mode)
+  return _msg;
+}
+
+// .sailor.editor.v1.Empty get_editor_render_mode = 66;
+inline bool ProtocolRequest::has_get_editor_render_mode() const {
+  return command_case() == kGetEditorRenderMode;
+}
+inline bool ProtocolRequest::_internal_has_get_editor_render_mode() const {
+  return command_case() == kGetEditorRenderMode;
+}
+inline void ProtocolRequest::set_has_get_editor_render_mode() {
+  _impl_._oneof_case_[0] = kGetEditorRenderMode;
+}
+inline void ProtocolRequest::clear_get_editor_render_mode() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (command_case() == kGetEditorRenderMode) {
+    if (GetArena() == nullptr) {
+      delete _impl_.command_.get_editor_render_mode_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.command_.get_editor_render_mode_);
+    }
+    clear_has_command();
+  }
+}
+inline ::sailor::editor::v1::Empty* ProtocolRequest::release_get_editor_render_mode() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolRequest.get_editor_render_mode)
+  if (command_case() == kGetEditorRenderMode) {
+    clear_has_command();
+    auto* temp = _impl_.command_.get_editor_render_mode_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.command_.get_editor_render_mode_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::Empty& ProtocolRequest::_internal_get_editor_render_mode() const {
+  return command_case() == kGetEditorRenderMode ? *_impl_.command_.get_editor_render_mode_ : reinterpret_cast<::sailor::editor::v1::Empty&>(::sailor::editor::v1::_Empty_default_instance_);
+}
+inline const ::sailor::editor::v1::Empty& ProtocolRequest::get_editor_render_mode() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolRequest.get_editor_render_mode)
+  return _internal_get_editor_render_mode();
+}
+inline ::sailor::editor::v1::Empty* ProtocolRequest::unsafe_arena_release_get_editor_render_mode() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolRequest.get_editor_render_mode)
+  if (command_case() == kGetEditorRenderMode) {
+    clear_has_command();
+    auto* temp = _impl_.command_.get_editor_render_mode_;
+    _impl_.command_.get_editor_render_mode_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolRequest::unsafe_arena_set_allocated_get_editor_render_mode(::sailor::editor::v1::Empty* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_command();
+  if (value) {
+    set_has_get_editor_render_mode();
+    _impl_.command_.get_editor_render_mode_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolRequest.get_editor_render_mode)
+}
+inline ::sailor::editor::v1::Empty* ProtocolRequest::_internal_mutable_get_editor_render_mode() {
+  if (command_case() != kGetEditorRenderMode) {
+    clear_command();
+    set_has_get_editor_render_mode();
+    _impl_.command_.get_editor_render_mode_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::Empty>(GetArena());
+  }
+  return _impl_.command_.get_editor_render_mode_;
+}
+inline ::sailor::editor::v1::Empty* ProtocolRequest::mutable_get_editor_render_mode() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::Empty* _msg = _internal_mutable_get_editor_render_mode();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolRequest.get_editor_render_mode)
+  return _msg;
+}
+
 inline bool ProtocolRequest::has_command() const {
   return command_case() != COMMAND_NOT_SET;
 }
@@ -18418,6 +19067,85 @@ inline ::sailor::editor::v1::AnimatorStateResult* ProtocolResponse::mutable_anim
   return _msg;
 }
 
+// .sailor.editor.v1.EditorRenderModeResult editor_render_mode_result = 23;
+inline bool ProtocolResponse::has_editor_render_mode_result() const {
+  return result_case() == kEditorRenderModeResult;
+}
+inline bool ProtocolResponse::_internal_has_editor_render_mode_result() const {
+  return result_case() == kEditorRenderModeResult;
+}
+inline void ProtocolResponse::set_has_editor_render_mode_result() {
+  _impl_._oneof_case_[0] = kEditorRenderModeResult;
+}
+inline void ProtocolResponse::clear_editor_render_mode_result() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  if (result_case() == kEditorRenderModeResult) {
+    if (GetArena() == nullptr) {
+      delete _impl_.result_.editor_render_mode_result_;
+    } else if (::google::protobuf::internal::DebugHardenClearOneofMessageOnArena()) {
+      ::google::protobuf::internal::MaybePoisonAfterClear(_impl_.result_.editor_render_mode_result_);
+    }
+    clear_has_result();
+  }
+}
+inline ::sailor::editor::v1::EditorRenderModeResult* ProtocolResponse::release_editor_render_mode_result() {
+  // @@protoc_insertion_point(field_release:sailor.editor.v1.ProtocolResponse.editor_render_mode_result)
+  if (result_case() == kEditorRenderModeResult) {
+    clear_has_result();
+    auto* temp = _impl_.result_.editor_render_mode_result_;
+    if (GetArena() != nullptr) {
+      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
+    }
+    _impl_.result_.editor_render_mode_result_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline const ::sailor::editor::v1::EditorRenderModeResult& ProtocolResponse::_internal_editor_render_mode_result() const {
+  return result_case() == kEditorRenderModeResult ? *_impl_.result_.editor_render_mode_result_ : reinterpret_cast<::sailor::editor::v1::EditorRenderModeResult&>(::sailor::editor::v1::_EditorRenderModeResult_default_instance_);
+}
+inline const ::sailor::editor::v1::EditorRenderModeResult& ProtocolResponse::editor_render_mode_result() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.ProtocolResponse.editor_render_mode_result)
+  return _internal_editor_render_mode_result();
+}
+inline ::sailor::editor::v1::EditorRenderModeResult* ProtocolResponse::unsafe_arena_release_editor_render_mode_result() {
+  // @@protoc_insertion_point(field_unsafe_arena_release:sailor.editor.v1.ProtocolResponse.editor_render_mode_result)
+  if (result_case() == kEditorRenderModeResult) {
+    clear_has_result();
+    auto* temp = _impl_.result_.editor_render_mode_result_;
+    _impl_.result_.editor_render_mode_result_ = nullptr;
+    return temp;
+  } else {
+    return nullptr;
+  }
+}
+inline void ProtocolResponse::unsafe_arena_set_allocated_editor_render_mode_result(::sailor::editor::v1::EditorRenderModeResult* value) {
+  // We rely on the oneof clear method to free the earlier contents
+  // of this oneof. We can directly use the pointer we're given to
+  // set the new value.
+  clear_result();
+  if (value) {
+    set_has_editor_render_mode_result();
+    _impl_.result_.editor_render_mode_result_ = value;
+  }
+  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:sailor.editor.v1.ProtocolResponse.editor_render_mode_result)
+}
+inline ::sailor::editor::v1::EditorRenderModeResult* ProtocolResponse::_internal_mutable_editor_render_mode_result() {
+  if (result_case() != kEditorRenderModeResult) {
+    clear_result();
+    set_has_editor_render_mode_result();
+    _impl_.result_.editor_render_mode_result_ =
+        ::google::protobuf::Message::DefaultConstruct<::sailor::editor::v1::EditorRenderModeResult>(GetArena());
+  }
+  return _impl_.result_.editor_render_mode_result_;
+}
+inline ::sailor::editor::v1::EditorRenderModeResult* ProtocolResponse::mutable_editor_render_mode_result() ABSL_ATTRIBUTE_LIFETIME_BOUND {
+  ::sailor::editor::v1::EditorRenderModeResult* _msg = _internal_mutable_editor_render_mode_result();
+  // @@protoc_insertion_point(field_mutable:sailor.editor.v1.ProtocolResponse.editor_render_mode_result)
+  return _msg;
+}
+
 inline bool ProtocolResponse::has_result() const {
   return result_case() != RESULT_NOT_SET;
 }
@@ -19175,6 +19903,58 @@ inline ::sailor::editor::v1::EditorStatsMode EditorStatsModeRequest::_internal_m
   return static_cast<::sailor::editor::v1::EditorStatsMode>(_impl_.mode_);
 }
 inline void EditorStatsModeRequest::_internal_set_mode(::sailor::editor::v1::EditorStatsMode value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.mode_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// EditorRenderModeRequest
+
+// .sailor.editor.v1.EditorRenderMode mode = 1;
+inline void EditorRenderModeRequest::clear_mode() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.mode_ = 0;
+}
+inline ::sailor::editor::v1::EditorRenderMode EditorRenderModeRequest::mode() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.EditorRenderModeRequest.mode)
+  return _internal_mode();
+}
+inline void EditorRenderModeRequest::set_mode(::sailor::editor::v1::EditorRenderMode value) {
+  _internal_set_mode(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.EditorRenderModeRequest.mode)
+}
+inline ::sailor::editor::v1::EditorRenderMode EditorRenderModeRequest::_internal_mode() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::sailor::editor::v1::EditorRenderMode>(_impl_.mode_);
+}
+inline void EditorRenderModeRequest::_internal_set_mode(::sailor::editor::v1::EditorRenderMode value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.mode_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// EditorRenderModeResult
+
+// .sailor.editor.v1.EditorRenderMode mode = 1;
+inline void EditorRenderModeResult::clear_mode() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.mode_ = 0;
+}
+inline ::sailor::editor::v1::EditorRenderMode EditorRenderModeResult::mode() const {
+  // @@protoc_insertion_point(field_get:sailor.editor.v1.EditorRenderModeResult.mode)
+  return _internal_mode();
+}
+inline void EditorRenderModeResult::set_mode(::sailor::editor::v1::EditorRenderMode value) {
+  _internal_set_mode(value);
+  // @@protoc_insertion_point(field_set:sailor.editor.v1.EditorRenderModeResult.mode)
+}
+inline ::sailor::editor::v1::EditorRenderMode EditorRenderModeResult::_internal_mode() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return static_cast<::sailor::editor::v1::EditorRenderMode>(_impl_.mode_);
+}
+inline void EditorRenderModeResult::_internal_set_mode(::sailor::editor::v1::EditorRenderMode value) {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.mode_ = value;
 }
@@ -23829,6 +24609,12 @@ struct is_proto_enum<::sailor::editor::v1::EditorStatsMode> : std::true_type {};
 template <>
 inline const EnumDescriptor* GetEnumDescriptor<::sailor::editor::v1::EditorStatsMode>() {
   return ::sailor::editor::v1::EditorStatsMode_descriptor();
+}
+template <>
+struct is_proto_enum<::sailor::editor::v1::EditorRenderMode> : std::true_type {};
+template <>
+inline const EnumDescriptor* GetEnumDescriptor<::sailor::editor::v1::EditorRenderMode>() {
+  return ::sailor::editor::v1::EditorRenderMode_descriptor();
 }
 
 }  // namespace protobuf

--- a/Runtime/RHI/RenderDebugView.h
+++ b/Runtime/RHI/RenderDebugView.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Sailor::RHI
+{
+	enum class ESceneViewRenderMode : uint8_t
+	{
+		Lit = 0,
+		AmbientOcclusion,
+		Cascades,
+		LightTiles
+	};
+
+	constexpr bool IsValidSceneViewRenderMode(ESceneViewRenderMode mode) noexcept
+	{
+		return mode == ESceneViewRenderMode::Lit ||
+			mode == ESceneViewRenderMode::AmbientOcclusion ||
+			mode == ESceneViewRenderMode::Cascades ||
+			mode == ESceneViewRenderMode::LightTiles;
+	}
+
+	constexpr const char* GetSceneViewRenderModeShaderDefine(
+		ESceneViewRenderMode mode) noexcept
+	{
+		switch (mode)
+		{
+		case ESceneViewRenderMode::AmbientOcclusion:
+			return "AO";
+		case ESceneViewRenderMode::Cascades:
+			return "CASCADES";
+		case ESceneViewRenderMode::LightTiles:
+			return "LIGHT_TILES";
+		case ESceneViewRenderMode::Lit:
+		default:
+			return "";
+		}
+	}
+}

--- a/Runtime/RHI/Renderer.cpp
+++ b/Runtime/RHI/Renderer.cpp
@@ -419,6 +419,7 @@ bool Renderer::PushFrame(const Sailor::FrameState& frame)
 
 		rhiSceneView->m_deltaTime = frame.GetDeltaTime();
 		rhiSceneView->m_currentTime = frame.GetWorld()->GetTime();
+		rhiSceneView->m_renderMode = App::GetEditorRenderMode();
 	}
 
 	const uint64_t sceneRevision = rhiSceneView->m_sceneRevision;

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -969,6 +969,7 @@ void RHISceneView::Clear()
 	m_virtualSceneVersions.Clear(false);
 	m_retainedSceneVersions.Clear();
 	m_sceneRevision = 0ull;
+	m_renderMode = ESceneViewRenderMode::Lit;
 	m_shadowCastersRevision = 0ull;
 	m_bHasCustomDepthShadowCasters = false;
 	m_pathTracerProxies.Clear(false);
@@ -982,6 +983,7 @@ void RHISceneViewSnapshot::ResetForReuse()
 	m_submissionContext.Clear();
 	m_sceneVersions.Clear();
 	m_sceneRevision = 0ull;
+	m_renderMode = ESceneViewRenderMode::Lit;
 	m_deltaTime = 0.0f;
 	m_frame = 0ull;
 	m_cameraIndex = 0u;
@@ -1275,6 +1277,7 @@ void RHISceneView::PrepareSnapshots()
 		res.m_submissionContext = m_submissionContext;
 		res.m_sceneVersions = GetRetainedSceneVersions();
 		res.m_sceneRevision = m_sceneRevision;
+		res.m_renderMode = m_renderMode;
 
 		Math::Frustum frustum;
 

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -5,6 +5,7 @@
 #include "Engine/Types.h"
 #include "RHI/Mesh.h"
 #include "RHI/Material.h"
+#include "RHI/RenderDebugView.h"
 #include "RHI/RenderSubmission.h"
 #include "RHI/Scene.h"
 #include "RHI/Lighting.h"
@@ -373,6 +374,7 @@ namespace Sailor::RHI
 		RHIRenderSubmissionContextPtr m_submissionContext{};
 		TSharedPtr<TVector<RHISceneVersionPtr>> m_sceneVersions{};
 		uint64_t m_sceneRevision = 0ull;
+		ESceneViewRenderMode m_renderMode = ESceneViewRenderMode::Lit;
 		float m_deltaTime = 0.0f;
 		uint64_t m_frame = 0ull;
 		uint32_t m_cameraIndex = 0u;
@@ -431,6 +433,7 @@ namespace Sailor::RHI
 		TVector<RHISceneVersionPtr> m_virtualSceneVersions{};
 		TSharedPtr<TVector<RHISceneVersionPtr>> m_retainedSceneVersions{};
 		uint64_t m_sceneRevision = 0ull;
+		ESceneViewRenderMode m_renderMode = ESceneViewRenderMode::Lit;
 
 		uint32_t m_totalNumLights = 0;
 		RHI::RHIShaderBindingSetPtr m_rhiLightsData{};

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -71,6 +71,7 @@ namespace
 {
 	Settings::GraphicsSettingsState g_graphicsSettingsState{};
 	std::atomic<Settings::ERenderStatsMode> g_renderStatsMode{ Settings::ERenderStatsMode::None };
+	std::atomic<RHI::ESceneViewRenderMode> g_editorRenderMode{ RHI::ESceneViewRenderMode::Lit };
 }
 
 App::~App() = default;
@@ -124,6 +125,22 @@ bool App::SetRenderStatsMode(Settings::ERenderStatsMode mode)
 	}
 
 	g_renderStatsMode.store(mode, std::memory_order_release);
+	return true;
+}
+
+RHI::ESceneViewRenderMode App::GetEditorRenderMode()
+{
+	return g_editorRenderMode.load(std::memory_order_acquire);
+}
+
+bool App::SetEditorRenderMode(RHI::ESceneViewRenderMode mode)
+{
+	if (!RHI::IsValidSceneViewRenderMode(mode))
+	{
+		return false;
+	}
+
+	g_editorRenderMode.store(mode, std::memory_order_release);
 	return true;
 }
 
@@ -413,6 +430,7 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	EditorRuntime::ResetForAppLifecycle();
 	g_graphicsSettingsState = Settings::GraphicsSettingsState{};
 	g_renderStatsMode.store(Settings::ERenderStatsMode::None, std::memory_order_release);
+	g_editorRenderMode.store(RHI::ESceneViewRenderMode::Lit, std::memory_order_release);
 
 	{
 		const std::lock_guard<std::mutex> shutdownLock(g_engineShutdownMutex);
@@ -1248,6 +1266,7 @@ void App::Shutdown()
 	s_pInstance = nullptr;
 	g_graphicsSettingsState = Settings::GraphicsSettingsState{};
 	g_renderStatsMode.store(Settings::ERenderStatsMode::None, std::memory_order_release);
+	g_editorRenderMode.store(RHI::ESceneViewRenderMode::Lit, std::memory_order_release);
 }
 
 bool App::IsRendererInitialized()

--- a/Runtime/Sailor.h
+++ b/Runtime/Sailor.h
@@ -9,6 +9,7 @@
 #include "Platform/Win32/Window.h"
 #include "Containers/Containers.h"
 #include "Math/Math.h"
+#include "RHI/RenderDebugView.h"
 #include "Settings/GraphicsSettings.h"
 #include "Workspace/WorkspaceContext.h"
 #include <functional>
@@ -59,6 +60,8 @@ namespace Sailor
 		SAILOR_API static Settings::EGraphicsQuality GetActiveGraphicsQuality();
 		SAILOR_API static Settings::ERenderStatsMode GetRenderStatsMode();
 		SAILOR_API static bool SetRenderStatsMode(Settings::ERenderStatsMode mode);
+		SAILOR_API static RHI::ESceneViewRenderMode GetEditorRenderMode();
+		SAILOR_API static bool SetEditorRenderMode(RHI::ESceneViewRenderMode mode);
 
 		SAILOR_API static void Initialize(const char** commandLineArgs = nullptr, int32_t num = 0);
 		SAILOR_API static void Start();

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -225,6 +225,9 @@ target_compile_features(InstanceIdContractTests PRIVATE cxx_std_20)
 target_compile_features(EcsLifecycleContractTests PRIVATE cxx_std_20)
 target_compile_features(BoundsContractTests PRIVATE cxx_std_20)
 target_compile_features(GpuCullingContractTests PRIVATE cxx_std_20)
+target_compile_definitions(GpuCullingContractTests PRIVATE
+    SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
+)
 target_compile_features(RHISceneVirtualizationTests PRIVATE cxx_std_20)
 target_compile_features(ModelImporterContractTests PRIVATE cxx_std_20)
 target_compile_features(AnimationSamplingContractTests PRIVATE cxx_std_20)

--- a/Tests/EditorEngineProtocolTests.cpp
+++ b/Tests/EditorEngineProtocolTests.cpp
@@ -53,6 +53,7 @@ namespace
 	constexpr uint32_t c_viewportEventBatchResultField = 19;
 	constexpr uint32_t c_viewportToolStateResultField = 21;
 	constexpr uint32_t c_animatorStateResultField = 22;
+	constexpr uint32_t c_editorRenderModeResultField = 23;
 	constexpr uint32_t c_emptyResultField = 10;
 	constexpr uint32_t c_initializeCommandField = 10;
 	constexpr uint32_t c_startCommandField = 11;
@@ -71,6 +72,8 @@ namespace
 	constexpr uint32_t c_getEditorSimulationStateCommandField = 62;
 	constexpr uint32_t c_previewAudioAssetCommandField = 63;
 	constexpr uint32_t c_setEditorStatsModeCommandField = 64;
+	constexpr uint32_t c_setEditorRenderModeCommandField = 65;
+	constexpr uint32_t c_getEditorRenderModeCommandField = 66;
 
 	void Require(bool condition, const std::string& message)
 	{
@@ -274,7 +277,7 @@ namespace
 					static_cast<size_t>(length));
 			}
 			else if (fieldNumber >= 10u &&
-				fieldNumber <= c_animatorStateResultField)
+				fieldNumber <= c_editorRenderModeResultField)
 			{
 				response.m_resultField = fieldNumber;
 				response.m_resultPayload.assign(
@@ -1129,6 +1132,119 @@ namespace
 			response.m_resultField == 0 &&
 			response.m_error.find("stats mode") != std::string::npos,
 			"an invalid Editor stats mode must fail without mutating runtime state");
+	}
+
+	void TestEditorRenderModeWireContract()
+	{
+		static_assert(
+			sailor::editor::v1::ProtocolRequest::
+				kSetEditorRenderModeFieldNumber ==
+			c_setEditorRenderModeCommandField);
+		static_assert(
+			sailor::editor::v1::ProtocolRequest::
+				kGetEditorRenderModeFieldNumber ==
+			c_getEditorRenderModeCommandField);
+		static_assert(
+			sailor::editor::v1::ProtocolResponse::
+				kEditorRenderModeResultFieldNumber ==
+			c_editorRenderModeResultField);
+		static_assert(
+			sailor::editor::v1::EditorRenderModeRequest::
+				kModeFieldNumber == 1);
+		static_assert(
+			sailor::editor::v1::EditorRenderModeResult::
+				kModeFieldNumber == 1);
+		static_assert(sailor::editor::v1::EDITOR_RENDER_MODE_LIT == 1);
+		static_assert(
+			sailor::editor::v1::EDITOR_RENDER_MODE_AMBIENT_OCCLUSION == 2);
+		static_assert(
+			sailor::editor::v1::EDITOR_RENDER_MODE_CASCADES == 3);
+		static_assert(
+			sailor::editor::v1::EDITOR_RENDER_MODE_LIGHT_TILES == 4);
+
+		Sailor::Protocol::TEditorEngineProtocolLifecycleGate gate;
+		std::string admissionError;
+		Require(
+			gate.TryBeginInitialization(admissionError),
+			"Render mode protocol fixture lifecycle must initialize");
+		gate.CompleteInitialization(true);
+		Sailor::Protocol::EditorEngineProtocolDependencies dependencies{};
+		dependencies.m_lifecycleGate = &gate;
+
+		std::string lightTilesRequest;
+		AppendVarintField(
+			lightTilesRequest,
+			1u,
+			sailor::editor::v1::EDITOR_RENDER_MODE_LIGHT_TILES);
+		TProtocolBuffer setBuffer;
+		const auto setResponse = RequireProtocolResponse(
+			MakeRequest(
+				EditorEngineProtocolVersion,
+				129,
+				c_setEditorRenderModeCommandField,
+				lightTilesRequest),
+			setBuffer,
+			dependencies);
+		Require(
+			setResponse.m_success &&
+			setResponse.m_resultField == c_boolResultField &&
+			setResponse.m_boolResult,
+			"a valid Editor render mode must update runtime state");
+
+		TProtocolBuffer getBuffer;
+		const auto getResponse = RequireProtocolResponse(
+			MakeRequest(
+				EditorEngineProtocolVersion,
+				130,
+				c_getEditorRenderModeCommandField),
+			getBuffer,
+			dependencies);
+		int32_t currentMode = 0;
+		Require(
+			getResponse.m_success &&
+			getResponse.m_resultField == c_editorRenderModeResultField &&
+			TryDecodeInt32Result(
+				reinterpret_cast<const uint8_t*>(
+					getResponse.m_resultPayload.data()),
+				getResponse.m_resultPayload.size(),
+				currentMode) &&
+			currentMode == sailor::editor::v1::EDITOR_RENDER_MODE_LIGHT_TILES,
+			"the typed render-mode query must return Engine truth");
+
+		std::string invalidModeRequest;
+		AppendVarintField(invalidModeRequest, 1u, 99u);
+		TProtocolBuffer invalidBuffer;
+		const auto invalidResponse = RequireProtocolResponse(
+			MakeRequest(
+				EditorEngineProtocolVersion,
+				131,
+				c_setEditorRenderModeCommandField,
+				invalidModeRequest),
+			invalidBuffer,
+			dependencies);
+		Require(
+			!invalidResponse.m_success &&
+			invalidResponse.m_resultField == 0 &&
+			invalidResponse.m_error.find("render mode") != std::string::npos,
+			"an invalid Editor render mode must be rejected");
+
+		std::string litRequest;
+		AppendVarintField(
+			litRequest,
+			1u,
+			sailor::editor::v1::EDITOR_RENDER_MODE_LIT);
+		TProtocolBuffer resetBuffer;
+		const auto resetResponse = RequireProtocolResponse(
+			MakeRequest(
+				EditorEngineProtocolVersion,
+				132,
+				c_setEditorRenderModeCommandField,
+				litRequest),
+			resetBuffer,
+			dependencies);
+		Require(
+			resetResponse.m_success && resetResponse.m_boolResult,
+			"the render-mode fixture must restore Lit mode");
 	}
 
 	void TestAudioPreviewWireContract()
@@ -2121,6 +2237,7 @@ int main()
 		TestModelInstanceWireContract();
 		TestEditorSimulationWireContract();
 		TestEditorStatsModeWireContract();
+		TestEditorRenderModeWireContract();
 		TestAudioPreviewWireContract();
 		TestEmbeddedNullIsRejected();
 		TestUtf8StringIsAccepted();

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -14,12 +14,16 @@
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
+#include <fstream>
 #include <functional>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <stdexcept>
 #include <string>
 #include <utility>
+#include <yaml-cpp/yaml.h>
 
 using namespace Sailor;
 using namespace Sailor::GraphicsDriver::Vulkan;
@@ -37,6 +41,92 @@ namespace
 		if (!condition)
 		{
 			throw std::runtime_error(message);
+		}
+	}
+
+	std::string ReadText(const std::filesystem::path& path)
+	{
+		std::ifstream input(path, std::ios::binary);
+		Require(input.is_open(), "renderer contract should be readable: " + path.generic_string());
+		return std::string(
+			std::istreambuf_iterator<char>(input),
+			std::istreambuf_iterator<char>());
+	}
+
+	std::string GetFrameGraphSetting(const YAML::Node& pass, const char* setting)
+	{
+		const YAML::Node settings = pass["string"];
+		if (!settings || !settings.IsSequence())
+		{
+			return {};
+		}
+
+		for (const YAML::Node& entry : settings)
+		{
+			const YAML::Node value = entry[setting];
+			if (value && value.IsScalar())
+			{
+				return value.as<std::string>();
+			}
+		}
+
+		return {};
+	}
+
+	void TestRendererGpuCullingPassContract()
+	{
+		const std::filesystem::path contentRoot =
+			std::filesystem::path(SAILOR_TEST_SOURCE_DIR) / "Content";
+		const char* rendererPaths[] =
+		{
+			"DefaultRenderer.renderer",
+			"EditorRenderer.renderer"
+		};
+
+		for (const char* rendererPath : rendererPaths)
+		{
+			const YAML::Node renderer = YAML::Load(ReadText(contentRoot / rendererPath));
+			const YAML::Node frame = renderer["frame"];
+			Require(frame && frame.IsSequence(),
+				std::string(rendererPath) + " should contain a frame graph");
+
+			uint32_t depthPasses = 0u;
+			uint32_t mainPasses = 0u;
+			for (const YAML::Node& pass : frame)
+			{
+				const YAML::Node nameNode = pass["name"];
+				if (!nameNode || !nameNode.IsScalar())
+				{
+					continue;
+				}
+
+				const std::string name = nameNode.as<std::string>();
+				const std::string tag = GetFrameGraphSetting(pass, "Tag");
+				if (name == "DepthPrepass" && (tag == "Opaque" || tag == "Masked"))
+				{
+					++depthPasses;
+					Require(GetFrameGraphSetting(pass, "GPUCulling") == "false",
+						std::string(rendererPath) + " must keep GPU culling disabled in " + tag +
+						" depth prepass");
+					Require(GetFrameGraphSetting(pass, "VirtualizeInstancePayloads") == "true",
+						std::string(rendererPath) + " must keep instance virtualization enabled in " + tag +
+						" depth prepass");
+				}
+				else if (name == "RenderScene" && (tag == "Opaque" || tag == "Masked"))
+				{
+					++mainPasses;
+					Require(GetFrameGraphSetting(pass, "GPUCulling") == "true",
+						std::string(rendererPath) + " must keep GPU culling enabled in " + tag +
+						" main pass");
+					Require(GetFrameGraphSetting(pass, "VirtualizeInstancePayloads") == "true",
+						std::string(rendererPath) + " must keep instance virtualization enabled in " + tag +
+						" main pass");
+				}
+			}
+
+			Require(depthPasses == 2u && mainPasses == 2u,
+				std::string(rendererPath) +
+				" should expose opaque and masked depth/main pass pairs");
 		}
 	}
 
@@ -776,6 +866,7 @@ namespace
 int main()
 {
 	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "RendererGpuCullingPassContract", TestRendererGpuCullingPassContract },
 		{ "MipExtentUsesVulkanFloorAndClamp", TestMipExtentUsesVulkanFloorAndClamp },
 		{ "PackedDrawMobilityPayloadVirtualization", TestPackedDrawMobilityPayloadVirtualization },
 		{ "MaterialVersionPublicationContract", TestMaterialVersionPublicationContract },

--- a/Tests/RHISceneVirtualizationTests.cpp
+++ b/Tests/RHISceneVirtualizationTests.cpp
@@ -301,11 +301,28 @@ namespace
 		auto context = RHIRenderSubmissionContextPtr::Make();
 		context->BeginSubmission(11ull, 1u);
 		view.SetSubmissionContext(context);
+		view.m_renderMode = ESceneViewRenderMode::Cascades;
 		view.PrepareSnapshots();
 
 		Require(view.m_snapshots.Num() == 1u &&
-			view.m_snapshots[0].m_submissionContext == context,
+			view.m_snapshots[0].m_submissionContext == context &&
+			view.m_snapshots[0].m_renderMode == ESceneViewRenderMode::Cascades,
 			"preparing a camera snapshot must retain the acquired flight submission context");
+		view.m_renderMode = ESceneViewRenderMode::AmbientOcclusion;
+		Require(
+			view.m_snapshots[0].m_renderMode == ESceneViewRenderMode::Cascades,
+			"a prepared frame snapshot must keep its render mode when the next frame changes");
+
+		Require(
+			std::string(GetSceneViewRenderModeShaderDefine(
+				ESceneViewRenderMode::AmbientOcclusion)) == "AO" &&
+			std::string(GetSceneViewRenderModeShaderDefine(
+				ESceneViewRenderMode::Cascades)) == "CASCADES" &&
+			std::string(GetSceneViewRenderModeShaderDefine(
+				ESceneViewRenderMode::LightTiles)) == "LIGHT_TILES" &&
+			std::string(GetSceneViewRenderModeShaderDefine(
+				ESceneViewRenderMode::Lit)).empty(),
+			"each Scene View render mode must resolve to its immutable shader variant");
 	}
 }
 

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -1083,6 +1083,9 @@ namespace
 		compileRuntimeFragment(
 			"Shaders/Standard_glTF.shader",
 			{ "CLEAR_COAT", "SHEEN", "TRANSMISSION" });
+		compileRuntimeFragment(
+			"Shaders/Standard_glTF.shader",
+			{ "DISABLE_SCREEN_SPACE_AO" });
 		const RHI::ShaderByteCode debugAoByteCode = compileRuntimeFragment(
 			"Shaders/Debug.shader",
 			{ "AO" });

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -14,6 +14,7 @@
 #include <iterator>
 #include <stdexcept>
 #include <string>
+#include <spirv_reflect.h>
 #include <yaml-cpp/yaml.h>
 
 namespace
@@ -127,6 +128,36 @@ namespace
 		{
 			Require(actual[index] == expected[index], context + " should preserve every word");
 		}
+	}
+
+	void RequireSpirvCombinedImageSamplerBinding(
+		const RHI::ShaderByteCode& byteCode,
+		uint32_t set,
+		uint32_t binding)
+	{
+		SpvReflectShaderModule module{};
+		Require(
+			spvReflectCreateShaderModule(
+				byteCode.Num() * sizeof(byteCode[0]),
+				&byteCode[0],
+				&module) == SPV_REFLECT_RESULT_SUCCESS,
+			"compiled shader artifact should support SPIR-V reflection");
+
+		SpvReflectResult result = SPV_REFLECT_RESULT_SUCCESS;
+		const SpvReflectDescriptorBinding* reflected =
+			spvReflectGetDescriptorBinding(&module, binding, set, &result);
+		const bool bMatches =
+			result == SPV_REFLECT_RESULT_SUCCESS &&
+			reflected &&
+			reflected->descriptor_type ==
+				SPV_REFLECT_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+		spvReflectDestroyShaderModule(&module);
+
+		Require(
+			bMatches,
+			std::string("compiled shader artifact should expose a combined image sampler at set ") +
+				std::to_string(set) +
+				", binding " + std::to_string(binding));
 	}
 
 	void WriteWords(const std::filesystem::path& path, const TVector<uint32_t>& words)
@@ -981,20 +1012,29 @@ namespace
 	{
 		const std::filesystem::path contentRoot =
 			std::filesystem::path(SAILOR_TEST_SOURCE_DIR) / "Content";
-		const std::array<const char*, 3> shaderPaths =
+		const std::array<const char*, 5> shaderPaths =
 		{
 			"Shaders/Standard.shader",
 			"Shaders/Standard_glTF.shader",
-			"Shaders/Landscape.shader"
+			"Shaders/Landscape.shader",
+			"Shaders/HBAO.shader",
+			"Shaders/HBAO_Blur.shader"
 		};
 
-		for (const char* shaderPath : shaderPaths)
+		auto compileRuntimeFragment = [&contentRoot](
+			const char* shaderPath,
+			std::initializer_list<const char*> permutationDefines)
+			-> RHI::ShaderByteCode
 		{
 			const std::filesystem::path sourcePath = contentRoot / shaderPath;
 			ShaderAsset shader;
 			shader.Deserialize(YAML::Load(ReadText(sourcePath)));
 
 			std::string source = shader.GetGlslCommonCode() + "\n#define FRAGMENT\n";
+			for (const char* define : permutationDefines)
+			{
+				source += std::string("#define ") + define + "\n";
+			}
 #if defined(__APPLE__)
 			source += "#define SAILOR_TEXTURE_REMAP\n";
 #endif
@@ -1033,7 +1073,25 @@ namespace
 				std::string("runtime fragment shader should compile: ") + shaderPath);
 			Require(!byteCode.IsEmpty(),
 				std::string("runtime fragment shader should produce SPIR-V: ") + shaderPath);
+			return byteCode;
+		};
+
+		for (const char* shaderPath : shaderPaths)
+		{
+			compileRuntimeFragment(shaderPath, {});
 		}
+		compileRuntimeFragment(
+			"Shaders/Standard_glTF.shader",
+			{ "CLEAR_COAT", "SHEEN", "TRANSMISSION" });
+		const RHI::ShaderByteCode debugAoByteCode = compileRuntimeFragment(
+			"Shaders/Debug.shader",
+			{ "AO" });
+		RequireSpirvCombinedImageSamplerBinding(
+			debugAoByteCode,
+			2u,
+			8u);
+		compileRuntimeFragment("Shaders/Debug.shader", { "CASCADES" });
+		compileRuntimeFragment("Shaders/Debug.shader", { "LIGHT_TILES" });
 
 		const char* computeShaderPath = "Shaders/ComputeLightCulling.shader";
 		ShaderAsset computeShader;


### PR DESCRIPTION
## Summary

- Add Lit, Ambient Occlusion, Cascades, and Light Tiles modes to the Scene View toolbar.
- Add typed Editor protocol and MCP get/set commands for live render-mode control.
- Capture the selected mode in each RHISceneView snapshot so queued frames keep independent state.
- Add a dedicated DebugView FrameGraph node with prewarmed immutable shader variants and Lit fallback.
- Correct HBAO reconstruction, texel-center sampling, and visibility power handling.
- Apply screen-space AO to diffuse/specular IBL and a bounded direct-light contact term for Standard, glTF, and Landscape materials.
- Keep GPU culling enabled for opaque/masked main rendering while disabling it in the corresponding depth prepasses.

## Linked Issue

Closes #181

## Implementation Notes

- Lit keeps the existing blit path; the game DefaultRenderer graph is not switched to debug output.
- Debug variants never mutate a material or define set retained by an in-flight command list.
- Screen-space AO remains the full visibility term for diffuse IBL and uses roughness/view-aware specular occlusion.
- A 0.5-bounded direct-light strength makes contact AO visible in analytic-light-dominated scenes. Emissive and transmission remain unchanged, and baked glTF material occlusion remains indirect-only.
- AO screen UVs use the actual AO texture extent, so renderer and viewport resolution differences cannot misalign the sample.
- DefaultRenderer and EditorRenderer disable GPU culling for opaque/masked DepthPrepass nodes and retain it for the matching RenderScene nodes. Instance payload virtualization remains enabled in both paths.

## Agent Workflow

- [x] Implementation Summary is posted.
- [x] Tech Review is approved or requested.
- [x] QA Report is posted or explicitly deferred.
- [x] Ready for human review only after Tech Review and QA approval.

## Tests

- [x] Focused native CTest set: 6/6 passed (protocol, viewport, RHI snapshot virtualization, shader artifacts).
- [x] `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --no-restore --maxcpucount:1`: 695/695 passed.
- [x] Release SailorLib and SailorExec built with parallelism 1.
- [x] Rebuilt and passed ShaderCacheArtifactTests, including the glTF `DISABLE_SCREEN_SPACE_AO` permutation.
- [x] GpuCullingContractTests passed, including the renderer pass configuration contract.
- [x] Live Everything Floats project DefaultRenderer validation: correct AO target, Standard/glTF/Landscape binding, visible Lit contribution, and three byte-identical consecutive AO captures.
- [x] Live Low/High MSAA A/B isolated the remaining AO flicker to depth-prepass GPU culling; disabling only depth culling fixed it while main-pass GPU culling remained enabled.
- [ ] Full visual world suite: blocked by an inherited Release teardown SIGSEGV in `MVKQueue` destruction after all GPU memory is released. The same `CombinedShadows` failure reproduces with the baseline dylib; `EmptyWorldStartupShutdown` passes.

## Risk

- Risk level: medium
- Risk notes: changes touch the Editor protocol, FrameGraph output, shared lighting shaders, and renderer pass configuration. Flight-local snapshot coverage, compiled SPIR-V permutations/reflection, focused native/Editor tests, and live Editor plus project DefaultRenderer validation cover the primary risks.
