### PR TITLE
Keep sky rendering while cloud noise loads in background

### DIFF
--- a/Runtime/FrameGraph/SkyNode.cpp
+++ b/Runtime/FrameGraph/SkyNode.cpp
@@ -166,53 +166,56 @@ float Remap(float value, float minValue, float maxValue, float newMinValue, floa
 	return newMinValue + (value - minValue) / (maxValue - minValue) * (newMaxValue - newMinValue);
 }
 
-TVector<uint8_t> SkyNode::GenerateCloudsNoiseLow() const
+TVector<uint8_t> SkyNode::LoadCloudsNoise(
+	const std::string& path, uint32_t resolution,
+	TVector<uint8_t> (*generate)())
+{
+	TVector<uint8_t> noise;
+	const size_t expectedSize = size_t(resolution) * resolution * resolution;
+	if (!AssetRegistry::ReadBinaryFile(path, noise) || noise.Num() != expectedSize)
+	{
+		noise = generate();
+		// The in-memory result remains usable even when the cache is read-only.
+		AssetRegistry::WriteBinaryFile(path, noise);
+	}
+	return noise;
+}
+
+TVector<uint8_t> SkyNode::GenerateCloudsNoiseLow()
 {
 	TVector<uint8_t> res;
 	res.Resize(CloudsNoiseLowResolution * CloudsNoiseLowResolution * CloudsNoiseLowResolution);
 
-	TVector<Tasks::ITaskPtr> tasks;
-	tasks.Reserve(CloudsNoiseLowResolution);
-
+	// This runs on the dedicated Background queue. Never wait for Worker jobs:
+	// frame preparation drains that queue and would stall behind cloud generation.
 	for (uint32_t z = 0; z < CloudsNoiseLowResolution; z++)
 	{
-		auto pTask = Tasks::CreateTask("Generate Clouds Noise Low", [=, this, &res]()
+		for (uint32_t y = 0; y < CloudsNoiseLowResolution; y++)
+		{
+			for (uint32_t x = 0; x < CloudsNoiseLowResolution; x++)
 			{
-				for (uint32_t y = 0; y < CloudsNoiseLowResolution; y++)
-				{
-					for (uint32_t x = 0; x < CloudsNoiseLowResolution; x++)
-					{
-						uint8_t& value = res[x + y * CloudsNoiseLowResolution + z * CloudsNoiseLowResolution * CloudsNoiseLowResolution];
+				uint8_t& value = res[x + y * CloudsNoiseLowResolution + z * CloudsNoiseLowResolution * CloudsNoiseLowResolution];
 
-						vec3 uv = vec3((float)x / CloudsNoiseLowResolution, (float)y / CloudsNoiseLowResolution, (float)z / CloudsNoiseLowResolution) + (0.5f / CloudsNoiseLowResolution);
+				vec3 uv = vec3((float)x / CloudsNoiseLowResolution, (float)y / CloudsNoiseLowResolution, (float)z / CloudsNoiseLowResolution) + (0.5f / CloudsNoiseLowResolution);
 
-						const float tiling = 5.0f;
+				const float tiling = 5.0f;
 
-						const float perlinNoiseLow = (Math::fBmTiledPerlin(uv * tiling, 4, (int32_t)tiling) + 1) * 0.5f;
-						const float cellularNoiseLow = Math::fBmTiledWorley(uv * tiling, 4, (int32_t)tiling);
-						const float cellularNoiseMid = Math::fBmTiledWorley(uv * tiling * 2.0f, 4, (int32_t)tiling * 2);
-						const float cellularNoiseHigh = Math::fBmTiledWorley(uv * tiling * 3.0f, 4, (int32_t)tiling * 3);
+				const float perlinNoiseLow = (Math::fBmTiledPerlin(uv * tiling, 4, (int32_t)tiling) + 1) * 0.5f;
+				const float cellularNoiseLow = Math::fBmTiledWorley(uv * tiling, 4, (int32_t)tiling);
+				const float cellularNoiseMid = Math::fBmTiledWorley(uv * tiling * 2.0f, 4, (int32_t)tiling * 2);
+				const float cellularNoiseHigh = Math::fBmTiledWorley(uv * tiling * 3.0f, 4, (int32_t)tiling * 3);
 
-						const float noise = Remap(perlinNoiseLow, (cellularNoiseLow * 0.625f + cellularNoiseMid * 0.25f + cellularNoiseHigh * 0.125f) - 1.0f, 1.0f, 0.0f, 1.0f);
+				const float noise = Remap(perlinNoiseLow, (cellularNoiseLow * 0.625f + cellularNoiseMid * 0.25f + cellularNoiseHigh * 0.125f) - 1.0f, 1.0f, 0.0f, 1.0f);
 
-						value = uint8_t(noise * 255.0f);
-					}
-				}
-
-			})->Run();
-
-		tasks.Add(pTask);
-	}
-
-	for (uint32_t i = 0; i < tasks.Num(); i++)
-	{
-		tasks[i]->Wait();
+				value = uint8_t(noise * 255.0f);
+			}
+		}
 	}
 
 	return res;
 }
 
-TVector<uint8_t> SkyNode::GenerateCloudsNoiseHigh() const
+TVector<uint8_t> SkyNode::GenerateCloudsNoiseHigh()
 {
 	TVector<uint8_t> res;
 	res.Resize(CloudsNoiseHighResolution * CloudsNoiseHighResolution * CloudsNoiseHighResolution);
@@ -279,6 +282,13 @@ TVector<glm::mat4x4> SkyNode::CreateEnvironmentViewMatrices()
 		glm::rotate(glm::mat4(1), glm::radians(180.0f), Math::vec3_Up),
 		glm::rotate(glm::mat4(1), glm::radians(0.0f), Math::vec3_Up),
 	};
+}
+
+bool SkyNode::AreCloudsResourcesReady() const
+{
+	return m_pCloudsMapTexture && m_pCloudsMapTexture->IsReady() &&
+		m_pCloudsNoiseLowTexture && m_pCloudsNoiseLowTexture->IsReady() &&
+		m_pCloudsNoiseHighTexture && m_pCloudsNoiseHighTexture->IsReady();
 }
 
 void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList, const RHI::RHISceneViewSnapshot& sceneView)
@@ -348,81 +358,66 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 		}
 
 		m_pCloudsMapTexture = m_clouds ? m_clouds->GetRHI() : nullptr;
+	}
 
-		if (!m_pCloudsMapTexture)
+	auto prepareNoise = [&](auto& task, RHITexturePtr& texture,
+		uint32_t resolution, const char* name, TVector<uint8_t> (*generate)())
+	{
+		if (texture)
 		{
-			commands->EndDebugRegion(commandList);
 			return;
 		}
-	}
-
-	if ((m_createNoiseLow && !m_createNoiseLow->IsFinished()) ||
-		(m_createNoiseHigh && !m_createNoiseHigh->IsFinished()))
-	{
-		commands->EndDebugRegion(commandList);
-		return;
-	}
-
-	if (!m_pCloudsNoiseHighTexture)
-	{
-		bool bShouldReturn = false;
-
-		TVector<uint8_t> noiseHigh;
-		auto pathNoiseHigh = std::filesystem::path(AssetRegistry::GetCacheFolder() + std::string("CloudsNoiseHigh.bin"));
-		if (!AssetRegistry::ReadBinaryFile(pathNoiseHigh, noiseHigh))
+		if (!task)
 		{
-			m_createNoiseHigh = Tasks::CreateTask("Generate Clouds Noise High",
-				[=, this]()
+			const std::string path = AssetRegistry::GetCacheFolder() + name + ".bin";
+			// Capture values only: a pending task may outlive this frame-graph node.
+			task = Tasks::CreateTaskWithResult<TVector<uint8_t>>(name,
+				[path, resolution, generate]()
 				{
-					auto cache = GenerateCloudsNoiseHigh();
-					AssetRegistry::WriteBinaryFile(pathNoiseHigh, cache);
-				})->Run();
-
-			bShouldReturn = true;
+					return LoadCloudsNoise(path, resolution, generate);
+				}, EThreadType::Background);
+			task->Run();
 		}
-
-		TVector<uint8_t> noiseLow;
-		auto pathNoiseLow = std::filesystem::path(AssetRegistry::GetCacheFolder() + std::string("CloudsNoiseLow.bin"));
-		if (!AssetRegistry::ReadBinaryFile(pathNoiseLow, noiseLow))
+		if (!task->IsFinished())
 		{
-			m_createNoiseLow = Tasks::CreateTask("Generate Clouds Noise Low",
-				[=, this]()
-				{
-					auto cache = GenerateCloudsNoiseLow();
-					AssetRegistry::WriteBinaryFile(pathNoiseLow, cache);
-				})->Run();
-
-			bShouldReturn = true;
-		}
-
-		if (bShouldReturn)
-		{
-			commands->EndDebugRegion(commandList);
 			return;
 		}
 
-		m_pCloudsNoiseHighTexture = driver->CreateTexture(noiseHigh.GetData(), noiseHigh.Num() * sizeof(uint8_t),
-			glm::ivec3(CloudsNoiseHighResolution, CloudsNoiseHighResolution, CloudsNoiseHighResolution),
-			(uint32_t)glm::max(1.0f, glm::log2((float)CloudsNoiseHighResolution)),
+		const auto& noise = task->GetResult();
+		texture = driver->CreateTexture(noise.GetData(), noise.Num() * sizeof(uint8_t),
+			glm::ivec3(resolution),
+			(uint32_t)glm::max(1.0f, glm::log2((float)resolution)),
 			ETextureType::Texture3D,
 			ETextureFormat::R8_UNORM,
 			ETextureFiltration::Linear,
 			ETextureClamping::Repeat,
 			ETextureUsageBit::TextureTransferSrc_Bit | ETextureUsageBit::TextureTransferDst_Bit | ETextureUsageBit::Sampled_Bit);
+		driver->SetDebugName(texture, name);
+		task.Clear();
+	};
 
-		driver->SetDebugName(m_pCloudsNoiseHighTexture, "CloudsNoiseHigh");
+	prepareNoise(m_createNoiseHigh, m_pCloudsNoiseHighTexture,
+		CloudsNoiseHighResolution, "CloudsNoiseHigh", &GenerateCloudsNoiseHigh);
+	prepareNoise(m_createNoiseLow, m_pCloudsNoiseLowTexture,
+		CloudsNoiseLowResolution, "CloudsNoiseLow", &GenerateCloudsNoiseLow);
 
-		m_pCloudsNoiseLowTexture = driver->CreateTexture(noiseLow.GetData(), noiseLow.Num() * sizeof(uint8_t),
-			glm::ivec3(CloudsNoiseLowResolution, CloudsNoiseLowResolution, CloudsNoiseLowResolution),
-			(uint32_t)glm::max(1.0f, glm::log2((float)CloudsNoiseLowResolution)),
+	if (!m_pCloudsNoiseFallbackTexture)
+	{
+		// Shared sky layouts still need valid 3D descriptors while clouds load.
+		const uint8_t emptyNoise = 0;
+		m_pCloudsNoiseFallbackTexture = driver->CreateTexture(&emptyNoise, sizeof(emptyNoise),
+			glm::ivec3(1), 1,
 			ETextureType::Texture3D,
 			ETextureFormat::R8_UNORM,
 			ETextureFiltration::Linear,
 			ETextureClamping::Repeat,
 			ETextureUsageBit::TextureTransferSrc_Bit | ETextureUsageBit::TextureTransferDst_Bit | ETextureUsageBit::Sampled_Bit);
-
-		driver->SetDebugName(m_pCloudsNoiseLowTexture, "CloudsNoiseLow");
+		driver->SetDebugName(m_pCloudsNoiseFallbackTexture, "PendingCloudsNoise");
 	}
+	const bool bCloudsReady = AreCloudsResourcesReady();
+	const auto cloudsMap = m_pCloudsMapTexture ? m_pCloudsMapTexture : driver->GetDefaultTexture();
+	const auto noiseLow = bCloudsReady ? m_pCloudsNoiseLowTexture : m_pCloudsNoiseFallbackTexture;
+	const auto noiseHigh = bCloudsReady ? m_pCloudsNoiseHighTexture : m_pCloudsNoiseFallbackTexture;
 
 	if (!m_pStarsShader)
 	{
@@ -537,7 +532,6 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 
 	if (!m_pBlitShader || !m_pBlitShader->IsReady() ||
 		!m_pStarsShader || !m_pStarsShader->IsReady() ||
-		!m_pCloudsShader || !m_pCloudsShader->IsReady() ||
 		!m_pSkyShader || !m_pSkyShader->IsReady() ||
 		!m_pSkyEnvShader || !m_pSkyEnvShader->IsReady() ||
 		!m_pSunShader || !m_pSunShader->IsReady() ||
@@ -551,6 +545,7 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 
 	if (!m_pSkyMaterial)
 	{
+		m_pCloudsMaterial.Clear();
 		m_pShaderBindings = driver->CreateShaderBindings();
 
 		// Firstly we must assign the correct layout
@@ -561,9 +556,9 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 		RHIShaderBindingPtr data = driver->AddBufferToShaderBindings(m_pShaderBindings, "data", uniformsSize, 0, RHI::EShaderBindingType::UniformBuffer);
 		driver->AddSamplerToShaderBindings(m_pShaderBindings, "skySampler", m_pSkyTexture, 1);
 		driver->AddSamplerToShaderBindings(m_pShaderBindings, "sunSampler", m_pSunTexture, 2);
-		driver->AddSamplerToShaderBindings(m_pShaderBindings, "cloudsMapSampler", m_pCloudsMapTexture, 3);
-		driver->AddSamplerToShaderBindings(m_pShaderBindings, "cloudsNoiseLowSampler", m_pCloudsNoiseLowTexture, 4);
-		driver->AddSamplerToShaderBindings(m_pShaderBindings, "cloudsNoiseHighSampler", m_pCloudsNoiseHighTexture, 5);
+		driver->AddSamplerToShaderBindings(m_pShaderBindings, "cloudsMapSampler", cloudsMap, 3);
+		driver->AddSamplerToShaderBindings(m_pShaderBindings, "cloudsNoiseLowSampler", noiseLow, 4);
+		driver->AddSamplerToShaderBindings(m_pShaderBindings, "cloudsNoiseHighSampler", noiseHigh, 5);
 		driver->AddSamplerToShaderBindings(m_pShaderBindings, "cloudsSampler", m_pCloudsTexture, 6);
 
 		auto ditherPattern = frameGraph->GetSampler("g_ditherPatternSampler");
@@ -581,11 +576,20 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 		m_pSkyEnvMaterial = driver->CreateMaterial(vertexDescription, EPrimitiveTopology::TriangleList, renderState, m_pSkyEnvShader, m_pShaderBindings);
 		m_pSunMaterial = driver->CreateMaterial(vertexDescription, EPrimitiveTopology::TriangleList, renderState, m_pSunShader, m_pShaderBindings);
 		m_pComposeMaterial = driver->CreateMaterial(vertexDescription, EPrimitiveTopology::TriangleList, renderState, m_pComposeShader, m_pShaderBindings);
-		m_pCloudsMaterial = driver->CreateMaterial(vertexDescription, EPrimitiveTopology::TriangleList, renderState, m_pCloudsShader, m_pShaderBindings);
 
 		RenderState renderStateMultiply{ false, false, 0, false, ECullMode::Back, EBlendMode::Multiply, EFillMode::Fill, 0, false };
 		m_pSunShaftsMaterial = driver->CreateMaterial(vertexDescription, EPrimitiveTopology::TriangleList, renderStateMultiply, m_pSunShaftsShader, m_pShaderBindings);
 	}
+	if (bCloudsReady && m_pCloudsShader && m_pCloudsShader->IsReady() && !m_pCloudsMaterial)
+	{
+		auto vertexDescription = driver->GetOrAddVertexDescription<RHI::VertexP3N3UV2C4>();
+		RenderState renderState{ false, false, 0.0f, false, ECullMode::Front, EBlendMode::None, EFillMode::Fill, 0, false };
+		m_pCloudsMaterial = driver->CreateMaterial(vertexDescription, EPrimitiveTopology::TriangleList, renderState, m_pCloudsShader, m_pShaderBindings);
+	}
+	// UpdateShaderBinding preserves the existing descriptor set when unchanged.
+	driver->UpdateShaderBinding(m_pShaderBindings, "cloudsMapSampler", cloudsMap, 0);
+	driver->UpdateShaderBinding(m_pShaderBindings, "cloudsNoiseLowSampler", noiseLow, 0);
+	driver->UpdateShaderBinding(m_pShaderBindings, "cloudsNoiseHighSampler", noiseHigh, 0);
 
 	// TODO: Should we update each frame?
 	if (auto bindings = GetShaderBindings())
@@ -689,7 +693,8 @@ void SkyNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPtr transf
 	}
 	commands->EndDebugRegion(commandList);
 
-	if (m_skyParams.m_cloudsDensity > CloudsVisibilityEpsilon &&
+	if (bCloudsReady && m_pCloudsMaterial &&
+		m_skyParams.m_cloudsDensity > CloudsVisibilityEpsilon &&
 		m_skyParams.m_cloudsCoverage > CloudsVisibilityEpsilon)
 	{
 		commands->BeginDebugRegion(commandList, "Clouds", DebugContext::Color_CmdPostProcess);

--- a/Runtime/FrameGraph/SkyNode.h
+++ b/Runtime/FrameGraph/SkyNode.h
@@ -14,8 +14,8 @@ namespace Sailor::Framegraph
 	{
 		const uint32_t EnvCubemapSize = 256u;
 		const uint32_t SunResolution = 32u;
-		const uint32_t CloudsNoiseHighResolution = 32u;
-		const uint32_t CloudsNoiseLowResolution = 128u;
+		static constexpr uint32_t CloudsNoiseHighResolution = 32u;
+		static constexpr uint32_t CloudsNoiseLowResolution = 128u;
 		static constexpr float CloudsVisibilityEpsilon = 0.0001f;
 
 		struct BrighStarCatalogue_Header
@@ -72,6 +72,7 @@ namespace Sailor::Framegraph
 		};
 
 		SAILOR_API void ConsumePendingSkyParams();
+		SAILOR_API bool AreCloudsResourcesReady() const;
 		SAILOR_API static glm::mat4 CreateEnvironmentProjectionMatrix();
 		SAILOR_API static TVector<glm::mat4x4> CreateEnvironmentViewMatrices();
 
@@ -112,12 +113,13 @@ namespace Sailor::Framegraph
 		RHI::RHITexturePtr m_pCloudsMapTexture{};
 		RHI::RHITexturePtr m_pCloudsNoiseHighTexture{};
 		RHI::RHITexturePtr m_pCloudsNoiseLowTexture{};
+		RHI::RHITexturePtr m_pCloudsNoiseFallbackTexture{};
 
 		RHI::RHIMeshPtr m_starsMesh{};
 
 		TexturePtr m_clouds{};
-		Tasks::ITaskPtr m_createNoiseLow{};
-		Tasks::ITaskPtr m_createNoiseHigh{};
+		Tasks::TaskPtr<TVector<uint8_t>> m_createNoiseLow{};
+		Tasks::TaskPtr<TVector<uint8_t>> m_createNoiseHigh{};
 
 		Tasks::TaskPtr<RHI::RHIMeshPtr, TPair<TVector<RHI::VertexP3C4>, TVector<uint32_t>>> m_loadMeshTask{};
 		Tasks::TaskPtr<RHI::RHIMeshPtr, TPair<TVector<RHI::VertexP3C4>, TVector<uint32_t>>> CreateStarsMesh();
@@ -135,8 +137,11 @@ namespace Sailor::Framegraph
 		static const glm::vec3& TemperatureToColor(uint32_t temperature);
 		static const glm::vec3& MorganKeenanToColor(char spectralType, char subType);
 
-		TVector<uint8_t> GenerateCloudsNoiseLow() const;
-		TVector<uint8_t> GenerateCloudsNoiseHigh() const;
+		SAILOR_API static TVector<uint8_t> LoadCloudsNoise(
+			const std::string& path, uint32_t resolution,
+			TVector<uint8_t> (*generate)());
+		static TVector<uint8_t> GenerateCloudsNoiseLow();
+		static TVector<uint8_t> GenerateCloudsNoiseHigh();
 
 		uint32_t m_ditherPatternIndex = 0;
 		uint32_t m_updateEnvCubemapPattern = 0;

--- a/Tests/SkyComponentContractTests.cpp
+++ b/Tests/SkyComponentContractTests.cpp
@@ -2,6 +2,7 @@
 #include <atomic>
 #include <cmath>
 #include <cstddef>
+#include <filesystem>
 #include <functional>
 #include <iostream>
 #include <limits>
@@ -12,6 +13,7 @@
 #include <vector>
 
 #include "AssetRegistry/Prefab/PrefabImporter.h"
+#include "AssetRegistry/AssetRegistry.h"
 #include "Components/LightComponent.h"
 #include "Components/SkyComponent.h"
 #include "Core/Reflection.h"
@@ -22,6 +24,7 @@
 #include "Engine/World.h"
 #include "FrameGraph/SkyNode.h"
 #include "Raytracing/SkyEnvironmentGenerator.h"
+#include "RHI/Texture.h"
 
 using namespace Sailor;
 
@@ -144,7 +147,93 @@ namespace
 		using Framegraph::SkyNode::ConsumePendingSkyParams;
 		using Framegraph::SkyNode::CreateEnvironmentProjectionMatrix;
 		using Framegraph::SkyNode::CreateEnvironmentViewMatrices;
+		using Framegraph::SkyNode::LoadCloudsNoise;
+		using Framegraph::SkyNode::AreCloudsResourcesReady;
+
+		void SetCloudTextures(RHI::RHITexturePtr map, RHI::RHITexturePtr low, RHI::RHITexturePtr high)
+		{
+			m_pCloudsMapTexture = map;
+			m_pCloudsNoiseLowTexture = low;
+			m_pCloudsNoiseHighTexture = high;
+		}
 	};
+
+	void TestCloudsWaitForAllTextureUploads()
+	{
+		class PendingTexture final : public RHI::RHITexture
+		{
+		public:
+			PendingTexture() : RHITexture(RHI::ETextureFiltration::Linear,
+				RHI::ETextureClamping::Repeat, false) {}
+			bool IsReady() const override { return ready; }
+			bool ready = false;
+		};
+		SkyNodeMailboxProbe node;
+		Require(!node.AreCloudsResourcesReady(), "clouds must be skipped before noise generation completes");
+		auto map = TRefPtr<PendingTexture>::Make();
+		auto low = TRefPtr<PendingTexture>::Make();
+		auto high = TRefPtr<PendingTexture>::Make();
+		node.SetCloudTextures(map, low, high);
+		Require(!node.AreCloudsResourcesReady(), "scheduled GPU uploads are not yet renderable");
+		map->ready = true;
+		high->ready = true;
+		Require(!node.AreCloudsResourcesReady(), "one completed noise volume must not enable clouds");
+		low->ready = true;
+		Require(node.AreCloudsResourcesReady(), "clouds become renderable when all uploads complete");
+		map->ready = false;
+		Require(!node.AreCloudsResourcesReady(), "clouds also require the weather map upload");
+		node.SetCloudTextures(map, nullptr, high);
+		Require(!node.AreCloudsResourcesReady(), "missing noise must disable clouds again");
+	}
+
+	void TestCloudNoiseCacheRecovery()
+	{
+		struct TemporaryCache
+		{
+			std::filesystem::path path = std::filesystem::temp_directory_path() /
+				("sailor-cloud-noise-" + FileId::CreateNewFileId().ToString());
+			TemporaryCache() { std::filesystem::create_directory(path); }
+			~TemporaryCache()
+			{
+				std::error_code error;
+				std::filesystem::remove_all(path, error);
+			}
+		} cache;
+		static uint32_t generationCount = 0;
+		generationCount = 0;
+		auto generate = +[]() -> TVector<uint8_t>
+		{
+			generationCount++;
+			return { 3, 17, 42, 65, 90, 127, 180, 255 };
+		};
+		const auto path = cache.path / "noise.bin";
+		auto verify = [](const TVector<uint8_t>& noise)
+		{
+			const TVector<uint8_t> expected{ 3, 17, 42, 65, 90, 127, 180, 255 };
+			Require(noise.Num() == expected.Num(), "noise must contain the entire volume");
+			for (size_t i = 0; i < expected.Num(); ++i)
+			{
+				Require(noise[i] == expected[i], "noise payload must survive the cache round trip");
+			}
+		};
+
+		verify(SkyNodeMailboxProbe::LoadCloudsNoise(path.string(), 2, generate));
+		Require(generationCount == 1, "a cold cache should generate the noise");
+		verify(SkyNodeMailboxProbe::LoadCloudsNoise(path.string(), 2, generate));
+		Require(generationCount == 1, "a valid cache should not regenerate noise");
+
+		AssetRegistry::WriteBinaryFile(path, TVector<uint8_t>{ 1, 2 });
+		verify(SkyNodeMailboxProbe::LoadCloudsNoise(path.string(), 2, generate));
+		Require(generationCount == 2, "a truncated cache should be regenerated");
+		AssetRegistry::WriteBinaryFile(path, TVector<uint8_t>{ 1, 2, 3, 4, 5, 6, 7, 8, 9 });
+		verify(SkyNodeMailboxProbe::LoadCloudsNoise(path.string(), 2, generate));
+		Require(generationCount == 3, "an oversized cache should be regenerated");
+
+		// A regular file cannot be used as a parent directory, even when run as root.
+		verify(SkyNodeMailboxProbe::LoadCloudsNoise((path / "unwritable.bin").string(), 2, generate));
+		Require(generationCount == 4,
+			"an unwritable cache must still return the generated in-memory volume");
+	}
 
 	glm::vec3 ReconstructEnvironmentDirection(
 		const glm::mat4& projection,
@@ -1210,6 +1299,8 @@ int main()
 		{ "EnvironmentKeyHashEquality", TestEnvironmentKeyHashEquality },
 		{ "TransientBakeEnvironmentUsesClearSkyParameters", TestTransientBakeEnvironmentUsesClearSkyParameters },
 		{ "SkyNodeMailboxHandoff", TestSkyNodeMailboxHandoff },
+		{ "CloudNoiseCacheRecovery", TestCloudNoiseCacheRecovery },
+		{ "CloudsWaitForAllTextureUploads", TestCloudsWaitForAllTextureUploads },
 		{ "EnvironmentCubemapOrientation", TestEnvironmentCubemapOrientation },
 		{ "ExplicitDirectionalLightSynchronization", TestExplicitDirectionalLightSynchronization },
 		{ "DestroyedLightReferencesSerializeAsNull", TestDestroyedLightReferencesSerializeAsNull },


### PR DESCRIPTION
## Summary

Keep the sky rendering while cloud noise is loaded or generated. Only the cloud pass is skipped until its resources are ready.

This is an independent fix based directly on `main` (`5bf68d9a9`). The cascaded-shadow fix stays in #199; neither PR contains the other's changes.

## Linked Issue

Direct user request; no separate issue.

## Implementation Notes

- Read or generate both noise volumes in Sailor tasks on the dedicated Background queue, without nested Worker tasks or waits.
- Return the generated bytes through the task result. A missing, incorrectly sized, or unwritable cache does not prevent the in-memory result from being used.
- Capture paths and generator functions by value so pending work does not access a destroyed SkyNode.
- Keep valid fallback descriptors while loading, then enable clouds only after the noise volumes, weather map, and cloud shader are ready.
- Leave the cloud render target transparent while pending, preserving the sky and sun passes.
- Keep noise formats and generation formulas unchanged. No generated assets, settings changes, or DemoSailor files are included.

## Tests

Validated locally on macOS arm64 at `1be89243c`:

- [x] `python3 update_deps.py`
- [x] Release build: `SkyComponentContractTests` and `SailorExec`.
- [x] `ctest --test-dir build-mac-vcpkg -C Release -R '^SkyComponentContractTests$' --output-on-failure` — passed; all 12 cases also passed directly.
- [x] Cache recovery tests: missing, valid, truncated, oversized, and unwritable cache.
- [x] Readiness test: clouds stay disabled until both volume uploads and the weather map are ready.
- [x] Bounded cold-noise runtime smoke on the independent PR head: both volumes generated at the expected sizes, two visual captures passed, and the engine exited normally in 12.18 s.
- [x] Windows MSVC, clang-cl and Editor CI passed on the exact merged PR head.
- [ ] Full world suite, sustained performance benchmark, and deterministic pre-completion screenshot assertion were not run.

The temporary smoke workspace fell back to the engine's default High profile after rejecting its incomplete test settings; it did not exercise the requested custom profile. Local runtime artifacts: `/private/tmp/sailor-cloud-task.Y5WSDF/`.

## Agent Workflow

- [x] Implementation Summary is posted below.
- [x] Merge-audit Tech Review completed; no blocking findings.
- [x] QA evidence and explicit test exceptions reviewed; see the merge-audit report.
- [x] Maintainer explicitly authorized merge after review and successful exact-head CI.

## Risk

Medium: changes task scheduling, resource-readiness gating, and sky descriptor updates. Generation is serialized on the Background queue; no GPU performance improvement is claimed.

Merged after the maintainer-requested audit as `5f07e02c81adca81f757a328c55dd99538d24e18`.
