### PR TITLE
Add environment-lit height fog and configurable shadow distance

### DIFF
--- a/Content/Shaders/AtmosphericFog.shader
+++ b/Content/Shaders/AtmosphericFog.shader
@@ -1,0 +1,106 @@
+---
+includes:
+- Shaders/Constants.glsl
+- Shaders/Math.glsl
+defines: []
+glslCommon: |
+  #version 460
+  #extension GL_ARB_separate_shader_objects : enable
+glslVertex: |
+  layout(location=DefaultPositionBinding) in vec3 inPosition;
+  layout(location=DefaultTexcoordBinding) in vec2 inTexcoord;
+  layout(location=0) out vec2 fragTexcoord;
+  void main()
+  {
+    gl_Position = vec4(inPosition, 1.0);
+    fragTexcoord = inTexcoord;
+  }
+glslFragment: |
+  layout(set=0, binding=0) uniform FrameData
+  {
+    mat4 view;
+    mat4 projection;
+    mat4 invProjection;
+    vec4 cameraPosition;
+    ivec2 viewportSize;
+    vec2 cameraZNearZFar;
+    float currentTime;
+    float deltaTime;
+  } frame;
+  layout(set=1, binding=1) uniform sampler2D depthSampler;
+  layout(set=1, binding=2) uniform samplerCube environmentSampler;
+  layout(set=1, binding=3) uniform samplerCube previousEnvironmentSampler;
+  layout(set=1, binding=0) uniform FogData
+  {
+    vec4 fog;
+    vec4 scattering;
+    vec4 directionToSun;
+    vec4 sunIlluminance;
+    vec4 previousDirectionToSun;
+    vec4 previousSunIlluminance;
+  } data;
+  layout(location=0) in vec2 fragTexcoord;
+  layout(location=0) out vec4 outColor;
+
+  vec3 AmbientRadiance(samplerCube environment, float lod)
+  {
+    // Environment's diffuse fallback already stores E / PI. Its full-sphere
+    // average estimates isotropic incoming radiance; do not divide by PI again.
+    // Six symmetric directions cancel the dominant directional SH bands.
+    return (textureLod(environment, vec3(1, 0, 0), lod).rgb +
+      textureLod(environment, vec3(-1, 0, 0), lod).rgb +
+      textureLod(environment, vec3(0, 1, 0), lod).rgb +
+      textureLod(environment, vec3(0, -1, 0), lod).rgb +
+      textureLod(environment, vec3(0, 0, 1), lod).rgb +
+      textureLod(environment, vec3(0, 0, -1), lod).rgb) / 6.0;
+  }
+
+  vec3 ScatteredRadiance(samplerCube environment, vec4 sunDirection, vec3 sunIlluminance, vec3 viewDirection)
+  {
+    float g = clamp(data.scattering.y, -0.95, 0.95);
+    // Looking toward the sun produces the forward-scattering lobe.
+    float cosine = clamp(dot(viewDirection, sunDirection.xyz), -1.0, 1.0);
+    float denominator = max(1.0 + g * g - 2.0 * g * cosine, 0.0001);
+    float phase = (1.0 - g * g) / (4.0 * PI * denominator * sqrt(denominator));
+    return AmbientRadiance(environment, sunDirection.w) + sunIlluminance * phase;
+  }
+
+  void main()
+  {
+    outColor = vec4(0.0);
+    float depth = textureLod(depthSampler, fragTexcoord, 0.0).r;
+    // Reverse-Z clear depth is sky, which already includes atmospheric scattering.
+    if(depth <= 0.0 || isnan(depth) || isinf(depth)) return;
+    vec2 uv = FramebufferUvToSceneProjectionUv(fragTexcoord);
+    vec4 viewPosition = frame.invProjection * vec4(uv * 2.0 - 1.0, depth, 1.0);
+    if(abs(viewPosition.w) < 0.000001) return;
+    vec3 displacement = transpose(mat3(frame.view)) * (viewPosition.xyz / viewPosition.w);
+    float distance = length(displacement);
+    float startDistance = max(data.fog.w, 0.0);
+    if(isnan(distance) || isinf(distance) || distance <= startDistance) return;
+
+    float startHeight = frame.cameraPosition.y + displacement.y * (startDistance / distance);
+    float endHeight = frame.cameraPosition.y + displacement.y;
+    float falloff = max(data.fog.y, 0.0);
+    float heightDelta = falloff * abs(endHeight - startHeight);
+    // Integrate from the denser endpoint: no growing exponential, and a
+    // continuous horizontal-ray limit instead of division by a tiny slope.
+    float integral = heightDelta < 0.001
+      ? 1.0 - heightDelta * 0.5 + heightDelta * heightDelta / 6.0
+      : (1.0 - exp(-heightDelta)) / heightDelta;
+    float density = max(data.fog.x, 0.0) * exp(clamp(
+      -falloff * (min(startHeight, endHeight) - data.fog.z), -80.0, 20.0));
+    float opticalDepth = min(80.0, density * (distance - startDistance) * integral);
+    float opacity = min(1.0 - exp(-opticalDepth), clamp(data.scattering.z, 0.0, 1.0));
+    vec3 radiance = ScatteredRadiance(environmentSampler, data.directionToSun,
+      data.sunIlluminance.rgb, displacement / distance);
+    if(data.scattering.w < 1.0)
+    {
+      vec3 previous = ScatteredRadiance(previousEnvironmentSampler, data.previousDirectionToSun,
+        data.previousSunIlluminance.rgb, displacement / distance);
+      radiance = mix(previous, radiance, clamp(data.scattering.w, 0.0, 1.0));
+    }
+    // Fixed-function source-over preserves HDR alpha metadata and avoids a
+    // framebuffer copy or simultaneous sampling/writing of the colour target.
+    outColor = vec4(clamp(data.scattering.x, 0.0, 1.0) * clamp(radiance, vec3(0.0), vec3(65504.0)), opacity);
+  }

--- a/Content/Shaders/AtmosphericFog.shader.asset
+++ b/Content/Shaders/AtmosphericFog.shader.asset
@@ -1,0 +1,3 @@
+assetInfoType: Sailor::ShaderAssetInfo
+fileId: 4C696C65-070E-4CEE-9C2A-ED1BBDDD00C3
+filename: AtmosphericFog.shader

--- a/Content/Shaders/Constants.glsl
+++ b/Content/Shaders/Constants.glsl
@@ -24,6 +24,5 @@
 #define MAX_SHADOW_MAP_SAMPLERS 128
 #define MAX_TEXTURES_IN_SCENE 8192
 #define NUM_CSM_CASCADES 4
-const float ShadowMaxDistance = 200;
 const float ShadowCascadeBlendFraction = 0.1;
 const float ShadowCascadeLevels[4] = { 0.025,0.075,0.2,1};

--- a/Content/Shaders/Debug.shader
+++ b/Content/Shaders/Debug.shader
@@ -142,11 +142,10 @@ glslFragment: |
         outColor.xyz += vec3(0.05,0.05,0.05);
     }
   #elif defined(CASCADES)
+    if(light.instance.length() == 0 || light.instance[0].activeCascadeCount == 0u) return;
     float linearDepth = texture(linearDepthSampler, fragTexcoord).r;
-    float shadowFarPlane = min(frame.cameraZNearZFar.y, ShadowMaxDistance);
-    const uint activeCascadeCount = light.instance.length() > 0 ?
-      clamp(light.instance[0].activeCascadeCount, 1u, uint(NUM_CSM_CASCADES)) :
-      uint(NUM_CSM_CASCADES);
+    float shadowFarPlane = min(frame.cameraZNearZFar.y, light.instance[0].shadowDistance);
+    const uint activeCascadeCount = clamp(light.instance[0].activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
     int layer = int(activeCascadeCount);
     for (int i = 0; i < int(activeCascadeCount); ++i)
     {

--- a/Content/Shaders/ForwardLighting.glsl
+++ b/Content/Shaders/ForwardLighting.glsl
@@ -204,7 +204,8 @@ float CalculateCascadedDirectionalShadow(
     frame.view,
     worldPosition,
     frame.cameraZNearZFar,
-    activeCascadeCount);
+    activeCascadeCount,
+    lightData.shadowDistance);
   if(cascadeLayer >= int(activeCascadeCount))
   {
     return 1.0;
@@ -228,7 +229,8 @@ float CalculateCascadedDirectionalShadow(
     worldPosition,
     frame.cameraZNearZFar,
     cascadeLayer,
-    activeCascadeCount);
+    activeCascadeCount,
+    lightData.shadowDistance);
   if(cascadeBlend > 0.0)
   {
     const int nextCascadeLayer = cascadeLayer + 1;
@@ -253,7 +255,8 @@ float CalculateCascadedDirectionalShadow(
     worldPosition,
     frame.cameraZNearZFar,
     cascadeLayer,
-    activeCascadeCount);
+    activeCascadeCount,
+    lightData.shadowDistance);
   return mix(shadow, 1.0, shadowDistanceFade);
 }
 

--- a/Content/Shaders/Lighting.glsl
+++ b/Content/Shaders/Lighting.glsl
@@ -31,6 +31,7 @@ struct LightData
   uint activeCascadeCount;
   float shadowBias;
   vec3 worldPosition;
+  float shadowDistance;
   vec3 direction;
   vec3 intensity;
   vec2 cutOff;
@@ -663,11 +664,12 @@ int SelectCascade(
   mat4 view,
   vec3 worldPosition,
   vec2 cameraZNearZFar,
-  uint activeCascadeCount)
+  uint activeCascadeCount,
+  float shadowDistance)
 {
   vec4 fragPosViewSpace = view * vec4(worldPosition, 1.0);
   float depthValue = abs(fragPosViewSpace.z / fragPosViewSpace.w);
-  float shadowFarPlane = min(cameraZNearZFar.y, ShadowMaxDistance);
+  float shadowFarPlane = min(cameraZNearZFar.y, shadowDistance);
   const uint safeCascadeCount = clamp(activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
   
   int layer = int(safeCascadeCount);
@@ -689,7 +691,8 @@ float CalculateCascadeBlend(
   vec3 worldPosition,
   vec2 cameraZNearZFar,
   int cascadeLayer,
-  uint activeCascadeCount)
+  uint activeCascadeCount,
+  float shadowDistance)
 {
   const uint safeCascadeCount = clamp(activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
   if(cascadeLayer < 0 || cascadeLayer >= int(safeCascadeCount) - 1)
@@ -699,7 +702,7 @@ float CalculateCascadeBlend(
 
   vec4 fragPosViewSpace = view * vec4(worldPosition, 1.0f);
   float depthValue = abs(fragPosViewSpace.z / fragPosViewSpace.w);
-  float shadowFarPlane = min(cameraZNearZFar.y, ShadowMaxDistance);
+  float shadowFarPlane = min(cameraZNearZFar.y, shadowDistance);
   float cascadeNear = cascadeLayer == 0 ?
     cameraZNearZFar.x :
     shadowFarPlane * GetActiveShadowCascadeLevel(
@@ -716,7 +719,8 @@ float CalculateShadowDistanceFade(
   vec3 worldPosition,
   vec2 cameraZNearZFar,
   int cascadeLayer,
-  uint activeCascadeCount)
+  uint activeCascadeCount,
+  float shadowDistance)
 {
   const uint safeCascadeCount = clamp(activeCascadeCount, 1u, uint(NUM_CSM_CASCADES));
   if(cascadeLayer != int(safeCascadeCount) - 1)
@@ -726,7 +730,7 @@ float CalculateShadowDistanceFade(
 
   const vec4 fragPosViewSpace = view * vec4(worldPosition, 1.0f);
   const float depthValue = abs(fragPosViewSpace.z / fragPosViewSpace.w);
-  const float shadowFarPlane = min(cameraZNearZFar.y, ShadowMaxDistance);
+  const float shadowFarPlane = min(cameraZNearZFar.y, shadowDistance);
   const float cascadeNear = safeCascadeCount > 1u ?
     shadowFarPlane * GetActiveShadowCascadeLevel(
       int(safeCascadeCount) - 2, safeCascadeCount) :

--- a/Editor.Tests/SettingsContractsTests.cs
+++ b/Editor.Tests/SettingsContractsTests.cs
@@ -5,6 +5,57 @@ namespace SailorEditor.Editor.Tests;
 public class SettingsContractsTests
 {
     [Fact]
+    public void ShadowDistance_RoundTripsThroughYamlAndEditorDraft()
+    {
+        var preset = GraphicsSettingsDefaults.Project.Graphics.Presets.Ultra with
+        {
+            ShadowDistance = 600
+        };
+        var source = GraphicsSettingsDefaults.Project with
+        {
+            Graphics = GraphicsSettingsDefaults.Project.Graphics with
+            {
+                Presets = GraphicsSettingsDefaults.Project.Graphics.Presets.With(
+                    GraphicsQualityLevel.Ultra, preset)
+            }
+        };
+        var diagnostics = new List<string>();
+        var parsed = GraphicsSettingsYamlCodec.ParseProject(
+            GraphicsSettingsYamlCodec.SerializeProject(source), diagnostics, "shadow-distance");
+        Assert.Empty(diagnostics);
+        Assert.Equal(1, parsed.SettingsVersion);
+        Assert.Equal(600, parsed.Graphics.Presets.Ultra.ShadowDistance);
+        Assert.Equal(200, parsed.Graphics.Presets.High.ShadowDistance);
+
+        var draft = GraphicsQualityPresetDraft.FromSettings(parsed.Graphics.Presets.Ultra);
+        var issues = new List<GraphicsSettingsValidationIssue>();
+        Assert.True(draft.TryBuild(GraphicsQualityLevel.Ultra, out var built, issues));
+        Assert.Empty(issues);
+        Assert.Equal(preset.ShadowDistance, built.ShadowDistance);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(10001)]
+    [InlineData(double.NaN)]
+    [InlineData(double.PositiveInfinity)]
+    public void ShadowDistance_RejectsNonFiniteOrOutOfRangeValues(double distance)
+    {
+        var source = GraphicsSettingsDefaults.Project with
+        {
+            Graphics = GraphicsSettingsDefaults.Project.Graphics with
+            {
+                Presets = GraphicsSettingsDefaults.Project.Graphics.Presets.With(
+                    GraphicsQualityLevel.Ultra,
+                    GraphicsSettingsDefaults.Project.Graphics.Presets.Ultra with { ShadowDistance = distance })
+            }
+        };
+        var result = GraphicsSettingsValidator.Validate(source);
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Issues, issue => issue.Path == "graphics.presets.Ultra.shadowDistance");
+    }
+
+    [Fact]
     public void SettingsCategory_ExposesHierarchyAndEntries()
     {
         var entry = new SettingsEntry("engine.vsync", "VSync", SettingsValueKind.Boolean, SettingsScope.Engine);

--- a/Editor/Settings/GraphicsSettings.cs
+++ b/Editor/Settings/GraphicsSettings.cs
@@ -81,6 +81,7 @@ public sealed record GraphicsQualityPresetSettings
     public int MsaaSamples { get; init; }
     public GraphicsShadowQuality ShadowQuality { get; init; }
     public double ShadowBias { get; init; }
+    public double ShadowDistance { get; init; } = 200.0;
     public int ShadowCascadeCount { get; init; }
     public IReadOnlyList<int> ShadowCascadeResolutions { get; init; } = [];
     public bool SupportSoftShadows { get; init; }
@@ -454,6 +455,12 @@ public static class GraphicsSettingsValidator
         if (preset.ShadowCascadeCount is < 1 or > 4)
         {
             AddRangeIssue(issues, $"{path}.shadowCascadeCount", "Shadow cascade count", "1 and 4");
+        }
+
+        if (!double.IsFinite(preset.ShadowDistance) ||
+            preset.ShadowDistance is < 1.0 or > 10000.0)
+        {
+            AddRangeIssue(issues, $"{path}.shadowDistance", "Shadow distance", "1 and 10000 meters");
         }
 
         if (preset.ShadowCascadeResolutions is null ||
@@ -894,6 +901,7 @@ public static class GraphicsSettingsYamlCodec
             MsaaSamples = ReadInt(preset, "msaaSamples", $"{path}.msaaSamples", issues),
             ShadowQuality = ReadEnum<GraphicsShadowQuality>(preset, "shadowQuality", $"{path}.shadowQuality", issues),
             ShadowBias = ReadDouble(preset, "shadowBias", $"{path}.shadowBias", issues),
+            ShadowDistance = ReadDouble(preset, "shadowDistance", $"{path}.shadowDistance", issues),
             ShadowCascadeCount = ReadInt(preset, "shadowCascadeCount", $"{path}.shadowCascadeCount", issues),
             ShadowCascadeResolutions = ReadIntSequence(preset, "shadowCascadeResolutions", $"{path}.shadowCascadeResolutions", issues),
             SupportSoftShadows = ReadBool(preset, "supportSoftShadows", $"{path}.supportSoftShadows", issues),
@@ -956,6 +964,7 @@ public static class GraphicsSettingsYamlCodec
         SetScalar(preset, "msaaSamples", settings.MsaaSamples);
         SetScalar(preset, "shadowQuality", settings.ShadowQuality);
         SetScalar(preset, "shadowBias", settings.ShadowBias);
+        SetScalar(preset, "shadowDistance", settings.ShadowDistance);
         SetScalar(preset, "shadowCascadeCount", settings.ShadowCascadeCount);
         SetNode(
             preset,

--- a/Editor/Settings/GraphicsSettingsDraft.cs
+++ b/Editor/Settings/GraphicsSettingsDraft.cs
@@ -36,6 +36,7 @@ public sealed record GraphicsQualityPresetDraft(
     int MsaaSamples,
     GraphicsShadowQuality ShadowQuality,
     string ShadowBias,
+    string ShadowDistance,
     int ShadowCascadeCount,
     string ShadowCascadeResolutions,
     bool SupportSoftShadows,
@@ -56,6 +57,7 @@ public sealed record GraphicsQualityPresetDraft(
             settings.MsaaSamples,
             settings.ShadowQuality,
             FormatDouble(settings.ShadowBias),
+            FormatDouble(settings.ShadowDistance),
             settings.ShadowCascadeCount,
             string.Join(", ", settings.ShadowCascadeResolutions),
             settings.SupportSoftShadows,
@@ -105,6 +107,12 @@ public sealed record GraphicsQualityPresetDraft(
             "Clouds resolution multiplier",
             issues,
             out var cloudsResolutionMultiplier);
+        valid &= TryParseDouble(
+            ShadowDistance,
+            $"{path}.shadowDistance",
+            "Shadow distance",
+            issues,
+            out var shadowDistance);
         valid &= TryParseInt(
             SkyResolution,
             $"{path}.skyResolution",
@@ -148,6 +156,7 @@ public sealed record GraphicsQualityPresetDraft(
             MsaaSamples = MsaaSamples,
             ShadowQuality = ShadowQuality,
             ShadowBias = shadowBias,
+            ShadowDistance = shadowDistance,
             ShadowCascadeCount = ShadowCascadeCount,
             ShadowCascadeResolutions = cascadeResolutions,
             SupportSoftShadows = SupportSoftShadows,

--- a/Editor/Settings/GraphicsSettingsService.cs
+++ b/Editor/Settings/GraphicsSettingsService.cs
@@ -934,6 +934,7 @@ static class GraphicsSettingsEquality
             left.MsaaSamples == right.MsaaSamples &&
             left.ShadowQuality == right.ShadowQuality &&
             left.ShadowBias.Equals(right.ShadowBias) &&
+            left.ShadowDistance.Equals(right.ShadowDistance) &&
             left.ShadowCascadeCount == right.ShadowCascadeCount &&
             left.ShadowCascadeResolutions.SequenceEqual(
                 right.ShadowCascadeResolutions) &&

--- a/Editor/Views/SettingsPanelView.cs
+++ b/Editor/Views/SettingsPanelView.cs
@@ -914,6 +914,7 @@ public sealed class SettingsPanelView : ContentView
         readonly Picker _msaaSamples;
         readonly Picker _shadowQuality;
         readonly Entry _shadowBias;
+        readonly Entry _shadowDistance;
         readonly Picker _shadowCascadeCount;
         readonly Entry _shadowCascadeResolutions;
         readonly Switch _supportSoftShadows;
@@ -952,6 +953,7 @@ public sealed class SettingsPanelView : ContentView
                 ShadowQualityOptions.Cast<object>().ToArray(),
                 ShadowQualityOptions.Single(x => x.Value == draft.ShadowQuality));
             _shadowBias = CreateEntry(draft.ShadowBias);
+            _shadowDistance = CreateEntry(draft.ShadowDistance);
             _shadowCascadeCount = CreatePicker(
                 new object[] { 1, 2, 3, 4 },
                 draft.ShadowCascadeCount);
@@ -1030,6 +1032,7 @@ public sealed class SettingsPanelView : ContentView
                     ? shadow.Value
                     : (GraphicsShadowQuality)(-1),
                 _shadowBias.Text ?? string.Empty,
+                _shadowDistance.Text ?? string.Empty,
                 _shadowCascadeCount.SelectedItem is int count ? count : 0,
                 _shadowCascadeResolutions.Text ?? string.Empty,
                 _supportSoftShadows.IsToggled,
@@ -1065,6 +1068,7 @@ public sealed class SettingsPanelView : ContentView
                     CreatePresetField("MSAA", "Supported sample count", _msaaSamples),
                     CreatePresetField("Shadow Quality Cap", "Global cap over authored light quality", _shadowQuality),
                     CreatePresetField("PCF Shadow Bias", "PCF caster and receiver bias, -16–16", _shadowBias),
+                    CreatePresetField("Shadow Distance", "Directional shadow range in meters, 1–10000", _shadowDistance),
                     CreatePresetField("Shadow Cascade Count", "Active directional cascades, 1–4", _shadowCascadeCount),
                     CreatePresetField("Cascade Resolutions", "Comma-separated powers of two, one per active cascade", _shadowCascadeResolutions),
                     CreatePresetField("Soft Shadows", "Enable soft shadow filtering", _supportSoftShadows),
@@ -1179,6 +1183,12 @@ public sealed class SettingsPanelView : ContentView
                 "Shadow bias",
                 issues,
                 out var shadowBias);
+            valid &= TryParseDouble(
+                _shadowDistance.Text,
+                $"{path}.shadowDistance",
+                "Shadow distance",
+                issues,
+                out var shadowDistance);
             valid &= TryParseCascadeResolutions(
                 _shadowCascadeResolutions.Text,
                 $"{path}.shadowCascadeResolutions",
@@ -1244,6 +1254,7 @@ public sealed class SettingsPanelView : ContentView
                 MsaaSamples = msaaSamples,
                 ShadowQuality = shadowQuality,
                 ShadowBias = shadowBias,
+                ShadowDistance = shadowDistance,
                 ShadowCascadeCount = cascadeCount,
                 ShadowCascadeResolutions = cascadeResolutions,
                 SupportSoftShadows = _supportSoftShadows.IsToggled,

--- a/ProjectSettings.yaml
+++ b/ProjectSettings.yaml
@@ -8,6 +8,7 @@ graphics:
       msaaSamples: 8
       shadowQuality: High
       shadowBias: 1.25
+      shadowDistance: 200
       shadowCascadeCount: 4
       shadowCascadeResolutions:
       - 4096
@@ -41,6 +42,7 @@ graphics:
       msaaSamples: 4
       shadowQuality: High
       shadowBias: 1.25
+      shadowDistance: 200
       shadowCascadeCount: 4
       shadowCascadeResolutions:
       - 2048
@@ -74,6 +76,7 @@ graphics:
       msaaSamples: 2
       shadowQuality: Medium
       shadowBias: 1.25
+      shadowDistance: 200
       shadowCascadeCount: 3
       shadowCascadeResolutions:
       - 2048
@@ -106,6 +109,7 @@ graphics:
       msaaSamples: 1
       shadowQuality: Low
       shadowBias: 1.25
+      shadowDistance: 200
       shadowCascadeCount: 2
       shadowCascadeResolutions:
       - 1024
@@ -137,6 +141,7 @@ graphics:
       msaaSamples: 1
       shadowQuality: VeryLow
       shadowBias: 1.25
+      shadowDistance: 200
       shadowCascadeCount: 1
       shadowCascadeResolutions:
       - 512

--- a/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
+++ b/Runtime/AssetRegistry/Shader/ShaderCompiler.cpp
@@ -190,7 +190,6 @@ std::string GenerateConstantsLibrary(uint32_t version)
 	stream << "#define MAX_SHADOW_MAP_SAMPLERS " << LightingECS::MaxShadowMapSamplers << "\n";
 	stream << "#define MAX_TEXTURES_IN_SCENE " << TextureImporter::MaxTexturesInScene << "\n";
 	stream << "#define NUM_CSM_CASCADES " << LightingECS::NumCascades << "\n";
-	stream << "const float ShadowMaxDistance = " << LightingECS::ShadowMaxDistance << ";\n";
 	stream << "const float ShadowCascadeBlendFraction = " << LightingECS::ShadowCascadeBlendFraction << ";\n";
 	stream << "const float ShadowCascadeLevels[" << LightingECS::NumCascades << "] = { ";
 

--- a/Runtime/ECS/LightingCSM.cpp
+++ b/Runtime/ECS/LightingCSM.cpp
@@ -155,7 +155,7 @@ void LightingECS::PrepareCSMPasses(const RHI::RHISceneViewPtr& sceneView,
 				cameraData.GetAspect(),
 				cameraData.GetFov(),
 				cameraData.GetZNear(),
-				(std::min)(cameraData.GetZFar(), ShadowMaxDistance),
+				(std::min)(cameraData.GetZFar(), App::GetActiveGraphicsSettings().m_shadowDistance),
 				10.0f,
 				glm::ivec2(0),
 				ShadowCasterDepthExtension) *

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -175,6 +175,7 @@ Tasks::ITaskPtr LightingECS::Tick(float deltaTime)
 				shaderData.m_shadowType = (uint32_t)effectiveShadowType;
 				shaderData.m_activeCascadeCount = (std::clamp)(graphicsProfile.m_shadowCascadeCount, 1u, NumCascades);
 				shaderData.m_shadowBias = graphicsProfile.m_shadowBias;
+				shaderData.m_shadowDistance = graphicsProfile.m_shadowDistance;
 				shaderData.m_bounds = glm::vec3(data.m_radius);
 				shaderData.m_intensity = data.m_intensity;
 				shaderData.m_direction = glm::normalize(ownerTransform.GetForwardVector());

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -144,7 +144,6 @@ namespace Sailor
 		// EVSM is based on https://www.cg.tuwien.ac.at/research/publications/2013/ADORJAN-2013-ASE/ADORJAN-2013-ASE-thesis.pdf
 		// Also handy paper: https://dl.acm.org/doi/pdf/10.5555/1375714.1375739
 		static constexpr uint32_t NumCascades = 4;
-		static constexpr float ShadowMaxDistance = 200.0f;
 		static constexpr float ShadowCasterDepthExtension = 200.0f;
 		static constexpr float ShadowCascadeBlendFraction = 0.1f;
 		static constexpr float ShadowCascadeLevels[NumCascades] = { 0.025f, 0.075f, 0.2f, 1.0f };

--- a/Runtime/FrameGraph/AtmosphericFogNode.cpp
+++ b/Runtime/FrameGraph/AtmosphericFogNode.cpp
@@ -1,0 +1,183 @@
+#include "AtmosphericFogNode.h"
+#include "AssetRegistry/AssetRegistry.h"
+#include "FrameGraph/EnvironmentNode.h"
+#include "Raytracing/SkyEnvironmentGenerator.h"
+#include "RHI/Cubemap.h"
+#include "RHI/RenderTarget.h"
+#include "RHI/SceneView.h"
+#include "RHI/Shader.h"
+#include "RHI/Surface.h"
+#include "RHI/VertexDescription.h"
+#include <cmath>
+
+using namespace Sailor;
+using namespace Sailor::RHI;
+using namespace Sailor::Framegraph;
+
+#ifndef _SAILOR_IMPORT_
+const char* AtmosphericFogNode::m_name = "AtmosphericFog";
+#endif
+
+AtmosphericFogNode::AtmosphericFogNode()
+{
+	SetVec4("fog", glm::vec4(0.0f));
+	SetVec4("scattering", glm::vec4(0.9f, 0.3f, 0.95f, 0.35f));
+}
+
+void AtmosphericFogNode::PreloadShader()
+{
+	if (!m_shader)
+	{
+		if (const auto info = App::GetSubmodule<AssetRegistry>()->GetAssetInfoPtr("Shaders/AtmosphericFog.shader"))
+		{
+			App::GetSubmodule<ShaderCompiler>()->LoadShader(info->GetFileId(), m_shader);
+		}
+	}
+}
+
+bool AtmosphericFogNode::IsShaderReady() const
+{
+	return m_shader && m_shader->IsReady();
+}
+
+void AtmosphericFogNode::Process(RHIFrameGraphPtr frameGraph, RHICommandListPtr transferCommandList,
+	RHICommandListPtr commandList, const RHISceneViewSnapshot& sceneView)
+{
+	SAILOR_PROFILE_FUNCTION();
+	ResetDrawCallStats();
+
+	m_parameters.m_fog = GetVec4("fog");
+	m_parameters.m_scattering = GetVec4("scattering");
+	for (uint32_t i = 0; i < 4; ++i)
+	{
+		if (!std::isfinite(m_parameters.m_fog[i]) || !std::isfinite(m_parameters.m_scattering[i])) return;
+	}
+	if (m_parameters.m_fog.x <= 0.0f || m_parameters.m_scattering.z <= 0.0f || !frameGraph) return;
+
+	RHITexturePtr color = GetResolvedAttachment("color");
+	RHISurfacePtr surface = GetRHIResource("color").DynamicCast<RHISurface>();
+	RHITexturePtr depth = GetResolvedAttachment("depthSampler");
+	for (const auto& resource : m_unresolvedResourceParams)
+	{
+		if (resource.First() == "color")
+		{
+			surface = frameGraph->GetSurface(*resource.Second());
+			color = surface ? surface->GetResolved() : frameGraph->GetRenderTarget(*resource.Second());
+		}
+		else if (resource.First() == "depthSampler") depth = frameGraph->GetRenderTarget(*resource.Second());
+	}
+	if (!color || !depth || !sceneView.m_frameBindings) return;
+	PreloadShader();
+	if (!IsShaderReady()) return;
+	const auto environment = frameGraph->GetSampler("g_irradianceCubemap").DynamicCast<RHICubemap>();
+	if (!environment) return;
+	const float transitionSeconds = glm::max(m_parameters.m_scattering.w, 0.0f);
+	const float deltaTime = std::isfinite(sceneView.m_deltaTime) ? glm::max(sceneView.m_deltaTime, 0.0f) : 0.0f;
+	m_lightingBlend = transitionSeconds > 0.0f
+		? glm::min(1.0f, m_lightingBlend + deltaTime / transitionSeconds) : 1.0f;
+	bool lightingChanged = false;
+	// Finish the current fade before adopting the newest generation. This keeps
+	// transitions continuous even if the producer updates faster than the fade.
+	if (environment != m_environment && m_lightingBlend >= 1.0f)
+	{
+		m_previousEnvironment = m_environment;
+		m_parameters.m_previousDirectionToSun = m_parameters.m_directionToSun;
+		m_parameters.m_previousSunIlluminance = m_parameters.m_sunIlluminance;
+		m_environment = environment;
+		m_parameters.m_directionToSun = glm::vec4(0, 1, 0, 0);
+		m_parameters.m_sunIlluminance = glm::vec4(0);
+		SkyParameters sky;
+		if (const auto node = frameGraph->GetGraphNode("Environment").DynamicCast<EnvironmentNode>();
+			node && node->GetEnvironmentSkyParams(sky))
+		{
+			m_parameters.m_directionToSun = glm::vec4(Math::SafeNormalize(-glm::vec3(sky.m_lightDirection),
+				Math::vec3_Up), m_parameters.m_directionToSun.w);
+			m_parameters.m_sunIlluminance = glm::vec4(Raytracing::CalculateDirectSunIlluminance(sky), 0);
+		}
+		m_lightingBlend = m_previousEnvironment && transitionSeconds > 0.0f ? 0.0f : 1.0f;
+		lightingChanged = true;
+	}
+	if (m_lightingBlend >= 1.0f && m_previousEnvironment != m_environment)
+	{
+		m_previousEnvironment = m_environment;
+		m_parameters.m_previousDirectionToSun = m_parameters.m_directionToSun;
+		m_parameters.m_previousSunIlluminance = m_parameters.m_sunIlluminance;
+		lightingChanged = true;
+	}
+	m_parameters.m_scattering.w = m_lightingBlend;
+
+	auto& driver = App::GetSubmodule<Renderer>()->GetDriver();
+	auto commands = App::GetSubmodule<Renderer>()->GetDriverCommands();
+	RHITexturePtr sampledDepth = depth;
+	if (const auto target = depth.DynamicCast<RHIRenderTarget>())
+	{
+		if (const auto aspect = target->GetDepthAspect()) sampledDepth = aspect;
+	}
+	if (!m_bindings || m_depthTexture != sampledDepth || lightingChanged)
+	{
+		m_bindings = driver->CreateShaderBindings();
+		driver->FillShadersLayout(m_bindings,
+			{ m_shader->GetDebugVertexShaderRHI(), m_shader->GetDebugFragmentShaderRHI() }, 1);
+		driver->AddBufferToShaderBindings(m_bindings, "data", sizeof(ShaderParameters), 0, EShaderBindingType::UniformBuffer);
+		driver->AddSamplerToShaderBindings(m_bindings, "depthSampler", sampledDepth, 1);
+		driver->AddSamplerToShaderBindings(m_bindings, "environmentSampler", m_environment, 2);
+		driver->AddSamplerToShaderBindings(m_bindings, "previousEnvironmentSampler", m_previousEnvironment, 3);
+		m_bindings->RecalculateCompatibility();
+		m_depthTexture = sampledDepth;
+	}
+	commands->UpdateShaderBinding(transferCommandList, m_bindings->GetOrAddShaderBinding("data"), &m_parameters, sizeof(m_parameters));
+	const bool multisampling = surface && surface->NeedsResolve();
+	if (!m_material || m_bMultisampling != multisampling)
+	{
+		m_bMultisampling = multisampling;
+		const RenderState state{ false, false, 0, false, ECullMode::None,
+			EBlendMode::AlphaBlendingPreserveAlpha, EFillMode::Fill, 0, multisampling };
+		m_material = driver->CreateMaterial(driver->GetOrAddVertexDescription<VertexP3N3UV2C4>(),
+			EPrimitiveTopology::TriangleList, state, m_shader);
+	}
+
+	commands->BeginDebugRegion(commandList, GetName(), DebugContext::Color_CmdPostProcess);
+	commands->ImageMemoryBarrier(commandList, depth, EImageLayout::ShaderReadOnlyOptimal);
+	commands->ImageMemoryBarrier(commandList, m_environment, EImageLayout::ShaderReadOnlyOptimal);
+	commands->ImageMemoryBarrier(commandList, m_previousEnvironment, EImageLayout::ShaderReadOnlyOptimal);
+	commands->ImageMemoryBarrier(commandList, color, EImageLayout::ColorAttachmentOptimal);
+	const glm::vec4 viewport(0, 0, color->GetExtent().x, color->GetExtent().y);
+	if (multisampling)
+	{
+		// Blend into the live MSAA surface as well as its resolve, so a later
+		// transparent pass cannot restore an unfogged multisampled background.
+		commands->ImageMemoryBarrier(commandList, surface->GetTarget(), EImageLayout::ColorAttachmentOptimal);
+		commands->BeginRenderPass(commandList, TVector<RHISurfacePtr>{surface}, nullptr,
+			viewport, glm::ivec2(0), false, glm::vec4(0), 0.0f, false);
+	}
+	else
+	{
+		commands->BeginRenderPass(commandList, TVector<RHITexturePtr>{color}, nullptr,
+			viewport, glm::ivec2(0), false, glm::vec4(0), 0.0f, false);
+	}
+	const auto mesh = frameGraph->GetFullscreenNdcQuad();
+	commands->BindMaterial(commandList, m_material);
+	commands->BindVertexBuffer(commandList, mesh->m_vertexBuffer, 0);
+	commands->BindIndexBuffer(commandList, mesh->m_indexBuffer, 0);
+	commands->BindShaderBindings(commandList, m_material, { sceneView.m_frameBindings, m_bindings });
+	commands->SetViewport(commandList, 0, 0, viewport.z, viewport.w,
+		glm::vec2(0), glm::vec2(viewport.z, viewport.w), 0, 1.0f);
+	commands->DrawIndexed(commandList, 6, 1,
+		uint32_t(mesh->m_indexBuffer->GetOffset() / sizeof(uint32_t)),
+		uint32_t(mesh->m_vertexBuffer->GetOffset() / mesh->m_vertexDescription->GetVertexStride()), 0);
+	RecordDrawCallStats(1);
+	commands->EndRenderPass(commandList);
+	commands->EndDebugRegion(commandList);
+}
+
+void AtmosphericFogNode::Clear()
+{
+	m_shader.Clear();
+	m_material.Clear();
+	m_bindings.Clear();
+	m_depthTexture.Clear();
+	m_environment.Clear();
+	m_previousEnvironment.Clear();
+	m_parameters = {};
+	m_lightingBlend = 1.0f;
+}

--- a/Runtime/FrameGraph/AtmosphericFogNode.h
+++ b/Runtime/FrameGraph/AtmosphericFogNode.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "FrameGraph/FrameGraphNode.h"
+
+namespace Sailor::Framegraph
+{
+	// Analytic height fog, composited once over opaque/masked HDR colour.
+	// fog = density (1/m), height falloff (1/m), base height (m), start distance (m).
+	// scattering = single-scattering albedo, anisotropy, maximum opacity, transition seconds.
+	class AtmosphericFogNode final : public TFrameGraphNode<AtmosphericFogNode>
+	{
+	public:
+		struct alignas(16) ShaderParameters
+		{
+			glm::vec4 m_fog{};
+			glm::vec4 m_scattering{};
+			glm::vec4 m_directionToSun{};
+			glm::vec4 m_sunIlluminance{};
+			glm::vec4 m_previousDirectionToSun{};
+			glm::vec4 m_previousSunIlluminance{};
+		};
+		static_assert(sizeof(ShaderParameters) == 96);
+		// Render-thread diagnostics, or after Renderer::WaitIdle().
+		const ShaderParameters& GetLightingParameters() const { return m_parameters; }
+		SAILOR_API AtmosphericFogNode();
+		SAILOR_API static const char* GetName() { return m_name; }
+		SAILOR_API void PreloadShader();
+		SAILOR_API bool IsShaderReady() const;
+		SAILOR_API virtual void Process(RHI::RHIFrameGraphPtr frameGraph,
+			RHI::RHICommandListPtr transferCommandList, RHI::RHICommandListPtr commandList,
+			const RHI::RHISceneViewSnapshot& sceneView) override;
+		SAILOR_API virtual void Clear() override;
+
+	private:
+		static const char* m_name;
+		ShaderSetPtr m_shader;
+		RHI::RHIMaterialPtr m_material;
+		RHI::RHIShaderBindingSetPtr m_bindings;
+		RHI::RHITexturePtr m_depthTexture;
+		RHI::RHICubemapPtr m_environment, m_previousEnvironment;
+		ShaderParameters m_parameters{};
+		float m_lightingBlend = 1.0f;
+		bool m_bMultisampling = false;
+	};
+
+	template class TFrameGraphNode<AtmosphericFogNode>;
+}

--- a/Runtime/FrameGraph/EnvironmentNode.cpp
+++ b/Runtime/FrameGraph/EnvironmentNode.cpp
@@ -162,13 +162,16 @@ void EnvironmentNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandListPt
 		}
 
 		SkyEnvironmentKey skyHash{};
+		m_environmentUsesSky = false;
 		TRefPtr<SkyNode> pSkyNode{};
 		if (auto node = frameGraph->GetGraphNode("Sky"))
 		{
 			pSkyNode = node.DynamicCast<SkyNode>();
-			if (!bLoadedEnvironmentMap)
+			if (!bLoadedEnvironmentMap && pSkyNode)
 			{
-				skyHash = pSkyNode->GetSkyParams().GetEnvironmentKey();
+				m_environmentSkyParams = pSkyNode->GetSkyParams();
+				m_environmentUsesSky = true;
+				skyHash = m_environmentSkyParams.GetEnvironmentKey();
 			}
 		}
 

--- a/Runtime/FrameGraph/EnvironmentNode.h
+++ b/Runtime/FrameGraph/EnvironmentNode.h
@@ -31,6 +31,14 @@ namespace Sailor::Framegraph
 		SAILOR_API virtual void Clear() override;
 
 		SAILOR_API void MarkDirty() { m_bIsDirty = true; };
+		// Render-thread lighting source paired with the prepared diffuse fallback. Authored HDR
+		// maps may already contain a sun, so they do not add the analytic Sky sun.
+		SAILOR_API bool GetEnvironmentSkyParams(SkyParameters& parameters) const
+		{
+			if (!m_environmentUsesSky) return false;
+			parameters = m_environmentSkyParams;
+			return true;
+		}
 
 		// CPU producers hand off owned pixels. Only Process touches GPU resources.
 		SAILOR_SHARED_API bool SetLocalReflection(LocalReflectionImage image);
@@ -67,6 +75,8 @@ namespace Sailor::Framegraph
 		RHI::RHITexturePtr m_brdfSampler{};
 
 		TexturePtr m_envMapTexture;
+		SkyParameters m_environmentSkyParams{};
+		bool m_environmentUsesSky = false;
 
 		bool m_bIsDirty = false;
 		static const char* m_name;

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -1415,8 +1415,8 @@ void ShadowPrepassNode::CalculateLightProjectionForCascades(
 	TVector<glm::mat4>& outMatrices)
 {
 	SAILOR_PROFILE_FUNCTION();
-	const float shadowFarPlane = (std::min)(cameraFarPlane, LightingECS::ShadowMaxDistance);
 	const auto& graphicsProfile = App::GetActiveGraphicsSettings();
+	const float shadowFarPlane = (std::min)(cameraFarPlane, graphicsProfile.m_shadowDistance);
 	const uint32_t activeCascadeCount = (std::clamp)(
 		graphicsProfile.m_shadowCascadeCount,
 		1u,

--- a/Runtime/GraphicsDriver/Vulkan/VulkanPipileneStates.cpp
+++ b/Runtime/GraphicsDriver/Vulkan/VulkanPipileneStates.cpp
@@ -233,7 +233,7 @@ VulkanPipelineStateBuilder::VulkanPipelineStateBuilder(VulkanDevicePtr pDevice)
 	auto mask = VkColorComponentFlagBits::VK_COLOR_COMPONENT_A_BIT | VkColorComponentFlagBits::VK_COLOR_COMPONENT_R_BIT |
 		VkColorComponentFlagBits::VK_COLOR_COMPONENT_G_BIT | VkColorComponentFlagBits::VK_COLOR_COMPONENT_B_BIT;
 
-	m_blendModes.Resize(4);
+	m_blendModes.Resize(5);
 
 	m_blendModes[(size_t)RHI::EBlendMode::None] = VulkanStateColorBlendingPtr::Make(false, VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ONE, VkBlendOp::VK_BLEND_OP_ADD,
 		VK_BLEND_FACTOR_ONE, VK_BLEND_FACTOR_ONE, VkBlendOp::VK_BLEND_OP_ADD, mask);
@@ -244,6 +244,10 @@ VulkanPipelineStateBuilder::VulkanPipelineStateBuilder(VulkanDevicePtr pDevice)
 
 	m_blendModes[(size_t)RHI::EBlendMode::AlphaBlending] = VulkanStateColorBlendingPtr::Make(true, VK_BLEND_FACTOR_SRC_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VkBlendOp::VK_BLEND_OP_ADD,
 		VK_BLEND_FACTOR_SRC_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VkBlendOp::VK_BLEND_OP_SUBTRACT, mask);
+
+	m_blendModes[(size_t)RHI::EBlendMode::AlphaBlendingPreserveAlpha] = VulkanStateColorBlendingPtr::Make(true,
+		VK_BLEND_FACTOR_SRC_ALPHA, VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA, VK_BLEND_OP_ADD,
+		VK_BLEND_FACTOR_ZERO, VK_BLEND_FACTOR_ONE, VK_BLEND_OP_ADD, mask);
 
 	m_blendModes[(size_t)RHI::EBlendMode::Multiply] = VulkanStateColorBlendingPtr::Make(true,
 		VK_BLEND_FACTOR_ONE,

--- a/Runtime/RHI/DebugContext.cpp
+++ b/Runtime/RHI/DebugContext.cpp
@@ -160,8 +160,8 @@ void DebugContext::DrawFrustum(const Math::Frustum& frustum, const glm::vec4 col
 
 void DebugContext::DrawLightCascades(const glm::mat4& lightView, const glm::mat4& cameraWorld, float aspect, float fovY, float zNear, float zFar, float duration)
 {
-	const float shadowFarPlane = (std::min)(zFar, LightingECS::ShadowMaxDistance);
 	const auto& graphicsProfile = App::GetActiveGraphicsSettings();
+	const float shadowFarPlane = (std::min)(zFar, graphicsProfile.m_shadowDistance);
 	const uint32_t activeCascadeCount = (std::clamp)(
 		graphicsProfile.m_shadowCascadeCount,
 		1u,

--- a/Runtime/RHI/Lighting.h
+++ b/Runtime/RHI/Lighting.h
@@ -16,12 +16,15 @@ namespace Sailor::RHI
 		uint32_t m_activeCascadeCount = 1u;
 		float m_shadowBias = 0.0f;
 		alignas(16) glm::vec3 m_worldPosition{};
+		float m_shadowDistance = 0.0f;
 		alignas(16) glm::vec3 m_direction{};
 		alignas(16) glm::vec3 m_intensity{};
 		alignas(16) glm::vec2 m_cutOff{};
 		alignas(16) glm::vec3 m_bounds{};
 	};
 
+	static_assert(offsetof(RHILightShaderData, m_shadowDistance) == 28u);
+	static_assert(offsetof(RHILightShaderData, m_direction) == 32u);
 	static_assert(offsetof(RHILightShaderData, m_cutOff) == 64u);
 	static_assert(offsetof(RHILightShaderData, m_bounds) == 80u);
 	static_assert(sizeof(RHILightShaderData) == 96u);

--- a/Runtime/RHI/Types.h
+++ b/Runtime/RHI/Types.h
@@ -412,7 +412,8 @@ namespace Sailor::RHI
 		None = 0,
 		Additive = 0x00000001,
 		AlphaBlending = 0x00000002,
-		Multiply = 0x00000003
+		Multiply = 0x00000003,
+		AlphaBlendingPreserveAlpha = 0x00000004
 	};
 
 	enum class EDepthCompare : uint8_t

--- a/Runtime/Settings/GraphicsSettings.cpp
+++ b/Runtime/Settings/GraphicsSettings.cpp
@@ -439,6 +439,25 @@ namespace
 			return false;
 		}
 
+		if (!ReadConvertedScalar(
+				profile,
+				"shadowDistance",
+				source,
+				profilePath + ".shadowDistance",
+				"a finite number",
+				outProfile.m_shadowDistance,
+				outDiagnostic) ||
+			!std::isfinite(outProfile.m_shadowDistance) ||
+			outProfile.m_shadowDistance < 1.0f || outProfile.m_shadowDistance > 10000.0f)
+		{
+			if (outDiagnostic.empty())
+			{
+				outDiagnostic = InvalidField(source, profilePath + ".shadowDistance",
+					"must be a finite number in the range [1, 10000]");
+			}
+			return false;
+		}
+
 		if (!ReadUint32(
 				profile,
 				"shadowCascadeCount",

--- a/Runtime/Settings/GraphicsSettings.h
+++ b/Runtime/Settings/GraphicsSettings.h
@@ -99,6 +99,7 @@ namespace Sailor::Settings
 		uint32_t m_msaaSamples = 1u;
 		ELightShadowQuality m_shadowQuality = ELightShadowQuality::Medium;
 		float m_shadowBias = 1.25f;
+		float m_shadowDistance = 200.0f;
 		uint32_t m_shadowCascadeCount = 1u;
 		std::array<uint32_t, MaxShadowCascades> m_shadowCascadeResolutions
 		{

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -28,6 +28,7 @@
 #include "RHI/SceneView.h"
 #include "RHI/Material.h"
 #include "RHI/VertexDescription.h"
+#include "Settings/GraphicsSettings.h"
 #include "Submodules/Editor.h"
 
 using namespace Sailor;
@@ -985,8 +986,8 @@ namespace
 	{
 		Require(std::abs(LightingECS::ShadowCascadeLevels[LightingECS::NumCascades - 1] - 1.0f) <= 0.0001f,
 			"the last shadow cascade must reach the configured shadow distance");
-		Require(LightingECS::ShadowMaxDistance == 200.0f,
-			"the meter-based editor scene should keep CSM coverage bounded to 200 meters");
+		Require(Settings::GraphicsQualityProfile{}.m_shadowDistance == 200.0f,
+			"the default profile should preserve 200 meter CSM coverage");
 		Require(LightingECS::ShadowCascadeBlendFraction > 0.0f,
 			"adjacent CSM projections must overlap for seam-free transitions");
 
@@ -1251,6 +1252,8 @@ namespace
 			"released GPU light payload should use an explicit invalid marker");
 		Require(offsetof(LightingECS::LightShaderData, m_shadowBias) == 12u,
 			"the profile shadow bias must occupy the existing std430 light padding");
+		Require(offsetof(LightingECS::LightShaderData, m_shadowDistance) == 28u,
+			"shadow distance must occupy the world-position padding without shifting GPU light fields");
 		Require(
 			offsetof(LightingECS::LightShaderData, m_cutOff) == 64u &&
 			offsetof(LightingECS::LightShaderData, m_bounds) == 80u &&

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -6,6 +6,9 @@
 #include "FrameGraph/DepthPrepassNode.h"
 #include "FrameGraph/RenderSceneNode.h"
 #include "FrameGraph/ShadowPrepassNode.h"
+#include "FrameGraph/AtmosphericFogNode.h"
+#include "GraphicsDriver/Vulkan/VulkanPipileneStates.h"
+#include "Settings/GraphicsSettings.h"
 #include "FrameGraph/RHIFrameGraph.h"
 #include "RHI/GpuCulling.h"
 #include "Core/StringHash.h"
@@ -33,6 +36,13 @@ using namespace Sailor::GraphicsDriver::Vulkan;
 
 namespace
 {
+	class BlendStateProbe : public VulkanPipelineStateBuilder
+	{
+	public:
+		BlendStateProbe() : VulkanPipelineStateBuilder(nullptr) {}
+		using VulkanPipelineStateBuilder::GetBlendState;
+	};
+
 	class RenderSceneNodeProbe : public Framegraph::RenderSceneNode
 	{
 	public:
@@ -1100,9 +1110,55 @@ namespace
 	}
 }
 
+namespace
+{
+	void TestAtmosphericFogBlendAndDisabledPass()
+	{
+		BlendStateProbe builder;
+		VkGraphicsPipelineCreateInfo pipeline{};
+		builder.GetBlendState(RHI::EBlendMode::AlphaBlendingPreserveAlpha)->Apply(pipeline);
+		Require(pipeline.pColorBlendState && pipeline.pColorBlendState->attachmentCount == 1,
+			"Fog compositing must affect a single colour attachment");
+		const auto& blend = pipeline.pColorBlendState->pAttachments[0];
+		Require(blend.blendEnable && blend.srcColorBlendFactor == VK_BLEND_FACTOR_SRC_ALPHA &&
+			blend.dstColorBlendFactor == VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA && blend.colorBlendOp == VK_BLEND_OP_ADD &&
+			blend.srcAlphaBlendFactor == VK_BLEND_FACTOR_ZERO && blend.dstAlphaBlendFactor == VK_BLEND_FACTOR_ONE &&
+			blend.alphaBlendOp == VK_BLEND_OP_ADD, "Fog must composite RGB without changing HDR alpha metadata");
+
+		Framegraph::AtmosphericFogNode node;
+		RHI::RHISceneViewSnapshot scene{};
+		// A disabled or invalid optional node must need no renderer/resources and issue no draw.
+		for (float density : { 0.0f, -1.0f, std::numeric_limits<float>::quiet_NaN() })
+		{
+			node.SetVec4("fog", glm::vec4(density, 0, 0, 0));
+			node.Process(nullptr, nullptr, nullptr, scene);
+			Require(node.GetDrawCallStats().m_numBatches == 0, "Disabled fog must not submit a pass");
+		}
+	}
+
+	void TestShadowDistanceSettings()
+	{
+		const auto path = std::filesystem::path(SAILOR_TEST_SOURCE_DIR) / "ProjectSettings.yaml";
+		const auto source = YAML::Load(ReadText(path));
+		for (float distance : { 1.0f, 600.0f, 10000.0f, 0.0f, 10001.0f,
+			std::numeric_limits<float>::quiet_NaN(), std::numeric_limits<float>::infinity() })
+		{
+			auto document = YAML::Clone(source);
+			document["graphics"]["presets"]["Ultra"]["shadowDistance"] = distance;
+			const auto parsed = Settings::ParseProjectGraphicsSettings(YAML::Dump(document), path.string());
+			const bool valid = std::isfinite(distance) && distance >= 1 && distance <= 10000;
+			Require(parsed.IsLoaded() == valid, "Native shadow distance must require a finite value in [1, 10000]");
+			if (valid) Require(parsed.m_settings.GetProfile(Settings::EGraphicsQuality::Ultra).m_shadowDistance == distance,
+				"Native shadow distance parser must preserve the requested range");
+		}
+	}
+}
+
 int main()
 {
 	const std::pair<const char*, std::function<void()>> tests[] = {
+		{ "AtmosphericFogBlendAndDisabledPass", TestAtmosphericFogBlendAndDisabledPass },
+		{ "ShadowDistanceSettings", TestShadowDistanceSettings },
 		{ "RendererGpuCullingPassContract", TestRendererGpuCullingPassContract },
 		{ "CurrentDepthPyramidReadiness", TestCurrentDepthPyramidReadiness },
 		{ "GpuCullingDispatchOrdering", TestGpuCullingDispatchOrdering },

--- a/Tests/ShaderCacheArtifactTests.cpp
+++ b/Tests/ShaderCacheArtifactTests.cpp
@@ -4,6 +4,7 @@
 #include "AssetRegistry/Shader/ShaderYamlIncludeResolver.h"
 #include "FrameGraph/RenderSceneNode.h"
 #include "FrameGraph/SkyParameters.h"
+#include "FrameGraph/AtmosphericFogNode.h"
 #include "FrameGraph/LocalReflection.h"
 #include "RHI/GlobalIllumination.h"
 #include "RHI/Lighting.h"
@@ -1323,6 +1324,29 @@ namespace
 				permutationDefines,
 				RHI::EShaderStage::Vertex);
 		};
+
+		const auto fogByteCode = compileRuntimeFragment("Shaders/AtmosphericFog.shader", {});
+		compileRuntimeVertex("Shaders/AtmosphericFog.shader", {});
+		RequireSpirvCombinedImageSamplerBinding(fogByteCode, 1u, 1u);
+		RequireSpirvCombinedImageSamplerBinding(fogByteCode, 1u, 2u);
+		RequireSpirvCombinedImageSamplerBinding(fogByteCode, 1u, 3u);
+		RequireSpirvDescriptorBindingAbsent(fogByteCode, 1u, 4u);
+		SpvReflectShaderModule fogModule{};
+		Require(spvReflectCreateShaderModule(fogByteCode.Num() * sizeof(uint32_t), fogByteCode.GetData(),
+			&fogModule) == SPV_REFLECT_RESULT_SUCCESS, "Fog shader must support reflection");
+		SpvReflectResult fogStatus;
+		const auto* fogBinding = spvReflectGetDescriptorBinding(&fogModule, 0u, 1u, &fogStatus);
+		const bool fogLayoutValid = fogStatus == SPV_REFLECT_RESULT_SUCCESS && fogBinding &&
+			fogBinding->descriptor_type == SPV_REFLECT_DESCRIPTOR_TYPE_UNIFORM_BUFFER &&
+			fogBinding->block.size == sizeof(Framegraph::AtmosphericFogNode::ShaderParameters) && fogBinding->block.member_count == 6 &&
+			fogBinding->block.members[0].offset == 0 && fogBinding->block.members[1].offset == 16 &&
+			fogBinding->block.members[2].offset == offsetof(Framegraph::AtmosphericFogNode::ShaderParameters, m_directionToSun) &&
+			fogBinding->block.members[3].offset == offsetof(Framegraph::AtmosphericFogNode::ShaderParameters, m_sunIlluminance) &&
+			fogBinding->block.members[4].offset == offsetof(Framegraph::AtmosphericFogNode::ShaderParameters, m_previousDirectionToSun) &&
+			fogBinding->block.members[5].offset == offsetof(Framegraph::AtmosphericFogNode::ShaderParameters, m_previousSunIlluminance) &&
+			fogModule.push_constant_block_count == 0 && fogModule.output_variable_count == 1;
+		spvReflectDestroyShaderModule(&fogModule);
+		Require(fogLayoutValid, "Fog shader must match the CPU medium/lighting snapshots and one colour output");
 
 		for (size_t shaderIndex = 0u;
 			shaderIndex < shaderPaths.size();


### PR DESCRIPTION
## Summary

Add environment-lit height fog and configurable directional shadow distance. This is an engine/editor-only follow-up to the demo work; it does not include DemoSailor content or scene tuning.

## Linked Issue

Requested directly in the development session; no issue is closed by this PR.

## Implementation Notes

- Add the optional `AtmosphericFog` frame-graph node and shader: one analytic height-fog draw after opaque/masked rendering, before transmission-background copy and transparent rendering.
- Reuse Environment's existing `g_irradianceCubemap` diffuse fallback and the associated Sky solar parameters. No new sky capture, cubemap allocation, probe sampling, or local-reflection capture.
- Fade environment/solar lighting together. Authored HDR maps use their ambient term without adding an extra analytic sun.
- Composite into HDR and the live MSAA surface using `AlphaBlendingPreserveAlpha`; do not write depth or motion vectors. Zero density, invalid parameters, or unavailable inputs skip the draw.
- Replace the fixed 200 m CSM limit with the quality preset's `shadowDistance`. Keep culling, projections, receiver cascade selection, blend/fade, debug visualization, native settings, YAML, and editor UI consistent.
- Preserve the 96-byte GPU light layout by using existing padding. Default shadow distance remains 200 m; valid range is 1–10000 m.
- Keep all project-owned schema/generator versions at 1. The tracked constants output is regenerated from its C++ producer.
- Add behavior/configuration/SPIR-V reflection tests.

Excluded: Sponza removal, Duck relocation, Bistro/landscape assets, generated probe data, unrelated shader sidecar timestamps, DemoSailor settings/content, and Windows packaging changes.

## Agent Workflow

- [x] Implementation Summary is posted in the PR description.
- [x] Tech Review requested.
- [x] Preflight validation is recorded below; formal QA handoff is deferred until Tech Review approval.
- [ ] Ready for human review only after Tech Review and QA approval.
- Merge and auto-merge are not requested.

## Tests

Fresh local validation on macOS Apple Silicon, 2026-09-06:

- Release build: `SailorLib`, `SailorExec`, and the four targeted C++ test executables — passed.
- `ctest --test-dir build-mac-vcpkg -C Release -R '^(GpuCullingContractTests|EcsLifecycleContractTests|SkyComponentContractTests|ShaderCacheArtifactTests)$' --output-on-failure` — **4/4 passed**.
- `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --configuration Release --no-restore` — **780/780 passed**.
- `dotnet build Editor/SailorEditor.csproj --configuration Release --framework net10.0-maccatalyst --runtime maccatalyst-arm64 --no-restore` — passed, **0 warnings / 0 errors**.
- Selected worlds through the repository's `run_world_tests.py` runner: `DirectionalShadow` and `CombinedShadows` — **2/2 passed**. Fresh `TestPassed` journal entries and PNG readbacks verified; both screenshots inspected.
- `git diff --check` — passed.
- Full world suite and Windows runtime/GPU testing were not run locally. Windows MSVC/clang-cl validation is delegated to the existing PR CI.

## Risk

- Risk level: **medium**.
- Fog is a low-frequency single-scattering approximation, not volumetric ray marching: no shadowed light shafts or local-light scattering. Transparent surfaces themselves are not fogged; transmission sees the fogged opaque/masked background.
- Fog follows Environment's existing update cadence/quantization; it does not force captures or environment refreshes. Six diffuse-map samples per pixel in steady state, twelve during transitions; no GPU timing claim is made.
- External workspaces must save/regenerate their version-1 quality presets with the new `shadowDistance` field. No legacy migration path or schema-version increment is introduced.
- Fog is opt-in and zero-density by default.