### PR TITLE
Fix cascaded shadow bias for reverse-Z depth

### DIFF
--- a/Content/Experimental/MeshParticles/Particle.shader
+++ b/Content/Experimental/MeshParticles/Particle.shader
@@ -283,8 +283,12 @@ glslFragment: |
         outColor = vin.color;        
         
         vec3 normal = normalize(vin.tangentBasis * vec3(0,0,1));
+        vec3 geometricNormal = NormalizeOrFallback(
+          cross(dFdx(vin.worldPosition), dFdy(vin.worldPosition)), normal);
         float lighting = max(0, dot(-light.instance[0].direction, normal));
-        float shadow = ShadowCalculation_Pcf(shadowMapSampler, lightsMatrices.instance[0] * vec4(vin.worldPosition, 1.0f), 0.00001, 0);
+        float shadow = CalculateDirectionalShadow(SHADOW_TYPE_PCF,
+          shadowMapSampler, lightsMatrices.instance[0], vin.worldPosition,
+          geometricNormal, light.instance[0].shadowBias, 0);
         outColor.xyz *= max(0.05, min(lighting, shadow));
     #endif
   }

--- a/Content/Shaders/ForwardLighting.glsl
+++ b/Content/Shaders/ForwardLighting.glsl
@@ -185,8 +185,7 @@ uint ResolveTextureSamplerIndex(uint globalTextureIndex)
 float CalculateCascadedDirectionalShadow(
   LightData lightData,
   vec3 worldPosition,
-  vec3 surfaceNormal,
-  vec3 surfaceToLightDirection)
+  vec3 surfaceNormal)
 {
   const uint activeCascadeCount = clamp(
     lightData.activeCascadeCount,
@@ -205,15 +204,14 @@ float CalculateCascadedDirectionalShadow(
   const uint cascadeShadowType = GetDirectionalCascadeShadowType(
     lightData.shadowType,
     cascadeLayer);
-  const vec3 shadowReceiverPosition = OffsetDirectionalShadowReceiver(
-    worldPosition,
-    surfaceNormal,
-    surfaceToLightDirection);
   const mat4 cascadeLightMatrix = lightsMatrices.instance[cascadeLayer];
   float shadow = CalculateDirectionalShadow(
     cascadeShadowType,
     shadowMaps[cascadeLayer],
-    cascadeLightMatrix * vec4(shadowReceiverPosition, 1.0),
+    cascadeLightMatrix,
+    worldPosition,
+    surfaceNormal,
+    lightData.shadowBias,
     cascadeLayer);
 
   const float cascadeBlend = CalculateCascadeBlend(
@@ -228,16 +226,15 @@ float CalculateCascadedDirectionalShadow(
     const uint nextCascadeShadowType = GetDirectionalCascadeShadowType(
       lightData.shadowType,
       nextCascadeLayer);
-    const vec3 nextShadowReceiverPosition = OffsetDirectionalShadowReceiver(
-      worldPosition,
-      surfaceNormal,
-      surfaceToLightDirection);
     const mat4 nextCascadeLightMatrix =
       lightsMatrices.instance[nextCascadeLayer];
     const float nextShadow = CalculateDirectionalShadow(
       nextCascadeShadowType,
       shadowMaps[nextCascadeLayer],
-      nextCascadeLightMatrix * vec4(nextShadowReceiverPosition, 1.0),
+      nextCascadeLightMatrix,
+      worldPosition,
+      surfaceNormal,
+      lightData.shadowBias,
       nextCascadeLayer);
     shadow = mix(shadow, nextShadow, cascadeBlend);
   }
@@ -314,8 +311,7 @@ ForwardLightSample ResolveForwardLightSample(
     result.shadow = CalculateCascadedDirectionalShadow(
       lightData,
       worldPosition,
-      geometricNormal,
-      result.direction);
+      geometricNormal);
   }
   else if(lightData.type == 1u || lightData.type == 2u)
   {

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -1,10 +1,8 @@
 const float EVSM_C1 = 40.0f;
 const float EVSM_C2 = 40.0f;
-// Offset the receiver before projecting it into a cascade. Applying bias after
-// projection makes the effective surface offset depend on that cascade's depth
-// range and precision, which exposes the split as a band.
-const float SHADOW_RECEIVER_LIGHT_OFFSET = 0.005f;
-const float SHADOW_RECEIVER_NORMAL_OFFSET = 0.02f;
+const float EVSM_RECEIVER_LIGHT_OFFSET = 0.005f;
+const float EVSM_RECEIVER_NORMAL_OFFSET = 0.02f;
+const float PCF_DEPTH_QUANTIZATION = 1.0f / 65535.0f;
 const uint SHADOW_TYPE_NONE = 0u;
 const uint SHADOW_TYPE_PCF = 1u;
 const uint SHADOW_TYPE_EVSM = 2u;
@@ -461,10 +459,15 @@ float LuminanceCzm(vec3 rgb)
     return dot(rgb, w);
 }
 
-float ManualPCF(sampler2D shadowMap, vec3 projCoords, float currentDepth)
+float ManualPCF(
+  sampler2D shadowMap,
+  vec3 projCoords,
+  float currentDepth,
+  vec2 receiverDepthGradient)
 {
    float shadow = 0.0;
-   vec2 texelSize = 1.0 / textureSize(shadowMap, 0);
+   const ivec2 mapSize = textureSize(shadowMap, 0);
+   const vec2 texelSize = 1.0 / vec2(mapSize);
    int samples = 16; // Number of samples
    float radius = 2.0; // Radius of the kernel
 
@@ -495,8 +498,13 @@ float ManualPCF(sampler2D shadowMap, vec3 projCoords, float currentDepth)
            continue;
        }
 
-       const float pcfDepth = texture(shadowMap, sampleUv).r;
-       shadow += currentDepth > pcfDepth ? 1.0 : 0.0;
+       const ivec2 texel = clamp(ivec2(floor(sampleUv * vec2(mapSize))),
+         ivec2(0), mapSize - ivec2(1));
+       const vec2 texelCenterUv = (vec2(texel) + 0.5f) * texelSize;
+       const float receiverDepth = currentDepth +
+         dot(receiverDepthGradient, texelCenterUv - projCoords.xy);
+       const float pcfDepth = texelFetch(shadowMap, texel, 0).r;
+       shadow += pcfDepth == 0.0f || receiverDepth > pcfDepth ? 1.0 : 0.0;
    }
 
    shadow /= float(samples);
@@ -711,7 +719,11 @@ float Chebyshev(vec2 moments, float currentDepth, float minVariance, float linst
     return ReduceLightBleed(variance / (variance + d * d), linstep);
 }
 
-float ShadowCalculation_Pcf(sampler2D shadowMap, vec4 fragPosLightSpace, int cascadeLayer)
+float ShadowCalculation_Pcf(
+  sampler2D shadowMap,
+  vec4 fragPosLightSpace,
+  vec2 receiverDepthGradient,
+  float receiverBiasScale)
 {
   vec3 projCoords = fragPosLightSpace.xyz / fragPosLightSpace.w;
   projCoords.xy = projCoords.xy * 0.5 + 0.5;
@@ -724,9 +736,11 @@ float ShadowCalculation_Pcf(sampler2D shadowMap, vec4 fragPosLightSpace, int cas
     return 1.0f;
   }
   
-  const float currentDepth = projCoords.z;
+  // PCF depth is stored in R16_UNORM, independently of the raster depth buffer.
+  const float currentDepth = projCoords.z +
+    receiverBiasScale * PCF_DEPTH_QUANTIZATION;
   
-  float shadow = ManualPCF(shadowMap, projCoords, currentDepth);
+  float shadow = ManualPCF(shadowMap, projCoords, currentDepth, receiverDepthGradient);
   return shadow;  
 }
 
@@ -743,7 +757,7 @@ float ShadowCalculation_Evsm(sampler2D shadowMap, vec4 fragPosLightSpace, int ca
     return 1.0f;
   }
   
-  vec4 shadow = texture(shadowMap, projCoords.xy);// > 0.39 ? 1.0f : 0.0f;
+  vec4 shadow = textureLod(shadowMap, projCoords.xy, 0.0f);
   const float currentDepth = exp(EVSM_C1 * projCoords.z);
   const float negCurrentDepth = -exp(-EVSM_C2 * projCoords.z);
   
@@ -753,10 +767,50 @@ float ShadowCalculation_Evsm(sampler2D shadowMap, vec4 fragPosLightSpace, int ca
   return clamp(1 - max(posValue, negValue), 0, 1);
 }
 
+vec2 CalculateShadowReceiverDepthGradient(mat4 lightMatrix, vec3 surfaceNormal)
+{
+  const vec3 lightX = vec3(lightMatrix[0][0], lightMatrix[1][0], lightMatrix[2][0]);
+  const vec3 lightY = vec3(lightMatrix[0][1], lightMatrix[1][1], lightMatrix[2][1]);
+  const vec3 lightZ = vec3(lightMatrix[0][2], lightMatrix[1][2], lightMatrix[2][2]);
+  const vec3 normal = normalize(surfaceNormal);
+  const vec3 lightDepthAxis = cross(lightX, lightY);
+  if(abs(dot(normal, normalize(lightDepthAxis))) < 0.001f)
+  {
+    return vec2(0.0f);
+  }
+
+  // Transform the plane normal by the inverse transpose. The common
+  // determinant cancels in the depth gradient, including for scaled parents.
+  const vec3 clipNormal = vec3(
+    dot(cross(lightY, lightZ), normal),
+    dot(cross(lightZ, lightX), normal),
+    dot(lightDepthAxis, normal));
+  // Clip-to-UV scale, with the texture Y axis flipped.
+  return vec2(-2.0f, 2.0f) * clipNormal.xy / clipNormal.z;
+}
+
+vec3 OffsetEvsmShadowReceiver(
+  vec3 worldPosition,
+  vec3 surfaceNormal,
+  vec3 surfaceToLightDirection,
+  float receiverBiasScale)
+{
+  const vec3 normal = normalize(surfaceNormal);
+  const vec3 toLight = normalize(surfaceToLightDirection);
+  const float cosTheta = clamp(dot(normal, toLight), 0.0f, 1.0f);
+  const float sinTheta = sqrt(max(1.0f - cosTheta * cosTheta, 0.0f));
+  return worldPosition + receiverBiasScale * (
+    toLight * EVSM_RECEIVER_LIGHT_OFFSET +
+    normal * (EVSM_RECEIVER_NORMAL_OFFSET * sinTheta));
+}
+
 float CalculateDirectionalShadow(
   uint shadowType,
   sampler2D shadowMap,
-  vec4 fragPosLightSpace,
+  mat4 lightMatrix,
+  vec3 worldPosition,
+  vec3 surfaceNormal,
+  float receiverBiasScale,
   int cascadeLayer)
 {
   if (shadowType == SHADOW_TYPE_NONE)
@@ -766,25 +820,22 @@ float CalculateDirectionalShadow(
 
   if (shadowType == SHADOW_TYPE_EVSM && cascadeLayer == 0)
   {
+    const vec3 lightX = vec3(lightMatrix[0][0], lightMatrix[1][0], lightMatrix[2][0]);
+    const vec3 lightY = vec3(lightMatrix[0][1], lightMatrix[1][1], lightMatrix[2][1]);
+    const vec3 lightZ = vec3(lightMatrix[0][2], lightMatrix[1][2], lightMatrix[2][2]);
+    const vec3 lightDepthAxis = cross(lightX, lightY);
+    const vec3 toLight = normalize(lightDepthAxis) * sign(dot(lightDepthAxis, lightZ));
+    const vec3 receiverPosition = OffsetEvsmShadowReceiver(
+      worldPosition, surfaceNormal, toLight, receiverBiasScale);
     return ShadowCalculation_Evsm(
       shadowMap,
-      fragPosLightSpace,
+      lightMatrix * vec4(receiverPosition, 1.0f),
       cascadeLayer);
   }
 
-  return ShadowCalculation_Pcf(shadowMap, fragPosLightSpace, cascadeLayer);
-}
-
-vec3 OffsetDirectionalShadowReceiver(
-  vec3 worldPosition,
-  vec3 surfaceNormal,
-  vec3 surfaceToLightDirection)
-{
-  const vec3 normal = normalize(surfaceNormal);
-  const vec3 toLight = normalize(surfaceToLightDirection);
-  const float cosTheta = clamp(dot(normal, toLight), 0.0f, 1.0f);
-  const float sinTheta = sqrt(max(1.0f - cosTheta * cosTheta, 0.0f));
-  return worldPosition +
-    toLight * SHADOW_RECEIVER_LIGHT_OFFSET +
-    normal * (SHADOW_RECEIVER_NORMAL_OFFSET * sinTheta);
+  return ShadowCalculation_Pcf(
+    shadowMap,
+    lightMatrix * vec4(worldPosition, 1.0f),
+    CalculateShadowReceiverDepthGradient(lightMatrix, surfaceNormal),
+    receiverBiasScale);
 }

--- a/Runtime/FrameGraph/ShadowPrepassNode.h
+++ b/Runtime/FrameGraph/ShadowPrepassNode.h
@@ -51,7 +51,8 @@ namespace Sailor
 			RHI::EShadowType shadowType,
 			float configuredBias) noexcept
 		{
-			return shadowType == RHI::EShadowType::PCF ? configuredBias : 0.0f;
+			// Reverse Z moves casters away from the light by decreasing their depth.
+			return shadowType == RHI::EShadowType::PCF ? -configuredBias : 0.0f;
 		}
 
 		SAILOR_API virtual void Process(RHI::RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandLists, const RHI::RHISceneViewSnapshot& sceneView) override;

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -134,16 +134,35 @@ namespace
 	void TestPcfRasterShadowBiasContract()
 	{
 		constexpr float configuredBias = 1.25f;
-		Require(
-			std::abs(ShadowPrepassNode::GetRasterShadowBias(
-				RHI::EShadowType::PCF,
-				configuredBias) - configuredBias) < 0.0001f,
-			"the configured raster bias must apply to PCF shadow maps");
-		Require(
-			ShadowPrepassNode::GetRasterShadowBias(
-				RHI::EShadowType::EVSM,
-				configuredBias) == 0.0f,
-			"EVSM shadow maps must retain their unbiased rasterization path");
+		constexpr float receiverDepth = 0.75f;
+		constexpr float depthUnit = 1.0f / 16777216.0f;
+		const auto biasedCasterDepth = [=](float casterDepth, float bias)
+		{
+			return casterDepth + depthUnit * ShadowPrepassNode::GetRasterShadowBias(
+				RHI::EShadowType::PCF, bias);
+		};
+
+		// A coplanar receiver must stop shadowing itself after the caster offset.
+		const float selfShadowDepth = receiverDepth;
+		Require(receiverDepth <= biasedCasterDepth(selfShadowDepth, 0.0f) &&
+			receiverDepth > biasedCasterDepth(selfShadowDepth, configuredBias),
+			"positive bias must reduce self-shadowing with reverse-Z depth comparison");
+		Require(biasedCasterDepth(selfShadowDepth, 0.0f) == selfShadowDepth,
+			"zero configured bias must preserve the caster depth");
+
+		const float initiallyLitDepth = receiverDepth - depthUnit;
+		Require(receiverDepth > initiallyLitDepth &&
+			receiverDepth <= biasedCasterDepth(initiallyLitDepth, -configuredBias),
+			"negative configured bias must reverse the caster offset toward the light");
+		Require(receiverDepth < biasedCasterDepth(0.8f, configuredBias),
+			"the default raster bias must preserve a separated blocker shadow");
+
+		for (float bias : { -configuredBias, 0.0f, configuredBias })
+		{
+			Require(ShadowPrepassNode::GetRasterShadowBias(
+				RHI::EShadowType::EVSM, bias) == 0.0f,
+				"EVSM shadow maps must retain their unbiased rasterization path");
+		}
 	}
 
 

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -1342,6 +1342,8 @@ namespace
 		compileRuntimeFragment(
 			"Shaders/Standard_glTF.shader",
 			{ "DISABLE_SCREEN_SPACE_AO" });
+		compileRuntimeVertex("Experimental/MeshParticles/Particle.shader", {});
+		compileRuntimeFragment("Experimental/MeshParticles/Particle.shader", {});
 		const RHI::ShaderByteCode hbaoByteCode = compileRuntimeFragment(
 			"Shaders/HBAO.shader",
 			{});


### PR DESCRIPTION
## Summary

Fix dark bands between directional shadow cascades and make the configured shadow bias effective. The previous world-space receiver offset could disappear when stored in a distant cascade's R16 depth texture; raster bias also had the wrong sign for reverse Z.

## Implementation notes

- Apply negative raster bias to PCF casters, keeping EVSM rasterization unbiased.
- Compare each PCF texel against the receiver plane at that texel's center, with a configurable R16 quantization margin.
- Pass `shadowBias` through both sides of cascade blending. Handle scaled/sheared light transforms and empty shadow-map texels.
- Update the particle shader to use geometric normals and cover its forward variant in shader compilation tests.

No asset, scene, preset, dependency, or schema changes are included.

## Linked issue

Direct user-reported fix; no separate issue. The user accepted the fix in the editor and requested this PR and merge.

## Validation

- Release engine and editor build; live editor verified in the intended workspace.
- `GpuCullingContractTests`, `BoundsContractTests`, and `ShaderCacheArtifactTests` passed.
- DirectionalShadow, PointShadow, SpotShadow, and CombinedShadows world smoke tests passed; screenshots inspected.
- Temporary Apple M5 GPU harness executed production GLSL: 53,248 receiver evaluations passed. The baseline reproduces an unoccluded plane changing from fully lit to fully shadowed across cascades; the fix keeps it lit in both and preserves separate blockers. Coverage includes signed bias, slopes, shear, borders, empty maps, and EVSM smoke checks. This harness is local validation, not a new CI test.
- Windows MSVC, clang-cl, and Editor CI: all passed on the exact merged PR head.

## Risk

Medium: shared shadow sampling changes. GPU timing was not benchmarked. Existing EVSM variance precision loss with unusually broad first-cascade projections is unchanged in scope.

## Agent workflow

- [x] Implementation summary recorded above.
- [x] Independent code review completed; identified edge cases fixed and re-reviewed.
- [x] Local QA completed and fix accepted by the user.
- [x] Current-head CI passed before merge.
- [x] Merged after the maintainer-requested audit as `6626e0ac1849a0aaabb08ea721076a0910953bcf`.