### PR TITLE
Profile GI and reduce Night City CPU submission overhead

### DIFF
--- a/Runtime/ECS/GlobalIlluminationECS.cpp
+++ b/Runtime/ECS/GlobalIlluminationECS.cpp
@@ -27,6 +27,7 @@ void GlobalIlluminationECS::BeginPlay()
 
 Tasks::ITaskPtr GlobalIlluminationECS::Tick(float deltaTime)
 {
+	SAILOR_PROFILE_FUNCTION();
 	InitializeFromWorld();
 	const bool bEnabled = IsEnabled();
 	if (bEnabled != m_bObservedEnabled)
@@ -604,6 +605,7 @@ void GlobalIlluminationECS::InitializeFromWorld()
 
 void GlobalIlluminationECS::TickBakedProvider()
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (HasRuntimeProviderState())
 	{
 		StopRuntimeProvider(true);
@@ -614,6 +616,7 @@ void GlobalIlluminationECS::TickBakedProvider()
 
 void GlobalIlluminationECS::TickRuntimeProvider(float deltaTime)
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!ShouldRunRuntimeProvider())
 	{
 		if (HasRuntimeProviderState())
@@ -709,6 +712,7 @@ void GlobalIlluminationECS::TickRuntimeProvider(float deltaTime)
 bool GlobalIlluminationECS::BeginRuntimeScenePreparation(
 	std::string& outDiagnostic)
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!GetWorld())
 	{
 		outDiagnostic = "runtime GI scene capture requires an active world";
@@ -810,6 +814,7 @@ bool GlobalIlluminationECS::BeginRuntimeScenePreparation(
 void GlobalIlluminationECS::ConsumeRuntimeScenePreparation(
 	const glm::vec3& priorityPosition)
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!m_runtimeScenePreparationTask ||
 		!m_runtimeScenePreparationTask->IsFinished())
 	{
@@ -875,6 +880,7 @@ bool GlobalIlluminationECS::StartRuntimeSolver(
 	const glm::vec3& priorityPosition,
 	std::string& outDiagnostic)
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!m_runtimePreparedScene || !m_runtimePreparedScene->m_sampler)
 	{
 		outDiagnostic = "runtime GI scene has no prepared ray sampler";
@@ -903,6 +909,7 @@ bool GlobalIlluminationECS::StartRuntimeSolver(
 
 void GlobalIlluminationECS::PublishRuntimeSnapshotIfNeeded()
 {
+	SAILOR_PROFILE_FUNCTION();
 	const RuntimeGIProbesStatus status = m_runtimeProbes.GetStatus();
 	if (status.m_publishedRevision == 0u ||
 		status.m_publishedRevision == m_runtimePublishedRevision)
@@ -1079,6 +1086,7 @@ bool GlobalIlluminationECS::StartLoad(
 
 void GlobalIlluminationECS::RefreshResidency()
 {
+	SAILOR_PROFILE_FUNCTION();
 	for (const auto& entry : m_bindings)
 	{
 		RuntimeBinding& binding = *entry.m_second;
@@ -1111,6 +1119,7 @@ void GlobalIlluminationECS::RefreshResidency()
 
 void GlobalIlluminationECS::RecomposeIfNeeded()
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!m_bCompositionDirty)
 	{
 		return;
@@ -1238,6 +1247,7 @@ void GlobalIlluminationECS::RecomposeIfNeeded()
 
 void GlobalIlluminationECS::DrawDebugVisualization() const
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!GetWorld())
 	{
 		return;

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -108,6 +108,10 @@ namespace
 		const RHI::RHIShadowCasterProxy& lhs,
 		const RHI::RHIShadowCasterProxy& rhs)
 	{
+		if (&lhs == &rhs)
+		{
+			return true;
+		}
 		if (lhs.m_staticMeshEcs != rhs.m_staticMeshEcs ||
 			lhs.m_worldAabb != rhs.m_worldAabb ||
 			lhs.m_skeletonOffset != rhs.m_skeletonOffset ||
@@ -311,6 +315,7 @@ void StaticMeshRendererECS::BeginPlay()
 
 void StaticMeshRendererECS::PublishSceneVersion(uint8_t spatialChangeMask)
 {
+	SAILOR_PROFILE_FUNCTION();
 	auto version = RHI::RHISpatialSceneVersionPtr::Make();
 	version->m_revision = ++m_sceneVersionRevision;
 	if (spatialChangeMask != 0u || !m_publishedSceneVersion)
@@ -364,6 +369,7 @@ void StaticMeshRendererECS::PublishSceneVersion(uint8_t spatialChangeMask)
 		auto rebuildSpatialRoot = [&](const TSharedPtr<TVector<RHI::RenderInstanceHandle>>& handles,
 			const TSharedPtr<TOctree<RHI::RenderInstanceHandle>>& octree)
 			{
+				SAILOR_PROFILE_SCOPE("Rebuild scene spatial root");
 				if (!handles || !octree)
 				{
 					return;
@@ -536,7 +542,12 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 	}
 
 	const size_t currentFrame = GetWorld()->GetCurrentFrame();
-	auto prepareProxyUpdate = [this, currentFrame](size_t componentIndex)
+	// Dirty-proxy workers only read the last published scene. Keep that immutable
+	// version alive through the join instead of serializing every record lookup
+	// on the mutable scene's lock.
+	const auto previousSceneVersion = m_rhiScene ?
+		m_rhiScene->GetCurrentVersion() : RHI::RHISceneVersionPtr{};
+	auto prepareProxyUpdate = [this, currentFrame, &previousSceneVersion](size_t componentIndex)
 		{
 			PreparedProxyUpdate result;
 			result.m_componentIndex = componentIndex;
@@ -643,13 +654,14 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			if (!bTopologyDirty && !bMaterialsDirty && m_rhiScene)
 			{
 				RHI::RenderInstanceHandle* renderHandle = nullptr;
-				RHI::RHISceneInstanceRecord previousRecord;
+				const RHI::RHISceneInstanceRecord* previousRecord = nullptr;
 				if (m_renderInstanceHandles.Find(componentIndex, renderHandle) &&
 					renderHandle &&
-					m_rhiScene->ResolveCurrent(*renderHandle, previousRecord))
+					previousSceneVersion &&
+					previousSceneVersion->Resolve(*renderHandle, previousRecord) && previousRecord)
 				{
-					const auto previousResource =
-						previousRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>();
+					const auto* previousResource = dynamic_cast<const RHI::RHISceneProxyResource*>(
+						previousRecord->m_topology.GetRawPtr());
 					Math::AABB worldBounds = model->GetBoundsAABB(data.GetMeshIndex());
 					worldBounds.Apply(ownerWorldMatrix);
 					if (previousResource && previousResource->m_bMeshTransformsAreLocal &&
@@ -805,6 +817,7 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 				"StaticMeshRendererECS:Prepare Dirty Proxies",
 				[beginIndex, endIndex, &dirtyComponents, &preparedUpdates, prepareProxyUpdate]()
 				{
+					SAILOR_PROFILE_SCOPE("Prepare dirty mesh proxies");
 					for (size_t index = beginIndex; index < endIndex; ++index)
 					{
 						preparedUpdates[index] = prepareProxyUpdate(dirtyComponents[index]);

--- a/Runtime/Engine/World.cpp
+++ b/Runtime/Engine/World.cpp
@@ -803,6 +803,7 @@ bool World::CanReparentPrefabObject(
 
 void World::Tick(FrameState& frameState)
 {
+	SAILOR_PROFILE_FUNCTION();
 	const bool bShouldCallBeginPlay = (m_mask & (uint8_t)EWorldBehaviourBit::CallBeginPlay) != 0;
 	const bool bShouldTick = (m_mask & (uint8_t)EWorldBehaviourBit::Tickable) != 0;
 	const bool bShouldEcsTick = (m_mask & (uint8_t)EWorldBehaviourBit::EcsTickable) != 0;

--- a/Runtime/GlobalIllumination/GIProbesComposition.cpp
+++ b/Runtime/GlobalIllumination/GIProbesComposition.cpp
@@ -53,6 +53,7 @@ GIProbesCompositionPlan GIProbesComposer::BuildPlan(
 	uint32_t maxStatesPerSnapshot,
 	EGIProbesCompositionValidation validation) noexcept
 {
+	SAILOR_PROFILE_FUNCTION();
 	try
 	{
 		TVector<const GIProbesCompositionInput*> active;
@@ -207,6 +208,7 @@ GIProbesCompositionResult GIProbesComposer::Compose(
 	const TVector<GIProbesCompositionInput>& inputs,
 	uint32_t maxStatesPerSnapshot) noexcept
 {
+	SAILOR_PROFILE_FUNCTION();
 	GIProbesCompositionPlan plan = BuildPlan(
 		inputs,
 		maxStatesPerSnapshot,

--- a/Runtime/GlobalIllumination/GIProbesScene.cpp
+++ b/Runtime/GlobalIllumination/GIProbesScene.cpp
@@ -362,6 +362,7 @@ bool Sailor::ObserveGIProbesSceneRevision(
 	GIProbesSceneRevision& outRevision,
 	std::string& outDiagnostic)
 {
+	SAILOR_PROFILE_FUNCTION();
 	outRevision = {};
 	outDiagnostic.clear();
 	if (!world)
@@ -440,6 +441,7 @@ bool Sailor::CaptureGIProbesScene(
 	std::string& outDiagnostic,
 	const GIProbesSceneWarningCallback& warning)
 {
+	SAILOR_PROFILE_FUNCTION();
 	outScene = {};
 	outDiagnostic.clear();
 	if (!world)
@@ -764,6 +766,7 @@ bool Sailor::PrepareGIProbesScene(
 	const Raytracing::PathTracer::ScenePreparationProgressCallback& progress,
 	const GIProbesSceneWarningCallback& warning)
 {
+	SAILOR_PROFILE_FUNCTION();
 	outPreparedScene = {};
 	outDiagnostic.clear();
 	const auto isCancelled = [cancel]() noexcept

--- a/Runtime/GlobalIllumination/GIProbesTracing.cpp
+++ b/Runtime/GlobalIllumination/GIProbesTracing.cpp
@@ -331,6 +331,7 @@ bool Sailor::TraceGIProbeTransport(
 	GIProbe& probe,
 	std::string& outDiagnostic)
 {
+	SAILOR_PROFILE_FUNCTION();
 	outDiagnostic.clear();
 	if (!Math::AllFinite(request.m_volumeMin) ||
 		!Math::AllFinite(request.m_volumeMax) ||
@@ -497,6 +498,7 @@ bool Sailor::AccumulateGIProbeIrradianceRange(
 	GIProbeIrradianceAccumulator& accumulator,
 	std::string& outDiagnostic)
 {
+	SAILOR_PROFILE_FUNCTION();
 	outDiagnostic.clear();
 	if (sequenceSampleCount == 0u ||
 		sequenceSampleCount > GIProbesMaxRaysPerProbe ||

--- a/Runtime/GlobalIllumination/RuntimeGIProbesGeneration.cpp
+++ b/Runtime/GlobalIllumination/RuntimeGIProbesGeneration.cpp
@@ -54,6 +54,7 @@ namespace Sailor
 
 	std::vector<uint32_t> RuntimeGIProbesService::Impl::BuildProgressiveProbeOrder(const Generation& generation)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		std::vector<uint32_t> result;
 		result.reserve(generation.m_probes.size());
 		if (generation.m_data->m_bricks.IsEmpty())
@@ -135,6 +136,7 @@ namespace Sailor
 		uint64_t generationId,
 		std::string& outDiagnostic)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		outDiagnostic.clear();
 		if (!Math::AllFinite(request.m_priorityPosition))
 		{
@@ -235,6 +237,7 @@ namespace Sailor
 
 	void RuntimeGIProbesService::Impl::ReuseGenerationState(Generation& next, const Generation& previous)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		std::vector<uint32_t> progressiveOrder = std::move(next.m_initialQueue);
 		next.m_initialQueue.reserve(progressiveOrder.size());
 		next.m_warmingQueue.clear();
@@ -325,6 +328,7 @@ namespace Sailor
 
 	bool RuntimeGIProbesService::Impl::ExecuteJob(Job& job, std::string& outDiagnostic)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		Generation& generation = *job.m_generation;
 		ProbeWork& work = job.m_work;
 		GIProbeTraceRequest traceRequest;

--- a/Runtime/GlobalIllumination/RuntimeGIProbesPublication.cpp
+++ b/Runtime/GlobalIllumination/RuntimeGIProbesPublication.cpp
@@ -31,6 +31,7 @@ namespace Sailor
 		std::string diagnostic,
 		double elapsedMilliseconds)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		const std::lock_guard<std::mutex> lock(m_mutex);
 		const std::shared_ptr<Generation>& generation = job.m_generation;
 		if (!m_generation || m_generation != generation || generation->m_cancel.load(std::memory_order_acquire))
@@ -125,6 +126,7 @@ namespace Sailor
 
 	void RuntimeGIProbesService::Impl::PublishIfNeeded()
 	{
+		SAILOR_PROFILE_FUNCTION();
 		const std::lock_guard<std::mutex> lock(m_mutex);
 		if (!m_generation || m_generation->m_bFailed || m_generation->m_dirtyCount == 0u)
 		{

--- a/Runtime/GlobalIllumination/RuntimeGIProbesScheduler.cpp
+++ b/Runtime/GlobalIllumination/RuntimeGIProbesScheduler.cpp
@@ -16,6 +16,7 @@ namespace Sailor
 
 	void RuntimeGIProbesService::Impl::StopWorkerTasks() noexcept
 	{
+		SAILOR_PROFILE_FUNCTION();
 		std::vector<Tasks::ITaskPtr> workerTasks;
 		{
 			const std::lock_guard<std::mutex> lock(m_mutex);
@@ -37,6 +38,7 @@ namespace Sailor
 
 	bool RuntimeGIProbesService::Impl::TryTakeJob(const std::shared_ptr<Generation>& generation, Job& outJob)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		const std::lock_guard<std::mutex> lock(m_mutex);
 		if (!CanDispatchWorkLocked() || m_generation != generation)
 		{
@@ -80,12 +82,14 @@ namespace Sailor
 
 	RuntimeGIProbesService::Impl::DispatchBatch RuntimeGIProbesService::Impl::GetDispatchBatch() const noexcept
 	{
+		SAILOR_PROFILE_FUNCTION();
 		const std::lock_guard<std::mutex> lock(m_mutex);
 		return CanDispatchWorkLocked() ? DispatchBatch{m_generation, m_workerCount} : DispatchBatch{};
 	}
 
 	void RuntimeGIProbesService::Impl::WorkerBatch(std::shared_ptr<Generation> generation, uint32_t maximumJobCount)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		for (uint32_t completedJobCount = 0u; completedJobCount < maximumJobCount; ++completedJobCount)
 		{
 			Job job;
@@ -107,6 +111,7 @@ namespace Sailor
 					(std::min)(100.0, elapsedMilliseconds * (1.0 / static_cast<double>(duty) - 1.0));
 				if (sleepMilliseconds > 0.05)
 				{
+					SAILOR_PROFILE_SCOPE("Runtime GI duty-cycle sleep");
 					std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(sleepMilliseconds));
 				}
 			}
@@ -115,6 +120,7 @@ namespace Sailor
 
 	void RuntimeGIProbesService::Impl::PumpWorkerTasks()
 	{
+		SAILOR_PROFILE_FUNCTION();
 		m_workerTasks.erase(std::remove_if(m_workerTasks.begin(),
 								m_workerTasks.end(),
 								[](const Tasks::ITaskPtr& task) { return !task || task->IsFinished(); }),

--- a/Runtime/GlobalIllumination/RuntimeGIProbesService.cpp
+++ b/Runtime/GlobalIllumination/RuntimeGIProbesService.cpp
@@ -13,6 +13,7 @@ namespace Sailor
 
 	bool RuntimeGIProbesService::Start(const RuntimeGIProbesStartRequest& request, std::string& outDiagnostic)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		if (!request.m_worldSettings.Validate(outDiagnostic) || !request.m_qualitySettings.Validate(outDiagnostic))
 		{
 			return false;
@@ -125,6 +126,7 @@ namespace Sailor
 
 	void RuntimeGIProbesService::Tick(float deltaTimeSeconds)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		{
 			const std::lock_guard<std::mutex> lock(m_impl->m_mutex);
 			if (m_impl->m_generation && std::isfinite(deltaTimeSeconds) && deltaTimeSeconds > 0.0f)
@@ -149,6 +151,7 @@ namespace Sailor
 
 	RuntimeGIProbesStatus RuntimeGIProbesService::GetStatus() const
 	{
+		SAILOR_PROFILE_FUNCTION();
 		const std::lock_guard<std::mutex> lock(m_impl->m_mutex);
 		m_impl->UpdateStatusLocked();
 		return m_impl->m_status;

--- a/Runtime/Math/Bounds.cpp
+++ b/Runtime/Math/Bounds.cpp
@@ -576,8 +576,6 @@ float Math::Triangle::Area() const
 
 bool Math::IntersectRayTriangle(const Ray& ray, const Triangle& tri, RaycastHit& outRaycastHit, float maxRayLength)
 {
-	SAILOR_PROFILE_FUNCTION();
-
 	outRaycastHit = RaycastHit();
 	outRaycastHit.m_rayLenght = maxRayLength;
 
@@ -649,8 +647,6 @@ void IntersectRayTriangle(Ray& ray, const Triangle& tri)
 
 float Math::IntersectRayAABB(const Ray& ray, const glm::vec3& bmin, const glm::vec3& bmax, float maxRayLength)
 {
-	SAILOR_PROFILE_FUNCTION();
-
 	const glm::vec3 t1 = (bmin - ray.GetOrigin()) * ray.GetReciprocalDirection();
 	const glm::vec3 t2 = (bmax - ray.GetOrigin()) * ray.GetReciprocalDirection();
 

--- a/Runtime/RHI/Batch.hpp
+++ b/Runtime/RHI/Batch.hpp
@@ -61,6 +61,14 @@ namespace Sailor::RHI
 
 		bool operator==(const RHIBatch& rhs) const
 		{
+			// Shared meshes in a traffic/vegetation run already have identical
+			// resource identities. Avoid retaining bindings and shaders per instance.
+			if (m_material == rhs.m_material &&
+				m_materialVersion == rhs.m_materialVersion &&
+				m_mesh == rhs.m_mesh && m_textureBindings == rhs.m_textureBindings)
+			{
+				return true;
+			}
 			const auto bindings = GetMaterialBindings();
 			const auto rhsBindings = rhs.GetMaterialBindings();
 			if (!m_material || !rhs.m_material || !m_mesh || !rhs.m_mesh ||
@@ -150,6 +158,7 @@ namespace Sailor::RHI
 		RHIMeshPtr m_mesh{};
 		uint32_t m_instanceIndex = 0u;
 		uint64_t m_stableSortKey = 0ull;
+		size_t m_batchSortHash = 0u;
 	};
 
 	struct PackedDrawGroup
@@ -859,6 +868,7 @@ namespace Sailor::RHI
 			for (auto& segment : m_segments)
 			{
 				segment.m_items.Clear(false);
+				segment.m_sortedItemIndices.Clear(false);
 				segment.m_reorderVisited.Clear(false);
 				segment.m_viewInstanceIndices.Clear(false);
 				segment.m_groups.Clear(false);
@@ -1124,6 +1134,7 @@ namespace Sailor::RHI
 
 		void Finalize(bool bPreserveInstanceOrder = false)
 		{
+			SAILOR_PROFILE_FUNCTION();
 			for (auto& segment : m_segments)
 			{
 				segment.m_viewInstanceIndices.Clear(false);
@@ -1141,10 +1152,23 @@ namespace Sailor::RHI
 
 				if (!bPreserveInstanceOrder)
 				{
-					segment.m_items.Sort([](const auto& lhs, const auto& rhs)
+					SAILOR_PROFILE_SCOPE("Sort packed draw items");
+					// A batch is immutable during finalization. Calculate its key once
+					// instead of retaining shared material bindings on every comparison.
+					segment.m_sortedItemIndices.Resize(segment.m_items.Num());
+					for (uint32_t index = 0u; index < segment.m_items.Num(); ++index)
 					{
-						const size_t lhsBatchHash = lhs.m_batch.GetHash();
-						const size_t rhsBatchHash = rhs.m_batch.GetHash();
+						segment.m_items[index].m_batchSortHash = segment.m_items[index].m_batch.GetHash();
+						segment.m_sortedItemIndices[index] = index;
+					}
+					// Sort indices so shared resource references stay in place. Moving
+					// the owning items repeatedly contends with other render passes.
+					segment.m_sortedItemIndices.Sort([&items = segment.m_items](uint32_t lhsIndex, uint32_t rhsIndex)
+					{
+						const auto& lhs = items[lhsIndex];
+						const auto& rhs = items[rhsIndex];
+						const size_t lhsBatchHash = lhs.m_batchSortHash;
+						const size_t rhsBatchHash = rhs.m_batchSortHash;
 						if (lhsBatchHash != rhsBatchHash)
 						{
 							return lhsBatchHash < rhsBatchHash;
@@ -1190,10 +1214,10 @@ namespace Sailor::RHI
 
 							uint32_t destination = start;
 							TPerInstanceData displaced = std::move(instances[destination]);
-							while (segment.m_items[destination].m_instanceIndex != start)
+							while (segment.m_items[segment.m_sortedItemIndices[destination]].m_instanceIndex != start)
 							{
 								const uint32_t source =
-									segment.m_items[destination].m_instanceIndex;
+									segment.m_items[segment.m_sortedItemIndices[destination]].m_instanceIndex;
 								instances[destination] = std::move(instances[source]);
 								segment.m_reorderVisited[destination] = 1u;
 								destination = source;
@@ -1207,7 +1231,8 @@ namespace Sailor::RHI
 				groups.Reserve(segment.m_items.Num());
 				for (uint32_t itemIndex = 0u; itemIndex < segment.m_items.Num(); ++itemIndex)
 				{
-					const auto& item = segment.m_items[itemIndex];
+					const auto& item = segment.m_items[bPreserveInstanceOrder ?
+						itemIndex : segment.m_sortedItemIndices[itemIndex]];
 					const bool bAppendToGroup = !bPreserveInstanceOrder &&
 						!groups.IsEmpty() &&
 						groups.Last()->m_numInstances < RHIBatch::MaxInstancesPerBatch &&
@@ -1299,6 +1324,7 @@ namespace Sailor::RHI
 		struct Segment
 		{
 			TVector<TPackedDrawItem<TPerInstanceData>> m_items{};
+			TVector<uint32_t> m_sortedItemIndices{};
 			TVector<uint8_t> m_reorderVisited{};
 			TVector<uint32_t> m_viewInstanceIndices{};
 			TVector<PackedDrawGroup> m_groups{};

--- a/Runtime/RHI/GlobalIllumination.cpp
+++ b/Runtime/RHI/GlobalIllumination.cpp
@@ -383,6 +383,7 @@ bool Sailor::RHI::BuildGlobalIlluminationGpuLayout(
 	RHIGlobalIlluminationGpuLayout& outLayout,
 	std::string& outDiagnostic) noexcept
 {
+	SAILOR_PROFILE_FUNCTION();
 	outLayout = {};
 	outDiagnostic.clear();
 	try
@@ -521,6 +522,7 @@ bool Sailor::RHI::BuildGlobalIlluminationGpuCoefficients(
 	TVector<RHIGlobalIlluminationGpuCoefficients>& outCoefficients,
 	std::string& outDiagnostic) noexcept
 {
+	SAILOR_PROFILE_FUNCTION();
 	outCoefficients.Clear();
 	outDiagnostic.clear();
 	try
@@ -619,6 +621,7 @@ bool Sailor::RHI::BuildGlobalIlluminationGpuStates(
 	TVector<RHIGlobalIlluminationGpuState>& outStates,
 	std::string& outDiagnostic) noexcept
 {
+	SAILOR_PROFILE_FUNCTION();
 	outStates.Clear();
 	outDiagnostic.clear();
 	try

--- a/Runtime/RHI/Scene.cpp
+++ b/Runtime/RHI/Scene.cpp
@@ -625,6 +625,7 @@ RHISceneVersionPtr RHIScene::PublishVersion(
 	uint64_t shadowRevision,
 	uint64_t spatialRevision)
 {
+	SAILOR_PROFILE_FUNCTION();
 	m_lock.Lock();
 	if (m_currentVersion &&
 		m_lastPublishedRevision == m_revision &&

--- a/Runtime/Raytracing/GIProbesPathTracer.cpp
+++ b/Runtime/Raytracing/GIProbesPathTracer.cpp
@@ -22,6 +22,7 @@ bool GIProbesPathTracer::Initialize(
 	const PathTracer::ScenePreparationProgressCallback& progress,
 	const PathTracer::ScenePreparationWarningCallback& warning)
 {
+	SAILOR_PROFILE_FUNCTION();
 	TVector<LightProxy> bakedLights;
 	bakedLights.Reserve(lights.Num());
 	for (const LightProxy& source : lights)

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -903,6 +903,7 @@ void App::Start()
 
 			//Frame successfully pushed
 			frameCounter++;
+			SAILOR_PROFILE_END_FRAME();
 			if (bRunsInsideEditor)
 			{
 				EditorRuntime::PumpEditorRemoteViewportsOnEngineThread();
@@ -971,7 +972,6 @@ void App::Start()
 		systemInputState = Win32::GlobalInput::GetInputState();
 		systemInputState.TrackForChanges(oldInputState);
 
-		SAILOR_PROFILE_END_FRAME();
 	}
 
 	pMainWindow->SetActive(false);

--- a/Runtime/Tasks/Scheduler.cpp
+++ b/Runtime/Tasks/Scheduler.cpp
@@ -215,9 +215,11 @@ void Scheduler::Initialize()
 		1u,
 		(std::min)(MaxGIThreads, coresCount));
 	const unsigned numReservedThreads = 8u + numRHIThreads;
-	const unsigned numThreads = coresCount > numReservedThreads
-		? coresCount - numReservedThreads
-		: 1u;
+	// Dedicated queues are often idle or throttled. Reserving all of their
+	// threads must not prevent an eight-way gameplay batch from running.
+	const unsigned minimumWorkers = (std::min)(8u, (std::max)(1u, coresCount));
+	const unsigned numThreads = (std::max)(minimumWorkers,
+		coresCount > numReservedThreads ? coresCount - numReservedThreads : 1u);
 
 	WorkerThread* newRenderingThread = new WorkerThread(
 		"Render Thread",
@@ -310,7 +312,8 @@ void Scheduler::Initialize()
 	m_threadTypes[m_audioThreadId] = EThreadType::Audio;
 	m_workerThreads.Emplace(newAudioThread);
 
-	SAILOR_LOG("Initialize Tasks::Scheduler. Cores count: %d, Worker threads count: %zd", coresCount, m_workerThreads.Num());
+	SAILOR_LOG("Initialize Tasks::Scheduler. Logical cores: %u, Worker threads: %u, GI threads: %u, total threads: %zd",
+		coresCount, numThreads, numGIThreads, m_workerThreads.Num());
 }
 
 void Scheduler::AttachCurrentThreadAsMainThread()

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -886,6 +886,20 @@ namespace
 			current->m_topology == original->m_topology &&
 			meshes->GetGlobalIlluminationContributorRevision() != revision,
 			"a later transform must update bounds and GI while retaining mesh topology");
+		Require(original->m_worldMatrix[3].x == 0.0f &&
+			current->m_worldBounds != original->m_worldBounds,
+			"transform publication must leave retained records unchanged");
+		world.AdvanceFrame();
+		object->GetTransformComponent().SetPosition(glm::vec3(4.0f, 0.0f, 0.0f));
+		transforms->Tick(0.016f);
+		transforms->PostTick();
+		meshes->Tick(0.016f);
+		const auto movedAgain = meshes->GetRHIScene()->GetCurrentVersion();
+		const RHI::RHISceneInstanceRecord* latest = nullptr;
+		Require(movedAgain->Resolve(handle, latest) && latest &&
+			latest->m_worldMatrix[3].x == 4.0f && current->m_worldMatrix[3].x == 2.0f &&
+			latest->m_topology == original->m_topology,
+			"successive transform updates must retain topology without lagging a frame");
 		meshes->UnregisterComponent(slot);
 		Require(meshes->GetRHIScene()->GetCurrentVersion()->m_staticHandles->IsEmpty(),
 			"unregistering the component must remove its published instance");

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -521,6 +521,56 @@ namespace
 			"a smaller platform texture/command limit must still take precedence");
 	}
 
+	void TestPackedDrawMixedMaterialSort()
+	{
+		struct Instance { uint32_t m_id = 0u; };
+		std::array<RHI::RHIMaterialPtr, 4> materials;
+		for (auto& material : materials)
+		{
+			material = RHI::RHIMaterialPtr::Make(
+				RHI::RenderState{}, RHI::RHIShaderPtr{}, RHI::RHIShaderPtr{});
+		}
+		std::array<RHI::RHIMeshPtr, 2> meshes{
+			RHI::RHIMeshPtr::Make(), RHI::RHIMeshPtr::Make() };
+		RHI::TPackedDrawPacket<Instance> packet;
+		constexpr uint32_t count = 4097u;
+		for (uint32_t flight = 0u; flight < 2u; ++flight)
+		{
+			packet.Reset();
+			for (auto& material : materials)
+			{
+				material->SetBindings(RHI::RHIShaderBindingSetPtr::Make());
+			}
+			for (uint32_t index = 0u; index < count; ++index)
+			{
+				const uint32_t id = (index * 37u) % count;
+				const auto& mesh = meshes[(id / materials.size()) % meshes.size()];
+				packet.Add(RHI::RHIBatch(materials[id % materials.size()], mesh), mesh, {id}, id);
+			}
+			packet.Finalize(false);
+			std::array<bool, count> seen{};
+			uint32_t visited = 0u;
+			for (const auto& group : packet.GetGroups())
+			{
+				uint32_t previousId = 0u;
+				for (uint32_t offset = 0u; offset < group.m_numInstances; ++offset)
+				{
+					const uint32_t storageIndex = packet.GetInstanceIndices()[group.m_firstInstance + offset];
+					const uint32_t id = packet.GetPayload(EMobilityType::Dynamic).m_instances[storageIndex].m_id;
+					Require(id < count && !seen[id], "sorted packets must retain every instance exactly once");
+					seen[id] = true;
+					++visited;
+					Require(group.m_batch.m_materialVersion == materials[id % materials.size()]->GetVersion() &&
+						group.m_mesh == meshes[(id / materials.size()) % meshes.size()],
+						"sorting and packet reuse must preserve each instance's mesh and material generation");
+					Require(offset == 0u || previousId < id, "instances sharing a draw must retain stable key order");
+					previousId = id;
+				}
+			}
+			Require(visited == count, "all mixed-material instances must reach the draw packet");
+		}
+	}
+
 	void TestPackedDrawMobilityPayloadVirtualization()
 	{
 		struct TestInstance
@@ -1314,6 +1364,7 @@ int main()
 		{ "MipExtentUsesVulkanFloorAndClamp", TestMipExtentUsesVulkanFloorAndClamp },
 		{ "PackedDrawMobilityPayloadVirtualization", TestPackedDrawMobilityPayloadVirtualization },
 		{ "PackedDrawBatchInstanceLimit", TestPackedDrawBatchInstanceLimit },
+		{ "PackedDrawMixedMaterialSort", TestPackedDrawMixedMaterialSort },
 		{ "MaterialVersionPublicationContract", TestMaterialVersionPublicationContract },
 		{ "DynamicSpatialRootIsolation", TestDynamicSpatialRootIsolation },
 		{ "InstancedViewLodAndDistanceContract", TestInstancedViewLodAndDistanceContract },


### PR DESCRIPTION
## Summary

Night City loses most of its CPU frame time in mesh publication and shadow/draw preparation once 16,384 vehicles move. Add usable Tracy instrumentation for the full GI lifecycle and reduce draw finalization and dirty-proxy contention. This is a measured first optimization pass; the scene still does not run smoothly.

## Linked Issue

Requested during Windows profiling. Stacked on #204 (`fix/windows-platform-runtime`); merge/rebase after that PR. This PR contains only the subsequent performance changes.

## Implementation Notes

- Profile GI scene capture/preparation, generation, job dispatch/execution, composition, publication, residency, and GPU payload preparation. Give duty-cycle sleep its own scope.
- Remove per-AABB/per-triangle scopes that emitted 222 million events in an early 90-second capture. Keep probe/batch scopes and count a Tracy frame only after successful frame submission.
- Cache each packed item's batch hash, stably sort indices while resource owners remain in place, and short-circuit identical batch resources. Preserve transparent order, shared arenas, material generations, and platform batch limits.
- Prepare dirty mesh proxies from a retained immutable scene version instead of locking the mutable scene for every vehicle. Skip deep comparison of identical shadow proxies.
- Allow eight general workers on CPUs with at least eight logical cores. The previous reservation formula provided only six on this 16-thread machine, despite dispatching eight traffic tasks.

The local DemoSailor traffic code dispatches eight Sailor tasks, registers dirty transforms on the world thread, and joins before ECS consumes transforms. That separate project has no Git metadata; its changes are local and are not engine-PR files.

## Agent Workflow

- [x] Implementation Summary included above.
- [x] Tech Review requested; PR remains draft.
- [x] Local validation recorded; independent QA approval deferred until review.
- [ ] Ready for human review only after Tech Review and QA approval.

## Tests and Measurements

Windows x64/MSVC Release, Tracy 0.11.1, RTX 3060 Laptop, 16 logical CPU cores:

- Rebuilt engine DLL, executable, and DemoSailor module with `SAILOR_BUILD_WITH_TRACY_PROFILER=ON`.
- 23 GPU culling/batching cases passed, including new mixed-material/generation sorting coverage.
- 37 ECS lifecycle cases passed, including successive transform publications retaining old snapshots and topology.
- RHIScene virtualization suite passed (12 scenarios).
- `git diff --check` passed.

Isolated finalization benchmark: four concurrent passes of 65,536 instances, four shared materials/four meshes, 40 measured samples after warmup. Median original-header time 180.997 ms; final implementation 32.753 ms, about 5.5x faster for that operation. This is not an FPS multiplier. The original full-scene capture was confounded by intersection instrumentation overhead, so it is not used to attribute the sort improvement.

Controlled Night City CPU comparison, existing `DEMOSAILOR_GI=off` on both runs, identical geometry/shadows and first 20 seconds of camera movement:

| Metric | Before final proxy/equality changes | After |
| --- | ---: | ---: |
| World-frame cadence | 8.09 FPS | 8.79 FPS |
| Mesh ECS median | 53.107 ms | 45.659 ms |
| Shadow preparation median | 66.716 ms | 59.644 ms |
| Traffic update median | 6.368 ms | 6.267 ms |

Full-lighting baseline after indexed sorting reached 4,356/4,356 probes at refinement 1.0 and panorama reflection 64 spp. During movement, GI tick median was 0.009 ms (mean 0.443 ms), traffic 6.410 ms on eight distinct workers, mesh ECS 53.681 ms, dynamic octree rebuilding 14.624 ms, and shadow preparation 67.824 ms. World-frame cadence was 7.32 FPS.

Final full-lighting validation reached the same GI/reflection quality, recorded 20 seconds of movement, and exited cleanly (engine/capture exit 0). Rendered output was visually checked. Comparing the **same first 15 seconds** in each full-lighting capture:

| Metric | Baseline | Final |
| --- | ---: | ---: |
| World-frame cadence | 7.25 FPS | 9.26 FPS |
| Mesh ECS median / p95 | 53.76 / 66.09 ms | 41.15 / 50.66 ms |
| Shadow preparation median / p95 | 67.90 / 85.95 ms | 53.92 / 68.83 ms |
| Traffic update median | 6.410 ms | 6.311 ms |
| GI tick median | 0.0093 ms | 0.0085 ms |

The observed cadence increase is 28% across these two captures, not a repeated statistical estimate. Final movement is at 360.663–380.885 seconds in the trace; 1,632 traffic batch zones used eight distinct workers. The full 20-second final interval measured 10.06 FPS, but later camera views change the load, so it is not used as the matched before/after figure.

Reproduction build:

```powershell
cmake -S D:/Projects/DemoSailor/Generated -B D:/Projects/DemoSailor/Cache/Build -DSAILOR_BUILD_WITH_TRACY_PROFILER=ON
$env:CL='/MP8'
cmake --build D:/Projects/DemoSailor/Cache/Build --config Release --target DemoSailor --parallel 8
```

The local captures/logs/CSV summaries are under `build/batch-contract-tests/night-city-*`. Graphics settings and generated probes are not committed. CPU scopes overlap and must not be summed as frame time. Cadence uses successive `ProcessCpuFrame` starts; the existing GPU FPS label is not end-to-end presentation FPS.

## Risk

Medium: shared batch templates and worker-pool sizing affect other scenes/platforms. Immutable publication is preserved and tested. macOS and GPU timestamp validation were not run in this pass. Dynamic octree rebuilding and per-view/shadow packet construction remain major costs; replacing them requires preserving versions retained by in-flight rendering. No schema or graphics-quality changes.
