### PR TITLE
Restore workspace Build menu and fix macOS module loading

### DIFF
--- a/Editor.Tests/Editor.Contracts.Tests.csproj
+++ b/Editor.Tests/Editor.Contracts.Tests.csproj
@@ -59,6 +59,8 @@
     <Compile Include="McpBridgeOptionsTests.cs" />
     <Compile Include="McpBridgeIntegrationTests.cs" />
     <Compile Include="WorkspaceBuildPlanTests.cs" />
+    <Compile Include="WorkspaceBuildServiceTests.cs" />
+    <Compile Include="WorkspaceCacheServiceTests.cs" />
     <Compile Include="McpYamlUtilitiesTests.cs" />
     <Compile Include="YamlHelperTests.cs" />
     <Compile Include="LandscapeVegetationBinaryTests.cs" />
@@ -99,6 +101,8 @@
     <Compile Include="EditorEngineProtocolTests.cs" />
     <Compile Include="EngineProtocolClientTests.cs" />
     <Compile Include="LocalEngineProtocolTransportTests.cs" />
+    <Compile Include="MacEngineLibraryLoaderTests.cs" />
+    <Compile Include="..\Editor\Protocol\MacEngineLibraryLoader.cs" Link="Protocol\MacEngineLibraryLoader.cs" />
     <Compile Include="..\Editor\Protocol\ClientWebSocketEngineProtocolTransport.cs" Link="Protocol\ClientWebSocketEngineProtocolTransport.cs" />
     <Compile Include="..\Editor\Protocol\EngineProtocolClient.cs" Link="Protocol\EngineProtocolClient.cs" />
     <Compile Include="..\Editor\Protocol\EngineProtocolNative.cs" Link="Protocol\EngineProtocolNative.cs" />
@@ -133,6 +137,7 @@
     <Compile Include="..\Editor\Workspace\WorkspaceYamlVersionProbe.cs" Link="Workspace\WorkspaceYamlVersionProbe.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceGeneratedProjectState.cs" Link="Workspace\WorkspaceGeneratedProjectState.cs" />
     <Compile Include="..\Editor\Workspace\WorkspacePathPolicy.cs" Link="Workspace\WorkspacePathPolicy.cs" />
+    <Compile Include="..\Editor\Workspace\WorkspaceCacheService.cs" Link="Workspace\WorkspaceCacheService.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceLifecycle.cs" Link="Workspace\WorkspaceLifecycle.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceActivationContracts.cs" Link="Workspace\WorkspaceActivationContracts.cs" />
     <Compile Include="..\Editor\Workspace\WorkspaceActivationCoordinator.cs" Link="Workspace\WorkspaceActivationCoordinator.cs" />

--- a/Editor.Tests/MacEngineLibraryLoaderTests.cs
+++ b/Editor.Tests/MacEngineLibraryLoaderTests.cs
@@ -1,0 +1,124 @@
+using System.Runtime.InteropServices;
+using SailorEditor.Protocol;
+using SailorEditor.Workspace;
+
+namespace SailorEditor.Tests;
+
+public sealed class MacEngineLibraryLoaderTests
+{
+    [Fact]
+    public async Task Load_MakesWeakEngineSymbolsAvailableToReloadedWorkspaceModules()
+    {
+        if (!OperatingSystem.IsMacOS())
+            return;
+
+        var root = Directory.CreateTempSubdirectory("sailor-dyld-tests-").FullName;
+        nint localEngine = nint.Zero;
+        nint globalEngine = nint.Zero;
+        try
+        {
+            // Unique C++ symbols keep this fixture independent of other images
+            // that dyld may retain after dlclose because of weak coalescing.
+            var symbolNamespace = "Engine_" + Guid.NewGuid().ToString("N");
+            var engineSource = Path.Combine(root, "Engine.cpp");
+            var moduleSource = Path.Combine(root, "Workspace.cpp");
+            var enginePath = Path.Combine(root, "libEngine.dylib");
+            var modulePath = Path.Combine(root, "libWorkspace.dylib");
+            await File.WriteAllTextAsync(engineSource, $$"""
+                namespace {{symbolNamespace}}
+                {
+                    template<typename T> struct Registration { static int value; };
+                    template<typename T> int Registration<T>::value = 41;
+                    template struct Registration<int>;
+                }
+                extern "C" int ReadEngineRegistration()
+                {
+                    return {{symbolNamespace}}::Registration<int>::value;
+                }
+                """);
+            await File.WriteAllTextAsync(moduleSource, $$"""
+                namespace {{symbolNamespace}}
+                {
+                    template<typename T> struct Registration { static int value; };
+                    extern template struct Registration<int>;
+                }
+                extern "C" int ReadWorkspaceRegistration()
+                {
+                    return {{symbolNamespace}}::Registration<int>::value + 1;
+                }
+                """);
+
+            await CompileAsync(root, "clang++", "-std=c++20", "-dynamiclib", engineSource,
+                "-o", enginePath, "-Wl,-install_name," + enginePath);
+            await CompileAsync(root, "clang++", "-std=c++20", "-dynamiclib", moduleSource,
+                enginePath, "-o", modulePath);
+
+            // Match Mono's local host load and DynamicLibrary's local module
+            // load explicitly; CoreCLR's NativeLibrary flags differ from Mono.
+            localEngine = LoadLocal(enginePath);
+            Assert.NotEqual(nint.Zero, localEngine);
+            var localModule = LoadLocal(modulePath);
+            try
+            {
+                Assert.Equal(nint.Zero, localModule);
+            }
+            finally
+            {
+                if (localModule != nint.Zero)
+                    NativeLibrary.Free(localModule);
+            }
+
+            globalEngine = MacEngineLibraryLoader.Load(enginePath);
+            for (var restart = 0; restart < 3; ++restart)
+            {
+                var module = LoadLocal(modulePath);
+                Assert.NotEqual(nint.Zero, module);
+                try
+                {
+                    var read = Marshal.GetDelegateForFunctionPointer<ReadRegistration>(
+                        NativeLibrary.GetExport(module, "ReadWorkspaceRegistration"));
+                    Assert.Equal(42, read());
+                }
+                finally
+                {
+                    NativeLibrary.Free(module);
+                }
+            }
+        }
+        finally
+        {
+            if (globalEngine != nint.Zero)
+                NativeLibrary.Free(globalEngine);
+            if (localEngine != nint.Zero)
+                NativeLibrary.Free(localEngine);
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Load_MissingLibraryReportsItsPath()
+    {
+        if (!OperatingSystem.IsMacOS())
+            return;
+
+        var path = Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".dylib");
+        var error = Assert.Throws<DllNotFoundException>(() => MacEngineLibraryLoader.Load(path));
+        Assert.Contains(path, error.Message);
+    }
+
+    static async Task CompileAsync(string directory, params string[] arguments)
+    {
+        using var timeout = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        var result = await new WorkspaceProcessRunner().RunAsync(
+            new WorkspaceProcessInvocation("/usr/bin/xcrun", arguments, directory), timeout.Token);
+        Assert.True(result.Succeeded, result.Output);
+    }
+
+    [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+    delegate int ReadRegistration();
+
+    static nint LoadLocal(string path) => Dlopen(path, 0x2 | 0x4);
+
+    [DllImport("/usr/lib/libSystem.B.dylib", EntryPoint = "dlopen", CallingConvention = CallingConvention.Cdecl)]
+    static extern nint Dlopen([MarshalAs(UnmanagedType.LPUTF8Str)] string path, int mode);
+}

--- a/Editor.Tests/WorkspaceBuildPlanTests.cs
+++ b/Editor.Tests/WorkspaceBuildPlanTests.cs
@@ -5,6 +5,30 @@ namespace SailorEditor.Tests;
 public sealed class WorkspaceBuildPlanTests
 {
     [Fact]
+    public void CreateConfigure_OnlyCreatesCMakeProjectInvocation()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "Sailor Workspace");
+        var session = new WorkspaceSession(
+            root,
+            Path.Combine(root, "workspace.sailor"),
+            WorkspaceManifest.CreateDefault("Game", root),
+            Path.Combine(root, "Content"),
+            Path.Combine(root, "Source"),
+            Path.Combine(root, "Generated"),
+            Path.Combine(root, "Cache"))
+        {
+            BuildDirectory = Path.Combine(root, "Cache", "Build"),
+            LogicOutputDirectory = Path.Combine(root, "Binaries"),
+        };
+
+        var plan = WorkspaceBuildPlan.CreateConfigure(session, "Release");
+
+        Assert.Single(plan.Invocations);
+        Assert.Equal("-S", plan.Invocations[0].Arguments[0]);
+        Assert.DoesNotContain("--build", plan.Invocations[0].Arguments);
+    }
+
+    [Fact]
     public void Create_BuildsConfigureAndTargetInvocationsWithoutShellQuoting()
     {
         var root = Path.Combine(Path.GetTempPath(), "Sailor Workspace");

--- a/Editor.Tests/WorkspaceBuildServiceTests.cs
+++ b/Editor.Tests/WorkspaceBuildServiceTests.cs
@@ -1,0 +1,106 @@
+using SailorEditor.Workspace;
+
+namespace SailorEditor.Tests;
+
+public sealed class WorkspaceBuildServiceTests : IDisposable
+{
+    readonly string root = Directory.CreateTempSubdirectory("sailor-build-tests-").FullName;
+    readonly FakeRunner runner = new();
+
+    WorkspaceBuildService CreateService()
+    {
+        var serializer = new WorkspaceManifestSerializer();
+        var lifecycle = new WorkspaceLifecycleService(serializer,
+            new WorkspaceTemplateService(serializer),
+            new RecentWorkspaceStore(Path.Combine(root, "recent.yaml")));
+        return new WorkspaceBuildService(lifecycle, runner);
+    }
+
+    WorkspaceSession Session => new(root, Path.Combine(root, "Game.sailor"),
+        WorkspaceManifest.CreateDefault("Game", Path.Combine(root, "Engine")),
+        Path.Combine(root, "Content"), Path.Combine(root, "Source"),
+        Path.Combine(root, "Generated"), Path.Combine(root, "Cache"))
+    {
+        BuildDirectory = Path.Combine(root, "Cache", "Build"),
+        LogicOutputDirectory = Path.Combine(root, "Binaries"),
+    };
+
+    [Fact]
+    public async Task Build_RequiresAnActiveWorkspace()
+    {
+        var result = await CreateService().BuildAsync("Release", configure: true);
+        Assert.False(result.Succeeded);
+        Assert.Empty(runner.Invocations);
+    }
+
+    [Fact]
+    public async Task Build_StopsAfterConfigureFailureAndKeepsCompilerOutput()
+    {
+        runner.ExitCode = 23;
+        var result = await CreateService().BuildAsync(Session, "Release", configure: true);
+        Assert.False(result.Succeeded);
+        Assert.Equal(23, result.ExitCode);
+        Assert.Single(runner.Invocations);
+        Assert.Contains("compiler diagnostic", result.Output);
+    }
+
+    [Fact]
+    public async Task Configure_DoesNotBuildOrOverwriteTheGeneratedProject()
+    {
+        Directory.CreateDirectory(Session.GeneratedProjectDirectory);
+        var project = Path.Combine(Session.GeneratedProjectDirectory, "CMakeLists.txt");
+        const string customProject = "project(UserOwnedProject)";
+        await File.WriteAllTextAsync(project, customProject);
+        var result = await CreateService().ConfigureAsync(Session, "Release");
+        Assert.True(result.Succeeded, result.Error);
+        Assert.Single(runner.Invocations);
+        Assert.DoesNotContain("--build", runner.Invocations[0].Arguments);
+        Assert.Equal(customProject, await File.ReadAllTextAsync(project));
+    }
+
+    [Fact]
+    public async Task Build_SucceedsAgainAfterCancelledInvocation()
+    {
+        var service = CreateService();
+        using var cancellation = new CancellationTokenSource();
+        runner.BeforeRun = () => cancellation.Cancel();
+        await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+            service.BuildAsync(Session, "Release", false, cancellation.Token));
+        runner.BeforeRun = null;
+        var result = await service.BuildAsync(Session, "Release", false);
+        Assert.True(result.Succeeded, result.Error);
+    }
+
+    [Fact]
+    public async Task Build_RejectsStaleGeneratedStateWithoutRunningCommands()
+    {
+        var session = Session with
+        {
+            GeneratedProjectState = new(WorkspaceGeneratedProjectStateStatus.Untracked,
+                "Review generated project state first.", []),
+        };
+        var service = CreateService();
+        Assert.False((await service.BuildAsync(session, "Release", true)).Succeeded);
+        Assert.False((await service.ConfigureAsync(session, "Release")).Succeeded);
+        Assert.Empty(runner.Invocations);
+    }
+
+    public void Dispose() => Directory.Delete(root, recursive: true);
+
+    sealed class FakeRunner : IWorkspaceProcessRunner
+    {
+        public readonly List<WorkspaceProcessInvocation> Invocations = [];
+        public int ExitCode;
+        public Action? BeforeRun;
+
+        public Task<WorkspaceProcessResult> RunAsync(WorkspaceProcessInvocation invocation,
+            CancellationToken cancellationToken = default)
+        {
+            Invocations.Add(invocation);
+            BeforeRun?.Invoke();
+            cancellationToken.ThrowIfCancellationRequested();
+            return Task.FromResult(new WorkspaceProcessResult(ExitCode,
+                "compiler diagnostic", TimeSpan.FromMilliseconds(1)));
+        }
+    }
+}

--- a/Editor.Tests/WorkspaceCacheServiceTests.cs
+++ b/Editor.Tests/WorkspaceCacheServiceTests.cs
@@ -1,0 +1,91 @@
+using SailorEditor.Workspace;
+
+namespace SailorEditor.Tests;
+
+public sealed class WorkspaceCacheServiceTests : IDisposable
+{
+    readonly string root = Directory.CreateTempSubdirectory("sailor-cache-tests-").FullName;
+    readonly WorkspaceCacheService service = new();
+
+    WorkspaceSession Session => new(root, Path.Combine(root, "Game.sailor"),
+        WorkspaceManifest.CreateDefault("Game", Path.Combine(root, "Engine")),
+        Path.Combine(root, "Content"), Path.Combine(root, "Source"),
+        Path.Combine(root, "Generated"), Path.Combine(root, "Cache"))
+    {
+        BuildDirectory = Path.Combine(root, "Cache", "Build"),
+        LogicOutputDirectory = Path.Combine(root, "Binaries"),
+    };
+
+    [Fact]
+    public void Clear_PreservesOldCacheAndProjectFiles()
+    {
+        var session = Session;
+        Directory.CreateDirectory(session.BuildDirectory);
+        File.WriteAllText(Path.Combine(session.BuildDirectory, "CMakeCache.txt"), "build cache");
+        Directory.CreateDirectory(session.ContentDirectory);
+        var scene = Path.Combine(session.ContentDirectory, "Scene.world");
+        File.WriteAllText(scene, "scene data");
+
+        var backup = service.Clear(session);
+
+        Assert.NotNull(backup);
+        Assert.Empty(Directory.EnumerateFileSystemEntries(session.CacheDirectory));
+        Assert.Equal("build cache", File.ReadAllText(Path.Combine(backup, "Build", "CMakeCache.txt")));
+        Assert.Equal("scene data", File.ReadAllText(scene));
+        Assert.NotEqual(backup, service.Clear(session));
+        Assert.True(Directory.Exists(backup));
+    }
+
+    [Fact]
+    public void Clear_CreatesAMissingCacheWithoutABackup()
+    {
+        Assert.Null(service.Clear(Session));
+        Assert.True(Directory.Exists(Session.CacheDirectory));
+    }
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("Content")]
+    [InlineData("Content/Cache")]
+    [InlineData("Source")]
+    [InlineData("Generated")]
+    [InlineData("Binaries")]
+    [InlineData("Engine")]
+    [InlineData(".sailor")]
+    public void Clear_RejectsUnsafeTargets(string path)
+    {
+        var session = Session with { CacheDirectory = Path.GetFullPath(path, root) };
+        Assert.Throws<InvalidOperationException>(() => service.Clear(session));
+    }
+
+    [Fact]
+    public void Clear_RejectsCacheContainingSource()
+    {
+        var session = Session with { SourceDirectory = Path.Combine(Session.CacheDirectory, "Source") };
+        Assert.Throws<InvalidOperationException>(() => service.Clear(session));
+    }
+
+    [Fact]
+    public void Clear_DoesNotFollowCacheLinkOutsideWorkspace()
+    {
+        if (OperatingSystem.IsWindows())
+            return; // Creating directory links requires privileges on Windows.
+
+        var workspace = Path.Combine(root, "Workspace");
+        var outside = Path.Combine(root, "Outside");
+        Directory.CreateDirectory(workspace);
+        Directory.CreateDirectory(outside);
+        var link = Path.Combine(workspace, "Cache");
+        Directory.CreateSymbolicLink(link, outside);
+        File.WriteAllText(Path.Combine(outside, "keep.txt"), "keep");
+        Assert.Throws<InvalidOperationException>(() => service.Clear(Session with
+        {
+            WorkspaceRoot = workspace,
+            CacheDirectory = link,
+        }));
+        Assert.Equal("keep", File.ReadAllText(Path.Combine(outside, "keep.txt")));
+    }
+
+    public void Dispose() => Directory.Delete(root, recursive: true);
+}

--- a/Editor/AppShell.xaml.cs
+++ b/Editor/AppShell.xaml.cs
@@ -60,6 +60,18 @@ namespace SailorEditor
             file.Add(new MenuFlyoutSeparator());
             file.Add(new MenuFlyoutItem { Text = "Exit" });
 
+#if !MACCATALYST
+            var build = new MenuBarItem { Text = "Build" };
+            build.Add(CreateWorkspaceMenuItem("Compile", () => _workspaceUi.CompileWorkspaceAsync()));
+            build.Add(CreateWorkspaceMenuItem("Reconfigure", () => _workspaceUi.ReconfigureWorkspaceAsync()));
+            build.Add(new MenuFlyoutSeparator());
+            build.Add(CreateWorkspaceMenuItem("Clear Cache", () => _workspaceUi.ClearWorkspaceCacheAsync()));
+            build.Add(CreateWorkspaceMenuItem("Rerun Engine", async () =>
+            {
+                await _workspaceUi.RestartEngineAsync();
+            }));
+#endif
+
             var window = new MenuBarItem { Text = "Window" };
             foreach (var panel in MauiProgram.GetService<Panels.PanelRegistry>().GetAllDescriptors().OrderBy(x => x.Title))
             {
@@ -75,6 +87,9 @@ namespace SailorEditor
             preferences.Add(new MenuFlyoutItem { Text = "Dark Theme", Command = new Command(() => ChangeTheme("DarkThemeStyle")) });
 
             MenuBarItems.Add(file);
+#if !MACCATALYST
+            MenuBarItems.Add(build);
+#endif
             MenuBarItems.Add(window);
             MenuBarItems.Add(preferences);
         }

--- a/Editor/MauiProgram.cs
+++ b/Editor/MauiProgram.cs
@@ -136,6 +136,7 @@ namespace SailorEditor
             builder.Services.AddSingleton<McpCSharpEvaluator>();
             builder.Services.AddSingleton<IWorkspaceProcessRunner, WorkspaceProcessRunner>();
             builder.Services.AddSingleton<WorkspaceBuildService>();
+            builder.Services.AddSingleton<WorkspaceCacheService>();
             builder.Services.AddSingleton<McpEditorHostService>();
             builder.Services.AddTransient<MainPage>();
             builder.Services.AddTransient<ContentFolderView>();

--- a/Editor/Platforms/MacCatalyst/AppDelegate.cs
+++ b/Editor/Platforms/MacCatalyst/AppDelegate.cs
@@ -15,6 +15,10 @@ public class AppDelegate : MauiUIApplicationDelegate
     static readonly Selector OpenRecentWorkspaceSelector = new("openRecentWorkspace:");
     static readonly Selector NewSceneSelector = new("newScene:");
     static readonly Selector ReloadAssetsSelector = new("reloadAssets:");
+    static readonly Selector CompileWorkspaceSelector = new("compileWorkspace:");
+    static readonly Selector ReconfigureWorkspaceSelector = new("reconfigureWorkspace:");
+    static readonly Selector ClearWorkspaceCacheSelector = new("clearWorkspaceCache:");
+    static readonly Selector RerunEngineSelector = new("rerunEngine:");
     static IReadOnlyList<WorkspaceRecentItem> recentWorkspaces = [];
 
     protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
@@ -73,6 +77,30 @@ public class AppDelegate : MauiUIApplicationDelegate
             });
 
         builder.InsertChildMenuAtStart(workspaceMenu, UIMenuIdentifier.File.GetConstant().ToString());
+
+        var buildMenu = UIMenu.Create(
+            "Build",
+            null,
+            new NSString("com.sailor.build"),
+            0,
+            new UIMenuElement[]
+            {
+                UICommand.Create("Compile", null, CompileWorkspaceSelector, null),
+                UICommand.Create("Reconfigure", null, ReconfigureWorkspaceSelector, null),
+                UIMenu.Create(
+                    string.Empty,
+                    null,
+                    new NSString("com.sailor.build.maintenance"),
+                    UIMenuOptions.DisplayInline,
+                    new UIMenuElement[]
+                    {
+                        UICommand.Create("Clear Cache", null, ClearWorkspaceCacheSelector, null),
+                        UICommand.Create("Rerun Engine", null, RerunEngineSelector, null)
+                    })
+            });
+        builder.InsertSiblingMenuAfter(
+            buildMenu,
+            UIMenuIdentifier.File.GetConstant().ToString());
     }
 
     public static void RequestMenuRebuild()
@@ -129,6 +157,25 @@ public class AppDelegate : MauiUIApplicationDelegate
     public void ReloadAssets(NSObject sender)
         => _ = MauiProgram.GetService<EngineService>().RequestAssetReloadAsync();
 
+    [Export("compileWorkspace:")]
+    public void CompileWorkspace(NSObject sender)
+        => RunWorkspaceAction(workspace => workspace.CompileWorkspaceAsync());
+
+    [Export("reconfigureWorkspace:")]
+    public void ReconfigureWorkspace(NSObject sender)
+        => RunWorkspaceAction(workspace => workspace.ReconfigureWorkspaceAsync());
+
+    [Export("clearWorkspaceCache:")]
+    public void ClearWorkspaceCache(NSObject sender)
+        => RunWorkspaceAction(workspace => workspace.ClearWorkspaceCacheAsync());
+
+    [Export("rerunEngine:")]
+    public void RerunEngine(NSObject sender)
+        => RunWorkspaceAction(async workspace =>
+        {
+            await workspace.RestartEngineAsync();
+        });
+
     static UIMenu BuildRecentWorkspacesMenu()
     {
         var recent = recentWorkspaces;
@@ -166,7 +213,15 @@ public class AppDelegate : MauiUIApplicationDelegate
     {
         _ = MainThread.InvokeOnMainThreadAsync(async () =>
         {
-            await action(MauiProgram.GetService<WorkspaceUiService>());
+            try
+            {
+                await action(MauiProgram.GetService<WorkspaceUiService>());
+            }
+            catch (Exception exception)
+            {
+                if (Microsoft.Maui.Controls.Shell.Current?.CurrentPage is { } page)
+                    await page.DisplayAlert("Workspace", exception.Message, "OK");
+            }
         });
     }
 }

--- a/Editor/Protocol/EngineProtocolNative.cs
+++ b/Editor/Protocol/EngineProtocolNative.cs
@@ -5,6 +5,9 @@ namespace SailorEditor.Protocol;
 internal static class EngineProtocolNative
 {
 #if MACCATALYST
+    // Keep one engine handle for the editor process, including runtime restarts.
+    static readonly Lazy<nint> bundledEngine = new(LoadBundledEngine);
+
     static EngineProtocolNative()
     {
         NativeLibrary.SetDllImportResolver(
@@ -16,17 +19,15 @@ internal static class EngineProtocolNative
                     return nint.Zero;
                 }
 
-                var bundledPath = Path.Combine(
-                    AppContext.BaseDirectory,
-                    "..",
-                    "Resources",
-                    $"{EngineLibrary}.dylib");
-                bundledPath = Path.GetFullPath(bundledPath);
-
-                return File.Exists(bundledPath)
-                    ? NativeLibrary.Load(bundledPath)
-                    : nint.Zero;
+                return bundledEngine.Value;
             });
+    }
+
+    static nint LoadBundledEngine()
+    {
+        var bundledPath = Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "Resources", $"{EngineLibrary}.dylib"));
+        return MacEngineLibraryLoader.Load(bundledPath);
     }
 #endif
 

--- a/Editor/Protocol/MacEngineLibraryLoader.cs
+++ b/Editor/Protocol/MacEngineLibraryLoader.cs
@@ -1,0 +1,49 @@
+using System.Runtime.InteropServices;
+
+namespace SailorEditor.Protocol;
+
+internal static class MacEngineLibraryLoader
+{
+    const int RtldNow = 0x2;
+    const int RtldGlobal = 0x8;
+
+    public static nint Load(string path)
+    {
+        if (!OperatingSystem.IsMacOS() && !OperatingSystem.IsMacCatalyst())
+            throw new PlatformNotSupportedException("The engine library loader requires macOS.");
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        // Mono's DllImportResolver only recognizes handles registered through
+        // NativeLibrary. A raw dlopen handle would fall back to a second image.
+        var handle = NativeLibrary.Load(path);
+        try
+        {
+            // Promote this same image so dyld can bind weak C++ template exports
+            // in workspace modules, without changing the modules' local scope.
+            _ = Dlerror();
+            var globalHandle = Dlopen(path, RtldNow | RtldGlobal);
+            if (globalHandle == nint.Zero)
+            {
+                var error = Marshal.PtrToStringUTF8(Dlerror()) ?? "dlopen returned a null handle.";
+                throw new DllNotFoundException($"Cannot expose engine library '{path}': {error}");
+            }
+            // NativeLibrary owns the remaining reference for the editor lifetime.
+            Dlclose(globalHandle);
+            return handle;
+        }
+        catch
+        {
+            NativeLibrary.Free(handle);
+            throw;
+        }
+    }
+
+    [DllImport("/usr/lib/libSystem.B.dylib", EntryPoint = "dlopen", CallingConvention = CallingConvention.Cdecl)]
+    static extern nint Dlopen([MarshalAs(UnmanagedType.LPUTF8Str)] string path, int mode);
+
+    [DllImport("/usr/lib/libSystem.B.dylib", EntryPoint = "dlerror", CallingConvention = CallingConvention.Cdecl)]
+    static extern nint Dlerror();
+
+    [DllImport("/usr/lib/libSystem.B.dylib", EntryPoint = "dlclose", CallingConvention = CallingConvention.Cdecl)]
+    static extern int Dlclose(nint handle);
+}

--- a/Editor/Services/WorkspaceUiService.cs
+++ b/Editor/Services/WorkspaceUiService.cs
@@ -18,6 +18,8 @@ internal sealed class WorkspaceUiService
     readonly WorldService _worldService;
     readonly AssetsService _assetsService;
     readonly InspectorPendingEditCoordinator _inspectorPendingEditCoordinator;
+    readonly WorkspaceBuildService _workspaceBuildService;
+    readonly WorkspaceCacheService _workspaceCache;
     readonly SemaphoreSlim _engineRestartGate = new(1, 1);
     static readonly FilePickerFileType WorkspaceManifestFileType = new(new Dictionary<DevicePlatform, IEnumerable<string>>
     {
@@ -36,7 +38,9 @@ internal sealed class WorkspaceUiService
         SelectionService selectionService,
         WorldService worldService,
         AssetsService assetsService,
-        InspectorPendingEditCoordinator inspectorPendingEditCoordinator)
+        InspectorPendingEditCoordinator inspectorPendingEditCoordinator,
+        WorkspaceBuildService workspaceBuildService,
+        WorkspaceCacheService workspaceCache)
     {
         _workspaceLifecycle = workspaceLifecycle;
         _engineService = engineService;
@@ -47,6 +51,8 @@ internal sealed class WorkspaceUiService
         _worldService = worldService;
         _assetsService = assetsService;
         _inspectorPendingEditCoordinator = inspectorPendingEditCoordinator;
+        _workspaceBuildService = workspaceBuildService;
+        _workspaceCache = workspaceCache;
         _activationCoordinator.StateChanged += OnActivationStateChanged;
         _engineService.OnLifecycleStateChanged += OnEngineLifecycleStateChanged;
     }
@@ -115,6 +121,248 @@ internal sealed class WorkspaceUiService
         }
     }
 
+    public Task CompileWorkspaceAsync(CancellationToken cancellationToken = default)
+        => RunWorkspaceMaintenanceAsync(
+            "Compile Workspace",
+            async (session, token) =>
+            {
+                var configure = !File.Exists(Path.Combine(session.BuildDirectory, "CMakeCache.txt"));
+                var result = await _workspaceBuildService.BuildAsync(
+                        session,
+                        "Release",
+                        configure,
+                        token)
+                    .ConfigureAwait(false);
+                if (!result.Succeeded)
+                    throw new InvalidOperationException(FormatWorkspaceBuildFailure(result));
+            },
+            cancellationToken);
+
+    public Task ReconfigureWorkspaceAsync(CancellationToken cancellationToken = default)
+        => RunWorkspaceMaintenanceAsync(
+            "Reconfigure Workspace",
+            async (session, token) =>
+            {
+                var result = await _workspaceBuildService.ConfigureAsync(
+                        session,
+                        "Release",
+                        token)
+                    .ConfigureAwait(false);
+                if (!result.Succeeded)
+                    throw new InvalidOperationException(FormatWorkspaceBuildFailure(result));
+            },
+            cancellationToken);
+
+    public async Task ClearWorkspaceCacheAsync(CancellationToken cancellationToken = default)
+    {
+        var session = _workspaceLifecycle.Current;
+        var page = GetPage();
+        if (session is null)
+        {
+            if (page is not null)
+                await page.DisplayAlert("Clear Cache", "No active workspace is open.", "OK");
+            return;
+        }
+
+        if (page is null || !await page.DisplayAlert(
+                "Clear Cache",
+                $"Move the project cache aside and rerun the Engine? The old cache will be kept beside it for recovery. Content, source code and built modules are preserved.{Environment.NewLine}{session.CacheDirectory}",
+                "Clear Cache",
+                "Cancel"))
+        {
+            return;
+        }
+
+        await RunWorkspaceMaintenanceAsync(
+            "Clear Workspace Cache",
+            (activeSession, _) =>
+            {
+                var backupPath = _workspaceCache.Clear(activeSession);
+                if (backupPath is not null)
+                    Console.WriteLine($"[WorkspaceUiService] Previous cache preserved at: {backupPath}");
+                return Task.CompletedTask;
+            },
+            cancellationToken,
+            session);
+    }
+
+    async Task RunWorkspaceMaintenanceAsync(
+        string operationName,
+        Func<WorkspaceSession, CancellationToken, Task> operation,
+        CancellationToken cancellationToken,
+        WorkspaceSession? requestedSession = null)
+    {
+        requestedSession ??= _workspaceLifecycle.Current;
+        if (requestedSession is null)
+        {
+            if (GetPage() is { } page)
+                await page.DisplayAlert(operationName, "No active workspace is open.", "OK");
+            return;
+        }
+
+        try
+        {
+            await _activationCoordinator.RunSerializedAsync(async token =>
+            {
+                if (!ReferenceEquals(_workspaceLifecycle.Current, requestedSession))
+                    throw new InvalidOperationException("The active workspace changed before the operation began.");
+
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                    _shellHost.SetStatus($"{operationName}: stopping Engine…"));
+                if (!await _inspectorPendingEditCoordinator
+                        .CommitPendingChangesAsync(token)
+                        .ConfigureAwait(false))
+                {
+                    throw new InvalidOperationException(
+                        "Pending Inspector changes could not be committed before stopping the Engine.");
+                }
+
+                var launchContext = _engineService.ActiveLaunchContext ?? _engineService.GetLaunchContext();
+                var snapshot = await CaptureRuntimeSnapshotAsync(token).ConfigureAwait(false);
+                _commandHistory.BeginWorkspaceChange();
+                _selectionService.BeginWorkspaceChange();
+                await _commandHistory.BeginWorkspaceChangeAsync(token).ConfigureAwait(false);
+
+                Exception? operationFailure = null;
+                try
+                {
+                    if (_engineService.State is EngineLifecycleState.Starting or
+                        EngineLifecycleState.Running or
+                        EngineLifecycleState.Stopping)
+                    {
+                        await _engineService.StopAsync(CancellationToken.None).ConfigureAwait(false);
+                    }
+
+                    await MainThread.InvokeOnMainThreadAsync(() =>
+                        _shellHost.SetStatus($"{operationName}…"));
+                    await operation(requestedSession, CancellationToken.None).ConfigureAwait(false);
+                }
+                catch (Exception exception)
+                {
+                    operationFailure = exception;
+                }
+
+                try
+                {
+                    await _engineService.RestartAsync(
+                            launchContext,
+                            snapshot.SerializedWorld,
+                            snapshot.ViewportToolState,
+                            CancellationToken.None)
+                        .ConfigureAwait(false);
+                    try
+                    {
+                        await _assetsService.RefreshAsync(CancellationToken.None).ConfigureAwait(false);
+                    }
+                    catch (Exception refreshFailure)
+                    {
+                        Console.WriteLine(
+                            $"[WorkspaceUiService] Engine restarted, but the Content projection refresh failed: {refreshFailure.Message}");
+                    }
+                    _commandHistory.CompleteWorkspaceChange();
+                    _selectionService.CompleteWorkspaceChange();
+                    _activationCoordinator.ReportRuntimeRecovered();
+                }
+                catch (Exception restartFailure)
+                {
+                    ShowRepairState($"Engine restart failed: {restartFailure.Message}");
+                    throw operationFailure is null
+                        ? new InvalidOperationException(
+                            $"{operationName} completed, but the Engine could not be restarted.",
+                            restartFailure)
+                        : new AggregateException(
+                            $"{operationName} failed and the Engine could not be restarted.",
+                            operationFailure,
+                            restartFailure);
+                }
+
+                if (operationFailure is not null)
+                    throw operationFailure;
+
+                await MainThread.InvokeOnMainThreadAsync(() =>
+                    _shellHost.SetStatus($"{operationName} completed."));
+            }, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception exception)
+        {
+            await MainThread.InvokeOnMainThreadAsync(async () =>
+            {
+                _shellHost.SetStatus($"{operationName} failed: {exception.Message}");
+                if (GetPage() is { } page)
+                    await page.DisplayAlert(operationName, exception.Message, "OK");
+            });
+        }
+    }
+
+    async Task<WorkspaceRuntimeSnapshot> CaptureRuntimeSnapshotAsync(
+        CancellationToken cancellationToken)
+    {
+        SceneViewportToolState? viewportToolState = null;
+        var serializedWorld = string.Empty;
+        if (_engineService.State == EngineLifecycleState.Running)
+        {
+            try
+            {
+                viewportToolState = await _engineService
+                    .GetViewportToolStateAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine($"[WorkspaceUiService] Unable to capture viewport state: {exception.Message}");
+            }
+
+            try
+            {
+                if (await _engineService
+                        .GetEditorSimulationStateAsync(cancellationToken)
+                        .ConfigureAwait(false) &&
+                    !await _engineService
+                        .SetEditorSimulationAsync(false, cancellationToken)
+                        .ConfigureAwait(false))
+                {
+                    throw new InvalidOperationException(
+                        "Physics simulation could not be stopped before restarting the Engine.");
+                }
+                serializedWorld = await _engineService
+                    .SerializeCurrentWorldAsync(cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine(
+                    $"[WorkspaceUiService] Live Engine snapshot failed; using the latest Editor world projection: {exception.Message}");
+            }
+        }
+
+        if (string.IsNullOrWhiteSpace(serializedWorld))
+        {
+            serializedWorld = await MainThread.InvokeOnMainThreadAsync(
+                _worldService.SerializeCurrentWorld);
+        }
+        if (string.IsNullOrWhiteSpace(serializedWorld))
+            throw new InvalidOperationException("The current scene could not be captured for Engine restart.");
+
+        return new WorkspaceRuntimeSnapshot(serializedWorld, viewportToolState);
+    }
+
+    sealed record WorkspaceRuntimeSnapshot(
+        string SerializedWorld,
+        SceneViewportToolState? ViewportToolState);
+
+    static string FormatWorkspaceBuildFailure(WorkspaceBuildResult build)
+    {
+        var message = build.Error ?? "Workspace compilation failed.";
+        if (string.IsNullOrWhiteSpace(build.Output))
+            return message;
+
+        const int maximumOutputLength = 4_000;
+        var output = build.Output.Trim();
+        if (output.Length > maximumOutputLength)
+            output = "…" + output[^maximumOutputLength..];
+        return $"{message}{Environment.NewLine}{Environment.NewLine}{output}";
+    }
+
     async Task<bool> RestartEngineCoreAsync(CancellationToken cancellationToken)
     {
         await MainThread.InvokeOnMainThreadAsync(() =>
@@ -139,62 +387,13 @@ internal sealed class WorkspaceUiService
             var launchContext =
                 _engineService.ActiveLaunchContext ??
                 _engineService.GetLaunchContext();
-            SceneViewportToolState? viewportToolState = null;
-            var serializedWorld = string.Empty;
-
-            if (_engineService.State == EngineLifecycleState.Running)
-            {
-                try
-                {
-                    viewportToolState = await _engineService
-                        .GetViewportToolStateAsync(cancellationToken)
-                        .ConfigureAwait(false);
-                }
-                catch (Exception exception)
-                {
-                    Console.WriteLine(
-                        $"[WorkspaceUiService] Unable to capture the Scene viewport tool state before restart: {exception.Message}");
-                }
-
-                try
-                {
-                    if (await _engineService
-                            .GetEditorSimulationStateAsync(cancellationToken)
-                            .ConfigureAwait(false) &&
-                        !await _engineService
-                            .SetEditorSimulationAsync(false, cancellationToken)
-                            .ConfigureAwait(false))
-                    {
-                        throw new InvalidOperationException(
-                            "Physics simulation could not be stopped before restarting the Engine.");
-                    }
-
-                    serializedWorld = await _engineService
-                        .SerializeCurrentWorldAsync(cancellationToken)
-                        .ConfigureAwait(false);
-                }
-                catch (Exception exception)
-                {
-                    Console.WriteLine(
-                        $"[WorkspaceUiService] Live Engine snapshot failed; using the latest Editor world projection: {exception.Message}");
-                }
-            }
-
-            if (string.IsNullOrWhiteSpace(serializedWorld))
-            {
-                serializedWorld = await MainThread.InvokeOnMainThreadAsync(
-                    _worldService.SerializeCurrentWorld);
-            }
-            if (string.IsNullOrWhiteSpace(serializedWorld))
-            {
-                throw new InvalidOperationException(
-                    "The current scene could not be captured for Engine recovery.");
-            }
+            var snapshot = await CaptureRuntimeSnapshotAsync(cancellationToken)
+                .ConfigureAwait(false);
 
             await _engineService.RestartAsync(
                     launchContext,
-                    serializedWorld,
-                    viewportToolState,
+                    snapshot.SerializedWorld,
+                    snapshot.ViewportToolState,
                     CancellationToken.None)
                 .ConfigureAwait(false);
 

--- a/Editor/Workspace/WorkspaceBuildService.cs
+++ b/Editor/Workspace/WorkspaceBuildService.cs
@@ -22,6 +22,18 @@ public sealed record WorkspaceBuildPlan(
     string Configuration,
     IReadOnlyList<WorkspaceProcessInvocation> Invocations)
 {
+    public static WorkspaceBuildPlan CreateConfigure(
+        WorkspaceSession session,
+        string configuration,
+        string cmakeExecutable = "cmake")
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        var normalizedConfiguration = NormalizeConfiguration(configuration);
+        return new WorkspaceBuildPlan(
+            normalizedConfiguration,
+            [CreateConfigureInvocation(session, normalizedConfiguration, cmakeExecutable)]);
+    }
+
     public static WorkspaceBuildPlan Create(
         WorkspaceSession session,
         string configuration,
@@ -32,21 +44,7 @@ public sealed record WorkspaceBuildPlan(
         var normalizedConfiguration = NormalizeConfiguration(configuration);
         var invocations = new List<WorkspaceProcessInvocation>(configure ? 2 : 1);
         if (configure)
-        {
-            var configureArguments = new List<string>
-            {
-                "-S",
-                session.GeneratedProjectDirectory,
-                "-B",
-                session.BuildDirectory,
-                "-DCMAKE_BUILD_TYPE=" + normalizedConfiguration,
-            };
-            AddVcpkgArguments(session, configureArguments);
-            invocations.Add(new WorkspaceProcessInvocation(
-                cmakeExecutable,
-                configureArguments,
-                session.WorkspaceRoot));
-        }
+            invocations.Add(CreateConfigureInvocation(session, normalizedConfiguration, cmakeExecutable));
 
         invocations.Add(new WorkspaceProcessInvocation(
             cmakeExecutable,
@@ -62,6 +60,26 @@ public sealed record WorkspaceBuildPlan(
             ],
             session.WorkspaceRoot));
         return new WorkspaceBuildPlan(normalizedConfiguration, invocations);
+    }
+
+    static WorkspaceProcessInvocation CreateConfigureInvocation(
+        WorkspaceSession session,
+        string configuration,
+        string cmakeExecutable)
+    {
+        var arguments = new List<string>
+        {
+            "-S",
+            session.GeneratedProjectDirectory,
+            "-B",
+            session.BuildDirectory,
+            "-DCMAKE_BUILD_TYPE=" + configuration,
+        };
+        AddVcpkgArguments(session, arguments);
+        return new WorkspaceProcessInvocation(
+            cmakeExecutable,
+            arguments,
+            session.WorkspaceRoot);
     }
 
     static void AddVcpkgArguments(
@@ -253,6 +271,17 @@ internal sealed class WorkspaceBuildService
                 string.Empty,
                 "An active workspace is required for a workspace build.");
         }
+
+        return await BuildAsync(session, configuration, configure, cancellationToken);
+    }
+
+    public async Task<WorkspaceBuildResult> BuildAsync(
+        WorkspaceSession session,
+        string configuration,
+        bool configure,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
         if (session.GeneratedProjectState.RequiresAttention)
         {
             return new WorkspaceBuildResult(
@@ -282,6 +311,52 @@ internal sealed class WorkspaceBuildService
                 exception.Message);
         }
 
+        return await RunAsync(session, plan, cancellationToken);
+    }
+
+    public Task<WorkspaceBuildResult> ConfigureAsync(
+        WorkspaceSession session,
+        string configuration,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        if (session.GeneratedProjectState.RequiresAttention)
+        {
+            return Task.FromResult(new WorkspaceBuildResult(
+                false,
+                configuration,
+                null,
+                TimeSpan.Zero,
+                Array.Empty<string>(),
+                string.Empty,
+                session.GeneratedProjectState.Guidance));
+        }
+
+        WorkspaceBuildPlan plan;
+        try
+        {
+            plan = WorkspaceBuildPlan.CreateConfigure(session, configuration);
+        }
+        catch (ArgumentException exception)
+        {
+            return Task.FromResult(new WorkspaceBuildResult(
+                false,
+                configuration,
+                null,
+                TimeSpan.Zero,
+                Array.Empty<string>(),
+                string.Empty,
+                exception.Message));
+        }
+
+        return RunAsync(session, plan, cancellationToken);
+    }
+
+    async Task<WorkspaceBuildResult> RunAsync(
+        WorkspaceSession session,
+        WorkspaceBuildPlan plan,
+        CancellationToken cancellationToken)
+    {
         await _buildGate.WaitAsync(cancellationToken);
         try
         {

--- a/Editor/Workspace/WorkspaceCacheService.cs
+++ b/Editor/Workspace/WorkspaceCacheService.cs
@@ -1,0 +1,60 @@
+#nullable enable
+
+namespace SailorEditor.Workspace;
+
+public sealed class WorkspaceCacheService
+{
+    // Keep the old cache beside the fresh one so clearing is recoverable and
+    // never recursively follows user-provided paths or links.
+    public string? Clear(WorkspaceSession session)
+    {
+        ArgumentNullException.ThrowIfNull(session);
+        var root = WorkspacePathPolicy.NormalizePhysicalPath(session.WorkspaceRoot);
+        var cache = WorkspacePathPolicy.NormalizePhysicalPath(session.CacheDirectory);
+        WorkspacePathPolicy.EnsureInsideRoot(root, cache, nameof(session.CacheDirectory));
+        if (WorkspacePathPolicy.IsSamePath(root, cache))
+            throw new InvalidOperationException("The workspace root cannot be cleared as a cache.");
+
+        var enginePath = session.Manifest.EnginePath
+            .Replace('/', Path.DirectorySeparatorChar)
+            .Replace('\\', Path.DirectorySeparatorChar);
+        var protectedPaths = new[]
+        {
+            session.ManifestPath,
+            session.ContentDirectory,
+            session.SourceDirectory,
+            session.GeneratedProjectDirectory,
+            session.LogicOutputDirectory,
+            Path.Combine(root, ".sailor"),
+            Path.GetFullPath(enginePath, root),
+        };
+        foreach (var path in protectedPaths.Where(path => !string.IsNullOrWhiteSpace(path)))
+        {
+            var protectedPath = WorkspacePathPolicy.NormalizePhysicalPath(path);
+            if (WorkspacePathPolicy.IsInsideRoot(cache, protectedPath) ||
+                WorkspacePathPolicy.IsInsideRoot(protectedPath, cache))
+            {
+                throw new InvalidOperationException(
+                    $"The cache overlaps a protected project or engine path: '{path}'.");
+            }
+        }
+
+        string? backupPath = null;
+        if (Directory.Exists(cache))
+        {
+            backupPath = cache + ".cleared-" + Guid.NewGuid().ToString("N");
+            Directory.Move(cache, backupPath);
+        }
+        try
+        {
+            Directory.CreateDirectory(cache);
+        }
+        catch
+        {
+            if (backupPath is not null && !Directory.Exists(cache))
+                Directory.Move(backupPath, cache);
+            throw;
+        }
+        return backupPath;
+    }
+}

--- a/Runtime/ECS/LandscapeGrassStreaming.cpp
+++ b/Runtime/ECS/LandscapeGrassStreaming.cpp
@@ -178,7 +178,6 @@ bool LandscapeECS::UpdateGrassResidency(const TVector<Math::Transform>& cameraTr
 	}
 
 	const uint32_t instanceBudget = (std::min)(App::GetActiveGraphicsSettings().m_vegetationInstanceBudget, 1048576u);
-	const size_t numCandidates = m_grassCandidatesScratch.Num();
 	SelectLandscapeGrassResidency(m_grassCandidatesScratch, instanceBudget, m_grassSelectionsScratch);
 	for (auto& selection : m_grassSelectionsScratch)
 	{
@@ -323,7 +322,6 @@ bool LandscapeECS::UpdateGrassResidency(const TVector<Math::Transform>& cameraTr
 	}
 
 	bool bChanged = false;
-	uint32_t activeInstances = 0u;
 	const uint64_t frame = GetWorld()->GetCurrentFrame();
 	auto findBuildRequest =
 		[this](size_t componentIndex, size_t chunkIndex, size_t profileIndex) -> GrassTransformBuildRequest*
@@ -491,7 +489,6 @@ bool LandscapeECS::UpdateGrassResidency(const TVector<Math::Transform>& cameraTr
 			}
 		}
 		component.m_activeGrassInstances = componentActiveInstances;
-		activeInstances += componentActiveInstances;
 	}
 	for (auto& buildRequest : m_grassBuildRequestsScratch)
 	{
@@ -500,11 +497,6 @@ bool LandscapeECS::UpdateGrassResidency(const TVector<Math::Transform>& cameraTr
 	if (bChanged)
 	{
 		++m_shadowCastersRevision;
-		SAILOR_LOG("LandscapeECS: grass residency changed to %u of %u graphics-quality instances across %zu visible "
-				   "candidates.",
-			activeInstances,
-			instanceBudget,
-			numCandidates);
 	}
 	return bChanged;
 }

--- a/Runtime/FrameGraph/AtmosphericFogNode.h
+++ b/Runtime/FrameGraph/AtmosphericFogNode.h
@@ -31,7 +31,7 @@ namespace Sailor::Framegraph
 		SAILOR_API virtual void Clear() override;
 
 	private:
-		static const char* m_name;
+		SAILOR_SHARED_API static const char* m_name;
 		ShaderSetPtr m_shader;
 		RHI::RHIMaterialPtr m_material;
 		RHI::RHIShaderBindingSetPtr m_bindings;

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -17,6 +17,7 @@
 #include "RHI/Material.h"
 #include "RHI/Mesh.h"
 #include "RHI/Texture.h"
+#include "RHI/VertexDescription.h"
 
 #include <algorithm>
 #include <cmath>
@@ -36,13 +37,6 @@ using namespace Sailor::GraphicsDriver::Vulkan;
 
 namespace
 {
-	class BlendStateProbe : public VulkanPipelineStateBuilder
-	{
-	public:
-		BlendStateProbe() : VulkanPipelineStateBuilder(nullptr) {}
-		using VulkanPipelineStateBuilder::GetBlendState;
-	};
-
 	class RenderSceneNodeProbe : public Framegraph::RenderSceneNode
 	{
 	public:
@@ -1114,9 +1108,19 @@ namespace
 {
 	void TestAtmosphericFogBlendAndDisabledPass()
 	{
-		BlendStateProbe builder;
+		VulkanPipelineStateBuilder builder(nullptr);
+		auto vertices = RHI::RHIVertexDescriptionPtr::Make();
+		vertices->SetVertexStride(sizeof(glm::vec3));
+		vertices->AddAttribute(0, 0, RHI::EFormat::R32G32B32_SFLOAT, 0);
+		const RHI::RenderState renderState(false, false, 0, false, RHI::ECullMode::None,
+			RHI::EBlendMode::AlphaBlendingPreserveAlpha, RHI::EFillMode::Fill, 0, false);
+		const auto& states = builder.BuildPipeline(vertices, { 0u }, RHI::EPrimitiveTopology::TriangleList,
+			renderState, { VK_FORMAT_R16G16B16A16_SFLOAT }, VK_FORMAT_UNDEFINED);
 		VkGraphicsPipelineCreateInfo pipeline{};
-		builder.GetBlendState(RHI::EBlendMode::AlphaBlendingPreserveAlpha)->Apply(pipeline);
+		for (const auto& state : states)
+		{
+			state->Apply(pipeline);
+		}
 		Require(pipeline.pColorBlendState && pipeline.pColorBlendState->attachmentCount == 1,
 			"Fog compositing must affect a single colour attachment");
 		const auto& blend = pipeline.pColorBlendState->pAttachments[0];
@@ -1126,6 +1130,8 @@ namespace
 			blend.alphaBlendOp == VK_BLEND_OP_ADD, "Fog must composite RGB without changing HDR alpha metadata");
 
 		Framegraph::AtmosphericFogNode node;
+		Require(std::string(Framegraph::AtmosphericFogNode::GetName()) == "AtmosphericFog" &&
+			node.GetDebugName() == "AtmosphericFog", "Fog node identity must be accessible across the runtime library boundary");
 		RHI::RHISceneViewSnapshot scene{};
 		// A disabled or invalid optional node must need no renderer/resources and issue no draw.
 		for (float density : { 0.0f, -1.0f, std::numeric_limits<float>::quiet_NaN() })


### PR DESCRIPTION
## Summary

Restore the editor's workspace Build menu, fix macOS workspace-module loading, and remove the noisy vegetation residency log.

Based on current `main` (`76a3a924e`, merged #202). This PR contains only 16 engine/editor code and test files; no scenes, models, generated assets, probes, or `Docs/AtmosphericFog.md`.

## Linked Issue

Requested directly by the user; no linked issue.

## Implementation Notes

- Restore **Build → Compile / Reconfigure / Clear Cache / Rerun Engine**, with native MacCatalyst menus and standard MAUI menus on other platforms.
- Serialize workspace maintenance with activation, commit pending Inspector edits, preserve the current scene and viewport state, stop the runtime before building, and attempt recovery even when a build fails.
- Keep Reconfigure separate from Compile; configure automatically on Compile only when the CMake cache is missing. Preserve user-owned generated project files and report compiler diagnostics.
- Make Clear Cache recoverable by moving the exact validated cache directory aside. Reject workspace roots, protected paths, and symlink escapes.
- Keep one Mono-registered macOS engine handle for the editor process and expose that same image with `RTLD_GLOBAL`, allowing workspace weak C++ symbols and reflected types to resolve after runtime restart. Workspace modules retain local loading scope.
- Remove the per-change grass residency message and its log-only counters without changing vegetation selection or shadow invalidation.
- Add behavioral tests for build/configure outcomes, cache safety, and weak-symbol resolution across repeated native-module loads.

## Tests

- [x] `python3 update_deps.py` after updating `origin/main`: dependencies already current.
- [x] `dotnet test Editor.Tests/Editor.Contracts.Tests.csproj --configuration Release`: **801 passed**.
- [x] macOS Release `SailorLib` and `LandscapeStreamingTests` build, after refreshing the existing CMake configuration.
- [x] `ctest --test-dir build-mac-vcpkg-editor -C Release -R '^LandscapeStreamingTests$' --output-on-failure`.
- [x] MacCatalyst ARM64 Release editor compilation to a separate output directory: **0 errors**; existing warnings and an isolated-output signing-path warning remain. This is compile validation, not a portable-package/signing check.
- [x] Earlier runtime smoke test of these editor changes: DemoSailor NightCity opened, all three project component types registered, and **Build → Rerun Engine** restored the scene and refreshed types.
- [x] `git diff --check`; only the explicit 16-file scope is committed.
- [ ] New-head Windows CI: pending.
- [ ] Full world/performance suite: not rerun; native runtime changes are limited to DLL symbol visibility and removing a diagnostic log.

## Windows CI Follow-up

The Windows Engine Build for merged #202 failed in `GpuCullingContractTests` and `ShaderCacheArtifactTests` with unresolved `AtmosphericFogNode::m_name` and `VulkanPipelineStateBuilder::GetBlendState`: [original failure](https://github.com/aantropov/sailor/actions/runs/34030985063).

Fixed in `ebd806350`:
- Mark the fog node name with `SAILOR_SHARED_API`, matching other nodes whose names are referenced by inline/template code across the runtime DLL boundary.
- Test the actual exported `BuildPipeline` result instead of exposing or calling the internal blend-state helper. Keep all RGB/alpha blend assertions and disabled-pass checks.
- Verify the fog node's static and virtual names through the compiled runtime interface.

Local Release builds and both affected test suites pass. Fresh MSVC and clang-cl CI on this commit are pending; no Windows success is claimed yet.

## Agent Workflow

- Implementation complete; implementation summary / local validation posted in the conversation.
- Tech review requested.
- Formal QA approval deferred until tech review and CI assessment.
- No merge or auto-merge requested.

## Risk

**Medium**: workspace stop/build/restart lifecycle and macOS dynamic-library visibility. Cache clearing is recoverable and path-checked; file formats and protocols remain unchanged.

