### PR TITLE
Add landscape LOD and vegetation streaming

### DIFF
--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="McpBridgeIntegrationTests.cs" />
     <Compile Include="WorkspaceBuildPlanTests.cs" />
     <Compile Include="McpYamlUtilitiesTests.cs" />
+    <Compile Include="LandscapeVegetationBinaryTests.cs" />
     <Compile Include="SettingsContractsTests.cs" />
     <Compile Include="UnifiedSettingsStoreTests.cs" />
     <Compile Include="GraphicsSettingsTests.cs" />
@@ -151,6 +152,7 @@
     <Compile Include="..\Editor\Mcp\McpEndpointDiscovery.cs" Link="Mcp\McpEndpointDiscovery.cs" />
     <Compile Include="..\Editor\Mcp\McpLoopbackAuthentication.cs" Link="Mcp\McpLoopbackAuthentication.cs" />
     <Compile Include="..\Editor\Mcp\McpYamlUtilities.cs" Link="Mcp\McpYamlUtilities.cs" />
+    <Compile Include="..\Editor\Mcp\LandscapeVegetationBinary.cs" Link="Mcp\LandscapeVegetationBinary.cs" />
     <Compile Include="..\Editor\McpBridge\McpBridgeOptions.cs" Link="McpBridge\McpBridgeOptions.cs" />
     <Compile Include="..\Editor\McpBridge\McpBridgeRunner.cs" Link="McpBridge\McpBridgeRunner.cs" />
     <Compile Include="..\Editor\Workflow\WorkflowProjections.cs" Link="Workflow\WorkflowProjections.cs" />

--- a/Editor.Tests/GraphicsSettingsTests.cs
+++ b/Editor.Tests/GraphicsSettingsTests.cs
@@ -17,6 +17,9 @@ public sealed class GraphicsSettingsTests
         Assert.Equal([4096, 2048, 2048, 1024], project.Graphics.Presets.Ultra.ShadowCascadeResolutions);
         Assert.Equal(0.85, project.Graphics.Presets.Medium.ResolutionFactor);
         Assert.Equal(GraphicsShadowQuality.Medium, project.Graphics.Presets.Medium.ShadowQuality);
+        Assert.Equal(65536, project.Graphics.Presets.Ultra.VegetationInstanceBudget);
+        Assert.Equal(32768, project.Graphics.Presets.High.VegetationInstanceBudget);
+        Assert.Equal(2048, project.Graphics.Presets.VeryLow.VegetationInstanceBudget);
         Assert.Equal(0.125, project.Graphics.Presets.VeryLow.CloudsResolutionMultiplier);
         Assert.Equal(2, project.Graphics.Presets.VeryLow.LodBias);
         Assert.True(GraphicsSettingsValidator.Validate(project).IsValid);
@@ -28,6 +31,7 @@ public sealed class GraphicsSettingsTests
         Assert.Contains("shadowBias: 0", yaml);
         Assert.Contains("VeryLow:", yaml);
         Assert.Contains("supportSoftShadows: true", yaml);
+        Assert.Contains("vegetationInstanceBudget: 32768", yaml);
     }
 
     [Fact]
@@ -44,6 +48,7 @@ public sealed class GraphicsSettingsTests
             ShadowCascadeResolutions = [1024, 300],
             CloudsResolutionMultiplier = 3.0,
             SkyResolution = 96,
+            VegetationInstanceBudget = 1048577,
             LodBias = 9
         };
         var document = GraphicsSettingsDefaults.Project with
@@ -67,7 +72,32 @@ public sealed class GraphicsSettingsTests
         Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.shadowCascadeResolutions");
         Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.cloudsResolutionMultiplier");
         Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.skyResolution");
+        Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.vegetationInstanceBudget");
         Assert.Contains(result.Issues, x => x.Path == "graphics.presets.High.lodBias");
+    }
+
+    [Fact]
+    public async Task LegacyPresetWithoutVegetationBudget_UsesItsQualityDefault()
+    {
+        using var workspace = TempWorkspace.Create();
+        var root = LoadRoot(
+            GraphicsSettingsYamlCodec.SerializeProject(GraphicsSettingsDefaults.Project));
+        var graphics = Assert.IsType<YamlMappingNode>(
+            root.Children[new YamlScalarNode("graphics")]);
+        var presets = Assert.IsType<YamlMappingNode>(
+            graphics.Children[new YamlScalarNode("presets")]);
+        var medium = Assert.IsType<YamlMappingNode>(
+            presets.Children[new YamlScalarNode("Medium")]);
+        medium.Children.Remove(new YamlScalarNode("vegetationInstanceBudget"));
+        await File.WriteAllTextAsync(workspace.Paths.ProjectSettingsPath, Save(root));
+
+        var snapshot = await new GraphicsSettingsService(() => workspace.Paths)
+            .EnsureLoadedAsync();
+
+        Assert.Equal(16384, snapshot.Project.Graphics.Presets.Medium.VegetationInstanceBudget);
+        Assert.DoesNotContain(
+            snapshot.Diagnostics,
+            value => value.Contains("vegetationInstanceBudget", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/Editor.Tests/LandscapeVegetationBinaryTests.cs
+++ b/Editor.Tests/LandscapeVegetationBinaryTests.cs
@@ -1,0 +1,102 @@
+using System.Buffers.Binary;
+using SailorEditor.Mcp;
+
+namespace SailorEditor.Tests;
+
+public sealed class LandscapeVegetationBinaryTests
+{
+    [Fact]
+    public void ReadPageReturnsExactFormatIdentityMatrixAndInstanceSettings()
+    {
+        var filepath = Path.Combine(
+            Path.GetTempPath(),
+            $"sailor-landscape-{Guid.NewGuid():N}.vegetation");
+        try
+        {
+            var bytes = new byte[
+                LandscapeVegetationBinary.HeaderSize +
+                LandscapeVegetationBinary.ChunkRecordSize +
+                LandscapeVegetationBinary.InstanceRecordSize];
+            "SLVEG001"u8.CopyTo(bytes);
+            U32(bytes, 8, LandscapeVegetationBinary.Version);
+            U32(bytes, 12, LandscapeVegetationBinary.EndianMarker);
+            U32(bytes, 16, LandscapeVegetationBinary.HeaderSize);
+            U32(bytes, 20, LandscapeVegetationBinary.ChunkRecordSize);
+            U32(bytes, 24, LandscapeVegetationBinary.InstanceRecordSize);
+            U32(bytes, 28, 1);
+            U32(bytes, 32, 1);
+            U32(bytes, 36, 2);
+            U32(bytes, 40, 1);
+            U64(bytes, 44, 1);
+            F32(bytes, 52, 64.0f);
+            U32(bytes, 56, 1);
+
+            var chunkOffset = checked((int)LandscapeVegetationBinary.HeaderSize);
+            U32(bytes, chunkOffset, 0);
+            U32(bytes, chunkOffset + 4, 0);
+            U64(bytes, chunkOffset + 8, 0);
+            U32(bytes, chunkOffset + 16, 1);
+
+            var instanceOffset = checked(chunkOffset +
+                (int)LandscapeVegetationBinary.ChunkRecordSize);
+            U64(bytes, instanceOffset, 0x1122334455667788UL);
+            U32(bytes, instanceOffset + 8, 1);
+            U32(bytes, instanceOffset + 12, LandscapeVegetationBinary.EnabledFlag);
+            float[] expectedMatrix =
+            [
+                1, 0, 0, 0,
+                0, 2, 0, 0,
+                0, 0, 3, 0,
+                4, 5, 6, 1
+            ];
+            for (var matrixIndex = 0; matrixIndex < expectedMatrix.Length; ++matrixIndex)
+            {
+                F32(bytes, instanceOffset + 16 + matrixIndex * sizeof(float),
+                    expectedMatrix[matrixIndex]);
+            }
+            I32(bytes, instanceOffset + 80, -2);
+            F32(bytes, instanceOffset + 84, 0.75f);
+            F32(bytes, instanceOffset + 88, 1.5f);
+            File.WriteAllBytes(filepath, bytes);
+
+            var result = LandscapeVegetationBinary.ReadPage(
+                filepath,
+                "VEGETATION-FILE-ID",
+                "Landscape/Vegetation/Landscape.vegetation",
+                requestedOffset: 0,
+                requestedLimit: 32);
+
+            Assert.True(result.Succeeded, result.Message);
+            Assert.Equal("VEGETATION-FILE-ID", result.VegetationFileId);
+            Assert.Equal("SLVEG001", result.Format.Magic);
+            Assert.Equal((ulong)1, result.TotalInstanceCount);
+            var instance = Assert.Single(result.Instances);
+            Assert.Equal("0x1122334455667788", instance.StableId);
+            Assert.Equal((uint)1, instance.ProfileIndex);
+            Assert.True(instance.Enabled);
+            Assert.Equal(expectedMatrix, instance.Matrix);
+            Assert.Equal(-2, instance.LodBias);
+            Assert.Equal(0.75f, instance.CullDistanceScale);
+            Assert.Equal(1.5f, instance.ShadowDistanceScale);
+        }
+        finally
+        {
+            File.Delete(filepath);
+        }
+    }
+
+    static void U32(byte[] bytes, int offset, uint value) =>
+        BinaryPrimitives.WriteUInt32LittleEndian(
+            bytes.AsSpan(offset, sizeof(uint)), value);
+
+    static void I32(byte[] bytes, int offset, int value) =>
+        BinaryPrimitives.WriteInt32LittleEndian(
+            bytes.AsSpan(offset, sizeof(int)), value);
+
+    static void U64(byte[] bytes, int offset, ulong value) =>
+        BinaryPrimitives.WriteUInt64LittleEndian(
+            bytes.AsSpan(offset, sizeof(ulong)), value);
+
+    static void F32(byte[] bytes, int offset, float value) =>
+        I32(bytes, offset, BitConverter.SingleToInt32Bits(value));
+}

--- a/Editor/Mcp/LandscapeVegetationBinary.cs
+++ b/Editor/Mcp/LandscapeVegetationBinary.cs
@@ -1,0 +1,332 @@
+#nullable enable
+
+using System.Buffers.Binary;
+
+namespace SailorEditor.Mcp;
+
+public sealed record McpLandscapeVegetationFormatField(
+    string Name,
+    int Offset,
+    string Type,
+    string Description);
+
+public sealed record McpLandscapeVegetationFormat(
+    string Magic,
+    uint Version,
+    string ByteOrder,
+    uint EndianMarker,
+    uint HeaderSize,
+    uint ChunkRecordSize,
+    uint InstanceRecordSize,
+    string MatrixLayout,
+    string CoordinateSpace,
+    uint MaxChunksPerAxis,
+    uint MaxProfileCount,
+    ulong MaxInstanceCount,
+    IReadOnlyList<McpLandscapeVegetationFormatField> HeaderFields,
+    IReadOnlyList<McpLandscapeVegetationFormatField> ChunkFields,
+    IReadOnlyList<McpLandscapeVegetationFormatField> InstanceFields);
+
+public sealed record McpLandscapeVegetationInstance(
+    string StableId,
+    uint ChunkX,
+    uint ChunkZ,
+    uint ProfileIndex,
+    uint Flags,
+    bool Enabled,
+    IReadOnlyList<float> Matrix,
+    int LodBias,
+    float CullDistanceScale,
+    float ShadowDistanceScale);
+
+public sealed record McpLandscapeVegetationSnapshot(
+    bool Succeeded,
+    string Message,
+    string VegetationFileId,
+    string AssetPath,
+    McpLandscapeVegetationFormat Format,
+    uint ChunksX,
+    uint ChunksZ,
+    float ChunkSize,
+    uint ProfileCount,
+    uint ChunkCount,
+    ulong TotalInstanceCount,
+    ulong Offset,
+    int Count,
+    IReadOnlyList<McpLandscapeVegetationInstance> Instances);
+
+internal static class LandscapeVegetationBinary
+{
+    public const uint Version = 1;
+    public const uint EndianMarker = 0x01020304;
+    public const uint HeaderSize = 64;
+    public const uint ChunkRecordSize = 24;
+    public const uint InstanceRecordSize = 96;
+    public const uint EnabledFlag = 1;
+    public const uint MaxProfileCount = 1024;
+    public const ulong MaxInstanceCount = 16UL * 1024UL * 1024UL;
+    static readonly byte[] Magic = "SLVEG001"u8.ToArray();
+
+    public static McpLandscapeVegetationFormat Describe() => new(
+        "SLVEG001",
+        Version,
+        "little-endian",
+        EndianMarker,
+        HeaderSize,
+        ChunkRecordSize,
+        InstanceRecordSize,
+        "16 float32 values in column-major order",
+        "Landscape local space",
+        64,
+        MaxProfileCount,
+        MaxInstanceCount,
+        [
+            new("magic", 0, "char[8]", "ASCII SLVEG001"),
+            new("version", 8, "uint32", "Format version"),
+            new("endianMarker", 12, "uint32", "0x01020304"),
+            new("headerSize", 16, "uint32", "Header byte size"),
+            new("chunkRecordSize", 20, "uint32", "Chunk table stride"),
+            new("instanceRecordSize", 24, "uint32", "Instance table stride"),
+            new("chunksX", 28, "uint32", "Landscape chunk count on X"),
+            new("chunksZ", 32, "uint32", "Landscape chunk count on Z"),
+            new("profileCount", 36, "uint32", "Vegetation profile count when saved"),
+            new("chunkCount", 40, "uint32", "Canonical Z-major chunk record count"),
+            new("instanceCount", 44, "uint64", "Total instance record count"),
+            new("chunkSize", 52, "float32", "Landscape chunk size in local units"),
+            new("flags", 56, "uint32", "Bit 0: matrices use Landscape local space"),
+            new("reserved", 60, "uint32", "Must be zero in version 1")
+        ],
+        [
+            new("chunkX", 0, "uint32", "Chunk X coordinate"),
+            new("chunkZ", 4, "uint32", "Chunk Z coordinate"),
+            new("firstInstance", 8, "uint64", "First global instance record"),
+            new("instanceCount", 16, "uint32", "Records owned by this chunk"),
+            new("reserved", 20, "uint32", "Must be zero in version 1")
+        ],
+        [
+            new("stableId", 0, "uint64", "Non-zero identity unique inside the asset"),
+            new("profileIndex", 8, "uint32", "Index into Landscape vegetation profiles"),
+            new("flags", 12, "uint32", "Bit 0: instance is enabled"),
+            new("matrix", 16, "float32[16]", "Affine local transform, column-major; its origin belongs to the owning chunk"),
+            new("lodBias", 80, "int32", "Additional per-instance LOD bias"),
+            new("cullDistanceScale", 84, "float32", "Main/depth cull-distance multiplier"),
+            new("shadowDistanceScale", 88, "float32", "Shadow cull-distance multiplier"),
+            new("reserved", 92, "uint32", "Must be zero in version 1")
+        ]);
+
+    public static McpLandscapeVegetationSnapshot ReadPage(
+        string filepath,
+        string fileId,
+        string assetPath,
+        long requestedOffset,
+        int requestedLimit)
+    {
+        var format = Describe();
+        try
+        {
+            using var stream = new FileStream(
+                filepath,
+                FileMode.Open,
+                FileAccess.Read,
+                FileShare.ReadWrite | FileShare.Delete);
+            var header = ReadExactly(stream, checked((int)HeaderSize));
+            if (!header.AsSpan(0, Magic.Length).SequenceEqual(Magic))
+                throw new InvalidDataException("Landscape vegetation magic is invalid.");
+
+            var version = U32(header, 8);
+            var endian = U32(header, 12);
+            var headerSize = U32(header, 16);
+            var chunkStride = U32(header, 20);
+            var instanceStride = U32(header, 24);
+            var chunksX = U32(header, 28);
+            var chunksZ = U32(header, 32);
+            var profileCount = U32(header, 36);
+            var chunkCount = U32(header, 40);
+            var instanceCount = U64(header, 44);
+            var chunkSize = F32(header, 52);
+            var flags = U32(header, 56);
+            var headerReserved = U32(header, 60);
+            if (version != Version || endian != EndianMarker ||
+                headerSize != HeaderSize || chunkStride != ChunkRecordSize ||
+                instanceStride != InstanceRecordSize)
+            {
+                throw new InvalidDataException(
+                    "Landscape vegetation header is incompatible with format version 1.");
+            }
+            if (chunksX == 0 || chunksZ == 0 || chunksX > 64 || chunksZ > 64 ||
+                (ulong)chunksX * chunksZ != chunkCount ||
+                !float.IsFinite(chunkSize) || chunkSize <= 0 ||
+                flags != 1u || headerReserved != 0u ||
+                profileCount > MaxProfileCount ||
+                instanceCount > MaxInstanceCount)
+            {
+                throw new InvalidDataException("Landscape vegetation header values are invalid.");
+            }
+
+            var expectedLength = checked(
+                (ulong)HeaderSize +
+                (ulong)chunkCount * ChunkRecordSize +
+                instanceCount * InstanceRecordSize);
+            if ((ulong)stream.Length != expectedLength)
+                throw new InvalidDataException("Landscape vegetation file length does not match its header.");
+
+            var chunks = new List<(uint X, uint Z, ulong First, uint Count)>(
+                checked((int)chunkCount));
+            ulong expectedFirst = 0;
+            for (uint chunkIndex = 0; chunkIndex < chunkCount; ++chunkIndex)
+            {
+                var record = ReadExactly(stream, checked((int)ChunkRecordSize));
+                var chunkX = U32(record, 0);
+                var chunkZ = U32(record, 4);
+                var first = U64(record, 8);
+                var count = U32(record, 16);
+                var chunkReserved = U32(record, 20);
+                if (chunkX != chunkIndex % chunksX ||
+                    chunkZ != chunkIndex / chunksX ||
+                    first != expectedFirst || first > instanceCount ||
+                    count > instanceCount - first || chunkReserved != 0u)
+                {
+                    throw new InvalidDataException("Landscape vegetation chunk table is not canonical.");
+                }
+                chunks.Add((chunkX, chunkZ, first, count));
+                expectedFirst += count;
+            }
+            if (expectedFirst != instanceCount)
+                throw new InvalidDataException("Landscape vegetation chunk ranges are incomplete.");
+
+            var offset = (ulong)Math.Max(requestedOffset, 0);
+            offset = Math.Min(offset, instanceCount);
+            var limit = Math.Clamp(requestedLimit, 1, 4096);
+            var end = Math.Min(instanceCount, offset + (ulong)limit);
+            var instances = new List<McpLandscapeVegetationInstance>(
+                checked((int)(end - offset)));
+            var instanceTableOffset = (ulong)HeaderSize +
+                (ulong)chunkCount * ChunkRecordSize;
+            foreach (var chunk in chunks)
+            {
+                var chunkEnd = chunk.First + chunk.Count;
+                var first = Math.Max(offset, chunk.First);
+                var last = Math.Min(end, chunkEnd);
+                for (var globalIndex = first; globalIndex < last; ++globalIndex)
+                {
+                    stream.Position = checked((long)(instanceTableOffset +
+                        globalIndex * InstanceRecordSize));
+                    var record = ReadExactly(stream, checked((int)InstanceRecordSize));
+                    var stableId = U64(record, 0);
+                    var profileIndex = U32(record, 8);
+                    var instanceFlags = U32(record, 12);
+                    var instanceReserved = U32(record, 92);
+                    var matrix = new float[16];
+                    for (var matrixIndex = 0; matrixIndex < matrix.Length; ++matrixIndex)
+                    {
+                        matrix[matrixIndex] = F32(record, 16 + matrixIndex * sizeof(float));
+                        if (!float.IsFinite(matrix[matrixIndex]))
+                            throw new InvalidDataException("Landscape vegetation contains a non-finite matrix.");
+                    }
+                    const float affineEpsilon = 1.0e-5f;
+                    if (MathF.Abs(matrix[3]) > affineEpsilon ||
+                        MathF.Abs(matrix[7]) > affineEpsilon ||
+                        MathF.Abs(matrix[11]) > affineEpsilon ||
+                        MathF.Abs(matrix[15] - 1.0f) > affineEpsilon)
+                    {
+                        throw new InvalidDataException(
+                            "Landscape vegetation instance matrices must be affine transforms.");
+                    }
+                    var landscapeWidth = chunksX * chunkSize;
+                    var landscapeDepth = chunksZ * chunkSize;
+                    var chunkMinX = chunk.X * chunkSize - landscapeWidth * 0.5f;
+                    var chunkMinZ = chunk.Z * chunkSize - landscapeDepth * 0.5f;
+                    var placementEpsilon = MathF.Max(0.001f, chunkSize * 0.0001f);
+                    if (matrix[12] < chunkMinX - placementEpsilon ||
+                        matrix[12] > chunkMinX + chunkSize + placementEpsilon ||
+                        matrix[14] < chunkMinZ - placementEpsilon ||
+                        matrix[14] > chunkMinZ + chunkSize + placementEpsilon)
+                    {
+                        throw new InvalidDataException(
+                            "Landscape vegetation instance origin is outside its owning chunk.");
+                    }
+                    var cullScale = F32(record, 84);
+                    var shadowScale = F32(record, 88);
+                    if (stableId == 0 || profileIndex >= profileCount ||
+                        (instanceFlags & ~EnabledFlag) != 0 || instanceReserved != 0 ||
+                        !float.IsFinite(cullScale) || cullScale <= 0 ||
+                        !float.IsFinite(shadowScale) || shadowScale <= 0)
+                    {
+                        throw new InvalidDataException("Landscape vegetation contains an invalid instance record.");
+                    }
+                    instances.Add(new McpLandscapeVegetationInstance(
+                        $"0x{stableId:X16}",
+                        chunk.X,
+                        chunk.Z,
+                        profileIndex,
+                        instanceFlags,
+                        (instanceFlags & EnabledFlag) != 0,
+                        matrix,
+                        I32(record, 80),
+                        cullScale,
+                        shadowScale));
+                }
+            }
+
+            return new McpLandscapeVegetationSnapshot(
+                true,
+                "Landscape vegetation asset read successfully.",
+                fileId,
+                assetPath,
+                format,
+                chunksX,
+                chunksZ,
+                chunkSize,
+                profileCount,
+                chunkCount,
+                instanceCount,
+                offset,
+                instances.Count,
+                instances);
+        }
+        catch (Exception exception) when (
+            exception is IOException or UnauthorizedAccessException or
+            InvalidDataException or OverflowException)
+        {
+            return Failure(fileId, assetPath, exception.Message);
+        }
+    }
+
+    public static McpLandscapeVegetationSnapshot Failure(
+        string fileId,
+        string assetPath,
+        string message) => new(
+            false,
+            message,
+            fileId,
+            assetPath,
+            Describe(),
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            Array.Empty<McpLandscapeVegetationInstance>());
+
+    static byte[] ReadExactly(Stream stream, int count)
+    {
+        var result = new byte[count];
+        stream.ReadExactly(result);
+        return result;
+    }
+
+    static uint U32(byte[] bytes, int offset) =>
+        BinaryPrimitives.ReadUInt32LittleEndian(bytes.AsSpan(offset, sizeof(uint)));
+
+    static int I32(byte[] bytes, int offset) =>
+        BinaryPrimitives.ReadInt32LittleEndian(bytes.AsSpan(offset, sizeof(int)));
+
+    static ulong U64(byte[] bytes, int offset) =>
+        BinaryPrimitives.ReadUInt64LittleEndian(bytes.AsSpan(offset, sizeof(ulong)));
+
+    static float F32(byte[] bytes, int offset) =>
+        BitConverter.Int32BitsToSingle(I32(bytes, offset));
+}

--- a/Editor/Mcp/McpEditorTools.cs
+++ b/Editor/Mcp/McpEditorTools.cs
@@ -157,6 +157,25 @@ internal sealed class McpEditorTools
                 UseStructuredContent = true,
             }),
         McpServerTool.Create(
+            (string targetComponentId,
+                long offset,
+                int limit,
+                CancellationToken cancellationToken) =>
+                GetLandscapeVegetationAsync(
+                    targetComponentId,
+                    offset,
+                    limit,
+                    cancellationToken),
+            new()
+            {
+                Name = "sailor_landscape_get_vegetation",
+                Description =
+                    "Read the binary vegetation asset referenced by a LandscapeComponent and return its exact fileId, " +
+                    "versioned binary format and a paged list of per-instance matrices/settings. " +
+                    "Matrices are Landscape-local and column-major. offset is a global instance index; limit is clamped to 1..4096.",
+                UseStructuredContent = true,
+            }),
+        McpServerTool.Create(
             (McpLandscapeApplyRequest request, CancellationToken cancellationToken) =>
                 ApplyLandscapeAsync(request, cancellationToken),
             new()
@@ -166,6 +185,7 @@ internal sealed class McpEditorTools
                     "Create or fully author a LandscapeComponent from a level description. " +
                     "Resolve material, texture and model fileIds with sailor_assets_list/get first. " +
                     "The request replaces terrain stamps and all vegetation profiles atomically. " +
+                    "Set vegetationFileId to link an existing Landscape.vegetation binary asset. " +
                     "A vegetation materialFileId is optional; leave it empty to use the GLB materials. " +
                     "Vegetation shadows accept None, NearOnly, or All. Leave targetComponentId empty to create a new Landscape GameObject. " +
                     "Pass the current workspace epoch and confirm=true; the complete edit is one undo entry.",
@@ -185,7 +205,7 @@ internal sealed class McpEditorTools
             {
                 Name = "sailor_landscape_regenerate",
                 Description =
-                    "Regenerate terrain, vegetation, render proxies and collision for an existing LandscapeComponent. " +
+                    "Reload its linked Landscape.vegetation asset, then regenerate terrain, vegetation, render proxies and collision. " +
                     "Requires its component instance ID, the current workspace epoch and confirm=true.",
                 UseStructuredContent = true,
             }),
@@ -427,6 +447,18 @@ internal sealed class McpEditorTools
                 expectedWorkspaceEpoch,
                 targetComponentId,
                 cancellationToken),
+            cancellationToken);
+
+    public Task<McpLandscapeVegetationSnapshot> GetLandscapeVegetationAsync(
+        string targetComponentId,
+        long offset,
+        int limit,
+        CancellationToken cancellationToken = default) =>
+        _editorThread.InvokeAsync(
+            () => Task.FromResult(_landscapeOperations.GetVegetation(
+                targetComponentId,
+                offset,
+                limit)),
             cancellationToken);
 
     public Task<object> UndoAsync(

--- a/Editor/Mcp/McpLandscapeContracts.cs
+++ b/Editor/Mcp/McpLandscapeContracts.cs
@@ -67,6 +67,7 @@ public sealed record McpLandscapeApplyRequest
     public float[] LodDistances { get; init; } = [96.0f, 192.0f];
     public float LodSkirtDepth { get; init; } = 2.0f;
     public float GrassResidencyHysteresis { get; init; } = 12.0f;
+    public string VegetationFileId { get; init; } = string.Empty;
     public McpLandscapeVegetationProfile[] Vegetation { get; init; } = [];
     public McpLandscapeSculptStamp[] Sculpt { get; init; } = [];
     public McpLandscapePaintStamp[] Paint { get; init; } = [];

--- a/Editor/Mcp/McpLandscapeContracts.cs
+++ b/Editor/Mcp/McpLandscapeContracts.cs
@@ -8,6 +8,8 @@ public sealed record McpLandscapeVegetationProfile
     public string MaterialFileId { get; init; } = string.Empty;
     public int MeshIndex { get; init; } = -1;
     public uint InstancesPerChunk { get; init; } = 4;
+    public string Residency { get; init; } = "Persistent";
+    public float Priority { get; init; } = 1.0f;
     public float MinScale { get; init; } = 0.75f;
     public float MaxScale { get; init; } = 1.25f;
     public float GroundOffset { get; init; }
@@ -62,6 +64,10 @@ public sealed record McpLandscapeApplyRequest
     public string HeightmapTextureFileId { get; init; } = string.Empty;
     public string[] MaterialMaskFileIds { get; init; } = [];
     public float TextureTiling { get; init; } = 0.15f;
+    public float[] LodDistances { get; init; } = [96.0f, 192.0f];
+    public float LodSkirtDepth { get; init; } = 2.0f;
+    public uint GrassInstanceBudget { get; init; } = 32768;
+    public float GrassResidencyHysteresis { get; init; } = 12.0f;
     public McpLandscapeVegetationProfile[] Vegetation { get; init; } = [];
     public McpLandscapeSculptStamp[] Sculpt { get; init; } = [];
     public McpLandscapePaintStamp[] Paint { get; init; } = [];

--- a/Editor/Mcp/McpLandscapeContracts.cs
+++ b/Editor/Mcp/McpLandscapeContracts.cs
@@ -66,7 +66,6 @@ public sealed record McpLandscapeApplyRequest
     public float TextureTiling { get; init; } = 0.15f;
     public float[] LodDistances { get; init; } = [96.0f, 192.0f];
     public float LodSkirtDepth { get; init; } = 2.0f;
-    public uint GrassInstanceBudget { get; init; } = 32768;
     public float GrassResidencyHysteresis { get; init; } = 12.0f;
     public McpLandscapeVegetationProfile[] Vegetation { get; init; } = [];
     public McpLandscapeSculptStamp[] Sculpt { get; init; } = [];

--- a/Editor/Mcp/McpLandscapeOperations.cs
+++ b/Editor/Mcp/McpLandscapeOperations.cs
@@ -2,6 +2,8 @@
 
 using System.Text.Json;
 using SailorEditor.Commands;
+using SailorEditor.Services;
+using SailorEditor.Utility;
 
 namespace SailorEditor.Mcp;
 
@@ -11,13 +13,69 @@ internal sealed class McpLandscapeOperations
 
     readonly McpSceneBatchExecutor _sceneBatch;
     readonly ICommandHistoryService _history;
+    readonly WorldService _world;
+    readonly AssetsService _assets;
 
     public McpLandscapeOperations(
         McpSceneBatchExecutor sceneBatch,
-        ICommandHistoryService history)
+        ICommandHistoryService history,
+        WorldService world,
+        AssetsService assets)
     {
         _sceneBatch = sceneBatch;
         _history = history;
+        _world = world;
+        _assets = assets;
+    }
+
+    public McpLandscapeVegetationSnapshot GetVegetation(
+        string targetComponentId,
+        long offset,
+        int limit)
+    {
+        if (string.IsNullOrWhiteSpace(targetComponentId) ||
+            !_world.TryGetComponent(
+                new SailorEngine.InstanceId(targetComponentId.Trim()),
+                out var component) ||
+            !string.Equals(
+                component.Typename?.Name,
+                LandscapeComponentType,
+                StringComparison.Ordinal))
+        {
+            return LandscapeVegetationBinary.Failure(
+                string.Empty,
+                string.Empty,
+                "A valid LandscapeComponent instance ID is required.");
+        }
+        if (!component.OverrideProperties.TryGetValue(
+                "vegetation",
+                out var property) ||
+            property is not Observable<SailorEngine.FileId> vegetation ||
+            vegetation.Value is null ||
+            vegetation.Value.IsEmpty())
+        {
+            return LandscapeVegetationBinary.Failure(
+                string.Empty,
+                string.Empty,
+                "The LandscapeComponent does not reference a vegetation asset.");
+        }
+
+        var fileId = vegetation.Value.Value;
+        if (!_assets.Assets.TryGetValue(vegetation.Value, out var asset) ||
+            asset is not SailorEditor.ViewModels.LandscapeVegetationFile ||
+            asset.Asset is null)
+        {
+            return LandscapeVegetationBinary.Failure(
+                fileId,
+                string.Empty,
+                "The referenced vegetation asset is not available in the active project.");
+        }
+        return LandscapeVegetationBinary.ReadPage(
+            asset.Asset.FullName,
+            fileId,
+            asset.Asset.FullName,
+            offset,
+            limit);
     }
 
     public Task<McpSceneBatchResult> ApplyAsync(
@@ -224,6 +282,7 @@ internal sealed class McpLandscapeOperations
             ["lodDistances"] = JsonSerializer.SerializeToElement(request.LodDistances),
             ["lodSkirtDepth"] = JsonSerializer.SerializeToElement(request.LodSkirtDepth),
             ["grassResidencyHysteresis"] = JsonSerializer.SerializeToElement(request.GrassResidencyHysteresis),
+            ["vegetation"] = JsonSerializer.SerializeToElement(request.VegetationFileId ?? string.Empty),
             ["sculptStamps"] = JsonSerializer.SerializeToElement(sculptValues),
             ["paintStamps"] = JsonSerializer.SerializeToElement(paintValues),
             ["vegetationModels"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.ModelFileId)),
@@ -247,6 +306,7 @@ internal sealed class McpLandscapeOperations
             ["vegetationColliderOffsetY"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.ColliderOffsetY)),
             ["regenerate"] = JsonSerializer.SerializeToElement(false),
             ["flatten"] = JsonSerializer.SerializeToElement(false),
+            ["saveVegetation"] = JsonSerializer.SerializeToElement(false),
         };
 
         if (string.IsNullOrWhiteSpace(request.TargetComponentId))

--- a/Editor/Mcp/McpLandscapeOperations.cs
+++ b/Editor/Mcp/McpLandscapeOperations.cs
@@ -107,6 +107,21 @@ internal sealed class McpLandscapeOperations
             return Fail("noiseScale must be a finite positive number.", out error);
         if (!IsFinitePositive(request.TextureTiling))
             return Fail("textureTiling must be a finite positive number.", out error);
+        if (request.LodDistances is null || request.LodDistances.Length > 7 ||
+            request.LodDistances.Any(value => !IsFinitePositive(value)) ||
+            !request.LodDistances.SequenceEqual(request.LodDistances.Order()))
+        {
+            return Fail("lodDistances must contain at most seven finite positive values in ascending order.", out error);
+        }
+        if (!float.IsFinite(request.LodSkirtDepth) || request.LodSkirtDepth is < 0.0f or > 64.0f)
+            return Fail("lodSkirtDepth must be finite and between 0 and 64.", out error);
+        if (request.GrassInstanceBudget > 1048576)
+            return Fail("grassInstanceBudget cannot exceed 1048576.", out error);
+        if (!float.IsFinite(request.GrassResidencyHysteresis) ||
+            request.GrassResidencyHysteresis is < 0.0f or > 512.0f)
+        {
+            return Fail("grassResidencyHysteresis must be finite and between 0 and 512.", out error);
+        }
         if (string.IsNullOrWhiteSpace(request.MaterialFileId))
             return Fail("materialFileId is required.", out error);
         if (request.LayerTextureFileIds is null || request.LayerTextureFileIds.Length != 4 ||
@@ -122,6 +137,7 @@ internal sealed class McpLandscapeOperations
 
         var vegetation = request.Vegetation ?? [];
         var shadowModes = new List<float>(vegetation.Length);
+        var residencyModes = new List<float>(vegetation.Length);
         foreach (var profile in vegetation)
         {
             if (string.IsNullOrWhiteSpace(profile.ModelFileId))
@@ -132,6 +148,10 @@ internal sealed class McpLandscapeOperations
                 return Fail("vegetation instancesPerChunk cannot exceed 2048.", out error);
             if (profile.MeshIndex < -1)
                 return Fail("vegetation meshIndex must be -1 (all meshes) or a non-negative mesh index.", out error);
+            if (!TryParseResidency(profile.Residency, out var residencyMode))
+                return Fail("vegetation residency must be Persistent or Grass.", out error);
+            if (!float.IsFinite(profile.Priority) || profile.Priority is < 0.0f or > 100.0f)
+                return Fail("vegetation priority must be finite and between 0 and 100.", out error);
             if (!IsFinitePositive(profile.MinScale) ||
                 !IsFinitePositive(profile.MaxScale) ||
                 profile.MaxScale < profile.MinScale)
@@ -159,7 +179,10 @@ internal sealed class McpLandscapeOperations
             {
                 return Fail("vegetation collider requires radius >= 0, height >= 2 * radius, and a finite Y offset.", out error);
             }
+            if (residencyMode == 1.0f && profile.ColliderRadius > 0.0f)
+                return Fail("Grass vegetation cannot create colliders; use Persistent residency for collidable profiles.", out error);
             shadowModes.Add(shadowMode);
+            residencyModes.Add(residencyMode);
         }
 
         var sculptValues = new List<float>((request.Sculpt?.Length ?? 0) * 5);
@@ -200,12 +223,18 @@ internal sealed class McpLandscapeOperations
             ["heightmapTexture"] = JsonSerializer.SerializeToElement(request.HeightmapTextureFileId ?? string.Empty),
             ["materialMasks"] = JsonSerializer.SerializeToElement(request.MaterialMaskFileIds),
             ["textureTiling"] = JsonSerializer.SerializeToElement(request.TextureTiling),
+            ["lodDistances"] = JsonSerializer.SerializeToElement(request.LodDistances),
+            ["lodSkirtDepth"] = JsonSerializer.SerializeToElement(request.LodSkirtDepth),
+            ["grassInstanceBudget"] = JsonSerializer.SerializeToElement(request.GrassInstanceBudget),
+            ["grassResidencyHysteresis"] = JsonSerializer.SerializeToElement(request.GrassResidencyHysteresis),
             ["sculptStamps"] = JsonSerializer.SerializeToElement(sculptValues),
             ["paintStamps"] = JsonSerializer.SerializeToElement(paintValues),
             ["vegetationModels"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.ModelFileId)),
             ["vegetationMaterials"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.MaterialFileId)),
             ["vegetationMeshIndex"] = JsonSerializer.SerializeToElement(vegetation.Select(value => (float)value.MeshIndex)),
             ["vegetationInstancesPerChunk"] = JsonSerializer.SerializeToElement(vegetation.Select(value => (float)value.InstancesPerChunk)),
+            ["vegetationResidency"] = JsonSerializer.SerializeToElement(residencyModes),
+            ["vegetationPriority"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.Priority)),
             ["vegetationMinScale"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.MinScale)),
             ["vegetationMaxScale"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.MaxScale)),
             ["vegetationGroundOffset"] = JsonSerializer.SerializeToElement(vegetation.Select(value => value.GroundOffset)),
@@ -283,6 +312,17 @@ internal sealed class McpLandscapeOperations
             "none" => 0.0f,
             "nearonly" or "near_only" or "near only" => 1.0f,
             "all" => 2.0f,
+            _ => -1.0f,
+        };
+        return mode >= 0.0f;
+    }
+
+    static bool TryParseResidency(string value, out float mode)
+    {
+        mode = value?.Trim().ToLowerInvariant() switch
+        {
+            "persistent" => 0.0f,
+            "grass" or "budgeted" or "budgetedgrass" or "budgeted_grass" => 1.0f,
             _ => -1.0f,
         };
         return mode >= 0.0f;

--- a/Editor/Mcp/McpLandscapeOperations.cs
+++ b/Editor/Mcp/McpLandscapeOperations.cs
@@ -115,8 +115,6 @@ internal sealed class McpLandscapeOperations
         }
         if (!float.IsFinite(request.LodSkirtDepth) || request.LodSkirtDepth is < 0.0f or > 64.0f)
             return Fail("lodSkirtDepth must be finite and between 0 and 64.", out error);
-        if (request.GrassInstanceBudget > 1048576)
-            return Fail("grassInstanceBudget cannot exceed 1048576.", out error);
         if (!float.IsFinite(request.GrassResidencyHysteresis) ||
             request.GrassResidencyHysteresis is < 0.0f or > 512.0f)
         {
@@ -225,7 +223,6 @@ internal sealed class McpLandscapeOperations
             ["textureTiling"] = JsonSerializer.SerializeToElement(request.TextureTiling),
             ["lodDistances"] = JsonSerializer.SerializeToElement(request.LodDistances),
             ["lodSkirtDepth"] = JsonSerializer.SerializeToElement(request.LodSkirtDepth),
-            ["grassInstanceBudget"] = JsonSerializer.SerializeToElement(request.GrassInstanceBudget),
             ["grassResidencyHysteresis"] = JsonSerializer.SerializeToElement(request.GrassResidencyHysteresis),
             ["sculptStamps"] = JsonSerializer.SerializeToElement(sculptValues),
             ["paintStamps"] = JsonSerializer.SerializeToElement(paintValues),

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -389,7 +389,7 @@ namespace SailorEditor.Services
                 try
                 {
                     created = await MainThread.InvokeOnMainThreadAsync(() =>
-                        PublishCreatedAnimationAsset(
+                        PublishCreatedAsset(
                             sourcePath,
                             targetFolder,
                             fileId));
@@ -422,6 +422,126 @@ namespace SailorEditor.Services
             }
         }
 
+        public async Task<LandscapeVegetationFile?> CreateLandscapeVegetationAssetAsync(
+            string baseName,
+            CancellationToken cancellationToken = default)
+        {
+            if (string.IsNullOrWhiteSpace(CurrentProjectRootPath))
+            {
+                return null;
+            }
+
+            var destinationDirectory = Path.Combine(
+                CurrentProjectRootPath,
+                "Landscape",
+                "Vegetation");
+            if (!ProjectContentPathPolicy.IsInsideRoot(
+                    CurrentProjectRootPath,
+                    destinationDirectory))
+            {
+                return null;
+            }
+            Directory.CreateDirectory(destinationDirectory);
+
+            var filename = GetUniqueAssetName(
+                destinationDirectory,
+                string.IsNullOrWhiteSpace(baseName) ? "Landscape" : baseName.Trim(),
+                ".vegetation");
+            var sourcePath = Path.Combine(destinationDirectory, filename);
+            var fileId = new FileId(
+                Guid.NewGuid().ToString().ToUpperInvariant());
+            var metadataContents = SerializeLandscapeVegetationAssetInfo(
+                fileId,
+                filename);
+
+            await _assetSaveLock.WaitAsync(cancellationToken)
+                .ConfigureAwait(false);
+            try
+            {
+                ProjectContentAssetWriteTransaction transaction;
+                (FileSystemWatcher Watcher, bool Enabled)[] watcherStates;
+                lock (_watcherLock)
+                {
+                    watcherStates = _contentWatchers
+                        .Select(watcher =>
+                            (watcher, watcher.EnableRaisingEvents))
+                        .ToArray();
+                    foreach (var watcherState in watcherStates)
+                    {
+                        watcherState.Watcher.EnableRaisingEvents = false;
+                    }
+                }
+
+                try
+                {
+                    transaction = _fileOperations.BeginWriteAssetPair(
+                        CurrentProjectRootPath,
+                        sourcePath,
+                        string.Empty,
+                        metadataContents,
+                        fileId.Value,
+                        overwrite: false);
+                }
+                finally
+                {
+                    lock (_watcherLock)
+                    {
+                        foreach (var watcherState in watcherStates)
+                        {
+                            if (_contentWatchers.Contains(watcherState.Watcher))
+                            {
+                                watcherState.Watcher.EnableRaisingEvents =
+                                    watcherState.Enabled;
+                            }
+                        }
+                    }
+                }
+
+                if (!transaction.Result.Succeeded)
+                {
+                    return null;
+                }
+
+                AssetFile? created;
+                try
+                {
+                    created = await MainThread.InvokeOnMainThreadAsync(() =>
+                        PublishCreatedAsset(
+                            sourcePath,
+                            targetFolder: null,
+                            fileId));
+                }
+                catch
+                {
+                    transaction.Rollback();
+                    throw;
+                }
+                if (created is not LandscapeVegetationFile vegetation)
+                {
+                    transaction.Rollback();
+                    return null;
+                }
+
+                var commit = transaction.Commit();
+                if (!commit.Succeeded)
+                {
+                    await MainThread.InvokeOnMainThreadAsync(Refresh);
+                    return null;
+                }
+
+                if (_engineService.IsRunning)
+                {
+                    await _engineService.RequestAssetReloadAsync(cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                return vegetation;
+            }
+            finally
+            {
+                _assetSaveLock.Release();
+            }
+        }
+
         AssetFile? FindAssetBySourcePath(string sourcePath) =>
             Files.FirstOrDefault(asset =>
                 asset.Asset is not null &&
@@ -429,7 +549,7 @@ namespace SailorEditor.Services
                     asset.Asset.FullName,
                     sourcePath));
 
-        AssetFile? PublishCreatedAnimationAsset(
+        AssetFile? PublishCreatedAsset(
             string sourcePath,
             AssetFolder? targetFolder,
             FileId expectedFileId)
@@ -540,6 +660,16 @@ namespace SailorEditor.Services
             };
             return SaveYaml(root);
         }
+
+        static string SerializeLandscapeVegetationAssetInfo(
+            FileId fileId,
+            string filename) => SaveYaml(
+            new YamlMappingNode
+            {
+                { "assetInfoType", "Sailor::LandscapeVegetationAssetInfo" },
+                { "fileId", fileId.Value },
+                { "filename", filename }
+            });
 
         static string CreateAnimationSetSource() => SaveYaml(
             new YamlMappingNode
@@ -2031,6 +2161,7 @@ namespace SailorEditor.Services
                 "Sailor::ShaderAssetInfo" => new ShaderFile(),
                 "Sailor::MaterialAssetInfo" => new MaterialFile(),
                 "Sailor::FrameGraphAssetInfo" => new FrameGraphFile(),
+                "Sailor::LandscapeVegetationAssetInfo" => new LandscapeVegetationFile(),
                 _ => CreateAssetFileByExtension(extension)
             };
             assetFile.AssetInfoTypeName = assetInfoType;
@@ -2086,6 +2217,7 @@ namespace SailorEditor.Services
             ".shader" => new ShaderFile(),
             ".mat" => new MaterialFile(),
             ".renderer" => new FrameGraphFile(),
+            ".vegetation" => new LandscapeVegetationFile(),
             ".glsl" => new ShaderLibraryFile(),
             _ => new AssetFile()
         };

--- a/Editor/Settings/GraphicsSettings.cs
+++ b/Editor/Settings/GraphicsSettings.cs
@@ -49,6 +49,7 @@ public sealed record GraphicsQualityPresetSettings
     public bool SupportSoftShadows { get; init; }
     public double CloudsResolutionMultiplier { get; init; }
     public int SkyResolution { get; init; }
+    public int VegetationInstanceBudget { get; init; }
     public int LodBias { get; init; }
 }
 
@@ -129,6 +130,7 @@ public static class GraphicsSettingsDefaults
             SupportSoftShadows = true,
             CloudsResolutionMultiplier = 1.0,
             SkyResolution = 512,
+            VegetationInstanceBudget = 65536,
             LodBias = -1
         },
         High = new GraphicsQualityPresetSettings
@@ -143,6 +145,7 @@ public static class GraphicsSettingsDefaults
             SupportSoftShadows = true,
             CloudsResolutionMultiplier = 0.75,
             SkyResolution = 256,
+            VegetationInstanceBudget = 32768,
             LodBias = 0
         },
         Medium = new GraphicsQualityPresetSettings
@@ -157,6 +160,7 @@ public static class GraphicsSettingsDefaults
             SupportSoftShadows = true,
             CloudsResolutionMultiplier = 0.5,
             SkyResolution = 256,
+            VegetationInstanceBudget = 16384,
             LodBias = 0
         },
         Low = new GraphicsQualityPresetSettings
@@ -171,6 +175,7 @@ public static class GraphicsSettingsDefaults
             SupportSoftShadows = false,
             CloudsResolutionMultiplier = 0.25,
             SkyResolution = 128,
+            VegetationInstanceBudget = 8192,
             LodBias = 1
         },
         VeryLow = new GraphicsQualityPresetSettings
@@ -185,6 +190,7 @@ public static class GraphicsSettingsDefaults
             SupportSoftShadows = false,
             CloudsResolutionMultiplier = 0.125,
             SkyResolution = 64,
+            VegetationInstanceBudget = 2048,
             LodBias = 2
         }
     };
@@ -383,6 +389,15 @@ public static class GraphicsSettingsValidator
                 "Sky resolution must be a power of two between 32 and 8192."));
         }
 
+        if (preset.VegetationInstanceBudget is < 0 or > 1048576)
+        {
+            AddRangeIssue(
+                issues,
+                $"{path}.vegetationInstanceBudget",
+                "Vegetation instance budget",
+                "0 and 1048576");
+        }
+
         if (preset.LodBias is < -8 or > 8)
         {
             AddRangeIssue(issues, $"{path}.lodBias", "LOD bias", "-8 and 8");
@@ -544,6 +559,7 @@ public static class GraphicsSettingsYamlCodec
                 presetsNode,
                 quality.ToString(),
                 $"graphics.presets.{quality}",
+                GraphicsSettingsDefaults.Presets.Get(quality),
                 issues);
             presets = presets.With(quality, preset);
         }
@@ -667,6 +683,7 @@ public static class GraphicsSettingsYamlCodec
         YamlMappingNode parent,
         string key,
         string path,
+        GraphicsQualityPresetSettings defaults,
         ICollection<GraphicsSettingsValidationIssue> issues)
     {
         var preset = ReadMapping(parent, key, path, issues);
@@ -682,6 +699,12 @@ public static class GraphicsSettingsYamlCodec
             SupportSoftShadows = ReadBool(preset, "supportSoftShadows", $"{path}.supportSoftShadows", issues),
             CloudsResolutionMultiplier = ReadDouble(preset, "cloudsResolutionMultiplier", $"{path}.cloudsResolutionMultiplier", issues),
             SkyResolution = ReadInt(preset, "skyResolution", $"{path}.skyResolution", issues),
+            VegetationInstanceBudget = ReadOptionalInt(
+                preset,
+                "vegetationInstanceBudget",
+                $"{path}.vegetationInstanceBudget",
+                defaults.VegetationInstanceBudget,
+                issues),
             LodBias = ReadInt(preset, "lodBias", $"{path}.lodBias", issues)
         };
     }
@@ -704,6 +727,7 @@ public static class GraphicsSettingsYamlCodec
         SetScalar(preset, "supportSoftShadows", settings.SupportSoftShadows);
         SetScalar(preset, "cloudsResolutionMultiplier", settings.CloudsResolutionMultiplier);
         SetScalar(preset, "skyResolution", settings.SkyResolution);
+        SetScalar(preset, "vegetationInstanceBudget", settings.VegetationInstanceBudget);
         SetScalar(preset, "lodBias", settings.LodBias);
     }
 
@@ -757,6 +781,33 @@ public static class GraphicsSettingsYamlCodec
 
         if (value is not null)
             issues.Add(new GraphicsSettingsValidationIssue(path, "An integer value is required."));
+        return 0;
+    }
+
+    static int ReadOptionalInt(
+        YamlMappingNode? parent,
+        string key,
+        string path,
+        int defaultValue,
+        ICollection<GraphicsSettingsValidationIssue> issues)
+    {
+        if (parent is null ||
+            !parent.Children.TryGetValue(new YamlScalarNode(key), out var node))
+        {
+            return defaultValue;
+        }
+        if (node is YamlScalarNode scalar &&
+            scalar.Value is not null &&
+            int.TryParse(
+                scalar.Value,
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var parsed))
+        {
+            return parsed;
+        }
+
+        issues.Add(new GraphicsSettingsValidationIssue(path, "An integer value is required."));
         return 0;
     }
 

--- a/Editor/Settings/GraphicsSettingsDraft.cs
+++ b/Editor/Settings/GraphicsSettingsDraft.cs
@@ -13,6 +13,7 @@ public sealed record GraphicsQualityPresetDraft(
     bool SupportSoftShadows,
     string CloudsResolutionMultiplier,
     string SkyResolution,
+    string VegetationInstanceBudget,
     string LodBias)
 {
     public static GraphicsQualityPresetDraft FromSettings(
@@ -28,6 +29,7 @@ public sealed record GraphicsQualityPresetDraft(
             settings.SupportSoftShadows,
             FormatDouble(settings.CloudsResolutionMultiplier),
             settings.SkyResolution.ToString(CultureInfo.InvariantCulture),
+            settings.VegetationInstanceBudget.ToString(CultureInfo.InvariantCulture),
             settings.LodBias.ToString(CultureInfo.InvariantCulture));
 
     internal bool TryBuild(
@@ -73,6 +75,12 @@ public sealed record GraphicsQualityPresetDraft(
             issues,
             out var skyResolution);
         valid &= TryParseInt(
+            VegetationInstanceBudget,
+            $"{path}.vegetationInstanceBudget",
+            "Vegetation instance budget",
+            issues,
+            out var vegetationInstanceBudget);
+        valid &= TryParseInt(
             LodBias,
             $"{path}.lodBias",
             "LOD bias",
@@ -91,6 +99,7 @@ public sealed record GraphicsQualityPresetDraft(
             SupportSoftShadows = SupportSoftShadows,
             CloudsResolutionMultiplier = cloudsResolutionMultiplier,
             SkyResolution = skyResolution,
+            VegetationInstanceBudget = vegetationInstanceBudget,
             LodBias = lodBias
         };
         return valid;

--- a/Editor/Settings/GraphicsSettingsService.cs
+++ b/Editor/Settings/GraphicsSettingsService.cs
@@ -869,5 +869,6 @@ static class GraphicsSettingsEquality
             left.CloudsResolutionMultiplier.Equals(
                 right.CloudsResolutionMultiplier) &&
             left.SkyResolution == right.SkyResolution &&
+            left.VegetationInstanceBudget == right.VegetationInstanceBudget &&
             left.LodBias == right.LodBias;
 }

--- a/Editor/ViewModels/AssetFile.cs
+++ b/Editor/ViewModels/AssetFile.cs
@@ -393,6 +393,7 @@ public partial class AssetFile : ObservableObject, ICloneable
             AnimationSetFile => "Sailor::AnimationSetAssetInfo",
             AudioFile => "Sailor::AudioAssetInfo",
             FrameGraphFile => "Sailor::FrameGraphAssetInfo",
+            LandscapeVegetationFile => "Sailor::LandscapeVegetationAssetInfo",
             MaterialFile => "Sailor::MaterialAssetInfo",
             ModelFile => "Sailor::ModelAssetInfo",
             PrefabFile => "Sailor::PrefabAssetInfo",

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -322,6 +322,18 @@ public class ComponentYamlConverter : IYamlTypeConverter
         {
             component.OverrideProperties["grassResidencyHysteresis"] = new Observable<float>(12.0f);
         }
+        if (component.Typename.Properties.ContainsKey("vegetation") &&
+            !component.OverrideProperties.ContainsKey("vegetation"))
+        {
+            component.OverrideProperties["vegetation"] =
+                new Observable<FileId>(new FileId());
+        }
+        if (component.Typename.Properties.ContainsKey("saveVegetation") &&
+            !component.OverrideProperties.ContainsKey("saveVegetation"))
+        {
+            component.OverrideProperties["saveVegetation"] =
+                new Observable<bool>(false);
+        }
 
         if (!component.OverrideProperties.TryGetValue(
                 "vegetationModels",

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -306,6 +306,28 @@ public class ComponentYamlConverter : IYamlTypeConverter
             component.OverrideProperties["materialMasks"] = new ObservableFileIdList();
         }
 
+        if (component.Typename.Properties.ContainsKey("lodDistances") &&
+            !component.OverrideProperties.ContainsKey("lodDistances"))
+        {
+            component.OverrideProperties["lodDistances"] =
+                new ObservableFloatList([96.0f, 192.0f]);
+        }
+        if (component.Typename.Properties.ContainsKey("lodSkirtDepth") &&
+            !component.OverrideProperties.ContainsKey("lodSkirtDepth"))
+        {
+            component.OverrideProperties["lodSkirtDepth"] = new Observable<float>(2.0f);
+        }
+        if (component.Typename.Properties.ContainsKey("grassInstanceBudget") &&
+            !component.OverrideProperties.ContainsKey("grassInstanceBudget"))
+        {
+            component.OverrideProperties["grassInstanceBudget"] = new Observable<uint>(32768u);
+        }
+        if (component.Typename.Properties.ContainsKey("grassResidencyHysteresis") &&
+            !component.OverrideProperties.ContainsKey("grassResidencyHysteresis"))
+        {
+            component.OverrideProperties["grassResidencyHysteresis"] = new Observable<float>(12.0f);
+        }
+
         if (!component.OverrideProperties.TryGetValue(
                 "vegetationModels",
                 out var modelsProperty) ||
@@ -317,6 +339,8 @@ public class ComponentYamlConverter : IYamlTypeConverter
         (string Name, float DefaultValue)[] properties =
         [
             ("vegetationMeshIndex", -1.0f),
+            ("vegetationResidency", 0.0f),
+            ("vegetationPriority", 1.0f),
             ("vegetationMinLod", 0.0f),
             ("vegetationMaxLod", 2.0f),
             ("vegetationLod1ScreenCoverage", 0.25f),

--- a/Editor/ViewModels/Component.cs
+++ b/Editor/ViewModels/Component.cs
@@ -317,11 +317,6 @@ public class ComponentYamlConverter : IYamlTypeConverter
         {
             component.OverrideProperties["lodSkirtDepth"] = new Observable<float>(2.0f);
         }
-        if (component.Typename.Properties.ContainsKey("grassInstanceBudget") &&
-            !component.OverrideProperties.ContainsKey("grassInstanceBudget"))
-        {
-            component.OverrideProperties["grassInstanceBudget"] = new Observable<uint>(32768u);
-        }
         if (component.Typename.Properties.ContainsKey("grassResidencyHysteresis") &&
             !component.OverrideProperties.ContainsKey("grassResidencyHysteresis"))
         {

--- a/Editor/ViewModels/LandscapeVegetationFile.cs
+++ b/Editor/ViewModels/LandscapeVegetationFile.cs
@@ -1,0 +1,5 @@
+namespace SailorEditor.ViewModels;
+
+public sealed class LandscapeVegetationFile : AssetFile
+{
+}

--- a/Editor/Views/ContentFolderView.xaml.cs
+++ b/Editor/Views/ContentFolderView.xaml.cs
@@ -1135,6 +1135,7 @@ namespace SailorEditor.Views
             ShaderFile or ShaderLibraryFile => "script_24.png",
             MaterialFile => "color_swatch_24.png",
             FrameGraphFile => "application_sidebar_list_24.png",
+            LandscapeVegetationFile => "document_24.png",
             _ => "document_24.png"
         };
 

--- a/Editor/Views/InspectorView/ComponentTemplate.Landscape.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.Landscape.cs
@@ -80,10 +80,34 @@ public partial class ComponentTemplate
             }
         };
 
+        var saveVegetation = new Button
+        {
+            Text = "Save Vegetation"
+        };
+        ToolTipProperties.SetText(
+            saveVegetation,
+            "Create or update the binary vegetation asset referenced by this Landscape");
+        saveVegetation.Clicked += async (_, _) =>
+        {
+            saveVegetation.IsEnabled = false;
+            var previousText = saveVegetation.Text;
+            saveVegetation.Text = "Saving…";
+            try
+            {
+                await SaveLandscapeVegetationAsync(component);
+            }
+            finally
+            {
+                saveVegetation.Text = previousText;
+                saveVegetation.IsEnabled = true;
+            }
+        };
+
         var toolbar = new Grid
         {
             ColumnDefinitions =
             {
+                new ColumnDefinition(GridLength.Star),
                 new ColumnDefinition(GridLength.Star),
                 new ColumnDefinition(GridLength.Star),
                 new ColumnDefinition(GridLength.Star)
@@ -93,6 +117,7 @@ public partial class ComponentTemplate
         toolbar.Add(generate, 0, 0);
         toolbar.Add(regenerate, 1, 0);
         toolbar.Add(flatten, 2, 0);
+        toolbar.Add(saveVegetation, 3, 0);
         Templates.AddGridRow(props, toolbar, GridLength.Auto);
         Grid.SetColumnSpan(toolbar, props.ColumnDefinitions.Count);
 
@@ -104,6 +129,60 @@ public partial class ComponentTemplate
         };
         Templates.AddGridRow(props, hint, GridLength.Auto);
         Grid.SetColumnSpan(hint, props.ColumnDefinitions.Count);
+    }
+
+    static async Task SaveLandscapeVegetationAsync(Component component)
+    {
+        var shell = MauiProgram.GetService<EditorShellHost>();
+        if (!component.OverrideProperties.TryGetValue(
+                "vegetation",
+                out var vegetationProperty) ||
+            vegetationProperty is not Observable<FileId> vegetation)
+        {
+            shell.SetStatus("Landscape vegetation property is unavailable.");
+            return;
+        }
+
+        if (vegetation.Value is null || vegetation.Value.IsEmpty())
+        {
+            var world = MauiProgram.GetService<WorldService>();
+            var ownerName = world.FindOwner(component)?.Name ?? "Landscape";
+            var created = await MauiProgram.GetService<AssetsService>()
+                .CreateLandscapeVegetationAssetAsync(ownerName);
+            if (created?.FileId is null || created.FileId.IsEmpty())
+            {
+                shell.SetStatus("Failed to create the Landscape vegetation asset.");
+                return;
+            }
+
+            var linked = await component.ApplyInspectorBatchAsync(() =>
+                vegetation.Value = new FileId(created.FileId.Value));
+            if (!linked)
+            {
+                shell.SetStatus("Vegetation asset was created, but the Landscape link failed.");
+                return;
+            }
+        }
+
+        if (!component.OverrideProperties.TryGetValue(
+                "saveVegetation",
+                out var actionProperty) ||
+            actionProperty is not Observable<bool> action)
+        {
+            shell.SetStatus("Landscape Save Vegetation action is unavailable.");
+            return;
+        }
+
+        var requested = await component.ApplyInspectorBatchAsync(() =>
+            action.Value = true);
+        await component.ApplyInspectorBatchAsync(() =>
+            action.Value = false);
+        if (!requested)
+        {
+            shell.SetStatus("Failed to request the Landscape vegetation save.");
+            return;
+        }
+        shell.SetStatus($"Vegetation save requested for {vegetation.Value.Value}.");
     }
 
     static async Task RebuildLandscapeAsync(Component component, bool advanceSeed)
@@ -288,7 +367,7 @@ public partial class ComponentTemplate
                     component, instancesPerChunk.Values[index], value => MathF.Max(0.0f, MathF.Round(value))));
                 var residencyPicker = new Picker
                 {
-                    ItemsSource = new[] { "Persistent", "Grass (budgeted)" },
+                    ItemsSource = new[] { "Persistent", "Frame budget" },
                     SelectedIndex = Math.Clamp((int)residency.Values[index].Value, 0, 1),
                     FontSize = 12,
                     BindingContext = component

--- a/Editor/Views/InspectorView/ComponentTemplate.Landscape.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.Landscape.cs
@@ -137,6 +137,8 @@ public partial class ComponentTemplate
                 out var materials,
                 out var meshIndex,
                 out var instancesPerChunk,
+                out var residency,
+                out var priority,
                 out var minScale,
                 out var maxScale,
                 out var groundOffset,
@@ -192,6 +194,8 @@ public partial class ComponentTemplate
                 materials.Values.Count,
                 meshIndex.Values.Count,
                 instancesPerChunk.Values.Count,
+                residency.Values.Count,
+                priority.Values.Count,
                 minScale.Values.Count,
                 maxScale.Values.Count,
                 groundOffset.Values.Count,
@@ -256,7 +260,8 @@ public partial class ComponentTemplate
                     await component.ApplyInspectorBatchAsync(() =>
                     {
                         RemoveLandscapeVegetationProfile(index, models, materials,
-                            meshIndex, instancesPerChunk, minScale, maxScale, groundOffset,
+                            meshIndex, instancesPerChunk, residency, priority,
+                            minScale, maxScale, groundOffset,
                             shadowMode, shadowDistance, minLod, maxLod,
                             lod1ScreenCoverage, lod2ScreenCoverage, cullDistance,
                             colliderRadius, colliderHeight, colliderOffsetY);
@@ -281,6 +286,23 @@ public partial class ComponentTemplate
                     component, meshIndex.Values[index], value => MathF.Max(-1.0f, MathF.Round(value))));
                 AddVegetationField(card, "Per chunk", CreateLandscapeFloatEditor(
                     component, instancesPerChunk.Values[index], value => MathF.Max(0.0f, MathF.Round(value))));
+                var residencyPicker = new Picker
+                {
+                    ItemsSource = new[] { "Persistent", "Grass (budgeted)" },
+                    SelectedIndex = Math.Clamp((int)residency.Values[index].Value, 0, 1),
+                    FontSize = 12,
+                    BindingContext = component
+                };
+                residencyPicker.SelectedIndexChanged += (_, _) =>
+                {
+                    if (residencyPicker.SelectedIndex < 0)
+                        return;
+                    residency.Values[index].Value = residencyPicker.SelectedIndex;
+                    _ = component.CommitInspectorChangesAsync();
+                };
+                AddVegetationField(card, "Residency", residencyPicker);
+                AddVegetationField(card, "Priority", CreateLandscapeFloatEditor(
+                    component, priority.Values[index], value => Math.Clamp(value, 0.0f, 100.0f)));
                 AddVegetationField(card, "Min scale", CreateLandscapeFloatEditor(
                     component, minScale.Values[index], value => MathF.Max(0.01f, value)));
                 AddVegetationField(card, "Max scale", CreateLandscapeFloatEditor(
@@ -337,6 +359,8 @@ public partial class ComponentTemplate
                     materials.Values.Add(new Observable<FileId>(new FileId()));
                     meshIndex.Values.Add(new Observable<float>(-1.0f));
                     instancesPerChunk.Values.Add(new Observable<float>(4.0f));
+                    residency.Values.Add(new Observable<float>(0.0f));
+                    priority.Values.Add(new Observable<float>(1.0f));
                     minScale.Values.Add(new Observable<float>(0.75f));
                     maxScale.Values.Add(new Observable<float>(1.25f));
                     groundOffset.Values.Add(new Observable<float>(0.0f));
@@ -527,6 +551,8 @@ public partial class ComponentTemplate
         ObservableFileIdList materials,
         ObservableFloatList meshIndex,
         ObservableFloatList instancesPerChunk,
+        ObservableFloatList residency,
+        ObservableFloatList priority,
         ObservableFloatList minScale,
         ObservableFloatList maxScale,
         ObservableFloatList groundOffset,
@@ -545,6 +571,8 @@ public partial class ComponentTemplate
         materials.Values.RemoveAt(index);
         meshIndex.Values.RemoveAt(index);
         instancesPerChunk.Values.RemoveAt(index);
+        residency.Values.RemoveAt(index);
+        priority.Values.RemoveAt(index);
         minScale.Values.RemoveAt(index);
         maxScale.Values.RemoveAt(index);
         groundOffset.Values.RemoveAt(index);
@@ -566,6 +594,8 @@ public partial class ComponentTemplate
         out ObservableFileIdList materials,
         out ObservableFloatList meshIndex,
         out ObservableFloatList instancesPerChunk,
+        out ObservableFloatList residency,
+        out ObservableFloatList priority,
         out ObservableFloatList minScale,
         out ObservableFloatList maxScale,
         out ObservableFloatList groundOffset,
@@ -584,6 +614,8 @@ public partial class ComponentTemplate
         component.OverrideProperties.TryGetValue("vegetationMaterials", out var materialsProperty);
         component.OverrideProperties.TryGetValue("vegetationMeshIndex", out var meshIndexProperty);
         component.OverrideProperties.TryGetValue("vegetationInstancesPerChunk", out var instancesPerChunkProperty);
+        component.OverrideProperties.TryGetValue("vegetationResidency", out var residencyProperty);
+        component.OverrideProperties.TryGetValue("vegetationPriority", out var priorityProperty);
         component.OverrideProperties.TryGetValue("vegetationMinScale", out var minScaleProperty);
         component.OverrideProperties.TryGetValue("vegetationMaxScale", out var maxScaleProperty);
         component.OverrideProperties.TryGetValue("vegetationGroundOffset", out var groundOffsetProperty);
@@ -602,6 +634,8 @@ public partial class ComponentTemplate
         materials = materialsProperty as ObservableFileIdList;
         meshIndex = meshIndexProperty as ObservableFloatList;
         instancesPerChunk = instancesPerChunkProperty as ObservableFloatList;
+        residency = residencyProperty as ObservableFloatList;
+        priority = priorityProperty as ObservableFloatList;
         minScale = minScaleProperty as ObservableFloatList;
         maxScale = maxScaleProperty as ObservableFloatList;
         groundOffset = groundOffsetProperty as ObservableFloatList;
@@ -619,6 +653,8 @@ public partial class ComponentTemplate
         {
             EnsureLandscapeProfileLength(materials, models.Values.Count);
             EnsureLandscapeProfileLength(meshIndex, models.Values.Count, -1.0f);
+            EnsureLandscapeProfileLength(residency, models.Values.Count, 0.0f);
+            EnsureLandscapeProfileLength(priority, models.Values.Count, 1.0f);
             EnsureLandscapeProfileLength(minLod, models.Values.Count, 0.0f);
             EnsureLandscapeProfileLength(maxLod, models.Values.Count, 2.0f);
             EnsureLandscapeProfileLength(lod1ScreenCoverage, models.Values.Count, 0.25f);
@@ -629,7 +665,8 @@ public partial class ComponentTemplate
             EnsureLandscapeProfileLength(colliderOffsetY, models.Values.Count, 1.0f);
         }
         return models is not null && materials is not null && meshIndex is not null &&
-            instancesPerChunk is not null && minScale is not null &&
+            instancesPerChunk is not null && residency is not null && priority is not null &&
+            minScale is not null &&
             maxScale is not null && groundOffset is not null &&
             shadowMode is not null && shadowDistance is not null &&
             minLod is not null && maxLod is not null &&

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -371,7 +371,8 @@ public partial class ComponentTemplate : DataTemplate
                     "layerTextures" or "heightmapTexture" or "materialMasks" or
                     "vegetationModels" or "vegetationMaterials" or
                     "vegetationMeshIndex" or
-                    "vegetationInstancesPerChunk" or "vegetationMinScale" or
+                    "vegetationInstancesPerChunk" or "vegetationResidency" or
+                    "vegetationPriority" or "vegetationMinScale" or
                     "vegetationMaxScale" or "vegetationGroundOffset" or
                     "vegetationShadowMode" or "vegetationShadowDistance" or
                     "vegetationMinLod" or "vegetationMaxLod" or

--- a/Editor/Views/InspectorView/ComponentTemplate.cs
+++ b/Editor/Views/InspectorView/ComponentTemplate.cs
@@ -247,7 +247,12 @@ public partial class ComponentTemplate : DataTemplate
                                 Vec4 vec4 => Templates.Vec4Editor((Component vm) => vec4),
                                 Vec3 vec3 => Templates.Vec3Editor((Component vm) => vec3),
                                 Vec2 vec2 => Templates.Vec2Editor((Component vm) => vec2),
-                                Observable<FileId> observableFileId => Templates.FileIdEditor(component.OverrideProperties[property.Key], nameof(Observable<FileId>.Value), (Observable<FileId> vm) => vm.Value, (vm, value) => vm.Value = value),
+                                Observable<FileId> observableFileId => Templates.FileIdEditor(
+                                    component.OverrideProperties[property.Key],
+                                    nameof(Observable<FileId>.Value),
+                                    (Observable<FileId> vm) => vm.Value,
+                                    (vm, value) => vm.Value = value,
+                                    ResolveFileIdSupportedType(component, property.Key)),
                                 ObservableFileIdList fileIds => Templates.FileIdListEditor(
                                     fileIds,
                                     ResolveFileIdListSupportedType(
@@ -379,7 +384,7 @@ public partial class ComponentTemplate : DataTemplate
                     "vegetationLod1ScreenCoverage" or "vegetationLod2ScreenCoverage" or
                     "vegetationCullDistance" or "vegetationColliderRadius" or
                     "vegetationColliderHeight" or "vegetationColliderOffsetY" or
-                    "regenerate" or "flatten")
+                    "regenerate" or "flatten" or "saveVegetation")
                 {
                     continue;
                 }
@@ -430,6 +435,21 @@ public partial class ComponentTemplate : DataTemplate
                 propertyName == "layerTextures"
                 ? typeof(TextureFile)
                 : null;
+    }
+
+    static Type ResolveFileIdSupportedType(
+        Component component,
+        string propertyName)
+    {
+        if (component.Typename.Name != "Sailor::LandscapeComponent")
+        {
+            return null;
+        }
+        return propertyName switch
+        {
+            "vegetation" => typeof(LandscapeVegetationFile),
+            _ => null
+        };
     }
 
     static Command CreateContextMenuCommand(

--- a/Editor/Views/SettingsPanelView.cs
+++ b/Editor/Views/SettingsPanelView.cs
@@ -919,6 +919,7 @@ public sealed class SettingsPanelView : ContentView
         readonly Switch _supportSoftShadows;
         readonly Entry _cloudsResolutionMultiplier;
         readonly Entry _skyResolution;
+        readonly Entry _vegetationInstanceBudget;
         readonly Entry _lodBias;
 
         public GraphicsPresetEditor(
@@ -953,6 +954,8 @@ public sealed class SettingsPanelView : ContentView
             _cloudsResolutionMultiplier = CreateEntry(
                 draft.CloudsResolutionMultiplier);
             _skyResolution = CreateEntry(draft.SkyResolution);
+            _vegetationInstanceBudget = CreateEntry(
+                draft.VegetationInstanceBudget);
             _lodBias = CreateEntry(draft.LodBias);
         }
 
@@ -972,6 +975,7 @@ public sealed class SettingsPanelView : ContentView
                 _supportSoftShadows.IsToggled,
                 _cloudsResolutionMultiplier.Text ?? string.Empty,
                 _skyResolution.Text ?? string.Empty,
+                _vegetationInstanceBudget.Text ?? string.Empty,
                 _lodBias.Text ?? string.Empty);
 
         public View CreateView(bool initiallyExpanded, bool isActive)
@@ -991,6 +995,7 @@ public sealed class SettingsPanelView : ContentView
                     CreatePresetField("Soft Shadows", "Enable soft shadow filtering", _supportSoftShadows),
                     CreatePresetField("Clouds Resolution Multiplier", "0.0625–2.0", _cloudsResolutionMultiplier),
                     CreatePresetField("Sky Resolution", "Power of two, 32–8192", _skyResolution),
+                    CreatePresetField("Vegetation Instance Budget", "Global active grass instances, 0–1048576", _vegetationInstanceBudget),
                     CreatePresetField("LOD Bias", "Signed index shift, -8 (finer) to +8 (coarser)", _lodBias)
                 }
             };
@@ -1094,6 +1099,12 @@ public sealed class SettingsPanelView : ContentView
                 issues,
                 out var skyResolution);
             valid &= TryParseInt(
+                _vegetationInstanceBudget.Text,
+                $"{path}.vegetationInstanceBudget",
+                "Vegetation instance budget",
+                issues,
+                out var vegetationInstanceBudget);
+            valid &= TryParseInt(
                 _lodBias.Text,
                 $"{path}.lodBias",
                 "LOD bias",
@@ -1123,6 +1134,7 @@ public sealed class SettingsPanelView : ContentView
                 SupportSoftShadows = _supportSoftShadows.IsToggled,
                 CloudsResolutionMultiplier = cloudsResolutionMultiplier,
                 SkyResolution = skyResolution,
+                VegetationInstanceBudget = vegetationInstanceBudget,
                 LodBias = lodBias
             };
             return valid;

--- a/ProjectSettings.yaml
+++ b/ProjectSettings.yaml
@@ -17,6 +17,7 @@ graphics:
       supportSoftShadows: true
       cloudsResolutionMultiplier: 1
       skyResolution: 512
+      vegetationInstanceBudget: 65536
       lodBias: -1
     High:
       resolutionFactor: 1
@@ -33,6 +34,7 @@ graphics:
       supportSoftShadows: true
       cloudsResolutionMultiplier: 0.75
       skyResolution: 256
+      vegetationInstanceBudget: 32768
       lodBias: 0
     Medium:
       resolutionFactor: 0.85
@@ -48,6 +50,7 @@ graphics:
       supportSoftShadows: true
       cloudsResolutionMultiplier: 0.5
       skyResolution: 256
+      vegetationInstanceBudget: 16384
       lodBias: 0
     Low:
       resolutionFactor: 0.7
@@ -62,6 +65,7 @@ graphics:
       supportSoftShadows: false
       cloudsResolutionMultiplier: 0.5
       skyResolution: 128
+      vegetationInstanceBudget: 8192
       lodBias: 1
     VeryLow:
       resolutionFactor: 0.5
@@ -75,5 +79,6 @@ graphics:
       supportSoftShadows: false
       cloudsResolutionMultiplier: 0.125
       skyResolution: 64
+      vegetationInstanceBudget: 2048
       lodBias: 2
 ...

--- a/Runtime/AssetRegistry/AssetRegistry.cpp
+++ b/Runtime/AssetRegistry/AssetRegistry.cpp
@@ -6,6 +6,7 @@
 #include "AssetRegistry/Animation/AnimationControllerAssetInfo.h"
 #include "AssetRegistry/AssetInfo.h"
 #include "AssetRegistry/FrameGraph/FrameGraphAssetInfo.h"
+#include "AssetRegistry/Landscape/LandscapeVegetationAsset.h"
 #include "AssetRegistry/Material/MaterialAssetInfo.h"
 #include "AssetRegistry/Model/ModelAssetInfo.h"
 #include "AssetRegistry/Prefab/PrefabAssetInfo.h"
@@ -774,6 +775,10 @@ IAssetInfoHandler* AssetRegistry::GetAssetInfoHandler(
 	if (assetInfoType == "Sailor::FrameGraphAssetInfo")
 	{
 		return App::GetSubmodule<FrameGraphAssetInfoHandler>();
+	}
+	if (assetInfoType == "Sailor::LandscapeVegetationAssetInfo")
+	{
+		return App::GetSubmodule<LandscapeVegetationAssetInfoHandler>();
 	}
 	if (assetInfoType == "Sailor::MaterialAssetInfo")
 	{

--- a/Runtime/AssetRegistry/Landscape/LandscapeVegetationAsset.cpp
+++ b/Runtime/AssetRegistry/Landscape/LandscapeVegetationAsset.cpp
@@ -1,0 +1,569 @@
+#include "AssetRegistry/Landscape/LandscapeVegetationAsset.h"
+
+#include "AssetRegistry/AssetRegistry.h"
+#include "Containers/Set.h"
+#include "Math/Math.h"
+#include "Workspace/WorkspaceCacheContract.h"
+
+#include <array>
+#include <bit>
+#include <cmath>
+#include <fstream>
+#include <limits>
+
+using namespace Sailor;
+
+namespace
+{
+	constexpr std::array<uint8_t, 8u> Magic = {
+		'S', 'L', 'V', 'E', 'G', '0', '0', '1'
+	};
+	void AppendU32(TVector<uint8_t>& bytes, uint32_t value)
+	{
+		for (uint32_t byte = 0u; byte < 4u; ++byte)
+		{
+			bytes.Add(static_cast<uint8_t>(value >> (byte * 8u)));
+		}
+	}
+
+	void AppendI32(TVector<uint8_t>& bytes, int32_t value)
+	{
+		AppendU32(bytes, std::bit_cast<uint32_t>(value));
+	}
+
+	void AppendU64(TVector<uint8_t>& bytes, uint64_t value)
+	{
+		for (uint32_t byte = 0u; byte < 8u; ++byte)
+		{
+			bytes.Add(static_cast<uint8_t>(value >> (byte * 8u)));
+		}
+	}
+
+	void AppendFloat(TVector<uint8_t>& bytes, float value)
+	{
+		AppendU32(bytes, std::bit_cast<uint32_t>(value));
+	}
+
+	bool ReadU32(
+		const TVector<uint8_t>& bytes,
+		size_t offset,
+		uint32_t& result)
+	{
+		if (offset > bytes.Num() || bytes.Num() - offset < 4u)
+		{
+			return false;
+		}
+		result = 0u;
+		for (uint32_t byte = 0u; byte < 4u; ++byte)
+		{
+			result |= static_cast<uint32_t>(bytes[offset + byte]) << (byte * 8u);
+		}
+		return true;
+	}
+
+	bool ReadI32(
+		const TVector<uint8_t>& bytes,
+		size_t offset,
+		int32_t& result)
+	{
+		uint32_t value = 0u;
+		if (!ReadU32(bytes, offset, value))
+		{
+			return false;
+		}
+		result = std::bit_cast<int32_t>(value);
+		return true;
+	}
+
+	bool ReadU64(
+		const TVector<uint8_t>& bytes,
+		size_t offset,
+		uint64_t& result)
+	{
+		if (offset > bytes.Num() || bytes.Num() - offset < 8u)
+		{
+			return false;
+		}
+		result = 0u;
+		for (uint32_t byte = 0u; byte < 8u; ++byte)
+		{
+			result |= static_cast<uint64_t>(bytes[offset + byte]) << (byte * 8u);
+		}
+		return true;
+	}
+
+	bool ReadFloat(
+		const TVector<uint8_t>& bytes,
+		size_t offset,
+		float& result)
+	{
+		uint32_t value = 0u;
+		if (!ReadU32(bytes, offset, value))
+		{
+			return false;
+		}
+		result = std::bit_cast<float>(value);
+		return true;
+	}
+
+	bool TryCalculateFileSize(
+		uint32_t chunkCount,
+		uint64_t instanceCount,
+		uint64_t& result)
+	{
+		if (instanceCount > LandscapeVegetationMaxInstances)
+		{
+			return false;
+		}
+		constexpr uint64_t header = LandscapeVegetationHeaderSize;
+		const uint64_t chunks = static_cast<uint64_t>(chunkCount) *
+			LandscapeVegetationChunkRecordSize;
+		const uint64_t instances = instanceCount *
+			LandscapeVegetationInstanceRecordSize;
+		result = header + chunks + instances;
+		return result >= header && result >= chunks && result >= instances &&
+			result <= static_cast<uint64_t>((std::numeric_limits<size_t>::max)());
+	}
+
+	bool IsFiniteMatrix(const glm::mat4& matrix)
+	{
+		return Math::AllFinite(matrix[0]) &&
+			Math::AllFinite(matrix[1]) &&
+			Math::AllFinite(matrix[2]) &&
+			Math::AllFinite(matrix[3]);
+	}
+
+	bool IsAffineMatrix(const glm::mat4& matrix)
+	{
+		constexpr float epsilon = 1.0e-5f;
+		return std::abs(matrix[0].w) <= epsilon &&
+			std::abs(matrix[1].w) <= epsilon &&
+			std::abs(matrix[2].w) <= epsilon &&
+			std::abs(matrix[3].w - 1.0f) <= epsilon;
+	}
+
+	bool Fail(std::string message, std::string& outDiagnostic)
+	{
+		outDiagnostic = std::move(message);
+		return false;
+	}
+}
+
+uint64_t LandscapeVegetationAssetData::GetInstanceCount() const
+{
+	uint64_t result = 0u;
+	for (const auto& chunk : m_chunks)
+	{
+		result += static_cast<uint64_t>(chunk.m_instances.Num());
+	}
+	return result;
+}
+
+void LandscapeVegetationAssetData::RebuildRuntimeIndices()
+{
+	for (auto& chunk : m_chunks)
+	{
+		chunk.m_enabledInstancesPerProfile.Clear();
+		chunk.m_enabledInstancesPerProfile.Resize(m_profileCount);
+		for (const auto& instance : chunk.m_instances)
+		{
+			if (instance.IsEnabled() && instance.m_profileIndex < m_profileCount)
+			{
+				++chunk.m_enabledInstancesPerProfile[instance.m_profileIndex];
+			}
+		}
+	}
+}
+
+bool LandscapeVegetationAssetData::Validate(std::string& outDiagnostic) const
+{
+	outDiagnostic.clear();
+	if (m_chunksX == 0u || m_chunksZ == 0u ||
+		m_chunksX > 64u || m_chunksZ > 64u)
+	{
+		return Fail("Landscape vegetation dimensions must be in the 1..64 range.", outDiagnostic);
+	}
+	if (!std::isfinite(m_chunkSize) || m_chunkSize <= 0.0f)
+	{
+		return Fail("Landscape vegetation chunk size must be finite and positive.", outDiagnostic);
+	}
+	if (m_profileCount > LandscapeVegetationMaxProfiles)
+	{
+		return Fail("Landscape vegetation profile count exceeds the supported limit.", outDiagnostic);
+	}
+	const uint64_t expectedChunkCount =
+		static_cast<uint64_t>(m_chunksX) * m_chunksZ;
+	if (m_chunks.Num() != expectedChunkCount)
+	{
+		return Fail("Landscape vegetation must contain exactly one record per landscape chunk.", outDiagnostic);
+	}
+	if (GetInstanceCount() > LandscapeVegetationMaxInstances)
+	{
+		return Fail("Landscape vegetation exceeds the supported instance count.", outDiagnostic);
+	}
+
+	TSet<uint64_t> stableIds;
+	const float landscapeWidth = m_chunksX * m_chunkSize;
+	const float landscapeDepth = m_chunksZ * m_chunkSize;
+	const float placementEpsilon = (std::max)(0.001f, m_chunkSize * 0.0001f);
+	for (size_t chunkIndex = 0u; chunkIndex < m_chunks.Num(); ++chunkIndex)
+	{
+		const auto& chunk = m_chunks[chunkIndex];
+		const uint32_t expectedX = static_cast<uint32_t>(chunkIndex % m_chunksX);
+		const uint32_t expectedZ = static_cast<uint32_t>(chunkIndex / m_chunksX);
+		if (chunk.m_chunkX != expectedX || chunk.m_chunkZ != expectedZ)
+		{
+			return Fail("Landscape vegetation chunks must be stored in canonical Z-major order.", outDiagnostic);
+		}
+		for (const auto& instance : chunk.m_instances)
+		{
+			if (instance.m_stableId == 0u || stableIds.Contains(instance.m_stableId))
+			{
+				return Fail("Landscape vegetation stable IDs must be non-zero and unique.", outDiagnostic);
+			}
+			stableIds.Insert(instance.m_stableId);
+			if (instance.m_profileIndex >= m_profileCount)
+			{
+				return Fail("Landscape vegetation contains an invalid profile index.", outDiagnostic);
+			}
+			if ((instance.m_flags & ~LandscapeVegetationInstanceEnabled) != 0u)
+			{
+				return Fail("Landscape vegetation contains unsupported instance flags.", outDiagnostic);
+			}
+			if (!IsFiniteMatrix(instance.m_transform))
+			{
+				return Fail("Landscape vegetation contains a non-finite instance matrix.", outDiagnostic);
+			}
+			if (!IsAffineMatrix(instance.m_transform))
+			{
+				return Fail("Landscape vegetation instance matrices must be affine transforms.", outDiagnostic);
+			}
+			const float chunkMinX = chunk.m_chunkX * m_chunkSize - landscapeWidth * 0.5f;
+			const float chunkMinZ = chunk.m_chunkZ * m_chunkSize - landscapeDepth * 0.5f;
+			const glm::vec3 position(instance.m_transform[3]);
+			if (position.x < chunkMinX - placementEpsilon ||
+				position.x > chunkMinX + m_chunkSize + placementEpsilon ||
+				position.z < chunkMinZ - placementEpsilon ||
+				position.z > chunkMinZ + m_chunkSize + placementEpsilon)
+			{
+				return Fail("Landscape vegetation instance origins must belong to their owning chunk.", outDiagnostic);
+			}
+			if (!std::isfinite(instance.m_cullDistanceScale) ||
+				instance.m_cullDistanceScale <= 0.0f ||
+				!std::isfinite(instance.m_shadowDistanceScale) ||
+				instance.m_shadowDistanceScale <= 0.0f)
+			{
+				return Fail("Landscape vegetation distance scales must be finite and positive.", outDiagnostic);
+			}
+		}
+	}
+	return true;
+}
+
+bool LandscapeVegetationAssetData::Save(
+	const std::filesystem::path& filepath,
+	std::string& outDiagnostic) const
+{
+	if (!Validate(outDiagnostic))
+	{
+		return false;
+	}
+
+	const uint64_t instanceCount = GetInstanceCount();
+	uint64_t fileSize = 0u;
+	if (!TryCalculateFileSize(
+		static_cast<uint32_t>(m_chunks.Num()),
+		instanceCount,
+		fileSize))
+	{
+		return Fail("Landscape vegetation file size is unsupported.", outDiagnostic);
+	}
+
+	TVector<uint8_t> bytes;
+	bytes.Reserve(static_cast<size_t>(fileSize));
+	for (uint8_t byte : Magic)
+	{
+		bytes.Add(byte);
+	}
+	AppendU32(bytes, LandscapeVegetationFormatVersion);
+	AppendU32(bytes, LandscapeVegetationEndianMarker);
+	AppendU32(bytes, LandscapeVegetationHeaderSize);
+	AppendU32(bytes, LandscapeVegetationChunkRecordSize);
+	AppendU32(bytes, LandscapeVegetationInstanceRecordSize);
+	AppendU32(bytes, m_chunksX);
+	AppendU32(bytes, m_chunksZ);
+	AppendU32(bytes, m_profileCount);
+	AppendU32(bytes, static_cast<uint32_t>(m_chunks.Num()));
+	AppendU64(bytes, instanceCount);
+	AppendFloat(bytes, m_chunkSize);
+	AppendU32(bytes, LandscapeVegetationLocalSpaceMatrices);
+	AppendU32(bytes, 0u);
+
+	uint64_t firstInstance = 0u;
+	for (const auto& chunk : m_chunks)
+	{
+		AppendU32(bytes, chunk.m_chunkX);
+		AppendU32(bytes, chunk.m_chunkZ);
+		AppendU64(bytes, firstInstance);
+		AppendU32(bytes, static_cast<uint32_t>(chunk.m_instances.Num()));
+		AppendU32(bytes, 0u);
+		firstInstance += static_cast<uint64_t>(chunk.m_instances.Num());
+	}
+	for (const auto& chunk : m_chunks)
+	{
+		for (const auto& instance : chunk.m_instances)
+		{
+			AppendU64(bytes, instance.m_stableId);
+			AppendU32(bytes, instance.m_profileIndex);
+			AppendU32(bytes, instance.m_flags);
+			for (glm::length_t column = 0; column < 4; ++column)
+			{
+				for (glm::length_t row = 0; row < 4; ++row)
+				{
+					AppendFloat(bytes, instance.m_transform[column][row]);
+				}
+			}
+			AppendI32(bytes, instance.m_lodBias);
+			AppendFloat(bytes, instance.m_cullDistanceScale);
+			AppendFloat(bytes, instance.m_shadowDistanceScale);
+			AppendU32(bytes, 0u);
+		}
+	}
+	if (bytes.Num() != fileSize)
+	{
+		return Fail("Landscape vegetation writer produced an unexpected byte count.", outDiagnostic);
+	}
+
+	return Workspace::AtomicReplaceWorkspaceCacheBinary(
+		filepath,
+		bytes.GetData(),
+		static_cast<uint64_t>(bytes.Num()),
+		outDiagnostic);
+}
+
+bool LandscapeVegetationAssetData::Load(
+	const std::filesystem::path& filepath,
+	std::string& outDiagnostic)
+{
+	outDiagnostic.clear();
+	std::error_code fileError;
+	const uint64_t fileSize = std::filesystem::file_size(filepath, fileError);
+	if (fileError)
+	{
+		return Fail("Cannot inspect landscape vegetation file: " + fileError.message() + ".", outDiagnostic);
+	}
+	if (fileSize < LandscapeVegetationHeaderSize ||
+		fileSize > static_cast<uint64_t>((std::numeric_limits<size_t>::max)()))
+	{
+		return Fail("Landscape vegetation file size is invalid.", outDiagnostic);
+	}
+
+	TVector<uint8_t> bytes;
+	bytes.Resize(static_cast<size_t>(fileSize));
+	std::ifstream stream(filepath, std::ios::binary);
+	if (!stream.is_open())
+	{
+		return Fail("Cannot open landscape vegetation file.", outDiagnostic);
+	}
+	stream.read(
+		reinterpret_cast<char*>(bytes.GetData()),
+		static_cast<std::streamsize>(bytes.Num()));
+	if (!stream || stream.gcount() != static_cast<std::streamsize>(bytes.Num()))
+	{
+		return Fail("Cannot read the complete landscape vegetation file.", outDiagnostic);
+	}
+	for (size_t index = 0u; index < Magic.size(); ++index)
+	{
+		if (bytes[index] != Magic[index])
+		{
+			return Fail("Landscape vegetation magic is invalid.", outDiagnostic);
+		}
+	}
+
+	uint32_t version = 0u;
+	uint32_t endianMarker = 0u;
+	uint32_t headerSize = 0u;
+	uint32_t chunkRecordSize = 0u;
+	uint32_t instanceRecordSize = 0u;
+	uint32_t chunksX = 0u;
+	uint32_t chunksZ = 0u;
+	uint32_t profileCount = 0u;
+	uint32_t chunkCount = 0u;
+	uint64_t instanceCount = 0u;
+	float chunkSize = 0.0f;
+	uint32_t flags = 0u;
+	uint32_t reserved = 0u;
+	if (!ReadU32(bytes, 8u, version) ||
+		!ReadU32(bytes, 12u, endianMarker) ||
+		!ReadU32(bytes, 16u, headerSize) ||
+		!ReadU32(bytes, 20u, chunkRecordSize) ||
+		!ReadU32(bytes, 24u, instanceRecordSize) ||
+		!ReadU32(bytes, 28u, chunksX) ||
+		!ReadU32(bytes, 32u, chunksZ) ||
+		!ReadU32(bytes, 36u, profileCount) ||
+		!ReadU32(bytes, 40u, chunkCount) ||
+		!ReadU64(bytes, 44u, instanceCount) ||
+		!ReadFloat(bytes, 52u, chunkSize) ||
+		!ReadU32(bytes, 56u, flags) ||
+		!ReadU32(bytes, 60u, reserved))
+	{
+		return Fail("Landscape vegetation header is truncated.", outDiagnostic);
+	}
+	if (version != LandscapeVegetationFormatVersion)
+	{
+		return Fail("Unsupported landscape vegetation format version.", outDiagnostic);
+	}
+	if (endianMarker != LandscapeVegetationEndianMarker)
+	{
+		return Fail("Landscape vegetation endian marker is invalid.", outDiagnostic);
+	}
+	if (headerSize != LandscapeVegetationHeaderSize ||
+		chunkRecordSize != LandscapeVegetationChunkRecordSize ||
+		instanceRecordSize != LandscapeVegetationInstanceRecordSize)
+	{
+		return Fail("Landscape vegetation record sizes are incompatible with version 1.", outDiagnostic);
+	}
+	if (flags != LandscapeVegetationLocalSpaceMatrices || reserved != 0u)
+	{
+		return Fail("Landscape vegetation version 1 header flags or reserved bytes are invalid.", outDiagnostic);
+	}
+	if (chunksX == 0u || chunksZ == 0u ||
+		chunksX > 64u || chunksZ > 64u ||
+		static_cast<uint64_t>(chunksX) * chunksZ != chunkCount)
+	{
+		return Fail("Landscape vegetation chunk dimensions do not match its table.", outDiagnostic);
+	}
+	if (profileCount > LandscapeVegetationMaxProfiles)
+	{
+		return Fail("Landscape vegetation profile count exceeds the supported limit.", outDiagnostic);
+	}
+	uint64_t expectedFileSize = 0u;
+	if (!TryCalculateFileSize(chunkCount, instanceCount, expectedFileSize) ||
+		expectedFileSize != fileSize)
+	{
+		return Fail("Landscape vegetation file length does not match its header.", outDiagnostic);
+	}
+
+	LandscapeVegetationAssetData loaded;
+	loaded.m_chunksX = chunksX;
+	loaded.m_chunksZ = chunksZ;
+	loaded.m_profileCount = profileCount;
+	loaded.m_chunkSize = chunkSize;
+	loaded.m_chunks.Resize(chunkCount);
+	const uint64_t instancesOffset = LandscapeVegetationHeaderSize +
+		static_cast<uint64_t>(chunkCount) * LandscapeVegetationChunkRecordSize;
+	uint64_t expectedFirstInstance = 0u;
+	for (uint32_t chunkIndex = 0u; chunkIndex < chunkCount; ++chunkIndex)
+	{
+		const size_t chunkOffset = LandscapeVegetationHeaderSize +
+			static_cast<size_t>(chunkIndex) * LandscapeVegetationChunkRecordSize;
+		uint32_t chunkX = 0u;
+		uint32_t chunkZ = 0u;
+		uint64_t firstInstance = 0u;
+		uint32_t numInstances = 0u;
+		uint32_t chunkReserved = 0u;
+		if (!ReadU32(bytes, chunkOffset, chunkX) ||
+			!ReadU32(bytes, chunkOffset + 4u, chunkZ) ||
+			!ReadU64(bytes, chunkOffset + 8u, firstInstance) ||
+			!ReadU32(bytes, chunkOffset + 16u, numInstances) ||
+			!ReadU32(bytes, chunkOffset + 20u, chunkReserved))
+		{
+			return Fail("Landscape vegetation chunk table is truncated.", outDiagnostic);
+		}
+		if (chunkX != chunkIndex % chunksX ||
+			chunkZ != chunkIndex / chunksX ||
+			firstInstance != expectedFirstInstance ||
+			firstInstance > instanceCount ||
+			static_cast<uint64_t>(numInstances) > instanceCount - firstInstance ||
+			chunkReserved != 0u)
+		{
+			return Fail("Landscape vegetation chunk table is not canonical.", outDiagnostic);
+		}
+
+		auto& chunk = loaded.m_chunks[chunkIndex];
+		chunk.m_chunkX = chunkX;
+		chunk.m_chunkZ = chunkZ;
+		chunk.m_instances.Resize(numInstances);
+		for (uint32_t localInstance = 0u; localInstance < numInstances; ++localInstance)
+		{
+			const uint64_t globalInstance = firstInstance + localInstance;
+			const size_t instanceOffset = static_cast<size_t>(instancesOffset +
+				globalInstance * LandscapeVegetationInstanceRecordSize);
+			auto& instance = chunk.m_instances[localInstance];
+			uint32_t instanceReserved = 0u;
+			if (!ReadU64(bytes, instanceOffset, instance.m_stableId) ||
+				!ReadU32(bytes, instanceOffset + 8u, instance.m_profileIndex) ||
+				!ReadU32(bytes, instanceOffset + 12u, instance.m_flags) ||
+				!ReadU32(bytes, instanceOffset + 92u, instanceReserved))
+			{
+				return Fail("Landscape vegetation instance record is truncated.", outDiagnostic);
+			}
+			if (instanceReserved != 0u)
+			{
+				return Fail("Landscape vegetation instance reserved bytes are invalid.", outDiagnostic);
+			}
+			size_t matrixOffset = instanceOffset + 16u;
+			for (glm::length_t column = 0; column < 4; ++column)
+			{
+				for (glm::length_t row = 0; row < 4; ++row)
+				{
+					if (!ReadFloat(bytes, matrixOffset, instance.m_transform[column][row]))
+					{
+						return Fail("Landscape vegetation matrix is truncated.", outDiagnostic);
+					}
+					matrixOffset += sizeof(float);
+				}
+			}
+			if (!ReadI32(bytes, instanceOffset + 80u, instance.m_lodBias) ||
+				!ReadFloat(bytes, instanceOffset + 84u, instance.m_cullDistanceScale) ||
+				!ReadFloat(bytes, instanceOffset + 88u, instance.m_shadowDistanceScale))
+			{
+				return Fail("Landscape vegetation per-instance settings are truncated.", outDiagnostic);
+			}
+		}
+		expectedFirstInstance += numInstances;
+	}
+	if (expectedFirstInstance != instanceCount || !loaded.Validate(outDiagnostic))
+	{
+		return false;
+	}
+	loaded.RebuildRuntimeIndices();
+
+	*this = std::move(loaded);
+	outDiagnostic = "Landscape vegetation loaded.";
+	return true;
+}
+
+YAML::Node LandscapeVegetationAssetInfo::Serialize() const
+{
+	return SerializeReflectedAssetInfo(*this);
+}
+
+void LandscapeVegetationAssetInfo::Deserialize(const YAML::Node& inData)
+{
+	DeserializeReflectedAssetInfo(*this, inData);
+}
+
+IAssetInfoHandler* LandscapeVegetationAssetInfo::GetHandler()
+{
+	return App::GetSubmodule<LandscapeVegetationAssetInfoHandler>();
+}
+
+LandscapeVegetationAssetInfoHandler::LandscapeVegetationAssetInfoHandler(
+	AssetRegistry* assetRegistry)
+{
+	m_supportedExtensions.Emplace("vegetation");
+	assetRegistry->RegisterAssetInfoHandler(m_supportedExtensions, this);
+}
+
+void LandscapeVegetationAssetInfoHandler::GetDefaultMeta(
+	YAML::Node& outDefaultYaml) const
+{
+	LandscapeVegetationAssetInfo defaultObject;
+	outDefaultYaml = defaultObject.Serialize();
+}
+
+AssetInfoPtr LandscapeVegetationAssetInfoHandler::CreateAssetInfo() const
+{
+	return new LandscapeVegetationAssetInfo();
+}

--- a/Runtime/AssetRegistry/Landscape/LandscapeVegetationAsset.h
+++ b/Runtime/AssetRegistry/Landscape/LandscapeVegetationAsset.h
@@ -1,0 +1,99 @@
+#pragma once
+
+#include "AssetRegistry/AssetInfo.h"
+#include "Containers/Vector.h"
+#include "Core/Singleton.hpp"
+
+#include <glm/mat4x4.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+
+namespace Sailor
+{
+	inline constexpr uint32_t LandscapeVegetationFormatVersion = 1u;
+	inline constexpr uint32_t LandscapeVegetationHeaderSize = 64u;
+	inline constexpr uint32_t LandscapeVegetationChunkRecordSize = 24u;
+	inline constexpr uint32_t LandscapeVegetationInstanceRecordSize = 96u;
+	inline constexpr uint32_t LandscapeVegetationEndianMarker = 0x01020304u;
+	inline constexpr uint32_t LandscapeVegetationMaxProfiles = 1024u;
+	inline constexpr uint64_t LandscapeVegetationMaxInstances =
+		16ull * 1024ull * 1024ull;
+	inline constexpr uint32_t LandscapeVegetationLocalSpaceMatrices = 1u << 0u;
+	inline constexpr uint32_t LandscapeVegetationInstanceEnabled = 1u << 0u;
+
+	struct LandscapeVegetationInstance final
+	{
+		uint64_t m_stableId = 0u;
+		uint32_t m_profileIndex = 0u;
+		uint32_t m_flags = LandscapeVegetationInstanceEnabled;
+		glm::mat4 m_transform{ 1.0f };
+		int32_t m_lodBias = 0;
+		float m_cullDistanceScale = 1.0f;
+		float m_shadowDistanceScale = 1.0f;
+
+		bool IsEnabled() const
+		{
+			return (m_flags & LandscapeVegetationInstanceEnabled) != 0u;
+		}
+	};
+
+	struct LandscapeVegetationChunkData final
+	{
+		uint32_t m_chunkX = 0u;
+		uint32_t m_chunkZ = 0u;
+		TVector<LandscapeVegetationInstance> m_instances{};
+		TVector<uint32_t> m_enabledInstancesPerProfile{};
+	};
+
+	struct LandscapeVegetationAssetData final
+	{
+		uint32_t m_chunksX = 0u;
+		uint32_t m_chunksZ = 0u;
+		uint32_t m_profileCount = 0u;
+		float m_chunkSize = 0.0f;
+		TVector<LandscapeVegetationChunkData> m_chunks{};
+
+		SAILOR_API bool Load(
+			const std::filesystem::path& filepath,
+			std::string& outDiagnostic);
+		SAILOR_API bool Save(
+			const std::filesystem::path& filepath,
+			std::string& outDiagnostic) const;
+		SAILOR_API bool Validate(std::string& outDiagnostic) const;
+		SAILOR_API uint64_t GetInstanceCount() const;
+		SAILOR_API void RebuildRuntimeIndices();
+	};
+
+	class LandscapeVegetationAssetInfo final : public AssetInfo
+	{
+		SAILOR_REFLECTABLE(LandscapeVegetationAssetInfo)
+
+	public:
+		SAILOR_API ~LandscapeVegetationAssetInfo() override = default;
+
+		SAILOR_API YAML::Node Serialize() const override;
+		SAILOR_API void Deserialize(const YAML::Node& inData) override;
+		SAILOR_API IAssetInfoHandler* GetHandler() override;
+	};
+
+	using LandscapeVegetationAssetInfoPtr = LandscapeVegetationAssetInfo*;
+
+	class LandscapeVegetationAssetInfoHandler final :
+		public TSubmodule<LandscapeVegetationAssetInfoHandler>,
+		public IAssetInfoHandler
+	{
+	public:
+		SAILOR_API explicit LandscapeVegetationAssetInfoHandler(
+			class AssetRegistry* assetRegistry);
+		SAILOR_API void GetDefaultMeta(YAML::Node& outDefaultYaml) const override;
+		SAILOR_API AssetInfoPtr CreateAssetInfo() const override;
+	};
+}
+
+REFL_AUTO(
+	type(Sailor::LandscapeVegetationAssetInfo, bases<Sailor::AssetInfo>),
+	field(m_fileId),
+	field(m_assetFilename)
+)

--- a/Runtime/Components/LandscapeComponent.cpp
+++ b/Runtime/Components/LandscapeComponent.cpp
@@ -20,6 +20,7 @@ void LandscapeComponent::Initialize()
 	data.SetLayerTextures(m_layerTextures);
 	data.SetImportMaps(m_heightmapTexture, m_materialMasks);
 	data.SetAuthoredStamps(m_sculptStamps, m_paintStamps);
+	data.SetVegetationAsset(m_vegetation);
 	data.SetVegetationProfiles(m_vegetationModels, m_vegetationMaterials,
 		m_vegetationMeshIndex, m_vegetationInstancesPerChunk,
 		m_vegetationResidency, m_vegetationPriority, m_vegetationMinScale,
@@ -62,6 +63,7 @@ void LandscapeComponent::MarkDirty()
 		data->SetLayerTextures(m_layerTextures);
 		data->SetImportMaps(m_heightmapTexture, m_materialMasks);
 		data->SetAuthoredStamps(m_sculptStamps, m_paintStamps);
+		data->SetVegetationAsset(m_vegetation);
 		data->SetVegetationProfiles(m_vegetationModels, m_vegetationMaterials,
 			m_vegetationMeshIndex, m_vegetationInstancesPerChunk,
 			m_vegetationResidency, m_vegetationPriority, m_vegetationMinScale,
@@ -101,6 +103,7 @@ void LandscapeComponent::SetLodSkirtDepth(float value) { m_lodSkirtDepth = std::
 void LandscapeComponent::SetGrassResidencyHysteresis(float value) { m_grassResidencyHysteresis = std::isfinite(value) ? (std::clamp)(value, 0.0f, 512.0f) : 12.0f; MarkDirty(); }
 void LandscapeComponent::SetSculptStamps(const TVector<float>& value) { m_sculptStamps = value; m_sculptStamps.Resize(m_sculptStamps.Num() / 5u * 5u); MarkDirty(); }
 void LandscapeComponent::SetPaintStamps(const TVector<float>& value) { m_paintStamps = value; m_paintStamps.Resize(m_paintStamps.Num() / 5u * 5u); MarkDirty(); }
+void LandscapeComponent::SetVegetation(const FileId& value) { m_vegetation = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationModels(const TVector<FileId>& value) { m_vegetationModels = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationMaterials(const TVector<FileId>& value) { m_vegetationMaterials = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationMeshIndex(const TVector<float>& value) { m_vegetationMeshIndex = value; MarkDirty(); }
@@ -127,8 +130,18 @@ void LandscapeComponent::SetRegenerate(bool value)
 	{
 		if (auto* data = TryGetData())
 		{
-			data->RequestFullRebuild();
+			data->RequestVegetationAssetReload();
 		}
 	}
 }
 void LandscapeComponent::SetFlatten(bool value) { m_bFlatten = false; if (value) { m_heightScale = 0.0f; MarkDirty(); } }
+void LandscapeComponent::SetSaveVegetation(bool value)
+{
+	if (value)
+	{
+		if (auto* data = TryGetData())
+		{
+			data->RequestSaveVegetation();
+		}
+	}
+}

--- a/Runtime/Components/LandscapeComponent.cpp
+++ b/Runtime/Components/LandscapeComponent.cpp
@@ -15,9 +15,7 @@ void LandscapeComponent::Initialize()
 	data.SetSettings(m_chunksX, m_chunksZ, m_chunkSize, m_chunkResolution,
 		m_heightScale, m_noiseScale, m_seed, m_textureTiling);
 	data.SetLodSettings(m_lodDistances, m_lodSkirtDepth);
-	data.SetVegetationStreamingSettings(
-		m_grassInstanceBudget,
-		m_grassResidencyHysteresis);
+	data.SetGrassResidencyHysteresis(m_grassResidencyHysteresis);
 	data.SetMaterial(m_material);
 	data.SetLayerTextures(m_layerTextures);
 	data.SetImportMaps(m_heightmapTexture, m_materialMasks);
@@ -59,9 +57,7 @@ void LandscapeComponent::MarkDirty()
 		data->SetSettings(m_chunksX, m_chunksZ, m_chunkSize, m_chunkResolution,
 			m_heightScale, m_noiseScale, m_seed, m_textureTiling);
 		data->SetLodSettings(m_lodDistances, m_lodSkirtDepth);
-		data->SetVegetationStreamingSettings(
-			m_grassInstanceBudget,
-			m_grassResidencyHysteresis);
+		data->SetGrassResidencyHysteresis(m_grassResidencyHysteresis);
 		data->SetMaterial(m_material);
 		data->SetLayerTextures(m_layerTextures);
 		data->SetImportMaps(m_heightmapTexture, m_materialMasks);
@@ -102,7 +98,6 @@ void LandscapeComponent::SetLodDistances(const TVector<float>& value)
 	MarkDirty();
 }
 void LandscapeComponent::SetLodSkirtDepth(float value) { m_lodSkirtDepth = std::isfinite(value) ? (std::clamp)(value, 0.0f, 64.0f) : 2.0f; MarkDirty(); }
-void LandscapeComponent::SetGrassInstanceBudget(uint32_t value) { m_grassInstanceBudget = (std::min)(value, 1048576u); MarkDirty(); }
 void LandscapeComponent::SetGrassResidencyHysteresis(float value) { m_grassResidencyHysteresis = std::isfinite(value) ? (std::clamp)(value, 0.0f, 512.0f) : 12.0f; MarkDirty(); }
 void LandscapeComponent::SetSculptStamps(const TVector<float>& value) { m_sculptStamps = value; m_sculptStamps.Resize(m_sculptStamps.Num() / 5u * 5u); MarkDirty(); }
 void LandscapeComponent::SetPaintStamps(const TVector<float>& value) { m_paintStamps = value; m_paintStamps.Resize(m_paintStamps.Num() / 5u * 5u); MarkDirty(); }

--- a/Runtime/Components/LandscapeComponent.cpp
+++ b/Runtime/Components/LandscapeComponent.cpp
@@ -2,6 +2,7 @@
 #include "Engine/GameObject.h"
 
 #include <algorithm>
+#include <cmath>
 
 using namespace Sailor;
 
@@ -13,12 +14,17 @@ void LandscapeComponent::Initialize()
 	data.SetOwner(GetOwner());
 	data.SetSettings(m_chunksX, m_chunksZ, m_chunkSize, m_chunkResolution,
 		m_heightScale, m_noiseScale, m_seed, m_textureTiling);
+	data.SetLodSettings(m_lodDistances, m_lodSkirtDepth);
+	data.SetVegetationStreamingSettings(
+		m_grassInstanceBudget,
+		m_grassResidencyHysteresis);
 	data.SetMaterial(m_material);
 	data.SetLayerTextures(m_layerTextures);
 	data.SetImportMaps(m_heightmapTexture, m_materialMasks);
 	data.SetAuthoredStamps(m_sculptStamps, m_paintStamps);
 	data.SetVegetationProfiles(m_vegetationModels, m_vegetationMaterials,
-		m_vegetationMeshIndex, m_vegetationInstancesPerChunk, m_vegetationMinScale,
+		m_vegetationMeshIndex, m_vegetationInstancesPerChunk,
+		m_vegetationResidency, m_vegetationPriority, m_vegetationMinScale,
 		m_vegetationMaxScale, m_vegetationGroundOffset,
 		m_vegetationShadowMode, m_vegetationShadowDistance,
 		m_vegetationMinLod, m_vegetationMaxLod,
@@ -52,12 +58,17 @@ void LandscapeComponent::MarkDirty()
 	{
 		data->SetSettings(m_chunksX, m_chunksZ, m_chunkSize, m_chunkResolution,
 			m_heightScale, m_noiseScale, m_seed, m_textureTiling);
+		data->SetLodSettings(m_lodDistances, m_lodSkirtDepth);
+		data->SetVegetationStreamingSettings(
+			m_grassInstanceBudget,
+			m_grassResidencyHysteresis);
 		data->SetMaterial(m_material);
 		data->SetLayerTextures(m_layerTextures);
 		data->SetImportMaps(m_heightmapTexture, m_materialMasks);
 		data->SetAuthoredStamps(m_sculptStamps, m_paintStamps);
 		data->SetVegetationProfiles(m_vegetationModels, m_vegetationMaterials,
-			m_vegetationMeshIndex, m_vegetationInstancesPerChunk, m_vegetationMinScale,
+			m_vegetationMeshIndex, m_vegetationInstancesPerChunk,
+			m_vegetationResidency, m_vegetationPriority, m_vegetationMinScale,
 			m_vegetationMaxScale, m_vegetationGroundOffset,
 			m_vegetationShadowMode, m_vegetationShadowDistance,
 			m_vegetationMinLod, m_vegetationMaxLod,
@@ -79,12 +90,28 @@ void LandscapeComponent::SetLayerTextures(const TVector<FileId>& value) { m_laye
 void LandscapeComponent::SetHeightmapTexture(const FileId& value) { m_heightmapTexture = value; MarkDirty(); }
 void LandscapeComponent::SetMaterialMasks(const TVector<FileId>& value) { m_materialMasks = value; if (m_materialMasks.Num() > 4u) m_materialMasks.Resize(4u); MarkDirty(); }
 void LandscapeComponent::SetTextureTiling(float value) { m_textureTiling = (std::max)(value, 0.001f); MarkDirty(); }
+void LandscapeComponent::SetLodDistances(const TVector<float>& value)
+{
+	m_lodDistances = value;
+	for (float& distance : m_lodDistances)
+	{
+		distance = std::isfinite(distance) ? (std::max)(distance, 1.0f) : 1.0f;
+	}
+	std::sort(m_lodDistances.begin(), m_lodDistances.end());
+	m_lodDistances.Resize((std::min)(m_lodDistances.Num(), size_t(7u)));
+	MarkDirty();
+}
+void LandscapeComponent::SetLodSkirtDepth(float value) { m_lodSkirtDepth = std::isfinite(value) ? (std::clamp)(value, 0.0f, 64.0f) : 2.0f; MarkDirty(); }
+void LandscapeComponent::SetGrassInstanceBudget(uint32_t value) { m_grassInstanceBudget = (std::min)(value, 1048576u); MarkDirty(); }
+void LandscapeComponent::SetGrassResidencyHysteresis(float value) { m_grassResidencyHysteresis = std::isfinite(value) ? (std::clamp)(value, 0.0f, 512.0f) : 12.0f; MarkDirty(); }
 void LandscapeComponent::SetSculptStamps(const TVector<float>& value) { m_sculptStamps = value; m_sculptStamps.Resize(m_sculptStamps.Num() / 5u * 5u); MarkDirty(); }
 void LandscapeComponent::SetPaintStamps(const TVector<float>& value) { m_paintStamps = value; m_paintStamps.Resize(m_paintStamps.Num() / 5u * 5u); MarkDirty(); }
 void LandscapeComponent::SetVegetationModels(const TVector<FileId>& value) { m_vegetationModels = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationMaterials(const TVector<FileId>& value) { m_vegetationMaterials = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationMeshIndex(const TVector<float>& value) { m_vegetationMeshIndex = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationInstancesPerChunk(const TVector<float>& value) { m_vegetationInstancesPerChunk = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationResidency(const TVector<float>& value) { m_vegetationResidency = value; MarkDirty(); }
+void LandscapeComponent::SetVegetationPriority(const TVector<float>& value) { m_vegetationPriority = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationMinScale(const TVector<float>& value) { m_vegetationMinScale = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationMaxScale(const TVector<float>& value) { m_vegetationMaxScale = value; MarkDirty(); }
 void LandscapeComponent::SetVegetationGroundOffset(const TVector<float>& value) { m_vegetationGroundOffset = value; MarkDirty(); }

--- a/Runtime/Components/LandscapeComponent.h
+++ b/Runtime/Components/LandscapeComponent.h
@@ -49,6 +49,8 @@ namespace Sailor
 		SAILOR_API void SetSculptStamps(const TVector<float>& value);
 		SAILOR_API const TVector<float>& GetPaintStamps() const { return m_paintStamps; }
 		SAILOR_API void SetPaintStamps(const TVector<float>& value);
+		SAILOR_API const FileId& GetVegetation() const { return m_vegetation; }
+		SAILOR_API void SetVegetation(const FileId& value);
 		SAILOR_API const TVector<FileId>& GetVegetationModels() const { return m_vegetationModels; }
 		SAILOR_API void SetVegetationModels(const TVector<FileId>& value);
 		SAILOR_API const TVector<FileId>& GetVegetationMaterials() const { return m_vegetationMaterials; }
@@ -91,6 +93,8 @@ namespace Sailor
 		SAILOR_API void SetRegenerate(bool value);
 		SAILOR_API bool GetFlatten() const { return m_bFlatten; }
 		SAILOR_API void SetFlatten(bool value);
+		SAILOR_API bool GetSaveVegetation() const { return false; }
+		SAILOR_API void SetSaveVegetation(bool value);
 
 		SAILOR_API size_t GetComponentIndex() const { return m_handle; }
 
@@ -116,6 +120,7 @@ namespace Sailor
 		float m_grassResidencyHysteresis = 12.0f;
 		TVector<float> m_sculptStamps{};
 		TVector<float> m_paintStamps{};
+		FileId m_vegetation{};
 		TVector<FileId> m_vegetationModels{};
 		TVector<FileId> m_vegetationMaterials{};
 		TVector<float> m_vegetationMeshIndex{};
@@ -178,6 +183,8 @@ REFL_AUTO(
 	func(SetSculptStamps, property("sculptStamps")),
 	func(GetPaintStamps, property("paintStamps")),
 	func(SetPaintStamps, property("paintStamps")),
+	func(GetVegetation, property("vegetation")),
+	func(SetVegetation, property("vegetation")),
 	func(GetVegetationModels, property("vegetationModels")),
 	func(SetVegetationModels, property("vegetationModels")),
 	func(GetVegetationMaterials, property("vegetationMaterials")),
@@ -219,5 +226,7 @@ REFL_AUTO(
 	func(GetRegenerate, property("regenerate")),
 	func(SetRegenerate, property("regenerate")),
 	func(GetFlatten, property("flatten")),
-	func(SetFlatten, property("flatten"))
+	func(SetFlatten, property("flatten")),
+	func(GetSaveVegetation, property("saveVegetation")),
+	func(SetSaveVegetation, property("saveVegetation"))
 )

--- a/Runtime/Components/LandscapeComponent.h
+++ b/Runtime/Components/LandscapeComponent.h
@@ -39,6 +39,14 @@ namespace Sailor
 		SAILOR_API void SetMaterialMasks(const TVector<FileId>& value);
 		SAILOR_API float GetTextureTiling() const { return m_textureTiling; }
 		SAILOR_API void SetTextureTiling(float value);
+		SAILOR_API const TVector<float>& GetLodDistances() const { return m_lodDistances; }
+		SAILOR_API void SetLodDistances(const TVector<float>& value);
+		SAILOR_API float GetLodSkirtDepth() const { return m_lodSkirtDepth; }
+		SAILOR_API void SetLodSkirtDepth(float value);
+		SAILOR_API uint32_t GetGrassInstanceBudget() const { return m_grassInstanceBudget; }
+		SAILOR_API void SetGrassInstanceBudget(uint32_t value);
+		SAILOR_API float GetGrassResidencyHysteresis() const { return m_grassResidencyHysteresis; }
+		SAILOR_API void SetGrassResidencyHysteresis(float value);
 		SAILOR_API const TVector<float>& GetSculptStamps() const { return m_sculptStamps; }
 		SAILOR_API void SetSculptStamps(const TVector<float>& value);
 		SAILOR_API const TVector<float>& GetPaintStamps() const { return m_paintStamps; }
@@ -51,6 +59,10 @@ namespace Sailor
 		SAILOR_API void SetVegetationMeshIndex(const TVector<float>& value);
 		SAILOR_API const TVector<float>& GetVegetationInstancesPerChunk() const { return m_vegetationInstancesPerChunk; }
 		SAILOR_API void SetVegetationInstancesPerChunk(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationResidency() const { return m_vegetationResidency; }
+		SAILOR_API void SetVegetationResidency(const TVector<float>& value);
+		SAILOR_API const TVector<float>& GetVegetationPriority() const { return m_vegetationPriority; }
+		SAILOR_API void SetVegetationPriority(const TVector<float>& value);
 		SAILOR_API const TVector<float>& GetVegetationMinScale() const { return m_vegetationMinScale; }
 		SAILOR_API void SetVegetationMinScale(const TVector<float>& value);
 		SAILOR_API const TVector<float>& GetVegetationMaxScale() const { return m_vegetationMaxScale; }
@@ -101,12 +113,18 @@ namespace Sailor
 		FileId m_heightmapTexture{};
 		TVector<FileId> m_materialMasks{};
 		float m_textureTiling = 0.15f;
+		TVector<float> m_lodDistances{ 96.0f, 192.0f };
+		float m_lodSkirtDepth = 2.0f;
+		uint32_t m_grassInstanceBudget = 32768u;
+		float m_grassResidencyHysteresis = 12.0f;
 		TVector<float> m_sculptStamps{};
 		TVector<float> m_paintStamps{};
 		TVector<FileId> m_vegetationModels{};
 		TVector<FileId> m_vegetationMaterials{};
 		TVector<float> m_vegetationMeshIndex{};
 		TVector<float> m_vegetationInstancesPerChunk{};
+		TVector<float> m_vegetationResidency{};
+		TVector<float> m_vegetationPriority{};
 		TVector<float> m_vegetationMinScale{};
 		TVector<float> m_vegetationMaxScale{};
 		TVector<float> m_vegetationGroundOffset{};
@@ -153,6 +171,14 @@ REFL_AUTO(
 	func(SetMaterialMasks, property("materialMasks")),
 	func(GetTextureTiling, property("textureTiling"), Range(0.001, 8.0)),
 	func(SetTextureTiling, property("textureTiling")),
+	func(GetLodDistances, property("lodDistances")),
+	func(SetLodDistances, property("lodDistances")),
+	func(GetLodSkirtDepth, property("lodSkirtDepth"), Range(0.0, 64.0)),
+	func(SetLodSkirtDepth, property("lodSkirtDepth")),
+	func(GetGrassInstanceBudget, property("grassInstanceBudget"), Range(0.0, 1048576.0)),
+	func(SetGrassInstanceBudget, property("grassInstanceBudget")),
+	func(GetGrassResidencyHysteresis, property("grassResidencyHysteresis"), Range(0.0, 512.0)),
+	func(SetGrassResidencyHysteresis, property("grassResidencyHysteresis")),
 	func(GetSculptStamps, property("sculptStamps")),
 	func(SetSculptStamps, property("sculptStamps")),
 	func(GetPaintStamps, property("paintStamps")),
@@ -165,6 +191,10 @@ REFL_AUTO(
 	func(SetVegetationMeshIndex, property("vegetationMeshIndex")),
 	func(GetVegetationInstancesPerChunk, property("vegetationInstancesPerChunk")),
 	func(SetVegetationInstancesPerChunk, property("vegetationInstancesPerChunk")),
+	func(GetVegetationResidency, property("vegetationResidency")),
+	func(SetVegetationResidency, property("vegetationResidency")),
+	func(GetVegetationPriority, property("vegetationPriority")),
+	func(SetVegetationPriority, property("vegetationPriority")),
 	func(GetVegetationMinScale, property("vegetationMinScale")),
 	func(SetVegetationMinScale, property("vegetationMinScale")),
 	func(GetVegetationMaxScale, property("vegetationMaxScale")),

--- a/Runtime/Components/LandscapeComponent.h
+++ b/Runtime/Components/LandscapeComponent.h
@@ -43,8 +43,6 @@ namespace Sailor
 		SAILOR_API void SetLodDistances(const TVector<float>& value);
 		SAILOR_API float GetLodSkirtDepth() const { return m_lodSkirtDepth; }
 		SAILOR_API void SetLodSkirtDepth(float value);
-		SAILOR_API uint32_t GetGrassInstanceBudget() const { return m_grassInstanceBudget; }
-		SAILOR_API void SetGrassInstanceBudget(uint32_t value);
 		SAILOR_API float GetGrassResidencyHysteresis() const { return m_grassResidencyHysteresis; }
 		SAILOR_API void SetGrassResidencyHysteresis(float value);
 		SAILOR_API const TVector<float>& GetSculptStamps() const { return m_sculptStamps; }
@@ -115,7 +113,6 @@ namespace Sailor
 		float m_textureTiling = 0.15f;
 		TVector<float> m_lodDistances{ 96.0f, 192.0f };
 		float m_lodSkirtDepth = 2.0f;
-		uint32_t m_grassInstanceBudget = 32768u;
 		float m_grassResidencyHysteresis = 12.0f;
 		TVector<float> m_sculptStamps{};
 		TVector<float> m_paintStamps{};
@@ -175,8 +172,6 @@ REFL_AUTO(
 	func(SetLodDistances, property("lodDistances")),
 	func(GetLodSkirtDepth, property("lodSkirtDepth"), Range(0.0, 64.0)),
 	func(SetLodSkirtDepth, property("lodSkirtDepth")),
-	func(GetGrassInstanceBudget, property("grassInstanceBudget"), Range(0.0, 1048576.0)),
-	func(SetGrassInstanceBudget, property("grassInstanceBudget")),
 	func(GetGrassResidencyHysteresis, property("grassResidencyHysteresis"), Range(0.0, 512.0)),
 	func(SetGrassResidencyHysteresis, property("grassResidencyHysteresis")),
 	func(GetSculptStamps, property("sculptStamps")),

--- a/Runtime/ECS/CameraECS.h
+++ b/Runtime/ECS/CameraECS.h
@@ -53,6 +53,10 @@ namespace Sailor
 		virtual Tasks::ITaskPtr Tick(float deltaTime) override;
 		void CopyCameraData(RHI::RHISceneViewPtr& outCameras);
 		bool TryGetActiveCamera(Math::Transform& outCameraTransform, CameraData& outCameraData);
+		const TVector<Math::Transform>& GetActiveCameraTransforms() const
+		{
+			return m_rhiCameraTransforms;
+		}
 
 		virtual uint32_t GetOrder() const override { return 100; }
 

--- a/Runtime/ECS/CameraECS.h
+++ b/Runtime/ECS/CameraECS.h
@@ -57,6 +57,10 @@ namespace Sailor
 		{
 			return m_rhiCameraTransforms;
 		}
+		const TVector<CameraData>& GetActiveCameras() const
+		{
+			return m_rhiCameras;
+		}
 
 		virtual uint32_t GetOrder() const override { return 100; }
 

--- a/Runtime/ECS/LandscapeECS.cpp
+++ b/Runtime/ECS/LandscapeECS.cpp
@@ -1,9 +1,11 @@
 #include "ECS/LandscapeECS.h"
+#include "ECS/LandscapeStreaming.h"
 
 #include "AssetRegistry/Material/MaterialImporter.h"
 #include "AssetRegistry/Model/ModelImporter.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
 #include "Components/LandscapeComponent.h"
+#include "ECS/CameraECS.h"
 #include "ECS/TransformECS.h"
 #include "ECS/PhysicsECS.h"
 #include "Engine/GameObject.h"
@@ -49,6 +51,9 @@ namespace
 		uint32_t m_chunkZ = 0u;
 		TVector<RHI::VertexP3N3T3B3UV2C4> m_vertices{};
 		TVector<uint32_t> m_indices{};
+		TVector<uint32_t> m_collisionIndices{};
+		TVector<uint32_t> m_lodFirstIndices{};
+		TVector<uint32_t> m_lodIndexCounts{};
 		TVector<VegetationInstance> m_vegetation{};
 		Math::AABB m_localBounds{};
 	};
@@ -189,6 +194,75 @@ namespace
 		return height;
 	}
 
+	void BuildLandscapeLodGeometry(
+		const LandscapeData& data,
+		LandscapeChunkCpuData& result)
+	{
+		const uint32_t resolution = data.m_chunkResolution;
+		const uint32_t row = resolution + 1u;
+		const uint32_t baseVertexCount = row * row;
+		if (data.m_lodSkirtDepth > 0.0f)
+		{
+			result.m_vertices.Reserve(
+				result.m_vertices.Num() + static_cast<size_t>(row) * 4u);
+			auto appendSkirtVertex = [&result, &data](uint32_t sourceIndex)
+				{
+					auto vertex = result.m_vertices[sourceIndex];
+					vertex.m_position.y -= data.m_lodSkirtDepth;
+					result.m_localBounds.Extend(
+						Math::AABB(vertex.m_position, glm::vec3(0.01f)));
+					result.m_vertices.Add(std::move(vertex));
+				};
+			for (uint32_t x = 0u; x <= resolution; ++x)
+			{
+				appendSkirtVertex(x);
+			}
+			for (uint32_t x = 0u; x <= resolution; ++x)
+			{
+				appendSkirtVertex(resolution * row + x);
+			}
+			for (uint32_t z = 0u; z <= resolution; ++z)
+			{
+				appendSkirtVertex(z * row);
+			}
+			for (uint32_t z = 0u; z <= resolution; ++z)
+			{
+				appendSkirtVertex(z * row + resolution);
+			}
+		}
+
+		const auto collisionCoordinates = BuildLandscapeLodCoordinates(resolution, 1u);
+		AppendLandscapeLodIndices(
+			resolution,
+			collisionCoordinates,
+			false,
+			result.m_collisionIndices);
+		uint32_t previousCoordinateCount = 0u;
+		uint32_t stride = 1u;
+		const size_t maxLods = data.m_lodDistances.Num() + 1u;
+		for (size_t lod = 0u; lod < maxLods; ++lod)
+		{
+			const auto coordinates = BuildLandscapeLodCoordinates(resolution, stride);
+			if (coordinates.Num() < 2u ||
+				(lod > 0u && coordinates.Num() == previousCoordinateCount))
+			{
+				break;
+			}
+			previousCoordinateCount = static_cast<uint32_t>(coordinates.Num());
+			result.m_lodFirstIndices.Add(static_cast<uint32_t>(result.m_indices.Num()));
+			AppendLandscapeLodIndices(
+				resolution,
+				coordinates,
+				data.m_lodSkirtDepth > 0.0f &&
+					result.m_vertices.Num() >= static_cast<size_t>(baseVertexCount) + row * 4u,
+				result.m_indices);
+			result.m_lodIndexCounts.Add(
+				static_cast<uint32_t>(result.m_indices.Num()) -
+				*result.m_lodFirstIndices.Last());
+			stride *= 2u;
+		}
+	}
+
 	LandscapeChunkCpuData BuildChunk(const LandscapeData& data,
 		const LandscapeCpuTexture& heightmap,
 		const TVector<LandscapeCpuTexture>& materialMasks,
@@ -281,23 +355,13 @@ namespace
 			}
 		}
 
-		result.m_indices.Reserve(static_cast<size_t>(resolution) * resolution * 6u);
-		for (uint32_t z = 0u; z < resolution; ++z)
-		{
-			for (uint32_t x = 0u; x < resolution; ++x)
-			{
-				const uint32_t i0 = z * row + x;
-				const uint32_t i1 = i0 + 1u;
-				const uint32_t i2 = i0 + row;
-				const uint32_t i3 = i2 + 1u;
-				result.m_indices.AddRange({ i0, i2, i1, i1, i2, i3 });
-			}
-		}
+		BuildLandscapeLodGeometry(data, result);
 
 		for (size_t profileIndex = 0u; profileIndex < data.m_vegetationProfiles.Num(); ++profileIndex)
 		{
 			const auto& profile = data.m_vegetationProfiles[profileIndex];
-			if (!profile.m_modelFileId)
+			if (!profile.m_modelFileId ||
+				profile.m_residency == ELandscapeVegetationResidency::Grass)
 			{
 				continue;
 			}
@@ -472,6 +536,200 @@ namespace
 			((chunkIndex & 0xfffffu) << 16u) | (instanceIndex & 0xffffu);
 	}
 
+	enum class EVegetationProxyBuildResult : uint8_t
+	{
+		Success,
+		Pending,
+		NoRenderData
+	};
+
+	EVegetationProxyBuildResult BuildLandscapeVegetationProxy(
+		size_t componentIndex,
+		size_t chunkIndex,
+		size_t profileIndex,
+		const LandscapeVegetationProfile& profile,
+		const glm::mat4& ownerMatrix,
+		uint64_t frame,
+		const TVector<glm::mat4>& instanceTransforms,
+		EMobilityType mobility,
+		uint64_t revision,
+		LandscapeVegetationRenderProxy& result)
+	{
+		const bool bUseMaterialOverride = static_cast<bool>(profile.m_materialFileId);
+		if (!profile.m_model || !profile.m_model->IsReady() ||
+			(bUseMaterialOverride && (!profile.m_material || !profile.m_material->IsReady())))
+		{
+			return EVegetationProxyBuildResult::Pending;
+		}
+
+		TVector<RHI::RHIMeshPtr> vegetationMeshes;
+		TVector<glm::mat4> vegetationModelMatrices;
+		Math::AABB vegetationBounds;
+		if (!profile.m_model->CollectRenderData(
+			profile.m_meshIndex,
+			vegetationMeshes,
+			vegetationModelMatrices,
+			vegetationBounds))
+		{
+			return EVegetationProxyBuildResult::NoRenderData;
+		}
+
+		TVector<MaterialPtr> vegetationMaterials;
+		vegetationMaterials.Reserve(vegetationMeshes.Num());
+		for (size_t meshIndex = 0u; meshIndex < vegetationMeshes.Num(); ++meshIndex)
+		{
+			MaterialPtr material = profile.m_material;
+			if (!bUseMaterialOverride)
+			{
+				const size_t materialIndex = vegetationMeshes[meshIndex]->ResolveMaterialIndex(
+					meshIndex,
+					profile.m_modelMaterials.Num());
+				material = materialIndex < profile.m_modelMaterials.Num() ?
+					profile.m_modelMaterials[materialIndex] : MaterialPtr{};
+			}
+			if (!material || !material->IsReady())
+			{
+				return EVegetationProxyBuildResult::Pending;
+			}
+			vegetationMaterials.Add(std::move(material));
+		}
+
+		RHI::RHISceneViewProxy vegetationProxy;
+		vegetationProxy.m_staticMeshEcs = LandscapeVegetationProxyId(
+			componentIndex,
+			chunkIndex,
+			profileIndex);
+		vegetationProxy.m_mobility = mobility;
+		vegetationProxy.m_worldMatrix = ownerMatrix;
+		vegetationProxy.m_frame = frame;
+		vegetationProxy.m_bCastShadows =
+			profile.m_shadowMode != ELandscapeVegetationShadowMode::None;
+		vegetationProxy.m_lodPolicy.m_bEnabled = true;
+		vegetationProxy.m_lodPolicy.m_minLod = profile.m_minLod;
+		vegetationProxy.m_lodPolicy.m_maxLod = profile.m_maxLod;
+		vegetationProxy.m_lodPolicy.m_screenCoverageThresholds =
+			profile.m_screenCoverageThresholds;
+		vegetationProxy.m_lodPolicy.m_maxCameraDistance = profile.m_cullDistance;
+
+		RHI::RHIInstancedMeshGroup instanceGroup;
+		instanceGroup.m_bCastShadows = vegetationProxy.m_bCastShadows;
+		instanceGroup.m_maxShadowDistance = (std::min)(
+			profile.m_cullDistance,
+			profile.m_shadowMode == ELandscapeVegetationShadowMode::NearOnly ?
+				profile.m_shadowDistance :
+				(std::numeric_limits<float>::max)());
+		instanceGroup.m_materials.Reserve(vegetationMeshes.Num());
+		instanceGroup.m_sourceMaterialShaders.Reserve(vegetationMeshes.Num());
+		instanceGroup.m_renderQueueTags.Reserve(vegetationMeshes.Num());
+		instanceGroup.m_baseColorFactors.Reserve(vegetationMeshes.Num());
+		instanceGroup.m_baseColorSamplers.Reserve(vegetationMeshes.Num());
+		instanceGroup.m_alphaCutoffs.Reserve(vegetationMeshes.Num());
+#if defined(__APPLE__)
+		instanceGroup.m_materialTextureSamplers.Resize(vegetationMeshes.Num());
+#endif
+		auto* textureImporter = App::GetSubmodule<TextureImporter>();
+		for (size_t meshIndex = 0u; meshIndex < vegetationMeshes.Num(); ++meshIndex)
+		{
+			MaterialPtr& material = vegetationMaterials[meshIndex];
+			instanceGroup.m_sourceMaterialShaders.Add(material->GetShader());
+			instanceGroup.m_materials.Add(material->GetOrAddRHI(
+				vegetationMeshes[meshIndex]->m_vertexDescription));
+			instanceGroup.m_renderQueueTags.Add(material->GetRenderState().GetTag());
+
+			glm::vec4 baseColorFactor{ 1.0f };
+			const glm::vec4* materialBaseColorFactor = nullptr;
+			if (!material->GetUniformsVec4().Find(
+				"material.baseColorFactor",
+				materialBaseColorFactor))
+			{
+				material->GetUniformsVec4().Find("material.albedo", materialBaseColorFactor);
+			}
+			if (materialBaseColorFactor)
+			{
+				baseColorFactor = *materialBaseColorFactor;
+			}
+			instanceGroup.m_baseColorFactors.Add(baseColorFactor);
+
+			float alphaCutoff = 0.5f;
+			const float* materialAlphaCutoff = nullptr;
+			if (material->GetUniformsFloat().Find(
+				"material.alphaCutoff",
+				materialAlphaCutoff) && materialAlphaCutoff)
+			{
+				alphaCutoff = *materialAlphaCutoff;
+			}
+			instanceGroup.m_alphaCutoffs.Add(alphaCutoff);
+
+			uint32_t baseColorSampler = 0u;
+			const TexturePtr* baseColorTexture = nullptr;
+			if (!material->GetSamplers().Find("baseColorSampler", baseColorTexture))
+			{
+				material->GetSamplers().Find("albedoSampler", baseColorTexture);
+			}
+			if (textureImporter && baseColorTexture && *baseColorTexture)
+			{
+				baseColorSampler = static_cast<uint32_t>(
+					textureImporter->GetTextureIndex((*baseColorTexture)->GetFileId()));
+			}
+			instanceGroup.m_baseColorSamplers.Add(baseColorSampler);
+#if defined(__APPLE__)
+			auto& requested = instanceGroup.m_materialTextureSamplers[meshIndex];
+			requested.Insert(0u);
+			if (textureImporter)
+			{
+				for (const auto& sampler : material->GetSamplers())
+				{
+					requested.Insert(sampler.m_second ? static_cast<uint32_t>(
+						textureImporter->GetTextureIndex(sampler.m_second->GetFileId())) : 0u);
+				}
+			}
+#endif
+		}
+
+		instanceGroup.m_meshes = std::move(vegetationMeshes);
+		instanceGroup.m_meshTransforms = std::move(vegetationModelMatrices);
+		instanceGroup.m_instanceTransforms = instanceTransforms;
+		Math::AABB batchedVegetationBounds;
+		for (const auto& localInstanceMatrix : instanceTransforms)
+		{
+			const glm::mat4 instanceMatrix = ownerMatrix * localInstanceMatrix;
+			Math::AABB instanceBounds = vegetationBounds;
+			instanceBounds.Apply(instanceMatrix);
+			batchedVegetationBounds.Extend(instanceBounds);
+		}
+		if (instanceGroup.m_instanceTransforms.IsEmpty() ||
+			instanceGroup.m_meshes.IsEmpty() ||
+			!batchedVegetationBounds.IsValid())
+		{
+			return EVegetationProxyBuildResult::NoRenderData;
+		}
+
+		vegetationProxy.m_worldAabb = batchedVegetationBounds;
+		auto vegetationShadowCaster = RHI::RHIShadowCasterProxyPtr::Make();
+		vegetationShadowCaster->m_staticMeshEcs = vegetationProxy.m_staticMeshEcs;
+		vegetationShadowCaster->m_mobility = mobility;
+		vegetationShadowCaster->m_skeletonOffset =
+			(std::numeric_limits<uint32_t>::max)();
+		vegetationShadowCaster->m_frame = vegetationProxy.m_frame;
+		vegetationShadowCaster->m_lodPolicy = vegetationProxy.m_lodPolicy;
+		vegetationShadowCaster->m_worldAabb = vegetationProxy.m_worldAabb;
+		vegetationProxy.m_shadowCaster = vegetationProxy.m_bCastShadows ?
+			vegetationShadowCaster : RHI::RHIShadowCasterProxyPtr{};
+		vegetationProxy.m_instancedGroups.Add(std::move(instanceGroup));
+
+		GetOctreeBounds(
+			vegetationProxy.m_worldAabb,
+			result.m_octreeCenter,
+			result.m_octreeExtents);
+		result.m_resource = RHI::RHISceneProxyResourcePtr::Make(
+			std::move(vegetationProxy));
+		result.m_profileIndex = profileIndex;
+		result.m_instanceCount = static_cast<uint32_t>(instanceTransforms.Num());
+		result.m_revision = revision;
+		result.m_mobility = mobility;
+		return EVegetationProxyBuildResult::Success;
+	}
+
 	bool AreVegetationProfileSettingsEqual(
 		const LandscapeVegetationProfile& lhs,
 		const LandscapeVegetationProfile& rhs)
@@ -480,6 +738,8 @@ namespace
 			lhs.m_materialFileId == rhs.m_materialFileId &&
 			lhs.m_meshIndex == rhs.m_meshIndex &&
 			lhs.m_instancesPerChunk == rhs.m_instancesPerChunk &&
+			lhs.m_residency == rhs.m_residency &&
+			lhs.m_priority == rhs.m_priority &&
 			lhs.m_minScale == rhs.m_minScale &&
 			lhs.m_maxScale == rhs.m_maxScale &&
 			lhs.m_groundOffset == rhs.m_groundOffset &&
@@ -575,6 +835,91 @@ namespace
 			MarkChunksIntersectingStamp(data, current, offset, margin);
 		}
 	}
+
+	float SampleLandscapeChunkHeight(
+		const LandscapeData& data,
+		const LandscapeChunk& chunk,
+		float x,
+		float z)
+	{
+		const uint32_t resolution = chunk.m_heightResolution;
+		const uint32_t row = resolution + 1u;
+		if (resolution == 0u ||
+			chunk.m_heightSamples.Num() < static_cast<size_t>(row) * row)
+		{
+			return 0.0f;
+		}
+
+		const float landscapeWidth = data.m_chunksX * data.m_chunkSize;
+		const float landscapeDepth = data.m_chunksZ * data.m_chunkSize;
+		const float originX = chunk.m_chunkX * data.m_chunkSize - landscapeWidth * 0.5f;
+		const float originZ = chunk.m_chunkZ * data.m_chunkSize - landscapeDepth * 0.5f;
+		const float sampleX = (std::clamp)(
+			(x - originX) / data.m_chunkSize,
+			0.0f,
+			1.0f) * resolution;
+		const float sampleZ = (std::clamp)(
+			(z - originZ) / data.m_chunkSize,
+			0.0f,
+			1.0f) * resolution;
+		const uint32_t x0 = static_cast<uint32_t>(std::floor(sampleX));
+		const uint32_t z0 = static_cast<uint32_t>(std::floor(sampleZ));
+		const uint32_t x1 = (std::min)(x0 + 1u, resolution);
+		const uint32_t z1 = (std::min)(z0 + 1u, resolution);
+		const float tx = sampleX - static_cast<float>(x0);
+		const float tz = sampleZ - static_cast<float>(z0);
+		const float a = glm::mix(
+			chunk.m_heightSamples[static_cast<size_t>(z0) * row + x0],
+			chunk.m_heightSamples[static_cast<size_t>(z0) * row + x1],
+			tx);
+		const float b = glm::mix(
+			chunk.m_heightSamples[static_cast<size_t>(z1) * row + x0],
+			chunk.m_heightSamples[static_cast<size_t>(z1) * row + x1],
+			tx);
+		return glm::mix(a, b, tz);
+	}
+
+	TVector<glm::mat4> BuildGrassInstanceTransforms(
+		const LandscapeData& data,
+		const LandscapeChunk& chunk,
+		size_t profileIndex,
+		uint32_t instanceCount)
+	{
+		TVector<glm::mat4> result;
+		if (profileIndex >= data.m_vegetationProfiles.Num())
+		{
+			return result;
+		}
+		const auto& profile = data.m_vegetationProfiles[profileIndex];
+		const float landscapeWidth = data.m_chunksX * data.m_chunkSize;
+		const float landscapeDepth = data.m_chunksZ * data.m_chunkSize;
+		const float originX = chunk.m_chunkX * data.m_chunkSize - landscapeWidth * 0.5f;
+		const float originZ = chunk.m_chunkZ * data.m_chunkSize - landscapeDepth * 0.5f;
+		result.Reserve(instanceCount);
+		for (uint32_t instance = 0u; instance < instanceCount; ++instance)
+		{
+			const uint32_t randomSeed = data.m_seed ^
+				static_cast<uint32_t>(chunk.m_chunkX * 92821u +
+					chunk.m_chunkZ * 68917u +
+					profileIndex * 4099u +
+					instance * 131u);
+			glm::vec3 position;
+			position.x = originX + Random01(randomSeed) * data.m_chunkSize;
+			position.z = originZ + Random01(randomSeed + 1u) * data.m_chunkSize;
+			position.y = SampleLandscapeChunkHeight(data, chunk, position.x, position.z) +
+				profile.m_groundOffset;
+			const float angle = Random01(randomSeed + 2u) * glm::two_pi<float>();
+			const float scale = glm::mix(
+				profile.m_minScale,
+				profile.m_maxScale,
+				Random01(randomSeed + 3u));
+			result.Add(
+				glm::translate(glm::mat4(1.0f), position) *
+				glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 1.0f, 0.0f)) *
+				glm::scale(glm::mat4(1.0f), glm::vec3(scale)));
+		}
+		return result;
+	}
 }
 
 void LandscapeData::SetSettings(uint32_t chunksX, uint32_t chunksZ,
@@ -622,6 +967,53 @@ void LandscapeData::SetMaterial(const MaterialPtr& material)
 	m_cachedSourceMaterialContentRevision = 0ull;
 	m_cachedSourceMaterialRenderMetadataRevision = 0ull;
 	RequestFullRebuild();
+}
+
+void LandscapeData::SetLodSettings(
+	const TVector<float>& distances,
+	float skirtDepth)
+{
+	TVector<float> normalizedDistances;
+	normalizedDistances.Reserve((std::min)(distances.Num(), size_t(7u)));
+	for (float distance : distances)
+	{
+		if (normalizedDistances.Num() >= 7u)
+		{
+			break;
+		}
+		if (std::isfinite(distance))
+		{
+			normalizedDistances.Add((std::max)(distance, 1.0f));
+		}
+	}
+	std::sort(normalizedDistances.begin(), normalizedDistances.end());
+	const float normalizedSkirtDepth = std::isfinite(skirtDepth) ?
+		(std::clamp)(skirtDepth, 0.0f, 64.0f) : 2.0f;
+	if (m_lodDistances == normalizedDistances &&
+		m_lodSkirtDepth == normalizedSkirtDepth)
+	{
+		return;
+	}
+	m_lodDistances = std::move(normalizedDistances);
+	m_lodSkirtDepth = normalizedSkirtDepth;
+	RequestFullRebuild();
+}
+
+void LandscapeData::SetVegetationStreamingSettings(
+	uint32_t grassInstanceBudget,
+	float grassResidencyHysteresis)
+{
+	const uint32_t normalizedBudget = (std::min)(grassInstanceBudget, 1048576u);
+	const float normalizedHysteresis = std::isfinite(grassResidencyHysteresis) ?
+		(std::clamp)(grassResidencyHysteresis, 0.0f, 512.0f) : 12.0f;
+	if (m_grassInstanceBudget == normalizedBudget &&
+		m_grassResidencyHysteresis == normalizedHysteresis)
+	{
+		return;
+	}
+	m_grassInstanceBudget = normalizedBudget;
+	m_grassResidencyHysteresis = normalizedHysteresis;
+	MarkDirty();
 }
 
 void LandscapeData::SetLayerTextures(const TVector<FileId>& textures)
@@ -698,6 +1090,8 @@ void LandscapeData::SetVegetationProfiles(
 	const TVector<FileId>& materials,
 	const TVector<float>& meshIndex,
 	const TVector<float>& instancesPerChunk,
+	const TVector<float>& residency,
+	const TVector<float>& priority,
 	const TVector<float>& minScale,
 	const TVector<float>& maxScale,
 	const TVector<float>& groundOffset,
@@ -724,6 +1118,11 @@ void LandscapeData::SetVegetationProfiles(
 			GetProfileValue(meshIndex, index, -1.0f), -1.0f, 65535.0f));
 		profile.m_instancesPerChunk = static_cast<uint32_t>((std::clamp)(
 			GetProfileValue(instancesPerChunk, index, 0.0f), 0.0f, 2048.0f));
+		profile.m_residency = static_cast<ELandscapeVegetationResidency>(
+			static_cast<uint32_t>((std::clamp)(
+				GetProfileValue(residency, index, 0.0f), 0.0f, 1.0f)));
+		profile.m_priority = (std::clamp)(
+			GetProfileValue(priority, index, 1.0f), 0.0f, 100.0f);
 		profile.m_minScale = (std::max)(GetProfileValue(minScale, index, 0.75f), 0.01f);
 		profile.m_maxScale = (std::max)(GetProfileValue(maxScale, index, 1.25f), profile.m_minScale);
 		profile.m_groundOffset = GetProfileValue(groundOffset, index, 0.0f);
@@ -746,6 +1145,10 @@ void LandscapeData::SetVegetationProfiles(
 		profile.m_colliderHeight = (std::max)(GetProfileValue(colliderHeight, index, 2.0f),
 			profile.m_colliderRadius * 2.0f);
 		profile.m_colliderOffsetY = GetProfileValue(colliderOffsetY, index, 1.0f);
+		if (profile.m_residency == ELandscapeVegetationResidency::Grass)
+		{
+			profile.m_colliderRadius = 0.0f;
+		}
 		profiles.Add(std::move(profile));
 	}
 
@@ -834,6 +1237,10 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 {
 	SAILOR_PROFILE_FUNCTION();
 	bool bSceneChanged = false;
+	const auto* cameraEcs = GetWorld() ? GetWorld()->GetECS<CameraECS>() : nullptr;
+	const TVector<Math::Transform> noCameraTransforms;
+	const auto& cameraTransforms = cameraEcs ?
+		cameraEcs->GetActiveCameraTransforms() : noCameraTransforms;
 	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
 	{
 		if (!IsComponentRegistered(componentIndex))
@@ -904,6 +1311,10 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		}
 		if (!data.IsDirty() && !transformChanged)
 		{
+			bSceneChanged |= UpdateGrassResidency(
+				componentIndex,
+				data,
+				cameraTransforms);
 			continue;
 		}
 		if (!owner || !bTerrainMaterialReady)
@@ -981,6 +1392,10 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		{
 			data.m_bIsDirty = false;
 			data.SetLastChange(owner->GetTransformComponent().GetFrameLastChange());
+			bSceneChanged |= UpdateGrassResidency(
+				componentIndex,
+				data,
+				cameraTransforms);
 			continue;
 		}
 
@@ -1041,15 +1456,23 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 				DestroyChunkPhysicsBodies(data, data.m_chunks[chunkIndex]);
 			}
 			LandscapeChunk chunk;
+			chunk.m_chunkX = cpu.m_chunkX;
+			chunk.m_chunkZ = cpu.m_chunkZ;
+			chunk.m_heightResolution = data.m_chunkResolution;
+			const size_t terrainVertexCount =
+				static_cast<size_t>(data.m_chunkResolution + 1u) *
+				(data.m_chunkResolution + 1u);
+			chunk.m_heightSamples.Resize(terrainVertexCount);
 			TVector<glm::vec3> collisionVertices;
-			collisionVertices.Resize(cpu.m_vertices.Num());
-			for (size_t vertexIndex = 0u; vertexIndex < cpu.m_vertices.Num(); ++vertexIndex)
+			collisionVertices.Resize(terrainVertexCount);
+			for (size_t vertexIndex = 0u; vertexIndex < terrainVertexCount; ++vertexIndex)
 			{
 				collisionVertices[vertexIndex] = cpu.m_vertices[vertexIndex].m_position;
+				chunk.m_heightSamples[vertexIndex] = cpu.m_vertices[vertexIndex].m_position.y;
 			}
 			uint32_t physicsBodyId = RigidBodyData::InvalidBodyId;
 			if (physics && physics->CreateStaticTriangleMesh(owner->GetInstanceId(),
-				collisionVertices, cpu.m_indices, glm::vec3(ownerTransform.m_position),
+				collisionVertices, cpu.m_collisionIndices, glm::vec3(ownerTransform.m_position),
 				ownerTransform.m_rotation, glm::vec3(ownerTransform.m_scale), physicsBodyId))
 			{
 				data.m_physicsBodies.Add(physicsBodyId);
@@ -1084,9 +1507,27 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			mesh->m_vertexDescription = RHI::Renderer::GetDriver()->GetOrAddVertexDescription<RHI::VertexP3N3T3B3UV2C4>();
 			mesh->m_bounds = cpu.m_localBounds;
 			mesh->m_materialIndex = 0u;
+			mesh->m_indexCount = cpu.m_lodIndexCounts.IsEmpty() ?
+				static_cast<uint32_t>(cpu.m_indices.Num()) : cpu.m_lodIndexCounts[0];
+			mesh->m_firstIndex = 0u;
+			mesh->m_vertexOffset = 0u;
 			RHI::Renderer::GetDriver()->UpdateMesh(mesh,
 				cpu.m_vertices.GetData(), cpu.m_vertices.Num() * sizeof(RHI::VertexP3N3T3B3UV2C4),
 				cpu.m_indices.GetData(), cpu.m_indices.Num() * sizeof(uint32_t));
+			for (size_t lodIndex = 1u; lodIndex < cpu.m_lodIndexCounts.Num(); ++lodIndex)
+			{
+				auto lodMesh = RHI::Renderer::GetDriver()->CreateMesh();
+				lodMesh->m_vertexDescription = mesh->m_vertexDescription;
+				lodMesh->m_vertexBuffer = mesh->m_vertexBuffer;
+				lodMesh->m_indexBuffer = mesh->m_indexBuffer;
+				lodMesh->m_bounds = mesh->m_bounds;
+				lodMesh->m_materialIndex = mesh->m_materialIndex;
+				lodMesh->m_bakedVolumeScale = mesh->m_bakedVolumeScale;
+				lodMesh->m_indexCount = cpu.m_lodIndexCounts[lodIndex];
+				lodMesh->m_firstIndex = cpu.m_lodFirstIndices[lodIndex];
+				lodMesh->m_vertexOffset = 0u;
+				mesh->m_lods.Add(std::move(lodMesh));
+			}
 
 			RHI::RHISceneViewProxy proxy;
 			proxy.m_staticMeshEcs = LandscapeProxyId(componentIndex, chunkIndex);
@@ -1095,6 +1536,14 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			proxy.m_worldAabb.Apply(ownerMatrix);
 			proxy.m_frame = GetWorld()->GetCurrentFrame();
 			proxy.m_bCastShadows = true;
+			proxy.m_lodPolicy.m_bEnabled = !mesh->m_lods.IsEmpty();
+			proxy.m_lodPolicy.m_minLod = 0u;
+			proxy.m_lodPolicy.m_maxLod = mesh->GetNumLods() - 1u;
+			proxy.m_lodPolicy.m_cameraDistanceThresholds = data.m_lodDistances;
+			if (proxy.m_lodPolicy.m_cameraDistanceThresholds.Num() >= mesh->GetNumLods())
+			{
+				proxy.m_lodPolicy.m_cameraDistanceThresholds.Resize(mesh->GetNumLods() - 1u);
+			}
 			proxy.m_meshes.Add(mesh);
 			proxy.m_meshModelMatrices.Add(ownerMatrix);
 			proxy.m_overrideMaterials.Add(data.m_runtimeMaterial->GetOrAddRHI(mesh->m_vertexDescription));
@@ -1102,6 +1551,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			AppendDepthMaterialMetadata(proxy, data.m_runtimeMaterial);
 			auto shadowCaster = RHI::RHIShadowCasterProxyPtr::Make();
 			shadowCaster->m_staticMeshEcs = proxy.m_staticMeshEcs;
+			shadowCaster->m_lodPolicy = proxy.m_lodPolicy;
 			shadowCaster->m_skeletonOffset = (std::numeric_limits<uint32_t>::max)();
 			shadowCaster->m_frame = proxy.m_frame;
 			AppendShadowMesh(*shadowCaster, mesh, ownerMatrix, data.m_runtimeMaterial,
@@ -1128,182 +1578,49 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			for (size_t profileIndex = 0u; profileIndex < data.m_vegetationProfiles.Num(); ++profileIndex)
 			{
 				auto& profile = data.m_vegetationProfiles[profileIndex];
-				const bool bUseMaterialOverride = static_cast<bool>(profile.m_materialFileId);
-				if (!profile.m_model || !profile.m_model->IsReady() ||
-					(bUseMaterialOverride && (!profile.m_material || !profile.m_material->IsReady())))
+				if (profile.m_residency == ELandscapeVegetationResidency::Grass)
 				{
-					++vegetationProfilesNotReady;
-					bVegetationResourcesPending = bVegetationResourcesPending ||
-						(profile.m_model && (!bUseMaterialOverride || profile.m_material));
 					continue;
 				}
 
-				TVector<RHI::RHIMeshPtr> vegetationMeshes;
-				TVector<glm::mat4> vegetationModelMatrices;
-				Math::AABB vegetationBounds;
-				if (!profile.m_model->CollectRenderData(profile.m_meshIndex,
-					vegetationMeshes, vegetationModelMatrices, vegetationBounds))
-				{
-					++vegetationProfilesWithoutRenderData;
-					continue;
-				}
-				TVector<MaterialPtr> vegetationMaterials;
-				vegetationMaterials.Reserve(vegetationMeshes.Num());
-				bool bVegetationMaterialsReady = true;
-				for (size_t meshIndex = 0u; meshIndex < vegetationMeshes.Num(); ++meshIndex)
-				{
-					MaterialPtr material = profile.m_material;
-					if (!bUseMaterialOverride)
-					{
-						const size_t materialIndex = vegetationMeshes[meshIndex]->ResolveMaterialIndex(
-							meshIndex, profile.m_modelMaterials.Num());
-						material = materialIndex < profile.m_modelMaterials.Num() ?
-							profile.m_modelMaterials[materialIndex] : MaterialPtr{};
-					}
-					if (!material || !material->IsReady())
-					{
-						bVegetationMaterialsReady = false;
-						break;
-					}
-					vegetationMaterials.Add(std::move(material));
-				}
-				if (!bVegetationMaterialsReady)
-				{
-					++vegetationProfilesNotReady;
-					bVegetationResourcesPending = bVegetationResourcesPending ||
-						(!bUseMaterialOverride && !profile.m_modelMaterials.IsEmpty());
-					continue;
-				}
-				LandscapeVegetationRenderProxy vegetationRenderProxy;
-				RHI::RHISceneViewProxy vegetationProxy;
-				vegetationProxy.m_staticMeshEcs = LandscapeVegetationProxyId(
-					componentIndex, chunkIndex, profileIndex);
-				vegetationProxy.m_worldMatrix = ownerMatrix;
-				vegetationProxy.m_frame = proxy.m_frame;
-				vegetationProxy.m_bCastShadows =
-					profile.m_shadowMode != ELandscapeVegetationShadowMode::None;
-				vegetationProxy.m_lodPolicy.m_bEnabled = true;
-				vegetationProxy.m_lodPolicy.m_minLod = profile.m_minLod;
-				vegetationProxy.m_lodPolicy.m_maxLod = profile.m_maxLod;
-				vegetationProxy.m_lodPolicy.m_screenCoverageThresholds =
-					profile.m_screenCoverageThresholds;
-				vegetationProxy.m_lodPolicy.m_maxCameraDistance = profile.m_cullDistance;
-				RHI::RHIInstancedMeshGroup instanceGroup;
-				instanceGroup.m_bCastShadows = vegetationProxy.m_bCastShadows;
-				instanceGroup.m_maxShadowDistance = (std::min)(profile.m_cullDistance,
-					profile.m_shadowMode == ELandscapeVegetationShadowMode::NearOnly ?
-					profile.m_shadowDistance : (std::numeric_limits<float>::max)());
-				instanceGroup.m_materials.Reserve(vegetationMeshes.Num());
-				instanceGroup.m_sourceMaterialShaders.Reserve(vegetationMeshes.Num());
-				instanceGroup.m_renderQueueTags.Reserve(vegetationMeshes.Num());
-				instanceGroup.m_baseColorFactors.Reserve(vegetationMeshes.Num());
-				instanceGroup.m_baseColorSamplers.Reserve(vegetationMeshes.Num());
-				instanceGroup.m_alphaCutoffs.Reserve(vegetationMeshes.Num());
-#if defined(__APPLE__)
-				instanceGroup.m_materialTextureSamplers.Resize(vegetationMeshes.Num());
-#endif
-				for (size_t meshIndex = 0u; meshIndex < vegetationMeshes.Num(); ++meshIndex)
-				{
-					MaterialPtr& material = vegetationMaterials[meshIndex];
-					instanceGroup.m_sourceMaterialShaders.Add(material->GetShader());
-					instanceGroup.m_materials.Add(material->GetOrAddRHI(
-						vegetationMeshes[meshIndex]->m_vertexDescription));
-					instanceGroup.m_renderQueueTags.Add(material->GetRenderState().GetTag());
-
-					glm::vec4 baseColorFactor{ 1.0f };
-					const glm::vec4* materialBaseColorFactor = nullptr;
-					if (!material->GetUniformsVec4().Find(
-						"material.baseColorFactor",
-						materialBaseColorFactor))
-					{
-						material->GetUniformsVec4().Find("material.albedo", materialBaseColorFactor);
-					}
-					if (materialBaseColorFactor)
-					{
-						baseColorFactor = *materialBaseColorFactor;
-					}
-					instanceGroup.m_baseColorFactors.Add(baseColorFactor);
-
-					float alphaCutoff = 0.5f;
-					const float* materialAlphaCutoff = nullptr;
-					if (material->GetUniformsFloat().Find(
-						"material.alphaCutoff",
-						materialAlphaCutoff) && materialAlphaCutoff)
-					{
-						alphaCutoff = *materialAlphaCutoff;
-					}
-					instanceGroup.m_alphaCutoffs.Add(alphaCutoff);
-
-					uint32_t baseColorSampler = 0u;
-					const TexturePtr* baseColorTexture = nullptr;
-					if (!material->GetSamplers().Find("baseColorSampler", baseColorTexture))
-					{
-						material->GetSamplers().Find("albedoSampler", baseColorTexture);
-					}
-					if (textureImporter && baseColorTexture && *baseColorTexture)
-					{
-						baseColorSampler = static_cast<uint32_t>(
-							textureImporter->GetTextureIndex((*baseColorTexture)->GetFileId()));
-					}
-					instanceGroup.m_baseColorSamplers.Add(baseColorSampler);
-#if defined(__APPLE__)
-					auto& requested = instanceGroup.m_materialTextureSamplers[meshIndex];
-					requested.Insert(0u);
-					if (textureImporter)
-					{
-						for (const auto& sampler : material->GetSamplers())
-						{
-							requested.Insert(sampler.m_second ? static_cast<uint32_t>(
-								textureImporter->GetTextureIndex(sampler.m_second->GetFileId())) : 0u);
-						}
-					}
-#endif
-				}
-				instanceGroup.m_meshes = std::move(vegetationMeshes);
-				instanceGroup.m_meshTransforms = std::move(vegetationModelMatrices);
-				auto vegetationShadowCaster = RHI::RHIShadowCasterProxyPtr::Make();
-				vegetationShadowCaster->m_staticMeshEcs = vegetationProxy.m_staticMeshEcs;
-				vegetationShadowCaster->m_skeletonOffset =
-					(std::numeric_limits<uint32_t>::max)();
-				vegetationShadowCaster->m_frame = vegetationProxy.m_frame;
-				vegetationShadowCaster->m_lodPolicy.m_bEnabled = true;
-				vegetationShadowCaster->m_lodPolicy.m_minLod = profile.m_minLod;
-				vegetationShadowCaster->m_lodPolicy.m_maxLod = profile.m_maxLod;
-				vegetationShadowCaster->m_lodPolicy.m_screenCoverageThresholds =
-					profile.m_screenCoverageThresholds;
-				Math::AABB batchedVegetationBounds;
+				TVector<glm::mat4> instanceTransforms;
+				instanceTransforms.Reserve(profile.m_instancesPerChunk);
 				for (const auto& placement : cpu.m_vegetation)
 				{
 					if (placement.m_profileIndex != profileIndex)
 					{
 						continue;
 					}
-
-					const glm::mat4 localInstanceMatrix =
+					instanceTransforms.Add(
 						glm::translate(glm::mat4(1.0f), placement.m_position) *
-						glm::rotate(glm::mat4(1.0f), placement.m_angle, glm::vec3(0.0f, 1.0f, 0.0f)) *
-						glm::scale(glm::mat4(1.0f), glm::vec3(placement.m_scale));
-					instanceGroup.m_instanceTransforms.Add(localInstanceMatrix);
-					const glm::mat4 instanceMatrix = ownerMatrix * localInstanceMatrix;
-					Math::AABB instanceBounds = vegetationBounds;
-					instanceBounds.Apply(instanceMatrix);
-					batchedVegetationBounds.Extend(instanceBounds);
+						glm::rotate(glm::mat4(1.0f), placement.m_angle,
+							glm::vec3(0.0f, 1.0f, 0.0f)) *
+						glm::scale(glm::mat4(1.0f), glm::vec3(placement.m_scale)));
 				}
-				if (instanceGroup.m_instanceTransforms.IsEmpty() ||
-					instanceGroup.m_meshes.IsEmpty() ||
-					!batchedVegetationBounds.IsValid())
+
+				LandscapeVegetationRenderProxy vegetationRenderProxy;
+				const auto buildResult = BuildLandscapeVegetationProxy(
+					componentIndex,
+					chunkIndex,
+					profileIndex,
+					profile,
+					ownerMatrix,
+					proxy.m_frame,
+					instanceTransforms,
+					EMobilityType::Static,
+					data.m_buildRevision + 1u,
+					vegetationRenderProxy);
+				if (buildResult == EVegetationProxyBuildResult::Pending)
 				{
+					++vegetationProfilesNotReady;
+					bVegetationResourcesPending = true;
 					continue;
 				}
-				vegetationProxy.m_worldAabb = batchedVegetationBounds;
-				vegetationShadowCaster->m_worldAabb = vegetationProxy.m_worldAabb;
-				vegetationProxy.m_shadowCaster = vegetationProxy.m_bCastShadows ?
-					vegetationShadowCaster : RHI::RHIShadowCasterProxyPtr{};
-				vegetationProxy.m_instancedGroups.Add(std::move(instanceGroup));
-				GetOctreeBounds(vegetationProxy.m_worldAabb,
-					vegetationRenderProxy.m_octreeCenter, vegetationRenderProxy.m_octreeExtents);
-				vegetationRenderProxy.m_resource =
-					RHI::RHISceneProxyResourcePtr::Make(std::move(vegetationProxy));
+				if (buildResult == EVegetationProxyBuildResult::NoRenderData)
+				{
+					++vegetationProfilesWithoutRenderData;
+					continue;
+				}
 				chunk.m_vegetationProxies.Add(std::move(vegetationRenderProxy));
 				++vegetationRenderProxies;
 			}
@@ -1325,6 +1642,10 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		data.SetLastChange(owner->GetTransformComponent().GetFrameLastChange());
 		++m_shadowCastersRevision;
 		bSceneChanged = true;
+		bSceneChanged |= UpdateGrassResidency(
+			componentIndex,
+			data,
+			cameraTransforms);
 		size_t vegetationPerChunk = 0u;
 		for (const auto& profile : data.m_vegetationProfiles)
 		{
@@ -1345,6 +1666,206 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 	return nullptr;
 }
 
+bool LandscapeECS::UpdateGrassResidency(
+	size_t componentIndex,
+	LandscapeData& component,
+	const TVector<Math::Transform>& cameraTransforms)
+{
+	if (component.m_chunks.IsEmpty())
+	{
+		component.m_activeGrassInstances = 0u;
+		return false;
+	}
+
+	auto grassKey = [&component](size_t chunkIndex, size_t profileIndex)
+		{
+			return chunkIndex * component.m_vegetationProfiles.Num() + profileIndex;
+		};
+	auto findResident = [](const LandscapeChunk& chunk, size_t profileIndex)
+		-> const LandscapeVegetationRenderProxy*
+		{
+			for (const auto& proxy : chunk.m_vegetationProxies)
+			{
+				if (proxy.m_mobility == EMobilityType::Dynamic &&
+					proxy.m_profileIndex == profileIndex)
+				{
+					return &proxy;
+				}
+			}
+			return nullptr;
+		};
+
+	TVector<LandscapeGrassCandidate> candidates;
+	for (size_t chunkIndex = 0u; chunkIndex < component.m_chunks.Num(); ++chunkIndex)
+	{
+		const auto& chunk = component.m_chunks[chunkIndex];
+		if (!chunk.m_resource || cameraTransforms.IsEmpty())
+		{
+			continue;
+		}
+		const Math::AABB& worldBounds = chunk.m_resource->m_proxy.m_worldAabb;
+		float minCameraDistance = (std::numeric_limits<float>::infinity)();
+		for (const auto& cameraTransform : cameraTransforms)
+		{
+			const glm::vec3 cameraPosition(cameraTransform.m_position);
+			const glm::vec3 closest = glm::clamp(
+				cameraPosition,
+				worldBounds.m_min,
+				worldBounds.m_max);
+			minCameraDistance = (std::min)(
+				minCameraDistance,
+				glm::distance(cameraPosition, closest));
+		}
+
+		for (size_t profileIndex = 0u;
+			profileIndex < component.m_vegetationProfiles.Num();
+			++profileIndex)
+		{
+			const auto& profile = component.m_vegetationProfiles[profileIndex];
+			if (profile.m_residency != ELandscapeVegetationResidency::Grass ||
+				!profile.m_modelFileId ||
+				profile.m_instancesPerChunk == 0u)
+			{
+				continue;
+			}
+			const bool bResident = findResident(chunk, profileIndex) != nullptr;
+			const float residencyDistance = profile.m_cullDistance +
+				(bResident ? component.m_grassResidencyHysteresis : 0.0f);
+			if (minCameraDistance > residencyDistance)
+			{
+				continue;
+			}
+			LandscapeGrassCandidate candidate;
+			candidate.m_chunkIndex = chunkIndex;
+			candidate.m_profileIndex = profileIndex;
+			candidate.m_capacity = profile.m_instancesPerChunk;
+			candidate.m_priority = profile.m_priority;
+			candidate.m_distance = minCameraDistance;
+			candidate.m_bResident = bResident;
+			candidate.m_residencyHysteresis =
+				component.m_grassResidencyHysteresis;
+			candidates.Add(std::move(candidate));
+		}
+	}
+
+	const auto selections = SelectLandscapeGrassResidency(
+		std::move(candidates),
+		component.m_grassInstanceBudget);
+	TMap<size_t, uint32_t> selectedCounts;
+	for (const auto& selection : selections)
+	{
+		selectedCounts[grassKey(
+			selection.m_chunkIndex,
+			selection.m_profileIndex)] = selection.m_instanceCount;
+	}
+
+	GameObjectPtr owner = const_cast<ObjectPtr&>(component.GetOwner()).StaticCast<GameObject>();
+	if (!owner)
+	{
+		return false;
+	}
+	const glm::mat4 ownerMatrix = owner->GetTransformComponent().GetCachedWorldMatrix();
+	const uint64_t frame = GetWorld()->GetCurrentFrame();
+	bool bChanged = false;
+	uint32_t activeInstances = 0u;
+	for (size_t chunkIndex = 0u; chunkIndex < component.m_chunks.Num(); ++chunkIndex)
+	{
+		auto& chunk = component.m_chunks[chunkIndex];
+		TVector<LandscapeVegetationRenderProxy> nextProxies;
+		nextProxies.Reserve(chunk.m_vegetationProxies.Num());
+		for (const auto& proxy : chunk.m_vegetationProxies)
+		{
+			if (proxy.m_mobility != EMobilityType::Dynamic)
+			{
+				nextProxies.Add(proxy);
+			}
+		}
+
+		for (size_t profileIndex = 0u;
+			profileIndex < component.m_vegetationProfiles.Num();
+			++profileIndex)
+		{
+			const auto& profile = component.m_vegetationProfiles[profileIndex];
+			if (profile.m_residency != ELandscapeVegetationResidency::Grass)
+			{
+				continue;
+			}
+
+			const LandscapeVegetationRenderProxy* resident =
+				findResident(chunk, profileIndex);
+			const uint32_t* selectedCountPtr = nullptr;
+			selectedCounts.Find(
+				grassKey(chunkIndex, profileIndex),
+				selectedCountPtr);
+			const uint32_t selectedCount = selectedCountPtr ? *selectedCountPtr : 0u;
+			if (selectedCount == 0u)
+			{
+				bChanged |= resident != nullptr;
+				continue;
+			}
+			if (resident && resident->m_instanceCount == selectedCount)
+			{
+				nextProxies.Add(*resident);
+				activeInstances += resident->m_instanceCount;
+				continue;
+			}
+
+			const auto instanceTransforms = BuildGrassInstanceTransforms(
+				component,
+				chunk,
+				profileIndex,
+				selectedCount);
+			LandscapeVegetationRenderProxy streamedProxy;
+			const uint64_t revision = (uint64_t(1u) << 63u) |
+				++component.m_streamingRevision;
+			const auto buildResult = BuildLandscapeVegetationProxy(
+				componentIndex,
+				chunkIndex,
+				profileIndex,
+				profile,
+				ownerMatrix,
+				frame,
+				instanceTransforms,
+				EMobilityType::Dynamic,
+				revision,
+				streamedProxy);
+			if (buildResult != EVegetationProxyBuildResult::Success)
+			{
+				if (resident && resident->m_instanceCount <= selectedCount)
+				{
+					nextProxies.Add(*resident);
+					activeInstances += resident->m_instanceCount;
+				}
+				else if (resident)
+				{
+					bChanged = true;
+				}
+				continue;
+			}
+			nextProxies.Add(std::move(streamedProxy));
+			activeInstances += selectedCount;
+			bChanged = true;
+		}
+
+		if (nextProxies.Num() != chunk.m_vegetationProxies.Num())
+		{
+			bChanged = true;
+		}
+		chunk.m_vegetationProxies = std::move(nextProxies);
+	}
+	component.m_activeGrassInstances = activeInstances;
+	if (bChanged)
+	{
+		++m_shadowCastersRevision;
+		SAILOR_LOG(
+			"LandscapeECS: grass residency changed to %u of %u budgeted instances across %zu candidates.",
+			activeInstances,
+			component.m_grassInstanceBudget,
+			selections.Num());
+	}
+	return bChanged;
+}
+
 void LandscapeECS::PublishSceneVersion()
 {
 	auto version = RHI::RHISpatialSceneVersionPtr::Make();
@@ -1352,12 +1873,29 @@ void LandscapeECS::PublishSceneVersion()
 	version->m_shadowCastersRevision = m_shadowCastersRevision;
 	version->m_scene = m_rhiScene;
 	TSet<size_t> activeProducerKeys;
-	size_t spatialHash = 1469598103934665603ull;
-	auto hashSpatialEntry = [&spatialHash](
+	size_t staticSpatialHash = 1469598103934665603ull;
+	size_t dynamicSpatialHash = 1099511628211ull;
+	bool bHasStaticSpatialEntries = false;
+	bool bHasDynamicSpatialEntries = false;
+	auto hashSpatialEntry = [&staticSpatialHash,
+		&dynamicSpatialHash,
+		&bHasStaticSpatialEntries,
+		&bHasDynamicSpatialEntries](
 		const RHI::RenderInstanceHandle& handle,
 		const glm::ivec3& center,
-		const glm::ivec3& extents)
+		const glm::ivec3& extents,
+		EMobilityType mobility)
 		{
+			if (mobility == EMobilityType::Dynamic)
+			{
+				bHasDynamicSpatialEntries = true;
+			}
+			else
+			{
+				bHasStaticSpatialEntries = true;
+			}
+			size_t& spatialHash = mobility == EMobilityType::Dynamic ?
+				dynamicSpatialHash : staticSpatialHash;
 			HashCombine(
 				spatialHash,
 				handle.m_slot,
@@ -1372,7 +1910,8 @@ void LandscapeECS::PublishSceneVersion()
 
 	auto publishProxy = [this, &activeProducerKeys](
 		const RHI::RHISceneProxyResourcePtr& resource,
-		uint64_t buildRevision) -> RHI::RenderInstanceHandle
+		uint64_t buildRevision,
+		EMobilityType mobility) -> RHI::RenderInstanceHandle
 		{
 			if (!m_rhiScene || !resource)
 			{
@@ -1393,7 +1932,7 @@ void LandscapeECS::PublishSceneVersion()
 
 			RHI::RHISceneInstanceRecord record;
 			record.m_producerKey = producerKey;
-			record.m_mobility = EMobilityType::Static;
+			record.m_mobility = mobility;
 			record.m_worldMatrix = proxy.m_worldMatrix;
 			record.m_worldBounds = proxy.m_worldAabb;
 			record.m_topology = resource;
@@ -1432,22 +1971,31 @@ void LandscapeECS::PublishSceneVersion()
 		const auto& data = m_components[componentIndex];
 		for (const auto& chunk : data.m_chunks)
 		{
-			const auto chunkHandle = publishProxy(chunk.m_resource, chunk.m_buildRevision);
+			const auto chunkHandle = publishProxy(
+				chunk.m_resource,
+				chunk.m_buildRevision,
+				EMobilityType::Static);
 			if (chunkHandle.IsValid())
 			{
-				hashSpatialEntry(chunkHandle, chunk.m_octreeCenter, chunk.m_octreeExtents);
+				hashSpatialEntry(
+					chunkHandle,
+					chunk.m_octreeCenter,
+					chunk.m_octreeExtents,
+					EMobilityType::Static);
 			}
 			for (const auto& vegetation : chunk.m_vegetationProxies)
 			{
 				const auto vegetationHandle = publishProxy(
 					vegetation.m_resource,
-					chunk.m_buildRevision);
+					vegetation.m_revision,
+					vegetation.m_mobility);
 				if (vegetationHandle.IsValid())
 				{
 					hashSpatialEntry(
 						vegetationHandle,
 						vegetation.m_octreeCenter,
-						vegetation.m_octreeExtents);
+						vegetation.m_octreeExtents,
+						vegetation.m_mobility);
 				}
 			}
 		}
@@ -1476,17 +2024,28 @@ void LandscapeECS::PublishSceneVersion()
 			m_publishedBuildRevisions.Remove(producerKey);
 		}
 
-		const bool bSpatialChanged = !m_publishedSceneVersion ||
-			m_spatialHash != spatialHash;
-		if (bSpatialChanged)
+		const bool bStaticSpatialChanged = !m_publishedSceneVersion ||
+			m_staticSpatialHash != staticSpatialHash;
+		const bool bDynamicSpatialChanged = !m_publishedSceneVersion ||
+			m_dynamicSpatialHash != dynamicSpatialHash;
+		if (bStaticSpatialChanged || bDynamicSpatialChanged)
 		{
 			++m_spatialRevision;
-			if (!activeProducerKeys.IsEmpty())
+		}
+
+		auto rebuildSpatialTree = [this](
+			EMobilityType mobility,
+			bool bHasEntries,
+			TSharedPtr<TOctree<RHI::RenderInstanceHandle>>& tree)
 			{
-				version->m_staticOctree =
-					TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
-						glm::ivec3(0, 0, 0), 16536 * 16, 4);
-				auto appendSpatialEntry = [this, &version](
+				if (!bHasEntries)
+				{
+					tree.Clear();
+					return;
+				}
+				tree = TSharedPtr<TOctree<RHI::RenderInstanceHandle>>::Make(
+					glm::ivec3(0, 0, 0), 16536 * 16, 4);
+				auto appendSpatialEntry = [this, &tree](
 					const RHI::RHISceneProxyResourcePtr& resource,
 					const glm::ivec3& center,
 					const glm::ivec3& extents)
@@ -1500,11 +2059,12 @@ void LandscapeECS::PublishSceneVersion()
 							resource->m_proxy.m_staticMeshEcs,
 							handle) && handle)
 						{
-							version->m_staticOctree->Update(center, extents, *handle);
+							tree->Update(center, extents, *handle);
 						}
 					};
 				for (size_t componentIndex = 0u;
-					componentIndex < m_components.Num(); ++componentIndex)
+					componentIndex < m_components.Num();
+					++componentIndex)
 				{
 					if (!IsComponentRegistered(componentIndex))
 					{
@@ -1512,26 +2072,51 @@ void LandscapeECS::PublishSceneVersion()
 					}
 					for (const auto& chunk : m_components[componentIndex].m_chunks)
 					{
-						appendSpatialEntry(
-							chunk.m_resource,
-							chunk.m_octreeCenter,
-							chunk.m_octreeExtents);
-						for (const auto& vegetation : chunk.m_vegetationProxies)
+						if (mobility == EMobilityType::Static)
 						{
 							appendSpatialEntry(
-								vegetation.m_resource,
-								vegetation.m_octreeCenter,
-								vegetation.m_octreeExtents);
+								chunk.m_resource,
+								chunk.m_octreeCenter,
+								chunk.m_octreeExtents);
+						}
+						for (const auto& vegetation : chunk.m_vegetationProxies)
+						{
+							if (vegetation.m_mobility == mobility)
+							{
+								appendSpatialEntry(
+									vegetation.m_resource,
+									vegetation.m_octreeCenter,
+									vegetation.m_octreeExtents);
+							}
 						}
 					}
 				}
-			}
+			};
+
+		if (bStaticSpatialChanged)
+		{
+			rebuildSpatialTree(
+				EMobilityType::Static,
+				bHasStaticSpatialEntries,
+				version->m_staticOctree);
 		}
 		else
 		{
 			version->m_staticOctree = m_publishedSceneVersion->m_staticOctree;
 		}
-		m_spatialHash = spatialHash;
+		if (bDynamicSpatialChanged)
+		{
+			rebuildSpatialTree(
+				EMobilityType::Dynamic,
+				bHasDynamicSpatialEntries,
+				version->m_dynamicOctree);
+		}
+		else
+		{
+			version->m_dynamicOctree = m_publishedSceneVersion->m_dynamicOctree;
+		}
+		m_staticSpatialHash = staticSpatialHash;
+		m_dynamicSpatialHash = dynamicSpatialHash;
 		version->m_sceneVersion = m_rhiScene->PublishVersion(
 			Material::GetGlobalContentRevision(),
 			m_shadowCastersRevision,
@@ -1560,7 +2145,8 @@ void LandscapeECS::EndPlay()
 	m_shadowCastersRevision = 0u;
 	m_sceneVersionRevision = 0u;
 	m_spatialRevision = 0u;
-	m_spatialHash = 0u;
+	m_staticSpatialHash = 0u;
+	m_dynamicSpatialHash = 0u;
 	m_publishedSceneVersion.Clear();
 	m_rhiScene.Clear();
 	m_renderInstanceHandles.Clear();

--- a/Runtime/ECS/LandscapeECS.cpp
+++ b/Runtime/ECS/LandscapeECS.cpp
@@ -550,7 +550,7 @@ namespace
 		const LandscapeVegetationProfile& profile,
 		const glm::mat4& ownerMatrix,
 		uint64_t frame,
-		const TVector<glm::mat4>& instanceTransforms,
+		TVector<glm::mat4> instanceTransforms,
 		EMobilityType mobility,
 		uint64_t revision,
 		LandscapeVegetationRenderProxy& result)
@@ -686,9 +686,7 @@ namespace
 #endif
 		}
 
-		instanceGroup.m_meshes = std::move(vegetationMeshes);
-		instanceGroup.m_meshTransforms = std::move(vegetationModelMatrices);
-		instanceGroup.m_instanceTransforms = instanceTransforms;
+		const uint32_t instanceCount = static_cast<uint32_t>(instanceTransforms.Num());
 		Math::AABB batchedVegetationBounds;
 		for (const auto& localInstanceMatrix : instanceTransforms)
 		{
@@ -697,12 +695,15 @@ namespace
 			instanceBounds.Apply(instanceMatrix);
 			batchedVegetationBounds.Extend(instanceBounds);
 		}
-		if (instanceGroup.m_instanceTransforms.IsEmpty() ||
-			instanceGroup.m_meshes.IsEmpty() ||
+		if (instanceTransforms.IsEmpty() ||
+			vegetationMeshes.IsEmpty() ||
 			!batchedVegetationBounds.IsValid())
 		{
 			return EVegetationProxyBuildResult::NoRenderData;
 		}
+		instanceGroup.m_meshes = std::move(vegetationMeshes);
+		instanceGroup.m_meshTransforms = std::move(vegetationModelMatrices);
+		instanceGroup.m_instanceTransforms = std::move(instanceTransforms);
 
 		vegetationProxy.m_worldAabb = batchedVegetationBounds;
 		auto vegetationShadowCaster = RHI::RHIShadowCasterProxyPtr::Make();
@@ -724,7 +725,7 @@ namespace
 		result.m_resource = RHI::RHISceneProxyResourcePtr::Make(
 			std::move(vegetationProxy));
 		result.m_profileIndex = profileIndex;
-		result.m_instanceCount = static_cast<uint32_t>(instanceTransforms.Num());
+		result.m_instanceCount = instanceCount;
 		result.m_revision = revision;
 		result.m_mobility = mobility;
 		return EVegetationProxyBuildResult::Success;
@@ -879,12 +880,63 @@ namespace
 		return glm::mix(a, b, tz);
 	}
 
+	uint64_t CalculateGrassViewRevision(
+		const LandscapeData& data,
+		const LandscapeVegetationProfile& profile,
+		const glm::mat4& inverseOwnerMatrix,
+		const TVector<glm::vec3>& cameraPositions)
+	{
+		const float meanInstanceSpacing = data.m_chunkSize /
+			std::sqrt(static_cast<float>((std::max)(profile.m_instancesPerChunk, 1u)));
+		const double cellSize = static_cast<double>((std::clamp)(
+			meanInstanceSpacing,
+			0.5f,
+			4.0f));
+		auto quantize = [cellSize](float value)
+			{
+				if (!std::isfinite(value))
+				{
+					return int64_t(0);
+				}
+				const double coordinate = std::floor(static_cast<double>(value) / cellSize);
+				return static_cast<int64_t>((std::clamp)(
+					coordinate,
+					static_cast<double>((std::numeric_limits<int64_t>::lowest)()),
+					static_cast<double>((std::numeric_limits<int64_t>::max)())));
+			};
+
+		size_t result = 1469598103934665603ull;
+		HashCombine(result, cameraPositions.Num());
+		for (const glm::vec3& worldPosition : cameraPositions)
+		{
+			const glm::vec3 localPosition = glm::vec3(
+				inverseOwnerMatrix * glm::vec4(worldPosition, 1.0f));
+			HashCombine(
+				result,
+				quantize(localPosition.x),
+				quantize(localPosition.y),
+				quantize(localPosition.z));
+		}
+		return static_cast<uint64_t>(result) | 1ull;
+	}
+
 	TVector<glm::mat4> BuildGrassInstanceTransforms(
 		const LandscapeData& data,
 		const LandscapeChunk& chunk,
 		size_t profileIndex,
-		uint32_t instanceCount)
+		uint32_t instanceCount,
+		const glm::mat4& ownerMatrix,
+		const TVector<glm::vec3>& cameraPositions)
 	{
+		struct InstancePlacement final
+		{
+			glm::vec3 m_position{};
+			float m_angle = 0.0f;
+			float m_scale = 1.0f;
+			float m_cameraDistanceSquared = 0.0f;
+			uint32_t m_instanceIndex = 0u;
+		};
+
 		TVector<glm::mat4> result;
 		if (profileIndex >= data.m_vegetationProfiles.Num())
 		{
@@ -895,28 +947,94 @@ namespace
 		const float landscapeDepth = data.m_chunksZ * data.m_chunkSize;
 		const float originX = chunk.m_chunkX * data.m_chunkSize - landscapeWidth * 0.5f;
 		const float originZ = chunk.m_chunkZ * data.m_chunkSize - landscapeDepth * 0.5f;
+		instanceCount = (std::min)(instanceCount, profile.m_instancesPerChunk);
 		result.Reserve(instanceCount);
-		for (uint32_t instance = 0u; instance < instanceCount; ++instance)
+		const bool bPartialSelection =
+			instanceCount < profile.m_instancesPerChunk &&
+			!cameraPositions.IsEmpty();
+		auto buildPlacement = [&](uint32_t instance)
 		{
 			const uint32_t randomSeed = data.m_seed ^
 				static_cast<uint32_t>(chunk.m_chunkX * 92821u +
 					chunk.m_chunkZ * 68917u +
 					profileIndex * 4099u +
 					instance * 131u);
-			glm::vec3 position;
-			position.x = originX + Random01(randomSeed) * data.m_chunkSize;
-			position.z = originZ + Random01(randomSeed + 1u) * data.m_chunkSize;
-			position.y = SampleLandscapeChunkHeight(data, chunk, position.x, position.z) +
+			InstancePlacement placement;
+			placement.m_instanceIndex = instance;
+			placement.m_position.x = originX + Random01(randomSeed) * data.m_chunkSize;
+			placement.m_position.z = originZ + Random01(randomSeed + 1u) * data.m_chunkSize;
+			placement.m_position.y = SampleLandscapeChunkHeight(
+				data,
+				chunk,
+				placement.m_position.x,
+				placement.m_position.z) +
 				profile.m_groundOffset;
-			const float angle = Random01(randomSeed + 2u) * glm::two_pi<float>();
-			const float scale = glm::mix(
+			placement.m_angle = Random01(randomSeed + 2u) * glm::two_pi<float>();
+			placement.m_scale = glm::mix(
 				profile.m_minScale,
 				profile.m_maxScale,
 				Random01(randomSeed + 3u));
+			if (bPartialSelection)
+			{
+				placement.m_cameraDistanceSquared =
+					(std::numeric_limits<float>::infinity)();
+				const glm::vec3 worldPosition = glm::vec3(
+					ownerMatrix * glm::vec4(placement.m_position, 1.0f));
+				for (const glm::vec3& cameraPosition : cameraPositions)
+				{
+					const glm::vec3 delta = worldPosition - cameraPosition;
+					placement.m_cameraDistanceSquared = (std::min)(
+						placement.m_cameraDistanceSquared,
+						glm::dot(delta, delta));
+				}
+			}
+			return placement;
+		};
+		auto appendTransform = [&result](const InstancePlacement& placement)
+		{
 			result.Add(
-				glm::translate(glm::mat4(1.0f), position) *
-				glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 1.0f, 0.0f)) *
-				glm::scale(glm::mat4(1.0f), glm::vec3(scale)));
+				glm::translate(glm::mat4(1.0f), placement.m_position) *
+				glm::rotate(glm::mat4(1.0f), placement.m_angle,
+					glm::vec3(0.0f, 1.0f, 0.0f)) *
+				glm::scale(glm::mat4(1.0f), glm::vec3(placement.m_scale)));
+		};
+
+		if (!bPartialSelection)
+		{
+			for (uint32_t instance = 0u; instance < instanceCount; ++instance)
+			{
+				appendTransform(buildPlacement(instance));
+			}
+			return result;
+		}
+
+		TVector<InstancePlacement> placements;
+		placements.Reserve(profile.m_instancesPerChunk);
+		for (uint32_t instance = 0u; instance < profile.m_instancesPerChunk; ++instance)
+		{
+			placements.Add(buildPlacement(instance));
+		}
+		auto compareDistance = [](const InstancePlacement& lhs, const InstancePlacement& rhs)
+			{
+				if (lhs.m_cameraDistanceSquared != rhs.m_cameraDistanceSquared)
+				{
+					return lhs.m_cameraDistanceSquared < rhs.m_cameraDistanceSquared;
+				}
+				return lhs.m_instanceIndex < rhs.m_instanceIndex;
+			};
+		std::nth_element(
+			placements.begin(),
+			placements.begin() + instanceCount,
+			placements.end(),
+			compareDistance);
+		placements.Resize(instanceCount);
+		placements.Sort([](const InstancePlacement& lhs, const InstancePlacement& rhs)
+			{
+				return lhs.m_instanceIndex < rhs.m_instanceIndex;
+			});
+		for (const auto& placement : placements)
+		{
+			appendTransform(placement);
 		}
 		return result;
 	}
@@ -999,21 +1117,16 @@ void LandscapeData::SetLodSettings(
 	RequestFullRebuild();
 }
 
-void LandscapeData::SetVegetationStreamingSettings(
-	uint32_t grassInstanceBudget,
+void LandscapeData::SetGrassResidencyHysteresis(
 	float grassResidencyHysteresis)
 {
-	const uint32_t normalizedBudget = (std::min)(grassInstanceBudget, 1048576u);
 	const float normalizedHysteresis = std::isfinite(grassResidencyHysteresis) ?
 		(std::clamp)(grassResidencyHysteresis, 0.0f, 512.0f) : 12.0f;
-	if (m_grassInstanceBudget == normalizedBudget &&
-		m_grassResidencyHysteresis == normalizedHysteresis)
+	if (m_grassResidencyHysteresis == normalizedHysteresis)
 	{
 		return;
 	}
-	m_grassInstanceBudget = normalizedBudget;
 	m_grassResidencyHysteresis = normalizedHysteresis;
-	MarkDirty();
 }
 
 void LandscapeData::SetLayerTextures(const TVector<FileId>& textures)
@@ -1239,8 +1352,11 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 	bool bSceneChanged = false;
 	const auto* cameraEcs = GetWorld() ? GetWorld()->GetECS<CameraECS>() : nullptr;
 	const TVector<Math::Transform> noCameraTransforms;
+	const TVector<CameraData> noCameras;
 	const auto& cameraTransforms = cameraEcs ?
 		cameraEcs->GetActiveCameraTransforms() : noCameraTransforms;
+	const auto& cameras = cameraEcs ?
+		cameraEcs->GetActiveCameras() : noCameras;
 	for (size_t componentIndex = 0; componentIndex < m_components.Num(); ++componentIndex)
 	{
 		if (!IsComponentRegistered(componentIndex))
@@ -1311,10 +1427,6 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		}
 		if (!data.IsDirty() && !transformChanged)
 		{
-			bSceneChanged |= UpdateGrassResidency(
-				componentIndex,
-				data,
-				cameraTransforms);
 			continue;
 		}
 		if (!owner || !bTerrainMaterialReady)
@@ -1392,10 +1504,6 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		{
 			data.m_bIsDirty = false;
 			data.SetLastChange(owner->GetTransformComponent().GetFrameLastChange());
-			bSceneChanged |= UpdateGrassResidency(
-				componentIndex,
-				data,
-				cameraTransforms);
 			continue;
 		}
 
@@ -1560,8 +1668,8 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			shadowCaster->m_worldAabb = proxy.m_worldAabb;
 			proxy.m_shadowCaster = shadowCaster->m_meshes.IsEmpty() ?
 				RHI::RHIShadowCasterProxyPtr{} : shadowCaster;
-			auto* textureImporter = App::GetSubmodule<TextureImporter>();
 #if defined(__APPLE__)
+			auto* textureImporter = App::GetSubmodule<TextureImporter>();
 			proxy.m_materialTextureSamplers.Resize(1u);
 			proxy.m_materialTextureSamplers[0].Insert(0u);
 			if (textureImporter)
@@ -1606,7 +1714,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 					profile,
 					ownerMatrix,
 					proxy.m_frame,
-					instanceTransforms,
+					std::move(instanceTransforms),
 					EMobilityType::Static,
 					data.m_buildRevision + 1u,
 					vegetationRenderProxy);
@@ -1642,10 +1750,6 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		data.SetLastChange(owner->GetTransformComponent().GetFrameLastChange());
 		++m_shadowCastersRevision;
 		bSceneChanged = true;
-		bSceneChanged |= UpdateGrassResidency(
-			componentIndex,
-			data,
-			cameraTransforms);
 		size_t vegetationPerChunk = 0u;
 		for (const auto& profile : data.m_vegetationProfiles)
 		{
@@ -1659,6 +1763,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			data.m_sculptStamps.Num() / 5u, data.m_paintStamps.Num() / 5u,
 			static_cast<unsigned long long>(data.m_buildRevision));
 	}
+	bSceneChanged |= UpdateGrassResidency(cameraTransforms, cameras);
 	if (bSceneChanged)
 	{
 		PublishSceneVersion();
@@ -1667,20 +1772,9 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 }
 
 bool LandscapeECS::UpdateGrassResidency(
-	size_t componentIndex,
-	LandscapeData& component,
-	const TVector<Math::Transform>& cameraTransforms)
+	const TVector<Math::Transform>& cameraTransforms,
+	const TVector<CameraData>& cameras)
 {
-	if (component.m_chunks.IsEmpty())
-	{
-		component.m_activeGrassInstances = 0u;
-		return false;
-	}
-
-	auto grassKey = [&component](size_t chunkIndex, size_t profileIndex)
-		{
-			return chunkIndex * component.m_vegetationProfiles.Num() + profileIndex;
-		};
 	auto findResident = [](const LandscapeChunk& chunk, size_t profileIndex)
 		-> const LandscapeVegetationRenderProxy*
 		{
@@ -1694,174 +1788,541 @@ bool LandscapeECS::UpdateGrassResidency(
 			}
 			return nullptr;
 		};
+	auto toChunkCoordinate = [](double localPosition, double extent, double chunkSize)
+		{
+			const double coordinate = std::floor(
+				(localPosition + extent * 0.5) / chunkSize);
+			return static_cast<int32_t>((std::clamp)(
+				coordinate,
+				static_cast<double>((std::numeric_limits<int32_t>::lowest)()),
+				static_cast<double>((std::numeric_limits<int32_t>::max)())));
+		};
 
-	TVector<LandscapeGrassCandidate> candidates;
-	for (size_t chunkIndex = 0u; chunkIndex < component.m_chunks.Num(); ++chunkIndex)
+	const size_t numCameras = (std::min)(cameraTransforms.Num(), cameras.Num());
+	m_cameraPositionsScratch.Resize(numCameras);
+	m_cameraFrustumsScratch.Resize(numCameras);
+	for (size_t cameraIndex = 0u; cameraIndex < numCameras; ++cameraIndex)
 	{
-		const auto& chunk = component.m_chunks[chunkIndex];
-		if (!chunk.m_resource || cameraTransforms.IsEmpty())
+		const auto& camera = cameras[cameraIndex];
+		const float aspect = std::isfinite(camera.GetAspect()) && camera.GetAspect() > 0.0f ?
+			camera.GetAspect() : 1.0f;
+		const float fov = std::isfinite(camera.GetFov()) ?
+			(std::clamp)(camera.GetFov(), 1.0f, 179.0f) : 90.0f;
+		const float zNear = std::isfinite(camera.GetZNear()) ?
+			(std::max)(camera.GetZNear(), 0.001f) : 0.1f;
+		const float zFar = std::isfinite(camera.GetZFar()) ?
+			(std::max)(camera.GetZFar(), zNear + 0.001f) : 1000.0f;
+		m_cameraPositionsScratch[cameraIndex] = glm::vec3(
+			cameraTransforms[cameraIndex].m_position);
+		m_cameraFrustumsScratch[cameraIndex].ExtractFrustumPlanes(
+			cameraTransforms[cameraIndex].Matrix(),
+			aspect,
+			fov,
+			zNear,
+			zFar);
+	}
+
+	m_grassCandidatesScratch.Clear(false);
+	for (size_t componentIndex = 0u; componentIndex < m_components.Num(); ++componentIndex)
+	{
+		if (!IsComponentRegistered(componentIndex))
 		{
 			continue;
 		}
-		const Math::AABB& worldBounds = chunk.m_resource->m_proxy.m_worldAabb;
-		float minCameraDistance = (std::numeric_limits<float>::infinity)();
-		for (const auto& cameraTransform : cameraTransforms)
+		auto& component = m_components[componentIndex];
+		component.m_activeGrassInstances = 0u;
+		GameObjectPtr owner = const_cast<ObjectPtr&>(component.GetOwner()).StaticCast<GameObject>();
+		if (!owner || component.m_chunks.IsEmpty() || numCameras == 0u)
 		{
-			const glm::vec3 cameraPosition(cameraTransform.m_position);
-			const glm::vec3 closest = glm::clamp(
-				cameraPosition,
-				worldBounds.m_min,
-				worldBounds.m_max);
-			minCameraDistance = (std::min)(
-				minCameraDistance,
-				glm::distance(cameraPosition, closest));
+			continue;
 		}
 
-		for (size_t profileIndex = 0u;
-			profileIndex < component.m_vegetationProfiles.Num();
-			++profileIndex)
+		const glm::mat4 ownerMatrix = owner->GetTransformComponent().GetCachedWorldMatrix();
+		const glm::mat4 inverseOwnerMatrix = glm::inverse(ownerMatrix);
+		const double landscapeWidth = static_cast<double>(component.m_chunksX) * component.m_chunkSize;
+		const double landscapeDepth = static_cast<double>(component.m_chunksZ) * component.m_chunkSize;
+		m_cameraChunkCoordinatesScratch.Clear(false);
+		for (size_t cameraIndex = 0u; cameraIndex < numCameras; ++cameraIndex)
 		{
-			const auto& profile = component.m_vegetationProfiles[profileIndex];
-			if (profile.m_residency != ELandscapeVegetationResidency::Grass ||
-				!profile.m_modelFileId ||
-				profile.m_instancesPerChunk == 0u)
+			const auto& cameraTransform = cameraTransforms[cameraIndex];
+			const glm::vec4 localPosition = inverseOwnerMatrix *
+				glm::vec4(glm::vec3(cameraTransform.m_position), 1.0f);
+			if (!std::isfinite(localPosition.x) || !std::isfinite(localPosition.z))
 			{
 				continue;
 			}
-			const bool bResident = findResident(chunk, profileIndex) != nullptr;
-			const float residencyDistance = profile.m_cullDistance +
-				(bResident ? component.m_grassResidencyHysteresis : 0.0f);
-			if (minCameraDistance > residencyDistance)
+			m_cameraChunkCoordinatesScratch.Add(glm::ivec2(
+				toChunkCoordinate(localPosition.x, landscapeWidth, component.m_chunkSize),
+				toChunkCoordinate(localPosition.z, landscapeDepth, component.m_chunkSize)));
+		}
+		if (m_cameraChunkCoordinatesScratch.IsEmpty())
+		{
+			continue;
+		}
+
+		for (size_t chunkIndex = 0u; chunkIndex < component.m_chunks.Num(); ++chunkIndex)
+		{
+			const auto& chunk = component.m_chunks[chunkIndex];
+			if (!chunk.m_resource)
 			{
 				continue;
 			}
-			LandscapeGrassCandidate candidate;
-			candidate.m_chunkIndex = chunkIndex;
-			candidate.m_profileIndex = profileIndex;
-			candidate.m_capacity = profile.m_instancesPerChunk;
-			candidate.m_priority = profile.m_priority;
-			candidate.m_distance = minCameraDistance;
-			candidate.m_bResident = bResident;
-			candidate.m_residencyHysteresis =
-				component.m_grassResidencyHysteresis;
-			candidates.Add(std::move(candidate));
+			bool bChunkResident = false;
+			for (const auto& proxy : chunk.m_vegetationProxies)
+			{
+				bChunkResident |= proxy.m_mobility == EMobilityType::Dynamic;
+			}
+			const Math::AABB& worldBounds = chunk.m_resource->m_proxy.m_worldAabb;
+			bool bOverlapsCameraFrustum = false;
+			for (const auto& frustum : m_cameraFrustumsScratch)
+			{
+				if (DoesLandscapeGrassChunkOverlapFrustum(
+						worldBounds,
+						frustum,
+						bChunkResident ? component.m_grassResidencyHysteresis : 0.0f))
+				{
+					bOverlapsCameraFrustum = true;
+					break;
+				}
+			}
+			if (!bOverlapsCameraFrustum)
+			{
+				continue;
+			}
+
+			uint32_t chunkRing = (std::numeric_limits<uint32_t>::max)();
+			uint32_t chunkManhattanDistance = (std::numeric_limits<uint32_t>::max)();
+			for (const glm::ivec2& cameraChunk : m_cameraChunkCoordinatesScratch)
+			{
+				const uint64_t distanceX = static_cast<uint64_t>(std::abs(
+					static_cast<int64_t>(cameraChunk.x) - chunk.m_chunkX));
+				const uint64_t distanceZ = static_cast<uint64_t>(std::abs(
+					static_cast<int64_t>(cameraChunk.y) - chunk.m_chunkZ));
+				const uint32_t ring = static_cast<uint32_t>((std::min)(
+					(std::max)(distanceX, distanceZ),
+					static_cast<uint64_t>((std::numeric_limits<uint32_t>::max)())));
+				const uint32_t manhattanDistance = static_cast<uint32_t>((std::min)(
+					distanceX + distanceZ,
+					static_cast<uint64_t>((std::numeric_limits<uint32_t>::max)())));
+				if (ring < chunkRing ||
+					(ring == chunkRing && manhattanDistance < chunkManhattanDistance))
+				{
+					chunkRing = ring;
+					chunkManhattanDistance = manhattanDistance;
+				}
+			}
+
+			float minCameraDistance = (std::numeric_limits<float>::infinity)();
+			for (size_t cameraIndex = 0u; cameraIndex < numCameras; ++cameraIndex)
+			{
+				const glm::vec3& cameraPosition = m_cameraPositionsScratch[cameraIndex];
+				const glm::vec3 closest = glm::clamp(
+					cameraPosition,
+					worldBounds.m_min,
+					worldBounds.m_max);
+				minCameraDistance = (std::min)(
+					minCameraDistance,
+					glm::distance(cameraPosition, closest));
+			}
+
+			for (size_t profileIndex = 0u;
+				profileIndex < component.m_vegetationProfiles.Num();
+				++profileIndex)
+			{
+				const auto& profile = component.m_vegetationProfiles[profileIndex];
+				if (profile.m_residency != ELandscapeVegetationResidency::Grass ||
+					!profile.m_modelFileId ||
+					profile.m_instancesPerChunk == 0u)
+				{
+					continue;
+				}
+				const bool bResident = findResident(chunk, profileIndex) != nullptr;
+				const float residencyDistance = profile.m_cullDistance +
+					(bResident ? component.m_grassResidencyHysteresis : 0.0f);
+				if (minCameraDistance > residencyDistance)
+				{
+					continue;
+				}
+
+				LandscapeGrassCandidate candidate;
+				candidate.m_componentIndex = componentIndex;
+				candidate.m_chunkIndex = chunkIndex;
+				candidate.m_profileIndex = profileIndex;
+				candidate.m_capacity = profile.m_instancesPerChunk;
+				candidate.m_chunkRing = chunkRing;
+				candidate.m_chunkManhattanDistance = chunkManhattanDistance;
+				candidate.m_priority = profile.m_priority;
+				candidate.m_bChunkResident = bChunkResident;
+				m_grassCandidatesScratch.Add(std::move(candidate));
+			}
 		}
 	}
 
-	const auto selections = SelectLandscapeGrassResidency(
-		std::move(candidates),
-		component.m_grassInstanceBudget);
-	TMap<size_t, uint32_t> selectedCounts;
-	for (const auto& selection : selections)
+	const uint32_t instanceBudget = (std::min)(
+		App::GetActiveGraphicsSettings().m_vegetationInstanceBudget,
+		1048576u);
+	const size_t numCandidates = m_grassCandidatesScratch.Num();
+	SelectLandscapeGrassResidency(
+		m_grassCandidatesScratch,
+		instanceBudget,
+		m_grassSelectionsScratch);
+	for (auto& selection : m_grassSelectionsScratch)
 	{
-		selectedCounts[grassKey(
-			selection.m_chunkIndex,
-			selection.m_profileIndex)] = selection.m_instanceCount;
+		if (!IsComponentRegistered(selection.m_componentIndex))
+		{
+			continue;
+		}
+		auto& component = m_components[selection.m_componentIndex];
+		if (selection.m_profileIndex >= component.m_vegetationProfiles.Num())
+		{
+			continue;
+		}
+		const auto& profile = component.m_vegetationProfiles[selection.m_profileIndex];
+		if (selection.m_instanceCount >= profile.m_instancesPerChunk)
+		{
+			continue;
+		}
+		GameObjectPtr owner = const_cast<ObjectPtr&>(component.GetOwner()).StaticCast<GameObject>();
+		if (!owner)
+		{
+			continue;
+		}
+		selection.m_viewRevision = CalculateGrassViewRevision(
+			component,
+			profile,
+			glm::inverse(owner->GetTransformComponent().GetCachedWorldMatrix()),
+			m_cameraPositionsScratch);
+	}
+	m_grassSelectionsScratch.Sort([](
+		const LandscapeGrassSelection& lhs,
+		const LandscapeGrassSelection& rhs)
+		{
+			if (lhs.m_componentIndex != rhs.m_componentIndex)
+			{
+				return lhs.m_componentIndex < rhs.m_componentIndex;
+			}
+			if (lhs.m_chunkIndex != rhs.m_chunkIndex)
+			{
+				return lhs.m_chunkIndex < rhs.m_chunkIndex;
+			}
+			return lhs.m_profileIndex < rhs.m_profileIndex;
+		});
+	auto findSelection = [this](
+		size_t componentIndex,
+		size_t chunkIndex,
+		size_t profileIndex) -> const LandscapeGrassSelection*
+		{
+			size_t first = 0u;
+			size_t last = m_grassSelectionsScratch.Num();
+			while (first < last)
+			{
+				const size_t middle = first + (last - first) / 2u;
+				const auto& selection = m_grassSelectionsScratch[middle];
+				const bool bBefore = selection.m_componentIndex < componentIndex ||
+					(selection.m_componentIndex == componentIndex &&
+						(selection.m_chunkIndex < chunkIndex ||
+							(selection.m_chunkIndex == chunkIndex &&
+								selection.m_profileIndex < profileIndex)));
+				if (bBefore)
+				{
+					first = middle + 1u;
+				}
+				else
+				{
+					last = middle;
+				}
+			}
+			if (first >= m_grassSelectionsScratch.Num())
+			{
+				return nullptr;
+			}
+			const auto& selection = m_grassSelectionsScratch[first];
+			return selection.m_componentIndex == componentIndex &&
+				selection.m_chunkIndex == chunkIndex &&
+				selection.m_profileIndex == profileIndex ?
+				&selection : nullptr;
+		};
+
+	m_grassBuildRequestsScratch.Clear(false);
+	for (size_t componentIndex = 0u; componentIndex < m_components.Num(); ++componentIndex)
+	{
+		if (!IsComponentRegistered(componentIndex))
+		{
+			continue;
+		}
+		auto& component = m_components[componentIndex];
+		GameObjectPtr owner = const_cast<ObjectPtr&>(component.GetOwner()).StaticCast<GameObject>();
+		if (!owner)
+		{
+			continue;
+		}
+		const glm::mat4 ownerMatrix = owner->GetTransformComponent().GetCachedWorldMatrix();
+		for (size_t chunkIndex = 0u; chunkIndex < component.m_chunks.Num(); ++chunkIndex)
+		{
+			auto& chunk = component.m_chunks[chunkIndex];
+			for (size_t profileIndex = 0u;
+				profileIndex < component.m_vegetationProfiles.Num();
+				++profileIndex)
+			{
+				const auto& profile = component.m_vegetationProfiles[profileIndex];
+				if (profile.m_residency != ELandscapeVegetationResidency::Grass)
+				{
+					continue;
+				}
+				const auto* resident = findResident(chunk, profileIndex);
+				const uint32_t residentCount = resident ? resident->m_instanceCount : 0u;
+				const auto* selection = findSelection(
+					componentIndex,
+					chunkIndex,
+					profileIndex);
+				const uint32_t selectedCount = selection ? selection->m_instanceCount : 0u;
+				const bool bPartialSelection = selection &&
+					selectedCount < profile.m_instancesPerChunk;
+				if (selectedCount == 0u ||
+					(residentCount == selectedCount &&
+						(!bPartialSelection ||
+							resident->m_viewRevision == selection->m_viewRevision)))
+				{
+					continue;
+				}
+
+				const LandscapeData* componentData = &component;
+				const LandscapeChunk* chunkData = &chunk;
+				auto task = Tasks::CreateTask<TVector<glm::mat4>>(
+					"LandscapeECS:Build Grass Transforms",
+					[componentData,
+						chunkData,
+						profileIndex,
+						selectedCount,
+						ownerMatrix,
+						this]()
+					{
+						return BuildGrassInstanceTransforms(
+							*componentData,
+							*chunkData,
+							profileIndex,
+							selectedCount,
+							ownerMatrix,
+							m_cameraPositionsScratch);
+					},
+					EThreadType::Worker);
+				task->Run();
+				GrassTransformBuildRequest request;
+				request.m_componentIndex = componentIndex;
+				request.m_chunkIndex = chunkIndex;
+				request.m_profileIndex = profileIndex;
+				request.m_instanceCount = selectedCount;
+				request.m_viewRevision = selection->m_viewRevision;
+				request.m_task = std::move(task);
+				m_grassBuildRequestsScratch.Add(std::move(request));
+			}
+		}
 	}
 
-	GameObjectPtr owner = const_cast<ObjectPtr&>(component.GetOwner()).StaticCast<GameObject>();
-	if (!owner)
-	{
-		return false;
-	}
-	const glm::mat4 ownerMatrix = owner->GetTransformComponent().GetCachedWorldMatrix();
-	const uint64_t frame = GetWorld()->GetCurrentFrame();
 	bool bChanged = false;
 	uint32_t activeInstances = 0u;
-	for (size_t chunkIndex = 0u; chunkIndex < component.m_chunks.Num(); ++chunkIndex)
+	const uint64_t frame = GetWorld()->GetCurrentFrame();
+	auto findBuildRequest = [this](
+		size_t componentIndex,
+		size_t chunkIndex,
+		size_t profileIndex) -> GrassTransformBuildRequest*
+		{
+			size_t first = 0u;
+			size_t last = m_grassBuildRequestsScratch.Num();
+			while (first < last)
+			{
+				const size_t middle = first + (last - first) / 2u;
+				const auto& request = m_grassBuildRequestsScratch[middle];
+				const bool bBefore = request.m_componentIndex < componentIndex ||
+					(request.m_componentIndex == componentIndex &&
+						(request.m_chunkIndex < chunkIndex ||
+							(request.m_chunkIndex == chunkIndex &&
+								request.m_profileIndex < profileIndex)));
+				if (bBefore)
+				{
+					first = middle + 1u;
+				}
+				else
+				{
+					last = middle;
+				}
+			}
+			if (first >= m_grassBuildRequestsScratch.Num())
+			{
+				return nullptr;
+			}
+			auto& request = m_grassBuildRequestsScratch[first];
+			return request.m_componentIndex == componentIndex &&
+				request.m_chunkIndex == chunkIndex &&
+				request.m_profileIndex == profileIndex ?
+				&request : nullptr;
+		};
+	for (size_t componentIndex = 0u; componentIndex < m_components.Num(); ++componentIndex)
 	{
-		auto& chunk = component.m_chunks[chunkIndex];
-		TVector<LandscapeVegetationRenderProxy> nextProxies;
-		nextProxies.Reserve(chunk.m_vegetationProxies.Num());
-		for (const auto& proxy : chunk.m_vegetationProxies)
+		if (!IsComponentRegistered(componentIndex))
 		{
-			if (proxy.m_mobility != EMobilityType::Dynamic)
-			{
-				nextProxies.Add(proxy);
-			}
+			continue;
 		}
-
-		for (size_t profileIndex = 0u;
-			profileIndex < component.m_vegetationProfiles.Num();
-			++profileIndex)
+		auto& component = m_components[componentIndex];
+		uint32_t componentActiveInstances = 0u;
+		GameObjectPtr owner = const_cast<ObjectPtr&>(component.GetOwner()).StaticCast<GameObject>();
+		const glm::mat4 ownerMatrix = owner ?
+			owner->GetTransformComponent().GetCachedWorldMatrix() : glm::mat4(1.0f);
+		for (size_t chunkIndex = 0u; chunkIndex < component.m_chunks.Num(); ++chunkIndex)
 		{
-			const auto& profile = component.m_vegetationProfiles[profileIndex];
-			if (profile.m_residency != ELandscapeVegetationResidency::Grass)
+			auto& chunk = component.m_chunks[chunkIndex];
+			bool bNeedsUpdate = false;
+			for (size_t profileIndex = 0u;
+				profileIndex < component.m_vegetationProfiles.Num();
+				++profileIndex)
+			{
+				const auto& profile = component.m_vegetationProfiles[profileIndex];
+				if (profile.m_residency != ELandscapeVegetationResidency::Grass)
+				{
+					continue;
+				}
+				const auto* resident = findResident(chunk, profileIndex);
+				const uint32_t residentCount = resident ? resident->m_instanceCount : 0u;
+				const auto* selection = findSelection(
+					componentIndex,
+					chunkIndex,
+					profileIndex);
+				const uint32_t selectedCount = selection ? selection->m_instanceCount : 0u;
+				const bool bPartialSelection = selection &&
+					selectedCount < profile.m_instancesPerChunk;
+				bNeedsUpdate |= residentCount != selectedCount ||
+					(resident && bPartialSelection &&
+						resident->m_viewRevision != selection->m_viewRevision);
+				componentActiveInstances += residentCount;
+			}
+			if (!bNeedsUpdate)
 			{
 				continue;
 			}
 
-			const LandscapeVegetationRenderProxy* resident =
-				findResident(chunk, profileIndex);
-			const uint32_t* selectedCountPtr = nullptr;
-			selectedCounts.Find(
-				grassKey(chunkIndex, profileIndex),
-				selectedCountPtr);
-			const uint32_t selectedCount = selectedCountPtr ? *selectedCountPtr : 0u;
-			if (selectedCount == 0u)
+			TVector<LandscapeVegetationRenderProxy> nextProxies;
+			nextProxies.Reserve(chunk.m_vegetationProxies.Num());
+			for (const auto& proxy : chunk.m_vegetationProxies)
 			{
-				bChanged |= resident != nullptr;
-				continue;
+				if (proxy.m_mobility != EMobilityType::Dynamic)
+				{
+					nextProxies.Add(proxy);
+				}
 			}
-			if (resident && resident->m_instanceCount == selectedCount)
+			bool bChunkChanged = false;
+			for (size_t profileIndex = 0u;
+				profileIndex < component.m_vegetationProfiles.Num();
+				++profileIndex)
 			{
-				nextProxies.Add(*resident);
-				activeInstances += resident->m_instanceCount;
-				continue;
-			}
+				const auto& profile = component.m_vegetationProfiles[profileIndex];
+				if (profile.m_residency != ELandscapeVegetationResidency::Grass)
+				{
+					continue;
+				}
 
-			const auto instanceTransforms = BuildGrassInstanceTransforms(
-				component,
-				chunk,
-				profileIndex,
-				selectedCount);
-			LandscapeVegetationRenderProxy streamedProxy;
-			const uint64_t revision = (uint64_t(1u) << 63u) |
-				++component.m_streamingRevision;
-			const auto buildResult = BuildLandscapeVegetationProxy(
-				componentIndex,
-				chunkIndex,
-				profileIndex,
-				profile,
-				ownerMatrix,
-				frame,
-				instanceTransforms,
-				EMobilityType::Dynamic,
-				revision,
-				streamedProxy);
-			if (buildResult != EVegetationProxyBuildResult::Success)
-			{
-				if (resident && resident->m_instanceCount <= selectedCount)
+				const auto* resident = findResident(chunk, profileIndex);
+				const auto* selection = findSelection(
+					componentIndex,
+					chunkIndex,
+					profileIndex);
+				const uint32_t selectedCount = selection ? selection->m_instanceCount : 0u;
+				if (selectedCount == 0u)
+				{
+					bChunkChanged |= resident != nullptr;
+					if (resident)
+					{
+						componentActiveInstances -= resident->m_instanceCount;
+					}
+					continue;
+				}
+				const bool bPartialSelection =
+					selectedCount < profile.m_instancesPerChunk;
+				if (resident && resident->m_instanceCount == selectedCount &&
+					(!bPartialSelection ||
+						resident->m_viewRevision == selection->m_viewRevision))
 				{
 					nextProxies.Add(*resident);
-					activeInstances += resident->m_instanceCount;
+					continue;
 				}
-				else if (resident)
+				if (!owner)
 				{
-					bChanged = true;
+					continue;
 				}
-				continue;
-			}
-			nextProxies.Add(std::move(streamedProxy));
-			activeInstances += selectedCount;
-			bChanged = true;
-		}
 
-		if (nextProxies.Num() != chunk.m_vegetationProxies.Num())
-		{
-			bChanged = true;
+				auto* buildRequest = findBuildRequest(
+					componentIndex,
+					chunkIndex,
+					profileIndex);
+				if (!buildRequest ||
+					buildRequest->m_instanceCount != selectedCount ||
+					buildRequest->m_viewRevision != selection->m_viewRevision)
+				{
+					if (resident)
+					{
+						nextProxies.Add(*resident);
+					}
+					continue;
+				}
+				buildRequest->m_task->Wait();
+				auto instanceTransforms = std::move(buildRequest->m_task->m_result);
+				LandscapeVegetationRenderProxy streamedProxy;
+				const uint64_t revision = (uint64_t(1u) << 63u) |
+					++component.m_streamingRevision;
+				const auto buildResult = BuildLandscapeVegetationProxy(
+					componentIndex,
+					chunkIndex,
+					profileIndex,
+					profile,
+					ownerMatrix,
+					frame,
+					std::move(instanceTransforms),
+					EMobilityType::Dynamic,
+					revision,
+					streamedProxy);
+				if (buildResult != EVegetationProxyBuildResult::Success)
+				{
+					if (resident && resident->m_instanceCount <= selectedCount)
+					{
+						nextProxies.Add(*resident);
+					}
+					else if (resident)
+					{
+						componentActiveInstances -= resident->m_instanceCount;
+						bChunkChanged = true;
+					}
+					continue;
+				}
+				streamedProxy.m_viewRevision = selection->m_viewRevision;
+				if (resident)
+				{
+					componentActiveInstances -= resident->m_instanceCount;
+				}
+				nextProxies.Add(std::move(streamedProxy));
+				componentActiveInstances += selectedCount;
+				bChunkChanged = true;
+			}
+
+			if (bChunkChanged)
+			{
+				chunk.m_vegetationProxies = std::move(nextProxies);
+				bChanged = true;
+			}
 		}
-		chunk.m_vegetationProxies = std::move(nextProxies);
+		component.m_activeGrassInstances = componentActiveInstances;
+		activeInstances += componentActiveInstances;
 	}
-	component.m_activeGrassInstances = activeInstances;
+	for (auto& buildRequest : m_grassBuildRequestsScratch)
+	{
+		buildRequest.m_task->Wait();
+	}
 	if (bChanged)
 	{
 		++m_shadowCastersRevision;
 		SAILOR_LOG(
-			"LandscapeECS: grass residency changed to %u of %u budgeted instances across %zu candidates.",
+			"LandscapeECS: grass residency changed to %u of %u graphics-quality instances across %zu visible candidates.",
 			activeInstances,
-			component.m_grassInstanceBudget,
-			selections.Num());
+			instanceBudget,
+			numCandidates);
 	}
 	return bChanged;
 }

--- a/Runtime/ECS/LandscapeECS.cpp
+++ b/Runtime/ECS/LandscapeECS.cpp
@@ -4,6 +4,7 @@
 #include "AssetRegistry/Material/MaterialImporter.h"
 #include "AssetRegistry/Model/ModelImporter.h"
 #include "AssetRegistry/Texture/TextureImporter.h"
+#include "AssetRegistry/AssetRegistry.h"
 #include "Components/LandscapeComponent.h"
 #include "ECS/CameraECS.h"
 #include "ECS/TransformECS.h"
@@ -39,14 +40,6 @@ namespace
 
 	struct LandscapeChunkCpuData
 	{
-		struct VegetationInstance
-		{
-			size_t m_profileIndex = 0u;
-			glm::vec3 m_position{};
-			float m_angle = 0.0f;
-			float m_scale = 1.0f;
-		};
-
 		uint32_t m_chunkX = 0u;
 		uint32_t m_chunkZ = 0u;
 		TVector<RHI::VertexP3N3T3B3UV2C4> m_vertices{};
@@ -54,7 +47,7 @@ namespace
 		TVector<uint32_t> m_collisionIndices{};
 		TVector<uint32_t> m_lodFirstIndices{};
 		TVector<uint32_t> m_lodIndexCounts{};
-		TVector<VegetationInstance> m_vegetation{};
+		TVector<LandscapeVegetationInstance> m_vegetation{};
 		Math::AABB m_localBounds{};
 	};
 
@@ -70,6 +63,123 @@ namespace
 	float Random01(uint32_t value)
 	{
 		return static_cast<float>(Hash(value) & 0x00ffffffu) / 16777215.0f;
+	}
+
+	uint64_t MakeVegetationStableId(
+		uint32_t chunkX,
+		uint32_t chunkZ,
+		size_t profileIndex,
+		uint32_t instanceIndex)
+	{
+		const uint64_t packed =
+			(static_cast<uint64_t>(chunkX) & 0x3full) |
+			((static_cast<uint64_t>(chunkZ) & 0x3full) << 6u) |
+			((static_cast<uint64_t>(profileIndex) & 0xffffffffull) << 12u) |
+			((static_cast<uint64_t>(instanceIndex) & 0x7ffull) << 44u);
+		return packed + 1u;
+	}
+
+	LandscapeVegetationInstance BuildProceduralVegetationInstance(
+		const LandscapeData& data,
+		uint32_t chunkX,
+		uint32_t chunkZ,
+		size_t profileIndex,
+		uint32_t instanceIndex,
+		float height)
+	{
+		const auto& profile = data.m_vegetationProfiles[profileIndex];
+		const float landscapeWidth = data.m_chunksX * data.m_chunkSize;
+		const float landscapeDepth = data.m_chunksZ * data.m_chunkSize;
+		const float originX = chunkX * data.m_chunkSize - landscapeWidth * 0.5f;
+		const float originZ = chunkZ * data.m_chunkSize - landscapeDepth * 0.5f;
+		const uint32_t randomSeed = data.m_seed ^
+			static_cast<uint32_t>(chunkX * 92821u + chunkZ * 68917u +
+				profileIndex * 4099u + instanceIndex * 131u);
+		const glm::vec3 position(
+			originX + Random01(randomSeed) * data.m_chunkSize,
+			height + profile.m_groundOffset,
+			originZ + Random01(randomSeed + 1u) * data.m_chunkSize);
+		const float angle = Random01(randomSeed + 2u) * glm::two_pi<float>();
+		const float scale = glm::mix(
+			profile.m_minScale,
+			profile.m_maxScale,
+			Random01(randomSeed + 3u));
+
+		LandscapeVegetationInstance result;
+		result.m_stableId = MakeVegetationStableId(
+			chunkX,
+			chunkZ,
+			profileIndex,
+			instanceIndex);
+		result.m_profileIndex = static_cast<uint32_t>(profileIndex);
+		result.m_transform =
+			glm::translate(glm::mat4(1.0f), position) *
+			glm::rotate(glm::mat4(1.0f), angle, glm::vec3(0.0f, 1.0f, 0.0f)) *
+			glm::scale(glm::mat4(1.0f), glm::vec3(scale));
+		return result;
+	}
+
+	bool IsVegetationAssetCompatible(const LandscapeData& data)
+	{
+		return data.m_bVegetationAssetLoaded &&
+			data.m_vegetationAssetData.m_chunksX == data.m_chunksX &&
+			data.m_vegetationAssetData.m_chunksZ == data.m_chunksZ &&
+			data.m_vegetationAssetData.m_chunkSize == data.m_chunkSize;
+	}
+
+	const LandscapeVegetationChunkData* GetAuthoredVegetationChunk(
+		const LandscapeData& data,
+		uint32_t chunkX,
+		uint32_t chunkZ)
+	{
+		if (!IsVegetationAssetCompatible(data) ||
+			chunkX >= data.m_chunksX || chunkZ >= data.m_chunksZ)
+		{
+			return nullptr;
+		}
+		const size_t chunkIndex = static_cast<size_t>(chunkZ) * data.m_chunksX + chunkX;
+		return chunkIndex < data.m_vegetationAssetData.m_chunks.Num() ?
+			&data.m_vegetationAssetData.m_chunks[chunkIndex] : nullptr;
+	}
+
+	void AppendRenderInstance(
+		const LandscapeVegetationInstance& instance,
+		LandscapeVegetationRenderInstances& result)
+	{
+		if (!instance.IsEnabled())
+		{
+			return;
+		}
+		result.m_transforms.Add(instance.m_transform);
+		result.m_lodBiases.Add(instance.m_lodBias);
+		result.m_cullDistanceScales.Add(instance.m_cullDistanceScale);
+		result.m_shadowDistanceScales.Add(instance.m_shadowDistanceScale);
+	}
+
+	uint32_t GetVegetationInstanceCapacity(
+		const LandscapeData& data,
+		const LandscapeChunk& chunk,
+		size_t profileIndex)
+	{
+		if (const auto* authored = GetAuthoredVegetationChunk(
+				data,
+				chunk.m_chunkX,
+				chunk.m_chunkZ))
+		{
+			if (profileIndex < authored->m_enabledInstancesPerProfile.Num())
+			{
+				return authored->m_enabledInstancesPerProfile[profileIndex];
+			}
+			uint32_t result = 0u;
+			for (const auto& instance : authored->m_instances)
+			{
+				result += instance.IsEnabled() &&
+					instance.m_profileIndex == profileIndex ? 1u : 0u;
+			}
+			return result;
+		}
+		return profileIndex < data.m_vegetationProfiles.Num() ?
+			data.m_vegetationProfiles[profileIndex].m_instancesPerChunk : 0u;
 	}
 
 	float SmoothNoise(int32_t x, int32_t z, uint32_t seed)
@@ -365,24 +475,39 @@ namespace
 			{
 				continue;
 			}
+			if (const auto* authored = GetAuthoredVegetationChunk(
+					data,
+					chunkX,
+					chunkZ))
+			{
+				for (const auto& instance : authored->m_instances)
+				{
+					if (instance.IsEnabled() &&
+						instance.m_profileIndex == profileIndex)
+					{
+						result.m_vegetation.Add(instance);
+					}
+				}
+				continue;
+			}
 			result.m_vegetation.Reserve(result.m_vegetation.Num() + profile.m_instancesPerChunk);
 			for (uint32_t instance = 0u; instance < profile.m_instancesPerChunk; ++instance)
 			{
 				const uint32_t randomSeed = data.m_seed ^
 					static_cast<uint32_t>(chunkX * 92821u + chunkZ * 68917u +
 						profileIndex * 4099u + instance * 131u);
-				LandscapeChunkCpuData::VegetationInstance placement;
-				placement.m_profileIndex = profileIndex;
-				placement.m_position.x = originX + Random01(randomSeed) * data.m_chunkSize;
-				placement.m_position.z = originZ + Random01(randomSeed + 1u) * data.m_chunkSize;
-				placement.m_position.y = SampleHeight(placement.m_position.x, placement.m_position.z,
+				const float positionX = originX + Random01(randomSeed) * data.m_chunkSize;
+				const float positionZ = originZ + Random01(randomSeed + 1u) * data.m_chunkSize;
+				const float height = SampleHeight(positionX, positionZ,
 					landscapeWidth, landscapeDepth, data.m_noiseScale, data.m_heightScale,
-					data.m_seed, data.m_sculptStamps, heightmap) +
-					profile.m_groundOffset;
-				placement.m_angle = Random01(randomSeed + 2u) * glm::two_pi<float>();
-				placement.m_scale = glm::mix(profile.m_minScale, profile.m_maxScale,
-					Random01(randomSeed + 3u));
-				result.m_vegetation.Add(std::move(placement));
+					data.m_seed, data.m_sculptStamps, heightmap);
+				result.m_vegetation.Add(BuildProceduralVegetationInstance(
+					data,
+					chunkX,
+					chunkZ,
+					profileIndex,
+					instance,
+					height));
 			}
 		}
 		return result;
@@ -550,7 +675,7 @@ namespace
 		const LandscapeVegetationProfile& profile,
 		const glm::mat4& ownerMatrix,
 		uint64_t frame,
-		TVector<glm::mat4> instanceTransforms,
+		LandscapeVegetationRenderInstances instances,
 		EMobilityType mobility,
 		uint64_t revision,
 		LandscapeVegetationRenderProxy& result)
@@ -686,16 +811,16 @@ namespace
 #endif
 		}
 
-		const uint32_t instanceCount = static_cast<uint32_t>(instanceTransforms.Num());
+		const uint32_t instanceCount = static_cast<uint32_t>(instances.m_transforms.Num());
 		Math::AABB batchedVegetationBounds;
-		for (const auto& localInstanceMatrix : instanceTransforms)
+		for (const auto& localInstanceMatrix : instances.m_transforms)
 		{
 			const glm::mat4 instanceMatrix = ownerMatrix * localInstanceMatrix;
 			Math::AABB instanceBounds = vegetationBounds;
 			instanceBounds.Apply(instanceMatrix);
 			batchedVegetationBounds.Extend(instanceBounds);
 		}
-		if (instanceTransforms.IsEmpty() ||
+		if (instances.m_transforms.IsEmpty() ||
 			vegetationMeshes.IsEmpty() ||
 			!batchedVegetationBounds.IsValid())
 		{
@@ -703,7 +828,12 @@ namespace
 		}
 		instanceGroup.m_meshes = std::move(vegetationMeshes);
 		instanceGroup.m_meshTransforms = std::move(vegetationModelMatrices);
-		instanceGroup.m_instanceTransforms = std::move(instanceTransforms);
+		instanceGroup.m_instanceTransforms = std::move(instances.m_transforms);
+		instanceGroup.m_instanceLodBiases = std::move(instances.m_lodBiases);
+		instanceGroup.m_instanceCullDistanceScales =
+			std::move(instances.m_cullDistanceScales);
+		instanceGroup.m_instanceShadowDistanceScales =
+			std::move(instances.m_shadowDistanceScales);
 
 		vegetationProxy.m_worldAabb = batchedVegetationBounds;
 		auto vegetationShadowCaster = RHI::RHIShadowCasterProxyPtr::Make();
@@ -880,14 +1010,222 @@ namespace
 		return glm::mix(a, b, tz);
 	}
 
+	bool TryLoadVegetationAsset(LandscapeData& data)
+	{
+		if (!data.m_bReloadVegetationAsset)
+		{
+			return data.m_bVegetationAssetLoaded;
+		}
+		data.m_bReloadVegetationAsset = false;
+		if (!data.m_vegetationAsset)
+		{
+			data.m_vegetationAssetData = {};
+			data.m_bVegetationAssetLoaded = false;
+			return false;
+		}
+
+		auto* registry = App::GetSubmodule<AssetRegistry>();
+		auto* assetInfo = registry ?
+			registry->GetAssetInfoPtr<LandscapeVegetationAssetInfoPtr>(
+				data.m_vegetationAsset) : nullptr;
+		if (!assetInfo)
+		{
+			SAILOR_LOG_ERROR(
+				"LandscapeECS: vegetation asset %s is not registered.",
+				data.m_vegetationAsset.ToString().c_str());
+			return data.m_bVegetationAssetLoaded;
+		}
+
+		LandscapeVegetationAssetData loaded;
+		std::string diagnostic;
+		if (!loaded.Load(assetInfo->GetAssetFilepath(), diagnostic))
+		{
+			SAILOR_LOG_ERROR(
+				"LandscapeECS: cannot load vegetation asset %s: %s",
+				data.m_vegetationAsset.ToString().c_str(),
+				diagnostic.c_str());
+			return data.m_bVegetationAssetLoaded;
+		}
+		if (loaded.m_chunksX != data.m_chunksX ||
+			loaded.m_chunksZ != data.m_chunksZ ||
+			loaded.m_chunkSize != data.m_chunkSize)
+		{
+			SAILOR_LOG_ERROR(
+				"LandscapeECS: vegetation asset %s targets %ux%u chunks of %.3fm, but the component uses %ux%u chunks of %.3fm.",
+				data.m_vegetationAsset.ToString().c_str(),
+				loaded.m_chunksX,
+				loaded.m_chunksZ,
+				loaded.m_chunkSize,
+				data.m_chunksX,
+				data.m_chunksZ,
+				data.m_chunkSize);
+			return data.m_bVegetationAssetLoaded;
+		}
+
+		const uint64_t instanceCount = loaded.GetInstanceCount();
+		data.m_vegetationAssetData = std::move(loaded);
+		data.m_bVegetationAssetLoaded = true;
+		SAILOR_LOG(
+			"LandscapeECS: loaded %llu instances from vegetation asset %s.",
+			static_cast<unsigned long long>(instanceCount),
+			data.m_vegetationAsset.ToString().c_str());
+		return true;
+	}
+
+	bool BuildProceduralVegetationAssetData(
+		const LandscapeData& data,
+		LandscapeVegetationAssetData& result,
+		std::string& outDiagnostic)
+	{
+		const size_t expectedChunkCount =
+			static_cast<size_t>(data.m_chunksX) * data.m_chunksZ;
+		if (data.m_chunks.Num() != expectedChunkCount)
+		{
+			outDiagnostic = "Landscape chunks are not ready for vegetation export.";
+			return false;
+		}
+
+		result = {};
+		result.m_chunksX = data.m_chunksX;
+		result.m_chunksZ = data.m_chunksZ;
+		result.m_profileCount = static_cast<uint32_t>(data.m_vegetationProfiles.Num());
+		result.m_chunkSize = data.m_chunkSize;
+		result.m_chunks.Resize(expectedChunkCount);
+		const float landscapeWidth = data.m_chunksX * data.m_chunkSize;
+		const float landscapeDepth = data.m_chunksZ * data.m_chunkSize;
+		for (size_t chunkIndex = 0u; chunkIndex < expectedChunkCount; ++chunkIndex)
+		{
+			const auto& sourceChunk = data.m_chunks[chunkIndex];
+			auto& chunk = result.m_chunks[chunkIndex];
+			chunk.m_chunkX = static_cast<uint32_t>(chunkIndex % data.m_chunksX);
+			chunk.m_chunkZ = static_cast<uint32_t>(chunkIndex / data.m_chunksX);
+			const float originX = chunk.m_chunkX * data.m_chunkSize -
+				landscapeWidth * 0.5f;
+			const float originZ = chunk.m_chunkZ * data.m_chunkSize -
+				landscapeDepth * 0.5f;
+			for (size_t profileIndex = 0u;
+				profileIndex < data.m_vegetationProfiles.Num();
+				++profileIndex)
+			{
+				const auto& profile = data.m_vegetationProfiles[profileIndex];
+				if (!profile.m_modelFileId)
+				{
+					continue;
+				}
+				chunk.m_instances.Reserve(
+					chunk.m_instances.Num() + profile.m_instancesPerChunk);
+				for (uint32_t instanceIndex = 0u;
+					instanceIndex < profile.m_instancesPerChunk;
+					++instanceIndex)
+				{
+					const uint32_t randomSeed = data.m_seed ^
+						static_cast<uint32_t>(chunk.m_chunkX * 92821u +
+							chunk.m_chunkZ * 68917u +
+							profileIndex * 4099u +
+							instanceIndex * 131u);
+					const float positionX = originX +
+						Random01(randomSeed) * data.m_chunkSize;
+					const float positionZ = originZ +
+						Random01(randomSeed + 1u) * data.m_chunkSize;
+					chunk.m_instances.Add(BuildProceduralVegetationInstance(
+						data,
+						chunk.m_chunkX,
+						chunk.m_chunkZ,
+						profileIndex,
+						instanceIndex,
+						SampleLandscapeChunkHeight(
+							data,
+							sourceChunk,
+							positionX,
+							positionZ)));
+				}
+			}
+		}
+		if (!result.Validate(outDiagnostic))
+		{
+			return false;
+		}
+		result.RebuildRuntimeIndices();
+		return true;
+	}
+
+	bool TrySaveVegetationAsset(LandscapeData& data)
+	{
+		if (!data.m_bSaveVegetationRequested)
+		{
+			return true;
+		}
+		data.m_bSaveVegetationRequested = false;
+		if (!data.m_vegetationAsset)
+		{
+			SAILOR_LOG_ERROR(
+				"LandscapeECS: Save Vegetation requires a vegetation asset reference.");
+			return false;
+		}
+
+		auto* registry = App::GetSubmodule<AssetRegistry>();
+		auto* assetInfo = registry ?
+			registry->GetAssetInfoPtr<LandscapeVegetationAssetInfoPtr>(
+				data.m_vegetationAsset) : nullptr;
+		if (!assetInfo || !assetInfo->IsWritable())
+		{
+			SAILOR_LOG_ERROR(
+				"LandscapeECS: vegetation asset %s is missing or read-only.",
+				data.m_vegetationAsset.ToString().c_str());
+			return false;
+		}
+
+		LandscapeVegetationAssetData generated;
+		const LandscapeVegetationAssetData* source = nullptr;
+		bool bGeneratedSource = false;
+		std::string diagnostic;
+		if (IsVegetationAssetCompatible(data))
+		{
+			source = &data.m_vegetationAssetData;
+		}
+		else if (BuildProceduralVegetationAssetData(data, generated, diagnostic))
+		{
+			source = &generated;
+			bGeneratedSource = true;
+		}
+		if (!source)
+		{
+			SAILOR_LOG_ERROR(
+				"LandscapeECS: cannot prepare vegetation asset %s: %s",
+				data.m_vegetationAsset.ToString().c_str(),
+				diagnostic.c_str());
+			return false;
+		}
+		if (!source->Save(assetInfo->GetAssetFilepath(), diagnostic))
+		{
+			SAILOR_LOG_ERROR(
+				"LandscapeECS: cannot save vegetation asset %s: %s",
+				data.m_vegetationAsset.ToString().c_str(),
+				diagnostic.c_str());
+			return false;
+		}
+		const uint64_t savedInstanceCount = source->GetInstanceCount();
+		if (bGeneratedSource)
+		{
+			data.m_vegetationAssetData = std::move(generated);
+			data.m_bVegetationAssetLoaded = true;
+		}
+		data.m_bReloadVegetationAsset = false;
+		SAILOR_LOG(
+			"LandscapeECS: saved %llu instances to vegetation asset %s.",
+			static_cast<unsigned long long>(savedInstanceCount),
+			data.m_vegetationAsset.ToString().c_str());
+		return true;
+	}
+
 	uint64_t CalculateGrassViewRevision(
 		const LandscapeData& data,
-		const LandscapeVegetationProfile& profile,
+		uint32_t instanceCapacity,
 		const glm::mat4& inverseOwnerMatrix,
 		const TVector<glm::vec3>& cameraPositions)
 	{
 		const float meanInstanceSpacing = data.m_chunkSize /
-			std::sqrt(static_cast<float>((std::max)(profile.m_instancesPerChunk, 1u)));
+			std::sqrt(static_cast<float>((std::max)(instanceCapacity, 1u)));
 		const double cellSize = static_cast<double>((std::clamp)(
 			meanInstanceSpacing,
 			0.5f,
@@ -920,7 +1258,7 @@ namespace
 		return static_cast<uint64_t>(result) | 1ull;
 	}
 
-	TVector<glm::mat4> BuildGrassInstanceTransforms(
+	LandscapeVegetationRenderInstances BuildGrassInstanceTransforms(
 		const LandscapeData& data,
 		const LandscapeChunk& chunk,
 		size_t profileIndex,
@@ -930,14 +1268,12 @@ namespace
 	{
 		struct InstancePlacement final
 		{
-			glm::vec3 m_position{};
-			float m_angle = 0.0f;
-			float m_scale = 1.0f;
+			LandscapeVegetationInstance m_instance{};
 			float m_cameraDistanceSquared = 0.0f;
 			uint32_t m_instanceIndex = 0u;
 		};
 
-		TVector<glm::mat4> result;
+		LandscapeVegetationRenderInstances result;
 		if (profileIndex >= data.m_vegetationProfiles.Num())
 		{
 			return result;
@@ -947,39 +1283,78 @@ namespace
 		const float landscapeDepth = data.m_chunksZ * data.m_chunkSize;
 		const float originX = chunk.m_chunkX * data.m_chunkSize - landscapeWidth * 0.5f;
 		const float originZ = chunk.m_chunkZ * data.m_chunkSize - landscapeDepth * 0.5f;
-		instanceCount = (std::min)(instanceCount, profile.m_instancesPerChunk);
-		result.Reserve(instanceCount);
-		const bool bPartialSelection =
-			instanceCount < profile.m_instancesPerChunk &&
-			!cameraPositions.IsEmpty();
-		auto buildPlacement = [&](uint32_t instance)
-		{
-			const uint32_t randomSeed = data.m_seed ^
-				static_cast<uint32_t>(chunk.m_chunkX * 92821u +
-					chunk.m_chunkZ * 68917u +
-					profileIndex * 4099u +
-					instance * 131u);
-			InstancePlacement placement;
-			placement.m_instanceIndex = instance;
-			placement.m_position.x = originX + Random01(randomSeed) * data.m_chunkSize;
-			placement.m_position.z = originZ + Random01(randomSeed + 1u) * data.m_chunkSize;
-			placement.m_position.y = SampleLandscapeChunkHeight(
+		TVector<InstancePlacement> placements;
+		if (const auto* authored = GetAuthoredVegetationChunk(
 				data,
-				chunk,
-				placement.m_position.x,
-				placement.m_position.z) +
-				profile.m_groundOffset;
-			placement.m_angle = Random01(randomSeed + 2u) * glm::two_pi<float>();
-			placement.m_scale = glm::mix(
-				profile.m_minScale,
-				profile.m_maxScale,
-				Random01(randomSeed + 3u));
-			if (bPartialSelection)
+				chunk.m_chunkX,
+				chunk.m_chunkZ))
+		{
+			placements.Reserve(authored->m_instances.Num());
+			for (const auto& instance : authored->m_instances)
+			{
+				if (!instance.IsEnabled() || instance.m_profileIndex != profileIndex)
+				{
+					continue;
+				}
+				InstancePlacement placement;
+				placement.m_instance = instance;
+				placement.m_instanceIndex = static_cast<uint32_t>(placements.Num());
+				placements.Add(std::move(placement));
+			}
+		}
+		else
+		{
+			placements.Reserve(profile.m_instancesPerChunk);
+			for (uint32_t instanceIndex = 0u;
+				instanceIndex < profile.m_instancesPerChunk;
+				++instanceIndex)
+			{
+				const uint32_t randomSeed = data.m_seed ^
+					static_cast<uint32_t>(chunk.m_chunkX * 92821u +
+						chunk.m_chunkZ * 68917u +
+						profileIndex * 4099u +
+						instanceIndex * 131u);
+				const float positionX = originX +
+					Random01(randomSeed) * data.m_chunkSize;
+				const float positionZ = originZ +
+					Random01(randomSeed + 1u) * data.m_chunkSize;
+				InstancePlacement placement;
+				placement.m_instance = BuildProceduralVegetationInstance(
+					data,
+					chunk.m_chunkX,
+					chunk.m_chunkZ,
+					profileIndex,
+					instanceIndex,
+					SampleLandscapeChunkHeight(
+						data,
+						chunk,
+						positionX,
+						positionZ));
+				placement.m_instanceIndex = instanceIndex;
+				placements.Add(std::move(placement));
+			}
+		}
+
+		instanceCount = (std::min)(
+			instanceCount,
+			static_cast<uint32_t>(placements.Num()));
+		result.m_transforms.Reserve(instanceCount);
+		result.m_lodBiases.Reserve(instanceCount);
+		result.m_cullDistanceScales.Reserve(instanceCount);
+		result.m_shadowDistanceScales.Reserve(instanceCount);
+		const bool bPartialSelection =
+			instanceCount < placements.Num() &&
+			!cameraPositions.IsEmpty();
+		if (bPartialSelection)
+		{
+			for (auto& placement : placements)
 			{
 				placement.m_cameraDistanceSquared =
 					(std::numeric_limits<float>::infinity)();
+				const glm::vec3 localPosition = glm::vec3(
+					placement.m_instance.m_transform[3]);
 				const glm::vec3 worldPosition = glm::vec3(
-					ownerMatrix * glm::vec4(placement.m_position, 1.0f));
+					ownerMatrix * glm::vec4(localPosition, 1.0f));
 				for (const glm::vec3& cameraPosition : cameraPositions)
 				{
 					const glm::vec3 delta = worldPosition - cameraPosition;
@@ -988,53 +1363,32 @@ namespace
 						glm::dot(delta, delta));
 				}
 			}
-			return placement;
-		};
-		auto appendTransform = [&result](const InstancePlacement& placement)
-		{
-			result.Add(
-				glm::translate(glm::mat4(1.0f), placement.m_position) *
-				glm::rotate(glm::mat4(1.0f), placement.m_angle,
-					glm::vec3(0.0f, 1.0f, 0.0f)) *
-				glm::scale(glm::mat4(1.0f), glm::vec3(placement.m_scale)));
-		};
-
-		if (!bPartialSelection)
-		{
-			for (uint32_t instance = 0u; instance < instanceCount; ++instance)
-			{
-				appendTransform(buildPlacement(instance));
-			}
-			return result;
-		}
-
-		TVector<InstancePlacement> placements;
-		placements.Reserve(profile.m_instancesPerChunk);
-		for (uint32_t instance = 0u; instance < profile.m_instancesPerChunk; ++instance)
-		{
-			placements.Add(buildPlacement(instance));
-		}
-		auto compareDistance = [](const InstancePlacement& lhs, const InstancePlacement& rhs)
-			{
-				if (lhs.m_cameraDistanceSquared != rhs.m_cameraDistanceSquared)
+			auto compareDistance = [](const InstancePlacement& lhs, const InstancePlacement& rhs)
 				{
-					return lhs.m_cameraDistanceSquared < rhs.m_cameraDistanceSquared;
-				}
-				return lhs.m_instanceIndex < rhs.m_instanceIndex;
-			};
-		std::nth_element(
-			placements.begin(),
-			placements.begin() + instanceCount,
-			placements.end(),
-			compareDistance);
-		placements.Resize(instanceCount);
-		placements.Sort([](const InstancePlacement& lhs, const InstancePlacement& rhs)
-			{
-				return lhs.m_instanceIndex < rhs.m_instanceIndex;
-			});
+					if (lhs.m_cameraDistanceSquared != rhs.m_cameraDistanceSquared)
+					{
+						return lhs.m_cameraDistanceSquared < rhs.m_cameraDistanceSquared;
+					}
+					return lhs.m_instanceIndex < rhs.m_instanceIndex;
+				};
+			std::nth_element(
+				placements.begin(),
+				placements.begin() + instanceCount,
+				placements.end(),
+				compareDistance);
+			placements.Resize(instanceCount);
+			placements.Sort([](const InstancePlacement& lhs, const InstancePlacement& rhs)
+				{
+					return lhs.m_instanceIndex < rhs.m_instanceIndex;
+				});
+		}
+		else
+		{
+			placements.Resize(instanceCount);
+		}
 		for (const auto& placement : placements)
 		{
-			appendTransform(placement);
+			AppendRenderInstance(placement.m_instance, result);
 		}
 		return result;
 	}
@@ -1188,6 +1542,30 @@ void LandscapeData::SetAuthoredStamps(const TVector<float>& sculptStamps,
 	}
 	m_sculptStamps = sculptStamps;
 	m_paintStamps = paintStamps;
+	MarkDirty();
+}
+
+void LandscapeData::SetVegetationAsset(const FileId& vegetationAsset)
+{
+	if (m_vegetationAsset == vegetationAsset)
+	{
+		return;
+	}
+	m_vegetationAsset = vegetationAsset;
+	m_vegetationAssetData = {};
+	m_bVegetationAssetLoaded = false;
+	RequestVegetationAssetReload();
+}
+
+void LandscapeData::RequestVegetationAssetReload()
+{
+	m_bReloadVegetationAsset = static_cast<bool>(m_vegetationAsset);
+	RequestFullRebuild();
+}
+
+void LandscapeData::RequestSaveVegetation()
+{
+	m_bSaveVegetationRequested = true;
 	MarkDirty();
 }
 
@@ -1473,6 +1851,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 				profile.m_bModelMaterialsRequested = true;
 			}
 		}
+		TryLoadVegetationAsset(data);
 
 		const size_t numLandscapeChunks = static_cast<size_t>(data.m_chunksX) * data.m_chunksZ;
 		const bool bRebuildAllChunks = data.m_bRebuildAllChunks ||
@@ -1502,6 +1881,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 		}
 		if (chunksToBuild.IsEmpty())
 		{
+			TrySaveVegetationAsset(data);
 			data.m_bIsDirty = false;
 			data.SetLastChange(owner->GetTransformComponent().GetFrameLastChange());
 			continue;
@@ -1589,18 +1969,29 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			TVector<Physics::CollisionShapeDesc> vegetationCollisionShapes;
 			for (const auto& placement : cpu.m_vegetation)
 			{
+				if (placement.m_profileIndex >= data.m_vegetationProfiles.Num())
+				{
+					continue;
+				}
 				const auto& profile = data.m_vegetationProfiles[placement.m_profileIndex];
 				if (profile.m_colliderRadius <= 0.0f)
 				{
 					continue;
 				}
+				const Math::Transform instanceTransform =
+					Math::Transform::FromMatrix(placement.m_transform);
+				const float instanceScale = (std::max)({
+					std::abs(instanceTransform.m_scale.x),
+					std::abs(instanceTransform.m_scale.y),
+					std::abs(instanceTransform.m_scale.z)
+				});
 				Physics::CollisionShapeDesc shape;
 				shape.m_type = Physics::ECollisionShapeType::Capsule;
-				shape.m_center = placement.m_position + glm::vec3(
-					0.0f, profile.m_colliderOffsetY * placement.m_scale, 0.0f);
-				shape.m_rotation = glm::angleAxis(placement.m_angle, glm::vec3(0.0f, 1.0f, 0.0f));
-				shape.m_radius = profile.m_colliderRadius * placement.m_scale;
-				shape.m_height = profile.m_colliderHeight * placement.m_scale;
+				shape.m_center = glm::vec3(instanceTransform.TransformPosition(
+					glm::vec4(0.0f, profile.m_colliderOffsetY, 0.0f, 1.0f)));
+				shape.m_rotation = instanceTransform.m_rotation;
+				shape.m_radius = profile.m_colliderRadius * instanceScale;
+				shape.m_height = profile.m_colliderHeight * instanceScale;
 				vegetationCollisionShapes.Add(std::move(shape));
 			}
 			if (physics && !vegetationCollisionShapes.IsEmpty() &&
@@ -1691,19 +2082,18 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 					continue;
 				}
 
-				TVector<glm::mat4> instanceTransforms;
-				instanceTransforms.Reserve(profile.m_instancesPerChunk);
+				LandscapeVegetationRenderInstances instances;
+				instances.m_transforms.Reserve(profile.m_instancesPerChunk);
+				instances.m_lodBiases.Reserve(profile.m_instancesPerChunk);
+				instances.m_cullDistanceScales.Reserve(profile.m_instancesPerChunk);
+				instances.m_shadowDistanceScales.Reserve(profile.m_instancesPerChunk);
 				for (const auto& placement : cpu.m_vegetation)
 				{
 					if (placement.m_profileIndex != profileIndex)
 					{
 						continue;
 					}
-					instanceTransforms.Add(
-						glm::translate(glm::mat4(1.0f), placement.m_position) *
-						glm::rotate(glm::mat4(1.0f), placement.m_angle,
-							glm::vec3(0.0f, 1.0f, 0.0f)) *
-						glm::scale(glm::mat4(1.0f), glm::vec3(placement.m_scale)));
+					AppendRenderInstance(placement, instances);
 				}
 
 				LandscapeVegetationRenderProxy vegetationRenderProxy;
@@ -1714,7 +2104,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 					profile,
 					ownerMatrix,
 					proxy.m_frame,
-					std::move(instanceTransforms),
+					std::move(instances),
 					EMobilityType::Static,
 					data.m_buildRevision + 1u,
 					vegetationRenderProxy);
@@ -1762,6 +2152,7 @@ Tasks::ITaskPtr LandscapeECS::Tick(float)
 			vegetationProfilesWithoutRenderData,
 			data.m_sculptStamps.Num() / 5u, data.m_paintStamps.Num() / 5u,
 			static_cast<unsigned long long>(data.m_buildRevision));
+		TrySaveVegetationAsset(data);
 	}
 	bSceneChanged |= UpdateGrassResidency(cameraTransforms, cameras);
 	if (bSceneChanged)
@@ -1931,8 +2322,15 @@ bool LandscapeECS::UpdateGrassResidency(
 			{
 				const auto& profile = component.m_vegetationProfiles[profileIndex];
 				if (profile.m_residency != ELandscapeVegetationResidency::Grass ||
-					!profile.m_modelFileId ||
-					profile.m_instancesPerChunk == 0u)
+					!profile.m_modelFileId)
+				{
+					continue;
+				}
+				const uint32_t instanceCapacity = GetVegetationInstanceCapacity(
+					component,
+					chunk,
+					profileIndex);
+				if (instanceCapacity == 0u)
 				{
 					continue;
 				}
@@ -1948,7 +2346,7 @@ bool LandscapeECS::UpdateGrassResidency(
 				candidate.m_componentIndex = componentIndex;
 				candidate.m_chunkIndex = chunkIndex;
 				candidate.m_profileIndex = profileIndex;
-				candidate.m_capacity = profile.m_instancesPerChunk;
+				candidate.m_capacity = instanceCapacity;
 				candidate.m_chunkRing = chunkRing;
 				candidate.m_chunkManhattanDistance = chunkManhattanDistance;
 				candidate.m_priority = profile.m_priority;
@@ -1977,8 +2375,15 @@ bool LandscapeECS::UpdateGrassResidency(
 		{
 			continue;
 		}
-		const auto& profile = component.m_vegetationProfiles[selection.m_profileIndex];
-		if (selection.m_instanceCount >= profile.m_instancesPerChunk)
+		if (selection.m_chunkIndex >= component.m_chunks.Num())
+		{
+			continue;
+		}
+		const uint32_t instanceCapacity = GetVegetationInstanceCapacity(
+			component,
+			component.m_chunks[selection.m_chunkIndex],
+			selection.m_profileIndex);
+		if (selection.m_instanceCount >= instanceCapacity)
 		{
 			continue;
 		}
@@ -1989,7 +2394,7 @@ bool LandscapeECS::UpdateGrassResidency(
 		}
 		selection.m_viewRevision = CalculateGrassViewRevision(
 			component,
-			profile,
+			instanceCapacity,
 			glm::inverse(owner->GetTransformComponent().GetCachedWorldMatrix()),
 			m_cameraPositionsScratch);
 	}
@@ -2076,8 +2481,12 @@ bool LandscapeECS::UpdateGrassResidency(
 					chunkIndex,
 					profileIndex);
 				const uint32_t selectedCount = selection ? selection->m_instanceCount : 0u;
+				const uint32_t instanceCapacity = GetVegetationInstanceCapacity(
+					component,
+					chunk,
+					profileIndex);
 				const bool bPartialSelection = selection &&
-					selectedCount < profile.m_instancesPerChunk;
+					selectedCount < instanceCapacity;
 				if (selectedCount == 0u ||
 					(residentCount == selectedCount &&
 						(!bPartialSelection ||
@@ -2088,7 +2497,7 @@ bool LandscapeECS::UpdateGrassResidency(
 
 				const LandscapeData* componentData = &component;
 				const LandscapeChunk* chunkData = &chunk;
-				auto task = Tasks::CreateTask<TVector<glm::mat4>>(
+				auto task = Tasks::CreateTask<LandscapeVegetationRenderInstances>(
 					"LandscapeECS:Build Grass Transforms",
 					[componentData,
 						chunkData,
@@ -2188,8 +2597,12 @@ bool LandscapeECS::UpdateGrassResidency(
 					chunkIndex,
 					profileIndex);
 				const uint32_t selectedCount = selection ? selection->m_instanceCount : 0u;
+				const uint32_t instanceCapacity = GetVegetationInstanceCapacity(
+					component,
+					chunk,
+					profileIndex);
 				const bool bPartialSelection = selection &&
-					selectedCount < profile.m_instancesPerChunk;
+					selectedCount < instanceCapacity;
 				bNeedsUpdate |= residentCount != selectedCount ||
 					(resident && bPartialSelection &&
 						resident->m_viewRevision != selection->m_viewRevision);
@@ -2236,7 +2649,10 @@ bool LandscapeECS::UpdateGrassResidency(
 					continue;
 				}
 				const bool bPartialSelection =
-					selectedCount < profile.m_instancesPerChunk;
+					selectedCount < GetVegetationInstanceCapacity(
+						component,
+						chunk,
+						profileIndex);
 				if (resident && resident->m_instanceCount == selectedCount &&
 					(!bPartialSelection ||
 						resident->m_viewRevision == selection->m_viewRevision))
@@ -2264,7 +2680,7 @@ bool LandscapeECS::UpdateGrassResidency(
 					continue;
 				}
 				buildRequest->m_task->Wait();
-				auto instanceTransforms = std::move(buildRequest->m_task->m_result);
+				auto instances = std::move(buildRequest->m_task->m_result);
 				LandscapeVegetationRenderProxy streamedProxy;
 				const uint64_t revision = (uint64_t(1u) << 63u) |
 					++component.m_streamingRevision;
@@ -2275,7 +2691,7 @@ bool LandscapeECS::UpdateGrassResidency(
 					profile,
 					ownerMatrix,
 					frame,
-					std::move(instanceTransforms),
+					std::move(instances),
 					EMobilityType::Dynamic,
 					revision,
 					streamedProxy);

--- a/Runtime/ECS/LandscapeECS.h
+++ b/Runtime/ECS/LandscapeECS.h
@@ -2,6 +2,7 @@
 
 #include "ECS/ECS.h"
 #include "ECS/LandscapeStreaming.h"
+#include "AssetRegistry/Landscape/LandscapeVegetationAsset.h"
 #include "RHI/SceneView.h"
 
 namespace Sailor
@@ -61,6 +62,14 @@ namespace Sailor
 		EMobilityType m_mobility = EMobilityType::Static;
 	};
 
+	struct LandscapeVegetationRenderInstances final
+	{
+		TVector<glm::mat4> m_transforms{};
+		TVector<int32_t> m_lodBiases{};
+		TVector<float> m_cullDistanceScales{};
+		TVector<float> m_shadowDistanceScales{};
+	};
+
 	struct LandscapeChunk final
 	{
 		RHI::RHISceneProxyResourcePtr m_resource{};
@@ -92,6 +101,9 @@ namespace Sailor
 			const TVector<FileId>& materialMasks);
 		SAILOR_API void SetAuthoredStamps(const TVector<float>& sculptStamps,
 			const TVector<float>& paintStamps);
+		SAILOR_API void SetVegetationAsset(const FileId& vegetationAsset);
+		SAILOR_API void RequestVegetationAssetReload();
+		SAILOR_API void RequestSaveVegetation();
 		SAILOR_API void RequestFullRebuild();
 		SAILOR_API void SetVegetationProfiles(
 			const TVector<FileId>& models,
@@ -138,6 +150,11 @@ namespace Sailor
 		TVector<FileId> m_materialMasks{};
 		TVector<float> m_sculptStamps{};
 		TVector<float> m_paintStamps{};
+		FileId m_vegetationAsset{};
+		LandscapeVegetationAssetData m_vegetationAssetData{};
+		bool m_bVegetationAssetLoaded = false;
+		bool m_bReloadVegetationAsset = false;
+		bool m_bSaveVegetationRequested = false;
 		TVector<LandscapeVegetationProfile> m_vegetationProfiles{};
 		TVector<LandscapeChunk> m_chunks{};
 		TVector<uint32_t> m_physicsBodies{};
@@ -170,7 +187,7 @@ namespace Sailor
 			size_t m_profileIndex = 0u;
 			uint32_t m_instanceCount = 0u;
 			uint64_t m_viewRevision = 0u;
-			Tasks::TaskPtr<TVector<glm::mat4>> m_task{};
+			Tasks::TaskPtr<LandscapeVegetationRenderInstances> m_task{};
 		};
 
 		void DestroyPhysicsBodies(LandscapeData& component);

--- a/Runtime/ECS/LandscapeECS.h
+++ b/Runtime/ECS/LandscapeECS.h
@@ -12,6 +12,12 @@ namespace Sailor
 		All
 	};
 
+	enum class ELandscapeVegetationResidency : uint8_t
+	{
+		Persistent = 0u,
+		Grass
+	};
+
 	struct LandscapeVegetationProfile final
 	{
 		FileId m_modelFileId{};
@@ -23,6 +29,9 @@ namespace Sailor
 		uint64_t m_cachedMaterialRenderMetadataRevision = 0ull;
 		int32_t m_meshIndex = -1;
 		uint32_t m_instancesPerChunk = 0u;
+		ELandscapeVegetationResidency m_residency =
+			ELandscapeVegetationResidency::Persistent;
+		float m_priority = 1.0f;
 		float m_minScale = 0.75f;
 		float m_maxScale = 1.25f;
 		float m_groundOffset = 0.0f;
@@ -42,6 +51,10 @@ namespace Sailor
 		RHI::RHISceneProxyResourcePtr m_resource{};
 		glm::ivec3 m_octreeCenter{};
 		glm::ivec3 m_octreeExtents{ 1 };
+		size_t m_profileIndex = 0u;
+		uint32_t m_instanceCount = 0u;
+		uint64_t m_revision = 0u;
+		EMobilityType m_mobility = EMobilityType::Static;
 	};
 
 	struct LandscapeChunk final
@@ -50,6 +63,10 @@ namespace Sailor
 		glm::ivec3 m_octreeCenter{};
 		glm::ivec3 m_octreeExtents{ 1 };
 		TVector<LandscapeVegetationRenderProxy> m_vegetationProxies{};
+		TVector<float> m_heightSamples{};
+		uint32_t m_heightResolution = 0u;
+		uint32_t m_chunkX = 0u;
+		uint32_t m_chunkZ = 0u;
 		TVector<uint32_t> m_physicsBodies{};
 		uint64_t m_buildRevision = 0u;
 	};
@@ -60,6 +77,12 @@ namespace Sailor
 		SAILOR_API void SetSettings(uint32_t chunksX, uint32_t chunksZ,
 			float chunkSize, uint32_t chunkResolution, float heightScale,
 			float noiseScale, uint32_t seed, float textureTiling);
+		SAILOR_API void SetLodSettings(
+			const TVector<float>& distances,
+			float skirtDepth);
+		SAILOR_API void SetVegetationStreamingSettings(
+			uint32_t grassInstanceBudget,
+			float grassResidencyHysteresis);
 		SAILOR_API void SetMaterial(const MaterialPtr& material);
 		SAILOR_API void SetLayerTextures(const TVector<FileId>& textures);
 		SAILOR_API void SetImportMaps(const FileId& heightmapTexture,
@@ -72,6 +95,8 @@ namespace Sailor
 			const TVector<FileId>& materials,
 			const TVector<float>& meshIndex,
 			const TVector<float>& instancesPerChunk,
+			const TVector<float>& residency,
+			const TVector<float>& priority,
 			const TVector<float>& minScale,
 			const TVector<float>& maxScale,
 			const TVector<float>& groundOffset,
@@ -98,6 +123,10 @@ namespace Sailor
 		float m_noiseScale = 0.035f;
 		uint32_t m_seed = 1337u;
 		float m_textureTiling = 0.15f;
+		TVector<float> m_lodDistances{ 96.0f, 192.0f };
+		float m_lodSkirtDepth = 2.0f;
+		uint32_t m_grassInstanceBudget = 32768u;
+		float m_grassResidencyHysteresis = 12.0f;
 		MaterialPtr m_material{};
 		MaterialPtr m_runtimeMaterial{};
 		uint64_t m_cachedSourceMaterialContentRevision = 0ull;
@@ -113,6 +142,8 @@ namespace Sailor
 		TSet<uint32_t> m_dirtyChunks{};
 		bool m_bRebuildAllChunks = true;
 		uint64_t m_buildRevision = 0u;
+		uint64_t m_streamingRevision = 0u;
+		uint32_t m_activeGrassInstances = 0u;
 
 		friend class LandscapeECS;
 	};
@@ -132,11 +163,16 @@ namespace Sailor
 	private:
 		void DestroyPhysicsBodies(LandscapeData& component);
 		void DestroyChunkPhysicsBodies(LandscapeData& component, LandscapeChunk& chunk);
+		bool UpdateGrassResidency(
+			size_t componentIndex,
+			LandscapeData& component,
+			const TVector<Math::Transform>& cameraTransforms);
 		void PublishSceneVersion();
 		uint64_t m_shadowCastersRevision = 0u;
 		uint64_t m_sceneVersionRevision = 0u;
 		uint64_t m_spatialRevision = 0u;
-		size_t m_spatialHash = 0u;
+		size_t m_staticSpatialHash = 0u;
+		size_t m_dynamicSpatialHash = 0u;
 		RHI::RHISpatialSceneVersionPtr m_publishedSceneVersion{};
 		RHI::RHIScenePtr m_rhiScene{};
 		TMap<size_t, RHI::RenderInstanceHandle> m_renderInstanceHandles{};

--- a/Runtime/ECS/LandscapeECS.h
+++ b/Runtime/ECS/LandscapeECS.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #include "ECS/ECS.h"
+#include "ECS/LandscapeStreaming.h"
 #include "RHI/SceneView.h"
 
 namespace Sailor
 {
+	class CameraData;
+
 	enum class ELandscapeVegetationShadowMode : uint8_t
 	{
 		None = 0u,
@@ -54,6 +57,7 @@ namespace Sailor
 		size_t m_profileIndex = 0u;
 		uint32_t m_instanceCount = 0u;
 		uint64_t m_revision = 0u;
+		uint64_t m_viewRevision = 0u;
 		EMobilityType m_mobility = EMobilityType::Static;
 	};
 
@@ -80,8 +84,7 @@ namespace Sailor
 		SAILOR_API void SetLodSettings(
 			const TVector<float>& distances,
 			float skirtDepth);
-		SAILOR_API void SetVegetationStreamingSettings(
-			uint32_t grassInstanceBudget,
+		SAILOR_API void SetGrassResidencyHysteresis(
 			float grassResidencyHysteresis);
 		SAILOR_API void SetMaterial(const MaterialPtr& material);
 		SAILOR_API void SetLayerTextures(const TVector<FileId>& textures);
@@ -125,7 +128,6 @@ namespace Sailor
 		float m_textureTiling = 0.15f;
 		TVector<float> m_lodDistances{ 96.0f, 192.0f };
 		float m_lodSkirtDepth = 2.0f;
-		uint32_t m_grassInstanceBudget = 32768u;
 		float m_grassResidencyHysteresis = 12.0f;
 		MaterialPtr m_material{};
 		MaterialPtr m_runtimeMaterial{};
@@ -161,12 +163,21 @@ namespace Sailor
 		SAILOR_API virtual void OnComponentUnregistered(size_t index, LandscapeData& component) override;
 
 	private:
+		struct GrassTransformBuildRequest final
+		{
+			size_t m_componentIndex = 0u;
+			size_t m_chunkIndex = 0u;
+			size_t m_profileIndex = 0u;
+			uint32_t m_instanceCount = 0u;
+			uint64_t m_viewRevision = 0u;
+			Tasks::TaskPtr<TVector<glm::mat4>> m_task{};
+		};
+
 		void DestroyPhysicsBodies(LandscapeData& component);
 		void DestroyChunkPhysicsBodies(LandscapeData& component, LandscapeChunk& chunk);
 		bool UpdateGrassResidency(
-			size_t componentIndex,
-			LandscapeData& component,
-			const TVector<Math::Transform>& cameraTransforms);
+			const TVector<Math::Transform>& cameraTransforms,
+			const TVector<CameraData>& cameras);
 		void PublishSceneVersion();
 		uint64_t m_shadowCastersRevision = 0u;
 		uint64_t m_sceneVersionRevision = 0u;
@@ -177,6 +188,12 @@ namespace Sailor
 		RHI::RHIScenePtr m_rhiScene{};
 		TMap<size_t, RHI::RenderInstanceHandle> m_renderInstanceHandles{};
 		TMap<size_t, uint64_t> m_publishedBuildRevisions{};
+		TVector<LandscapeGrassCandidate> m_grassCandidatesScratch{};
+		TVector<LandscapeGrassSelection> m_grassSelectionsScratch{};
+		TVector<glm::ivec2> m_cameraChunkCoordinatesScratch{};
+		TVector<glm::vec3> m_cameraPositionsScratch{};
+		TVector<Math::Frustum> m_cameraFrustumsScratch{};
+		TVector<GrassTransformBuildRequest> m_grassBuildRequestsScratch{};
 	};
 
 	template class ECS::TSystem<LandscapeECS, LandscapeData>;

--- a/Runtime/ECS/LandscapeStreaming.cpp
+++ b/Runtime/ECS/LandscapeStreaming.cpp
@@ -1,0 +1,165 @@
+#include "ECS/LandscapeStreaming.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+using namespace Sailor;
+
+TVector<uint32_t> Sailor::BuildLandscapeLodCoordinates(
+	uint32_t resolution,
+	uint32_t stride)
+{
+	TVector<uint32_t> result;
+	if (resolution == 0u)
+	{
+		return result;
+	}
+
+	stride = (std::max)(stride, 1u);
+	result.Reserve(static_cast<size_t>(resolution / stride) + 2u);
+	for (uint32_t coordinate = 0u; coordinate < resolution;)
+	{
+		result.Add(coordinate);
+		const uint32_t remaining = resolution - coordinate;
+		coordinate += (std::min)(stride, remaining);
+	}
+	result.Add(resolution);
+	return result;
+}
+
+void Sailor::AppendLandscapeLodIndices(
+	uint32_t resolution,
+	const TVector<uint32_t>& coordinates,
+	bool bIncludeSkirts,
+	TVector<uint32_t>& indices)
+{
+	if (resolution == 0u || coordinates.Num() < 2u)
+	{
+		return;
+	}
+
+	const uint32_t row = resolution + 1u;
+	for (size_t z = 0u; z + 1u < coordinates.Num(); ++z)
+	{
+		for (size_t x = 0u; x + 1u < coordinates.Num(); ++x)
+		{
+			const uint32_t i0 = coordinates[z] * row + coordinates[x];
+			const uint32_t i1 = coordinates[z] * row + coordinates[x + 1u];
+			const uint32_t i2 = coordinates[z + 1u] * row + coordinates[x];
+			const uint32_t i3 = coordinates[z + 1u] * row + coordinates[x + 1u];
+			indices.AddRange({ i0, i2, i1, i1, i2, i3 });
+		}
+	}
+	if (!bIncludeSkirts)
+	{
+		return;
+	}
+
+	const uint32_t baseVertexCount = row * row;
+	auto appendEdge = [&indices, &coordinates](
+		auto topIndex,
+		auto skirtIndex,
+		bool bReverseWinding)
+		{
+			for (size_t segment = 0u; segment + 1u < coordinates.Num(); ++segment)
+			{
+				const uint32_t coordinate0 = coordinates[segment];
+				const uint32_t coordinate1 = coordinates[segment + 1u];
+				const uint32_t top0 = topIndex(coordinate0);
+				const uint32_t top1 = topIndex(coordinate1);
+				const uint32_t bottom0 = skirtIndex(coordinate0);
+				const uint32_t bottom1 = skirtIndex(coordinate1);
+				if (bReverseWinding)
+				{
+					indices.AddRange({ top0, bottom0, top1, top1, bottom0, bottom1 });
+				}
+				else
+				{
+					indices.AddRange({ top0, top1, bottom0, top1, bottom1, bottom0 });
+				}
+			}
+		};
+
+	appendEdge(
+		[](uint32_t x) { return x; },
+		[baseVertexCount](uint32_t x) { return baseVertexCount + x; },
+		false);
+	appendEdge(
+		[row, resolution](uint32_t x) { return resolution * row + x; },
+		[baseVertexCount, row](uint32_t x) { return baseVertexCount + row + x; },
+		true);
+	appendEdge(
+		[row](uint32_t z) { return z * row; },
+		[baseVertexCount, row](uint32_t z) { return baseVertexCount + row * 2u + z; },
+		true);
+	appendEdge(
+		[row, resolution](uint32_t z) { return z * row + resolution; },
+		[baseVertexCount, row](uint32_t z) { return baseVertexCount + row * 3u + z; },
+		false);
+}
+
+TVector<LandscapeGrassSelection> Sailor::SelectLandscapeGrassResidency(
+	TVector<LandscapeGrassCandidate> candidates,
+	uint32_t instanceBudget)
+{
+	candidates.Sort([](
+		const LandscapeGrassCandidate& lhs,
+		const LandscapeGrassCandidate& rhs)
+		{
+			const float lhsPriority = std::isfinite(lhs.m_priority) ? lhs.m_priority : 0.0f;
+			const float rhsPriority = std::isfinite(rhs.m_priority) ? rhs.m_priority : 0.0f;
+			if (lhsPriority != rhsPriority)
+			{
+				return lhsPriority > rhsPriority;
+			}
+			const float lhsDistance = std::isfinite(lhs.m_distance) ?
+				lhs.m_distance : (std::numeric_limits<float>::infinity)();
+			const float rhsDistance = std::isfinite(rhs.m_distance) ?
+				rhs.m_distance : (std::numeric_limits<float>::infinity)();
+			const float lhsHysteresis = lhs.m_bResident &&
+				std::isfinite(lhs.m_residencyHysteresis) ?
+				(std::max)(lhs.m_residencyHysteresis, 0.0f) : 0.0f;
+			const float rhsHysteresis = rhs.m_bResident &&
+				std::isfinite(rhs.m_residencyHysteresis) ?
+				(std::max)(rhs.m_residencyHysteresis, 0.0f) : 0.0f;
+			const float lhsRankDistance = (std::max)(lhsDistance - lhsHysteresis, 0.0f);
+			const float rhsRankDistance = (std::max)(rhsDistance - rhsHysteresis, 0.0f);
+			if (lhsRankDistance != rhsRankDistance)
+			{
+				return lhsRankDistance < rhsRankDistance;
+			}
+			if (lhs.m_bResident != rhs.m_bResident)
+			{
+				return lhs.m_bResident;
+			}
+			if (lhs.m_chunkIndex != rhs.m_chunkIndex)
+			{
+				return lhs.m_chunkIndex < rhs.m_chunkIndex;
+			}
+			return lhs.m_profileIndex < rhs.m_profileIndex;
+		});
+
+	TVector<LandscapeGrassSelection> result;
+	for (const auto& candidate : candidates)
+	{
+		if (instanceBudget == 0u)
+		{
+			break;
+		}
+		const uint32_t selectedCount = (std::min)(
+			candidate.m_capacity,
+			instanceBudget);
+		if (selectedCount == 0u)
+		{
+			continue;
+		}
+		LandscapeGrassSelection selection;
+		selection.m_chunkIndex = candidate.m_chunkIndex;
+		selection.m_profileIndex = candidate.m_profileIndex;
+		selection.m_instanceCount = selectedCount;
+		result.Add(std::move(selection));
+		instanceBudget -= selectedCount;
+	}
+	return result;
+}

--- a/Runtime/ECS/LandscapeStreaming.cpp
+++ b/Runtime/ECS/LandscapeStreaming.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <cmath>
-#include <limits>
 
 using namespace Sailor;
 
@@ -99,48 +98,45 @@ void Sailor::AppendLandscapeLodIndices(
 		false);
 }
 
-TVector<LandscapeGrassSelection> Sailor::SelectLandscapeGrassResidency(
-	TVector<LandscapeGrassCandidate> candidates,
-	uint32_t instanceBudget)
+void Sailor::SelectLandscapeGrassResidency(
+	TVector<LandscapeGrassCandidate>& candidates,
+	uint32_t instanceBudget,
+	TVector<LandscapeGrassSelection>& outSelections)
 {
 	candidates.Sort([](
 		const LandscapeGrassCandidate& lhs,
 		const LandscapeGrassCandidate& rhs)
 		{
+			if (lhs.m_chunkRing != rhs.m_chunkRing)
+			{
+				return lhs.m_chunkRing < rhs.m_chunkRing;
+			}
+			if (lhs.m_bChunkResident != rhs.m_bChunkResident)
+			{
+				return lhs.m_bChunkResident;
+			}
+			if (lhs.m_chunkManhattanDistance != rhs.m_chunkManhattanDistance)
+			{
+				return lhs.m_chunkManhattanDistance < rhs.m_chunkManhattanDistance;
+			}
+			if (lhs.m_componentIndex != rhs.m_componentIndex)
+			{
+				return lhs.m_componentIndex < rhs.m_componentIndex;
+			}
+			if (lhs.m_chunkIndex != rhs.m_chunkIndex)
+			{
+				return lhs.m_chunkIndex < rhs.m_chunkIndex;
+			}
 			const float lhsPriority = std::isfinite(lhs.m_priority) ? lhs.m_priority : 0.0f;
 			const float rhsPriority = std::isfinite(rhs.m_priority) ? rhs.m_priority : 0.0f;
 			if (lhsPriority != rhsPriority)
 			{
 				return lhsPriority > rhsPriority;
 			}
-			const float lhsDistance = std::isfinite(lhs.m_distance) ?
-				lhs.m_distance : (std::numeric_limits<float>::infinity)();
-			const float rhsDistance = std::isfinite(rhs.m_distance) ?
-				rhs.m_distance : (std::numeric_limits<float>::infinity)();
-			const float lhsHysteresis = lhs.m_bResident &&
-				std::isfinite(lhs.m_residencyHysteresis) ?
-				(std::max)(lhs.m_residencyHysteresis, 0.0f) : 0.0f;
-			const float rhsHysteresis = rhs.m_bResident &&
-				std::isfinite(rhs.m_residencyHysteresis) ?
-				(std::max)(rhs.m_residencyHysteresis, 0.0f) : 0.0f;
-			const float lhsRankDistance = (std::max)(lhsDistance - lhsHysteresis, 0.0f);
-			const float rhsRankDistance = (std::max)(rhsDistance - rhsHysteresis, 0.0f);
-			if (lhsRankDistance != rhsRankDistance)
-			{
-				return lhsRankDistance < rhsRankDistance;
-			}
-			if (lhs.m_bResident != rhs.m_bResident)
-			{
-				return lhs.m_bResident;
-			}
-			if (lhs.m_chunkIndex != rhs.m_chunkIndex)
-			{
-				return lhs.m_chunkIndex < rhs.m_chunkIndex;
-			}
 			return lhs.m_profileIndex < rhs.m_profileIndex;
 		});
 
-	TVector<LandscapeGrassSelection> result;
+	outSelections.Clear(false);
 	for (const auto& candidate : candidates)
 	{
 		if (instanceBudget == 0u)
@@ -155,11 +151,29 @@ TVector<LandscapeGrassSelection> Sailor::SelectLandscapeGrassResidency(
 			continue;
 		}
 		LandscapeGrassSelection selection;
+		selection.m_componentIndex = candidate.m_componentIndex;
 		selection.m_chunkIndex = candidate.m_chunkIndex;
 		selection.m_profileIndex = candidate.m_profileIndex;
 		selection.m_instanceCount = selectedCount;
-		result.Add(std::move(selection));
+		outSelections.Add(std::move(selection));
 		instanceBudget -= selectedCount;
 	}
-	return result;
+}
+
+bool Sailor::DoesLandscapeGrassChunkOverlapFrustum(
+	const Math::AABB& worldBounds,
+	const Math::Frustum& frustum,
+	float residencyMargin)
+{
+	if (!worldBounds.IsValid())
+	{
+		return false;
+	}
+
+	Math::AABB cullingBounds = worldBounds;
+	const float margin = std::isfinite(residencyMargin) ?
+		(std::max)(residencyMargin, 0.0f) : 0.0f;
+	cullingBounds.m_min -= glm::vec3(margin);
+	cullingBounds.m_max += glm::vec3(margin);
+	return frustum.OverlapsAABB(cullingBounds);
 }

--- a/Runtime/ECS/LandscapeStreaming.h
+++ b/Runtime/ECS/LandscapeStreaming.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Core/Defines.h"
+#include "Memory/LockFreeHeapAllocator.h"
+#include "Containers/Vector.h"
+
+namespace Sailor
+{
+	struct LandscapeGrassCandidate final
+	{
+		size_t m_chunkIndex = 0u;
+		size_t m_profileIndex = 0u;
+		uint32_t m_capacity = 0u;
+		float m_priority = 1.0f;
+		float m_distance = 0.0f;
+		bool m_bResident = false;
+		float m_residencyHysteresis = 0.0f;
+	};
+
+	struct LandscapeGrassSelection final
+	{
+		size_t m_chunkIndex = 0u;
+		size_t m_profileIndex = 0u;
+		uint32_t m_instanceCount = 0u;
+	};
+
+	SAILOR_API TVector<uint32_t> BuildLandscapeLodCoordinates(
+		uint32_t resolution,
+		uint32_t stride);
+	SAILOR_API void AppendLandscapeLodIndices(
+		uint32_t resolution,
+		const TVector<uint32_t>& coordinates,
+		bool bIncludeSkirts,
+		TVector<uint32_t>& indices);
+
+	SAILOR_API TVector<LandscapeGrassSelection> SelectLandscapeGrassResidency(
+		TVector<LandscapeGrassCandidate> candidates,
+		uint32_t instanceBudget);
+}

--- a/Runtime/ECS/LandscapeStreaming.h
+++ b/Runtime/ECS/LandscapeStreaming.h
@@ -3,25 +3,29 @@
 #include "Core/Defines.h"
 #include "Memory/LockFreeHeapAllocator.h"
 #include "Containers/Vector.h"
+#include "Math/Bounds.h"
 
 namespace Sailor
 {
 	struct LandscapeGrassCandidate final
 	{
+		size_t m_componentIndex = 0u;
 		size_t m_chunkIndex = 0u;
 		size_t m_profileIndex = 0u;
 		uint32_t m_capacity = 0u;
+		uint32_t m_chunkRing = 0u;
+		uint32_t m_chunkManhattanDistance = 0u;
 		float m_priority = 1.0f;
-		float m_distance = 0.0f;
-		bool m_bResident = false;
-		float m_residencyHysteresis = 0.0f;
+		bool m_bChunkResident = false;
 	};
 
 	struct LandscapeGrassSelection final
 	{
+		size_t m_componentIndex = 0u;
 		size_t m_chunkIndex = 0u;
 		size_t m_profileIndex = 0u;
 		uint32_t m_instanceCount = 0u;
+		uint64_t m_viewRevision = 0u;
 	};
 
 	SAILOR_API TVector<uint32_t> BuildLandscapeLodCoordinates(
@@ -33,7 +37,12 @@ namespace Sailor
 		bool bIncludeSkirts,
 		TVector<uint32_t>& indices);
 
-	SAILOR_API TVector<LandscapeGrassSelection> SelectLandscapeGrassResidency(
-		TVector<LandscapeGrassCandidate> candidates,
-		uint32_t instanceBudget);
+	SAILOR_API void SelectLandscapeGrassResidency(
+		TVector<LandscapeGrassCandidate>& candidates,
+		uint32_t instanceBudget,
+		TVector<LandscapeGrassSelection>& outSelections);
+	SAILOR_API bool DoesLandscapeGrassChunkOverlapFrustum(
+		const Math::AABB& worldBounds,
+		const Math::Frustum& frustum,
+		float residencyMargin = 0.0f);
 }

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -502,7 +502,10 @@ void LightingECS::PrepareCSMPasses(
 			ShadowCasterDepthExtension) * directionalLight.m_lightMatrix;
 		Math::Frustum broadFrustum;
 		broadFrustum.ExtractFrustumPlanes(broadLightMatrix);
-		sceneView->TraceShadowCasters(broadFrustum, m_csmBroadCastersScratch);
+		sceneView->TraceShadowCasters(
+			broadFrustum,
+			glm::vec3(cameraTransform.m_position),
+			m_csmBroadCastersScratch);
 		const auto& shadowCasters = m_csmBroadCastersScratch;
 		std::array<Tasks::TaskPtr<TVector<RHI::RHIVisibleShadowCaster>>, NumCascades>
 			cascadeCasterTasks{};
@@ -1297,6 +1300,7 @@ void LightingECS::PrepareLocalShadowPasses(
 	const RHI::RHISceneViewPtr& sceneView,
 	const TVector<RHI::RHILightProxy>& spotLights,
 	const TVector<RHI::RHILightProxy>& pointLights,
+	const Math::Transform& cameraTransform,
 	const CameraData& cameraData,
 	uint32_t viewportHeight,
 	uint32_t flightSlot,
@@ -1462,7 +1466,9 @@ void LightingECS::PrepareLocalShadowPasses(
 				shadowPass.m_lightMatrix = lightMatrices[face];
 				shadowPass.m_lighMatrixIndex = shadowSlot;
 				shadowPass.m_shadowType = RHI::EShadowType::PCF;
-				shadowPass.m_meshList = sceneView->TraceShadowCasters(shadowFrustum);
+				shadowPass.m_meshList = sceneView->TraceShadowCasters(
+					shadowFrustum,
+					glm::vec3(cameraTransform.m_position));
 
 				CSMLightState snapshot{};
 				snapshot.m_componentIndex = lightProxy.m_index;
@@ -1590,6 +1596,7 @@ void LightingECS::FillLightingData(RHI::RHISceneViewPtr& sceneView)
 			sceneView,
 			m_spotLightsScratch,
 			m_pointLightsScratch,
+			sceneView->m_cameraTransforms[i],
 			camera,
 			viewportHeight,
 			flightSlot,

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -196,6 +196,7 @@ namespace Sailor
 			const RHI::RHISceneViewPtr& sceneView,
 			const TVector<RHI::RHILightProxy>& spotLights,
 			const TVector<RHI::RHILightProxy>& pointLights,
+			const Math::Transform& cameraTransform,
 			const CameraData& cameraData,
 			uint32_t viewportHeight,
 			uint32_t flightSlot,

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -62,6 +62,27 @@ namespace
 		HashCombine(result, std::hash<glm::mat4>{}(matrix));
 	}
 
+	int32_t ResolveInstanceLodBias(
+		const RHIInstancedMeshGroup& group,
+		size_t instanceIndex)
+	{
+		return instanceIndex < group.m_instanceLodBiases.Num() ?
+			group.m_instanceLodBiases[instanceIndex] : 0;
+	}
+
+	float ResolveInstanceDistanceScale(
+		const TVector<float>& scales,
+		size_t instanceIndex)
+	{
+		if (instanceIndex >= scales.Num() ||
+			!std::isfinite(scales[instanceIndex]) ||
+			scales[instanceIndex] <= 0.0f)
+		{
+			return 1.0f;
+		}
+		return scales[instanceIndex];
+	}
+
 	void HashMaterialVersion(size_t& result, const RHIMaterialPtr& material)
 	{
 		if (!material)
@@ -125,6 +146,9 @@ namespace
 			HashCombine(
 				geometryRevision,
 				group.m_instanceTransforms.Num(),
+				group.m_instanceLodBiases.Num(),
+				group.m_instanceCullDistanceScales.Num(),
+				group.m_instanceShadowDistanceScales.Num(),
 				group.m_meshes.Num(),
 				group.m_bCastShadows,
 				std::hash<float>{}(group.m_maxShadowDistance));
@@ -139,6 +163,18 @@ namespace
 			for (const auto& matrix : group.m_instanceTransforms)
 			{
 				HashMatrix(geometryRevision, matrix);
+			}
+			for (int32_t lodBias : group.m_instanceLodBiases)
+			{
+				HashCombine(geometryRevision, lodBias);
+			}
+			for (float scale : group.m_instanceCullDistanceScales)
+			{
+				HashCombine(geometryRevision, std::hash<float>{}(scale));
+			}
+			for (float scale : group.m_instanceShadowDistanceScales)
+			{
+				HashCombine(geometryRevision, std::hash<float>{}(scale));
 			}
 		}
 		resource.m_geometryRevision = geometryRevision;
@@ -460,9 +496,15 @@ RHIMeshPtr RHIVisibleSceneProxy::ResolveInstancedMesh(
 		group,
 		instanceIndex,
 		meshIndex));
-	const uint32_t lod = source->m_lodPolicy.Resolve(
+	uint32_t lod = source->m_lodPolicy.Resolve(
 		CalculateScreenCoverage(worldBounds, viewMatrix, projectionMatrix),
 		mesh->GetNumLods());
+	lod = Settings::ApplyLodBias(
+		lod,
+		mesh->GetNumLods(),
+		source->m_lodPolicy.m_minLod,
+		source->m_lodPolicy.m_maxLod,
+		ResolveInstanceLodBias(group, instanceIndex));
 	if (lod > 0u)
 	{
 		if (auto lodMesh = mesh->GetLod(lod))
@@ -498,7 +540,10 @@ bool RHIVisibleSceneProxy::IsInstancedMeshWithinDistance(
 		cameraPosition,
 		worldBounds.m_min,
 		worldBounds.m_max);
-	return glm::distance(cameraPosition, closestPoint) <= maxDistance;
+	const float instanceMaxDistance = maxDistance * ResolveInstanceDistanceScale(
+		group.m_instanceCullDistanceScales,
+		instanceIndex);
+	return glm::distance(cameraPosition, closestPoint) <= instanceMaxDistance;
 }
 
 const RHIShadowCasterProxy* RHIVisibleShadowCaster::GetSource() const
@@ -657,9 +702,15 @@ RHIMeshPtr RHIVisibleShadowCaster::ResolveInstancedMesh(
 		group,
 		instanceIndex,
 		meshIndex));
-	const uint32_t lod = topology->m_lodPolicy.Resolve(
+	uint32_t lod = topology->m_lodPolicy.Resolve(
 		CalculateScreenCoverage(worldBounds, glm::mat4(1.0f), shadowViewProjection),
 		mesh->GetNumLods());
+	lod = Settings::ApplyLodBias(
+		lod,
+		mesh->GetNumLods(),
+		topology->m_lodPolicy.m_minLod,
+		topology->m_lodPolicy.m_maxLod,
+		ResolveInstanceLodBias(group, instanceIndex));
 	if (lod > 0u)
 	{
 		if (auto lodMesh = mesh->GetLod(lod))
@@ -695,7 +746,10 @@ bool RHIVisibleShadowCaster::IsInstancedMeshWithinDistance(
 		cameraPosition,
 		worldBounds.m_min,
 		worldBounds.m_max);
-	return glm::distance(cameraPosition, closestPoint) <= maxDistance;
+	const float instanceMaxDistance = maxDistance * ResolveInstanceDistanceScale(
+		group.m_instanceShadowDistanceScales,
+		instanceIndex);
+	return glm::distance(cameraPosition, closestPoint) <= instanceMaxDistance;
 }
 
 float Sailor::RHI::CalculateScreenCoverage(

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -108,6 +108,10 @@ namespace
 		{
 			HashCombine(geometryRevision, std::hash<float>{}(threshold));
 		}
+		for (float threshold : proxy.m_lodPolicy.m_cameraDistanceThresholds)
+		{
+			HashCombine(geometryRevision, std::hash<float>{}(threshold));
+		}
 		for (const auto& mesh : proxy.m_meshes)
 		{
 			HashCombine(geometryRevision, mesh);
@@ -394,6 +398,7 @@ RHIMeshPtr RHIVisibleSceneProxy::ResolveMesh(const RHIMeshPtr& sourceMesh) const
 	{
 		const uint32_t lod = source->m_lodPolicy.Resolve(
 			m_screenCoverage,
+			m_cameraDistance,
 			mesh->GetNumLods());
 		if (lod > 0u)
 		{
@@ -594,7 +599,10 @@ RHIMeshPtr RHIVisibleShadowCaster::ResolveMesh(
 		GetWorldBounds(),
 		glm::mat4(1.0f),
 		shadowViewProjection);
-	const uint32_t lod = topology->m_lodPolicy.Resolve(coverage, mesh->GetNumLods());
+	const uint32_t lod = topology->m_lodPolicy.Resolve(
+		coverage,
+		m_cameraDistance,
+		mesh->GetNumLods());
 	if (lod > 0u)
 	{
 		if (auto lodMesh = mesh->GetLod(lod))
@@ -768,6 +776,14 @@ float Sailor::RHI::CalculateScreenCoverage(
 
 uint32_t RHI::RHILodPolicy::Resolve(float screenCoverage, uint32_t numAvailableLods) const
 {
+	return Resolve(screenCoverage, 0.0f, numAvailableLods);
+}
+
+uint32_t RHI::RHILodPolicy::Resolve(
+	float screenCoverage,
+	float cameraDistance,
+	uint32_t numAvailableLods) const
+{
 	if (numAvailableLods == 0u)
 	{
 		return 0u;
@@ -777,15 +793,32 @@ uint32_t RHI::RHILodPolicy::Resolve(float screenCoverage, uint32_t numAvailableL
 	const uint32_t minLod = (std::min)(m_minLod, highestAvailableLod);
 	const uint32_t maxLod = (std::max)(minLod, (std::min)(m_maxLod, highestAvailableLod));
 	uint32_t selectedLod = 0u;
-	const float coverage = (std::clamp)(screenCoverage, 0.0f, 1.0f);
-	for (size_t index = 0u; index < m_screenCoverageThresholds.Num(); ++index)
+	if (!m_cameraDistanceThresholds.IsEmpty())
 	{
-		if (!std::isfinite(m_screenCoverageThresholds[index]) ||
-			coverage >= m_screenCoverageThresholds[index])
+		const float distance = std::isfinite(cameraDistance) ?
+			(std::max)(cameraDistance, 0.0f) :
+			(std::numeric_limits<float>::infinity)();
+		for (float threshold : m_cameraDistanceThresholds)
 		{
-			break;
+			if (!std::isfinite(threshold) || distance < threshold)
+			{
+				break;
+			}
+			++selectedLod;
 		}
-		selectedLod = static_cast<uint32_t>(index + 1u);
+	}
+	else
+	{
+		const float coverage = (std::clamp)(screenCoverage, 0.0f, 1.0f);
+		for (size_t index = 0u; index < m_screenCoverageThresholds.Num(); ++index)
+		{
+			if (!std::isfinite(m_screenCoverageThresholds[index]) ||
+				coverage >= m_screenCoverageThresholds[index])
+			{
+				break;
+			}
+			selectedLod = static_cast<uint32_t>(index + 1u);
+		}
 	}
 	const int32_t lodBias = App::GetInstance() ?
 		App::GetActiveGraphicsSettings().m_lodBias : 0;
@@ -1191,15 +1224,18 @@ void RHISceneView::TraceScene(
 
 }
 
-TVector<RHIVisibleShadowCaster> RHISceneView::TraceShadowCasters(const Math::Frustum& frustum) const
+TVector<RHIVisibleShadowCaster> RHISceneView::TraceShadowCasters(
+	const Math::Frustum& frustum,
+	const glm::vec3& lodReferencePosition) const
 {
 	TVector<RHIVisibleShadowCaster> result;
-	TraceShadowCasters(frustum, result);
+	TraceShadowCasters(frustum, lodReferencePosition, result);
 	return result;
 }
 
 void RHISceneView::TraceShadowCasters(
 	const Math::Frustum& frustum,
+	const glm::vec3& lodReferencePosition,
 	TVector<RHIVisibleShadowCaster>& result) const
 {
 	SAILOR_PROFILE_FUNCTION();
@@ -1226,7 +1262,9 @@ void RHISceneView::TraceShadowCasters(
 			continue;
 		}
 
-		auto appendHandle = [&result, &sceneVersion = spatialVersion->m_sceneVersion](
+		auto appendHandle = [&result,
+			&lodReferencePosition,
+			&sceneVersion = spatialVersion->m_sceneVersion](
 			const RenderInstanceHandle& handle)
 			{
 				const RHISceneInstanceRecord* record = nullptr;
@@ -1246,6 +1284,13 @@ void RHISceneView::TraceShadowCasters(
 				visible.m_handle = handle;
 				visible.m_record = record;
 				visible.m_resource = resource;
+				const glm::vec3 closest = glm::clamp(
+					lodReferencePosition,
+					record->m_worldBounds.m_min,
+					record->m_worldBounds.m_max);
+				visible.m_cameraDistance = glm::distance(
+					lodReferencePosition,
+					closest);
 				result.Add(std::move(visible));
 		};
 		if (spatialVersion->m_dynamicOctree)
@@ -1321,13 +1366,17 @@ void RHISceneView::PrepareSnapshots()
 			auto& proxy = res.m_proxies[visibleProxyReadIndex];
 			const auto* source = proxy.GetSource();
 			bool bKeepProxy = source != nullptr;
-			if (source && std::isfinite(source->m_lodPolicy.m_maxCameraDistance))
+			if (source)
 			{
 				const glm::vec3 closest = glm::clamp(
 					cameraPosition,
 					proxy.GetWorldBounds().m_min,
 					proxy.GetWorldBounds().m_max);
-				bKeepProxy = glm::distance(cameraPosition, closest) <=
+				proxy.m_cameraDistance = glm::distance(cameraPosition, closest);
+			}
+			if (source && std::isfinite(source->m_lodPolicy.m_maxCameraDistance))
+			{
+				bKeepProxy = proxy.m_cameraDistance <=
 					source->m_lodPolicy.m_maxCameraDistance;
 			}
 			if (!bKeepProxy)

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -83,6 +83,9 @@ namespace Sailor::RHI
 	struct RHIInstancedMeshGroup
 	{
 		TVector<glm::mat4> m_instanceTransforms{};
+		TVector<int32_t> m_instanceLodBiases{};
+		TVector<float> m_instanceCullDistanceScales{};
+		TVector<float> m_instanceShadowDistanceScales{};
 		TVector<RHIMeshPtr> m_meshes{};
 		TVector<glm::mat4> m_meshTransforms{};
 		TVector<RHIMaterialPtr> m_materials{};

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -52,9 +52,14 @@ namespace Sailor::RHI
 		uint32_t m_minLod = 0u;
 		uint32_t m_maxLod = 2u;
 		TVector<float> m_screenCoverageThresholds{ 0.25f, 0.05f };
+		TVector<float> m_cameraDistanceThresholds{};
 		float m_maxCameraDistance = (std::numeric_limits<float>::infinity)();
 
 		SAILOR_API uint32_t Resolve(float screenCoverage, uint32_t numAvailableLods) const;
+		SAILOR_API uint32_t Resolve(
+			float screenCoverage,
+			float cameraDistance,
+			uint32_t numAvailableLods) const;
 	};
 
 	struct RHIShadowCasterProxy
@@ -168,6 +173,7 @@ namespace Sailor::RHI
 		const RHISceneInstanceRecord* m_record = nullptr;
 		const RHISceneProxyResource* m_resource = nullptr;
 		float m_screenCoverage = 1.0f;
+		float m_cameraDistance = 0.0f;
 
 		SAILOR_API const RHISceneViewProxy* GetSource() const;
 		SAILOR_API const glm::mat4& GetWorldMatrix() const;
@@ -203,6 +209,7 @@ namespace Sailor::RHI
 		// The owning RHISceneVersion is retained by the submission snapshot.
 		const RHISceneInstanceRecord* m_record = nullptr;
 		const RHISceneProxyResource* m_resource = nullptr;
+		float m_cameraDistance = 0.0f;
 
 		SAILOR_API const RHIShadowCasterProxy* GetSource() const;
 		SAILOR_API const glm::mat4& GetWorldMatrix() const;
@@ -237,7 +244,7 @@ namespace Sailor::RHI
 
 	static_assert(sizeof(RHIVisibleSceneProxy) <= sizeof(void*) * 4u,
 		"Visible scene records must remain lightweight immutable references.");
-	static_assert(sizeof(RHIVisibleShadowCaster) <= sizeof(void*) * 3u,
+	static_assert(sizeof(RHIVisibleShadowCaster) <= sizeof(void*) * 4u,
 		"Visible shadow records must remain lightweight immutable references.");
 
 	/**
@@ -413,9 +420,12 @@ namespace Sailor::RHI
 			const Math::Frustum& frustum,
 			TVector<RHIVisibleSceneProxy>& outVisibleProxies,
 			bool bSkipMaterials) const;
-		SAILOR_API TVector<RHIVisibleShadowCaster> TraceShadowCasters(const Math::Frustum& frustum) const;
+		SAILOR_API TVector<RHIVisibleShadowCaster> TraceShadowCasters(
+			const Math::Frustum& frustum,
+			const glm::vec3& lodReferencePosition) const;
 		SAILOR_API void TraceShadowCasters(
 			const Math::Frustum& frustum,
+			const glm::vec3& lodReferencePosition,
 			TVector<RHIVisibleShadowCaster>& outVisibleCasters) const;
 		SAILOR_API void PrepareSnapshots();
 		SAILOR_API void PrepareDebugDrawCommandLists(

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -10,6 +10,7 @@
 #include "AssetRegistry/Animation/AnimationControllerImporter.h"
 #include "AssetRegistry/Audio/AudioAssetInfo.h"
 #include "AssetRegistry/Audio/AudioImporter.h"
+#include "AssetRegistry/Landscape/LandscapeVegetationAsset.h"
 #include "AssetRegistry/Material/MaterialImporter.h"
 #include "AssetRegistry/FrameGraph/FrameGraphAssetInfo.h"
 #include "AssetRegistry/FrameGraph/FrameGraphImporter.h"
@@ -619,6 +620,8 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	auto animationControllerInfoHandler = s_pInstance->AddSubmodule(TSubmodule<AnimationControllerAssetInfoHandler>::Make(assetRegistry));
 	auto animationSetInfoHandler = s_pInstance->AddSubmodule(TSubmodule<AnimationSetAssetInfoHandler>::Make(assetRegistry));
 	auto audioInfoHandler = s_pInstance->AddSubmodule(TSubmodule<AudioAssetInfoHandler>::Make(assetRegistry));
+	auto landscapeVegetationInfoHandler = s_pInstance->AddSubmodule(
+		TSubmodule<LandscapeVegetationAssetInfoHandler>::Make(assetRegistry));
 	auto materialInfoHandler = s_pInstance->AddSubmodule(TSubmodule<MaterialAssetInfoHandler>::Make(assetRegistry));
 	auto frameGraphInfoHandler = s_pInstance->AddSubmodule(TSubmodule<FrameGraphAssetInfoHandler>::Make(assetRegistry));
 	auto prefabInfoHandler = s_pInstance->AddSubmodule(TSubmodule<PrefabAssetInfoHandler>::Make(assetRegistry));

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -620,7 +620,7 @@ void App::Initialize(const char** commandLineArgs, int32_t num)
 	auto animationControllerInfoHandler = s_pInstance->AddSubmodule(TSubmodule<AnimationControllerAssetInfoHandler>::Make(assetRegistry));
 	auto animationSetInfoHandler = s_pInstance->AddSubmodule(TSubmodule<AnimationSetAssetInfoHandler>::Make(assetRegistry));
 	auto audioInfoHandler = s_pInstance->AddSubmodule(TSubmodule<AudioAssetInfoHandler>::Make(assetRegistry));
-	auto landscapeVegetationInfoHandler = s_pInstance->AddSubmodule(
+	s_pInstance->AddSubmodule(
 		TSubmodule<LandscapeVegetationAssetInfoHandler>::Make(assetRegistry));
 	auto materialInfoHandler = s_pInstance->AddSubmodule(TSubmodule<MaterialAssetInfoHandler>::Make(assetRegistry));
 	auto frameGraphInfoHandler = s_pInstance->AddSubmodule(TSubmodule<FrameGraphAssetInfoHandler>::Make(assetRegistry));

--- a/Runtime/Settings/GraphicsSettings.cpp
+++ b/Runtime/Settings/GraphicsSettings.cpp
@@ -54,6 +54,7 @@ namespace
 		bool bSupportSoftShadows,
 		float cloudsResolutionMultiplier,
 		uint32_t skyResolution,
+		uint32_t vegetationInstanceBudget,
 		int32_t lodBias)
 	{
 		GraphicsQualityProfile profile;
@@ -67,6 +68,7 @@ namespace
 		profile.m_bSupportSoftShadows = bSupportSoftShadows;
 		profile.m_cloudsResolutionMultiplier = cloudsResolutionMultiplier;
 		profile.m_skyResolution = skyResolution;
+		profile.m_vegetationInstanceBudget = vegetationInstanceBudget;
 		profile.m_lodBias = lodBias;
 		return profile;
 	}
@@ -261,6 +263,37 @@ namespace
 		YAML::Node field;
 		if (!ReadScalar(parent, fieldName, source, fieldPath, field, outDiagnostic))
 		{
+			return false;
+		}
+
+		const std::string scalar = field.Scalar();
+		const char* begin = scalar.data();
+		const char* end = begin + scalar.size();
+		const auto parsed = std::from_chars(begin, end, outValue);
+		if (scalar.empty() || parsed.ec != std::errc() || parsed.ptr != end)
+		{
+			outDiagnostic = InvalidField(source, fieldPath, "must be an unsigned 32-bit integer");
+			return false;
+		}
+		return true;
+	}
+
+	bool ReadOptionalUint32(
+		const YAML::Node& parent,
+		const char* fieldName,
+		const std::string& source,
+		const std::string& fieldPath,
+		uint32_t& outValue,
+		std::string& outDiagnostic)
+	{
+		const YAML::Node field = FindField(parent, fieldName);
+		if (!field.IsDefined())
+		{
+			return true;
+		}
+		if (!field.IsScalar())
+		{
+			outDiagnostic = InvalidField(source, fieldPath, "must be an unsigned 32-bit integer");
 			return false;
 		}
 
@@ -665,6 +698,25 @@ namespace
 			return false;
 		}
 
+		if (!ReadOptionalUint32(
+				profile,
+				"vegetationInstanceBudget",
+				source,
+				profilePath + ".vegetationInstanceBudget",
+				outProfile.m_vegetationInstanceBudget,
+				outDiagnostic) ||
+			outProfile.m_vegetationInstanceBudget > 1048576u)
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(
+					source,
+					profilePath + ".vegetationInstanceBudget",
+					"must be in the range [0, 1048576]");
+			}
+			return false;
+		}
+
 		return true;
 	}
 
@@ -754,6 +806,7 @@ Sailor::Settings::GraphicsSettings::GraphicsSettings()
 		true,
 		1.0f,
 		512u,
+		65536u,
 		-1);
 	m_presets[QualityIndex(EGraphicsQuality::High)] = MakeProfile(
 		1.0f,
@@ -766,6 +819,7 @@ Sailor::Settings::GraphicsSettings::GraphicsSettings()
 		true,
 		0.75f,
 		256u,
+		32768u,
 		0);
 	m_presets[QualityIndex(EGraphicsQuality::Medium)] = MakeProfile(
 		0.85f,
@@ -778,6 +832,7 @@ Sailor::Settings::GraphicsSettings::GraphicsSettings()
 		true,
 		0.5f,
 		256u,
+		16384u,
 		0);
 	m_presets[QualityIndex(EGraphicsQuality::Low)] = MakeProfile(
 		0.7f,
@@ -790,6 +845,7 @@ Sailor::Settings::GraphicsSettings::GraphicsSettings()
 		false,
 		0.25f,
 		128u,
+		8192u,
 		1);
 	m_presets[QualityIndex(EGraphicsQuality::VeryLow)] = MakeProfile(
 		0.5f,
@@ -802,6 +858,7 @@ Sailor::Settings::GraphicsSettings::GraphicsSettings()
 		false,
 		0.125f,
 		64u,
+		2048u,
 		2);
 }
 

--- a/Runtime/Settings/GraphicsSettings.h
+++ b/Runtime/Settings/GraphicsSettings.h
@@ -89,6 +89,7 @@ namespace Sailor::Settings
 		bool m_bSupportSoftShadows = false;
 		float m_cloudsResolutionMultiplier = 0.5f;
 		uint32_t m_skyResolution = 256u;
+		uint32_t m_vegetationInstanceBudget = 32768u;
 		int32_t m_lodBias = 0;
 
 		bool IsShadowCascadeActive(uint32_t cascadeIndex) const noexcept;

--- a/Tests/BoundsContractTests.cpp
+++ b/Tests/BoundsContractTests.cpp
@@ -176,6 +176,30 @@ namespace
 		Require(policy.Resolve(1.0f, 3) == 1, "the configured minimum LOD must be respected");
 	}
 
+	void TestLodPolicyResolvesCameraDistance()
+	{
+		RHI::RHILodPolicy policy;
+		policy.m_bEnabled = true;
+		policy.m_minLod = 0;
+		policy.m_maxLod = 2;
+		policy.m_cameraDistanceThresholds = { 50.0f, 100.0f };
+
+		Require(policy.Resolve(0.0f, 49.999f, 3) == 0,
+			"distance below the first threshold must select the highest-detail LOD");
+		Require(policy.Resolve(1.0f, 50.0f, 3) == 1,
+			"the first distance threshold must select the middle LOD independently of coverage");
+		Require(policy.Resolve(1.0f, 100.0f, 3) == 2,
+			"the second distance threshold must select the lowest-detail LOD");
+		Require(policy.Resolve(1.0f, std::numeric_limits<float>::infinity(), 3) == 2,
+			"non-finite distance must resolve to the lowest configured LOD");
+		Require(policy.Resolve(1.0f, 100.0f, 2) == 1,
+			"distance LOD must clamp to the available mesh count");
+
+		policy.m_minLod = 1;
+		Require(policy.Resolve(0.0f, 0.0f, 3) == 1,
+			"distance LOD must respect the configured minimum LOD");
+	}
+
 	void TestStabilizedShadowProjectionKeepsReceiverGuardBand()
 	{
 		Math::Frustum cameraSlice;
@@ -215,6 +239,7 @@ int main()
 		{ "ReverseZFrustumCornersUseZeroToOneDepth", TestReverseZFrustumCornersUseZeroToOneDepth },
 		{ "ShadowProjectionIncludesCastersTowardLightSource", TestShadowProjectionIncludesCastersTowardLightSource },
 		{ "LodPolicyResolvesCoverageAndAvailableMeshes", TestLodPolicyResolvesCoverageAndAvailableMeshes },
+		{ "LodPolicyResolvesCameraDistance", TestLodPolicyResolvesCameraDistance },
 		{ "StabilizedShadowProjectionKeepsReceiverGuardBand", TestStabilizedShadowProjectionKeepsReceiverGuardBand },
 	};
 

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -62,6 +62,10 @@ add_executable(BoundsContractTests
     BoundsContractTests.cpp
 )
 
+add_executable(LandscapeStreamingTests
+    LandscapeStreamingTests.cpp
+)
+
 add_executable(GpuCullingContractTests
     GpuCullingContractTests.cpp
 )
@@ -224,6 +228,7 @@ target_compile_features(SmartPointerTests PRIVATE cxx_std_20)
 target_compile_features(InstanceIdContractTests PRIVATE cxx_std_20)
 target_compile_features(EcsLifecycleContractTests PRIVATE cxx_std_20)
 target_compile_features(BoundsContractTests PRIVATE cxx_std_20)
+target_compile_features(LandscapeStreamingTests PRIVATE cxx_std_20)
 target_compile_features(GpuCullingContractTests PRIVATE cxx_std_20)
 target_compile_definitions(GpuCullingContractTests PRIVATE
     SAILOR_TEST_SOURCE_DIR="${PROJECT_SOURCE_DIR}"
@@ -281,6 +286,7 @@ target_link_libraries(SmartPointerTests PRIVATE Sailor::Runtime)
 target_link_libraries(InstanceIdContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(EcsLifecycleContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(BoundsContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(LandscapeStreamingTests PRIVATE Sailor::Runtime)
 target_link_libraries(GpuCullingContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(RHISceneVirtualizationTests PRIVATE Sailor::Runtime)
 target_link_libraries(ModelImporterContractTests PRIVATE Sailor::Runtime)
@@ -332,6 +338,7 @@ if(WIN32)
     sailor_stage_workspace_test_runtime(ShaderCacheArtifactTests)
     sailor_stage_workspace_test_runtime(EcsLifecycleContractTests)
     sailor_stage_workspace_test_runtime(BoundsContractTests)
+    sailor_stage_workspace_test_runtime(LandscapeStreamingTests)
     sailor_stage_workspace_test_runtime(GpuCullingContractTests)
     sailor_stage_workspace_test_runtime(ModelImporterContractTests)
     sailor_stage_workspace_test_runtime(VulkanDescriptorCacheTests)
@@ -385,6 +392,9 @@ target_include_directories(EcsLifecycleContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(BoundsContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(LandscapeStreamingTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(GpuCullingContractTests PRIVATE
@@ -535,6 +545,11 @@ add_test(
 )
 
 add_test(
+    NAME LandscapeStreamingTests
+    COMMAND LandscapeStreamingTests
+)
+
+add_test(
     NAME GpuCullingContractTests
     COMMAND GpuCullingContractTests
 )
@@ -649,6 +664,7 @@ set_tests_properties(
     InstanceIdContractTests
     EcsLifecycleContractTests
     BoundsContractTests
+    LandscapeStreamingTests
     GpuCullingContractTests
     RHISceneVirtualizationTests
     ModelImporterContractTests

--- a/Tests/GraphicsSettingsTests.cpp
+++ b/Tests/GraphicsSettingsTests.cpp
@@ -162,6 +162,7 @@ graphics:
       supportSoftShadows: true
       cloudsResolutionMultiplier: 0.5
       skyResolution: 256
+      vegetationInstanceBudget: 12345
       lodBias: 0
     Low:
       resolutionFactor: 0.7
@@ -246,7 +247,8 @@ graphics:
 			"inactive cascade access should return a safe zero extent");
 		Require(ultra.m_bSupportSoftShadows &&
 			IsNear(ultra.m_cloudsResolutionMultiplier, 1.0f) &&
-			ultra.m_skyResolution == 512u && ultra.m_lodBias == -1,
+			ultra.m_skyResolution == 512u &&
+			ultra.m_vegetationInstanceBudget == 65536u && ultra.m_lodBias == -1,
 			"Ultra should match the remaining planned defaults");
 
 		const GraphicsQualityProfile& high = defaults.GetProfile(EGraphicsQuality::High);
@@ -257,7 +259,8 @@ graphics:
 			high.m_shadowCascadeResolutions ==
 				std::array<uint32_t, MaxShadowCascades>{ 2048u, 2048u, 1024u, 1024u } &&
 			high.m_bSupportSoftShadows && IsNear(high.m_cloudsResolutionMultiplier, 0.75f) &&
-			high.m_skyResolution == 256u && high.m_lodBias == 0,
+			high.m_skyResolution == 256u &&
+			high.m_vegetationInstanceBudget == 32768u && high.m_lodBias == 0,
 			"High should match the complete planned defaults");
 
 		const GraphicsQualityProfile& medium = defaults.GetProfile(EGraphicsQuality::Medium);
@@ -268,7 +271,8 @@ graphics:
 			medium.m_shadowCascadeResolutions ==
 				std::array<uint32_t, MaxShadowCascades>{ 2048u, 1024u, 512u, 0u } &&
 			medium.m_bSupportSoftShadows && IsNear(medium.m_cloudsResolutionMultiplier, 0.5f) &&
-			medium.m_skyResolution == 256u && medium.m_lodBias == 0,
+			medium.m_skyResolution == 256u &&
+			medium.m_vegetationInstanceBudget == 16384u && medium.m_lodBias == 0,
 			"Medium should match the complete planned defaults");
 
 		const GraphicsQualityProfile& low = defaults.GetProfile(EGraphicsQuality::Low);
@@ -279,7 +283,8 @@ graphics:
 			low.m_shadowCascadeResolutions ==
 				std::array<uint32_t, MaxShadowCascades>{ 1024u, 512u, 0u, 0u } &&
 			!low.m_bSupportSoftShadows && IsNear(low.m_cloudsResolutionMultiplier, 0.25f) &&
-			low.m_skyResolution == 128u && low.m_lodBias == 1,
+			low.m_skyResolution == 128u &&
+			low.m_vegetationInstanceBudget == 8192u && low.m_lodBias == 1,
 			"Low should match the complete planned defaults");
 
 		const GraphicsQualityProfile& veryLow = defaults.GetProfile(EGraphicsQuality::VeryLow);
@@ -291,7 +296,8 @@ graphics:
 			veryLow.m_shadowCascadeCount == 1u &&
 			!veryLow.m_bSupportSoftShadows &&
 			IsNear(veryLow.m_cloudsResolutionMultiplier, 0.125f) &&
-			veryLow.m_skyResolution == 64u && veryLow.m_lodBias == 2,
+			veryLow.m_skyResolution == 64u &&
+			veryLow.m_vegetationInstanceBudget == 2048u && veryLow.m_lodBias == 2,
 			"VeryLow should match the planned fallback values");
 
 		const GraphicsExtent renderExtent = ResolveRenderDimensions(1919u, 1079u, 0.5f);
@@ -351,6 +357,9 @@ graphics:
 					"explicit positive signed LOD bias should deserialize");
 				Require(parsed.m_settings.GetProfile(EGraphicsQuality::Medium).m_fpsCap == 120u,
 					"FPS cap should deserialize with the active quality profile");
+				Require(parsed.m_settings.GetProfile(EGraphicsQuality::Medium).m_vegetationInstanceBudget == 12345u &&
+					parsed.m_settings.GetProfile(EGraphicsQuality::Ultra).m_vegetationInstanceBudget == 65536u,
+					"vegetation budgets should deserialize when present and use quality defaults when omitted");
 				Require(IsNear(parsed.m_settings.GetProfile(EGraphicsQuality::Ultra).m_shadowBias, 1.25f),
 					"shadow bias should deserialize with the quality profile");
 				Require(parsed.m_settings.GetProfile(EGraphicsQuality::Medium).m_shadowCascadeResolutions[3] == 0u,
@@ -411,6 +420,9 @@ graphics:
 		RequireInvalidProjectField(
 			ReplaceFirst(ValidProjectSettings(), "skyResolution: 512", "skyResolution: 100"),
 			"graphics.presets.Ultra.skyResolution");
+		RequireInvalidProjectField(
+			ReplaceFirst(ValidProjectSettings(), "vegetationInstanceBudget: 12345", "vegetationInstanceBudget: 1048577"),
+			"graphics.presets.Medium.vegetationInstanceBudget");
 		RequireInvalidProjectField(
 			ReplaceFirst(ValidProjectSettings(), "lodBias: -1", "lodBias: -9"),
 			"graphics.presets.Ultra.lodBias");

--- a/Tests/LandscapeStreamingTests.cpp
+++ b/Tests/LandscapeStreamingTests.cpp
@@ -1,0 +1,171 @@
+#include "ECS/LandscapeStreaming.h"
+
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+#include <utility>
+
+using namespace Sailor;
+
+namespace
+{
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	void RequireCoordinates(
+		const TVector<uint32_t>& actual,
+		std::initializer_list<uint32_t> expected,
+		const std::string& message)
+	{
+		Require(actual.Num() == expected.size(), message + ": unexpected coordinate count");
+		size_t index = 0u;
+		for (uint32_t coordinate : expected)
+		{
+			Require(actual[index] == coordinate, message + ": unexpected coordinate value");
+			++index;
+		}
+	}
+
+	void TestLodCoordinatesPreserveChunkBoundaries()
+	{
+		RequireCoordinates(
+			BuildLandscapeLodCoordinates(10u, 4u),
+			{ 0u, 4u, 8u, 10u },
+			"non-divisible LOD stride must preserve the final chunk edge");
+		RequireCoordinates(
+			BuildLandscapeLodCoordinates(24u, 4u),
+			{ 0u, 4u, 8u, 12u, 16u, 20u, 24u },
+			"divisible LOD stride must preserve regular coordinates");
+		RequireCoordinates(
+			BuildLandscapeLodCoordinates(3u, 0u),
+			{ 0u, 1u, 2u, 3u },
+			"zero stride must normalize to the full-resolution grid");
+		Require(BuildLandscapeLodCoordinates(0u, 4u).IsEmpty(),
+			"zero-resolution chunks must not produce LOD coordinates");
+	}
+
+	void TestLodIndicesStayWithinPackedTerrainAndSkirtVertices()
+	{
+		constexpr uint32_t resolution = 10u;
+		constexpr uint32_t row = resolution + 1u;
+		constexpr uint32_t baseVertexCount = row * row;
+		constexpr uint32_t packedVertexCount = baseVertexCount + row * 4u;
+		const auto coordinates = BuildLandscapeLodCoordinates(resolution, 4u);
+
+		TVector<uint32_t> terrainIndices;
+		AppendLandscapeLodIndices(
+			resolution,
+			coordinates,
+			false,
+			terrainIndices);
+		Require(terrainIndices.Num() == 54u,
+			"a four-coordinate grid must produce nine terrain quads");
+		for (uint32_t index : terrainIndices)
+		{
+			Require(index < baseVertexCount,
+				"terrain-only LOD indices must address base vertices");
+		}
+
+		TVector<uint32_t> skirtedIndices;
+		AppendLandscapeLodIndices(
+			resolution,
+			coordinates,
+			true,
+			skirtedIndices);
+		Require(skirtedIndices.Num() == 126u,
+			"every LOD edge segment must append two skirt triangles");
+		bool bReferencesSkirt = false;
+		for (uint32_t index : skirtedIndices)
+		{
+			Require(index < packedVertexCount,
+				"skirted LOD indices must remain inside the packed vertex allocation");
+			bReferencesSkirt |= index >= baseVertexCount;
+		}
+		Require(bReferencesSkirt,
+			"a skirted LOD range must reference the appended skirt vertices");
+	}
+
+	void TestGrassSelectionIsPrioritizedDeterministicAndBudgeted()
+	{
+		TVector<LandscapeGrassCandidate> candidates = {
+			{ 7u, 1u, 5u, 1.0f, 3.0f, false, 0.0f },
+			{ 3u, 0u, 4u, 2.0f, 100.0f, false, 0.0f },
+			{ 1u, 2u, 5u, 1.0f, 3.0f, true, 0.0f },
+			{ 0u, 0u, 5u, 1.0f, 2.0f, false, 0.0f },
+		};
+
+		const auto first = SelectLandscapeGrassResidency(candidates, 11u);
+		const auto second = SelectLandscapeGrassResidency(candidates, 11u);
+		Require(first.Num() == 3u && second.Num() == first.Num(),
+			"the hard budget must select exactly three candidate ranges");
+		Require(first[0].m_chunkIndex == 3u && first[0].m_instanceCount == 4u,
+			"profile priority must win before camera distance");
+		Require(first[1].m_chunkIndex == 0u && first[1].m_instanceCount == 5u,
+			"camera distance must order candidates with equal priority");
+		Require(first[2].m_chunkIndex == 1u && first[2].m_instanceCount == 2u,
+			"resident state must stabilize equal candidates and the final range must be partially admitted");
+
+		uint32_t totalInstances = 0u;
+		for (size_t index = 0u; index < first.Num(); ++index)
+		{
+			totalInstances += first[index].m_instanceCount;
+			Require(first[index].m_chunkIndex == second[index].m_chunkIndex &&
+				first[index].m_profileIndex == second[index].m_profileIndex &&
+				first[index].m_instanceCount == second[index].m_instanceCount,
+				"identical inputs must produce an identical selection order and count");
+		}
+		Require(totalInstances == 11u,
+			"selected instances must fill the budget without exceeding it");
+		Require(SelectLandscapeGrassResidency(candidates, 0u).IsEmpty(),
+			"a zero instance budget must produce an empty active set");
+	}
+
+	void TestGrassResidencyHysteresisPreventsBoundaryChurn()
+	{
+		TVector<LandscapeGrassCandidate> candidates = {
+			{ 0u, 0u, 4u, 1.0f, 10.0f, false, 0.0f },
+			{ 1u, 0u, 4u, 1.0f, 11.0f, true, 2.0f },
+		};
+		const auto retained = SelectLandscapeGrassResidency(candidates, 4u);
+		Require(retained.Num() == 1u && retained[0].m_chunkIndex == 1u,
+			"a resident chunk must remain selected while the challenger is inside its hysteresis margin");
+
+		candidates[1].m_distance = 13.0f;
+		const auto replaced = SelectLandscapeGrassResidency(candidates, 4u);
+		Require(replaced.Num() == 1u && replaced[0].m_chunkIndex == 0u,
+			"a meaningfully nearer chunk must replace a resident beyond its hysteresis margin");
+	}
+}
+
+int main()
+{
+	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "LodCoordinatesPreserveChunkBoundaries", TestLodCoordinatesPreserveChunkBoundaries },
+		{ "LodIndicesStayWithinPackedTerrainAndSkirtVertices", TestLodIndicesStayWithinPackedTerrainAndSkirtVertices },
+		{ "GrassSelectionIsPrioritizedDeterministicAndBudgeted", TestGrassSelectionIsPrioritizedDeterministicAndBudgeted },
+		{ "GrassResidencyHysteresisPreventsBoundaryChurn", TestGrassResidencyHysteresisPreventsBoundaryChurn },
+	};
+
+	for (const auto& test : tests)
+	{
+		try
+		{
+			test.second();
+			std::cout << "[PASS] " << test.first << std::endl;
+		}
+		catch (const std::exception& error)
+		{
+			std::cerr << "[FAIL] " << test.first << ": " << error.what() << std::endl;
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/Tests/LandscapeStreamingTests.cpp
+++ b/Tests/LandscapeStreamingTests.cpp
@@ -1,6 +1,10 @@
+#include "AssetRegistry/Landscape/LandscapeVegetationAsset.h"
 #include "ECS/LandscapeStreaming.h"
 
+#include <chrono>
+#include <filesystem>
 #include <functional>
+#include <fstream>
 #include <initializer_list>
 #include <iostream>
 #include <stdexcept>
@@ -11,6 +15,31 @@ using namespace Sailor;
 
 namespace
 {
+	class ScopedTemporaryDirectory final
+	{
+	public:
+		ScopedTemporaryDirectory()
+		{
+			const auto suffix = std::chrono::steady_clock::now()
+				.time_since_epoch()
+				.count();
+			m_path = std::filesystem::temp_directory_path() /
+				("sailor-landscape-vegetation-" + std::to_string(suffix));
+			std::filesystem::create_directories(m_path);
+		}
+
+		~ScopedTemporaryDirectory()
+		{
+			std::error_code error;
+			std::filesystem::remove_all(m_path, error);
+		}
+
+		const std::filesystem::path& GetPath() const { return m_path; }
+
+	private:
+		std::filesystem::path m_path{};
+	};
+
 	void Require(bool condition, const std::string& message)
 	{
 		if (!condition)
@@ -198,6 +227,95 @@ namespace
 		Require(DoesLandscapeGrassChunkOverlapFrustum(edgeChunk, frustum, 8.0f),
 			"the residency margin must retain a chunk near a frustum edge");
 	}
+
+	void TestVegetationBinaryRoundTripsMatricesAndInstanceSettings()
+	{
+		ScopedTemporaryDirectory directory;
+		const auto filepath = directory.GetPath() / "Landscape.vegetation";
+
+		LandscapeVegetationAssetData source;
+		source.m_chunksX = 2u;
+		source.m_chunksZ = 1u;
+		source.m_profileCount = 2u;
+		source.m_chunkSize = 64.0f;
+		source.m_chunks.Resize(2u);
+		source.m_chunks[0].m_chunkX = 0u;
+		source.m_chunks[0].m_chunkZ = 0u;
+		source.m_chunks[1].m_chunkX = 1u;
+		source.m_chunks[1].m_chunkZ = 0u;
+
+		LandscapeVegetationInstance first;
+		first.m_stableId = 0x1122334455667788ull;
+		first.m_profileIndex = 1u;
+		first.m_lodBias = -2;
+		first.m_cullDistanceScale = 0.75f;
+		first.m_shadowDistanceScale = 1.5f;
+		first.m_transform = glm::mat4(1.0f);
+		first.m_transform[0][0] = 1.25f;
+		first.m_transform[1][1] = 2.0f;
+		first.m_transform[2][2] = 0.75f;
+		first.m_transform[3] = glm::vec4(-13.0f, 4.0f, 15.0f, 1.0f);
+		source.m_chunks[0].m_instances.Add(first);
+
+		LandscapeVegetationInstance second;
+		second.m_stableId = 0x8877665544332211ull;
+		second.m_profileIndex = 0u;
+		second.m_flags = 0u;
+		second.m_transform[3] = glm::vec4(12.0f, 3.0f, -7.0f, 1.0f);
+		second.m_lodBias = 3;
+		second.m_cullDistanceScale = 2.0f;
+		second.m_shadowDistanceScale = 0.5f;
+		source.m_chunks[1].m_instances.Add(second);
+
+		std::string diagnostic;
+		Require(source.Save(filepath, diagnostic), diagnostic);
+		Require(std::filesystem::file_size(filepath) ==
+			LandscapeVegetationHeaderSize +
+			2u * LandscapeVegetationChunkRecordSize +
+			2u * LandscapeVegetationInstanceRecordSize,
+			"the vegetation writer must use the documented fixed record layout");
+
+		LandscapeVegetationAssetData loaded;
+		Require(loaded.Load(filepath, diagnostic), diagnostic);
+		Require(loaded.m_chunksX == source.m_chunksX &&
+			loaded.m_chunksZ == source.m_chunksZ &&
+			loaded.m_profileCount == source.m_profileCount &&
+			loaded.m_chunkSize == source.m_chunkSize &&
+			loaded.GetInstanceCount() == 2u,
+			"the vegetation header must round-trip exactly");
+		Require(loaded.m_chunks[0].m_enabledInstancesPerProfile.Num() == 2u &&
+			loaded.m_chunks[0].m_enabledInstancesPerProfile[1] == 1u &&
+			loaded.m_chunks[1].m_enabledInstancesPerProfile[0] == 0u,
+			"the runtime profile-count index must include only enabled instances");
+		const auto& loadedFirst = loaded.m_chunks[0].m_instances[0];
+		Require(loadedFirst.m_stableId == first.m_stableId &&
+			loadedFirst.m_profileIndex == first.m_profileIndex &&
+			loadedFirst.m_flags == first.m_flags &&
+			loadedFirst.m_lodBias == first.m_lodBias &&
+			loadedFirst.m_cullDistanceScale == first.m_cullDistanceScale &&
+			loadedFirst.m_shadowDistanceScale == first.m_shadowDistanceScale,
+			"per-instance identity and render settings must round-trip exactly");
+		for (glm::length_t column = 0; column < 4; ++column)
+		{
+			for (glm::length_t row = 0; row < 4; ++row)
+			{
+				Require(loadedFirst.m_transform[column][row] ==
+					first.m_transform[column][row],
+					"the column-major instance matrix must round-trip exactly");
+			}
+		}
+		Require(!loaded.m_chunks[1].m_instances[0].IsEnabled(),
+			"disabled authored instances must remain in the asset");
+
+		std::fstream corrupt(filepath, std::ios::binary | std::ios::in | std::ios::out);
+		Require(corrupt.is_open(), "the test must be able to corrupt the saved file");
+		corrupt.seekp(0);
+		corrupt.put('X');
+		corrupt.close();
+		LandscapeVegetationAssetData rejected;
+		Require(!rejected.Load(filepath, diagnostic),
+			"a vegetation asset with invalid magic must be rejected");
+	}
 }
 
 int main()
@@ -209,6 +327,7 @@ int main()
 		{ "GrassResidencyStabilityNeverOverridesANearerRing", TestGrassResidencyStabilityNeverOverridesANearerRing },
 		{ "GrassSelectionUsesOneBudgetAcrossLandscapeComponents", TestGrassSelectionUsesOneBudgetAcrossLandscapeComponents },
 		{ "GrassChunksMustOverlapTheCameraFrustum", TestGrassChunksMustOverlapTheCameraFrustum },
+		{ "VegetationBinaryRoundTripsMatricesAndInstanceSettings", TestVegetationBinaryRoundTripsMatricesAndInstanceSettings },
 	};
 
 	for (const auto& test : tests)

--- a/Tests/LandscapeStreamingTests.cpp
+++ b/Tests/LandscapeStreamingTests.cpp
@@ -92,25 +92,29 @@ namespace
 			"a skirted LOD range must reference the appended skirt vertices");
 	}
 
-	void TestGrassSelectionIsPrioritizedDeterministicAndBudgeted()
+	void TestGrassSelectionFillsStableChunkRingsWithinGlobalBudget()
 	{
 		TVector<LandscapeGrassCandidate> candidates = {
-			{ 7u, 1u, 5u, 1.0f, 3.0f, false, 0.0f },
-			{ 3u, 0u, 4u, 2.0f, 100.0f, false, 0.0f },
-			{ 1u, 2u, 5u, 1.0f, 3.0f, true, 0.0f },
-			{ 0u, 0u, 5u, 1.0f, 2.0f, false, 0.0f },
+			{ 0u, 7u, 1u, 4u, 1u, 1u, 100.0f, false },
+			{ 0u, 3u, 0u, 3u, 0u, 0u, 1.0f, false },
+			{ 0u, 3u, 1u, 2u, 0u, 0u, 2.0f, false },
+			{ 0u, 9u, 0u, 5u, 1u, 2u, 1.0f, true },
 		};
 
-		const auto first = SelectLandscapeGrassResidency(candidates, 11u);
-		const auto second = SelectLandscapeGrassResidency(candidates, 11u);
+		TVector<LandscapeGrassSelection> first;
+		TVector<LandscapeGrassSelection> second;
+		SelectLandscapeGrassResidency(candidates, 8u, first);
+		SelectLandscapeGrassResidency(candidates, 8u, second);
 		Require(first.Num() == 3u && second.Num() == first.Num(),
 			"the hard budget must select exactly three candidate ranges");
-		Require(first[0].m_chunkIndex == 3u && first[0].m_instanceCount == 4u,
-			"profile priority must win before camera distance");
-		Require(first[1].m_chunkIndex == 0u && first[1].m_instanceCount == 5u,
-			"camera distance must order candidates with equal priority");
-		Require(first[2].m_chunkIndex == 1u && first[2].m_instanceCount == 2u,
-			"resident state must stabilize equal candidates and the final range must be partially admitted");
+		Require(first[0].m_chunkIndex == 3u && first[0].m_profileIndex == 1u &&
+			first[0].m_instanceCount == 2u,
+			"the current chunk must be filled first and use profile priority within that chunk");
+		Require(first[1].m_chunkIndex == 3u && first[1].m_profileIndex == 0u &&
+			first[1].m_instanceCount == 3u,
+			"all admitted profiles from the current chunk must precede neighboring chunks");
+		Require(first[2].m_chunkIndex == 9u && first[2].m_instanceCount == 3u,
+			"an already resident neighbor must be retained within its ring and may partially fill the budget");
 
 		uint32_t totalInstances = 0u;
 		for (size_t index = 0u; index < first.Num(); ++index)
@@ -121,26 +125,78 @@ namespace
 				first[index].m_instanceCount == second[index].m_instanceCount,
 				"identical inputs must produce an identical selection order and count");
 		}
-		Require(totalInstances == 11u,
+		Require(totalInstances == 8u,
 			"selected instances must fill the budget without exceeding it");
-		Require(SelectLandscapeGrassResidency(candidates, 0u).IsEmpty(),
+		TVector<LandscapeGrassSelection> empty;
+		SelectLandscapeGrassResidency(candidates, 0u, empty);
+		Require(empty.IsEmpty(),
 			"a zero instance budget must produce an empty active set");
 	}
 
-	void TestGrassResidencyHysteresisPreventsBoundaryChurn()
+	void TestGrassResidencyStabilityNeverOverridesANearerRing()
 	{
 		TVector<LandscapeGrassCandidate> candidates = {
-			{ 0u, 0u, 4u, 1.0f, 10.0f, false, 0.0f },
-			{ 1u, 0u, 4u, 1.0f, 11.0f, true, 2.0f },
+			{ 0u, 0u, 0u, 4u, 1u, 1u, 1.0f, false },
+			{ 0u, 1u, 0u, 4u, 1u, 2u, 1.0f, true },
 		};
-		const auto retained = SelectLandscapeGrassResidency(candidates, 4u);
+		TVector<LandscapeGrassSelection> retained;
+		SelectLandscapeGrassResidency(candidates, 4u, retained);
 		Require(retained.Num() == 1u && retained[0].m_chunkIndex == 1u,
-			"a resident chunk must remain selected while the challenger is inside its hysteresis margin");
+			"a resident chunk must remain selected over another candidate in the same ring");
 
-		candidates[1].m_distance = 13.0f;
-		const auto replaced = SelectLandscapeGrassResidency(candidates, 4u);
+		for (auto& candidate : candidates)
+		{
+			if (candidate.m_chunkIndex == 0u)
+			{
+				candidate.m_chunkRing = 0u;
+			}
+		}
+		TVector<LandscapeGrassSelection> replaced;
+		SelectLandscapeGrassResidency(candidates, 4u, replaced);
 		Require(replaced.Num() == 1u && replaced[0].m_chunkIndex == 0u,
-			"a meaningfully nearer chunk must replace a resident beyond its hysteresis margin");
+			"a candidate in a nearer chunk ring must replace a resident from a farther ring");
+	}
+
+	void TestGrassSelectionUsesOneBudgetAcrossLandscapeComponents()
+	{
+		TVector<LandscapeGrassCandidate> candidates = {
+			{ 1u, 0u, 0u, 4u, 0u, 0u, 1.0f, false },
+			{ 0u, 0u, 0u, 4u, 0u, 0u, 1.0f, false },
+		};
+		TVector<LandscapeGrassSelection> selected;
+		SelectLandscapeGrassResidency(candidates, 6u, selected);
+		Require(selected.Num() == 2u &&
+			selected[0].m_componentIndex == 0u && selected[0].m_instanceCount == 4u &&
+			selected[1].m_componentIndex == 1u && selected[1].m_instanceCount == 2u,
+			"one deterministic budget must be shared across all landscape components");
+	}
+
+	void TestGrassChunksMustOverlapTheCameraFrustum()
+	{
+		Math::Frustum frustum;
+		frustum.ExtractFrustumPlanes(
+			glm::mat4(1.0f),
+			1.0f,
+			90.0f,
+			0.1f,
+			100.0f);
+
+		Require(DoesLandscapeGrassChunkOverlapFrustum(
+			Math::AABB(glm::vec3(0.0f, 0.0f, -8.0f), glm::vec3(1.0f)),
+			frustum),
+			"a grass chunk in front of the camera must be admitted");
+		Require(!DoesLandscapeGrassChunkOverlapFrustum(
+			Math::AABB(glm::vec3(0.0f, 0.0f, 8.0f), glm::vec3(1.0f)),
+			frustum),
+			"a grass chunk behind the camera must not consume the budget");
+
+		const Math::AABB edgeChunk(
+			glm::vec3(15.0f, 0.0f, -8.0f),
+			glm::vec3(0.5f));
+		Require(!DoesLandscapeGrassChunkOverlapFrustum(edgeChunk, frustum),
+			"a non-resident chunk outside the side plane must be culled");
+		Require(DoesLandscapeGrassChunkOverlapFrustum(edgeChunk, frustum, 8.0f),
+			"the residency margin must retain a chunk near a frustum edge");
 	}
 }
 
@@ -149,8 +205,10 @@ int main()
 	const std::pair<const char*, std::function<void()>> tests[] = {
 		{ "LodCoordinatesPreserveChunkBoundaries", TestLodCoordinatesPreserveChunkBoundaries },
 		{ "LodIndicesStayWithinPackedTerrainAndSkirtVertices", TestLodIndicesStayWithinPackedTerrainAndSkirtVertices },
-		{ "GrassSelectionIsPrioritizedDeterministicAndBudgeted", TestGrassSelectionIsPrioritizedDeterministicAndBudgeted },
-		{ "GrassResidencyHysteresisPreventsBoundaryChurn", TestGrassResidencyHysteresisPreventsBoundaryChurn },
+		{ "GrassSelectionFillsStableChunkRingsWithinGlobalBudget", TestGrassSelectionFillsStableChunkRingsWithinGlobalBudget },
+		{ "GrassResidencyStabilityNeverOverridesANearerRing", TestGrassResidencyStabilityNeverOverridesANearerRing },
+		{ "GrassSelectionUsesOneBudgetAcrossLandscapeComponents", TestGrassSelectionUsesOneBudgetAcrossLandscapeComponents },
+		{ "GrassChunksMustOverlapTheCameraFrustum", TestGrassChunksMustOverlapTheCameraFrustum },
 	};
 
 	for (const auto& test : tests)


### PR DESCRIPTION
## Summary

- Add camera-distance LODs for landscape chunks, packed into one mesh allocation per chunk with reusable boundary skirts.
- Move the grass instance budget to the global graphics quality preset and apply one hard budget across all landscape components.
- Admit only chunks intersecting an active camera frustum, then fill stable visible chunk rings from the current chunk outward.
- Admit complete chunk/profile ranges while budget remains; select the nearest instances only for the final partial boundary range.
- Build changed grass transforms on worker tasks, retain scratch allocations, move transform arrays into immutable proxies, and skip proxy-vector work when residency is unchanged.
- Keep terrain and persistent vegetation in the static scene partition while publishing streamed grass through the dynamic partition.
- Preserve one active topology for main, depth, CSM, and local shadows through copy-on-write RHIScene versions that remain valid across frames in flight.

Closes #186
Closes #187

## Architecture and safety

- Terrain LOD index ranges share the chunk vertex/index buffers; physics keeps the full-resolution base grid.
- Active camera frustums reject chunks that cannot contribute to the view. Per-profile cull distance and residency hysteresis still apply.
- Visible candidates are ordered by chunk ring, resident stability, Manhattan distance, component/chunk key, and profile priority. This fills a visible chunk before moving to the next one.
- The graphics quality profile owns `vegetationInstanceBudget`; legacy project settings without the field use the corresponding quality default.
- Complete selected ranges preserve deterministic instance order and do not calculate camera distances.
- A partial boundary range ranks deterministic placements by distance to the nearest active camera with `nth_element`. Only that partial range receives a quantized camera-view revision and is rebuilt when the useful nearest set can change.
- Transform generation reads immutable landscape height/profile data on worker `Task` jobs. RHI proxy construction and scene publication remain on the owning thread.
- Published proxy resources are replaced rather than mutated. Older scene versions retain their resources until submitted frames release them.
- Terrain and persistent vegetation reuse the static octree. Streamed grass has an independent dynamic hash/octree, so camera-driven changes do not rebuild immutable landscape spatial data.
- Grass profiles do not create colliders; collidable vegetation remains persistent.

## Validation

- `cmake --build build-mac-vcpkg --target BoundsContractTests LandscapeStreamingTests RHISceneVirtualizationTests GpuCullingContractTests GraphicsSettingsTests --parallel 1`
- `ctest --test-dir build-mac-vcpkg --output-on-failure -R '^(BoundsContractTests|LandscapeStreamingTests|RHISceneVirtualizationTests|GpuCullingContractTests|GraphicsSettingsTests)$'` — 5/5 passed.
- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --configuration Release --no-restore` — 696/696 passed.
- `python3 build_editor.py --framework net10.0-maccatalyst --config Release --runtime maccatalyst-arm64` — editor and MCP bridge built with zero warnings and zero errors.
- Rebuilt the `EverythingFloats` workspace module with one build job.
- Verified the exact Release dylib hash inside the app bundle and passed `codesign --verify --deep --strict`.
- Opened `Everything Floats - Highland Trail`; MCP reported the expected workspace/world and `engineState: Running`.
- With the restored High test budget of 16000, focus changes updated visible residency from 750/13 candidates to 1150/19 and 900/16 without crashes.
- With an isolated temporary budget of 512, residency remained exactly 512/512 while camera focus changed visible candidates from 13 to 18/17 and 15. No repeated residency rebuild occurred during a 10-second stationary interval. The temporary setting was restored after validation.
- Builds and runtime checks were serial and short to limit host heat.

## Deferred

An authored vegetation binary asset format remains optional follow-up work. The issue does not define its schema, importer, versioning, or ownership contract; deterministic placement remains behind the residency-selection boundary so another source can be added without redesigning the streaming policy.

A formal before/after FPS and GPU-memory benchmark is not included in this correctness pass.