### PR TITLE
Refactor shared YAML and forward lighting code

### DIFF
--- a/Content/Shaders/ForwardLighting.glsl
+++ b/Content/Shaders/ForwardLighting.glsl
@@ -1,0 +1,546 @@
+#if defined(VERTEX) || defined(FRAGMENT)
+
+struct PerInstanceData
+{
+  mat4 model;
+  vec4 sphereBounds;
+  uint materialInstance;
+  uint skeletonOffset;
+  uint isCulled;
+  uint padding;
+  vec4 bakedVolumeScale;
+};
+
+layout(set = 0, binding = 0) uniform FrameData
+{
+  mat4 view;
+  mat4 projection;
+  mat4 invProjection;
+  vec4 cameraPosition;
+  ivec2 viewportSize;
+  vec2 cameraZNearZFar;
+  float currentTime;
+  float deltaTime;
+} frame;
+
+layout(set = 0, binding = 1) uniform PreviousFrameData
+{
+  mat4 view;
+  mat4 projection;
+  mat4 invProjection;
+  vec4 cameraPosition;
+  ivec2 viewportSize;
+  vec2 cameraZNearZFar;
+  float currentTime;
+  float deltaTime;
+} previousFrame;
+
+layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
+{
+  PerInstanceData instance[];
+} data;
+
+#endif
+
+#ifdef VERTEX
+
+layout(std430, set = 2, binding = 1) readonly buffer InstanceIndicesSSBO
+{
+  uint instance[];
+} instanceIndices;
+
+void BuildForwardVertexFrame(
+  mat4 modelMatrix,
+  vec3 position,
+  vec3 sourceNormal,
+  vec3 sourceTangent,
+  vec3 sourceBitangent,
+  out vec3 worldPosition,
+  out vec3 normal,
+  out mat3 tangentBasis)
+{
+  vec4 vertexPosition = modelMatrix * vec4(position, 1.0);
+  worldPosition = vertexPosition.xyz / vertexPosition.w;
+  gl_Position = frame.projection * (frame.view * vertexPosition);
+
+  mat3 linearMatrix = mat3(modelMatrix);
+  mat3 normalMatrix = transpose(inverse(linearMatrix));
+  normal = normalize(normalMatrix * sourceNormal);
+
+  vec3 tangent = linearMatrix * sourceTangent;
+  tangent -= normal * dot(normal, tangent);
+  float tangentLengthSquared = dot(tangent, tangent);
+  if(tangentLengthSquared > 1e-8)
+  {
+    tangent *= inversesqrt(tangentLengthSquared);
+  }
+  else
+  {
+    vec3 fallbackAxis = abs(normal.y) < 0.999
+      ? vec3(0.0, 1.0, 0.0)
+      : vec3(1.0, 0.0, 0.0);
+    tangent = normalize(cross(fallbackAxis, normal));
+  }
+
+  vec3 transformedBitangent = linearMatrix * sourceBitangent;
+  float handedness = dot(cross(normal, tangent), transformedBitangent) < 0.0
+    ? -1.0
+    : 1.0;
+  vec3 bitangent = normalize(cross(normal, tangent)) * handedness;
+  tangentBasis = mat3(tangent, bitangent, normal);
+}
+
+#endif
+
+#ifdef FRAGMENT
+
+layout(std430, set = 1, binding = 0) readonly buffer LightDataSSBO
+{
+  LightData instance[];
+} light;
+
+layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
+{
+  uint indices[];
+} culledLights;
+
+layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
+{
+  LightsGrid instance[];
+} lightsGrid;
+
+layout(set = 1, binding = 3) uniform samplerCube g_irradianceCubemap;
+layout(set = 1, binding = 4) uniform sampler2D g_brdfSampler;
+layout(set = 1, binding = 5) uniform samplerCube g_envCubemap;
+
+layout(std430, set = 1, binding = 6) readonly buffer LightsMatricesSSBO
+{
+  mat4 instance[];
+} lightsMatrices;
+
+layout(std430, set = 1, binding = 7) readonly buffer ShadowIndicesSSBO
+{
+  uint instance[];
+} shadowIndices;
+
+layout(set = 1, binding = 8) uniform sampler2D g_aoSampler;
+layout(set = 1, binding = 9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
+
+#ifdef TRANSMISSION
+layout(set = 1, binding = 10) uniform sampler2D g_transmissionFramebufferSampler;
+#endif
+
+layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
+{
+  uint instance[];
+} shadowAtlasTiles;
+
+#if defined(SAILOR_TEXTURE_REMAP)
+layout(std430, set = 4, binding = 0) readonly buffer TextureSamplerRemapSSBO
+{
+  uint indices[];
+} textureSamplerRemap;
+layout(set = 4, binding = 1) uniform sampler2D textureSamplers[];
+#else
+layout(set = 4, binding = 0) uniform sampler2D textureSamplers[];
+#endif
+
+const float Epsilon = 0.00001;
+const vec3 Fdielectric = vec3(0.04);
+
+struct ForwardPbrMaterial
+{
+  vec3 baseColor;
+  float metallic;
+  float roughness;
+  float ambientOcclusion;
+  float diffuseWeight;
+};
+
+struct ForwardLightSample
+{
+  vec3 direction;
+  vec3 radiance;
+  float falloff;
+  float shadow;
+};
+
+struct ForwardLightList
+{
+  uint offset;
+  uint count;
+  bool overflow;
+};
+
+uint ResolveTextureSamplerIndex(uint globalTextureIndex)
+{
+#if defined(SAILOR_TEXTURE_REMAP)
+  return textureSamplerRemap.indices[globalTextureIndex];
+#else
+  return globalTextureIndex;
+#endif
+}
+
+float CalculateCascadedDirectionalShadow(
+  LightData lightData,
+  vec3 worldPosition,
+  vec3 surfaceNormal,
+  vec3 surfaceToLightDirection)
+{
+  const uint activeCascadeCount = clamp(
+    lightData.activeCascadeCount,
+    1u,
+    uint(NUM_CSM_CASCADES));
+  const int cascadeLayer = SelectCascade(
+    frame.view,
+    worldPosition,
+    frame.cameraZNearZFar,
+    activeCascadeCount);
+  if(cascadeLayer >= int(activeCascadeCount))
+  {
+    return 1.0;
+  }
+
+  const uint cascadeShadowType = GetDirectionalCascadeShadowType(
+    lightData.shadowType,
+    cascadeLayer);
+  const vec3 shadowReceiverPosition = OffsetDirectionalShadowReceiver(
+    worldPosition,
+    surfaceNormal,
+    surfaceToLightDirection,
+    GetDirectionalShadowReceiverBiasScale(
+      cascadeShadowType,
+      lightData.shadowBias));
+  const mat4 cascadeLightMatrix = lightsMatrices.instance[cascadeLayer];
+  float shadow = CalculateDirectionalShadow(
+    cascadeShadowType,
+    shadowMaps[cascadeLayer],
+    cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0),
+    cascadeLayer);
+
+  const float cascadeBlend = CalculateCascadeBlend(
+    frame.view,
+    worldPosition,
+    frame.cameraZNearZFar,
+    cascadeLayer,
+    activeCascadeCount);
+  if(cascadeBlend > 0.0)
+  {
+    const int nextCascadeLayer = cascadeLayer + 1;
+    const uint nextCascadeShadowType = GetDirectionalCascadeShadowType(
+      lightData.shadowType,
+      nextCascadeLayer);
+    const vec3 nextShadowReceiverPosition = OffsetDirectionalShadowReceiver(
+      worldPosition,
+      surfaceNormal,
+      surfaceToLightDirection,
+      GetDirectionalShadowReceiverBiasScale(
+        nextCascadeShadowType,
+        lightData.shadowBias));
+    const mat4 nextCascadeLightMatrix =
+      lightsMatrices.instance[nextCascadeLayer];
+    const float nextShadow = CalculateDirectionalShadow(
+      nextCascadeShadowType,
+      shadowMaps[nextCascadeLayer],
+      nextCascadeLightMatrix * vec4(nextShadowReceiverPosition, 1.0),
+      nextCascadeLayer);
+    shadow = mix(shadow, nextShadow, cascadeBlend);
+  }
+
+  const float shadowDistanceFade = CalculateShadowDistanceFade(
+    frame.view,
+    worldPosition,
+    frame.cameraZNearZFar,
+    cascadeLayer,
+    activeCascadeCount);
+  return mix(shadow, 1.0, shadowDistanceFade);
+}
+
+float CalculateLocalLightShadow(
+  LightData lightData,
+  uint lightIndex,
+  vec3 worldPosition,
+  vec3 surfaceNormal,
+  vec3 surfaceToLightDirection)
+{
+  const uint packedShadowIndex = shadowIndices.instance[lightIndex];
+  if(lightData.shadowType == SHADOW_TYPE_NONE ||
+    packedShadowIndex == INVALID_SHADOW_MAP_INDEX)
+  {
+    return 1.0;
+  }
+
+  uint shadowMapIndex = packedShadowIndex & SHADOW_MAP_INDEX_MASK;
+  if(lightData.type == 1u)
+  {
+    shadowMapIndex += SelectPointShadowFace(
+      worldPosition - lightData.worldPosition);
+  }
+  if(shadowMapIndex >= MAX_SHADOWS_IN_VIEW)
+  {
+    return 1.0;
+  }
+
+  const uint packedAtlasTile = shadowAtlasTiles.instance[shadowMapIndex];
+  const uint shadowSamplerIndex = NUM_CSM_CASCADES +
+    DecodeShadowAtlasIndex(packedAtlasTile);
+  if(shadowSamplerIndex >= MAX_SHADOW_MAP_SAMPLERS)
+  {
+    return 1.0;
+  }
+
+  return CalculateLocalPcfShadow(
+    shadowMaps[nonuniformEXT(shadowSamplerIndex)],
+    lightsMatrices.instance[shadowMapIndex],
+    DecodeShadowAtlasRect(packedAtlasTile),
+    worldPosition,
+    surfaceNormal,
+    surfaceToLightDirection,
+    length(lightData.worldPosition - worldPosition),
+    (packedShadowIndex & SOFT_SHADOW_MAP_BIT) != 0u,
+    lightData.shadowBias);
+}
+
+ForwardLightSample ResolveForwardLightSample(
+  LightData lightData,
+  uint lightIndex,
+  vec3 worldPosition,
+  vec3 surfaceNormal)
+{
+  ForwardLightSample result;
+  result.radiance = lightData.intensity;
+  result.falloff = 1.0;
+  result.shadow = 1.0;
+  result.direction = vec3(0.0);
+
+  if(lightData.type == 0u)
+  {
+    result.direction = -lightData.direction;
+    result.shadow = CalculateCascadedDirectionalShadow(
+      lightData,
+      worldPosition,
+      surfaceNormal,
+      result.direction);
+  }
+  else if(lightData.type == 1u || lightData.type == 2u)
+  {
+    vec3 pointToLight = lightData.worldPosition - worldPosition;
+    float pointToLightLengthSquared = dot(pointToLight, pointToLight);
+    result.direction = pointToLightLengthSquared > Epsilon
+      ? pointToLight * inversesqrt(pointToLightLengthSquared)
+      : vec3(0.0);
+    const float distanceToLight = length(pointToLight);
+    result.falloff = CalculateLocalLightRangeAttenuation(
+      lightData,
+      distanceToLight);
+    if(lightData.type == 2u)
+    {
+      const float coneRange = lightData.cutOff.x - lightData.cutOff.y;
+      const float coneCos = dot(
+        result.direction,
+        normalize(-lightData.direction));
+      result.falloff *= clamp(
+        (coneCos - lightData.cutOff.y) / max(coneRange, Epsilon),
+        0.0,
+        1.0);
+      if(coneCos < lightData.cutOff.y)
+      {
+        result.falloff = 0.0;
+      }
+    }
+    result.shadow = CalculateLocalLightShadow(
+      lightData,
+      lightIndex,
+      worldPosition,
+      surfaceNormal,
+      result.direction);
+  }
+
+  return result;
+}
+
+vec3 EvaluateForwardPbrDirectLighting(
+  ForwardLightSample lightSample,
+  ForwardPbrMaterial materialData,
+  vec3 F0,
+  vec3 surfaceToCamera,
+  float cosLo,
+  vec3 normal)
+{
+  vec3 halfVector = lightSample.direction + surfaceToCamera;
+  float halfVectorLengthSquared = dot(halfVector, halfVector);
+  vec3 Lh = halfVectorLengthSquared > Epsilon
+    ? halfVector * inversesqrt(halfVectorLengthSquared)
+    : normal;
+
+  float cosLi = max(0.0, dot(normal, lightSample.direction));
+  float cosLh = max(0.0, dot(normal, Lh));
+  vec3 F = FresnelSchlick(
+    F0,
+    max(0.0, dot(Lh, surfaceToCamera)));
+  float D = NdfGGX(cosLh, materialData.roughness);
+  float G = GeometrySchlickGGX(
+    cosLi,
+    cosLo,
+    materialData.roughness);
+  vec3 kd = mix(
+    vec3(1.0) - F,
+    vec3(0.0),
+    materialData.metallic) * materialData.diffuseWeight;
+  vec3 diffuseBrdf = kd * materialData.baseColor;
+  vec3 specularBrdf = (F * D * G) /
+    max(Epsilon, 4.0 * cosLi * cosLo);
+  return (diffuseBrdf + specularBrdf) *
+    lightSample.radiance * cosLi * lightSample.falloff;
+}
+
+vec3 CalculateForwardPbrLighting(
+  LightData lightData,
+  uint lightIndex,
+  ForwardPbrMaterial materialData,
+  vec3 F0,
+  vec3 surfaceToCamera,
+  float cosLo,
+  vec3 normal,
+  vec3 worldPosition)
+{
+  const ForwardLightSample lightSample = ResolveForwardLightSample(
+    lightData,
+    lightIndex,
+    worldPosition,
+    normal);
+  return lightSample.shadow * EvaluateForwardPbrDirectLighting(
+    lightSample,
+    materialData,
+    F0,
+    surfaceToCamera,
+    cosLo,
+    normal);
+}
+
+vec3 CalculateForwardAmbientLighting(
+  ForwardPbrMaterial materialData,
+  vec3 F0,
+  vec3 reflectionDirection,
+  vec3 normal,
+  vec3 geometricNormal,
+  vec3 worldPosition,
+  vec3 surfaceToCamera,
+  float cosLo,
+  vec2 screenUv,
+  out float environmentVisibility)
+{
+  GlobalIlluminationSampleDebug globalIlluminationDebug;
+  environmentVisibility = 1.0;
+  vec3 irradiance = vec3(0.0);
+  if(!TryResolveGlobalIlluminationDiffuseIrradiance(
+    screenUv,
+    worldPosition,
+    normal,
+    geometricNormal,
+    surfaceToCamera,
+    reflectionDirection,
+    irradiance,
+    environmentVisibility,
+    globalIlluminationDebug))
+  {
+    irradiance = texture(g_irradianceCubemap, normal).rgb;
+  }
+  if(GlobalIlluminationDebugUsesProbeData())
+  {
+    return irradiance;
+  }
+
+  vec3 F = FresnelSchlick(F0, cosLo);
+  vec3 kd = mix(
+    vec3(1.0) - F,
+    vec3(0.0),
+    materialData.metallic) * materialData.diffuseWeight;
+  vec3 diffuseIbl = kd * materialData.baseColor * irradiance;
+  float ambientOcclusion = clamp(
+    materialData.ambientOcclusion,
+    0.0,
+    1.0);
+  if(globalIlluminationHeader.stateAndDebug.z ==
+    GLOBAL_ILLUMINATION_DEBUG_INDIRECT_ONLY)
+  {
+    return diffuseIbl * ambientOcclusion;
+  }
+
+  int specularTextureLevels = textureQueryLevels(g_envCubemap);
+  vec3 specularIrradiance = textureLod(
+    g_envCubemap,
+    reflectionDirection,
+    materialData.roughness * specularTextureLevels).rgb;
+  vec2 specularBrdf = texture(
+    g_brdfSampler,
+    vec2(cosLo, materialData.roughness)).rg;
+  vec3 specularIbl =
+    (F0 * specularBrdf.x + specularBrdf.y) * specularIrradiance;
+  float specularOcclusion = CalculateSpecularOcclusion(
+    min(ambientOcclusion, environmentVisibility),
+    cosLo,
+    materialData.roughness);
+  vec3 indirectLighting = diffuseIbl * ambientOcclusion +
+    specularIbl * specularOcclusion;
+  return ApplyGlobalIlluminationDebug(
+    indirectLighting,
+    globalIlluminationDebug);
+}
+
+ForwardLightList ResolveForwardLightList(vec2 fragmentPosition)
+{
+  ForwardLightList result;
+  const uint tileIndex = GetLightTileIndex(
+    fragmentPosition,
+    frame.viewportSize);
+  const uint gridLength = uint(lightsGrid.instance.length());
+  const bool hasLightTile = tileIndex < gridLength;
+  result.offset = hasLightTile
+    ? lightsGrid.instance[tileIndex].offset
+    : 0u;
+  const uint listLength = uint(culledLights.indices.length());
+  const uint availableLights = result.offset < listLength
+    ? listLength - result.offset
+    : 0u;
+  const uint packedLightCount = hasLightTile
+    ? lightsGrid.instance[tileIndex].num
+    : 0u;
+  result.overflow =
+    (packedLightCount & LIGHT_TILE_OVERFLOW_BIT) != 0u;
+  result.count = 0u;
+  if(hasLightTile)
+  {
+#ifdef SUPPORT_LIGHTS_OVERFLOW
+    result.count = result.overflow
+      ? min(
+          packedLightCount & LIGHT_TILE_COUNT_MASK,
+          uint(light.instance.length()))
+      : min(
+          packedLightCount & LIGHT_TILE_COUNT_MASK,
+          availableLights);
+#else
+    result.count = min(
+      min(
+        packedLightCount & LIGHT_TILE_COUNT_MASK,
+        uint(LIGHTS_PER_TILE)),
+      availableLights);
+#endif
+  }
+  return result;
+}
+
+uint ResolveForwardLightIndex(
+  ForwardLightList lightList,
+  uint localLightIndex)
+{
+#ifdef SUPPORT_LIGHTS_OVERFLOW
+  return lightList.overflow
+    ? localLightIndex
+    : culledLights.indices[lightList.offset + localLightIndex];
+#else
+  return culledLights.indices[lightList.offset + localLightIndex];
+#endif
+}
+
+#endif

--- a/Content/Shaders/ForwardLighting.glsl.asset
+++ b/Content/Shaders/ForwardLighting.glsl.asset
@@ -1,0 +1,3 @@
+assetInfoType: Sailor::ShaderAssetInfo
+fileId: 26617C46-3D79-473A-B384-866D37E47DF6
+filename: ForwardLighting.glsl

--- a/Content/Shaders/Landscape.shader
+++ b/Content/Shaders/Landscape.shader
@@ -4,6 +4,7 @@ includes:
 - Shaders/Math.glsl
 - Shaders/Lighting.glsl
 - Shaders/GlobalIllumination.glsl
+- Shaders/ForwardLighting.glsl
 
 defines:
 - SUPPORT_LIGHTS_OVERFLOW
@@ -33,155 +34,23 @@ glslVertex: |
     mat3 tangentBasis;
   } vout;
 
-  struct PerInstanceData
-  {
-      mat4 model;
-      vec4 sphereBounds;
-      uint materialInstance;
-      uint skeletonOffset;
-      uint isCulled;
-      uint padding;
-      vec4 bakedVolumeScale;
-  };
-
-  struct MaterialData
-  {
-    vec4 albedo;
-    vec4 ambient;
-    vec4 emission;
-    vec4 layerUvScale;
-
-    float metallic;
-    float roughness;
-    float ao;
-
-    uint layer0Sampler;
-    uint layer1Sampler;
-    uint layer2Sampler;
-    uint layer3Sampler;
-  };
-
-  layout(set = 0, binding = 0) uniform FrameData
-  {
-      mat4 view;
-      mat4 projection;
-      mat4 invProjection;
-      vec4 cameraPosition;
-      ivec2 viewportSize;
-      vec2 cameraZNearZFar;
-      float currentTime;
-      float deltaTime;
-  } frame;
-
-  layout(set = 0, binding = 1) uniform PreviousFrameData
-  {
-      mat4 view;
-      mat4 projection;
-      mat4 invProjection;
-      vec4 cameraPosition;
-      ivec2 viewportSize;
-      vec2 cameraZNearZFar;
-      float currentTime;
-      float deltaTime;
-  } previousFrame;
-
-  layout(std430, set = 1, binding = 0) readonly buffer LightDataSSBO
-  {
-    LightData instance[];
-  } light;
-
-  layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
-  {
-      uint indices[MAX_TEXTURES_IN_SCENE];
-  } culledLights;
-
-  layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
-  {
-      LightsGrid instance[];
-  } lightsGrid;
-
-  layout(set=1, binding=3) uniform samplerCube g_irradianceCubemap;
-  layout(set=1, binding=4) uniform sampler2D   g_brdfSampler;
-  layout(set=1, binding=5) uniform samplerCube g_envCubemap;
-
-  layout(std430, set = 1, binding = 6) readonly buffer LightsMatricesSSBO
-  {
-      mat4 instance[];
-  } lightsMatrices;
-
-  layout(std430, set = 1, binding = 7) readonly buffer ShadowIndicesSSBO
-  {
-      uint instance[];
-  } shadowIndices;
-
-  layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
-
-     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
-     {
-         uint instance[];
-     } shadowAtlasTiles;
-
-  layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
-  {
-      PerInstanceData instance[];
-  } data;
-
-  layout(std430, set = 2, binding = 1) readonly buffer InstanceIndicesSSBO
-  {
-      uint instance[];
-  } instanceIndices;
-
-  layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
-  {
-      MaterialData instance[];
-  } material;
-
-  #if defined(SAILOR_TEXTURE_REMAP)
-  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
-  {
-      uint indices[MAX_TEXTURES_IN_SCENE];
-  } textureSamplerRemap;
-  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
-  #else
-  layout(set=4, binding=0) uniform sampler2D textureSamplers[];
-  #endif
-
   void main()
   {
     uint instanceIndex = instanceIndices.instance[gl_InstanceIndex];
     mat4 modelMatrix = data.instance[instanceIndex].model;
-    vec4 vertexPosition = modelMatrix * vec4(inPosition, 1.0);
-    vout.worldPosition = vertexPosition.xyz / vertexPosition.w;
-
-    gl_Position = frame.projection * (frame.view * vertexPosition);
-
-    mat3 linearMatrix = mat3(modelMatrix);
-    mat3 normalMatrix = transpose(inverse(linearMatrix));
-    vec3 normal = normalize(normalMatrix * inNormal);
-
-    vec3 tangent = linearMatrix * inTangent;
-    tangent -= normal * dot(normal, tangent);
-    float tangentLengthSquared = dot(tangent, tangent);
-    if(tangentLengthSquared > 1e-8)
-    {
-      tangent *= inversesqrt(tangentLengthSquared);
-    }
-    else
-    {
-      vec3 fallbackAxis = abs(normal.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
-      tangent = normalize(cross(fallbackAxis, normal));
-    }
-
-    vec3 transformedBitangent = linearMatrix * inBitangent;
-    float handedness = dot(cross(normal, tangent), transformedBitangent) < 0.0 ? -1.0 : 1.0;
-    vec3 bitangent = normalize(cross(normal, tangent)) * handedness;
+    BuildForwardVertexFrame(
+      modelMatrix,
+      inPosition,
+      inNormal,
+      inTangent,
+      inBitangent,
+      vout.worldPosition,
+      vout.normal,
+      vout.tangentBasis);
 
     vout.color = inColor;
-    vout.normal = normal;
     vout.texcoord = inTexcoord;
     materialInstance = data.instance[instanceIndex].materialInstance;
-    vout.tangentBasis = mat3(tangent, bitangent, normal);
   }
 
 glslFragment: |
@@ -199,17 +68,6 @@ glslFragment: |
 
   layout(location=0) out vec4 outColor;
 
-  struct PerInstanceData
-  {
-      mat4 model;
-      vec4 sphereBounds;
-      uint materialInstance;
-      uint skeletonOffset;
-      uint isCulled;
-      uint padding;
-      vec4 bakedVolumeScale;
-  };
-
   struct MaterialData
   {
     vec4 albedo;
@@ -227,378 +85,15 @@ glslFragment: |
     uint layer3Sampler;
   };
 
-  layout(set = 0, binding = 0) uniform FrameData
-  {
-      mat4 view;
-      mat4 projection;
-      mat4 invProjection;
-      vec4 cameraPosition;
-      ivec2 viewportSize;
-      vec2 cameraZNearZFar;
-      float currentTime;
-      float deltaTime;
-  } frame;
-
-  layout(set = 0, binding = 1) uniform PreviousFrameData
-  {
-      mat4 view;
-      mat4 projection;
-      mat4 invProjection;
-      vec4 cameraPosition;
-      ivec2 viewportSize;
-      vec2 cameraZNearZFar;
-      float currentTime;
-      float deltaTime;
-  } previousFrame;
-
-  layout(std430, set = 1, binding = 0) readonly buffer LightDataSSBO
-  {
-    LightData instance[];
-  } light;
-
-  layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
-  {
-      uint indices[];
-  } culledLights;
-
-  layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
-  {
-      LightsGrid instance[];
-  } lightsGrid;
-
-  layout(set=1, binding=3) uniform samplerCube g_irradianceCubemap;
-  layout(set=1, binding=4) uniform sampler2D   g_brdfSampler;
-  layout(set=1, binding=5) uniform samplerCube g_envCubemap;
-
-  layout(std430, set = 1, binding = 6) readonly buffer LightsMatricesSSBO
-  {
-      mat4 instance[];
-  } lightsMatrices;
-
-  layout(std430, set = 1, binding = 7) readonly buffer ShadowIndicesSSBO
-  {
-      uint instance[];
-  } shadowIndices;
-
-  layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
-
-     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
-     {
-         uint instance[];
-     } shadowAtlasTiles;
-
-  layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
-  {
-      PerInstanceData instance[];
-  } data;
-
   layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
   {
       MaterialData instance[];
   } material;
 
-  //layout(set=3, binding=1) uniform sampler2D layer0Sampler;
-  //layout(set=3, binding=2) uniform sampler2D layer1Sampler;
-  //layout(set=3, binding=3) uniform sampler2D layer2Sampler;
-  //layout(set=3, binding=4) uniform sampler2D layer3Sampler;
-
-  #if defined(SAILOR_TEXTURE_REMAP)
-  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
-  {
-      uint indices[];
-  } textureSamplerRemap;
-  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
-  #else
-  layout(set=4, binding=0) uniform sampler2D textureSamplers[];
-  #endif
-
-  uint ResolveTextureSamplerIndex(uint globalTextureIndex)
-  {
-  #if defined(SAILOR_TEXTURE_REMAP)
-      return textureSamplerRemap.indices[globalTextureIndex];
-  #else
-      return globalTextureIndex;
-  #endif
-  }
-
   MaterialData GetMaterialData()
   {
       return material.instance[materialInstance];
   }
-
-  float CalculateCascadedDirectionalShadow(
-    LightData light,
-    vec3 worldPosition,
-    vec3 surfaceNormal,
-    vec3 surfaceToLightDirection)
-  {
-    const uint activeCascadeCount = clamp(
-      light.activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
-    const int cascadeLayer = SelectCascade(
-      frame.view, worldPosition, frame.cameraZNearZFar, activeCascadeCount);
-    if(cascadeLayer >= int(activeCascadeCount))
-    {
-      return 1.0f;
-    }
-
-    const uint cascadeShadowType = GetDirectionalCascadeShadowType(
-      light.shadowType,
-      cascadeLayer);
-    const vec3 shadowReceiverPosition = OffsetDirectionalShadowReceiver(
-      worldPosition,
-      surfaceNormal,
-      surfaceToLightDirection,
-      GetDirectionalShadowReceiverBiasScale(
-        cascadeShadowType,
-        light.shadowBias));
-    const mat4 cascadeLightMatrix = lightsMatrices.instance[cascadeLayer];
-    float shadow = CalculateDirectionalShadow(
-      cascadeShadowType,
-      shadowMaps[cascadeLayer],
-      cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f),
-      cascadeLayer);
-    const float cascadeBlend = CalculateCascadeBlend(
-      frame.view,
-      worldPosition,
-      frame.cameraZNearZFar,
-      cascadeLayer,
-      activeCascadeCount);
-    if(cascadeBlend > 0.0f)
-    {
-      const int nextCascadeLayer = cascadeLayer + 1;
-      const uint nextCascadeShadowType = GetDirectionalCascadeShadowType(
-        light.shadowType,
-        nextCascadeLayer);
-      const vec3 nextShadowReceiverPosition = OffsetDirectionalShadowReceiver(
-        worldPosition,
-        surfaceNormal,
-        surfaceToLightDirection,
-        GetDirectionalShadowReceiverBiasScale(
-          nextCascadeShadowType,
-          light.shadowBias));
-      const mat4 nextCascadeLightMatrix = lightsMatrices.instance[nextCascadeLayer];
-      const float nextShadow = CalculateDirectionalShadow(
-        nextCascadeShadowType,
-        shadowMaps[nextCascadeLayer],
-        nextCascadeLightMatrix * vec4(nextShadowReceiverPosition, 1.0f),
-        nextCascadeLayer);
-      shadow = mix(shadow, nextShadow, cascadeBlend);
-    }
-
-    const float shadowDistanceFade = CalculateShadowDistanceFade(
-      frame.view,
-      worldPosition,
-      frame.cameraZNearZFar,
-      cascadeLayer,
-      activeCascadeCount);
-    shadow = mix(shadow, 1.0f, shadowDistanceFade);
-
-    return shadow;
-  }
-
-  float CalculateLocalLightShadow(
-    LightData light,
-    uint lightIndex,
-    vec3 worldPosition,
-    vec3 surfaceNormal,
-    vec3 surfaceToLightDirection)
-  {
-    const uint packedShadowIndex = shadowIndices.instance[lightIndex];
-    if(light.shadowType == SHADOW_TYPE_NONE ||
-       packedShadowIndex == INVALID_SHADOW_MAP_INDEX)
-    {
-      return 1.0f;
-    }
-
-    uint shadowMapIndex = packedShadowIndex & SHADOW_MAP_INDEX_MASK;
-    if(light.type == 1u)
-    {
-      shadowMapIndex += SelectPointShadowFace(worldPosition - light.worldPosition);
-    }
-    if(shadowMapIndex >= MAX_SHADOWS_IN_VIEW)
-    {
-      return 1.0f;
-    }
-
-    const uint packedAtlasTile = shadowAtlasTiles.instance[shadowMapIndex];
-    const uint shadowSamplerIndex = NUM_CSM_CASCADES + DecodeShadowAtlasIndex(packedAtlasTile);
-    if(shadowSamplerIndex >= MAX_SHADOW_MAP_SAMPLERS)
-    {
-      return 1.0f;
-    }
-
-    return CalculateLocalPcfShadow(
-      shadowMaps[nonuniformEXT(shadowSamplerIndex)],
-      lightsMatrices.instance[shadowMapIndex],
-      DecodeShadowAtlasRect(packedAtlasTile),
-      worldPosition,
-      surfaceNormal,
-      surfaceToLightDirection,
-      length(light.worldPosition - worldPosition),
-      (packedShadowIndex & SOFT_SHADOW_MAP_BIT) != 0u,
-      light.shadowBias);
-  }
-
-  const float Epsilon = 0.00001;
-  vec3 CalculateLighting(LightData light, uint lightIndex, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
-  {
-    float falloff = 1.0f;
-    float attenuation = 1.0;
-    float shadow = 1.0f;
-    vec3 Li = -light.direction;
-
-    // Directional light
-    if(light.type == 0)
-    {
-        attenuation = 1.0;
-
-        shadow = CalculateCascadedDirectionalShadow(
-          light,
-          worldPos,
-          normal,
-          -light.direction);
-    }
-    // Point light
-    else if(light.type == 1)
-    {
-      // Attenuation
-      const float distance    = length(light.worldPosition - worldPos);
-      falloff = CalculateLocalLightRangeAttenuation(light, distance);
-      Li = normalize(light.worldPosition - worldPos);
-      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
-    }
-    // Spot light
-    else if(light.type == 2)
-    {
-      // Attenuation
-      vec3 lightDir = normalize(light.worldPosition - worldPos);
-      Li = lightDir;
-      float epsilon   = light.cutOff.x - light.cutOff.y;
-      float theta = dot(lightDir, normalize(-light.direction));
-      const float distance    = length(light.worldPosition - worldPos);
-      falloff = CalculateLocalLightRangeAttenuation(light, distance) *
-        clamp((theta - light.cutOff.y) / epsilon, 0.0, 1.0);
-
-      if(theta < light.cutOff.y)
-      {
-        falloff = 0.0f;
-      }
-
-      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
-    }
-    vec3 Lradiance = light.intensity;
-
-    // Half-vector between Li and Lo.
-    vec3 Lh = normalize(Li + Lo);
-
-    // Calculate angles between surface normal and various light vectors.
-    float cosLi = max(0.0, dot(normal, Li));
-    float cosLh = max(0.0, dot(normal, Lh));
-
-    // Calculate Fresnel term for direct lighting.
-    vec3 F  = FresnelSchlick(F0, max(0.0, dot(Lh, Lo)));
-    // Calculate normal distribution for specular BRDF.
-    float D = NdfGGX(cosLh, material.roughness);
-    // Calculate geometric attenuation for specular BRDF.
-    float G = GeometrySchlickGGX(cosLi, cosLo, material.roughness);
-
-    // Diffuse scattering happens due to light being refracted multiple times by a dielectric medium.
-    // Metals on the other hand either reflect or absorb energy, so diffuse contribution is always zero.
-    // To be energy conserving we must scale diffuse BRDF contribution based on Fresnel factor & metalness.
-    vec3 kd = mix(vec3(1.0) - F, vec3(0.0), material.metallic);
-
-    // Lambert diffuse BRDF.
-    // We don't scale by 1/PI for lighting & material units to be more convenient.
-    // See: https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/
-    vec3 diffuseBRDF = kd * material.albedo.xyz;
-
-    // Cook-Torrance specular microfacet BRDF.
-    vec3 specularBRDF = (F * D * G) / max(Epsilon, 4.0 * cosLi * cosLo);
-
-    // Total contribution for this light.
-    return shadow * ((diffuseBRDF + specularBRDF) * Lradiance * cosLi) * falloff;
-  }
-
-  vec3 AmbientLighting(
-    MaterialData material,
-    vec3 F0,
-    vec3 Lr,
-    vec3 normal,
-    vec3 geometricNormal,
-    vec3 worldPosition,
-    vec3 surfaceToCamera,
-    float cosLo,
-    vec2 screenUv)
-  {
-    // Baked probes replace diffuse environment irradiance only. Specular IBL
-    // remains sourced from the pre-filtered environment cubemap.
-    GlobalIlluminationSampleDebug globalIlluminationDebug;
-    float environmentVisibility = 1.0;
-    vec3 irradiance = vec3(0.0);
-    if(!TryResolveGlobalIlluminationDiffuseIrradiance(
-      screenUv,
-      worldPosition,
-      normal,
-      geometricNormal,
-      surfaceToCamera,
-      Lr,
-      irradiance,
-      environmentVisibility,
-      globalIlluminationDebug))
-    {
-      irradiance = texture(g_irradianceCubemap, normal).rgb;
-    }
-    if(GlobalIlluminationDebugUsesProbeData())
-    {
-      return irradiance;
-    }
-
-    // Calculate Fresnel term for ambient lighting.
-    // Since we use pre-filtered cubemap(s) and irradiance is coming from many directions
-    // use cosLo instead of angle with light's half-vector (cosLh above).
-    // See: https://seblagarde.wordpress.com/2011/08/17/hello-world/
-    vec3 F = FresnelSchlick(F0, cosLo);
-
-    // Get diffuse contribution factor (as with direct lighting).
-    vec3 kd = mix(vec3(1.0) - F, vec3(0.0), material.metallic);
-
-    // Irradiance map contains exitant radiance assuming Lambertian BRDF, no need to scale by 1/PI here either.
-    vec3 diffuseIBL = kd * material.albedo.xyz * irradiance;
-
-    float ambientOcclusion = clamp(material.ao, 0.0, 1.0);
-    if(globalIlluminationHeader.stateAndDebug.z ==
-      GLOBAL_ILLUMINATION_DEBUG_INDIRECT_ONLY)
-    {
-      return diffuseIBL * ambientOcclusion;
-    }
-
-    // Sample pre-filtered specular reflection environment at correct mipmap level.
-    int specularTextureLevels = textureQueryLevels(g_envCubemap);
-    vec3 specularIrradiance = textureLod(g_envCubemap, Lr, material.roughness * specularTextureLevels).rgb;
-
-    // Split-sum approximation factors for Cook-Torrance specular BRDF.
-    vec2 specularBRDF = texture(g_brdfSampler, vec2(cosLo, material.roughness)).rg;
-
-    // Total specular IBL contribution.
-    vec3 specularIBL = (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance;
-
-    // Ambient occlusion applies to all indirect lighting. Use a view- and
-    // roughness-dependent approximation for specular IBL so smooth surfaces
-    // retain plausible reflections without leaking them into occluded areas.
-    float specularOcclusion = CalculateSpecularOcclusion(
-      min(ambientOcclusion, environmentVisibility),
-      cosLo,
-      material.roughness);
-    vec3 indirectLighting = diffuseIBL * ambientOcclusion +
-      specularIBL * specularOcclusion;
-    return ApplyGlobalIlluminationDebug(
-      indirectLighting,
-      globalIlluminationDebug);
-  }
-
-  // Constant normal incidence Fresnel factor for all dielectrics.
-  const vec3 Fdielectric = vec3(0.04);
 
   void main()
   {
@@ -624,8 +119,12 @@ glslFragment: |
     const vec3 geometricNormal = normalize(vin.normal);
     vec3 normal = geometricNormal;
 
-    //outColor.xyz = AmbientLighting(material, vin.normal, vin.worldPosition, viewDirection);
-    outColor.xyz = vec3(0);
+    const ForwardPbrMaterial forwardMaterial = ForwardPbrMaterial(
+      material.albedo.xyz,
+      material.metallic,
+      material.roughness,
+      material.ao,
+      1.0);
 
     // Angle between surface normal and outgoing light direction.
     float cosLo = max(0.0, dot(normal, -viewDirection));
@@ -636,42 +135,17 @@ glslFragment: |
     // Fresnel reflectance at normal incidence (for metals use albedo color).
     vec3 F0 = mix(Fdielectric, material.albedo.xyz, material.metallic);
 
-    //outColor.xyz += vec3(texture(g_envCubemap, R).xyz);
-    //outColor.xyz *= max(0.1, dot(normalize(-vec3(-0.3, -0.5, 0.1)), vin.normal.xyz)) * 0.5;
-
     const bool bEvaluateDirectLighting =
       !GlobalIlluminationDebugSuppressesDirectLighting();
-    uint offset = 0u;
-    bool lightsOverflow = false;
-    uint numLights = 0u;
+    ForwardLightList lightList = ForwardLightList(0u, 0u, false);
     if(bEvaluateDirectLighting)
     {
-      const uint tileIndex = GetLightTileIndex(
-        gl_FragCoord.xy,
-        frame.viewportSize);
-      const uint gridLength = uint(lightsGrid.instance.length());
-      const bool hasLightTile = tileIndex < gridLength;
-      offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0u;
-      const uint listLength = uint(culledLights.indices.length());
-      const uint availableLights = offset < listLength
-        ? listLength - offset
-        : 0u;
-      const uint packedNumLights = hasLightTile
-        ? lightsGrid.instance[tileIndex].num
-        : 0u;
-      lightsOverflow =
-        (packedNumLights & LIGHT_TILE_OVERFLOW_BIT) != 0u;
-      numLights = !hasLightTile ? 0u :
-    #ifdef SUPPORT_LIGHTS_OVERFLOW
-        (lightsOverflow ? min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(light.instance.length())) :
-            min(packedNumLights & LIGHT_TILE_COUNT_MASK, availableLights));
-    #else
-        min(min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(LIGHTS_PER_TILE)), availableLights);
-    #endif
+      lightList = ResolveForwardLightList(gl_FragCoord.xy);
     }
 
-    const vec3 indirectLighting = AmbientLighting(
-      material,
+    float environmentVisibility = 1.0;
+    const vec3 indirectLighting = CalculateForwardAmbientLighting(
+      forwardMaterial,
       F0,
       Lr,
       normal,
@@ -679,18 +153,15 @@ glslFragment: |
       vin.worldPosition,
       -viewDirection,
       cosLo,
-      viewportUv);
+      viewportUv,
+      environmentVisibility);
     outColor.xyz = indirectLighting;
 
     if(bEvaluateDirectLighting)
     {
-      for(int i = 0; i < numLights; i++)
+      for(uint i = 0u; i < lightList.count; ++i)
       {
-    #ifdef SUPPORT_LIGHTS_OVERFLOW
-        uint index = lightsOverflow ? uint(i) : culledLights.indices[offset + i];
-    #else
-        uint index = culledLights.indices[offset + i];
-    #endif
+        const uint index = ResolveForwardLightIndex(lightList, i);
         if(index == uint(-1) ||
             index >= uint(light.instance.length()) ||
             light.instance[index].type == INVALID_LIGHT_TYPE)
@@ -698,7 +169,15 @@ glslFragment: |
             continue;
         }
 
-        outColor.xyz += CalculateLighting(light.instance[index], index, material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
+        outColor.xyz += CalculateForwardPbrLighting(
+          light.instance[index],
+          index,
+          forwardMaterial,
+          F0,
+          -viewDirection,
+          cosLo,
+          normal,
+          vin.worldPosition);
       }
       outColor.xyz = indirectLighting +
         (outColor.xyz - indirectLighting) *

--- a/Content/Shaders/Standard.shader
+++ b/Content/Shaders/Standard.shader
@@ -4,6 +4,7 @@ includes:
 - Shaders/Math.glsl
 - Shaders/Lighting.glsl
 - Shaders/GlobalIllumination.glsl
+- Shaders/ForwardLighting.glsl
 
 defines:
 - ALPHA_CUTOUT
@@ -34,154 +35,23 @@ glslVertex: |
     mat3 tangentBasis;
   } vout;
   
-  struct PerInstanceData
-  {
-      mat4 model;
-      vec4 sphereBounds;
-      uint materialInstance;
-      uint skeletonOffset;
-      uint isCulled;
-      uint padding;
-      vec4 bakedVolumeScale;
-  };
-  
-  struct MaterialData
-  {
-    vec4 albedo;
-    vec4 ambient;
-    vec4 emission;
-    
-    float metallic;
-    float roughness;
-    float ao;
-    
-    uint albedoSampler;
-    uint metalnessSampler;
-    uint normalSampler;
-    uint roughnessSampler;
-  };
-  
-  layout(set = 0, binding = 0) uniform FrameData
-  {
-      mat4 view;
-      mat4 projection;
-      mat4 invProjection;
-      vec4 cameraPosition;
-      ivec2 viewportSize;
-      vec2 cameraZNearZFar;
-      float currentTime;
-      float deltaTime;
-  } frame;
-  
-  layout(set = 0, binding = 1) uniform PreviousFrameData
-  {
-      mat4 view;
-      mat4 projection;
-      mat4 invProjection;
-      vec4 cameraPosition;
-      ivec2 viewportSize;
-      vec2 cameraZNearZFar;
-      float currentTime;
-      float deltaTime;
-  } previousFrame;
-  
-  layout(std430, set = 1, binding = 0) readonly buffer LightDataSSBO
-  {  
-    LightData instance[];
-  } light;
-  
-  layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
-  {
-      uint indices[MAX_TEXTURES_IN_SCENE];
-  } culledLights;
-  
-  layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
-  {
-      LightsGrid instance[];
-  } lightsGrid;
-  
-  layout(set=1, binding=3) uniform samplerCube g_irradianceCubemap;
-  layout(set=1, binding=4) uniform sampler2D   g_brdfSampler;
-  layout(set=1, binding=5) uniform samplerCube g_envCubemap;
-
-  layout(std430, set = 1, binding = 6) readonly buffer LightsMatricesSSBO
-  {
-      mat4 instance[];
-  } lightsMatrices;
-
-  layout(std430, set = 1, binding = 7) readonly buffer ShadowIndicesSSBO
-  {
-      uint instance[];
-  } shadowIndices;
-
-  layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
-
-     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
-     {
-         uint instance[];
-     } shadowAtlasTiles;
-
-  layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
-  {
-      PerInstanceData instance[];
-  } data;
-
-  layout(std430, set = 2, binding = 1) readonly buffer InstanceIndicesSSBO
-  {
-      uint instance[];
-  } instanceIndices;
-  
-  layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
-  {
-      MaterialData instance[];
-  } material;
-  
-  #if defined(SAILOR_TEXTURE_REMAP)
-  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
-  {
-      uint indices[MAX_TEXTURES_IN_SCENE];
-  } textureSamplerRemap;
-  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
-  #else
-  layout(set=4, binding=0) uniform sampler2D textureSamplers[];
-  #endif
-  
   void main() 
   {
     uint instanceIndex = instanceIndices.instance[gl_InstanceIndex];
     mat4 modelMatrix = data.instance[instanceIndex].model;
-    vec4 vertexPosition = modelMatrix * vec4(inPosition, 1.0);
-    vout.worldPosition = vertexPosition.xyz / vertexPosition.w;
-
-    gl_Position = frame.projection * (frame.view * vertexPosition);
-
-    mat3 linearMatrix = mat3(modelMatrix);
-    mat3 normalMatrix = transpose(inverse(linearMatrix));
-    vec3 normal = normalize(normalMatrix * inNormal);
-
-    vec3 tangent = linearMatrix * inTangent;
-    tangent -= normal * dot(normal, tangent);
-    float tangentLengthSquared = dot(tangent, tangent);
-    if(tangentLengthSquared > 1e-8)
-    {
-      tangent *= inversesqrt(tangentLengthSquared);
-    }
-    else
-    {
-      vec3 fallbackAxis = abs(normal.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
-      tangent = normalize(cross(fallbackAxis, normal));
-    }
-
-    vec3 transformedBitangent = linearMatrix * inBitangent;
-    float handedness = dot(cross(normal, tangent), transformedBitangent) < 0.0 ? -1.0 : 1.0;
-    vec3 bitangent = normalize(cross(normal, tangent)) * handedness;
+    BuildForwardVertexFrame(
+      modelMatrix,
+      inPosition,
+      inNormal,
+      inTangent,
+      inBitangent,
+      vout.worldPosition,
+      vout.normal,
+      vout.tangentBasis);
 
     vout.color = inColor;
-    vout.normal = normal;
     vout.texcoord = inTexcoord;
     materialInstance = data.instance[instanceIndex].materialInstance;
-    vout.tangentBasis = mat3(tangent, bitangent, normal);
   }
 
 glslFragment: |
@@ -199,17 +69,6 @@ glslFragment: |
   
   layout(location=0) out vec4 outColor;
   
-  struct PerInstanceData
-  {
-      mat4 model;
-      vec4 sphereBounds;
-      uint materialInstance;
-      uint skeletonOffset;
-      uint isCulled;
-      uint padding;
-      vec4 bakedVolumeScale;
-  };
-  
   struct MaterialData
   {
     vec4 albedo;
@@ -226,380 +85,16 @@ glslFragment: |
     uint roughnessSampler;
   };
   
-  layout(set = 0, binding = 0) uniform FrameData
-  {
-      mat4 view;
-      mat4 projection;
-      mat4 invProjection;
-      vec4 cameraPosition;
-      ivec2 viewportSize;
-      vec2 cameraZNearZFar;
-      float currentTime;
-      float deltaTime;
-  } frame;
-  
-  layout(set = 0, binding = 1) uniform PreviousFrameData
-  {
-      mat4 view;
-      mat4 projection;
-      mat4 invProjection;
-      vec4 cameraPosition;
-      ivec2 viewportSize;
-      vec2 cameraZNearZFar;
-      float currentTime;
-      float deltaTime;
-  } previousFrame;
-  
-  layout(std430, set = 1, binding = 0) readonly buffer LightDataSSBO
-  {  
-    LightData instance[];
-  } light;
-  
-  layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
-  {
-      uint indices[];
-  } culledLights;
-  
-  layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
-  {
-      LightsGrid instance[];
-  } lightsGrid;
-  
-  layout(set=1, binding=3) uniform samplerCube g_irradianceCubemap;
-  layout(set=1, binding=4) uniform sampler2D   g_brdfSampler;
-  layout(set=1, binding=5) uniform samplerCube g_envCubemap;
-
-  layout(std430, set = 1, binding = 6) readonly buffer LightsMatricesSSBO
-  {
-      mat4 instance[];
-  } lightsMatrices;
-  
-  layout(std430, set = 1, binding = 7) readonly buffer ShadowIndicesSSBO
-  {
-      uint instance[];
-  } shadowIndices;
-
-  layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
-
-     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
-     {
-         uint instance[];
-     } shadowAtlasTiles;
-  
-  layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
-  {
-      PerInstanceData instance[];
-  } data;
-  
   layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
   {
       MaterialData instance[];
   } material;
-  
-  //layout(set=3, binding=1) uniform sampler2D albedoSampler;
-  //layout(set=3, binding=2) uniform sampler2D metalnessSampler;
-  //layout(set=3, binding=3) uniform sampler2D normalSampler;
-  //layout(set=3, binding=4) uniform sampler2D roughnessSampler;
-  
-  #if defined(SAILOR_TEXTURE_REMAP)
-  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
-  {
-      uint indices[];
-  } textureSamplerRemap;
-  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
-  #else
-  layout(set=4, binding=0) uniform sampler2D textureSamplers[];
-  #endif
-
-  uint ResolveTextureSamplerIndex(uint globalTextureIndex)
-  {
-  #if defined(SAILOR_TEXTURE_REMAP)
-      return textureSamplerRemap.indices[globalTextureIndex];
-  #else
-      return globalTextureIndex;
-  #endif
-  }
   
   MaterialData GetMaterialData()
   {
       return material.instance[materialInstance];
   }
 
-  float CalculateCascadedDirectionalShadow(
-    LightData light,
-    vec3 worldPosition,
-    vec3 surfaceNormal,
-    vec3 surfaceToLightDirection)
-  {
-    const uint activeCascadeCount = clamp(
-      light.activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
-    const int cascadeLayer = SelectCascade(
-      frame.view, worldPosition, frame.cameraZNearZFar, activeCascadeCount);
-    if(cascadeLayer >= int(activeCascadeCount))
-    {
-      return 1.0f;
-    }
-
-    const uint cascadeShadowType = GetDirectionalCascadeShadowType(
-      light.shadowType,
-      cascadeLayer);
-    const vec3 shadowReceiverPosition = OffsetDirectionalShadowReceiver(
-      worldPosition,
-      surfaceNormal,
-      surfaceToLightDirection,
-      GetDirectionalShadowReceiverBiasScale(
-        cascadeShadowType,
-        light.shadowBias));
-    const mat4 cascadeLightMatrix = lightsMatrices.instance[cascadeLayer];
-    float shadow = CalculateDirectionalShadow(
-      cascadeShadowType,
-      shadowMaps[cascadeLayer],
-      cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f),
-      cascadeLayer);
-
-    const float cascadeBlend = CalculateCascadeBlend(
-      frame.view,
-      worldPosition,
-      frame.cameraZNearZFar,
-      cascadeLayer,
-      activeCascadeCount);
-    if(cascadeBlend > 0.0f)
-    {
-      const int nextCascadeLayer = cascadeLayer + 1;
-      const uint nextCascadeShadowType = GetDirectionalCascadeShadowType(
-        light.shadowType,
-        nextCascadeLayer);
-      const vec3 nextShadowReceiverPosition = OffsetDirectionalShadowReceiver(
-        worldPosition,
-        surfaceNormal,
-        surfaceToLightDirection,
-        GetDirectionalShadowReceiverBiasScale(
-          nextCascadeShadowType,
-          light.shadowBias));
-      const mat4 nextCascadeLightMatrix = lightsMatrices.instance[nextCascadeLayer];
-      const float nextShadow = CalculateDirectionalShadow(
-        nextCascadeShadowType,
-        shadowMaps[nextCascadeLayer],
-        nextCascadeLightMatrix * vec4(nextShadowReceiverPosition, 1.0f),
-        nextCascadeLayer);
-      shadow = mix(shadow, nextShadow, cascadeBlend);
-    }
-
-    const float shadowDistanceFade = CalculateShadowDistanceFade(
-      frame.view,
-      worldPosition,
-      frame.cameraZNearZFar,
-      cascadeLayer,
-      activeCascadeCount);
-    shadow = mix(shadow, 1.0f, shadowDistanceFade);
-
-    return shadow;
-  }
-
-  float CalculateLocalLightShadow(
-    LightData light,
-    uint lightIndex,
-    vec3 worldPosition,
-    vec3 surfaceNormal,
-    vec3 surfaceToLightDirection)
-  {
-    const uint packedShadowIndex = shadowIndices.instance[lightIndex];
-    if(light.shadowType == SHADOW_TYPE_NONE ||
-       packedShadowIndex == INVALID_SHADOW_MAP_INDEX)
-    {
-      return 1.0f;
-    }
-
-    uint shadowMapIndex = packedShadowIndex & SHADOW_MAP_INDEX_MASK;
-    if(light.type == 1u)
-    {
-      shadowMapIndex += SelectPointShadowFace(worldPosition - light.worldPosition);
-    }
-    if(shadowMapIndex >= MAX_SHADOWS_IN_VIEW)
-    {
-      return 1.0f;
-    }
-
-    const uint packedAtlasTile = shadowAtlasTiles.instance[shadowMapIndex];
-    const uint shadowSamplerIndex = NUM_CSM_CASCADES + DecodeShadowAtlasIndex(packedAtlasTile);
-    if(shadowSamplerIndex >= MAX_SHADOW_MAP_SAMPLERS)
-    {
-      return 1.0f;
-    }
-
-    return CalculateLocalPcfShadow(
-      shadowMaps[nonuniformEXT(shadowSamplerIndex)],
-      lightsMatrices.instance[shadowMapIndex],
-      DecodeShadowAtlasRect(packedAtlasTile),
-      worldPosition,
-      surfaceNormal,
-      surfaceToLightDirection,
-      length(light.worldPosition - worldPosition),
-      (packedShadowIndex & SOFT_SHADOW_MAP_BIT) != 0u,
-      light.shadowBias);
-  }
-  
-  const float Epsilon = 0.00001;
-  vec3 CalculateLighting(LightData light, uint lightIndex, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
-  {
-    float falloff = 1.0f;
-    float attenuation = 1.0;
-    float shadow = 1.0f;
-    vec3 Li = -light.direction;
-    
-    // Directional light
-    if(light.type == 0)
-    {
-        attenuation = 1.0;
-      
-        shadow = CalculateCascadedDirectionalShadow(
-          light,
-          worldPos,
-          normal,
-          -light.direction);
-    }
-    // Point light
-    else if(light.type == 1)
-    {
-      // Attenuation
-      const float distance    = length(light.worldPosition - worldPos);
-      falloff = CalculateLocalLightRangeAttenuation(light, distance);
-      Li = normalize(light.worldPosition - worldPos);
-      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
-    }
-    // Spot light
-    else if(light.type == 2)
-    {
-      // Attenuation
-      vec3 lightDir = normalize(light.worldPosition - worldPos);
-      Li = lightDir;
-      float epsilon   = light.cutOff.x - light.cutOff.y;
-      float theta = dot(lightDir, normalize(-light.direction));
-      const float distance    = length(light.worldPosition - worldPos);
-      falloff = CalculateLocalLightRangeAttenuation(light, distance) *
-        clamp((theta - light.cutOff.y) / epsilon, 0.0, 1.0);
-      
-      if(theta < light.cutOff.y)
-      {
-        falloff = 0.0f;
-      }
-
-      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
-    }
-    vec3 Lradiance = light.intensity;
-
-    // Half-vector between Li and Lo.
-    vec3 Lh = normalize(Li + Lo);
-
-    // Calculate angles between surface normal and various light vectors.
-    float cosLi = max(0.0, dot(normal, Li));
-    float cosLh = max(0.0, dot(normal, Lh));
-
-    // Calculate Fresnel term for direct lighting. 
-    vec3 F  = FresnelSchlick(F0, max(0.0, dot(Lh, Lo)));
-    // Calculate normal distribution for specular BRDF.
-    float D = NdfGGX(cosLh, material.roughness);
-    // Calculate geometric attenuation for specular BRDF.
-    float G = GeometrySchlickGGX(cosLi, cosLo, material.roughness);
-
-    // Diffuse scattering happens due to light being refracted multiple times by a dielectric medium.
-    // Metals on the other hand either reflect or absorb energy, so diffuse contribution is always zero.
-    // To be energy conserving we must scale diffuse BRDF contribution based on Fresnel factor & metalness.
-    vec3 kd = mix(vec3(1.0) - F, vec3(0.0), material.metallic);
-
-    // Lambert diffuse BRDF.
-    // We don't scale by 1/PI for lighting & material units to be more convenient.
-    // See: https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/
-    vec3 diffuseBRDF = kd * material.albedo.xyz;
-
-    // Cook-Torrance specular microfacet BRDF.
-    vec3 specularBRDF = (F * D * G) / max(Epsilon, 4.0 * cosLi * cosLo);
-
-    // Total contribution for this light.
-    return shadow * ((diffuseBRDF + specularBRDF) * Lradiance * cosLi) * falloff;    
-  }
-  
-  vec3 AmbientLighting(
-    MaterialData material,
-    vec3 F0,
-    vec3 Lr,
-    vec3 normal,
-    vec3 geometricNormal,
-    vec3 worldPosition,
-    vec3 surfaceToCamera,
-    float cosLo,
-    vec2 screenUv)
-  {
-    // Baked probes replace diffuse environment irradiance only. Specular IBL
-    // remains sourced from the pre-filtered environment cubemap.
-    GlobalIlluminationSampleDebug globalIlluminationDebug;
-    float environmentVisibility = 1.0;
-    vec3 irradiance = vec3(0.0);
-    if(!TryResolveGlobalIlluminationDiffuseIrradiance(
-      screenUv,
-      worldPosition,
-      normal,
-      geometricNormal,
-      surfaceToCamera,
-      Lr,
-      irradiance,
-      environmentVisibility,
-      globalIlluminationDebug))
-    {
-      irradiance = texture(g_irradianceCubemap, normal).rgb;
-    }
-    if(GlobalIlluminationDebugUsesProbeData())
-    {
-      return irradiance;
-    }
-    
-    // Calculate Fresnel term for ambient lighting.
-    // Since we use pre-filtered cubemap(s) and irradiance is coming from many directions
-    // use cosLo instead of angle with light's half-vector (cosLh above).
-    // See: https://seblagarde.wordpress.com/2011/08/17/hello-world/
-    vec3 F = FresnelSchlick(F0, cosLo);
-    
-    // Get diffuse contribution factor (as with direct lighting).
-    vec3 kd = mix(vec3(1.0) - F, vec3(0.0), material.metallic);
-    
-    // Irradiance map contains exitant radiance assuming Lambertian BRDF, no need to scale by 1/PI here either.
-    vec3 diffuseIBL = kd * material.albedo.xyz * irradiance;
-
-    float ambientOcclusion = clamp(material.ao, 0.0, 1.0);
-    if(globalIlluminationHeader.stateAndDebug.z ==
-      GLOBAL_ILLUMINATION_DEBUG_INDIRECT_ONLY)
-    {
-      return diffuseIBL * ambientOcclusion;
-    }
-    
-    // Sample pre-filtered specular reflection environment at correct mipmap level.
-    int specularTextureLevels = textureQueryLevels(g_envCubemap);
-    vec3 specularIrradiance = textureLod(g_envCubemap, Lr, material.roughness * specularTextureLevels).rgb;
-    
-    // Split-sum approximation factors for Cook-Torrance specular BRDF.
-    vec2 specularBRDF = texture(g_brdfSampler, vec2(cosLo, material.roughness)).rg;
-    
-    // Total specular IBL contribution.
-    vec3 specularIBL = (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance;
-
-    // Ambient occlusion applies to all indirect lighting. Use a view- and
-    // roughness-dependent approximation for specular IBL so smooth surfaces
-    // retain plausible reflections without leaking them into occluded areas.
-    float specularOcclusion = CalculateSpecularOcclusion(
-      min(ambientOcclusion, environmentVisibility),
-      cosLo,
-      material.roughness);
-    vec3 indirectLighting = diffuseIBL * ambientOcclusion +
-      specularIBL * specularOcclusion;
-    return ApplyGlobalIlluminationDebug(
-      indirectLighting,
-      globalIlluminationDebug);
-  }
-  
-  // Constant normal incidence Fresnel factor for all dielectrics.
-  const vec3 Fdielectric = vec3(0.04);
-  
   void main() 
   {
     const vec3 viewDirection = normalize(vin.worldPosition - frame.cameraPosition.xyz);
@@ -640,9 +135,13 @@ glslFragment: |
       const vec3 tangentNormal = normalize(2.0 * texture(textureSamplers[nonuniformEXT(ResolveTextureSamplerIndex(material.normalSampler))], vin.texcoord).rgb - 1.0);
       normal = normalize(vin.tangentBasis * tangentNormal);
     }
-    
-    //outColor.xyz = AmbientLighting(material, vin.normal, vin.worldPosition, viewDirection);
-    outColor.xyz = vec3(0);
+
+    const ForwardPbrMaterial forwardMaterial = ForwardPbrMaterial(
+      material.albedo.xyz,
+      material.metallic,
+      material.roughness,
+      material.ao,
+      1.0);
     
     // Angle between surface normal and outgoing light direction.
     float cosLo = max(0.0, dot(normal, -viewDirection));
@@ -653,42 +152,17 @@ glslFragment: |
     // Fresnel reflectance at normal incidence (for metals use albedo color).
     vec3 F0 = mix(Fdielectric, material.albedo.xyz, material.metallic);
     
-    //outColor.xyz += vec3(texture(g_envCubemap, R).xyz);
-    //outColor.xyz *= max(0.1, dot(normalize(-vec3(-0.3, -0.5, 0.1)), vin.normal.xyz)) * 0.5;
-  
     const bool bEvaluateDirectLighting =
       !GlobalIlluminationDebugSuppressesDirectLighting();
-    uint offset = 0u;
-    bool lightsOverflow = false;
-    uint numLights = 0u;
+    ForwardLightList lightList = ForwardLightList(0u, 0u, false);
     if(bEvaluateDirectLighting)
     {
-      const uint tileIndex = GetLightTileIndex(
-        gl_FragCoord.xy,
-        frame.viewportSize);
-      const uint gridLength = uint(lightsGrid.instance.length());
-      const bool hasLightTile = tileIndex < gridLength;
-      offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0u;
-      const uint listLength = uint(culledLights.indices.length());
-      const uint availableLights = offset < listLength
-        ? listLength - offset
-        : 0u;
-      const uint packedNumLights = hasLightTile
-        ? lightsGrid.instance[tileIndex].num
-        : 0u;
-      lightsOverflow =
-        (packedNumLights & LIGHT_TILE_OVERFLOW_BIT) != 0u;
-      numLights = !hasLightTile ? 0u :
-    #ifdef SUPPORT_LIGHTS_OVERFLOW
-        (lightsOverflow ? min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(light.instance.length())) :
-            min(packedNumLights & LIGHT_TILE_COUNT_MASK, availableLights));
-    #else
-        min(min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(LIGHTS_PER_TILE)), availableLights);
-    #endif
+      lightList = ResolveForwardLightList(gl_FragCoord.xy);
     }
-    
-    const vec3 indirectLighting = AmbientLighting(
-      material,
+
+    float environmentVisibility = 1.0;
+    const vec3 indirectLighting = CalculateForwardAmbientLighting(
+      forwardMaterial,
       F0,
       Lr,
       normal,
@@ -696,18 +170,15 @@ glslFragment: |
       vin.worldPosition,
       -viewDirection,
       cosLo,
-      viewportUv);
+      viewportUv,
+      environmentVisibility);
     outColor.xyz = indirectLighting;
     
     if(bEvaluateDirectLighting)
     {
-      for(int i = 0; i < numLights; i++)
+      for(uint i = 0u; i < lightList.count; ++i)
       {
-    #ifdef SUPPORT_LIGHTS_OVERFLOW
-        uint index = lightsOverflow ? uint(i) : culledLights.indices[offset + i];
-    #else
-        uint index = culledLights.indices[offset + i];
-    #endif
+        const uint index = ResolveForwardLightIndex(lightList, i);
         if(index == uint(-1) ||
             index >= uint(light.instance.length()) ||
             light.instance[index].type == INVALID_LIGHT_TYPE)
@@ -715,7 +186,15 @@ glslFragment: |
             continue;
         }
 
-        outColor.xyz += CalculateLighting(light.instance[index], index, material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
+        outColor.xyz += CalculateForwardPbrLighting(
+          light.instance[index],
+          index,
+          forwardMaterial,
+          F0,
+          -viewDirection,
+          cosLo,
+          normal,
+          vin.worldPosition);
       }
       outColor.xyz = indirectLighting +
         (outColor.xyz - indirectLighting) *

--- a/Content/Shaders/Standard_glTF.shader
+++ b/Content/Shaders/Standard_glTF.shader
@@ -4,6 +4,7 @@ includes:
 - Shaders/Math.glsl
 - Shaders/Lighting.glsl
 - Shaders/GlobalIllumination.glsl
+- Shaders/ForwardLighting.glsl
 
 defines:
  - ALPHA_CUTOUT
@@ -45,58 +46,6 @@ glslVertex: |
   #endif
   } vout;
   
-  struct PerInstanceData
-  {
-    mat4 model;
-    vec4 sphereBounds;
-    uint materialInstance;
-    uint skeletonOffset;
-    uint isCulled;
-    uint padding;
-    vec4 bakedVolumeScale;
-  };
-  
-  struct MaterialData
-  {
-    vec4 baseColorFactor;
-    vec4 emissiveFactor;
-
-    float metallicFactor;
-    float roughnessFactor;
-    float occlusionStrength;
-    float normalScale;
-    float alphaCutoff;
-
-    uint baseColorSampler;
-    uint normalSampler;
-    uint ormSampler;
-    uint occlusionSampler;
-    uint emissiveSampler;
-
-    float clearcoatFactor;
-    float clearcoatRoughnessFactor;
-    float clearcoatNormalScale;
-
-    float sheenRoughnessFactor;
-    vec4 sheenColorFactor;
-
-    uint clearcoatSampler;
-    uint clearcoatRoughnessSampler;
-    uint clearcoatNormalSampler;
-    uint sheenColorSampler;
-    uint sheenRoughnessSampler;
-
-  #ifdef TRANSMISSION
-    float transmissionFactor;
-    uint transmissionSampler;
-    float thicknessFactor;
-    float attenuationDistance;
-    float indexOfRefraction;
-    uint thicknessSampler;
-    vec4 attenuationColor;
-  #endif
-  };
-
   struct BoneData
   {
     mat4 matrix;
@@ -104,92 +53,6 @@ glslVertex: |
 
   const uint INVALID_SKELETON_OFFSET = 0xFFFFFFFFu;
   
-  layout(set = 0, binding = 0) uniform FrameData
-  {
-    mat4 view;
-    mat4 projection;
-    mat4 invProjection;
-    vec4 cameraPosition;
-    ivec2 viewportSize;
-    vec2 cameraZNearZFar;
-    float currentTime;
-    float deltaTime;
-  } frame;
-  
-  layout(set = 0, binding = 1) uniform PreviousFrameData
-  {
-    mat4 view;
-    mat4 projection;
-    mat4 invProjection;
-    vec4 cameraPosition;
-    ivec2 viewportSize;
-    vec2 cameraZNearZFar;
-    float currentTime;
-    float deltaTime;
-  } previousFrame;
-  
-  layout(std430, set = 1, binding = 0) readonly buffer LightDataSSBO
-  {  
-    LightData instance[];
-  } light;
-  
-  layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
-  {
-      uint indices[MAX_TEXTURES_IN_SCENE];
-  } culledLights;
-  
-  layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
-  {
-      LightsGrid instance[];
-  } lightsGrid;
-  
-  layout(set=1, binding=3) uniform samplerCube g_irradianceCubemap;
-  layout(set=1, binding=4) uniform sampler2D   g_brdfSampler;
-  layout(set=1, binding=5) uniform samplerCube g_envCubemap;
-
-  layout(std430, set = 1, binding = 6) readonly buffer LightsMatricesSSBO
-  {
-      mat4 instance[];
-  } lightsMatrices;
-
-  layout(std430, set = 1, binding = 7) readonly buffer ShadowIndicesSSBO
-  {
-      uint instance[];
-  } shadowIndices;
-
-  layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
-
-     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
-     {
-         uint instance[];
-     } shadowAtlasTiles;
-
-  layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
-  {
-      PerInstanceData instance[];
-  } data;
-
-  layout(std430, set = 2, binding = 1) readonly buffer InstanceIndicesSSBO
-  {
-      uint instance[];
-  } instanceIndices;
-  
-  layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
-  {
-      MaterialData instance[];
-  } material;
-  
-  #if defined(SAILOR_TEXTURE_REMAP)
-  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
-  {
-      uint indices[MAX_TEXTURES_IN_SCENE];
-  } textureSamplerRemap;
-  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
-  #else
-  layout(set=4, binding=0) uniform sampler2D textureSamplers[];
-  #endif
-
   #ifdef SKINNING
   layout(std430, set = 5, binding = 0) readonly buffer BoneMatricesSSBO
   {
@@ -223,34 +86,15 @@ glslVertex: |
     }
   #endif
 
-    vec4 vertexPosition = modelMatrix * vec4(inPosition, 1.0);
-    vout.worldPosition = vertexPosition.xyz / vertexPosition.w;
-
-    gl_Position = frame.projection * (frame.view * vertexPosition);
-
-    mat3 linearMatrix = mat3(modelMatrix);
-    mat3 normalMatrix = transpose(inverse(linearMatrix));
-    vec3 normal = normalize(normalMatrix * inNormal);
-
-    vec3 tangent = linearMatrix * inTangent;
-    tangent -= normal * dot(normal, tangent);
-    float tangentLengthSquared = dot(tangent, tangent);
-    if(tangentLengthSquared > 1e-8)
-    {
-      tangent *= inversesqrt(tangentLengthSquared);
-    }
-    else
-    {
-      vec3 fallbackAxis = abs(normal.y) < 0.999 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
-      tangent = normalize(cross(fallbackAxis, normal));
-    }
-
-    vec3 transformedBitangent = linearMatrix * inBitangent;
-    float handedness = dot(cross(normal, tangent), transformedBitangent) < 0.0 ? -1.0 : 1.0;
-    vec3 bitangent = normalize(cross(normal, tangent)) * handedness;
-
-    vout.normal = normal;
-    vout.tangentBasis = mat3(tangent, bitangent, normal);
+    BuildForwardVertexFrame(
+      modelMatrix,
+      inPosition,
+      inNormal,
+      inTangent,
+      inBitangent,
+      vout.worldPosition,
+      vout.normal,
+      vout.tangentBasis);
 
     vout.color = inColor;
     vout.texcoord = inTexcoord;
@@ -274,17 +118,6 @@ glslFragment: |
   } vin;
   
   layout(location=0) out vec4 outColor;
-  
-  struct PerInstanceData
-  {
-      mat4 model;
-      vec4 sphereBounds;
-      uint materialInstance;
-      uint skeletonOffset;
-      uint isCulled;
-      uint padding;
-      vec4 bakedVolumeScale;
-  };
   
   struct MaterialData
   {
@@ -327,229 +160,15 @@ glslFragment: |
   #endif
   };
   
-  layout(set = 0, binding = 0) uniform FrameData
-  {
-      mat4 view;
-      mat4 projection;
-      mat4 invProjection;
-      vec4 cameraPosition;
-      ivec2 viewportSize;
-      vec2 cameraZNearZFar;
-      float currentTime;
-      float deltaTime;
-  } frame;
-  
-  layout(set = 0, binding = 1) uniform PreviousFrameData
-  {
-      mat4 view;
-      mat4 projection;
-      mat4 invProjection;
-      vec4 cameraPosition;
-      ivec2 viewportSize;
-      vec2 cameraZNearZFar;
-      float currentTime;
-      float deltaTime;
-  } previousFrame;
-  
-  layout(std430, set = 1, binding = 0) readonly buffer LightDataSSBO
-  {  
-    LightData instance[];
-  } light;
-  
-  layout(std430, set = 1, binding = 1) readonly buffer CulledLightsSSBO
-  {
-      uint indices[];
-  } culledLights;
-  
-  layout(std430, set = 1, binding = 2) readonly buffer LightsGridSSBO
-  {
-      LightsGrid instance[];
-  } lightsGrid;
-  
-  layout(set=1, binding=3) uniform samplerCube g_irradianceCubemap;
-  layout(set=1, binding=4) uniform sampler2D   g_brdfSampler;
-  layout(set=1, binding=5) uniform samplerCube g_envCubemap;
-
-  layout(std430, set = 1, binding = 6) readonly buffer LightsMatricesSSBO
-  {
-      mat4 instance[];
-  } lightsMatrices;
-  
-  layout(std430, set = 1, binding = 7) readonly buffer ShadowIndicesSSBO
-  {
-      uint instance[];
-  } shadowIndices;
-
-  layout(set=1, binding=8) uniform sampler2D g_aoSampler;
-  layout(set=1, binding=9) uniform sampler2D shadowMaps[MAX_SHADOW_MAP_SAMPLERS];
-  #ifdef TRANSMISSION
-  layout(set=1, binding=10) uniform sampler2D g_transmissionFramebufferSampler;
-  #endif
-
-     layout(std430, set = 1, binding = 11) readonly buffer ShadowAtlasTilesSSBO
-     {
-         uint instance[];
-     } shadowAtlasTiles;
-  
-  layout(std430, set = 2, binding = 0) readonly buffer PerInstanceDataSSBO
-  {
-      PerInstanceData instance[];
-  } data;
-  
   layout(std430, set = 3, binding = 0) readonly buffer MaterialDataSSBO
   {
       MaterialData instance[];
   } material;
   
-  //layout(set=3, binding=1) uniform sampler2D albedoSampler;
-  //layout(set=3, binding=2) uniform sampler2D metalnessSampler;
-  //layout(set=3, binding=3) uniform sampler2D normalSampler;
-  //layout(set=3, binding=4) uniform sampler2D roughnessSampler;
-  
-  #if defined(SAILOR_TEXTURE_REMAP)
-  layout(std430, set=4, binding=0) readonly buffer TextureSamplerRemapSSBO
-  {
-      uint indices[];
-  } textureSamplerRemap;
-  layout(set=4, binding=1) uniform sampler2D textureSamplers[];
-  #else
-  layout(set=4, binding=0) uniform sampler2D textureSamplers[];
-  #endif
-
-  uint ResolveTextureSamplerIndex(uint globalTextureIndex)
-  {
-  #if defined(SAILOR_TEXTURE_REMAP)
-      if(globalTextureIndex >= MAX_TEXTURES_IN_SCENE)
-      {
-        return 0;
-      }
-      return textureSamplerRemap.indices[globalTextureIndex];
-  #else
-      return globalTextureIndex;
-  #endif
-  }
-  
   MaterialData GetMaterialData()
   {
       return material.instance[materialInstance];
   }
-
-  float CalculateCascadedDirectionalShadow(
-    LightData light,
-    vec3 worldPosition,
-    vec3 surfaceNormal,
-    vec3 surfaceToLightDirection)
-  {
-    const uint activeCascadeCount = clamp(
-      light.activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
-    const int cascadeLayer = SelectCascade(
-      frame.view, worldPosition, frame.cameraZNearZFar, activeCascadeCount);
-    if(cascadeLayer >= int(activeCascadeCount))
-    {
-      return 1.0f;
-    }
-
-    const uint cascadeShadowType = GetDirectionalCascadeShadowType(
-      light.shadowType,
-      cascadeLayer);
-    const vec3 shadowReceiverPosition = OffsetDirectionalShadowReceiver(
-      worldPosition,
-      surfaceNormal,
-      surfaceToLightDirection,
-      GetDirectionalShadowReceiverBiasScale(
-        cascadeShadowType,
-        light.shadowBias));
-    const mat4 cascadeLightMatrix = lightsMatrices.instance[cascadeLayer];
-    float shadow = CalculateDirectionalShadow(
-      cascadeShadowType,
-      shadowMaps[cascadeLayer],
-      cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0f),
-      cascadeLayer);
-
-    const float cascadeBlend = CalculateCascadeBlend(
-      frame.view,
-      worldPosition,
-      frame.cameraZNearZFar,
-      cascadeLayer,
-      activeCascadeCount);
-    if(cascadeBlend > 0.0f)
-    {
-      const int nextCascadeLayer = cascadeLayer + 1;
-      const uint nextCascadeShadowType = GetDirectionalCascadeShadowType(
-        light.shadowType,
-        nextCascadeLayer);
-      const vec3 nextShadowReceiverPosition = OffsetDirectionalShadowReceiver(
-        worldPosition,
-        surfaceNormal,
-        surfaceToLightDirection,
-        GetDirectionalShadowReceiverBiasScale(
-          nextCascadeShadowType,
-          light.shadowBias));
-      const mat4 nextCascadeLightMatrix = lightsMatrices.instance[nextCascadeLayer];
-      const float nextShadow = CalculateDirectionalShadow(
-        nextCascadeShadowType,
-        shadowMaps[nextCascadeLayer],
-        nextCascadeLightMatrix * vec4(nextShadowReceiverPosition, 1.0f),
-        nextCascadeLayer);
-      shadow = mix(shadow, nextShadow, cascadeBlend);
-    }
-
-    const float shadowDistanceFade = CalculateShadowDistanceFade(
-      frame.view,
-      worldPosition,
-      frame.cameraZNearZFar,
-      cascadeLayer,
-      activeCascadeCount);
-    shadow = mix(shadow, 1.0f, shadowDistanceFade);
-
-    return shadow;
-  }
-
-  float CalculateLocalLightShadow(
-    LightData light,
-    uint lightIndex,
-    vec3 worldPosition,
-    vec3 surfaceNormal,
-    vec3 surfaceToLightDirection)
-  {
-    const uint packedShadowIndex = shadowIndices.instance[lightIndex];
-    if(light.shadowType == SHADOW_TYPE_NONE ||
-       packedShadowIndex == INVALID_SHADOW_MAP_INDEX)
-    {
-      return 1.0f;
-    }
-
-    uint shadowMapIndex = packedShadowIndex & SHADOW_MAP_INDEX_MASK;
-    if(light.type == 1u)
-    {
-      shadowMapIndex += SelectPointShadowFace(worldPosition - light.worldPosition);
-    }
-    if(shadowMapIndex >= MAX_SHADOWS_IN_VIEW)
-    {
-      return 1.0f;
-    }
-
-    const uint packedAtlasTile = shadowAtlasTiles.instance[shadowMapIndex];
-    const uint shadowSamplerIndex = NUM_CSM_CASCADES + DecodeShadowAtlasIndex(packedAtlasTile);
-    if(shadowSamplerIndex >= MAX_SHADOW_MAP_SAMPLERS)
-    {
-      return 1.0f;
-    }
-
-    const vec4 atlasRect = DecodeShadowAtlasRect(packedAtlasTile);
-    return CalculateLocalPcfShadow(
-      shadowMaps[nonuniformEXT(shadowSamplerIndex)],
-      lightsMatrices.instance[shadowMapIndex],
-      atlasRect,
-      worldPosition,
-      surfaceNormal,
-      surfaceToLightDirection,
-      length(light.worldPosition - worldPosition),
-      (packedShadowIndex & SOFT_SHADOW_MAP_BIT) != 0u,
-      light.shadowBias);
-  }
-  
-  const float Epsilon = 0.00001;
 
   #ifdef TRANSMISSION
   float ApplyIorToRoughness(float roughness, float ior)
@@ -617,116 +236,56 @@ glslFragment: |
   }
   #endif
 
-  vec3 CalculateLighting(LightData light, uint lightIndex, MaterialData material, vec3 F0, vec3 Lo,float cosLo, vec3 normal, vec3 worldPos)
+  vec3 CalculateLighting(
+    LightData lightData,
+    uint lightIndex,
+    MaterialData materialData,
+    ForwardPbrMaterial forwardMaterial,
+    vec3 F0,
+    vec3 surfaceToCamera,
+    float cosLo,
+    vec3 normal,
+    vec3 worldPosition)
   {
-    float falloff = 1.0f;
-    float shadow = 1.0f;
-    vec3 pointToLight = light.type == 0 ?
-      -light.direction :
-      light.worldPosition - worldPos;
-    float pointToLightLengthSquared = dot(pointToLight, pointToLight);
-    vec3 Li = pointToLightLengthSquared > Epsilon ?
-      pointToLight * inversesqrt(pointToLightLengthSquared) :
-      vec3(0.0);
-    
-    // Directional light
-    if(light.type == 0)
-    {
-        shadow = CalculateCascadedDirectionalShadow(
-          light,
-          worldPos,
-          normal,
-          Li);
-    }
-    // Point light
-    else if(light.type == 1)
-    {
-      // Attenuation
-      const float distance    = length(pointToLight);
-      falloff = CalculateLocalLightRangeAttenuation(light, distance);
-      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
-    }
-    // Spot light
-    else if(light.type == 2)
-    {
-      // Attenuation
-      vec3 lightDir = Li;
-      float epsilon   = light.cutOff.x - light.cutOff.y;
-      float theta = dot(lightDir, normalize(-light.direction));
-      const float distance    = length(pointToLight);
-      falloff = CalculateLocalLightRangeAttenuation(light, distance) *
-        clamp((theta - light.cutOff.y) / max(epsilon, Epsilon), 0.0, 1.0);
-      
-      if(theta < light.cutOff.y)
-      {
-        falloff = 0.0f;
-      }
-
-      shadow = CalculateLocalLightShadow(light, lightIndex, worldPos, normal, Li);
-    }
-    
-    vec3 Lradiance = light.intensity;
-
-    // Half-vector between Li and Lo.
-    vec3 halfVector = Li + Lo;
-    float halfVectorLengthSquared = dot(halfVector, halfVector);
-    vec3 Lh = halfVectorLengthSquared > Epsilon ?
-      halfVector * inversesqrt(halfVectorLengthSquared) :
-      normal;
-
-    // Calculate angles between surface normal and various light vectors.
-    float cosLi = max(0.0, dot(normal, Li));
-    float cosLh = max(0.0, dot(normal, Lh));
-
-    // Calculate Fresnel term for direct lighting. 
-    vec3 F  = FresnelSchlick(F0, max(0.0, dot(Lh, Lo)));
-    // Calculate normal distribution for specular BRDF.
-    float D = NdfGGX(cosLh, material.roughnessFactor);
-    // Calculate geometric attenuation for specular BRDF.
-    float G = GeometrySchlickGGX(cosLi, cosLo, material.roughnessFactor);
-
-    // Diffuse scattering happens due to light being refracted multiple times by a dielectric medium.
-    // Metals on the other hand either reflect or absorb energy, so diffuse contribution is always zero.
-    // To be energy conserving we must scale diffuse BRDF contribution based on Fresnel factor & metalness.
-    vec3 kd = mix(vec3(1.0) - F, vec3(0.0), material.metallicFactor);
-  #ifdef TRANSMISSION
-    kd *= 1.0 - material.transmissionFactor;
-  #endif
-
-    // Lambert diffuse BRDF.
-    // We don't scale by 1/PI for lighting & material units to be more convenient.
-    // See: https://seblagarde.wordpress.com/2012/01/08/pi-or-not-to-pi-in-game-lighting-equation/
-    vec3 diffuseBRDF = kd * material.baseColorFactor.xyz;
-
-    // Cook-Torrance specular microfacet BRDF.
-    vec3 specularBRDF = (F * D * G) / max(Epsilon, 4.0 * cosLi * cosLo);
-
-    vec3 directLighting =
-      (diffuseBRDF + specularBRDF) * Lradiance * cosLi * falloff;
+    const ForwardLightSample lightSample = ResolveForwardLightSample(
+      lightData,
+      lightIndex,
+      worldPosition,
+      normal);
+    vec3 directLighting = EvaluateForwardPbrDirectLighting(
+      lightSample,
+      forwardMaterial,
+      F0,
+      surfaceToCamera,
+      cosLo,
+      normal);
+    const float falloff = lightSample.falloff;
+    const float shadow = lightSample.shadow;
+    const vec3 lightRadiance = lightSample.radiance;
 
   #ifdef TRANSMISSION
     vec3 refractionNormal = gl_FrontFacing ? normal : -normal;
     vec3 refractionDirection = GetRefractionDirection(
       refractionNormal,
-      Lo,
-      material.indexOfRefraction);
+      surfaceToCamera,
+      materialData.indexOfRefraction);
     vec3 transmissionRay = GetVolumeTransmissionRay(
       refractionDirection,
-      material.thicknessFactor,
+      materialData.thicknessFactor,
       vin.modelScale);
     float transmissionRayLength = length(transmissionRay);
     float canTransmit = step(Epsilon, dot(
       refractionDirection,
       refractionDirection));
-    float dielectricTransmission = material.transmissionFactor *
-      (1.0 - clamp(material.metallicFactor, 0.0, 1.0));
+    float dielectricTransmission = materialData.transmissionFactor *
+      (1.0 - clamp(materialData.metallicFactor, 0.0, 1.0));
 
     if(canTransmit > 0.0 &&
       dielectricTransmission > Epsilon)
     {
-      vec3 exitPointToLight = light.type == 0 ?
-        -light.direction :
-        light.worldPosition - (worldPos + transmissionRay);
+      vec3 exitPointToLight = lightData.type == 0 ?
+        -lightData.direction :
+        lightData.worldPosition - (worldPosition + transmissionRay);
       float exitPointToLightLength = length(exitPointToLight);
       if(exitPointToLightLength > Epsilon)
       {
@@ -742,7 +301,7 @@ glslFragment: |
         {
           vec3 mirroredLi = mirroredLiVector *
             inversesqrt(mirroredLiLengthSquared);
-          vec3 transmissionHalfVector = mirroredLi + Lo;
+          vec3 transmissionHalfVector = mirroredLi + surfaceToCamera;
           float transmissionHalfLengthSquared = dot(
             transmissionHalfVector,
             transmissionHalfVector);
@@ -751,8 +310,8 @@ glslFragment: |
             vec3 transmissionH = transmissionHalfVector *
               inversesqrt(transmissionHalfLengthSquared);
             float alphaRoughness = ApplyIorToRoughness(
-              material.roughnessFactor * material.roughnessFactor,
-              material.indexOfRefraction);
+              materialData.roughnessFactor * materialData.roughnessFactor,
+              materialData.indexOfRefraction);
             float transmissionDistribution = NdfGGXAlpha(
               clamp(dot(refractionNormal, transmissionH), 0.0, 1.0),
               max(alphaRoughness, Epsilon));
@@ -761,7 +320,7 @@ glslFragment: |
               0.0,
               1.0);
             float transmissionCosLo = clamp(
-              dot(refractionNormal, Lo),
+              dot(refractionNormal, surfaceToCamera),
               0.0,
               1.0);
             float transmissionVisibility = VisibilityGGXAlpha(
@@ -769,41 +328,41 @@ glslFragment: |
               transmissionCosLo,
               max(alphaRoughness, Epsilon));
             float dielectricFresnel =
-              (material.indexOfRefraction - 1.0) /
-              (material.indexOfRefraction + 1.0);
+              (materialData.indexOfRefraction - 1.0) /
+              (materialData.indexOfRefraction + 1.0);
             vec3 transmissionFresnel = FresnelSchlick(
               vec3(dielectricFresnel * dielectricFresnel),
-              clamp(abs(dot(Lo, transmissionH)), 0.0, 1.0));
+              clamp(abs(dot(surfaceToCamera, transmissionH)), 0.0, 1.0));
 
             float transmissionFalloff = falloff;
-            if(light.type == 1)
+            if(lightData.type == 1)
             {
               transmissionFalloff = CalculateLocalLightRangeAttenuation(
-                light,
+                lightData,
                 exitPointToLightLength);
             }
-            else if(light.type == 2)
+            else if(lightData.type == 2)
             {
-              float coneRange = light.cutOff.x - light.cutOff.y;
+              float coneRange = lightData.cutOff.x - lightData.cutOff.y;
               float coneCos = dot(
                 transmissionLi,
-                normalize(-light.direction));
+                normalize(-lightData.direction));
               transmissionFalloff = CalculateLocalLightRangeAttenuation(
-                light,
+                lightData,
                 exitPointToLightLength) * clamp(
-                (coneCos - light.cutOff.y) / max(coneRange, Epsilon),
+                (coneCos - lightData.cutOff.y) / max(coneRange, Epsilon),
                 0.0,
                 1.0);
             }
 
             vec3 volumeAttenuation = GetVolumeAttenuation(
               transmissionRayLength,
-              material.attenuationColor.rgb,
-              material.attenuationDistance);
-            directLighting += material.baseColorFactor.rgb *
+              materialData.attenuationColor.rgb,
+              materialData.attenuationDistance);
+            directLighting += materialData.baseColorFactor.rgb *
               transmissionDistribution * transmissionVisibility *
               volumeAttenuation * (vec3(1.0) - transmissionFresnel) *
-              dielectricTransmission * Lradiance * transmissionFalloff;
+              dielectricTransmission * lightRadiance * transmissionFalloff;
           }
         }
       }
@@ -814,87 +373,6 @@ glslFragment: |
     return shadow * directLighting;
   }
   
-  vec3 AmbientLighting(
-    MaterialData material,
-    vec3 F0,
-    vec3 Lr,
-    vec3 normal,
-    vec3 geometricNormal,
-    vec3 worldPosition,
-    vec3 surfaceToCamera,
-    float cosLo,
-    vec2 screenUv,
-    out float environmentVisibility)
-  {
-    // Baked probes replace diffuse environment irradiance only. Specular IBL
-    // remains sourced from the pre-filtered environment cubemap.
-    GlobalIlluminationSampleDebug globalIlluminationDebug;
-    environmentVisibility = 1.0;
-    vec3 irradiance = vec3(0.0);
-    if(!TryResolveGlobalIlluminationDiffuseIrradiance(
-      screenUv,
-      worldPosition,
-      normal,
-      geometricNormal,
-      surfaceToCamera,
-      Lr,
-      irradiance,
-      environmentVisibility,
-      globalIlluminationDebug))
-    {
-      irradiance = texture(g_irradianceCubemap, normal).rgb;
-    }
-    if(GlobalIlluminationDebugUsesProbeData())
-    {
-      return irradiance;
-    }
-    
-    // Calculate Fresnel term for ambient lighting.
-    // Since we use pre-filtered cubemap(s) and irradiance is coming from many directions
-    // use cosLo instead of angle with light's half-vector (cosLh above).
-    // See: https://seblagarde.wordpress.com/2011/08/17/hello-world/
-    vec3 F = FresnelSchlick(F0, cosLo);
-    
-    // Get diffuse contribution factor (as with direct lighting).
-    vec3 kd = mix(vec3(1.0) - F, vec3(0.0), material.metallicFactor);
-  #ifdef TRANSMISSION
-    kd *= 1.0 - material.transmissionFactor;
-  #endif
-    
-    // Irradiance map contains exitant radiance assuming Lambertian BRDF, no need to scale by 1/PI here either.
-    vec3 diffuseIBL = kd * material.baseColorFactor.xyz * irradiance;
-
-    float ambientOcclusion = clamp(material.occlusionStrength, 0.0, 1.0);
-    if(globalIlluminationHeader.stateAndDebug.z ==
-      GLOBAL_ILLUMINATION_DEBUG_INDIRECT_ONLY)
-    {
-      return diffuseIBL * ambientOcclusion;
-    }
-    
-    // Sample pre-filtered specular reflection environment at correct mipmap level.
-    int specularTextureLevels = textureQueryLevels(g_envCubemap);
-    vec3 specularIrradiance = textureLod(g_envCubemap, Lr, material.roughnessFactor * specularTextureLevels).rgb;
-    
-    // Split-sum approximation factors for Cook-Torrance specular BRDF.
-    vec2 specularBRDF = texture(g_brdfSampler, vec2(cosLo, material.roughnessFactor)).rg;
-    
-    // Total specular IBL contribution.
-    vec3 specularIBL = (F0 * specularBRDF.x + specularBRDF.y) * specularIrradiance;
-
-    // Apply visibility directly to diffuse IBL and use a view- and
-    // roughness-aware approximation for specular IBL. The bounded analytic
-    // contact term is composed separately after direct-light accumulation.
-    float specularOcclusion = CalculateSpecularOcclusion(
-      min(ambientOcclusion, environmentVisibility),
-      cosLo,
-      material.roughnessFactor);
-    vec3 indirectLighting = diffuseIBL * ambientOcclusion +
-      specularIBL * specularOcclusion;
-    return ApplyGlobalIlluminationDebug(
-      indirectLighting,
-      globalIlluminationDebug);
-  }
-
   #ifdef CLEAR_COAT
   vec3 ClearCoatLighting(LightData light, float roughness, vec3 F0, vec3 Lo, float cosLo, vec3 normal, vec3 worldPos)
   {
@@ -1009,9 +487,6 @@ glslFragment: |
   }
   #endif
   
-  // Constant normal incidence Fresnel factor for all dielectrics.
-  const vec3 Fdielectric = vec3(0.04);
-  
   void main() 
   {
     const vec3 viewDirection = normalize(vin.worldPosition - frame.cameraPosition.xyz);
@@ -1096,6 +571,17 @@ glslFragment: |
     material.attenuationColor = clamp(material.attenuationColor, vec4(0.0), vec4(1.0));
   #endif
 
+    float diffuseWeight = 1.0;
+  #ifdef TRANSMISSION
+    diffuseWeight -= material.transmissionFactor;
+  #endif
+    const ForwardPbrMaterial forwardMaterial = ForwardPbrMaterial(
+      material.baseColorFactor.xyz,
+      material.metallicFactor,
+      material.roughnessFactor,
+      material.occlusionStrength,
+      diffuseWeight);
+
     const vec3 geometricNormal = normalize(vin.normal);
     vec3 normal;
     if(material.normalSampler != 0)
@@ -1121,7 +607,6 @@ glslFragment: |
     vec3 LrCC = 2.0 * cosLoCC * clearcoatNormal + viewDirection;
   #endif
     
-    //outColor.xyz = AmbientLighting(material, vin.normal, vin.worldPosition, viewDirection);
     outColor.xyz = vec3(material.emissiveFactor.xyz);
     
     // Angle between surface normal and outgoing light direction.
@@ -1138,43 +623,17 @@ glslFragment: |
     vec3 F0 = mix(Fdielectric, material.baseColorFactor.xyz, material.metallicFactor);
   #endif
     
-    //outColor.xyz += vec3(texture(g_envCubemap, R).xyz);
-    //outColor.xyz *= max(0.1, dot(normalize(-vec3(-0.3, -0.5, 0.1)), vin.normal.xyz)) * 0.5;
-  
     const bool bEvaluateDirectLighting =
       !GlobalIlluminationDebugSuppressesDirectLighting();
-    uint offset = 0u;
-    bool lightsOverflow = false;
-    uint numLights = 0u;
+    ForwardLightList lightList = ForwardLightList(0u, 0u, false);
     if(bEvaluateDirectLighting)
     {
-      const uint tileIndex = GetLightTileIndex(
-        gl_FragCoord.xy,
-        frame.viewportSize);
-      const uint gridLength = uint(lightsGrid.instance.length());
-      const bool hasLightTile = tileIndex < gridLength;
-      offset = hasLightTile ? lightsGrid.instance[tileIndex].offset : 0u;
-      const uint listLength = uint(culledLights.indices.length());
-      const uint availableLights = offset < listLength
-        ? listLength - offset
-        : 0u;
-      const uint packedNumLights = hasLightTile
-        ? lightsGrid.instance[tileIndex].num
-        : 0u;
-      lightsOverflow =
-        (packedNumLights & LIGHT_TILE_OVERFLOW_BIT) != 0u;
-      numLights = !hasLightTile ? 0u :
-    #ifdef SUPPORT_LIGHTS_OVERFLOW
-        (lightsOverflow ? min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(light.instance.length())) :
-            min(packedNumLights & LIGHT_TILE_COUNT_MASK, availableLights));
-    #else
-        min(min(packedNumLights & LIGHT_TILE_COUNT_MASK, uint(LIGHTS_PER_TILE)), availableLights);
-    #endif
+      lightList = ResolveForwardLightList(gl_FragCoord.xy);
     }
     
     float environmentVisibility = 1.0;
-    outColor.xyz += AmbientLighting(
-      material,
+    outColor.xyz += CalculateForwardAmbientLighting(
+      forwardMaterial,
       F0,
       Lr,
       normal,
@@ -1198,13 +657,9 @@ glslFragment: |
     
     if(bEvaluateDirectLighting)
     {
-      for(int i = 0; i < numLights; i++)
+      for(uint i = 0u; i < lightList.count; ++i)
       {
-    #ifdef SUPPORT_LIGHTS_OVERFLOW
-        uint index = lightsOverflow ? uint(i) : culledLights.indices[offset + i];
-    #else
-        uint index = culledLights.indices[offset + i];
-    #endif
+        const uint index = ResolveForwardLightIndex(lightList, i);
         if(index == uint(-1) ||
             index >= uint(light.instance.length()) ||
             light.instance[index].type == INVALID_LIGHT_TYPE)
@@ -1212,7 +667,16 @@ glslFragment: |
             continue;
         }
 
-        outColor.xyz += CalculateLighting(light.instance[index], index, material, F0, -viewDirection, cosLo, normal, vin.worldPosition);
+        outColor.xyz += CalculateLighting(
+          light.instance[index],
+          index,
+          material,
+          forwardMaterial,
+          F0,
+          -viewDirection,
+          cosLo,
+          normal,
+          vin.worldPosition);
   #ifdef CLEAR_COAT
         outColor.xyz += material.clearcoatFactor * ClearCoatLighting(light.instance[index], material.clearcoatRoughnessFactor, Fdielectric, -viewDirection, cosLoCC, clearcoatNormal, vin.worldPosition);
   #endif

--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="McpBridgeIntegrationTests.cs" />
     <Compile Include="WorkspaceBuildPlanTests.cs" />
     <Compile Include="McpYamlUtilitiesTests.cs" />
+    <Compile Include="YamlHelperTests.cs" />
     <Compile Include="LandscapeVegetationBinaryTests.cs" />
     <Compile Include="SettingsContractsTests.cs" />
     <Compile Include="UnifiedSettingsStoreTests.cs" />
@@ -143,6 +144,7 @@
     <Compile Include="..\Editor\Utility\EditorComponentYamlContract.cs" Link="Utility\EditorComponentYamlContract.cs" />
     <Compile Include="..\Editor\Utility\InspectorPropertyPresentation.cs" Link="Utility\InspectorPropertyPresentation.cs" />
     <Compile Include="..\Editor\Utility\GameObjectMobilityPolicy.cs" Link="Utility\GameObjectMobilityPolicy.cs" />
+    <Compile Include="..\Editor\Utility\YamlHelper.cs" Link="Utility\YamlHelper.cs" />
     <Compile Include="..\Editor\Controls\FloatValueConverter.cs" Link="Controls\FloatValueConverter.cs" />
     <Compile Include="..\Editor\Controls\IntValueConverter.cs" Link="Controls\IntValueConverter.cs" />
     <Compile Include="..\Editor\Controls\UIntValueConverter.cs" Link="Controls\UIntValueConverter.cs" />

--- a/Editor.Tests/YamlHelperTests.cs
+++ b/Editor.Tests/YamlHelperTests.cs
@@ -1,0 +1,87 @@
+using System.Globalization;
+using SailorEditor.Helpers;
+using YamlDotNet.RepresentationModel;
+
+namespace Editor.Tests;
+
+public sealed class YamlHelperTests
+{
+    [Fact]
+    public void TypedLookups_OnlyReturnMatchingNodeKinds()
+    {
+        var root = new YamlMappingNode
+        {
+            { "mapping", new YamlMappingNode { { "value", "nested" } } },
+            { "sequence", new YamlSequenceNode("first", "second") },
+            { "scalar", "value" }
+        };
+
+        Assert.True(YamlHelper.TryGetMapping(root, "mapping", out var mapping));
+        Assert.Equal("nested", YamlHelper.ReadString(mapping, "value"));
+        Assert.True(YamlHelper.TryGetSequence(root, "sequence", out var sequence));
+        Assert.Equal(2, sequence.Children.Count);
+        Assert.True(YamlHelper.TryGetScalar(root, "scalar", out var scalar));
+        Assert.Equal("value", scalar);
+
+        Assert.False(YamlHelper.TryGetMapping(root, "sequence", out _));
+        Assert.False(YamlHelper.TryGetSequence(root, "scalar", out _));
+        Assert.False(YamlHelper.TryGetScalar(root, "mapping", out _));
+        Assert.False(YamlHelper.TryGetScalar(root, "missing", out _));
+    }
+
+    [Fact]
+    public void ScalarReads_PreserveFallbackAndRequiredValuePolicies()
+    {
+        var root = new YamlMappingNode
+        {
+            { "empty", "" },
+            { "whitespace", "   " },
+            { "null", new YamlScalarNode(null) }
+        };
+
+        Assert.Equal("", YamlHelper.ReadString(root, "empty", "fallback"));
+        Assert.Equal("fallback", YamlHelper.ReadString(root, "null", "fallback"));
+        Assert.Equal("fallback", YamlHelper.ReadString(root, "missing", "fallback"));
+        Assert.True(YamlHelper.TryGetScalar(root, "whitespace", out var whitespace));
+        Assert.Equal("   ", whitespace);
+        Assert.False(YamlHelper.TryGetScalar(
+            root,
+            "whitespace",
+            out _,
+            requireNonWhitespace: true));
+    }
+
+    [Fact]
+    public void NumericReadsAndWrites_AreCultureInvariant()
+    {
+        var previousCulture = CultureInfo.CurrentCulture;
+        try
+        {
+            CultureInfo.CurrentCulture = CultureInfo.GetCultureInfo("fr-FR");
+            var root = new YamlMappingNode
+            {
+                { "unsigned", "18446744073709551615" },
+                { "integer", "-17" },
+                { "float", "1.5" },
+                { "bool", "true" },
+                { "invalid", "not-a-number" }
+            };
+
+            Assert.Equal(ulong.MaxValue, YamlHelper.ReadUInt64(root, "unsigned"));
+            Assert.Equal(-17, YamlHelper.ReadInt(root, "integer"));
+            Assert.Equal(1.5f, YamlHelper.ReadFloat(root, "float"));
+            Assert.True(YamlHelper.ReadBool(root, "bool"));
+            Assert.Equal(23, YamlHelper.ReadInt(root, "invalid", 23));
+            Assert.Equal(2.5f, YamlHelper.ReadFloat(root, "missing", 2.5f));
+
+            Assert.Equal("18446744073709551615", YamlHelper.Scalar(ulong.MaxValue).Value);
+            Assert.Equal("-17", YamlHelper.Scalar(-17).Value);
+            Assert.Equal("1.5", YamlHelper.Scalar(1.5f).Value);
+            Assert.Equal("true", YamlHelper.Scalar(true).Value);
+        }
+        finally
+        {
+            CultureInfo.CurrentCulture = previousCulture;
+        }
+    }
+}

--- a/Editor/Content/PrefabOverrideApplier.cs
+++ b/Editor/Content/PrefabOverrideApplier.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using SailorEditor.Helpers;
 using YamlDotNet.RepresentationModel;
 
 namespace SailorEditor.Content;
@@ -37,8 +38,8 @@ public static class PrefabOverrideApplier
         YamlMappingNode source,
         YamlMappingNode linked)
     {
-        if (!TryGetSequence(source, "gameObjects", out var sourceObjects) ||
-            !TryGetSequence(linked, "gameObjects", out var linkedObjects))
+        if (!YamlHelper.TryGetSequence(source, "gameObjects", out var sourceObjects) ||
+            !YamlHelper.TryGetSequence(linked, "gameObjects", out var linkedObjects))
         {
             return;
         }
@@ -48,7 +49,7 @@ public static class PrefabOverrideApplier
         foreach (var sourceObject in sourceObjects.Children
                      .OfType<YamlMappingNode>())
         {
-            if (!TryGetScalar(sourceObject, "instanceId", out var sourceId) ||
+            if (!TryGetRequiredScalar(sourceObject, "instanceId", out var sourceId) ||
                 !linkedByInstanceId.TryGetValue(
                     ResolveLiveInstanceId(sourceId, instanceIds),
                     out var linkedObject))
@@ -73,8 +74,8 @@ public static class PrefabOverrideApplier
         YamlMappingNode source,
         YamlMappingNode linked)
     {
-        if (!TryGetSequence(source, "components", out var sourceComponents) ||
-            !TryGetSequence(linked, "components", out var linkedComponents))
+        if (!YamlHelper.TryGetSequence(source, "components", out var sourceComponents) ||
+            !YamlHelper.TryGetSequence(linked, "components", out var linkedComponents))
         {
             return;
         }
@@ -83,8 +84,8 @@ public static class PrefabOverrideApplier
         var linkedByInstanceId = linkedComponents.Children
             .OfType<YamlMappingNode>()
             .Where(component =>
-                TryGetMapping(component, "overrideProperties", out var properties) &&
-                TryGetScalar(properties, "instanceId", out _))
+                YamlHelper.TryGetMapping(component, "overrideProperties", out var properties) &&
+                TryGetRequiredScalar(properties, "instanceId", out _))
             .ToDictionary(
                 component => GetScalar(
                     (YamlMappingNode)component.Children[
@@ -95,15 +96,15 @@ public static class PrefabOverrideApplier
         foreach (var sourceComponent in sourceComponents.Children
                      .OfType<YamlMappingNode>())
         {
-            if (!TryGetMapping(
+            if (!YamlHelper.TryGetMapping(
                     sourceComponent,
                     "overrideProperties",
                     out var sourceProperties) ||
-                !TryGetScalar(sourceProperties, "instanceId", out var sourceId) ||
+                !TryGetRequiredScalar(sourceProperties, "instanceId", out var sourceId) ||
                 !linkedByInstanceId.TryGetValue(
                     ResolveLiveInstanceId(sourceId, instanceIds),
                     out var linkedComponent) ||
-                !TryGetMapping(
+                !YamlHelper.TryGetMapping(
                     linkedComponent,
                     "overrideProperties",
                     out var linkedProperties))
@@ -111,8 +112,8 @@ public static class PrefabOverrideApplier
                 continue;
             }
 
-            if (TryGetScalar(sourceComponent, "typename", out var sourceType) &&
-                TryGetScalar(linkedComponent, "typename", out var linkedType) &&
+            if (TryGetRequiredScalar(sourceComponent, "typename", out var sourceType) &&
+                TryGetRequiredScalar(linkedComponent, "typename", out var linkedType) &&
                 !string.Equals(sourceType, linkedType, StringComparison.Ordinal))
             {
                 continue;
@@ -126,15 +127,15 @@ public static class PrefabOverrideApplier
         YamlMappingNode source,
         YamlMappingNode linked)
     {
-        if (!TryGetMapping(linked, "gameObjectOverrides", out var overrides) ||
-            !TryGetSequence(source, "gameObjects", out var gameObjects))
+        if (!YamlHelper.TryGetMapping(linked, "gameObjectOverrides", out var overrides) ||
+            !YamlHelper.TryGetSequence(source, "gameObjects", out var gameObjects))
         {
             return;
         }
 
         var byInstanceId = gameObjects.Children
             .OfType<YamlMappingNode>()
-            .Where(gameObject => TryGetScalar(
+            .Where(gameObject => TryGetRequiredScalar(
                 gameObject,
                 "instanceId",
                 out _))
@@ -165,15 +166,15 @@ public static class PrefabOverrideApplier
     }
 
     static bool IsPrefabRoot(YamlMappingNode gameObject) =>
-        TryGetScalar(gameObject, "parentIndex", out var parentIndex) &&
+        TryGetRequiredScalar(gameObject, "parentIndex", out var parentIndex) &&
         parentIndex == uint.MaxValue.ToString(CultureInfo.InvariantCulture);
 
     static void ApplyComponentOverrides(
         YamlMappingNode source,
         YamlMappingNode linked)
     {
-        if (!TryGetMapping(linked, "componentOverrides", out var overrides) ||
-            !TryGetSequence(source, "components", out var components))
+        if (!YamlHelper.TryGetMapping(linked, "componentOverrides", out var overrides) ||
+            !YamlHelper.TryGetSequence(source, "components", out var components))
         {
             return;
         }
@@ -181,8 +182,8 @@ public static class PrefabOverrideApplier
         var byInstanceId = components.Children
             .OfType<YamlMappingNode>()
             .Where(component =>
-                TryGetMapping(component, "overrideProperties", out var properties) &&
-                TryGetScalar(properties, "instanceId", out _))
+                YamlHelper.TryGetMapping(component, "overrideProperties", out var properties) &&
+                TryGetRequiredScalar(properties, "instanceId", out _))
             .ToDictionary(
                 component => GetScalar(
                     (YamlMappingNode)component.Children[
@@ -195,11 +196,11 @@ public static class PrefabOverrideApplier
             if (sourceId is null ||
                 entry.Value is not YamlMappingNode reflectedOverride ||
                 !byInstanceId.TryGetValue(sourceId, out var target) ||
-                !TryGetMapping(
+                !YamlHelper.TryGetMapping(
                     reflectedOverride,
                     "overrideProperties",
                     out var changedProperties) ||
-                !TryGetMapping(
+                !YamlHelper.TryGetMapping(
                     target,
                     "overrideProperties",
                     out var targetProperties))
@@ -207,7 +208,7 @@ public static class PrefabOverrideApplier
                 continue;
             }
 
-            if (TryGetScalar(reflectedOverride, "typename", out var typename))
+            if (TryGetRequiredScalar(reflectedOverride, "typename", out var typename))
             {
                 target.Children[new YamlScalarNode("typename")] =
                     new YamlScalarNode(typename);
@@ -234,7 +235,7 @@ public static class PrefabOverrideApplier
     static Dictionary<string, string> ReadInstanceIdMap(
         YamlMappingNode linked)
     {
-        if (!TryGetMapping(linked, "instanceIds", out var mapping))
+        if (!YamlHelper.TryGetMapping(linked, "instanceIds", out var mapping))
             return new Dictionary<string, string>(StringComparer.Ordinal);
 
         return mapping.Children
@@ -250,7 +251,7 @@ public static class PrefabOverrideApplier
     static Dictionary<string, YamlMappingNode> IndexByInstanceId(
         YamlSequenceNode nodes) => nodes.Children
         .OfType<YamlMappingNode>()
-        .Where(node => TryGetScalar(node, "instanceId", out _))
+        .Where(node => TryGetRequiredScalar(node, "instanceId", out _))
         .ToDictionary(
             node => GetScalar(node, "instanceId"),
             StringComparer.Ordinal);
@@ -274,57 +275,18 @@ public static class PrefabOverrideApplier
         return sourceId;
     }
 
-    static bool TryGetMapping(
+    static bool TryGetRequiredScalar(
         YamlMappingNode parent,
         string key,
-        out YamlMappingNode mapping)
-    {
-        if (parent.Children.TryGetValue(
-                new YamlScalarNode(key),
-                out var value) &&
-            value is YamlMappingNode resolved)
-        {
-            mapping = resolved;
-            return true;
-        }
-
-        mapping = null!;
-        return false;
-    }
-
-    static bool TryGetSequence(
-        YamlMappingNode parent,
-        string key,
-        out YamlSequenceNode sequence)
-    {
-        if (parent.Children.TryGetValue(
-                new YamlScalarNode(key),
-                out var value) &&
-            value is YamlSequenceNode resolved)
-        {
-            sequence = resolved;
-            return true;
-        }
-
-        sequence = null!;
-        return false;
-    }
-
-    static bool TryGetScalar(
-        YamlMappingNode parent,
-        string key,
-        out string value)
-    {
-        value = string.Empty;
-        return parent.Children.TryGetValue(
-                new YamlScalarNode(key),
-                out var node) &&
-            node is YamlScalarNode { Value: not null } scalar &&
-            !string.IsNullOrWhiteSpace(value = scalar.Value);
-    }
+        out string value) =>
+        YamlHelper.TryGetScalar(
+            parent,
+            key,
+            out value,
+            requireNonWhitespace: true);
 
     static string GetScalar(YamlMappingNode parent, string key) =>
-        TryGetScalar(parent, key, out var value)
+        TryGetRequiredScalar(parent, key, out var value)
             ? value
             : throw new InvalidDataException(
                 $"Prefab field '{key}' is missing.");

--- a/Editor/Services/AssetsService.cs
+++ b/Editor/Services/AssetsService.cs
@@ -2186,14 +2186,8 @@ namespace SailorEditor.Services
                 throw new InvalidDataException($"Asset metadata root must be a map: {assetInfo.FullName}");
             }
 
-            static string ReadScalar(YamlMappingNode root, string name)
-                => root.Children.TryGetValue(new YamlScalarNode(name), out var node) &&
-                    node is YamlScalarNode scalar
-                    ? scalar.Value ?? string.Empty
-                    : string.Empty;
-
-            var fileId = ReadScalar(root, "fileId");
-            var filename = ReadScalar(root, "filename");
+            var fileId = YamlHelper.ReadString(root, "fileId");
+            var filename = YamlHelper.ReadString(root, "filename");
             if (string.IsNullOrWhiteSpace(fileId) || string.IsNullOrWhiteSpace(filename))
             {
                 throw new InvalidDataException($"Asset metadata requires fileId and filename: {assetInfo.FullName}");
@@ -2202,7 +2196,7 @@ namespace SailorEditor.Services
             return new AssetMetadataIdentity(
                 fileId,
                 filename,
-                ReadScalar(root, "assetInfoType"));
+                YamlHelper.ReadString(root, "assetInfoType"));
         }
 
         private static AssetFile CreateAssetFileByExtension(string extension) => extension switch
@@ -2222,28 +2216,6 @@ namespace SailorEditor.Services
             ".glsl" => new ShaderLibraryFile(),
             _ => new AssetFile()
         };
-
-        private static string TryReadScalar(FileInfo assetInfo, string fieldName)
-        {
-            try
-            {
-                using var reader = new StreamReader(assetInfo.FullName);
-                var yaml = new YamlStream();
-                yaml.Load(reader);
-                if (yaml.Documents.Count > 0 &&
-                    yaml.Documents[0].RootNode is YamlMappingNode root &&
-                    root.Children.TryGetValue(new YamlScalarNode(fieldName), out var node))
-                {
-                    return node?.ToString();
-                }
-            }
-            catch (YamlException ex)
-            {
-                Console.WriteLine($"[AssetsService] Failed to read {fieldName}: {assetInfo.FullName} :: {ex.Message}");
-            }
-
-            return null;
-        }
 
         private void TryPopulateAssetMetadataFromYaml(AssetFile assetFile)
         {
@@ -2267,26 +2239,27 @@ namespace SailorEditor.Services
                     return;
                 }
 
-                if (string.IsNullOrEmpty(assetFile.AssetInfoTypeName) && root.Children.TryGetValue(new YamlScalarNode("assetInfoType"), out var assetInfoTypeNode))
+                if (string.IsNullOrEmpty(assetFile.AssetInfoTypeName) &&
+                    YamlHelper.TryGetScalar(root, "assetInfoType", out var assetInfoType))
                 {
-                    assetFile.AssetInfoTypeName = assetInfoTypeNode?.ToString();
+                    assetFile.AssetInfoTypeName = assetInfoType;
                 }
 
-                if ((assetFile.FileId == null || assetFile.FileId.IsEmpty()) && root.Children.TryGetValue(new YamlScalarNode("fileId"), out var fileIdNode))
+                if ((assetFile.FileId == null || assetFile.FileId.IsEmpty()) &&
+                    YamlHelper.TryGetScalar(root, "fileId", out var fileId))
                 {
-                    var value = fileIdNode?.ToString();
-                    if (!string.IsNullOrWhiteSpace(value))
+                    if (!string.IsNullOrWhiteSpace(fileId))
                     {
-                        assetFile.FileId = new FileId(value);
+                        assetFile.FileId = new FileId(fileId);
                     }
                 }
 
-                if ((assetFile.Filename == null || assetFile.Filename.IsEmpty()) && root.Children.TryGetValue(new YamlScalarNode("filename"), out var filenameNode))
+                if ((assetFile.Filename == null || assetFile.Filename.IsEmpty()) &&
+                    YamlHelper.TryGetScalar(root, "filename", out var filename))
                 {
-                    var value = filenameNode?.ToString();
-                    if (!string.IsNullOrWhiteSpace(value))
+                    if (!string.IsNullOrWhiteSpace(filename))
                     {
-                        assetFile.Filename = new FileId(value);
+                        assetFile.Filename = new FileId(filename);
                     }
                 }
             }

--- a/Editor/Utility/YamlHelper.cs
+++ b/Editor/Utility/YamlHelper.cs
@@ -3,18 +3,108 @@ using YamlDotNet.Core;
 using YamlDotNet.RepresentationModel;
 using System.Collections.Generic;
 using System.Globalization;
-using Window = Microsoft.Maui.Controls.Window;
 
 namespace SailorEditor.Helpers
 {
-    static class YamlHelper
+    internal static class YamlHelper
     {
+        public static bool TryGetMapping(
+            YamlMappingNode parent,
+            string key,
+            out YamlMappingNode mapping) =>
+            TryGetNode(parent, key, out mapping);
+
+        public static bool TryGetSequence(
+            YamlMappingNode parent,
+            string key,
+            out YamlSequenceNode sequence) =>
+            TryGetNode(parent, key, out sequence);
+
+        public static bool TryGetScalar(
+            YamlMappingNode parent,
+            string key,
+            out string value,
+            bool requireNonWhitespace = false)
+        {
+            value = string.Empty;
+            if (!TryGetNode<YamlScalarNode>(parent, key, out var scalar) ||
+                scalar.Value is null)
+            {
+                return false;
+            }
+
+            value = scalar.Value;
+            return !requireNonWhitespace || !string.IsNullOrWhiteSpace(value);
+        }
+
+        public static string ReadString(
+            YamlMappingNode parent,
+            string key,
+            string fallback = "") =>
+            TryGetScalar(parent, key, out var value) ? value : fallback;
+
+        public static ulong ReadUInt64(
+            YamlMappingNode parent,
+            string key,
+            ulong fallback = 0) =>
+            ulong.TryParse(
+                ReadString(parent, key),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var value)
+                ? value
+                : fallback;
+
+        public static int ReadInt(
+            YamlMappingNode parent,
+            string key,
+            int fallback = 0) =>
+            int.TryParse(
+                ReadString(parent, key),
+                NumberStyles.Integer,
+                CultureInfo.InvariantCulture,
+                out var value)
+                ? value
+                : fallback;
+
+        public static float ReadFloat(
+            YamlMappingNode parent,
+            string key,
+            float fallback = 0.0f) =>
+            float.TryParse(
+                ReadString(parent, key),
+                NumberStyles.Float,
+                CultureInfo.InvariantCulture,
+                out var value)
+                ? value
+                : fallback;
+
+        public static bool ReadBool(
+            YamlMappingNode parent,
+            string key,
+            bool fallback = false) =>
+            bool.TryParse(ReadString(parent, key), out var value)
+                ? value
+                : fallback;
+
+        public static YamlScalarNode Scalar(ulong value) =>
+            new(value.ToString(CultureInfo.InvariantCulture));
+
+        public static YamlScalarNode Scalar(int value) =>
+            new(value.ToString(CultureInfo.InvariantCulture));
+
+        public static YamlScalarNode Scalar(float value) =>
+            new(value.ToString("R", CultureInfo.InvariantCulture));
+
+        public static YamlScalarNode Scalar(bool value) =>
+            new(value ? "true" : "false");
+
         public static void EmitNode(IEmitter emitter, YamlNode node)
         {
             switch (node)
             {
                 case YamlScalarNode scalar:
-                    emitter.Emit(new Scalar(null, null, scalar.Value, ScalarStyle.Any, true, false));
+                    emitter.Emit(new Scalar(null, null, scalar.Value!, ScalarStyle.Any, true, false));
                     break;
                 case YamlMappingNode mapping:
                     emitter.Emit(new MappingStart(null, null, false, MappingStyle.Block));
@@ -60,6 +150,23 @@ namespace SailorEditor.Helpers
                 emitter.Emit(new Scalar(null, v.ToString(CultureInfo.InvariantCulture)));
             }
             emitter.Emit(new SequenceEnd());
+        }
+
+        static bool TryGetNode<TNode>(
+            YamlMappingNode parent,
+            string key,
+            out TNode node)
+            where TNode : YamlNode
+        {
+            if (parent.Children.TryGetValue(new YamlScalarNode(key), out var value) &&
+                value is TNode resolved)
+            {
+                node = resolved;
+                return true;
+            }
+
+            node = null!;
+            return false;
         }
     };
 }

--- a/Editor/ViewModels/AnimationControllerFile.cs
+++ b/Editor/ViewModels/AnimationControllerFile.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using SailorEngine;
+using SailorEditor.Helpers;
 using SailorEditor.Utility;
 using System.ComponentModel;
 using System.Globalization;
@@ -325,7 +326,7 @@ public partial class AnimationControllerFile : AssetFile
 
     void LoadControllerRoot(YamlMappingNode root)
     {
-        var defaultStateId = ReadUInt64(root, "defaultState");
+        var defaultStateId = YamlHelper.ReadUInt64(root, "defaultState");
         var parameters = ReadList(root, "parameters", AnimationControllerParameter.FromYaml);
         var states = ReadList(root, "states", AnimationControllerState.FromYaml);
         var transitions = ReadList(root, "transitions", AnimationControllerTransition.FromYaml);
@@ -397,8 +398,7 @@ public partial class AnimationControllerFile : AssetFile
         where T : INotifyPropertyChanged
     {
         var result = new ObservableList<T>();
-        if (root.Children.TryGetValue(new YamlScalarNode(key), out var value) &&
-            value is YamlSequenceNode sequence)
+        if (YamlHelper.TryGetSequence(root, key, out var sequence))
         {
             foreach (var node in sequence.Children.OfType<YamlMappingNode>())
             {
@@ -461,26 +461,6 @@ public partial class AnimationControllerFile : AssetFile
         }
     }
 
-    internal static string ReadString(YamlMappingNode node, string key, string fallback = "") =>
-        node.Children.TryGetValue(new YamlScalarNode(key), out var value) &&
-        value is YamlScalarNode scalar ? scalar.Value ?? fallback : fallback;
-
-    internal static ulong ReadUInt64(YamlMappingNode node, string key, ulong fallback = 0) =>
-        ulong.TryParse(ReadString(node, key), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ? value : fallback;
-
-    internal static int ReadInt(YamlMappingNode node, string key, int fallback = 0) =>
-        int.TryParse(ReadString(node, key), NumberStyles.Integer, CultureInfo.InvariantCulture, out var value) ? value : fallback;
-
-    internal static float ReadFloat(YamlMappingNode node, string key, float fallback = 0.0f) =>
-        float.TryParse(ReadString(node, key), NumberStyles.Float, CultureInfo.InvariantCulture, out var value) ? value : fallback;
-
-    internal static bool ReadBool(YamlMappingNode node, string key, bool fallback = false) =>
-        bool.TryParse(ReadString(node, key), out var value) ? value : fallback;
-
-    internal static YamlScalarNode Scalar(ulong value) => new(value.ToString(CultureInfo.InvariantCulture));
-    internal static YamlScalarNode Scalar(int value) => new(value.ToString(CultureInfo.InvariantCulture));
-    internal static YamlScalarNode Scalar(float value) => new(value.ToString("R", CultureInfo.InvariantCulture));
-    internal static YamlScalarNode Scalar(bool value) => new(value ? "true" : "false");
 }
 
 public partial class AnimationControllerParameter : ObservableObject
@@ -505,7 +485,7 @@ public partial class AnimationControllerParameter : ObservableObject
 
     public static AnimationControllerParameter FromYaml(YamlMappingNode node)
     {
-        var serializedType = AnimationControllerFile.ReadString(node, "type", "Float");
+        var serializedType = YamlHelper.ReadString(node, "type", "Float");
         if (!Enum.TryParse<AnimationControllerParameterType>(
                 serializedType,
                 ignoreCase: false,
@@ -517,20 +497,20 @@ public partial class AnimationControllerParameter : ObservableObject
         }
         var result = new AnimationControllerParameter
         {
-            Id = AnimationControllerFile.ReadUInt64(node, "id"),
-            Name = AnimationControllerFile.ReadString(node, "name"),
+            Id = YamlHelper.ReadUInt64(node, "id"),
+            Name = YamlHelper.ReadString(node, "name"),
             Type = type
         };
         switch (type)
         {
             case AnimationControllerParameterType.Float:
-                result.DefaultFloat = AnimationControllerFile.ReadFloat(node, "default");
+                result.DefaultFloat = YamlHelper.ReadFloat(node, "default");
                 break;
             case AnimationControllerParameterType.Int:
-                result.DefaultInt = AnimationControllerFile.ReadInt(node, "default");
+                result.DefaultInt = YamlHelper.ReadInt(node, "default");
                 break;
             case AnimationControllerParameterType.Bool:
-                result.DefaultBool = AnimationControllerFile.ReadBool(node, "default");
+                result.DefaultBool = YamlHelper.ReadBool(node, "default");
                 break;
         }
         return result;
@@ -540,20 +520,20 @@ public partial class AnimationControllerParameter : ObservableObject
     {
         var result = new YamlMappingNode
         {
-            { "id", AnimationControllerFile.Scalar(Id) },
+            { "id", YamlHelper.Scalar(Id) },
             { "name", Name ?? string.Empty },
             { "type", Type.ToString() }
         };
         switch (Type)
         {
             case AnimationControllerParameterType.Float:
-                result.Add("default", AnimationControllerFile.Scalar(DefaultFloat));
+                result.Add("default", YamlHelper.Scalar(DefaultFloat));
                 break;
             case AnimationControllerParameterType.Int:
-                result.Add("default", AnimationControllerFile.Scalar(DefaultInt));
+                result.Add("default", YamlHelper.Scalar(DefaultInt));
                 break;
             case AnimationControllerParameterType.Bool:
-                result.Add("default", AnimationControllerFile.Scalar(DefaultBool));
+                result.Add("default", YamlHelper.Scalar(DefaultBool));
                 break;
         }
         return result;
@@ -585,34 +565,34 @@ public partial class AnimationControllerState : ObservableObject
 
     public static AnimationControllerState FromYaml(YamlMappingNode node)
     {
-        var editor = node.Children.TryGetValue(new YamlScalarNode("editor"), out var value)
-            ? value as YamlMappingNode
+        var editor = YamlHelper.TryGetMapping(node, "editor", out var editorMapping)
+            ? editorMapping
             : null;
         return new AnimationControllerState
         {
-            Id = AnimationControllerFile.ReadUInt64(node, "id"),
-            Name = AnimationControllerFile.ReadString(node, "name"),
-            Clip = AnimationControllerFile.ReadString(node, "clip"),
-            Speed = AnimationControllerFile.ReadFloat(node, "speed", 1.0f),
-            Loop = AnimationControllerFile.ReadBool(node, "loop", true),
-            EditorX = editor is null ? 0.0f : AnimationControllerFile.ReadFloat(editor, "x"),
-            EditorY = editor is null ? 0.0f : AnimationControllerFile.ReadFloat(editor, "y")
+            Id = YamlHelper.ReadUInt64(node, "id"),
+            Name = YamlHelper.ReadString(node, "name"),
+            Clip = YamlHelper.ReadString(node, "clip"),
+            Speed = YamlHelper.ReadFloat(node, "speed", 1.0f),
+            Loop = YamlHelper.ReadBool(node, "loop", true),
+            EditorX = editor is null ? 0.0f : YamlHelper.ReadFloat(editor, "x"),
+            EditorY = editor is null ? 0.0f : YamlHelper.ReadFloat(editor, "y")
         };
     }
 
     public YamlMappingNode ToYaml() => new()
     {
-        { "id", AnimationControllerFile.Scalar(Id) },
+        { "id", YamlHelper.Scalar(Id) },
         { "name", Name ?? string.Empty },
         { "clip", Clip ?? string.Empty },
-        { "speed", AnimationControllerFile.Scalar(Speed) },
-        { "loop", AnimationControllerFile.Scalar(Loop) },
+        { "speed", YamlHelper.Scalar(Speed) },
+        { "loop", YamlHelper.Scalar(Loop) },
         {
             "editor",
             new YamlMappingNode
             {
-                { "x", AnimationControllerFile.Scalar(EditorX) },
-                { "y", AnimationControllerFile.Scalar(EditorY) }
+                { "x", YamlHelper.Scalar(EditorX) },
+                { "y", YamlHelper.Scalar(EditorY) }
             }
         }
     };
@@ -637,7 +617,7 @@ public partial class AnimationControllerCondition : ObservableObject
 
     public static AnimationControllerCondition FromYaml(YamlMappingNode node)
     {
-        var serializedOperation = AnimationControllerFile.ReadString(
+        var serializedOperation = YamlHelper.ReadString(
             node,
             "operation",
             "Equal");
@@ -652,21 +632,21 @@ public partial class AnimationControllerCondition : ObservableObject
         }
         return new AnimationControllerCondition
         {
-            ParameterId = AnimationControllerFile.ReadUInt64(node, "parameter"),
+            ParameterId = YamlHelper.ReadUInt64(node, "parameter"),
             Operation = operation,
-            FloatValue = AnimationControllerFile.ReadFloat(node, "floatValue"),
-            IntValue = AnimationControllerFile.ReadInt(node, "intValue"),
-            BoolValue = AnimationControllerFile.ReadBool(node, "boolValue")
+            FloatValue = YamlHelper.ReadFloat(node, "floatValue"),
+            IntValue = YamlHelper.ReadInt(node, "intValue"),
+            BoolValue = YamlHelper.ReadBool(node, "boolValue")
         };
     }
 
     public YamlMappingNode ToYaml() => new()
     {
-        { "parameter", AnimationControllerFile.Scalar(ParameterId) },
+        { "parameter", YamlHelper.Scalar(ParameterId) },
         { "operation", Operation.ToString() },
-        { "floatValue", AnimationControllerFile.Scalar(FloatValue) },
-        { "intValue", AnimationControllerFile.Scalar(IntValue) },
-        { "boolValue", AnimationControllerFile.Scalar(BoolValue) }
+        { "floatValue", YamlHelper.Scalar(FloatValue) },
+        { "intValue", YamlHelper.Scalar(IntValue) },
+        { "boolValue", YamlHelper.Scalar(BoolValue) }
     };
 }
 
@@ -705,16 +685,15 @@ public partial class AnimationControllerTransition : ObservableObject
     {
         var result = new AnimationControllerTransition
         {
-            Id = AnimationControllerFile.ReadUInt64(node, "id"),
-            FromStateId = AnimationControllerFile.ReadUInt64(node, "from"),
-            ToStateId = AnimationControllerFile.ReadUInt64(node, "to"),
-            Priority = AnimationControllerFile.ReadInt(node, "priority"),
-            Duration = AnimationControllerFile.ReadFloat(node, "duration", 0.2f),
-            HasExitTime = AnimationControllerFile.ReadBool(node, "hasExitTime"),
-            ExitTime = AnimationControllerFile.ReadFloat(node, "exitTime")
+            Id = YamlHelper.ReadUInt64(node, "id"),
+            FromStateId = YamlHelper.ReadUInt64(node, "from"),
+            ToStateId = YamlHelper.ReadUInt64(node, "to"),
+            Priority = YamlHelper.ReadInt(node, "priority"),
+            Duration = YamlHelper.ReadFloat(node, "duration", 0.2f),
+            HasExitTime = YamlHelper.ReadBool(node, "hasExitTime"),
+            ExitTime = YamlHelper.ReadFloat(node, "exitTime")
         };
-        if (node.Children.TryGetValue(new YamlScalarNode("conditions"), out var value) &&
-            value is YamlSequenceNode sequence)
+        if (YamlHelper.TryGetSequence(node, "conditions", out var sequence))
         {
             foreach (var condition in sequence.Children.OfType<YamlMappingNode>())
             {
@@ -733,13 +712,13 @@ public partial class AnimationControllerTransition : ObservableObject
         }
         return new YamlMappingNode
         {
-            { "id", AnimationControllerFile.Scalar(Id) },
-            { "from", AnimationControllerFile.Scalar(FromStateId) },
-            { "to", AnimationControllerFile.Scalar(ToStateId) },
-            { "priority", AnimationControllerFile.Scalar(Priority) },
-            { "duration", AnimationControllerFile.Scalar(Duration) },
-            { "hasExitTime", AnimationControllerFile.Scalar(HasExitTime) },
-            { "exitTime", AnimationControllerFile.Scalar(ExitTime) },
+            { "id", YamlHelper.Scalar(Id) },
+            { "from", YamlHelper.Scalar(FromStateId) },
+            { "to", YamlHelper.Scalar(ToStateId) },
+            { "priority", YamlHelper.Scalar(Priority) },
+            { "duration", YamlHelper.Scalar(Duration) },
+            { "hasExitTime", YamlHelper.Scalar(HasExitTime) },
+            { "exitTime", YamlHelper.Scalar(ExitTime) },
             { "conditions", conditions }
         };
     }
@@ -804,15 +783,14 @@ public partial class AnimationSetFile : AssetFile
         }
 
         Clips = [];
-        if (root.Children.TryGetValue(new YamlScalarNode("clips"), out var value) &&
-            value is YamlSequenceNode sequence)
+        if (YamlHelper.TryGetSequence(root, "clips", out var sequence))
         {
             foreach (var node in sequence.Children.OfType<YamlMappingNode>())
             {
                 Clips.Add(new AnimationSetClip
                 {
-                    Slot = AnimationControllerFile.ReadString(node, "slot"),
-                    Animation = new FileId(AnimationControllerFile.ReadString(node, "animation"))
+                    Slot = YamlHelper.ReadString(node, "slot"),
+                    Animation = new FileId(YamlHelper.ReadString(node, "animation"))
                 });
             }
         }

--- a/Editor/ViewModels/FrameGraphFile.cs
+++ b/Editor/ViewModels/FrameGraphFile.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using SailorEditor.Helpers;
 using SailorEditor.Utility;
 using SailorEditor.Workflow;
 using System.Collections.Specialized;
@@ -194,12 +195,11 @@ public partial class FrameGraphFile : AssetFile
         list.ItemChanged += (_, _) => MarkDirty(propertyName);
     }
 
-    static ObservableList<T> ReadList<T>(YamlMappingNode root, string name, Func<YamlMappingNode, T> factory)
+    static ObservableList<T> ReadList<T>(YamlMappingNode? root, string name, Func<YamlMappingNode, T> factory)
         where T : INotifyPropertyChanged
     {
         var result = new ObservableList<T>();
-        if (root?.Children.TryGetValue(new YamlScalarNode(name), out var node) != true ||
-            node is not YamlSequenceNode sequence)
+        if (root is null || !YamlHelper.TryGetSequence(root, name, out var sequence))
         {
             return result;
         }
@@ -212,11 +212,10 @@ public partial class FrameGraphFile : AssetFile
         return result;
     }
 
-    static ObservableList<FrameGraphScalar> ReadNamedScalarList(YamlMappingNode root, string name)
+    static ObservableList<FrameGraphScalar> ReadNamedScalarList(YamlMappingNode? root, string name)
     {
         var result = new ObservableList<FrameGraphScalar>();
-        if (root?.Children.TryGetValue(new YamlScalarNode(name), out var node) != true ||
-            node is not YamlSequenceNode sequence)
+        if (root is null || !YamlHelper.TryGetSequence(root, name, out var sequence))
         {
             return result;
         }
@@ -236,11 +235,10 @@ public partial class FrameGraphFile : AssetFile
         return result;
     }
 
-    static ObservableList<FrameGraphVec4Value> ReadNamedVec4List(YamlMappingNode root, string name)
+    static ObservableList<FrameGraphVec4Value> ReadNamedVec4List(YamlMappingNode? root, string name)
     {
         var result = new ObservableList<FrameGraphVec4Value>();
-        if (root?.Children.TryGetValue(new YamlScalarNode(name), out var node) != true ||
-            node is not YamlSequenceNode sequence)
+        if (root is null || !YamlHelper.TryGetSequence(root, name, out var sequence))
         {
             return result;
         }
@@ -315,9 +313,9 @@ public partial class FrameGraphSampler : ObservableObject
 
     public static FrameGraphSampler FromYaml(YamlMappingNode node) => new()
     {
-        Name = ReadString(node, "name"),
-        FileId = ReadString(node, "fileId"),
-        Path = ReadString(node, "path")
+        Name = YamlHelper.ReadString(node, "name"),
+        FileId = YamlHelper.ReadString(node, "fileId"),
+        Path = YamlHelper.ReadString(node, "path")
     };
 
     public YamlMappingNode ToYaml() => new()
@@ -327,8 +325,6 @@ public partial class FrameGraphSampler : ObservableObject
         { "path", Path ?? string.Empty }
     };
 
-    static string ReadString(YamlMappingNode node, string name) =>
-        node.Children.TryGetValue(new YamlScalarNode(name), out var value) && value is YamlScalarNode scalar ? scalar.Value ?? string.Empty : string.Empty;
 }
 
 public partial class FrameGraphRenderTarget : ObservableObject
@@ -368,17 +364,17 @@ public partial class FrameGraphRenderTarget : ObservableObject
 
     public static FrameGraphRenderTarget FromYaml(YamlMappingNode node) => new()
     {
-        Name = ReadString(node, "name"),
-        Format = ReadString(node, "format", "R16G16B16A16_SFLOAT"),
-        Width = ReadString(node, "width", "ViewportWidth"),
-        Height = ReadString(node, "height", "ViewportHeight"),
-        Clamping = ReadString(node, "clamping"),
-        Filtration = ReadString(node, "filtration"),
-        Reduction = ReadString(node, "reduction"),
-        IsSurface = ReadBool(node, "bIsSurface"),
-        IsCompatibleWithComputeShaders = ReadBool(node, "bIsCompatibleWithComputeShaders"),
-        GenerateMips = ReadBool(node, "bGenerateMips"),
-        MaxMipLevel = ReadInt(node, "maxMipLevel")
+        Name = YamlHelper.ReadString(node, "name"),
+        Format = YamlHelper.ReadString(node, "format", "R16G16B16A16_SFLOAT"),
+        Width = YamlHelper.ReadString(node, "width", "ViewportWidth"),
+        Height = YamlHelper.ReadString(node, "height", "ViewportHeight"),
+        Clamping = YamlHelper.ReadString(node, "clamping"),
+        Filtration = YamlHelper.ReadString(node, "filtration"),
+        Reduction = YamlHelper.ReadString(node, "reduction"),
+        IsSurface = YamlHelper.ReadBool(node, "bIsSurface"),
+        IsCompatibleWithComputeShaders = YamlHelper.ReadBool(node, "bIsCompatibleWithComputeShaders"),
+        GenerateMips = YamlHelper.ReadBool(node, "bGenerateMips"),
+        MaxMipLevel = YamlHelper.ReadInt(node, "maxMipLevel")
     };
 
     public YamlMappingNode ToYaml()
@@ -413,14 +409,6 @@ public partial class FrameGraphRenderTarget : ObservableObject
         }
     }
 
-    static string ReadString(YamlMappingNode node, string name, string fallback = "") =>
-        node.Children.TryGetValue(new YamlScalarNode(name), out var value) && value is YamlScalarNode scalar ? scalar.Value ?? fallback : fallback;
-
-    static bool ReadBool(YamlMappingNode node, string name) =>
-        node.Children.TryGetValue(new YamlScalarNode(name), out var value) && bool.TryParse((value as YamlScalarNode)?.Value, out var parsed) && parsed;
-
-    static int ReadInt(YamlMappingNode node, string name) =>
-        node.Children.TryGetValue(new YamlScalarNode(name), out var value) && int.TryParse((value as YamlScalarNode)?.Value, out var parsed) ? parsed : 0;
 }
 
 public partial class FrameGraphScalar : ObservableObject
@@ -556,8 +544,8 @@ public partial class FrameGraphNode : ObservableObject
     {
         var result = new FrameGraphNode
         {
-            Name = ReadString(node, "name"),
-            Tag = ReadString(node, "tag")
+            Name = YamlHelper.ReadString(node, "name"),
+            Tag = YamlHelper.ReadString(node, "tag")
         };
         ReadNamedScalarList(node, "string", result.Strings);
         ReadNamedScalarList(node, "float", result.Floats);
@@ -592,13 +580,9 @@ public partial class FrameGraphNode : ObservableObject
         }
     }
 
-    static string ReadString(YamlMappingNode node, string name) =>
-        node.Children.TryGetValue(new YamlScalarNode(name), out var value) && value is YamlScalarNode scalar ? scalar.Value ?? string.Empty : string.Empty;
-
     static void ReadNamedScalarList(YamlMappingNode node, string name, ObservableList<FrameGraphScalar> values)
     {
-        if (!node.Children.TryGetValue(new YamlScalarNode(name), out var value) ||
-            value is not YamlSequenceNode sequence)
+        if (!YamlHelper.TryGetSequence(node, name, out var sequence))
         {
             return;
         }
@@ -618,8 +602,7 @@ public partial class FrameGraphNode : ObservableObject
 
     static void ReadVec4List(YamlMappingNode node, ObservableList<FrameGraphVec4Value> values)
     {
-        if (!node.Children.TryGetValue(new YamlScalarNode("vec4"), out var value) ||
-            value is not YamlSequenceNode sequence)
+        if (!YamlHelper.TryGetSequence(node, "vec4", out var sequence))
         {
             return;
         }
@@ -639,8 +622,7 @@ public partial class FrameGraphNode : ObservableObject
 
     static void ReadRenderTargets(YamlMappingNode node, ObservableList<FrameGraphTargetBinding> values)
     {
-        if (!node.Children.TryGetValue(new YamlScalarNode("renderTargets"), out var value) ||
-            value is not YamlSequenceNode sequence)
+        if (!YamlHelper.TryGetSequence(node, "renderTargets", out var sequence))
         {
             return;
         }

--- a/Runtime/AssetRegistry/AssetCache.cpp
+++ b/Runtime/AssetRegistry/AssetCache.cpp
@@ -5,6 +5,7 @@
 #include "Containers/ConcurrentMap.h"
 #include "Core/Utils.h"
 #include "Core/YamlSerializable.h"
+#include "Core/YamlUtils.h"
 #include "Sailor.h"
 #include "Tasks/Tasks.h"
 #include "YamlExceptionBoundary.h"
@@ -45,12 +46,6 @@ namespace
 		return result;
 	}
 
-	template<typename T>
-	bool TryDecodeScalar(const YAML::Node& node, T& outValue)
-	{
-		return node.IsScalar() && YAML::convert<T>::decode(node, outValue);
-	}
-
 	Workspace::WorkspaceCacheIdentity MakeExpectedIdentity()
 	{
 		return Workspace::MakeWorkspaceCacheIdentity(
@@ -72,15 +67,10 @@ namespace
 			return false;
 		}
 
-		uint32_t matches = 0;
-		for (const auto& field : map)
-		{
-			if (field.first.IsScalar() && field.first.Scalar() == fieldName)
-			{
-				outField = field.second;
-				++matches;
-			}
-		}
+		const size_t matches = Utils::CountYamlMapField(
+			map,
+			fieldName,
+			&outField);
 
 		if (matches != 1)
 		{
@@ -221,12 +211,12 @@ void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 			}
 
 			std::string decodedSourcePath;
-			if (!TryDecodeScalar(fileId, m_fileId) ||
-				!TryDecodeScalar(assetImportTime, m_assetImportTime) ||
-				!TryDecodeScalar(sourcePath, decodedSourcePath) ||
-				!TryDecodeScalar(modificationTimeNanoseconds, m_sourceRevision.m_modificationTimeNanoseconds) ||
-				!TryDecodeScalar(fileSize, m_sourceRevision.m_fileSize) ||
-				!TryDecodeScalar(contentHash, m_sourceRevision.m_contentHash))
+			if (!Utils::TryDecodeYamlScalar(fileId, m_fileId) ||
+				!Utils::TryDecodeYamlScalar(assetImportTime, m_assetImportTime) ||
+				!Utils::TryDecodeYamlScalar(sourcePath, decodedSourcePath) ||
+				!Utils::TryDecodeYamlScalar(modificationTimeNanoseconds, m_sourceRevision.m_modificationTimeNanoseconds) ||
+				!Utils::TryDecodeYamlScalar(fileSize, m_sourceRevision.m_fileSize) ||
+				!Utils::TryDecodeYamlScalar(contentHash, m_sourceRevision.m_contentHash))
 			{
 				return;
 			}
@@ -248,11 +238,11 @@ void AssetCache::AssetCacheData::Entry::Deserialize(const YAML::Node& inData)
 			{
 				return;
 			}
-			if (!TryDecodeScalar(metadataFilename, m_metadataFilename) ||
-				!TryDecodeScalar(metadataModificationTime, m_metadataRevision.m_modificationTimeNanoseconds) ||
-				!TryDecodeScalar(metadataFileSize, m_metadataRevision.m_fileSize) ||
-				!TryDecodeScalar(metadataContentHash, m_metadataRevision.m_contentHash) ||
-				!TryDecodeScalar(assetInfoType, m_assetInfoType))
+			if (!Utils::TryDecodeYamlScalar(metadataFilename, m_metadataFilename) ||
+				!Utils::TryDecodeYamlScalar(metadataModificationTime, m_metadataRevision.m_modificationTimeNanoseconds) ||
+				!Utils::TryDecodeYamlScalar(metadataFileSize, m_metadataRevision.m_fileSize) ||
+				!Utils::TryDecodeYamlScalar(metadataContentHash, m_metadataRevision.m_contentHash) ||
+				!Utils::TryDecodeYamlScalar(assetInfoType, m_assetInfoType))
 			{
 				return;
 			}
@@ -341,7 +331,7 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 		}
 
 		FileId fileId;
-		if (!TryDecodeScalar(serializedEntry.first, fileId) || !fileId)
+		if (!Utils::TryDecodeYamlScalar(serializedEntry.first, fileId) || !fileId)
 		{
 			outDiagnostic = "Asset cache contains invalid file id '" + serializedFileId + "'.";
 			return false;
@@ -395,12 +385,12 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 
 		AssetCacheData::Entry entry;
 		std::string serializedSourcePath;
-		if (!TryDecodeScalar(entryFileId, entry.m_fileId) ||
-			!TryDecodeScalar(assetImportTime, entry.m_assetImportTime) ||
-			!TryDecodeScalar(modificationTimeNanoseconds, entry.m_sourceRevision.m_modificationTimeNanoseconds) ||
-			!TryDecodeScalar(fileSize, entry.m_sourceRevision.m_fileSize) ||
-			!TryDecodeScalar(contentHash, entry.m_sourceRevision.m_contentHash) ||
-			!TryDecodeScalar(sourcePath, serializedSourcePath))
+		if (!Utils::TryDecodeYamlScalar(entryFileId, entry.m_fileId) ||
+			!Utils::TryDecodeYamlScalar(assetImportTime, entry.m_assetImportTime) ||
+			!Utils::TryDecodeYamlScalar(modificationTimeNanoseconds, entry.m_sourceRevision.m_modificationTimeNanoseconds) ||
+			!Utils::TryDecodeYamlScalar(fileSize, entry.m_sourceRevision.m_fileSize) ||
+			!Utils::TryDecodeYamlScalar(contentHash, entry.m_sourceRevision.m_contentHash) ||
+			!Utils::TryDecodeYamlScalar(sourcePath, serializedSourcePath))
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId +
 				"' contains an invalid scalar value.";
@@ -435,11 +425,11 @@ bool AssetCache::AssetCacheData::TryDeserialize(
 		{
 			return false;
 		}
-		if (!TryDecodeScalar(metadataFilename, entry.m_metadataFilename) ||
-			!TryDecodeScalar(metadataModificationTime, entry.m_metadataRevision.m_modificationTimeNanoseconds) ||
-			!TryDecodeScalar(metadataFileSize, entry.m_metadataRevision.m_fileSize) ||
-			!TryDecodeScalar(metadataContentHash, entry.m_metadataRevision.m_contentHash) ||
-			!TryDecodeScalar(assetInfoType, entry.m_assetInfoType))
+		if (!Utils::TryDecodeYamlScalar(metadataFilename, entry.m_metadataFilename) ||
+			!Utils::TryDecodeYamlScalar(metadataModificationTime, entry.m_metadataRevision.m_modificationTimeNanoseconds) ||
+			!Utils::TryDecodeYamlScalar(metadataFileSize, entry.m_metadataRevision.m_fileSize) ||
+			!Utils::TryDecodeYamlScalar(metadataContentHash, entry.m_metadataRevision.m_contentHash) ||
+			!Utils::TryDecodeYamlScalar(assetInfoType, entry.m_assetInfoType))
 		{
 			outDiagnostic = "Asset cache entry '" + serializedFileId +
 				"' contains an invalid lazy metadata scalar value.";

--- a/Runtime/AssetRegistry/Shader/ShaderCache.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCache.cpp
@@ -5,6 +5,7 @@
 #include "AssetRegistry/Shader/ShaderDependencyFingerprint.h"
 #include "AssetRegistry/Shader/ShaderCompiler.h"
 #include "Core/Utils.h"
+#include "Core/YamlUtils.h"
 #include "Sailor.h"
 #include "YamlExceptionBoundary.h"
 
@@ -110,62 +111,40 @@ namespace
 		const std::string& context,
 		std::string& outDiagnostic)
 	{
-		if (!node.IsMap())
-		{
-			outDiagnostic = context + " must be a YAML map.";
-			return false;
-		}
-
-		TSet<std::string> expected;
+		TVector<std::string> requiredFields;
+		requiredFields.Reserve(expectedFields.size());
 		for (const char* field : expectedFields)
 		{
-			expected.Insert(field);
+			requiredFields.Add(field);
 		}
 
-		TSet<std::string> actual;
-		for (const auto& field : node)
+		const Utils::YamlMapValidationResult validation =
+			Utils::ValidateYamlMapFields(node, requiredFields);
+		switch (validation.m_error)
 		{
-			if (!field.first.IsScalar())
-			{
-				outDiagnostic = context + " contains a non-scalar field name.";
-				return false;
-			}
-
-			const std::string name = field.first.Scalar();
-			if (!actual.Insert(name))
-			{
-				outDiagnostic = context + " contains duplicate field '" + name + "'.";
-				return false;
-			}
-			if (!expected.Contains(name))
-			{
-				outDiagnostic = context + " contains unknown field '" + name + "'.";
-				return false;
-			}
+		case Utils::EYamlMapValidationError::None:
+			return true;
+		case Utils::EYamlMapValidationError::ExpectedMap:
+			outDiagnostic = context + " must be a YAML map.";
+			break;
+		case Utils::EYamlMapValidationError::NonScalarKey:
+			outDiagnostic = context + " contains a non-scalar field name.";
+			break;
+		case Utils::EYamlMapValidationError::EmptyKey:
+		case Utils::EYamlMapValidationError::UnknownField:
+			outDiagnostic = context + " contains unknown field '" +
+				validation.m_fieldName + "'.";
+			break;
+		case Utils::EYamlMapValidationError::DuplicateKey:
+			outDiagnostic = context + " contains duplicate field '" +
+				validation.m_fieldName + "'.";
+			break;
+		case Utils::EYamlMapValidationError::MissingField:
+			outDiagnostic = context + " is missing required field '" +
+				validation.m_fieldName + "'.";
+			break;
 		}
-
-		for (const std::string& field : expected)
-		{
-			if (!actual.Contains(field))
-			{
-				outDiagnostic = context + " is missing required field '" + field + "'.";
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	YAML::Node FindField(const YAML::Node& node, const char* fieldName)
-	{
-		for (const auto& field : node)
-		{
-			if (field.first.IsScalar() && field.first.Scalar() == fieldName)
-			{
-				return field.second;
-			}
-		}
-		return YAML::Node(YAML::NodeType::Undefined);
+		return false;
 	}
 
 	bool PathsEqual(const std::filesystem::path& lhs, const std::filesystem::path& rhs)
@@ -515,13 +494,13 @@ bool ShaderCache::TryDeserializeShaderCachePayload(
 		return false;
 	}
 
-	const YAML::Node shaderCache = FindField(root, "shaderCache");
+	const YAML::Node shaderCache = Utils::FindYamlMapField(root, "shaderCache");
 	if (!ValidateExactFields(shaderCache, { "entries" }, "Shader cache payload", outDiagnostic))
 	{
 		return false;
 	}
 
-	const YAML::Node entriesNode = FindField(shaderCache, "entries");
+	const YAML::Node entriesNode = Utils::FindYamlMapField(shaderCache, "entries");
 	if (!entriesNode.IsMap())
 	{
 		outDiagnostic = "Shader cache field 'entries' must be a YAML map, including when empty.";
@@ -536,8 +515,8 @@ bool ShaderCache::TryDeserializeShaderCachePayload(
 		{
 			return false;
 		}
-		const YAML::Node byteLength = FindField(node, "byteLength");
-		const YAML::Node checksum = FindField(node, "checksum");
+		const YAML::Node byteLength = Utils::FindYamlMapField(node, "byteLength");
+		const YAML::Node checksum = Utils::FindYamlMapField(node, "checksum");
 		if (!byteLength.IsScalar() || !checksum.IsScalar())
 		{
 			outDiagnostic = context + " fields must be unsigned integer scalars.";
@@ -566,9 +545,9 @@ bool ShaderCache::TryDeserializeShaderCachePayload(
 		{
 			return false;
 		}
-		return parseMetadata(FindField(node, "vertex"), outSet.m_vertex, context + " vertex artifact") &&
-			parseMetadata(FindField(node, "fragment"), outSet.m_fragment, context + " fragment artifact") &&
-			parseMetadata(FindField(node, "compute"), outSet.m_compute, context + " compute artifact");
+		return parseMetadata(Utils::FindYamlMapField(node, "vertex"), outSet.m_vertex, context + " vertex artifact") &&
+			parseMetadata(Utils::FindYamlMapField(node, "fragment"), outSet.m_fragment, context + " fragment artifact") &&
+			parseMetadata(Utils::FindYamlMapField(node, "compute"), outSet.m_compute, context + " compute artifact");
 	};
 
 	ShaderCacheData candidate;
@@ -611,32 +590,32 @@ bool ShaderCache::TryDeserializeShaderCachePayload(
 			const std::string context = "Shader cache entry '" + serializedFileId +
 				"' at index " + std::to_string(index);
 			const YAML::Node entryNode = entrySequence[index];
-				if (!ValidateExactFields(
-					entryNode,
-					{ "fileId", "timestamp", "sourceFingerprint", "permutation", "generation", "regular", "debug" },
+			if (!ValidateExactFields(
+				entryNode,
+				{ "fileId", "timestamp", "sourceFingerprint", "permutation", "generation", "regular", "debug" },
 				context,
 				outDiagnostic))
 			{
 				return false;
 			}
 
-				const YAML::Node entryFileId = FindField(entryNode, "fileId");
-				const YAML::Node timestamp = FindField(entryNode, "timestamp");
-				const YAML::Node sourceFingerprint = FindField(entryNode, "sourceFingerprint");
-				const YAML::Node permutation = FindField(entryNode, "permutation");
-				const YAML::Node generation = FindField(entryNode, "generation");
-				if (!entryFileId.IsScalar() || !timestamp.IsScalar() ||
-					!sourceFingerprint.IsScalar() || !permutation.IsScalar() || !generation.IsScalar())
+			const YAML::Node entryFileId = Utils::FindYamlMapField(entryNode, "fileId");
+			const YAML::Node timestamp = Utils::FindYamlMapField(entryNode, "timestamp");
+			const YAML::Node sourceFingerprint = Utils::FindYamlMapField(entryNode, "sourceFingerprint");
+			const YAML::Node permutation = Utils::FindYamlMapField(entryNode, "permutation");
+			const YAML::Node generation = Utils::FindYamlMapField(entryNode, "generation");
+			if (!entryFileId.IsScalar() || !timestamp.IsScalar() ||
+				!sourceFingerprint.IsScalar() || !permutation.IsScalar() || !generation.IsScalar())
 			{
 				outDiagnostic = context + " contains a non-scalar identity or timestamp field.";
 				return false;
 			}
 
 			ShaderCacheData::Entry entry;
-				entry.m_fileId = entryFileId.as<FileId>();
-				entry.m_timestamp = timestamp.as<std::time_t>();
-				entry.m_sourceFingerprint = sourceFingerprint.as<uint64_t>();
-				entry.m_permutation = permutation.as<uint32_t>();
+			entry.m_fileId = entryFileId.as<FileId>();
+			entry.m_timestamp = timestamp.as<std::time_t>();
+			entry.m_sourceFingerprint = sourceFingerprint.as<uint64_t>();
+			entry.m_permutation = permutation.as<uint32_t>();
 			entry.m_generation = generation.as<std::string>();
 			if (!entry.m_fileId || entry.m_fileId != fileId)
 			{
@@ -655,8 +634,8 @@ bool ShaderCache::TryDeserializeShaderCachePayload(
 				return false;
 			}
 
-			if (!parseSet(FindField(entryNode, "regular"), entry.m_regular, context + " regular artifacts") ||
-				!parseSet(FindField(entryNode, "debug"), entry.m_debug, context + " debug artifacts"))
+			if (!parseSet(Utils::FindYamlMapField(entryNode, "regular"), entry.m_regular, context + " regular artifacts") ||
+				!parseSet(Utils::FindYamlMapField(entryNode, "debug"), entry.m_debug, context + " debug artifacts"))
 			{
 				return false;
 			}

--- a/Runtime/Core/YamlUtils.cpp
+++ b/Runtime/Core/YamlUtils.cpp
@@ -1,0 +1,197 @@
+#include "Core/YamlUtils.h"
+
+#include <sstream>
+
+#include <yaml-cpp/eventhandler.h>
+#include <yaml-cpp/parser.h>
+
+using namespace Sailor;
+
+namespace
+{
+	class YamlDocumentCounter final : public YAML::EventHandler
+	{
+	public:
+		void OnDocumentStart(const YAML::Mark&) override
+		{
+			++m_numDocuments;
+		}
+
+		void OnDocumentEnd() override {}
+		void OnNull(const YAML::Mark&, YAML::anchor_t) override {}
+		void OnAlias(const YAML::Mark&, YAML::anchor_t) override {}
+		void OnScalar(
+			const YAML::Mark&,
+			const std::string&,
+			YAML::anchor_t,
+			const std::string&) override {}
+		void OnSequenceStart(
+			const YAML::Mark&,
+			const std::string&,
+			YAML::anchor_t,
+			YAML::EmitterStyle::value) override {}
+		void OnSequenceEnd() override {}
+		void OnMapStart(
+			const YAML::Mark&,
+			const std::string&,
+			YAML::anchor_t,
+			YAML::EmitterStyle::value) override {}
+		void OnMapEnd() override {}
+
+		size_t GetNumDocuments() const noexcept
+		{
+			return m_numDocuments;
+		}
+
+	private:
+		size_t m_numDocuments = 0u;
+	};
+}
+
+bool Utils::TryLoadSingleYamlDocument(
+	const std::string& payload,
+	YAML::Node& outDocument,
+	std::string& outDiagnostic) noexcept
+{
+	outDocument = YAML::Node(YAML::NodeType::Undefined);
+	size_t documentCount = 0u;
+	if (!External::GuardYamlExceptions(
+			[&]()
+			{
+				std::istringstream input(payload);
+				YAML::Parser parser(input);
+				YamlDocumentCounter counter;
+				while (parser.HandleNextDocument(counter)) {}
+				documentCount = counter.GetNumDocuments();
+				if (documentCount == 1u)
+				{
+					outDocument = YAML::Load(payload);
+				}
+			},
+			outDiagnostic))
+	{
+		return false;
+	}
+
+	if (documentCount != 1u)
+	{
+		outDiagnostic = "expected exactly one YAML document, found " +
+			std::to_string(documentCount);
+		return false;
+	}
+
+	outDiagnostic.clear();
+	return true;
+}
+
+size_t Utils::CountYamlMapField(
+	const YAML::Node& map,
+	const std::string& fieldName,
+	YAML::Node* outField)
+{
+	if (outField != nullptr)
+	{
+		*outField = YAML::Node(YAML::NodeType::Undefined);
+	}
+
+	if (!map.IsMap())
+	{
+		return 0u;
+	}
+
+	size_t count = 0u;
+	for (const auto& field : map)
+	{
+		if (field.first.IsScalar() && field.first.Scalar() == fieldName)
+		{
+			if (outField != nullptr && count == 0u)
+			{
+				*outField = field.second;
+			}
+			++count;
+		}
+	}
+	return count;
+}
+
+YAML::Node Utils::FindYamlMapField(
+	const YAML::Node& map,
+	const std::string& fieldName)
+{
+	YAML::Node field(YAML::NodeType::Undefined);
+	CountYamlMapField(map, fieldName, &field);
+	return field;
+}
+
+Utils::YamlMapValidationResult Utils::ValidateYamlMap(
+	const YAML::Node& map)
+{
+	if (!map.IsMap())
+	{
+		return { EYamlMapValidationError::ExpectedMap, {} };
+	}
+
+	TSet<std::string> fields;
+	for (const auto& field : map)
+	{
+		if (!field.first.IsScalar())
+		{
+			return { EYamlMapValidationError::NonScalarKey, {} };
+		}
+
+		const std::string name = field.first.Scalar();
+		if (name.empty())
+		{
+			return { EYamlMapValidationError::EmptyKey, name };
+		}
+		if (!fields.Insert(name))
+		{
+			return { EYamlMapValidationError::DuplicateKey, name };
+		}
+	}
+
+	return {};
+}
+
+Utils::YamlMapValidationResult Utils::ValidateYamlMapFields(
+	const YAML::Node& map,
+	const TVector<std::string>& requiredFields,
+	const TVector<std::string>& optionalFields)
+{
+	const YamlMapValidationResult mapValidation = ValidateYamlMap(map);
+	if (!mapValidation.IsValid())
+	{
+		return mapValidation;
+	}
+
+	TSet<std::string> expectedFields;
+	for (const std::string& field : requiredFields)
+	{
+		expectedFields.Insert(field);
+	}
+	for (const std::string& field : optionalFields)
+	{
+		expectedFields.Insert(field);
+	}
+
+	TSet<std::string> actualFields;
+	for (const auto& field : map)
+	{
+		const std::string name = field.first.Scalar();
+		actualFields.Insert(name);
+		if (!expectedFields.Contains(name))
+		{
+			return { EYamlMapValidationError::UnknownField, name };
+		}
+	}
+
+	for (const std::string& field : requiredFields)
+	{
+		if (!actualFields.Contains(field))
+		{
+			return { EYamlMapValidationError::MissingField, field };
+		}
+	}
+
+	return {};
+}

--- a/Runtime/Core/YamlUtils.h
+++ b/Runtime/Core/YamlUtils.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "Core/Defines.h"
+#include "Containers/Containers.h"
+#include "YamlExceptionBoundary.h"
+
+#include <cstddef>
+#include <string>
+
+#include <yaml-cpp/yaml.h>
+
+namespace Sailor::Utils
+{
+	enum class EYamlMapValidationError
+	{
+		None,
+		ExpectedMap,
+		NonScalarKey,
+		EmptyKey,
+		DuplicateKey,
+		UnknownField,
+		MissingField
+	};
+
+	struct SAILOR_API YamlMapValidationResult final
+	{
+		EYamlMapValidationError m_error = EYamlMapValidationError::None;
+		std::string m_fieldName{};
+
+		bool IsValid() const noexcept
+		{
+			return m_error == EYamlMapValidationError::None;
+		}
+	};
+
+	SAILOR_API bool TryLoadSingleYamlDocument(
+		const std::string& payload,
+		YAML::Node& outDocument,
+		std::string& outDiagnostic) noexcept;
+
+	SAILOR_API size_t CountYamlMapField(
+		const YAML::Node& map,
+		const std::string& fieldName,
+		YAML::Node* outField = nullptr);
+
+	SAILOR_API YAML::Node FindYamlMapField(
+		const YAML::Node& map,
+		const std::string& fieldName);
+
+	SAILOR_API YamlMapValidationResult ValidateYamlMap(
+		const YAML::Node& map);
+
+	SAILOR_API YamlMapValidationResult ValidateYamlMapFields(
+		const YAML::Node& map,
+		const TVector<std::string>& requiredFields,
+		const TVector<std::string>& optionalFields = {});
+
+	template<typename TValue>
+	bool TryDecodeYamlScalar(
+		const YAML::Node& node,
+		TValue& outValue,
+		std::string& outDiagnostic) noexcept
+	{
+		if (!node.IsDefined() || !node.IsScalar())
+		{
+			outDiagnostic = "expected a YAML scalar";
+			return false;
+		}
+
+		return External::TryConvertYaml(node, outValue, outDiagnostic);
+	}
+
+	template<typename TValue>
+	bool TryDecodeYamlScalar(
+		const YAML::Node& node,
+		TValue& outValue) noexcept
+	{
+		std::string diagnostic;
+		return TryDecodeYamlScalar(node, outValue, diagnostic);
+	}
+}

--- a/Runtime/GlobalIllumination/GISettings.cpp
+++ b/Runtime/GlobalIllumination/GISettings.cpp
@@ -1,4 +1,5 @@
 #include "GlobalIllumination/GISettings.h"
+#include "Core/YamlUtils.h"
 
 #include <algorithm>
 #include <cmath>
@@ -88,9 +89,12 @@ bool GISettings::Deserialize(
 	m_mode = EGlobalIlluminationMode::RealtimeAndBaked;
 	m_probes.Clear();
 	outDiagnostic.clear();
-	try
+
+	auto deserialize = [&]() -> bool
 	{
-		const YAML::Node giNode = worldRoot["globalIllumination"];
+		const YAML::Node giNode = Utils::FindYamlMapField(
+			worldRoot,
+			"globalIllumination");
 		if (!giNode)
 		{
 			return true;
@@ -100,7 +104,7 @@ bool GISettings::Deserialize(
 			outDiagnostic = "globalIllumination must be a map";
 			return false;
 		}
-		const YAML::Node globalModeNode = giNode["mode"];
+		const YAML::Node globalModeNode = Utils::FindYamlMapField(giNode, "mode");
 		if (!globalModeNode || !globalModeNode.IsScalar())
 		{
 			outDiagnostic = "globalIllumination.mode is required";
@@ -115,7 +119,7 @@ bool GISettings::Deserialize(
 			return false;
 		}
 		m_mode = *parsedGlobalMode;
-		const YAML::Node probesNode = giNode["probes"];
+		const YAML::Node probesNode = Utils::FindYamlMapField(giNode, "probes");
 		if (!probesNode)
 		{
 			return true;
@@ -135,9 +139,9 @@ bool GISettings::Deserialize(
 				outDiagnostic = "a globalIllumination.probes entry has an empty name or invalid binding";
 				return false;
 			}
-			const YAML::Node assetNode = bindingNode["asset"];
+			const YAML::Node assetNode = Utils::FindYamlMapField(bindingNode, "asset");
 			const YAML::Node fileIdNode = assetNode && assetNode.IsMap()
-				? assetNode["fileId"]
+				? Utils::FindYamlMapField(assetNode, "fileId")
 				: YAML::Node();
 			if (!fileIdNode || !fileIdNode.IsScalar())
 			{
@@ -148,7 +152,7 @@ bool GISettings::Deserialize(
 
 			GlobalIlluminationProbeBinding binding;
 			binding.m_asset.Deserialize(fileIdNode);
-			const YAML::Node modeNode = bindingNode["mode"];
+			const YAML::Node modeNode = Utils::FindYamlMapField(bindingNode, "mode");
 			if (!modeNode || !modeNode.IsScalar())
 			{
 				outDiagnostic = "global-illumination probe binding '" + name +
@@ -165,11 +169,15 @@ bool GISettings::Deserialize(
 				return false;
 			}
 			binding.m_mode = *parsedProbeMode;
-			binding.m_initialWeight = bindingNode["initialWeight"]
-				? bindingNode["initialWeight"].as<float>()
+			const YAML::Node initialWeightNode = Utils::FindYamlMapField(
+				bindingNode,
+				"initialWeight");
+			binding.m_initialWeight = initialWeightNode
+				? initialWeightNode.as<float>()
 				: 0.0f;
-			binding.m_bPreload = bindingNode["preload"]
-				? bindingNode["preload"].as<bool>()
+			const YAML::Node preloadNode = Utils::FindYamlMapField(bindingNode, "preload");
+			binding.m_bPreload = preloadNode
+				? preloadNode.as<bool>()
 				: false;
 			if (!m_probes.Insert(name, std::move(binding)))
 			{
@@ -178,20 +186,17 @@ bool GISettings::Deserialize(
 			}
 		}
 		return Validate(outDiagnostic);
-	}
-	catch (const std::exception& exception)
+	};
+
+	bool bResult = false;
+	std::string yamlDiagnostic;
+	if (!External::TryInvokeYaml(deserialize, bResult, yamlDiagnostic))
 	{
 		m_mode = EGlobalIlluminationMode::RealtimeAndBaked;
 		m_probes.Clear();
 		outDiagnostic = std::string("cannot parse globalIllumination settings: ") +
-			exception.what();
+			yamlDiagnostic;
 		return false;
 	}
-	catch (...)
-	{
-		m_mode = EGlobalIlluminationMode::RealtimeAndBaked;
-		m_probes.Clear();
-		outDiagnostic = "cannot parse globalIllumination settings: unknown failure";
-		return false;
-	}
+	return bResult;
 }

--- a/Runtime/Settings/GraphicsSettings.cpp
+++ b/Runtime/Settings/GraphicsSettings.cpp
@@ -1,5 +1,6 @@
 #include "Settings/GraphicsSettings.h"
 
+#include "Core/YamlUtils.h"
 #include "RHI/Types.h"
 #include "Workspace/WorkspaceContext.h"
 #include "Workspace/WorkspacePathEncoding.h"
@@ -13,7 +14,6 @@
 #include <sstream>
 #include <system_error>
 #include <utility>
-#include <yaml-cpp/eventhandler.h>
 #include <yaml-cpp/yaml.h>
 
 namespace
@@ -93,94 +93,15 @@ namespace
 		return source + " is invalid: field " + Quote(fieldPath) + " " + requirement + ".";
 	}
 
-	class YamlDocumentCounter final : public YAML::EventHandler
-	{
-	public:
-		void OnDocumentStart(const YAML::Mark&) override { ++m_numDocuments; }
-		void OnDocumentEnd() override {}
-		void OnNull(const YAML::Mark&, YAML::anchor_t) override {}
-		void OnAlias(const YAML::Mark&, YAML::anchor_t) override {}
-		void OnScalar(
-			const YAML::Mark&,
-			const std::string&,
-			YAML::anchor_t,
-			const std::string&) override {}
-		void OnSequenceStart(
-			const YAML::Mark&,
-			const std::string&,
-			YAML::anchor_t,
-			YAML::EmitterStyle::value) override {}
-		void OnSequenceEnd() override {}
-		void OnMapStart(
-			const YAML::Mark&,
-			const std::string&,
-			YAML::anchor_t,
-			YAML::EmitterStyle::value) override {}
-		void OnMapEnd() override {}
-
-		size_t GetNumDocuments() const noexcept { return m_numDocuments; }
-
-	private:
-		size_t m_numDocuments = 0u;
-	};
-
-	bool TryLoadSingleDocument(
-		const std::string& payload,
-		YAML::Node& outDocument,
-		std::string& outDiagnostic) noexcept
-	{
-		size_t documentCount = 0u;
-		if (!External::GuardYamlExceptions(
-				[&]()
-				{
-					std::istringstream input(payload);
-					YAML::Parser parser(input);
-					YamlDocumentCounter counter;
-					while (parser.HandleNextDocument(counter)) {}
-					documentCount = counter.GetNumDocuments();
-					if (documentCount == 1u)
-					{
-						outDocument = YAML::Load(payload);
-					}
-				},
-				outDiagnostic))
-		{
-			return false;
-		}
-		if (documentCount != 1u)
-		{
-			outDiagnostic = "expected exactly one YAML document, found " +
-				std::to_string(documentCount);
-			return false;
-		}
-		return true;
-	}
-
-	YAML::Node FindField(const YAML::Node& document, const char* fieldName)
-	{
-		if (!document.IsMap())
-		{
-			return YAML::Node(YAML::NodeType::Undefined);
-		}
-
-		for (const auto& field : document)
-		{
-			if (field.first.IsScalar() && field.first.Scalar() == fieldName)
-			{
-				return field.second;
-			}
-		}
-
-		return YAML::Node(YAML::NodeType::Undefined);
-	}
-
 	bool ValidateMap(
 		const YAML::Node& document,
 		const std::string& source,
 		const std::string& fieldPath,
 		std::string& outDiagnostic)
 	{
-		if (!document.IsMap())
+		const Utils::YamlMapValidationResult validation =
+			Utils::ValidateYamlMap(document);
+		if (validation.m_error == Utils::EYamlMapValidationError::ExpectedMap)
 		{
 			outDiagnostic = fieldPath.empty()
 				? source + " is invalid: the document root must be a map."
@@ -188,33 +109,21 @@ namespace
 			return false;
 		}
 
-		size_t fieldIndex = 0u;
-		for (const auto& field : document)
+		if (validation.m_error == Utils::EYamlMapValidationError::NonScalarKey ||
+			validation.m_error == Utils::EYamlMapValidationError::EmptyKey)
 		{
-			if (!field.first.IsScalar() || field.first.Scalar().empty())
-			{
-				outDiagnostic = fieldPath.empty()
-					? source + " is invalid: the document contains an empty or non-scalar field name."
-					: InvalidField(source, fieldPath, "contains an empty or non-scalar field name");
-				return false;
-			}
-
-			const std::string key = field.first.Scalar();
-			size_t previousIndex = 0u;
-			for (const auto& previousField : document)
-			{
-				if (previousIndex++ >= fieldIndex)
-				{
-					break;
-				}
-				if (previousField.first.IsScalar() && previousField.first.Scalar() == key)
-				{
-					const std::string duplicatePath = fieldPath.empty() ? key : fieldPath + "." + key;
-					outDiagnostic = InvalidField(source, duplicatePath, "is duplicated");
-					return false;
-				}
-			}
-			++fieldIndex;
+			outDiagnostic = fieldPath.empty()
+				? source + " is invalid: the document contains an empty or non-scalar field name."
+				: InvalidField(source, fieldPath, "contains an empty or non-scalar field name");
+			return false;
+		}
+		if (validation.m_error == Utils::EYamlMapValidationError::DuplicateKey)
+		{
+			const std::string duplicatePath = fieldPath.empty()
+				? validation.m_fieldName
+				: fieldPath + "." + validation.m_fieldName;
+			outDiagnostic = InvalidField(source, duplicatePath, "is duplicated");
+			return false;
 		}
 
 		return true;
@@ -228,7 +137,7 @@ namespace
 		YAML::Node& outValue,
 		std::string& outDiagnostic)
 	{
-		outValue = FindField(parent, fieldName);
+		outValue = Utils::FindYamlMapField(parent, fieldName);
 		if (!outValue.IsDefined())
 		{
 			outDiagnostic = InvalidField(source, fieldPath, "is required and must be a map");
@@ -245,7 +154,7 @@ namespace
 		YAML::Node& outValue,
 		std::string& outDiagnostic)
 	{
-		outValue = FindField(parent, fieldName);
+		outValue = Utils::FindYamlMapField(parent, fieldName);
 		if (!outValue.IsDefined() || !outValue.IsScalar())
 		{
 			outDiagnostic = InvalidField(source, fieldPath, "is required and must be a scalar");
@@ -288,7 +197,7 @@ namespace
 		uint32_t& outValue,
 		std::string& outDiagnostic)
 	{
-		const YAML::Node field = FindField(parent, fieldName);
+		const YAML::Node field = Utils::FindYamlMapField(parent, fieldName);
 		if (!field.IsDefined())
 		{
 			return true;
@@ -549,7 +458,9 @@ namespace
 		}
 
 		const std::string cascadePath = profilePath + ".shadowCascadeResolutions";
-		const YAML::Node cascadeResolutions = FindField(profile, "shadowCascadeResolutions");
+		const YAML::Node cascadeResolutions = Utils::FindYamlMapField(
+			profile,
+			"shadowCascadeResolutions");
 		if (!cascadeResolutions.IsDefined() || !cascadeResolutions.IsSequence() ||
 			cascadeResolutions.size() != outProfile.m_shadowCascadeCount)
 		{
@@ -987,7 +898,7 @@ Sailor::Settings::ProjectGraphicsSettingsLoadResult Sailor::Settings::ParseProje
 	const std::string source = SourceLabel(sourceName, "ProjectSettings.yaml");
 	YAML::Node document;
 	std::string yamlDiagnostic;
-	if (!TryLoadSingleDocument(payload, document, yamlDiagnostic))
+	if (!Utils::TryLoadSingleYamlDocument(payload, document, yamlDiagnostic))
 	{
 		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
 		result.m_diagnostic = source + " is invalid YAML: " + yamlDiagnostic;
@@ -1087,7 +998,7 @@ Sailor::Settings::EditorGraphicsSettingsLoadResult Sailor::Settings::ParseEditor
 	const std::string source = SourceLabel(sourceName, "EditorSettings.yaml");
 	YAML::Node document;
 	std::string yamlDiagnostic;
-	if (!TryLoadSingleDocument(payload, document, yamlDiagnostic))
+	if (!Utils::TryLoadSingleYamlDocument(payload, document, yamlDiagnostic))
 	{
 		result.m_status = EGraphicsSettingsLoadStatus::Invalid;
 		result.m_diagnostic = source + " is invalid YAML: " + yamlDiagnostic;

--- a/Runtime/Workspace/WorkspaceCacheContract.cpp
+++ b/Runtime/Workspace/WorkspaceCacheContract.cpp
@@ -1,6 +1,7 @@
 #include "Workspace/WorkspaceCacheContract.h"
 #include "Containers/Containers.h"
 
+#include "Core/YamlUtils.h"
 #include "Workspace/WorkspaceContext.h"
 #include "Workspace/WorkspaceModuleApi.h"
 #include "YamlExceptionBoundary.h"
@@ -83,40 +84,29 @@ namespace
 		return sourceName.empty() ? "workspace cache" : sourceName;
 	}
 
-	YAML::Node FindField(const YAML::Node& document, const char* fieldName)
-	{
-		for (const auto& field : document)
-		{
-			if (field.first.IsScalar() && field.first.Scalar() == fieldName)
-			{
-				return field.second;
-			}
-		}
-
-		return YAML::Node(YAML::NodeType::Undefined);
-	}
-
 	bool ValidateMapKeys(
 		const YAML::Node& document,
 		const std::string& sourceName,
 		std::string& outDiagnostic)
 	{
-		TSet<std::string> keys;
-		for (const auto& field : document)
+		const Sailor::Utils::YamlMapValidationResult validation =
+			Sailor::Utils::ValidateYamlMap(document);
+		if (validation.m_error ==
+			Sailor::Utils::EYamlMapValidationError::NonScalarKey)
 		{
-			if (!field.first.IsScalar())
-			{
-				outDiagnostic = sourceName + " is corrupt: its envelope contains a non-scalar field name.";
-				return false;
-			}
-
-			const std::string key = field.first.Scalar();
-			if (key.empty() || !keys.Insert(key))
-			{
-				outDiagnostic = sourceName + " is corrupt: its envelope contains duplicate or empty field " +
-					Quote(key) + ".";
-				return false;
-			}
+			outDiagnostic = sourceName +
+				" is corrupt: its envelope contains a non-scalar field name.";
+			return false;
+		}
+		if (validation.m_error ==
+				Sailor::Utils::EYamlMapValidationError::EmptyKey ||
+			validation.m_error ==
+				Sailor::Utils::EYamlMapValidationError::DuplicateKey)
+		{
+			outDiagnostic = sourceName +
+				" is corrupt: its envelope contains duplicate or empty field " +
+				Quote(validation.m_fieldName) + ".";
+			return false;
 		}
 
 		return true;
@@ -140,7 +130,9 @@ namespace
 
 		for (const std::string& requiredField : EnvelopeFields)
 		{
-			if (!FindField(document, requiredField.c_str()).IsDefined())
+			if (!Sailor::Utils::FindYamlMapField(
+					document,
+					requiredField).IsDefined())
 			{
 				outDiagnostic = sourceName + " is corrupt: its current envelope is missing required field " +
 					Quote(requiredField) + ".";
@@ -197,7 +189,9 @@ namespace
 		std::string& outDiagnostic,
 		bool bAllowEmpty = false)
 	{
-		const YAML::Node field = FindField(document, fieldName);
+		const YAML::Node field = Sailor::Utils::FindYamlMapField(
+			document,
+			fieldName);
 		if (!field.IsDefined() || !field.IsScalar())
 		{
 			outDiagnostic = sourceName + " is corrupt: field " + Quote(fieldName) +
@@ -681,7 +675,9 @@ WorkspaceCacheLoadResult Sailor::Workspace::ParseWorkspaceCacheEnvelope(
 		return Fail(EWorkspaceCacheLoadStatus::Corrupt, std::move(diagnostic));
 	}
 
-	const YAML::Node cacheVersionField = FindField(document, CacheVersionField);
+	const YAML::Node cacheVersionField = Sailor::Utils::FindYamlMapField(
+		document,
+		CacheVersionField);
 	if (!cacheVersionField.IsDefined())
 	{
 		return VersionMismatch(
@@ -710,7 +706,9 @@ WorkspaceCacheLoadResult Sailor::Workspace::ParseWorkspaceCacheEnvelope(
 			std::to_string(cacheVersion));
 	}
 
-	const YAML::Node payloadVersionField = FindField(document, PayloadVersionField);
+	const YAML::Node payloadVersionField = Sailor::Utils::FindYamlMapField(
+		document,
+		PayloadVersionField);
 	if (!payloadVersionField.IsDefined())
 	{
 		return VersionMismatch(

--- a/Runtime/Workspace/WorkspaceContext.cpp
+++ b/Runtime/Workspace/WorkspaceContext.cpp
@@ -1,5 +1,6 @@
 #include "Workspace/WorkspaceContext.h"
 #include "Containers/Containers.h"
+#include "Core/YamlUtils.h"
 #include "Workspace/WorkspacePathEncoding.h"
 #include "YamlExceptionBoundary.h"
 
@@ -14,7 +15,6 @@
 
 namespace
 {
-	using Sailor::TSet;
 	using Sailor::TVector;
 	using namespace Sailor::Workspace;
 
@@ -202,42 +202,31 @@ namespace
 		return true;
 	}
 
-	YAML::Node FindField(const YAML::Node& document, const char* fieldName)
-	{
-		for (const auto& field : document)
-		{
-			if (field.first.IsScalar() && field.first.Scalar() == fieldName)
-			{
-				return field.second;
-			}
-		}
-
-		return YAML::Node(YAML::NodeType::Undefined);
-	}
-
 	bool ValidateManifestMap(const YAML::Node& document, std::string& outError)
 	{
-		if (!document.IsMap())
+		const Sailor::Utils::YamlMapValidationResult validation =
+			Sailor::Utils::ValidateYamlMap(document);
+		if (validation.m_error ==
+			Sailor::Utils::EYamlMapValidationError::ExpectedMap)
 		{
 			outError = "Workspace manifest must contain a YAML map.";
 			return false;
 		}
 
-		TSet<std::string> keys;
-		for (const auto& field : document)
+		if (validation.m_error ==
+			Sailor::Utils::EYamlMapValidationError::NonScalarKey)
 		{
-			if (!field.first.IsScalar())
-			{
-				outError = "Workspace manifest contains a non-scalar field name.";
-				return false;
-			}
-
-			const std::string key = field.first.Scalar();
-			if (key.empty() || !keys.Insert(key))
-			{
-				outError = "Workspace manifest contains duplicate or empty field '" + key + "'.";
-				return false;
-			}
+			outError = "Workspace manifest contains a non-scalar field name.";
+			return false;
+		}
+		if (validation.m_error ==
+				Sailor::Utils::EYamlMapValidationError::EmptyKey ||
+			validation.m_error ==
+				Sailor::Utils::EYamlMapValidationError::DuplicateKey)
+		{
+			outError = "Workspace manifest contains duplicate or empty field '" +
+				validation.m_fieldName + "'.";
+			return false;
 		}
 
 		return true;
@@ -256,15 +245,10 @@ namespace
 		}
 
 		YAML::Node version;
-		size_t versionCount = 0;
-		for (const auto& field : document)
-		{
-			if (field.first.IsScalar() && field.first.Scalar() == "manifestVersion")
-			{
-				version = field.second;
-				++versionCount;
-			}
-		}
+		const size_t versionCount = Sailor::Utils::CountYamlMapField(
+			document,
+			"manifestVersion",
+			&version);
 
 		if (versionCount == 0)
 		{
@@ -308,7 +292,9 @@ namespace
 		std::string& outValue,
 		std::string& outError)
 	{
-		const YAML::Node field = FindField(document, fieldName);
+		const YAML::Node field = Sailor::Utils::FindYamlMapField(
+			document,
+			fieldName);
 		if (!field.IsDefined())
 		{
 			if (bRequired)

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -54,6 +54,10 @@ add_executable(InstanceIdContractTests
     InstanceIdContractTests.cpp
 )
 
+add_executable(YamlUtilsContractTests
+    YamlUtilsContractTests.cpp
+)
+
 add_executable(EcsLifecycleContractTests
     EcsLifecycleContractTests.cpp
 )
@@ -230,6 +234,7 @@ target_compile_features(EditorEngineWebSocketServerTests PRIVATE cxx_std_20)
 target_compile_features(EditorViewportSessionTests PRIVATE cxx_std_20)
 target_compile_features(SmartPointerTests PRIVATE cxx_std_20)
 target_compile_features(InstanceIdContractTests PRIVATE cxx_std_20)
+target_compile_features(YamlUtilsContractTests PRIVATE cxx_std_20)
 target_compile_features(EcsLifecycleContractTests PRIVATE cxx_std_20)
 target_compile_features(BoundsContractTests PRIVATE cxx_std_20)
 target_compile_features(LandscapeStreamingTests PRIVATE cxx_std_20)
@@ -292,6 +297,7 @@ target_link_libraries(EditorEngineWebSocketServerTests PRIVATE
 target_link_libraries(EditorViewportSessionTests PRIVATE Sailor::Runtime)
 target_link_libraries(SmartPointerTests PRIVATE Sailor::Runtime)
 target_link_libraries(InstanceIdContractTests PRIVATE Sailor::Runtime)
+target_link_libraries(YamlUtilsContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(EcsLifecycleContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(BoundsContractTests PRIVATE Sailor::Runtime)
 target_link_libraries(LandscapeStreamingTests PRIVATE Sailor::Runtime)
@@ -396,6 +402,9 @@ target_include_directories(SmartPointerTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(InstanceIdContractTests PRIVATE
+    ${SAILOR_RUNTIME_DIR}
+)
+target_include_directories(YamlUtilsContractTests PRIVATE
     ${SAILOR_RUNTIME_DIR}
 )
 target_include_directories(EcsLifecycleContractTests PRIVATE
@@ -545,6 +554,11 @@ add_test(
 add_test(
     NAME InstanceIdContractTests
     COMMAND InstanceIdContractTests
+)
+
+add_test(
+    NAME YamlUtilsContractTests
+    COMMAND YamlUtilsContractTests
 )
 
 add_test(

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -2,6 +2,7 @@
 #include "AssetRegistry/Shader/ShaderCompiler.h"
 #include "AssetRegistry/Shader/ShaderDependencyFingerprint.h"
 #include "AssetRegistry/Shader/ShaderYamlIncludeResolver.h"
+#include "FrameGraph/RenderSceneNode.h"
 #include "RHI/GlobalIllumination.h"
 #include "Workspace/WorkspaceCacheContract.h"
 
@@ -1156,16 +1157,20 @@ namespace
 			"Shaders/HBAO_Blur.shader"
 		};
 
-		auto compileRuntimeFragment = [&contentRoot](
+		auto compileRuntimeStage = [&contentRoot](
 			const char* shaderPath,
-			std::initializer_list<const char*> permutationDefines)
+			std::initializer_list<const char*> permutationDefines,
+			RHI::EShaderStage stage)
 			-> RHI::ShaderByteCode
 		{
 			const std::filesystem::path sourcePath = contentRoot / shaderPath;
 			ShaderAsset shader;
 			shader.Deserialize(YAML::Load(ReadText(sourcePath)));
 
-			std::string source = shader.GetGlslCommonCode() + "\n#define FRAGMENT\n";
+			const bool bVertex = stage == RHI::EShaderStage::Vertex;
+			const char* stageDefine = bVertex ? "VERTEX" : "FRAGMENT";
+			std::string source = shader.GetGlslCommonCode() +
+				"\n#define " + stageDefine + "\n";
 			for (const char* define : permutationDefines)
 			{
 				source += std::string("#define ") + define + "\n";
@@ -1195,20 +1200,41 @@ namespace
 				std::string("runtime shader includes should resolve for ") + shaderPath +
 					": " + diagnostic);
 
-			source += "\n#ifdef FRAGMENT\n" + shader.GetGlslFragmentCode() +
+			source += "\n#ifdef " + std::string(stageDefine) + "\n" +
+				(bVertex ? shader.GetGlslVertexCode() : shader.GetGlslFragmentCode()) +
 				"\n#endif\n";
 			RHI::ShaderByteCode byteCode;
 			Require(
 				ShaderCompilerTestAccess::CompileGlslToSpirv(
 					shaderPath,
 					source,
-					RHI::EShaderStage::Fragment,
+					stage,
 					byteCode,
 					false),
-				std::string("runtime fragment shader should compile: ") + shaderPath);
+				std::string("runtime shader stage should compile: ") + shaderPath +
+					" " + stageDefine);
 			Require(!byteCode.IsEmpty(),
-				std::string("runtime fragment shader should produce SPIR-V: ") + shaderPath);
+				std::string("runtime shader stage should produce SPIR-V: ") +
+					shaderPath + " " + stageDefine);
 			return byteCode;
+		};
+		auto compileRuntimeFragment = [&compileRuntimeStage](
+			const char* shaderPath,
+			std::initializer_list<const char*> permutationDefines)
+		{
+			return compileRuntimeStage(
+				shaderPath,
+				permutationDefines,
+				RHI::EShaderStage::Fragment);
+		};
+		auto compileRuntimeVertex = [&compileRuntimeStage](
+			const char* shaderPath,
+			std::initializer_list<const char*> permutationDefines)
+		{
+			return compileRuntimeStage(
+				shaderPath,
+				permutationDefines,
+				RHI::EShaderStage::Vertex);
 		};
 
 		for (size_t shaderIndex = 0u;
@@ -1219,6 +1245,20 @@ namespace
 				compileRuntimeFragment(shaderPaths[shaderIndex], {});
 			if (shaderIndex < 3u)
 			{
+				const RHI::ShaderByteCode vertexByteCode =
+					compileRuntimeVertex(shaderPaths[shaderIndex], {});
+				RequireSpirvStorageBufferBinding(vertexByteCode, 2u, 0u);
+				RequireSpirvStorageBufferBinding(vertexByteCode, 2u, 1u);
+				RequireSpirvStorageBufferArrayStride(
+					vertexByteCode,
+					2u,
+					0u,
+					sizeof(Framegraph::RenderSceneNode::PerInstanceData));
+				RequireSpirvStorageBufferArrayStride(
+					vertexByteCode,
+					2u,
+					1u,
+					sizeof(uint32_t));
 				RequireSpirvStorageBufferBinding(byteCode, 1u, 12u);
 				RequireSpirvDescriptorBindingAbsent(byteCode, 1u, 13u);
 				RequireSpirvStorageBufferBinding(byteCode, 1u, 14u);
@@ -1264,6 +1304,9 @@ namespace
 		compileRuntimeFragment(
 			"Shaders/Standard_glTF.shader",
 			{ "CLEAR_COAT", "SHEEN", "TRANSMISSION" });
+		compileRuntimeVertex(
+			"Shaders/Standard_glTF.shader",
+			{ "SKINNING", "TRANSMISSION" });
 		compileRuntimeFragment(
 			"Shaders/Standard_glTF.shader",
 			{ "DISABLE_SCREEN_SPACE_AO" });

--- a/Tests/YamlUtilsContractTests.cpp
+++ b/Tests/YamlUtilsContractTests.cpp
@@ -1,0 +1,148 @@
+#include "Core/YamlUtils.h"
+
+#include <cstdint>
+#include <iostream>
+#include <stdexcept>
+#include <string>
+
+using namespace Sailor;
+
+namespace
+{
+	void Require(bool condition, const std::string& message)
+	{
+		if (!condition)
+		{
+			throw std::runtime_error(message);
+		}
+	}
+
+	void TestSingleDocumentLoading()
+	{
+		YAML::Node document;
+		std::string diagnostic;
+		Require(
+			Utils::TryLoadSingleYamlDocument("name: Sailor\nvalue: 42\n", document, diagnostic),
+			"one YAML document should load: " + diagnostic);
+		Require(document.IsMap() && document["name"].as<std::string>() == "Sailor",
+			"single-document loading should return the parsed document");
+
+		Require(
+			!Utils::TryLoadSingleYamlDocument({}, document, diagnostic) &&
+				diagnostic.find("found 0") != std::string::npos && !document.IsDefined(),
+			"an empty payload should be rejected as zero documents");
+		Require(
+			!Utils::TryLoadSingleYamlDocument("---\nvalue: 1\n---\nvalue: 2\n", document, diagnostic) &&
+				diagnostic.find("found 2") != std::string::npos && !document.IsDefined(),
+			"a multi-document payload should be rejected without exposing a document");
+		Require(
+			!Utils::TryLoadSingleYamlDocument("value: [1\n", document, diagnostic) &&
+				!diagnostic.empty() && !document.IsDefined(),
+			"malformed YAML should report the parser failure without exposing a document");
+	}
+
+	void TestMapStructureValidation()
+	{
+		YAML::Node map(YAML::NodeType::Map);
+		map.force_insert("name", "first");
+		map.force_insert("name", "second");
+		const Utils::YamlMapValidationResult duplicate = Utils::ValidateYamlMap(map);
+		Require(
+			duplicate.m_error == Utils::EYamlMapValidationError::DuplicateKey &&
+				duplicate.m_fieldName == "name",
+			"map validation should identify duplicate scalar keys");
+
+		YAML::Node first;
+		Require(Utils::CountYamlMapField(map, "name", &first) == 2u &&
+			first.as<std::string>() == "first",
+			"field counting should preserve duplicate detection and the first-match lookup contract");
+		Require(Utils::FindYamlMapField(map, "name").as<std::string>() == "first",
+			"field lookup should match yaml-cpp's first-match map indexing behavior");
+
+		YAML::Node nonScalarKey(YAML::NodeType::Sequence);
+		nonScalarKey.push_back("key");
+		YAML::Node nonScalarMap(YAML::NodeType::Map);
+		nonScalarMap.force_insert(nonScalarKey, "value");
+		Require(
+			Utils::ValidateYamlMap(nonScalarMap).m_error ==
+				Utils::EYamlMapValidationError::NonScalarKey,
+			"map validation should reject non-scalar keys");
+
+		YAML::Node emptyKeyMap(YAML::NodeType::Map);
+		emptyKeyMap.force_insert("", "value");
+		Require(
+			Utils::ValidateYamlMap(emptyKeyMap).m_error ==
+				Utils::EYamlMapValidationError::EmptyKey,
+			"map validation should reject empty field names");
+		Require(
+			Utils::ValidateYamlMap(YAML::Node(YAML::NodeType::Sequence)).m_error ==
+				Utils::EYamlMapValidationError::ExpectedMap,
+			"map validation should reject non-map nodes");
+	}
+
+	void TestExactFieldValidation()
+	{
+		const TVector<std::string> required{ "name", "value" };
+		const TVector<std::string> optional{ "enabled" };
+
+		YAML::Node valid(YAML::NodeType::Map);
+		valid["name"] = "Sailor";
+		valid["value"] = 42;
+		valid["enabled"] = true;
+		Require(Utils::ValidateYamlMapFields(valid, required, optional).IsValid(),
+			"required and optional fields should validate");
+
+		YAML::Node unknown = YAML::Clone(valid);
+		unknown["unexpected"] = 1;
+		const Utils::YamlMapValidationResult unknownResult =
+			Utils::ValidateYamlMapFields(unknown, required, optional);
+		Require(
+			unknownResult.m_error == Utils::EYamlMapValidationError::UnknownField &&
+				unknownResult.m_fieldName == "unexpected",
+			"exact field validation should identify unknown fields");
+
+		YAML::Node missing = YAML::Clone(valid);
+		missing.remove("value");
+		const Utils::YamlMapValidationResult missingResult =
+			Utils::ValidateYamlMapFields(missing, required, optional);
+		Require(
+			missingResult.m_error == Utils::EYamlMapValidationError::MissingField &&
+				missingResult.m_fieldName == "value",
+			"exact field validation should identify missing required fields");
+	}
+
+	void TestScalarDecoding()
+	{
+		uint32_t value = 0u;
+		std::string diagnostic;
+		Require(Utils::TryDecodeYamlScalar(YAML::Node("42"), value, diagnostic) && value == 42u,
+			"typed scalar decoding should convert valid scalar values");
+
+		YAML::Node map(YAML::NodeType::Map);
+		map["value"] = 42;
+		Require(!Utils::TryDecodeYamlScalar(map, value, diagnostic) &&
+			diagnostic.find("scalar") != std::string::npos,
+			"typed scalar decoding should reject structured nodes");
+		Require(!Utils::TryDecodeYamlScalar(YAML::Node("not-an-integer"), value, diagnostic) &&
+			!diagnostic.empty(),
+			"typed scalar decoding should report conversion failures");
+	}
+}
+
+int main()
+{
+	try
+	{
+		TestSingleDocumentLoading();
+		TestMapStructureValidation();
+		TestExactFieldValidation();
+		TestScalarDecoding();
+		std::cout << "[PASS] YAML utility contracts" << std::endl;
+		return 0;
+	}
+	catch (const std::exception& exception)
+	{
+		std::cerr << "[FAIL] YAML utility contracts: " << exception.what() << std::endl;
+		return 1;
+	}
+}


### PR DESCRIPTION
## Summary

- Extract shared native YAML document, map validation, field lookup, and typed scalar helpers while preserving caller-specific policy and diagnostics.
- Extend the Editor YAML helper with typed node access and invariant scalar conversion, then migrate repeated lenient readers.
- Move common forward-rendering resources, shadows, light-list resolution, base metallic/roughness BRDF, and ambient IBL into `ForwardLighting.glsl` for Standard, Landscape, and glTF shaders.
- Add behavioral YAML tests and compiled SPIR-V permutation/reflection coverage.

## Linked Issue

Closes #190

## Implementation Notes

- Serialized schemas, asset/protocol versions, descriptor bindings, material layouts, and existing compatibility policy are unchanged.
- glTF transmission, clear-coat, sheen, and material sampling remain in the owning shader.
- No `.probes` or `.probes.asset` files are included.

## Agent Workflow

- [x] Implementation Summary is posted.
- [ ] Tech Review is approved or requested.
- [ ] QA Report is posted or explicitly deferred.
- [ ] Ready for human review only after Tech Review and QA approval.

## Tests

- [ ] `ctest --test-dir build-mac-vcpkg -C Debug --output-on-failure` (the local generator uses `build-mac-make`; see results below)
- [x] `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj` — 765 passed
- [ ] `python3 run_world_tests.py --config Release` (not run)
- [x] Other:
  - Focused native contracts: 6/6 passed (`YamlUtils`, workspace context/cache, asset cache, GI, shader cache/artifacts).
  - Full native CTest: 33/34 passed. `WorkspaceModuleRuntimeTests` has an inherited, unrelated failure: `a module must not claim an owner that is already registered`; this ticket does not touch WorkspaceModule runtime or its test.
  - Full native Debug build and Release `SailorLib` build passed.
  - Full Editor Debug and Release MacCatalyst arm64 builds passed with no errors.
  - Release Editor MCP state verified `EverythingFloats` / `Everything Floats - Highland Trail`, engine running.
  - Lit A/B median GPU frame: 50.21 ms baseline vs 50.45 ms branch (+0.48%). Affected node medians: Masked 25.54 vs 25.53 ms, DepthPrepass/Masked 5.71 vs 5.80 ms, Opaque 4.48 vs 4.44 ms.
  - Lit and GI Only output were visually compared against the pre-refactor Release binary at the same camera; no #190 visual regression was observed.

## Risk

- Risk level: medium
- Risk notes: Shared shader code affects three production material paths. The risk is covered by production permutation compilation, SPIR-V descriptor/stride reflection, Release runtime visual comparison, and sequential GPU timing A/B.
