### PR TITLE
Profile GI and reuse camera LOD across render passes

### DIFF
--- a/Runtime/ECS/GlobalIlluminationECS.cpp
+++ b/Runtime/ECS/GlobalIlluminationECS.cpp
@@ -27,6 +27,7 @@ void GlobalIlluminationECS::BeginPlay()
 
 Tasks::ITaskPtr GlobalIlluminationECS::Tick(float deltaTime)
 {
+	SAILOR_PROFILE_FUNCTION();
 	InitializeFromWorld();
 	const bool bEnabled = IsEnabled();
 	if (bEnabled != m_bObservedEnabled)
@@ -604,6 +605,7 @@ void GlobalIlluminationECS::InitializeFromWorld()
 
 void GlobalIlluminationECS::TickBakedProvider()
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (HasRuntimeProviderState())
 	{
 		StopRuntimeProvider(true);
@@ -614,6 +616,7 @@ void GlobalIlluminationECS::TickBakedProvider()
 
 void GlobalIlluminationECS::TickRuntimeProvider(float deltaTime)
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!ShouldRunRuntimeProvider())
 	{
 		if (HasRuntimeProviderState())
@@ -709,6 +712,7 @@ void GlobalIlluminationECS::TickRuntimeProvider(float deltaTime)
 bool GlobalIlluminationECS::BeginRuntimeScenePreparation(
 	std::string& outDiagnostic)
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!GetWorld())
 	{
 		outDiagnostic = "runtime GI scene capture requires an active world";
@@ -810,6 +814,7 @@ bool GlobalIlluminationECS::BeginRuntimeScenePreparation(
 void GlobalIlluminationECS::ConsumeRuntimeScenePreparation(
 	const glm::vec3& priorityPosition)
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!m_runtimeScenePreparationTask ||
 		!m_runtimeScenePreparationTask->IsFinished())
 	{
@@ -875,6 +880,7 @@ bool GlobalIlluminationECS::StartRuntimeSolver(
 	const glm::vec3& priorityPosition,
 	std::string& outDiagnostic)
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!m_runtimePreparedScene || !m_runtimePreparedScene->m_sampler)
 	{
 		outDiagnostic = "runtime GI scene has no prepared ray sampler";
@@ -903,6 +909,7 @@ bool GlobalIlluminationECS::StartRuntimeSolver(
 
 void GlobalIlluminationECS::PublishRuntimeSnapshotIfNeeded()
 {
+	SAILOR_PROFILE_FUNCTION();
 	const RuntimeGIProbesStatus status = m_runtimeProbes.GetStatus();
 	if (status.m_publishedRevision == 0u ||
 		status.m_publishedRevision == m_runtimePublishedRevision)
@@ -1079,6 +1086,7 @@ bool GlobalIlluminationECS::StartLoad(
 
 void GlobalIlluminationECS::RefreshResidency()
 {
+	SAILOR_PROFILE_FUNCTION();
 	for (const auto& entry : m_bindings)
 	{
 		RuntimeBinding& binding = *entry.m_second;
@@ -1111,6 +1119,7 @@ void GlobalIlluminationECS::RefreshResidency()
 
 void GlobalIlluminationECS::RecomposeIfNeeded()
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!m_bCompositionDirty)
 	{
 		return;
@@ -1238,6 +1247,7 @@ void GlobalIlluminationECS::RecomposeIfNeeded()
 
 void GlobalIlluminationECS::DrawDebugVisualization() const
 {
+	SAILOR_PROFILE_FUNCTION();
 	if (!GetWorld())
 	{
 		return;

--- a/Runtime/ECS/LightingCSM.cpp
+++ b/Runtime/ECS/LightingCSM.cpp
@@ -17,6 +17,7 @@ using namespace Sailor::Tasks;
 bool CSMLightState::CanReuse(uint32_t componentIndex,
 	RHI::EShadowType shadowType,
 	const glm::mat4& lightMatrix,
+	size_t lodCameraRevision,
 	uint64_t sceneRevision,
 	const TSharedPtr<TVector<RHI::RHISceneVersionPtr>>& sceneVersions,
 	const Math::Frustum& shadowFrustum,
@@ -34,6 +35,10 @@ bool CSMLightState::CanReuse(uint32_t componentIndex,
 		return false;
 	}
 	if (m_bContainsDynamicCasters && m_submissionToken != currentSubmissionToken)
+	{
+		return false;
+	}
+	if (m_bContainsCameraLodCasters && m_lodCameraRevision != lodCameraRevision)
 	{
 		return false;
 	}
@@ -84,6 +89,7 @@ void LightingECS::PrepareCSMPasses(const RHI::RHISceneViewPtr& sceneView,
 
 	outUpdateShadowMaps.Reserve(outUpdateShadowMaps.Num() + directionalLights.Num() * NumCascades);
 	const auto casterSceneVersions = sceneView->GetRetainedSceneVersions();
+	const size_t lodCameraRevision = CalculateShadowLodCameraRevision(cameraData);
 	const auto submissionToken = sceneView->GetOrCreateSubmissionCompletionToken();
 	auto& csmSnapshots = flightResources.m_csmSnapshots;
 	const auto& graphicsProfile = App::GetActiveGraphicsSettings();
@@ -121,6 +127,7 @@ void LightingECS::PrepareCSMPasses(const RHI::RHISceneViewPtr& sceneView,
 										  csmSnapshots[currentSnapshotIndex].CanReuse(directionalLight.m_index,
 											  shadowType,
 											  lightMatrices[cascadeIndex],
+											  lodCameraRevision,
 											  sceneView->m_shadowCastersRevision,
 											  casterSceneVersions,
 											  frustums[cascadeIndex],
@@ -162,7 +169,7 @@ void LightingECS::PrepareCSMPasses(const RHI::RHISceneViewPtr& sceneView,
 			directionalLight.m_lightMatrix;
 		Math::Frustum broadFrustum;
 		broadFrustum.ExtractFrustumPlanes(broadLightMatrix);
-		sceneView->TraceShadowCasters(broadFrustum, glm::vec3(cameraTransform.m_position), m_csmBroadCastersScratch);
+		sceneView->TraceShadowCasters(broadFrustum, m_csmBroadCastersScratch);
 		const auto& shadowCasters = m_csmBroadCastersScratch;
 		std::array<Tasks::TaskPtr<TVector<RHI::RHIVisibleShadowCaster>>, NumCascades> cascadeCasterTasks{};
 		for (uint32_t cascadeIndex = 0; cascadeIndex < numCascades; ++cascadeIndex)
@@ -220,11 +227,13 @@ void LightingECS::PrepareCSMPasses(const RHI::RHISceneViewPtr& sceneView,
 			snapshot.m_componentIndex = directionalLight.m_index;
 			snapshot.m_shadowType = cascade.m_shadowType;
 			snapshot.m_lightMatrix = lightMatrices[k];
+			snapshot.m_lodCameraRevision = lodCameraRevision;
 			snapshot.m_sceneRevision = sceneView->m_shadowCastersRevision;
 			snapshot.m_animationRevision = sceneView->m_animationRevision;
 			snapshot.m_casterSceneVersions = casterSceneVersions;
 			ResolveShadowCasterUpdatePolicy(
-				cascade.m_meshList, snapshot.m_bContainsDynamicCasters, snapshot.m_bContainsAnimatedCasters);
+				cascade.m_meshList, snapshot.m_bContainsDynamicCasters, snapshot.m_bContainsAnimatedCasters,
+				snapshot.m_bContainsCameraLodCasters);
 
 			const bool bEvsmCascade = cascade.m_shadowType == RHI::EShadowType::EVSM;
 			const glm::ivec2 shadowMapExtent(graphicsProfile.GetShadowCascadeResolution(k));

--- a/Runtime/ECS/LightingECS.cpp
+++ b/Runtime/ECS/LightingECS.cpp
@@ -41,19 +41,30 @@ namespace Sailor::LightingECSInternal
 
 	void ResolveShadowCasterUpdatePolicy(const TVector<RHI::RHIVisibleShadowCaster>& casters,
 		bool& outContainsDynamicCasters,
-		bool& outContainsAnimatedCasters)
+		bool& outContainsAnimatedCasters,
+		bool& outContainsCameraLodCasters)
 	{
 		outContainsDynamicCasters = false;
 		outContainsAnimatedCasters = false;
+		outContainsCameraLodCasters = false;
 		for (const auto& caster : casters)
 		{
 			outContainsDynamicCasters |= caster.GetMobility() == EMobilityType::Dynamic;
 			outContainsAnimatedCasters |= caster.GetSkeletonOffset() != (std::numeric_limits<uint32_t>::max)();
-			if (outContainsDynamicCasters && outContainsAnimatedCasters)
+			outContainsCameraLodCasters |= caster.m_resource && caster.m_resource->m_proxy.m_lodPolicy.m_bEnabled;
+			if (outContainsDynamicCasters && outContainsAnimatedCasters && outContainsCameraLodCasters)
 			{
 				return;
 			}
 		}
+	}
+
+	size_t CalculateShadowLodCameraRevision(const CameraData& camera)
+	{
+		size_t revision = 0u;
+		HashCombine(revision, std::hash<glm::mat4>{}(camera.GetViewMatrix()),
+			std::hash<glm::mat4>{}(camera.GetProjectionMatrix()), App::GetActiveGraphicsSettings().m_lodBias);
+		return revision;
 	}
 
 	RHI::RHISubmissionCompletionTokenPtr AcquireShadowPayloadToken(

--- a/Runtime/ECS/LightingECS.h
+++ b/Runtime/ECS/LightingECS.h
@@ -50,8 +50,10 @@ namespace Sailor
 		uint64_t m_sceneRevision = 0;
 		uint64_t m_animationRevision = 0;
 		uint64_t m_resourceRevision = 0;
+		size_t m_lodCameraRevision = 0u;
 		bool m_bContainsDynamicCasters = false;
 		bool m_bContainsAnimatedCasters = false;
+		bool m_bContainsCameraLodCasters = false;
 		TSharedPtr<TVector<RHI::RHISceneVersionPtr>> m_casterSceneVersions{};
 		RHI::RHIRenderTargetPtr m_shadowMap{};
 		RHI::RHISubmissionCompletionTokenPtr m_submissionToken{};
@@ -61,6 +63,7 @@ namespace Sailor
 			uint32_t componentIndex,
 			RHI::EShadowType shadowType,
 			const glm::mat4& lightMatrix,
+			size_t lodCameraRevision,
 			uint64_t sceneRevision,
 			const TSharedPtr<TVector<RHI::RHISceneVersionPtr>>& sceneVersions,
 			const Math::Frustum& shadowFrustum,

--- a/Runtime/ECS/LightingECSInternal.h
+++ b/Runtime/ECS/LightingECSInternal.h
@@ -10,7 +10,10 @@ namespace Sailor::LightingECSInternal
 
 	void ResolveShadowCasterUpdatePolicy(const TVector<RHI::RHIVisibleShadowCaster>& casters,
 		bool& outContainsDynamicCasters,
-		bool& outContainsAnimatedCasters);
+		bool& outContainsAnimatedCasters,
+		bool& outContainsCameraLodCasters);
+
+	size_t CalculateShadowLodCameraRevision(const CameraData& camera);
 
 	RHI::RHISubmissionCompletionTokenPtr AcquireShadowPayloadToken(
 		const RHI::RHISubmissionCompletionTokenPtr& cachedToken);

--- a/Runtime/ECS/LightingLocalShadows.cpp
+++ b/Runtime/ECS/LightingLocalShadows.cpp
@@ -578,6 +578,7 @@ void LightingECS::PrepareLocalShadowPasses(const RHI::RHISceneViewPtr& sceneView
 {
 	const uint64_t frame = GetWorld()->GetCurrentFrame();
 	const auto casterSceneVersions = sceneView->GetRetainedSceneVersions();
+	const size_t lodCameraRevision = CalculateShadowLodCameraRevision(cameraData);
 	const auto submissionToken = sceneView->GetOrCreateSubmissionCompletionToken();
 	outUpdateShadowMaps.Reserve(outUpdateShadowMaps.Num() + spotLights.Num() + pointLights.Num() * 6u);
 
@@ -690,6 +691,7 @@ void LightingECS::PrepareLocalShadowPasses(const RHI::RHISceneViewPtr& sceneView
 				if (cachedState.m_resourceRevision == allocation.m_revision && cachedState.CanReuse(lightProxy.m_index,
 																				   RHI::EShadowType::PCF,
 																				   lightMatrices[face],
+																				   lodCameraRevision,
 																				   sceneView->m_shadowCastersRevision,
 																				   casterSceneVersions,
 																				   shadowFrustum,
@@ -708,18 +710,20 @@ void LightingECS::PrepareLocalShadowPasses(const RHI::RHISceneViewPtr& sceneView
 				shadowPass.m_lighMatrixIndex = shadowSlot;
 				shadowPass.m_shadowType = RHI::EShadowType::PCF;
 				shadowPass.m_meshList =
-					sceneView->TraceShadowCasters(shadowFrustum, glm::vec3(cameraTransform.m_position));
+					sceneView->TraceShadowCasters(shadowFrustum);
 
 				CSMLightState snapshot{};
 				snapshot.m_componentIndex = lightProxy.m_index;
 				snapshot.m_shadowType = RHI::EShadowType::PCF;
 				snapshot.m_lightMatrix = lightMatrices[face];
+				snapshot.m_lodCameraRevision = lodCameraRevision;
 				snapshot.m_sceneRevision = sceneView->m_shadowCastersRevision;
 				snapshot.m_animationRevision = sceneView->m_animationRevision;
 				snapshot.m_resourceRevision = allocation.m_revision;
 				snapshot.m_casterSceneVersions = casterSceneVersions;
 				ResolveShadowCasterUpdatePolicy(
-					shadowPass.m_meshList, snapshot.m_bContainsDynamicCasters, snapshot.m_bContainsAnimatedCasters);
+					shadowPass.m_meshList, snapshot.m_bContainsDynamicCasters, snapshot.m_bContainsAnimatedCasters,
+					snapshot.m_bContainsCameraLodCasters);
 				shadowPass.m_shadowMap = m_localShadowAtlases[allocation.m_atlasIndex].m_texture;
 				snapshot.m_submissionToken = submissionToken;
 				snapshot.m_payloadCompletionToken = AcquireShadowPayloadToken(cachedState.m_payloadCompletionToken);

--- a/Runtime/ECS/StaticMeshRendererECS.cpp
+++ b/Runtime/ECS/StaticMeshRendererECS.cpp
@@ -108,6 +108,10 @@ namespace
 		const RHI::RHIShadowCasterProxy& lhs,
 		const RHI::RHIShadowCasterProxy& rhs)
 	{
+		if (&lhs == &rhs)
+		{
+			return true;
+		}
 		if (lhs.m_staticMeshEcs != rhs.m_staticMeshEcs ||
 			lhs.m_worldAabb != rhs.m_worldAabb ||
 			lhs.m_skeletonOffset != rhs.m_skeletonOffset ||
@@ -311,6 +315,7 @@ void StaticMeshRendererECS::BeginPlay()
 
 void StaticMeshRendererECS::PublishSceneVersion(uint8_t spatialChangeMask)
 {
+	SAILOR_PROFILE_FUNCTION();
 	auto version = RHI::RHISpatialSceneVersionPtr::Make();
 	version->m_revision = ++m_sceneVersionRevision;
 	if (spatialChangeMask != 0u || !m_publishedSceneVersion)
@@ -364,6 +369,7 @@ void StaticMeshRendererECS::PublishSceneVersion(uint8_t spatialChangeMask)
 		auto rebuildSpatialRoot = [&](const TSharedPtr<TVector<RHI::RenderInstanceHandle>>& handles,
 			const TSharedPtr<TOctree<RHI::RenderInstanceHandle>>& octree)
 			{
+				SAILOR_PROFILE_SCOPE("Rebuild scene spatial root");
 				if (!handles || !octree)
 				{
 					return;
@@ -536,7 +542,12 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 	}
 
 	const size_t currentFrame = GetWorld()->GetCurrentFrame();
-	auto prepareProxyUpdate = [this, currentFrame](size_t componentIndex)
+	// Dirty-proxy workers only read the last published scene. Keep that immutable
+	// version alive through the join instead of serializing every record lookup
+	// on the mutable scene's lock.
+	const auto previousSceneVersion = m_rhiScene ?
+		m_rhiScene->GetCurrentVersion() : RHI::RHISceneVersionPtr{};
+	auto prepareProxyUpdate = [this, currentFrame, &previousSceneVersion](size_t componentIndex)
 		{
 			PreparedProxyUpdate result;
 			result.m_componentIndex = componentIndex;
@@ -643,13 +654,14 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 			if (!bTopologyDirty && !bMaterialsDirty && m_rhiScene)
 			{
 				RHI::RenderInstanceHandle* renderHandle = nullptr;
-				RHI::RHISceneInstanceRecord previousRecord;
+				const RHI::RHISceneInstanceRecord* previousRecord = nullptr;
 				if (m_renderInstanceHandles.Find(componentIndex, renderHandle) &&
 					renderHandle &&
-					m_rhiScene->ResolveCurrent(*renderHandle, previousRecord))
+					previousSceneVersion &&
+					previousSceneVersion->Resolve(*renderHandle, previousRecord) && previousRecord)
 				{
-					const auto previousResource =
-						previousRecord.m_topology.DynamicCast<RHI::RHISceneProxyResource>();
+					const auto* previousResource = dynamic_cast<const RHI::RHISceneProxyResource*>(
+						previousRecord->m_topology.GetRawPtr());
 					Math::AABB worldBounds = model->GetBoundsAABB(data.GetMeshIndex());
 					worldBounds.Apply(ownerWorldMatrix);
 					if (previousResource && previousResource->m_bMeshTransformsAreLocal &&
@@ -805,6 +817,7 @@ Tasks::ITaskPtr StaticMeshRendererECS::Tick(float deltaTime)
 				"StaticMeshRendererECS:Prepare Dirty Proxies",
 				[beginIndex, endIndex, &dirtyComponents, &preparedUpdates, prepareProxyUpdate]()
 				{
+					SAILOR_PROFILE_SCOPE("Prepare dirty mesh proxies");
 					for (size_t index = beginIndex; index < endIndex; ++index)
 					{
 						preparedUpdates[index] = prepareProxyUpdate(dirtyComponents[index]);

--- a/Runtime/Engine/World.cpp
+++ b/Runtime/Engine/World.cpp
@@ -803,6 +803,7 @@ bool World::CanReparentPrefabObject(
 
 void World::Tick(FrameState& frameState)
 {
+	SAILOR_PROFILE_FUNCTION();
 	const bool bShouldCallBeginPlay = (m_mask & (uint8_t)EWorldBehaviourBit::CallBeginPlay) != 0;
 	const bool bShouldTick = (m_mask & (uint8_t)EWorldBehaviourBit::Tickable) != 0;
 	const bool bShouldEcsTick = (m_mask & (uint8_t)EWorldBehaviourBit::EcsTickable) != 0;

--- a/Runtime/FrameGraph/DepthPrepassNode.cpp
+++ b/Runtime/FrameGraph/DepthPrepassNode.cpp
@@ -96,27 +96,15 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 			auto& m_customPacket = submissionResources->m_customPacket;
 
 			syncSharedResources.Lock();
-			auto& requestedPacketTextures =
-				submissionResources->m_requestedPacketTextures;
-			for (auto& requestedTextures : requestedPacketTextures)
-			{
-				requestedTextures.Reset();
-			}
-
 			SAILOR_PROFILE_SCOPE("Filter sceneView by tag");
 
 			constexpr size_t PayloadRevisionSeed = Fnv1aOffsetBasis;
 			std::array<size_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
 				payloadRevisions{};
-			std::array<uint32_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
-				numRelevantProxies{};
-			std::array<bool, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
-				bUsesPacketTextures{};
 			for (size_t index = 0u; index < payloadRevisions.size(); ++index)
 			{
 				payloadRevisions[index] = PayloadRevisionSeed;
 				HashCombine(payloadRevisions[index], index);
-				bUsesPacketTextures[index] = bMaskedQueue;
 			}
 			const size_t staticPayloadIndex =
 				RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
@@ -146,116 +134,6 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						bMaskedQueue,
 						sceneViewSnapshot.m_submissionContext->GetMaterialRevision(),
 						sceneViewSnapshot.GetMobilityRevision(mobility));
-				}
-			}
-			for (const auto& proxy : sceneViewSnapshot.m_proxies)
-			{
-				const auto* source = proxy.GetSource();
-				if (!source || !proxy.m_resource)
-				{
-					continue;
-				}
-				const EMobilityType payloadMobility = proxy.GetMobility();
-				const size_t payloadIndex =
-					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(payloadMobility);
-				bool bContributesToQueue = false;
-				for (size_t materialIndex = 0u;
-					materialIndex < source->GetMaterials().Num(); ++materialIndex)
-				{
-					const auto& material = source->GetMaterials()[materialIndex];
-					const bool bRelevant = material &&
-						material->GetRenderState().GetTag() == QueueTagHash;
-					bContributesToQueue |= bRelevant;
-					const bool bCustom = bRelevant &&
-						material->GetRenderState().IsRequiredCustomDepthShader();
-					bUsesPacketTextures[payloadIndex] =
-						bUsesPacketTextures[payloadIndex] || bCustom;
-#if defined(__APPLE__)
-					if ((bMaskedQueue || bCustom) &&
-						materialIndex < source->m_materialTextureSamplers.Num())
-					{
-						for (uint32_t texture : source->m_materialTextureSamplers[materialIndex])
-						{
-							requestedPacketTextures[payloadIndex].Insert(texture);
-						}
-					}
-#endif
-				}
-				for (const auto& group : source->m_instancedGroups)
-				{
-					for (size_t materialIndex = 0u;
-						materialIndex < group.m_materials.Num(); ++materialIndex)
-					{
-						const auto& material = group.m_materials[materialIndex];
-						const bool bRelevant = material &&
-							material->GetRenderState().GetTag() == QueueTagHash;
-						bContributesToQueue |= bRelevant;
-						const bool bCustom = bRelevant &&
-							material->GetRenderState().IsRequiredCustomDepthShader();
-						bUsesPacketTextures[payloadIndex] =
-							bUsesPacketTextures[payloadIndex] || bCustom;
-#if defined(__APPLE__)
-						if ((bMaskedQueue || bCustom) &&
-							materialIndex < group.m_materialTextureSamplers.Num())
-						{
-							for (uint32_t texture : group.m_materialTextureSamplers[materialIndex])
-							{
-								requestedPacketTextures[payloadIndex].Insert(texture);
-							}
-						}
-#endif
-					}
-				}
-				if (bContributesToQueue)
-				{
-					++numRelevantProxies[payloadIndex];
-					if (!usesPagedArena(payloadIndex))
-					{
-						HashCombine(
-							payloadRevisions[payloadIndex],
-							proxy.m_handle.m_slot,
-							proxy.m_handle.m_generation,
-							proxy.m_resource->m_depthRevision,
-							source->m_staticMeshEcs,
-							std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
-							proxy.GetSkeletonOffset());
-						for (size_t meshIndex = 0u; meshIndex < source->m_meshes.Num(); ++meshIndex)
-						{
-							if (meshIndex < source->GetMaterials().Num() &&
-								source->GetMaterials()[meshIndex] &&
-								source->GetMaterials()[meshIndex]->GetRenderState().GetTag() == QueueTagHash)
-							{
-								HashCombine(payloadRevisions[payloadIndex], proxy.ResolveMesh(meshIndex));
-							}
-						}
-						for (const auto& group : source->m_instancedGroups)
-						{
-							for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
-							{
-								if (meshIndex < group.m_materials.Num() &&
-									group.m_materials[meshIndex] &&
-									group.m_materials[meshIndex]->GetRenderState().GetTag() == QueueTagHash)
-								{
-									HashCombine(payloadRevisions[payloadIndex], proxy.ResolveMesh(group.m_meshes[meshIndex]));
-							}
-						}
-						}
-					}
-				}
-			}
-			for (size_t index = 0u; index < payloadRevisions.size(); ++index)
-			{
-				const uint64_t textureDescriptorRevision = bUsesPacketTextures[index] ?
-					Framegraph::Details::CalculateTextureDependencyRevision(
-						requestedPacketTextures[index].GetIndices()) : 0ull;
-				if (!usesPagedArena(index))
-				{
-					HashCombine(
-						payloadRevisions[index],
-						numRelevantProxies[index],
-						QueueTagHash,
-						bMaskedQueue,
-						textureDescriptorRevision);
 				}
 			}
 			m_packet.Reset();
@@ -663,7 +541,7 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 						continue;
 					}
 
-					const auto mesh = proxy.ResolveMesh(i);
+					const auto& mesh = sceneViewSnapshot.ResolveMesh(proxy, i);
 					if (!mesh)
 					{
 						const bool bExpectedCustomDepth = !bMaskedQueue &&
@@ -999,12 +877,8 @@ Tasks::TaskPtr<void, void> DepthPrepassNode::Prepare(RHI::RHIFrameGraphPtr frame
 							{
 								continue;
 							}
-							const auto mesh = proxy.ResolveInstancedMesh(
-								group,
-								instanceIndex,
-								meshIndex,
-								sceneViewSnapshot.m_camera->GetViewMatrix(),
-								sceneViewSnapshot.m_camera->GetProjectionMatrix());
+							const auto& mesh = sceneViewSnapshot.ResolveInstancedMesh(
+								proxy, groupIndex, instanceIndex, meshIndex);
 							if (!mesh)
 							{
 								if (bRequiredCustomDepth)

--- a/Runtime/FrameGraph/DepthPrepassNode.h
+++ b/Runtime/FrameGraph/DepthPrepassNode.h
@@ -113,9 +113,6 @@ namespace Sailor
 			TVector<CustomPerInstanceData> m_customArenaRangeInstances{};
 			TVector<uint64_t> m_customArenaRangeStableKeys{};
 			TVector<RHI::PackedDrawArenaMaterialRun> m_customArenaRangeMaterialVersionRuns{};
-			std::array<Framegraph::TextureDependencyCollector,
-				RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
-				m_requestedPacketTextures{};
 		};
 
 		struct DepthMaterialKey

--- a/Runtime/FrameGraph/RHIFrameGraph.cpp
+++ b/Runtime/FrameGraph/RHIFrameGraph.cpp
@@ -1130,6 +1130,7 @@ TVector<Sailor::Tasks::TaskPtr<void, void>> RHIFrameGraph::Prepare(RHI::RHIScene
 	auto frameRefPtr = this->ToRefPtr<RHIFrameGraph>();
 	for (auto& snapshot : rhiSceneView->m_snapshots)
 	{
+		snapshot.PrepareLods(snapshot.m_camera->GetViewMatrix(), snapshot.m_camera->GetProjectionMatrix());
 		snapshot.m_previousMotionFrame.Clear();
 		if (snapshot.m_cameraIndex < m_motionHistory.Num() && m_motionHistory[snapshot.m_cameraIndex])
 		{

--- a/Runtime/FrameGraph/RenderSceneNode.cpp
+++ b/Runtime/FrameGraph/RenderSceneNode.cpp
@@ -425,18 +425,9 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 			auto& m_orderedDrawItems = submissionResources->m_orderedDrawItems;
 
 			syncSharedResources.Lock();
-			auto& requestedPacketTextures =
-				submissionResources->m_requestedPacketTextures;
-			for (auto& requestedTextures : requestedPacketTextures)
-			{
-				requestedTextures.Reset();
-			}
-
 			constexpr size_t PayloadRevisionSeed = Fnv1aOffsetBasis;
 			std::array<size_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
 				payloadRevisions{};
-			std::array<uint32_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
-				numRelevantProxies{};
 			for (size_t index = 0u; index < payloadRevisions.size(); ++index)
 			{
 				payloadRevisions[index] = PayloadRevisionSeed;
@@ -472,117 +463,6 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 					HashCombine(payloadRevisions[payloadIndex], sceneViewSnapshot.m_previousMotionFrame ?
 						sceneViewSnapshot.m_previousMotionFrame->m_mobilityRevisions[static_cast<size_t>(mobility)] : 0ull);
 				}
-			}
-			for (const auto& proxy : sceneViewSnapshot.m_proxies)
-			{
-				const auto* source = proxy.GetSource();
-				if (!source || !proxy.m_resource)
-				{
-					continue;
-				}
-				bool bContributesToQueue = false;
-				for (size_t renderQueueTag : source->m_renderQueueTags)
-				{
-					bContributesToQueue |= renderQueueTag == QueueTagHash;
-				}
-				for (const auto& group : source->m_instancedGroups)
-				{
-					for (size_t renderQueueTag : group.m_renderQueueTags)
-					{
-						bContributesToQueue |= renderQueueTag == QueueTagHash;
-					}
-				}
-				const EMobilityType payloadMobility = bBackToFront ?
-					EMobilityType::Dynamic : proxy.GetMobility();
-				const size_t payloadIndex =
-					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(payloadMobility);
-#if defined(__APPLE__)
-				for (size_t materialIndex = 0u;
-					materialIndex < source->m_materialTextureSamplers.Num(); ++materialIndex)
-				{
-					if (materialIndex < source->m_renderQueueTags.Num() &&
-						source->m_renderQueueTags[materialIndex] == QueueTagHash)
-					{
-						for (uint32_t texture : source->m_materialTextureSamplers[materialIndex])
-						{
-							requestedPacketTextures[payloadIndex].Insert(texture);
-						}
-					}
-				}
-				for (const auto& group : source->m_instancedGroups)
-				{
-					for (size_t materialIndex = 0u;
-						materialIndex < group.m_materialTextureSamplers.Num(); ++materialIndex)
-					{
-						if (materialIndex < group.m_renderQueueTags.Num() &&
-							group.m_renderQueueTags[materialIndex] == QueueTagHash)
-						{
-							for (uint32_t texture : group.m_materialTextureSamplers[materialIndex])
-							{
-								requestedPacketTextures[payloadIndex].Insert(texture);
-							}
-						}
-					}
-				}
-#endif
-				if (bContributesToQueue)
-				{
-					++numRelevantProxies[payloadIndex];
-					if (!usesPagedArena(payloadIndex))
-					{
-						HashCombine(
-							payloadRevisions[payloadIndex],
-							proxy.m_handle.m_slot,
-							proxy.m_handle.m_generation,
-							proxy.m_resource->m_mainRevision,
-							source->m_staticMeshEcs,
-							std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
-							proxy.GetSkeletonOffset(),
-							proxy.GetRenderFlags());
-						HashMotionHistory(payloadRevisions[payloadIndex], sceneViewSnapshot, proxy);
-						for (size_t meshIndex = 0u; meshIndex < source->m_meshes.Num(); ++meshIndex)
-						{
-							if (meshIndex < source->m_renderQueueTags.Num() &&
-								source->m_renderQueueTags[meshIndex] == QueueTagHash)
-							{
-								HashCombine(payloadRevisions[payloadIndex], proxy.ResolveMesh(meshIndex));
-							}
-						}
-						for (const auto& group : source->m_instancedGroups)
-						{
-							for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
-							{
-								if (meshIndex < group.m_renderQueueTags.Num() &&
-									group.m_renderQueueTags[meshIndex] == QueueTagHash)
-								{
-									HashCombine(payloadRevisions[payloadIndex], proxy.ResolveMesh(group.m_meshes[meshIndex]));
-								}
-							}
-						}
-					}
-				}
-			}
-			for (size_t index = 0u; index < payloadRevisions.size(); ++index)
-			{
-				const uint64_t textureDescriptorRevision =
-					Details::CalculateTextureDependencyRevision(
-						requestedPacketTextures[index].GetIndices());
-				if (!usesPagedArena(index))
-				{
-					HashCombine(
-						payloadRevisions[index],
-						numRelevantProxies[index],
-						QueueTagHash,
-						bBackToFront,
-						textureDescriptorRevision);
-				}
-			}
-			if (bBackToFront)
-			{
-				HashCombine(
-					payloadRevisions[RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(
-						EMobilityType::Dynamic)],
-					std::hash<glm::mat4>{}(sceneViewSnapshot.m_camera->GetViewMatrix()));
 			}
 			m_packet.Reset();
 			m_orderedDrawItems.Clear(false);
@@ -859,7 +739,7 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 						break;
 					}
 
-					const auto mesh = proxy.ResolveMesh(i);
+					const auto& mesh = sceneViewSnapshot.ResolveMesh(proxy, i);
 					const auto& material = source->GetMaterials()[i];
 
 					const bool bRelevantMaterial = material &&
@@ -1045,12 +925,8 @@ Tasks::TaskPtr<void, void> RenderSceneNode::Prepare(RHI::RHIFrameGraphPtr frameG
 							{
 								continue;
 							}
-							const auto mesh = proxy.ResolveInstancedMesh(
-								group,
-								instanceIndex,
-								meshIndex,
-								sceneViewSnapshot.m_camera->GetViewMatrix(),
-								sceneViewSnapshot.m_camera->GetProjectionMatrix());
+							const auto& mesh = sceneViewSnapshot.ResolveInstancedMesh(
+								proxy, groupIndex, instanceIndex, meshIndex);
 							if (!mesh)
 							{
 								bPayloadComplete[payloadIndex] = false;

--- a/Runtime/FrameGraph/RenderSceneNode.h
+++ b/Runtime/FrameGraph/RenderSceneNode.h
@@ -100,9 +100,6 @@ namespace Sailor::Framegraph
 			TVector<PerInstanceData> m_arenaRangeInstances{};
 			TVector<uint64_t> m_arenaRangeStableKeys{};
 			TVector<RHI::PackedDrawArenaMaterialRun> m_arenaRangeMaterialVersionRuns{};
-			std::array<TextureDependencyCollector,
-				RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
-				m_requestedPacketTextures{};
 		};
 
 		SAILOR_SHARED_API static const char* m_name;

--- a/Runtime/FrameGraph/ShadowPrepassNode.cpp
+++ b/Runtime/FrameGraph/ShadowPrepassNode.cpp
@@ -344,8 +344,6 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 		auto& shadowPayloadRevisions = submissionResources->m_shadowPayloadRevisions;
 		auto& bBuildShadowPayloads = submissionResources->m_buildShadowPayloads;
 		auto& bShadowPayloadComplete = submissionResources->m_shadowPayloadComplete;
-		auto& requestedPacketTextures =
-			submissionResources->m_requestedPacketTextures;
 		shadowPayloadRevisions.Clear(false);
 		bBuildShadowPayloads.Clear(false);
 		bShadowPayloadComplete.Clear(false);
@@ -354,10 +352,6 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 		bShadowPayloadComplete.Resize(NumShadowPasses);
 		for (uint32_t passIndex = 0u; passIndex < NumShadowPasses; ++passIndex)
 		{
-			for (auto& requestedTextures : requestedPacketTextures)
-			{
-				requestedTextures.Reset();
-			}
 			const auto& shadowPass = sceneView.m_shadowMapsToUpdate[passIndex];
 			size_t viewKey = Fnv1aOffsetBasis;
 			HashCombine(
@@ -372,8 +366,6 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 			viewResources->Begin(viewKey);
 			submissionResources->m_activeShadowViews.Add(viewResources);
 
-			std::array<uint32_t, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
-				numRelevantCasters{};
 			for (size_t index = 0u; index < shadowPayloadRevisions[passIndex].size(); ++index)
 			{
 				auto& revision = shadowPayloadRevisions[passIndex][index];
@@ -407,101 +399,6 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 				}
 			}
 
-			for (const auto& proxy : shadowPass.m_meshList)
-			{
-				const auto* source = proxy.GetSource();
-				if (!source || !proxy.m_resource)
-				{
-					continue;
-				}
-				const EMobilityType mobility = proxy.GetMobility();
-				const size_t payloadIndex =
-					RHI::TPackedDrawPacket<PerInstanceData>::ToSegmentIndex(mobility);
-				auto& revision = shadowPayloadRevisions[passIndex][payloadIndex];
-				++numRelevantCasters[payloadIndex];
-				if (!usesPagedArena(payloadIndex))
-				{
-					HashCombine(
-						revision,
-						proxy.m_handle.m_slot,
-						proxy.m_handle.m_generation,
-						proxy.m_resource->m_shadowRevision,
-						proxy.GetProducerKey(),
-						std::hash<glm::mat4>{}(proxy.GetWorldMatrix()),
-						proxy.GetSkeletonOffset());
-				}
-
-				for (const auto& shadowMesh : source->m_meshes)
-				{
-					if (shadowMesh.m_renderQueueTag != opaqueQueueTag &&
-						shadowMesh.m_renderQueueTag != maskedQueueTag)
-					{
-						continue;
-					}
-					if (!usesPagedArena(payloadIndex))
-					{
-						HashCombine(revision, proxy.ResolveMesh(shadowMesh, shadowPass.m_lightMatrix));
-					}
-#if defined(__APPLE__)
-					if (shadowMesh.m_renderQueueTag == maskedQueueTag ||
-						shadowMesh.m_customDepthMaterial)
-					{
-						for (uint32_t texture : shadowMesh.m_materialTextureSamplers)
-						{
-							requestedPacketTextures[payloadIndex].Insert(texture);
-						}
-					}
-#endif
-				}
-				const auto* topology = &proxy.m_resource->m_proxy;
-				for (const auto& group : topology->m_instancedGroups)
-				{
-					if (!group.m_bCastShadows)
-					{
-						continue;
-					}
-					for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
-					{
-						const size_t renderQueueTag = meshIndex < group.m_renderQueueTags.Num() ?
-							group.m_renderQueueTags[meshIndex] : 0u;
-						if (renderQueueTag != opaqueQueueTag && renderQueueTag != maskedQueueTag)
-						{
-							continue;
-						}
-						if (!usesPagedArena(payloadIndex))
-						{
-							HashCombine(
-								revision,
-								proxy.ResolveMesh(group.m_meshes[meshIndex], shadowPass.m_lightMatrix));
-						}
-#if defined(__APPLE__)
-						const bool bCustomDepth = meshIndex < group.m_materials.Num() &&
-							group.m_materials[meshIndex] &&
-							group.m_materials[meshIndex]->GetRenderState().IsRequiredCustomDepthShader();
-						if ((renderQueueTag == maskedQueueTag || bCustomDepth) &&
-							meshIndex < group.m_materialTextureSamplers.Num())
-						{
-							for (uint32_t texture : group.m_materialTextureSamplers[meshIndex])
-							{
-								requestedPacketTextures[payloadIndex].Insert(texture);
-							}
-						}
-#endif
-					}
-				}
-			}
-
-			for (size_t index = 0u; index < shadowPayloadRevisions[passIndex].size(); ++index)
-			{
-				if (!usesPagedArena(index))
-				{
-					HashCombine(
-						shadowPayloadRevisions[passIndex][index],
-						numRelevantCasters[index],
-						Framegraph::Details::CalculateTextureDependencyRevision(
-							requestedPacketTextures[index].GetIndices()));
-				}
-			}
 			if (bVirtualizeInstancePayloads)
 			{
 				for (const EMobilityType mobility :
@@ -791,7 +688,7 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 				for (size_t shadowMeshIndex = 0u; shadowMeshIndex < source->m_meshes.Num(); ++shadowMeshIndex)
 				{
 					const auto& shadowMesh = source->m_meshes[shadowMeshIndex];
-					const auto mesh = proxy.ResolveMesh(shadowMesh, shadowPass.m_lightMatrix);
+					const auto& mesh = sceneView.ResolveMesh(proxy, shadowMeshIndex);
 					if (!mesh)
 					{
 						if (shadowMesh.m_renderQueueTag == opaqueQueueTag ||
@@ -1000,8 +897,8 @@ void ShadowPrepassNode::Process(RHIFrameGraphPtr frameGraph, RHI::RHICommandList
 							{
 								continue;
 							}
-							const auto mesh =
-								proxy.ResolveInstancedMesh(group, instanceIndex, meshIndex, shadowPass.m_lightMatrix);
+							const auto& mesh =
+								sceneView.ResolveInstancedMesh(proxy, groupIndex, instanceIndex, meshIndex);
 							if (!mesh)
 							{
 								bShadowPayloadComplete[passIndex][payloadIndex] = false;

--- a/Runtime/FrameGraph/ShadowPrepassNode.h
+++ b/Runtime/FrameGraph/ShadowPrepassNode.h
@@ -130,9 +130,6 @@ namespace Sailor
 			TVector<std::array<bool, RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>>
 				m_shadowPayloadComplete{};
 			uint32_t m_numActiveShadowViews = 0u;
-			std::array<Framegraph::TextureDependencyCollector,
-				RHI::TPackedDrawPacket<PerInstanceData>::NumMobilitySegments>
-				m_requestedPacketTextures{};
 			TVector<RHI::RHITexturePtr> m_renderPassColorAttachments{};
 			TVector<RHI::RHIShaderBindingSetPtr> m_blurDrawBindingSets{};
 			TVector<PerInstanceData> m_arenaRangeInstances{};

--- a/Runtime/GlobalIllumination/GIProbesComposition.cpp
+++ b/Runtime/GlobalIllumination/GIProbesComposition.cpp
@@ -53,6 +53,7 @@ GIProbesCompositionPlan GIProbesComposer::BuildPlan(
 	uint32_t maxStatesPerSnapshot,
 	EGIProbesCompositionValidation validation) noexcept
 {
+	SAILOR_PROFILE_FUNCTION();
 	try
 	{
 		TVector<const GIProbesCompositionInput*> active;
@@ -207,6 +208,7 @@ GIProbesCompositionResult GIProbesComposer::Compose(
 	const TVector<GIProbesCompositionInput>& inputs,
 	uint32_t maxStatesPerSnapshot) noexcept
 {
+	SAILOR_PROFILE_FUNCTION();
 	GIProbesCompositionPlan plan = BuildPlan(
 		inputs,
 		maxStatesPerSnapshot,

--- a/Runtime/GlobalIllumination/GIProbesScene.cpp
+++ b/Runtime/GlobalIllumination/GIProbesScene.cpp
@@ -362,6 +362,7 @@ bool Sailor::ObserveGIProbesSceneRevision(
 	GIProbesSceneRevision& outRevision,
 	std::string& outDiagnostic)
 {
+	SAILOR_PROFILE_FUNCTION();
 	outRevision = {};
 	outDiagnostic.clear();
 	if (!world)
@@ -440,6 +441,7 @@ bool Sailor::CaptureGIProbesScene(
 	std::string& outDiagnostic,
 	const GIProbesSceneWarningCallback& warning)
 {
+	SAILOR_PROFILE_FUNCTION();
 	outScene = {};
 	outDiagnostic.clear();
 	if (!world)
@@ -764,6 +766,7 @@ bool Sailor::PrepareGIProbesScene(
 	const Raytracing::PathTracer::ScenePreparationProgressCallback& progress,
 	const GIProbesSceneWarningCallback& warning)
 {
+	SAILOR_PROFILE_FUNCTION();
 	outPreparedScene = {};
 	outDiagnostic.clear();
 	const auto isCancelled = [cancel]() noexcept

--- a/Runtime/GlobalIllumination/GIProbesTracing.cpp
+++ b/Runtime/GlobalIllumination/GIProbesTracing.cpp
@@ -331,6 +331,7 @@ bool Sailor::TraceGIProbeTransport(
 	GIProbe& probe,
 	std::string& outDiagnostic)
 {
+	SAILOR_PROFILE_FUNCTION();
 	outDiagnostic.clear();
 	if (!Math::AllFinite(request.m_volumeMin) ||
 		!Math::AllFinite(request.m_volumeMax) ||
@@ -497,6 +498,7 @@ bool Sailor::AccumulateGIProbeIrradianceRange(
 	GIProbeIrradianceAccumulator& accumulator,
 	std::string& outDiagnostic)
 {
+	SAILOR_PROFILE_FUNCTION();
 	outDiagnostic.clear();
 	if (sequenceSampleCount == 0u ||
 		sequenceSampleCount > GIProbesMaxRaysPerProbe ||

--- a/Runtime/GlobalIllumination/RuntimeGIProbesGeneration.cpp
+++ b/Runtime/GlobalIllumination/RuntimeGIProbesGeneration.cpp
@@ -54,6 +54,7 @@ namespace Sailor
 
 	std::vector<uint32_t> RuntimeGIProbesService::Impl::BuildProgressiveProbeOrder(const Generation& generation)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		std::vector<uint32_t> result;
 		result.reserve(generation.m_probes.size());
 		if (generation.m_data->m_bricks.IsEmpty())
@@ -135,6 +136,7 @@ namespace Sailor
 		uint64_t generationId,
 		std::string& outDiagnostic)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		outDiagnostic.clear();
 		if (!Math::AllFinite(request.m_priorityPosition))
 		{
@@ -235,6 +237,7 @@ namespace Sailor
 
 	void RuntimeGIProbesService::Impl::ReuseGenerationState(Generation& next, const Generation& previous)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		std::vector<uint32_t> progressiveOrder = std::move(next.m_initialQueue);
 		next.m_initialQueue.reserve(progressiveOrder.size());
 		next.m_warmingQueue.clear();
@@ -325,6 +328,7 @@ namespace Sailor
 
 	bool RuntimeGIProbesService::Impl::ExecuteJob(Job& job, std::string& outDiagnostic)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		Generation& generation = *job.m_generation;
 		ProbeWork& work = job.m_work;
 		GIProbeTraceRequest traceRequest;

--- a/Runtime/GlobalIllumination/RuntimeGIProbesPublication.cpp
+++ b/Runtime/GlobalIllumination/RuntimeGIProbesPublication.cpp
@@ -31,6 +31,7 @@ namespace Sailor
 		std::string diagnostic,
 		double elapsedMilliseconds)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		const std::lock_guard<std::mutex> lock(m_mutex);
 		const std::shared_ptr<Generation>& generation = job.m_generation;
 		if (!m_generation || m_generation != generation || generation->m_cancel.load(std::memory_order_acquire))
@@ -125,6 +126,7 @@ namespace Sailor
 
 	void RuntimeGIProbesService::Impl::PublishIfNeeded()
 	{
+		SAILOR_PROFILE_FUNCTION();
 		const std::lock_guard<std::mutex> lock(m_mutex);
 		if (!m_generation || m_generation->m_bFailed || m_generation->m_dirtyCount == 0u)
 		{

--- a/Runtime/GlobalIllumination/RuntimeGIProbesScheduler.cpp
+++ b/Runtime/GlobalIllumination/RuntimeGIProbesScheduler.cpp
@@ -16,6 +16,7 @@ namespace Sailor
 
 	void RuntimeGIProbesService::Impl::StopWorkerTasks() noexcept
 	{
+		SAILOR_PROFILE_FUNCTION();
 		std::vector<Tasks::ITaskPtr> workerTasks;
 		{
 			const std::lock_guard<std::mutex> lock(m_mutex);
@@ -37,6 +38,7 @@ namespace Sailor
 
 	bool RuntimeGIProbesService::Impl::TryTakeJob(const std::shared_ptr<Generation>& generation, Job& outJob)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		const std::lock_guard<std::mutex> lock(m_mutex);
 		if (!CanDispatchWorkLocked() || m_generation != generation)
 		{
@@ -80,12 +82,14 @@ namespace Sailor
 
 	RuntimeGIProbesService::Impl::DispatchBatch RuntimeGIProbesService::Impl::GetDispatchBatch() const noexcept
 	{
+		SAILOR_PROFILE_FUNCTION();
 		const std::lock_guard<std::mutex> lock(m_mutex);
 		return CanDispatchWorkLocked() ? DispatchBatch{m_generation, m_workerCount} : DispatchBatch{};
 	}
 
 	void RuntimeGIProbesService::Impl::WorkerBatch(std::shared_ptr<Generation> generation, uint32_t maximumJobCount)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		for (uint32_t completedJobCount = 0u; completedJobCount < maximumJobCount; ++completedJobCount)
 		{
 			Job job;
@@ -107,6 +111,7 @@ namespace Sailor
 					(std::min)(100.0, elapsedMilliseconds * (1.0 / static_cast<double>(duty) - 1.0));
 				if (sleepMilliseconds > 0.05)
 				{
+					SAILOR_PROFILE_SCOPE("Runtime GI duty-cycle sleep");
 					std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(sleepMilliseconds));
 				}
 			}
@@ -115,6 +120,7 @@ namespace Sailor
 
 	void RuntimeGIProbesService::Impl::PumpWorkerTasks()
 	{
+		SAILOR_PROFILE_FUNCTION();
 		m_workerTasks.erase(std::remove_if(m_workerTasks.begin(),
 								m_workerTasks.end(),
 								[](const Tasks::ITaskPtr& task) { return !task || task->IsFinished(); }),

--- a/Runtime/GlobalIllumination/RuntimeGIProbesService.cpp
+++ b/Runtime/GlobalIllumination/RuntimeGIProbesService.cpp
@@ -13,6 +13,7 @@ namespace Sailor
 
 	bool RuntimeGIProbesService::Start(const RuntimeGIProbesStartRequest& request, std::string& outDiagnostic)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		if (!request.m_worldSettings.Validate(outDiagnostic) || !request.m_qualitySettings.Validate(outDiagnostic))
 		{
 			return false;
@@ -125,6 +126,7 @@ namespace Sailor
 
 	void RuntimeGIProbesService::Tick(float deltaTimeSeconds)
 	{
+		SAILOR_PROFILE_FUNCTION();
 		{
 			const std::lock_guard<std::mutex> lock(m_impl->m_mutex);
 			if (m_impl->m_generation && std::isfinite(deltaTimeSeconds) && deltaTimeSeconds > 0.0f)
@@ -149,6 +151,7 @@ namespace Sailor
 
 	RuntimeGIProbesStatus RuntimeGIProbesService::GetStatus() const
 	{
+		SAILOR_PROFILE_FUNCTION();
 		const std::lock_guard<std::mutex> lock(m_impl->m_mutex);
 		m_impl->UpdateStatusLocked();
 		return m_impl->m_status;

--- a/Runtime/Math/Bounds.cpp
+++ b/Runtime/Math/Bounds.cpp
@@ -576,8 +576,6 @@ float Math::Triangle::Area() const
 
 bool Math::IntersectRayTriangle(const Ray& ray, const Triangle& tri, RaycastHit& outRaycastHit, float maxRayLength)
 {
-	SAILOR_PROFILE_FUNCTION();
-
 	outRaycastHit = RaycastHit();
 	outRaycastHit.m_rayLenght = maxRayLength;
 
@@ -649,8 +647,6 @@ void IntersectRayTriangle(Ray& ray, const Triangle& tri)
 
 float Math::IntersectRayAABB(const Ray& ray, const glm::vec3& bmin, const glm::vec3& bmax, float maxRayLength)
 {
-	SAILOR_PROFILE_FUNCTION();
-
 	const glm::vec3 t1 = (bmin - ray.GetOrigin()) * ray.GetReciprocalDirection();
 	const glm::vec3 t2 = (bmax - ray.GetOrigin()) * ray.GetReciprocalDirection();
 

--- a/Runtime/RHI/Batch.hpp
+++ b/Runtime/RHI/Batch.hpp
@@ -61,6 +61,14 @@ namespace Sailor::RHI
 
 		bool operator==(const RHIBatch& rhs) const
 		{
+			// Shared meshes in a traffic/vegetation run already have identical
+			// resource identities. Avoid retaining bindings and shaders per instance.
+			if (m_material == rhs.m_material &&
+				m_materialVersion == rhs.m_materialVersion &&
+				m_mesh == rhs.m_mesh && m_textureBindings == rhs.m_textureBindings)
+			{
+				return true;
+			}
 			const auto bindings = GetMaterialBindings();
 			const auto rhsBindings = rhs.GetMaterialBindings();
 			if (!m_material || !rhs.m_material || !m_mesh || !rhs.m_mesh ||
@@ -150,6 +158,7 @@ namespace Sailor::RHI
 		RHIMeshPtr m_mesh{};
 		uint32_t m_instanceIndex = 0u;
 		uint64_t m_stableSortKey = 0ull;
+		size_t m_batchSortHash = 0u;
 	};
 
 	struct PackedDrawGroup
@@ -859,6 +868,7 @@ namespace Sailor::RHI
 			for (auto& segment : m_segments)
 			{
 				segment.m_items.Clear(false);
+				segment.m_sortedItemIndices.Clear(false);
 				segment.m_reorderVisited.Clear(false);
 				segment.m_viewInstanceIndices.Clear(false);
 				segment.m_groups.Clear(false);
@@ -1124,6 +1134,7 @@ namespace Sailor::RHI
 
 		void Finalize(bool bPreserveInstanceOrder = false)
 		{
+			SAILOR_PROFILE_FUNCTION();
 			for (auto& segment : m_segments)
 			{
 				segment.m_viewInstanceIndices.Clear(false);
@@ -1141,10 +1152,23 @@ namespace Sailor::RHI
 
 				if (!bPreserveInstanceOrder)
 				{
-					segment.m_items.Sort([](const auto& lhs, const auto& rhs)
+					SAILOR_PROFILE_SCOPE("Sort packed draw items");
+					// A batch is immutable during finalization. Calculate its key once
+					// instead of retaining shared material bindings on every comparison.
+					segment.m_sortedItemIndices.Resize(segment.m_items.Num());
+					for (uint32_t index = 0u; index < segment.m_items.Num(); ++index)
 					{
-						const size_t lhsBatchHash = lhs.m_batch.GetHash();
-						const size_t rhsBatchHash = rhs.m_batch.GetHash();
+						segment.m_items[index].m_batchSortHash = segment.m_items[index].m_batch.GetHash();
+						segment.m_sortedItemIndices[index] = index;
+					}
+					// Sort indices so shared resource references stay in place. Moving
+					// the owning items repeatedly contends with other render passes.
+					segment.m_sortedItemIndices.Sort([&items = segment.m_items](uint32_t lhsIndex, uint32_t rhsIndex)
+					{
+						const auto& lhs = items[lhsIndex];
+						const auto& rhs = items[rhsIndex];
+						const size_t lhsBatchHash = lhs.m_batchSortHash;
+						const size_t rhsBatchHash = rhs.m_batchSortHash;
 						if (lhsBatchHash != rhsBatchHash)
 						{
 							return lhsBatchHash < rhsBatchHash;
@@ -1190,10 +1214,10 @@ namespace Sailor::RHI
 
 							uint32_t destination = start;
 							TPerInstanceData displaced = std::move(instances[destination]);
-							while (segment.m_items[destination].m_instanceIndex != start)
+							while (segment.m_items[segment.m_sortedItemIndices[destination]].m_instanceIndex != start)
 							{
 								const uint32_t source =
-									segment.m_items[destination].m_instanceIndex;
+									segment.m_items[segment.m_sortedItemIndices[destination]].m_instanceIndex;
 								instances[destination] = std::move(instances[source]);
 								segment.m_reorderVisited[destination] = 1u;
 								destination = source;
@@ -1207,7 +1231,8 @@ namespace Sailor::RHI
 				groups.Reserve(segment.m_items.Num());
 				for (uint32_t itemIndex = 0u; itemIndex < segment.m_items.Num(); ++itemIndex)
 				{
-					const auto& item = segment.m_items[itemIndex];
+					const auto& item = segment.m_items[bPreserveInstanceOrder ?
+						itemIndex : segment.m_sortedItemIndices[itemIndex]];
 					const bool bAppendToGroup = !bPreserveInstanceOrder &&
 						!groups.IsEmpty() &&
 						groups.Last()->m_numInstances < RHIBatch::MaxInstancesPerBatch &&
@@ -1299,6 +1324,7 @@ namespace Sailor::RHI
 		struct Segment
 		{
 			TVector<TPackedDrawItem<TPerInstanceData>> m_items{};
+			TVector<uint32_t> m_sortedItemIndices{};
 			TVector<uint8_t> m_reorderVisited{};
 			TVector<uint32_t> m_viewInstanceIndices{};
 			TVector<PackedDrawGroup> m_groups{};

--- a/Runtime/RHI/GlobalIllumination.cpp
+++ b/Runtime/RHI/GlobalIllumination.cpp
@@ -383,6 +383,7 @@ bool Sailor::RHI::BuildGlobalIlluminationGpuLayout(
 	RHIGlobalIlluminationGpuLayout& outLayout,
 	std::string& outDiagnostic) noexcept
 {
+	SAILOR_PROFILE_FUNCTION();
 	outLayout = {};
 	outDiagnostic.clear();
 	try
@@ -521,6 +522,7 @@ bool Sailor::RHI::BuildGlobalIlluminationGpuCoefficients(
 	TVector<RHIGlobalIlluminationGpuCoefficients>& outCoefficients,
 	std::string& outDiagnostic) noexcept
 {
+	SAILOR_PROFILE_FUNCTION();
 	outCoefficients.Clear();
 	outDiagnostic.clear();
 	try
@@ -619,6 +621,7 @@ bool Sailor::RHI::BuildGlobalIlluminationGpuStates(
 	TVector<RHIGlobalIlluminationGpuState>& outStates,
 	std::string& outDiagnostic) noexcept
 {
+	SAILOR_PROFILE_FUNCTION();
 	outStates.Clear();
 	outDiagnostic.clear();
 	try

--- a/Runtime/RHI/Scene.cpp
+++ b/Runtime/RHI/Scene.cpp
@@ -625,6 +625,7 @@ RHISceneVersionPtr RHIScene::PublishVersion(
 	uint64_t shadowRevision,
 	uint64_t spatialRevision)
 {
+	SAILOR_PROFILE_FUNCTION();
 	m_lock.Lock();
 	if (m_currentVersion &&
 		m_lastPublishedRevision == m_revision &&

--- a/Runtime/RHI/SceneView.cpp
+++ b/Runtime/RHI/SceneView.cpp
@@ -1,4 +1,4 @@
-﻿#include "SceneView.h"
+#include "SceneView.h"
 #include "Core/StringHash.h"
 #include "ECS/CameraECS.h"
 #include "ECS/TransformECS.h"
@@ -412,39 +412,6 @@ uint64_t RHIVisibleSceneProxy::GetContentRevision() const
 	return m_record ? m_record->m_topologyRevision : 0ull;
 }
 
-RHIMeshPtr RHIVisibleSceneProxy::ResolveMesh(size_t meshIndex) const
-{
-	const auto* source = GetSource();
-	if (!source || meshIndex >= source->m_meshes.Num())
-	{
-		return {};
-	}
-
-	auto mesh = source->m_meshes[meshIndex];
-	return ResolveMesh(mesh);
-}
-
-RHIMeshPtr RHIVisibleSceneProxy::ResolveMesh(const RHIMeshPtr& sourceMesh) const
-{
-	auto mesh = sourceMesh;
-	const auto* source = GetSource();
-	if (mesh && source && source->m_lodPolicy.m_bEnabled)
-	{
-		const uint32_t lod = source->m_lodPolicy.Resolve(
-			m_screenCoverage,
-			m_cameraDistance,
-			mesh->GetNumLods());
-		if (lod > 0u)
-		{
-			if (auto lodMesh = mesh->GetLod(lod))
-			{
-				mesh = std::move(lodMesh);
-			}
-		}
-	}
-	return mesh;
-}
-
 glm::mat4 RHIVisibleSceneProxy::ResolveMeshWorldMatrix(size_t meshIndex) const
 {
 	const auto* source = GetSource();
@@ -469,48 +436,6 @@ glm::mat4 RHIVisibleSceneProxy::ResolveInstancedMeshWorldMatrix(
 	const glm::mat4 meshTransform = meshIndex < group.m_meshTransforms.Num() ?
 		group.m_meshTransforms[meshIndex] : glm::mat4(1.0f);
 	return GetWorldMatrix() * group.m_instanceTransforms[instanceIndex] * meshTransform;
-}
-
-RHIMeshPtr RHIVisibleSceneProxy::ResolveInstancedMesh(
-	const RHIInstancedMeshGroup& group,
-	size_t instanceIndex,
-	size_t meshIndex,
-	const glm::mat4& viewMatrix,
-	const glm::mat4& projectionMatrix) const
-{
-	if (meshIndex >= group.m_meshes.Num())
-	{
-		return {};
-	}
-	auto mesh = group.m_meshes[meshIndex];
-	const auto* source = GetSource();
-	if (!mesh || !source || !source->m_lodPolicy.m_bEnabled)
-	{
-		return mesh;
-	}
-
-	Math::AABB worldBounds = mesh->m_bounds;
-	worldBounds.Apply(ResolveInstancedMeshWorldMatrix(
-		group,
-		instanceIndex,
-		meshIndex));
-	uint32_t lod = source->m_lodPolicy.Resolve(
-		CalculateScreenCoverage(worldBounds, viewMatrix, projectionMatrix),
-		mesh->GetNumLods());
-	lod = Settings::ApplyLodBias(
-		lod,
-		mesh->GetNumLods(),
-		source->m_lodPolicy.m_minLod,
-		source->m_lodPolicy.m_maxLod,
-		ResolveInstanceLodBias(group, instanceIndex));
-	if (lod > 0u)
-	{
-		if (auto lodMesh = mesh->GetLod(lod))
-		{
-			mesh = std::move(lodMesh);
-		}
-	}
-	return mesh;
 }
 
 bool RHIVisibleSceneProxy::IsInstancedMeshWithinDistance(
@@ -620,42 +545,6 @@ uint64_t RHIVisibleShadowCaster::GetContentRevision() const
 	return m_resource ? m_resource->m_shadowRevision : 0ull;
 }
 
-RHIMeshPtr RHIVisibleShadowCaster::ResolveMesh(
-	const RHIShadowMeshProxy& shadowMesh,
-	const glm::mat4& shadowViewProjection) const
-{
-	return ResolveMesh(shadowMesh.m_mesh, shadowViewProjection);
-}
-
-RHIMeshPtr RHIVisibleShadowCaster::ResolveMesh(
-	const RHIMeshPtr& sourceMesh,
-	const glm::mat4& shadowViewProjection) const
-{
-	auto mesh = sourceMesh;
-	const auto* topology = m_resource ? &m_resource->m_proxy : nullptr;
-	if (!mesh || !topology || !topology->m_lodPolicy.m_bEnabled)
-	{
-		return mesh;
-	}
-
-	const float coverage = CalculateScreenCoverage(
-		GetWorldBounds(),
-		glm::mat4(1.0f),
-		shadowViewProjection);
-	const uint32_t lod = topology->m_lodPolicy.Resolve(
-		coverage,
-		m_cameraDistance,
-		mesh->GetNumLods());
-	if (lod > 0u)
-	{
-		if (auto lodMesh = mesh->GetLod(lod))
-		{
-			mesh = std::move(lodMesh);
-		}
-	}
-	return mesh;
-}
-
 glm::mat4 RHIVisibleShadowCaster::ResolveMeshWorldMatrix(
 	const RHIShadowMeshProxy& shadowMesh) const
 {
@@ -676,47 +565,6 @@ glm::mat4 RHIVisibleShadowCaster::ResolveInstancedMeshWorldMatrix(
 	const glm::mat4 meshTransform = meshIndex < group.m_meshTransforms.Num() ?
 		group.m_meshTransforms[meshIndex] : glm::mat4(1.0f);
 	return GetWorldMatrix() * group.m_instanceTransforms[instanceIndex] * meshTransform;
-}
-
-RHIMeshPtr RHIVisibleShadowCaster::ResolveInstancedMesh(
-	const RHIInstancedMeshGroup& group,
-	size_t instanceIndex,
-	size_t meshIndex,
-	const glm::mat4& shadowViewProjection) const
-{
-	if (meshIndex >= group.m_meshes.Num())
-	{
-		return {};
-	}
-	auto mesh = group.m_meshes[meshIndex];
-	const auto* topology = m_resource ? &m_resource->m_proxy : nullptr;
-	if (!mesh || !topology || !topology->m_lodPolicy.m_bEnabled)
-	{
-		return mesh;
-	}
-
-	Math::AABB worldBounds = mesh->m_bounds;
-	worldBounds.Apply(ResolveInstancedMeshWorldMatrix(
-		group,
-		instanceIndex,
-		meshIndex));
-	uint32_t lod = topology->m_lodPolicy.Resolve(
-		CalculateScreenCoverage(worldBounds, glm::mat4(1.0f), shadowViewProjection),
-		mesh->GetNumLods());
-	lod = Settings::ApplyLodBias(
-		lod,
-		mesh->GetNumLods(),
-		topology->m_lodPolicy.m_minLod,
-		topology->m_lodPolicy.m_maxLod,
-		ResolveInstanceLodBias(group, instanceIndex));
-	if (lod > 0u)
-	{
-		if (auto lodMesh = mesh->GetLod(lod))
-		{
-			mesh = std::move(lodMesh);
-		}
-	}
-	return mesh;
 }
 
 bool RHIVisibleShadowCaster::IsInstancedMeshWithinDistance(
@@ -875,114 +723,6 @@ uint32_t RHI::RHILodPolicy::Resolve(
 		lodBias);
 }
 
-namespace
-{
-	uint32_t ResolveProxyLod(
-		const StaticMeshRendererData& data,
-		const Math::AABB& worldBounds,
-		const CameraData& camera,
-		const RHIMeshPtr& mesh)
-	{
-		if (!mesh)
-		{
-			return 0u;
-		}
-
-		const float screenCoverage = CalculateScreenCoverage(
-			worldBounds,
-			camera.GetViewMatrix(),
-			camera.GetProjectionMatrix());
-		return data.ResolveLod(screenCoverage, mesh->GetNumLods());
-	}
-
-	[[maybe_unused]] void ApplyCustomLodToMeshes(
-		const RHILodPolicy& policy,
-		const Math::AABB& worldBounds,
-		const CameraData& camera,
-		TVector<RHIMeshPtr>& meshes)
-	{
-		const float coverage = CalculateScreenCoverage(
-			worldBounds, camera.GetViewMatrix(), camera.GetProjectionMatrix());
-		for (auto& mesh : meshes)
-		{
-			if (!mesh)
-			{
-				continue;
-			}
-			const uint32_t lod = policy.Resolve(coverage, mesh->GetNumLods());
-			if (lod > 0u)
-			{
-				if (RHIMeshPtr lodMesh = mesh->GetLod(lod))
-				{
-					mesh = std::move(lodMesh);
-				}
-			}
-		}
-	}
-
-	[[maybe_unused]] void ApplyLodToMeshes(
-		const StaticMeshRendererData& data,
-		const Math::AABB& worldBounds,
-		const CameraData& camera,
-		TVector<RHIMeshPtr>& meshes)
-	{
-		for (auto& mesh : meshes)
-		{
-			const uint32_t lod = ResolveProxyLod(
-				data,
-				worldBounds,
-				camera,
-				mesh);
-			if (lod > 0u)
-			{
-				if (RHIMeshPtr lodMesh = mesh->GetLod(lod))
-				{
-					mesh = std::move(lodMesh);
-				}
-			}
-		}
-	}
-
-	[[maybe_unused]] RHIShadowCasterProxyPtr CreateLodShadowCaster(
-		const RHIShadowCasterProxyPtr& source,
-		WorldPtr world,
-		const CameraData& camera)
-	{
-		if (!source || !world)
-		{
-			return source;
-		}
-
-		auto* meshEcs = world->GetECS<StaticMeshRendererECS>();
-		const bool bUseStaticMeshSettings = meshEcs &&
-			meshEcs->IsComponentRegistered(source->m_staticMeshEcs);
-		if (!source->m_lodPolicy.m_bEnabled && !bUseStaticMeshSettings)
-		{
-			return source;
-		}
-
-		RHIShadowCasterProxyPtr result = RHIShadowCasterProxyPtr::Make(*source);
-		const float coverage = CalculateScreenCoverage(
-			source->m_worldAabb, camera.GetViewMatrix(), camera.GetProjectionMatrix());
-		for (auto& shadowMesh : result->m_meshes)
-		{
-			const uint32_t lod = source->m_lodPolicy.m_bEnabled ?
-				source->m_lodPolicy.Resolve(coverage,
-					shadowMesh.m_mesh ? shadowMesh.m_mesh->GetNumLods() : 0u) :
-				ResolveProxyLod(meshEcs->GetComponentData(source->m_staticMeshEcs),
-					source->m_worldAabb, camera, shadowMesh.m_mesh);
-			if (lod > 0u)
-			{
-				if (RHIMeshPtr lodMesh = shadowMesh.m_mesh->GetLod(lod))
-				{
-					shadowMesh.m_mesh = std::move(lodMesh);
-				}
-			}
-		}
-		return result;
-	}
-}
-
 void RHISceneView::PrepareDebugDrawCommandLists(
 	WorldPtr world,
 	const glm::ivec2& renderExtent)
@@ -1072,6 +812,8 @@ void RHISceneViewSnapshot::ResetForReuse()
 	m_cameraIndex = 0u;
 	m_cameraTransform = {};
 	m_proxies.Clear(false);
+	m_lodMeshes.Clear(false);
+	m_instancedLodOffsets.Clear(false);
 	m_pathTracerProxies.Clear(false);
 	m_pathTracerTLASInstances.Clear(false);
 	m_pathTracerMaterials.Clear(false);
@@ -1096,6 +838,195 @@ void RHISceneViewSnapshot::ResetForReuse()
 	m_globalIllumination.Clear();
 	m_debugDrawSecondaryCmdList.Clear();
 	m_drawImGui.Clear();
+}
+
+const RHIMeshPtr& RHISceneViewSnapshot::ResolveMesh(const RHIVisibleSceneProxy& proxy, size_t meshIndex) const
+{
+	const auto* source = proxy.GetSource();
+	if (!source || meshIndex >= source->m_meshes.Num())
+	{
+		static const RHIMeshPtr empty;
+		return empty;
+	}
+	return proxy.m_meshLodOffset == RHIVisibleSceneProxy::InvalidIndex ?
+		source->m_meshes[meshIndex] : m_lodMeshes[proxy.m_meshLodOffset + meshIndex];
+}
+
+const RHIMeshPtr& RHISceneViewSnapshot::ResolveMesh(const RHIVisibleShadowCaster& proxy, size_t meshIndex) const
+{
+	const auto* source = proxy.GetSource();
+	if (!source || meshIndex >= source->m_meshes.Num())
+	{
+		static const RHIMeshPtr empty;
+		return empty;
+	}
+	return proxy.m_meshLodOffset == RHIVisibleSceneProxy::InvalidIndex ?
+		source->m_meshes[meshIndex].m_mesh : m_lodMeshes[proxy.m_meshLodOffset + meshIndex];
+}
+
+void RHISceneViewSnapshot::PrepareLods(const glm::mat4& viewMatrix, const glm::mat4& projectionMatrix)
+{
+	SAILOR_PROFILE_FUNCTION();
+	m_lodMeshes.Clear(false);
+	m_instancedLodOffsets.Clear(false);
+	struct LodOffsets
+	{
+		uint32_t m_main = RHIVisibleSceneProxy::InvalidIndex;
+		uint32_t m_shadow = RHIVisibleSceneProxy::InvalidIndex;
+		uint32_t m_instanced = RHIVisibleSceneProxy::InvalidIndex;
+	};
+	TMap<const void*, LodOffsets> preparedInstances;
+	TMap<const RHISceneProxyResource*, bool> topologyHasLods;
+	const glm::vec3 cameraPosition(m_cameraTransform.m_position);
+	auto prepare = [&](const RHIVisibleSceneProxy& proxy)
+		{
+			LodOffsets offsets;
+			const auto* source = proxy.GetSource();
+			if (!source || !source->m_lodPolicy.m_bEnabled)
+			{
+				return offsets;
+			}
+			bool* hasLods = nullptr;
+			if (!topologyHasLods.Find(proxy.m_resource, hasLods))
+			{
+				bool bHasLods = false;
+				for (const auto& mesh : source->m_meshes)
+				{
+					bHasLods |= mesh && mesh->GetNumLods() > 1u;
+				}
+				if (source->m_shadowCaster)
+				{
+					for (const auto& mesh : source->m_shadowCaster->m_meshes)
+					{
+						bHasLods |= mesh.m_mesh && mesh.m_mesh->GetNumLods() > 1u;
+					}
+				}
+				for (const auto& group : source->m_instancedGroups)
+				{
+					for (const auto& mesh : group.m_meshes)
+					{
+						bHasLods |= mesh && mesh->GetNumLods() > 1u;
+					}
+				}
+				topologyHasLods.Insert(proxy.m_resource, bHasLods);
+				if (!bHasLods)
+				{
+					return offsets;
+				}
+			}
+			else if (!*hasLods)
+			{
+				return offsets;
+			}
+			// Record identity also distinguishes equal handles in different scene roots.
+			const void* key = proxy.m_record ? static_cast<const void*>(proxy.m_record) : proxy.m_resource;
+			LodOffsets* existing = nullptr;
+			if (preparedInstances.Find(key, existing))
+			{
+				return *existing;
+			}
+			const auto& policy = source->m_lodPolicy;
+			const float coverage = policy.m_cameraDistanceThresholds.IsEmpty() ?
+				CalculateScreenCoverage(proxy.GetWorldBounds(), viewMatrix, projectionMatrix) : 1.0f;
+			const float cameraDistance = glm::distance(cameraPosition,
+				glm::clamp(cameraPosition, proxy.GetWorldBounds().m_min, proxy.GetWorldBounds().m_max));
+			auto selectMesh = [&](const RHIMeshPtr& mesh, float meshCoverage, float distance, int32_t instanceBias)
+				{
+					if (!mesh || mesh->GetNumLods() <= 1u)
+					{
+						return mesh;
+					}
+					uint32_t lod = policy.Resolve(meshCoverage, distance, mesh->GetNumLods());
+					if (instanceBias != 0)
+					{
+						lod = Settings::ApplyLodBias(lod, mesh->GetNumLods(),
+							policy.m_minLod, policy.m_maxLod, instanceBias);
+					}
+					if (lod > 0u)
+					{
+						if (auto selected = mesh->GetLod(lod))
+						{
+							return selected;
+						}
+					}
+					return mesh;
+				};
+			offsets.m_main = static_cast<uint32_t>(m_lodMeshes.Num());
+			for (const auto& mesh : source->m_meshes)
+			{
+				m_lodMeshes.Add(selectMesh(mesh, coverage, cameraDistance, 0));
+			}
+			offsets.m_shadow = static_cast<uint32_t>(m_lodMeshes.Num());
+			if (source->m_shadowCaster)
+			{
+				for (const auto& shadowMesh : source->m_shadowCaster->m_meshes)
+				{
+					RHIMeshPtr selected;
+					bool bSelected = false;
+					for (size_t meshIndex = 0u; meshIndex < source->m_meshes.Num(); ++meshIndex)
+					{
+						if (source->m_meshes[meshIndex] == shadowMesh.m_mesh)
+						{
+							selected = m_lodMeshes[offsets.m_main + meshIndex];
+							bSelected = true;
+							break;
+						}
+					}
+					if (!bSelected)
+					{
+						selected = selectMesh(shadowMesh.m_mesh, coverage, cameraDistance, 0);
+					}
+					m_lodMeshes.Add(std::move(selected));
+				}
+			}
+			offsets.m_instanced = static_cast<uint32_t>(m_instancedLodOffsets.Num());
+			for (const auto& group : source->m_instancedGroups)
+			{
+				m_instancedLodOffsets.Add(static_cast<uint32_t>(m_lodMeshes.Num()));
+				for (size_t meshIndex = 0u; meshIndex < group.m_meshes.Num(); ++meshIndex)
+				{
+					const auto& mesh = group.m_meshes[meshIndex];
+					for (size_t instanceIndex = 0u; instanceIndex < group.m_instanceTransforms.Num(); ++instanceIndex)
+					{
+						if (!mesh || mesh->GetNumLods() <= 1u)
+						{
+							m_lodMeshes.Add(mesh);
+							continue;
+						}
+						Math::AABB bounds = mesh->m_bounds;
+						bounds.Apply(proxy.ResolveInstancedMeshWorldMatrix(group, instanceIndex, meshIndex));
+						const float instanceCoverage = policy.m_cameraDistanceThresholds.IsEmpty() ?
+							CalculateScreenCoverage(bounds, viewMatrix, projectionMatrix) : 1.0f;
+						const float distance = glm::distance(cameraPosition,
+							glm::clamp(cameraPosition, bounds.m_min, bounds.m_max));
+						m_lodMeshes.Add(selectMesh(mesh, instanceCoverage, distance,
+							ResolveInstanceLodBias(group, instanceIndex)));
+					}
+				}
+			}
+			preparedInstances.Insert(key, offsets);
+			return offsets;
+		};
+
+	for (auto& proxy : m_proxies)
+	{
+		const auto offsets = prepare(proxy);
+		proxy.m_meshLodOffset = offsets.m_main;
+		proxy.m_instancedLodOffset = offsets.m_instanced;
+	}
+	for (auto& pass : m_shadowMapsToUpdate)
+	{
+		for (auto& caster : pass.m_meshList)
+		{
+			RHIVisibleSceneProxy proxy;
+			proxy.m_handle = caster.m_handle;
+			proxy.m_record = caster.m_record;
+			proxy.m_resource = caster.m_resource;
+			const auto offsets = prepare(proxy);
+			caster.m_meshLodOffset = offsets.m_shadow;
+			caster.m_instancedLodOffset = offsets.m_instanced;
+		}
+	}
 }
 
 uint64_t RHISceneViewSnapshot::GetMobilityRevision(EMobilityType mobility) const
@@ -1281,17 +1212,15 @@ void RHISceneView::TraceScene(
 }
 
 TVector<RHIVisibleShadowCaster> RHISceneView::TraceShadowCasters(
-	const Math::Frustum& frustum,
-	const glm::vec3& lodReferencePosition) const
+	const Math::Frustum& frustum) const
 {
 	TVector<RHIVisibleShadowCaster> result;
-	TraceShadowCasters(frustum, lodReferencePosition, result);
+	TraceShadowCasters(frustum, result);
 	return result;
 }
 
 void RHISceneView::TraceShadowCasters(
 	const Math::Frustum& frustum,
-	const glm::vec3& lodReferencePosition,
 	TVector<RHIVisibleShadowCaster>& result) const
 {
 	SAILOR_PROFILE_FUNCTION();
@@ -1319,7 +1248,6 @@ void RHISceneView::TraceShadowCasters(
 		}
 
 		auto appendHandle = [&result,
-			&lodReferencePosition,
 			&sceneVersion = spatialVersion->m_sceneVersion](
 			const RenderInstanceHandle& handle)
 			{
@@ -1340,13 +1268,6 @@ void RHISceneView::TraceShadowCasters(
 				visible.m_handle = handle;
 				visible.m_record = record;
 				visible.m_resource = resource;
-				const glm::vec3 closest = glm::clamp(
-					lodReferencePosition,
-					record->m_worldBounds.m_min,
-					record->m_worldBounds.m_max);
-				visible.m_cameraDistance = glm::distance(
-					lodReferencePosition,
-					closest);
 				result.Add(std::move(visible));
 		};
 		if (spatialVersion->m_dynamicOctree)
@@ -1426,17 +1347,18 @@ void RHISceneView::PrepareSnapshots()
 			auto& proxy = res.m_proxies[visibleProxyReadIndex];
 			const auto* source = proxy.GetSource();
 			bool bKeepProxy = source != nullptr;
+			float cameraDistance = 0.0f;
 			if (source)
 			{
 				const glm::vec3 closest = glm::clamp(
 					cameraPosition,
 					proxy.GetWorldBounds().m_min,
 					proxy.GetWorldBounds().m_max);
-				proxy.m_cameraDistance = glm::distance(cameraPosition, closest);
+				cameraDistance = glm::distance(cameraPosition, closest);
 			}
 			if (source && std::isfinite(source->m_lodPolicy.m_maxCameraDistance))
 			{
-				bKeepProxy = proxy.m_cameraDistance <=
+				bKeepProxy = cameraDistance <=
 					source->m_lodPolicy.m_maxCameraDistance;
 			}
 			if (!bKeepProxy)
@@ -1478,13 +1400,6 @@ void RHISceneView::PrepareSnapshots()
 				return reinterpret_cast<uintptr_t>(lhs.m_resource) <
 					reinterpret_cast<uintptr_t>(rhs.m_resource);
 			});
-		for (auto& proxy : res.m_proxies)
-		{
-			proxy.m_screenCoverage = CalculateScreenCoverage(
-				proxy.GetWorldBounds(),
-				camera.GetViewMatrix(),
-				camera.GetProjectionMatrix());
-		}
 		if (i < m_debugDraw.Num())
 		{
 			res.m_debugDrawSecondaryCmdList = m_debugDraw[i];

--- a/Runtime/RHI/SceneView.h
+++ b/Runtime/RHI/SceneView.h
@@ -177,8 +177,9 @@ namespace Sailor::RHI
 		// RHISceneViewSnapshot::m_sceneVersions for the whole submission.
 		const RHISceneInstanceRecord* m_record = nullptr;
 		const RHISceneProxyResource* m_resource = nullptr;
-		float m_screenCoverage = 1.0f;
-		float m_cameraDistance = 0.0f;
+		uint32_t m_meshLodOffset = InvalidIndex;
+		uint32_t m_instancedLodOffset = InvalidIndex;
+		static constexpr uint32_t InvalidIndex = (std::numeric_limits<uint32_t>::max)();
 
 		SAILOR_API const RHISceneViewProxy* GetSource() const;
 		SAILOR_API const glm::mat4& GetWorldMatrix() const;
@@ -187,19 +188,11 @@ namespace Sailor::RHI
 		SAILOR_API uint32_t GetSkeletonOffset() const;
 		SAILOR_API uint32_t GetRenderFlags() const;
 		SAILOR_API uint64_t GetContentRevision() const;
-		SAILOR_API RHIMeshPtr ResolveMesh(size_t meshIndex) const;
-		SAILOR_API RHIMeshPtr ResolveMesh(const RHIMeshPtr& mesh) const;
 		SAILOR_API glm::mat4 ResolveMeshWorldMatrix(size_t meshIndex) const;
 		SAILOR_API glm::mat4 ResolveInstancedMeshWorldMatrix(
 			const RHIInstancedMeshGroup& group,
 			size_t instanceIndex,
 			size_t meshIndex) const;
-		SAILOR_API RHIMeshPtr ResolveInstancedMesh(
-			const RHIInstancedMeshGroup& group,
-			size_t instanceIndex,
-			size_t meshIndex,
-			const glm::mat4& viewMatrix,
-			const glm::mat4& projectionMatrix) const;
 		SAILOR_API bool IsInstancedMeshWithinDistance(
 			const RHIInstancedMeshGroup& group,
 			size_t instanceIndex,
@@ -214,7 +207,8 @@ namespace Sailor::RHI
 		// The owning RHISceneVersion is retained by the submission snapshot.
 		const RHISceneInstanceRecord* m_record = nullptr;
 		const RHISceneProxyResource* m_resource = nullptr;
-		float m_cameraDistance = 0.0f;
+		uint32_t m_meshLodOffset = RHIVisibleSceneProxy::InvalidIndex;
+		uint32_t m_instancedLodOffset = RHIVisibleSceneProxy::InvalidIndex;
 
 		SAILOR_API const RHIShadowCasterProxy* GetSource() const;
 		SAILOR_API const glm::mat4& GetWorldMatrix() const;
@@ -223,22 +217,11 @@ namespace Sailor::RHI
 		SAILOR_API uint32_t GetSkeletonOffset() const;
 		SAILOR_API uint64_t GetProducerKey() const;
 		SAILOR_API uint64_t GetContentRevision() const;
-		SAILOR_API RHIMeshPtr ResolveMesh(
-			const RHIShadowMeshProxy& shadowMesh,
-			const glm::mat4& shadowViewProjection) const;
-		SAILOR_API RHIMeshPtr ResolveMesh(
-			const RHIMeshPtr& mesh,
-			const glm::mat4& shadowViewProjection) const;
 		SAILOR_API glm::mat4 ResolveMeshWorldMatrix(const RHIShadowMeshProxy& shadowMesh) const;
 		SAILOR_API glm::mat4 ResolveInstancedMeshWorldMatrix(
 			const RHIInstancedMeshGroup& group,
 			size_t instanceIndex,
 			size_t meshIndex) const;
-		SAILOR_API RHIMeshPtr ResolveInstancedMesh(
-			const RHIInstancedMeshGroup& group,
-			size_t instanceIndex,
-			size_t meshIndex,
-			const glm::mat4& shadowViewProjection) const;
 		SAILOR_API bool IsInstancedMeshWithinDistance(
 			const RHIInstancedMeshGroup& group,
 			size_t instanceIndex,
@@ -304,6 +287,23 @@ namespace Sailor::RHI
 	struct RHISceneViewSnapshot
 	{
 		SAILOR_API void ResetForReuse();
+		SAILOR_API void PrepareLods(const glm::mat4& viewMatrix, const glm::mat4& projectionMatrix);
+		SAILOR_API const RHIMeshPtr& ResolveMesh(const RHIVisibleSceneProxy& proxy, size_t meshIndex) const;
+		SAILOR_API const RHIMeshPtr& ResolveMesh(const RHIVisibleShadowCaster& proxy, size_t meshIndex) const;
+
+		template<typename TProxy>
+		const RHIMeshPtr& ResolveInstancedMesh(const TProxy& proxy,
+			size_t groupIndex, size_t instanceIndex, size_t meshIndex) const
+		{
+			const auto& group = proxy.m_resource->m_proxy.m_instancedGroups[groupIndex];
+			if (proxy.m_instancedLodOffset == RHIVisibleSceneProxy::InvalidIndex)
+			{
+				return group.m_meshes[meshIndex];
+			}
+			return m_lodMeshes[m_instancedLodOffsets[proxy.m_instancedLodOffset + groupIndex] +
+				meshIndex * group.m_instanceTransforms.Num() + instanceIndex];
+		}
+
 		SAILOR_API uint64_t GetMobilityRevision(EMobilityType mobility) const;
 
 		template<typename TCallback>
@@ -394,6 +394,9 @@ namespace Sailor::RHI
 		Math::Transform m_cameraTransform{};
 		TUniquePtr<CameraData> m_camera{};
 		TVector<RHIVisibleSceneProxy> m_proxies{};
+		// Camera-selected meshes shared by main, depth and every shadow pass.
+		TVector<RHIMeshPtr> m_lodMeshes{};
+		TVector<uint32_t> m_instancedLodOffsets{};
 		TVector<RHIPathTracerProxy> m_pathTracerProxies{};
 		TVector<Sailor::Raytracing::PathTracer::TLASInstance> m_pathTracerTLASInstances{};
 		TVector<MaterialPtr> m_pathTracerMaterials{};
@@ -431,11 +434,9 @@ namespace Sailor::RHI
 			TVector<RHIVisibleSceneProxy>& outVisibleProxies,
 			bool bSkipMaterials) const;
 		SAILOR_API TVector<RHIVisibleShadowCaster> TraceShadowCasters(
-			const Math::Frustum& frustum,
-			const glm::vec3& lodReferencePosition) const;
+			const Math::Frustum& frustum) const;
 		SAILOR_API void TraceShadowCasters(
 			const Math::Frustum& frustum,
-			const glm::vec3& lodReferencePosition,
 			TVector<RHIVisibleShadowCaster>& outVisibleCasters) const;
 		SAILOR_API void PrepareSnapshots();
 		SAILOR_API void PrepareDebugDrawCommandLists(

--- a/Runtime/Raytracing/GIProbesPathTracer.cpp
+++ b/Runtime/Raytracing/GIProbesPathTracer.cpp
@@ -22,6 +22,7 @@ bool GIProbesPathTracer::Initialize(
 	const PathTracer::ScenePreparationProgressCallback& progress,
 	const PathTracer::ScenePreparationWarningCallback& warning)
 {
+	SAILOR_PROFILE_FUNCTION();
 	TVector<LightProxy> bakedLights;
 	bakedLights.Reserve(lights.Num());
 	for (const LightProxy& source : lights)

--- a/Runtime/Sailor.cpp
+++ b/Runtime/Sailor.cpp
@@ -903,6 +903,7 @@ void App::Start()
 
 			//Frame successfully pushed
 			frameCounter++;
+			SAILOR_PROFILE_END_FRAME();
 			if (bRunsInsideEditor)
 			{
 				EditorRuntime::PumpEditorRemoteViewportsOnEngineThread();
@@ -971,7 +972,6 @@ void App::Start()
 		systemInputState = Win32::GlobalInput::GetInputState();
 		systemInputState.TrackForChanges(oldInputState);
 
-		SAILOR_PROFILE_END_FRAME();
 	}
 
 	pMainWindow->SetActive(false);

--- a/Runtime/Tasks/Scheduler.cpp
+++ b/Runtime/Tasks/Scheduler.cpp
@@ -215,9 +215,11 @@ void Scheduler::Initialize()
 		1u,
 		(std::min)(MaxGIThreads, coresCount));
 	const unsigned numReservedThreads = 8u + numRHIThreads;
-	const unsigned numThreads = coresCount > numReservedThreads
-		? coresCount - numReservedThreads
-		: 1u;
+	// Dedicated queues are often idle or throttled. Reserving all of their
+	// threads must not prevent an eight-way gameplay batch from running.
+	const unsigned minimumWorkers = (std::min)(8u, (std::max)(1u, coresCount));
+	const unsigned numThreads = (std::max)(minimumWorkers,
+		coresCount > numReservedThreads ? coresCount - numReservedThreads : 1u);
 
 	WorkerThread* newRenderingThread = new WorkerThread(
 		"Render Thread",
@@ -310,7 +312,8 @@ void Scheduler::Initialize()
 	m_threadTypes[m_audioThreadId] = EThreadType::Audio;
 	m_workerThreads.Emplace(newAudioThread);
 
-	SAILOR_LOG("Initialize Tasks::Scheduler. Cores count: %d, Worker threads count: %zd", coresCount, m_workerThreads.Num());
+	SAILOR_LOG("Initialize Tasks::Scheduler. Logical cores: %u, Worker threads: %u, GI threads: %u, total threads: %zd",
+		coresCount, numThreads, numGIThreads, m_workerThreads.Num());
 }
 
 void Scheduler::AttachCurrentThreadAsMainThread()

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -886,6 +886,20 @@ namespace
 			current->m_topology == original->m_topology &&
 			meshes->GetGlobalIlluminationContributorRevision() != revision,
 			"a later transform must update bounds and GI while retaining mesh topology");
+		Require(original->m_worldMatrix[3].x == 0.0f &&
+			current->m_worldBounds != original->m_worldBounds,
+			"transform publication must leave retained records unchanged");
+		world.AdvanceFrame();
+		object->GetTransformComponent().SetPosition(glm::vec3(4.0f, 0.0f, 0.0f));
+		transforms->Tick(0.016f);
+		transforms->PostTick();
+		meshes->Tick(0.016f);
+		const auto movedAgain = meshes->GetRHIScene()->GetCurrentVersion();
+		const RHI::RHISceneInstanceRecord* latest = nullptr;
+		Require(movedAgain->Resolve(handle, latest) && latest &&
+			latest->m_worldMatrix[3].x == 4.0f && current->m_worldMatrix[3].x == 2.0f &&
+			latest->m_topology == original->m_topology,
+			"successive transform updates must retain topology without lagging a frame");
 		meshes->UnregisterComponent(slot);
 		Require(meshes->GetRHIScene()->GetCurrentVersion()->m_staticHandles->IsEmpty(),
 			"unregistering the component must remove its published instance");

--- a/Tests/EcsLifecycleContractTests.cpp
+++ b/Tests/EcsLifecycleContractTests.cpp
@@ -1026,6 +1026,7 @@ namespace
 			cachedState.m_componentIndex,
 			cachedState.m_shadowType,
 			cachedState.m_lightMatrix,
+			0u,
 			cachedState.m_sceneRevision,
 			cachedState.m_casterSceneVersions,
 			shadowFrustum),
@@ -1034,17 +1035,34 @@ namespace
 			cachedState.m_componentIndex,
 			cachedState.m_shadowType,
 			movedLightMatrix,
+			0u,
 			cachedState.m_sceneRevision,
 			cachedState.m_casterSceneVersions,
 			shadowFrustum),
 			"a changed cascade projection must invalidate the cached shadow map even for camera motion below the old threshold");
 
 		CSMLightState pendingState = cachedState;
+		CSMLightState cameraLodState = cachedState;
+		cameraLodState.m_bContainsCameraLodCasters = true;
+		cameraLodState.m_lodCameraRevision = 5u;
+		Require(cameraLodState.CanReuse(cameraLodState.m_componentIndex, cameraLodState.m_shadowType,
+			cameraLodState.m_lightMatrix, 5u, cameraLodState.m_sceneRevision,
+			cameraLodState.m_casterSceneVersions, shadowFrustum) &&
+			!cameraLodState.CanReuse(cameraLodState.m_componentIndex, cameraLodState.m_shadowType,
+				cameraLodState.m_lightMatrix, 6u, cameraLodState.m_sceneRevision,
+				cameraLodState.m_casterSceneVersions, shadowFrustum),
+			"camera-dependent LOD must invalidate both local and directional shadow caches when its camera reference changes");
+		cameraLodState.m_bContainsCameraLodCasters = false;
+		Require(cameraLodState.CanReuse(cameraLodState.m_componentIndex, cameraLodState.m_shadowType,
+			cameraLodState.m_lightMatrix, 6u, cameraLodState.m_sceneRevision,
+			cameraLodState.m_casterSceneVersions, shadowFrustum),
+			"camera changes must preserve cached shadows whose casters have no camera-dependent LOD");
 		pendingState.m_submissionToken = RHI::RHISubmissionCompletionTokenPtr::Make();
 		Require(!pendingState.CanReuse(
 			pendingState.m_componentIndex,
 			pendingState.m_shadowType,
 			pendingState.m_lightMatrix,
+			0u,
 			pendingState.m_sceneRevision,
 			pendingState.m_casterSceneVersions,
 			shadowFrustum),
@@ -1053,6 +1071,7 @@ namespace
 			pendingState.m_componentIndex,
 			pendingState.m_shadowType,
 			pendingState.m_lightMatrix,
+			0u,
 			pendingState.m_sceneRevision,
 			pendingState.m_casterSceneVersions,
 			shadowFrustum,
@@ -1067,6 +1086,7 @@ namespace
 			incompletePayloadState.m_componentIndex,
 			incompletePayloadState.m_shadowType,
 			incompletePayloadState.m_lightMatrix,
+			0u,
 			incompletePayloadState.m_sceneRevision,
 			incompletePayloadState.m_casterSceneVersions,
 			shadowFrustum),
@@ -1079,6 +1099,7 @@ namespace
 			pendingPayloadState.m_componentIndex,
 			pendingPayloadState.m_shadowType,
 			pendingPayloadState.m_lightMatrix,
+			0u,
 			pendingPayloadState.m_sceneRevision,
 			pendingPayloadState.m_casterSceneVersions,
 			shadowFrustum,
@@ -1092,6 +1113,7 @@ namespace
 			dynamicState.m_componentIndex,
 			dynamicState.m_shadowType,
 			dynamicState.m_lightMatrix,
+			0u,
 			dynamicState.m_sceneRevision,
 			dynamicState.m_casterSceneVersions,
 			shadowFrustum,
@@ -1101,6 +1123,7 @@ namespace
 			dynamicState.m_componentIndex,
 			dynamicState.m_shadowType,
 			dynamicState.m_lightMatrix,
+			0u,
 			dynamicState.m_sceneRevision,
 			dynamicState.m_casterSceneVersions,
 			shadowFrustum,
@@ -1114,6 +1137,7 @@ namespace
 			animatedState.m_componentIndex,
 			animatedState.m_shadowType,
 			animatedState.m_lightMatrix,
+			0u,
 			animatedState.m_sceneRevision,
 			animatedState.m_casterSceneVersions,
 			shadowFrustum,
@@ -1124,6 +1148,7 @@ namespace
 			animatedState.m_componentIndex,
 			animatedState.m_shadowType,
 			animatedState.m_lightMatrix,
+			0u,
 			animatedState.m_sceneRevision,
 			animatedState.m_casterSceneVersions,
 			shadowFrustum,

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -998,8 +998,21 @@ namespace
 
 		RHI::RHIVisibleSceneProxy cameraView;
 		cameraView.m_resource = resource.GetRawPtr();
-		Require(cameraView.ResolveInstancedMesh(group, 0u, 0u, view, projection) == baseMesh &&
-			cameraView.ResolveInstancedMesh(group, 1u, 0u, view, projection) == lodMesh,
+		RHI::RHISceneViewSnapshot snapshot;
+		snapshot.m_proxies.Add(cameraView);
+		snapshot.m_shadowMapsToUpdate.Resize(2u);
+		RHI::RHIVisibleShadowCaster shadowView;
+		shadowView.m_resource = resource.GetRawPtr();
+		for (auto& pass : snapshot.m_shadowMapsToUpdate)
+		{
+			pass.m_meshList.Add(shadowView);
+		}
+		snapshot.m_shadowMapsToUpdate[0].m_lightMatrix = glm::mat4(1.0f);
+		snapshot.m_shadowMapsToUpdate[1].m_lightMatrix = projection * glm::scale(glm::mat4(1.0f), glm::vec3(10.0f));
+		snapshot.PrepareLods(view, projection);
+		cameraView = snapshot.m_proxies[0];
+		Require(snapshot.ResolveInstancedMesh(cameraView, 0u, 0u, 0u) == baseMesh &&
+			snapshot.ResolveInstancedMesh(cameraView, 0u, 1u, 0u) == lodMesh,
 			"main and depth view classification must select LOD per vegetation instance instead of per chunk");
 		Require(cameraView.IsInstancedMeshWithinDistance(
 				group, 0u, 0u, glm::vec3(0.0f), 10.0f) &&
@@ -1007,14 +1020,120 @@ namespace
 				group, 1u, 0u, glm::vec3(0.0f), 10.0f),
 			"vegetation distance culling must use per-instance bounds");
 
-		RHI::RHIVisibleShadowCaster shadowView;
-		shadowView.m_resource = resource.GetRawPtr();
-		const glm::mat4 shadowViewProjection = projection * view;
-		Require(shadowView.ResolveInstancedMesh(
-				group, 0u, 0u, shadowViewProjection) == baseMesh &&
-			shadowView.ResolveInstancedMesh(
-				group, 1u, 0u, shadowViewProjection) == lodMesh,
-			"shadow views must retain independent per-instance LOD classification");
+		for (const auto& pass : snapshot.m_shadowMapsToUpdate)
+		{
+			Require(&snapshot.ResolveInstancedMesh(pass.m_meshList[0], 0u, 1u, 0u) ==
+				&snapshot.ResolveInstancedMesh(cameraView, 0u, 1u, 0u),
+				"every shadow projection must read the camera snapshot's shared per-instance mesh selection");
+		}
+
+		auto biasedProxy = resource->m_proxy;
+		biasedProxy.m_instancedGroups[0].m_instanceLodBiases = { 1, -1 };
+		auto biasedResource = RHI::RHISceneProxyResourcePtr::Make(std::move(biasedProxy));
+		RHI::RHISceneViewSnapshot biasedSnapshot;
+		cameraView.m_resource = biasedResource.GetRawPtr();
+		biasedSnapshot.m_proxies.Add(cameraView);
+		biasedSnapshot.PrepareLods(view, projection);
+		Require(biasedSnapshot.ResolveInstancedMesh(biasedSnapshot.m_proxies[0], 0u, 0u, 0u) == lodMesh &&
+			biasedSnapshot.ResolveInstancedMesh(biasedSnapshot.m_proxies[0], 0u, 1u, 0u) == baseMesh,
+			"snapshot preparation must retain positive and negative vegetation instance LOD biases");
+		auto distanceProxy = resource->m_proxy;
+		distanceProxy.m_lodPolicy.m_cameraDistanceThresholds = { 10.0f };
+		distanceProxy.m_lodPolicy.m_screenCoverageThresholds = { 0.0f };
+		auto distanceResource = RHI::RHISceneProxyResourcePtr::Make(std::move(distanceProxy));
+		biasedSnapshot.m_proxies[0].m_resource = distanceResource.GetRawPtr();
+		biasedSnapshot.PrepareLods(view, projection);
+		Require(biasedSnapshot.ResolveInstancedMesh(biasedSnapshot.m_proxies[0], 0u, 0u, 0u) == baseMesh &&
+			biasedSnapshot.ResolveInstancedMesh(biasedSnapshot.m_proxies[0], 0u, 1u, 0u) == lodMesh,
+			"camera distance policies must classify instances by their own world bounds");
+	}
+
+	void TestSnapshotCameraLodContract()
+	{
+		auto baseMesh = RHI::RHIMeshPtr::Make();
+		auto lod1 = RHI::RHIMeshPtr::Make();
+		auto lod2 = RHI::RHIMeshPtr::Make();
+		baseMesh->m_lods = { lod1, lod2 };
+		auto shorterMesh = RHI::RHIMeshPtr::Make();
+		shorterMesh->m_lods = { lod1 };
+		auto missingLodMesh = RHI::RHIMeshPtr::Make();
+		missingLodMesh->m_lods = { lod1, {} };
+		RHI::RHISceneViewProxy source;
+		source.m_worldMatrix = glm::mat4(1.0f);
+		source.m_lodPolicy.m_bEnabled = true;
+		source.m_lodPolicy.m_cameraDistanceThresholds = { 5.0f, 15.0f };
+		source.m_meshes = { baseMesh, shorterMesh, missingLodMesh, {} };
+		source.m_shadowCaster = RHI::RHIShadowCasterProxyPtr::Make();
+		for (const auto& mesh : { shorterMesh, baseMesh, missingLodMesh })
+		{
+			RHI::RHIShadowMeshProxy shadowMesh;
+			shadowMesh.m_mesh = mesh;
+			source.m_shadowCaster->m_meshes.Add(shadowMesh);
+		}
+		auto resource = RHI::RHISceneProxyResourcePtr::Make(std::move(source));
+		RHI::RHISceneInstanceRecord farRecord;
+		farRecord.m_worldBounds = Math::AABB(glm::vec3(0.0f, 0.0f, -20.0f), glm::vec3(0.5f));
+		RHI::RHISceneInstanceRecord nearRecord;
+		nearRecord.m_worldBounds = Math::AABB(glm::vec3(0.0f, 0.0f, -2.0f), glm::vec3(0.5f));
+		RHI::RHIVisibleSceneProxy visible;
+		visible.m_resource = resource.GetRawPtr();
+		visible.m_record = &farRecord;
+		RHI::RHISceneViewSnapshot snapshot;
+		snapshot.m_proxies.Add(visible);
+		RHI::RHIVisibleShadowCaster caster;
+		caster.m_resource = resource.GetRawPtr();
+		caster.m_record = &farRecord;
+		snapshot.m_shadowMapsToUpdate.Resize(2u);
+		for (auto& pass : snapshot.m_shadowMapsToUpdate)
+		{
+			pass.m_meshList.Add(caster);
+			caster.m_record = &nearRecord;
+			pass.m_meshList.Add(caster);
+			caster.m_record = &farRecord;
+		}
+		const glm::mat4 projection = glm::perspective(glm::radians(60.0f), 1.0f, 0.1f, 100.0f);
+		snapshot.PrepareLods(glm::mat4(1.0f), projection);
+		Require(snapshot.ResolveMesh(snapshot.m_proxies[0], 0u) == lod2 &&
+			snapshot.ResolveMesh(snapshot.m_proxies[0], 1u) == lod1 &&
+			snapshot.ResolveMesh(snapshot.m_proxies[0], 2u) == missingLodMesh &&
+			!snapshot.ResolveMesh(snapshot.m_proxies[0], 3u),
+			"camera LOD selection must respect each mesh's available chain and preserve missing meshes");
+		for (const auto& pass : snapshot.m_shadowMapsToUpdate)
+		{
+			Require(snapshot.ResolveMesh(pass.m_meshList[0], 0u) == lod1 &&
+				snapshot.ResolveMesh(pass.m_meshList[0], 1u) == lod2,
+				"shadow mesh order must not change the camera's selected LOD");
+			Require(snapshot.ResolveMesh(pass.m_meshList[1], 1u) == baseMesh,
+				"shadow-only records must select from the camera independently of another record sharing their topology and handle");
+		}
+		RHI::RHISceneViewSnapshot movedSnapshot;
+		movedSnapshot.m_proxies = snapshot.m_proxies;
+		movedSnapshot.m_shadowMapsToUpdate = snapshot.m_shadowMapsToUpdate;
+		movedSnapshot.m_cameraTransform.m_position.z = -20.0f;
+		movedSnapshot.PrepareLods(glm::translate(glm::mat4(1.0f), glm::vec3(0.0f, 0.0f, 20.0f)), projection);
+		Require(movedSnapshot.ResolveMesh(movedSnapshot.m_proxies[0], 0u) == baseMesh &&
+			snapshot.ResolveMesh(snapshot.m_proxies[0], 0u) == lod2,
+			"a second camera or submission must not overwrite the retained snapshot's LOD selection");
+		movedSnapshot.ResetForReuse();
+		Require(snapshot.ResolveMesh(snapshot.m_proxies[0], 0u) == lod2,
+			"recycling another snapshot must not release this submission's selected meshes");
+		auto disabledSource = resource->m_proxy;
+		disabledSource.m_lodPolicy.m_bEnabled = false;
+		auto disabledResource = RHI::RHISceneProxyResourcePtr::Make(std::move(disabledSource));
+		visible.m_resource = disabledResource.GetRawPtr();
+		movedSnapshot.m_proxies.Add(visible);
+		movedSnapshot.PrepareLods(glm::mat4(1.0f), projection);
+		Require(movedSnapshot.ResolveMesh(movedSnapshot.m_proxies[0], 0u) == baseMesh,
+			"disabling LOD must preserve base geometry regardless of camera distance");
+		RHI::RHISceneViewProxy baseOnlySource;
+		auto baseOnlyMesh = RHI::RHIMeshPtr::Make();
+		baseOnlySource.m_lodPolicy.m_bEnabled = true;
+		baseOnlySource.m_meshes.Add(baseOnlyMesh);
+		auto baseOnlyResource = RHI::RHISceneProxyResourcePtr::Make(std::move(baseOnlySource));
+		movedSnapshot.m_proxies[0].m_resource = baseOnlyResource.GetRawPtr();
+		movedSnapshot.PrepareLods(glm::mat4(1.0f), projection);
+		Require(movedSnapshot.ResolveMesh(movedSnapshot.m_proxies[0], 0u) == baseOnlyMesh,
+			"meshes without an LOD chain must remain drawable with LOD enabled");
 	}
 	void TestBatchTextureBindingIdentityContract()
 	{
@@ -1368,6 +1487,7 @@ int main()
 		{ "MaterialVersionPublicationContract", TestMaterialVersionPublicationContract },
 		{ "DynamicSpatialRootIsolation", TestDynamicSpatialRootIsolation },
 		{ "InstancedViewLodAndDistanceContract", TestInstancedViewLodAndDistanceContract },
+		{ "SnapshotCameraLodContract", TestSnapshotCameraLodContract },
 		{ "BatchTextureBindingIdentityContract", TestBatchTextureBindingIdentityContract },
 		{ "RenderResourceVirtualizationContract", TestRenderResourceVirtualizationContract },
 		{ "ShaderReadOnlyBarrierSynchronizesShaderSampling", TestShaderReadOnlyBarrierSynchronizesShaderSampling },

--- a/Tests/GpuCullingContractTests.cpp
+++ b/Tests/GpuCullingContractTests.cpp
@@ -521,6 +521,56 @@ namespace
 			"a smaller platform texture/command limit must still take precedence");
 	}
 
+	void TestPackedDrawMixedMaterialSort()
+	{
+		struct Instance { uint32_t m_id = 0u; };
+		std::array<RHI::RHIMaterialPtr, 4> materials;
+		for (auto& material : materials)
+		{
+			material = RHI::RHIMaterialPtr::Make(
+				RHI::RenderState{}, RHI::RHIShaderPtr{}, RHI::RHIShaderPtr{});
+		}
+		std::array<RHI::RHIMeshPtr, 2> meshes{
+			RHI::RHIMeshPtr::Make(), RHI::RHIMeshPtr::Make() };
+		RHI::TPackedDrawPacket<Instance> packet;
+		constexpr uint32_t count = 4097u;
+		for (uint32_t flight = 0u; flight < 2u; ++flight)
+		{
+			packet.Reset();
+			for (auto& material : materials)
+			{
+				material->SetBindings(RHI::RHIShaderBindingSetPtr::Make());
+			}
+			for (uint32_t index = 0u; index < count; ++index)
+			{
+				const uint32_t id = (index * 37u) % count;
+				const auto& mesh = meshes[(id / materials.size()) % meshes.size()];
+				packet.Add(RHI::RHIBatch(materials[id % materials.size()], mesh), mesh, {id}, id);
+			}
+			packet.Finalize(false);
+			std::array<bool, count> seen{};
+			uint32_t visited = 0u;
+			for (const auto& group : packet.GetGroups())
+			{
+				uint32_t previousId = 0u;
+				for (uint32_t offset = 0u; offset < group.m_numInstances; ++offset)
+				{
+					const uint32_t storageIndex = packet.GetInstanceIndices()[group.m_firstInstance + offset];
+					const uint32_t id = packet.GetPayload(EMobilityType::Dynamic).m_instances[storageIndex].m_id;
+					Require(id < count && !seen[id], "sorted packets must retain every instance exactly once");
+					seen[id] = true;
+					++visited;
+					Require(group.m_batch.m_materialVersion == materials[id % materials.size()]->GetVersion() &&
+						group.m_mesh == meshes[(id / materials.size()) % meshes.size()],
+						"sorting and packet reuse must preserve each instance's mesh and material generation");
+					Require(offset == 0u || previousId < id, "instances sharing a draw must retain stable key order");
+					previousId = id;
+				}
+			}
+			Require(visited == count, "all mixed-material instances must reach the draw packet");
+		}
+	}
+
 	void TestPackedDrawMobilityPayloadVirtualization()
 	{
 		struct TestInstance
@@ -1314,6 +1364,7 @@ int main()
 		{ "MipExtentUsesVulkanFloorAndClamp", TestMipExtentUsesVulkanFloorAndClamp },
 		{ "PackedDrawMobilityPayloadVirtualization", TestPackedDrawMobilityPayloadVirtualization },
 		{ "PackedDrawBatchInstanceLimit", TestPackedDrawBatchInstanceLimit },
+		{ "PackedDrawMixedMaterialSort", TestPackedDrawMixedMaterialSort },
 		{ "MaterialVersionPublicationContract", TestMaterialVersionPublicationContract },
 		{ "DynamicSpatialRootIsolation", TestDynamicSpatialRootIsolation },
 		{ "InstancedViewLodAndDistanceContract", TestInstancedViewLodAndDistanceContract },


### PR DESCRIPTION
## Summary

When Night City's 16,384 vehicles move, CPU time is dominated by publishing mesh transforms and preparing draw packets. Main, depth, and shadow passes repeated LOD selection and traversed Dynamic records to calculate cache revisions that were never used. Prepare camera-selected meshes once in `RHIFrameGraph::Prepare`, reuse them across all passes, and remove those redundant revision traversals. Keep GI lifecycle profiling and the earlier packet-sorting/publication optimizations in this PR.

Targets `main`, which already contains the Windows fixes from #204. Includes the GI/batching optimizations from #205 (merged only into `fix/windows-platform-runtime`) and the camera snapshot LOD optimization.

## Implementation

- `RHISceneViewSnapshot::PrepareLods` prepares the union of camera-visible objects and shadow casters. Main, depth, all cascades, and local-light shadows read the snapshot's selected meshes. Shadow-only objects also use the camera. Every vegetation instance keeps its own bounds, distance policy, and LOD bias.
- Deduplicate by immutable record identity, including records from different scene roots. Store selections in contiguous snapshot-owned arrays; visible records remain 32 bytes. A later camera/submission cannot overwrite retained selections. Skip topologies without an actual LOD chain.
- Invalidate camera-dependent shadow caches when view, projection, or global LOD bias changes. Preserve cache reuse for casters with LOD disabled. Frustum and distance culling remain specific to each pass.
- Remove the unused per-proxy Dynamic revision scans and their unused texture collectors. Persistent Static/Stationary arenas still use scene mobility/material revisions; actual per-draw texture binding and material-generation validation are preserved on all platforms.
- Cache packed-item batch hashes, stably sort indices while owning resources remain in place, and short-circuit identical batch resources. Preserve transparent order, immutable arenas, material generations, and platform batch limits.
- Prepare dirty mesh proxies from a retained immutable scene version rather than locking the mutable scene for every vehicle. Avoid deep comparison of identical shadow proxies. Permit eight general workers on CPUs with at least eight logical cores.
- Profile GI capture, generation, task execution, publication, composition, residency, and GPU payload preparation. Keep duty-cycle sleep separate, avoid per-ray intersection events, and mark Tracy frames only after successful submission.

The separate local DemoSailor project dispatches eight Sailor traffic tasks, registers dirty transforms on the world thread, and joins before ECS consumes them. That project has no Git metadata; its traffic changes are local, not engine-PR files.

## Validation

Windows x64, Ryzen 7 5800H / RTX 3060 Laptop, MSVC Release with Tracy 0.11.1:

- Rebuilt engine DLL, executable, and DemoSailor module with `SAILOR_BUILD_WITH_TRACY_PROFILER=ON`.
- 24 GPU culling/batching cases, 37 ECS lifecycle cases, 12 RHIScene virtualization scenarios, and 10 bounds cases passed.
- LOD coverage includes shared selection across differing shadow projections, reordered shadow meshes, shadow-only records, independent cameras/submissions, available/missing LODs, disabled LOD, base-only meshes, and vegetation instance bias/distance policies. Shadow-cache tests cover camera revision changes and retained reuse without camera-dependent LOD.
- `DirectionalShadow`, `PointShadow`, `SpotShadow`, `GpuOcclusionCulling`, and `DynamicMaterials` completed with exit 0 through the existing world-test runner functions.
- `git diff --check` passed. Updated dependencies after fetching the merged main branch, as required by AGENTS.md; all packages were already current. The final branch tree is identical to the measured and validated `501239d3` tree. macOS validation and independent Tech Review/QA remain pending.

Controlled Night City comparison against `cb4b02ea` (the previous optimization checkpoint), with `DEMOSAILOR_GI=off` in both runs. Same first **20 seconds of camera movement**, 16,384 Dynamic vehicles, 229 city models, 1024x576 / factor 1, MSAA 4, two 2048 shadow cascades and shadow distance 600:

| Metric | Before snapshot LOD / scan removal | Final |
| --- | ---: | ---: |
| World-frame cadence | 9.16 FPS | 14.22 FPS |
| Shadow preparation median / p95 | 58.53 / 70.04 ms | 22.29 / 26.59 ms |
| Mesh ECS median / p95 | 43.39 / 50.45 ms | 42.80 / 45.81 ms |
| Traffic update median | 6.227 ms | 6.278 ms |

The final snapshot LOD stage takes 3.30 ms median. Two intermediate runs before skipping base-only topologies measured 13.58 and 13.68 FPS over the same first 20 seconds. The observed final cadence improvement is approximately 55%; these captures are not a statistical confidence interval. Mesh publication remains a major CPU bottleneck.

The earlier isolated packet-finalization benchmark used four concurrent passes, 65,536 instances/pass, four materials/four meshes and 40 samples after warmup: original-header median 180.997 ms, optimized 32.753 ms. This operation-level improvement is not an FPS multiplier.

Full-lighting comparison against the previous `night-city-final` capture uses the same first **15 seconds** after all 4,356 GI probes reach refinement 1.0 and panorama reflections reach 64 spp:

| Metric | Previous checkpoint | Final |
| --- | ---: | ---: |
| World-frame cadence | 9.26 FPS | 13.20 FPS |
| Shadow preparation median | 53.92 ms | 23.78 ms |
| Mesh ECS median | 41.15 ms | 40.36 ms |
| GI tick median | 0.0085 ms | 0.0074 ms |

The full-lighting run reached readiness after 302.27 seconds, recorded 20 seconds of movement, and both engine and capture exited 0. The captured Night City image was visually checked. All compared runs used byte-identical ProjectSettings.yaml (SHA-256 `fe2cb4ed0c9d3ca80b9481b65e2a9397440b905d1668b53ab2fd8432fcc84eb7`).

Reproduction:

```powershell
cmake -S D:/Projects/DemoSailor/Generated -B D:/Projects/DemoSailor/Cache/Build -DSAILOR_BUILD_WITH_TRACY_PROFILER=ON
$env:CL='/MP8'
cmake --build D:/Projects/DemoSailor/Cache/Build --config Release --target DemoSailor --parallel 8
```

Local traces, logs, summaries, and screenshots are under `build/batch-contract-tests/camera-lod-*`; the controlled baseline is `mobility-dynamic`. Cadence is derived from successive `ProcessCpuFrame` starts, not the GPU FPS label or measured presentation times. CPU zones overlap and must not be summed as frame time.

## Review considerations

Medium risk: snapshot ownership, shared batching and shadow reuse affect all rendering platforms. Shadows now deliberately use the camera's selected LOD; this can change their detail relative to the former light-projection selection. Graphics settings and schema versions are unchanged. Generated probes and other derived assets are not committed. Tech Review is requested; independent QA follows review.
